### PR TITLE
plan 74 W1.3b — deterministic ext4 materialization from a staged OCI rootfs

### DIFF
--- a/crates/mvm-build/src/oci_to_rootfs/error.rs
+++ b/crates/mvm-build/src/oci_to_rootfs/error.rs
@@ -89,6 +89,27 @@ pub enum OciUnpackError {
         reason: &'static str,
     },
 
+    /// `mke2fs` exited non-zero or could not be spawned. Plan 74
+    /// W1.3b — the host-side orchestrator that turns a staged
+    /// rootfs into an ext4 image file. Includes the upstream
+    /// stderr so the failure mode is debuggable without re-running
+    /// with `-v`.
+    #[error("mke2fs failed: {reason}")]
+    Mke2fsFailed { reason: String },
+
+    /// An operation that this crate exposes is not supported on
+    /// the current host. ext4 image materialization, for example,
+    /// requires Linux + `mke2fs`; on macOS the W1.5 CLI
+    /// orchestrator will run it inside the builder VM per
+    /// ADR-050. Callers that hit this variant on macOS should
+    /// route the operation through the builder VM rather than
+    /// reporting failure to the user.
+    #[error("host does not support {operation}: {reason}")]
+    HostUnsupported {
+        operation: &'static str,
+        reason: &'static str,
+    },
+
     /// Underlying `std::io` failure during file creation, write,
     /// or close.
     #[error("io error: {0}")]

