### PR TITLE
feat(core): workspace-volume attach + workspace_id threading

### DIFF
--- a/crates/mvm-core/src/domain/instance.rs
+++ b/crates/mvm-core/src/domain/instance.rs
@@ -6,6 +6,89 @@ use serde::{Deserialize, Serialize};
 use crate::idle_metrics::IdleMetrics;
 use crate::pool::Role;
 
+// ============================================================================
+// Workspace volume attach + workload classification (cross-repo with mvmd)
+// ============================================================================
+//
+// These types are the canonical mvm-core definitions for the workspace
+// volume attach surface introduced in mvmd Phase 1057/1058 (plan 32 —
+// `mvmd-integrations` memory service). They were defined locally in
+// `mvmd-runtime` first and are promoted here so the protocol types can
+// thread them without a circular dep. mvmd will drop its local copies
+// and re-export from `mvm_core::instance` once it bumps its mvm pin.
+
+/// Read/write mode for a workspace volume attached to an instance.
+#[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq, Hash)]
+#[serde(rename_all = "snake_case")]
+pub enum VolumeMode {
+    ReadOnly,
+    ReadWrite,
+}
+
+/// Request to attach a workspace-scoped volume into an instance at start.
+///
+/// Identity is `(workspace_id, name)`; the on-host backing file lives at
+/// `/var/lib/mvm/workspaces/<workspace_id>/volumes/<name>.ext4` (mvmd's
+/// `mvmd_runtime::vm::workspace::volumes` owns the layout). `mount_path`
+/// is threaded through to the guest config-drive metadata.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct VolumeAttach {
+    /// Workspace that owns the volume.
+    pub workspace_id: String,
+    /// Volume name within the workspace (file stem of `<name>.ext4`).
+    pub name: String,
+    /// Mount path inside the guest.
+    pub mount_path: String,
+    pub mode: VolumeMode,
+}
+
+/// Workload class — drives sleep policy, auto-provision rules, and
+/// resource defaults. Sandbox is the user-controlled ephemeral default;
+/// Service is workspace-owned, auto-provisioned, long-running (e.g. the
+/// per-workspace memory service).
+#[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq, Hash, Default)]
+#[serde(rename_all = "snake_case")]
+pub enum WorkloadClass {
+    /// User-controlled, ephemeral. Default for sandboxes.
+    #[default]
+    Sandbox,
+    /// Auto-provisioned, workspace-owned, long-running.
+    Service,
+}
+
+// ============================================================================
+// Desired instance state (declarative target the reconciler drives toward)
+// ============================================================================
+
+/// Declarative per-instance desired state.
+///
+/// Carries identity + the workspace/volume/class metadata that the
+/// scheduler and `mvm-hostd` need to materialize an instance. Distinct
+/// from [`InstanceState`], which is the *observed* runtime state.
+///
+/// Backward compatibility: every field added after the initial shape
+/// MUST carry `#[serde(default)]` so older serialized payloads keep
+/// deserializing cleanly. Tested via
+/// `test_desired_instance_backward_compat`.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct DesiredInstance {
+    pub instance_id: String,
+    pub pool_id: String,
+    pub tenant_id: String,
+    /// Workspace this instance belongs to.
+    /// Required for service-class workloads; optional for sandbox-class
+    /// during migration (None = workspace-unknown, treated as
+    /// tenant-only).
+    #[serde(default)]
+    pub workspace_id: Option<String>,
+    /// Workspace-scoped volumes to attach at instance start.
+    #[serde(default)]
+    pub volumes: Vec<VolumeAttach>,
+    /// Workload class — drives sleep policy, auto-provision rules, etc.
+    #[serde(default)]
+    pub workload_class: WorkloadClass,
+}
+
 /// Instance lifecycle status. Only instances have runtime state.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(rename_all = "snake_case")]
