### PR TITLE
feat(mvm-build,mvm-builder-init): plan 73 followup B.2 — builder-VM install pipeline

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4175,6 +4175,8 @@ name = "mvm-builder-init"
 version = "0.14.0"
 dependencies = [
  "nix 0.29.0",
+ "serde_json",
+ "tempfile",
 ]
 
 [[package]]

--- a/crates/mvm-build/src/app_deps.rs
+++ b/crates/mvm-build/src/app_deps.rs
@@ -14,12 +14,15 @@
 //!    returns `InstallResult { cache_hit: true, .. }` carrying the
 //!    canonical `volume_hash` + `manifest.sha256` the supervisor's
 //!    admission gate (Followup A) pins.
-//! 2. **Cache miss → builder-VM dispatch.** Slice B.1 reserves the
-//!    seam but does not yet drive the builder VM; instead it returns
-//!    [`InstallError::BuilderVmNotWired`]. Slice B.2 replaces this
-//!    branch with a call into
-//!    `crates/mvm-build/src/builder_vm.rs::LibkrunBuilderVm::run_build`
-//!    (with mounted lockfile + source root + writable volume out).
+//! 2. **Cache miss → builder-VM dispatch.** Slice B.2 calls
+//!    [`InstallDriver::run_install`] (blanket-impl'd for every
+//!    [`crate::builder_vm::BuilderVm`]) with the canonical mount
+//!    layout (source_root → `/work`, an in-cache scratch dir →
+//!    `/out`), then seals the resulting volume via
+//!    [`mvm_sdk::compile::deps_audit::seal_volume`] and renames it
+//!    into the cache. Callers that want to skip dispatch (testing
+//!    a cache-hit-only path) pass `driver = None` and get
+//!    [`InstallError::DriverNotProvided`] on miss.
 //!
 //! ### Why the cache key is a lockfile hash
 //!
@@ -56,17 +59,25 @@
 //! Per CLAUDE.md ("Host Nix is never used by mvmctl"): this module
 //! does not invoke host Nix and does not call out to any host
 //! installer. Every operation here is pure I/O — sha256 streaming,
-//! filesystem reads, `verify_sealed_volume`. The actual install runs
-//! inside the libkrun builder VM (slice B.2).
+//! filesystem reads, `verify_sealed_volume`, and a typed dispatch
+//! through [`InstallDriver`]. The actual install runs inside the
+//! libkrun builder VM (slice B.2), which the driver wraps.
 
+use std::collections::BTreeMap;
 use std::fs;
 use std::io::{self, Read};
 use std::path::{Path, PathBuf};
 
-use mvm_sdk::compile::deps_audit::{VolumeError, verify_sealed_volume};
+use chrono::Utc;
+use mvm_sdk::compile::deps_audit::{
+    FILE_CONTENT_DIR, FILE_CVE, FILE_FETCH_LOG, FILE_MANIFEST, FILE_SBOM, VolumeError, seal_volume,
+    verify_sealed_volume,
+};
 use serde::{Deserialize, Serialize};
 use sha2::{Digest, Sha256};
 use thiserror::Error;
+
+use crate::builder_vm::{BuilderArtifacts, BuilderJob, BuilderMounts, BuilderVm, BuilderVmError};
 
 /// Subdirectory under the deps-volumes root that holds the
 /// `lockfile_hash → volume_hash` index. Kept out of the supervisor's
@@ -206,32 +217,121 @@ pub enum InstallError {
         volume_hash: String,
     },
 
-    /// The cache miss path. Slice B.1's deliberate seam — slice B.2
-    /// replaces this branch with a builder-VM dispatch. The error
-    /// message points users at the manual cache-population path so
-    /// they can hand-author a sealed volume for testing the
-    /// downstream admission gates (Followup A) before B.2 lands.
+    /// Cache miss + no driver supplied. The caller asked for a
+    /// pure-cache lookup but the entry doesn't exist. Distinct
+    /// from a builder-VM failure because no VM was attempted —
+    /// this is the "test setup wants a cache hit only" path.
     #[error(
         "no cached deps volume for lockfile_hash {lockfile_hash} ({language}/{gate}); \
-         builder-VM install pipeline is not yet wired (Plan 73 Followup B.2). \
-         To unblock local testing, hand-author a sealed volume under \
-         `{cache_root}/<volume_hash>/` (use `mvm_sdk::compile::deps_audit::seal_volume`) \
-         and place a pointer at `{cache_root}/index/{lockfile_hash}`."
+         caller passed no InstallDriver so the builder-VM install pipeline was not attempted. \
+         Pass `Some(&LibkrunBuilderVm::default())` or hand-author a sealed volume."
     )]
-    BuilderVmNotWired {
+    DriverNotProvided {
         lockfile_hash: String,
         language: &'static str,
         gate: &'static str,
-        cache_root: PathBuf,
     },
+
+    /// The builder VM ran but its install pipeline failed before
+    /// emitting the sealed-volume artifacts. Wraps the underlying
+    /// [`BuilderVmError`] so the diagnostic (missing libkrun,
+    /// installer non-zero exit, missing sealed-volume artifact) is
+    /// surfaced verbatim.
+    #[error("builder VM install pipeline failed for lockfile_hash {lockfile_hash}: {source}")]
+    BuilderVmFailed {
+        lockfile_hash: String,
+        #[source]
+        source: BuilderVmError,
+    },
+
+    /// The builder VM completed but the artifacts it produced
+    /// didn't seal cleanly — typically because one of the sealed
+    /// sidecars is missing or unreadable. Wraps the
+    /// [`VolumeError`] so the operator sees which artifact failed.
+    #[error("sealing builder-VM-produced volume for lockfile_hash {lockfile_hash}: {source}")]
+    SealFailed {
+        lockfile_hash: String,
+        #[source]
+        source: VolumeError,
+    },
+
+    /// Failed to move the sealed volume into the cache. Almost
+    /// always a permissions / cross-device-link issue.
+    #[error(
+        "moving sealed volume into cache `{}`: {source}",
+        dest.display()
+    )]
+    CacheInstallFailed {
+        dest: PathBuf,
+        #[source]
+        source: io::Error,
+    },
+
+    /// Builder backend variant returned something other than
+    /// [`BuilderArtifacts::InstallVolume`] from an
+    /// [`BuilderJob::Install`]. Means the backend has a bug; fail
+    /// closed rather than try to interpret a mismatched shape.
+    #[error(
+        "builder VM returned non-install artifact for an install job (lockfile_hash {lockfile_hash})"
+    )]
+    BuilderVmShapeMismatch { lockfile_hash: String },
 }
 
