### PR TITLE
feat(libkrun): plan 57 W3.3 — configurable per-VM vsock socket dir + mode decision

### DIFF
--- a/crates/mvm-libkrun/examples/libkrun-smoke.rs
+++ b/crates/mvm-libkrun/examples/libkrun-smoke.rs
@@ -117,9 +117,19 @@ fn main() -> ExitCode {
         eprintln!("warn: krun_set_log_level failed: {e}");
     }
 
+    // Per-VM vsock socket dir. The smoke binary doesn't run a sibling
+    // listener (it becomes the guest), so any AF_VSOCK connect inside
+    // the guest will fail with ECONNREFUSED — that's expected for the
+    // W3 spike. Plan 57 W4's supervisor adds the host-side listener.
+    let socket_dir = format!("{}/.mvm/vms/mvm-libkrun-smoke", args.home);
+    if let Err(e) = std::fs::create_dir_all(&socket_dir) {
+        eprintln!("warn: create_dir_all {socket_dir}: {e}");
+    }
+
     let mut ctx = KrunContext::new("mvm-libkrun-smoke", &args.kernel, &args.rootfs)
         .with_resources(args.vcpus, args.mem_mib)
         .with_cmdline(&args.cmdline)
+        .with_vsock_socket_dir(&socket_dir)
         .add_vsock_port(mvm_guest::vsock::GUEST_AGENT_PORT);
     if let Some(dd) = args.data_disk {
         ctx = ctx.add_disk("data", dd, false);
@@ -173,6 +183,7 @@ struct Args {
     console_output: Option<String>,
     vcpus: u8,
     mem_mib: u32,
+    home: String,
     help: bool,
 }
 
@@ -227,6 +238,7 @@ impl Args {
             console_output,
             vcpus,
             mem_mib,
+            home,
             help,
         })
     }

--- a/crates/mvm-libkrun/src/lib.rs
+++ b/crates/mvm-libkrun/src/lib.rs
@@ -188,6 +188,19 @@ pub struct KrunContext {
     /// default for an interactive smoke test). Plan 57 W3 uses this
     /// to capture early-boot kernel output for diagnosis.
     pub console_output_path: Option<String>,
+    /// Directory on the host where the per-vsock-port Unix socket
+    /// files live. libkrun proxies between each guest-side
+    /// `AF_VSOCK` port (TSI / virtio-vsock) and the corresponding
+    /// `vsock-<port>.sock` inside this directory; a sibling host
+    /// process (e.g. `mvmctl console <vm>` or the guest-agent
+    /// vsock client in mvm-supervisor) speaks to the guest by
+    /// opening the unix socket. When `None`, [`vsock_socket_path`]
+    /// falls back to `/tmp/mvm-libkrun-<name>-vsock-<port>.sock`
+    /// — fine for the spike smoke binary, but real consumers
+    /// (Plan 57 W4 supervisor, Plan 72 builder-VM launcher) should
+    /// always set a stable per-VM dir under `~/.mvm/vms/<name>/`
+    /// so cross-process clients can find it.
+    pub vsock_socket_dir: Option<String>,
 }
 
 impl KrunContext {
@@ -209,6 +222,23 @@ impl KrunContext {
             vsock_ports: Vec::new(),
             extra_disks: Vec::new(),
             console_output_path: None,
+            vsock_socket_dir: None,
+        }
+    }
+
+    /// Resolve the host-side unix socket path libkrun should pair
+    /// with `port`. If [`Self::vsock_socket_dir`] is set, returns
+    /// `<dir>/vsock-<port>.sock`; otherwise falls back to a per-VM
+    /// `/tmp` path scoped by [`Self::name`]. The fallback is fine
+    /// for the spike smoke binary but real consumers should always
+    /// supply an explicit dir (see field docs).
+    pub fn vsock_socket_path(&self, port: u32) -> std::path::PathBuf {
+        match &self.vsock_socket_dir {
+            Some(dir) => std::path::PathBuf::from(dir).join(format!("vsock-{port}.sock")),
+            None => std::path::PathBuf::from(format!(
+                "/tmp/mvm-libkrun-{}-vsock-{port}.sock",
+                self.name
+            )),
         }
     }
 
