### PR TITLE
feat(mk-guest): ship vsock kernel modules in rootfs

### DIFF
--- a/nix/images/builder-vm/flake.nix
+++ b/nix/images/builder-vm/flake.nix
@@ -194,6 +194,13 @@
         let
           pkgs = import nixpkgs { inherit system; };
           builderInit = mvmBuilderInitFor system;
+          # Stock nixpkgs kernel. Pass it to `mkGuest` so the rootfs
+          # ships its module tree (`/lib/modules/<kver>/`); the
+          # builder VM doesn't run the standard `/init` modprobe path
+          # (its cmdline pins `init=/sbin/mvm-builder-init`) but the
+          # modules sit alongside so `mvm-builder-init` or downstream
+          # tools can load them on demand.
+          kernelPkg = pkgs.linuxPackages.kernel;
           rootfs = (libFor { inherit system; }).mkGuest {
             name = "mvm-builder-vm";
             # mkGuest requires an entrypoint declaration. At runtime
@@ -206,8 +213,8 @@
               "/sbin/mvm-builder-init" =
                 "${builderInit}/bin/mvm-builder-init";
             };
+            kernel = kernelPkg;
           };
-          kernelPkg = pkgs.linuxPackages.kernel;
           kernelFile =
             if pkgs.stdenv.hostPlatform.isAarch64 then "Image" else "bzImage";
         in

--- a/nix/images/builder/flake.nix
+++ b/nix/images/builder/flake.nix
@@ -114,12 +114,19 @@
       mkBuilderImage = system:
         let
           pkgs = import nixpkgs { inherit system; };
+          # Stock nixpkgs kernel. Pass it to `mkGuest` so the rootfs
+          # ships its module tree (`/lib/modules/<kver>/`) and `/init`
+          # can `modprobe vmw_vsock_virtio_transport` before the agent
+          # forks. Without modules the agent fails to open AF_VSOCK
+          # (nixpkgs default config has VSOCK=m) and every host-side
+          # surface (`mvmctl console`, `dev shell`, `build`) goes dark.
+          kernelPkg = pkgs.linuxPackages.kernel;
           rootfs = (libFor { inherit system; }).mkGuest {
             name = "mvm-dev";
             entrypoint.shell = "/bin/sh";
             packages = builderPackages pkgs;
+            kernel = kernelPkg;
           };
-          kernelPkg = pkgs.linuxPackages.kernel;
           kernelFile =
             if pkgs.stdenv.hostPlatform.isAarch64
             then "Image"

--- a/nix/lib/mk-guest.nix
+++ b/nix/lib/mk-guest.nix
@@ -78,6 +78,15 @@ in
 , dev            ? null
 , uids           ? null   # { agent = <int>; entrypoint = <int>; } — see below
 , extraFiles     ? { }
+# Optional kernel package. When set, mkGuest copies its module
+# tree (`/lib/modules/<kver>/`) into the rootfs and `/init` runs
+# `modprobe vmw_vsock_virtio_transport` before forking the agent.
+# Required when the kernel ships AF_VSOCK as a module (the default
+# nixpkgs `linuxPackages.kernel` config). Without it,
+# `mvm-guest-agent`'s `socket(AF_VSOCK, …)` returns EAFNOSUPPORT and
+# every host-side surface (`mvmctl console`, `dev shell`, `build`)
+# goes dark on a guest booted from that kernel.
+, kernel         ? null
 }:
 let
   entrypointKind = classifyEntrypoint entrypoint;
@@ -206,6 +215,18 @@ let
     # mountpoints instead.
     /bin/busybox mount -t tmpfs -o mode=1777,nosuid,nodev tmpfs /tmp
     /bin/busybox mount -t tmpfs -o mode=0755,nosuid,nodev tmpfs /run
+
+    # Stage 2.25 — vsock kernel modules. Stock nixpkgs kernel ships
+    # AF_VSOCK as `=m`; without modprobe the agent's
+    # `socket(AF_VSOCK, …)` returns EAFNOSUPPORT. modprobe-ing
+    # `vmw_vsock_virtio_transport` pulls in `vsock` +
+    # `vmw_vsock_virtio_transport_common` via modules.dep. Silently
+    # skipped when `/lib/modules` is absent — e.g. on a future kernel
+    # that ships VSOCK=y, or when `mkGuest` was called without the
+    # `kernel` argument.
+    if [ -d /lib/modules ]; then
+      /bin/busybox modprobe vmw_vsock_virtio_transport 2>/dev/null || true
+    fi
 
     # Stage 2.5 — guest agent supervisor. Fork the agent into
     # the background under its own uid before we drop to the
@@ -399,6 +420,46 @@ let
     mkdir -p "$out/usr/local/bin"
     cp ${agentBinary} "$out/usr/local/bin/mvm-guest-agent"
     chmod 0555 "$out/usr/local/bin/mvm-guest-agent"
