### PR TITLE
plan 73 followup B.3: mvmctl up deps_volume + --prod/--dev gates

### DIFF
--- a/crates/mvm-build/src/app_deps_gate.rs
+++ b/crates/mvm-build/src/app_deps_gate.rs
@@ -1,0 +1,603 @@
+//! Build-time gate for the [`crate::app_deps::InstallResult`] artifacts
+//! produced by the libkrun builder VM (Plan 73 Followup B.2). Inspects
+//! the sealed-volume sidecars on disk (`sbom.cdx.json`, `cve.json`)
+//! and either:
+//!
+//! - **`GateLevel::Prod`** — fails closed (typed [`GateError`] variants)
+//!   on missing artifacts, the documented "tool not on PATH" stubs, or
+//!   any CVE finding whose `severity` parses to `high` / `critical`.
+//! - **`GateLevel::Dev`** — every prod-rejection condition becomes a
+//!   `tracing::warn!` line; the install still succeeds and the
+//!   surrounding `mvmctl up` flow continues to admit the workload.
+//!
+//! ADR-047 §"Lifecycle gates" pins the contract; this module is the
+//! host-side enforcer. The matching builder-VM-side B.2 fallbacks
+//! emit:
+//!
+//! - `SBOM_EMPTY_STUB` =
+//!   `{"bomFormat":"CycloneDX","specVersion":"1.5","components":[]}`
+//!   when `cyclonedx-py` / `pnpm sbom` is missing.
+//! - `CVE_EMPTY_STUB` = `{"results":[]}` when `pip-audit` /
+//!   `pnpm audit --json` is missing.
+//!
+//! Both stubs are deliberately distinguishable from a legitimate
+//! "zero findings" install (a real SBOM always has ≥1 component for
+//! a non-empty install; a real CVE scan emits at least the tool's
+//! schema marker even with no findings). The prod gate rejects both
+//! shapes; the dev gate logs and continues. The CI gate (Followup D)
+//! sits on top of the prod variant: stub-fallback is acceptable for
+//! local `--dev` iteration, never for the release path.
+//!
+//! ### Why parse with `serde_json::Value`
+//!
+//! The SBOM + CVE shapes are tool-defined and evolve out of band of
+//! mvm releases (`pip-audit` adds fields between minor versions;
+//! CycloneDX 1.6 ships during the followup window). A typed struct
+//! would force a coordinated cargo bump every time. `serde_json::Value`
+//! lets the gate inspect the two fields it actually cares about
+//! (`components.len()` on SBOM; `severity` / `aliases` / `name` on
+//! every CVE-finding shape) and ignore everything else.
+
+use std::path::Path;
+use std::{fs, io};
+
+use mvm_sdk::compile::deps_audit::{FILE_CVE, FILE_SBOM};
+use thiserror::Error;
+
+use crate::app_deps::{GateLevel, InstallResult};
+
+/// Typed gate failure surfaced under [`GateLevel::Prod`]. Each variant
+/// maps 1:1 to an ADR-047 §"Lifecycle gates" rejection condition; the
+/// caller (`mvmctl up`) bubbles these to the user with the underlying
+/// path so an operator can debug without reading mvm internals.
+#[derive(Debug, Error)]
+pub enum GateError {
+    /// `sbom.cdx.json` is missing entirely (B.2 always writes one, so
+    /// this only fires on a manually-tampered volume).
+    #[error("SBOM file missing at {path}; prod admission requires a CycloneDX 1.5 SBOM")]
+    SbomMissingFile { path: String },
+
+    /// `sbom.cdx.json` is unreadable. Almost always a permissions
+    /// issue; surfaced separately so the operator sees the underlying
+    /// io::Error.
+    #[error("failed to read SBOM at {path}: {source}")]
+    SbomReadFailed {
+        path: String,
+        #[source]
+        source: io::Error,
+    },
+
+    /// `sbom.cdx.json` parsed as JSON but is the documented empty-stub
+    /// shape (`components: []`). Means `cyclonedx-py` / `pnpm sbom`
+    /// was missing on the builder-VM PATH at install time — fine for
+    /// `--dev`, refused for `--prod`.
+    #[error(
+        "SBOM at {path} is the empty-tool stub (zero components); the SBOM tool was missing \
+         in the builder VM. Acceptable for --dev; --prod requires a real SBOM"
+    )]
+    MissingSbom { path: String },
+
+    /// `sbom.cdx.json` could not be parsed as JSON.
+    #[error("SBOM at {path} could not be parsed as JSON: {source}")]
+    SbomParseFailed {
+        path: String,
+        #[source]
+        source: serde_json::Error,
+    },
+
+    /// `cve.json` is missing entirely.
+    #[error(
+        "CVE scan file missing at {path}; prod admission requires a pip-audit / pnpm-audit result"
+    )]
+    CveMissingFile { path: String },
+
+    /// `cve.json` is unreadable.
+    #[error("failed to read CVE scan at {path}: {source}")]
+    CveReadFailed {
+        path: String,
+        #[source]
+        source: io::Error,
+    },
+
+    /// `cve.json` is the documented empty-tool stub (`{"results":[]}`).
+    /// Means `pip-audit` / `pnpm audit --json` was missing on the
+    /// builder-VM PATH — fine for `--dev`, refused for `--prod`.
+    #[error(
+        "CVE scan at {path} is the empty-tool stub (no scan run); the CVE tool was missing \
+         in the builder VM. Acceptable for --dev; --prod requires a real scan"
+    )]
+    MissingCveScan { path: String },
+
+    /// `cve.json` could not be parsed as JSON.
+    #[error("CVE scan at {path} could not be parsed as JSON: {source}")]
+    CveParseFailed {
+        path: String,
+        #[source]
+        source: serde_json::Error,
+    },
+
+    /// At least one CVE finding has a `severity` of `high` or
+    /// `critical`. The first such finding wins so the operator sees a
+    /// concrete name; remaining findings are not enumerated here but
+    /// remain available via `mvmctl deps inspect` (Followup C).
+    #[error(
+        "CVE scan at {path} reports a {severity} severity finding for {package}; \
+         --prod refuses to admit"
+    )]
+    HighCveFinding {
+        path: String,
+        package: String,
+        severity: String,
+    },
+}
+
+/// Apply the build-time gate to an [`InstallResult`]. Reads the
+/// SBOM + CVE sidecars from `result.volume_dir` and either fails
+/// closed (`--prod`) or warns and continues (`--dev`).
+///
+/// ### Prod-gate rejection order
+///
+/// 1. SBOM missing / unreadable / unparseable → typed error
+///    (`SbomMissingFile`, `SbomReadFailed`, `SbomParseFailed`).
+/// 2. SBOM is the empty-tool stub → [`GateError::MissingSbom`].
+/// 3. CVE file missing / unreadable / unparseable → typed error.
+/// 4. CVE file is the empty-tool stub → [`GateError::MissingCveScan`].
+/// 5. CVE file carries a `high` / `critical` finding →
+///    [`GateError::HighCveFinding`] (first such finding wins).
+///
+/// On dev, every step that would fail closed emits a `tracing::warn!`
+/// line with the same content; the function returns `Ok(())`.
+pub fn apply_install_gate(result: &InstallResult, gate: GateLevel) -> Result<(), GateError> {
+    let sbom_path = result.volume_dir.join(FILE_SBOM);
+    let cve_path = result.volume_dir.join(FILE_CVE);
+
+    let sbom_outcome = inspect_sbom(&sbom_path);
+    let cve_outcome = inspect_cve(&cve_path);
+
+    match gate {
+        GateLevel::Prod => {
+            apply_outcome_prod(sbom_outcome)?;
+            apply_outcome_prod(cve_outcome)?;
+            Ok(())
+        }
+        GateLevel::Dev => {
+            warn_outcome_dev(sbom_outcome, "SBOM");
+            warn_outcome_dev(cve_outcome, "CVE scan");
+            Ok(())
+        }
+    }
+}
+
+/// Internal: enumerate every gate signal a single artifact can carry.
+/// Keeping outcomes typed (rather than mapping straight to
+/// `Result<(), GateError>`) makes the `--dev` warn-and-continue path
+/// trivial: each outcome renders to one warning line.
+enum Outcome {
+    Ok,
+    Fail(GateError),
+}
+
+fn apply_outcome_prod(o: Outcome) -> Result<(), GateError> {
+    match o {
+        Outcome::Ok => Ok(()),
+        Outcome::Fail(e) => Err(e),
+    }
+}
+
+fn warn_outcome_dev(o: Outcome, kind: &str) {
+    if let Outcome::Fail(e) = o {
+        tracing::warn!(
+            kind = kind,
+            error = %e,
+            "app-deps gate (dev): rejection condition observed; admitting anyway"
+        );
+    }
+}
+
+/// Read + classify the SBOM sidecar.
+fn inspect_sbom(path: &Path) -> Outcome {
+    let bytes = match read_artifact(path) {
+        Ok(Some(b)) => b,
+        Ok(None) => {
+            return Outcome::Fail(GateError::SbomMissingFile {
+                path: path.display().to_string(),
+            });
+        }
+        Err(source) => {
+            return Outcome::Fail(GateError::SbomReadFailed {
+                path: path.display().to_string(),
+                source,
+            });
+        }
+    };
+
+    let parsed: serde_json::Value = match serde_json::from_slice(&bytes) {
+        Ok(v) => v,
+        Err(source) => {
+            return Outcome::Fail(GateError::SbomParseFailed {
+                path: path.display().to_string(),
+                source,
+            });
+        }
+    };
+
+    if sbom_is_empty_stub(&parsed) {
+        return Outcome::Fail(GateError::MissingSbom {
+            path: path.display().to_string(),
+        });
+    }
+
+    Outcome::Ok
+}
+
+/// Read + classify the CVE-scan sidecar.
+fn inspect_cve(path: &Path) -> Outcome {
+    let bytes = match read_artifact(path) {
+        Ok(Some(b)) => b,
+        Ok(None) => {
+            return Outcome::Fail(GateError::CveMissingFile {
+                path: path.display().to_string(),
+            });
+        }
+        Err(source) => {
+            return Outcome::Fail(GateError::CveReadFailed {
+                path: path.display().to_string(),
+                source,
+            });
+        }
+    };
+
+    let parsed: serde_json::Value = match serde_json::from_slice(&bytes) {
+        Ok(v) => v,
+        Err(source) => {
+            return Outcome::Fail(GateError::CveParseFailed {
+                path: path.display().to_string(),
+                source,
+            });
+        }
+    };
+
+    if cve_is_empty_stub(&parsed) {
+        return Outcome::Fail(GateError::MissingCveScan {
+            path: path.display().to_string(),
+        });
+    }
+
+    if let Some((package, severity)) = first_high_or_critical_finding(&parsed) {
+        return Outcome::Fail(GateError::HighCveFinding {
+            path: path.display().to_string(),
+            package,
+            severity,
+        });
+    }
+
+    Outcome::Ok
+}
+
+/// Read a sidecar path, distinguishing "missing" (Ok(None)) from
+/// "unreadable" (Err) so the caller can fork the typed error.
+fn read_artifact(path: &Path) -> Result<Option<Vec<u8>>, io::Error> {
+    match fs::read(path) {
+        Ok(b) => Ok(Some(b)),
+        Err(e) if e.kind() == io::ErrorKind::NotFound => Ok(None),
+        Err(e) => Err(e),
+    }
+}
+
+/// Recognize the builder-VM-emitted empty SBOM stub. The fingerprint
+/// the prod gate rejects: CycloneDX shape with zero components. Real
+/// installs always emit ≥1 component, so this is a stable signal
+/// that `cyclonedx-py` / `pnpm sbom` wasn't on the builder VM PATH.
+fn sbom_is_empty_stub(value: &serde_json::Value) -> bool {
+    let bom_format = value.get("bomFormat").and_then(|v| v.as_str());
+    let components = value.get("components").and_then(|v| v.as_array());
+    matches!(bom_format, Some("CycloneDX")) && components.map(|c| c.is_empty()).unwrap_or(false)
+}
+
+/// Recognize the builder-VM-emitted empty CVE stub:
+/// `{"results":[]}`. Real `pip-audit` runs always emit additional
+/// schema markers (`dependencies`, `summary`); `pnpm audit --json`
+/// always emits a `metadata` object. An empty `results` array with
+/// no companions is the stub signature.
+fn cve_is_empty_stub(value: &serde_json::Value) -> bool {
+    let Some(obj) = value.as_object() else {
+        return false;
+    };
+    let Some(results) = obj.get("results").and_then(|v| v.as_array()) else {
+        return false;
+    };
+    if !results.is_empty() {
+        return false;
+    }
+    // Real-tool output always carries at least one companion key.
+    // The stub literally has `{"results":[]}` and nothing else.
+    obj.len() == 1
+}
+
+/// Walk the CVE-scan JSON for the first `high` / `critical` finding.
+///
+/// Tolerant of both `pip-audit` and `pnpm audit` shapes:
+///
+/// - `pip-audit`: top-level `{"dependencies":[{"name":"...","vulns":[
+///   {"id":"...","aliases":[...]} ]}], ...}` — severity carried per-vuln
+///   under `severity` (sometimes `fix_versions[].severity`).
+/// - `pnpm audit --json`: top-level
+///   `{"advisories":{"ID":{"module_name":"...","severity":"high",...}}}`.
+///
+/// Rather than encode each tool's shape, this walks every nested
+/// object/array and inspects any node that carries a `severity` field.
+/// If the severity parses to `high` / `critical`, return its closest
+/// "name-like" sibling (`package`, `name`, `module_name`, `package_name`,
+/// or "unknown"). First hit wins.
+fn first_high_or_critical_finding(value: &serde_json::Value) -> Option<(String, String)> {
+    fn walk(node: &serde_json::Value, current_name: Option<String>) -> Option<(String, String)> {
+        match node {
+            serde_json::Value::Object(map) => {
+                // Prefer the local node's name field, fall back to the
+                // parent's. `pnpm audit` keys advisories by ID so the
+                // name lives on the node itself.
+                let local_name = name_from_object(map);
+                let effective_name = local_name.clone().or(current_name.clone());
+                if let Some(sev) = map.get("severity").and_then(|v| v.as_str()) {
+                    let normalized = sev.to_ascii_lowercase();
+                    if matches!(normalized.as_str(), "high" | "critical") {
+                        let pkg = effective_name
+                            .clone()
+                            .unwrap_or_else(|| "unknown".to_string());
+                        return Some((pkg, normalized));
+                    }
+                }
+                for (k, v) in map {
+                    // `pnpm audit` keyed by advisory ID; inject the key
+                    // as a context name when no explicit name field is
+                    // present on the child.
+                    let pass_name = local_name.clone().or_else(|| {
+                        if k == "advisories" || k == "vulnerabilities" {
+                            None
+                        } else {
+                            Some(k.clone())
+                        }
+                    });
+                    if let Some(hit) = walk(v, pass_name) {
+                        return Some(hit);
+                    }
+                }
+                None
+            }
+            serde_json::Value::Array(arr) => {
+                for item in arr {
+                    if let Some(hit) = walk(item, current_name.clone()) {
+                        return Some(hit);
+                    }
+                }
+                None
+            }
+            _ => None,
+        }
+    }
+
+    fn name_from_object(map: &serde_json::Map<String, serde_json::Value>) -> Option<String> {
+        for key in ["package", "package_name", "module_name", "name"] {
+            if let Some(s) = map.get(key).and_then(|v| v.as_str()) {
+                return Some(s.to_string());
+            }
+        }
+        None
+    }
+
+    walk(value, None)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::app_deps::InstallResult;
+    use std::path::Path;
+    use tempfile::TempDir;
+
+    /// Build a fake [`InstallResult`] backed by a fresh tempdir.
+    /// Returns the dir guard alongside so the caller can drop it
+    /// after the assertion runs.
+    fn fixture() -> (TempDir, InstallResult) {
+        let tmp = tempfile::tempdir().expect("tmp");
+        let dir = tmp.path().to_path_buf();
+        let result = InstallResult {
+            volume_hash: "a".repeat(64),
+            manifest_sha256: "b".repeat(64),
+            cache_hit: false,
+            volume_dir: dir,
+            lockfile_sha256: "c".repeat(64),
+        };
+        (tmp, result)
+    }
+
+    fn write_artifact(volume_dir: &Path, name: &str, body: &[u8]) {
+        std::fs::write(volume_dir.join(name), body).unwrap();
+    }
+
+    const REAL_SBOM: &str = r#"{
+        "bomFormat":"CycloneDX","specVersion":"1.5",
+        "components":[{"type":"library","name":"requests","version":"2.31.0"}]
+    }"#;
+
+    const REAL_CVE_NO_FINDINGS: &str = r#"{
+        "results":[],
+        "dependencies":[],
+        "summary":{"fixed":0,"vulnerable":0,"skipped":0}
+    }"#;
+
+    const REAL_CVE_HIGH: &str = r#"{
+        "dependencies":[
+            {"name":"flask","vulns":[
+                {"id":"PYSEC-2023-1","severity":"high","aliases":["CVE-2023-30861"]}
+            ]}
+        ]
+    }"#;
+
+    const REAL_CVE_CRITICAL_PNPM: &str = r#"{
+        "advisories":{
+            "1234":{"module_name":"lodash","severity":"critical","title":"prototype poll"}
+        },
+        "metadata":{"vulnerabilities":{"critical":1}}
+    }"#;
+
+    const STUB_SBOM: &str = r#"{"bomFormat":"CycloneDX","specVersion":"1.5","components":[]}"#;
+    const STUB_CVE: &str = r#"{"results":[]}"#;
+
+    #[test]
+    fn prod_passes_with_real_sbom_and_clean_cve() {
+        let (_g, r) = fixture();
+        write_artifact(&r.volume_dir, FILE_SBOM, REAL_SBOM.as_bytes());
+        write_artifact(&r.volume_dir, FILE_CVE, REAL_CVE_NO_FINDINGS.as_bytes());
+        apply_install_gate(&r, GateLevel::Prod).expect("clean run passes prod");
+    }
+
+    #[test]
+    fn prod_rejects_stub_sbom_as_missing_sbom() {
+        let (_g, r) = fixture();
+        write_artifact(&r.volume_dir, FILE_SBOM, STUB_SBOM.as_bytes());
+        write_artifact(&r.volume_dir, FILE_CVE, REAL_CVE_NO_FINDINGS.as_bytes());
+        let err = apply_install_gate(&r, GateLevel::Prod).expect_err("must fail");
+        assert!(matches!(err, GateError::MissingSbom { .. }), "got {err:?}");
+    }
+
+    #[test]
+    fn prod_rejects_stub_cve_as_missing_cve_scan() {
+        let (_g, r) = fixture();
+        write_artifact(&r.volume_dir, FILE_SBOM, REAL_SBOM.as_bytes());
+        write_artifact(&r.volume_dir, FILE_CVE, STUB_CVE.as_bytes());
+        let err = apply_install_gate(&r, GateLevel::Prod).expect_err("must fail");
+        assert!(
+            matches!(err, GateError::MissingCveScan { .. }),
+            "got {err:?}"
+        );
+    }
+
+    #[test]
+    fn prod_rejects_high_cve_finding_pip_audit_shape() {
+        let (_g, r) = fixture();
+        write_artifact(&r.volume_dir, FILE_SBOM, REAL_SBOM.as_bytes());
+        write_artifact(&r.volume_dir, FILE_CVE, REAL_CVE_HIGH.as_bytes());
+        let err = apply_install_gate(&r, GateLevel::Prod).expect_err("must fail");
+        match err {
+            GateError::HighCveFinding {
+                package, severity, ..
+            } => {
+                assert_eq!(package, "flask");
+                assert_eq!(severity, "high");
+            }
+            other => panic!("wrong variant: {other:?}"),
+        }
+    }
+
+    #[test]
+    fn prod_rejects_critical_cve_finding_pnpm_shape() {
+        let (_g, r) = fixture();
+        write_artifact(&r.volume_dir, FILE_SBOM, REAL_SBOM.as_bytes());
+        write_artifact(&r.volume_dir, FILE_CVE, REAL_CVE_CRITICAL_PNPM.as_bytes());
+        let err = apply_install_gate(&r, GateLevel::Prod).expect_err("must fail");
+        match err {
+            GateError::HighCveFinding {
+                package, severity, ..
+            } => {
+                assert_eq!(package, "lodash");
+                assert_eq!(severity, "critical");
+            }
+            other => panic!("wrong variant: {other:?}"),
+        }
+    }
+
+    #[test]
+    fn prod_rejects_missing_sbom_file() {
+        let (_g, r) = fixture();
+        // Only CVE — no SBOM file at all.
+        write_artifact(&r.volume_dir, FILE_CVE, REAL_CVE_NO_FINDINGS.as_bytes());
+        let err = apply_install_gate(&r, GateLevel::Prod).expect_err("must fail");
+        assert!(
+            matches!(err, GateError::SbomMissingFile { .. }),
+            "got {err:?}"
+        );
+    }
+
+    #[test]
+    fn prod_rejects_missing_cve_file() {
+        let (_g, r) = fixture();
+        write_artifact(&r.volume_dir, FILE_SBOM, REAL_SBOM.as_bytes());
+        let err = apply_install_gate(&r, GateLevel::Prod).expect_err("must fail");
+        assert!(
+            matches!(err, GateError::CveMissingFile { .. }),
+            "got {err:?}"
+        );
+    }
+
+    #[test]
+    fn prod_rejects_malformed_sbom_json() {
+        let (_g, r) = fixture();
+        write_artifact(&r.volume_dir, FILE_SBOM, b"{ not json }");
+        write_artifact(&r.volume_dir, FILE_CVE, REAL_CVE_NO_FINDINGS.as_bytes());
+        let err = apply_install_gate(&r, GateLevel::Prod).expect_err("must fail");
+        assert!(
+            matches!(err, GateError::SbomParseFailed { .. }),
+            "got {err:?}"
+        );
+    }
+
+    #[test]
+    fn prod_rejects_malformed_cve_json() {
+        let (_g, r) = fixture();
+        write_artifact(&r.volume_dir, FILE_SBOM, REAL_SBOM.as_bytes());
+        write_artifact(&r.volume_dir, FILE_CVE, b"{ not json }");
+        let err = apply_install_gate(&r, GateLevel::Prod).expect_err("must fail");
+        assert!(
+            matches!(err, GateError::CveParseFailed { .. }),
+            "got {err:?}"
+        );
+    }
+
+    #[test]
+    fn dev_warns_and_continues_on_every_prod_rejection() {
+        // Both sidecars are stubs + the cve stub has no high findings
+        // (it can't — it's empty). On --dev the function returns Ok
+        // and the operator sees warnings instead.
+        let (_g, r) = fixture();
+        write_artifact(&r.volume_dir, FILE_SBOM, STUB_SBOM.as_bytes());
+        write_artifact(&r.volume_dir, FILE_CVE, STUB_CVE.as_bytes());
+        apply_install_gate(&r, GateLevel::Dev).expect("dev never errors");
+    }
+
+    #[test]
+    fn dev_with_high_cve_finding_warns_and_continues() {
+        let (_g, r) = fixture();
+        write_artifact(&r.volume_dir, FILE_SBOM, REAL_SBOM.as_bytes());
+        write_artifact(&r.volume_dir, FILE_CVE, REAL_CVE_HIGH.as_bytes());
+        apply_install_gate(&r, GateLevel::Dev).expect("dev never errors");
+    }
+
+    #[test]
+    fn medium_and_low_severity_pass_prod() {
+        // Only high / critical fail closed; "medium" and "low" are
+        // tolerated. This matches ADR-047 §"Lifecycle gates".
+        let cve = r#"{
+            "dependencies":[
+                {"name":"foo","vulns":[
+                    {"id":"X","severity":"medium"},
+                    {"id":"Y","severity":"low"}
+                ]}
+            ]
+        }"#;
+        let (_g, r) = fixture();
+        write_artifact(&r.volume_dir, FILE_SBOM, REAL_SBOM.as_bytes());
+        write_artifact(&r.volume_dir, FILE_CVE, cve.as_bytes());
+        apply_install_gate(&r, GateLevel::Prod).expect("medium/low passes prod");
+    }
+
+    #[test]
+    fn empty_results_with_companion_keys_is_not_a_stub() {
+        // A real `pip-audit` run with zero findings ships the
+        // `dependencies` + `summary` companions; not the stub shape.
+        let (_g, r) = fixture();
+        write_artifact(&r.volume_dir, FILE_SBOM, REAL_SBOM.as_bytes());
+        write_artifact(&r.volume_dir, FILE_CVE, REAL_CVE_NO_FINDINGS.as_bytes());
+        apply_install_gate(&r, GateLevel::Prod).expect("real clean scan passes prod");
+    }
+}