@@ -252,6 +282,15 @@ impl KrunContext {
     /// place (writes to the calling process's stdout).
     pub fn with_console_output(mut self, path: impl Into<String>) -> Self {
         self.console_output_path = Some(path.into());
+        self
+    }
+
+    /// Set the per-VM directory libkrun should place vsock unix
+    /// socket files under. See [`Self::vsock_socket_dir`] for the
+    /// rationale; this builder method ensures consumers can chain it
+    /// alongside the other resource setters.
+    pub fn with_vsock_socket_dir(mut self, dir: impl Into<String>) -> Self {
+        self.vsock_socket_dir = Some(dir.into());
         self
     }
 }
@@ -309,30 +348,40 @@ fn configure(ctx: &KrunContext) -> Result<sys::Context, Error> {
     for disk in &ctx.extra_disks {
         krun.add_disk(&disk.id, Path::new(&disk.path), disk.read_only)?;
     }
-    // NOTE on vsock device wiring (plan 57 W3.3, deferred):
+    // libkrun's vsock model — what plan 57 W3.3 settled on after the
+    // first end-to-end smoke (2026-05-13):
     //
-    // libkrun exposes two vsock APIs:
-    //   - `krun_add_vsock(ctx, tsi_features)` — adds a *virtio-vsock*
-    //     device the guest sees as `/dev/vsock`.
-    //   - `krun_add_vsock_port(ctx, port, host_path)` — registers a
-    //     port→host-Unix-socket mapping for TSI (Transparent Socket
-    //     Impersonation) mode.
+    // - TSI (Transparent Socket Impersonation) is auto-enabled when
+    //   no virtio-net device is added. The libkrun README is
+    //   explicit: "TSI for AF_INET and AF_INET6 is automatically
+    //   enabled when no network interface is added to the VM." We
+    //   never call `krun_add_net_*`, so TSI is always on, and the
+    //   virtio-vsock device exists implicitly.
     //
-    // Calling both in the same context returns `-EEXIST` from the
-    // second call: TSI mode and a plain virtio-vsock device are
-    // mutually exclusive in libkrun's current design. Plan 57 W3.3
-    // (separate PR) picks the right one for the guest agent and
-    // wires the cross-process socket path; until then `add_vsock_port`
-    // is exercised by itself, which is what the W1 unit tests asserted
-    // and what the W3 boot smoke ran against.
+    // - `krun_add_vsock` (no `_port`) is for *adding a second
+    //   independent virtio-vsock device*. Because TSI already
+    //   provides one, calling it returns `-EEXIST` (verified on
+    //   libkrun 1.17.4). Do not call it from the W3 path.
+    //
+    // - `krun_add_vsock_port(ctx, port, host_path)` pairs a
+    //   guest-side vsock port with a host unix socket. libkrun
+    //   does *not* create the socket file — that's the host's
+    //   responsibility. The owning host process binds a
+    //   `UnixListener` at `host_path` before calling `start_enter`;
+    //   when the guest opens `AF_VSOCK` to `port`, libkrun proxies
+    //   it to a client connection at the listener.
+    //
+    // The W4 supervisor / Plan 72 builder-VM launcher own the
+    // listener; this configure() step just registers the path so
+    // libkrun knows where to send traffic. The smoke binary
+    // (`examples/libkrun-smoke.rs`) registers the path too even
+    // though it has no sibling listener — that's fine: an
+    // unbound path means the guest's AF_VSOCK connects will fail
+    // with ECONNREFUSED inside the guest, which the W3 spike
+    // doesn't care about. The W4 PR adds the listener.
     for &port in &ctx.vsock_ports {
-        // libkrun's `krun_add_vsock_port` requires a host-side Unix
-        // socket path. The full backend wiring (which generates that
-        // path under ~/.mvm/vms/<name>/) lands alongside the W4 state
-        // tracker; the W1 + W3 exercises use a stub path scoped to
-        // the VM name so concurrent guests don't clash.
-        let socket = format!("/tmp/mvm-libkrun-{}-vsock-{port}.sock", ctx.name);
-        krun.add_vsock_port(port, Path::new(&socket))?;
+        let socket = ctx.vsock_socket_path(port);
+        krun.add_vsock_port(port, &socket)?;
     }
     if let Some(console_path) = &ctx.console_output_path {
         krun.set_console_output(Path::new(console_path))?;
@@ -439,6 +488,48 @@ mod tests {
         assert_eq!(ctx.vcpus, 2);
         assert_eq!(ctx.ram_mib, 512);
         assert_eq!(ctx.vsock_ports, vec![5252]);
+    }
+
+    /// Plan 57 W3.3: the per-VM `vsock_socket_dir` overrides the
+    /// `/tmp` fallback. Real consumers (W4 supervisor, Plan 72
+    /// builder-VM launcher) always supply a dir under
+    /// `~/.mvm/vms/<name>/` so cross-process clients can find it
+    /// without scanning `/tmp`.
+    #[test]
+    fn vsock_socket_path_falls_back_to_tmp_when_no_dir_set() {
+        let ctx = KrunContext::new("vm-1", "/k", "/r");
+        let path = ctx.vsock_socket_path(5252);
+        assert_eq!(
+            path,
+            std::path::PathBuf::from("/tmp/mvm-libkrun-vm-1-vsock-5252.sock")
+        );
+    }
+
+    #[test]
+    fn vsock_socket_path_uses_configured_dir_when_set() {
+        let ctx =
+            KrunContext::new("vm-1", "/k", "/r").with_vsock_socket_dir("/home/user/.mvm/vms/vm-1");
+        let path = ctx.vsock_socket_path(5252);
+        assert_eq!(
+            path,
+            std::path::PathBuf::from("/home/user/.mvm/vms/vm-1/vsock-5252.sock")
+        );
+    }
+
+    /// Multiple ports share one dir; libkrun proxies each
+    /// independently. The name → port pairing keeps cross-VM
+    /// concurrency on a single host from clashing.
+    #[test]
+    fn vsock_socket_path_distinguishes_ports() {
+        let ctx = KrunContext::new("vm-1", "/k", "/r")
+            .with_vsock_socket_dir("/d")
+            .add_vsock_port(5252)
+            .add_vsock_port(5253);
+        let a = ctx.vsock_socket_path(5252);
+        let b = ctx.vsock_socket_path(5253);
+        assert_ne!(a, b);
+        assert!(a.file_name().unwrap().to_string_lossy().contains("5252"));
+        assert!(b.file_name().unwrap().to_string_lossy().contains("5253"));
     }
 
     #[test]

--- a/specs/plans/57-libkrun-spike.md
+++ b/specs/plans/57-libkrun-spike.md
@@ -65,7 +65,7 @@ Goal: `mvmctl` + libkrun + `Hypervisor.framework` boot a guest without the macOS
 
 ### W3 — End-to-end boot validation (the actual spike, 2–3 days)
 
-> Status update 2026-05-13: **W3.1, W3.2, W3.4 (cmdline + console) shipped.** W3.3 (vsock health check) deferred to a follow-on PR — see "Findings" below for why.
+> Status update 2026-05-13: **W3.1, W3.2, W3.4 (cmdline + console) shipped in PR #154.** W3.3 vsock plumbing decision shipped in the follow-on PR; the host-side listener + full guest-agent ping still wait on W4's process-lifecycle work. See "Findings" + "W3.3 follow-up" below.
 
 Goal: prove a real Nix-built kernel + ext4 rootfs boots in libkrun on macOS Apple Silicon and the guest agent comes up on vsock.
 
@@ -105,6 +105,16 @@ What's **deferred to a follow-on PR (W3.3)**:
 - A vsock health-check ping against `mvm_guest::vsock::GUEST_AGENT_PORT` from the host. `krun_start_enter` consumes the calling process (calls `exit()` on success), so the ping has to come from a sibling process or fork. The W4 supervisor-thread / launchd lane resolves the process-lifecycle side of this naturally.
 
 Decision recorded: **the libkrun macOS Apple Silicon path is viable.** Plan 72 (builder-VM-via-libkrun) is unblocked on the boot side; the remaining wiring is state-tracking (W4) and CI (W5).
+
+#### W3.3 follow-up — vsock plumbing decision, 2026-05-13
+
+After reading the libkrun upstream README (Homebrew ships it as `/opt/homebrew/Cellar/libkrun/1.17.4/README.md`) and an empty-listener experiment on this host:
+
+1. **TSI (Transparent Socket Impersonation) is auto-enabled** when no virtio-net device is added. The README is explicit: "TSI for AF_INET and AF_INET6 is automatically enabled when no network interface is added to the VM." We never call `krun_add_net_*`, so TSI is on and the virtio-vsock device is created implicitly. The earlier "`add_vsock` vs `add_vsock_port` are mutually exclusive" finding was the symptom — `add_vsock` is documented as *adding a second independent virtio-vsock device*, which collides with the TSI-provided one. The right call for our use case is `add_vsock_port` alone; `add_vsock` is the wrong API for mvm and stays out of the `configure()` path.
+2. **libkrun does not create the host-side unix socket file.** Verified by running the smoke binary with `~/.mvm/vms/<name>/` set as the per-VM dir and inspecting the dir at +10s — empty. The host is responsible for binding a `UnixListener` at the path before `start_enter`; libkrun then proxies traffic from each guest-side `AF_VSOCK port` to a *client* connection at that listener. Apple Container's `start_vsock_proxy_listener` (`crates/mvm-providers/src/apple_container/macos.rs`) is the analogue; the W4 supervisor adopts the same pattern.
+3. **Per-VM socket dir is now configurable.** `KrunContext::with_vsock_socket_dir(...)` + the `vsock_socket_path(port) -> PathBuf` helper. Default fallback (used by the smoke binary) is `/tmp/mvm-libkrun-<name>-vsock-<port>.sock`; W4 + Plan 72 consumers always supply `~/.mvm/vms/<name>/` so cross-process clients (e.g. `mvmctl console`) can find the socket without scanning `/tmp`.
+
+Full guest-agent health-check ping is still W4-gated: the smoke binary becomes the guest, so it can't simultaneously be the host that connects to the unix listener. Once W4 lands a sibling supervisor process (or launchd unit), the same wiring + the existing `mvm_guest::vsock` framing closes the loop.
 
 ### W4 — State tracking decision (1–2 days)
 


### PR DESCRIPTION
## Summary

Codifies the vsock plumbing decision after the W3 boot smoke surfaced two ambiguities — `krun_add_vsock` vs `krun_add_vsock_port`, and where the host-side unix socket file actually comes from.

**Findings** (verified against libkrun 1.17.4 on macOS Apple Silicon):

1. **TSI auto-enables when no virtio-net device is added.** The libkrun README is explicit. We never call `krun_add_net_*`, so TSI is always on and the virtio-vsock device exists implicitly. `krun_add_vsock(0)` after `krun_add_vsock_port(...)` returns `-EEXIST` because it tries to add a *second* device on top of the TSI-provided one. The right call for mvm is `add_vsock_port` alone — `add_vsock` stays out of `configure()`.
2. **libkrun does NOT create the host-side unix socket file.** Verified by booting with `~/.mvm/vms/<name>/` as the per-VM dir and inspecting it at +10s — empty. The host is responsible for binding a `UnixListener` at the configured path before `start_enter`; libkrun then proxies guest-side `AF_VSOCK` port traffic to client connections at that listener. Apple Container's `start_vsock_proxy_listener` is the analogue; the W4 supervisor adopts the same pattern.

**Changes:**

- `KrunContext` gains `vsock_socket_dir: Option<String>` + a `vsock_socket_path(port) -> PathBuf` helper. Resolves to `<dir>/vsock-<port>.sock` when set; falls back to `/tmp/mvm-libkrun-<name>-vsock-<port>.sock` for the spike. Builder method `with_vsock_socket_dir(...)`.
- `configure()` calls `ctx.vsock_socket_path(port)` instead of the hard-coded `/tmp` format; the inline NOTE block becomes the authoritative comment on libkrun's vsock model (TSI auto-on, `add_vsock` is the wrong API for mvm, host owns the listener).
- `examples/libkrun-smoke.rs` switches to `~/.mvm/vms/mvm-libkrun-smoke/` as the per-VM dir. The smoke binary itself doesn't bind a sibling listener — the calling process becomes the guest — so guest-side AF_VSOCK connects still fail with ECONNREFUSED, which is expected for the spike. Plan 57 W4 adds the host listener.
- Three new `vsock_socket_path_*` unit tests cover the resolution paths.
- `specs/plans/57-libkrun-spike.md` grows a "W3.3 follow-up" subsection recording the decision so it doesn't get re-litigated.

Full guest-agent health-check ping is still W4-gated — the smoke binary can't simultaneously be the guest and the host that connects to the unix listener.

## Test plan

- [x] `cargo build --workspace` — green.
- [x] `cargo test -p mvm-libkrun --features libkrun-sys` — 11/11 pass, including `vsock_socket_path_falls_back_to_tmp_when_no_dir_set`, `vsock_socket_path_uses_configured_dir_when_set`, `vsock_socket_path_distinguishes_ports`.
- [x] `cargo clippy --workspace -- -D warnings` and `cargo clippy -p mvm-libkrun --features libkrun-sys --all-targets -- -D warnings` — both clean.
- [x] Manually re-ran the smoke binary against `~/.mvm/dev/current/` artifacts; kernel still boots to `EXT4-fs (vda): mounted filesystem … r/w with ordered data mode`. Per-VM dir stays empty during the run — confirms libkrun doesn't auto-create the socket file.

🤖 Generated with [Claude Code](https://claude.com/claude-code)