### PR TITLE
Sprint 46-48: cross-platform expansion roadmap (plan 53)

### DIFF
--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -1,0 +1,110 @@
+name: Windows (informational)
+
+# Plan 53 Plan I.1: Windows CI lane.
+#
+# Status: **non-blocking informational.** Plan 53's goal is to expose Windows
+# compatibility issues so they can be fixed incrementally in Sprint 47+.
+# Until the workspace fully compiles on Windows, this workflow runs with
+# `continue-on-error: true` and is excluded from required PR checks.
+#
+# Known unconditional unix-isms blocking a clean Windows build (audit list
+# from the Sprint 47 lane-laying pass; track each as its own follow-up):
+#
+# - `crates/mvm-apple-container/src/lib.rs::vsock_connect` returns
+#   `std::os::unix::net::UnixStream`, which doesn't exist on Windows.
+#   Callers in `mvm-runtime/src/vsock_transport.rs`,
+#   `mvm-runtime/src/linux_env.rs`, `mvm-cli/src/commands/vm/console.rs`,
+#   and `mvm-cli/src/commands/env/apple_container.rs` propagate this.
+# - Various `~/.mvm/...` path constructions assume `$HOME`. Windows uses
+#   `%USERPROFILE%`; follow-up under plan 53 Plan I.4 (WSL2 bootstrap).
+# - Lima / Firecracker shell-out paths assume POSIX shells.
+#
+# When we close this list, flip `continue-on-error: false` on all jobs and
+# add `windows-build` to the required-checks set in branch protection.
+#
+# This workflow uses no user-controlled inputs in `run:` blocks (only
+# cargo and the actions/* set), so the GHA injection-attack class doesn't
+# apply here.
+
+on:
+  pull_request:
+    branches: [main]
+    paths:
+      # Run only when something Windows-relevant changes — keeps the lane
+      # cheap while still surfacing regressions in the platform-detection
+      # paths and the Cargo.toml gating story.
+      - "crates/mvm-core/src/platform/**"
+      - "crates/mvm-apple-container/**"
+      - "crates/mvm-runtime/src/vm/cow.rs"
+      - "crates/**/Cargo.toml"
+      - "Cargo.toml"
+      - "Cargo.lock"
+      - ".github/workflows/windows.yml"
+  push:
+    branches: [main]
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+env:
+  CARGO_TERM_COLOR: always
+
+jobs:
+  windows-check:
+    # Aspirational: `cargo check --workspace` on Windows. Currently expected
+    # to fail at the `mvm-apple-container` vsock_connect signature; the job
+    # is non-blocking so PRs can land while the audit list is worked off.
+    name: Windows check (non-blocking)
+    runs-on: windows-latest
+    continue-on-error: true
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Install Rust toolchain
+        uses: dtolnay/rust-toolchain@stable
+
+      - name: Cache cargo
+        uses: actions/cache@v5
+        with:
+          path: |
+            ~/.cargo/registry
+            ~/.cargo/git
+            target
+          key: windows-cargo-${{ hashFiles('**/Cargo.lock') }}
+          restore-keys: windows-cargo-
+
+      - name: Check workspace (informational)
+        # Allowed to fail until the unix-ism audit list is closed.
+        run: cargo check --workspace
+        continue-on-error: true
+
+  windows-build-mvm-core:
+    # mvm-core is the platform-agnostic foundation crate (no shell-out, no
+    # vsock, no Lima). It MUST compile on Windows — this is the first job
+    # we'll promote to a required check once it's stable. Today: expected
+    # to be green; non-blocking until promoted.
+    name: Windows build mvm-core (non-blocking, slated for promotion)
+    runs-on: windows-latest
+    continue-on-error: true
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Install Rust toolchain
+        uses: dtolnay/rust-toolchain@stable
+
+      - name: Cache cargo
+        uses: actions/cache@v5
+        with:
+          path: |
+            ~/.cargo/registry
+            ~/.cargo/git
+            target
+          key: windows-cargo-mvm-core-${{ hashFiles('**/Cargo.lock') }}
+          restore-keys: windows-cargo-mvm-core-
+
+      - name: Build mvm-core
+        run: cargo build -p mvm-core
+
+      - name: Test mvm-core
+        run: cargo test -p mvm-core --lib

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2322,6 +2322,7 @@ dependencies = [
  "mvm-build",
  "mvm-core",
  "mvm-guest",
+ "mvm-libkrun",
  "mvm-mcp",
  "mvm-runtime",
  "mvm-security",
@@ -2349,6 +2350,7 @@ dependencies = [
  "base64 0.22.1",
  "chrono",
  "fs2",
+ "mvm-libkrun",
  "regex",
  "serde",
  "serde_json",
@@ -2377,6 +2379,14 @@ dependencies = [
  "serde",
  "serde_json",
  "tempfile",
+ "tracing",
+]
+
+[[package]]
+name = "mvm-libkrun"
+version = "0.1.0"
+dependencies = [
+ "libc",
  "tracing",
 ]
 
@@ -2433,6 +2443,7 @@ dependencies = [
  "mvm-build",
  "mvm-core",
  "mvm-guest",
+ "mvm-libkrun",
  "mvm-security",
  "opendal",
  "rand 0.8.6",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,6 +11,7 @@ members = [
     "crates/mvm-cli",
     "crates/mvm-mcp",
     "crates/mvm-apple-container",
+    "crates/mvm-libkrun",
     "xtask",
 ]
 # cargo-fuzz crates have to be excluded from the main workspace because
@@ -110,6 +111,7 @@ mvm-supervisor = { path = "crates/mvm-supervisor", version = "0.13.0" }
 mvm-cli = { path = "crates/mvm-cli", version = "0.13.0" }
 mvm-mcp = { path = "crates/mvm-mcp", version = "0.13.0" }
 mvm-apple-container = { path = "crates/mvm-apple-container", version = "0.7.0" }
+mvm-libkrun = { path = "crates/mvm-libkrun", version = "0.1.0" }
 
 # Dev dependencies
 assert_cmd = "2"

--- a/crates/mvm-cli/Cargo.toml
+++ b/crates/mvm-cli/Cargo.toml
@@ -15,6 +15,7 @@ mvm-runtime.workspace = true
 mvm-build.workspace = true
 mvm-security.workspace = true
 mvm-apple-container.workspace = true
+mvm-libkrun.workspace = true
 mvm-mcp.workspace = true
 anyhow.workspace = true
 chrono.workspace = true

--- a/crates/mvm-cli/src/bootstrap.rs
+++ b/crates/mvm-cli/src/bootstrap.rs
@@ -9,12 +9,72 @@ use mvm_runtime::shell;
 ///
 /// - macOS: requires Homebrew
 /// - Linux: requires apt, dnf, or pacman
+/// - Windows: requires WSL2 (delegates to [`bootstrap_wsl2`])
 pub fn check_package_manager() -> Result<()> {
     if cfg!(target_os = "macos") {
         check_homebrew()
+    } else if cfg!(target_os = "windows") {
+        bootstrap_wsl2()
     } else {
         check_linux_package_manager()
     }
+}
+
+/// WSL2 bootstrap path (plan 53 §"Plan I.4"). On Windows, mvm runs
+/// inside a WSL2 distro — the Windows-side `mvmctl.exe` is a launcher
+/// that ensures WSL2 is configured and the Linux-side `mvmctl` is
+/// installed inside the chosen distro.
+///
+/// The current implementation detects WSL2 readiness and surfaces an
+/// install hint; full automation (running `wsl --install` + provisioning
+/// the distro) happens in a follow-up once we've validated the user
+/// flow on a real Windows host. See
+/// `public/.../guides/windows-wsl2.md` for the manual walkthrough
+/// users follow today.
+#[cfg(target_os = "windows")]
+pub fn bootstrap_wsl2() -> Result<()> {
+    use std::process::Command;
+
+    if which::which("wsl").is_err() {
+        anyhow::bail!(
+            "WSL is not installed on this Windows host.\n\
+             Install it from an elevated PowerShell:\n  \
+                 wsl --install\n\
+             Then reboot and re-run `mvmctl bootstrap`. See\n  \
+                 https://github.com/auser/mvm/blob/main/public/src/content/docs/install/windows.md"
+        );
+    }
+
+    // `wsl --status` returns 0 if WSL2 is configured and at least one
+    // distro is registered. We don't parse the output — exit code is
+    // sufficient signal for the bootstrap path.
+    let status = Command::new("wsl")
+        .arg("--status")
+        .status()
+        .map_err(|e| anyhow::anyhow!("could not invoke wsl: {e}"))?;
+    if !status.success() {
+        anyhow::bail!(
+            "WSL2 is not configured.\n\
+             From an elevated PowerShell:\n  \
+                 wsl --install\n  \
+                 wsl --update\n\
+             Then re-run `mvmctl bootstrap`."
+        );
+    }
+
+    ui::info(
+        "WSL2 detected. Install mvmctl inside your WSL2 distro and run\n  \
+            wsl -d Ubuntu -- mvmctl bootstrap\n\
+         to complete setup. See guides/windows-wsl2 for the full walkthrough.",
+    );
+    Ok(())
+}
+
+/// On non-Windows hosts, `bootstrap_wsl2` is a no-op so callers don't
+/// have to cfg-gate at every call site.
+#[cfg(not(target_os = "windows"))]
+pub fn bootstrap_wsl2() -> Result<()> {
+    Ok(())
 }
 
 /// Check if Homebrew is installed and accessible (macOS only).
@@ -117,6 +177,39 @@ echo "Lima ${LIMA_VERSION} installed successfully"
 /// Check if the platform requires Lima.
 pub fn is_lima_required() -> bool {
     platform::current().needs_lima()
+}
+
+/// Print an informational hint about libkrun availability (plan 53
+/// §"Plan E"). libkrun is optional — when it's available, `mvmctl run`
+/// can use it as a Tier 2 backend on macOS Intel and macOS <26 (where
+/// Apple Container is unavailable) without going through Lima. This
+/// function does *not* attempt to install libkrun automatically since
+/// it lives in the host's package manager (Homebrew on macOS, distro
+/// packages on Linux).
+///
+/// Idempotent and safe to call from any bootstrap path.
+pub fn hint_libkrun_if_useful() {
+    let plat = platform::current();
+    // Skip on Linux+KVM (Firecracker is the right backend) and on
+    // Windows (libkrun has no Windows port).
+    if plat.has_kvm() || plat.is_windows() {
+        return;
+    }
+    if mvm_libkrun::is_available() {
+        ui::info(
+            "Detected libkrun on this host; you can opt in with `mvmctl run --hypervisor libkrun`.",
+        );
+        return;
+    }
+    // Only suggest the install on platforms where libkrun would
+    // materially improve the user experience — i.e. macOS without
+    // Apple Container, where today the only path is Lima.
+    if matches!(plat, Platform::MacOS) && !plat.has_apple_containers() {
+        ui::info(&format!(
+            "Tip: install libkrun for a no-Lima Tier 2 microVM path on this Mac.\n  {}",
+            mvm_libkrun::install_hint()
+        ));
+    }
 }
 
 /// Detect a legacy `mvm` Lima VM left over from before W7.2 renamed the

--- a/crates/mvm-cli/src/commands/vm/up.rs
+++ b/crates/mvm-cli/src/commands/vm/up.rs
@@ -296,6 +296,12 @@ pub(super) fn cmd_run(params: RunParams<'_>) -> Result<()> {
         hypervisor
     };
 
+    // ADR-002 / plan 53: emit a loud, suppressible banner when the
+    // active backend is not a hardware-isolated microVM. Today this
+    // only fires for the Docker tier; future non-microVM backends
+    // would inherit the same banner via their `security_profile()`.
+    emit_security_banner_if_needed(effective_hypervisor);
+
     // Apple Container doesn't need Lima — skip the upfront check entirely.
     // For Firecracker on macOS, Lima is required for both build and runtime.
     let needs_lima = effective_hypervisor != "apple-container"
@@ -985,4 +991,89 @@ pub(super) fn cmd_run(params: RunParams<'_>) -> Result<()> {
     }
 
     Ok(())
+}
+
+// ── Security posture banner (ADR-002 / plan 53) ──────────────────────
+
+/// Print a loud warning banner whenever the active backend is not a
+/// hardware-isolated microVM tier (today: Docker only). Suppressible
+/// via `MVM_ACK_DOCKER_TIER=1` or `[security] ack_docker_tier = true`
+/// in `~/.mvm/config.toml`.
+///
+/// Idempotent and side-effect-only (the actual posture data lives in
+/// `mvmctl doctor`); the banner is intentionally noisy because the
+/// security tier change is the most important fact about the run.
+pub(super) fn emit_security_banner_if_needed(hypervisor: &str) {
+    if security_banner_acknowledged() {
+        return;
+    }
+    let backend = AnyBackend::from_hypervisor(hypervisor);
+    let profile = backend.security_profile();
+    if profile.layer_coverage.is_microvm() {
+        return;
+    }
+    let dropped = profile.dropped_claims();
+    let dropped_str = dropped
+        .iter()
+        .map(u8::to_string)
+        .collect::<Vec<_>>()
+        .join(", ");
+    ui::warn(&format!(
+        "⚠ SECURITY POSTURE: {tier} — reduced isolation\n   \
+        Active backend '{name}' is not a hardware-isolated microVM.\n   \
+        Layer L1-L3 collapse to the host kernel; ADR-002 claims [{dropped_str}] do NOT hold.\n   \
+        Recent container-escape CVEs (2024-2025): CVE-2024-21626, CVE-2024-1753,\n   \
+        CVE-2025-9074, CVE-2025-23266, CVE-2025-31133, CVE-2025-52565.\n   \
+        Suppress this banner with MVM_ACK_DOCKER_TIER=1 or\n   \
+        [security] ack_docker_tier = true in ~/.mvm/config.toml.",
+        tier = profile.tier,
+        name = backend.name(),
+    ));
+}
+
+fn security_banner_acknowledged() -> bool {
+    if matches!(
+        std::env::var("MVM_ACK_DOCKER_TIER").as_deref(),
+        Ok("1") | Ok("true") | Ok("TRUE") | Ok("yes")
+    ) {
+        return true;
+    }
+    mvm_core::user_config::load(None).security.ack_docker_tier
+}
+
+#[cfg(test)]
+mod security_banner_tests {
+    use super::*;
+
+    #[test]
+    fn microvm_tier_does_not_trigger_banner_logic() {
+        // Firecracker is a microVM tier — `security_banner_acknowledged`'s
+        // result shouldn't matter because is_microvm() short-circuits.
+        let backend = AnyBackend::from_hypervisor("firecracker");
+        assert!(backend.security_profile().layer_coverage.is_microvm());
+    }
+
+    #[test]
+    fn docker_tier_is_detected_as_non_microvm() {
+        let backend = AnyBackend::from_hypervisor("docker");
+        assert!(!backend.security_profile().layer_coverage.is_microvm());
+    }
+
+    #[test]
+    fn ack_env_var_suppresses_banner() {
+        // SAFETY: tests run single-threaded with --test-threads=1 in CI;
+        // the env var is restored before the function returns.
+        // We use a unique value so concurrent tests don't collide.
+        let prev = std::env::var("MVM_ACK_DOCKER_TIER").ok();
+        unsafe {
+            std::env::set_var("MVM_ACK_DOCKER_TIER", "1");
+        }
+        assert!(security_banner_acknowledged());
+        unsafe {
+            match prev {
+                Some(v) => std::env::set_var("MVM_ACK_DOCKER_TIER", v),
+                None => std::env::remove_var("MVM_ACK_DOCKER_TIER"),
+            }
+        }
+    }
 }

--- a/crates/mvm-cli/src/doctor.rs
+++ b/crates/mvm-cli/src/doctor.rs
@@ -4,8 +4,10 @@ use serde::Serialize;
 use crate::ui;
 use mvm_core::config::fc_version;
 use mvm_core::platform::{self, Platform};
+use mvm_core::vm_backend::ClaimStatus;
 use mvm_runtime::config::VM_NAME;
 use mvm_runtime::shell;
+use mvm_runtime::vm::backend::AnyBackend;
 use mvm_runtime::vm::lima;
 
 #[derive(Debug, Serialize)]
@@ -16,9 +18,33 @@ struct Check {
     info: String,
 }
 
+/// JSON-serializable view of a backend's ADR-002 security profile,
+/// surfaced under `security_posture` in `mvmctl doctor --json`.
+#[derive(Debug, Serialize)]
+struct SecurityPostureReport {
+    /// Backend name (e.g. "firecracker", "docker").
+    backend: String,
+    /// Tier label: "Tier 1", "Tier 2", "Tier 3".
+    tier: &'static str,
+    /// Layer coverage flags (L1..L5).
+    layers: [bool; 5],
+    /// Whether L1+L2+L3 are all enforced — i.e. this is a real microVM tier.
+    is_microvm: bool,
+    /// Per-claim status strings (1..7), one of "Holds", "DoesNotApply",
+    /// "DoesNotHold".
+    claims: [&'static str; 7],
+    /// 1-indexed claim numbers that do not hold for this backend.
+    dropped_claims: Vec<u8>,
+    /// 1-indexed claim numbers that don't apply to this backend.
+    na_claims: Vec<u8>,
+    /// Per-backend rationale (`notes` field of `BackendSecurityProfile`).
+    notes: Vec<&'static str>,
+}
+
 #[derive(Debug, Serialize)]
 struct DoctorReport {
     checks: Vec<Check>,
+    security_posture: SecurityPostureReport,
     all_ok: bool,
 }
 
@@ -97,9 +123,16 @@ pub fn run(json: bool) -> Result<()> {
     checks.push(security_snapshot_key_check());
     checks.push(security_snapshot_dirs_check());
 
+    // ── Active backend security posture (ADR-002 / plan 53) ──────
+    let security_posture = collect_security_posture();
+
     // ── Render ────────────────────────────────────────────────────
     let all_ok = checks.iter().all(|c| c.ok);
-    let report = DoctorReport { checks, all_ok };
+    let report = DoctorReport {
+        checks,
+        security_posture,
+        all_ok,
+    };
 
     if json {
         println!("{}", serde_json::to_string_pretty(&report)?);
@@ -155,6 +188,109 @@ fn render_text(report: &DoctorReport) {
         ui::status_line(
             &format!("  {}:", c.name),
             &format!("{} ({})", status, c.info),
+        );
+    }
+    render_security_posture(&report.security_posture);
+}
+
+// ── Active backend security posture (ADR-002 / plan 53) ──────
+
+/// Build the [`SecurityPostureReport`] for the backend that `mvmctl run`
+/// would auto-select on this host. Pure data — no I/O beyond reading
+/// the platform detection (which is already cached).
+fn collect_security_posture() -> SecurityPostureReport {
+    let backend = AnyBackend::auto_select();
+    let profile = backend.security_profile();
+    let layers = [
+        profile.layer_coverage.l1_host_hypervisor,
+        profile.layer_coverage.l2_vmm,
+        profile.layer_coverage.l3_guest_kernel,
+        profile.layer_coverage.l4_guest_agent,
+        profile.layer_coverage.l5_workload,
+    ];
+    let claims = [
+        claim_status_label(profile.claims[0]),
+        claim_status_label(profile.claims[1]),
+        claim_status_label(profile.claims[2]),
+        claim_status_label(profile.claims[3]),
+        claim_status_label(profile.claims[4]),
+        claim_status_label(profile.claims[5]),
+        claim_status_label(profile.claims[6]),
+    ];
+    SecurityPostureReport {
+        backend: backend.name().to_string(),
+        tier: profile.tier,
+        layers,
+        is_microvm: profile.layer_coverage.is_microvm(),
+        claims,
+        dropped_claims: profile.dropped_claims(),
+        na_claims: profile.na_claims(),
+        notes: profile.notes.to_vec(),
+    }
+}
+
+const fn claim_status_label(s: ClaimStatus) -> &'static str {
+    match s {
+        ClaimStatus::Holds => "Holds",
+        ClaimStatus::DoesNotApply => "DoesNotApply",
+        ClaimStatus::DoesNotHold => "DoesNotHold",
+    }
+}
+
+/// Render the per-backend security posture in `mvmctl doctor` text mode.
+///
+/// Always prints the active backend, tier, layer coverage, and per-claim
+/// status. When the backend is not a microVM tier (Docker today), prints
+/// a loud warning banner with the recent container-escape CVEs.
+fn render_security_posture(p: &SecurityPostureReport) {
+    let title = "Security posture (active backend)";
+    println!("\n{}", title);
+    println!("{}", "-".repeat(title.len()));
+    println!("  Active backend: {}", p.backend);
+    println!("  Tier: {}", p.tier);
+
+    let layer_marks: String = p
+        .layers
+        .iter()
+        .enumerate()
+        .map(|(i, ok)| format!("L{}{}", i + 1, if *ok { " ✓" } else { " ✗" }))
+        .collect::<Vec<_>>()
+        .join("  ");
+    println!("  Layer coverage: {layer_marks}");
+
+    if !p.dropped_claims.is_empty() {
+        let list = p
+            .dropped_claims
+            .iter()
+            .map(|n| n.to_string())
+            .collect::<Vec<_>>()
+            .join(", ");
+        println!("  Claims that do NOT hold: {list}");
+    } else {
+        println!("  Claims: all seven hold ✓");
+    }
+    if !p.na_claims.is_empty() {
+        let list = p
+            .na_claims
+            .iter()
+            .map(|n| n.to_string())
+            .collect::<Vec<_>>()
+            .join(", ");
+        println!("  Claims that do not apply: {list}");
+    }
+    for note in &p.notes {
+        println!("  · {note}");
+    }
+
+    if !p.is_microvm {
+        ui::warn(
+            "\n  ⚠ This backend is not a hardware-isolated microVM. The L1-L3\n   \
+             layers collapse to the host kernel; ADR-002 claims 1, 2, 3 do NOT\n   \
+             hold. Recent container-escape CVEs (2024-2025): CVE-2024-21626,\n   \
+             CVE-2024-1753, CVE-2025-9074, CVE-2025-23266, CVE-2025-31133,\n   \
+             CVE-2025-52565. Set MVM_ACK_DOCKER_TIER=1 (or [security]\n   \
+             ack_docker_tier = true in ~/.mvm/config.toml) to suppress the\n   \
+             per-run banner. See https://docs.mvm.dev/security/matryoshka.",
         );
     }
 }
@@ -1129,10 +1265,24 @@ mod tests {
                 ok: true,
                 info: "v1.0".to_string(),
             }],
+            security_posture: collect_security_posture(),
             all_ok: true,
         };
         let json = serde_json::to_string(&report).unwrap();
         assert!(json.contains("\"name\":\"test\""));
         assert!(json.contains("\"all_ok\":true"));
+        assert!(json.contains("\"security_posture\""));
+        assert!(json.contains("\"tier\""));
+    }
+
+    #[test]
+    fn collect_security_posture_returns_a_real_tier() {
+        let posture = collect_security_posture();
+        assert!(
+            posture.tier == "Tier 1" || posture.tier == "Tier 2" || posture.tier == "Tier 3",
+            "unexpected tier: {}",
+            posture.tier
+        );
+        assert_eq!(posture.claims.len(), 7);
     }
 }

--- a/crates/mvm-cli/src/doctor.rs
+++ b/crates/mvm-cli/src/doctor.rs
@@ -96,6 +96,7 @@ pub fn run(json: bool) -> Result<()> {
 
     checks.push(kvm_check(plat, in_vm));
     checks.push(apple_container_check(plat));
+    checks.push(libkrun_check(plat));
     checks.push(docker_check(plat));
 
     if plat.needs_lima() {
@@ -456,6 +457,37 @@ fn docker_check(plat: Platform) -> Check {
             category: "platform",
             ok: true, // Not a failure — just unavailable
             info: "not available (install Docker Desktop or Docker Engine)".to_string(),
+        }
+    }
+}
+
+/// libkrun availability — plan 53 §"Plan E". Probes the host for the
+/// libkrun shared library at the standard install paths. `ok: true`
+/// regardless of presence (libkrun is optional); the `info` field
+/// surfaces the install hint when missing so users see exactly what
+/// to run.
+fn libkrun_check(plat: Platform) -> Check {
+    if plat.is_windows() {
+        return Check {
+            name: "libkrun",
+            category: "platform",
+            ok: true,
+            info: "n/a (no Windows port — use WSL2)".to_string(),
+        };
+    }
+    if plat.has_libkrun() {
+        Check {
+            name: "libkrun",
+            category: "platform",
+            ok: true,
+            info: "available".to_string(),
+        }
+    } else {
+        Check {
+            name: "libkrun",
+            category: "platform",
+            ok: true, // Optional; not a failure.
+            info: format!("not available ({})", mvm_libkrun::install_hint()),
         }
     }
 }

--- a/crates/mvm-core/Cargo.toml
+++ b/crates/mvm-core/Cargo.toml
@@ -12,6 +12,7 @@ authors.workspace = true
 anyhow.workspace = true
 base64.workspace = true
 chrono.workspace = true
+mvm-libkrun.workspace = true
 serde.workspace = true
 serde_json.workspace = true
 sha2.workspace = true

--- a/crates/mvm-core/src/platform/platform.rs
+++ b/crates/mvm-core/src/platform/platform.rs
@@ -53,6 +53,24 @@ impl Platform {
         is_macos_26_or_later()
     }
 
+    /// Whether libkrun is installed on this host.
+    ///
+    /// libkrun (plan 53 §"Plan E") is a library-style VMM that runs on
+    /// Linux KVM and macOS Hypervisor.framework — including macOS Intel
+    /// where Apple Container is unavailable. Detection is a filesystem
+    /// probe of standard install paths (Homebrew on macOS, distro
+    /// packages on Linux); it does *not* guarantee the library will
+    /// load cleanly or that we have the macOS hypervisor entitlement.
+    /// The Sprint 48 spike phase wires up the actual VM lifecycle on
+    /// top of this detection.
+    pub fn has_libkrun(self) -> bool {
+        // Windows is unsupported regardless of any library being present.
+        if matches!(self, Platform::Windows) {
+            return false;
+        }
+        mvm_libkrun::is_available()
+    }
+
     /// Whether Docker is available on this platform.
     ///
     /// Runtime check — calls `docker version` to verify the daemon is running.
@@ -256,6 +274,23 @@ mod tests {
         assert!(!Platform::LinuxNoKvm.has_apple_containers());
         assert!(!Platform::Wsl2.has_apple_containers());
         assert!(!Platform::Windows.has_apple_containers());
+    }
+
+    #[test]
+    fn test_has_libkrun_returns_false_on_windows_regardless_of_filesystem() {
+        // Windows: libkrun has no Windows port. Always false irrespective
+        // of what `mvm_libkrun::is_available()` would say.
+        assert!(!Platform::Windows.has_libkrun());
+    }
+
+    #[test]
+    fn test_has_libkrun_consistent_with_libkrun_crate() {
+        // On non-Windows platforms, has_libkrun() agrees with the
+        // libkrun crate's authoritative is_available() probe.
+        let plat = current();
+        if !matches!(plat, Platform::Windows) {
+            assert_eq!(plat.has_libkrun(), mvm_libkrun::is_available());
+        }
     }
 
     #[test]

--- a/crates/mvm-core/src/protocol/vm_backend.rs
+++ b/crates/mvm-core/src/protocol/vm_backend.rs
@@ -201,6 +201,117 @@ pub struct VmCapabilities {
     pub tap_networking: bool,
 }
 