--- a/crates/mvm-build/src/lib.rs
+++ b/crates/mvm-build/src/lib.rs
@@ -1,4 +1,5 @@
 pub mod app_deps;
+pub mod app_deps_gate;
 pub mod artifacts;
 pub mod backend;
 pub mod builder_vm;

--- a/crates/mvm-cli/src/commands/tests.rs
+++ b/crates/mvm-cli/src/commands/tests.rs
@@ -288,6 +288,110 @@ fn test_up_dev_and_prod_are_mutually_exclusive() {
     );
 }
 
+// Plan 73 Followup B.3 — `--from-workload-ir <path>` flag wires
+// `mvmctl up` into the app-deps install pipeline. These tests pin
+// the flag-parse surface (clap-side); the install-pipeline integration
+// itself is covered by `app_deps_gate::tests` + the helper unit tests
+// in `vm/up.rs::resolve_deps_volume_binding`-adjacent fixtures.
+
+#[test]
+fn test_up_from_workload_ir_flag_parses() {
+    let cli = Cli::try_parse_from([
+        "mvmctl",
+        "up",
+        "--flake",
+        ".",
+        "--from-workload-ir",
+        "./workload.ir.json",
+    ])
+    .expect("clap parses --from-workload-ir");
+    match cli.command {
+        Commands::Up(up::Args {
+            from_workload_ir, ..
+        }) => {
+            assert_eq!(
+                from_workload_ir,
+                Some(std::path::PathBuf::from("./workload.ir.json"))
+            );
+        }
+        _ => panic!("Expected Up command"),
+    }
+}
+
+#[test]
+fn test_up_from_workload_ir_absent_means_none() {
+    // Claim-8 preservation guard: when the user doesn't pass the
+    // flag, `from_workload_ir` is `None` and `mvmctl up` runs its
+    // pre-Followup-B.3 path with `deps_volume = None` on the plan.
+    let cli = Cli::try_parse_from(["mvmctl", "up", "--flake", "."]).unwrap();
+    match cli.command {
+        Commands::Up(up::Args {
+            from_workload_ir, ..
+        }) => {
+            assert!(from_workload_ir.is_none());
+        }
+        _ => panic!("Expected Up command"),
+    }
+}
+
+#[test]
+fn test_up_from_workload_ir_combines_with_prod_gate_flag() {
+    let cli = Cli::try_parse_from([
+        "mvmctl",
+        "up",
+        "--flake",
+        ".",
+        "--from-workload-ir",
+        "./workload.ir.json",
+        "--prod",
+    ])
+    .expect("clap parses --from-workload-ir + --prod");
+    match cli.command {
+        Commands::Up(up::Args {
+            from_workload_ir,
+            build_mode,
+            ..
+        }) => {
+            assert_eq!(
+                from_workload_ir,
+                Some(std::path::PathBuf::from("./workload.ir.json"))
+            );
+            assert!(build_mode.prod);
+            assert_eq!(build_mode.resolve(), mvm_build::pipeline::BuildMode::Prod);
+        }
+        _ => panic!("Expected Up command"),
+    }
+}
+
+#[test]
+fn test_up_from_workload_ir_combines_with_dev_gate_flag() {
+    let cli = Cli::try_parse_from([
+        "mvmctl",
+        "up",
+        "--flake",
+        ".",
+        "--from-workload-ir",
+        "./workload.ir.json",
+        "--dev",
+    ])
+    .expect("clap parses --from-workload-ir + --dev");
+    match cli.command {
+        Commands::Up(up::Args {
+            from_workload_ir,
+            build_mode,
+            ..
+        }) => {
+            assert_eq!(
+                from_workload_ir,
+                Some(std::path::PathBuf::from("./workload.ir.json"))
+            );
+            assert!(build_mode.dev);
+            assert_eq!(build_mode.resolve(), mvm_build::pipeline::BuildMode::Dev);
+        }
+        _ => panic!("Expected Up command"),
+    }
+}
+
 #[test]
 fn test_up_manifest_short_flag() {
     let cli = Cli::try_parse_from(["mvmctl", "up", "-m", "openclaw"]).unwrap();

--- a/crates/mvm-cli/src/commands/vm/host_signer.rs
+++ b/crates/mvm-cli/src/commands/vm/host_signer.rs
@@ -360,6 +360,7 @@ mod tests {
             exec_timeout_secs: 0,
             destroy_on_exit: true,
             bundle_pin: None,
+            deps_volume: None,
         })
         .expect("synth");
 