@@ -290,5 +373,106 @@ mod tests {
         assert_eq!(InstanceStatus::Running.to_string(), "running");
         assert_eq!(InstanceStatus::Sleeping.to_string(), "sleeping");
         assert_eq!(InstanceStatus::Destroyed.to_string(), "destroyed");
+    }
+
+    // ------------- VolumeMode / VolumeAttach / WorkloadClass -------------
+
+    #[test]
+    fn test_volume_mode_serializes_snake_case() {
+        assert_eq!(
+            serde_json::to_string(&VolumeMode::ReadOnly).unwrap(),
+            "\"read_only\""
+        );
+        assert_eq!(
+            serde_json::to_string(&VolumeMode::ReadWrite).unwrap(),
+            "\"read_write\""
+        );
+        let parsed: VolumeMode = serde_json::from_str("\"read_only\"").unwrap();
+        assert_eq!(parsed, VolumeMode::ReadOnly);
+    }
+
+    #[test]
+    fn test_workload_class_serializes_snake_case() {
+        assert_eq!(
+            serde_json::to_string(&WorkloadClass::Sandbox).unwrap(),
+            "\"sandbox\""
+        );
+        assert_eq!(
+            serde_json::to_string(&WorkloadClass::Service).unwrap(),
+            "\"service\""
+        );
+    }
+
+    #[test]
+    fn test_workload_class_default_is_sandbox() {
+        assert_eq!(WorkloadClass::default(), WorkloadClass::Sandbox);
+    }
+
+    #[test]
+    fn test_volume_attach_roundtrip() {
+        let attach = VolumeAttach {
+            workspace_id: "ws-prod".to_string(),
+            name: "memory".to_string(),
+            mount_path: "/var/lib/memory".to_string(),
+            mode: VolumeMode::ReadWrite,
+        };
+        let json = serde_json::to_string(&attach).unwrap();
+        let parsed: VolumeAttach = serde_json::from_str(&json).unwrap();
+        assert_eq!(parsed, attach);
+    }
+
+    // ------------- DesiredInstance -------------
+
+    #[test]
+    fn test_desired_instance_roundtrip_full() {
+        let di = DesiredInstance {
+            instance_id: "i-abc123".to_string(),
+            pool_id: "memory-svc".to_string(),
+            tenant_id: "acme".to_string(),
+            workspace_id: Some("ws-prod".to_string()),
+            volumes: vec![VolumeAttach {
+                workspace_id: "ws-prod".to_string(),
+                name: "memory".to_string(),
+                mount_path: "/var/lib/memory".to_string(),
+                mode: VolumeMode::ReadWrite,
+            }],
+            workload_class: WorkloadClass::Service,
+        };
+        let json = serde_json::to_string(&di).unwrap();
+        let parsed: DesiredInstance = serde_json::from_str(&json).unwrap();
+        assert_eq!(parsed, di);
+    }
+
+    #[test]
+    fn test_desired_instance_backward_compat() {
+        // Pre-workspace JSON (no workspace_id, volumes, workload_class)
+        // must still deserialize with defaults — sandbox-class sandboxes
+        // produced before Phase 1058 land here.
+        let json = r#"{
+            "instance_id": "i-legacy",
+            "pool_id": "workers",
+            "tenant_id": "acme"
+        }"#;
+        let parsed: DesiredInstance = serde_json::from_str(json).unwrap();
+        assert_eq!(parsed.instance_id, "i-legacy");
+        assert_eq!(parsed.workspace_id, None);
+        assert!(parsed.volumes.is_empty());
+        assert_eq!(parsed.workload_class, WorkloadClass::Sandbox);
+    }
+
+    #[test]
+    fn test_desired_instance_partial_compat() {
+        // Mid-migration payload: workspace_id present, but no volumes
+        // and no workload_class — should default sensibly.
+        let json = r#"{
+            "instance_id": "i-mid",
+            "pool_id": "workers",
+            "tenant_id": "acme",
+            "workspace_id": "ws-prod"
+        }"#;
+        let parsed: DesiredInstance = serde_json::from_str(json).unwrap();
+        assert_eq!(parsed.workspace_id.as_deref(), Some("ws-prod"));
+        assert!(parsed.volumes.is_empty());
+        assert_eq!(parsed.workload_class, WorkloadClass::Sandbox);
     }
 }

