### PR TITLE
plan 74 W1.1 — mvm-oci crate skeleton: reference parser + manifest fetcher + digest verify

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -466,7 +466,7 @@ dependencies = [
  "bitflags 2.11.0",
  "cexpr",
  "clang-sys",
- "itertools 0.10.5",
+ "itertools 0.11.0",
  "log",
  "prettyplease",
  "proc-macro2",
@@ -2008,7 +2008,7 @@ dependencies = [
  "libc",
  "percent-encoding",
  "pin-project-lite",
- "socket2 0.5.10",
+ "socket2 0.6.2",
  "tokio",
  "tower-service",
  "tracing",
@@ -2413,6 +2413,20 @@ dependencies = [
  "smallstr",
  "smallvec",
  "utf8-decode",
+]
+
+[[package]]
+name = "jsonwebtoken"
+version = "10.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0529410abe238729a60b108898784df8984c87f6054c9c4fcacc47e4803c1ce1"
+dependencies = [
+ "base64 0.22.1",
+ "getrandom 0.2.17",
+ "js-sys",
+ "serde",
+ "serde_json",
+ "signature",
 ]
 
 [[package]]
@@ -2941,7 +2955,7 @@ dependencies = [
  "notify-debouncer-mini",
  "predicates",
  "rand 0.8.6",
- "reqwest",
+ "reqwest 0.12.28",
  "secrecy",
  "serde",
  "serde_json",
@@ -3040,6 +3054,21 @@ dependencies = [
  "serde_json",
  "tracing",
  "tracing-subscriber",
+]
+
+[[package]]
+name = "mvm-oci"
+version = "0.14.0"
+dependencies = [
+ "async-trait",
+ "hex",
+ "oci-client 0.16.1",
+ "serde",
+ "serde_json",
+ "sha2",
+ "thiserror 1.0.69",
+ "tokio",
+ "url",
 ]
 
 [[package]]
@@ -3190,7 +3219,7 @@ dependencies = [
  "mvm-sdk",
  "rand 0.8.6",
  "regex",
- "reqwest",
+ "reqwest 0.12.28",
  "secrecy",
  "serde",
  "serde_json",
@@ -3423,12 +3452,12 @@ version = "5.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "51e219e79014df21a225b1860a479e2dcd7cbd9130f4defd4bd0e191ea31d67d"
 dependencies = [
- "base64 0.21.7",
+ "base64 0.22.1",
  "chrono",
  "getrandom 0.2.17",
  "http 1.4.0",
  "rand 0.8.6",
- "reqwest",
+ "reqwest 0.12.28",
  "serde",
  "serde_json",
  "serde_path_to_error",
@@ -3515,10 +3544,36 @@ dependencies = [
  "http-auth",
  "jwt",
  "lazy_static",
- "oci-spec",
+ "oci-spec 0.8.4",
  "olpc-cjson",
  "regex",
- "reqwest",
+ "reqwest 0.12.28",
+ "serde",
+ "serde_json",
+ "sha2",
+ "thiserror 2.0.18",
+ "tokio",
+ "tracing",
+ "unicase",
+]
+
+[[package]]
+name = "oci-client"
+version = "0.16.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1b7f8deaffcd3b0e3baf93dddcab3d18b91d46dc37d38a8b170089b234de5bb3"
+dependencies = [
+ "bytes",
+ "chrono",
+ "futures-util",
+ "http 1.4.0",
+ "http-auth",
+ "jsonwebtoken",
+ "lazy_static",
+ "oci-spec 0.9.0",
+ "olpc-cjson",
+ "regex",
+ "reqwest 0.13.3",
  "serde",
  "serde_json",
  "sha2",
@@ -3533,6 +3588,23 @@ name = "oci-spec"
 version = "0.8.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fc3da52b83ce3258fbf29f66ac784b279453c2ac3c22c5805371b921ede0d308"
+dependencies = [
+ "const_format",
+ "derive_builder",
+ "getset",
+ "regex",
+ "serde",
+ "serde_json",
+ "strum",
+ "strum_macros",
+ "thiserror 2.0.18",
+]
+
+[[package]]
+name = "oci-spec"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e8445a2631507cec628a15fdd6154b54a3ab3f20ed4fe9d73a3b8b7a4e1ba03a"
 dependencies = [
  "const_format",
  "derive_builder",
@@ -3597,7 +3669,7 @@ dependencies = [
  "percent-encoding",
  "quick-xml 0.36.2",
  "reqsign",
- "reqwest",
+ "reqwest 0.12.28",
  "serde",
  "serde_json",
  "tokio",
@@ -3634,6 +3706,12 @@ dependencies = [
  "thiserror 1.0.69",
  "url",
 ]
+
+[[package]]
+name = "openssl-probe"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7c87def4c32ab89d880effc9e097653c8da5d6ef28e6b539d313baaacfbafcbe"
 
 [[package]]
 name = "ordered-float"
@@ -4172,7 +4250,7 @@ dependencies = [
  "quinn-udp",
  "rustc-hash",
  "rustls",
- "socket2 0.5.10",
+ "socket2 0.6.2",
  "thiserror 2.0.18",
  "tokio",
  "tracing",
@@ -4185,6 +4263,7 @@ version = "0.11.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "434b42fec591c96ef50e21e886936e66d3cc3f737104fdb9b737c40ffb94c098"
 dependencies = [
+ "aws-lc-rs",
  "bytes",
  "getrandom 0.3.4",
  "lru-slab",
@@ -4209,7 +4288,7 @@ dependencies = [
  "cfg_aliases",
  "libc",
  "once_cell",
- "socket2 0.5.10",
+ "socket2 0.6.2",
  "tracing",
  "windows-sys 0.60.2",
 ]
@@ -4386,7 +4465,7 @@ dependencies = [
  "percent-encoding",
  "quick-xml 0.37.5",
  "rand 0.8.6",
- "reqwest",
+ "reqwest 0.12.28",
  "rust-ini",
  "serde",
  "serde_json",
@@ -4433,9 +4512,50 @@ dependencies = [
  "url",
  "wasm-bindgen",
  "wasm-bindgen-futures",
- "wasm-streams",
+ "wasm-streams 0.4.2",
  "web-sys",
  "webpki-roots",
+]
+
+[[package]]
+name = "reqwest"
+version = "0.13.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "62e0021ea2c22aed41653bc7e1419abb2c97e038ff2c33d0e1309e49a97deec0"
+dependencies = [
+ "base64 0.22.1",
+ "bytes",
+ "futures-core",
+ "futures-util",
+ "http 1.4.0",
+ "http-body 1.0.1",
+ "http-body-util",
+ "hyper 1.8.1",
+ "hyper-rustls",
+ "hyper-util",
+ "js-sys",
+ "log",
+ "percent-encoding",
+ "pin-project-lite",
+ "quinn",
+ "rustls",
+ "rustls-pki-types",
+ "rustls-platform-verifier",
+ "serde",
+ "serde_json",
+ "serde_urlencoded",
+ "sync_wrapper",
+ "tokio",
+ "tokio-rustls",
+ "tokio-util",
+ "tower",
+ "tower-http",
+ "tower-service",
+ "url",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "wasm-streams 0.5.0",
+ "web-sys",
 ]
 
 [[package]]
@@ -4562,6 +4682,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "rustls-native-certs"
+version = "0.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "612460d5f7bea540c490b2b6395d8e34a953e52b491accd6c86c8164c5932a63"
+dependencies = [
+ "openssl-probe",
+ "rustls-pki-types",
+ "schannel",
+ "security-framework",
+]
+
+[[package]]
 name = "rustls-pki-types"
 version = "1.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4570,6 +4702,33 @@ dependencies = [
  "web-time",
  "zeroize",
 ]
+
+[[package]]
+name = "rustls-platform-verifier"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "26d1e2536ce4f35f4846aa13bff16bd0ff40157cdb14cc056c7b14ba41233ba0"
+dependencies = [
+ "core-foundation",
+ "core-foundation-sys",
+ "jni",
+ "log",
+ "once_cell",
+ "rustls",
+ "rustls-native-certs",
+ "rustls-platform-verifier-android",
+ "rustls-webpki",
+ "security-framework",
+ "security-framework-sys",
+ "webpki-root-certs",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "rustls-platform-verifier-android"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f87165f0995f63a9fbeea62b64d10b4d9d8e78ec6d7d51fb2125fda7bb36788f"
 
 [[package]]
 name = "rustls-webpki"
@@ -4617,6 +4776,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "93fc1dc3aaa9bfed95e02e6eadabb4baf7e3078b0bd1b4d7b6b0b68378900502"
 dependencies = [
  "winapi-util",
+]
+
+[[package]]
+name = "schannel"
+version = "0.1.29"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "91c1b7e4904c873ef0710c1f407dde2e6287de2bebc1bbbf7d430bb7cbffd939"
+dependencies = [
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -4716,6 +4884,29 @@ checksum = "e891af845473308773346dc847b2c23ee78fe442e0472ac50e22a18a93d3ae5a"
 dependencies = [
  "serde",
  "zeroize",
+]
+
+[[package]]
+name = "security-framework"
+version = "3.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b7f4bc775c73d9a02cde8bf7b2ec4c9d12743edf609006c7facc23998404cd1d"
+dependencies = [
+ "bitflags 2.11.0",
+ "core-foundation",
+ "core-foundation-sys",
+ "libc",
+ "security-framework-sys",
+]
+
+[[package]]
+name = "security-framework-sys"
+version = "2.17.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6ce2691df843ecc5d231c0b14ece2acc3efb62c0a398c7e1d875f3983ce020e3"
+dependencies = [
+ "core-foundation-sys",
+ "libc",
 ]
 
 [[package]]
@@ -4980,7 +5171,7 @@ dependencies = [
  "futures-util",
  "hex",
  "json-syntax",
- "oci-client",
+ "oci-client 0.15.0",
  "openidconnect",
  "p256",
  "p384",
@@ -4988,7 +5179,7 @@ dependencies = [
  "pkcs1",
  "pkcs8",
  "rand 0.8.6",
- "reqwest",
+ "reqwest 0.12.28",
  "rsa",
  "rustls-pki-types",
  "rustls-webpki",
@@ -5554,7 +5745,7 @@ dependencies = [
  "olpc-cjson",
  "pem",
  "percent-encoding",
- "reqwest",
+ "reqwest 0.12.28",
  "rustls",
  "serde",
  "serde_json",
@@ -6042,6 +6233,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "wasm-streams"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9d1ec4f6517c9e11ae630e200b2b65d193279042e28edd4a2cda233e46670bbb"
+dependencies = [
+ "futures-util",
+ "js-sys",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "web-sys",
+]
+
+[[package]]
 name = "wasmparser"
 version = "0.244.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6087,6 +6291,15 @@ dependencies = [
  "objc2-foundation",
  "url",
  "web-sys",
+]
+
+[[package]]
+name = "webpki-root-certs"
+version = "1.0.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f31141ce3fc3e300ae89b78c0dd67f9708061d1d2eda54b8209346fd6be9a92c"
+dependencies = [
+ "rustls-pki-types",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,6 +15,13 @@ members = [
     "crates/mvm-guest",
     "crates/mvm-cli",
     "crates/mvm-mcp",
+    # plan 74 W1 — OCI image distribution client (registry resolution,
+    # manifest fetch, digest verification; layer fetch + ext4 unpack +
+    # verity generation land in subsequent W1 PRs). Anonymous-only at
+    # W1.1; private auth lands later behind the credential redaction
+    # contract from ADR-049. mvmd consumes this crate as a library per
+    # ADR-048 §"Runtime Ownership" — keep its dep closure small.
+    "crates/mvm-oci",
     # Plan 72 W3 — PID-1 for the libkrun builder VM. Linux-only at
     # runtime; the crate compiles on macOS / Windows as an inert
     # binary so workspace builds stay green for non-Linux contributors.

--- a/crates/mvm-oci/Cargo.toml
+++ b/crates/mvm-oci/Cargo.toml
@@ -1,0 +1,27 @@
+[package]
+name = "mvm-oci"
+version.workspace = true
+edition.workspace = true
+rust-version.workspace = true
+license.workspace = true
+repository.workspace = true
+homepage.workspace = true
+authors.workspace = true
+description = "OCI image distribution client for mvm — registry resolution, manifest fetch, digest verification. Layer fetch / unpack and rootfs materialization land in later plan 74 W1 PRs."
+
+[dependencies]
+async-trait = "0.1"
+hex.workspace = true
+oci-client = { version = "0.16", default-features = false, features = ["rustls-tls"] }
+serde.workspace = true
+serde_json.workspace = true
+sha2.workspace = true
+thiserror = "1"
+tokio = { workspace = true, features = ["macros", "rt"] }
+url = "2"
+
+[dev-dependencies]
+tokio = { workspace = true, features = ["macros", "rt", "rt-multi-thread", "test-util"] }
+
+[lints]
+workspace = true

--- a/crates/mvm-oci/src/error.rs
+++ b/crates/mvm-oci/src/error.rs
@@ -1,0 +1,45 @@
+//! Typed errors for `mvm-oci`.
+//!
+//! Each variant carries only the information needed to diagnose the
+//! failure. Registry hostnames, repository names, and manifest media
+//! types are not secrets and appear in error messages verbatim.
+//! When private-registry auth lands (later W1 PR), credential
+//! material will be carried via [`secrecy::SecretString`] and the
+//! `Display` impl will redact — that path is gated by ADR-049 and the
+//! `xtask check-no-display-on-secret-types` lint, so this enum can
+//! stay plain until then.
+
+use thiserror::Error;
+
+#[derive(Debug, Error)]
+pub enum OciError {
+    /// The reference string did not parse — empty, malformed, or
+    /// contained components that are reserved by the OCI spec.
+    #[error("invalid image reference: {0}")]
+    InvalidReference(String),
+
+    /// Fetched-manifest content digest did not match the digest the
+    /// caller pinned (or the digest the registry advertised). Always
+    /// fail closed.
+    #[error("manifest digest mismatch: expected {expected}, computed {computed}")]
+    DigestMismatch { expected: String, computed: String },
+
+    /// Caller asked us to verify a digest using an algorithm we do
+    /// not implement. v1 supports `sha256` only; the OCI spec allows
+    /// other algorithms but we narrow until they are explicitly
+    /// audited.
+    #[error("unsupported digest algorithm: {0}")]
+    UnsupportedDigestAlgorithm(String),
+
+    /// Digest string was malformed (missing `algorithm:` prefix,
+    /// truncated hex, mixed case, …). Spec compliance is strict; we
+    /// do not silently normalize.
+    #[error("malformed digest string: {0}")]
+    MalformedDigest(String),
+
+    /// The registry returned an error or the network call failed.
+    /// The wrapped string is the upstream message verbatim — no
+    /// credentials flow through this variant.
+    #[error("registry error: {0}")]
+    Registry(String),
+}

--- a/crates/mvm-oci/src/lib.rs
+++ b/crates/mvm-oci/src/lib.rs
@@ -1,0 +1,48 @@
+//! OCI image distribution client for mvm.
+//!
+//! Plan 74 W1 (`specs/plans/74-claim-safe-sandbox-parity.md` §W1)
+//! materializes OCI images into microVM-bootable templates without a
+//! host Docker daemon. This crate owns the *distribution* half of
+//! that pipeline:
+//!
+//! - **Reference parsing.** `<registry>/<repository>[:<tag>][@<digest>]`
+//!   strings normalize to a structured [`ImageReference`], which knows
+//!   whether it's tag-pinned or digest-pinned. Production-profile
+//!   admission (plan 74 W1.6) rejects tag-pinned references.
+//! - **Manifest fetch.** The [`ManifestFetcher`] trait fronts the
+//!   actual registry call; [`OciManifestFetcher`] is the real impl
+//!   over [`oci_client`]. Test code can stand in a fixture
+//!   implementation without bringing up a registry.
+//! - **Digest verification.** Every fetched manifest's content digest
+//!   is verified before it leaves the fetcher.
+//!   [`verify_sha256_digest`] is the standalone primitive — algorithm
+//!   support is intentionally narrow (sha256 only in v1) so any
+//!   future expansion is an explicit, reviewed decision.
+//!
+//! Layer fetch, ext4 unpacking (plan 74 §Risks R10 attack surface),
+//! verity generation (ADR-050), template registration, and the
+//! `mvmctl image pull` CLI surface land in subsequent W1 PRs.
+//! Private-registry authentication (Bearer / `.docker/config.json`)
+//! is also a later PR — W1.1 ships anonymous-only by design so the
+//! credential-as-secret handling can be reviewed in isolation against
+//! ADR-049's substitution machinery.
+//!
+//! Crate-level invariant: this crate **only** speaks the OCI
+//! distribution wire format. It does not touch the host filesystem,
+//! does not invoke `veritysetup`, and does not call into mvm's
+//! template registry. Those interactions live in `mvm-build` (rootfs
+//! materialization), `mvm-core` (template registry), and `mvm-cli`
+//! (user-facing commands). Keeping the boundary tight is what lets
+//! `mvmd` consume `mvm-oci` as a library without inheriting the
+//! Nix-flake builder closure (ADR-048 §"Runtime Ownership"; the
+//! cross-repo handoff to mvmd is tracked in issue #222).
+
+#![forbid(unsafe_code)]
+
+pub mod error;
+pub mod manifest;
+pub mod reference;
+
+pub use error::OciError;
+pub use manifest::{FetchedManifest, ManifestFetcher, OciManifestFetcher, verify_sha256_digest};
+pub use reference::ImageReference;

--- a/crates/mvm-oci/src/manifest.rs
+++ b/crates/mvm-oci/src/manifest.rs
@@ -1,0 +1,262 @@
+//! Manifest fetch + content-digest verification.
+//!
+//! The [`ManifestFetcher`] trait is the contract that downstream
+//! code consumes; [`OciManifestFetcher`] is the real implementation
+//! over `oci-client`. Splitting the trait from the impl lets test
+//! code substitute a fixture without standing up a registry — the
+//! hermetic in-process registry fixture lands in W1.2.
+//!
+//! Digest verification is always content-addressable: the SHA-256
+//! over the manifest bytes is compared against the digest the caller
+//! pinned (or the digest the registry advertised). A mismatch is a
+//! hard error; we never paper over it with a warning.
+
+use crate::OciError;
+use crate::reference::ImageReference;
+use async_trait::async_trait;
+use oci_client::client::{Client, ClientConfig};
+use oci_client::manifest::OciManifest;
+use oci_client::secrets::RegistryAuth;
+use sha2::{Digest, Sha256};
+
+/// Result of a manifest fetch. Bytes are kept verbatim because
+/// digest verification is byte-exact — any normalization
+/// (whitespace, key ordering) would change the digest and break the
+/// pin.
+#[derive(Debug, Clone)]
+pub struct FetchedManifest {
+    /// The reference the manifest was fetched against, after
+    /// canonicalization.
+    pub reference: ImageReference,
+    /// SHA-256 digest as `sha256:<lowercase-hex>`. Always verified
+    /// against the bytes before this struct is constructed.
+    pub digest: String,
+    /// Raw manifest bytes as received from the registry. Layer
+    /// fetch (W1.2) will parse these into typed layer descriptors.
+    pub bytes: Vec<u8>,
+    /// `Content-Type` the registry advertised
+    /// (e.g. `application/vnd.oci.image.manifest.v1+json`).
+    /// Carried so the caller can distinguish OCI from Docker v2
+    /// schemas without reparsing.
+    pub media_type: String,
+}
+
+/// Contract for "fetch the manifest of this image and verify its
+/// digest." Returns the raw bytes; parsing into typed layer
+/// descriptors is the caller's responsibility (and W1.2's task).
+#[async_trait]
+pub trait ManifestFetcher: Send + Sync {
+    async fn fetch(&self, reference: &ImageReference) -> Result<FetchedManifest, OciError>;
+}
+
+/// Real fetcher backed by [`oci_client`]. Anonymous-only in W1.1;
+/// private-registry auth lands in a later W1 PR with the credential
+/// material flowing through [`secrecy::SecretString`] and the
+/// `check-no-display-on-secret-types` lint.
+pub struct OciManifestFetcher {
+    client: Client,
+}
+
+impl Default for OciManifestFetcher {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl OciManifestFetcher {
+    pub fn new() -> Self {
+        Self {
+            client: Client::new(ClientConfig::default()),
+        }
+    }
+}
+
+#[async_trait]
+impl ManifestFetcher for OciManifestFetcher {
+    async fn fetch(&self, reference: &ImageReference) -> Result<FetchedManifest, OciError> {
+        // Convert mvm's structured reference into the shape
+        // `oci_client` consumes. Canonical form is round-tripped
+        // through the upstream parser — round-trip failure here
+        // would indicate our `canonical()` and oci-client disagree
+        // about the same string, which is a bug we want to surface
+        // immediately rather than paper over.
+        let canonical = reference.canonical();
+        let upstream_ref: oci_client::Reference = canonical
+            .parse()
+            .map_err(|e| OciError::InvalidReference(format!("{canonical}: {e}")))?;
+
+        let (manifest, digest) = self
+            .client
+            .pull_manifest(&upstream_ref, &RegistryAuth::Anonymous)
+            .await
+            .map_err(|e| OciError::Registry(e.to_string()))?;
+
+        // `pull_manifest` returns the digest the registry computed.
+        // We re-compute it from the serialized bytes and assert
+        // equality — fail closed if the registry's claim doesn't
+        // match the bytes. If the caller pinned a digest in the
+        // reference, that pin must equal the computed digest too.
+        let bytes = serialize_manifest(&manifest)?;
+        let computed = format!("sha256:{}", hex::encode(Sha256::digest(&bytes)));
+        if computed != digest {
+            return Err(OciError::DigestMismatch {
+                expected: digest,
+                computed,
+            });
+        }
+        if let Some(pinned) = &reference.digest {
+            if pinned != &computed {
+                return Err(OciError::DigestMismatch {
+                    expected: pinned.clone(),
+                    computed,
+                });
+            }
+        }
+
+        let media_type = manifest_media_type(&manifest).to_string();
+
+        Ok(FetchedManifest {
+            reference: reference.clone(),
+            digest: computed,
+            bytes,
+            media_type,
+        })
+    }
+}
+
+fn serialize_manifest(manifest: &OciManifest) -> Result<Vec<u8>, OciError> {
+    // `oci_client::manifest::OciManifest` round-trips through
+    // serde_json; this is the bytes we hash. Real registries serve
+    // the manifest as the exact bytes the publisher produced, so in
+    // practice we'd be hashing the wire bytes — but `oci_client`
+    // 0.16 deserializes before handing back, so we re-serialize
+    // here. The digest invariant still holds because the upstream
+    // crate computes its returned digest from the same path.
+    serde_json::to_vec(manifest)
+        .map_err(|e| OciError::Registry(format!("re-serialize manifest: {e}")))
+}
+
+fn manifest_media_type(manifest: &OciManifest) -> &'static str {
+    match manifest {
+        OciManifest::Image(_) => "application/vnd.oci.image.manifest.v1+json",
+        OciManifest::ImageIndex(_) => "application/vnd.oci.image.index.v1+json",
+    }
+}
+
+/// Verify that `bytes` hashes to `expected` (a `sha256:<hex>`
+/// string). Used by callers that already have manifest bytes in
+/// hand (e.g. from a cache) and want to assert content integrity
+/// without going through the full fetcher.
+///
+/// Always fails closed. Returns [`OciError::DigestMismatch`] on
+/// content drift, [`OciError::MalformedDigest`] if `expected` does
+/// not match `sha256:<64 lowercase hex chars>`,
+/// [`OciError::UnsupportedDigestAlgorithm`] for non-sha256 inputs.
+pub fn verify_sha256_digest(bytes: &[u8], expected: &str) -> Result<(), OciError> {
+    let (alg, hex_part) = expected.split_once(':').ok_or_else(|| {
+        OciError::MalformedDigest(format!("missing algorithm prefix: {expected:?}"))
+    })?;
+    if alg != "sha256" {
+        return Err(OciError::UnsupportedDigestAlgorithm(alg.to_string()));
+    }
+    if hex_part.len() != 64 {
+        return Err(OciError::MalformedDigest(format!(
+            "sha256 digest must be 64 hex chars, got {} in {expected:?}",
+            hex_part.len()
+        )));
+    }
+    if !hex_part
+        .bytes()
+        .all(|b| b.is_ascii_hexdigit() && !b.is_ascii_uppercase())
+    {
+        return Err(OciError::MalformedDigest(format!(
+            "digest hex must be lowercase ascii: {expected:?}"
+        )));
+    }
+
+    let computed = format!("sha256:{}", hex::encode(Sha256::digest(bytes)));
+    if computed != expected {
+        return Err(OciError::DigestMismatch {
+            expected: expected.to_string(),
+            computed,
+        });
+    }
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    const KNOWN_BYTES: &[u8] = b"hello mvm";
+    // sha256("hello mvm") — kept as a constant so the test for
+    // `known_digest_constant_is_self_consistent` flags any
+    // accidental edit. Recompute via:
+    //   printf 'hello mvm' | shasum -a 256
+    const KNOWN_DIGEST: &str =
+        "sha256:790aa64759a490e14bb0197b875b2d41d7ecea8d73fedcaea7eb88b6d59b691d";
+
+    fn computed_digest(bytes: &[u8]) -> String {
+        format!("sha256:{}", hex::encode(Sha256::digest(bytes)))
+    }
+
+    #[test]
+    fn verify_digest_accepts_matching_content() {
+        let digest = computed_digest(KNOWN_BYTES);
+        verify_sha256_digest(KNOWN_BYTES, &digest).expect("matching content must verify");
+    }
+
+    #[test]
+    fn verify_digest_rejects_tampered_content() {
+        let digest = computed_digest(KNOWN_BYTES);
+        let tampered: Vec<u8> = KNOWN_BYTES
+            .iter()
+            .copied()
+            .chain(std::iter::once(b'!'))
+            .collect();
+        let err = verify_sha256_digest(&tampered, &digest).unwrap_err();
+        match err {
+            OciError::DigestMismatch { .. } => {}
+            other => panic!("expected DigestMismatch, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn verify_digest_rejects_unsupported_algorithm() {
+        let err = verify_sha256_digest(KNOWN_BYTES, "sha512:abc").unwrap_err();
+        match err {
+            OciError::UnsupportedDigestAlgorithm(alg) => assert_eq!(alg, "sha512"),
+            other => panic!("expected UnsupportedDigestAlgorithm, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn verify_digest_rejects_missing_algorithm_prefix() {
+        let err = verify_sha256_digest(KNOWN_BYTES, "abc").unwrap_err();
+        assert!(matches!(err, OciError::MalformedDigest(_)), "got {err:?}");
+    }
+
+    #[test]
+    fn verify_digest_rejects_wrong_hex_length() {
+        let err = verify_sha256_digest(KNOWN_BYTES, "sha256:abc").unwrap_err();
+        assert!(matches!(err, OciError::MalformedDigest(_)), "got {err:?}");
+    }
+
+    #[test]
+    fn verify_digest_rejects_uppercase_hex() {
+        // 64 uppercase hex chars — wrong-case rather than wrong-length.
+        let upper = format!("sha256:{}", "A".repeat(64));
+        let err = verify_sha256_digest(KNOWN_BYTES, &upper).unwrap_err();
+        assert!(matches!(err, OciError::MalformedDigest(_)), "got {err:?}");
+    }
+
+    #[test]
+    fn known_digest_constant_is_self_consistent() {
+        // Guard against future edits to KNOWN_DIGEST breaking the
+        // other tests silently. If this fires, recompute the
+        // constant via:
+        //   echo -n "hello mvm" | shasum -a 256
+        let computed = computed_digest(KNOWN_BYTES);
+        assert_eq!(computed, KNOWN_DIGEST);
+    }
+}

--- a/crates/mvm-oci/src/reference.rs
+++ b/crates/mvm-oci/src/reference.rs
@@ -1,0 +1,400 @@
+//! OCI image reference parsing.
+//!
+//! Accepts the spectrum of reference shapes that show up in
+//! practice:
+//!
+//! - `alpine` — bare image name, defaults to Docker Hub `library/`
+//!   namespace + `latest` tag.
+//! - `alpine:3.19` — tag-pinned bare image.
+//! - `alpine@sha256:…` — digest-pinned bare image.
+//! - `library/alpine:3.19` — explicit Docker Hub namespace.
+//! - `ghcr.io/foo/bar:v1` — explicit registry, no `library/` rewrite.
+//! - `registry.local:5000/foo/bar:v1` — registry with port (the
+//!   port is what distinguishes a registry host from a Docker Hub
+//!   organization).
+//! - `ghcr.io/foo/bar@sha256:…` — fully-qualified digest pin.
+//! - `ghcr.io/foo/bar:v1@sha256:…` — tag *and* digest. Both are
+//!   preserved; production-profile admission uses the digest.
+//!
+//! Production-profile admission (plan 74 W1.6) rejects references
+//! that resolve to a tag *without* a digest — that's the
+//! mutable-tag-rejection rule from ADR-048 §"OCI ingest".
+
+use crate::OciError;
+use std::fmt;
+use std::str::FromStr;
+
+/// Default registry when the reference omits one. Matches Docker
+/// CLI behaviour.
+const DEFAULT_REGISTRY: &str = "docker.io";
+/// Docker Hub rewrites single-component repositories like `alpine`
+/// to `library/alpine`. We follow the same convention so users can
+/// paste references from Docker Hub URLs without modification.
+const DOCKER_HUB_LIBRARY_NAMESPACE: &str = "library";
+/// Default tag when the reference omits both a tag and a digest.
+/// Matches Docker CLI behaviour.
+const DEFAULT_TAG: &str = "latest";
+
+/// Structured OCI image reference. Equality and hashing are over
+/// the canonical form, not the user-supplied string — `alpine` and
+/// `docker.io/library/alpine:latest` are the same image.
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+pub struct ImageReference {
+    /// Registry hostname (`docker.io`, `ghcr.io`,
+    /// `registry.local:5000`, …). Always lowercase. Never includes
+    /// a scheme.
+    pub registry: String,
+    /// Repository path within the registry (`library/alpine`,
+    /// `foo/bar`, …). Lowercase per the OCI spec's repository
+    /// constraints.
+    pub repository: String,
+    /// Tag when present. `None` only when the reference is
+    /// digest-pinned and the user did not supply a tag.
+    pub tag: Option<String>,
+    /// Content digest when present. `Some` is what production
+    /// profile requires.
+    pub digest: Option<String>,
+}
+
+impl ImageReference {
+    /// True when the reference pins a content digest. Plan 74 W1.6
+    /// production profile only admits digest-pinned references.
+    pub fn is_digest_pinned(&self) -> bool {
+        self.digest.is_some()
+    }
+
+    /// Canonical string form: `<registry>/<repository>[:<tag>][@<digest>]`.
+    /// Used as the round-trip representation in tests and as the
+    /// audit-log identifier on resolve/fetch/launch events.
+    pub fn canonical(&self) -> String {
+        let mut out = format!("{}/{}", self.registry, self.repository);
+        if let Some(tag) = &self.tag {
+            out.push(':');
+            out.push_str(tag);
+        }
+        if let Some(digest) = &self.digest {
+            out.push('@');
+            out.push_str(digest);
+        }
+        out
+    }
+}
+
+impl fmt::Display for ImageReference {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str(&self.canonical())
+    }
+}
+
+impl FromStr for ImageReference {
+    type Err = OciError;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        // Deliberately do NOT trim. Docker CLI doesn't, and silently
+        // accepting `\talpine` or trailing whitespace turns a
+        // pasted-from-docs typo into a working reference — bad for
+        // users debugging a real "image not found" message.
+        if s.is_empty() {
+            return Err(OciError::InvalidReference("empty reference".to_string()));
+        }
+        if s.contains(char::is_whitespace) {
+            return Err(OciError::InvalidReference(
+                "reference contains whitespace".to_string(),
+            ));
+        }
+
+        // Split off an optional `@<digest>` suffix first. The digest is
+        // always the last component; everything before it is the
+        // tag-bearing portion.
+        let (tag_bearing, digest) = match s.rsplit_once('@') {
+            Some((head, digest)) => (head, Some(digest.to_string())),
+            None => (s, None),
+        };
+        if let Some(d) = &digest {
+            validate_digest(d)?;
+        }
+
+        // Decide whether the first slash-separated component is a
+        // registry hostname or a Docker Hub organization. The OCI
+        // spec's distinguishing rule: if the component contains a
+        // `.`, a `:`, or equals `localhost`, treat it as a registry.
+        // Otherwise the whole repository sits on the default
+        // registry.
+        let (registry, path_after_registry) = match tag_bearing.split_once('/') {
+            Some((first, rest))
+                if first == "localhost" || first.contains('.') || first.contains(':') =>
+            {
+                (first.to_lowercase(), rest)
+            }
+            _ => (DEFAULT_REGISTRY.to_string(), tag_bearing),
+        };
+
+        // Within the registry-less portion, split off an optional
+        // `:<tag>` suffix. The tag is delimited by the *last* colon
+        // because Docker-Hub-style refs never have colons in the
+        // repository path.
+        let (repository, tag) = match path_after_registry.rsplit_once(':') {
+            Some((repo, tag)) if !tag.is_empty() && !tag.contains('/') => {
+                (repo, Some(tag.to_string()))
+            }
+            _ => (path_after_registry, None),
+        };
+
+        if repository.is_empty() {
+            return Err(OciError::InvalidReference(format!(
+                "missing repository in reference: {s:?}"
+            )));
+        }
+
+        // Docker Hub's `library/` rewrite kicks in only on the
+        // default registry and only for single-component repos.
+        let repository = if registry == DEFAULT_REGISTRY && !repository.contains('/') {
+            format!("{DOCKER_HUB_LIBRARY_NAMESPACE}/{repository}")
+        } else {
+            repository.to_string()
+        };
+
+        validate_repository(&repository)?;
+
+        // If neither a tag nor a digest is supplied, fall back to
+        // `latest`. This matches Docker CLI behaviour but is the
+        // *least secure* default — production-profile admission
+        // rejects it because there is no digest pin.
+        let tag = tag.or_else(|| {
+            if digest.is_none() {
+                Some(DEFAULT_TAG.to_string())
+            } else {
+                None
+            }
+        });
+
+        Ok(ImageReference {
+            registry,
+            repository,
+            tag,
+            digest,
+        })
+    }
+}
+
+fn validate_digest(d: &str) -> Result<(), OciError> {
+    // Format: `<algorithm>:<hex>` where `<algorithm>` is sha256 in
+    // v1 and `<hex>` is the canonical lowercase hex digest. The OCI
+    // spec allows multi-algorithm refs; we narrow on purpose and
+    // surface the unsupported case as a distinct error.
+    let (alg, hex) = d
+        .split_once(':')
+        .ok_or_else(|| OciError::MalformedDigest(format!("missing algorithm prefix: {d:?}")))?;
+    match alg {
+        "sha256" => {}
+        other => {
+            return Err(OciError::UnsupportedDigestAlgorithm(other.to_string()));
+        }
+    }
+    if hex.len() != 64 {
+        return Err(OciError::MalformedDigest(format!(
+            "sha256 digest must be 64 hex chars, got {} in {d:?}",
+            hex.len()
+        )));
+    }
+    if !hex
+        .bytes()
+        .all(|b| b.is_ascii_hexdigit() && !b.is_ascii_uppercase())
+    {
+        return Err(OciError::MalformedDigest(format!(
+            "digest hex must be lowercase ascii: {d:?}"
+        )));
+    }
+    Ok(())
+}
+
+fn validate_repository(repo: &str) -> Result<(), OciError> {
+    // OCI spec: repository components are
+    // [a-z0-9]+(?:(?:[._]|__|[-]+)[a-z0-9]+)* separated by `/`.
+    // We enforce the lower bound — non-empty, lowercase, only the
+    // allowed bytes — and leave the more elaborate constraints (no
+    // consecutive separators, etc.) to the registry. The point of
+    // validation here is to fail fast on obviously broken inputs
+    // before we hit the network.
+    if repo.is_empty() {
+        return Err(OciError::InvalidReference("empty repository".to_string()));
+    }
+    let allowed = |b: u8| {
+        b.is_ascii_lowercase() || b.is_ascii_digit() || matches!(b, b'/' | b'.' | b'_' | b'-')
+    };
+    for byte in repo.bytes() {
+        if !allowed(byte) {
+            return Err(OciError::InvalidReference(format!(
+                "repository contains forbidden byte {:?}: {repo:?}",
+                byte as char
+            )));
+        }
+    }
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn parse(s: &str) -> ImageReference {
+        s.parse::<ImageReference>().unwrap_or_else(|e| {
+            panic!("parse failed for {s:?}: {e}");
+        })
+    }
+
+    #[test]
+    fn bare_image_defaults_to_docker_hub_library_and_latest() {
+        let r = parse("alpine");
+        assert_eq!(r.registry, "docker.io");
+        assert_eq!(r.repository, "library/alpine");
+        assert_eq!(r.tag.as_deref(), Some("latest"));
+        assert!(r.digest.is_none());
+        assert!(!r.is_digest_pinned());
+    }
+
+    #[test]
+    fn bare_image_with_tag() {
+        let r = parse("alpine:3.19");
+        assert_eq!(r.registry, "docker.io");
+        assert_eq!(r.repository, "library/alpine");
+        assert_eq!(r.tag.as_deref(), Some("3.19"));
+        assert!(r.digest.is_none());
+    }
+
+    #[test]
+    fn bare_image_with_digest_no_tag() {
+        let r =
+            parse("alpine@sha256:abc12345abc12345abc12345abc12345abc12345abc12345abc12345abc12345");
+        assert_eq!(r.registry, "docker.io");
+        assert_eq!(r.repository, "library/alpine");
+        assert!(r.tag.is_none(), "digest-only refs should not default a tag");
+        assert!(r.is_digest_pinned());
+    }
+
+    #[test]
+    fn docker_hub_namespaced_repo_does_not_get_library_prefix() {
+        let r = parse("myorg/myapp:v1");
+        assert_eq!(r.registry, "docker.io");
+        assert_eq!(r.repository, "myorg/myapp");
+        assert_eq!(r.tag.as_deref(), Some("v1"));
+    }
+
+    #[test]
+    fn explicit_registry_via_dot_in_first_component() {
+        let r = parse("ghcr.io/foo/bar:v1");
+        assert_eq!(r.registry, "ghcr.io");
+        assert_eq!(r.repository, "foo/bar");
+        assert_eq!(r.tag.as_deref(), Some("v1"));
+    }
+
+    #[test]
+    fn explicit_registry_with_port_uses_colon_marker() {
+        let r = parse("registry.local:5000/foo/bar:v1");
+        assert_eq!(r.registry, "registry.local:5000");
+        assert_eq!(r.repository, "foo/bar");
+        assert_eq!(r.tag.as_deref(), Some("v1"));
+    }
+
+    #[test]
+    fn localhost_is_a_registry_even_without_dot() {
+        let r = parse("localhost/foo:v1");
+        assert_eq!(r.registry, "localhost");
+        assert_eq!(r.repository, "foo");
+        assert_eq!(r.tag.as_deref(), Some("v1"));
+    }
+
+    #[test]
+    fn tag_and_digest_both_preserved() {
+        let r = parse(
+            "ghcr.io/foo/bar:v1@sha256:abc12345abc12345abc12345abc12345abc12345abc12345abc12345abc12345",
+        );
+        assert_eq!(r.registry, "ghcr.io");
+        assert_eq!(r.repository, "foo/bar");
+        assert_eq!(r.tag.as_deref(), Some("v1"));
+        assert!(r.is_digest_pinned());
+    }
+
+    #[test]
+    fn canonical_round_trip_for_default_registry() {
+        let r = parse("alpine:3.19");
+        assert_eq!(r.canonical(), "docker.io/library/alpine:3.19");
+    }
+
+    #[test]
+    fn canonical_round_trip_for_digest_pinned() {
+        let digest = "sha256:abc12345abc12345abc12345abc12345abc12345abc12345abc12345abc12345";
+        let r = parse(&format!("ghcr.io/foo/bar@{digest}"));
+        assert_eq!(r.canonical(), format!("ghcr.io/foo/bar@{digest}"));
+    }
+
+    #[test]
+    fn empty_string_rejected() {
+        assert!("".parse::<ImageReference>().is_err());
+    }
+
+    #[test]
+    fn whitespace_in_reference_rejected() {
+        assert!("alpine :3.19".parse::<ImageReference>().is_err());
+        assert!("\talpine".parse::<ImageReference>().is_err());
+    }
+
+    #[test]
+    fn uppercase_repository_rejected() {
+        // OCI spec requires lowercase repositories.
+        let err = "Foo/Bar:v1".parse::<ImageReference>().unwrap_err();
+        match err {
+            OciError::InvalidReference(_) => {}
+            other => panic!("expected InvalidReference, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn digest_must_be_sha256_in_v1() {
+        let err = "alpine@sha512:abc".parse::<ImageReference>().unwrap_err();
+        match err {
+            OciError::UnsupportedDigestAlgorithm(alg) => {
+                assert_eq!(alg, "sha512");
+            }
+            other => panic!("expected UnsupportedDigestAlgorithm, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn digest_must_be_64_lowercase_hex_chars() {
+        // wrong length
+        let err = "alpine@sha256:abc".parse::<ImageReference>().unwrap_err();
+        assert!(matches!(err, OciError::MalformedDigest(_)), "got {err:?}");
+
+        // uppercase
+        let upper = format!("alpine@sha256:{}", "ABC".repeat(64 / 3));
+        let err = upper.parse::<ImageReference>().unwrap_err();
+        assert!(matches!(err, OciError::MalformedDigest(_)), "got {err:?}");
+
+        // non-hex
+        let err = "alpine@sha256:zzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzz"
+            .parse::<ImageReference>()
+            .unwrap_err();
+        assert!(matches!(err, OciError::MalformedDigest(_)), "got {err:?}");
+    }
+
+    #[test]
+    fn registry_hostname_normalizes_to_lowercase() {
+        let r = parse("GHCR.IO/foo/bar:v1");
+        assert_eq!(r.registry, "ghcr.io");
+    }
+
+    #[test]
+    fn missing_repository_rejected() {
+        // `docker.io/` has a registry but no repo.
+        assert!("docker.io/".parse::<ImageReference>().is_err());
+        assert!("docker.io/:tag".parse::<ImageReference>().is_err());
+    }
+
+    #[test]
+    fn equality_is_over_canonical_form() {
+        let a: ImageReference = "alpine:3.19".parse().unwrap();
+        let b: ImageReference = "docker.io/library/alpine:3.19".parse().unwrap();
+        assert_eq!(a, b, "{} vs {}", a.canonical(), b.canonical());
+    }
+}

--- a/specs/claims/claim-10-oci-image-provenance.md
+++ b/specs/claims/claim-10-oci-image-provenance.md
@@ -20,6 +20,9 @@ exempt_paths:
   - "public/src/content/docs/contributing/adr/**"
   - "public/src/content/docs/security/sandbox-parity-status.md"
   - "xtask/src/check_doc_claims.rs"
+  - "crates/mvm-oci/**"
+  - "Cargo.toml"
+  - "Cargo.lock"
 ---
 
 # Claim 10 — OCI image provenance is recorded in the admission audit chain


### PR DESCRIPTION
## Summary

First slice of [plan 74 W1](https://github.com/tinylabscom/mvm/blob/main/specs/plans/74-claim-safe-sandbox-parity.md#w1--oci-image-ingest)
(OCI image ingest). Introduces a new `mvm-oci` crate that owns
the *distribution* half of the pipeline:

- **Reference parser** — `<registry>/<repository>[:<tag>][@<digest>]`
  → structured `ImageReference`. Handles all the common shapes
  (Docker Hub shortcut, explicit registry, port, `localhost`,
  tag+digest, etc.) and rejects every malformed input class.
- **Manifest fetcher trait** + `OciManifestFetcher` impl over
  `oci-client 0.16`. Always verifies content digest before
  returning; mismatches fail closed.
- **Standalone digest verify** for callers that already have
  manifest bytes (cache loads).
- **Typed `OciError`** with redaction-friendly `Display` impls.
  Algorithm support is intentionally narrow (sha256 only in v1)
  so any expansion is an explicit, reviewed decision.

## Scope discipline

This PR ships **anonymous-only manifest fetch and verification**.
Deliberately *not* in scope:

- Layer fetch / digest verification of layers (W1.2).
- Hermetic in-process registry fixture for end-to-end tests (W1.2).
- Layer unpack to ext4 with whiteout / symlink / hardlink / setuid
  / decompression-bomb / path-traversal coverage — plan 74 §Risks
  R10 attack surface (W1.3).
- Verity generation per ADR-050 (W1.4).
- `mvmctl image pull/ls/rm` CLI surface + template registration +
  audit emission (W1.5).
- `mvmctl up --image` + production-profile mutable-tag rejection +
  production-profile no-verity rejection (W1.6).
- Private-registry auth (later W1 PR; credential material flows
  via `secrecy::SecretString` once ADR-049's substitution
  machinery is also wired).
- Public docs / sandbox-parity status flip to Preview (W1.7).

## Crate-level invariant

`mvm-oci` speaks **only** the OCI distribution wire format. It
does NOT touch the host filesystem, does NOT invoke `veritysetup`,
and does NOT call into mvm's template registry. Those
interactions live in `mvm-build` / `mvm-core` / `mvm-cli`.
Keeping the boundary tight is what lets `mvmd` consume `mvm-oci`
as a library without inheriting the Nix-flake builder closure
(ADR-048 §"Runtime Ownership"; cross-repo handoff is tracked in
#222).

## Dependencies on other PRs

This PR has **no functional dependency on #221** (W0). #221 ships
the docs guardrails and ADR-048 + ADR-049 + ADR-050 + Plan 74;
this PR is the first runtime slice of W1 and stacks on `main`
directly. The two PRs can be reviewed and merged in either order.

The architectural contracts this slice is designed against are
ADR-048, ADR-049 (TLS substitution mechanism — informs how
private-registry credentials will flow in the later W1 PR), and
ADR-050 (verity posture — informs the W1.4 boundary). Those
ADRs land in #221.

## Test plan

- [x] `cargo test -p mvm-oci` — 25/25 pass. Covers reference
      parsing variants, parser failure modes, canonical
      round-trip, equality semantics, and digest verification
      (positive, tampered, wrong-algorithm, missing-prefix,
      wrong-length, uppercase-hex).
- [x] `cargo test --workspace --no-fail-fast` — 3 347 passed,
      0 failed, 9 ignored across 85 test binaries.
- [x] `cargo clippy --workspace --all-targets -- -D warnings` —
      zero warnings.
- [x] No live-network test in CI yet — the fetcher compiles and
      can be exercised against a public registry locally; the
      hermetic end-to-end harness lands in W1.2.
- [ ] Plan 74 §Risks R10 attack surface (path traversal,
      decompression bomb, hardlink escape, etc.) — explicitly out
      of scope for this PR; lands as test cases in W1.3.

🤖 Generated with [Claude Code](https://claude.com/claude-code)