--- a/crates/mvm-cli/src/commands/vm/plan_admission.rs
+++ b/crates/mvm-cli/src/commands/vm/plan_admission.rs
@@ -239,6 +239,7 @@ mod tests {
             exec_timeout_secs: 0,
             destroy_on_exit: true,
             bundle_pin: None,
+            deps_volume: None,
         }
     }
 

--- a/crates/mvm-cli/src/commands/vm/plan_builder.rs
+++ b/crates/mvm-cli/src/commands/vm/plan_builder.rs
@@ -38,9 +38,9 @@
 use anyhow::Result;
 use chrono::{Duration, Utc};
 use mvm_plan::{
-    ArtifactPolicy, AttestationMode, AttestationRequirement, ExecutionPlan, FsPolicyRef,
-    KeyRotationSpec, Nonce, PlanId, PolicyRef, PostRunLifecycle, Resources, RuntimeProfileRef,
-    SCHEMA_VERSION, SignedImageRef, TenantId, TimeoutSpec, WorkloadId,
+    ArtifactPolicy, AttestationMode, AttestationRequirement, DepsVolumeBinding, ExecutionPlan,
+    FsPolicyRef, KeyRotationSpec, Nonce, PlanId, PolicyRef, PostRunLifecycle, Resources,
+    RuntimeProfileRef, SCHEMA_VERSION, SignedImageRef, TenantId, TimeoutSpec, WorkloadId,
 };
 use rand::RngCore;
 use std::collections::BTreeMap;
