### PR TITLE
Plan 73 Followup F — TS runner doctor + project-local resolution

### DIFF
--- a/crates/mvm-cli/src/commands/build/compile.rs
+++ b/crates/mvm-cli/src/commands/build/compile.rs
@@ -351,16 +351,16 @@ fn resolve_interpreter(lang: ScriptLanguage) -> Result<PathBuf> {
             if let Some(p) = env_override("MVM_TSX") {
                 return Ok(p);
             }
-            for candidate in ["tsx", "bun", "deno"] {
-                if let Ok(found) = which::which(candidate) {
-                    return Ok(found);
-                }
+            // Project-local `./node_modules/.bin/<runner>` wins over a
+            // PATH-installed runner: this lets a `package.json` /
+            // lockfile pin the exact version without forcing the user
+            // to install one globally. Resolution is cwd-relative
+            // because `mvmctl compile` is run from a project root.
+            // See `crate::ts_runner` for the full resolution order.
+            if let Some(p) = crate::ts_runner::resolve() {
+                return Ok(p);
             }
-            bail!(
-                "no TypeScript runner found on PATH (tried `tsx`, `bun`, `deno`). \
-                 Install one (e.g. `npm install -g tsx`) or set `MVM_TSX=<path>` \
-                 and re-run."
-            )
+            bail!("{}", crate::ts_runner::install_hint())
         }
     }
 }
@@ -456,4 +456,58 @@ fn resolve_manifest_dir(args: &Args) -> Result<PathBuf> {
         }
     };
     Ok(basis)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::sync::Mutex;
+
+    /// Serializes tests that mutate `MVM_TSX` (process-wide).
+    static ENV_LOCK: Mutex<()> = Mutex::new(());
+
+    /// Restore-on-drop guard for `MVM_TSX`. Used to exercise the
+    /// env-override short-circuit in `resolve_interpreter` without
+    /// leaking state into sibling tests.
+    struct TsxGuard {
+        _guard: std::sync::MutexGuard<'static, ()>,
+        prev: Option<String>,
+    }
+
+    impl TsxGuard {
+        fn set(value: Option<&str>) -> Self {
+            let g = ENV_LOCK.lock().unwrap_or_else(|e| e.into_inner());
+            let prev = std::env::var("MVM_TSX").ok();
+            unsafe {
+                match value {
+                    Some(v) => std::env::set_var("MVM_TSX", v),
+                    None => std::env::remove_var("MVM_TSX"),
+                }
+            }
+            TsxGuard { _guard: g, prev }
+        }
+    }
+
+    impl Drop for TsxGuard {
+        fn drop(&mut self) {
+            unsafe {
+                match &self.prev {
+                    Some(v) => std::env::set_var("MVM_TSX", v),
+                    None => std::env::remove_var("MVM_TSX"),
+                }
+            }
+        }
+    }
+
+    #[test]
+    fn resolve_interpreter_typescript_honours_mvm_tsx_override() {
+        // Sanity: MVM_TSX pin must short-circuit before the
+        // project-local / PATH lookup. We can't usefully check that
+        // the path *exists* (no fixture), but we can check that the
+        // returned PathBuf is the override verbatim.
+        let _g = TsxGuard::set(Some("/usr/local/bin/tsx-pinned"));
+        let resolved =
+            resolve_interpreter(ScriptLanguage::TypeScript).expect("MVM_TSX must short-circuit");
+        assert_eq!(resolved, PathBuf::from("/usr/local/bin/tsx-pinned"));
+    }
 }

