### PR TITLE
feat(mvm-supervisor): L7EgressProxy + PolicyToolGate — plan 37 Waves 2.6 + 2.7a

### DIFF
--- a/crates/mvm-plan/src/lib.rs
+++ b/crates/mvm-plan/src/lib.rs
@@ -37,6 +37,6 @@ pub use signing::{PlanVerifyError, SignedExecutionPlan, sign_plan, verify_plan};
 pub use types::{
     ArtifactPolicy, AttestationMode, AttestationRequirement, FsPolicyRef, KeyRotationSpec, Nonce,
     NonceParseError, PlanId, PolicyRef, PostRunLifecycle, ReleasePin, Resources, RuntimeProfileRef,
-    SecretBinding, SecretSource, SignedImageRef, TenantId, TimeoutSpec, WorkloadId,
+    SecretBinding, SecretSource, SignedImageRef, TenantId, TimeoutSpec, Variant, WorkloadId,
 };
 pub use validity::{NonceStore, PlanValidityError, check_window};

--- a/crates/mvm-plan/src/types.rs
+++ b/crates/mvm-plan/src/types.rs
@@ -81,6 +81,33 @@ pub struct PolicyRef(pub String);
 #[serde(transparent)]
 pub struct FsPolicyRef(pub String);
 
+/// Workload variant — `Dev` is the development sandbox (carries the
+/// dev guest agent's RCE-by-design Exec handler, accepts looser
+/// policies), `Prod` is the production posture (no dev primitives,
+/// strict policy gates). Wave 2.6's `L7EgressProxy` consults this
+/// at construction time to refuse plain-HTTP egress for `Prod`.
+///
+/// Mirrors `passthru.variant` from Nix-side `mkGuest`. The supervisor
+/// resolves it from the workload's `SignedImageRef.name` suffix or
+/// from the policy bundle's bound variant — Wave 1 already has
+/// `audit::AuditEntry::variant` recording this for every entry, so
+/// the value flows through the audit chain unchanged.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum Variant {
+    Dev,
+    Prod,
+}
+
+impl Variant {
+    /// True iff this variant carries production-strict policy
+    /// requirements (no dev RCE primitives, no plain-HTTP egress,
+    /// verity-required rootfs, etc.).
+    pub fn is_prod(self) -> bool {
+        matches!(self, Variant::Prod)
+    }
+}
+
 /// A secret binding from a name (visible inside the guest) to its
 /// source (resolved by the supervisor's `KeystoreReleaser` per Wave 3).
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]

--- a/crates/mvm-policy/src/lib.rs
+++ b/crates/mvm-policy/src/lib.rs
@@ -27,7 +27,8 @@ pub mod signing;
 
 pub use bundle::{PolicyBundle, PolicyId, SCHEMA_VERSION, TenantOverlay};
 pub use policies::{
-    ArtifactPolicy, AuditPolicy, EgressPolicy, KeyPolicy, NetworkPolicy, PiiPolicy, ToolPolicy,
+    ArtifactPolicy, AuditPolicy, DEFAULT_BODY_CAP_BYTES, EgressPolicy, KeyPolicy, NetworkPolicy,
+    PiiPolicy, ToolPolicy,
 };
 pub use resolver::{EffectivePolicy, EmergencyDeny, resolve};
 pub use signing::{BundleVerifyError, SignedPolicyBundle, sign_bundle, verify_bundle};

--- a/crates/mvm-policy/src/policies.rs
+++ b/crates/mvm-policy/src/policies.rs
@@ -30,21 +30,54 @@ pub struct NetworkPolicy {
     pub preset: Option<String>,
 }
 
-/// L7 egress policy. Plan 37 §15 differentiator. Wave 2 fills:
-///   - inspector chain (SecretsScanner, SsrfGuard, InjectionGuard,
-///     DestinationPolicy)
-///   - AiProviderRouter
-///   - allowed destinations / SNI pin set
+/// L7 egress policy. Plan 37 §15 differentiator. Wave 2.6 fills the
+/// fields the `L7EgressProxy` actually consumes:
+/// - `allow_list` is the (host, port) destination policy.
+/// - `allow_plain_http` opens the plain-HTTP code path; **the
+///   supervisor refuses to honour `true` for `Variant::Prod`** so
+///   production workloads can never accidentally egress unencrypted.
+/// - `body_cap_bytes` bounds the body read for plain-HTTP. `0` means
+///   "use default" ([`DEFAULT_BODY_CAP_BYTES`], 16 MiB) — matches
+///   AI-provider request sizes (long contexts + image uploads).
+/// - `disabled_inspectors` lets operators turn off specific
+///   inspectors by name (e.g., disable `pii_redactor` for an
+///   analytics workload that scrubs upstream).
 ///
-/// Today: a stub flag indicating whether the egress proxy is on at
-/// all. The proxy itself is plan 32 / PR #23 (foundation only).
+/// `mode` is retained for compatibility with Wave 1's stub; the
+/// supervisor honours `mode = Some("open")` as a kill-switch that
+/// skips the proxy entirely. New fields are `#[serde(default)]` so
+/// older bundles continue to parse.
 #[derive(Debug, Clone, PartialEq, Eq, Default, Serialize, Deserialize)]
 #[serde(deny_unknown_fields)]
 pub struct EgressPolicy {
-    /// `open` — no proxy. `l3` — drop-on-deny IP allowlist (plan 32).
-    /// `l3_plus_l7` — Wave 2 differentiator. Stub today.
+    /// `open` — no proxy. Anything else routes through the L7 chain.
     pub mode: Option<String>,
+    /// (host, port) allowlist consumed by `DestinationPolicy`.
+    /// `port = 0` is the explicit "any port for this host" wildcard.
+    #[serde(default)]
+    pub allow_list: Vec<(String, u16)>,
+    /// Whether plain HTTP (not just CONNECT/HTTPS) is permitted.
+    /// **Forbidden for `Variant::Prod`** — the supervisor's
+    /// `with_l7_egress` builder rejects this combination at policy
+    /// load.
+    #[serde(default)]
+    pub allow_plain_http: bool,
+    /// Body read cap for plain-HTTP (bytes). `0` means "use default"
+    /// ([`DEFAULT_BODY_CAP_BYTES`]).
+    #[serde(default)]
+    pub body_cap_bytes: u64,
+    /// Per-name inspector opt-out. Empty == every inspector enabled.
+    /// Names match `Inspector::name()` strings: `destination_policy`,
+    /// `ssrf_guard`, `secrets_scanner`, `injection_guard`,
+    /// `pii_redactor`.
+    #[serde(default)]
+    pub disabled_inspectors: Vec<String>,
 }
+
+/// Default body cap when `EgressPolicy::body_cap_bytes` is 0.
+/// 16 MiB — matches AI-provider request sizes (long contexts +
+/// image uploads). Configurable per workload via the policy field.
+pub const DEFAULT_BODY_CAP_BYTES: u64 = 16 * 1024 * 1024;
 
 /// PII redaction policy. Plan 37 §15.1.
 #[derive(Debug, Clone, PartialEq, Eq, Default, Serialize, Deserialize)]

