### PR TITLE
feat(builder-vm): plan 72 W1–W5 — libkrun-backed builder scaffolding

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -245,6 +245,60 @@ jobs:
             staging/builder-image-${{ matrix.arch }}-checksums-sha256.txt
             staging/builder-image-${{ matrix.arch }}.manifest.json
 
+  # Plan 72 W2 / ADR-046: the Layer-1 "builder VM" image — the
+  # microVM that runs `nix build` against the user-facing Layer-2
+  # flakes (dev shell, user --flake, etc.). Distinct from the
+  # existing `builder-image` job above (which is the sealed/verity
+  # variant of the Layer-2 dev image consumed by mvmd). Built on
+  # the same matrix; uploads vmlinux + rootfs.ext4 + cmdline +
+  # manifest.json. `download_builder_vm_image` (plan 72 W5)
+  # consumes these.
+  builder-vm-image:
+    strategy:
+      matrix:
+        include:
+          - arch: aarch64
+            runner: ubuntu-24.04-arm
+          - arch: x86_64
+            runner: ubuntu-latest
+    runs-on: ${{ matrix.runner }}
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Install Nix
+        uses: DeterminateSystems/nix-installer-action@main
+
+      - name: Build builder VM image
+        env:
+          ARCH: ${{ matrix.arch }}
+        run: |
+          SYSTEM="${ARCH}-linux"
+          nix build "./nix/images/builder-vm#packages.${SYSTEM}.default" \
+            --no-link --print-out-paths > /tmp/builder-vm-store-path.txt
+          STORE_PATH=$(head -1 /tmp/builder-vm-store-path.txt)
+          mkdir -p staging
+          cp "$STORE_PATH/vmlinux"       "staging/builder-vm-vmlinux-${ARCH}"
+          cp "$STORE_PATH/rootfs.ext4"   "staging/builder-vm-rootfs-${ARCH}.ext4"
+          cp "$STORE_PATH/cmdline"       "staging/builder-vm-cmdline-${ARCH}"
+          cp "$STORE_PATH/manifest.json" "staging/builder-vm-${ARCH}.manifest.json"
+          cd staging
+          sha256sum "builder-vm-vmlinux-${ARCH}" \
+                    "builder-vm-rootfs-${ARCH}.ext4" \
+                    "builder-vm-cmdline-${ARCH}" \
+                    "builder-vm-${ARCH}.manifest.json" \
+            > "builder-vm-${ARCH}-checksums-sha256.txt"
+
+      - name: Upload builder VM image artifacts
+        uses: actions/upload-artifact@v7
+        with:
+          name: builder-vm-image-${{ matrix.arch }}
+          path: |
+            staging/builder-vm-vmlinux-${{ matrix.arch }}
+            staging/builder-vm-rootfs-${{ matrix.arch }}.ext4
+            staging/builder-vm-cmdline-${{ matrix.arch }}
+            staging/builder-vm-${{ matrix.arch }}.manifest.json
+            staging/builder-vm-${{ matrix.arch }}-checksums-sha256.txt
+
   default-microvm:
     # Build the bundled default microVM image used by `mvmctl exec` /
     # `mvmctl up` when no --flake or --template was given. Mirrors the
@@ -288,7 +342,7 @@ jobs:
             staging/default-microvm-${{ matrix.arch }}-checksums-sha256.txt
 
   release:
-    needs: [build, dev-image, builder-image, default-microvm]
+    needs: [build, dev-image, builder-image, builder-vm-image, default-microvm]
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
@@ -385,6 +439,11 @@ jobs:
             artifacts/builder-image-*-checksums-sha256.txt \
             artifacts/builder-image-*.manifest.json \
             artifacts/builder-image-*.manifest.json.bundle \
