### PR TITLE
refactor(mvm-build): drop dead host-Nix probe

### DIFF
--- a/crates/mvm-build/src/builder_vm.rs
+++ b/crates/mvm-build/src/builder_vm.rs
@@ -194,17 +194,17 @@ impl ArtifactSidecar {
 /// lets call sites be wired against the future API and lets tests
 /// cover the error path.
 pub trait BuilderVm {
-    /// Step 1 (ADR-013): probe whether the local environment is
-    /// already capable of a Linux build (host Nix + nix-darwin
-    /// linux-builder, or Linux + host Nix). When `true`, the caller
-    /// should fall through to `HostBackend` and skip the builder VM.
-    fn host_can_build(&self) -> Result<bool, BuilderVmError>;
-
     /// Steps 2-5 (ADR-013): pull the OCI image (if not cached),
     /// spawn a sandbox with the given mounts, run `nix build` for
     /// the job, and extract artifacts to `mounts.artifact_out`.
     /// Idempotent w.r.t. the image cache; not idempotent w.r.t. the
     /// artifact dir (caller cleans up).
+    ///
+    /// There is no host-Nix fallback. The CLAUDE.md invariant —
+    /// *"Host Nix is never used by mvmctl, even when present"* —
+    /// rules out a `host_can_build`-style probe: every Nix evaluation
+    /// must go through a VM we launched, so we always take the
+    /// builder-VM path.
     fn run_build(
         &self,
         job: &BuilderJob,
@@ -260,9 +260,6 @@ pub enum BuilderVmError {
 pub struct StubBuilderVm;
 
 impl BuilderVm for StubBuilderVm {
-    fn host_can_build(&self) -> Result<bool, BuilderVmError> {
-        Err(BuilderVmError::NotYetImplemented)
-    }
     fn run_build(
         &self,
         _job: &BuilderJob,
@@ -402,26 +399,8 @@ fn shell_quote_arg(input: &str) -> String {
     format!("'{}'", input.replace('\'', "'\\''"))
 }
 
-/// Probe whether the host already has Nix available. True covers
-/// both:
-///   - Linux with host Nix (`nix` on PATH; `nix build` runs natively).
-///   - macOS with nix-darwin's `linux-builder` configured (`nix` on
-///     PATH; nix transparently routes Linux derivations to the
-///     configured SSH-backed Linux VM).
-///
-/// Returns false on macOS Intel / pre-26 / no-KVM-Linux without
-/// host Nix — the case the microsandbox builder serves.
-#[cfg(feature = "contributor-bootstrap")]
-fn host_nix_available() -> bool {
-    which::which("nix").is_ok()
-}
-
 #[cfg(feature = "contributor-bootstrap")]
 impl BuilderVm for MicrosandboxBuilderVm {
-    fn host_can_build(&self) -> Result<bool, BuilderVmError> {
-        Ok(host_nix_available())
-    }
-
     fn run_build(
         &self,
         job: &BuilderJob,
@@ -801,20 +780,6 @@ mod tests {
     }
 
     #[test]
-    fn stub_returns_not_yet_implemented_for_host_can_build() {
-        let stub = StubBuilderVm;
-        let err = stub.host_can_build().expect_err("stub returns err");
-        assert!(
-            matches!(err, BuilderVmError::NotYetImplemented),
-            "got {err:?}"
-        );
-        assert!(
-            err.to_string().contains("ADR-013"),
-            "error should point at ADR: {err}"
-        );
-    }
-
-    #[test]
     fn stub_returns_not_yet_implemented_for_run_build() {
         let stub = StubBuilderVm;
         let job = BuilderJob {
@@ -965,18 +930,6 @@ mod tests {
             "got {err:?}"
         );
         assert!(err.to_string().contains("does not exist"), "msg: {err}");
-    }
-
-    #[cfg(feature = "contributor-bootstrap")]
-    #[test]
-    fn host_can_build_is_a_pure_pathfn() {
-        // Result depends on whether the test runner has `nix` on
-        // PATH — both outcomes are valid. The test asserts the
-        // function returns Ok rather than erroring, since the impl
-        // shouldn't ever return Err here (only the absence vs.
-        // presence of nix matters).
-        let b = MicrosandboxBuilderVm::default();
-        assert!(b.host_can_build().is_ok());
     }
 
     #[test]

--- a/crates/mvm-build/src/libkrun_builder.rs
+++ b/crates/mvm-build/src/libkrun_builder.rs
@@ -217,18 +217,6 @@ fn ensure_utf8_path(p: &std::path::Path, field: &str) -> Result<(), BuilderVmErr
 }
 
 impl BuilderVm for LibkrunBuilderVm {
-    fn host_can_build(&self) -> Result<bool, BuilderVmError> {
-        // libkrun never satisfies the "host can build Linux
-        // derivations directly" predicate — by definition we run
-        // the VM. Returning `false` makes the dispatch in
-        // `ensure_dev_image` fall through to `run_build` rather
-        // than short-circuiting to host Nix (forbidden anyway per
-        // CLAUDE.md §"Host Nix is never used by mvmctl"). When
-        // libkrun isn't installed the call site can still consult
-        // `mvm_libkrun::is_available()` for a clearer error.
-        Ok(false)
-    }
-
     fn run_build(
         &self,
         job: &BuilderJob,
@@ -750,13 +738,6 @@ mod tests {
         assert_eq!(vm.vcpus, 4);
         assert_eq!(vm.memory_mib, 4096);
         assert_eq!(vm.nix_store_mib, 65536);
-    }
-
-    #[test]
-    fn host_can_build_always_false() {
-        // libkrun never short-circuits to host Nix.
-        let vm = LibkrunBuilderVm::default();
-        assert!(!vm.host_can_build().unwrap());
     }
 
     #[test]


### PR DESCRIPTION
## Summary

- Removes `host_can_build()` from the `BuilderVm` trait and its three implementations (`StubBuilderVm`, `MicrosandboxBuilderVm`, `LibkrunBuilderVm`).
- Removes `host_nix_available()` — a `which::which(\"nix\").is_ok()` PATH probe that directly violated CLAUDE.md's "Host Nix is never used by mvmctl, even when present" invariant.
- Replaces the trait-level doc paragraph that introduced the probe with a comment citing the invariant, so future contributors don't add it back.

## Why

`host_can_build()` had no production caller in the tree: `ensure_dev_image`, `build_image_via_microsandbox`, the xtask, and the libkrun builder all skip it and call `run_build` directly. `LibkrunBuilderVm`'s impl was already a hard-coded `Ok(false)` with a comment citing the same invariant. The trait method existed only to be exercised by three unit tests (also removed).

`which` stays in `mvm-build`'s deps — `libkrun_builder.rs` still uses it to locate `mvm-libkrun-supervisor` on PATH (a runtime supervisor binary, separate concern).

## Test plan

- [x] `cargo build --workspace` — clean
- [x] `cargo clippy --workspace --all-targets -- -D warnings` — clean
- [x] `cargo test -p mvm-build` (default features + `contributor-bootstrap`) — 5/5 pass
- [x] `cargo test --workspace -- --skip mk_guest_eval_assertions_all_pass_when_nix_available` — all suites pass on a clean run (mvm-guest passes 215/215 in isolation; a flake under parallel test load on a memory-pressured host produced four timing-flakes in `lifecycle_hooks` + `entrypoint`, none in code this PR touches)

🤖 Generated with [Claude Code](https://claude.com/claude-code)