### PR TITLE
feat(ci): plan 57 W5 — libkrun-macos paths-gated lane

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -295,3 +295,92 @@ jobs:
 
       - name: Run tests
         run: cargo test
+
+  # ── Lane: libkrun (macOS Apple Silicon, paths-gated) ──
+  # macos-latest is ~10x the per-minute cost of ubuntu-latest (ADR-038),
+  # so this lane is path-gated: it only spins up the heavy steps when a
+  # PR touches libkrun code or its direct consumers, or on pushes to
+  # main where the cost is worth catching post-merge drift.
+  #
+  # What it validates that the Linux lanes don't:
+  #   - bindgen + libclang against the Homebrew libkrun.h is wired
+  #     correctly (the `libkrun-sys` feature compiles + links).
+  #   - the `mvm-libkrun-supervisor` binary builds.
+  #   - the sys::Context::* FFI round-trips against the real
+  #     libkrun.dylib (8 wrapper unit tests in mvm-libkrun).
+  #   - LibkrunBackend's spawn / PID-file / signal logic compiles
+  #     and its non-FFI unit tests pass.
+  #
+  # End-to-end VM boot (plan 57 W4.3) is out of scope here - GitHub
+  # macOS runners don't expose Hypervisor.framework to user-mode
+  # processes, so `krun_start_enter` can't actually create a guest.
+  # The lane catches everything before that boundary.
+  libkrun-macos:
+    name: libkrun (macOS Apple Silicon)
+    runs-on: macos-latest
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Detect libkrun-touching paths
+        id: filter
+        uses: dorny/paths-filter@v3
+        with:
+          filters: |
+            libkrun:
+              - 'crates/mvm-libkrun/**'
+              - 'crates/mvm-backend/src/libkrun.rs'
+              - 'crates/mvm-backend/Cargo.toml'
+              - 'crates/mvm-providers/src/apple_container/**'
+              - 'specs/plans/57-libkrun-spike.md'
+              - '.github/workflows/ci.yml'
+
+      - name: Install Rust toolchain
+        if: steps.filter.outputs.libkrun == 'true' || github.ref == 'refs/heads/main'
+        uses: dtolnay/rust-toolchain@nightly
+        with:
+          components: clippy
+
+      - name: Install libkrun
+        if: steps.filter.outputs.libkrun == 'true' || github.ref == 'refs/heads/main'
+        # `libkrun` ships from Sergio Lopez's `slp/krun` Homebrew tap
+        # (not core homebrew). The bottle puts `libkrun.h` +
+        # `libkrun.dylib` under `/opt/homebrew/{include,lib}` on Apple
+        # Silicon - exactly the layout `crates/mvm-libkrun/build.rs`
+        # probes for.
+        run: |
+          brew tap slp/krun
+          brew install libkrun
+
+      - name: Cache cargo
+        if: steps.filter.outputs.libkrun == 'true' || github.ref == 'refs/heads/main'
+        uses: actions/cache@v5
+        with:
+          path: |
+            ~/.cargo/registry
+            ~/.cargo/git
+            target
+          key: ${{ runner.os }}-cargo-libkrun-${{ hashFiles('**/Cargo.lock') }}
+          restore-keys: ${{ runner.os }}-cargo-libkrun-
+
+      - name: Default-feature workspace build (no libkrun-sys)
+        if: steps.filter.outputs.libkrun == 'true' || github.ref == 'refs/heads/main'
+        # Sanity: the fallback path (no libkrun-sys) keeps compiling.
+        # Mirrors how every other workspace consumer that touches
+        # mvm-libkrun builds.
+        run: cargo build -p mvm-libkrun -p mvm-backend
+
+      - name: Build mvm-libkrun with libkrun-sys (lib + bin + examples)
+        if: steps.filter.outputs.libkrun == 'true' || github.ref == 'refs/heads/main'
+        run: cargo build -p mvm-libkrun --features libkrun-sys --all-targets
+
+      - name: Test mvm-libkrun with libkrun-sys
+        if: steps.filter.outputs.libkrun == 'true' || github.ref == 'refs/heads/main'
+        run: cargo test -p mvm-libkrun --features libkrun-sys
+
+      - name: Test mvm-backend (libkrun module)
+        if: steps.filter.outputs.libkrun == 'true' || github.ref == 'refs/heads/main'
+        run: cargo test -p mvm-backend libkrun
+
+      - name: Clippy mvm-libkrun --features libkrun-sys --all-targets
+        if: steps.filter.outputs.libkrun == 'true' || github.ref == 'refs/heads/main'
+        run: cargo clippy -p mvm-libkrun --features libkrun-sys --all-targets -- -D warnings

