### PR TITLE
plan 74 W1.4b.2 — runtime-overlay Nix flake (per-arch verity-sealed ext4)

### DIFF
--- a/nix/images/runtime-overlay/flake.nix
+++ b/nix/images/runtime-overlay/flake.nix
@@ -1,0 +1,328 @@
+{
+  description = "mvm runtime overlay disk — verity-sealed ext4 carrying the guest agent + seccomp shim + runner, mounted at /mvm/runtime in every microVM (ADR-051)";
+
+  # ── Why this flake exists ─────────────────────────────────────────
+  #
+  # ADR-051 (`specs/adrs/051-mvm-runtime-overlay-disk.md`) introduces
+  # a second virtio-blk device that every mvm microVM attaches at
+  # boot — Nix-built rootfs and OCI-pulled rootfs alike. The
+  # overlay carries the in-VM binaries mvm controls (the guest
+  # agent, the per-service seccomp shim, the verity-initrd PID 1
+  # binary, the function-workload runner) plus a placeholder for
+  # the per-language SDK runtime libraries that ADR-049's vsock
+  # substitution depends on (the libraries themselves land in
+  # plan 74 W4; this flake reserves the directory layout today so
+  # the boot path is stable).
+  #
+  # The flake produces, per supported system, a `$out/` containing:
+  #
+  #   overlay.ext4      — the rootfs the kernel mounts at
+  #                       /mvm/runtime via dm-verity. Read-only at
+  #                       boot.
+  #   overlay.verity    — dm-verity sidecar (Merkle tree).
+  #   overlay.roothash  — 64 lowercase hex chars + newline. What
+  #                       mvm-verity-init reads from the kernel
+  #                       cmdline as `mvm.runtime_roothash=<hex>`.
+  #   VERSION           — semver of the producing mvmctl. The
+  #                       resolver (`mvm_build::runtime_overlay`,
+  #                       plan 74 W1.4b.1) refuses to attach an
+  #                       overlay whose VERSION disagrees with the
+  #                       running mvmctl's version.
+  #
+  # The four file names + the per-arch directory layout under
+  # `~/.cache/mvm/runtime-overlay/<version>/<arch>/` are the contract
+  # `RuntimeOverlayResolver::resolve` enforces. Renaming any of
+  # them breaks the resolver test
+  # `resolve_returns_artifact_when_all_files_present_and_version_matches`.
+  #
+  # ── Why a *separate* flake rather than rolling this into
+  # `nix/lib/mk-guest.nix` ───────────────────────────────────────────
+  #
+  # `mkGuest` builds per-image rootfs. The runtime overlay is *one*
+  # artifact shared by every microVM mvmctl boots, regardless of
+  # what `mkGuest` produces for the rootfs. Splitting the
+  # derivation here keeps two properties:
+  #
+  # 1. The overlay is rebuilt only when mvm bumps the agent /
+  #    runner / shim — *not* per user-supplied rootfs. The verity
+  #    roothash is content-addressable, so two identical overlays
+  #    cache-hit cleanly.
+  # 2. Per ADR-051's `mkGuest` refactor (W1.4b.3), the per-image
+  #    closure stops carrying `mvm-guest-agent`, `mvm-seccomp-apply`,
+  #    `mvm-runner`. Those binaries live here. Net effect: every
+  #    Nix-built image shrinks by ~10-15 MB.
+  #
+  # ── Why this flake doesn't pull in microvm.nix ─────────────────
+  #
+  # microvm.nix is the NixOS module that turns a system
+  # configuration into a Firecracker/Cloud-Hypervisor-bootable
+  # rootfs. It's overkill here: the overlay isn't a bootable VM,
+  # it's a verity-sealed data disk. We use bare `pkgs.runCommand`
+  # + the workspace's binaries + `mkfs.ext4 -d` + `veritysetup
+  # format`.
+  #
+  # ── Determinism ────────────────────────────────────────────────
+  #
+  # Two builds of this flake against the same workspace state
+  # must produce byte-identical `overlay.ext4` + `overlay.verity`
+  # + identical `overlay.roothash`. ADR-051's per-version cache
+  # depends on this property. We pin every source of mkfs.ext4
+  # randomness (UUID, hash_seed, SOURCE_DATE_EPOCH) and every
+  # source of veritysetup randomness (salt, data block size, hash
+  # algo). Nix's sandbox covers the rest (timestamps,
+  # parallelism-induced ordering).
+  #
+  # ── Cryptsetup version pin (issue #223) ────────────────────────
+  #
+  # The W3 verity build pins `cryptsetup` via the same nixpkgs
+  # commit. The OCI-pull path's seal_with_verity (W1.4a) inherits
+  # whatever cryptsetup is on `$PATH` in the builder VM. This
+  # flake stays consistent with the W3 derivation by routing
+  # through the same `nixpkgs.cryptsetup` attribute. Issue #223
+  # tracks tightening this to an explicit version override.
+
+  inputs = {
+    nixpkgs.url = "github:NixOS/nixpkgs/nixos-25.11";
+  };
+
+  outputs =
+    { self, nixpkgs, ... }:
+    let
+      systems = [ "aarch64-linux" "x86_64-linux" ];
+      forAllSystems = nixpkgs.lib.genAttrs systems;
+
+      # Workspace staging — same `MVM_WORKSPACE_PATH` env override
+      # the builder-vm flake uses, for the libkrun-builder-VM
+      # sandbox case.
+      workspaceRoot =
+        let
+          envPath = builtins.getEnv "MVM_WORKSPACE_PATH";
+        in
+        if envPath != "" then /. + envPath else ../../..;
+
+      workspace = builtins.path {
+        path = workspaceRoot;
+        name = "mvm-workspace";
+        filter =
+          path: _type:
+          let
+            base = baseNameOf path;
+          in
+          !(builtins.elem base [
+            "target"
+            ".git"
+            "result"
+            "node_modules"
+            ".direnv"
+            ".cargo"
+            ".claude"
+            ".worktrees"
+          ])
+          && !(nixpkgs.lib.hasPrefix "result-" base);
+      };
+
+      # mvmctl semver pinned to match
+      # `[workspace.package].version` in the root Cargo.toml. The
+      # `RuntimeOverlayResolver` rejects an overlay whose VERSION
+      # file disagrees with the running mvmctl. Bumping the
+      # workspace version requires bumping this string too — keep
+      # the two in lock-step or `mvmctl up` admission fails.
+      overlayVersion = "0.14.0";
+
+      # mvm-guest binaries — agent + seccomp shim + verity-init.
+      # `mvm-verity-init` is the initrd PID 1; it lives in the
+      # initramfs cpio.gz, *not* in this overlay. We still build
+      # it here because the rustPlatform derivation produces all
+      # three binaries from one `--package mvm-guest` build (per
+      # `nix/packages/mvm-guest-agent.nix`'s
+      # `--bin mvm-guest-agent --bin mvm-seccomp-apply --bin mvm-verity-init`
+      # flags); we just don't copy the verity-init binary into the
+      # overlay's staging dir.
+      mvmGuestFor = system:
+        let
+          pkgs = import nixpkgs { inherit system; };
+        in
+        import (workspace + "/nix/packages/mvm-guest-agent.nix") {
+          inherit pkgs;
+          lib = pkgs.lib;
+          mvmSrc = workspace;
+          # No dev-shell — the overlay ships the production agent.
+          # ADR-002 §W4.3's `prod-agent-no-exec` CI gate asserts
+          # `mvm_guest_agent::do_exec` is absent from this binary.
+          withDevShell = false;
+        };
+
+      # mvm-runner — the function-workload entrypoint runner
+      # (plan 60 Phase 5 Slice C). Same rustPlatform pattern as
+      # the guest agent; workspace Cargo.lock drives the closure.
+      mvmRunnerFor = system:
+        let
+          pkgs = import nixpkgs { inherit system; };
+        in
+        pkgs.rustPlatform.buildRustPackage {
+          pname = "mvm-runner";
+          version = overlayVersion;
+          src = workspace;
+          cargoLock = {
+            lockFile = workspace + "/Cargo.lock";
+          };
+          buildAndTestSubdir = "crates/mvm-runner";
+          doCheck = false;
+          meta = {
+            description = "mvm function-workload entrypoint runner (plan 60 Phase 5 Slice C)";
+            mainProgram = "mvm-runner";
+          };
+        };
+
+      # Pinned-for-determinism flags. MUST mirror:
+      #
+      # - `mvm_build::oci_to_rootfs::ext4::Mke2fsOptions::default`
+      #   for ext4 (UUID, hash_seed, block size, SOURCE_DATE_EPOCH).
+      # - `mvm_build::oci_to_rootfs::verity::VeritysetupOptions::default`
+      #   for verity (data block 1024, hash block 4096, zero salt,
+      #   sha256).
+      #
+      # The unit tests
+      # `defaults_match_mvm_verity_init_constants` (W1.4a) and
+      # `defaults_are_deterministic_and_pinned` (W1.3b) enforce
+      # the Rust-side constants; this comment is the cross-stack
+      # contract. If you bump either side, bump both.
+      overlayUuid = "00000000-0000-0000-0000-00000000beef";
+      overlayHashSeed = "00000000-0000-0000-0000-00000000cafe";
+      overlayBlockSize = 1024;
+      overlayVeritySalt = "0000000000000000000000000000000000000000000000000000000000000000";
+      overlayVerityHashAlgorithm = "sha256";
+      overlayVerityHashBlockSize = 4096;
+
+      # Target overlay size: 32 MiB. ADR-051 §"Open questions" pins
+      # a hard cap of 32 MiB for the overlay budget; today's
+      # contents fit in well under that, but using the cap as the
+      # nominal size leaves headroom for the W4 SDK runtime
+      # libraries without re-allocating the ext4 each release.
+      overlaySizeBytes = 32 * 1024 * 1024;
+
+      mkRuntimeOverlay = system:
+        let
+          pkgs = import nixpkgs { inherit system; };
+          guest = mvmGuestFor system;
+          runner = mvmRunnerFor system;
+        in
+        pkgs.runCommand "mvm-runtime-overlay-${system}"
+          {
+            nativeBuildInputs = [
+              pkgs.e2fsprogs
+              pkgs.cryptsetup # provides veritysetup
+              pkgs.coreutils
+            ];
+            passthru = {
+              inherit guest runner;
+              version = overlayVersion;
+              dataBlockSize = overlayBlockSize;
+              verityHashAlgorithm = overlayVerityHashAlgorithm;
+            };
+          }
+          ''
+            set -euo pipefail
+
+            # Staging tree — the eventual filesystem root inside the
+            # overlay ext4. The kernel mounts this at /mvm/runtime
+            # inside the guest, so the *FS root* contains
+            # /agent, /seccomp-apply, /runner, /sdk-py/, /sdk-ts/,
+            # /VERSION.
+            staging="$TMPDIR/staging"
+            mkdir -p "$staging"
+            cp ${guest}/bin/mvm-guest-agent      "$staging/agent"
+            cp ${guest}/bin/mvm-seccomp-apply    "$staging/seccomp-apply"
+            cp ${runner}/bin/mvm-runner          "$staging/runner"
+
+            # SDK runtime library placeholders. plan 74 W4 fills
+            # these with the pyo3 / napi-rs hook libraries that
+            # ADR-049's vsock substitution depends on. Today they
+            # exist so the boot path stabilizes and downstream
+            # code (PYTHONPATH/NODE_PATH injection in the service
+            # supervisor) can reference fixed mount points.
+            mkdir -p "$staging/sdk-py" "$staging/sdk-ts"
+            cat > "$staging/sdk-py/README.md" <<EOF
+            mvm-sdk-runtime Python hooks (plan 74 W4 — placeholder).
+            EOF
+            cat > "$staging/sdk-ts/README.md" <<EOF
+            mvm-sdk-runtime TypeScript hooks (plan 74 W4 — placeholder).
+            EOF
+
+            # Version pin. The resolver compares this to the
+            # running mvmctl version and refuses to attach a
+            # mismatched overlay.
+            echo "${overlayVersion}" > "$staging/VERSION"
+
+            chmod -R u+rwX,go+rX "$staging"
+
+            mkdir -p $out
+
+            # ext4 generation. Mirrors
+            # `mvm_build::oci_to_rootfs::ext4::materialize_to_ext4`
+            # parameters — same UUID / hash_seed / block size /
+            # SOURCE_DATE_EPOCH conventions. Pre-allocate the
+            # output file at the fixed budget (32 MiB) so the size
+            # is also part of the deterministic shape.
+            truncate -s ${toString overlaySizeBytes} $out/overlay.ext4
+            SOURCE_DATE_EPOCH=0 \
+              mkfs.ext4 -F \
+                -t ext4 \
+                -L mvm-runtime-overlay \
+                -U ${overlayUuid} \
+                -E hash_seed=${overlayHashSeed} \
+                -E no_copy_xattrs \
+                -b ${toString overlayBlockSize} \
+                -d "$staging" \
+                $out/overlay.ext4
+
+            # Verity sidecar. Parameters mirror
+            # `mvm_build::oci_to_rootfs::verity::VeritysetupOptions::default` —
+            # data block 1024 (must match `mvm-verity-init.rs`'s
+            # DATA_BLOCK_SIZE constant), hash block 4096, zero
+            # salt, sha256.
+            touch $out/overlay.verity
+            veritysetup_out=$(
+              veritysetup format \
+                --data-block-size=${toString overlayBlockSize} \
+                --hash-block-size=${toString overlayVerityHashBlockSize} \
+                --salt=${overlayVeritySalt} \
+                --hash=${overlayVerityHashAlgorithm} \
+                $out/overlay.ext4 \
+                $out/overlay.verity
+            )
+
+            # Extract the root hash from veritysetup's
+            # "Root hash:" output line and write it as
+            # `<hex>\n` — the resolver reads the file with
+            # `trim()` so the trailing newline is fine.
+            echo "$veritysetup_out" \
+              | grep -i '^Root hash:' \
+              | sed 's/^[Rr]oot [Hh]ash:[[:space:]]*//' \
+              | tr 'A-F' 'a-f' \
+              > $out/overlay.roothash
+
+            # Repeat VERSION at the artifact-dir level so the
+            # resolver can read it without mounting the ext4. The
+            # in-rootfs VERSION (under $staging) is for boot-time
+            # introspection (an in-guest tool could read
+            # /mvm/runtime/VERSION). Both must agree.
+            echo "${overlayVersion}" > $out/VERSION
+
+            # Permissions + summary.
+            chmod 0644 $out/overlay.ext4 $out/overlay.verity $out/overlay.roothash $out/VERSION
+
+            echo "mvm-runtime-overlay built for ${system}" >&2
+            echo "  overlay.ext4 size: $(stat -c%s $out/overlay.ext4) bytes" >&2
+            echo "  roothash: $(cat $out/overlay.roothash)" >&2
+            echo "  VERSION: $(cat $out/VERSION)" >&2
+          '';
+
+    in
+    {
+      packages = forAllSystems (system: {
+        default = mkRuntimeOverlay system;
+        runtime-overlay = mkRuntimeOverlay system;
+      });
+    };
+}