--- a/crates/mvm-build/src/oci_to_rootfs/ext4.rs
+++ b/crates/mvm-build/src/oci_to_rootfs/ext4.rs
@@ -1,0 +1,390 @@
+//! ext4 materialization from a staged rootfs.
+//!
+//! After [`crate::oci_to_rootfs::ImageStaging::apply_layer`] has
+//! populated a staging directory, this module produces the
+//! `rootfs.ext4` image that Firecracker / libkrun / Apple
+//! Container load as the guest's root device. Output is **byte-
+//! deterministic** for a given staged tree + options — this is
+//! load-bearing for ADR-050's pull-time verity story: the verity
+//! sidecar generated next would otherwise differ across runs and
+//! defeat the per-digest verity cache.
+//!
+//! Determinism comes from pinning everything `mke2fs` randomizes
+//! by default:
+//!
+//! - `-U <uuid>` — filesystem UUID.
+//! - `-E hash_seed=<uuid>` — htree directory-hash seed (controls
+//!   dirent ordering inside a directory).
+//! - `SOURCE_DATE_EPOCH=0` env — every file's mtime is pinned to
+//!   the Unix epoch.
+//! - `-E no_copy_xattrs` — xattrs are skipped uniformly (we don't
+//!   forward OCI xattrs through unpack today anyway).
+//! - `-b 4096` — fixed block size.
+//! - `-t ext4` — fixed FS type.
+//!
+//! ## Host support
+//!
+//! `mke2fs` is Linux-only. On Linux, [`materialize_to_ext4`]
+//! shells out directly. On macOS / Windows the same function
+//! returns [`OciUnpackError::HostUnsupported`]; the W1.5 CLI
+//! orchestrator routes the call through the libkrun builder VM
+//! per ADR-050. This module's job is to be the in-process
+//! orchestrator; the host-vs-VM routing decision lives one layer
+//! up.
+
+use crate::oci_to_rootfs::error::OciUnpackError;
+use crate::oci_to_rootfs::unpack::StagedRootfs;
+use std::path::{Path, PathBuf};
+
+/// Knobs for [`materialize_to_ext4`]. Defaults produce a
+/// byte-deterministic image suitable for ADR-050 verity
+/// generation; callers can override any field to e.g. label the
+/// filesystem differently for a non-mvm consumer.
+#[derive(Debug, Clone)]
+pub struct Mke2fsOptions {
+    /// `-L` label written into the superblock. 16-byte max
+    /// (ext4 limit); longer values are truncated by `mke2fs`.
+    pub label: String,
+    /// `-U` filesystem UUID. Default
+    /// `00000000-0000-0000-0000-000000000001` — pinned for
+    /// determinism. Override via [`with_random_uuid`] if a
+    /// caller specifically wants a fresh UUID.
+    pub uuid: String,
+    /// Hash seed for htree dirent ordering. Default
+    /// `00000000-0000-0000-0000-000000000002`. The seed must
+    /// stay pinned across runs for verity-cache hits.
+    pub hash_seed: String,
+    /// Block size in bytes. Default 4096 — what the kernel
+    /// expects for a verity-protected root, and what mvm's
+    /// existing `verityArtifacts` Nix derivation uses.
+    pub block_size: u32,
+    /// Extra bytes added on top of [`estimate_image_size`]'s
+    /// computed minimum, to account for `mke2fs`'s metadata
+    /// overhead and any post-format writes. Default 4 MiB; an
+    /// undersized image yields a hard `mke2fs` failure rather
+    /// than truncated content, so the padding is for ergonomics,
+    /// not correctness.
+    pub size_padding_bytes: u64,
+    /// `SOURCE_DATE_EPOCH` env value passed to `mke2fs`. Default
+    /// 0 — every file timestamp becomes the Unix epoch. This is
+    /// what ADR-050's verity story expects so two runs of the
+    /// same source tree produce byte-identical ext4.
+    pub source_date_epoch: u64,
+    /// Override the `mke2fs` binary location. Default `None` —
+    /// the binary is resolved via `$PATH`. Tests use this to
+    /// substitute a stub.
+    pub mke2fs_binary: Option<PathBuf>,
+}
+
+impl Default for Mke2fsOptions {
+    fn default() -> Self {
+        Self {
+            label: "mvm-rootfs".to_string(),
+            uuid: "00000000-0000-0000-0000-000000000001".to_string(),
+            hash_seed: "00000000-0000-0000-0000-000000000002".to_string(),
+            block_size: 4096,
+            size_padding_bytes: 4 * 1024 * 1024,
+            source_date_epoch: 0,
+            mke2fs_binary: None,
+        }
+    }
+}
+
+/// Final descriptor produced by [`materialize_to_ext4`].
+#[derive(Debug, Clone)]
+pub struct MaterializedRootfs {
+    /// Absolute path to the ext4 image file on the host fs.
+    pub path: PathBuf,
+    /// File size in bytes, exactly what was passed to
+    /// `mke2fs` via the preallocated output file.
+    pub size_bytes: u64,
+    /// Label written into the superblock (matches `options.label`).
+    pub label: String,
+    /// Filesystem UUID written into the superblock.
+    pub uuid: String,
+}
+
+/// Compute the minimum ext4 image size for the staged tree.
+/// Walks every entry under `staged_root` to sum regular-file
+/// bytes, then adds a small per-entry overhead (~256 bytes for
+/// the inode + dirent) plus the options-supplied padding,
+/// rounded up to a multiple of `block_size`. The minimum result
+/// is always at least 1 MiB — `mke2fs` rejects smaller images
+/// outright.
+pub fn estimate_image_size(
+    staged_root: &Path,
+    options: &Mke2fsOptions,
+) -> Result<u64, OciUnpackError> {
+    let (total_file_bytes, entries) = walk_size(staged_root)?;
+    // Per-entry overhead covers inode + directory entry + a bit
+    // of slack for bitmap/group-descriptor growth. 1024 bytes per
+    // entry is conservative — typical ext4 needs ~256, but
+    // small-files workloads can exceed that.
+    let entry_overhead = entries.saturating_mul(1024);
+    // Group-descriptor + superblock + reserved-blocks overhead
+    // grows with image size. ~1.5% is a generous floor.
+    let metadata_overhead = total_file_bytes / 64;
+    let raw = total_file_bytes
+        .saturating_add(entry_overhead)
+        .saturating_add(metadata_overhead)
+        .saturating_add(options.size_padding_bytes);
+    let block = options.block_size.max(512) as u64;
+    let rounded = raw.div_ceil(block).saturating_mul(block);
+    Ok(rounded.max(1024 * 1024))
+}
+
+/// Produce an ext4 image file at `output` from the contents of
+/// `staged.root`, with deterministic on-disk bytes for a given
+/// (staged tree, options) pair.
+///
+/// Linux-only at runtime; non-Linux hosts return
+/// [`OciUnpackError::HostUnsupported`]. The W1.5 CLI orchestrator
+/// routes the macOS path through the libkrun builder VM (per
+/// ADR-050) — that routing lives one layer up, not in this
+/// module.
+pub fn materialize_to_ext4(
+    staged: &StagedRootfs,
+    output: &Path,
+    options: &Mke2fsOptions,
+) -> Result<MaterializedRootfs, OciUnpackError> {
+    let size_bytes = estimate_image_size(&staged.root, options)?;
+
+    #[cfg(target_os = "linux")]
+    {
+        prepare_output_file(output, size_bytes)?;
+        run_mke2fs(&staged.root, output, options)?;
+        Ok(MaterializedRootfs {
+            path: output.to_path_buf(),
+            size_bytes,
+            label: options.label.clone(),
+            uuid: options.uuid.clone(),
+        })
+    }
+
+    #[cfg(not(target_os = "linux"))]
+    {
+        // Touch the variables to silence unused-variable warnings
+        // while keeping the same function signature across hosts.
+        let _ = (output, size_bytes);
+        Err(OciUnpackError::HostUnsupported {
+            operation: "ext4 image materialization (mke2fs)",
+            reason: "mke2fs is Linux-only; the W1.5 CLI orchestrator routes this through the libkrun builder VM (ADR-050)",
+        })
+    }
+}
+
+#[cfg(target_os = "linux")]
+fn prepare_output_file(output: &Path, size_bytes: u64) -> Result<(), OciUnpackError> {
+    if let Some(parent) = output.parent() {
+        std::fs::create_dir_all(parent)?;
+    }
+    let file = std::fs::File::create(output)?;
+    file.set_len(size_bytes)?;
+    Ok(())
+}
+
+#[cfg(target_os = "linux")]
+fn run_mke2fs(
+    staged_root: &Path,
+    output: &Path,
+    options: &Mke2fsOptions,
+) -> Result<(), OciUnpackError> {
+    let binary: &Path = options
+        .mke2fs_binary
+        .as_deref()
+        .unwrap_or_else(|| Path::new("mke2fs"));
+    let mut cmd = std::process::Command::new(binary);
+    cmd.env("SOURCE_DATE_EPOCH", options.source_date_epoch.to_string())
+        .args(["-F"]) // overwrite the preallocated output file
+        .args(["-t", "ext4"])
+        .args(["-L", &options.label])
+        .args(["-U", &options.uuid])
+        .args(["-E", &format!("hash_seed={}", options.hash_seed)])
+        .args(["-E", "no_copy_xattrs"])
+        .args(["-b", &options.block_size.to_string()])
+        .arg("-d")
+        .arg(staged_root)
+        .arg(output);
+    let exec = cmd.output().map_err(|e| OciUnpackError::Mke2fsFailed {
+        reason: format!("spawn `{}`: {e}", binary.display()),
+    })?;
+    if !exec.status.success() {
+        let stderr = String::from_utf8_lossy(&exec.stderr).into_owned();
+        let stdout = String::from_utf8_lossy(&exec.stdout).into_owned();
+        return Err(OciUnpackError::Mke2fsFailed {
+            reason: format!(
+                "exit {:?}; stderr={stderr}; stdout={stdout}",
+                exec.status.code()
+            ),
+        });
+    }
+    Ok(())
+}
+
+/// Recursive directory walk that returns
+/// `(total_file_bytes, total_entry_count)`. Counts every entry
+/// type (regular files, directories, symlinks). Symlinks count
+/// once toward `entries` and contribute their *link target
+/// string length* toward `bytes`, which is what ext4 actually
+/// stores for fast-symlinks under 60 bytes (longer ones spill
+/// into a block; the overestimate is fine).
+fn walk_size(root: &Path) -> Result<(u64, u64), OciUnpackError> {
+    fn visit(dir: &Path, bytes: &mut u64, entries: &mut u64) -> Result<(), OciUnpackError> {
+        for entry in std::fs::read_dir(dir)? {
+            let entry = entry?;
+            *entries = entries.saturating_add(1);
+            let metadata = entry.metadata()?;
+            if metadata.is_dir() && !metadata.file_type().is_symlink() {
+                visit(&entry.path(), bytes, entries)?;
+            } else if metadata.is_file() {
+                *bytes = bytes.saturating_add(metadata.len());
+            } else if metadata.file_type().is_symlink() {
+                let link_target = std::fs::read_link(entry.path())?;
+                let len = link_target.as_os_str().as_encoded_bytes().len() as u64;
+                *bytes = bytes.saturating_add(len);
+            }
+        }
+        Ok(())
+    }
+
+    let mut bytes: u64 = 0;
+    let mut entries: u64 = 0;
+    if root.is_dir() {
+        visit(root, &mut bytes, &mut entries)?;
+    }
+    Ok((bytes, entries))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::fs;
+    use tempfile::TempDir;
+
+    fn defaults() -> Mke2fsOptions {
+        Mke2fsOptions::default()
+    }
+
+    #[test]
+    fn defaults_are_deterministic_and_pinned() {
+        let o = defaults();
+        assert_eq!(o.label, "mvm-rootfs");
+        assert_eq!(o.uuid, "00000000-0000-0000-0000-000000000001");
+        assert_eq!(o.hash_seed, "00000000-0000-0000-0000-000000000002");
+        assert_eq!(o.block_size, 4096);
+        assert_eq!(o.source_date_epoch, 0);
+        // Padding is large enough to absorb mke2fs overhead but
+        // not so large that small images pay an outsized cost.
+        assert_eq!(o.size_padding_bytes, 4 * 1024 * 1024);
+    }
+
+    #[test]
+    fn empty_staging_estimate_is_dominated_by_padding() {
+        let tmp = TempDir::new().unwrap();
+        let est = estimate_image_size(tmp.path(), &defaults()).unwrap();
+        // Empty staging contributes zero raw bytes, so the
+        // estimate equals the padding (rounded up to block
+        // size). Default padding is 4 MiB which is already
+        // block-aligned, so the result is exactly that.
+        assert_eq!(est, 4 * 1024 * 1024);
+    }
+
+    #[test]
+    fn empty_staging_with_zero_padding_clamps_to_1_mib_floor() {
+        let tmp = TempDir::new().unwrap();
+        let opts = Mke2fsOptions {
+            size_padding_bytes: 0,
+            ..defaults()
+        };
+        let est = estimate_image_size(tmp.path(), &opts).unwrap();
+        // Below 1 MiB the clamp kicks in. mke2fs would reject a
+        // smaller image; the floor protects against that.
+        assert_eq!(est, 1024 * 1024);
+    }
+
+    #[test]
+    fn estimate_rounds_up_to_block_boundary() {
+        let tmp = TempDir::new().unwrap();
+        // Write a single 17-byte file. With the 4 MiB padding +
+        // per-entry overhead, the rounded result must be a
+        // multiple of the 4096-byte block size.
+        fs::write(tmp.path().join("payload"), b"seventeen-bytes!!").unwrap();
+        let est = estimate_image_size(tmp.path(), &defaults()).unwrap();
+        assert_eq!(est % 4096, 0, "{est} should be a multiple of 4096");
+    }
+
+    #[test]
+    fn estimate_includes_padding_above_raw_file_bytes() {
+        let tmp = TempDir::new().unwrap();
+        fs::write(tmp.path().join("payload"), vec![0u8; 1000]).unwrap();
+        let est = estimate_image_size(tmp.path(), &defaults()).unwrap();
+        // Default padding alone is 4 MiB, plus entry overhead
+        // adds another 1 KiB. The estimate must be comfortably
+        // above the raw 1000-byte file.
+        assert!(
+            est > 4 * 1024 * 1024,
+            "estimate {est} should exceed padding floor"
+        );
+    }
+
+    #[test]
+    fn estimate_grows_with_file_count() {
+        let tmp_few = TempDir::new().unwrap();
+        for i in 0..5 {
+            fs::write(tmp_few.path().join(format!("f{i}")), b"x").unwrap();
+        }
+        let est_few = estimate_image_size(tmp_few.path(), &defaults()).unwrap();
+
+        let tmp_many = TempDir::new().unwrap();
+        for i in 0..5000 {
+            fs::write(tmp_many.path().join(format!("f{i}")), b"x").unwrap();
+        }
+        let est_many = estimate_image_size(tmp_many.path(), &defaults()).unwrap();
+        assert!(
+            est_many > est_few,
+            "estimate for 5000 entries ({est_many}) should exceed estimate for 5 ({est_few})"
+        );
+    }
+
+    #[test]
+    fn estimate_handles_nested_directories() {
+        let tmp = TempDir::new().unwrap();
+        fs::create_dir_all(tmp.path().join("a/b/c")).unwrap();
+        fs::write(tmp.path().join("a/b/c/leaf"), b"leaf-bytes").unwrap();
+        let est = estimate_image_size(tmp.path(), &defaults()).unwrap();
+        assert!(est >= 1024 * 1024);
+    }
+
+    #[test]
+    fn estimate_handles_symlinks_without_following_them() {
+        let tmp = TempDir::new().unwrap();
+        fs::write(tmp.path().join("real"), b"real-bytes").unwrap();
+        #[cfg(unix)]
+        std::os::unix::fs::symlink("real", tmp.path().join("link")).unwrap();
+        let est = estimate_image_size(tmp.path(), &defaults()).unwrap();
+        assert!(est >= 1024 * 1024);
+        // The symlink counts as one entry but doesn't double-count
+        // the target's bytes (we read the link target string,
+        // not the file behind it).
+    }
+
+    #[cfg(not(target_os = "linux"))]
+    #[test]
+    fn materialize_returns_host_unsupported_on_non_linux() {
+        let tmp = TempDir::new().unwrap();
+        let staged = StagedRootfs {
+            root: tmp.path().to_path_buf(),
+        };
+        let output = tmp.path().join("rootfs.ext4");
+        let err = materialize_to_ext4(&staged, &output, &defaults()).unwrap_err();
+        match err {
+            OciUnpackError::HostUnsupported { operation, .. } => {
+                assert!(
+                    operation.contains("ext4"),
+                    "operation message should name ext4: got {operation:?}"
+                );
+            }
+            other => panic!("expected HostUnsupported, got {other:?}"),
+        }
+    }
+}

