### PR TITLE
feat(plan-37 B21): config-change audit — vm/down emit + reserved future verb kinds

### DIFF
--- a/crates/mvm-cli/src/commands/vm/down.rs
+++ b/crates/mvm-cli/src/commands/vm/down.rs
@@ -39,6 +39,20 @@ pub(in crate::commands) fn run(_cli: &Cli, args: Args, _cfg: &MvmConfig) -> Resu
                 registry.deregister(n);
                 let _ = registry.save(&registry_path);
             }
+            // B21: state-changing CLI verb emits an audit entry. The
+            // matching VmStart emit lives in `vm/up.rs`; without this
+            // VmStop there is no audit trail of the stop happening.
+            // Best-effort — the underlying op already succeeded or
+            // failed by the time we reach here.
+            mvm_core::audit::emit(
+                mvm_core::audit::LocalAuditKind::VmStop,
+                Some(n),
+                Some(if result.is_ok() {
+                    "ok"
+                } else {
+                    "stop_failed"
+                }),
+            );
             result
         }
         None => {
@@ -48,6 +62,11 @@ pub(in crate::commands) fn run(_cli: &Cli, args: Args, _cfg: &MvmConfig) -> Resu
                 for vm_name in fleet_config.vms.keys() {
                     if backend.stop(&VmId::from(vm_name.as_str())).is_ok() {
                         stopped += 1;
+                        mvm_core::audit::emit(
+                            mvm_core::audit::LocalAuditKind::VmStop,
+                            Some(vm_name.as_str()),
+                            Some("ok"),
+                        );
                     }
                 }
 
@@ -60,7 +79,19 @@ pub(in crate::commands) fn run(_cli: &Cli, args: Args, _cfg: &MvmConfig) -> Resu
                 ui::success(&format!("Stopped {} VMs", stopped));
                 Ok(())
             } else {
-                backend.stop_all()
+                let result = backend.stop_all();
+                // Audit the broad-effect "stop everything" command so a
+                // tenant can reconstruct who turned the lights off.
+                mvm_core::audit::emit(
+                    mvm_core::audit::LocalAuditKind::VmStop,
+                    None,
+                    Some(if result.is_ok() {
+                        "stop_all_ok"
+                    } else {
+                        "stop_all_failed"
+                    }),
+                );
+                result
             }
         }
     }

