### PR TITLE
feat(mvm-build): plan 73 followup B.1 — install_app_deps host orchestrator

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4158,6 +4158,7 @@ dependencies = [
  "mvm-core",
  "mvm-guest",
  "mvm-libkrun",
+ "mvm-sdk",
  "serde",
  "serde_json",
  "sha2 0.10.9",

--- a/crates/mvm-build/Cargo.toml
+++ b/crates/mvm-build/Cargo.toml
@@ -11,6 +11,13 @@ authors.workspace = true
 [dependencies]
 mvm-core.workspace = true
 mvm-guest.workspace = true
+# Plan 73 Followup B.1 — `install_app_deps` reuses
+# `mvm_sdk::compile::deps_audit::{verify_sealed_volume, VolumeError}`
+# for cache-hit verification. The orchestrator owns the cache
+# probe + miss-path placeholder; the audit primitives stay in
+# `mvm-sdk` so the supervisor and the builder VM go through the
+# same types.
+mvm-sdk.workspace = true
 anyhow.workspace = true
 chrono.workspace = true
 # Optional — see the same dep in `mvm-backend/Cargo.toml` for the

--- a/crates/mvm-build/src/app_deps.rs
+++ b/crates/mvm-build/src/app_deps.rs
@@ -1,0 +1,398 @@
+//! Host-side orchestrator for the application-dependency install
+//! pipeline (ADR-047, Plan 73 Followup B).
+//!
+//! This module is the host-side seam between a user's `mvmctl build`
+//! invocation and the builder-VM-side install pipeline that runs
+//! `uv pip install --no-deps`, `pnpm install --frozen-lockfile`, etc.
+//! It does **two** things:
+//!
+//! 1. **Cache resolution.** Given an [`InstallSpec`] pointing at a
+//!    lockfile, derive a stable `lockfile_hash`, look it up in the
+//!    deps-volume index, and — on a cache hit — re-verify the on-disk
+//!    sealed volume via
+//!    [`mvm_sdk::compile::deps_audit::verify_sealed_volume`]. A hit
+//!    returns `InstallResult { cache_hit: true, .. }` carrying the
+//!    canonical `volume_hash` + `manifest.sha256` the supervisor's
+//!    admission gate (Followup A) pins.
+//! 2. **Cache miss → builder-VM dispatch.** Slice B.1 reserves the
+//!    seam but does not yet drive the builder VM; instead it returns
+//!    [`InstallError::BuilderVmNotWired`]. Slice B.2 replaces this
+//!    branch with a call into
+//!    `crates/mvm-build/src/builder_vm.rs::LibkrunBuilderVm::run_build`
+//!    (with mounted lockfile + source root + writable volume out).
+//!
+//! ### Why the cache key is a lockfile hash
+//!
+//! ADR-047 §"Lifecycle gates" pins the *volume* hash at admission
+//! time, but the volume hash bakes in `cve.json` and `meta.json` —
+//! values only the builder VM knows after the install runs. The
+//! orchestrator needs a key it can derive *before* the VM runs so it
+//! can answer "have I already installed this lockfile?" without a
+//! VM spawn. The lockfile sha256 is that key: same lockfile bytes
+//! ⇒ same key ⇒ same cached volume.
+//!
+//! The cache layout is:
+//!
+//! ```text
+//! <deps_volumes_dir>/
+//! ├── <volume_hash>/          # sealed volume (content + sidecars)
+//! │   ├── content/
+//! │   ├── sbom.cdx.json
+//! │   ├── fetch.log
+//! │   ├── cve.json
+//! │   └── meta.json
+//! └── index/
+//!     └── <lockfile_hash>     # plain text: <volume_hash>\n
+//! ```
+//!
+//! The supervisor only ever reads the `<volume_hash>/` directories;
+//! the `index/` tree is host-orchestrator state. A corrupt index
+//! entry can only ever cause a cache *miss* — the verifier still
+//! re-derives the canonical volume_hash from disk, so a tampered
+//! index can't pass a forged volume into admission.
+//!
+//! ### Cross-platform
+//!
+//! Per CLAUDE.md ("Host Nix is never used by mvmctl"): this module
+//! does not invoke host Nix and does not call out to any host
+//! installer. Every operation here is pure I/O — sha256 streaming,
+//! filesystem reads, `verify_sealed_volume`. The actual install runs
+//! inside the libkrun builder VM (slice B.2).
+
+use std::fs;
+use std::io::{self, Read};
+use std::path::{Path, PathBuf};
+
+use mvm_sdk::compile::deps_audit::{VolumeError, verify_sealed_volume};
+use serde::{Deserialize, Serialize};
+use sha2::{Digest, Sha256};
+use thiserror::Error;
+
+/// Subdirectory under the deps-volumes root that holds the
+/// `lockfile_hash → volume_hash` index. Kept out of the supervisor's
+/// admission path (it only walks `<root>/<volume_hash>/`).
+pub const INDEX_SUBDIR: &str = "index";
+
+/// Which language ecosystem the lockfile belongs to. Determines
+/// which installer the builder VM dispatches (slice B.2) and
+/// participates in the cache key so the same lockfile bytes can't
+/// accidentally collide across ecosystems.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum Language {
+    Python,
+    Node,
+}
+
+impl Language {
+    /// Short token mixed into the cache key. Stable wire-string;
+    /// must not change without a cache-rebuild.
+    pub fn token(&self) -> &'static str {
+        match self {
+            Self::Python => "python",
+            Self::Node => "node",
+        }
+    }
+}
+
+/// ADR-047 §"Lifecycle gates" — the gate level controls strictness
+/// of the builder-VM-side checks (attestations, CVE severity). The
+/// orchestrator carries it through to slice B.2; in B.1 it
+/// participates in the cache key so a `--dev` cache entry can't
+/// satisfy a `--prod` request.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum GateLevel {
+    /// Warnings on missing attestations / non-critical CVEs.
+    Dev,
+    /// Fails closed on missing attestations or high/critical CVEs.
+    Prod,
+}
+
+impl GateLevel {
+    pub fn token(&self) -> &'static str {
+        match self {
+            Self::Dev => "dev",
+            Self::Prod => "prod",
+        }
+    }
+}
+
+/// What the caller wants installed. Pure data — the orchestrator
+/// reads files at the given paths but does not retain handles.
+#[derive(Debug, Clone)]
+pub struct InstallSpec {
+    /// Path to the lockfile (`uv.lock`, `package-lock.json`,
+    /// `pnpm-lock.yaml`). Hashed verbatim — the orchestrator does
+    /// not parse it.
+    pub lockfile: PathBuf,
+    /// Project root that holds the lockfile + any auxiliary inputs
+    /// the installer needs (`pyproject.toml`, `package.json`). Slice
+    /// B.2 bind-mounts this into the builder VM; B.1 records the
+    /// path on `InstallResult` for diagnostics but does not read
+    /// from it.
+    pub source_root: PathBuf,
+    pub language: Language,
+    pub gate: GateLevel,
+    /// Optional override for the deps-volumes cache root. When
+    /// `None`, resolves to
+    /// [`mvm_core::config::mvm_deps_volumes_dir`] (which itself
+    /// honors `MVM_DEPS_VOLUMES_DIR` — same env knob Followup A's
+    /// admission verifier uses).
+    pub cache_root_override: Option<PathBuf>,
+}
+
+/// Result of a successful install resolution. The caller (slice
+/// B.3's `mvmctl build` wiring + Followup A's `ExecutionPlan`
+/// synthesis) pins both `volume_hash` and `manifest_sha256` into
+/// the plan so the admission verifier can re-derive them.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct InstallResult {
+    pub volume_hash: String,
+    pub manifest_sha256: String,
+    pub cache_hit: bool,
+    /// The path the supervisor will read from at admission time.
+    pub volume_dir: PathBuf,
+    /// The sha256 of the lockfile bytes, surfaced for diagnostics +
+    /// `mvmctl deps inspect` (slice B.3).
+    pub lockfile_sha256: String,
+}
+
+#[derive(Debug, Error)]
+pub enum InstallError {
+    #[error("install spec lockfile `{}` is missing", .0.display())]
+    LockfileMissing(PathBuf),
+
+    #[error("install spec source root `{}` is missing", .0.display())]
+    SourceRootMissing(PathBuf),
+
+    #[error("failed to read lockfile `{}`: {source}", path.display())]
+    LockfileIo {
+        path: PathBuf,
+        #[source]
+        source: io::Error,
+    },
+
+    #[error("failed to read cache index `{}`: {source}", path.display())]
+    IndexIo {
+        path: PathBuf,
+        #[source]
+        source: io::Error,
+    },
+
+    /// Cache hit on the index, but the volume directory it pointed
+    /// at failed [`verify_sealed_volume`]. Propagates the underlying
+    /// audit error so tamper-detection messages flow through. The
+    /// orchestrator does **not** silently demote this to a miss —
+    /// a corrupt cache entry needs operator attention.
+    #[error("cache verify failed for lockfile_hash {lockfile_hash}: {source}")]
+    CacheVerifyFailed {
+        lockfile_hash: String,
+        #[source]
+        source: VolumeError,
+    },
+
+    /// Cache hit on the index, the volume verified, but the
+    /// volume_hash that lived inside the volume disagrees with the
+    /// hash the index pointed at. Means someone overwrote a
+    /// directory in-place. Fail closed — same posture as
+    /// [`Self::CacheVerifyFailed`].
+    #[error(
+        "cache index hash mismatch for lockfile_hash {lockfile_hash}: index said {index_hash}, on-disk volume sealed at {volume_hash}"
+    )]
+    CacheHashMismatch {
+        lockfile_hash: String,
+        index_hash: String,
+        volume_hash: String,
+    },
+
+    /// The cache miss path. Slice B.1's deliberate seam — slice B.2
+    /// replaces this branch with a builder-VM dispatch. The error
+    /// message points users at the manual cache-population path so
+    /// they can hand-author a sealed volume for testing the
+    /// downstream admission gates (Followup A) before B.2 lands.
+    #[error(
+        "no cached deps volume for lockfile_hash {lockfile_hash} ({language}/{gate}); \
+         builder-VM install pipeline is not yet wired (Plan 73 Followup B.2). \
+         To unblock local testing, hand-author a sealed volume under \
+         `{cache_root}/<volume_hash>/` (use `mvm_sdk::compile::deps_audit::seal_volume`) \
+         and place a pointer at `{cache_root}/index/{lockfile_hash}`."
+    )]
+    BuilderVmNotWired {
+        lockfile_hash: String,
+        language: &'static str,
+        gate: &'static str,
+        cache_root: PathBuf,
+    },
+}
+
+/// Resolve a deps install for `spec`. Pure host-side operation —
+/// hashes the lockfile, probes the cache index, and either returns
+/// a verified [`InstallResult`] or the [`InstallError::BuilderVmNotWired`]
+/// placeholder. Does not invoke the builder VM and does not write to
+/// the cache.
+pub fn install_app_deps(spec: &InstallSpec) -> Result<InstallResult, InstallError> {
+    if !spec.lockfile.is_file() {
+        return Err(InstallError::LockfileMissing(spec.lockfile.clone()));
+    }
+    if !spec.source_root.is_dir() {
+        return Err(InstallError::SourceRootMissing(spec.source_root.clone()));
+    }
+
+    let lockfile_sha256 =
+        sha256_file(&spec.lockfile).map_err(|source| InstallError::LockfileIo {
+            path: spec.lockfile.clone(),
+            source,
+        })?;
+    let lockfile_hash = derive_lockfile_hash(&lockfile_sha256, spec.language, spec.gate);
+    let cache_root = resolve_cache_root(spec.cache_root_override.as_deref());
+
+    match lookup_cached_volume(&cache_root, &lockfile_hash)? {
+        Some(volume_hash) => {
+            let volume_dir = cache_root.join(&volume_hash);
+            let computed = verify_sealed_volume(&volume_dir).map_err(|source| {
+                InstallError::CacheVerifyFailed {
+                    lockfile_hash: lockfile_hash.clone(),
+                    source,
+                }
+            })?;
+            if computed != volume_hash {
+                return Err(InstallError::CacheHashMismatch {
+                    lockfile_hash,
+                    index_hash: volume_hash,
+                    volume_hash: computed,
+                });
+            }
+            let manifest_sha256 =
+                sha256_file(&volume_dir.join(mvm_sdk::compile::deps_audit::FILE_MANIFEST))
+                    .map_err(|source| InstallError::LockfileIo {
+                        path: volume_dir.join(mvm_sdk::compile::deps_audit::FILE_MANIFEST),
+                        source,
+                    })?;
+            Ok(InstallResult {
+                volume_hash,
+                manifest_sha256,
+                cache_hit: true,
+                volume_dir,
+                lockfile_sha256,
+            })
+        }
+        None => Err(InstallError::BuilderVmNotWired {
+            lockfile_hash,
+            language: spec.language.token(),
+            gate: spec.gate.token(),
+            cache_root,
+        }),
+    }
+}
+
+/// Derive the stable cache key from the lockfile sha256 + the
+/// language + the gate. Pure function so callers (tests, future
+/// `mvmctl deps inspect`) can reproduce it without re-hashing.
+///
+/// The mix-in tokens prevent two ecosystems from colliding on a
+/// byte-identical lockfile (`requirements.txt` vs. a Node lockfile
+/// of the same length), and prevent a `--dev` cache entry from
+/// satisfying a `--prod` admission request.
+pub fn derive_lockfile_hash(lockfile_sha256: &str, language: Language, gate: GateLevel) -> String {
+    let mut h = Sha256::new();
+    h.update(b"mvm-app-deps-v1\n");
+    h.update(language.token().as_bytes());
+    h.update(b"\n");
+    h.update(gate.token().as_bytes());
+    h.update(b"\n");
+    h.update(lockfile_sha256.as_bytes());
+    hex(&h.finalize())
+}
+
+/// Resolve the deps-volumes cache root, honoring the per-call
+/// override and falling back to
+/// [`mvm_core::config::mvm_deps_volumes_dir`] (which itself honors
+/// `MVM_DEPS_VOLUMES_DIR`). Shared lookup with Followup A's
+/// admission verifier — no duplication.
+pub fn resolve_cache_root(override_path: Option<&Path>) -> PathBuf {
+    override_path
+        .map(Path::to_path_buf)
+        .unwrap_or_else(|| PathBuf::from(mvm_core::config::mvm_deps_volumes_dir()))
+}
+
+/// Read the cache index entry for a `lockfile_hash`. Returns the
+/// recorded `volume_hash` on hit, `None` on miss (no index file).
+/// I/O errors other than `NotFound` propagate.
+fn lookup_cached_volume(
+    cache_root: &Path,
+    lockfile_hash: &str,
+) -> Result<Option<String>, InstallError> {
+    let path = cache_root.join(INDEX_SUBDIR).join(lockfile_hash);
+    match fs::read_to_string(&path) {
+        Ok(s) => {
+            let trimmed = s.trim().to_owned();
+            if trimmed.is_empty() {
+                Ok(None)
+            } else {
+                Ok(Some(trimmed))
+            }
+        }
+        Err(e) if e.kind() == io::ErrorKind::NotFound => Ok(None),
+        Err(source) => Err(InstallError::IndexIo { path, source }),
+    }
+}
+
+fn sha256_file(path: &Path) -> Result<String, io::Error> {
+    let mut f = fs::File::open(path)?;
+    let mut h = Sha256::new();
+    let mut buf = [0u8; 64 * 1024];
+    loop {
+        let n = f.read(&mut buf)?;
+        if n == 0 {
+            break;
+        }
+        h.update(&buf[..n]);
+    }
+    Ok(hex(&h.finalize()))
+}
+
+fn hex(bytes: &[u8]) -> String {
+    let mut out = String::with_capacity(bytes.len() * 2);
+    for b in bytes {
+        out.push_str(&format!("{b:02x}"));
+    }
+    out
+}
+
+#[cfg(test)]
+mod tests {
+    //! Module-level unit coverage for the pure helpers; the
+    //! end-to-end orchestrator paths (cache hit, miss, tamper,
+    //! determinism) live in
+    //! `crates/mvm-build/tests/app_deps_orchestrator.rs` so they
+    //! exercise the public API.
+    use super::*;
+
+    #[test]
+    fn lockfile_hash_differs_across_languages() {
+        let h_py = derive_lockfile_hash("aa", Language::Python, GateLevel::Dev);
+        let h_node = derive_lockfile_hash("aa", Language::Node, GateLevel::Dev);
+        assert_ne!(h_py, h_node);
+    }
+
+    #[test]
+    fn lockfile_hash_differs_across_gates() {
+        let h_dev = derive_lockfile_hash("aa", Language::Python, GateLevel::Dev);
+        let h_prod = derive_lockfile_hash("aa", Language::Python, GateLevel::Prod);
+        assert_ne!(h_dev, h_prod);
+    }
+
+    #[test]
+    fn lockfile_hash_is_pure() {
+        let h1 = derive_lockfile_hash("aa", Language::Python, GateLevel::Dev);
+        let h2 = derive_lockfile_hash("aa", Language::Python, GateLevel::Dev);
+        assert_eq!(h1, h2);
+    }
+
+    #[test]
+    fn resolve_cache_root_prefers_override() {
+        let p = PathBuf::from("/tmp/forced");
+        assert_eq!(resolve_cache_root(Some(&p)), p);
+    }
+}

