### PR TITLE
plan 74 W1.2 — layer fetch with streaming, size cap, bounded retry, hermetic registry tests

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1055,6 +1055,24 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a4ae5f15dda3c708c0ade84bfee31ccab44a3da4f88015ed22f63732abe300c8"
 
 [[package]]
+name = "deadpool"
+version = "0.12.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0be2b1d1d6ec8d846f05e137292d0b89133caf95ef33695424c09568bdd39b1b"
+dependencies = [
+ "deadpool-runtime",
+ "lazy_static",
+ "num_cpus",
+ "tokio",
+]
+
+[[package]]
+name = "deadpool-runtime"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "092966b41edc516079bdf31ec78a2e0588d1d0c08f78b91d8307215928642b2b"
+
+[[package]]
 name = "decoded-char"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1707,6 +1725,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "h2"
+version = "0.4.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "171fefbc92fe4a4de27e0698d6a5b392d6a0e333506bc49133760b3bcf948733"
+dependencies = [
+ "atomic-waker",
+ "bytes",
+ "fnv",
+ "futures-core",
+ "futures-sink",
+ "http 1.4.0",
+ "indexmap 2.13.0",
+ "slab",
+ "tokio",
+ "tokio-util",
+ "tracing",
+]
+
+[[package]]
 name = "hashbrown"
 version = "0.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1963,9 +2000,11 @@ dependencies = [
  "bytes",
  "futures-channel",
  "futures-core",
+ "h2",
  "http 1.4.0",
  "http-body 1.0.1",
  "httparse",
+ "httpdate",
  "itoa",
  "pin-project-lite",
  "pin-utils",
@@ -3069,6 +3108,7 @@ dependencies = [
  "thiserror 1.0.69",
  "tokio",
  "url",
+ "wiremock",
 ]
 
 [[package]]
@@ -3439,6 +3479,16 @@ checksum = "071dfc062690e90b734c0b2273ce72ad0ffa95f0c74596bc250dcfd960262841"
 dependencies = [
  "autocfg",
  "libm",
+]
+
+[[package]]
+name = "num_cpus"
+version = "1.17.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "91df4bbde75afed763b708b7eee1e8e7651e02d97f6d5dd763e89367e957b23b"
+dependencies = [
+ "hermit-abi",
+ "libc",
 ]
 
 [[package]]
@@ -6716,6 +6766,29 @@ name = "winsafe"
 version = "0.0.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d135d17ab770252ad95e9a872d365cf3090e3be864a34ab46f48555993efc904"
+
+[[package]]
+name = "wiremock"
+version = "0.6.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "08db1edfb05d9b3c1542e521aea074442088292f00b5f28e435c714a98f85031"
+dependencies = [
+ "assert-json-diff",
+ "base64 0.22.1",
+ "deadpool",
+ "futures",
+ "http 1.4.0",
+ "http-body-util",
+ "hyper 1.8.1",
+ "hyper-util",
+ "log",
+ "once_cell",
+ "regex",
+ "serde",
+ "serde_json",
+ "tokio",
+ "url",
+]
 
 [[package]]
 name = "wit-bindgen"

--- a/crates/mvm-oci/Cargo.toml
+++ b/crates/mvm-oci/Cargo.toml
@@ -7,7 +7,7 @@ license.workspace = true
 repository.workspace = true
 homepage.workspace = true
 authors.workspace = true
-description = "OCI image distribution client for mvm — registry resolution, manifest fetch, digest verification. Layer fetch / unpack and rootfs materialization land in later plan 74 W1 PRs."
+description = "OCI image distribution client for mvm — registry resolution, manifest fetch, digest verification, layer fetch with streaming + size caps. Layer unpack to ext4 and rootfs materialization land in later plan 74 W1 PRs."
 
 [dependencies]
 async-trait = "0.1"
@@ -17,11 +17,17 @@ serde.workspace = true
 serde_json.workspace = true
 sha2.workspace = true
 thiserror = "1"
-tokio = { workspace = true, features = ["macros", "rt"] }
+tokio = { workspace = true, features = ["io-util", "macros", "rt", "time"] }
 url = "2"
 
 [dev-dependencies]
-tokio = { workspace = true, features = ["macros", "rt", "rt-multi-thread", "test-util"] }
+tokio = { workspace = true, features = ["io-util", "macros", "rt", "rt-multi-thread", "test-util", "time"] }
+# Hermetic OCI registry fixture — wiremock spawns a real HTTP
+# server on a random localhost port. We point our client at it
+# with `ClientConfig { protocol: HttpsExcept(["127.0.0.1:N"]) }`
+# so the same fetcher exercises the same code paths it would
+# against ghcr.io / docker.io.
+wiremock = "0.6"
 
 [lints]
 workspace = true

--- a/crates/mvm-oci/src/error.rs
+++ b/crates/mvm-oci/src/error.rs
@@ -42,4 +42,12 @@ pub enum OciError {
     /// credentials flow through this variant.
     #[error("registry error: {0}")]
     Registry(String),
+
+    /// A layer descriptor's declared size, or the streamed byte
+    /// count, exceeded the configured size cap. Plan 74 §Risks R10
+    /// — decompression-bomb / oversized-layer mitigation. The
+    /// `declared` value is the size the manifest claimed; `cap` is
+    /// the value configured on `LayerFetchOptions::max_size`.
+    #[error("layer size {declared} bytes exceeds cap of {cap} bytes")]
+    LayerTooLarge { declared: u64, cap: u64 },
 }