-/// Resolve a deps install for `spec`. Pure host-side operation —
-/// hashes the lockfile, probes the cache index, and either returns
-/// a verified [`InstallResult`] or the [`InstallError::BuilderVmNotWired`]
-/// placeholder. Does not invoke the builder VM and does not write to
-/// the cache.
-pub fn install_app_deps(spec: &InstallSpec) -> Result<InstallResult, InstallError> {
+/// Driver indirection so `install_app_deps` can be tested without
+/// a live libkrun host. Production callers pass an instance of
+/// [`crate::libkrun_builder::LibkrunBuilderVm`]; tests pass a
+/// fixture that pre-populates `artifact_out` with hand-authored
+/// content/SBOM/fetch.log/CVE/result.json.
+///
+/// Defining this as a trait — rather than wiring `LibkrunBuilderVm`
+/// directly — keeps the `backends-builder-vm-libkrun` feature gate
+/// pure: `install_app_deps` compiles + tests without dragging
+/// libkrun-sys onto every CI runner.
+pub trait InstallDriver {
+    fn run_install(
+        &self,
+        spec_path: &Path,
+        source_root: &Path,
+        artifact_out: &Path,
+    ) -> Result<BuilderArtifacts, BuilderVmError>;
+}
+
+/// Blanket impl: any [`BuilderVm`] is also an [`InstallDriver`].
+/// The driver wraps the `BuilderJob::Install` call with the
+/// canonical mount layout (source_root → `/work`, artifact_out
+/// → `/out`). Host-Nix store reuse is intentionally absent for
+/// install jobs — uv / pnpm don't touch `/nix/store`.
+impl<T: BuilderVm> InstallDriver for T {
+    fn run_install(
+        &self,
+        spec_path: &Path,
+        source_root: &Path,
+        artifact_out: &Path,
+    ) -> Result<BuilderArtifacts, BuilderVmError> {
+        let job = BuilderJob::Install {
+            spec_path: spec_path.to_path_buf(),
+        };
+        let mounts = BuilderMounts {
+            flake_src: source_root.to_path_buf(),
+            host_nix_store: None,
+            artifact_out: artifact_out.to_path_buf(),
+        };
+        self.run_build(&job, &mounts)
+    }
+}
+
+/// Resolve a deps install for `spec`. Cache-hit path is pure I/O
+/// (no driver needed); cache-miss path dispatches the install via
+/// [`InstallDriver`] (typically [`crate::libkrun_builder::LibkrunBuilderVm`]),
+/// seals the result, and renames it into the cache.
+///
+/// Pass `driver = None` to assert no VM dispatch can happen —
+/// tests that should only exercise the cache-hit path use this to
+/// force a panic on inadvertent miss.
+pub fn install_app_deps(
+    spec: &InstallSpec,
+    driver: Option<&dyn InstallDriver>,
+) -> Result<InstallResult, InstallError> {
     if !spec.lockfile.is_file() {
         return Err(InstallError::LockfileMissing(spec.lockfile.clone()));
     }
@@ -247,43 +347,254 @@ pub fn install_app_deps(spec: &InstallSpec) -> Result<InstallResult, InstallErro
     let lockfile_hash = derive_lockfile_hash(&lockfile_sha256, spec.language, spec.gate);
     let cache_root = resolve_cache_root(spec.cache_root_override.as_deref());
 
-    match lookup_cached_volume(&cache_root, &lockfile_hash)? {
-        Some(volume_hash) => {
-            let volume_dir = cache_root.join(&volume_hash);
-            let computed = verify_sealed_volume(&volume_dir).map_err(|source| {
-                InstallError::CacheVerifyFailed {
-                    lockfile_hash: lockfile_hash.clone(),
-                    source,
-                }
-            })?;
-            if computed != volume_hash {
-                return Err(InstallError::CacheHashMismatch {
-                    lockfile_hash,
-                    index_hash: volume_hash,
-                    volume_hash: computed,
-                });
-            }
-            let manifest_sha256 =
-                sha256_file(&volume_dir.join(mvm_sdk::compile::deps_audit::FILE_MANIFEST))
-                    .map_err(|source| InstallError::LockfileIo {
-                        path: volume_dir.join(mvm_sdk::compile::deps_audit::FILE_MANIFEST),
-                        source,
-                    })?;
-            Ok(InstallResult {
-                volume_hash,
-                manifest_sha256,
-                cache_hit: true,
-                volume_dir,
-                lockfile_sha256,
-            })
-        }
-        None => Err(InstallError::BuilderVmNotWired {
-            lockfile_hash,
-            language: spec.language.token(),
-            gate: spec.gate.token(),
-            cache_root,
-        }),
+    if let Some(volume_hash) = lookup_cached_volume(&cache_root, &lockfile_hash)? {
+        return finalize_cache_hit(&cache_root, &lockfile_hash, &volume_hash, &lockfile_sha256);
     }
+
+    let driver = driver.ok_or_else(|| InstallError::DriverNotProvided {
+        lockfile_hash: lockfile_hash.clone(),
+        language: spec.language.token(),
+        gate: spec.gate.token(),
+    })?;
+    run_install_via_driver(spec, driver, &cache_root, &lockfile_hash, &lockfile_sha256)
+}
+
+/// Cache-hit completion path. Verifies the on-disk volume, cross-
+/// checks the recorded hash, and builds the `InstallResult`.
+fn finalize_cache_hit(
+    cache_root: &Path,
+    lockfile_hash: &str,
+    volume_hash: &str,
+    lockfile_sha256: &str,
+) -> Result<InstallResult, InstallError> {
+    let volume_dir = cache_root.join(volume_hash);
+    let computed =
+        verify_sealed_volume(&volume_dir).map_err(|source| InstallError::CacheVerifyFailed {
+            lockfile_hash: lockfile_hash.to_string(),
+            source,
+        })?;
+    if computed != volume_hash {
+        return Err(InstallError::CacheHashMismatch {
+            lockfile_hash: lockfile_hash.to_string(),
+            index_hash: volume_hash.to_string(),
+            volume_hash: computed,
+        });
+    }
+    let manifest_path = volume_dir.join(FILE_MANIFEST);
+    let manifest_sha256 =
+        sha256_file(&manifest_path).map_err(|source| InstallError::LockfileIo {
+            path: manifest_path,
+            source,
+        })?;
+    Ok(InstallResult {
+        volume_hash: volume_hash.to_string(),
+        manifest_sha256,
+        cache_hit: true,
+        volume_dir,
+        lockfile_sha256: lockfile_sha256.to_string(),
+    })
+}
+
+/// Cache-miss path: dispatch the install pipeline through the
+/// builder VM, seal its output, and install it into the cache.
+///
+/// Pipeline:
+/// 1. Synthesize the install spec JSON the guest reads.
+/// 2. Stage a writable scratch dir under
+///    `<cache_root>/in-progress/<id>/` — the builder VM mounts
+///    this at `/out`. Doing the scratch under the cache root
+///    (rather than `/tmp`) avoids cross-device rename when we
+///    move the sealed volume into the cache.
+/// 3. Drive the VM via [`InstallDriver::run_install`].
+/// 4. Seal the artifacts via
+///    `mvm_sdk::compile::deps_audit::seal_volume`. Annotates the
+///    sealed manifest with the lockfile hash + language/gate
+///    tokens so `mvmctl deps inspect` can surface them.
+/// 5. Write the manifest, rename the scratch dir to
+///    `<cache_root>/<volume_hash>/`, write the index pointer.
+fn run_install_via_driver(
+    spec: &InstallSpec,
+    driver: &dyn InstallDriver,
+    cache_root: &Path,
+    lockfile_hash: &str,
+    lockfile_sha256: &str,
+) -> Result<InstallResult, InstallError> {
+    fs::create_dir_all(cache_root).map_err(|source| InstallError::IndexIo {
+        path: cache_root.to_path_buf(),
+        source,
+    })?;
+    let in_progress_root = cache_root.join("in-progress");
+    fs::create_dir_all(&in_progress_root).map_err(|source| InstallError::IndexIo {
+        path: in_progress_root.clone(),
+        source,
+    })?;
+    let scratch = in_progress_root.join(unique_scratch_id());
+    fs::create_dir_all(&scratch).map_err(|source| InstallError::IndexIo {
+        path: scratch.clone(),
+        source,
+    })?;
+
+    // Stage the install spec JSON next to the scratch dir (not
+    // inside it — `/out` should only carry the sealed-volume
+    // artifacts post-run).
+    let spec_path = scratch.with_extension("spec.json");
+    let spec_body = install_spec_json(spec);
+    fs::write(&spec_path, spec_body).map_err(|source| InstallError::IndexIo {
+        path: spec_path.clone(),
+        source,
+    })?;
+
+    let artifacts = driver
+        .run_install(&spec_path, &spec.source_root, &scratch)
+        .map_err(|source| InstallError::BuilderVmFailed {
+            lockfile_hash: lockfile_hash.to_string(),
+            source,
+        })?;
+    // Best-effort cleanup of the spec — the install succeeded, so
+    // a lingering spec.json under cache_root would only be noise.
+    let _ = fs::remove_file(&spec_path);
+
+    let volume_dir = match artifacts {
+        BuilderArtifacts::InstallVolume { volume_dir, .. } => volume_dir,
+        _ => {
+            // Clean up the scratch dir so a buggy backend doesn't
+            // leave half-populated dirs lying around.
+            let _ = fs::remove_dir_all(&scratch);
+            return Err(InstallError::BuilderVmShapeMismatch {
+                lockfile_hash: lockfile_hash.to_string(),
+            });
+        }
+    };
+
+    // Seal the artifacts. `seal_volume` reads + hashes the four
+    // sidecars; the annotations capture lockfile-key context for
+    // `mvmctl deps inspect` (B.3).
+    let content = volume_dir.join(FILE_CONTENT_DIR);
+    let sbom = volume_dir.join(FILE_SBOM);
+    let fetch_log = volume_dir.join(FILE_FETCH_LOG);
+    let cve = volume_dir.join(FILE_CVE);
+    let mut annotations = BTreeMap::new();
+    annotations.insert("language".to_string(), spec.language.token().to_string());
+    annotations.insert("gate".to_string(), spec.gate.token().to_string());
+    annotations.insert("lockfile_sha256".to_string(), lockfile_sha256.to_string());
+    annotations.insert("lockfile_hash".to_string(), lockfile_hash.to_string());
+    let created_at = Utc::now().to_rfc3339();
+    let sealed = seal_volume(&content, &sbom, &fetch_log, &cve, created_at, annotations).map_err(
+        |source| InstallError::SealFailed {
+            lockfile_hash: lockfile_hash.to_string(),
+            source,
+        },
+    )?;
+    let manifest_path = volume_dir.join(FILE_MANIFEST);
+    fs::write(&manifest_path, &sealed.manifest_bytes).map_err(|source| InstallError::IndexIo {
+        path: manifest_path.clone(),
+        source,
+    })?;
+
+    // Rename the scratch dir to its canonical hash-named slot.
+    // If a previous run already populated this slot (concurrent
+    // install racing the same lockfile), preserve the older value
+    // and delete our scratch — the index/volume both verify the
+    // same content, so either is correct.
+    let final_dir = cache_root.join(&sealed.volume_hash);
+    if final_dir.exists() {
+        let _ = fs::remove_dir_all(&volume_dir);
+    } else {
+        fs::rename(&volume_dir, &final_dir).map_err(|source| InstallError::CacheInstallFailed {
+            dest: final_dir.clone(),
+            source,
+        })?;
+    }
+
+    // Write the lockfile_hash → volume_hash index pointer.
+    let index_dir = cache_root.join(INDEX_SUBDIR);
+    fs::create_dir_all(&index_dir).map_err(|source| InstallError::IndexIo {
+        path: index_dir.clone(),
+        source,
+    })?;
+    let index_path = index_dir.join(lockfile_hash);
+    fs::write(&index_path, &sealed.volume_hash).map_err(|source| InstallError::IndexIo {
+        path: index_path.clone(),
+        source,
+    })?;
+
+    let manifest_sha256 =
+        sha256_file(&final_dir.join(FILE_MANIFEST)).map_err(|source| InstallError::LockfileIo {
+            path: final_dir.join(FILE_MANIFEST),
+            source,
+        })?;
+    Ok(InstallResult {
+        volume_hash: sealed.volume_hash,
+        manifest_sha256,
+        cache_hit: false,
+        volume_dir: final_dir,
+        lockfile_sha256: lockfile_sha256.to_string(),
+    })
+}
+
+/// Serialize an [`InstallSpec`] into the JSON shape
+/// `mvm-builder-init::install_spec::parse` expects. Hand-rolled
+/// (rather than serde-derived) so the wire shape stays pinned —
+/// adding a field on either side surfaces here, not as a silent
+/// drift.
+fn install_spec_json(spec: &InstallSpec) -> String {
+    format!(
+        r#"{{"language":"{lang}","lockfile_relative_path":"{path}","source_mount":"/work","gate":"{gate}"}}"#,
+        lang = spec.language.token(),
+        // The lockfile path is recorded relative to the source
+        // root so the guest can resolve it against its `/work`
+        // mount. `.strip_prefix` returns the relative tail; on
+        // an absolute lockfile that isn't under source_root we
+        // fall back to the bare file name (rare but possible
+        // for callers that constructed `spec.lockfile` manually).
+        path = json_string_escape(
+            &spec
+                .lockfile
+                .strip_prefix(&spec.source_root)
+                .map(Path::to_path_buf)
+                .unwrap_or_else(|_| spec
+                    .lockfile
+                    .file_name()
+                    .map(PathBuf::from)
+                    .unwrap_or_default())
+                .to_string_lossy()
+        ),
+        gate = spec.gate.token(),
+    )
+}
+
+/// JSON-string escaper matching the one in
+/// `mvm-builder-init::install_spec` so the spec round-trips
+/// unchanged. Mirrors the RFC 8259 §7 must-escape set.
+fn json_string_escape(s: &str) -> String {
+    let mut out = String::with_capacity(s.len());
+    for c in s.chars() {
+        match c {
+            '"' => out.push_str("\\\""),
+            '\\' => out.push_str("\\\\"),
+            '\n' => out.push_str("\\n"),
+            '\r' => out.push_str("\\r"),
+            '\t' => out.push_str("\\t"),
+            c if (c as u32) < 0x20 => out.push_str(&format!("\\u{:04x}", c as u32)),
+            c => out.push(c),
+        }
+    }
+    out
+}
+
+/// Monotonic-with-pid scratch ID for the per-invocation
+/// `in-progress/<id>/` dir. Same pattern as
+/// `libkrun_builder::unique_job_id` — duplicated here so this
+/// module stays usable without the `backends-builder-vm-libkrun`
+/// feature gate.
+fn unique_scratch_id() -> String {
+    use std::time::{SystemTime, UNIX_EPOCH};
+    let stamp = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .map(|d| d.as_millis())
+        .unwrap_or(0);
+    let pid = std::process::id();
+    format!("{stamp:013}-{pid}")
 }
 
 /// Derive the stable cache key from the lockfile sha256 + the

--- a/crates/mvm-build/src/libkrun_builder.rs
+++ b/crates/mvm-build/src/libkrun_builder.rs
@@ -248,15 +248,6 @@ impl BuilderVm for LibkrunBuilderVm {
         self.validate_mounts(mounts)?;
         self.validate_job(job)?;
 
-        // Plan 73 Followup B.2.0 plumbing: the Install variant is
-        // a typed seam for the application-deps install pipeline
-        // (Followup B.2). The flake-build path below is unchanged;
-        // the install path lands in B.2.
-        match job {
-            BuilderJob::Flake { .. } => {}
-            BuilderJob::Install { .. } => return Err(BuilderVmError::NotYetImplemented),
-        }
-
         // 2. Refuse to proceed on a host without libkrun. The
         //    `backends-builder-vm-libkrun` feature being compiled
         //    in doesn't imply the runtime library is installed.
@@ -283,10 +274,10 @@ impl BuilderVm for LibkrunBuilderVm {
         //    warm Nix store.
         let nix_store_img = ensure_nix_store_image(host_arch_tag(), u64::from(self.nix_store_mib))?;
 
-        // 6. Stage the per-build job dir (`cmd.sh` + `env` +
-        //    placeholder `result`). The job ID derives from a
-        //    monotonic timestamp so concurrent invocations on
-        //    one host don't clobber.
+        // 6. Stage the per-build job dir. Flake jobs get
+        //    `cmd.sh`; install jobs get `install_spec.json`.
+        //    `mvm-builder-init` (Plan 72 W3 + Plan 73 Followup
+        //    B.2) dispatches based on which file it sees.
         let job_id = unique_job_id();
         let job_dir = builder_vm_cache_dir().join("jobs").join(&job_id);
         stage_job_dir(&job_dir, job)?;
@@ -294,7 +285,9 @@ impl BuilderVm for LibkrunBuilderVm {
         // 7. Build the `KrunContext` libkrun consumes. Three
         //    virtio-fs shares (work / out / job), one virtio-blk
         //    (Nix store), and the canonical cmdline pinned at the
-        //    flake output.
+        //    flake output. The mount layout is identical for
+        //    flake + install jobs — the guest decides what to do
+        //    with each share based on the staged job files.
         let vm_name = format!("mvm-builder-vm-{job_id}");
         let vm_state_dir = builder_vm_cache_dir().join("vms").join(&vm_name);
         std::fs::create_dir_all(&vm_state_dir).map_err(|e| {
@@ -341,47 +334,14 @@ impl BuilderVm for LibkrunBuilderVm {
             )));
         }
 
-        // 9. Read the guest's structured exit status.
-        let result = read_job_result(&job_dir)?;
-        if result.exit_code != 0 {
-            return Err(BuilderVmError::NixBuildFailed(format!(
-                "guest cmd.sh exited {} — stderr tail:\n{}",
-                result.exit_code, result.stderr_tail
-            )));
+        // 9. Per-variant result parsing + artifact validation.
+        //    Flake jobs read `<job_dir>/result` (legacy shape);
+        //    install jobs read `<artifact_out>/result.json` and
+        //    return a different artifact variant.
+        match job {
+            BuilderJob::Flake { .. } => finalize_flake_job(&job_dir, &mounts.artifact_out, &job_id),
+            BuilderJob::Install { .. } => finalize_install_job(&mounts.artifact_out),
         }
-
-        // 10. Validate the artifacts the cmd.sh script was
-        //     supposed to drop into `/out`. The guest wrote them
-        //     via virtio-fs — they show up on the host at
-        //     `mounts.artifact_out`.
-        let rootfs_path = mounts.artifact_out.join("rootfs.ext4");
-        if !rootfs_path.is_file() {
-            return Err(BuilderVmError::ExtractionFailed(format!(
-                "builder VM exited cleanly but {} was not written",
-                rootfs_path.display()
-            )));
-        }
-        let kernel_path_out = mounts.artifact_out.join("vmlinux");
-        let kernel_path = if kernel_path_out.is_file() {
-            Some(kernel_path_out)
-        } else {
-            None
-        };
-
-        Ok(BuilderArtifacts::Image {
-            rootfs_path,
-            kernel_path,
-            // The Nix store path hash isn't trivially recoverable
-            // from inside the host here — `nix build` printed it
-            // to stdout inside the guest and the cmd.sh discards
-            // it after copy. Plan 72 W5 can plumb it through via
-            // a `/job/store-path` sidecar if cache-keying needs
-            // it; for now the artifact dir's own digest is the
-            // cache key the host carries.
-            revision_hash: job_id,
-            lock_hash: None,
-            accessible: None,
-        })
     }
 
     fn cleanup(&self) -> Result<(), BuilderVmError> {
@@ -539,29 +499,57 @@ fn unique_job_id() -> String {
     format!("{now:013}-{pid}")
 }
 
-/// Stage `<job_dir>/cmd.sh` with the shell script the guest's
-/// PID 1 (`mvm-builder-init`) executes. `cmd.sh` runs
-/// `/bin/sh -eu` and is responsible for invoking `nix build`
-/// against the user's flake and dropping `vmlinux` +
-/// `rootfs.ext4` into `/out`.
+/// Filename of the install-spec JSON the host stages for
+/// install jobs. Matches the constant `mvm-builder-init` checks
+/// for inside the VM — keep these in sync.
+pub(crate) const INSTALL_SPEC_FILENAME: &str = "install_spec.json";
+
+/// Filename of the install report `mvm-builder-init` writes into
+/// `artifact_out/` after the install pipeline finishes. The host
+/// reads + parses this to decide whether the install succeeded.
+pub(crate) const INSTALL_RESULT_FILENAME: &str = "result.json";
+
+/// Stage the per-job dir for the given [`BuilderJob`].
 ///
-/// Plan 73 Followup B.2.0 added the [`BuilderJob`] dispatch
-/// here. The `Flake` arm renders today's `nix build` script;
-/// the `Install` arm errors with [`BuilderVmError::NotYetImplemented`]
-/// — Followup B.2 fills it in by emitting the per-ecosystem
-/// install script + result.json contract.
+/// - [`BuilderJob::Flake`]: writes `<job_dir>/cmd.sh` with the
+///   `nix build` script the guest's PID 1 dispatches via
+///   `/bin/sh -eu`.
+/// - [`BuilderJob::Install`]: copies the caller's install spec
+///   to `<job_dir>/install_spec.json`. `mvm-builder-init` probes
+///   for this filename first; when present it routes through the
+///   app-deps install pipeline (Plan 73 Followup B.2) instead of
+///   running `cmd.sh`.
+///
+/// The two modes are mutually exclusive — install jobs don't
+/// emit a `cmd.sh`, flake jobs don't emit an install spec.
 fn stage_job_dir(job_dir: &Path, job: &BuilderJob) -> Result<(), BuilderVmError> {
+    std::fs::create_dir_all(job_dir).map_err(|e| {
+        BuilderVmError::ExtractionFailed(format!("creating job dir {}: {e}", job_dir.display()))
+    })?;
+
     let (flake_ref, attr_path) = match job {
         BuilderJob::Flake {
             flake_ref,
             attr_path,
         } => (flake_ref.as_str(), attr_path.as_str()),
-        BuilderJob::Install { .. } => return Err(BuilderVmError::NotYetImplemented),
+        BuilderJob::Install { spec_path } => {
+            // Copy the caller's spec into the per-job dir so the
+            // virtio-fs share carries it into the guest at
+            // `/job/install_spec.json`. `mvm-builder-init`
+            // (Plan 73 Followup B.2) detects that filename and
+            // dispatches through the install pipeline instead of
+            // running cmd.sh.
+            let dst = job_dir.join(INSTALL_SPEC_FILENAME);
+            std::fs::copy(spec_path, &dst).map_err(|e| {
+                BuilderVmError::ExtractionFailed(format!(
+                    "copying install spec {} -> {}: {e}",
+                    spec_path.display(),
+                    dst.display()
+                ))
+            })?;
+            return Ok(());
+        }
     };
-
-    std::fs::create_dir_all(job_dir).map_err(|e| {
-        BuilderVmError::ExtractionFailed(format!("creating job dir {}: {e}", job_dir.display()))
-    })?;
 
     // Render the `cmd.sh` content. flake_ref and attr_path are
     // user-controlled; emit them inside `'…'` quoted shell
@@ -634,6 +622,127 @@ chmod 0644 /out/rootfs.ext4 2>/dev/null || true
 /// then reopen. Standard sh-escape pattern.
 fn shell_single_quote_escape(s: &str) -> String {
     s.replace('\'', "'\\''")
+}
+
+/// Finalize a flake build: read `<job_dir>/result`, validate the
+/// `rootfs.ext4` (and optional `vmlinux`) landed in
+/// `artifact_out`, return a [`BuilderArtifacts::Image`].
+fn finalize_flake_job(
+    job_dir: &Path,
+    artifact_out: &Path,
+    job_id: &str,
+) -> Result<BuilderArtifacts, BuilderVmError> {
+    let result = read_job_result(job_dir)?;
+    if result.exit_code != 0 {
+        return Err(BuilderVmError::NixBuildFailed(format!(
+            "guest cmd.sh exited {} — stderr tail:\n{}",
+            result.exit_code, result.stderr_tail
+        )));
+    }
+
+    let rootfs_path = artifact_out.join("rootfs.ext4");
+    if !rootfs_path.is_file() {
+        return Err(BuilderVmError::ExtractionFailed(format!(
+            "builder VM exited cleanly but {} was not written",
+            rootfs_path.display()
+        )));
+    }
+    let kernel_path_out = artifact_out.join("vmlinux");
+    let kernel_path = if kernel_path_out.is_file() {
+        Some(kernel_path_out)
+    } else {
+        None
+    };
+
+    Ok(BuilderArtifacts::Image {
+        rootfs_path,
+        kernel_path,
+        // The Nix store path hash isn't trivially recoverable
+        // from inside the host here — `nix build` printed it
+        // to stdout inside the guest and the cmd.sh discards
+        // it after copy. Plan 72 W5 can plumb it through via
+        // a `/job/store-path` sidecar if cache-keying needs
+        // it; for now the artifact dir's own digest is the
+        // cache key the host carries.
+        revision_hash: job_id.to_string(),
+        lock_hash: None,
+        accessible: None,
+    })
+}
+
+/// Finalize an install job (Plan 73 Followup B.2): validate the
+/// install report `mvm-builder-init` wrote to
+/// `<artifact_out>/result.json`, fail closed on `installer_exit_code
+/// != 0`, and return [`BuilderArtifacts::InstallVolume`] pointing
+/// at the directory. Sealing the volume (via
+/// `mvm_sdk::compile::deps_audit::seal_volume`) and renaming into
+/// the deps cache is the orchestrator's job
+/// (`mvm_build::app_deps::install_app_deps`) — keeping it out of
+/// the builder VM means the same code path covers fresh installs
+/// and cache rehydrations.
+fn finalize_install_job(artifact_out: &Path) -> Result<BuilderArtifacts, BuilderVmError> {
+    let result_path = artifact_out.join(INSTALL_RESULT_FILENAME);
+    if !result_path.is_file() {
+        return Err(BuilderVmError::ExtractionFailed(format!(
+            "install job VM exited cleanly but {} was not written",
+            result_path.display()
+        )));
+    }
+    let body = std::fs::read_to_string(&result_path).map_err(|e| {
+        BuilderVmError::ExtractionFailed(format!("reading {}: {e}", result_path.display()))
+    })?;
+    let report: InstallResultReport = serde_json::from_str(&body).map_err(|e| {
+        BuilderVmError::ExtractionFailed(format!(
+            "parsing {} as JSON: {e}\nbody:\n{body}",
+            result_path.display()
+        ))
+    })?;
+
+    if report.installer_exit_code != 0 {
+        let reason = report
+            .failure_reason
+            .clone()
+            .unwrap_or_else(|| format!("installer exited {}", report.installer_exit_code));
+        return Err(BuilderVmError::NixBuildFailed(format!(
+            "install pipeline failed inside builder VM: {reason}"
+        )));
+    }
+
+    // The four sealed-volume artifacts must all be present —
+    // mvm-builder-init emits stubs on missing optional tooling
+    // (SBOM / CVE) so absence here means the guest crashed mid-
+    // pipeline. seal_volume would catch this too, but failing
+    // closed at the builder layer pins the error to the right
+    // diagnostic message.
+    for name in ["content", "sbom.cdx.json", "fetch.log", "cve.json"] {
+        let p = artifact_out.join(name);
+        if !p.exists() {
+            return Err(BuilderVmError::ExtractionFailed(format!(
+                "install job VM exited cleanly but sealed-volume artifact {} is missing",
+                p.display()
+            )));
+        }
+    }
+
+    Ok(BuilderArtifacts::InstallVolume {
+        volume_dir: artifact_out.to_path_buf(),
+        result_json_path: result_path,
+    })
+}
+
+/// Parsed shape of `<artifact_out>/result.json` — the install
+/// report `mvm-builder-init::install::InstallReport::to_json`
+/// emits. Field set kept in sync with the writer; an additive
+/// change to the writer (B.2.x egress allowlist diagnostics, for
+/// example) needs a matching `#[serde(default)]` field here.
+#[derive(Debug, Deserialize)]
+struct InstallResultReport {
+    installer_exit_code: i32,
+    /// Set when `mvm-builder-init` synthesizes a failure report
+    /// (e.g. installer binary missing on PATH). Surfaced in the
+    /// host-side error message.
+    #[serde(default)]
+    failure_reason: Option<String>,
 }
 
 /// Read and parse `<job_dir>/result`. The guest's PID 1
@@ -907,11 +1016,13 @@ mod tests {
     }
 
     #[test]
-    fn run_build_rejects_install_variant_with_not_yet_implemented() {
-        // Plumbing-only: the Install variant is a typed seam for
-        // Followup B.2. Until then libkrun must surface
-        // NotYetImplemented after passing input validation rather
-        // than proceeding into the flake-build pipeline.
+    fn run_build_surfaces_environment_gaps_for_install_variant() {
+        // Plan 73 Followup B.2 wires the Install variant — passing
+        // input validation no longer trips NotYetImplemented. With
+        // a CI runner that doesn't carry libkrun + the supervisor
+        // binary, run_build now surfaces the same environment-gap
+        // shape as the Flake variant. Asserts the wiring proceeds
+        // past validation rather than short-circuiting.
         let scratch = TempDir::new().unwrap();
         let spec_path = scratch.path().join("spec.json");
         std::fs::write(&spec_path, b"{}").unwrap();
@@ -920,24 +1031,126 @@ mod tests {
             .run_build(&BuilderJob::Install { spec_path }, &mounts)
             .unwrap_err();
         assert!(
-            matches!(err, BuilderVmError::NotYetImplemented),
+            matches!(
+                err,
+                BuilderVmError::MicrosandboxUnavailable(_) | BuilderVmError::ExtractionFailed(_)
+            ),
+            "unexpected error variant: {err:?}"
+        );
+    }
+
+    #[test]
+    fn stage_job_dir_install_copies_spec_into_job_dir() {
+        // Plan 73 Followup B.2: install jobs stage
+        // `<job_dir>/install_spec.json` rather than `cmd.sh`. The
+        // guest's `mvm-builder-init` probes for that filename and
+        // dispatches through the install pipeline.
+        let scratch = TempDir::new().unwrap();
+        let job_dir = scratch.path().join("job-1");
+        let spec_path = scratch.path().join("spec.json");
+        let spec_body = br#"{"language":"python","lockfile_relative_path":"uv.lock","source_mount":"/work","gate":"dev"}"#;
+        std::fs::write(&spec_path, spec_body).unwrap();
+        stage_job_dir(&job_dir, &BuilderJob::Install { spec_path }).expect("stage ok");
+        let dst = job_dir.join(INSTALL_SPEC_FILENAME);
+        assert!(dst.is_file(), "install_spec.json must be staged at {dst:?}");
+        let on_disk = std::fs::read(&dst).unwrap();
+        assert_eq!(on_disk, spec_body, "spec bytes must round-trip verbatim");
+        // No cmd.sh is emitted for install jobs.
+        assert!(
+            !job_dir.join("cmd.sh").exists(),
+            "install jobs must not stage cmd.sh"
+        );
+    }
+
+    #[test]
+    fn finalize_install_job_requires_result_json() {
+        // Empty artifact dir → ExtractionFailed pointing at the
+        // missing result.json. Surfaces guest crashes that
+        // prevented mvm-builder-init from finalizing the report.
+        let scratch = TempDir::new().unwrap();
+        let err = finalize_install_job(scratch.path()).unwrap_err();
+        assert!(matches!(err, BuilderVmError::ExtractionFailed(_)));
+        assert!(err.to_string().contains("result.json"), "got {err}");
+    }
+
+    #[test]
+    fn finalize_install_job_rejects_nonzero_installer_exit() {
+        let scratch = TempDir::new().unwrap();
+        // Populate enough of the layout that the missing-artifacts
+        // check doesn't trip first.
+        std::fs::create_dir_all(scratch.path().join("content")).unwrap();
+        std::fs::write(scratch.path().join("sbom.cdx.json"), b"{}").unwrap();
+        std::fs::write(scratch.path().join("fetch.log"), b"").unwrap();
+        std::fs::write(scratch.path().join("cve.json"), b"{}").unwrap();
+        std::fs::write(
+            scratch.path().join(INSTALL_RESULT_FILENAME),
+            br#"{"installer_exit_code":1,"sbom_emitted":false,"cve_emitted":false,"language":"python","gate":"dev","content_path":"/out/content","sbom_path":"/out/sbom.cdx.json","fetch_log_path":"/out/fetch.log","cve_path":"/out/cve.json","failure_reason":"lockfile not found"}"#,
+        )
+        .unwrap();
+        let err = finalize_install_job(scratch.path()).unwrap_err();
+        match err {
+            BuilderVmError::NixBuildFailed(msg) => {
+                assert!(msg.contains("lockfile not found"), "got {msg}");
+            }
+            other => panic!("wrong variant: {other:?}"),
+        }
+    }
+
+    #[test]
+    fn finalize_install_job_returns_install_volume_on_happy_path() {
+        let scratch = TempDir::new().unwrap();
+        std::fs::create_dir_all(scratch.path().join("content")).unwrap();
+        std::fs::write(scratch.path().join("sbom.cdx.json"), b"{}").unwrap();
+        std::fs::write(scratch.path().join("fetch.log"), b"").unwrap();
+        std::fs::write(scratch.path().join("cve.json"), b"{}").unwrap();
+        std::fs::write(
+            scratch.path().join(INSTALL_RESULT_FILENAME),
+            br#"{"installer_exit_code":0,"sbom_emitted":true,"cve_emitted":true,"language":"python","gate":"prod","content_path":"/out/content","sbom_path":"/out/sbom.cdx.json","fetch_log_path":"/out/fetch.log","cve_path":"/out/cve.json"}"#,
+        )
+        .unwrap();
+        let art = finalize_install_job(scratch.path()).unwrap();
+        match art {
+            BuilderArtifacts::InstallVolume {
+                volume_dir,
+                result_json_path,
+            } => {
+                assert_eq!(volume_dir, scratch.path());
+                assert_eq!(
+                    result_json_path,
+                    scratch.path().join(INSTALL_RESULT_FILENAME)
+                );
+            }
+            other => panic!("wrong variant: {other:?}"),
+        }
+    }
+
+    #[test]
+    fn finalize_install_job_rejects_missing_sealed_artifact() {
+        let scratch = TempDir::new().unwrap();
+        // result.json says success, but the sealed-volume sidecars
+        // are missing. Fail closed so seal_volume doesn't later
+        // chase a half-populated dir.
+        std::fs::write(
+            scratch.path().join(INSTALL_RESULT_FILENAME),
+            br#"{"installer_exit_code":0,"sbom_emitted":true,"cve_emitted":true,"language":"python","gate":"dev","content_path":"/out/content","sbom_path":"/out/sbom.cdx.json","fetch_log_path":"/out/fetch.log","cve_path":"/out/cve.json"}"#,
+        )
+        .unwrap();
+        let err = finalize_install_job(scratch.path()).unwrap_err();
+        assert!(
+            matches!(err, BuilderVmError::ExtractionFailed(_)),
             "got {err:?}"
         );
     }
 
     #[test]
-    fn stage_job_dir_rejects_install_variant() {
-        // The stager only knows about the Flake shape today. The
-        // Install seam returns NotYetImplemented so B.2 can swap
-        // in the per-ecosystem install script without touching
-        // call sites.
+    fn finalize_install_job_rejects_malformed_result_json() {
         let scratch = TempDir::new().unwrap();
-        let job_dir = scratch.path().join("job-1");
-        let spec_path = scratch.path().join("spec.json");
-        std::fs::write(&spec_path, b"{}").unwrap();
-        let err =
-            stage_job_dir(&job_dir, &BuilderJob::Install { spec_path }).expect_err("install path");
-        assert!(matches!(err, BuilderVmError::NotYetImplemented));
+        std::fs::write(scratch.path().join(INSTALL_RESULT_FILENAME), b"{not valid").unwrap();
+        let err = finalize_install_job(scratch.path()).unwrap_err();
+        match err {
+            BuilderVmError::ExtractionFailed(msg) => assert!(msg.contains("parsing"), "got {msg}"),
+            other => panic!("wrong variant: {other:?}"),
+        }
     }
 
     #[test]

--- a/crates/mvm-build/tests/app_deps_orchestrator.rs
+++ b/crates/mvm-build/tests/app_deps_orchestrator.rs
@@ -22,14 +22,16 @@
 use std::collections::BTreeMap;
 use std::fs;
 use std::path::{Path, PathBuf};
+use std::sync::Mutex;
 
 use mvm_build::app_deps::{
-    GateLevel, InstallError, InstallSpec, Language, derive_lockfile_hash, install_app_deps,
-    resolve_cache_root,
+    GateLevel, InstallDriver, InstallError, InstallSpec, Language, derive_lockfile_hash,
+    install_app_deps, resolve_cache_root,
 };
+use mvm_build::builder_vm::{BuilderArtifacts, BuilderVmError};
 use mvm_sdk::compile::deps_audit::{
     FILE_CONTENT_DIR, FILE_CVE, FILE_FETCH_LOG, FILE_MANIFEST, FILE_SBOM, VolumeSealResult,
-    seal_volume,
+    seal_volume, verify_sealed_volume,
 };
 use sha2::{Digest, Sha256};
 
@@ -169,7 +171,11 @@ fn sha256_file(p: &Path) -> String {
 fn cache_hit_returns_verified_install_result() {
     let (fx, sealed) = Fixture::new(true);
     let sealed = sealed.expect("populated");
-    let res = install_app_deps(&fx.spec()).expect("install ok");
+    // `None` driver is fine on a cache hit — the orchestrator
+    // short-circuits before dispatch. Passing a panicking driver
+    // would also work; `None` documents the intent that the
+    // builder VM is unnecessary on the hot path.
+    let res = install_app_deps(&fx.spec(), None).expect("install ok");
     assert!(res.cache_hit, "expected cache_hit=true");
     assert_eq!(res.volume_hash, sealed.volume_hash);
     assert_eq!(res.volume_dir, fx.cache_root.join(&sealed.volume_hash));
@@ -184,19 +190,17 @@ fn cache_hit_returns_verified_install_result() {
 }
 
 #[test]
-fn cache_miss_returns_builder_vm_not_wired() {
+fn cache_miss_without_driver_returns_driver_not_provided() {
     let (fx, _) = Fixture::new(false);
-    let err = install_app_deps(&fx.spec()).expect_err("must miss");
+    let err = install_app_deps(&fx.spec(), None).expect_err("must miss");
     match err {
-        InstallError::BuilderVmNotWired {
+        InstallError::DriverNotProvided {
             lockfile_hash,
             language,
             gate,
-            cache_root,
         } => {
             assert_eq!(language, "python");
             assert_eq!(gate, "dev");
-            assert_eq!(cache_root, fx.cache_root);
             // The lockfile_hash is the derived key; check it matches
             // the helper so users + slice B.2 can reproduce it.
             let expected =
@@ -216,7 +220,7 @@ fn cache_hit_on_tampered_cve_fails_verify() {
     let cve_path = fx.cache_root.join(&sealed.volume_hash).join(FILE_CVE);
     fs::write(&cve_path, br#"{"results":["FORGED"]}"#).unwrap();
 
-    let err = install_app_deps(&fx.spec()).expect_err("must fail closed");
+    let err = install_app_deps(&fx.spec(), None).expect_err("must fail closed");
     match err {
         InstallError::CacheVerifyFailed { lockfile_hash, .. } => {
             let expected =
@@ -249,7 +253,7 @@ fn cache_index_hash_mismatch_fails_closed() {
     // `seal_volume` use). We also want the volume_hash variant
     // covered for the case where two different sealed dirs collide;
     // build a second sealed dir to exercise it.
-    let err = install_app_deps(&fx.spec()).expect_err("must fail closed");
+    let err = install_app_deps(&fx.spec(), None).expect_err("must fail closed");
     assert!(
         matches!(err, InstallError::CacheVerifyFailed { .. }),
         "expected CacheVerifyFailed for missing dir, got: {err:?}"
@@ -261,7 +265,7 @@ fn cache_index_hash_mismatch_fails_closed() {
     let real_dir = fx.cache_root.join(&sealed.volume_hash);
     let bogus_dir = fx.cache_root.join(&bogus_hash);
     fs::rename(&real_dir, &bogus_dir).unwrap();
-    let err = install_app_deps(&fx.spec()).expect_err("must fail closed");
+    let err = install_app_deps(&fx.spec(), None).expect_err("must fail closed");
     match err {
         InstallError::CacheHashMismatch {
             lockfile_hash: lh,
@@ -282,14 +286,14 @@ fn lockfile_hash_is_deterministic_across_invocations() {
     // diagnostic. Asserts the cache key is a pure function of
     // (lockfile bytes, language, gate).
     let (fx, _) = Fixture::new(false);
-    let first = install_app_deps(&fx.spec()).expect_err("miss");
-    let second = install_app_deps(&fx.spec()).expect_err("miss");
+    let first = install_app_deps(&fx.spec(), None).expect_err("miss");
+    let second = install_app_deps(&fx.spec(), None).expect_err("miss");
     let (first_hash, second_hash) = match (&first, &second) {
         (
-            InstallError::BuilderVmNotWired {
+            InstallError::DriverNotProvided {
                 lockfile_hash: a, ..
             },
-            InstallError::BuilderVmNotWired {
+            InstallError::DriverNotProvided {
                 lockfile_hash: b, ..
             },
         ) => (a, b),
@@ -302,7 +306,7 @@ fn lockfile_hash_is_deterministic_across_invocations() {
 fn missing_lockfile_returns_typed_error() {
     let (mut fx, _) = Fixture::new(false);
     fx.lockfile = fx.source_root.join("does-not-exist.lock");
-    let err = install_app_deps(&fx.spec()).expect_err("missing lockfile");
+    let err = install_app_deps(&fx.spec(), None).expect_err("missing lockfile");
     assert!(
         matches!(err, InstallError::LockfileMissing(_)),
         "got: {err:?}"
@@ -313,7 +317,7 @@ fn missing_lockfile_returns_typed_error() {
 fn missing_source_root_returns_typed_error() {
     let (mut fx, _) = Fixture::new(false);
     fx.source_root = fx.tmp.path().join("no-such-project");
-    let err = install_app_deps(&fx.spec()).expect_err("missing source_root");
+    let err = install_app_deps(&fx.spec(), None).expect_err("missing source_root");
     assert!(
         matches!(err, InstallError::SourceRootMissing(_)),
         "got: {err:?}"
@@ -326,4 +330,231 @@ fn override_takes_precedence_over_env() {
     // circuits before `mvm_deps_volumes_dir()` is consulted.
     let p = PathBuf::from("/tmp/precedence-fixture");
     assert_eq!(resolve_cache_root(Some(&p)), p);
+}
+
+// ─────────────────────────────────────────────────────────────────
+// Cache-miss dispatch path — Plan 73 Followup B.2.
+//
+// A mock `InstallDriver` impl simulates the builder VM by directly
+// populating the `artifact_out` directory with hand-authored
+// content/sbom/fetch.log/cve/result.json. The orchestrator then
+// seals + installs the volume into the cache.
+//
+// Confirms the full flow without a live libkrun host: the seam is
+// the driver call, and the mock proves the orchestrator's pre/post
+// logic.
+// ─────────────────────────────────────────────────────────────────
+
+/// Mock driver behaviors a single test can configure. The mock
+/// captures the path it was invoked with so tests can assert the
+/// orchestrator passed the right spec.
+enum MockBehavior {
+    /// Happy path: pre-populate artifact_out with realistic
+    /// payloads; return `InstallVolume`.
+    Success,
+    /// Builder VM ran but its install pipeline failed.
+    BuilderFailure(BuilderVmError),
+    /// Buggy backend: returned the wrong artifact shape.
+    WrongShape,
+}
+
+struct MockDriver {
+    behavior: MockBehavior,
+    captured_spec: Mutex<Option<PathBuf>>,
+    captured_artifact_out: Mutex<Option<PathBuf>>,
+}
+
+impl MockDriver {
+    fn new(behavior: MockBehavior) -> Self {
+        Self {
+            behavior,
+            captured_spec: Mutex::new(None),
+            captured_artifact_out: Mutex::new(None),
+        }
+    }
+}
+
+impl InstallDriver for MockDriver {
+    fn run_install(
+        &self,
+        spec_path: &Path,
+        _source_root: &Path,
+        artifact_out: &Path,
+    ) -> Result<BuilderArtifacts, BuilderVmError> {
+        *self.captured_spec.lock().unwrap() = Some(spec_path.to_path_buf());
+        *self.captured_artifact_out.lock().unwrap() = Some(artifact_out.to_path_buf());
+        match &self.behavior {
+            MockBehavior::Success => {
+                fs::create_dir_all(artifact_out.join("content")).unwrap();
+                fs::write(
+                    artifact_out.join("content").join("pkg.py"),
+                    b"# installed pkg\n",
+                )
+                .unwrap();
+                fs::write(
+                    artifact_out.join("sbom.cdx.json"),
+                    br#"{"bomFormat":"CycloneDX","specVersion":"1.5","components":[]}"#,
+                )
+                .unwrap();
+                fs::write(
+                    artifact_out.join("fetch.log"),
+                    b"GET https://pypi.org/simple/requests/\n",
+                )
+                .unwrap();
+                fs::write(artifact_out.join("cve.json"), br#"{"results":[]}"#).unwrap();
+                fs::write(
+                    artifact_out.join("result.json"),
+                    br#"{"installer_exit_code":0,"sbom_emitted":true,"cve_emitted":true,"language":"python","gate":"dev","content_path":"/out/content","sbom_path":"/out/sbom.cdx.json","fetch_log_path":"/out/fetch.log","cve_path":"/out/cve.json"}"#,
+                )
+                .unwrap();
+                Ok(BuilderArtifacts::InstallVolume {
+                    volume_dir: artifact_out.to_path_buf(),
+                    result_json_path: artifact_out.join("result.json"),
+                })
+            }
+            MockBehavior::BuilderFailure(e) => Err(clone_builder_err(e)),
+            MockBehavior::WrongShape => Ok(BuilderArtifacts::Image {
+                rootfs_path: artifact_out.join("rootfs.ext4"),
+                kernel_path: None,
+                revision_hash: "deadbeef".to_string(),
+                lock_hash: None,
+                accessible: None,
+            }),
+        }
+    }
+}
+
+/// `BuilderVmError` doesn't impl `Clone`, but the mock needs to
+/// reuse one behavior across calls. The variants we care about for
+/// testing all carry strings, so we hand-construct an equivalent.
+fn clone_builder_err(e: &BuilderVmError) -> BuilderVmError {
+    match e {
+        BuilderVmError::NixBuildFailed(s) => BuilderVmError::NixBuildFailed(s.clone()),
+        BuilderVmError::ExtractionFailed(s) => BuilderVmError::ExtractionFailed(s.clone()),
+        BuilderVmError::MicrosandboxUnavailable(s) => {
+            BuilderVmError::MicrosandboxUnavailable(s.clone())
+        }
+        BuilderVmError::ImagePullFailed(s) => BuilderVmError::ImagePullFailed(s.clone()),
+        BuilderVmError::NotYetImplemented => BuilderVmError::NotYetImplemented,
+    }
+}
+
+#[test]
+fn cache_miss_with_driver_runs_install_and_caches_result() {
+    let (fx, _) = Fixture::new(false);
+    let driver = MockDriver::new(MockBehavior::Success);
+    let res = install_app_deps(&fx.spec(), Some(&driver)).expect("install ok");
+
+    assert!(!res.cache_hit, "expected cache_hit=false on fresh install");
+    assert!(res.volume_hash.len() == 64);
+    assert!(res.volume_dir.is_dir(), "volume dir must exist after seal");
+    assert_eq!(res.volume_dir, fx.cache_root.join(&res.volume_hash));
+
+    // The orchestrator must have written every sealed-volume
+    // artifact into the final hashed dir.
+    assert!(res.volume_dir.join(FILE_CONTENT_DIR).is_dir());
+    assert!(res.volume_dir.join(FILE_SBOM).is_file());
+    assert!(res.volume_dir.join(FILE_FETCH_LOG).is_file());
+    assert!(res.volume_dir.join(FILE_CVE).is_file());
+    assert!(res.volume_dir.join(FILE_MANIFEST).is_file());
+
+    // The index pointer must round-trip the volume hash.
+    let lockfile_sha = sha256_file(&fx.lockfile);
+    let lockfile_hash = derive_lockfile_hash(&lockfile_sha, Language::Python, GateLevel::Dev);
+    let index_body = fs::read_to_string(fx.cache_root.join("index").join(&lockfile_hash)).unwrap();
+    assert_eq!(index_body.trim(), res.volume_hash);
+
+    // verify_sealed_volume succeeds — the orchestrator's seal +
+    // rename produced a canonical layout.
+    let derived = verify_sealed_volume(&res.volume_dir).expect("verify after seal");
+    assert_eq!(derived, res.volume_hash);
+
+    // Driver was invoked with the right spec path under the cache.
+    let spec_path = driver.captured_spec.lock().unwrap().clone().unwrap();
+    assert!(spec_path.starts_with(&fx.cache_root));
+    assert!(spec_path.extension().map(|e| e == "json").unwrap_or(false));
+}
+
+#[test]
+fn cache_miss_then_hit_round_trips_through_dispatch() {
+    let (fx, _) = Fixture::new(false);
+    let driver = MockDriver::new(MockBehavior::Success);
+    let first = install_app_deps(&fx.spec(), Some(&driver)).expect("install 1");
+    assert!(!first.cache_hit);
+
+    // Second call sees the freshly-cached volume.
+    let second = install_app_deps(&fx.spec(), None).expect("install 2 (cache hit)");
+    assert!(second.cache_hit);
+    assert_eq!(first.volume_hash, second.volume_hash);
+    assert_eq!(first.manifest_sha256, second.manifest_sha256);
+}
+
+#[test]
+fn builder_vm_failure_propagates_as_typed_error() {
+    let (fx, _) = Fixture::new(false);
+    let driver = MockDriver::new(MockBehavior::BuilderFailure(
+        BuilderVmError::NixBuildFailed("installer exited 1".to_string()),
+    ));
+    let err = install_app_deps(&fx.spec(), Some(&driver)).expect_err("must fail");
+    match err {
+        InstallError::BuilderVmFailed { source, .. } => match source {
+            BuilderVmError::NixBuildFailed(s) => assert!(s.contains("installer exited 1")),
+            other => panic!("wrong inner variant: {other:?}"),
+        },
+        other => panic!("wrong outer variant: {other:?}"),
+    }
+}
+
+#[test]
+fn builder_vm_shape_mismatch_fails_closed() {
+    let (fx, _) = Fixture::new(false);
+    let driver = MockDriver::new(MockBehavior::WrongShape);
+    let err = install_app_deps(&fx.spec(), Some(&driver)).expect_err("must fail");
+    assert!(
+        matches!(err, InstallError::BuilderVmShapeMismatch { .. }),
+        "got: {err:?}"
+    );
+}
+
+#[test]
+fn seal_failure_surfaces_as_typed_error() {
+    // Driver returns InstallVolume but the artifact dir is
+    // missing required sidecars — sealing fails on the missing
+    // content dir hash.
+    let (fx, _) = Fixture::new(false);
+
+    struct BadDriver;
+    impl InstallDriver for BadDriver {
+        fn run_install(
+            &self,
+            _spec_path: &Path,
+            _source_root: &Path,
+            artifact_out: &Path,
+        ) -> Result<BuilderArtifacts, BuilderVmError> {
+            fs::create_dir_all(artifact_out).unwrap();
+            // result.json says success, but `content/` is absent —
+            // seal_volume's hash_dir will fail. Note the orchestrator's
+            // own pre-seal sealed-artifact check isn't run today —
+            // the seal layer catches it.
+            fs::write(
+                artifact_out.join("result.json"),
+                br#"{"installer_exit_code":0,"sbom_emitted":true,"cve_emitted":true,"language":"python","gate":"dev","content_path":"/out/content","sbom_path":"/out/sbom.cdx.json","fetch_log_path":"/out/fetch.log","cve_path":"/out/cve.json"}"#,
+            )
+            .unwrap();
+            // Provide only the SBOM so seal_volume gets past
+            // result.json check but fails on the missing content dir.
+            fs::write(artifact_out.join("sbom.cdx.json"), b"{}").unwrap();
+            fs::write(artifact_out.join("fetch.log"), b"").unwrap();
+            fs::write(artifact_out.join("cve.json"), b"{}").unwrap();
+            Ok(BuilderArtifacts::InstallVolume {
+                volume_dir: artifact_out.to_path_buf(),
+                result_json_path: artifact_out.join("result.json"),
+            })
+        }
+    }
+    let err = install_app_deps(&fx.spec(), Some(&BadDriver)).expect_err("must fail");
+    assert!(
+        matches!(err, InstallError::SealFailed { .. }),
+        "got: {err:?}"
+    );
 }

--- a/crates/mvm-builder-init/Cargo.toml
+++ b/crates/mvm-builder-init/Cargo.toml
@@ -24,6 +24,13 @@ path = "src/main.rs"
 # workspace builds don't drag in the dep tree.
 nix = { version = "0.29", features = ["mount", "reboot"] }
 
+[dev-dependencies]
+# Test scratch dirs + JSON parsing for assertions against the
+# hand-rolled `InstallReport::to_json` output. Production builds
+# never see these — they live behind `cfg(test)` only.
+tempfile.workspace = true
+serde_json.workspace = true
+
 [lints]
 workspace = true
 

--- a/crates/mvm-builder-init/src/install.rs
+++ b/crates/mvm-builder-init/src/install.rs
@@ -1,0 +1,863 @@
+//! Install-pipeline runner. Plan 73 Followup B.2, ADR-047.
+//!
+//! Given an [`InstallSpec`] (parsed from `/job/install_spec.json`)
+//! and a job directory, run the per-language installer + the audit
+//! sidecars, then write `/job/result.json` describing the outcome.
+//!
+//! ## Pipeline
+//!
+//! For each language:
+//!
+//! 1. **Installer.** `uv pip install --no-deps --requirement
+//!    <lockfile> --target <content_dir>` (Python) or `pnpm install
+//!    --frozen-lockfile --dir <content_dir>` (Node). stdout + stderr
+//!    are tee'd to `<job_dir>/fetch.log` so every URL the installer
+//!    dialed is captured for the ADR-047 audit gate.
+//! 2. **SBOM.** `cyclonedx-py environment <content_dir>` (Python)
+//!    or `pnpm sbom --dir <content_dir>` (Node). Output written to
+//!    `<job_dir>/sbom.cdx.json`. **Optional gate**: if the tool
+//!    isn't on PATH, write a CycloneDX-1.5 empty-stub and log a
+//!    warning rather than fail the install. Hard-gating on missing
+//!    SBOM tools is a follow-on slice (B.2.x) once the builder VM
+//!    flake guarantees their presence.
+//! 3. **CVE scan.** `pip-audit --requirement <lockfile> --format
+//!    json` or `pnpm audit --json` against the populated content
+//!    dir. Same fallback as SBOM: missing tool → stub + warn.
+//! 4. **Result manifest.** `result.json` with the installer exit
+//!    code, sidecar paths, and per-sidecar success flags.
+//!
+//! ## Cross-platform
+//!
+//! The runner is cross-platform on purpose so unit tests can
+//! exercise the dispatch logic on macOS via shell stubs. Linux is
+//! where it runs in production (inside the libkrun builder VM);
+//! macOS is where contributors run `cargo test`. Both pin the same
+//! `InstallSpec` → command-line mapping so a tool-shape drift
+//! surfaces at test time, not at first boot inside the VM.
+//!
+//! The runner takes a `&dyn CommandRunner` so the same code path
+//! drives a real `Command::spawn` in production and an injected
+//! shell-stub in tests.
+
+use std::fs;
+use std::path::{Path, PathBuf};
+use std::process::{Command, Stdio};
+
+use crate::install_spec::{GateLevel, InstallSpec, Language};
+
+/// Subdir under `<job_dir>` that holds the installed payload. Same
+/// name as the canonical sealed-volume layout
+/// (`mvm_sdk::compile::deps_audit::FILE_CONTENT_DIR`) so the host
+/// can rename `<job_dir>` straight into a sealed volume without
+/// shuffling files. Mirrors that constant explicitly rather than
+/// re-exporting because `mvm-builder-init` doesn't depend on
+/// `mvm-sdk` (kept tiny per Plan 72 §W3 size budget).
+pub const CONTENT_SUBDIR: &str = "content";
+pub const SBOM_FILENAME: &str = "sbom.cdx.json";
+pub const FETCH_LOG_FILENAME: &str = "fetch.log";
+pub const CVE_FILENAME: &str = "cve.json";
+pub const RESULT_FILENAME: &str = "result.json";
+
+/// CycloneDX-1.5 empty stub. Emitted when the SBOM tool is missing
+/// from the builder VM PATH. ADR-047 §"Lifecycle gates" treats a
+/// stub SBOM as a `dev`-gate-only artifact; `prod` gating on a stub
+/// is wired in a follow-on slice (B.2.x).
+const SBOM_EMPTY_STUB: &str = r#"{"bomFormat":"CycloneDX","specVersion":"1.5","components":[]}"#;
+
+/// Minimal pip-audit / pnpm-audit empty stub. Same dev-vs-prod
+/// gating note as the SBOM stub.
+const CVE_EMPTY_STUB: &str = r#"{"results":[]}"#;
+
+/// Result of the install pipeline. Serialized to `result.json`
+/// inside the job dir; the host (`LibkrunBuilderVm::run_build`
+/// Install arm) reads it after the VM powers off.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct InstallReport {
+    pub installer_exit_code: i32,
+    pub sbom_emitted: bool,
+    pub cve_emitted: bool,
+    pub language: Language,
+    pub gate: GateLevel,
+    pub content_path: String,
+    pub sbom_path: String,
+    pub fetch_log_path: String,
+    pub cve_path: String,
+}
+
+impl InstallReport {
+    /// Hand-rolled JSON serializer — matches the style of
+    /// `mvm-builder-init::linux::write_result`. Keeps `serde_json`
+    /// out of the init binary's closure.
+    pub fn to_json(&self) -> String {
+        format!(
+            r#"{{"installer_exit_code":{exit},"sbom_emitted":{sbom},"cve_emitted":{cve},"language":"{lang}","gate":"{gate}","content_path":"{content}","sbom_path":"{sbom_path}","fetch_log_path":"{fetch}","cve_path":"{cve_path}"}}"#,
+            exit = self.installer_exit_code,
+            sbom = self.sbom_emitted,
+            cve = self.cve_emitted,
+            lang = self.language.as_str(),
+            gate = self.gate.as_str(),
+            content = json_escape(&self.content_path),
+            sbom_path = json_escape(&self.sbom_path),
+            fetch = json_escape(&self.fetch_log_path),
+            cve_path = json_escape(&self.cve_path),
+        )
+    }
+}
+
+/// Abstraction over the `Command::spawn`-and-tee dance so unit
+/// tests can inject shell stubs. Production callers use
+/// [`SystemCommandRunner`] which spawns real subprocesses.
+pub trait CommandRunner {
+    /// Run `program` with `args` (cwd: any working dir the runner
+    /// picks). Tee stdout + stderr to `log_path` if `Some`; ignore
+    /// them otherwise. Returns the child's exit code on clean exit,
+    /// or a string error otherwise (program not on PATH, spawn
+    /// failure, …).
+    ///
+    /// `extra_path` is prepended to the runner's `PATH` lookup —
+    /// production drives it from `MVM_INSTALL_TOOLS_PATH`; tests
+    /// hand it a tempdir full of shell stubs.
+    fn run(
+        &self,
+        program: &str,
+        args: &[&str],
+        log_path: Option<&Path>,
+        extra_path: Option<&Path>,
+    ) -> Result<i32, String>;
+
+    /// Whether `program` resolves on PATH (with `extra_path`
+    /// prepended). Used by the SBOM + CVE optional-gate paths to
+    /// fall back to a stub when the tool isn't installed.
+    fn is_available(&self, program: &str, extra_path: Option<&Path>) -> bool;
+}
+
+/// Real `Command`-backed runner. Spawns each command with the
+/// inherited environment plus `extra_path` prepended to `PATH`,
+/// tees combined stdout/stderr to `log_path`, and returns the
+/// child's exit code.
+///
+/// Tee semantics: we open `log_path` in append mode and pass it as
+/// the child's stdout+stderr (via `Stdio::from`). That captures
+/// every byte the installer wrote — including the URLs `uv` /
+/// `pnpm` print to stderr during fetch — into one merged log the
+/// host seals later.
+pub struct SystemCommandRunner;
+
+impl CommandRunner for SystemCommandRunner {
+    fn run(
+        &self,
+        program: &str,
+        args: &[&str],
+        log_path: Option<&Path>,
+        extra_path: Option<&Path>,
+    ) -> Result<i32, String> {
+        let mut cmd = Command::new(program);
+        cmd.args(args);
+        if let Some(extra) = extra_path {
+            let path_env = std::env::var_os("PATH").unwrap_or_default();
+            let mut prepended = std::ffi::OsString::from(extra);
+            if !path_env.is_empty() {
+                prepended.push(":");
+                prepended.push(&path_env);
+            }
+            cmd.env("PATH", prepended);
+        }
+
+        match log_path {
+            Some(path) => {
+                let f = fs::OpenOptions::new()
+                    .create(true)
+                    .append(true)
+                    .open(path)
+                    .map_err(|e| format!("open {} for log: {e}", path.display()))?;
+                let f_err = f
+                    .try_clone()
+                    .map_err(|e| format!("clone log handle for stderr: {e}"))?;
+                cmd.stdout(Stdio::from(f));
+                cmd.stderr(Stdio::from(f_err));
+            }
+            None => {
+                cmd.stdout(Stdio::null());
+                cmd.stderr(Stdio::null());
+            }
+        }
+
+        let status = cmd
+            .status()
+            .map_err(|e| format!("spawn `{program}`: {e}"))?;
+        Ok(status.code().unwrap_or(-1))
+    }
+
+    fn is_available(&self, program: &str, extra_path: Option<&Path>) -> bool {
+        let path_env = std::env::var_os("PATH").unwrap_or_default();
+        let mut paths: Vec<PathBuf> = Vec::new();
+        if let Some(extra) = extra_path {
+            paths.push(extra.to_path_buf());
+        }
+        for p in std::env::split_paths(&path_env) {
+            paths.push(p);
+        }
+        for dir in paths {
+            let candidate = dir.join(program);
+            if candidate.is_file() {
+                return true;
+            }
+        }
+        false
+    }
+}
+
+/// Errors from the install pipeline. The installer-exit-code path
+/// is not an error — we always emit `result.json` so the host can
+/// distinguish "installer ran and failed" from "init crashed
+/// before it could run."
+#[derive(Debug)]
+pub enum InstallError {
+    /// Directory create / file write / spec parse failed before
+    /// any installer could run.
+    Io(String),
+    /// Installer binary (`uv` / `pnpm`) wasn't on PATH at all.
+    /// Distinct from a non-zero exit (which lands in
+    /// `installer_exit_code`); a missing installer is a builder-VM
+    /// configuration bug, not a user's lockfile issue.
+    InstallerMissing { program: String },
+}
+
+impl std::fmt::Display for InstallError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::Io(s) => write!(f, "install IO: {s}"),
+            Self::InstallerMissing { program } => {
+                write!(f, "installer `{program}` not on PATH inside the builder VM")
+            }
+        }
+    }
+}
+
+impl std::error::Error for InstallError {}
+
+/// Public entry point. Run the install pipeline for `spec`,
+/// writing the four sealed-volume artifacts (`content/`, SBOM,
+/// fetch log, CVE) into `out_dir` and the install report into
+/// `job_dir/result.json`. `runner` spawns each subprocess;
+/// `extra_path` flows into the runner so tests can stub binaries.
+///
+/// Splitting `out_dir` from `job_dir` keeps the host's mount
+/// layout honest: the host bind-mounts the (writable) sealed-
+/// volume directory at `/out` and the per-job scratch at `/job`.
+/// Co-locating the sidecars in `/out` lets the host rename the
+/// whole directory into the deps cache in one syscall, without
+/// shuffling files across mount points.
+pub fn run_install(
+    spec: &InstallSpec,
+    job_dir: &Path,
+    out_dir: &Path,
+    runner: &dyn CommandRunner,
+    extra_path: Option<&Path>,
+) -> Result<InstallReport, InstallError> {
+    fs::create_dir_all(out_dir)
+        .map_err(|e| InstallError::Io(format!("create {}: {e}", out_dir.display())))?;
+    let content_dir = out_dir.join(CONTENT_SUBDIR);
+    fs::create_dir_all(&content_dir)
+        .map_err(|e| InstallError::Io(format!("create {}: {e}", content_dir.display())))?;
+    let fetch_log = out_dir.join(FETCH_LOG_FILENAME);
+    let sbom = out_dir.join(SBOM_FILENAME);
+    let cve = out_dir.join(CVE_FILENAME);
+    fs::create_dir_all(job_dir)
+        .map_err(|e| InstallError::Io(format!("create {}: {e}", job_dir.display())))?;
+
+    // Truncate fetch.log so a retry doesn't append onto a stale
+    // half-written log. The installer step appends; if we skipped
+    // this we'd accumulate logs across re-runs of the same job dir.
+    fs::write(&fetch_log, b"")
+        .map_err(|e| InstallError::Io(format!("truncate {}: {e}", fetch_log.display())))?;
+
+    let lockfile_in_vm = format!("{}/{}", spec.source_mount, spec.lockfile_relative_path);
+    let installer = installer_for(spec.language);
+    if !runner.is_available(installer.program, extra_path) {
+        return Err(InstallError::InstallerMissing {
+            program: installer.program.to_string(),
+        });
+    }
+
+    let installer_args = installer.args(&lockfile_in_vm, &content_dir);
+    let installer_args_refs: Vec<&str> = installer_args.iter().map(|s| s.as_str()).collect();
+    let installer_exit_code = runner
+        .run(
+            installer.program,
+            &installer_args_refs,
+            Some(&fetch_log),
+            extra_path,
+        )
+        .map_err(InstallError::Io)?;
+
+    // Best-effort SBOM + CVE; the optional-gate fallback emits a
+    // CycloneDX-1.5 empty stub if the tool isn't available. The
+    // host's audit-gate slice (B.3) decides whether a stub is
+    // acceptable for `--prod`; today both gate levels accept it
+    // with a warning.
+    let sbom_emitted = run_sbom(spec.language, &content_dir, &sbom, runner, extra_path);
+    let cve_emitted = run_cve(spec.language, &lockfile_in_vm, &cve, runner, extra_path);
+
+    Ok(InstallReport {
+        installer_exit_code,
+        sbom_emitted,
+        cve_emitted,
+        language: spec.language,
+        gate: spec.gate,
+        content_path: content_dir.to_string_lossy().into_owned(),
+        sbom_path: sbom.to_string_lossy().into_owned(),
+        fetch_log_path: fetch_log.to_string_lossy().into_owned(),
+        cve_path: cve.to_string_lossy().into_owned(),
+    })
+}
+
+/// Per-language installer dispatch table. Returned as a value
+/// rather than a const so the args list can interpolate the
+/// caller's `lockfile_in_vm` / `content_dir` strings without
+/// allocations leaking through the surface.
+struct Installer {
+    program: &'static str,
+}
+
+fn installer_for(language: Language) -> Installer {
+    match language {
+        // `uv pip install --no-deps --requirements <lock> --target
+        // <dir>` is the documented "install a lockfile into a
+        // target directory without writing the source tree"
+        // invocation (uv docs §"Installing into a target
+        // directory"). `--no-deps` skips transitive resolution
+        // because the lockfile is already fully resolved.
+        Language::Python => Installer { program: "uv" },
+        // `pnpm install --frozen-lockfile --dir <dir>` installs the
+        // lockfile-pinned tree into `<dir>/node_modules` without
+        // mutating the lockfile or fetching anything not in it.
+        // `--prefix` is the older flag; `--dir` is the documented
+        // current one.
+        Language::Node => Installer { program: "pnpm" },
+    }
+}
+
+impl Installer {
+    fn args(&self, lockfile_in_vm: &str, content_dir: &Path) -> Vec<String> {
+        match self.program {
+            "uv" => vec![
+                "pip".to_string(),
+                "install".to_string(),
+                "--no-deps".to_string(),
+                "--requirements".to_string(),
+                lockfile_in_vm.to_string(),
+                "--target".to_string(),
+                content_dir.to_string_lossy().into_owned(),
+            ],
+            "pnpm" => vec![
+                "install".to_string(),
+                "--frozen-lockfile".to_string(),
+                "--dir".to_string(),
+                content_dir.to_string_lossy().into_owned(),
+            ],
+            _ => Vec::new(),
+        }
+    }
+}
+
+/// Run the SBOM emitter, returning `true` if the tool ran cleanly,
+/// `false` if we fell back to the stub. Side effect: writes the
+/// SBOM (real or stub) to `sbom_path`.
+fn run_sbom(
+    language: Language,
+    content_dir: &Path,
+    sbom_path: &Path,
+    runner: &dyn CommandRunner,
+    extra_path: Option<&Path>,
+) -> bool {
+    let (program, args): (&str, Vec<String>) = match language {
+        Language::Python => (
+            "cyclonedx-py",
+            vec![
+                "environment".to_string(),
+                content_dir.to_string_lossy().into_owned(),
+                "--output-file".to_string(),
+                sbom_path.to_string_lossy().into_owned(),
+            ],
+        ),
+        Language::Node => (
+            "pnpm",
+            vec![
+                "sbom".to_string(),
+                "--dir".to_string(),
+                content_dir.to_string_lossy().into_owned(),
+                "--output".to_string(),
+                sbom_path.to_string_lossy().into_owned(),
+            ],
+        ),
+    };
+    if !runner.is_available(program, extra_path) {
+        eprintln!(
+            "mvm-builder-init: SBOM tool `{program}` not on PATH — writing CycloneDX empty stub. \
+             B.2.x will hard-gate this once the builder VM flake guarantees the tool."
+        );
+        let _ = fs::write(sbom_path, SBOM_EMPTY_STUB);
+        return false;
+    }
+    let args_refs: Vec<&str> = args.iter().map(|s| s.as_str()).collect();
+    match runner.run(program, &args_refs, None, extra_path) {
+        Ok(0) => true,
+        Ok(code) => {
+            eprintln!(
+                "mvm-builder-init: SBOM tool `{program}` exited {code} — writing CycloneDX stub"
+            );
+            let _ = fs::write(sbom_path, SBOM_EMPTY_STUB);
+            false
+        }
+        Err(e) => {
+            eprintln!("mvm-builder-init: SBOM tool spawn failed: {e}");
+            let _ = fs::write(sbom_path, SBOM_EMPTY_STUB);
+            false
+        }
+    }
+}
+
+/// Same pattern as [`run_sbom`] for the CVE-scan side.
+fn run_cve(
+    language: Language,
+    lockfile_in_vm: &str,
+    cve_path: &Path,
+    runner: &dyn CommandRunner,
+    extra_path: Option<&Path>,
+) -> bool {
+    let (program, args): (&str, Vec<String>) = match language {
+        Language::Python => (
+            "pip-audit",
+            vec![
+                "--requirement".to_string(),
+                lockfile_in_vm.to_string(),
+                "--format".to_string(),
+                "json".to_string(),
+                "--output".to_string(),
+                cve_path.to_string_lossy().into_owned(),
+            ],
+        ),
+        Language::Node => (
+            "pnpm",
+            vec![
+                "audit".to_string(),
+                "--json".to_string(),
+                "--output".to_string(),
+                cve_path.to_string_lossy().into_owned(),
+            ],
+        ),
+    };
+    if !runner.is_available(program, extra_path) {
+        eprintln!(
+            "mvm-builder-init: CVE tool `{program}` not on PATH — writing empty-results stub. \
+             B.2.x will hard-gate this once the builder VM flake guarantees the tool."
+        );
+        let _ = fs::write(cve_path, CVE_EMPTY_STUB);
+        return false;
+    }
+    let args_refs: Vec<&str> = args.iter().map(|s| s.as_str()).collect();
+    match runner.run(program, &args_refs, None, extra_path) {
+        // `pip-audit` and `pnpm audit` both exit nonzero when they
+        // *find* vulnerabilities — that's the whole point of the
+        // scan. The output file still represents a successful
+        // emission. Treat any "ran without crashing" as a success
+        // (the host audit gate inspects the JSON shape, not the
+        // exit code). Anything truly broken (spawn failure, signal
+        // termination) propagates as a stub fallback.
+        Ok(_code) => cve_path.is_file(),
+        Err(e) => {
+            eprintln!("mvm-builder-init: CVE tool spawn failed: {e}");
+            let _ = fs::write(cve_path, CVE_EMPTY_STUB);
+            false
+        }
+    }
+}
+
+/// Same minimal JSON escaper as `linux::json_escape` (kept local so
+/// `install` doesn't pull from a Linux-only module). Handles the
+/// RFC 8259 §7 must-escape set; UTF-8 passes through.
+fn json_escape(s: &str) -> String {
+    let mut out = String::with_capacity(s.len());
+    for c in s.chars() {
+        match c {
+            '"' => out.push_str("\\\""),
+            '\\' => out.push_str("\\\\"),
+            '\n' => out.push_str("\\n"),
+            '\r' => out.push_str("\\r"),
+            '\t' => out.push_str("\\t"),
+            c if (c as u32) < 0x20 => {
+                out.push_str(&format!("\\u{:04x}", c as u32));
+            }
+            c => out.push(c),
+        }
+    }
+    out
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::cell::RefCell;
+    use std::sync::Mutex;
+
+    fn ok_spec() -> InstallSpec {
+        InstallSpec {
+            language: Language::Python,
+            lockfile_relative_path: "uv.lock".to_string(),
+            source_mount: "/work".to_string(),
+            gate: GateLevel::Dev,
+        }
+    }
+
+    #[test]
+    fn report_to_json_round_trips_through_serde_json() {
+        // We hand-roll the writer, but the contract is "valid JSON
+        // a serde_json reader can parse." Use serde_json::Value
+        // (test-only, via the workspace dev-deps) to assert that.
+        let report = InstallReport {
+            installer_exit_code: 0,
+            sbom_emitted: true,
+            cve_emitted: false,
+            language: Language::Python,
+            gate: GateLevel::Prod,
+            content_path: "/job/content".to_string(),
+            sbom_path: "/job/sbom.cdx.json".to_string(),
+            fetch_log_path: "/job/fetch.log".to_string(),
+            cve_path: "/job/cve.json".to_string(),
+        };
+        let body = report.to_json();
+        let parsed: serde_json::Value = serde_json::from_str(&body).expect("valid JSON");
+        assert_eq!(parsed["installer_exit_code"], 0);
+        assert_eq!(parsed["sbom_emitted"], true);
+        assert_eq!(parsed["cve_emitted"], false);
+        assert_eq!(parsed["language"], "python");
+        assert_eq!(parsed["gate"], "prod");
+        assert_eq!(parsed["content_path"], "/job/content");
+    }
+
+    #[test]
+    fn report_json_escapes_quotes_in_paths() {
+        let report = InstallReport {
+            installer_exit_code: 0,
+            sbom_emitted: true,
+            cve_emitted: true,
+            language: Language::Node,
+            gate: GateLevel::Dev,
+            content_path: r#"/job/content "weird""#.to_string(),
+            sbom_path: "/job/sbom.cdx.json".to_string(),
+            fetch_log_path: "/job/fetch.log".to_string(),
+            cve_path: "/job/cve.json".to_string(),
+        };
+        let body = report.to_json();
+        let parsed: serde_json::Value = serde_json::from_str(&body).expect("valid JSON");
+        assert_eq!(parsed["content_path"], r#"/job/content "weird""#);
+    }
+
+    /// Record of every command the stub runner saw. Per-call entry
+    /// has the program name + arg list + whether log_path was set.
+    /// Tests assert the right sequence of invocations.
+    #[derive(Debug, Clone, PartialEq, Eq)]
+    struct Invocation {
+        program: String,
+        args: Vec<String>,
+        logged: bool,
+    }
+
+    struct StubRunner {
+        // Set of program names the runner pretends are installed.
+        available: Vec<String>,
+        // Exit code each program returns when invoked. Defaults to
+        // 0 for any not in the table.
+        exits: Vec<(String, i32)>,
+        // Captured invocations. RefCell so the test stays
+        // `&dyn CommandRunner`; Mutex would be overkill (one-
+        // threaded test runner).
+        calls: Mutex<RefCell<Vec<Invocation>>>,
+    }
+
+    impl StubRunner {
+        fn new(available: &[&str]) -> Self {
+            Self {
+                available: available.iter().map(|s| s.to_string()).collect(),
+                exits: Vec::new(),
+                calls: Mutex::new(RefCell::new(Vec::new())),
+            }
+        }
+
+        fn with_exit(mut self, program: &str, code: i32) -> Self {
+            self.exits.push((program.to_string(), code));
+            self
+        }
+
+        fn calls(&self) -> Vec<Invocation> {
+            self.calls.lock().unwrap().borrow().clone()
+        }
+
+        fn exit_for(&self, program: &str) -> i32 {
+            self.exits
+                .iter()
+                .find(|(p, _)| p == program)
+                .map(|(_, c)| *c)
+                .unwrap_or(0)
+        }
+    }
+
+    impl CommandRunner for StubRunner {
+        fn run(
+            &self,
+            program: &str,
+            args: &[&str],
+            log_path: Option<&Path>,
+            _extra_path: Option<&Path>,
+        ) -> Result<i32, String> {
+            self.calls.lock().unwrap().borrow_mut().push(Invocation {
+                program: program.to_string(),
+                args: args.iter().map(|s| s.to_string()).collect(),
+                logged: log_path.is_some(),
+            });
+            // Make the side-effect of writing real output for SBOM
+            // / CVE tools explicit — without it the test for
+            // `--output <path>` flags wouldn't see a file land.
+            // We sniff for `--output` / `--output-file` and write
+            // a placeholder so downstream checks see a real file.
+            for (i, a) in args.iter().enumerate() {
+                if (*a == "--output" || *a == "--output-file")
+                    && let Some(path) = args.get(i + 1)
+                {
+                    let _ = fs::write(path, br#"{"stub":true}"#);
+                }
+            }
+            // Tee log behavior: write a marker into log_path so
+            // tests can assert tee'd capture happened.
+            if let Some(path) = log_path {
+                let _ = fs::OpenOptions::new()
+                    .create(true)
+                    .append(true)
+                    .open(path)
+                    .and_then(|mut f| {
+                        use std::io::Write;
+                        writeln!(f, "STUB: {program}")
+                    });
+            }
+            Ok(self.exit_for(program))
+        }
+
+        fn is_available(&self, program: &str, _extra_path: Option<&Path>) -> bool {
+            self.available.iter().any(|p| p == program)
+        }
+    }
+
+    #[test]
+    fn python_happy_path_runs_uv_then_sidecars() {
+        let tmp = tempfile::tempdir().unwrap();
+        let runner = StubRunner::new(&["uv", "cyclonedx-py", "pip-audit"]);
+        let report = run_install(
+            &ok_spec(),
+            &tmp.path().join("job"),
+            tmp.path(),
+            &runner,
+            None,
+        )
+        .unwrap();
+        assert_eq!(report.installer_exit_code, 0);
+        assert!(report.sbom_emitted);
+        assert!(report.cve_emitted);
+        assert!(report.content_path.ends_with("/content"));
+
+        let calls = runner.calls();
+        // First call: uv pip install --no-deps --requirements
+        // /work/uv.lock --target <content_dir>.
+        assert_eq!(calls[0].program, "uv");
+        assert_eq!(calls[0].args[0], "pip");
+        assert_eq!(calls[0].args[1], "install");
+        assert!(calls[0].args.contains(&"--no-deps".to_string()));
+        assert!(calls[0].args.contains(&"/work/uv.lock".to_string()));
+        assert!(calls[0].logged, "installer must tee to fetch.log");
+
+        // Subsequent: cyclonedx-py + pip-audit.
+        assert!(calls.iter().any(|c| c.program == "cyclonedx-py"));
+        assert!(calls.iter().any(|c| c.program == "pip-audit"));
+
+        // Artifacts on disk.
+        assert!(tmp.path().join(CONTENT_SUBDIR).is_dir());
+        assert!(tmp.path().join(FETCH_LOG_FILENAME).is_file());
+        assert!(tmp.path().join(SBOM_FILENAME).is_file());
+        assert!(tmp.path().join(CVE_FILENAME).is_file());
+    }
+
+    #[test]
+    fn node_happy_path_runs_pnpm() {
+        let tmp = tempfile::tempdir().unwrap();
+        let spec = InstallSpec {
+            language: Language::Node,
+            lockfile_relative_path: "pnpm-lock.yaml".to_string(),
+            source_mount: "/work".to_string(),
+            gate: GateLevel::Prod,
+        };
+        let runner = StubRunner::new(&["pnpm"]);
+        let report =
+            run_install(&spec, &tmp.path().join("job"), tmp.path(), &runner, None).unwrap();
+        assert_eq!(report.language, Language::Node);
+        assert_eq!(report.gate, GateLevel::Prod);
+        let calls = runner.calls();
+        assert_eq!(calls[0].program, "pnpm");
+        assert_eq!(calls[0].args[0], "install");
+        assert!(calls[0].args.contains(&"--frozen-lockfile".to_string()));
+    }
+
+    #[test]
+    fn missing_installer_returns_typed_error() {
+        let tmp = tempfile::tempdir().unwrap();
+        // "uv" absent → InstallerMissing.
+        let runner = StubRunner::new(&["cyclonedx-py", "pip-audit"]);
+        let err = run_install(
+            &ok_spec(),
+            &tmp.path().join("job"),
+            tmp.path(),
+            &runner,
+            None,
+        )
+        .unwrap_err();
+        match err {
+            InstallError::InstallerMissing { program } => assert_eq!(program, "uv"),
+            other => panic!("wrong variant: {other:?}"),
+        }
+    }
+
+    #[test]
+    fn nonzero_installer_exit_lands_in_report() {
+        // Installer ran but failed — the report carries the exit
+        // code; the host treats nonzero as a hard failure. Critical
+        // distinction from the missing-installer case.
+        let tmp = tempfile::tempdir().unwrap();
+        let runner = StubRunner::new(&["uv", "cyclonedx-py", "pip-audit"]).with_exit("uv", 1);
+        let report = run_install(
+            &ok_spec(),
+            &tmp.path().join("job"),
+            tmp.path(),
+            &runner,
+            None,
+        )
+        .unwrap();
+        assert_eq!(report.installer_exit_code, 1);
+        // Sidecars still run — the SBOM / CVE captures empty
+        // state for the partial install, which is informative.
+        assert!(report.sbom_emitted);
+    }
+
+    #[test]
+    fn missing_sbom_tool_emits_stub_and_logs_warning() {
+        let tmp = tempfile::tempdir().unwrap();
+        // No `cyclonedx-py`.
+        let runner = StubRunner::new(&["uv", "pip-audit"]);
+        let report = run_install(
+            &ok_spec(),
+            &tmp.path().join("job"),
+            tmp.path(),
+            &runner,
+            None,
+        )
+        .unwrap();
+        assert!(
+            !report.sbom_emitted,
+            "stub fallback marks sbom_emitted=false"
+        );
+        let body = fs::read_to_string(tmp.path().join(SBOM_FILENAME)).unwrap();
+        // Stub matches the CycloneDX-1.5 empty shape.
+        let parsed: serde_json::Value = serde_json::from_str(&body).unwrap();
+        assert_eq!(parsed["bomFormat"], "CycloneDX");
+        assert_eq!(parsed["specVersion"], "1.5");
+        assert!(parsed["components"].as_array().unwrap().is_empty());
+    }
+
+    #[test]
+    fn missing_cve_tool_emits_stub() {
+        let tmp = tempfile::tempdir().unwrap();
+        let runner = StubRunner::new(&["uv", "cyclonedx-py"]);
+        let report = run_install(
+            &ok_spec(),
+            &tmp.path().join("job"),
+            tmp.path(),
+            &runner,
+            None,
+        )
+        .unwrap();
+        assert!(!report.cve_emitted);
+        let body = fs::read_to_string(tmp.path().join(CVE_FILENAME)).unwrap();
+        let parsed: serde_json::Value = serde_json::from_str(&body).unwrap();
+        assert!(parsed["results"].as_array().unwrap().is_empty());
+    }
+
+    #[test]
+    fn pnpm_node_spec_dispatches_pnpm_sbom_and_audit() {
+        let tmp = tempfile::tempdir().unwrap();
+        let spec = InstallSpec {
+            language: Language::Node,
+            lockfile_relative_path: "pnpm-lock.yaml".to_string(),
+            source_mount: "/work".to_string(),
+            gate: GateLevel::Dev,
+        };
+        let runner = StubRunner::new(&["pnpm"]);
+        let report =
+            run_install(&spec, &tmp.path().join("job"), tmp.path(), &runner, None).unwrap();
+        assert!(report.sbom_emitted);
+        assert!(report.cve_emitted);
+        let calls = runner.calls();
+        // Both the SBOM and the audit invocation hit pnpm — three
+        // pnpm calls total (install, sbom, audit).
+        let pnpm_invocations: Vec<&Invocation> =
+            calls.iter().filter(|c| c.program == "pnpm").collect();
+        assert_eq!(pnpm_invocations.len(), 3, "calls: {calls:?}");
+        let subs: Vec<&str> = pnpm_invocations
+            .iter()
+            .map(|c| c.args[0].as_str())
+            .collect();
+        assert!(subs.contains(&"install"));
+        assert!(subs.contains(&"sbom"));
+        assert!(subs.contains(&"audit"));
+    }
+
+    #[test]
+    fn fetch_log_is_truncated_per_run() {
+        // Two runs against the same job dir must not concatenate
+        // their fetch logs. The runner truncates the log before
+        // dispatch so a retry produces a fresh transcript.
+        let tmp = tempfile::tempdir().unwrap();
+        let runner = StubRunner::new(&["uv", "cyclonedx-py", "pip-audit"]);
+        let _ = run_install(
+            &ok_spec(),
+            &tmp.path().join("job"),
+            tmp.path(),
+            &runner,
+            None,
+        )
+        .unwrap();
+        let first = fs::read_to_string(tmp.path().join(FETCH_LOG_FILENAME)).unwrap();
+        let _ = run_install(
+            &ok_spec(),
+            &tmp.path().join("job"),
+            tmp.path(),
+            &runner,
+            None,
+        )
+        .unwrap();
+        let second = fs::read_to_string(tmp.path().join(FETCH_LOG_FILENAME)).unwrap();
+        // Truncation means we don't see the first run's content
+        // duplicated in the second.
+        let first_marker = "STUB: uv";
+        assert_eq!(
+            second.matches(first_marker).count(),
+            first.matches(first_marker).count(),
+            "log was not truncated between runs"
+        );
+    }
+
+    #[test]
+    fn json_escape_handles_quotes_backslashes_controls() {
+        assert_eq!(json_escape("a\"b"), "a\\\"b");
+        assert_eq!(json_escape("a\\b"), "a\\\\b");
+        assert_eq!(json_escape("a\nb"), "a\\nb");
+        assert_eq!(json_escape("\x01"), "\\u0001");
+    }
+}

--- a/crates/mvm-builder-init/src/install_spec.rs
+++ b/crates/mvm-builder-init/src/install_spec.rs
@@ -1,0 +1,481 @@
+//! Install-spec parsing for the application-deps install pipeline
+//! (Plan 73 Followup B.2, ADR-047).
+//!
+//! The host stages a JSON spec at `/job/install_spec.json` and
+//! `mvm-builder-init`, at PID 1, parses it and dispatches the
+//! per-language install protocol. This module is cross-platform on
+//! purpose — the install-spec shape is part of the host↔guest wire
+//! contract and the parser sees coverage from `cargo test` on every
+//! developer host, not just the Linux cross-compile. The actual
+//! installer dispatch (which `Command::spawn`s `uv` / `pnpm` etc.)
+//! lives in `linux::install` and is gated to the in-VM target.
+//!
+//! ## Wire shape
+//!
+//! ```json
+//! {
+//!   "language": "python" | "node",
+//!   "lockfile_relative_path": "uv.lock",
+//!   "source_mount": "/work",
+//!   "gate": "prod" | "dev"
+//! }
+//! ```
+//!
+//! Hand-rolled parser rather than pulling `serde_json` in: the
+//! Plan 72 W3 size budget caps the init binary at ≤ 1.5 MiB on
+//! aarch64-linux. The shape is closed (four fields, two enums) and
+//! the parser sees ~zero churn — adding `serde_json` for one
+//! load-bearing read isn't worth ~150 KiB of binary growth.
+
+use std::fmt;
+
+/// Which language ecosystem to install for. Mirrors
+/// `mvm_build::app_deps::Language` on the host side, with the same
+/// wire tokens, so the spec round-trips unchanged.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum Language {
+    Python,
+    Node,
+}
+
+impl Language {
+    pub fn as_str(&self) -> &'static str {
+        match self {
+            Self::Python => "python",
+            Self::Node => "node",
+        }
+    }
+}
+
+/// Audit-gate strictness. Mirrors `mvm_build::app_deps::GateLevel`.
+/// The builder VM honors this when running the SBOM + CVE side
+/// pipeline (it doesn't fail the install on missing optional
+/// gates today; ADR-047 §"Lifecycle gates" formalizes the strict
+/// mode in a follow-on slice).
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum GateLevel {
+    Dev,
+    Prod,
+}
+
+impl GateLevel {
+    pub fn as_str(&self) -> &'static str {
+        match self {
+            Self::Dev => "dev",
+            Self::Prod => "prod",
+        }
+    }
+}
+
+/// Parsed install spec. Fields use plain `String` rather than typed
+/// paths so the spec stays portable across the host (which staged
+/// it from `LibkrunBuilderVm`) and the guest (which interprets it
+/// against in-VM mounts).
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct InstallSpec {
+    pub language: Language,
+    pub lockfile_relative_path: String,
+    pub source_mount: String,
+    pub gate: GateLevel,
+}
+
+#[derive(Debug)]
+pub enum SpecError {
+    /// JSON wasn't an object or had a structural defect (unbalanced
+    /// braces, trailing garbage, …).
+    Malformed(String),
+    /// A required key was missing.
+    MissingField(&'static str),
+    /// A field had the wrong type or an out-of-enum value.
+    InvalidField { field: &'static str, value: String },
+}
+
+impl fmt::Display for SpecError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::Malformed(why) => write!(f, "install_spec.json is malformed: {why}"),
+            Self::MissingField(name) => {
+                write!(f, "install_spec.json is missing required field `{name}`")
+            }
+            Self::InvalidField { field, value } => {
+                write!(
+                    f,
+                    "install_spec.json field `{field}` has invalid value `{value}`"
+                )
+            }
+        }
+    }
+}
+
+impl std::error::Error for SpecError {}
+
+/// Parse the spec JSON from a raw byte slice. Accepts only the
+/// closed shape documented above; any unknown top-level key fails
+/// closed (`Malformed`) so a future field-name typo on the host
+/// surfaces immediately rather than being silently ignored.
+///
+/// Hand-rolled minimal JSON parser — supports the exact subset the
+/// install spec needs:
+///
+/// - Top-level object `{ ... }`.
+/// - String values (`"..."`) with backslash escapes (`\"`, `\\`,
+///   `\n`, `\r`, `\t`).
+/// - No nested objects, arrays, numbers, booleans, or nulls (the
+///   spec doesn't use them).
+/// - Insignificant whitespace anywhere.
+pub fn parse(bytes: &[u8]) -> Result<InstallSpec, SpecError> {
+    let text =
+        std::str::from_utf8(bytes).map_err(|e| SpecError::Malformed(format!("not UTF-8: {e}")))?;
+    let pairs = parse_top_object(text)?;
+
+    let mut language: Option<Language> = None;
+    let mut lockfile: Option<String> = None;
+    let mut source_mount: Option<String> = None;
+    let mut gate: Option<GateLevel> = None;
+
+    for (key, value) in pairs {
+        match key.as_str() {
+            "language" => {
+                language = Some(match value.as_str() {
+                    "python" => Language::Python,
+                    "node" => Language::Node,
+                    other => {
+                        return Err(SpecError::InvalidField {
+                            field: "language",
+                            value: other.to_string(),
+                        });
+                    }
+                });
+            }
+            "lockfile_relative_path" => {
+                if value.is_empty() {
+                    return Err(SpecError::InvalidField {
+                        field: "lockfile_relative_path",
+                        value: value.clone(),
+                    });
+                }
+                lockfile = Some(value);
+            }
+            "source_mount" => {
+                if value.is_empty() {
+                    return Err(SpecError::InvalidField {
+                        field: "source_mount",
+                        value: value.clone(),
+                    });
+                }
+                source_mount = Some(value);
+            }
+            "gate" => {
+                gate = Some(match value.as_str() {
+                    "dev" => GateLevel::Dev,
+                    "prod" => GateLevel::Prod,
+                    other => {
+                        return Err(SpecError::InvalidField {
+                            field: "gate",
+                            value: other.to_string(),
+                        });
+                    }
+                });
+            }
+            other => {
+                return Err(SpecError::Malformed(format!(
+                    "unknown top-level field `{other}`"
+                )));
+            }
+        }
+    }
+
+    Ok(InstallSpec {
+        language: language.ok_or(SpecError::MissingField("language"))?,
+        lockfile_relative_path: lockfile
+            .ok_or(SpecError::MissingField("lockfile_relative_path"))?,
+        source_mount: source_mount.ok_or(SpecError::MissingField("source_mount"))?,
+        gate: gate.ok_or(SpecError::MissingField("gate"))?,
+    })
+}
+
+/// Parse a top-level JSON object into `(key, value)` pairs of string
+/// → string. The closed install-spec shape has only string fields,
+/// so this is sufficient.
+fn parse_top_object(text: &str) -> Result<Vec<(String, String)>, SpecError> {
+    let mut cur = Cursor::new(text);
+    cur.skip_ws();
+    cur.expect('{')?;
+    let mut pairs = Vec::new();
+    cur.skip_ws();
+    if cur.peek() == Some('}') {
+        cur.advance();
+        cur.skip_ws();
+        if cur.peek().is_some() {
+            return Err(SpecError::Malformed(
+                "trailing content after closing brace".to_string(),
+            ));
+        }
+        return Ok(pairs);
+    }
+    loop {
+        cur.skip_ws();
+        let key = cur.parse_string()?;
+        cur.skip_ws();
+        cur.expect(':')?;
+        cur.skip_ws();
+        let value = cur.parse_string()?;
+        pairs.push((key, value));
+        cur.skip_ws();
+        match cur.peek() {
+            Some(',') => {
+                cur.advance();
+            }
+            Some('}') => {
+                cur.advance();
+                cur.skip_ws();
+                if cur.peek().is_some() {
+                    return Err(SpecError::Malformed(
+                        "trailing content after closing brace".to_string(),
+                    ));
+                }
+                return Ok(pairs);
+            }
+            Some(c) => {
+                return Err(SpecError::Malformed(format!(
+                    "expected ',' or '}}' after value, got '{c}'"
+                )));
+            }
+            None => {
+                return Err(SpecError::Malformed(
+                    "unexpected end of input inside object".to_string(),
+                ));
+            }
+        }
+    }
+}
+
+struct Cursor<'a> {
+    src: &'a str,
+    idx: usize,
+}
+
+impl<'a> Cursor<'a> {
+    fn new(src: &'a str) -> Self {
+        Self { src, idx: 0 }
+    }
+
+    fn peek(&self) -> Option<char> {
+        self.src[self.idx..].chars().next()
+    }
+
+    fn advance(&mut self) {
+        if let Some(c) = self.peek() {
+            self.idx += c.len_utf8();
+        }
+    }
+
+    fn skip_ws(&mut self) {
+        while let Some(c) = self.peek() {
+            if c.is_whitespace() {
+                self.advance();
+            } else {
+                break;
+            }
+        }
+    }
+
+    fn expect(&mut self, c: char) -> Result<(), SpecError> {
+        match self.peek() {
+            Some(got) if got == c => {
+                self.advance();
+                Ok(())
+            }
+            Some(got) => Err(SpecError::Malformed(format!("expected '{c}', got '{got}'"))),
+            None => Err(SpecError::Malformed(format!(
+                "expected '{c}', got end of input"
+            ))),
+        }
+    }
+
+    fn parse_string(&mut self) -> Result<String, SpecError> {
+        self.expect('"')?;
+        let mut out = String::new();
+        loop {
+            match self.peek() {
+                Some('"') => {
+                    self.advance();
+                    return Ok(out);
+                }
+                Some('\\') => {
+                    self.advance();
+                    match self.peek() {
+                        Some('"') => out.push('"'),
+                        Some('\\') => out.push('\\'),
+                        Some('/') => out.push('/'),
+                        Some('n') => out.push('\n'),
+                        Some('r') => out.push('\r'),
+                        Some('t') => out.push('\t'),
+                        Some(c) => {
+                            return Err(SpecError::Malformed(format!(
+                                "unsupported escape sequence `\\{c}`"
+                            )));
+                        }
+                        None => {
+                            return Err(SpecError::Malformed(
+                                "string ended after backslash".to_string(),
+                            ));
+                        }
+                    }
+                    self.advance();
+                }
+                Some(c) => {
+                    out.push(c);
+                    self.advance();
+                }
+                None => {
+                    return Err(SpecError::Malformed(
+                        "string was not terminated".to_string(),
+                    ));
+                }
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn ok_spec() -> &'static str {
+        r#"{
+            "language": "python",
+            "lockfile_relative_path": "uv.lock",
+            "source_mount": "/work",
+            "gate": "dev"
+        }"#
+    }
+
+    #[test]
+    fn parses_minimal_python_spec() {
+        let spec = parse(ok_spec().as_bytes()).unwrap();
+        assert_eq!(spec.language, Language::Python);
+        assert_eq!(spec.lockfile_relative_path, "uv.lock");
+        assert_eq!(spec.source_mount, "/work");
+        assert_eq!(spec.gate, GateLevel::Dev);
+    }
+
+    #[test]
+    fn parses_node_prod_spec() {
+        let body = r#"{"language":"node","lockfile_relative_path":"pnpm-lock.yaml","source_mount":"/work","gate":"prod"}"#;
+        let spec = parse(body.as_bytes()).unwrap();
+        assert_eq!(spec.language, Language::Node);
+        assert_eq!(spec.gate, GateLevel::Prod);
+    }
+
+    #[test]
+    fn rejects_unknown_language() {
+        let body = r#"{"language":"ruby","lockfile_relative_path":"Gemfile.lock","source_mount":"/work","gate":"dev"}"#;
+        let err = parse(body.as_bytes()).unwrap_err();
+        match err {
+            SpecError::InvalidField { field, value } => {
+                assert_eq!(field, "language");
+                assert_eq!(value, "ruby");
+            }
+            other => panic!("wrong variant: {other:?}"),
+        }
+    }
+
+    #[test]
+    fn rejects_unknown_gate() {
+        let body = r#"{"language":"python","lockfile_relative_path":"uv.lock","source_mount":"/work","gate":"strict"}"#;
+        let err = parse(body.as_bytes()).unwrap_err();
+        assert!(matches!(err, SpecError::InvalidField { field: "gate", .. }));
+    }
+
+    #[test]
+    fn rejects_missing_language() {
+        let body = r#"{"lockfile_relative_path":"uv.lock","source_mount":"/work","gate":"dev"}"#;
+        let err = parse(body.as_bytes()).unwrap_err();
+        assert!(matches!(err, SpecError::MissingField("language")));
+    }
+
+    #[test]
+    fn rejects_missing_lockfile() {
+        let body = r#"{"language":"python","source_mount":"/work","gate":"dev"}"#;
+        let err = parse(body.as_bytes()).unwrap_err();
+        assert!(matches!(
+            err,
+            SpecError::MissingField("lockfile_relative_path")
+        ));
+    }
+
+    #[test]
+    fn rejects_missing_source_mount() {
+        let body = r#"{"language":"python","lockfile_relative_path":"uv.lock","gate":"dev"}"#;
+        let err = parse(body.as_bytes()).unwrap_err();
+        assert!(matches!(err, SpecError::MissingField("source_mount")));
+    }
+
+    #[test]
+    fn rejects_missing_gate() {
+        let body =
+            r#"{"language":"python","lockfile_relative_path":"uv.lock","source_mount":"/work"}"#;
+        let err = parse(body.as_bytes()).unwrap_err();
+        assert!(matches!(err, SpecError::MissingField("gate")));
+    }
+
+    #[test]
+    fn rejects_empty_string_fields() {
+        let body = r#"{"language":"python","lockfile_relative_path":"","source_mount":"/work","gate":"dev"}"#;
+        let err = parse(body.as_bytes()).unwrap_err();
+        assert!(matches!(
+            err,
+            SpecError::InvalidField {
+                field: "lockfile_relative_path",
+                ..
+            }
+        ));
+    }
+
+    #[test]
+    fn rejects_unknown_field() {
+        // `deny_unknown_fields`-style behavior — a typo in the host
+        // staging code surfaces here, not silently.
+        let body = r#"{"language":"python","lockfile_relative_path":"uv.lock","source_mount":"/work","gate":"dev","extra":"oops"}"#;
+        let err = parse(body.as_bytes()).unwrap_err();
+        match err {
+            SpecError::Malformed(why) => assert!(why.contains("extra"), "msg: {why}"),
+            other => panic!("wrong variant: {other:?}"),
+        }
+    }
+
+    #[test]
+    fn rejects_non_utf8_bytes() {
+        let err = parse(b"\xff\xff\xff").unwrap_err();
+        assert!(matches!(err, SpecError::Malformed(_)));
+    }
+
+    #[test]
+    fn rejects_truncated_input() {
+        let err = parse(b"{\"language\":\"python\"").unwrap_err();
+        assert!(matches!(err, SpecError::Malformed(_)));
+    }
+
+    #[test]
+    fn handles_string_escapes_in_path() {
+        let body = r#"{"language":"python","lockfile_relative_path":"sub\\dir\\uv.lock","source_mount":"/work","gate":"dev"}"#;
+        let spec = parse(body.as_bytes()).unwrap();
+        assert_eq!(spec.lockfile_relative_path, "sub\\dir\\uv.lock");
+    }
+
+    #[test]
+    fn rejects_trailing_garbage() {
+        let body = r#"{"language":"python","lockfile_relative_path":"uv.lock","source_mount":"/work","gate":"dev"} extra"#;
+        let err = parse(body.as_bytes()).unwrap_err();
+        assert!(matches!(err, SpecError::Malformed(_)));
+    }
+
+    #[test]
+    fn language_token_round_trip() {
+        assert_eq!(Language::Python.as_str(), "python");
+        assert_eq!(Language::Node.as_str(), "node");
+        assert_eq!(GateLevel::Dev.as_str(), "dev");
+        assert_eq!(GateLevel::Prod.as_str(), "prod");
+    }
+}

--- a/crates/mvm-builder-init/src/main.rs
+++ b/crates/mvm-builder-init/src/main.rs
@@ -56,6 +56,23 @@
 
 use std::process::ExitCode;
 
+// Cross-platform modules. The install-spec parser and install
+// pipeline runner live here so `cargo test` on macOS exercises the
+// dispatch logic via shell stubs without paying for a Linux cross-
+// compile. The Linux-only `linux` module composes them with the
+// real PID-1 mount / power-off dance.
+//
+// `allow(dead_code)` because the modules are consumed from
+// `linux::run_install_job` on Linux and from `#[cfg(test)]` blocks
+// on every host. On non-Linux non-test builds (workspace ergonomics
+// + reproducible builds) every public item looks "unused" — clippy
+// would flag them otherwise. Real dead code would still surface as
+// red because the tests would lose coverage.
+#[allow(dead_code)]
+mod install;
+#[allow(dead_code)]
+mod install_spec;
+
 fn main() -> ExitCode {
     #[cfg(target_os = "linux")]
     {
@@ -125,6 +142,14 @@ mod linux {
     /// (`krun_set_console_output`).
     const STDERR_TAIL_LINES: usize = 20;
 
+    /// Filename for the structured install spec (Plan 73 Followup
+    /// B.2). When `/job/install_spec.json` is present the init
+    /// binary routes through the app-deps install pipeline instead
+    /// of dispatching `/job/cmd.sh`. The two modes are mutually
+    /// exclusive — install jobs don't carry a cmd.sh, flake jobs
+    /// don't carry an install_spec.json.
+    const INSTALL_SPEC_FILENAME: &str = "install_spec.json";
+
     pub fn run() -> ExitCode {
         eprintln!("mvm-builder-init: pid 1 starting");
 
@@ -142,6 +167,17 @@ mod linux {
             eprintln!("mvm-builder-init: setup_network warning (non-fatal): {e}");
         }
 
+        // Plan 73 Followup B.2 dispatch: install jobs hand the init
+        // binary a structured spec rather than a shell script. We
+        // probe for the spec first; if absent, fall through to the
+        // existing cmd.sh flake-build flow.
+        let install_spec_path = format!("{JOB_DIR}/{INSTALL_SPEC_FILENAME}");
+        if Path::new(&install_spec_path).exists() {
+            eprintln!("mvm-builder-init: install spec detected, routing through install pipeline");
+            run_install_job(&install_spec_path);
+            return power_off();
+        }
+
         let cmd_path = format!("{JOB_DIR}/cmd.sh");
         if !Path::new(&cmd_path).exists() {
             write_result(2, &format!("missing {cmd_path}"));
@@ -151,6 +187,102 @@ mod linux {
         let (code, tail) = run_job(&cmd_path);
         write_result(code, &tail);
         power_off()
+    }
+
+    /// Drive the install pipeline against `/job/install_spec.json`.
+    /// Emits `/job/result.json` (the typed report — distinct from
+    /// `/job/result`, which the flake-build path writes); the host
+    /// reads it to pick up exit code + sidecar paths.
+    ///
+    /// We deliberately don't propagate failures back as a process
+    /// exit code: the VM is going to `reboot()` regardless, and
+    /// the host distinguishes "install failed" vs "init crashed"
+    /// via the *presence* of result.json. Anything that prevents
+    /// us from writing result.json gets logged + falls through.
+    fn run_install_job(spec_path: &str) {
+        use crate::install::{InstallError, RESULT_FILENAME, SystemCommandRunner, run_install};
+        use crate::install_spec::parse;
+
+        let bytes = match std::fs::read(spec_path) {
+            Ok(b) => b,
+            Err(e) => {
+                eprintln!("mvm-builder-init: read {spec_path}: {e}");
+                write_install_failure(2, &format!("read install spec: {e}"));
+                return;
+            }
+        };
+        let spec = match parse(&bytes) {
+            Ok(s) => s,
+            Err(e) => {
+                eprintln!("mvm-builder-init: parse {spec_path}: {e}");
+                write_install_failure(2, &format!("parse install spec: {e}"));
+                return;
+            }
+        };
+
+        let runner = SystemCommandRunner;
+        let report = match run_install(&spec, Path::new(JOB_DIR), Path::new(OUT_DIR), &runner, None)
+        {
+            Ok(r) => r,
+            Err(InstallError::InstallerMissing { program }) => {
+                eprintln!(
+                    "mvm-builder-init: installer `{program}` not on PATH — builder VM is missing required tools"
+                );
+                write_install_failure(
+                    127,
+                    &format!("installer `{program}` not on PATH inside builder VM"),
+                );
+                return;
+            }
+            Err(InstallError::Io(why)) => {
+                eprintln!("mvm-builder-init: install pipeline IO: {why}");
+                write_install_failure(2, &format!("install pipeline IO: {why}"));
+                return;
+            }
+        };
+
+        // Write the typed report into /out — the host reads it
+        // from `artifact_out/result.json` post-power-off. Plan 73
+        // Followup B.2's contract: result.json lives next to the
+        // four sealed-volume artifacts so a single virtio-fs
+        // share carries everything the host needs. Hand-rolled
+        // JSON via InstallReport::to_json so we don't pull
+        // serde_json into the init binary's closure.
+        let path = format!("{OUT_DIR}/{RESULT_FILENAME}");
+        if let Err(e) = std::fs::write(&path, format!("{}\n", report.to_json())) {
+            eprintln!("mvm-builder-init: failed to write {path}: {e}");
+        }
+    }
+
+    /// Emit a synthetic install-failure result so the host can
+    /// distinguish "guest crashed before running install" from
+    /// "install ran and exited nonzero." The shape matches
+    /// [`crate::install::InstallReport::to_json`] so the host's
+    /// parser doesn't need a separate code path.
+    fn write_install_failure(exit_code: i32, reason: &str) {
+        use crate::install::{
+            CONTENT_SUBDIR, CVE_FILENAME, FETCH_LOG_FILENAME, RESULT_FILENAME, SBOM_FILENAME,
+        };
+        let escaped = json_escape(reason);
+        // Synthesize a result.json that pins all sidecars at their
+        // canonical paths but flags everything as un-emitted. The
+        // host's parser sees installer_exit_code != 0 and refuses
+        // to seal the volume.
+        let body = format!(
+            r#"{{"installer_exit_code":{exit_code},"sbom_emitted":false,"cve_emitted":false,"language":"unknown","gate":"unknown","content_path":"{OUT_DIR}/{CONTENT_SUBDIR}","sbom_path":"{OUT_DIR}/{SBOM_FILENAME}","fetch_log_path":"{OUT_DIR}/{FETCH_LOG_FILENAME}","cve_path":"{OUT_DIR}/{CVE_FILENAME}","failure_reason":"{escaped}"}}"#,
+        );
+        let path = format!("{OUT_DIR}/{RESULT_FILENAME}");
+        // Best-effort: if /out isn't mounted (the install-spec
+        // dispatch ran before virtio-fs came up), at least try
+        // /job so the host has *somewhere* to pick up the failure
+        // signal.
+        if let Err(e) = std::fs::write(&path, format!("{body}\n")) {
+            eprintln!("mvm-builder-init: failed to write {path}: {e}");
+            let fallback = format!("{JOB_DIR}/{RESULT_FILENAME}");
+            if let Err(e2) = std::fs::write(&fallback, format!("{body}\n")) {
+                eprintln!("mvm-builder-init: failed to write {fallback}: {e2}");
+            }
+        }
     }
 
     fn setup_filesystems() -> Result<(), String> {

--- a/nix/images/builder-vm/flake.nix
+++ b/nix/images/builder-vm/flake.nix
@@ -106,6 +106,21 @@
 
       # Per Plan 72 §W2 — narrower than the dev-shell image.
       # See module-level docs above for the rationale on each.
+      #
+      # Plan 73 Followup B.2 adds the application-dependency
+      # install pipeline (ADR-047): `uv` / `pnpm` drive the
+      # installer, `cyclonedx-py` / `pnpm sbom` emit SBOMs, and
+      # `pip-audit` / `pnpm audit` run the CVE scan. Each is
+      # currently a soft gate — `mvm-builder-init::install`
+      # emits a CycloneDX-1.5 empty stub when the SBOM / CVE
+      # tool isn't on PATH and logs a warning. B.2.x will
+      # hard-gate the SBOM + CVE side once the egress allowlist
+      # lands.
+      #
+      # TODO(B.2.x): pin a network egress allowlist
+      # (`pypi.org`, `files.pythonhosted.org`, `registry.npmjs.org`,
+      # `objects.githubusercontent.com`) per ADR-047 §"Lifecycle
+      # gates" — today's builder VM has open egress.
       builderPackages = pkgs: with pkgs; [
         bashInteractive
         coreutils
@@ -122,6 +137,16 @@
         iproute2
         e2fsprogs
         util-linux
+        # Plan 73 Followup B.2 — app-deps install pipeline.
+        uv
+        pnpm
+        # `cyclonedx-py` ships under `python3Packages` in
+        # nixpkgs (the upstream package name; `pkgs.cyclonedx-py`
+        # is the entry point binary). Pulls a Python interpreter
+        # closure but the same one `pip-audit` needs, so the
+        # marginal cost is minor.
+        python3Packages.cyclonedx-bom
+        python3Packages.pip-audit
       ];
 
       # Build `mvm-builder-init` (Plan 72 W3) for the target system.


### PR DESCRIPTION
## Summary

Wires the application-dependency install pipeline (ADR-047, Plan 73 Followup B) end-to-end through the libkrun builder VM. Cache miss on `install_app_deps` now dispatches through an `InstallDriver` (blanket-impl'd for every `BuilderVm`), runs `uv` / `pnpm` inside the VM with audit sidecars (SBOM + CVE + fetch log), and seals the result into the deps-volume cache.

## Scope (what landed)

Three surfaces:

1. **`mvm-builder-init` install protocol** (`crates/mvm-builder-init/src/install_spec.rs` + `install.rs`):
   - Parses `/job/install_spec.json` (closed shape: `language`, `lockfile_relative_path`, `source_mount`, `gate`).
   - Dispatches `uv pip install --no-deps --requirements <lockfile> --target /out/content` for Python, `pnpm install --frozen-lockfile --dir /out/content` for Node.
   - Tees stdout+stderr to `/out/fetch.log` (the URL-audit artifact).
   - Runs SBOM via `cyclonedx-py` / `pnpm sbom` → `/out/sbom.cdx.json`.
   - Runs CVE via `pip-audit` / `pnpm audit` → `/out/cve.json`.
   - **Soft-gate** on missing optional tools: emit CycloneDX-1.5 empty stub / `{\"results\":[]}` stub + warning, don't fail the install. Hard-gating moves to B.2.x.
   - Emits `/out/result.json` (typed report). `linux::run` probes for the install spec first; absent, falls through to the legacy cmd.sh dispatch.
   - Hand-rolled JSON parser (no `serde_json` dep) to keep the init binary under the Plan 72 W3 ≤1.5 MiB size budget.

2. **Builder VM flake additions** (`nix/images/builder-vm/flake.nix`):
   - Adds `uv`, `pnpm`, `python3Packages.cyclonedx-bom`, `python3Packages.pip-audit` to the builder package set.
   - TODO marker for the egress allowlist (B.2.x).

3. **Host-side wiring** (`crates/mvm-build/src/`):
   - `libkrun_builder::stage_job_dir` Install arm copies the spec to `<job_dir>/install_spec.json`.
   - `libkrun_builder::finalize_install_job` parses `<artifact_out>/result.json`, validates `installer_exit_code == 0` + all four sealed-volume artifacts present, returns `BuilderArtifacts::InstallVolume`.
   - `app_deps::install_app_deps` replaces the `BuilderVmNotWired` seam with the `InstallDriver` trait. Cache miss → driver dispatch → `seal_volume` → rename into `<cache>/<volume_hash>/` → write `index/<lockfile_hash>`.
   - New typed errors: `DriverNotProvided`, `BuilderVmFailed`, `SealFailed`, `CacheInstallFailed`, `BuilderVmShapeMismatch`.

## Non-goals (deferred)

- **B.2.x — egress allowlist.** Today's builder VM has open egress. The ADR-047 allowlist (`pypi.org`, `files.pythonhosted.org`, `registry.npmjs.org`, `objects.githubusercontent.com`) lands in a follow-on PR, alongside hard-failing `--prod` when SBOM / CVE tools are missing.
- **B.3 — CLI gate flags.** `mvmctl build --deps`, `mvmctl deps audit`, `mvmctl deps inspect` are user-facing surfaces for Followups C / D; this PR ships only the data layer.

## Test plan

- **mvm-builder-init** (26 tests, cross-platform): install-spec parser (missing/unknown fields, malformed JSON, escape sequences), install dispatcher against a stub `CommandRunner` (Python + Node happy paths, missing installer, missing SBOM / CVE tool fallback, nonzero installer exit, log truncation).
- **mvm-build orchestrator** (13 tests): `MockDriver` simulates the builder VM by pre-populating `artifact_out` with hand-authored sealed-volume artifacts. Covers cache hit, cache miss + driver dispatch, miss-then-hit round trip, builder VM failure (typed propagation), shape mismatch, seal failure, all pre-existing tamper/missing/race paths.
- **libkrun_builder** (6 new tests): `finalize_install_job` paths + `stage_job_dir` install variant.
- End-to-end against a real `LibkrunBuilderVm` is **out of scope** for CI (no libkrun on Linux runners + no builder VM image populated). Manual smoke checklist below.

CI gates run locally before push:
- [x] `cargo fmt --check`
- [x] `cargo clippy --workspace --all-targets -- -D warnings`
- [x] `cargo clippy --workspace --all-targets --all-features -- -D warnings`
- [x] `cargo run -p xtask -- check-no-display-on-secret-types`
- [x] `cargo test -p mvm-builder-init` (26 passed)
- [x] `cargo test -p mvm-build` (98 passed with libkrun feature)

The workspace-wide `cargo test --workspace` exhibits a pre-existing flake on `mvm-cli::commands::ops::tenant::tests::destroy_*` (host-signer file-creation race when run in parallel; passes when isolated, reproduces on stashed `origin/main`). Unrelated to this PR.

## Manual smoke checklist

On a macOS Apple Silicon host with libkrun installed and the Plan 72 builder VM image populated at `~/.cache/mvm/builder-vm/<arch>/`:

- [ ] Construct an `InstallSpec` for a small Python lockfile (e.g. `requests`). Call `install_app_deps(&spec, Some(&LibkrunBuilderVm::default()))`.
- [ ] Confirm `~/.mvm/volumes/deps/<volume_hash>/` exists with `content/`, `sbom.cdx.json`, `fetch.log`, `cve.json`, `meta.json`, and `index/<lockfile_hash>` points at the volume_hash.
- [ ] Re-run; confirm `cache_hit: true` and no VM spawn.
- [ ] Tamper a sidecar; confirm next call fails with `CacheVerifyFailed`.
- [ ] Repeat for a Node `pnpm-lock.yaml` fixture.
- [ ] Confirm `result.json` records `sbom_emitted: true` + `cve_emitted: true` (i.e. the SBOM / CVE tools were on the builder VM PATH).

🤖 Generated with [Claude Code](https://claude.com/claude-code)