### PR TITLE
chore(ci): dedup + consolidate redundant CI jobs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -152,105 +152,18 @@ jobs:
       - name: Run E2E tests
         run: cargo test --test e2e
 
-  audit:
-    name: Security Audit (cargo-audit)
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v6
-
-      - name: Install cargo-audit
-        run: cargo install --locked cargo-audit
-
-      - name: Run audit
-        # Ignored advisories must mirror deny.toml's [advisories].ignore.
-        # cargo-audit doesn't read deny.toml; CLI flags keep both tools
-        # in sync. Plan 36 PR-A.2 introduced sigstore which transitively
-        # pulls rsa (RUSTSEC-2023-0071, threat-model not applicable to
-        # verification-only use) and proc-macro-error v1
-        # (RUSTSEC-2024-0370, build-time only).
-        run: cargo audit --ignore RUSTSEC-2025-0057 --ignore RUSTSEC-2024-0384 --ignore RUSTSEC-2025-0119 --ignore RUSTSEC-2023-0071 --ignore RUSTSEC-2024-0370 --ignore RUSTSEC-2026-0009
-
-  deny:
-    name: Supply chain (cargo-deny — ADR-002 §W5.2)
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v6
-
-      - name: Install Rust toolchain
-        uses: dtolnay/rust-toolchain@nightly
-
-      - name: Install cargo-deny
-        run: cargo install --locked cargo-deny
-
-      - name: Run cargo-deny check
-        run: cargo deny check
-
-  reproducibility:
-    name: Reproducibility (ADR-002 §W5.3)
-    runs-on: ubuntu-latest
-    env:
-      # Pinning SOURCE_DATE_EPOCH and CARGO_INCREMENTAL=0 are the two
-      # cheap knobs that turn rustc into a deterministic compiler in
-      # most cases. The double-build below catches anything that
-      # leaks past these. ADR-002 §W5.3.
-      SOURCE_DATE_EPOCH: "1700000000"
-      CARGO_INCREMENTAL: "0"
-      RUSTFLAGS: "-D warnings --remap-path-prefix=${{ github.workspace }}=."
-    steps:
-      - uses: actions/checkout@v6
-
-      - name: Install Rust toolchain
-        uses: dtolnay/rust-toolchain@nightly
-
-      - name: Build A
-        run: cargo build --release --locked --bin mvmctl
-
-      - name: Hash A
-        run: sha256sum target/release/mvmctl | tee /tmp/hash-a.txt
-
-      - name: Clean
-        run: cargo clean
-
-      - name: Build B
-        run: cargo build --release --locked --bin mvmctl
-
-      - name: Hash B
-        run: sha256sum target/release/mvmctl | tee /tmp/hash-b.txt
-
-      - name: Compare hashes
-        run: |
-          set -euo pipefail
-          a=$(awk '{print $1}' /tmp/hash-a.txt)
-          b=$(awk '{print $1}' /tmp/hash-b.txt)
-          if [ "$a" != "$b" ]; then
-            echo "::error::Reproducibility mismatch: $a != $b" >&2
-            echo "Two builds of the same source produced different binaries." >&2
-            echo "Investigate before merging — non-determinism can mask supply-chain injection." >&2
-            exit 1
-          fi
-          echo "ok: matching sha256 across two clean builds: $a"
-
-  prod-agent-no-exec:
-    name: Prod guest agent has no dev-shell symbols (ADR-002 §W4.3)
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v6
-
-      - name: Install Rust toolchain
-        uses: dtolnay/rust-toolchain@nightly
-
-      - name: Cache cargo
-        uses: actions/cache@v5
-        with:
-          path: |
-            ~/.cargo/registry
-            ~/.cargo/git
-            target
-          key: ${{ runner.os }}-cargo-prodagent-${{ hashFiles('**/Cargo.lock') }}
-          restore-keys: ${{ runner.os }}-cargo-prodagent-
-
-      - name: Build prod agent and check for do_exec
-        run: ./scripts/check-prod-agent-no-exec.sh
+  # The following four ADR-002 enforcement jobs were originally defined
+  # here but are now consolidated into .github/workflows/security.yml
+  # (W6.3). Removed to dedup the per-PR CI surface — the security.yml
+  # versions remain the canonical merge gate AND extend coverage via a
+  # nightly cron, which the ci.yml copies couldn't:
+  #   - Security Audit (cargo-audit)            → security.yml::cargo-audit (§W5.2)
+  #   - Supply chain (cargo-deny)               → security.yml::cargo-deny (§W5.2)
+  #   - Reproducibility (§W5.3)                  → security.yml::reproducibility
+  #   - Prod guest agent has no dev-shell …      → security.yml::prod-agent-no-exec (§W4.3)
+  # Every dropped job's enforcement contract is preserved verbatim in
+  # security.yml; this is purely a CI-surface dedup, not a security
+  # regression.
 
   mcp-server-smoke:
     name: MCP server stdio roundtrip (plan 32 / Proposal A)

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -36,10 +36,15 @@ env:
 
 jobs:
   # ── Lane 1: Supply chain ──────────────────────────────────────────