### PR DESCRIPTION
**Stacks on #238 (W1.4b.1).** Base is
`feat/plan74-w1-overlay-resolver`; once that merges, this PR
auto-rebases.

## Summary

Adds the Nix flake at `nix/images/runtime-overlay/flake.nix`
that produces the artifacts W1.4b.1's
`RuntimeOverlayResolver` consumes. ADR-051's overlay disk now
has both a *consumer* (the host-side resolver from W1.4b.1) and
a *producer* (this flake).

## What this flake builds

For each of `aarch64-linux` and `x86_64-linux`:

```text
$out/
  overlay.ext4      — verity-sealed rootfs, kernel mounts at
                      /mvm/runtime in every microVM
  overlay.verity    — dm-verity sidecar
  overlay.roothash  — 64 lowercase hex chars + newline; what
                      mvm-verity-init reads from cmdline as
                      `mvm.runtime_roothash=<hex>`
  VERSION           — semver matched by RuntimeOverlayResolver
```

These four file names are the contract W1.4b.1's resolver
tests assert (`resolve_returns_artifact_when_all_files_present_and_version_matches`).

## Overlay contents

```text
/agent              — mvm-guest-agent (no dev-shell)
/seccomp-apply       — mvm-seccomp-apply
/runner              — mvm-runner
/sdk-py/README.md    — placeholder for plan 74 W4 (pyo3 hooks)
/sdk-ts/README.md    — placeholder for plan 74 W4 (napi-rs hooks)
/VERSION             — in-guest introspection
```

