### PR TITLE
feat(builder-vm): plan 72 W5 dispatch — ensure_dev_image tries libkrun first

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -261,7 +261,10 @@ contributor-bootstrap = [
 # W4; default-on after Plan 72 W5 cutover. Only `mvm-build` carries
 # the implementation today; the feature surfaces here so workspace-
 # level builds can opt in cleanly.
-backends-builder-vm-libkrun = ["mvm-build/backends-builder-vm-libkrun"]
+backends-builder-vm-libkrun = [
+    "mvm-build/backends-builder-vm-libkrun",
+    "mvm-cli/backends-builder-vm-libkrun",
+]
 custom-dns = ["mvm-cli/custom-dns"]
 dev-watch = ["mvm-cli/dev-watch"]
 manifest-verify = [

--- a/crates/mvm-cli/Cargo.toml
+++ b/crates/mvm-cli/Cargo.toml
@@ -69,6 +69,11 @@ contributor-bootstrap = [
     "mvm-build/contributor-bootstrap",
     "mvm-backend/contributor-bootstrap",
 ]
+# Plan 72 W5 cutover: when on, `ensure_dev_image` tries the
+# libkrun-backed builder VM (`LibkrunBuilderVm`) before falling
+# back to the microsandbox path. Default-off until the cutover
+# is battle-tested; flip in a follow-up PR.
+backends-builder-vm-libkrun = ["mvm-build/backends-builder-vm-libkrun"]
 custom-dns = ["mvm-supervisor/custom-dns"]
 dev-watch = ["dep:notify", "dep:notify-debouncer-mini"]
 manifest-verify = [

--- a/crates/mvm-cli/src/commands/env/apple_container.rs
+++ b/crates/mvm-cli/src/commands/env/apple_container.rs
@@ -551,9 +551,23 @@ fn plist_env_string_value(plist: &str, key: &str) -> Option<String> {
 fn ensure_dev_image() -> Result<(String, String)> {
     let local_flake = find_dev_image_flake().ok();
 
-    #[cfg(feature = "contributor-bootstrap")]
-    if let Some(flake_dir) = &local_flake {
-        let out_dir = format!("{}/dev/current", mvm_core::config::mvm_data_dir());
+    // Prepare the shared output directory for any source-checkout
+    // build path. Pulled out of the per-backend branches below so
+    // both the libkrun (W5 cutover) and microsandbox (legacy) paths
+    // see the same writable dir. Variable is unused when both
+    // builder-VM features are off (downloaded-prebuilt-only build);
+    // the cfg-gated underscore prefix keeps the `-D warnings` lint
+    // happy without losing the readable name.
+    #[cfg(any(
+        feature = "backends-builder-vm-libkrun",
+        feature = "contributor-bootstrap"
+    ))]
+    let out_dir = format!("{}/dev/current", mvm_core::config::mvm_data_dir());
+    #[cfg(any(
+        feature = "backends-builder-vm-libkrun",
+        feature = "contributor-bootstrap"
+    ))]
+    if local_flake.is_some() {
         if let Some(parent) = std::path::Path::new(&out_dir).parent() {
             std::fs::create_dir_all(parent)
                 .with_context(|| format!("creating dev-image out parent {}", parent.display()))?;
@@ -573,7 +587,37 @@ fn ensure_dev_image() -> Result<(String, String)> {
         }
         std::fs::create_dir_all(&out_dir)
             .with_context(|| format!("creating dev-image out dir {out_dir}"))?;
+    }
 
+    // Plan 72 W5 cutover: when `backends-builder-vm-libkrun` is on
+    // AND libkrun is installed on the host, build via libkrun. If
+    // it fails for any reason — Layer 1 bootstrap missing,
+    // supervisor binary not on PATH, libkrun rejecting the VM —
+    // fall through to the microsandbox path so users on hosts in
+    // transition aren't blocked. A future PR will flip to
+    // "libkrun-only" once the cutover is battle-tested.
+    #[cfg(feature = "backends-builder-vm-libkrun")]
+    if let Some(flake_dir) = &local_flake
+        && mvm_libkrun::is_available()
+    {
+        ui::info(&format!(
+            "Building dev image via libkrun builder VM (Plan 72 W5) from: {flake_dir}"
+        ));
+        match build_image_via_libkrun(flake_dir, &out_dir) {
+            Ok((kernel, rootfs)) => {
+                ui::success(&format!("Dev image ready at {out_dir} (via libkrun)."));
+                return Ok((kernel, rootfs));
+            }
+            Err(e) => {
+                ui::warn(&format!(
+                    "libkrun builder failed ({e}); falling back to microsandbox path."
+                ));
+            }
+        }
+    }
+
+    #[cfg(feature = "contributor-bootstrap")]
+    if let Some(flake_dir) = &local_flake {
         ui::info(&format!(
             "Building dev image via microsandbox builder VM from: {flake_dir}"
         ));
@@ -1748,6 +1792,103 @@ fn build_image_via_microsandbox(flake_dir: &str, out_dir: &str) -> Result<(Strin
     }
     if !std::path::Path::new(&rootfs).exists() {
         anyhow::bail!("builder VM did not produce rootfs.ext4 at {rootfs}");
+    }
+    Ok((kernel, rootfs))
+}
+
+/// Build the dev image via libkrun (Plan 72 W5 cutover, Layer 2).
+///
+/// Parallel to [`build_image_via_microsandbox`] but uses the
+/// [`LibkrunBuilderVm`] launcher that #172 wired in W4. Two-layer
+/// rule from ADR-046:
+///
+/// 1. **Layer 1**: ensure the cached builder VM image exists at
+///    `~/.cache/mvm/builder-vm/<arch>/`. If empty, call
+///    [`bootstrap_builder_vm_image`] (which requires the
+///    `contributor-bootstrap` feature to run Stage 0 microsandbox
+///    against `nix/images/builder-vm/flake.nix`). Subsequent runs
+///    skip this step and reuse the cache.
+/// 2. **Layer 2**: invoke `LibkrunBuilderVm::run_build` against the
+///    user's dev-shell flake. The Layer 1 image boots inside
+///    libkrun, runs `nix build` against the workspace mounted at
+///    `/work`, and copies `vmlinux + rootfs.ext4` to `/out`.
+///
+/// On any error, the caller decides whether to bail or fall through
+/// to the microsandbox path — currently the W5 dispatch falls
+/// through, so a libkrun build failure is *not* fatal; the
+/// microsandbox path retries. That's the safe cutover semantics for
+/// this slice; a future PR will tighten to "libkrun-only when
+/// `backends-builder-vm-libkrun` is on" once the path is battle-tested.
+#[cfg(feature = "backends-builder-vm-libkrun")]
+fn build_image_via_libkrun(flake_dir: &str, out_dir: &str) -> Result<(String, String)> {
+    use mvm_build::builder_vm::{BuilderJob, BuilderMounts, BuilderVm, host_system_linux};
+    use mvm_build::libkrun_builder::LibkrunBuilderVm;
+
+    // Layer 1 — ensure the builder VM image is in the cache.
+    let arch = if cfg!(target_arch = "aarch64") {
+        "aarch64"
+    } else {
+        "x86_64"
+    };
+    let layer1_cache = format!("{}/builder-vm/{arch}", mvm_core::config::mvm_cache_dir());
+    let layer1_kernel = format!("{layer1_cache}/vmlinux");
+    let layer1_rootfs = format!("{layer1_cache}/rootfs.ext4");
+    if !std::path::Path::new(&layer1_kernel).exists()
+        || !std::path::Path::new(&layer1_rootfs).exists()
+    {
+        ui::info(
+            "Layer 1 builder VM image not in cache; bootstrapping via Stage 0 microsandbox \
+             (one-time, takes a few minutes).",
+        );
+        bootstrap_builder_vm_image().context("Layer 1 builder VM bootstrap")?;
+    }
+
+    // Layer 2 — build the user's dev-shell flake via libkrun.
+    let flake_src = std::path::PathBuf::from(flake_dir);
+    let workspace_root = flake_src
+        .parent()
+        .and_then(|p| p.parent())
+        .and_then(|p| p.parent())
+        .ok_or_else(|| {
+            anyhow::anyhow!("flake dir is not three levels deep in workspace: {flake_dir}")
+        })?
+        .to_path_buf();
+    let flake_rel = flake_src
+        .strip_prefix(&workspace_root)
+        .map_err(|_| anyhow::anyhow!("flake dir not under derived workspace root: {flake_dir}"))?;
+    let guest_flake_ref = format!(
+        "path:/work/{}",
+        flake_rel
+            .to_str()
+            .ok_or_else(|| anyhow::anyhow!("flake subpath has non-UTF-8 bytes: {flake_rel:?}"))?
+    );
+
+    let job = BuilderJob {
+        flake_ref: guest_flake_ref,
+        attr_path: format!("packages.{}.default", host_system_linux()),
+    };
+    let mounts = BuilderMounts {
+        flake_src: workspace_root,
+        // libkrun doesn't bind-mount the host's /nix store — it
+        // uses the persistent virtio-blk store the launcher manages.
+        host_nix_store: None,
+        artifact_out: std::path::PathBuf::from(out_dir),
+    };
+
+    ui::info(&format!(
+        "Building dev image via libkrun (Layer 2) from: {flake_dir}"
+    ));
+    LibkrunBuilderVm::default()
+        .run_build(&job, &mounts)
+        .map_err(|e| anyhow::anyhow!("libkrun builder VM: {e}"))?;
+
+    let kernel = format!("{out_dir}/vmlinux");
+    let rootfs = format!("{out_dir}/rootfs.ext4");
+    if !std::path::Path::new(&kernel).exists() {
+        anyhow::bail!("libkrun builder VM did not produce vmlinux at {kernel}");
+    }
+    if !std::path::Path::new(&rootfs).exists() {
+        anyhow::bail!("libkrun builder VM did not produce rootfs.ext4 at {rootfs}");
     }
     Ok((kernel, rootfs))
 }

--- a/specs/plans/72-builder-vm-via-libkrun.md
+++ b/specs/plans/72-builder-vm-via-libkrun.md
@@ -309,6 +309,29 @@ Reshape `ensure_dev_image` to encode the two-layer artifact rule from ADR-046 §
 - Live test `tests/dev_up_contributor_bootstrap.rs` exercises the `--features contributor-bootstrap` Stage 0 path. This test must explicitly verify that no host `nix` binary is invoked (e.g. by putting a poisoned `nix` shim at the front of `PATH` that exits non-zero and asserting the build still succeeds).
 - A contributor edit to `nix/images/builder-vm/flake.nix` (e.g. adding `htop` to `builderPackages`) shows up in the next `mvmctl dev up` without a release-pipeline round-trip.
 
+#### W5 progress — dispatch swap (2026-05-13)
+
+Second slice of W5 after the bootstrap helpers in #178. Wires the libkrun-first branch into `ensure_dev_image`:
+
+- **`build_image_via_libkrun(flake_dir, out_dir)`** — parallel to `build_image_via_microsandbox`. Layer 1: probes `~/.cache/mvm/builder-vm/<arch>/{vmlinux,rootfs.ext4}`; on cache miss calls `bootstrap_builder_vm_image()` (Stage 0 microsandbox, requires `contributor-bootstrap`). Layer 2: constructs `BuilderJob` + `BuilderMounts` against the dev-shell flake, delegates to `LibkrunBuilderVm::run_build`, validates the `vmlinux + rootfs.ext4` output.
+- **`ensure_dev_image` dispatch** — when `backends-builder-vm-libkrun` is on AND `mvm_libkrun::is_available()`, try the libkrun path first. On any failure (Layer 1 bootstrap missing, supervisor binary not on PATH, libkrun rejecting the VM, etc.) fall through to the existing microsandbox path. The cascade lets users on hosts mid-transition keep working while the new path lands.
+- **Feature wiring** — `backends-builder-vm-libkrun` propagates from workspace → `mvm-cli` → `mvm-build`. Default-off in this PR for safety; a follow-up flips the default once the cutover is battle-tested.
+
+**Verified locally** (macOS Apple Silicon):
+
+- `cargo build -p mvm-cli` — green (no feature).
+- `cargo build -p mvm-cli --features backends-builder-vm-libkrun` — green.
+- `cargo build -p mvm-cli --features contributor-bootstrap` — green.
+- `cargo build -p mvm-cli --features "backends-builder-vm-libkrun contributor-bootstrap"` — green.
+- `cargo clippy -p mvm-cli --features backends-builder-vm-libkrun --all-targets -- -D warnings` and the combined-feature variant — both clean.
+- `cargo test -p mvm-cli --features backends-builder-vm-libkrun` — 487/487 pass.
+
+**Still queued for W5**:
+
+- Flip `backends-builder-vm-libkrun` default to ON. Held back here because users without libkrun installed need a graceful path; today they keep the microsandbox fallback. After the next CI lane lands ("libkrun-only path proves itself"), the flip is a one-line Cargo.toml change.
+- Live tests `tests/dev_up_libkrun.rs` + `tests/dev_up_contributor_bootstrap.rs`. Not in this slice; needs the prebuilt download path (currently absent for installed binaries) or fixtures pre-staged in CI.
+- Air-gapped variant + `mvmctl builder-vm bootstrap` subcommand.
+
 ---
 
 ## W6 — Hygiene (not removal)


### PR DESCRIPTION
## Summary

Second slice of Plan 72 W5 after #178's bootstrap helpers. Wires the libkrun-first branch into `ensure_dev_image` so source-checkout contributors with both `backends-builder-vm-libkrun` and libkrun installed actually build via the new path.

### `build_image_via_libkrun(flake_dir, out_dir)`

Parallel to `build_image_via_microsandbox`. Two-layer rule from ADR-046:

- **Layer 1**: probe `~/.cache/mvm/builder-vm/<arch>/{vmlinux,rootfs.ext4}`. On cache miss, call `bootstrap_builder_vm_image()` (#178) which runs Stage 0 microsandbox against `nix/images/builder-vm/flake.nix`. Requires the `contributor-bootstrap` feature for Stage 0; without it the bootstrap surfaces an actionable rebuild hint.
- **Layer 2**: construct `BuilderJob` + `BuilderMounts` against the dev-shell flake (mounted at `/work`), delegate to `LibkrunBuilderVm::run_build` (#172), validate the `vmlinux + rootfs.ext4` output.

### `ensure_dev_image` dispatch

New branch added BEFORE the existing microsandbox branch. Active when `backends-builder-vm-libkrun` is on AND `mvm_libkrun::is_available()` returns true. On any failure inside the libkrun branch, falls through to the microsandbox path so users on hosts in transition aren't blocked. A future PR will tighten to "libkrun-only" once the cutover is battle-tested.

### Feature wiring

- `mvm-cli/Cargo.toml`: new `backends-builder-vm-libkrun` feature that re-exports `mvm-build/backends-builder-vm-libkrun`.
- Workspace root `Cargo.toml`: existing chain extended to include `mvm-cli`.

Default-off in this PR; the flip is a small follow-up.

## Test plan

- [x] `cargo build -p mvm-cli` (no feature) — green.
- [x] `cargo build -p mvm-cli --features backends-builder-vm-libkrun` — green.
- [x] `cargo build -p mvm-cli --features contributor-bootstrap` — green.
- [x] `cargo build -p mvm-cli --features "backends-builder-vm-libkrun contributor-bootstrap"` — green.
- [x] `cargo clippy -p mvm-cli --features backends-builder-vm-libkrun --all-targets -- -D warnings` and the combined variant — both clean.
- [x] `cargo test -p mvm-cli --features backends-builder-vm-libkrun` — 487/487 pass.

## Out of scope (queued for next W5 slices)

- **Default flip** of `backends-builder-vm-libkrun` to ON.
- **Live tests** `tests/dev_up_libkrun.rs` + `tests/dev_up_contributor_bootstrap.rs`.
- Air-gapped variant + `mvmctl builder-vm bootstrap` subcommand.

🤖 Generated with [Claude Code](https://claude.com/claude-code)