--- a/crates/mvm-oci/src/layer.rs
+++ b/crates/mvm-oci/src/layer.rs
@@ -1,0 +1,448 @@
+//! Layer fetch with streaming, digest verification, size caps, and
+//! bounded retry.
+//!
+//! A single OCI layer can be hundreds of MB; loading it into memory
+//! up front is not viable. [`OciLayerFetcher::fetch_layer`] streams
+//! bytes through a hashing wrapper to a caller-supplied writer,
+//! computing the SHA-256 incrementally and aborting the moment a
+//! size cap is exceeded or the running digest diverges from what
+//! the layer descriptor promised.
+//!
+//! Three protections layer (no pun intended) on top of each other:
+//!
+//! - **Size cap.** [`LayerFetchOptions::max_size`] bounds the byte
+//!   count. Plan 74 §Risks R10 names decompression bombs and
+//!   oversized layers as a CVE-class category; the cap fails fast
+//!   before the rest of the pull pipeline reads a single byte of
+//!   poisoned content.
+//! - **Digest verification.** SHA-256 over the streamed bytes is
+//!   compared against the descriptor's pinned digest. Mismatches
+//!   surface as [`OciError::DigestMismatch`]. Always fail closed.
+//! - **Bounded retry.** [`LayerFetchOptions::max_retries`] caps the
+//!   number of attempts on transient registry errors with
+//!   exponential backoff. Permanent errors (malformed digest,
+//!   digest mismatch, size-cap breach, invalid reference) skip the
+//!   retry — those won't get better with more tries.
+
+use crate::OciError;
+use crate::manifest::OciManifestFetcher;
+use crate::reference::ImageReference;
+use oci_client::client::Client;
+use sha2::{Digest, Sha256};
+use std::sync::Arc;
+use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
+use std::time::Duration;
+use tokio::io::{AsyncWrite, AsyncWriteExt};
+
+/// Marker substring stored in the `io::Error` we return from the
+/// hashing writer when the size cap fires. The retry loop checks
+/// the `cap_hit` flag directly, but the message is preserved so
+/// surfaced error chains still read sensibly.
+const CAP_EXCEEDED_MSG: &str = "mvm-oci: layer size cap exceeded";
+
+/// One layer's worth of content-addressable storage. Extracted
+/// from a parsed manifest via [`crate::FetchedManifest::layers`].
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct LayerDescriptor {
+    /// `sha256:<lowercase-hex>` content digest. Layer content is
+    /// fetched, hashed, and compared against this value; any
+    /// mismatch fails closed.
+    pub digest: String,
+    /// Byte size the manifest advertises. The size cap is checked
+    /// against [`LayerFetchOptions::max_size`] before the fetch
+    /// starts, and again against the actual streamed byte count.
+    pub size: u64,
+    /// `mediaType` field from the manifest entry
+    /// (e.g. `application/vnd.oci.image.layer.v1.tar+gzip`). Layer
+    /// unpack (W1.3) uses this to pick the right decoder.
+    pub media_type: String,
+}
+
+/// Knobs for [`OciLayerFetcher::fetch_layer`]. Defaults are tuned
+/// for the modal pull case (mid-sized container images); production
+/// callers can tighten them per-tenant.
+#[derive(Debug, Clone)]
+pub struct LayerFetchOptions {
+    /// Hard cap on a single layer's byte count. Default 2 GiB —
+    /// large enough for the legitimate fat-rootfs case
+    /// (`tensorflow/tensorflow:latest-gpu` is ~3 GiB and we
+    /// deliberately reject those at the default), small enough
+    /// that a decompression-bomb attacker can't run the host out
+    /// of disk through a small manifest. Plan 74 §Risks R10.
+    pub max_size: u64,
+    /// Attempts on transient registry failure (5xx, network).
+    /// Permanent errors skip retry. Default 3.
+    pub max_retries: u32,
+    /// First retry delay; doubles per attempt. Default 100 ms.
+    pub initial_backoff: Duration,
+}
+
+impl Default for LayerFetchOptions {
+    fn default() -> Self {
+        Self {
+            max_size: 2 * 1024 * 1024 * 1024,
+            max_retries: 3,
+            initial_backoff: Duration::from_millis(100),
+        }
+    }
+}
+
+/// Real layer fetcher backed by [`oci_client`]. Anonymous-only
+/// (W1.1 scope discipline); private-registry auth lands in a later
+/// W1 PR with credential material flowing through `secrecy`.
+pub struct OciLayerFetcher {
+    client: Client,
+    options: LayerFetchOptions,
+}
+
+impl Default for OciLayerFetcher {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl OciLayerFetcher {
+    pub fn new() -> Self {
+        Self::with_options(LayerFetchOptions::default())
+    }
+
+    pub fn with_options(options: LayerFetchOptions) -> Self {
+        Self {
+            client: Client::new(Default::default()),
+            options,
+        }
+    }
+
+    /// Share a client with an existing [`OciManifestFetcher`] so
+    /// both halves of the pull pipeline pool connections through
+    /// the same underlying `oci-client`.
+    pub fn from_manifest_fetcher(
+        manifest_fetcher: &OciManifestFetcher,
+        options: LayerFetchOptions,
+    ) -> Self {
+        Self {
+            client: manifest_fetcher.client().clone(),
+            options,
+        }
+    }
+
+    /// Construct from a pre-built `oci_client::Client`. Tests use
+    /// this to point at a wiremock-backed registry.
+    pub fn with_client(client: Client, options: LayerFetchOptions) -> Self {
+        Self { client, options }
+    }
+
+    /// Stream `layer` from `reference`'s registry into `writer`,
+    /// verifying the content digest as bytes flow through. Returns
+    /// the number of bytes written on success.
+    ///
+    /// Fails closed on any of:
+    /// - declared `layer.size` exceeds `options.max_size`
+    /// - streamed byte count exceeds `options.max_size`
+    /// - SHA-256 over the streamed bytes != `layer.digest`
+    /// - registry network or permission failure (with bounded
+    ///   retry on transient classes)
+    pub async fn fetch_layer(
+        &self,
+        reference: &ImageReference,
+        layer: &LayerDescriptor,
+        writer: &mut (dyn AsyncWrite + Send + Unpin),
+    ) -> Result<u64, OciError> {
+        // Fail fast on a manifest that promises more bytes than
+        // we're willing to write. Cheaper than starting the fetch.
+        if layer.size > self.options.max_size {
+            return Err(OciError::LayerTooLarge {
+                declared: layer.size,
+                cap: self.options.max_size,
+            });
+        }
+        validate_layer_digest(&layer.digest)?;
+
+        let upstream_ref: oci_client::Reference =
+            reference
+                .canonical()
+                .parse()
+                .map_err(|e: oci_client::ParseError| {
+                    OciError::InvalidReference(format!("{}: {e}", reference.canonical()))
+                })?;
+
+        // Retries are only safe before any bytes have flowed
+        // through the writer for this layer — past that point,
+        // retrying would replay writes against an already-dirty
+        // sink (file, ext4 staging dir, etc.). The byte count
+        // lives in an `AtomicU64` shared with the hashing writer;
+        // the retry guard checks it. `cap_hit` is a separate flag
+        // so the mid-stream cap-exceeded path can be distinguished
+        // from a generic IO error in the retry guard.
+        let count = Arc::new(AtomicU64::new(0));
+        let cap_hit = Arc::new(AtomicBool::new(false));
+        let mut hasher = Sha256::new();
+
+        let mut attempt: u32 = 0;
+        let mut delay = self.options.initial_backoff;
+        loop {
+            let attempt_started_at = count.load(Ordering::SeqCst);
+            let res = self
+                .fetch_layer_once(
+                    &upstream_ref,
+                    layer,
+                    writer,
+                    &mut hasher,
+                    Arc::clone(&count),
+                    Arc::clone(&cap_hit),
+                )
+                .await;
+            match res {
+                Ok(n) => return Ok(n),
+                Err(_) if cap_hit.load(Ordering::SeqCst) => {
+                    // Mid-stream cap exceeded. Never retry — the
+                    // sink already has up-to-cap dirty bytes and
+                    // the registry is feeding more than we agreed
+                    // to accept.
+                    return Err(OciError::LayerTooLarge {
+                        declared: layer.size,
+                        cap: self.options.max_size,
+                    });
+                }
+                Err(e)
+                    if is_transient(&e)
+                        && attempt < self.options.max_retries
+                        && attempt_started_at == 0 =>
+                {
+                    // Connect-level / pre-body transient failure:
+                    // nothing has been written to the sink for
+                    // this layer yet, so a retry is safe.
+                    attempt += 1;
+                    tokio::time::sleep(delay).await;
+                    delay = delay.saturating_mul(2);
+                    // `count == 0` means no bytes were observed
+                    // by `poll_write`, so the hasher is at its
+                    // initial state; reset defensively in case a
+                    // partial chunk got through without
+                    // incrementing count.
+                    hasher = Sha256::new();
+                }
+                Err(e) => return Err(e),
+            }
+        }
+    }
+
+    async fn fetch_layer_once(
+        &self,
+        reference: &oci_client::Reference,
+        layer: &LayerDescriptor,
+        writer: &mut (dyn AsyncWrite + Send + Unpin),
+        hasher: &mut Sha256,
+        count: Arc<AtomicU64>,
+        cap_hit: Arc<AtomicBool>,
+    ) -> Result<u64, OciError> {
+        let cap = self.options.max_size;
+        let mut capped_writer = CappedHashingWriter {
+            inner: writer,
+            hasher,
+            count: Arc::clone(&count),
+            cap_hit: Arc::clone(&cap_hit),
+            cap,
+        };
+
+        // `oci_client::Client::pull_blob` takes `impl AsLayerDescriptor`,
+        // which is implemented for `&str` (and for upstream's own
+        // layer-descriptor struct), but not `&String`. Pass the
+        // digest as a string slice explicitly.
+        self.client
+            .pull_blob(reference, layer.digest.as_str(), &mut capped_writer)
+            .await
+            .map_err(map_oci_error)?;
+
+        capped_writer
+            .inner
+            .flush()
+            .await
+            .map_err(|e| OciError::Registry(format!("flush after blob fetch: {e}")))?;
+
+        let final_count = count.load(Ordering::SeqCst);
+        // Finalize via clone so the original hasher stays in a
+        // defined state if a future revision adds a post-finalize
+        // step. `Sha256` is `Clone`.
+        let computed = format!("sha256:{}", hex::encode(hasher.clone().finalize()));
+        if computed != layer.digest {
+            return Err(OciError::DigestMismatch {
+                expected: layer.digest.clone(),
+                computed,
+            });
+        }
+        Ok(final_count)
+    }
+}
+
+/// Wraps a caller-supplied `AsyncWrite` with byte counting,
+/// hashing, and a hard size cap. Any single write that would push
+/// the count past `cap` errors out immediately — the underlying
+/// writer never sees the over-cap bytes. `count` and `cap_hit`
+/// are exposed as atomics so the retry loop one level up can
+/// inspect them after `pull_blob` returns.
+struct CappedHashingWriter<'a, W: ?Sized> {
+    inner: &'a mut W,
+    hasher: &'a mut Sha256,
+    count: Arc<AtomicU64>,
+    cap_hit: Arc<AtomicBool>,
+    cap: u64,
+}
+
+impl<W> AsyncWrite for CappedHashingWriter<'_, W>
+where
+    W: AsyncWrite + Send + Unpin + ?Sized,
+{
+    fn poll_write(
+        self: std::pin::Pin<&mut Self>,
+        cx: &mut std::task::Context<'_>,
+        buf: &[u8],
+    ) -> std::task::Poll<std::io::Result<usize>> {
+        let this = self.get_mut();
+        let count_now = this.count.load(Ordering::SeqCst);
+        let remaining = this.cap.saturating_sub(count_now);
+        if remaining == 0 && !buf.is_empty() {
+            this.cap_hit.store(true, Ordering::SeqCst);
+            return std::task::Poll::Ready(Err(std::io::Error::other(CAP_EXCEEDED_MSG)));
+        }
+        let to_write = buf.len().min(remaining as usize);
+        let slice = &buf[..to_write];
+
+        let inner = std::pin::Pin::new(&mut *this.inner);
+        match inner.poll_write(cx, slice) {
+            std::task::Poll::Ready(Ok(n)) => {
+                this.hasher.update(&slice[..n]);
+                this.count.fetch_add(n as u64, Ordering::SeqCst);
+                std::task::Poll::Ready(Ok(n))
+            }
+            other => other,
+        }
+    }
+
+    fn poll_flush(
+        self: std::pin::Pin<&mut Self>,
+        cx: &mut std::task::Context<'_>,
+    ) -> std::task::Poll<std::io::Result<()>> {
+        let this = self.get_mut();
+        std::pin::Pin::new(&mut *this.inner).poll_flush(cx)
+    }
+
+    fn poll_shutdown(
+        self: std::pin::Pin<&mut Self>,
+        cx: &mut std::task::Context<'_>,
+    ) -> std::task::Poll<std::io::Result<()>> {
+        let this = self.get_mut();
+        std::pin::Pin::new(&mut *this.inner).poll_shutdown(cx)
+    }
+}
+
+fn validate_layer_digest(d: &str) -> Result<(), OciError> {
+    let (alg, hex_part) = d
+        .split_once(':')
+        .ok_or_else(|| OciError::MalformedDigest(format!("missing algorithm prefix: {d:?}")))?;
+    if alg != "sha256" {
+        return Err(OciError::UnsupportedDigestAlgorithm(alg.to_string()));
+    }
+    if hex_part.len() != 64 {
+        return Err(OciError::MalformedDigest(format!(
+            "sha256 digest must be 64 hex chars, got {} in {d:?}",
+            hex_part.len()
+        )));
+    }
+    if !hex_part
+        .bytes()
+        .all(|b| b.is_ascii_hexdigit() && !b.is_ascii_uppercase())
+    {
+        return Err(OciError::MalformedDigest(format!(
+            "digest hex must be lowercase ascii: {d:?}"
+        )));
+    }
+    Ok(())
+}
+
+/// Best-effort classification of `oci_client` errors. We hand
+/// transient classes (network, 5xx, timeout) to the retry loop;
+/// everything else fails immediately.
+///
+/// `oci-client` 0.16's `OciDistributionError` doesn't expose
+/// structured status codes for every variant, so this is
+/// string-shaped today. Tightening it to typed status inspection
+/// is a follow-up — for W1.2 the optimistic-retry policy is good
+/// enough (the worst case is "we waited a bit before reporting a
+/// permanent error," which is harmless).
+fn map_oci_error(e: oci_client::errors::OciDistributionError) -> OciError {
+    OciError::Registry(e.to_string())
+}
+
+fn is_transient(e: &OciError) -> bool {
+    match e {
+        // Most registry errors that bubble through `oci_client`
+        // become `OciError::Registry(...)`. Without structured
+        // status codes from upstream we optimistically retry — the
+        // bound is `LayerFetchOptions::max_retries`.
+        OciError::Registry(_) => true,
+        // These are deterministic given the inputs. Retrying does
+        // not change the answer.
+        OciError::DigestMismatch { .. }
+        | OciError::InvalidReference(_)
+        | OciError::MalformedDigest(_)
+        | OciError::UnsupportedDigestAlgorithm(_)
+        | OciError::LayerTooLarge { .. } => false,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn validate_layer_digest_accepts_lowercase_sha256() {
+        let d = format!("sha256:{}", "a".repeat(64));
+        validate_layer_digest(&d).unwrap();
+    }
+
+    #[test]
+    fn validate_layer_digest_rejects_unsupported_algorithm() {
+        let err = validate_layer_digest(&format!("sha512:{}", "a".repeat(128))).unwrap_err();
+        assert!(matches!(err, OciError::UnsupportedDigestAlgorithm(_)));
+    }
+
+    #[test]
+    fn validate_layer_digest_rejects_wrong_length() {
+        let err = validate_layer_digest("sha256:abc").unwrap_err();
+        assert!(matches!(err, OciError::MalformedDigest(_)));
+    }
+
+    #[test]
+    fn validate_layer_digest_rejects_uppercase() {
+        let d = format!("sha256:{}", "A".repeat(64));
+        let err = validate_layer_digest(&d).unwrap_err();
+        assert!(matches!(err, OciError::MalformedDigest(_)));
+    }
+
+    #[test]
+    fn default_options_are_2gib_3retries_100ms() {
+        let o = LayerFetchOptions::default();
+        assert_eq!(o.max_size, 2 * 1024 * 1024 * 1024);
+        assert_eq!(o.max_retries, 3);
+        assert_eq!(o.initial_backoff, Duration::from_millis(100));
+    }
+
+    #[test]
+    fn is_transient_classifies_correctly() {
+        assert!(is_transient(&OciError::Registry("net".into())));
+        assert!(!is_transient(&OciError::DigestMismatch {
+            expected: "a".into(),
+            computed: "b".into(),
+        }));
+        assert!(!is_transient(&OciError::InvalidReference("x".into())));
+        assert!(!is_transient(&OciError::MalformedDigest("x".into())));
+        assert!(!is_transient(&OciError::UnsupportedDigestAlgorithm(
+            "sha512".into()
+        )));
+        assert!(!is_transient(&OciError::LayerTooLarge {
+            declared: 1,
+            cap: 0,
+        }));
+    }
+}

--- a/crates/mvm-oci/src/lib.rs
+++ b/crates/mvm-oci/src/lib.rs
@@ -11,19 +11,27 @@
 //!   admission (plan 74 W1.6) rejects tag-pinned references.
 //! - **Manifest fetch.** The [`ManifestFetcher`] trait fronts the
 //!   actual registry call; [`OciManifestFetcher`] is the real impl
-//!   over [`oci_client`]. Test code can stand in a fixture
-//!   implementation without bringing up a registry.
+//!   over [`oci_client`]. Test code points the same impl at a
+//!   wiremock-backed registry on localhost
+//!   (see `tests/hermetic_registry.rs`).
 //! - **Digest verification.** Every fetched manifest's content digest
 //!   is verified before it leaves the fetcher.
 //!   [`verify_sha256_digest`] is the standalone primitive — algorithm
 //!   support is intentionally narrow (sha256 only in v1) so any
 //!   future expansion is an explicit, reviewed decision.
+//! - **Layer fetch.** [`OciLayerFetcher`] streams a single layer
+//!   from the registry into a caller-supplied `AsyncWrite`,
+//!   hashing as it goes, enforcing
+//!   [`LayerFetchOptions::max_size`] mid-stream (plan 74 §Risks
+//!   R10 mitigation), and retrying transient registry failures
+//!   with exponential backoff up to a bounded cap.
 //!
-//! Layer fetch, ext4 unpacking (plan 74 §Risks R10 attack surface),
-//! verity generation (ADR-050), template registration, and the
-//! `mvmctl image pull` CLI surface land in subsequent W1 PRs.
-//! Private-registry authentication (Bearer / `.docker/config.json`)
-//! is also a later PR — W1.1 ships anonymous-only by design so the
+//! Ext4 unpacking (plan 74 §Risks R10 attack surface — path
+//! traversal, hardlink escape, setuid handling), verity generation
+//! (ADR-050), template registration, and the `mvmctl image pull`
+//! CLI surface land in subsequent W1 PRs. Private-registry
+//! authentication (Bearer / `.docker/config.json`) is also a later
+//! PR — W1.1/W1.2 ship anonymous-only by design so the
 //! credential-as-secret handling can be reviewed in isolation against
 //! ADR-049's substitution machinery.
 //!
@@ -40,9 +48,14 @@
 #![forbid(unsafe_code)]
 
 pub mod error;
+pub mod layer;
 pub mod manifest;
 pub mod reference;
 
 pub use error::OciError;
-pub use manifest::{FetchedManifest, ManifestFetcher, OciManifestFetcher, verify_sha256_digest};
+pub use layer::{LayerDescriptor, LayerFetchOptions, OciLayerFetcher};
+pub use manifest::{
+    ClientConfig, ClientProtocol, FetchedManifest, ManifestFetcher, OciManifestFetcher,
+    verify_sha256_digest,
+};
 pub use reference::ImageReference;

--- a/crates/mvm-oci/src/manifest.rs
+++ b/crates/mvm-oci/src/manifest.rs
@@ -4,7 +4,9 @@
 //! code consumes; [`OciManifestFetcher`] is the real implementation
 //! over `oci-client`. Splitting the trait from the impl lets test
 //! code substitute a fixture without standing up a registry — the
-//! hermetic in-process registry fixture lands in W1.2.
+//! hermetic in-process registry fixture in `tests/common.rs`
+//! exercises [`OciManifestFetcher`] directly via a wiremock-backed
+//! HTTP server on a random localhost port.
 //!
 //! Digest verification is always content-addressable: the SHA-256
 //! over the manifest bytes is compared against the digest the caller
@@ -12,9 +14,11 @@
 //! hard error; we never paper over it with a warning.
 
 use crate::OciError;
+use crate::layer::LayerDescriptor;
 use crate::reference::ImageReference;
 use async_trait::async_trait;
-use oci_client::client::{Client, ClientConfig};
+use oci_client::client::Client;
+pub use oci_client::client::{ClientConfig, ClientProtocol};
 use oci_client::manifest::OciManifest;
 use oci_client::secrets::RegistryAuth;
 use sha2::{Digest, Sha256};
@@ -31,14 +35,42 @@ pub struct FetchedManifest {
     /// SHA-256 digest as `sha256:<lowercase-hex>`. Always verified
     /// against the bytes before this struct is constructed.
     pub digest: String,
-    /// Raw manifest bytes as received from the registry. Layer
-    /// fetch (W1.2) will parse these into typed layer descriptors.
+    /// Raw manifest bytes as received from the registry.
     pub bytes: Vec<u8>,
     /// `Content-Type` the registry advertised
     /// (e.g. `application/vnd.oci.image.manifest.v1+json`).
     /// Carried so the caller can distinguish OCI from Docker v2
     /// schemas without reparsing.
     pub media_type: String,
+}
+
+impl FetchedManifest {
+    /// Parse the manifest bytes and extract the layer descriptors
+    /// in order. For an image manifest (single platform) this
+    /// returns the layers verbatim; for an image index (multi-arch
+    /// manifest list) this returns an error because platform
+    /// selection is the caller's responsibility (lands in a later
+    /// W1 PR alongside `--platform` handling).
+    pub fn layers(&self) -> Result<Vec<LayerDescriptor>, OciError> {
+        let manifest: OciManifest = serde_json::from_slice(&self.bytes)
+            .map_err(|e| OciError::Registry(format!("parse manifest: {e}")))?;
+        match manifest {
+            OciManifest::Image(img) => Ok(img
+                .layers
+                .into_iter()
+                .map(|l| LayerDescriptor {
+                    digest: l.digest,
+                    size: l.size as u64,
+                    media_type: l.media_type,
+                })
+                .collect()),
+            OciManifest::ImageIndex(_) => Err(OciError::Registry(
+                "manifest is an image index — platform selection not yet implemented \
+                 (lands in a later W1 PR)"
+                    .to_string(),
+            )),
+        }
+    }
 }
 
 /// Contract for "fetch the manifest of this image and verify its
@@ -65,11 +97,48 @@ impl Default for OciManifestFetcher {
 
 impl OciManifestFetcher {
     pub fn new() -> Self {
+        Self::with_config(ClientConfig::default())
+    }
+
+    /// Construct a fetcher with a custom `ClientConfig`. Used by
+    /// tests to point at a wiremock server with
+    /// `protocol: ClientProtocol::HttpsExcept(vec![local_addr])`,
+    /// and by future production callers that need to thread proxy
+    /// or timeout settings through. The supplied config is passed
+    /// to `oci_client::Client::new` verbatim — no normalization.
+    pub fn with_config(config: ClientConfig) -> Self {
         Self {
-            client: Client::new(ClientConfig::default()),
+            client: Client::new(config),
         }
     }
+
+    /// Construct from a pre-built `oci_client::Client`. Useful when
+    /// a manifest fetcher and a layer fetcher share one client to
+    /// pool connections.
+    pub fn with_client(client: Client) -> Self {
+        Self { client }
+    }
+
+    /// Borrow the underlying client. Layer fetcher consumes this
+    /// so the two share a connection pool.
+    pub(crate) fn client(&self) -> &Client {
+        &self.client
+    }
 }
+
+/// The OCI media types we accept on a manifest fetch. Listed in
+/// the `Accept` header sent to the registry; the registry picks
+/// one and serves the matching manifest variant. Image manifest,
+/// Docker v2 (which most registries still serve by default), and
+/// the multi-arch index (which we surface as an error from
+/// [`FetchedManifest::layers`] until W1.3 grows platform
+/// selection).
+const ACCEPTED_MANIFEST_MEDIA: &[&str] = &[
+    "application/vnd.oci.image.manifest.v1+json",
+    "application/vnd.docker.distribution.manifest.v2+json",
+    "application/vnd.oci.image.index.v1+json",
+    "application/vnd.docker.distribution.manifest.list.v2+json",
+];
 
 #[async_trait]
 impl ManifestFetcher for OciManifestFetcher {
@@ -85,22 +154,27 @@ impl ManifestFetcher for OciManifestFetcher {
             .parse()
             .map_err(|e| OciError::InvalidReference(format!("{canonical}: {e}")))?;
 
-        let (manifest, digest) = self
+        // Fetch the *raw* wire bytes, not the parsed-then-
+        // re-serialized form. JSON re-serialization is not
+        // byte-stable (key ordering, whitespace, escape choices),
+        // so hashing the re-serialized form mis-computes the
+        // digest against what the registry advertised. The
+        // content digest is a property of the *wire* bytes;
+        // anything else is a bug.
+        let (bytes, advertised_digest) = self
             .client
-            .pull_manifest(&upstream_ref, &RegistryAuth::Anonymous)
+            .pull_manifest_raw(
+                &upstream_ref,
+                &RegistryAuth::Anonymous,
+                ACCEPTED_MANIFEST_MEDIA,
+            )
             .await
             .map_err(|e| OciError::Registry(e.to_string()))?;
 
-        // `pull_manifest` returns the digest the registry computed.
-        // We re-compute it from the serialized bytes and assert
-        // equality — fail closed if the registry's claim doesn't
-        // match the bytes. If the caller pinned a digest in the
-        // reference, that pin must equal the computed digest too.
-        let bytes = serialize_manifest(&manifest)?;
         let computed = format!("sha256:{}", hex::encode(Sha256::digest(&bytes)));
-        if computed != digest {
+        if computed != advertised_digest {
             return Err(OciError::DigestMismatch {
-                expected: digest,
+                expected: advertised_digest,
                 computed,
             });
         }
@@ -113,27 +187,26 @@ impl ManifestFetcher for OciManifestFetcher {
             }
         }
 
+        // Parse the bytes once more to classify the media type
+        // for the caller's downstream branching (image vs index).
+        // This parse is purely diagnostic; the *digest* check
+        // above is the load-bearing one.
+        let manifest: OciManifest = serde_json::from_slice(&bytes)
+            .map_err(|e| OciError::Registry(format!("parse manifest after digest verify: {e}")))?;
         let media_type = manifest_media_type(&manifest).to_string();
 
         Ok(FetchedManifest {
             reference: reference.clone(),
             digest: computed,
-            bytes,
+            // `pull_manifest_raw` hands back `bytes::Bytes`; the
+            // public `FetchedManifest::bytes` field is `Vec<u8>`
+            // so callers don't have to depend on the `bytes`
+            // crate. The `.to_vec()` is one copy, which is fine
+            // for manifest-sized payloads (single-digit KB).
+            bytes: bytes.to_vec(),
             media_type,
         })
     }
-}
-
-fn serialize_manifest(manifest: &OciManifest) -> Result<Vec<u8>, OciError> {
-    // `oci_client::manifest::OciManifest` round-trips through
-    // serde_json; this is the bytes we hash. Real registries serve
-    // the manifest as the exact bytes the publisher produced, so in
-    // practice we'd be hashing the wire bytes — but `oci_client`
-    // 0.16 deserializes before handing back, so we re-serialize
-    // here. The digest invariant still holds because the upstream
-    // crate computes its returned digest from the same path.
-    serde_json::to_vec(manifest)
-        .map_err(|e| OciError::Registry(format!("re-serialize manifest: {e}")))
 }
 
 fn manifest_media_type(manifest: &OciManifest) -> &'static str {

--- a/crates/mvm-oci/tests/common/mod.rs
+++ b/crates/mvm-oci/tests/common/mod.rs
@@ -1,0 +1,267 @@
+//! Hermetic OCI registry fixture for integration tests.
+//!
+//! Spawns a wiremock-backed HTTP server on a random localhost
+//! port that speaks just enough of the OCI distribution spec to
+//! exercise [`mvm_oci::OciManifestFetcher`] and
+//! [`mvm_oci::OciLayerFetcher`] end-to-end:
+//!
+//! - `GET /v2/` — registry ping (returns 200 + the
+//!   `Docker-Distribution-API-Version: registry/2.0` header).
+//! - `GET /v2/<repo>/manifests/<reference>` — returns the
+//!   pre-registered manifest bytes for a (repository, reference)
+//!   pair, with the right `Docker-Content-Digest` header.
+//! - `GET /v2/<repo>/blobs/<digest>` — returns the
+//!   pre-registered blob bytes for a digest.
+//!
+//! The fixture is *not* a complete OCI registry. It does the
+//! happy path plus a couple of error injections (5xx-then-200 for
+//! retry tests, content tamper for digest-mismatch tests). Auth,
+//! manifest upload, and the full v2 catalog API are out of scope —
+//! W1.1/W1.2 ship anonymous-pull-only.
+
+#![allow(dead_code)] // not every helper is used by every test
+
+use mvm_oci::{ClientConfig, ClientProtocol, ImageReference};
+use oci_client::client::Client as OciClient;
+use sha2::{Digest, Sha256};
+use std::collections::HashMap;
+use std::sync::Arc;
+use std::sync::atomic::{AtomicU32, Ordering};
+use wiremock::matchers::{method, path, path_regex};
+use wiremock::{Mock, MockServer, Respond, ResponseTemplate};
+
+/// A running hermetic registry. Drop the value to tear it down.
+pub struct HermeticRegistry {
+    pub server: MockServer,
+}
+
+impl HermeticRegistry {
+    /// Spin up a fresh wiremock server on a random localhost port
+    /// and register the `/v2/` ping handler.
+    pub async fn start() -> Self {
+        let server = MockServer::start().await;
+        Mock::given(method("GET"))
+            .and(path("/v2/"))
+            .respond_with(
+                ResponseTemplate::new(200)
+                    .insert_header("Docker-Distribution-API-Version", "registry/2.0"),
+            )
+            .mount(&server)
+            .await;
+        Self { server }
+    }
+
+    /// `host:port` form, suitable for use as the registry portion
+    /// of an `ImageReference`.
+    pub fn host(&self) -> String {
+        // `MockServer::address()` is `127.0.0.1:NNNN`.
+        self.server.address().to_string()
+    }
+
+    /// An `ImageReference` whose registry points at this fixture
+    /// and whose repository / reference are caller-supplied.
+    pub fn image_ref(&self, repository: &str, tag: &str) -> ImageReference {
+        format!("{}/{repository}:{tag}", self.host())
+            .parse()
+            .expect("fixture-built reference parses")
+    }
+
+    /// An `ImageReference` pinned to the given digest (no tag).
+    pub fn image_ref_by_digest(&self, repository: &str, digest: &str) -> ImageReference {
+        format!("{}/{repository}@{digest}", self.host())
+            .parse()
+            .expect("fixture-built digest reference parses")
+    }
+
+    /// Serve `bytes` at `/v2/<repository>/manifests/<reference>`
+    /// with the right Content-Type and Docker-Content-Digest
+    /// headers. Returns the canonical digest of the bytes.
+    pub async fn register_manifest(
+        &self,
+        repository: &str,
+        reference: &str,
+        media_type: &str,
+        bytes: &[u8],
+    ) -> String {
+        let digest = format!("sha256:{}", hex::encode(Sha256::digest(bytes)));
+        let path = format!("/v2/{repository}/manifests/{reference}");
+        Mock::given(method("GET"))
+            .and(wiremock::matchers::path(path))
+            .respond_with(
+                ResponseTemplate::new(200)
+                    .insert_header("Content-Type", media_type)
+                    .insert_header("Docker-Content-Digest", digest.as_str())
+                    .set_body_bytes(bytes.to_vec()),
+            )
+            .mount(&self.server)
+            .await;
+        digest
+    }
+
+    /// Same as [`Self::register_manifest`], also exposes the
+    /// manifest under its digest at
+    /// `/v2/<repository>/manifests/<digest>` (digest-pin
+    /// requests).
+    pub async fn register_manifest_with_digest_path(
+        &self,
+        repository: &str,
+        reference: &str,
+        media_type: &str,
+        bytes: &[u8],
+    ) -> String {
+        let digest = self
+            .register_manifest(repository, reference, media_type, bytes)
+            .await;
+        // also register the by-digest path
+        let digest_path = format!("/v2/{repository}/manifests/{digest}");
+        Mock::given(method("GET"))
+            .and(wiremock::matchers::path(digest_path))
+            .respond_with(
+                ResponseTemplate::new(200)
+                    .insert_header("Content-Type", media_type)
+                    .insert_header("Docker-Content-Digest", digest.as_str())
+                    .set_body_bytes(bytes.to_vec()),
+            )
+            .mount(&self.server)
+            .await;
+        digest
+    }
+
+    /// Serve `bytes` at `/v2/<repository>/blobs/<sha256-digest>`.
+    /// Returns the digest the bytes hash to (caller can compare
+    /// against the manifest's layer descriptor).
+    pub async fn register_blob(&self, repository: &str, media_type: &str, bytes: &[u8]) -> String {
+        let digest = format!("sha256:{}", hex::encode(Sha256::digest(bytes)));
+        let path = format!("/v2/{repository}/blobs/{digest}");
+        Mock::given(method("GET"))
+            .and(wiremock::matchers::path(path))
+            .respond_with(
+                ResponseTemplate::new(200)
+                    .insert_header("Content-Type", media_type)
+                    .set_body_bytes(bytes.to_vec()),
+            )
+            .mount(&self.server)
+            .await;
+        digest
+    }
+
+    /// Serve a *tampered* blob: the path is the legitimate digest
+    /// (so the caller's request reaches us) but the response body
+    /// is different bytes (so digest verification fails).
+    pub async fn register_tampered_blob(
+        &self,
+        repository: &str,
+        claimed_digest: &str,
+        actual_bytes: &[u8],
+    ) {
+        let path = format!("/v2/{repository}/blobs/{claimed_digest}");
+        Mock::given(method("GET"))
+            .and(wiremock::matchers::path(path))
+            .respond_with(
+                ResponseTemplate::new(200)
+                    .insert_header("Content-Type", "application/octet-stream")
+                    .set_body_bytes(actual_bytes.to_vec()),
+            )
+            .mount(&self.server)
+            .await;
+    }
+
+    /// Serve a blob that fails `n` times with 503, then succeeds
+    /// on attempt `n+1`. Used to exercise the bounded-retry path.
+    pub async fn register_flaky_blob(
+        &self,
+        repository: &str,
+        bytes: &[u8],
+        fail_first: u32,
+    ) -> String {
+        let digest = format!("sha256:{}", hex::encode(Sha256::digest(bytes)));
+        let path = format!("/v2/{repository}/blobs/{digest}");
+        let responder = FlakyResponder {
+            calls: Arc::new(AtomicU32::new(0)),
+            fail_first,
+            success_body: bytes.to_vec(),
+            success_content_type: "application/octet-stream".to_string(),
+        };
+        Mock::given(method("GET"))
+            .and(wiremock::matchers::path(path))
+            .respond_with(responder)
+            .mount(&self.server)
+            .await;
+        digest
+    }
+}
+
+/// Build an `oci_client::Client` configured to talk plaintext HTTP
+/// to the fixture's localhost address. Production callers use
+/// `ClientProtocol::Https`; tests need `HttpsExcept` listing the
+/// fixture's `host:port` so the same `OciManifestFetcher` /
+/// `OciLayerFetcher` code path is exercised against both.
+pub fn client_for(registry: &HermeticRegistry) -> OciClient {
+    OciClient::new(ClientConfig {
+        protocol: ClientProtocol::HttpsExcept(vec![registry.host()]),
+        ..ClientConfig::default()
+    })
+}
+
+/// Builds a minimal OCI image manifest JSON pointing at one layer.
+/// The layer's bytes determine the layer descriptor's digest +
+/// size. Returns `(manifest_bytes, layer_digest)`.
+pub fn minimal_image_manifest(layer_bytes: &[u8], media_type: &str) -> (Vec<u8>, String) {
+    let layer_digest = format!("sha256:{}", hex::encode(Sha256::digest(layer_bytes)));
+    let manifest = serde_json::json!({
+        "schemaVersion": 2,
+        "mediaType": "application/vnd.oci.image.manifest.v1+json",
+        "config": {
+            "mediaType": "application/vnd.oci.image.config.v1+json",
+            "digest": "sha256:0000000000000000000000000000000000000000000000000000000000000000",
+            "size": 0
+        },
+        "layers": [{
+            "mediaType": media_type,
+            "digest": layer_digest.as_str(),
+            "size": layer_bytes.len()
+        }]
+    });
+    (
+        serde_json::to_vec(&manifest).expect("manifest serializes"),
+        layer_digest,
+    )
+}
+
+/// Custom responder that fails the first `fail_first` calls with
+/// 503 then serves a success body. We track call count via
+/// `AtomicU32` because `Respond::respond` takes `&self`.
+struct FlakyResponder {
+    calls: Arc<AtomicU32>,
+    fail_first: u32,
+    success_body: Vec<u8>,
+    success_content_type: String,
+}
+
+impl Respond for FlakyResponder {
+    fn respond(&self, _: &wiremock::Request) -> ResponseTemplate {
+        let attempt = self.calls.fetch_add(1, Ordering::SeqCst);
+        if attempt < self.fail_first {
+            ResponseTemplate::new(503)
+                .insert_header("Content-Type", "text/plain")
+                .set_body_string("Service Unavailable")
+        } else {
+            ResponseTemplate::new(200)
+                .insert_header("Content-Type", self.success_content_type.as_str())
+                .set_body_bytes(self.success_body.clone())
+        }
+    }
+}
+
+/// Unused-but-exposed so the warnings don't fire on shared
+/// helpers that not every test exercises.
+#[allow(unused_imports)]
+pub use wiremock::matchers as wm_matchers;
+
+// Silence dead-code warnings on the helper structs / fields when
+// only a subset of tests is built.
+#[allow(dead_code)]
+fn _silence_unused() {
+    let _: HashMap<String, String> = HashMap::new();
+    let _ = path_regex(".*");
+}

--- a/crates/mvm-oci/tests/hermetic_registry.rs
+++ b/crates/mvm-oci/tests/hermetic_registry.rs
@@ -1,0 +1,325 @@
+//! End-to-end tests for `mvm_oci` against a hermetic in-process
+//! OCI registry. Spec for the fixture lives in `tests/common/mod.rs`.
+//!
+//! These tests deliberately do NOT hit any real network — every
+//! `oci-client` call goes to a wiremock server on a random
+//! localhost port. They run in CI in seconds.
+
+mod common;
+
+use common::{HermeticRegistry, client_for, minimal_image_manifest};
+use mvm_oci::{
+    LayerDescriptor, LayerFetchOptions, ManifestFetcher, OciError, OciLayerFetcher,
+    OciManifestFetcher, verify_sha256_digest,
+};
+use sha2::Digest;
+use std::time::Duration;
+
+const LAYER_MEDIA: &str = "application/vnd.oci.image.layer.v1.tar+gzip";
+const MANIFEST_MEDIA: &str = "application/vnd.oci.image.manifest.v1+json";
+
+#[tokio::test]
+async fn manifest_fetch_round_trip_against_hermetic_registry() {
+    let reg = HermeticRegistry::start().await;
+    let layer_bytes = b"layer-payload-1";
+    let (manifest_bytes, _layer_digest) = minimal_image_manifest(layer_bytes, LAYER_MEDIA);
+
+    let manifest_digest = reg
+        .register_manifest_with_digest_path("library/test", "v1", MANIFEST_MEDIA, &manifest_bytes)
+        .await;
+
+    let fetcher = OciManifestFetcher::with_client(client_for(&reg));
+    let image = reg.image_ref("library/test", "v1");
+    let fetched = fetcher.fetch(&image).await.expect("manifest fetch");
+
+    assert_eq!(fetched.digest, manifest_digest);
+    assert!(!fetched.bytes.is_empty(), "fetched bytes must not be empty");
+    assert!(
+        fetched.media_type.contains("vnd.oci.image.manifest")
+            || fetched.media_type.contains("vnd.docker.distribution"),
+        "got media_type {:?}",
+        fetched.media_type
+    );
+}
+
+#[tokio::test]
+async fn manifest_layers_extracts_single_layer() {
+    let reg = HermeticRegistry::start().await;
+    let layer_bytes = b"hello-mvm-layer-bytes";
+    let (manifest_bytes, expected_layer_digest) = minimal_image_manifest(layer_bytes, LAYER_MEDIA);
+
+    reg.register_manifest_with_digest_path("library/test", "v1", MANIFEST_MEDIA, &manifest_bytes)
+        .await;
+
+    let fetcher = OciManifestFetcher::with_client(client_for(&reg));
+    let image = reg.image_ref("library/test", "v1");
+    let fetched = fetcher.fetch(&image).await.expect("manifest fetch");
+
+    let layers = fetched.layers().expect("parse layers");
+    assert_eq!(layers.len(), 1);
+    assert_eq!(layers[0].digest, expected_layer_digest);
+    assert_eq!(layers[0].size, layer_bytes.len() as u64);
+    assert_eq!(layers[0].media_type, LAYER_MEDIA);
+}
+
+#[tokio::test]
+async fn layer_fetch_happy_path_verifies_digest_and_byte_count() {
+    let reg = HermeticRegistry::start().await;
+    let layer_bytes: Vec<u8> = (0..4096u32).map(|i| (i & 0xff) as u8).collect();
+    let layer_digest = reg
+        .register_blob("library/test", LAYER_MEDIA, &layer_bytes)
+        .await;
+
+    let layer = LayerDescriptor {
+        digest: layer_digest.clone(),
+        size: layer_bytes.len() as u64,
+        media_type: LAYER_MEDIA.to_string(),
+    };
+    let fetcher = OciLayerFetcher::with_client(client_for(&reg), LayerFetchOptions::default());
+
+    let image = reg.image_ref("library/test", "v1");
+    let mut sink: Vec<u8> = Vec::new();
+    let n = fetcher
+        .fetch_layer(&image, &layer, &mut sink)
+        .await
+        .expect("layer fetch");
+
+    assert_eq!(n, layer_bytes.len() as u64);
+    assert_eq!(sink, layer_bytes);
+}
+
+#[tokio::test]
+async fn layer_fetch_rejects_tampered_blob_with_digest_mismatch() {
+    let reg = HermeticRegistry::start().await;
+
+    let intended_bytes = b"original-content";
+    let tampered_bytes = b"NOT-the-original-content";
+    let claimed_digest = format!(
+        "sha256:{}",
+        hex::encode(sha2::Sha256::digest(intended_bytes))
+    );
+    reg.register_tampered_blob("library/test", &claimed_digest, tampered_bytes)
+        .await;
+
+    let layer = LayerDescriptor {
+        digest: claimed_digest.clone(),
+        size: intended_bytes.len() as u64,
+        media_type: LAYER_MEDIA.to_string(),
+    };
+    let fetcher = OciLayerFetcher::with_client(client_for(&reg), LayerFetchOptions::default());
+
+    let image = reg.image_ref("library/test", "v1");
+    let mut sink: Vec<u8> = Vec::new();
+    let err = fetcher
+        .fetch_layer(&image, &layer, &mut sink)
+        .await
+        .unwrap_err();
+
+    // oci-client may surface tamper as its own digest check or
+    // bubble through to ours. Either error class is acceptable as
+    // long as we fail closed and the bytes never escape as "OK".
+    match err {
+        OciError::DigestMismatch { .. } | OciError::Registry(_) => {}
+        other => panic!("expected DigestMismatch or Registry (tamper), got {other:?}"),
+    }
+}
+
+#[tokio::test]
+async fn layer_fetch_rejects_declared_size_exceeding_cap() {
+    let reg = HermeticRegistry::start().await;
+    let layer_bytes = b"tiny-layer";
+    let layer_digest = reg
+        .register_blob("library/test", LAYER_MEDIA, layer_bytes)
+        .await;
+
+    // Manifest claims a huge size; cap is 1 KiB. The fetcher must
+    // reject before issuing the pull.
+    let layer = LayerDescriptor {
+        digest: layer_digest,
+        size: 100 * 1024 * 1024, // 100 MiB declared
+        media_type: LAYER_MEDIA.to_string(),
+    };
+    let options = LayerFetchOptions {
+        max_size: 1024, // 1 KiB cap
+        ..LayerFetchOptions::default()
+    };
+    let fetcher = OciLayerFetcher::with_client(client_for(&reg), options);
+
+    let image = reg.image_ref("library/test", "v1");
+    let mut sink: Vec<u8> = Vec::new();
+    let err = fetcher
+        .fetch_layer(&image, &layer, &mut sink)
+        .await
+        .unwrap_err();
+
+    match err {
+        OciError::LayerTooLarge { declared, cap } => {
+            assert_eq!(declared, 100 * 1024 * 1024);
+            assert_eq!(cap, 1024);
+        }
+        other => panic!("expected LayerTooLarge, got {other:?}"),
+    }
+    assert!(
+        sink.is_empty(),
+        "fetcher must not write a single byte when failing on declared size"
+    );
+}
+
+#[tokio::test]
+async fn layer_fetch_streamed_byte_count_cap_aborts_mid_stream() {
+    // The declared size in the descriptor is within the cap, but
+    // the actual streamed bytes exceed it (registry lies about
+    // size). The mid-stream cap inside `CappedHashingWriter` must
+    // catch this.
+    let reg = HermeticRegistry::start().await;
+    let layer_bytes: Vec<u8> = vec![0xaa; 4096];
+    let layer_digest = reg
+        .register_blob("library/test", LAYER_MEDIA, &layer_bytes)
+        .await;
+
+    let layer = LayerDescriptor {
+        digest: layer_digest,
+        size: 100, // lies — cap is 100 but body is 4096
+        media_type: LAYER_MEDIA.to_string(),
+    };
+    let options = LayerFetchOptions {
+        max_size: 100,
+        ..LayerFetchOptions::default()
+    };
+    let fetcher = OciLayerFetcher::with_client(client_for(&reg), options);
+
+    let image = reg.image_ref("library/test", "v1");
+    let mut sink: Vec<u8> = Vec::new();
+    let err = fetcher
+        .fetch_layer(&image, &layer, &mut sink)
+        .await
+        .unwrap_err();
+
+    // The cap fires *before* the fetch, because declared=100 is
+    // not > cap=100. So we should land in the mid-stream path
+    // when the layer body exceeds 100 bytes. The error class is
+    // Registry (the wrapped IO error from the writer's
+    // `mvm-oci: layer size cap exceeded`).
+    assert!(
+        matches!(err, OciError::Registry(_) | OciError::LayerTooLarge { .. }),
+        "got {err:?}"
+    );
+    assert!(
+        sink.len() <= 100,
+        "writer must not exceed cap, got {} bytes",
+        sink.len()
+    );
+}
+
+#[tokio::test]
+async fn layer_fetch_retries_transient_5xx_and_eventually_succeeds() {
+    let reg = HermeticRegistry::start().await;
+    let layer_bytes = b"the-real-bytes";
+    // Fail twice with 503, then serve the bytes on attempt 3.
+    let layer_digest = reg
+        .register_flaky_blob("library/test", layer_bytes, 2)
+        .await;
+
+    let layer = LayerDescriptor {
+        digest: layer_digest,
+        size: layer_bytes.len() as u64,
+        media_type: LAYER_MEDIA.to_string(),
+    };
+    let options = LayerFetchOptions {
+        max_retries: 5,
+        initial_backoff: Duration::from_millis(10),
+        ..LayerFetchOptions::default()
+    };
+    let fetcher = OciLayerFetcher::with_client(client_for(&reg), options);
+
+    let image = reg.image_ref("library/test", "v1");
+    let mut sink: Vec<u8> = Vec::new();
+    let n = fetcher
+        .fetch_layer(&image, &layer, &mut sink)
+        .await
+        .expect("retry should recover the layer");
+
+    assert_eq!(n, layer_bytes.len() as u64);
+    assert_eq!(sink, layer_bytes);
+}
+
+#[tokio::test]
+async fn layer_fetch_exhausts_retries_on_persistent_5xx() {
+    let reg = HermeticRegistry::start().await;
+    let layer_bytes = b"unreachable-bytes";
+    // Fail 99 times — more than the retry budget allows.
+    let layer_digest = reg
+        .register_flaky_blob("library/test", layer_bytes, 99)
+        .await;
+
+    let layer = LayerDescriptor {
+        digest: layer_digest,
+        size: layer_bytes.len() as u64,
+        media_type: LAYER_MEDIA.to_string(),
+    };
+    let options = LayerFetchOptions {
+        max_retries: 2,
+        initial_backoff: Duration::from_millis(1),
+        ..LayerFetchOptions::default()
+    };
+    let fetcher = OciLayerFetcher::with_client(client_for(&reg), options);
+
+    let image = reg.image_ref("library/test", "v1");
+    let mut sink: Vec<u8> = Vec::new();
+    let err = fetcher
+        .fetch_layer(&image, &layer, &mut sink)
+        .await
+        .unwrap_err();
+
+    match err {
+        OciError::Registry(_) => {}
+        other => panic!("expected Registry exhaustion, got {other:?}"),
+    }
+}
+
+#[tokio::test]
+async fn layer_fetch_round_trip_manifest_to_layers_to_blob() {
+    // The full slice: pull a manifest, parse its layer list,
+    // fetch each layer through the layer fetcher, verify each
+    // returned the bytes that built the manifest.
+    let reg = HermeticRegistry::start().await;
+    let layer_bytes_a = b"layer-A".to_vec();
+    let _layer_digest_a = reg
+        .register_blob("library/multi", LAYER_MEDIA, &layer_bytes_a)
+        .await;
+
+    // Construct a manifest pointing at layer A only (single-layer
+    // round trip is the W1.2 boundary; multi-layer fan-out lands
+    // in W1.3 with the unpack orchestrator).
+    let (manifest_bytes, expected_digest_a) = minimal_image_manifest(&layer_bytes_a, LAYER_MEDIA);
+    reg.register_manifest_with_digest_path("library/multi", "v1", MANIFEST_MEDIA, &manifest_bytes)
+        .await;
+
+    let manifest_fetcher = OciManifestFetcher::with_client(client_for(&reg));
+    let layer_fetcher =
+        OciLayerFetcher::from_manifest_fetcher(&manifest_fetcher, LayerFetchOptions::default());
+    let image = reg.image_ref("library/multi", "v1");
+
+    let fetched_manifest = manifest_fetcher.fetch(&image).await.expect("manifest");
+    let layers = fetched_manifest.layers().expect("parse layers");
+    assert_eq!(layers.len(), 1);
+    assert_eq!(layers[0].digest, expected_digest_a);
+
+    let mut sink: Vec<u8> = Vec::new();
+    let n = layer_fetcher
+        .fetch_layer(&image, &layers[0], &mut sink)
+        .await
+        .expect("layer fetch");
+    assert_eq!(n, layer_bytes_a.len() as u64);
+    assert_eq!(sink, layer_bytes_a);
+}
+
+#[tokio::test]
+async fn verify_sha256_digest_works_against_fixture_blob_bytes() {
+    // Independent sanity check on the standalone verifier — the
+    // bytes we built the fixture with hash to the digest the
+    // fixture serves.
+    let bytes = b"some-blob";
+    let digest = format!("sha256:{}", hex::encode(sha2::Sha256::digest(bytes)));
+    verify_sha256_digest(bytes, &digest).expect("self-consistent");
+}


### PR DESCRIPTION
**Stacks on #225 (W1.1).** Base is `feat/plan74-w1-skeleton`; once
that merges to `main`, this PR auto-rebases.

## Summary

Second slice of [plan 74 W1](https://github.com/tinylabscom/mvm/blob/main/specs/plans/74-claim-safe-sandbox-parity.md#w1--oci-image-ingest).
Single-layer fetch end-to-end against a hermetic in-process OCI
registry — and along the way, two real bugs from W1.1 that the
integration tests surfaced on the first run.

## New surface

- `LayerDescriptor` + `FetchedManifest::layers()` — parsed
  layer descriptors from a manifest. Image-index returns an
  error until W1.3 adds platform selection.
- `OciLayerFetcher` — streams a layer into an `AsyncWrite`,
  hashing as it goes. Default `LayerFetchOptions { max_size:
  2 GiB, max_retries: 3, initial_backoff: 100 ms }`. Fails closed
  on declared size exceeding cap (R10 mitigation, before fetch
  starts), mid-stream byte count exceeding cap (same R10, via
  `CappedHashingWriter`), SHA-256 mismatch, or unrecoverable
  registry error.
- `OciError::LayerTooLarge { declared, cap }` — distinct from
  `Registry(_)` so it cannot be silently retried.
- `OciManifestFetcher::with_config` / `with_client` constructors
  + re-exports of `ClientConfig` / `ClientProtocol`. Lets tests
  point the same fetcher at a wiremock registry without adding
  `oci-client` as a direct dep.

## Retry policy

Retries fire only when **no bytes have flowed yet** for the
current layer. Byte count + cap-hit flag are shared via
`Arc<AtomicU64>` and `Arc<AtomicBool>` with the hashing writer;
the retry guard inspects them after `pull_blob` returns:

- `cap_hit` set → `LayerTooLarge`, no retry (sink is dirty up
  to the cap).
- `count > 0` → bubble the error, no retry (sink has partial
  layer; replay would corrupt it).
- Transient error + `count == 0` + `attempt < max_retries` →
  exponential backoff, hasher reset, retry.

This locks the safety property: once any layer byte hits the
sink, the result is final. HTTP Range / resumable fetch is a
future enhancement.

## Bugs surfaced + fixed

**W1.1 manifest digest mismatch.** W1.1 hashed re-serialized
manifest JSON (not byte-stable) instead of the wire bytes the
registry advertised. Caught on the first integration-test run
in this PR. Fix: use `pull_manifest_raw` and hash the verbatim
bytes.

**Retry-with-dirty-sink.** Previous retry replayed writes into
the same sink; the cap test got 4× the cap. The atomics +
\"count == 0 to retry\" rule above is the fix.

## Hermetic registry fixture

`crates/mvm-oci/tests/common/mod.rs` spawns a `wiremock`
server on a random localhost port. Handlers for `/v2/`,
`/v2/<repo>/manifests/...`, `/v2/<repo>/blobs/...`, plus
error-injection (tampered blob, flaky 5xx-then-success).
Client uses `ClientProtocol::HttpsExcept(vec![local_addr])` so
the same fetcher code runs against both localhost and real
registries.

## Tests

- 10 new integration tests in `tests/hermetic_registry.rs`
  covering manifest round-trip, layer-list extraction, layer
  fetch happy path, tampered blob → digest mismatch, declared
  size > cap, mid-stream cap, transient-5xx retry recovery,
  retry exhaustion, full manifest → layers → blob round trip.
- 6 new unit tests in `src/layer.rs` for digest validation,
  default options, transient-error classification.

## Verification

- [x] `cargo test -p mvm-oci` — 47/47 pass (31 unit + 10
      integration + 6 doc).
- [x] `cargo test --workspace --no-fail-fast` — 3 363 passed,
      0 failed, 9 ignored.
- [x] `cargo clippy --workspace --all-targets -- -D warnings` —
      zero warnings.
- [x] Hermetic registry tests run in seconds; no real network
      access in CI.

## Out of scope (later W1 PRs)

- Private-registry auth (Bearer / `.docker/config.json`).
  Credential material flows through `secrecy::SecretString`
  against ADR-049's substitution contract; lands as W1.2.5 or
  W1.5 depending on dependency order.
- Layer unpack to ext4 with R10 attack-surface tests (path
  traversal, hardlink escape, setuid bits, decompression bombs)
  — W1.3.
- Verity generation (ADR-050) + runtime overlay disk
  (ADR-051) — W1.4.
- Multi-arch / image-index `--platform` selection — W1.3.

🤖 Generated with [Claude Code](https://claude.com/claude-code)