### PR TITLE
chore(builder-vm): plan 72 W6 hygiene — drop LibkrunNotShipped + refresh stale module doc

### DIFF
--- a/crates/mvm-build/src/builder_vm.rs
+++ b/crates/mvm-build/src/builder_vm.rs
@@ -250,17 +250,6 @@ pub enum BuilderVmError {
     /// extraction-dir issue).
     #[error("extracting artifacts from builder sandbox: {0}")]
     ExtractionFailed(String),
-
-    /// The libkrun builder VM is scaffolded (Plan 72 W1) but the
-    /// actual VM launch hasn't shipped yet. Plan 72 W2–W4 fill this
-    /// in. Distinct from [`Self::NotYetImplemented`] (which is the
-    /// microsandbox path's pre-Sprint-50 sentinel) so callers can
-    /// match precisely on which side is incomplete.
-    #[error(
-        "libkrun builder VM launch is scaffolded but not implemented yet; \
-         see specs/plans/72-builder-vm-via-libkrun.md §W2-W4"
-    )]
-    LibkrunNotShipped,
 }
 
 /// Stub implementation. Every method returns

--- a/crates/mvm-build/src/libkrun_builder.rs
+++ b/crates/mvm-build/src/libkrun_builder.rs
@@ -1,52 +1,59 @@
-//! Libkrun-backed builder VM (Plan 72 W1 scaffolding).
+//! Libkrun-backed builder VM.
 //!
 //! Plan 72 ADR-046 chose libkrun-direct (on macOS Apple Silicon /
 //! Intel) and Firecracker (on Linux) as the replacement for the
-//! microsandbox-backed builder VM. This module is the libkrun half.
+//! microsandbox-backed builder VM. This module is the libkrun half;
+//! W1 → W4 of the migration shipped the launcher end-to-end.
 //!
-//! ## Status — Plan 72 W1 (scaffolding)
+//! ## What `LibkrunBuilderVm` does
 //!
-//! What W1 ships:
+//! Given a populated builder VM image cache and `mvm-libkrun-supervisor`
+//! on PATH, `run_build` runs a one-shot `nix build` against the
+//! caller's `BuilderJob` and returns `BuilderArtifacts`. The
+//! pipeline (in [`BuilderVm::run_build`]):
 //!
-//! - The `LibkrunBuilderVm` struct + `BuilderVm` trait impl shape.
-//! - Resource defaults matching Plan 72 §W1 (4 vCPU, 4 GiB RAM,
-//!   64 GiB sparse virtio-blk for the persistent `/nix` store).
-//! - Mount-validation (existence, UTF-8 representability for the
-//!   libkrun C API boundary, artifact-dir creation).
-//! - Host probe (`host_can_build`) that consults libkrun's
-//!   `is_available()` so callers can sanity-check the environment
-//!   before invoking `run_build`.
-//!
-//! What W1 does NOT ship (deferred to W2–W4):
-//!
-//! - The builder VM image acquisition (W2 — `nix/images/builder-vm/`
-//!   flake + CI release artifact + `~/.cache/mvm/builder-vm/<arch>/`
-//!   cache).
-//! - The `mvm-builder-init` PID-1 binary (W3).
-//! - virtio-fs / virtio-blk / vsock plumbing for `/work`, `/out`,
-//!   `/job`, `/nix-store` mounts (W4).
-//! - The actual `mvm_libkrun::start_enter` invocation +
-//!   power-off detection + job-result extraction (W4 + W5 cutover).
-//!
-//! Until W2–W4 land, `run_build` returns
-//! [`BuilderVmError::LibkrunNotShipped`] after validation, so callers
-//! can wire dispatch and exercise the error path in tests; the
-//! data-plane fills in incrementally.
+//! 1. Validate mounts + job (`validate_mounts`, `validate_job`).
+//! 2. Check `mvm_libkrun::is_available()` — bail with install hint
+//!    if libkrun isn't on the host.
+//! 3. Locate `mvm-libkrun-supervisor` (env override / next-to-exe /
+//!    PATH).
+//! 4. Read the builder VM image from
+//!    `~/.cache/mvm/builder-vm/<arch>/` — vmlinux + rootfs.ext4 +
+//!    cmdline.txt + manifest.json, the shape Plan 72 W2's flake
+//!    emits. Populated by Plan 72 W5's `bootstrap_builder_vm_image`
+//!    (`mvm-cli::commands::env::apple_container`).
+//! 5. Allocate / reuse the persistent `/nix-store-<arch>.img`
+//!    sparse virtio-blk image (64 GiB cap by default; idempotent
+//!    across invocations so the warm Nix store survives).
+//! 6. Stage `<job_dir>/cmd.sh` with the shell-escaped flake_ref +
+//!    attr_path, plus the canonical `nix build` invocation.
+//! 7. Build a `KrunContext`: kernel + rootfs + cmdline + per-VM
+//!    vsock dir + virtio-blk (Nix store) + virtio-fs (work / out /
+//!    job).
+//! 8. Spawn `mvm-libkrun-supervisor`, pipe the `SupervisorConfig`
+//!    JSON to stdin, **wait** for it to exit (unlike
+//!    `LibkrunBackend::start` which returns after the PID file
+//!    appears — the builder is a one-shot).
+//! 9. Read `<job_dir>/result` (JSON: `{exit_code, stderr_tail}`)
+//!    that `mvm-builder-init` wrote.
+//! 10. Validate the artifact dir now contains `rootfs.ext4` (and
+//!     optionally `vmlinux`); return `BuilderArtifacts`.
 //!
 //! ## Feature gate
 //!