SDK runtime libraries are intentionally placeholders today;
W4 fills them with the ADR-049 vsock substitution hooks.
Reserving the directory layout now means service-supervisor
env injection (PYTHONPATH/NODE_PATH) and mount-point
conventions stabilize before W4 lands.

`mvm-verity-init` is built by the same
`nix/packages/mvm-guest-agent.nix` derivation but **does not**
go into the overlay — it lives in the initramfs cpio.gz that
runs as PID 1.

## Determinism contract

Two builds against the same workspace produce byte-identical
artifacts. ADR-051's per-version cache requires this. The
flake mirrors the Rust-side constants (`MVM_VERITY_DATA_BLOCK_SIZE`,
`MVM_VERITY_PINNED_SALT`, `Mke2fsOptions::default`) verbatim:
data block size 1024 (matches `mvm-verity-init.rs:203`'s
`DATA_BLOCK_SIZE`), zero salt, sha256, pinned mkfs UUID +
hash_seed, `SOURCE_DATE_EPOCH=0`.

The cross-stack chain is documented in the flake header so a
future contributor changing block size on either side sees the
ripple they'd need to make.

## Cryptsetup version pin (issue #223)

The flake currently uses `pkgs.cryptsetup` from the pinned
`nixpkgs/nixos-25.11` input. Issue #223 tracks tightening to
an explicit version override so the overlay roothash stays
stable across nixpkgs bumps.