-  # Maps to ADR-002 §W5.2 — advisories, license allowlist, multi-
-  # version bans, and registry source allowlist. Cheap (<2 min).
-  cargo-deny:
-    name: Supply chain — cargo-deny (ADR-002 §W5.2)
+  # Both cargo-deny (advisories + licenses + bans + sources) and
+  # cargo-audit (RustSec advisories) share the same Rust toolchain
+  # setup and run in <2 min apiece. Combined into one job so a PR
+  # only spawns one supply-chain runner instead of two. Each step's
+  # failure surfaces in the job log under its own step name; both
+  # tools' --ignore lists must stay in lockstep with deny.toml.
+  # ADR-002 §W5.2.
+  supply-chain:
+    name: Supply chain — cargo-deny + cargo-audit (ADR-002 §W5.2)
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
@@ -47,20 +52,13 @@ jobs:
       - name: Install Rust toolchain
         uses: dtolnay/rust-toolchain@nightly
 
-      - name: Install cargo-deny
-        run: cargo install --locked cargo-deny
+      - name: Install cargo-deny + cargo-audit
+        run: |
+          cargo install --locked cargo-deny
+          cargo install --locked cargo-audit
 
       - name: cargo deny check
         run: cargo deny check
-
-  cargo-audit:
-    name: Supply chain — cargo-audit (ADR-002 §W5.2)
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v6
-
-      - name: Install cargo-audit
-        run: cargo install --locked cargo-audit
 
       - name: cargo audit
         # Ignored advisories must mirror deny.toml's `[advisories].ignore`.
@@ -68,13 +66,19 @@ jobs:
         # discoverable way to keep the two tools in sync.
         run: cargo audit --ignore RUSTSEC-2025-0057 --ignore RUSTSEC-2024-0384 --ignore RUSTSEC-2025-0119 --ignore RUSTSEC-2023-0071 --ignore RUSTSEC-2024-0370 --ignore RUSTSEC-2026-0009
 
-  # ── Lane 2: Production-agent symbol gate ──────────────────────────
-  # ADR-002 §W4.3 — production builds of mvm-guest-agent must not
-  # contain mvm_guest_agent::do_exec. Catches accidental re-enable
-  # of the dev-shell feature. Anchors on the binary's crate name to
-  # skip stdlib's identically-named symbol.
-  prod-agent-no-exec:
-    name: Guest agent — no dev-shell symbols (ADR-002 §W4.3)
+  # ── Lane 2: Rust-side fast security checks ────────────────────────
+  # Two short cargo invocations that share toolchain + cache:
+  #   - ADR-002 §W4.3 prod-agent symbol gate (no dev-shell symbols
+  #     in the production guest agent build).
+  #   - ADR-002 §W5.1 hash-verify regression (mvm-cli unit tests
+  #     for the download-and-verify code path; run in isolation
+  #     here so a regression is visible in this workflow even when
+  #     the broader test job in ci.yml is skipped).
+  # Combined into one job so a PR only spawns one fast-checks
+  # runner instead of two. Each step's failure surfaces under its
+  # own step name in the job log.
+  rust-fast-checks:
+    name: Rust fast security checks (ADR-002 §W4.3 + §W5.1)
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
@@ -89,11 +93,14 @@ jobs:
             ~/.cargo/registry
             ~/.cargo/git
             target
-          key: cargo-prodagent-${{ hashFiles('**/Cargo.lock') }}
-          restore-keys: cargo-prodagent-
+          key: cargo-rust-fast-checks-${{ hashFiles('**/Cargo.lock') }}
+          restore-keys: cargo-rust-fast-checks-
 
-      - name: Build prod agent and check for do_exec
+      - name: Prod guest agent has no dev-shell symbols (§W4.3)
         run: ./scripts/check-prod-agent-no-exec.sh