--- a/crates/mvm-core/src/protocol/protocol.rs
+++ b/crates/mvm-core/src/protocol/protocol.rs
@@ -1,6 +1,7 @@
 use anyhow::{Context, Result};
 use serde::{Deserialize, Serialize};
 
+use crate::instance::VolumeAttach;
 use crate::tenant::TenantNet;
 
 /// Default Unix domain socket path for hostd.
@@ -39,7 +40,16 @@ const MAX_FRAME_SIZE: usize = 1024 * 1024;
 /// that shifts the wire format without bumping this constant fails
 /// CI on the mvmd side. The fixtures live next to the test;
 /// regenerate them in the same commit that bumps the version.
-pub const PROTOCOL_VERSION: u32 = 1;
+///
+/// **History:**
+/// - `1`: initial shape (plan 60 Phase 8, ADR-043).
+/// - `2`: workspace-volume attach — `workspace_id` threaded through
+///   every instance-scoped `HostdRequest` variant and `volumes:
+///   Vec<VolumeAttach>` added to `StartInstance`. All new fields are
+///   `#[serde(default)]` so old payloads still deserialize; the bump
+///   forces mvmd-side fixture refresh because byte output changes
+///   when defaults are present (JSON keys appear with default values).
+pub const PROTOCOL_VERSION: u32 = 2;
 
 // ============================================================================
 // Request/Response types
