### PR TITLE
Plan 73 Followup B.2.0 — generalize BuilderJob/BuilderArtifacts for install jobs (plumbing prereq for B.2)

### DIFF
--- a/crates/mvm-build/src/builder_vm.rs
+++ b/crates/mvm-build/src/builder_vm.rs
@@ -71,44 +71,104 @@ pub struct BuilderMounts {
     pub artifact_out: PathBuf,
 }
 
-/// What the builder is asked to produce. The flake attribute path is
-/// system-specific; the bootstrap maps host architecture to the
-/// matching Linux system (`aarch64-linux` on Apple Silicon,
-/// `x86_64-linux` on Intel/AMD).
+/// What the builder is asked to produce.
+///
+/// Plan 73 Followup B.2.0 generalised this from a single nix-build
+/// shape into an enum so the same trait can dispatch both the
+/// existing flake builds (`Flake`) and the application-dependency
+/// install pipeline (`Install`) that Followup B.2 will wire. Each
+/// variant pairs 1:1 with a [`BuilderArtifacts`] variant — see the
+/// per-variant docs there for the expected outputs.
+///
+/// This is plumbing only: the `Install` variant is reserved here so
+/// B.2 can land behavior changes against a stable shape, and today
+/// every backend errors with [`BuilderVmError::NotYetImplemented`]
+/// when it sees an `Install` job.
 #[derive(Debug, Clone, PartialEq, Eq)]
