### PR TITLE
feat(libkrun): plan 57 W3 — end-to-end boot validation on macOS Apple Silicon

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4273,6 +4273,8 @@ version = "0.14.0"
 dependencies = [
  "bindgen",
  "libc",
+ "mvm-guest",
+ "mvm-providers",
  "tracing",
 ]
 

--- a/crates/mvm-libkrun/Cargo.toml
+++ b/crates/mvm-libkrun/Cargo.toml
@@ -49,5 +49,26 @@ default = []
 # Linux contributors who don't run the Tier 2 backend).
 libkrun-sys = []
 
+[dev-dependencies]
+# The plan 57 W3 smoke example pulls `GUEST_AGENT_PORT` so the smoke
+# binary and the production vsock plumbing stay in sync on which port
+# the guest agent expects.
+mvm-guest.workspace = true
+# `ensure_signed()` is plan 57 W2's codesigning gate. macOS rejects
+# any process that calls `Hypervisor.framework` without
+# `com.apple.security.hypervisor`; the smoke binary self-signs on
+# first run and re-spawns, same as `mvmctl up --hypervisor
+# apple-container` does.
+mvm-providers.workspace = true
+
+# Plan 57 W3 — manual smoke binary that boots a Nix-built kernel +
+# ext4 rootfs via libkrun and blocks until the guest exits. Gated on
+# `libkrun-sys` so the example only compiles on hosts with libkrun.h
+# present.
+[[example]]
+name = "libkrun-smoke"
+path = "examples/libkrun-smoke.rs"
+required-features = ["libkrun-sys"]
+
 [lints]
 workspace = true

