### PR TITLE
docs: scrub user-facing Lima references across public docs site

### DIFF
--- a/public/src/content/docs/contributing/adr/001-multi-backend.md
+++ b/public/src/content/docs/contributing/adr/001-multi-backend.md
@@ -24,7 +24,7 @@ Use Firecracker as the primary production backend. Support multiple backends: Ap
 ## Rationale
 
 - **Firecracker**: Minimalist design (<50K LOC), ~125ms cold boot, snapshot support, hardware isolation via KVM
-- **Apple Container**: Sub-second startup on macOS 26+, no Lima overhead, native vsock -- ideal for dev workflows
+- **Apple Container**: Sub-second startup on macOS 26+, native Hypervisor.framework, native vsock -- ideal for dev workflows
 - **Auto-selection**: Developers get the best experience on their platform without manual configuration
 - **Docker**: Universal fallback when no hypervisor is available -- pause/resume via container lifecycle, unix socket guest channel
 - **microvm.nix**: NixOS-native QEMU runner with vsock and TAP networking support
@@ -35,14 +35,14 @@ Use Firecracker as the primary production backend. Support multiple backends: Ap
 1. **KVM available** (Linux with `/dev/kvm`) -- Firecracker directly
 2. **macOS 26+** (Apple Silicon) -- Apple Virtualization.framework
 3. **Docker running** -- Docker as container-based fallback
-4. **Other** (macOS <26, Linux without KVM) -- Lima VM + Firecracker
+4. **Other** (macOS <26 / Intel, Linux without KVM) -- libkrun via Hypervisor.framework, or Docker fallback (see ADR-013)
 
 Override with `--hypervisor firecracker`, `--hypervisor apple-container`, `--hypervisor qemu`, or `--hypervisor docker`.
 
 ## Consequences
 
 - Requires Linux with `/dev/kvm` for native Firecracker, or macOS 26+ for Apple Container
-- Lima is only needed as a fallback (macOS <26 or Linux without KVM, and Docker not available)
+- macOS <26 / Intel falls back to libkrun via Hypervisor.framework; Docker is the final tier (see ADR-013 for the Lima retirement)
 - Guests must use a Linux kernel (no Windows/macOS guests)
 - No OCI image compatibility -- uses Nix flakes for image building instead
 - Snapshots only available on Firecracker backend

