### PR TITLE
feat(mvm-cli,sdks): plan 73 followup H-live — mvmctl run --mode live transport

### DIFF
--- a/crates/mvm-base/src/ui.rs
+++ b/crates/mvm-base/src/ui.rs
@@ -20,6 +20,33 @@ pub fn is_verbose() -> bool {
     VERBOSE.load(Ordering::Relaxed)
 }
 
+/// When set, `info` / `success` / `warn` / `step` / `progress` route
+/// to stderr instead of stdout. Errors already go to stderr
+/// unconditionally. The toggle exists so verbs that emit a final
+/// structured-JSON envelope on stdout (`mvmctl up --up-json`,
+/// Followup H-live) can suppress chrome from the parsed channel
+/// without rewriting every call site.
+static CHROME_TO_STDERR: AtomicBool = AtomicBool::new(false);
+
+/// Route `[mvm]` chatter to stderr instead of stdout. Used by verbs
+/// that emit a machine-readable envelope on stdout. Idempotent; the
+/// flag is process-global, so callers reset it when they're done.
+pub fn set_chrome_to_stderr(on: bool) {
+    CHROME_TO_STDERR.store(on, Ordering::Relaxed);
+}
+
+/// Whether chrome is currently routed to stderr. Public so that
+/// the parallel `mvm-cli::ui` mirror module can honor the same
+/// flag without each crate maintaining its own atomic.
+pub fn is_chrome_routed_to_stderr() -> bool {
+    CHROME_TO_STDERR.load(Ordering::Relaxed)
+}
+
+/// Internal alias used by the in-module print helpers.
+fn chrome_to_stderr() -> bool {
+    is_chrome_routed_to_stderr()
+}
+
 // ---------------------------------------------------------------------------
 // Colored message helpers
 // ---------------------------------------------------------------------------
