### PR TITLE
feat(libkrun): plan 57 W4.1 — one-process-per-VM supervisor binary

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4275,6 +4275,8 @@ dependencies = [
  "libc",
  "mvm-guest",
  "mvm-providers",
+ "serde",
+ "serde_json",
  "tracing",
 ]
 

--- a/crates/mvm-libkrun/Cargo.toml
+++ b/crates/mvm-libkrun/Cargo.toml
@@ -34,6 +34,23 @@ build = "build.rs"
 [dependencies]
 libc.workspace = true
 tracing = "0.1"
+# Plan 57 W4 supervisor binary (`src/bin/mvm-libkrun-supervisor.rs`)
+# needs JSON config parsing on stdin and pulls `ensure_signed()` from
+# mvm-providers (macOS codesigning gate). All optional and gated on
+# `libkrun-sys` so the default workspace build (CI fast lane, hosts
+# without libkrun.h) skips the heavier dep graph.
+#
+# We intentionally do NOT pull `mvm-guest` from regular deps: that
+# would close a cycle (mvm-core → mvm-libkrun → mvm-guest → mvm-core,
+# since mvm-core depends on mvm-libkrun for `Platform::has_libkrun`).
+# The supervisor receives the vsock port list via the JSON config —
+# the symbolic `GUEST_AGENT_PORT` constant is only needed by callers
+# composing the config, not by the supervisor consuming it. The
+# `libkrun-smoke` example keeps `mvm-guest` as a dev-dep because
+# dev-deps are excluded from cycle analysis.
+mvm-providers = { workspace = true, optional = true }
+serde = { workspace = true, optional = true }
+serde_json = { workspace = true, optional = true }
 
 [build-dependencies]
 # `bindgen` is required only when the `libkrun-sys` feature is on; we
@@ -46,13 +63,17 @@ bindgen = "0.72"
 default = []
 # Opt-in: generate FFI bindings and link `libkrun`. Off by default so
 # the workspace builds on hosts without libkrun installed (CI fast lane,
-# Linux contributors who don't run the Tier 2 backend).
-libkrun-sys = []
+# Linux contributors who don't run the Tier 2 backend). Enables the
+# supervisor binary and its mvm-guest/mvm-providers/serde dep chain.
+libkrun-sys = [
+    "dep:mvm-providers",
+    "dep:serde",
+    "dep:serde_json",
+]
 
 [dev-dependencies]
-# The plan 57 W3 smoke example pulls `GUEST_AGENT_PORT` so the smoke
-# binary and the production vsock plumbing stay in sync on which port
-# the guest agent expects.
+# The plan 57 W3 smoke example shares `GUEST_AGENT_PORT` with the
+# production vsock plumbing.
 mvm-guest.workspace = true
 # `ensure_signed()` is plan 57 W2's codesigning gate. macOS rejects
 # any process that calls `Hypervisor.framework` without
@@ -68,6 +89,16 @@ mvm-providers.workspace = true
 [[example]]
 name = "libkrun-smoke"
 path = "examples/libkrun-smoke.rs"
+required-features = ["libkrun-sys"]
+
+# Plan 57 W4 — long-running supervisor process. One process per
+# libkrun guest. Reads a JSON `SupervisorConfig` on stdin, binds host
+# vsock listeners, writes its PID under ~/.mvm/vms/<name>/, then
+# `start_enter`s the guest. The W4.2 PR wires
+# `LibkrunBackend::start()` to spawn this binary.
+[[bin]]
+name = "mvm-libkrun-supervisor"
+path = "src/bin/mvm-libkrun-supervisor.rs"
 required-features = ["libkrun-sys"]
 
 [lints]