@@ -100,6 +100,16 @@ pub struct SynthesisInput<'a> {
     /// backend dispatch. Sprint 52 W2 follow-on substrate — populating
     /// it from `mvmctl up` flags is the next step.
     pub bundle_pin: Option<mvm_plan::bundle::PlanArtifact>,
+    /// Optional pin to an application-dependencies volume sealed by
+    /// `mvm_sdk::compile::deps_audit::seal_volume`. Populated by
+    /// `mvmctl up`'s deps-install path (Plan 73 Followup B.3) when
+    /// the workload declares `App.dependencies = Dependencies::Python
+    /// | Dependencies::Node`; absent when `Dependencies::None` /
+    /// no `--from-workload-ir` flag is set. The supervisor's admit
+    /// path re-runs `verify_sealed_volume` against the pinned
+    /// `volume_hash` + `manifest_sha256` before backend dispatch
+    /// (ADR-047 security claim 9).
+    pub deps_volume: Option<DepsVolumeBinding>,
 }
 
 /// Build an unsigned `ExecutionPlan` from CLI-shaped input.
@@ -177,11 +187,11 @@ pub fn synthesize_plan(input: &SynthesisInput<'_>) -> Result<ExecutionPlan> {
         valid_until: now + Duration::minutes(VALIDITY_WINDOW_MINUTES),
         nonce,
         bundle: input.bundle_pin.clone(),
-        // Plan 73 Followup A: synthesizers don't pin a deps volume
-        // yet — that lands once `mvmctl build --deps` (Followup C)
-        // emits the binding. Today's `mvmctl up` flow always passes
-        // `None` and the supervisor skips the deps-volume gate.
-        deps_volume: None,
+        // Plan 73 Followup B.3: populated by the caller when an
+        // `mvmctl up --from-workload-ir <path>` invocation drove
+        // `install_app_deps` to a sealed volume. `None` preserves
+        // claim 8 (the supervisor's deps-volume gate is skipped).
+        deps_volume: input.deps_volume.clone(),
     })
 }
 
@@ -213,6 +223,7 @@ mod tests {
             exec_timeout_secs: 0,
             destroy_on_exit: false,
             bundle_pin: None,
+            deps_volume: None,
         }
     }
 
@@ -345,5 +356,42 @@ mod tests {
     fn schema_version_is_pinned() {
         let plan = synthesize_plan(&input("myvm")).unwrap();
         assert_eq!(plan.schema_version, SCHEMA_VERSION);
+    }
+
+    #[test]
+    fn without_deps_volume_plan_carries_none() {
+        // Claim-8 preservation guard: when the caller doesn't pin a
+        // deps volume, the plan carries `deps_volume = None` and the
+        // supervisor's admission path skips the gate (Followup A).
+        let plan = synthesize_plan(&input("myvm")).unwrap();
+        assert!(plan.deps_volume.is_none());
+    }
+
+    #[test]
+    fn with_deps_volume_plan_carries_binding_verbatim() {
+        // Followup B.3 path: `mvmctl up`'s install pipeline yielded
+        // an `InstallResult`; the caller turns it into a
+        // `DepsVolumeBinding` and threads it through synthesis. The
+        // plan field must round-trip the volume + manifest hashes
+        // verbatim so the supervisor's verifier (Followup A) re-derives
+        // them against the on-disk volume.
+        let volume_hash = "a".repeat(64);
+        let manifest_sha256 = "b".repeat(64);
+        let binding = DepsVolumeBinding::new(&volume_hash, &manifest_sha256).expect("binding");
+        let mut inp = input("myvm");
+        inp.deps_volume = Some(binding.clone());
+        let plan = synthesize_plan(&inp).unwrap();
+        assert_eq!(plan.deps_volume, Some(binding));
+    }
+
+    #[test]
+    fn deps_volume_round_trips_through_serde() {
+        let binding = DepsVolumeBinding::new("a".repeat(64), "b".repeat(64)).expect("binding");
+        let mut inp = input("myvm");
+        inp.deps_volume = Some(binding.clone());
+        let plan = synthesize_plan(&inp).unwrap();
+        let json = serde_json::to_string(&plan).expect("plan serializes");
+        let parsed: ExecutionPlan = serde_json::from_str(&json).expect("plan parses");
+        assert_eq!(parsed.deps_volume, Some(binding));
     }
 }

--- a/crates/mvm-cli/src/commands/vm/run_plan.rs
+++ b/crates/mvm-cli/src/commands/vm/run_plan.rs
@@ -207,6 +207,11 @@ fn synthesis_input_for_app<'a>(workload: &'a Workload, app: &'a App) -> Result<S
         exec_timeout_secs: 0,
         destroy_on_exit: true,
         bundle_pin: None,
+        // Plan-mode synthesis (Followup H-plan) does not run the
+        // install pipeline; it synthesizes one plan per Sandbox call
+        // for dry-run admission. Followup B.3 wires deps_volume into
+        // the live `mvmctl up` path only.
+        deps_volume: None,
     })
 }
 

