### PR TITLE
feat(builder-vm): plan 72 W5 — find_builder_vm_flake + bootstrap_builder_vm_image

### DIFF
--- a/crates/mvm-build/src/builder_vm.rs
+++ b/crates/mvm-build/src/builder_vm.rs
@@ -624,6 +624,11 @@ cp -L "$src/rootfs.ext4" "$out/rootfs.ext4"
 [ -f "$src/initrd" ] && cp -L "$src/initrd" "$out/initrd"
 [ -f "$src/initrd.cpio.gz" ] && cp -L "$src/initrd.cpio.gz" "$out/initrd.cpio.gz"
 [ -f "$src/mvm-meta.json" ] && cp -L "$src/mvm-meta.json" "$out/mvm-meta.json"
+# Plan 72 W2 outputs: builder-vm flake emits cmdline.txt +
+# manifest.json alongside vmlinux + rootfs.ext4. dev-shell flakes
+# don't, so the test is a no-op there.
+[ -f "$src/cmdline.txt" ] && cp -L "$src/cmdline.txt" "$out/cmdline.txt"
+[ -f "$src/manifest.json" ] && cp -L "$src/manifest.json" "$out/manifest.json"
 chmod -R u+w "$out"
 "#,
         out = shell_quote_arg(BUILDER_GUEST_OUT_DIR),

--- a/crates/mvm-cli/src/commands/env/apple_container.rs
+++ b/crates/mvm-cli/src/commands/env/apple_container.rs
@@ -1726,6 +1726,122 @@ fn find_dev_image_flake() -> Result<String> {
     anyhow::bail!("Dev image flake not found. Expected at nix/images/builder/flake.nix")
 }
 
