### PR TITLE
feat(cli): mvmctl session attach/exec/run-code verbs (plan 52 phase 3+4)

### DIFF
--- a/crates/mvm-cli/src/commands/session/attach.rs
+++ b/crates/mvm-cli/src/commands/session/attach.rs
@@ -1,0 +1,63 @@
+//! `mvmctl session attach <session-id>` — re-attach a fresh client
+//! to an existing session and dispatch invokes against it. Plan 52
+//! phase 3.
+//!
+//! Trust model: session ids are trusted within the local-machine
+//! substrate boundary — anyone with filesystem access to the session
+//! registry already has equivalent privileges. Cross-host attach
+//! requires authentication, which is mvmd's concern, not mvm's.
+//!
+//! v1 scope is bookkeeping: the verb verifies the session exists,
+//! increments `invoke_count`, updates `last_invoke_at`, and emits a
+//! `SessionAttach` audit record. The actual `dispatch_in_session`
+//! runtime primitive (boot/dispatch on a warm VM) lands in a
+//! follow-up alongside the per-session VM lifecycle integration.
+
+use anyhow::{Context, Result, bail};
+use clap::Args as ClapArgs;
+use std::path::PathBuf;
+
+use super::Cli;
+use mvm_core::config::ensure_data_dir;
+use mvm_core::policy::audit::{LocalAuditEvent, LocalAuditKind, LocalAuditLog};
+use mvm_core::session::{self, SessionStatus};
+use mvm_core::user_config::MvmConfig;
+
+#[derive(ClapArgs, Debug, Clone)]
+pub(in crate::commands) struct Args {
+    pub session_id: String,
+}
+
+pub(in crate::commands) fn run(_cli: &Cli, args: Args, _cfg: &MvmConfig) -> Result<()> {
+    let data_dir = PathBuf::from(ensure_data_dir().context("ensure ~/.mvm exists")?);
+    let mut record = match session::read(&data_dir, &args.session_id)? {
+        Some(r) => r,
+        None => bail!("session not found: {}", args.session_id),
+    };
+
+    if record.status == SessionStatus::Killed {
+        bail!("session {} is killed; cannot attach", args.session_id);
+    }
+
+    // Bookkeeping update — bump invoke_count and last_invoke_at to
+    // reflect the attach. mvmforge's Session.attach() relies on this
+    // shape to update its in-process counters consistently with the
+    // substrate.
+    record.invoke_count = record.invoke_count.saturating_add(1);
+    record.last_invoke_at = Some(chrono::Utc::now().to_rfc3339());
+    if record.status == SessionStatus::Created {
+        record.status = SessionStatus::Running;
+    }
+    session::write(&data_dir, &record).context("persist session record")?;
+
+    let log_path = data_dir.join("audit.log");
+    if let Ok(log) = LocalAuditLog::open(&log_path) {
+        let _ = log.append(&LocalAuditEvent::now(
+            LocalAuditKind::SessionAttach,
+            None,
+            Some(format!("session_id={}", args.session_id)),
+        ));
+    }
+
+    Ok(())
+}