--- a/crates/mvm-libkrun/src/bin/mvm-libkrun-supervisor.rs
+++ b/crates/mvm-libkrun/src/bin/mvm-libkrun-supervisor.rs
@@ -1,0 +1,80 @@
+//! Plan 57 W4 — one-libkrun-guest-per-process supervisor.
+//!
+//! Reads a [`SupervisorConfig`] JSON document on stdin, ad-hoc
+//! codesigns itself for `Hypervisor.framework` (macOS W2 gate),
+//! creates the per-VM state directory, writes its own PID, then
+//! calls [`run_supervisor`] which blocks in `krun_start_enter`
+//! until the guest powers off.
+//!
+//! ## Why one process per VM
+//!
+//! `krun_start_enter` calls `exit()` on the calling process when
+//! the guest exits cleanly. An in-process registry (plan 57 W4
+//! Option A) would tear down every other libkrun guest the parent
+//! `mvmctl` is supervising. One process per VM scopes the `exit()`
+//! to a single supervisor; the parent `mvmctl` returns immediately
+//! after spawning and survives a guest's shutdown.
+//!
+//! ## Usage (manual)
+//!
+//! ```sh
+//! cat <<EOF | mvm-libkrun-supervisor
+//! {
+//!   "krun": {
+//!     "name": "mvm-libkrun-smoke",
+//!     "kernel_path": "/Users/me/.mvm/dev/current/vmlinux",
+//!     "rootfs_path": "/Users/me/.mvm/dev/current/rootfs.ext4",
+//!     "vcpus": 1,
+//!     "ram_mib": 512,
+//!     "kernel_cmdline": "console=hvc0 root=/dev/vda rw init=/init",
+//!     "vsock_ports": [5252],
+//!     "extra_disks": [],
+//!     "console_output_path": "/tmp/mvm-libkrun-smoke.log",
+//!     "vsock_socket_dir": "/Users/me/.mvm/vms/mvm-libkrun-smoke"
+//!   },
+//!   "vm_state_dir": "/Users/me/.mvm/vms/mvm-libkrun-smoke",
+//!   "pid_file_name": null
+//! }
+//! EOF
+//! ```
+//!
+//! Production callers (`LibkrunBackend::start()` — plan 57 W4.2)
+//! produce the JSON programmatically and pipe it via
+//! `std::process::Command::stdin`.
+
+use std::io::Read;
+use std::process::ExitCode;
+
+use mvm_libkrun::{SupervisorConfig, run_supervisor};
+
+fn main() -> ExitCode {
+    // macOS Hypervisor.framework rejects any process without
+    // `com.apple.security.hypervisor`. Plan 57 W2's ad-hoc signer
+    // self-signs + re-spawns the binary on first run; subsequent
+    // invocations are silent (`MVM_SIGNED=1`). Without this,
+    // `krun_start_enter` fails at VM creation with rc -22.
+    mvm_providers::apple_container::ensure_signed();
+
+    let mut json = String::new();
+    if let Err(e) = std::io::stdin().read_to_string(&mut json) {
+        eprintln!("error: read SupervisorConfig JSON from stdin: {e}");
+        return ExitCode::from(2);
+    }
+
+    let cfg: SupervisorConfig = match serde_json::from_str(&json) {
+        Ok(c) => c,
+        Err(e) => {
+            eprintln!("error: parse SupervisorConfig JSON: {e}");
+            return ExitCode::from(2);
+        }
+    };
+
+    // run_supervisor returns Result<Infallible, _>; on success
+    // libkrun has already called exit() on this process.
+    match run_supervisor(&cfg) {
+        Err(e) => {
+            eprintln!("supervisor failed: {e}");
+            ExitCode::from(1)
+        }
+    }
+}

