### PR TITLE
feat(mvm-supervisor): launch + stop happy path — plan 37 Wave 1.4

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -5,16 +5,19 @@
 All Nix builds, Firecracker operations, `mvmctl` commands, test execution, clippy checks, and Linux-specific commands MUST be run inside the Lima VM. Use `limactl shell mvm-builder -- <command>` to execute commands inside the VM. The Lima VM name is `mvm-builder` (renamed from `mvm` in W7.2).
 
 If the Lima VM is not running, boot it with:
+
 ```bash
 cargo run -- dev
 ```
 
 Once running, access it with:
+
 ```bash
 limactl shell mvm-builder
 ```
 
 Examples:
+
 - `limactl shell mvm-builder -- cargo run --quiet -- template build openclaw --force`
 - `limactl shell mvm-builder -- cargo run --quiet -- run --template openclaw --name oc`
 - `limactl shell mvm-builder -- cargo run --quiet -- logs oc`
@@ -117,6 +120,7 @@ Privacy and security are **critical priorities** for this project and must be co
 **ALWAYS** run `cargo clippy --workspace -- -D warnings` after every code change and fix every finding before committing or declaring a task done. Clippy warnings are treated as errors — the CI pre-commit hook enforces this and will block commits.
 
 Rules:
+
 - **Never suppress a lint with `#[allow(...)]`** — fix the underlying issue instead. If you think a suppression is genuinely necessary, explain why in a comment and get explicit approval.
 - **Fix warnings immediately** — do not accumulate clippy debt. A warning introduced now becomes harder to diagnose later.
 - **Common findings to watch for**: `clippy::too_many_arguments` (refactor into a params struct), `clippy::redundant_closure`, `clippy::needless_pass_by_value`, `clippy::single_match` → `if let`, unused imports/variables.
@@ -163,6 +167,7 @@ Documentation is a **first-class deliverable**. Every code change that touches u
 **NEVER** save screenshots, images, or any binary artifacts to the project root or any directory within the repository. Always save screenshots and temporary files to `/tmp/` (e.g. `/tmp/screenshot.png`, `/tmp/page-snapshot.png`). This prevents binary files from polluting the git history.
 
 When using Playwright or other browser tools, explicitly set the output path to `/tmp/`:
+
 - Screenshots: `filename: "/tmp/screenshot.png"`
 - Snapshots: `filename: "/tmp/snapshot.md"`
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2468,12 +2468,15 @@ version = "0.13.0"
 dependencies = [
  "async-trait",
  "chrono",
+ "ed25519-dalek",
  "mvm-core",
  "mvm-plan",
  "mvm-policy",
+ "rand 0.8.6",
  "serde",
  "serde_json",
  "thiserror 1.0.69",
+ "tokio",
  "tracing",
 ]
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2463,6 +2463,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "mvm-supervisor"
+version = "0.13.0"
+dependencies = [
+ "async-trait",
+ "chrono",
+ "mvm-core",
+ "mvm-plan",
+ "mvm-policy",
+ "serde",
+ "serde_json",
+ "thiserror 1.0.69",
+ "tracing",
+]
+
+[[package]]
 name = "mvmctl"
 version = "0.13.0"
 dependencies = [

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,6 +4,7 @@ members = [
     "crates/mvm-security",
     "crates/mvm-plan",
     "crates/mvm-policy",
+    "crates/mvm-supervisor",
     "crates/mvm-runtime",
     "crates/mvm-build",
     "crates/mvm-guest",
@@ -104,6 +105,7 @@ mvm-runtime = { path = "crates/mvm-runtime", version = "0.13.0" }
 mvm-security = { path = "crates/mvm-security", version = "0.13.0" }
 mvm-plan = { path = "crates/mvm-plan", version = "0.13.0" }
 mvm-policy = { path = "crates/mvm-policy", version = "0.13.0" }
+mvm-supervisor = { path = "crates/mvm-supervisor", version = "0.13.0" }
 mvm-cli = { path = "crates/mvm-cli", version = "0.13.0" }
 mvm-mcp = { path = "crates/mvm-mcp", version = "0.13.0" }
 mvm-apple-container = { path = "crates/mvm-apple-container", version = "0.7.0" }

--- a/crates/mvm-supervisor/Cargo.toml
+++ b/crates/mvm-supervisor/Cargo.toml
@@ -14,7 +14,12 @@ mvm-plan.workspace = true
 mvm-policy.workspace = true
 async-trait = "0.1"
 chrono.workspace = true
+ed25519-dalek.workspace = true
 serde.workspace = true
 serde_json.workspace = true
 thiserror = "1"
 tracing.workspace = true
+
+[dev-dependencies]
+rand.workspace = true
+tokio = { workspace = true, features = ["macros", "rt"] }

--- a/crates/mvm-supervisor/Cargo.toml
+++ b/crates/mvm-supervisor/Cargo.toml
@@ -1,0 +1,20 @@
+[package]
+name = "mvm-supervisor"
+description = "Trusted host-side supervisor: owns egress proxy, tool gate, key release, audit signing, artifact capture, plan execution state machine. Plan 37 §7B."
+version.workspace = true
+edition.workspace = true
+license.workspace = true
+repository.workspace = true
+homepage.workspace = true
+authors.workspace = true
+
+[dependencies]
+mvm-core.workspace = true
+mvm-plan.workspace = true
+mvm-policy.workspace = true
+async-trait = "0.1"
+chrono.workspace = true
+serde.workspace = true
+serde_json.workspace = true
+thiserror = "1"
+tracing.workspace = true

--- a/crates/mvm-supervisor/src/artifact.rs
+++ b/crates/mvm-supervisor/src/artifact.rs
@@ -1,0 +1,47 @@
+//! Artifact collector slot. Wave 3 — captures runtime artifacts.
+//!
+//! Plan 37 §21: post-run, the supervisor sweeps the workload's
+//! `artifact_policy.capture_paths` (typically `/artifacts` mounted
+//! via virtiofs) and persists the contents to a per-tenant store.
+//! Retention is governed by `artifact_policy.retention_days`. Wave
+//! 1.3 lands the trait surface; Wave 3 wires the real impl.
+
+use async_trait::async_trait;
+use mvm_plan::PlanId;
+use thiserror::Error;
+
+#[derive(Debug, Error)]
+pub enum ArtifactError {
+    #[error("artifact collector not wired (Noop slot)")]
+    NotWired,
+
+    #[error("io error during capture: {0}")]
+    Io(String),
+}
+
+#[async_trait]
+pub trait ArtifactCollector: Send + Sync {
+    /// Sweep the workload's capture paths and persist the contents
+    /// keyed by `plan_id`. Wave 3's real impl streams via virtiofs
+    /// and writes to the tenant's encrypted artifact store.
+    async fn collect(&self, plan_id: &PlanId) -> Result<(), ArtifactError>;
+}
+
+pub struct NoopArtifactCollector;
+
+#[async_trait]
+impl ArtifactCollector for NoopArtifactCollector {
+    async fn collect(&self, _plan_id: &PlanId) -> Result<(), ArtifactError> {
+        Err(ArtifactError::NotWired)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn noop_artifact_collector_is_constructable() {
+        let _: Box<dyn ArtifactCollector> = Box::new(NoopArtifactCollector);
+    }
+}

--- a/crates/mvm-supervisor/src/audit.rs
+++ b/crates/mvm-supervisor/src/audit.rs
@@ -1,0 +1,86 @@
+//! Audit signer slot. Wave 3 — chain-signed audit stream.
+//!
+//! Plan 37 §22: the supervisor signs each audit entry into the
+//! previous entry's hash, producing a tamper-evident chain. Per
+//! `mvm-policy::AuditPolicy`, entries can also be replicated to
+//! per-tenant streams. Wave 1.3 ships the trait surface; Wave 3
+//! wires the real chain-signing impl.
+
+use async_trait::async_trait;
+use chrono::{DateTime, Utc};
+use mvm_plan::{PlanId, TenantId};
+use serde::{Deserialize, Serialize};
+use thiserror::Error;
+
+/// One audit-stream entry. Plan 37 §22's "audit binding" — every
+/// entry references both the plan id+version and the policy
+/// bundle id+version that were in force when the event happened.
+/// Wave 3's chain-signing wraps this struct.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct AuditEntry {
+    pub timestamp: DateTime<Utc>,
+    pub tenant: TenantId,
+    pub plan_id: PlanId,
+    pub plan_version: u32,
+    pub event: String,
+    /// Free-form details. Inherits `audit_labels` from the plan plus
+    /// per-event extras the supervisor adds.
+    #[serde(default)]
+    pub labels: std::collections::BTreeMap<String, String>,
+}
+
+#[derive(Debug, Error)]
+pub enum AuditError {
+    #[error("audit signer not wired (Noop slot)")]
+    NotWired,
+
+    #[error("io error writing audit entry: {0}")]
+    Io(String),
+}
+
+#[async_trait]
+pub trait AuditSigner: Send + Sync {
+    /// Sign and persist one entry. Wave 3's chain-signing impl
+    /// computes `prev_hash` from the previous entry, derives the
+    /// current entry's signature, and writes both to the audit
+    /// stream destination(s).
+    async fn sign_and_emit(&self, entry: &AuditEntry) -> Result<(), AuditError>;
+}
+
+pub struct NoopAuditSigner;
+
+#[async_trait]
+impl AuditSigner for NoopAuditSigner {
+    async fn sign_and_emit(&self, _entry: &AuditEntry) -> Result<(), AuditError> {
+        Err(AuditError::NotWired)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn noop_audit_signer_is_constructable() {
+        let _: Box<dyn AuditSigner> = Box::new(NoopAuditSigner);
+    }
+
+    #[test]
+    fn audit_entry_serde_roundtrip() {
+        let entry = AuditEntry {
+            timestamp: Utc::now(),
+            tenant: TenantId("t".to_string()),
+            plan_id: PlanId("p".to_string()),
+            plan_version: 1,
+            event: "plan.verified".to_string(),
+            labels: std::collections::BTreeMap::from([(
+                "actor".to_string(),
+                "supervisor".to_string(),
+            )]),
+        };
+        let bytes = serde_json::to_vec(&entry).unwrap();
+        let parsed: AuditEntry = serde_json::from_slice(&bytes).unwrap();
+        assert_eq!(parsed, entry);
+    }
+}

--- a/crates/mvm-supervisor/src/backend.rs
+++ b/crates/mvm-supervisor/src/backend.rs
@@ -1,0 +1,70 @@
+//! Backend launcher slot — what the supervisor calls to actually
+//! start a VM once it's verified the plan.
+//!
+//! Plan 37 §3.1 specifies an open `BackendRegistry`; for Wave 1.4
+//! we just need an abstraction so `Supervisor::launch(plan)` can
+//! be tested without a real Firecracker. The registry + concrete
+//! `FirecrackerBackend` / `AppleContainerBackend` impls land in
+//! a follow-up that lifts today's `mvm-runtime/src/vm/backend.rs`
+//! `AnyBackend` enum behind this trait.
+
+use async_trait::async_trait;
+use mvm_plan::{ExecutionPlan, PlanId};
+use thiserror::Error;
+
+#[derive(Debug, Error)]
+pub enum BackendError {
+    #[error("backend not wired (Noop slot)")]
+    NotWired,
+
+    #[error("backend launch failed: {0}")]
+    LaunchFailed(String),
+
+    #[error("backend stop failed: {0}")]
+    StopFailed(String),
+
+    #[error("backend not aware of plan {plan_id:?}")]
+    UnknownPlan { plan_id: PlanId },
+}
+
+/// Async because real backends drive Firecracker's HTTP API or
+/// Apple Container's vsock RPC, both of which the supervisor will
+/// eventually pump from a tokio runtime.
+#[async_trait]
+pub trait BackendLauncher: Send + Sync {
+    /// Issue the start request. Returns when the backend has
+    /// accepted the request — not necessarily when the guest is
+    /// ready. The supervisor's state machine separately transitions
+    /// `Launched -> Running` after the guest agent pings (Wave 2).
+    async fn launch(&self, plan: &ExecutionPlan) -> Result<(), BackendError>;
+
+    /// Stop the workload identified by `plan_id`.
+    async fn stop(&self, plan_id: &PlanId) -> Result<(), BackendError>;
+}
+
+/// Fail-closed default. A supervisor wired with `NoopBackendLauncher`
+/// can't start any workload — the launch attempt errors with
+/// `BackendError::NotWired` before the supervisor transitions to
+/// `Launched`.
+pub struct NoopBackendLauncher;
+
+#[async_trait]
+impl BackendLauncher for NoopBackendLauncher {
+    async fn launch(&self, _plan: &ExecutionPlan) -> Result<(), BackendError> {
+        Err(BackendError::NotWired)
+    }
+
+    async fn stop(&self, _plan_id: &PlanId) -> Result<(), BackendError> {
+        Err(BackendError::NotWired)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn noop_backend_launcher_is_constructable() {
+        let _: Box<dyn BackendLauncher> = Box::new(NoopBackendLauncher);
+    }
+}

--- a/crates/mvm-supervisor/src/egress.rs
+++ b/crates/mvm-supervisor/src/egress.rs
@@ -1,0 +1,77 @@
+//! Egress proxy slot. Wave 2 differentiator.
+//!
+//! Plan 37 §15: the supervisor owns a single trusted egress proxy
+//! that the workload's outbound traffic must traverse. The proxy
+//! enforces L7 rules (SNI/Host pin sets), inspects payloads via the
+//! inspector chain (`SecretsScanner`, `SsrfGuard`, `InjectionGuard`,
+//! `DestinationPolicy`), and routes AI-provider calls through the
+//! `AiProviderRouter` + `PiiRedactor`. Wave 1.3 lands the trait
+//! surface; Wave 2 fills the inspector chain.
+
+use async_trait::async_trait;
+use thiserror::Error;
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum EgressDecision {
+    /// Allow the request to flow through unchanged.
+    Allow,
+    /// Block the request. The `reason` is surfaced to the workload
+    /// (and to the audit stream).
+    Deny { reason: String },
+}
+
+#[derive(Debug, Error)]
+pub enum EgressError {
+    #[error("egress proxy not wired (Noop slot)")]
+    NotWired,
+
+    #[error("inspector chain rejected request: {reason}")]
+    Rejected { reason: String },
+
+    #[error("upstream unreachable: {0}")]
+    UpstreamUnreachable(String),
+}
+
+/// Async because Wave 2's real impl streams body bytes through the
+/// inspector chain incrementally — a request can be allowed at
+/// header-time, then have its body redacted by `PiiRedactor`
+/// mid-stream, all under one `inspect` call.
+#[async_trait]
+pub trait EgressProxy: Send + Sync {
+    /// Inspect an outbound HTTP request. The signature is intentionally
+    /// loose at this stage — Wave 2 introduces the concrete `EgressRequest`
+    /// + `EgressResponse` shapes once the inspector chain is wired.
+    async fn inspect(&self, host: &str, path: &str) -> Result<EgressDecision, EgressError>;
+}
+
+/// Fail-closed default. A supervisor wired with `NoopEgressProxy`
+/// refuses every outbound request.
+///
+/// This is intentional: a misconfigured deployment that forgot to wire
+/// the real proxy fails loudly on the first egress attempt instead of
+/// silently leaking traffic. Wave 2's real `L7EgressProxy` replaces
+/// this slot.
+pub struct NoopEgressProxy;
+
+#[async_trait]
+impl EgressProxy for NoopEgressProxy {
+    async fn inspect(&self, _host: &str, _path: &str) -> Result<EgressDecision, EgressError> {
+        Err(EgressError::NotWired)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    // Wave 1.3 doesn't pull tokio as a dev-dep yet; the contract
+    // test for the async `inspect` happy path lands in Wave 2
+    // alongside the real `L7EgressProxy` impl. For now, confirm
+    // the trait object constructs (which transitively asserts
+    // `Send + Sync`) so a misconfigured `Default::default()`
+    // supervisor compiles before it runs.
+    #[test]
+    fn noop_egress_proxy_is_constructable() {
+        let _: Box<dyn EgressProxy> = Box::new(NoopEgressProxy);
+    }
+}

--- a/crates/mvm-supervisor/src/keystore.rs
+++ b/crates/mvm-supervisor/src/keystore.rs
@@ -1,0 +1,69 @@
+//! Keystore releaser slot. Wave 3 — attestation-gated key release.
+//!
+//! Plan 37 §12.2: per-run secret grants. The supervisor releases a
+//! plan's `secrets: Vec<SecretBinding>` only after `attestation`
+//! passes (Wave 3 wires Tpm2 / SevSnp / Tdx providers). Grants are
+//! revoked on plan exit; an audit entry is emitted on grant + revoke.
+
+use async_trait::async_trait;
+use mvm_plan::SecretBinding;
+use thiserror::Error;
+
+/// A live secret grant — name (workload-visible) + opaque value the
+/// supervisor surfaces via the secrets-mount filesystem
+/// (`/run/mvm-secrets/<name>`). The `value` is wrapped in a
+/// zeroize-on-drop type in Wave 3; today it's a plain String stub
+/// for shape only.
+#[derive(Debug, Clone)]
+pub struct SecretGrant {
+    pub name: String,
+    pub value: String,
+}
+
+#[derive(Debug, Error)]
+pub enum KeystoreError {
+    #[error("keystore releaser not wired (Noop slot)")]
+    NotWired,
+
+    #[error("attestation requirement not satisfied: {0}")]
+    AttestationFailed(String),
+
+    #[error("secret {name} not found in resolver")]
+    NotFound { name: String },
+}
+
+#[async_trait]
+pub trait KeystoreReleaser: Send + Sync {
+    /// Resolve a `SecretBinding` to a live grant. Wave 3's real impl
+    /// gates this on attestation evidence collected during launch;
+    /// the trait signature is intentionally loose so Wave 3 can pass
+    /// the attestation evidence without changing this method's
+    /// shape.
+    async fn release(&self, binding: &SecretBinding) -> Result<SecretGrant, KeystoreError>;
+
+    /// Revoke a previously-released grant. Called on plan teardown.
+    async fn revoke(&self, name: &str) -> Result<(), KeystoreError>;
+}
+
+pub struct NoopKeystoreReleaser;
+
+#[async_trait]
+impl KeystoreReleaser for NoopKeystoreReleaser {
+    async fn release(&self, _binding: &SecretBinding) -> Result<SecretGrant, KeystoreError> {
+        Err(KeystoreError::NotWired)
+    }
+
+    async fn revoke(&self, _name: &str) -> Result<(), KeystoreError> {
+        Err(KeystoreError::NotWired)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn noop_keystore_releaser_is_constructable() {
+        let _: Box<dyn KeystoreReleaser> = Box::new(NoopKeystoreReleaser);
+    }
+}

--- a/crates/mvm-supervisor/src/lib.rs
+++ b/crates/mvm-supervisor/src/lib.rs
@@ -1,0 +1,48 @@
+//! mvm-supervisor — trusted host-side supervisor.
+//!
+//! Plan 37 §7B (CORNERSTONE). A single host-side process that owns:
+//! egress proxy (§15), tool gate (§2.2/§15), keystore releaser (§12.2),
+//! audit signer (§22), artifact collector (§21), and the plan
+//! execution state machine. **Tenant code never runs in Zone B.**
+//!
+//! Wave 1.3 of plan 37 lands the *skeleton*: each component is a
+//! trait + a `Noop` impl returning a typed error / pass-through, and
+//! the plan state machine carries every transition the launch path
+//! will eventually walk. The actual lift of `mvm-hostd`'s daemon
+//! binary into a `mvm-supervisor` binary, plus systemd unit + launchd
+//! plist, lands in Wave 1.4 (Supervisor::launch happy path).
+//!
+//! Why scaffold-first: each component lifts a sizeable chunk of
+//! today's `mvm-runtime/src/security/*`. Landing the trait surface
+//! first lets every sub-component move under it with a typed contract,
+//! rather than the current grab-bag of free functions. The Noop impls
+//! are the fail-closed default — a supervisor wired up with default
+//! Noop slots refuses every non-trivial operation, so a misconfigured
+//! deployment cannot accidentally pass tenant traffic through an
+//! unwired component.
+//!
+//! Structure:
+//! - `state` — `PlanState` + `PlanStateMachine` (transition rules
+//!   for the supervisor's plan lifecycle).
+//! - `egress` — `EgressProxy` trait + `NoopEgressProxy`.
+//! - `tool_gate` — `ToolGate` trait + `NoopToolGate`.
+//! - `keystore` — `KeystoreReleaser` trait + `NoopKeystoreReleaser`.
+//! - `audit` — `AuditSigner` trait + `NoopAuditSigner`.
+//! - `artifact` — `ArtifactCollector` trait + `NoopArtifactCollector`.
+//! - `supervisor` — `Supervisor` aggregate that owns the slots.
+
+pub mod artifact;
+pub mod audit;
+pub mod egress;
+pub mod keystore;
+pub mod state;
+pub mod supervisor;
+pub mod tool_gate;
+
+pub use artifact::{ArtifactCollector, ArtifactError, NoopArtifactCollector};
+pub use audit::{AuditError, AuditSigner, NoopAuditSigner};
+pub use egress::{EgressDecision, EgressError, EgressProxy, NoopEgressProxy};
+pub use keystore::{KeystoreError, KeystoreReleaser, NoopKeystoreReleaser, SecretGrant};
+pub use state::{PlanState, PlanStateMachine, StateTransitionError};
+pub use supervisor::{Supervisor, SupervisorError};
+pub use tool_gate::{NoopToolGate, ToolDecision, ToolError, ToolGate};

--- a/crates/mvm-supervisor/src/lib.rs
+++ b/crates/mvm-supervisor/src/lib.rs
@@ -33,6 +33,7 @@
 
 pub mod artifact;
 pub mod audit;
+pub mod backend;
 pub mod egress;
 pub mod keystore;
 pub mod state;
@@ -41,6 +42,7 @@ pub mod tool_gate;
 
 pub use artifact::{ArtifactCollector, ArtifactError, NoopArtifactCollector};
 pub use audit::{AuditError, AuditSigner, NoopAuditSigner};
+pub use backend::{BackendError, BackendLauncher, NoopBackendLauncher};
 pub use egress::{EgressDecision, EgressError, EgressProxy, NoopEgressProxy};
 pub use keystore::{KeystoreError, KeystoreReleaser, NoopKeystoreReleaser, SecretGrant};
 pub use state::{PlanState, PlanStateMachine, StateTransitionError};

--- a/crates/mvm-supervisor/src/state.rs
+++ b/crates/mvm-supervisor/src/state.rs
@@ -1,0 +1,209 @@
+//! Plan execution state machine.
+//!
+//! Plan 37 §7B specifies the transitions:
+//!
+//! ```text
+//! Pending  ──verified──▶  Verified
+//! Verified ──launched──▶  Launched
+//! Launched ──running ──▶  Running
+//! Running  ──stopping──▶  Stopping
+//! Stopping ──stopped ──▶  Stopped
+//! ```
+//!
+//! Plus error paths from any state to `Failed { from }`. Every
+//! transition is logged as an audit entry once `AuditSigner` is
+//! wired (Wave 3); here we return the error and let the caller
+//! decide.
+
+use serde::{Deserialize, Serialize};
+use thiserror::Error;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum PlanState {
+    /// Plan accepted but not yet verified (signature, schema, version,
+    /// not_after, revocation, image digest). Initial state.
+    Pending,
+    /// Verification passed. Resources reserved, image fetched, but
+    /// the VM has not been launched yet.
+    Verified,
+    /// VM start request issued to the backend; awaiting boot.
+    Launched,
+    /// Guest agent is up; supervisor has dispatched the workload.
+    Running,
+    /// Workload finishing; teardown in progress (artifact collection,
+    /// secret revocation, audit flush).
+    Stopping,
+    /// Workload finished and supervisor has released every resource.
+    /// Terminal.
+    Stopped,
+    /// Any state can transition to Failed; the `from` field records
+    /// the state we left so the audit trail names the failure point.
+    Failed,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Error)]
+pub enum StateTransitionError {
+    #[error("transition {from:?} -> {to:?} is not allowed by the plan state machine")]
+    Disallowed { from: PlanState, to: PlanState },
+}
+
+/// Tracks one workload's lifecycle. The state machine is a thin
+/// contract — the transitions are the rule set; the work each
+/// transition does (verify image, launch backend, capture artifacts,
+/// etc.) lives in `Supervisor::launch` (Wave 1.4) and pulls each
+/// component slot in turn.
+#[derive(Debug, Clone)]
+pub struct PlanStateMachine {
+    state: PlanState,
+}
+
+impl Default for PlanStateMachine {
+    fn default() -> Self {
+        Self {
+            state: PlanState::Pending,
+        }
+    }
+}
+
+impl PlanStateMachine {
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    pub fn current(&self) -> PlanState {
+        self.state
+    }
+
+    /// Attempt a transition. The allowed transitions are:
+    ///
+    /// - Pending  → Verified | Failed
+    /// - Verified → Launched | Failed
+    /// - Launched → Running | Failed
+    /// - Running  → Stopping | Failed
+    /// - Stopping → Stopped | Failed
+    /// - Failed   → (terminal, no further transitions)
+    /// - Stopped  → (terminal, no further transitions)
+    pub fn transition(&mut self, to: PlanState) -> Result<PlanState, StateTransitionError> {
+        let from = self.state;
+        let allowed = matches!(
+            (from, to),
+            (PlanState::Pending, PlanState::Verified)
+                | (PlanState::Pending, PlanState::Failed)
+                | (PlanState::Verified, PlanState::Launched)
+                | (PlanState::Verified, PlanState::Failed)
+                | (PlanState::Launched, PlanState::Running)
+                | (PlanState::Launched, PlanState::Failed)
+                | (PlanState::Running, PlanState::Stopping)
+                | (PlanState::Running, PlanState::Failed)
+                | (PlanState::Stopping, PlanState::Stopped)
+                | (PlanState::Stopping, PlanState::Failed)
+        );
+        if !allowed {
+            return Err(StateTransitionError::Disallowed { from, to });
+        }
+        self.state = to;
+        Ok(to)
+    }
+
+    pub fn is_terminal(&self) -> bool {
+        matches!(self.state, PlanState::Stopped | PlanState::Failed)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn happy_path_walks_every_state() {
+        let mut m = PlanStateMachine::new();
+        assert_eq!(m.current(), PlanState::Pending);
+        m.transition(PlanState::Verified).unwrap();
+        m.transition(PlanState::Launched).unwrap();
+        m.transition(PlanState::Running).unwrap();
+        m.transition(PlanState::Stopping).unwrap();
+        m.transition(PlanState::Stopped).unwrap();
+        assert!(m.is_terminal());
+    }
+
+    #[test]
+    fn each_state_can_transition_to_failed() {
+        for state in [
+            PlanState::Pending,
+            PlanState::Verified,
+            PlanState::Launched,
+            PlanState::Running,
+            PlanState::Stopping,
+        ] {
+            let mut m = PlanStateMachine::new();
+            // Walk to `state` first.
+            match state {
+                PlanState::Pending => {}
+                PlanState::Verified => {
+                    m.transition(PlanState::Verified).unwrap();
+                }
+                PlanState::Launched => {
+                    m.transition(PlanState::Verified).unwrap();
+                    m.transition(PlanState::Launched).unwrap();
+                }
+                PlanState::Running => {
+                    m.transition(PlanState::Verified).unwrap();
+                    m.transition(PlanState::Launched).unwrap();
+                    m.transition(PlanState::Running).unwrap();
+                }
+                PlanState::Stopping => {
+                    m.transition(PlanState::Verified).unwrap();
+                    m.transition(PlanState::Launched).unwrap();
+                    m.transition(PlanState::Running).unwrap();
+                    m.transition(PlanState::Stopping).unwrap();
+                }
+                _ => unreachable!(),
+            }
+            m.transition(PlanState::Failed).unwrap();
+            assert!(m.is_terminal());
+        }
+    }
+
+    #[test]
+    fn skipping_states_is_disallowed() {
+        let mut m = PlanStateMachine::new();
+        // Pending -> Running (skipping Verified + Launched) must fail.
+        match m.transition(PlanState::Running) {
+            Err(StateTransitionError::Disallowed { from, to }) => {
+                assert_eq!(from, PlanState::Pending);
+                assert_eq!(to, PlanState::Running);
+            }
+            other => panic!("expected Disallowed, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn no_transitions_out_of_terminal_states() {
+        let mut m = PlanStateMachine::new();
+        m.transition(PlanState::Verified).unwrap();
+        m.transition(PlanState::Launched).unwrap();
+        m.transition(PlanState::Running).unwrap();
+        m.transition(PlanState::Stopping).unwrap();
+        m.transition(PlanState::Stopped).unwrap();
+        // Stopped -> anything must fail.
+        assert!(m.transition(PlanState::Running).is_err());
+        assert!(m.transition(PlanState::Failed).is_err());
+
+        let mut m2 = PlanStateMachine::new();
+        m2.transition(PlanState::Failed).unwrap();
+        // Failed -> anything must fail.
+        assert!(m2.transition(PlanState::Verified).is_err());
+        assert!(m2.transition(PlanState::Stopped).is_err());
+    }
+
+    #[test]
+    fn backwards_transitions_disallowed() {
+        let mut m = PlanStateMachine::new();
+        m.transition(PlanState::Verified).unwrap();
+        m.transition(PlanState::Launched).unwrap();
+        m.transition(PlanState::Running).unwrap();
+        // Running -> Verified is not allowed.
+        assert!(m.transition(PlanState::Verified).is_err());
+    }
+}

--- a/crates/mvm-supervisor/src/supervisor.rs
+++ b/crates/mvm-supervisor/src/supervisor.rs
@@ -1,0 +1,100 @@
+//! `Supervisor` — aggregate that owns every component slot plus the
+//! plan execution state machine.
+//!
+//! Wave 1.3 ships the type with `Default::default()` returning a
+//! supervisor wired with every `Noop` slot. The actual
+//! `Supervisor::launch(plan)` happy path that walks the state
+//! machine and pulls each slot lands in Wave 1.4.
+
+use std::sync::Arc;
+
+use thiserror::Error;
+
+use crate::artifact::{ArtifactCollector, NoopArtifactCollector};
+use crate::audit::{AuditSigner, NoopAuditSigner};
+use crate::egress::{EgressProxy, NoopEgressProxy};
+use crate::keystore::{KeystoreReleaser, NoopKeystoreReleaser};
+use crate::state::{PlanStateMachine, StateTransitionError};
+use crate::tool_gate::{NoopToolGate, ToolGate};
+
+#[derive(Debug, Error)]
+pub enum SupervisorError {
+    #[error("plan state transition failed: {0}")]
+    State(#[from] StateTransitionError),
+
+    #[error("egress proxy error: {0}")]
+    Egress(String),
+
+    #[error("tool gate error: {0}")]
+    Tool(String),
+
+    #[error("keystore error: {0}")]
+    Keystore(String),
+
+    #[error("audit error: {0}")]
+    Audit(String),
+
+    #[error("artifact error: {0}")]
+    Artifact(String),
+}
+
+/// Trusted host-side supervisor. Plan 37 §7B.
+///
+/// Holds Arc-wrapped trait objects so the daemon can hand the same
+/// supervisor to multiple plan-execution tasks without cloning each
+/// component. The Arc indirection also lets future tests swap one
+/// slot at a time (e.g. mock `EgressProxy`, real `AuditSigner`)
+/// without rebuilding the whole struct.
+pub struct Supervisor {
+    pub egress: Arc<dyn EgressProxy>,
+    pub tool_gate: Arc<dyn ToolGate>,
+    pub keystore: Arc<dyn KeystoreReleaser>,
+    pub audit: Arc<dyn AuditSigner>,
+    pub artifact: Arc<dyn ArtifactCollector>,
+    pub state: PlanStateMachine,
+}
+
+impl Default for Supervisor {
+    /// Default is the fail-closed configuration: every component slot
+    /// is `Noop`, so any non-trivial operation errors with `NotWired`
+    /// until a real impl is plumbed in. Plan 37 §7B's invariant —
+    /// "tenant code never runs in Zone B unless every slot is owned
+    /// by a real impl" — is encoded by this default + the typed
+    /// errors each Noop returns.
+    fn default() -> Self {
+        Self {
+            egress: Arc::new(NoopEgressProxy),
+            tool_gate: Arc::new(NoopToolGate),
+            keystore: Arc::new(NoopKeystoreReleaser),
+            audit: Arc::new(NoopAuditSigner),
+            artifact: Arc::new(NoopArtifactCollector),
+            state: PlanStateMachine::new(),
+        }
+    }
+}
+
+impl Supervisor {
+    pub fn new() -> Self {
+        Self::default()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::state::PlanState;
+
+    #[test]
+    fn default_supervisor_starts_in_pending() {
+        let s = Supervisor::default();
+        assert_eq!(s.state.current(), PlanState::Pending);
+    }
+
+    #[test]
+    fn supervisor_aggregates_every_slot() {
+        // Pure type-level assertion that every component is wired
+        // in Default. If a future field is added without a Default,
+        // this test won't compile.
+        let _ = Supervisor::default();
+    }
+}

--- a/crates/mvm-supervisor/src/supervisor.rs
+++ b/crates/mvm-supervisor/src/supervisor.rs
@@ -1,26 +1,43 @@
 //! `Supervisor` — aggregate that owns every component slot plus the
-//! plan execution state machine.
+//! plan execution state machine, and drives the launch lifecycle.
 //!
-//! Wave 1.3 ships the type with `Default::default()` returning a
-//! supervisor wired with every `Noop` slot. The actual
-//! `Supervisor::launch(plan)` happy path that walks the state
-//! machine and pulls each slot lands in Wave 1.4.
+//! Wave 1.3 shipped the type with `Default::default()` returning a
+//! supervisor wired with every `Noop` slot. Wave 1.4 (this module's
+//! current state) adds the `Supervisor::launch(plan)` happy path:
+//!   1. verify the signed plan
+//!   2. transition Pending → Verified
+//!   3. ask the backend to launch
+//!   4. transition Verified → Launched → Running
+//!
+//! Plus `Supervisor::stop(plan_id)` to walk Running → Stopping → Stopped.
+//! The supervisor is sync today but the slot trait methods are async
+//! (real impls drive HTTP / vsock); `launch` and `stop` are async.
 
 use std::sync::Arc;
 
+use ed25519_dalek::VerifyingKey;
+use mvm_plan::{PlanId, SignedExecutionPlan};
 use thiserror::Error;
+use tracing::warn;
 
 use crate::artifact::{ArtifactCollector, NoopArtifactCollector};
 use crate::audit::{AuditSigner, NoopAuditSigner};
+use crate::backend::{BackendError, BackendLauncher, NoopBackendLauncher};
 use crate::egress::{EgressProxy, NoopEgressProxy};
 use crate::keystore::{KeystoreReleaser, NoopKeystoreReleaser};
-use crate::state::{PlanStateMachine, StateTransitionError};
+use crate::state::{PlanState, PlanStateMachine, StateTransitionError};
 use crate::tool_gate::{NoopToolGate, ToolGate};
 
 #[derive(Debug, Error)]
 pub enum SupervisorError {
+    #[error("plan signature/parse failed: {0}")]
+    PlanVerify(String),
+
     #[error("plan state transition failed: {0}")]
     State(#[from] StateTransitionError),
+
+    #[error("backend error: {0}")]
+    Backend(#[from] BackendError),
 
     #[error("egress proxy error: {0}")]
     Egress(String),
@@ -38,29 +55,21 @@ pub enum SupervisorError {
     Artifact(String),
 }
 
-/// Trusted host-side supervisor. Plan 37 §7B.
-///
-/// Holds Arc-wrapped trait objects so the daemon can hand the same
-/// supervisor to multiple plan-execution tasks without cloning each
-/// component. The Arc indirection also lets future tests swap one
-/// slot at a time (e.g. mock `EgressProxy`, real `AuditSigner`)
-/// without rebuilding the whole struct.
 pub struct Supervisor {
     pub egress: Arc<dyn EgressProxy>,
     pub tool_gate: Arc<dyn ToolGate>,
     pub keystore: Arc<dyn KeystoreReleaser>,
     pub audit: Arc<dyn AuditSigner>,
     pub artifact: Arc<dyn ArtifactCollector>,
+    pub backend: Arc<dyn BackendLauncher>,
     pub state: PlanStateMachine,
 }
 
 impl Default for Supervisor {
-    /// Default is the fail-closed configuration: every component slot
-    /// is `Noop`, so any non-trivial operation errors with `NotWired`
-    /// until a real impl is plumbed in. Plan 37 §7B's invariant —
-    /// "tenant code never runs in Zone B unless every slot is owned
-    /// by a real impl" — is encoded by this default + the typed
-    /// errors each Noop returns.
+    /// Default is the fail-closed configuration: every component
+    /// slot is `Noop`. Plan 37 §7B's invariant — "tenant code never
+    /// runs in Zone B unless every slot is owned by a real impl" —
+    /// is encoded by the `*Error::NotWired` returns from each Noop.
     fn default() -> Self {
         Self {
             egress: Arc::new(NoopEgressProxy),
@@ -68,6 +77,7 @@ impl Default for Supervisor {
             keystore: Arc::new(NoopKeystoreReleaser),
             audit: Arc::new(NoopAuditSigner),
             artifact: Arc::new(NoopArtifactCollector),
+            backend: Arc::new(NoopBackendLauncher),
             state: PlanStateMachine::new(),
         }
     }
@@ -77,24 +87,314 @@ impl Supervisor {
     pub fn new() -> Self {
         Self::default()
     }
+
+    /// Drive a workload's launch lifecycle: verify the signed plan,
+    /// walk the state machine, request the backend launch.
+    ///
+    /// On any failure the state transitions to `PlanState::Failed`
+    /// (best-effort — if the supervisor is already in a terminal
+    /// state the second transition errors out, which is fine because
+    /// we're already returning an error).
+    ///
+    /// `trusted_keys` mirrors `mvm_plan::verify_plan`'s contract —
+    /// pass the supervisor's trusted-key set so a plan signed by an
+    /// unknown party is refused before any other step runs.
+    ///
+    /// Wave 2 wires the supervisor's component slots into the launch
+    /// path (apply egress policy, release secrets, etc.). Today's
+    /// "happy path" is intentionally narrow: parse + verify + state
+    /// walk + backend dispatch. The component slots are still all
+    /// Noop by default, so a `Supervisor::default()` walking this
+    /// path will fail at backend dispatch with `BackendError::NotWired`
+    /// (the fail-closed invariant) until a real `BackendLauncher`
+    /// is plumbed in.
+    pub async fn launch(
+        &mut self,
+        signed: &SignedExecutionPlan,
+        trusted_keys: &[(&str, &VerifyingKey)],
+    ) -> Result<(), SupervisorError> {
+        // Step 1: signature + schema + version pin.
+        let plan = match mvm_plan::verify_plan(signed, trusted_keys) {
+            Ok(p) => p,
+            Err(e) => {
+                let err = SupervisorError::PlanVerify(e.to_string());
+                self.transition_or_warn(PlanState::Failed);
+                return Err(err);
+            }
+        };
+
+        // Step 2: Pending → Verified.
+        self.state.transition(PlanState::Verified).map_err(|e| {
+            self.transition_or_warn(PlanState::Failed);
+            SupervisorError::from(e)
+        })?;
+
+        // Step 3: backend dispatch.
+        if let Err(e) = self.backend.launch(&plan).await {
+            self.transition_or_warn(PlanState::Failed);
+            return Err(SupervisorError::from(e));
+        }
+
+        // Step 4: Verified → Launched → Running. Wave 2's real impl
+        // will block between Launched and Running waiting for the
+        // guest agent's first ping; today the transition is immediate
+        // because there's no real guest to wait for.
+        self.state.transition(PlanState::Launched).map_err(|e| {
+            self.transition_or_warn(PlanState::Failed);
+            SupervisorError::from(e)
+        })?;
+        self.state.transition(PlanState::Running).map_err(|e| {
+            self.transition_or_warn(PlanState::Failed);
+            SupervisorError::from(e)
+        })?;
+
+        Ok(())
+    }
+
+    /// Drive a workload's teardown lifecycle: Running → Stopping →
+    /// Stopped, with a backend stop call in between.
+    pub async fn stop(&mut self, plan_id: &PlanId) -> Result<(), SupervisorError> {
+        self.state.transition(PlanState::Stopping).map_err(|e| {
+            self.transition_or_warn(PlanState::Failed);
+            SupervisorError::from(e)
+        })?;
+
+        if let Err(e) = self.backend.stop(plan_id).await {
+            self.transition_or_warn(PlanState::Failed);
+            return Err(SupervisorError::from(e));
+        }
+
+        self.state.transition(PlanState::Stopped).map_err(|e| {
+            self.transition_or_warn(PlanState::Failed);
+            SupervisorError::from(e)
+        })?;
+        Ok(())
+    }
+
+    /// Best-effort transition to the given state, logging on
+    /// disallowed transitions instead of bailing. Used in error
+    /// paths where we want to record the failure but the state
+    /// machine may already be in a terminal state.
+    fn transition_or_warn(&mut self, to: PlanState) {
+        if let Err(e) = self.state.transition(to) {
+            warn!(?e, ?to, "state transition during error handling failed");
+        }
+    }
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::state::PlanState;
+    use crate::backend::BackendLauncher;
+    use async_trait::async_trait;
+    use ed25519_dalek::SigningKey;
+    use mvm_plan::*;
+    use rand::rngs::OsRng;
+    use std::collections::BTreeMap;
+    use std::sync::Mutex;
+
+    /// Test backend that records every call and lets the test pick
+    /// success or failure per method.
+    struct MockBackend {
+        launch_calls: Mutex<Vec<PlanId>>,
+        stop_calls: Mutex<Vec<PlanId>>,
+        launch_should_fail: bool,
+        stop_should_fail: bool,
+    }
+
+    impl MockBackend {
+        fn new() -> Self {
+            Self {
+                launch_calls: Mutex::new(Vec::new()),
+                stop_calls: Mutex::new(Vec::new()),
+                launch_should_fail: false,
+                stop_should_fail: false,
+            }
+        }
+
+        fn launches(&self) -> Vec<PlanId> {
+            self.launch_calls.lock().unwrap().clone()
+        }
+
+        fn stops(&self) -> Vec<PlanId> {
+            self.stop_calls.lock().unwrap().clone()
+        }
+    }
+
+    #[async_trait]
+    impl BackendLauncher for MockBackend {
+        async fn launch(&self, plan: &ExecutionPlan) -> Result<(), BackendError> {
+            self.launch_calls.lock().unwrap().push(plan.plan_id.clone());
+            if self.launch_should_fail {
+                return Err(BackendError::LaunchFailed("mock".into()));
+            }
+            Ok(())
+        }
+
+        async fn stop(&self, plan_id: &PlanId) -> Result<(), BackendError> {
+            self.stop_calls.lock().unwrap().push(plan_id.clone());
+            if self.stop_should_fail {
+                return Err(BackendError::StopFailed("mock".into()));
+            }
+            Ok(())
+        }
+    }
+
+    fn sample_plan() -> ExecutionPlan {
+        ExecutionPlan {
+            schema_version: SCHEMA_VERSION,
+            plan_id: PlanId("01HXTEST0000000000000000".to_string()),
+            plan_version: 1,
+            tenant: TenantId("tenant-a".to_string()),
+            workload: WorkloadId("workload-1".to_string()),
+            runtime_profile: RuntimeProfileRef("firecracker".to_string()),
+            image: SignedImageRef {
+                name: "tenant-worker-aarch64".to_string(),
+                sha256: "a".repeat(64),
+                cosign_bundle: None,
+            },
+            resources: Resources {
+                cpus: 2,
+                mem_mib: 1024,
+                disk_mib: 4096,
+                timeouts: TimeoutSpec {
+                    boot_secs: 30,
+                    exec_secs: 600,
+                },
+            },
+            network_policy: PolicyRef("default-deny".to_string()),
+            fs_policy: FsPolicyRef("default".to_string()),
+            secrets: vec![],
+            egress_policy: PolicyRef("agent-l7".to_string()),
+            tool_policy: PolicyRef("read-only".to_string()),
+            artifact_policy: ArtifactPolicy {
+                capture_paths: vec!["/artifacts".to_string()],
+                retention_days: 30,
+            },
+            audit_labels: BTreeMap::new(),
+            key_rotation: KeyRotationSpec { interval_days: 7 },
+            attestation: AttestationRequirement {
+                mode: AttestationMode::Noop,
+            },
+            release_pin: None,
+            post_run: PostRunLifecycle {
+                destroy_on_exit: true,
+                snapshot_on_idle: false,
+                idle_secs: 0,
+            },
+        }
+    }
+
+    fn sign_sample(plan: &ExecutionPlan) -> (SignedExecutionPlan, SigningKey, VerifyingKey) {
+        let sk = SigningKey::generate(&mut OsRng);
+        let vk = sk.verifying_key();
+        let signed = sign_plan(plan, &sk, "test");
+        (signed, sk, vk)
+    }
+
+    fn make_supervisor_with_backend(b: Arc<MockBackend>) -> Supervisor {
+        let mut s = Supervisor::new();
+        s.backend = b;
+        s
+    }
+
+    #[tokio::test]
+    async fn happy_path_launch_walks_to_running() {
+        let plan = sample_plan();
+        let (signed, _sk, vk) = sign_sample(&plan);
+        let backend = Arc::new(MockBackend::new());
+        let mut s = make_supervisor_with_backend(backend.clone());
+
+        s.launch(&signed, &[("test", &vk)]).await.unwrap();
+
+        assert_eq!(s.state.current(), PlanState::Running);
+        assert_eq!(backend.launches(), vec![plan.plan_id.clone()]);
+        assert!(backend.stops().is_empty());
+    }
+
+    #[tokio::test]
+    async fn happy_path_stop_walks_to_stopped() {
+        let plan = sample_plan();
+        let (signed, _sk, vk) = sign_sample(&plan);
+        let backend = Arc::new(MockBackend::new());
+        let mut s = make_supervisor_with_backend(backend.clone());
+
+        s.launch(&signed, &[("test", &vk)]).await.unwrap();
+        s.stop(&plan.plan_id).await.unwrap();
+
+        assert_eq!(s.state.current(), PlanState::Stopped);
+        assert!(s.state.is_terminal());
+        assert_eq!(backend.stops(), vec![plan.plan_id.clone()]);
+    }
+
+    #[tokio::test]
+    async fn invalid_signature_keeps_state_pending_or_failed() {
+        let plan = sample_plan();
+        let (mut signed, _sk, vk) = sign_sample(&plan);
+        // Corrupt the payload after signing.
+        signed.0.payload[0] ^= 0x01;
+
+        let backend = Arc::new(MockBackend::new());
+        let mut s = make_supervisor_with_backend(backend.clone());
+
+        let result = s.launch(&signed, &[("test", &vk)]).await;
+        assert!(matches!(result, Err(SupervisorError::PlanVerify(_))));
+        // We transition to Failed on error.
+        assert_eq!(s.state.current(), PlanState::Failed);
+        // Backend was never asked to launch.
+        assert!(backend.launches().is_empty());
+    }
+
+    #[tokio::test]
+    async fn unknown_signer_blocks_before_backend() {
+        let plan = sample_plan();
+        let (signed, _sk, _vk) = sign_sample(&plan);
+        let (_other_sk, other_vk) = {
+            let sk = SigningKey::generate(&mut OsRng);
+            let vk = sk.verifying_key();
+            (sk, vk)
+        };
+
+        let backend = Arc::new(MockBackend::new());
+        let mut s = make_supervisor_with_backend(backend.clone());
+
+        let result = s.launch(&signed, &[("not-the-signer", &other_vk)]).await;
+        assert!(matches!(result, Err(SupervisorError::PlanVerify(_))));
+        assert_eq!(s.state.current(), PlanState::Failed);
+        assert!(backend.launches().is_empty());
+    }
+
+    #[tokio::test]
+    async fn backend_failure_transitions_to_failed() {
+        let plan = sample_plan();
+        let (signed, _sk, vk) = sign_sample(&plan);
+        let mut backend = MockBackend::new();
+        backend.launch_should_fail = true;
+        let backend = Arc::new(backend);
+        let mut s = make_supervisor_with_backend(backend.clone());
+
+        let result = s.launch(&signed, &[("test", &vk)]).await;
+        assert!(matches!(result, Err(SupervisorError::Backend(_))));
+        assert_eq!(s.state.current(), PlanState::Failed);
+        // Backend was called, but state never reached Launched/Running.
+        assert_eq!(backend.launches(), vec![plan.plan_id.clone()]);
+    }
+
+    #[tokio::test]
+    async fn default_supervisor_fails_closed_at_backend() {
+        let plan = sample_plan();
+        let (signed, _sk, vk) = sign_sample(&plan);
+        let mut s = Supervisor::new();
+        // No backend swap — Default's NoopBackendLauncher fails closed.
+
+        let result = s.launch(&signed, &[("test", &vk)]).await;
+        assert!(matches!(result, Err(SupervisorError::Backend(_))));
+        assert_eq!(s.state.current(), PlanState::Failed);
+    }
 
     #[test]
     fn default_supervisor_starts_in_pending() {
         let s = Supervisor::default();
         assert_eq!(s.state.current(), PlanState::Pending);
-    }
-
-    #[test]
-    fn supervisor_aggregates_every_slot() {
-        // Pure type-level assertion that every component is wired
-        // in Default. If a future field is added without a Default,
-        // this test won't compile.
-        let _ = Supervisor::default();
     }
 }

--- a/crates/mvm-supervisor/src/tool_gate.rs
+++ b/crates/mvm-supervisor/src/tool_gate.rs
@@ -1,0 +1,49 @@
+//! Tool-call gate slot. Wave 2 differentiator.
+//!
+//! Plan 37 §2.2 / §15: the supervisor mediates every tool the
+//! workload invokes via vsock RPC. The gate consults the plan's
+//! `tool_policy: PolicyRef`, looks the bundle up via
+//! `mvm-policy::ToolPolicy`, and allow/deny per call. Audit entries
+//! reference both the plan id and the tool name.
+
+use async_trait::async_trait;
+use thiserror::Error;
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum ToolDecision {
+    Allow,
+    Deny { reason: String },
+}
+
+#[derive(Debug, Error)]
+pub enum ToolError {
+    #[error("tool gate not wired (Noop slot)")]
+    NotWired,
+
+    #[error("tool {name} is not on the plan's allowlist")]
+    NotAllowed { name: String },
+}
+
+#[async_trait]
+pub trait ToolGate: Send + Sync {
+    async fn check(&self, tool_name: &str) -> Result<ToolDecision, ToolError>;
+}
+
+pub struct NoopToolGate;
+
+#[async_trait]
+impl ToolGate for NoopToolGate {
+    async fn check(&self, _tool_name: &str) -> Result<ToolDecision, ToolError> {
+        Err(ToolError::NotWired)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn noop_tool_gate_is_constructable() {
+        let _: Box<dyn ToolGate> = Box::new(NoopToolGate);
+    }
+}


### PR DESCRIPTION
## Summary

Stacked on PR #36 (Wave 1.3). Wires `Supervisor::launch(signed_plan,
trusted_keys)` and `Supervisor::stop(plan_id)` to drive the plan
execution lifecycle end-to-end through the state machine + a
`BackendLauncher` slot. Plan 37 §"Wave 1 — Foundation" item 4.

## Launch path

```
Pending
  │
  │ verify_plan(signed, trusted_keys) — sig + schema + version
  ▼
Verified
  │
  │ backend.launch(&plan).await
  ▼
Launched
  │
  │ (Wave 2 will block here until guest agent ping)
  ▼
Running
```

Stop path: `Running → Stopping → backend.stop() → Stopped`.

Any error transitions to `Failed` (best-effort: disallowed
transitions during error handling are logged via `tracing::warn`).
The state machine ensures `Failed` is absorbing.

## What lands

- `mvm-supervisor::backend::BackendLauncher` async trait with
  `launch(&plan)` + `stop(&plan_id)` methods. `NoopBackendLauncher`
  fails closed.
- `Supervisor::launch` + `Supervisor::stop` async methods.
- `SupervisorError` enum extended with `PlanVerify` variant.

## Fail-closed invariant preserved

A `Supervisor::default()` walking this path fails at backend
dispatch with `BackendError::NotWired` because the default
`NoopBackendLauncher` refuses every launch — the test
`default_supervisor_fails_closed_at_backend` codifies this.

## Component slots not yet in launch path

Wave 2 wires the egress / tool gate / keystore / audit / artifact
slots into the launch path. Today's "happy path" is intentionally
narrow: parse + verify + state walk + backend dispatch.

## Test plan

- [x] `cargo test -p mvm-supervisor` — 19 tests passing (was 13)
- [x] 6 new supervisor launch path tests:
  - `happy_path_launch_walks_to_running`
  - `happy_path_stop_walks_to_stopped`
  - `invalid_signature_keeps_state_pending_or_failed`
  - `unknown_signer_blocks_before_backend`
  - `backend_failure_transitions_to_failed`
  - `default_supervisor_fails_closed_at_backend`
- [x] `cargo clippy --workspace --all-targets -- -D warnings` clean

Tests use a `MockBackend` that records every launch/stop call so
assertions verify the supervisor walked the state machine in
order *and* called the backend exactly when expected.

## Stacked PR

Targets `feat/plan-37-wave-1-mvm-supervisor` (PR #36). Auto-retargets
to `main` once the stack lands.

## Non-goals (deferred per plan 37)

- Component slots wired into launch path — Wave 2
- Real Firecracker backend impl + `mvm-runtime/vm/backend.rs`
  `AnyBackend` lift behind the `BackendLauncher` trait — follow-up
- mvm-hostd → mvm-supervisor binary lift + systemd unit + launchd
  plist — follow-up
- Audit binding to (plan_id, plan_version, bundle_id, bundle_version,
  image_digest) — Wave 1.5

🤖 Generated with [Claude Code](https://claude.com/claude-code)