--- a/specs/plans/57-libkrun-spike.md
+++ b/specs/plans/57-libkrun-spike.md
@@ -145,6 +145,28 @@ Goal: regression coverage on every PR.
 - **W5.1** Extend `.github/workflows/ci.yml` with a `libkrun-macos-arm64` job that runs on `macos-latest` (which is Apple Silicon as of late 2025), installs libkrun via Homebrew, runs `cargo test -p mvm-libkrun -p mvm --test libkrun_smoke`. The smoke test boots `examples/minimal` and asserts the guest agent responds.
 - **W5.2** Once W3 lands, **the smoke test is the gate** — it'll catch regressions in libkrun's API, the Nix kernel cmdline, our wrapper code, and the codesigning path simultaneously.
 
+#### W5 progress (2026-05-13)
+
+The `libkrun-macos` lane shipped with a `dorny/paths-filter@v3` gate so the macOS runner (~10× per-minute cost vs ubuntu-latest, per ADR-038) only spins up the heavy steps when a PR touches:
+
+- `crates/mvm-libkrun/**`
+- `crates/mvm-backend/src/libkrun.rs`
+- `crates/mvm-backend/Cargo.toml`
+- `crates/mvm-providers/src/apple_container/**` (W2 codesigning gate)
+- `specs/plans/57-libkrun-spike.md`
+- `.github/workflows/ci.yml`
+
+Or on any push to `main` regardless of path, so post-merge drift is still surfaced.
+
+What the lane validates that the Linux lanes cannot:
+
+1. `bindgen` + `libclang` consume the Homebrew `libkrun.h` cleanly — the `libkrun-sys` feature builds and links against `libkrun.dylib`.
+2. The `mvm-libkrun-supervisor` binary compiles (`required-features = ["libkrun-sys"]`).
+3. `mvm_libkrun::sys::Context::*` round-trips against the real `libkrun.dylib` — the 8 unit tests in `mvm-libkrun` covering `create_ctx`, `set_log_level`, `set_vm_config`.
+4. `LibkrunBackend`'s spawn / PID-file / signal logic in `mvm-backend` builds + its 12 non-FFI tests pass (path resolver branches, status / list with no VMs, etc.).
+
+**Out of scope for W5** (folded into W4.3 instead): end-to-end VM boot. GitHub macOS runners don't expose `Hypervisor.framework` to user-mode processes, so `krun_start_enter` can't actually create a guest there. The lane catches everything *before* that boundary; full boot validation needs a self-hosted runner or a working minimal-rootfs harness, which is W4.3's job.
+
 ### W6 — Cross-platform expansion (1 sprint follow-up — out of scope here)
 
 Out of scope for plan 57 itself. Tracked as W6 so the path is named:


### PR DESCRIPTION
## Summary

Locks in regression coverage for everything plan 57 W1–W4.2 shipped. Adds a `libkrun-macos` lane on `macos-latest` (Apple Silicon) that runs only when a PR touches libkrun code (or on every push to `main`).

**What it validates that the existing Linux lanes can't:**

1. `bindgen` + `libclang` consume the Homebrew `libkrun.h` cleanly — the `libkrun-sys` feature builds and links against `libkrun.dylib`.
2. The `mvm-libkrun-supervisor` binary compiles (`required-features = ["libkrun-sys"]`).
3. `mvm_libkrun::sys::Context::*` FFI round-trips against the real `libkrun.dylib` — the 8 wrapper unit tests in mvm-libkrun.
4. `LibkrunBackend`'s spawn / PID-file / signal logic in mvm-backend builds + its 12 non-FFI tests pass.

**Cost gating** via `dorny/paths-filter@v3` keeps the macOS runner (~10× per-minute cost vs ubuntu-latest, per ADR-038) out of every unrelated PR. The filter matches:

- `crates/mvm-libkrun/**`
- `crates/mvm-backend/src/libkrun.rs`
- `crates/mvm-backend/Cargo.toml`
- `crates/mvm-providers/src/apple_container/**` (W2 codesigning gate)
- `specs/plans/57-libkrun-spike.md`
- `.github/workflows/ci.yml`

Pushes to `main` always run regardless of path so post-merge drift is still surfaced.

Each step that needs the macOS runner is itself gated on the same condition — when the filter says "not libkrun", the runner spins up, the filter step runs, and every subsequent step is a no-op. That's the standard `dorny/paths-filter` pattern; it costs a few seconds of runner time per skip but it's cheap relative to the 1–2 minutes a full lane run would take.

**Out of scope** (folded into W4.3 instead): end-to-end VM boot. GitHub macOS runners don't expose `Hypervisor.framework` to user-mode processes, so `krun_start_enter` can't actually create a guest there. The lane catches everything *before* that boundary; full boot validation needs a self-hosted runner or a working minimal-rootfs harness.

## Test plan

- [x] `python3 -c "yaml.safe_load(open('.github/workflows/ci.yml'))"` — YAML parses.
- [x] Touches `.github/workflows/ci.yml`, so the new lane gates itself on this very PR. The CI run will show whether the lane fires correctly on a libkrun-touching diff.
- [x] Plan 57 W5 section updated inline with implementation notes (gating rules, what's validated, what's out of scope).

🤖 Generated with [Claude Code](https://claude.com/claude-code)