--- a/crates/mvm-build/src/oci_to_rootfs/mod.rs
+++ b/crates/mvm-build/src/oci_to_rootfs/mod.rs
@@ -10,8 +10,11 @@
 //!    reserved-path collision, size caps, unsupported entry
 //!    types).
 //! 3. Caller calls `finalize` to release the staging directory and
-//!    get a [`StagedRootfs`] descriptor pointing at it. ext4
-//!    materialization (W1.3b) consumes that descriptor next.
+//!    get a [`StagedRootfs`] descriptor pointing at it.
+//! 4. Caller hands the descriptor to [`materialize_to_ext4`]
+//!    (Linux-only at runtime; W1.5 routes non-Linux through the
+//!    libkrun builder VM per ADR-050), which produces a
+//!    byte-deterministic ext4 image suitable for verity sealing.
 //!
 //! Layers are assumed to arrive *decompressed*. The caller (W1.5
 //! CLI orchestrator) is responsible for piping fetched layer bytes
@@ -38,8 +41,10 @@
 //! write landing in staging.
 
 pub mod error;
+pub mod ext4;
 mod path_validation;
 mod unpack;
 
 pub use error::OciUnpackError;
+pub use ext4::{MaterializedRootfs, Mke2fsOptions, estimate_image_size, materialize_to_ext4};
 pub use unpack::{ImageStaging, LayerStats, StagedRootfs, StagingOptions};