--- a/crates/mvm-libkrun/src/lib.rs
+++ b/crates/mvm-libkrun/src/lib.rs
@@ -52,6 +52,15 @@ pub enum Error {
     /// A path or string argument contained an interior NUL byte or
     /// was not representable as UTF-8 / a C string.
     InvalidCString,
+    /// Filesystem I/O failure while setting up the supervisor's per-VM
+    /// state directory or PID file. Carries a free-form context
+    /// string rather than the raw `io::Error` so the `PartialEq`/`Eq`
+    /// derives on `Error` keep working.
+    Io {
+        /// Operation + path + underlying message, formatted by the
+        /// caller. E.g. `create_dir_all /Users/x/.mvm/vms/foo: permission denied`.
+        context: String,
+    },
 }
 
 impl std::fmt::Display for Error {
@@ -70,6 +79,7 @@ impl std::fmt::Display for Error {
                 f,
                 "argument contained an interior NUL byte or non-UTF-8 path"
             ),
+            Self::Io { context } => write!(f, "supervisor I/O error: {context}"),
         }
     }
 }
@@ -150,6 +160,7 @@ pub fn install_paths() -> Vec<&'static str> {
 /// order disks are added); each `KrunDisk` becomes `/dev/vdb`,
 /// `/dev/vdc`, … in the order they appear in [`KrunContext::extra_disks`].
 #[derive(Debug, Clone)]