-//! Gated behind `backends-builder-vm-libkrun`. Default-off until W5's
-//! cutover flips the polarity. Library consumers that don't need the
-//! libkrun builder build with `default-features = false`.
+//! Gated behind `backends-builder-vm-libkrun`. Default-off until
+//! Plan 72 W5.B / W5.C cutover flips `ensure_dev_image` to dispatch
+//! through `LibkrunBuilderVm`. Library consumers that don't need
+//! the libkrun builder build with `default-features = false`.
 //!
 //! ## Not the runtime backend
 //!
 //! `LibkrunBackend` (`crates/mvm-backend/src/libkrun.rs`) is for
-//! running user microVMs; this module is for building them. The two
-//! share `mvm-libkrun`'s FFI but compose differently — the builder
-//! mounts a workspace + persistent `/nix`-store disk and runs a
-//! one-shot `nix build`, while the runtime mounts the user's rootfs
-//! and runs the user's entrypoint.
+//! running user microVMs; this module is for building them. The
+//! two share `mvm-libkrun`'s FFI but compose differently — the
+//! builder mounts a workspace + persistent `/nix`-store disk and
+//! runs a one-shot `nix build`, while the runtime mounts the
+//! user's rootfs and runs the user's entrypoint.
 
 use std::io::Write;
 use std::path::{Path, PathBuf};


### PR DESCRIPTION
## Summary

Plan 72 W4 (#172) shipped the real \`LibkrunBuilderVm::run_build\` body — no path returns \`BuilderVmError::LibkrunNotShipped\` anymore. Drop the variant and refresh the module-level docs that described the W1 "scaffolding returns the trip-wire" contract, which has been superseded.

## Changes

- **Remove \`BuilderVmError::LibkrunNotShipped\`** from \`mvm-build/src/builder_vm.rs\`. Was a deliberate dead variant during W1–W3 so callers could match precisely on which side of the migration was incomplete. The W4 body returns the real variants (\`MicrosandboxUnavailable\` / \`ExtractionFailed\` / \`NixBuildFailed\`) for the same conditions, with actionable context strings.

- **Rewrite the \`libkrun_builder\` module-level doc** to describe the post-W4 reality:
  - 10-step pipeline from validate → libkrun-availability → image resolution → sparse Nix-store → job staging → KrunContext build → supervisor spawn-and-wait → result parse → artifact validate → \`BuilderArtifacts\` return.
  - Cross-references to where each step's plumbing landed (W2 flake output shape, W3 \`mvm-builder-init\`, W4 virtio-fs surface, W5 \`bootstrap_builder_vm_image\`).
  - Removes the "Until W2–W4 land, \`run_build\` returns \`LibkrunNotShipped\` after validation" disclaimer that no longer applies.

## Not in this PR

- **Full removal of microsandbox** from the workspace. Plan 72 says defer until W5 has soaked ≥ 8 weeks without regressions.
- **W5.B / W5.C dispatch swap** of \`ensure_dev_image\`. Independent follow-up.
- **CLAUDE.md updates** — the two project invariants there are already accurate.

## Verified locally

\`\`\`
cargo check --workspace --all-targets                                          ✅
cargo check --workspace --all-targets --features backends-builder-vm-libkrun   ✅
cargo test  -p mvm-build --features backends-builder-vm-libkrun --lib libkrun_builder
  test result: ok. 20 passed; 0 failed.
cargo fmt   --all -- --check                                                   ✅
\`\`\`

🤖 Generated with [Claude Code](https://claude.com/claude-code)