### PR TITLE
fix(mvm-ir): annotate SecretRef + SecretMount with allow(secret-debug)

### DIFF
--- a/crates/mvm-ir/src/workload.rs
+++ b/crates/mvm-ir/src/workload.rs
@@ -377,6 +377,9 @@ pub enum EnvValue {
     },
 }
 
+// allow(secret-debug): metadata-only — `name` is a secret-store key (not
+// the secret value), `mount` is a delivery shape (env-var name or file
+// path). No secret bytes ever live in this struct.
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize, JsonSchema)]
 #[serde(deny_unknown_fields)]
 pub struct SecretRef {
@@ -384,6 +387,9 @@ pub struct SecretRef {
     pub mount: SecretMount,
 }
 
+// allow(secret-debug): metadata-only — variants carry the env-var name
+// or filesystem path the secret will be delivered at, not the secret
+// itself. The actual material is resolved at admission time.
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize, JsonSchema)]
 #[serde(tag = "kind", rename_all = "snake_case", deny_unknown_fields)]
 pub enum SecretMount {


### PR DESCRIPTION
## Summary

Fixes the `check-no-display-on-secret-types` lint failure currently red on main (introduced by PR #146 alongside the `SecretRef` / `SecretMount` types in `mvm-ir::workload`). Two annotations, six lines added.

Both types are **metadata-only**:

- `SecretRef` — `name: String` (a key in the secret store, not the value) and `mount: SecretMount` (a delivery-shape descriptor).
- `SecretMount` — `Env { var: String }` or `File { path: String }`, both describing *where* the resolved secret will be delivered, not *what* it is.

Same shape as `MasterKeyState` in `mvm-core::domain::volume`, which already carries the `allow(secret-debug)` annotation for the same reason. The actual secret material is fetched at admission time and never enters the IR.

## Test plan

- [x] `cargo run -p xtask -- check-no-display-on-secret-types` reports `clean` locally
- [x] Pre-commit hooks pass (fmt + clippy + adr-coverage)
- [ ] CI green on the PR

## Why this is its own PR

Pulled out of PR #148 (the plan-71 → plan-72 renumber) to keep that PR's scope tight. Once this lands, PR #148's CI passes naturally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)