### PR TITLE
feat(libkrun): plan 57 W1 — real bindgen FFI behind libkrun-sys feature

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4114,6 +4114,7 @@ dependencies = [
  "mvm-build",
  "mvm-core",
  "mvm-guest",
+ "mvm-libkrun",
  "mvm-providers",
  "serde",
  "serde_json",
@@ -4186,6 +4187,7 @@ dependencies = [
  "mvm-build",
  "mvm-core",
  "mvm-guest",
+ "mvm-libkrun",
  "mvm-mcp",
  "mvm-plan",
  "mvm-policy",
@@ -4220,6 +4222,7 @@ dependencies = [
  "base64 0.22.1",
  "chrono",
  "fs2",
+ "mvm-libkrun",
  "mvm-providers",
  "regex",
  "serde",
@@ -4262,6 +4265,15 @@ dependencies = [
  "serde",
  "serde_json",
  "sha2 0.10.9",
+]
+
+[[package]]
+name = "mvm-libkrun"
+version = "0.14.0"
+dependencies = [
+ "bindgen",
+ "libc",
+ "tracing",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,6 +7,7 @@ members = [
     "crates/mvm-policy",
     "crates/mvm-supervisor",
     "crates/mvm-providers",
+    "crates/mvm-libkrun",
     "crates/mvm-backend",
     "crates/mvm-base",
     "crates/mvm",
@@ -175,6 +176,11 @@ mvm-sdk = { path = "crates/mvm-sdk", version = "0.14.0" }
 mvm-sdk-macros = { path = "crates/mvm-sdk-macros", version = "0.14.0" }
 mvm-mcp = { path = "crates/mvm-mcp", version = "0.14.0" }
 mvm-providers = { path = "crates/mvm-providers", version = "0.14.0" }
+# Plan 57 W1 — libkrun FFI bindings split out of mvm-providers so the
+# bindgen + libclang build cost is isolated from the Apple-VZ objc2
+# stack. Default feature set is empty; consumers wanting real FFI
+# enable `libkrun-sys` on a host with libkrun installed.
+mvm-libkrun = { path = "crates/mvm-libkrun", version = "0.14.0" }
 mvm-backend = { path = "crates/mvm-backend", version = "0.14.0", default-features = false }
 
 # Dev dependencies

--- a/crates/mvm-backend/Cargo.toml
+++ b/crates/mvm-backend/Cargo.toml
@@ -39,6 +39,7 @@ mvm-core.workspace = true
 mvm-guest.workspace = true
 mvm-base.workspace = true
 mvm-providers.workspace = true
+mvm-libkrun.workspace = true
 
 anyhow.workspace = true
 # microsandbox pulls sqlx-sqlite -> libsqlite3-sys (links = "sqlite3"),

--- a/crates/mvm-backend/src/libkrun.rs
+++ b/crates/mvm-backend/src/libkrun.rs
@@ -50,10 +50,10 @@ impl VmBackend for LibkrunBackend {
     }
 
     fn start(&self, config: &VmStartConfig) -> Result<VmId> {
-        if !mvm_providers::libkrun::is_available() {
+        if !mvm_libkrun::is_available() {
             anyhow::bail!(
                 "libkrun is not installed on this host.\n  {}",
-                mvm_providers::libkrun::install_hint()
+                mvm_libkrun::install_hint()
             );
         }
 
@@ -62,13 +62,12 @@ impl VmBackend for LibkrunBackend {
             .as_deref()
             .ok_or_else(|| anyhow::anyhow!("libkrun backend requires a kernel path"))?;
 
-        let ctx =
-            mvm_providers::libkrun::KrunContext::new(&config.name, kernel, &config.rootfs_path)
-                .with_resources(
-                    u8::try_from(config.cpus.clamp(1, u32::from(u8::MAX))).unwrap_or(u8::MAX),
-                    config.memory_mib,
-                )
-                .add_vsock_port(mvm_guest::vsock::GUEST_AGENT_PORT);
+        let ctx = mvm_libkrun::KrunContext::new(&config.name, kernel, &config.rootfs_path)
+            .with_resources(
+                u8::try_from(config.cpus.clamp(1, u32::from(u8::MAX))).unwrap_or(u8::MAX),
+                config.memory_mib,
+            )
+            .add_vsock_port(mvm_guest::vsock::GUEST_AGENT_PORT);
 
         // W6.2.1: thread the build-time sidecar into per-VM runtime
         // metadata so `mvmctl console` enforces the accessible/sealed
@@ -82,13 +81,13 @@ impl VmBackend for LibkrunBackend {
             config.name, ctx.vcpus, ctx.ram_mib
         ));
 
-        mvm_providers::libkrun::start(&ctx).map_err(|e| anyhow::anyhow!("libkrun start: {e}"))?;
+        mvm_libkrun::start(&ctx).map_err(|e| anyhow::anyhow!("libkrun start: {e}"))?;
         ui::success(&format!("libkrun VM '{}' started.", config.name));
         Ok(VmId(config.name.clone()))
     }
 
     fn stop(&self, id: &VmId) -> Result<()> {
-        mvm_providers::libkrun::stop(&id.0).map_err(|e| anyhow::anyhow!("libkrun stop: {e}"))
+        mvm_libkrun::stop(&id.0).map_err(|e| anyhow::anyhow!("libkrun stop: {e}"))
     }
 
     fn stop_all(&self) -> Result<()> {
@@ -129,13 +128,13 @@ impl VmBackend for LibkrunBackend {
     }
 
     fn is_available(&self) -> Result<bool> {
-        Ok(mvm_providers::libkrun::is_available())
+        Ok(mvm_libkrun::is_available())
     }
 
     fn install(&self) -> Result<()> {
         ui::info(&format!(
             "libkrun must be installed via the host's package manager.\n  {}",
-            mvm_providers::libkrun::install_hint()
+            mvm_libkrun::install_hint()
         ));
         Ok(())
     }
@@ -214,9 +213,9 @@ mod tests {
         // The install() method is informational on every host — it shells
         // out to ui::info instead of attempting to install. The check is
         // just that we can call it without panicking; the actual hint
-        // copy lives in mvm_providers::libkrun::install_hint().
+        // copy lives in mvm_libkrun::install_hint().
         LibkrunBackend.install().expect("install hint never errors");
-        let hint = mvm_providers::libkrun::install_hint();
+        let hint = mvm_libkrun::install_hint();
         assert!(!hint.is_empty());
     }
 

--- a/crates/mvm-cli/Cargo.toml
+++ b/crates/mvm-cli/Cargo.toml
@@ -19,6 +19,7 @@ mvm = { workspace = true, default-features = false }
 mvm-build = { workspace = true, default-features = false }
 mvm-security.workspace = true
 mvm-providers.workspace = true
+mvm-libkrun.workspace = true
 mvm-backend = { workspace = true, default-features = false }
 mvm-mcp.workspace = true
 mvm-plan.workspace = true

--- a/crates/mvm-cli/src/bootstrap.rs
+++ b/crates/mvm-cli/src/bootstrap.rs
@@ -126,7 +126,7 @@ pub fn hint_libkrun_if_useful() {
     if plat.has_kvm() || plat.is_windows() {
         return;
     }
-    if mvm_providers::libkrun::is_available() {
+    if mvm_libkrun::is_available() {
         ui::info(
             "Detected libkrun on this host; you can opt in with `mvmctl run --hypervisor libkrun`.",
         );
@@ -138,7 +138,7 @@ pub fn hint_libkrun_if_useful() {
     if matches!(plat, Platform::MacOS) && !plat.has_apple_containers() {
         ui::info(&format!(
             "Tip: install libkrun for a no-Lima Tier 2 microVM path on this Mac.\n  {}",
-            mvm_providers::libkrun::install_hint()
+            mvm_libkrun::install_hint()
         ));
     }
 }

--- a/crates/mvm-cli/src/doctor.rs
+++ b/crates/mvm-cli/src/doctor.rs
@@ -579,7 +579,7 @@ fn libkrun_check(plat: Platform) -> Check {
             name: "libkrun",
             category: "platform",
             ok: true, // Optional; not a failure.
-            info: format!("not available ({})", mvm_providers::libkrun::install_hint()),
+            info: format!("not available ({})", mvm_libkrun::install_hint()),
         }
     }
 }

--- a/crates/mvm-core/Cargo.toml
+++ b/crates/mvm-core/Cargo.toml
@@ -13,6 +13,7 @@ anyhow.workspace = true
 base64.workspace = true
 chrono.workspace = true
 mvm-providers.workspace = true
+mvm-libkrun.workspace = true
 serde.workspace = true
 serde_json.workspace = true
 sha2.workspace = true

--- a/crates/mvm-core/src/platform/platform.rs
+++ b/crates/mvm-core/src/platform/platform.rs
@@ -56,7 +56,7 @@ impl Platform {
         if matches!(self, Platform::Windows) {
             return false;
         }
-        mvm_providers::libkrun::is_available()
+        mvm_libkrun::is_available()
     }
 
     /// Whether the bundled microsandbox runtime is usable on this
@@ -293,7 +293,7 @@ mod tests {
     #[test]
     fn test_has_libkrun_returns_false_on_windows_regardless_of_filesystem() {
         // Windows: libkrun has no Windows port. Always false irrespective
-        // of what `mvm_providers::libkrun::is_available()` would say.
+        // of what `mvm_libkrun::is_available()` would say.
         assert!(!Platform::Windows.has_libkrun());
     }
 
@@ -303,7 +303,7 @@ mod tests {
         // libkrun crate's authoritative is_available() probe.
         let plat = current();
         if !matches!(plat, Platform::Windows) {
-            assert_eq!(plat.has_libkrun(), mvm_providers::libkrun::is_available());
+            assert_eq!(plat.has_libkrun(), mvm_libkrun::is_available());
         }
     }
 

--- a/crates/mvm-libkrun/Cargo.toml
+++ b/crates/mvm-libkrun/Cargo.toml
@@ -1,0 +1,53 @@
+[package]
+name = "mvm-libkrun"
+version.workspace = true
+edition.workspace = true
+description = "Rust bindings for the Red Hat libkrun C library (Linux KVM, macOS HVF)"
+license.workspace = true
+repository.workspace = true
+homepage.workspace = true
+authors.workspace = true
+build = "build.rs"
+
+# ── What this crate is ─────────────────────────────────────────────
+#
+# Thin Rust bindings + a safe wrapper around Red Hat libkrun's C API.
+# libkrun is a library-style VMM: linked directly into the calling
+# binary, no out-of-process daemon. On Linux it uses KVM; on macOS it
+# uses Hypervisor.framework. mvm uses it as a Tier 2 microVM backend
+# and (post-Plan-71) the builder-VM substrate.
+#
+# Two build modes:
+#
+#   * default (no feature) — no FFI, no link to libkrun. `start`/`stop`
+#     return `Error::NotYetWired`. The workspace builds cleanly on hosts
+#     without libkrun installed.
+#
+#   * `libkrun-sys` — bindgen-generated FFI + `-lkrun` link. Requires
+#     libkrun.h on the host (probed by build.rs at the standard install
+#     locations) and a working libkrun shared library at link time.
+#
+# Plan 57 W1 lands the bindings; W2 adds macOS codesigning entitlements;
+# W3 validates an end-to-end boot. This crate stays narrowly focused on
+# the FFI surface — backend dispatch lives in mvm-backend.
+
+[dependencies]
+libc.workspace = true
+tracing = "0.1"
+
+[build-dependencies]
+# `bindgen` is required only when the `libkrun-sys` feature is on; we
+# still list it unconditionally so the crate manifest reflects the real
+# build-time graph. The build script returns early when the feature is
+# off, so libclang isn't invoked in the default workspace build.
+bindgen = "0.72"
+
+[features]
+default = []
+# Opt-in: generate FFI bindings and link `libkrun`. Off by default so
+# the workspace builds on hosts without libkrun installed (CI fast lane,
+# Linux contributors who don't run the Tier 2 backend).
+libkrun-sys = []
+
+[lints]
+workspace = true

--- a/crates/mvm-libkrun/build.rs
+++ b/crates/mvm-libkrun/build.rs
@@ -1,0 +1,95 @@
+//! Build script for mvm-libkrun.
+//!
+//! When the `libkrun-sys` cargo feature is on:
+//!   1. Probe for `libkrun.h` at the three standard install locations
+//!      (Apple Silicon Homebrew, Intel/manual, Linux distro).
+//!   2. Run `bindgen` to emit Rust FFI bindings into `OUT_DIR/libkrun_sys.rs`.
+//!   3. Emit `cargo:rustc-link-lib=krun` so the linker pulls in the shared
+//!      library.
+//!
+//! When the feature is off, this script is a noop — the workspace builds
+//! cleanly on hosts without libkrun installed.
+
+use std::env;
+use std::path::{Path, PathBuf};
+
+fn main() {
+    println!("cargo:rerun-if-changed=build.rs");
+    println!("cargo:rerun-if-env-changed=MVM_LIBKRUN_HEADER");
+
+    if env::var_os("CARGO_FEATURE_LIBKRUN_SYS").is_none() {
+        // Default build path — no FFI, no link, no bindgen invocation.
+        return;
+    }
+
+    let header = locate_header().unwrap_or_else(|| {
+        panic!(
+            "libkrun-sys feature is enabled but libkrun.h was not found.\n\
+             Checked: {}.\n\
+             Install libkrun (`brew install libkrun` on macOS, distro package on Linux)\n\
+             or point MVM_LIBKRUN_HEADER at the header path.",
+            probe_paths()
+                .iter()
+                .map(|p| p.display().to_string())
+                .collect::<Vec<_>>()
+                .join(", "),
+        )
+    });
+
+    println!("cargo:rerun-if-changed={}", header.display());
+
+    let out_path =
+        PathBuf::from(env::var("OUT_DIR").expect("OUT_DIR set by cargo")).join("libkrun_sys.rs");
+
+    let include_dir = header
+        .parent()
+        .expect("libkrun.h has a parent directory")
+        .to_path_buf();
+
+    bindgen::Builder::default()
+        .header(header.to_string_lossy())
+        .clang_arg(format!("-I{}", include_dir.display()))
+        // Keep the generated surface small — only the symbols we wrap in
+        // sys.rs plus the KRUN_* constants we need at the type level.
+        .allowlist_function("krun_.*")
+        .allowlist_var("KRUN_.*")
+        .layout_tests(false)
+        .generate_comments(false)
+        .parse_callbacks(Box::new(bindgen::CargoCallbacks::new()))
+        .generate()
+        .expect("bindgen failed to generate libkrun bindings")
+        .write_to_file(&out_path)
+        .expect("failed to write libkrun bindings");
+
+    // Tell the linker to pull in libkrun. On macOS the dylib is found via
+    // the standard Homebrew library path; on Linux via the distro install.
+    println!("cargo:rustc-link-lib=krun");
+
+    // Make sure the linker can find the dylib next to the header we probed.
+    // Homebrew installs to /opt/homebrew/{include,lib}; the symmetric `lib`
+    // sibling is the right hint without hardcoding paths in every consumer.
+    if let Some(prefix) = include_dir.parent() {
+        let lib_dir = prefix.join("lib");
+        if lib_dir.exists() {
+            println!("cargo:rustc-link-search=native={}", lib_dir.display());
+        }
+    }
+}
+
+fn locate_header() -> Option<PathBuf> {
+    if let Some(override_path) = env::var_os("MVM_LIBKRUN_HEADER") {
+        let p = PathBuf::from(override_path);
+        if p.is_file() {
+            return Some(p);
+        }
+    }
+    probe_paths().into_iter().find(|p| p.is_file())
+}
+
+fn probe_paths() -> Vec<PathBuf> {
+    vec![
+        Path::new("/opt/homebrew/include/libkrun.h").to_path_buf(),
+        Path::new("/usr/local/include/libkrun.h").to_path_buf(),
+        Path::new("/usr/include/libkrun.h").to_path_buf(),
+    ]
+}

--- a/crates/mvm-libkrun/src/lib.rs
+++ b/crates/mvm-libkrun/src/lib.rs
@@ -1,43 +1,34 @@
-//! libkrun backend bindings for mvm.
+//! Rust bindings for Red Hat libkrun (Linux KVM, macOS Hypervisor.framework).
 //!
-//! libkrun is Red Hat's library-style VMM (Apache-2.0). Unlike Firecracker
-//! (separate binary, HTTP API) or Apple Virtualization.framework (Swift /
-//! objc2 FFI), libkrun is a C library you link directly into your binary.
-//! On Linux it uses KVM; on macOS it uses Hypervisor.framework — making it
-//! the only VMM in mvm's consideration set that runs on **both** macOS
-//! Apple Silicon and macOS Intel without Lima. On Linux it gives us a
-//! single-binary alternative to the firecracker-on-PATH dependency.
+//! libkrun is a library-style VMM: linked directly into the calling binary
+//! rather than spawned as a separate daemon. On Linux it uses KVM; on
+//! macOS it uses Hypervisor.framework. It is the only VMM mvm carries
+//! that runs on both macOS Apple Silicon **and** macOS Intel without
+//! Lima.
 //!
-//! See plan 53 §"Plan E" for design context and the fork test that
-//! qualified libkrun as the one new backend we add in Sprint 48.
+//! # Build modes
 //!
-//! # Status (Sprint 48 lane-laying)
+//! - **default** (no feature) — no FFI, no link to libkrun. [`start`]
+//!   and [`stop`] return [`Error::NotYetWired`]. The workspace compiles
+//!   on hosts without libkrun installed.
+//! - **`libkrun-sys`** — bindgen-generated FFI from `libkrun.h` plus
+//!   `-lkrun` linking. [`start`] and [`stop`] dispatch through
+//!   [`sys::Context`] into real libkrun calls.
 //!
-//! This crate ships **scaffolding** with the final public API shape:
-//! [`KrunContext`] for construction, [`start`] / [`stop`] for lifecycle,
-//! [`is_available`] for runtime detection. The implementation is gated
-//! on a real libkrun install — see `specs/plans/57-libkrun-spike.md`
-//! for the work that lands the bindings, codesigning, and end-to-end
-//! boot validation.
-//!
-//! Until then, [`start`] / [`stop`] return [`Error::NotYetWired`] with a
-//! pointer to plan 57, and [`is_available`] checks the host for a
-//! libkrun shared library at standard install locations (Homebrew on
-//! macOS, distro packages on Linux).
-//!
-//! # Platform support
-//!
-//! - **macOS Apple Silicon**: libkrun ships in Homebrew as `libkrun`.
-//! - **macOS Intel**: libkrun via Hypervisor.framework also works.
-//! - **Linux x86_64 / aarch64**: libkrun is in most distro repos, or
-//!   build from source via Nix.
-//! - **Windows**: not supported. libkrun has no Windows port.
+//! Plan 57 W1 wires the bindings; W2 adds the macOS codesigning
+//! entitlement; W3 validates an end-to-end boot. This crate stays
+//! narrowly focused on the FFI; backend dispatch and lifecycle live in
+//! `mvm-backend` and `mvm-cli`.
 
 use std::path::Path;
 
-/// Errors returned by this crate. `NotYetWired` is the placeholder
-/// until the Plan E spike lands; once the bindings are real, this
-/// variant goes away.
+#[cfg(feature = "libkrun-sys")]
+mod sys;
+
+#[cfg(feature = "libkrun-sys")]
+pub use sys::{KernelFormat, LogLevel};
+
+/// Errors returned by this crate.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum Error {
     /// libkrun is not installed on the host (no shared library found at
@@ -46,15 +37,21 @@ pub enum Error {
         /// Suggested install command for the user.
         install_hint: &'static str,
     },
-    /// libkrun is installed but this crate's bindings haven't landed
-    /// yet (Plan E spike pending). Returned by [`start`] / [`stop`]
-    /// in Sprint 48 scaffolding.
+    /// Built without the `libkrun-sys` feature — the FFI bindings are
+    /// compiled out so [`start`] / [`stop`] cannot dispatch. Rebuild
+    /// with `--features libkrun-sys` on a host where libkrun is
+    /// installed.
     NotYetWired {
         /// Tracking issue / plan reference.
         tracking: &'static str,
     },
-    /// Generic libkrun call failure — populated once bindings are real.
-    Krun(String),
+    /// libkrun returned a negative errno from one of its C functions.
+    /// The value is the raw return code (which libkrun documents as
+    /// `-EINVAL`, `-ENOMEM`, etc. for most calls).
+    Krun(i32),
+    /// A path or string argument contained an interior NUL byte or
+    /// was not representable as UTF-8 / a C string.
+    InvalidCString,
 }
 
 impl std::fmt::Display for Error {
@@ -65,11 +62,14 @@ impl std::fmt::Display for Error {
             }
             Self::NotYetWired { tracking } => write!(
                 f,
-                "libkrun bindings are not yet wired up (tracking: {tracking}). \
-                 The Plan E spike phase has to land before this backend can \
-                 boot guests."
+                "libkrun FFI is not compiled into this build (tracking: {tracking}). \
+                 Rebuild with `--features libkrun-sys` on a host with libkrun installed."
             ),
-            Self::Krun(msg) => write!(f, "libkrun call failed: {msg}"),
+            Self::Krun(rc) => write!(f, "libkrun call failed with rc {rc}"),
+            Self::InvalidCString => write!(
+                f,
+                "argument contained an interior NUL byte or non-UTF-8 path"
+            ),
         }
     }
 }
@@ -80,9 +80,8 @@ impl std::error::Error for Error {}
 /// shared library at the standard install locations.
 ///
 /// **Not the same as "is functional"** — even if `is_available()`
-/// returns `true`, the [`start`] call may still fail with
-/// [`Error::NotYetWired`] until the libkrun spike (specs/plans/
-/// 57-libkrun-spike.md) lands the real bindings. Treat this as a
+/// returns `true`, a build without the `libkrun-sys` feature will still
+/// return [`Error::NotYetWired`] from [`start`]. Treat this as a
 /// precondition probe: if it returns `false`, point the user at
 /// [`install_hint`].
 pub fn is_available() -> bool {
@@ -147,8 +146,9 @@ pub fn install_paths() -> Vec<&'static str> {
 
 /// Configuration for a libkrun guest VM.
 ///
-/// Final API shape — the spike phase will populate the inner
-/// representation but callers won't have to change.
+/// Pure data — no I/O until [`start`] consumes it. Field shape is
+/// stable across the W1 → W3 transition; the FFI calls that consume
+/// each field live in [`sys`] under the `libkrun-sys` feature.
 #[derive(Debug, Clone)]
 pub struct KrunContext {
     pub name: String,
@@ -193,22 +193,70 @@ impl KrunContext {
     }
 }
 
-/// Start a libkrun guest from `ctx`. Currently a stub — see
-/// [`Error::NotYetWired`].
+/// Start a libkrun guest from `ctx`.
+///
+/// **Plan 57 W1 scope.** With the `libkrun-sys` feature enabled, this
+/// allocates a libkrun configuration context, applies CPU/memory,
+/// kernel, rootfs, and vsock-port configuration through the FFI, then
+/// frees the context and returns `Ok(())`. It does **not** call
+/// `krun_start_enter` (which blocks until the guest exits) — the
+/// blocking-thread lifecycle and state-tracking work is W3 + W4 of
+/// plan 57. Today the call exists so consumers can exercise the
+/// wrapper end-to-end on a host with libkrun installed; the W3 PR
+/// upgrades it to actually boot.
+///
+/// Without the feature, returns [`Error::NotYetWired`].
 pub fn start(ctx: &KrunContext) -> Result<(), Error> {
     if !is_available() {
         return Err(Error::NotInstalled {
             install_hint: install_hint(),
         });
     }
-    let _ = ctx; // silence unused-arg until bindings land
-    Err(Error::NotYetWired {
-        tracking: "specs/plans/57-libkrun-spike.md",
-    })
+    #[cfg(not(feature = "libkrun-sys"))]
+    {
+        let _ = ctx;
+        Err(Error::NotYetWired {
+            tracking: "specs/plans/57-libkrun-spike.md W3+W4",
+        })
+    }
+    #[cfg(feature = "libkrun-sys")]
+    {
+        start_via_ffi(ctx)
+    }
 }
 
-/// Stop a running libkrun guest by name. Stub for the Sprint 48
-/// scaffolding — see [`Error::NotYetWired`].
+#[cfg(feature = "libkrun-sys")]
+fn start_via_ffi(ctx: &KrunContext) -> Result<(), Error> {
+    let krun = sys::Context::new()?;
+    krun.set_vm_config(ctx.vcpus, ctx.ram_mib)?;
+    krun.set_kernel(
+        Path::new(&ctx.kernel_path),
+        sys::KernelFormat::Elf,
+        None,
+        ctx.kernel_cmdline.as_deref(),
+    )?;
+    krun.add_disk("root", Path::new(&ctx.rootfs_path), false)?;
+    for &port in &ctx.vsock_ports {
+        // libkrun's `krun_add_vsock_port` requires a host-side Unix
+        // socket path. The full backend wiring (which generates that
+        // path under ~/.mvm/vms/<name>/) lands in W3 alongside the
+        // boot validation. For W1 the FFI exercise stops short of
+        // booting, so a stub path is sufficient to confirm the wrapper
+        // accepts the call.
+        let socket = format!("/tmp/mvm-libkrun-{}-vsock-{port}.sock", ctx.name);
+        krun.add_vsock_port(port, Path::new(&socket))?;
+    }
+    // `krun_start_enter` deliberately not invoked — that's W3 + W4.
+    // Dropping the context here frees it cleanly through `Context::Drop`.
+    Ok(())
+}
+
+/// Stop a running libkrun guest by name.
+///
+/// **Plan 57 W1 scope.** The blocking-thread + registry lifecycle that
+/// would let us find and signal a running VM is W4 of plan 57. Today
+/// this returns [`Error::NotYetWired`] regardless of feature — there
+/// is no running state to stop yet.
 pub fn stop(name: &str) -> Result<(), Error> {
     if !is_available() {
         return Err(Error::NotInstalled {
@@ -217,7 +265,7 @@ pub fn stop(name: &str) -> Result<(), Error> {
     }
     let _ = name;
     Err(Error::NotYetWired {
-        tracking: "specs/plans/57-libkrun-spike.md",
+        tracking: "specs/plans/57-libkrun-spike.md W4",
     })
 }
 
@@ -254,31 +302,35 @@ mod tests {
     }
 
     #[test]
-    fn start_errors_when_not_installed_or_not_yet_wired() {
-        let ctx = KrunContext::new("vm", "/k", "/r");
-        let err = start(&ctx).expect_err("scaffolding always errors");
-        // Either "not installed" (most common in CI) or "not yet wired"
-        // (when libkrun *is* installed on the dev's host) — both are
-        // acceptable surfaces for the scaffolding phase.
-        assert!(matches!(
-            err,
-            Error::NotInstalled { .. } | Error::NotYetWired { .. }
-        ));
-    }
-
-    #[test]
     fn error_display_messages_are_actionable() {
         let not_installed = Error::NotInstalled {
             install_hint: "brew install libkrun",
         };
         let not_wired = Error::NotYetWired {
-            tracking: "plan 53",
+            tracking: "plan 57",
         };
-        let krun_err = Error::Krun("kvm_create failed".to_string());
+        let krun_err = Error::Krun(-22);
+        let invalid = Error::InvalidCString;
         // Each variant produces a non-empty, distinct message that
         // names what to do next.
         assert!(format!("{not_installed}").contains("brew install"));
-        assert!(format!("{not_wired}").contains("plan 53"));
-        assert!(format!("{krun_err}").contains("kvm_create"));
+        assert!(format!("{not_wired}").contains("plan 57"));
+        assert!(format!("{krun_err}").contains("-22"));
+        assert!(format!("{invalid}").contains("NUL"));
+    }
+
+    /// When libkrun isn't installed on the host, `start` short-circuits
+    /// before touching the FFI — works the same way with or without
+    /// the `libkrun-sys` feature.
+    #[test]
+    fn start_errors_when_not_installed() {
+        if is_available() {
+            // Host has libkrun; this test exercises the fast-fail path,
+            // not the FFI surface, so skip.
+            return;
+        }
+        let ctx = KrunContext::new("vm", "/k", "/r");
+        let err = start(&ctx).expect_err("scaffolding errors without libkrun");
+        assert!(matches!(err, Error::NotInstalled { .. }));
     }
 }

--- a/crates/mvm-libkrun/src/sys.rs
+++ b/crates/mvm-libkrun/src/sys.rs
@@ -1,0 +1,244 @@
+//! Safe wrappers around the bindgen-generated libkrun FFI.
+//!
+//! Only compiled when the `libkrun-sys` feature is on. The wrappers
+//! translate libkrun's "negative i32 = errno" convention into
+//! `Result<_, super::Error>` and own all `CString` conversions for
+//! path arguments. Each wrapper is one FFI call deep.
+//!
+//! `krun_start_enter` is not called from here — it blocks until the
+//! guest exits and is the W3+W4 lifecycle scope. The Plan 57 W1
+//! deliverable is the bindings + thin wrapper only; consumers exercise
+//! the configuration calls today and pick up boot in a later PR.
+
+#![allow(
+    non_upper_case_globals,
+    non_camel_case_types,
+    non_snake_case,
+    dead_code,
+    clippy::missing_safety_doc,
+    clippy::too_many_arguments
+)]
+
+use std::ffi::CString;
+use std::path::Path;
+
+use crate::Error;
+
+mod bindings {
+    include!(concat!(env!("OUT_DIR"), "/libkrun_sys.rs"));
+}
+
+/// Kernel-format constants exposed to callers without leaking the
+/// bindgen-generated identifier names.
+#[derive(Debug, Clone, Copy)]
+pub enum KernelFormat {
+    Raw,
+    Elf,
+    PeGz,
+    ImageBz2,
+    ImageGz,
+    ImageZstd,
+}
+
+impl KernelFormat {
+    fn as_u32(self) -> u32 {
+        match self {
+            KernelFormat::Raw => bindings::KRUN_KERNEL_FORMAT_RAW,
+            KernelFormat::Elf => bindings::KRUN_KERNEL_FORMAT_ELF,
+            KernelFormat::PeGz => bindings::KRUN_KERNEL_FORMAT_PE_GZ,
+            KernelFormat::ImageBz2 => bindings::KRUN_KERNEL_FORMAT_IMAGE_BZ2,
+            KernelFormat::ImageGz => bindings::KRUN_KERNEL_FORMAT_IMAGE_GZ,
+            KernelFormat::ImageZstd => bindings::KRUN_KERNEL_FORMAT_IMAGE_ZSTD,
+        }
+    }
+}
+
+/// Log-level constants matching `KRUN_LOG_LEVEL_*` in libkrun.h.
+#[derive(Debug, Clone, Copy)]
+pub enum LogLevel {
+    Off,
+    Error,
+    Warn,
+    Info,
+    Debug,
+    Trace,
+}
+
+impl LogLevel {
+    fn as_u32(self) -> u32 {
+        match self {
+            LogLevel::Off => 0,
+            LogLevel::Error => 1,
+            LogLevel::Warn => 2,
+            LogLevel::Info => 3,
+            LogLevel::Debug => 4,
+            LogLevel::Trace => 5,
+        }
+    }
+}
+
+/// Owned libkrun configuration context. Frees the underlying ctx_id on
+/// drop so callers don't have to thread cleanup through every error
+/// path.
+pub struct Context {
+    ctx_id: u32,
+}
+
+impl Context {
+    /// Allocate a new libkrun configuration context.
+    pub fn new() -> Result<Self, Error> {
+        let rc = unsafe { bindings::krun_create_ctx() };
+        if rc < 0 {
+            return Err(Error::Krun(rc));
+        }
+        // krun_create_ctx returns the ctx id as a non-negative i32.
+        Ok(Self { ctx_id: rc as u32 })
+    }
+
+    pub fn id(&self) -> u32 {
+        self.ctx_id
+    }
+
+    pub fn set_vm_config(&self, num_vcpus: u8, ram_mib: u32) -> Result<(), Error> {
+        check(unsafe { bindings::krun_set_vm_config(self.ctx_id, num_vcpus, ram_mib) })
+    }
+
+    pub fn set_root_disk(&self, disk_path: &Path) -> Result<(), Error> {
+        let path = cstring(disk_path)?;
+        check(unsafe { bindings::krun_set_root_disk(self.ctx_id, path.as_ptr()) })
+    }
+
+    pub fn set_kernel(
+        &self,
+        kernel_path: &Path,
+        kernel_format: KernelFormat,
+        initramfs: Option<&Path>,
+        cmdline: Option<&str>,
+    ) -> Result<(), Error> {
+        let kernel = cstring(kernel_path)?;
+        let initramfs = match initramfs {
+            Some(p) => Some(cstring(p)?),
+            None => None,
+        };
+        let cmdline = match cmdline {
+            Some(s) => Some(CString::new(s).map_err(|_| Error::InvalidCString)?),
+            None => None,
+        };
+        let initramfs_ptr = initramfs.as_ref().map_or(std::ptr::null(), |s| s.as_ptr());
+        let cmdline_ptr = cmdline.as_ref().map_or(std::ptr::null(), |s| s.as_ptr());
+        check(unsafe {
+            bindings::krun_set_kernel(
+                self.ctx_id,
+                kernel.as_ptr(),
+                kernel_format.as_u32(),
+                initramfs_ptr,
+                cmdline_ptr,
+            )
+        })
+    }
+
+    pub fn add_vsock(&self, tsi_features: u32) -> Result<(), Error> {
+        check(unsafe { bindings::krun_add_vsock(self.ctx_id, tsi_features) })
+    }
+
+    pub fn add_vsock_port(&self, port: u32, host_path: &Path) -> Result<(), Error> {
+        let path = cstring(host_path)?;
+        check(unsafe { bindings::krun_add_vsock_port(self.ctx_id, port, path.as_ptr()) })
+    }
+
+    pub fn add_virtiofs(&self, tag: &str, host_path: &Path) -> Result<(), Error> {
+        let tag = CString::new(tag).map_err(|_| Error::InvalidCString)?;
+        let path = cstring(host_path)?;
+        check(unsafe { bindings::krun_add_virtiofs(self.ctx_id, tag.as_ptr(), path.as_ptr()) })
+    }
+
+    pub fn add_disk(&self, block_id: &str, disk_path: &Path, read_only: bool) -> Result<(), Error> {
+        let block = CString::new(block_id).map_err(|_| Error::InvalidCString)?;
+        let path = cstring(disk_path)?;
+        check(unsafe {
+            bindings::krun_add_disk(self.ctx_id, block.as_ptr(), path.as_ptr(), read_only)
+        })
+    }
+
+    pub fn set_console_output(&self, host_path: &Path) -> Result<(), Error> {
+        let path = cstring(host_path)?;
+        check(unsafe { bindings::krun_set_console_output(self.ctx_id, path.as_ptr()) })
+    }
+
+    /// Returns the shutdown eventfd. The caller is responsible for
+    /// closing it (libkrun documents that the fd is owned by the
+    /// caller once returned).
+    pub fn shutdown_eventfd(&self) -> Result<i32, Error> {
+        let rc = unsafe { bindings::krun_get_shutdown_eventfd(self.ctx_id) };
+        if rc < 0 { Err(Error::Krun(rc)) } else { Ok(rc) }
+    }
+
+    /// Block the calling thread, starting the guest. libkrun's
+    /// `krun_start_enter` calls `exit()` on success with the guest's
+    /// status; on failure it returns a negative errno. Plan 57 W1
+    /// surfaces the wrapper but does not call it from `crate::start` —
+    /// that lands in W3 + W4 alongside the registry that owns the
+    /// blocking thread.
+    pub fn start_enter(&self) -> Result<std::convert::Infallible, Error> {
+        let rc = unsafe { bindings::krun_start_enter(self.ctx_id) };
+        // On success the call does not return; if we observe one, it's
+        // an error path.
+        Err(Error::Krun(rc))
+    }
+}
+
+impl Drop for Context {
+    fn drop(&mut self) {
+        let rc = unsafe { bindings::krun_free_ctx(self.ctx_id) };
+        if rc < 0 {
+            tracing::warn!(
+                ctx_id = self.ctx_id,
+                rc,
+                "krun_free_ctx returned non-zero on drop"
+            );
+        }
+    }
+}
+
+/// Set libkrun's global log level. Wraps `krun_set_log_level`.
+pub fn set_log_level(level: LogLevel) -> Result<(), Error> {
+    check(unsafe { bindings::krun_set_log_level(level.as_u32()) })
+}
+
+fn check(rc: i32) -> Result<(), Error> {
+    if rc < 0 { Err(Error::Krun(rc)) } else { Ok(()) }
+}
+
+fn cstring(path: &Path) -> Result<CString, Error> {
+    let s = path.to_str().ok_or(Error::InvalidCString)?;
+    CString::new(s).map_err(|_| Error::InvalidCString)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn create_and_drop_context() {
+        // Smoke test: the FFI links cleanly and an empty context can be
+        // allocated + freed. Doesn't boot a VM (that's W3) — just proves
+        // the wrapper round-trips through libkrun.
+        let ctx = Context::new().expect("libkrun ctx allocation succeeds on a host with libkrun");
+        assert!(ctx.id() < u32::MAX);
+        // Drop runs krun_free_ctx; assertion is the absence of a panic.
+    }
+
+    #[test]
+    fn log_level_is_settable() {
+        // `set_log_level` is the first FFI call any process does — it
+        // touches no resources beyond the global logger. A round-trip
+        // here catches a broken link without needing a ctx.
+        set_log_level(LogLevel::Warn).expect("krun_set_log_level returns zero");
+    }
+
+    #[test]
+    fn vm_config_round_trips() {
+        let ctx = Context::new().expect("ctx allocation");
+        ctx.set_vm_config(1, 128).expect("vm config accepted");
+    }
+}

--- a/crates/mvm-providers/Cargo.toml
+++ b/crates/mvm-providers/Cargo.toml
@@ -2,23 +2,23 @@
 name = "mvm-providers"
 version.workspace = true
 edition.workspace = true
-description = "Virtualization-framework primitives for mvm — libkrun bindings, Apple VZ FFI"
+description = "Apple Virtualization.framework FFI primitives for mvm"
 license.workspace = true
 repository.workspace = true
 homepage.workspace = true
 authors.workspace = true
-build = "build.rs"
 
 # ── What this crate is ─────────────────────────────────────────────
 #
 # The internal FFI / SDK shim layer between mvm-backend (which
-# implements `VmBackend`) and the underlying virtualization frameworks.
-# Each module wraps one framework:
+# implements `VmBackend`) and the Apple Virtualization.framework
+# stack:
 #
-#   libkrun         — Red Hat libkrun C library (Linux KVM + macOS HVF)
 #   apple_container — Apple Virtualization.framework via objc2 + Swift
 #
-# Future modules: cloud_hypervisor (FFI shim), windows_wfp, etc.
+# libkrun bindings live in the sibling `mvm-libkrun` crate. Plan 57
+# W1 split them out so the bindgen + libclang build cost stays out
+# of every consumer that doesn't link libkrun.
 #
 # This is NOT the user-facing "Provider" concept from ADR-012 — that
 # concept (linux/mlx as user-selectable execution targets) lives in

--- a/crates/mvm-providers/build.rs
+++ b/crates/mvm-providers/build.rs
@@ -1,4 +1,0 @@
-fn main() {
-    // No build-time steps needed.
-    // Uses objc2-virtualization for direct Virtualization.framework access.
-}

--- a/crates/mvm-providers/src/lib.rs
+++ b/crates/mvm-providers/src/lib.rs
@@ -1,10 +1,13 @@
 //! mvm-providers — virtualization-framework primitives.
 //!
-//! Internal FFI / SDK shim layer. Each module wraps one underlying
-//! virtualization framework:
+//! Internal FFI / SDK shim layer for the Apple Virtualization.framework
+//! integration:
 //!
-//!   - [`libkrun`]         — Red Hat libkrun C library (Linux KVM, macOS HVF)
 //!   - [`apple_container`] — Apple Virtualization.framework (macOS only)
+//!
+//! libkrun FFI lives in its sibling crate `mvm-libkrun` (split out by
+//! plan 57 W1 so the `bindgen` + `libclang` build cost stays out of
+//! consumers that don't link libkrun).
 //!
 //! [`mvm-backend`](https://docs.rs/mvm-backend) consumes these modules
 //! to implement the `VmBackend` trait. End-user code should never
@@ -18,8 +21,6 @@
 //! but address different layers: this crate is *internal FFI*; ADR-012
 //! talks about *user-selectable execution targets*. The disambiguation
 //! note in ADR-012 carries the full story.
-
-pub mod libkrun;
 
 // `apple_container` is unconditionally exposed; the module itself uses
 // `#[cfg(target_os = "macos")]` to gate the Virtualization.framework


### PR DESCRIPTION
## Summary

- Splits libkrun bindings out of `mvm-providers` into a dedicated `mvm-libkrun` crate so the bindgen + libclang build cost is isolated from the heavy `objc2-virtualization` stack (Plan 57 names this crate path verbatim).
- New `libkrun-sys` cargo feature (default off): when on, `build.rs` probes `libkrun.h` at `/opt/homebrew/include`, `/usr/local/include`, `/usr/include` (plus `MVM_LIBKRUN_HEADER` override), runs `bindgen 0.72` with an allowlist on `krun_.*` / `KRUN_.*`, and emits `cargo:rustc-link-lib=krun`. When off, the workspace builds cleanly on hosts without libkrun installed.
- `src/sys.rs` provides a safe `Context` newtype that owns the ctx_id (Drop → `krun_free_ctx`) and wraps the 13 W1-scope FFI calls (`create_ctx`, `free_ctx`, `set_vm_config`, `set_root_disk`, `set_kernel`, `add_vsock`, `add_vsock_port`, `add_virtiofs`, `add_disk`, `set_console_output`, `get_shutdown_eventfd`, `start_enter`, `set_log_level`). All return `Result<_, Error::Krun(i32)>` per plan 57 W1.4.
- `start()` allocates a context, applies VM config + kernel + rootfs disk + vsock ports through the FFI when `libkrun-sys` is on, then drops the context. `krun_start_enter` is deliberately **not** invoked — booting is W3+W4 scope per the plan's "don't try to boot a VM yet."
- Mechanical `mvm_providers::libkrun::*` → `mvm_libkrun::*` rename in `mvm-backend`, `mvm-cli`, `mvm-core`. `mvm-providers` description tightened to Apple-VZ only.

W2 (codesigning entitlement), W3 (boot validation), W4 (state tracking), W5 (CI lane) follow as separate PRs.

## Test plan

- [x] `cargo build --workspace` — fallback path green on hosts without libkrun installed.
- [x] `cargo build -p mvm-libkrun --features libkrun-sys` — links `libkrun.dylib` via the symmetric Homebrew prefix.
- [x] `cargo test -p mvm-libkrun --features libkrun-sys` — 8/8 pass on macOS Apple Silicon with libkrun 1.17.4 (Homebrew), including `create_and_drop_context`, `log_level_is_settable`, `vm_config_round_trips` — real FFI round-trips into libkrun, not stubs.
- [x] `cargo clippy --workspace -- -D warnings` and `cargo clippy -p mvm-libkrun --features libkrun-sys -- -D warnings` — both clean.
- [x] `cargo test --workspace` — green (single unrelated nix-daemon environment failure on this dev host: `mk_guest_eval_assertions_all_pass_when_nix_available`, fails on a clean stash too).

🤖 Generated with [Claude Code](https://claude.com/claude-code)