--- a/crates/mvm-build/tests/oci_ext4_materialization.rs
+++ b/crates/mvm-build/tests/oci_ext4_materialization.rs
@@ -1,0 +1,159 @@
+//! Linux-gated integration test for [`mvm_build::oci_to_rootfs::
+//! materialize_to_ext4`].
+//!
+//! `mke2fs` is Linux-only and not present on macOS / Windows
+//! contributor laptops by default. These tests run when:
+//!
+//! 1. The target OS is Linux (`#[cfg(target_os = "linux")]`).
+//! 2. `mke2fs` is on `$PATH` at test time. If missing, the test
+//!    skips cleanly with a one-line note rather than failing —
+//!    contributor environments that don't have `e2fsprogs`
+//!    installed shouldn't see false negatives.
+//! 3. The CI lane that runs them is the same Linux KVM lane that
+//!    already runs the Plan 72 W3 verity regression — the host
+//!    has `mke2fs` from `e2fsprogs` and the privilege bits
+//!    `mke2fs -d` needs.
+
+#![cfg(target_os = "linux")]
+
+use mvm_build::oci_to_rootfs::{
+    ImageStaging, MaterializedRootfs, Mke2fsOptions, StagingOptions, materialize_to_ext4,
+};
+use std::io::Cursor;
+use std::path::Path;
+use tempfile::TempDir;
+
+/// Returns true when `mke2fs` is on `$PATH`. Tests that need a
+/// real `mke2fs` call this and exit early on miss.
+fn mke2fs_available() -> bool {
+    which::which("mke2fs").is_ok()
+}
+
+fn skip_if_no_mke2fs() -> bool {
+    if !mke2fs_available() {
+        eprintln!(
+            "mvm-oci ext4 integration test skipped: mke2fs not on $PATH \
+             (install e2fsprogs to run this test)"
+        );
+        return true;
+    }
+    false
+}
+
+fn write_file(root: &Path, rel: &str, bytes: &[u8]) {
+    let dest = root.join(rel);
+    if let Some(parent) = dest.parent() {
+        std::fs::create_dir_all(parent).unwrap();
+    }
+    std::fs::write(dest, bytes).unwrap();
+}
+
+fn fresh_staging() -> (TempDir, ImageStaging) {
+    let tmp = TempDir::new().unwrap();
+    let staging = ImageStaging::new(tmp.path(), StagingOptions::default()).unwrap();
+    (tmp, staging)
+}
+
+#[test]
+fn materialize_produces_a_real_ext4_image() {
+    if skip_if_no_mke2fs() {
+        return;
+    }
+
+    let (staging_dir, staging) = fresh_staging();
+    write_file(staging_dir.path(), "etc/hello", b"hello mvm");
+    write_file(staging_dir.path(), "bin/sh", b"#!/bin/sh\necho ok\n");
+    let staged = staging.finalize().unwrap();
+
+    let out_dir = TempDir::new().unwrap();
+    let output = out_dir.path().join("rootfs.ext4");
+    let mat: MaterializedRootfs = materialize_to_ext4(&staged, &output, &Mke2fsOptions::default())
+        .expect("materialize_to_ext4");
+
+    assert!(output.exists(), "ext4 file must exist on disk");
+    assert_eq!(mat.path, output);
+    assert!(mat.size_bytes >= 1024 * 1024);
+    assert_eq!(mat.label, "mvm-rootfs");
+    assert_eq!(mat.uuid, "00000000-0000-0000-0000-000000000001");
+
+    // Confirm the on-disk size matches what we told mke2fs to
+    // produce. mke2fs respects the file's preallocated length.
+    let meta = std::fs::metadata(&output).unwrap();
+    assert_eq!(meta.len(), mat.size_bytes);
+
+    // First 1024 bytes of an ext4 image are the boot block (all
+    // zeros for non-bootable filesystems); bytes 1024..1080 are
+    // the superblock. The ext4 magic 0xef53 lives at offset
+    // 0x438 within the superblock (1024 + 0x38 = 1080 + 56).
+    let buf = std::fs::read(&output).unwrap();
+    let magic = u16::from_le_bytes([buf[1024 + 0x38], buf[1024 + 0x39]]);
+    assert_eq!(magic, 0xef53, "ext4 superblock magic must be 0xef53");
+}
+
+#[test]
+fn materialize_is_byte_deterministic_for_the_same_input() {
+    if skip_if_no_mke2fs() {
+        return;
+    }
+
+    // Two independent staging directories with identical
+    // contents must produce byte-identical ext4 output — this
+    // is the property ADR-050's verity cache hinges on.
+    fn build_one() -> Vec<u8> {
+        let (staging_dir, staging) = fresh_staging();
+        write_file(staging_dir.path(), "etc/version", b"v1");
+        write_file(staging_dir.path(), "usr/bin/tool", b"tool-payload");
+        write_file(staging_dir.path(), "usr/lib/lib.so", b"lib-bytes");
+        let staged = staging.finalize().unwrap();
+
+        let out_dir = TempDir::new().unwrap();
+        let output = out_dir.path().join("rootfs.ext4");
+        materialize_to_ext4(&staged, &output, &Mke2fsOptions::default()).expect("materialize");
+        std::fs::read(&output).unwrap()
+    }
+
+    let a = build_one();
+    let b = build_one();
+    assert_eq!(
+        a.len(),
+        b.len(),
+        "byte-deterministic output must have stable size"
+    );
+    assert_eq!(
+        a, b,
+        "byte-deterministic output must produce identical bytes \
+         (verity cache invariant — see ADR-050)"
+    );
+}
+
+#[test]
+fn materialize_through_unpack_round_trip() {
+    if skip_if_no_mke2fs() {
+        return;
+    }
+
+    // Build a tar in memory, unpack it via ImageStaging, then
+    // materialize. Covers the W1.3a → W1.3b boundary.
+    use tar::{Builder, Header};
+    let mut b = Builder::new(Vec::new());
+    let body = b"unpack-then-materialize\n";
+    let mut h = Header::new_gnu();
+    h.set_size(body.len() as u64);
+    h.set_mode(0o644);
+    h.set_entry_type(tar::EntryType::Regular);
+    h.set_cksum();
+    b.append_data(&mut h, "etc/marker", body.as_slice())
+        .unwrap();
+    let tar_bytes = b.into_inner().unwrap();
+
+    let (staging_dir, mut staging) = fresh_staging();
+    staging.apply_layer(Cursor::new(tar_bytes)).unwrap();
+    let staged = staging.finalize().unwrap();
+
+    let out_dir = TempDir::new().unwrap();
+    let output = out_dir.path().join("rootfs.ext4");
+    let mat =
+        materialize_to_ext4(&staged, &output, &Mke2fsOptions::default()).expect("materialize");
+    assert!(mat.size_bytes >= 1024 * 1024);
+    let _ = staging_dir; // keep the staging dir alive for the duration
+}