+// ---------------------------------------------------------------------------
+// BackendSecurityProfile — per-backend ADR-002 claim coverage
+// ---------------------------------------------------------------------------
+
+/// Status of a single ADR-002 security claim for a backend.
+///
+/// See ADR-002 §"The seven CI-enforced claims" for the claim definitions.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+pub enum ClaimStatus {
+    /// The claim holds for this backend; the CI gate enforces it.
+    Holds,
+    /// The claim does not apply to this backend (e.g. vsock-framing
+    /// fuzzing for a backend that uses unix sockets instead of vsock).
+    DoesNotApply,
+    /// The claim does **not** hold for this backend — the security tier
+    /// is reduced and `mvmctl doctor` flags it.
+    DoesNotHold,
+}
+
+/// Coverage of the five Matryoshka trust layers (ADR-002 §"Trust layers").
+///
+/// `true` means the layer is enforced by hardware/software isolation under
+/// this backend; `false` means the layer collapses into the host kernel
+/// or another preceding layer (e.g. Docker has L1–L3 = false because it
+/// shares the host kernel with the workload).
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default, Serialize, Deserialize)]
+pub struct LayerCoverage {
+    /// L1 — Host + hypervisor (KVM, VZ, HVF).
+    pub l1_host_hypervisor: bool,
+    /// L2 — VMM (Firecracker, Containerization, libkrun).
+    pub l2_vmm: bool,
+    /// L3 — Guest kernel (ephemeral, isolated).
+    pub l3_guest_kernel: bool,
+    /// L4 — Guest agent (uid 901 setpriv, no_new_privs).
+    pub l4_guest_agent: bool,
+    /// L5 — Workload (per-service uid, bounding-set drop, seccomp).
+    pub l5_workload: bool,
+}
+
+impl LayerCoverage {
+    /// All five layers enforced — the Tier 1 / Tier 2 shape.
+    pub const fn all_layers() -> Self {
+        Self {
+            l1_host_hypervisor: true,
+            l2_vmm: true,
+            l3_guest_kernel: true,
+            l4_guest_agent: true,
+            l5_workload: true,
+        }
+    }
+
+    /// Whether this backend provides hardware-isolated microVM execution
+    /// (L1+L2+L3 all enforced). When `false`, the backend is a Tier 3
+    /// shared-kernel container — `mvmctl run` emits a loud banner.
+    pub const fn is_microvm(self) -> bool {
+        self.l1_host_hypervisor && self.l2_vmm && self.l3_guest_kernel
+    }
+}
+
+/// Per-backend declaration of ADR-002 security-claim coverage.
+///
+/// `mvmctl doctor` and `mvmctl run` consume this to render the active
+/// backend's security posture. The seven claims are stored at indices
+/// `0..7` (claim 1 = `claims[0]`):
+///
+/// 1. No host-fs access from a guest beyond explicit shares
+/// 2. No guest binary can elevate to uid 0
+/// 3. A tampered rootfs ext4 fails to boot
+/// 4. The guest agent does not contain `do_exec` in production builds
+/// 5. Vsock framing is fuzzed
+/// 6. Pre-built dev image is hash-verified
+/// 7. Cargo deps are audited on every PR
+///
+/// `notes` provides per-backend rationale shown in doctor output and is
+/// where backends explain partial claims (e.g. "claim 3 partial — verified
+/// boot for VZ-backed rootfs not yet wired up").
+#[derive(Debug, Clone)]
+pub struct BackendSecurityProfile {
+    /// Status of claims 1..=7 (indexed 0..7).
+    pub claims: [ClaimStatus; 7],
+    /// Layer coverage in the Matryoshka model.
+    pub layer_coverage: LayerCoverage,
+    /// Human-readable security tier: `"Tier 1"`, `"Tier 2"`, `"Tier 3"`.
+    pub tier: &'static str,
+    /// Backend-specific rationale shown in doctor output.
+    pub notes: &'static [&'static str],
+}
+
+impl BackendSecurityProfile {
+    /// 1-indexed claim numbers (1..=7) that do not hold for this backend.
+    pub fn dropped_claims(&self) -> Vec<u8> {
+        self.claims
+            .iter()
+            .enumerate()
+            .filter(|(_, s)| matches!(s, ClaimStatus::DoesNotHold))
+            .map(|(i, _)| (i + 1) as u8)
+            .collect()
+    }
+
+    /// 1-indexed claim numbers that don't apply to this backend (e.g.
+    /// vsock-framing fuzzing for a unix-socket backend).
+    pub fn na_claims(&self) -> Vec<u8> {
+        self.claims
+            .iter()
+            .enumerate()
+            .filter(|(_, s)| matches!(s, ClaimStatus::DoesNotApply))
+            .map(|(i, _)| (i + 1) as u8)
+            .collect()
+    }
+}
+
 /// Summary info for a managed VM, returned by [`VmBackend::list`].
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct VmInfo {
@@ -301,6 +412,28 @@ pub trait VmBackend: Send + Sync {
     /// Backends that don't support guest communication may return an error.
     fn guest_channel_info(&self, _id: &VmId) -> Result<GuestChannelInfo> {
         anyhow::bail!("{} does not provide guest channel info", self.name())
+    }
+
+    /// Return the ADR-002 security profile for this backend.
+    ///
+    /// Each backend declares which of the seven CI-enforced claims hold,
+    /// which Matryoshka layers it covers, and a tier label. `mvmctl doctor`
+    /// renders this; `mvmctl run` uses it to emit a loud, suppressible
+    /// banner whenever the active backend is not a microVM tier.
+    ///
+    /// The default impl returns a conservative "claims unknown" profile
+    /// (all `DoesNotHold`, no layer coverage). All in-tree backends
+    /// override this with an explicit declaration.
+    fn security_profile(&self) -> BackendSecurityProfile {
+        BackendSecurityProfile {
+            claims: [ClaimStatus::DoesNotHold; 7],
+            layer_coverage: LayerCoverage::default(),
+            tier: "Unknown",
+            notes: &[
+                "Backend has not declared its security profile.",
+                "Treat as untrusted until profile is explicit.",
+            ],
+        }
     }
 }
 
@@ -477,5 +610,80 @@ mod tests {
             }
             _ => panic!("Expected UnixSocket variant"),
         }
+    }
+
+    #[test]
+    fn test_layer_coverage_all_layers_is_microvm() {
+        let cov = LayerCoverage::all_layers();
+        assert!(cov.is_microvm());
+        assert!(cov.l1_host_hypervisor);
+        assert!(cov.l2_vmm);
+        assert!(cov.l3_guest_kernel);
+        assert!(cov.l4_guest_agent);
+        assert!(cov.l5_workload);
+    }
+
+    #[test]
+    fn test_layer_coverage_default_is_not_microvm() {
+        let cov = LayerCoverage::default();
+        assert!(!cov.is_microvm());
+    }
+
+    #[test]
+    fn test_layer_coverage_docker_shape_is_not_microvm() {
+        let cov = LayerCoverage {
+            l1_host_hypervisor: false,
+            l2_vmm: false,
+            l3_guest_kernel: false,
+            l4_guest_agent: true,
+            l5_workload: true,
+        };
+        assert!(!cov.is_microvm());
+    }
+
+    #[test]
+    fn test_claim_status_serde_roundtrip() {
+        let statuses = [
+            ClaimStatus::Holds,
+            ClaimStatus::DoesNotApply,
+            ClaimStatus::DoesNotHold,
+        ];
+        for s in statuses {
+            let json = serde_json::to_string(&s).unwrap();
+            let parsed: ClaimStatus = serde_json::from_str(&json).unwrap();
+            assert_eq!(parsed, s);
+        }
+    }
+
+    #[test]
+    fn test_backend_security_profile_dropped_claims() {
+        let profile = BackendSecurityProfile {
+            claims: [
+                ClaimStatus::DoesNotHold,  // 1
+                ClaimStatus::DoesNotHold,  // 2
+                ClaimStatus::DoesNotHold,  // 3
+                ClaimStatus::Holds,        // 4
+                ClaimStatus::DoesNotApply, // 5
+                ClaimStatus::Holds,        // 6
+                ClaimStatus::Holds,        // 7
+            ],
+            layer_coverage: LayerCoverage::default(),
+            tier: "Tier 3",
+            notes: &[],
+        };
+        assert_eq!(profile.dropped_claims(), vec![1, 2, 3]);
+        assert_eq!(profile.na_claims(), vec![5]);
+    }
+
+    #[test]
+    fn test_backend_security_profile_tier_1_drops_nothing() {
+        let profile = BackendSecurityProfile {
+            claims: [ClaimStatus::Holds; 7],
+            layer_coverage: LayerCoverage::all_layers(),
+            tier: "Tier 1",
+            notes: &[],
+        };
+        assert!(profile.dropped_claims().is_empty());
+        assert!(profile.na_claims().is_empty());
     }
 }

--- a/crates/mvm-core/src/user_config.rs
+++ b/crates/mvm-core/src/user_config.rs
@@ -2,6 +2,21 @@ use anyhow::{Context, Result};
 use serde::{Deserialize, Serialize};
 use std::path::{Path, PathBuf};
 
+/// Security-related operator preferences.
+///
+/// Lives under `[security]` in `~/.mvm/config.toml`. Used by Plan B (the
+/// Docker-tier acknowledgment banner) and is the seam where future
+/// posture knobs land.
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+#[serde(default)]
+pub struct SecurityConfig {
+    /// Acknowledge that the active backend is the Tier 3 Docker fallback
+    /// (no microVM isolation). When `true`, `mvmctl run` does not print
+    /// the per-run security warning banner. Equivalent to setting the
+    /// `MVM_ACK_DOCKER_TIER=1` environment variable.
+    pub ack_docker_tier: bool,
+}
+
 /// Persistent operator configuration stored at `~/.mvm/config.toml`.
 ///
 /// CLI flags always take precedence over these values. This config is
@@ -23,6 +38,8 @@ pub struct MvmConfig {
     pub metrics_port: Option<u16>,
     /// URL for remote image catalog. None means use bundled catalog only.
     pub catalog_url: Option<String>,
+    /// Security-related operator preferences (`[security]` section).
+    pub security: SecurityConfig,
 }
 
 impl Default for MvmConfig {
@@ -35,6 +52,7 @@ impl Default for MvmConfig {
             log_format: None,
             metrics_port: None,
             catalog_url: None,
+            security: SecurityConfig::default(),
         }
     }
 }
@@ -189,6 +207,37 @@ mod tests {
         assert_eq!(cfg.default_memory_mib, 512);
         assert!(cfg.log_format.is_none());
         assert!(cfg.metrics_port.is_none());
+        // Security defaults: ack_docker_tier off — banner emits unless suppressed.
+        assert!(!cfg.security.ack_docker_tier);
+    }
+
+    #[test]
+    fn test_security_section_roundtrip() {
+        let cfg = MvmConfig {
+            security: SecurityConfig {
+                ack_docker_tier: true,
+            },
+            ..MvmConfig::default()
+        };
+        let text = toml::to_string_pretty(&cfg).unwrap();
+        let parsed: MvmConfig = toml::from_str(&text).unwrap();
+        assert!(parsed.security.ack_docker_tier);
+    }
+
+    #[test]
+    fn test_legacy_config_without_security_section_still_loads() {
+        // Older config files written before the [security] section was
+        // added must continue to deserialize cleanly with default security
+        // values. Serde's `#[serde(default)]` on the struct gives us this.
+        let legacy = r#"
+            lima_cpus = 4
+            lima_mem_gib = 8
+            default_cpus = 2
+            default_memory_mib = 512
+        "#;
+        let cfg: MvmConfig = toml::from_str(legacy).unwrap();
+        assert_eq!(cfg.lima_cpus, 4);
+        assert!(!cfg.security.ack_docker_tier);
     }
 
     #[test]

--- a/crates/mvm-libkrun/Cargo.toml
+++ b/crates/mvm-libkrun/Cargo.toml
@@ -1,0 +1,22 @@
+[package]
+name = "mvm-libkrun"
+version = "0.1.0"
+edition = "2024"
+description = "libkrun (Red Hat) backend bindings for mvm — Linux KVM and macOS Hypervisor.framework"
+license = "Apache-2.0"
+# Plan 53 / Sprint 48 / Plan E.
+# Status: scaffolding. The public API surface is final but lifecycle
+# methods return "not yet wired" until the spike phase confirms the
+# bindings shape against a real libkrun.h. See plan 53 §"Plan E".
+#
+# When a host has libkrun installed (Homebrew on macOS, distro package
+# on Linux), is_available() returns true; otherwise the API errors with
+# a hint pointing the user at install instructions.
+
+[dependencies]
+tracing = "0.1"
+
+# `libc` provides ENOENT, etc. for error classification and is already
+# a workspace dep on every platform we ship.
+[dependencies.libc]
+version = "0.2"

--- a/crates/mvm-libkrun/src/lib.rs
+++ b/crates/mvm-libkrun/src/lib.rs
@@ -16,12 +16,12 @@
 //! This crate ships **scaffolding** with the final public API shape:
 //! [`KrunContext`] for construction, [`start`] / [`stop`] for lifecycle,
 //! [`is_available`] for runtime detection. The implementation is gated
-//! on a real libkrun install — the spike phase of Plan E (boot a Nix-built
-//! ext4 rootfs in libkrun + verify vsock + verify codesigning entitlement)
-//! lands in a follow-up before lifecycle methods do real work.
+//! on a real libkrun install — see `specs/plans/57-libkrun-spike.md`
+//! for the work that lands the bindings, codesigning, and end-to-end
+//! boot validation.
 //!
 //! Until then, [`start`] / [`stop`] return [`Error::NotYetWired`] with a
-//! pointer to the open issue, and [`is_available`] checks the host for a
+//! pointer to plan 57, and [`is_available`] checks the host for a
 //! libkrun shared library at standard install locations (Homebrew on
 //! macOS, distro packages on Linux).
 //!
@@ -81,9 +81,10 @@ impl std::error::Error for Error {}
 ///
 /// **Not the same as "is functional"** — even if `is_available()`
 /// returns `true`, the [`start`] call may still fail with
-/// [`Error::NotYetWired`] until the Plan E spike phase lands the
-/// real bindings. Treat this as a precondition probe: if it returns
-/// `false`, point the user at [`install_hint`].
+/// [`Error::NotYetWired`] until the libkrun spike (specs/plans/
+/// 57-libkrun-spike.md) lands the real bindings. Treat this as a
+/// precondition probe: if it returns `false`, point the user at
+/// [`install_hint`].
 pub fn is_available() -> bool {
     install_paths().iter().any(|p| Path::new(p).exists())
 }
@@ -202,7 +203,7 @@ pub fn start(ctx: &KrunContext) -> Result<(), Error> {
     }
     let _ = ctx; // silence unused-arg until bindings land
     Err(Error::NotYetWired {
-        tracking: "plan 53 §\"Plan E\" / Sprint 48 spike phase",
+        tracking: "specs/plans/57-libkrun-spike.md",
     })
 }
 
@@ -216,7 +217,7 @@ pub fn stop(name: &str) -> Result<(), Error> {
     }
     let _ = name;
     Err(Error::NotYetWired {
-        tracking: "plan 53 §\"Plan E\" / Sprint 48 spike phase",
+        tracking: "specs/plans/57-libkrun-spike.md",
     })
 }
 

--- a/crates/mvm-libkrun/src/lib.rs
+++ b/crates/mvm-libkrun/src/lib.rs
@@ -1,0 +1,283 @@
+//! libkrun backend bindings for mvm.
+//!
+//! libkrun is Red Hat's library-style VMM (Apache-2.0). Unlike Firecracker
+//! (separate binary, HTTP API) or Apple Virtualization.framework (Swift /
+//! objc2 FFI), libkrun is a C library you link directly into your binary.
+//! On Linux it uses KVM; on macOS it uses Hypervisor.framework — making it
+//! the only VMM in mvm's consideration set that runs on **both** macOS
+//! Apple Silicon and macOS Intel without Lima. On Linux it gives us a
+//! single-binary alternative to the firecracker-on-PATH dependency.
+//!
+//! See plan 53 §"Plan E" for design context and the fork test that
+//! qualified libkrun as the one new backend we add in Sprint 48.
+//!
+//! # Status (Sprint 48 lane-laying)
+//!
+//! This crate ships **scaffolding** with the final public API shape:
+//! [`KrunContext`] for construction, [`start`] / [`stop`] for lifecycle,
+//! [`is_available`] for runtime detection. The implementation is gated
+//! on a real libkrun install — the spike phase of Plan E (boot a Nix-built
+//! ext4 rootfs in libkrun + verify vsock + verify codesigning entitlement)
+//! lands in a follow-up before lifecycle methods do real work.
+//!
+//! Until then, [`start`] / [`stop`] return [`Error::NotYetWired`] with a
+//! pointer to the open issue, and [`is_available`] checks the host for a
+//! libkrun shared library at standard install locations (Homebrew on
+//! macOS, distro packages on Linux).
+//!
+//! # Platform support
+//!
+//! - **macOS Apple Silicon**: libkrun ships in Homebrew as `libkrun`.
+//! - **macOS Intel**: libkrun via Hypervisor.framework also works.
+//! - **Linux x86_64 / aarch64**: libkrun is in most distro repos, or
+//!   build from source via Nix.
+//! - **Windows**: not supported. libkrun has no Windows port.
+
+use std::path::Path;
+
+/// Errors returned by this crate. `NotYetWired` is the placeholder
+/// until the Plan E spike lands; once the bindings are real, this
+/// variant goes away.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum Error {
+    /// libkrun is not installed on the host (no shared library found at
+    /// any of the standard locations checked by [`is_available`]).
+    NotInstalled {
+        /// Suggested install command for the user.
+        install_hint: &'static str,
+    },
+    /// libkrun is installed but this crate's bindings haven't landed
+    /// yet (Plan E spike pending). Returned by [`start`] / [`stop`]
+    /// in Sprint 48 scaffolding.
+    NotYetWired {
+        /// Tracking issue / plan reference.
+        tracking: &'static str,
+    },
+    /// Generic libkrun call failure — populated once bindings are real.
+    Krun(String),
+}
+
+impl std::fmt::Display for Error {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::NotInstalled { install_hint } => {
+                write!(f, "libkrun is not installed on this host. {install_hint}")
+            }
+            Self::NotYetWired { tracking } => write!(
+                f,
+                "libkrun bindings are not yet wired up (tracking: {tracking}). \
+                 The Plan E spike phase has to land before this backend can \
+                 boot guests."
+            ),
+            Self::Krun(msg) => write!(f, "libkrun call failed: {msg}"),
+        }
+    }
+}
+
+impl std::error::Error for Error {}
+
+/// Detect whether libkrun is installed on the host by probing for the
+/// shared library at the standard install locations.
+///
+/// **Not the same as "is functional"** — even if `is_available()`
+/// returns `true`, the [`start`] call may still fail with
+/// [`Error::NotYetWired`] until the Plan E spike phase lands the
+/// real bindings. Treat this as a precondition probe: if it returns
+/// `false`, point the user at [`install_hint`].
+pub fn is_available() -> bool {
+    install_paths().iter().any(|p| Path::new(p).exists())
+}
+
+/// Human-readable install hint used in error messages and `mvmctl
+/// doctor` output. Caller-platform-aware so users see the right
+/// command for their OS.
+pub const fn install_hint() -> &'static str {
+    #[cfg(target_os = "macos")]
+    {
+        "Install via Homebrew: `brew install libkrun`."
+    }
+    #[cfg(all(target_os = "linux", target_arch = "x86_64"))]
+    {
+        "Install via your distro package manager (e.g. `apt install libkrun-dev` \
+         on Debian/Ubuntu, `dnf install libkrun-devel` on Fedora) or build from \
+         source: https://github.com/containers/libkrun"
+    }
+    #[cfg(all(target_os = "linux", target_arch = "aarch64"))]
+    {
+        "Install via your distro package manager or build from source: \
+         https://github.com/containers/libkrun"
+    }
+    #[cfg(target_os = "windows")]
+    {
+        "libkrun is not supported on Windows. Use --hypervisor docker \
+         or install WSL2 and run mvm inside a Linux distro."
+    }
+    #[cfg(not(any(target_os = "macos", target_os = "linux", target_os = "windows")))]
+    {
+        "libkrun is not supported on this platform."
+    }
+}
+
+/// Standard filesystem locations checked by [`is_available`]. Order is
+/// "most likely first" so the predicate short-circuits on the typical
+/// developer install.
+pub fn install_paths() -> Vec<&'static str> {
+    #[cfg(target_os = "macos")]
+    {
+        vec![
+            "/opt/homebrew/lib/libkrun.dylib", // Apple Silicon Homebrew
+            "/usr/local/lib/libkrun.dylib",    // Intel Homebrew + manual installs
+        ]
+    }
+    #[cfg(target_os = "linux")]
+    {
+        vec![
+            "/usr/lib/x86_64-linux-gnu/libkrun.so",
+            "/usr/lib/aarch64-linux-gnu/libkrun.so",
+            "/usr/lib64/libkrun.so",
+            "/usr/local/lib/libkrun.so",
+        ]
+    }
+    #[cfg(not(any(target_os = "macos", target_os = "linux")))]
+    {
+        Vec::new()
+    }
+}
+
+/// Configuration for a libkrun guest VM.
+///
+/// Final API shape — the spike phase will populate the inner
+/// representation but callers won't have to change.
+#[derive(Debug, Clone)]
+pub struct KrunContext {
+    pub name: String,
+    pub kernel_path: String,
+    pub rootfs_path: String,
+    pub vcpus: u8,
+    pub ram_mib: u32,
+    pub kernel_cmdline: Option<String>,
+    pub vsock_ports: Vec<u32>,
+}
+
+impl KrunContext {
+    /// Construct a context for a guest. No I/O — this is pure
+    /// configuration. The actual VM creation happens in [`start`].
+    pub fn new(
+        name: impl Into<String>,
+        kernel_path: impl Into<String>,
+        rootfs_path: impl Into<String>,
+    ) -> Self {
+        Self {
+            name: name.into(),
+            kernel_path: kernel_path.into(),
+            rootfs_path: rootfs_path.into(),
+            vcpus: 1,
+            ram_mib: 256,
+            kernel_cmdline: None,
+            vsock_ports: Vec::new(),
+        }
+    }
+
+    /// Set CPU and memory shape.
+    pub fn with_resources(mut self, vcpus: u8, ram_mib: u32) -> Self {
+        self.vcpus = vcpus;
+        self.ram_mib = ram_mib;
+        self
+    }
+
+    /// Append a vsock port the guest agent will listen on.
+    pub fn add_vsock_port(mut self, port: u32) -> Self {
+        self.vsock_ports.push(port);
+        self
+    }
+}
+
+/// Start a libkrun guest from `ctx`. Currently a stub — see
+/// [`Error::NotYetWired`].
+pub fn start(ctx: &KrunContext) -> Result<(), Error> {
+    if !is_available() {
+        return Err(Error::NotInstalled {
+            install_hint: install_hint(),
+        });
+    }
+    let _ = ctx; // silence unused-arg until bindings land
+    Err(Error::NotYetWired {
+        tracking: "plan 53 §\"Plan E\" / Sprint 48 spike phase",
+    })
+}
+
+/// Stop a running libkrun guest by name. Stub for the Sprint 48
+/// scaffolding — see [`Error::NotYetWired`].
+pub fn stop(name: &str) -> Result<(), Error> {
+    if !is_available() {
+        return Err(Error::NotInstalled {
+            install_hint: install_hint(),
+        });
+    }
+    let _ = name;
+    Err(Error::NotYetWired {
+        tracking: "plan 53 §\"Plan E\" / Sprint 48 spike phase",
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn install_paths_are_platform_specific() {
+        let paths = install_paths();
+        #[cfg(target_os = "macos")]
+        assert!(paths.iter().any(|p| p.ends_with(".dylib")));
+        #[cfg(target_os = "linux")]
+        assert!(paths.iter().any(|p| p.ends_with(".so")));
+        #[cfg(target_os = "windows")]
+        assert!(paths.is_empty());
+    }
+
+    #[test]
+    fn install_hint_is_non_empty() {
+        // All platforms produce *some* hint, even Windows ("not supported").
+        assert!(!install_hint().is_empty());
+    }
+
+    #[test]
+    fn krun_context_builds_without_io() {
+        let ctx = KrunContext::new("vm-1", "/path/vmlinux", "/path/rootfs.ext4")
+            .with_resources(2, 512)
+            .add_vsock_port(5252);
+        assert_eq!(ctx.name, "vm-1");
+        assert_eq!(ctx.vcpus, 2);
+        assert_eq!(ctx.ram_mib, 512);
+        assert_eq!(ctx.vsock_ports, vec![5252]);
+    }
+
+    #[test]
+    fn start_errors_when_not_installed_or_not_yet_wired() {
+        let ctx = KrunContext::new("vm", "/k", "/r");
+        let err = start(&ctx).expect_err("scaffolding always errors");
+        // Either "not installed" (most common in CI) or "not yet wired"
+        // (when libkrun *is* installed on the dev's host) — both are
+        // acceptable surfaces for the scaffolding phase.
+        assert!(matches!(
+            err,
+            Error::NotInstalled { .. } | Error::NotYetWired { .. }
+        ));
+    }
+
+    #[test]
+    fn error_display_messages_are_actionable() {
+        let not_installed = Error::NotInstalled {
+            install_hint: "brew install libkrun",
+        };
+        let not_wired = Error::NotYetWired {
+            tracking: "plan 53",
+        };
+        let krun_err = Error::Krun("kvm_create failed".to_string());
+        // Each variant produces a non-empty, distinct message that
+        // names what to do next.
+        assert!(format!("{not_installed}").contains("brew install"));
+        assert!(format!("{not_wired}").contains("plan 53"));
+        assert!(format!("{krun_err}").contains("kvm_create"));
+    }
+}

--- a/crates/mvm-runtime/Cargo.toml
+++ b/crates/mvm-runtime/Cargo.toml
@@ -30,4 +30,5 @@ tera.workspace = true
 toml.workspace = true
 tracing.workspace = true
 mvm-apple-container.workspace = true
+mvm-libkrun.workspace = true
 libc.workspace = true

--- a/crates/mvm-runtime/src/vm/apple_container.rs
+++ b/crates/mvm-runtime/src/vm/apple_container.rs
@@ -26,8 +26,8 @@
 
 use anyhow::Result;
 use mvm_core::vm_backend::{
-    GuestChannelInfo, VmBackend, VmCapabilities, VmId, VmInfo, VmNetworkInfo, VmStartConfig,
-    VmStatus,
+    BackendSecurityProfile, ClaimStatus, GuestChannelInfo, LayerCoverage, VmBackend,
+    VmCapabilities, VmId, VmInfo, VmNetworkInfo, VmStartConfig, VmStatus,
 };
 
 use crate::ui;
@@ -184,6 +184,30 @@ impl VmBackend for AppleContainerBackend {
             port: mvm_apple_container::GUEST_AGENT_PORT,
         })
     }
+
+    fn security_profile(&self) -> BackendSecurityProfile {
+        // Tier 2: hardware isolation via Apple VZ (Hypervisor.framework).
+        // Claim 3 (verified boot via dm-verity) is partial — the W3
+        // pipeline currently targets Firecracker; the VZ-backed rootfs
+        // still boots without the dm-verity initramfs.
+        BackendSecurityProfile {
+            claims: [
+                ClaimStatus::Holds,       // 1 — host-fs isolation via VZ
+                ClaimStatus::Holds,       // 2 — uid-0 protections same as FC
+                ClaimStatus::DoesNotHold, // 3 — verified boot for VZ rootfs not yet wired
+                ClaimStatus::Holds,       // 4 — guest agent has no do_exec in prod
+                ClaimStatus::Holds,       // 5 — vsock framing is fuzzed
+                ClaimStatus::Holds,       // 6 — image hash verification
+                ClaimStatus::Holds,       // 7 — cargo deps audited
+            ],
+            layer_coverage: LayerCoverage::all_layers(),
+            tier: "Tier 2",
+            notes: &[
+                "Hardware isolation via Apple VZ (Containerization.framework).",
+                "Claim 3 (verified boot) is partial — dm-verity for VZ-backed rootfs not yet wired.",
+            ],
+        }
+    }
 }
 
 /// Read persisted port mappings from the VM state directory.
@@ -223,6 +247,18 @@ mod tests {
         assert!(!caps.snapshots);
         assert!(caps.vsock);
         assert!(!caps.tap_networking);
+    }
+
+    #[test]
+    fn test_apple_container_security_profile_tier_2_partial_claim_3() {
+        let backend = AppleContainerBackend;
+        let profile = backend.security_profile();
+        assert_eq!(profile.tier, "Tier 2");
+        // L1-L5 all enforced (VZ provides hardware isolation).
+        assert!(profile.layer_coverage.is_microvm());
+        // Only claim 3 (verified boot) does not hold yet.
+        assert_eq!(profile.dropped_claims(), vec![3]);
+        assert!(profile.na_claims().is_empty());
     }
 
     #[test]

--- a/crates/mvm-runtime/src/vm/apple_container.rs
+++ b/crates/mvm-runtime/src/vm/apple_container.rs
@@ -24,7 +24,7 @@
 //!               └── vminitd (PID 1, gRPC over vsock:1024)
 //! ```
 
-use anyhow::Result;
+use anyhow::{Context, Result};
 use mvm_core::vm_backend::{
     BackendSecurityProfile, ClaimStatus, GuestChannelInfo, LayerCoverage, VmBackend,
     VmCapabilities, VmId, VmInfo, VmNetworkInfo, VmStartConfig, VmStatus,
@@ -85,6 +85,14 @@ impl VmBackend for AppleContainerBackend {
             );
         }
 
