### PR TITLE
cleanup: drop dev-VM dependency, promote SlotPrune Emits row to live test

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8699,6 +8699,7 @@ dependencies = [
  "clap",
  "clap_mangen",
  "mvm-cli",
+ "sha2 0.10.9",
  "tempfile",
 ]
 

--- a/crates/mvm-build/src/pipeline/dev_build.rs
+++ b/crates/mvm-build/src/pipeline/dev_build.rs
@@ -186,24 +186,62 @@ pub struct DevBuildCleanupReport {
 
 /// Remove old cached dev builds, keeping the newest `keep` revisions.
 ///
-/// Returns a report with the number of removed revisions and removed paths.
+/// Operates directly on the host filesystem under [`dev_builds_dir`]
+/// (`~/.mvm/dev/builds/`). Lima-era versions of this function shelled
+/// through `ShellEnvironment` so the `ls`/`rm` ran inside the dev VM,
+/// but the dev VM only ever bind-mounted the same host directory —
+/// the indirection was the artifact of a now-retired runtime, not a
+/// semantic requirement. Running on the host directly drops the
+/// dev-VM dependency: `mvmctl cleanup` now works in CI / fresh
+/// installs where the builder VM isn't (yet) reachable.
+///
+/// Returns a report with the number of removed revisions and the
+/// list of removed absolute paths.
 #[instrument(skip_all, fields(keep))]
-pub fn cleanup_old_dev_builds(
-    env: &dyn ShellEnvironment,
-    keep: usize,
-) -> Result<DevBuildCleanupReport> {
-    let builds_dir = dev_builds_dir();
-    let list_script = format!(
-        "if [ -d {dir} ]; then ls -1dt {dir}/* 2>/dev/null || true; fi",
-        dir = shell_quote(&builds_dir),
-    );
-    let output = env.shell_exec_stdout(&list_script)?;
-    let builds: Vec<&str> = output
-        .lines()
-        .filter(|line| !line.trim().is_empty())
-        .collect();
+pub fn cleanup_old_dev_builds(keep: usize) -> Result<DevBuildCleanupReport> {
+    cleanup_builds_in(std::path::Path::new(&dev_builds_dir()), keep)
+}
 
-    if builds.len() <= keep {
+/// Inner helper that operates on an explicit `builds_dir`. Lifted
+/// out so unit tests can drive the logic against a tempdir without
+/// touching `HOME` / `MVM_DATA_DIR`. The public
+/// [`cleanup_old_dev_builds`] is the production entry point.
+///
+/// Newest-first sort uses mtime. Ties go to lexicographic order so a
+/// deterministic outcome survives the rare clock-resolution collision.
+fn cleanup_builds_in(builds_dir: &std::path::Path, keep: usize) -> Result<DevBuildCleanupReport> {
+    if !builds_dir.is_dir() {
+        return Ok(DevBuildCleanupReport {
+            removed_count: 0,
+            removed_paths: vec![],
+        });
+    }
+
+    // Collect (path, mtime) tuples for every immediate child dir.
+    // Files at this level are unexpected — the layout is one dir per
+    // revision hash — but we tolerate them by ignoring (they're not
+    // candidates for prune).
+    let mut entries: Vec<(std::path::PathBuf, std::time::SystemTime)> = Vec::new();
+    for entry in std::fs::read_dir(builds_dir)
+        .with_context(|| format!("reading {}", builds_dir.display()))?
+        .flatten()
+    {
+        let path = entry.path();
+        if !path.is_dir() {
+            continue;
+        }
+        let mtime = entry
+            .metadata()
+            .and_then(|m| m.modified())
+            .unwrap_or(std::time::SystemTime::UNIX_EPOCH);
+        entries.push((path, mtime));
+    }
+    // Newest first; ties broken by lexicographic path order so the
+    // outcome is deterministic on filesystems whose mtime resolution
+    // is coarser than the test loop creates entries.
+    entries.sort_by(|a, b| b.1.cmp(&a.1).then_with(|| a.0.cmp(&b.0)));
+
+    if entries.len() <= keep {
         return Ok(DevBuildCleanupReport {
             removed_count: 0,
             removed_paths: vec![],
@@ -211,9 +249,9 @@ pub fn cleanup_old_dev_builds(
     }
 
     let mut removed_paths = Vec::new();
-    for path in builds.iter().skip(keep) {
-        env.shell_exec(&format!("rm -rf {}", shell_quote(path)))?;
-        removed_paths.push((*path).to_string());
+    for (path, _) in entries.iter().skip(keep) {
+        std::fs::remove_dir_all(path).with_context(|| format!("removing {}", path.display()))?;
+        removed_paths.push(path.display().to_string());
     }
 
     Ok(DevBuildCleanupReport {
@@ -1062,46 +1100,53 @@ mod tests {
 
     #[test]
     fn test_cleanup_old_dev_builds_no_directory() {
-        let env = TestEnv::new();
-        env.stub_stdout("ls -1dt", "");
-
-        let report = cleanup_old_dev_builds(&env, 2).unwrap();
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let report = cleanup_builds_in(&tmp.path().join("does-not-exist"), 2).unwrap();
         assert_eq!(report.removed_count, 0);
         assert!(report.removed_paths.is_empty());
     }
 
     #[test]
     fn test_cleanup_old_dev_builds_keeps_newest() {
-        let env = TestEnv::new();
-        env.stub_stdout(
-            "ls -1dt",
-            concat!(
-                "/home/test/.mvm/dev/builds/newest\n",
-                "/home/test/.mvm/dev/builds/middle\n",
-                "/home/test/.mvm/dev/builds/oldest\n"
-            ),
-        );
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let builds = tmp.path().join("builds");
+        std::fs::create_dir_all(&builds).expect("mkdir builds");
 
-        let report = cleanup_old_dev_builds(&env, 1).unwrap();
+        // Create three build dirs with a 50 ms gap so mtimes are
+        // distinct on filesystems with coarse resolution (HFS+ is
+        // 1 s; APFS / most Linux is 1 ns — 50 ms covers both).
+        for name in ["oldest", "middle", "newest"] {
+            std::fs::create_dir(builds.join(name)).expect("mkdir build subdir");
+            std::thread::sleep(std::time::Duration::from_millis(50));
+        }
+
+        let report = cleanup_builds_in(&builds, 1).unwrap();
         assert_eq!(report.removed_count, 2);
-        assert_eq!(
-            report.removed_paths,
-            vec![
-                "/home/test/.mvm/dev/builds/middle".to_string(),
-                "/home/test/.mvm/dev/builds/oldest".to_string()
-            ]
-        );
-
-        let exec_log = env.exec_log.lock().unwrap();
+        // Removed paths are sorted newest-first then by removal
+        // order — "middle" and "oldest" should be in the report.
+        let names: Vec<String> = report
+            .removed_paths
+            .iter()
+            .filter_map(|p| {
+                std::path::Path::new(p)
+                    .file_name()?
+                    .to_str()
+                    .map(String::from)
+            })
+            .collect();
+        assert!(names.contains(&"oldest".to_string()), "got {names:?}");
+        assert!(names.contains(&"middle".to_string()), "got {names:?}");
         assert!(
-            exec_log
-                .iter()
-                .any(|cmd| cmd.contains("rm -rf '/home/test/.mvm/dev/builds/middle'"))
+            !names.contains(&"newest".to_string()),
+            "newest must be kept; got {names:?}"
         );
         assert!(
-            exec_log
-                .iter()
-                .any(|cmd| cmd.contains("rm -rf '/home/test/.mvm/dev/builds/oldest'"))
+            builds.join("newest").is_dir(),
+            "newest build dir must still exist on disk"
+        );
+        assert!(
+            !builds.join("middle").exists() && !builds.join("oldest").exists(),
+            "pruned build dirs must be removed from disk"
         );
     }
 

--- a/crates/mvm-cli/src/commands/bundle/gc.rs
+++ b/crates/mvm-cli/src/commands/bundle/gc.rs
@@ -118,11 +118,7 @@ pub(in crate::commands) fn run(_cli: &Cli, args: Args, _cfg: &MvmConfig) -> Resu
         }
         s
     };
-    mvm_core::audit::emit(
-        mvm_core::audit::LocalAuditKind::BundleGc,
-        None,
-        Some(&detail),
-    );
+    mvm_core::audit_emit!(BundleGc, "{detail}");
 
     println!("Removed {} bundle(s).", removed.len());
     for sha in &removed {

--- a/crates/mvm-cli/src/commands/bundle/install.rs
+++ b/crates/mvm-cli/src/commands/bundle/install.rs
@@ -68,13 +68,11 @@ pub(in crate::commands) fn run(_cli: &Cli, args: Args, _cfg: &MvmConfig) -> Resu
         .install(&bytes, &trust, args.force)
         .with_context(|| format!("installing bundle from {}", args.source))?;
 
-    mvm_core::audit::emit(
-        mvm_core::audit::LocalAuditKind::BundleInstall,
-        None,
-        Some(&format!(
-            "bundle_sha256={},key_id={}",
-            installed.sha256, installed.manifest.key_id.0,
-        )),
+    mvm_core::audit_emit!(
+        BundleInstall,
+        "bundle_sha256={},key_id={}",
+        installed.sha256,
+        installed.manifest.key_id.0,
     );
 
     println!(

--- a/crates/mvm-cli/src/commands/env/apple_container.rs
+++ b/crates/mvm-cli/src/commands/env/apple_container.rs
@@ -563,10 +563,29 @@ fn ensure_dev_image() -> Result<(String, String)> {
         .with_context(|| format!("creating prebuilt dir {prebuilt_dir}"))?;
     let kernel_path = format!("{prebuilt_dir}/vmlinux");
     let rootfs_path = format!("{prebuilt_dir}/rootfs.ext4");
-    // Cache hit on the current version's dir — fast path.
+    // Cache hit on the current version's dir — fast path. Validate
+    // first; if either file is below the size floor or the rootfs
+    // lacks the ext4 magic, treat the cache as poisoned and delete it
+    // so the cascade below can re-populate from a healthy source. The
+    // typical poisoning vector is an earlier copy from a stub or
+    // half-downloaded source — the size floor catches the stub case
+    // (~12 B vs. ~16 MiB minimum), and the magic check catches a
+    // wrong-format file at the right size.
     if std::path::Path::new(&kernel_path).exists() && std::path::Path::new(&rootfs_path).exists() {
-        prune_old_prebuilts(&prebuilt_root, version);
-        return Ok((kernel_path, rootfs_path));
+        match validate_dev_image_artifacts(&kernel_path, &rootfs_path) {
+            Ok(()) => {
+                prune_old_prebuilts(&prebuilt_root, version);
+                return Ok((kernel_path, rootfs_path));
+            }
+            Err(e) => {
+                ui::warn(&format!(
+                    "Cached dev image at {prebuilt_dir} failed sanity check ({e}); \
+                     deleting and rebuilding."
+                ));
+                let _ = std::fs::remove_file(&kernel_path);
+                let _ = std::fs::remove_file(&rootfs_path);
+            }
+        }
     }
     // Source-checkout-first. When the binary was compiled out of an
     // mvm source tree that has `nix/images/dev-prebuilt/<arch>/`
@@ -577,6 +596,12 @@ fn ensure_dev_image() -> Result<(String, String)> {
     // for source checkouts that haven't vendored anything yet, in
     // which case we fall through to the published prebuilt as before.
     if let Some((src_kernel, src_rootfs, source_label)) = find_vendored_dev_image() {
+        validate_dev_image_artifacts(&src_kernel, &src_rootfs).with_context(|| {
+            format!(
+                "vendored dev image at {source_label} failed sanity check — \
+                 refusing to copy garbage into the prebuilt cache"
+            )
+        })?;
         ui::info(&format!(
             "Using vendored dev image from source checkout ({source_label})."
         ));
@@ -658,6 +683,15 @@ fn find_local_fallback_image() -> Option<(std::path::PathBuf, std::path::PathBuf
             if !kernel.is_file() || !rootfs.is_file() {
                 continue;
             }
+            // Silently skip cache entries that look corrupt (stub
+            // bytes from a botched earlier copy, half-written
+            // downloads, etc.). The auto-discover path is best-effort
+            // — surfacing every bad candidate as a warning would
+            // spam the boot path; the cascade just falls through to
+            // a healthier candidate or to the next layer.
+            if validate_dev_image_artifacts(&kernel, &rootfs).is_err() {
+                continue;
+            }
             let mtime = std::fs::metadata(&rootfs)
                 .and_then(|m| m.modified())
                 .unwrap_or(std::time::UNIX_EPOCH);
@@ -669,6 +703,78 @@ fn find_local_fallback_image() -> Option<(std::path::PathBuf, std::path::PathBuf
     candidates.sort_by_key(|(mtime, ..)| *mtime);
     let (_, dir, label) = candidates.into_iter().next_back()?;
     Some((dir.join("vmlinux"), dir.join("rootfs.ext4"), label))
+}
+
+/// Sanity-check that a `(vmlinux, rootfs.ext4)` pair looks like a real
+/// dev image. Fast-fails before copying or returning the artifacts as
+/// usable, so a stub or truncated file can't poison the prebuilt cache.
+///
+/// Two checks per file:
+///
+/// - **Size floor.** A real `vmlinux` is several MiB (typical ARM64
+///   Image is 15–20 MiB); a real `rootfs.ext4` is ~700 MiB. Reject
+///   anything under a conservative floor (1 MiB / 4 MiB respectively)
+///   to catch the stub-file case (~12 B from a botched test, ~0 B
+///   from a torn-down download).
+/// - **Ext4 magic.** The ext4 superblock starts at byte 1024; the
+///   `s_magic` field is at byte 1080 (offset 56 inside the
+///   superblock) and equals `0xEF53` little-endian. Only the rootfs
+///   gets this check — `vmlinux` formats vary by arch (ARM64
+///   `Image`, x86 bzImage, etc.) so there's no portable magic to
+///   match.
+fn validate_dev_image_artifacts(
+    kernel: impl AsRef<std::path::Path>,
+    rootfs: impl AsRef<std::path::Path>,
+) -> Result<()> {
+    const KERNEL_MIN_BYTES: u64 = 1024 * 1024;
+    const ROOTFS_MIN_BYTES: u64 = 4 * 1024 * 1024;
+    const EXT4_MAGIC_OFFSET: u64 = 1024 + 56;
+    const EXT4_MAGIC: [u8; 2] = [0x53, 0xEF];
+
+    let kernel = kernel.as_ref();
+    let rootfs = rootfs.as_ref();
+
+    let kernel_size = std::fs::metadata(kernel)
+        .with_context(|| format!("stat {}", kernel.display()))?
+        .len();
+    if kernel_size < KERNEL_MIN_BYTES {
+        anyhow::bail!(
+            "kernel at {} is only {} bytes (expected ≥ {})",
+            kernel.display(),
+            kernel_size,
+            KERNEL_MIN_BYTES,
+        );
+    }
+
+    let rootfs_size = std::fs::metadata(rootfs)
+        .with_context(|| format!("stat {}", rootfs.display()))?
+        .len();
+    if rootfs_size < ROOTFS_MIN_BYTES {
+        anyhow::bail!(
+            "rootfs at {} is only {} bytes (expected ≥ {})",
+            rootfs.display(),
+            rootfs_size,
+            ROOTFS_MIN_BYTES,
+        );
+    }
+
+    use std::io::{Read, Seek, SeekFrom};
+    let mut f =
+        std::fs::File::open(rootfs).with_context(|| format!("open {}", rootfs.display()))?;
+    f.seek(SeekFrom::Start(EXT4_MAGIC_OFFSET))
+        .with_context(|| format!("seek to ext4 magic in {}", rootfs.display()))?;
+    let mut magic = [0u8; 2];
+    f.read_exact(&mut magic)
+        .with_context(|| format!("read ext4 magic from {}", rootfs.display()))?;
+    if magic != EXT4_MAGIC {
+        anyhow::bail!(
+            "rootfs at {} does not have ext4 magic at offset {} (got {magic:02x?})",
+            rootfs.display(),
+            EXT4_MAGIC_OFFSET,
+        );
+    }
+
+    Ok(())
 }
 
 /// Look for a vendored dev image inside the source checkout the mvmctl

--- a/crates/mvm-cli/src/commands/env/cleanup.rs
+++ b/crates/mvm-cli/src/commands/env/cleanup.rs
@@ -30,20 +30,27 @@ pub(in crate::commands) fn run(_cli: &Cli, args: Args, _cfg: &MvmConfig) -> Resu
         anyhow::bail!("--keep must be greater than 0 (or use --all)");
     }
 
-    // Show disk usage before cleanup.
+    // Show disk usage before cleanup. Reads the dev VM if it's up;
+    // returns `None` if it isn't (and we keep going — disk reporting
+    // is informational, not load-bearing).
     let disk_before = vm_disk_usage_pct();
     if let Some(pct) = disk_before {
-        ui::info(&format!("Lima VM disk usage: {}%", pct));
+        ui::info(&format!("Dev VM disk usage: {}%", pct));
     }
 
-    // Step 1: Clear temp files first — when the disk is 100% full the nix
-    // daemon cannot start, so we need to free a little space before GC.
+    // Step 1: Clear temp files inside the dev VM. Best-effort — the
+    // call discards its Result so an unreachable VM degrades to a
+    // silent skip (the host doesn't have its own /tmp blowup to
+    // clean; the VM is the only place that fills up).
     ui::info("Clearing temporary files...");
     let _ = shell::run_in_vm("sudo rm -rf /tmp/* /var/tmp/* 2>/dev/null");
 
-    // Step 2: Remove old dev-build symlinks and artifacts.
-    let env = mvm::build_env::RuntimeBuildEnv;
-    let report = mvm_build::dev_build::cleanup_old_dev_builds(&env, keep_count)?;
+    // Step 2: Remove old dev-build subdirs under `~/.mvm/dev/builds/`.
+    // Pure host filesystem work — no dev-VM dependency. Earlier
+    // versions shelled through `ShellEnvironment`, but the VM only
+    // bind-mounted the same host path; the indirection has been
+    // dropped along with the rest of the Lima-era plumbing.
+    let report = mvm_build::dev_build::cleanup_old_dev_builds(keep_count)?;
 
     if args.verbose {
         if report.removed_paths.is_empty() {
@@ -68,7 +75,7 @@ pub(in crate::commands) fn run(_cli: &Cli, args: Args, _cfg: &MvmConfig) -> Resu
         ));
     }
 
-    // Step 3: Garbage-collect unreferenced Nix store paths inside the Lima VM.
+    // Step 3: Garbage-collect unreferenced Nix store paths inside the dev VM.
     ui::info("Running nix-collect-garbage...");
     match shell::run_in_vm_stdout("nix-collect-garbage -d 2>&1 | tail -3") {
         Ok(output) => {
@@ -102,13 +109,22 @@ pub(in crate::commands) fn run(_cli: &Cli, args: Args, _cfg: &MvmConfig) -> Resu
             Some(before) if before > pct => format!(" (freed {}%)", before - pct),
             _ => String::new(),
         };
-        ui::success(&format!("Lima VM disk usage: {}%{}", pct, freed_msg));
+        ui::success(&format!("Dev VM disk usage: {}%{}", pct, freed_msg));
     }
+
+    // Plan 60 Phase 4 / Plan 37 §6 — every state-changing CLI verb
+    // emits one audit record per attempt, even on no-op. `cleanup`
+    // mutates the host's `~/.mvm/dev/builds/` directory (Step 2);
+    // the count lands in the audit detail so an operator scanning
+    // the log can correlate cache-eviction events with disk-usage
+    // dips.
+    let removed = report.removed_count;
+    mvm_core::audit_emit!(SlotPrune, "source=cleanup removed={removed}");
 
     Ok(())
 }
 
-/// Read the Lima VM root filesystem usage percentage.
+/// Read the dev VM root filesystem usage percentage.
 fn vm_disk_usage_pct() -> Option<u8> {
     let output = shell::run_in_vm_stdout("df --output=pcent / 2>/dev/null | tail -1").ok()?;
     output.trim().trim_end_matches('%').trim().parse().ok()

--- a/crates/mvm-cli/src/commands/manifest/export_oci.rs
+++ b/crates/mvm-cli/src/commands/manifest/export_oci.rs
@@ -89,11 +89,7 @@ pub(in crate::commands) fn run(_cli: &Cli, args: Args, _cfg: &MvmConfig) -> Resu
     })?;
     let bytes = std::fs::metadata(&args.out).map(|m| m.len()).unwrap_or(0);
 
-    mvm_core::audit::emit(
-        mvm_core::audit::LocalAuditKind::ImageExportOci,
-        None,
-        Some(&format!("template={slot_hash},bytes={bytes}")),
-    );
+    mvm_core::audit_emit!(ImageExportOci, "template={slot_hash},bytes={bytes}");
 
     println!(
         "Exported OCI tarball to {} ({} bytes)",

--- a/crates/mvm-cli/src/commands/trust/add.rs
+++ b/crates/mvm-cli/src/commands/trust/add.rs
@@ -72,11 +72,7 @@ pub(in crate::commands) fn run(_cli: &Cli, args: Args, _cfg: &MvmConfig) -> Resu
         perms.set_mode(0o644);
         std::fs::set_permissions(&dst, perms)?;
     }
-    mvm_core::audit::emit(
-        mvm_core::audit::LocalAuditKind::TrustAdd,
-        None,
-        Some(&format!("key_id={}", key_id.0)),
-    );
+    mvm_core::audit_emit!(TrustAdd, "key_id={}", key_id.0);
 
     println!("Trusted key_id {}", key_id.0);
     Ok(())

--- a/crates/mvm-cli/src/commands/trust/remove.rs
+++ b/crates/mvm-cli/src/commands/trust/remove.rs
@@ -28,11 +28,7 @@ pub(in crate::commands) fn run(_cli: &Cli, args: Args, _cfg: &MvmConfig) -> Resu
     let path = dir.join(format!("{}.pub", id.0));
     match std::fs::remove_file(&path) {
         Ok(()) => {
-            mvm_core::audit::emit(
-                mvm_core::audit::LocalAuditKind::TrustRemove,
-                None,
-                Some(&format!("key_id={}", id.0)),
-            );
+            mvm_core::audit_emit!(TrustRemove, "key_id={}", id.0);
             println!("Removed key_id {}", id.0);
             Ok(())
         }

--- a/nix/images/builder/flake.nix
+++ b/nix/images/builder/flake.nix
@@ -1,0 +1,185 @@
+{
+  description = "mvm dev VM image — Linux kernel + ext4 rootfs with Nix + build tools";
+
+  # ── Why this flake exists ────────────────────────────────────────────
+  #
+  # `cargo xtask build-dev-image` runs `nix build` against
+  # `packages.<system>.default` here, expects a derivation whose `$out`
+  # directory contains `vmlinux` and `rootfs.ext4`, and drops those into
+  # the vendored slot at `nix/images/dev-prebuilt/<arch>/` where
+  # `mvm_cli::commands::env::apple_container::find_vendored_dev_image`
+  # picks them up at highest precedence. The same shape is what
+  # `.github/workflows/release.yml`'s `dev-image` job uploads to the
+  # release page; the source-checkout and release-page paths share one
+  # contract.
+  #
+  # ── Architecture ─────────────────────────────────────────────────────
+  #
+  # We bring in the parent `mvm` flake as an input. The parent exposes
+  # `lib.<system>.mkGuest` (`nix/lib/mk-guest.nix`) which builds a
+  # busybox-PID-1 rootfs with the production `mvm-guest-agent` baked
+  # in — that binary is load-bearing for `mvmctl console`,
+  # `mvmctl dev shell`, and every guest-side hook the host CLI relies
+  # on. Replicating that wiring outside `mkGuest` would mean re-doing
+  # the vsock + setpriv + uid-drop dance that ADR-002 §W2-§W4
+  # specifies, so this flake leans on `mkGuest` instead.
+  #
+  # `mkGuest` returns an ext4 image derivation; we pair it with a
+  # nixpkgs-built Linux kernel and `runCommand`-wrap both into a
+  # single output directory.
+
+  inputs = {
+    # Point at the parent flake. `path:../..` resolves relative to
+    # this flake's directory at evaluation time. Falls back through
+    # the standard flake resolution if invoked with an explicit
+    # `--override-input mvm <abs-path>`.
+    mvm.url = "path:../..";
+    # Pin nixpkgs through the parent so version drift between flakes
+    # doesn't surface as "two store paths for the same library."
+    nixpkgs.follows = "mvm/nixpkgs";
+  };
+
+  outputs =
+    { self, mvm, nixpkgs, ... }:
+    let
+      # Only Linux targets — the dev VM is a Linux microVM regardless
+      # of host. `mvmctl` consumes `aarch64` on Apple Silicon and on
+      # aarch64-linux, `x86_64` everywhere else; the flake exposes
+      # both so the matrix in `release.yml` and the xtask can pick
+      # either by system identifier.
+      systems = [ "aarch64-linux" "x86_64-linux" ];
+      forAllSystems = nixpkgs.lib.genAttrs systems;
+
+      # The set of packages baked into the rootfs. Keep this list
+      # tight — every entry expands the closure and the rootfs size,
+      # and the rootfs travels through every `dev up` cache layer.
+      # The contents mirror what `nix/images/builder/flake.nix` at
+      # commit 20f776e (the historical version, retired with v1)
+      # carried — same shape, but pruned to what the current
+      # mvmctl + microsandbox path actually needs.
+      builderPackages = pkgs: with pkgs; [
+        # Core shell + textutils so `mvmctl dev shell` is usable.
+        bashInteractive
+        coreutils
+        gnugrep
+        gnused
+        gawk
+        findutils
+        which
+        less
+
+        # `nix` itself — the whole point of the builder VM is running
+        # `nix build` against user flakes.
+        nix
+        git
+
+        # Common build deps a user flake might shell out to.
+        gnumake
+        curl
+        jq
+
+        # Networking helpers for the bridge_ensure path in
+        # `mvm-runtime/src/vm/network.rs`. iptables stays here even
+        # though we're not doing host-side networking on macOS —
+        # when this image is consumed by an mvmd worker on Linux,
+        # iptables is what gates the per-tenant bridge.
+        iproute2
+        iptables
+
+        # Filesystem + process tools used by both nix-collect-garbage
+        # and by `mvmctl dev shell` interactive sessions.
+        e2fsprogs
+        util-linux
+        procps
+      ];
+
+      # Build the kernel + rootfs pair for a given system. Wrapped in
+      # a `runCommand` so the output is a directory `mvmctl` can scan
+      # rather than an arbitrarily-named .img file.
+      mkBuilderImage = system:
+        let
+          pkgs = import nixpkgs { inherit system; };
+
+          # mkGuest with the dev variant: `entrypoint.shell` triggers
+          # the dev-shell feature on the guest agent (the `do_exec`
+          # vsock handler that `mvmctl exec`/`console` rely on) and
+          # makes the rootfs `passthru.mvm.accessible = true`, so
+          # `mvmctl dev shell` actually attaches.
+          rootfs = mvm.lib.${system}.mkGuest {
+            name = "mvm-dev";
+            entrypoint.shell = "/bin/sh";
+            packages = builderPackages pkgs;
+          };
+
+          # nixpkgs's default Linux kernel for the target system.
+          # `linuxPackages.kernel` is the stable channel selection;
+          # bumping to a newer LTS is a future config knob.
+          # `kernelFile` resolves to "Image" on aarch64 and "bzImage"
+          # on x86_64 — both Apple Container and Firecracker accept
+          # the raw kernel image at those names.
+          kernelPkg = pkgs.linuxPackages.kernel;
+          kernelFile =
+            if pkgs.stdenv.hostPlatform.isAarch64
+            then "Image"
+            else "bzImage";
+        in
+        pkgs.runCommand "mvm-dev-image-${system}"
+          {
+            # Surface the inputs so a debugger / `nix eval` can pick
+            # them apart without re-running the build.
+            passthru = {
+              inherit rootfs;
+              kernel = kernelPkg;
+              inherit (rootfs.passthru) mvm;
+            };
+          }
+          ''
+            mkdir -p $out
+
+            # Kernel image → $out/vmlinux. Try the arch-appropriate
+            # filename first, then fall back to either common name
+            # so a kernel package built with a non-default config
+            # still resolves.
+            if [ -f ${kernelPkg}/${kernelFile} ]; then
+              cp ${kernelPkg}/${kernelFile} $out/vmlinux
+            elif [ -f ${kernelPkg}/Image ]; then
+              cp ${kernelPkg}/Image $out/vmlinux
+            elif [ -f ${kernelPkg}/bzImage ]; then
+              cp ${kernelPkg}/bzImage $out/vmlinux
+            else
+              echo "kernel package ${kernelPkg} did not produce Image or bzImage" >&2
+              ls -la ${kernelPkg} >&2
+              exit 1
+            fi
+
+            # Rootfs → $out/rootfs.ext4. mkGuest's output is an
+            # ext4 image; nixpkgs `make-ext4-fs.nix` emits the .img
+            # file inside the derivation `$out` directory. Handle
+            # both the "single file is $out" and "$out is a dir
+            # containing the .img" cases — exact shape varies by
+            # nixpkgs version.
+            if [ -f ${rootfs} ]; then
+              cp ${rootfs} $out/rootfs.ext4
+            else
+              img=$(find ${rootfs} -maxdepth 1 -name '*.img' -o -name '*.ext4' | head -1)
+              if [ -z "$img" ]; then
+                echo "mkGuest output at ${rootfs} contains no .img or .ext4 file" >&2
+                ls -la ${rootfs} >&2
+                exit 1
+              fi
+              cp "$img" $out/rootfs.ext4
+            fi
+
+            chmod 0644 $out/vmlinux $out/rootfs.ext4
+          '';
+    in
+    {
+      # `packages.<sys>.default` is the contract the xtask + the
+      # release workflow share. Keep the attribute name stable;
+      # additional variants (e.g., a future sealed builder image)
+      # land as sibling attributes, not replacements.
+      packages = forAllSystems (system: {
+        default = mkBuilderImage system;
+      });
+    };
+}

--- a/tests/audit_emissions_live.rs
+++ b/tests/audit_emissions_live.rs
@@ -34,6 +34,11 @@
 //!   path key)
 //! - `mvmctl config set <key> <value>` → `ConfigChange`
 //! - `mvmctl config show` → **no** audit entry
+//! - `mvmctl cleanup --keep 5` → `SlotPrune`
+//!   (`source=cleanup removed=N`; the VM-dependent Step 1 / Step 3
+//!   degrade to warnings when the dev VM isn't reachable, but
+//!   Step 2 — the build-cache prune — runs on host fs and the
+//!   audit emit always fires)
 //! - `mvmctl snapshot rm <name>` → `SnapshotDelete`
 //!   (test pre-creates `~/.mvm/instances/<name>/snapshot/` so the
 //!   bail-when-missing branch doesn't short-circuit the emit)
@@ -694,6 +699,46 @@ fn config_show_does_not_emit_audit_entry() {
         hits, 0,
         "read-only `config show` must not emit; got {hits} \
          config_change entry/entries. Full log:\n{log}"
+    );
+}
+
+#[test]
+fn cleanup_emits_slot_prune_audit_entry_even_with_no_builds() {
+    // `mvmctl cleanup --keep 5` is the highest-friction Emits row
+    // promoted to a live test: it runs three steps, two of which
+    // (`run_in_vm` for /tmp cleanup + nix-collect-garbage) need a
+    // running dev VM. Pre-refactor, the verb panicked out before
+    // reaching the audit emit when the VM was unreachable. The
+    // host-fallback in `cleanup_old_dev_builds` (now plain
+    // `std::fs::read_dir` / `remove_dir_all`) lets Step 2 succeed
+    // against `~/.mvm/dev/builds/` directly; the VM-dependent
+    // steps degrade to warnings, and the emit lands at the end
+    // regardless. The test asserts the empty-cache case (zero
+    // build dirs to prune) — `count=0` is the Plan 37 §6
+    // every-attempt-emits invariant in action.
+    let sandbox = AuditSandbox::new();
+    let output = sandbox
+        .mvmctl()
+        .args(["cleanup", "--keep", "5"])
+        .output()
+        .expect("spawn mvmctl");
+    assert!(
+        output.status.success(),
+        "mvmctl cleanup --keep 5 failed: stderr={}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+
+    let log = read_audit_log(&sandbox.audit_log_path());
+    let hits = count_entries_with_kind(&log, "slot_prune");
+    assert!(
+        hits >= 1,
+        "expected ≥1 slot_prune entry in audit log, got {hits}. \
+         Full log:\n{log}"
+    );
+    assert!(
+        log.contains("source=cleanup"),
+        "slot_prune detail must carry source=cleanup to disambiguate \
+         from manifest-prune emits. Full log:\n{log}"
     );
 }
 

--- a/tests/audit_emissions_live.rs
+++ b/tests/audit_emissions_live.rs
@@ -49,6 +49,10 @@
 //!   (top-level ReadOnly verbs — three more rows from
 //!   `AUDIT_POSTURE` pinned against a future regression that
 //!   adds an emit to a read-only path)
+//! - `mvmctl uninstall --yes --dry-run` → **no** audit entry
+//!   (the positive `Uninstall` path is real-system-destructive
+//!   and not safely-hermetic, but the dry-run path is read-only
+//!   by contract and can be pinned)
 //! - `mvmctl secret put / get / ls / rm` → secret-side audit JSONL
 //!   at `~/.mvm/audit/secrets.jsonl` carries one entry per call
 //!   with `"action":"put"` / `"get"` / `"list"` / `"delete"`. The
@@ -944,6 +948,37 @@ fn catalog_list_does_not_emit_audit_entry() {
         log.is_empty(),
         "read-only `mvmctl catalog list` must not write to the \
          LocalAudit stream. Full log:\n{log}"
+    );
+}
+
+#[test]
+fn uninstall_dry_run_does_not_emit_audit_entry() {
+    // `mvmctl uninstall --yes` emits `Uninstall` at the end, but
+    // its three filesystem mutations (`/var/lib/mvm`, `~/.mvm/`,
+    // `/usr/local/bin/mvmctl`) are real system paths that can't
+    // safely be exercised in a hermetic test — a dev with an
+    // actual install on the local machine would have sudo block
+    // the test mid-run. The dry-run path returns before any of
+    // those steps and (per the implementation) before the audit
+    // emit; this test pins that contract.
+    let sandbox = AuditSandbox::new();
+    let output = sandbox
+        .mvmctl()
+        .args(["uninstall", "--yes", "--dry-run"])
+        .output()
+        .expect("spawn mvmctl");
+    assert!(
+        output.status.success(),
+        "mvmctl uninstall --yes --dry-run failed: stderr={}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+
+    let log = read_audit_log(&sandbox.audit_log_path());
+    let hits = count_entries_with_kind(&log, "uninstall");
+    assert_eq!(
+        hits, 0,
+        "dry-run must not write uninstall audit entries, got {hits}. \
+         Full log:\n{log}"
     );
 }
 

--- a/tests/audit_emissions_live.rs
+++ b/tests/audit_emissions_live.rs
@@ -45,6 +45,10 @@
 //! - `mvmctl snapshot ls` → **no** audit entry
 //! - `mvmctl audit tail` / `audit verify` → **no** audit entry
 //! - `mvmctl attest status` → **no** audit entry
+//! - `mvmctl ls` / `metrics` / `catalog list` → **no** audit entry
+//!   (top-level ReadOnly verbs — three more rows from
+//!   `AUDIT_POSTURE` pinned against a future regression that
+//!   adds an emit to a read-only path)
 //! - `mvmctl secret put / get / ls / rm` → secret-side audit JSONL
 //!   at `~/.mvm/audit/secrets.jsonl` carries one entry per call
 //!   with `"action":"put"` / `"get"` / `"list"` / `"delete"`. The
@@ -866,6 +870,80 @@ fn audit_verify_does_not_emit_local_audit_entry() {
         log.is_empty(),
         "read-only `audit verify` must not write to the LocalAudit \
          stream. Full log:\n{log}"
+    );
+}
+
+#[test]
+fn top_level_ls_does_not_emit_audit_entry() {
+    // `mvmctl ls` reports running VMs. Pure read. Top-level
+    // `("ls", AuditPosture::ReadOnly)` row in `AUDIT_POSTURE`.
+    // Pinning the empty-sandbox case — output is "No running VMs."
+    // and the audit log stays empty.
+    let sandbox = AuditSandbox::new();
+    let output = sandbox
+        .mvmctl()
+        .args(["ls"])
+        .output()
+        .expect("spawn mvmctl");
+    assert!(
+        output.status.success(),
+        "mvmctl ls failed: stderr={}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+
+    let log = read_audit_log(&sandbox.audit_log_path());
+    assert!(
+        log.is_empty(),
+        "read-only `mvmctl ls` must not write to the LocalAudit \
+         stream. Full log:\n{log}"
+    );
+}
+
+#[test]
+fn metrics_does_not_emit_audit_entry() {
+    // `mvmctl metrics` prints Prometheus exposition. Pure read.
+    let sandbox = AuditSandbox::new();
+    let output = sandbox
+        .mvmctl()
+        .args(["metrics"])
+        .output()
+        .expect("spawn mvmctl");
+    assert!(
+        output.status.success(),
+        "mvmctl metrics failed: stderr={}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+
+    let log = read_audit_log(&sandbox.audit_log_path());
+    assert!(
+        log.is_empty(),
+        "read-only `mvmctl metrics` must not write to the LocalAudit \
+         stream. Full log:\n{log}"
+    );
+}
+
+#[test]
+fn catalog_list_does_not_emit_audit_entry() {
+    // `mvmctl catalog list` enumerates bundled images. The catalog
+    // is compiled in; no disk reads beyond mvmctl's binary itself.
+    // Pure read.
+    let sandbox = AuditSandbox::new();
+    let output = sandbox
+        .mvmctl()
+        .args(["catalog", "list"])
+        .output()
+        .expect("spawn mvmctl");
+    assert!(
+        output.status.success(),
+        "mvmctl catalog list failed: stderr={}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+
+    let log = read_audit_log(&sandbox.audit_log_path());
+    assert!(
+        log.is_empty(),
+        "read-only `mvmctl catalog list` must not write to the \
+         LocalAudit stream. Full log:\n{log}"
     );
 }
 

--- a/xtask/Cargo.toml
+++ b/xtask/Cargo.toml
@@ -9,6 +9,7 @@ anyhow.workspace = true
 clap.workspace = true
 clap_mangen.workspace = true
 mvm-cli.workspace = true
+sha2.workspace = true
 
 [dev-dependencies]
 tempfile.workspace = true

--- a/xtask/src/build_dev_image.rs
+++ b/xtask/src/build_dev_image.rs
@@ -1,0 +1,330 @@
+//! `cargo xtask build-dev-image` — build the dev VM image via Nix and drop
+//! the outputs into the vendored slot at
+//! `nix/images/dev-prebuilt/<arch>/{vmlinux, rootfs.ext4}`.
+//!
+//! That slot is the highest-precedence source in
+//! `mvm_cli::commands::env::apple_container::find_vendored_dev_image` — when
+//! the binary runs from a source checkout that has those files, it boots
+//! from them directly and skips the GitHub-release download. So populating
+//! the slot is what flips `mvmctl dev up` from "downloading prebuilt"
+//! (currently a 404 against `tinylabscom/mvm` v0.14.0) to "using vendored
+//! dev image from source checkout".
+//!
+//! ## Contract
+//!
+//! Mirrors the asset-shape produced by `.github/workflows/release.yml`'s
+//! `dev-image` job: each invocation produces an `<arch>` sibling under
+//! `nix/images/dev-prebuilt/` with:
+//!
+//! - `vmlinux` — the kernel image.
+//! - `rootfs.ext4` — the ext4 root filesystem.
+//! - `checksums-sha256.txt` — SHA-256 of both files, in the same
+//!   `<hash>  <name>` format that `sha256sum` and
+//!   `mvm-security::image_verify::verify_unsigned_checksums` parse.
+//!
+//! ## Prerequisites
+//!
+//! The xtask shells out to `nix build`; the host must have Nix on PATH
+//! and able to build the requested Linux system. On native Linux that's
+//! the kernel's KVM; on macOS that's either a remote builder via
+//! `builders` in `/etc/nix/nix.conf` or `nix-darwin`'s `linux-builder`
+//! NixOS module. Failure to build is propagated with the underlying
+//! Nix stderr — the xtask never silently substitutes a stale or
+//! prebuilt artifact.
+//!
+//! The expected flake is at `nix/images/builder/flake.nix` and exposes
+//! `packages.<system>.default` as a derivation whose `$out` directory
+//! contains `vmlinux` and `rootfs.ext4`. If the flake is missing the
+//! xtask fails fast with a pointer at the git history (commit `20f776e`
+//! has the historical version) so callers know exactly what to restore
+//! before retrying.
+
+use anyhow::{Context, Result};
+use std::path::{Path, PathBuf};
+
+/// Parse `cargo xtask build-dev-image [--arch <arch>]` and dispatch.
+pub fn run(args: &[String], workspace: &Path) -> Result<()> {
+    let mut arch: Option<String> = None;
+    let mut iter = args.iter();
+    while let Some(arg) = iter.next() {
+        match arg.as_str() {
+            "--arch" => {
+                arch = iter.next().cloned();
+            }
+            "--help" | "-h" => {
+                println!("{HELP_TEXT}");
+                return Ok(());
+            }
+            other => anyhow::bail!("Unknown argument to build-dev-image: {other:?}. Try --help."),
+        }
+    }
+
+    let arch = arch.unwrap_or_else(|| host_arch_for_linux().to_string());
+    validate_arch(&arch)?;
+    build_and_install(workspace, &arch)
+}
+
+const HELP_TEXT: &str = "\
+Usage: cargo xtask build-dev-image [--arch <arch>]
+
+Builds the dev VM image via `nix build ./nix/images/builder#packages.<arch>-linux.default`
+and copies vmlinux + rootfs.ext4 + checksums into nix/images/dev-prebuilt/<arch>/.
+
+Args:
+  --arch <arch>   Target architecture (aarch64 or x86_64).
+                  Default: the host architecture mapped to its linux variant
+                  (aarch64-darwin → aarch64, x86_64-linux → x86_64, etc.).
+
+Prerequisites:
+  - `nix` on PATH with flakes enabled.
+  - A working builder for the target Linux system (native KVM on Linux,
+    remote builder or nix-darwin linux-builder on macOS).
+  - The flake at nix/images/builder/flake.nix exposes
+    packages.<arch>-linux.default with vmlinux + rootfs.ext4 in $out.
+";
+
+/// Map the host arch to the matching Linux-system identifier used by
+/// `mvmctl`'s download path (`download_dev_image` uses the same mapping
+/// at `apple_container.rs`). Defaults are "aarch64" on Apple Silicon /
+/// aarch64-linux and "x86_64" everywhere else — mirrors the
+/// `cfg!(target_arch = "aarch64")` test there.
+fn host_arch_for_linux() -> &'static str {
+    if cfg!(target_arch = "aarch64") {
+        "aarch64"
+    } else {
+        "x86_64"
+    }
+}
+
+fn validate_arch(arch: &str) -> Result<()> {
+    if !matches!(arch, "aarch64" | "x86_64") {
+        anyhow::bail!("Unsupported --arch {arch:?}. Supported: aarch64, x86_64.");
+    }
+    Ok(())
+}
+
+fn build_and_install(workspace: &Path, arch: &str) -> Result<()> {
+    let builder_flake = workspace.join("nix").join("images").join("builder");
+    let flake_nix = builder_flake.join("flake.nix");
+    if !flake_nix.exists() {
+        anyhow::bail!(
+            "Builder flake not found at {}.\n\n\
+             The flake existed historically at git commit 20f776e; restore it via\n\
+             `git show 20f776e:nix/images/builder/flake.nix > {}`\n\
+             (adapt inputs as needed — the historical version references a\n\
+             nix/dev/ sibling that no longer exists in the tree).",
+            flake_nix.display(),
+            flake_nix.display(),
+        );
+    }
+
+    if !nix_on_path() {
+        anyhow::bail!(
+            "`nix` not found on PATH. Install Nix from https://nixos.org/download \
+             and re-run."
+        );
+    }
+
+    let attr = format!("packages.{arch}-linux.default");
+    let flake_ref = format!("{}#{attr}", builder_flake.display());
+
+    println!("xtask build-dev-image: nix build {flake_ref}");
+    let store_path = run_nix_build(&flake_ref)?;
+    let store_path = Path::new(&store_path);
+
+    let src_kernel = store_path.join("vmlinux");
+    let src_rootfs = store_path.join("rootfs.ext4");
+    if !src_kernel.is_file() {
+        anyhow::bail!(
+            "nix build succeeded but {} is missing — does the flake's \
+             packages.{arch}-linux.default output expose a vmlinux file in \
+             its $out directory?",
+            src_kernel.display(),
+        );
+    }
+    if !src_rootfs.is_file() {
+        anyhow::bail!(
+            "nix build succeeded but {} is missing — does the flake's \
+             packages.{arch}-linux.default output expose a rootfs.ext4 file \
+             in its $out directory?",
+            src_rootfs.display(),
+        );
+    }
+
+    let dest_dir = vendored_slot(workspace, arch);
+    std::fs::create_dir_all(&dest_dir)
+        .with_context(|| format!("creating vendored slot at {}", dest_dir.display()))?;
+
+    let dest_kernel = dest_dir.join("vmlinux");
+    let dest_rootfs = dest_dir.join("rootfs.ext4");
+    copy_with_mode(&src_kernel, &dest_kernel)?;
+    copy_with_mode(&src_rootfs, &dest_rootfs)?;
+    let checksums = format!(
+        "{}  vmlinux\n{}  rootfs.ext4\n",
+        sha256_hex(&dest_kernel)?,
+        sha256_hex(&dest_rootfs)?,
+    );
+    let checksums_path = dest_dir.join("checksums-sha256.txt");
+    std::fs::write(&checksums_path, checksums)
+        .with_context(|| format!("writing {}", checksums_path.display()))?;
+
+    println!("\nVendored dev image installed:");
+    println!("  {}", dest_kernel.display());
+    println!("  {}", dest_rootfs.display());
+    println!("  {}", checksums_path.display());
+    println!(
+        "\n`mvmctl dev up` from this checkout will now boot from the vendored\n\
+         slot instead of downloading from the release page."
+    );
+    Ok(())
+}
+
+fn nix_on_path() -> bool {
+    std::process::Command::new("nix")
+        .arg("--version")
+        .stdout(std::process::Stdio::null())
+        .stderr(std::process::Stdio::null())
+        .status()
+        .map(|s| s.success())
+        .unwrap_or(false)
+}
+
+/// Run `nix build <flake_ref> --no-link --print-out-paths` and return the
+/// resolved store path of the first output line. Nix's stderr is
+/// inherited so the operator sees per-derivation build progress in real
+/// time — capturing it would silently swallow a 30-minute toolchain
+/// rebuild's status updates.
+fn run_nix_build(flake_ref: &str) -> Result<String> {
+    let output = std::process::Command::new("nix")
+        .args([
+            "--extra-experimental-features",
+            "nix-command flakes",
+            "build",
+            flake_ref,
+            "--no-link",
+            "--print-out-paths",
+        ])
+        .stdout(std::process::Stdio::piped())
+        .stderr(std::process::Stdio::inherit())
+        .output()
+        .with_context(|| format!("spawning `nix build {flake_ref}`"))?;
+    if !output.status.success() {
+        anyhow::bail!(
+            "`nix build {flake_ref}` failed with exit {}. See stderr above.",
+            output.status.code().unwrap_or(-1)
+        );
+    }
+    let stdout = String::from_utf8(output.stdout).context("nix build emitted non-UTF-8 stdout")?;
+    let store_path = stdout
+        .lines()
+        .find(|l| l.starts_with("/nix/store/"))
+        .ok_or_else(|| {
+            anyhow::anyhow!("nix build produced no /nix/store/... output path (stdout: {stdout:?})")
+        })?
+        .trim()
+        .to_string();
+    Ok(store_path)
+}
+
+/// Copy a file, then chmod the destination to 0644 so the operator can
+/// re-run the xtask without `rm`-ing read-only Nix store copies. Nix
+/// store files are mode 0444; `std::fs::copy` preserves source mode by
+/// default, which would make a subsequent overwrite EACCES.
+fn copy_with_mode(src: &Path, dest: &Path) -> Result<()> {
+    std::fs::copy(src, dest)
+        .with_context(|| format!("copying {} → {}", src.display(), dest.display()))?;
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::PermissionsExt;
+        std::fs::set_permissions(dest, std::fs::Permissions::from_mode(0o644))
+            .with_context(|| format!("chmod 0644 on {}", dest.display()))?;
+    }
+    Ok(())
+}
+
+fn sha256_hex(path: &Path) -> Result<String> {
+    use std::io::Read;
+    let mut f = std::fs::File::open(path)
+        .with_context(|| format!("opening {} for hashing", path.display()))?;
+    let mut hasher = sha2::Sha256::new();
+    let mut buf = [0u8; 64 * 1024];
+    loop {
+        let n = f
+            .read(&mut buf)
+            .with_context(|| format!("reading {} during hash", path.display()))?;
+        if n == 0 {
+            break;
+        }
+        use sha2::Digest;
+        hasher.update(&buf[..n]);
+    }
+    use sha2::Digest;
+    Ok(format!("{:x}", hasher.finalize()))
+}
+
+/// Resolve the path the workspace was built from. Lifted out so tests
+/// can target a tempdir without setting `CARGO_MANIFEST_DIR`.
+pub fn vendored_slot(workspace: &Path, arch: &str) -> PathBuf {
+    workspace
+        .join("nix")
+        .join("images")
+        .join("dev-prebuilt")
+        .join(arch)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn validate_arch_accepts_supported() {
+        assert!(validate_arch("aarch64").is_ok());
+        assert!(validate_arch("x86_64").is_ok());
+    }
+
+    #[test]
+    fn validate_arch_rejects_others() {
+        assert!(validate_arch("riscv64").is_err());
+        assert!(validate_arch("").is_err());
+        // Guard against accidentally accepting full system identifiers —
+        // the flake attribute we emit assumes the caller passes the
+        // bare arch and we append `-linux`.
+        assert!(validate_arch("aarch64-linux").is_err());
+    }
+
+    #[test]
+    fn host_arch_is_one_of_the_supported() {
+        let arch = host_arch_for_linux();
+        assert!(validate_arch(arch).is_ok());
+    }
+
+    #[test]
+    fn vendored_slot_resolves_under_workspace() {
+        let tmp = tempfile::tempdir().unwrap();
+        let slot = vendored_slot(tmp.path(), "aarch64");
+        assert!(slot.starts_with(tmp.path()));
+        assert!(slot.ends_with("nix/images/dev-prebuilt/aarch64"));
+    }
+
+    #[test]
+    fn build_fails_with_clear_message_when_flake_missing() {
+        let tmp = tempfile::tempdir().unwrap();
+        let err = build_and_install(tmp.path(), "aarch64").unwrap_err();
+        let msg = format!("{err}");
+        assert!(
+            msg.contains("Builder flake not found"),
+            "expected a clear flake-missing error, got: {msg}"
+        );
+        assert!(
+            msg.contains("20f776e"),
+            "expected the historical-recovery pointer, got: {msg}"
+        );
+    }
+
+    #[test]
+    fn help_flag_short_circuits() {
+        // --help should not require a workspace state — should print and exit Ok.
+        let tmp = tempfile::tempdir().unwrap();
+        run(&["--help".to_string()], tmp.path()).expect("help should be Ok");
+    }
+}

--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -1,6 +1,7 @@
 use anyhow::{Context, Result};
 use std::path::{Path, PathBuf};
 
+mod build_dev_image;
 mod check_adr_coverage;
 mod check_audit_positional;
 mod check_no_display_on_secret_types;
@@ -26,8 +27,12 @@ fn main() -> Result<()> {
             check_audit_positional::run(&workspace)
         }
         Some("perf") => perf::run(&args[2..]),
+        Some("build-dev-image") => {
+            let workspace = workspace_root();
+            build_dev_image::run(&args[2..], &workspace)
+        }
         Some(other) => anyhow::bail!(
-            "Unknown xtask: {:?}. Available: gen-man, check-adr-coverage, check-no-display-on-secret-types, check-audit-positional, perf",
+            "Unknown xtask: {:?}. Available: gen-man, check-adr-coverage, check-no-display-on-secret-types, check-audit-positional, perf, build-dev-image",
             other
         ),
         None => {
@@ -47,6 +52,9 @@ fn main() -> Result<()> {
             );
             eprintln!(
                 "  perf <subcommand>                       Plan 60 Phase 9 perf gates (rootfs-size, boot)"
+            );
+            eprintln!(
+                "  build-dev-image [--arch <arch>]         Build the dev VM image and drop it into nix/images/dev-prebuilt/<arch>/"
             );
             std::process::exit(1);
         }


### PR DESCRIPTION
Replacement for #107 (auto-closed when its base `feat/sprint-51-batch-3` was deleted on the #106 merge). Same content; retargets to main.

See #107 for the full description.

🤖 Generated with [Claude Code](https://claude.com/claude-code)