--- a/public/src/content/docs/contributing/development.md
+++ b/public/src/content/docs/contributing/development.md
@@ -6,7 +6,7 @@ description: Getting started as a contributor to mvm.
 ## Prerequisites
 
 - **Rust 1.85+** (Edition 2024) — install via [rustup](https://rustup.rs)
-- **macOS or Linux** — macOS for development via Lima, Linux for native `/dev/kvm`
+- **macOS or Linux** — macOS for development via Apple Container (26+) or libkrun (pre-26); Linux for native `/dev/kvm`
 - **Nix** (optional) — only needed for building microVM images
 
 Run the bootstrap script on a fresh machine:
@@ -24,7 +24,7 @@ just build
 # Run CLI
 just run -- --help
 
-# Dev mode (auto-bootstraps Lima + Firecracker)
+# Dev mode (auto-bootstraps the dev VM + Firecracker)
 just run -- dev
 
 # Release build (stripped, LTO)
@@ -80,18 +80,19 @@ just lint         # Both format check + clippy
 
 ### Multi-Backend
 
-mvmctl supports four backends: Firecracker (native Linux), Apple Container (macOS 26+), Docker (universal fallback), and microvm.nix (NixOS QEMU). The `VmBackend` trait in `mvm-core` abstracts the lifecycle; `AnyBackend` in `mvm-runtime` dispatches at runtime. Auto-selection priority: KVM → Apple Container → Docker → Lima + Firecracker.
+mvmctl supports five backends: Firecracker (native Linux), Apple Container (macOS 26+), libkrun (macOS Intel / pre-26 via Hypervisor.framework), Docker (universal fallback), and microvm.nix (NixOS QEMU). The `VmBackend` trait in `mvm-core` abstracts the lifecycle; `AnyBackend` in `mvm-runtime` dispatches at runtime. Auto-selection priority: KVM → Apple Container → libkrun → Docker.
 
 ### Host vs. VM
 
-All Linux operations (networking, Firecracker, cgroups) run inside the Lima VM on macOS <26:
+All Linux operations (networking, Firecracker, cgroups) run inside the builder VM on macOS:
 
 ```rust
-// This runs a bash script inside the Lima VM (or natively on Linux with KVM)
+// On Linux this runs directly on the host; on macOS it routes into the
+// libkrun-backed builder VM.
 mvm_runtime::shell::run_in_vm("ip link add br-tenant-1 type bridge")?;
 ```
 
-On native Linux, `run_in_vm` runs directly without Lima. On macOS 26+, the Apple Container backend handles VM lifecycle natively.
+On native Linux, `run_in_vm` executes directly on the host. On macOS, it delegates into the builder VM (Apple Container on 26+, libkrun on pre-26).
 
 ### Key Patterns
 
@@ -114,7 +115,7 @@ When adding fields to structs in serialized state:
 Beyond the standard build/test/lint cycle, mvmctl provides commands for managing the dev environment:
 
 ```bash
-# First-time setup (installs deps, creates Lima VM, default network)
+# First-time setup (installs deps, creates the dev VM, default network)
 just run -- init
 
 # Image catalog — browse and build images from Nix templates

--- a/public/src/content/docs/deploy/aws.md
+++ b/public/src/content/docs/deploy/aws.md
@@ -52,7 +52,7 @@ cargo install --git https://github.com/tinylabscom/mvm mvmctl
 mvmctl bootstrap
 ```
 
-`mvmctl bootstrap` is idempotent. On a Linux host with `/dev/kvm` it skips the Lima install (Lima is only needed on macOS). It pulls the dev image, verifies the SHA-256 manifest (claim 6), and installs Firecracker.
+`mvmctl bootstrap` is idempotent. On a Linux host with `/dev/kvm` it installs Firecracker, pulls the dev image, and verifies the SHA-256 manifest (claim 6).
 
 ## Verify Tier 1 isolation
 
@@ -81,7 +81,6 @@ Rule of thumb:
 - 10 GiB — Nix store overhead (mvm bootstrap closure)
 - 5 GiB per Firecracker rootfs you keep around
 - 5–20 GiB per template snapshot
-- 5 GiB Lima VM (only on macOS hosts; not applicable here)
 
 For a CI runner that builds and runs a few microVMs, 50 GiB is comfortable. For a developer instance with many templates, 100 GiB.
 

--- a/public/src/content/docs/deploy/ubicloud.md
+++ b/public/src/content/docs/deploy/ubicloud.md
@@ -37,7 +37,7 @@ The Ubicloud VM gives you `/dev/kvm` (it advertises nested virt to the guest), s
 
 Use the Ubicloud console or CLI to provision a VM. Recommended sizing for an mvm host:
 
-- **vCPUs**: 8+ (mvm guests cost 1–2 vCPUs each; the host needs headroom for the Lima-equivalent build environment)
+- **vCPUs**: 8+ (mvm guests cost 1–2 vCPUs each; the host needs headroom for build work)
 - **RAM**: 16+ GiB
 - **Disk**: 100+ GiB
 - **Image**: Ubuntu 24.04 LTS
@@ -59,7 +59,7 @@ cargo install --git https://github.com/tinylabscom/mvm mvmctl
 mvmctl bootstrap
 ```
 
-Same as the [AWS guide](/deploy/aws) from this point on. `mvmctl bootstrap` detects `/dev/kvm` and skips the Lima install path.
+Same as the [AWS guide](/deploy/aws) from this point on. `mvmctl bootstrap` detects `/dev/kvm` and uses Firecracker natively.
 
 ## Verify
 

--- a/public/src/content/docs/getting-started/first-microvm.md
+++ b/public/src/content/docs/getting-started/first-microvm.md
@@ -12,20 +12,20 @@ mvmctl auto-selects the best backend for your platform:
 ```
 Linux (KVM):    mvmctl up  -->  Firecracker microVM (direct)
 macOS 26+:      mvmctl up  -->  Apple Container (Virtualization.framework)
-Docker:         mvmctl up  -->  Docker container (universal fallback)
-macOS <26:      mvmctl up  -->  Lima VM  -->  Firecracker microVM
+macOS <26:     mvmctl up  -->  libkrun microVM (Hypervisor.framework)
+Docker:        mvmctl up  -->  Docker container (Tier 3 fallback)
 ```
 
 | Layer | Access command | Has your project files? |
 |-------|---------------|------------------------|
 | Host | Your normal terminal | Yes |
-| Lima VM (macOS <26) | `mvmctl dev` or `mvmctl dev shell` | Yes (~ mounted read/write) |
+| Dev VM (macOS) | `mvmctl dev` or `mvmctl dev shell` | Yes (~ mounted read/write) |
 | MicroVM | (headless, no SSH) | No (isolated filesystem) |
 
 MicroVMs are **headless workloads** with no SSH access -- they communicate via vsock only.
 
 :::note
-On Linux with `/dev/kvm`, the Lima layer is skipped entirely -- Firecracker runs directly. On macOS 26+, Apple Virtualization.framework is used instead of Lima + Firecracker. If neither is available, Docker serves as a universal fallback.
+On Linux with `/dev/kvm`, the dev-VM layer is skipped entirely -- Firecracker runs directly. On macOS 26+, Apple Virtualization.framework is used. On macOS pre-26 (Intel or older Apple Silicon), libkrun runs microVMs via Hypervisor.framework. If none of those work, Docker serves as a Tier 3 fallback.
 :::
 
 ## Scaffold a project

--- a/public/src/content/docs/getting-started/installation.md
+++ b/public/src/content/docs/getting-started/installation.md
@@ -48,7 +48,7 @@ mvmctl automatically detects your platform at startup and selects the best VM ba
 | Platform | Backend | What happens |
 |----------|---------|-------------|
 | **Linux with `/dev/kvm`** | Firecracker | Runs directly on KVM. Smallest attack surface, fastest cold boot. |
-| **macOS** (Apple Silicon / Intel) | microsandbox (libkrun) | Native Hypervisor.framework. No Lima, no Docker Desktop. |
+| **macOS** (Apple Silicon / Intel) | microsandbox (libkrun) | Native Hypervisor.framework. No Docker Desktop required. |
 | **Linux without `/dev/kvm`** | microsandbox | Software-emulation fallback (slower; meant for CI runners). |
 | **Docker available** | Docker | Tier 3 container fallback. Used only if no hypervisor backend works. |
 

--- a/public/src/content/docs/guides/building-microvm-images.md
+++ b/public/src/content/docs/guides/building-microvm-images.md
@@ -187,7 +187,7 @@ nix flake check --no-build
 mvm bootstraps a Linux builder microVM on first build (microsandbox-backed; see [ADR-013 §"Linux builder via microsandbox"](/contributing/adr/013-microsandbox-pivot/)) and runs `nix build` inside it. You don't need host-side Nix.
 
 - **Linux**: the builder microVM runs on Firecracker against `/dev/kvm`. Firecracker is also the default runtime backend. If you've opted into host-side Nix and it can build Linux derivations, mvm uses it directly and skips the builder VM.
-- **macOS**: the builder microVM runs on libkrun via Hypervisor.framework — no Lima hop. The resulting microVM is then booted on the same backend. If you already have [`nix-darwin`'s `linux-builder`](https://nix.dev/manual/nix/stable/installation/installing-binary) or a remote `nix-daemon` configured, mvm detects and uses it instead.
+- **macOS**: the builder microVM runs on libkrun via Hypervisor.framework. The resulting microVM is then booted on the same backend. If you already have [`nix-darwin`'s `linux-builder`](https://nix.dev/manual/nix/stable/installation/installing-binary) or a remote `nix-daemon` configured, mvm detects and uses it instead.
 - **Windows**: Tauri-only (the `mvm-studio` desktop app packages a WSL2-backed builder + runtime). See [ADR-031](https://github.com/tinylabscom/mvm/blob/main/specs/adrs/031-cross-platform-strategy.md).
 
 ## Rootless workloads

--- a/public/src/content/docs/guides/exec.md
+++ b/public/src/content/docs/guides/exec.md
@@ -146,7 +146,7 @@ The snapshot path activates only when:
   the snapshot's recorded layout), AND
 - the active backend reports snapshot support.
 
-On macOS / Lima QEMU, vsock snapshots return `os error 95` (EOPNOTSUPP);
+On macOS backends without Firecracker (Apple Container, libkrun), vsock snapshots return `os error 95` (EOPNOTSUPP);
 restore failures fall back to cold boot with a warning rather than
 aborting. The harder branch -- parameterized snapshots that allow
 `--add-dir` -- is tracked in [issue #7](https://github.com/tinylabscom/mvm/issues/7).

--- a/public/src/content/docs/guides/networking.md
+++ b/public/src/content/docs/guides/networking.md
@@ -9,9 +9,9 @@ Networking differs by backend:
 
 | Backend | Network Type | Guest IP | Host Access |
 |---------|-------------|----------|-------------|
-| Firecracker (Linux) | TAP device | 172.16.0.2/30 | Direct via TAP |
-| Firecracker (Lima) | TAP in Lima VM | 172.16.0.2/30 | Via Lima NAT |
+| Firecracker (Linux native) | TAP device | 172.16.0.2/30 | Direct via TAP |
 | Apple Container | vmnet | DHCP-assigned | Via vmnet bridge |
+| libkrun (macOS) | TSI (transparent socket impl) | host-loopback | Via per-port vsock listeners |
 | microvm.nix | TAP device | 172.16.0.2/30 | Direct via TAP |
 | Docker | Docker bridge | Docker-assigned | Via Docker port mapping |
 
@@ -20,12 +20,10 @@ Networking differs by backend:
 ```
 Firecracker microVM (172.16.0.2/30, eth0)
     | TAP interface (tap0)
-Lima VM (172.16.0.1/30, tap0)  --  iptables NAT  --  internet
-    | Lima virtualization
-Host (macOS / Linux)
+Linux host (172.16.0.1/30, tap0)  --  iptables NAT  --  internet
 ```
 
-The microVM has internet access via NAT through the Lima VM (or directly on native Linux). The TAP device connects the microVM to the host network namespace.
+On Linux with `/dev/kvm`, Firecracker boots directly on the host — no VM hop. The TAP device connects the microVM to the host network namespace and gets NAT'd to the internet. On macOS hosts, networking is backend-specific: Apple Container uses vmnet bridge mode; libkrun uses TSI (transparent socket impl) where outbound TCP/UDP appears as host-side socket calls.
 
 ## Port Forwarding
 
@@ -75,7 +73,7 @@ mvmctl up --flake . \
     --network-allow api.openai.com:443
 ```
 
-Network policies are enforced via iptables FORWARD rules on the bridge interface inside the Lima VM. DNS (port 53) is always allowed so domain resolution works. Rules are automatically cleaned up when the VM stops.
+Network policies are enforced via iptables FORWARD rules on the bridge interface (Firecracker backend on Linux). DNS (port 53) is always allowed so domain resolution works. Rules are automatically cleaned up when the VM stops. On macOS backends, policies are enforced at the host-side TSI/vmnet layer rather than via iptables.
 
 **Built-in presets:**
 

--- a/public/src/content/docs/guides/nix-flakes.md
+++ b/public/src/content/docs/guides/nix-flakes.md
@@ -3,7 +3,7 @@ title: Writing Nix Flakes
 description: Create custom Nix flakes that build microVM images for mvm.
 ---
 
-mvmctl uses Nix flakes to produce reproducible microVM images. Each build runs `nix build` inside the Linux environment (Lima VM on macOS, native on Linux), producing a kernel and rootfs. The same rootfs works on all backends (Firecracker, Apple Container).
+mvmctl uses Nix flakes to produce reproducible microVM images. Each build runs `nix build` inside the Linux build environment (a libkrun-backed builder VM on macOS, the host shell on Linux with `/dev/kvm`), producing a kernel and rootfs. The same rootfs works on all backends (Firecracker, Apple Container, libkrun).
 
 ## Minimal Flake
 
@@ -258,7 +258,7 @@ All three helpers return the same shape: `{ package, service, healthCheck }`. Th
 
 When you run `mvmctl build --flake .`:
 
-1. The flake is copied into the Linux environment (Lima VM on macOS, native on Linux)
+1. The flake is copied into the Linux build environment (builder VM on macOS, native on Linux with `/dev/kvm`)
 2. `nix build` runs inside that environment
 3. The resulting closure is packed into the rootfs
 4. Kernel and rootfs artifacts are cached

--- a/public/src/content/docs/guides/troubleshooting.md
+++ b/public/src/content/docs/guides/troubleshooting.md
@@ -3,35 +3,31 @@ title: Troubleshooting
 description: Common issues and their solutions.
 ---
 
-## Lima VM Issues
+## Dev VM Issues
 
-### "Lima VM not found"
+The dev VM is the Linux environment mvmctl runs Nix builds in. On macOS 26+ it's an Apple Container; on macOS Intel / pre-26 it's libkrun via `Hypervisor.framework`; on Linux with `/dev/kvm` the host shell *is* the dev environment and no VM hop exists.
+
+### "Dev VM is not running"
 
 ```
-Error: Lima VM 'mvm-builder' is not available. Run 'mvmctl bootstrap' first.
+Error: Dev VM is not running. Start it with: mvmctl dev up
 ```
 
-**Fix**: Run `mvmctl bootstrap` (idempotent — installs Lima/Firecracker if missing, no-ops otherwise).
+**Fix**: `mvmctl dev up` (idempotent — installs Firecracker if missing, no-ops otherwise).
 
-### "Failed to run command in Lima VM"
-
-The Lima VM exists but is stopped.
-
-**Fix**:
-```bash
-limactl start mvm-builder
-# or
-mvmctl dev  # auto-starts Lima
-```
-
-### Lima VM is stuck
+### Dev VM is stuck
 
 ```bash
-limactl stop mvm-builder --force
-limactl start mvm-builder
+mvmctl dev down
+mvmctl dev up
 ```
 
-If that fails:
+If that fails, rebuild from scratch:
+```bash
+mvmctl dev rebuild
+```
+
+Or for a full reset:
 ```bash
 mvmctl uninstall
 mvmctl bootstrap
@@ -54,8 +50,8 @@ mvmctl logs <name> --hypervisor   # Firecracker logs
 
 **Fix**:
 ```bash
-# Check for orphaned TAP devices (inside Lima VM)
-limactl shell mvm-builder bash -c "ip link show | grep tap"
+# Check for orphaned TAP devices (inside the dev VM)
+mvmctl dev shell -- ip link show | grep tap
 ```
 
 ### Instance won't start after sleep
@@ -105,7 +101,7 @@ mvmctl build --flake .
 error: No space left on device
 ```
 
-**Cause**: The Nix store or Lima disk is full.
+**Cause**: The Nix store or dev VM disk is full.
 
 **Fix**:
 ```bash
@@ -150,32 +146,32 @@ error: timed out waiting for ...
 
 **Cause**: Network connectivity issue or a service failed to start within the expected time.
 
-**Fix**: Check that the Lima VM has internet access and that your service binds to the correct port. Use `mvmctl logs <name>` to inspect guest output.
+**Fix**: Check that the dev VM has internet access and that your service binds to the correct port. Use `mvmctl logs <name>` to inspect guest output.
 
 ## Network Issues
 
 ### MicroVM has no internet
 
 ```bash
-# Inside the Lima VM, check NAT rules
-limactl shell mvm-builder bash -c "sudo iptables -t nat -L"
+# Inside the dev VM, check NAT rules
+mvmctl dev shell -- sudo iptables -t nat -L
 
 # Check the TAP device exists
-limactl shell mvm-builder bash -c "ip link show tap0"
+mvmctl dev shell -- ip link show tap0
 ```
 
 ### Can't access project files inside microVM
 
-The Firecracker microVM has an **isolated filesystem**. Use `mvmctl dev shell` to access the Lima VM where your home directory is mounted, or pass volumes with `--volume`.
+The Firecracker microVM has an **isolated filesystem**. Use `mvmctl dev shell` to access the dev VM where your home directory is mounted, or pass volumes with `--volume`.
 
 ## Performance Issues
 
-### Lima VM is slow
+### Dev VM is slow
 
-Adjust resources:
+Adjust resources (or persist the override with `mvmctl config set dev_vm_cpus 8 && mvmctl config set dev_vm_mem_gib 16`):
 ```bash
-mvmctl uninstall
-mvmctl dev up --lima-cpus 8 --lima-mem 16
+mvmctl dev down
+mvmctl dev up --cpus 8 --memory 16
 ```
 
 ### Wrong backend selected
@@ -241,7 +237,7 @@ export MVM_ACK_DOCKER_TIER=1
 
 ### Rootfs corrupted
 
-Re-run `mvmctl bootstrap` — it's idempotent and repaves any corrupted rootfs from the upstream squashfs without destroying the Lima VM:
+Re-run `mvmctl bootstrap` — it's idempotent and repaves any corrupted rootfs from the upstream squashfs without destroying the dev VM:
 ```bash
 mvmctl bootstrap
 ```

--- a/public/src/content/docs/install/macos.md
+++ b/public/src/content/docs/install/macos.md
@@ -1,6 +1,6 @@
 ---
 title: "Install mvm on macOS"
-description: "mvm on macOS runs natively via microsandbox + libkrun on Hypervisor.framework — no Lima, no Docker Desktop. Apple Silicon (arm64) is the primary target; Intel Macs work too."
+description: "mvm on macOS runs natively via microsandbox + libkrun on Hypervisor.framework. No Docker Desktop required. Apple Silicon (arm64) is the primary target; Intel Macs work too."
 ---
 
 mvm on macOS can use **microsandbox** as the backend — a libkrun wrapper that boots microVMs on Apple's Hypervisor.framework. Source builds keep this dependency-heavy backend behind the `contributor-bootstrap` feature; release builds that include macOS microsandbox support are built with that feature enabled. The choice is recorded in [ADR-013](/contributing/adr/013-microsandbox-pivot/) and ADR-031.

--- a/public/src/content/docs/reference/architecture.md
+++ b/public/src/content/docs/reference/architecture.md
@@ -11,15 +11,15 @@ mvmctl supports multiple VM backends and auto-selects the best one for your plat
 |---------|----------|-------------------|
 | Firecracker | Linux with `/dev/kvm` | 1st (preferred) |
 | Apple Container | macOS 26+ (Apple Silicon) | 2nd |
-| Docker | Any platform with Docker daemon | 3rd |
+| libkrun | macOS Intel / macOS pre-26 (Hypervisor.framework) | 3rd |
+| Docker | Any platform with Docker daemon | 4th (reduced isolation) |
 | microvm.nix | Linux (NixOS-native QEMU) | Via `--hypervisor qemu` |
-| Lima + Firecracker | macOS <26, Linux without KVM | 4th (legacy fallback) |
 
 ```
 Linux (KVM):    mvmctl up  -->  Firecracker microVM (direct)
 macOS 26+:      mvmctl up  -->  Apple Container (Virtualization.framework)
-Docker:         mvmctl up  -->  Docker container (universal fallback)
-macOS <26:      mvmctl up  -->  Lima VM (Ubuntu)  -->  Firecracker microVM
+macOS <26:      mvmctl up  -->  libkrun microVM (Hypervisor.framework)
+Docker:         mvmctl up  -->  Docker container (Tier 3 fallback)
 ```
 
 All backends consume the same Nix-built ext4 rootfs. Override auto-detection with `--hypervisor`:
@@ -34,12 +34,12 @@ mvmctl doctor   # check available backends
 
 ### Backend Capabilities
 
-| Capability | Firecracker | Apple Container | microvm.nix | Docker | Lima + FC |
-|------------|:-----------:|:---------------:|:-----------:|:------:|:---------:|
-| Snapshots | Yes | No | No | No | Yes |
-| Pause/resume | Yes | No | No | Yes | Yes |
-| vsock | Yes | Yes | Yes | No | Yes |
-| TAP networking | Yes | No (vmnet) | Yes | No | Yes |
+| Capability | Firecracker | Apple Container | libkrun | microvm.nix | Docker |
+|------------|:-----------:|:---------------:|:-------:|:-----------:|:------:|
+| Snapshots | Yes | No | No | No | No |
+| Pause/resume | Yes | No | No | No | Yes |
+| vsock | Yes | Yes | Yes | Yes | No |
+| TAP networking | Yes | No (vmnet) | TSI | Yes | No |
 | Port forwarding (`-p`) | Yes | Yes | Yes | Yes | Yes |
 | Detach mode (`-d`) | Yes | Yes | Yes | Yes | Yes |
 
@@ -85,8 +85,9 @@ VM lifecycle abstraction defined in `mvm-core`:
 - `capabilities()` -- pause/resume, snapshots, vsock, TAP networking
 
 Implementations:
-- **`FirecrackerBackend`** -- KVM microVMs via Firecracker (Linux native or via Lima)
+- **`FirecrackerBackend`** -- KVM microVMs via Firecracker (Linux native)
 - **`AppleContainerBackend`** -- Virtualization.framework (macOS 26+)
+- **`LibkrunBackend`** -- Hypervisor.framework via libkrun (macOS Intel / pre-26)
 - **`MicrovmNixBackend`** -- NixOS-native QEMU runner
 - **`DockerBackend`** -- Container-based fallback, universal platform support
 - **`AnyBackend`** -- enum dispatch, auto-selects at runtime
@@ -101,7 +102,7 @@ Where Linux commands run. Defined in `mvm-core`:
 - `run_capture()` -- run and capture both stdout and stderr
 
 Implementations:
-- **`LimaEnv`** -- delegates commands via `limactl shell mvm-builder` (macOS <26, or Linux without KVM)
+- **`BuilderVmEnv`** -- delegates commands into the microsandbox/libkrun builder VM (macOS hosts)
 - **`NativeEnv`** -- runs commands directly (Linux with `/dev/kvm`)
 
 ### ShellEnvironment
@@ -126,9 +127,9 @@ Extends `ShellEnvironment` for fleet orchestration:
 At startup, mvmctl detects the platform and selects the appropriate backend:
 
 1. **Linux with `/dev/kvm`** -- uses `FirecrackerBackend` directly via `NativeEnv`
-2. **macOS 26+** -- uses `AppleContainerBackend` for VM lifecycle; Nix builds still run in Lima
-3. **Docker available** -- uses `DockerBackend` as a universal fallback
-4. **macOS <26 / Linux without KVM** -- uses `FirecrackerBackend` via `LimaEnv`
+2. **macOS 26+** -- uses `AppleContainerBackend` for VM lifecycle; Nix builds run inside the builder VM
+3. **macOS Intel / pre-26** -- uses `LibkrunBackend` via `Hypervisor.framework`; Nix builds run inside the builder VM
+4. **No KVM / no Apple Container / no libkrun** -- falls back to `DockerBackend` (reduced isolation; see [Matryoshka model](/security/matryoshka))
 
 ```
 Host (macOS/Linux)
@@ -150,9 +151,9 @@ No initrd is needed -- the kernel boots directly into a busybox init script on t
 | Platform | Architecture | Backend |
 |----------|-------------|---------|
 | macOS 26+ | Apple Silicon (aarch64) | Apple Container (native) |
-| macOS <26 | Apple Silicon (aarch64) | Lima + Firecracker |
-| macOS <26 | Intel (x86_64) | Lima + Firecracker |
+| macOS pre-26 | Apple Silicon (aarch64) | libkrun (Hypervisor.framework) |
+| macOS pre-26 | Intel (x86_64) | libkrun (Hypervisor.framework) |
 | Linux with `/dev/kvm` | x86_64, aarch64 | Firecracker (native) |
-| Linux without `/dev/kvm` | x86_64, aarch64 | Docker or Lima + Firecracker |
+| Linux without `/dev/kvm` | x86_64, aarch64 | Docker (Tier 3 fallback) |
 | WSL2 | x86_64 | Docker (may have KVM) |
 | Any platform with Docker | x86_64, aarch64 | Docker (universal fallback) |

--- a/public/src/content/docs/reference/cli-commands.md
+++ b/public/src/content/docs/reference/cli-commands.md
@@ -323,10 +323,10 @@ The snapshot path activates only when *all* of the following hold:
   snapshot's recorded drive layout);
 - the active backend reports snapshot support.
 
-On macOS / Lima QEMU, vsock snapshots return `os error 95` (EOPNOTSUPP);
-restore failures fall back to cold boot with a warning rather than
-aborting the exec. See the [Sandboxed Exec](/guides/exec/) guide for
-the full background.
+On macOS backends without Firecracker (Apple Container, libkrun), vsock
+snapshots return `os error 95` (EOPNOTSUPP); restore failures fall back
+to cold boot with a warning rather than aborting the exec. See the
+[Sandboxed Exec](/guides/exec/) guide for the full background.
 
 ## Default microVM Image
 
@@ -412,7 +412,6 @@ All commands accept these global options:
 | `MVM_TEMPLATE_REGISTRY_SECRET_ACCESS_KEY` | S3 secret access key | None |
 | `MVM_TEMPLATE_REGISTRY_PREFIX` | Key prefix inside the bucket | `mvm` |
 | `MVM_TEMPLATE_REGISTRY_REGION` | S3 region | `us-east-1` |
-| `MVM_SSH_PORT` | Lima SSH local port | `60022` |
 | `OPENAI_API_KEY` | Enables LLM-backed template planning for `template init --prompt` | None |
 | `MVM_TEMPLATE_PROVIDER` | Prompt planning provider: `auto`, `openai`, `local`, or `heuristic` | `auto` |
 | `MVM_TEMPLATE_OPENAI_MODEL` | OpenAI model used for prompt planning | `gpt-5.2` |

--- a/public/src/content/docs/reference/filesystem.md
+++ b/public/src/content/docs/reference/filesystem.md
@@ -5,7 +5,7 @@ description: Drive model, mount points, and filesystem layout inside microVMs.
 
 ## Drive Model
 
-Each microVM gets up to four virtio-block drives (on all backends -- Firecracker, Apple Container, microvm.nix, Docker, Lima + Firecracker):
+Each microVM gets up to four virtio-block drives (on all backends -- Firecracker, Apple Container, libkrun, microvm.nix, Docker):
 
 | Drive | Mount Point | Permissions | Purpose |
 |-------|-------------|-------------|---------|
@@ -89,7 +89,7 @@ mvmctl up --flake . --volume ./data:/data:1024
 
 ## Host-Side Layout
 
-On the host (or inside the Lima VM on macOS <26), mvm stores data at:
+On the host (on Linux) or inside the builder VM (on macOS), mvm stores data at:
 
 ```
 ~/.mvm/                  # MVM_DATA_DIR

--- a/public/src/content/docs/security/matryoshka.md
+++ b/public/src/content/docs/security/matryoshka.md
@@ -78,7 +78,7 @@ ack_docker_tier = true
 
 - **Production / untrusted code** → Tier 1. Linux + KVM + Firecracker. No exceptions.
 - **macOS dev or CI on Apple Silicon** → Tier 2 (Apple Container or libkrun). Verified boot is the open item.
-- **macOS Intel or no-Lima Linux dev** → Tier 2 (libkrun).
+- **macOS Intel / pre-26 dev** → Tier 2 (libkrun).
 - **Anywhere else** → Tier 3 (Docker), with the banner caveats.
 
 `mvmctl doctor` reports your current tier on the running host.


### PR DESCRIPTION
## Summary

Follow-up to #198 (CLI surface). This sweeps the **public docs site** (`public/src/content/docs/`) — the guides, reference pages, install/deploy walkthroughs, and contributor guide — replacing Lima references with the actual current architecture: Apple Container on macOS 26+, libkrun on macOS Intel / pre-26, native KVM on Linux, microsandbox-backed builder VM for Nix work.

## What's left after this

Only two intentional Lima references remain across the entire docs site:

- `contributing/adr/013-microsandbox-pivot.md` — the ADR that *records* the Lima retirement. Its Lima refs are the historical record and must stay.
- One cross-link in `contributing/adr/001-multi-backend.md` pointing to ADR-013 for the retirement context.

## Test plan

- [x] Docs are pure markdown — no build verification needed beyond the Astro site rebuilding on merge (Pages workflow)
- [x] No code touched

🤖 Generated with [Claude Code](https://claude.com/claude-code)