+            artifacts/builder-vm-vmlinux-* \
+            artifacts/builder-vm-rootfs-* \
+            artifacts/builder-vm-cmdline-* \
+            artifacts/builder-vm-*.manifest.json \
+            artifacts/builder-vm-*-checksums-sha256.txt \
             artifacts/default-microvm-vmlinux-* \
             artifacts/default-microvm-rootfs-* \
             artifacts/default-microvm-*-checksums-sha256.txt \

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4155,6 +4155,7 @@ dependencies = [
  "microsandbox",
  "mvm-core",
  "mvm-guest",
+ "mvm-libkrun",
  "serde",
  "serde_json",
  "sha2 0.10.9",
@@ -4164,6 +4165,13 @@ dependencies = [
  "toml",
  "tracing",
  "which 6.0.3",
+]
+
+[[package]]
+name = "mvm-builder-init"
+version = "0.14.0"
+dependencies = [
+ "libc",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,6 +25,10 @@ members = [
     # plan 60 Phase 5 Slice C — in-guest entrypoint runner for
     # function-call workloads, ported from mvmforge-runtime.
     "crates/mvm-runner",
+    # plan 72 W3 — PID 1 for the builder microVM. Linux-only at run
+    # time; compiles as a stub on macOS so `cargo build --workspace`
+    # on a contributor's Mac doesn't fail.
+    "crates/mvm-builder-init",
     "xtask",
 ]
 # cargo-fuzz crates have to be excluded from the main workspace because
@@ -252,6 +256,13 @@ backends-microsandbox = [
     "mvm-backend/backends-microsandbox",
     "mvm-build/backends-microsandbox",
     "mvm-cli/backends-microsandbox",
+]
+# Plan 72 W1 / W5 — opt-in libkrun-backed builder VM. Stays out of
+# the default feature set until plan 57 W3 (boot validation) lands
+# and plan 72 W5's cutover flips polarity.
+backends-builder-vm-libkrun = [
+    "mvm-build/backends-builder-vm-libkrun",
+    "mvm-cli/backends-builder-vm-libkrun",
 ]
 custom-dns = ["mvm-cli/custom-dns"]
 dev-watch = ["mvm-cli/dev-watch"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -264,6 +264,11 @@ backends-builder-vm-libkrun = [
     "mvm-build/backends-builder-vm-libkrun",
     "mvm-cli/backends-builder-vm-libkrun",
 ]
+# Plan 72 W5 Stage 0 — microsandbox bootstrap for the in-repo
+# builder-vm flake. Contributors enable this when they edit
+# `nix/images/builder-vm/` and want their changes reflected in the
+# next `mvmctl dev up` without a release-pipeline round-trip.
+contributor-bootstrap = ["mvm-cli/contributor-bootstrap"]
 custom-dns = ["mvm-cli/custom-dns"]
 dev-watch = ["mvm-cli/dev-watch"]
 manifest-verify = [

--- a/crates/mvm-build/Cargo.toml
+++ b/crates/mvm-build/Cargo.toml
@@ -21,6 +21,10 @@ chrono.workspace = true
 # unconditional so `mvm-base` and `pipeline::dev_build` keep compiling
 # either way.
 microsandbox = { workspace = true, optional = true }
+# Plan 72 W1 — libkrun-backed builder VM. Wired behind the
+# `backends-builder-vm-libkrun` feature so the dep stays out of the
+# default closure until plan 57 W3 makes the boot path operational.
+mvm-libkrun = { workspace = true, optional = true }
 serde.workspace = true
 serde_json.workspace = true
 sha2.workspace = true
@@ -37,6 +41,13 @@ tempfile.workspace = true
 # Heavy microsandbox support is opt-in for lean default builds.
 default = []
 backends-microsandbox = ["dep:microsandbox"]
+# Plan 72 W1 scaffolding. Default-off — plan 72 W5 flips this to
+# `default` once plan 57 W3 (libkrun boot validation) lands and
+# `ensure_builder_vm_image` (plan 72 W5) is wired. Today, enabling
+# the feature compiles the `LibkrunBuilderVm` shape but `run_build`
+# surfaces `BuilderVmError::LibkrunUnavailable` until the libkrun
+# crate's `start()` stops returning `NotYetWired`.
+backends-builder-vm-libkrun = ["dep:mvm-libkrun"]
 
 [lints]
 workspace = true

--- a/crates/mvm-build/src/builder_vm.rs
+++ b/crates/mvm-build/src/builder_vm.rs
@@ -237,6 +237,20 @@ pub enum BuilderVmError {
     #[error("microsandbox not available: {0}")]
     MicrosandboxUnavailable(String),
 
+    /// libkrun isn't installed, the `libkrun-sys` feature is off in
+    /// this build, or plan 57 W3 (libkrun boot validation) hasn't
+    /// landed yet. The message identifies which case applies.
+    #[error("libkrun-backed builder unavailable: {0}")]
+    LibkrunUnavailable(String),
+
+    /// The builder VM image (kernel + rootfs.ext4) couldn't be
+    /// resolved. Source-checkout path: the in-repo flake didn't build
+    /// or the cache miss couldn't be reconciled. Installed-binary
+    /// path: the release artifact download failed, was tampered, or
+    /// is missing entirely. The message names the specific failure.
+    #[error("builder VM image not available: {0}")]
+    BuilderImageMissing(String),
+
     /// OCI image pull failed (network, registry auth, digest
     /// mismatch). Wraps the underlying error.
     #[error("OCI image pull failed: {0}")]

--- a/crates/mvm-build/src/builder_vm.rs
+++ b/crates/mvm-build/src/builder_vm.rs
@@ -627,6 +627,11 @@ cp -L "$src/rootfs.ext4" "$out/rootfs.ext4"
 [ -f "$src/initrd" ] && cp -L "$src/initrd" "$out/initrd"
 [ -f "$src/initrd.cpio.gz" ] && cp -L "$src/initrd.cpio.gz" "$out/initrd.cpio.gz"
 [ -f "$src/mvm-meta.json" ] && cp -L "$src/mvm-meta.json" "$out/mvm-meta.json"
+# Plan 72 W5 — builder-vm flake emits cmdline + manifest.json
+# alongside vmlinux + rootfs. Conditional copies so dev-image builds
+# (which don't produce these) stay unaffected.
+[ -f "$src/cmdline" ] && cp -L "$src/cmdline" "$out/cmdline"
+[ -f "$src/manifest.json" ] && cp -L "$src/manifest.json" "$out/manifest.json"
 chmod -R u+w "$out"
 "#,
         out = shell_quote_arg(BUILDER_GUEST_OUT_DIR),

--- a/crates/mvm-build/src/lib.rs
+++ b/crates/mvm-build/src/lib.rs
@@ -5,6 +5,13 @@ pub mod cache;
 pub mod firecracker;
 pub mod template_reuse;
 
+// Plan 72 W1 — `LibkrunBuilderVm` scaffolding behind
+// `backends-builder-vm-libkrun`. The module name `libkrun_builder`
+// disambiguates from `mvm-libkrun` (the FFI crate) so search-grep
+// for "libkrun_builder" lands on the trait impl, not the bindings.
+#[cfg(feature = "backends-builder-vm-libkrun")]
+pub mod libkrun_builder;
+
 pub mod nix;
 pub mod pipeline;
 

--- a/crates/mvm-build/src/libkrun_builder.rs
+++ b/crates/mvm-build/src/libkrun_builder.rs
@@ -1,0 +1,1102 @@
+//! libkrun-backed `BuilderVm` implementation (plan 72 W1 / ADR-046).
+//!
+//! Replaces `MicrosandboxBuilderVm` on the user-facing Layer-2 build
+//! path: instead of starting an OCI-image-backed microsandbox VM (whose
+//! 4 GiB writable overlay overflows on the dev image's `nix build`
+//! closure), `LibkrunBuilderVm` boots the purpose-built builder VM
+//! image from `nix/images/builder-vm/` (plan 72 W2), running `mvm-builder-init`
+//! as PID 1 (plan 72 W3). The host attaches three virtio-fs shares
+//! (workspace at `/work`, artifact dir at `/out`, job dir at `/job`),
+//! a virtio-blk holding the persistent `/nix` store at `/dev/vdb`, and
+//! a virtio-net link. The init runs `/job/cmd.sh`, writes the exit
+//! code to `/job/result`, and powers off; this code copies the
+//! artifacts back from `/out` to the host's `mounts.artifact_out`.
+//!
+//! ## Status (plan 72 W1)
+//!
+//! **Scaffolding behind `backends-builder-vm-libkrun`.** The trait
+//! contract is wired and the host-side staging (job dir, persistent
+//! `/nix` image allocation, path validation, artifact resolution after
+//! boot) is implemented. The libkrun boot itself returns
+//! [`BuilderVmError::LibkrunUnavailable`] until plan 57 W3 lands its
+//! `start_enter` + `shutdown_eventfd` thread-and-poll lifecycle. The
+//! image-resolution path returns [`BuilderVmError::BuilderImageMissing`]
+//! until plan 72 W5 wires `find_builder_vm_flake()` + `download_builder_vm_image`.
+//!
+//! ## Why split from `mvm-libkrun`
+//!
+//! `mvm-libkrun` carries only the libkrun FFI surface — kernel,
+//! rootfs, vsock, virtio-fs, virtio-blk wiring. The build-pipeline
+//! concerns (resolving the builder VM image, staging cmd.sh, copying
+//! artifacts back, mapping exit codes to `BuilderVmError`) live here
+//! so the FFI crate stays lean and the build crate keeps the
+//! workflow-aware logic.
+
+use std::fs;
+use std::path::{Path, PathBuf};
+
+use crate::builder_vm::{
+    BuilderArtifacts, BuilderJob, BuilderMounts, BuilderVm, BuilderVmError,
+    BUILDER_GUEST_OUT_DIR, BUILDER_GUEST_WORK_DIR,
+};
+
+/// Default vCPU count. Plan 72 W1 §Interface — `nix build` is CPU
+/// heavy; 4 is the sweet spot for laptop-class hosts.
+pub const DEFAULT_VCPUS: u8 = 4;
+/// Default memory in MiB. Plan 72 W1 §Interface — covers nixpkgs
+/// stdenv builds with headroom for the substituter fetcher's TLS
+/// closure.
+pub const DEFAULT_MEMORY_MIB: u32 = 4096;
+/// Default size of the persistent `/nix` virtio-blk image, in MiB.
+/// Sparse-allocated (only used blocks consume host disk). 64 GiB
+/// accommodates the worst-case rustc + nixpkgs stdenv closure with
+/// substantial cached output room.
+pub const DEFAULT_NIX_STORE_MIB: u32 = 65_536;
+/// In-guest mount point for the job directory (cmd.sh, env, result).
+pub const BUILDER_GUEST_JOB_DIR: &str = "/job";
+/// In-guest virtio-blk device for the persistent Nix store. Must
+/// match `mvm-builder-init`'s `NIX_STORE_DEV` constant.
+pub const NIX_STORE_GUEST_DEV: &str = "/dev/vdb";
+
+/// virtio-fs tag the guest mounts to see the workspace. Must match
+/// `mvm-builder-init`'s `VIRTIOFS_SHARES`.
+pub const VIRTIOFS_TAG_WORK: &str = "mvm-work";
+/// virtio-fs tag for the host's artifact output dir.
+pub const VIRTIOFS_TAG_OUT: &str = "mvm-out";
+/// virtio-fs tag for the host's job dir (cmd.sh + result).
+pub const VIRTIOFS_TAG_JOB: &str = "mvm-job";
+
+/// Max wall-clock for a single build. ADR-046 mentions a 30-minute
+/// cap; surface it here so plan 57 W3's poll loop has a published
+/// upper bound. Cold-cache builds for the dev image typically run
+/// in 4-8 minutes; this is "something is wrong" territory.
+pub const BUILD_TIMEOUT_SECS: u64 = 30 * 60;
+
+/// libkrun-backed builder. See module docs for status.
+#[derive(Debug, Clone)]
+pub struct LibkrunBuilderVm {
+    pub vcpus: u8,
+    pub memory_mib: u32,
+    pub nix_store_mib: u32,
+    /// Plan 72 W4 air-gapped variant. When `true`, the cmd.sh sets
+    /// `NIX_CONFIG="substituters ="` so `nix build` won't hit the
+    /// network — the builder VM is expected to satisfy the closure
+    /// from the seed `/nix` baked into the rootfs image. The init
+    /// also skips DHCP (best-effort; init runs `udhcpc` unconditionally
+    /// today, but a missing route turns the substituter calls into
+    /// no-ops). Tracked in plan 72 W4 §Air-gapped mode.
+    pub offline: bool,
+    /// Pre-resolved builder VM image. Injected by mvm-cli's
+    /// `ensure_builder_vm_image` (plan 72 W5) so this crate doesn't
+    /// take a dep on the CLI. When `None`, `run_build` returns
+    /// `BuilderImageMissing` with a hint telling the caller to
+    /// inject it.
+    pub image: Option<BuilderVmImage>,
+}
+
+impl Default for LibkrunBuilderVm {
+    fn default() -> Self {
+        Self {
+            vcpus: DEFAULT_VCPUS,
+            memory_mib: DEFAULT_MEMORY_MIB,
+            nix_store_mib: DEFAULT_NIX_STORE_MIB,
+            offline: false,
+            image: None,
+        }
+    }
+}
+
+impl LibkrunBuilderVm {
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Override the default CPU + memory pair.
+    pub fn with_resources(mut self, vcpus: u8, memory_mib: u32) -> Self {
+        self.vcpus = vcpus;
+        self.memory_mib = memory_mib;
+        self
+    }
+
+    /// Override the persistent `/nix` store image size in MiB. The
+    /// image is sparse-allocated, so a larger value only costs more
+    /// when actually used; leaving it at the default is almost always
+    /// the right call.
+    pub fn with_nix_store_size(mut self, mib: u32) -> Self {
+        self.nix_store_mib = mib;
+        self
+    }
+
+    /// Plan 72 W4 §Air-gapped mode. Build everything from the seed
+    /// `/nix` baked into the rootfs — no substituter calls, no
+    /// network dependence. Useful for CI lanes that need to prove
+    /// the seed closure is complete and for offline contributor
+    /// workflows.
+    pub fn with_offline(mut self) -> Self {
+        self.offline = true;
+        self
+    }
+
+    /// Inject a pre-resolved [`BuilderVmImage`]. mvm-cli's
+    /// `ensure_builder_vm_image` builds one via the source-checkout
+    /// cache lookup (plan 72 W5) or release-download path
+    /// (plan 72 W5 follow-on) and hands it here. The DI shape keeps
+    /// mvm-build from needing to know about mvm-cli's cache layout.
+    pub fn with_image(mut self, image: BuilderVmImage) -> Self {
+        self.image = Some(image);
+        self
+    }
+
+    /// Variant of [`BuilderVm::run_build`] that threads a
+    /// [`ConsoleCapture`] through the boot lifecycle. Plan 57 W3's
+    /// `start_enter` + `shutdown_eventfd` poll will feed each
+    /// console line into `capture.line(...)`; for now the seam is
+    /// in place but no lines are emitted because the libkrun start
+    /// call returns before booting.
+    ///
+    /// `BuilderVm::run_build` calls this with a
+    /// [`PrintlnConsoleCapture`] so callers that don't care about
+    /// live progress get the default behaviour (stdout passthrough).
+    pub fn run_build_with_capture(
+        &self,
+        job: &BuilderJob,
+        mounts: &BuilderMounts,
+        capture: &mut dyn ConsoleCapture,
+    ) -> Result<BuilderArtifacts, BuilderVmError> {
+        self.run_build_inner(job, mounts, capture)
+    }
+
+    fn run_build_inner(
+        &self,
+        job: &BuilderJob,
+        mounts: &BuilderMounts,
+        capture: &mut dyn ConsoleCapture,
+    ) -> Result<BuilderArtifacts, BuilderVmError> {
+        validate_mounts(mounts)?;
+
+        let image = match self.image.as_ref() {
+            Some(img) => img.clone(),
+            None => ensure_builder_vm_image()?,
+        };
+
+        let cache = cache_dir()?;
+        let job_id = job_id_for(job);
+        let job_dir = stage_job_dir(&cache, &job_id, job, self.offline)?;
+        let nix_store_img = ensure_nix_store_image(&cache, self.nix_store_mib)?;
+
+        let plan = LaunchPlan {
+            image,
+            vcpus: self.vcpus,
+            memory_mib: self.memory_mib,
+            nix_store_img,
+            job_dir,
+            mounts: mounts.clone(),
+            offline: self.offline,
+        };
+
+        launch_and_wait(&plan, capture)?;
+
+        collect_artifacts(mounts, &plan.job_dir)
+    }
+}
+
+// ──────────────────────── console capture ──────────────────────────
+
+/// Origin of a console line emitted by the builder VM.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ConsoleSource {
+    /// Primary kernel console (boot messages, `/init` output, the
+    /// builder VM's cmd.sh stdout+stderr merged).
+    Boot,
+    /// Job-script stderr fanned out over vsock — populated by plan
+    /// 57 W3's vsock console plumbing when it lands. Today the
+    /// boot console carries everything and this variant is unused.
+    JobStderr,
+}
+
+/// Sink for console lines emitted while the builder VM boots and
+/// runs the job. Pluggable so the CLI can colorise/forward to a UI
+/// progress bar, tests can record into a buffer, and headless
+/// production paths can no-op.
+///
+/// `Send` so plan 57 W3's threaded poll can hand the capture across
+/// the boot-thread boundary; no `Sync` requirement because each call
+/// is owned by the single drainer thread.
+pub trait ConsoleCapture: Send {
+    /// Called once per line. Implementations format as they see fit;
+    /// no newline is included in `line`.
+    fn line(&mut self, source: ConsoleSource, line: &str);
+}
+
+/// Default capture: prints every line to stdout, prefixed with the
+/// source tag. Plan 57 W3 will swap in a streaming variant in the
+/// CLI; this lives here so library consumers + tests have a
+/// concrete impl to reach for.
+#[derive(Debug, Default)]
+pub struct PrintlnConsoleCapture;
+
+impl ConsoleCapture for PrintlnConsoleCapture {
+    fn line(&mut self, source: ConsoleSource, line: &str) {
+        let tag = match source {
+            ConsoleSource::Boot => "builder",
+            ConsoleSource::JobStderr => "job",
+        };
+        println!("[{tag}] {line}");
+    }
+}
+
+/// In-memory capture used by tests + ad-hoc diagnostics. Stores
+/// every line with its source tag so the test can assert ordering
+/// and content.
+#[derive(Debug, Default)]
+pub struct RecordingConsoleCapture {
+    pub lines: Vec<(ConsoleSource, String)>,
+}
+
+impl ConsoleCapture for RecordingConsoleCapture {
+    fn line(&mut self, source: ConsoleSource, line: &str) {
+        self.lines.push((source, line.to_string()));
+    }
+}
+
+impl BuilderVm for LibkrunBuilderVm {
+    fn host_can_build(&self) -> Result<bool, BuilderVmError> {
+        // CLAUDE.md §"Host Nix is never used by mvmctl" — the libkrun
+        // path never delegates to host Nix, even when installed. This
+        // is a deliberate divergence from `MicrosandboxBuilderVm::host_can_build`
+        // (which checks `which::which("nix")`) and the reason is
+        // determinism: the same mvmctl binary should produce the same
+        // artifacts on every host regardless of host tooling.
+        Ok(false)
+    }
+
+    fn run_build(
+        &self,
+        job: &BuilderJob,
+        mounts: &BuilderMounts,
+    ) -> Result<BuilderArtifacts, BuilderVmError> {
+        // Trait callers get the println capture by default. Callers
+        // wanting custom routing use `run_build_with_capture`.
+        let mut capture = PrintlnConsoleCapture;
+        self.run_build_inner(job, mounts, &mut capture)
+    }
+}
+
+// ─────────────────────── public helpers (testable) ──────────────────
+
+/// Root cache directory for builder VM artifacts: `${mvm cache}/builder-vm`.
+/// Delegates to `mvm_core::config::mvm_cache_dir()` which honors
+/// `MVM_CACHE_DIR` → `XDG_CACHE_HOME/mvm` → `$HOME/.cache/mvm`, so
+/// the libkrun builder shares the same precedence as every other
+/// mvm cache consumer (dev images, default microVM images, etc.).
+pub fn cache_dir() -> Result<PathBuf, BuilderVmError> {
+    Ok(PathBuf::from(mvm_core::config::mvm_cache_dir()).join("builder-vm"))
+}
+
+/// Path to the persistent `/nix` store virtio-blk image for the
+/// running architecture. One image per arch since the closure shapes
+/// differ; sparse-allocated up to `nix_store_mib` on first creation.
+pub fn nix_store_image_path(cache: &Path) -> PathBuf {
+    cache.join(format!("nix-store-{}.img", host_arch_tag()))
+}
+
+/// Architecture tag used in cache filenames. Matches the release
+/// artifact arch suffix (`aarch64`, `x86_64`) so a contributor moving
+/// between machines on the same arch reuses the cache.
+pub fn host_arch_tag() -> &'static str {
+    match std::env::consts::ARCH {
+        "aarch64" => "aarch64",
+        "x86_64" => "x86_64",
+        other => other,
+    }
+}
+
+/// Validate the caller-supplied mounts. Mirrors microsandbox's
+/// `flake_src.exists()` + `create_dir_all(artifact_out)` checks;
+/// additionally rejects non-UTF-8 paths because libkrun's FFI
+/// requires `CString` and a non-UTF-8 path can't survive that.
+pub fn validate_mounts(mounts: &BuilderMounts) -> Result<(), BuilderVmError> {
+    if !mounts.flake_src.exists() {
+        return Err(BuilderVmError::ExtractionFailed(format!(
+            "flake source path does not exist: {}",
+            mounts.flake_src.display()
+        )));
+    }
+    if path_has_nul_or_non_utf8(&mounts.flake_src) {
+        return Err(BuilderVmError::ExtractionFailed(format!(
+            "flake source path is not UTF-8 / contains NUL: {}",
+            mounts.flake_src.display()
+        )));
+    }
+    if path_has_nul_or_non_utf8(&mounts.artifact_out) {
+        return Err(BuilderVmError::ExtractionFailed(format!(
+            "artifact output path is not UTF-8 / contains NUL: {}",
+            mounts.artifact_out.display()
+        )));
+    }
+    fs::create_dir_all(&mounts.artifact_out).map_err(|e| {
+        BuilderVmError::ExtractionFailed(format!(
+            "creating artifact output dir {}: {e}",
+            mounts.artifact_out.display()
+        ))
+    })?;
+    if let Some(store) = mounts.host_nix_store.as_deref()
+        && path_has_nul_or_non_utf8(store)
+    {
+        return Err(BuilderVmError::ExtractionFailed(format!(
+            "host_nix_store path is not UTF-8 / contains NUL: {}",
+            store.display()
+        )));
+    }
+    Ok(())
+}
+
+/// Deterministic job ID for a (flake_ref, attr_path) pair. Pure hash
+/// — no timestamp — so re-running the same build reuses the same
+/// job dir, which makes incremental diffing easier in CI logs. If
+/// callers need uniqueness across concurrent runs, they pass distinct
+/// `BuilderJob` values; we don't paper over that here.
+pub fn job_id_for(job: &BuilderJob) -> String {
+    use std::collections::hash_map::DefaultHasher;
+    use std::hash::{Hash, Hasher};
+    let mut h = DefaultHasher::new();
+    job.flake_ref.hash(&mut h);
+    job.attr_path.hash(&mut h);
+    format!("{:x}", h.finish())
+}
+
+// ──────────────────── private staging + launch ──────────────────────
+
+struct LaunchPlan {
+    image: BuilderVmImage,
+    vcpus: u8,
+    memory_mib: u32,
+    nix_store_img: PathBuf,
+    job_dir: PathBuf,
+    mounts: BuilderMounts,
+    offline: bool,
+}
+
+/// Resolved builder VM image — paths to the kernel, rootfs, and
+/// kernel cmdline string. The image-acquisition logic itself lives
+/// in `mvm-cli` (plan 72 W5); this type is `pub` so the CLI can
+/// construct values and inject them via `LibkrunBuilderVm::with_image`.
+#[derive(Debug, Clone)]
+pub struct BuilderVmImage {
+    pub kernel: PathBuf,
+    pub rootfs: PathBuf,
+    pub cmdline: String,
+}
+
+impl BuilderVmImage {
+    /// File name conventions matching `nix/images/builder-vm/flake.nix`'s
+    /// emitted artifacts. Kept here as constants so the CLI's cache
+    /// layout and this module's loader can't drift.
+    pub const KERNEL_FILENAME: &'static str = "vmlinux";
+    pub const ROOTFS_FILENAME: &'static str = "rootfs.ext4";
+    pub const CMDLINE_FILENAME: &'static str = "cmdline";
+
+    /// Build a `BuilderVmImage` from a directory containing the three
+    /// expected files. The CLI's cache layout writes them under
+    /// `~/.cache/mvm/builder-vm/<key>/{vmlinux,rootfs.ext4,cmdline}`
+    /// so this is the canonical inverse of "stash a freshly-built
+    /// image into the cache."
+    ///
+    /// Errors with `BuilderImageMissing` when any file is absent —
+    /// the message names the missing entry so the caller can hint at
+    /// "did the build complete?" vs "wrong cache dir?".
+    pub fn load_from_dir(dir: &Path) -> Result<Self, BuilderVmError> {
+        let kernel = dir.join(Self::KERNEL_FILENAME);
+        let rootfs = dir.join(Self::ROOTFS_FILENAME);
+        let cmdline_path = dir.join(Self::CMDLINE_FILENAME);
+        for (name, path) in [
+            (Self::KERNEL_FILENAME, &kernel),
+            (Self::ROOTFS_FILENAME, &rootfs),
+            (Self::CMDLINE_FILENAME, &cmdline_path),
+        ] {
+            if !path.exists() {
+                return Err(BuilderVmError::BuilderImageMissing(format!(
+                    "missing {name} in builder VM image dir {}",
+                    dir.display()
+                )));
+            }
+        }
+        let cmdline = fs::read_to_string(&cmdline_path)
+            .map_err(|e| {
+                BuilderVmError::BuilderImageMissing(format!(
+                    "reading {}: {e}",
+                    cmdline_path.display()
+                ))
+            })?
+            .trim()
+            .to_string();
+        if cmdline.is_empty() {
+            return Err(BuilderVmError::BuilderImageMissing(format!(
+                "cmdline file is empty: {}",
+                cmdline_path.display()
+            )));
+        }
+        Ok(Self {
+            kernel,
+            rootfs,
+            cmdline,
+        })
+    }
+}
+
+fn ensure_builder_vm_image() -> Result<BuilderVmImage, BuilderVmError> {
+    // Plan 72 W5 implementation lives in `mvm-cli` (`builder_vm_image`
+    // module). Callers in mvm-cli inject a pre-resolved image via
+    // `LibkrunBuilderVm::with_image` so this fallback never fires in
+    // production. Library consumers that construct a bare
+    // `LibkrunBuilderVm` and call `run_build` hit this branch and get
+    // an actionable hint.
+    Err(BuilderVmError::BuilderImageMissing(format!(
+        "Layer-1 builder VM image not injected — call \
+         `LibkrunBuilderVm::with_image()` before `run_build`, or use the \
+         resolver in `mvm-cli` (plan 72 W5). For ad-hoc testing, build \
+         the image with `nix build path:./nix/images/builder-vm#packages.{}-linux.default` \
+         and load it via `BuilderVmImage::load_from_dir`.",
+        host_arch_tag()
+    )))
+}
+
+fn ensure_nix_store_image(cache: &Path, size_mib: u32) -> Result<PathBuf, BuilderVmError> {
+    fs::create_dir_all(cache).map_err(|e| {
+        BuilderVmError::ExtractionFailed(format!(
+            "creating builder-vm cache dir {}: {e}",
+            cache.display()
+        ))
+    })?;
+    let path = nix_store_image_path(cache);
+    if path.exists() {
+        return Ok(path);
+    }
+    // Sparse-allocate: open + seek + write 1 byte at SIZE-1 produces
+    // a sparse hole on every filesystem that supports them (ext4,
+    // APFS, ZFS, btrfs). Filesystems without sparse support get a
+    // dense file; rare enough that we don't special-case.
+    let size_bytes = u64::from(size_mib) * 1024 * 1024;
+    let f = fs::File::create(&path).map_err(|e| {
+        BuilderVmError::ExtractionFailed(format!(
+            "create /nix store image {}: {e}",
+            path.display()
+        ))
+    })?;
+    f.set_len(size_bytes).map_err(|e| {
+        BuilderVmError::ExtractionFailed(format!(
+            "truncate /nix store image to {size_bytes} bytes: {e}"
+        ))
+    })?;
+    // mvm-builder-init formats this on first boot via mkfs.ext4 —
+    // host-side formatting would need a host-installed mke2fs that
+    // CLAUDE.md says we don't depend on. Leaving the file blank is
+    // intentional.
+    Ok(path)
+}
+
+pub fn stage_job_dir(
+    cache: &Path,
+    job_id: &str,
+    job: &BuilderJob,
+    offline: bool,
+) -> Result<PathBuf, BuilderVmError> {
+    let jobs_root = cache.join("jobs");
+    fs::create_dir_all(&jobs_root).map_err(|e| {
+        BuilderVmError::ExtractionFailed(format!(
+            "creating jobs dir {}: {e}",
+            jobs_root.display()
+        ))
+    })?;
+    let job_dir = jobs_root.join(job_id);
+    fs::create_dir_all(&job_dir).map_err(|e| {
+        BuilderVmError::ExtractionFailed(format!(
+            "creating job dir {}: {e}",
+            job_dir.display()
+        ))
+    })?;
+
+    fs::write(job_dir.join("cmd.sh"), build_cmd_script(job, offline)).map_err(|e| {
+        BuilderVmError::ExtractionFailed(format!("writing cmd.sh: {e}"))
+    })?;
+    // Empty result file — mvm-builder-init overwrites with the exit
+    // code on poweroff. Creating it host-side makes "did the build
+    // run at all?" easy to detect: a zero-length result means the
+    // init never finished writing.
+    fs::write(job_dir.join("result"), "").map_err(|e| {
+        BuilderVmError::ExtractionFailed(format!("writing empty result file: {e}"))
+    })?;
+
+    Ok(job_dir)
+}
+
+/// Generate the in-guest build script. Mirrors `MicrosandboxBuilderVm`'s
+/// `build_script` shape so the two backends produce identical artifacts
+/// for the same job — only the launcher differs.
+///
+/// When `offline` is true, sets `NIX_CONFIG` to disable substituters so
+/// `nix build` resolves the closure entirely from the seed `/nix`
+/// baked into the rootfs (plan 72 W4 §Air-gapped mode).
+pub fn build_cmd_script(job: &BuilderJob, offline: bool) -> String {
+    let flake_ref = shell_quote_arg(&job.flake_ref);
+    let attr_path = shell_quote_arg(&job.attr_path);
+    let work = shell_quote_arg(BUILDER_GUEST_WORK_DIR);
+    let out = shell_quote_arg(BUILDER_GUEST_OUT_DIR);
+    // Two-line NIX_CONFIG when offline: first the experimental-features
+    // toggle nix needs to recognise the flake CLI, then `substituters =`
+    // (empty list) which prevents nix from reaching for cache.nixos.org.
+    // Online mode keeps the single experimental-features line; nix uses
+    // its default substituter set.
+    let nix_config_line = if offline {
+        // Use a HEREDOC-style multiline value; nix splits NIX_CONFIG on
+        // newlines. `substituters =` (empty RHS) is the canonical way
+        // to disable all binary cache fetchers in nix.conf.
+        r#"export NIX_CONFIG='experimental-features = nix-command flakes
+substituters =
+'"#
+        .to_string()
+    } else {
+        "export NIX_CONFIG=\"experimental-features = nix-command flakes\"".to_string()
+    };
+    // Note: same `safe.directory` + `MVM_WORKSPACE_PATH` dance as the
+    // microsandbox path (see `MicrosandboxBuilderVm::run_build_async`).
+    // The libkrun path inherits the same constraints — virtio-fs share
+    // metadata can trip git discovery the same way an msb agent sock
+    // could.
+    format!(
+        r#"set -euo pipefail
+git config --global --add safe.directory '*'
+cd {work}
+{nix_config_line}
+export MVM_WORKSPACE_PATH={work}
+out_path=$(nix build {flake_ref}#{attr_path} \
+  --no-link --print-out-paths --no-write-lock-file --impure \
+  | tail -n 1)
+test -n "$out_path" || {{ echo "nix build produced no output path" >&2; exit 1; }}
+cp -L "$out_path/vmlinux"     {out}/vmlinux     2>/dev/null || true
+cp -L "$out_path/rootfs.ext4" {out}/rootfs.ext4
+[ -f "$out_path/initrd" ]          && cp -L "$out_path/initrd"          {out}/initrd
+[ -f "$out_path/initrd.cpio.gz" ]  && cp -L "$out_path/initrd.cpio.gz"  {out}/initrd.cpio.gz
+[ -f "$out_path/mvm-meta.json" ]   && cp -L "$out_path/mvm-meta.json"   {out}/mvm-meta.json
+chmod -R u+w {out}
+echo "$out_path" > {out}/.nix-out-path
+"#
+    )
+}
+
+/// Single-quote a shell argument the same way microsandbox's builder
+/// does. Same helper duplicated rather than shared because the two
+/// backends are deliberately independent — when microsandbox is
+/// deleted in W5+, this stays.
+fn shell_quote_arg(input: &str) -> String {
+    format!("'{}'", input.replace('\'', "'\\''"))
+}
+
+fn launch_and_wait(
+    plan: &LaunchPlan,
+    capture: &mut dyn ConsoleCapture,
+) -> Result<(), BuilderVmError> {
+    #[cfg(feature = "backends-builder-vm-libkrun")]
+    {
+        use mvm_libkrun::KrunContext;
+
+        if !mvm_libkrun::is_available() {
+            return Err(BuilderVmError::LibkrunUnavailable(format!(
+                "libkrun shared library not found on this host. {}",
+                mvm_libkrun::install_hint()
+            )));
+        }
+
+        let kernel_path = string_or_err(&plan.image.kernel, "kernel")?;
+        let rootfs_path = string_or_err(&plan.image.rootfs, "rootfs")?;
+        let mut ctx = KrunContext::new("mvm-builder-vm", kernel_path, rootfs_path)
+            .with_resources(plan.vcpus, plan.memory_mib);
+        ctx.kernel_cmdline = Some(plan.image.cmdline.clone());
+
+        // The actual virtio-fs / virtio-blk / vsock wiring + start +
+        // shutdown-eventfd poll lives in plan 57 W3. `mvm_libkrun::start`
+        // returns `NotYetWired` until that lands; we surface that as
+        // a typed `BuilderVmError` so callers get a consistent error
+        // shape regardless of which dependency is missing.
+        //
+        // The virtual-disk + virtio-fs + vsock plumbing (host_path bindings
+        // for the three shares + the /dev/vdb image) is captured in plan
+        // 72 W4 — that wave reshapes this match to call the actual
+        // `start_with_config(...)` signature exposed by plan 57 W3.
+        // For now, the `capture` parameter is plumbed through but no
+        // lines fire because the boot doesn't complete.
+        let _ = (&plan.nix_store_img, &plan.job_dir, &plan.mounts, plan.offline);
+        // Surface the launch intent on the capture so callers verify
+        // wiring works even before booting. Plan 57 W3 replaces this
+        // with real console-line callbacks.
+        capture.line(
+            ConsoleSource::Boot,
+            "mvm-builder-vm: launching (plan 57 W3 pending)",
+        );
+        mvm_libkrun::start(&ctx).map_err(|e| match e {
+            mvm_libkrun::Error::NotYetWired { tracking } => BuilderVmError::LibkrunUnavailable(
+                format!("libkrun boot wiring not landed yet (tracking: {tracking})"),
+            ),
+            mvm_libkrun::Error::NotInstalled { install_hint } => {
+                BuilderVmError::LibkrunUnavailable(format!(
+                    "libkrun not installed on this host. {install_hint}"
+                ))
+            }
+            mvm_libkrun::Error::Krun(rc) => {
+                BuilderVmError::LibkrunUnavailable(format!("libkrun call failed: rc {rc}"))
+            }
+            mvm_libkrun::Error::InvalidCString => BuilderVmError::LibkrunUnavailable(
+                "libkrun rejected a path argument (NUL byte or non-UTF-8)".into(),
+            ),
+        })?;
+
+        // Plan 57 W3 turns this into "block until shutdown eventfd
+        // fires or BUILD_TIMEOUT_SECS elapses"; today the call above
+        // returns immediately without booting and the result file is
+        // empty.
+        Ok(())
+    }
+
+    #[cfg(not(feature = "backends-builder-vm-libkrun"))]
+    {
+        let _ = (plan, capture);
+        Err(BuilderVmError::LibkrunUnavailable(
+            "compiled without `backends-builder-vm-libkrun` feature".into(),
+        ))
+    }
+}
+
+fn collect_artifacts(
+    mounts: &BuilderMounts,
+    job_dir: &Path,
+) -> Result<BuilderArtifacts, BuilderVmError> {
+    let result_path = job_dir.join("result");
+    let result_body = fs::read_to_string(&result_path).map_err(|e| {
+        BuilderVmError::ExtractionFailed(format!(
+            "reading {}: {e}",
+            result_path.display()
+        ))
+    })?;
+    let trimmed = result_body.trim();
+    if trimmed.is_empty() {
+        return Err(BuilderVmError::ExtractionFailed(format!(
+            "job result file {} is empty — builder VM didn't finish",
+            result_path.display()
+        )));
+    }
+    let exit_code: i32 = trimmed
+        .parse()
+        .map_err(|e| BuilderVmError::ExtractionFailed(format!(
+            "job result {trimmed:?} not an integer: {e}"
+        )))?;
+    if exit_code != 0 {
+        return Err(BuilderVmError::NixBuildFailed(format!(
+            "build script exited {exit_code} inside builder VM"
+        )));
+    }
+
+    let rootfs_path = mounts.artifact_out.join("rootfs.ext4");
+    if !rootfs_path.exists() {
+        return Err(BuilderVmError::ExtractionFailed(format!(
+            "build reported success but {} is missing",
+            rootfs_path.display()
+        )));
+    }
+    let kernel_path = {
+        let p = mounts.artifact_out.join("vmlinux");
+        if p.exists() { Some(p) } else { None }
+    };
+    let revision_hash = read_revision_hash(&mounts.artifact_out);
+    let accessible = crate::builder_vm::ArtifactSidecar::read_from_dir(&mounts.artifact_out)
+        .ok()
+        .flatten()
+        .map(|s| s.accessible);
+
+    Ok(BuilderArtifacts {
+        rootfs_path,
+        kernel_path,
+        revision_hash,
+        lock_hash: None,
+        accessible,
+    })
+}
+
+fn read_revision_hash(out: &Path) -> String {
+    // `.nix-out-path` is written by `build_cmd_script` so the host
+    // can recover the source store path without re-parsing nix's
+    // stdout. Extract just the hash prefix to match
+    // `extract_revision_hash` from the microsandbox path.
+    let marker = out.join(".nix-out-path");
+    let Ok(body) = fs::read_to_string(&marker) else {
+        return String::new();
+    };
+    body.trim()
+        .trim_start_matches("/nix/store/")
+        .split('-')
+        .next()
+        .unwrap_or("")
+        .to_string()
+}
+
+fn string_or_err(path: &Path, label: &str) -> Result<String, BuilderVmError> {
+    path.to_str().map(str::to_string).ok_or_else(|| {
+        BuilderVmError::ExtractionFailed(format!(
+            "{label} path is not UTF-8: {}",
+            path.display()
+        ))
+    })
+}
+
+fn path_has_nul_or_non_utf8(path: &Path) -> bool {
+    // libkrun's FFI takes paths via `CString`, which forbids interior
+    // NULs and (by way of the `&Path` → `&str` step we do in
+    // `string_or_err`) non-UTF-8 sequences. Reject both here so the
+    // failure surfaces as a typed BuilderVmError with the offending
+    // path in the message rather than the opaque `Error::InvalidCString`
+    // libkrun would return at boot.
+    match path.as_os_str().to_str() {
+        None => true,
+        Some(s) => s.as_bytes().contains(&0),
+    }
+}
+
+// ──────────────────────── tests ────────────────────────────────────
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::ffi::OsString;
+    use tempfile::tempdir;
+
+    fn make_job() -> BuilderJob {
+        BuilderJob {
+            flake_ref: "path:/work".to_string(),
+            attr_path: "packages.aarch64-linux.default".to_string(),
+        }
+    }
+
+    fn make_mounts(flake_src: &Path, artifact_out: &Path) -> BuilderMounts {
+        BuilderMounts {
+            flake_src: flake_src.to_path_buf(),
+            host_nix_store: None,
+            artifact_out: artifact_out.to_path_buf(),
+        }
+    }
+
+    #[test]
+    fn defaults_match_plan_72_w1() {
+        let vm = LibkrunBuilderVm::new();
+        assert_eq!(vm.vcpus, 4);
+        assert_eq!(vm.memory_mib, 4096);
+        assert_eq!(vm.nix_store_mib, 65_536);
+        assert!(!vm.offline);
+        assert!(vm.image.is_none());
+    }
+
+    fn write_fake_image(dir: &Path) -> BuilderVmImage {
+        fs::write(dir.join(BuilderVmImage::KERNEL_FILENAME), b"fake kernel").unwrap();
+        fs::write(dir.join(BuilderVmImage::ROOTFS_FILENAME), b"fake rootfs").unwrap();
+        fs::write(
+            dir.join(BuilderVmImage::CMDLINE_FILENAME),
+            "console=hvc0 root=/dev/vda ro init=/usr/local/bin/mvm-builder-init\n",
+        )
+        .unwrap();
+        BuilderVmImage::load_from_dir(dir).unwrap()
+    }
+
+    #[test]
+    fn builder_vm_image_load_from_dir_reads_all_three_files() {
+        let dir = tempdir().unwrap();
+        let img = write_fake_image(dir.path());
+        assert!(img.kernel.ends_with(BuilderVmImage::KERNEL_FILENAME));
+        assert!(img.rootfs.ends_with(BuilderVmImage::ROOTFS_FILENAME));
+        assert!(
+            img.cmdline.contains("init=/usr/local/bin/mvm-builder-init"),
+            "cmdline should include init=; got {:?}",
+            img.cmdline
+        );
+        assert!(
+            !img.cmdline.ends_with('\n'),
+            "load_from_dir should trim trailing newline"
+        );
+    }
+
+    #[test]
+    fn builder_vm_image_missing_file_errors() {
+        let dir = tempdir().unwrap();
+        fs::write(dir.path().join(BuilderVmImage::KERNEL_FILENAME), b"k").unwrap();
+        fs::write(dir.path().join(BuilderVmImage::ROOTFS_FILENAME), b"r").unwrap();
+        // cmdline absent
+        let err = BuilderVmImage::load_from_dir(dir.path()).unwrap_err();
+        let msg = format!("{err}");
+        assert!(
+            matches!(err, BuilderVmError::BuilderImageMissing(_)),
+            "want BuilderImageMissing, got {msg}"
+        );
+        assert!(
+            msg.contains(BuilderVmImage::CMDLINE_FILENAME),
+            "error should name the missing file: {msg}"
+        );
+    }
+
+    #[test]
+    fn builder_vm_image_empty_cmdline_errors() {
+        let dir = tempdir().unwrap();
+        fs::write(dir.path().join(BuilderVmImage::KERNEL_FILENAME), b"k").unwrap();
+        fs::write(dir.path().join(BuilderVmImage::ROOTFS_FILENAME), b"r").unwrap();
+        fs::write(dir.path().join(BuilderVmImage::CMDLINE_FILENAME), b"   \n").unwrap();
+        let err = BuilderVmImage::load_from_dir(dir.path()).unwrap_err();
+        assert!(
+            matches!(err, BuilderVmError::BuilderImageMissing(_)),
+            "empty-after-trim cmdline should error: {err:?}"
+        );
+    }
+
+    #[test]
+    fn with_image_injects_resolved_image() {
+        let dir = tempdir().unwrap();
+        let img = write_fake_image(dir.path());
+        let vm = LibkrunBuilderVm::new().with_image(img.clone());
+        assert!(vm.image.is_some());
+        let stored = vm.image.unwrap();
+        assert_eq!(stored.kernel, img.kernel);
+        assert_eq!(stored.rootfs, img.rootfs);
+        assert_eq!(stored.cmdline, img.cmdline);
+    }
+
+    #[test]
+    fn with_resources_overrides_fields() {
+        let vm = LibkrunBuilderVm::new()
+            .with_resources(2, 1024)
+            .with_nix_store_size(8192);
+        assert_eq!(vm.vcpus, 2);
+        assert_eq!(vm.memory_mib, 1024);
+        assert_eq!(vm.nix_store_mib, 8192);
+    }
+
+    #[test]
+    fn host_can_build_always_false() {
+        // CLAUDE.md §"Host Nix is never used by mvmctl" — even on a
+        // host with nix installed and `which nix` succeeding, the
+        // libkrun path must not delegate. This test pins the
+        // invariant so a future "well, let's check…" PR can't sneak
+        // it in.
+        let vm = LibkrunBuilderVm::new();
+        assert!(!vm.host_can_build().unwrap());
+    }
+
+    #[test]
+    fn validate_mounts_rejects_missing_flake_src() {
+        let out = tempdir().unwrap();
+        let mounts = make_mounts(Path::new("/nonexistent/path/xyz"), out.path());
+        let err = validate_mounts(&mounts).unwrap_err();
+        assert!(
+            matches!(err, BuilderVmError::ExtractionFailed(_)),
+            "want ExtractionFailed, got {err:?}"
+        );
+    }
+
+    #[test]
+    fn validate_mounts_creates_artifact_out() {
+        let flake_src = tempdir().unwrap();
+        let parent = tempdir().unwrap();
+        let artifact_out = parent.path().join("new-subdir");
+        assert!(!artifact_out.exists());
+        let mounts = make_mounts(flake_src.path(), &artifact_out);
+        validate_mounts(&mounts).expect("create_dir_all should succeed");
+        assert!(artifact_out.exists(), "artifact_out not created");
+    }
+
+    #[test]
+    fn job_id_is_deterministic_for_same_job() {
+        let job = make_job();
+        let id_a = job_id_for(&job);
+        let id_b = job_id_for(&job);
+        assert_eq!(id_a, id_b);
+        assert!(!id_a.is_empty(), "job id should be non-empty");
+    }
+
+    #[test]
+    fn job_id_differs_for_different_jobs() {
+        let job_a = make_job();
+        let mut job_b = make_job();
+        job_b.attr_path = "packages.x86_64-linux.default".to_string();
+        assert_ne!(job_id_for(&job_a), job_id_for(&job_b));
+    }
+
+    #[test]
+    fn stage_job_dir_writes_cmd_and_result() {
+        let cache = tempdir().unwrap();
+        let job = make_job();
+        let id = job_id_for(&job);
+        let dir = stage_job_dir(cache.path(), &id, &job, false).unwrap();
+        let cmd = fs::read_to_string(dir.join("cmd.sh")).unwrap();
+        assert!(cmd.contains("nix build"), "cmd.sh missing nix build line");
+        assert!(
+            cmd.contains("'path:/work'"),
+            "cmd.sh missing single-quoted flake_ref: {cmd}"
+        );
+        let result = fs::read_to_string(dir.join("result")).unwrap();
+        assert_eq!(result, "", "result file should be empty pre-boot");
+    }
+
+    #[test]
+    fn ensure_nix_store_image_sparse_allocates_once() {
+        let cache = tempdir().unwrap();
+        let img_a = ensure_nix_store_image(cache.path(), 16).unwrap();
+        let meta_a = fs::metadata(&img_a).unwrap();
+        assert_eq!(meta_a.len(), 16 * 1024 * 1024);
+
+        // Idempotent: second call returns the same path without
+        // re-truncating (file is preserved as-is).
+        let img_b = ensure_nix_store_image(cache.path(), 1024).unwrap();
+        assert_eq!(img_a, img_b);
+        let meta_b = fs::metadata(&img_b).unwrap();
+        assert_eq!(
+            meta_b.len(),
+            16 * 1024 * 1024,
+            "second call must not resize an existing image"
+        );
+    }
+
+    #[test]
+    fn ensure_builder_vm_image_signals_missing_w5() {
+        let err = ensure_builder_vm_image().unwrap_err();
+        assert!(
+            matches!(err, BuilderVmError::BuilderImageMissing(_)),
+            "want BuilderImageMissing (plan 72 W5 placeholder), got {err:?}"
+        );
+    }
+
+    #[test]
+    fn virtiofs_tags_match_guest_init() {
+        // mvm-builder-init's VIRTIOFS_SHARES must match these tags or
+        // the guest can't mount what the host attaches. Locking the
+        // contract here on the host side; the matching test on the
+        // guest side lives in mvm_builder_init's tests.
+        assert_eq!(VIRTIOFS_TAG_WORK, "mvm-work");
+        assert_eq!(VIRTIOFS_TAG_OUT, "mvm-out");
+        assert_eq!(VIRTIOFS_TAG_JOB, "mvm-job");
+        // BUILDER_GUEST_JOB_DIR doubles as the in-guest path; the
+        // init crate's JOB_DIR constant matches.
+        assert_eq!(BUILDER_GUEST_JOB_DIR, "/job");
+    }
+
+    #[test]
+    fn build_cmd_script_quotes_unusual_chars() {
+        let job = BuilderJob {
+            flake_ref: "weird's flake".to_string(),
+            attr_path: "packages.x86_64-linux.default".to_string(),
+        };
+        let script = build_cmd_script(&job, false);
+        assert!(
+            script.contains("'weird'\\''s flake'"),
+            "single quotes not properly escaped: {script}"
+        );
+    }
+
+    #[test]
+    fn build_cmd_script_online_omits_substituters() {
+        let job = make_job();
+        let script = build_cmd_script(&job, false);
+        assert!(
+            !script.contains("substituters ="),
+            "online build script must not disable substituters: {script}"
+        );
+        assert!(
+            script.contains("experimental-features = nix-command flakes"),
+            "online build script must still enable flakes CLI: {script}"
+        );
+    }
+
+    #[test]
+    fn build_cmd_script_offline_disables_substituters() {
+        let job = make_job();
+        let script = build_cmd_script(&job, true);
+        // Offline mode emits a multi-line NIX_CONFIG that disables
+        // every substituter so nix builds entirely from the seed /nix.
+        assert!(
+            script.contains("substituters ="),
+            "offline build script must zero out substituters: {script}"
+        );
+        assert!(
+            script.contains("experimental-features = nix-command flakes"),
+            "offline build script must still enable flakes CLI: {script}"
+        );
+    }
+
+    #[test]
+    fn with_offline_flips_field() {
+        let online = LibkrunBuilderVm::new();
+        assert!(!online.offline);
+        let offline = LibkrunBuilderVm::new().with_offline();
+        assert!(offline.offline);
+        // Other resources unaffected.
+        assert_eq!(offline.vcpus, online.vcpus);
+        assert_eq!(offline.memory_mib, online.memory_mib);
+    }
+
+    #[test]
+    fn recording_console_capture_collects_lines_in_order() {
+        let mut cap = RecordingConsoleCapture::default();
+        cap.line(ConsoleSource::Boot, "boot line 1");
+        cap.line(ConsoleSource::JobStderr, "job err");
+        cap.line(ConsoleSource::Boot, "boot line 2");
+        assert_eq!(cap.lines.len(), 3);
+        assert_eq!(cap.lines[0], (ConsoleSource::Boot, "boot line 1".to_string()));
+        assert_eq!(
+            cap.lines[1],
+            (ConsoleSource::JobStderr, "job err".to_string())
+        );
+        assert_eq!(cap.lines[2], (ConsoleSource::Boot, "boot line 2".to_string()));
+    }
+
+    #[test]
+    fn println_console_capture_is_send_and_constructible() {
+        // Compile-time check: the trait object must be Send so plan 57
+        // W3's poll thread can own it. Construction is a no-arg default,
+        // so callers don't need to know what fields exist.
+        fn assert_send<T: Send>() {}
+        assert_send::<PrintlnConsoleCapture>();
+        assert_send::<Box<dyn ConsoleCapture>>();
+        let _: Box<dyn ConsoleCapture> = Box::new(PrintlnConsoleCapture);
+    }
+
+    #[test]
+    fn validate_mounts_rejects_non_utf8_flake_src() {
+        // Construct a non-UTF-8 OsString — Unix-only because Windows
+        // OsStrings are 16-bit and the failure shape differs. Skip
+        // on platforms where invalid sequences can't be expressed.
+        #[cfg(target_family = "unix")]
+        {
+            use std::os::unix::ffi::OsStringExt;
+            let invalid_bytes = vec![0xFFu8, 0xFE, b'/', b'f', b'l', b'a', b'k', b'e'];
+            let os_path = OsString::from_vec(invalid_bytes);
+            let flake_src = PathBuf::from(os_path);
+            // We can't easily create() a file with this path on every
+            // filesystem; instead skip the existence check by checking
+            // the helper directly.
+            assert!(
+                path_has_nul_or_non_utf8(&flake_src),
+                "non-UTF-8 path should fail the helper"
+            );
+        }
+        // Make sure the test compiles on non-unix too — no-op.
+        let _ = OsString::new();
+    }
+
+    #[test]
+    fn validate_mounts_rejects_nul_byte_path() {
+        #[cfg(target_family = "unix")]
+        {
+            use std::os::unix::ffi::OsStringExt;
+            let bytes = vec![b'/', b'f', b'l', 0, b'a', b'k', b'e'];
+            let os_path = OsString::from_vec(bytes);
+            let path = PathBuf::from(os_path);
+            assert!(
+                path_has_nul_or_non_utf8(&path),
+                "path with embedded NUL should fail the helper"
+            );
+        }
+    }
+}

--- a/crates/mvm-builder-init/Cargo.toml
+++ b/crates/mvm-builder-init/Cargo.toml
@@ -1,0 +1,25 @@
+[package]
+name = "mvm-builder-init"
+version.workspace = true
+edition.workspace = true
+rust-version.workspace = true
+description = "PID 1 for the mvm builder microVM — mounts pseudofs + /dev/vdb /nix store, runs /job/cmd.sh, powers off"
+license.workspace = true
+repository.workspace = true
+homepage.workspace = true
+authors.workspace = true
+
+[[bin]]
+name = "mvm-builder-init"
+path = "src/main.rs"
+
+[dependencies]
+# libc is the only runtime dep on Linux — every system call goes
+# through it. No serde / tokio / anyhow: the binary needs to stay
+# under the 1.5 MiB plan-72 W3 budget and start in well under 8 s
+# from `init=` exec to /job/cmd.sh launch.
+[target.'cfg(target_os = "linux")'.dependencies]
+libc = { workspace = true }
+
+[lints]
+workspace = true

--- a/crates/mvm-builder-init/src/main.rs
+++ b/crates/mvm-builder-init/src/main.rs
@@ -1,0 +1,426 @@
+//! PID 1 for the mvm builder microVM (plan 72 W3 / ADR-046).
+//!
+//! The builder VM is an ephemeral appliance: the kernel boots, this
+//! binary stages the build environment (persistent `/nix` store on
+//! `/dev/vdb`, virtio-fs mounts for `/work`/`/out`/`/job`, eth0 DHCP),
+//! execs `/job/cmd.sh`, writes the exit code to `/job/result`, then
+//! powers the VM off. The host (`LibkrunBuilderVm`, plan 72 W1) reads
+//! the artifacts in `/out` and the result code in `/job/result`.
+//!
+//! ## Why a Rust binary, not a shell PID 1
+//!
+//! ADR-046 §"Open questions" debated `mvm-builder-init` as either a
+//! shell `/init` script (busybox) or a Rust binary. The plan picks
+//! Rust because (a) the format-or-mount handshake on `/dev/vdb` is
+//! easier to express correctly with libc syscalls than with a chain
+//! of busybox applets that have to handle "is ext4 already" themselves,
+//! (b) virtio-fs `mount(2)` flag plumbing is brittle in shell, and
+//! (c) reboot semantics are direct — one `libc::reboot(RB_POWER_OFF)`
+//! call instead of relying on a busybox applet's behaviour.
+//!
+//! ## Kernel cmdline contract (set by `LibkrunBuilderVm`)
+//!
+//!   console=hvc0 root=/dev/vda ro rootfstype=ext4 init=/usr/local/bin/mvm-builder-init
+//!
+//! The plan-72 W2 spec named `/sbin/mvm-builder-init` as the init
+//! path. `mkGuest`'s `packages` arg lands binaries at
+//! `/usr/local/bin/<name>` via store-path symlinks; rather than
+//! extend `mkGuest` with a separate sbin-install hook just for the
+//! builder VM, we use the path `mkGuest` already produces. The
+//! `cmdline` file emitted alongside `vmlinux` + `rootfs.ext4` carries
+//! this exact string so the launcher and the rootfs agree.
+//!
+//! ## Virtio-fs tags (host-side `LibkrunBuilderVm::run_build`)
+//!
+//!   "mvm-work" → /work   (read-only bind of the workspace)
+//!   "mvm-out"  → /out    (read-write artifact dir)
+//!   "mvm-job"  → /job    (read-write, contains cmd.sh + env + result)
+//!
+//! All three are best-effort here: the qemu smoke test (plan 72 W3
+//! acceptance) boots without virtio-fs and relies on the in-rootfs
+//! versions of those dirs. Inside libkrun the host attaches them.
+//!
+//! ## Linux-only
+//!
+//! Builds as a stub on non-Linux targets so `cargo build --workspace`
+//! on macOS still succeeds — the crate is in the workspace member
+//! list and gets walked by every `cargo` invocation.
+
+#![cfg_attr(not(target_os = "linux"), allow(dead_code))]
+
+#[cfg(not(target_os = "linux"))]
+fn main() {
+    eprintln!("mvm-builder-init: Linux-only PID 1; this build is a stub");
+    std::process::exit(1);
+}
+
+#[cfg(target_os = "linux")]
+fn main() -> ! {
+    linux::run()
+}
+
+#[cfg(target_os = "linux")]
+mod linux {
+    use std::ffi::CString;
+    use std::fs;
+    use std::io;
+    use std::os::unix::fs::FileExt;
+    use std::path::Path;
+    use std::process::Command;
+    use std::time::Duration;
+
+    const NIX_STORE_DEV: &str = "/dev/vdb";
+    const NIX_STORE_MOUNT: &str = "/nix-store";
+    const NIX_TARGET: &str = "/nix";
+    const SEED_MARKER_SUBDIR: &str = "store";
+    const JOB_DIR: &str = "/job";
+    const CMD_SCRIPT: &str = "/job/cmd.sh";
+    const RESULT_FILE: &str = "/job/result";
+    const POWEROFF_SETTLE_MS: u64 = 200;
+
+    /// virtio-fs share tags. Must match host-side `LibkrunBuilderVm`.
+    /// Kept as constants here so both halves see the same set when the
+    /// host wiring lands in plan 72 W1.
+    const VIRTIOFS_SHARES: &[(&str, &str)] = &[
+        ("mvm-work", "/work"),
+        ("mvm-out", "/out"),
+        ("mvm-job", JOB_DIR),
+    ];
+
+    pub fn run() -> ! {
+        msg("mvm-builder-init: starting");
+
+        // Pseudofs first — nothing else is possible without /proc, /dev.
+        // These are required: if they fail, panic + console-log + power
+        // off so the host sees the failure rather than a stuck VM.
+        require_mount("proc", "/proc", "proc", 0, "");
+        require_mount("sysfs", "/sys", "sysfs", 0, "");
+        require_mount("devtmpfs", "/dev", "devtmpfs", 0, "");
+        require_mount("tmpfs", "/tmp", "tmpfs", 0, "mode=1777");
+
+        // Persistent /nix store on /dev/vdb. Format-if-blank then mount
+        // + bind. ensure_nix_store panics if /dev/vdb is present but
+        // unrecoverable; with no virtio-blk attached, ensure_nix_store
+        // logs + skips (qemu smoke test path).
+        ensure_nix_store();
+
+        // virtio-fs shares — best-effort. The qemu smoke fixture has
+        // none of these attached, so failures are warnings.
+        for (tag, target) in VIRTIOFS_SHARES {
+            mount_virtiofs(tag, target);
+        }
+
+        // Network — best-effort. Offline builds (no eth0, or no DHCP
+        // response) still proceed; nix substituters fail, which the job
+        // script's exit code surfaces. Don't gate on this.
+        bring_up_network();
+
+        let exit_code = run_job();
+        let _ = fs::write(RESULT_FILE, format!("{exit_code}\n"));
+        msg(&format!(
+            "mvm-builder-init: job exited {exit_code}, powering off"
+        ));
+
+        sync_and_poweroff();
+    }
+
+    // ──────────────────────── /nix store setup ─────────────────────────
+
+    fn ensure_nix_store() {
+        if !Path::new(NIX_STORE_DEV).exists() {
+            // No virtio-blk attached (qemu smoke test or misconfigured
+            // launch). Skip the persistent store; nix builds will write
+            // to the rootfs's /nix/store and lose their cache on poweroff,
+            // but the boot path still completes.
+            msg(&format!(
+                "mvm-builder-init: {NIX_STORE_DEV} absent — skipping persistent /nix"
+            ));
+            return;
+        }
+
+        if !ensure_dir(NIX_STORE_MOUNT) || !ensure_dir(NIX_TARGET) {
+            // create_dir_all failed — log and skip the bind; nix builds
+            // still work against the rootfs's /nix.
+            return;
+        }
+
+        if !is_ext4(NIX_STORE_DEV) {
+            msg("mvm-builder-init: /dev/vdb has no ext4 superblock, formatting");
+            if run_status("/usr/local/bin/mkfs.ext4", &[
+                "-F",
+                "-L",
+                "mvm-nix-store",
+                NIX_STORE_DEV,
+            ]) != 0
+            {
+                msg("mvm-builder-init: mkfs.ext4 failed — proceeding without persistent /nix");
+                return;
+            }
+        }
+
+        if let Err(e) = do_mount(NIX_STORE_DEV, NIX_STORE_MOUNT, "ext4", 0, "") {
+            msg(&format!(
+                "mvm-builder-init: mount {NIX_STORE_DEV} → {NIX_STORE_MOUNT} failed: {e}"
+            ));
+            return;
+        }
+        msg("mvm-builder-init: /dev/vdb mounted at /nix-store");
+
+        // Seed-copy: first boot only. We test for /nix-store/store as
+        // the marker because that's what a populated nix store always
+        // contains; the seed copy writes /nix-store/store +
+        // /nix-store/var on first boot, and the marker lets subsequent
+        // boots skip the (~15s) copy.
+        let seed_marker = format!("{NIX_STORE_MOUNT}/{SEED_MARKER_SUBDIR}");
+        if !Path::new(&seed_marker).exists() {
+            msg("mvm-builder-init: seeding /nix-store from rootfs /nix");
+            // `/bin/cp` is a busybox applet symlink installed by mkGuest.
+            // `-a` preserves perms + symlinks + timestamps; trailing `/.`
+            // on the src copies directory *contents*, not the dir itself.
+            if run_status("/bin/cp", &["-a", "/nix/.", NIX_STORE_MOUNT]) != 0 {
+                msg("mvm-builder-init: warn: seed copy returned non-zero");
+            }
+        }
+
+        if let Err(e) = do_mount(NIX_STORE_MOUNT, NIX_TARGET, "", libc::MS_BIND, "") {
+            msg(&format!(
+                "mvm-builder-init: bind {NIX_STORE_MOUNT} → {NIX_TARGET} failed: {e}"
+            ));
+            return;
+        }
+        msg("mvm-builder-init: /nix bind-mounted onto persistent volume");
+    }
+
+    /// Read the ext4 superblock magic (offset 0x438, 2 bytes LE).
+    /// Returns false on any I/O error — the caller treats "unknown"
+    /// the same as "blank" and re-formats.
+    fn is_ext4(device: &str) -> bool {
+        let Ok(f) = fs::File::open(device) else {
+            return false;
+        };
+        let mut buf = [0u8; 2];
+        if f.read_exact_at(&mut buf, 0x438).is_err() {
+            return false;
+        }
+        u16::from_le_bytes(buf) == 0xEF53
+    }
+
+    // ──────────────────────── virtio-fs mounts ─────────────────────────
+
+    fn mount_virtiofs(tag: &str, target: &str) {
+        if !ensure_dir(target) {
+            return;
+        }
+        // Probe for a virtio-fs device with this tag by attempting the
+        // mount. The kernel returns ENODEV / EINVAL when no virtio-fs
+        // backend offers the tag. We swallow both — qemu smoke + offline
+        // boots have no shares attached and that's OK.
+        match do_mount(tag, target, "virtiofs", 0, "") {
+            Ok(()) => msg(&format!("mvm-builder-init: virtiofs {tag} mounted at {target}")),
+            Err(e) => msg(&format!(
+                "mvm-builder-init: virtiofs {tag} → {target} skipped: {e}"
+            )),
+        }
+    }
+
+    // ─────────────────────────── network ───────────────────────────────
+
+    fn bring_up_network() {
+        // `ip` and `udhcpc` are busybox applets installed by mkGuest at
+        // /bin/<name>. We call by absolute path because the init's env
+        // is empty (kernel sets only argv[0]).
+        if run_status("/bin/ip", &["link", "set", "eth0", "up"]) != 0 {
+            msg("mvm-builder-init: warn: ip link set eth0 up failed");
+            return;
+        }
+        // -n: exit if no lease in -t tries
+        // -q: quit after one lease
+        // -t 10: try 10 times before giving up (~10s with default backoff)
+        let rc = run_status("/bin/udhcpc", &[
+            "-i", "eth0",
+            "-n",
+            "-q",
+            "-t", "10",
+        ]);
+        if rc == 0 {
+            msg("mvm-builder-init: eth0 up via udhcpc");
+        } else {
+            msg(&format!(
+                "mvm-builder-init: warn: udhcpc exited {rc} — proceeding offline"
+            ));
+        }
+    }
+
+    // ─────────────────────────── job exec ──────────────────────────────
+
+    fn run_job() -> i32 {
+        if !Path::new(CMD_SCRIPT).exists() {
+            msg(&format!("mvm-builder-init: no {CMD_SCRIPT}, exiting 2"));
+            return 2;
+        }
+        // /bin/sh is a busybox applet symlink. `-e` aborts on error,
+        // `-u` aborts on undefined-var reference — the same posture the
+        // microsandbox builder script used (see plan 72 W0.3).
+        match Command::new("/bin/sh").args(["-eu", CMD_SCRIPT]).status() {
+            Ok(status) => exit_code_from_status(status),
+            Err(e) => {
+                msg(&format!("mvm-builder-init: spawn /bin/sh failed: {e}"));
+                127
+            }
+        }
+    }
+
+    /// Map a unix `ExitStatus` to an i32 result code.
+    /// - Normal exit → the program's exit code.
+    /// - Killed by signal → 128 + signum (the conventional shell
+    ///   encoding). Callers reading /job/result see e.g. 137 for SIGKILL.
+    fn exit_code_from_status(status: std::process::ExitStatus) -> i32 {
+        use std::os::unix::process::ExitStatusExt;
+        if let Some(code) = status.code() {
+            return code;
+        }
+        128 + status.signal().unwrap_or(0)
+    }
+
+    // ─────────────────────────── poweroff ──────────────────────────────
+
+    fn sync_and_poweroff() -> ! {
+        unsafe {
+            libc::sync();
+        }
+        // Brief settle so the console buffer flushes before the kernel
+        // halts — without this, the last "powering off" message
+        // sometimes doesn't make it to the host-side console capture.
+        std::thread::sleep(Duration::from_millis(POWEROFF_SETTLE_MS));
+        unsafe {
+            libc::reboot(libc::RB_POWER_OFF);
+        }
+        // `reboot(RB_POWER_OFF)` either powers off or errors. If we
+        // return, sleep forever so the kernel doesn't panic on PID 1
+        // exit (which surfaces as "Kernel panic - not syncing: Attempted
+        // to kill init!" and obscures the real failure on console).
+        loop {
+            std::thread::sleep(Duration::from_secs(3600));
+        }
+    }
+
+    // ───────────────────────── helpers ─────────────────────────────────
+
+    fn require_mount(source: &str, target: &str, fstype: &str, flags: libc::c_ulong, data: &str) {
+        if let Err(e) = do_mount(source, target, fstype, flags, data) {
+            // Fatal: try to surface the failure on console then halt.
+            // The kernel will panic on PID 1 exit if we just return.
+            msg(&format!(
+                "mvm-builder-init: FATAL: mount {source} → {target} ({fstype}): {e}"
+            ));
+            std::thread::sleep(Duration::from_millis(POWEROFF_SETTLE_MS));
+            unsafe {
+                libc::reboot(libc::RB_POWER_OFF);
+            }
+            loop {
+                std::thread::sleep(Duration::from_secs(3600));
+            }
+        }
+    }
+
+    fn do_mount(
+        source: &str,
+        target: &str,
+        fstype: &str,
+        flags: libc::c_ulong,
+        data: &str,
+    ) -> Result<(), String> {
+        let _ = fs::create_dir_all(target);
+        let src = CString::new(source).map_err(|_| "source has NUL")?;
+        let tgt = CString::new(target).map_err(|_| "target has NUL")?;
+        let typ = CString::new(fstype).map_err(|_| "fstype has NUL")?;
+        let dat = CString::new(data).map_err(|_| "data has NUL")?;
+        let rc = unsafe {
+            libc::mount(
+                src.as_ptr(),
+                tgt.as_ptr(),
+                typ.as_ptr(),
+                flags,
+                dat.as_ptr().cast(),
+            )
+        };
+        if rc != 0 {
+            return Err(format!(
+                "mount({source}→{target},{fstype}): {}",
+                io::Error::last_os_error()
+            ));
+        }
+        Ok(())
+    }
+
+    fn ensure_dir(path: &str) -> bool {
+        match fs::create_dir_all(path) {
+            Ok(()) => true,
+            Err(e) => {
+                msg(&format!("mvm-builder-init: create_dir_all({path}): {e}"));
+                false
+            }
+        }
+    }
+
+    fn run_status(prog: &str, args: &[&str]) -> i32 {
+        match Command::new(prog).args(args).status() {
+            Ok(s) => exit_code_from_status(s),
+            Err(e) => {
+                msg(&format!(
+                    "mvm-builder-init: spawn {prog} {args:?} failed: {e}"
+                ));
+                -1
+            }
+        }
+    }
+
+    fn msg(s: &str) {
+        // Best-effort console write. /dev/console is created by
+        // devtmpfs at boot before init runs; the first message logs
+        // before we mount /dev so the write may silently fail on the
+        // very first line — eprintln! covers the early window via the
+        // kernel-attached stdio.
+        let _ = fs::write("/dev/console", format!("{s}\n"));
+        eprintln!("{s}");
+    }
+
+    // ──────────────────────── unit tests ───────────────────────────────
+
+    #[cfg(test)]
+    mod tests {
+        use super::*;
+        use std::os::unix::process::ExitStatusExt;
+
+        #[test]
+        fn exit_code_normal_exit() {
+            // ExitStatus::from_raw on Linux uses the waitpid encoding:
+            // (status & 0xff00) >> 8 = exit code on a normal exit.
+            let s = std::process::ExitStatus::from_raw(7 << 8);
+            assert_eq!(exit_code_from_status(s), 7);
+        }
+
+        #[test]
+        fn exit_code_zero() {
+            let s = std::process::ExitStatus::from_raw(0);
+            assert_eq!(exit_code_from_status(s), 0);
+        }
+
+        #[test]
+        fn exit_code_signal() {
+            // Signal 9 (SIGKILL): low 7 bits = signum; bit 7 = core-dump
+            // (we don't care). The conventional shell encoding maps this
+            // to 128 + signum = 137.
+            let s = std::process::ExitStatus::from_raw(9);
+            assert_eq!(exit_code_from_status(s), 137);
+        }
+
+        #[test]
+        fn virtiofs_shares_match_host_contract() {
+            // If this list changes, plan 72 W1's LibkrunBuilderVm must
+            // attach the same tags or the guest can't see the shares.
+            let tags: Vec<&str> = VIRTIOFS_SHARES.iter().map(|(t, _)| *t).collect();
+            assert_eq!(tags, vec!["mvm-work", "mvm-out", "mvm-job"]);
+        }
+    }
+}

--- a/crates/mvm-builder-init/tests/builder_init_smoke.rs
+++ b/crates/mvm-builder-init/tests/builder_init_smoke.rs
@@ -1,0 +1,55 @@
+//! qemu boot smoke test for `mvm-builder-init` (plan 72 W3
+//! acceptance criterion).
+//!
+//! Boots the builder-vm flake's kernel + rootfs.ext4 under
+//! `qemu-system-aarch64` (or `qemu-system-x86_64` on x86) with:
+//!
+//!   - virtio-blk on /dev/vdb: a 5 MiB raw image (blank — init formats it)
+//!   - virtio-fs on tag `mvm-job`: a host dir containing `cmd.sh` that
+//!     runs `echo ok > /out/result.txt`
+//!   - virtio-fs on tag `mvm-out`: an empty host dir to receive output
+//!
+//! Asserts:
+//!   - boot-to-poweroff completes within 8s wall clock
+//!   - /out/result.txt on the host contains `ok\n`
+//!   - the host's job dir's `result` file contains `0\n`
+//!
+//! Status: **stub** — gated behind `#[ignore]` until plan 72 W2 lands
+//! a built kernel + rootfs.ext4 the test can consume. The bare crate
+//! `cargo build` (cross-compiled to aarch64-linux) is W3's primary
+//! acceptance until then; this file documents the qemu fixture
+//! contract so the reviewer of plan 72 W4 has a concrete target.
+//!
+//! When un-ignoring this, point `MVM_BUILDER_VM_IMAGE_DIR` at a
+//! directory containing `vmlinux` + `rootfs.ext4` produced by
+//! `nix build path:nix/images/builder-vm#packages.<system>.default`.
+
+#![cfg(target_os = "linux")]
+
+use std::env;
+use std::path::PathBuf;
+
+#[test]
+#[ignore = "plan 72 W3 qemu fixture — requires built builder-vm image + qemu-system"]
+fn boots_runs_job_and_powers_off() {
+    let image_dir = match env::var("MVM_BUILDER_VM_IMAGE_DIR") {
+        Ok(v) => PathBuf::from(v),
+        Err(_) => panic!(
+            "MVM_BUILDER_VM_IMAGE_DIR not set — point at a dir containing \
+             vmlinux + rootfs.ext4 (from nix build nix/images/builder-vm#packages.<system>.default)"
+        ),
+    };
+
+    let vmlinux = image_dir.join("vmlinux");
+    let rootfs = image_dir.join("rootfs.ext4");
+    assert!(
+        vmlinux.exists() && rootfs.exists(),
+        "{vmlinux:?} / {rootfs:?} not present — did the builder-vm flake build?"
+    );
+
+    // TODO(plan 72 W3 follow-on): wire qemu-system invocation here.
+    // The full fixture (5 MiB virtio-blk + two virtiofsd backends +
+    // exit-on-poweroff trapping) is non-trivial; landing it alongside
+    // W4 (network + vsock plumbing) keeps the in-flight PR focused on
+    // the init binary itself rather than the test rig.
+}

--- a/crates/mvm-cli/Cargo.toml
+++ b/crates/mvm-cli/Cargo.toml
@@ -69,6 +69,11 @@ backends-microsandbox = [
     "mvm-build/backends-microsandbox",
     "mvm-backend/backends-microsandbox",
 ]
+# Plan 72 W1 / W5 scaffolding — forwards mvm-build's libkrun-builder
+# feature so `mvm_cli::builder_vm_image::ensure_builder_vm_image` is
+# compiled in. Plan 72 W5 flips this to `default` once the libkrun
+# boot lifecycle (plan 57 W3) ships.
+backends-builder-vm-libkrun = ["mvm-build/backends-builder-vm-libkrun"]
 custom-dns = ["mvm-supervisor/custom-dns"]
 dev-watch = ["dep:notify", "dep:notify-debouncer-mini"]
 manifest-verify = [

--- a/crates/mvm-cli/Cargo.toml
+++ b/crates/mvm-cli/Cargo.toml
@@ -74,6 +74,17 @@ backends-microsandbox = [
 # compiled in. Plan 72 W5 flips this to `default` once the libkrun
 # boot lifecycle (plan 57 W3) ships.
 backends-builder-vm-libkrun = ["mvm-build/backends-builder-vm-libkrun"]
+# Plan 72 W5 Stage 0 — microsandbox-backed bootstrap for building the
+# in-repo `nix/images/builder-vm/flake.nix` on a contributor laptop
+# without host Nix. Pulls in `backends-microsandbox` for the
+# `MicrosandboxBuilderVm` impl. Plan 72 W5's cutover deletes the
+# end-user-facing microsandbox path and renames `backends-microsandbox`
+# → `contributor-bootstrap` for clarity; the forward here is the
+# bridge until that consolidation lands.
+contributor-bootstrap = [
+    "backends-microsandbox",
+    "backends-builder-vm-libkrun",
+]
 custom-dns = ["mvm-supervisor/custom-dns"]
 dev-watch = ["dep:notify", "dep:notify-debouncer-mini"]
 manifest-verify = [

--- a/crates/mvm-cli/src/builder_vm_image.rs
+++ b/crates/mvm-cli/src/builder_vm_image.rs
@@ -153,16 +153,41 @@ pub fn ensure_builder_vm_image() -> Result<BuilderVmImage> {
             {
                 return Ok(img);
             }
+
+            // Stage 0 bootstrap — populate the cache by running
+            // `nix build` inside a microsandbox VM. Only available when
+            // built with `--features contributor-bootstrap` since that
+            // pulls in the microsandbox dep closure (sqlx-sqlite,
+            // microsandbox-runtime, etc.) that the default mvmctl
+            // binary leaves out.
+            #[cfg(feature = "contributor-bootstrap")]
+            {
+                build_builder_vm_image_via_microsandbox(&flake_dir, &cache).with_context(|| {
+                    format!(
+                        "Stage 0 microsandbox build of builder-vm flake at {} → {}",
+                        flake_dir.display(),
+                        cache.display(),
+                    )
+                })?;
+                BuilderVmImage::load_from_dir(&cache).with_context(|| {
+                    format!(
+                        "loading freshly-built builder VM image from {}",
+                        cache.display()
+                    )
+                })
+            }
+
+            #[cfg(not(feature = "contributor-bootstrap"))]
             anyhow::bail!(
                 "Source-checkout cache miss for builder VM image at {cache_disp}\n\
-                 Build it locally with:\n\
+                 Rebuild mvmctl with `--features contributor-bootstrap` to \
+                 enable the Stage 0 microsandbox bootstrap that populates this \
+                 cache. Or build the image manually:\n\
                  \n  \
                  nix build path:{flake_disp}#packages.{arch}-linux.default --out-link {cache_disp}/result\n\
                  \n\
                  then copy `result/vmlinux`, `result/rootfs.ext4`, and \
-                 `result/cmdline` into {cache_disp}. The Stage-0 bootstrap \
-                 that does this automatically is plan 72 W5's \
-                 `--features contributor-bootstrap`.",
+                 `result/cmdline` into {cache_disp}.",
                 cache_disp = cache.display(),
                 flake_disp = flake_dir.display(),
                 arch = std::env::consts::ARCH,
@@ -190,6 +215,127 @@ pub fn ensure_builder_vm_image() -> Result<BuilderVmImage> {
             })
         }
     }
+}
+
+// ──────────────────── Stage 0 microsandbox bootstrap ──────────────
+
+/// Build the in-repo `nix/images/builder-vm/` flake inside a
+/// microsandbox VM running `nixos/nix:2.24.10` (the same OCI image
+/// the existing dev-image builder uses) and stash the artifacts under
+/// `dest_dir`. The flake emits vmlinux + rootfs.ext4 + cmdline +
+/// manifest.json; `MicrosandboxBuilderVm`'s copy_script extracts them
+/// back to `dest_dir` over the bind-mounted `/out`.
+///
+/// This is plan 72 W5's Stage 0 — the contributor-bootstrap path that
+/// lets a developer modify `nix/images/builder-vm/flake.nix` and see
+/// their change in the next `mvmctl dev up` without a release-pipeline
+/// round-trip (CLAUDE.md §"Source-checkout builds never depend on
+/// mvm-published artifacts").
+///
+/// Why microsandbox + `nixos/nix:2.24.10` rather than host Nix:
+/// CLAUDE.md §"Host Nix is never used by mvmctl" applies here too.
+/// Every Nix evaluation goes through a VM we launched; this is the
+/// only Stage 0 path. The 4 GiB microsandbox overlay limit (ADR-046
+/// §"Open questions") applies but the builder-vm rootfs closure
+/// fits — plan 72 W2 §"Image size budget" enforces ≤ 1.2 GiB
+/// uncompressed at flake-build time.
+#[cfg(feature = "contributor-bootstrap")]
+pub fn build_builder_vm_image_via_microsandbox(
+    flake_dir: &Path,
+    dest_dir: &Path,
+) -> Result<()> {
+    use mvm_build::builder_vm::{
+        BUILDER_GUEST_WORK_DIR, BuilderJob, BuilderMounts, BuilderVm, MicrosandboxBuilderVm,
+        host_system_linux,
+    };
+
+    if !flake_dir.exists() {
+        anyhow::bail!("builder-vm flake dir does not exist: {}", flake_dir.display());
+    }
+    std::fs::create_dir_all(dest_dir).with_context(|| {
+        format!(
+            "creating destination cache dir {} for builder VM image",
+            dest_dir.display()
+        )
+    })?;
+
+    // The builder-vm flake at `<workspace>/nix/images/builder-vm/`
+    // uses `builtins.path { path = ../../..; }` to capture the
+    // workspace root (for mkGuest's `mvmSrc` + `Cargo.lock`). Mount
+    // the whole workspace at /work and point `flake_ref` at the
+    // subdir — same pattern as `build_image_via_microsandbox` in
+    // `commands/env/apple_container.rs`.
+    let workspace_root = flake_dir
+        .parent()
+        .and_then(Path::parent)
+        .and_then(Path::parent)
+        .ok_or_else(|| {
+            anyhow::anyhow!(
+                "flake dir is not three levels deep in workspace: {}",
+                flake_dir.display()
+            )
+        })?
+        .to_path_buf();
+    let flake_rel = flake_dir.strip_prefix(&workspace_root).map_err(|_| {
+        anyhow::anyhow!(
+            "flake dir not under derived workspace root: {}",
+            flake_dir.display()
+        )
+    })?;
+    let flake_rel_str = flake_rel.to_str().ok_or_else(|| {
+        anyhow::anyhow!("flake subpath has non-UTF-8 bytes: {flake_rel:?}")
+    })?;
+    let guest_flake_ref = format!("path:{BUILDER_GUEST_WORK_DIR}/{flake_rel_str}");
+
+    // Bind /nix opportunistically on Linux hosts that already run
+    // native Nix — same rationale as the dev-image path. Skipped on
+    // macOS (Darwin-targeted closures + permission tangle).
+    let host_nix_store = if cfg!(target_os = "macos") {
+        None
+    } else {
+        let host_nix = PathBuf::from("/nix");
+        if host_nix.join("store").is_dir() {
+            Some(host_nix)
+        } else {
+            None
+        }
+    };
+
+    let job = BuilderJob {
+        flake_ref: guest_flake_ref,
+        attr_path: format!("packages.{}.default", host_system_linux()),
+    };
+    let mounts = BuilderMounts {
+        flake_src: workspace_root,
+        host_nix_store,
+        artifact_out: dest_dir.to_path_buf(),
+    };
+
+    MicrosandboxBuilderVm::default()
+        .run_build(&job, &mounts)
+        .map_err(|e| anyhow::anyhow!("Stage 0 microsandbox build failed: {e}"))?;
+
+    // MicrosandboxBuilderVm's copy_script handles vmlinux, rootfs.ext4,
+    // cmdline, and manifest.json (plan 72 W5 added cmdline + manifest
+    // to the copy list). Sanity-check the three files BuilderVmImage
+    // expects before returning.
+    for required in [
+        BuilderVmImage::KERNEL_FILENAME,
+        BuilderVmImage::ROOTFS_FILENAME,
+        BuilderVmImage::CMDLINE_FILENAME,
+    ] {
+        let p = dest_dir.join(required);
+        if !p.exists() {
+            anyhow::bail!(
+                "Stage 0 build completed but {} is missing from {}. \
+                 The builder-vm flake may have failed to emit it (check the \
+                 microsandbox build logs above) or the copy_script regressed.",
+                required,
+                dest_dir.display()
+            );
+        }
+    }
+    Ok(())
 }
 
 // ─────────────────── release download (ADR-002 §W5.1) ────────────
@@ -519,13 +665,18 @@ mod tests {
         );
     }
 
-    #[cfg(feature = "backends-builder-vm-libkrun")]
+    #[cfg(all(
+        feature = "backends-builder-vm-libkrun",
+        not(feature = "contributor-bootstrap")
+    ))]
     #[test]
     fn ensure_builder_vm_image_signals_cache_miss_for_source_checkout() {
-        // The cache dir under the contributor's real $HOME may or may
-        // not be populated (depends on whether they've built locally
-        // before). Force it to miss by redirecting `mvm_cache_dir()`
-        // at a temp dir for the duration of this test.
+        // Without `contributor-bootstrap`, the source-checkout cache
+        // miss path errors with a hint telling the user to rebuild
+        // mvmctl with the feature on. The `contributor-bootstrap`
+        // variant of this test path is harder to unit-test (it
+        // genuinely attempts a microsandbox build) — coverage there
+        // lives in the planned live test `dev_up_contributor_bootstrap.rs`.
         //
         // We rely on `MVM_CACHE_DIR` env-var precedence in
         // `mvm_core::config::mvm_cache_dir()`. `std::env::set_var` is
@@ -548,6 +699,28 @@ mod tests {
         assert!(
             msg.contains("cache miss") || msg.contains("Cache miss"),
             "error should mention the cache miss: {msg}"
+        );
+        assert!(
+            msg.contains("contributor-bootstrap"),
+            "without the feature, error should point at it: {msg}"
+        );
+    }
+
+    #[cfg(feature = "contributor-bootstrap")]
+    #[test]
+    fn build_builder_vm_image_via_microsandbox_validates_flake_dir() {
+        // Negative path: the function should reject a non-existent
+        // flake dir before reaching the (expensive) microsandbox
+        // spawn step. The positive path requires a working sandbox
+        // and is exercised by the planned live test
+        // `dev_up_contributor_bootstrap.rs`.
+        let scratch = tempdir().unwrap();
+        let missing = scratch.path().join("does-not-exist");
+        let err = build_builder_vm_image_via_microsandbox(&missing, scratch.path()).unwrap_err();
+        let msg = format!("{err}");
+        assert!(
+            msg.contains("does not exist"),
+            "should reject missing flake dir: {msg}"
         );
     }
 }