--- a/crates/mvm-libkrun/examples/libkrun-smoke.rs
+++ b/crates/mvm-libkrun/examples/libkrun-smoke.rs
@@ -1,0 +1,237 @@
+//! Plan 57 W3 smoke test — boot a Nix-built kernel + ext4 rootfs via
+//! libkrun on macOS Apple Silicon and observe the result.
+//!
+//! Build:
+//!   cargo build --example libkrun-smoke -p mvm-libkrun --features libkrun-sys
+//!
+//! Run (defaults pull from `~/.mvm/dev/current/`, the dev-VM artifacts
+//! shipped by `mvmctl dev up` pre-Plan-72):
+//!   target/debug/examples/libkrun-smoke
+//!
+//! Override any path:
+//!   libkrun-smoke \
+//!     --kernel /path/to/vmlinux \
+//!     --rootfs /path/to/rootfs.ext4 \
+//!     --data-disk /path/to/nix-store.img \
+//!     --cmdline 'console=hvc0 root=/dev/vda rw init=/init' \
+//!     --console-output /tmp/mvm-libkrun-smoke.log
+//!
+//! ## What it proves
+//!
+//! libkrun's macOS Apple Silicon (Hypervisor.framework) path can load
+//! a Nix-built ARM64 kernel and attach an ext4 rootfs as `/dev/vda`.
+//! `krun_start_enter` blocks until the guest exits; the smoke test
+//! process becomes the guest. On success libkrun calls `exit()` with
+//! the guest's exit code — there is no "after". A boot failure
+//! surfaces as a libkrun error code returned from `start_enter`.
+//!
+//! ## Hard-coded for this iteration
+//!
+//! - `--cmdline` defaults to the same line Apple Container uses on
+//!   macOS (`console=hvc0 root=/dev/vda rw init=/init`), because both
+//!   backends drive `Hypervisor.framework` and share the virtio-console
+//!   wiring. The Firecracker `console=ttyS0` cmdline is wrong here.
+//! - Kernel format is `KrunContext`'s default (Raw). ARM64 Linux
+//!   "Image" files use the raw format; ELF kernels would need
+//!   `KernelFormat::Elf`.
+//! - The default vsock port (`GUEST_AGENT_PORT`) is configured so the
+//!   guest-agent listener has a host-side socket to bind to; the
+//!   actual health-check ping is a follow-on W3.3 task and is *not*
+//!   run from this binary (the calling process becomes the guest, so
+//!   there is no opportunity to dial the socket from here).
+//!
+//! ## Not yet wired
+//!
+//! - Boot timing / health-check ping over vsock — needs a separate
+//!   host process or a fork(); the smoke binary is single-process and
+//!   inherits the process-exits-on-success contract of
+//!   `krun_start_enter`. W3.3 covers that wiring in a follow-on PR.
+
+use std::path::{Path, PathBuf};
+use std::process::ExitCode;
+
+use mvm_libkrun::{KrunContext, LogLevel, set_log_level, start_enter};
+
+fn main() -> ExitCode {
+    let args = match Args::parse() {
+        Ok(a) => a,
+        Err(msg) => {
+            eprintln!("error: {msg}\n");
+            eprintln!("{HELP}");
+            return ExitCode::from(2);
+        }
+    };
+
+    if args.help {
+        println!("{HELP}");
+        return ExitCode::SUCCESS;
+    }
+
+    // macOS Hypervisor.framework rejects any process that lacks the
+    // `com.apple.security.hypervisor` entitlement (plan 57 W2 added
+    // the joint VZ + Hypervisor entitlement set). `ensure_signed`
+    // ad-hoc codesigns the current binary on first run and re-spawns
+    // with `MVM_SIGNED=1`; subsequent runs are silent. Without this
+    // call, `krun_start_enter` fails at VM creation with rc -22.
+    mvm_providers::apple_container::ensure_signed();
+
+    // Sanity-check every path that has to exist before we hand it to
+    // libkrun. The C wrapper would fail later anyway, but failing here
+    // gives a clearer error.
+    for (label, path) in [("kernel", &args.kernel), ("rootfs", &args.rootfs)] {
+        if !Path::new(path).is_file() {
+            eprintln!("error: {label} path does not exist or is not a file: {path}");
+            return ExitCode::from(2);
+        }
+    }
+    if let Some(dd) = &args.data_disk
+        && !Path::new(dd).is_file()
+    {
+        eprintln!("error: data-disk path does not exist or is not a file: {dd}");
+        return ExitCode::from(2);
+    }
+
+    eprintln!("plan 57 W3 — libkrun boot smoke");
+    eprintln!("  kernel:   {}", args.kernel);
+    eprintln!("  rootfs:   {}", args.rootfs);
+    if let Some(dd) = &args.data_disk {
+        eprintln!("  data:     {dd} (as /dev/vdb)");
+    }
+    eprintln!("  cmdline:  {}", args.cmdline);
+    eprintln!("  vcpus:    {}", args.vcpus);
+    eprintln!("  mem MiB:  {}", args.mem_mib);
+    if let Some(co) = &args.console_output {
+        eprintln!("  console → {co}");
+    } else {
+        eprintln!("  console → (process stdout)");
+    }
+    eprintln!();
+    eprintln!("krun_start_enter blocks until the guest exits, then calls");
+    eprintln!("exit() with the guest's status. ^C kills the host process,");
+    eprintln!("which tears the guest down with it.");
+    eprintln!();
+
+    // Crank libkrun's own log level so a boot failure surfaces with
+    // some context rather than a bare errno.
+    if let Err(e) = set_log_level(LogLevel::Debug) {
+        eprintln!("warn: krun_set_log_level failed: {e}");
+    }
+
+    let mut ctx = KrunContext::new("mvm-libkrun-smoke", &args.kernel, &args.rootfs)
+        .with_resources(args.vcpus, args.mem_mib)
+        .with_cmdline(&args.cmdline)
+        .add_vsock_port(mvm_guest::vsock::GUEST_AGENT_PORT);
+    if let Some(dd) = args.data_disk {
+        ctx = ctx.add_disk("data", dd, false);
+    }
+    if let Some(co) = args.console_output {
+        ctx = ctx.with_console_output(co);
+    }
+
+    match start_enter(&ctx) {
+        // `start_enter` returns `Result<Infallible, _>`; on success the
+        // process is already gone, so the Ok arm is unreachable in
+        // practice and the match is over `Err` only.
+        Err(e) => {
+            eprintln!("\nlibkrun start_enter failed: {e}");
+            ExitCode::from(1)
+        }
+    }
+}
+
+const HELP: &str = "\
+plan 57 W3 — libkrun boot smoke
+
+Boots a Nix-built kernel + ext4 rootfs through libkrun on macOS Apple
+Silicon and blocks until the guest exits. Defaults target the dev-VM
+artifacts under ~/.mvm/dev/current/.
+
+USAGE:
+    libkrun-smoke [OPTIONS]
+
+OPTIONS:
+    --kernel <PATH>           kernel image (ARM64 'Image' / raw format)
+                              [default: ~/.mvm/dev/current/vmlinux]
+    --rootfs <PATH>           ext4 root filesystem image
+                              [default: ~/.mvm/dev/current/rootfs.ext4]
+    --data-disk <PATH>        optional second virtio-blk device (/dev/vdb)
+                              [default: ~/.mvm/dev/nix-store.img if it exists]
+    --cmdline <STRING>        kernel command line
+                              [default: 'console=hvc0 root=/dev/vda rw init=/init']
+    --console-output <PATH>   route hvc0 console to a file
+                              [default: inherit calling process's stdout]
+    --vcpus <N>               vCPU count [default: 1]
+    --mem <MIB>               guest RAM in MiB [default: 512]
+    -h, --help                show this help
+";
+
+struct Args {
+    kernel: String,
+    rootfs: String,
+    data_disk: Option<String>,
+    cmdline: String,
+    console_output: Option<String>,
+    vcpus: u8,
+    mem_mib: u32,
+    help: bool,
+}
+
+impl Args {
+    fn parse() -> Result<Self, String> {
+        let home = std::env::var("HOME").map_err(|_| "HOME not set".to_string())?;
+        let default_kernel = format!("{home}/.mvm/dev/current/vmlinux");
+        let default_rootfs = format!("{home}/.mvm/dev/current/rootfs.ext4");
+        let default_data = format!("{home}/.mvm/dev/nix-store.img");
+        let auto_data = PathBuf::from(&default_data)
+            .is_file()
+            .then_some(default_data);
+
+        let mut kernel = default_kernel;
+        let mut rootfs = default_rootfs;
+        let mut data_disk = auto_data;
+        let mut cmdline = "console=hvc0 root=/dev/vda rw init=/init".to_string();
+        let mut console_output: Option<String> = None;
+        let mut vcpus: u8 = 1;
+        let mut mem_mib: u32 = 512;
+        let mut help = false;
+
+        let mut it = std::env::args().skip(1);
+        while let Some(arg) = it.next() {
+            match arg.as_str() {
+                "-h" | "--help" => help = true,
+                "--kernel" => kernel = next_value(&mut it, "--kernel")?,
+                "--rootfs" => rootfs = next_value(&mut it, "--rootfs")?,
+                "--data-disk" => data_disk = Some(next_value(&mut it, "--data-disk")?),
+                "--no-data-disk" => data_disk = None,
+                "--cmdline" => cmdline = next_value(&mut it, "--cmdline")?,
+                "--console-output" => {
+                    console_output = Some(next_value(&mut it, "--console-output")?)
+                }
+                "--vcpus" => {
+                    let v = next_value(&mut it, "--vcpus")?;
+                    vcpus = v.parse().map_err(|e| format!("--vcpus: {e}"))?;
+                }
+                "--mem" => {
+                    let v = next_value(&mut it, "--mem")?;
+                    mem_mib = v.parse().map_err(|e| format!("--mem: {e}"))?;
+                }
+                other => return Err(format!("unknown argument: {other}")),
+            }
+        }
+
+        Ok(Args {
+            kernel,
+            rootfs,
+            data_disk,
+            cmdline,
+            console_output,
+            vcpus,
+            mem_mib,
+            help,
+        })
+    }
+}
+
+fn next_value(it: &mut impl Iterator<Item = String>, flag: &str) -> Result<String, String> {
+    it.next().ok_or_else(|| format!("{flag} requires a value"))
+}

--- a/crates/mvm-libkrun/src/lib.rs
+++ b/crates/mvm-libkrun/src/lib.rs
@@ -26,7 +26,7 @@ use std::path::Path;
 mod sys;
 
 #[cfg(feature = "libkrun-sys")]
-pub use sys::{KernelFormat, LogLevel};
+pub use sys::{KernelFormat, LogLevel, set_log_level};
 
 /// Errors returned by this crate.
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -144,11 +144,30 @@ pub fn install_paths() -> Vec<&'static str> {
     }
 }
 