--- a/crates/mvm-cli/src/commands/session/exec.rs
+++ b/crates/mvm-cli/src/commands/session/exec.rs
@@ -1,0 +1,75 @@
+//! `mvmctl session exec <session-id> [--] <command> [args...]` —
+//! run an ad-hoc command against a dev-mode session. Plan 52
+//! phase 4.
+//!
+//! **Refused on prod-mode sessions** at the substrate layer — never
+//! gated on client-side checks alone. Production sessions never
+//! grant exec capability; the only way to get exec is to start the
+//! session with `--mode dev`, which is a deliberate choice operators
+//! make once per session.
+
+use anyhow::{Context, Result, bail};
+use clap::Args as ClapArgs;
+use std::path::PathBuf;
+
+use super::Cli;
+use mvm_core::config::ensure_data_dir;
+use mvm_core::policy::audit::{LocalAuditEvent, LocalAuditKind, LocalAuditLog};
+use mvm_core::session::{self, SessionMode};
+use mvm_core::user_config::MvmConfig;
+
+#[derive(ClapArgs, Debug, Clone)]
+pub(in crate::commands) struct Args {
+    pub session_id: String,
+    /// Command + args to run against the session. Use `--` before
+    /// the command if any of its args look like flags.
+    #[arg(trailing_var_arg = true, num_args = 1..)]
+    pub command: Vec<String>,
+}
+
+pub(in crate::commands) fn run(_cli: &Cli, args: Args, _cfg: &MvmConfig) -> Result<()> {
+    let data_dir = PathBuf::from(ensure_data_dir().context("ensure ~/.mvm exists")?);
+    let record = match session::read(&data_dir, &args.session_id)? {
+        Some(r) => r,
+        None => bail!("session not found: {}", args.session_id),
+    };
+
+    if record.mode == SessionMode::Prod {
+        // Hard refusal at the substrate layer.
+        bail!(
+            "session {} is mode=prod; exec is dev-only — start a session with --mode dev",
+            args.session_id
+        );
+    }
+
+    // v1: bookkeeping only — record the intent. The actual
+    // dispatch_in_session integration lands when the runtime's
+    // session-VM lifecycle primitives ship.
+    let argv_summary = if args.command.len() <= 8 {
+        args.command.join(" ")
+    } else {
+        format!(
+            "{} ...({} args)",
+            args.command[..3].join(" "),
+            args.command.len()
+        )
+    };
+
+    let log_path = data_dir.join("audit.log");
+    if let Ok(log) = LocalAuditLog::open(&log_path) {
+        let _ = log.append(&LocalAuditEvent::now(
+            LocalAuditKind::SessionExec,
+            None,
+            Some(format!(
+                "session_id={} argv={}",
+                args.session_id, argv_summary
+            )),
+        ));
+    }
+
+    eprintln!(
+        "session exec: bookkeeping-only in v1 (session_id={}, argv={argv_summary})",
+        args.session_id
+    );
+    Ok(())
+}

--- a/crates/mvm-cli/src/commands/session/mod.rs
+++ b/crates/mvm-cli/src/commands/session/mod.rs
@@ -1,17 +1,17 @@
-//! `mvmctl session` — session lifecycle verbs. Plan 51.
+//! `mvmctl session` — session lifecycle verbs. Plan 51 + Plan 52.
 //!
 //! Operates on the on-disk session registry at
 //! `~/.mvm/sessions/<id>.json` (see `mvm_core::session`). Each verb
 //! reads + writes the registry atomically; mvmctl is one-shot, no
 //! daemon coordination.
 //!
-//! `start` and `stop` are bookkeeping only in v1 — they create /
-//! remove the JSON record but do not boot or tear down VMs. The
-//! per-session VM materialization integration ships in a follow-up
-//! once the runtime's session-VM lifecycle primitives land. Until
-//! then, mvmforge's `Session` class uses these verbs for correlation
-//! and `mvmctl invoke <id>` continues to dispatch one-off invokes
-//! against the workload.
+//! Verbs are bookkeeping-only in v1 — they create / mutate / remove
+//! the JSON record but do not boot or tear down VMs. The per-session
+//! VM materialization integration ships in a follow-up once the
+//! runtime's session-VM lifecycle primitives land. Until then,
+//! mvmforge's `Session` class uses these verbs for correlation and
+//! `mvmctl invoke <id>` continues to dispatch one-off invokes against
+//! the workload.
 
 use anyhow::Result;
 use clap::{Args as ClapArgs, Subcommand};
@@ -19,8 +19,11 @@ use clap::{Args as ClapArgs, Subcommand};
 use super::Cli;
 use mvm_core::user_config::MvmConfig;
 
+mod attach;
+mod exec;
 mod info;
 mod kill;
+mod run_code;
 mod set_timeout;
 mod start;
 mod stop;
