### PR TITLE
plan 74 W0 — claims hygiene + docs guardrails (+ ADR-048, plan 74, W1-W6 attack plan)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -125,15 +125,9 @@ jobs:
       - name: No forbidden dependency families
         run: cargo run -p xtask -- check-forbidden-deps
 
-      # Plan 75 W0 — user-facing repo text cannot use phrases
-      # gated by a claim file in specs/claims/ whose status is
-      # not Shipped. Prevents docs / README / CLI help from
-      # claiming a capability before its CI gate passes. Each
-      # claim file declares its own exempt_paths; design docs
-      # (specs/**) and history (CHANGELOG.md) are exempt by
-      # convention. Hard gate; admit a phrase by either flipping
-      # its claim to Shipped (once the CI gate ratifies it) or
-      # adding the path to the claim's exempt_paths.
+      - name: Gated doc claims (plan 74 W0)
+        run: cargo run -p xtask -- check-doc-claims
+
       - name: No overclaiming (gated phrases from specs/claims/)
         run: cargo run -p xtask -- check-no-overclaim
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6630,6 +6630,7 @@ dependencies = [
  "clap_mangen",
  "mvm-build",
  "mvm-cli",
+ "regex",
  "serde",
  "serde_json",
  "sha2",

--- a/crates/mvm-cli/src/commands/vm/run_plan.rs
+++ b/crates/mvm-cli/src/commands/vm/run_plan.rs
@@ -346,6 +346,7 @@ mod tests {
             mode: Some(RunMode::Plan),
             dev: false,
             prod: false,
+            dry_run: false,
             argv: Vec::new(),
         }
     }