+/// Extra block device to attach to the guest alongside the rootfs.
+///
+/// libkrun mounts the rootfs at `/dev/vda` (by convention from the
+/// order disks are added); each `KrunDisk` becomes `/dev/vdb`,
+/// `/dev/vdc`, … in the order they appear in [`KrunContext::extra_disks`].
+#[derive(Debug, Clone)]
+pub struct KrunDisk {
+    /// Symbolic identifier passed to `krun_add_disk` (`block_id`).
+    /// Not user-visible inside the guest; libkrun uses it for
+    /// bookkeeping.
+    pub id: String,
+    /// Host path to the backing image (raw format).
+    pub path: String,
+    /// `true` opens the device read-only at the libkrun layer. Useful
+    /// for dm-verity sidecars and signed root images.
+    pub read_only: bool,
+}
+
 /// Configuration for a libkrun guest VM.
 ///
-/// Pure data — no I/O until [`start`] consumes it. Field shape is
-/// stable across the W1 → W3 transition; the FFI calls that consume
-/// each field live in [`sys`] under the `libkrun-sys` feature.
+/// Pure data — no I/O until [`start`] / [`start_enter`] consume it.
+/// Field shape is stable across the W1 → W3 transition; the FFI calls
+/// that consume each field live in [`sys`] under the `libkrun-sys`
+/// feature.
 #[derive(Debug, Clone)]
 pub struct KrunContext {
     pub name: String,
@@ -158,11 +177,23 @@ pub struct KrunContext {
     pub ram_mib: u32,
     pub kernel_cmdline: Option<String>,
     pub vsock_ports: Vec<u32>,
+    /// Additional virtio-blk devices, appearing as `/dev/vdb`,
+    /// `/dev/vdc`, … in the order listed. Empty by default; the
+    /// dev-VM builder VM uses one entry for the Nix-store overlay
+    /// disk (`MVM_NIX_STORE_DISK`).
+    pub extra_disks: Vec<KrunDisk>,
+    /// When `Some`, libkrun routes the guest's hvc0 console to this
+    /// host path (a regular file, FIFO, or device). When `None`, the
+    /// console writes inherit the calling process's stdout (the
+    /// default for an interactive smoke test). Plan 57 W3 uses this
+    /// to capture early-boot kernel output for diagnosis.
+    pub console_output_path: Option<String>,
 }
 
 impl KrunContext {
     /// Construct a context for a guest. No I/O — this is pure
-    /// configuration. The actual VM creation happens in [`start`].
+    /// configuration. The actual VM creation happens in [`start`] or
+    /// [`start_enter`].
     pub fn new(
         name: impl Into<String>,
         kernel_path: impl Into<String>,
@@ -176,6 +207,8 @@ impl KrunContext {
             ram_mib: 256,
             kernel_cmdline: None,
             vsock_ports: Vec::new(),
+            extra_disks: Vec::new(),
+            console_output_path: None,
         }
     }
 
@@ -186,9 +219,39 @@ impl KrunContext {
         self
     }
 
+    /// Set the kernel command line (replaces the default).
+    pub fn with_cmdline(mut self, cmdline: impl Into<String>) -> Self {
+        self.kernel_cmdline = Some(cmdline.into());
+        self
+    }
+
     /// Append a vsock port the guest agent will listen on.
     pub fn add_vsock_port(mut self, port: u32) -> Self {
         self.vsock_ports.push(port);
+        self
+    }
+
+    /// Attach an additional virtio-blk device. The first call appears
+    /// as `/dev/vdb` in the guest, the second `/dev/vdc`, etc.
+    pub fn add_disk(
+        mut self,
+        id: impl Into<String>,
+        path: impl Into<String>,
+        read_only: bool,
+    ) -> Self {
+        self.extra_disks.push(KrunDisk {
+            id: id.into(),
+            path: path.into(),
+            read_only,
+        });
+        self
+    }
+
+    /// Route the guest's hvc0 console output to `path`. Pass `None`
+    /// (or omit the call) to leave libkrun's default behavior in
+    /// place (writes to the calling process's stdout).
+    pub fn with_console_output(mut self, path: impl Into<String>) -> Self {
+        self.console_output_path = Some(path.into());
         self
     }
 }
@@ -225,30 +288,107 @@ pub fn start(ctx: &KrunContext) -> Result<(), Error> {
     }
 }
 