@@ -44,6 +47,13 @@ pub(in crate::commands) enum SessionAction {
     Kill(kill::Args),
     /// Print a session's record as JSON on stdout.
     Info(info::Args),
+    /// Re-attach a fresh client to an existing session.
+    Attach(attach::Args),
+    /// Run an ad-hoc command against a dev-mode session (refused on prod).
+    Exec(exec::Args),
+    /// Run an ad-hoc code snippet against a dev-mode session (refused on prod).
+    #[command(name = "run-code")]
+    RunCode(run_code::Args),
 }
 
 pub(in crate::commands) fn run(cli: &Cli, args: Args, cfg: &MvmConfig) -> Result<()> {
@@ -53,5 +63,8 @@ pub(in crate::commands) fn run(cli: &Cli, args: Args, cfg: &MvmConfig) -> Result
         SessionAction::SetTimeout(a) => set_timeout::run(cli, a, cfg),
         SessionAction::Kill(a) => kill::run(cli, a, cfg),
         SessionAction::Info(a) => info::run(cli, a, cfg),
+        SessionAction::Attach(a) => attach::run(cli, a, cfg),
+        SessionAction::Exec(a) => exec::run(cli, a, cfg),
+        SessionAction::RunCode(a) => run_code::run(cli, a, cfg),
     }
 }

--- a/crates/mvm-cli/src/commands/session/run_code.rs
+++ b/crates/mvm-cli/src/commands/session/run_code.rs
@@ -1,0 +1,81 @@
+//! `mvmctl session run-code <session-id> <code>` — run an ad-hoc
+//! code snippet against a dev-mode session. Plan 52 phase 4.
+//!
+//! Like `exec`, **refused on prod-mode sessions** at the substrate
+//! layer. Code is logged as a SHA-256 hash, not the code itself —
+//! user code may carry arbitrary content (including secrets) and
+//! the audit log shouldn't be a side-channel.
+
+use anyhow::{Context, Result, bail};
+use clap::Args as ClapArgs;
+use sha2::{Digest, Sha256};
+use std::path::PathBuf;
+
+use super::Cli;
+use mvm_core::config::ensure_data_dir;
+use mvm_core::policy::audit::{LocalAuditEvent, LocalAuditKind, LocalAuditLog};
+use mvm_core::session::{self, SessionMode};
+use mvm_core::user_config::MvmConfig;
+
+#[derive(ClapArgs, Debug, Clone)]
+pub(in crate::commands) struct Args {
+    pub session_id: String,
+    /// Code snippet to run. Language is inferred from the session's
+    /// wrapper config. Pass `-` to read from stdin.
+    pub code: String,
+}
+
+pub(in crate::commands) fn run(_cli: &Cli, args: Args, _cfg: &MvmConfig) -> Result<()> {
+    let data_dir = PathBuf::from(ensure_data_dir().context("ensure ~/.mvm exists")?);
+    let record = match session::read(&data_dir, &args.session_id)? {
+        Some(r) => r,
+        None => bail!("session not found: {}", args.session_id),
+    };
+
+    if record.mode == SessionMode::Prod {
+        bail!(
+            "session {} is mode=prod; run-code is dev-only — start a session with --mode dev",
+            args.session_id
+        );
+    }
+
+    let code = if args.code == "-" {
+        use std::io::Read;
+        let mut buf = String::new();
+        std::io::stdin()
+            .read_to_string(&mut buf)
+            .context("read code from stdin")?;
+        buf
+    } else {
+        args.code.clone()
+    };
+
+    let mut hasher = Sha256::new();
+    hasher.update(code.as_bytes());
+    let code_hash = hasher
+        .finalize()
+        .iter()
+        .map(|b| format!("{b:02x}"))
+        .collect::<String>();
+
+    let log_path = data_dir.join("audit.log");
+    if let Ok(log) = LocalAuditLog::open(&log_path) {
+        let _ = log.append(&LocalAuditEvent::now(
+            LocalAuditKind::SessionRunCode,
+            None,
+            Some(format!(
+                "session_id={} code_sha256={} code_bytes={}",
+                args.session_id,
+                code_hash,
+                code.len()
+            )),
+        ));
+    }
+
+    eprintln!(
+        "session run-code: bookkeeping-only in v1 (session_id={}, code_sha256={code_hash}, code_bytes={})",
+        args.session_id,
+        code.len()
+    );
+    Ok(())
+}