--- a/public/astro.config.mjs
+++ b/public/astro.config.mjs
@@ -119,6 +119,7 @@ export default defineConfig({
             { label: "Threat model", slug: "security/threat-model" },
             { label: "Seven CI claims", slug: "security/ci-claims" },
             { label: "Verified boot", slug: "security/verified-boot" },
+            { label: "Sandbox parity status", slug: "security/sandbox-parity-status" },
           ],
         },
         {

--- a/public/src/content/docs/guides/exec.md
+++ b/public/src/content/docs/guides/exec.md
@@ -160,27 +160,25 @@ mvmctl exec --timeout 300 -- ./long-running-task.sh
 
 Defaults: 2 vCPUs, 512 MiB, 60-second timeout per command.
 
-## Driving from an mvmforge launch plan
+## Driving from a launch plan
 
-If you're using [mvmforge](https://github.com/tinylabscom/decorationer)
-to declare workloads, you can hand `mvmctl exec` either the `launch.json`
-artifact from `mvmforge compile` or the Workload IR manifest from
-`mvmforge emit` — `--launch-plan` accepts both shapes and auto-detects:
+`mvmctl exec --launch-plan <path>` accepts either of two JSON
+shapes — a `launch.json` artifact (top-level `entrypoint`) or a
+Workload IR manifest (top-level `apps[]`) — and auto-detects which
+one it is given. Both shapes were historically produced by the
+`mvmforge` toolchain
+([see the migration guide](/guides/mvmforge-migration/));
+the canonical producer today is `mvmctl compile` in the mvm SDK.
 
 ```bash
-mvmforge compile manifest.json --out ./build
+mvmctl compile manifest.json --out ./build
 mvmctl exec --launch-plan ./build/launch.json
-```
-
-```bash
-mvmforge emit app.py > manifest.json
-mvmctl exec --launch-plan manifest.json
 ```
 
 Only the entrypoint is consumed in v1; image selection still comes from
 `--manifest` or the bundled default.
 
-**LaunchPlan artifact** (`mvmforge compile`'s `launch.json` output):
+**LaunchPlan artifact** (top-level `entrypoint`):
 
 ```json
 {
@@ -195,7 +193,7 @@ Only the entrypoint is consumed in v1; image selection still comes from
 }
 ```
 
-**Workload IR manifest** (`mvmforge emit` stdout):
+**Workload IR manifest** (top-level `apps[]`):
 
 ```json
 {
@@ -213,10 +211,10 @@ Only the entrypoint is consumed in v1; image selection still comes from
 }
 ```
 
-For long-running workloads, prefer `mvmforge up` (or
-`mvmctl up --flake <artifact-dir>`): mvmforge bakes the entrypoint into
-the generated flake's `services.<id>.command`, and mvm's PID-1 init
-supervises it across reboots.
+For long-running workloads, prefer `mvmctl up --flake <artifact-dir>`:
+the SDK bakes the entrypoint into the generated flake's
+`services.<id>.command`, and mvm's PID-1 init supervises it across
+reboots.
 
 Multi-app launch plans are rejected -- that's an orchestration concern
 that belongs in `mvmd`, not in `mvmctl exec`. Env precedence (lowest →

--- a/public/src/content/docs/reference/cli-commands.md
+++ b/public/src/content/docs/reference/cli-commands.md
@@ -276,7 +276,7 @@ the feature, so the handler is not present in the binary at all.
 |---------|-------------|
 | `mvmctl exec -- <cmd>...` | Boot the bundled default microVM image, run `<cmd>`, exit |
 | `mvmctl exec --manifest <name> -- <cmd>...` | Boot a registered template instead of the default |
-| `mvmctl exec --launch-plan <path> ` | Run the entrypoint from an [mvmforge](https://github.com/tinylabscom/decorationer) document — either the `launch.json` artifact (top-level `entrypoint`) or the Workload IR manifest (top-level `apps[]`). Mutually exclusive with trailing argv |
+| `mvmctl exec --launch-plan <path> ` | Run the entrypoint from a `launch.json` artifact (top-level `entrypoint`) or a Workload IR manifest (top-level `apps[]`). See the [mvmforge migration guide](/guides/mvmforge-migration/) for the historical origin. Mutually exclusive with trailing argv |
 | `mvmctl exec --add-dir HOST:GUEST[:MODE] -- <cmd>` | Mount a host directory inside the guest. `MODE` is `ro` (default — writes discarded) or `rw` (writes rsynced back to the host after the command exits — see [ADR-002](/contributing/adr/002-writable-add-dir/)). Repeatable |
 | `mvmctl exec --env KEY=VAL -- <cmd>` | Inject an environment variable. Repeatable. Overrides any env vars carried by `--launch-plan` |
 | `mvmctl exec --cpus <n>` / `--memory <size>` | Resize the transient VM (defaults: 2 vCPUs, 512 MiB) |
@@ -290,17 +290,19 @@ mvmctl exec --manifest minimal -- /bin/true            # named template
 mvmctl exec --add-dir .:/work -- ls /work              # share current dir, RO
 mvmctl exec --add-dir .:/work:rw -- touch /work/x      # writable, rsynced back
 mvmctl exec -e DEBUG=1 -- env | grep DEBUG             # env var injection
-mvmctl exec --launch-plan ./launch.json                # mvmforge entrypoint
+mvmctl exec --launch-plan ./launch.json                # launch-plan entrypoint
 ```
 
 ### Launch-plan shape
 
-`--launch-plan` accepts either of mvmforge's two JSON documents — the
-shape is auto-detected. Only the entrypoint is consumed (image selection
-still comes from `--manifest` or the bundled default in v1).
+`--launch-plan` accepts either of two JSON shapes — the shape is
+auto-detected. Only the entrypoint is consumed (image selection
+still comes from `--manifest` or the bundled default in v1). Both
+shapes were historically produced by the `mvmforge` toolchain
+([migration guide](/guides/mvmforge-migration/)); `mvmctl compile`
+is the canonical producer today.
 
-**LaunchPlan artifact** (`mvmforge compile`'s `launch.json`, top-level
-`entrypoint`):
+**LaunchPlan artifact** (top-level `entrypoint`):
 
 ```json
 {
@@ -315,7 +317,7 @@ still comes from `--manifest` or the bundled default in v1).
 }
 ```
 
-**Workload IR manifest** (`mvmforge emit` stdout, top-level `apps[]`):
+**Workload IR manifest** (top-level `apps[]`):
 
 ```json
 {

--- a/public/src/content/docs/security/sandbox-parity-status.md
+++ b/public/src/content/docs/security/sandbox-parity-status.md
@@ -1,0 +1,218 @@
+---
+title: Sandbox parity status
+description: Which sandbox-parity claims mvm makes today, and which are Preview, Planned, or deliberately Not claimed. Backed by ADR-048 and the cargo xtask check-doc-claims lint.
+---
+
+mvm makes seven sandbox-parity claims relative to microsandbox's
+published positioning. Each claim has a defined gate
+([ADR-048](https://github.com/tinylabscom/mvm/blob/main/specs/adrs/048-claim-safe-sandbox-parity.md))
+and a current status. Public docs and release notes use the language
+in this table — anything stronger is enforced by the
+`cargo xtask check-doc-claims` lint in CI.
+
+## Status taxonomy
+
+| Status         | Meaning                                                                                                                |
+| -------------- | ---------------------------------------------------------------------------------------------------------------------- |
+| **Shipped**    | Implemented, documented, tested, and wired through at least one production-capable backend.                            |
+| **Preview**    | Implemented behind an explicit flag or limited backend matrix; docs must name limitations.                             |
+| **Planned**    | ADR/plan exists; not available to users.                                                                               |
+| **Not claimed**| Deliberately absent or rejected.                                                                                       |
+
+## Current status
+
+The seven claim ids correspond to ADR-048
+§"The seven target claims". Each row's machine marker (HTML comment
+above the row) is what the docs lint reads — flipping the status
+requires editing both the marker and the visible cell.
+
+<!-- claim:claims-hygiene status:Shipped -->
+<!-- claim:oci-ingest status:Planned -->
+<!-- claim:network-policy status:Planned -->
+<!-- claim:secret-non-leakage status:Planned -->
+<!-- claim:sdk-lifecycle status:Planned -->
+<!-- claim:cold-start status:Planned -->
+<!-- claim:filesystem-backends status:Planned -->
+
+| Claim id              | Description                                                                                                              | Status      |
+| --------------------- | ------------------------------------------------------------------------------------------------------------------------ | ----------- |
+| `claims-hygiene`      | Public docs clearly distinguish Shipped, Preview, Planned, and Not claimed.                                              | **Shipped** |
+| `oci-ingest`          | Run digest-pinned OCI images in microVMs without Docker as the runtime.                                                  | **Planned** |
+| `network-policy`      | Deny-by-default egress with DNS pinning, SNI/Host enforcement, metadata endpoint protection, and audit.                  | **Planned** |
+| `secret-non-leakage`  | Workloads receive opaque placeholders; real secret values are substituted only by trusted host-side policy.              | **Planned** |
+| `sdk-lifecycle`       | Python/TypeScript/Rust SDKs create, run, inspect, snapshot, and stop sandboxes with cleanup bound to the parent process. | **Planned** |
+| `cold-start`          | Latency numbers produced by a reproducible harness, split by fresh boot, guest-agent-ready, snapshot restore, warm pool. | **Planned** |
+| `filesystem-backends` | Local, encrypted, object-store, and in-memory filesystem substrates share one contract; mountable vs API-only is stated. | **Planned** |
+
+## What each status means in practice
+
+### `claims-hygiene` — Shipped
+
+This page is the artifact. The companion `cargo xtask check-doc-claims`
+lint runs in CI and rejects gated marketing phrases on any page that
+isn't this one or the deliberate `mvmforge` migration guide.
+Contributors flip a row to Shipped only when the underlying CI gate
+exists.
+
+### `oci-ingest` — Planned
+
+Today mvm builds rootfs from a Nix flake or from a bundled template
+catalog. There is no `mvmctl image pull` command, no OCI layer
+unpacker, and no digest-pinned launch path. The
+[round-trip OCI bridge](https://github.com/tinylabscom/mvm/blob/main/crates/mvm-backend/src/docker.rs)
+loads mvm-built images into Docker; it does NOT pull upstream images.
+
+To move to Preview: ship `mvmctl image pull` with digest
+verification, layer unpack with whiteout, symlink, and hardlink
+coverage, and an integration test against a hermetic local registry.
+
+To move to Shipped: production profile rejects mutable tags, audit
+events fire for resolve, fetch, cache-hit, materialize, verify,
+launch, and delete; mvmd-side consumer is wired (mvmd ADR-0020
+cross-repo handoff).
+
+Tracking work:
+[Plan 74 W1](https://github.com/tinylabscom/mvm/blob/main/specs/plans/74-claim-safe-sandbox-parity.md#w1--oci-image-ingest).
+
+### `network-policy` — Planned
+
+Today's egress enforcement is L3 allow-listing
+([ADR-004](https://github.com/tinylabscom/mvm/blob/main/specs/adrs/004-egress-policy.md)).
+There is no DNS pinning resolver, no HTTPS SNI/Host policy, and the
+metadata endpoint (`169.254.169.254`) is not blocked by default.
+
+To move to Preview: ship the pinning DNS resolver and an L7 proxy
+that enforces Host on HTTP and SNI on HTTPS CONNECT, with audit
+events for allow, deny, dns-pin, dns-reject, and proxy-fail.
+
+To move to Shipped: per-plan network policy flows through the
+signed `ExecutionPlan`; integration tests prove DNS rebinding,
+raw-IP bypass, wrong-SNI, and metadata-endpoint denial.
+
+Tracking work:
+[Plan 74 W2](https://github.com/tinylabscom/mvm/blob/main/specs/plans/74-claim-safe-sandbox-parity.md#w2--programmable-network-policy).
+
+### `secret-non-leakage` — Planned
+
+Today secrets reach the guest as plain env or mounted files. A
+compromised guest can read them. ADR-048 §"Non-goals" explicitly
+states mvm will **not claim** secret non-leakage for that legacy
+flow. The placeholder + host-side substitution path is Planned.
+
+To move to Preview: ship the `SecretPlaceholder` type, host-side
+grant registry, and L7-proxy substitution for at least one provider
+end-to-end, behind a default-off feature flag.
+
+To move to Shipped: the default flow is placeholder-based; redaction
+wrappers cover plan JSON, logs, audit, errors, cache keys, route
+labels, and panic output; hostile-guest exfiltration tests run in
+CI; the legacy env/file path sits behind
+`unsafe_guest_secret_materialization` and is documented as such.
+
+Tracking work:
+[Plan 74 W3](https://github.com/tinylabscom/mvm/blob/main/specs/plans/74-claim-safe-sandbox-parity.md#w3--secret-placeholders-and-host-side-substitution).
+
+### `sdk-lifecycle` — Planned
+
+`crates/mvm-sdk` ships today as the build-time SDK
+([migration guide](/guides/mvmforge-migration/)) — it lets a user
+declare a workload, emit canonical IR, and compile entrypoints
+statically. There is no runtime lifecycle surface: no Python or
+TypeScript `create` / run / `snapshot` / `stop` methods that own
+a sandbox from a parent process.
+
+To move to Preview: ship the Rust lifecycle API plus a Python
+binding (pyo3), shared fixture suite, parent-process lease using
+`PR_SET_PDEATHSIG` on Linux.
+
+To move to Shipped: TypeScript binding via napi-rs; parent-death
+cleanup works on both Linux and macOS (kqueue `NOTE_EXIT` on
+macOS); static decorator compilation stays separate from the
+runtime control surface (no importing user code to inspect it).
+
+Tracking work:
+[Plan 74 W4](https://github.com/tinylabscom/mvm/blob/main/specs/plans/74-claim-safe-sandbox-parity.md#w4--sdk-owned-lifecycle).
+
+### `cold-start` — Planned
+
+`runtime_boot_bench` covers Apple Container serial and parallel
+boots today, but mvm has no published end-to-end latency number
+covering Firecracker, libkrun, snapshot restore, and warm-pool
+claim under a single methodology.
+ADR-048 §"Non-goals" explicitly forbids claiming
+<!-- allow(doc-claim:cold-start): explicit non-goal callout -->
+sub-100ms until measured data supports it.
+
+To move to Preview: one canonical report, one host, one backend
+(e.g. macOS Apple Silicon + libkrun), p50/p95/p99/max, with
+readiness boundary named on every row.
+
+To move to Shipped: the harness runs on at least two backends; CI
+budget gates have been green for at least one week;
+`specs/perf/` carries a published report contributors can diff
+their changes against.
+
+Tracking work:
+[Plan 74 W5](https://github.com/tinylabscom/mvm/blob/main/specs/plans/74-claim-safe-sandbox-parity.md#w5--cold-start-measurement-and-budgets).
+
+### `filesystem-backends` — Planned
+
+mvm has volume primitives (virtio-fs `--add-dir`, named volumes)
+and an instance-snapshot path with HMAC-sealed monotonic-epoch
+replay protection. There is no shared `VolumeBackend` conformance
+suite and no encrypted, object-store, or in-memory backend.
+
+To move to Preview: conformance test scaffold runs against local
+and in-memory backends; capability flags (mountable vs API-only)
+land.
+
+To move to Shipped: encrypted and object-store backends pass the
+same suite; path-traversal, symlink-escape, concurrent-write, and
+large-file edge cases are covered by tests; audit records emit on
+attach, detach, read, write, delete, rename, snapshot, and health.
+
+Tracking work:
+[Plan 74 W6](https://github.com/tinylabscom/mvm/blob/main/specs/plans/74-claim-safe-sandbox-parity.md#w6--extensible-filesystem-backends).
+
+## Deliberately not claimed
+
+ADR-048 §"Non-goals" names the postures mvm rejects:
+
+- Docker or a Docker daemon as the production runtime.
+- Kubernetes or Compose compatibility.
+- Sub-100ms cold boot before measured data supports it.
+- The phrase
+  <!-- allow(doc-claim:secret-non-leakage): non-goal callout -->
+  "secrets cannot leak" for legacy env/file injection
+  flows — those flows reach the guest in plaintext today and the
+  ADR forbids the claim.
+- Bypassing signed plans, audit, or verified artifact checks for
+  developer ergonomics.
+
+These are policy commitments. A future PR cannot flip them by
+editing this page alone — ADR-048 must be amended first.
+
+## Reading the table programmatically
+
+The `<!-- claim:<id> status:<word> -->` HTML comments above each
+row are the machine-readable source of truth.
+`cargo xtask check-doc-claims` reads them per-file: if a gated
+phrase fires on a page and the same page declares `status:Shipped`
+for the corresponding claim, the lint allows it. This page is also
+on a short path allow-list (along with the mvmforge migration
+guide) because its job is to *talk about* every gated phrase.
+
+Inline opt-outs use the comment form
+<!-- allow(doc-claim:claims-hygiene): example below is markup, not a claim -->
+`<!-- allow(doc-claim:<id>): <reason> -->` on the same line or
+within two lines above the phrase. The reason field is required
+so audit bypasses stay visible in git blame.
+
+## Related reading
+
+- [ADR-048: Claim-safe sandbox parity roadmap](https://github.com/tinylabscom/mvm/blob/main/specs/adrs/048-claim-safe-sandbox-parity.md)
+- [Plan 74: workstreams W0-W6](https://github.com/tinylabscom/mvm/blob/main/specs/plans/74-claim-safe-sandbox-parity.md)
+- [Plan 74 attack plan: sequencing for W1-W6](https://github.com/tinylabscom/mvm/blob/main/specs/plans/74-w1-w6-attack-plan.md)
+- [Seven CI-enforced security claims](/security/ci-claims/) — the
+  existing operator-facing security guarantees this page does NOT
+  duplicate.

--- a/specs/SPRINT.md
+++ b/specs/SPRINT.md
@@ -42,6 +42,8 @@ Recent maintenance:
 - [x] Extended `runtime_boot_bench` with TOML config-file input, Apple Container backend defaults, configurable CPU/memory sizing, and Apple guest-agent readiness probing.
 - [x] Removed the remaining third-party sandbox Cargo dependency and backend/builder compile paths; `Cargo.lock` no longer carries the transitive SeaORM/SQLx stack, including the MySQL driver.
 - [x] Preserved macOS cross-architecture support after the cleanup: Apple Container stays scoped to macOS 26+ Apple Silicon, while direct libkrun remains the macOS Apple Silicon + Intel path.
+- [x] Added ADR-048 and Plan 74 to turn the Microsandbox comparison into claim-gated `mvm` runtime work: docs hygiene, OCI ingest, programmable networking, secret placeholders, SDK-owned lifecycle, measured cold-starts, and filesystem backend contracts.
+- [ ] Plan 74 W0 (claims hygiene and docs guardrails) in flight — new public Sandbox parity status page (`security/sandbox-parity-status.md`), `cargo xtask check-doc-claims` lint covering `<100ms` / `any OCI image` / `secrets cannot leak` / variants, `mvmforge` cleanup in `guides/exec.md` and `reference/cli-commands.md`, gap-analysis updated for current `crates/mvm-sdk` layout and mvmd ADR-0020 handoff, and a new `specs/plans/74-w1-w6-attack-plan.md` sequencing sidecar that defers risk discussion to plan 74's `## Risks` section (R1-R12).
 
 ## In-flight workstreams
 
@@ -1689,6 +1691,39 @@ Shipped:
 5. *Backwards compatibility: every existing workspace test plus
    `cargo clippy --workspace --all-targets -- -D warnings` stays
    green throughout.*
+
+## Sprint 53 — Claim-safe sandbox parity (W0 in flight) [`plans/74-claim-safe-sandbox-parity.md`](plans/74-claim-safe-sandbox-parity.md) | [`adrs/048-claim-safe-sandbox-parity.md`](adrs/048-claim-safe-sandbox-parity.md) | [`plans/74-w1-w6-attack-plan.md`](plans/74-w1-w6-attack-plan.md)
+
+### W0 — Claims hygiene and docs guardrails  🟡 in flight
+
+Stops overclaiming before runtime work (W1-W6) lands. Ships a public
+"Sandbox parity status" page that classifies every claim
+(`claims-hygiene` / `oci-ingest` / `network-policy` /
+`secret-non-leakage` / `sdk-lifecycle` / `cold-start` /
+`filesystem-backends`) as Shipped / Preview / Planned / Not claimed;
+adds `cargo xtask check-doc-claims` to the `lint` CI job, which
+rejects gated marketing phrases (`<100ms` and variants, `any OCI
+image`, `arbitrary OCI image`, `secrets cannot leak`, `never enters
+the guest`) on public docs unless the file marks the relevant claim
+Shipped or carries an `<!-- allow(doc-claim:<id>): <reason> -->`
+opt-out; strips live `mvmforge` references from
+`guides/exec.md` and `reference/cli-commands.md` (the deliberate
+migration guide stays); updates `specs/gap-analysis-vs-microsandbox.md`
+for the current `crates/mvm-sdk` + `crates/mvm-sdk-macros` layout
+and the mvmd ADR-0020 cross-repo handoff; and lands plan 74's
+`## Risks` section (R1-R12, eight cross-cutting plus four
+architectural) plus the `74-w1-w6-attack-plan.md` sequencing
+sidecar so W1-W6 don't get re-planned mid-flight.
+
+### W1-W6 — Proposed
+
+OCI ingest, programmable network policy, secret placeholders,
+SDK-owned lifecycle, cold-start measurement, extensible filesystem
+backends. Sequencing, dependencies, and per-workstream attack plans
+in `plans/74-w1-w6-attack-plan.md`. Risk R9 (TLS substitution
+mechanism — proxy-with-CA vs vsock side-channel vs host-side
+reconstruction) is the single architectural gate; recommended to
+land its own ADR before W2 codes the proxy.
 
 ## Completed Sprints
 

--- a/specs/adrs/048-claim-safe-sandbox-parity.md
+++ b/specs/adrs/048-claim-safe-sandbox-parity.md
@@ -1,0 +1,155 @@
+# ADR 048: Claim-safe sandbox parity roadmap
+
+- Status: Proposed
+- Date: 2026-05-14
+- Owner: MVM Project
+- Related: ADR-004 (egress policy), ADR-031 (cross-platform strategy), ADR-041 (signed audited execution plans), ADR-047 (app dependency audit pipeline), mvmd ADR-0020 (OCI images as microVM workloads)
+
+## Context
+
+Microsandbox's public positioning has sharpened the product bar for local and fleet-managed code sandboxes:
+
+- sub-100ms cold start
+- embedded, no-root, no-daemon SDK-owned runtime
+- cross-platform native operation
+- arbitrary OCI image input
+- secrets that do not enter the guest
+- programmable DNS/TLS-aware network policy
+- extensible filesystem backends
+- snapshot/fork/restore workflows
+- in-perimeter and air-gapped deployment
+
+`mvm` already has stronger operator/security primitives in several areas: Nix-built rootfs artifacts, signed plans, audit chains, dm-verity posture, Firecracker as the Tier-1 backend, vsock-only guest communication, and multi-backend architecture. The gap is that several developer-facing claims are not yet defensible as shipped behavior.
+
+This ADR records the claims we want to make and the runtime primitives `mvm` must own before those claims are allowed in public docs, landing pages, or release notes.
+
+## Decision
+
+`mvm` will pursue claim-safe parity for seven claims, but each claim is gated by implementation and tests. Marketing language must use the claim status taxonomy below until the gate is green.
+
+### Claim status taxonomy
+
+| Status | Meaning |
+|---|---|
+| Shipped | Implemented, documented, tested, and wired through at least one production-capable backend. |
+| Preview | Implemented behind an explicit flag or limited backend matrix; docs must name limitations. |
+| Planned | ADR/plan exists; not available to users. |
+| Not claimed | Deliberately absent or rejected. |
+
+### The seven target claims
+
+1. **Claims hygiene:** public docs clearly distinguish Shipped, Preview, Planned, and Not claimed.
+2. **OCI ingest:** users can run digest-pinned OCI images in microVMs without Docker as the runtime.
+3. **Programmable network policy:** deny-by-default egress with DNS pinning, SNI/Host enforcement, metadata endpoint protection, and audit.
+4. **Secrets do not enter guests by default:** workloads receive opaque placeholders; real secret values are substituted only by trusted host-side policy for approved destinations.
+5. **SDK-owned lifecycle:** Python/TypeScript/Rust SDKs can create, exec, inspect, snapshot, and stop sandboxes with cleanup bound to the parent process.
+6. **Measured cold-start story:** published latency numbers are produced by a reproducible harness and split by fresh boot, guest-agent-ready, snapshot restore, and warm-pool claim.
+7. **Extensible filesystem backends:** local, encrypted, object-store-backed, and in-memory filesystem substrates share one contract and state which backends are mountable versus API-only.
+
+## Runtime Ownership
+
+`mvm` owns the local primitives:
+
+- OCI distribution, verification, unpacking, whiteout handling, rootfs materialization, template registration, and launch.
+- Local egress enforcement surfaces: L3 rules, DNS pinning resolver, L7 proxy, SNI/Host policy, and audit emission.
+- Host-side secret placeholder registry, policy-bound substitution, grant revocation, and redaction at all boundaries.
+- SDK process-owned lifecycle over local `mvm` primitives.
+- Performance harnesses and budgets for local backends.
+- Storage and filesystem backend contracts.
+
+`mvmd` owns fleet/product policy:
+
+- Tenant image policy, registry allow rules, cache isolation, route exposure, and API admission.
+- Fleet egress policy, tenant DNS policy, quota, and audit aggregation.
+- Tenant secret providers, per-tenant grant policy, and cross-node revocation.
+- Warm pools, placement, wake-on-demand, public API, generated SDKs, and web console claims.
+
+If a primitive is missing in `mvm`, `mvmd` must not implement a parallel runtime path. The primitive is added to `mvm` first, then consumed by `mvmd`.
+
+## Claim Gates
+
+### OCI ingest
+
+Public claim allowed only when:
+
+- `mvmctl image pull <ref>` resolves an immutable digest and records requested ref plus launched digest.
+- Production profile rejects mutable tags unless an explicit local/dev policy allows them.
+- Layer unpacking handles whiteouts, symlinks, hardlinks, ownership, permissions, entrypoint, env, workdir, and exposed ports.
+- Rootfs artifacts are tenant/cache scoped correctly.
+- Tests cover digest pinning, mutable-tag rejection, private registry auth, whiteout behavior, and secret/cache non-leakage.
+
+### Programmable network policy
+
+Public claim allowed only when:
+
+- `deny` is a first-class default policy.
+- DNS answers for allowed names are pinned for the workload lifetime.
+- HTTP Host and HTTPS SNI are verified against policy.
+- Direct metadata endpoint access is blocked by default.
+- Policy decisions emit audit records for allow, deny, DNS pin, DNS reject, and proxy failure.
+- Integration tests prove DNS rebinding, raw-IP bypass, wrong-SNI, and metadata access are blocked.
+
+### Secret non-leakage
+
+Public claim allowed only when:
+
+- Default SDK/CLI secret flow gives the guest only an opaque placeholder or a scoped, non-reusable grant.
+- Real secret values never appear in guest env, guest files, guest argv, logs, audit detail, plan JSON, cache keys, route labels, error messages, or panic output.
+- Substitution is bound to destination policy and transport identity.
+- Grant revocation runs on stop, crash, timeout, and parent-process death.
+- Tests cover hostile guest exfiltration attempts, destination mismatch, redirect chains, wrong SNI, plaintext HTTP, audit redaction, and crash cleanup.
+
+### SDK lifecycle
+
+Public claim allowed only when:
+
+- Python, TypeScript, and Rust SDKs expose the same core lifecycle surface.
+- SDK-created sandboxes are owned by the SDK process unless explicitly detached.
+- Parent death triggers sandbox cleanup or documented lease expiry.
+- The lifecycle surface works without importing or executing untrusted user code during static compilation.
+- Tests cover create, exec, filesystem read/write/list, logs, snapshot, stop, parent cleanup, and error redaction.
+
+### Cold-start
+
+Public claim allowed only when:
+
+- The harness records host, backend, kernel/rootfs digest, CPU model, memory, vCPU count, storage mode, and readiness signal.
+- Numbers are published as p50/p95/p99/max and identify the readiness boundary.
+- Fresh boot, guest-agent-ready boot, snapshot restore, and warm-pool claim are reported separately.
+- CI enforces regression budgets for representative artifacts.
+
+### Filesystem backends
+
+Public claim allowed only when:
+
+- The `VolumeBackend`/filesystem contract has conformance tests reused by every backend.
+- Docs distinguish mountable backends from API-only backends.
+- Encrypted backends encrypt content and names where promised.
+- Object-store backends define consistency, rename, partial-write, and health semantics.
+- Tests cover path traversal, symlink escape, concurrent writes, large files, deletion, rename, and audit.
+
+## Consequences
+
+### Positive
+
+- The project can make stronger developer-facing claims without weakening the existing operator/security story.
+- `mvmd` can expose product capabilities without forking runtime behavior.
+- Docs gain a safe vocabulary for features that are planned but not yet shipped.
+
+### Negative
+
+- OCI ingest and secret substitution increase attack surface and test burden.
+- The SDK lifecycle surface forces `mvm` to become more than a CLI.
+- Secret substitution requires a trusted egress path; it cannot be bolted onto unrestricted networking.
+
+## Non-goals
+
+- Docker or a Docker daemon as the production runtime.
+- Kubernetes or Compose compatibility.
+- Claiming sub-100ms cold boot before measured data supports it.
+- Claiming "secrets cannot leak" for legacy env/file injection flows.
+- Bypassing signed plans, audit, or verified artifact checks for developer ergonomics.
+
+## Implementation Plan
+
+Tracked in [`specs/plans/74-claim-safe-sandbox-parity.md`](../plans/74-claim-safe-sandbox-parity.md).

--- a/specs/adrs/049-secret-substitution-mechanism.md
+++ b/specs/adrs/049-secret-substitution-mechanism.md
@@ -1,0 +1,236 @@
+# ADR 049: TLS substitution mechanism for guest secret placeholders
+
+- Status: Proposed
+- Date: 2026-05-14
+- Owner: MVM Project
+- Related: ADR-002 (microVM security posture), ADR-004 (egress policy), ADR-041 (signed audited execution plans), ADR-048 (claim-safe sandbox parity), Plan 74 W2 + W3, Plan 74 §Risks R9
+
+## Context
+
+Plan 74 W3 makes the secret-non-leakage claim defensible: workloads
+receive an opaque `mvm-secret://<grant-id>` placeholder instead of
+the real secret value, and the host swaps the placeholder for the
+real value at egress time, only when destination policy passes.
+
+ADR-048 §"Secret non-leakage" gates the claim on
+"substitution is bound to destination policy and transport
+identity." Plan 74 W3 says "integrate substitution with the L7
+egress proxy after destination policy passes." Both are consistent
+with three architectural shapes, with very different trust
+footprints. Shipping W3 without picking turns the substitution
+code into ad-hoc PR-review architecture and risks one shape
+landing "temporarily" and never being revisited. This ADR picks.
+
+The three candidates:
+
+**(a) Proxy-with-CA.** Install an mvm-issued CA in the guest's
+trust store. The supervisor-owned L7 proxy terminates TLS,
+substitutes the placeholder in plaintext request bytes,
+re-encrypts to upstream with a fresh TLS session.
+
+**(b) Vsock side-channel.** The guest's SDK runtime library hooks
+the HTTP client's credential-loading step. At egress the hook
+calls a host-side substitution service over vsock, requesting a
+signed credential for the placeholder; the host validates
+destination policy and returns the credential; the hook injects
+it into the actual request. The guest's TLS stack is untouched;
+the proxy stays SNI-only.
+
+**(c) Host-side request reconstruction.** The guest issues
+plaintext HTTP through the proxy; the proxy substitutes in
+plaintext on the host and does the TLS handshake to upstream.
+
+## Decision
+
+**The default substitution mechanism is (b) vsock side-channel.**
+**(a) proxy-with-CA lands later as an explicit opt-in feature
+flag** for legacy workloads that cannot be modified. **(c) is
+rejected** as architecturally inadequate.
+
+### Substitution flow (b — default)
+
+1. Plan admission mints a `SecretPlaceholder` per grant: opaque
+   token, grant id, allowed destinations (host + path patterns),
+   expiry, signed under the host signer.
+2. The placeholder is delivered to the guest as env or argv —
+   `OPENAI_API_KEY=mvm-secret://01H9Q…XYZ`. The token is a ULID,
+   not a UUID, so it sorts and is cryptographically distinguishable
+   from any plausible plaintext secret.
+3. The guest's `mvm-sdk-runtime` library (one per Python, TS,
+   Rust) hooks the HTTP client's outbound request. At hook time it:
+   - Resolves the placeholder via `$MVM_SECRET_VSOCK_PORT`
+     (host-injected at boot).
+   - Sends a substitution request over vsock:
+     `(grant_id, target_url, method, scheme)`.
+   - Receives `Authorization: Bearer …` (or arbitrary
+     header/body fragment, per the placeholder's substitution
+     descriptor) signed by the supervisor.
+   - Injects into the outbound request and lets the guest's
+     normal TLS stack send it.
+4. The supervisor's substitution service, on each call:
+   - Verifies the grant id against the active-grants registry.
+   - Verifies the target URL matches the placeholder's allowed
+     destinations.
+   - Emits `secret.substitute.allow` or
+     `secret.substitute.deny` to the audit chain.
+   - Returns the materialized credential (or a structured
+     denial). The real secret value never leaves the supervisor.
+
+### Coverage matrix (b)
+
+| Language    | Library                | Hook point                                    |
+| ----------- | ---------------------- | --------------------------------------------- |
+| Python      | `requests`             | `Session.send` middleware                     |
+| Python      | `httpx`                | `Client.send` + `AsyncClient.send`            |
+| Python      | `aiohttp`              | `ClientSession._request`                      |
+| Python      | `urllib3` (direct)     | Pool manager `urlopen` wrapper                |
+| TypeScript  | global `fetch`         | Polyfill via `mvm-sdk-runtime` install hook   |
+| TypeScript  | `axios`                | `interceptors.request`                        |
+| TypeScript  | `node:http(s)`         | `request` patch in install hook               |
+| Rust        | `reqwest`              | `reqwest_middleware::Middleware`              |
+| Rust        | `hyper`                | `tower::Layer`                                |
+| Rust        | `tonic` (gRPC)         | `Interceptor`                                 |
+
+SDK-bundled clients (OpenAI Python, Anthropic JS, etc.) inherit
+their underlying HTTP-library hook. The `mvm-sdk-runtime` package
+exposes a `register_substitution_handler(name, fn)` for SDKs that
+inject credentials in non-standard places (e.g. AWS SigV4, which
+signs the request body — the handler intercepts at signature time,
+not at header injection).
+
+### Non-HTTP egress
+
+Out of scope for v1 substitution. SSH, raw TCP, DB protocols
+(PostgreSQL/MySQL wire), mTLS APIs see no substitution by default.
+Two paths offered:
+
+- **L4 deny.** Plan 74 W2's deny-by-default policy keeps non-HTTP
+  egress closed. Workloads that need DB or SSH egress declare a
+  destination policy explicitly; secrets for those destinations
+  flow via in-image config bound by `unsafe_guest_secret_materialization`
+  (ADR-048 documents this as "not a non-leakage claim").
+- **Future ADR.** Non-HTTP substitution can land later via a
+  per-protocol hook contract; the vsock service is protocol-agnostic.
+
+### Legacy opt-in (a — proxy-with-CA, behind feature flag)
+
+For workloads that cannot be modified (vendored binaries, third-party
+agents, customer-provided rootfs), provide an opt-in feature flag
+`unsafe_guest_tls_inspection`:
+
+- Per-workload CA issued at admission; CA private key never leaves
+  the supervisor.
+- CA cert installed in guest's trust store at boot via the existing
+  `/etc/ssl/certs/` overlay path.
+- The L7 proxy terminates TLS, runs the substitution, re-encrypts.
+- CA cert is revoked at workload stop; subsequent workloads get a
+  fresh CA.
+
+The flag's name is deliberately load-bearing: it expands the trust
+boundary, and the docs page for the status row carries the
+expansion as an explicit caveat. The `cargo xtask check-doc-claims`
+lint W0 builds will not allow "secrets cannot leak" on any page
+that enables this flag without also marking it Preview, not
+Shipped, for that workload class.
+
+### Rejected: (c) host-side reconstruction
+
+Breaks the modal egress destination — every SaaS API mvm users
+care about (OpenAI, Anthropic, Stripe, AWS, GitHub) requires
+HTTPS. Plaintext-through-proxy is only viable for internal CIDR
+egress, which is rarely secret-bearing in practice. The complexity
+of running both (c) for plaintext + (b) for HTTPS would exceed the
+complexity of just shipping (b) for everything.
+
+## Consequences
+
+### Positive
+
+- No expansion of the host trust boundary. The supervisor's
+  responsibilities grow (substitution service, grant registry) but
+  the **guest's** trust store is unchanged. ADR-002's threat model
+  holds without revision.
+- Protocol-agnostic. HTTP/1.1, HTTP/2, HTTP/3, gRPC, mTLS — the
+  guest emits a request shape the proxy already supports; the
+  substitution happens before TLS, not inside it.
+- Auditable. Every substitution is an explicit vsock RPC; every
+  call emits an audit-chain entry naming the grant, destination,
+  and outcome.
+- Cold-start friendly. One vsock round-trip + Ed25519-sign per
+  egress; well under the boot budget being negotiated in W5.
+- Tractable hostile-guest tests. The threat model is "guest
+  attempts to extract the real secret value." Vsock substitution
+  never returns the raw value, only a signed credential bound to
+  a destination — the guest cannot replay it elsewhere.
+
+### Negative
+
+- **Library coverage burden.** Each HTTP-library hook is small
+  (~30-100 LoC), but the matrix is broad. SaaS SDKs that bake
+  custom auth (AWS SigV4, GCP IAP) need explicit handlers.
+- **Opt-out by raw socket.** A guest can ignore `mvm-sdk-runtime`
+  and call socket(2) directly. Acceptable: the user's SDK choice
+  is their own attack surface. The host still enforces L4
+  destination policy (W2) and audits the connection.
+- **Two paths to maintain.** (b) default plus (a) feature flag is
+  more code than (a) alone. Mitigated by the flag being explicit
+  and the (a) path being a thin alternative — both share the
+  destination-policy enforcer and the audit emitter.
+
+## Non-goals
+
+- Replacing the guest's HTTP stack. The library hooks are
+  cooperative; the guest opts in by importing `mvm-sdk-runtime`
+  (which the SDK installs by default in built images).
+- Substitution into binary protocols (gRPC body fields, mTLS
+  client auth, custom binary wire) in v1. Future ADR.
+- Generic TLS interception for non-secret purposes (e.g. DLP,
+  content scanning). The substitution service is bound to grant
+  semantics; broader inspection requires (a) and a separate ADR.
+- Claiming non-leakage for the legacy `unsafe_guest_secret_materialization`
+  env/file flow. ADR-048 §"Non-goals" already forbids this.
+
+## Open questions
+
+- **AWS SigV4-shaped auth.** SigV4 signs the request body after
+  building it. The substitution must happen *before* SigV4 signs.
+  The `mvm-sdk-runtime` AWS shim hooks `boto3`/`aws-sdk-js` at
+  credential-loading rather than at request-send. Coverage TBD
+  for the full AWS service surface.
+- **WebSocket auth.** Most use a connect-time `Authorization`
+  header that fits cleanly into the substitution model. Some use
+  post-connect token messages; those need protocol-specific
+  hooks.
+- **Long-running connections that outlive grants.** A grant with
+  a 1h expiry on a 24h workload: the guest re-requests
+  substitution at re-connect time and gets a fresh credential.
+  The placeholder-token-to-grant mapping is many-to-one across
+  the workload lifetime.
+
+## Implementation Plan
+
+Tracked in [`specs/plans/74-claim-safe-sandbox-parity.md`](../plans/74-claim-safe-sandbox-parity.md)
+§W3. Plan 74 §Risks R9 closes when this ADR ships and W3 task
+list adopts the vsock substitution mechanism.
+
+W3 task additions on top of plan 74 as-written:
+
+- Vsock substitution service in `crates/mvm-supervisor/src/secrets/substitute.rs`.
+- `mvm-sdk-runtime` Python package with hooks for `requests`,
+  `httpx`, `aiohttp`.
+- `mvm-sdk-runtime` TypeScript package with `fetch` polyfill +
+  `axios` interceptor.
+- `mvm-sdk-runtime` Rust crate with `reqwest::Middleware` + `hyper::Service` shim.
+- Hostile-guest tests:
+  - Raw socket bypass attempt → L4 policy denies + audits.
+  - Substitution replay attempt (re-use signed credential on a
+    different destination) → upstream rejects + audits.
+  - Library bypass attempt (`socket.send` directly with the
+    placeholder string) → string egresses unchanged but does not
+    authenticate anywhere.
+- W3 status row on the public sandbox-parity page flips to
+  Preview when the Rust core ships, Shipped when the three SDK
+  bindings + hostile-guest tests run in CI.
+
+The legacy `unsafe_guest_tls_inspection` opt-in (a) is a
+separate, later workstream — not part of W3 v1.

--- a/specs/adrs/050-oci-image-verity-posture.md
+++ b/specs/adrs/050-oci-image-verity-posture.md
@@ -1,0 +1,220 @@
+# ADR 050: Verity posture for pulled OCI images
+
+- Status: Proposed
+- Date: 2026-05-14
+- Owner: MVM Project
+- Related: ADR-002 (microVM security posture, claim 3), ADR-013 (image acquisition), ADR-046 (builder VM via libkrun), ADR-048 (claim-safe sandbox parity), Plan 74 W1, Plan 74 §Risks R3, mvmd ADR-0020 (OCI images as microVM workloads)
+
+## Context
+
+Plan 74 W1 adds `mvmctl image pull <ref>` so users can launch
+arbitrary OCI images in microVMs without a host Docker daemon.
+The pull path materializes an OCI image to an ext4 rootfs and
+registers it as a first-class template.
+
+The project's existing claim 3
+([`CLAUDE.md` "Security model"](../../CLAUDE.md))
+is **"a tampered rootfs ext4 fails to boot,"** enforced by:
+
+- `nix/flake.nix::verityArtifacts` — runs `veritysetup format`
+  deterministically against the rootfs, emits `rootfs.verity`
+  sidecar + `rootfs.roothash`.
+- `mvm-verity-init` initramfs — built once, reused per image, runs
+  as PID 1, mounts dm-verity over the rootfs, panics on
+  block-level tamper.
+- `mvm.roothash=<hex>` on the kernel cmdline, passed by every
+  backend's `start_with_verity` path.
+- `probe_verity_sidecar` (`crates/mvm-backend/src/microvm.rs`)
+  conditionally attaches the sidecar at `/dev/vdb` and the
+  initramfs as `initrd`.
+
+Today every production launch goes through this path because every
+production image is Nix-built. OCI input is arbitrary — the user
+supplies a registry reference, mvm pulls layers, unpacks to ext4,
+and launches. Without further policy, claim 3 silently weakens: a
+pulled image may have no verity sidecar at all, and
+`probe_verity_sidecar` returns `(None, None)` instead of panicking.
+
+Two architectural options for keeping (or relaxing) claim 3 under
+OCI ingest:
+
+**Option A — Pull-time verity generation.** Every pulled image gets
+a sidecar + roothash generated at pull time. Claim 3 remains
+unchanged: every production launch carries verity.
+
+**Option B — Documented carve-out.** Pulled images live in an
+"unverified" template lane. Claim 3 narrows to
+"Nix-built and prebuilt images." Audit chain (claim 8) is offered
+as the integrity story for pulled images.
+
+This ADR picks before W1 codes.
+
+## Decision
+
+**Option A — pull-time verity generation, by default, in the
+production profile.** A `--no-verity` opt-out is available in the
+dev profile only. Production-profile admission rejects images
+without a verity sidecar.
+
+### Generation flow
+
+1. `mvmctl image pull <ref>` runs inside the libkrun builder VM
+   (Plan 72 default). The builder VM has `veritysetup` available
+   as part of its base closure — adding it costs a single
+   `cryptsetup` dependency that's already transitively needed for
+   `nix/flake.nix::verityArtifacts`.
+2. After layer unpack produces `rootfs.ext4`:
+   - Run `veritysetup format --data-block-size=4096
+     --hash-block-size=4096 rootfs.ext4 rootfs.verity` and capture
+     the roothash.
+   - Write `rootfs.roothash` next to the rootfs in the template
+     directory, same shape as Nix-built templates.
+3. `probe_verity_sidecar` already detects the pair; no plumbing
+   change in `mvm-backend`.
+4. Template registry records `(requested_ref, resolved_digest,
+   source_registry, cache_scope, verity_roothash)`. The roothash
+   becomes a content-addressable identifier — re-pulling the same
+   digest hits the verity cache.
+
+### Caching
+
+Layer fetch is already content-addressed by digest. Verity
+generation is deterministic with pinned block sizes and pinned
+zero salt. Cache key: `sha256(layer-digests-sorted)`. Cache hit
+skips both the unpack and the verity generation. Cache lives
+under `~/.cache/mvm/oci/verity-by-digest/<digest>.{verity,roothash}`,
+mode 0700 directory per claim W1.5.
+
+### Production-profile admission
+
+Plan 74 W1 already specs production-profile mutable-tag rejection
+(`policy::profile::production` rejects `image pull` with a tag,
+allows only digest pins). This ADR adds a parallel rule:
+
+- Production profile rejects `oci.launch` for any template whose
+  registry entry lacks `verity_roothash`.
+- The `--no-verity` flag is silently dropped in production
+  profile with an admission-time error citing this ADR.
+
+### Dev-profile escape
+
+`mvmctl image pull --no-verity <ref>` skips verity generation in
+the dev profile only. Documented as "faster first pull;
+boot-time tamper detection unavailable for this template." The
+public sandbox-parity status page's `oci-ingest` row names this as
+a Preview-state limitation while W1 stabilizes.
+
+### Why not Option B (carve-out)
+
+Audit chain (claim 8) proves **provenance** — the image came from
+the named registry at the named digest, the launch was admitted by
+the host signer. Verity (claim 3) proves **integrity at boot** —
+the bytes on disk match the cryptographic hash that was good
+yesterday. These cover different threats:
+
+| Threat                                              | Audit catches? | Verity catches? |
+| --------------------------------------------------- | -------------- | --------------- |
+| Wrong image (bad provenance)                        | Yes            | No              |
+| On-disk corruption (cosmic ray / FS bug)            | No             | Yes             |
+| Local-host tamper after pull                        | No             | Yes             |
+| Concurrent shared-cache poisoning                   | No             | Yes             |
+| Supply-chain tamper in the registry                 | Partial (digest pinning) | Yes (after first good pull) |
+
+Option B leaves four of the five rows uncovered. Conflating
+"audit covers it" with "verity covers it" produces a two-tier
+trust story that's hard to message and easy for users to misread.
+ADR-048 §"Non-goals" already forbids
+"bypassing verified artifact checks for developer ergonomics" —
+Option B is on the spectrum of that.
+
+## Consequences
+
+### Positive
+
+- Claim 3 invariant unchanged. One boot path, one trust story,
+  one production-profile admission gate.
+- The `probe_verity_sidecar` code path is exercised by every
+  launch — no "is this path even tested in prod?" risk.
+- Verity cache is content-addressable, so the cost amortizes
+  across pulls of the same digest. Layer reuse already gives us
+  this for image content; the verity cache extends it.
+
+### Negative
+
+- **First pull is slower.** `veritysetup format` against a 200 MB
+  rootfs runs in a few seconds; for very large images (1+ GB)
+  it can reach tens of seconds. Mitigated by per-digest caching
+  and by the libkrun builder VM doing the work off the main
+  thread (Plan 72 default).
+- **`veritysetup` becomes a builder-VM closure dep.** Already
+  transitively present via `cryptsetup` (used by
+  `verityArtifacts`); adding it explicitly increases the builder
+  VM's Stage 0 closure marginally. Per the active builder-VM
+  cost discussion, every new `rustPlatform.buildRustPackage`
+  doubles transient sandbox cost — `veritysetup` is C, not Rust,
+  so it pays once and doesn't compound.
+- **Verity-cache invalidation has to be airtight.** A stale
+  sidecar paired with a rebuilt rootfs is a verity panic at
+  boot. Cache key includes the layer-digest set; layer-digest
+  collision is cryptographically impossible.
+
+## Non-goals
+
+- Verity on `--add-dir` writable mounts. Those are explicitly
+  mutable (claim W6); `dm-verity` is not the right tool.
+- Verity on snapshot upper layers. Snapshots are HMAC-sealed with
+  a monotonic-epoch replay-store (claim 8 / instance pause+resume
+  semantics); different mechanism, different trust story.
+- Online verity regeneration for in-flight images (e.g. mutating
+  a pulled rootfs on the host before launch). The pull-and-seal
+  contract is immutable: any modification requires a new pull or
+  a snapshot.
+- Verifying the OCI manifest's own digest as part of claim 3.
+  That's claim-8-territory (signed audit of the resolve event).
+
+## Open questions
+
+- **`veritysetup` versioning.** Sidecar format is stable across
+  recent `cryptsetup` releases, but pin the version in the
+  builder-VM flake to avoid silent regeneration drift across
+  builds.
+- **Image-size DoS at pull time.** A malicious registry could
+  serve a 100 GB manifest. Layer-size + total-rootfs caps belong
+  in Plan 74 W1's R10 (OCI layer unpack attack surface)
+  mitigation, not this ADR; they bound the verity-generation cost
+  upstream.
+
+## Implementation Plan
+
+Tracked in [`specs/plans/74-claim-safe-sandbox-parity.md`](../plans/74-claim-safe-sandbox-parity.md)
+§W1. Plan 74 §Risks R3 closes when this ADR ships and W1's task
+list adopts pull-time verity by default.
+
+W1 task additions on top of plan 74 as-written:
+
+- `veritysetup` pinned in the builder-VM flake closure
+  (`nix/images/builder-vm/flake.nix`).
+- `crates/mvm-build/src/oci_to_rootfs.rs::generate_verity` —
+  runs `veritysetup format` after ext4 emission, parses roothash
+  from stdout, writes both files to the template directory.
+- Verity-cache directory layout under
+  `~/.cache/mvm/oci/verity-by-digest/`, mode 0700.
+- `mvm-policy::profile::production` admission rule rejecting
+  `oci.launch` when `template.verity_roothash.is_none()`.
+- `--no-verity` dev-profile-only CLI flag with admission-time
+  rejection in production profile, citing this ADR.
+- Tests:
+  - **Positive path.** Pull `alpine:3.19` (digest-pinned), launch
+    via `mvmctl up --image`, verify dm-verity panics on a
+    flipped data block in the rootfs (same regression shape as
+    Plan 27 W3 §runbook step 4).
+  - **Cache hit.** Re-pull the same digest, assert no
+    `veritysetup` invocation.
+  - **Production admission.** `MVM_PRODUCTION=1 mvmctl image
+    pull --no-verity` exits non-zero with the documented error.
+  - **Sidecar tamper.** Manually corrupt `rootfs.verity` between
+    pull and launch; assert kernel panics before userspace.
+
+The `oci-ingest` row on the public sandbox-parity page records
+the verity posture in the per-claim "what would move it to
+Shipped" note.

--- a/specs/adrs/051-mvm-runtime-overlay-disk.md
+++ b/specs/adrs/051-mvm-runtime-overlay-disk.md
@@ -1,0 +1,301 @@
+# ADR 051: Mvm runtime overlay disk
+
+- Status: Proposed
+- Date: 2026-05-14
+- Owner: MVM Project
+- Related: ADR-002 (microVM security posture, claims 2 + 3 + 4), ADR-046 (builder VM via libkrun), ADR-048 (claim-safe sandbox parity), ADR-049 (TLS substitution mechanism), ADR-050 (verity posture for pulled OCI images), Plan 74 W1 + W3 + W4
+
+## Context
+
+Plan 74 W1 lets users launch arbitrary OCI images in microVMs. An
+OCI image's rootfs is **user content**: bytes the user pulled from
+a registry, pinned by a content digest the user controls. mvm
+needs the *guest agent*, the *seccomp shim*, and the per-language
+*SDK runtime library* (ADR-049 vsock substitution hooks) present
+in every microVM regardless of how that rootfs got there.
+
+Today mvm-built images bake the agent in:
+`nix/lib/mk-guest.nix` adds `mvm-guest-agent` to the closure,
+`mvm-seccomp-apply` is invoked from the systemd-style service
+launch line, and image-builders bring their own SDK runtime by
+including it in their flake. None of that machinery applies to a
+pulled `alpine:3.19` or `python:3.12`.
+
+Two ways to fix it:
+
+**Option A — Inject into the OCI rootfs at unpack time.** Layer
+unpack (W1.3) writes the agent + SDK runtime into the rootfs
+between the last OCI layer and the verity seal. Pros: the rootfs
+"just works" — every binary inside the guest can find the agent
+without env tweaks. Cons: the digest of the rootfs no longer
+matches the OCI image's digest (we mutated it), so the
+content-addressable identity is lost. Every layer-unpack PR has
+to special-case the "post-OCI, pre-verity" injection point.
+Conflates user content with mvm content in one ext4 blob.
+
+**Option B — A separate verity-sealed disk attached at boot.** mvm
+builds a small ext4 containing the agent + SDK runtime, verity-
+seals it the same way it seals rootfs, and attaches it as a
+second virtio-blk device at every microVM start. The OCI rootfs
+is left byte-for-byte identical to what the registry served.
+Both Nix-built and OCI-pulled images get the same agent story.
+
+This ADR picks Option B and makes it the default for *every*
+microVM, not just OCI-pulled ones. Unifying the agent story is
+the most valuable side-effect — it eliminates the "where is the
+agent today vs. where will it live tomorrow" split that would
+otherwise haunt W1 and every future image factory.
+
+## Decision
+
+**Every mvm microVM boots with two block devices: a rootfs
+(`/dev/vda`, user content, ext4) and an mvm-runtime overlay
+(`/dev/vdc`, mvm content, ext4). Both are verity-sealed; both
+roothashes appear on the kernel cmdline; mvm-verity-init
+validates both before pivot_root.** The overlay is mounted
+read-only at `/mvm/runtime` inside the guest. Service launches
+inject the language-specific path env vars (`PYTHONPATH`,
+`NODE_PATH`, …) before forking the workload.
+
+### Overlay contents (per-arch, ~10-20 MB)
+
+```text
+/mvm/runtime/
+├── agent                       (mvm-guest-agent, statically linked,
+│                                uid 901)
+├── seccomp-apply               (mvm-seccomp-apply shim)
+├── runner                      (mvm-runner, function-workload runtime)
+├── sdk-py/                     (mvm-sdk-runtime Python wheel +
+│                                deps; importable via PYTHONPATH)
+├── sdk-ts/                     (mvm-sdk-runtime npm package +
+│                                deps; importable via NODE_PATH)
+├── certs/                      (CA bundle for outbound TLS from
+│                                the agent itself; user TLS uses
+│                                the rootfs's trust store)
+└── VERSION                     (semver matching the mvm release
+                                 that produced this overlay)
+```
+
+The overlay does NOT contain a shell, libc, or anything a
+workload could `execve`. It is a *data* disk plus three mvm-
+controlled binaries. The shell + libc that workloads use live in
+the rootfs — Nix-built or OCI-pulled, the user's choice.
+
+### Boot path
+
+1. Firecracker starts the kernel with the verity initramfs as
+   PID 1, and the cmdline:
+   ```text
+   root=/dev/mapper/root
+   mvm.roothash=<rootfs-roothash>
+   mvm.runtime_roothash=<overlay-roothash>
+   ```
+2. `mvm-verity-init` constructs `/dev/mapper/root` over `/dev/vda`
+   + `/dev/vdb` (existing rootfs verity sidecar), and
+   `/dev/mapper/runtime` over `/dev/vdc` + `/dev/vdd` (overlay
+   verity sidecar). Either roothash panics on tamper.
+3. Mount `/dev/mapper/root` at `/sysroot`.
+4. Mount `/dev/mapper/runtime` at `/sysroot/mvm/runtime` (ro,
+   bind-mount the verity device over the rootfs's `/mvm/runtime`
+   directory; `/mvm` is reserved per the path-collision rule
+   below).
+5. pivot_root to `/sysroot`.
+6. Exec `/mvm/runtime/agent` as PID 1 of userspace, which spawns
+   the service supervisor.
+
+Service supervisor injects per-service env vars (PYTHONPATH /
+NODE_PATH / …) before forking the workload's entrypoint.
+
+### Verity story
+
+Identical to rootfs verity:
+
+- Deterministic `veritysetup format` with pinned block sizes and
+  pinned salt (same parameters as `nix/flake.nix::verityArtifacts`).
+- Sidecar emitted alongside the overlay ext4 as part of the
+  release artifacts: `runtime-overlay-{arch}-{version}.ext4`,
+  `.verity`, `.roothash`.
+- mvmctl picks the overlay whose `VERSION` matches the running
+  `mvmctl` semver. Mismatched versions are an admission-time
+  error, not a silent boot.
+
+### Path reservation
+
+`/mvm/` is reserved. An OCI image that ships content at `/mvm`
+collides with the mount point. Admission-time check rejects such
+images with a clear error: `error: OCI image carries content at
+/mvm — this path is reserved for the mvm runtime overlay`. Easy
+to surface in W1.3 layer unpack: walk the layer tarballs once,
+fail if any entry starts with `/mvm/` (any directory or file).
+
+### Refactor consequences for `mkGuest`
+
+`nix/lib/mk-guest.nix` stops baking `mvm-guest-agent`,
+`mvm-seccomp-apply`, and `mvm-runner` into the per-image closure.
+Those binaries come from the overlay at boot. Net effect:
+
+- mvm-built rootfs gets smaller (~10-15 MB drop, since the agent
+  and runner aren't duplicated per image).
+- One code path for "where does the agent live" across Nix-built
+  and OCI-pulled. Easier to reason about, easier to test, easier
+  to ship a security fix to (single overlay rebuild, not N
+  per-image flake bumps).
+- A microVM running an old mvmctl with an old overlay still boots
+  — the agent's vsock protocol is versioned (ADR-002 §W4.1 with
+  `#[serde(deny_unknown_fields)]`), so a newer host talking to an
+  older guest agent fails admission cleanly rather than silently
+  misbehaving.
+
+This is a one-time refactor of `mkGuest` (estimated 1-3 days). It
+lands inside plan 74 W1 because that's the workstream that forces
+the issue.
+
+## Consequences
+
+### Positive
+
+- OCI rootfs stays byte-for-byte identical to the registry
+  content. Digest pins hold; reproducibility for the OCI half of
+  the story is the registry's reproducibility, full stop.
+- Mvm controls its own runtime story in one place. A CVE in the
+  guest agent ships one fix (rebuild the overlay, bump the
+  roothash, push the artifact) rather than N flake bumps.
+- The SDK runtime library (per-language, ADR-049 vsock hooks)
+  has a stable mount point. SDK upgrades become "rebuild the
+  overlay"; no per-image work.
+- Verity claim 3 is *strengthened*: a tampered overlay panics
+  the kernel just like a tampered rootfs would. Two roothashes,
+  both load-bearing.
+- Snapshot/fork (claim 8 / instance pause+resume) is unaffected.
+  The overlay is read-only and content-addressed; it's not in
+  the snapshot delta.
+
+### Negative
+
+- A second block device per microVM. Firecracker and libkrun
+  both support N drives, well under any practical cap, so no
+  hard limit issue. Verify Apple Container backend's drive count
+  (W3 verity shipped 2026-04-30 with two drives already; three
+  is on the edge of what's tested).
+- An additional release artifact per arch
+  (`runtime-overlay-{arch}.ext4` + `.verity` + `.roothash`).
+  Adds ~10-20 MB per arch to the release payload.
+- `/mvm` path reservation is a contract with users. Documented
+  on the public `oci-ingest` status row; admission-time check
+  for OCI images.
+- `mkGuest` refactor is real surface area — every existing
+  Nix-built image rebuilds when the overlay-vs-baked split
+  lands. One-time cost.
+
+## Non-goals
+
+- **User-supplied overlays.** v1 ships one mvm-controlled
+  overlay per arch. Custom overlays (e.g. a vendor-supplied
+  language-specific SDK pack) can be a future ADR; out of scope
+  here.
+- **Writable overlay.** The overlay is read-only and
+  verity-sealed. Workloads that need writable shared state use
+  `--add-dir`, volumes, or the snapshot upper layer — those have
+  their own contracts.
+- **Replacing initramfs.** `mvm-verity-init` stays in the
+  initramfs blob, not in the overlay. The initramfs needs to run
+  before any disk is mounted; chicken-and-egg.
+- **Multi-version coexistence on one host.** Each running mvmctl
+  uses one overlay version. Snapshot restore across mvmctl
+  versions is governed by the existing snapshot epoch contract,
+  not by the overlay.
+- **Embedded language interpreters.** The overlay does not ship
+  Python, Node, or any other interpreter. Those come from the
+  user's rootfs (Nix-built or OCI-pulled). The overlay's
+  `sdk-py/` is the *library*; the interpreter is the user's
+  responsibility.
+
+## Open questions
+
+- **Versioning policy for the overlay.** Mvm semver bumps roll
+  the overlay too. Should the overlay carry a *separate* semver
+  for backward-compat windows ("any agent v2.x speaks to any
+  host v2.y for y >= x")? Probably yes; the vsock protocol
+  already has this shape (`#[serde(deny_unknown_fields)]` +
+  versioned envelope per ADR-002 W4.1). Pin the policy in the
+  W1.3 implementation PR.
+- **Overlay size budget.** ~10-20 MB is the rough target. Hard
+  cap of 32 MB is reasonable; bump only with an ADR amendment.
+  Constrains future SDK additions: if Python + TS + Rust SDKs
+  combined exceed 32 MB, we either trim, split overlays per
+  language, or amend.
+- **Apple Container backend with three drives.** Verified-boot
+  shipped 2026-04-30 with two drives (rootfs + verity sidecar);
+  adding the overlay makes three. Confirm
+  `setInitialRamdiskURL` + three virtio-blk devices is supported
+  on the macOS path before flipping the overlay to default.
+- **Bootloader path for cross-arch.** Firecracker handles the
+  drives identically on aarch64 and x86_64, but the kernel
+  cmdline parameters differ in subtle ways. The overlay's
+  `mvm.runtime_roothash=` parameter needs the same cmdline shape
+  the existing `mvm.roothash=` uses, on every backend.
+
+## Implementation Plan
+
+Tracked in [`specs/plans/74-claim-safe-sandbox-parity.md`](../plans/74-claim-safe-sandbox-parity.md)
+§W1.3 (layer unpack — needs the `/mvm` collision check) and §W1.4
+(verity generation — extends to also generate the overlay).
+ADR-051's task list folds into W1 as:
+
+- `nix/images/runtime-overlay/flake.nix` — new flake building the
+  per-arch overlay ext4 + verity sidecar + roothash.
+  Deterministic; pinned `cryptsetup` per #223.
+- `mvm-build/src/runtime_overlay.rs` — host-side path resolver
+  that picks the right overlay artifact for the running mvmctl
+  version. Cached under `~/.cache/mvm/runtime-overlay/<version>/`.
+- `mvm-backend` — attach the overlay drive + sidecar at every
+  microVM start; thread `mvm.runtime_roothash=<hex>` into the
+  cmdline alongside the existing `mvm.roothash=`.
+- `crates/mvm-guest/src/bin/mvm-verity-init.rs` — extend to
+  construct the second dm-verity target and bind-mount it at
+  `/mvm/runtime`. Add `mvm.runtime_roothash=` to the cmdline
+  parser; absence is an admission-time error.
+- `nix/lib/mk-guest.nix` — drop `mvm-guest-agent`,
+  `mvm-seccomp-apply`, `mvm-runner` from the per-image closure.
+  Add a build-time check that the rootfs does not contain
+  `/mvm`.
+- `mvm-build/src/oci_to_rootfs.rs` (W1.3) — walk OCI layers
+  before unpack; fail if any entry starts with `/mvm/`.
+- Service supervisor — inject `PYTHONPATH=/mvm/runtime/sdk-py:...`
+  and `NODE_PATH=/mvm/runtime/sdk-ts:...` per service.
+- Release pipeline — emit the overlay artifact alongside the
+  existing per-arch kernel + dev image + default microvm image
+  artifacts.
+
+W1 plan workstream additions:
+
+| Task                                                | Lives in W1 sub-PR |
+| --------------------------------------------------- | ------------------ |
+| Build the overlay flake                             | W1.3 prep          |
+| Attach the overlay at boot                          | W1.4 (alongside verity wiring) |
+| `mkGuest` refactor + per-image closure shrink       | W1.4               |
+| `/mvm` collision check on OCI unpack                | W1.3               |
+| Apple Container three-drive verification             | W1.4               |
+
+### Tests
+
+- **Positive boot.** Cold-boot an mvm-built image + the overlay;
+  agent comes up at uid 901; `/mvm/runtime/sdk-py/` is importable
+  from a Python service.
+- **Tamper test.** Flip a byte in the overlay ext4 between
+  mvmctl pull and microvm start; assert kernel panics with the
+  expected verity message, agent never starts.
+- **Path collision test.** Construct an OCI manifest whose layer
+  ships `/mvm/foo`; assert admission-time rejection with the
+  documented error.
+- **Version mismatch.** Manually point mvmctl at an overlay
+  produced by a different mvmctl version; assert
+  admission-time error.
+- **Snapshot restore.** Snapshot a running microvm, restore on
+  the same host; assert the overlay is re-attached with the same
+  roothash and verity holds.
+- **Apple Container.** Same set against the macOS backend.
+
+The overlay becomes a first-class CI artifact gated by the same
+deterministic-build checks the kernel and dev image already get
+(claim 7 — Cargo deps audited + reproducibility double-build).

--- a/specs/claims/claim-10-oci-image-provenance.md
+++ b/specs/claims/claim-10-oci-image-provenance.md
@@ -18,6 +18,8 @@ exempt_paths:
   - ".github/**"
   - "memory/**"
   - "public/src/content/docs/contributing/adr/**"
+  - "public/src/content/docs/security/sandbox-parity-status.md"
+  - "xtask/src/check_doc_claims.rs"
 ---
 
 # Claim 10 — OCI image provenance is recorded in the admission audit chain

--- a/specs/gap-analysis-vs-libkrun.md
+++ b/specs/gap-analysis-vs-libkrun.md
@@ -32,11 +32,11 @@ CLI is Docker-shaped: `msb run|start|stop|rm|ls|ps|inspect|logs|metrics` plus a 
 |---|---|---|---|
 | Sub-100ms cold boot | Claimed | Not measured / not advertised | **Gap** |
 | Daemonless runtime | Yes (child of SDK process) | Mostly (CLI-spawned FC, optional supervisor) | Parity-ish |
-| OCI image as primary rootfs source | Yes (Docker Hub, GHCR, ECR, GCR) | Round-trip only — Nix flake → `dockerTools.streamLayeredImage` → OCI tar → `docker load` (`crates/mvm-backend/src/docker.rs:3-5`). No upstream `docker pull <image>` ingest; no `fn pull` anywhere in the workspace. | **Partial — round-trip yes, upstream pull no** |
+| OCI image as primary rootfs source | Yes (Docker Hub, GHCR, ECR, GCR) | Round-trip only — Nix flake → `dockerTools.streamLayeredImage` → OCI tar → `docker load` (`crates/mvm-backend/src/docker.rs:3-5`). No upstream `docker pull <image>` ingest. Upstream-pull ingest tracked as plan 74 W1; cross-repo handoff to mvmd via mvmd ADR-0020 (OCI images as microVM workloads). | **Partial — round-trip yes, upstream pull planned** |
 | Nix-built reproducible rootfs | No | Yes (catalog, flakes, Mvmfile) | **Lead** |
-| Python SDK | Yes | Not in `crates/` today. Planned in plan 60 Phase 5 as `python/` (pyo3-bound). ~7-10 day estimate, not started. | **Gap (planned)** |
-| TypeScript SDK | Yes | Not in `crates/` today. Planned in plan 60 Phase 5 as `typescript/` (napi-rs). Not started. | **Gap (planned)** |
-| Rust SDK | Yes (`libkrun` crate) | Not in `crates/` today. `mvm-sdk` existed in the previous iteration (`../mvm`) and as `mvmforge-sdk` in `../mvmforge`. Plan 60 Phase 5 ports it back as `crates/mvm-sdk/` + `mvm-sdk-macros` + `mvm-sdk-addon`. | **Gap (planned, port available)** |
+| Python SDK | Yes | Build-time decorator surface ships in `crates/mvm-sdk` (declarations + IR emission); runtime lifecycle surface (`create` / run / `snapshot` / `stop`) tracked as plan 74 W4. pyo3 binding planned. | **Partial (decorator yes, runtime lifecycle planned)** |
+| TypeScript SDK | Yes | Build-time decorator surface ships via the Rust core in `crates/mvm-sdk`; runtime lifecycle surface tracked as plan 74 W4. napi-rs binding planned. | **Partial (decorator yes, runtime lifecycle planned)** |
+| Rust SDK | Yes (`libkrun` crate) | Build-time SDK ships as `crates/mvm-sdk` + `crates/mvm-sdk-macros` (ported from the previous `mvmforge-sdk` per [migration guide](../public/src/content/docs/guides/mvmforge-migration.md)). Runtime lifecycle surface tracked as plan 74 W4. | **Partial (build-time yes, lifecycle planned)** |
 | Snapshots (capture writable layer, restart) | Yes (`msb snapshot create`) | Yes — instance pause/resume with HMAC + replay-store seal | **Lead** (stronger) |
 | Templates (pre-baked rootfs) | Implicit via image layers | Yes, first-class (`template build/list/...`) | **Lead** |
 | Volumes (named, persistent) | Yes (`volume create/ls/rm`) | virtio-fs mounts via `vm volume`, no named-volume CRUD | Partial |

--- a/specs/plans/74-claim-safe-sandbox-parity.md
+++ b/specs/plans/74-claim-safe-sandbox-parity.md
@@ -229,12 +229,11 @@ claim 3 silently.
   `image pull`-sourced templates. Audit chain (claim 8) still covers
   provenance.
 
-**Mitigation owner.** W1 lead picks A or B before code lands; the
-choice goes in the W1 ADR and the public status page row for
-oci-ingest names the verity posture. ADR-048 §"Non-goals" already
-forbids "bypassing verified artifact checks for developer
-ergonomics" — Option B is compatible with that *only if* the
-exclusion is explicit, not implicit.
+**Mitigation owner.** Resolved by [ADR-050](../adrs/050-oci-image-verity-posture.md):
+pull-time verity generation by default; `--no-verity` is
+dev-profile-only; production-profile admission rejects pulled
+templates without a verity sidecar. ADR-050 §Implementation Plan
+adds the concrete task list onto W1.
 
 ### R4 — Audit volume without backpressure (W2)
 
@@ -368,12 +367,13 @@ code into ad-hoc PR-review architecture. Worse: an (a)-style CA
 installation can land "temporarily" and never get reverted, expanding
 the trust footprint of every guest without an explicit decision.
 
-**Mitigation owner.** Pick the substitution mechanism before W2
-codes the proxy — it shapes the proxy. **R9 deserves its own ADR**;
-fold the decision in alongside W2's egress design. ADR-048 §"Non-
-goals" forbids "claiming secrets cannot leak for legacy env/file
-injection flows" — that posture is consistent with (b) being the
-default and (a) being an explicit, named opt-in.
+**Mitigation owner.** Resolved by [ADR-049](../adrs/049-secret-substitution-mechanism.md):
+default substitution is the vsock side-channel (b); (a)
+proxy-with-CA lands later behind `unsafe_guest_tls_inspection`
+for legacy workloads only; (c) host-side reconstruction is
+rejected. ADR-049 §Implementation Plan extends W3's task list
+with the vsock substitution service, per-language SDK runtime
+hooks, and hostile-guest tests.
 
 ### R10 — OCI layer unpack attack surface (W1)
 

--- a/specs/plans/74-claim-safe-sandbox-parity.md
+++ b/specs/plans/74-claim-safe-sandbox-parity.md
@@ -235,6 +235,34 @@ dev-profile-only; production-profile admission rejects pulled
 templates without a verity sidecar. ADR-050 §Implementation Plan
 adds the concrete task list onto W1.
 
+### R13 — Guest agent and SDK runtime placement for pulled images (W1, W3, W4)
+
+**Current state.** `nix/lib/mk-guest.nix` bakes
+`mvm-guest-agent`, `mvm-seccomp-apply`, and `mvm-runner` into
+every Nix-built image's closure. Per-language SDK runtime
+libraries (ADR-049 vsock substitution hooks) are also expected to
+sit inside the rootfs. An OCI-pulled rootfs (W1) is **user
+content** with none of those binaries — left alone, the agent
+has nowhere to live, ADR-049's hooks have nothing to bind to,
+and W3 substitution silently breaks for OCI workloads.
+
+**Failure mode.** Two bad options if left unaddressed: (a)
+inject the agent + SDK runtime into the OCI rootfs at unpack
+time, mutating the image and breaking digest pinning; or (b)
+ship OCI ingest with no agent inside pulled images, making them
+second-class citizens that can't be `mvmctl exec`'d, can't
+participate in W3 secret substitution, and can't use the W4
+lifecycle surface. Either way the unified-runtime promise of
+ADR-048 collapses.
+
+**Mitigation owner.** Resolved by [ADR-051](../adrs/051-mvm-runtime-overlay-disk.md):
+ship a separate verity-sealed `mvm-runtime` overlay disk
+attached to every microVM (Nix-built and OCI-pulled alike),
+mounted read-only at `/mvm/runtime/`. The OCI rootfs stays
+byte-for-byte identical to the registry content. ADR-051
+§Implementation Plan folds the overlay build, `mkGuest`
+refactor, and `/mvm` path-collision check into W1.3 and W1.4.
+
 ### R4 — Audit volume without backpressure (W2)
 
 **Current state.** Today's L3 allow-list emits per-event audit (the

--- a/specs/plans/74-claim-safe-sandbox-parity.md
+++ b/specs/plans/74-claim-safe-sandbox-parity.md
@@ -1,0 +1,499 @@
+# Plan 74: Claim-safe sandbox parity
+
+**Status:** Proposed  
+**Date:** 2026-05-14  
+**ADR:** [`../adrs/048-claim-safe-sandbox-parity.md`](../adrs/048-claim-safe-sandbox-parity.md)  
+**Goal:** make the seven target sandbox claims defensible for `mvm` without weakening the existing signed-plan, audit, verified-boot, and Nix-first security posture.
+
+## Workstreams
+
+### W0 — Claims hygiene and docs guardrails
+
+**Goal:** stop overclaiming before runtime work lands.
+
+- [ ] Add a public feature-status table: Shipped, Preview, Planned, Not claimed.
+- [ ] Update Python SDK docs that still reference `mvmforge` instead of the current `mvm`/`mvmctl` surface.
+- [ ] Add a docs check that blocks phrases like "any OCI image", "secrets cannot leak", and "<100ms" unless the corresponding claim gate file is marked Shipped.
+- [ ] Update `specs/gap-analysis-vs-microsandbox.md` to include current SDK directories and mvmd ADR-0020.
+
+**Verification:**
+
+- Documentation-only test or xtask grep fails on gated claim phrases outside approved files.
+
+### W1 — OCI image ingest
+
+**Goal:** `mvmctl image pull <ref>` materializes OCI images into microVM artifacts.
+
+- [ ] Add `mvm-oci` or `mvm-build::oci` module for registry resolution, auth, manifest fetch, layer fetch, and digest verification.
+- [ ] Implement OCI layer unpack with whiteout, symlink, hardlink, ownership, permissions, xattr policy, env, entrypoint, workdir, and exposed-port extraction.
+- [ ] Materialize to ext4/rootfs artifact compatible with existing backend launch.
+- [ ] Register pulled artifacts as templates with requested ref, resolved digest, source registry, and cache scope metadata.
+- [ ] Add `mvmctl image pull`, `mvmctl image ls`, `mvmctl image rm`, and `mvmctl up --image`.
+- [ ] Add policy hooks for mutable-tag rejection in production profile.
+- [ ] Emit audit records for resolve, fetch, cache hit, materialize, verify, launch, and delete.
+
+**Tests:**
+
+- Unit fixtures for whiteouts, symlinks, hardlinks, file modes, invalid manifests, digest mismatch, and max-size rejection.
+- Integration test running `alpine` or a hermetic local registry fixture through `mvmctl up --image`.
+- Negative tests for mutable tag rejection under production policy and private cache isolation.
+
+### W2 — Programmable network policy
+
+**Goal:** ship the L7 path currently represented as plan/stub work.
+
+- [ ] Implement supervisor-owned DNS resolver with admission-time pinning.
+- [ ] Wire all guest egress through the trusted proxy for restricted policies.
+- [ ] Enforce HTTP Host and HTTPS CONNECT/SNI policy.
+- [ ] Block metadata endpoints and local control-plane ranges by default.
+- [ ] Add per-plan network policy objects with explicit defaults.
+- [ ] Emit audit entries for every allow/deny and DNS pin/reject event.
+
+**Tests:**
+
+- DNS rebinding denied.
+- Raw IP bypass denied.
+- Wrong SNI denied.
+- HTTP Host mismatch denied.
+- `169.254.169.254` and local control-plane ranges denied.
+- Allowed destination succeeds and records audit.
+
+### W3 — Secret placeholders and host-side substitution
+
+**Goal:** default secret flow prevents real secret values from entering guests.
+
+- [ ] Add `SecretPlaceholder` type with opaque token, plan id, secret name, allowed destinations, expiry, and grant id.
+- [ ] Update SDK/IR secret references to request placeholder mode by default.
+- [ ] Implement supervisor grant registry with revoke-on-stop/crash/timeout/parent-death.
+- [ ] Integrate substitution with the L7 egress proxy after destination policy passes.
+- [ ] Add redaction wrappers for plan JSON, logs, audit, errors, route labels, and cache keys.
+- [ ] Keep legacy env/file injection behind an explicit `unsafe_guest_secret_materialization` flag.
+
+**Tests:**
+
+- Guest receives no real secret in env, files, argv, logs, plan JSON, or audit.
+- Placeholder only substitutes for approved destination.
+- Redirect to unapproved destination fails closed.
+- Wrong SNI and plaintext HTTP do not receive substitution.
+- Grant revokes after stop, crash, and parent death.
+
+### W4 — SDK-owned lifecycle
+
+**Goal:** Python, TypeScript, and Rust SDKs can own local sandbox lifecycle without shelling out through an undocumented path.
+
+- [ ] Define shared lifecycle contract: `create`, `exec`, `files.read/write/list/remove`, `logs`, `snapshot`, `fork`, `stop`, `destroy`.
+- [ ] Add a stable local control API in Rust and bind it to Python/TypeScript.
+- [ ] Implement parent-process lease and cleanup semantics.
+- [ ] Add explicit detach mode for long-running sandboxes.
+- [ ] Keep static decorator compilation separate from lifecycle execution; no importing user code to inspect it.
+
+**Tests:**
+
+- Same fixture suite runs against Rust, Python, and TypeScript SDKs.
+- Parent process death cleans up non-detached sandboxes.
+- Detached sandboxes survive and are discoverable by CLI.
+- Error paths redact secrets.
+
+### W5 — Cold-start measurement and budgets
+
+**Goal:** publish measured latency claims with reproducible methodology.
+
+- [ ] Extend `runtime_boot_bench` and `cargo xtask perf boot` into one canonical harness.
+- [ ] Record backend, host, CPU, memory, vCPU, kernel digest, rootfs digest, storage mode, readiness signal, and run count.
+- [ ] Report fresh start-return, guest-agent-ready, snapshot restore, warm-pool claim, and SDK create-to-exec separately.
+- [ ] Store benchmark reports under `specs/perf/` or public docs with exact command lines.
+- [ ] Add CI budget gates for representative artifacts.
+
+**Initial claim target:**
+
+- Do not claim `<100ms` cold boot until p95 fresh guest-agent-ready supports it.
+- It is acceptable to claim faster warm-pool or snapshot numbers if those are measured and labeled.
+
+### W6 — Extensible filesystem backends
+
+**Goal:** make filesystem backend extensibility a tested contract, not just a trait.
+
+- [ ] Split the current storage contract into mountable and API-only capability flags.
+- [ ] Add conformance tests for local, encrypted, object store, and memory backends.
+- [ ] Define consistency and rename semantics for object stores.
+- [ ] Add path traversal, symlink escape, concurrent write, and large-file tests.
+- [ ] Add audit records for attach, detach, read, write, delete, rename, snapshot, and backend health failure.
+- [ ] Expose mountable backends through VM volume operations; expose API-only backends through guest agent or host-side file API.
+
+## Cross-repo handoff to mvmd
+
+`mvmd` may expose a capability only after the owning `mvm` primitive has a stable API and tests. The handoff contract for each workstream is:
+
+| mvm workstream | mvmd consumes |
+|---|---|
+| W1 OCI ingest | Tenant image policy, Sandboxfile image fields, API/CLI `--image` |
+| W2 network policy | Tenant egress/DNS policy and fleet audit aggregation |
+| W3 placeholders | Tenant secret providers and cross-node grant revocation |
+| W4 SDK lifecycle | Generated API SDKs and MCP sandbox server behavior |
+| W5 benchmarks | Fleet-facing latency claims and warm-pool SLOs |
+| W6 filesystem | Managed storage, buckets, encrypted/object-store backends |
+
+## Risks
+
+The workstreams above are sized to be independently shippable, but a
+handful of cross-cutting risks can force architectural change late if
+they go unnoticed. Each risk names the workstream(s) it threatens, the
+current evidence, the failure mode if ignored, and the assigned
+mitigation owner.
+
+### R1 — Supervisor as concentrated trust surface (W2, W3)
+
+**Current state.** `crates/mvm-supervisor/src/l7_proxy.rs:21,357`
+implements L4 policy (proto/CIDR/port) only and emits one audit entry
+per request (`flow.egress.allowed` / `flow.egress.denied`). The
+keystore releaser (`crates/mvm-supervisor/src/keystore.rs:23-81`) is a
+`Noop` today — attestation-gated secret release is pending. The
+supervisor runs in host userspace (ADR-002 L2, "host-side proxy
+socket 0700") and is single-host trusted.
+
+**Failure mode.** W2 wires body inspection (`SecretsScanner`,
+`PiiRedactor`, `SsrfGuard`) and W3 makes the supervisor the single
+mint-and-revoke point for `SecretPlaceholder` substitution. A
+supervisor compromise or crash now exposes every active grant and
+plaintext request body on the wire. The trust footprint grows from
+"audit + admission" to "audit + admission + secret substitution +
+egress content".
+
+**Mitigation owner.** W2 must add per-request audit quotas and
+backpressure to the inspector chain (no quota trait exists today —
+`crates/mvm-supervisor/src/audit_recorder.rs:36`). W3 must split the
+grant registry from the substitution code so a single bug doesn't
+cross-contaminate both — they share a process but should not share a
+crash boundary. Document the trust footprint expansion in the
+status-page entry for both claims so users opt in knowingly.
+
+### R2 — Panic-output secret redaction is new infrastructure (W3)
+
+**Current state.** No `panic::set_hook` exists anywhere in the
+workspace. The `check-no-display-on-secret-types` lint
+(`xtask/src/check_no_display_on_secret_types.rs`) is a name-based
+compile-time check — it rejects `Debug`/`Display` derives on types
+matching `*Secret*` / `*Password*` / `*Token*` / `*Key*` patterns. It
+does NOT prevent panics from leaking secrets carried in generic
+containers (`String`, `Vec<u8>`, `HashMap<String, String>`).
+
+**Failure mode.** A `format!("{e:?}")` of an error type containing a
+`String` field whose value happens to be a secret writes plaintext to
+stderr. The ADR-048 gate "real secret values never appear in ...
+panic output" then fails the moment any `unwrap()`-on-secret-bearing
+result fires. Extending the existing lint cannot solve this — it's a
+runtime concern, not a typing concern.
+
+**Mitigation owner.** W3 must build a custom `panic::set_hook` in the
+supervisor init path (likely `crates/mvm-supervisor/src/lib.rs`) that
+runs the panic message through a redaction filter keyed on the active
+grant registry. The filter sees the message after Rust formats it,
+substitutes any known plaintext secret with `<redacted:grant-id>`,
+and emits the redacted form. Add a hostile-guest test that triggers a
+panic from a guest-controlled path (e.g. malformed request body) and
+asserts the secret does not appear on the supervisor's stderr. This
+is mandatory new code, not a refactor of the lint.
+
+### R3 — Per-pull verity generation decision is unresolved (W1)
+
+**Current state.** Claim 3 of the security model
+(`CLAUDE.md` "Security model" §3) is "a tampered rootfs ext4 fails to
+boot," backed by `mvm-verity-init`
+(`crates/mvm-guest/src/bin/mvm-verity-init.rs`), the
+`probe_verity_sidecar` plumbing
+(`crates/mvm-backend/src/microvm.rs:1525-1547`), and the deterministic
+`verityArtifacts` Nix derivation. The initramfs is a static binary
+that's reused for every rootfs — only the sidecar + roothash are
+per-image. `probe_verity_sidecar` already returns `(None, None)` when
+artifacts are missing, so an "unverified" lane exists technically
+even though no production code path uses it.
+
+**Failure mode.** OCI input is arbitrary, not Nix-built. Every pull
+needs either (a) a verity sidecar generated at pull time (extra
+`veritysetup format` step, requires the binary on the pull path,
+slows first pull by seconds-to-tens-of-seconds for typical image
+sizes) or (b) a documented carve-out that pulled images run without
+dm-verity. Today plan 74 W1 does not pick. Shipping W1 without
+deciding leaks the decision into ad-hoc PR review and risks weakening
+claim 3 silently.
+
+**Two clean options, pick before W1 starts:**
+
+- **Option A (strict claim 3):** Pull-time verity generation for
+  every image. Adds `veritysetup` to the pull path (or to the builder
+  VM that runs the pull), regenerates the sidecar whenever the rootfs
+  blob changes, keeps claim 3 unchanged.
+- **Option B (documented carve-out):** Pulled images live in an
+  "unverified" template lane gated by a profile flag. Claim 3 becomes
+  "Nix-built and prebuilt images" with an explicit exclusion for
+  `image pull`-sourced templates. Audit chain (claim 8) still covers
+  provenance.
+
+**Mitigation owner.** W1 lead picks A or B before code lands; the
+choice goes in the W1 ADR and the public status page row for
+oci-ingest names the verity posture. ADR-048 §"Non-goals" already
+forbids "bypassing verified artifact checks for developer
+ergonomics" — Option B is compatible with that *only if* the
+exclusion is explicit, not implicit.
+
+### R4 — Audit volume without backpressure (W2)
+
+**Current state.** Today's L3 allow-list emits per-event audit (the
+audit category exists at
+`crates/mvm-supervisor/src/audit_recorder.rs:36` — `flow.egress.*`).
+No batching, no sampling, no per-tenant quota.
+`~/.mvm/audit/<tenant>.jsonl` is append-only.
+
+**Failure mode.** W2 wires per-request audit on the L7 proxy. A
+malicious or buggy workload that emits thousands of requests per
+second turns the audit log into a DoS — disk fills, audit signer
+falls behind, the chain-signed log loses real-time integrity.
+
+**Mitigation owner.** W2 adds an audit-sink trait with per-tenant
+rate limits and lossy-but-counted overflow (one chain entry recording
+"N events dropped" so the chain stays intact). The trait also belongs
+in front of every new audit kind W3/W6 introduces. Add to plan 74 W2
+task list explicitly.
+
+### R5 — Snapshot/fork interaction with placeholders (W3)
+
+**Current state.** Snapshots are HMAC-sealed with monotonic-epoch
+replay protection (`mvm-core/src/instance.rs` snapshot path). Grants
+live in supervisor memory (W3 design), not in the snapshot.
+
+**Failure mode.** A workload snapshotted with active grants gets
+restored on a different host or after a long delay. The original
+grant has been revoked (parent-process death, timeout); the restored
+workload sees the placeholder env var but cannot complete the
+substitution because the grant is gone. Worse: if grants are
+inadvertently included in the snapshot, restoring on a second host
+revives an already-revoked grant.
+
+**Mitigation owner.** W3 spec must state that snapshots NEVER carry
+grant state — restore re-runs admission and produces fresh grants.
+Add a snapshot-restore-with-placeholder test to W3's test list.
+
+### R6 — Cross-platform supervisor parity (W2, W3, W4)
+
+**Current state.** ADR-031 names cross-platform strategy but the L3
+allow-list today uses `nftables` on Linux; no macOS equivalent ships
+in `crates/mvm-supervisor`. The supervisor process binary is built
+for the host OS; libkrun runs on macOS, Firecracker on Linux.
+
+**Failure mode.** W2 builds a kernel-netfilter-shaped policy
+enforcement layer. If the implementation reaches for `nftables` /
+`iptables` directly, the macOS supervisor cannot enforce. W4's
+parent-process lease (`PR_SET_PDEATHSIG` on Linux, kqueue `NOTE_EXIT`
+on macOS) has the same shape — both platforms must land in lock-step
+or the SDK lifecycle claim is false on one of them.
+
+**Mitigation owner.** W2 lead picks an L7 proxy implementation that's
+a user-space process (not a kernel netfilter rule); the proxy is the
+policy point on both platforms. W4 lead implements the macOS kqueue
+path in the same PR as the Linux `prctl` path — neither lands alone.
+Document the platform matrix on the status page rows for both claims.
+
+### R7 — Cold-start measurement transparency (W5)
+
+**Current state.** `runtime_boot_bench` (`crates/mvm/tests/`) covers
+serial-and-parallel boots on Apple Container; no Firecracker
+fresh-boot number is published. ADR-048 §"Non-goals" explicitly
+forbids claiming `<100ms` before measured data supports it.
+
+**Failure mode.** First measurements may show fresh Firecracker boot
+in the 200-500ms range with audit append, plan signing, and verity
+attach in the path. Microsandbox's `<100ms` claim is warm-pool
+restore, not fresh boot — but their public docs do not always label
+this. If we publish only a fresh-boot number, we look slower than we
+are; if we publish only a warm-pool number, we overclaim. Either is a
+defensible-claim failure.
+
+**Mitigation owner.** W5 lead publishes p50/p95/p99 numbers for
+*every* readiness boundary (start-return / guest-agent-ready /
+snapshot-restore / warm-pool-claim / SDK-create-to-exec) in the same
+table, with backend + host context on every row. The status-page row
+for cold-start cites the table directly. The `check-doc-claims` lint
+W0 builds will block any unqualified `<100ms` until the cold-start
+row is Shipped *and* the page that quotes the number is on the
+allow-list. Don't fight the lint — let it force discipline.
+
+### R8 — mvmd cross-repo handoff discipline (all workstreams)
+
+**Current state.** "If a primitive is missing in mvm, mvmd must not
+implement a parallel runtime path" (ADR-048 §"Runtime Ownership").
+The handoff contract per workstream is listed above in "Cross-repo
+handoff to mvmd". No enforcement mechanism today — it's a convention.
+
+**Failure mode.** mvmd reaches for an unstable or slow mvm primitive,
+decides to fork its own path "temporarily," and the fork persists.
+The plan-74 promise that mvmd consumes mvm primitives unmodified
+collapses.
+
+**Mitigation owner.** Each workstream's Shipped gate includes the
+sentence "primitive is consumable by mvmd as a library with a
+documented API surface." A workstream is not Shipped until the
+mvmd-side issue exists referencing the mvm API by file:line. This
+keeps the cross-repo contract from being implicit.
+
+### R9 — TLS substitution mechanism is undecided (W2, W3)
+
+**Current state.** ADR-048 §"Secret non-leakage" says "substitution
+is bound to destination policy and transport identity" and plan 74
+W3 says "integrate substitution with the L7 egress proxy after
+destination policy passes." Neither names *how* the proxy reaches
+into a TLS-encrypted body to swap a placeholder for a real value.
+Three architectural shapes are compatible with the words; they have
+very different attack surfaces.
+
+**Three options:**
+
+- **(a) Proxy-with-CA.** Install an mvm CA in the guest's trust
+  store, terminate TLS at the proxy, substitute in plaintext,
+  re-encrypt to upstream. We then own a CA in every guest — any
+  guest TLS library bug becomes a supervisor-host compromise. Most
+  invasive. Equivalent to a corporate-MITM proxy.
+- **(b) Vsock side-channel.** Guest receives a
+  `mvm-secret://<grant-id>` token, calls a host-side library over
+  vsock at egress time to mint a per-request signed header; the
+  host signs/substitutes and the guest emits the request as-is. No
+  CA needed; the proxy stays SNI-only. Requires guest cooperation —
+  a Python/Node SDK helper that hooks into `requests`/`fetch`.
+- **(c) Host-side request reconstruction.** Guest issues plaintext
+  HTTP through the proxy; proxy does TLS to upstream. Substitution
+  happens in plaintext on the host. Breaks any SaaS that forbids
+  unencrypted client-to-proxy.
+
+**Failure mode.** Shipping W3 without picking turns the substitution
+code into ad-hoc PR-review architecture. Worse: an (a)-style CA
+installation can land "temporarily" and never get reverted, expanding
+the trust footprint of every guest without an explicit decision.
+
+**Mitigation owner.** Pick the substitution mechanism before W2
+codes the proxy — it shapes the proxy. **R9 deserves its own ADR**;
+fold the decision in alongside W2's egress design. ADR-048 §"Non-
+goals" forbids "claiming secrets cannot leak for legacy env/file
+injection flows" — that posture is consistent with (b) being the
+default and (a) being an explicit, named opt-in.
+
+### R10 — OCI layer unpack attack surface (W1)
+
+**Current state.** Plan 74 W1 names "whitelists, symlinks, hardlinks,
+ownership, permissions" once. Industry has shipped multiple CVEs in
+this space: Docker CVE-2019-14271 (path traversal via `tarSum`),
+CVE-2024-21626 (runc `WORKDIR` cwd escape), and a long tail of
+gzip-bomb / tar-slip variants.
+
+**Failure mode.** Any of the following unpack bugs gives a hostile
+image author host-side code execution at pull time:
+
+- **Path traversal**: tar entries with `../../etc/passwd`.
+- **Decompression bomb**: nested gzip plus a small manifest pointing
+  at TB-scale layer bodies — fills disk or OOM-kills the unpacker.
+- **Symlink-then-overwrite race**: layer 1 creates
+  `/etc/passwd → /target`; layer 2 writes `/target` as
+  attacker-controlled content.
+- **Hardlink escape**: a hardlink in the OCI layer pointing at a
+  host file mounted via `--add-dir`.
+- **Setuid/setgid bits**: pulled rootfs may carry setuid binaries.
+  Claim 2 (`setpriv --no-new-privs`) drops capabilities at service
+  launch, but `find /sandbox -perm -4000` still reports them. The
+  layered defense holds; the discoverable surface is wider than
+  Nix-built images.
+- **Registry MITM**: a non-HTTPS registry URL or a manifest without
+  a content digest lets a network attacker substitute the body.
+
+**Mitigation owner.** W1 lead enumerates each of the above as an
+explicit test case in the W1 tasks list (not a generic "whitelist /
+symlink coverage" bullet). Pull path enforces `https://` + digest
+on every fetch. Layer unpack runs inside the builder VM, not on the
+host, so a layer-unpack RCE is bounded by VM isolation rather than
+hitting the host filesystem directly — this is a strong reason to
+keep the unpack path inside libkrun and not "optimize" it onto the
+host later.
+
+### R11 — Non-HTTP egress posture is unspecified (W2)
+
+**Current state.** Plan 74 W2 specs "HTTP Host and HTTPS CONNECT/SNI."
+It is silent on every other egress protocol.
+
+**Failure mode.** The supervisor-owned L7 proxy enforces policy for
+exactly the protocols it parses. Without an explicit decision the
+following are de facto allowed (or worse, ambiguous):
+
+- **HTTP/2 connection reuse.** A single TCP+TLS connection carries
+  multiple streams; each stream has its own `:authority`
+  pseudo-header. SNI-only inspection sees the first stream's
+  host; subsequent streams to other hosts bypass policy.
+- **HTTP/3 / QUIC.** UDP-based, no TCP CONNECT to intercept. SNI
+  is in the QUIC initial packet but the path is foreign to a
+  TCP proxy.
+- **WebSockets.** HTTP upgrade then bidirectional binary frames;
+  per-request inspection breaks once the upgrade completes.
+- **gRPC.** HTTP/2 + protobuf. Body inspection requires schema.
+- **Raw TCP, SSH, mTLS APIs, DB protocols (PG/MySQL).** No Host
+  header at all. The L7 proxy is irrelevant; only L3/L4
+  allow-list applies.
+
+This is also a W3 risk: secrets cannot be substituted into a
+channel the proxy doesn't parse.
+
+**Mitigation owner.** W2 spec must pick an explicit posture per
+protocol class. Recommended default: **deny by default; allow
+HTTP/1.1 + HTTP/2 + HTTPS CONNECT explicitly; block HTTP/3/QUIC
+egress at the L4 layer until a QUIC-aware proxy ships; document
+WebSockets/gRPC/raw-TCP as "destination-policy-only, no body
+inspection".** W3's default flow restricts secrets to HTTP
+destinations until non-HTTP substitution has a design.
+
+### R12 — DNS bypass via DoH/DoT (W2)
+
+**Current state.** Plan 74 W2 builds a supervisor-owned pinning
+resolver. Guest libc honours `/etc/resolv.conf`, which our network
+controls. But a guest can trivially bypass this by using DNS over
+HTTPS (DoH, `https://1.1.1.1/dns-query`) or DNS over TLS (DoT,
+TCP/853 to known providers).
+
+**Failure mode.** Pinning is a marketing claim, not a security
+boundary. A workload that bundles `cloudflare-dns` or uses Go's
+`http.Transport{DialTLS}` to talk directly to a DoH endpoint
+resolves arbitrary names without our pinning ever seeing the query.
+The W2 audit log shows "no DNS activity" while the workload
+exfiltrates via `attacker.example.com`.
+
+**Mitigation owner.** W2 implements at least one of the following:
+
+- **L4 blocklist of known DoH/DoT providers** (Cloudflare, Google,
+  Quad9, NextDNS, Mullvad, etc.) — pragmatic, cat-and-mouse with
+  new providers, easy to maintain.
+- **Transparent intercept of :443 to known DoH endpoints** — bend
+  the request through the L7 proxy and either rewrite or block —
+  heavier, requires R9-style TLS handling.
+- **Block all egress to A/AAAA/HTTPS records the pinning resolver
+  did not resolve** — strongest, requires keeping a per-connection
+  table of "this destination IP was resolved via the pinning path"
+  and dropping anything else. This is the technically correct
+  default; document it.
+
+W2 ships option 3 as default; option 1 is the fallback for cases
+where the resolver path is incomplete (e.g. statically-linked Go
+binaries that ignore `/etc/resolv.conf`).
+
+## Risks resolved since plan was written
+
+- **Builder-VM transition (was blocking).** Plan 72 W0-W6 shipped
+  2026-05-13; the libkrun builder VM is the default backend and
+  `mvmctl dev up` is reliably green on contributor laptops and CI.
+  In-microVM integration tests gate behind `#[ignore]` +
+  `MVM_LIBKRUN_E2E=1` for local runs; CI runs them on the
+  ubuntu-latest `/dev/kvm` lane. Apple Silicon CI builds and
+  unit-tests but does not boot. No blocker to W1, W2, W3, or W4
+  starting now.
+
+## Definition of Done
+
+- Every target claim has a status table entry.
+- Every Shipped claim has tests and docs.
+- `cargo test --workspace` passes on host where applicable.
+- Linux-only/network/microVM tests are gated and run in the builder VM before merge.
+- `cargo clippy --workspace --all-targets -- -D warnings` passes in the builder environment before merge.
+- `specs/SPRINT.md` is updated as workstreams move from Proposed to active.

--- a/specs/plans/74-w1-w6-attack-plan.md
+++ b/specs/plans/74-w1-w6-attack-plan.md
@@ -510,21 +510,26 @@ Quick map from workstream to load-bearing risks:
 
 | Workstream | Risks that affect kickoff   |
 | ---------- | --------------------------- |
-| W1 OCI     | **R3** (verity A or B before code lands), **R10** (layer-unpack CVE class), R8 |
+| W1 OCI     | **R3** (verity A or B before code lands), **R10** (layer-unpack CVE class), **R13** (runtime overlay disk gates W1.3-W1.4), R8 |
 | W2 network | R1, **R4** (audit backpressure), R6, **R9** (TLS substitution mechanism), **R11** (non-HTTP egress), **R12** (DoH/DoT bypass), R8 |
-| W3 secrets | R1, **R2** (panic hook is new), R5 (snapshot interaction), R6, **R9** (substitution mechanism gates W3 entirely), R11 (non-HTTP secret channels), R8 |
-| W4 SDK     | R6 (macOS kqueue parity), R8 |
+| W3 secrets | R1, **R2** (panic hook is new), R5 (snapshot interaction), R6, **R9** (substitution mechanism gates W3 entirely), R11 (non-HTTP secret channels), R13 (SDK runtime is in the overlay), R8 |
+| W4 SDK     | R6 (macOS kqueue parity), R13 (SDK lifecycle binaries live in the overlay), R8 |
 | W5 perf    | R7 (publish every readiness boundary), R8 |
 | W6 storage | R4 (new audit kinds), R8 |
 
-**R3 and R9 are now decided** —
+**R3, R9, and R13 are now decided** —
 [ADR-050](050-oci-image-verity-posture.md) picks pull-time verity
-generation for W1, and
-[ADR-049](049-secret-substitution-mechanism.md) picks the vsock
-side-channel for W3 (with proxy-with-CA available later as an
-explicit opt-in feature flag). Both ADRs ship with concrete task
-additions for their workstreams. The remaining top-level risks
-(R1, R2, R4-R8, R10-R12) stay open and reference the parent plan.
+generation for W1, [ADR-049](049-secret-substitution-mechanism.md)
+picks the vsock side-channel for W3 (with proxy-with-CA available
+later as an explicit opt-in feature flag), and
+[ADR-051](051-mvm-runtime-overlay-disk.md) introduces a separate
+verity-sealed mvm-runtime overlay disk that hosts the guest
+agent, seccomp shim, runner, and per-language SDK runtime
+libraries for *every* microVM (Nix-built and OCI-pulled alike),
+unifying the agent placement story. ADR-051 also forces a
+one-time refactor of `mkGuest` to stop baking those binaries
+into per-image closures. The remaining top-level risks (R1, R2,
+R4-R8, R10-R12) stay open and reference the parent plan.
 
 ## Verification
 

--- a/specs/plans/74-w1-w6-attack-plan.md
+++ b/specs/plans/74-w1-w6-attack-plan.md
@@ -1,0 +1,537 @@
+# Plan 74 — Attack plan for W1-W6
+
+**Status:** Proposed
+**Date:** 2026-05-14
+**Parent plan:** [`74-claim-safe-sandbox-parity.md`](74-claim-safe-sandbox-parity.md)
+**ADR:** [`../adrs/048-claim-safe-sandbox-parity.md`](../adrs/048-claim-safe-sandbox-parity.md)
+
+## Why this attack plan
+
+Plan 74 enumerates seven workstreams (W0-W6) but does not pick an
+execution order, identify the hard dependencies between them, or
+state which artifact has to land before a Shipped/Preview status
+flip is allowed. This doc fills that gap so a contributor can pick
+up any workstream without re-deriving the strategy.
+
+W0 (claims hygiene + docs guardrails) ships first — it is the
+prerequisite for every other workstream because it establishes the
+**status table** that every other workstream flips entries in. Once
+W0 lands, the new `xtask check-doc-claims` lint blocks marketing
+language that runs ahead of implementation. W1-W6 then flip table
+rows from Planned → Preview → Shipped as their gates close.
+
+## Dependency graph
+
+```
+W0 (claims hygiene)  ─── ships first; gates every claim flip
+│
+├── W5 (cold-start)         independent, lightest lift
+├── W6 (filesystem)          independent, conformance tests
+├── W4 (SDK lifecycle)       independent (sits on `mvm-sdk` crate already in tree)
+├── W1 (OCI ingest)          independent of W2-W6 but largest greenfield surface
+└── W2 (network policy)  ──► W3 (secret placeholders)
+                            hard chain: placeholders substitute at the L7 proxy
+                            that W2 builds; W3 cannot ship until W2 is Shipped
+```
+
+Only one hard chain exists: **W3 depends on W2**. The L7 proxy
+that W2 builds is the policy-enforcement point where W3
+substitutes placeholders. Without it, W3 reverts to the legacy
+env/file injection path which ADR-048 §"Non-goals" explicitly
+forbids us from claiming as "secrets cannot leak".
+
+Everything else is parallel-safe.
+
+## Recommended sequencing
+
+### Single-contributor track (optimizes claims-flipping-per-week)
+
+| Order | Workstream         | Why this order                                                          | Rough effort |
+| ----- | ------------------ | ----------------------------------------------------------------------- | ------------ |
+| 1     | W5 cold-start      | Quickest claim flip — measurement, no new runtime; harness exists       | 1-2 weeks    |
+| 2     | W4 SDK lifecycle   | Biggest adoption move; `mvm-sdk` crate already ported, lifecycle missing | 4-6 weeks   |
+| 3     | W1 OCI ingest      | Opens the Docker-shaped audience; new code surface                       | 4-6 weeks   |
+| 4     | W2 network policy  | Prerequisite for W3; deny-by-default + DNS pin + L7 proxy + SNI/Host    | 4-6 weeks    |
+| 5     | W3 secret placeholders | The microsandbox-headline differentiator; rides on W2's proxy        | 3-4 weeks    |
+| 6     | W6 filesystem      | Lowest marketing weight; mostly conformance tests + capability flags    | 2-3 weeks    |
+
+Total: ~18-27 contributor-weeks.
+
+### Two-contributor parallel track (faster wall-clock)
+
+- **Track A (adoption):** W5 → W4 → W1.
+- **Track B (security):** W6 → W2 → W3. W6 is sequenced ahead of
+  W2 on this track because the conformance-test scaffolding is
+  needed before we add object-store/encrypted backends that W2 is
+  going to want to audit via the same channel.
+
+Total: ~10-14 wall-clock weeks; ~24-32 contributor-weeks total
+(the parallel track has overhead — coordination, shared audit
+schema decisions).
+
+## Per-workstream attack plan
+
+### W1 — OCI image ingest
+
+**Scope.** `mvmctl image pull <ref>` resolves an OCI reference to
+an immutable digest, fetches layers, unpacks to an ext4 rootfs,
+records the manifest's entrypoint/env/workdir/exposed-ports, and
+registers the result as a first-class template consumable by
+`mvmctl up --image`. No host Docker daemon, no shell-out to
+`skopeo`.
+
+**Hard dependencies.** None on W2-W6. Pulls into existing
+template registry (`mvm-core/src/template.rs`) and template
+build path (`mvm-build/src/dev_build.rs`).
+
+**Key new code.**
+- `crates/mvm-oci/` — registry resolution, auth (Bearer + Basic),
+  manifest fetch, layer fetch, digest verification, max-size and
+  layer-count caps.
+- `crates/mvm-build/src/oci_to_rootfs.rs` — layer unpack with
+  whiteouts, symlinks, hardlinks, ownership/permissions, xattr
+  policy.
+- `crates/mvm-cli/src/commands/image/pull.rs` — CLI surface.
+- Audit kinds in `mvm-core/src/policy/audit.rs`:
+  `oci.resolve`, `oci.fetch`, `oci.cache.hit`,
+  `oci.materialize`, `oci.verify`, `oci.launch`, `oci.delete`.
+
+**Shipped gate (ADR-048 §"OCI ingest").**
+- `mvmctl image pull <ref>` resolves an immutable digest and
+  records requested ref + launched digest in the template.
+- Production profile rejects mutable tags
+  (`policy::profile::production`); dev profile allows them with
+  audit.
+- Layer unpacking covers whiteouts, symlinks, hardlinks,
+  ownership, permissions, entrypoint, env, workdir, exposed
+  ports.
+- Rootfs artifacts are tenant/cache scoped — no cross-tenant
+  read.
+- Tests cover digest pinning, mutable-tag rejection, private
+  registry auth, whiteout behavior, secret/cache non-leakage.
+
+**Status-table transitions.**
+- Planned → **Preview** when `image pull` materializes Alpine
+  end-to-end with digest pinning, but mutable-tag rejection and
+  full whiteout coverage are not yet in.
+- Preview → **Shipped** when every gate bullet above is green
+  and a hermetic local-registry integration test runs in CI.
+
+**Suggested PR breakdown.**
+1. `mvm-oci` crate skeleton + manifest fetch + digest verify
+   (no unpack yet). Unit tests against a fixture manifest.
+2. Layer fetch + digest verify + bounded retry. Hermetic
+   in-process registry fixture for tests.
+3. Layer unpack with whiteouts/symlinks/hardlinks; conformance
+   tests against the OCI test corpus.
+4. CLI surface (`image pull/ls/rm`); template registration
+   plumbing.
+5. `mvmctl up --image <ref>` + production-profile mutable-tag
+   rejection + audit emission.
+6. Doc page in `public/src/content/docs/guides/oci-images.md`
+   and status-table flip to Shipped.
+
+**Risk.** Largest greenfield surface. The hard part is policy:
+once we accept arbitrary OCI input, the "Nix-built reproducible
+rootfs" claim (claim 7 of the security model, deterministic
+double-build CI) no longer applies to pulled images. The page
+must say this explicitly. Verified-boot (claim 3) requires
+generating dm-verity sidecars per pulled image — straightforward
+mechanically (we have `verityArtifacts` in `nix/flake.nix`) but
+adds non-trivial wall-clock to each pull.
+
+**Cross-repo handoff to mvmd.** Tenant image policy and registry
+allow-list rules (mvmd ADR-0020) consume `mvm-oci` as a library;
+mvmd never spawns a parallel pull path.
+
+### W2 — Programmable network policy
+
+**Scope.** Supervisor-owned DNS resolver with admission-time
+pinning, L7 trusted proxy that all guest egress flows through
+under restricted policies, HTTP-Host and HTTPS-CONNECT/SNI
+enforcement, default block on metadata endpoints and
+local control-plane ranges.
+
+**Hard dependencies.** Builds on existing L3 allow-list and
+ADR-004 (egress policy). No dependency on W1, W4-W6.
+
+**Key new code.**
+- `crates/mvm-supervisor/src/network/dns.rs` — pinning resolver.
+- `crates/mvm-supervisor/src/network/proxy/` — L7 proxy
+  (HTTP + HTTPS CONNECT + SNI inspection).
+- `crates/mvm-core/src/policy/network.rs` — per-plan
+  `NetworkPolicy` type with explicit defaults.
+- Audit kinds: `net.allow`, `net.deny`, `net.dns.pin`,
+  `net.dns.reject`, `net.proxy.fail`.
+
+**Shipped gate (ADR-048 §"Programmable network policy").**
+- `deny` is a first-class default policy in a `production`
+  profile.
+- DNS answers for allowed names are pinned for workload lifetime.
+- HTTP Host and HTTPS SNI verified against policy.
+- `169.254.169.254` and local control-plane ranges blocked by
+  default.
+- Audit records emitted for allow, deny, DNS pin, DNS reject,
+  proxy failure.
+- Integration tests prove DNS rebinding, raw-IP bypass,
+  wrong-SNI, metadata access are denied.
+
+**Status-table transitions.**
+- Planned → **Preview** when the L7 proxy can enforce Host/SNI
+  for a single fixed policy, but per-plan policy objects are not
+  yet wired.
+- Preview → **Shipped** when per-plan `NetworkPolicy` objects
+  flow through the signed `ExecutionPlan`, all gate bullets are
+  green, and the DNS-rebinding + raw-IP bypass + wrong-SNI tests
+  pass in CI.
+
+**Suggested PR breakdown.**
+1. Pinning DNS resolver + per-plan A/AAAA cache. Unit tests.
+2. L7 proxy scaffold (HTTP Host enforcement). Integration test
+   against a fixture origin.
+3. HTTPS CONNECT + SNI policy. Test for wrong-SNI denial.
+4. Default-block metadata + local control-plane ranges. Test
+   for `169.254.169.254` denial.
+5. Per-plan `NetworkPolicy` type + admission wiring + audit.
+6. Doc page in `public/src/content/docs/guides/network-policy.md`
+   and status-table flip.
+
+**Risk.** TLS interception is the dragon. We do NOT MITM TLS —
+SNI inspection only. State this clearly so users understand the
+proxy enforces *destination policy*, not *content policy*.
+Document the interaction with verified-boot: the proxy lives in
+the supervisor on the host, not in the guest, so it does not
+extend the verified-boot chain.
+
+### W3 — Secret placeholders and host-side substitution
+
+**Scope.** Default secret flow gives the guest only an opaque
+placeholder string. Real secret values are substituted by the
+host-side egress proxy after destination policy passes. Grants
+revoke on stop/crash/timeout/parent-death. Legacy env/file
+injection stays behind `unsafe_guest_secret_materialization`.
+
+**Hard dependencies.** **W2 must be Shipped first.** The
+substitution point is the L7 proxy that W2 builds. Cannot ship
+this without a trusted proxy that sees every egress connection.
+
+**Key new code.**
+- `crates/mvm-core/src/secrets/placeholder.rs` —
+  `SecretPlaceholder` (token, plan id, name, allowed
+  destinations, expiry, grant id).
+- `crates/mvm-supervisor/src/secrets/grant_registry.rs` —
+  grant lifecycle, revocation hooks.
+- `crates/mvm-supervisor/src/network/proxy/substitution.rs` —
+  request body / header rewrite at proxy.
+- Redaction wrappers in `mvm-core/src/policy/audit.rs`,
+  `mvm-cli/src/logging.rs`, plan JSON, error messages.
+
+**Shipped gate (ADR-048 §"Secret non-leakage").**
+- Default SDK/CLI flow gives the guest only an opaque
+  placeholder.
+- Real secret values never appear in guest env, files, argv,
+  logs, audit detail, plan JSON, cache keys, route labels, error
+  messages, or panic output.
+- Substitution is bound to destination policy and transport
+  identity (SNI/Host match).
+- Grant revocation on stop, crash, timeout, parent-process
+  death.
+- Tests cover hostile-guest exfiltration attempts, destination
+  mismatch, redirect chains, wrong SNI, plaintext HTTP, audit
+  redaction, crash cleanup.
+
+**Status-table transitions.**
+- Planned → **Preview** when placeholder + substitution work
+  end-to-end for one provider (e.g. Anthropic), but `redacted`
+  formatting is missing in some audit paths.
+- Preview → **Shipped** when every redaction wrapper is in
+  place, and hostile-guest exfiltration tests run in CI.
+
+**Suggested PR breakdown.**
+1. `SecretPlaceholder` type + serde + tests; opaque `Display`
+   (already covered by `xtask check-no-display-on-secret-types`).
+2. Grant registry + lifecycle hooks (stop/crash/timeout/parent).
+3. Substitution logic in the W2 proxy. Hostile-guest tests.
+4. Redaction wrappers across plan JSON, logs, audit, errors,
+   cache keys, route labels.
+5. Default-flow flip in `mvm-sdk` and `mvmctl up`; legacy path
+   behind `unsafe_guest_secret_materialization`.
+6. Doc page in `public/src/content/docs/security/secret-placeholders.md`
+   and status-table flip.
+
+**Risk.** The ADR's gate bullet "Real secret values never appear
+in ... panic output" is hard. Rust panic messages can carry
+arbitrary captured `Debug` output. We need a panic hook that
+redacts known-secret payloads, and a `xtask` lint that catches
+new `format!("{e:?}")` of secret-typed errors. ADR-048
+§"Non-goals" explicitly forbids claiming this for the legacy
+env/file path — make sure the status table row stays Preview
+until the default flow is the placeholder path.
+
+### W4 — SDK-owned lifecycle
+
+**Scope.** Python/TypeScript/Rust SDKs expose the same lifecycle
+surface — `create`, `exec`, `files.read/write/list/remove`,
+`logs`, `snapshot`, `fork`, `stop`, `destroy` — over a stable
+local control API. Sandboxes are owned by the SDK process;
+parent-death triggers cleanup unless `detach=true`.
+
+**Hard dependencies.** None. Rides on `crates/mvm-sdk` (already
+ported per Plan 60). The lifecycle ports onto the existing
+`up`/`stop`/`exec`/`logs` plumbing without rewriting it.
+
+**Key new code.**
+- `crates/mvm-sdk/src/lifecycle.rs` — core lifecycle contract +
+  Rust binding.
+- `python/` — pyo3 binding (already specified in Plan 60
+  Phase 5).
+- `typescript/` — napi-rs binding.
+- `crates/mvm-supervisor/src/lease.rs` — parent-process lease
+  using `prctl(PR_SET_PDEATHSIG)` on Linux,
+  `pthread_kill_other_threads_np`/parent-pid watcher on macOS.
+- `crates/mvm-cli/src/commands/sandbox/` — `mvmctl sandbox ls`
+  for detached sandboxes.
+
+**Shipped gate (ADR-048 §"SDK lifecycle").**
+- Python, TS, and Rust SDKs expose the same surface.
+- SDK-created sandboxes are owned by the SDK process unless
+  `detach=true`.
+- Parent death triggers sandbox cleanup or documented lease
+  expiry.
+- Lifecycle surface works without importing or executing
+  untrusted user code during static compilation
+  (the existing `mvmctl compile` AST-walk path stays).
+- Tests cover create, exec, files.*, logs, snapshot, stop,
+  parent cleanup, error redaction.
+
+**Status-table transitions.**
+- Planned → **Preview** when Rust + Python surfaces are
+  functional but the TS binding is not.
+- Preview → **Shipped** when all three SDKs run the same fixture
+  suite, and parent-death cleanup test is green on Linux + macOS.
+
+**Suggested PR breakdown.**
+1. Rust `lifecycle` module + parent-process lease + cleanup
+   test on Linux.
+2. macOS parent-pid watcher; same cleanup test on macOS CI.
+3. `mvmctl sandbox ls` for detached sandboxes; audit on
+   create/destroy.
+4. Python binding (pyo3) + shared fixture suite.
+5. TypeScript binding (napi-rs); same fixture suite passes.
+6. Doc page in `public/src/content/docs/guides/sdk-lifecycle.md`
+   and status-table flip.
+
+**Risk.** Cross-platform parent-death handling. Linux gets
+`PR_SET_PDEATHSIG` for free; macOS needs a watcher thread or a
+kqueue `EVFILT_PROC NOTE_EXIT` subscription. Get this right or
+the "cleanup bound to parent" claim is false on macOS.
+
+### W5 — Cold-start measurement and budgets
+
+**Scope.** Extend `runtime_boot_bench` and
+`cargo xtask perf boot` into one canonical harness that reports
+fresh start-return, guest-agent-ready, snapshot restore,
+warm-pool claim, and SDK create-to-exec separately. Publish
+numbers with full host/backend/kernel/rootfs context.
+
+**Hard dependencies.** None. The harness exists; this is
+consolidation + reporting + CI budget gates.
+
+**Key new code (mostly refactors).**
+- `crates/mvm/src/perf/harness.rs` — single canonical harness.
+- `xtask/src/perf.rs` — extend with a `report` subcommand that
+  emits a markdown table under `specs/perf/`.
+- `specs/perf/` — checked-in benchmark reports per host/backend.
+- `.github/workflows/perf.yml` — CI budget gates for
+  representative artifacts; regression diff against prior report.
+
+**Shipped gate (ADR-048 §"Cold-start").**
+- Harness records host, backend, kernel/rootfs digest, CPU
+  model, memory, vCPU count, storage mode, readiness signal.
+- Numbers published as p50/p95/p99/max with readiness boundary
+  named.
+- Fresh boot, guest-agent-ready boot, snapshot restore,
+  warm-pool claim reported separately.
+- CI enforces regression budgets for representative artifacts.
+
+**Status-table transitions.**
+- Planned → **Preview** when one canonical report runs on one
+  host and one backend (e.g. macOS Apple Silicon + libkrun).
+- Preview → **Shipped** when the harness runs on at least two
+  backends, CI budget gates are green for ≥1 week, and
+  `specs/perf/` carries a published report.
+
+**ADR-048 §"Non-goals" constraint.** **Do NOT claim sub-100ms
+cold boot until p95 fresh guest-agent-ready supports it.** It is
+acceptable to claim faster warm-pool or snapshot numbers
+*labeled as such*. The gated phrase regex in W0's
+`check-doc-claims` will block any unqualified `<100ms` claim
+until the cold-start status row is flipped to Shipped *and* the
+docs that quote the number sit on the status-table page.
+
+**Suggested PR breakdown.**
+1. Consolidate `runtime_boot_bench` + `xtask perf boot` into
+   one harness; emit JSON.
+2. Add markdown `report` subcommand; commit first report under
+   `specs/perf/`.
+3. CI workflow `perf.yml` + budget gates.
+4. Doc page in `public/src/content/docs/reference/performance.md`
+   with the published numbers + methodology link.
+
+**Risk.** Numbers that disappoint. Microsandbox markets
+<100ms; we may be at 200-500ms on Firecracker cold boot with
+audit append and plan signing in the path. That is OK — publish
+the truth + warm-pool/snapshot numbers separately. Do not try to
+hide it behind misleading phrasing; the `check-doc-claims` lint
+will catch it.
+
+### W6 — Extensible filesystem backends
+
+**Scope.** Split the storage contract into mountable + API-only
+capability flags. Add conformance tests reused by every backend
+(local, encrypted, object store, memory). Define consistency /
+rename semantics for object stores. Cover path traversal,
+symlink escape, concurrent write, large-file edge cases.
+
+**Hard dependencies.** None. Builds on existing
+`crates/mvm-storage` `VolumeBackend` trait.
+
+**Key new code.**
+- `crates/mvm-storage/src/capability.rs` — `Mountable` vs
+  `ApiOnly` capability flags.
+- `crates/mvm-storage/tests/conformance.rs` — single conformance
+  suite reused per backend.
+- `crates/mvm-storage/src/backends/object_store.rs` — semantics
+  for consistency, rename, partial-write, health.
+- Audit kinds: `volume.attach`, `volume.detach`, `volume.read`,
+  `volume.write`, `volume.delete`, `volume.rename`,
+  `volume.snapshot`, `volume.backend.health.fail`.
+
+**Shipped gate (ADR-048 §"Filesystem backends").**
+- `VolumeBackend` / filesystem contract has conformance tests
+  reused by every backend.
+- Docs distinguish mountable from API-only backends.
+- Encrypted backends encrypt content + names where promised.
+- Object-store backends define consistency, rename,
+  partial-write, health semantics.
+- Tests cover path traversal, symlink escape, concurrent writes,
+  large files, deletion, rename, audit.
+
+**Status-table transitions.**
+- Planned → **Preview** when the conformance suite passes for
+  local + memory backends but encrypted/object-store are
+  incomplete.
+- Preview → **Shipped** when all four backends pass conformance
+  + the path-traversal/symlink-escape negative tests run in CI.
+
+**Suggested PR breakdown.**
+1. Capability flag split + minimal `Mountable` / `ApiOnly`
+   plumbing. No behavior change.
+2. Conformance test scaffold; local + memory backends pass.
+3. Encrypted backend (content + name encryption); conformance +
+   ciphertext-shape tests.
+4. Object-store backend (S3-API); conformance + consistency +
+   rename + partial-write tests.
+5. Audit emission across attach/detach/read/write/etc.
+6. Doc page in `public/src/content/docs/reference/storage-backends.md`
+   and status-table flip.
+
+**Risk.** Encrypted-backend "names where promised" — this is
+optional per the ADR ("where promised"). Decide up front whether
+the encrypted backend encrypts names; document the decision.
+Object-store consistency under concurrent writes is fundamentally
+weaker than ext4 — the contract MUST state this explicitly.
+
+## Cross-cutting concerns
+
+### CI gates per claim
+
+Each Shipped status flip requires a corresponding CI lane to
+exist *before* the flip:
+
+| Claim                 | CI gate that must be green                                  |
+| --------------------- | ----------------------------------------------------------- |
+| oci-ingest            | Hermetic-registry integration job + digest-pin negative test |
+| network-policy        | DNS rebinding + raw-IP bypass + wrong-SNI denial tests       |
+| secret-non-leakage    | Hostile-guest exfiltration + redaction sweep tests           |
+| sdk-lifecycle         | Same fixture suite green on Linux + macOS, 3 SDKs            |
+| cold-start            | Budget gate green for ≥1 week + published `specs/perf/` report |
+| filesystem-backends   | Conformance suite green per backend + traversal/escape tests |
+
+A status flip PR must include the workflow change *and* the
+status-table edit in the same commit. Otherwise the
+`check-doc-claims` lint can't be trusted as the gate (table
+edit without CI = false Shipped; CI without table edit = wasted
+gate).
+
+### Status-table flip discipline
+
+Flipping a row from Planned → Preview or Preview → Shipped is
+the moment that unblocks marketing language. The flip is a
+two-line edit (the `<!-- claim:foo status:Preview -->` marker
+and the visible table cell). Combine it with:
+
+1. The CI workflow change that enforces the gate.
+2. A new doc page (or section) under
+   `public/src/content/docs/`.
+3. An update to the per-claim "what would move it to Preview /
+   Shipped" mini-section on
+   `public/src/content/docs/security/sandbox-parity-status.md`
+   to reflect the new baseline.
+
+### Definition of done per workstream
+
+A workstream is "done" when:
+
+1. All ADR-048 gate bullets are checked.
+2. The status-table row is flipped to Shipped and the CI
+   workflow that enforces the gate is in `.github/workflows/`.
+3. A user-facing doc page exists (not a placeholder).
+4. `cargo test --workspace` + `cargo clippy --workspace
+   --all-targets -- -D warnings` clean on host.
+5. Linux-only tests (vsock, jailer/seccomp, dm-verity, network
+   namespaces) pass in the builder VM per AGENTS.md.
+6. `specs/SPRINT.md` updated to reflect completion.
+7. The `cargo xtask check-doc-claims` lint stays clean after
+   the flip (i.e., the new docs that quote previously-gated
+   phrases now legitimately have the Shipped marker).
+
+## Risks
+
+The eight cross-cutting risks (R1-R8) plus the "Risks resolved since
+plan was written" note live in the parent plan
+[`74-claim-safe-sandbox-parity.md` §"Risks"](74-claim-safe-sandbox-parity.md#risks).
+That section is the canonical reference — owners, current evidence,
+mitigation assignments. This sidecar does not duplicate; pick up the
+relevant Rn entry when starting a workstream and check it against
+current code state before kicking off.
+
+Quick map from workstream to load-bearing risks:
+
+| Workstream | Risks that affect kickoff   |
+| ---------- | --------------------------- |
+| W1 OCI     | **R3** (verity A or B before code lands), **R10** (layer-unpack CVE class), R8 |
+| W2 network | R1, **R4** (audit backpressure), R6, **R9** (TLS substitution mechanism), **R11** (non-HTTP egress), **R12** (DoH/DoT bypass), R8 |
+| W3 secrets | R1, **R2** (panic hook is new), R5 (snapshot interaction), R6, **R9** (substitution mechanism gates W3 entirely), R11 (non-HTTP secret channels), R8 |
+| W4 SDK     | R6 (macOS kqueue parity), R8 |
+| W5 perf    | R7 (publish every readiness boundary), R8 |
+| W6 storage | R4 (new audit kinds), R8 |
+
+**R9 is the single biggest gate** — pick the TLS substitution shape
+(proxy-with-CA / vsock side-channel / host-side reconstruction)
+before W2 codes the proxy. The decision shapes W2's proxy and W3's
+entire substitution architecture. Strongly recommend its own ADR
+before either workstream starts.
+
+## Verification
+
+This doc is descriptive. To check its claims:
+
+- Status taxonomy + seven claims: `specs/adrs/048-claim-safe-sandbox-parity.md`.
+- W0 lint behaviour: `xtask/src/check_doc_claims.rs` (after
+  W0 lands) + inline unit tests.
+- mvmd handoff: mvmd ADR-0020 in the sibling repo (cross-repo
+  reference; not in this tree).
+- Builder-VM transition state:
+  `specs/plans/72-libkrun-builder-vm.md` (or successor) and the
+  memory note `project_builder_vm_being_replaced.md`.

--- a/specs/plans/74-w1-w6-attack-plan.md
+++ b/specs/plans/74-w1-w6-attack-plan.md
@@ -517,11 +517,14 @@ Quick map from workstream to load-bearing risks:
 | W5 perf    | R7 (publish every readiness boundary), R8 |
 | W6 storage | R4 (new audit kinds), R8 |
 
-**R9 is the single biggest gate** — pick the TLS substitution shape
-(proxy-with-CA / vsock side-channel / host-side reconstruction)
-before W2 codes the proxy. The decision shapes W2's proxy and W3's
-entire substitution architecture. Strongly recommend its own ADR
-before either workstream starts.
+**R3 and R9 are now decided** —
+[ADR-050](050-oci-image-verity-posture.md) picks pull-time verity
+generation for W1, and
+[ADR-049](049-secret-substitution-mechanism.md) picks the vsock
+side-channel for W3 (with proxy-with-CA available later as an
+explicit opt-in feature flag). Both ADRs ship with concrete task
+additions for their workstreams. The remaining top-level risks
+(R1, R2, R4-R8, R10-R12) stay open and reference the parent plan.
 
 ## Verification
 

--- a/xtask/Cargo.toml
+++ b/xtask/Cargo.toml
@@ -10,6 +10,7 @@ clap.workspace = true
 clap_mangen.workspace = true
 mvm-build.workspace = true
 mvm-cli.workspace = true
+regex.workspace = true
 serde.workspace = true
 serde_json.workspace = true
 sha2.workspace = true

--- a/xtask/src/check_doc_claims.rs
+++ b/xtask/src/check_doc_claims.rs
@@ -1,0 +1,401 @@
+//! `xtask check-doc-claims`
+//!
+//! Plan 74 W0 — claims hygiene lint. Reject marketing phrases that
+//! over-claim mvm's runtime posture in public docs. Each gated phrase
+//! maps to a claim id from ADR-048 §"The seven target claims"
+//! (`specs/adrs/048-claim-safe-sandbox-parity.md`). A phrase is only
+//! allowed in a file that either (a) marks the corresponding claim
+//! `Shipped` via a machine marker, (b) carries an inline opt-out
+//! comment, or (c) sits on the path allow-list.
+//!
+//! ## Scan scope
+//!
+//! `public/src/content/docs/**/*.{md,mdx}` plus the repo-root
+//! `README.md`. Deliberately narrow:
+//!
+//! - `specs/`, `CLAUDE.md`, `AGENTS.md`, and crate-level `*.md` are
+//!   contributor-facing, not user-facing. We don't lint them.
+//! - The status table page itself
+//!   (`public/src/content/docs/security/sandbox-parity-status.md`)
+//!   must quote every gated phrase — it's the source of truth — so
+//!   it's path-allowed.
+//! - The migration guide
+//!   (`public/src/content/docs/guides/mvmforge-migration.md`) is a
+//!   deliberate historical archive and stays path-allowed.
+//!
+//! ## Machine markers
+//!
+//! Files can declare a claim's status with an HTML comment:
+//!
+//! ```text
+//! <!-- claim:cold-start status:Shipped -->
+//! ```
+//!
+//! A gated phrase whose claim id has `status:Shipped` in the same
+//! file is allowed without an inline opt-out.
+//!
+//! ## Inline opt-out
+//!
+//! `<!-- allow(doc-claim:<claim_id>): <reason> -->` on the same line
+//! or up to two lines above the offending phrase suppresses the
+//! finding. Keyed by claim id (not phrase slug) so a single comment
+//! covers every variant of the same claim. Matches the
+//! `allow(audit-positional)` / `allow(secret-debug)` convention used
+//! elsewhere in the workspace.
+//!
+//! ## Why the lint reads raw source
+//!
+//! HTML comments are not stripped before scanning. A banned phrase
+//! buried inside an arbitrary `<!-- ... -->` block still counts as a
+//! finding unless the author adds the explicit opt-out marker. This
+//! prevents commented-out copy-paste from sneaking past the gate.
+
+use anyhow::{Context, Result, bail};
+use regex::Regex;
+use std::collections::HashMap;
+use std::path::{Path, PathBuf};
+
+const DOCS_DIR: &str = "public/src/content/docs";
+const README: &str = "README.md";
+
+/// Files where a gated phrase is allowed regardless of status or
+/// opt-out. These are pages whose job is to *talk about* the gated
+/// phrases — the status table itself, and the deliberate migration
+/// archive.
+const PATH_ALLOW_LIST: &[&str] = &[
+    "public/src/content/docs/security/sandbox-parity-status.md",
+    "public/src/content/docs/guides/mvmforge-migration.md",
+];
+
+/// Gated phrase → claim id. Each entry is a regex compiled once at
+/// run time. Keep the list small enough that a human can review it.
+const GATED: &[(&str, &str)] = &[
+    (r"(?i)\bany\s+OCI\s+images?\b", "oci-ingest"),
+    (r"(?i)\barbitrary\s+OCI\s+images?\b", "oci-ingest"),
+    (r"(?i)\bsecrets?\s+cannot\s+leak\b", "secret-non-leakage"),
+    (r"(?i)never\s+enters?\s+the\s+guest", "secret-non-leakage"),
+    (r"(?i)<\s*100\s*ms\b", "cold-start"),
+    (r"(?i)\bsub-?\s*100\s*ms\b", "cold-start"),
+];
+
+#[derive(Debug, Clone)]
+struct Finding {
+    path: PathBuf,
+    line: usize,
+    claim_id: String,
+    snippet: String,
+}
+
+/// Run the lint over `public/src/content/docs/**/*.{md,mdx}` and the
+/// repo-root `README.md` rooted at `workspace`.
+pub fn run(workspace: &Path) -> Result<()> {
+    let docs_dir = workspace.join(DOCS_DIR);
+    if !docs_dir.is_dir() {
+        bail!(
+            "expected docs dir at {}; got nothing",
+            docs_dir.display()
+        );
+    }
+
+    let patterns = compile_patterns()?;
+
+    let mut findings: Vec<Finding> = Vec::new();
+
+    visit_doc_files(&docs_dir, &mut |path| -> Result<()> {
+        if is_path_allowed(workspace, path) {
+            return Ok(());
+        }
+        let source = std::fs::read_to_string(path)
+            .with_context(|| format!("reading {}", path.display()))?;
+        findings.extend(lint_source(path, &source, &patterns));
+        Ok(())
+    })?;
+
+    let readme = workspace.join(README);
+    if readme.is_file() && !is_path_allowed(workspace, &readme) {
+        let source = std::fs::read_to_string(&readme)
+            .with_context(|| format!("reading {}", readme.display()))?;
+        findings.extend(lint_source(&readme, &source, &patterns));
+    }
+
+    if findings.is_empty() {
+        eprintln!(
+            "check-doc-claims: clean (scanned {}/**/*.{{md,mdx}} and {})",
+            DOCS_DIR, README
+        );
+        return Ok(());
+    }
+
+    eprintln!(
+        "check-doc-claims: {} gated-phrase finding(s) — flip the \
+         claim row to Shipped in the status table, add an \
+         `<!-- allow(doc-claim:<id>): <reason> -->` opt-out, or \
+         reword the phrase",
+        findings.len()
+    );
+    for f in &findings {
+        eprintln!(
+            "  {}:{} — claim:{} — {}",
+            f.path.display(),
+            f.line,
+            f.claim_id,
+            f.snippet
+        );
+    }
+    std::process::exit(1);
+}
+
+fn compile_patterns() -> Result<Vec<(Regex, &'static str)>> {
+    GATED
+        .iter()
+        .map(|(pat, claim)| {
+            Regex::new(pat)
+                .with_context(|| format!("compiling gated regex {pat}"))
+                .map(|re| (re, *claim))
+        })
+        .collect()
+}
+
+fn is_path_allowed(workspace: &Path, path: &Path) -> bool {
+    let rel = match path.strip_prefix(workspace) {
+        Ok(rel) => rel,
+        Err(_) => return false,
+    };
+    let rel_str = rel.to_string_lossy().replace('\\', "/");
+    PATH_ALLOW_LIST.iter().any(|allowed| rel_str == *allowed)
+}
+
+fn visit_doc_files(dir: &Path, cb: &mut dyn FnMut(&Path) -> Result<()>) -> Result<()> {
+    for entry in
+        std::fs::read_dir(dir).with_context(|| format!("reading dir {}", dir.display()))?
+    {
+        let entry = entry?;
+        let path = entry.path();
+        if path.is_dir() {
+            let name = path
+                .file_name()
+                .and_then(|n| n.to_str())
+                .unwrap_or_default();
+            if matches!(name, "target" | "node_modules" | ".git") {
+                continue;
+            }
+            visit_doc_files(&path, cb)?;
+        } else if path
+            .extension()
+            .and_then(|e| e.to_str())
+            .map(|e| matches!(e, "md" | "mdx"))
+            .unwrap_or(false)
+        {
+            cb(&path)?;
+        }
+    }
+    Ok(())
+}
+
+/// Discover `<!-- claim:<id> status:<word> -->` markers in the file
+/// and return a map from claim id to status string (lower-cased).
+fn discover_claim_statuses(source: &str) -> HashMap<String, String> {
+    let marker_re = Regex::new(
+        r"(?i)<!--\s*claim:\s*([A-Za-z0-9_-]+)\s+status:\s*([A-Za-z][A-Za-z _-]*?)\s*-->",
+    )
+    .expect("static claim marker regex compiles");
+
+    let mut statuses = HashMap::new();
+    for cap in marker_re.captures_iter(source) {
+        let claim = cap[1].to_string();
+        let status = cap[2].trim().to_lowercase();
+        statuses.insert(claim, status);
+    }
+    statuses
+}
+
+/// True when a window of up to two lines before `idx` (and the
+/// matching line itself) carries an inline opt-out for `claim_id`.
+fn has_allow_in_window(lines: &[&str], idx: usize, claim_id: &str) -> bool {
+    let start = idx.saturating_sub(2);
+    let end = (idx + 1).min(lines.len());
+    let needle = format!("allow(doc-claim:{claim_id})");
+    lines[start..end].iter().any(|l| l.contains(&needle))
+}
+
+fn lint_source(path: &Path, source: &str, patterns: &[(Regex, &'static str)]) -> Vec<Finding> {
+    let statuses = discover_claim_statuses(source);
+    let lines: Vec<&str> = source.lines().collect();
+    let mut findings = Vec::new();
+
+    for (i, raw) in lines.iter().enumerate() {
+        for (re, claim_id) in patterns {
+            if !re.is_match(raw) {
+                continue;
+            }
+            if statuses
+                .get(*claim_id)
+                .map(|s| s == "shipped")
+                .unwrap_or(false)
+            {
+                continue;
+            }
+            if has_allow_in_window(&lines, i, claim_id) {
+                continue;
+            }
+            findings.push(Finding {
+                path: path.to_path_buf(),
+                line: i + 1,
+                claim_id: (*claim_id).to_string(),
+                snippet: raw.trim().to_string(),
+            });
+            // One finding per line is enough; if multiple phrases
+            // match the same line they almost always cite the same
+            // claim id and the author will fix them together.
+            break;
+        }
+    }
+    findings
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn patterns() -> Vec<(Regex, &'static str)> {
+        compile_patterns().expect("static patterns compile")
+    }
+
+    #[test]
+    fn clean_doc_is_clean() {
+        let src = "# Heading\n\nNothing controversial here.\n";
+        let findings = lint_source(Path::new("ok.md"), src, &patterns());
+        assert!(findings.is_empty(), "expected no findings, got {findings:?}");
+    }
+
+    #[test]
+    fn raw_sub_100ms_fires() {
+        let src = "Boot time is <100ms today.\n";
+        let findings = lint_source(Path::new("x.md"), src, &patterns());
+        assert_eq!(findings.len(), 1);
+        assert_eq!(findings[0].claim_id, "cold-start");
+        assert_eq!(findings[0].line, 1);
+    }
+
+    #[test]
+    fn inline_allow_suppresses() {
+        let src = "<!-- allow(doc-claim:cold-start): example only -->\n\
+                   Boot time is <100ms today.\n";
+        let findings = lint_source(Path::new("x.md"), src, &patterns());
+        assert!(findings.is_empty(), "opt-out should suppress; got {findings:?}");
+    }
+
+    #[test]
+    fn allow_on_same_line_suppresses() {
+        let src = "Boot time is <100ms <!-- allow(doc-claim:cold-start): pre-merge demo -->\n";
+        let findings = lint_source(Path::new("x.md"), src, &patterns());
+        assert!(findings.is_empty(), "same-line opt-out should suppress");
+    }
+
+    #[test]
+    fn shipped_status_marker_unlocks_claim() {
+        let src = "<!-- claim:cold-start status:Shipped -->\n\
+                   p95 fresh-boot is now <100ms.\n";
+        let findings = lint_source(Path::new("x.md"), src, &patterns());
+        assert!(findings.is_empty(), "Shipped marker should unlock; got {findings:?}");
+    }
+
+    #[test]
+    fn planned_status_marker_does_not_unlock() {
+        let src = "<!-- claim:cold-start status:Planned -->\n\
+                   We will eventually hit <100ms.\n";
+        let findings = lint_source(Path::new("x.md"), src, &patterns());
+        assert_eq!(findings.len(), 1);
+        assert_eq!(findings[0].claim_id, "cold-start");
+    }
+
+    #[test]
+    fn html_comment_does_not_hide_phrase() {
+        // A banned phrase buried in a regular comment is still a
+        // finding — only the explicit allow marker bypasses.
+        let src = "<!-- TODO: rewrite the sub-100ms pitch later -->\n";
+        let findings = lint_source(Path::new("x.md"), src, &patterns());
+        assert_eq!(findings.len(), 1);
+        assert_eq!(findings[0].claim_id, "cold-start");
+    }
+
+    #[test]
+    fn variant_spelling_catches_oci_phrases() {
+        let cases = &[
+            ("We accept any OCI image.", "oci-ingest"),
+            ("Run arbitrary OCI images locally.", "oci-ingest"),
+        ];
+        for (src, expected_claim) in cases {
+            let findings = lint_source(Path::new("x.md"), src, &patterns());
+            assert_eq!(findings.len(), 1, "case {src:?}");
+            assert_eq!(findings[0].claim_id, *expected_claim, "case {src:?}");
+        }
+    }
+
+    #[test]
+    fn variant_spelling_catches_secret_phrases() {
+        let cases = &[
+            ("Secrets cannot leak.", "secret-non-leakage"),
+            ("The secret cannot leak from the guest.", "secret-non-leakage"),
+            ("The value never enters the guest.", "secret-non-leakage"),
+            ("Real secrets never enter the guest.", "secret-non-leakage"),
+        ];
+        for (src, expected_claim) in cases {
+            let findings = lint_source(Path::new("x.md"), src, &patterns());
+            assert_eq!(findings.len(), 1, "case {src:?}");
+            assert_eq!(findings[0].claim_id, *expected_claim, "case {src:?}");
+        }
+    }
+
+    #[test]
+    fn variant_spelling_catches_cold_start_phrases() {
+        let cases = &[
+            "Boot in sub-100ms.",
+            "Boot in sub 100 ms.",
+            "Boot in <100ms.",
+            "Boot in <  100  ms.",
+        ];
+        for src in cases {
+            let findings = lint_source(Path::new("x.md"), src, &patterns());
+            assert_eq!(findings.len(), 1, "case {src:?}");
+            assert_eq!(findings[0].claim_id, "cold-start", "case {src:?}");
+        }
+    }
+
+    #[test]
+    fn allow_marker_keyed_by_claim_covers_all_variants() {
+        let src = "<!-- allow(doc-claim:cold-start): all variants -->\n\
+                   Boot in sub-100ms. Or <100ms. Or sub 100 ms.\n";
+        let findings = lint_source(Path::new("x.md"), src, &patterns());
+        assert!(
+            findings.is_empty(),
+            "claim-id-keyed allow should cover variants; got {findings:?}"
+        );
+    }
+
+    #[test]
+    fn allow_marker_for_wrong_claim_does_not_suppress() {
+        let src = "<!-- allow(doc-claim:oci-ingest): wrong claim -->\n\
+                   Boot in sub-100ms.\n";
+        let findings = lint_source(Path::new("x.md"), src, &patterns());
+        assert_eq!(findings.len(), 1, "wrong claim id should not suppress");
+        assert_eq!(findings[0].claim_id, "cold-start");
+    }
+
+    #[test]
+    fn status_marker_is_case_insensitive_on_value() {
+        let src_shipped = "<!-- claim:cold-start status:shipped -->\n\
+                           Boot in <100ms.\n";
+        assert!(
+            lint_source(Path::new("x.md"), src_shipped, &patterns()).is_empty(),
+            "lower-case 'shipped' should match"
+        );
+
+        let src_mixed = "<!-- claim:cold-start status:SHIPPED -->\n\
+                         Boot in <100ms.\n";
+        assert!(
+            lint_source(Path::new("x.md"), src_mixed, &patterns()).is_empty(),
+            "upper-case 'SHIPPED' should match"
+        );
+    }
+}

--- a/xtask/src/check_doc_claims.rs
+++ b/xtask/src/check_doc_claims.rs
@@ -91,10 +91,7 @@ struct Finding {
 pub fn run(workspace: &Path) -> Result<()> {
     let docs_dir = workspace.join(DOCS_DIR);
     if !docs_dir.is_dir() {
-        bail!(
-            "expected docs dir at {}; got nothing",
-            docs_dir.display()
-        );
+        bail!("expected docs dir at {}; got nothing", docs_dir.display());
     }
 
     let patterns = compile_patterns()?;
@@ -105,8 +102,8 @@ pub fn run(workspace: &Path) -> Result<()> {
         if is_path_allowed(workspace, path) {
             return Ok(());
         }
-        let source = std::fs::read_to_string(path)
-            .with_context(|| format!("reading {}", path.display()))?;
+        let source =
+            std::fs::read_to_string(path).with_context(|| format!("reading {}", path.display()))?;
         findings.extend(lint_source(path, &source, &patterns));
         Ok(())
     })?;
@@ -166,9 +163,7 @@ fn is_path_allowed(workspace: &Path, path: &Path) -> bool {
 }
 
 fn visit_doc_files(dir: &Path, cb: &mut dyn FnMut(&Path) -> Result<()>) -> Result<()> {
-    for entry in
-        std::fs::read_dir(dir).with_context(|| format!("reading dir {}", dir.display()))?
-    {
+    for entry in std::fs::read_dir(dir).with_context(|| format!("reading dir {}", dir.display()))? {
         let entry = entry?;
         let path = entry.path();
         if path.is_dir() {
@@ -265,7 +260,10 @@ mod tests {
     fn clean_doc_is_clean() {
         let src = "# Heading\n\nNothing controversial here.\n";
         let findings = lint_source(Path::new("ok.md"), src, &patterns());
-        assert!(findings.is_empty(), "expected no findings, got {findings:?}");
+        assert!(
+            findings.is_empty(),
+            "expected no findings, got {findings:?}"
+        );
     }
 
     #[test]
@@ -282,7 +280,10 @@ mod tests {
         let src = "<!-- allow(doc-claim:cold-start): example only -->\n\
                    Boot time is <100ms today.\n";
         let findings = lint_source(Path::new("x.md"), src, &patterns());
-        assert!(findings.is_empty(), "opt-out should suppress; got {findings:?}");
+        assert!(
+            findings.is_empty(),
+            "opt-out should suppress; got {findings:?}"
+        );
     }
 
     #[test]
@@ -297,7 +298,10 @@ mod tests {
         let src = "<!-- claim:cold-start status:Shipped -->\n\
                    p95 fresh-boot is now <100ms.\n";
         let findings = lint_source(Path::new("x.md"), src, &patterns());
-        assert!(findings.is_empty(), "Shipped marker should unlock; got {findings:?}");
+        assert!(
+            findings.is_empty(),
+            "Shipped marker should unlock; got {findings:?}"
+        );
     }
 
     #[test]
@@ -336,7 +340,10 @@ mod tests {
     fn variant_spelling_catches_secret_phrases() {
         let cases = &[
             ("Secrets cannot leak.", "secret-non-leakage"),
-            ("The secret cannot leak from the guest.", "secret-non-leakage"),
+            (
+                "The secret cannot leak from the guest.",
+                "secret-non-leakage",
+            ),
             ("The value never enters the guest.", "secret-non-leakage"),
             ("Real secrets never enter the guest.", "secret-non-leakage"),
         ];

--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -4,6 +4,7 @@ use std::path::{Path, PathBuf};
 mod build_dev_image;
 mod check_adr_coverage;
 mod check_audit_positional;
+mod check_doc_claims;
 mod check_forbidden_deps;
 mod check_no_display_on_secret_types;
 mod check_no_overclaim;
@@ -29,6 +30,10 @@ fn main() -> Result<()> {
             let workspace = workspace_root();
             check_audit_positional::run(&workspace)
         }
+        Some("check-doc-claims") => {
+            let workspace = workspace_root();
+            check_doc_claims::run(&workspace)
+        }
         Some("check-forbidden-deps") => {
             let workspace = workspace_root();
             check_forbidden_deps::run(&workspace)
@@ -51,7 +56,7 @@ fn main() -> Result<()> {
             gen_stubs::check(&workspace)
         }
         Some(other) => anyhow::bail!(
-            "Unknown xtask: {:?}. Available: gen-man, check-adr-coverage, check-no-display-on-secret-types, check-audit-positional, check-forbidden-deps, check-no-overclaim, perf, build-dev-image, gen-stubs, check-stubs",
+            "Unknown xtask: {:?}. Available: gen-man, check-adr-coverage, check-no-display-on-secret-types, check-audit-positional, check-doc-claims, check-forbidden-deps, check-no-overclaim, perf, build-dev-image, gen-stubs, check-stubs",
             other
         ),
         None => {
@@ -68,6 +73,9 @@ fn main() -> Result<()> {
             );
             eprintln!(
                 "  check-audit-positional                  Plan 60 Phase 4 lint: reject positional audit::emit / event-chain calls"
+            );
+            eprintln!(
+                "  check-doc-claims                        Plan 74 W0 lint: reject gated marketing phrases in public docs"
             );
             eprintln!(
                 "  check-forbidden-deps                    Reject sea-* and mysql crates in Cargo.lock"


### PR DESCRIPTION
## Summary

Plan 74 W0 — claims hygiene + docs guardrails. Docs/lint only, no
runtime changes. The PR also lands the foundational ADR/plan triad
because both were untracked in `main` and W0's value depends on them
being load-bearing in CI. A follow-up commit lands **ADR-049** and
**ADR-050**, which close the two architectural risks (R9 and R3)
raised by Plan 74's `## Risks` section.

### Planning artifacts

- **ADR-048** records seven sandbox-parity claims and the gates
  that must close before each is allowed in public docs.
- **Plan 74** sequences W0-W6 and carries a fully-cited
  `## Risks` section (R1-R12) plus a "Risks resolved" note
  confirming the libkrun builder VM (Plan 72) is the default and
  W1-W4 are not infra-blocked.
- **`74-w1-w6-attack-plan.md`** sidecar sequences W1-W6 and maps
  each workstream to the relevant risks.
- **ADR-049 — TLS substitution mechanism for guest secret
  placeholders.** Picks the vsock side-channel as the W3
  default; rejects proxy-with-CA (CA in every guest expands the
  host trust boundary) and host-side reconstruction (breaks HTTPS
  SaaS). (a) lands later behind `unsafe_guest_tls_inspection`.
- **ADR-050 — Verity posture for pulled OCI images.** Picks
  pull-time verity generation by default; dev profile gets
  `--no-verity`; production-profile admission rejects pulled
  templates without a verity sidecar. Claim 3 stays unchanged.

### W0 implementation

- **`cargo xtask check-doc-claims`** rejects gated marketing
  phrases (`<100ms` and variants, `any OCI image`, `arbitrary OCI
  image[s]`, `secrets cannot leak`, `never enters the guest`) in
  `public/src/content/docs/**/*.{md,mdx}` + `README.md` unless
  the file declares the corresponding claim Shipped via a
  `<!-- claim:<id> status:Shipped -->` machine marker, carries an
  `<!-- allow(doc-claim:<id>): <reason> -->` opt-out comment, or
  sits on a short path allow-list (the status page + the
  `mvmforge` migration guide). 13 inline unit tests; wired into
  the `lint` CI job alongside the existing
  check-no-display-on-secret-types / check-audit-positional
  gates.
- **New `Sandbox parity status` page** at
  `public/src/content/docs/security/sandbox-parity-status.md`
  (registered in the Security sidebar) is the source of truth
  for which claims are Shipped / Preview / Planned / Not claimed.
  Six claims start as Planned; `claims-hygiene` ships with this
  PR.
- **`mvmforge` cleanup**: live references stripped from
  `guides/exec.md` and `reference/cli-commands.md`; remaining
  mentions are pointers to the migration guide. The migration
  guide is intentionally retained and path-allow-listed.
- **Gap analysis updated** for the current `crates/mvm-sdk` +
  `crates/mvm-sdk-macros` layout and the mvmd ADR-0020
  cross-repo handoff for OCI ingest.
- **`specs/SPRINT.md`** notes Sprint 53 W0 in flight; W1-W6 stay
  Proposed.

## Commit structure

1. `docs(specs): add ADR-048, Plan 74, and W1-W6 attack plan` —
   the conceptual foundation.
2. `feat(xtask,docs): plan 74 W0` — the implementation.
3. `docs(adrs): ADR-049 + ADR-050 close plan 74 R3 and R9` —
   architectural decisions that gate W1 and W2/W3.

## Out of scope (W1-W6 implementation)

No runtime code, no network policy, no OCI ingest, no secret
placeholder runtime, no SDK lifecycle surface, no boot benchmark
harness, no filesystem backends. Those are W1-W6 and land later
under their own PRs. With ADR-049 and ADR-050 landed, W1, W2,
W3 all have stable architectural contracts to code against. R1,
R2, R4-R8, R10-R12 stay open per Plan 74 §Risks.

## Test plan

- [x] `cargo test --workspace --no-fail-fast` — 3 200 passed,
      0 failed, 9 ignored across 79 test binaries (host).
- [x] `cargo clippy --workspace --all-targets -- -D warnings` —
      zero warnings.
- [x] `cargo run -p xtask -- check-doc-claims` — clean on the
      post-W0 repo.
- [x] Negative test: inject `<100ms` into a non-allow-listed
      page → lint exits 1 with file:line + claim id; revert
      restores green.
- [x] `cargo test -p xtask check_doc_claims` — 13/13 pass.
- [ ] CI lint job runs `check-doc-claims` cleanly.
- [ ] Astro/Starlight site builds with the new sidebar entry.
- [ ] mvmd ADR-0020 cross-repo follow-up issue opened (out of
      scope for this PR — flag for W1 kickoff).

🤖 Generated with [Claude Code](https://claude.com/claude-code)