+/// Plan 72 W5 sibling of [`find_dev_image_flake`] — locate the
+/// **builder VM** flake at `nix/images/builder-vm/flake.nix`.
+///
+/// Distinct from the dev-shell image flake at `nix/images/builder/`:
+/// the builder-vm flake produces a small (busybox + nix + tools)
+/// rootfs whose closure fits in microsandbox's 4 GiB overlay, so
+/// Stage 0 (`build_image_via_microsandbox`) can build it without
+/// hitting the disk-full ceiling that motivated the whole Plan 72
+/// migration. The dev-shell flake includes rustc + the workspace's
+/// cargo closure, which does not fit and is what
+/// `LibkrunBuilderVm` (Plan 72 W4) handles via virtio-blk-backed
+/// `/nix` instead.
+///
+/// `dead_code` allow: today the only non-test caller is
+/// [`bootstrap_builder_vm_image`], which itself isn't wired to
+/// `ensure_dev_image` yet (that's the W5.B dispatch swap). Once
+/// the swap lands, the lint clears naturally.
+#[allow(dead_code)]
+fn find_builder_vm_flake() -> Result<String> {
+    let manifest_dir = env!("CARGO_MANIFEST_DIR");
+    let workspace_root = std::path::Path::new(manifest_dir)
+        .parent()
+        .and_then(|p| p.parent())
+        .ok_or_else(|| anyhow::anyhow!("Cannot find workspace root"))?;
+
+    let candidate = workspace_root.join("nix").join("images").join("builder-vm");
+    if candidate.join("flake.nix").exists() {
+        return Ok(candidate.to_str().unwrap_or(".").to_string());
+    }
+
+    anyhow::bail!(
+        "Builder VM flake not found. Expected at nix/images/builder-vm/flake.nix \
+         (Plan 72 W2 artifact)."
+    )
+}
+
+/// Plan 72 W5 — populate `~/.cache/mvm/builder-vm/<arch>/` with
+/// `vmlinux` + `rootfs.ext4` + `cmdline.txt` + `manifest.json`
+/// from the in-repo W2 flake, using Stage 0 (microsandbox +
+/// `nixos/nix:2.24.10`) as the bootstrap.
+///
+/// `LibkrunBuilderVm::run_build` reads from this cache; this
+/// function is what fills it. The two-layer artifact rule from
+/// ADR-046 in action:
+///
+/// - Layer 1 (this function): build the **builder VM image**
+///   via microsandbox (small closure, fits 4 GiB overlay).
+/// - Layer 2 (a future `ensure_dev_image` rework): use the
+///   Layer 1 image plus libkrun to build the **dev shell
+///   image** with the large rustc closure.
+///
+/// Source-checkout-only by design — `find_builder_vm_flake()`
+/// must succeed. Installed binaries take the download-prebuilt
+/// path (deferred to a Plan 72 W2 release-workflow follow-up).
+///
+/// Requires the `contributor-bootstrap` feature for the
+/// microsandbox path. When the feature is off, returns a clear
+/// error pointing at the rebuild command.
+///
+/// `dead_code` allow: W5.B (next PR) wires this into
+/// `ensure_dev_image` so source-checkout `mvmctl dev up` invokes
+/// it on cache miss. Today the function exists, has tests, and
+/// is callable directly — but no production code path reaches it,
+/// hence the lint silencing.
+#[allow(dead_code)]
+fn bootstrap_builder_vm_image() -> Result<()> {
+    let flake_dir = find_builder_vm_flake().with_context(|| {
+        "bootstrap requires a source checkout of mvm (the builder-vm flake is \
+         only present in-repo; for installed binaries the prebuilt download path \
+         from Plan 72's release-workflow follow-up will populate the cache instead)"
+    })?;
+
+    let arch = if cfg!(target_arch = "aarch64") {
+        "aarch64"
+    } else {
+        "x86_64"
+    };
+    let out_dir = format!("{}/builder-vm/{arch}", mvm_core::config::mvm_cache_dir());
+    std::fs::create_dir_all(&out_dir)
+        .with_context(|| format!("creating builder-vm cache dir {out_dir}"))?;
+
+    #[cfg(feature = "contributor-bootstrap")]
+    {
+        ui::info(&format!(
+            "Bootstrapping builder VM image via Stage 0 (microsandbox + nixos/nix:2.24.10) \
+             from: {flake_dir}"
+        ));
+        match build_image_via_microsandbox(&flake_dir, &out_dir) {
+            Ok((kernel, rootfs)) => {
+                ui::success(&format!(
+                    "Builder VM image ready at {out_dir} (kernel={kernel}, rootfs={rootfs})."
+                ));
+                Ok(())
+            }
+            Err(e) => Err(anyhow::anyhow!(
+                "Stage 0 microsandbox build of the builder-vm flake at {flake_dir} failed: {e}\n\
+                 The builder-vm rootfs closure is meant to fit in microsandbox's 4 GiB overlay \
+                 (no rustc, no cargo crates — see Plan 72 §W2). If it doesn't, the package list \
+                 in nix/images/builder-vm/flake.nix needs trimming."
+            )),
+        }
+    }
+
+    #[cfg(not(feature = "contributor-bootstrap"))]
+    {
+        let _ = flake_dir;
+        let _ = out_dir;
+        anyhow::bail!(
+            "Builder VM Stage 0 bootstrap requires the `contributor-bootstrap` feature. \
+             Rebuild with `cargo install --path . --features contributor-bootstrap` \
+             (source-checkout contributors) or wait for Plan 72's release-workflow \
+             follow-up that publishes the builder-vm prebuilt."
+        );
+    }
+}
+
 /// Locate the bundled `nix/images/default-tenant/` flake.
 ///
 /// This is the fallback used by image-taking commands (`mvmctl exec`,
@@ -1967,6 +2083,51 @@ mod hash_verify_tests {
         assert!(
             err.contains("did not include") && err.contains("dev-vmlinux-x86_64"),
             "expected missing-entry error, got: {err}"
+        );
+    }
+}
+
+#[cfg(test)]
+mod builder_vm_bootstrap_tests {
+    //! Plan 72 W5 — `find_builder_vm_flake` + `bootstrap_builder_vm_image`.
+    use super::*;
+
+    #[test]
+    fn find_builder_vm_flake_resolves_to_in_repo_path() {
+        // From a source checkout, the helper must find the W2
+        // flake at <workspace>/nix/images/builder-vm/flake.nix.
+        // `env!("CARGO_MANIFEST_DIR")` is baked at compile time
+        // and points at the workspace's mvm-cli crate dir, so
+        // this assertion is robust across `cargo test` and
+        // `cargo nextest`.
+        let path = find_builder_vm_flake().expect("expected builder-vm flake present in repo");
+        assert!(
+            path.ends_with("nix/images/builder-vm"),
+            "unexpected flake path: {path}"
+        );
+        // The flake file itself must be readable.
+        assert!(
+            std::path::Path::new(&path).join("flake.nix").is_file(),
+            "flake.nix missing under {path}"
+        );
+    }
+
+    /// When the `contributor-bootstrap` feature is OFF, Stage 0
+    /// has no driver and the bootstrap must error with the
+    /// rebuild hint rather than silently no-op.
+    #[cfg(not(feature = "contributor-bootstrap"))]
+    #[test]
+    fn bootstrap_builder_vm_image_errors_without_contributor_bootstrap() {
+        let err = bootstrap_builder_vm_image()
+            .expect_err("expected an error when contributor-bootstrap is off")
+            .to_string();
+        assert!(
+            err.contains("contributor-bootstrap"),
+            "error should mention the missing feature: {err}"
+        );
+        assert!(
+            err.contains("Rebuild") || err.contains("--features"),
+            "error should hint at the rebuild command: {err}"
         );
     }
 }