--- a/crates/mvm-cli/src/builder_vm_image.rs
+++ b/crates/mvm-cli/src/builder_vm_image.rs
@@ -1,0 +1,553 @@
+//! Layer-1 builder VM image acquisition (plan 72 W5).
+//!
+//! Resolves the kernel + rootfs.ext4 + cmdline triple consumed by
+//! [`mvm_build::libkrun_builder::LibkrunBuilderVm::with_image`]. Two
+//! acquisition paths per ADR-046 §"Two artifact layers, two
+//! acquisition paths":
+//!
+//!   1. **Source checkout** (`find_builder_vm_flake()` returns Ok):
+//!      look in `${mvm_cache_dir}/builder-vm/<sha256-key>/` where
+//!      the key hashes `nix/images/builder-vm/flake.nix` (+ its
+//!      lock if present). On cache miss, the bootstrap-build path
+//!      (Stage 0 — microsandbox + `nixos/nix:2.24.10` per plan 72
+//!      W5) populates the cache. That bootstrap lives in a follow-on
+//!      and gates on `--features contributor-bootstrap`; this module
+//!      surfaces a clear error pointing there until it ships.
+//!
+//!   2. **Installed binary** (no source checkout): look in
+//!      `${mvm_cache_dir}/builder-vm/v<mvmctl-version>/`. On miss,
+//!      [`download_builder_vm_image`] fetches the four artifacts
+//!      (vmlinux, rootfs.ext4, cmdline, checksums.txt) from the
+//!      matching GitHub release and SHA-256 verifies per
+//!      ADR-002 §W5.1. The `MVM_SKIP_HASH_VERIFY=1` env var is the
+//!      documented emergency escape.
+//!
+//! ## Why this lives in mvm-cli, not mvm-build
+//!
+//! The trait-impl side (`LibkrunBuilderVm` in `mvm-build`) has to
+//! stay narrow — it's the runtime VM driver. The image-acquisition
+//! side has a much wider blast radius (filesystem layouts, version
+//! strings, eventual HTTP, cache pruning) and shares that surface
+//! with the existing dev-image / default-microvm acquisition logic
+//! that already lives in `mvm-cli`. Keeping all three resolvers in
+//! one crate means a future "unify the cache layout" refactor
+//! touches one module.
+
+use std::collections::HashMap;
+use std::io::Read;
+use std::path::{Path, PathBuf};
+
+use anyhow::{Context, Result};
+use sha2::{Digest, Sha256};
+
+#[cfg(feature = "backends-builder-vm-libkrun")]
+use mvm_build::libkrun_builder::BuilderVmImage;
+
+#[cfg(feature = "backends-builder-vm-libkrun")]
+use crate::http;
+
+/// Locate the Layer-1 builder VM Nix flake in a source checkout.
+///
+/// Returns `Ok(path)` when `<workspace_root>/nix/images/builder-vm/flake.nix`
+/// exists. The workspace root is derived from `CARGO_MANIFEST_DIR`,
+/// which resolves to this crate's source dir at compile time:
+///
+///   - Source checkouts: `<repo>/crates/mvm-cli` → workspace = `<repo>`
+///   - Installed binaries (cargo registry): no `nix/images/...` in
+///     a registry tarball, so we return Err and the caller falls
+///     through to the release-download path.
+///
+/// Mirrors `find_dev_image_flake` in `commands/env/apple_container.rs`
+/// (the Layer-2 / dev-shell resolver) — same shape, different
+/// directory. The two resolvers stay separate so plan 72 W5 can
+/// rename `nix/images/builder/` → `nix/images/dev-shell/` without
+/// touching this side.
+pub fn find_builder_vm_flake() -> Result<PathBuf> {
+    let manifest_dir = env!("CARGO_MANIFEST_DIR");
+    let workspace_root = Path::new(manifest_dir)
+        .parent()
+        .and_then(Path::parent)
+        .ok_or_else(|| anyhow::anyhow!("cannot locate workspace root from {manifest_dir}"))?;
+    let candidate = workspace_root
+        .join("nix")
+        .join("images")
+        .join("builder-vm");
+    if candidate.join("flake.nix").exists() {
+        return Ok(candidate);
+    }
+    anyhow::bail!(
+        "Builder VM flake not found. Expected at nix/images/builder-vm/flake.nix \
+         (this is a source-checkout signal — installed mvmctl binaries hit the \
+         release-download path instead)."
+    )
+}
+
+/// Compute the source-checkout cache key for a builder VM flake.
+///
+/// Key = sha256(flake.nix bytes || `\0` || flake.lock bytes). The
+/// NUL separator distinguishes (flake.nix = "AB", lock = "C") from
+/// (flake.nix = "A", lock = "BC"). When `flake.lock` is absent
+/// (first `nix build` hasn't happened yet) the key hashes only
+/// flake.nix; on next run, the freshly-written lock file changes the
+/// key, which forces a rebuild — that's the intended invariant per
+/// plan 72 W5 ("any contributor edit to either invalidates").
+pub fn cache_key_from_flake(flake_dir: &Path) -> Result<String> {
+    let flake_nix = flake_dir.join("flake.nix");
+    let flake_nix_bytes = std::fs::read(&flake_nix)
+        .with_context(|| format!("reading {}", flake_nix.display()))?;
+    let mut hasher = Sha256::new();
+    hasher.update(&flake_nix_bytes);
+    hasher.update([0u8]);
+    let lock_path = flake_dir.join("flake.lock");
+    if lock_path.exists() {
+        let lock_bytes = std::fs::read(&lock_path)
+            .with_context(|| format!("reading {}", lock_path.display()))?;
+        hasher.update(&lock_bytes);
+    }
+    Ok(format!("{:x}", hasher.finalize()))
+}
+
+/// Root directory for cached builder VM images. Mirrors
+/// `mvm_build::libkrun_builder::cache_dir()` but exposes a `Result<PathBuf>`-free
+/// helper for mvm-cli's `Result<...>` callers — both delegate to
+/// `mvm_core::config::mvm_cache_dir()` for the precedence rule.
+pub fn cache_root() -> PathBuf {
+    PathBuf::from(mvm_core::config::mvm_cache_dir()).join("builder-vm")
+}
+
+/// Cache subdirectory for a source-checkout build, keyed by the
+/// flake's hash. Plan 72 W5 "if `~/.cache/mvm/builder-vm/<hash>/`
+/// exists and is hash-valid → use it" — this is `<hash>`.
+pub fn source_cache_dir(flake_dir: &Path) -> Result<PathBuf> {
+    let key = cache_key_from_flake(flake_dir)?;
+    Ok(cache_root().join(key))
+}
+
+/// Cache subdirectory for an installed-binary build, keyed by the
+/// running mvmctl version. Plan 72 W5 "outside a source checkout:
+/// download the mvm-published prebuilt for the running mvmctl
+/// version".
+pub fn installed_cache_dir() -> PathBuf {
+    let version = env!("CARGO_PKG_VERSION");
+    cache_root().join(format!("v{version}"))
+}
+
+/// Resolve the Layer-1 builder VM image, preferring (in order):
+///   1. Source-checkout cache hit at `<cache>/builder-vm/<flake-hash>/`.
+///   2. Installed-binary cache hit at `<cache>/builder-vm/v<version>/`.
+///   3. Discoverable error pointing at the bootstrap/download
+///      follow-on that fills those caches.
+///
+/// Plan 72 W5 turns step 3 into "kick off Stage 0 / download" — for
+/// the in-flight scaffolding PR we surface the cache-miss path so
+/// contributors can manually populate the cache for ad-hoc testing
+/// (drop `vmlinux` + `rootfs.ext4` + `cmdline` from a fresh
+/// `nix build` into the directory the error names).
+#[cfg(feature = "backends-builder-vm-libkrun")]
+pub fn ensure_builder_vm_image() -> Result<BuilderVmImage> {
+    match find_builder_vm_flake() {
+        Ok(flake_dir) => {
+            let cache = source_cache_dir(&flake_dir)?;
+            if cache.is_dir()
+                && let Ok(img) = BuilderVmImage::load_from_dir(&cache)
+            {
+                return Ok(img);
+            }
+            anyhow::bail!(
+                "Source-checkout cache miss for builder VM image at {cache_disp}\n\
+                 Build it locally with:\n\
+                 \n  \
+                 nix build path:{flake_disp}#packages.{arch}-linux.default --out-link {cache_disp}/result\n\
+                 \n\
+                 then copy `result/vmlinux`, `result/rootfs.ext4`, and \
+                 `result/cmdline` into {cache_disp}. The Stage-0 bootstrap \
+                 that does this automatically is plan 72 W5's \
+                 `--features contributor-bootstrap`.",
+                cache_disp = cache.display(),
+                flake_disp = flake_dir.display(),
+                arch = std::env::consts::ARCH,
+            )
+        }
+        Err(_no_source) => {
+            let cache = installed_cache_dir();
+            if cache.is_dir()
+                && let Ok(img) = BuilderVmImage::load_from_dir(&cache)
+            {
+                return Ok(img);
+            }
+            download_builder_vm_image(&cache).with_context(|| {
+                format!(
+                    "downloading builder VM image v{version} to {cache_disp}",
+                    cache_disp = cache.display(),
+                    version = env!("CARGO_PKG_VERSION"),
+                )
+            })?;
+            BuilderVmImage::load_from_dir(&cache).with_context(|| {
+                format!(
+                    "loading downloaded builder VM image from {}",
+                    cache.display()
+                )
+            })
+        }
+    }
+}
+
+// ─────────────────── release download (ADR-002 §W5.1) ────────────
+
+/// Architecture suffix used in release artifact filenames. Mirrors
+/// the matrix used by `download_dev_image` so installed binaries on
+/// Apple Silicon and Linux aarch64 share the artifact set.
+pub fn release_arch_tag() -> &'static str {
+    if cfg!(target_arch = "aarch64") {
+        "aarch64"
+    } else {
+        "x86_64"
+    }
+}
+
+/// Base URL for the matching mvmctl release. Each binary downloads
+/// the artifacts tagged with its own `CARGO_PKG_VERSION`; bumping
+/// the binary automatically invalidates the cache and pulls fresh
+/// artifacts on the next miss.
+#[cfg(feature = "backends-builder-vm-libkrun")]
+fn release_base_url() -> String {
+    let version = env!("CARGO_PKG_VERSION");
+    format!("https://github.com/tinylabscom/mvm/releases/download/v{version}")
+}
+
+/// Download the four builder VM image artifacts to `dest_dir` (the
+/// installed-binary cache subdir), SHA-256 verifying each against
+/// the release's `builder-vm-<arch>-checksums-sha256.txt` file.
+///
+/// On success, the dest dir contains `vmlinux`, `rootfs.ext4`, and
+/// `cmdline` — the three filenames [`BuilderVmImage::load_from_dir`]
+/// expects.
+///
+/// `MVM_SKIP_HASH_VERIFY=1` downgrades hash mismatches to warnings
+/// (ADR-002 §W5.1 emergency-rotation escape). Never set in CI.
+///
+/// Feature-gated because the only consumer
+/// ([`BuilderVmImage::load_from_dir`]) lives behind the same flag —
+/// downloading the image without the ability to load it would be
+/// dead weight in the default binary.
+#[cfg(feature = "backends-builder-vm-libkrun")]
+pub fn download_builder_vm_image(dest_dir: &Path) -> Result<()> {
+    std::fs::create_dir_all(dest_dir)
+        .with_context(|| format!("creating builder VM cache dir {}", dest_dir.display()))?;
+
+    let arch = release_arch_tag();
+    let base = release_base_url();
+
+    let vmlinux_name = format!("builder-vm-vmlinux-{arch}");
+    let rootfs_name = format!("builder-vm-rootfs-{arch}.ext4");
+    let cmdline_name = format!("builder-vm-cmdline-{arch}");
+    let checksums_name = format!("builder-vm-{arch}-checksums-sha256.txt");
+
+    let checksums_url = format!("{base}/{checksums_name}");
+    let checksums_body = http::fetch_text(&checksums_url).with_context(|| {
+        format!(
+            "fetching {checksums_name} from {checksums_url} — the release tag may \
+             predate plan 72 W2 or be missing the builder-vm artifacts entirely"
+        )
+    })?;
+    let expected = parse_checksums(&checksums_body);
+
+    for (src_name, dest_filename) in [
+        (vmlinux_name.as_str(), BuilderVmImage::KERNEL_FILENAME),
+        (rootfs_name.as_str(), BuilderVmImage::ROOTFS_FILENAME),
+        (cmdline_name.as_str(), BuilderVmImage::CMDLINE_FILENAME),
+    ] {
+        let url = format!("{base}/{src_name}");
+        let dest = dest_dir.join(dest_filename);
+        http::download_file(&url, &dest)
+            .with_context(|| format!("downloading {src_name} from {url}"))?;
+        verify_artifact_hash(&dest, src_name, expected.get(src_name))?;
+    }
+
+    Ok(())
+}
+
+/// Parse a `sha256sum`-format file into `{filename → hex hash}`.
+/// Tolerant of leading whitespace and the `*` binary-mode prefix
+/// some tools emit. Lines that don't fit `<hash>  <name>` are skipped
+/// silently — release files always conform to the canonical format,
+/// and a parse error here would mask the more useful "expected hash
+/// missing for X" downstream error from [`verify_artifact_hash`].
+pub fn parse_checksums(body: &str) -> HashMap<String, String> {
+    let mut out = HashMap::new();
+    for line in body.lines() {
+        let line = line.trim();
+        if line.is_empty() || line.starts_with('#') {
+            continue;
+        }
+        // `<sha256-hex>  <filename>` (two spaces is canonical; tolerate one)
+        // or `<sha256-hex> *<filename>` for binary-mode entries.
+        let Some((hash, rest)) = line.split_once(char::is_whitespace) else {
+            continue;
+        };
+        if hash.len() != 64 || !hash.chars().all(|c| c.is_ascii_hexdigit()) {
+            continue;
+        }
+        let name = rest.trim_start().trim_start_matches('*');
+        if name.is_empty() {
+            continue;
+        }
+        out.insert(name.to_string(), hash.to_ascii_lowercase());
+    }
+    out
+}
+
+/// Compute the lowercase-hex SHA-256 of a file's contents.
+///
+/// Streamed so the hash works against multi-GiB rootfs files
+/// without loading them entirely into memory.
+pub fn sha256_of_file(path: &Path) -> Result<String> {
+    let mut f = std::fs::File::open(path)
+        .with_context(|| format!("opening {} for hashing", path.display()))?;
+    let mut hasher = Sha256::new();
+    let mut buf = [0u8; 64 * 1024];
+    loop {
+        let n = f
+            .read(&mut buf)
+            .with_context(|| format!("reading {} for hashing", path.display()))?;
+        if n == 0 {
+            break;
+        }
+        hasher.update(&buf[..n]);
+    }
+    Ok(format!("{:x}", hasher.finalize()))
+}
+
+/// Verify a downloaded artifact's SHA-256 against the expected hash.
+///
+/// Errors when:
+/// - `expected` is `None` — the checksums file didn't list this artifact
+/// - the computed hash doesn't match — likely tampering or a partial download
+///
+/// `MVM_SKIP_HASH_VERIFY=1` downgrades mismatches to a tracing warning
+/// without aborting; documented in ADR-002 §W5.1 as an emergency escape.
+pub fn verify_artifact_hash(path: &Path, name: &str, expected: Option<&String>) -> Result<()> {
+    let expected = expected.ok_or_else(|| {
+        anyhow::anyhow!(
+            "checksums file did not list {name} — refusing to trust an unverified \
+             artifact (the release publisher must include every per-arch entry)"
+        )
+    })?;
+    let actual = sha256_of_file(path)?;
+    if actual == *expected {
+        return Ok(());
+    }
+    if std::env::var_os("MVM_SKIP_HASH_VERIFY").is_some() {
+        tracing::warn!(
+            artifact = name,
+            expected = %expected,
+            actual = %actual,
+            "MVM_SKIP_HASH_VERIFY set — accepting hash mismatch. ADR-002 §W5.1 \
+             documents this as an emergency-rotation escape only; never set in CI."
+        );
+        return Ok(());
+    }
+    // Best-effort cleanup so a subsequent run doesn't reuse the
+    // poisoned file. Cache layer is responsible for re-creating dir
+    // on next miss.
+    let _ = std::fs::remove_file(path);
+    anyhow::bail!(
+        "{name} hash mismatch: expected {expected}, got {actual}. \
+         File deleted to force re-download on next attempt."
+    )
+}
+
+// ──────────────────────────── tests ────────────────────────────
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use tempfile::tempdir;
+
+    #[test]
+    fn cache_root_lives_under_mvm_cache() {
+        let root = cache_root();
+        assert!(root.ends_with("builder-vm"));
+        assert!(root.parent().unwrap().ends_with("mvm"));
+    }
+
+    #[test]
+    fn installed_cache_dir_uses_version() {
+        let dir = installed_cache_dir();
+        let last = dir.file_name().unwrap().to_str().unwrap();
+        assert_eq!(last, format!("v{}", env!("CARGO_PKG_VERSION")));
+    }
+
+    #[test]
+    fn cache_key_changes_when_flake_changes() {
+        let dir = tempdir().unwrap();
+        std::fs::write(dir.path().join("flake.nix"), b"version 1").unwrap();
+        let key_a = cache_key_from_flake(dir.path()).unwrap();
+        std::fs::write(dir.path().join("flake.nix"), b"version 2").unwrap();
+        let key_b = cache_key_from_flake(dir.path()).unwrap();
+        assert_ne!(
+            key_a, key_b,
+            "key must change when flake.nix bytes change"
+        );
+        assert_eq!(key_a.len(), 64, "sha256 hex digest should be 64 chars");
+    }
+
+    #[test]
+    fn cache_key_changes_when_lock_appears() {
+        let dir = tempdir().unwrap();
+        std::fs::write(dir.path().join("flake.nix"), b"flake body").unwrap();
+        let key_without_lock = cache_key_from_flake(dir.path()).unwrap();
+        std::fs::write(dir.path().join("flake.lock"), b"{}").unwrap();
+        let key_with_lock = cache_key_from_flake(dir.path()).unwrap();
+        assert_ne!(
+            key_without_lock, key_with_lock,
+            "appearing flake.lock must invalidate the cache key (forces rebuild)"
+        );
+    }
+
+    #[test]
+    fn cache_key_missing_flake_nix_errors() {
+        let dir = tempdir().unwrap();
+        let err = cache_key_from_flake(dir.path()).unwrap_err();
+        let msg = format!("{err}");
+        assert!(
+            msg.contains("flake.nix"),
+            "error should mention flake.nix: {msg}"
+        );
+    }
+
+    #[test]
+    fn source_cache_dir_uses_hash_subdir() {
+        let dir = tempdir().unwrap();
+        std::fs::write(dir.path().join("flake.nix"), b"abc").unwrap();
+        let key = cache_key_from_flake(dir.path()).unwrap();
+        let cache = source_cache_dir(dir.path()).unwrap();
+        let last = cache.file_name().unwrap().to_str().unwrap();
+        assert_eq!(last, key);
+    }
+
+    #[test]
+    fn find_builder_vm_flake_finds_the_in_repo_flake() {
+        // This test runs from the workspace checkout — CARGO_MANIFEST_DIR
+        // resolves into <repo>/crates/mvm-cli, so the workspace root is
+        // <repo>, and <repo>/nix/images/builder-vm/flake.nix is what
+        // plan 72 W2 just landed.
+        let dir = find_builder_vm_flake().unwrap();
+        assert!(dir.ends_with("nix/images/builder-vm"));
+        assert!(dir.join("flake.nix").exists());
+    }
+
+    // 64-char hex strings used as fake sha256 digests in the tests
+    // below. sha256("") is the canonical empty-input vector; any other
+    // 64-char hex is just an opaque distinct value.
+    const SHA_EMPTY: &str = "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855";
+    const SHA_OTHER: &str = "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef";
+
+    #[test]
+    fn parse_checksums_handles_canonical_sha256sum_format() {
+        let body = format!("{SHA_EMPTY}  vmlinux\n{SHA_OTHER}  rootfs.ext4\n");
+        let map = parse_checksums(&body);
+        assert_eq!(map.len(), 2);
+        assert_eq!(map.get("vmlinux").unwrap(), SHA_EMPTY);
+        assert_eq!(map.get("rootfs.ext4").unwrap(), SHA_OTHER);
+    }
+
+    #[test]
+    fn parse_checksums_tolerates_binary_prefix_and_blank_lines() {
+        let body = format!("\n# this is a comment\n{SHA_EMPTY} *vmlinux\n\n");
+        let map = parse_checksums(&body);
+        assert_eq!(map.len(), 1);
+        assert!(map.contains_key("vmlinux"));
+    }
+
+    #[test]
+    fn parse_checksums_skips_malformed_lines() {
+        let body = format!("not-a-hash-at-all  vmlinux\n{SHA_EMPTY}  good\n");
+        let map = parse_checksums(&body);
+        assert_eq!(map.len(), 1);
+        assert!(map.contains_key("good"));
+        assert!(!map.contains_key("vmlinux"));
+    }
+
+    #[test]
+    fn sha256_of_file_matches_known_vector() {
+        let dir = tempdir().unwrap();
+        let path = dir.path().join("data");
+        std::fs::write(&path, b"abc").unwrap();
+        // sha256("abc") = ba7816bf8f01cfea414140de5dae2223b00361a396177a9cb410ff61f20015ad
+        assert_eq!(
+            sha256_of_file(&path).unwrap(),
+            "ba7816bf8f01cfea414140de5dae2223b00361a396177a9cb410ff61f20015ad"
+        );
+    }
+
+    #[test]
+    fn verify_artifact_hash_accepts_matching_hash() {
+        let dir = tempdir().unwrap();
+        let path = dir.path().join("data");
+        std::fs::write(&path, b"abc").unwrap();
+        let expected = "ba7816bf8f01cfea414140de5dae2223b00361a396177a9cb410ff61f20015ad".to_string();
+        verify_artifact_hash(&path, "data", Some(&expected)).unwrap();
+        assert!(path.exists(), "matching hash must not delete the file");
+    }
+
+    #[test]
+    fn verify_artifact_hash_rejects_mismatch_and_deletes() {
+        let dir = tempdir().unwrap();
+        let path = dir.path().join("data");
+        std::fs::write(&path, b"abc").unwrap();
+        let wrong = "0".repeat(64);
+        let err = verify_artifact_hash(&path, "data", Some(&wrong)).unwrap_err();
+        let msg = format!("{err}");
+        assert!(msg.contains("hash mismatch"), "want mismatch error: {msg}");
+        assert!(
+            !path.exists(),
+            "verify_artifact_hash must delete the poisoned file"
+        );
+    }
+
+    #[test]
+    fn verify_artifact_hash_errors_when_expected_missing() {
+        let dir = tempdir().unwrap();
+        let path = dir.path().join("data");
+        std::fs::write(&path, b"abc").unwrap();
+        let err = verify_artifact_hash(&path, "data", None).unwrap_err();
+        let msg = format!("{err}");
+        assert!(
+            msg.contains("did not list"),
+            "want 'did not list' message: {msg}"
+        );
+    }
+
+    #[cfg(feature = "backends-builder-vm-libkrun")]
+    #[test]
+    fn ensure_builder_vm_image_signals_cache_miss_for_source_checkout() {
+        // The cache dir under the contributor's real $HOME may or may
+        // not be populated (depends on whether they've built locally
+        // before). Force it to miss by redirecting `mvm_cache_dir()`
+        // at a temp dir for the duration of this test.
+        //
+        // We rely on `MVM_CACHE_DIR` env-var precedence in
+        // `mvm_core::config::mvm_cache_dir()`. `std::env::set_var` is
+        // process-global; since we're inside `cargo test` with the
+        // default thread-per-test runner, this can race with other
+        // tests that also touch MVM_CACHE_DIR. Lock the env-var
+        // section if you add another such test.
+        let scratch = tempdir().unwrap();
+        // Safety: this test is single-threaded with respect to its
+        // own MVM_CACHE_DIR usage; cargo test runs tests in parallel
+        // but no other test in this module touches the var.
+        unsafe {
+            std::env::set_var("MVM_CACHE_DIR", scratch.path());
+        }
+        let err = ensure_builder_vm_image().unwrap_err();
+        unsafe {
+            std::env::remove_var("MVM_CACHE_DIR");
+        }
+        let msg = format!("{err}");
+        assert!(
+            msg.contains("cache miss") || msg.contains("Cache miss"),
+            "error should mention the cache miss: {msg}"
+        );
+    }
+}

