### PR TITLE
feat(audit): cover snapshot/image integrity failures and build outcomes

### DIFF
--- a/crates/mvm-cli/src/commands/build/build.rs
+++ b/crates/mvm-cli/src/commands/build/build.rs
@@ -186,9 +186,17 @@ fn build_manifest(
                     .with_error(&format!("{:#}", e))
                     .emit();
             }
+            audit_build_error("manifest", &persisted.manifest_path, &e);
             return Err(e);
         }
     };
+
+    audit_build_ok(
+        "manifest",
+        &persisted.manifest_path,
+        &persisted.manifest_hash,
+        &revision.revision_hash,
+    );
 
     if json {
         #[derive(Serialize)]
@@ -224,7 +232,14 @@ fn build_manifest(
 }
 
 fn build_mvmfile(path: &str, output: Option<&str>) -> Result<()> {
-    let elf_path = image::build(path, output)?;
+    let elf_path = match image::build(path, output) {
+        Ok(p) => p,
+        Err(e) => {
+            audit_build_error("mvmfile", path, &e);
+            return Err(e);
+        }
+    };
+    audit_build_ok("mvmfile", path, "", &elf_path);
     ui::success(&format!("\nImage ready: {}", elf_path));
     ui::info(&format!("Run with: mvmctl start {}", elf_path));
     Ok(())
@@ -273,9 +288,11 @@ fn build_flake(flake_ref: &str, profile: Option<&str>, watch: bool, json: bool) 
                         .with_error(&format!("{:#}", e))
                         .emit();
                 }
+                audit_build_error("flake", &resolved, &e);
                 return Err(e);
             }
         };
+        audit_build_ok("flake", &resolved, "", &result.revision_hash);
         if let Err(e) = mvm_build::dev_build::ensure_guest_agent_if_needed(env, &result) {
             ui::warn(&format!(
                 "Could not verify guest agent ({}). If built with mkGuest, the agent is already included.",
@@ -348,4 +365,39 @@ fn build_flake(flake_ref: &str, profile: Option<&str>, watch: bool, json: bool) 
             }
         }
     }
+}
+
+/// Emit a `TemplateBuild` audit line for a successful build.
+///
+/// `mode` is one of `manifest` / `flake` / `mvmfile` so the audit log
+/// distinguishes the build-graph entry path; the artifact identifier
+/// (revision hash for nix builds, ELF path for mvmfile) lands in the
+/// detail string so a reader can correlate without parsing JSON.
+fn audit_build_ok(mode: &str, source: &str, slot_hash: &str, artifact: &str) {
+    let detail = if slot_hash.is_empty() {
+        format!("mode={mode} source={source} artifact={artifact}")
+    } else {
+        format!("mode={mode} source={source} slot_hash={slot_hash} artifact={artifact}")
+    };
+    mvm_core::audit::emit(
+        mvm_core::audit::LocalAuditKind::TemplateBuild,
+        None,
+        Some(&detail),
+    );
+}
+
+/// Emit a `TemplateBuildError` audit line for a failed build.
+///
+/// Records the same `mode`/`source` shape as the success path so an
+/// operator scanning the log sees a paired success/failure pattern.
+/// Only the first line of the error chain lands in the detail to keep
+/// the audit record bounded.
+fn audit_build_error(mode: &str, source: &str, err: &anyhow::Error) {
+    let head = err.to_string();
+    let head = head.lines().next().unwrap_or("").trim();
+    mvm_core::audit::emit(
+        mvm_core::audit::LocalAuditKind::TemplateBuildError,
+        None,
+        Some(&format!("mode={mode} source={source} error={head}")),
+    );
 }

