### PR TITLE
feat(builder-vm): plan 73 followup B.2.x — egress allowlist via HTTPS proxy

### DIFF
--- a/.github/workflows/architecture.yml
+++ b/.github/workflows/architecture.yml
@@ -38,10 +38,15 @@ jobs:
   #      orchestrator doesn't need privilege. Collapsing into mvmd
   #      would destroy the privilege boundary it exists to provide.
   #   2. Per-VM security primitives — L7 egress proxy
-  #      (`crates/mvm-supervisor/src/l7_proxy.rs`). Inspects outbound
-  #      HTTP from each guest. Lives next to the workload, not at the
-  #      orchestrator tier — moving to mvmd would force every per-VM
-  #      flow through the control plane.
+  #      (`crates/mvm-supervisor/src/l7_proxy.rs`) and builder-VM
+  #      install-time egress allowlist proxy
+  #      (`crates/mvm-egress-proxy/`). The L7 proxy inspects outbound
+  #      HTTP from each running guest; the install proxy enforces
+  #      ADR-047's registry allowlist inside the builder VM during
+  #      `uv pip install` / `pnpm install` (Plan 73 Followup B.2.x).
+  #      Both live next to the workload, not at the orchestrator
+  #      tier — moving either to mvmd would force every per-VM flow
+  #      through the control plane.
   #   3. Per-VM provider plumbing — Apple Container sockets
   #      (`crates/mvm-providers/src/apple_container/macos.rs`).
   #      Provider-specific guest-channel transport.
@@ -99,6 +104,7 @@ jobs:
               --glob '!**/examples/**' \
               --glob '!crates/mvm/src/hostd/**' \
               --glob '!crates/mvm-supervisor/src/l7_proxy.rs' \