## Out of scope (later W1.4b PRs)

- Rust orchestrator that invokes `nix build` against this
  flake — W1.4b.3 alongside backend wiring.
- Backend attachment of the second drive +
  `mvm.runtime_roothash=` cmdline arg — W1.4b.3.
- `mvm-verity-init` extension to validate the second roothash
  and bind-mount at `/sysroot/mvm/runtime` — W1.4b.3.
- `mkGuest` refactor to drop agent/shim/runner from per-image
  closures — W1.4b.3.
- Service-supervisor PYTHONPATH/NODE_PATH injection — W1.4b.4.
- Release-pipeline emission + download orchestrator — W1.4b.4.

## Verification

- [x] `cargo test --workspace --no-fail-fast` — **3 422
      passed, 0 failed, 9 ignored**. Baseline unchanged
      (this PR is Nix-only).
- [x] `cargo clippy --workspace --all-targets -- -D warnings` —
      zero warnings.
- [ ] `nix build .#default` inside the builder VM —
      contributor-side verification path. Not gated in this
      PR's CI; review-by-similarity against the existing
      `builder-vm/flake.nix` which uses identical shapes.

## Stack snapshot

| PR | Branch | Base | Subject |
| --- | --- | --- | --- |
| #221 | `feat/plan74-w0` | `main` | W0 + ADRs 048-051 + Plan 74 |
| #225 | `feat/plan74-w1-skeleton` | `main` | W1.1 |
| #229 | `feat/plan74-w1-layers` | `feat/plan74-w1-skeleton` | W1.2 |
| #233 | `feat/plan74-w1-unpack` | `main` | W1.3a |
| #235 | `feat/plan74-w1-ext4` | `feat/plan74-w1-unpack` | W1.3b |
| #237 | `feat/plan74-w1-verity` | `feat/plan74-w1-ext4` | W1.4a |
| #238 | `feat/plan74-w1-overlay-resolver` | `feat/plan74-w1-verity` | W1.4b.1 |
| **this** | `feat/plan74-w1-overlay-flake` | `feat/plan74-w1-overlay-resolver` | W1.4b.2 |

🤖 Generated with [Claude Code](https://claude.com/claude-code)