+
+      - name: Hash-verify regression (§W5.1)
+        run: cargo test -p mvm-cli --lib hash_verify_tests
 
   # ── Lane 3: Reproducibility ────────────────────────────────────────
   # ADR-002 §W5.3 — two clean builds must produce byte-identical
@@ -193,23 +200,6 @@ jobs:
           path: |
             crates/mvm-guest/fuzz/corpus/
             crates/mvm-guest/fuzz/artifacts/
-
-  # ── Lane 5: Hash-verify regression ─────────────────────────────────
-  # ADR-002 §W5.1 — the unit tests that exercise the
-  # download-and-verify code path live in mvm-cli. Run them in
-  # isolation so a regression is visible in this workflow even when
-  # the broader test job in ci.yml is skipped.
-  hash-verify-tests:
-    name: Hash-verify regression (ADR-002 §W5.1)
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v6
-
-      - name: Install Rust toolchain
-        uses: dtolnay/rust-toolchain@nightly
-
-      - name: Run hash-verify tests
-        run: cargo test -p mvm-cli --lib hash_verify_tests
 
   # ── Lane 6: Verified boot artifact gate ────────────────────────────
   # ADR-002 §W3.4 — production microVM Nix builds must emit


### PR DESCRIPTION
## Summary

Reduces per-PR CI from ~20 jobs to ~12 by removing duplicates and
consolidating short jobs that share toolchain setup. **Every
ADR-002 §W3–W6 enforcement check still runs** — no security gate
is dropped or weakened. Pure throughput improvement.

## Changes

### ci.yml: drop 4 jobs duplicated in security.yml

W6.3 introduced security.yml as the consolidated security-gate
workflow, but the matching ci.yml copies were never removed. Each
ran twice per push for no extra coverage.

| ci.yml job (removed) | security.yml job (canonical, kept) |
|----------------------|-------------------------------------|
| `audit:` "Security Audit (cargo-audit)" | `cargo-audit:` (now merged into `supply-chain:` below) |
| `deny:` "Supply chain (cargo-deny)" | `cargo-deny:` (now merged into `supply-chain:` below) |
| `reproducibility:` (§W5.3) | `reproducibility:` (§W5.3) |
| `prod-agent-no-exec:` (§W4.3) | (now merged into `rust-fast-checks:` below) |

### security.yml: merge two pairs of short jobs

Both pairs share Rust toolchain setup; running them as separate
jobs spawned a runner each just to install the toolchain again.

**Merged `cargo-deny` + `cargo-audit` → `supply-chain`** (one job,
two cargo invocations). Each step's failure surfaces under its own
step name in the job log; both --ignore lists must stay in
lockstep with deny.toml (unchanged).

**Merged `prod-agent-no-exec` + `hash-verify-tests` → `rust-fast-checks`**
(one job, two short cargo invocations). Both are <2 min apiece;
the cargo cache key was renamed to reflect the combined surface.

### Heavy jobs left alone

`reproducibility` (~8 min double-build), `fuzz` (already PR-throttled
to 5 min), `verified-boot-artifacts` (~5 min Nix build),
`flake-locks-clean`, `builder-image-reproducibility` (already
PR-skipped) all stay separate. Combining them with anything else
gains nothing — they're already at minimum runner count for their
work shape.

## Per-PR CI surface

| | Before | After PR #30 v1 (dedup only) | After PR #30 v2 (this) |
|---|---|---|---|
| ci.yml | 11 | 7 | 7 |
| security.yml | 9 | 9 | 7 |
| **Total active on PR** | ~20 | ~16 | ~13 |

(`builder-image-reproducibility` skips on PR throughout; net active
jobs land at ~12 once that skip is counted.)

## Security posture

- Every threat-model claim from ADR-002 §W3–W6 still has its merge
  gate. No advisory ignore was loosened.
- `deny.toml` + cargo-audit `--ignore` flags carry the full
  audited-acceptance set unchanged from PR #26's plan-36 sigstore
  additions.
- Failure granularity: when a combined job fails, the failing step
  name surfaces in the job log (e.g. "supply-chain / cargo audit"
  vs "supply-chain / cargo deny check"). Triage UX is preserved.

## Test plan

- [x] YAML lint with `python3 -c "import yaml; yaml.safe_load(...)"`
- [x] ci.yml job count: 11 → 7
- [x] security.yml job count: 9 → 7 (one of which skips on PR)
- [x] Pre-commit hooks (1137 tests, clippy clean)
- [ ] CI on this PR exercises the new shape end-to-end

🤖 Generated with [Claude Code](https://claude.com/claude-code)