+              --glob '!crates/mvm-egress-proxy/**' \
               --glob '!crates/mvm-providers/src/apple_container/**' \
               --glob '!crates/mvm-cli/src/metrics_server.rs' \
               --glob '!crates/mvm-cli/src/template_cmd.rs' \

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4174,6 +4174,7 @@ dependencies = [
 name = "mvm-builder-init"
 version = "0.14.0"
 dependencies = [
+ "libc",
  "nix 0.29.0",
  "serde_json",
  "tempfile",
@@ -4250,6 +4251,14 @@ dependencies = [
  "tracing",
  "tracing-subscriber",
  "uuid",
+]
+
+[[package]]
+name = "mvm-egress-proxy"
+version = "0.14.0"
+dependencies = [
+ "libc",
+ "tempfile",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,6 +19,11 @@ members = [
     # runtime; the crate compiles on macOS / Windows as an inert
     # binary so workspace builds stay green for non-Linux contributors.
     "crates/mvm-builder-init",
+    # Plan 73 Followup B.2.x — HTTP CONNECT proxy with hostname
+    # allowlist for the builder VM's application-deps install.
+    # Linux-only at runtime; same workspace-ergonomics rule as
+    # mvm-builder-init.
+    "crates/mvm-egress-proxy",
     # plan 60 Phase 5 — build-time SDK port from ../mvmforge.
     # mvm-ir is the canonical Workload IR; mvm-sdk is the builder
     # surface; mvm-sdk-macros is a placeholder for the proc-macro
@@ -208,6 +213,11 @@ mvm-providers = { path = "crates/mvm-providers", version = "0.14.0" }
 # enable `libkrun-sys` on a host with libkrun installed.
 mvm-libkrun = { path = "crates/mvm-libkrun", version = "0.14.0" }
 mvm-backend = { path = "crates/mvm-backend", version = "0.14.0", default-features = false }
+
+# Plan 73 Followup B.2.x — builder-VM egress allowlist proxy.
+# mvm-builder-init spawns this as a subprocess before the
+# installer + tears it down after.
+mvm-egress-proxy = { path = "crates/mvm-egress-proxy", version = "0.14.0" }
 
 # Dev dependencies
 assert_cmd = "2"

--- a/crates/mvm-builder-init/Cargo.toml
+++ b/crates/mvm-builder-init/Cargo.toml
@@ -22,7 +22,10 @@ path = "src/main.rs"
 [target.'cfg(target_os = "linux")'.dependencies]
 # Linux mount/reboot syscalls. Kept Linux-only so non-Linux
 # workspace builds don't drag in the dep tree.
-nix = { version = "0.29", features = ["mount", "reboot"] }
+nix = { version = "0.29", features = ["mount", "reboot", "signal"] }
+# libc for SIGTERM / SIGKILL when tearing the egress proxy down
+# after the installer exits. Linux-only same as nix above.
+libc.workspace = true
 
 [dev-dependencies]
 # Test scratch dirs + JSON parsing for assertions against the

--- a/crates/mvm-builder-init/src/install.rs
+++ b/crates/mvm-builder-init/src/install.rs
@@ -44,6 +44,7 @@ use std::path::{Path, PathBuf};
 use std::process::{Command, Stdio};
 
 use crate::install_spec::{GateLevel, InstallSpec, Language};
+use crate::proxy::{PROXY_URL, ProxyLifecycle};
 
 /// Subdir under `<job_dir>` that holds the installed payload. Same
 /// name as the canonical sealed-volume layout
@@ -123,6 +124,24 @@ pub trait CommandRunner {
         args: &[&str],
         log_path: Option<&Path>,
         extra_path: Option<&Path>,
+    ) -> Result<i32, String> {
+        self.run_with_env(program, args, log_path, extra_path, &[])
+    }
+
+    /// Like [`Self::run`] but accepts extra environment variables
+    /// to set on the child. The installer wrap path
+    /// ([`run_install`]) uses this to inject `HTTP_PROXY` +
+    /// `HTTPS_PROXY` pointing at the in-VM `mvm-egress-proxy`
+    /// (Plan 73 Followup B.2.x). Implementors that don't need
+    /// env-var injection can rely on the default impl of
+    /// [`Self::run`] and override only this method.
+    fn run_with_env(
+        &self,
+        program: &str,
+        args: &[&str],
+        log_path: Option<&Path>,
+        extra_path: Option<&Path>,
+        env: &[(&str, &str)],
     ) -> Result<i32, String>;
 
     /// Whether `program` resolves on PATH (with `extra_path`
@@ -144,12 +163,13 @@ pub trait CommandRunner {
 pub struct SystemCommandRunner;
 
 impl CommandRunner for SystemCommandRunner {
-    fn run(
+    fn run_with_env(
         &self,
         program: &str,
         args: &[&str],
         log_path: Option<&Path>,
         extra_path: Option<&Path>,
+        env: &[(&str, &str)],
     ) -> Result<i32, String> {
         let mut cmd = Command::new(program);
         cmd.args(args);
@@ -161,6 +181,9 @@ impl CommandRunner for SystemCommandRunner {
                 prepended.push(&path_env);
             }
             cmd.env("PATH", prepended);
+        }
+        for (k, v) in env {
+            cmd.env(k, v);
         }
 
         match log_path {
@@ -236,11 +259,31 @@ impl std::fmt::Display for InstallError {
 
 impl std::error::Error for InstallError {}
 
-/// Public entry point. Run the install pipeline for `spec`,
-/// writing the four sealed-volume artifacts (`content/`, SBOM,
-/// fetch log, CVE) into `out_dir` and the install report into
-/// `job_dir/result.json`. `runner` spawns each subprocess;
-/// `extra_path` flows into the runner so tests can stub binaries.
+/// Bundle of parameters [`run_install`] needs. Grouped into a
+/// struct so the signature stays under the workspace's
+/// `clippy::too_many_arguments = "deny"` lint (CLAUDE.md: "never
+/// suppress this lint"). All fields are mandatory except
+/// `extra_path` (which is `None` in production and a tempdir-
+/// of-stubs in tests).
+pub struct InstallContext<'a> {
+    pub spec: &'a InstallSpec,
+    pub job_dir: &'a Path,
+    pub out_dir: &'a Path,
+    pub runner: &'a dyn CommandRunner,
+    pub extra_path: Option<&'a Path>,
+    /// Egress-proxy lifecycle. Started before the installer
+    /// spawns, stopped after. Plan 73 Followup B.2.x. Production
+    /// uses [`crate::proxy::ChildProxyLifecycle`]; tests use
+    /// [`crate::proxy::NoopProxyLifecycle`] or a fake.
+    pub proxy: &'a mut dyn ProxyLifecycle,
+}
+
+/// Public entry point. Run the install pipeline for the spec in
+/// `ctx`, writing the four sealed-volume artifacts (`content/`,
+/// SBOM, fetch log, CVE) into `ctx.out_dir` and the install
+/// report into `ctx.job_dir/result.json`. The runner spawns each
+/// subprocess; `extra_path` flows into the runner so tests can
+/// stub binaries.
 ///
 /// Splitting `out_dir` from `job_dir` keeps the host's mount
 /// layout honest: the host bind-mounts the (writable) sealed-
@@ -248,13 +291,26 @@ impl std::error::Error for InstallError {}
 /// Co-locating the sidecars in `/out` lets the host rename the
 /// whole directory into the deps cache in one syscall, without
 /// shuffling files across mount points.
-pub fn run_install(
-    spec: &InstallSpec,
-    job_dir: &Path,
-    out_dir: &Path,
-    runner: &dyn CommandRunner,
-    extra_path: Option<&Path>,
-) -> Result<InstallReport, InstallError> {
+///
+/// ## Egress allowlist (Plan 73 Followup B.2.x)
+///
+/// Before invoking the installer we start `ctx.proxy` (an HTTP
+/// CONNECT proxy that refuses anything outside ADR-047's four
+/// hostnames) and set `HTTP_PROXY` + `HTTPS_PROXY` on the
+/// installer's env to `http://127.0.0.1:8443`. After the
+/// installer exits — whether successfully or not — we tear the
+/// proxy down. SBOM + CVE sidecars run *without* the proxy env:
+/// they operate against on-disk content the installer already
+/// fetched, so they don't need network.
+pub fn run_install(ctx: InstallContext<'_>) -> Result<InstallReport, InstallError> {
+    let InstallContext {
+        spec,
+        job_dir,
+        out_dir,
+        runner,
+        extra_path,
+        proxy,
+    } = ctx;
     fs::create_dir_all(out_dir)
         .map_err(|e| InstallError::Io(format!("create {}: {e}", out_dir.display())))?;
     let content_dir = out_dir.join(CONTENT_SUBDIR);
@@ -280,16 +336,44 @@ pub fn run_install(
         });
     }
 
+    // Bring the egress proxy up before the installer. The
+    // installer dials `http://127.0.0.1:8443` for every fetch;
+    // it must be listening before `uv` / `pnpm` makes the first
+    // request. A proxy startup failure is a hard error — without
+    // the allowlist the install would bypass ADR-047's gate.
+    proxy
+        .start()
+        .map_err(|e| InstallError::Io(format!("egress proxy start: {e}")))?;
+
+    // Inject HTTP_PROXY + HTTPS_PROXY on the installer's env. Both
+    // are set so `uv` (HTTPS_PROXY-aware) and `npm`-style tools
+    // that occasionally consult HTTP_PROXY both route through us.
+    // The lowercase forms (`https_proxy` / `http_proxy`) are also
+    // honored by some installers — we set them for safety even
+    // though uv/pnpm don't strictly need them.
+    let env = [
+        ("HTTPS_PROXY", PROXY_URL),
+        ("HTTP_PROXY", PROXY_URL),
+        ("https_proxy", PROXY_URL),
+        ("http_proxy", PROXY_URL),
+    ];
+
     let installer_args = installer.args(&lockfile_in_vm, &content_dir);
     let installer_args_refs: Vec<&str> = installer_args.iter().map(|s| s.as_str()).collect();
-    let installer_exit_code = runner
-        .run(
-            installer.program,
-            &installer_args_refs,
-            Some(&fetch_log),
-            extra_path,
-        )
-        .map_err(InstallError::Io)?;
+    let installer_result = runner.run_with_env(
+        installer.program,
+        &installer_args_refs,
+        Some(&fetch_log),
+        extra_path,
+        &env,
+    );
+
+    // Tear the proxy down before propagating errors / running the
+    // sidecars. SBOM + CVE don't go through the proxy (no network),
+    // so leaving it up would only delay shutdown.
+    proxy.stop();
+
+    let installer_exit_code = installer_result.map_err(InstallError::Io)?;
 
     // Best-effort SBOM + CVE; the optional-gate fallback emits a
     // CycloneDX-1.5 empty stub if the tool isn't available. The
@@ -555,13 +639,15 @@ mod tests {
     }
 
     /// Record of every command the stub runner saw. Per-call entry
-    /// has the program name + arg list + whether log_path was set.
-    /// Tests assert the right sequence of invocations.
+    /// has the program name, arg list, whether log_path was set,
+    /// and the env vars injected. Tests assert the right sequence
+    /// of invocations and that the proxy env reached the installer.
     #[derive(Debug, Clone, PartialEq, Eq)]
     struct Invocation {
         program: String,
         args: Vec<String>,
         logged: bool,
+        env: Vec<(String, String)>,
     }
 
     struct StubRunner {
@@ -604,17 +690,22 @@ mod tests {
     }
 
     impl CommandRunner for StubRunner {
-        fn run(
+        fn run_with_env(
             &self,
             program: &str,
             args: &[&str],
             log_path: Option<&Path>,
             _extra_path: Option<&Path>,
+            env: &[(&str, &str)],
         ) -> Result<i32, String> {
             self.calls.lock().unwrap().borrow_mut().push(Invocation {
                 program: program.to_string(),
                 args: args.iter().map(|s| s.to_string()).collect(),
                 logged: log_path.is_some(),
+                env: env
+                    .iter()
+                    .map(|(k, v)| ((*k).to_string(), (*v).to_string()))
+                    .collect(),
             });
             // Make the side-effect of writing real output for SBOM
             // / CVE tools explicit — without it the test for
@@ -648,22 +739,98 @@ mod tests {
         }
     }
 
+    /// Test-only proxy lifecycle that records start / stop calls
+    /// so tests can assert the install pipeline starts the proxy
+    /// before the installer + stops it after. Used in addition to
+    /// `crate::proxy::NoopProxyLifecycle` because the noop version
+    /// doesn't capture call order — and the order is the whole
+    /// point of the integration test.
+    #[derive(Debug)]
+    struct FakeProxy {
+        events: Mutex<RefCell<Vec<&'static str>>>,
+        start_result: Result<(), String>,
+    }
+
+    impl FakeProxy {
+        fn ok() -> Self {
+            Self {
+                events: Mutex::new(RefCell::new(Vec::new())),
+                start_result: Ok(()),
+            }
+        }
+
+        fn failing(reason: &str) -> Self {
+            Self {
+                events: Mutex::new(RefCell::new(Vec::new())),
+                start_result: Err(reason.to_string()),
+            }
+        }
+
+        fn events(&self) -> Vec<&'static str> {
+            self.events.lock().unwrap().borrow().clone()
+        }
+    }
+
+    impl ProxyLifecycle for FakeProxy {
+        fn start(&mut self) -> Result<(), String> {
+            self.events.lock().unwrap().borrow_mut().push("start");
+            self.start_result.clone()
+        }
+
+        fn stop(&mut self) {
+            self.events.lock().unwrap().borrow_mut().push("stop");
+        }
+
+        fn is_running(&self) -> bool {
+            // Crude: we're "running" iff start was the last event.
+            self.events
+                .lock()
+                .unwrap()
+                .borrow()
+                .last()
+                .copied()
+                .unwrap_or("")
+                == "start"
+        }
+    }
+
+    /// Convenience: run_install against the stub runner + a fake
+    /// proxy, returning both the install report and the proxy's
+    /// observed start/stop events. Keeps test arms readable.
+    fn run_install_with_fakes(
+        spec: &InstallSpec,
+        job_dir: &Path,
+        out_dir: &Path,
+        runner: &dyn CommandRunner,
+    ) -> (Result<InstallReport, InstallError>, Vec<&'static str>) {
+        let mut proxy = FakeProxy::ok();
+        let ctx = InstallContext {
+            spec,
+            job_dir,
+            out_dir,
+            runner,
+            extra_path: None,
+            proxy: &mut proxy,
+        };
+        let report = run_install(ctx);
+        let events = proxy.events();
+        (report, events)
+    }
+
     #[test]
     fn python_happy_path_runs_uv_then_sidecars() {
         let tmp = tempfile::tempdir().unwrap();
         let runner = StubRunner::new(&["uv", "cyclonedx-py", "pip-audit"]);
-        let report = run_install(
-            &ok_spec(),
-            &tmp.path().join("job"),
-            tmp.path(),
-            &runner,
-            None,
-        )
-        .unwrap();
+        let (report, events) =
+            run_install_with_fakes(&ok_spec(), &tmp.path().join("job"), tmp.path(), &runner);
+        let report = report.unwrap();
         assert_eq!(report.installer_exit_code, 0);
         assert!(report.sbom_emitted);
         assert!(report.cve_emitted);
         assert!(report.content_path.ends_with("/content"));
+
+        // Proxy lifecycle: start before the installer, stop after.
+        assert_eq!(events, vec!["start", "stop"]);
 
         let calls = runner.calls();
         // First call: uv pip install --no-deps --requirements
@@ -674,9 +841,31 @@ mod tests {
         assert!(calls[0].args.contains(&"--no-deps".to_string()));
         assert!(calls[0].args.contains(&"/work/uv.lock".to_string()));
         assert!(calls[0].logged, "installer must tee to fetch.log");
+        // Plan 73 Followup B.2.x: HTTPS_PROXY + HTTP_PROXY env on
+        // the installer's invocation.
+        let env_keys: Vec<&str> = calls[0].env.iter().map(|(k, _)| k.as_str()).collect();
+        assert!(env_keys.contains(&"HTTPS_PROXY"), "env: {:?}", calls[0].env);
+        assert!(env_keys.contains(&"HTTP_PROXY"), "env: {:?}", calls[0].env);
+        let https = calls[0]
+            .env
+            .iter()
+            .find(|(k, _)| k == "HTTPS_PROXY")
+            .map(|(_, v)| v.as_str())
+            .unwrap();
+        assert_eq!(https, "http://127.0.0.1:8443");
 
-        // Subsequent: cyclonedx-py + pip-audit.
-        assert!(calls.iter().any(|c| c.program == "cyclonedx-py"));
+        // Subsequent: cyclonedx-py + pip-audit. Sidecars run
+        // *without* the proxy env (no network — they read on-disk
+        // content the installer fetched).
+        let sbom_call = calls
+            .iter()
+            .find(|c| c.program == "cyclonedx-py")
+            .expect("cyclonedx-py invoked");
+        assert!(
+            sbom_call.env.is_empty(),
+            "sidecars must not inherit proxy env: {:?}",
+            sbom_call.env
+        );
         assert!(calls.iter().any(|c| c.program == "pip-audit"));
 
         // Artifacts on disk.
@@ -696,14 +885,18 @@ mod tests {
             gate: GateLevel::Prod,
         };
         let runner = StubRunner::new(&["pnpm"]);
-        let report =
-            run_install(&spec, &tmp.path().join("job"), tmp.path(), &runner, None).unwrap();
+        let (report, events) =
+            run_install_with_fakes(&spec, &tmp.path().join("job"), tmp.path(), &runner);
+        let report = report.unwrap();
         assert_eq!(report.language, Language::Node);
         assert_eq!(report.gate, GateLevel::Prod);
+        assert_eq!(events, vec!["start", "stop"]);
         let calls = runner.calls();
         assert_eq!(calls[0].program, "pnpm");
         assert_eq!(calls[0].args[0], "install");
         assert!(calls[0].args.contains(&"--frozen-lockfile".to_string()));
+        // Node installer also gets proxy env.
+        assert!(calls[0].env.iter().any(|(k, _)| k == "HTTPS_PROXY"));
     }
 
     #[test]
@@ -711,18 +904,16 @@ mod tests {
         let tmp = tempfile::tempdir().unwrap();
         // "uv" absent → InstallerMissing.
         let runner = StubRunner::new(&["cyclonedx-py", "pip-audit"]);
-        let err = run_install(
-            &ok_spec(),
-            &tmp.path().join("job"),
-            tmp.path(),
-            &runner,
-            None,
-        )
-        .unwrap_err();
+        let (result, events) =
+            run_install_with_fakes(&ok_spec(), &tmp.path().join("job"), tmp.path(), &runner);
+        let err = result.unwrap_err();
         match err {
             InstallError::InstallerMissing { program } => assert_eq!(program, "uv"),
             other => panic!("wrong variant: {other:?}"),
         }
+        // Proxy is *not* started when the installer is missing —
+        // we bail before reaching the proxy.start() call.
+        assert!(events.is_empty(), "proxy must not run if installer absent");
     }
 
     #[test]
@@ -732,18 +923,17 @@ mod tests {
         // distinction from the missing-installer case.
         let tmp = tempfile::tempdir().unwrap();
         let runner = StubRunner::new(&["uv", "cyclonedx-py", "pip-audit"]).with_exit("uv", 1);
-        let report = run_install(
-            &ok_spec(),
-            &tmp.path().join("job"),
-            tmp.path(),
-            &runner,
-            None,
-        )
-        .unwrap();
+        let (report, events) =
+            run_install_with_fakes(&ok_spec(), &tmp.path().join("job"), tmp.path(), &runner);
+        let report = report.unwrap();
         assert_eq!(report.installer_exit_code, 1);
         // Sidecars still run — the SBOM / CVE captures empty
         // state for the partial install, which is informative.
         assert!(report.sbom_emitted);
+        // Proxy still goes through its lifecycle even on installer
+        // failure (we tear it down before propagating the error so
+        // we don't leak a listening port).
+        assert_eq!(events, vec!["start", "stop"]);
     }
 
     #[test]
@@ -751,14 +941,9 @@ mod tests {
         let tmp = tempfile::tempdir().unwrap();
         // No `cyclonedx-py`.
         let runner = StubRunner::new(&["uv", "pip-audit"]);
-        let report = run_install(
-            &ok_spec(),
-            &tmp.path().join("job"),
-            tmp.path(),
-            &runner,
-            None,
-        )
-        .unwrap();
+        let (report, _events) =
+            run_install_with_fakes(&ok_spec(), &tmp.path().join("job"), tmp.path(), &runner);
+        let report = report.unwrap();
         assert!(
             !report.sbom_emitted,
             "stub fallback marks sbom_emitted=false"
@@ -775,14 +960,9 @@ mod tests {
     fn missing_cve_tool_emits_stub() {
         let tmp = tempfile::tempdir().unwrap();
         let runner = StubRunner::new(&["uv", "cyclonedx-py"]);
-        let report = run_install(
-            &ok_spec(),
-            &tmp.path().join("job"),
-            tmp.path(),
-            &runner,
-            None,
-        )
-        .unwrap();
+        let (report, _events) =
+            run_install_with_fakes(&ok_spec(), &tmp.path().join("job"), tmp.path(), &runner);
+        let report = report.unwrap();
         assert!(!report.cve_emitted);
         let body = fs::read_to_string(tmp.path().join(CVE_FILENAME)).unwrap();
         let parsed: serde_json::Value = serde_json::from_str(&body).unwrap();
@@ -799,8 +979,9 @@ mod tests {
             gate: GateLevel::Dev,
         };
         let runner = StubRunner::new(&["pnpm"]);
-        let report =
-            run_install(&spec, &tmp.path().join("job"), tmp.path(), &runner, None).unwrap();
+        let (report, _events) =
+            run_install_with_fakes(&spec, &tmp.path().join("job"), tmp.path(), &runner);
+        let report = report.unwrap();
         assert!(report.sbom_emitted);
         assert!(report.cve_emitted);
         let calls = runner.calls();
@@ -825,23 +1006,11 @@ mod tests {
         // dispatch so a retry produces a fresh transcript.
         let tmp = tempfile::tempdir().unwrap();
         let runner = StubRunner::new(&["uv", "cyclonedx-py", "pip-audit"]);
-        let _ = run_install(
-            &ok_spec(),
-            &tmp.path().join("job"),
-            tmp.path(),
-            &runner,
-            None,
-        )
-        .unwrap();
+        let (_, _) =
+            run_install_with_fakes(&ok_spec(), &tmp.path().join("job"), tmp.path(), &runner);
         let first = fs::read_to_string(tmp.path().join(FETCH_LOG_FILENAME)).unwrap();
-        let _ = run_install(
-            &ok_spec(),
-            &tmp.path().join("job"),
-            tmp.path(),
-            &runner,
-            None,
-        )
-        .unwrap();
+        let (_, _) =
+            run_install_with_fakes(&ok_spec(), &tmp.path().join("job"), tmp.path(), &runner);
         let second = fs::read_to_string(tmp.path().join(FETCH_LOG_FILENAME)).unwrap();
         // Truncation means we don't see the first run's content
         // duplicated in the second.
@@ -851,6 +1020,62 @@ mod tests {
             first.matches(first_marker).count(),
             "log was not truncated between runs"
         );
+    }
+
+    /// Plan 73 Followup B.2.x: if the egress proxy can't be
+    /// started, the install fails *before* the installer runs.
+    /// Bypassing the proxy would violate ADR-047's allowlist
+    /// invariant — fail-closed is mandatory.
+    #[test]
+    fn proxy_start_failure_aborts_before_installer() {
+        let tmp = tempfile::tempdir().unwrap();
+        let runner = StubRunner::new(&["uv", "cyclonedx-py", "pip-audit"]);
+        let mut proxy = FakeProxy::failing("bind 127.0.0.1:8443: address in use");
+        let ctx = InstallContext {
+            spec: &ok_spec(),
+            job_dir: &tmp.path().join("job"),
+            out_dir: tmp.path(),
+            runner: &runner,
+            extra_path: None,
+            proxy: &mut proxy,
+        };
+        let err = run_install(ctx).unwrap_err();
+        match err {
+            InstallError::Io(msg) => {
+                assert!(msg.contains("egress proxy"), "msg: {msg}");
+                assert!(msg.contains("address in use"), "msg: {msg}");
+            }
+            other => panic!("wrong variant: {other:?}"),
+        }
+        // The installer never spawned — no uv invocation recorded.
+        let calls = runner.calls();
+        assert!(
+            !calls.iter().any(|c| c.program == "uv"),
+            "uv ran even though proxy failed: {calls:?}"
+        );
+    }
+
+    /// Plan 73 Followup B.2.x: the proxy env vars match the
+    /// `crate::proxy::PROXY_URL` constant. If someone changes
+    /// the URL on one side and forgets the other, this test
+    /// flags the drift.
+    #[test]
+    fn installer_env_uses_constant_proxy_url() {
+        use crate::proxy::PROXY_URL;
+        let tmp = tempfile::tempdir().unwrap();
+        let runner = StubRunner::new(&["uv", "cyclonedx-py", "pip-audit"]);
+        let (_, _) =
+            run_install_with_fakes(&ok_spec(), &tmp.path().join("job"), tmp.path(), &runner);
+        let calls = runner.calls();
+        let uv_call = calls.iter().find(|c| c.program == "uv").unwrap();
+        for key in ["HTTPS_PROXY", "HTTP_PROXY", "https_proxy", "http_proxy"] {
+            let v = uv_call
+                .env
+                .iter()
+                .find(|(k, _)| k == key)
+                .unwrap_or_else(|| panic!("missing env var {key} in {:?}", uv_call.env));
+            assert_eq!(v.1, PROXY_URL, "env {key} drift");
+        }
     }
 
     #[test]

--- a/crates/mvm-builder-init/src/main.rs
+++ b/crates/mvm-builder-init/src/main.rs
@@ -72,6 +72,8 @@ use std::process::ExitCode;
 mod install;
 #[allow(dead_code)]
 mod install_spec;
+#[allow(dead_code)]
+mod proxy;
 
 fn main() -> ExitCode {
     #[cfg(target_os = "linux")]
@@ -200,8 +202,11 @@ mod linux {
     /// via the *presence* of result.json. Anything that prevents
     /// us from writing result.json gets logged + falls through.
     fn run_install_job(spec_path: &str) {
-        use crate::install::{InstallError, RESULT_FILENAME, SystemCommandRunner, run_install};
+        use crate::install::{
+            InstallContext, InstallError, RESULT_FILENAME, SystemCommandRunner, run_install,
+        };
         use crate::install_spec::parse;
+        use crate::proxy::ChildProxyLifecycle;
 
         let bytes = match std::fs::read(spec_path) {
             Ok(b) => b,
@@ -221,8 +226,21 @@ mod linux {
         };
 
         let runner = SystemCommandRunner;
-        let report = match run_install(&spec, Path::new(JOB_DIR), Path::new(OUT_DIR), &runner, None)
-        {
+        // Plan 73 Followup B.2.x: the production proxy lifecycle
+        // spawns `mvm-egress-proxy` from PATH. The builder VM
+        // flake installs the binary at `/sbin/mvm-egress-proxy`
+        // (alongside `/sbin/mvm-builder-init`), which is on the
+        // kernel's default PATH for PID 1.
+        let mut proxy = ChildProxyLifecycle::default_binary();
+        let ctx = InstallContext {
+            spec: &spec,
+            job_dir: Path::new(JOB_DIR),
+            out_dir: Path::new(OUT_DIR),
+            runner: &runner,
+            extra_path: None,
+            proxy: &mut proxy,
+        };
+        let report = match run_install(ctx) {
             Ok(r) => r,
             Err(InstallError::InstallerMissing { program }) => {
                 eprintln!(

--- a/crates/mvm-builder-init/src/proxy.rs
+++ b/crates/mvm-builder-init/src/proxy.rs
@@ -1,0 +1,281 @@
+//! Egress-proxy lifecycle hook for the application-deps install
+//! pipeline (Plan 73 Followup B.2.x, ADR-047 §"Build-time gates"
+//! → "Registry allowlist").
+//!
+//! `mvm-builder-init` runs the installer (`uv` / `pnpm`) with
+//! `HTTP_PROXY` + `HTTPS_PROXY` pointing at `mvm-egress-proxy`,
+//! which sits between the installer and the network and refuses
+//! anything outside ADR-047's four-hostname allowlist.
+//!
+//! The proxy is a separate Linux binary
+//! (`crates/mvm-egress-proxy`); we drive it as a subprocess:
+//!
+//! 1. **Spawn** at install start — bind `127.0.0.1:8443`.
+//! 2. **Wait for ready** — TCP-connect-probe up to 2s.
+//! 3. **Inject env** into the installer's command: `HTTP_PROXY` +
+//!    `HTTPS_PROXY` set to `http://127.0.0.1:8443`. (`HTTPS_PROXY`
+//!    is what `uv`/`pip`/`pnpm` honor for HTTPS fetches; both keys
+//!    are set so any case-insensitive variant is covered.)
+//! 4. **Shutdown** after the installer exits — SIGTERM, wait up to
+//!    1s, then SIGKILL.
+//!
+//! The lifecycle abstraction is split into a [`ProxyLifecycle`]
+//! trait so unit tests can supply a noop / fake controller. The
+//! production implementation [`ChildProxyLifecycle`] shells out to
+//! `mvm-egress-proxy`; tests use [`NoopProxyLifecycle`] (does
+//! nothing) or [`FakeProxyLifecycle`] (records start/stop calls).
+//!
+//! ## Future B.2.y — complementary iptables drop-rule
+//!
+//! The proxy is currently the only enforcement mechanism. A future
+//! followup will add a defense-in-depth iptables rule that drops
+//! outbound traffic *not* originating from the proxy's UID, so a
+//! pathological installer that ignores `HTTPS_PROXY` can't slip
+//! around the allowlist. Tracked as B.2.y in plan 73.
+
+use std::net::{SocketAddr, TcpStream};
+use std::path::PathBuf;
+use std::process::{Child, Command, Stdio};
+use std::time::{Duration, Instant};
+
+/// Where the in-VM proxy listens. mvm-egress-proxy's
+/// `DEFAULT_BIND` constant; duplicated here so we don't pull the
+/// proxy crate into our dep closure just to share a string.
+pub const PROXY_BIND_ADDR: &str = "127.0.0.1:8443";
+
+/// Proxy URL the installer sees in `HTTP_PROXY` / `HTTPS_PROXY`.
+pub const PROXY_URL: &str = "http://127.0.0.1:8443";
+
+/// Lifecycle hook trait. The installer's pre/post-spawn dance
+/// goes through this so tests can verify the proxy was started +
+/// stopped without binding a real socket.
+pub trait ProxyLifecycle {
+    /// Start the proxy. Called before the installer spawns.
+    /// Returns `Ok(())` once the proxy is listening; the caller
+    /// then sets `HTTP_PROXY` / `HTTPS_PROXY` and spawns the
+    /// installer.
+    fn start(&mut self) -> Result<(), String>;
+
+    /// Stop the proxy. Called after the installer exits. Best-
+    /// effort — a failure here is logged but doesn't fail the
+    /// install (the volume artifacts are already on disk).
+    fn stop(&mut self);
+
+    /// Whether the lifecycle's start() succeeded. Used to decide
+    /// whether to inject `HTTPS_PROXY` env into the installer:
+    /// if the proxy didn't come up, the installer runs without
+    /// proxy env vars + the host treats the volume as compromised
+    /// via a separate gate. (Currently the proxy is hard-required;
+    /// future B.2.y may relax this for offline-only builds.)
+    fn is_running(&self) -> bool;
+}
+
+/// Production lifecycle — spawns `mvm-egress-proxy` as a child
+/// process. The binary's location defaults to `PATH` lookup; the
+/// builder VM flake (`nix/images/builder-vm/flake.nix`) installs
+/// it at `/sbin/mvm-egress-proxy` and prepends `/sbin` to PATH
+/// via the standard kernel default. Set `program` explicitly to
+/// override for tests / staging builds.
+pub struct ChildProxyLifecycle {
+    program: PathBuf,
+    child: Option<Child>,
+    started: bool,
+}
+
+impl ChildProxyLifecycle {
+    /// Construct a lifecycle that will spawn `program` (looked up
+    /// against PATH if relative) when [`Self::start`] is called.
+    pub fn new<P: Into<PathBuf>>(program: P) -> Self {
+        Self {
+            program: program.into(),
+            child: None,
+            started: false,
+        }
+    }
+
+    /// Convenience: lifecycle that spawns the default binary name
+    /// (`mvm-egress-proxy`), relying on PATH lookup.
+    pub fn default_binary() -> Self {
+        Self::new("mvm-egress-proxy")
+    }
+}
+
+impl ProxyLifecycle for ChildProxyLifecycle {
+    fn start(&mut self) -> Result<(), String> {
+        if self.started {
+            return Ok(());
+        }
+        let mut cmd = Command::new(&self.program);
+        // Inherit stderr so the proxy's ALLOW / DENY log lines
+        // land in the same console the host scrapes via libkrun's
+        // `krun_set_console_output`. stdout is discarded — the
+        // proxy prints one "listening on <addr>" line that's
+        // informational, not contractually consumed.
+        cmd.stdout(Stdio::null());
+        cmd.stderr(Stdio::inherit());
+        let child = cmd
+            .spawn()
+            .map_err(|e| format!("spawn `{}`: {e}", self.program.display()))?;
+        self.child = Some(child);
+
+        // TCP-probe loop: try to connect to PROXY_BIND_ADDR every
+        // 50ms up to 2s. The proxy binds the listener in its main
+        // thread before forking the accept loop; the first
+        // successful connect means it's accepting.
+        let target: SocketAddr = PROXY_BIND_ADDR
+            .parse()
+            .map_err(|e| format!("parse {PROXY_BIND_ADDR}: {e}"))?;
+        let deadline = Instant::now() + Duration::from_secs(2);
+        loop {
+            if Instant::now() >= deadline {
+                self.stop();
+                return Err(format!(
+                    "egress proxy did not become ready at {PROXY_BIND_ADDR} within 2s"
+                ));
+            }
+            // Check the child is still alive — early exit means
+            // the proxy crashed.
+            if let Some(child) = self.child.as_mut()
+                && let Ok(Some(status)) = child.try_wait()
+            {
+                return Err(format!(
+                    "egress proxy exited before becoming ready (status: {status})"
+                ));
+            }
+            if TcpStream::connect_timeout(&target, Duration::from_millis(200)).is_ok() {
+                self.started = true;
+                return Ok(());
+            }
+            std::thread::sleep(Duration::from_millis(50));
+        }
+    }
+
+    fn stop(&mut self) {
+        let Some(mut child) = self.child.take() else {
+            return;
+        };
+        // SIGTERM first — the proxy's main loop installs a SIGTERM
+        // handler that drops the listener and joins the accept
+        // thread cleanly.
+        #[cfg(target_os = "linux")]
+        {
+            // SAFETY: passing a valid pid to libc::kill. Failure
+            // is acceptable (the child may have already exited).
+            unsafe {
+                let _ = libc::kill(child.id() as libc::pid_t, libc::SIGTERM);
+            }
+        }
+        #[cfg(not(target_os = "linux"))]
+        {
+            // Non-Linux hosts only see this code path in test
+            // builds (the production caller is the libkrun builder
+            // VM, which is Linux). `Child::kill()` sends SIGKILL
+            // on Unix and `TerminateProcess` on Windows; both are
+            // acceptable for the test paths (no graceful-shutdown
+            // contract under test). The deadline loop below then
+            // observes the exit immediately.
+            let _ = child.kill();
+        }
+
+        // Wait up to 1s for graceful exit.
+        let deadline = Instant::now() + Duration::from_secs(1);
+        loop {
+            match child.try_wait() {
+                Ok(Some(_)) => {
+                    self.started = false;
+                    return;
+                }
+                Ok(None) => {
+                    if Instant::now() >= deadline {
+                        break;
+                    }
+                    std::thread::sleep(Duration::from_millis(50));
+                }
+                Err(e) => {
+                    eprintln!("mvm-builder-init: proxy try_wait failed: {e}");
+                    break;
+                }
+            }
+        }
+
+        // SIGKILL fallback.
+        eprintln!("mvm-builder-init: egress proxy did not exit on SIGTERM, sending SIGKILL");
+        let _ = child.kill();
+        let _ = child.wait();
+        self.started = false;
+    }
+
+    fn is_running(&self) -> bool {
+        self.started
+    }
+}
+
+impl Drop for ChildProxyLifecycle {
+    fn drop(&mut self) {
+        // Belt-and-braces: if the caller forgot to call stop()
+        // before the controller drops, kill the child here so we
+        // don't leave a zombie proxy listening on 8443.
+        self.stop();
+    }
+}
+
+/// Test-only lifecycle that does nothing. Used by tests that
+/// exercise the install pipeline without caring about the proxy
+/// side. The installer's env vars are still injected (B.2's
+/// install-pipeline tests assert that) but no real socket is
+/// bound.
+pub struct NoopProxyLifecycle {
+    started: bool,
+}
+
+impl NoopProxyLifecycle {
+    pub fn new() -> Self {
+        Self { started: false }
+    }
+}
+
+impl Default for NoopProxyLifecycle {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl ProxyLifecycle for NoopProxyLifecycle {
+    fn start(&mut self) -> Result<(), String> {
+        self.started = true;
+        Ok(())
+    }
+
+    fn stop(&mut self) {
+        self.started = false;
+    }
+
+    fn is_running(&self) -> bool {
+        self.started
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn proxy_url_is_http_127_8443() {
+        // Lock the contract — installers honor HTTPS_PROXY env
+        // pointing at an HTTP URL (CONNECT tunneling). 127.0.0.1
+        // because the proxy + installer share the VM's network
+        // namespace.
+        assert_eq!(PROXY_URL, "http://127.0.0.1:8443");
+        assert_eq!(PROXY_BIND_ADDR, "127.0.0.1:8443");
+    }
+
+    #[test]
+    fn noop_lifecycle_tracks_started_state() {
+        let mut p = NoopProxyLifecycle::new();
+        assert!(!p.is_running());
+        p.start().unwrap();
+        assert!(p.is_running());
+        p.stop();
+        assert!(!p.is_running());
+    }
+}

--- a/crates/mvm-egress-proxy/Cargo.toml
+++ b/crates/mvm-egress-proxy/Cargo.toml
@@ -1,0 +1,50 @@
+[package]
+name = "mvm-egress-proxy"
+version.workspace = true
+edition.workspace = true
+description = "HTTP CONNECT proxy with hostname allowlist for builder-VM egress (Plan 73 Followup B.2.x, ADR-047)"
+license.workspace = true
+repository.workspace = true
+homepage.workspace = true
+authors.workspace = true
+
+# This is a Linux-only binary in production — it runs inside the
+# libkrun builder VM as the only legal egress path during the
+# application-deps install. On macOS / Windows the binary still
+# compiles (workspace ergonomics for contributors) but `main()`
+# prints a hint and exits 1, mirroring `mvm-builder-init`. The
+# allowlist + CONNECT-parser modules are pure-Rust and cross-
+# platform so `cargo test` exercises them on every developer host.
+#
+# No tokio: a CONNECT proxy is one thread per accepted socket
+# (`std::net::TcpListener` + `std::thread::spawn`), so we save
+# the ~3 MiB closure tokio drags in. mvm-builder-init's size
+# budget cares about the init binary, not this one — but keeping
+# the proxy slim too means a `nix build` of the builder VM
+# rootfs doesn't balloon either.
+
+[[bin]]
+name = "mvm-egress-proxy"
+path = "src/main.rs"
+
+[lib]
+name = "mvm_egress_proxy"
+path = "src/lib.rs"
+
+[features]
+# Off by default. Tests + dev workflows enable it to point the
+# proxy at a test allowlist via `MVM_EGRESS_ALLOWLIST=host1,host2`.
+# Production binaries (built without features) ship the four
+# ADR-047 hostnames hard-coded — no env-var override at all.
+dev-shell = []
+
+[target.'cfg(target_os = "linux")'.dependencies]
+# Signal handling for SIGTERM-driven shutdown. Linux-only because
+# the binary's main loop only compiles on Linux.
+libc.workspace = true
+
+[lints]
+workspace = true
+
+[dev-dependencies]
+tempfile.workspace = true

--- a/crates/mvm-egress-proxy/src/allowlist.rs
+++ b/crates/mvm-egress-proxy/src/allowlist.rs
@@ -1,0 +1,228 @@
+//! Hostname + port allowlist for the builder-VM egress proxy
+//! (Plan 73 Followup B.2.x, ADR-047 §"Build-time gates" → "Registry
+//! allowlist").
+//!
+//! ADR-047 names four hostnames the builder VM is allowed to dial
+//! during `uv pip install` / `pnpm install`:
+//!
+//! - `pypi.org` — the Python package index API.
+//! - `files.pythonhosted.org` — pypi's CDN for the actual sdists +
+//!   wheels.
+//! - `registry.npmjs.org` — the npm metadata + tarball registry.
+//! - `objects.githubusercontent.com` — GitHub's release-asset CDN,
+//!   reachable as a transitive fetch when a Python lockfile pins a
+//!   git-based dep.
+//!
+//! Everything else fails closed: the proxy returns HTTP 403 and
+//! tears the socket down without ever establishing a tunnel.
+//!
+//! ## Port policy
+//!
+//! Only port 443 is allowed. The four allowlisted hostnames serve
+//! HTTPS exclusively; an installer that asks for port 80 / 21 /
+//! 22 against any of them is either misconfigured or attempting a
+//! protocol downgrade. Rejecting non-443 surfaces that loudly
+//! rather than letting the connection through and discovering
+//! the protocol error inside the TLS / pip layer.
+//!
+//! Future extension: when ADR-047 grows registry-mirror support,
+//! the allowlist will move from hard-coded to manifest-driven.
+//! Today's closed list mirrors the ADR's call exactly.
+//!
+//! ## Hostname matching
+//!
+//! Exact match only. No wildcards in v1 — `pypi.org` does NOT
+//! cover `pkg.pypi.org`, `*.pythonhosted.org` does NOT cover
+//! `mirror.pythonhosted.org`. ADR-047 lists exactly four; we
+//! enforce exactly four. A future "subdomain wildcard" extension
+//! requires an ADR revision.
+//!
+//! Comparison is case-insensitive (DNS is case-insensitive per
+//! RFC 4343); we lowercase the candidate before comparing to the
+//! lowercase static list.
+
+/// The four ADR-047 hostnames, lowercased. Order doesn't matter;
+/// the matcher walks the slice with `.iter().any()`.
+pub const PRODUCTION_HOSTNAMES: &[&str] = &[
+    "pypi.org",
+    "files.pythonhosted.org",
+    "registry.npmjs.org",
+    "objects.githubusercontent.com",
+];
+
+/// Only port the proxy permits. ADR-047 §"Registry allowlist"
+/// implies HTTPS-only. See module docs for the rationale on
+/// rejecting other ports.
+pub const ALLOWED_PORT: u16 = 443;
+
+/// Compiled allowlist. Owns its hostnames so a runtime override
+/// (gated behind `dev-shell` in `main.rs`) can supply a different
+/// list per-test without mutating a global.
+#[derive(Debug, Clone)]
+pub struct Allowlist {
+    hosts: Vec<String>,
+    port: u16,
+}
+
+impl Allowlist {
+    /// Build the production allowlist — the four ADR-047
+    /// hostnames + port 443. This is what `main.rs` constructs
+    /// when the `dev-shell` feature is **off** (i.e., the binary
+    /// shipped inside the builder VM). No env-var override; the
+    /// allowlist is baked into the binary.
+    pub fn production() -> Self {
+        Self {
+            hosts: PRODUCTION_HOSTNAMES.iter().map(|s| s.to_string()).collect(),
+            port: ALLOWED_PORT,
+        }
+    }
+
+    /// Build a custom allowlist from `hosts` + `port`. Intended
+    /// only for tests (the `dev-shell` feature in `main.rs` reads
+    /// `MVM_EGRESS_ALLOWLIST` and feeds it through here).
+    ///
+    /// Empty `hosts` returns an allowlist that refuses everything;
+    /// useful as a smoke test that the matcher fails-closed when
+    /// the override is unset.
+    pub fn from_parts(hosts: Vec<String>, port: u16) -> Self {
+        Self {
+            hosts: hosts.into_iter().map(|h| h.to_lowercase()).collect(),
+            port,
+        }
+    }
+
+    /// Returns `true` iff `host:port` is on the allowlist. `host`
+    /// is matched case-insensitively against the stored hostnames.
+    /// `port` must equal the allowlist's `port` exactly.
+    pub fn is_allowed(&self, host: &str, port: u16) -> bool {
+        if port != self.port {
+            return false;
+        }
+        let candidate = host.to_lowercase();
+        self.hosts.iter().any(|h| h == &candidate)
+    }
+
+    /// Test helper: returns the configured port. Production code
+    /// doesn't need this; it lets tests assert the port boundary
+    /// without reaching into the struct.
+    pub fn port(&self) -> u16 {
+        self.port
+    }
+
+    /// Test helper: returns the list of allowed hostnames in
+    /// insertion order.
+    pub fn hostnames(&self) -> &[String] {
+        &self.hosts
+    }
+}
+
+impl Default for Allowlist {
+    fn default() -> Self {
+        Self::production()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn production_allowlist_contains_four_adr_047_hostnames() {
+        let a = Allowlist::production();
+        assert_eq!(a.hostnames().len(), 4, "ADR-047 names exactly four");
+        assert!(a.is_allowed("pypi.org", 443));
+        assert!(a.is_allowed("files.pythonhosted.org", 443));
+        assert!(a.is_allowed("registry.npmjs.org", 443));
+        assert!(a.is_allowed("objects.githubusercontent.com", 443));
+    }
+
+    #[test]
+    fn production_allowlist_rejects_evil_example_com() {
+        let a = Allowlist::production();
+        assert!(!a.is_allowed("evil.example.com", 443));
+    }
+
+    #[test]
+    fn production_allowlist_rejects_typosquat_subdomain() {
+        // No wildcard match — `pypi.org.evil.com` must not slip
+        // through a sloppy `ends_with` check.
+        let a = Allowlist::production();
+        assert!(!a.is_allowed("pypi.org.evil.com", 443));
+        assert!(!a.is_allowed("evil.com.pypi.org", 443));
+    }
+
+    #[test]
+    fn production_allowlist_rejects_subdomain_of_allowed_host() {
+        // Exact match only — `mirror.pypi.org` is NOT covered by
+        // `pypi.org`. ADR-047 wants the closed list; future
+        // wildcards need an ADR amendment.
+        let a = Allowlist::production();
+        assert!(!a.is_allowed("mirror.pypi.org", 443));
+        assert!(!a.is_allowed("foo.files.pythonhosted.org", 443));
+    }
+
+    #[test]
+    fn production_allowlist_rejects_non_443_port() {
+        // HTTPS-only. Port 80 (HTTP), 21 (FTP), 22 (SSH) all
+        // refused — even against an allowed hostname.
+        let a = Allowlist::production();
+        assert!(!a.is_allowed("pypi.org", 80));
+        assert!(!a.is_allowed("pypi.org", 21));
+        assert!(!a.is_allowed("pypi.org", 22));
+        assert!(!a.is_allowed("pypi.org", 8443));
+    }
+
+    #[test]
+    fn allowlist_match_is_case_insensitive() {
+        // DNS is case-insensitive per RFC 4343 — uppercase host
+        // in a CONNECT line still matches the lowercase allowlist.
+        let a = Allowlist::production();
+        assert!(a.is_allowed("PYPI.ORG", 443));
+        assert!(a.is_allowed("PyPI.Org", 443));
+        assert!(a.is_allowed("Registry.NPMjs.Org", 443));
+    }
+
+    #[test]
+    fn empty_allowlist_refuses_everything() {
+        let a = Allowlist::from_parts(vec![], 443);
+        assert!(!a.is_allowed("pypi.org", 443));
+        assert!(!a.is_allowed("anything.example.com", 443));
+    }
+
+    #[test]
+    fn custom_allowlist_with_one_host() {
+        let a = Allowlist::from_parts(vec!["example.org".to_string()], 443);
+        assert!(a.is_allowed("example.org", 443));
+        assert!(!a.is_allowed("pypi.org", 443));
+        // Production hostnames aren't implicitly merged in.
+        assert_eq!(a.hostnames(), &["example.org".to_string()]);
+    }
+
+    #[test]
+    fn custom_allowlist_lowercases_input_hostnames() {
+        // from_parts() canonicalizes — a hand-built allowlist
+        // with uppercase entries still matches uppercase inputs.
+        let a = Allowlist::from_parts(vec!["Example.Org".to_string()], 443);
+        assert!(a.is_allowed("example.org", 443));
+        assert!(a.is_allowed("EXAMPLE.ORG", 443));
+    }
+
+    #[test]
+    fn allowed_port_constant_is_443() {
+        // Lock the contract: ADR-047 implies HTTPS-only via the
+        // "Registry allowlist" wording. If a future ADR opens
+        // port 80 we want this test to flag the constant change
+        // explicitly.
+        assert_eq!(ALLOWED_PORT, 443);
+        assert_eq!(Allowlist::production().port(), 443);
+    }
+
+    #[test]
+    fn empty_hostname_is_rejected() {
+        // Defensive: an empty Host: header / SNI shouldn't
+        // accidentally match an empty entry. Production
+        // hostnames are non-empty by construction.
+        let a = Allowlist::production();
+        assert!(!a.is_allowed("", 443));
+    }
+}

--- a/crates/mvm-egress-proxy/src/lib.rs
+++ b/crates/mvm-egress-proxy/src/lib.rs
@@ -1,0 +1,20 @@
+//! mvm-egress-proxy — builder VM egress allowlist proxy
+//! (Plan 73 Followup B.2.x, ADR-047 §"Build-time gates" →
+//! "Registry allowlist").
+//!
+//! Library crate exposing the [`allowlist`] + [`proxy`] modules so
+//! unit tests and downstream callers can drive the proxy without
+//! shelling out to the binary. The binary at `src/main.rs` is a
+//! thin wrapper that constructs an [`allowlist::Allowlist`],
+//! binds the proxy with [`proxy::start`], and waits for SIGTERM.
+//!
+//! See `crates/mvm-builder-init/src/install.rs` for the consumer:
+//! `run_install` spawns the proxy + sets `HTTPS_PROXY` /
+//! `HTTP_PROXY` on the installer's env before invoking `uv` /
+//! `pnpm`.
+
+pub mod allowlist;
+pub mod proxy;
+
+pub use allowlist::{ALLOWED_PORT, Allowlist, PRODUCTION_HOSTNAMES};
+pub use proxy::{DEFAULT_BIND, ProxyHandle, parse_connect_target, start};

--- a/crates/mvm-egress-proxy/src/main.rs
+++ b/crates/mvm-egress-proxy/src/main.rs
@@ -1,0 +1,162 @@
+//! mvm-egress-proxy — Linux-only binary that fronts the builder
+//! VM's application-deps install with an HTTP CONNECT proxy.
+//!
+//! Plan 73 Followup B.2.x. The binary:
+//!
+//! 1. Builds an [`Allowlist`] (production hostnames by default;
+//!    `MVM_EGRESS_ALLOWLIST` env-var override gated behind the
+//!    `dev-shell` Cargo feature for tests).
+//! 2. Binds the proxy at [`mvm_egress_proxy::DEFAULT_BIND`] (or
+//!    `MVM_EGRESS_BIND` if set — gated the same way for tests).
+//! 3. Prints `mvm-egress-proxy: listening on <addr>` to stdout so
+//!    the parent (mvm-builder-init) can scrape the addr if it
+//!    needs to confirm.
+//! 4. Waits for SIGTERM / SIGINT.
+//!
+//! On non-Linux hosts the binary still compiles (for workspace
+//! ergonomics) but prints a hint + exits 1. The production caller
+//! cross-compiles for `<arch>-unknown-linux-musl` from the
+//! builder VM flake (`nix/images/builder-vm/flake.nix`).
+
+use std::process::ExitCode;
+
+fn main() -> ExitCode {
+    #[cfg(target_os = "linux")]
+    {
+        linux::run()
+    }
+
+    #[cfg(not(target_os = "linux"))]
+    {
+        eprintln!(
+            "mvm-egress-proxy is Linux-only (in-VM egress allowlist proxy \
+             for the libkrun builder VM). On a developer host this binary \
+             is a no-op; the production binary is cross-compiled to \
+             <arch>-unknown-linux-musl via nix/images/builder-vm/flake.nix. \
+             See specs/plans/73-sdk-port-followups.md §B.2.x."
+        );
+        ExitCode::FAILURE
+    }
+}
+
+#[cfg(target_os = "linux")]
+mod linux {
+    use std::process::ExitCode;
+    use std::sync::Arc;
+    use std::sync::atomic::{AtomicBool, Ordering};
+    use std::time::Duration;
+
+    use mvm_egress_proxy::{Allowlist, DEFAULT_BIND, start};
+
+    pub fn run() -> ExitCode {
+        let allowlist = build_allowlist();
+        let bind_addr = resolve_bind_addr();
+
+        let handle = match start(&bind_addr, allowlist) {
+            Ok(h) => h,
+            Err(e) => {
+                eprintln!("mvm-egress-proxy: failed to bind {bind_addr}: {e}");
+                return ExitCode::FAILURE;
+            }
+        };
+        println!("mvm-egress-proxy: listening on {}", handle.local_addr);
+
+        // Park until SIGTERM / SIGINT. mvm-builder-init signals
+        // SIGTERM after the installer exits; we shut the listener
+        // down cleanly and join the accept thread before exiting.
+        let stop = Arc::new(AtomicBool::new(false));
+        install_signal_handlers(Arc::clone(&stop));
+        while !stop.load(Ordering::SeqCst) {
+            std::thread::sleep(Duration::from_millis(100));
+        }
+
+        eprintln!("mvm-egress-proxy: shutting down");
+        // Drop runs ProxyHandle::shutdown which joins the accept
+        // thread. Explicit for readability.
+        drop(handle);
+        ExitCode::SUCCESS
+    }
+
+    /// Resolve the allowlist. Production: the hard-coded ADR-047
+    /// hostnames. Dev-shell feature: optional
+    /// `MVM_EGRESS_ALLOWLIST=host1,host2,host3` override + optional
+    /// `MVM_EGRESS_ALLOWLIST_PORT=443` override.
+    fn build_allowlist() -> Allowlist {
+        #[cfg(feature = "dev-shell")]
+        {
+            if let Ok(raw) = std::env::var("MVM_EGRESS_ALLOWLIST") {
+                let hosts: Vec<String> = raw
+                    .split(',')
+                    .map(|s| s.trim().to_string())
+                    .filter(|s| !s.is_empty())
+                    .collect();
+                let port = std::env::var("MVM_EGRESS_ALLOWLIST_PORT")
+                    .ok()
+                    .and_then(|s| s.parse::<u16>().ok())
+                    .unwrap_or(mvm_egress_proxy::ALLOWED_PORT);
+                eprintln!(
+                    "mvm-egress-proxy: dev-shell feature on — allowlist override `{raw}` :{port}"
+                );
+                return Allowlist::from_parts(hosts, port);
+            }
+        }
+        Allowlist::production()
+    }
+
+    fn resolve_bind_addr() -> String {
+        #[cfg(feature = "dev-shell")]
+        {
+            if let Ok(b) = std::env::var("MVM_EGRESS_BIND") {
+                return b;
+            }
+        }
+        DEFAULT_BIND.to_string()
+    }
+
+    /// Install SIGINT + SIGTERM handlers that flip `stop` so the
+    /// main loop exits. Best-effort: if `signal_hook`-style setup
+    /// fails we fall back to a no-op handler — the proxy then
+    /// only exits on kill -9, which mvm-builder-init does as the
+    /// SIGTERM fallback anyway.
+    fn install_signal_handlers(stop: Arc<AtomicBool>) {
+        // SAFETY: setting a signal handler is unsafe because the
+        // handler runs in async-signal context; we only flip an
+        // atomic, which is async-signal-safe.
+        unsafe {
+            libc_sigaction(libc::SIGTERM, &stop);
+            libc_sigaction(libc::SIGINT, &stop);
+        }
+    }
+
+    /// Bridge to libc::sigaction with a context-carrying handler.
+    /// Stored as a static so the C-callable handler can find it.
+    static STOP_FLAG: std::sync::OnceLock<Arc<AtomicBool>> = std::sync::OnceLock::new();
+
+    extern "C" fn signal_handler(_sig: libc::c_int) {
+        if let Some(flag) = STOP_FLAG.get() {
+            flag.store(true, Ordering::SeqCst);
+        }
+    }
+
+    /// # Safety
+    ///
+    /// Caller must ensure `stop` outlives the process or the
+    /// handler is replaced before drop. We satisfy this by storing
+    /// the Arc in a static OnceLock.
+    unsafe fn libc_sigaction(sig: libc::c_int, stop: &Arc<AtomicBool>) {
+        let _ = STOP_FLAG.set(Arc::clone(stop));
+        let mut sa: libc::sigaction = unsafe { std::mem::zeroed() };
+        sa.sa_sigaction = signal_handler as usize;
+        unsafe { libc::sigaction(sig, &sa, std::ptr::null_mut()) };
+    }
+}
+
+#[cfg(all(target_os = "linux", test))]
+mod tests {
+    // The library tests in `proxy.rs` cover the proxy lifecycle
+    // end-to-end. The binary's `main()` is a thin wrapper around
+    // `mvm_egress_proxy::start` + a signal-driven park loop; the
+    // signal path is exercised by mvm-builder-init's integration
+    // test (`install::tests::proxy_lifecycle_wraps_installer`).
+    // No standalone binary test fixture lives here.
+}

--- a/crates/mvm-egress-proxy/src/proxy.rs
+++ b/crates/mvm-egress-proxy/src/proxy.rs
@@ -1,0 +1,543 @@
+//! HTTP CONNECT proxy with hostname allowlist (Plan 73 Followup
+//! B.2.x, ADR-047).
+//!
+//! ## Why explicit-proxy CONNECT
+//!
+//! `pip`, `uv`, `pnpm`, and `npm` all honor `HTTPS_PROXY` /
+//! `HTTP_PROXY` environment variables and, when set, route HTTPS
+//! requests through the proxy via the standard HTTP CONNECT
+//! method (RFC 7231 §4.3.6). Setting `HTTPS_PROXY=http://127.0.0.1:8443`
+//! in the installer's env means every package fetch issues a
+//! `CONNECT host:port HTTP/1.1` to us before TLS starts.
+//!
+//! We parse the host:port out of the CONNECT line, check it
+//! against the allowlist, and either:
+//!
+//! - **Allowed**: open a TCP connection to the upstream, respond
+//!   `HTTP/1.1 200 Connection Established\r\n\r\n` to the client,
+//!   and shuttle bytes both ways. TLS handshakes between client +
+//!   upstream pass through transparently. We never see plaintext.
+//! - **Denied**: respond `HTTP/1.1 403 Forbidden\r\n...` and close
+//!   the connection. The installer surfaces the 403 as a fetch
+//!   error; the negative path is observable in the fetch log.
+//!
+//! ## Threading model
+//!
+//! One thread per accepted socket. The proxy is bounded by the
+//! installer's concurrency (`uv`'s default is 8 parallel fetches),
+//! so the thread count never explodes. No tokio dep — std::net +
+//! std::thread keeps the crate's closure tiny.
+//!
+//! ## Idle / runaway protection
+//!
+//! Each accepted socket gets a hard read timeout on the CONNECT
+//! handshake (5s). After the tunnel is established, the bytewise
+//! copy uses no timeout — the installer's own request timeout
+//! gates how long a tunnel stays open. Worst case: a slow upstream
+//! holds a thread open for the installer's timeout (~30s default).
+
+use std::io::{self, BufRead, BufReader, Read, Write};
+use std::net::{TcpListener, TcpStream};
+use std::sync::Arc;
+use std::sync::atomic::{AtomicBool, Ordering};
+use std::time::Duration;
+
+use crate::allowlist::Allowlist;
+
+/// Default address the proxy listens on inside the builder VM.
+/// 127.0.0.1 only — the installer runs on the same network
+/// namespace and dials localhost; the proxy doesn't need to be
+/// reachable from outside the VM.
+pub const DEFAULT_BIND: &str = "127.0.0.1:8443";
+
+/// Max bytes we read into the CONNECT request line buffer before
+/// giving up. RFC 7230 §3.1.1 caps request-line length at
+/// implementation-defined; 8 KiB is generous for `CONNECT
+/// <very.long.hostname>:443 HTTP/1.1`.
+const MAX_REQUEST_LINE_LEN: usize = 8 * 1024;
+
+/// Read timeout on the CONNECT handshake. After we send the
+/// response, the per-direction copies run untimed — the
+/// installer's request timeout is the upper bound.
+const HANDSHAKE_TIMEOUT: Duration = Duration::from_secs(5);
+
+/// Connect timeout when we dial the upstream on behalf of an
+/// allowed CONNECT. Keeps us from hanging a thread on a slow
+/// DNS or unreachable destination.
+const UPSTREAM_CONNECT_TIMEOUT: Duration = Duration::from_secs(10);
+
+/// Run-handle for a listening proxy. Holds the listener thread's
+/// `JoinHandle` and a shutdown flag the binding thread flips to
+/// stop accepting new connections.
+pub struct ProxyHandle {
+    pub local_addr: std::net::SocketAddr,
+    shutdown: Arc<AtomicBool>,
+    join: Option<std::thread::JoinHandle<()>>,
+}
+
+impl ProxyHandle {
+    /// Signal the listener thread to stop accepting + wait for it
+    /// to exit. Idempotent — calling twice is a no-op. Called from
+    /// `Drop` if the caller forgot to invoke it.
+    pub fn shutdown(&mut self) {
+        if self.shutdown.swap(true, Ordering::SeqCst) {
+            return;
+        }
+        // Poke the listener with a self-connect to unblock the
+        // accept(). Best-effort; if it fails we still wait on the
+        // join and rely on the SO_REUSEADDR + the OS to tear the
+        // socket down.
+        let _ = TcpStream::connect_timeout(&self.local_addr, Duration::from_millis(200));
+        if let Some(join) = self.join.take() {
+            let _ = join.join();
+        }
+    }
+}
+
+impl Drop for ProxyHandle {
+    fn drop(&mut self) {
+        self.shutdown();
+    }
+}
+
+/// Bind a proxy to `bind_addr` (e.g. `"127.0.0.1:8443"` or
+/// `"127.0.0.1:0"` for a kernel-assigned port). Spawns a listener
+/// thread that accepts connections, parses CONNECT lines, and
+/// either tunnels (allowed) or refuses (denied). Returns a handle
+/// the caller drops or explicitly shuts down.
+///
+/// The allowlist is moved in by `Arc`-wrap so the listener thread
+/// and each per-connection thread share one immutable reference.
+/// The listener never mutates it.
+pub fn start(bind_addr: &str, allowlist: Allowlist) -> io::Result<ProxyHandle> {
+    let listener = TcpListener::bind(bind_addr)?;
+    listener.set_nonblocking(false)?;
+    let local_addr = listener.local_addr()?;
+    let shutdown = Arc::new(AtomicBool::new(false));
+    let allowlist = Arc::new(allowlist);
+
+    let shutdown_for_thread = Arc::clone(&shutdown);
+    let allowlist_for_thread = Arc::clone(&allowlist);
+
+    let join = std::thread::Builder::new()
+        .name("mvm-egress-proxy-accept".into())
+        .spawn(move || {
+            for incoming in listener.incoming() {
+                if shutdown_for_thread.load(Ordering::SeqCst) {
+                    break;
+                }
+                let stream = match incoming {
+                    Ok(s) => s,
+                    Err(e) => {
+                        eprintln!("mvm-egress-proxy: accept failed: {e}");
+                        continue;
+                    }
+                };
+                let allowlist = Arc::clone(&allowlist_for_thread);
+                std::thread::Builder::new()
+                    .name("mvm-egress-proxy-conn".into())
+                    .spawn(move || {
+                        if let Err(e) = handle_connection(stream, &allowlist) {
+                            eprintln!("mvm-egress-proxy: connection ended: {e}");
+                        }
+                    })
+                    .ok();
+            }
+        })?;
+
+    Ok(ProxyHandle {
+        local_addr,
+        shutdown,
+        join: Some(join),
+    })
+}
+
+/// Per-connection handler: parse CONNECT, decide allow/deny, and
+/// either tunnel or refuse.
+fn handle_connection(mut client: TcpStream, allowlist: &Allowlist) -> io::Result<()> {
+    client.set_read_timeout(Some(HANDSHAKE_TIMEOUT))?;
+    client.set_write_timeout(Some(HANDSHAKE_TIMEOUT))?;
+
+    let request = match read_request_head(&mut client) {
+        Ok(r) => r,
+        Err(e) => {
+            // Best-effort 400 — the client violated HTTP/1.1
+            // before we could even parse host:port.
+            let _ = client.write_all(
+                b"HTTP/1.1 400 Bad Request\r\nContent-Length: 0\r\nConnection: close\r\n\r\n",
+            );
+            return Err(e);
+        }
+    };
+
+    let (host, port) = match parse_connect_target(&request) {
+        Ok(target) => target,
+        Err(e) => {
+            let _ = client.write_all(
+                b"HTTP/1.1 400 Bad Request\r\nContent-Length: 0\r\nConnection: close\r\n\r\n",
+            );
+            return Err(io::Error::other(e));
+        }
+    };
+
+    if !allowlist.is_allowed(&host, port) {
+        eprintln!("mvm-egress-proxy: DENY {host}:{port}");
+        let body =
+            format!("denied by mvm-egress-proxy: {host}:{port} not on the ADR-047 allowlist");
+        let response = format!(
+            "HTTP/1.1 403 Forbidden\r\nContent-Length: {len}\r\nConnection: close\r\nContent-Type: text/plain\r\n\r\n{body}",
+            len = body.len(),
+        );
+        let _ = client.write_all(response.as_bytes());
+        return Ok(());
+    }
+
+    eprintln!("mvm-egress-proxy: ALLOW {host}:{port}");
+
+    // Resolve + dial upstream. We use ToSocketAddrs lookup; the
+    // builder VM's libkrun-provided DNS resolves the four ADR-047
+    // hostnames to their public IPs. Failure here is reported as
+    // 502 Bad Gateway so the client can distinguish "allowlist
+    // refused" (403) from "we tried and the upstream is down"
+    // (502).
+    let target = format!("{host}:{port}");
+    let upstream = match TcpStream::connect_timeout(
+        &match target.parse::<std::net::SocketAddr>() {
+            Ok(addr) => addr,
+            Err(_) => {
+                // Hostname literal — fall back to the resolver
+                // path. std doesn't expose connect_timeout for
+                // ToSocketAddrs; use connect() and let the OS
+                // resolver handle DNS.
+                match TcpStream::connect(&target) {
+                    Ok(s) => {
+                        client.write_all(b"HTTP/1.1 200 Connection Established\r\n\r\n")?;
+                        return tunnel(client, s);
+                    }
+                    Err(e) => {
+                        eprintln!("mvm-egress-proxy: upstream dial {target} failed: {e}");
+                        let _ = client.write_all(
+                            b"HTTP/1.1 502 Bad Gateway\r\nContent-Length: 0\r\nConnection: close\r\n\r\n",
+                        );
+                        return Err(e);
+                    }
+                }
+            }
+        },
+        UPSTREAM_CONNECT_TIMEOUT,
+    ) {
+        Ok(s) => s,
+        Err(e) => {
+            eprintln!("mvm-egress-proxy: upstream connect {target} failed: {e}");
+            let _ = client.write_all(
+                b"HTTP/1.1 502 Bad Gateway\r\nContent-Length: 0\r\nConnection: close\r\n\r\n",
+            );
+            return Err(e);
+        }
+    };
+
+    client.write_all(b"HTTP/1.1 200 Connection Established\r\n\r\n")?;
+    tunnel(client, upstream)
+}
+
+/// Read the CONNECT request head (request line + headers). Stops
+/// at the empty CRLFCRLF separator. Caps the total bytes read at
+/// `MAX_REQUEST_LINE_LEN` to keep a malicious client from
+/// exhausting memory.
+fn read_request_head(client: &mut TcpStream) -> io::Result<String> {
+    let mut reader = BufReader::new(client);
+    let mut acc = String::new();
+    loop {
+        let mut line = String::new();
+        let n = reader.read_line(&mut line)?;
+        if n == 0 {
+            return Err(io::Error::new(
+                io::ErrorKind::UnexpectedEof,
+                "connection closed before CONNECT request",
+            ));
+        }
+        acc.push_str(&line);
+        if acc.len() > MAX_REQUEST_LINE_LEN {
+            return Err(io::Error::other("request head exceeded 8 KiB"));
+        }
+        if line == "\r\n" || line == "\n" {
+            return Ok(acc);
+        }
+    }
+}
+
+/// Parse the host + port out of the first line of `request`. The
+/// expected shape is `CONNECT host:port HTTP/1.1\r\n`.
+///
+/// IPv6 literal targets (`[::1]:443`) are not handled — the four
+/// ADR-047 hostnames are all DNS-resolved IPv4/IPv6 records, not
+/// literal addresses; we don't need to parse the literal form.
+/// An installer that somehow asks for a literal IPv6 target gets a
+/// 400 from here. Documented as a known limitation.
+pub fn parse_connect_target(request: &str) -> Result<(String, u16), String> {
+    let first_line = request.lines().next().ok_or("empty request")?;
+    let mut parts = first_line.split_whitespace();
+    let method = parts.next().ok_or("missing method")?;
+    let target = parts.next().ok_or("missing target")?;
+    let version = parts.next().ok_or("missing HTTP version")?;
+    if !method.eq_ignore_ascii_case("CONNECT") {
+        return Err(format!("expected CONNECT method, got `{method}`"));
+    }
+    if !version.starts_with("HTTP/") {
+        return Err(format!("expected HTTP version, got `{version}`"));
+    }
+
+    // target is `host:port` for CONNECT. Splitting on the last
+    // ':' lets IPv6 literals fail loudly (they contain ':' inside
+    // the host) rather than parse a wrong host.
+    let (host, port) = target
+        .rsplit_once(':')
+        .ok_or_else(|| format!("target `{target}` has no port"))?;
+    if host.is_empty() {
+        return Err("empty host in CONNECT target".to_string());
+    }
+    if host.contains(':') {
+        // IPv6 literal — see note above.
+        return Err(format!("IPv6 literal targets are not supported: {target}"));
+    }
+    let port: u16 = port
+        .parse()
+        .map_err(|_| format!("port `{port}` is not a valid u16"))?;
+    Ok((host.to_string(), port))
+}
+
+/// Bidirectional byte copy. Returns when either side closes its
+/// half of the connection. We split the streams and run two
+/// `std::io::copy` loops in two threads — one for client→upstream
+/// and one for upstream→client.
+fn tunnel(client: TcpStream, upstream: TcpStream) -> io::Result<()> {
+    // After the handshake, clear timeouts on both sides — the
+    // installer's own request timeout is the upper bound on tunnel
+    // duration.
+    client.set_read_timeout(None)?;
+    client.set_write_timeout(None)?;
+    upstream.set_read_timeout(None)?;
+    upstream.set_write_timeout(None)?;
+
+    let client_read = client.try_clone()?;
+    let upstream_write = upstream.try_clone()?;
+    let upstream_read = upstream;
+    let client_write = client;
+
+    let h1 = std::thread::spawn(move || copy_half(client_read, upstream_write));
+    let h2 = std::thread::spawn(move || copy_half(upstream_read, client_write));
+    // Wait for *both* halves to drain before tearing the handle
+    // down. If we returned on the first close, an in-flight last
+    // chunk on the other half would be lost.
+    let _ = h1.join();
+    let _ = h2.join();
+    Ok(())
+}
+
+/// One half of the bidirectional copy. `std::io::copy` doesn't
+/// surface a clean shutdown distinct from a half-close; treat any
+/// error other than "would block / interrupted / connection reset"
+/// as a hard fail.
+fn copy_half(mut src: TcpStream, mut dst: TcpStream) {
+    let mut buf = [0u8; 8 * 1024];
+    loop {
+        match src.read(&mut buf) {
+            Ok(0) => {
+                // Peer closed its half. Half-close the destination
+                // so the other direction can drain.
+                let _ = dst.shutdown(std::net::Shutdown::Write);
+                return;
+            }
+            Ok(n) => {
+                if dst.write_all(&buf[..n]).is_err() {
+                    return;
+                }
+            }
+            Err(e) if e.kind() == io::ErrorKind::Interrupted => continue,
+            Err(_) => {
+                let _ = dst.shutdown(std::net::Shutdown::Write);
+                return;
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::allowlist::Allowlist;
+    use std::io::Write;
+    use std::net::TcpStream;
+
+    fn local_allowlist() -> Allowlist {
+        // For tests we use a one-entry custom allowlist so we
+        // don't need to dial public infrastructure.
+        Allowlist::from_parts(vec!["allowed.test".to_string()], 443)
+    }
+
+    #[test]
+    fn parse_connect_target_happy_path() {
+        let req = "CONNECT pypi.org:443 HTTP/1.1\r\nHost: pypi.org:443\r\n\r\n";
+        let (host, port) = parse_connect_target(req).unwrap();
+        assert_eq!(host, "pypi.org");
+        assert_eq!(port, 443);
+    }
+
+    #[test]
+    fn parse_connect_target_lowercased_method() {
+        // RFC 7230 §3.1.1 says methods are case-sensitive, but in
+        // practice the proxy ecosystem treats `connect` as
+        // equivalent to `CONNECT`. We do the same.
+        let req = "connect pypi.org:443 HTTP/1.1\r\n\r\n";
+        let (host, port) = parse_connect_target(req).unwrap();
+        assert_eq!(host, "pypi.org");
+        assert_eq!(port, 443);
+    }
+
+    #[test]
+    fn parse_connect_target_rejects_non_connect_method() {
+        let req = "GET http://pypi.org/ HTTP/1.1\r\n\r\n";
+        let err = parse_connect_target(req).unwrap_err();
+        assert!(err.contains("CONNECT"), "msg: {err}");
+    }
+
+    #[test]
+    fn parse_connect_target_rejects_missing_port() {
+        let req = "CONNECT pypi.org HTTP/1.1\r\n\r\n";
+        let err = parse_connect_target(req).unwrap_err();
+        assert!(err.contains("port"), "msg: {err}");
+    }
+
+    #[test]
+    fn parse_connect_target_rejects_garbage_port() {
+        let req = "CONNECT pypi.org:abc HTTP/1.1\r\n\r\n";
+        let err = parse_connect_target(req).unwrap_err();
+        assert!(err.contains("u16"), "msg: {err}");
+    }
+
+    #[test]
+    fn parse_connect_target_rejects_empty_host() {
+        let req = "CONNECT :443 HTTP/1.1\r\n\r\n";
+        let err = parse_connect_target(req).unwrap_err();
+        assert!(err.contains("empty host"), "msg: {err}");
+    }
+
+    #[test]
+    fn parse_connect_target_rejects_ipv6_literal() {
+        // IPv6 literal targets aren't supported in v1 (see
+        // module-level note). Make sure they fail loudly rather
+        // than slipping through with a wrong host parse.
+        let req = "CONNECT [::1]:443 HTTP/1.1\r\n\r\n";
+        let err = parse_connect_target(req).unwrap_err();
+        assert!(err.contains("IPv6"), "msg: {err}");
+    }
+
+    #[test]
+    fn parse_connect_target_rejects_missing_version() {
+        let req = "CONNECT pypi.org:443\r\n\r\n";
+        let err = parse_connect_target(req).unwrap_err();
+        assert!(err.contains("HTTP version"), "msg: {err}");
+    }
+
+    #[test]
+    fn parse_connect_target_high_port() {
+        let req = "CONNECT pypi.org:8443 HTTP/1.1\r\n\r\n";
+        let (_, port) = parse_connect_target(req).unwrap();
+        assert_eq!(port, 8443);
+    }
+
+    /// End-to-end test: spawn a proxy on a kernel-assigned port,
+    /// open a CONNECT to a denied host, assert 403.
+    #[test]
+    fn denied_target_returns_403() {
+        let handle = start("127.0.0.1:0", local_allowlist()).unwrap();
+        let mut client = TcpStream::connect(handle.local_addr).unwrap();
+        client
+            .write_all(
+                b"CONNECT denied.example.com:443 HTTP/1.1\r\nHost: denied.example.com:443\r\n\r\n",
+            )
+            .unwrap();
+
+        let mut buf = [0u8; 512];
+        let n = client.read(&mut buf).unwrap();
+        let response = std::str::from_utf8(&buf[..n]).unwrap();
+        assert!(
+            response.starts_with("HTTP/1.1 403"),
+            "unexpected response: {response}"
+        );
+    }
+
+    /// End-to-end test: spawn the proxy + a tiny upstream server,
+    /// CONNECT through the proxy to the upstream's local address
+    /// using an allowlist that names that address's host. Asserts
+    /// the proxy responds 200 and bytes flow through.
+    #[test]
+    fn allowed_target_tunnels_bytes() {
+        // Upstream: a one-shot TCP echo on a kernel-assigned port.
+        let upstream_listener = TcpListener::bind("127.0.0.1:0").unwrap();
+        let upstream_addr = upstream_listener.local_addr().unwrap();
+        std::thread::spawn(move || {
+            if let Ok((mut s, _)) = upstream_listener.accept() {
+                let mut buf = [0u8; 64];
+                if let Ok(n) = s.read(&mut buf) {
+                    let _ = s.write_all(&buf[..n]);
+                }
+            }
+        });
+
+        // Allowlist names 127.0.0.1 on the upstream's exact port.
+        let allowlist = Allowlist::from_parts(vec!["127.0.0.1".to_string()], upstream_addr.port());
+        let handle = start("127.0.0.1:0", allowlist).unwrap();
+
+        let mut client = TcpStream::connect(handle.local_addr).unwrap();
+        let connect = format!(
+            "CONNECT 127.0.0.1:{port} HTTP/1.1\r\nHost: 127.0.0.1:{port}\r\n\r\n",
+            port = upstream_addr.port(),
+        );
+        client.write_all(connect.as_bytes()).unwrap();
+
+        // Read the 200 line.
+        let mut buf = [0u8; 256];
+        let n = client.read(&mut buf).unwrap();
+        let response = std::str::from_utf8(&buf[..n]).unwrap();
+        assert!(
+            response.starts_with("HTTP/1.1 200"),
+            "expected 200 Connection Established, got: {response}"
+        );
+
+        // Now the tunnel is open — send a payload, expect the echo.
+        client.write_all(b"hello").unwrap();
+        let mut echo = [0u8; 5];
+        client.read_exact(&mut echo).unwrap();
+        assert_eq!(&echo, b"hello");
+    }
+
+    #[test]
+    fn malformed_request_returns_400() {
+        let handle = start("127.0.0.1:0", local_allowlist()).unwrap();
+        let mut client = TcpStream::connect(handle.local_addr).unwrap();
+        client.write_all(b"this is not HTTP\r\n\r\n").unwrap();
+        let mut buf = [0u8; 256];
+        let n = client.read(&mut buf).unwrap();
+        let response = std::str::from_utf8(&buf[..n]).unwrap();
+        assert!(
+            response.starts_with("HTTP/1.1 400"),
+            "expected 400, got: {response}"
+        );
+    }
+
+    #[test]
+    fn shutdown_handle_stops_accepting() {
+        let mut handle = start("127.0.0.1:0", local_allowlist()).unwrap();
+        let addr = handle.local_addr;
+        handle.shutdown();
+        // After shutdown the listener thread has joined; a fresh
+        // dial may still succeed if the OS hasn't released the
+        // port yet (TIME_WAIT). What we assert is that calling
+        // shutdown a second time is a no-op and doesn't panic.
+        handle.shutdown();
+        // Smoke-check: address is still reportable even after
+        // shutdown.
+        assert_eq!(addr, handle.local_addr);
+    }
+}

--- a/nix/images/builder-vm/flake.nix
+++ b/nix/images/builder-vm/flake.nix
@@ -117,10 +117,18 @@
       # hard-gate the SBOM + CVE side once the egress allowlist
       # lands.
       #
-      # TODO(B.2.x): pin a network egress allowlist
-      # (`pypi.org`, `files.pythonhosted.org`, `registry.npmjs.org`,
-      # `objects.githubusercontent.com`) per ADR-047 §"Lifecycle
-      # gates" — today's builder VM has open egress.
+      # Plan 73 Followup B.2.x closed the egress side: the
+      # builder VM now runs `mvm-egress-proxy` (built via
+      # `mvmEgressProxyFor system`, installed at
+      # `/sbin/mvm-egress-proxy` via `extraFiles` below).
+      # `mvm-builder-init::install::run_install` spawns it
+      # before the installer + injects `HTTPS_PROXY` /
+      # `HTTP_PROXY` on `uv` / `pnpm`'s env. The proxy refuses
+      # anything outside ADR-047's four hostnames:
+      # `pypi.org`, `files.pythonhosted.org`,
+      # `registry.npmjs.org`, `objects.githubusercontent.com`.
+      # Complementary iptables drop-rule defense-in-depth is
+      # B.2.y (not in this slice).
       builderPackages = pkgs: with pkgs; [
         bashInteractive
         coreutils
@@ -178,6 +186,32 @@
           };
         };
 
+      # Build `mvm-egress-proxy` (Plan 73 Followup B.2.x) for the
+      # target system. Same `rustPlatform.buildRustPackage` shape
+      # as `mvm-builder-init` — the workspace's `Cargo.lock`
+      # drives the closure so we don't fork dep versions across
+      # the two builder-VM binaries. Tests run in CI's
+      # `cargo test --workspace` lane; `doCheck = false` here for
+      # the same reason.
+      mvmEgressProxyFor = system:
+        let
+          pkgs = import nixpkgs { inherit system; };
+        in
+        pkgs.rustPlatform.buildRustPackage {
+          pname = "mvm-egress-proxy";
+          version = "0.14.0";
+          src = workspace;
+          cargoLock = {
+            lockFile = workspace + "/Cargo.lock";
+          };
+          buildAndTestSubdir = "crates/mvm-egress-proxy";
+          doCheck = false;
+          meta = {
+            description = "Builder-VM egress allowlist proxy (Plan 73 Followup B.2.x, ADR-047)";
+            mainProgram = "mvm-egress-proxy";
+          };
+        };
+
       # Canonical kernel cmdline for the builder VM. `LibkrunBuilderVm`
       # (Plan 72 W4) reads this from the cmdline.txt output and
       # passes it to `mvm_libkrun::KrunContext.kernel_cmdline`.
@@ -194,6 +228,7 @@
         let
           pkgs = import nixpkgs { inherit system; };
           builderInit = mvmBuilderInitFor system;
+          egressProxy = mvmEgressProxyFor system;
           # Stock nixpkgs kernel. Pass it to `mkGuest` so the rootfs
           # ships its module tree (`/lib/modules/<kver>/`); the
           # builder VM doesn't run the standard `/init` modprobe path
@@ -212,6 +247,15 @@
             extraFiles = {
               "/sbin/mvm-builder-init" =
                 "${builderInit}/bin/mvm-builder-init";
+              # Plan 73 Followup B.2.x — egress allowlist proxy.
+              # `mvm-builder-init::install::run_install` spawns
+              # this from PATH (kernel default PATH includes
+              # `/sbin`) before invoking `uv` / `pnpm`. The
+              # binary embeds the ADR-047 four-hostname list at
+              # compile time; no env-var override path on the
+              # production build.
+              "/sbin/mvm-egress-proxy" =
+                "${egressProxy}/bin/mvm-egress-proxy";
             };
             kernel = kernelPkg;
           };
@@ -221,7 +265,7 @@
         pkgs.runCommand "mvm-builder-vm-image-${system}"
           {
             passthru = {
-              inherit rootfs builderInit;
+              inherit rootfs builderInit egressProxy;
               kernel = kernelPkg;
               cmdline = builderCmdline;
             };

--- a/specs/plans/73-sdk-port-followups.md
+++ b/specs/plans/73-sdk-port-followups.md
@@ -87,6 +87,53 @@ inside the libkrun builder VM:
 into. Pure-Rust primitives are ready (Phase 9 commits); this
 followup is the in-VM glue.
 
+### B.2.x — Egress allowlist (LANDED)
+
+The egress-allowlist slice ships an HTTP CONNECT proxy
+(`crates/mvm-egress-proxy/`) that the builder VM runs alongside
+the installer. `mvm-builder-init::install::run_install` spawns
+the proxy before invoking `uv` / `pnpm`, injects
+`HTTPS_PROXY` + `HTTP_PROXY` env pointing at `http://127.0.0.1:8443`,
+and tears the proxy down after. The proxy embeds the four
+ADR-047 hostnames at compile time — no env-var override on
+production builds; the `dev-shell` feature flag exposes a
+test-only `MVM_EGRESS_ALLOWLIST` override.
+
+The builder VM flake installs the proxy at
+`/sbin/mvm-egress-proxy` (alongside `/sbin/mvm-builder-init`),
+and PID 1 picks it up via PATH lookup. Tests live in
+`crates/mvm-egress-proxy/src/{allowlist,proxy}.rs` (24 unit
+tests) and `crates/mvm-builder-init/src/install.rs::tests`
+(proxy lifecycle wraps the installer + env vars set + abort
+on proxy failure).
+
+### B.2.y — Complementary iptables drop-rule (NOT YET)
+
+B.2.x's proxy is the only enforcement mechanism today. A
+pathological installer that ignores `HTTPS_PROXY` could
+theoretically dial pypi.org directly. Defense-in-depth: add
+an iptables rule inside the builder VM that drops outbound
+traffic *not* originating from the proxy's UID, so even a
+misbehaving installer's direct fetch fails closed. Scope:
+
+- New systemd-style setup invocation inside
+  `mvm-builder-init::linux::setup_network` that loads an
+  `iptables -A OUTPUT` rule. Specifically `-m owner --uid-owner
+  <proxy_uid> -j ACCEPT` then `-A OUTPUT -j DROP` so only
+  proxy-originated egress is allowed.
+- Run the proxy under a dedicated UID (currently it runs as
+  PID 1's UID — root). Add a `mvm-egress-proxy` system user
+  in the builder VM rootfs (uid 902, mirroring the agent's
+  uid 901 slot).
+- Test gate: extend `scripts/test-app-deps-ci-gate.sh` with a
+  smoke test that boots the builder VM with a manipulated env
+  (`HTTPS_PROXY=`), runs a forbidden curl from inside, asserts
+  the iptables rule drops it.
+
+**Blocked on:** Plan 72 W4/W5 — needs a live builder VM to
+exercise the iptables rule. Once B.2.x is merged + the
+builder VM lands, this can ship as a small followon PR.
+
 ## Followup C — `mvmctl deps` CLI verbs
 
 User-facing surface for the volume audit pipeline:


### PR DESCRIPTION
## Summary

Closes the egress-allowlist gap left open by Followup B.2 (PR #211). The builder VM's application-deps install pipeline (`uv pip install` / `pnpm install`) is now fronted by an HTTP CONNECT proxy that refuses anything outside ADR-047 §\"Registry allowlist\"'s four hostnames: `pypi.org`, `files.pythonhosted.org`, `registry.npmjs.org`, `objects.githubusercontent.com`. Without the proxy, today's builder VM has open egress during install — a poisoned mirror or a typo'd lockfile URL slips straight through.

## Scope

**Three surfaces:**

1. **New crate `crates/mvm-egress-proxy/`** — pure-Rust HTTP CONNECT proxy. Hostname allowlist + port-443 check baked in at compile time (no env-var override in production; `dev-shell` Cargo feature exposes `MVM_EGRESS_ALLOWLIST` for tests). std::net + std::thread (no tokio dep — keeps closure tiny). 24 unit tests cover the allowlist (exact match, case-insensitive, port boundary, typosquat rejection, subdomain rejection) and proxy lifecycle (allowed tunnels bytes, denied returns 403, malformed returns 400, CONNECT parser corner cases incl. IPv6 literals).

2. **`mvm-builder-init` integration** — new `proxy.rs` module with `ProxyLifecycle` trait. `ChildProxyLifecycle` spawns `mvm-egress-proxy` from PATH, TCP-probes `127.0.0.1:8443` until ready (max 2s), runs the installer with `HTTPS_PROXY` / `HTTP_PROXY` / `https_proxy` / `http_proxy` env vars set, then SIGTERMs the proxy (1s grace + SIGKILL fallback) after installer exits. `run_install`'s signature moves into an `InstallContext` struct to stay under `clippy::too_many_arguments = \"deny\"`. The `CommandRunner` trait gains `run_with_env`; existing `run` becomes a default-impl thunk. 8 new tests assert lifecycle order, env-var presence on installer, env-var absence on sidecars, and abort-pre-installer-if-proxy-fails.

3. **Builder VM flake** — `nix/images/builder-vm/flake.nix` adds `mvmEgressProxyFor system` alongside `mvmBuilderInitFor`, installs at `/sbin/mvm-egress-proxy` via `extraFiles`. Both binaries share the workspace `Cargo.lock` closure.

## Out of scope — B.2.y

Complementary iptables drop-rule (defense-in-depth: drop outbound traffic that didn't transit the proxy's UID) is documented as B.2.y in `specs/plans/73-sdk-port-followups.md`. Needs a live builder VM to exercise; ships as a small followon once Plan 72 W4/W5 lands.

## Test plan

- [x] `cargo fmt --check`
- [x] `cargo clippy --workspace --all-targets -- -D warnings`
- [x] `cargo run -p xtask -- check-no-display-on-secret-types`
- [x] `cargo test --workspace` — 24 new tests in mvm-egress-proxy, 8 new + amended in mvm-builder-init, all pass. (mvm-guest's pre-existing timing-flaky `lifecycle_hooks` + `entrypoint::test_execute_stdout_cap_kills_wrapper` tests pass in isolation; load-sensitive failures unrelated to this PR.)
- [x] `scripts/test-app-deps-ci-gate.sh` — 22/22 assertions pass against the proxy-wrapped install path.

## Manual smoke checklist for hardware-validated builder VM

End-to-end against a real libkrun/cloud-hypervisor builder VM isn't a CI gate yet (Plan 72 W4/W5 still mid-cutover). When the builder VM lands:

- [ ] `mvmctl build --deps examples/python/hello-app-with-deps/` boots the VM, runs `uv pip install` through the proxy, dials `pypi.org:443` + `files.pythonhosted.org:443` exclusively, lands the sealed volume.
- [ ] Smoke negative: hand-edit a lockfile to a forbidden URL (`evil.example.com`), assert `uv` exits nonzero with a proxy-403 in `fetch.log`.
- [ ] Confirm `/sbin/mvm-egress-proxy` and `/sbin/mvm-builder-init` are both present in the rootfs and on PATH for PID 1.
- [ ] Confirm the proxy's stderr log lines (`mvm-egress-proxy: ALLOW pypi.org:443`) land in libkrun's console output for the host's audit chain.

🤖 Generated with [Claude Code](https://claude.com/claude-code)