### PR TITLE
plan 74 W1.4a — verity sidecar generation for OCI rootfs

### DIFF
--- a/crates/mvm-build/src/oci_to_rootfs/error.rs
+++ b/crates/mvm-build/src/oci_to_rootfs/error.rs
@@ -97,6 +97,14 @@ pub enum OciUnpackError {
     #[error("mke2fs failed: {reason}")]
     Mke2fsFailed { reason: String },
 
+    /// `veritysetup format` exited non-zero, could not be spawned,
+    /// or produced output that didn't include a parseable
+    /// `Root hash:` line. Plan 74 W1.4a — verity sidecar
+    /// generation per ADR-050. Includes the upstream stderr /
+    /// stdout when present so failures are debuggable.
+    #[error("veritysetup failed: {reason}")]
+    VeritysetupFailed { reason: String },
+
     /// An operation that this crate exposes is not supported on
     /// the current host. ext4 image materialization, for example,
     /// requires Linux + `mke2fs`; on macOS the W1.5 CLI

--- a/crates/mvm-build/src/oci_to_rootfs/mod.rs
+++ b/crates/mvm-build/src/oci_to_rootfs/mod.rs
@@ -14,7 +14,13 @@
 //! 4. Caller hands the descriptor to [`materialize_to_ext4`]
 //!    (Linux-only at runtime; W1.5 routes non-Linux through the
 //!    libkrun builder VM per ADR-050), which produces a
-//!    byte-deterministic ext4 image suitable for verity sealing.
+//!    byte-deterministic ext4 image.
+//! 5. Caller hands the [`MaterializedRootfs`] to
+//!    [`seal_with_verity`] (also Linux-only) to generate the
+//!    dm-verity sidecar + root hash that satisfies ADR-050. Two
+//!    runs against byte-identical ext4 input produce
+//!    byte-identical sidecars + the same root hash; this is the
+//!    invariant the per-digest verity cache depends on.
 //!
 //! Layers are assumed to arrive *decompressed*. The caller (W1.5
 //! CLI orchestrator) is responsible for piping fetched layer bytes
@@ -44,7 +50,12 @@ pub mod error;
 pub mod ext4;
 mod path_validation;
 mod unpack;
+pub mod verity;
 
 pub use error::OciUnpackError;
 pub use ext4::{MaterializedRootfs, Mke2fsOptions, estimate_image_size, materialize_to_ext4};
 pub use unpack::{ImageStaging, LayerStats, StagedRootfs, StagingOptions};
+pub use verity::{
+    MVM_VERITY_DATA_BLOCK_SIZE, MVM_VERITY_HASH_ALGORITHM, MVM_VERITY_HASH_BLOCK_SIZE,
+    MVM_VERITY_PINNED_SALT, VeritySealedRootfs, VeritysetupOptions, seal_with_verity,
+};

--- a/crates/mvm-build/src/oci_to_rootfs/verity.rs
+++ b/crates/mvm-build/src/oci_to_rootfs/verity.rs
@@ -1,0 +1,451 @@
+//! Verity sidecar generation for an ext4 image, per ADR-050.
+//!
+//! `veritysetup format` produces a separate "hash device" (the
+//! Merkle tree over the rootfs's data blocks) plus a root hash.
+//! At boot, `mvm-verity-init` recomputes the Merkle tree and
+//! asserts the root hash matches the value pinned on the kernel
+//! cmdline. Any byte-level tamper of the rootfs panics the
+//! kernel before userspace.
+//!
+//! ## Parameters (DO NOT CHANGE without updating `mvm-verity-init`)
+//!
+//! - `--data-block-size=1024` — must match the hard-coded
+//!   constant in `mvm-guest/src/bin/mvm-verity-init.rs`. The
+//!   comment there explains why we use 1 KiB blocks (matches
+//!   mke2fs's default for sub-512 MiB images, lines up with
+//!   ext4's device-block-size constraint).
+//! - `--hash-block-size=4096` — veritysetup default; the hash
+//!   tree's internal node size.
+//! - `--salt=00…00` (64 hex zeros) — pinned for determinism.
+//!   Any non-zero salt would tie the root hash to the salt,
+//!   defeating the ADR-050 per-digest verity cache.
+//! - `sha256` hash algorithm — what `mvm-verity-init` expects.
+//!
+//! ## Determinism story
+//!
+//! Two `seal_with_verity` runs against byte-identical inputs
+//! produce byte-identical sidecars *and* identical root hashes.
+//! This is the load-bearing invariant for ADR-050's per-digest
+//! verity cache. The integration tests assert it.
+//!
+//! ## Host support
+//!
+//! Linux-only at runtime. `veritysetup` is part of `cryptsetup`,
+//! installed via the `e2fsprogs`-adjacent `cryptsetup-bin` package
+//! (Debian/Ubuntu) or the `cryptsetup` package (Alpine, Fedora,
+//! Arch). On macOS / Windows the function returns
+//! [`OciUnpackError::HostUnsupported`]; the W1.5 CLI orchestrator
+//! routes through the libkrun builder VM per ADR-050.
+
+use crate::oci_to_rootfs::error::OciUnpackError;
+use crate::oci_to_rootfs::ext4::MaterializedRootfs;
+use std::path::{Path, PathBuf};
+
+/// `data-block-size` pinned to 1024 bytes. Must match the
+/// `DATA_BLOCK_SIZE` constant in
+/// `crates/mvm-guest/src/bin/mvm-verity-init.rs` or boot fails
+/// with "metadata block 0 is corrupted" at the dm-verity layer.
+pub const MVM_VERITY_DATA_BLOCK_SIZE: u32 = 1024;
+
+/// `hash-block-size` pinned to 4096 bytes. Matches veritysetup's
+/// own default; the kernel's verity target reads metadata at
+/// this block size regardless of the data block size.
+pub const MVM_VERITY_HASH_BLOCK_SIZE: u32 = 4096;
+
+/// 64 hex characters of zero. Pinned salt is the load-bearing
+/// determinism guarantee — any non-zero salt would couple the
+/// root hash to the salt and defeat per-digest caching.
+pub const MVM_VERITY_PINNED_SALT: &str =
+    "0000000000000000000000000000000000000000000000000000000000000000";
+
+/// `sha256` hash algorithm. Must match
+/// `mvm-verity-init.rs`'s expected algorithm.
+pub const MVM_VERITY_HASH_ALGORITHM: &str = "sha256";
+
+/// Knobs for [`seal_with_verity`]. Defaults are pinned to the
+/// values `mvm-verity-init` expects at boot; callers can
+/// override for tests or future ADRs but production paths should
+/// use `Default::default()`.
+#[derive(Debug, Clone)]
+pub struct VeritysetupOptions {
+    /// Data block size in bytes. See module docs for why this
+    /// must be 1024 for compatibility with `mvm-verity-init`.
+    pub data_block_size: u32,
+    /// Hash tree internal block size. Default 4096
+    /// (veritysetup default).
+    pub hash_block_size: u32,
+    /// Salt as 64 hex characters. Default is all-zero
+    /// (`MVM_VERITY_PINNED_SALT`) to make the root hash a
+    /// function of the rootfs bytes alone.
+    pub salt: String,
+    /// Hash algorithm. Default `sha256`.
+    pub algorithm: String,
+    /// Override the `veritysetup` binary location. Default
+    /// `None` → resolved via `$PATH`. Tests use this to
+    /// substitute a stub.
+    pub veritysetup_binary: Option<PathBuf>,
+}
+
+impl Default for VeritysetupOptions {
+    fn default() -> Self {
+        Self {
+            data_block_size: MVM_VERITY_DATA_BLOCK_SIZE,
+            hash_block_size: MVM_VERITY_HASH_BLOCK_SIZE,
+            salt: MVM_VERITY_PINNED_SALT.to_string(),
+            algorithm: MVM_VERITY_HASH_ALGORITHM.to_string(),
+            veritysetup_binary: None,
+        }
+    }
+}
+
+/// Final descriptor produced by [`seal_with_verity`].
+#[derive(Debug, Clone)]
+pub struct VeritySealedRootfs {
+    /// Path to the rootfs ext4 (unchanged from input).
+    pub rootfs_path: PathBuf,
+    /// Path to the verity hash device — the Merkle tree sidecar
+    /// the kernel reads at boot.
+    pub sidecar_path: PathBuf,
+    /// Path to a text file containing the root hash as
+    /// lowercase hex. The kernel cmdline gets the same hash via
+    /// `mvm.roothash=<hex>`.
+    pub roothash_path: PathBuf,
+    /// Root hash itself, lowercase hex (typically 64 chars for
+    /// sha256). The on-disk file at `roothash_path` carries the
+    /// same string with a trailing newline.
+    pub roothash: String,
+    /// Algorithm used. Mirrored from options for diagnostics;
+    /// always `sha256` today.
+    pub algorithm: String,
+    /// Data block size used. Mirrored from options for
+    /// diagnostics; always `MVM_VERITY_DATA_BLOCK_SIZE` today.
+    pub data_block_size: u32,
+}
+
+/// Seal `rootfs` with a verity sidecar.
+///
+/// Output paths default to siblings of `rootfs.rootfs_path`:
+///
+/// - `<rootfs-stem>.verity` for the hash device
+/// - `<rootfs-stem>.roothash` for the text-file root hash
+///
+/// Linux-only at runtime; non-Linux hosts return
+/// [`OciUnpackError::HostUnsupported`]. The W1.5 CLI
+/// orchestrator routes the macOS path through the libkrun
+/// builder VM per ADR-050.
+pub fn seal_with_verity(
+    rootfs: &MaterializedRootfs,
+    options: &VeritysetupOptions,
+) -> Result<VeritySealedRootfs, OciUnpackError> {
+    validate_options(options)?;
+    let (sidecar_path, roothash_path) = derive_output_paths(&rootfs.path);
+
+    #[cfg(target_os = "linux")]
+    {
+        prepare_sidecar(&sidecar_path)?;
+        let roothash = run_veritysetup_format(&rootfs.path, &sidecar_path, options)?;
+        write_roothash_file(&roothash_path, &roothash)?;
+        Ok(VeritySealedRootfs {
+            rootfs_path: rootfs.path.clone(),
+            sidecar_path,
+            roothash_path,
+            roothash,
+            algorithm: options.algorithm.clone(),
+            data_block_size: options.data_block_size,
+        })
+    }
+
+    #[cfg(not(target_os = "linux"))]
+    {
+        let _ = (sidecar_path, roothash_path);
+        Err(OciUnpackError::HostUnsupported {
+            operation: "verity sidecar generation (veritysetup format)",
+            reason: "veritysetup is Linux-only; the W1.5 CLI orchestrator routes this through the libkrun builder VM (ADR-050)",
+        })
+    }
+}
+
+fn validate_options(options: &VeritysetupOptions) -> Result<(), OciUnpackError> {
+    if options.salt.len() != 64 || !options.salt.bytes().all(|b| b.is_ascii_hexdigit()) {
+        return Err(OciUnpackError::VeritysetupFailed {
+            reason: format!(
+                "salt must be exactly 64 hex characters; got {:?} (length {})",
+                options.salt,
+                options.salt.len()
+            ),
+        });
+    }
+    if options.algorithm.is_empty() {
+        return Err(OciUnpackError::VeritysetupFailed {
+            reason: "algorithm must be a non-empty algorithm name (e.g. \"sha256\")".to_string(),
+        });
+    }
+    if !options.data_block_size.is_power_of_two() {
+        return Err(OciUnpackError::VeritysetupFailed {
+            reason: format!(
+                "data_block_size {} must be a power of two",
+                options.data_block_size
+            ),
+        });
+    }
+    if !options.hash_block_size.is_power_of_two() {
+        return Err(OciUnpackError::VeritysetupFailed {
+            reason: format!(
+                "hash_block_size {} must be a power of two",
+                options.hash_block_size
+            ),
+        });
+    }
+    Ok(())
+}
+
+fn derive_output_paths(rootfs: &Path) -> (PathBuf, PathBuf) {
+    // We name the sidecar / roothash files by stem so any rootfs
+    // path works. `<dir>/rootfs.ext4` → `<dir>/rootfs.verity` +
+    // `<dir>/rootfs.roothash`, matching the names the existing
+    // Nix-built path produces (`nix/flake.nix`'s
+    // `verityArtifacts`).
+    let stem = rootfs
+        .file_stem()
+        .map(|s| s.to_os_string())
+        .unwrap_or_else(|| std::ffi::OsString::from("rootfs"));
+    let parent = rootfs.parent().unwrap_or_else(|| Path::new(""));
+    let mut sidecar = parent.join(&stem);
+    sidecar.set_extension("verity");
+    let mut roothash = parent.join(&stem);
+    roothash.set_extension("roothash");
+    (sidecar, roothash)
+}
+
+#[cfg(target_os = "linux")]
+fn prepare_sidecar(sidecar: &Path) -> Result<(), OciUnpackError> {
+    if let Some(parent) = sidecar.parent() {
+        std::fs::create_dir_all(parent)?;
+    }
+    // veritysetup format expects to write to an existing,
+    // possibly-empty file. Truncate or create.
+    let _ = std::fs::File::create(sidecar)?;
+    Ok(())
+}
+
+#[cfg(target_os = "linux")]
+fn run_veritysetup_format(
+    rootfs: &Path,
+    sidecar: &Path,
+    options: &VeritysetupOptions,
+) -> Result<String, OciUnpackError> {
+    let binary: &Path = options
+        .veritysetup_binary
+        .as_deref()
+        .unwrap_or_else(|| Path::new("veritysetup"));
+    let mut cmd = std::process::Command::new(binary);
+    cmd.arg("format")
+        .arg(format!("--data-block-size={}", options.data_block_size))
+        .arg(format!("--hash-block-size={}", options.hash_block_size))
+        .arg(format!("--salt={}", options.salt))
+        .arg(format!("--hash={}", options.algorithm))
+        .arg(rootfs)
+        .arg(sidecar);
+    let exec = cmd
+        .output()
+        .map_err(|e| OciUnpackError::VeritysetupFailed {
+            reason: format!("spawn `{}`: {e}", binary.display()),
+        })?;
+    if !exec.status.success() {
+        let stderr = String::from_utf8_lossy(&exec.stderr).into_owned();
+        let stdout = String::from_utf8_lossy(&exec.stdout).into_owned();
+        return Err(OciUnpackError::VeritysetupFailed {
+            reason: format!(
+                "exit {:?}; stderr={stderr}; stdout={stdout}",
+                exec.status.code()
+            ),
+        });
+    }
+    let stdout = String::from_utf8_lossy(&exec.stdout);
+    parse_root_hash(&stdout).ok_or_else(|| OciUnpackError::VeritysetupFailed {
+        reason: format!(
+            "veritysetup format succeeded but produced no `Root hash:` line; stdout={}",
+            stdout.trim()
+        ),
+    })
+}
+
+/// Extract the root hash from `veritysetup format` stdout. The
+/// output is a block of "key:value" lines; we look for the
+/// `Root hash:` line and return its trimmed hex value (lowercase).
+///
+/// Compiled on every host so the unit tests can exercise it
+/// without `veritysetup` installed; on non-Linux production
+/// builds the function is unreachable, which clippy flags
+/// without the `cfg_attr` below.
+#[cfg_attr(not(target_os = "linux"), allow(dead_code))]
+fn parse_root_hash(stdout: &str) -> Option<String> {
+    for line in stdout.lines() {
+        // Be permissive about case (`Root hash` vs `Roothash`)
+        // and surrounding whitespace; veritysetup's output
+        // format has been stable but a future version might
+        // shift formatting.
+        let lower = line.to_lowercase();
+        if lower.starts_with("root hash:") || lower.starts_with("roothash:") {
+            let (_, value) = line.split_once(':')?;
+            // Hash values from veritysetup are hex; lowercase
+            // them for consistency.
+            return Some(value.trim().to_lowercase());
+        }
+    }
+    None
+}
+
+#[cfg(target_os = "linux")]
+fn write_roothash_file(path: &Path, roothash: &str) -> Result<(), OciUnpackError> {
+    if let Some(parent) = path.parent() {
+        std::fs::create_dir_all(parent)?;
+    }
+    let mut content = roothash.to_string();
+    content.push('\n');
+    std::fs::write(path, content)?;
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use tempfile::TempDir;
+
+    fn defaults() -> VeritysetupOptions {
+        VeritysetupOptions::default()
+    }
+
+    #[test]
+    fn defaults_match_mvm_verity_init_constants() {
+        let o = defaults();
+        assert_eq!(o.data_block_size, 1024);
+        assert_eq!(o.hash_block_size, 4096);
+        assert_eq!(o.salt, MVM_VERITY_PINNED_SALT);
+        assert_eq!(o.algorithm, "sha256");
+        // The constants themselves are the contract; restate
+        // them so any future drift fires this test before the
+        // kernel panics at boot.
+        assert_eq!(MVM_VERITY_DATA_BLOCK_SIZE, 1024);
+        assert_eq!(MVM_VERITY_HASH_BLOCK_SIZE, 4096);
+        assert_eq!(MVM_VERITY_PINNED_SALT.len(), 64);
+        assert!(MVM_VERITY_PINNED_SALT.bytes().all(|b| b == b'0'));
+        assert_eq!(MVM_VERITY_HASH_ALGORITHM, "sha256");
+    }
+
+    #[test]
+    fn derive_output_paths_uses_rootfs_stem() {
+        let (sidecar, roothash) = derive_output_paths(Path::new("/tmp/foo/rootfs.ext4"));
+        assert_eq!(sidecar, PathBuf::from("/tmp/foo/rootfs.verity"));
+        assert_eq!(roothash, PathBuf::from("/tmp/foo/rootfs.roothash"));
+    }
+
+    #[test]
+    fn derive_output_paths_handles_no_extension() {
+        let (sidecar, roothash) = derive_output_paths(Path::new("/tmp/foo/myimage"));
+        assert_eq!(sidecar, PathBuf::from("/tmp/foo/myimage.verity"));
+        assert_eq!(roothash, PathBuf::from("/tmp/foo/myimage.roothash"));
+    }
+
+    #[test]
+    fn derive_output_paths_handles_alternate_extension() {
+        let (sidecar, roothash) = derive_output_paths(Path::new("/tmp/foo/myimage.img"));
+        assert_eq!(sidecar, PathBuf::from("/tmp/foo/myimage.verity"));
+        assert_eq!(roothash, PathBuf::from("/tmp/foo/myimage.roothash"));
+    }
+
+    #[test]
+    fn validate_rejects_wrong_length_salt() {
+        let opts = VeritysetupOptions {
+            salt: "00".to_string(),
+            ..defaults()
+        };
+        let err = validate_options(&opts).unwrap_err();
+        assert!(matches!(err, OciUnpackError::VeritysetupFailed { .. }));
+    }
+
+    #[test]
+    fn validate_rejects_non_hex_salt() {
+        let opts = VeritysetupOptions {
+            salt: "z".repeat(64),
+            ..defaults()
+        };
+        let err = validate_options(&opts).unwrap_err();
+        assert!(matches!(err, OciUnpackError::VeritysetupFailed { .. }));
+    }
+
+    #[test]
+    fn validate_rejects_non_power_of_two_data_block() {
+        let opts = VeritysetupOptions {
+            data_block_size: 1000,
+            ..defaults()
+        };
+        let err = validate_options(&opts).unwrap_err();
+        assert!(matches!(err, OciUnpackError::VeritysetupFailed { .. }));
+    }
+
+    #[test]
+    fn validate_rejects_empty_algorithm() {
+        let opts = VeritysetupOptions {
+            algorithm: String::new(),
+            ..defaults()
+        };
+        let err = validate_options(&opts).unwrap_err();
+        assert!(matches!(err, OciUnpackError::VeritysetupFailed { .. }));
+    }
+
+    #[test]
+    fn parse_root_hash_finds_line_with_canonical_format() {
+        let stdout = "VERITY header information for /tmp/rootfs.verity\n\
+                      UUID:            abc\n\
+                      Hash type:       1\n\
+                      Data blocks:     1024\n\
+                      Data block size: 1024\n\
+                      Hash block size: 4096\n\
+                      Hash algorithm:  sha256\n\
+                      Salt:            0000000000000000\n\
+                      Root hash:       ABC123def456\n";
+        assert_eq!(parse_root_hash(stdout), Some("abc123def456".to_string()));
+    }
+
+    #[test]
+    fn parse_root_hash_handles_lowercase_input() {
+        let stdout = "Root hash: 0123456789abcdef\n";
+        assert_eq!(
+            parse_root_hash(stdout),
+            Some("0123456789abcdef".to_string())
+        );
+    }
+
+    #[test]
+    fn parse_root_hash_returns_none_when_absent() {
+        let stdout = "VERITY header information\nUUID: x\nNo hash here.\n";
+        assert_eq!(parse_root_hash(stdout), None);
+    }
+
+    #[test]
+    fn parse_root_hash_returns_none_on_empty_input() {
+        assert_eq!(parse_root_hash(""), None);
+    }
+
+    #[cfg(not(target_os = "linux"))]
+    #[test]
+    fn seal_returns_host_unsupported_on_non_linux() {
+        let tmp = TempDir::new().unwrap();
+        let rootfs_path = tmp.path().join("rootfs.ext4");
+        std::fs::write(&rootfs_path, b"unused").unwrap();
+        let rootfs = MaterializedRootfs {
+            path: rootfs_path,
+            size_bytes: 0,
+            label: "mvm-rootfs".to_string(),
+            uuid: "00000000-0000-0000-0000-000000000001".to_string(),
+        };
+        let err = seal_with_verity(&rootfs, &defaults()).unwrap_err();
+        match err {
+            OciUnpackError::HostUnsupported { operation, .. } => {
+                assert!(operation.contains("verity"), "got {operation:?}");
+            }
+            other => panic!("expected HostUnsupported, got {other:?}"),
+        }
+    }
+}

--- a/crates/mvm-build/tests/oci_verity_sealing.rs
+++ b/crates/mvm-build/tests/oci_verity_sealing.rs
@@ -1,0 +1,254 @@
+//! Linux-gated integration test for [`mvm_build::oci_to_rootfs::
+//! seal_with_verity`].
+//!
+//! `veritysetup` is Linux-only and not present on macOS / Windows
+//! contributor laptops by default. These tests gate on:
+//!
+//! 1. `#[cfg(target_os = "linux")]` — the whole file compiles only
+//!    on Linux.
+//! 2. `which::which("veritysetup")` — skips cleanly when
+//!    `cryptsetup` (which provides `veritysetup`) isn't installed.
+//!    Contributor environments without `cryptsetup` see a one-line
+//!    note rather than a false failure.
+//! 3. `which::which("mke2fs")` — the round-trip tests need to
+//!    produce a real ext4 first (via W1.3b's `materialize_to_ext4`),
+//!    then seal it. CI's Linux KVM lane has both binaries.
+
+#![cfg(target_os = "linux")]
+
+use mvm_build::oci_to_rootfs::{
+    ImageStaging, MaterializedRootfs, Mke2fsOptions, OciUnpackError, StagingOptions,
+    VeritysetupOptions, materialize_to_ext4, seal_with_verity,
+};
+use std::path::Path;
+use tempfile::TempDir;
+
+fn skip_if_no_veritysetup() -> bool {
+    if which::which("veritysetup").is_err() {
+        eprintln!(
+            "mvm-oci verity integration test skipped: veritysetup not on $PATH \
+             (install cryptsetup to run this test)"
+        );
+        return true;
+    }
+    false
+}
+
+fn skip_if_no_mke2fs() -> bool {
+    if which::which("mke2fs").is_err() {
+        eprintln!("mvm-oci verity integration test skipped: mke2fs not on $PATH");
+        return true;
+    }
+    false
+}
+
+fn write_file(root: &Path, rel: &str, bytes: &[u8]) {
+    let dest = root.join(rel);
+    if let Some(parent) = dest.parent() {
+        std::fs::create_dir_all(parent).unwrap();
+    }
+    std::fs::write(dest, bytes).unwrap();
+}
+
+/// Build a small ext4 image from a tiny staging tree and return
+/// the [`MaterializedRootfs`]. Each test calls this to get a
+/// fresh ext4 to seal.
+fn make_small_ext4() -> (TempDir, MaterializedRootfs) {
+    let staging_tmp = TempDir::new().unwrap();
+    let staging = ImageStaging::new(staging_tmp.path(), StagingOptions::default()).unwrap();
+    write_file(staging_tmp.path(), "etc/version", b"v1");
+    write_file(staging_tmp.path(), "bin/sh", b"#!/bin/sh\necho ok\n");
+    let staged = staging.finalize().unwrap();
+
+    let out_dir = TempDir::new().unwrap();
+    let output = out_dir.path().join("rootfs.ext4");
+    // mke2fs default options use 4096-byte blocks; verity expects
+    // 1024 for compatibility with mvm-verity-init. Override.
+    let mke2fs_options = Mke2fsOptions {
+        block_size: 1024,
+        ..Mke2fsOptions::default()
+    };
+    let materialized =
+        materialize_to_ext4(&staged, &output, &mke2fs_options).expect("materialize_to_ext4");
+
+    // Carry the staging tmp around so the staged dir lives long
+    // enough for the verity step to read the rootfs. The returned
+    // tempdir owns the ext4 output too — keep it.
+    (out_dir, materialized)
+}
+
+#[test]
+fn seal_produces_sidecar_and_roothash_files() {
+    if skip_if_no_veritysetup() || skip_if_no_mke2fs() {
+        return;
+    }
+    let (_keep_alive, rootfs) = make_small_ext4();
+
+    let sealed =
+        seal_with_verity(&rootfs, &VeritysetupOptions::default()).expect("seal_with_verity");
+
+    // Sidecar + roothash files exist next to the rootfs.
+    assert!(
+        sealed.sidecar_path.exists(),
+        "verity sidecar must exist at {:?}",
+        sealed.sidecar_path
+    );
+    assert!(
+        sealed.roothash_path.exists(),
+        "roothash file must exist at {:?}",
+        sealed.roothash_path
+    );
+
+    // Root hash is 64 lowercase hex chars (sha256) and matches
+    // the file's contents.
+    assert_eq!(sealed.roothash.len(), 64, "sha256 hex must be 64 chars");
+    assert!(
+        sealed
+            .roothash
+            .bytes()
+            .all(|b| b.is_ascii_hexdigit() && !b.is_ascii_uppercase()),
+        "roothash must be lowercase hex: {:?}",
+        sealed.roothash
+    );
+    let on_disk = std::fs::read_to_string(&sealed.roothash_path).unwrap();
+    assert_eq!(on_disk.trim(), sealed.roothash);
+
+    // Metadata fields mirror the options.
+    assert_eq!(sealed.algorithm, "sha256");
+    assert_eq!(sealed.data_block_size, 1024);
+}
+
+#[test]
+fn seal_is_byte_deterministic_for_identical_rootfs_bytes() {
+    if skip_if_no_veritysetup() || skip_if_no_mke2fs() {
+        return;
+    }
+
+    // ADR-050 §"Caching" — byte-identical input must produce the
+    // same root hash and the same sidecar bytes. The per-digest
+    // verity cache depends on this invariant.
+    let (_keep_a, rootfs_a) = make_small_ext4();
+    let (_keep_b, rootfs_b) = make_small_ext4();
+
+    // Cross-check: the two rootfs images themselves are
+    // byte-identical (W1.3b's determinism is the precondition).
+    let bytes_a = std::fs::read(&rootfs_a.path).unwrap();
+    let bytes_b = std::fs::read(&rootfs_b.path).unwrap();
+    assert_eq!(
+        bytes_a, bytes_b,
+        "precondition: W1.3b ext4 generation should be byte-deterministic"
+    );
+
+    let sealed_a = seal_with_verity(&rootfs_a, &VeritysetupOptions::default()).expect("seal a");
+    let sealed_b = seal_with_verity(&rootfs_b, &VeritysetupOptions::default()).expect("seal b");
+
+    assert_eq!(
+        sealed_a.roothash, sealed_b.roothash,
+        "ADR-050 verity-cache invariant: identical rootfs → identical roothash"
+    );
+    let sidecar_a = std::fs::read(&sealed_a.sidecar_path).unwrap();
+    let sidecar_b = std::fs::read(&sealed_b.sidecar_path).unwrap();
+    assert_eq!(
+        sidecar_a, sidecar_b,
+        "ADR-050 verity-cache invariant: identical rootfs → identical sidecar bytes"
+    );
+}
+
+#[test]
+fn seal_followed_by_veritysetup_verify_returns_zero() {
+    // The runbook (`specs/runbooks/w3-verified-boot.md` Step 2)
+    // says the canonical post-condition for a Nix-built verity
+    // artifact is `veritysetup verify` returning 0. Our OCI-path
+    // sidecar must meet the same bar.
+    if skip_if_no_veritysetup() || skip_if_no_mke2fs() {
+        return;
+    }
+    let (_keep, rootfs) = make_small_ext4();
+    let sealed = seal_with_verity(&rootfs, &VeritysetupOptions::default()).expect("seal");
+
+    let verify = std::process::Command::new("veritysetup")
+        .arg("verify")
+        .arg(&sealed.rootfs_path)
+        .arg(&sealed.sidecar_path)
+        .arg(&sealed.roothash)
+        .output()
+        .expect("spawn veritysetup verify");
+    assert!(
+        verify.status.success(),
+        "veritysetup verify must accept the sidecar we produced; stderr={}",
+        String::from_utf8_lossy(&verify.stderr)
+    );
+}
+
+#[test]
+fn seal_detects_post_format_rootfs_tamper() {
+    // If anyone flips bytes in the rootfs after sealing,
+    // `veritysetup verify` against the same root hash must
+    // reject the artifact. This is the load-bearing R3 / claim 3
+    // property — the rootfs is sealed to the hash, not to a
+    // mutable filename.
+    if skip_if_no_veritysetup() || skip_if_no_mke2fs() {
+        return;
+    }
+    let (_keep, rootfs) = make_small_ext4();
+    let sealed = seal_with_verity(&rootfs, &VeritysetupOptions::default()).expect("seal");
+
+    // Flip a single byte somewhere inside the data region. The
+    // first 64 KiB of an ext4 image is mostly superblock /
+    // group-descriptor / inode-table territory; data blocks live
+    // a few hundred KiB in. We pick offset 200 KiB to land in a
+    // data block reliably for our small test image.
+    use std::io::{Seek, SeekFrom, Write};
+    let mut file = std::fs::OpenOptions::new()
+        .write(true)
+        .open(&sealed.rootfs_path)
+        .unwrap();
+    let len = file.metadata().unwrap().len();
+    let tamper_offset = (200 * 1024).min(len.saturating_sub(1));
+    file.seek(SeekFrom::Start(tamper_offset)).unwrap();
+    file.write_all(&[0xff]).unwrap();
+    file.sync_all().unwrap();
+    drop(file);
+
+    let verify = std::process::Command::new("veritysetup")
+        .arg("verify")
+        .arg(&sealed.rootfs_path)
+        .arg(&sealed.sidecar_path)
+        .arg(&sealed.roothash)
+        .output()
+        .expect("spawn veritysetup verify");
+    assert!(
+        !verify.status.success(),
+        "veritysetup verify must reject a tampered rootfs; stdout={} stderr={}",
+        String::from_utf8_lossy(&verify.stdout),
+        String::from_utf8_lossy(&verify.stderr)
+    );
+}
+
+#[test]
+fn seal_returns_error_on_missing_rootfs_file() {
+    if skip_if_no_veritysetup() {
+        return;
+    }
+    let tmp = TempDir::new().unwrap();
+    let missing_path = tmp.path().join("does-not-exist.ext4");
+    let rootfs = MaterializedRootfs {
+        path: missing_path,
+        size_bytes: 0,
+        label: "mvm-rootfs".to_string(),
+        uuid: "00000000-0000-0000-0000-000000000001".to_string(),
+    };
+    let err = seal_with_verity(&rootfs, &VeritysetupOptions::default()).unwrap_err();
+    // Either the file-creation step for the sidecar fails (if
+    // its parent dir is fine but veritysetup needs the data
+    // device first), or veritysetup itself fails on the missing
+    // data device. Both are acceptable — the property is "we
+    // fail closed, not silently."
+    assert!(
+        matches!(
+            err,
+            OciUnpackError::VeritysetupFailed { .. } | OciUnpackError::Io(_)
+        ),
+        "expected VeritysetupFailed or Io, got {err:?}"
+    );
+}

--- a/specs/claims/claim-10-oci-image-provenance.md
+++ b/specs/claims/claim-10-oci-image-provenance.md
@@ -27,6 +27,7 @@ exempt_paths:
   - "crates/mvm-build/tests/oci_unpack_attacks.rs"
   - "crates/mvm-build/tests/oci_unpack_common/**"
   - "crates/mvm-build/tests/oci_ext4_materialization.rs"
+  - "crates/mvm-build/tests/oci_verity_sealing.rs"
 ---
 
 # Claim 10 — OCI image provenance is recorded in the admission audit chain


### PR DESCRIPTION
**Stacks on #235 (W1.3b).** Base is `feat/plan74-w1-ext4`; once
that merges to `main`, this PR auto-rebases.

## Summary

Verity-sealing half of plan 74 W1.4: turn the byte-deterministic
ext4 from `materialize_to_ext4` into a dm-verity-sealed triple
(`rootfs.ext4` + `rootfs.verity` + `rootfs.roothash`) satisfying
ADR-050.

**W1.4b** (the runtime overlay disk per ADR-051 — new Nix flake +
mkGuest refactor + backend wiring) is a separate PR with its own
review focus.

## New surface

`mvm_build::oci_to_rootfs::verity`:

- `VeritysetupOptions` — pinned-for-determinism knobs.
- Public constants `MVM_VERITY_DATA_BLOCK_SIZE` (1024),
  `MVM_VERITY_HASH_BLOCK_SIZE` (4096), `MVM_VERITY_PINNED_SALT`
  (64 hex zeros), `MVM_VERITY_HASH_ALGORITHM` (sha256).
- `seal_with_verity(rootfs, options) -> VeritySealedRootfs` —
  Linux: shells out to `veritysetup format` with pinned params,
  parses the `Root hash:` line, writes the `.roothash` text
  file. Non-Linux: `HostUnsupported`.
- `VeritySealedRootfs { rootfs_path, sidecar_path, roothash_path,
  roothash, algorithm, data_block_size }`.

## Load-bearing contract

`data-block-size=1024` MUST match `mvm-verity-init.rs:203`'s
hard-coded `DATA_BLOCK_SIZE = 1024` or boot panics with
\"metadata block 0 is corrupted.\" The
`defaults_match_mvm_verity_init_constants` unit test enforces
this — any drift fires the test before contributors see a
verity-init panic.

Salt is all-zero (64 hex). Per ADR-050 caching, salt MUST be
deterministic so the root hash is a function of rootfs bytes
alone — any non-zero salt couples the hash to the salt and
defeats the per-digest cache.

## New error variant

`OciUnpackError::VeritysetupFailed { reason }` — non-zero exit,
spawn failure, or stdout without a parseable `Root hash:` line.
Carries upstream stderr/stdout for debugging.

## Tests

Cross-platform unit (13 new):
- `defaults_match_mvm_verity_init_constants` (contract check)
- output-path derivation (3 variants)
- input validation (salt length, hex, algorithm, block size — 4 cases)
- `parse_root_hash` (4 cases including absent / empty inputs)
- `seal_returns_host_unsupported_on_non_linux` (non-Linux gated)

Linux-gated integration (5 new, gated on
`#[cfg(target_os = \"linux\")]` + `which::which(\"veritysetup\")`
+ `which::which(\"mke2fs\")`; skips cleanly when missing):
- `seal_produces_sidecar_and_roothash_files` (happy path)
- `seal_is_byte_deterministic_for_identical_rootfs_bytes`
  (ADR-050 invariant — same ext4 → same sidecar bytes + same root
  hash)
- `seal_followed_by_veritysetup_verify_returns_zero` (the W3
  runbook's canonical post-condition — OCI-path sidecar meets
  the same bar as the Nix-built one)
- `seal_detects_post_format_rootfs_tamper` (R3 / claim 3
  end-to-end: flip a byte after sealing → verify rejects)
- `seal_returns_error_on_missing_rootfs_file` (fail-closed)

## Verification

- [x] `cargo test -p mvm-build` — 13 new verity unit tests pass.
- [x] `cargo test --workspace --no-fail-fast` — **3,407 passed,
      0 failed, 9 ignored** across 86 binaries.
- [x] `cargo clippy --workspace --all-targets -- -D warnings` —
      zero warnings.
- [x] Linux integration tests gated by both `cfg(target_os)` and
      `which::which` — clean skip on contributor laptops without
      cryptsetup.

## Out of scope (later W1 PRs)

- Runtime overlay disk per ADR-051 — W1.4b.
- Verity-cache hit/miss orchestration keyed by layer digest —
  W1.5.
- Wiring the OCI-path sidecar into the boot cmdline + verity
  initramfs — W1.5.
- The macOS path through the libkrun builder VM — W1.5
  orchestrator routing.

## Stack snapshot (open PRs on plan 74)

| PR | Branch | Base | Subject |
| --- | --- | --- | --- |
| #221 | `feat/plan74-w0` | `main` | W0 + ADRs 048-051 + Plan 74 |
| #225 | `feat/plan74-w1-skeleton` | `main` | W1.1 mvm-oci crate skeleton |
| #229 | `feat/plan74-w1-layers` | `feat/plan74-w1-skeleton` | W1.2 layer fetch + hermetic tests |
| #233 | `feat/plan74-w1-unpack` | `main` | W1.3a layer unpack + R10 tests |
| #235 | `feat/plan74-w1-ext4` | `feat/plan74-w1-unpack` | W1.3b ext4 materialization |
| **this** | `feat/plan74-w1-verity` | `feat/plan74-w1-ext4` | W1.4a verity sealing |

🤖 Generated with [Claude Code](https://claude.com/claude-code)