--- a/crates/mvm-cli/src/doctor.rs
+++ b/crates/mvm-cli/src/doctor.rs
@@ -141,6 +141,7 @@ pub fn run(json: bool) -> Result<()> {
     checks.push(apple_container_check(plat));
     checks.push(libkrun_check(plat));
     checks.push(docker_check(plat));
+    checks.push(ts_runner_check());
 
     checks.push(disk_space_check(false));
 
@@ -581,6 +582,64 @@ fn libkrun_check(plat: Platform) -> Check {
             ok: true, // Optional; not a failure.
             info: format!("not available ({})", mvm_libkrun::install_hint()),
         }
+    }
+}
+
+/// TypeScript runner probe — `mvmctl compile <script.ts>` auto-runs
+/// the script on the host with `MVM_SDK_MODE=record` and lowers the
+/// emitted recording into a Workload. That path needs a TS-aware
+/// runner (`tsx`, `bun`, or `deno`); plain `node` can't execute `.ts`
+/// in mvm's supported Node range.
+///
+/// **WARN (not FAIL) when missing.** A TS runner is only required if
+/// the user actually runs `mvmctl compile` on a `.ts` script — most
+/// mvm workflows (Python, IR-JSON, decorator-only TS) don't need one.
+/// Doctor surfaces the install hint so the gap is discoverable, but
+/// `mvmctl doctor` still exits 0 to avoid breaking CI on hosts that
+/// genuinely don't want a Node toolchain.
+///
+/// Probe is cheap: at most three `which::which` lookups plus one
+/// cwd-relative `is_file` per runner — no subprocesses.
+fn ts_runner_check() -> Check {
+    // Project-local resolution wins over PATH — see
+    // `crate::ts_runner` module docs for the full order.
+    if let Some(p) = crate::ts_runner::project_local() {
+        return Check {
+            name: "TypeScript runner",
+            category: "tools",
+            ok: true,
+            info: format!(
+                "project-local at {} (used by `mvmctl compile <script.ts>`)",
+                p.display()
+            ),
+        };
+    }
+    if let Some(p) = crate::ts_runner::on_path() {
+        return Check {
+            name: "TypeScript runner",
+            category: "tools",
+            ok: true,
+            info: format!(
+                "{} on PATH ({})",
+                p.file_name()
+                    .and_then(|s| s.to_str())
+                    .unwrap_or("<unknown>"),
+                p.display()
+            ),
+        };
+    }
+    Check {
+        name: "TypeScript runner",
+        category: "tools",
+        // `ok: true` is the WARN posture — doctor reports the gap in
+        // the `info` field but does not exit nonzero. The install
+        // hint is verbose on purpose; this is the one place users
+        // discover the project-local + global recipes.
+        ok: true,
+        info: format!(
+            "not found — {} (only required if you run `mvmctl compile <script.ts>`)",
+            crate::ts_runner::install_hint()
+        ),
     }
 }
 