--- a/crates/mvm-policy/src/resolver.rs
+++ b/crates/mvm-policy/src/resolver.rs
@@ -157,6 +157,10 @@ mod tests {
             },
             egress: EgressPolicy {
                 mode: Some("base-egress".to_string()),
+                allow_list: vec![],
+                allow_plain_http: false,
+                body_cap_bytes: 0,
+                disabled_inspectors: vec![],
             },
             pii: PiiPolicy {
                 mode: Some("detect".to_string()),

--- a/crates/mvm-policy/src/signing.rs
+++ b/crates/mvm-policy/src/signing.rs
@@ -99,6 +99,7 @@ mod tests {
             },
             egress: EgressPolicy {
                 mode: Some("l3_plus_l7".to_string()),
+                ..EgressPolicy::default()
             },
             pii: PiiPolicy {
                 mode: Some("redact".to_string()),

--- a/crates/mvm-supervisor/Cargo.toml
+++ b/crates/mvm-supervisor/Cargo.toml
@@ -19,8 +19,13 @@ regex.workspace = true
 serde.workspace = true
 serde_json.workspace = true
 thiserror = "1"
+# Wave 2.6: L7EgressProxy uses tokio::net::lookup_host for the
+# production DnsResolver impl. Tests use only `macros + rt`, the
+# proxy needs `net` for lookup. `rt-multi-thread` lands when the
+# TCP listener loop ships in 2.6 chunk (c).
+tokio = { workspace = true, features = ["net", "rt"] }
 tracing.workspace = true
 
 [dev-dependencies]
 rand.workspace = true
-tokio = { workspace = true, features = ["macros", "rt"] }
+tokio = { workspace = true, features = ["macros", "rt", "rt-multi-thread", "net", "io-util", "time"] }

--- a/crates/mvm-supervisor/src/l7_proxy.rs
+++ b/crates/mvm-supervisor/src/l7_proxy.rs
@@ -1,0 +1,1135 @@
+//! `L7EgressProxy` — the real `EgressProxy` impl that wires the
+//! inspector chain (Waves 2.1–2.5) into outbound HTTP traffic.
+//!
+//! Plan 37 §15 (Wave 2.6 / Phase 1). See
+//! `specs/plans/37-wave-2.6-l7-egress-proxy.md` for the full design.
+//!
+//! ## Phase 1 scope (this module)
+//!
+//! - Pure inspection logic in [`L7EgressProxy::evaluate`]: takes
+//!   (host, port, body) and a mockable `DnsResolver`, runs the
+//!   chain twice (once with the host string, then again after
+//!   DNS-pinning the resolved IP), returns an [`EgressDecision`]
+//!   plus a structured [`AuditFields`] payload.
+//! - HTTP CONNECT request parsing in [`parse_connect`].
+//! - Per-connection lifecycle in [`L7EgressProxy::serve_connection`]:
+//!   reads the CONNECT line, calls `evaluate`, writes a
+//!   `200 Connection Established` or `403 Forbidden` response, and
+//!   on Allow splices bytes via `tokio::io::copy_bidirectional` to
+//!   the pinned upstream IP.
+//! - TCP listener loop in [`L7EgressProxy::serve`].
+//! - Audit emission via [`AuditSigner`] for every request.
+//!
+//! ## Out of scope (Wave 2.6.5)
+//!
+//! - TLS MITM (Phase 2).
+//! - HTTP/2 / HTTP/3, connection pooling, bandwidth caps.
+//! - Plain-HTTP request body inspection — Phase 1 ships HTTPS
+//!   CONNECT only, plain HTTP is gated on `EgressPolicy::allow_plain_http`
+//!   which the supervisor refuses to honour for `Variant::Prod`.
+
+use std::net::{IpAddr, SocketAddr};
+use std::sync::Arc;
+use std::time::Instant;
+
+use async_trait::async_trait;
+use chrono::{DateTime, Utc};
+use tokio::io::{AsyncReadExt, AsyncWriteExt};
+use tokio::net::{TcpListener, TcpStream};
+
+use crate::audit::AuditError;
+use crate::egress::{EgressDecision, EgressError, EgressProxy};
+use crate::inspector::{InspectorChain, InspectorVerdict, RequestCtx};
+
+/// Async DNS resolver, abstracted so tests can inject mock IPs and
+/// the production wiring uses `tokio::net::lookup_host`. Returns
+/// the **first** address — the proxy resolves once, pins that IP
+/// into `RequestCtx`, and connects to it (not the hostname); this
+/// is the DNS-rebinding defence.
+#[async_trait]
+pub trait DnsResolver: Send + Sync {
+    async fn resolve_one(&self, host: &str, port: u16) -> Result<IpAddr, EgressError>;
+}
+
+/// Production resolver — wraps `tokio::net::lookup_host`. Returns
+/// the first resolved address (IPv4 preferred when both are
+/// returned by the OS resolver, but no explicit ordering is
+/// guaranteed). Tests use a [`MockDnsResolver`] instead.
+pub struct TokioDnsResolver;
+
+#[async_trait]
+impl DnsResolver for TokioDnsResolver {
+    async fn resolve_one(&self, host: &str, port: u16) -> Result<IpAddr, EgressError> {
+        let target = format!("{host}:{port}");
+        let mut iter = tokio::net::lookup_host(target.as_str())
+            .await
+            .map_err(|e| EgressError::UpstreamUnreachable(format!("dns lookup {target}: {e}")))?;
+        match iter.next() {
+            Some(addr) => Ok(addr.ip()),
+            None => Err(EgressError::UpstreamUnreachable(format!(
+                "dns lookup {target}: no addresses returned"
+            ))),
+        }
+    }
+}
+
+/// Verdict outcome surfaced to the audit signer. `Allow` means the
+/// chain ran end-to-end; `Deny` means an inspector short-circuited;
+/// `Transform` means at least one inspector returned `Transform`
+/// (i.e., PII detected) but the chain still ended in Allow.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum EgressOutcome {
+    Allow,
+    Deny,
+    Transform,
+}
+
+/// Structured audit payload emitted per request, regardless of
+/// outcome. The proxy hands this to [`crate::audit::AuditSigner`]
+/// after each [`evaluate`](L7EgressProxy::evaluate) call.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct AuditFields {
+    pub outcome: EgressOutcome,
+    pub deciding_inspector: &'static str,
+    pub host: String,
+    pub port: u16,
+    pub path: String,
+    /// Every `Transform { note }` collected during the run, in
+    /// chain order. Empty when no inspector returned Transform.
+    pub transforms: Vec<String>,
+    /// Populated for `outcome == Deny`. Reason text from the
+    /// short-circuiting inspector.
+    pub reason: Option<String>,
+    /// Pinned destination IP after DNS resolution. `None` when the
+    /// chain denied before resolution (e.g., DestinationPolicy
+    /// blocked on the host string).
+    pub resolved_ip: Option<IpAddr>,
+    pub duration_ms: u32,
+    pub timestamp: DateTime<Utc>,
+}
+
+#[derive(Debug, Clone)]
+pub struct EvaluationResult {
+    pub decision: EgressDecision,
+    pub audit: AuditFields,
+}
+
+/// Sink the proxy hands [`AuditFields`] to. The supervisor's
+/// production wiring wraps this around an [`AuditSigner`] +
+/// plan/bundle binding, building proper `AuditEntry` records.
+/// Tests use [`CapturingEgressAuditSink`] directly.
+#[async_trait]
+pub trait EgressAuditSink: Send + Sync {
+    async fn record(&self, fields: &AuditFields) -> Result<(), AuditError>;
+}
+
+/// In-memory sink for tests + dev mode. Wave 3's chain-signing
+/// production sink will replace this in non-dev paths.
+pub struct CapturingEgressAuditSink {
+    entries: std::sync::Mutex<Vec<AuditFields>>,
+}
+
+impl CapturingEgressAuditSink {
+    pub fn new() -> Self {
+        Self {
+            entries: std::sync::Mutex::new(Vec::new()),
+        }
+    }
+
+    pub fn entries(&self) -> Vec<AuditFields> {
+        self.entries
+            .lock()
+            .expect("CapturingEgressAuditSink mutex poisoned")
+            .clone()
+    }
+}
+
+impl Default for CapturingEgressAuditSink {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+#[async_trait]
+impl EgressAuditSink for CapturingEgressAuditSink {
+    async fn record(&self, fields: &AuditFields) -> Result<(), AuditError> {
+        self.entries
+            .lock()
+            .expect("CapturingEgressAuditSink mutex poisoned")
+            .push(fields.clone());
+        Ok(())
+    }
+}
+
+/// Sink that swallows audit records. Useful as a default for
+/// callsites that don't yet have a plan/bundle binding (the
+/// supervisor wires a real sink before exposing the proxy to
+/// workload traffic). Errors silently — tests should use
+/// [`CapturingEgressAuditSink`] when verifying audit emission.
+pub struct NoopEgressAuditSink;
+
+#[async_trait]
+impl EgressAuditSink for NoopEgressAuditSink {
+    async fn record(&self, _fields: &AuditFields) -> Result<(), AuditError> {
+        Ok(())
+    }
+}
+
+/// Parsed `CONNECT host:port HTTP/1.x` request line. Phase 1 only
+/// handles CONNECT; plain-HTTP request parsing lands in 2.6.5.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ConnectRequest {
+    pub host: String,
+    pub port: u16,
+}
+
+#[derive(Debug, thiserror::Error, PartialEq, Eq)]
+pub enum ConnectParseError {
+    #[error("expected CONNECT method, got {0}")]
+    NotConnect(String),
+    #[error("authority missing port: {0}")]
+    AuthorityMissingPort(String),
+    #[error("authority port not a u16: {0}")]
+    BadPort(String),
+    #[error("malformed request line")]
+    Malformed,
+    #[error("non-utf8 bytes in request line")]
+    NonUtf8,
+}
+
+/// Parse the first line of an HTTP CONNECT request.
+///
+/// Accepts `CONNECT host:port HTTP/1.x\r\n`. Tolerant about the
+/// HTTP-version field (we only require it starts with `HTTP/1.`),
+/// strict about the method and authority shape.
+///
+/// Phase 1 only consumes the request line — full header parsing
+/// isn't needed because we're either (a) accepting the CONNECT
+/// (in which case bytes after the empty line are the client's TLS
+/// payload, opaque to us) or (b) refusing it (we reply with 403
+/// and close).
+pub fn parse_connect(line: &[u8]) -> Result<ConnectRequest, ConnectParseError> {
+    let line = std::str::from_utf8(line).map_err(|_| ConnectParseError::NonUtf8)?;
+    let line = line
+        .strip_suffix("\r\n")
+        .or_else(|| line.strip_suffix('\n'))
+        .unwrap_or(line);
+    let mut parts = line.splitn(3, ' ');
+    let method = parts.next().ok_or(ConnectParseError::Malformed)?;
+    let authority = parts.next().ok_or(ConnectParseError::Malformed)?;
+    let version = parts.next().ok_or(ConnectParseError::Malformed)?;
+    if !method.eq_ignore_ascii_case("CONNECT") {
+        return Err(ConnectParseError::NotConnect(method.to_string()));
+    }
+    if !version.starts_with("HTTP/1.") {
+        return Err(ConnectParseError::Malformed);
+    }
+    let (host, port_str) = authority
+        .rsplit_once(':')
+        .ok_or_else(|| ConnectParseError::AuthorityMissingPort(authority.to_string()))?;
+    if host.is_empty() {
+        return Err(ConnectParseError::AuthorityMissingPort(
+            authority.to_string(),
+        ));
+    }
+    let port: u16 = port_str
+        .parse()
+        .map_err(|_| ConnectParseError::BadPort(port_str.to_string()))?;
+    Ok(ConnectRequest {
+        host: host.to_string(),
+        port,
+    })
+}
+
+pub struct L7EgressProxy {
+    chain: Arc<InspectorChain>,
+    resolver: Arc<dyn DnsResolver>,
+    audit: Arc<dyn EgressAuditSink>,
+    body_cap_bytes: usize,
+    /// Whether plain-HTTP requests (where the proxy reads the body
+    /// before invoking the chain) are allowed. The HTTPS CONNECT
+    /// path doesn't read bodies and is unaffected by this flag.
+    allow_plain_http: bool,
+}
+
+impl L7EgressProxy {
+    pub fn new(
+        chain: Arc<InspectorChain>,
+        resolver: Arc<dyn DnsResolver>,
+        audit: Arc<dyn EgressAuditSink>,
+        body_cap_bytes: usize,
+        allow_plain_http: bool,
+    ) -> Self {
+        Self {
+            chain,
+            resolver,
+            audit,
+            body_cap_bytes,
+            allow_plain_http,
+        }
+    }
+
+    pub fn body_cap_bytes(&self) -> usize {
+        self.body_cap_bytes
+    }
+
+    pub fn allow_plain_http(&self) -> bool {
+        self.allow_plain_http
+    }
+
+    /// Bind a TCP listener to `bind_addr` and accept connections.
+    /// Each accepted connection is served on a fresh tokio task
+    /// via [`L7EgressProxy::serve_connection`]. Returns when the
+    /// listener errors or the future is dropped.
+    ///
+    /// The proxy is `Arc`-wrapped so per-connection tasks can
+    /// hold a clone without taking exclusive ownership.
+    pub async fn serve(self: Arc<Self>, bind_addr: SocketAddr) -> std::io::Result<()> {
+        let listener = TcpListener::bind(bind_addr).await?;
+        loop {
+            let (stream, peer) = listener.accept().await?;
+            let proxy = Arc::clone(&self);
+            tokio::spawn(async move {
+                if let Err(e) = proxy.serve_connection(stream, peer).await {
+                    // Audit sink already recorded the verdict; this
+                    // log line is for operator-side noise on
+                    // unrecoverable I/O.
+                    tracing::warn!(peer = %peer, error = %e, "proxy connection ended with error");
+                }
+            });
+        }
+    }
+
+    /// Serve one accepted client connection: read the CONNECT
+    /// request line, run [`evaluate`], write the `200`/`403`
+    /// response, and on Allow splice bytes to the pinned upstream.
+    pub async fn serve_connection(
+        self: Arc<Self>,
+        mut client: TcpStream,
+        _peer: SocketAddr,
+    ) -> std::io::Result<()> {
+        // Read the request line (up to the first \r\n). Cap at 8 KiB
+        // — a CONNECT line never exceeds this and an unbounded read
+        // is a DoS vector.
+        let mut buf = [0u8; 8192];
+        let mut filled = 0usize;
+        let line_end = loop {
+            if filled == buf.len() {
+                let _ = write_status(&mut client, 400, "Request-line too long").await;
+                return Ok(());
+            }
+            let n = client.read(&mut buf[filled..]).await?;
+            if n == 0 {
+                // Client hung up before sending a full line. Nothing
+                // to audit (we don't even know the host) — drop.
+                return Ok(());
+            }
+            filled += n;
+            if let Some(idx) = find_subsequence(&buf[..filled], b"\r\n") {
+                break idx;
+            }
+        };
+        let request_line = &buf[..line_end];
+
+        let req = match parse_connect(request_line) {
+            Ok(req) => req,
+            Err(e) => {
+                let _ = write_status(&mut client, 400, &format!("bad CONNECT: {e}")).await;
+                return Ok(());
+            }
+        };
+
+        // Run the chain. Body is empty for CONNECT.
+        let result = match self.evaluate(&req.host, req.port, Vec::new()).await {
+            Ok(r) => r,
+            Err(EgressError::UpstreamUnreachable(msg)) => {
+                let _ = write_status(&mut client, 502, &format!("dns: {msg}")).await;
+                return Ok(());
+            }
+            Err(e) => {
+                let _ = write_status(&mut client, 500, &format!("internal: {e}")).await;
+                return Ok(());
+            }
+        };
+
+        // Emit audit BEFORE responding so the audit chain sees
+        // every attempt even if the client hangs up after.
+        let _ = self.audit.record(&result.audit).await;
+
+        match result.decision {
+            EgressDecision::Deny { reason } => {
+                let _ = write_403(&mut client, &reason).await;
+                Ok(())
+            }
+            EgressDecision::Allow => {
+                // Connect to the pinned IP, NOT the hostname (DNS
+                // rebinding defence — the IP we ran SsrfGuard
+                // against is the only IP we'll connect to).
+                let upstream_ip = match result.audit.resolved_ip {
+                    Some(ip) => ip,
+                    None => {
+                        // Host was an IP literal; SsrfGuard already
+                        // checked it. Use it directly.
+                        match req.host.parse::<IpAddr>() {
+                            Ok(ip) => ip,
+                            Err(_) => {
+                                // Should not happen — evaluate must
+                                // populate resolved_ip for hostnames.
+                                let _ =
+                                    write_status(&mut client, 500, "internal: missing pinned IP")
+                                        .await;
+                                return Ok(());
+                            }
+                        }
+                    }
+                };
+                let upstream_addr = SocketAddr::new(upstream_ip, req.port);
+                match TcpStream::connect(upstream_addr).await {
+                    Ok(mut upstream) => {
+                        if write_200_established(&mut client).await.is_err() {
+                            return Ok(());
+                        }
+                        let _ = tokio::io::copy_bidirectional(&mut client, &mut upstream).await;
+                        Ok(())
+                    }
+                    Err(e) => {
+                        let _ =
+                            write_status(&mut client, 502, &format!("upstream connect: {e}")).await;
+                        Ok(())
+                    }
+                }
+            }
+        }
+    }
+
+    /// Core inspection routine. Runs the chain twice: once on the
+    /// host string (catches `DestinationPolicy` denials before any
+    /// network work), then again after DNS-pinning the resolved IP
+    /// into `ctx.resolved_ip` (catches `SsrfGuard` denials post-
+    /// resolution). Returns the decision plus a structured audit
+    /// payload the caller hands to `AuditSigner`.
+    ///
+    /// Body-cap enforcement is the caller's responsibility *for the
+    /// HTTPS CONNECT path* (no body read there); for the plain-HTTP
+    /// path, the caller checks `body.len() > body_cap_bytes` before
+    /// invoking this and returns `body_too_large` outside the chain.
+    /// This separation keeps `evaluate` focused on the chain and
+    /// keeps the cap visible at the read site.
+    pub async fn evaluate(
+        &self,
+        host: &str,
+        port: u16,
+        body: Vec<u8>,
+    ) -> Result<EvaluationResult, EgressError> {
+        let started = Instant::now();
+        let mut ctx = RequestCtx::new(host, port, "").with_body(body);
+        let mut transforms: Vec<String> = Vec::new();
+
+        // First pass: chain runs against the host string. If the
+        // host is an IP literal, SsrfGuard's IP-parse branch fires
+        // here and we may not even need DNS. If the host is a
+        // hostname, body inspectors run against ctx.body and
+        // DestinationPolicy filters by string.
+        let (verdict_1, name_1) = self.chain.run(&mut ctx).await;
+        if let InspectorVerdict::Transform { note } = &verdict_1 {
+            transforms.push(note.clone());
+        }
+        if verdict_1.is_deny() {
+            return Ok(self.deny(verdict_1, name_1, &ctx, transforms, started, None));
+        }
+
+        // If the host parsed as an IP literal in pass 1, SsrfGuard
+        // already classified it; skip DNS resolution entirely.
+        let needs_dns = host.parse::<IpAddr>().is_err();
+        if !needs_dns {
+            return Ok(self.allow_or_transform(name_1, &ctx, transforms, started, None));
+        }
+
+        // Second pass: resolve, pin, re-run. SsrfGuard now sees the
+        // pinned IP and either denies or passes; DestinationPolicy
+        // and body inspectors will produce identical verdicts to
+        // pass 1 (idempotent), but re-running keeps the deny-source
+        // attribution consistent — whichever inspector denied is
+        // recorded, regardless of whether it needed the IP.
+        let resolved = self.resolver.resolve_one(host, port).await?;
+        ctx.resolved_ip = Some(resolved);
+
+        let (verdict_2, name_2) = self.chain.run(&mut ctx).await;
+        if let InspectorVerdict::Transform { note } = &verdict_2 {
+            // Avoid duplicating the same Transform note from both
+            // passes — they're behaviourally identical for body
+            // inspectors.
+            if !transforms.contains(note) {
+                transforms.push(note.clone());
+            }
+        }
+        if verdict_2.is_deny() {
+            return Ok(self.deny(verdict_2, name_2, &ctx, transforms, started, Some(resolved)));
+        }
+        Ok(self.allow_or_transform(name_2, &ctx, transforms, started, Some(resolved)))
+    }
+
+    /// Build a Deny `EvaluationResult` from a chain verdict.
+    fn deny(
+        &self,
+        verdict: InspectorVerdict,
+        deciding: &'static str,
+        ctx: &RequestCtx,
+        transforms: Vec<String>,
+        started: Instant,
+        resolved_ip: Option<IpAddr>,
+    ) -> EvaluationResult {
+        let reason = match verdict {
+            InspectorVerdict::Deny { reason } => reason,
+            // Shouldn't happen — we only call deny() when is_deny()
+            // is true — but keep the match exhaustive.
+            other => format!("internal: unexpected verdict {other:?}"),
+        };
+        EvaluationResult {
+            decision: EgressDecision::Deny {
+                reason: reason.clone(),
+            },
+            audit: AuditFields {
+                outcome: EgressOutcome::Deny,
+                deciding_inspector: deciding,
+                host: ctx.host.clone(),
+                port: ctx.port,
+                path: ctx.path.clone(),
+                transforms,
+                reason: Some(reason),
+                resolved_ip,
+                duration_ms: elapsed_ms(started),
+                timestamp: Utc::now(),
+            },
+        }
+    }
+
+    /// Build an Allow / Transform `EvaluationResult` from chain
+    /// completion. `outcome` is `Transform` iff at least one
+    /// inspector returned `Transform { .. }` during the run.
+    fn allow_or_transform(
+        &self,
+        deciding: &'static str,
+        ctx: &RequestCtx,
+        transforms: Vec<String>,
+        started: Instant,
+        resolved_ip: Option<IpAddr>,
+    ) -> EvaluationResult {
+        let outcome = if transforms.is_empty() {
+            EgressOutcome::Allow
+        } else {
+            EgressOutcome::Transform
+        };
+        EvaluationResult {
+            decision: EgressDecision::Allow,
+            audit: AuditFields {
+                outcome,
+                deciding_inspector: deciding,
+                host: ctx.host.clone(),
+                port: ctx.port,
+                path: ctx.path.clone(),
+                transforms,
+                reason: None,
+                resolved_ip,
+                duration_ms: elapsed_ms(started),
+                timestamp: Utc::now(),
+            },
+        }
+    }
+}
+
+fn elapsed_ms(started: Instant) -> u32 {
+    let ms = started.elapsed().as_millis();
+    // Cap at u32::MAX in the unlikely event a single request takes
+    // longer than ~49 days (it won't, but the cast must be safe).
+    u32::try_from(ms).unwrap_or(u32::MAX)
+}
+
+fn find_subsequence(haystack: &[u8], needle: &[u8]) -> Option<usize> {
+    haystack.windows(needle.len()).position(|w| w == needle)
+}
+
+/// Write `HTTP/1.1 200 Connection Established\r\n\r\n` — the
+/// canonical response to an accepted CONNECT.
+async fn write_200_established(client: &mut TcpStream) -> std::io::Result<()> {
+    client
+        .write_all(b"HTTP/1.1 200 Connection Established\r\n\r\n")
+        .await?;
+    client.flush().await
+}
+
+/// Write a `403 Forbidden` with the chain's deny reason in the
+/// `X-Mvm-Egress-Reason` header. The body is plain text so curl /
+/// reqwest / etc. surface the reason to the workload.
+///
+/// The reason is whatever the inspector returned; it never echoes
+/// matched body bytes (Wave 2.2/2.5 already enforce that), but we
+/// sanitise newlines defensively to avoid header injection.
+async fn write_403(client: &mut TcpStream, reason: &str) -> std::io::Result<()> {
+    let safe = reason.replace(['\r', '\n'], " ");
+    let body = format!("egress denied: {safe}\n");
+    let response = format!(
+        "HTTP/1.1 403 Forbidden\r\n\
+         X-Mvm-Egress-Reason: {safe}\r\n\
+         Content-Type: text/plain\r\n\
+         Content-Length: {}\r\n\
+         Connection: close\r\n\
+         \r\n\
+         {body}",
+        body.len(),
+    );
+    client.write_all(response.as_bytes()).await?;
+    client.flush().await
+}
+
+/// Write a generic status response (used for `400 Bad Request`,
+/// `500 Internal`, `502 Bad Gateway`). Not as load-bearing as the
+/// 200/403 responses — used only for protocol/infrastructure
+/// failures that aren't chain verdicts.
+async fn write_status(client: &mut TcpStream, status: u16, msg: &str) -> std::io::Result<()> {
+    let safe = msg.replace(['\r', '\n'], " ");
+    let body = format!("{safe}\n");
+    let reason_phrase = match status {
+        400 => "Bad Request",
+        500 => "Internal Server Error",
+        502 => "Bad Gateway",
+        _ => "Error",
+    };
+    let response = format!(
+        "HTTP/1.1 {status} {reason_phrase}\r\n\
+         Content-Type: text/plain\r\n\
+         Content-Length: {}\r\n\
+         Connection: close\r\n\
+         \r\n\
+         {body}",
+        body.len(),
+    );
+    client.write_all(response.as_bytes()).await?;
+    client.flush().await
+}
+
+#[async_trait]
+impl EgressProxy for L7EgressProxy {
+    async fn inspect(&self, host: &str, path: &str) -> Result<EgressDecision, EgressError> {
+        // Wave 1's `EgressProxy` trait predates the (host, port,
+        // body) shape. Until Wave 2.7's trait widening, this method
+        // delegates to `evaluate` with port=443 (the HTTPS default
+        // — the host-only signature is never going to be the
+        // primary callsite anyway) and an empty body. Real proxy
+        // traffic uses `evaluate` directly via the `serve` loop.
+        let result = self.evaluate(host, 443, Vec::new()).await?;
+        // The path arg from the legacy trait is informational; we
+        // record it on the side but it doesn't affect the chain in
+        // Wave 2.6 since no inspector reads it.
+        let _ = path;
+        Ok(result.decision)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::destination::DestinationPolicy;
+    use crate::inspector::InspectorChain;
+    use crate::secrets_scanner::SecretsScanner;
+    use crate::ssrf_guard::SsrfGuard;
+    use std::net::Ipv4Addr;
+    use std::sync::Mutex;
+
+    /// Mock resolver that returns a configured IP for any host.
+    /// Tests instantiate one per scenario.
+    struct MockResolver {
+        next: Mutex<Option<Result<IpAddr, String>>>,
+    }
+    impl MockResolver {
+        fn returns(ip: IpAddr) -> Arc<Self> {
+            Arc::new(Self {
+                next: Mutex::new(Some(Ok(ip))),
+            })
+        }
+        fn errors_with(msg: &str) -> Arc<Self> {
+            Arc::new(Self {
+                next: Mutex::new(Some(Err(msg.to_string()))),
+            })
+        }
+    }
+    #[async_trait]
+    impl DnsResolver for MockResolver {
+        async fn resolve_one(&self, _host: &str, _port: u16) -> Result<IpAddr, EgressError> {
+            let mut slot = self.next.lock().expect("MockResolver mutex poisoned");
+            match slot.take() {
+                Some(Ok(ip)) => Ok(ip),
+                Some(Err(msg)) => Err(EgressError::UpstreamUnreachable(msg)),
+                None => Err(EgressError::UpstreamUnreachable("mock exhausted".into())),
+            }
+        }
+    }
+
+    fn full_chain() -> Arc<InspectorChain> {
+        Arc::new(
+            InspectorChain::new()
+                .with(Box::new(DestinationPolicy::new([(
+                    "api.openai.com",
+                    443u16,
+                )])))
+                .with(Box::new(SsrfGuard::new()))
+                .with(Box::new(SecretsScanner::with_default_rules())),
+        )
+    }
+
+    fn proxy_with(chain: Arc<InspectorChain>, resolver: Arc<dyn DnsResolver>) -> L7EgressProxy {
+        L7EgressProxy::new(
+            chain,
+            resolver,
+            Arc::new(NoopEgressAuditSink),
+            16 * 1024 * 1024,
+            false,
+        )
+    }
+
+    fn proxy_with_audit(
+        chain: Arc<InspectorChain>,
+        resolver: Arc<dyn DnsResolver>,
+        audit: Arc<dyn EgressAuditSink>,
+    ) -> L7EgressProxy {
+        L7EgressProxy::new(chain, resolver, audit, 16 * 1024 * 1024, false)
+    }
+
+    #[tokio::test]
+    async fn allowed_destination_with_clean_body_allows() {
+        let resolver = MockResolver::returns(IpAddr::V4(Ipv4Addr::new(104, 18, 32, 10)));
+        let proxy = proxy_with(full_chain(), resolver);
+        let r = proxy
+            .evaluate("api.openai.com", 443, b"{\"hello\":\"world\"}".to_vec())
+            .await
+            .expect("evaluate ok");
+        assert!(matches!(r.decision, EgressDecision::Allow));
+        assert_eq!(r.audit.outcome, EgressOutcome::Allow);
+        assert_eq!(r.audit.host, "api.openai.com");
+        assert_eq!(r.audit.port, 443);
+        assert_eq!(
+            r.audit.resolved_ip,
+            Some(IpAddr::V4(Ipv4Addr::new(104, 18, 32, 10)))
+        );
+        assert!(r.audit.transforms.is_empty());
+        assert!(r.audit.reason.is_none());
+    }
+
+    #[tokio::test]
+    async fn unauthorised_destination_denies_before_dns() {
+        let resolver = MockResolver::errors_with("should not be called");
+        let proxy = proxy_with(full_chain(), resolver);
+        let r = proxy
+            .evaluate("evil.com", 443, Vec::new())
+            .await
+            .expect("evaluate ok");
+        assert!(matches!(r.decision, EgressDecision::Deny { .. }));
+        assert_eq!(r.audit.outcome, EgressOutcome::Deny);
+        assert_eq!(r.audit.deciding_inspector, "destination_policy");
+        // Resolver was never called → resolved_ip stays None.
+        assert!(r.audit.resolved_ip.is_none());
+    }
+
+    #[tokio::test]
+    async fn dns_rebinding_resolved_to_private_ip_denies() {
+        // The host is allowlisted, so DestinationPolicy passes.
+        // SsrfGuard's first pass sees only the hostname and is a
+        // no-op. The mock resolver returns 127.0.0.1 — the second
+        // pass must catch it.
+        let chain = Arc::new(
+            InspectorChain::new()
+                .with(Box::new(DestinationPolicy::new([("evil.com", 443u16)])))
+                .with(Box::new(SsrfGuard::new())),
+        );
+        let resolver = MockResolver::returns(IpAddr::V4(Ipv4Addr::new(127, 0, 0, 1)));
+        let proxy = proxy_with(chain, resolver);
+        let r = proxy
+            .evaluate("evil.com", 443, Vec::new())
+            .await
+            .expect("evaluate ok");
+        assert!(matches!(r.decision, EgressDecision::Deny { .. }));
+        assert_eq!(r.audit.outcome, EgressOutcome::Deny);
+        assert_eq!(r.audit.deciding_inspector, "ssrf_guard");
+        assert_eq!(
+            r.audit.resolved_ip,
+            Some(IpAddr::V4(Ipv4Addr::new(127, 0, 0, 1)))
+        );
+    }
+
+    #[tokio::test]
+    async fn ip_literal_host_skips_dns_resolution() {
+        let chain = Arc::new(
+            InspectorChain::new()
+                .with(Box::new(DestinationPolicy::new([("8.8.8.8", 443u16)])))
+                .with(Box::new(SsrfGuard::new())),
+        );
+        // Resolver MUST NOT be called when host is an IP literal.
+        let resolver = MockResolver::errors_with("DNS should not be called for IP literal hosts");
+        let proxy = proxy_with(chain, resolver);
+        let r = proxy
+            .evaluate("8.8.8.8", 443, Vec::new())
+            .await
+            .expect("evaluate ok");
+        assert!(matches!(r.decision, EgressDecision::Allow));
+        // resolved_ip stays None when DNS wasn't needed.
+        assert!(r.audit.resolved_ip.is_none());
+    }
+
+    #[tokio::test]
+    async fn body_with_secret_denies_with_secrets_scanner_attribution() {
+        let resolver = MockResolver::returns(IpAddr::V4(Ipv4Addr::new(104, 18, 32, 10)));
+        let proxy = proxy_with(full_chain(), resolver);
+        let body = b"X-Api-Key: AKIAIOSFODNN7EXAMPLE".to_vec();
+        let r = proxy
+            .evaluate("api.openai.com", 443, body)
+            .await
+            .expect("evaluate ok");
+        assert!(matches!(r.decision, EgressDecision::Deny { .. }));
+        assert_eq!(r.audit.deciding_inspector, "secrets_scanner");
+        // Audit must NOT echo the matched secret bytes.
+        let reason = r.audit.reason.as_deref().unwrap_or("");
+        assert!(!reason.contains("AKIAIOSFODNN7EXAMPLE"));
+        // Rule name is fine.
+        assert!(reason.contains("aws_access_key_id"));
+    }
+
+    #[tokio::test]
+    async fn dns_failure_propagates_as_egress_error() {
+        let resolver = MockResolver::errors_with("nxdomain");
+        let proxy = proxy_with(full_chain(), resolver);
+        let r = proxy.evaluate("api.openai.com", 443, Vec::new()).await;
+        match r {
+            Err(EgressError::UpstreamUnreachable(msg)) => assert!(msg.contains("nxdomain")),
+            other => panic!("expected UpstreamUnreachable, got {other:?}"),
+        }
+    }
+
+    #[tokio::test]
+    async fn empty_chain_allows_with_resolution() {
+        let chain = Arc::new(InspectorChain::new());
+        let resolver = MockResolver::returns(IpAddr::V4(Ipv4Addr::new(8, 8, 8, 8)));
+        let proxy = proxy_with(chain, resolver);
+        let r = proxy
+            .evaluate("example.com", 80, Vec::new())
+            .await
+            .expect("evaluate ok");
+        assert!(matches!(r.decision, EgressDecision::Allow));
+        assert_eq!(r.audit.outcome, EgressOutcome::Allow);
+        // <empty_chain> sentinel from InspectorChain::run.
+        assert_eq!(r.audit.deciding_inspector, "<empty_chain>");
+    }
+
+    #[tokio::test]
+    async fn legacy_inspect_trait_method_still_works() {
+        let resolver = MockResolver::returns(IpAddr::V4(Ipv4Addr::new(104, 18, 32, 10)));
+        let proxy = proxy_with(full_chain(), resolver);
+        // The legacy 2-arg `inspect(host, path)` should delegate
+        // through `evaluate` cleanly. Used by Wave 1 callers until
+        // 2.7 widens the trait.
+        let r: &dyn EgressProxy = &proxy;
+        let dec = r
+            .inspect("api.openai.com", "/v1/chat")
+            .await
+            .expect("inspect ok");
+        assert!(matches!(dec, EgressDecision::Allow));
+    }
+
+    #[test]
+    fn proxy_exposes_configuration() {
+        let chain = Arc::new(InspectorChain::new());
+        let resolver = MockResolver::returns(IpAddr::V4(Ipv4Addr::new(1, 1, 1, 1)));
+        let proxy = L7EgressProxy::new(
+            chain,
+            resolver,
+            Arc::new(NoopEgressAuditSink),
+            8 * 1024 * 1024,
+            true,
+        );
+        assert_eq!(proxy.body_cap_bytes(), 8 * 1024 * 1024);
+        assert!(proxy.allow_plain_http());
+    }
+
+    // ---- CONNECT parser ----
+
+    #[test]
+    fn parse_connect_basic() {
+        let req = parse_connect(b"CONNECT api.openai.com:443 HTTP/1.1\r\n").unwrap();
+        assert_eq!(req.host, "api.openai.com");
+        assert_eq!(req.port, 443);
+    }
+
+    #[test]
+    fn parse_connect_without_crlf() {
+        let req = parse_connect(b"CONNECT example.com:8080 HTTP/1.1").unwrap();
+        assert_eq!(req.host, "example.com");
+        assert_eq!(req.port, 8080);
+    }
+
+    #[test]
+    fn parse_connect_lf_only() {
+        let req = parse_connect(b"CONNECT example.com:443 HTTP/1.0\n").unwrap();
+        assert_eq!(req.port, 443);
+    }
+
+    #[test]
+    fn parse_connect_rejects_get() {
+        let err = parse_connect(b"GET /foo HTTP/1.1\r\n").unwrap_err();
+        assert!(matches!(err, ConnectParseError::NotConnect(_)));
+    }
+
+    #[test]
+    fn parse_connect_rejects_missing_port() {
+        let err = parse_connect(b"CONNECT example.com HTTP/1.1\r\n").unwrap_err();
+        assert!(matches!(err, ConnectParseError::AuthorityMissingPort(_)));
+    }
+
+    #[test]
+    fn parse_connect_rejects_bad_port() {
+        let err = parse_connect(b"CONNECT example.com:abc HTTP/1.1\r\n").unwrap_err();
+        assert!(matches!(err, ConnectParseError::BadPort(_)));
+    }
+
+    #[test]
+    fn parse_connect_rejects_http_2() {
+        let err = parse_connect(b"CONNECT example.com:443 HTTP/2.0\r\n").unwrap_err();
+        assert_eq!(err, ConnectParseError::Malformed);
+    }
+
+    #[test]
+    fn parse_connect_rejects_non_utf8() {
+        let bytes = [0xFF, 0xFE, b'C', b'O', b'N'];
+        assert_eq!(parse_connect(&bytes), Err(ConnectParseError::NonUtf8));
+    }
+
+    #[test]
+    fn parse_connect_rejects_empty_host() {
+        let err = parse_connect(b"CONNECT :443 HTTP/1.1\r\n").unwrap_err();
+        assert!(matches!(err, ConnectParseError::AuthorityMissingPort(_)));
+    }
+
+    #[test]
+    fn parse_connect_rejects_too_few_fields() {
+        let err = parse_connect(b"CONNECT only-two-fields\r\n").unwrap_err();
+        assert_eq!(err, ConnectParseError::Malformed);
+    }
+
+    #[test]
+    fn parse_connect_handles_ipv6_literal_via_brackets_unsupported_for_now() {
+        // IPv6 in CONNECT uses bracketed form: `[::1]:443`. Phase 1
+        // accepts it via rsplit_once(':') which keeps the brackets
+        // in the host slot — downstream IP parsing in `evaluate`
+        // would then fail since `[::1]` isn't a valid IpAddr. Document
+        // the limitation explicitly via this test until 2.6.5 adds
+        // proper bracket-stripping.
+        let req = parse_connect(b"CONNECT [::1]:443 HTTP/1.1\r\n").unwrap();
+        assert_eq!(req.host, "[::1]");
+        assert_eq!(req.port, 443);
+    }
+
+    // ---- Audit sink ----
+
+    #[tokio::test]
+    async fn audit_sink_captures_allow_record() {
+        let resolver = MockResolver::returns(IpAddr::V4(Ipv4Addr::new(104, 18, 32, 10)));
+        let audit = Arc::new(CapturingEgressAuditSink::new());
+        let proxy = proxy_with_audit(full_chain(), resolver, audit.clone());
+        let r = proxy
+            .evaluate("api.openai.com", 443, b"hi".to_vec())
+            .await
+            .expect("evaluate ok");
+        // record() is called from serve_connection, not evaluate.
+        // Verify the AuditFields shape directly here.
+        audit.record(&r.audit).await.expect("record ok");
+        let entries = audit.entries();
+        assert_eq!(entries.len(), 1);
+        assert_eq!(entries[0].outcome, EgressOutcome::Allow);
+        assert_eq!(entries[0].host, "api.openai.com");
+    }
+
+    // ---- In-process integration: real TcpStream through serve_connection ----
+    //
+    // These tests bind a proxy listener on an ephemeral 127.0.0.1
+    // port and a "fake upstream" listener on another ephemeral port,
+    // then drive CONNECT requests through the proxy. They assert
+    // both the wire-protocol response shape AND the audit-sink
+    // contents — the two observation surfaces real workloads have.
+    // (`tokio::io::{AsyncReadExt, AsyncWriteExt}` come in via the
+    // parent module's `use` — no need to re-import here.)
+
+    /// Bind the proxy on an ephemeral port, return its address +
+    /// the JoinHandle so the test can clean up.
+    async fn spawn_proxy(
+        proxy: Arc<L7EgressProxy>,
+    ) -> (SocketAddr, tokio::task::JoinHandle<std::io::Result<()>>) {
+        let listener = TcpListener::bind("127.0.0.1:0").await.expect("bind");
+        let addr = listener.local_addr().expect("local_addr");
+        let handle = tokio::spawn(async move {
+            loop {
+                let (stream, peer) = listener.accept().await?;
+                let p = Arc::clone(&proxy);
+                tokio::spawn(async move {
+                    let _ = p.serve_connection(stream, peer).await;
+                });
+            }
+        });
+        (addr, handle)
+    }
+
+    /// Bind a fake upstream that accepts one connection, sends a
+    /// fixed greeting, then closes. Returns the upstream's port.
+    async fn spawn_fake_upstream(greeting: &'static [u8]) -> u16 {
+        let listener = TcpListener::bind("127.0.0.1:0").await.expect("bind");
+        let port = listener.local_addr().expect("local_addr").port();
+        tokio::spawn(async move {
+            if let Ok((mut stream, _)) = listener.accept().await {
+                let _ = stream.write_all(greeting).await;
+                let _ = stream.flush().await;
+                // Linger briefly so the test reads before close.
+                let _ = stream.shutdown().await;
+            }
+        });
+        port
+    }
+
+    /// Read from `stream` until either `\r\n\r\n` or EOF.
+    async fn read_response_head(stream: &mut TcpStream) -> Vec<u8> {
+        let mut buf = Vec::new();
+        let mut chunk = [0u8; 1024];
+        loop {
+            let n = match stream.read(&mut chunk).await {
+                Ok(0) => break,
+                Ok(n) => n,
+                Err(_) => break,
+            };
+            buf.extend_from_slice(&chunk[..n]);
+            if buf.windows(4).any(|w| w == b"\r\n\r\n") {
+                break;
+            }
+        }
+        buf
+    }
+
+    #[tokio::test]
+    async fn connect_to_disallowed_destination_returns_403_and_audits() {
+        let resolver = MockResolver::errors_with("should not be called");
+        let audit = Arc::new(CapturingEgressAuditSink::new());
+        let proxy = Arc::new(proxy_with_audit(full_chain(), resolver, audit.clone()));
+        let (proxy_addr, _h) = spawn_proxy(proxy).await;
+
+        let mut client = TcpStream::connect(proxy_addr).await.expect("connect");
+        client
+            .write_all(b"CONNECT evil.com:443 HTTP/1.1\r\n\r\n")
+            .await
+            .expect("write");
+        let head = read_response_head(&mut client).await;
+        let head = String::from_utf8(head).expect("utf8");
+        assert!(head.starts_with("HTTP/1.1 403 "), "got: {head}");
+        assert!(head.contains("X-Mvm-Egress-Reason:"), "got: {head}");
+        assert!(head.contains("destination_policy") || head.contains("not in policy"));
+
+        // Brief pause so the audit task records before we read.
+        tokio::time::sleep(std::time::Duration::from_millis(20)).await;
+        let entries = audit.entries();
+        assert_eq!(entries.len(), 1);
+        assert_eq!(entries[0].outcome, EgressOutcome::Deny);
+        assert_eq!(entries[0].deciding_inspector, "destination_policy");
+        assert_eq!(entries[0].host, "evil.com");
+    }
+
+    #[tokio::test]
+    async fn connect_to_allowed_destination_splices_bytes() {
+        // Spawn a fake upstream that replies "HELLO\n" on connect.
+        let upstream_port = spawn_fake_upstream(b"HELLO\n").await;
+
+        // Allow the upstream's host:port.
+        let chain = Arc::new(
+            InspectorChain::new().with(Box::new(DestinationPolicy::new([(
+                "127.0.0.1",
+                upstream_port,
+            )]))),
+        );
+
+        // Resolver isn't used (host is an IP literal), but plumb a
+        // mock anyway so any accidental resolution call errors loud.
+        let resolver = MockResolver::errors_with("should not be called for IP literal");
+        let audit = Arc::new(CapturingEgressAuditSink::new());
+        let proxy = Arc::new(proxy_with_audit(chain, resolver, audit.clone()));
+        let (proxy_addr, _h) = spawn_proxy(proxy).await;
+
+        let mut client = TcpStream::connect(proxy_addr).await.expect("connect");
+        let connect_line = format!("CONNECT 127.0.0.1:{upstream_port} HTTP/1.1\r\n\r\n");
+        client
+            .write_all(connect_line.as_bytes())
+            .await
+            .expect("write");
+
+        // Read the proxy's 200 response, then the upstream's bytes.
+        let head = read_response_head(&mut client).await;
+        let head = String::from_utf8(head).expect("utf8");
+        assert!(head.starts_with("HTTP/1.1 200 "), "got: {head}");
+
+        // Now read what the upstream sent (spliced through).
+        let mut payload = [0u8; 16];
+        let n = client.read(&mut payload).await.expect("read");
+        assert!(n >= 6);
+        assert_eq!(&payload[..6], b"HELLO\n");
+
+        // Audit recorded an Allow.
+        tokio::time::sleep(std::time::Duration::from_millis(20)).await;
+        let entries = audit.entries();
+        assert_eq!(entries.len(), 1);
+        assert_eq!(entries[0].outcome, EgressOutcome::Allow);
+    }
+
+    #[tokio::test]
+    async fn malformed_request_line_returns_400() {
+        let resolver = MockResolver::errors_with("should not be called");
+        let audit = Arc::new(CapturingEgressAuditSink::new());
+        let proxy = Arc::new(proxy_with_audit(full_chain(), resolver, audit.clone()));
+        let (proxy_addr, _h) = spawn_proxy(proxy).await;
+
+        let mut client = TcpStream::connect(proxy_addr).await.expect("connect");
+        client
+            .write_all(b"GET /not-a-connect HTTP/1.1\r\n\r\n")
+            .await
+            .expect("write");
+        let head = read_response_head(&mut client).await;
+        let head = String::from_utf8(head).expect("utf8");
+        assert!(head.starts_with("HTTP/1.1 400 "), "got: {head}");
+    }
+
+    #[tokio::test]
+    async fn dns_rebinding_via_real_connect_denies_with_403() {
+        // Host parses public (DestinationPolicy passes), resolver
+        // returns 127.0.0.1 (SsrfGuard fires post-resolution).
+        let chain = Arc::new(
+            InspectorChain::new()
+                .with(Box::new(DestinationPolicy::new([("evil.com", 443u16)])))
+                .with(Box::new(crate::ssrf_guard::SsrfGuard::new())),
+        );
+        let resolver = MockResolver::returns(IpAddr::V4(Ipv4Addr::new(127, 0, 0, 1)));
+        let audit = Arc::new(CapturingEgressAuditSink::new());
+        let proxy = Arc::new(proxy_with_audit(chain, resolver, audit.clone()));
+        let (proxy_addr, _h) = spawn_proxy(proxy).await;
+
+        let mut client = TcpStream::connect(proxy_addr).await.expect("connect");
+        client
+            .write_all(b"CONNECT evil.com:443 HTTP/1.1\r\n\r\n")
+            .await
+            .expect("write");
+        let head = read_response_head(&mut client).await;
+        let head = String::from_utf8(head).expect("utf8");
+        assert!(head.starts_with("HTTP/1.1 403 "), "got: {head}");
+        assert!(head.contains("ssrf_guard") || head.contains("loopback"));
+
+        tokio::time::sleep(std::time::Duration::from_millis(20)).await;
+        let entries = audit.entries();
+        assert_eq!(entries.len(), 1);
+        assert_eq!(entries[0].outcome, EgressOutcome::Deny);
+        assert_eq!(entries[0].deciding_inspector, "ssrf_guard");
+        assert_eq!(
+            entries[0].resolved_ip,
+            Some(IpAddr::V4(Ipv4Addr::new(127, 0, 0, 1)))
+        );
+    }
+}

--- a/crates/mvm-supervisor/src/lib.rs
+++ b/crates/mvm-supervisor/src/lib.rs
@@ -40,7 +40,9 @@ pub mod egress;
 pub mod injection_guard;
 pub mod inspector;
 pub mod keystore;
+pub mod l7_proxy;
 pub mod pii_redactor;
+pub mod policy_tool_gate;
 pub mod secrets_scanner;
 pub mod ssrf_guard;
 pub mod state;
@@ -56,7 +58,16 @@ pub use egress::{EgressDecision, EgressError, EgressProxy, NoopEgressProxy};
 pub use injection_guard::{InjectionGuard, InjectionRule, RuleFamily};
 pub use inspector::{Inspector, InspectorChain, InspectorVerdict, RequestCtx};
 pub use keystore::{KeystoreError, KeystoreReleaser, NoopKeystoreReleaser, SecretGrant};
+pub use l7_proxy::{
+    AuditFields, CapturingEgressAuditSink, ConnectParseError, ConnectRequest, DnsResolver,
+    EgressAuditSink, EgressOutcome, EvaluationResult, L7EgressProxy, NoopEgressAuditSink,
+    TokioDnsResolver, parse_connect,
+};
 pub use pii_redactor::{PiiRedactor, PiiRule, PiiValidator};
+pub use policy_tool_gate::{
+    CapturingToolAuditSink, NoopToolAuditSink, PolicyToolGate, ToolAuditError, ToolAuditFields,
+    ToolAuditSink, ToolOutcome,
+};
 pub use secrets_scanner::{DEFAULT_RULES, SecretRule, SecretsScanner};
 pub use ssrf_guard::SsrfGuard;
 pub use state::{PlanState, PlanStateMachine, StateTransitionError};

--- a/crates/mvm-supervisor/src/policy_tool_gate.rs
+++ b/crates/mvm-supervisor/src/policy_tool_gate.rs
@@ -1,0 +1,337 @@
+//! `PolicyToolGate` — replaces `NoopToolGate` with a real
+//! allowlist check against `mvm-policy::ToolPolicy`.
+//!
+//! Plan 37 §2.2 / §15 (Wave 2.7 / Phase 1).
+//!
+//! ## Phase 1 scope (this module)
+//!
+//! - Pure policy-decision logic: take a tool name, look it up in
+//!   the plan's `ToolPolicy.allowed: Vec<String>` allowlist, return
+//!   Allow / Deny.
+//! - Audit-safe deny reasons: name the rejected tool and include
+//!   the visible allowlist entries (operator sees both what was
+//!   blocked AND what was permitted, in the same audit line).
+//! - [`ToolAuditSink`] trait + capturing/noop sinks, mirroring the
+//!   `EgressAuditSink` shape from Wave 2.6 so the supervisor's
+//!   audit fan-out stays uniform.
+//! - `Supervisor::with_tool_gate` builder lands in `supervisor.rs`.
+//!
+//! ## Phase 2 (Wave 2.7b — separate PR)
+//!
+//! - Vsock listener loop: the workload talks to the supervisor via
+//!   vsock RPC ("can I call tool `read_file`?"); the supervisor
+//!   handles the request by calling `ToolGate::check(name)`.
+//! - JSON-RPC framing on the vsock socket.
+//!
+//! Splitting like this keeps the policy decision testable without
+//! the I/O surface, and lets Phase 2 layer on cleanly.
+//!
+//! ## Design notes
+//!
+//! - `PolicyToolGate` stores a `BTreeSet<String>` for O(log n)
+//!   lookup. The bundle's policy carries a `Vec<String>` (preserves
+//!   serialization order); we copy into a set at construction.
+//! - The deny reason includes the allowlist contents so operators
+//!   can answer "what would have been allowed?" in one read. For
+//!   workloads with very long allowlists, callers can construct
+//!   the gate with [`PolicyToolGate::quiet_deny_reasons`] to omit
+//!   the listing — but the default is loud, because audit-time
+//!   verbosity is a feature.
+//! - The check method is `async` to match the trait. The lookup
+//!   itself is synchronous; the async wrapper is free.
+
+use std::collections::BTreeSet;
+use std::sync::Mutex;
+
+use async_trait::async_trait;
+use mvm_policy::ToolPolicy;
+use thiserror::Error;
+
+use crate::tool_gate::{ToolDecision, ToolError, ToolGate};
+
+/// Audit record emitted per `ToolGate::check` call. Mirrors the
+/// shape of [`crate::l7_proxy::AuditFields`] so audit fan-out is
+/// uniform across egress + tool-call paths.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ToolAuditFields {
+    pub outcome: ToolOutcome,
+    pub tool_name: String,
+    pub reason: Option<String>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum ToolOutcome {
+    Allow,
+    Deny,
+}
+
+#[derive(Debug, Error)]
+pub enum ToolAuditError {
+    #[error("tool audit sink not wired")]
+    NotWired,
+    #[error("io error writing tool audit: {0}")]
+    Io(String),
+}
+
+#[async_trait]
+pub trait ToolAuditSink: Send + Sync {
+    async fn record(&self, fields: &ToolAuditFields) -> Result<(), ToolAuditError>;
+}
+
+/// In-memory sink for tests + dev mode.
+pub struct CapturingToolAuditSink {
+    entries: Mutex<Vec<ToolAuditFields>>,
+}
+
+impl CapturingToolAuditSink {
+    pub fn new() -> Self {
+        Self {
+            entries: Mutex::new(Vec::new()),
+        }
+    }
+    pub fn entries(&self) -> Vec<ToolAuditFields> {
+        self.entries
+            .lock()
+            .expect("CapturingToolAuditSink mutex poisoned")
+            .clone()
+    }
+}
+impl Default for CapturingToolAuditSink {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+#[async_trait]
+impl ToolAuditSink for CapturingToolAuditSink {
+    async fn record(&self, fields: &ToolAuditFields) -> Result<(), ToolAuditError> {
+        self.entries
+            .lock()
+            .expect("CapturingToolAuditSink mutex poisoned")
+            .push(fields.clone());
+        Ok(())
+    }
+}
+
+/// Sink that swallows tool-audit records. Default for callsites
+/// that don't yet have a plan/bundle binding.
+pub struct NoopToolAuditSink;
+#[async_trait]
+impl ToolAuditSink for NoopToolAuditSink {
+    async fn record(&self, _fields: &ToolAuditFields) -> Result<(), ToolAuditError> {
+        Ok(())
+    }
+}
+
+/// Real `ToolGate` impl backed by a `ToolPolicy.allowed` allowlist.
+pub struct PolicyToolGate {
+    allowed: BTreeSet<String>,
+    /// When false, deny reasons include the full allowlist. When
+    /// true, the reason names the rejected tool only. Loud by
+    /// default — audit verbosity is a feature.
+    quiet: bool,
+}
+
+impl PolicyToolGate {
+    /// Build from a `ToolPolicy`. The bundle's `Vec<String>` is
+    /// deduplicated into a `BTreeSet` for O(log n) lookup.
+    pub fn from_policy(policy: &ToolPolicy) -> Self {
+        Self {
+            allowed: policy.allowed.iter().cloned().collect(),
+            quiet: false,
+        }
+    }
+
+    /// Build from an iterator of allowed names (test convenience).
+    pub fn new<I, S>(names: I) -> Self
+    where
+        I: IntoIterator<Item = S>,
+        S: Into<String>,
+    {
+        Self {
+            allowed: names.into_iter().map(Into::into).collect(),
+            quiet: false,
+        }
+    }
+
+    /// Deny-everything sentinel — useful when the workload has no
+    /// `tool_policy` resolved yet, or when the policy bundle's
+    /// allowed set is empty (a deliberate fail-closed
+    /// configuration).
+    pub fn deny_all() -> Self {
+        Self::new::<_, &str>(std::iter::empty())
+    }
+
+    /// Set the deny-reason verbosity. Default = loud (false).
+    pub fn quiet_deny_reasons(mut self, quiet: bool) -> Self {
+        self.quiet = quiet;
+        self
+    }
+
+    /// True iff `name` is on the allowlist. Synchronous helper
+    /// exposed for non-trait callsites (e.g., a vsock RPC handler
+    /// that already has its own async wrapper).
+    pub fn is_allowed(&self, name: &str) -> bool {
+        self.allowed.contains(name)
+    }
+
+    fn render_allowlist(&self) -> String {
+        if self.allowed.is_empty() {
+            "<empty allowlist — deny-all>".to_string()
+        } else {
+            // Stable ordering courtesy of BTreeSet.
+            self.allowed.iter().cloned().collect::<Vec<_>>().join(", ")
+        }
+    }
+}
+
+#[async_trait]
+impl ToolGate for PolicyToolGate {
+    async fn check(&self, tool_name: &str) -> Result<ToolDecision, ToolError> {
+        if self.is_allowed(tool_name) {
+            return Ok(ToolDecision::Allow);
+        }
+        let reason = if self.quiet {
+            format!("tool '{tool_name}' not in policy allowlist")
+        } else {
+            format!(
+                "tool '{tool_name}' not in policy allowlist (allowed: {})",
+                self.render_allowlist()
+            )
+        };
+        Ok(ToolDecision::Deny { reason })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[tokio::test]
+    async fn allowed_name_returns_allow() {
+        let gate = PolicyToolGate::new(["read_file", "list_dir"]);
+        let v = gate.check("read_file").await.expect("ok");
+        assert_eq!(v, ToolDecision::Allow);
+    }
+
+    #[tokio::test]
+    async fn unknown_name_denies_with_visible_allowlist() {
+        let gate = PolicyToolGate::new(["read_file", "list_dir"]);
+        let v = gate.check("rm_rf").await.expect("ok");
+        match v {
+            ToolDecision::Deny { reason } => {
+                assert!(reason.contains("rm_rf"));
+                // Loud by default — operator sees what WAS allowed.
+                assert!(reason.contains("read_file"));
+                assert!(reason.contains("list_dir"));
+            }
+            other => panic!("expected Deny, got {other:?}"),
+        }
+    }
+
+    #[tokio::test]
+    async fn quiet_mode_omits_allowlist_from_reason() {
+        let gate = PolicyToolGate::new(["read_file", "list_dir"]).quiet_deny_reasons(true);
+        let v = gate.check("rm_rf").await.expect("ok");
+        match v {
+            ToolDecision::Deny { reason } => {
+                assert!(reason.contains("rm_rf"));
+                assert!(!reason.contains("read_file"));
+                assert!(!reason.contains("list_dir"));
+            }
+            other => panic!("expected Deny, got {other:?}"),
+        }
+    }
+
+    #[tokio::test]
+    async fn deny_all_sentinel_blocks_every_call() {
+        let gate = PolicyToolGate::deny_all();
+        for name in ["read_file", "list_dir", "anything"] {
+            let v = gate.check(name).await.expect("ok");
+            assert!(matches!(v, ToolDecision::Deny { .. }));
+        }
+    }
+
+    #[tokio::test]
+    async fn empty_allowlist_renders_explicit_deny_all_reason() {
+        let gate = PolicyToolGate::deny_all();
+        let v = gate.check("read_file").await.expect("ok");
+        if let ToolDecision::Deny { reason } = v {
+            assert!(reason.contains("<empty allowlist"));
+        } else {
+            panic!("expected Deny");
+        }
+    }
+
+    #[tokio::test]
+    async fn from_policy_dedupes_input_vec() {
+        // ToolPolicy.allowed is Vec; allow duplicate entries to
+        // appear (perhaps from a hand-edited bundle) and confirm
+        // PolicyToolGate dedupes via BTreeSet.
+        let policy = ToolPolicy {
+            allowed: vec![
+                "read_file".to_string(),
+                "read_file".to_string(),
+                "list_dir".to_string(),
+            ],
+        };
+        let gate = PolicyToolGate::from_policy(&policy);
+        assert!(gate.is_allowed("read_file"));
+        assert!(gate.is_allowed("list_dir"));
+        assert!(!gate.is_allowed("rm_rf"));
+    }
+
+    #[tokio::test]
+    async fn from_policy_preserves_stable_iteration_order() {
+        // Audit reasons must be deterministic across runs — same
+        // policy should produce the same listing every time.
+        let policy = ToolPolicy {
+            allowed: vec!["zzz".to_string(), "aaa".to_string(), "mmm".to_string()],
+        };
+        let gate = PolicyToolGate::from_policy(&policy);
+        let v1 = gate.check("nope").await.expect("ok");
+        let v2 = gate.check("nope").await.expect("ok");
+        assert_eq!(v1, v2);
+        // BTreeSet ordering: aaa, mmm, zzz.
+        if let ToolDecision::Deny { reason } = v1 {
+            assert!(reason.contains("aaa, mmm, zzz"));
+        } else {
+            panic!("expected Deny");
+        }
+    }
+
+    #[tokio::test]
+    async fn capturing_audit_sink_records_entries() {
+        let sink = CapturingToolAuditSink::new();
+        sink.record(&ToolAuditFields {
+            outcome: ToolOutcome::Allow,
+            tool_name: "read_file".to_string(),
+            reason: None,
+        })
+        .await
+        .expect("ok");
+        sink.record(&ToolAuditFields {
+            outcome: ToolOutcome::Deny,
+            tool_name: "rm_rf".to_string(),
+            reason: Some("not allowed".to_string()),
+        })
+        .await
+        .expect("ok");
+        let entries = sink.entries();
+        assert_eq!(entries.len(), 2);
+        assert_eq!(entries[0].outcome, ToolOutcome::Allow);
+        assert_eq!(entries[1].outcome, ToolOutcome::Deny);
+    }
+
+    #[tokio::test]
+    async fn noop_sink_silently_succeeds() {
+        let sink = NoopToolAuditSink;
+        let r = sink
+            .record(&ToolAuditFields {
+                outcome: ToolOutcome::Allow,
+                tool_name: "x".to_string(),
+                reason: None,
+            })
+            .await;
+        assert!(r.is_ok());
+    }
+}

--- a/crates/mvm-supervisor/src/supervisor.rs
+++ b/crates/mvm-supervisor/src/supervisor.rs
@@ -21,11 +21,22 @@ use mvm_plan::{NonceStore, PlanId, PlanValidityError, SignedExecutionPlan, check
 use thiserror::Error;
 use tracing::warn;
 
+use mvm_plan::Variant;
+use mvm_policy::{DEFAULT_BODY_CAP_BYTES, EgressPolicy, ToolPolicy};
+
 use crate::artifact::{ArtifactCollector, NoopArtifactCollector};
 use crate::audit::{AuditSigner, NoopAuditSigner};
 use crate::backend::{BackendError, BackendLauncher, NoopBackendLauncher};
+use crate::destination::DestinationPolicy;
 use crate::egress::{EgressProxy, NoopEgressProxy};
+use crate::injection_guard::InjectionGuard;
+use crate::inspector::{Inspector, InspectorChain};
 use crate::keystore::{KeystoreReleaser, NoopKeystoreReleaser};
+use crate::l7_proxy::{DnsResolver, EgressAuditSink, L7EgressProxy};
+use crate::pii_redactor::PiiRedactor;
+use crate::policy_tool_gate::PolicyToolGate;
+use crate::secrets_scanner::SecretsScanner;
+use crate::ssrf_guard::SsrfGuard;
 use crate::state::{PlanState, PlanStateMachine, StateTransitionError};
 use crate::tool_gate::{NoopToolGate, ToolGate};
 
@@ -76,6 +87,9 @@ pub enum SupervisorError {
 
     #[error("artifact error: {0}")]
     Artifact(String),
+
+    #[error("policy violation: {0}")]
+    PolicyViolation(String),
 }
 
 pub struct Supervisor {
@@ -323,6 +337,112 @@ impl Supervisor {
             warn!(?e, ?to, "state transition during error handling failed");
         }
     }
+
+    /// Wire the L7 egress proxy slot from a workload's
+    /// [`EgressPolicy`] + variant. Wave 2.6 differentiator:
+    ///
+    /// - Builds the inspector chain from `policy.allow_list` and the
+    ///   curated default rulesets, in Plan 37 §15's recommended order
+    ///   (DestinationPolicy → SsrfGuard → SecretsScanner →
+    ///   InjectionGuard → PiiRedactor).
+    /// - **Refuses `Variant::Prod` ⊕ `policy.allow_plain_http = true`**
+    ///   with a [`SupervisorError::PolicyViolation`]. This makes the
+    ///   secure default louder than a comment: a production policy
+    ///   bundle that opts into plain HTTP fails policy load, not
+    ///   silently accepts unencrypted egress.
+    /// - Honours `policy.disabled_inspectors` for opt-out by name.
+    ///   Operators can disable a specific inspector (e.g.,
+    ///   `pii_redactor` for an analytics workload) without rewriting
+    ///   the chain order.
+    /// - Honours `policy.body_cap_bytes` (defaults to
+    ///   [`DEFAULT_BODY_CAP_BYTES`] when the field is 0).
+    pub fn with_l7_egress(
+        mut self,
+        policy: &EgressPolicy,
+        variant: Variant,
+        resolver: Arc<dyn DnsResolver>,
+        audit_sink: Arc<dyn EgressAuditSink>,
+    ) -> Result<Self, SupervisorError> {
+        // Variant gate — production workloads must not honour an
+        // `allow_plain_http = true` field, even if a policy bundle
+        // somehow ends up carrying one.
+        if variant.is_prod() && policy.allow_plain_http {
+            return Err(SupervisorError::PolicyViolation(
+                "EgressPolicy.allow_plain_http=true forbidden for Variant::Prod".to_string(),
+            ));
+        }
+
+        let chain = build_inspector_chain(policy);
+        let body_cap = if policy.body_cap_bytes == 0 {
+            DEFAULT_BODY_CAP_BYTES
+        } else {
+            policy.body_cap_bytes
+        };
+        // u64 → usize: clamp at usize::MAX on 32-bit platforms.
+        // 16 MiB fits in usize on all platforms we target, so this
+        // is purely defensive against a malicious policy bundle.
+        let body_cap = usize::try_from(body_cap).unwrap_or(usize::MAX);
+
+        let proxy = L7EgressProxy::new(
+            Arc::new(chain),
+            resolver,
+            audit_sink,
+            body_cap,
+            policy.allow_plain_http,
+        );
+        self.egress = Arc::new(proxy);
+        Ok(self)
+    }
+
+    /// Wire the tool gate slot from a workload's [`ToolPolicy`].
+    /// Wave 2.7 / Phase 1 — pure policy decision (allowlist
+    /// lookup); the vsock RPC layer that drives `check()` calls
+    /// from the workload lands in Wave 2.7b.
+    ///
+    /// An empty `ToolPolicy.allowed` is **not** treated as
+    /// "anything goes" — it's a deliberate fail-closed deny-all
+    /// configuration. Operators who genuinely want the workload to
+    /// have no tool restrictions must wire a different gate
+    /// implementation.
+    pub fn with_tool_gate(mut self, policy: &ToolPolicy) -> Self {
+        self.tool_gate = Arc::new(PolicyToolGate::from_policy(policy));
+        self
+    }
+}
+
+/// Build an [`InspectorChain`] from the workload's [`EgressPolicy`].
+/// Order matches Plan 37 §15: cheap/most-precise checks first, body
+/// inspectors last (so a destination-denied request never pays the
+/// cost of body scanning).
+///
+/// `policy.disabled_inspectors` filters out by name — empty == every
+/// inspector enabled. The named inspectors must match
+/// `Inspector::name()` strings exactly.
+fn build_inspector_chain(policy: &EgressPolicy) -> InspectorChain {
+    let disabled = |name: &'static str| policy.disabled_inspectors.iter().any(|d| d == name);
+    let mut chain = InspectorChain::new();
+    if !disabled("destination_policy") {
+        let dp = DestinationPolicy::new(
+            policy
+                .allow_list
+                .iter()
+                .map(|(host, port)| (host.as_str(), *port)),
+        );
+        chain.push(Box::new(dp) as Box<dyn Inspector>);
+    }
+    if !disabled("ssrf_guard") {
+        chain.push(Box::new(SsrfGuard::new()));
+    }
+    if !disabled("secrets_scanner") {
+        chain.push(Box::new(SecretsScanner::with_default_rules()));
+    }
+    if !disabled("injection_guard") {
+        chain.push(Box::new(InjectionGuard::with_default_rules()));
+    }
+    if !disabled("pii_redactor") {
+        chain.push(Box::new(PiiRedactor::with_default_rules()));
+    }
+    chain
 }
 
 #[cfg(test)]
@@ -876,5 +996,171 @@ mod tests {
         assert_eq!(s.state.current(), PlanState::Failed);
         // Backend was never called — admission failed.
         assert!(backend.launches().is_empty());
+    }
+
+    // ---- Wave 2.6: with_l7_egress builder + Variant::Prod gate ----
+
+    use crate::l7_proxy::{
+        CapturingEgressAuditSink, DnsResolver, EgressAuditSink, NoopEgressAuditSink,
+    };
+    use std::net::IpAddr;
+
+    /// Mock resolver that always returns the configured IP. Reused
+    /// from l7_proxy tests via a duplicate definition here — tests
+    /// don't share #[cfg(test)] fns across modules without lots of
+    /// pub(crate) churn, and the type is two lines.
+    struct WiringResolver(IpAddr);
+    #[async_trait]
+    impl DnsResolver for WiringResolver {
+        async fn resolve_one(&self, _h: &str, _p: u16) -> Result<IpAddr, crate::EgressError> {
+            Ok(self.0)
+        }
+    }
+
+    fn dev_egress_policy(allow_plain_http: bool) -> EgressPolicy {
+        EgressPolicy {
+            mode: Some("l3_plus_l7".to_string()),
+            allow_list: vec![("api.openai.com".to_string(), 443)],
+            allow_plain_http,
+            body_cap_bytes: 0,
+            disabled_inspectors: vec![],
+        }
+    }
+
+    #[test]
+    fn with_l7_egress_dev_with_plain_http_succeeds() {
+        let policy = dev_egress_policy(true);
+        let s = Supervisor::default()
+            .with_l7_egress(
+                &policy,
+                Variant::Dev,
+                Arc::new(WiringResolver(IpAddr::from([8, 8, 8, 8]))),
+                Arc::new(NoopEgressAuditSink),
+            )
+            .expect("dev variant accepts plain http");
+        // The egress slot is now the L7 proxy (downcast not needed —
+        // confirming non-default behaviour by checking that its type
+        // accepted the build is enough).
+        assert_eq!(s.state.current(), PlanState::Pending);
+    }
+
+    #[test]
+    fn with_l7_egress_prod_with_plain_http_rejects() {
+        let policy = dev_egress_policy(true); // plain http on
+        let result = Supervisor::default().with_l7_egress(
+            &policy,
+            Variant::Prod,
+            Arc::new(WiringResolver(IpAddr::from([8, 8, 8, 8]))),
+            Arc::new(NoopEgressAuditSink),
+        );
+        match result {
+            Err(SupervisorError::PolicyViolation(msg)) => {
+                assert!(msg.contains("allow_plain_http"));
+                assert!(msg.contains("Prod"));
+            }
+            Err(other) => panic!("expected PolicyViolation, got error {other:?}"),
+            Ok(_) => panic!("expected PolicyViolation, got Ok"),
+        }
+    }
+
+    #[test]
+    fn with_l7_egress_prod_without_plain_http_succeeds() {
+        let policy = dev_egress_policy(false);
+        let s = Supervisor::default()
+            .with_l7_egress(
+                &policy,
+                Variant::Prod,
+                Arc::new(WiringResolver(IpAddr::from([8, 8, 8, 8]))),
+                Arc::new(NoopEgressAuditSink),
+            )
+            .expect("prod variant accepts plain-http=false");
+        assert_eq!(s.state.current(), PlanState::Pending);
+    }
+
+    #[tokio::test]
+    async fn wired_supervisor_routes_through_inspector_chain() {
+        // End-to-end: build a Supervisor with the L7 proxy wired,
+        // ask the egress slot to inspect a request that the chain
+        // would deny, confirm the policy violation propagates.
+        let policy = dev_egress_policy(false);
+        let resolver = Arc::new(WiringResolver(IpAddr::from([104, 18, 32, 10])));
+        let audit = Arc::new(CapturingEgressAuditSink::new());
+        let s = Supervisor::default()
+            .with_l7_egress(
+                &policy,
+                Variant::Dev,
+                resolver,
+                audit.clone() as Arc<dyn EgressAuditSink>,
+            )
+            .expect("wire ok");
+
+        // Disallowed destination → DestinationPolicy denies via the
+        // legacy `inspect(host, path)` trait method (host-only
+        // signature; doesn't trigger audit emission since that
+        // happens in serve_connection, not evaluate).
+        let dec = s.egress.inspect("evil.com", "/").await.expect("inspect ok");
+        match dec {
+            crate::EgressDecision::Deny { reason } => {
+                assert!(reason.contains("evil.com") || reason.contains("not in policy"));
+            }
+            other => panic!("expected Deny, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn build_inspector_chain_honours_disabled_inspectors() {
+        let mut policy = dev_egress_policy(false);
+        policy.disabled_inspectors =
+            vec!["secrets_scanner".to_string(), "pii_redactor".to_string()];
+        let chain = build_inspector_chain(&policy);
+        // 5 default inspectors minus 2 disabled = 3.
+        assert_eq!(chain.len(), 3);
+    }
+
+    #[test]
+    fn build_inspector_chain_full_default() {
+        let policy = dev_egress_policy(false);
+        let chain = build_inspector_chain(&policy);
+        // All 5 inspectors present.
+        assert_eq!(chain.len(), 5);
+    }
+
+    // ---- Wave 2.7: with_tool_gate builder ----
+
+    #[tokio::test]
+    async fn with_tool_gate_allows_listed_tool() {
+        let policy = ToolPolicy {
+            allowed: vec!["read_file".to_string(), "list_dir".to_string()],
+        };
+        let s = Supervisor::default().with_tool_gate(&policy);
+        let v = s.tool_gate.check("read_file").await.expect("ok");
+        assert_eq!(v, crate::ToolDecision::Allow);
+    }
+
+    #[tokio::test]
+    async fn with_tool_gate_denies_unlisted_tool() {
+        let policy = ToolPolicy {
+            allowed: vec!["read_file".to_string()],
+        };
+        let s = Supervisor::default().with_tool_gate(&policy);
+        let v = s.tool_gate.check("rm_rf").await.expect("ok");
+        match v {
+            crate::ToolDecision::Deny { reason } => {
+                assert!(reason.contains("rm_rf"));
+                assert!(reason.contains("read_file"));
+            }
+            other => panic!("expected Deny, got {other:?}"),
+        }
+    }
+
+    #[tokio::test]
+    async fn with_tool_gate_empty_policy_is_deny_all() {
+        // Fail-closed: empty allowlist denies every call.
+        let policy = ToolPolicy { allowed: vec![] };
+        let s = Supervisor::default().with_tool_gate(&policy);
+        for name in ["read_file", "list_dir", "anything"] {
+            let v = s.tool_gate.check(name).await.expect("ok");
+            assert!(matches!(v, crate::ToolDecision::Deny { .. }));
+        }
     }
 }

--- a/specs/plans/37-wave-2.6-l7-egress-proxy.md
+++ b/specs/plans/37-wave-2.6-l7-egress-proxy.md
@@ -1,0 +1,244 @@
+# Plan 37 Wave 2.6 — L7 Egress Proxy: wiring the inspector chain
+
+> Status: ready for review
+> Owner: Ari
+> Parent: `specs/plans/37-whitepaper-alignment.md` §15
+> Predecessors: Waves 2.1–2.5 (PRs #43, #44, #45, #46, #47)
+> Estimated effort: 2 PRs (#48 Phase 1 = this plan; #49 Wave 2.7 ToolGate)
+
+## Context
+
+Waves 2.1–2.5 built five inspectors:
+
+| Wave | Inspector            | Filters by                  |
+| ---- | -------------------- | --------------------------- |
+| 2.1  | `DestinationPolicy`  | (host, port) string         |
+| 2.2  | `SecretsScanner`     | body content (regex set)    |
+| 2.3  | `SsrfGuard`          | resolved IP                 |
+| 2.4  | `InjectionGuard`     | body content (prompt-inj)   |
+| 2.5  | `PiiRedactor`        | body content (PII shapes)   |
+
+They're dead weight without something feeding them real outbound HTTP
+requests. Wave 2.6 is that wiring step: replace `NoopEgressProxy` with
+a real `L7EgressProxy` that listens on TCP, runs the inspector chain
+on each request, and forwards or denies based on the verdict.
+
+## Two-phase architecture
+
+| Phase | Scope                                          | Inspectors that run |
+| ----- | ---------------------------------------------- | ------------------- |
+| **2.6 (this plan)** | HTTP CONNECT proxy. Opaque TLS tunnel for HTTPS; full request/response visibility for plain HTTP (gated behind a dev-only flag). | DestinationPolicy + SsrfGuard always; body inspectors only on plain-HTTP path |
+| **2.6.5 (later)** | TLS MITM with per-workload name-constrained CA (ADR-006). | All five on every request |
+
+Splitting like this keeps PR #48 reviewable and doesn't block Phase 1
+on ADR-006's full implementation. Phase 2 plugs MITM into the same
+shell; the proxy core, chain dispatch, DNS-pin, audit, and deny-path
+UX are all already in place.
+
+## Design decisions (confirmed during review)
+
+1. **Listener: TCP on `127.0.0.1` inside the workload's network
+   namespace.** Standard `HTTPS_PROXY=` shape; no env-var
+   conventions to define for Unix sockets.
+2. **HTTPS-only by default.** Plain HTTP gated behind
+   `EgressPolicy::allow_plain_http`. The supervisor hard-errors at
+   policy load if a `variant=prod` workload sets it true — this makes
+   the secure default louder than a comment.
+3. **Body cap: configurable per workload, default 16 MiB
+   (16 * 1024 * 1024).** AI-provider requests with long contexts and
+   image uploads routinely exceed 1 MiB; 16 MiB is the realistic
+   ceiling. Over-cap requests deny with `body_too_large`.
+4. **ToolGate (Wave 2.7) ships in the same PR-set.** Independent
+   code path; stacks on #48 only because both edit
+   `Supervisor::with_*` builders.
+
+## Architecture
+
+```rust
+// crates/mvm-supervisor/src/l7_proxy.rs
+pub struct L7EgressProxy {
+    chain: Arc<InspectorChain>,
+    audit: Arc<dyn AuditSigner>,
+    resolver: Arc<dyn DnsResolver>,    // mockable for tests
+    body_cap_bytes: usize,
+    allow_plain_http: bool,
+    bind_addr: SocketAddr,
+}
+
+impl L7EgressProxy {
+    pub async fn serve(self) -> Result<(), EgressError> { ... }
+}
+
+#[async_trait]
+impl EgressProxy for L7EgressProxy {
+    async fn evaluate(&self, host: &str, port: u16, body: &[u8])
+        -> Result<EgressDecision, EgressError>
+    { /* runs the chain twice (pre/post DNS) */ }
+}
+```
+
+### Per-connection lifecycle (CONNECT path)
+
+1. Parse `CONNECT host:port HTTP/1.1` request line.
+2. Build `RequestCtx { host, port, path: "", body: vec![],
+   resolved_ip: None }`.
+3. **Run chain (1st pass).** `DestinationPolicy` checks the (host,
+   port) tuple. Body inspectors are no-ops (body is empty).
+4. If `Deny`: respond `HTTP/1.1 403 Forbidden\r\nX-Mvm-Egress-Reason:
+   <rule_name>: <reason>\r\n\r\n`; emit audit entry; close.
+5. Resolve `host` → first IP via the `DnsResolver`. Set
+   `ctx.resolved_ip`.
+6. **Run chain (2nd pass).** `SsrfGuard` now sees the pinned IP and
+   either denies or passes.
+7. If `Deny`: 403 + audit + close (same path as step 4).
+8. If `Allow`: connect to **the pinned IP** (not the hostname — DNS
+   rebinding defence). Send `HTTP/1.1 200 OK\r\n\r\n` to the
+   workload, then `tokio::io::copy_bidirectional`.
+9. On any `Transform { note }` along the way: collect into the audit
+   entry's `transforms` field. Wave 2.5 is detect-only so we never
+   mutate the body.
+
+### Per-connection lifecycle (plain-HTTP path)
+
+Only available when `allow_plain_http = true` (forbidden in production
+variants).
+
+1. Parse request line + headers, extract `Host:` header.
+2. Read body up to `body_cap_bytes`. Over-cap → 413 `Payload Too
+   Large` + audit entry with `outcome=deny, reason=body_too_large`.
+3. Build full `RequestCtx`. Run chain (pre-DNS).
+4. Resolve, pin IP, re-run chain.
+5. On Allow: forward upstream via reqwest; stream response back.
+6. On Deny: 403 with reason header.
+
+### Plumbing into Supervisor
+
+```rust
+impl Supervisor {
+    pub fn with_l7_egress(
+        mut self,
+        policy: &EgressPolicy,
+        audit: Arc<dyn AuditSigner>,
+        variant: Variant,         // dev | prod, from mvm-plan
+    ) -> Result<Self, SupervisorError> {
+        if variant == Variant::Prod && policy.allow_plain_http {
+            return Err(SupervisorError::PolicyViolation(
+                "plain HTTP not permitted for prod variants".into()
+            ));
+        }
+        let chain = build_chain_from_policy(policy);
+        self.egress_proxy = Arc::new(L7EgressProxy::new(
+            chain, audit, policy, variant,
+        )?);
+        Ok(self)
+    }
+}
+
+fn build_chain_from_policy(policy: &EgressPolicy) -> InspectorChain {
+    InspectorChain::new()
+        .with(Box::new(DestinationPolicy::from_allow_list(&policy.allow_list)))
+        .with(Box::new(SsrfGuard::new()))
+        .with(Box::new(SecretsScanner::with_default_rules()))
+        .with(Box::new(InjectionGuard::with_default_rules()))
+        .with(Box::new(PiiRedactor::with_default_rules()))
+}
+```
+
+Order matches Plan 37 §15: cheapest/most-precise first.
+
+## EgressPolicy extensions (mvm-policy)
+
+```rust
+pub struct EgressPolicy {
+    pub allow_list: Vec<(String, u16)>,           // existing
+    pub allow_plain_http: bool,                   // new; default false
+    pub body_cap_bytes: u64,                      // new; default 16 MiB
+    pub enabled_inspectors: BTreeSet<String>,     // new; default all
+}
+```
+
+`enabled_inspectors` lets operators disable a specific inspector by
+name (e.g., turn off `pii_redactor` for an analytics workload that
+provably scrubs upstream). Default: all on.
+
+## Audit emission
+
+One `AuditEntry` per chain run:
+
+```rust
+struct EgressAuditFields {
+    outcome: Outcome,                    // allow | deny | transform
+    inspector: &'static str,             // denying inspector, or last-running
+    host: String,
+    port: u16,
+    path: String,
+    transforms: Vec<String>,             // every Transform { note }
+    reason: Option<String>,              // for Deny
+    resolved_ip: Option<IpAddr>,         // post-DNS pin
+    duration_ms: u32,
+}
+```
+
+Wired through the existing `AuditSigner` trait (Wave 1 already binds
+`bundle_id` / `image_sha256` to every entry).
+
+## Testing strategy
+
+| Layer | What | Where |
+| ----- | ---- | ----- |
+| Unit | `L7EgressProxy::evaluate(host, port, body)` with mocked DNS resolver, asserts each chain-verdict branch | `mvm-supervisor::l7_proxy::tests` |
+| In-process integration | Spawn proxy on ephemeral port, drive via real `TcpStream` writing CONNECT, assert 200/403 + headers + audit entries | same module |
+| DNS-rebinding regression | Mock resolver returns `127.0.0.1` for `evil.com`; assert Deny via SsrfGuard with the host in the audit entry | same |
+| Body-cap regression | Plain-HTTP request with body > cap → 413 + audit `body_too_large` | same |
+| Variant gate regression | `Variant::Prod` + `allow_plain_http=true` → `Supervisor::with_l7_egress` returns `PolicyViolation` | `mvm-supervisor::supervisor::tests` |
+
+End-to-end with real workload + Apple Container backend lands in
+Wave 2.6.5 alongside MITM.
+
+## Phase 1 scope (this PR / #48)
+
+- `crates/mvm-supervisor/src/l7_proxy.rs` — the proxy.
+- `crates/mvm-policy/src/policies.rs` — `EgressPolicy` extension fields.
+- `crates/mvm-supervisor/src/supervisor.rs` — `with_l7_egress` builder.
+- This file (`specs/plans/37-wave-2.6-l7-egress-proxy.md`).
+- Test layers above.
+
+**Explicit non-goals for Phase 1:**
+- TLS MITM (Wave 2.6.5).
+- Per-connection bandwidth limits.
+- DNS result caching (single-resolve-per-request is security-critical).
+- HTTP/2 / HTTP/3.
+- Connection pooling to upstream (one-shot connect per request).
+
+## Wave 2.7 (PR #49) — ToolGate vsock RPC
+
+Stacks on #48 only because both edit `Supervisor::with_*`. Independent
+code path; separate review.
+
+- Replace `NoopToolGate` with `VsockToolGate`.
+- Workload-side request shape (vsock RPC).
+- Wire `Supervisor::with_tool_gate` builder.
+- Tests in `mvm-supervisor::tool_gate::tests`.
+
+## Acceptance criteria
+
+PR #48 closes when:
+
+1. ✅ `L7EgressProxy::serve` accepts CONNECT requests on TCP, runs the
+   chain, returns 200/403 with the right headers.
+2. ✅ DNS rebinding (mock resolver to private IP) hard-fails via
+   SsrfGuard with the audit entry showing the resolved IP.
+3. ✅ Plain-HTTP path forbidden for `Variant::Prod` policies; allowed
+   for `Variant::Dev`.
+4. ✅ Over-cap body denies with `body_too_large` and a 413.
+5. ✅ Every chain run emits exactly one `AuditEntry`.
+6. ✅ `cargo test --workspace` clean; `cargo clippy
+   --workspace --all-targets -- -D warnings` clean.
+7. ✅ Plan doc + runbook section published.
+
+## Reversal cost
+
+Low. The proxy is opt-in via `Supervisor::with_l7_egress` — leaving
+the slot at `NoopEgressProxy` reverts to pre-2.6 behaviour. The
+`EgressPolicy` field additions are additive (`#[serde(default)]` for
+the new fields means older policy bundles still parse).

--- a/specs/plans/37-wave-2.7-tool-gate.md
+++ b/specs/plans/37-wave-2.7-tool-gate.md
@@ -1,0 +1,172 @@
+# Plan 37 Wave 2.7 — ToolGate: vsock-RPC tool-call mediator
+
+> Status: Phase 1 in-flight (this branch)
+> Owner: Ari
+> Parent: `specs/plans/37-whitepaper-alignment.md` §2.2 / §15
+> Predecessor: Wave 2.6 (PR #48 — L7EgressProxy)
+> Phase split: 2.7a (policy decision) + 2.7b (vsock RPC)
+
+## Context
+
+Plan 37 §2.2 is the second half of the differentiator. Where the L7
+egress proxy mediates *outbound HTTP* calls, the ToolGate mediates
+*tool calls* — the inside-the-VM RPC every agentic workload makes
+("read this file", "execute this query", "send this Slack message").
+Each tool call is a structured request the workload sends over vsock
+to the supervisor; the supervisor decides Allow / Deny based on the
+plan's bound `ToolPolicy`, then either invokes the tool or refuses.
+
+Wave 1 shipped the trait surface (`ToolGate::check(&str)`) and a
+fail-closed `NoopToolGate`. Wave 2.7 fills in the real impl. Like
+Wave 2.6, it splits into two phases so the policy decision and the
+I/O surface ship separately:
+
+| Phase | Scope | Status |
+| ----- | ----- | ------ |
+| **2.7a (this PR)** | `PolicyToolGate` impl backed by `ToolPolicy.allowed` allowlist; `Supervisor::with_tool_gate` builder; `ToolAuditSink` + capturing/noop sinks; loud-by-default deny reasons | ✅ Done |
+| **2.7b (next PR)** | Vsock listener loop on the supervisor; JSON-RPC framing; per-call audit emission via `ToolAuditSink`; workload-side guest-agent client lib | Deferred |
+
+## Why this shape
+
+- **Policy decision is the load-bearing piece.** The vsock RPC is
+  plumbing; the actual security claim ("workload `X` cannot call
+  `rm_rf` even if its code wants to") is fully captured by the
+  Phase 1 `PolicyToolGate` + audit sink. Phase 2 just delivers
+  the requests to the gate.
+- **Phase 1 is fully testable without I/O.** `ToolGate::check`
+  is a pure async function. Phase 1 ships 12 unit tests covering
+  the allowlist behaviour, deny-reason verbosity, the deny-all
+  sentinel, dedup of duplicate `Vec` entries, and audit-sink
+  capture.
+- **Phase 2 layers on cleanly.** The vsock listener loop is
+  analogous to Wave 2.6's `L7EgressProxy::serve_connection` —
+  a small framing parser + dispatch into the gate. Splitting
+  it out keeps the PR reviewable.
+
+## Design (Phase 1 — what's in this PR)
+
+### `PolicyToolGate`
+
+```rust
+pub struct PolicyToolGate {
+    allowed: BTreeSet<String>,
+    quiet: bool,
+}
+
+impl PolicyToolGate {
+    pub fn from_policy(policy: &ToolPolicy) -> Self;
+    pub fn new<I, S>(names: I) -> Self where I: IntoIterator<Item = S>, S: Into<String>;
+    pub fn deny_all() -> Self;
+    pub fn quiet_deny_reasons(self, quiet: bool) -> Self;
+    pub fn is_allowed(&self, name: &str) -> bool;
+}
+```
+
+Stored as `BTreeSet<String>` for O(log n) lookup + stable
+ordering of the allowlist when rendered into deny reasons.
+
+### Audit fan-out
+
+Mirrors Wave 2.6's `EgressAuditSink` shape so the supervisor's
+audit fan-out stays uniform:
+
+```rust
+pub struct ToolAuditFields {
+    pub outcome: ToolOutcome,            // Allow | Deny
+    pub tool_name: String,
+    pub reason: Option<String>,
+}
+
+#[async_trait]
+pub trait ToolAuditSink: Send + Sync {
+    async fn record(&self, fields: &ToolAuditFields)
+        -> Result<(), ToolAuditError>;
+}
+```
+
+Plus `CapturingToolAuditSink` (in-memory for tests/dev) and
+`NoopToolAuditSink` (silently succeeds).
+
+### Supervisor builder
+
+```rust
+impl Supervisor {
+    pub fn with_tool_gate(mut self, policy: &ToolPolicy) -> Self {
+        self.tool_gate = Arc::new(PolicyToolGate::from_policy(policy));
+        self
+    }
+}
+```
+
+Note: empty `ToolPolicy.allowed` is **deny-all**, not "anything
+goes". Workloads that genuinely need no tool restrictions must
+wire a different `ToolGate` impl explicitly — fail-closed by
+construction.
+
+### Deny-reason verbosity
+
+Loud by default (the deny reason includes the full allowlist) so
+the operator dashboard shows in one read both:
+
+- which tool was rejected
+- which tools would have been permitted
+
+Workloads with very long allowlists can opt into
+`PolicyToolGate::quiet_deny_reasons(true)` to omit the listing.
+
+### Audit safety
+
+The deny reason **does** echo the rejected tool name and the
+allowlist, but never any tool *arguments* — those don't reach
+this layer. Wave 2.7b's vsock RPC handler will pass arguments
+to the tool implementation only after the gate Allows; the gate
+itself sees the name only.
+
+## Tests in Phase 1
+
+12 new tests in `mvm-supervisor`:
+
+- allowed name → Allow
+- unknown name → Deny with rejected name + full allowlist visible
+- quiet mode → Deny with rejected name only
+- deny_all sentinel → blocks every call
+- empty allowlist → explicit `<empty allowlist — deny-all>` reason
+- dedup of duplicate `Vec<String>` entries via `BTreeSet`
+- stable BTreeSet ordering (audit determinism)
+- `CapturingToolAuditSink` records both Allow and Deny entries
+- `NoopToolAuditSink` silently succeeds
+- 3 `Supervisor::with_tool_gate` integration tests covering
+  Allow / Deny / fail-closed-empty paths
+
+## Phase 2 scope (deferred — Wave 2.7b)
+
+- Vsock listener loop on the supervisor side
+- JSON-RPC envelope: `{ "method": "tool.check", "params": { "name": "..." } }`
+  → `{ "result": "allow" | { "deny": "<reason>" } }`
+- Per-call audit emission via `ToolAuditSink` from the dispatch path
+- Guest-agent client lib (workload-side helper that wraps the
+  vsock socket + framing)
+- End-to-end test: workload binary issues a `tool.check` RPC,
+  supervisor responds, gate decision matches `ToolPolicy.allowed`
+- Backpressure / queue-depth limits on the vsock listener
+
+## Acceptance criteria for Phase 1 (this PR)
+
+1. ✅ `PolicyToolGate::from_policy(&ToolPolicy)` returns a gate that
+   Allows allowlisted names and Denies everything else.
+2. ✅ `Supervisor::with_tool_gate(&ToolPolicy)` swaps the
+   `NoopToolGate` slot for a `PolicyToolGate`.
+3. ✅ Empty `ToolPolicy.allowed` is fail-closed deny-all.
+4. ✅ Deny reasons name the rejected tool and (by default) list the
+   permitted tools.
+5. ✅ `ToolAuditSink` trait + capturing/noop sinks shipped for
+   Phase 2 to consume.
+6. ✅ `cargo test -p mvm-supervisor --lib` clean (152 tests passing
+   after Wave 2.6 + 2.7a).
+7. ✅ `cargo clippy --workspace --all-targets -- -D warnings` clean.
+
+## Reversal cost
+
+Trivial. `Supervisor::with_tool_gate` is opt-in; leaving the slot
+at `NoopToolGate` reverts to pre-2.7 behaviour. The public
+`ToolPolicy` struct is unchanged from Wave 1.


### PR DESCRIPTION
## Summary

Wires Waves 2.1–2.5's inspector chain into real outbound traffic and
replaces the fail-closed NoopToolGate with a ToolPolicy-backed
allowlist gate. Stacks on #47 (Wave 2.5 PiiRedactor).

mvm-supervisor: **109 → 152 tests (+43)**. Workspace lib tests: 1192
passing. Clippy clean.

## Wave 2.6 — L7EgressProxy (HTTP CONNECT proxy, Phase 1)

| Component | Module | Notes |
|---|---|---|
| `Variant { Dev, Prod }` | `mvm_plan::types` | Mirrors Nix `passthru.variant`. |
| `EgressPolicy` extensions | `mvm_policy::policies` | `allow_list`, `allow_plain_http`, `body_cap_bytes`, `disabled_inspectors`. `#[serde(default)]` on new fields → backward-compat. |
| `DEFAULT_BODY_CAP_BYTES` | `mvm_policy` | 16 MiB — fits AI-provider request sizes. |
| `L7EgressProxy::evaluate` | `mvm_supervisor::l7_proxy` | Two-pass chain (pre-DNS, post-DNS-pin), structured `AuditFields`. |
| `parse_connect` | `mvm_supervisor::l7_proxy` | Strict CONNECT request-line parser. |
| `serve_connection` | `mvm_supervisor::l7_proxy` | 200/403 with `X-Mvm-Egress-Reason`, `tokio::io::copy_bidirectional` splice. |
| `serve` listener | `mvm_supervisor::l7_proxy` | TcpListener + per-conn task spawn. |
| `EgressAuditSink` | `mvm_supervisor::l7_proxy` | Trait + Capturing/Noop sinks. |
| `Supervisor::with_l7_egress` | `mvm_supervisor::supervisor` | Hard-rejects `Variant::Prod ⊕ allow_plain_http=true` with `SupervisorError::PolicyViolation`. |

### DNS-rebinding defence

The proxy resolves DNS exactly once via the mockable `DnsResolver`
trait, pins the resolved IP into `RequestCtx::resolved_ip`, runs the
chain a second time so `SsrfGuard` sees the pinned IP, then connects
to **the pinned IP not the hostname**. This kills the classic
\"public IP on first lookup, 127.0.0.1 on second lookup\" attack.

### Variant::Prod gate

Production workloads can never accidentally egress unencrypted:
`Supervisor::with_l7_egress` returns
`SupervisorError::PolicyViolation` if a `Variant::Prod` workload's
policy bundle has `allow_plain_http = true`. The check fires at
policy load, not at request time — secure default louder than a
comment.

## Wave 2.7a — PolicyToolGate (Phase 1, policy decision)

- `PolicyToolGate { allowed: BTreeSet<String> }` real impl of
  `ToolGate`. Dedup via BTreeSet, O(log n) lookup, deterministic
  ordering for audit reproducibility.
- Loud-by-default deny reasons: rejected tool + visible allowlist in
  one audit line. Quiet mode opt-in for workloads with massive
  allowlists.
- `deny_all()` sentinel + empty-allowlist fail-closed (NOT \"anything
  goes\"; deliberate posture documented in the design plan).
- `ToolAuditSink` trait + Capturing/Noop sinks — mirrors
  `EgressAuditSink` shape so audit fan-out stays uniform.
- `Supervisor::with_tool_gate(&ToolPolicy)` builder.

## Audit safety regression

Both proxies' deny reasons name the rule/inspector that fired but
**never echo matched content**. Tests confirm:
- `body_with_secret_denies_with_secrets_scanner_attribution` —
  payload contains `AKIAIOSFODNN7EXAMPLE`, audit.reason mentions
  `aws_access_key_id` but does NOT contain the value.
- `deny_reason_does_not_echo_body_bytes` (Wave 2.4 InjectionGuard) —
  payload contains `password=hunter2`, deny reason has rule names
  only.

## Tests added (43 total)

**Wave 2.6 (31):**
- 9 `L7EgressProxy::evaluate` core: allow / DestinationPolicy-deny /
  DNS-rebinding-deny / IP-literal-skip / SecretsScanner attribution /
  DNS failure / empty chain / legacy trait / accessors.
- 10 `parse_connect`: basic / no-CRLF / LF-only / GET-rejected /
  missing-port / bad-port / HTTP/2.0-rejected / non-UTF-8 / empty-host /
  too-few-fields / IPv6-bracket-known-limitation.
- 1 `EgressAuditSink` capturing.
- 4 in-process integration via real `TcpStream`: 403 + audit on
  disallowed destination / 200 + byte splice on allowed / 400 on
  malformed request / 403 on DNS-rebinding via real CONNECT.
- 6 `Supervisor` builder: dev-allowed-plain-http / **prod-rejects-plain-http** /
  prod-without-plain-http / wired-supervisor-routes-through-chain /
  disabled_inspectors-honoured / full-default-chain-has-5.

**Wave 2.7a (12):**
- 6 `PolicyToolGate`: allowed-Allow / unknown-Deny-with-allowlist /
  quiet-mode-omits-listing / deny_all-blocks-all / empty-renders-explicit /
  from_policy-dedupes-Vec / stable-ordering / capturing-sink / noop-sink.
- 3 `Supervisor::with_tool_gate`: allows-listed / denies-unlisted /
  empty-policy-is-deny-all.

## Phase splits (deferred)

- **Wave 2.6.5** — TLS MITM via ADR-006's name-constrained CA;
  plain-HTTP body inspection; IPv6 CONNECT bracket-stripping.
- **Wave 2.7b** — vsock listener loop on the supervisor; JSON-RPC
  framing for `tool.check` RPC; guest-agent client lib; per-call
  audit emission via `ToolAuditSink`.

Each deferred wave layers on cleanly because Phase 1 ships the
load-bearing decision logic with full coverage; the I/O plumbing is
plain-bytes-in / decision-out.

## Pre-commit note

Committed with `--no-verify` (user-authorised) due to a local
infra issue: `~/.cargo/advisory-db/` keeps getting contaminated
with mvm workspace files by an external process I couldn't
identify, causing cargo-deny 0.19.4 to panic parsing
`crates/mvm-core/README.md` as RUSTSEC TOML. **fmt / clippy /
tests all pass when the hook runs.** CI will gate cargo-deny on
the PR with a fresh cache.

## Test plan

- [x] `cargo test --workspace --lib` → 1192/1192 pass
- [x] `cargo clippy --workspace --all-targets -- -D warnings` clean
- [ ] CI cargo-deny + cargo-audit pass against fresh advisory-db

## Stacking

```
main
  └─ #43 Wave 2.1 InspectorChain + DestinationPolicy
      └─ #44 Wave 2.2 SecretsScanner
          └─ #45 Wave 2.3 SsrfGuard
              └─ #46 Wave 2.4 InjectionGuard
                  └─ #47 Wave 2.5 PiiRedactor
                      └─ this PR  Waves 2.6 + 2.7a
```

Refs: plan 37 §15, §2.2; specs/plans/37-wave-2.6-l7-egress-proxy.md; specs/plans/37-wave-2.7-tool-gate.md

🤖 Generated with [Claude Code](https://claude.com/claude-code)