-pub struct BuilderJob {
-    /// Flake reference (e.g. `git+file:///work?dir=.`, `.#default`,
-    /// `path:./.`).
-    pub flake_ref: String,
-    /// Attribute path under the flake (e.g.
-    /// `packages.x86_64-linux.tenant-worker`). Resolved by callers
-    /// before invoking the builder.
-    pub attr_path: String,
+pub enum BuilderJob {
+    /// Build a Nix flake attribute. The flake attribute path is
+    /// system-specific; callers map host architecture to the
+    /// matching Linux system (`aarch64-linux` on Apple Silicon,
+    /// `x86_64-linux` on Intel/AMD).
+    Flake {
+        /// Flake reference (e.g. `git+file:///work?dir=.`, `.#default`,
+        /// `path:./.`).
+        flake_ref: String,
+        /// Attribute path under the flake (e.g.
+        /// `packages.x86_64-linux.tenant-worker`). Resolved by callers
+        /// before invoking the builder.
+        attr_path: String,
+    },
+
+    /// Application-dependency install pipeline (ADR-047, Followup
+    /// B.2). The builder VM reads a serialised install spec from
+    /// `spec_path` (lockfile + source-root + ecosystem + gate),
+    /// runs the corresponding package manager (`uv pip install
+    /// --no-deps`, `pnpm install --frozen-lockfile`, …) inside the
+    /// VM, seals the resulting volume with SBOM + fetch log + CVE +
+    /// attestations, and emits a `result.json` next to the volume.
+    ///
+    /// **Today every backend errors with
+    /// [`BuilderVmError::NotYetImplemented`] for this variant.**
+    /// Plan 73 Followup B.2 wires the libkrun backend; the
+    /// microsandbox backend never gets this variant.
+    Install {
+        /// Absolute host path to the install-spec JSON the builder
+        /// VM reads at start-up. Followup B.2 defines the shape;
+        /// today the orchestrator does not produce one.
+        spec_path: PathBuf,
+    },
 }
 
-/// Result of a successful build. Mirrors the host-backend's
-/// `BackendBuildResult` shape so the runtime path can consume both
-/// transparently.
+/// Result of a successful build. The variant returned matches the
+/// [`BuilderJob`] variant the caller passed: a `Flake` job yields
+/// [`BuilderArtifacts::Image`]; an `Install` job yields
+/// [`BuilderArtifacts::InstallVolume`].
+///
+/// Mirrors the host-backend's `BackendBuildResult` shape so the
+/// runtime path can consume both transparently.
 #[derive(Debug, Clone, PartialEq, Eq)]
-pub struct BuilderArtifacts {
-    /// Absolute host path to the extracted rootfs (typically
-    /// `~/.mvm/dev/builds/<rev>/rootfs.ext4`).
-    pub rootfs_path: PathBuf,
-    /// Optional kernel image path (some flakes emit one; verity
-    /// initramfs is paired with the kernel).
-    pub kernel_path: Option<PathBuf>,
-    /// Nix store revision hash (the leading `<hash>` segment of the
-    /// derivation's output store path). Used as the artifact dir
-    /// name and for cache lookups.
-    pub revision_hash: String,
-    /// `flake.lock` SHA-256, recorded for cache tracking.
-    pub lock_hash: Option<String>,
-    /// `passthru.mvm.accessible` — wires through to
-    /// `runtime_meta.accessible`, populating the W6.2 console gate.
-    /// `None` means the flake didn't surface the field; callers
-    /// default to `true` for backward compatibility (W6.2's same
-    /// default).
-    pub accessible: Option<bool>,
+pub enum BuilderArtifacts {
+    /// Output of a [`BuilderJob::Flake`] build — a kernel +
+    /// rootfs pair ready for boot, plus revision metadata.
+    Image {
+        /// Absolute host path to the extracted rootfs (typically
+        /// `~/.mvm/dev/builds/<rev>/rootfs.ext4`).
+        rootfs_path: PathBuf,
+        /// Optional kernel image path (some flakes emit one; verity
+        /// initramfs is paired with the kernel).
+        kernel_path: Option<PathBuf>,
+        /// Nix store revision hash (the leading `<hash>` segment of
+        /// the derivation's output store path). Used as the artifact
+        /// dir name and for cache lookups.
+        revision_hash: String,
+        /// `flake.lock` SHA-256, recorded for cache tracking.
+        lock_hash: Option<String>,
+        /// `passthru.mvm.accessible` — wires through to
+        /// `runtime_meta.accessible`, populating the W6.2 console
+        /// gate. `None` means the flake didn't surface the field;
+        /// callers default to `true` for backward compatibility
+        /// (W6.2's same default).
+        accessible: Option<bool>,
+    },
+
+    /// Output of a [`BuilderJob::Install`] run — a sealed deps
+    /// volume on the host filesystem plus a structured result
+    /// document. Followup B.2 will fill this in; today no backend
+    /// constructs this variant.
+    InstallVolume {
+        /// Directory the builder VM sealed the application-deps
+        /// volume into (content + SBOM + fetch log + CVE scan +
+        /// attestations + meta). Caller hashes this with
+        /// `mvm_sdk::compile::deps_audit::verify_sealed_volume` to
+        /// derive the canonical `volume_hash`.
+        volume_dir: PathBuf,
+        /// JSON sidecar emitted by `mvm-builder-init` next to the
+        /// volume describing the install outcome (exit code,
+        /// installer stderr tail, timings). Shape pinned by
+        /// Followup B.2.
+        result_json_path: PathBuf,
+    },
 }
 
 /// Filename for the sidecar manifest written next to a built
@@ -369,11 +429,15 @@ fn block_on<F: std::future::Future>(fut: F) -> F::Output {
     rt.block_on(fut)
 }
 
-/// Unique-per-build sandbox name derived from a flake reference +
-/// attr path + a timestamp. Doesn't need to be cryptographically
-/// random — microsandbox uses it as a handle for `Sandbox::get` etc.,
+/// Unique-per-build sandbox name derived from the job + a
+/// timestamp. Doesn't need to be cryptographically random —
+/// microsandbox uses it as a handle for `Sandbox::get` etc.,
 /// and the sandbox is torn down at the end of `run_build` so name
 /// collisions only matter for concurrent invocations.
+///
+/// Only the [`BuilderJob::Flake`] variant ever reaches this helper
+/// because microsandbox refuses install jobs upstream; the match
+/// arm for `Install` is wired for compile completeness.
 #[cfg(feature = "contributor-bootstrap")]
 fn sandbox_name(job: &BuilderJob) -> String {
     use std::time::{SystemTime, UNIX_EPOCH};
@@ -383,8 +447,18 @@ fn sandbox_name(job: &BuilderJob) -> String {
         .unwrap_or(0);
     let mut h = std::collections::hash_map::DefaultHasher::new();
     use std::hash::{Hash, Hasher};
-    job.flake_ref.hash(&mut h);
-    job.attr_path.hash(&mut h);
+    match job {
+        BuilderJob::Flake {
+            flake_ref,
+            attr_path,
+        } => {
+            flake_ref.hash(&mut h);
+            attr_path.hash(&mut h);
+        }
+        BuilderJob::Install { spec_path } => {
+            spec_path.hash(&mut h);
+        }
+    }
     format!("mvm-builder-{:x}-{}", h.finish(), stamp)
 }
 
@@ -406,6 +480,19 @@ impl BuilderVm for MicrosandboxBuilderVm {
         job: &BuilderJob,
         mounts: &BuilderMounts,
     ) -> Result<BuilderArtifacts, BuilderVmError> {
+        // Microsandbox is contributor-bootstrap only and runs the
+        // nix-build path. The Install variant is reserved for Plan
+        // 73 Followup B.2 on the libkrun backend; surface the
+        // mismatch with NotYetImplemented rather than silently
+        // falling through.
+        let (flake_ref, attr_path) = match job {
+            BuilderJob::Flake {
+                flake_ref,
+                attr_path,
+            } => (flake_ref.clone(), attr_path.clone()),
+            BuilderJob::Install { .. } => return Err(BuilderVmError::NotYetImplemented),
+        };
+
         // Validate caller-supplied paths early; microsandbox will
         // also reject these but with less useful messages.
         if !mounts.flake_src.exists() {
@@ -429,8 +516,8 @@ impl BuilderVm for MicrosandboxBuilderVm {
             flake_src: mounts.flake_src.clone(),
             host_nix_store: mounts.host_nix_store.clone(),
             artifact_out: mounts.artifact_out.clone(),
-            flake_ref: job.flake_ref.clone(),
-            attr_path: job.attr_path.clone(),
+            flake_ref,
+            attr_path,
         };
 
         block_on(async move { run_build_async(params).await })
@@ -647,7 +734,7 @@ chmod -R u+w "$out"
         if p.exists() { Some(p) } else { None }
     };
 
-    Ok(BuilderArtifacts {
+    Ok(BuilderArtifacts::Image {
         rootfs_path,
         kernel_path,
         revision_hash,
@@ -782,9 +869,27 @@ mod tests {
     #[test]
     fn stub_returns_not_yet_implemented_for_run_build() {
         let stub = StubBuilderVm;
-        let job = BuilderJob {
+        let job = BuilderJob::Flake {
             flake_ref: ".".to_string(),
             attr_path: "packages.x86_64-linux.default".to_string(),
+        };
+        let mounts = BuilderMounts {
+            flake_src: PathBuf::from("/tmp/flake"),
+            host_nix_store: None,
+            artifact_out: PathBuf::from("/tmp/out"),
+        };
+        let err = stub.run_build(&job, &mounts).expect_err("stub returns err");
+        assert!(matches!(err, BuilderVmError::NotYetImplemented));
+    }
+
+    #[test]
+    fn stub_returns_not_yet_implemented_for_install_job() {
+        // The B.2.0 plumbing reserves the Install variant; until B.2
+        // wires behavior, every backend (including the stub) must
+        // surface NotYetImplemented for it.
+        let stub = StubBuilderVm;
+        let job = BuilderJob::Install {
+            spec_path: PathBuf::from("/tmp/spec.json"),
         };
         let mounts = BuilderMounts {
             flake_src: PathBuf::from("/tmp/flake"),
@@ -868,7 +973,7 @@ mod tests {
         // Same flake+attr produces the same hash segment; only the
         // timestamp varies. Lets us assert the prefix without
         // hard-coding the full name.
-        let job = BuilderJob {
+        let job = BuilderJob::Flake {
             flake_ref: "git+file:///work".to_string(),
             attr_path: "packages.x86_64-linux.default".to_string(),
         };
@@ -913,7 +1018,7 @@ mod tests {
         // nonexistent flake src; we expect a clear error before
         // anything heavy fires.
         let b = MicrosandboxBuilderVm::default();
-        let job = BuilderJob {
+        let job = BuilderJob::Flake {
             flake_ref: ".".to_string(),
             attr_path: "packages.x86_64-linux.default".to_string(),
         };
@@ -930,6 +1035,30 @@ mod tests {
             "got {err:?}"
         );
         assert!(err.to_string().contains("does not exist"), "msg: {err}");
+    }
+
+    #[cfg(feature = "contributor-bootstrap")]
+    #[test]
+    fn microsandbox_rejects_install_job_variant() {
+        // The microsandbox backend doesn't get install-pipeline
+        // support (Plan 73 Followup B.2 wires libkrun only). Any
+        // Install job must fail fast with NotYetImplemented.
+        let b = MicrosandboxBuilderVm::default();
+        let job = BuilderJob::Install {
+            spec_path: PathBuf::from("/tmp/spec.json"),
+        };
+        let mounts = BuilderMounts {
+            flake_src: PathBuf::from("/tmp"),
+            host_nix_store: None,
+            artifact_out: PathBuf::from("/tmp/mvm-builder-install-test-out"),
+        };
+        let err = b
+            .run_build(&job, &mounts)
+            .expect_err("install variant must error on microsandbox");
+        assert!(
+            matches!(err, BuilderVmError::NotYetImplemented),
+            "got {err:?}"
+        );
     }
 
     #[test]

--- a/crates/mvm-build/src/libkrun_builder.rs
+++ b/crates/mvm-build/src/libkrun_builder.rs
@@ -186,21 +186,42 @@ impl LibkrunBuilderVm {
         Ok(())
     }
 
-    /// Validate the job description. Both fields must be non-empty
-    /// strings; `flake_ref` may include a `path:` or `git+` prefix
-    /// but the prefix-less form is also accepted (libkrun runs the
-    /// command verbatim inside the builder VM, where the file
-    /// system is paths libkrun mounted).
+    /// Validate the job description. For [`BuilderJob::Flake`] both
+    /// fields must be non-empty strings (`flake_ref` may include a
+    /// `path:` or `git+` prefix but the prefix-less form is also
+    /// accepted — libkrun runs the command verbatim inside the
+    /// builder VM). For [`BuilderJob::Install`] the spec path must
+    /// exist on the host; B.2 will fill in the rest of the
+    /// install-pipeline validation against the parsed spec.
     pub(crate) fn validate_job(&self, job: &BuilderJob) -> Result<(), BuilderVmError> {
-        if job.flake_ref.trim().is_empty() {
-            return Err(BuilderVmError::NixBuildFailed(
-                "BuilderJob.flake_ref is empty".to_string(),
-            ));
-        }
-        if job.attr_path.trim().is_empty() {
-            return Err(BuilderVmError::NixBuildFailed(
-                "BuilderJob.attr_path is empty".to_string(),
-            ));
+        match job {
+            BuilderJob::Flake {
+                flake_ref,
+                attr_path,
+            } => {
+                if flake_ref.trim().is_empty() {
+                    return Err(BuilderVmError::NixBuildFailed(
+                        "BuilderJob.flake_ref is empty".to_string(),
+                    ));
+                }
+                if attr_path.trim().is_empty() {
+                    return Err(BuilderVmError::NixBuildFailed(
+                        "BuilderJob.attr_path is empty".to_string(),
+                    ));
+                }
+            }
+            BuilderJob::Install { spec_path } => {
+                // The install pipeline ships in Plan 73 Followup B.2;
+                // validate the file exists so a future caller's
+                // typo surfaces here rather than as an opaque
+                // NotYetImplemented mid-pipeline.
+                if !spec_path.is_file() {
+                    return Err(BuilderVmError::ExtractionFailed(format!(
+                        "BuilderJob::Install spec_path does not exist or is not a file: {}",
+                        spec_path.display()
+                    )));
+                }
+            }
         }
         Ok(())
     }
@@ -226,6 +247,15 @@ impl BuilderVm for LibkrunBuilderVm {
         //    errors than failing inside the libkrun FFI.
         self.validate_mounts(mounts)?;
         self.validate_job(job)?;
+
+        // Plan 73 Followup B.2.0 plumbing: the Install variant is
+        // a typed seam for the application-deps install pipeline
+        // (Followup B.2). The flake-build path below is unchanged;
+        // the install path lands in B.2.
+        match job {
+            BuilderJob::Flake { .. } => {}
+            BuilderJob::Install { .. } => return Err(BuilderVmError::NotYetImplemented),
+        }
 
         // 2. Refuse to proceed on a host without libkrun. The
         //    `backends-builder-vm-libkrun` feature being compiled
@@ -338,7 +368,7 @@ impl BuilderVm for LibkrunBuilderVm {
             None
         };
 
-        Ok(BuilderArtifacts {
+        Ok(BuilderArtifacts::Image {
             rootfs_path,
             kernel_path,
             // The Nix store path hash isn't trivially recoverable
@@ -514,7 +544,21 @@ fn unique_job_id() -> String {
 /// `/bin/sh -eu` and is responsible for invoking `nix build`
 /// against the user's flake and dropping `vmlinux` +
 /// `rootfs.ext4` into `/out`.
+///
+/// Plan 73 Followup B.2.0 added the [`BuilderJob`] dispatch
+/// here. The `Flake` arm renders today's `nix build` script;
+/// the `Install` arm errors with [`BuilderVmError::NotYetImplemented`]
+/// — Followup B.2 fills it in by emitting the per-ecosystem
+/// install script + result.json contract.
 fn stage_job_dir(job_dir: &Path, job: &BuilderJob) -> Result<(), BuilderVmError> {
+    let (flake_ref, attr_path) = match job {
+        BuilderJob::Flake {
+            flake_ref,
+            attr_path,
+        } => (flake_ref.as_str(), attr_path.as_str()),
+        BuilderJob::Install { .. } => return Err(BuilderVmError::NotYetImplemented),
+    };
+
     std::fs::create_dir_all(job_dir).map_err(|e| {
         BuilderVmError::ExtractionFailed(format!("creating job dir {}: {e}", job_dir.display()))
     })?;
@@ -573,8 +617,8 @@ fi
 chmod 0644 /out/rootfs.ext4 2>/dev/null || true
 [ -f /out/vmlinux ] && chmod 0644 /out/vmlinux 2>/dev/null || true
 "#,
-        flake_ref = shell_single_quote_escape(&job.flake_ref),
-        attr_path = shell_single_quote_escape(&job.attr_path),
+        flake_ref = shell_single_quote_escape(flake_ref),
+        attr_path = shell_single_quote_escape(attr_path),
     );
 
     let cmd_path = job_dir.join("cmd.sh");
@@ -726,7 +770,7 @@ mod tests {
     }
 
     fn ok_job() -> BuilderJob {
-        BuilderJob {
+        BuilderJob::Flake {
             flake_ref: "path:/work".to_string(),
             attr_path: "packages.x86_64-linux.default".to_string(),
         }
@@ -813,7 +857,7 @@ mod tests {
 
     #[test]
     fn validate_job_rejects_empty_flake_ref() {
-        let job = BuilderJob {
+        let job = BuilderJob::Flake {
             flake_ref: "".to_string(),
             attr_path: "packages.x86_64-linux.default".to_string(),
         };
@@ -823,12 +867,77 @@ mod tests {
 
     #[test]
     fn validate_job_rejects_whitespace_only_attr_path() {
-        let job = BuilderJob {
+        let job = BuilderJob::Flake {
             flake_ref: "path:/work".to_string(),
             attr_path: "   ".to_string(),
         };
         let err = LibkrunBuilderVm::default().validate_job(&job).unwrap_err();
         assert!(format!("{err}").contains("attr_path"));
+    }
+
+    #[test]
+    fn validate_job_rejects_install_with_missing_spec() {
+        // The Install variant validates that spec_path actually
+        // exists — Followup B.2 will read it inside the VM, so the
+        // host needs the file present before dispatch.
+        let job = BuilderJob::Install {
+            spec_path: PathBuf::from("/definitely/does/not/exist.json"),
+        };
+        let err = LibkrunBuilderVm::default().validate_job(&job).unwrap_err();
+        assert!(
+            matches!(err, BuilderVmError::ExtractionFailed(_)),
+            "got {err:?}"
+        );
+        assert!(
+            format!("{err}").contains("spec_path"),
+            "expected spec_path in error: {err}"
+        );
+    }
+
+    #[test]
+    fn validate_job_accepts_install_with_existing_spec() {
+        // Smoke-test the happy path of Install validation. We
+        // don't construct a real spec — the parsing arrives in
+        // B.2. We only check that a real file passes.
+        let scratch = TempDir::new().unwrap();
+        let spec_path = scratch.path().join("spec.json");
+        std::fs::write(&spec_path, b"{}").unwrap();
+        let job = BuilderJob::Install { spec_path };
+        LibkrunBuilderVm::default().validate_job(&job).unwrap();
+    }
+
+    #[test]
+    fn run_build_rejects_install_variant_with_not_yet_implemented() {
+        // Plumbing-only: the Install variant is a typed seam for
+        // Followup B.2. Until then libkrun must surface
+        // NotYetImplemented after passing input validation rather
+        // than proceeding into the flake-build pipeline.
+        let scratch = TempDir::new().unwrap();
+        let spec_path = scratch.path().join("spec.json");
+        std::fs::write(&spec_path, b"{}").unwrap();
+        let mounts = ok_mounts(&scratch);
+        let err = LibkrunBuilderVm::default()
+            .run_build(&BuilderJob::Install { spec_path }, &mounts)
+            .unwrap_err();
+        assert!(
+            matches!(err, BuilderVmError::NotYetImplemented),
+            "got {err:?}"
+        );
+    }
+
+    #[test]
+    fn stage_job_dir_rejects_install_variant() {
+        // The stager only knows about the Flake shape today. The
+        // Install seam returns NotYetImplemented so B.2 can swap
+        // in the per-ecosystem install script without touching
+        // call sites.
+        let scratch = TempDir::new().unwrap();
+        let job_dir = scratch.path().join("job-1");
+        let spec_path = scratch.path().join("spec.json");
+        std::fs::write(&spec_path, b"{}").unwrap();
+        let err =
+            stage_job_dir(&job_dir, &BuilderJob::Install { spec_path }).expect_err("install path");
+        assert!(matches!(err, BuilderVmError::NotYetImplemented));
     }
 
     #[test]
@@ -888,7 +997,7 @@ mod tests {
     fn stage_job_dir_writes_cmd_sh_with_escaped_inputs() {
         let scratch = TempDir::new().unwrap();
         let job_dir = scratch.path().join("job-1");
-        let job = BuilderJob {
+        let job = BuilderJob::Flake {
             flake_ref: "path:/work/nix/images/foo".to_string(),
             attr_path: "packages.x86_64-linux.default".to_string(),
         };

--- a/crates/mvm-build/src/pipeline/dev_build.rs
+++ b/crates/mvm-build/src/pipeline/dev_build.rs
@@ -614,7 +614,7 @@ fn dev_build_via_microsandbox(
         flake_ref.to_string()
     });
 
-    let job = BuilderJob {
+    let job = BuilderJob::Flake {
         // Inside the sandbox, the flake source is bind-mounted at
         // `/work` — the build command references that path, not
         // the host path the user passed in.
@@ -653,14 +653,27 @@ fn dev_build_via_microsandbox(
         .run_build(&job, &mounts)
         .map_err(|e| anyhow::anyhow!("microsandbox builder VM: {e}"))?;
 
+    // Plan 73 Followup B.2.0: BuilderArtifacts is now an enum. The
+    // microsandbox / libkrun nix-build paths both return `Image`;
+    // surface any future variant slipping through as an error
+    // rather than a silent path mismatch.
+    let revision_hash = match artifacts {
+        crate::builder_vm::BuilderArtifacts::Image { revision_hash, .. } => revision_hash,
+        crate::builder_vm::BuilderArtifacts::InstallVolume { .. } => {
+            anyhow::bail!(
+                "microsandbox builder returned BuilderArtifacts::InstallVolume \
+                 for a Flake job — unreachable until Plan 73 Followup B.2"
+            );
+        }
+    };
+
     // Move staging dir to its final hashed location. If a parallel
     // build raced us to the same revision (cache hit), discard
     // ours.
-    let final_dir = dev_build_dir(&artifacts.revision_hash);
+    let final_dir = dev_build_dir(&revision_hash);
     if std::path::Path::new(&final_dir).exists() {
         env.log_info(&format!(
-            "Cache hit on rev {}; discarding staged build.",
-            artifacts.revision_hash
+            "Cache hit on rev {revision_hash}; discarding staged build."
         ));
         let _ = std::fs::remove_dir_all(&staging);
     } else if let Err(e) = std::fs::rename(&staging, &final_dir) {
@@ -697,7 +710,7 @@ fn dev_build_via_microsandbox(
         vmlinux_path,
         initrd_path,
         rootfs_path,
-        revision_hash: artifacts.revision_hash,
+        revision_hash,
         cached: false,
         runner_dir,
         artifact_sizes,

--- a/crates/mvm-cli/src/commands/env/apple_container.rs
+++ b/crates/mvm-cli/src/commands/env/apple_container.rs
@@ -1798,7 +1798,7 @@ fn build_image_via_microsandbox(flake_dir: &str, out_dir: &str) -> Result<(Strin
         }
     };
 
-    let job = BuilderJob {
+    let job = BuilderJob::Flake {
         flake_ref: guest_flake_ref,
         attr_path: format!("packages.{}.default", host_system_linux()),
     };
@@ -2157,7 +2157,7 @@ fn build_image_via_libkrun(out_dir: &str) -> Result<(String, String)> {
     // the git fetcher, which would discover `/work/.git` and trip on
     // worktree files whose `gitdir:` redirects point outside the
     // mount).
-    let job = BuilderJob {
+    let job = BuilderJob::Flake {
         flake_ref: "path:/work/nix/images/builder".to_string(),
         attr_path: format!("packages.{}.default", host_system_linux()),
     };

--- a/xtask/src/build_dev_image.rs
+++ b/xtask/src/build_dev_image.rs
@@ -146,7 +146,7 @@ fn build_and_install(workspace: &Path, arch: &str) -> Result<()> {
     // `mvm-workspace = path:..` to /work/, where `Cargo.lock` lives.
     let artifact_out =
         tempfile::tempdir().context("creating tempdir for builder artifact extraction")?;
-    let job = BuilderJob {
+    let job = BuilderJob::Flake {
         // Bare path — nix auto-detects /work as a git repo (the host
         // workspace's `.git` is in the bind-mount) and uses the
         // git+file fetcher. That gives us two things `path:` doesn't:
@@ -186,19 +186,39 @@ fn build_and_install(workspace: &Path, arch: &str) -> Result<()> {
         .run_build(&job, &mounts)
         .map_err(|e| anyhow::anyhow!("microsandbox builder failed: {e}"))?;
 
-    let src_kernel = artifacts.kernel_path.ok_or_else(|| {
-        anyhow::anyhow!(
-            "builder produced no vmlinux — the flake's \
-             packages.{arch}-linux.default output must include `vmlinux` \
-             in its $out directory"
-        )
-    })?;
-    if !artifacts.rootfs_path.is_file() {
-        anyhow::bail!(
-            "builder reported success but rootfs.ext4 is missing at {}",
-            artifacts.rootfs_path.display(),
-        );
-    }
+    // Plan 73 Followup B.2.0: BuilderArtifacts is now an enum. The
+    // xtask path always feeds a Flake job, so it always receives an
+    // Image. Surface a future variant as an error rather than a
+    // silent path mismatch.
+    let (src_kernel, src_rootfs) = match artifacts {
+        mvm_build::builder_vm::BuilderArtifacts::Image {
+            kernel_path,
+            rootfs_path,
+            ..
+        } => {
+            let kernel = kernel_path.ok_or_else(|| {
+                anyhow::anyhow!(
+                    "builder produced no vmlinux — the flake's \
+                     packages.{arch}-linux.default output must include `vmlinux` \
+                     in its $out directory"
+                )
+            })?;
+            if !rootfs_path.is_file() {
+                anyhow::bail!(
+                    "builder reported success but rootfs.ext4 is missing at {}",
+                    rootfs_path.display(),
+                );
+            }
+            (kernel, rootfs_path)
+        }
+        mvm_build::builder_vm::BuilderArtifacts::InstallVolume { .. } => {
+            anyhow::bail!(
+                "xtask build-dev-image expected a Flake build but the \
+                 builder returned an InstallVolume — unreachable until \
+                 Plan 73 Followup B.2"
+            );
+        }
+    };
 
     let dest_dir = vendored_slot(workspace, arch);
     std::fs::create_dir_all(&dest_dir)
@@ -206,7 +226,7 @@ fn build_and_install(workspace: &Path, arch: &str) -> Result<()> {
     let dest_kernel = dest_dir.join("vmlinux");
     let dest_rootfs = dest_dir.join("rootfs.ext4");
     copy_with_mode(&src_kernel, &dest_kernel)?;
-    copy_with_mode(&artifacts.rootfs_path, &dest_rootfs)?;
+    copy_with_mode(&src_rootfs, &dest_rootfs)?;
     let checksums = format!(
         "{}  vmlinux\n{}  rootfs.ext4\n",
         sha256_hex(&dest_kernel)?,


### PR DESCRIPTION
## Summary

Plumbing-only refactor that generalises `BuilderJob` and
`BuilderArtifacts` so the `BuilderVm` trait can carry the
application-dependency install pipeline (Plan 73 Followup B.2)
alongside the existing nix-build shape. No behavior changes —
every existing nix-build code path is unchanged from the caller's
point of view. The new `Install` variants are typed seams that
error with `BuilderVmError::NotYetImplemented` until B.2 fills in
the install pipeline.

Investigated and confirmed by the previous B.2 agent: the old
struct-shaped `BuilderJob`/`BuilderArtifacts` were nix-build only,
and `LibkrunBuilderVm::run_build` hardcoded the nix-build flow in
`stage_job_dir` + post-run validation. B.2 needed the trait to
generalise first; that's this PR.

## Scope (plumbing only)

- `BuilderJob` → enum `{ Flake { flake_ref, attr_path }, Install { spec_path } }`
- `BuilderArtifacts` → enum `{ Image { ... existing fields }, InstallVolume { volume_dir, result_json_path } }`
- `LibkrunBuilderVm::run_build` matches on the variant; flake arm is
  byte-for-byte unchanged from prior behavior; install arm
  short-circuits with `NotYetImplemented` after `spec_path` is
  validated to exist.
- `stage_job_dir` matches on the variant; `Install` returns
  `NotYetImplemented` so B.2 can swap in the per-ecosystem install
  script without touching the call site.
- `MicrosandboxBuilderVm` refuses `Install` upstream — microsandbox
  is contributor-bootstrap only and never gets install support
  (matches the module docs).
- Updated call sites: `pipeline/dev_build.rs`, `xtask::build_dev_image`,
  `mvm-cli::commands::env::apple_container::{build_image_via_microsandbox,
  build_image_via_libkrun}`. Each consumer pattern-matches on
  `BuilderArtifacts::Image { .. }`.
- New tests cover the `Install`-variant rejection on every backend
  (`StubBuilderVm`, `MicrosandboxBuilderVm`, `LibkrunBuilderVm`)
  and the `spec_path` existence check in `validate_job`.

## What B.2 still needs to do

- Define the on-disk shape of the install spec JSON read at
  `spec_path`.
- Swap `BuilderVmError::NotYetImplemented` in `LibkrunBuilderVm::run_build`
  + `stage_job_dir` for the real install-pipeline dispatch: emit
  the per-ecosystem `cmd.sh`, run the package manager inside the
  guest, seal the resulting volume with SBOM + fetch log + CVE +
  attestations.
- Construct a `BuilderArtifacts::InstallVolume { volume_dir,
  result_json_path }` from the sealed volume.
- Replace `InstallError::BuilderVmNotWired` in
  `crates/mvm-build/src/app_deps.rs` with a `BuilderJob::Install`
  dispatch through `LibkrunBuilderVm`. (`app_deps.rs` is intentionally
  untouched in this PR — its seam is forward-compatible.)

## Test plan

- [x] `cargo fmt --check`
- [x] `cargo clippy --workspace --all-targets -- -D warnings`
- [x] `cargo run -p xtask -- check-no-display-on-secret-types`
- [x] `cargo test --workspace` — all pass
- [x] New tests for `Install`-variant rejection on every backend
- [x] New test that `validate_job` enforces `Install::spec_path` exists
- [x] Existing nix-build tests unchanged in shape and still pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)