### PR TITLE
[codex] Add run dry-run preflight output

### DIFF
--- a/crates/mvm-cli/src/commands/tests.rs
+++ b/crates/mvm-cli/src/commands/tests.rs
@@ -1346,6 +1346,7 @@ fn run_default_profile_argv_only() {
             timeout,
             receipt,
             json,
+            dry_run,
             launch_plan,
             argv,
         }) => {
@@ -1358,6 +1359,7 @@ fn run_default_profile_argv_only() {
             assert_eq!(timeout, 60);
             assert!(receipt.is_none(), "receipt should default to None");
             assert!(!json, "json should default to false");
+            assert!(!dry_run, "dry_run should default to false");
             assert!(launch_plan.is_none(), "launch_plan should default to None");
             assert_eq!(argv, vec!["uname".to_string(), "-a".to_string()]);
         }
@@ -1418,6 +1420,25 @@ fn run_json_flag_parses() {
     let cli = Cli::try_parse_from(["mvmctl", "run", "--json", "--", "/bin/true"]).expect("parse");
     match cli.command {
         Commands::Run(exec::RunArgs { json, argv, .. }) => {
+            assert!(json);
+            assert_eq!(argv, vec!["/bin/true".to_string()]);
+        }
+        _ => panic!("Expected Run command"),
+    }
+}
+
+#[test]
+fn run_dry_run_json_flags_parse() {
+    let cli = Cli::try_parse_from(["mvmctl", "run", "--dry-run", "--json", "--", "/bin/true"])
+        .expect("parse");
+    match cli.command {
+        Commands::Run(exec::RunArgs {
+            dry_run,
+            json,
+            argv,
+            ..
+        }) => {
+            assert!(dry_run);
             assert!(json);
             assert_eq!(argv, vec!["/bin/true".to_string()]);
         }

--- a/crates/mvm-cli/src/commands/vm/exec.rs
+++ b/crates/mvm-cli/src/commands/vm/exec.rs
@@ -110,6 +110,13 @@ pub(in crate::commands) struct RunArgs {
     /// artifact is needed.
     #[arg(long)]
     pub json: bool,
+    /// Validate and explain the effective run plan without booting a VM.
+    ///
+    /// This preflight never resolves, builds, or starts the selected image. It
+    /// reports hashes and policy-relevant metadata only; raw argv, env values,
+    /// and host paths are omitted.
+    #[arg(long)]
+    pub dry_run: bool,
     /// Path to an mvmforge launch document. Mutually exclusive with trailing argv.
     #[arg(long, value_name = "PATH", conflicts_with = "argv")]
     pub launch_plan: Option<String>,
@@ -178,6 +185,19 @@ pub(in crate::commands) fn run_receipt(
 
 pub(in crate::commands) fn run_secure(cli: &Cli, args: RunArgs, cfg: &MvmConfig) -> Result<()> {
     validate_run_profile(&args)?;
+    if args.dry_run {
+        let summary = RunPreflightSummary::from_args(&args)?;
+        if args.json {
+            println!(
+                "{}",
+                serde_json::to_string_pretty(&summary)
+                    .context("serializing run preflight JSON summary")?
+            );
+        } else {
+            print_run_preflight_human(&summary);
+        }
+        return Ok(());
+    }
     let receipt_path = args.receipt.clone();
     if args.json || receipt_path.is_some() {
         let receipt_input = ReceiptInput::from_run_args(&args)?;
@@ -271,18 +291,7 @@ fn build_exec_request(args: Args, command_name: &str) -> Result<crate::exec::Exe
     }
     let mut env_pairs = Vec::with_capacity(args.env.len());
     for kv in &args.env {
-        let (k, v) = kv
-            .split_once('=')
-            .ok_or_else(|| anyhow::anyhow!("--env '{kv}': expected KEY=VALUE"))?;
-        if k.is_empty() {
-            anyhow::bail!("--env '{kv}': KEY must not be empty");
-        }
-        if !k.chars().all(|c| c.is_ascii_alphanumeric() || c == '_')
-            || k.starts_with(|c: char| c.is_ascii_digit())
-        {
-            anyhow::bail!("--env '{kv}': KEY must match [A-Za-z_][A-Za-z0-9_]* (got '{k}')");
-        }
-        env_pairs.push((k.to_string(), v.to_string()));
+        env_pairs.push(parse_env_pair(kv)?);
     }
     // Plan 38 §4: --manifest <PATH> accepts a manifest path / dir in
     // addition to legacy names. Resolve up front so the downstream
@@ -396,6 +405,49 @@ struct RunJsonSummary {
     receipt_path: Option<PathBuf>,
 }
 
+#[derive(Debug, Clone, Serialize, Deserialize)]
+struct RunPreflightSummary {
+    schema_version: u32,
+    dry_run: bool,
+    will_execute: bool,
+    invocation: RunPreflightInvocation,
+    resources: RunPreflightResources,
+    image: RunPreflightImage,
+    receipt: RunPreflightReceipt,
+    notes: Vec<String>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+struct RunPreflightReceipt {
+    requested: bool,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    path_sha256: Option<String>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+struct RunPreflightInvocation {
+    profile: String,
+    command: ReceiptCommand,
+    env_keys: Vec<String>,
+    add_dirs: Vec<ReceiptAddDir>,
+    timeout_secs: u64,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+struct RunPreflightResources {
+    cpus: u32,
+    memory: String,
+    memory_mib: u32,
+    timeout_secs: u64,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(tag = "kind", rename_all = "snake_case")]
+enum RunPreflightImage {
+    DefaultMicrovm,
+    Manifest { argument_sha256: String },
+}
+
 impl RunJsonSummary {
     fn from_parts(
         invocation: ReceiptInput,
@@ -407,6 +459,112 @@ impl RunJsonSummary {
             invocation,
             outcome: ReceiptOutcome::from_exec_output(output),
             receipt_path,
+        }
+    }
+}
+
+impl RunPreflightSummary {
+    fn from_args(args: &RunArgs) -> Result<Self> {
+        let memory_mib = parse_human_size(&args.memory).context("Invalid --memory")?;
+        for kv in &args.env {
+            parse_env_pair(kv)?;
+        }
+        // Force mount parsing now so dry-run rejects the same malformed or
+        // disallowed host-share specs as an actual run, without resolving an
+        // image or touching the VM runtime.
+        for spec in &args.add_dir {
+            crate::exec::AddDir::parse(spec)?;
+        }
+        let image = match args.manifest.as_ref() {
+            Some(manifest) => RunPreflightImage::Manifest {
+                argument_sha256: sha256_hex(manifest.as_bytes()),
+            },
+            None => RunPreflightImage::DefaultMicrovm,
+        };
+        let mut notes = vec![
+            "preflight only; no image was resolved, built, booted, or executed".to_string(),
+            "raw argv, env values, and host paths are intentionally omitted".to_string(),
+        ];
+        if args.receipt.is_some() {
+            notes.push(
+                "receipt path is hashed, but no receipt is written during dry-run".to_string(),
+            );
+        }
+
+        let receipt_input = ReceiptInput::from_run_args(args)?;
+
+        Ok(Self {
+            schema_version: 1,
+            dry_run: true,
+            will_execute: false,
+            invocation: RunPreflightInvocation {
+                profile: receipt_input.profile,
+                command: receipt_input.command,
+                env_keys: receipt_input.env_keys,
+                add_dirs: receipt_input.add_dirs,
+                timeout_secs: receipt_input.timeout_secs,
+            },
+            resources: RunPreflightResources {
+                cpus: args.cpus,
+                memory: args.memory.clone(),
+                memory_mib,
+                timeout_secs: args.timeout,
+            },
+            image,
+            receipt: RunPreflightReceipt {
+                requested: args.receipt.is_some(),
+                path_sha256: args
+                    .receipt
+                    .as_ref()
+                    .map(|path| sha256_hex(path.to_string_lossy().as_bytes())),
+            },
+            notes,
+        })
+    }
+}
+
+fn print_run_preflight_human(summary: &RunPreflightSummary) {
+    println!("mvmctl run dry-run: no VM will be booted");
+    match &summary.image {
+        RunPreflightImage::DefaultMicrovm => {
+            println!("image: bundled default microVM (not resolved)");
+        }
+        RunPreflightImage::Manifest { argument_sha256 } => {
+            println!("image: manifest/template argument sha256={argument_sha256} (not resolved)");
+        }
+    }
+    println!(
+        "resources: cpus={} memory={} ({} MiB) timeout={}s",
+        summary.resources.cpus,
+        summary.resources.memory,
+        summary.resources.memory_mib,
+        summary.resources.timeout_secs
+    );
+    println!("profile: {}", summary.invocation.profile);
+    println!("command: {}", summary.invocation.command.describe());
+    if summary.invocation.env_keys.is_empty() {
+        println!("env: none");
+    } else {
+        println!("env keys: {}", summary.invocation.env_keys.join(","));
+    }
+    if summary.invocation.add_dirs.is_empty() {
+        println!("host shares: none");
+    } else {
+        println!("host shares:");
+        for dir in &summary.invocation.add_dirs {
+            println!(
+                "  host_sha256={} -> {} ({})",
+                dir.host_path_sha256,
+                dir.guest_path,
+                if dir.read_only { "ro" } else { "rw" }
+            );
+        }
+    }
+    if summary.receipt.requested {
+        if let Some(path_sha256) = &summary.receipt.path_sha256 {
+            println!("receipt: requested path_sha256={path_sha256} (not written in dry-run)");
+        } else {
+            println!("receipt: requested (not written in dry-run)");
         }
     }
 }
@@ -463,6 +621,20 @@ impl ReceiptInput {
     }
 }
 
+impl ReceiptCommand {
+    fn describe(&self) -> String {
+        match self {
+            Self::Inline {
+                argv_len,
+                argv_sha256,
+            } => format!("inline argv_len={argv_len} argv_sha256={argv_sha256}"),
+            Self::LaunchPlan { path_sha256 } => {
+                format!("launch_plan path_sha256={path_sha256}")
+            }
+        }
+    }
+}
+
 impl ReceiptOutcome {
     fn from_exec_output(output: &crate::exec::ExecOutput) -> Self {
         Self {
@@ -474,6 +646,21 @@ impl ReceiptOutcome {
             stderr_bytes: output.stderr.len(),
         }
     }
+}
+
+fn parse_env_pair(kv: &str) -> Result<(String, String)> {
+    let (k, v) = kv
+        .split_once('=')
+        .ok_or_else(|| anyhow::anyhow!("--env '{kv}': expected KEY=VALUE"))?;
+    if k.is_empty() {
+        anyhow::bail!("--env '{kv}': KEY must not be empty");
+    }
+    if !k.chars().all(|c| c.is_ascii_alphanumeric() || c == '_')
+        || k.starts_with(|c: char| c.is_ascii_digit())
+    {
+        anyhow::bail!("--env '{kv}': KEY must match [A-Za-z_][A-Za-z0-9_]* (got '{k}')");
+    }
+    Ok((k.to_string(), v.to_string()))
 }
 
 fn write_run_receipt(
@@ -587,6 +774,7 @@ mod tests {
             timeout: 60,
             receipt: None,
             json: false,
+            dry_run: false,
             launch_plan: None,
             argv: vec!["/bin/true".to_string()],
         }
@@ -681,6 +869,44 @@ mod tests {
         assert!(json.contains("/tmp/receipt.json"));
         assert!(!json.contains("sensitive stdout"));
         assert!(!json.contains("sensitive stderr"));
+    }
+
+    #[test]
+    fn run_preflight_summary_is_redacted_and_does_not_execute() {
+        let mut args = run_args(RunProfile::Dev);
+        args.dry_run = true;
+        args.json = true;
+        args.manifest = Some("/private/manifest/mvm.toml".to_string());
+        args.argv = vec!["curl".to_string(), "token-secret".to_string()];
+        args.env.push("API_TOKEN=secret-value".to_string());
+        args.add_dir.push("/private/project:/work:ro".to_string());
+        args.receipt = Some(PathBuf::from("/tmp/run-receipt.json"));
+
+        let summary = RunPreflightSummary::from_args(&args).expect("preflight summary");
+        let json = serde_json::to_string(&summary).expect("serialize summary");
+
+        assert!(summary.dry_run);
+        assert!(!summary.will_execute);
+        assert_eq!(summary.resources.memory_mib, 512);
+        assert!(json.contains("\"kind\":\"manifest\""));
+        assert!(json.contains("API_TOKEN"));
+        assert!(json.contains("/work"));
+        assert!(json.contains("\"requested\":true"));
+        assert!(!json.contains("/tmp/run-receipt.json"));
+        assert!(!json.contains("/private/manifest/mvm.toml"));
+        assert!(!json.contains("token-secret"));
+        assert!(!json.contains("secret-value"));
+        assert!(!json.contains("/private/project"));
+    }
+
+    #[test]
+    fn run_preflight_validates_env_keys() {
+        let mut args = run_args(RunProfile::Standard);
+        args.dry_run = true;
+        args.env.push("1BAD=value".to_string());
+
+        let err = RunPreflightSummary::from_args(&args).expect_err("invalid env key");
+        assert!(err.to_string().contains("KEY must match"));
     }
 
     #[test]

--- a/public/src/content/docs/reference/cli-commands.md
+++ b/public/src/content/docs/reference/cli-commands.md
@@ -195,11 +195,19 @@ dev-feature guest agent; production guests should use `mvmctl invoke`.
 | `mvmctl run --env KEY=VAL -- <cmd>` | Inject an explicit environment variable. Repeatable; disabled by `--profile restrictive` |
 | `mvmctl run --cpus <n> --memory <size> -- <cmd>` | Resize the transient VM |
 | `mvmctl run --timeout <secs> -- <cmd>` | Per-command timeout |
+| `mvmctl run --dry-run -- <cmd>` | Validate and explain the run plan without resolving an image, booting a VM, writing a receipt, or executing the command |
+| `mvmctl run --dry-run --json -- <cmd>` | Print the dry-run preflight summary as redacted JSON |
 | `mvmctl run --receipt <path> -- <cmd>` | Write a signed JSON receipt with invocation hashes, output hashes, and exit status. Raw argv, env values, stdout, and stderr are not stored. |
 | `mvmctl run --json -- <cmd>` | Print a redacted JSON execution summary with invocation metadata and output hashes. Guest stdout/stderr are not streamed. |
 | `mvmctl run --json --receipt <path> -- <cmd>` | Print the same JSON summary and also write a signed receipt artifact |
 | `mvmctl receipt verify <path>` | Verify a signed run receipt against `~/.mvm/keys/host-signer.pub` |
 | `mvmctl receipt verify <path> --pubkey <path>` | Verify a signed run receipt against an explicit raw Ed25519 public key |
+
+`run --dry-run` is a preflight-only path. It validates profile, env-key,
+resource, and host-share policy, then reports hashes and policy-relevant
+metadata. Manifest arguments, argv, host paths, and receipt paths are hashed
+rather than printed. It deliberately does not resolve manifests, build/download
+the default image, start a VM, execute the command, or write a receipt.
 
 `run --json` is intended for machine callers. It preserves the command's exit
 code, but the JSON does not include raw argv, env values, stdout, stderr, or host

--- a/specs/SPRINT.md
+++ b/specs/SPRINT.md
@@ -1626,6 +1626,11 @@ Shipped:
 - `mvmctl run --json` emits an unsigned machine-readable execution summary
   using the same redacted invocation/outcome shape as receipts. Guest stdout
   and stderr are not streamed in JSON mode; only hashes and byte counts appear.
+- `mvmctl run --dry-run` validates and explains the run plan without resolving
+  an image, building/downloading the default image, booting a VM, writing a
+  receipt, or executing the command. `--dry-run --json` emits the same redacted
+  preflight shape for machine callers, hashing manifest arguments, argv, env
+  values, host paths, and receipt paths.
 - Live smoke coverage for `mvmctl run --json --receipt` is gated behind
   `MVM_LIVE_SMOKE=1` and compares the public JSON summary to the signed
   receipt without allowing raw guest output into either artifact.


### PR DESCRIPTION
## Summary

Adds a preflight mode for the secure one-shot run UX:

- `mvmctl run --dry-run` validates and explains the effective run plan without resolving/building an image, booting a VM, writing a receipt, or executing the command
- `mvmctl run --dry-run --json` emits a machine-readable redacted summary
- hashes manifest arguments, argv, host paths, env values, and receipt paths instead of printing sensitive values
- documents the command and updates `specs/SPRINT.md`

## Verification

- `cargo fmt --check`
- `cargo test -p mvm-cli json`
- `cargo test -p mvm-cli run_preflight`
- `cargo test -p mvm-cli dry_run`
- `cargo check -p mvm-cli`
- `cargo clippy -p mvm-cli -- -D warnings`
- `cargo test -p mvm-cli -- --test-threads=1`
- `cargo run --quiet -- run --dry-run --json --manifest /private/manifest/mvm.toml --env API_TOKEN=secret-value --add-dir /private/project:/work:ro --receipt /tmp/run-receipt.json -- curl token-secret`