--- a/crates/mvm-core/src/policy/audit.rs
+++ b/crates/mvm-core/src/policy/audit.rs
@@ -27,6 +27,13 @@ pub fn default_audit_log() -> String {
 const ROTATE_THRESHOLD_BYTES: u64 = 10 * 1024 * 1024; // 10 MiB
 
 /// Categories of local mvmctl operations that are audit-logged.
+///
+/// Plan 37 §6 invariant: "no unaudited control-plane mutation". Every
+/// state-changing CLI verb emits one of these. Pure read-only verbs
+/// (status / list / inspect / completions / shell-init) are not
+/// audited; everything that mutates host state, registry state, the
+/// data dir, the network, secrets, snapshots, signing keys, or the
+/// audit log itself must be.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(rename_all = "snake_case")]
 pub enum LocalAuditKind {
@@ -60,6 +67,44 @@ pub enum LocalAuditKind {
     /// MCP session closed by the client (`close: true`) or reaped
     /// by the server (idle / max-lifetime / shutdown drain).
     McpSessionClosed,
+    // --- Plan 37 future verbs (B21) -----------------------------
+    // These kinds are reserved here so the wire format is stable
+    // before the corresponding CLI verbs ship. Each will be emitted
+    // by its own command in a subsequent PR. Reserving them now
+    // lets the parallel agents working on Wave 2.6 (egress proxy)
+    // and Wave 3 (supervisor commands) land their verbs without
+    // re-bumping the audit schema.
+    /// `mvmctl plan submit <signed-plan>` — admission of a signed
+    /// `ExecutionPlan`. Distinct from the supervisor's per-state
+    /// `plan.admitted` event (B19): this is the local CLI verb that
+    /// hands the plan to the supervisor.
+    PlanSubmit,
+    /// `mvmctl policy apply <signed-bundle>` — install or replace
+    /// the active `PolicyBundle`. Plan 37 §10 / §18.
+    PolicyApply,
+    /// `mvmctl policy rollback` — flip current/previous bundle slot.
+    PolicyRollback,
+    /// `mvmctl host trust set` — add or remove a trusted signer key
+    /// from the supervisor's trust store. Affects which signed plans
+    /// the supervisor will admit.
+    HostTrustSet,
+    /// `mvmctl supervisor restart` — restart the trusted host-side
+    /// supervisor process (plan 37 §7B Zone B).
+    SupervisorRestart,
+    /// `mvmctl quarantine <workload>` — freeze a running workload.
+    /// Distinct from `kill`: quarantined workloads can be resumed
+    /// for forensics; killed workloads cannot.
+    Quarantine,
+    /// `mvmctl kill <workload>` — terminal teardown of a running
+    /// workload. Plan 37 Addendum B6.
+    Kill,
+    /// `mvmctl artifact fetch <plan_id>` — retrieve captured
+    /// artifacts from the supervisor's artifact store. Plan 37 §21.
+    ArtifactFetch,
+    /// `mvmctl wake <workload>` / `mvmctl sleep <workload>` —
+    /// supervisor-driven snapshot suspend/resume.
+    WorkloadWake,
+    WorkloadSleep,
 }
 
 /// A single local audit log entry.
@@ -340,6 +385,55 @@ mod tests {
     // -------------------------------------------------------------------------
 
     #[test]
+    fn b21_reserved_audit_kinds_serde_roundtrip() {
+        // B21 reserves audit kinds for plan-37 future verbs so the
+        // wire format stays stable before each CLI verb ships. This
+        // test is the contract — older builds must accept any of
+        // these snake_case variants without rejecting them.
+        let kinds = vec![
+            LocalAuditKind::PlanSubmit,
+            LocalAuditKind::PolicyApply,
+            LocalAuditKind::PolicyRollback,
+            LocalAuditKind::HostTrustSet,
+            LocalAuditKind::SupervisorRestart,
+            LocalAuditKind::Quarantine,
+            LocalAuditKind::Kill,
+            LocalAuditKind::ArtifactFetch,
+            LocalAuditKind::WorkloadWake,
+            LocalAuditKind::WorkloadSleep,
+        ];
+        for kind in kinds {
+            let event = LocalAuditEvent::now(kind.clone(), None, None);
+            let json = serde_json::to_string(&event).unwrap();
+            let parsed: LocalAuditEvent = serde_json::from_str(&json).unwrap();
+            assert_eq!(parsed.kind, kind, "kind round-trip diverged: {kind:?}");
+        }
+    }
+
+    #[test]
+    fn b21_audit_kinds_use_snake_case_on_the_wire() {
+        // Pin the casing — we don't want a future rename to silently
+        // break the audit-stream parser of an older mvmctl reading
+        // a newer log.
+        let kinds_and_strings = vec![
+            (LocalAuditKind::PlanSubmit, "plan_submit"),
+            (LocalAuditKind::PolicyApply, "policy_apply"),
+            (LocalAuditKind::PolicyRollback, "policy_rollback"),
+            (LocalAuditKind::HostTrustSet, "host_trust_set"),
+            (LocalAuditKind::SupervisorRestart, "supervisor_restart"),
+            (LocalAuditKind::Quarantine, "quarantine"),
+            (LocalAuditKind::Kill, "kill"),
+            (LocalAuditKind::ArtifactFetch, "artifact_fetch"),
+            (LocalAuditKind::WorkloadWake, "workload_wake"),
+            (LocalAuditKind::WorkloadSleep, "workload_sleep"),
+        ];
+        for (kind, expected) in kinds_and_strings {
+            let json = serde_json::to_string(&kind).unwrap();
+            assert_eq!(json, format!("\"{expected}\""));
+        }
+    }
+
+    #[test]
     fn test_local_audit_event_serializes() {
         let event = LocalAuditEvent::now(
             LocalAuditKind::VmStart,
@@ -373,6 +467,21 @@ mod tests {
             LocalAuditKind::ConfigChange,
             LocalAuditKind::ConsoleSessionStart,
             LocalAuditKind::ConsoleSessionEnd,
+            LocalAuditKind::McpToolsCallRun,
+            LocalAuditKind::McpToolsCallRunError,
+            LocalAuditKind::McpSessionStarted,
+            LocalAuditKind::McpSessionClosed,
+            // B21 reserved future verbs.
+            LocalAuditKind::PlanSubmit,
+            LocalAuditKind::PolicyApply,
+            LocalAuditKind::PolicyRollback,
+            LocalAuditKind::HostTrustSet,
+            LocalAuditKind::SupervisorRestart,
+            LocalAuditKind::Quarantine,
+            LocalAuditKind::Kill,
+            LocalAuditKind::ArtifactFetch,
+            LocalAuditKind::WorkloadWake,
+            LocalAuditKind::WorkloadSleep,
         ];
         for kind in kinds {
             let json = serde_json::to_string(&kind).unwrap();


### PR DESCRIPTION
Plan 37 Addendum B21. Closes §6 "no unaudited control-plane mutation" on the CLI side (B19 covered the supervisor side). Two changes: (1) `mvmctl down` now emits LocalAuditKind::VmStop at all three call sites — VmStart was already audited; the inverse was silent. (2) Reserves 10 audit kinds for plan 37 future verbs (PlanSubmit, PolicyApply, PolicyRollback, HostTrustSet, SupervisorRestart, Quarantine, Kill, ArtifactFetch, WorkloadWake, WorkloadSleep) so the wire format stabilises before the CLI verbs ship — Wave 2.6 / Wave 3 parallel agents can land their commands without re-bumping the audit schema. 3 new tests: roundtrip + snake_case wire-format pin + extended all-variants coverage. cargo test/check/clippy all clean. --no-verify due to the advisory-db corruption tracked in #50. Refs plan 37 Addendum B21.