+/// Apply every `KrunContext` field to a freshly-allocated libkrun
+/// configuration context. Shared between [`start`] (W1: configure +
+/// drop) and [`start_enter`] (W3: configure + boot).
 #[cfg(feature = "libkrun-sys")]
-fn start_via_ffi(ctx: &KrunContext) -> Result<(), Error> {
+fn configure(ctx: &KrunContext) -> Result<sys::Context, Error> {
     let krun = sys::Context::new()?;
     krun.set_vm_config(ctx.vcpus, ctx.ram_mib)?;
+    // ARM64 Linux kernels build as the "Image" format (a flat binary
+    // header + payload, not ELF). libkrun's `RAW` kernel format consumes
+    // them directly. x86_64 bzImage is also `RAW`. ELF-format kernels
+    // (rare outside test fixtures) would need `KernelFormat::Elf`.
     krun.set_kernel(
         Path::new(&ctx.kernel_path),
-        sys::KernelFormat::Elf,
+        sys::KernelFormat::Raw,
         None,
         ctx.kernel_cmdline.as_deref(),
     )?;
     krun.add_disk("root", Path::new(&ctx.rootfs_path), false)?;
+    for disk in &ctx.extra_disks {
+        krun.add_disk(&disk.id, Path::new(&disk.path), disk.read_only)?;
+    }
+    // NOTE on vsock device wiring (plan 57 W3.3, deferred):
+    //
+    // libkrun exposes two vsock APIs:
+    //   - `krun_add_vsock(ctx, tsi_features)` — adds a *virtio-vsock*
+    //     device the guest sees as `/dev/vsock`.
+    //   - `krun_add_vsock_port(ctx, port, host_path)` — registers a
+    //     port→host-Unix-socket mapping for TSI (Transparent Socket
+    //     Impersonation) mode.
+    //
+    // Calling both in the same context returns `-EEXIST` from the
+    // second call: TSI mode and a plain virtio-vsock device are
+    // mutually exclusive in libkrun's current design. Plan 57 W3.3
+    // (separate PR) picks the right one for the guest agent and
+    // wires the cross-process socket path; until then `add_vsock_port`
+    // is exercised by itself, which is what the W1 unit tests asserted
+    // and what the W3 boot smoke ran against.
     for &port in &ctx.vsock_ports {
         // libkrun's `krun_add_vsock_port` requires a host-side Unix
         // socket path. The full backend wiring (which generates that
-        // path under ~/.mvm/vms/<name>/) lands in W3 alongside the
-        // boot validation. For W1 the FFI exercise stops short of
-        // booting, so a stub path is sufficient to confirm the wrapper
-        // accepts the call.
+        // path under ~/.mvm/vms/<name>/) lands alongside the W4 state
+        // tracker; the W1 + W3 exercises use a stub path scoped to
+        // the VM name so concurrent guests don't clash.
         let socket = format!("/tmp/mvm-libkrun-{}-vsock-{port}.sock", ctx.name);
         krun.add_vsock_port(port, Path::new(&socket))?;
     }
-    // `krun_start_enter` deliberately not invoked — that's W3 + W4.
-    // Dropping the context here frees it cleanly through `Context::Drop`.
+    if let Some(console_path) = &ctx.console_output_path {
+        krun.set_console_output(Path::new(console_path))?;
+    }
+    Ok(krun)
+}
+
+#[cfg(feature = "libkrun-sys")]
+fn start_via_ffi(ctx: &KrunContext) -> Result<(), Error> {
+    let _krun = configure(ctx)?;
+    // `krun_start_enter` deliberately not invoked here — that's
+    // [`start_enter`]. Dropping the context frees it cleanly through
+    // `Context::Drop`.
     Ok(())
+}
+
+/// Boot a libkrun guest from `ctx` and block until it exits.
+///
+/// **Plan 57 W3 spike entry point.** Configures libkrun the same way
+/// [`start`] does, then calls `krun_start_enter`. libkrun's
+/// `start_enter` calls `exit()` on the calling process with the
+/// guest's exit code when the guest powers off cleanly, so this
+/// function does not return on success — its return type is
+/// [`std::convert::Infallible`] in the `Ok` arm.
+///
+/// Use cases:
+/// - the W3 smoke binary (`crates/mvm-libkrun/examples/libkrun-smoke.rs`)
+///   that validates a real Nix-built kernel + ext4 rootfs boots on
+///   macOS Apple Silicon;
+/// - one-shot guest invocations where the caller wants the process
+///   to exit alongside the guest.
+///
+/// **Not yet suitable** for `LibkrunBackend::start()` — that consumer
+/// needs the surrounding mvmctl process to keep running after the VM
+/// boots. The blocking-thread + per-VM registry lifecycle is W4 of
+/// plan 57.
+///
+/// Without the `libkrun-sys` feature, returns [`Error::NotYetWired`].
+pub fn start_enter(ctx: &KrunContext) -> Result<std::convert::Infallible, Error> {
+    if !is_available() {
+        return Err(Error::NotInstalled {
+            install_hint: install_hint(),
+        });
+    }
+    #[cfg(not(feature = "libkrun-sys"))]
+    {
+        let _ = ctx;
+        Err(Error::NotYetWired {
+            tracking: "specs/plans/57-libkrun-spike.md W3",
+        })
+    }
+    #[cfg(feature = "libkrun-sys")]
+    {
+        let krun = configure(ctx)?;
+        krun.start_enter()
+    }
 }
 
 /// Stop a running libkrun guest by name.

--- a/specs/plans/57-libkrun-spike.md
+++ b/specs/plans/57-libkrun-spike.md
@@ -65,6 +65,8 @@ Goal: `mvmctl` + libkrun + `Hypervisor.framework` boot a guest without the macOS
 
 ### W3 — End-to-end boot validation (the actual spike, 2–3 days)
 
+> Status update 2026-05-13: **W3.1, W3.2, W3.4 (cmdline + console) shipped.** W3.3 (vsock health check) deferred to a follow-on PR — see "Findings" below for why.
+
 Goal: prove a real Nix-built kernel + ext4 rootfs boots in libkrun on macOS Apple Silicon and the guest agent comes up on vsock.
 
 - **W3.1** Pick the validation flake. `examples/minimal` is the canonical "smallest-thing-that-boots" target across mvm. Build it: `mvmctl build --flake examples/minimal`. Outputs are `vmlinux`, `rootfs.ext4`, and possibly `initrd`.
@@ -75,6 +77,34 @@ Goal: prove a real Nix-built kernel + ext4 rootfs boots in libkrun on macOS Appl
   - **Console device.** No serial → console output may not appear. Confirm libkrun routes hvc0 to stdout in the calling process, or wire it through a host-side log file.
   - **vsock device naming.** Firecracker uses `/dev/vhost-vsock`; libkrun's macOS path uses an internal abstraction. Confirm the guest sees vsock on cid 3 (standard guest CID) and the agent's listening port matches.
   - **Verified boot (claim 3) is out of scope for the spike.** The Nix flake's `verifiedBoot = false` exemption (the dev VM path) covers this. Plan 25 §W3 follow-up promotes claim 3 from "DoesNotHold" to "Holds" for libkrun once dm-verity is wired through.
+
+#### Findings — first end-to-end boot, 2026-05-13
+
+Run on: macOS 15.6 (Apple Silicon, M-series), libkrun 1.17.4 via Homebrew, kernel + rootfs from the pre-Plan-72 `~/.mvm/dev/current/` dev-VM artifacts (built 2026-05-12).
+
+**Boot path shipped**: `cargo run --example libkrun-smoke -p mvm-libkrun --features libkrun-sys`. Source: `crates/mvm-libkrun/examples/libkrun-smoke.rs`.
+
+What worked first-try on the W2 codesigned binary:
+
+1. **`console=hvc0 root=/dev/vda rw init=/init` is correct.** The plan's prediction held: libkrun's Hypervisor.framework path drops the Firecracker `console=ttyS0` form and uses virtio-console (`hvc0`) — the same cmdline Apple Container already produces in `crates/mvm-providers/src/apple_container/macos.rs`. Without this swap the kernel boots but emits no console output.
+2. **ARM64 "Image" kernel format = libkrun `KRUN_KERNEL_FORMAT_RAW`.** Nix's `nixpkgs.linuxPackages` cross-built `vmlinux` is a flat ARM64 boot Image, not ELF. `KernelFormat::Raw` consumes it directly. W1's wrapper had defaulted to `Elf`; the W3 smoke flipped that, and the W1 unit test doesn't exercise the kernel-format value so the change is safe.
+3. **Multiple virtio-blk devices work.** Rootfs at `/dev/vda` (736 MiB ext4), `~/.mvm/dev/nix-store.img` at `/dev/vdb` (64 GiB sparse). The kernel boot log enumerates both; `EXT4-fs (vda): mounted filesystem … r/w with ordered data mode` is the success signal.
+4. **`krun_set_console_output(path)` routes hvc0 to a host file** — confirmed by checking `/tmp/mvm-libkrun-smoke-console.log` for the full kernel boot log post-shutdown. Useful for both manual smoke tests and the W5 CI lane.
+5. **Plan 57 W2's codesigning gate is load-bearing.** The first run without `ensure_signed()` failed at `krun_start_enter` with `Internal(Vm(VmSetup(VmCreate)))` / rc `-22`. After `ensure_signed()` self-signs the binary with both entitlements and re-spawns, boot succeeds. The smoke binary now calls `ensure_signed()` first so subsequent reruns are silent (`MVM_SIGNED=1`).
+
+Risks the plan named that **did not materialize**:
+
+- The Nix `mkGuest` build did not need a `cmdlineFor = "libkrun" | "firecracker"` switch. Overriding `KrunContext.kernel_cmdline` at runtime is sufficient — the same kernel binary boots under Firecracker (`ttyS0`) and libkrun (`hvc0`) depending on what the host passes.
+- The codesigning entitlement composed cleanly with the existing VZ entitlement (plan 57 W2 + PR #151 already validated this for the codesign step; W3 confirmed it at runtime).
+- No `mkGuest` change was needed for libkrun-specific kernel features.
+
+What's **deferred to a follow-on PR (W3.3)**:
+
+- **`krun_add_vsock` vs `krun_add_vsock_port` are mutually exclusive in libkrun's current API.** Calling `add_vsock(0)` after `add_vsock_port(...)` returns `-EEXIST`; the reverse order has the same result. The W3 smoke ran with only `add_vsock_port` (which is enough for TSI-mode pseudo-vsock) and the guest booted to userspace, but the dev rootfs's guest-agent listener uses true virtio-vsock and needs `add_vsock`. Picking the right mode (real virtio-vsock for the guest agent, TSI for ipc-style port forwards) and the per-VM host socket path is W3.3.
+- The dev rootfs `/init` itself hits a BusyBox-vs-util-linux incompatibility (`setpriv: unrecognized option: reuid=990`) — orthogonal to libkrun. Tracked separately under the dev-VM owners; the libkrun layer did its job by getting `/init` running.
+- A vsock health-check ping against `mvm_guest::vsock::GUEST_AGENT_PORT` from the host. `krun_start_enter` consumes the calling process (calls `exit()` on success), so the ping has to come from a sibling process or fork. The W4 supervisor-thread / launchd lane resolves the process-lifecycle side of this naturally.
+
+Decision recorded: **the libkrun macOS Apple Silicon path is viable.** Plan 72 (builder-VM-via-libkrun) is unblocked on the boot side; the remaining wiring is state-tracking (W4) and CI (W5).
 
 ### W4 — State tracking decision (1–2 days)
 


### PR DESCRIPTION
## Summary

Validates libkrun's macOS Apple Silicon path end-to-end. A real Nix-built ARM64 kernel + ext4 rootfs boots through libkrun / Hypervisor.framework, mounts `/dev/vda`, attaches `/dev/vdb`, and runs `/init`. The lane is viable; plan 72 (builder-VM migration) is unblocked on the boot side.

- Extend `KrunContext` with `extra_disks: Vec<KrunDisk>` (additional virtio-blk devices → `/dev/vdb`, `/dev/vdc`, …) and `console_output_path: Option<String>` (route `hvc0` to a host file). Builders: `add_disk`, `with_console_output`, `with_cmdline`. Additive — existing constructors keep working.
- Add `mvm_libkrun::start_enter(ctx) -> Result<Infallible, Error>` that configures libkrun the same way `start()` does and then calls `krun_start_enter`. The function does not return on success (libkrun calls `exit()` with the guest's status). This is the W3 spike entry point; W4's supervisor lane adapts it for `LibkrunBackend::start()`.
- Flip the default kernel format from `Elf` to `Raw`. Nix cross-built ARM64 kernels ship as the "Image" format (flat header + payload, not ELF), and `RAW` is the right libkrun parameter.
- New `crates/mvm-libkrun/examples/libkrun-smoke.rs`. Manual smoke binary, gated on `libkrun-sys`. Defaults pull from `~/.mvm/dev/current/{vmlinux,rootfs.ext4}` plus the optional `~/.mvm/dev/nix-store.img`. Calls `ensure_signed()` first — without W2's codesigning gate, `krun_start_enter` fails at VM creation with `rc -22`.
- Document W3 findings inline in `specs/plans/57-libkrun-spike.md` — what worked, what didn't materialize as a risk, and the W3.3 vsock-mode question deferred to a follow-on PR (`krun_add_vsock` and `krun_add_vsock_port` are mutually exclusive in libkrun's current API).

## What this proves

```
$ cargo run --example libkrun-smoke -p mvm-libkrun --features libkrun-sys
…
[    0.116759] EXT4-fs (vda): mounted filesystem 44444444-… r/w with ordered data mode.
[    0.120082] Run /init as init process
```

`console=hvc0 root=/dev/vda rw init=/init` is correct; the plan's prediction held. `KrunContext::add_disk` exposes the `vdb` attachment; `console_output_path` captures hvc0 into a host file for post-mortem reading.

## Test plan

- [x] `cargo build --workspace` — green (no feature).
- [x] `cargo build -p mvm-libkrun --features libkrun-sys` and `cargo build --example libkrun-smoke -p mvm-libkrun --features libkrun-sys` — green.
- [x] `cargo test -p mvm-libkrun --features libkrun-sys` — 8/8 pass; W1 wrapper tests still happy with the new shared `configure(ctx)` factor-out.
- [x] `cargo clippy --workspace -- -D warnings` and `cargo clippy -p mvm-libkrun --features libkrun-sys --all-targets -- -D warnings` — both clean.
- [x] **Manual W3 spike**: ran `libkrun-smoke` against `~/.mvm/dev/current/{vmlinux,rootfs.ext4}` on macOS Apple Silicon + libkrun 1.17.4. Observed kernel boot up through `Run /init as init process`. Reproducible across reruns.

## Out of scope (filed as W3.3 / W4 / W5)

- **vsock health check** — `krun_add_vsock` + `krun_add_vsock_port` are mutually exclusive in libkrun's current API. Picking the right mode and per-VM host socket path is W3.3. The boot itself doesn't depend on this.
- **`LibkrunBackend::start()` lifecycle** — `start_enter` consumes the calling process. W4 wires the supervisor-thread / launchd lane.
- **CI lane** — `libkrun-macos-arm64` GH Action is W5.

🤖 Generated with [Claude Code](https://claude.com/claude-code)