+
+    # Kernel modules. `/init` `modprobe`s vsock before forking the
+    # agent (default nixpkgs kernel ships AF_VSOCK as `=m`); without
+    # `/lib/modules/<kver>/` in the rootfs, modprobe has nothing to
+    # load and the agent fails to open AF_VSOCK.
+    #
+    # nixpkgs splits the aarch64-linux kernel into two derivations:
+    # `kernel` ships `Image` + `System.map` + `dtbs/` (no modules),
+    # while `kernel.modules` owns the `lib/modules/<kver>/` tree
+    # (built with `INSTALL_MOD_PATH=$out`). Probe `kernel.modules`
+    # first (modern nixpkgs), fall back to `kernel`'s own `$out` for
+    # single-output kernel packages microvm.nix wraps.
+    ${lib.optionalString (kernel != null) (
+      let
+        candidates =
+          (if kernel ? modules then [ kernel.modules ] else [ ])
+          ++ [ kernel ];
+        candidateRefs = lib.concatMapStringsSep " " (c: ''"${c}"'') candidates;
+      in ''
+        for cand in ${candidateRefs}; do
+          if [ -d "$cand/lib/modules" ]; then
+            shopt -s nullglob
+            kmod_dirs=("$cand"/lib/modules/*)
+            shopt -u nullglob
+            for src in "''${kmod_dirs[@]}"; do
+              kver=$(${pkgs.coreutils}/bin/basename "$src")
+              mkdir -p "$out/lib/modules/$kver"
+              cp -a --reflink=auto "$src/." "$out/lib/modules/$kver/"
+              # Drop build-machine `source`/`build` symlinks that
+              # point into host nix-store dev outputs the guest
+              # can't resolve. modprobe warns on every invocation
+              # otherwise; the guest never reads kernel headers.
+              rm -f "$out/lib/modules/$kver/source" \
+                    "$out/lib/modules/$kver/build"
+            done
+            break
+          fi
+        done
+      ''
+    )}
 
     # Extra user-supplied files.
     ${extraFilePopulation}


### PR DESCRIPTION
## Summary

Adds an optional `kernel` argument to `mkGuest` that, when set, copies the kernel's `/lib/modules/<kver>/` tree into the rootfs. `/init` then `modprobe`s `vmw_vsock_virtio_transport` before forking the agent.

Without this, stock `pkgs.linuxPackages.kernel` ships AF_VSOCK as `=m`, the rootfs has no module tree, the in-guest `mvm-guest-agent`'s `socket(AF_VSOCK, …)` returns `EAFNOSUPPORT`, and every host-side surface that talks to the agent (`mvmctl console`, `mvmctl dev shell`, `mvmctl build`) silently fails.

Recreates the work from #117 (closed against `feat/mock-backend`, which got resolved separately) on current `main` in a minimal three-file diff so it lands before the libkrun migration churn. Refinements that were on the closed branch — modules-tree trim, ELF strip, hardlink-dedupe — are deliberately left out; they're independent follow-ups.

## Files

- `nix/lib/mk-guest.nix`:
  - New `kernel ? null` arg.
  - `cp -a --reflink=auto` the module tree from the appropriate output (`kernel.modules` first — modern nixpkgs convention — falling back to `kernel` itself for single-output kernel packages microvm.nix wraps).
  - Drop the build-machine `source`/`build` symlinks (point into host nix-store dev outputs the guest can't resolve; modprobe warns otherwise).
  - `/init` Stage 2.25: `modprobe vmw_vsock_virtio_transport` (pulls in `vsock` + `vmw_vsock_virtio_transport_common` via modules.dep). Silently skipped when `/lib/modules` is absent.

- `nix/images/builder/flake.nix` + `nix/images/builder-vm/flake.nix`:
  Pass `kernel = pkgs.linuxPackages.kernel` to `mkGuest`. No other behavior change — the kernel was already being copied to `$out/vmlinux` by the outer `runCommand`; this plumbs the same derivation into mkGuest so the modules land in the rootfs alongside.

## Test plan

- [x] `cargo build --workspace` — clean (no Rust changes).
- [ ] CI nix-eval lane — pending push.
- End-to-end verified locally on the kernel-modules iteration earlier this week:
  - `mvmctl dev up` boots, agent opens AF_VSOCK.
  - `mvmctl console mvm-dev --command "lsmod | grep vsock"` shows `vmw_vsock_virtio_transport`, `vmw_vsock_virtio_transport_common`, `vsock` all `Live`.

## Relationship to #117

#117 carried the same fix plus eight commits of rootfs refinements (modules-tree trim to vsock closure, ELF strip, hardlink-dedupe, `/share` trim, GNU duplicate removal). That PR was closed against `feat/mock-backend`. This PR is the minimal kernel-modules-in-rootfs subset on top of current `main`; the refinements can land as separate follow-ups now that the foundation is in.

🤖 Generated with [Claude Code](https://claude.com/claude-code)