+        // Plan 53 Plan D: clone the rootfs to a per-instance path so
+        // each running VM owns its disk image. Apple VZ refuses to
+        // attach the same writable disk to two VMs concurrently; the
+        // clone also keeps templates pristine across multiple instances.
+        // APFS Copy-on-Write makes this O(1) regardless of rootfs size
+        // when source and destination live on the same volume.
+        let effective_rootfs = prepare_instance_rootfs(&config.name, &config.rootfs_path)?;
+
         ui::info(&format!(
             "Starting Apple Container '{}' (cpus={}, mem={}MiB)...",
             config.name, config.cpus, config.memory_mib
@@ -93,7 +101,9 @@ impl VmBackend for AppleContainerBackend {
         mvm_apple_container::start(
             &config.name,
             kernel_path,
-            &config.rootfs_path,
+            effective_rootfs
+                .to_str()
+                .ok_or_else(|| anyhow::anyhow!("instance rootfs path is not valid UTF-8"))?,
             config.cpus,
             config.memory_mib as u64,
         )
@@ -104,8 +114,22 @@ impl VmBackend for AppleContainerBackend {
     }
 
     fn stop(&self, id: &VmId) -> Result<()> {
-        mvm_apple_container::stop(&id.0)
-            .map_err(|e| anyhow::anyhow!("Apple Container stop failed: {e}"))
+        let stop_result = mvm_apple_container::stop(&id.0)
+            .map_err(|e| anyhow::anyhow!("Apple Container stop failed: {e}"));
+        // Best-effort: remove the per-instance rootfs clone (Plan D).
+        // A missing file means stop already cleaned up or the VM never
+        // reached the clone step.
+        if let Ok(path) = instance_rootfs_path(&id.0)
+            && path.exists()
+            && let Err(e) = std::fs::remove_file(&path)
+        {
+            tracing::warn!(
+                path = %path.display(),
+                error = %e,
+                "failed to remove per-instance rootfs clone"
+            );
+        }
+        stop_result
     }
 
     fn stop_all(&self) -> Result<()> {
@@ -210,6 +234,73 @@ impl VmBackend for AppleContainerBackend {
     }
 }
 
+/// Per-instance rootfs path inside `~/.mvm/vms/<vm_name>/`.
+///
+/// Plan 53 Plan D: the rootfs clone (CoW on APFS, byte copy elsewhere)
+/// lives here. Each running Apple Container VM owns its own copy so VZ
+/// can attach it writable without conflicting with sibling instances.
+fn instance_rootfs_path(vm_name: &str) -> Result<std::path::PathBuf> {
+    let home = std::env::var("HOME").unwrap_or_default();
+    if home.is_empty() {
+        anyhow::bail!("HOME is not set; cannot resolve instance rootfs path");
+    }
+    Ok(instance_rootfs_path_at(
+        std::path::Path::new(&home),
+        vm_name,
+    ))
+}
+
+fn instance_rootfs_path_at(base: &std::path::Path, vm_name: &str) -> std::path::PathBuf {
+    base.join(".mvm")
+        .join("vms")
+        .join(vm_name)
+        .join("rootfs.ext4")
+}
+
+/// Materialize the per-instance rootfs for an Apple Container VM and
+/// return its absolute path.
+///
+/// If the source path is already the per-instance path (rare, but
+/// possible for a re-start), this is a no-op. Otherwise, it removes
+/// any stale per-instance file from a prior failed run, then clones
+/// the source into the per-instance location via [`reflink_or_copy`].
+/// The strategy used (Reflink vs Copied) is logged so users can see
+/// when the fast path applied.
+fn prepare_instance_rootfs(vm_name: &str, source_rootfs: &str) -> Result<std::path::PathBuf> {
+    let instance_path = instance_rootfs_path(vm_name)?;
+    prepare_instance_rootfs_inner(&instance_path, source_rootfs)
+}
+
+/// Inner implementation that doesn't read `HOME`. Tests pass a tempdir
+/// here directly so they don't have to mutate process-global env vars.
+fn prepare_instance_rootfs_inner(
+    instance_path: &std::path::Path,
+    source_rootfs: &str,
+) -> Result<std::path::PathBuf> {
+    let source_path = std::path::Path::new(source_rootfs);
+    if source_path == instance_path {
+        // Already the per-instance copy — nothing to clone.
+        return Ok(instance_path.to_path_buf());
+    }
+    if instance_path.exists() {
+        std::fs::remove_file(instance_path).with_context(|| {
+            format!(
+                "removing stale per-instance rootfs at {}",
+                instance_path.display()
+            )
+        })?;
+    }
+    let strategy =
+        crate::vm::template::lifecycle::clone_rootfs_for_instance(source_path, instance_path)?;
+    tracing::info!(
+        ?strategy,
+        source = %source_path.display(),
+        instance = %instance_path.display(),
+        "prepared per-instance rootfs",
+    );
+    Ok(instance_path.to_path_buf())
+}
+
 /// Read persisted port mappings from the VM state directory.
 fn read_vm_ports(vm_name: &str) -> Vec<mvm_core::vm_backend::VmPortMapping> {
     let home = std::env::var("HOME").unwrap_or_default();
@@ -259,6 +350,48 @@ mod tests {
         // Only claim 3 (verified boot) does not hold yet.
         assert_eq!(profile.dropped_claims(), vec![3]);
         assert!(profile.na_claims().is_empty());
+    }
+
+    #[test]
+    fn instance_rootfs_path_at_layout() {
+        let p = instance_rootfs_path_at(std::path::Path::new("/var/home/user"), "vm-1");
+        assert_eq!(
+            p,
+            std::path::PathBuf::from("/var/home/user/.mvm/vms/vm-1/rootfs.ext4")
+        );
+    }
+
+    #[test]
+    fn prepare_instance_rootfs_inner_clones_into_per_instance_path() {
+        let temp = tempfile::tempdir().expect("tempdir");
+        let src = temp.path().join("template.ext4");
+        std::fs::write(&src, b"template payload").expect("write src");
+
+        let instance = temp.path().join(".mvm/vms/test-vm/rootfs.ext4");
+        let path = prepare_instance_rootfs_inner(&instance, src.to_str().unwrap()).expect("clone");
+
+        assert_eq!(path, instance);
+        assert_eq!(std::fs::read(&path).unwrap(), b"template payload");
+
+        // Idempotent stale-cleanup: a second call after writes to the
+        // clone should produce a fresh per-instance copy from the source.
+        std::fs::write(&path, b"prior failed run").expect("write stale");
+        let second_path =
+            prepare_instance_rootfs_inner(&instance, src.to_str().unwrap()).expect("re-clone");
+        assert_eq!(std::fs::read(&second_path).unwrap(), b"template payload");
+    }
+
+    #[test]
+    fn prepare_instance_rootfs_inner_is_noop_when_source_matches_destination() {
+        let temp = tempfile::tempdir().expect("tempdir");
+        let instance = temp.path().join(".mvm/vms/restart/rootfs.ext4");
+        std::fs::create_dir_all(instance.parent().unwrap()).expect("mkdir");
+        std::fs::write(&instance, b"already-instance").expect("seed");
+
+        let p = prepare_instance_rootfs_inner(&instance, instance.to_str().unwrap()).expect("noop");
+        assert_eq!(p, instance);
+        // Source content preserved — no clone, no stale-cleanup.
+        assert_eq!(std::fs::read(&instance).unwrap(), b"already-instance");
     }
 
     #[test]

--- a/crates/mvm-runtime/src/vm/backend.rs
+++ b/crates/mvm-runtime/src/vm/backend.rs
@@ -6,6 +6,7 @@ use mvm_core::vm_backend::{
 
 use super::apple_container::AppleContainerBackend;
 use super::docker::DockerBackend;
+use super::libkrun::LibkrunBackend;
 use super::{firecracker, microvm, microvm_nix};
 use crate::config::{PortMapping, VMS_DIR};
 use crate::shell::run_in_vm_stdout;
@@ -195,6 +196,9 @@ pub enum AnyBackend {
     MicrovmNix(MicrovmNixBackend),
     AppleContainer(AppleContainerBackend),
     Docker(DockerBackend),
+    /// libkrun (plan 53 §"Plan E") — Linux KVM / macOS HVF, including
+    /// macOS Intel where Apple Container is unavailable.
+    Libkrun(LibkrunBackend),
 }
 
 impl AnyBackend {
@@ -216,11 +220,14 @@ impl AnyBackend {
     /// Select backend by hypervisor name.
     ///
     /// Supported: `"firecracker"` (default), `"qemu"` (via microvm.nix),
-    /// `"apple-container"` (macOS 26+). Unknown names fall back to Firecracker.
+    /// `"apple-container"` (macOS 26+), `"libkrun"` (Linux KVM / macOS
+    /// HVF), `"docker"` (Tier 3 fallback). Unknown names fall back to
+    /// Firecracker.
     pub fn from_hypervisor(name: &str) -> Self {
         match name {
             "apple-container" => Self::AppleContainer(AppleContainerBackend),
             "docker" => Self::Docker(DockerBackend),
+            "libkrun" | "krun" => Self::Libkrun(LibkrunBackend),
             "qemu" => Self::MicrovmNix(MicrovmNixBackend),
             _ => Self::Firecracker(FirecrackerBackend),
         }
@@ -229,9 +236,11 @@ impl AnyBackend {
     /// Select the best backend for the current platform.
     ///
     /// Priority:
-    /// 1. Firecracker (if /dev/kvm available — fastest, production-grade)
-    /// 2. Apple Container (macOS 26+ — sub-second dev startup)
-    /// 3. Firecracker via Lima (macOS fallback)
+    /// 1. Firecracker (if /dev/kvm available — fastest, production-grade Tier 1)
+    /// 2. Apple Container (macOS 26+ — sub-second dev startup, Tier 2)
+    /// 3. libkrun (Linux KVM / macOS HVF — Intel Mac path, Tier 2)
+    /// 4. Docker (Tier 3 fallback — banner emitted; not promoted)
+    /// 5. Firecracker via Lima (legacy macOS fallback)
     pub fn auto_select() -> Self {
         let plat = mvm_core::platform::current();
 
@@ -245,12 +254,22 @@ impl AnyBackend {
             return Self::AppleContainer(AppleContainerBackend);
         }
 
-        // 3. Docker available → universal fallback (works on all platforms)
+        // 3. libkrun installed → use it. Critical for macOS Intel and
+        //    macOS <26 where Apple Container is unavailable. Same Tier 2
+        //    posture as Apple Container, but no Lima dependency.
+        if plat.has_libkrun() {
+            return Self::Libkrun(LibkrunBackend);
+        }
+
+        // 4. Docker available → universal Tier 3 fallback. The CLI emits
+        //    a loud, suppressible banner when this path is taken (plan 53
+        //    Plan B). Not preferred; only chosen when no microVM tier is
+        //    available on this host.
         if plat.has_docker() {
             return Self::Docker(DockerBackend);
         }
 
-        // 4. Firecracker via Lima (legacy macOS fallback)
+        // 5. Firecracker via Lima (legacy macOS fallback)
         Self::Firecracker(FirecrackerBackend)
     }
 
@@ -261,6 +280,7 @@ impl AnyBackend {
             Self::MicrovmNix(b) => b,
             Self::AppleContainer(b) => b,
             Self::Docker(b) => b,
+            Self::Libkrun(b) => b,
         }
     }
 
@@ -408,6 +428,26 @@ mod tests {
         let profile = backend.security_profile();
         assert_eq!(profile.tier, "Tier 3");
         assert!(!profile.layer_coverage.is_microvm());
+    }
+
+    #[test]
+    fn test_any_backend_from_hypervisor_libkrun() {
+        // Both `libkrun` and `krun` aliases route to the same backend
+        // — `krun` is the libkrun project's preferred short name and
+        // appears in some user docs.
+        for name in ["libkrun", "krun"] {
+            let backend = AnyBackend::from_hypervisor(name);
+            assert_eq!(backend.name(), "libkrun");
+        }
+    }
+
+    #[test]
+    fn test_any_backend_libkrun_is_tier_2() {
+        let backend = AnyBackend::from_hypervisor("libkrun");
+        let profile = backend.security_profile();
+        assert_eq!(profile.tier, "Tier 2");
+        assert!(profile.layer_coverage.is_microvm());
+        assert_eq!(profile.dropped_claims(), vec![3]);
     }
 
     #[test]

--- a/crates/mvm-runtime/src/vm/backend.rs
+++ b/crates/mvm-runtime/src/vm/backend.rs
@@ -1,5 +1,8 @@
 use anyhow::Result;
-use mvm_core::vm_backend::{VmBackend, VmCapabilities, VmId, VmInfo, VmStartConfig, VmStatus};
+use mvm_core::vm_backend::{
+    BackendSecurityProfile, ClaimStatus, LayerCoverage, VmBackend, VmCapabilities, VmId, VmInfo,
+    VmStartConfig, VmStatus,
+};
 
 use super::apple_container::AppleContainerBackend;
 use super::docker::DockerBackend;
@@ -166,6 +169,21 @@ impl VmBackend for FirecrackerBackend {
     fn install(&self) -> Result<()> {
         firecracker::install()
     }
+
+    fn security_profile(&self) -> BackendSecurityProfile {
+        // Tier 1: full ADR-002. All seven CI-enforced claims hold.
+        // Hardware isolation via KVM; verified boot via dm-verity (W3,
+        // shipped 2026-04-30).
+        BackendSecurityProfile {
+            claims: [ClaimStatus::Holds; 7],
+            layer_coverage: LayerCoverage::all_layers(),
+            tier: "Tier 1",
+            notes: &[
+                "Full ADR-002 — all seven CI-enforced claims hold.",
+                "Hardware isolation via KVM. Verified boot via dm-verity (W3).",
+            ],
+        }
+    }
 }
 
 /// Backend-agnostic dispatch enum.
@@ -310,6 +328,10 @@ impl AnyBackend {
     pub fn install(&self) -> Result<()> {
         self.inner().install()
     }
+
+    pub fn security_profile(&self) -> BackendSecurityProfile {
+        self.inner().security_profile()
+    }
 }
 
 #[cfg(test)]
@@ -333,6 +355,22 @@ mod tests {
     }
 
     #[test]
+    fn test_firecracker_security_profile_tier_1_holds_all_claims() {
+        let backend = FirecrackerBackend;
+        let profile = backend.security_profile();
+        assert_eq!(profile.tier, "Tier 1");
+        assert!(profile.layer_coverage.is_microvm());
+        assert!(profile.dropped_claims().is_empty());
+        assert!(profile.na_claims().is_empty());
+        assert!(
+            profile
+                .claims
+                .iter()
+                .all(|s| matches!(s, ClaimStatus::Holds))
+        );
+    }
+
+    #[test]
     fn test_microvm_nix_backend_name() {
         let backend = MicrovmNixBackend;
         assert_eq!(backend.name(), "microvm-nix");
@@ -346,6 +384,30 @@ mod tests {
         assert!(!caps.snapshots);
         assert!(caps.vsock);
         assert!(caps.tap_networking);
+    }
+
+    #[test]
+    fn test_microvm_nix_security_profile_tier_2_partial_claim_3() {
+        let backend = MicrovmNixBackend;
+        let profile = backend.security_profile();
+        assert_eq!(profile.tier, "Tier 2");
+        assert!(profile.layer_coverage.is_microvm());
+        assert_eq!(profile.dropped_claims(), vec![3]);
+    }
+
+    #[test]
+    fn test_any_backend_dispatches_security_profile_for_firecracker() {
+        let backend = AnyBackend::from_hypervisor("firecracker");
+        let profile = backend.security_profile();
+        assert_eq!(profile.tier, "Tier 1");
+    }
+
+    #[test]
+    fn test_any_backend_dispatches_security_profile_for_docker() {
+        let backend = AnyBackend::from_hypervisor("docker");
+        let profile = backend.security_profile();
+        assert_eq!(profile.tier, "Tier 3");
+        assert!(!profile.layer_coverage.is_microvm());
     }
 
     #[test]

--- a/crates/mvm-runtime/src/vm/cow.rs
+++ b/crates/mvm-runtime/src/vm/cow.rs
@@ -1,0 +1,247 @@
+//! Reflink (copy-on-write) file cloning primitives.
+//!
+//! Plan 53 / Sprint 47 / Plan D: APFS Copy-on-Write for Apple Container
+//! templates. Cloning a 1 GiB ext4 rootfs via `clonefile(2)` on macOS
+//! takes ~constant time regardless of file size, since APFS only writes
+//! new metadata and shares the underlying blocks until either side writes.
+//! The same shape works on Linux via the `FICLONE` ioctl on btrfs/xfs/
+//! overlayfs — those filesystems also have block-level CoW. ext4 returns
+//! `EOPNOTSUPP` (the Linux-on-Lima default), so the caller falls back to
+//! a regular byte copy.
+//!
+//! See ADR-002 §"Trust layers" for the security context (the cloned ext4
+//! is the L3 rootfs; per-instance writes diverge into the clone's blocks
+//! and never touch the template) and plan 53 §"Plan D" for the design.
+
+use std::io;
+use std::path::Path;
+
+/// What strategy [`reflink_or_copy`] used to materialize the destination.
+///
+/// `Reflink` is the fast path (O(1) metadata operation, blocks shared
+/// until written). `Copied` is the byte-copy fallback that fires when
+/// the filesystem doesn't support reflinks (ext4 without explicit
+/// support, NTFS on Windows, network mounts, cross-volume copies on
+/// APFS, etc.).
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum CloneStrategy {
+    /// Filesystem-level CoW clone (`clonefile(2)` on macOS,
+    /// `FICLONE` ioctl on Linux btrfs/xfs).
+    Reflink,
+    /// Byte-by-byte copy (slow path, no CoW).
+    Copied,
+}
+
+/// Reflink-clone `src` to `dst`. Errors with `EOPNOTSUPP` if the
+/// underlying filesystem does not support reflinks.
+///
+/// Use [`reflink_or_copy`] if you want to fall back to a regular copy
+/// instead of erroring.
+///
+/// On macOS: `libc::clonefile(src, dst, 0)`.
+/// On Linux: `ioctl(dst_fd, FICLONE, src_fd)` after creating `dst`.
+/// On other platforms: always returns `EOPNOTSUPP`.
+pub fn reflink_or_err(src: &Path, dst: &Path) -> io::Result<()> {
+    #[cfg(target_os = "macos")]
+    {
+        macos::clonefile_path(src, dst)
+    }
+    #[cfg(target_os = "linux")]
+    {
+        linux::ficlone(src, dst)
+    }
+    #[cfg(not(any(target_os = "macos", target_os = "linux")))]
+    {
+        let _ = (src, dst);
+        Err(io::Error::from_raw_os_error(libc_eopnotsupp()))
+    }
+}
+
+/// Reflink-clone `src` to `dst`, falling back to a byte copy if the
+/// filesystem doesn't support reflinks. Returns the strategy used so
+/// callers can log the fast/slow path for performance analysis.
+///
+/// Always succeeds modulo I/O errors (missing source, permission denied,
+/// disk full, etc.).
+pub fn reflink_or_copy(src: &Path, dst: &Path) -> io::Result<CloneStrategy> {
+    match reflink_or_err(src, dst) {
+        Ok(()) => Ok(CloneStrategy::Reflink),
+        Err(e) if is_unsupported(&e) => {
+            std::fs::copy(src, dst)?;
+            Ok(CloneStrategy::Copied)
+        }
+        Err(e) => Err(e),
+    }
+}
+
+fn is_unsupported(e: &io::Error) -> bool {
+    // ENOTSUP and EOPNOTSUPP are the same value on macOS/Linux but
+    // we check both names defensively. EXDEV indicates cross-device
+    // (cross-volume) — APFS CoW requires same volume, btrfs/xfs FICLONE
+    // requires same filesystem instance.
+    matches!(
+        e.raw_os_error(),
+        Some(libc::ENOTSUP) | Some(libc::EXDEV) | Some(libc::EINVAL)
+    )
+}
+
+#[cfg(target_os = "macos")]
+mod macos {
+    use std::ffi::CString;
+    use std::io;
+    use std::os::unix::ffi::OsStrExt;
+    use std::path::Path;
+
+    // `clonefile(const char *src, const char *dst, uint32_t flags)` from
+    // `<sys/clonefile.h>`. Available since macOS 10.12.
+    unsafe extern "C" {
+        fn clonefile(src: *const libc::c_char, dst: *const libc::c_char, flags: u32)
+        -> libc::c_int;
+    }
+
+    pub(super) fn clonefile_path(src: &Path, dst: &Path) -> io::Result<()> {
+        let src_c = CString::new(src.as_os_str().as_bytes())
+            .map_err(|e| io::Error::new(io::ErrorKind::InvalidInput, e))?;
+        let dst_c = CString::new(dst.as_os_str().as_bytes())
+            .map_err(|e| io::Error::new(io::ErrorKind::InvalidInput, e))?;
+        // SAFETY: both pointers come from CStrings that outlive the call.
+        // Flags = 0 means default (clone metadata + data links, no
+        // symlink follow).
+        let rc = unsafe { clonefile(src_c.as_ptr(), dst_c.as_ptr(), 0) };
+        if rc == 0 {
+            Ok(())
+        } else {
+            Err(io::Error::last_os_error())
+        }
+    }
+}
+
+#[cfg(target_os = "linux")]
+mod linux {
+    use std::fs::OpenOptions;
+    use std::io;
+    use std::os::fd::AsRawFd;
+    use std::path::Path;
+
+    // ioctl(dst, FICLONE, src) — see <linux/fs.h>. Encoded the same way
+    // across architectures: _IOW('f', 9, int).
+    const FICLONE: libc::c_ulong = 0x4020_9409;
+
+    pub(super) fn ficlone(src: &Path, dst: &Path) -> io::Result<()> {
+        let src_fd = OpenOptions::new().read(true).open(src)?;
+        let dst_fd = OpenOptions::new().write(true).create_new(true).open(dst)?;
+        // SAFETY: both file descriptors are owned and valid for the
+        // duration of the ioctl. FICLONE atomically clones extents from
+        // src into dst (which must be empty / freshly created).
+        let rc = unsafe { libc::ioctl(dst_fd.as_raw_fd(), FICLONE, src_fd.as_raw_fd()) };
+        if rc == 0 {
+            Ok(())
+        } else {
+            // Clean up the empty destination so the caller's copy
+            // fallback can recreate it without EEXIST.
+            let err = io::Error::last_os_error();
+            drop(dst_fd);
+            let _ = std::fs::remove_file(dst);
+            Err(err)
+        }
+    }
+}
+
+#[cfg(not(any(target_os = "macos", target_os = "linux")))]
+fn libc_eopnotsupp() -> i32 {
+    libc::ENOTSUP
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn unsupported_errors_classify_correctly() {
+        let enotsup = io::Error::from_raw_os_error(libc::ENOTSUP);
+        let exdev = io::Error::from_raw_os_error(libc::EXDEV);
+        let einval = io::Error::from_raw_os_error(libc::EINVAL);
+        let other = io::Error::from_raw_os_error(libc::EACCES);
+        assert!(is_unsupported(&enotsup));
+        assert!(is_unsupported(&exdev));
+        assert!(is_unsupported(&einval));
+        assert!(!is_unsupported(&other));
+    }
+
+    /// On macOS with an APFS-backed `TMPDIR` (the default), `clonefile`
+    /// always works. The test asserts the fast path was taken and that
+    /// writes to the clone don't tamper the source.
+    #[cfg(target_os = "macos")]
+    #[test]
+    fn macos_clonefile_creates_independent_copy() {
+        let dir = tempfile::tempdir().expect("create tempdir");
+        let src_path = dir.path().join("src.bin");
+        let dst_path = dir.path().join("dst.bin");
+        // 1 MiB of arbitrary bytes — small enough to keep the test fast,
+        // large enough that "block-level CoW" is the only way to hit the
+        // expected timing on real APFS volumes.
+        let payload: Vec<u8> = (0..1_048_576).map(|i| (i % 251) as u8).collect();
+        std::fs::write(&src_path, &payload).expect("write src");
+
+        let strategy =
+            reflink_or_copy(&src_path, &dst_path).expect("reflink_or_copy on macOS APFS tempdir");
+        assert_eq!(strategy, CloneStrategy::Reflink);
+
+        // The clone has the same contents as the source.
+        let cloned = std::fs::read(&dst_path).expect("read clone");
+        assert_eq!(cloned, payload, "clone must byte-equal source");
+
+        // Writing to the clone does not mutate the source. APFS CoW
+        // diverges blocks at the first write to either side.
+        std::fs::write(&dst_path, b"clone-only payload").expect("write clone");
+        let src_after = std::fs::read(&src_path).expect("re-read src");
+        assert_eq!(
+            src_after, payload,
+            "writing to clone must not affect source"
+        );
+    }
+
+    /// `reflink_or_err` errors `EEXIST` if the destination already
+    /// exists — both on macOS (`clonefile` rejects existing dst) and on
+    /// Linux (we call `create_new(true)`). The test exercises the
+    /// real-OS surface, not just the helper logic.
+    #[test]
+    fn reflink_or_err_refuses_existing_destination() {
+        let dir = tempfile::tempdir().expect("create tempdir");
+        let src_path = dir.path().join("src.bin");
+        let dst_path = dir.path().join("dst.bin");
+        std::fs::write(&src_path, b"src content").expect("write src");
+        std::fs::write(&dst_path, b"existing").expect("write dst");
+
+        let result = reflink_or_err(&src_path, &dst_path);
+        // Either AlreadyExists (Linux create_new) or "File exists"
+        // wrapped from clonefile's EEXIST. Both are surfacings of the
+        // same invariant: never silently overwrite.
+        assert!(result.is_err());
+    }
+
+    /// `reflink_or_copy` falls back to a byte copy when the source path
+    /// can be read but the FS doesn't support reflinks. We can't easily
+    /// force EOPNOTSUPP on macOS APFS (it always works), so this test
+    /// exercises the *Copied* path on Linux ext4 (where `FICLONE`
+    /// returns EOPNOTSUPP) and is skipped elsewhere.
+    #[cfg(target_os = "linux")]
+    #[test]
+    fn linux_falls_back_to_copy_on_ext4() {
+        let dir = tempfile::tempdir().expect("create tempdir");
+        // /tmp on Linux CI runners is usually ext4 or tmpfs. tmpfs
+        // does support FICLONE (Linux 5.10+); ext4 doesn't unless
+        // mounted with explicit reflink support. We accept either
+        // outcome and just assert the helper succeeded.
+        let src_path = dir.path().join("src.bin");
+        let dst_path = dir.path().join("dst.bin");
+        std::fs::write(&src_path, b"hello").expect("write src");
+        let strategy = reflink_or_copy(&src_path, &dst_path).expect("clone or copy");
+        assert!(matches!(
+            strategy,
+            CloneStrategy::Reflink | CloneStrategy::Copied
+        ));
+        let read = std::fs::read(&dst_path).expect("read dst");
+        assert_eq!(read, b"hello");
+    }
+}

--- a/crates/mvm-runtime/src/vm/docker.rs
+++ b/crates/mvm-runtime/src/vm/docker.rs
@@ -10,8 +10,8 @@
 
 use anyhow::Result;
 use mvm_core::vm_backend::{
-    GuestChannelInfo, VmBackend, VmCapabilities, VmId, VmInfo, VmNetworkInfo, VmStartConfig,
-    VmStatus,
+    BackendSecurityProfile, ClaimStatus, GuestChannelInfo, LayerCoverage, VmBackend,
+    VmCapabilities, VmId, VmInfo, VmNetworkInfo, VmStartConfig, VmStatus,
 };
 
 use crate::ui;
@@ -348,6 +348,38 @@ impl VmBackend for DockerBackend {
             path: std::path::PathBuf::from(format!("{home}/.mvm/vms/{}/agent/agent.sock", id.0)),
         })
     }
+
+    fn security_profile(&self) -> BackendSecurityProfile {
+        // Tier 3: container isolation, not a microVM. L1-L3 collapse to
+        // the host kernel. Claims 1, 2, 3 do NOT hold. Claims 4, 6, 7
+        // still hold (guest agent has no do_exec; image hash is verified;
+        // cargo deps are audited). Claim 5 (vsock framing) does not apply
+        // — this backend uses a unix socket, not vsock.
+        BackendSecurityProfile {
+            claims: [
+                ClaimStatus::DoesNotHold, // 1 — shared host kernel; no FS isolation guarantee
+                ClaimStatus::DoesNotHold, // 2 — container escapes to uid 0 are real (Leaky Vessels et al.)
+                ClaimStatus::DoesNotHold, // 3 — no microVM rootfs, no dm-verity
+                ClaimStatus::Holds,       // 4 — guest agent built without do_exec for prod
+                ClaimStatus::DoesNotApply, // 5 — unix socket transport, not vsock
+                ClaimStatus::Holds,       // 6 — image hash verified
+                ClaimStatus::Holds,       // 7 — cargo deps audited
+            ],
+            layer_coverage: LayerCoverage {
+                l1_host_hypervisor: false, // shared host kernel, no hypervisor
+                l2_vmm: false,             // container runtime is L2 = host kernel
+                l3_guest_kernel: false,    // shared with host
+                l4_guest_agent: true,
+                l5_workload: true,
+            },
+            tier: "Tier 3",
+            notes: &[
+                "Container isolation, not hardware-isolated microVM.",
+                "L1-L3 collapse to the host kernel.",
+                "Use only for non-security-sensitive workloads. See ADR-002 §\"Per-backend tier matrix\".",
+            ],
+        }
+    }
 }
 
 #[cfg(test)]
@@ -378,5 +410,22 @@ mod tests {
     #[test]
     fn test_image_tag() {
         assert_eq!(image_tag("hello"), "mvm-hello:latest");
+    }
+
+    #[test]
+    fn test_docker_security_profile_tier_3_drops_l1_through_l3() {
+        let backend = DockerBackend;
+        let profile = backend.security_profile();
+        assert_eq!(profile.tier, "Tier 3");
+        assert!(!profile.layer_coverage.is_microvm());
+        assert!(!profile.layer_coverage.l1_host_hypervisor);
+        assert!(!profile.layer_coverage.l2_vmm);
+        assert!(!profile.layer_coverage.l3_guest_kernel);
+        assert!(profile.layer_coverage.l4_guest_agent);
+        assert!(profile.layer_coverage.l5_workload);
+        // Claims 1, 2, 3 do not hold; claim 5 (vsock fuzzing) does not apply
+        // (Docker uses a unix socket); claims 4, 6, 7 hold.
+        assert_eq!(profile.dropped_claims(), vec![1, 2, 3]);
+        assert_eq!(profile.na_claims(), vec![5]);
     }
 }

--- a/crates/mvm-runtime/src/vm/libkrun.rs
+++ b/crates/mvm-runtime/src/vm/libkrun.rs
@@ -1,0 +1,227 @@
+//! libkrun backend for mvm.
+//!
+//! Plan 53 §"Plan E" / Sprint 48: scaffolding for a Tier 2 microVM
+//! backend that runs on Linux KVM, macOS Apple Silicon, and macOS Intel
+//! (the only VMM in mvm's tree that covers all three). The lifecycle
+//! delegates to [`mvm_libkrun`], which in turn wraps the Red Hat libkrun
+//! C library.
+//!
+//! # Status
+//!
+//! This file provides the final `VmBackend` shape: [`LibkrunBackend`]
+//! declares its capabilities, security profile, and dispatch through
+//! [`AnyBackend`](super::backend::AnyBackend). `start()` and `stop()`
+//! delegate to `mvm_libkrun`, which today returns a "not yet wired"
+//! error pointing at the Plan E spike phase. Once the spike confirms
+//! kernel + vsock + entitlement compatibility, the lifecycle will be
+//! real with no caller-side changes.
+
+use anyhow::Result;
+use mvm_core::vm_backend::{
+    BackendSecurityProfile, ClaimStatus, GuestChannelInfo, LayerCoverage, VmBackend,
+    VmCapabilities, VmId, VmInfo, VmStartConfig, VmStatus,
+};
+
+use crate::ui;
+
+/// libkrun backend (Linux KVM / macOS Hypervisor.framework).
+pub struct LibkrunBackend;
+
+impl VmBackend for LibkrunBackend {
+    fn name(&self) -> &str {
+        "libkrun"
+    }
+
+    fn capabilities(&self) -> VmCapabilities {
+        // libkrun does not support memory snapshots (same trade as
+        // Apple Container) — vsock and TAP are available; pause/resume
+        // is theoretically possible but not exposed by libkrun's public
+        // C API today.
+        VmCapabilities {
+            pause_resume: false,
+            snapshots: false,
+            vsock: true,
+            tap_networking: false,
+        }
+    }
+
+    fn start(&self, config: &VmStartConfig) -> Result<VmId> {
+        if !mvm_libkrun::is_available() {
+            anyhow::bail!(
+                "libkrun is not installed on this host.\n  {}",
+                mvm_libkrun::install_hint()
+            );
+        }
+
+        let kernel = config
+            .kernel_path
+            .as_deref()
+            .ok_or_else(|| anyhow::anyhow!("libkrun backend requires a kernel path"))?;
+
+        let ctx = mvm_libkrun::KrunContext::new(&config.name, kernel, &config.rootfs_path)
+            .with_resources(
+                u8::try_from(config.cpus.clamp(1, u32::from(u8::MAX))).unwrap_or(u8::MAX),
+                config.memory_mib,
+            )
+            .add_vsock_port(mvm_guest::vsock::GUEST_AGENT_PORT);
+
+        ui::info(&format!(
+            "Starting libkrun VM '{}' (cpus={}, mem={}MiB)...",
+            config.name, ctx.vcpus, ctx.ram_mib
+        ));
+
+        mvm_libkrun::start(&ctx).map_err(|e| anyhow::anyhow!("libkrun start: {e}"))?;
+        ui::success(&format!("libkrun VM '{}' started.", config.name));
+        Ok(VmId(config.name.clone()))
+    }
+
+    fn stop(&self, id: &VmId) -> Result<()> {
+        mvm_libkrun::stop(&id.0).map_err(|e| anyhow::anyhow!("libkrun stop: {e}"))
+    }
+
+    fn stop_all(&self) -> Result<()> {
+        // Until the Plan E spike lands a real registry of running
+        // libkrun VMs, stop_all is a no-op. Real implementation tracks
+        // VMs in `~/.mvm/vms/<name>/libkrun.pid` (parallel to
+        // Firecracker's pidfile convention).
+        Ok(())
+    }
+
+    fn status(&self, _id: &VmId) -> Result<VmStatus> {
+        // No real lifecycle yet — assume stopped.
+        Ok(VmStatus::Stopped)
+    }
+
+    fn list(&self) -> Result<Vec<VmInfo>> {
+        Ok(Vec::new())
+    }
+
+    fn logs(&self, id: &VmId, _lines: u32, _hypervisor: bool) -> Result<String> {
+        anyhow::bail!("libkrun logs not yet implemented for VM '{}'", id.0)
+    }
+
+    fn is_available(&self) -> Result<bool> {
+        Ok(mvm_libkrun::is_available())
+    }
+
+    fn install(&self) -> Result<()> {
+        ui::info(&format!(
+            "libkrun must be installed via the host's package manager.\n  {}",
+            mvm_libkrun::install_hint()
+        ));
+        Ok(())
+    }
+
+    fn guest_channel_info(&self, _id: &VmId) -> Result<GuestChannelInfo> {
+        // libkrun exposes vsock as a host-side abstract socket; the
+        // guest agent listens on the shared `GUEST_AGENT_PORT` port,
+        // identical to Firecracker and Apple Container, so callers can
+        // share the same vsock client implementation across backends.
+        Ok(GuestChannelInfo::Vsock {
+            cid: 3, // standard guest CID
+            port: mvm_guest::vsock::GUEST_AGENT_PORT,
+        })
+    }
+
+    fn security_profile(&self) -> BackendSecurityProfile {
+        // Tier 2: hardware isolation via KVM (Linux) or Hypervisor.framework
+        // (macOS). Comparable VMM TCB to Firecracker — libkrun is rust-vmm
+        // based, ~80K LOC, no Firecracker-excluded features (so it passes
+        // the plan 53 §"fork test"). Claim 3 (verified boot) is partial
+        // because the W3 dm-verity pipeline currently targets Firecracker;
+        // libkrun support is a follow-up.
+        BackendSecurityProfile {
+            claims: [
+                ClaimStatus::Holds,       // 1 — host-fs isolation via KVM/HVF
+                ClaimStatus::Holds,       // 2 — uid-0 protections same as FC
+                ClaimStatus::DoesNotHold, // 3 — verified boot for libkrun rootfs not yet wired
+                ClaimStatus::Holds,       // 4 — guest agent has no do_exec in prod
+                ClaimStatus::Holds,       // 5 — vsock framing is fuzzed
+                ClaimStatus::Holds,       // 6 — image hash verification
+                ClaimStatus::Holds,       // 7 — cargo deps audited
+            ],
+            layer_coverage: LayerCoverage::all_layers(),
+            tier: "Tier 2",
+            notes: &[
+                "Hardware isolation via KVM (Linux) or Hypervisor.framework (macOS).",
+                "Comparable VMM TCB to Firecracker; passes plan 53 §\"fork test\".",
+                "Claim 3 (verified boot) is partial — dm-verity pipeline targets Firecracker today.",
+                "Runs on macOS Intel where Apple Container is unavailable.",
+            ],
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn libkrun_backend_name() {
+        assert_eq!(LibkrunBackend.name(), "libkrun");
+    }
+
+    #[test]
+    fn libkrun_capabilities() {
+        let caps = LibkrunBackend.capabilities();
+        assert!(caps.vsock);
+        assert!(!caps.snapshots);
+        assert!(!caps.pause_resume);
+        assert!(!caps.tap_networking);
+    }
+
+    #[test]
+    fn libkrun_security_profile_is_tier_2_with_partial_claim_3() {
+        let profile = LibkrunBackend.security_profile();
+        assert_eq!(profile.tier, "Tier 2");
+        assert!(profile.layer_coverage.is_microvm());
+        // Claim 3 (verified boot) is the only partial claim; everything
+        // else holds because libkrun matches Firecracker's L2 properties.
+        assert_eq!(profile.dropped_claims(), vec![3]);
+        assert!(profile.na_claims().is_empty());
+    }
+
+    #[test]
+    fn libkrun_install_message_is_actionable() {
+        // The install() method is informational on every host — it shells
+        // out to ui::info instead of attempting to install. The check is
+        // just that we can call it without panicking; the actual hint
+        // copy lives in mvm_libkrun::install_hint().
+        LibkrunBackend.install().expect("install hint never errors");
+        let hint = mvm_libkrun::install_hint();
+        assert!(!hint.is_empty());
+    }
+
+    #[test]
+    fn libkrun_start_errors_when_kernel_path_missing() {
+        let config = VmStartConfig {
+            name: "libkrun-test".to_string(),
+            rootfs_path: "/tmp/rootfs.ext4".to_string(),
+            ..Default::default()
+        };
+        // No kernel_path set → start should fail with a precise message
+        // before attempting to call into mvm_libkrun.
+        let err = LibkrunBackend
+            .start(&config)
+            .expect_err("expected failure without kernel_path");
+        let msg = err.to_string();
+        assert!(
+            msg.contains("kernel path") || msg.contains("not installed"),
+            "unexpected error message: {msg}"
+        );
+    }
+
+    #[test]
+    fn libkrun_status_returns_stopped_in_scaffolding() {
+        let status = LibkrunBackend
+            .status(&VmId("any-vm".to_string()))
+            .expect("status should not error");
+        assert_eq!(status, VmStatus::Stopped);
+    }
+
+    #[test]
+    fn libkrun_list_returns_empty_in_scaffolding() {
+        let vms = LibkrunBackend.list().expect("list should not error");
+        assert!(vms.is_empty());
+    }
+}

--- a/crates/mvm-runtime/src/vm/microvm_nix.rs
+++ b/crates/mvm-runtime/src/vm/microvm_nix.rs
@@ -1,5 +1,8 @@
 use anyhow::Result;
-use mvm_core::vm_backend::{VmBackend, VmCapabilities, VmId, VmInfo, VmStartConfig, VmStatus};
+use mvm_core::vm_backend::{
+    BackendSecurityProfile, ClaimStatus, LayerCoverage, VmBackend, VmCapabilities, VmId, VmInfo,
+    VmStartConfig, VmStatus,
+};
 
 use crate::config::VMS_DIR;
 use crate::shell::{run_in_vm, run_in_vm_stdout, run_in_vm_visible};
@@ -141,6 +144,31 @@ impl VmBackend for MicrovmNixBackend {
         // Nix must already be installed; runner scripts are built via nix build
         ui::info("microvm.nix backends require Nix. Use 'mvmctl setup' to install.");
         Ok(())
+    }
+
+    fn security_profile(&self) -> BackendSecurityProfile {
+        // Tier 2: QEMU-based, KVM-backed. The QEMU device model is much
+        // larger than Firecracker's, so the L2 audit cost is higher.
+        // Claim 3 (verified boot) is partial — the W3 dm-verity pipeline
+        // currently targets Firecracker only.
+        BackendSecurityProfile {
+            claims: [
+                ClaimStatus::Holds,       // 1
+                ClaimStatus::Holds,       // 2
+                ClaimStatus::DoesNotHold, // 3 — W3 pipeline targets Firecracker
+                ClaimStatus::Holds,       // 4
+                ClaimStatus::Holds,       // 5
+                ClaimStatus::Holds,       // 6
+                ClaimStatus::Holds,       // 7
+            ],
+            layer_coverage: LayerCoverage::all_layers(),
+            tier: "Tier 2",
+            notes: &[
+                "QEMU-based via microvm.nix; KVM-backed.",
+                "L2 audit cost higher than Firecracker due to QEMU's larger device model.",
+                "Claim 3 (verified boot) is partial — W3 pipeline targets Firecracker today.",
+            ],
+        }
     }
 }
 

--- a/crates/mvm-runtime/src/vm/mod.rs
+++ b/crates/mvm-runtime/src/vm/mod.rs
@@ -7,6 +7,7 @@ pub mod egress_proxy;
 pub mod firecracker;
 pub mod image;
 pub mod instance_snapshot;
+pub mod libkrun;
 pub mod lima;
 pub mod lima_state;
 pub mod microvm;

--- a/crates/mvm-runtime/src/vm/mod.rs
+++ b/crates/mvm-runtime/src/vm/mod.rs
@@ -1,6 +1,7 @@
 // Dev mode
 pub mod apple_container;
 pub mod backend;
+pub mod cow;
 pub mod docker;
 pub mod egress_proxy;
 pub mod firecracker;

--- a/crates/mvm-runtime/src/vm/template/lifecycle.rs
+++ b/crates/mvm-runtime/src/vm/template/lifecycle.rs
@@ -1,3 +1,4 @@
+use std::path::Path;
 use std::time::{Duration, Instant};
 
 use anyhow::{Context, Result, anyhow};
@@ -10,11 +11,41 @@ use tracing::{instrument, warn};
 
 use crate::shell;
 use crate::ui;
+use crate::vm::cow::{CloneStrategy, reflink_or_copy};
 use mvm_core::pool::ArtifactPaths;
 use mvm_core::template::{TemplateRevision, template_current_symlink};
 use mvm_core::time::utc_now;
 
 use super::registry::TemplateRegistry;
+
+/// Reflink-clone a rootfs file for per-instance use.
+///
+/// Plan 53 Plan D: when starting a VM from a template (or any time
+/// concurrent instances need their own writable rootfs), call this
+/// instead of pointing the hypervisor at the source directly. The
+/// clone shares blocks with the source until either side writes, so
+/// on APFS / btrfs / xfs the operation is O(1) wall-clock regardless
+/// of rootfs size. On filesystems without reflink support (ext4 in
+/// the default Lima VM, NTFS, etc.) it falls back to a byte copy.
+///
+/// `src` must exist; `dst` must not. The destination's parent
+/// directory is created if it doesn't already exist.
+///
+/// Apple VZ and Firecracker each expect a running VM to own its disk
+/// image — sharing a rootfs path between two concurrent VMs makes
+/// the second start fail. This helper is the seam where that
+/// per-instance ownership is created.
+#[instrument(skip_all, fields(src = %src.display(), dst = %dst.display()))]
+pub fn clone_rootfs_for_instance(src: &Path, dst: &Path) -> Result<CloneStrategy> {
+    if let Some(parent) = dst.parent() {
+        std::fs::create_dir_all(parent)
+            .with_context(|| format!("creating parent directory for {}", dst.display()))?;
+    }
+    let strategy = reflink_or_copy(src, dst)
+        .with_context(|| format!("cloning rootfs {} -> {}", src.display(), dst.display()))?;
+    tracing::debug!(?strategy, "rootfs clone complete");
+    Ok(strategy)
+}
 
 /// Run a shell command in the VM and check its exit code.
 /// Returns an error with stderr context if the command fails.
@@ -2113,5 +2144,37 @@ mod tests {
         };
         let b = a.clone();
         assert_eq!(a, b);
+    }
+
+    #[test]
+    fn clone_rootfs_creates_independent_per_instance_copy() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let src = dir.path().join("template.ext4");
+        let dst = dir.path().join("vms/instance-1/rootfs.ext4");
+        std::fs::write(&src, b"template payload").expect("write src");
+
+        // Parent of dst doesn't exist yet — helper must create it.
+        let strategy = clone_rootfs_for_instance(&src, &dst).expect("clone");
+        assert!(matches!(
+            strategy,
+            CloneStrategy::Reflink | CloneStrategy::Copied
+        ));
+        assert_eq!(std::fs::read(&dst).unwrap(), b"template payload");
+
+        // Writing to the per-instance copy must not mutate the template.
+        std::fs::write(&dst, b"instance-only writes").expect("write dst");
+        assert_eq!(std::fs::read(&src).unwrap(), b"template payload");
+    }
+
+    #[test]
+    fn clone_rootfs_refuses_to_overwrite_existing_destination() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let src = dir.path().join("template.ext4");
+        let dst = dir.path().join("instance.ext4");
+        std::fs::write(&src, b"src").expect("write src");
+        std::fs::write(&dst, b"existing").expect("write dst");
+        // Existing destination must error — reflink_or_copy refuses
+        // to overwrite to keep template/instance state honest.
+        assert!(clone_rootfs_for_instance(&src, &dst).is_err());
     }
 }

--- a/installer/winget/Mvm.Mvmctl.installer.yaml
+++ b/installer/winget/Mvm.Mvmctl.installer.yaml
@@ -1,0 +1,21 @@
+# Plan 53 / Sprint 48 / Plan I.3.
+# Template — version + URL + SHA256 are stamped by `xtask release` per
+# release. Never commit a hand-edited copy with a real SHA — the value
+# below is a placeholder that will fail manifest validation, by design.
+
+PackageIdentifier: Mvm.Mvmctl
+PackageVersion: 0.13.0
+InstallerType: zip
+NestedInstallerType: portable
+NestedInstallerFiles:
+  - RelativeFilePath: mvmctl.exe
+    PortableCommandAlias: mvmctl
+Installers:
+  - Architecture: x64
+    InstallerUrl: https://github.com/auser/mvm/releases/download/v0.13.0/mvmctl-x86_64-pc-windows-msvc.zip
+    InstallerSha256: 0000000000000000000000000000000000000000000000000000000000000000
+  - Architecture: arm64
+    InstallerUrl: https://github.com/auser/mvm/releases/download/v0.13.0/mvmctl-aarch64-pc-windows-msvc.zip
+    InstallerSha256: 0000000000000000000000000000000000000000000000000000000000000000
+ManifestType: installer
+ManifestVersion: 1.6.0

--- a/installer/winget/Mvm.Mvmctl.locale.en-US.yaml
+++ b/installer/winget/Mvm.Mvmctl.locale.en-US.yaml
@@ -1,0 +1,27 @@
+PackageIdentifier: Mvm.Mvmctl
+PackageVersion: 0.13.0
+PackageLocale: en-US
+Publisher: Tinylabs
+PublisherUrl: https://github.com/auser/mvm
+PublisherSupportUrl: https://github.com/auser/mvm/issues
+PackageName: mvmctl
+PackageUrl: https://github.com/auser/mvm
+License: Apache-2.0
+LicenseUrl: https://github.com/auser/mvm/blob/main/LICENSE
+ShortDescription: Build and run Firecracker microVMs from Nix flakes — Linux, macOS, and WSL2.
+Description: |-
+  mvmctl is a Rust CLI for building and running hardware-isolated microVMs
+  via Firecracker (Linux + KVM), Apple Container (macOS 26+ Apple Silicon),
+  or libkrun (Linux KVM / macOS HVF). On Windows, the supported path is
+  WSL2 — see https://github.com/auser/mvm/blob/main/public/src/content/docs/install/windows.md
+  for the WSL2 quickstart.
+Tags:
+  - microvm
+  - firecracker
+  - rust
+  - virtualization
+  - sandbox
+  - vmm
+ReleaseNotesUrl: https://github.com/auser/mvm/releases/tag/v0.13.0
+ManifestType: defaultLocale
+ManifestVersion: 1.6.0

--- a/installer/winget/Mvm.Mvmctl.yaml
+++ b/installer/winget/Mvm.Mvmctl.yaml
@@ -1,0 +1,5 @@
+PackageIdentifier: Mvm.Mvmctl
+PackageVersion: 0.13.0
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.6.0

--- a/installer/winget/README.md
+++ b/installer/winget/README.md
@@ -1,0 +1,33 @@
+# Windows winget manifest for mvm
+
+Plan 53 / Sprint 48 / Plan I.3.
+
+## Status
+
+The three manifest files in this directory (`Mvm.Mvmctl.installer.yaml`,
+`Mvm.Mvmctl.locale.en-US.yaml`, `Mvm.Mvmctl.yaml`) are the **template**
+that gets submitted to the [winget-pkgs](https://github.com/microsoft/winget-pkgs)
+community repository when each release of `mvmctl` ships.
+
+They are not used at build time — winget pulls them from the Microsoft
+repository, not from this directory. We keep them in-tree so:
+
+1. Reviewers can see exactly what the published manifest looks like.
+2. The release script (`xtask release`) can stamp the new version +
+   SHA-256 into them and open a PR against winget-pkgs without the
+   release engineer having to recreate the YAML by hand each time.
+
+## What's deferred
+
+- **Code signing.** The current manifest points at the unsigned
+  `mvmctl.exe` from the GitHub release. winget accepts unsigned
+  binaries but flags them in the install UI. A signed MSI is a future
+  enhancement (~$300/yr cert + signing automation).
+- **Submission automation.** Today an mvm release-engineer manually
+  opens the winget-pkgs PR. Plan 53 doesn't track automating this —
+  it's noisy CI work disproportionate to the volume of mvm releases.
+
+See [`public/.../install/windows.md`](../../public/src/content/docs/install/windows.md)
+for the user-facing install flow. Once `winget install Mvm.Mvmctl` is
+live (i.e., the manifest has been merged upstream), the install doc
+can promote it to the primary path.

--- a/public/astro.config.mjs
+++ b/public/astro.config.mjs
@@ -49,6 +49,12 @@ export default defineConfig({
           ],
         },
         {
+          label: "Install",
+          items: [
+            { label: "Windows (WSL2)", slug: "install/windows" },
+          ],
+        },
+        {
           label: "Guides",
           items: [
             { label: "Writing Nix Flakes", slug: "guides/nix-flakes" },
@@ -57,6 +63,8 @@ export default defineConfig({
             { label: "Config & Secrets", slug: "guides/config-secrets" },
             { label: "Networking", slug: "guides/networking" },
             { label: "Troubleshooting", slug: "guides/troubleshooting" },
+            { label: "Windows: WSL2 walkthrough", slug: "guides/windows-wsl2" },
+            { label: "Windows: troubleshooting", slug: "guides/windows-troubleshooting" },
           ],
         },
         {

--- a/public/astro.config.mjs
+++ b/public/astro.config.mjs
@@ -60,6 +60,19 @@ export default defineConfig({
           ],
         },
         {
+          label: "Security",
+          items: [
+            { label: "Matryoshka Model", slug: "security/matryoshka" },
+          ],
+        },
+        {
+          label: "Deploy",
+          items: [
+            { label: "AWS EC2", slug: "deploy/aws" },
+            { label: "Ubicloud", slug: "deploy/ubicloud" },
+          ],
+        },
+        {
           label: "Reference",
           items: [
             { label: "CLI Commands", slug: "reference/cli-commands" },

--- a/public/src/content/docs/deploy/aws.md
+++ b/public/src/content/docs/deploy/aws.md
@@ -1,0 +1,99 @@
+---
+title: "Deploy mvm on AWS EC2"
+description: "Run mvm on AWS EC2 with full Tier 1 (Firecracker + KVM) isolation using nested-virt instance families."
+---
+
+mvm runs natively on EC2 instance families that expose nested KVM. As of February 2026, AWS made nested virtualization standard on the **C8i / M8i / R8i** Intel-based families — you no longer need a bare-metal instance to get `/dev/kvm`. This page walks through provisioning a fresh instance and getting `mvmctl` running with full Tier 1 isolation.
+
+## Pick an instance type
+
+| Family | Use case | Sweet spot |
+|---|---|---|
+| **C8i** | CPU-heavy workloads, CI runners | `c8i.4xlarge` (16 vCPU, 32 GiB) — about $0.86/hr in Frankfurt as of Feb 2026 |
+| **M8i** | General-purpose dev / mixed workloads | `m8i.2xlarge` (8 vCPU, 32 GiB) |
+| **R8i** | Memory-heavy workloads (large guest counts) | `r8i.2xlarge` (8 vCPU, 64 GiB) |
+
+Older families (C7i, M7i, R7i, M6i, etc.) do *not* expose `/dev/kvm`. If you're stuck on one of those, see the [troubleshooting "No /dev/kvm available" section](/guides/troubleshooting#no-devkvm-available-cloud-vms-without-nested-virt) for the Tier 3 Docker fallback.
+
+The `*.metal` (bare-metal) variants also work but are dramatically more expensive and only worth it for very large workload counts. The standard nested-virt families are the default answer in 2026.
+
+## Provision
+
+Pick an AMI:
+
+- **Ubuntu 24.04 LTS** (recommended) — `ami-*-ubuntu-noble-24.04-amd64-server-*`
+- **Amazon Linux 2023** — `al2023-ami-*-x86_64`
+
+A standard EC2 launch — VPC public subnet, security group allowing SSH from your IP, EBS gp3 root volume sized for image cache. We recommend **at least 50 GiB** of EBS — the Nix store + Firecracker images add up quickly. 100 GiB is comfortable for active development.
+
+No special IAM role is required for basic mvm operation. If you plan to push images to ECR or S3, add the corresponding IAM permissions to the instance profile.
+
+## Bootstrap
+
+SSH in, then:
+
+```bash
+# Ubuntu 24.04
+sudo apt-get update
+sudo apt-get install -y curl git build-essential
+
+# Amazon Linux 2023
+sudo dnf install -y curl git gcc
+
+# Both — install Nix (multi-user)
+sh <(curl -L https://nixos.org/nix/install) --daemon
+. /etc/profile.d/nix.sh
+
+# Install mvmctl
+cargo install --git https://github.com/auser/mvm mvmctl
+# or grab a release binary from https://github.com/auser/mvm/releases
+
+# First-time setup
+mvmctl bootstrap
+```
+
+`mvmctl bootstrap` is idempotent. On a Linux host with `/dev/kvm` it skips the Lima install (Lima is only needed on macOS). It pulls the dev image, verifies the SHA-256 manifest (claim 6), and installs Firecracker.
+
+## Verify Tier 1 isolation
+
+```bash
+$ mvmctl doctor
+...
+Active backend: firecracker (KVM available)
+
+✓ SECURITY POSTURE: Tier 1 — full microVM isolation
+   Layer coverage: L1 ✓  L2 ✓  L3 ✓  L4 ✓  L5 ✓
+   All seven ADR-002 claims hold.
+```
+
+If you see "Tier 3 — Docker" or a missing-KVM warning, you're not on a nested-virt instance — go back to the instance-type table.
+
+## Networking
+
+mvm guests run on a private TAP bridge (`172.16.0.0/24`); they're NAT'd through the EC2 instance's primary interface. **No EC2 security-group changes are required for normal mvm use** — the vsock-based guest agent stays on the loopback inside the instance, and any port forwards mvm exposes are explicit and use loopback by default (claim, ADR-002 W4.4).
+
+If you `mvmctl run --port-forward 8080:8080`, the guest's port 8080 maps to the EC2 instance's `127.0.0.1:8080`. To expose that to the public internet, add a security-group rule **explicitly** — mvm doesn't do that for you.
+
+## EBS sizing
+
+Rule of thumb:
+
+- 10 GiB — Nix store overhead (mvm bootstrap closure)
+- 5 GiB per Firecracker rootfs you keep around
+- 5–20 GiB per template snapshot
+- 5 GiB Lima VM (only on macOS hosts; not applicable here)
+
+For a CI runner that builds and runs a few microVMs, 50 GiB is comfortable. For a developer instance with many templates, 100 GiB.
+
+## Operational notes
+
+- **Stopped instances** retain their EBS volume; mvm state is preserved across stop/start. The instance gets a new public IP unless you attach an Elastic IP.
+- **Image rebuilds** can be CPU-bound; the C8i family is the right pick for that.
+- **AWS Bedrock AgentCore** also runs on Firecracker. If you're weighing self-hosted mvm against managed AgentCore, both carry the same Tier 1 isolation; the trade is operational complexity vs cost vs lock-in.
+- **Spot instances** work fine for mvm — the only state that matters across reboots is what you've persisted to disk. Templates survive an instance restart; running VMs do not (they're intentionally ephemeral).
+
+## See also
+
+- [Quick start](/getting-started/quickstart) for the basic `mvmctl` flow.
+- [Matryoshka model](/security/matryoshka) for what Tier 1 actually promises.
+- [Troubleshooting → No /dev/kvm available](/guides/troubleshooting#no-devkvm-available-cloud-vms-without-nested-virt) if you ended up on a non-nested-virt instance.

--- a/public/src/content/docs/deploy/ubicloud.md
+++ b/public/src/content/docs/deploy/ubicloud.md
@@ -1,0 +1,100 @@
+---
+title: "Deploy mvm on Ubicloud bare-metal"
+description: "Run mvm on Ubicloud's open-source bare-metal cloud, which uses Cloud Hypervisor under the hood. Includes license and posture trade-offs vs AWS."
+---
+
+[Ubicloud](https://www.ubicloud.com/) is an open-source cloud provider that runs Cloud Hypervisor on bare-metal Linux+KVM hosts, with Ruby + PostgreSQL as the control plane. It's a working alternative to AWS for self-hosted infrastructure, and mvm runs on it cleanly — Ubicloud provisions a Linux VM with `/dev/kvm`, and mvm runs Firecracker inside that VM.
+
+> ### License caveat: AGPL
+>
+> Ubicloud is licensed **AGPL-3.0**. If you operate Ubicloud for internal use only, this is uneventful. If you offer a service to third parties built on Ubicloud, the AGPL's network-use clause requires you to provide source for the modifications you've deployed. mvm itself is unaffected by Ubicloud's license; this is only relevant to operators of Ubicloud.
+
+## When to pick Ubicloud over AWS
+
+Three real reasons:
+
+1. **You want to own the hardware.** Ubicloud runs on rented bare-metal (Hetzner, Latitude.sh, your colo). Cost-per-vCPU is dramatically lower than AWS at scale. Trade: you operate the control plane.
+2. **You need a fully open-source stack.** Ubicloud's source is published; AWS's isn't. If your compliance posture requires open-source-everywhere, Ubicloud is one of the few real answers.
+3. **You're already running Ubicloud.** mvm composes with what you have.
+
+If none of those apply, AWS C8i/M8i/R8i (see [the AWS guide](/deploy/aws)) is simpler.
+
+## Architecture
+
+Ubicloud's architecture is *also* matryoshka-shaped, which is nice from an mvm perspective:
+
+```
+Ubicloud bare-metal (Linux + KVM)
+    └── Ubicloud-managed VM (Cloud Hypervisor + Linux namespaces)
+            └── mvmctl
+                    └── Firecracker microVM (mvm's L1+L2)
+                            └── Your workload (mvm's L3-L5)
+```
+
+The Ubicloud VM gives you `/dev/kvm` (it advertises nested virt to the guest), so mvm runs Firecracker natively at full Tier 1. You get *two* hardware-isolated layers: Cloud Hypervisor for the bare-metal-to-tenant boundary, Firecracker for the workload boundary. Useful if you're running a multi-tenant offering on top of mvm.
+
+## Provision a Ubicloud VM
+
+Use the Ubicloud console or CLI to provision a VM. Recommended sizing for an mvm host:
+
+- **vCPUs**: 8+ (mvm guests cost 1–2 vCPUs each; the host needs headroom for the Lima-equivalent build environment)
+- **RAM**: 16+ GiB
+- **Disk**: 100+ GiB
+- **Image**: Ubuntu 24.04 LTS
+
+When prompted for nested virtualization, **enable it**. Ubicloud's default may or may not — verify by checking `/dev/kvm` after first boot.
+
+## Bootstrap
+
+SSH in, then:
+
+```bash
+sudo apt-get update
+sudo apt-get install -y curl git build-essential
+
+sh <(curl -L https://nixos.org/nix/install) --daemon
+. /etc/profile.d/nix.sh
+
+cargo install --git https://github.com/auser/mvm mvmctl
+mvmctl bootstrap
+```
+
+Same as the [AWS guide](/deploy/aws) from this point on. `mvmctl bootstrap` detects `/dev/kvm` and skips the Lima install path.
+
+## Verify
+
+```bash
+$ mvmctl doctor
+...
+Active backend: firecracker (KVM available)
+
+✓ SECURITY POSTURE: Tier 1 — full microVM isolation
+   Layer coverage: L1 ✓  L2 ✓  L3 ✓  L4 ✓  L5 ✓
+   All seven ADR-002 claims hold.
+```
+
+If `mvmctl doctor` reports KVM unavailable, the Ubicloud VM didn't get nested virt. Recreate it with nesting explicitly enabled.
+
+## Trade-offs vs AWS
+
+| | AWS C8i/M8i/R8i | Ubicloud |
+|---|---|---|
+| **Cost** | ~$0.86/hr (`c8i.4xlarge`) | Lower — depends on bare-metal provider |
+| **Operational overhead** | Low (managed) | Higher (you run the control plane) |
+| **License** | Closed-source | AGPL-3.0 (relevant for service operators) |
+| **Region availability** | Global | Wherever your bare-metal provider runs |
+| **Nested virt** | Standard on C8i/M8i/R8i | Manual enable per VM |
+| **Time to first VM** | ~5 min | Depends on Ubicloud install/setup |
+| **Egress cost** | High | Provider-dependent (often much lower) |
+
+Both carry the same Tier 1 isolation when configured correctly. The decision is operational/economic, not security.
+
+## Why mvm doesn't ship a Cloud-Hypervisor backend
+
+Tangentially relevant since Ubicloud runs CH: mvm has *considered and rejected* adding Cloud Hypervisor as a first-class backend (see [Plan 54 in the project repo](https://github.com/auser/mvm/blob/main/specs/plans/54-cloud-hypervisor-deferred.md)). Reason: every advantage CH ships is a feature Firecracker deliberately excluded for attack-surface reasons. We keep Firecracker as the unambiguous security baseline. This is unrelated to Ubicloud's choice to use CH at *its* layer (where the larger device model is needed for general-purpose guests).
+
+## See also
+
+- [Matryoshka model](/security/matryoshka) — why running Firecracker inside a Cloud-Hypervisor host is two layers of microVM isolation, not one.
+- [AWS deployment guide](/deploy/aws) — the simpler default if license/cost don't push you to Ubicloud.
+- [Ubicloud documentation](https://www.ubicloud.com/docs) — for everything below the Linux VM in the matryoshka diagram.

--- a/public/src/content/docs/guides/troubleshooting.md
+++ b/public/src/content/docs/guides/troubleshooting.md
@@ -189,6 +189,28 @@ mvmctl up --flake . --hypervisor qemu    # microvm.nix
 mvmctl doctor   # check available backends
 ```
 
+### No `/dev/kvm` available (cloud VMs without nested virt)
+
+Hitting `KVM not available` on a cloud instance? Three options, in order of recommendation.
+
+**Option 1 — Switch to a nested-virt instance type.** Most cloud providers added nested KVM in 2025–2026. After moving to one of these, Firecracker runs natively and you get full Tier 1 isolation:
+
+| Provider | Nested-virt instance families |
+|---|---|
+| AWS | C8i / M8i / R8i (Feb 2026 onward) — e.g. `c8i.4xlarge` |
+| GCE | n2 with `--enable-nested-virtualization` |
+| Azure | Dasv5 / Easv5 |
+
+**Option 2 — Use the Tier 3 Docker fallback.** Works in any environment with Docker Engine. **Reduced security tier** — see the [Matryoshka model](/security/matryoshka). The L1–L3 layers collapse to the host kernel, so claims 1, 2, and 3 do not hold. Use only for non-security-sensitive workloads (CI scratch, local experiments).
+
+```bash
+mvmctl up --flake . --hypervisor docker
+# Suppress the per-run banner once you've acknowledged the tier:
+export MVM_ACK_DOCKER_TIER=1
+```
+
+**Option 3 — PVM (advanced, external).** [SlicerVM's PVM mode](https://docs.slicervm.com/tasks/pvm/) runs real microVMs without `/dev/kvm` via a patched Firecracker plus a `kvm_pvm` host kernel module. mvm doesn't ship this — the maintenance cost (kernel patch + custom guest images, x86_64 only) is outside mvm's scope. If you need real microVM isolation on a non-nested-virt cloud VM and Option 1 isn't available, SlicerVM is the working answer in the ecosystem today.
+
 ### Rootfs corrupted
 
 Re-run `mvmctl bootstrap` — it's idempotent and repaves any corrupted rootfs from the upstream squashfs without destroying the Lima VM:

--- a/public/src/content/docs/guides/windows-troubleshooting.md
+++ b/public/src/content/docs/guides/windows-troubleshooting.md
@@ -1,0 +1,131 @@
+---
+title: "Windows troubleshooting"
+description: "Common Windows-specific issues with mvm: WSL2 setup, nested virt, port forwarding, BIOS, and Hyper-V interactions."
+---
+
+This page is the Windows-specific FAQ. For Windows install steps see [Install on Windows](/install/windows); for the WSL2 walkthrough see [the WSL2 guide](/guides/windows-wsl2). General mvm troubleshooting (build issues, network issues, etc.) lives in [the main troubleshooting page](/guides/troubleshooting).
+
+## Setup
+
+### `wsl --install` fails with "this update only applies..."
+
+Your Windows version is too old. mvm requires Windows 10 21H2 (build 19044) or any Windows 11. Run `winver` to check; update via Windows Update if you're behind.
+
+### `wsl --install` succeeds but the Ubuntu shell doesn't open
+
+Two common causes:
+
+1. **Hyper-V is disabled.** Open *Turn Windows features on or off* and enable both *Virtual Machine Platform* and *Windows Subsystem for Linux*. Reboot.
+2. **CPU virtualization is off in BIOS.** Look for *Intel VT-x* / *AMD-V* / *SVM*. Enable, save, reboot.
+
+After either fix, `wsl --shutdown` then reopen Ubuntu.
+
+### "WSL2 requires an update to its kernel component"
+
+Run:
+```powershell
+wsl --update
+```
+
+If `wsl --update` returns "no update available" but the error persists, the kernel package failed to register. Reinstall manually from the [Microsoft download page](https://learn.microsoft.com/en-us/windows/wsl/install-manual).
+
+## Nested virt (`/dev/kvm` inside WSL2)
+
+### `/dev/kvm` is missing
+
+mvm needs `/dev/kvm` inside the WSL2 distro for Tier 1 isolation. If it's missing:
+
+1. **Update WSL itself:**
+   ```powershell
+   wsl --update
+   wsl --shutdown
+   ```
+2. **Confirm CPU support:**
+   ```bash
+   grep -E '(vmx|svm)' /proc/cpuinfo
+   ```
+   If empty, your CPU doesn't expose virt or BIOS has it disabled.
+3. **Confirm Hyper-V isn't blocking nested virt:** modern Hyper-V exposes nested virt by default to WSL2. Some third-party security tools (Kaspersky, certain enterprise EDR products) install Hyper-V hypervisors that block nested virt. Disable those temporarily to confirm.
+
+### `mvmctl doctor` reports "KVM not available" even though `/dev/kvm` exists
+
+Permissions issue. Inside the WSL2 distro:
+
+```bash
+ls -la /dev/kvm
+```
+
+If the device is owned by root and your user isn't in the `kvm` group:
+
+```bash
+sudo usermod -aG kvm $(whoami)
+exit  # log out and back in for the group change to take effect
+```
+
+If `kvm` group doesn't exist, `sudo groupadd kvm` then chown.
+
+## Port forwarding
+
+### `localhost:<port>` from Windows doesn't reach the mvm guest
+
+mvm forwards guest port → WSL2-loopback (`127.0.0.1`). Microsoft's automatic localhost forwarding usually picks that up, but several things can break it:
+
+- **Corporate VPNs** (Cisco AnyConnect, Palo Alto GlobalProtect) frequently kill WSL2's localhost mapping. Workaround: connect to the WSL2 distro's IP directly:
+  ```bash
+  hostname -I  # in the distro
+  ```
+  Then `http://<that-ip>:<port>` from Windows.
+- **Windows Firewall** can block the forwarding listener. Allow inbound TCP on the relevant port for the *vEthernet (WSL)* adapter.
+- **`localhost` resolves to IPv6** but the listener is IPv4. Try `127.0.0.1:<port>` explicitly.
+
+### "Address already in use" when starting mvm guest
+
+Another process on the WSL2 distro (or a stale forward from a prior run) is using the port. Run:
+
+```bash
+ss -tlnp | grep :<port>
+```
+
+— and kill the holder, or pick a different port forward.
+
+## File system
+
+### Nix builds are *extremely* slow
+
+You're working from a `/mnt/c/...` path. NTFS-via-9p is many times slower than ext4 inside the WSL2 distro. **Move your project into the WSL2 ext4 filesystem** (e.g. `~/work/...`) and rebuild. Don't keep Nix store on `/mnt/c/`.
+
+### `mvmctl bootstrap` reports "permission denied" creating `~/.mvm`
+
+`HOME` inside the distro should be `/home/<your-user>`. If you accidentally launched the distro with `HOME=/mnt/c/Users/<you>`, NTFS permissions may not allow the `0700` chmod that `mvmctl` does for `~/.mvm` (W1.5). Fix: `unset HOME` and re-run, or set `HOME=/home/<user>` explicitly.
+
+## Tier 3 Docker fallback
+
+### Banner nagging on every `mvmctl run`
+
+When the auto-selected backend is Tier 3 Docker, mvm prints a security warning. Once you've read [the Matryoshka model](/security/matryoshka) and accept the reduced isolation:
+
+```powershell
+$env:MVM_ACK_DOCKER_TIER = "1"
+```
+
+(or persist it in your shell profile / Windows env settings).
+
+Equivalently: `~/.mvm/config.toml`:
+```toml
+[security]
+ack_docker_tier = true
+```
+
+### Docker Desktop says "WSL2 backend required"
+
+Docker Desktop on Windows 10/11 uses WSL2 by default. If you've manually switched to Hyper-V backend, switch back via *Docker Desktop → Settings → General → Use the WSL 2 based engine*.
+
+## Anything else
+
+[Open a GitHub issue](https://github.com/auser/mvm/issues) with the output of:
+
+```bash
+mvmctl doctor --json > doctor.json
+```
+
+— attached, plus your Windows version (`winver`) and WSL kernel (`wsl --version`).

--- a/public/src/content/docs/guides/windows-wsl2.md
+++ b/public/src/content/docs/guides/windows-wsl2.md
@@ -1,0 +1,92 @@
+---
+title: "WSL2 walkthrough for mvm"
+description: "Step-by-step WSL2 setup for mvm with notes on nested virt, port forwarding, file sharing, and the bootstrap automation that's coming in Sprint 48."
+---
+
+This page is the long-form companion to the [Windows install quickstart](/install/windows). It walks through the WSL2 setup choices that matter for mvm and documents a few quirks unique to running microVMs on Windows.
+
+## Why WSL2 for mvm
+
+WSL2 is a real Linux kernel running under Hyper-V. From inside a WSL2 distro:
+
+- **`/dev/kvm` is available** (since Windows 10 21H2). Firecracker runs natively, giving you Tier 1 microVM isolation — the same as a native Linux host.
+- **Filesystem is real Linux ext4**. APFS-style copy-on-write isn't here yet (Sprint 47 Plan D ships APFS CoW for macOS Apple Container; WSL2's ext4 will fall back to byte-copy in `mvm-runtime::vm::cow::reflink_or_copy`), but everything functionally works.
+- **Networking is bridged** through Hyper-V's vmswitch. Port forwarding from Windows host to a WSL2 distro is automatic for `127.0.0.1` binds; mvm guests behind the WSL2 distro need an additional hop, covered below.
+
+The cost is one nested VM hop: workload runs inside Firecracker microVM → which runs inside WSL2 → which runs inside Hyper-V on the Windows host. The boot-time penalty is small (~150ms), the runtime penalty is in the noise.
+
+## Setup
+
+The [install quickstart](/install/windows) covers `wsl --install` + `cargo install`. Two follow-up steps that matter for mvm specifically:
+
+### Confirm nested KVM works
+
+```bash
+ls -l /dev/kvm
+```
+
+Should show a character device. If `/dev/kvm` is missing, WSL2 didn't pick up nested virt. Two fixes:
+
+1. **Update Windows + WSL** to current versions:
+   ```powershell
+   wsl --update
+   ```
+2. **Confirm BIOS settings**: VT-x / AMD-V enabled, Hyper-V allowed.
+
+If `mvmctl doctor` still reports KVM unavailable, see the [No /dev/kvm available](/guides/troubleshooting#no-devkvm-available-cloud-vms-without-nested-virt) entry.
+
+### Allocate WSL2 resources
+
+WSL2 starts with a default of 50% of host RAM and all CPUs. mvm guests run inside this budget. For a comfortable dev machine:
+
+`%USERPROFILE%\.wslconfig`:
+```ini
+[wsl2]
+memory=12GB
+processors=8
+```
+
+Then restart WSL: `wsl --shutdown` and reopen the Ubuntu shell.
+
+## Port forwarding (Windows host ↔ mvm guest)
+
+mvm guests inside WSL2 run on the `172.16.0.0/24` TAP bridge, which is invisible from the Windows host by default. To expose a guest service to a Windows-side browser:
+
+1. **Forward the guest port to the WSL2 distro's loopback** with mvm's standard mechanism:
+   ```bash
+   mvmctl run --port-forward 8080:80 --flake .
+   ```
+   This binds `127.0.0.1:8080` inside the WSL2 distro to the guest's port 80.
+
+2. **WSL2's automatic localhost forwarding** ([documented by Microsoft](https://learn.microsoft.com/en-us/windows/wsl/networking#accessing-network-applications)) makes `localhost:8080` on Windows reach the WSL2 distro's loopback. Open `http://localhost:8080` in a Windows browser and you're hitting the mvm guest.
+
+If localhost forwarding isn't working (some corporate VPN clients break it), fall back to the WSL2 distro's IP:
+
+```bash
+hostname -I  # inside WSL2 — gives the distro's IP on the Hyper-V vmswitch
+```
+
+Then `http://<that-ip>:8080` from Windows.
+
+## File sharing
+
+`/mnt/c/` (and similar) inside WSL2 maps to Windows drives. **Don't put your Nix store on `/mnt/c/`** — the cross-fs perf is brutal and Nix's case-sensitivity assumptions don't hold on NTFS. Keep mvm work inside the WSL2 ext4 filesystem (e.g. `~/work/...`).
+
+If you need to read source from a Windows directory, do it explicitly with `cp` rather than running `cargo build` against a `/mnt/c/` path.
+
+## What's coming in Sprint 48
+
+[Plan I.4](https://github.com/auser/mvm/blob/main/specs/plans/53-cross-platform-roadmap.md) (WSL2 bootstrap automation) will turn the manual steps above into:
+
+```powershell
+mvmctl bootstrap
+```
+
+— detect Windows + WSL2 status, offer to install if missing, install mvm into the chosen distro, set up shared `~/.mvm`. Until then, follow the [install quickstart](/install/windows).
+
+## See also
+
+- [Install on Windows](/install/windows)
+- [Matryoshka model](/security/matryoshka) — what Tier 1 promises and why WSL2 carries it
+- [Windows troubleshooting](/guides/windows-troubleshooting)
+- [WSL2 documentation](https://learn.microsoft.com/en-us/windows/wsl/)

--- a/public/src/content/docs/install/windows.md
+++ b/public/src/content/docs/install/windows.md
@@ -1,0 +1,82 @@
+---
+title: "Install mvm on Windows"
+description: "mvm runs on Windows via WSL2 with first-class Tier 1 microVM isolation. This page is the entry point for Windows users."
+---
+
+mvm on Windows uses **WSL2** as its primary supported path. Inside a WSL2 distro you get the same Tier 1 microVM isolation as a Linux host (Firecracker + KVM). This is the recommended setup for any Windows user who wants real microVM workloads.
+
+If WSL2 isn't an option for your environment, you can fall back to the Tier 3 Docker tier — but that's a container, not a microVM, and the security model collapses. See the [Matryoshka model](/security/matryoshka) for what each tier promises.
+
+## Quickstart (WSL2 — recommended)
+
+You'll need: Windows 10 21H2+ or Windows 11 (any), with a CPU that supports virtualization (most modern Intel/AMD). Most laptops bought after 2018 qualify.
+
+1. **Enable WSL2** (one-time, requires admin):
+   ```powershell
+   wsl --install
+   ```
+   This installs WSL2 + the default Ubuntu distro and enables the Hyper-V components mvm needs. Reboot when prompted.
+
+2. **Open the Ubuntu shell** (Start menu → "Ubuntu") and update:
+   ```bash
+   sudo apt-get update && sudo apt-get install -y curl git build-essential
+   ```
+
+3. **Install Nix (multi-user)**:
+   ```bash
+   sh <(curl -L https://nixos.org/nix/install) --daemon
+   . /etc/profile.d/nix.sh
+   ```
+
+4. **Install mvmctl**:
+   ```bash
+   cargo install --git https://github.com/auser/mvm mvmctl
+   ```
+   Or download a release binary from the [releases page](https://github.com/auser/mvm/releases).
+
+5. **First-time setup**:
+   ```bash
+   mvmctl bootstrap
+   ```
+   This pulls the dev image, verifies the SHA-256 manifest, and installs Firecracker. Idempotent — safe to re-run.
+
+6. **Verify Tier 1 isolation**:
+   ```bash
+   mvmctl doctor
+   ```
+   Look for `Active backend: firecracker (KVM available)` and the all-✓ Security posture section.
+
+You're done. From here, follow the [Quick Start](/getting-started/quickstart) — everything works the same as on a native Linux host because WSL2 *is* a Linux host as far as mvm is concerned.
+
+See the [WSL2 walkthrough](/guides/windows-wsl2) for detail on bootstrap automation, port forwarding from Windows to a guest, and a few WSL2-specific quirks.
+
+## Alternative: Tier 3 Docker fallback
+
+If WSL2 isn't an option (corporate IT lock-down, no nested virt, etc.), Docker Desktop on Windows can run mvm at Tier 3. **You give up microVM isolation** — see the [Matryoshka model](/security/matryoshka) — so this path is for *non-security-sensitive* workloads only.
+
+```powershell
+# Inside a Docker Desktop linux container or WSL2 distro:
+mvmctl run --hypervisor docker --flake .
+```
+
+`mvmctl run` will print a loud warning banner naming the seven CVEs and the dropped claims. Suppress it once you've acknowledged the tier:
+
+```powershell
+$env:MVM_ACK_DOCKER_TIER = "1"
+```
+
+The Docker tier exists as a convenience, not a sandbox. If your workload involves untrusted code, AI-generated scripts, or anything you wouldn't run as your own user, switch to WSL2.
+
+## What about native Windows microVMs?
+
+There isn't a maintained native-Windows microVM stack we'd want to ship today. We considered Cloud Hypervisor + WHPX (the Hyper-V virtualization API) and rejected it for security-posture reasons — see [plan 53 §"Plan F"](https://github.com/auser/mvm/blob/main/specs/plans/54-cloud-hypervisor-deferred.md) and the [Matryoshka model](/security/matryoshka). The 2026 microVM ecosystem treats Windows as a *guest OS*, not a *host platform* for microVM tooling. WSL2 is the right answer.
+
+If you need a real native-Windows microVM tool, look at Docker Desktop's own sandbox feature (released Jan 2026) — it uses Hyper-V directly and is purpose-built for that. mvm complements rather than competes.
+
+## Troubleshooting
+
+- **"WSL2 not available" on install** — make sure CPU virtualization is enabled in BIOS. On laptops this is often *Intel VT-x* / *AMD-V*. After enabling, run `wsl --install` again.
+- **`/dev/kvm` missing inside WSL2** — older Windows builds don't expose nested KVM. Update Windows to the latest 11 release; `wsl --update` after.
+- **`mvmctl doctor` reports "no KVM available"** — see the [No /dev/kvm available](/guides/troubleshooting#no-devkvm-available-cloud-vms-without-nested-virt) troubleshooting entry.
+
+See [Windows troubleshooting](/guides/windows-troubleshooting) for the full Windows-specific FAQ.

--- a/public/src/content/docs/security/matryoshka.md
+++ b/public/src/content/docs/security/matryoshka.md
@@ -1,0 +1,101 @@
+---
+title: "The Matryoshka model: how mvm isolates untrusted code"
+description: "mvm runs untrusted Linux workloads in microVMs. This page explains the five trust layers, the seven CI-enforced security claims, and which claims hold for each backend."
+---
+
+mvm's job is to let you run **untrusted code** — third-party software, AI-generated scripts, CI runners, sandbox workloads — and trust the isolation. This page explains the security model in one diagram and one matrix.
+
+## The five trust layers
+
+```
+┌───────────────────────────────────────────────────────────┐
+│ L5 — Workload (your untrusted code)                       │
+├───────────────────────────────────────────────────────────┤
+│ L4 — Guest agent (parses host messages, launches code)    │
+├───────────────────────────────────────────────────────────┤
+│ L3 — Guest kernel (Linux, ephemeral, isolated)            │
+├───────────────────────────────────────────────────────────┤
+│ L2 — VMM (Firecracker, Rust, seccomp-jailed)              │
+├───────────────────────────────────────────────────────────┤
+│ L1 — Host + hypervisor (KVM / Apple VZ / HVF)             │
+└───────────────────────────────────────────────────────────┘
+```
+
+Each layer trusts only the layer **below** it. An attacker has to break through every boundary above to reach the host. A failure in any one layer is bounded — the layer below still enforces its own contract.
+
+This pattern (sometimes called the *matryoshka* model after the nested Russian dolls) is the same defense-in-depth used by Fly.io Sprites, AWS Lambda's SnapStart, E2B, Vercel Sandbox, and Kata Containers. mvm's adaptation is that **L5 is enforced inside the guest** — even a guest-kernel compromise doesn't give arbitrary access to other in-guest services. See [ADR-002](https://github.com/auser/mvm/blob/main/specs/adrs/002-microvm-security-posture.md) for the full decision record.
+
+## The seven claims
+
+mvm makes seven CI-enforced security claims. Each one is backed by a continuous-integration check that fails the build if the claim ceases to hold.
+
+| # | Claim | Defends layer | How it's enforced |
+|---|---|---|---|
+| 1 | No host-fs access from a guest beyond explicit shares | L2 / L5 | Per-service uid + seccomp `standard` default + setpriv bounding-set drop |
+| 2 | No guest binary can elevate to uid 0 | L2 / L4 | `setpriv --no-new-privs` in launch path; `/etc/{passwd,group}` are read-only bind-mounts |
+| 3 | A tampered rootfs ext4 fails to boot | L3 | dm-verity sidecar + roothash on cmdline + `mvm-verity-init` initramfs |
+| 4 | The guest agent does not contain `do_exec` in production builds | L4 | CI symbol-grep on the prod binary; absence is enforced |
+| 5 | Vsock framing is fuzzed | L2 / L4 | `cargo-fuzz` targets cover every host↔guest message; `deny_unknown_fields` on every type |
+| 6 | Pre-built dev image is hash-verified | supply chain | SHA-256 manifest streamed through the download |
+| 7 | Cargo deps are audited on every PR | supply chain | `cargo-deny` + `cargo-audit` jobs; reproducibility double-build |
+
+L1 (host + hypervisor) doesn't carry its own claim — the host is **trusted** by definition. If your host is compromised, every layer falls. Locking down the host (firewall, package hygiene, full-disk encryption) is your responsibility.
+
+## Per-backend tier matrix
+
+mvm runs on multiple backends. Not all backends carry all seven claims. The tier you actually get depends on which backend mvm picks for your run.
+
+| Backend | L1 | L2 | L3 | L4 | L5 | Tier |
+|---|---|---|---|---|---|---|
+| **Firecracker** (Linux + KVM) | ✅ | ✅ | ✅ | ✅ | ✅ | **Tier 1** — full ADR-002. All seven claims hold. |
+| **Apple Container** (macOS 26+ Apple Silicon) | ✅ | ✅ | ⚠️ | ✅ | ✅ | Tier 2 — claim 3 (verified boot) is partial. Other six claims hold. |
+| **libkrun** (Linux KVM, macOS HVF) | ✅ | ✅ | ⚠️ | ✅ | ✅ | Tier 2 — same as Apple Container. |
+| **Docker** (any host with Docker) | ❌ | ❌ | ❌ | ✅ | ✅ | **Tier 3** — claims 1, 2, 3 do **not** hold. L1–L3 collapse to the host kernel. |
+| **microvm.nix** (QEMU + KVM) | ✅ | ⚠️ | ⚠️ | ✅ | ✅ | Tier 2 — QEMU's larger device model raises L2 audit cost. |
+
+✅ = layer fully enforced.  ⚠️ = layer partial (named exception).  ❌ = layer collapsed (claim does not apply).
+
+### Tier 3 (Docker) is convenience, not isolation
+
+mvm's Docker backend exists so you can run a workload in a non-virt environment (e.g., a CI host without `/dev/kvm`, a developer laptop without nested virt). It's **not** a microVM. The isolation comes from the Linux kernel's namespace and cgroup machinery, which is *shared with the host kernel*.
+
+In 2024–2025 the container ecosystem produced seven CVEs (Leaky Vessels, NVIDIAScape, runc race conditions, Buildah mount, Docker Desktop priv-esc, runc masked-path, runc `/dev/console`) that all yielded **host escape** from inside a container. None of those matter inside a microVM — the guest kernel is isolated by hardware. They all matter inside a Docker container.
+
+If `mvmctl` auto-selects Tier 3 because no microVM-capable backend is available, the CLI prints a banner naming the dropped claims and the recent CVEs. You can suppress the banner once you've acknowledged the tier with:
+
+```sh
+export MVM_ACK_DOCKER_TIER=1
+```
+
+or in `~/.mvm/config.toml`:
+
+```toml
+[security]
+ack_docker_tier = true
+```
+
+### Choosing a tier
+
+- **Production / untrusted code** → Tier 1. Linux + KVM + Firecracker. No exceptions.
+- **macOS dev or CI on Apple Silicon** → Tier 2 (Apple Container or libkrun). Verified boot is the open item.
+- **macOS Intel or no-Lima Linux dev** → Tier 2 (libkrun).
+- **Anywhere else** → Tier 3 (Docker), with the banner caveats.
+
+`mvmctl doctor` reports your current tier on the running host.
+
+## What's not promised
+
+ADR-002 names three explicit non-goals so we don't accidentally commit to defending against them:
+
+- **A malicious host.** mvm trusts the host with the hypervisor and the build keys. If your laptop or your server is compromised, every layer falls.
+- **Multi-tenant guests.** One guest = one workload. Sharing a single guest VM between mutually-distrusting tenants is out of scope.
+- **Hardware-backed key attestation** (TPM/SEV/etc.) is out of scope for v1.
+
+If your threat model needs any of those, mvm is not the right tool today. ADR-002 documents these limits explicitly.
+
+## See also
+
+- [ADR-002 (full decision record)](https://github.com/auser/mvm/blob/main/specs/adrs/002-microvm-security-posture.md)
+- [Plan 25 (microVM hardening — the implementation sequence for the seven claims)](https://github.com/auser/mvm/blob/main/specs/plans/25-microvm-hardening.md)
+- [Plan 53 (cross-platform roadmap — backend tier discipline)](https://github.com/auser/mvm/blob/main/specs/plans/53-cross-platform-roadmap.md)
+- ["Your container is not a sandbox" (emirb, 2026)](https://emirb.github.io/blog/microvm-2026/) — the post that crystallized the matryoshka framing in the broader microVM ecosystem.

--- a/specs/SPRINT.md
+++ b/specs/SPRINT.md
@@ -786,7 +786,7 @@ suspicious.
 
 - **Sprint 46 — Foundation (~5 days, narrative + UX, zero arch risk).** Plans A (Matryoshka ADR rewrite), B (Doctor security-claims-by-tier output), C (PVM FAQ entry), J (AWS deployment guide), K (Ubicloud deployment guide), plus deferred-backlog placeholder files for Plans F/G/H.
 - **Sprint 47 — macOS parity + Windows foundation (~1 sprint).** Plan D (APFS CoW for Apple Container templates) + Plan I.1 (Windows CI lane) + Plan I.2 (Windows install docs, WSL2-first).
-- **Sprint 48 — libkrun + Windows installer (~1.5 sprints).** Plan E (libkrun backend — Intel Mac + macOS-no-Lima) + Plan I.3 (winget manifest) + Plan I.4 (WSL2 bootstrap automation).
+- **Sprint 48 — libkrun + Windows installer (~1.5 sprints).** Plan E (libkrun backend — Intel Mac + macOS-no-Lima) + Plan I.3 (winget manifest) + Plan I.4 (WSL2 bootstrap automation). Sprint 48 ships **scaffolding** for libkrun (final API, dispatch, doctor, install hints); the spike phase that lands real C bindings + boot validation is tracked separately in [`plans/57-libkrun-spike.md`](plans/57-libkrun-spike.md).
 
 **Deferred backlog (rationale captured in plan 53):**
 

--- a/specs/SPRINT.md
+++ b/specs/SPRINT.md
@@ -776,6 +776,37 @@ suspicious.
   mode 0700 (W1.2) gates to local user; cross-host authn is
   mvmd's problem.
 
+## Sprint 46+ — Cross-platform expansion (proposed)  [`plans/53-cross-platform-roadmap.md`](plans/53-cross-platform-roadmap.md)
+
+**Goal:** turn cross-platform support into a coherent multi-platform release without forking the security narrative. Decision recorded in plan 53 as **Option B — Pragmatic**: Firecracker stays the security baseline, Apple Container is the macOS exception, **libkrun** is the only new backend (Intel Mac + macOS-no-Lima), Docker stays as Tier 3 with loud warnings, Windows is first-class via WSL2 with bootstrap automation.
+
+**Why this sprint, why now:** today mvm fully supports Linux + KVM (Firecracker) and macOS 26+ Apple Silicon (Apple Container, plan 23). Older macOS, Intel Macs, and Windows hosts are second-class. The 2026 microVM ecosystem (SlicerVM, libkrun, AWS nested-virt EC2) makes a coherent multi-platform release tractable; we want to land it before the gap widens.
+
+**Three sequential sprint slots:**
+
+- **Sprint 46 — Foundation (~5 days, narrative + UX, zero arch risk).** Plans A (Matryoshka ADR rewrite), B (Doctor security-claims-by-tier output), C (PVM FAQ entry), J (AWS deployment guide), K (Ubicloud deployment guide), plus deferred-backlog placeholder files for Plans F/G/H.
+- **Sprint 47 — macOS parity + Windows foundation (~1 sprint).** Plan D (APFS CoW for Apple Container templates) + Plan I.1 (Windows CI lane) + Plan I.2 (Windows install docs, WSL2-first).
+- **Sprint 48 — libkrun + Windows installer (~1.5 sprints).** Plan E (libkrun backend — Intel Mac + macOS-no-Lima) + Plan I.3 (winget manifest) + Plan I.4 (WSL2 bootstrap automation).
+
+**Deferred backlog (rationale captured in plan 53):**
+
+- **Plan F — Cloud Hypervisor backend.** *Rejected* for security-posture reasons. Every advantage CH ships (nested KVM in guests, GPU passthrough, larger device model, Windows-guest support) is exactly what Firecracker excluded for attack surface. Adding CH would fork the security narrative. Trigger conditions to revisit are documented in plan 53 §Plan F.
+- **Plan G — crosvm backend.** *Deferred.* Niche for our user base; libkrun (Plan E) covers the embeddable cross-platform niche. Trigger: real Chrome OS / Android demand.
+- **Plan H — rust-vmm internalization.** *Rejected for now.* Composing rust-vmm crates into a working VMM is *building a VMM*; that's Firecracker's and libkrun's job. Trigger: custom-VMM-required feature.
+
+**Sprint 46+ success criteria (per slot):**
+
+- After Sprint 46: ADR-002 displays the layer model + per-backend tier matrix; `mvmctl doctor` and `mvmctl run` emit the Docker-tier warning banner; AWS + Ubicloud deployment guides published; deferred plans 54/55/56 placeholder files committed.
+- After Sprint 47: macOS Apple Container template instantiation <1s via APFS CoW; `cargo build --workspace` green on Windows; Windows install docs (WSL2-first) published.
+- After Sprint 48: libkrun runs on Linux + KVM, macOS Apple Silicon (no Lima), and macOS Intel; `winget install mvm` works on Windows; `mvmctl bootstrap` on Windows configures WSL2 + Ubuntu + mvm automatically.
+
+**Non-goals (named explicitly):**
+
+- Cloud Hypervisor backend (Plan F, rejected).
+- Promoting Docker to a first-class Windows path via pre-built rootfs distribution (would conflict with the security posture).
+- Native-Windows microVMs via Cloud Hypervisor + WHPX (depends on Plan F).
+- Eliminating Lima from the macOS *build* path (libkrun solves runtime only; build-on-host is future work).
+
 ## Completed Sprints
 
 - [01-foundation.md](sprints/01-foundation.md)

--- a/specs/adrs/002-microvm-security-posture.md
+++ b/specs/adrs/002-microvm-security-posture.md
@@ -1,14 +1,17 @@
 ---
 title: "ADR-002: microVM security posture — explicit guarantees, layered defenses"
-status: Proposed
+status: Accepted
 date: 2026-04-30
+revised: 2026-05-07
 supersedes: none
-related: ADR-001 (multi-backend execution); plan 25-microvm-hardening
+related: ADR-001 (multi-backend execution); plan 25-microvm-hardening; plan 53-cross-platform-roadmap
 ---
 
 ## Status
 
-Proposed. Implementation tracked in `specs/plans/25-microvm-hardening.md`.
+Accepted. Implementation tracked in `specs/plans/25-microvm-hardening.md`. Workstreams W1–W6 shipped 2026-04-30.
+
+The 2026-05-07 revision adds the **Trust layers (Matryoshka model)** section, names the seven CI-enforced claims explicitly, and adds a **per-backend tier matrix** showing which claims hold for each backend in `AnyBackend`. None of the original decisions or surfaces change — the revision is a re-framing for legibility, motivated by plan 53 (cross-platform roadmap) where multiple backends with different tier coverage now coexist.
 
 ## Context
 
@@ -54,6 +57,71 @@ A *malicious host* (the macOS or Linux machine running mvmctl itself)
 is **explicitly out of scope**. mvmctl trusts the host with the
 hypervisor, the GC roots, the launchd plists, the user's secrets in
 `/mnt/secrets`, and the private build keys.
+
+## Trust layers (Matryoshka model)
+
+mvm's defense-in-depth is structured as five trust layers nested like a
+matryoshka doll. Each layer trusts the layer *below* it and nothing
+else; an attacker has to break through every boundary above to reach
+the host. A failure in any one layer is bounded — the layer below
+still enforces its own contract.
+
+```
+┌───────────────────────────────────────────────────────────────┐
+│ L5 — Workload (untrusted code, AI-generated, user scripts)    │
+│      enforced by: per-service uid (W2.1), bounding-set drop   │
+│                   (W2.3), seccomp tier `standard` (W1.1, W2.4)│
+├───────────────────────────────────────────────────────────────┤
+│ L4 — Guest agent (parses host messages, launches services)    │
+│      enforced by: uid 901 setpriv (W4.5), no_new_privs,       │
+│                   `do_exec` absent in prod (W4.3),            │
+│                   fuzzed deser + deny_unknown_fields (W4.1-2) │
+├───────────────────────────────────────────────────────────────┤
+│ L3 — Guest kernel (Linux from Nix, ephemeral, isolated)       │
+│      enforced by: dm-verity rootfs + roothash on cmdline +    │
+│                   mvm-verity-init initramfs (W3)              │
+├───────────────────────────────────────────────────────────────┤
+│ L2 — VMM (userspace, Rust, seccomp-jailed, unprivileged)      │
+│      enforced by: minimal device set (Firecracker), seccomp   │
+│                   default-on, host-side proxy socket 0700     │
+│                   (W1.2), port allowlist (W1.3)               │
+├───────────────────────────────────────────────────────────────┤
+│ L1 — Host + hypervisor (KVM on Linux, Apple VZ on macOS,      │
+│                          Hypervisor.framework via libkrun)    │
+│      enforced by: hardware (CPU rings, EPT, IOMMU); host      │
+│                   hardening is the user's responsibility      │
+└───────────────────────────────────────────────────────────────┘
+```
+
+The "matryoshka" framing comes from the 2026 microVM ecosystem
+discourse (notably <https://emirb.github.io/blog/microvm-2026/>).
+It is the same pattern used by Fly.io Sprites, AWS Lambda's
+SnapStart, E2B, Vercel Sandbox, and Kata Containers. The mvm
+adaptation is that L5 is enforced *inside* the guest by uid/seccomp
+(plan 26), so even a guest-kernel compromise (L3 fall) doesn't grant
+arbitrary access to other in-guest services.
+
+## The seven CI-enforced claims
+
+Each claim is backed by a CI gate that fails the build if the claim
+ceases to hold. Claims are mapped to the trust layer they *primarily*
+defend; many claims have ripple effects across multiple layers, but
+the primary defended layer is the one the gate fails first.
+
+| # | Claim | Primary layer | Workstream | CI gate |
+|---|---|---|---|---|
+| 1 | No host-fs access from a guest beyond explicit shares | L2/L5 | W2.1, W1.1, W2.3, W2.4 | seccomp regression; per-service-uid bind audit |
+| 2 | No guest binary can elevate to uid 0 | L2/L4 | W2.2, W2.3 | bind-mount RO assertion; setpriv `--no-new-privs` regression |
+| 3 | A tampered rootfs ext4 fails to boot | L3 | W3.1–W3.4 | `verified-boot-artifacts` + live-KVM tamper test in `security.yml` |
+| 4 | The guest agent does not contain `do_exec` in production builds | L4 | W4.3 | `prod-agent-no-exec` symbol-grep job in `ci.yml` |
+| 5 | Vsock framing is fuzzed | L2/L4 | W4.1, W4.2 | `cargo-fuzz` targets in `crates/mvm-guest/fuzz/`; `deny_unknown_fields` audit |
+| 6 | Pre-built dev image is hash-verified | cross-cutting (supply chain) | W5.1 | `download_dev_image` SHA-256 check; `MVM_SKIP_HASH_VERIFY` only documented escape |
+| 7 | Cargo deps are audited on every PR | cross-cutting (supply chain) | W5.2 | `cargo-deny` + `cargo-audit` jobs; reproducibility double-build (W5.3) |
+
+L1 (host + hypervisor) has no claim of its own — the host is trusted
+by definition (see Threat model). L1 *enables* claim 3 (verified boot
+needs a hypervisor that respects the kernel cmdline). If the host is
+compromised, every layer falls; that case is explicitly out of scope.
 
 ## Surfaces
 
@@ -137,6 +205,39 @@ The following are decided and committed for v1 of this hardening:
    backed key attestation is out of scope. These limits are in the
    ADR so we don't accidentally commit to defending against them.
 
+## Per-backend tier matrix
+
+Plan 53 (cross-platform roadmap) introduces multiple backends —
+Firecracker, Apple Container, libkrun, Docker, microvm.nix — each
+with different layer coverage. A given user run carries the tier of
+its active backend, not the strongest tier the project supports. The
+following matrix is what `mvmctl doctor` reports and what the
+mvm-cli startup banner surfaces (loudly, when the active backend
+falls below Tier 1).
+
+| Backend | L1 | L2 | L3 | L4 | L5 | Notes |
+|---|---|---|---|---|---|---|
+| Firecracker (Linux + KVM) | ✅ | ✅ | ✅ | ✅ | ✅ | **Tier 1** — full ADR-002. All seven claims hold. |
+| Apple Container (macOS 26+ Apple Silicon) | ✅ VZ | ✅ Containerization | ⚠️ no verified boot yet | ✅ | ✅ | Tier 2 — claim 3 partial; claims 1, 2, 4, 5, 6, 7 hold. |
+| libkrun (Linux KVM, macOS HVF) | ✅ | ✅ | ⚠️ no verified boot yet | ✅ | ✅ | Tier 2 — claim 3 partial; comparable VMM TCB to Firecracker. |
+| Docker | ❌ shared host kernel | ❌ container runtime is L2=host kernel | ❌ shared with host | ✅ | ✅ | **Tier 3** — claims 1, 2, 3 do *not* hold; 4, 6, 7 hold; 5 N/A (unix socket). |
+| microvm.nix (QEMU) | ✅ KVM | ⚠️ QEMU TCB much larger | ⚠️ partial verified boot | ✅ | ✅ | Tier 2 — claims 3 partial; QEMU's larger device model raises L2 audit cost. |
+
+**Tier discipline**: Tier 1 is the production default and the only
+tier that carries the *full* ADR-002 promise. Tier 2 carries six of
+the seven claims with claim 3 (verified boot) tracked as a follow-up
+once verified-boot lands for VZ/HVF. Tier 3 (Docker) carries only the
+supply-chain and guest-agent claims; the L1–L3 isolation collapses to
+the host kernel. Plan 53 §"Security posture decision" documents *why*
+we keep Docker available but unpromoted — the convenience is real,
+but we refuse to launder a container as a microVM in marketing or in
+auto-selected defaults.
+
+`mvmctl doctor` (plan 40 folded the standalone `security` verb into
+doctor) renders this matrix per-host with the active backend
+highlighted and prints a loud `MVM_ACK_DOCKER_TIER`-suppressible
+warning banner whenever Tier 3 is auto-selected.
+
 ## Consequences
 
 ### Positive
@@ -188,7 +289,13 @@ uid because of a use case we didn't foresee):
 ## References
 
 - Plan: `specs/plans/25-microvm-hardening.md`
+- Plan: `specs/plans/53-cross-platform-roadmap.md` (per-backend tier discipline)
 - Related ADRs: `001-multi-backend.md`, `public/.../adr/001-firecracker-only.md`
+- User-facing version of the layer model: `public/src/content/docs/security/matryoshka.md`
 - Surface enumeration came from this session's audit; the seven
   numbered "additional surfaces" beyond the eight in the existing
   posture document are folded into the table above.
+- The "matryoshka" framing draws on the 2026 microVM ecosystem
+  discourse (e.g. <https://emirb.github.io/blog/microvm-2026/>);
+  the same defense-in-depth pattern is used by Fly.io Sprites,
+  AWS Lambda SnapStart, E2B, Vercel Sandbox, and Kata Containers.

--- a/specs/plans/25-microvm-hardening.md
+++ b/specs/plans/25-microvm-hardening.md
@@ -39,6 +39,23 @@ We protect against three adversaries, in order of priority:
 Out of scope for this plan: a fully malicious *host* (mvmctl trusts the
 host completely; the host runs the hypervisor, holds private keys, etc.).
 
+## Layer mapping (added 2026-05-07)
+
+ADR-002's 2026-05-07 revision frames the seven CI-enforced claims
+around a five-layer trust model (the "Matryoshka model"). This plan's
+W1–W6 workstreams map onto layers as follows; see
+`specs/adrs/002-microvm-security-posture.md` §"Trust layers" for the
+full diagram and per-backend tier matrix.
+
+| Workstream | Primary layer(s) defended | Claims |
+|---|---|---|
+| W1 — Cheap defaults | L2 (proxy socket, port allowlist), cross-cutting | 1 (W1.1), supports 5 |
+| W2 — Defense in depth inside the VM | L4, L5 | 1 (W2.1, W2.3, W2.4), 2 (W2.2, W2.3) |
+| W3 — Verified boot | L3 | 3 |
+| W4 — Guest agent attack surface | L4 | 4 (W4.3), 5 (W4.1, W4.2) |
+| W5 — Supply chain | cross-cutting | 6 (W5.1), 7 (W5.2, W5.3) |
+| W6 — Documentation and CI gates | meta — gates the other layers | enforces 1–7 |
+
 ## Workstreams
 
 Each item is independently shippable. Numbering is execution order.

--- a/specs/plans/53-cross-platform-roadmap.md
+++ b/specs/plans/53-cross-platform-roadmap.md
@@ -1,0 +1,519 @@
+# Plan 53 — Cross-platform release roadmap (Option B — Pragmatic)
+
+## Summary
+
+mvm currently ships fully on Linux + KVM (Firecracker) and macOS 26+ Apple Silicon (Apple Container, see plan 23). Older macOS, Intel Macs, and Windows hosts are second-class today. This plan turns that into a coherent multi-platform release without forking the project's security narrative.
+
+The decision recorded here is **Option B — Pragmatic**: keep Firecracker as the unambiguous security baseline, add **libkrun** as a fourth backend (Intel Mac + macOS-no-Lima + Linux native option with Firecracker-comparable TCB), keep Docker as a clearly-marked Tier 3 with a loud `MVM_ACK_DOCKER_TIER`-suppressible warning, and treat Windows as a real first-class consumer of the WSL2 path with bootstrap automation. Cloud Hypervisor and the native-Windows microVM path (CH+WHPX) are **explicitly rejected** for now because they would fork the security narrative; the rationale lives in Plan F below so it doesn't have to be re-derived.
+
+The roadmap is sized at roughly three sprints of work (foundation → macOS parity + Windows foundation → libkrun + Windows installer). Each numbered Plan A–K has goal, files, phases, tests, risks, and effort. Plans F, G, H are deferred-with-rationale backlog placeholders.
+
+## Per-platform reality after this roadmap
+
+- **Linux + KVM** — Firecracker direct. Tier 1, full ADR-002 guarantees.
+- **Linux without KVM** — Docker fallback (loud warning).
+- **macOS 26+ Apple Silicon** — Apple Container or libkrun. Choose Apple Container for tightest VZ integration (plan 23); libkrun for a no-Lima single-binary path.
+- **macOS <26 / Intel Mac** — libkrun (new). Today these users are stuck on Lima + Firecracker; libkrun gives them a real native path.
+- **WSL2** — works as Linux; Firecracker if nested KVM available, Docker otherwise.
+- **Native Windows** — WSL2 setup is the supported path with first-class bootstrap automation. Users without WSL2 see a clear "install WSL2" message; the Docker backend is reachable but not promoted.
+
+## What "microVM" means in this codebase (after roadmap)
+
+| Backend | Hardware iso? | vsock? | Snapshots? | Verified boot? |
+|---|---|---|---|---|
+| Firecracker | Yes (KVM) | Yes | Yes | Yes (W3) |
+| Apple Container | Yes (VZ) | Yes | No | No |
+| **libkrun (planned)** | Yes (KVM on Linux, Hypervisor.framework on macOS) | Yes | No | No |
+| Docker | No (shared kernel) | No (unix socket) | No | No |
+| microvm.nix (QEMU) | Yes (KVM) | Yes | No | Partial |
+
+The seven ADR-002 security claims apply *fully* to Firecracker and *partially* (no W3 verified boot) to Apple Container and libkrun. They mostly **do not apply** to Docker. Plans A and B make this legible to users.
+
+## Security posture decision
+
+We considered three options:
+
+- **Strict** — Firecracker + Apple Container only. No new backends. Windows = WSL2 docs only.
+- **Pragmatic (chosen)** — Firecracker + Apple Container + libkrun. Docker stays as Tier 3 fallback with loud warnings, not promoted. Windows = WSL2-first with bootstrap automation.
+- **Permissive** — Add Cloud Hypervisor for DinD/GPU/Windows-guests. Promote Docker to first-class Windows path with pre-built images and `mvmctl pull`. Long-term native-Windows microVMs via CH+WHPX.
+
+**Why we rejected Permissive**: every advantage we'd ship by adding Cloud Hypervisor is a feature Firecracker deliberately excluded for attack-surface reasons (nested KVM, GPU passthrough, larger device model, Windows-guest paths). CH is ~106K LOC vs Firecracker's ~83K. Adding it forks the security narrative — "Firecracker is the secure default, but you can opt into a larger-TCB VMM" is a different project than "we use Firecracker because microVM isolation comes from minimalism." Same logic for promoting Docker to first-class on Windows: the `mvmctl pull` + pre-built-image story would pull Tier 3 into the user's default expectations. We avoid that fork.
+
+**Why we rejected Strict**: it leaves Intel Mac users with no path other than Lima, and ignores a strictly-additive opportunity (libkrun has comparable TCB to Firecracker, runs on Hypervisor.framework on both Mac architectures, and is library-style so the binary is self-contained). Strict was the safer narrative choice but Pragmatic is materially better DX for the same posture.
+
+**The fork test we apply going forward**: any new backend or feature must satisfy "do the seven claims still hold (or partially hold with named exceptions) without changing Firecracker's role as the security baseline?" Cloud Hypervisor fails this test today; libkrun passes (smaller TCB, no Firecracker-excluded features); Docker passes only as an explicit Tier 3.
+
+## Lessons from prior art (condensed)
+
+- **SlicerVM landed on the same architecture we're heading toward**: Firecracker on Linux + Apple VZ on macOS + WSL2-only Windows + APFS CoW for macOS templates. They added Cloud Hypervisor for GPU passthrough; we're not following them there.
+- **The emirb 2026 microVM blog post** (https://emirb.github.io/blog/microvm-2026/) argues containers aren't a security boundary, with seven 2024–2025 CVEs as receipts. Plan B's loud Docker-tier warning takes this seriously.
+- **Windows in 2026 is a guest, not a host platform** for microVM tooling. Plan I treats Windows as a first-class consumer of the WSL2 path rather than trying to build a Windows-native microVM stack.
+- **rust-vmm is a foundation, not a backend.** Improving `vm-memory` benefits Firecracker, libkrun, et al. simultaneously. Argues for thin abstraction layers and for picking VMMs that share the foundation (libkrun does).
+
+---
+
+# Implementation plans
+
+Plans are organized by tier. Each plan has: **goal · files · phases · tests · risks · effort**. Plans F, G, H are deferred backlog placeholders.
+
+## Plan A — Matryoshka ADR rewrite
+
+**Goal**: Restructure ADR-002 around a 5-layer trust model. Map the seven CI-enforced claims onto layers. Add a per-backend tier matrix that makes the Docker-tier security collapse visible at a glance.
+
+**Files**:
+- `specs/adrs/002-microvm-security-posture.md` — restructure (in-place update)
+- `public/src/content/docs/security/matryoshka.md` (new) — user-facing version
+- `specs/plans/25-microvm-hardening.md` — cross-references from W1–W6 to layer numbers
+
+**Layer model**:
+
+| Layer | Description | What's at this layer in mvm |
+|---|---|---|
+| L1 | Host + hypervisor | macOS + VZ, Linux + KVM, libkrun's KVM/HVF |
+| L2 | VMM (userspace) | Firecracker (~83K LOC Rust, seccomp-jailed), Containerization, libkrun |
+| L3 | Guest kernel | Custom Linux from Nix; dm-verity'd rootfs (Firecracker only today) |
+| L4 | Guest agent | uid 901 under setpriv, no_new_privs |
+| L5 | Workload | Per-service uid, bounding-set drop, seccomp tier `standard` |
+
+**Claim → layer mapping** (using ADR-002's existing claim numbers):
+- L1: enables 3 (verified boot precondition)
+- L2: 1 (no host-fs leak), 2 (no uid-0 escape via VMM), 5 (vsock framing fuzzed — host parser)
+- L3: 3 (verified boot, dm-verity)
+- L4: 4 (no `do_exec` in prod), 5 (guest framing too)
+- L5: 1 extends here via per-service uid (W2.1)
+- Cross-cutting: 6 (image hash), 7 (cargo deps audit)
+
+**Per-backend tier matrix**:
+
+| Backend | L1 | L2 | L3 | L4 | L5 | Notes |
+|---|---|---|---|---|---|---|
+| Firecracker (Linux+KVM) | ✅ | ✅ | ✅ | ✅ | ✅ | Full ADR-002 |
+| Apple Container | ✅ | ✅ | ⚠️ | ✅ | ✅ | No verified boot yet |
+| libkrun | ✅ | ✅ | ⚠️ | ✅ | ✅ | No verified boot yet; comparable TCB to FC |
+| Docker | ❌ | ❌ | ❌ | ✅ | ✅ | L1–L3 collapse to host kernel; **Tier 3 only** |
+| microvm.nix (QEMU) | ✅ | ⚠️ | ⚠️ | ✅ | ✅ | QEMU TCB much larger; partial verified boot |
+
+**Phases**:
+1. Draft layer diagram and write claim → layer mapping table.
+2. Build per-backend matrix.
+3. Update plan 25 to reference layers alongside W1–W6.
+4. Mirror to user-facing docs.
+5. Cross-link from ADR-001 (multi-backend).
+
+**Tests / verification**:
+- Every claim 1–7 appears in the mapping.
+- Every backend in `AnyBackend` appears in the matrix.
+
+**Risk**: Authoring only.
+
+**Effort**: 1–2 days.
+
+---
+
+## Plan B — Doctor security-claims-by-tier output
+
+**Goal**: `mvmctl doctor` and `mvmctl run` surface the active backend's security profile. Loud, suppressible warning when Docker tier is auto-selected.
+
+**Files**:
+- `crates/mvm-core/src/protocol/vm_backend.rs` — add `BackendSecurityProfile`, `ClaimStatus`, `LayerCoverage`
+- `crates/mvm-runtime/src/vm/{firecracker,apple_container,docker,microvm_nix}.rs` — implement `security_profile()` per backend
+- `crates/mvm-runtime/src/vm/backend.rs` — `AnyBackend::security_profile()` dispatch
+- `crates/mvm-cli/src/doctor.rs` — render new "Security posture (active backend)" section
+- `crates/mvm-cli/src/commands/vm/up.rs` — startup banner when Docker tier selected
+- `crates/mvm-core/src/user_config.rs` — add `[security] ack_docker_tier = bool`
+
+**API**:
+```rust
+pub struct BackendSecurityProfile {
+    pub claims: [ClaimStatus; 7],
+    pub layer_coverage: LayerCoverage,
+    pub notes: &'static [&'static str],
+}
+
+pub enum ClaimStatus { Holds, DoesNotApply, DoesNotHold }
+
+pub struct LayerCoverage { l1_host_hypervisor: bool, l2_vmm: bool, l3_guest_kernel: bool, l4_guest_agent: bool, l5_workload: bool }
+```
+
+**Per-backend declarations**:
+- Firecracker: all `Holds`, all layers true.
+- AppleContainer / libkrun: claim 3 = `DoesNotHold` (no verified boot yet), all others `Holds`, all layers true.
+- Docker: claims 1/2/3 = `DoesNotHold`, claim 5 = `DoesNotApply` (unix socket), 4/6/7 = `Holds`. L1/L2/L3 = false.
+- microvm.nix: claim 3 = `DoesNotHold` until verified boot lands for QEMU path.
+
+**Doctor output sketch (Docker case)**:
+```
+Active backend: docker (auto-selected; KVM unavailable)
+
+⚠️  SECURITY POSTURE: Docker tier — reduced isolation
+   Container isolation, not hardware-isolated microVMs.
+   Layer coverage: L1 ✗  L2 ✗  L3 ✗  L4 ✓  L5 ✓
+   Claims that DO NOT hold: 1, 2, 3
+   Recent container-escape CVEs (2024–2025):
+     CVE-2024-21626, CVE-2024-1753, CVE-2025-9074,
+     CVE-2025-23266, CVE-2025-31133, CVE-2025-52565
+   Acknowledge with MVM_ACK_DOCKER_TIER=1 to silence this banner.
+```
+
+**Phases**:
+1. Add types in `mvm-core`.
+2. Implement `security_profile()` for each backend.
+3. Wire dispatch through `AnyBackend`.
+4. Doctor renderer + JSON output extension.
+5. `mvmctl run` startup banner with `MVM_ACK_DOCKER_TIER` ack.
+6. Tests.
+
+**Tests**:
+- `vm_backend::tests::profile_serializes_correctly`
+- `firecracker::tests::profile_holds_all_claims`
+- `docker::tests::profile_drops_l1_l3_claims`
+- Integration: `mvmctl doctor` text + `--json` output.
+- CLI: `mvmctl run --hypervisor docker` (mocked) emits banner; `MVM_ACK_DOCKER_TIER=1` suppresses it.
+
+**Risk**: Subjective claim-status calls. Mitigation: rationale in `notes` field per backend.
+
+**Effort**: 1 day. **Sequence**: after Plan A.
+
+---
+
+## Plan C — PVM FAQ entry
+
+**Goal**: Users hitting "no `/dev/kvm`" know their options without re-discovering the landscape.
+
+**Files**:
+- `public/src/content/docs/guides/troubleshooting.md` — new section "No /dev/kvm available."
+- `crates/mvm-cli/src/doctor.rs` — link from KVM-fail message.
+
+**Content** (~200 words):
+> **No `/dev/kvm` on your cloud VM?** Three options.
+> 1. **Switch to a nested-virt instance.** AWS C8i/M8i/R8i (Feb 2026), GCE n2 nested, Azure Dasv5/Easv5 — these expose `/dev/kvm` and Firecracker runs natively.
+> 2. **Use Tier 3 Docker fallback.** Works in any environment with Docker. **Reduced security tier** — see Matryoshka model. Use only for non-security-sensitive workloads.
+> 3. **PVM (advanced, external).** [SlicerVM's PVM mode](https://docs.slicervm.com/tasks/pvm/) runs real microVMs without `/dev/kvm` via a patched Firecracker + kernel module. mvm doesn't ship this.
+
+**Effort**: 1 hour.
+
+---
+
+## Plan D — APFS CoW for Apple Container templates
+
+**Goal**: `mvmctl run --template foo` on macOS Apple Container starts in <1s by `clonefile(2)`-ing the template's `rootfs.ext4` instead of copying. Side benefit: opportunistic Linux reflinks on btrfs/xfs/overlayfs.
+
+**Files**:
+- `crates/mvm-runtime/src/vm/cow.rs` (new) — `reflink_or_err`, `reflink_or_copy`
+- `crates/mvm-runtime/src/vm/template/lifecycle.rs` — add `template_clone_for_instance(template_id, instance_dir) -> Result<CloneStrategy>`
+- `crates/mvm-runtime/src/vm/apple_container.rs` — call clone in `start()` before pointing VZ at the disk
+- `crates/mvm-runtime/src/vm/firecracker.rs` — opportunistic clone on Linux
+- `crates/mvm-runtime/src/vm/mod.rs` — export `cow` module
+- `crates/mvm-runtime/Cargo.toml` — `libc.workspace = true` already present; no new deps
+
+**API**:
+```rust
+pub enum CloneStrategy { Reflink, Copied }
+pub fn reflink_or_err(src: &Path, dst: &Path) -> io::Result<()>;
+pub fn reflink_or_copy(src: &Path, dst: &Path) -> io::Result<CloneStrategy>;
+```
+
+**Implementation notes**:
+- macOS: `libc::clonefile(src.as_ptr(), dst.as_ptr(), 0)` under `#[cfg(target_os = "macos")]`.
+- Linux: `ioctl(dst_fd, FICLONE, src_fd)` under `#[cfg(target_os = "linux")]`. Returns `EOPNOTSUPP` on non-reflink filesystems.
+- Other OSes: unconditional `Err(EOPNOTSUPP)`.
+
+**Boot path on Apple Container**:
+1. `start()` resolves template's `rootfs.ext4` path.
+2. `reflink_or_copy(template/rootfs.ext4, instance/rootfs.ext4)`.
+3. Pass `instance/rootfs.ext4` to `VZDiskImageStorageDeviceAttachment(writable: true)`.
+4. On instance stop, delete `instance/rootfs.ext4`. Template stays pristine.
+
+**Phases**:
+1. **Spike**: standalone POC clonefile-ing a 1GB ext4 + booting it in VZ. Confirm VZ tolerance, single-volume requirement, ext4 UUID handling.
+2. Add `cow.rs` with primitives + tests.
+3. Add `template_clone_for_instance()` in `lifecycle.rs`.
+4. Wire into Apple Container backend.
+5. Wire into Firecracker backend (opportunistic).
+6. Tests + integration.
+
+**Tests**:
+- Unit: `cow::tests::clonefile_macos_creates_o1_clone` (cfg-gated; assert <100ms for 1GB).
+- Unit: `cow::tests::ficlone_linux_with_supporting_fs` (skipped if FS doesn't support).
+- Integration: build template, run, assert wall-clock <1s, assert template `rootfs.ext4` mtime unchanged after instance writes.
+- Stress: 5 concurrent `mvmctl run --template foo` → all start, disk usage barely grows.
+
+**Risks**:
+1. **VZ tolerance** — confirm in spike.
+2. **Single-volume requirement** — APFS CoW only within the same volume. Document `~/.mvm` placement.
+3. **ext4 UUID collisions** — multiple instances with same UUID may confuse mount/systemd. Mitigation: `tune2fs -U random` after clone, or audit boot path.
+4. **Linux reflink coverage** — ext4 needs explicit support; btrfs/xfs work. Lima's ext4 limits Linux benefit.
+
+**Effort**: 2–4 days spike + integration; +2 days for Linux opportunistic path; +1 day for tests/docs.
+
+---
+
+## Plan E — libkrun backend
+
+**Goal**: Add libkrun as a 4th backend in `AnyBackend`. Adds Intel Mac support (Apple VZ doesn't), removes Lima from the macOS runtime hot path entirely (libkrun is library-style), and provides a Linux native option with TCB comparable to Firecracker.
+
+**Why libkrun specifically**: Only VMM in our consideration set that runs on Linux (KVM), macOS Apple Silicon (Hypervisor.framework), **and macOS Intel** (Hypervisor.framework). Library-style — links into our binary — so no separate VMM process. Used in production by Microsandbox. Apache-2.0. **Passes our fork test**: comparable TCB to Firecracker, no Firecracker-excluded features.
+
+**Files**:
+- `crates/mvm-libkrun/` (new crate)
+  - `Cargo.toml` — bindgen build dep
+  - `build.rs` — generate Rust bindings from `libkrun.h`
+  - `src/lib.rs` — safe wrapper over the unsafe bindings
+  - `src/{macos,linux}.rs` — platform-specific glue
+- `crates/mvm-runtime/src/vm/libkrun.rs` (new) — `LibkrunBackend` impl
+- `crates/mvm-runtime/src/vm/backend.rs` — add `Libkrun(LibkrunBackend)` variant + `auto_select` rules
+- `crates/mvm-cli/src/commands/vm/up.rs` — `--hypervisor libkrun` value
+- `crates/mvm-core/src/platform/platform.rs` — `has_libkrun()` detection
+- `nix/` — Nix derivation for libkrun
+- `crates/mvm-cli/src/bootstrap.rs` — install libkrun (Homebrew on macOS, distro pkg/binary on Linux)
+- `crates/mvm-cli/src/doctor.rs` — libkrun availability check
+
+**API surface** (safe wrapper):
+```rust
+pub struct KrunContext { /* opaque handle */ }
+
+impl KrunContext {
+    pub fn new(name: &str) -> Result<Self>;
+    pub fn set_vm_config(&mut self, vcpus: u8, ram_mib: u32) -> Result<()>;
+    pub fn set_root_disk(&mut self, path: &Path) -> Result<()>;
+    pub fn set_kernel(&mut self, path: &Path, cmdline: &str) -> Result<()>;
+    pub fn add_vsock_port(&mut self, port: u32, path: &Path) -> Result<()>;
+    pub fn start(self) -> Result<KrunHandle>;
+}
+```
+
+**Phases**:
+1. **Spike** — boot a minimal Nix-built ext4 rootfs in libkrun on macOS Apple Silicon. Confirm vsock + console + Nix kernel compatibility.
+2. **`mvm-libkrun` crate** — bindgen + safe wrapper. Single platform first.
+3. **Cross-platform expansion** — Linux + macOS Intel boot paths.
+4. **`LibkrunBackend`** — implements `VmBackend` with `VmCapabilities { snapshots: false, vsock: true, pause_resume: false, tap_networking: false }` and `BackendSecurityProfile` mirroring Apple Container (claim 3 = DoesNotHold).
+5. **AnyBackend dispatch** — add variant, update `auto_select`: KVM-Linux → AppleContainer → libkrun → Docker → Firecracker-via-Lima.
+6. **Bootstrap install + doctor check.**
+7. **Tests** — bindings safety, lifecycle, vsock, parity with Firecracker for golden-path workloads.
+8. **Docs** — when to choose libkrun vs Apple Container vs Firecracker; Intel-Mac story; macOS-no-Lima story.
+
+**Decision points the spike must resolve**:
+- Does our Nix-built kernel boot in libkrun? (Should: similar minimal config to Firecracker.)
+- Does the guest agent run unchanged? (vsock should be transparent.)
+- Codesigning: does libkrun need `com.apple.security.hypervisor` entitlement that mvmctl doesn't have today?
+
+**Tests**:
+- `mvm_libkrun::tests::context_lifecycle`
+- `LibkrunBackend::tests::profile_holds_most_claims`
+- Integration: `mvmctl run --hypervisor libkrun --flake examples/minimal` boots, vsock health check responds.
+- CI lanes: macOS-arm64, macOS-x86_64, Linux-x86_64.
+
+**Risks**:
+1. **C library binding complexity** — bindgen-generated unsafe Rust. Mitigation: small surface.
+2. **Hypervisor.framework lower-level than VZ** — Apple may break ABI between macOS releases. Mitigation: pin libkrun version; CI on multiple macOS versions.
+3. **Codesigning entitlement** — investigate during spike; if blocking, document as macOS-Apple-Silicon-only initially.
+4. **Build path still needs Linux** — libkrun solves runtime only; Lima stays for Nix builds on macOS. Tracked as future work.
+
+**Effort**: 1–1.5 sprints. Spike (3 days) + crate + backend (1 week) + bootstrap/doctor/docs (3 days).
+
+---
+
+## Plan F — Cloud Hypervisor backend (rejected — backlog placeholder)
+
+**Status**: Considered and **rejected** for security-posture reasons. The full rationale is captured here so it doesn't have to be re-derived. A separate placeholder file at `specs/plans/54-cloud-hypervisor-deferred.md` should mirror this section once Sprint 1 lands.
+
+**Why rejected**: Cloud Hypervisor's value proposition — nested KVM inside guests, GPU passthrough, larger device model, Windows-guest support — is exactly the set of features Firecracker excluded for attack-surface reasons. Adding CH would fork our security narrative ("Firecracker for security, CH if you need the extra features"). We'd rather keep Firecracker as the unambiguous secure baseline.
+
+**Trigger conditions to revisit**:
+- A user demonstrates a need that *cannot* be satisfied by Firecracker, libkrun, or Apple Container, AND
+- We're prepared to update ADR-002 to acknowledge a forked security model with explicit "use CH only when X" guidance.
+
+Both conditions must hold. The first alone is not enough.
+
+**Effort if pulled**: ~1 sprint to implement, plus ADR-002 update.
+
+---
+
+## Plan G — crosvm backend (deferred backlog placeholder)
+
+**Status**: Considered and deferred. Crosvm is Google's KVM-based VMM, primarily targeting Chrome OS and the Android emulator. Mature but niche for our user base. libkrun (Plan E) covers the "embeddable cross-platform" niche we care about.
+
+A separate placeholder file at `specs/plans/55-crosvm-deferred.md` should mirror this once Sprint 1 lands.
+
+**Trigger conditions**: Real user demand for Chrome OS host or Android-workload guest support.
+
+**Effort if pulled**: ~1 sprint.
+
+---
+
+## Plan H — rust-vmm internalization (deferred backlog placeholder)
+
+**Status**: Considered and rejected for now. Composing rust-vmm crates into a working VMM is *building a VMM* — that's Firecracker's and libkrun's job, not ours. The shell-out approach has costs (process boundary, requires `firecracker` binary on PATH) but the boundary is also a feature: a Firecracker lifecycle bug doesn't crash mvmctl.
+
+A separate placeholder file at `specs/plans/56-rust-vmm-internalization-deferred.md` should mirror this once Sprint 1 lands.
+
+**Trigger conditions**: We need a custom VMM with an mvm-specific isolation property no upstream offers. (Plan E — libkrun — addresses the "single binary, no external dependency" pull factor.)
+
+---
+
+## Plan I — Windows community support (WSL2-first)
+
+**Goal**: Windows users have a real, supported, well-documented path: WSL2 with mvm-aware bootstrap automation, native installer, dedicated docs, and a working CI lane. Docker remains reachable as Tier 3 but is *not* promoted to a first-class Windows path — users without WSL2 see "install WSL2" as the recommended answer.
+
+**What we're explicitly NOT doing** (and why):
+- **Pre-built rootfs distribution from CI for Docker tier consumption** — would elevate Docker (Tier 3, no microVM isolation) to a first-class Windows experience and pull container-tier workloads into the user's default expectations. Conflicts with our security posture.
+- **Cloud Hypervisor + WHPX exploration for native-Windows microVMs** — depends on Plan F which we rejected.
+
+**Files**:
+- `crates/mvm-cli/src/bootstrap.rs` — Windows-aware bootstrap detects WSL2 availability, offers to install it, installs mvm in the distro
+- `.github/workflows/windows.yml` (new) — Windows CI lane
+- `installer/winget/` (new) — winget package manifest
+- `public/src/content/docs/install/windows.md` (new) — top-level Windows install guide (WSL2-first)
+- `public/src/content/docs/guides/windows-wsl2.md` (new) — WSL2 walkthrough
+- `public/src/content/docs/guides/windows-troubleshooting.md` (new)
+
+**Phases** (each independently shippable):
+
+**Phase I.1 — Windows CI lane**
+- Goal: `cargo build --workspace` and `cargo test -p mvm-core` green on Windows.
+- Implementation: GitHub Actions Windows runner, audit `cfg(target_os = "windows")` across the codebase, fix unconditional unix-isms. Workspace gates `mvm-apple-container` via `[target.'cfg(target_os = "macos")'.dependencies]` (plan 20 specifies this; verify).
+- Tests: green CI lane.
+- Effort: 2–3 days.
+
+**Phase I.2 — Windows install docs (WSL2-first)**
+- Goal: One clear primary path (WSL2) with a small "alternative tiers" section.
+- Content:
+  - **Quickstart**: install WSL2 + Ubuntu, install mvm in the distro. Full Tier 1 isolation if WSL2 has nested KVM.
+  - **Alternative**: Docker tier (with explicit "no microVM isolation" caveat).
+  - **Troubleshooting**: nested-virt detection, BIOS settings, common errors.
+- Effort: 1 day.
+
+**Phase I.3 — winget manifest**
+- Goal: `winget install mvm` works.
+- Implementation: winget manifest pointing to GitHub release artifact (`mvmctl.exe` from Phase I.1). Initial version is unsigned standalone exe; signed MSI is a future enhancement.
+- Effort: half day.
+
+**Phase I.4 — WSL2 bootstrap automation**
+- Goal: `mvmctl bootstrap` on Windows host detects whether WSL2 is configured, offers to install Ubuntu + mvm in the distro, sets up shared `~/.mvm`.
+- Implementation: Windows-only branch in `bootstrap.rs` shells out to `wsl --install`, then `wsl -d Ubuntu` to install mvm inside.
+- Tests: manual Windows test (CI is hard for WSL2 setup).
+- Effort: 2 days.
+
+**Risks**:
+1. **CI cost** — Windows runners are slower. Mitigation: PR-only on Windows-relevant files; full matrix on main.
+2. **WSL2 setup variance** — distros and Windows versions vary. Mitigation: support Ubuntu 24.04 LTS only initially.
+3. **MSI signing cost** — proper Windows installer needs a code-signing cert (~$300/yr). Mitigation: ship unsigned standalone exe via winget initially.
+
+**Effort**: 5–6 days total across all four phases.
+
+---
+
+## Plan J — AWS deployment guide
+
+**Goal**: Clear instructions for running mvm on AWS EC2 with nested virt (mostly C8i/M8i/R8i families, Feb 2026+).
+
+**Files**:
+- `public/src/content/docs/deploy/aws.md` (new)
+
+**Content** (~500 words): instance types with nested KVM (e.g. `c8i.4xlarge` ≈ $0.86/hr Frankfurt), bootstrap commands for Ubuntu 24.04 / AL2023, IAM (probably none), EBS sizing, security groups (none needed for vsock loopback), tip about AWS Bedrock AgentCore using Firecracker too.
+
+**Effort**: half day.
+
+---
+
+## Plan K — Ubicloud deployment guide
+
+**Goal**: Show how to run mvm on Ubicloud bare-metal.
+
+**Files**:
+- `public/src/content/docs/deploy/ubicloud.md` (new)
+
+**Content** (~400 words): What Ubicloud is (open-source cloud, AGPL — note license implications), provisioning, installing mvm, trade-offs vs AWS.
+
+**Effort**: half day.
+
+---
+
+# Sequencing recommendation
+
+Roughly **3 sprints of work**, sequenced by risk × payoff:
+
+### Sprint 1 — Foundation (~5 days)
+**Theme: narrative + UX, zero arch risk, immediate marketability.**
+- Plan A — Matryoshka ADR rewrite (1–2 days)
+- Plan B — Doctor security-claims-by-tier (1 day)
+- Plan C — PVM FAQ entry (1 hour)
+- Plan J — AWS deployment guide (half day)
+- Plan K — Ubicloud deployment guide (half day)
+- Plan F — CH rejection placeholder file (1 hour)
+- Plan G — crosvm deferred placeholder file (1 hour)
+- Plan H — rust-vmm deferred placeholder file (1 hour)
+
+**Outcome**: cohesive security narrative, honest UX for Tier 3 Docker, deployment guides, full backlog rationale paper trail.
+
+### Sprint 2 — macOS parity + Windows foundation (~1 sprint)
+**Theme: close the macOS UX gap; lay the Windows community foundation.**
+- Plan D — APFS CoW for Apple Container templates (~5 days)
+- Plan I.1 — Windows CI lane (parallel, ~3 days)
+- Plan I.2 — Windows install docs (parallel, 1 day)
+
+**Outcome**: macOS templates feel as fast as Linux; Windows CI green; Windows users have real install docs.
+
+### Sprint 3 — libkrun + Windows installer (~1.5 sprints)
+**Theme: Intel Mac support + macOS-no-Lima + native Windows install path.**
+- Plan E — libkrun backend (full sprint + buffer)
+- Plan I.3 — winget manifest (parallel, half day)
+- Plan I.4 — WSL2 bootstrap automation (parallel, 2 days)
+
+**Outcome**: Intel Mac users have a real path; Windows users `winget install mvm` and get guided WSL2 setup.
+
+### Backlog (no scheduled work; rationale documented)
+- Plan F — Cloud Hypervisor (rejected for posture reasons)
+- Plan G — crosvm (deferred; trigger: Chrome OS / Android demand)
+- Plan H — rust-vmm internalization (deferred; trigger: custom-VMM-required feature)
+
+---
+
+# Critical files referenced
+
+| File | Plans that touch it |
+|---|---|
+| `crates/mvm-core/src/protocol/vm_backend.rs` | B (security profile) |
+| `crates/mvm-core/src/platform/platform.rs` | E (has_libkrun), I (Windows detection) |
+| `crates/mvm-runtime/src/vm/backend.rs` | E (new variant), B (profile dispatch) |
+| `crates/mvm-runtime/src/vm/{firecracker,apple_container,docker,microvm_nix}.rs` | B (security profiles), D (CoW for FC + AC) |
+| `crates/mvm-runtime/src/vm/cow.rs` (new) | D |
+| `crates/mvm-runtime/src/vm/template/lifecycle.rs` | D |
+| `crates/mvm-runtime/src/vm/libkrun.rs` (new) | E |
+| `crates/mvm-libkrun/` (new crate) | E |
+| `crates/mvm-cli/src/commands/vm/up.rs` | B (banner), E (CLI flag) |
+| `crates/mvm-cli/src/doctor.rs` | B (security section), C (KVM-fail link), E (libkrun check) |
+| `crates/mvm-cli/src/bootstrap.rs` | E (libkrun install), I.4 (WSL2 automation) |
+| `specs/adrs/002-microvm-security-posture.md` | A |
+| `specs/plans/{25,54,55,56}-*.md` | A (cross-refs); F, G, H placeholders |
+| `public/src/content/docs/security/matryoshka.md` (new) | A |
+| `public/src/content/docs/install/windows.md` (new) | I.2 |
+| `public/src/content/docs/guides/windows-{wsl2,troubleshooting}.md` (new) | I.2 |
+| `public/src/content/docs/deploy/{aws,ubicloud}.md` (new) | J, K |
+| `public/src/content/docs/guides/troubleshooting.md` | C |
+| `.github/workflows/windows.yml` (new) | I.1 |
+| `installer/winget/` (new) | I.3 |
+
+# End-to-end verification (post-Sprint-3)
+
+- `cargo test --workspace` green on Linux + macOS-arm64 + macOS-x86_64 + Windows.
+- `cargo clippy --workspace -- -D warnings` zero warnings on all four.
+- `mvmctl doctor` on each platform reports correct active backend, security profile, and (Docker tier only) the warning banner.
+- `mvmctl run --hypervisor firecracker` on Linux + KVM: works, full ADR-002 claims hold.
+- `mvmctl run --hypervisor apple-container` on macOS 26+ Apple Silicon: works, ~700ms cold start.
+- `mvmctl run --hypervisor libkrun` on Linux + KVM: works.
+- `mvmctl run --hypervisor libkrun` on macOS Apple Silicon: works without Lima.
+- `mvmctl run --hypervisor libkrun` on macOS Intel: works without Lima.
+- `mvmctl run --template foo --hypervisor apple-container`: cold start <1s via APFS CoW.
+- Windows + WSL2: `winget install mvm` → `mvmctl bootstrap` configures WSL2 distro with mvm + Firecracker; full Tier 1 isolation when nested KVM available.
+- ADR-002 displays the layer model + per-backend tier matrix; user-facing security doc mirrors it.
+
+## References
+
+- ADR-001 (multi-backend execution): `public/src/content/docs/contributing/adr/001-multi-backend.md`
+- ADR-002 (microVM security posture): `specs/adrs/002-microvm-security-posture.md`
+- Plan 20 (multi-backend abstraction): `specs/plans/20-multi-backend-abstraction.md`
+- Plan 23 (Apple Container dev): `specs/plans/23-apple-container-dev.md`
+- Plan 25 (microVM hardening): `specs/plans/25-microvm-hardening.md`
+- SlicerVM PVM mode: https://docs.slicervm.com/tasks/pvm/
+- "Your Container Is Not a Sandbox" (emirb 2026): https://emirb.github.io/blog/microvm-2026/

--- a/specs/plans/54-cloud-hypervisor-deferred.md
+++ b/specs/plans/54-cloud-hypervisor-deferred.md
@@ -1,0 +1,64 @@
+# Plan 54 — Cloud Hypervisor backend (deferred — rejected for posture reasons)
+
+> Status: deferred
+> Decision recorded: 2026-05-07 (plan 53)
+> Trigger to revisit: see "Trigger conditions" below
+
+## Why this plan exists
+
+Plan 53 (cross-platform roadmap) considered Cloud Hypervisor (CH) as a fifth backend in `AnyBackend`. After weighing the security tradeoffs, we **rejected** it. This file documents the rationale so a future contributor or reviewer doesn't have to re-derive the decision.
+
+## What CH would have given us
+
+Cloud Hypervisor is a Rust-based, KVM-on-Linux + WHPX-on-Windows VMM (~106K LOC) maintained by Intel and Microsoft. Adding it would unlock:
+
+- **Nested KVM inside the guest** — Docker-in-Docker, Android emulators, anything that needs `/dev/kvm` from inside an mvm guest.
+- **GPU passthrough** — VFIO devices for ML workloads.
+- **Larger emulated device set** — virtio devices Firecracker doesn't ship.
+- **Windows guest support** — running Windows VMs (not just Linux) inside an mvm-managed VM.
+- **WHPX host on Windows** — a path toward native-Windows microVMs without WSL2.
+
+## Why we rejected it
+
+Every advantage above is a feature **Firecracker deliberately excluded for attack-surface reasons**. The Firecracker team's design philosophy is "remove devices and code paths until you can audit what's left." Cloud Hypervisor's philosophy is broader: "include the features people need for general-purpose virtualization with minimal-spirit defaults." Both are reasonable; they're not the same.
+
+If we shipped CH alongside Firecracker, our security narrative would split:
+
+> *"mvm uses Firecracker for security. If you need DinD or GPU passthrough, you can opt into Cloud Hypervisor — but its TCB is ~28% larger, its device model is ~4× larger, and the seven CI-enforced claims that hold for Firecracker need separate per-claim audits for CH."*
+
+That's a *forked* security story, and it pulls Firecracker's status from "the secure backend" to "the secure-by-default backend, unless you opt out." The forking is what we're avoiding.
+
+The user-facing ADR-002 is built on the premise that *all* in-tree backends carry the seven claims (Tier 1) or document explicit, named exceptions (Tier 2). CH would either need full Tier 1 audit work — which we'd have to redo for each release — or it would land as Tier 2 with claims 1, 2, 3, and 5 marked as "TBD pending CH-specific verification." Neither is appealing.
+
+The cleaner answer is: Firecracker is the security baseline, and any need that pushes outside Firecracker's deliberate exclusions is a sign that mvm isn't the right tool for that workload. Use Cloud Hypervisor directly via `cloud-hypervisor`'s CLI; mvm doesn't try to be a universal VMM frontend.
+
+## Trigger conditions to revisit
+
+Both conditions must hold:
+
+1. **A user demonstrates a need that *cannot* be satisfied by Firecracker, libkrun, or Apple Container.** Examples that would qualify: a security-research workload that requires nested KVM (rare); a GPU-accelerated ML inference workload that can't be served by the host (very rare); a Windows-guest requirement (not in scope for our user base today).
+2. **We're prepared to update ADR-002 to acknowledge a forked security model** with explicit per-claim notes for CH and a `mvmctl doctor` warning whenever the active backend is CH ("Tier 1.5 — six of seven claims hold; claim X is partial because Y").
+
+The first condition alone is not enough — convenience wants are not posture-changing decisions.
+
+## What "implementation if pulled" would look like
+
+For estimation only; not commitments.
+
+- **Files to create**:
+  - `crates/mvm-runtime/src/vm/cloud_hypervisor.rs` — `CloudHypervisorBackend` impl over CH's HTTP-API-over-unix-socket.
+  - `specs/plans/<NN>-cloud-hypervisor-backend.md` — full plan with phases and tests.
+- **Files to modify**:
+  - `crates/mvm-runtime/src/vm/backend.rs` — add `CloudHypervisor` variant + `auto_select` rules.
+  - `crates/mvm-cli/src/commands/vm/up.rs` — `--hypervisor cloud-hypervisor` (alias `chv`).
+  - `crates/mvm-core/src/protocol/vm_backend.rs` — extend `VmCapabilities` with `nested_kvm`, `gpu_passthrough`, `non_linux_guest`.
+  - `crates/mvm-cli/src/bootstrap.rs` — install `cloud-hypervisor` binary (Nix package, distro packages, GitHub release).
+  - `crates/mvm-cli/src/doctor.rs` — CH availability check + posture banner.
+  - `specs/adrs/002-microvm-security-posture.md` — new tier row, per-claim notes for CH.
+- **Effort**: ~1 sprint to implement the backend, plus the ADR update.
+
+## References
+
+- Plan 53 §"Security posture decision" — the fork test.
+- ADR-002 — the seven claims that any new backend must respect.
+- emirb 2026 microVM blog post — *"If yes [DinD/GPU/Windows]: Cloud Hypervisor. If no: Firecracker."* This plan picks "no."

--- a/specs/plans/55-crosvm-deferred.md
+++ b/specs/plans/55-crosvm-deferred.md
@@ -1,0 +1,52 @@
+# Plan 55 — crosvm backend (deferred)
+
+> Status: deferred
+> Decision recorded: 2026-05-07 (plan 53)
+> Trigger to revisit: see "Trigger conditions" below
+
+## Why this plan exists
+
+Plan 53 (cross-platform roadmap) evaluated crosvm as a possible new backend. After weighing the fit against our user base, we **deferred** it. This file documents the assessment so a future contributor doesn't have to redo the analysis.
+
+## What crosvm is
+
+crosvm is Google's KVM-based VMM, written in Rust, BSD-3-Clause licensed, maintained primarily for Chrome OS (where it runs Linux apps via the Crostini container) and the Android emulator (post-QEMU replacement). Like Firecracker and Cloud Hypervisor, it builds on the rust-vmm crate ecosystem (`vm-memory`, `kvm-ioctls`, `virtio-queue`, etc.).
+
+Mature, production-quality, well-tested. No question about whether it works.
+
+## Why we deferred it
+
+Crosvm is a *good* VMM. The question isn't quality; it's whether it solves a problem mvm currently has. Three filters:
+
+1. **Does it cover a host platform we don't already cover?**
+   No. crosvm is KVM-on-Linux only. Plan 53's libkrun (Plan E) covers the cross-platform niche (Linux KVM + macOS Hypervisor.framework), and Firecracker already covers Linux+KVM at Tier 1.
+
+2. **Does it solve a feature gap that Firecracker can't?**
+   Marginal. crosvm has good wayland/audio/GPU virtualization for Chrome OS workloads — none of which mvm targets. Cloud Hypervisor (Plan F, also deferred) covers nested KVM and GPU passthrough more explicitly when those are needed.
+
+3. **Does it have a passionate user base asking for it?**
+   Not today. No issues, no community asks.
+
+Adding crosvm without one of those filters being met means more code to maintain, more CI lanes to keep green, more docs to write — for no measurable gain.
+
+## Trigger conditions to revisit
+
+Any one of these would warrant a re-evaluation:
+
+1. **A user opens an issue specifically requesting crosvm support** (likely tied to a Chrome OS or Android-emulator workload).
+2. **mvm wants to support Chrome OS as a host platform.** crosvm is the canonical VMM there.
+3. **Both Firecracker and libkrun become unmaintained** (extremely unlikely; both have multiple corporate backers).
+
+## What "implementation if pulled" would look like
+
+For estimation only; not commitments.
+
+- **Files**: same shape as Plan F (Cloud Hypervisor) — HTTP-API-over-socket lifecycle wrapper, new `AnyBackend` variant, CLI flag, bootstrap install, doctor check.
+- **Effort**: ~1 sprint.
+- **Security posture**: comparable to Cloud Hypervisor (rust-vmm based, similar TCB size). Would land as Tier 2 with the same per-claim notes as CH if accepted.
+
+## References
+
+- Plan 53 §"Implementation plans → Plan G" — the high-level summary.
+- Plan E (libkrun) — the embeddable cross-platform niche we *did* fill.
+- Plan F (`54-cloud-hypervisor-deferred.md`) — the related "considered, rejected" decision for the feature-rich-VMM niche.

--- a/specs/plans/56-rust-vmm-internalization-deferred.md
+++ b/specs/plans/56-rust-vmm-internalization-deferred.md
@@ -1,0 +1,64 @@
+# Plan 56 — rust-vmm internalization (deferred — rejected for now)
+
+> Status: deferred
+> Decision recorded: 2026-05-07 (plan 53)
+> Trigger to revisit: see "Trigger conditions" below
+
+## Why this plan exists
+
+Plan 53 (cross-platform roadmap) considered replacing our shell-out-to-the-`firecracker`-binary approach with direct linkage to the rust-vmm crate ecosystem. After weighing the costs and the lack of a concrete pull factor, we **rejected** it for now. This file documents the reasoning.
+
+## What "rust-vmm internalization" means
+
+rust-vmm is a collection of Rust crates (`kvm-ioctls`, `vm-memory`, `virtio-queue`, `vhost`, `linux-loader`, `vfio-ioctls`, `vm-superio`, etc.) that VMMs are built from. Firecracker, Cloud Hypervisor, libkrun, crosvm, and Dragonball all share these crates. An improvement to `vm-memory` (e.g. Kani formal verification, IOMMU support, guest_memfd) benefits all of them simultaneously.
+
+"Internalization" would mean: instead of `mvm-runtime` shell-out-and-talk-to-the-`firecracker`-binary, we'd link rust-vmm crates directly into mvmctl and *be* a VMM.
+
+## Why we rejected it for now
+
+Three reasons.
+
+### 1. Composing rust-vmm crates into a working VMM is *building a VMM*
+
+rust-vmm provides primitives. Turning primitives into a working VMM means handling:
+
+- Boot sequence (kernel loading, cmdline, initrd handoff).
+- Device model wiring (which devices, in what order, with what features negotiated).
+- Memory layout (mmap, KVM slots, IOMMU when relevant).
+- vCPU lifecycle and scheduling.
+- Snapshot and restore (Firecracker has a particularly mature implementation).
+- Seccomp jail for the VMM process itself.
+- Crash handling and graceful shutdown.
+
+That's Firecracker's job, and the Firecracker team does it well. Doing it ourselves would mean signing up for ~50K LOC of net-new code and ongoing maintenance for behavior we already get for free.
+
+### 2. The shell-out boundary is a feature, not a cost
+
+Today `mvmctl run` spawns `firecracker` as a subprocess. The boundary has costs (process startup overhead, requires `firecracker` on PATH, version coupling between mvmctl and the `firecracker` release we test against), but it has benefits we'd lose by linking:
+
+- A Firecracker lifecycle bug doesn't crash mvmctl.
+- Firecracker's seccomp jail applies to the Firecracker process, not the entire mvmctl process.
+- We can swap `firecracker` versions without rebuilding mvmctl.
+- The boundary is a clean place for telemetry and observability.
+
+For libkrun (Plan E) the situation is different — libkrun is *designed* to be linked, and the "single-binary, no external dependency" UX is one of the pull factors. That makes libkrun a special case, not a precedent.
+
+### 3. There's no concrete feature gain we'd unlock
+
+The blog-post argument for rust-vmm internalization (emirb 2026: *"rust-vmm is the real revolution, not any single VMM"*) is right *for VMM authors*. mvm is a layer up: we orchestrate VMMs. We benefit from rust-vmm via Firecracker and libkrun, but we don't need to compose the crates ourselves to capture that benefit.
+
+If we ever need an mvm-specific isolation property no upstream VMM offers, that's the trigger. Until then, the cost is real and the benefit is hypothetical.
+
+## Trigger conditions to revisit
+
+Any one of these would warrant reopening the question:
+
+1. **We need a custom VMM for an mvm-specific isolation property no upstream VMM offers.** Examples: an mvm-specific snapshot format with a security property neither Firecracker nor libkrun ships; an mvm-specific seccomp filter set that requires linking; a custom virtio device unique to mvm.
+2. **We're shipping a single-binary distribution and the firecracker-binary-on-PATH dependency becomes a real distribution problem.** (Plan E — libkrun — mostly addresses this since libkrun *is* linked.)
+3. **The Firecracker upstream stops maintaining a stable release cadence we can rely on.** Currently AWS keeps Firecracker on a steady cadence; this is unlikely to change.
+
+## References
+
+- Plan 53 §"Implementation plans → Plan H" — the high-level summary.
+- Plan E (libkrun) — the case where linkage *is* the right answer because the VMM is designed for it.
+- emirb 2026 microVM blog post — the argument for rust-vmm. Right for VMM authors; less compelling for orchestrators.

--- a/specs/plans/57-libkrun-spike.md
+++ b/specs/plans/57-libkrun-spike.md
@@ -1,0 +1,174 @@
+# Plan 57 — libkrun spike (turn scaffolding into a working backend)
+
+> Status: pending (spike — start when bandwidth permits)
+> Owner: TBD
+> Started: —
+> Depends on: plan 53 §"Plan E" (Sprint 48 scaffolding — landed 2026-05-07)
+> Tracking breadcrumb: `mvm_libkrun::Error::NotYetWired { tracking: "plan 53 §\"Plan E\" / Sprint 48 spike phase" }`
+
+## Why
+
+Sprint 48 shipped libkrun **scaffolding**: the public Rust API (`KrunContext`, `start`, `stop`, `is_available`), platform detection (`Platform::has_libkrun`), `LibkrunBackend` wired into `AnyBackend` with the `--hypervisor libkrun` flag, the right `auto_select` priority order, a Tier 2 `BackendSecurityProfile`, doctor visibility, and bootstrap install hints. What's missing is the part that actually boots VMs: real C-library bindings, codesigning, and end-to-end kernel + rootfs validation on at least one platform.
+
+This plan is the spike to close that gap. It is **explicitly scoped to one-platform proof of viability** — boot a Nix-built ext4 rootfs on macOS Apple Silicon, confirm vsock + console work, confirm the Nix kernel is compatible. Once that's done, follow-up work expands to Linux + macOS Intel and lands the daemonization / state-tracking story.
+
+When this plan ships, Intel Mac users get a real Tier 2 microVM tier with no Lima dependency, and Linux users get a single-binary alternative to firecracker-on-PATH.
+
+## Prerequisites
+
+A macOS Apple Silicon dev machine with:
+
+- macOS 14+ (Sonoma or later — Hypervisor.framework features libkrun uses are all available there).
+- Homebrew installed.
+- Xcode command line tools (for codesigning).
+- An Apple developer cert for codesigning (the dev binary path uses ad-hoc signing; the spike doesn't need a paid developer account).
+- libkrun installed: `brew install libkrun`.
+
+The spike does not require a paid Apple developer account, but the
+follow-up "ship a notarized release" work does. That's tracked outside
+this plan.
+
+## Workstreams
+
+Each item is independently shippable. Numbering is execution order.
+
+### W1 — Real C bindings (1–2 days)
+
+Goal: replace the hand-written stub API in `mvm-libkrun` with `bindgen`-generated FFI plus a thin safe wrapper.
+
+- **W1.1** Add `bindgen` to `crates/mvm-libkrun/Cargo.toml` as a `[build-dependencies]` entry.
+- **W1.2** Write `crates/mvm-libkrun/build.rs`. The build script:
+  - Probes for `libkrun.h` at `/opt/homebrew/include/libkrun.h` (Apple Silicon Homebrew), `/usr/local/include/libkrun.h` (Intel/manual), `/usr/include/libkrun.h` (Linux distro).
+  - Calls `bindgen` to generate Rust bindings into `OUT_DIR/libkrun_sys.rs`.
+  - Emits `cargo:rustc-link-lib=krun` so the linker pulls in the shared library.
+  - Falls back to "no-FFI mode" (the current Sprint 48 stub behavior) if `libkrun.h` isn't present, so the workspace still builds on hosts without libkrun installed. Use a feature flag like `libkrun-sys` (default off) or a `cfg(any(libkrun_h_found))` set by the build script.
+- **W1.3** Wrap the generated bindings in `crates/mvm-libkrun/src/sys.rs` (private module), exposing safe Rust functions to the existing `lib.rs` API surface. The C calls to wrap are roughly:
+  - `krun_create_ctx() -> i32` (negative = error)
+  - `krun_set_log_level(level: u32)`
+  - `krun_set_vm_config(ctx, num_vcpus: u8, ram_mib: u32) -> i32`
+  - `krun_set_root_disk(ctx, path: *const c_char) -> i32`
+  - `krun_set_kernel(ctx, path: *const c_char, type_: u32, cmdline: *const c_char) -> i32`
+  - `krun_add_vsock_port(ctx, port: u32, filepath: *const c_char) -> i32`
+  - `krun_set_workdir(ctx, path: *const c_char) -> i32`
+  - `krun_set_env(ctx, envp: *const *const c_char) -> i32`
+  - `krun_start_enter(ctx) -> i32` (blocks until guest exits)
+  - The exact set varies by libkrun version; pin to the one Homebrew ships on the spike day and document the version in `Cargo.toml`.
+- **W1.4** Replace `Error::NotYetWired` returns in `lib.rs::start` and `lib.rs::stop` with calls into the safe wrapper. Keep `Error::NotInstalled` as the front-stop guard. Add a new `Error::Krun(i32)` (already declared) for non-zero return codes from libkrun.
+
+### W2 — macOS codesigning entitlement (0.5–1 day)
+
+Goal: `mvmctl` + libkrun + `Hypervisor.framework` boot a guest without the macOS kernel rejecting the syscall.
+
+- **W2.1** Add `com.apple.security.hypervisor` to the existing entitlements plist (the same one that gates `mvm-apple-container`'s VZ usage). Confirm the dev binary builds and codesigns (ad-hoc) cleanly. Path: probably `crates/mvm-apple-container/macos/Entitlements.plist` or wherever `ensure_signed()` reads from.
+- **W2.2** Test the `ensure_signed()` machinery in `crates/mvm-apple-container/src/macos.rs` covers the new libkrun consumer. The hypervisor entitlement is shared between VZ and libkrun, so `mvmctl.app` only needs to be signed once.
+- **W2.3** Document the first-run UX in `public/.../guides/troubleshooting.md`: which Gatekeeper / SIP prompts appear, and whether the user has to right-click → Open the first time. (For ad-hoc signed binaries on macOS 14+, the prompt is one click.)
+
+### W3 — End-to-end boot validation (the actual spike, 2–3 days)
+
+Goal: prove a real Nix-built kernel + ext4 rootfs boots in libkrun on macOS Apple Silicon and the guest agent comes up on vsock.
+
+- **W3.1** Pick the validation flake. `examples/minimal` is the canonical "smallest-thing-that-boots" target across mvm. Build it: `mvmctl build --flake examples/minimal`. Outputs are `vmlinux`, `rootfs.ext4`, and possibly `initrd`.
+- **W3.2** Construct a `KrunContext` pointing at those artifacts and invoke `mvm_libkrun::start()` directly (bypass the `LibkrunBackend` for the spike — the backend's job is to plumb config, not validate boot). Run from a unit test or a small `examples/libkrun-smoke.rs` binary.
+- **W3.3** Confirm the guest agent's vsock listener responds. Use `mvm_guest::vsock::GUEST_AGENT_PORT` and the existing health-check protocol that Firecracker / Apple Container already use.
+- **W3.4** **Risks to validate explicitly**:
+  - **Kernel cmdline.** Firecracker boots with `console=ttyS0`; libkrun expects `console=hvc0` (virtio-console). Likely fix: pass a libkrun-specific cmdline via `KrunContext.kernel_cmdline`. The Nix build may need a `mkGuest` `cmdlineFor = "libkrun" | "firecracker"` parameter, or just override at runtime via the existing cmdline plumbing in `VmStartConfig`.
+  - **Console device.** No serial → console output may not appear. Confirm libkrun routes hvc0 to stdout in the calling process, or wire it through a host-side log file.
+  - **vsock device naming.** Firecracker uses `/dev/vhost-vsock`; libkrun's macOS path uses an internal abstraction. Confirm the guest sees vsock on cid 3 (standard guest CID) and the agent's listening port matches.
+  - **Verified boot (claim 3) is out of scope for the spike.** The Nix flake's `verifiedBoot = false` exemption (the dev VM path) covers this. Plan 25 §W3 follow-up promotes claim 3 from "DoesNotHold" to "Holds" for libkrun once dm-verity is wired through.
+
+### W4 — State tracking decision (1–2 days)
+
+Goal: decide and implement how mvmctl tracks running libkrun VMs.
+
+libkrun is a library, not a daemon. `krun_start_enter` blocks the calling thread until the guest exits. Two options:
+
+- **Option A — In-process registry.** mvmctl spawns a background thread per VM; the thread holds the libkrun handle and waits on `krun_start_enter`. State lives in a shared `OnceLock<Mutex<HashMap<VmId, KrunHandle>>>`. Closing the mvmctl process kills the VM (libkrun's threads exit when the process dies).
+  - Pro: simple. Pro: matches the dev workflow ("`mvmctl run` keeps the VM alive while you work, ^C to stop").
+  - Con: doesn't support `mvmctl start` + come-back-later flows.
+
+- **Option B — Daemonize via launchd / systemd.** Same pattern as `mvm-apple-container`'s `install_launchd_direct`. mvmctl writes a launchd plist (or systemd unit on Linux), launchd starts a background `mvmctl libkrun-supervise <vm-name>` process, that process holds the libkrun handle. State persists across mvmctl invocations.
+  - Pro: matches Firecracker / Apple Container UX (`mvmctl start` returns immediately).
+  - Con: more code, more failure modes.
+
+**Recommendation**: ship Option A first (covers the dev workflow), file a follow-up issue for Option B once the spike validates the rest of the stack. Most users in Sprint 48 are dev-mode users; the persistent-VM use case is rarer for libkrun specifically.
+
+- **W4.1** Implement Option A. Files: `crates/mvm-runtime/src/vm/libkrun.rs` gains a `LIBKRUN_VMS: OnceLock<Mutex<HashMap<VmId, KrunHandle>>>` static. `start()` spawns the supervisor thread; `stop()` signals it to exit; `list()` returns keys; `status()` checks presence.
+- **W4.2** `stop_all()` becomes a real implementation (today it's an empty `Ok(())` placeholder).
+
+### W5 — CI lanes (0.5–1 day)
+
+Goal: regression coverage on every PR.
+
+- **W5.1** Extend `.github/workflows/ci.yml` with a `libkrun-macos-arm64` job that runs on `macos-latest` (which is Apple Silicon as of late 2025), installs libkrun via Homebrew, runs `cargo test -p mvm-libkrun -p mvm-runtime --test libkrun_smoke`. The smoke test boots `examples/minimal` and asserts the guest agent responds.
+- **W5.2** Once W3 lands, **the smoke test is the gate** — it'll catch regressions in libkrun's API, the Nix kernel cmdline, our wrapper code, and the codesigning path simultaneously.
+
+### W6 — Cross-platform expansion (1 sprint follow-up — out of scope here)
+
+Out of scope for plan 57 itself. Tracked as W6 so the path is named:
+
+- **W6.1** macOS Intel — same steps as Apple Silicon but x86_64 build. The libkrun bindings should "just work" since they're identical at the C level.
+- **W6.2** Linux x86_64 — KVM path. Different libkrun internals (no Hypervisor.framework, no entitlements), but the C API is identical. Codesigning concerns evaporate on Linux.
+- **W6.3** Linux aarch64 — same as x86_64.
+- **W6.4** Promote claim 3 (verified boot) for libkrun to `Holds` once dm-verity is wired through `KrunContext`. Ties into plan 25 §W3.
+
+These each merit their own one-day sub-sprint *after* plan 57 ships.
+
+## Files to create or modify
+
+| File | Workstream | Action |
+|---|---|---|
+| `crates/mvm-libkrun/Cargo.toml` | W1.1 | add `bindgen` build-dep |
+| `crates/mvm-libkrun/build.rs` | W1.2 | new — generate bindings, set link flags |
+| `crates/mvm-libkrun/src/sys.rs` | W1.3 | new — safe wrapper over generated bindings |
+| `crates/mvm-libkrun/src/lib.rs` | W1.4 | replace `NotYetWired` returns with real calls |
+| `crates/mvm-apple-container/macos/Entitlements.plist` (or equivalent) | W2.1 | add `com.apple.security.hypervisor` if not already present |
+| `crates/mvm-runtime/src/vm/libkrun.rs` | W4.1 | wire `LIBKRUN_VMS` registry, real lifecycle |
+| `examples/libkrun-smoke.rs` | W5.1 | new — minimal end-to-end test binary |
+| `.github/workflows/ci.yml` | W5.1 | new `libkrun-macos-arm64` job |
+| `public/.../guides/troubleshooting.md` | W2.3 | first-run codesigning prompt FAQ |
+
+## Risks
+
+1. **libkrun's macOS Apple Silicon support is younger than its Linux story.** If the spike hits a libkrun upstream bug, file it and either (a) wait, (b) patch via a pinned fork, or (c) descope to Linux-first and revisit Apple Silicon when upstream catches up.
+2. **The Nix kernel may need a libkrun-specific cmdline variant.** Plan 25 §W3 already adds a kernel-cmdline knob for verified boot; libkrun would consume the same plumbing. Likely a small addition; flag if it grows.
+3. **Codesigning entitlement may not compose with the existing VZ entitlement.** Apple's docs say `com.apple.security.hypervisor` covers both VZ and direct Hypervisor.framework usage, but verify on a real signed build before committing.
+4. **The `bindgen` build dep adds a non-trivial build-time cost** (libclang). Mitigate by gating the bindings generation behind a `libkrun-sys` cargo feature so the default workspace build (CI fast lane, hosts without libkrun installed) skips it.
+5. **In-process registry (W4 Option A) means mvmctl can't be terminal-detached.** Document this clearly. The follow-up daemonization (W6) addresses it for users who need `mvmctl start` + walk-away.
+
+## Verification
+
+When the spike is done:
+
+- `cargo test -p mvm-libkrun --features libkrun-sys` passes on a host with libkrun installed.
+- `cargo test --workspace` continues to pass on hosts *without* libkrun installed (fallback build path).
+- `mvmctl run --hypervisor libkrun --flake examples/minimal` boots, the guest agent responds to vsock health checks, and `Ctrl-C` stops the VM cleanly.
+- `mvmctl doctor` shows `libkrun: available` on the dev host and reports the active backend as `libkrun` when KVM/Apple Container are both unavailable.
+- `mvmctl run --hypervisor libkrun` on a host **without** libkrun installed errors with the exact `install_hint()` message — not a generic "command failed."
+- The CI lane (W5) is green on PRs that touch `crates/mvm-libkrun/`, `crates/mvm-runtime/src/vm/libkrun.rs`, or any file `examples/libkrun-smoke.rs` depends on.
+
+## Non-goals (named explicitly)
+
+- **Daemonized libkrun VMs across mvmctl invocations.** W4 Option A (in-process) is the spike scope; Option B (launchd / systemd) is W6.
+- **macOS Intel + Linux x86_64 + Linux aarch64.** All deferred to W6 sub-sprints.
+- **Verified boot (ADR-002 claim 3) for libkrun.** The dev-VM exemption from plan 25 §W3.4 applies; promoting claim 3 is W6.4.
+- **Notarization / paid Apple developer cert.** Ad-hoc signing is sufficient for the spike. Notarization is part of the release-engineering follow-up.
+- **GPU paravirt** (libkrun's `paravirtualized GPU` feature). Not needed for mvm's workloads; revisit if a real user asks.
+
+## Reversal cost
+
+If the spike fails (e.g., libkrun's macOS path turns out to be too immature), the reversal is cheap:
+
+- **W1 changes**: roll back the bindgen + sys.rs work; the crate falls back to its current Sprint 48 scaffolding shape (already a working state).
+- **W2 changes**: remove the `com.apple.security.hypervisor` entitlement addition (no other tier depends on it being present except VZ, which already had it).
+- **W3–W5**: pure additions; deletion is the rollback.
+
+The `LibkrunBackend` and `AnyBackend::Libkrun` variant stay in place either way — the scaffolding shipped in Sprint 48 is independently useful as a "documented placeholder" even if the spike never lands.
+
+## References
+
+- Plan 53 §"Plan E" — the design context and fork test that qualified libkrun.
+- Plan 25 §W3 — verified boot (claim 3); libkrun support tracked in W6.4 here.
+- Sprint 48 commit `ac8c9b2` — scaffolding that this plan upgrades.
+- ADR-002 §"Per-backend tier matrix" — Tier 2 expectations for libkrun.
+- libkrun upstream: <https://github.com/containers/libkrun>
+- `mvm_libkrun::Error::NotYetWired` — the runtime breadcrumb that points readers at this plan.


### PR DESCRIPTION
## Summary

- Plan 53 ("Option B — Pragmatic") cross-platform expansion landed in three sprint slices on top of `main`. Firecracker stays the security baseline; **libkrun** is the new backend (Intel Mac + macOS-no-Lima); Docker stays Tier 3 with loud warnings; Windows is first-class via WSL2.
- ADR-002 restructured around the **Matryoshka 5-layer trust model** with explicit per-backend tier matrix. `mvmctl doctor` and `mvmctl run` surface the active backend's security profile; Tier 3 (Docker) emits a loud, suppressible warning naming the seven 2024–2025 container-escape CVEs.
- APFS Copy-on-Write for Apple Container templates: `mvmctl run --template foo` now O(1)-clones the rootfs into a per-instance writable copy, so concurrent VMs don't fight over the disk image.
- libkrun shipping as scaffolding (final API, dispatch, doctor visibility, Tier 2 BackendSecurityProfile, install hints). The boot-validation spike that lights up the lifecycle is filed as `specs/plans/57-libkrun-spike.md`.
- Windows community story: WSL2-first install docs (`install/windows.md`, `guides/windows-wsl2.md`, `guides/windows-troubleshooting.md`), non-blocking Windows CI lane with documented unix-ism audit list, winget manifest template under `installer/winget/`, WSL2-aware bootstrap path (`bootstrap_wsl2()`).
- Three deferred-with-rationale backlog plans: `54-cloud-hypervisor-deferred.md` (rejected for posture reasons), `55-crosvm-deferred.md` (niche fit), `56-rust-vmm-internalization-deferred.md` (composing rust-vmm = building a VMM).
- AWS EC2 + Ubicloud deployment guides; PVM FAQ entry pointing users at SlicerVM for non-KVM cloud VMs that still need real microVMs.

## Commits

8 commits sequenced as one sprint slice each so reviewers can step through:

```
fd668fe  docs(plans): file libkrun spike as plan 57 (the followup to Sprint 48)
713cb6a  docs(installer): winget manifest template (Sprint 48 plan I.3)
ac8c9b2  feat(libkrun): add libkrun backend scaffolding (Sprint 48 plan E)
9998a22  feat(windows): WSL2-first install docs + non-blocking CI lane (Sprint 47 plans I.1, I.2)
b06525b  feat(runtime): APFS CoW for Apple Container templates (Sprint 47 plan D)
defa372  feat(security): backend security profile + doctor tier output + docker-tier banner (Sprint 46 plan B)
121c332  docs(security): Matryoshka layer model + per-backend tier matrix (Sprint 46 plans A, C, F, G, H, J, K)
0c15c0e  docs(plans): cross-platform expansion roadmap (plan 53) — Option B
```

42 files changed, +3759 / -20 lines. Each commit independently passes `cargo test --workspace` + `cargo clippy --workspace --all-targets -- -D warnings` via the pre-commit hook (1789–1805 tests across the suite).

## What's deferred (named in commits + plans)

- **libkrun spike** — real C bindings, codesigning entitlement, end-to-end boot validation. Plan 57 has the workstreams (W1–W6).
- **Cloud Hypervisor** — rejected for posture reasons (would fork the security narrative). Trigger conditions in plan 54.
- **crosvm** — deferred until a Chrome OS / Android-emulator user shows up. Trigger conditions in plan 55.
- **rust-vmm internalization** — composing rust-vmm crates is *building a VMM*, which is Firecracker's and libkrun's job. Trigger conditions in plan 56.
- **Windows CI unix-ism audit list** — documented in `.github/workflows/windows.yml`. Primary blocker is `mvm-apple-container::vsock_connect` returning unix-only `UnixStream`.

## Test plan

- [x] `cargo test --workspace` — 1805 tests pass on macOS (full nextest run via pre-commit).
- [x] `cargo clippy --workspace --all-targets -- -D warnings` — zero warnings.
- [x] `mvmctl doctor` smoke — reports the new `libkrun` row in the platform section + the active-backend security posture section.
- [ ] `mvmctl run --hypervisor libkrun` end-to-end boot — gated on plan 57 spike landing.
- [ ] `mvmctl run --template foo --hypervisor apple-container` cold-start <1s — gated on a real macOS 26 host (the local dev box is macOS 15).
- [ ] Windows CI green on `mvm-core` — workflow ships non-blocking; will validate on the first PR that touches the relevant paths.

🤖 Generated with [Claude Code](https://claude.com/claude-code)