--- a/crates/mvm-cli/src/commands/vm/up.rs
+++ b/crates/mvm-cli/src/commands/vm/up.rs
@@ -119,6 +119,13 @@ struct AdmitPlanForBootParams<'a> {
     /// admit path re-verifies on every launch. Production callers
     /// thread `args.bundle_pin`; tests pass `None`.
     pub bundle_pin: Option<&'a std::path::Path>,
+    /// Optional deps-volume binding produced by `mvmctl up`'s
+    /// install pipeline (Plan 73 Followup B.3). When `Some`, the
+    /// synthesised `ExecutionPlan` carries `deps_volume = Some(...)`,
+    /// and the supervisor's admission gate (Followup A) re-verifies
+    /// the on-disk sealed volume before launch — ADR-047 claim 9.
+    /// `None` preserves the claim-8 baseline (no deps gate).
+    pub deps_volume: Option<mvm_plan::DepsVolumeBinding>,
 }
 
 /// Bundle of artifacts produced by a successful admission: the
@@ -230,6 +237,7 @@ fn admit_plan_for_boot(p: AdmitPlanForBootParams<'_>) -> Result<Option<Admission
         exec_timeout_secs: 0,
         destroy_on_exit: true,
         bundle_pin: bundle_pin.clone(),
+        deps_volume: p.deps_volume.clone(),
     };
     let admission_ctx = match (&bundle_resolver, &bundle_trust) {
         (Some(r), Some(t)) => Some(BundleAdmissionContext {
@@ -386,6 +394,150 @@ pub(super) fn emit_failed_if(ctx: &Option<AdmissionContext>, class: &str, err: &
     }
 }
 
+/// Plan 73 Followup B.3 — resolve a deps-volume binding for the
+/// supplied Workload IR.
+///
+/// When `workload_ir_path = None` the function returns `Ok(None)` and
+/// the synthesized plan carries `deps_volume = None` (claim-8 preserved).
+///
+/// When the IR loads cleanly + has a `Dependencies::Python` /
+/// `Dependencies::Node` declaration, runs `install_app_deps` against
+/// the host cache (driver = `None`: cache-hit-only — `mvmctl up`
+/// does not spawn the builder VM today; `mvmctl deps build`
+/// (Followup C) is the verb that drives the cache-miss path) and
+/// then runs `apply_install_gate` on the resolved volume. On `--prod`
+/// any gate-error bubbles as `anyhow::Error`; on `--dev` warnings
+/// are logged and the function still returns the binding.
+///
+/// IR-load errors propagate verbatim so the user sees them (a typo in
+/// `--from-workload-ir <path>` should fail before VM boot, not silently
+/// degrade to "no deps").
+fn resolve_deps_volume_binding(
+    workload_ir_path: Option<&std::path::Path>,
+    build_mode: mvm_build::pipeline::BuildMode,
+) -> Result<Option<mvm_plan::DepsVolumeBinding>> {
+    resolve_deps_volume_binding_with_cache(workload_ir_path, build_mode, None)
+}
+
+/// Cache-root-overridable form of [`resolve_deps_volume_binding`].
+/// Tests inject a per-tempdir override so they don't touch the user's
+/// `~/.mvm/volumes/deps/` and don't race each other through the
+/// shared `MVM_DEPS_VOLUMES_DIR` env var. Production callers route
+/// through the no-override helper which resolves the canonical path.
+fn resolve_deps_volume_binding_with_cache(
+    workload_ir_path: Option<&std::path::Path>,
+    build_mode: mvm_build::pipeline::BuildMode,
+    cache_root_override: Option<&std::path::Path>,
+) -> Result<Option<mvm_plan::DepsVolumeBinding>> {
+    let Some(ir_path) = workload_ir_path else {
+        return Ok(None);
+    };
+    let bytes = std::fs::read(ir_path)
+        .with_context(|| format!("reading workload IR at {}", ir_path.display()))?;
+    let workload: mvm_ir::Workload = serde_json::from_slice(&bytes)
+        .with_context(|| format!("parsing workload IR at {}", ir_path.display()))?;
+
+    // v1 surface: one app per workload. ADR-0009; the IR validator
+    // (`mvm validate`) rejects empty `apps`, so `[0]` is safe on a
+    // validated IR. Multi-app workloads with mixed dep declarations
+    // are a future ADR — punt now.
+    let Some(app) = workload.apps.first() else {
+        anyhow::bail!(
+            "workload IR at {} has no apps; --from-workload-ir requires at least one app",
+            ir_path.display()
+        );
+    };
+
+    // `Dependencies::None` and absent-field both mean "no lockfile".
+    let dep = match &app.dependencies {
+        None | Some(mvm_ir::Dependencies::None) => return Ok(None),
+        Some(d) => d,
+    };
+
+    // Resolve lockfile path + language from the IR.
+    let (language, lockfile_rel) = match dep {
+        mvm_ir::Dependencies::Python { lockfile, .. } => {
+            (mvm_build::app_deps::Language::Python, lockfile)
+        }
+        mvm_ir::Dependencies::Node { lockfile, .. } => {
+            (mvm_build::app_deps::Language::Node, lockfile)
+        }
+        // unreachable: handled above.
+        mvm_ir::Dependencies::None => return Ok(None),
+    };
+    let source_root = source_root_for_app(app, ir_path)?;
+    let lockfile_path = source_root.join(lockfile_rel);
+    let gate = match build_mode {
+        mvm_build::pipeline::BuildMode::Prod => mvm_build::app_deps::GateLevel::Prod,
+        mvm_build::pipeline::BuildMode::Dev => mvm_build::app_deps::GateLevel::Dev,
+    };
+
+    let spec = mvm_build::app_deps::InstallSpec {
+        lockfile: lockfile_path,
+        source_root,
+        language,
+        gate,
+        cache_root_override: cache_root_override.map(std::path::Path::to_path_buf),
+    };
+
+    // Driver = None: `mvmctl up` is the consumer of an already-built
+    // deps volume. The cache-miss → builder-VM dispatch is the job of
+    // `mvmctl deps build` (Followup C). On a miss we surface the
+    // typed `DriverNotProvided` to the user with a pointer to that
+    // verb (lands in C).
+    let install = mvm_build::app_deps::install_app_deps(&spec, None).map_err(|e| match e {
+        mvm_build::app_deps::InstallError::DriverNotProvided { .. } => anyhow::anyhow!(
+            "no cached deps volume for this lockfile; run `mvmctl deps build \
+                 --from-workload-ir {}` first (Plan 73 Followup C)",
+            ir_path.display()
+        ),
+        other => anyhow::Error::new(other),
+    })?;
+
+    // Gate. On --prod a typed `GateError` aborts the boot; on --dev
+    // every issue is logged + we proceed with the binding.
+    mvm_build::app_deps_gate::apply_install_gate(&install, gate)
+        .with_context(|| format!("app-deps gate ({gate:?}) refused the install"))?;
+
+    let binding = mvm_plan::DepsVolumeBinding::new(&install.volume_hash, &install.manifest_sha256)
+        .map_err(|e| {
+            anyhow::anyhow!(
+                "install pipeline returned a malformed hash pair: {e} \
+                     (volume_hash={}, manifest_sha256={})",
+                install.volume_hash,
+                install.manifest_sha256
+            )
+        })?;
+    Ok(Some(binding))
+}
+
+/// Resolve the `source_root` for an app's lockfile path. For
+/// `Source::LocalPath { path, .. }` the source root is the directory
+/// the path resolves against — relative paths root at the IR file's
+/// parent; absolute paths are used verbatim. Other source kinds (`Nix
+/// derivation`, `OCI image`) carry no host-resolvable source root, so
+/// they're refused here with a hint.
+fn source_root_for_app(app: &mvm_ir::App, ir_path: &std::path::Path) -> Result<std::path::PathBuf> {
+    match &app.source {
+        mvm_ir::Source::LocalPath { path, .. } => {
+            let p = std::path::Path::new(path);
+            if p.is_absolute() {
+                Ok(p.to_path_buf())
+            } else {
+                let base = ir_path
+                    .parent()
+                    .unwrap_or_else(|| std::path::Path::new("."));
+                Ok(base.join(p))
+            }
+        }
+        mvm_ir::Source::NixDerivation { .. } | mvm_ir::Source::OciImage { .. } => anyhow::bail!(
+            "Workload IR app source is {:?}; --from-workload-ir + dependency \
+             installation only supports `Source::LocalPath` today",
+            app.source
+        ),
+    }
+}
+
 #[derive(ClapArgs, Debug, Clone)]
 pub(in crate::commands) struct Args {
     /// Nix flake reference (local path or remote URI)
@@ -489,8 +641,24 @@ pub(in crate::commands) struct Args {
     #[arg(long, value_name = "PATH")]
     pub bundle_pin: Option<std::path::PathBuf>,
     /// Build-mode override flags (`--dev` / `--prod`). Default: `--prod`.
+    /// These also drive the Plan 73 Followup B.3 app-deps gate when
+    /// `--from-workload-ir` is set: `--prod` fails closed on missing
+    /// SBOM / missing CVE scan / high or critical CVE findings;
+    /// `--dev` warns and continues.
     #[command(flatten)]
     pub build_mode: super::super::shared::BuildModeFlags,
+    /// Path to a Workload IR JSON describing the app being booted.
+    /// When the IR carries `App.dependencies = Dependencies::Python
+    /// | Dependencies::Node`, `mvmctl up` resolves the lockfile
+    /// through `mvm_build::app_deps::install_app_deps` (cache-hit
+    /// only — Plan 73 Followup B.3 does not spawn the builder VM
+    /// from `mvmctl up`; the volume must already exist) and pins
+    /// the resulting `DepsVolumeBinding` into the synthesized
+    /// `ExecutionPlan`. When omitted or when the IR carries
+    /// `Dependencies::None`, the plan's `deps_volume` is `None`
+    /// (claim-8 preserved). ADR-047 claim 9.
+    #[arg(long = "from-workload-ir", value_name = "PATH")]
+    pub from_workload_ir: Option<std::path::PathBuf>,
 }
 
 pub(in crate::commands) fn run(_cli: &Cli, args: Args, cfg: &MvmConfig) -> Result<()> {
@@ -631,6 +799,7 @@ pub(in crate::commands) fn run(_cli: &Cli, args: Args, cfg: &MvmConfig) -> Resul
         no_supervisor: args.no_supervisor,
         bundle_pin: args.bundle_pin.as_deref(),
         build_mode,
+        workload_ir_path: args.from_workload_ir.as_deref(),
     })
 }
 
@@ -670,6 +839,12 @@ pub(in crate::commands) struct RunParams<'a> {
     /// `Some(p)` populates `PlanArtifact` in the synthesised plan.
     pub(super) bundle_pin: Option<&'a std::path::Path>,
     pub(super) build_mode: mvm_build::pipeline::BuildMode,
+    /// Optional path to a Workload IR JSON. When set + the IR
+    /// carries `App.dependencies = Dependencies::Python |
+    /// Dependencies::Node`, the deps install pipeline runs +
+    /// pins a `DepsVolumeBinding` into the synthesized plan.
+    /// Plan 73 Followup B.3.
+    pub(super) workload_ir_path: Option<&'a std::path::Path>,
 }
 
 pub(super) fn cmd_run(params: RunParams<'_>) -> Result<()> {
@@ -701,6 +876,7 @@ pub(super) fn cmd_run(params: RunParams<'_>) -> Result<()> {
         no_supervisor,
         bundle_pin,
         build_mode,
+        workload_ir_path,
     } = params;
     let _span =
         tracing::info_span!("cmd_run", name = ?name, cpus = ?cpus, memory_mib = ?memory).entered();
@@ -811,6 +987,14 @@ pub(super) fn cmd_run(params: RunParams<'_>) -> Result<()> {
     // replay-window across the lifetime of the process.
     let admission_ledger = InMemoryNonceLedger::new();
 
+    // Plan 73 Followup B.3 — resolve the deps-volume binding once
+    // (cache-hit path only — `mvmctl up` does not spawn the builder
+    // VM today; that's `mvmctl deps build` in Followup C) and thread
+    // it to every admit_plan_for_boot call site below. Returns
+    // `Ok(None)` when `--from-workload-ir` is absent or the IR
+    // carries no lockfile (claim-8 preserved).
+    let deps_volume_binding = resolve_deps_volume_binding(workload_ir_path, build_mode)?;
+
     // Direct boot mode: launchd agent passes kernel/rootfs via env vars.
     // Skip the build/template loading entirely.
     if std::env::var("MVM_DIRECT_BOOT").as_deref() == Ok("1") {
@@ -834,6 +1018,7 @@ pub(super) fn cmd_run(params: RunParams<'_>) -> Result<()> {
             audit_dir: None,
             policy_dir: None,
             bundle_pin,
+            deps_volume: deps_volume_binding.clone(),
         })?;
 
         let start_config = mvm_core::vm_backend::VmStartConfig {
@@ -1179,6 +1364,7 @@ pub(super) fn cmd_run(params: RunParams<'_>) -> Result<()> {
         audit_dir: None,
         policy_dir: None,
         bundle_pin,
+        deps_volume: deps_volume_binding.clone(),
     })?;
 
     // If a template snapshot exists AND the backend supports snapshots,
@@ -1505,6 +1691,7 @@ pub(super) fn cmd_run(params: RunParams<'_>) -> Result<()> {
                 audit_dir: None,
                 policy_dir: None,
                 bundle_pin,
+                deps_volume: deps_volume_binding.clone(),
             }) {
                 Ok(ctx) => ctx,
                 Err(e) => {
@@ -1772,6 +1959,7 @@ mod admit_plan_tests {
             audit_dir: None,
             policy_dir: None,
             bundle_pin: None,
+            deps_volume: None,
         })
         .expect("must succeed");
         assert!(result.is_none(), "no_supervisor must return None");
@@ -1797,6 +1985,7 @@ mod admit_plan_tests {
             audit_dir: Some(audit_dir.path()),
             policy_dir: None,
             bundle_pin: None,
+            deps_volume: None,
         })
         .expect("admission")
         .expect("Some when admission ran");
@@ -1835,6 +2024,7 @@ mod admit_plan_tests {
             audit_dir: Some(audit_dir.path()),
             policy_dir: None,
             bundle_pin: None,
+            deps_volume: None,
         })
         .expect_err("missing rootfs must fail");
         assert!(
@@ -1867,6 +2057,7 @@ mod admit_plan_tests {
             audit_dir: Some(audit_dir.path()),
             policy_dir: None,
             bundle_pin: None,
+            deps_volume: None,
         })
         .unwrap()
         .unwrap();