--- a/specs/claims/claim-10-oci-image-provenance.md
+++ b/specs/claims/claim-10-oci-image-provenance.md
@@ -26,6 +26,7 @@ exempt_paths:
   - "crates/mvm-build/src/oci_to_rootfs/**"
   - "crates/mvm-build/tests/oci_unpack_attacks.rs"
   - "crates/mvm-build/tests/oci_unpack_common/**"
+  - "crates/mvm-build/tests/oci_ext4_materialization.rs"
 ---
 
 # Claim 10 — OCI image provenance is recorded in the admission audit chain


### PR DESCRIPTION
**Stacks on #233 (W1.3a).** Base is `feat/plan74-w1-unpack`; once
that merges to `main`, this PR auto-rebases.

## Summary

Second half of plan 74 W1.3: turn the staged-directory output of
[`ImageStaging::finalize`](https://github.com/tinylabscom/mvm/blob/main/crates/mvm-build/src/oci_to_rootfs/unpack.rs)
(landed in W1.3a) into a byte-deterministic `rootfs.ext4` image
suitable for ADR-050 verity sealing.

## New surface

`mvm_build::oci_to_rootfs::ext4`:

- `Mke2fsOptions` — pinned-for-determinism knobs (label, UUID,
  htree hash seed, block size, SOURCE_DATE_EPOCH, padding,
  optional `mke2fs` binary override).
- `estimate_image_size(staged_root, options)` — walks the tree,
  sums file bytes + per-entry overhead + metadata overhead +
  padding, rounds to block-size, floors at 1 MiB.
- `materialize_to_ext4(staged, output, options)` — Linux:
  preallocates output + shells out to `mke2fs -d`. Non-Linux:
  returns `HostUnsupported`; the W1.5 CLI orchestrator routes
  through the libkrun builder VM per ADR-050.
- `MaterializedRootfs { path, size_bytes, label, uuid }`.

## Determinism story

Every source of `mke2fs` randomness pinned: `-U <uuid>`, `-E
hash_seed=<uuid>`, `SOURCE_DATE_EPOCH=0`, `-E no_copy_xattrs`,
`-b 4096`. The
`materialize_is_byte_deterministic_for_the_same_input`
integration test builds the same staging tree in two separate
tempdirs and asserts the resulting ext4 bytes are identical.
This is the load-bearing invariant for ADR-050's per-digest
verity cache: same input → same ext4 → same verity sidecar →
cache hit on the next pull.

## New error variants on `OciUnpackError`

- `Mke2fsFailed { reason }` — `mke2fs` non-zero exit; includes
  upstream stderr/stdout for debugging.
- `HostUnsupported { operation, reason }` — generic shape for
  "needs a feature this host doesn't have." Reusable for future
  Linux-only operations.

## Tests

Cross-platform unit (8 new):

- `defaults_are_deterministic_and_pinned`
- `empty_staging_estimate_is_dominated_by_padding`
- `empty_staging_with_zero_padding_clamps_to_1_mib_floor`
- `estimate_rounds_up_to_block_boundary`
- `estimate_includes_padding_above_raw_file_bytes`
- `estimate_grows_with_file_count`
- `estimate_handles_nested_directories`
- `estimate_handles_symlinks_without_following_them`
- `materialize_returns_host_unsupported_on_non_linux` (gated to non-Linux)

Linux-gated integration tests (3 new, gated on
`#[cfg(target_os = \"linux\")]` + `which::which(\"mke2fs\")`,
skips cleanly when `e2fsprogs` isn't installed):

- `materialize_produces_a_real_ext4_image` — verifies
  superblock magic `0xef53` at offset 0x438.
- `materialize_is_byte_deterministic_for_the_same_input` — two
  runs → identical bytes. ADR-050 verity-cache invariant.
- `materialize_through_unpack_round_trip` — tar → unpack →
  materialize end-to-end through W1.3a.

## Verification

- [x] `cargo test -p mvm-build` — 60+ pass (33 unit incl. 8 new
      ext4 + 23 R10 integration + pipeline). Linux integration
      file compiles but doesn't add tests on macOS.
- [x] `cargo test --workspace --no-fail-fast` — 3 394 passed,
      0 failed, 9 ignored across 85 binaries.
- [x] `cargo clippy --workspace --all-targets -- -D warnings` —
      zero warnings.

## Out of scope (later W1 PRs)

- The macOS path through the libkrun builder VM — W1.5
  orchestrator routing.
- Verity sidecar generation (`veritysetup format`) — W1.4 per
  ADR-050.
- Verity-cache hit/miss orchestration keyed by layer digest —
  W1.4.
- CLI surface (`mvmctl image pull`) — W1.5.

## Stack snapshot (open PRs on plan 74)

| PR | Branch | Base | Subject |
| --- | --- | --- | --- |
| #221 | `feat/plan74-w0` | `main` | W0 + ADRs 048-051 + Plan 74 |
| #225 | `feat/plan74-w1-skeleton` | `main` | W1.1 mvm-oci crate skeleton |
| #229 | `feat/plan74-w1-layers` | `feat/plan74-w1-skeleton` | W1.2 layer fetch + hermetic tests |
| #233 | `feat/plan74-w1-unpack` | `main` | W1.3a layer unpack + R10 tests |
| **this** | `feat/plan74-w1-ext4` | `feat/plan74-w1-unpack` | W1.3b ext4 materialization |

🤖 Generated with [Claude Code](https://claude.com/claude-code)