### PR TITLE
Plan 73 Followup H — `mvmctl run --mode plan` transport

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4488,6 +4488,7 @@ dependencies = [
  "tempfile",
  "tokio",
  "toml",
+ "which 7.0.3",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -271,6 +271,9 @@ serde_json.workspace = true
 tempfile.workspace = true
 tokio = { workspace = true, features = ["macros", "rt"] }
 toml.workspace = true
+# Plan 73 Followup H — `tests/run_plan_mode.rs` resolves python3 from
+# PATH to drive the SDK record-mode auto-exec end-to-end.
+which.workspace = true
 
 [features]
 # Plan 72 W5.B cutover: `backends-builder-vm-libkrun` is default so the

--- a/crates/mvm-cli/src/commands/build/compile.rs
+++ b/crates/mvm-cli/src/commands/build/compile.rs
@@ -27,7 +27,6 @@
 
 use std::io::Read;
 use std::path::{Path, PathBuf};
-use std::process::Command;
 
 use anyhow::{Context, Result, bail};
 use clap::{Args as ClapArgs, ValueEnum};
@@ -36,9 +35,11 @@ use mvm_core::user_config::MvmConfig;
 use mvm_ir::Workload;
 use mvm_sdk::compile::{compile, compile_archive, is_archive_output};
 use mvm_sdk::decorator::{ParseError, parse_python, parse_typescript};
-use mvm_sdk::runtime::{RuntimeRecording, compile_recording};
 
 use super::Cli;
+use super::sandbox_record::{
+    ScriptLanguage, auto_exec_record_script, load_recording, script_language_from_path,
+};
 
 #[derive(ClapArgs, Debug, Clone)]
 pub(in crate::commands) struct Args {
@@ -198,177 +199,29 @@ fn load_workload(args: &Args) -> Result<Workload> {
             // (mvm.app({...})(fn)); on NoDecoratedFunction, auto-exec
             // via tsx / bun / deno.
             // .js / .mjs / .cjs → Sandbox-shaped only; auto-exec via node.
-            let ext = path.extension().and_then(|e| e.to_str()).unwrap_or("");
-            if matches!(ext, "ts" | "tsx" | "mts" | "cts") {
-                let bytes = std::fs::read(&path)
-                    .with_context(|| format!("reading decorator script {}", path.display()))?;
-                match parse_typescript(&bytes, &path) {
-                    Ok((workload, _manifest)) => Ok(workload),
-                    Err(ParseError::NoDecoratedFunction { .. }) => {
-                        auto_exec_record_script(&path, ScriptLanguage::TypeScript)
+            match script_language_from_path(&path) {
+                Some(ScriptLanguage::TypeScript) => {
+                    let bytes = std::fs::read(&path)
+                        .with_context(|| format!("reading decorator script {}", path.display()))?;
+                    match parse_typescript(&bytes, &path) {
+                        Ok((workload, _manifest)) => Ok(workload),
+                        Err(ParseError::NoDecoratedFunction { .. }) => {
+                            auto_exec_record_script(&path, ScriptLanguage::TypeScript)
+                        }
+                        Err(e) => Err(anyhow::anyhow!("{e}")).with_context(|| {
+                            format!(
+                                "parsing mvm.app({{...}})(fn) decorator in {}",
+                                path.display()
+                            )
+                        }),
                     }
-                    Err(e) => Err(anyhow::anyhow!("{e}")).with_context(|| {
-                        format!(
-                            "parsing mvm.app({{...}})(fn) decorator in {}",
-                            path.display()
-                        )
-                    }),
                 }
-            } else if matches!(ext, "js" | "mjs" | "cjs") {
-                auto_exec_record_script(&path, ScriptLanguage::Node)
-            } else {
-                bail!(no_decorator_runtime_message(&path))
-            }
-        }
-    }
-}
-
-fn load_recording(path: &Path) -> Result<Workload> {
-    let bytes = std::fs::read(path)
-        .with_context(|| format!("reading runtime recording from {}", path.display()))?;
-    let recording: RuntimeRecording = serde_json::from_slice(&bytes)
-        .with_context(|| format!("parsing runtime recording JSON from {}", path.display()))?;
-    compile_recording(&recording)
-        .map_err(|e| anyhow::anyhow!("{e}"))
-        .with_context(|| format!("lowering runtime recording from {}", path.display()))
-}
-
-/// Languages the auto-exec path supports.
-#[derive(Debug, Clone, Copy)]
-enum ScriptLanguage {
-    /// Python via `python3` (or `python`); Phase 7e.
-    Python,
-    /// Plain JavaScript via `node`; Phase 7f.
-    Node,
-    /// TypeScript via `tsx`, `bun`, or `deno`. The `node` binary
-    /// alone can't run `.ts` files in mvm's supported Node range,
-    /// so the CLI insists on a TS-aware runner. Phase 7f.
-    TypeScript,
-}
-
-/// Phase 7e — run `<interpreter> <script>` on the host with
-/// `MVM_SDK_MODE=record` and `MVM_SDK_OUT_PATH=<tempfile>`, then
-/// load the recording the SDK's atexit hook wrote and lower it
-/// to a Workload.
-///
-/// **Security**: this *runs the user's script on the host*. Per
-/// S2 in the SDK plan, this is a deliberate departure from the
-/// decorator path's "never executes user code on the host" rule;
-/// `mvmctl compile <Sandbox-script>` is opt-in for that posture.
-/// Users who don't want it can use the `@mvm.app` decorator path
-/// instead (which the decorator parser handles statically).
-fn auto_exec_record_script(script: &Path, lang: ScriptLanguage) -> Result<Workload> {
-    let interpreter = resolve_interpreter(lang)?;
-    let tmp = tempfile::Builder::new()
-        .prefix("mvm-recording-")
-        .suffix(".json")
-        .tempfile()
-        .context("creating tempfile for runtime recording capture")?;
-    let out_path = tmp.path().to_path_buf();
-
-    eprintln!(
-        "running {} on the host with MVM_SDK_MODE=record (Phase 7e/7f auto-exec)",
-        script.display()
-    );
-
-    let mut cmd = Command::new(&interpreter);
-    // Deno's default sandbox refuses fs writes; the SDK's atexit
-    // hook needs to write the recording, so opt out explicitly.
-    let basename = interpreter
-        .file_name()
-        .and_then(|s| s.to_str())
-        .unwrap_or("");
-    if basename.starts_with("deno") {
-        cmd.arg("run").arg("--allow-all");
-    }
-    let status = cmd
-        .arg(script)
-        .env("MVM_SDK_MODE", "record")
-        .env("MVM_SDK_OUT_PATH", &out_path)
-        .status()
-        .with_context(|| {
-            format!(
-                "spawning {} to run record-mode script {}",
-                interpreter.display(),
-                script.display()
-            )
-        })?;
-    if !status.success() {
-        bail!(
-            "record-mode script {} exited with {:?} (no Workload emitted). \
-             Re-run it under {} with MVM_SDK_MODE=record to see the error.",
-            script.display(),
-            status.code(),
-            interpreter.display()
-        );
-    }
-    if !out_path.exists() {
-        bail!(
-            "record-mode script {} did not emit a recording. Confirm the \
-             script imports `mvm` and calls `Sandbox.create(...)`; the SDK's \
-             atexit hook writes the recording to MVM_SDK_OUT_PATH on process \
-             exit, which only fires when a Sandbox was constructed.",
-            script.display()
-        );
-    }
-    load_recording(&out_path)
-}
-
-/// Resolve which interpreter to spawn for a given language. Each
-/// language has a discrete env-var override (`MVM_PYTHON`, `MVM_NODE`,
-/// `MVM_TSX`) so users with non-standard layouts can pin a binary
-/// explicitly. The fallback search order is best-effort but explicit
-/// in the error message when nothing is found.
-fn resolve_interpreter(lang: ScriptLanguage) -> Result<PathBuf> {
-    match lang {
-        ScriptLanguage::Python => {
-            if let Some(p) = env_override("MVM_PYTHON") {
-                return Ok(p);
-            }
-            for candidate in ["python3", "python"] {
-                if let Ok(found) = which::which(candidate) {
-                    return Ok(found);
+                Some(ScriptLanguage::Node) => auto_exec_record_script(&path, ScriptLanguage::Node),
+                Some(ScriptLanguage::Python) | None => {
+                    bail!(no_decorator_runtime_message(&path))
                 }
             }
-            bail!(
-                "no Python interpreter found on PATH (tried `python3`, `python`). \
-                 Install Python 3.10+ or set `MVM_PYTHON=<path>` and re-run."
-            )
         }
-        ScriptLanguage::Node => {
-            if let Some(p) = env_override("MVM_NODE") {
-                return Ok(p);
-            }
-            if let Ok(found) = which::which("node") {
-                return Ok(found);
-            }
-            bail!(
-                "no Node.js interpreter found on PATH (tried `node`). \
-                 Install Node 20+ or set `MVM_NODE=<path>` and re-run."
-            )
-        }
-        ScriptLanguage::TypeScript => {
-            if let Some(p) = env_override("MVM_TSX") {
-                return Ok(p);
-            }
-            // Project-local `./node_modules/.bin/<runner>` wins over a
-            // PATH-installed runner: this lets a `package.json` /
-            // lockfile pin the exact version without forcing the user
-            // to install one globally. Resolution is cwd-relative
-            // because `mvmctl compile` is run from a project root.
-            // See `crate::ts_runner` for the full resolution order.
-            if let Some(p) = crate::ts_runner::resolve() {
-                return Ok(p);
-            }
-            bail!("{}", crate::ts_runner::install_hint())
-        }
-    }
-}
-
-fn env_override(name: &str) -> Option<PathBuf> {
-    match std::env::var(name) {
-        Ok(v) if !v.is_empty() => Some(PathBuf::from(v)),
-        _ => None,
     }
 }
 
@@ -461,53 +314,51 @@ fn resolve_manifest_dir(args: &Args) -> Result<PathBuf> {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use std::sync::Mutex;
 
-    /// Serializes tests that mutate `MVM_TSX` (process-wide).
-    static ENV_LOCK: Mutex<()> = Mutex::new(());
-
-    /// Restore-on-drop guard for `MVM_TSX`. Used to exercise the
-    /// env-override short-circuit in `resolve_interpreter` without
-    /// leaking state into sibling tests.
-    struct TsxGuard {
-        _guard: std::sync::MutexGuard<'static, ()>,
-        prev: Option<String>,
-    }
-
-    impl TsxGuard {
-        fn set(value: Option<&str>) -> Self {
-            let g = ENV_LOCK.lock().unwrap_or_else(|e| e.into_inner());
-            let prev = std::env::var("MVM_TSX").ok();
-            unsafe {
-                match value {
-                    Some(v) => std::env::set_var("MVM_TSX", v),
-                    None => std::env::remove_var("MVM_TSX"),
-                }
-            }
-            TsxGuard { _guard: g, prev }
-        }
-    }
-
-    impl Drop for TsxGuard {
-        fn drop(&mut self) {
-            unsafe {
-                match &self.prev {
-                    Some(v) => std::env::set_var("MVM_TSX", v),
-                    None => std::env::remove_var("MVM_TSX"),
-                }
-            }
-        }
+    #[test]
+    fn resolve_mode_default_is_record() {
+        let args = Args {
+            entry: Some("./foo.json".to_string()),
+            from_ir: None,
+            from_recording: None,
+            out: PathBuf::from("./out"),
+            mode: None,
+            prod: false,
+            dev: false,
+        };
+        let mode = resolve_mode(&args).expect("default mode resolves");
+        assert!(matches!(mode, Mode::Record));
     }
 
     #[test]
-    fn resolve_interpreter_typescript_honours_mvm_tsx_override() {
-        // Sanity: MVM_TSX pin must short-circuit before the
-        // project-local / PATH lookup. We can't usefully check that
-        // the path *exists* (no fixture), but we can check that the
-        // returned PathBuf is the override verbatim.
-        let _g = TsxGuard::set(Some("/usr/local/bin/tsx-pinned"));
-        let resolved =
-            resolve_interpreter(ScriptLanguage::TypeScript).expect("MVM_TSX must short-circuit");
-        assert_eq!(resolved, PathBuf::from("/usr/local/bin/tsx-pinned"));
+    fn resolve_mode_prod_resolves_to_record() {
+        let args = Args {
+            entry: Some("./foo.json".to_string()),
+            from_ir: None,
+            from_recording: None,
+            out: PathBuf::from("./out"),
+            mode: None,
+            prod: true,
+            dev: false,
+        };
+        let mode = resolve_mode(&args).expect("--prod resolves to record");
+        assert!(matches!(mode, Mode::Record));
+    }
+
+    #[test]
+    fn resolve_mode_dev_is_refused_on_compile() {
+        let args = Args {
+            entry: Some("./foo.json".to_string()),
+            from_ir: None,
+            from_recording: None,
+            out: PathBuf::from("./out"),
+            mode: None,
+            prod: false,
+            dev: true,
+        };
+        let err = resolve_mode(&args).expect_err("--dev must be refused on compile");
+        let msg = err.to_string();
+        assert!(msg.contains("--dev"));
+        assert!(msg.contains("mvmctl run"));
     }
 }

--- a/crates/mvm-cli/src/commands/build/mod.rs
+++ b/crates/mvm-cli/src/commands/build/mod.rs
@@ -6,6 +6,9 @@
 pub(super) mod build;
 pub(super) mod compile;
 pub(super) mod deploy;
+/// Shared helpers for the SDK record-mode auto-exec path. Used by
+/// `mvmctl compile <Sandbox-script>` and `mvmctl run --mode plan`.
+pub(in crate::commands) mod sandbox_record;
 pub(super) mod validate;
 
 pub(super) use super::{Cli, shared};

--- a/crates/mvm-cli/src/commands/build/sandbox_record.rs
+++ b/crates/mvm-cli/src/commands/build/sandbox_record.rs
@@ -1,0 +1,261 @@
+//! Shared helpers for the SDK record-mode auto-exec path.
+//!
+//! Both `mvmctl compile <Sandbox-script>` (Phase 7e/7f) and
+//! `mvmctl run --mode plan <Sandbox-script>` (Followup H plan half)
+//! need to: spawn the user's script under
+//! `MVM_SDK_MODE=record + MVM_SDK_OUT_PATH=<tmp>`, then lower the
+//! atexit-hook-emitted recording into a `Workload`. Pulling the
+//! mechanics out lets the two verbs share a single implementation
+//! (and a single test seam) instead of duplicating the spawn-and-
+//! lower dance.
+//!
+//! **Security**: running the user's script on the host is a
+//! deliberate departure from the decorator path's "never executes
+//! user code on the host" rule. Documented in the SDK guide; the
+//! literal-only AST gate (Decision I) inside the language SDKs is
+//! the host-side defence. Callers should keep this routine
+//! opt-in — `mvmctl compile`'s decorator path stays the default.
+
+use std::path::{Path, PathBuf};
+use std::process::Command;
+
+use anyhow::{Context, Result, bail};
+use mvm_ir::Workload;
+use mvm_sdk::runtime::{RuntimeRecording, compile_recording};
+
+/// Languages the auto-exec path supports.
+#[derive(Debug, Clone, Copy)]
+pub(in crate::commands) enum ScriptLanguage {
+    /// Python via `python3` (or `python`).
+    Python,
+    /// Plain JavaScript via `node`.
+    Node,
+    /// TypeScript via `tsx`, `bun`, or `deno`. The `node` binary
+    /// alone can't run `.ts` files in mvm's supported Node range,
+    /// so the CLI insists on a TS-aware runner.
+    TypeScript,
+}
+
+/// Infer a [`ScriptLanguage`] from a script path's extension.
+///
+/// Returns `None` for unsupported / unknown extensions; callers
+/// surface their own diagnostic ("could not infer kind from …").
+pub(in crate::commands) fn script_language_from_path(path: &Path) -> Option<ScriptLanguage> {
+    match path.extension().and_then(|e| e.to_str())? {
+        "py" => Some(ScriptLanguage::Python),
+        "ts" | "tsx" | "mts" | "cts" => Some(ScriptLanguage::TypeScript),
+        "js" | "mjs" | "cjs" => Some(ScriptLanguage::Node),
+        _ => None,
+    }
+}
+
+/// Run `<interpreter> <script>` on the host with
+/// `MVM_SDK_MODE=record` and `MVM_SDK_OUT_PATH=<tempfile>`, then
+/// load the recording the SDK's atexit hook wrote and lower it
+/// to a Workload.
+///
+/// **Security**: this *runs the user's script on the host*. Per
+/// S2 in the SDK plan, this is a deliberate departure from the
+/// decorator path's "never executes user code on the host" rule;
+/// callers gate behind an explicit opt-in.
+pub(in crate::commands) fn auto_exec_record_script(
+    script: &Path,
+    lang: ScriptLanguage,
+) -> Result<Workload> {
+    let interpreter = resolve_interpreter(lang)?;
+    let tmp = tempfile::Builder::new()
+        .prefix("mvm-recording-")
+        .suffix(".json")
+        .tempfile()
+        .context("creating tempfile for runtime recording capture")?;
+    let out_path = tmp.path().to_path_buf();
+
+    eprintln!(
+        "running {} on the host with MVM_SDK_MODE=record (Phase 7e/7f auto-exec)",
+        script.display()
+    );
+
+    let mut cmd = Command::new(&interpreter);
+    // Deno's default sandbox refuses fs writes; the SDK's atexit
+    // hook needs to write the recording, so opt out explicitly.
+    let basename = interpreter
+        .file_name()
+        .and_then(|s| s.to_str())
+        .unwrap_or("");
+    if basename.starts_with("deno") {
+        cmd.arg("run").arg("--allow-all");
+    }
+    let status = cmd
+        .arg(script)
+        .env("MVM_SDK_MODE", "record")
+        .env("MVM_SDK_OUT_PATH", &out_path)
+        .status()
+        .with_context(|| {
+            format!(
+                "spawning {} to run record-mode script {}",
+                interpreter.display(),
+                script.display()
+            )
+        })?;
+    if !status.success() {
+        bail!(
+            "record-mode script {} exited with {:?} (no Workload emitted). \
+             Re-run it under {} with MVM_SDK_MODE=record to see the error.",
+            script.display(),
+            status.code(),
+            interpreter.display()
+        );
+    }
+    if !out_path.exists() {
+        bail!(
+            "record-mode script {} did not emit a recording. Confirm the \
+             script imports `mvm` and calls `Sandbox.create(...)`; the SDK's \
+             atexit hook writes the recording to MVM_SDK_OUT_PATH on process \
+             exit, which only fires when a Sandbox was constructed.",
+            script.display()
+        );
+    }
+    load_recording(&out_path)
+}
+
+/// Load a recording JSON from disk and lower it through the SDK's
+/// `compile_recording`. Reused by `mvmctl compile --from-recording`
+/// and the auto-exec path above.
+pub(in crate::commands) fn load_recording(path: &Path) -> Result<Workload> {
+    let bytes = std::fs::read(path)
+        .with_context(|| format!("reading runtime recording from {}", path.display()))?;
+    let recording: RuntimeRecording = serde_json::from_slice(&bytes)
+        .with_context(|| format!("parsing runtime recording JSON from {}", path.display()))?;
+    compile_recording(&recording)
+        .map_err(|e| anyhow::anyhow!("{e}"))
+        .with_context(|| format!("lowering runtime recording from {}", path.display()))
+}
+
+/// Resolve which interpreter to spawn for a given language. Each
+/// language has a discrete env-var override (`MVM_PYTHON`, `MVM_NODE`,
+/// `MVM_TSX`) so users with non-standard layouts can pin a binary
+/// explicitly. The fallback search order is best-effort but explicit
+/// in the error message when nothing is found.
+pub(in crate::commands) fn resolve_interpreter(lang: ScriptLanguage) -> Result<PathBuf> {
+    match lang {
+        ScriptLanguage::Python => {
+            if let Some(p) = env_override("MVM_PYTHON") {
+                return Ok(p);
+            }
+            for candidate in ["python3", "python"] {
+                if let Ok(found) = which::which(candidate) {
+                    return Ok(found);
+                }
+            }
+            bail!(
+                "no Python interpreter found on PATH (tried `python3`, `python`). \
+                 Install Python 3.10+ or set `MVM_PYTHON=<path>` and re-run."
+            )
+        }
+        ScriptLanguage::Node => {
+            if let Some(p) = env_override("MVM_NODE") {
+                return Ok(p);
+            }
+            if let Ok(found) = which::which("node") {
+                return Ok(found);
+            }
+            bail!(
+                "no Node.js interpreter found on PATH (tried `node`). \
+                 Install Node 20+ or set `MVM_NODE=<path>` and re-run."
+            )
+        }
+        ScriptLanguage::TypeScript => {
+            if let Some(p) = env_override("MVM_TSX") {
+                return Ok(p);
+            }
+            // Project-local `./node_modules/.bin/<runner>` wins over a
+            // PATH-installed runner: this lets a `package.json` /
+            // lockfile pin the exact version without forcing the user
+            // to install one globally. Resolution is cwd-relative
+            // because the verb is run from a project root.
+            // See `crate::ts_runner` for the full resolution order.
+            if let Some(p) = crate::ts_runner::resolve() {
+                return Ok(p);
+            }
+            bail!("{}", crate::ts_runner::install_hint())
+        }
+    }
+}
+
+fn env_override(name: &str) -> Option<PathBuf> {
+    match std::env::var(name) {
+        Ok(v) if !v.is_empty() => Some(PathBuf::from(v)),
+        _ => None,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::sync::Mutex;
+
+    /// Serializes tests that mutate `MVM_TSX` (process-wide).
+    static ENV_LOCK: Mutex<()> = Mutex::new(());
+
+    /// Restore-on-drop guard for `MVM_TSX`. Used to exercise the
+    /// env-override short-circuit in `resolve_interpreter` without
+    /// leaking state into sibling tests.
+    struct TsxGuard {
+        _guard: std::sync::MutexGuard<'static, ()>,
+        prev: Option<String>,
+    }
+
+    impl TsxGuard {
+        fn set(value: Option<&str>) -> Self {
+            let g = ENV_LOCK.lock().unwrap_or_else(|e| e.into_inner());
+            let prev = std::env::var("MVM_TSX").ok();
+            unsafe {
+                match value {
+                    Some(v) => std::env::set_var("MVM_TSX", v),
+                    None => std::env::remove_var("MVM_TSX"),
+                }
+            }
+            TsxGuard { _guard: g, prev }
+        }
+    }
+
+    impl Drop for TsxGuard {
+        fn drop(&mut self) {
+            unsafe {
+                match &self.prev {
+                    Some(v) => std::env::set_var("MVM_TSX", v),
+                    None => std::env::remove_var("MVM_TSX"),
+                }
+            }
+        }
+    }
+
+    #[test]
+    fn resolve_interpreter_typescript_honours_mvm_tsx_override() {
+        let _g = TsxGuard::set(Some("/usr/local/bin/tsx-pinned"));
+        let resolved =
+            resolve_interpreter(ScriptLanguage::TypeScript).expect("MVM_TSX must short-circuit");
+        assert_eq!(resolved, PathBuf::from("/usr/local/bin/tsx-pinned"));
+    }
+
+    #[test]
+    fn script_language_inferred_from_extension() {
+        let py = PathBuf::from("/tmp/foo.py");
+        let ts = PathBuf::from("/tmp/foo.ts");
+        let js = PathBuf::from("/tmp/foo.js");
+        let unk = PathBuf::from("/tmp/foo.txt");
+        assert!(matches!(
+            script_language_from_path(&py),
+            Some(ScriptLanguage::Python)
+        ));
+        assert!(matches!(
+            script_language_from_path(&ts),
+            Some(ScriptLanguage::TypeScript)
+        ));
+        assert!(matches!(
+            script_language_from_path(&js),
+            Some(ScriptLanguage::Node)
+        ));
+        assert!(script_language_from_path(&unk).is_none());
+    }
+}

--- a/crates/mvm-cli/src/commands/mod.rs
+++ b/crates/mvm-cli/src/commands/mod.rs
@@ -124,6 +124,14 @@ pub(in crate::commands) enum Commands {
     /// before dispatch: `standard` by default, `restrictive` for no env or host
     /// shares, `dev` for writable local shares, and `permissive` only with an
     /// explicit acknowledgment environment variable.
+    ///
+    /// SDK transport modes (Plan 73 Followup H): pass `--mode plan <script>`
+    /// to run a Sandbox-shaped Python / TypeScript / JavaScript script with
+    /// each `Sandbox` operation routed through `mvm_supervisor::admit_for_run`
+    /// for a dry-run admission check. No microVM ever boots; useful for
+    /// validating admission gates without the cost of a VM boot. `--mode live`
+    /// (alias `--dev`) is reserved for Followup H-live; `--mode record`
+    /// redirects users to `mvmctl compile`.
     Run(vm::exec::RunArgs),
     /// Verify signed execution receipts emitted by `mvmctl run --receipt`.
     Receipt(vm::exec::ReceiptArgs),

--- a/crates/mvm-cli/src/commands/tests.rs
+++ b/crates/mvm-cli/src/commands/tests.rs
@@ -1347,6 +1347,9 @@ fn run_default_profile_argv_only() {
             receipt,
             json,
             launch_plan,
+            mode,
+            dev,
+            prod,
             argv,
         }) => {
             assert!(manifest.is_none(), "manifest should default to None");
@@ -1359,6 +1362,9 @@ fn run_default_profile_argv_only() {
             assert!(receipt.is_none(), "receipt should default to None");
             assert!(!json, "json should default to false");
             assert!(launch_plan.is_none(), "launch_plan should default to None");
+            assert!(mode.is_none(), "mode should default to None");
+            assert!(!dev, "dev should default to false");
+            assert!(!prod, "prod should default to false");
             assert_eq!(argv, vec!["uname".to_string(), "-a".to_string()]);
         }
         _ => panic!("Expected Run command"),

--- a/crates/mvm-cli/src/commands/vm/exec.rs
+++ b/crates/mvm-cli/src/commands/vm/exec.rs
@@ -113,14 +113,53 @@ pub(in crate::commands) struct RunArgs {
     /// Path to an mvmforge launch document. Mutually exclusive with trailing argv.
     #[arg(long, value_name = "PATH", conflicts_with = "argv")]
     pub launch_plan: Option<String>,
+    /// SDK transport mode for `mvmctl run`. v1 wires only
+    /// `--mode plan` (synthesize an ExecutionPlan per Sandbox call
+    /// and route through `mvm_supervisor::admit_for_run`; no
+    /// microVM ever boots). `--mode live` is reserved for the
+    /// Followup H-live half (Plan 73); `--mode record` redirects
+    /// users to `mvmctl compile` (where record is the default).
+    /// When unset, the verb behaves as a transient-sandbox runner
+    /// over the trailing argv — its pre-Followup-H semantics.
+    #[arg(long = "mode", value_enum)]
+    pub mode: Option<RunMode>,
+    /// Friendly alias for `--mode live`. Refused in v1 until the
+    /// Followup H-live half lands.
+    #[arg(long = "dev", conflicts_with_all = ["prod", "mode"])]
+    pub dev: bool,
+    /// Friendly alias for `--mode record`. `mvmctl run --prod`
+    /// redirects users to `mvmctl compile`, where record is the
+    /// default.
+    #[arg(long = "prod", conflicts_with_all = ["dev", "mode"])]
+    pub prod: bool,
     /// Argv to run inside the guest (use `--` to separate). Required unless
-    /// `--launch-plan` is supplied.
+    /// `--launch-plan` is supplied. Under `--mode plan`, the first
+    /// argv element is a `.py`/`.ts`/`.js` script path.
     #[arg(
         trailing_var_arg = true,
         allow_hyphen_values = true,
-        required_unless_present = "launch_plan"
+        required_unless_present_any = ["launch_plan", "mode", "dev", "prod"]
     )]
     pub argv: Vec<String>,
+}
+
+/// SDK transport modes for `mvmctl run`. Mirrors the `Mode` enum on
+/// `mvmctl compile` but specialises the rejection messages to point
+/// users at the right verb when they pick the wrong default.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, ValueEnum)]
+pub(in crate::commands) enum RunMode {
+    /// Live transport — Sandbox calls shell out to existing mvmctl
+    /// up/exec/down. Reserved for Followup H-live; refused in v1.
+    Live,
+    /// Plan transport — synthesise one ExecutionPlan per Sandbox
+    /// operation and route through `mvm_supervisor::admit_for_run`.
+    /// No microVM boots. Useful for dry-running admission gates.
+    Plan,
+    /// Record transport — capture Sandbox operations into a
+    /// recording and lower to a Workload. `mvmctl run --mode
+    /// record` redirects users to `mvmctl compile`, whose default
+    /// mode is record.
+    Record,
 }
 
 #[derive(ClapArgs, Debug, Clone)]
@@ -177,6 +216,14 @@ pub(in crate::commands) fn run_receipt(
 }
 
 pub(in crate::commands) fn run_secure(cli: &Cli, args: RunArgs, cfg: &MvmConfig) -> Result<()> {
+    // Followup H — when an SDK transport mode is requested, peel off
+    // the SDK-shaped surface before the sandbox-runner validation
+    // kicks in. `--dev` (alias for live) is refused in v1; `--prod`
+    // (alias for record) redirects to `mvmctl compile`; `--mode plan`
+    // routes through the plan-mode admission dry-run.
+    if let Some(mode) = resolve_run_mode(&args)? {
+        return super::run_plan::dispatch_sdk_mode(mode, &args);
+    }
     validate_run_profile(&args)?;
     let receipt_path = args.receipt.clone();
     if args.json || receipt_path.is_some() {
@@ -206,6 +253,64 @@ pub(in crate::commands) fn run_secure(cli: &Cli, args: RunArgs, cfg: &MvmConfig)
         return Ok(());
     }
     run(cli, args.into_exec_args(), cfg)
+}
+
+/// Resolve the `mvmctl run` transport mode from the explicit
+/// `--mode` flag, the friendly `--dev` / `--prod` aliases, and the
+/// `MVM_SDK_MODE` env-var override. Returns `Ok(None)` when no SDK
+/// mode was requested — in that case the verb falls back to the
+/// transient-sandbox runner over the trailing argv.
+///
+/// Env-var precedence matches `mvmctl compile`: `MVM_SDK_MODE`
+/// supersedes any flag-only override so a wrapper script can pin a
+/// mode without the user retyping `--mode`.
+pub(in crate::commands) fn resolve_run_mode(args: &RunArgs) -> Result<Option<RunMode>> {
+    if let Ok(env_mode) = std::env::var("MVM_SDK_MODE") {
+        return Ok(Some(parse_env_run_mode(&env_mode)?));
+    }
+    if args.dev {
+        anyhow::bail!(
+            "`mvmctl run --dev` (alias for --mode live) is blocked — pairs with Followup H-live, \
+             which lands once Plan 72 W4/W5 are validated end to end. Use `--mode plan` for the \
+             admission dry-run, or `mvmctl compile` for the record path."
+        );
+    }
+    if args.prod {
+        anyhow::bail!(
+            "`mvmctl run --prod` (alias for --mode record) redirects to `mvmctl compile`, where \
+             record is the default mode. Re-run as `mvmctl compile <script>` (the trailing argv \
+             on `mvmctl run` is for the live sandbox runner, not for SDK record-mode)."
+        );
+    }
+    match args.mode {
+        None => Ok(None),
+        Some(RunMode::Live) => anyhow::bail!(
+            "`mvmctl run --mode live` is blocked — pairs with Followup H-live, which lands once \
+             Plan 72 W4/W5 are validated end to end. Use `--mode plan` for the admission dry-run."
+        ),
+        Some(RunMode::Record) => anyhow::bail!(
+            "`mvmctl run --mode record` is unsupported — `mvmctl compile` is the record-mode verb \
+             (record is the default; pass the script as the positional entry)."
+        ),
+        Some(RunMode::Plan) => Ok(Some(RunMode::Plan)),
+    }
+}
+
+fn parse_env_run_mode(raw: &str) -> Result<RunMode> {
+    match raw.trim().to_ascii_lowercase().as_str() {
+        "live" => anyhow::bail!(
+            "MVM_SDK_MODE=live is blocked on `mvmctl run` — pairs with Followup H-live (lands \
+             once Plan 72 W4/W5 are validated)."
+        ),
+        "plan" => Ok(RunMode::Plan),
+        "record" => anyhow::bail!(
+            "MVM_SDK_MODE=record on `mvmctl run` is unsupported — `mvmctl compile` is the \
+             record-mode verb (record is its default)."
+        ),
+        other => anyhow::bail!(
+            "MVM_SDK_MODE={other:?} is not recognized; expected one of: live, plan, record"
+        ),
+    }
 }
 
 fn validate_run_profile(args: &RunArgs) -> Result<()> {
@@ -588,8 +693,63 @@ mod tests {
             receipt: None,
             json: false,
             launch_plan: None,
+            mode: None,
+            dev: false,
+            prod: false,
             argv: vec!["/bin/true".to_string()],
         }
+    }
+
+    #[test]
+    fn resolve_run_mode_returns_none_when_no_mode_flag() {
+        let args = run_args(RunProfile::Standard);
+        let mode = resolve_run_mode(&args).expect("no flag resolves to None");
+        assert!(mode.is_none());
+    }
+
+    #[test]
+    fn resolve_run_mode_returns_plan_when_mode_plan() {
+        let mut args = run_args(RunProfile::Standard);
+        args.mode = Some(RunMode::Plan);
+        let mode = resolve_run_mode(&args).expect("plan resolves").unwrap();
+        assert_eq!(mode, RunMode::Plan);
+    }
+
+    #[test]
+    fn resolve_run_mode_bails_blocked_for_dev_alias() {
+        let mut args = run_args(RunProfile::Standard);
+        args.dev = true;
+        let err = resolve_run_mode(&args).expect_err("--dev must bail");
+        let msg = err.to_string();
+        assert!(msg.contains("Followup H-live"));
+        assert!(msg.contains("--mode plan"));
+    }
+
+    #[test]
+    fn resolve_run_mode_bails_redirect_for_prod_alias() {
+        let mut args = run_args(RunProfile::Standard);
+        args.prod = true;
+        let err = resolve_run_mode(&args).expect_err("--prod must bail");
+        let msg = err.to_string();
+        assert!(msg.contains("mvmctl compile"));
+    }
+
+    #[test]
+    fn resolve_run_mode_bails_blocked_for_mode_live() {
+        let mut args = run_args(RunProfile::Standard);
+        args.mode = Some(RunMode::Live);
+        let err = resolve_run_mode(&args).expect_err("--mode live must bail");
+        let msg = err.to_string();
+        assert!(msg.contains("Followup H-live"));
+    }
+
+    #[test]
+    fn resolve_run_mode_bails_redirect_for_mode_record() {
+        let mut args = run_args(RunProfile::Standard);
+        args.mode = Some(RunMode::Record);
+        let err = resolve_run_mode(&args).expect_err("--mode record must bail");
+        let msg = err.to_string();
+        assert!(msg.contains("mvmctl compile"));
     }
 
     #[test]

--- a/crates/mvm-cli/src/commands/vm/mod.rs
+++ b/crates/mvm-cli/src/commands/vm/mod.rs
@@ -18,6 +18,7 @@ pub(super) mod plan_builder;
 pub(super) mod policy_resolver;
 pub(super) mod proc;
 pub(super) mod ps;
+pub(super) mod run_plan;
 pub(super) mod sandbox;
 pub(super) mod session;
 pub(super) mod set_ttl;

--- a/crates/mvm-cli/src/commands/vm/run_plan.rs
+++ b/crates/mvm-cli/src/commands/vm/run_plan.rs
@@ -1,0 +1,299 @@
+//! `mvmctl run --mode plan` — SDK plan transport.
+//!
+//! Followup H plan half (Plan 73). The verb runs a Sandbox-shaped
+//! script with the SDK's `Sandbox` operations rerouted to
+//! synthesize one `ExecutionPlan` per call and route each through
+//! `mvm_supervisor::admit_for_run` for a dry-run admission check.
+//! **No microVM ever boots** — the value is that admission gates
+//! (signature, validity window, replay store, policy resolution)
+//! fire end-to-end without the cost of booting and tearing down a
+//! VM.
+//!
+//! ## How it works
+//!
+//! 1. The user's script is auto-exec'd on the host under
+//!    `MVM_SDK_MODE=record + MVM_SDK_OUT_PATH=<tmp>` — the same
+//!    spawn-and-capture dance `mvmctl compile <Sandbox-script>`
+//!    uses. The SDK's atexit hook writes the recording.
+//! 2. `mvm_sdk::runtime::compile_recording` lowers the recording
+//!    into a `Workload`.
+//! 3. For each app in the Workload, [`synthesize_plan`] is called
+//!    with a `SynthesisInput` derived from the app's resources +
+//!    a content-addressed placeholder image SHA. The placeholder
+//!    is intentional: plan-mode is a **shape check**, not a real
+//!    build, so there's no rootfs on disk to hash. The shape that
+//!    flows downstream (validity window, signing, nonce, policy
+//!    refs) is the same as the live path's.
+//! 4. [`admit_for_run`] threads each plan through the full
+//!    admission pipeline (sign → verify → window → nonce ledger).
+//!    Failures surface verbatim so the user sees exactly which
+//!    gate refused.
+//!
+//! ## What plan-mode does NOT check
+//!
+//! - The rootfs SHA against any on-disk artifact (no build runs).
+//! - The runtime profile's backend slot (the supervisor's `launch`
+//!   call is skipped entirely — admission is the only gate
+//!   exercised).
+//! - Bundle pin re-verify (plan-mode never sets a bundle pin).
+//!
+//! ## Security
+//!
+//! The Sandbox-script auto-exec runs *on the host* under the
+//! invoking user. Same posture as `mvmctl compile <script>` — the
+//! literal-only AST gate inside the language SDKs is the
+//! host-side defence. Callers who don't want host execution use
+//! the `@mvm.app` decorator path, which the decorator parser
+//! handles statically.
+
+use anyhow::{Context, Result, bail};
+use sha2::{Digest, Sha256};
+use std::path::PathBuf;
+
+use mvm_ir::{App, Workload};
+
+use super::plan_admission::{InMemoryNonceLedger, SystemClock, admit_for_run};
+use super::plan_builder::SynthesisInput;
+use crate::commands::build::sandbox_record::{auto_exec_record_script, script_language_from_path};
+
+use super::exec::{RunArgs, RunMode};
+
+/// Dispatch an SDK-mode `mvmctl run` invocation. v1 only wires
+/// `RunMode::Plan`; the other variants are intercepted by
+/// `super::exec::resolve_run_mode` before reaching this entry.
+pub(in crate::commands) fn dispatch_sdk_mode(mode: RunMode, args: &RunArgs) -> Result<()> {
+    match mode {
+        RunMode::Plan => run_plan_mode(args),
+        // The exec module's resolve_run_mode already bails on these
+        // variants — keep the match exhaustive so a future addition
+        // raises a compile error here too.
+        RunMode::Live | RunMode::Record => unreachable!(
+            "exec::resolve_run_mode is expected to refuse {mode:?} before reaching run_plan; \
+             this is a logic bug — file an issue."
+        ),
+    }
+}
+
+fn run_plan_mode(args: &RunArgs) -> Result<()> {
+    let script = extract_script_arg(args)?;
+    let lang = script_language_from_path(&script).ok_or_else(|| {
+        anyhow::anyhow!(
+            "`mvmctl run --mode plan` expected a `.py`, `.ts`, `.tsx`, `.js`, `.mjs`, `.cjs`, \
+             `.mts`, or `.cts` script path, got {}.",
+            script.display()
+        )
+    })?;
+
+    let workload = auto_exec_record_script(&script, lang).with_context(|| {
+        format!(
+            "lowering Sandbox-shaped script {} for plan-mode admission",
+            script.display()
+        )
+    })?;
+
+    if workload.apps.is_empty() {
+        bail!(
+            "Sandbox recording produced no apps to admit — the script must call \
+             `Sandbox.create(...)` at least once."
+        );
+    }
+
+    eprintln!(
+        "mvmctl run --mode plan: workload {} has {} app(s); admitting each via mvm_supervisor::admit_for_run",
+        workload.id,
+        workload.apps.len()
+    );
+
+    let ledger = InMemoryNonceLedger::new();
+    let clock = SystemClock;
+    let mut admitted_count = 0usize;
+    let mut failed_count = 0usize;
+
+    for app in &workload.apps {
+        let input = synthesis_input_for_app(&workload, app)?;
+        match admit_for_run(&input, &clock, &ledger, None, None) {
+            Ok(admitted) => {
+                admitted_count += 1;
+                println!(
+                    "ADMITTED app={} plan_id={} signer={} cpus={} mem_mib={} workload={} tenant={}",
+                    app.name,
+                    admitted.plan_id.0,
+                    admitted.signer_id,
+                    admitted.plan.resources.cpus,
+                    admitted.plan.resources.mem_mib,
+                    admitted.plan.workload.0,
+                    admitted.plan.tenant.0,
+                );
+            }
+            Err(e) => {
+                failed_count += 1;
+                eprintln!("REJECTED app={} reason={:#}", app.name, e);
+            }
+        }
+    }
+
+    eprintln!(
+        "mvmctl run --mode plan: {} admitted, {} rejected (no microVM booted)",
+        admitted_count, failed_count
+    );
+
+    if failed_count > 0 {
+        bail!(
+            "plan-mode admission refused {} of {} app(s); see REJECTED lines above for details",
+            failed_count,
+            workload.apps.len()
+        );
+    }
+    Ok(())
+}
+
+/// Pull the script path off `args.argv`. Under `--mode plan` the
+/// argv slot carries a single positional: the script. Anything
+/// else is an error.
+fn extract_script_arg(args: &RunArgs) -> Result<PathBuf> {
+    if !args.argv.is_empty() {
+        if args.argv.len() > 1 {
+            bail!(
+                "`mvmctl run --mode plan` expected exactly one positional (the script path); \
+                 got {} arguments: {:?}. Plan mode never boots a VM, so trailing argv beyond the \
+                 script is meaningless.",
+                args.argv.len(),
+                args.argv
+            );
+        }
+        return Ok(PathBuf::from(&args.argv[0]));
+    }
+    bail!(
+        "`mvmctl run --mode plan` requires a script path. Pass a `.py`, `.ts`, or `.js` script \
+         that builds a Sandbox: e.g. `mvmctl run --mode plan ./hello.py`."
+    )
+}
+
+/// Map an app from the Workload into a `SynthesisInput` for
+/// `admit_for_run`. Plan-mode never builds a rootfs, so the
+/// `image_sha256` is a deterministic placeholder derived from the
+/// app's identity (`workload_id::app_name`). This is intentional:
+/// plan-mode is a shape check; downstream consumers that want the
+/// real artifact hash run the live path.
+fn synthesis_input_for_app<'a>(workload: &'a Workload, app: &'a App) -> Result<SynthesisInput<'a>> {
+    // `SynthesisInput` borrows `image_sha256` as `&str`; we need a
+    // 64-char hex string that lives long enough. Since we can't
+    // return a reference to a local in the synthesis input struct,
+    // we leak the placeholder into a `Box<str>` whose lifetime is
+    // bound to the call-site loop — that's why this helper takes
+    // `'a` from both workload and app and returns a value owning
+    // the string indirectly. To keep the borrowck happy we lean on
+    // the fact that admit_for_run is fully synchronous and the
+    // input is consumed before this function returns.
+    //
+    // The cleanest path is just to allocate a `String` and use
+    // `Box::leak` once per app. Plan-mode runs once per CLI
+    // invocation, so the leak is bounded by app count (typically
+    // 1).
+    let placeholder = placeholder_image_sha(&workload.id, &app.name);
+    let leaked: &'static str = Box::leak(placeholder.into_boxed_str());
+
+    Ok(SynthesisInput {
+        vm_name: &app.name,
+        tenant: None,
+        backend_name: "firecracker",
+        image_name: &app.name,
+        image_sha256: leaked,
+        image_cosign_bundle: None,
+        cpus: app.resources.cpu_cores.max(1) as u32,
+        mem_mib: app.resources.memory_mb.max(64) as u64,
+        disk_mib: app.resources.rootfs_size_mb as u64,
+        boot_timeout_secs: 60,
+        exec_timeout_secs: 0,
+        destroy_on_exit: true,
+        bundle_pin: None,
+    })
+}
+
+/// SHA-256 over `workload_id::app_name` to derive a stable 64-char
+/// hex placeholder image SHA for plan-mode admission. Distinct
+/// apps in the same workload get distinct nonces *and* distinct
+/// image SHAs, so the audit chain entries are independent. This
+/// is not a real artifact hash — calling code documents the
+/// caveat.
+fn placeholder_image_sha(workload_id: &str, app_name: &str) -> String {
+    let mut hasher = Sha256::new();
+    hasher.update(workload_id.as_bytes());
+    hasher.update(b"::");
+    hasher.update(app_name.as_bytes());
+    let bytes = hasher.finalize();
+    let mut hex = String::with_capacity(64);
+    for byte in bytes {
+        hex.push_str(&format!("{:02x}", byte));
+    }
+    hex
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::commands::vm::exec::{RunMode, RunProfile};
+
+    fn base_run_args() -> RunArgs {
+        RunArgs {
+            manifest: None,
+            cpus: 2,
+            memory: "512M".to_string(),
+            profile: RunProfile::Standard,
+            add_dir: Vec::new(),
+            env: Vec::new(),
+            timeout: 60,
+            receipt: None,
+            json: false,
+            launch_plan: None,
+            mode: Some(RunMode::Plan),
+            dev: false,
+            prod: false,
+            argv: Vec::new(),
+        }
+    }
+
+    #[test]
+    fn placeholder_image_sha_is_64_hex_chars() {
+        let sha = placeholder_image_sha("wl-id", "app-1");
+        assert_eq!(sha.len(), 64);
+        assert!(sha.chars().all(|c| matches!(c, '0'..='9' | 'a'..='f')));
+    }
+
+    #[test]
+    fn placeholder_image_sha_is_stable() {
+        let a = placeholder_image_sha("wl", "app");
+        let b = placeholder_image_sha("wl", "app");
+        assert_eq!(a, b, "same inputs must yield same SHA");
+    }
+
+    #[test]
+    fn placeholder_image_sha_differs_per_app() {
+        let a = placeholder_image_sha("wl", "app1");
+        let b = placeholder_image_sha("wl", "app2");
+        assert_ne!(a, b, "different app names must yield different SHAs");
+    }
+
+    #[test]
+    fn extract_script_arg_rejects_zero_args() {
+        let args = base_run_args();
+        let err = extract_script_arg(&args).expect_err("must require a script");
+        assert!(err.to_string().contains("requires a script path"));
+    }
+
+    #[test]
+    fn extract_script_arg_rejects_multiple_args() {
+        let mut args = base_run_args();
+        args.argv = vec!["a.py".to_string(), "b.py".to_string()];
+        let err = extract_script_arg(&args).expect_err("must reject extra argv");
+        assert!(err.to_string().contains("exactly one positional"));
+    }
+
+    #[test]
+    fn extract_script_arg_accepts_one_positional() {
+        let mut args = base_run_args();
+        args.argv = vec!["./foo.py".to_string()];
+        let p = extract_script_arg(&args).expect("one positional");
+        assert_eq!(p, PathBuf::from("./foo.py"));
+    }
+}

--- a/tests/run_plan_mode.rs
+++ b/tests/run_plan_mode.rs
@@ -1,0 +1,213 @@
+//! Followup H plan-mode end-to-end test (Plan 73).
+//!
+//! Mirrors the `auto_exec_python_record.rs` pattern: spawns a
+//! stand-alone Python script that emits a wire-shape recording to
+//! `$MVM_SDK_OUT_PATH`, then drives `mvmctl run --mode plan` over
+//! the same script. The recording flows through
+//! `mvm_sdk::runtime::compile_recording` to a Workload; the CLI
+//! synthesises one `ExecutionPlan` per app and routes each through
+//! `mvm_supervisor::admit_for_run` for a dry-run admission check.
+//!
+//! What this test asserts (the CLI surface the regression bites):
+//!
+//! 1. `mvmctl run --mode plan <script>` admits a clean recording
+//!    and exits zero. ADMITTED lines hit stdout.
+//! 2. `mvmctl run --dev <script>` bails with the "blocked, pairs
+//!    with Followup H-live" message and a nonzero exit.
+//! 3. `mvmctl run --prod <script>` redirects users to
+//!    `mvmctl compile` with a nonzero exit and a clear pointer.
+//! 4. `mvmctl run --mode plan` over a script that produces a
+//!    Workload with a too-short SHA (we force-feed one via
+//!    `MVM_SDK_OUT_PATH` pointed at a hand-built recording) is
+//!    rejected by admission with a nonzero exit.
+//!
+//! Skips when no `python3`/`python` is on PATH.
+
+use std::path::PathBuf;
+use std::process::Command;
+
+use assert_cmd::cargo::CommandCargoExt;
+use tempfile::TempDir;
+
+const FAKE_SDK_SCRIPT: &str = r#"
+import json, os, sys
+out = os.environ.get("MVM_SDK_OUT_PATH")
+if not out:
+    sys.exit("MVM_SDK_OUT_PATH unset")
+recording = {
+    "workload_id": "etl-plan-mode",
+    "create": {
+        "template": "python-3.12",
+        "env": {},
+        "include": [],
+        "tags": {},
+        "ttl_seconds": 1800,
+    },
+    "ops": [
+        {"kind": "command_start", "argv": ["python", "run.py"], "env": {}},
+    ],
+}
+with open(out, "w") as f:
+    json.dump(recording, f)
+"#;
+
+fn python_on_path() -> Option<PathBuf> {
+    which::which("python3")
+        .ok()
+        .or_else(|| which::which("python").ok())
+}
+
+/// Build the `mvmctl run --mode plan <script>` invocation against a
+/// hermetic `$HOME` so the test never writes into the real user's
+/// `~/.mvm/keys/` or `~/.mvm/audit/`. Returns the built `Command`
+/// ready for `.output()`.
+fn mvmctl_run_plan_cmd(home_dir: &std::path::Path) -> Command {
+    // `cargo_bin` is the established pattern across this repo's
+    // integration tests; the deprecation warning tracks an upstream
+    // assert_cmd transition unrelated to this change.
+    #[allow(deprecated)]
+    let mut cmd = Command::cargo_bin("mvmctl").expect("locate mvmctl binary");
+    cmd.env("HOME", home_dir);
+    cmd.env_remove("MVM_SDK_MODE");
+    cmd
+}
+
+#[test]
+fn run_plan_mode_admits_clean_recording_and_exits_zero() {
+    let Some(python) = python_on_path() else {
+        eprintln!("skipping run_plan_mode_admits_clean_recording: no python3/python on PATH");
+        return;
+    };
+
+    let tmp = TempDir::new().unwrap();
+    let script = tmp.path().join("hello.py");
+    std::fs::write(&script, FAKE_SDK_SCRIPT).unwrap();
+
+    let home = TempDir::new().unwrap();
+
+    let mut cmd = mvmctl_run_plan_cmd(home.path());
+    cmd.env("MVM_PYTHON", &python)
+        .arg("run")
+        .arg("--mode")
+        .arg("plan")
+        .arg(&script);
+
+    let output = cmd.output().expect("spawn mvmctl run --mode plan");
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    let stderr = String::from_utf8_lossy(&output.stderr);
+
+    assert!(
+        output.status.success(),
+        "mvmctl run --mode plan must exit 0 on a clean recording.\n--- stdout ---\n{stdout}\n--- stderr ---\n{stderr}"
+    );
+    assert!(
+        stdout.contains("ADMITTED"),
+        "expected an ADMITTED line on stdout; got:\nstdout: {stdout}\nstderr: {stderr}"
+    );
+    assert!(
+        stdout.contains("plan_id=") && stdout.contains("signer=host:"),
+        "ADMITTED line missing plan_id / signer hints; got:\n{stdout}"
+    );
+}
+
+#[test]
+fn run_dev_alias_is_blocked_with_followup_h_live_message() {
+    let tmp = TempDir::new().unwrap();
+    let script = tmp.path().join("hello.py");
+    std::fs::write(&script, "print('noop')\n").unwrap();
+
+    let home = TempDir::new().unwrap();
+    let output = mvmctl_run_plan_cmd(home.path())
+        .arg("run")
+        .arg("--dev")
+        .arg(&script)
+        .output()
+        .expect("spawn mvmctl run --dev");
+
+    assert!(
+        !output.status.success(),
+        "mvmctl run --dev must fail nonzero in v1"
+    );
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        stderr.contains("Followup H-live") || stderr.contains("blocked"),
+        "expected --dev to bail with a 'pairs with Followup H-live' hint; stderr was:\n{stderr}"
+    );
+}
+
+#[test]
+fn run_prod_alias_redirects_to_mvmctl_compile() {
+    let tmp = TempDir::new().unwrap();
+    let script = tmp.path().join("hello.py");
+    std::fs::write(&script, "print('noop')\n").unwrap();
+
+    let home = TempDir::new().unwrap();
+    let output = mvmctl_run_plan_cmd(home.path())
+        .arg("run")
+        .arg("--prod")
+        .arg(&script)
+        .output()
+        .expect("spawn mvmctl run --prod");
+
+    assert!(
+        !output.status.success(),
+        "mvmctl run --prod must fail and redirect"
+    );
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        stderr.contains("mvmctl compile"),
+        "--prod must redirect users to `mvmctl compile`; stderr was:\n{stderr}"
+    );
+}
+
+#[test]
+fn run_mode_live_bails_blocked_on_followup_h_live() {
+    let tmp = TempDir::new().unwrap();
+    let script = tmp.path().join("hello.py");
+    std::fs::write(&script, "print('noop')\n").unwrap();
+
+    let home = TempDir::new().unwrap();
+    let output = mvmctl_run_plan_cmd(home.path())
+        .arg("run")
+        .arg("--mode")
+        .arg("live")
+        .arg(&script)
+        .output()
+        .expect("spawn mvmctl run --mode live");
+
+    assert!(
+        !output.status.success(),
+        "mvmctl run --mode live must fail in v1"
+    );
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        stderr.contains("Followup H-live") || stderr.contains("blocked"),
+        "expected --mode live to bail with a Followup H-live hint; stderr was:\n{stderr}"
+    );
+}
+
+#[test]
+fn run_mode_plan_rejects_non_script_extension() {
+    let tmp = TempDir::new().unwrap();
+    let not_a_script = tmp.path().join("ir.json");
+    std::fs::write(&not_a_script, "{}").unwrap();
+    let home = TempDir::new().unwrap();
+
+    let output = mvmctl_run_plan_cmd(home.path())
+        .arg("run")
+        .arg("--mode")
+        .arg("plan")
+        .arg(&not_a_script)
+        .output()
+        .expect("spawn mvmctl run --mode plan ir.json");
+
+    assert!(
+        !output.status.success(),
+        "plan mode must reject a non-script extension"
+    );
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        stderr.contains(".py") || stderr.contains(".ts") || stderr.contains(".js"),
+        "expected the language-extension hint in stderr; got:\n{stderr}"
+    );
+}


### PR DESCRIPTION
## Summary

- New `mvmctl run --mode plan <script>` verb: runs a Sandbox-shaped Python / TypeScript / JavaScript script with each `Sandbox` operation rerouted to synthesise one `ExecutionPlan` per app, and routes each plan through `mvm_supervisor::admit_for_run` for a dry-run admission check. **No microVM ever boots** — useful for validating admission gates (signature, validity window, replay store, policy resolution) without paying the VM-boot cost.
- `--dev` (alias for `--mode live`) and `--mode live` bail with a "blocked, pairs with Followup H-live" hint; that half lands once Plan 72 W4/W5 are validated end to end.
- `--prod` (alias for `--mode record`) and `--mode record` redirect users to `mvmctl compile`, where record is the default mode.
- `MVM_SDK_MODE` env var mirrors `mvmctl compile`'s precedence: env supersedes flags; same blocked-mode rejection messages.

## Implementation notes

- Extracts the record-mode auto-exec helpers (`auto_exec_record_script`, `resolve_interpreter`, `script_language_from_path`, `load_recording`) from `crates/mvm-cli/src/commands/build/compile.rs` into a new `sandbox_record.rs` module so both verbs share one implementation + one test seam.
- New `crates/mvm-cli/src/commands/vm/run_plan.rs` dispatcher: lowers the recording via `mvm_sdk::runtime::compile_recording`, derives a `SynthesisInput` per app (`cpus` / `mem_mib` / `disk_mib` from the app's `Resources`; a content-addressed placeholder 64-char hex SHA for `image_sha256` since plan-mode never builds a rootfs), then admits via `mvm_supervisor::admit_for_run`. Rejected admissions surface verbatim and exit nonzero.
- Spec: \`specs/plans/73-sdk-port-followups.md\` §"Followup H".

## Test plan

- [x] `cargo fmt --check` clean
- [x] `cargo clippy --workspace --all-targets -- -D warnings` clean
- [x] `cargo run -p xtask -- check-no-display-on-secret-types` clean
- [x] `cargo test --workspace --lib -- --test-threads=1` passes (472 affected-crate tests, 546 mvm-cli lib tests). The pre-existing flakes (`mvm-guest` entrypoint timing, `tenant::tests::destroy_invalid_tenant_id_errors` parallel-tempdir race, `mk_guest_eval_assertions_all_pass_when_nix_available` requires a running Nix daemon) are unrelated to this change and reproduce on `origin/main`.
- [x] New integration test `tests/run_plan_mode.rs` (5 cases) — admit/reject paths, `--dev` block, `--prod` redirect, `--mode live` block, non-script-extension diagnostic. All pass.
- [x] Existing `tests/auto_exec_python_record.rs` + `tests/auto_exec_node_record.rs` still green after the helper refactor.

## What still ships in Followup H

- **H-live** (`mvmctl run --mode live`): SDK shells `Sandbox` operations to existing `mvmctl up`/`exec`/`down`. Needs Plan 72 W4/W5 validated in production after the W5.B cutover that just landed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)