+#[cfg_attr(feature = "libkrun-sys", derive(serde::Serialize, serde::Deserialize))]
 pub struct KrunDisk {
     /// Symbolic identifier passed to `krun_add_disk` (`block_id`).
     /// Not user-visible inside the guest; libkrun uses it for
@@ -169,6 +180,7 @@ pub struct KrunDisk {
 /// that consume each field live in [`sys`] under the `libkrun-sys`
 /// feature.
 #[derive(Debug, Clone)]
+#[cfg_attr(feature = "libkrun-sys", derive(serde::Serialize, serde::Deserialize))]
 pub struct KrunContext {
     pub name: String,
     pub kernel_path: String,
@@ -348,8 +360,8 @@ fn configure(ctx: &KrunContext) -> Result<sys::Context, Error> {
     for disk in &ctx.extra_disks {
         krun.add_disk(&disk.id, Path::new(&disk.path), disk.read_only)?;
     }
-    // libkrun's vsock model — what plan 57 W3.3 settled on after the
-    // first end-to-end smoke (2026-05-13):
+    // libkrun's vsock model — refined by plan 57 W4 after a closer
+    // read of `libkrun.h`:
     //
     // - TSI (Transparent Socket Impersonation) is auto-enabled when
     //   no virtio-net device is added. The libkrun README is
@@ -358,30 +370,28 @@ fn configure(ctx: &KrunContext) -> Result<sys::Context, Error> {
     //   never call `krun_add_net_*`, so TSI is always on, and the
     //   virtio-vsock device exists implicitly.
     //
-    // - `krun_add_vsock` (no `_port`) is for *adding a second
-    //   independent virtio-vsock device*. Because TSI already
-    //   provides one, calling it returns `-EEXIST` (verified on
-    //   libkrun 1.17.4). Do not call it from the W3 path.
+    // - `krun_add_vsock` is for *adding a second independent*
+    //   virtio-vsock device, and requires `krun_disable_implicit_vsock`
+    //   first. Because TSI already provides one, naively calling it
+    //   returns `-EEXIST` (verified on libkrun 1.17.4). Do not use
+    //   from mvm's path.
     //
-    // - `krun_add_vsock_port(ctx, port, host_path)` pairs a
-    //   guest-side vsock port with a host unix socket. libkrun
-    //   does *not* create the socket file — that's the host's
-    //   responsibility. The owning host process binds a
-    //   `UnixListener` at `host_path` before calling `start_enter`;
-    //   when the guest opens `AF_VSOCK` to `port`, libkrun proxies
-    //   it to a client connection at the listener.
-    //
-    // The W4 supervisor / Plan 72 builder-VM launcher own the
-    // listener; this configure() step just registers the path so
-    // libkrun knows where to send traffic. The smoke binary
-    // (`examples/libkrun-smoke.rs`) registers the path too even
-    // though it has no sibling listener — that's fine: an
-    // unbound path means the guest's AF_VSOCK connects will fail
-    // with ECONNREFUSED inside the guest, which the W3 spike
-    // doesn't care about. The W4 PR adds the listener.
+    // - **Direction matters.** `krun_add_vsock_port` (no `_2`)
+    //   documents "port that the guest will connect to for IPC" —
+    //   guest is the client, host is the server, host binds the
+    //   listener. `krun_add_vsock_port2(..., listen=true)` flips
+    //   it: "guest expects connections to be initiated from host
+    //   side" — guest is the server, libkrun creates the unix
+    //   socket file as a listener, host processes connect as
+    //   clients. mvm's guest agent always *listens* on
+    //   `GUEST_AGENT_PORT`, so `listen=true` is the right mode for
+    //   every vsock port we register here. The W3.3 PR used
+    //   `add_vsock_port` (no `_2`); that was the wrong direction
+    //   but happened to boot because nothing in the guest actually
+    //   tried to use vsock. W4 corrects it.
     for &port in &ctx.vsock_ports {
         let socket = ctx.vsock_socket_path(port);
-        krun.add_vsock_port(port, &socket)?;
+        krun.add_vsock_port2(port, &socket, /* listen = */ true)?;
     }
     if let Some(console_path) = &ctx.console_output_path {
         krun.set_console_output(Path::new(console_path))?;
@@ -437,6 +447,76 @@ pub fn start_enter(ctx: &KrunContext) -> Result<std::convert::Infallible, Error>
     {
         let krun = configure(ctx)?;
         krun.start_enter()
+    }
+}
+
+/// Configuration consumed by [`run_supervisor`] — the JSON shape that
+/// the `mvm-libkrun-supervisor` binary reads from stdin and that
+/// `LibkrunBackend::start()` produces. Holds the [`KrunContext`] plus
+/// supervisor-process bookkeeping fields that don't belong on the
+/// pure-FFI config type.
+#[cfg(feature = "libkrun-sys")]
+#[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
+pub struct SupervisorConfig {
+    /// The guest configuration to hand to libkrun.
+    pub krun: KrunContext,
+    /// Directory under which the supervisor writes its PID file and
+    /// (via `KrunContext::vsock_socket_dir`) the per-port vsock
+    /// listener sockets. Typically `~/.mvm/vms/<name>/`. Created if
+    /// absent.
+    pub vm_state_dir: String,
+    /// File name inside `vm_state_dir` to receive the supervisor's
+    /// PID. Defaults to `"libkrun.pid"` when `None`. Plan 72's
+    /// builder VM uses a different name (`builder.pid`) so the user
+    /// dev VM and the builder can coexist in the same directory tree.
+    pub pid_file_name: Option<String>,
+}
+
+#[cfg(feature = "libkrun-sys")]
+impl SupervisorConfig {
+    fn pid_file(&self) -> std::path::PathBuf {
+        std::path::PathBuf::from(&self.vm_state_dir)
+            .join(self.pid_file_name.as_deref().unwrap_or("libkrun.pid"))
+    }
+}
+
+/// Run a libkrun guest under a long-lived supervisor process.
+///
+/// **Plan 57 W4 entry point.** Each call owns exactly one libkrun
+/// guest for the lifetime of the calling process. Steps:
+///
+/// 1. Create `vm_state_dir` if absent.
+/// 2. Write the calling process's PID to `<vm_state_dir>/<pid_file_name>`.
+/// 3. Call [`start_enter`], which configures libkrun (including the
+///    `add_vsock_port2(listen=true)` host-listener registration so
+///    libkrun creates the unix socket file as a server) and then
+///    blocks the calling thread in `krun_start_enter`.
+///
+/// `krun_start_enter` calls `exit()` on the supervisor when the
+/// guest powers off cleanly. That's the point of running one process
+/// per VM — only this supervisor terminates; the parent `mvmctl` and
+/// any sibling supervisors are unaffected.
+///
+/// Without the `libkrun-sys` feature, returns [`Error::NotYetWired`].
+#[cfg(feature = "libkrun-sys")]
+pub fn run_supervisor(cfg: &SupervisorConfig) -> Result<std::convert::Infallible, Error> {
+    std::fs::create_dir_all(&cfg.vm_state_dir).map_err(|e| Error::Io {
+        context: format!("create_dir_all {}: {e}", cfg.vm_state_dir),
+    })?;
+    let pid_path = cfg.pid_file();
+    let pid = std::process::id().to_string();
+    std::fs::write(&pid_path, &pid).map_err(|e| Error::Io {
+        context: format!("write pid file {}: {e}", pid_path.display()),
+    })?;
+    start_enter(&cfg.krun)
+}
+
+/// Non-FFI-feature stub so callers can reference the function name
+/// regardless of build configuration. Returns [`Error::NotYetWired`].
+#[cfg(not(feature = "libkrun-sys"))]
+pub fn run_supervisor_unavailable() -> Error {
+    Error::NotYetWired {
+        tracking: "specs/plans/57-libkrun-spike.md W4 — rebuild with --features libkrun-sys",
     }
 }
 

--- a/crates/mvm-libkrun/src/sys.rs
+++ b/crates/mvm-libkrun/src/sys.rs
@@ -146,6 +146,21 @@ impl Context {
         check(unsafe { bindings::krun_add_vsock_port(self.ctx_id, port, path.as_ptr()) })
     }
 
+    /// Like [`Self::add_vsock_port`], but explicitly states which side
+    /// listens. With `listen = true` ("guest expects connections to
+    /// be initiated from host side"), libkrun creates a unix socket
+    /// **listener** at `host_path`; sibling host processes connect to
+    /// it as clients and libkrun forwards the connection to the
+    /// guest's `AF_VSOCK` server. This is the right mode for mvm's
+    /// guest agent, which always listens on `GUEST_AGENT_PORT`. With
+    /// `listen = false`, libkrun does not create the file — the host
+    /// is expected to bind a listener at `host_path` and libkrun
+    /// proxies guest-initiated connects to it.
+    pub fn add_vsock_port2(&self, port: u32, host_path: &Path, listen: bool) -> Result<(), Error> {
+        let path = cstring(host_path)?;
+        check(unsafe { bindings::krun_add_vsock_port2(self.ctx_id, port, path.as_ptr(), listen) })
+    }
+
     pub fn add_virtiofs(&self, tag: &str, host_path: &Path) -> Result<(), Error> {
         let tag = CString::new(tag).map_err(|_| Error::InvalidCString)?;
         let path = cstring(host_path)?;

--- a/specs/plans/57-libkrun-spike.md
+++ b/specs/plans/57-libkrun-spike.md
@@ -130,10 +130,13 @@ libkrun is a library, not a daemon. `krun_start_enter` blocks the calling thread
   - Pro: matches Firecracker / Apple Container UX (`mvmctl start` returns immediately).
   - Con: more code, more failure modes.
 
-**Recommendation**: ship Option A first (covers the dev workflow), file a follow-up issue for Option B once the spike validates the rest of the stack. Most users in Sprint 48 are dev-mode users; the persistent-VM use case is rarer for libkrun specifically.
+**Recommendation (revised 2026-05-13 after the W3 spike): ship Option B.** Option A's "background thread holds the libkrun handle" pattern collapses on close: `krun_start_enter` calls `exit()` on the *whole process* when the guest powers off cleanly (libkrun documents this; reproduced in the W3 smoke as the `start_enter` return type becoming `Result<Infallible, _>`). That means stopping any one VM in a multi-VM registry would tear down the mvmctl process and every other libkrun guest it was supervising. Option A *would* work for the single-VM dev shell, but the moment the design grows to plan 72's builder VM + a user-facing `mvmctl up --hypervisor libkrun`, Option A's blast radius is unacceptable. Option B (subprocess per VM) sidesteps the `exit()` problem entirely — each supervisor process owns exactly one libkrun guest, and the parent mvmctl returns immediately after spawning.
 
-- **W4.1** Implement Option A. Files: `crates/mvm/src/vm/libkrun.rs` gains a `LIBKRUN_VMS: OnceLock<Mutex<HashMap<VmId, KrunHandle>>>` static. `start()` spawns the supervisor thread; `stop()` signals it to exit; `list()` returns keys; `status()` checks presence.
-- **W4.2** `stop_all()` becomes a real implementation (today it's an empty `Ok(())` placeholder).
+- **W4.1** Add a `mvm-libkrun-supervisor` binary in `crates/mvm-libkrun/src/bin/`. It reads a `SupervisorConfig` JSON document from stdin, runs `ensure_signed()` (W2 codesigning gate), creates the per-VM directory under `~/.mvm/vms/<name>/`, writes its own PID to `~/.mvm/vms/<name>/libkrun.pid`, registers each vsock port via `krun_add_vsock_port2(listen=true)` (libkrun then creates the unix socket file as a listener when the guest binds to the matching `AF_VSOCK` port), then calls `mvm_libkrun::start_enter`. Process lifetime equals VM lifetime: `exit()` from libkrun terminates only this supervisor, not its parent.
+
+  *Finding from the W4 spike run (2026-05-13):* the supervisor writes its PID and reaches `start_enter` cleanly. With the dev-VM artifacts the guest boots through the kernel but the rootfs's init crashes at a BusyBox `setpriv: unrecognized option: reuid=990`, so the guest never gets to `AF_VSOCK::bind(GUEST_AGENT_PORT)`. libkrun creates the unix socket file lazily on first guest bind, so the per-VM dir stays empty until a working guest agent runs. The supervisor infrastructure is correct; full vsock proof needs the dev-VM init fix (orthogonal — tracked under the dev-VM owners) or a minimal test rootfs that just opens a vsock listener.
+- **W4.2** Wire `LibkrunBackend::start()` to spawn the supervisor via `std::process::Command::new(supervisor_path())`, pipe the config JSON to stdin, and return. `LibkrunBackend::stop()` reads the PID file and signals (SIGTERM, optionally promoted via shutdown_eventfd). `list()` walks `~/.mvm/vms/*/libkrun.pid`. `stop_all()` iterates the same walk.
+- **W4.3** Add an integration test that spawns the supervisor on the W3 dev artifacts, connects a `UnixStream` to the bound vsock listener, and waits for libkrun to proxy a single byte. This is the missing W3.3 health-check that the spike couldn't run in-process.
 
 ### W5 — CI lanes (0.5–1 day)
 
@@ -162,7 +165,8 @@ These each merit their own one-day sub-sprint *after* plan 57 ships.
 | `crates/mvm-libkrun/src/sys.rs` | W1.3 | new — safe wrapper over generated bindings |
 | `crates/mvm-libkrun/src/lib.rs` | W1.4 | replace `NotYetWired` returns with real calls |
 | `crates/mvm-apple-container/macos/Entitlements.plist` (or equivalent) | W2.1 | add `com.apple.security.hypervisor` if not already present |
-| `crates/mvm/src/vm/libkrun.rs` | W4.1 | wire `LIBKRUN_VMS` registry, real lifecycle |
+| `crates/mvm-libkrun/src/bin/mvm-libkrun-supervisor.rs` | W4.1 | new — one process per libkrun guest, owns the host-side vsock listeners + PID file |
+| `crates/mvm-backend/src/libkrun.rs` | W4.2 | wire `LibkrunBackend::start/stop/list` to spawn / signal / walk the supervisor processes |
 | `examples/libkrun-smoke.rs` | W5.1 | new — minimal end-to-end test binary |
 | `.github/workflows/ci.yml` | W5.1 | new `libkrun-macos-arm64` job |
 | `public/.../guides/troubleshooting.md` | W2.3 | first-run codesigning prompt FAQ |


### PR DESCRIPTION
## Summary

Adds `mvm-libkrun-supervisor`, the long-running subprocess that owns exactly one libkrun guest for its lifetime. Reverses plan 57 W4's recommendation from Option A (in-process registry) to **Option B (subprocess per VM)** — the only design that survives libkrun's `krun_start_enter → exit()` contract. The in-process registry would tear down sibling guests every time one shut down.

- **New binary**: `crates/mvm-libkrun/src/bin/mvm-libkrun-supervisor.rs`. Reads a `SupervisorConfig` JSON document on stdin, calls `ensure_signed()` (W2 codesigning gate), then `run_supervisor` which creates `~/.mvm/vms/<name>/`, writes the supervisor's PID, and blocks in `krun_start_enter`. Gated via `[[bin]] required-features = ["libkrun-sys"]`.
- **New library surface**: `SupervisorConfig` (feature-gated), `run_supervisor()` (feature-gated), `Error::Io { context }` variant. `KrunContext` + `KrunDisk` get serde derives via `cfg_attr` so default builds don't pull serde.
- **Vsock direction fix**: switch `configure()` from `add_vsock_port` to `add_vsock_port2(listen=true)`. `krun_add_vsock_port` (no `_2`) documents "port that the **guest** will connect to" — guest-as-client, host-as-server. mvm's guest agent always *listens*, so the right call is `add_vsock_port2(listen=true)` where libkrun creates the unix socket file as a listener that host clients dial. The W3.3 boot still worked because nothing in the (broken) dev-VM init actually opened AF_VSOCK.
- **Dep wiring**: `mvm-providers`, `serde`, `serde_json` added as **optional** deps gated on `libkrun-sys`. `mvm-guest` is intentionally *not* in regular deps — that would close a cycle (`mvm-core → mvm-libkrun → mvm-guest → mvm-core`). The supervisor receives the vsock port list via JSON; the symbolic `GUEST_AGENT_PORT` constant is for callers composing the config.
- **Plan update**: `specs/plans/57-libkrun-spike.md` W4 rewritten with the Option B preference + the `exit()` blast-radius rationale, and W4.1/W4.2/W4.3 re-cast around the supervisor. Files-table updated. A "Finding from the W4 spike run" paragraph records what works today (PID write + kernel boot) and what stays gated on a working guest init (vsock socket file creation, full health-check ping).

## Manual verification on this Mac (macOS Apple Silicon, libkrun 1.17.4)

```
$ cat /tmp/cfg.json | ./target/debug/mvm-libkrun-supervisor &
$ ls ~/.mvm/vms/mvm-libkrun-smoke/
  libkrun.pid                                    # ← supervisor wrote PID
$ grep 'EXT4-fs\|Run /init' /tmp/console.log
  EXT4-fs (vda): mounted filesystem ... r/w
  Run /init as init process                      # ← kernel up, init runs
```

The vsock socket file does not appear during this run because the dev-VM rootfs's init crashes at a BusyBox `setpriv --reuid=990` before any guest process can bind to `AF_VSOCK port 5252`. libkrun creates the listener lazily on first guest bind. The supervisor infrastructure is correct; full vsock proof needs the dev-VM init fix (orthogonal — tracked under the dev-VM owners) or a minimal test rootfs.

## Test plan

- [x] `cargo build --workspace` — green.
- [x] `cargo test -p mvm-libkrun --features libkrun-sys` — 11/11 pass (no W1/W3/W3.3 regressions).
- [x] `cargo clippy --workspace -- -D warnings` and `cargo clippy -p mvm-libkrun --features libkrun-sys --all-targets -- -D warnings` — both clean.
- [x] Manual: piped JSON config to the supervisor, observed PID write + kernel boot.

## Out of scope (filed as W4.2 / W4.3 / W5)

- **W4.2** — `LibkrunBackend::start()` spawns the supervisor via `std::process::Command::new(supervisor_path()).stdin(json).spawn()`. Separate PR.
- **W4.3** — integration test against a working guest, validating the host-client → libkrun → guest AF_VSOCK round-trip.
- **W5** — `libkrun-macos-arm64` CI lane.

🤖 Generated with [Claude Code](https://claude.com/claude-code)