--- a/crates/mvm-cli/src/commands/env/apple_container.rs
+++ b/crates/mvm-cli/src/commands/env/apple_container.rs
@@ -1468,6 +1468,11 @@ pub fn cmd_dev_import_image(
 /// counter set discoverable in one place. mvmd plan 23's
 /// reconciliation loop will alert on attack-shaped spikes
 /// (sig_invalid, digest_mismatch, revoked).
+///
+/// Security-relevant outcomes (everything except `network`, which is
+/// operational) also emit a `LocalAuditKind::ImageVerifyFailed` event
+/// so `mvmctl audit tail` shows the rejection. The counter is the
+/// alerting channel; the audit line is the forensics channel.
 fn bump_verify_outcome(outcome: &str) {
     let m = mvm_core::observability::metrics::global();
     let counter = match outcome {
@@ -1485,6 +1490,16 @@ fn bump_verify_outcome(outcome: &str) {
         }
     };
     counter.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
+    if outcome != "network" {
+        let mvmctl_version = env!("CARGO_PKG_VERSION");
+        mvm_core::audit::emit(
+            mvm_core::audit::LocalAuditKind::ImageVerifyFailed,
+            None,
+            Some(&format!(
+                "outcome={outcome} mvmctl_version={mvmctl_version}"
+            )),
+        );
+    }
 }
 
 /// HEAD-probe a URL. Returns Ok(true) when the resource is reachable

--- a/crates/mvm-core/src/policy/audit.rs
+++ b/crates/mvm-core/src/policy/audit.rs
@@ -112,6 +112,25 @@ pub enum LocalAuditKind {
     /// new fingerprints + the list of VMs whose per-VM leaves were
     /// re-signed. Plan 34 §"Files (summary)".
     EgressCaRotated,
+    // --- Lifecycle integrity events ---
+    /// `mvmctl build` failed before producing a slot/revision. Paired
+    /// with the existing `TemplateBuild` success kind so every build
+    /// attempt — success or failure — leaves a single audit line.
+    TemplateBuildError,
+    /// Snapshot integrity verification failed at resume time. Covers
+    /// HMAC tag mismatch (tampered bytes or rotated host key), version
+    /// mismatch under strict mode, and lower-level I/O / encoding
+    /// failures from `mvm_security::snapshot_hmac::verify`. ADR-007 /
+    /// plan 41 W4 — refusing to resume a tampered snapshot is a
+    /// security signal and must be auditable.
+    SnapshotIntegrityFailed,
+    /// Pre-flight verification of a downloaded dev image manifest
+    /// failed: cosign signature invalid, manifest version pin off,
+    /// `not_after` past, or the published version is on the signed
+    /// revocation list. Plan 36 / ADR 005 — every refusal is an
+    /// auditable event so an operator can correlate "image rejected
+    /// at 14:03" with their CDN logs.
+    ImageVerifyFailed,
 }
 
 /// A single local audit log entry.
@@ -191,9 +210,17 @@ impl LocalAuditLog {
 /// Errors are logged via `tracing::warn!` and never propagated — audit
 /// failures must not block the operation being logged.
 pub fn emit(kind: LocalAuditKind, vm_name: Option<&str>, detail: Option<&str>) {
+    emit_to(&PathBuf::from(default_audit_log()), kind, vm_name, detail);
+}
+
+/// Emit a local audit event to an explicit path (best-effort).
+///
+/// Same contract as [`emit`] but the destination is supplied by the
+/// caller. Used by tests so emission can be observed without mutating
+/// `MVM_STATE_DIR` (which serializes badly across the test runner).
+pub fn emit_to(path: &Path, kind: LocalAuditKind, vm_name: Option<&str>, detail: Option<&str>) {
     let event = LocalAuditEvent::now(kind, vm_name.map(str::to_owned), detail.map(str::to_owned));
-    let path = PathBuf::from(default_audit_log());
-    match LocalAuditLog::open(&path).and_then(|log| log.append(&event)) {
+    match LocalAuditLog::open(path).and_then(|log| log.append(&event)) {
         Ok(()) => {}
         Err(e) => tracing::warn!("audit log write failed: {e}"),
     }
@@ -491,11 +518,51 @@ mod tests {
             LocalAuditKind::WorkloadSleep,
             // Plan 34 / ADR-006 egress L7.
             LocalAuditKind::EgressCaRotated,
+            // Lifecycle integrity gap-fillers.
+            LocalAuditKind::TemplateBuildError,
+            LocalAuditKind::SnapshotIntegrityFailed,
+            LocalAuditKind::ImageVerifyFailed,
         ];
         for kind in kinds {
             let json = serde_json::to_string(&kind).unwrap();
             assert!(!json.is_empty());
         }
+    }
+
+    #[test]
+    fn lifecycle_gap_kinds_use_snake_case_on_the_wire() {
+        // Pin the casing for the new gap-fillers exactly like the B21
+        // and egress kinds — the audit log is a stable parsed format
+        // for downstream tools (`mvmctl audit`, log shippers).
+        let kinds_and_strings = [
+            (LocalAuditKind::TemplateBuildError, "template_build_error"),
+            (
+                LocalAuditKind::SnapshotIntegrityFailed,
+                "snapshot_integrity_failed",
+            ),
+            (LocalAuditKind::ImageVerifyFailed, "image_verify_failed"),
+        ];
+        for (kind, expected) in kinds_and_strings {
+            let json = serde_json::to_string(&kind).unwrap();
+            assert_eq!(json, format!("\"{expected}\""));
+        }
+    }
+
+    #[test]
+    fn emit_to_writes_a_single_jsonl_line() {
+        let tmp = tempfile::tempdir().unwrap();
+        let path = tmp.path().join("audit.jsonl");
+        emit_to(
+            &path,
+            LocalAuditKind::SnapshotIntegrityFailed,
+            Some("vm-x"),
+            Some("variant=tag_mismatch"),
+        );
+        let contents = std::fs::read_to_string(&path).unwrap();
+        assert_eq!(contents.lines().count(), 1, "exactly one line per emit");
+        assert!(contents.contains("snapshot_integrity_failed"));
+        assert!(contents.contains("vm-x"));
+        assert!(contents.contains("tag_mismatch"));
     }
 
     #[test]

--- a/crates/mvm-runtime/src/vm/template/lifecycle.rs
+++ b/crates/mvm-runtime/src/vm/template/lifecycle.rs
@@ -1770,21 +1770,44 @@ pub fn verify_snapshot_artifacts(snap_dir: &str) -> Result<()> {
     {
         Ok(_) => Ok(()),
         Err(VerifyError::VersionMismatch { sealed, current }) => {
-            // Without --allow-stale-snapshot we hard-refuse; with the
-            // env var we already accepted above.
+            audit_snapshot_integrity_failure(
+                snap_dir,
+                &format!("variant=version_mismatch sealed={sealed} current={current}"),
+            );
             anyhow::bail!(
                 "snapshot at {snap_dir} was sealed by mvmctl '{sealed}' but \
                  current is '{current}'. Set MVM_ALLOW_STALE_SNAPSHOT=1 to override."
             )
         }
-        Err(VerifyError::TagMismatch) => anyhow::bail!(
-            "snapshot at {snap_dir} failed HMAC verification — files have been \
-             tampered or the host key changed. Refusing to resume."
-        ),
-        Err(other) => Err(anyhow::anyhow!(
-            "snapshot at {snap_dir} integrity check failed: {other}"
-        )),
+        Err(VerifyError::TagMismatch) => {
+            audit_snapshot_integrity_failure(snap_dir, "variant=tag_mismatch");
+            anyhow::bail!(
+                "snapshot at {snap_dir} failed HMAC verification — files have been \
+                 tampered or the host key changed. Refusing to resume."
+            )
+        }
+        Err(other) => {
+            audit_snapshot_integrity_failure(snap_dir, &format!("variant=other detail={other}"));
+            Err(anyhow::anyhow!(
+                "snapshot at {snap_dir} integrity check failed: {other}"
+            ))
+        }
     }
+}
+
+/// Emit a `SnapshotIntegrityFailed` local audit event.
+///
+/// `snap_dir` lands in `vm_name` so an operator scanning the audit log
+/// can correlate the failure with the specific template snapshot
+/// directory; `detail` carries the variant string distinguishing
+/// tamper (`tag_mismatch`) from version drift (`version_mismatch`)
+/// from lower-level I/O / encoding failures (`other`).
+fn audit_snapshot_integrity_failure(snap_dir: &str, detail: &str) {
+    mvm_core::audit::emit(
+        mvm_core::audit::LocalAuditKind::SnapshotIntegrityFailed,
+        Some(snap_dir),
+        Some(detail),
+    );
 }
 
 #[cfg(test)]


### PR DESCRIPTION
## Summary

Wires audit emissions into three lifecycle stages whose security-critical refusals previously left no trace in `mvmctl audit tail`:

- **Snapshot HMAC integrity failures** (`vm/template/lifecycle.rs::verify_snapshot_artifacts`) — `TagMismatch` is the tamper signal for ADR-002 claim #6 and used to bubble an error string only.
- **Dev image manifest verification** (`commands/env/apple_container.rs::bump_verify_outcome`) — `sig_invalid` / `digest_mismatch` / `version_skew` / `revoked` / `expired` updated metric counters but never appeared in the audit log.
- **`mvmctl build` outcomes** (manifest, flake, mvmfile paths) — produced no audit entry on success or failure, leaving no compliance trail for image construction.

## Changes

Three new `LocalAuditKind` variants in `mvm-core/src/policy/audit.rs`:
- `SnapshotIntegrityFailed` — `vm_name` carries the snap_dir; `detail` distinguishes `tag_mismatch` / `version_mismatch` / `other`.
- `ImageVerifyFailed` — emitted from `bump_verify_outcome` for every outcome except `network` (operational, not security).
- `TemplateBuildError` — paired with the existing `TemplateBuild` success kind so every build attempt leaves exactly one line.

Adds `audit::emit_to(path, ...)` so tests can observe emission without mutating `MVM_STATE_DIR` (process-global; races across nextest workers).

## Out of scope (named for visibility, follow-up PRs welcome)

- Vsock frame-level events (entrypoint dispatch, `AuthenticatedFrame` failures) still go through `bail!()` without an audit record.
- Supervisor chain-signed audit (`mvm-supervisor/src/audit.rs`) is still a `NoopAuditSigner`.
- `mvmctl down` still doesn't distinguish forceful kill vs graceful shutdown — the current `down.rs` has no separate mode flag.

## Test plan

- [x] `cargo test -p mvm-core --lib audit::` — 14 passed, including 3 new (snake_case wire pinning + emit_to single-line append)
- [x] `cargo test -p mvm-core -p mvm-runtime -p mvm-cli` — full suite passes on host
- [x] `cargo clippy -p mvm-core -p mvm-runtime -p mvm-cli --all-targets -- -D warnings` — clean on host and inside Lima
- [ ] Manual: trigger a tampered snapshot resume, confirm one new line in `~/.local/state/mvm/log/audit.jsonl` with `snapshot_integrity_failed` and `variant=tag_mismatch` (requires Linux with KVM)
- [ ] Manual: `mvmctl build .` on a known-bad flake, confirm `template_build_error` line with the error head

🤖 Generated with [Claude Code](https://claude.com/claude-code)