--- a/crates/mvm-cli/src/commands/env/apple_container.rs
+++ b/crates/mvm-cli/src/commands/env/apple_container.rs
@@ -498,28 +498,42 @@ pub(super) fn cmd_dev_apple_container_status() -> Result<()> {
 fn ensure_dev_image() -> Result<(String, String)> {
     let local_flake = find_dev_image_flake().ok();
 
+    // Plan 72 W5 cutover (partial). When the libkrun builder is on,
+    // try the Layer-1+Layer-2 libkrun path first; on error, warn and
+    // fall through to the microsandbox path. Once plan 57 W3 lands
+    // (libkrun boot validation), this branch always succeeds in a
+    // source checkout and the microsandbox path below gets deleted
+    // along with `backends-microsandbox` itself (W5 §"Feature flag
+    // polarity"). Today the branch is dead-on-arrival — every libkrun
+    // call returns `LibkrunUnavailable` — but the wiring lets a
+    // contributor flip the feature flag on and watch the path light
+    // up the moment 57 W3 merges.
+    #[cfg(feature = "backends-builder-vm-libkrun")]
+    if let Some(flake_dir) = &local_flake {
+        let out_dir = prepare_dev_image_out_dir()?;
+        ui::info(&format!(
+            "Building dev image via libkrun builder VM from: {flake_dir}"
+        ));
+        match try_build_dev_image_via_libkrun(flake_dir, &out_dir) {
+            Ok((kernel, rootfs)) => {
+                ui::success(&format!("Dev image ready at {out_dir} (libkrun)."));
+                return Ok((kernel, rootfs));
+            }
+            Err(e) => {
+                ui::warn(&format!(
+                    "libkrun-backed dev image build failed: {e}\n\
+                     Falling back to microsandbox. Plan 57 W3 (libkrun boot \
+                     validation) is the gating dep — until it lands, this fallback \
+                     is the load-bearing path."
+                ));
+                // Fall through to the microsandbox branch below.
+            }
+        }
+    }
+
     #[cfg(feature = "backends-microsandbox")]
     if let Some(flake_dir) = &local_flake {
-        let out_dir = format!("{}/dev/current", mvm_core::config::mvm_data_dir());
-        if let Some(parent) = std::path::Path::new(&out_dir).parent() {
-            std::fs::create_dir_all(parent)
-                .with_context(|| format!("creating dev-image out parent {}", parent.display()))?;
-        }
-        // Replace a stale symlink (e.g. the nix-darwin `linux-builder`
-        // legacy points `current` at a root-owned `/nix/store/…-mvm-dev`
-        // path) with a real, writable directory. `create_dir_all` is a
-        // no-op against an existing symlink, so without this the
-        // microsandbox bind-mount of `out_dir` lands on the read-only
-        // Nix store path and Apple Container fails with EACCES.
-        if std::path::Path::new(&out_dir)
-            .symlink_metadata()
-            .is_ok_and(|m| m.file_type().is_symlink())
-        {
-            std::fs::remove_file(&out_dir)
-                .with_context(|| format!("removing stale dev-image symlink at {out_dir}"))?;
-        }
-        std::fs::create_dir_all(&out_dir)
-            .with_context(|| format!("creating dev-image out dir {out_dir}"))?;
+        let out_dir = prepare_dev_image_out_dir()?;
 
         ui::info(&format!(
             "Building dev image via microsandbox builder VM from: {flake_dir}"
@@ -1695,6 +1709,112 @@ fn build_image_via_microsandbox(flake_dir: &str, out_dir: &str) -> Result<(Strin
     }
     if !std::path::Path::new(&rootfs).exists() {
         anyhow::bail!("builder VM did not produce rootfs.ext4 at {rootfs}");
+    }
+    Ok((kernel, rootfs))
+}
+
+/// Prepare the host-side directory the dev-image build's artifacts
+/// land in. Shared by the libkrun (plan 72 W5) and microsandbox (W7.x)
+/// branches of `ensure_dev_image` so the two paths cannot diverge on
+/// out-dir layout.
+///
+/// Replaces a stale symlink at `~/.mvm/dev/current` with a real
+/// writable directory. The legacy nix-darwin `linux-builder` path
+/// pointed `current` at a root-owned `/nix/store/...-mvm-dev` store
+/// path; `create_dir_all` is a no-op against an existing symlink, so
+/// without the unlink the bind-mount would land on the read-only
+/// store path and the builder VM would EACCES on artifact writes.
+#[cfg(any(feature = "backends-microsandbox", feature = "backends-builder-vm-libkrun"))]
+fn prepare_dev_image_out_dir() -> Result<String> {
+    let out_dir = format!("{}/dev/current", mvm_core::config::mvm_data_dir());
+    if let Some(parent) = std::path::Path::new(&out_dir).parent() {
+        std::fs::create_dir_all(parent)
+            .with_context(|| format!("creating dev-image out parent {}", parent.display()))?;
+    }
+    if std::path::Path::new(&out_dir)
+        .symlink_metadata()
+        .is_ok_and(|m| m.file_type().is_symlink())
+    {
+        std::fs::remove_file(&out_dir)
+            .with_context(|| format!("removing stale dev-image symlink at {out_dir}"))?;
+    }
+    std::fs::create_dir_all(&out_dir)
+        .with_context(|| format!("creating dev-image out dir {out_dir}"))?;
+    Ok(out_dir)
+}
+
+/// Build the Layer-2 dev image inside the Layer-1 libkrun builder VM.
+///
+/// Plan 72 W5 cutover entry-point. Resolves the Layer-1 builder VM
+/// image via `crate::builder_vm_image::ensure_builder_vm_image()`
+/// (cache lookup → Stage 0 microsandbox build under
+/// `--features contributor-bootstrap` → release download — see
+/// `mvm_cli::builder_vm_image`), then constructs a
+/// `LibkrunBuilderVm` with that image and runs the same nix build
+/// job the microsandbox path produces.
+///
+/// Until plan 57 W3 (libkrun boot validation) lands, the underlying
+/// `LibkrunBuilderVm::run_build` returns `LibkrunUnavailable` from
+/// every call — this helper exists so the wiring is in place and the
+/// branch in `ensure_dev_image` can flip the moment the boot path
+/// works. The error path in `ensure_dev_image` warns + falls through
+/// to microsandbox during the transition.
+#[cfg(feature = "backends-builder-vm-libkrun")]
+fn try_build_dev_image_via_libkrun(flake_dir: &str, out_dir: &str) -> Result<(String, String)> {
+    use mvm_build::builder_vm::{
+        BUILDER_GUEST_WORK_DIR, BuilderJob, BuilderMounts, host_system_linux,
+    };
+    use mvm_build::libkrun_builder::LibkrunBuilderVm;
+
+    let flake_src = std::path::PathBuf::from(flake_dir);
+    if !flake_src.exists() {
+        anyhow::bail!("flake dir does not exist: {flake_dir}");
+    }
+
+    // Derive workspace root + relative subdir, same as
+    // `build_image_via_microsandbox`. The libkrun path inherits the
+    // same `path:`-URL + workspace-mount-at-/work convention so the
+    // flake's `builtins.path { path = ../../..; }` resolves under
+    // `/work/...` inside the guest.
+    let workspace_root = flake_src
+        .parent()
+        .and_then(|p| p.parent())
+        .and_then(|p| p.parent())
+        .ok_or_else(|| {
+            anyhow::anyhow!("flake dir is not three levels deep in workspace: {flake_dir}")
+        })?
+        .to_path_buf();
+    let flake_rel = flake_src.strip_prefix(&workspace_root).map_err(|_| {
+        anyhow::anyhow!("flake dir not under derived workspace root: {flake_dir}")
+    })?;
+    let flake_rel_str = flake_rel.to_str().ok_or_else(|| {
+        anyhow::anyhow!("flake subpath has non-UTF-8 bytes: {flake_rel:?}")
+    })?;
+    let guest_flake_ref = format!("path:{BUILDER_GUEST_WORK_DIR}/{flake_rel_str}");
+
+    let job = BuilderJob {
+        flake_ref: guest_flake_ref,
+        attr_path: format!("packages.{}.default", host_system_linux()),
+    };
+    let mounts = BuilderMounts {
+        flake_src: workspace_root,
+        host_nix_store: None,
+        artifact_out: std::path::PathBuf::from(out_dir),
+    };
+
+    let image = crate::builder_vm_image::ensure_builder_vm_image()
+        .context("resolving Layer-1 builder VM image (plan 72 W5)")?;
+    let vm = LibkrunBuilderVm::new().with_image(image);
+    mvm_build::builder_vm::BuilderVm::run_build(&vm, &job, &mounts)
+        .map_err(|e| anyhow::anyhow!("libkrun builder VM run_build: {e}"))?;
+
+    let kernel = format!("{out_dir}/vmlinux");
+    let rootfs = format!("{out_dir}/rootfs.ext4");
+    if !std::path::Path::new(&kernel).exists() {
+        anyhow::bail!("libkrun builder VM did not produce vmlinux at {kernel}");
+    }
+    if !std::path::Path::new(&rootfs).exists() {
+        anyhow::bail!("libkrun builder VM did not produce rootfs.ext4 at {rootfs}");
     }
     Ok((kernel, rootfs))
 }

--- a/crates/mvm-cli/src/lib.rs
+++ b/crates/mvm-cli/src/lib.rs
@@ -2,6 +2,13 @@
 // Depends on mvm-core, mvm, mvm-build
 
 pub mod bootstrap;
+// plan 72 W5 — Layer-1 builder VM image acquisition (source-checkout
+// cache lookup + release-download stub). `find_builder_vm_flake` is
+// unconditional (useful from `mvmctl doctor` to surface "is this a
+// source checkout?"); the `ensure_builder_vm_image` resolver gates
+// behind `backends-builder-vm-libkrun` because it returns a
+// `BuilderVmImage` from that feature's gated module.
+pub mod builder_vm_image;
 pub mod commands;
 pub mod config_watcher;
 pub mod doctor;

--- a/nix/images/builder-vm/flake.nix
+++ b/nix/images/builder-vm/flake.nix
@@ -1,0 +1,265 @@
+{
+  description = "mvm builder VM image — Linux kernel + ext4 rootfs running mvm-builder-init as PID 1";
+
+  # ── What this flake is ────────────────────────────────────────────
+  #
+  # Plan 72 W2 / ADR-046. The "builder VM" is the Layer-1 artifact a
+  # contributor (or end user) boots to run `nix build` against the
+  # in-repo Layer-2 flakes (the dev shell, user `--flake` images, etc.).
+  # Boots under libkrun on macOS and Firecracker on Linux. The host
+  # attaches three virtio-fs shares (the workspace at /work, a writable
+  # /out, and a job dir with cmd.sh + result), one virtio-blk holding
+  # the persistent /nix store, and a virtio-net link. mvm-builder-init
+  # mounts everything, runs `/job/cmd.sh`, writes the exit code to
+  # `/job/result`, and powers the VM off.
+  #
+  # ── How it differs from the existing nix/images/builder/ flake ────
+  #
+  # The existing `nix/images/builder/` is the Layer-2 image users boot
+  # (and W5 of plan 72 renames it to `nix/images/dev-shell/` so the
+  # distinction is grep-obvious). This `nix/images/builder-vm/` flake
+  # is Layer 1: it's purpose-built to run `nix build`, never run by an
+  # end user directly.
+  #
+  # Differences:
+  #
+  #   • Slim package set — no iptables, no procps, no `less`. Just the
+  #     tools `mvm-builder-init` shells out to (busybox applets) plus
+  #     what `nix build` invokes (nix, git, curl, jq, gnumake, etc.).
+  #   • mvm-builder-init at /usr/local/bin/mvm-builder-init (via
+  #     mkGuest's package symlink hook). Kernel cmdline `init=`
+  #     points at that path; mkGuest's own /init script never runs.
+  #   • Sealed (`dev = false`) so mvm-guest-agent strips the do_exec
+  #     handler — the builder VM has no need for interactive RPCs.
+  #   • Emits `$out/cmdline` + `$out/manifest.json` alongside vmlinux
+  #     + rootfs.ext4 so the launcher reads the cmdline string from a
+  #     file instead of hard-coding it host-side.
+  #
+  # ── Acquisition rule (ADR-046 §"Two artifact layers") ────────────
+  #
+  # In a source checkout, `mvmctl dev up` resolves this flake locally
+  # via `find_builder_vm_flake()` (plan 72 W5) and builds it from
+  # source. Outside a source checkout, `mvmctl` downloads the matching
+  # release artifacts (vmlinux, rootfs.ext4, cmdline, manifest.json) +
+  # SHA-256 verifies via the manifest. The release workflow
+  # (`.github/workflows/release.yml`'s `builder-vm-image` job) is the
+  # source of those artifacts.
+  #
+  # ── Workspace staging (mirrors nix/images/builder/flake.nix) ──────
+  #
+  # Skip the `mvm.url = "path:../.."` flake input because path inputs
+  # can't be locked by content hash and the lock can't be rewritten on
+  # a read-only sandbox mount. Stage the workspace once via
+  # `builtins.path` (filtered to exclude target/, .git/, etc.) and
+  # `import` `nix/lib/default.nix` directly. Same shape `lib.<system>`
+  # would produce, no flake input → no lock validation failure.
+
+  inputs = {
+    nixpkgs.url = "github:NixOS/nixpkgs/nixos-25.11";
+    microvm = {
+      url = "github:microvm-nix/microvm.nix";
+      inputs.nixpkgs.follows = "nixpkgs";
+    };
+  };
+
+  outputs =
+    { self, nixpkgs, microvm, ... }:
+    let
+      systems = [ "aarch64-linux" "x86_64-linux" ];
+      forAllSystems = nixpkgs.lib.genAttrs systems;
+
+      # Kernel cmdline — emitted as `$out/cmdline` and consumed by the
+      # launcher (plan 72 W1). Centralising the string here means a
+      # cmdline tweak (e.g. enabling additional kernel debug output)
+      # is a one-file change rather than a host/guest contract update.
+      #
+      # `init=/usr/local/bin/mvm-builder-init` is where mkGuest puts
+      # `packages` binaries via its symlink hook. The plan-72 W2 spec
+      # text named `/sbin/mvm-builder-init`; using the existing
+      # mkGuest install path avoids extending mkGuest with a separate
+      # sbin-install branch just for this image.
+      kernelCmdline = "console=hvc0 root=/dev/vda ro rootfstype=ext4 init=/usr/local/bin/mvm-builder-init";
+
+      # See `nix/images/builder/flake.nix` for the rationale for env-var
+      # override; the same logic applies here — when the host's
+      # `LibkrunBuilderVm` runs `nix build` inside an in-flight builder
+      # VM (the bootstrap case), the workspace is bind-mounted at /work
+      # and `MVM_WORKSPACE_PATH=/work` redirects `builtins.path`. The
+      # path filter is the same conservative exclude list — none of
+      # those dirs are needed to build mvm-builder-init or the rootfs.
+      workspaceRoot =
+        let
+          envPath = builtins.getEnv "MVM_WORKSPACE_PATH";
+        in
+        if envPath != "" then /. + envPath else ../../..;
+
+      workspace = builtins.path {
+        path = workspaceRoot;
+        name = "mvm-workspace";
+        filter =
+          path: _type:
+          let
+            base = baseNameOf path;
+          in
+          !(builtins.elem base [
+            "target"
+            ".git"
+            "result"
+            "node_modules"
+            ".direnv"
+            ".cargo"
+            ".claude"
+            ".worktrees"
+          ])
+          && !(nixpkgs.lib.hasPrefix "result-" base);
+      };
+
+      libFor = import (workspace + "/nix/lib") {
+        inherit nixpkgs microvm;
+        mvmSrc = workspace;
+      };
+
+      # Slim builder-VM package set — only what `nix build` and
+      # `mvm-builder-init` actually exec. Compare with the dev image's
+      # `builderPackages` in `nix/images/builder/flake.nix` which adds
+      # `bashInteractive`, `which`, `less`, `iproute2`, `iptables`, and
+      # `procps` for interactive use. None of those are needed for an
+      # ephemeral build appliance — `iproute2` is replaced by busybox's
+      # `ip` applet (mvm-builder-init invokes `/bin/ip` directly).
+      builderVmPackages = pkgs: with pkgs; [
+        coreutils gnugrep gnused gawk findutils
+        nix git gnumake curl jq e2fsprogs util-linux
+      ];
+
+      mkBuilderVmImage = system:
+        let
+          pkgs = import nixpkgs { inherit system; };
+
+          # mvm-builder-init Rust binary, built from the workspace at
+          # `mvmSrc` via `nix/packages/mvm-builder-init.nix`. The
+          # closure lands in the rootfs's `/nix/store`; mkGuest's
+          # `packages` symlink loop puts the bin at
+          # `/usr/local/bin/mvm-builder-init` which the kernel
+          # cmdline's `init=` resolves to.
+          builderInitPkg = pkgs.callPackage ../../packages/mvm-builder-init.nix {
+            mvmSrc = workspace;
+          };
+
+          rootfs = (libFor { inherit system; }).mkGuest {
+            name = "mvm-builder";
+            # `command` entrypoint = sealed mode → mvm-guest-agent
+            # strips the do_exec handler. The entrypoint itself is dead
+            # code because the kernel cmdline's `init=` bypasses
+            # mkGuest's /init script; pointing it at the same binary
+            # is just defensive (a future caller booting without the
+            # cmdline override would still end up running the right
+            # thing).
+            entrypoint.command = [ "/usr/local/bin/mvm-builder-init" ];
+            packages = (builderVmPackages pkgs) ++ [ builderInitPkg ];
+            # The builder VM gets generous resources — `nix build` is
+            # CPU + memory heavy. The launcher (`LibkrunBuilderVm`)
+            # can override these via its own KrunContext shape.
+            vcpus = 4;
+            memory_mib = 4096;
+          };
+
+          kernelPkg = pkgs.linuxPackages.kernel;
+          kernelFile =
+            if pkgs.stdenv.hostPlatform.isAarch64
+            then "Image"
+            else "bzImage";
+        in
+        pkgs.runCommand "mvm-builder-vm-${system}"
+          {
+            passthru = {
+              inherit rootfs;
+              kernel = kernelPkg;
+              builderInit = builderInitPkg;
+              inherit (rootfs.passthru) mvm;
+              cmdline = kernelCmdline;
+            };
+            # Hard fail in CI if the rootfs balloons past plan 72 W2's
+            # 1.2 GiB uncompressed budget. Caught here so the release
+            # workflow never uploads an over-budget artifact.
+            rootfsMaxBytes = 1258291200; # 1.2 GiB
+          }
+          ''
+            mkdir -p $out
+
+            # Kernel — copy whichever Image/bzImage the arch produces
+            # to a stable `$out/vmlinux` name. The launcher consumes
+            # `<image>/vmlinux` regardless of arch.
+            if [ -f ${kernelPkg}/${kernelFile} ]; then
+              cp ${kernelPkg}/${kernelFile} $out/vmlinux
+            elif [ -f ${kernelPkg}/Image ]; then
+              cp ${kernelPkg}/Image $out/vmlinux
+            elif [ -f ${kernelPkg}/bzImage ]; then
+              cp ${kernelPkg}/bzImage $out/vmlinux
+            else
+              echo "kernel package ${kernelPkg} produced no Image/bzImage" >&2
+              ls -la ${kernelPkg} >&2
+              exit 1
+            fi
+
+            # Rootfs — mkGuest emits either a file directly or a
+            # directory containing *.img / *.ext4. Same handling as the
+            # dev image flake.
+            if [ -f ${rootfs} ]; then
+              cp ${rootfs} $out/rootfs.ext4
+            else
+              img=$(find ${rootfs} -maxdepth 1 -name '*.img' -o -name '*.ext4' | head -1)
+              if [ -z "$img" ]; then
+                echo "mkGuest output at ${rootfs} contains no .img or .ext4 file" >&2
+                ls -la ${rootfs} >&2
+                exit 1
+              fi
+              cp "$img" $out/rootfs.ext4
+            fi
+
+            chmod 0644 $out/vmlinux $out/rootfs.ext4
+
+            # Size budget check — fail the build before the artifact
+            # gets uploaded if we've blown past the 1.2 GiB target.
+            actual=$(${pkgs.coreutils}/bin/stat -c %s $out/rootfs.ext4)
+            if [ "$actual" -gt "$rootfsMaxBytes" ]; then
+              echo "FATAL: rootfs.ext4 size $actual bytes exceeds budget $rootfsMaxBytes bytes (plan 72 W2)" >&2
+              echo "       trim builderVmPackages or audit the closure to fit." >&2
+              exit 1
+            fi
+
+            # Kernel cmdline — emitted as a file so the launcher reads
+            # the string from a known location instead of hard-coding it.
+            printf '%s\n' '${kernelCmdline}' > $out/cmdline
+
+            # Manifest — sha256 + size for each artifact, plus the
+            # cmdline string for cross-checking. Read by
+            # `download_builder_vm_image` (plan 72 W5) to verify a
+            # release-downloaded image matches the manifest checksum.
+            kernel_sha=$(${pkgs.coreutils}/bin/sha256sum $out/vmlinux | ${pkgs.coreutils}/bin/cut -d' ' -f1)
+            rootfs_sha=$(${pkgs.coreutils}/bin/sha256sum $out/rootfs.ext4 | ${pkgs.coreutils}/bin/cut -d' ' -f1)
+            cmdline_sha=$(${pkgs.coreutils}/bin/sha256sum $out/cmdline | ${pkgs.coreutils}/bin/cut -d' ' -f1)
+            kernel_size=$(${pkgs.coreutils}/bin/stat -c %s $out/vmlinux)
+            rootfs_size=$(${pkgs.coreutils}/bin/stat -c %s $out/rootfs.ext4)
+            cmdline_size=$(${pkgs.coreutils}/bin/stat -c %s $out/cmdline)
+            cat > $out/manifest.json <<MANIFEST
+            {
+              "schema_version": 1,
+              "artifact": "mvm-builder-vm",
+              "system": "${system}",
+              "cmdline": "${kernelCmdline}",
+              "files": {
+                "vmlinux":     { "sha256": "$kernel_sha",  "size": $kernel_size },
+                "rootfs.ext4": { "sha256": "$rootfs_sha",  "size": $rootfs_size },
+                "cmdline":     { "sha256": "$cmdline_sha", "size": $cmdline_size }
+              }
+            }
+            MANIFEST
+            chmod 0644 $out/cmdline $out/manifest.json
+          '';
+    in
+    {
+      packages = forAllSystems (system: {
+        default = mkBuilderVmImage system;
+      });
+    };
+}

--- a/nix/packages/mvm-builder-init.nix
+++ b/nix/packages/mvm-builder-init.nix
@@ -1,0 +1,53 @@
+# `mvm-builder-init` — PID 1 for the builder microVM (plan 72 W3).
+#
+# Built from the workspace at `mvmSrc` via `rustPlatform.buildRustPackage`,
+# selecting only the `mvm-builder-init` crate's bin so the workspace's
+# heavy members (microsandbox, libkrun bindings, the full mvm CLI) don't
+# enter the closure. The resulting binary lands at `$out/bin/mvm-builder-init`
+# and is referenced from `nix/images/builder-vm/flake.nix` as one of the
+# `packages` mkGuest installs into the rootfs — mkGuest's symlink loop
+# puts it at `/usr/local/bin/mvm-builder-init`, which is the path the
+# kernel cmdline's `init=` points at.
+#
+# Mirrors `nix/packages/mvm-guest-agent.nix`. The two could share a
+# build-helper later but the size/feature flags differ enough that
+# duplicating the small `buildRustPackage` call is cheaper than the
+# abstraction.
+
+{ pkgs
+, lib
+, mvmSrc
+}:
+
+pkgs.rustPlatform.buildRustPackage {
+  pname = "mvm-builder-init";
+  version = "0.14.0";
+
+  src = mvmSrc;
+
+  # Workspace lockfile is the source of truth — same as the guest-agent
+  # build. `buildRustPackage` vendors the closure even though we only
+  # build the one crate; unused deps compile zero code.
+  cargoLock.lockFile = mvmSrc + "/Cargo.lock";
+
+  # Single bin. The crate's main.rs is `#![cfg]`-gated to a Linux-only
+  # implementation; on macOS it compiles to a stub that exits 1. Inside
+  # this builder we always target Linux so the real impl is what gets
+  # built.
+  cargoBuildFlags = [
+    "--package" "mvm-builder-init"
+    "--bin" "mvm-builder-init"
+  ];
+
+  # Pure-logic unit tests (exit-status decoding, virtio-fs tag contract)
+  # run by the workspace's `cargo test` lane. Skip here so the package
+  # build stays focused on the binary itself.
+  doCheck = false;
+
+  meta = with lib; {
+    description = "PID 1 for the mvm builder microVM (plan 72)";
+    homepage = "https://github.com/tinylabscom/mvm";
+    license = licenses.asl20;
+    platforms = platforms.linux;
+  };
+}


### PR DESCRIPTION
## Summary

Plan 72 / ADR-046: replace `MicrosandboxBuilderVm` on the user-facing build path with a libkrun-backed `LibkrunBuilderVm`. This PR lands the host- and guest-side scaffolding for **W1 through W5 (download path)**. The boot-and-validate path itself is gated on plan 57 W3.

- **W2** — `nix/images/builder-vm/` flake. Slim package set, bakes `mvm-builder-init` as PID 1, emits `vmlinux + rootfs.ext4 + cmdline + manifest.json`. New `builder-vm-image` release workflow job uploads the artifacts (aarch64 + x86_64).
- **W3** — `crates/mvm-builder-init`. Linux-only Rust PID 1: mounts pseudofs, formats/seeds/binds `/nix-store → /nix`, mounts `mvm-{work,out,job}` virtio-fs shares, brings up eth0 via udhcpc, runs `/job/cmd.sh`, writes `/job/result`, `RB_POWER_OFF`. macOS cfg-stub keeps `cargo build --workspace` working.
- **W1** — `crates/mvm-build/src/libkrun_builder.rs`. `LibkrunBuilderVm` impls `BuilderVm` trait. `host_can_build` returns `false` (CLAUDE.md §"Host Nix is never used by mvmctl"). `run_build` validates mounts, stages `cmd.sh`, sparse-allocates the persistent `/nix` store image, attempts `mvm_libkrun::start` (returns `LibkrunUnavailable` until plan 57 W3). New `BuilderVmError::{LibkrunUnavailable, BuilderImageMissing}`.
- **W4** — `with_offline()` sets `NIX_CONFIG="substituters ="` for air-gapped builds. `ConsoleCapture` trait with `Println` + `Recording` impls; plan 57 W3 will replace the placeholder line emission with real per-line callbacks.
- **W5 prep** — `BuilderVmImage` is now `pub` with `load_from_dir()`. New `image: Option<BuilderVmImage>` field + `with_image()` setter for DI from `mvm-cli`. `cache_dir()` delegates to `mvm_core::config::mvm_cache_dir()` so libkrun builder shares the cache-precedence rule with every other mvm cache consumer.
- **W5 download** — `mvm_cli::builder_vm_image::{find_builder_vm_flake, cache_key_from_flake, ensure_builder_vm_image, download_builder_vm_image, parse_checksums, sha256_of_file, verify_artifact_hash}`. Cache key hashes `sha256(flake.nix || \0 || flake.lock)` so any contributor edit forces a rebuild. Installed-binary cache miss fetches the four release artifacts and SHA-256-verifies via the per-arch checksums file. `MVM_SKIP_HASH_VERIFY=1` honored per ADR-002 §W5.1.

Feature wiring: new `backends-builder-vm-libkrun` feature forwards through `mvmctl → mvm-cli → mvm-build` (default-off; flips to default in plan 72 W5's cutover once plan 57 W3 lands).

## Still pending on plan 72

- Stage 0 bootstrap (`--features contributor-bootstrap`) — source-checkout cache-miss path
- `ensure_dev_image` reshape (Layer-1 + Layer-2 unification)
- `backends-microsandbox` → `contributor-bootstrap` rename
- Live tests `dev_up_libkrun.rs` / `dev_up_contributor_bootstrap.rs` (need plan 57 W3)
- W6 hygiene (8 weeks after W5 ships)

## Test plan

- [x] `cargo build --workspace` (default features)
- [x] `cargo build --workspace --features backends-builder-vm-libkrun`
- [x] `cargo test -p mvm-build --features backends-builder-vm-libkrun --lib libkrun_builder` → 23 passing
- [x] `cargo test -p mvm-cli --features backends-builder-vm-libkrun --lib builder_vm_image` → 15 passing
- [x] `cargo clippy --workspace --all-targets [--features backends-builder-vm-libkrun] -- -D warnings` → clean under both feature combos
- [x] `mvm-builder-init` cross-checked + clippy'd on `x86_64-unknown-linux-gnu` (Linux runner does the actual link in CI)
- [ ] qemu smoke test (`tests/builder_init_smoke.rs`) — stub `#[ignore]`'d, full fixture lands with plan 72 W4 alongside vsock/network plumbing
- [ ] End-to-end `mvmctl dev up` against builder VM — gated on plan 57 W3

🤖 Generated with [Claude Code](https://claude.com/claude-code)