### PR TITLE
feat(macos-codesign): plan 57 W2 follow-on — entitlement test + troubleshooting docs

### DIFF
--- a/crates/mvm-providers/src/apple_container/macos.rs
+++ b/crates/mvm-providers/src/apple_container/macos.rs
@@ -378,22 +378,27 @@ pub fn ensure_signed() {
     std::process::exit(1);
 }
 
+/// Ad-hoc entitlements plist applied by [`sign_binary`]. Lifted to a
+/// const so the entitlement set is testable from the module's unit
+/// tests (`test_entitlements_cover_both_frameworks`) — the merged W2
+/// change inlined the XML, which made the "did we keep both keys"
+/// invariant invisible to CI.
+const ENTITLEMENTS_PLIST: &str = "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n\
+    <!DOCTYPE plist PUBLIC \"-//Apple//DTD PLIST 1.0//EN\" \
+    \"http://www.apple.com/DTDs/PropertyList-1.0.dtd\">\n\
+    <plist version=\"1.0\"><dict>\n\
+    <key>com.apple.security.virtualization</key><true/>\n\
+    <key>com.apple.security.hypervisor</key><true/>\n\
+    </dict></plist>";
+
 /// Sign the binary ad-hoc with both VZ and Hypervisor.framework
 /// entitlements (no self-restart).
 ///
 /// Called by `ensure_signed()` and also by the `-d` detach path to
 /// pre-sign before installing the launchd agent.
 fn sign_binary(exe_str: &str) {
-    let ent = "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n\
-        <!DOCTYPE plist PUBLIC \"-//Apple//DTD PLIST 1.0//EN\" \
-        \"http://www.apple.com/DTDs/PropertyList-1.0.dtd\">\n\
-        <plist version=\"1.0\"><dict>\n\
-        <key>com.apple.security.virtualization</key><true/>\n\
-        <key>com.apple.security.hypervisor</key><true/>\n\
-        </dict></plist>";
-
     let ent_path = std::env::temp_dir().join("mvm-entitlements.plist");
-    if std::fs::write(&ent_path, ent).is_err() {
+    if std::fs::write(&ent_path, ENTITLEMENTS_PLIST).is_err() {
         return;
     }
 
@@ -1056,6 +1061,26 @@ mod tests {
             .map(|d| d.as_nanos())
             .unwrap_or(0);
         format!("{}-{}", std::process::id(), nanos)
+    }
+
+    /// Plan 57 W2: both `com.apple.security.virtualization` (VZ) and
+    /// `com.apple.security.hypervisor` (direct Hypervisor.framework /
+    /// libkrun) must be stamped by the same ad-hoc sign so a single
+    /// `mvmctl` binary can drive both backends without re-signing on
+    /// every backend swap. A regression that drops either key is a
+    /// silent runtime failure (kernel rejects the framework call),
+    /// so guard the invariant from CI.
+    #[test]
+    fn test_entitlements_cover_both_frameworks() {
+        assert!(
+            ENTITLEMENTS_PLIST.contains("<key>com.apple.security.virtualization</key>"),
+            "entitlements plist must declare the VZ entitlement"
+        );
+        assert!(
+            ENTITLEMENTS_PLIST.contains("<key>com.apple.security.hypervisor</key>"),
+            "entitlements plist must declare the direct Hypervisor.framework entitlement \
+             (required by libkrun on macOS)"
+        );
     }
 
     #[test]

--- a/public/src/content/docs/guides/troubleshooting.md
+++ b/public/src/content/docs/guides/troubleshooting.md
@@ -189,6 +189,34 @@ mvmctl up --flake . --hypervisor qemu    # microvm.nix
 mvmctl doctor   # check available backends
 ```
 
+### macOS: first-run codesigning for `apple-container` and `libkrun`
+
+Both `mvmctl up --hypervisor apple-container` and (once plan 57 W3 wires guest boot) `mvmctl up --hypervisor libkrun` need ad-hoc codesigning before the macOS kernel will let the binary touch the hypervisor APIs:
+
+- `com.apple.security.virtualization` — required by `Virtualization.framework` (the `apple-container` backend).
+- `com.apple.security.hypervisor` — required by direct `Hypervisor.framework` callers (the `libkrun` backend).
+
+On the **first** run of either backend, `mvmctl` ad-hoc signs itself with both entitlements and re-spawns the current invocation. The same signed binary covers both backends, so swapping `--hypervisor` between `apple-container` and `libkrun` does not re-sign.
+
+What you'll see on the first run:
+
+```
+$ mvmctl up --flake . --hypervisor apple-container
+INFO Signing binary with virtualization + hypervisor entitlements...
+…starts the VM…
+```
+
+On macOS 14+ the ad-hoc signature is accepted by Gatekeeper without an extra prompt. If you had previously installed `mvmctl` from a Homebrew bottle signed against an older entitlement set (virtualization only), the re-spawn will trigger once on the next run after upgrade to lift the binary to both entitlements; subsequent runs are silent.
+
+To pre-sign in CI (skip the re-spawn entirely), set `MVM_SIGNED=1` once the binary on disk already carries both entitlements — the wrapper trusts the env var and skips the codesign probe.
+
+If the signing step itself fails, check that the Xcode command-line tools are installed:
+
+```bash
+xcode-select --install
+codesign --version    # should report a build number
+```
+
 ### No `/dev/kvm` available (cloud VMs without nested virt)
 
 Hitting `KVM not available` on a cloud instance? Three options, in order of recommendation.


### PR DESCRIPTION
## Summary

PR #151 shipped the core plan 57 W2 work (`com.apple.security.hypervisor` added alongside the existing virtualization entitlement, plus the dual-entitlement check in `ensure_signed()`). Two gaps remained that this PR closes:

1. **The entitlements plist had no CI guard.** PR #151 inlined the XML inside `sign_binary()`, so a future edit that silently drops either key wouldn't fail any test. Lift the plist to a private `ENTITLEMENTS_PLIST` const and add `test_entitlements_cover_both_frameworks` asserting both keys remain present. A drop becomes a red CI lane, not a silent runtime kernel rejection.
2. **No user-facing docs for the first-run UX.** The codesign + re-spawn path is invisible until a user sees the `INFO Signing binary with virtualization + hypervisor entitlements...` line on first run and wonders what's happening. Add a `### macOS: first-run codesigning for apple-container and libkrun` section to `guides/troubleshooting.md` covering which entitlement gates which framework, the one-time re-sign on upgrade, the `MVM_SIGNED=1` CI escape, and how to fix a broken Xcode CLI tools install.

Pure additive — no behavior change beyond the new test gate. Plan 57 W3 (end-to-end boot validation) and the `LibkrunBackend` ensure_signed wiring (deferred to plan 72 W1 per PR #151) remain separate PRs.

## Test plan

- [x] `cargo test -p mvm-providers` — 13/13 pass on macOS Apple Silicon, including the new `test_entitlements_cover_both_frameworks`.
- [x] `cargo clippy --workspace -- -D warnings` — clean.
- [x] The const refactor is byte-equivalent to the inlined plist PR #151 shipped (same XML, same keys, just moved + reused).

🤖 Generated with [Claude Code](https://claude.com/claude-code)