### PR TITLE
perf(libkrun): faster mvmctl stop — SIGTERM handler + 2s SIGKILL fallback

### DIFF
--- a/crates/mvm-backend/src/libkrun.rs
+++ b/crates/mvm-backend/src/libkrun.rs
@@ -44,8 +44,16 @@ pub struct LibkrunBackend;
 const PID_FILE_TIMEOUT: Duration = Duration::from_secs(5);
 
 /// How long [`LibkrunBackend::stop`] waits after `SIGTERM` before
-/// escalating to `SIGKILL`.
-const STOP_TIMEOUT: Duration = Duration::from_secs(5);
+/// escalating to `SIGKILL`. Tight because libkrun's signal handling
+/// under `krun_start_enter` is empirically unreliable — when the
+/// supervisor is spawned via `std::process::Command` (the production
+/// `mvmctl up` path), SIGTERM often doesn't reach the in-supervisor
+/// `sigaction` handler before we escalate. The in-supervisor handler
+/// (see `mvm_libkrun::install_shutdown_handler`) still helps the
+/// shell-stop case where SIGTERM is delivered cleanly (~200 ms); in
+/// the always-escalate cargo-spawn / launchd path a shorter timeout
+/// means `mvmctl stop` returns in 2 s instead of 5 s.
+const STOP_TIMEOUT: Duration = Duration::from_secs(2);
 
 /// Default kernel cmdline for libkrun-launched guests.
 /// `console=hvc0` matches libkrun's virtio-console wiring (plan 57 W3

--- a/crates/mvm-libkrun/src/lib.rs
+++ b/crates/mvm-libkrun/src/lib.rs
@@ -444,8 +444,67 @@ pub fn start_enter(ctx: &KrunContext) -> Result<std::convert::Infallible, Error>
     #[cfg(feature = "libkrun-sys")]
     {
         let krun = configure(ctx)?;
+        install_shutdown_handler(&krun)?;
         krun.start_enter()
     }
+}
+
+/// Best-effort SIGTERM handler that drops the supervisor process
+/// immediately, so `mvmctl stop` / `kill -TERM <pid>` *may* reap it
+/// without the 5-second SIGKILL escalation `LibkrunBackend::stop`
+/// would otherwise hit.
+///
+/// "Best-effort" because libkrun's signal-mask behavior under
+/// `krun_start_enter` is empirically inconsistent: the same binary
+/// killed manually from a shell exits in ~100 ms, but when spawned
+/// by `LibkrunBackend::start` (via `std::process::Command`) the
+/// handler installed here doesn't always run before
+/// `LibkrunBackend::stop` falls back to `SIGKILL` at 5 s. The
+/// inconsistency seems to come from libkrun blocking SIGTERM on
+/// every thread mid-`start_enter`, so the kernel can't always find
+/// a thread to deliver to. Installing the handler is still net
+/// positive: in the manual-stop path it lets the process exit
+/// cleanly, and in the spawned-by-LibkrunBackend path it's a no-op
+/// that doesn't *hurt*.
+///
+/// More robust options investigated and rejected:
+/// - `krun_get_shutdown_eventfd` returns a valid fd on Homebrew's
+///   libkrun 1.17.4 but the header docs it as gated on
+///   `krun_start_event` (libkrun-efi only); writes to the fd vanish
+///   under the `start_enter` entry point we use.
+/// - A dedicated `sigwait` thread spawned before `start_enter`
+///   makes `krun_start_enter` itself return `-EINVAL` (rc -22).
+///   libkrun appears to want exclusive control of the process's
+///   signal mask. Don't do that.
+#[cfg(feature = "libkrun-sys")]
+fn install_shutdown_handler(_krun: &sys::Context) -> Result<(), Error> {
+    extern "C" fn handle_sigterm(_sig: libc::c_int) {
+        // SAFETY: `_exit` is async-signal-safe per POSIX
+        // (signal-safety(7)). Status 143 = 128 + SIGTERM, the
+        // conventional shell convention for "killed by SIGTERM".
+        unsafe {
+            libc::_exit(143);
+        }
+    }
+
+    // SAFETY: `sigaction` is async-signal-safe and we pass a
+    // properly-zeroed `sigaction` struct. The handler we install is
+    // itself signal-safe (single `_exit` call).
+    unsafe {
+        let mut sa: libc::sigaction = std::mem::zeroed();
+        sa.sa_sigaction = handle_sigterm as *const () as usize;
+        sa.sa_flags = 0;
+        libc::sigemptyset(&mut sa.sa_mask);
+        if libc::sigaction(libc::SIGTERM, &sa, std::ptr::null_mut()) != 0 {
+            return Err(Error::Io {
+                context: format!(
+                    "sigaction(SIGTERM) failed: {}",
+                    std::io::Error::last_os_error()
+                ),
+            });
+        }
+    }
+    Ok(())
 }
 
 /// Configuration consumed by [`run_supervisor`] — the JSON shape that


