### PR TITLE
chore: feature-gate sigstore verification

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -241,6 +241,11 @@ backends-microsandbox = [
     "mvm-build/backends-microsandbox",
     "mvm-cli/backends-microsandbox",
 ]
+manifest-verify = [
+    "mvm/manifest-verify",
+    "mvm-cli/manifest-verify",
+    "mvm-security/manifest-verify",
+]
 
 [profile.release]
 opt-level = 3

--- a/crates/mvm-cli/Cargo.toml
+++ b/crates/mvm-cli/Cargo.toml
@@ -66,6 +66,10 @@ backends-microsandbox = [
     "mvm-build/backends-microsandbox",
     "mvm-backend/backends-microsandbox",
 ]
+manifest-verify = [
+    "mvm/manifest-verify",
+    "mvm-security/manifest-verify",
+]
 
 [lints]
 workspace = true

--- a/crates/mvm-security/Cargo.toml
+++ b/crates/mvm-security/Cargo.toml
@@ -10,10 +10,11 @@ authors.workspace = true
 
 [features]
 # Enables cosign-keyless manifest verification via the sigstore Rust crate.
-# Default-on for release builds; disable with --no-default-features for a
-# smaller binary at the cost of a fail-closed `verify_manifest` stub.
+# Opt-in because Sigstore pulls a large OIDC/TUF/Rekor dependency graph.
+# Builds without it keep the same public API, but `verify_manifest` and
+# `verify_signed_payload` fail closed.
 # Plan 36 / ADR 005.
-default = ["manifest-verify"]
+default = []
 manifest-verify = ["dep:sigstore", "dep:tokio"]
 
 # Hardware attestation provider stubs (plan 60 Phase 6).

--- a/crates/mvm/Cargo.toml
+++ b/crates/mvm/Cargo.toml
@@ -48,6 +48,7 @@ backends-microsandbox = [
     "mvm-build/backends-microsandbox",
     "mvm-backend/backends-microsandbox",
 ]
+manifest-verify = ["mvm-security/manifest-verify"]
 
 [lints]
 workspace = true

--- a/tests/audit_emissions_live.rs
+++ b/tests/audit_emissions_live.rs
@@ -75,6 +75,11 @@
 //!   entry (the `ATTEST` leaves are all ReadOnly)
 //! - `mvmctl session ls` / `volume ls <vm>` → **no** audit entry
 //!   (SESSION ls and VOLUME ls leaves are both ReadOnly)
+//! - `mvmctl volume mount <vm> ...` → `VmVolumeAdd` (Plan 67:
+//!   the verb operates purely on the host-side
+//!   `~/.mvm/instances/<vm>/volume_mounts.json` registry — no
+//!   virtio-fs daemon attach, no backend dispatch)
+//! - `mvmctl volume unmount <vm> <guest>` → `VmVolumeRemove`
 //! - `mvmctl ls` / `metrics` / `catalog list` → **no** audit entry
 //!   (top-level ReadOnly verbs — three more rows from
 //!   `AUDIT_POSTURE` pinned against a future regression that
@@ -1333,6 +1338,105 @@ fn volume_ls_does_not_emit_audit_entry() {
         log.is_empty(),
         "read-only `volume ls` must not write to the LocalAudit \
          stream. Full log:\n{log}"
+    );
+}
+
+#[test]
+fn volume_mount_emits_vm_volume_add_audit_entry() {
+    // Plan 67: `volume mount` operates purely on the host-side
+    // `~/.mvm/instances/<vm>/volume_mounts.json` registry — no
+    // virtio-fs daemon attach, no Firecracker socket. The audit
+    // emit fires after the registry write. Hermetic out of the box.
+    let sandbox = AuditSandbox::new();
+    let host_share = sandbox.home_path().join("share");
+    std::fs::create_dir_all(&host_share).expect("mkdir host share");
+
+    let output = sandbox
+        .mvmctl()
+        .args([
+            "volume",
+            "mount",
+            "vol-test-vm",
+            "--volume",
+            "mydata",
+            "--host",
+            host_share.to_str().expect("utf-8 path"),
+            "--guest",
+            "/mnt/data",
+        ])
+        .output()
+        .expect("spawn mvmctl volume mount");
+    assert!(
+        output.status.success(),
+        "mvmctl volume mount failed: stderr={}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+
+    let log = read_audit_log(&sandbox.audit_log_path());
+    let hits = count_entries_with_kind(&log, "vm_volume_add");
+    assert!(
+        hits >= 1,
+        "expected ≥1 vm_volume_add entry, got {hits}. Full log:\n{log}"
+    );
+    assert!(
+        log.contains("\"vm_name\":\"vol-test-vm\""),
+        "vm_volume_add must carry vm_name=vol-test-vm. Full log:\n{log}"
+    );
+    assert!(
+        log.contains("guest=/mnt/data"),
+        "vm_volume_add detail must record guest=/mnt/data. Full log:\n{log}"
+    );
+}
+
+#[test]
+fn volume_unmount_emits_vm_volume_remove_audit_entry() {
+    // Plan 67: mount-then-unmount round-trip. Both emits land in
+    // the LocalAudit stream; this test pins the remove half.
+    let sandbox = AuditSandbox::new();
+    let host_share = sandbox.home_path().join("share");
+    std::fs::create_dir_all(&host_share).expect("mkdir host share");
+
+    let mount = sandbox
+        .mvmctl()
+        .args([
+            "volume",
+            "mount",
+            "vol-rm-vm",
+            "--volume",
+            "mydata",
+            "--host",
+            host_share.to_str().expect("utf-8 path"),
+            "--guest",
+            "/mnt/data",
+        ])
+        .output()
+        .expect("spawn mvmctl volume mount");
+    assert!(
+        mount.status.success(),
+        "mvmctl volume mount failed: stderr={}",
+        String::from_utf8_lossy(&mount.stderr)
+    );
+
+    let unmount = sandbox
+        .mvmctl()
+        .args(["volume", "unmount", "vol-rm-vm", "/mnt/data"])
+        .output()
+        .expect("spawn mvmctl volume unmount");
+    assert!(
+        unmount.status.success(),
+        "mvmctl volume unmount failed: stderr={}",
+        String::from_utf8_lossy(&unmount.stderr)
+    );
+
+    let log = read_audit_log(&sandbox.audit_log_path());
+    let hits = count_entries_with_kind(&log, "vm_volume_remove");
+    assert!(
+        hits >= 1,
+        "expected ≥1 vm_volume_remove entry, got {hits}. Full log:\n{log}"
+    );
+    assert!(
+        log.contains("\"vm_name\":\"vol-rm-vm\""),
+        "vm_volume_remove must carry vm_name=vol-rm-vm. Full log:\n{log}"
     );
 }
 


### PR DESCRIPTION
## Summary
- make Sigstore/cosign keyless manifest verification opt-in via the manifest-verify feature
- keep image verification APIs fail-closed when the feature is disabled
- add pass-through manifest-verify features at the root, mvm, and mvm-cli levels

## Verification
- cargo check -p mvm-security -p mvm-cli
- cargo check -p mvm-security --features manifest-verify
- cargo test -p mvm-security image_verify
- cargo test -p mvm-security --features manifest-verify image_verify
- cargo build --features manifest-verify
- cargo test --workspace