### PR TITLE
chore(lint): unbreak Lint CI — secret-debug allow + fmt drift sweep

### DIFF
--- a/crates/mvm-cli/src/commands/build/compile.rs
+++ b/crates/mvm-cli/src/commands/build/compile.rs
@@ -57,7 +57,11 @@ pub(in crate::commands) struct Args {
     /// `mvm.emit_recording_json()`) from this path and lower it into
     /// a Workload before compile. Mutually exclusive with `--from-ir`
     /// and the positional entry.
-    #[arg(long = "from-recording", value_name = "PATH", conflicts_with = "from_ir")]
+    #[arg(
+        long = "from-recording",
+        value_name = "PATH",
+        conflicts_with = "from_ir"
+    )]
     pub from_recording: Option<PathBuf>,
 
     /// Output path. Directory by default; ending in `.tar.gz`/`.tgz`
@@ -185,9 +189,8 @@ fn load_workload(args: &Args) -> Result<Workload> {
                     // `--from-recording` does.
                     auto_exec_record_script(&path, ScriptLanguage::Python)
                 }
-                Err(e) => Err(anyhow::anyhow!("{e}")).with_context(|| {
-                    format!("parsing @mvm.app decorator in {}", path.display())
-                }),
+                Err(e) => Err(anyhow::anyhow!("{e}"))
+                    .with_context(|| format!("parsing @mvm.app decorator in {}", path.display())),
             }
         }
         WorkloadSource::RuntimeScript(path) => {

--- a/crates/mvm-cli/src/commands/tests.rs
+++ b/crates/mvm-cli/src/commands/tests.rs
@@ -1912,7 +1912,9 @@ fn test_compile_from_recording_parses() {
             ..
         }) => {
             assert_eq!(
-                from_recording.as_deref().map(|p| p.to_string_lossy().into_owned()),
+                from_recording
+                    .as_deref()
+                    .map(|p| p.to_string_lossy().into_owned()),
                 Some("/tmp/rec.json".to_string())
             );
             assert!(from_ir.is_none());
@@ -1945,8 +1947,8 @@ fn test_compile_from_recording_conflicts_with_from_ir() {
 
 #[test]
 fn test_compile_default_no_from_flags_leaves_them_none() {
-    let cli = Cli::try_parse_from(["mvmctl", "compile", "--from-ir", "/tmp/ir.json"])
-        .expect("parse");
+    let cli =
+        Cli::try_parse_from(["mvmctl", "compile", "--from-ir", "/tmp/ir.json"]).expect("parse");
     match cli.command {
         Commands::Compile(compile::Args {
             from_ir,

--- a/crates/mvm-cli/tests/auto_exec_node_record.rs
+++ b/crates/mvm-cli/tests/auto_exec_node_record.rs
@@ -65,8 +65,7 @@ fn auto_exec_node_script_emits_recording_and_compile_lowers_it() {
     let bytes = std::fs::read(&out_recording).unwrap();
     let recording: mvm_sdk::runtime::RuntimeRecording =
         serde_json::from_slice(&bytes).expect("recording JSON parses");
-    let workload =
-        mvm_sdk::runtime::compile_recording(&recording).expect("lowering succeeds");
+    let workload = mvm_sdk::runtime::compile_recording(&recording).expect("lowering succeeds");
 
     assert_eq!(workload.id, "etl-test-node");
     let app = &workload.apps[0];

--- a/crates/mvm-cli/tests/auto_exec_python_record.rs
+++ b/crates/mvm-cli/tests/auto_exec_python_record.rs
@@ -44,15 +44,15 @@ with open(out, "w") as f:
 "#;
 
 fn python3_on_path() -> Option<std::path::PathBuf> {
-    which::which("python3").ok().or_else(|| which::which("python").ok())
+    which::which("python3")
+        .ok()
+        .or_else(|| which::which("python").ok())
 }
 
 #[test]
 fn auto_exec_python_script_emits_recording_and_compile_lowers_it() {
     let Some(python) = python3_on_path() else {
-        eprintln!(
-            "skipping auto_exec_python_script_emits_recording: no python3/python on PATH"
-        );
+        eprintln!("skipping auto_exec_python_script_emits_recording: no python3/python on PATH");
         return;
     };
 
@@ -79,8 +79,7 @@ fn auto_exec_python_script_emits_recording_and_compile_lowers_it() {
     let bytes = std::fs::read(&out_recording).unwrap();
     let recording: mvm_sdk::runtime::RuntimeRecording =
         serde_json::from_slice(&bytes).expect("recording JSON parses");
-    let workload =
-        mvm_sdk::runtime::compile_recording(&recording).expect("lowering succeeds");
+    let workload = mvm_sdk::runtime::compile_recording(&recording).expect("lowering succeeds");
 
     assert_eq!(workload.id, "etl-test");
     match &workload.apps[0].entrypoints[0] {

--- a/crates/mvm-guest/src/lifecycle_hooks.rs
+++ b/crates/mvm-guest/src/lifecycle_hooks.rs
@@ -74,10 +74,7 @@ pub enum ReadinessError {
         "after_start readiness probe `{}` did not succeed within {elapsed:?}",
         script.display()
     )]
-    Timeout {
-        script: PathBuf,
-        elapsed: Duration,
-    },
+    Timeout { script: PathBuf, elapsed: Duration },
 
     /// The script path doesn't exist or isn't executable. Surface
     /// distinct from `ExecError` so the caller can fall through

--- a/crates/mvm-sdk/src/addon/manifest.rs
+++ b/crates/mvm-sdk/src/addon/manifest.rs
@@ -144,6 +144,10 @@ fn default_credential_ttl_hours() -> u32 {
 /// be added in a non-breaking minor release. Today only `Generated`
 /// is shipped; the registry rejects manifests that try to use any
 /// other variant at publish time.
+// allow(secret-debug): metadata enum with no payload — `Debug`
+// reveals only the variant name (a published schema constant), never
+// credential material. Future `Static`/`UserSupplied` variants follow
+// the same shape: they describe credential *provenance*, not bytes.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize, JsonSchema)]
 #[serde(rename_all = "snake_case")]
 #[non_exhaustive]

--- a/crates/mvm-sdk/src/compile/deps_audit.rs
+++ b/crates/mvm-sdk/src/compile/deps_audit.rs
@@ -118,7 +118,10 @@ pub enum VolumeError {
         artifact,
         volume.display()
     )]
-    ArtifactMissing { volume: PathBuf, artifact: &'static str },
+    ArtifactMissing {
+        volume: PathBuf,
+        artifact: &'static str,
+    },
 
     #[error("failed to read volume artifact `{}`: {source}", path.display())]
     Io {
@@ -215,11 +218,10 @@ pub fn verify_sealed_volume(volume_dir: &Path) -> Result<String, VolumeError> {
             artifact: FILE_MANIFEST,
         });
     }
-    let manifest_bytes =
-        std::fs::read(&manifest_path).map_err(|e| VolumeError::Io {
-            path: manifest_path.clone(),
-            source: e,
-        })?;
+    let manifest_bytes = std::fs::read(&manifest_path).map_err(|e| VolumeError::Io {
+        path: manifest_path.clone(),
+        source: e,
+    })?;
     let manifest: VolumeManifest =
         serde_json::from_slice(&manifest_bytes).map_err(|source| VolumeError::ManifestParse {
             volume: volume_dir.to_path_buf(),
@@ -622,4 +624,3 @@ mod tests {
         assert!(err.to_string().contains("future_field"));
     }
 }
-

--- a/crates/mvm-sdk/src/runtime.rs
+++ b/crates/mvm-sdk/src/runtime.rs
@@ -173,8 +173,13 @@ pub fn resolve_base_image(template: &str) -> Result<Image, LowerError> {
 /// Closed, hand-curated list of known base-image templates. Exposed
 /// so `mvmctl doctor` / SDK error messages can render an actionable
 /// list when a user mistypes a template name.
-pub const KNOWN_BASE_IMAGES: &[&str] =
-    &["python-3.12", "python-3.13", "node-22", "node-lts", "minimal"];
+pub const KNOWN_BASE_IMAGES: &[&str] = &[
+    "python-3.12",
+    "python-3.13",
+    "node-22",
+    "node-lts",
+    "minimal",
+];
 
 // ────────────────────────────────────────────────────────────────────
 // Lowering — recording → Workload.
@@ -434,7 +439,10 @@ mod tests {
             HookCmd::Shell { line } => {
                 assert!(line.contains("base64 -d"), "got: {line}");
                 assert!(line.contains("/app/config.json"), "got: {line}");
-                assert!(line.contains(&b64(b"{\"hello\":\"world\"}\n")), "got: {line}");
+                assert!(
+                    line.contains(&b64(b"{\"hello\":\"world\"}\n")),
+                    "got: {line}"
+                );
                 assert!(line.contains("mkdir -p"), "got: {line}");
             }
             other => panic!("expected Shell hook, got {other:?}"),


### PR DESCRIPTION
## Summary

Unbreaks the Lint job on \`main\`, which has been red since #179 (SDK port) on two pre-existing issues unrelated to any particular feature PR.

- **Fix 1:** \`CredentialsKind\` (\`crates/mvm-sdk/src/addon/manifest.rs:155\`) derives \`Debug\` on a type whose name contains \"Credentials\". xtask's \`check-no-display-on-secret-types\` flags this as a potential leak; it isn't (variant-only enum, no payload bytes). Annotated with \`// allow(secret-debug): <reason>\` placed inside xtask's 10-line scan window.
- **Fix 2:** \`cargo +nightly fmt\` drift on 7 files — 162 lines of mechanical reformatting (struct-field wrapping, attribute-arg layout). Applied once.

## Verification

| Step | Result |
|---|---|
| \`cargo +nightly fmt -- --check\` | ✅ |
| \`cargo clippy --workspace --tests -- -D warnings\` | ✅ |
| \`cargo run -p xtask -- check-no-display-on-secret-types\` | ✅ clean |
| \`cargo run -p xtask -- check-adr-coverage\` | ⚠️ 13 broken refs (already \`continue-on-error: true\` in the workflow at line 109 — non-blocking) |

## Why one PR for two fixes

Each fix is one mechanical change. Splitting them costs two admin-merges through a still-red gate. Both are non-controversial and have the same scope (\"unbreak CI\").

## Not in this PR

The 13 broken ADR refs from \`check-adr-coverage\` (ADR-001/-009/-015/-018/etc.). That step is informational-only and doesn't gate merge. Cleaning them up is a separate effort — some need real ADRs written, some are dead pointers to deleted ADRs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)