@@ -1883,6 +2074,7 @@ mod admit_plan_tests {
             audit_dir: Some(audit_dir.path()),
             policy_dir: None,
             bundle_pin: None,
+            deps_volume: None,
         })
         .unwrap()
         .unwrap();
@@ -1941,6 +2133,7 @@ mod admit_plan_tests {
             audit_dir: Some(audit_dir.path()),
             policy_dir: Some(policy_dir.path()),
             bundle_pin: None,
+            deps_volume: None,
         })
         .expect("admission")
         .expect("Some when admission ran");
@@ -2016,6 +2209,7 @@ bundle_version = 1
                 exec_timeout_secs: 0,
                 destroy_on_exit: true,
                 bundle_pin: None,
+                deps_volume: None,
             },
             &SystemClock,
             &ledger,
@@ -2073,6 +2267,7 @@ bundle_version = 1
                 exec_timeout_secs: 0,
                 destroy_on_exit: true,
                 bundle_pin: None,
+                deps_volume: None,
             },
             &SystemClock,
             &ledger,
@@ -2154,6 +2349,7 @@ disabled_inspectors = ["ssrf_guarrd"]
                 exec_timeout_secs: 0,
                 destroy_on_exit: true,
                 bundle_pin: None,
+                deps_volume: None,
             },
             &SystemClock,
             &ledger,
@@ -2241,6 +2437,7 @@ port_hi  = 443
                 exec_timeout_secs: 0,
                 destroy_on_exit: true,
                 bundle_pin: None,
+                deps_volume: None,
             },
             &SystemClock,
             &ledger,