### PR DESCRIPTION
## Summary

Plan 72 W5 first half — Stage 0 bootstrap infrastructure that populates \`~/.cache/mvm/builder-vm/<arch>/\` from the in-repo W2 flake. Sets the stage for the W5.B dispatch swap in \`ensure_dev_image\` (next PR) without touching the user-facing control flow yet.

## Changes

- **\`find_builder_vm_flake()\`** in \`mvm-cli/.../apple_container.rs\` — sibling of \`find_dev_image_flake\`. Resolves the in-repo W2 flake at \`nix/images/builder-vm/flake.nix\`.

- **\`bootstrap_builder_vm_image()\`** — orchestrates Stage 0 of the two-layer artifact rule from ADR-046:

  | Step | What |
  |------|------|
  | 1 | Locate the in-repo builder-vm flake (source-checkout only) |
  | 2 | Allocate \`~/.cache/mvm/builder-vm/<arch>/\` |
  | 3 | Invoke \`build_image_via_microsandbox(flake_dir, out_dir)\` — the same helper that builds the dev-shell flake today, but pointed at the much smaller builder-vm rootfs closure (busybox + nix + tools, no rustc) that fits in microsandbox's 4 GiB overlay |
  | 4 | vmlinux + rootfs.ext4 + cmdline.txt + manifest.json land in the cache where \`LibkrunBuilderVm\` (Plan 72 W4) reads them |

  Requires \`--features contributor-bootstrap\`. Without it, returns an actionable error pointing at the rebuild command.

- **microsandbox copy script extension** in \`mvm-build/src/builder_vm.rs\` — also copies \`cmdline.txt\` and \`manifest.json\` from the Nix store output to \`/out\`. Dev-shell flake doesn't produce those files (no-op there); the builder-vm flake produces both and they're load-bearing for \`LibkrunBuilderVm\`.

## What this PR does NOT do

- **Swap \`ensure_dev_image\` dispatch** to use \`LibkrunBuilderVm\`. That's W5.B / W5.C — wiring the dev-up call site to: cache check → bootstrap on empty → \`LibkrunBuilderVm\` builds the dev-shell flake. Real engineering with real failure modes; its own PR.
- **\`mvmctl builder-vm bootstrap\` CLI subcommand.** Touches Clap parsing + audit envelope wiring. Defer to a small follow-up.

## Tests (2 new)

- \`find_builder_vm_flake_resolves_to_in_repo_path\`
- \`bootstrap_builder_vm_image_errors_without_contributor_bootstrap\` (off-feature build → rebuild hint)

\`#[allow(dead_code)]\` on the two new functions for now — neither has a production caller yet (W5.B wires them); both are test-reachable. Lint clears once the dispatch swap lands.

## Verified locally

\`\`\`
cargo check  -p mvm-cli --all-targets                                          ✅
cargo check  -p mvm-cli --features contributor-bootstrap --all-targets        ✅
cargo test   -p mvm-cli --lib builder_vm_bootstrap
  test result: ok. 2 passed; 0 failed.
cargo clippy -p mvm-cli --all-targets -- -D warnings                          ✅
cargo fmt    --all -- --check                                                 ✅
\`\`\`

🤖 Generated with [Claude Code](https://claude.com/claude-code)