--- a/crates/mvm-build/src/lib.rs
+++ b/crates/mvm-build/src/lib.rs
@@ -1,3 +1,4 @@
+pub mod app_deps;
 pub mod artifacts;
 pub mod backend;
 pub mod builder_vm;

--- a/crates/mvm-build/tests/app_deps_orchestrator.rs
+++ b/crates/mvm-build/tests/app_deps_orchestrator.rs
@@ -1,0 +1,329 @@
+//! End-to-end coverage for the [`mvm_build::app_deps`] host
+//! orchestrator (Plan 73 Followup B.1). Uses on-disk sealed-volume
+//! fixtures hand-authored via
+//! [`mvm_sdk::compile::deps_audit::seal_volume`] so the cache-hit
+//! path exercises the same wire format the builder VM will emit in
+//! slice B.2.
+//!
+//! The cache layout under test:
+//!
+//! ```text
+//! <cache_root>/
+//! ├── <volume_hash>/      # hand-authored sealed volume
+//! │   ├── content/
+//! │   ├── sbom.cdx.json
+//! │   ├── fetch.log
+//! │   ├── cve.json
+//! │   └── meta.json
+//! └── index/
+//!     └── <lockfile_hash>  # plain text: <volume_hash>\n
+//! ```
+
+use std::collections::BTreeMap;
+use std::fs;
+use std::path::{Path, PathBuf};
+
+use mvm_build::app_deps::{
+    GateLevel, InstallError, InstallSpec, Language, derive_lockfile_hash, install_app_deps,
+    resolve_cache_root,
+};
+use mvm_sdk::compile::deps_audit::{
+    FILE_CONTENT_DIR, FILE_CVE, FILE_FETCH_LOG, FILE_MANIFEST, FILE_SBOM, VolumeSealResult,
+    seal_volume,
+};
+use sha2::{Digest, Sha256};
+
+/// All-in-one fixture: a tempdir with a `cache_root/`, a
+/// `source_root/`, and a hand-authored lockfile + sealed volume.
+struct Fixture {
+    tmp: tempfile::TempDir,
+    cache_root: PathBuf,
+    source_root: PathBuf,
+    lockfile: PathBuf,
+}
+
+impl Fixture {
+    /// Build a fixture with a populated source root + lockfile.
+    /// `populate_cache=true` also seals a volume into the cache and
+    /// writes its index entry; `false` exercises the miss path.
+    fn new(populate_cache: bool) -> (Self, Option<VolumeSealResult>) {
+        let tmp = tempfile::tempdir().unwrap();
+        let root = tmp.path();
+        let cache_root = root.join("cache");
+        let source_root = root.join("project");
+        fs::create_dir_all(&cache_root).unwrap();
+        fs::create_dir_all(&source_root).unwrap();
+
+        // Realistic uv.lock-shaped bytes. Hashed verbatim by the
+        // orchestrator; the content doesn't have to parse.
+        let lockfile = source_root.join("uv.lock");
+        fs::write(
+            &lockfile,
+            b"version = 1\n[[package]]\nname = \"requests\"\nversion = \"2.31.0\"\n",
+        )
+        .unwrap();
+        // A source file or two so the source_root is a real dir.
+        fs::write(
+            source_root.join("pyproject.toml"),
+            b"[project]\nname=\"t\"\n",
+        )
+        .unwrap();
+
+        let sealed = if populate_cache {
+            Some(seal_into_cache(&cache_root, &lockfile))
+        } else {
+            None
+        };
+
+        (
+            Self {
+                tmp,
+                cache_root,
+                source_root,
+                lockfile,
+            },
+            sealed,
+        )
+    }
+
+    fn spec(&self) -> InstallSpec {
+        InstallSpec {
+            lockfile: self.lockfile.clone(),
+            source_root: self.source_root.clone(),
+            language: Language::Python,
+            gate: GateLevel::Dev,
+            cache_root_override: Some(self.cache_root.clone()),
+        }
+    }
+}
+
+/// Build a minimal sealed volume at `<cache_root>/<volume_hash>/`
+/// using `seal_volume`, then write the matching index pointer at
+/// `<cache_root>/index/<lockfile_hash>`. Returns the seal result
+/// so callers can assert against `volume_hash`.
+fn seal_into_cache(cache_root: &Path, lockfile_path: &Path) -> VolumeSealResult {
+    // Sealed volume materialized inside a scratch dir first; the
+    // orchestrator's cache-hit path reads from the resulting hashed
+    // directory at `<cache_root>/<volume_hash>/`.
+    let scratch = cache_root.join("scratch");
+    let content_dir = scratch.join(FILE_CONTENT_DIR);
+    fs::create_dir_all(&content_dir).unwrap();
+    fs::write(content_dir.join("requests-2.31.0.dist-info"), b"meta\n").unwrap();
+    fs::create_dir_all(content_dir.join("requests")).unwrap();
+    fs::write(
+        content_dir.join("requests").join("__init__.py"),
+        b"# stub\n",
+    )
+    .unwrap();
+
+    let sbom = scratch.join(FILE_SBOM);
+    fs::write(&sbom, br#"{"bomFormat":"CycloneDX","specVersion":"1.5"}"#).unwrap();
+    let fetch_log = scratch.join(FILE_FETCH_LOG);
+    fs::write(
+        &fetch_log,
+        b"GET https://pypi.org/simple/requests/\nGET https://files.pythonhosted.org/...\n",
+    )
+    .unwrap();
+    let cve = scratch.join(FILE_CVE);
+    fs::write(&cve, br#"{"results":[]}"#).unwrap();
+
+    let result = seal_volume(
+        &content_dir,
+        &sbom,
+        &fetch_log,
+        &cve,
+        "2026-05-13T00:00:00Z",
+        BTreeMap::new(),
+    )
+    .expect("seal_volume");
+
+    // Rename the scratch dir to `<cache_root>/<volume_hash>/` and
+    // drop `meta.json` inside.
+    let final_dir = cache_root.join(&result.volume_hash);
+    fs::rename(&scratch, &final_dir).unwrap();
+    fs::write(final_dir.join(FILE_MANIFEST), &result.manifest_bytes).unwrap();
+
+    // Index pointer.
+    let lockfile_sha = sha256_file(lockfile_path);
+    let lockfile_hash = derive_lockfile_hash(&lockfile_sha, Language::Python, GateLevel::Dev);
+    let index_dir = cache_root.join("index");
+    fs::create_dir_all(&index_dir).unwrap();
+    fs::write(index_dir.join(&lockfile_hash), &result.volume_hash).unwrap();
+
+    result
+}
+
+fn sha256_file(p: &Path) -> String {
+    let bytes = fs::read(p).unwrap();
+    let mut h = Sha256::new();
+    h.update(&bytes);
+    let out = h.finalize();
+    let mut s = String::new();
+    for b in out {
+        s.push_str(&format!("{b:02x}"));
+    }
+    s
+}
+
+#[test]
+fn cache_hit_returns_verified_install_result() {
+    let (fx, sealed) = Fixture::new(true);
+    let sealed = sealed.expect("populated");
+    let res = install_app_deps(&fx.spec()).expect("install ok");
+    assert!(res.cache_hit, "expected cache_hit=true");
+    assert_eq!(res.volume_hash, sealed.volume_hash);
+    assert_eq!(res.volume_dir, fx.cache_root.join(&sealed.volume_hash));
+    // manifest_sha256 is the sha256 of the on-disk meta.json bytes —
+    // the supervisor's admission gate pins this separately from the
+    // volume_hash (Followup A §"manifest_sha256 cross-check").
+    assert!(!res.manifest_sha256.is_empty());
+    assert_eq!(res.manifest_sha256.len(), 64);
+    // Lockfile sha is the un-mixed-in value; deterministic over the
+    // lockfile bytes.
+    assert_eq!(res.lockfile_sha256, sha256_file(&fx.lockfile));
+}
+
+#[test]
+fn cache_miss_returns_builder_vm_not_wired() {
+    let (fx, _) = Fixture::new(false);
+    let err = install_app_deps(&fx.spec()).expect_err("must miss");
+    match err {
+        InstallError::BuilderVmNotWired {
+            lockfile_hash,
+            language,
+            gate,
+            cache_root,
+        } => {
+            assert_eq!(language, "python");
+            assert_eq!(gate, "dev");
+            assert_eq!(cache_root, fx.cache_root);
+            // The lockfile_hash is the derived key; check it matches
+            // the helper so users + slice B.2 can reproduce it.
+            let expected =
+                derive_lockfile_hash(&sha256_file(&fx.lockfile), Language::Python, GateLevel::Dev);
+            assert_eq!(lockfile_hash, expected);
+        }
+        other => panic!("wrong variant: {other:?}"),
+    }
+}
+
+#[test]
+fn cache_hit_on_tampered_cve_fails_verify() {
+    let (fx, sealed) = Fixture::new(true);
+    let sealed = sealed.unwrap();
+    // Hand-corrupt cve.json in the cached volume — same tamper the
+    // SDK's `verify_detects_tampered_cve` test exercises.
+    let cve_path = fx.cache_root.join(&sealed.volume_hash).join(FILE_CVE);
+    fs::write(&cve_path, br#"{"results":["FORGED"]}"#).unwrap();
+
+    let err = install_app_deps(&fx.spec()).expect_err("must fail closed");
+    match err {
+        InstallError::CacheVerifyFailed { lockfile_hash, .. } => {
+            let expected =
+                derive_lockfile_hash(&sha256_file(&fx.lockfile), Language::Python, GateLevel::Dev);
+            assert_eq!(lockfile_hash, expected);
+        }
+        other => panic!("wrong variant: {other:?}"),
+    }
+}
+
+#[test]
+fn cache_index_hash_mismatch_fails_closed() {
+    // Index pointer says one volume, the on-disk dir is sealed at a
+    // different hash. Means someone overwrote a directory in place;
+    // fail closed rather than serve a stale cached value.
+    let (fx, sealed) = Fixture::new(true);
+    let sealed = sealed.unwrap();
+    let bogus_hash = "f".repeat(64);
+    let lockfile_sha = sha256_file(&fx.lockfile);
+    let lockfile_hash = derive_lockfile_hash(&lockfile_sha, Language::Python, GateLevel::Dev);
+    fs::write(
+        fx.cache_root.join("index").join(&lockfile_hash),
+        &bogus_hash,
+    )
+    .unwrap();
+    // The bogus_hash dir doesn't exist either, so we get a Missing
+    // error wrapped in CacheVerifyFailed (not CacheHashMismatch —
+    // that variant only triggers when the dir exists but seals to a
+    // different hash, which is unreachable via legitimate
+    // `seal_volume` use). We also want the volume_hash variant
+    // covered for the case where two different sealed dirs collide;
+    // build a second sealed dir to exercise it.
+    let err = install_app_deps(&fx.spec()).expect_err("must fail closed");
+    assert!(
+        matches!(err, InstallError::CacheVerifyFailed { .. }),
+        "expected CacheVerifyFailed for missing dir, got: {err:?}"
+    );
+
+    // Now: place the *real* sealed volume under the bogus hash —
+    // verify_sealed_volume succeeds but the derived hash disagrees
+    // with the index pointer. This is the CacheHashMismatch path.
+    let real_dir = fx.cache_root.join(&sealed.volume_hash);
+    let bogus_dir = fx.cache_root.join(&bogus_hash);
+    fs::rename(&real_dir, &bogus_dir).unwrap();
+    let err = install_app_deps(&fx.spec()).expect_err("must fail closed");
+    match err {
+        InstallError::CacheHashMismatch {
+            lockfile_hash: lh,
+            index_hash,
+            volume_hash,
+        } => {
+            assert_eq!(lh, lockfile_hash);
+            assert_eq!(index_hash, bogus_hash);
+            assert_eq!(volume_hash, sealed.volume_hash);
+        }
+        other => panic!("wrong variant: {other:?}"),
+    }
+}
+
+#[test]
+fn lockfile_hash_is_deterministic_across_invocations() {
+    // Same lockfile bytes → same derived cache path → same miss
+    // diagnostic. Asserts the cache key is a pure function of
+    // (lockfile bytes, language, gate).
+    let (fx, _) = Fixture::new(false);
+    let first = install_app_deps(&fx.spec()).expect_err("miss");
+    let second = install_app_deps(&fx.spec()).expect_err("miss");
+    let (first_hash, second_hash) = match (&first, &second) {
+        (
+            InstallError::BuilderVmNotWired {
+                lockfile_hash: a, ..
+            },
+            InstallError::BuilderVmNotWired {
+                lockfile_hash: b, ..
+            },
+        ) => (a, b),
+        _ => panic!("expected miss variant from both calls"),
+    };
+    assert_eq!(first_hash, second_hash);
+}
+
+#[test]
+fn missing_lockfile_returns_typed_error() {
+    let (mut fx, _) = Fixture::new(false);
+    fx.lockfile = fx.source_root.join("does-not-exist.lock");
+    let err = install_app_deps(&fx.spec()).expect_err("missing lockfile");
+    assert!(
+        matches!(err, InstallError::LockfileMissing(_)),
+        "got: {err:?}"
+    );
+}
+
+#[test]
+fn missing_source_root_returns_typed_error() {
+    let (mut fx, _) = Fixture::new(false);
+    fx.source_root = fx.tmp.path().join("no-such-project");
+    let err = install_app_deps(&fx.spec()).expect_err("missing source_root");
+    assert!(
+        matches!(err, InstallError::SourceRootMissing(_)),
+        "got: {err:?}"
+    );
+}
+
+#[test]
+fn override_takes_precedence_over_env() {
+    // `cache_root_override` is the canonical knob; assert it short-
+    // circuits before `mvm_deps_volumes_dir()` is consulted.
+    let p = PathBuf::from("/tmp/precedence-fixture");
+    assert_eq!(resolve_cache_root(Some(&p)), p);
+}


### PR DESCRIPTION
## Summary

First slice of Plan 73 Followup B — the host-side orchestrator for ADR-047's application-dependency install pipeline. Lands the typed surface (`InstallSpec` / `InstallResult` / `InstallError`), the cache layout, and end-to-end integration tests against hand-authored sealed-volume fixtures. The builder-VM dispatch is deliberately left as the `BuilderVmNotWired` cutover seam for slice B.2.

## Scope (what landed)

- **Orchestrator** (`crates/mvm-build/src/app_deps.rs`)
  - `install_app_deps(&InstallSpec) -> Result<InstallResult, InstallError>` — hashes the lockfile, derives a stable `lockfile_hash` (sha256 mixed with language + gate tokens so ecosystem and `--dev`/`--prod` can't alias), probes the cache, and on hit re-verifies via `mvm_sdk::compile::deps_audit::verify_sealed_volume`.
  - Typed error enum covering missing inputs, IO failures, cache-verify tamper detection, index/seal hash disagreement, and the explicit `BuilderVmNotWired` slot.
- **Cache layout** — the deps-volumes root grows an `index/` subtree alongside the supervisor-readable `<volume_hash>/` directories. The orchestrator reuses `mvm_core::config::mvm_deps_volumes_dir` (and therefore `MVM_DEPS_VOLUMES_DIR`) — same resolution Followup A's admission verifier uses, no duplicate logic.
- **Integration tests** (`crates/mvm-build/tests/app_deps_orchestrator.rs`) — 8 end-to-end tests against `seal_volume`-built fixtures: cache hit, cache miss, tampered `cve.json`, index/seal disagreement, lockfile-hash determinism, missing lockfile / source-root errors, override-precedence. Plus 4 unit tests for the pure helpers.

## Non-goals (deferred to B.2 / B.3)

- **No builder VM invocation.** `LibkrunBuilderVm::run_build` is untouched; cache miss returns `InstallError::BuilderVmNotWired`. This is the cutover seam slice B.2 will replace with a real VM dispatch.
- **No `mvmctl` / `mvmd` wiring.** `mvmctl build` / `up` / etc. don't yet call `install_app_deps`. CLI wiring (`mvmctl deps inspect`, `mvmctl deps audit`, `mvmctl build --deps`) lands with slice B.3.

Cross-platform — pure host I/O (sha256 streaming + filesystem reads); honors CLAUDE.md's "Host Nix is never used by mvmctl" invariant.

## Test plan

- [x] `cargo fmt --check` clean
- [x] `cargo clippy --workspace --all-targets -- -D warnings` clean
- [x] `cargo run -p xtask -- check-no-display-on-secret-types` clean
- [x] `cargo test -p mvm-build` — new module + integration suite green
- [x] `cargo test --workspace` — modulo the pre-existing flaky `mvm-guest::lifecycle_hooks::run_shutdown_hook_succeeds_for_fast_script` timing test (passes in isolation; unrelated to this change)

🤖 Generated with [Claude Code](https://claude.com/claude-code)