@@ -30,12 +57,20 @@ fn prefix() -> String {
 
 /// Print an informational message: [mvm] message
 pub fn info(msg: &str) {
-    println!("{} {}", prefix(), msg);
+    if chrome_to_stderr() {
+        eprintln!("{} {}", prefix(), msg);
+    } else {
+        println!("{} {}", prefix(), msg);
+    }
 }
 
 /// Print a success message: [mvm] message (in green)
 pub fn success(msg: &str) {
-    println!("{} {}", prefix(), msg.green());
+    if chrome_to_stderr() {
+        eprintln!("{} {}", prefix(), msg.green());
+    } else {
+        println!("{} {}", prefix(), msg.green());
+    }
 }
 
 /// Print an error message: [mvm] ERROR: message (in red).
@@ -45,17 +80,26 @@ pub fn error(msg: &str) {
 
 /// Print a warning message: [mvm] message (in yellow)
 pub fn warn(msg: &str) {
-    println!("{} {}", prefix(), msg.yellow());
+    if chrome_to_stderr() {
+        eprintln!("{} {}", prefix(), msg.yellow());
+    } else {
+        println!("{} {}", prefix(), msg.yellow());
+    }
 }
 
 /// Print a numbered step: [mvm] Step n/total: message
 pub fn step(n: u32, total: u32, msg: &str) {
-    println!(
+    let formatted = format!(
         "\n{} {} {}",
         prefix(),
         format!("Step {}/{}:", n, total).bold().yellow(),
         msg,
     );
+    if chrome_to_stderr() {
+        eprintln!("{formatted}");
+    } else {
+        println!("{formatted}");
+    }
 }
 
 /// Print a progress / chatter message that's only useful when
@@ -65,7 +109,11 @@ pub fn progress(msg: &str) {
     if !is_verbose() {
         return;
     }
-    println!("{} {}", prefix(), msg);
+    if chrome_to_stderr() {
+        eprintln!("{} {}", prefix(), msg);
+    } else {
+        println!("{} {}", prefix(), msg);
+    }
 }
 
 // ---------------------------------------------------------------------------

--- a/crates/mvm-cli/src/commands/vm/exec.rs
+++ b/crates/mvm-cli/src/commands/vm/exec.rs
@@ -113,18 +113,23 @@ pub(in crate::commands) struct RunArgs {
     /// Path to an mvmforge launch document. Mutually exclusive with trailing argv.
     #[arg(long, value_name = "PATH", conflicts_with = "argv")]
     pub launch_plan: Option<String>,
-    /// SDK transport mode for `mvmctl run`. v1 wires only
-    /// `--mode plan` (synthesize an ExecutionPlan per Sandbox call
-    /// and route through `mvm_supervisor::admit_for_run`; no
-    /// microVM ever boots). `--mode live` is reserved for the
-    /// Followup H-live half (Plan 73); `--mode record` redirects
-    /// users to `mvmctl compile` (where record is the default).
+    /// SDK transport mode for `mvmctl run`.
+    ///
+    /// - `--mode plan` (Followup H-plan): synthesize an
+    ///   ExecutionPlan per Sandbox call and route through
+    ///   `mvm_supervisor::admit_for_run`; no microVM ever boots.
+    /// - `--mode live` (Followup H-live, Plan 73): spawn the user's
+    ///   script with `MVM_SDK_MODE=live` so the SDK shells each
+    ///   `Sandbox` operation to existing `mvmctl up` / `proc start` /
+    ///   `fs write` / `down` against a real microVM.
+    /// - `--mode record` redirects users to `mvmctl compile` (where
+    ///   record is the default mode).
+    ///
     /// When unset, the verb behaves as a transient-sandbox runner
     /// over the trailing argv — its pre-Followup-H semantics.
     #[arg(long = "mode", value_enum)]
     pub mode: Option<RunMode>,
-    /// Friendly alias for `--mode live`. Refused in v1 until the
-    /// Followup H-live half lands.
+    /// Friendly alias for `--mode live` (Plan 73 Followup H-live).
     #[arg(long = "dev", conflicts_with_all = ["prod", "mode"])]
     pub dev: bool,
     /// Friendly alias for `--mode record`. `mvmctl run --prod`
@@ -149,7 +154,8 @@ pub(in crate::commands) struct RunArgs {
 #[derive(Debug, Clone, Copy, PartialEq, Eq, ValueEnum)]
 pub(in crate::commands) enum RunMode {
     /// Live transport — Sandbox calls shell out to existing mvmctl
-    /// up/exec/down. Reserved for Followup H-live; refused in v1.
+    /// up / proc start / fs write / down against a real microVM.
+    /// Plan 73 Followup H-live.
     Live,
     /// Plan transport — synthesise one ExecutionPlan per Sandbox
     /// operation and route through `mvm_supervisor::admit_for_run`.
@@ -269,11 +275,7 @@ pub(in crate::commands) fn resolve_run_mode(args: &RunArgs) -> Result<Option<Run
         return Ok(Some(parse_env_run_mode(&env_mode)?));
     }
     if args.dev {
-        anyhow::bail!(
-            "`mvmctl run --dev` (alias for --mode live) is blocked — pairs with Followup H-live, \
-             which lands once Plan 72 W4/W5 are validated end to end. Use `--mode plan` for the \
-             admission dry-run, or `mvmctl compile` for the record path."
-        );
+        return Ok(Some(RunMode::Live));
     }
     if args.prod {
         anyhow::bail!(
@@ -284,10 +286,7 @@ pub(in crate::commands) fn resolve_run_mode(args: &RunArgs) -> Result<Option<Run
     }
     match args.mode {
         None => Ok(None),
-        Some(RunMode::Live) => anyhow::bail!(
-            "`mvmctl run --mode live` is blocked — pairs with Followup H-live, which lands once \
-             Plan 72 W4/W5 are validated end to end. Use `--mode plan` for the admission dry-run."
-        ),
+        Some(RunMode::Live) => Ok(Some(RunMode::Live)),
         Some(RunMode::Record) => anyhow::bail!(
             "`mvmctl run --mode record` is unsupported — `mvmctl compile` is the record-mode verb \
              (record is the default; pass the script as the positional entry)."
@@ -298,10 +297,7 @@ pub(in crate::commands) fn resolve_run_mode(args: &RunArgs) -> Result<Option<Run
 
 fn parse_env_run_mode(raw: &str) -> Result<RunMode> {
     match raw.trim().to_ascii_lowercase().as_str() {
-        "live" => anyhow::bail!(
-            "MVM_SDK_MODE=live is blocked on `mvmctl run` — pairs with Followup H-live (lands \
-             once Plan 72 W4/W5 are validated)."
-        ),
+        "live" => Ok(RunMode::Live),
         "plan" => Ok(RunMode::Plan),
         "record" => anyhow::bail!(
             "MVM_SDK_MODE=record on `mvmctl run` is unsupported — `mvmctl compile` is the \
@@ -716,13 +712,13 @@ mod tests {
     }
 
     #[test]
-    fn resolve_run_mode_bails_blocked_for_dev_alias() {
+    fn resolve_run_mode_returns_live_for_dev_alias() {
         let mut args = run_args(RunProfile::Standard);
         args.dev = true;
-        let err = resolve_run_mode(&args).expect_err("--dev must bail");
-        let msg = err.to_string();
-        assert!(msg.contains("Followup H-live"));
-        assert!(msg.contains("--mode plan"));
+        let mode = resolve_run_mode(&args)
+            .expect("--dev resolves to Some(Live) post-H-live")
+            .expect("must be Some(Live)");
+        assert_eq!(mode, RunMode::Live);
     }
 
     #[test]
@@ -735,12 +731,13 @@ mod tests {
     }
 
     #[test]
-    fn resolve_run_mode_bails_blocked_for_mode_live() {
+    fn resolve_run_mode_returns_live_for_mode_live() {
         let mut args = run_args(RunProfile::Standard);
         args.mode = Some(RunMode::Live);
-        let err = resolve_run_mode(&args).expect_err("--mode live must bail");
-        let msg = err.to_string();
-        assert!(msg.contains("Followup H-live"));
+        let mode = resolve_run_mode(&args)
+            .expect("--mode live resolves to Some(Live) post-H-live")
+            .expect("must be Some(Live)");
+        assert_eq!(mode, RunMode::Live);
     }
 
     #[test]

--- a/crates/mvm-cli/src/commands/vm/run_plan.rs
+++ b/crates/mvm-cli/src/commands/vm/run_plan.rs
@@ -1,13 +1,22 @@
-//! `mvmctl run --mode plan` — SDK plan transport.
+//! `mvmctl run --mode plan|live` — SDK transports.
 //!
-//! Followup H plan half (Plan 73). The verb runs a Sandbox-shaped
-//! script with the SDK's `Sandbox` operations rerouted to
-//! synthesize one `ExecutionPlan` per call and route each through
-//! `mvm_supervisor::admit_for_run` for a dry-run admission check.
-//! **No microVM ever boots** — the value is that admission gates
-//! (signature, validity window, replay store, policy resolution)
-//! fire end-to-end without the cost of booting and tearing down a
-//! VM.
+//! Two transports share this module:
+//!
+//! - **plan** (Followup H-plan, already shipped): runs a
+//!   Sandbox-shaped script with the SDK in record mode, lowers the
+//!   captured recording, synthesises one `ExecutionPlan` per app
+//!   and routes each through `mvm_supervisor::admit_for_run` for a
+//!   dry-run admission check. **No microVM ever boots** — the value
+//!   is that admission gates (signature, validity window, replay
+//!   store, policy resolution) fire end-to-end without the cost of
+//!   booting and tearing down a VM.
+//! - **live** (Followup H-live, this module's other half): spawns
+//!   the user's script with `MVM_SDK_MODE=live` and
+//!   `MVM_CLI_BIN=<path-to-mvmctl>` so the SDK shells each
+//!   `Sandbox` operation to existing `mvmctl up` / `proc start` /
+//!   `fs write` / `down` against a real microVM. No plan
+//!   synthesis here — the SDK drives plan-64 admission once per
+//!   per-call shell via the wrapped verbs.
 //!
 //! ## How it works
 //!
@@ -58,20 +67,95 @@ use crate::commands::build::sandbox_record::{auto_exec_record_script, script_lan
 
 use super::exec::{RunArgs, RunMode};
 
-/// Dispatch an SDK-mode `mvmctl run` invocation. v1 only wires
-/// `RunMode::Plan`; the other variants are intercepted by
-/// `super::exec::resolve_run_mode` before reaching this entry.
+/// Dispatch an SDK-mode `mvmctl run` invocation. Plan and Live both
+/// reach this entry now (Followup H-plan + Followup H-live);
+/// `Record` is still refused at the `resolve_run_mode` layer.
 pub(in crate::commands) fn dispatch_sdk_mode(mode: RunMode, args: &RunArgs) -> Result<()> {
     match mode {
         RunMode::Plan => run_plan_mode(args),
-        // The exec module's resolve_run_mode already bails on these
-        // variants — keep the match exhaustive so a future addition
-        // raises a compile error here too.
-        RunMode::Live | RunMode::Record => unreachable!(
-            "exec::resolve_run_mode is expected to refuse {mode:?} before reaching run_plan; \
-             this is a logic bug — file an issue."
+        RunMode::Live => run_live_mode(args),
+        RunMode::Record => unreachable!(
+            "exec::resolve_run_mode refuses RunMode::Record before reaching dispatch; this is a \
+             logic bug — file an issue."
         ),
     }
+}
+
+/// Followup H-live (Plan 73): spawn the user's Sandbox-shaped
+/// script with `MVM_SDK_MODE=live` + the resolved `mvmctl`
+/// binary path on the env so the SDK shells each `Sandbox`
+/// operation to `mvmctl up` / `proc start` / `fs write` / `down`
+/// against a real microVM.
+///
+/// The wire shape — the env-var contract:
+///
+/// - `MVM_SDK_MODE=live` — branch in the SDK toggling the
+///   subprocess transport on.
+/// - `MVM_CLI_BIN=<absolute-path>` — the binary the SDK shells to.
+///   We pass our own absolute path (resolved via
+///   [`std::env::current_exe`]) so a `cargo run -- run --mode
+///   live` flow finds the same `mvmctl` it invoked through.
+/// - Inherited stdio + env — the SDK prints its own output;
+///   nothing is captured here.
+///
+/// Errors: the user's script exit code propagates verbatim. We
+/// surface a wrapped error only when the spawn itself fails (PATH
+/// resolution, missing interpreter, etc.).
+fn run_live_mode(args: &RunArgs) -> Result<()> {
+    let script = extract_script_arg(args)?;
+    let lang = script_language_from_path(&script).ok_or_else(|| {
+        anyhow::anyhow!(
+            "`mvmctl run --mode live` expected a `.py`, `.ts`, `.tsx`, `.js`, `.mjs`, `.cjs`, \
+             `.mts`, or `.cts` script path, got {}.",
+            script.display()
+        )
+    })?;
+
+    let interpreter = crate::commands::build::sandbox_record::resolve_interpreter(lang)?;
+    let mvmctl_bin = std::env::current_exe()
+        .context("resolving the running mvmctl binary path for MVM_CLI_BIN")?;
+
+    eprintln!(
+        "mvmctl run --mode live: spawning {} {} (MVM_CLI_BIN={})",
+        interpreter.display(),
+        script.display(),
+        mvmctl_bin.display(),
+    );
+
+    let mut cmd = std::process::Command::new(&interpreter);
+    // Deno's default sandbox refuses fs + subprocess; the SDK's
+    // live mode shells to `mvmctl`, so opt out explicitly. The
+    // same opt-out lives in `auto_exec_record_script`.
+    let basename = interpreter
+        .file_name()
+        .and_then(|s| s.to_str())
+        .unwrap_or("");
+    if basename.starts_with("deno") {
+        cmd.arg("run").arg("--allow-all");
+    }
+    let status = cmd
+        .arg(&script)
+        .env("MVM_SDK_MODE", "live")
+        .env("MVM_CLI_BIN", &mvmctl_bin)
+        .status()
+        .with_context(|| {
+            format!(
+                "spawning {} to run live-mode script {}",
+                interpreter.display(),
+                script.display()
+            )
+        })?;
+
+    if !status.success() {
+        anyhow::bail!(
+            "live-mode script {} exited with {:?}; the SDK's subprocess transport reports each \
+             failed `mvmctl` shell in its own diagnostic. Re-run the script directly to see the \
+             unfiltered output.",
+            script.display(),
+            status.code(),
+        );
+    }
+    Ok(())
 }
 
 fn run_plan_mode(args: &RunArgs) -> Result<()> {
@@ -147,16 +231,16 @@ fn run_plan_mode(args: &RunArgs) -> Result<()> {
     Ok(())
 }
 
-/// Pull the script path off `args.argv`. Under `--mode plan` the
-/// argv slot carries a single positional: the script. Anything
-/// else is an error.
+/// Pull the script path off `args.argv`. Both `--mode plan` and
+/// `--mode live` consume the argv slot as a single positional:
+/// the script. Anything else is an error.
 fn extract_script_arg(args: &RunArgs) -> Result<PathBuf> {
     if !args.argv.is_empty() {
         if args.argv.len() > 1 {
             bail!(
-                "`mvmctl run --mode plan` expected exactly one positional (the script path); \
-                 got {} arguments: {:?}. Plan mode never boots a VM, so trailing argv beyond the \
-                 script is meaningless.",
+                "`mvmctl run --mode plan|live` expected exactly one positional (the script \
+                 path); got {} arguments: {:?}. Both SDK transport modes consume a single \
+                 script — trailing argv has no meaning here.",
                 args.argv.len(),
                 args.argv
             );
@@ -164,8 +248,8 @@ fn extract_script_arg(args: &RunArgs) -> Result<PathBuf> {
         return Ok(PathBuf::from(&args.argv[0]));
     }
     bail!(
-        "`mvmctl run --mode plan` requires a script path. Pass a `.py`, `.ts`, or `.js` script \
-         that builds a Sandbox: e.g. `mvmctl run --mode plan ./hello.py`."
+        "`mvmctl run --mode plan|live` requires a script path. Pass a `.py`, `.ts`, or `.js` \
+         script that builds a Sandbox: e.g. `mvmctl run --mode live ./hello.py`."
     )
 }
 

--- a/crates/mvm-cli/src/commands/vm/up.rs
+++ b/crates/mvm-cli/src/commands/vm/up.rs
@@ -659,6 +659,25 @@ pub(in crate::commands) struct Args {
     /// (claim-8 preserved). ADR-047 claim 9.
     #[arg(long = "from-workload-ir", value_name = "PATH")]
     pub from_workload_ir: Option<std::path::PathBuf>,
+    /// Emit a one-line JSON envelope on stdout when the VM is up.
+    /// Routes the friendly `[mvm]` chrome to stderr so the SDK
+    /// live-mode transport (Plan 73 Followup H-live) can parse a
+    /// single JSON document instead of teaching the SDK to scrape
+    /// the human-formatted log.
+    ///
+    /// Envelope shape (schema_version=1):
+    ///
+    /// ```json
+    /// {"schema_version": 1, "vm_id": "myvm",
+    ///  "build_mode": "dev"|"prod"}
+    /// ```
+    ///
+    /// `build_mode` is read from the resolved template's
+    /// `TemplateRevision.build_mode` (defaulting to `prod`) and
+    /// is the load-bearing signal the SDK uses to enforce the
+    /// claim-4 dev-only `do_exec` rule client-side.
+    #[arg(long = "up-json")]
+    pub up_json: bool,
 }
 
 pub(in crate::commands) fn run(_cli: &Cli, args: Args, cfg: &MvmConfig) -> Result<()> {
@@ -771,6 +790,34 @@ pub(in crate::commands) fn run(_cli: &Cli, args: Args, cfg: &MvmConfig) -> Resul
         );
     }
 
+    // `--up-json` routes the friendly `[mvm]` chrome to stderr and
+    // suppresses the auto-watch / auto-forward loops that would
+    // otherwise block forever — the SDK live-mode transport (Plan 73
+    // Followup H-live) drives subsequent `proc start`/`fs write`/
+    // `down` calls from outside, so `mvmctl up` must return as soon
+    // as the VM is up. We also imply `--detach` for the Apple
+    // Container launchd path so the agent owns the VM lifecycle.
+    if args.up_json {
+        mvm::ui::set_chrome_to_stderr(true);
+        if args.watch {
+            anyhow::bail!(
+                "--up-json is incompatible with --watch (the JSON envelope is emitted once on first boot; watch reboots the VM repeatedly)."
+            );
+        }
+        if args.forward {
+            anyhow::bail!(
+                "--up-json is incompatible with --forward (--forward blocks until Ctrl+C; --up-json must return as soon as the VM is up)."
+            );
+        }
+    }
+
+    // Capture the effective up-json + name eagerly so we can emit
+    // the envelope on stdout after `cmd_run` returns. The friendly
+    // chrome is already routed to stderr above.
+    let up_json_resolved = args.up_json;
+    let user_supplied_name = args.name.clone();
+    let template_name_for_envelope = resolved_template_arg.clone();
+
     cmd_run(RunParams {
         flake_ref: args.flake.as_deref(),
         template_name: resolved_template_arg.as_deref(),
@@ -787,7 +834,7 @@ pub(in crate::commands) fn run(_cli: &Cli, args: Args, cfg: &MvmConfig) -> Resul
         metrics_port: args.metrics_port,
         watch_config: args.watch_config,
         watch: args.watch,
-        detach: args.detach,
+        detach: args.detach || args.up_json,
         network_policy,
         network_name: &args.network,
         seccomp_tier,
@@ -800,7 +847,56 @@ pub(in crate::commands) fn run(_cli: &Cli, args: Args, cfg: &MvmConfig) -> Resul
         bundle_pin: args.bundle_pin.as_deref(),
         build_mode,
         workload_ir_path: args.from_workload_ir.as_deref(),
-    })
+        up_json: args.up_json,
+    })?;
+
+    // Plan 73 Followup H-live: after a successful boot, emit a
+    // one-line JSON envelope on stdout. The SDK live-mode transport
+    // reads this envelope verbatim and threads `vm_id` + `build_mode`
+    // through to subsequent `proc start` / `fs write` / `down`
+    // shells. The friendly chrome already went to stderr above.
+    if up_json_resolved {
+        let vm_id = user_supplied_name
+            .or_else(|| std::env::var("MVM_REEXEC_NAME").ok())
+            .unwrap_or_default();
+        let build_mode_str = match template_name_for_envelope.as_deref() {
+            Some(t) => template_build_mode_for_envelope(t).unwrap_or("prod"),
+            None => match build_mode {
+                mvm_build::pipeline::BuildMode::Dev => "dev",
+                mvm_build::pipeline::BuildMode::Prod => "prod",
+            },
+        };
+        let envelope = serde_json::json!({
+            "schema_version": 1,
+            "vm_id": vm_id,
+            "build_mode": build_mode_str,
+        });
+        println!("{}", envelope);
+    }
+    Ok(())
+}
+
+/// Resolve a template's `TemplateRevision.build_mode` for the
+/// `--up-json` envelope. Returns `Some("dev")` / `Some("prod")` when
+/// the revision parses cleanly, `None` when the template isn't on
+/// disk (no spec to read, treat as prod downstream). Tolerates I/O
+/// errors by returning `None` — the envelope's `build_mode` is a
+/// hint, not a security boundary (the agent's `do_exec` strip is
+/// the load-bearing W4.3 gate per ADR-002 §W4.3). Live-mode SDK
+/// clients use it to reject `commands.start` against a prod
+/// template *before* any vsock round-trip; a missing / unreadable
+/// spec falls through to the agent's response (the agent still
+/// fails closed).
+fn template_build_mode_for_envelope(template_name: &str) -> Option<&'static str> {
+    // `template_load_current_revision` walks the same `current`
+    // symlink the boot path uses, so the resolution matches what the
+    // running VM was built from.
+    let revision =
+        mvm::vm::template::lifecycle::template_load_current_revision(template_name).ok()??;
+    match revision.build_mode.as_deref() {
+        Some("dev") => Some("dev"),
+        _ => Some("prod"),
+    }
 }
 
 pub(in crate::commands) struct RunParams<'a> {
@@ -845,6 +941,12 @@ pub(in crate::commands) struct RunParams<'a> {
     /// pins a `DepsVolumeBinding` into the synthesized plan.
     /// Plan 73 Followup B.3.
     pub(super) workload_ir_path: Option<&'a std::path::Path>,
+    /// When `true`, `cmd_run` emits a one-line JSON envelope on
+    /// stdout right before returning. Plan 73 Followup H-live: the
+    /// SDK live-mode transport parses this envelope to thread the
+    /// generated VM id + the template's `build_mode` through to
+    /// subsequent `proc start` / `fs write` / `down` calls.
+    pub(super) up_json: bool,
 }
 
 pub(super) fn cmd_run(params: RunParams<'_>) -> Result<()> {
@@ -877,6 +979,7 @@ pub(super) fn cmd_run(params: RunParams<'_>) -> Result<()> {
         bundle_pin,
         build_mode,
         workload_ir_path,
+        up_json: _up_json,
     } = params;
     let _span =
         tracing::info_span!("cmd_run", name = ?name, cpus = ?cpus, memory_mib = ?memory).entered();

--- a/crates/mvm-cli/src/ui.rs
+++ b/crates/mvm-cli/src/ui.rs
@@ -23,12 +23,20 @@ fn prefix() -> String {
 
 /// Print an informational message: [mvm] message
 pub fn info(msg: &str) {
-    println!("{} {}", prefix(), msg);
+    if mvm::ui::is_chrome_routed_to_stderr() {
+        eprintln!("{} {}", prefix(), msg);
+    } else {
+        println!("{} {}", prefix(), msg);
+    }
 }
 
 /// Print a success message: [mvm] message (in green)
 pub fn success(msg: &str) {
-    println!("{} {}", prefix(), msg.green());
+    if mvm::ui::is_chrome_routed_to_stderr() {
+        eprintln!("{} {}", prefix(), msg.green());
+    } else {
+        println!("{} {}", prefix(), msg.green());
+    }
 }
 
 /// Print an error message: [mvm] ERROR: message (in red)
@@ -38,17 +46,26 @@ pub fn error(msg: &str) {
 
 /// Print a warning message: [mvm] message (in yellow)
 pub fn warn(msg: &str) {
-    println!("{} {}", prefix(), msg.yellow());
+    if mvm::ui::is_chrome_routed_to_stderr() {
+        eprintln!("{} {}", prefix(), msg.yellow());
+    } else {
+        println!("{} {}", prefix(), msg.yellow());
+    }
 }
 
 /// Print a numbered step: [mvm] Step n/total: message
 pub fn step(n: u32, total: u32, msg: &str) {
-    println!(
+    let formatted = format!(
         "\n{} {} {}",
         prefix(),
         format!("Step {}/{}:", n, total).bold().yellow(),
         msg,
     );
+    if mvm::ui::is_chrome_routed_to_stderr() {
+        eprintln!("{formatted}");
+    } else {
+        println!("{formatted}");
+    }
 }
 
 // ---------------------------------------------------------------------------

--- a/sdks/python/mvm/__init__.py
+++ b/sdks/python/mvm/__init__.py
@@ -64,8 +64,11 @@ from mvm._dsl import (
 )
 from mvm._sandbox import (
     DEFAULT_TTL_SECONDS,
+    MVM_CLI_BIN_ENV,
     RecordingNotActiveError,
     Sandbox,
+    SandboxDevOnly,
+    SandboxLiveError,
     SandboxModeError,
     current_recording_dict,
     emit_recording_json,
@@ -75,6 +78,7 @@ from mvm._session import current_session_id
 
 __all__ = [
     "DEFAULT_TTL_SECONDS",
+    "MVM_CLI_BIN_ENV",
     "SCHEMA_VERSION",
     "EmittingContextError",
     "MsgpackUnavailable",
@@ -85,6 +89,8 @@ __all__ = [
     "RemoteError",
     "RemoteFunction",
     "Sandbox",
+    "SandboxDevOnly",
+    "SandboxLiveError",
     "SandboxModeError",
     "SecretInArgError",
     "SecretInArgWarning",

--- a/sdks/python/mvm/_sandbox.py
+++ b/sdks/python/mvm/_sandbox.py
@@ -1,20 +1,31 @@
-"""Sandbox — e2b-style imperative runtime SDK. SDK port Phase 7b.
+"""Sandbox — e2b-style imperative runtime SDK. SDK port Phase 7b +
+Plan 73 Followup H-live.
 
 The decorator surface (``@mvm.app(...)``) is static; the host
 parses the source AST and never imports the script. The runtime
 surface (``Sandbox.create(...)``) is imperative: the host *does*
 execute the user's Python script (per S2 in the SDK plan — a
-documented departure), with the SDK reconfigured to record each
-``Sandbox`` method call into a :class:`RuntimeRecording` instead
-of dialing a real microVM.
+documented departure), with the SDK reconfigured to either record
+each ``Sandbox`` method call into a :class:`RuntimeRecording` or
+shell each call to ``mvmctl`` against a real microVM, depending
+on the active mode.
 
-Phase 7b ships *only record mode*. ``MVM_SDK_MODE=record`` is the
-mode the recorder reads; ``live`` and ``plan`` raise
-:class:`NotImplementedError` until Plan 72 unblocks
-``mvmctl up``/``exec``. The record-mode lowering happens on the
-Rust side (``crates/mvm-sdk/src/runtime.rs::compile_recording``);
-this module's job is just to build a wire-compatible recording
-JSON document.
+Two modes are live:
+
+- ``MVM_SDK_MODE=record`` (the original Phase 7b contract):
+  every ``Sandbox`` call appends to an in-process recording. The
+  host's ``mvmctl compile`` / ``mvmctl run --mode plan`` verbs
+  lower the recording via ``compile_recording``.
+- ``MVM_SDK_MODE=live`` (Plan 73 Followup H-live): every
+  ``Sandbox`` call shells to ``$MVM_CLI_BIN`` (``mvmctl up``,
+  ``mvmctl proc start``, ``mvmctl fs write``, ``mvmctl down``)
+  against a real microVM. The shell is dispatched by
+  :class:`_LiveTransport` below.
+
+``MVM_SDK_MODE=plan`` remains an error here — the host's
+``mvmctl run --mode plan`` verb is what runs a Sandbox script
+under that transport; the SDK itself never enters "plan" mode
+directly.
 
 Wire shape (matches the Rust ``RuntimeRecording`` serde types,
 ``deny_unknown_fields`` on both sides — a typo'd field name fails
@@ -51,6 +62,8 @@ import enum
 import json
 import os
 import re
+import secrets
+import subprocess
 import sys
 from typing import Any
 
@@ -59,8 +72,11 @@ from mvm._dsl import literal as _literal_value
 
 __all__ = [
     "DEFAULT_TTL_SECONDS",
+    "MVM_CLI_BIN_ENV",
     "RecordingNotActiveError",
     "Sandbox",
+    "SandboxDevOnly",
+    "SandboxLiveError",
     "SandboxModeError",
     "current_recording_dict",
     "emit_recording_json",
@@ -76,6 +92,13 @@ MVM_SDK_MODE_ENV = "MVM_SDK_MODE"
 #: parsing stdout (which the user's own script may write to).
 MVM_SDK_OUT_PATH_ENV = "MVM_SDK_OUT_PATH"
 
+#: Plan 73 Followup H-live — when ``MVM_SDK_MODE=live`` is set, the
+#: SDK shells out to the ``mvmctl`` binary at this path. The host's
+#: ``mvmctl run --mode live`` verb sets it to its own
+#: ``current_exe()`` so a `cargo run -- run --mode live` flow finds
+#: the same binary it invoked through.
+MVM_CLI_BIN_ENV = "MVM_CLI_BIN"
+
 #: Plan ``Considerations to fold in or defer`` — every
 #: ``Sandbox.create()`` sets a default 30-minute TTL so the
 #: orchestrator can reap orphaned VMs after a crashed record-mode
@@ -85,14 +108,47 @@ DEFAULT_TTL_SECONDS = 1800
 
 class SandboxModeError(RuntimeError):
     """Raised when the configured ``MVM_SDK_MODE`` isn't supported by
-    this SDK build. Phase 7b ships record-only — ``live`` and ``plan``
-    are blocked on Plan 72."""
+    this SDK build (e.g. ``MVM_SDK_MODE=plan`` against the in-process
+    SDK — plan mode lives in the host CLI, not here)."""
 
 
 class RecordingNotActiveError(RuntimeError):
     """Raised when a ``Sandbox`` method is called outside a recording
     session (i.e. before ``Sandbox.create`` ran, or after
     :func:`reset_recording`)."""
+
+
+class SandboxLiveError(RuntimeError):
+    """Raised when a live-mode shell to ``mvmctl`` fails. Carries the
+    failing argv, exit code, and captured stderr so user scripts can
+    see exactly which verb refused and why."""
+
+    def __init__(
+        self,
+        message: str,
+        *,
+        argv: list[str] | None = None,
+        exit_code: int | None = None,
+        stderr: str | None = None,
+    ) -> None:
+        super().__init__(message)
+        self.argv = list(argv) if argv else []
+        self.exit_code = exit_code
+        self.stderr = stderr or ""
+
+
+class SandboxDevOnly(SandboxLiveError):
+    """Raised when the SDK refuses a live-mode ``commands.start``
+    call because the resolved template is a *prod* template.
+
+    Per ADR-002 §W4.3 (security claim 4 in :doc:`CLAUDE.md`) the
+    guest agent strips the ``do_exec`` handler in production
+    builds. The agent itself fails closed, but the SDK refuses
+    *before* any vsock traffic so a user typo doesn't make a
+    spurious round-trip. ``commands.start`` is the only Sandbox
+    surface that hits ``proc start``; ``files.write`` and
+    ``kill`` route to verbs that are available in prod builds
+    too."""
 
 
 # ────────────────────────────────────────────────────────────────────
@@ -105,12 +161,40 @@ class RecordingNotActiveError(RuntimeError):
 
 _recording: dict[str, Any] | None = None
 
+#: Live-mode bookkeeping. Mirrors `_recording`'s "one session per
+#: process" invariant — a live Sandbox is stashed here so a second
+#: `Sandbox.create(...)` call inside the same process is refused.
+_live_sandbox: "Sandbox | None" = None
+
+
+def _live_sandbox_active() -> bool:
+    """Return True if a live-mode Sandbox is currently registered."""
+    return _live_sandbox is not None
+
+
+def _register_live(sb: "Sandbox") -> None:
+    """Register a live-mode Sandbox so the one-per-process gate
+    fires on a second `Sandbox.create` call."""
+    global _live_sandbox
+    _live_sandbox = sb
+
+
+def _clear_live() -> None:
+    """Clear the live-mode registration. Called by
+    `Sandbox.kill()` so a script that explicitly kills + reopens
+    works as expected (the context-manager exit path also
+    clears)."""
+    global _live_sandbox
+    _live_sandbox = None
+
 
 def reset_recording() -> None:
-    """Clear the in-flight recording. Tests use this between
-    runs; production never calls it (the process exits)."""
-    global _recording
+    """Clear the in-flight recording state and any live registration.
+    Tests use this between runs; production never calls it (the
+    process exits)."""
+    global _recording, _live_sandbox
     _recording = None
+    _live_sandbox = None
 
 
 def current_recording_dict() -> dict[str, Any] | None:
@@ -172,18 +256,34 @@ atexit.register(_flush_recording_to_out_path)
 def _resolve_mode() -> str:
     """Read ``MVM_SDK_MODE``. Defaults to ``record`` so a bare
     ``python sandbox.py`` invoked by the CLI works without an env
-    var. ``live`` and ``plan`` aren't supported in Phase 7b."""
+    var.
+
+    Accepts ``record`` (Phase 7b record transport, in-process
+    recording) and ``live`` (Plan 73 Followup H-live, shells to
+    ``mvmctl``). ``plan`` belongs to the host CLI's
+    ``mvmctl run --mode plan`` verb — not a valid value here, so
+    we refuse it with an actionable hint."""
     raw = os.environ.get(MVM_SDK_MODE_ENV, "record").strip().lower()
     if raw == "record":
-        return raw
-    if raw in {"live", "plan"}:
+        return "record"
+    if raw == "live":
+        if not os.environ.get(MVM_CLI_BIN_ENV):
+            raise SandboxModeError(
+                "MVM_SDK_MODE=live requires MVM_CLI_BIN to point at a `mvmctl` binary. "
+                "The host's `mvmctl run --mode live` verb sets this automatically; if "
+                "you're running the SDK directly, export MVM_CLI_BIN=/path/to/mvmctl "
+                "before invoking your script."
+            )
+        return "live"
+    if raw == "plan":
         raise SandboxModeError(
-            f"MVM_SDK_MODE={raw!r} is not supported in this SDK build — "
-            "live/plan transports are blocked on Plan 72. Use 'record' or "
-            "the @mvm.app decorator path."
+            "MVM_SDK_MODE=plan is not a SDK-side transport — the host CLI's "
+            "`mvmctl run --mode plan` verb runs your script under record mode and "
+            "synthesises ExecutionPlans for admission dry-run. Drop MVM_SDK_MODE and "
+            "let `mvmctl run --mode plan` set the recording state for you."
         )
     raise SandboxModeError(
-        f"MVM_SDK_MODE={raw!r} is invalid — expected one of: record, live, plan"
+        f"MVM_SDK_MODE={raw!r} is invalid — expected one of: record, live"
     )
 
 
@@ -320,17 +420,25 @@ class _Commands:
     def start(
         self, argv: list[str], *, env: dict[str, Any] | None = None
     ) -> None:
-        """Record a ``commands.start(argv, env=...)`` op.
+        """Record or shell a ``commands.start(argv, env=...)`` op.
 
-        The *last* ``commands.start`` in the recording becomes the
-        workload's entrypoint; everything earlier becomes a
-        ``before_start`` hook in declaration order. Live transport
-        (actually exec'ing the command in a microVM) is deferred to a
-        post-Plan-71 follow-up."""
+        In record mode the *last* ``commands.start`` in the recording
+        becomes the workload's entrypoint; everything earlier
+        becomes a ``before_start`` hook in declaration order.
+
+        In live mode the call shells to ``mvmctl proc start <vm>``
+        against the running microVM. The SDK refuses with
+        :class:`SandboxDevOnly` if the resolved template is a
+        prod template (the agent's W4.3 ``do_exec`` strip would
+        refuse anyway, but the SDK fails closed first to avoid a
+        spurious vsock round-trip — ADR-002 claim 4)."""
         if not isinstance(argv, list) or not all(isinstance(a, str) for a in argv):
             raise TypeError("argv must be a list[str]")
         if not argv:
             raise ValueError("argv must be non-empty")
+        if self._sandbox._live is not None:
+            self._sandbox._live.commands_start(argv, env)
+            return
         _require_recording()
         _recording["ops"].append(
             {
@@ -348,13 +456,17 @@ class _Files:
         self._sandbox = sandbox
 
     def write(self, path: str, content: bytes | str) -> None:
-        """Record a ``files.write(path, content)`` op.
+        """Record or shell a ``files.write(path, content)`` op.
 
-        ``content`` is bytes (passed through verbatim) or str
-        (utf-8 encoded). The recording stores base64 so JSON
-        survives any byte content; the Rust lowering emits a
-        ``before_start`` shell hook that ``base64 -d``s back to the
-        file."""
+        In record mode: ``content`` is bytes (passed through
+        verbatim) or str (utf-8 encoded). The recording stores
+        base64 so JSON survives any byte content; the Rust lowering
+        emits a ``before_start`` shell hook that ``base64 -d``s
+        back to the file.
+
+        In live mode: the same bytes stream via stdin into
+        ``mvmctl fs write <vm> <path>`` — ``mvmctl fs write``
+        already accepts stdin when ``--content`` is omitted."""
         if not isinstance(path, str) or not path:
             raise ValueError("path must be a non-empty str")
         if isinstance(content, str):
@@ -366,6 +478,9 @@ class _Files:
                 f"files.write content must be bytes or str; got "
                 f"{type(content).__name__}"
             )
+        if self._sandbox._live is not None:
+            self._sandbox._live.files_write(path, data)
+            return
         _require_recording()
         _recording["ops"].append(
             {
@@ -376,19 +491,285 @@ class _Files:
         )
 
 
+class _LiveTransport:
+    """Live-mode transport — shells each Sandbox call to the host's
+    ``mvmctl`` binary.
+
+    Created by :meth:`Sandbox.create` when ``MVM_SDK_MODE=live``.
+    Holds the resolved ``mvmctl`` binary path, the generated
+    ``vm_id``, and the template's ``build_mode`` ("dev" / "prod")
+    parsed from ``mvmctl up --up-json``'s stdout envelope. The
+    ``build_mode`` is what the SDK uses to enforce the W4.3
+    dev-only ``proc start`` rule client-side."""
+
+    SCHEMA_VERSION = 1
+
+    def __init__(
+        self,
+        *,
+        mvm_cli_bin: str,
+        vm_id: str,
+        build_mode: str,
+    ) -> None:
+        self.mvm_cli_bin = mvm_cli_bin
+        self.vm_id = vm_id
+        self.build_mode = build_mode
+        self._killed = False
+
+    @classmethod
+    def for_template(
+        cls,
+        *,
+        template: str,
+        workload_id: str,
+        ttl_seconds: int,
+    ) -> "_LiveTransport":
+        """Run ``mvmctl up --up-json --detach --name <id> --manifest
+        <template>`` and parse the JSON envelope. Raises
+        :class:`SandboxLiveError` on any failure."""
+        mvm_cli_bin = os.environ.get(MVM_CLI_BIN_ENV) or ""
+        if not mvm_cli_bin:
+            raise SandboxModeError(
+                "MVM_SDK_MODE=live requires MVM_CLI_BIN to point at a `mvmctl` binary."
+            )
+        # Generate a short, validatable VM id. `mvmctl up` rejects
+        # names that don't match its validator; alphanumerics with
+        # a hyphen are safe.
+        suffix = secrets.token_hex(4)
+        vm_id = f"sdk-{workload_id[:24]}-{suffix}".lower()
+        vm_id = "".join(c if (c.isalnum() or c == "-") else "-" for c in vm_id)
+
+        argv = [
+            mvm_cli_bin,
+            "up",
+            "--up-json",
+            "--name",
+            vm_id,
+            "--manifest",
+            template,
+            "--ttl",
+            f"{ttl_seconds}s",
+        ]
+        try:
+            result = subprocess.run(
+                argv,
+                check=False,
+                capture_output=True,
+                text=True,
+            )
+        except FileNotFoundError as exc:
+            raise SandboxLiveError(
+                f"`{mvm_cli_bin}` not found on disk; check MVM_CLI_BIN",
+                argv=argv,
+            ) from exc
+
+        if result.returncode != 0:
+            raise SandboxLiveError(
+                f"`mvmctl up` failed with exit code {result.returncode}",
+                argv=argv,
+                exit_code=result.returncode,
+                stderr=result.stderr,
+            )
+
+        envelope = _parse_up_envelope(result.stdout, argv=argv)
+        return cls(
+            mvm_cli_bin=mvm_cli_bin,
+            vm_id=envelope["vm_id"],
+            build_mode=envelope["build_mode"],
+        )
+
+    def commands_start(
+        self, argv: list[str], env: dict[str, Any] | None
+    ) -> None:
+        """Shell ``mvmctl proc start <vm> -e ... -- <argv>``.
+
+        Refuses with :class:`SandboxDevOnly` when the resolved
+        template is prod (ADR-002 §W4.3, claim 4). The agent fails
+        closed anyway; the SDK refuses first so a typo doesn't
+        emit a spurious vsock request."""
+        if self.build_mode != "dev":
+            raise SandboxDevOnly(
+                f"`commands.start` requires a dev-mode template; resolved template "
+                f"build_mode={self.build_mode!r}. ADR-002 §W4.3 (security claim 4) "
+                f"strips the agent's `do_exec` handler in prod builds — re-build the "
+                f"template with `mvmctl template build --dev <name>`, or use "
+                f"`files.write` to stage inputs into the running VM instead.",
+                argv=["proc", "start", self.vm_id, *argv],
+            )
+        shell = [self.mvm_cli_bin, "proc", "start", self.vm_id]
+        if env:
+            # `mvmctl proc start` expects `-e KEY=VALUE` pairs.
+            # We only forward literal env values in live mode;
+            # secret_ref values would need the host keystore round-trip
+            # the orchestrator owns.
+            for key, value in env.items():
+                if isinstance(value, str):
+                    shell += ["-e", f"{key}={value}"]
+                elif isinstance(value, dict) and value.get("kind") == "literal":
+                    shell += ["-e", f"{key}={value['value']}"]
+                else:
+                    # secret_ref / unknown — refuse rather than leak.
+                    raise SandboxLiveError(
+                        f"`commands.start` env {key!r} carries a non-literal value; "
+                        f"live mode only forwards literal env vars (secrets must be "
+                        f"injected via the host keystore + `--secret` on `mvmctl up`).",
+                        argv=shell,
+                    )
+        shell += ["--", *argv]
+        self._run_shell(shell)
+
+    def files_write(self, path: str, data: bytes) -> None:
+        """Shell ``mvmctl fs write <vm> <path>`` with the file
+        bytes piped through stdin. The mvmctl verb accepts stdin
+        when ``--content`` is omitted."""
+        shell = [self.mvm_cli_bin, "fs", "write", self.vm_id, path]
+        try:
+            result = subprocess.run(
+                shell,
+                input=data,
+                check=False,
+                capture_output=True,
+            )
+        except FileNotFoundError as exc:
+            raise SandboxLiveError(
+                f"`{self.mvm_cli_bin}` not found on disk; check MVM_CLI_BIN",
+                argv=shell,
+            ) from exc
+        if result.returncode != 0:
+            raise SandboxLiveError(
+                f"`mvmctl fs write` failed with exit code {result.returncode}",
+                argv=shell,
+                exit_code=result.returncode,
+                stderr=result.stderr.decode("utf-8", errors="replace"),
+            )
+
+    def kill(self) -> None:
+        """Shell ``mvmctl down <vm>``. Idempotent — repeated kills
+        from the context manager + an explicit `sb.kill()` are
+        coalesced so we don't trip on a double-down."""
+        if self._killed:
+            return
+        self._killed = True
+        shell = [self.mvm_cli_bin, "down", self.vm_id]
+        try:
+            result = subprocess.run(
+                shell,
+                check=False,
+                capture_output=True,
+                text=True,
+            )
+        except FileNotFoundError as exc:
+            raise SandboxLiveError(
+                f"`{self.mvm_cli_bin}` not found on disk; check MVM_CLI_BIN",
+                argv=shell,
+            ) from exc
+        if result.returncode != 0:
+            # Print but don't raise — kill is the cleanup path; a
+            # failure here usually means the VM was already torn
+            # down by the orchestrator's TTL reaper.
+            sys.stderr.write(
+                f"mvm-sdk live: `mvmctl down {self.vm_id}` exited "
+                f"with {result.returncode}: {result.stderr}\n"
+            )
+
+    def _run_shell(self, shell: list[str]) -> None:
+        try:
+            result = subprocess.run(
+                shell,
+                check=False,
+                capture_output=True,
+                text=True,
+            )
+        except FileNotFoundError as exc:
+            raise SandboxLiveError(
+                f"`{self.mvm_cli_bin}` not found on disk; check MVM_CLI_BIN",
+                argv=shell,
+            ) from exc
+        # Mirror the SDK's "user prints to their own stdout"
+        # contract: the wrapped verbs' stdout is the SDK's value
+        # for the call (e.g. proc start prints a pid token), so
+        # forward it verbatim. stderr goes to our stderr.
+        if result.stdout:
+            sys.stdout.write(result.stdout)
+        if result.stderr:
+            sys.stderr.write(result.stderr)
+        if result.returncode != 0:
+            raise SandboxLiveError(
+                f"`{' '.join(shell)}` failed with exit code {result.returncode}",
+                argv=shell,
+                exit_code=result.returncode,
+                stderr=result.stderr,
+            )
+
+
+def _parse_up_envelope(stdout: str, *, argv: list[str]) -> dict[str, str]:
+    """Parse ``mvmctl up --up-json`` stdout. The envelope is a single
+    JSON line; trailing newlines tolerated. Raises
+    :class:`SandboxLiveError` if the envelope is malformed."""
+    line = stdout.strip()
+    if not line:
+        raise SandboxLiveError(
+            "`mvmctl up --up-json` produced empty stdout — expected a JSON envelope.",
+            argv=argv,
+        )
+    try:
+        parsed = json.loads(line)
+    except json.JSONDecodeError as exc:
+        raise SandboxLiveError(
+            f"`mvmctl up --up-json` stdout is not valid JSON: {exc.msg}",
+            argv=argv,
+            stderr=line,
+        ) from exc
+    if not isinstance(parsed, dict):
+        raise SandboxLiveError(
+            f"`mvmctl up --up-json` envelope must be a JSON object; got {type(parsed).__name__}",
+            argv=argv,
+        )
+    schema = parsed.get("schema_version")
+    if schema != _LiveTransport.SCHEMA_VERSION:
+        raise SandboxLiveError(
+            f"`mvmctl up --up-json` envelope schema_version={schema!r}; "
+            f"SDK supports {_LiveTransport.SCHEMA_VERSION}",
+            argv=argv,
+        )
+    vm_id = parsed.get("vm_id")
+    build_mode = parsed.get("build_mode")
+    if not isinstance(vm_id, str) or not vm_id:
+        raise SandboxLiveError(
+            "`mvmctl up --up-json` envelope is missing a non-empty `vm_id` field.",
+            argv=argv,
+        )
+    if build_mode not in ("dev", "prod"):
+        raise SandboxLiveError(
+            f"`mvmctl up --up-json` envelope build_mode={build_mode!r}; "
+            f"expected 'dev' or 'prod'.",
+            argv=argv,
+        )
+    return {"vm_id": vm_id, "build_mode": build_mode}
+
+
 class Sandbox:
-    """A recordable handle for an imperative ``Sandbox`` script.
+    """A recordable / live handle for an imperative ``Sandbox``
+    script.
 
-    Construct via :meth:`Sandbox.create` — the direct constructor is
-    used internally so the recording session can be set up first.
-    Supports context-manager usage; ``__exit__`` records a final
-    ``kill`` op (dropped by the Rust lowering, but the
-    bookkeeping is preserved for tooling)."""
+    Construct via :meth:`Sandbox.create`. Under ``MVM_SDK_MODE=record``
+    the constructor sets up an in-process recording; under
+    ``MVM_SDK_MODE=live`` it shells ``mvmctl up`` to boot a real
+    microVM and stashes the resulting handle on
+    ``self._live``. Supports context-manager usage; ``__exit__``
+    issues a ``kill`` (record-mode: appends a kill op; live-mode:
+    shells ``mvmctl down``)."""
 
-    def __init__(self, workload_id: str) -> None:
+    def __init__(
+        self,
+        workload_id: str,
+        *,
+        live: "_LiveTransport | None" = None,
+    ) -> None:
         self._workload_id = workload_id
         self._commands = _Commands(self)
         self._files = _Files(self)
+        self._live = live
 
     @classmethod
     def create(
@@ -406,14 +787,17 @@ class Sandbox:
         """Start a new sandbox session.
 
         ``template`` resolves to a base image on the Rust side (see
-        ``runtime::resolve_base_image``); unknown templates fail at
-        lower time, not here, because the wire shape preserves them
-        verbatim. ``workload_id`` defaults to the template (the CLI
-        overrides with the script's basename when invoked via
-        ``mvmctl compile``)."""
-        _resolve_mode()  # raises if MVM_SDK_MODE is live/plan/garbage
+        ``runtime::resolve_base_image``); in record mode unknown
+        templates fail at lower time, not here, because the wire
+        shape preserves them verbatim. In live mode unknown
+        templates fail when ``mvmctl up --manifest <template>``
+        rejects them — that failure surfaces as
+        :class:`SandboxLiveError` here. ``workload_id`` defaults to
+        the template (the CLI overrides with the script's basename
+        when invoked via ``mvmctl compile``)."""
+        mode = _resolve_mode()  # raises if MVM_SDK_MODE is invalid
         global _recording
-        if _recording is not None:
+        if _recording is not None or _live_sandbox_active():
             raise RuntimeError(
                 "a Sandbox session is already active — call "
                 "Sandbox.kill() or exit the `with` block before "
@@ -428,6 +812,17 @@ class Sandbox:
             ttl_seconds = DEFAULT_TTL_SECONDS
         wid = workload_id or template
 
+        if mode == "live":
+            live = _LiveTransport.for_template(
+                template=template,
+                workload_id=wid,
+                ttl_seconds=ttl_seconds,
+            )
+            sb = cls(wid, live=live)
+            _register_live(sb)
+            return sb
+
+        # record mode (existing path).
         create_dict: dict[str, Any] = {
             "template": template,
             "env": _encode_env_map(env),
@@ -460,10 +855,17 @@ class Sandbox:
         return self._files
 
     def kill(self) -> None:
-        """Record a ``kill`` op. The Rust lowering drops these (the
-        microVM TTL is the orchestrator's job), but the bookkeeping
-        is preserved through the recording so tooling can introspect
-        intent."""
+        """Issue a ``kill`` against the active transport.
+
+        In record mode, appends a ``kill`` op (the Rust lowering
+        drops these; the microVM TTL is the orchestrator's job, but
+        the bookkeeping is preserved through the recording so
+        tooling can introspect intent). In live mode, shells
+        ``mvmctl down <vm>``."""
+        if self._live is not None:
+            self._live.kill()
+            _clear_live()
+            return
         _require_recording()
         _recording["ops"].append({"kind": "kill"})
 

--- a/sdks/python/tests/test_sandbox.py
+++ b/sdks/python/tests/test_sandbox.py
@@ -142,15 +142,20 @@ def test_context_manager_records_kill_on_exit() -> None:
 # ── modes ────────────────────────────────────────────────────────────
 
 
-def test_live_mode_raises_until_plan_71_unblocks() -> None:
+def test_live_mode_requires_mvm_cli_bin() -> None:
+    """Plan 73 Followup H-live — MVM_SDK_MODE=live without
+    MVM_CLI_BIN must fail with an actionable hint."""
     os.environ["MVM_SDK_MODE"] = "live"
-    with pytest.raises(mvm.SandboxModeError, match="Plan 72"):
+    os.environ.pop("MVM_CLI_BIN", None)
+    with pytest.raises(mvm.SandboxModeError, match="MVM_CLI_BIN"):
         mvm.Sandbox.create("python-3.12")
 
 
-def test_plan_mode_raises_until_plan_71_unblocks() -> None:
+def test_plan_mode_redirects_to_host_cli() -> None:
+    """Plan mode lives in the host CLI; the SDK should refuse with
+    a redirect message."""
     os.environ["MVM_SDK_MODE"] = "plan"
-    with pytest.raises(mvm.SandboxModeError, match="Plan 72"):
+    with pytest.raises(mvm.SandboxModeError, match="mvmctl run --mode plan"):
         mvm.Sandbox.create("python-3.12")
 
 

--- a/sdks/python/tests/test_sandbox_live.py
+++ b/sdks/python/tests/test_sandbox_live.py
@@ -1,0 +1,344 @@
+"""Live-mode Sandbox tests (Plan 73 Followup H-live).
+
+Each test stands up a fixture `mvmctl` shell script that records its
+argv to a sidecar file and emits whatever stdout the live transport
+needs (e.g. the `mvmctl up --up-json` envelope). The SDK shells to
+the fixture via `MVM_CLI_BIN`; no real microVM boots.
+
+What we assert:
+
+1. `Sandbox.create` parses the JSON envelope and stashes vm_id +
+   build_mode on the live transport.
+2. `Sandbox.commands.start` against a dev template shells to
+   `mvmctl proc start` with the right argv shape.
+3. `Sandbox.commands.start` against a prod template raises
+   `SandboxDevOnly` *before* any vsock shell (security claim 4
+   client-side enforcement).
+4. `Sandbox.files.write` shells to `mvmctl fs write` with bytes on
+   stdin.
+5. `Sandbox.kill()` shells to `mvmctl down`.
+6. The context-manager `__exit__` calls `mvmctl down` once.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import stat
+from pathlib import Path
+
+import pytest
+
+import mvm
+from mvm._sandbox import _parse_up_envelope
+
+
+@pytest.fixture(autouse=True)
+def _isolate() -> None:
+    """Clean module state + env between tests."""
+    mvm.reset_recording()
+    os.environ.pop("MVM_SDK_MODE", None)
+    os.environ.pop("MVM_CLI_BIN", None)
+    yield
+    mvm.reset_recording()
+    os.environ.pop("MVM_SDK_MODE", None)
+    os.environ.pop("MVM_CLI_BIN", None)
+
+
+def _write_fixture_mvmctl(
+    tmp_path: Path,
+    *,
+    up_envelope: dict[str, str | int] | None,
+    up_exit: int = 0,
+    proc_exit: int = 0,
+    fs_exit: int = 0,
+    down_exit: int = 0,
+) -> Path:
+    """Write a shell script that pretends to be `mvmctl`. It
+    records each invocation's argv + stdin to sidecar files so
+    tests can assert wire shape, and emits the requested
+    envelope on `mvmctl up --up-json`.
+    """
+    log = tmp_path / "fixture-calls.log"
+    stdin_dir = tmp_path / "fixture-stdin"
+    stdin_dir.mkdir(exist_ok=True)
+
+    envelope_json = json.dumps(up_envelope) if up_envelope is not None else ""
+
+    script = tmp_path / "fake-mvmctl"
+    script.write_text(
+        f"""#!/usr/bin/env bash
+set -u
+verb=${{1:-}}
+shift || true
+echo "$verb $*" >> {log!s}
+case "$verb" in
+  up)
+    # Record stdin for completeness (mvmctl up has none).
+    if [ -t 0 ]; then :; else cat > {stdin_dir!s}/up-stdin.bin || true; fi
+    if [ "{up_exit}" -eq 0 ]; then
+      echo '{envelope_json}'
+    fi
+    exit {up_exit}
+    ;;
+  proc)
+    sub=$1
+    if [ -t 0 ]; then :; else cat > {stdin_dir!s}/proc-stdin.bin || true; fi
+    if [ "{proc_exit}" -eq 0 ] && [ "$sub" = "start" ]; then
+      echo "pid-token-abc123"
+    fi
+    exit {proc_exit}
+    ;;
+  fs)
+    sub=$1
+    if [ "$sub" = "write" ]; then
+      cat > {stdin_dir!s}/fs-write-stdin.bin
+    fi
+    exit {fs_exit}
+    ;;
+  down)
+    exit {down_exit}
+    ;;
+  *)
+    echo "fake-mvmctl: unrecognized verb $verb" >&2
+    exit 2
+    ;;
+esac
+"""
+    )
+    script.chmod(stat.S_IRUSR | stat.S_IWUSR | stat.S_IXUSR | stat.S_IRGRP | stat.S_IXGRP)
+    return script
+
+
+def _read_fixture_log(tmp_path: Path) -> list[str]:
+    log = tmp_path / "fixture-calls.log"
+    if not log.exists():
+        return []
+    return [line for line in log.read_text().splitlines() if line]
+
+
+# ── envelope parsing ─────────────────────────────────────────────────
+
+
+def test_parse_up_envelope_accepts_dev_payload() -> None:
+    parsed = _parse_up_envelope(
+        '{"schema_version": 1, "vm_id": "sb-xyz", "build_mode": "dev"}\n',
+        argv=["mvmctl", "up"],
+    )
+    assert parsed == {"vm_id": "sb-xyz", "build_mode": "dev"}
+
+
+def test_parse_up_envelope_rejects_unknown_schema() -> None:
+    with pytest.raises(mvm.SandboxLiveError, match="schema_version"):
+        _parse_up_envelope(
+            '{"schema_version": 99, "vm_id": "x", "build_mode": "dev"}',
+            argv=["mvmctl", "up"],
+        )
+
+
+def test_parse_up_envelope_rejects_missing_vm_id() -> None:
+    with pytest.raises(mvm.SandboxLiveError, match="vm_id"):
+        _parse_up_envelope(
+            '{"schema_version": 1, "build_mode": "dev"}',
+            argv=["mvmctl", "up"],
+        )
+
+
+def test_parse_up_envelope_rejects_unknown_build_mode() -> None:
+    with pytest.raises(mvm.SandboxLiveError, match="build_mode"):
+        _parse_up_envelope(
+            '{"schema_version": 1, "vm_id": "x", "build_mode": "staging"}',
+            argv=["mvmctl", "up"],
+        )
+
+
+def test_parse_up_envelope_rejects_empty_stdout() -> None:
+    with pytest.raises(mvm.SandboxLiveError, match="empty stdout"):
+        _parse_up_envelope("", argv=["mvmctl", "up"])
+
+
+def test_parse_up_envelope_rejects_invalid_json() -> None:
+    with pytest.raises(mvm.SandboxLiveError, match="not valid JSON"):
+        _parse_up_envelope("not json", argv=["mvmctl", "up"])
+
+
+# ── live-mode boot ───────────────────────────────────────────────────
+
+
+def test_sandbox_create_live_parses_envelope_and_records_vm(
+    tmp_path: Path,
+) -> None:
+    script = _write_fixture_mvmctl(
+        tmp_path,
+        up_envelope={
+            "schema_version": 1,
+            "vm_id": "sb-test-vm",
+            "build_mode": "dev",
+        },
+    )
+    os.environ["MVM_SDK_MODE"] = "live"
+    os.environ["MVM_CLI_BIN"] = str(script)
+
+    sb = mvm.Sandbox.create("python-3.12", workload_id="testwid")
+    assert sb._live is not None
+    assert sb._live.vm_id == "sb-test-vm"
+    assert sb._live.build_mode == "dev"
+
+    calls = _read_fixture_log(tmp_path)
+    assert len(calls) == 1
+    assert calls[0].startswith("up --up-json --name ")
+    assert "--manifest python-3.12" in calls[0]
+    assert "--ttl" in calls[0]
+
+
+def test_sandbox_create_live_propagates_mvmctl_failure(
+    tmp_path: Path,
+) -> None:
+    script = _write_fixture_mvmctl(tmp_path, up_envelope=None, up_exit=7)
+    os.environ["MVM_SDK_MODE"] = "live"
+    os.environ["MVM_CLI_BIN"] = str(script)
+
+    with pytest.raises(mvm.SandboxLiveError, match="exit code 7"):
+        mvm.Sandbox.create("python-3.12")
+
+
+# ── commands.start (claim-4 dev-only enforcement) ──────────────────
+
+
+def test_commands_start_dev_template_shells_to_proc_start(
+    tmp_path: Path,
+) -> None:
+    script = _write_fixture_mvmctl(
+        tmp_path,
+        up_envelope={
+            "schema_version": 1,
+            "vm_id": "sb-dev-vm",
+            "build_mode": "dev",
+        },
+    )
+    os.environ["MVM_SDK_MODE"] = "live"
+    os.environ["MVM_CLI_BIN"] = str(script)
+
+    sb = mvm.Sandbox.create("python-dev")
+    sb.commands.start(["python", "run.py"], env={"MODE": "test"})
+
+    calls = _read_fixture_log(tmp_path)
+    # 1: up, 2: proc start
+    assert len(calls) == 2
+    assert calls[1].startswith("proc start sb-dev-vm")
+    assert "-e MODE=test" in calls[1]
+    assert "-- python run.py" in calls[1]
+
+
+def test_commands_start_prod_template_raises_sandbox_dev_only(
+    tmp_path: Path,
+) -> None:
+    """Security claim 4: SDK refuses commands.start client-side
+    before any vsock traffic when the template is prod."""
+    script = _write_fixture_mvmctl(
+        tmp_path,
+        up_envelope={
+            "schema_version": 1,
+            "vm_id": "sb-prod-vm",
+            "build_mode": "prod",
+        },
+    )
+    os.environ["MVM_SDK_MODE"] = "live"
+    os.environ["MVM_CLI_BIN"] = str(script)
+
+    sb = mvm.Sandbox.create("python-prod")
+    # Only 1 call (`up`) so far.
+    assert len(_read_fixture_log(tmp_path)) == 1
+
+    with pytest.raises(mvm.SandboxDevOnly, match="dev-mode template"):
+        sb.commands.start(["python", "run.py"])
+
+    # The SDK must NOT have shelled to `mvmctl proc start`.
+    calls = _read_fixture_log(tmp_path)
+    assert len(calls) == 1, f"unexpected vsock traffic: {calls}"
+    assert not any(c.startswith("proc") for c in calls)
+
+
+# ── files.write ──────────────────────────────────────────────────────
+
+
+def test_files_write_shells_with_stdin_bytes(tmp_path: Path) -> None:
+    script = _write_fixture_mvmctl(
+        tmp_path,
+        up_envelope={
+            "schema_version": 1,
+            "vm_id": "sb-fs-vm",
+            "build_mode": "dev",
+        },
+    )
+    os.environ["MVM_SDK_MODE"] = "live"
+    os.environ["MVM_CLI_BIN"] = str(script)
+
+    sb = mvm.Sandbox.create("python-dev")
+    sb.files.write("/app/config.json", b'{"x":1}')
+
+    calls = _read_fixture_log(tmp_path)
+    assert any(c.startswith("fs write sb-fs-vm /app/config.json") for c in calls)
+    stdin_path = tmp_path / "fixture-stdin" / "fs-write-stdin.bin"
+    assert stdin_path.read_bytes() == b'{"x":1}'
+
+
+# ── kill / context manager ───────────────────────────────────────────
+
+
+def test_kill_shells_to_mvmctl_down(tmp_path: Path) -> None:
+    script = _write_fixture_mvmctl(
+        tmp_path,
+        up_envelope={
+            "schema_version": 1,
+            "vm_id": "sb-kill-vm",
+            "build_mode": "dev",
+        },
+    )
+    os.environ["MVM_SDK_MODE"] = "live"
+    os.environ["MVM_CLI_BIN"] = str(script)
+
+    sb = mvm.Sandbox.create("python-dev")
+    sb.kill()
+
+    calls = _read_fixture_log(tmp_path)
+    assert any(c == "down sb-kill-vm" for c in calls)
+
+
+def test_context_manager_kills_on_exit(tmp_path: Path) -> None:
+    script = _write_fixture_mvmctl(
+        tmp_path,
+        up_envelope={
+            "schema_version": 1,
+            "vm_id": "sb-ctx-vm",
+            "build_mode": "dev",
+        },
+    )
+    os.environ["MVM_SDK_MODE"] = "live"
+    os.environ["MVM_CLI_BIN"] = str(script)
+
+    with mvm.Sandbox.create("python-dev") as sb:
+        sb.files.write("/app/data.txt", "hi")
+
+    calls = _read_fixture_log(tmp_path)
+    down_calls = [c for c in calls if c.startswith("down ")]
+    assert len(down_calls) == 1
+
+
+def test_one_sandbox_per_process_in_live_mode(tmp_path: Path) -> None:
+    """v1 scope: one app per workload — a second `Sandbox.create`
+    must refuse while the first is live."""
+    script = _write_fixture_mvmctl(
+        tmp_path,
+        up_envelope={
+            "schema_version": 1,
+            "vm_id": "sb-first",
+            "build_mode": "dev",
+        },
+    )
+    os.environ["MVM_SDK_MODE"] = "live"
+    os.environ["MVM_CLI_BIN"] = str(script)
+
+    mvm.Sandbox.create("python-dev")
+    with pytest.raises(RuntimeError, match="already active"):
+        mvm.Sandbox.create("python-dev")

--- a/sdks/typescript/src/_sandbox.ts
+++ b/sdks/typescript/src/_sandbox.ts
@@ -1,26 +1,32 @@
 /**
- * Sandbox — e2b-style imperative runtime SDK. SDK port Phase 7c.
+ * Sandbox — e2b-style imperative runtime SDK. SDK port Phase 7c +
+ * Plan 73 Followup H-live.
  *
  * TypeScript mirror of `sdks/python/mvm/_sandbox.py`. The
  * decorator surface (`mvm.app({...})((fn))`) is static; the host
  * parses the source AST without running it. The runtime surface
  * (`Sandbox.create(...)`) is imperative: the host *does* run
  * the user's TypeScript module (per S2 in the SDK plan — a
- * documented departure), with the SDK reconfigured to record
- * each method call into a {@link RuntimeRecording} instead of
- * dialing a real microVM.
+ * documented departure), with the SDK reconfigured to either
+ * record each method call into a {@link RuntimeRecording} or
+ * shell each call to `mvmctl` against a real microVM,
+ * depending on the active mode.
  *
- * Phase 7c ships *record mode only*. `MVM_SDK_MODE=record` is the
- * mode the recorder reads; `live` and `plan` throw
- * {@link SandboxModeError} until Plan 72 unblocks
- * `mvmctl up`/`exec`. The record-mode lowering happens on the
- * Rust side (`crates/mvm-sdk/src/runtime.rs::compile_recording`);
- * this module's only job is to build a wire-compatible recording
- * JSON document.
+ * Two modes are live:
  *
- * Wire shape matches the Rust `RuntimeRecording` serde types,
- * `deny_unknown_fields` on both sides — a typo'd field fails
- * closed at the Rust boundary.
+ * - `MVM_SDK_MODE=record` (the original Phase 7c contract):
+ *   every `Sandbox` call appends to an in-process recording;
+ *   the Rust lowering at `mvm_sdk::runtime::compile_recording`
+ *   produces a Workload.
+ * - `MVM_SDK_MODE=live` (Plan 73 Followup H-live): every
+ *   `Sandbox` call shells to `$MVM_CLI_BIN` (`mvmctl up`,
+ *   `mvmctl proc start`, `mvmctl fs write`, `mvmctl down`)
+ *   against a real microVM. The shell is dispatched by
+ *   {@link LiveTransport} below.
+ *
+ * `MVM_SDK_MODE=plan` remains an error here — the host CLI's
+ * `mvmctl run --mode plan` verb runs Sandbox scripts under that
+ * transport; the SDK itself never enters "plan" mode directly.
  */
 
 import type { EnvValue, Network, Resources } from "./ir/workload.js";
@@ -54,7 +60,8 @@ export interface RuntimeRecordingWire {
 // Errors.
 // ────────────────────────────────────────────────────────────────────
 
-/** Raised when `MVM_SDK_MODE` is unsupported by this build. */
+/** Raised when `MVM_SDK_MODE` is unsupported by this build, or
+ *  `MVM_SDK_MODE=live` is requested without `MVM_CLI_BIN` set. */
 export class SandboxModeError extends Error {
   constructor(message: string) {
     super(message);
@@ -68,6 +75,46 @@ export class RecordingNotActiveError extends Error {
   constructor(message: string) {
     super(message);
     this.name = "RecordingNotActiveError";
+  }
+}
+
+/** Raised when a live-mode shell to `mvmctl` fails. Carries the
+ *  failing argv, exit code, and captured stderr so user scripts
+ *  can see exactly which verb refused and why. */
+export class SandboxLiveError extends Error {
+  readonly argv: string[];
+  readonly exitCode: number | null;
+  readonly stderr: string;
+
+  constructor(
+    message: string,
+    opts: { argv?: string[]; exitCode?: number | null; stderr?: string } = {},
+  ) {
+    super(message);
+    this.name = "SandboxLiveError";
+    this.argv = opts.argv ?? [];
+    this.exitCode = opts.exitCode ?? null;
+    this.stderr = opts.stderr ?? "";
+  }
+}
+
+/** Raised when the SDK refuses a live-mode `commands.start` call
+ *  because the resolved template is a *prod* template.
+ *
+ *  Per ADR-002 §W4.3 (security claim 4 in `CLAUDE.md`) the guest
+ *  agent strips the `do_exec` handler in production builds. The
+ *  agent itself fails closed, but the SDK refuses *before* any
+ *  vsock traffic so a typo doesn't make a spurious round-trip.
+ *  `commands.start` is the only Sandbox surface that hits
+ *  `proc start`; `files.write` / `kill` route to verbs that are
+ *  available in prod builds too. */
+export class SandboxDevOnly extends SandboxLiveError {
+  constructor(
+    message: string,
+    opts: { argv?: string[] } = {},
+  ) {
+    super(message, opts);
+    this.name = "SandboxDevOnly";
   }
 }
 
@@ -90,12 +137,21 @@ export const MVM_SDK_MODE_ENV = "MVM_SDK_MODE";
  *  parsing stdout (which the user's own script may write to). */
 export const MVM_SDK_OUT_PATH_ENV = "MVM_SDK_OUT_PATH";
 
+/** Plan 73 Followup H-live — when `MVM_SDK_MODE=live` is set, the
+ *  SDK shells out to the `mvmctl` binary at this path. The host's
+ *  `mvmctl run --mode live` verb sets it to its own
+ *  `current_exe()` so a `cargo run -- run --mode live` flow finds
+ *  the same binary it invoked through. */
+export const MVM_CLI_BIN_ENV = "MVM_CLI_BIN";
+
 let recording: RuntimeRecordingWire | null = null;
 
-/** Clear the in-flight recording. Tests use this between runs;
- *  production never calls it (the process exits). */
+/** Clear the in-flight recording state and any live registration.
+ *  Tests use this between runs; production never calls it (the
+ *  process exits). */
 export function resetRecording(): void {
   recording = null;
+  liveSandbox = null;
 }
 
 /** Return the active recording (or null). Useful for tools that
@@ -164,19 +220,34 @@ if (typeof process !== "undefined" && typeof process.on === "function") {
 // Mode + TTL helpers.
 // ────────────────────────────────────────────────────────────────────
 
-function resolveMode(): "record" {
+type SandboxMode = "record" | "live";
+
+function resolveMode(): SandboxMode {
   const raw =
     (typeof process !== "undefined" ? process.env[MVM_SDK_MODE_ENV] : undefined) ?? "record";
   const norm = raw.trim().toLowerCase();
   if (norm === "record") return "record";
-  if (norm === "live" || norm === "plan") {
+  if (norm === "live") {
+    const bin =
+      typeof process !== "undefined" ? process.env[MVM_CLI_BIN_ENV] : undefined;
+    if (!bin) {
+      throw new SandboxModeError(
+        "MVM_SDK_MODE=live requires MVM_CLI_BIN to point at a `mvmctl` binary. " +
+          "The host's `mvmctl run --mode live` verb sets this automatically; if you're " +
+          "running the SDK directly, set MVM_CLI_BIN=/path/to/mvmctl before invoking your script.",
+      );
+    }
+    return "live";
+  }
+  if (norm === "plan") {
     throw new SandboxModeError(
-      `MVM_SDK_MODE=${JSON.stringify(norm)} is not supported in this SDK build — ` +
-        "live/plan transports are blocked on Plan 72. Use 'record' or the mvm.app decorator path.",
+      "MVM_SDK_MODE=plan is not a SDK-side transport — the host CLI's `mvmctl run --mode plan` " +
+        "verb runs your script under record mode and synthesises ExecutionPlans for admission " +
+        "dry-run. Drop MVM_SDK_MODE and let `mvmctl run --mode plan` set the recording state for you.",
     );
   }
   throw new SandboxModeError(
-    `MVM_SDK_MODE=${JSON.stringify(norm)} is invalid — expected one of: record, live, plan`,
+    `MVM_SDK_MODE=${JSON.stringify(norm)} is invalid — expected one of: record, live`,
   );
 }
 
@@ -270,26 +341,314 @@ function requireRecording(): RuntimeRecordingWire {
   return recording;
 }
 
-/** A recordable handle for an imperative Sandbox script.
+/** Live-mode transport — shells each Sandbox call to the host's
+ *  `mvmctl` binary.
  *
- *  Construct via `Sandbox.create(...)` — direct construction is
- *  used internally so the recording session is initialized first.
- *  Use `[Symbol.dispose]` (TS 5.2+) for automatic cleanup, or call
- *  `sb.kill()` explicitly. */
+ *  Created by `Sandbox.create(...)` when `MVM_SDK_MODE=live`. Holds
+ *  the resolved `mvmctl` path, the generated `vmId`, and the
+ *  template's `build_mode` parsed from the `mvmctl up --up-json`
+ *  envelope. The `build_mode` is what the SDK uses to enforce the
+ *  W4.3 dev-only `proc start` rule client-side. */
+export class LiveTransport {
+  static readonly SCHEMA_VERSION = 1;
+
+  readonly mvmCliBin: string;
+  readonly vmId: string;
+  readonly buildMode: "dev" | "prod";
+  private killed = false;
+
+  constructor(opts: { mvmCliBin: string; vmId: string; buildMode: "dev" | "prod" }) {
+    this.mvmCliBin = opts.mvmCliBin;
+    this.vmId = opts.vmId;
+    this.buildMode = opts.buildMode;
+  }
+
+  static forTemplate(opts: {
+    template: string;
+    workloadId: string;
+    ttlSeconds: number;
+  }): LiveTransport {
+    const mvmCliBin =
+      typeof process !== "undefined" ? process.env[MVM_CLI_BIN_ENV] ?? "" : "";
+    if (!mvmCliBin) {
+      throw new SandboxModeError(
+        "MVM_SDK_MODE=live requires MVM_CLI_BIN to point at a `mvmctl` binary.",
+      );
+    }
+    // Generate a short, validatable VM id. `mvmctl up` rejects
+    // names that don't match its validator; alphanumerics with a
+    // hyphen are safe.
+    const suffix = randomHex(4);
+    const slug = opts.workloadId
+      .slice(0, 24)
+      .toLowerCase()
+      .replace(/[^a-z0-9-]/g, "-");
+    const vmId = `sdk-${slug}-${suffix}`;
+
+    const argv = [
+      "up",
+      "--up-json",
+      "--name",
+      vmId,
+      "--manifest",
+      opts.template,
+      "--ttl",
+      `${opts.ttlSeconds}s`,
+    ];
+    // eslint-disable-next-line @typescript-eslint/no-require-imports
+    const child = require("node:child_process") as typeof import("node:child_process");
+    let result;
+    try {
+      result = child.spawnSync(mvmCliBin, argv, {
+        encoding: "utf-8",
+      });
+    } catch (err) {
+      throw new SandboxLiveError(
+        `\`${mvmCliBin}\` not found on disk; check MVM_CLI_BIN: ${String(err)}`,
+        { argv: [mvmCliBin, ...argv] },
+      );
+    }
+    if (result.error) {
+      throw new SandboxLiveError(
+        `failed to spawn \`${mvmCliBin}\`: ${result.error.message}`,
+        { argv: [mvmCliBin, ...argv] },
+      );
+    }
+    if (result.status !== 0) {
+      throw new SandboxLiveError(
+        `\`mvmctl up\` failed with exit code ${result.status}`,
+        {
+          argv: [mvmCliBin, ...argv],
+          exitCode: result.status,
+          stderr: result.stderr ?? "",
+        },
+      );
+    }
+    const envelope = parseUpEnvelope(result.stdout ?? "", [mvmCliBin, ...argv]);
+    return new LiveTransport({
+      mvmCliBin,
+      vmId: envelope.vm_id,
+      buildMode: envelope.build_mode,
+    });
+  }
+
+  commandsStart(argv: string[], env: Record<string, EnvValue | string> | undefined): void {
+    if (this.buildMode !== "dev") {
+      throw new SandboxDevOnly(
+        `\`commands.start\` requires a dev-mode template; resolved template ` +
+          `build_mode=${JSON.stringify(this.buildMode)}. ADR-002 §W4.3 (security ` +
+          `claim 4) strips the agent's \`do_exec\` handler in prod builds — ` +
+          `re-build the template with \`mvmctl template build --dev <name>\`, ` +
+          `or use \`files.write\` to stage inputs into the running VM instead.`,
+        { argv: ["proc", "start", this.vmId, ...argv] },
+      );
+    }
+    const shell = [this.mvmCliBin, "proc", "start", this.vmId];
+    if (env) {
+      for (const [key, value] of Object.entries(env)) {
+        if (typeof value === "string") {
+          shell.push("-e", `${key}=${value}`);
+        } else if (
+          typeof value === "object" &&
+          value !== null &&
+          (value as { kind?: string }).kind === "literal"
+        ) {
+          shell.push("-e", `${key}=${(value as { value: string }).value}`);
+        } else {
+          throw new SandboxLiveError(
+            `\`commands.start\` env ${JSON.stringify(key)} carries a non-literal value; ` +
+              "live mode only forwards literal env vars (secrets must be injected via " +
+              "the host keystore + `--secret` on `mvmctl up`).",
+            { argv: shell },
+          );
+        }
+      }
+    }
+    shell.push("--", ...argv);
+    this.runShell(shell);
+  }
+
+  filesWrite(path: string, data: Uint8Array): void {
+    const shell = [this.mvmCliBin, "fs", "write", this.vmId, path];
+    // eslint-disable-next-line @typescript-eslint/no-require-imports
+    const child = require("node:child_process") as typeof import("node:child_process");
+    let result;
+    try {
+      result = child.spawnSync(shell[0], shell.slice(1), {
+        input: Buffer.from(data),
+      });
+    } catch (err) {
+      throw new SandboxLiveError(
+        `\`${this.mvmCliBin}\` not found on disk; check MVM_CLI_BIN: ${String(err)}`,
+        { argv: shell },
+      );
+    }
+    if (result.error) {
+      throw new SandboxLiveError(`failed to spawn: ${result.error.message}`, {
+        argv: shell,
+      });
+    }
+    if (result.status !== 0) {
+      throw new SandboxLiveError(
+        `\`mvmctl fs write\` failed with exit code ${result.status}`,
+        {
+          argv: shell,
+          exitCode: result.status,
+          stderr: result.stderr ? result.stderr.toString("utf-8") : "",
+        },
+      );
+    }
+  }
+
+  kill(): void {
+    if (this.killed) return;
+    this.killed = true;
+    const shell = [this.mvmCliBin, "down", this.vmId];
+    // eslint-disable-next-line @typescript-eslint/no-require-imports
+    const child = require("node:child_process") as typeof import("node:child_process");
+    try {
+      const result = child.spawnSync(shell[0], shell.slice(1), {
+        encoding: "utf-8",
+      });
+      if (result.status !== 0) {
+        // Don't throw — kill is the cleanup path; a failure here
+        // usually means the VM was already torn down by the
+        // orchestrator's TTL reaper.
+        // eslint-disable-next-line no-console
+        console.error(
+          `mvm-sdk live: \`mvmctl down ${this.vmId}\` exited with ${result.status}: ${result.stderr ?? ""}`,
+        );
+      }
+    } catch (err) {
+      // eslint-disable-next-line no-console
+      console.error(`mvm-sdk live: failed to spawn \`mvmctl down\`: ${String(err)}`);
+    }
+  }
+
+  private runShell(shell: string[]): void {
+    // eslint-disable-next-line @typescript-eslint/no-require-imports
+    const child = require("node:child_process") as typeof import("node:child_process");
+    let result;
+    try {
+      result = child.spawnSync(shell[0], shell.slice(1), { encoding: "utf-8" });
+    } catch (err) {
+      throw new SandboxLiveError(
+        `\`${this.mvmCliBin}\` not found on disk; check MVM_CLI_BIN: ${String(err)}`,
+        { argv: shell },
+      );
+    }
+    if (result.error) {
+      throw new SandboxLiveError(`failed to spawn: ${result.error.message}`, {
+        argv: shell,
+      });
+    }
+    if (result.stdout) process.stdout.write(result.stdout);
+    if (result.stderr) process.stderr.write(result.stderr);
+    if (result.status !== 0) {
+      throw new SandboxLiveError(
+        `\`${shell.join(" ")}\` failed with exit code ${result.status}`,
+        {
+          argv: shell,
+          exitCode: result.status,
+          stderr: result.stderr ?? "",
+        },
+      );
+    }
+  }
+}
+
+/** Parse an `mvmctl up --up-json` stdout envelope. The envelope is
+ *  a single JSON line; trailing newlines tolerated. Throws
+ *  `SandboxLiveError` on any shape violation. Exported for tests. */
+export function parseUpEnvelope(
+  stdout: string,
+  argv: string[],
+): { vm_id: string; build_mode: "dev" | "prod" } {
+  const line = stdout.trim();
+  if (!line) {
+    throw new SandboxLiveError(
+      "`mvmctl up --up-json` produced empty stdout — expected a JSON envelope.",
+      { argv },
+    );
+  }
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(line);
+  } catch (err) {
+    throw new SandboxLiveError(
+      `\`mvmctl up --up-json\` stdout is not valid JSON: ${String(err)}`,
+      { argv, stderr: line },
+    );
+  }
+  if (typeof parsed !== "object" || parsed === null) {
+    throw new SandboxLiveError(
+      "`mvmctl up --up-json` envelope must be a JSON object.",
+      { argv },
+    );
+  }
+  const obj = parsed as Record<string, unknown>;
+  if (obj.schema_version !== LiveTransport.SCHEMA_VERSION) {
+    throw new SandboxLiveError(
+      `\`mvmctl up --up-json\` envelope schema_version=${JSON.stringify(obj.schema_version)}; ` +
+        `SDK supports ${LiveTransport.SCHEMA_VERSION}`,
+      { argv },
+    );
+  }
+  if (typeof obj.vm_id !== "string" || obj.vm_id.length === 0) {
+    throw new SandboxLiveError(
+      "`mvmctl up --up-json` envelope is missing a non-empty `vm_id` field.",
+      { argv },
+    );
+  }
+  if (obj.build_mode !== "dev" && obj.build_mode !== "prod") {
+    throw new SandboxLiveError(
+      `\`mvmctl up --up-json\` envelope build_mode=${JSON.stringify(obj.build_mode)}; ` +
+        "expected 'dev' or 'prod'.",
+      { argv },
+    );
+  }
+  return { vm_id: obj.vm_id, build_mode: obj.build_mode };
+}
+
+function randomHex(byteCount: number): string {
+  // eslint-disable-next-line @typescript-eslint/no-require-imports
+  const crypto = require("node:crypto") as typeof import("node:crypto");
+  return crypto.randomBytes(byteCount).toString("hex");
+}
+
+/** Live-mode bookkeeping. Mirrors `recording`'s "one session per
+ *  process" invariant — a live Sandbox is stashed here so a second
+ *  `Sandbox.create(...)` call inside the same process is refused. */
+let liveSandbox: Sandbox | null = null;
+
+function isLiveActive(): boolean {
+  return liveSandbox !== null;
+}
+
+/** A recordable / live handle for an imperative Sandbox script.
+ *
+ *  Construct via `Sandbox.create(...)`. Under `MVM_SDK_MODE=record`
+ *  the constructor sets up an in-process recording; under
+ *  `MVM_SDK_MODE=live` it shells `mvmctl up` to boot a real
+ *  microVM and stashes the resulting handle on
+ *  `this._live`. Use `[Symbol.dispose]` (TS 5.2+) for automatic
+ *  cleanup, or call `sb.kill()` explicitly. */
 export class Sandbox {
   readonly workloadId: string;
   readonly commands: SandboxCommands;
   readonly files: SandboxFiles;
+  readonly _live: LiveTransport | null;
 
-  private constructor(workloadId: string) {
+  private constructor(workloadId: string, live: LiveTransport | null) {
     this.workloadId = workloadId;
-    this.commands = new SandboxCommands();
-    this.files = new SandboxFiles();
+    this._live = live;
+    this.commands = new SandboxCommands(this);
+    this.files = new SandboxFiles(this);
   }
 
   static create(template: string, options: SandboxCreateOptions = {}): Sandbox {
-    resolveMode(); // throws if MVM_SDK_MODE is live/plan/garbage.
-    if (recording !== null) {
+    const mode = resolveMode();
+    if (recording !== null || isLiveActive()) {
       throw new Error(
         "a Sandbox session is already active — call Sandbox.kill() before creating another. " +
           "Per the SDK plan's 'v1 scope: one app per workload' decision, a script may construct at most one Sandbox.",
@@ -304,6 +663,18 @@ export class Sandbox {
     }
     const wid = options.workloadId ?? template;
 
+    if (mode === "live") {
+      const live = LiveTransport.forTemplate({
+        template,
+        workloadId: wid,
+        ttlSeconds,
+      });
+      const sb = new Sandbox(wid, live);
+      liveSandbox = sb;
+      return sb;
+    }
+
+    // record mode (existing path).
     const create: SandboxCreateWire = {
       template,
       env: encodeEnvMap(options.env),
@@ -319,10 +690,15 @@ export class Sandbox {
       create,
       ops: [],
     };
-    return new Sandbox(wid);
+    return new Sandbox(wid, null);
   }
 
   kill(): void {
+    if (this._live !== null) {
+      this._live.kill();
+      liveSandbox = null;
+      return;
+    }
     requireRecording().ops.push({ kind: "kill" });
   }
 
@@ -334,12 +710,22 @@ export class Sandbox {
 }
 
 export class SandboxCommands {
+  private readonly sandbox: Sandbox;
+
+  constructor(sandbox: Sandbox) {
+    this.sandbox = sandbox;
+  }
+
   start(argv: string[], options: SandboxCommandsStartOptions = {}): void {
     if (!Array.isArray(argv) || !argv.every((a) => typeof a === "string")) {
       throw new TypeError("argv must be a string[]");
     }
     if (argv.length === 0) {
       throw new RangeError("argv must be non-empty");
+    }
+    if (this.sandbox._live !== null) {
+      this.sandbox._live.commandsStart([...argv], options.env);
+      return;
     }
     requireRecording().ops.push({
       kind: "command_start",
@@ -350,6 +736,12 @@ export class SandboxCommands {
 }
 
 export class SandboxFiles {
+  private readonly sandbox: Sandbox;
+
+  constructor(sandbox: Sandbox) {
+    this.sandbox = sandbox;
+  }
+
   write(path: string, content: Uint8Array | string): void {
     if (typeof path !== "string" || path.length === 0) {
       throw new TypeError("path must be a non-empty string");
@@ -361,6 +753,10 @@ export class SandboxFiles {
       bytes = content;
     } else {
       throw new TypeError("files.write content must be Uint8Array or string");
+    }
+    if (this.sandbox._live !== null) {
+      this.sandbox._live.filesWrite(path, bytes);
+      return;
     }
     requireRecording().ops.push({
       kind: "files_write",

--- a/sdks/typescript/src/index.ts
+++ b/sdks/typescript/src/index.ts
@@ -52,20 +52,25 @@ import type {
 // "mvm-sdk"` directly rather than reaching into the `ir/` sub-path.
 export * from "./ir/workload.js";
 
-// Sandbox record-mode SDK (Phase 7c + 7f). Imperative companion to
-// the static `mvm.app({...})` decorator above.
+// Sandbox SDK (Phase 7c + 7f + Plan 73 Followup H-live). Imperative
+// companion to the static `mvm.app({...})` decorator above.
 export {
   DEFAULT_TTL_SECONDS,
+  LiveTransport,
+  MVM_CLI_BIN_ENV,
   MVM_SDK_MODE_ENV,
   MVM_SDK_OUT_PATH_ENV,
   RecordingNotActiveError,
   Sandbox,
   SandboxCommands,
+  SandboxDevOnly,
   SandboxFiles,
+  SandboxLiveError,
   SandboxModeError,
   currentRecording,
   emitRecordingJson,
   flushRecordingToOutPath,
+  parseUpEnvelope,
   resetRecording,
 } from "./_sandbox.js";
 export type {

--- a/sdks/typescript/tests/sandbox.test.ts
+++ b/sdks/typescript/tests/sandbox.test.ts
@@ -137,14 +137,15 @@ describe("Sandbox.kill / dispose", () => {
 // ── modes ────────────────────────────────────────────────────────────
 
 describe("MVM_SDK_MODE", () => {
-  it("live mode throws until Plan 72 unblocks", () => {
+  it("live mode without MVM_CLI_BIN throws", () => {
     process.env.MVM_SDK_MODE = "live";
-    expect(() => mvm.Sandbox.create("python-3.12")).toThrow(/Plan 72/);
+    delete process.env.MVM_CLI_BIN;
+    expect(() => mvm.Sandbox.create("python-3.12")).toThrow(/MVM_CLI_BIN/);
   });
 
-  it("plan mode throws until Plan 72 unblocks", () => {
+  it("plan mode redirects to mvmctl run --mode plan", () => {
     process.env.MVM_SDK_MODE = "plan";
-    expect(() => mvm.Sandbox.create("python-3.12")).toThrow(/Plan 72/);
+    expect(() => mvm.Sandbox.create("python-3.12")).toThrow(/mvmctl run --mode plan/);
   });
 
   it("invalid mode throws with actionable message", () => {
@@ -238,7 +239,6 @@ describe("flushRecordingToOutPath", () => {
   // tmpdir helper out of the box. Cleanup runs in afterEach.
   const tmpFiles: string[] = [];
   const tmpFile = (): string => {
-    const fs = require("node:fs");
     const os = require("node:os");
     const path = require("node:path");
     const p = path.join(os.tmpdir(), `mvm-rec-${Date.now()}-${Math.random()}.json`);

--- a/sdks/typescript/tests/sandbox_live.test.ts
+++ b/sdks/typescript/tests/sandbox_live.test.ts
@@ -1,0 +1,311 @@
+/**
+ * Live-mode Sandbox tests (Plan 73 Followup H-live).
+ *
+ * Mirrors `sdks/python/tests/test_sandbox_live.py`. Each test stands
+ * up a fixture `mvmctl` shell script that records its argv to a
+ * sidecar file and emits the expected stdout. The SDK shells to the
+ * fixture via `MVM_CLI_BIN`; no real microVM boots.
+ */
+
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import * as fs from "node:fs";
+import * as os from "node:os";
+import * as path from "node:path";
+import * as mvm from "../src/index.js";
+
+let tmpDir: string;
+
+interface FixtureOptions {
+  upEnvelope: Record<string, unknown> | null;
+  upExit?: number;
+  procExit?: number;
+  fsExit?: number;
+  downExit?: number;
+}
+
+function writeFixtureMvmctl(opts: FixtureOptions): string {
+  const log = path.join(tmpDir, "fixture-calls.log");
+  const stdinDir = path.join(tmpDir, "fixture-stdin");
+  fs.mkdirSync(stdinDir, { recursive: true });
+
+  const envelopeJson = opts.upEnvelope === null ? "" : JSON.stringify(opts.upEnvelope);
+  const upExit = opts.upExit ?? 0;
+  const procExit = opts.procExit ?? 0;
+  const fsExit = opts.fsExit ?? 0;
+  const downExit = opts.downExit ?? 0;
+
+  const script = path.join(tmpDir, "fake-mvmctl");
+  fs.writeFileSync(
+    script,
+    `#!/usr/bin/env bash
+set -u
+verb=\${1:-}
+shift || true
+echo "$verb $*" >> ${JSON.stringify(log)}
+case "$verb" in
+  up)
+    if [ -t 0 ]; then :; else cat > ${JSON.stringify(path.join(stdinDir, "up-stdin.bin"))} || true; fi
+    if [ "${upExit}" -eq 0 ]; then
+      echo '${envelopeJson}'
+    fi
+    exit ${upExit}
+    ;;
+  proc)
+    sub=$1
+    if [ -t 0 ]; then :; else cat > ${JSON.stringify(path.join(stdinDir, "proc-stdin.bin"))} || true; fi
+    if [ "${procExit}" -eq 0 ] && [ "$sub" = "start" ]; then
+      echo "pid-token-abc123"
+    fi
+    exit ${procExit}
+    ;;
+  fs)
+    sub=$1
+    if [ "$sub" = "write" ]; then
+      cat > ${JSON.stringify(path.join(stdinDir, "fs-write-stdin.bin"))}
+    fi
+    exit ${fsExit}
+    ;;
+  down)
+    exit ${downExit}
+    ;;
+  *)
+    echo "fake-mvmctl: unrecognized verb $verb" >&2
+    exit 2
+    ;;
+esac
+`,
+    { mode: 0o755 },
+  );
+  return script;
+}
+
+function readFixtureLog(): string[] {
+  const log = path.join(tmpDir, "fixture-calls.log");
+  if (!fs.existsSync(log)) return [];
+  return fs.readFileSync(log, "utf-8").split("\n").filter((l) => l.length > 0);
+}
+
+beforeEach(() => {
+  tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "mvm-sdk-live-"));
+  mvm.resetRecording();
+  delete process.env.MVM_SDK_MODE;
+  delete process.env.MVM_CLI_BIN;
+});
+
+afterEach(() => {
+  mvm.resetRecording();
+  delete process.env.MVM_SDK_MODE;
+  delete process.env.MVM_CLI_BIN;
+  fs.rmSync(tmpDir, { recursive: true, force: true });
+});
+
+// ── envelope parsing ─────────────────────────────────────────────────
+
+describe("parseUpEnvelope", () => {
+  it("accepts a dev payload", () => {
+    const parsed = mvm.parseUpEnvelope(
+      '{"schema_version": 1, "vm_id": "sb-xyz", "build_mode": "dev"}\n',
+      ["mvmctl", "up"],
+    );
+    expect(parsed).toEqual({ vm_id: "sb-xyz", build_mode: "dev" });
+  });
+
+  it("rejects unknown schema", () => {
+    expect(() =>
+      mvm.parseUpEnvelope('{"schema_version": 99, "vm_id": "x", "build_mode": "dev"}', [
+        "mvmctl",
+        "up",
+      ]),
+    ).toThrow(/schema_version/);
+  });
+
+  it("rejects missing vm_id", () => {
+    expect(() =>
+      mvm.parseUpEnvelope('{"schema_version": 1, "build_mode": "dev"}', ["mvmctl", "up"]),
+    ).toThrow(/vm_id/);
+  });
+
+  it("rejects unknown build_mode", () => {
+    expect(() =>
+      mvm.parseUpEnvelope(
+        '{"schema_version": 1, "vm_id": "x", "build_mode": "staging"}',
+        ["mvmctl", "up"],
+      ),
+    ).toThrow(/build_mode/);
+  });
+
+  it("rejects empty stdout", () => {
+    expect(() => mvm.parseUpEnvelope("", ["mvmctl", "up"])).toThrow(/empty stdout/);
+  });
+
+  it("rejects invalid JSON", () => {
+    expect(() => mvm.parseUpEnvelope("not json", ["mvmctl", "up"])).toThrow(
+      /not valid JSON/,
+    );
+  });
+});
+
+// ── live-mode boot ───────────────────────────────────────────────────
+
+describe("Sandbox.create (live mode)", () => {
+  it("parses envelope and records vm_id + build_mode", () => {
+    const script = writeFixtureMvmctl({
+      upEnvelope: {
+        schema_version: 1,
+        vm_id: "sb-test-vm",
+        build_mode: "dev",
+      },
+    });
+    process.env.MVM_SDK_MODE = "live";
+    process.env.MVM_CLI_BIN = script;
+
+    const sb = mvm.Sandbox.create("python-3.12", { workloadId: "testwid" });
+    expect(sb._live).not.toBeNull();
+    expect(sb._live!.vmId).toBe("sb-test-vm");
+    expect(sb._live!.buildMode).toBe("dev");
+
+    const calls = readFixtureLog();
+    expect(calls.length).toBe(1);
+    expect(calls[0]).toMatch(/^up --up-json --name /);
+    expect(calls[0]).toContain("--manifest python-3.12");
+    expect(calls[0]).toContain("--ttl");
+  });
+
+  it("propagates mvmctl failure", () => {
+    const script = writeFixtureMvmctl({
+      upEnvelope: null,
+      upExit: 7,
+    });
+    process.env.MVM_SDK_MODE = "live";
+    process.env.MVM_CLI_BIN = script;
+
+    expect(() => mvm.Sandbox.create("python-3.12")).toThrow(/exit code 7/);
+  });
+
+  it("enforces one-sandbox-per-process", () => {
+    const script = writeFixtureMvmctl({
+      upEnvelope: {
+        schema_version: 1,
+        vm_id: "sb-first",
+        build_mode: "dev",
+      },
+    });
+    process.env.MVM_SDK_MODE = "live";
+    process.env.MVM_CLI_BIN = script;
+
+    mvm.Sandbox.create("python-dev");
+    expect(() => mvm.Sandbox.create("python-dev")).toThrow(/already active/);
+  });
+});
+
+// ── commands.start (claim-4 dev-only enforcement) ──────────────────
+
+describe("Sandbox.commands.start (live mode)", () => {
+  it("shells to proc start against dev template", () => {
+    const script = writeFixtureMvmctl({
+      upEnvelope: {
+        schema_version: 1,
+        vm_id: "sb-dev-vm",
+        build_mode: "dev",
+      },
+    });
+    process.env.MVM_SDK_MODE = "live";
+    process.env.MVM_CLI_BIN = script;
+
+    const sb = mvm.Sandbox.create("python-dev");
+    sb.commands.start(["python", "run.py"], { env: { MODE: "test" } });
+
+    const calls = readFixtureLog();
+    expect(calls.length).toBe(2);
+    expect(calls[1]).toMatch(/^proc start sb-dev-vm/);
+    expect(calls[1]).toContain("-e MODE=test");
+    expect(calls[1]).toContain("-- python run.py");
+  });
+
+  it("raises SandboxDevOnly against prod template (no vsock traffic)", () => {
+    const script = writeFixtureMvmctl({
+      upEnvelope: {
+        schema_version: 1,
+        vm_id: "sb-prod-vm",
+        build_mode: "prod",
+      },
+    });
+    process.env.MVM_SDK_MODE = "live";
+    process.env.MVM_CLI_BIN = script;
+
+    const sb = mvm.Sandbox.create("python-prod");
+    expect(readFixtureLog().length).toBe(1); // only `up`
+
+    expect(() => sb.commands.start(["python", "run.py"])).toThrow(
+      mvm.SandboxDevOnly,
+    );
+    // Critical: SDK must NOT have shelled to `mvmctl proc start`.
+    const calls = readFixtureLog();
+    expect(calls.length).toBe(1);
+    expect(calls.some((c) => c.startsWith("proc"))).toBe(false);
+  });
+});
+
+// ── files.write ──────────────────────────────────────────────────────
+
+describe("Sandbox.files.write (live mode)", () => {
+  it("shells with stdin bytes", () => {
+    const script = writeFixtureMvmctl({
+      upEnvelope: {
+        schema_version: 1,
+        vm_id: "sb-fs-vm",
+        build_mode: "dev",
+      },
+    });
+    process.env.MVM_SDK_MODE = "live";
+    process.env.MVM_CLI_BIN = script;
+
+    const sb = mvm.Sandbox.create("python-dev");
+    sb.files.write("/app/config.json", new TextEncoder().encode('{"x":1}'));
+
+    const calls = readFixtureLog();
+    expect(calls.some((c) => c.startsWith("fs write sb-fs-vm /app/config.json"))).toBe(true);
+    const stdinPath = path.join(tmpDir, "fixture-stdin", "fs-write-stdin.bin");
+    expect(fs.readFileSync(stdinPath, "utf-8")).toBe('{"x":1}');
+  });
+});
+
+// ── kill / dispose ───────────────────────────────────────────────────
+
+describe("Sandbox.kill (live mode)", () => {
+  it("shells to mvmctl down", () => {
+    const script = writeFixtureMvmctl({
+      upEnvelope: {
+        schema_version: 1,
+        vm_id: "sb-kill-vm",
+        build_mode: "dev",
+      },
+    });
+    process.env.MVM_SDK_MODE = "live";
+    process.env.MVM_CLI_BIN = script;
+
+    const sb = mvm.Sandbox.create("python-dev");
+    sb.kill();
+
+    const calls = readFixtureLog();
+    expect(calls).toContain("down sb-kill-vm");
+  });
+
+  it("[Symbol.dispose] kills once", () => {
+    const script = writeFixtureMvmctl({
+      upEnvelope: {
+        schema_version: 1,
+        vm_id: "sb-ctx-vm",
+        build_mode: "dev",
+      },
+    });
+    process.env.MVM_SDK_MODE = "live";
+    process.env.MVM_CLI_BIN = script;
+
+    const sb = mvm.Sandbox.create("python-dev");
+    sb[Symbol.dispose]();
+
+    const downCalls = readFixtureLog().filter((c) => c.startsWith("down "));
+    expect(downCalls.length).toBe(1);
+  });
+});

--- a/tests/run_live_mode.rs
+++ b/tests/run_live_mode.rs
@@ -1,0 +1,360 @@
+//! Followup H-live end-to-end test (Plan 73).
+//!
+//! Mirrors the `run_plan_mode.rs` pattern, but for the live
+//! transport. The test stands up:
+//!
+//! - A fixture `mvmctl` shell script (the "fake mvmctl") that
+//!   records each invocation's argv and emits the
+//!   `mvmctl up --up-json` envelope the SDK expects.
+//! - A real `mvmctl run --mode live <script>` invocation that
+//!   spawns the user script with `MVM_SDK_MODE=live` +
+//!   `MVM_CLI_BIN=<fixture>`.
+//! - A user Python script that constructs a `Sandbox` and calls
+//!   one `commands.start`.
+//!
+//! What the test asserts:
+//!
+//! 1. `mvmctl run --mode live` spawns the user script with the
+//!    right env vars (the fixture verifies `MVM_CLI_BIN` was set
+//!    by writing the binary path into its own log).
+//! 2. The SDK shells `mvmctl up --up-json` and parses the envelope.
+//! 3. The SDK shells `mvmctl proc start` against the dev VM.
+//! 4. The SDK shells `mvmctl down` on `Sandbox.__exit__`.
+//! 5. Against a prod-template envelope, the SDK raises
+//!    `SandboxDevOnly` *before* any `proc start` shell — security
+//!    claim 4 enforcement.
+//!
+//! No real microVM boots. Skips when no `python3`/`python` is on
+//! PATH.
+
+use std::path::PathBuf;
+use std::process::Command;
+
+use assert_cmd::cargo::CommandCargoExt;
+use tempfile::TempDir;
+
+const USER_SCRIPT_DEV: &str = r#"
+import mvm
+
+sb = mvm.Sandbox.create("python-dev", workload_id="livehello")
+sb.commands.start(["echo", "hi"], env={"MODE": "test"})
+sb.files.write("/app/data.bin", b"hello")
+sb.kill()
+"#;
+
+const USER_SCRIPT_PROD_REJECTED: &str = r#"
+import mvm, sys
+
+sb = mvm.Sandbox.create("python-prod", workload_id="liveprod")
+try:
+    sb.commands.start(["echo", "hi"])
+except mvm.SandboxDevOnly as exc:
+    print(f"DEVONLY_REJECTED: {exc}", file=sys.stderr)
+    sb.kill()
+    sys.exit(0)
+else:
+    print("UNEXPECTED: commands.start did not raise SandboxDevOnly", file=sys.stderr)
+    sys.exit(1)
+"#;
+
+fn python_on_path() -> Option<PathBuf> {
+    which::which("python3")
+        .ok()
+        .or_else(|| which::which("python").ok())
+}
+
+/// Write a fixture `mvmctl` shell script that records its argv to a
+/// log file and emits the requested envelope on `up --up-json`.
+fn write_fixture_mvmctl(dir: &std::path::Path, build_mode: &str) -> PathBuf {
+    let log = dir.join("fixture-calls.log");
+    let stdin_dir = dir.join("fixture-stdin");
+    std::fs::create_dir_all(&stdin_dir).unwrap();
+    let envelope =
+        format!(r#"{{"schema_version": 1, "vm_id": "sb-itest-vm", "build_mode": "{build_mode}"}}"#);
+
+    let script_path = dir.join("fake-mvmctl");
+    let script_body = format!(
+        r#"#!/usr/bin/env bash
+set -u
+verb=${{1:-}}
+shift || true
+echo "$verb $*" >> {log}
+case "$verb" in
+  up)
+    echo '{envelope}'
+    exit 0
+    ;;
+  proc)
+    if [ "${{1:-}}" = "start" ]; then
+      echo "pid-token-itest"
+    fi
+    exit 0
+    ;;
+  fs)
+    if [ "${{1:-}}" = "write" ]; then
+      cat > {stdin_dir}/fs-write-stdin.bin
+    fi
+    exit 0
+    ;;
+  down)
+    exit 0
+    ;;
+  *)
+    echo "fake-mvmctl: unrecognized verb $verb" >&2
+    exit 2
+    ;;
+esac
+"#,
+        log = log.display(),
+        envelope = envelope,
+        stdin_dir = stdin_dir.display(),
+    );
+    std::fs::write(&script_path, script_body).unwrap();
+    let mut perms = std::fs::metadata(&script_path).unwrap().permissions();
+    use std::os::unix::fs::PermissionsExt;
+    perms.set_mode(0o755);
+    std::fs::set_permissions(&script_path, perms).unwrap();
+    script_path
+}
+
+fn read_fixture_log(dir: &std::path::Path) -> Vec<String> {
+    let log = dir.join("fixture-calls.log");
+    if !log.exists() {
+        return Vec::new();
+    }
+    std::fs::read_to_string(&log)
+        .unwrap_or_default()
+        .lines()
+        .filter(|l| !l.is_empty())
+        .map(|s| s.to_string())
+        .collect()
+}
+
+/// Build the `mvmctl run --mode live <script>` invocation. The
+/// fixture `mvmctl` shell script lives in `fixture_dir`; we point
+/// the SDK at it via `MVM_CLI_BIN` — except that's set by the verb
+/// itself, so we instead provide a wrapper script that, when
+/// invoked by `mvmctl run --mode live`, hijacks `MVM_CLI_BIN`
+/// before reaching the SDK.
+///
+/// In practice the verb sets `MVM_CLI_BIN=<current_exe>`. To
+/// avoid a real `mvmctl up` going out and trying to boot a VM,
+/// the test overrides `MVM_CLI_BIN` directly via `Command::env`
+/// after the verb sets it — that's not possible because the verb
+/// is the spawner. So instead the test inlines the env override
+/// by running the user script directly with `MVM_SDK_MODE=live`
+/// and `MVM_CLI_BIN=<fixture>` — bypassing `mvmctl run --mode
+/// live`. A separate test below asserts that the verb itself
+/// dispatches; this one asserts the SDK transport.
+#[allow(dead_code)]
+fn _phantom_doc() {}
+
+#[test]
+fn sdk_live_dev_template_shells_to_proc_start() {
+    let Some(python) = python_on_path() else {
+        eprintln!("skipping sdk_live_dev_template: no python3/python on PATH");
+        return;
+    };
+
+    let tmp = TempDir::new().unwrap();
+    let script = tmp.path().join("hello.py");
+    std::fs::write(&script, USER_SCRIPT_DEV).unwrap();
+    let fixture = write_fixture_mvmctl(tmp.path(), "dev");
+
+    // Run the user script directly under MVM_SDK_MODE=live with
+    // the fixture mvmctl. This is the inner half of what `mvmctl
+    // run --mode live` does — the verb just spawns the script
+    // with the same env vars.
+    let mut cmd = Command::new(&python);
+    cmd.env("MVM_SDK_MODE", "live")
+        .env("MVM_CLI_BIN", &fixture)
+        .env(
+            "PYTHONPATH",
+            std::env::current_dir().unwrap().join("sdks/python"),
+        )
+        .arg(&script);
+
+    let output = cmd.output().expect("spawn user script");
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        output.status.success(),
+        "live-mode user script must exit 0.\n--- stdout ---\n{stdout}\n--- stderr ---\n{stderr}"
+    );
+
+    let calls = read_fixture_log(tmp.path());
+    // 1: up --up-json, 2: proc start, 3: fs write, 4: down
+    assert!(
+        calls.len() >= 4,
+        "expected >= 4 mvmctl shells (up, proc start, fs write, down); got {calls:?}"
+    );
+    assert!(
+        calls[0].starts_with("up --up-json"),
+        "first shell must be `up --up-json`, got {:?}",
+        calls[0]
+    );
+    assert!(
+        calls
+            .iter()
+            .any(|c| c.starts_with("proc start sb-itest-vm")),
+        "expected a `proc start sb-itest-vm` shell; got {calls:?}"
+    );
+    assert!(
+        calls
+            .iter()
+            .any(|c| c.starts_with("fs write sb-itest-vm /app/data.bin")),
+        "expected a `fs write sb-itest-vm /app/data.bin` shell; got {calls:?}"
+    );
+    assert!(
+        calls.iter().any(|c| c.starts_with("down sb-itest-vm")),
+        "expected a `down sb-itest-vm` shell; got {calls:?}"
+    );
+}
+
+#[test]
+fn sdk_live_prod_template_raises_sandbox_dev_only_before_proc_start() {
+    let Some(python) = python_on_path() else {
+        eprintln!("skipping sdk_live_prod_template: no python3/python on PATH");
+        return;
+    };
+
+    let tmp = TempDir::new().unwrap();
+    let script = tmp.path().join("prod.py");
+    std::fs::write(&script, USER_SCRIPT_PROD_REJECTED).unwrap();
+    let fixture = write_fixture_mvmctl(tmp.path(), "prod");
+
+    let mut cmd = Command::new(&python);
+    cmd.env("MVM_SDK_MODE", "live")
+        .env("MVM_CLI_BIN", &fixture)
+        .env(
+            "PYTHONPATH",
+            std::env::current_dir().unwrap().join("sdks/python"),
+        )
+        .arg(&script);
+
+    let output = cmd.output().expect("spawn prod user script");
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        output.status.success(),
+        "user script handles SandboxDevOnly itself and exits 0.\n--- stdout ---\n{stdout}\n--- stderr ---\n{stderr}"
+    );
+    assert!(
+        stderr.contains("DEVONLY_REJECTED"),
+        "expected the user script's SandboxDevOnly handler to fire; stderr was:\n{stderr}"
+    );
+
+    let calls = read_fixture_log(tmp.path());
+    assert!(
+        !calls.iter().any(|c| c.starts_with("proc")),
+        "SDK must NOT have shelled to `mvmctl proc start` against a prod template (security claim 4 client-side enforcement); but the fixture saw: {calls:?}"
+    );
+    assert!(
+        calls.iter().any(|c| c.starts_with("up --up-json")),
+        "the `up` shell must still have fired; got {calls:?}"
+    );
+}
+
+#[test]
+fn run_mode_live_dispatches_to_user_script() {
+    let Some(python) = python_on_path() else {
+        eprintln!("skipping run_mode_live_dispatches: no python3/python on PATH");
+        return;
+    };
+
+    let tmp = TempDir::new().unwrap();
+    let script = tmp.path().join("noop.py");
+    // No-op script — we only assert that mvmctl run --mode live
+    // spawns it under MVM_SDK_MODE=live + MVM_CLI_BIN. The script
+    // writes a sentinel file so we can confirm it ran.
+    let sentinel = tmp.path().join("ran-under-live.flag");
+    std::fs::write(
+        &script,
+        format!(
+            r#"
+import os, sys
+mode = os.environ.get("MVM_SDK_MODE", "")
+mvm_bin = os.environ.get("MVM_CLI_BIN", "")
+with open(r"{sentinel}", "w") as f:
+    f.write(f"mode={{mode}} mvm_bin_set={{bool(mvm_bin)}}")
+sys.exit(0)
+"#,
+            sentinel = sentinel.display(),
+        ),
+    )
+    .unwrap();
+
+    let home = TempDir::new().unwrap();
+    #[allow(deprecated)]
+    let mut cmd = Command::cargo_bin("mvmctl").expect("locate mvmctl binary");
+    cmd.env("HOME", home.path())
+        .env_remove("MVM_SDK_MODE")
+        .env("MVM_PYTHON", &python)
+        .arg("run")
+        .arg("--mode")
+        .arg("live")
+        .arg(&script);
+
+    let output = cmd.output().expect("spawn mvmctl run --mode live");
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        output.status.success(),
+        "mvmctl run --mode live must exit 0 on a clean script.\n--- stdout ---\n{stdout}\n--- stderr ---\n{stderr}"
+    );
+    let sentinel_contents =
+        std::fs::read_to_string(&sentinel).expect("user script must write the sentinel");
+    assert!(
+        sentinel_contents.contains("mode=live"),
+        "MVM_SDK_MODE must be `live` inside the spawned script; got: {sentinel_contents}"
+    );
+    assert!(
+        sentinel_contents.contains("mvm_bin_set=True"),
+        "MVM_CLI_BIN must be set by the verb; got: {sentinel_contents}"
+    );
+}
+
+#[test]
+fn run_dev_alias_dispatches_live_mode() {
+    let Some(python) = python_on_path() else {
+        eprintln!("skipping run_dev_alias_dispatches: no python3/python on PATH");
+        return;
+    };
+
+    let tmp = TempDir::new().unwrap();
+    let script = tmp.path().join("noop.py");
+    let sentinel = tmp.path().join("ran-via-dev-alias.flag");
+    std::fs::write(
+        &script,
+        format!(
+            r#"
+import os, sys
+with open(r"{sentinel}", "w") as f:
+    f.write(os.environ.get("MVM_SDK_MODE", "(unset)"))
+sys.exit(0)
+"#,
+            sentinel = sentinel.display(),
+        ),
+    )
+    .unwrap();
+
+    let home = TempDir::new().unwrap();
+    #[allow(deprecated)]
+    let mut cmd = Command::cargo_bin("mvmctl").expect("locate mvmctl binary");
+    cmd.env("HOME", home.path())
+        .env_remove("MVM_SDK_MODE")
+        .env("MVM_PYTHON", &python)
+        .arg("run")
+        .arg("--dev")
+        .arg(&script);
+
+    let output = cmd.output().expect("spawn mvmctl run --dev");
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        output.status.success(),
+        "mvmctl run --dev must dispatch live mode (post-Followup-H-live). stderr was:\n{stderr}"
+    );
+    let sentinel_contents =
+        std::fs::read_to_string(&sentinel).expect("user script must write the sentinel");
+    assert_eq!(sentinel_contents.trim(), "live");
+}

--- a/tests/run_plan_mode.rs
+++ b/tests/run_plan_mode.rs
@@ -12,14 +12,13 @@
 //!
 //! 1. `mvmctl run --mode plan <script>` admits a clean recording
 //!    and exits zero. ADMITTED lines hit stdout.
-//! 2. `mvmctl run --dev <script>` bails with the "blocked, pairs
-//!    with Followup H-live" message and a nonzero exit.
-//! 3. `mvmctl run --prod <script>` redirects users to
+//! 2. `mvmctl run --prod <script>` redirects users to
 //!    `mvmctl compile` with a nonzero exit and a clear pointer.
-//! 4. `mvmctl run --mode plan` over a script that produces a
-//!    Workload with a too-short SHA (we force-feed one via
-//!    `MVM_SDK_OUT_PATH` pointed at a hand-built recording) is
-//!    rejected by admission with a nonzero exit.
+//! 3. `mvmctl run --mode plan` over a non-script path is rejected
+//!    with the language-extension hint.
+//!
+//! The `--dev` alias and `--mode live` happy paths are exercised
+//! in `tests/run_live_mode.rs` post-Followup-H-live.
 //!
 //! Skips when no `python3`/`python` is on PATH.
 
@@ -111,31 +110,6 @@ fn run_plan_mode_admits_clean_recording_and_exits_zero() {
 }
 
 #[test]
-fn run_dev_alias_is_blocked_with_followup_h_live_message() {
-    let tmp = TempDir::new().unwrap();
-    let script = tmp.path().join("hello.py");
-    std::fs::write(&script, "print('noop')\n").unwrap();
-
-    let home = TempDir::new().unwrap();
-    let output = mvmctl_run_plan_cmd(home.path())
-        .arg("run")
-        .arg("--dev")
-        .arg(&script)
-        .output()
-        .expect("spawn mvmctl run --dev");
-
-    assert!(
-        !output.status.success(),
-        "mvmctl run --dev must fail nonzero in v1"
-    );
-    let stderr = String::from_utf8_lossy(&output.stderr);
-    assert!(
-        stderr.contains("Followup H-live") || stderr.contains("blocked"),
-        "expected --dev to bail with a 'pairs with Followup H-live' hint; stderr was:\n{stderr}"
-    );
-}
-
-#[test]
 fn run_prod_alias_redirects_to_mvmctl_compile() {
     let tmp = TempDir::new().unwrap();
     let script = tmp.path().join("hello.py");
@@ -157,32 +131,6 @@ fn run_prod_alias_redirects_to_mvmctl_compile() {
     assert!(
         stderr.contains("mvmctl compile"),
         "--prod must redirect users to `mvmctl compile`; stderr was:\n{stderr}"
-    );
-}
-
-#[test]
-fn run_mode_live_bails_blocked_on_followup_h_live() {
-    let tmp = TempDir::new().unwrap();
-    let script = tmp.path().join("hello.py");
-    std::fs::write(&script, "print('noop')\n").unwrap();
-
-    let home = TempDir::new().unwrap();
-    let output = mvmctl_run_plan_cmd(home.path())
-        .arg("run")
-        .arg("--mode")
-        .arg("live")
-        .arg(&script)
-        .output()
-        .expect("spawn mvmctl run --mode live");
-
-    assert!(
-        !output.status.success(),
-        "mvmctl run --mode live must fail in v1"
-    );
-    let stderr = String::from_utf8_lossy(&output.stderr);
-    assert!(
-        stderr.contains("Followup H-live") || stderr.contains("blocked"),
-        "expected --mode live to bail with a Followup H-live hint; stderr was:\n{stderr}"
     );
 }
 


### PR DESCRIPTION
## Summary

- Unblocks the live half of Followup H (Plan 73). `mvmctl run --mode live <script>` (alias `--dev`) spawns the user's Python / TypeScript script with `MVM_SDK_MODE=live` + `MVM_CLI_BIN=<resolved-mvmctl>`; the SDK shells each `Sandbox` operation to existing `mvmctl up` / `proc start` / `fs write` / `down` against a real microVM.
- New `mvmctl up --up-json` flag emits a single-line JSON envelope `{"schema_version": 1, "vm_id": "...", "build_mode": "dev|prod"}` on stdout (routes the `[mvm]` chrome to stderr via a new `mvm_base::ui::set_chrome_to_stderr` toggle). The SDK uses the `build_mode` field to enforce the W4.3 dev-only `do_exec` rule client-side.
- Python + TypeScript SDKs grow a `_LiveTransport` / `LiveTransport` class, two new exceptions (`SandboxLiveError`, `SandboxDevOnly`), and route the existing `Sandbox.commands.start` / `files.write` / `kill` / `__exit__` (or `[Symbol.dispose]`) entry points to the new shell branch when live mode is active.

## Scope (Python + TS + CLI)

**CLI (`crates/mvm-cli`)**
- `commands/vm/exec.rs`: `resolve_run_mode` accepts `--dev` / `--mode live` (was previously refused).
- `commands/vm/run_plan.rs`: new `run_live_mode` dispatcher; spawns the script under `MVM_SDK_MODE=live` + `MVM_CLI_BIN=<current_exe>`.
- `commands/vm/up.rs`: new `--up-json` flag (forces `--detach`, refuses `--watch` / `--forward`, emits the JSON envelope on stdout). New `template_build_mode_for_envelope` helper resolves the template's `TemplateRevision.build_mode`.
- `commands/build/sandbox_record.rs`: `resolve_interpreter` + `script_language_from_path` made reusable (no shape change; the live verb shares the resolver record-mode auto-exec already uses).
- `crates/mvm-base/src/ui.rs` + `crates/mvm-cli/src/ui.rs`: new `CHROME_TO_STDERR` atomic; `info` / `success` / `warn` / `step` / `progress` route to stderr when set.

**Python SDK (`sdks/python/mvm/_sandbox.py`)**
- New `_LiveTransport` class (parses the `--up-json` envelope, shells subsequent operations, refuses `commands.start` on a prod template).
- New `SandboxLiveError` + `SandboxDevOnly` exceptions exported via `mvm`.
- `_resolve_mode()` now accepts `live` (requires `MVM_CLI_BIN`), refuses `plan` with a redirect to `mvmctl run --mode plan`.

**TypeScript SDK (`sdks/typescript/src/_sandbox.ts`)**
- Mirror of the Python transport built on `node:child_process.spawnSync`.
- Exports `LiveTransport`, `SandboxLiveError`, `SandboxDevOnly`, `parseUpEnvelope`, `MVM_CLI_BIN_ENV`.

## SandboxDevOnly enforcement (security claim 4)

Per ADR-002 §W4.3 (CLAUDE.md security claim 4) the guest agent strips the `do_exec` handler in prod builds. Both SDKs now refuse `commands.start` client-side when the resolved template's `build_mode == "prod"`, **before** any vsock round-trip. `files.write` and `kill` route to `mvmctl fs write` / `mvmctl down`, which remain available in prod builds, so the dev-only gate is scoped to `commands.start` only. The agent still fails closed; the SDK fails first so a typo doesn't emit spurious vsock traffic.

## Test plan

- [x] `cargo test --workspace` — passes (added `tests/run_live_mode.rs` with 4 tests).
- [x] `cargo clippy --workspace --all-targets -- -D warnings` — clean.
- [x] `cargo fmt --check` — clean.
- [x] `cargo run -p xtask -- check-no-display-on-secret-types` — clean.
- [x] `pytest sdks/python/tests/` — passes (added `test_sandbox_live.py` with 14 tests covering envelope parsing, live boot, `SandboxDevOnly` enforcement, files.write stdin shell, kill, context manager).
- [x] `npm test` in `sdks/typescript` — passes (added `sandbox_live.test.ts`, 14 tests mirroring the Python coverage).
- [x] Updated pre-existing tests that asserted `--dev` / `--mode live` should bail with the H-live blocker message (these now dispatch live mode instead).

## Manual smoke checklist for a real dev microVM

Out of CI scope, but the post-merge validation loop:

1. `mvmctl dev up` (libkrun-backed dev VM, Plan 72).
2. `mvmctl template build --dev hello-dev` (creates a dev template with the agent's `do_exec` handler intact).
3. Write a script:
   ```python
   import mvm
   with mvm.Sandbox.create("hello-dev") as sb:
       sb.commands.start(["echo", "hi"])
       sb.files.write("/tmp/note.txt", "hello from sdk live")
   ```
4. `mvmctl run --dev ./hello.py` — should boot a real microVM, exec `echo hi`, write the file, tear down via `__exit__`.
5. Re-build the template with `--prod` and re-run — `commands.start` should raise `SandboxDevOnly` before any vsock traffic; the `up` shell still fires.
6. Repeat (3)–(5) with a TypeScript script using `mvm.Sandbox.create(...)` to validate the mirror transport.

## Out of scope

- Real-microVM end-to-end smoke in CI (Plan 72 W4/W5 dev VM is the dependency).
- `snapshot.create` / `metrics.read` Sandbox surfaces (not yet exposed in the SDK API — only the four verbs listed in the SDK plan's mapping are wired).
- `secret_ref` env values in live `commands.start` — refused with `SandboxLiveError`. The orchestrator's keystore release path is what owns secrets; v1 live mode only forwards literal env vars.

🤖 Generated with [Claude Code](https://claude.com/claude-code)