@@ -2269,6 +2466,394 @@ port_hi  = 443
         assert!(
             content.contains("\"error_class\":\"policy-l4-spec-invalid\""),
             "audit chain must classify the failure: {content}"
+        );
+    }
+}
+
+// Plan 73 Followup B.3 — `resolve_deps_volume_binding` unit tests.
+//
+// These cover the new helper that turns a Workload IR + a build-mode
+// flag into an `Option<DepsVolumeBinding>` for plan synthesis. The
+// cache-miss path (which would dispatch the libkrun builder VM)
+// surfaces as `DriverNotProvided` per Followup B.3's policy ("mvmctl
+// up consumes a cached volume; mvmctl deps build is the verb that
+// drives the cache-miss path"); cache-hit fixtures use the same
+// `seal_volume` primitives as `mvm-build/tests/app_deps_orchestrator.rs`
+// so the wire format stays pinned.
+#[cfg(test)]
+mod resolve_deps_volume_tests {
+    use super::*;
+    use mvm_sdk::compile::deps_audit::{
+        FILE_CONTENT_DIR, FILE_CVE, FILE_FETCH_LOG, FILE_MANIFEST, FILE_SBOM, seal_volume,
+    };
+    use std::collections::BTreeMap;
+    use std::path::Path;
+
+    /// Build a workload-IR JSON file with the supplied `dependencies`
+    /// shape. Returns the path the test should pass to
+    /// `resolve_deps_volume_binding`.
+    fn write_workload_ir(
+        dir: &Path,
+        deps: Option<serde_json::Value>,
+        source_path: &str,
+    ) -> std::path::PathBuf {
+        let mut app = serde_json::json!({
+            "name": "app1",
+            "source": { "kind": "local_path", "path": source_path },
+            "image": { "kind": "nix_packages", "packages": ["python3"] },
+            "entrypoints": [
+                { "kind": "command", "command": ["/bin/true"] }
+            ],
+            "resources": { "memory_mb": 256, "cpu_cores": 1, "rootfs_size_mb": 512 }
+        });
+        if let Some(d) = deps {
+            app["dependencies"] = d;
+        }
+        let workload = serde_json::json!({
+            "schema_version": "0.1.0",
+            "id": "test-workload",
+            "apps": [app]
+        });
+        let path = dir.join("workload.ir.json");
+        std::fs::write(&path, serde_json::to_string_pretty(&workload).unwrap()).unwrap();
+        path
+    }
+
+    /// Seal a deps volume into `cache_root/<volume_hash>/` and write
+    /// the index pointer so a subsequent `install_app_deps` call
+    /// returns `cache_hit = true`. Mirrors `seal_into_cache` in
+    /// `crates/mvm-build/tests/app_deps_orchestrator.rs`.
+    fn seal_volume_into_cache(
+        cache_root: &Path,
+        lockfile_path: &Path,
+        sbom_body: &[u8],
+        cve_body: &[u8],
+    ) -> String {
+        let scratch = cache_root.join("scratch");
+        let content_dir = scratch.join(FILE_CONTENT_DIR);
+        std::fs::create_dir_all(&content_dir).unwrap();
+        std::fs::write(content_dir.join("placeholder"), b"installed\n").unwrap();
+        let sbom = scratch.join(FILE_SBOM);
+        std::fs::write(&sbom, sbom_body).unwrap();
+        let fetch_log = scratch.join(FILE_FETCH_LOG);
+        std::fs::write(&fetch_log, b"GET https://pypi.org/x\n").unwrap();
+        let cve = scratch.join(FILE_CVE);
+        std::fs::write(&cve, cve_body).unwrap();
+
+        let sealed = seal_volume(
+            &content_dir,
+            &sbom,
+            &fetch_log,
+            &cve,
+            "2026-05-14T00:00:00Z",
+            BTreeMap::new(),
+        )
+        .expect("seal");
+        let final_dir = cache_root.join(&sealed.volume_hash);
+        std::fs::rename(&scratch, &final_dir).unwrap();
+        std::fs::write(final_dir.join(FILE_MANIFEST), &sealed.manifest_bytes).unwrap();
+
+        // Index pointer.
+        let lockfile_bytes = std::fs::read(lockfile_path).unwrap();
+        use sha2::{Digest, Sha256};
+        let mut h = Sha256::new();
+        h.update(&lockfile_bytes);
+        let mut lock_sha = String::new();
+        for b in h.finalize() {
+            lock_sha.push_str(&format!("{b:02x}"));
+        }
+        let lockfile_hash = mvm_build::app_deps::derive_lockfile_hash(
+            &lock_sha,
+            mvm_build::app_deps::Language::Python,
+            mvm_build::app_deps::GateLevel::Prod,
+        );
+        let index = cache_root.join("index");
+        std::fs::create_dir_all(&index).unwrap();
+        std::fs::write(index.join(&lockfile_hash), &sealed.volume_hash).unwrap();
+        sealed.volume_hash
+    }
+
+    const REAL_SBOM: &[u8] =
+        br#"{"bomFormat":"CycloneDX","specVersion":"1.5","components":[{"name":"requests"}]}"#;
+    const REAL_CVE: &[u8] = br#"{"results":[],"dependencies":[],"summary":{"fixed":0}}"#;
+
+    #[test]
+    fn no_workload_ir_returns_none() {
+        // Claim-8 preservation: `mvmctl up` without `--from-workload-ir`
+        // never touches the deps cache and produces a plan whose
+        // `deps_volume` is `None`.
+        let binding =
+            resolve_deps_volume_binding(None, mvm_build::pipeline::BuildMode::Prod).unwrap();
+        assert!(binding.is_none());
+    }
+
+    #[test]
+    fn workload_ir_without_dependencies_returns_none() {
+        let tmp = tempfile::tempdir().unwrap();
+        let project = tmp.path().join("project");
+        std::fs::create_dir_all(&project).unwrap();
+        let ir = write_workload_ir(tmp.path(), None, project.to_str().unwrap());
+        let binding =
+            resolve_deps_volume_binding(Some(&ir), mvm_build::pipeline::BuildMode::Prod).unwrap();
+        assert!(binding.is_none());
+    }
+
+    #[test]
+    fn workload_ir_with_dependencies_none_returns_none() {
+        let tmp = tempfile::tempdir().unwrap();
+        let project = tmp.path().join("project");
+        std::fs::create_dir_all(&project).unwrap();
+        let ir = write_workload_ir(
+            tmp.path(),
+            Some(serde_json::json!({ "kind": "none" })),
+            project.to_str().unwrap(),
+        );
+        let binding =
+            resolve_deps_volume_binding(Some(&ir), mvm_build::pipeline::BuildMode::Prod).unwrap();
+        assert!(binding.is_none());
+    }
+
+    #[test]
+    fn workload_ir_with_python_lockfile_cache_hit_returns_binding() {
+        // Plan 73 Followup B.3 happy path: workload declares a
+        // `Dependencies::Python` with a lockfile; the cache already
+        // holds a sealed volume; resolve_deps_volume_binding produces
+        // a `DepsVolumeBinding` whose hashes match the seal result.
+        let tmp = tempfile::tempdir().unwrap();
+        let project = tmp.path().join("project");
+        std::fs::create_dir_all(&project).unwrap();
+        std::fs::write(
+            project.join("uv.lock"),
+            b"version = 1\n[[package]]\nname = \"requests\"\n",
+        )
+        .unwrap();
+
+        let ir = write_workload_ir(
+            tmp.path(),
+            Some(serde_json::json!({
+                "kind": "python",
+                "lockfile": "uv.lock",
+                "tool": "uv"
+            })),
+            project.to_str().unwrap(),
+        );
+
+        // Per-test cache root keeps parallel `cargo test` from
+        // racing on `~/.mvm/volumes/deps/` or a shared env var.
+        let cache_root = tmp.path().join("cache");
+        std::fs::create_dir_all(&cache_root).unwrap();
+        let volume_hash =
+            seal_volume_into_cache(&cache_root, &project.join("uv.lock"), REAL_SBOM, REAL_CVE);
+
+        let binding = resolve_deps_volume_binding_with_cache(
+            Some(&ir),
+            mvm_build::pipeline::BuildMode::Prod,
+            Some(&cache_root),
+        )
+        .expect("cache hit + clean prod gate")
+        .expect("Some when IR carries Python deps");
+        assert_eq!(binding.volume_hash, volume_hash);
+    }
+
+    #[test]
+    fn workload_ir_with_python_lockfile_cache_miss_surfaces_typed_error() {
+        // Cache miss under `mvmctl up` is currently a hard error
+        // pointing at `mvmctl deps build` (Followup C). The error
+        // message must mention that verb so the user knows how to
+        // proceed.
+        let tmp = tempfile::tempdir().unwrap();
+        let project = tmp.path().join("project");
+        std::fs::create_dir_all(&project).unwrap();
+        std::fs::write(project.join("uv.lock"), b"unique-bytes-12345\n").unwrap();
+
+        let ir = write_workload_ir(
+            tmp.path(),
+            Some(serde_json::json!({
+                "kind": "python",
+                "lockfile": "uv.lock",
+                "tool": "uv"
+            })),
+            project.to_str().unwrap(),
+        );
+
+        let cache_root = tmp.path().join("cache");
+        std::fs::create_dir_all(&cache_root).unwrap();
+
+        let err = resolve_deps_volume_binding_with_cache(
+            Some(&ir),
+            mvm_build::pipeline::BuildMode::Prod,
+            Some(&cache_root),
+        )
+        .expect_err("must fail on cache miss");
+        let msg = format!("{err:#}");
+        assert!(
+            msg.contains("mvmctl deps build"),
+            "miss diagnostic must point at the C verb: {msg}"
+        );
+    }
+
+    #[test]
+    fn workload_ir_prod_gate_rejects_stub_sbom() {
+        // Cache holds a sealed volume whose SBOM is the documented
+        // empty-tool stub — `cyclonedx-py` wasn't on the builder VM
+        // PATH. `--prod` (the default for `mvmctl up`) must refuse.
+        let tmp = tempfile::tempdir().unwrap();
+        let project = tmp.path().join("project");
+        std::fs::create_dir_all(&project).unwrap();
+        std::fs::write(project.join("uv.lock"), b"some-stub-lockfile\n").unwrap();
+
+        let ir = write_workload_ir(
+            tmp.path(),
+            Some(serde_json::json!({
+                "kind": "python",
+                "lockfile": "uv.lock",
+                "tool": "uv"
+            })),
+            project.to_str().unwrap(),
+        );
+
+        let cache_root = tmp.path().join("cache");
+        std::fs::create_dir_all(&cache_root).unwrap();
+        let stub_sbom = br#"{"bomFormat":"CycloneDX","specVersion":"1.5","components":[]}"#;
+        let _ = seal_volume_into_cache(&cache_root, &project.join("uv.lock"), stub_sbom, REAL_CVE);
+
+        let err = resolve_deps_volume_binding_with_cache(
+            Some(&ir),
+            mvm_build::pipeline::BuildMode::Prod,
+            Some(&cache_root),
+        )
+        .expect_err("stub SBOM must fail prod gate");
+        let chain: Vec<String> = err.chain().map(|e| e.to_string()).collect();
+        assert!(
+            chain
+                .iter()
+                .any(|s| s.contains("empty-tool stub") || s.contains("SBOM")),
+            "error chain must mention SBOM stub: {chain:?}"
+        );
+    }
+
+    #[test]
+    fn workload_ir_dev_gate_warns_and_returns_binding_for_stub_sbom() {
+        // Same stub-SBOM scenario, but `--dev`: the helper logs a
+        // warning and returns the binding. The plan synthesizer
+        // gets `Some(...)` and the supervisor's admit gate verifies
+        // the on-disk volume the normal way.
+        let tmp = tempfile::tempdir().unwrap();
+        let project = tmp.path().join("project");
+        std::fs::create_dir_all(&project).unwrap();
+        std::fs::write(project.join("uv.lock"), b"dev-stub-lockfile\n").unwrap();
+
+        let ir = write_workload_ir(
+            tmp.path(),
+            Some(serde_json::json!({
+                "kind": "python",
+                "lockfile": "uv.lock",
+                "tool": "uv"
+            })),
+            project.to_str().unwrap(),
+        );
+
+        let cache_root = tmp.path().join("cache");
+        std::fs::create_dir_all(&cache_root).unwrap();
+
+        // Re-seal the cache under the *dev* lockfile_hash variant.
+        let scratch = cache_root.join("dev-scratch");
+        let content_dir = scratch.join(FILE_CONTENT_DIR);
+        std::fs::create_dir_all(&content_dir).unwrap();
+        std::fs::write(content_dir.join("placeholder"), b"installed\n").unwrap();
+        let sbom = scratch.join(FILE_SBOM);
+        std::fs::write(
+            &sbom,
+            br#"{"bomFormat":"CycloneDX","specVersion":"1.5","components":[]}"#,
+        )
+        .unwrap();
+        let fetch_log = scratch.join(FILE_FETCH_LOG);
+        std::fs::write(&fetch_log, b"").unwrap();
+        let cve = scratch.join(FILE_CVE);
+        std::fs::write(&cve, REAL_CVE).unwrap();
+        let sealed = seal_volume(
+            &content_dir,
+            &sbom,
+            &fetch_log,
+            &cve,
+            "2026-05-14T00:00:00Z",
+            BTreeMap::new(),
+        )
+        .unwrap();
+        let final_dir = cache_root.join(&sealed.volume_hash);
+        std::fs::rename(&scratch, &final_dir).unwrap();
+        std::fs::write(final_dir.join(FILE_MANIFEST), &sealed.manifest_bytes).unwrap();
+        let lockfile_bytes = std::fs::read(project.join("uv.lock")).unwrap();
+        use sha2::{Digest, Sha256};
+        let mut h = Sha256::new();
+        h.update(&lockfile_bytes);
+        let mut lock_sha = String::new();
+        for b in h.finalize() {
+            lock_sha.push_str(&format!("{b:02x}"));
+        }
+        let lockfile_hash = mvm_build::app_deps::derive_lockfile_hash(
+            &lock_sha,
+            mvm_build::app_deps::Language::Python,
+            mvm_build::app_deps::GateLevel::Dev,
+        );
+        let index = cache_root.join("index");
+        std::fs::create_dir_all(&index).unwrap();
+        std::fs::write(index.join(&lockfile_hash), &sealed.volume_hash).unwrap();
+
+        let binding = resolve_deps_volume_binding_with_cache(
+            Some(&ir),
+            mvm_build::pipeline::BuildMode::Dev,
+            Some(&cache_root),
+        )
+        .expect("dev gate warns + returns Ok")
+        .expect("Some when IR carries Python deps");
+        assert_eq!(binding.volume_hash, sealed.volume_hash);
+    }
+
+    #[test]
+    fn workload_ir_with_unparseable_json_propagates_error() {
+        let tmp = tempfile::tempdir().unwrap();
+        let bad = tmp.path().join("garbage.ir.json");
+        std::fs::write(&bad, b"this is not json").unwrap();
+        let err = resolve_deps_volume_binding(Some(&bad), mvm_build::pipeline::BuildMode::Prod)
+            .expect_err("must fail on bad JSON");
+        let msg = format!("{err:#}");
+        assert!(
+            msg.contains("parsing workload IR"),
+            "error must mention parsing: {msg}"
+        );
+    }
+
+    #[test]
+    fn workload_ir_non_local_path_source_rejected() {
+        // `Source::OciImage` doesn't carry a host-resolvable
+        // source root for the install pipeline. Surface a clear
+        // error rather than silently failing later.
+        let tmp = tempfile::tempdir().unwrap();
+        let workload = serde_json::json!({
+            "schema_version": "0.1.0",
+            "id": "oci-workload",
+            "apps": [{
+                "name": "app1",
+                "source": {
+                    "kind": "oci_image",
+                    "reference": "library/python:3.12",
+                    "digest": "sha256:abc"
+                },
+                "image": { "kind": "nix_packages", "packages": ["python3"] },
+                "entrypoints": [{ "kind": "command", "command": ["/bin/true"] }],
+                "resources": { "memory_mb": 256, "cpu_cores": 1, "rootfs_size_mb": 512 },
+                "dependencies": { "kind": "python", "lockfile": "uv.lock", "tool": "uv" }
+            }]
+        });
+        let path = tmp.path().join("workload.ir.json");
+        std::fs::write(&path, serde_json::to_string_pretty(&workload).unwrap()).unwrap();
+        let err = resolve_deps_volume_binding(Some(&path), mvm_build::pipeline::BuildMode::Prod)
+            .expect_err("non-local source must fail");
+        let msg = format!("{err:#}");
+        assert!(
+            msg.contains("Source::LocalPath") || msg.contains("LocalPath"),
+            "error must name the unsupported source kind: {msg}"
         );
     }
 }