### PR DESCRIPTION
## Summary

Cuts `mvmctl stop --hypervisor libkrun` from a 5s floor to either ~200ms (shell-stop path, SIGTERM honored) or 2s (cargo/launchd-spawn path, SIGKILL fallback). Plan 57 W4.3's e2e test runtime drops from 5.4s → 2.6s in the always-escalate case.

### Why two paths

The supervisor (`mvm_libkrun::run_supervisor → start_enter`) now installs a `sigaction(SIGTERM)` handler before calling `krun_start_enter`. The handler is signal-safe (single `_exit(143)` call); on signal delivery the process terminates immediately, parent `LibkrunBackend` sees the supervisor exit within one 100ms poll cycle.

That works cleanly **when the supervisor is launched from an interactive shell** — manual verification against `~/.mvm/dev/current/` artifacts: `kill -TERM <pid>` exits the supervisor in ~200ms.

It does **not** work reliably **when the supervisor is spawned via `std::process::Command::spawn`** (the `LibkrunBackend::start` path, exercised by the W4.3 cargo test and `mvmctl up` in production). Empirically, SIGTERM delivered to the spawned supervisor doesn't reach the installed handler before the parent escalates; libkrun's internal signal handling appears to differ between shell-spawn and Command-spawn contexts.

Investigated and rejected:
- **Dedicated `sigwait` handler thread**: makes `krun_start_enter` return rc -22 (EINVAL). libkrun wants exclusive control of the process signal mask.
- **`pthread_sigmask(SIG_UNBLOCK, SIGTERM)` after `sigaction`**: no effect; SIGTERM still queues without firing the handler in Command-spawn context.
- **`krun_get_shutdown_eventfd`**: returns a valid fd against generic libkrun 1.17.4 but writes vanish under `start_enter` — the header gates it on a `krun_start_event` entry point that doesn't exist in the generic Homebrew build.

Pragmatic answer is **both**:

1. Install the sigaction handler regardless. When SIGTERM *does* reach it (shell-stop), shutdown is ~200ms instead of 5s.
2. Reduce `STOP_TIMEOUT` from 5s to 2s. When SIGTERM doesn't reach the handler (cargo/Command-spawn), SIGKILL escalation happens 3s sooner.

User-visible: `mvmctl stop` returns in 2s worst case, ~200ms best case.

## Test plan

- [x] Manual shell-spawn: `kill -TERM <pid>` → supervisor exits in **200ms** (measured with a 100ms-resolution poll loop, two consecutive runs).
- [x] Cargo-spawn: `cargo test -p mvm-backend --test libkrun_lifecycle_e2e -- --ignored` finishes in **2.56s** (was 5.4s).
- [x] `cargo clippy -p mvm-libkrun --features libkrun-sys --all-targets -- -D warnings` — clean.
- [x] `cargo clippy -p mvm-backend --all-targets -- -D warnings` — clean.
- [x] `cargo test -p mvm-backend libkrun` — 12/12 pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)