--- a/crates/mvm-core/src/policy/audit.rs
+++ b/crates/mvm-core/src/policy/audit.rs
@@ -163,6 +163,23 @@ pub enum LocalAuditKind {
     /// `Killed`. Inflight invokes against the session resolve as
     /// failures with `kind = "session-killed"`.
     SessionKill,
+    /// `mvmctl session attach <id>` re-attached a fresh client to an
+    /// existing session. Detail carries `session_id`. Auditable even
+    /// for read-only attaches because attach is a session-state
+    /// observation worth correlating with the calling client.
+    SessionAttach,
+    /// `mvmctl session exec <id> -- <argv>` ran an ad-hoc command
+    /// against a dev-mode session. Refused on prod sessions at the
+    /// substrate layer — never gated on client-side checks alone.
+    /// Detail carries `session_id` and the argv (truncated for
+    /// long invocations).
+    SessionExec,
+    /// `mvmctl session run-code <id> <code>` ran an ad-hoc code
+    /// snippet against a dev-mode session. Refused on prod sessions
+    /// at the substrate layer. Detail carries `session_id` and a
+    /// SHA-256 of the code (not the code itself — code may carry
+    /// arbitrary user content, including secrets).
+    SessionRunCode,
 }
 
 /// A single local audit log entry.

--- a/tests/session_verbs.rs
+++ b/tests/session_verbs.rs
@@ -224,3 +224,123 @@ fn session_start_with_dev_mode_persists_mode() {
     .unwrap();
     assert_eq!(json["mode"], "dev");
 }
+
+// ── Plan 52 phase 3+4: attach / exec / run-code ─────────────────────
+
+fn start_session(tmp: &TempDir, mode: &str) -> String {
+    String::from_utf8(
+        mvm_with_data_dir(tmp.path())
+            .args(["session", "start", "wl", "--mode", mode])
+            .output()
+            .unwrap()
+            .stdout,
+    )
+    .unwrap()
+    .trim()
+    .to_string()
+}
+
+#[test]
+fn session_attach_increments_invoke_count() {
+    let tmp = TempDir::new().unwrap();
+    let id = start_session(&tmp, "prod");
+
+    mvm_with_data_dir(tmp.path())
+        .args(["session", "attach", &id])
+        .assert()
+        .success();
+    mvm_with_data_dir(tmp.path())
+        .args(["session", "attach", &id])
+        .assert()
+        .success();
+
+    let json: Value = serde_json::from_slice(
+        &mvm_with_data_dir(tmp.path())
+            .args(["session", "info", &id])
+            .output()
+            .unwrap()
+            .stdout,
+    )
+    .unwrap();
+    assert_eq!(json["invoke_count"], 2);
+    assert_eq!(json["status"], "running");
+    assert!(
+        json.get("last_invoke_at")
+            .and_then(|v| v.as_str())
+            .is_some(),
+        "attach should set last_invoke_at"
+    );
+}
+
+#[test]
+fn session_attach_refuses_killed_session() {
+    let tmp = TempDir::new().unwrap();
+    let id = start_session(&tmp, "prod");
+    mvm_with_data_dir(tmp.path())
+        .args(["session", "kill", &id])
+        .assert()
+        .success();
+
+    mvm_with_data_dir(tmp.path())
+        .args(["session", "attach", &id])
+        .assert()
+        .failure()
+        .stderr(predicate::str::contains("killed"));
+}
+
+#[test]
+fn session_exec_refuses_prod_session() {
+    let tmp = TempDir::new().unwrap();
+    let id = start_session(&tmp, "prod");
+
+    mvm_with_data_dir(tmp.path())
+        .args(["session", "exec", &id, "--", "ls", "/"])
+        .assert()
+        .failure()
+        .stderr(predicate::str::contains("dev-only"));
+}
+
+#[test]
+fn session_exec_succeeds_on_dev_session() {
+    let tmp = TempDir::new().unwrap();
+    let id = start_session(&tmp, "dev");
+
+    mvm_with_data_dir(tmp.path())
+        .args(["session", "exec", &id, "--", "ls", "/"])
+        .assert()
+        .success();
+}
+
+#[test]
+fn session_run_code_refuses_prod_session() {
+    let tmp = TempDir::new().unwrap();
+    let id = start_session(&tmp, "prod");
+
+    mvm_with_data_dir(tmp.path())
+        .args(["session", "run-code", &id, "print(1)"])
+        .assert()
+        .failure()
+        .stderr(predicate::str::contains("dev-only"));
+}
+
+#[test]
+fn session_run_code_succeeds_on_dev_session() {
+    let tmp = TempDir::new().unwrap();
+    let id = start_session(&tmp, "dev");
+
+    mvm_with_data_dir(tmp.path())
+        .args(["session", "run-code", &id, "print(1)"])
+        .assert()
+        .success()
+        .stderr(predicate::str::contains("code_sha256="));
+}
+
+#[test]
+fn session_attach_on_missing_errors() {
+    let tmp = TempDir::new().unwrap();
+    mvm_with_data_dir(tmp.path())
+        .args(["session", "attach", "ses-nonexistent"])
+        .assert()
+        .failure()
+        .stderr(predicate::str::contains("session not found"));
+}