@@ -56,12 +66,25 @@ pub enum HostdRequest {
         tenant_id: String,
         pool_id: String,
         instance_id: String,
+        /// Workspace owning the instance (PROTOCOL_VERSION 2+).
+        /// `None` for legacy sandbox-class instances created before
+        /// workspace identity was threaded through.
+        #[serde(default)]
+        workspace_id: Option<String>,
+        /// Workspace-scoped volumes to attach at start
+        /// (PROTOCOL_VERSION 2+). Wiring into the Firecracker config
+        /// happens mvmd-side in `mvmd_runtime::vm::workspace::*`.
+        #[serde(default)]
+        volumes: Vec<VolumeAttach>,
     },
     /// Stop a running instance (kill FC, teardown cgroup, TAP).
     StopInstance {
         tenant_id: String,
         pool_id: String,
         instance_id: String,
+        /// Workspace owning the instance (PROTOCOL_VERSION 2+).
+        #[serde(default)]
+        workspace_id: Option<String>,
     },
     /// Snapshot and suspend an instance.
     SleepInstance {
@@ -71,12 +94,18 @@ pub enum HostdRequest {
         force: bool,
         #[serde(default)]
         drain_timeout_secs: Option<u64>,
+        /// Workspace owning the instance (PROTOCOL_VERSION 2+).
+        #[serde(default)]
+        workspace_id: Option<String>,
     },
     /// Restore an instance from snapshot.
     WakeInstance {
         tenant_id: String,
         pool_id: String,
         instance_id: String,
+        /// Workspace owning the instance (PROTOCOL_VERSION 2+).
+        #[serde(default)]
+        workspace_id: Option<String>,
     },
     /// Destroy an instance and optionally wipe volumes.
     DestroyInstance {
@@ -84,6 +113,9 @@ pub enum HostdRequest {
         pool_id: String,
         instance_id: String,
         wipe_volumes: bool,
+        /// Workspace owning the instance (PROTOCOL_VERSION 2+).
+        #[serde(default)]
+        workspace_id: Option<String>,
     },
     /// Create per-tenant bridge and NAT rules.
     SetupNetwork { tenant_id: String, net: TenantNet },
@@ -202,8 +234,9 @@ mod tests {
     /// here means a PR can't silently bump the const without also
     /// updating this test (and prompting the fixture re-gen).
     #[test]
-    fn protocol_version_is_one() {
-        assert_eq!(PROTOCOL_VERSION, 1);
+    fn protocol_version_is_two() {
+        // Bumped from 1 to 2 in the workspace-volume attach change.
+        assert_eq!(PROTOCOL_VERSION, 2);
     }
 
     #[test]
@@ -222,6 +255,8 @@ mod tests {
             tenant_id: "acme".to_string(),
             pool_id: "workers".to_string(),
             instance_id: "i-abc123".to_string(),
+            workspace_id: None,
+            volumes: vec![],
         };
         let json = serde_json::to_string(&req).unwrap();
         let parsed: HostdRequest = serde_json::from_str(&json).unwrap();
@@ -230,10 +265,46 @@ mod tests {
                 tenant_id,
                 pool_id,
                 instance_id,
+                workspace_id,
+                volumes,
             } => {
                 assert_eq!(tenant_id, "acme");
                 assert_eq!(pool_id, "workers");
                 assert_eq!(instance_id, "i-abc123");
+                assert_eq!(workspace_id, None);
+                assert!(volumes.is_empty());
+            }
+            _ => panic!("Wrong variant"),
+        }
+    }
+
+    #[test]
+    fn test_hostd_request_start_with_workspace_volumes_roundtrip() {
+        use crate::instance::{VolumeAttach, VolumeMode};
+        let req = HostdRequest::StartInstance {
+            tenant_id: "acme".to_string(),
+            pool_id: "memory-svc".to_string(),
+            instance_id: "i-mem".to_string(),
+            workspace_id: Some("ws-prod".to_string()),
+            volumes: vec![VolumeAttach {
+                workspace_id: "ws-prod".to_string(),
+                name: "memory".to_string(),
+                mount_path: "/var/lib/memory".to_string(),
+                mode: VolumeMode::ReadWrite,
+            }],
+        };
+        let json = serde_json::to_string(&req).unwrap();
+        let parsed: HostdRequest = serde_json::from_str(&json).unwrap();
+        match parsed {
+            HostdRequest::StartInstance {
+                workspace_id,
+                volumes,
+                ..
+            } => {
+                assert_eq!(workspace_id.as_deref(), Some("ws-prod"));
+                assert_eq!(volumes.len(), 1);
+                assert_eq!(volumes[0].mount_path, "/var/lib/memory");
+                assert_eq!(volumes[0].mode, VolumeMode::ReadWrite);
             }
             _ => panic!("Wrong variant"),
         }
@@ -245,6 +316,7 @@ mod tests {
             tenant_id: "acme".to_string(),
             pool_id: "workers".to_string(),
             instance_id: "i-abc123".to_string(),
+            workspace_id: None,
         };
         let json = serde_json::to_string(&req).unwrap();
         let parsed: HostdRequest = serde_json::from_str(&json).unwrap();
@@ -259,6 +331,7 @@ mod tests {
             instance_id: "i-abc123".to_string(),
             force: true,
             drain_timeout_secs: Some(30),
+            workspace_id: Some("ws-prod".to_string()),
         };
         let json = serde_json::to_string(&req).unwrap();
         let parsed: HostdRequest = serde_json::from_str(&json).unwrap();
@@ -266,10 +339,12 @@ mod tests {
             HostdRequest::SleepInstance {
                 force,
                 drain_timeout_secs,
+                workspace_id,
                 ..
             } => {
                 assert!(force);
                 assert_eq!(drain_timeout_secs, Some(30));
+                assert_eq!(workspace_id.as_deref(), Some("ws-prod"));
             }
             _ => panic!("Wrong variant"),
         }
@@ -281,6 +356,7 @@ mod tests {
             tenant_id: "acme".to_string(),
             pool_id: "workers".to_string(),
             instance_id: "i-abc123".to_string(),
+            workspace_id: None,
         };
         let json = serde_json::to_string(&req).unwrap();
         let parsed: HostdRequest = serde_json::from_str(&json).unwrap();
@@ -294,6 +370,7 @@ mod tests {
             pool_id: "workers".to_string(),
             instance_id: "i-abc123".to_string(),
             wipe_volumes: true,
+            workspace_id: None,
         };
         let json = serde_json::to_string(&req).unwrap();
         let parsed: HostdRequest = serde_json::from_str(&json).unwrap();
@@ -301,6 +378,104 @@ mod tests {
             HostdRequest::DestroyInstance { wipe_volumes, .. } => assert!(wipe_volumes),
             _ => panic!("Wrong variant"),
         }
+    }
+
+    /// PROTOCOL_VERSION 1 wire format — payload predates workspace_id
+    /// and volumes. Must still deserialize so an mvmd-agent pinned to
+    /// v1 can still talk to a v2 mvm-hostd while the cross-repo bump
+    /// rolls out.
+    #[test]
+    fn test_hostd_request_start_v1_backward_compat() {
+        let v1_json = r#"{
+            "StartInstance": {
+                "tenant_id": "acme",
+                "pool_id": "workers",
+                "instance_id": "i-legacy"
+            }
+        }"#;
+        let parsed: HostdRequest = serde_json::from_str(v1_json).unwrap();
+        match parsed {
+            HostdRequest::StartInstance {
+                tenant_id,
+                workspace_id,
+                volumes,
+                ..
+            } => {
+                assert_eq!(tenant_id, "acme");
+                assert_eq!(workspace_id, None);
+                assert!(volumes.is_empty());
+            }
+            _ => panic!("Wrong variant"),
+        }
+    }
+
+    /// Same v1-compat check for the other instance-scoped variants —
+    /// the workspace_id field must be optional everywhere it landed.
+    #[test]
+    fn test_hostd_request_instance_variants_v1_backward_compat() {
+        let cases = [
+            r#"{"StopInstance":{"tenant_id":"t","pool_id":"p","instance_id":"i"}}"#,
+            r#"{"SleepInstance":{"tenant_id":"t","pool_id":"p","instance_id":"i","force":false}}"#,
+            r#"{"WakeInstance":{"tenant_id":"t","pool_id":"p","instance_id":"i"}}"#,
+            r#"{"DestroyInstance":{"tenant_id":"t","pool_id":"p","instance_id":"i","wipe_volumes":false}}"#,
+        ];
+        for json in cases {
+            let parsed: HostdRequest = serde_json::from_str(json)
+                .unwrap_or_else(|e| panic!("v1 payload {json:?} should parse: {e}"));
+            // Each instance variant carries workspace_id; assert it
+            // defaults to None when the v1 payload omits it.
+            let ws = match &parsed {
+                HostdRequest::StopInstance { workspace_id, .. } => workspace_id,
+                HostdRequest::SleepInstance { workspace_id, .. } => workspace_id,
+                HostdRequest::WakeInstance { workspace_id, .. } => workspace_id,
+                HostdRequest::DestroyInstance { workspace_id, .. } => workspace_id,
+                _ => panic!("unexpected variant for {json:?}"),
+            };
+            assert_eq!(
+                ws, &None,
+                "v1 payload {json:?} should default workspace_id to None"
+            );
+        }
+    }
+
+    /// PROTOCOL_VERSION 2 canonical fixture for StartInstance with the
+    /// new fields populated. mvmd-side `tests/mvmd_compat.rs` mirrors
+    /// this shape; if the serialized bytes drift, both sides need a
+    /// refresh in the same commit (ADR-043).
+    #[test]
+    fn test_hostd_request_start_v2_fixture() {
+        use crate::instance::{VolumeAttach, VolumeMode};
+        let req = HostdRequest::StartInstance {
+            tenant_id: "acme".to_string(),
+            pool_id: "memory-svc".to_string(),
+            instance_id: "i-mem-001".to_string(),
+            workspace_id: Some("ws-prod".to_string()),
+            volumes: vec![VolumeAttach {
+                workspace_id: "ws-prod".to_string(),
+                name: "memory".to_string(),
+                mount_path: "/var/lib/memory".to_string(),
+                mode: VolumeMode::ReadWrite,
+            }],
+        };
+        let actual = serde_json::to_string(&req).unwrap();
+        let expected = concat!(
+            r#"{"StartInstance":{"#,
+            r#""tenant_id":"acme","#,
+            r#""pool_id":"memory-svc","#,
+            r#""instance_id":"i-mem-001","#,
+            r#""workspace_id":"ws-prod","#,
+            r#""volumes":[{"#,
+            r#""workspace_id":"ws-prod","#,
+            r#""name":"memory","#,
+            r#""mount_path":"/var/lib/memory","#,
+            r#""mode":"read_write""#,
+            r#"}]"#,
+            r#"}}"#,
+        );
+        assert_eq!(actual, expected);
+        // Round-trip the fixture to make sure parsing matches construction.
+        let parsed: HostdRequest = serde_json::from_str(expected).unwrap();
+        assert!(matches!(parsed, HostdRequest::StartInstance { .. }));
     }
 
     #[test]
@@ -379,11 +554,14 @@ mod tests {
                 tenant_id: "t".to_string(),
                 pool_id: "p".to_string(),
                 instance_id: "i".to_string(),
+                workspace_id: None,
+                volumes: vec![],
             },
             HostdRequest::StopInstance {
                 tenant_id: "t".to_string(),
                 pool_id: "p".to_string(),
                 instance_id: "i".to_string(),
+                workspace_id: None,
             },
             HostdRequest::SleepInstance {
                 tenant_id: "t".to_string(),
@@ -391,17 +569,20 @@ mod tests {
                 instance_id: "i".to_string(),
                 force: false,
                 drain_timeout_secs: None,
+                workspace_id: None,
             },
             HostdRequest::WakeInstance {
                 tenant_id: "t".to_string(),
                 pool_id: "p".to_string(),
                 instance_id: "i".to_string(),
+                workspace_id: None,
             },
             HostdRequest::DestroyInstance {
                 tenant_id: "t".to_string(),
                 pool_id: "p".to_string(),
                 instance_id: "i".to_string(),
                 wipe_volumes: false,
+                workspace_id: None,
             },
             HostdRequest::SetupNetwork {
                 tenant_id: "t".to_string(),

--- a/crates/mvm/src/hostd/server.rs
+++ b/crates/mvm/src/hostd/server.rs
@@ -74,6 +74,11 @@ fn execute(request: HostdRequest) -> HostdResponse {
             tenant_id,
             pool_id,
             instance_id,
+            // workspace_id + volumes (PROTOCOL_VERSION 2+) are consumed
+            // mvmd-side in `mvmd_runtime::vm::workspace::*`; the legacy
+            // mvm-hostd implementation here ignores them until plan 60
+            // lifts hostd into mvmd.
+            ..
         } => {
             if let Err(e) = validate_ids(&tenant_id, &pool_id, Some(&instance_id)) {
                 return HostdResponse::Error {
@@ -91,6 +96,7 @@ fn execute(request: HostdRequest) -> HostdResponse {
             tenant_id,
             pool_id,
             instance_id,
+            ..
         } => {
             if let Err(e) = validate_ids(&tenant_id, &pool_id, Some(&instance_id)) {
                 return HostdResponse::Error {
@@ -110,6 +116,7 @@ fn execute(request: HostdRequest) -> HostdResponse {
             instance_id,
             force,
             drain_timeout_secs: _,
+            ..
         } => {
             if let Err(e) = validate_ids(&tenant_id, &pool_id, Some(&instance_id)) {
                 return HostdResponse::Error {
@@ -127,6 +134,7 @@ fn execute(request: HostdRequest) -> HostdResponse {
             tenant_id,
             pool_id,
             instance_id,
+            ..
         } => {
             if let Err(e) = validate_ids(&tenant_id, &pool_id, Some(&instance_id)) {
                 return HostdResponse::Error {
@@ -145,6 +153,7 @@ fn execute(request: HostdRequest) -> HostdResponse {
             pool_id,
             instance_id,
             wipe_volumes,
+            ..
         } => {
             if let Err(e) = validate_ids(&tenant_id, &pool_id, Some(&instance_id)) {
                 return HostdResponse::Error {
@@ -214,6 +223,8 @@ mod tests {
             tenant_id: "INVALID!!".to_string(),
             pool_id: "workers".to_string(),
             instance_id: "i-abc".to_string(),
+            workspace_id: None,
+            volumes: vec![],
         });
         match resp {
             HostdResponse::Error { message } => {
@@ -229,6 +240,7 @@ mod tests {
             tenant_id: "acme".to_string(),
             pool_id: "INVALID!!".to_string(),
             instance_id: "i-abc".to_string(),
+            workspace_id: None,
         });
         match resp {
             HostdResponse::Error { message } => {


### PR DESCRIPTION
## Summary

Cross-repo unblock for [tinylabscom/mvmd#16](https://github.com/tinylabscom/mvmd/pull/16) (branch `feat/mvmd-integrations-memory`, Sprint 139 plan 32 — workspace-scoped memory service).

Promotes the workspace-volume attach surface from mvmd-runtime's local copies into `mvm-core` so the protocol types can thread them without circular deps:

- **`mvm_core::instance::{VolumeMode, VolumeAttach, WorkloadClass}`** — promoted from mvmd-runtime. `WorkloadClass::default()` is `Sandbox`.
- **`mvm_core::instance::DesiredInstance`** — new declarative per-instance shape (identity + `workspace_id`, `volumes`, `workload_class`).
- **`HostdRequest`** — `workspace_id: Option<String>` threaded through every instance-scoped variant (`Start/Stop/Sleep/Wake/Destroy`); `volumes: Vec<VolumeAttach>` added to `StartInstance`.
- **`PROTOCOL_VERSION`** bumped 1 → 2 with v1-payload backward-compat tests + a v2 canonical wire fixture pinned in-test.

All new fields use `#[serde(default)]`, so v1 payloads still deserialize cleanly. The legacy `mvm-hostd` consumer in `crates/mvm/src/hostd/server.rs` ignores the new fields via `..` patterns — wiring volumes into the Firecracker config is mvmd-side (out of scope per the prompt).

## Bump-policy note (ADR-043)

ADR-043 currently says \"do not bump PROTOCOL_VERSION for new fields with `#[serde(default)]`.\" Bumping here is the right call because mvmd's `tests/mvmd_compat.rs` pins frozen-byte fixtures (not parse-result equivalence) — adding a `serde(default)` field changes serialized JSON output (the new key appears with its default value), so the fixture would silently drift without the bump. ADR-043 text could be tightened in a follow-up, but the bump itself follows the prompt and the fixture-test rationale in ADR-043 §\"The mvmd-side gate.\"

## After this lands (mvmd-side)

1. Bump the mvm git pin in `mvmd/Cargo.toml`.
2. Drop local `VolumeMode` / `VolumeAttach` / `WorkloadClass` from `mvmd-runtime`; re-export from `mvm_core::instance`.
3. Plumb `workspace_id` + `volumes` from `DesiredInstance` into the `HostdRequest::StartInstance` mvmd-agent sends.
4. Wire volumes into Firecracker config via `mvmd_runtime::vm::workspace::prepare_workspace_volume_attach`.

## Prompt + origin

- Origin prompt: `tinylabscom/mvmd:specs/prompts/mvm-core-workspace-volume-attach.md` (on `feat/mvmd-integrations-memory`)
- mvmd-side plan: `tinylabscom/mvmd:specs/plans/32-mvmd-integrations-memory.md`

## Test plan

- [x] `cargo build --workspace` clean
- [x] `cargo test --workspace --no-fail-fast` — all suites pass (mvm-core: 537 ✓, mvm: 123 ✓, full workspace zero failures)
- [x] `cargo clippy --workspace --all-targets -- -D warnings` clean
- [x] `cargo fmt -- --check` clean
- [x] New tests cover: `VolumeMode`/`WorkloadClass` snake_case, `WorkloadClass::default() == Sandbox`, `VolumeAttach` roundtrip, `DesiredInstance` full roundtrip + partial-payload defaults + fully-omitted-payload defaults, `HostdRequest::StartInstance` v2 canonical fixture, v1-payload backward compat for `Start/Stop/Sleep/Wake/Destroy`

🤖 Generated with [Claude Code](https://claude.com/claude-code)