### PR DESCRIPTION
## Summary

Two pieces of CLI plumbing on top of B.2's "install pipeline exists" so claim 9 actually fires for user workloads:

- **`mvmctl up --from-workload-ir <path>`** loads a Workload IR JSON, reads its `App.dependencies`, and (on `Dependencies::Python` / `Dependencies::Node`) drives `mvm_build::app_deps::install_app_deps` to a sealed volume. The resulting `InstallResult` becomes a `DepsVolumeBinding` pinned into the synthesized `ExecutionPlan`; Followup A's supervisor admission gate verifies the on-disk volume before backend dispatch. `Dependencies::None` / no flag → `deps_volume = None` (claim 8 preserved).
- **Build-time gate** on the `InstallResult` artifacts via the existing `--prod` / `--dev` flag shape (`BuildModeFlags`): `--prod` fails closed with typed `GateError::{MissingSbom, MissingCveScan, HighCveFinding, ...}` on stubs / high+critical CVE findings; `--dev` warns and continues.

## Scope

- `crates/mvm-build/src/app_deps_gate.rs` (new) — `apply_install_gate(InstallResult, GateLevel)` + 9 `GateError` variants. Reads `sbom.cdx.json` + `cve.json` from the sealed volume, recognizes B.2's empty-tool stub fingerprints, walks pip-audit + pnpm-audit JSON shapes for high/critical severities.
- `mvm-plan::DepsVolumeBinding` threaded through `SynthesisInput`; `synthesize_plan` pins it onto `ExecutionPlan.deps_volume`.
- `AdmitPlanForBootParams.deps_volume` threaded through all three `mvmctl up` admit call sites (direct-boot, main, watch-rebuild).
- `up::resolve_deps_volume_binding{,_with_cache}` — host helper that loads IR → dispatches install → applies gate. Cache-root override keeps the tests hermetic.
- v1 surface is cache-hit-only: cache-miss under `mvmctl up` raises a typed diagnostic pointing at `mvmctl deps build` (Followup C — the verb that drives the cache-miss path).

## Test plan

- [x] `cargo fmt --check` clean
- [x] `cargo clippy --workspace --all-targets -- -D warnings` clean
- [x] `cargo run -p xtask -- check-no-display-on-secret-types` clean
- [x] `cargo test --workspace` passes
- [x] **Gate tests** (13): every typed prod rejection (`MissingSbom`, `MissingCveScan`, `HighCveFinding` for pip-audit + pnpm-audit shapes, missing files, malformed JSON), dev warn-and-continue, medium/low CVE pass-through.
- [x] **Plan-synthesis tests**: with/without `deps_volume`; full serde round-trip with the binding present.
- [x] **`resolve_deps_volume_binding` tests** (9): no IR → None; `Dependencies::None` → None; cache-hit → binding; cache-miss → diagnostic mentioning `mvmctl deps build`; stub SBOM → prod-gate failure; dev gate warns + returns binding; unparseable IR + non-local-path source rejected.
- [x] **CLI flag-parse tests** (4): `--from-workload-ir` parses; absent → `None`; combines with `--dev` / `--prod`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)