### PR DESCRIPTION
## Summary

Plan 52 phases 3 + 4: extends Plan 51's \`mvmctl session\` subcommand
with three more verbs:

- \`session attach <id>\` (phase 3) — re-attach a fresh client to an
  existing session. Increments \`invoke_count\`, updates
  \`last_invoke_at\`, transitions \`Created\` → \`Running\`. Refuses on
  killed sessions.
- \`session exec <id> -- <cmd>\` (phase 4) — ad-hoc command against a
  dev-mode session. **Refused on prod-mode sessions** at the
  substrate layer.
- \`session run-code <id> <code>\` (phase 4) — ad-hoc code snippet,
  same prod refusal. Code is hashed (SHA-256) before logging — the
  audit log shouldn't be a side-channel for user secrets.

**Stacked on tinylabscom/mvm#90 (Plan 51)** — once that merges, the
diff here becomes just the new verbs + audit kinds.

## What's in this PR

- Three new audit kinds: \`SessionAttach\`, \`SessionExec\`,
  \`SessionRunCode\`. Each verb logs via the existing
  FileAuditSigner chain.
- Session-mode gating: \`exec\` and \`run-code\` hard-refuse on
  \`mode=prod\` sessions at the substrate layer — never gated on
  client-side checks alone.
- attach increments invoke counters consistent with mvmforge's
  \`Session\` class bookkeeping expectations.

## Tests (15/15 passing)

Plan 51's 8 tests + 7 new Plan 52 tests:
- attach increments \`invoke_count\` + transitions \`Created\` → \`Running\`
- attach refuses \`Killed\` sessions
- exec refuses prod sessions (substrate-layer hard refusal)
- exec succeeds on dev sessions
- run-code refuses prod sessions
- run-code succeeds on dev sessions + emits SHA-256
- attach on missing session errors clearly

\`cargo clippy -p mvm-cli -p mvm-core --all-targets -- -D warnings\` clean.

## v1 scope

These verbs are **bookkeeping-only in v1**. The actual
\`dispatch_in_session\` runtime primitive (boot/dispatch on a warm
VM) lands in a follow-up alongside the per-session VM lifecycle
integration. mvmforge's \`Session.attach()\` / \`Session.exec_cmd()\` /
\`Session.run_code()\` already use these verbs for correlation;
production dispatch ships when the runtime primitives ship.

## Plan 52's other phases still pending

- Phase 4b: agent-side fd-3 wiring in \`entrypoint.rs::execute()\`
  (cold path).
- Phase 4c: warm-process pool fd-3 wiring.
- Phase 4d: wrapper template updates (move envelope from
  stderr-marker to fd-3 record).
- Spoof-attempt regression test against the full fd-3 pipeline.

Phase 4a (the \`EntrypointEvent::Control\` wire type) shipped in
commit 24b68a8 on the spec branch; this PR sits orthogonal to it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)