@@ -1565,6 +1624,97 @@ mod tests {
         assert!(
             c.info.contains("0700"),
             "info should report the data dir's mode, got: {}",
+            c.info
+        );
+    }
+
+    #[test]
+    fn ts_runner_check_reports_warn_posture_with_install_hint_when_missing() {
+        // Force a clean lookup: no MVM_TSX pin, no project-local
+        // ./node_modules/.bin, and (most critically) an empty PATH
+        // so the host's own `tsx`/`bun`/`deno` can't make this test
+        // flaky. The probe must still return `ok: true` (WARN, not
+        // FAIL) so `mvmctl doctor` exits 0 on a host without a TS
+        // runner.
+        let g = ENV_LOCK.lock().unwrap_or_else(|e| e.into_inner());
+        let prev_path = std::env::var("PATH").ok();
+        let prev_tsx = std::env::var("MVM_TSX").ok();
+        let prev_cwd = std::env::current_dir().expect("cwd");
+        let tmp = tempfile::tempdir().unwrap();
+        unsafe {
+            std::env::set_var("PATH", "");
+            std::env::remove_var("MVM_TSX");
+        }
+        std::env::set_current_dir(tmp.path()).expect("chdir");
+
+        let c = ts_runner_check();
+
+        // Restore before any assert can fail the test.
+        let _ = std::env::set_current_dir(&prev_cwd);
+        unsafe {
+            match prev_path {
+                Some(v) => std::env::set_var("PATH", v),
+                None => std::env::remove_var("PATH"),
+            }
+            match prev_tsx {
+                Some(v) => std::env::set_var("MVM_TSX", v),
+                None => std::env::remove_var("MVM_TSX"),
+            }
+        }
+        drop(g);
+
+        assert_eq!(c.name, "TypeScript runner");
+        assert_eq!(c.category, "tools");
+        assert!(
+            c.ok,
+            "TS-runner probe is WARN-only (informational), not FAIL: info={}",
+            c.info
+        );
+        assert!(
+            c.info.contains("not found"),
+            "expected 'not found' marker, got: {}",
+            c.info
+        );
+        // Install hint must be inlined so `mvmctl doctor` users
+        // don't need to re-discover the per-OS recipe elsewhere.
+        for s in ["tsx", "bun", "deno", "MVM_TSX"] {
+            assert!(c.info.contains(s), "info missing {s:?}: {}", c.info);
+        }
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn ts_runner_check_reports_pass_when_project_local_present() {
+        use std::os::unix::fs::PermissionsExt;
+        let g = ENV_LOCK.lock().unwrap_or_else(|e| e.into_inner());
+        let prev_cwd = std::env::current_dir().expect("cwd");
+        let prev_tsx = std::env::var("MVM_TSX").ok();
+        let tmp = tempfile::tempdir().unwrap();
+        let bin = tmp.path().join("node_modules").join(".bin");
+        std::fs::create_dir_all(&bin).unwrap();
+        let tsx = bin.join("tsx");
+        std::fs::write(&tsx, "#!/bin/sh\nexit 0\n").unwrap();
+        std::fs::set_permissions(&tsx, std::fs::Permissions::from_mode(0o755)).unwrap();
+        unsafe {
+            std::env::remove_var("MVM_TSX");
+        }
+        std::env::set_current_dir(tmp.path()).expect("chdir");
+
+        let c = ts_runner_check();
+
+        let _ = std::env::set_current_dir(&prev_cwd);
+        unsafe {
+            match prev_tsx {
+                Some(v) => std::env::set_var("MVM_TSX", v),
+                None => std::env::remove_var("MVM_TSX"),
+            }
+        }
+        drop(g);
+
+        assert!(c.ok);
+        assert!(
+            c.info.contains("project-local"),
+            "expected 'project-local' marker, got: {}",
             c.info
         );
     }

--- a/crates/mvm-cli/src/lib.rs
+++ b/crates/mvm-cli/src/lib.rs
@@ -12,6 +12,7 @@ pub mod metrics_server;
 pub mod security_cmd;
 pub mod shell_init;
 pub mod template_cmd;
+pub mod ts_runner;
 pub mod ui;
 pub mod update;
 pub mod watch;

--- a/crates/mvm-cli/src/ts_runner.rs
+++ b/crates/mvm-cli/src/ts_runner.rs
@@ -1,0 +1,213 @@
+//! TypeScript runner discovery — shared by `mvmctl compile` (auto-run
+//! of record-mode `.ts` scripts) and `mvmctl doctor` (host-environment
+//! probe). Lives in its own module so the install-hint string is one
+//! source of truth between the two surfaces.
+//!
+//! Resolution order applied by [`resolve`]:
+//!
+//! 1. `MVM_TSX` env override — explicit user pin (handled by the
+//!    caller; this module is only the post-override fallback).
+//! 2. `./node_modules/.bin/tsx` — cwd-relative, pins the runner via
+//!    the project's lockfile.
+//! 3. `./node_modules/.bin/bun`.
+//! 4. `./node_modules/.bin/deno`.
+//! 5. `tsx` on `PATH`.
+//! 6. `bun` on `PATH`.
+//! 7. `deno` on `PATH`.
+//! 8. `None` — the caller surfaces [`install_hint`] to the user.
+
+use std::path::PathBuf;
+
+/// Candidate runners, in priority order. `tsx` wins because it's the
+/// canonical TypeScript-only runner and ships the smallest install
+/// footprint (`npm install -g tsx`); `bun` and `deno` are full
+/// toolchains that also accept `.ts` input.
+pub(crate) const CANDIDATES: [&str; 3] = ["tsx", "bun", "deno"];
+
+/// Look for a TS runner under `./node_modules/.bin/<name>`
+/// (cwd-relative). `tsx` wins over `bun` wins over `deno`. Returns
+/// the first existing **file** (npm/pnpm install
+/// `node_modules/.bin/tsx` as a symlink, which still passes
+/// `is_file()` through the symlink). Returns `None` if no runner is
+/// present so the caller can fall through to a `PATH` search.
+pub(crate) fn project_local() -> Option<PathBuf> {
+    let cwd = std::env::current_dir().ok()?;
+    let base = cwd.join("node_modules").join(".bin");
+    if !base.is_dir() {
+        return None;
+    }
+    for candidate in CANDIDATES {
+        let p = base.join(candidate);
+        if p.is_file() {
+            return Some(p);
+        }
+    }
+    None
+}
+
+/// Search `PATH` for `tsx`, then `bun`, then `deno`. Returns the
+/// first hit, or `None` if no candidate is on `PATH`.
+pub(crate) fn on_path() -> Option<PathBuf> {
+    for candidate in CANDIDATES {
+        if let Ok(found) = which::which(candidate) {
+            return Some(found);
+        }
+    }
+    None
+}
+
+/// Resolve the runner without consulting `MVM_TSX` (the env-override
+/// is the caller's responsibility — it's a single `std::env::var`
+/// lookup and the caller already special-cases the empty-string
+/// case). Returns the first existing candidate per the order in
+/// the module docs, or `None` so the caller can `bail!` with
+/// [`install_hint`].
+pub(crate) fn resolve() -> Option<PathBuf> {
+    project_local().or_else(on_path)
+}
+
+/// Single source of truth for the "install a TS runner" message
+/// surfaced by `mvmctl compile` (on `bail!`) and `mvmctl doctor`
+/// (on a WARN result). Listing every install path keeps the two
+/// messages aligned and avoids users re-discovering the same
+/// recipes in two places.
+pub(crate) fn install_hint() -> &'static str {
+    "no TypeScript runner found on PATH (tried `tsx`, `bun`, `deno`) \
+     and no project-local `./node_modules/.bin/{tsx,bun,deno}`. Install one: \
+     `brew install tsx` (macOS) / `npm install -g tsx` / `pnpm add -g tsx` / \
+     `yarn global add tsx` — or `brew install oven-sh/bun/bun` / \
+     `curl -fsSL https://bun.sh/install | bash` for bun, or \
+     `brew install deno` / `curl -fsSL https://deno.land/install.sh | sh` \
+     for deno. Add the runner to your `package.json` devDependencies so \
+     `./node_modules/.bin/tsx` resolves without polluting global PATH, or \
+     set `MVM_TSX=<path>` to an explicit binary."
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::path::Path;
+    use std::sync::Mutex;
+
+    /// `std::env::set_current_dir` is process-wide; this Mutex stops
+    /// `cargo test`'s thread pool from racing between two cwd-mutating
+    /// tests. The lock is held for the lifetime of [`CwdGuard`].
+    static CWD_LOCK: Mutex<()> = Mutex::new(());
+
+    struct CwdGuard {
+        _guard: std::sync::MutexGuard<'static, ()>,
+        prev: PathBuf,
+    }
+
+    impl CwdGuard {
+        fn enter(dir: &Path) -> Self {
+            let g = CWD_LOCK.lock().unwrap_or_else(|e| e.into_inner());
+            let prev = std::env::current_dir().expect("cwd");
+            std::env::set_current_dir(dir).expect("chdir");
+            CwdGuard { _guard: g, prev }
+        }
+    }
+
+    impl Drop for CwdGuard {
+        fn drop(&mut self) {
+            let _ = std::env::set_current_dir(&self.prev);
+        }
+    }
+
+    #[cfg(unix)]
+    fn write_exec(path: &Path, body: &str) {
+        use std::os::unix::fs::PermissionsExt;
+        std::fs::write(path, body).unwrap();
+        let mut perms = std::fs::metadata(path).unwrap().permissions();
+        perms.set_mode(0o755);
+        std::fs::set_permissions(path, perms).unwrap();
+    }
+
+    #[test]
+    fn project_local_returns_none_when_no_node_modules() {
+        let tmp = tempfile::tempdir().unwrap();
+        let _g = CwdGuard::enter(tmp.path());
+        assert!(
+            project_local().is_none(),
+            "expected None without ./node_modules/.bin"
+        );
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn project_local_prefers_tsx_over_bun_and_deno() {
+        let tmp = tempfile::tempdir().unwrap();
+        let bin = tmp.path().join("node_modules").join(".bin");
+        std::fs::create_dir_all(&bin).unwrap();
+        // Plant all three; tsx must win.
+        for name in CANDIDATES {
+            write_exec(&bin.join(name), "#!/bin/sh\nexit 0\n");
+        }
+        let _g = CwdGuard::enter(tmp.path());
+        let resolved = project_local().expect("should resolve");
+        assert_eq!(
+            resolved.file_name().and_then(|s| s.to_str()),
+            Some("tsx"),
+            "tsx must win the priority order"
+        );
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn project_local_falls_through_to_bun_when_only_bun_present() {
+        let tmp = tempfile::tempdir().unwrap();
+        let bin = tmp.path().join("node_modules").join(".bin");
+        std::fs::create_dir_all(&bin).unwrap();
+        write_exec(&bin.join("bun"), "#!/bin/sh\nexit 0\n");
+        let _g = CwdGuard::enter(tmp.path());
+        let resolved = project_local().expect("should resolve bun");
+        assert_eq!(resolved.file_name().and_then(|s| s.to_str()), Some("bun"));
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn project_local_falls_through_to_deno_when_only_deno_present() {
+        let tmp = tempfile::tempdir().unwrap();
+        let bin = tmp.path().join("node_modules").join(".bin");
+        std::fs::create_dir_all(&bin).unwrap();
+        write_exec(&bin.join("deno"), "#!/bin/sh\nexit 0\n");
+        let _g = CwdGuard::enter(tmp.path());
+        let resolved = project_local().expect("should resolve deno");
+        assert_eq!(resolved.file_name().and_then(|s| s.to_str()), Some("deno"));
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn resolve_picks_project_local_over_path_when_both_present() {
+        // Plant ./node_modules/.bin/tsx; even if PATH carries another
+        // `tsx`, the project-local one must win.
+        let tmp = tempfile::tempdir().unwrap();
+        let bin = tmp.path().join("node_modules").join(".bin");
+        std::fs::create_dir_all(&bin).unwrap();
+        let tsx = bin.join("tsx");
+        write_exec(&tsx, "#!/bin/sh\nexit 0\n");
+
+        let _g = CwdGuard::enter(tmp.path());
+        let resolved = resolve().expect("project-local tsx must resolve");
+        // Symlink-canonicalize to handle macOS /var → /private/var.
+        let resolved = std::fs::canonicalize(&resolved).unwrap_or(resolved);
+        let expected = std::fs::canonicalize(&tsx).unwrap_or(tsx);
+        assert_eq!(resolved, expected);
+    }
+
+    #[test]
+    fn install_hint_covers_all_runners_and_resolution_paths() {
+        let hint = install_hint();
+        for s in [
+            "tsx",
+            "bun",
+            "deno",
+            "brew install",
+            "npm install -g tsx",
+            "node_modules",
+            "MVM_TSX",
+        ] {
+            assert!(hint.contains(s), "install_hint missing {s:?}: {hint}");
+        }
+    }
+}

--- a/public/src/content/docs/guides/sdk.md
+++ b/public/src/content/docs/guides/sdk.md
@@ -107,3 +107,55 @@ Nix factory to bake into `/etc/mvm/hooks/<phase>.sh`.
 `.tar.gz`. v1 ships a stub HTTP client that logs the bundle and exits
 0; the real `POST /v1/workloads` lands once mvmd Plan 48 Phase 1090
 is live.
+
+## TypeScript runner
+
+`mvmctl compile app.ts` walks the AST statically for `mvm.app({...})`
+calls and does not run user code. When a `.ts` script uses the
+record-mode `Sandbox` API instead (no `mvm.app` decorator), `mvmctl
+compile` falls back to **auto-run**: it spawns the script on the host
+with `MVM_SDK_MODE=record` set, and the SDK's atexit hook writes a
+recording JSON that the CLI then lowers into a `Workload`.
+
+That auto-run path needs a TypeScript-aware runner — plain `node`
+cannot execute `.ts` in mvm's supported Node range. Three runners
+are supported, in priority order: **`tsx`**, **`bun`**, **`deno`**.
+
+### Install one
+
+| OS         | Recipe                                                                                  |
+| ---------- | --------------------------------------------------------------------------------------- |
+| macOS (Homebrew) | `brew install tsx` *or* `brew install oven-sh/bun/bun` *or* `brew install deno`      |
+| Any (npm)        | `npm install -g tsx`                                                                  |
+| Any (pnpm)       | `pnpm add -g tsx`                                                                     |
+| Any (yarn)       | `yarn global add tsx`                                                                 |
+| Any (bun)        | `curl -fsSL https://bun.sh/install \| bash`                                           |
+| Any (deno)       | `curl -fsSL https://deno.land/install.sh \| sh`                                       |
+
+Prefer the project-local install if you want a reproducible lockfile-
+pinned runner:
+
+```sh
+npm install --save-dev tsx
+```
+
+That puts the binary at `./node_modules/.bin/tsx`, and `mvmctl
+compile` picks it up automatically — see the resolution order below.
+
+### Resolution order
+
+`mvmctl compile` resolves the runner in this order, picking the
+first hit:
+
+1. `MVM_TSX=<path>` env override — explicit pin (any binary).
+2. `./node_modules/.bin/tsx` — cwd-relative, lockfile-pinned.
+3. `./node_modules/.bin/bun`.
+4. `./node_modules/.bin/deno`.
+5. `tsx` on `PATH`.
+6. `bun` on `PATH`.
+7. `deno` on `PATH`.
+
+If nothing resolves, the command fails with the install hint
+shown above. `mvmctl doctor` surfaces the same hint in its
+`Tools` section — run it after a fresh checkout to confirm
+your host is wired up.


### PR DESCRIPTION
## Summary

Three UX improvements to Phase 7f's TypeScript auto-exec path
that `mvmctl compile <script.ts>` falls back to when a script
uses the record-mode `Sandbox` API:

- **`mvmctl doctor` probe.** New "TypeScript runner" check
  under the `Tools` section. WARN-only (`ok: true`) so a host
  without a TS runner doesn't fail doctor — the runner is only
  needed if the user actually runs `mvmctl compile` on a `.ts`
  script. Surfaces the same install hint as the `bail!` path.
- **Project-local resolution.** New `crate::ts_runner` module
  centralizes runner discovery + install-hint as one source of
  truth. Order: `MVM_TSX` → `./node_modules/.bin/{tsx,bun,deno}`
  (NEW) → `tsx`/`bun`/`deno` on PATH → install-hint bail. Lets
  users pin the runner via `package.json` devDependencies.
- **Install-recipe docs.** New "TypeScript runner" section in
  `public/src/content/docs/guides/sdk.md` with a per-OS install
  matrix (Homebrew / npm / pnpm / yarn / bun.sh / deno.land)
  and the resolution order spelled out.

## Test plan

- [x] `cargo fmt --check`
- [x] `cargo clippy --workspace --all-targets -- -D warnings`
- [x] `cargo run -p xtask -- check-no-display-on-secret-types`
- [x] `cargo test --workspace` — passes except the pre-existing
      `mk_guest_eval_assertions_all_pass_when_nix_available`
      nix-eval test that fails on macOS dev machines (documented
      in CLAUDE.md as expected on host envs without nix)
- [x] New unit tests in `ts_runner::tests` cover project-local
      discovery (tsx priority, bun + deno fall-through,
      none-found, project-local-vs-PATH precedence)
- [x] New `doctor::tests::ts_runner_check_*` tests cover the
      WARN posture (empty PATH → `ok: true` + install hint
      inlined) and the PASS posture (planted
      `./node_modules/.bin/tsx`)
- [x] New `compile::tests::resolve_interpreter_typescript_honours_mvm_tsx_override`
      pins the env-override short-circuit

Plan 73 spec: `specs/plans/73-sdk-port-followups.md` §"Followup F".

🤖 Generated with [Claude Code](https://claude.com/claude-code)