### PR TITLE
chore: scrub user-visible Lima references; rename lima_cpus → dev_vm_cpus

### DIFF
--- a/crates/mvm-backend/src/image.rs
+++ b/crates/mvm-backend/src/image.rs
@@ -374,7 +374,7 @@ fn repair_dev_null() -> Result<()> {
     // skip the command if /dev/null itself is broken.
     let check = run_in_vm("test -c /dev/null -a -w /dev/null")?;
     if !check.status.success() {
-        ui::warn("Repairing /dev/null in Lima VM...");
+        ui::warn("Repairing /dev/null in builder VM...");
         run_in_vm(
             "sudo rm -f /dev/null && sudo mknod /dev/null c 1 3 && sudo chmod 666 /dev/null",
         )?;

--- a/crates/mvm-cli/src/bootstrap.rs
+++ b/crates/mvm-cli/src/bootstrap.rs
@@ -113,10 +113,9 @@ pub fn check_homebrew() -> Result<()> {
 /// Print an informational hint about libkrun availability (plan 53
 /// §"Plan E"). libkrun is optional — when it's available, `mvmctl run`
 /// can use it as a Tier 2 backend on macOS Intel and macOS <26 (where
-/// Apple Container is unavailable) without going through Lima. This
-/// function does *not* attempt to install libkrun automatically since
-/// it lives in the host's package manager (Homebrew on macOS, distro
-/// packages on Linux).
+/// Apple Container is unavailable). This function does *not* attempt
+/// to install libkrun automatically since it lives in the host's
+/// package manager (Homebrew on macOS, distro packages on Linux).
 ///
 /// Idempotent and safe to call from any bootstrap path.
 pub fn hint_libkrun_if_useful() {
@@ -134,10 +133,10 @@ pub fn hint_libkrun_if_useful() {
     }
     // Only suggest the install on platforms where libkrun would
     // materially improve the user experience — i.e. macOS without
-    // Apple Container, where today the only path is Lima.
+    // Apple Container.
     if matches!(plat, Platform::MacOS) && !plat.has_apple_containers() {
         ui::info(&format!(
-            "Tip: install libkrun for a no-Lima Tier 2 microVM path on this Mac.\n  {}",
+            "Tip: install libkrun for a Tier 2 microVM path on this Mac.\n  {}",
             mvm_libkrun::install_hint()
         ));
     }

--- a/crates/mvm-cli/src/commands/env/dev.rs
+++ b/crates/mvm-cli/src/commands/env/dev.rs
@@ -178,9 +178,9 @@ pub(in crate::commands) fn run(_cli: &Cli, args: Args, cfg: &MvmConfig) -> Resul
             shell,
         } => {
             // CLI flag wins; otherwise fall back to per-user config defaults.
-            let effective_cpus = if cpus == 8 { cfg.lima_cpus } else { cpus };
+            let effective_cpus = if cpus == 8 { cfg.dev_vm_cpus } else { cpus };
             let effective_mem = if memory == 16 {
-                cfg.lima_mem_gib
+                cfg.dev_vm_mem_gib
             } else {
                 memory
             };
@@ -294,9 +294,9 @@ pub(in crate::commands) fn run(_cli: &Cli, args: Args, cfg: &MvmConfig) -> Resul
             let _ = std::fs::remove_dir_all(&cache_dir);
 
             // Up
-            let effective_cpus = if cpus == 8 { cfg.lima_cpus } else { cpus };
+            let effective_cpus = if cpus == 8 { cfg.dev_vm_cpus } else { cpus };
             let effective_mem = if memory == 16 {
-                cfg.lima_mem_gib
+                cfg.dev_vm_mem_gib
             } else {
                 memory
             };

--- a/crates/mvm-cli/src/commands/mod.rs
+++ b/crates/mvm-cli/src/commands/mod.rs
@@ -45,7 +45,7 @@ pub(in crate::commands) struct Cli {
 pub(in crate::commands) enum Commands {
     /// Full environment setup from scratch
     Bootstrap(env::bootstrap::Args),
-    /// Manage the Lima development environment (up, down, shell, status)
+    /// Manage the dev VM (up, down, shell, status). macOS uses Apple Container; Linux uses native KVM.
     Dev(env::dev::Args),
     /// Remove old dev-build artifacts and run Nix garbage collection
     Cleanup(env::cleanup::Args),
@@ -99,7 +99,7 @@ pub(in crate::commands) enum Commands {
     Metrics(ops::metrics::Args),
     /// Read or write global operator config (~/.mvm/config.toml)
     Config(ops::config::Args),
-    /// Remove Lima VM, Firecracker binary, and all mvm state (clean uninstall)
+    /// Remove the dev VM, Firecracker binary, and all mvm state (clean uninstall)
     Uninstall(env::uninstall::Args),
     /// View the local audit log (~/.mvm/log/audit.jsonl)
     Audit(ops::audit::Args),
@@ -305,7 +305,7 @@ pub fn run() -> Result<()> {
         tracing::warn!("failed to install signal handler: {e}");
     }
 
-    // Load operator config once; used as fallback for lima_cpus, lima_mem, cpus, memory.
+    // Load operator config once; used as fallback for dev_vm_cpus, dev_vm_mem_gib, cpus, memory.
     let cfg = mvm_core::user_config::load(None);
 
     // Plan 60 Phase 4 — wrap dispatch in cmd.<verb>.{invoked,completed,failed}

--- a/crates/mvm-cli/src/commands/ops/config.rs
+++ b/crates/mvm-cli/src/commands/ops/config.rs
@@ -21,7 +21,7 @@ pub(in crate::commands) enum ConfigAction {
     Edit,
     /// Set a single config key
     Set {
-        /// Config key (e.g. lima_cpus)
+        /// Config key (e.g. dev_vm_cpus)
         key: String,
         /// New value
         value: String,

--- a/crates/mvm-cli/src/commands/shared/hints.rs
+++ b/crates/mvm-cli/src/commands/shared/hints.rs
@@ -7,24 +7,21 @@ use crate::ui;
 pub fn with_hints(result: Result<()>) -> Result<()> {
     if let Err(ref e) = result {
         let msg = format!("{:#}", e);
-        if msg.contains("limactl: command not found") || msg.contains("limactl: not found") {
-            ui::warn("Hint: Install Lima with 'brew install lima' or run 'mvmctl bootstrap'.");
-        } else if msg.contains("firecracker: command not found")
-            || msg.contains("firecracker: not found")
+        if msg.contains("firecracker: command not found") || msg.contains("firecracker: not found")
         {
             ui::warn("Hint: Run 'mvmctl setup' to install Firecracker.");
         } else if msg.contains("/dev/kvm") {
             ui::warn(
                 "Hint: Enable KVM/virtualization in your BIOS or VM settings.\n      \
-                 On macOS, KVM is available inside the Lima VM.",
+                 On macOS, mvm uses Hypervisor.framework via libkrun — install it with 'brew install libkrun'.",
             );
         } else if msg.contains("Permission denied") && msg.contains(".mvm") {
             ui::warn("Hint: Check directory permissions on ~/.mvm (set MVM_DATA_DIR to override).");
         } else if msg.contains("nix: command not found") || msg.contains("nix: not found") {
-            ui::warn("Hint: Nix is installed inside the Lima VM. Run 'mvmctl shell' first.");
-        } else if msg.contains("Lima VM is not running") || msg.contains("VM is not started") {
+            ui::warn("Hint: Nix is installed inside the dev VM. Run 'mvmctl dev shell' first.");
+        } else if msg.contains("dev VM is not running") || msg.contains("VM is not started") {
             ui::warn(
-                "Hint: Start the dev environment with 'mvmctl dev' or run 'mvmctl setup' \
+                "Hint: Start the dev environment with 'mvmctl dev up' or run 'mvmctl setup' \
                  to initialise it first.",
             );
         } else if msg.contains("already exists") && msg.contains("template") {
@@ -41,17 +38,17 @@ pub fn with_hints(result: Result<()>) -> Result<()> {
         {
             ui::warn(
                 "Hint: Flake attribute not found. Your flake.lock may be stale.\n      \
-                 Try: nix flake update (inside the Lima VM or flake directory).",
+                 Try: nix flake update (from the flake directory).",
             );
         } else if msg.contains("No space left on device") || msg.contains("ENOSPC") {
             ui::warn(
                 "Hint: Disk full. Run 'mvmctl doctor' to check space, \
-                 or run 'nix-collect-garbage -d' inside the Lima VM.",
+                 or run 'nix-collect-garbage -d' inside the dev VM.",
             );
         } else if msg.contains("timed out") || msg.contains("connection refused") {
             ui::warn(
-                "Hint: The Lima VM may be unresponsive. Try 'mvmctl status' or \
-                 restart with 'mvmctl stop && mvmctl dev'.",
+                "Hint: The dev VM may be unresponsive. Try 'mvmctl dev status' or \
+                 restart with 'mvmctl dev down && mvmctl dev up'.",
             );
         } else if msg.contains("hash mismatch") && msg.contains("got:") {
             ui::warn(

--- a/crates/mvm-cli/src/commands/tests.rs
+++ b/crates/mvm-cli/src/commands/tests.rs
@@ -842,12 +842,12 @@ fn test_config_show_parses() {
 
 #[test]
 fn test_config_set_parses() {
-    let cli = Cli::try_parse_from(["mvmctl", "config", "set", "lima_cpus", "4"]).unwrap();
+    let cli = Cli::try_parse_from(["mvmctl", "config", "set", "dev_vm_cpus", "4"]).unwrap();
     match cli.command {
         Commands::Config(config::Args {
             action: ConfigAction::Set { key, value },
         }) => {
-            assert_eq!(key, "lima_cpus");
+            assert_eq!(key, "dev_vm_cpus");
             assert_eq!(value, "4");
         }
         _ => panic!("Expected Config Set command"),
@@ -855,23 +855,23 @@ fn test_config_set_parses() {
 }
 
 #[test]
-fn test_config_show_output_contains_lima_cpus() {
+fn test_config_show_output_contains_dev_vm_cpus() {
     let tmp = tempfile::tempdir().unwrap();
     let cfg = mvm_core::user_config::MvmConfig::default();
     mvm_core::user_config::save(&cfg, Some(tmp.path())).unwrap();
     let loaded = mvm_core::user_config::load(Some(tmp.path()));
     let text = toml::to_string_pretty(&loaded).unwrap();
-    assert!(text.contains("lima_cpus"));
+    assert!(text.contains("dev_vm_cpus"));
 }
 
 #[test]
 fn test_config_set_persists() {
     let tmp = tempfile::tempdir().unwrap();
     let mut cfg = mvm_core::user_config::load(Some(tmp.path()));
-    mvm_core::user_config::set_key(&mut cfg, "lima_cpus", "4").unwrap();
+    mvm_core::user_config::set_key(&mut cfg, "dev_vm_cpus", "4").unwrap();
     mvm_core::user_config::save(&cfg, Some(tmp.path())).unwrap();
     let reloaded = mvm_core::user_config::load(Some(tmp.path()));
-    assert_eq!(reloaded.lima_cpus, 4);
+    assert_eq!(reloaded.dev_vm_cpus, 4);
 }
 
 #[test]

--- a/crates/mvm-cli/src/config_watcher.rs
+++ b/crates/mvm-cli/src/config_watcher.rs
@@ -153,7 +153,7 @@ mod tests {
         std::thread::sleep(Duration::from_millis(50));
 
         let updated = MvmConfig {
-            lima_cpus: 4,
+            dev_vm_cpus: 4,
             ..MvmConfig::default()
         };
         write_config(&config_path, &updated);
@@ -164,7 +164,7 @@ mod tests {
         while std::time::Instant::now() < deadline {
             match watcher.receiver.try_recv() {
                 Ok(ConfigReloadEvent::Reloaded(cfg)) => {
-                    assert_eq!(cfg.lima_cpus, 4);
+                    assert_eq!(cfg.dev_vm_cpus, 4);
                     received = true;
                     break;
                 }
@@ -225,20 +225,20 @@ mod tests {
         let mut cfg = MvmConfig::default();
 
         let new_cfg = MvmConfig {
-            lima_cpus: 12,
+            dev_vm_cpus: 12,
             ..MvmConfig::default()
         };
         tx.send(ConfigReloadEvent::Reloaded(new_cfg)).unwrap();
 
         cfg = apply_pending_reloads(cfg, &rx);
-        assert_eq!(cfg.lima_cpus, 12);
+        assert_eq!(cfg.dev_vm_cpus, 12);
     }
 
     #[test]
     fn test_apply_pending_reloads_keeps_cfg_on_error() {
         let (tx, rx) = mpsc::channel();
         let mut cfg = MvmConfig {
-            lima_cpus: 6,
+            dev_vm_cpus: 6,
             ..MvmConfig::default()
         };
 
@@ -247,6 +247,6 @@ mod tests {
 
         cfg = apply_pending_reloads(cfg, &rx);
         // Config unchanged after parse error.
-        assert_eq!(cfg.lima_cpus, 6);
+        assert_eq!(cfg.dev_vm_cpus, 6);
     }
 }

--- a/crates/mvm-cli/src/security_cmd.rs
+++ b/crates/mvm-cli/src/security_cmd.rs
@@ -9,7 +9,7 @@ use crate::ui;
 
 /// Run the `mvm security status` command.
 ///
-/// Probes the host/Lima VM for security feature availability across
+/// Probes the host/builder VM for security feature availability across
 /// [`SecurityLayer`] variants and produces a posture report.
 pub fn run(json: bool) -> Result<()> {
     let checks = collect_checks();
@@ -232,11 +232,11 @@ fn no_vm_check(layer: SecurityLayer, name: &str) -> PostureCheck {
         layer,
         name: name.to_string(),
         passed: false,
-        detail: "Lima VM not running".to_string(),
+        detail: "builder VM not running".to_string(),
     }
 }
 
-/// Quick probe to see if the Lima VM is reachable.
+/// Quick probe to see if the builder VM is reachable.
 fn vm_is_reachable() -> bool {
     shell::run_in_vm_stdout("echo ok").is_ok()
 }
@@ -334,7 +334,7 @@ mod tests {
     fn test_no_vm_check_always_fails() {
         let check = no_vm_check(SecurityLayer::SeccompFilter, "Seccomp strict profile");
         assert!(!check.passed);
-        assert!(check.detail.contains("Lima VM not running"));
+        assert!(check.detail.contains("builder VM not running"));
     }
 
     #[test]

--- a/crates/mvm-core/src/user_config.rs
+++ b/crates/mvm-core/src/user_config.rs
@@ -24,10 +24,11 @@ pub struct SecurityConfig {
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(default)]
 pub struct MvmConfig {
-    /// vCPUs allocated to the Lima VM (default: 8)
-    pub lima_cpus: u32,
-    /// Memory in GiB allocated to the Lima VM (default: 16)
-    pub lima_mem_gib: u32,
+    /// vCPUs allocated to the dev VM (default: 8). macOS uses Apple
+    /// Container; Linux uses native KVM.
+    pub dev_vm_cpus: u32,
+    /// Memory in GiB allocated to the dev VM (default: 16).
+    pub dev_vm_mem_gib: u32,
     /// Default vCPU count for `mvmctl run` (default: 2)
     pub default_cpus: u32,
     /// Default memory in MiB for `mvmctl run` (default: 512)
@@ -45,8 +46,8 @@ pub struct MvmConfig {
 impl Default for MvmConfig {
     fn default() -> Self {
         Self {
-            lima_cpus: 8,
-            lima_mem_gib: 16,
+            dev_vm_cpus: 8,
+            dev_vm_mem_gib: 16,
             default_cpus: 2,
             default_memory_mib: 512,
             log_format: None,
@@ -134,14 +135,14 @@ pub fn save(cfg: &MvmConfig, override_dir: Option<&Path>) -> Result<()> {
 /// Returns `Err` for unknown keys or unparseable values.
 pub fn set_key(cfg: &mut MvmConfig, key: &str, value: &str) -> Result<()> {
     match key {
-        "lima_cpus" => {
-            cfg.lima_cpus = value.parse().with_context(|| {
-                format!("lima_cpus must be a positive integer, got {:?}", value)
+        "dev_vm_cpus" => {
+            cfg.dev_vm_cpus = value.parse().with_context(|| {
+                format!("dev_vm_cpus must be a positive integer, got {:?}", value)
             })?;
         }
-        "lima_mem_gib" => {
-            cfg.lima_mem_gib = value.parse().with_context(|| {
-                format!("lima_mem_gib must be a positive integer, got {:?}", value)
+        "dev_vm_mem_gib" => {
+            cfg.dev_vm_mem_gib = value.parse().with_context(|| {
+                format!("dev_vm_mem_gib must be a positive integer, got {:?}", value)
             })?;
         }
         "default_cpus" => {
@@ -185,7 +186,7 @@ pub fn set_key(cfg: &mut MvmConfig, key: &str, value: &str) -> Result<()> {
         }
         other => {
             anyhow::bail!(
-                "Unknown config key {:?}. Valid keys: lima_cpus, lima_mem_gib, \
+                "Unknown config key {:?}. Valid keys: dev_vm_cpus, dev_vm_mem_gib, \
                  default_cpus, default_memory_mib, log_format, metrics_port, catalog_url",
                 other
             );
@@ -201,8 +202,8 @@ mod tests {
     #[test]
     fn test_default_values() {
         let cfg = MvmConfig::default();
-        assert_eq!(cfg.lima_cpus, 8);
-        assert_eq!(cfg.lima_mem_gib, 16);
+        assert_eq!(cfg.dev_vm_cpus, 8);
+        assert_eq!(cfg.dev_vm_mem_gib, 16);
         assert_eq!(cfg.default_cpus, 2);
         assert_eq!(cfg.default_memory_mib, 512);
         assert!(cfg.log_format.is_none());
@@ -230,36 +231,36 @@ mod tests {
         // added must continue to deserialize cleanly with default security
         // values. Serde's `#[serde(default)]` on the struct gives us this.
         let legacy = r#"
-            lima_cpus = 4
-            lima_mem_gib = 8
+            dev_vm_cpus = 4
+            dev_vm_mem_gib = 8
             default_cpus = 2
             default_memory_mib = 512
         "#;
         let cfg: MvmConfig = toml::from_str(legacy).unwrap();
-        assert_eq!(cfg.lima_cpus, 4);
+        assert_eq!(cfg.dev_vm_cpus, 4);
         assert!(!cfg.security.ack_docker_tier);
     }
 
     #[test]
     fn test_toml_roundtrip() {
         let cfg = MvmConfig {
-            lima_cpus: 4,
+            dev_vm_cpus: 4,
             metrics_port: Some(9091),
             ..MvmConfig::default()
         };
 
         let text = toml::to_string_pretty(&cfg).unwrap();
         let parsed: MvmConfig = toml::from_str(&text).unwrap();
-        assert_eq!(parsed.lima_cpus, 4);
+        assert_eq!(parsed.dev_vm_cpus, 4);
         assert_eq!(parsed.metrics_port, Some(9091));
-        assert_eq!(parsed.lima_mem_gib, 16);
+        assert_eq!(parsed.dev_vm_mem_gib, 16);
     }
 
     #[test]
     fn test_load_from_empty_dir_returns_defaults_and_creates_file() {
         let tmp = tempfile::tempdir().unwrap();
         let cfg = load(Some(tmp.path()));
-        assert_eq!(cfg.lima_cpus, 8);
+        assert_eq!(cfg.dev_vm_cpus, 8);
         // File should have been created
         assert!(tmp.path().join("config.toml").exists());
     }
@@ -268,22 +269,22 @@ mod tests {
     fn test_save_and_load_roundtrip() {
         let tmp = tempfile::tempdir().unwrap();
         let cfg = MvmConfig {
-            lima_cpus: 6,
+            dev_vm_cpus: 6,
             default_memory_mib: 1024,
             ..MvmConfig::default()
         };
         save(&cfg, Some(tmp.path())).unwrap();
 
         let loaded = load(Some(tmp.path()));
-        assert_eq!(loaded.lima_cpus, 6);
+        assert_eq!(loaded.dev_vm_cpus, 6);
         assert_eq!(loaded.default_memory_mib, 1024);
     }
 
     #[test]
     fn test_set_key_known_key() {
         let mut cfg = MvmConfig::default();
-        set_key(&mut cfg, "lima_cpus", "4").unwrap();
-        assert_eq!(cfg.lima_cpus, 4);
+        set_key(&mut cfg, "dev_vm_cpus", "4").unwrap();
+        assert_eq!(cfg.dev_vm_cpus, 4);
     }
 
     #[test]
@@ -291,7 +292,7 @@ mod tests {
         let mut cfg = MvmConfig::default();
         let err = set_key(&mut cfg, "not_a_key", "5").unwrap_err();
         assert!(err.to_string().contains("Unknown config key"));
-        assert!(err.to_string().contains("lima_cpus"));
+        assert!(err.to_string().contains("dev_vm_cpus"));
     }
 
     #[test]
@@ -323,7 +324,7 @@ mod tests {
     #[test]
     fn test_set_key_invalid_value_error() {
         let mut cfg = MvmConfig::default();
-        let err = set_key(&mut cfg, "lima_cpus", "not-a-number").unwrap_err();
+        let err = set_key(&mut cfg, "dev_vm_cpus", "not-a-number").unwrap_err();
         assert!(err.to_string().contains("integer"));
     }
 }

--- a/public/src/components/landing/Architecture.tsx
+++ b/public/src/components/landing/Architecture.tsx
@@ -73,7 +73,7 @@ export function Architecture() {
                 </div>
                 <div className="mt-3 flex flex-wrap gap-x-4 gap-y-1 text-[10px] text-label">
                   <span><strong className="text-emphasis">Linux + KVM</strong> — native</span>
-                  <span><strong className="text-emphasis">macOS</strong> — via Lima VM</span>
+                  <span><strong className="text-emphasis">macOS</strong> — via libkrun / Apple Container</span>
                 </div>
               </div>
 
@@ -90,8 +90,8 @@ export function Architecture() {
                   </div>
                 </div>
                 <p className="mt-2 text-xs text-label leading-relaxed">
-                  Native macOS 26+ on Apple Silicon. Sub-second startup, no Lima
-                  needed.
+                  Native macOS 26+ on Apple Silicon. Sub-second startup via
+                  Apple Container.
                 </p>
                 <div className="mt-3 flex flex-wrap gap-1.5">
                   {["vsock", "fast boot"].map((c) => (
@@ -129,7 +129,7 @@ export function Architecture() {
                   ))}
                 </div>
                 <div className="mt-3 text-[10px] text-label">
-                  <strong className="text-emphasis">Linux</strong> — native or via Lima
+                  <strong className="text-emphasis">Linux</strong> — native KVM
                 </div>
               </div>
 

--- a/public/src/components/landing/Hero.tsx
+++ b/public/src/components/landing/Hero.tsx
@@ -4,7 +4,7 @@ import { Button } from "../ui/button";
 const lines = [
   { text: "$ mvmctl dev", delay: 0 },
   { text: "  Detecting platform... macOS (Apple Silicon)", delay: 800, dim: true },
-  { text: "  Backend: firecracker (via Lima)", delay: 1400, dim: true },
+  { text: "  Backend: libkrun (Apple Hypervisor.framework)", delay: 1400, dim: true },
   { text: "  Ready.", delay: 2000, accent: true },
   { text: "", delay: 2400 },
   { text: "$ mvmctl build --flake .", delay: 2800 },

--- a/public/src/content/docs/reference/cli-commands.md
+++ b/public/src/content/docs/reference/cli-commands.md
@@ -41,17 +41,16 @@ description: Complete command reference for mvmctl.
 
 | Command | Description |
 |---------|-------------|
-| `mvmctl bootstrap` | Full setup from scratch: Homebrew deps (macOS), Lima, Firecracker, kernel, rootfs (idempotent — safe to re-run) |
+| `mvmctl bootstrap` | Full setup from scratch: Homebrew deps (macOS), Firecracker, kernel, rootfs (idempotent — safe to re-run) |
 | `mvmctl bootstrap --production` | Production mode (skip Homebrew, assume Linux with apt) |
-| `mvmctl dev [up]` | Auto-bootstrap if needed, start dev VM, drop into shell. Uses Apple Container on macOS 26+, Lima otherwise. |
+| `mvmctl dev [up]` | Auto-bootstrap if needed, start dev VM, drop into shell. Uses Apple Container on macOS 26+; native KVM on Linux. |
 | `mvmctl dev up --project ~/dir` | Auto-bootstrap then cd into a project directory |
 | `mvmctl dev up --metrics-port PORT` | Bind a Prometheus metrics endpoint (0 = disabled) |
 | `mvmctl dev up --watch-config` | Reload ~/.mvm/config.toml automatically when it changes |
-| `mvmctl dev up --lima` | Force Lima backend even on macOS 26+ |
 | `mvmctl dev up --shell` (or `-s`) | Open an interactive shell after starting |
-| `mvmctl dev down` | Stop the Lima development VM |
+| `mvmctl dev down` | Stop the dev VM |
 | `mvmctl dev down --reset` | Also delete the cached dev image so the next `dev up` rebuilds from local source |
-| `mvmctl dev shell` | Open a shell in the running Lima VM |
+| `mvmctl dev shell` | Open a shell in the running dev VM |
 | `mvmctl dev shell --project ~/dir` | Open shell and cd into a project directory |
 | `mvmctl dev status` | Show dev environment backend, running state, and cached image paths |
 | `mvmctl dev rebuild` | Stop, clear cache, and rebuild + restart the dev VM |
@@ -128,7 +127,7 @@ description: Complete command reference for mvmctl.
 |---------|-------------|
 | `mvmctl config show` | Print current config as TOML |
 | `mvmctl config edit` | Open the config file in $EDITOR (falls back to nano) |
-| `mvmctl config set <key> <value>` | Set a single config key (e.g. `mvmctl config set lima_cpus 4`) |
+| `mvmctl config set <key> <value>` | Set a single config key (e.g. `mvmctl config set dev_vm_cpus 4`) |
 
 ## Audit
 


### PR DESCRIPTION
## Summary

- ADR-013 retired Lima but its name was still showing up in CLI help, hints, config keys, landing page, and public docs. Refresh the user-facing surfaces to match what mvmctl actually runs (Apple Container, libkrun, native KVM, dev VM).
- Rename config keys `lima_cpus` / `lima_mem_gib` → `dev_vm_cpus` / `dev_vm_mem_gib`. No legacy alias — first version, per repo policy (no backcompat shims).

## Files touched

- CLI surface: `commands/mod.rs`, `commands/env/dev.rs`, `commands/ops/config.rs`, `commands/shared/hints.rs`, `commands/tests.rs`, `config_watcher.rs`, `security_cmd.rs`, `bootstrap.rs`
- Core: `mvm-core/src/user_config.rs` (struct fields, set_key, tests)
- Runtime message: `mvm-backend/src/image.rs` (repair_dev_null warn)
- Public surfaces: `public/src/content/docs/reference/cli-commands.md`, landing `Hero.tsx` + `Architecture.tsx`

Internal historical comments that say "ADR-013 dropped Lima" or "Lima-era resolver" are left alone — they're informational migration markers, not user-visible. Same for `specs/backlog/*` (frozen sprint archives) and ADRs 001/013 (the historical record of the Lima removal itself).

## Test plan

- [x] `cargo build -p mvm-cli -p mvm-core -p mvm-backend` — green
- [x] `cargo test -p mvm-cli --lib` — 530 passed
- [x] `cargo test -p mvm-core --lib` — 541 passed
- [x] `cargo clippy -p mvm-cli -p mvm-core -p mvm-backend -- -D warnings` — zero warnings
- [x] `cargo fmt --check` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)