### PR TITLE
plan 74 W1.4b.3a — Rust orchestrator for runtime-overlay nix build

### DIFF
--- a/crates/mvm-build/src/runtime_overlay.rs
+++ b/crates/mvm-build/src/runtime_overlay.rs
@@ -28,18 +28,33 @@
 //! versioned per ADR-002 §W4.1; a stale overlay paired with a
 //! newer host would silently misbehave).
 //!
-//! ## Out of scope
+//! ## Two ways to land an artifact in the cache
 //!
-//! - **Building** the overlay (`nix build`). W1.4b.2 lands the
-//!   Nix flake that produces these artifacts.
-//! - **Downloading** the overlay from a release. W1.4b.4 wires
-//!   the artifact-acquisition path (similar to how
-//!   `download_dev_image` works for the dev VM image).
-//! - **Attaching** the overlay to a microVM at boot. W1.4b.2 /
-//!   .3 land the backend + `mvm-verity-init` extensions.
+//! 1. **Build from the flake.** [`build_overlay_with_nix`]
+//!    shells out to `nix build` against
+//!    `<workspace>/nix/images/runtime-overlay/` (W1.4b.2's flake)
+//!    and returns paths into the nix store. Linux-only — `nix`
+//!    is unavailable on the macOS host per CLAUDE.md's "Host
+//!    Nix is never used by mvmctl" rule, so the function gates
+//!    on `target_os = "linux"`. The macOS path runs through the
+//!    libkrun builder VM (W1.4b.3b's wiring).
+//! 2. **Download from a release.** W1.4b.4 wires the
+//!    artifact-acquisition path (similar to how
+//!    `download_dev_image` works for the dev VM image).
 //!
-//! This module is pure file I/O + string parsing. Cross-
-//! platform; no `cfg(target_os)` gates.
+//! ## Out of scope (this PR)
+//!
+//! - **Attaching** the overlay to a microVM at boot. W1.4b.3b
+//!   lands the backend + `mvm-verity-init` extensions.
+//! - **Routing macOS calls** through the libkrun builder VM.
+//!   W1.4b.3b also wires this (same VM the builder-vm flake
+//!   runs in today).
+//! - **`mkGuest` refactor** to drop the agent / shim / runner
+//!   from per-image closures. W1.4b.3c.
+//!
+//! The resolver and the build-spec construction are pure file
+//! I/O + string parsing; only [`build_overlay_with_nix`] gates
+//! on Linux.
 
 use std::path::{Path, PathBuf};
 use thiserror::Error;
@@ -127,6 +142,23 @@ pub enum RuntimeOverlayError {
     /// unreadable.
     #[error("runtime overlay VERSION file invalid: {reason}")]
     InvalidVersionFile { reason: String },
+
+    /// `nix build` exited non-zero or couldn't be spawned. Plan
+    /// 74 W1.4b.3a — the orchestrator that drives `nix build`
+    /// against the runtime-overlay flake. Includes the upstream
+    /// stderr so failures are debuggable without re-running with
+    /// `--verbose`.
+    #[error("nix build failed: {reason}")]
+    NixBuildFailed { reason: String },
+
+    /// The runtime-overlay operation is unsupported on this
+    /// host. `nix build` runs Linux-only; macOS callers route
+    /// through the libkrun builder VM (W1.4b.3b's wiring).
+    #[error("host does not support {operation}: {reason}")]
+    HostUnsupported {
+        operation: &'static str,
+        reason: &'static str,
+    },
 
     /// Underlying io failure during a file read.
     #[error("io error: {0}")]
@@ -323,6 +355,203 @@ fn read_and_validate_roothash(path: &Path) -> Result<String, RuntimeOverlayError
         });
     }
     Ok(trimmed.to_string())
+}
+
+// =================================================================
+// Build orchestrator (W1.4b.3a)
+// =================================================================
+
+/// Spec for `nix build` of the runtime-overlay flake at
+/// `<workspace>/nix/images/runtime-overlay/`. Pure data; the
+/// actual invocation lives in [`build_overlay_with_nix`].
+///
+/// The spec exposes its argv + env separately so callers that
+/// drive `nix build` *inside* the libkrun builder VM (rather
+/// than on the host) can plumb the same shape through without
+/// reaching for an external command.
+#[derive(Debug, Clone)]
+pub struct OverlayBuildSpec {
+    /// Workspace root — the dir containing `nix/`, `crates/`,
+    /// `Cargo.toml`. The flake reads
+    /// `<workspace_root>/nix/images/runtime-overlay/flake.nix`.
+    pub workspace_root: PathBuf,
+    /// Which target arch to build for. Maps to the Nix
+    /// `system` attribute on the flake's `packages` output.
+    pub arch: Arch,
+    /// Where the resulting result-symlink should live. Typically
+    /// a tempdir or a staging location under
+    /// `~/.cache/mvm/runtime-overlay/<version>/<arch>/.work/` —
+    /// the install-to-cache step is the caller's responsibility.
+    pub out_link: PathBuf,
+    /// Override the `nix` binary location. Default `None` ⇒
+    /// resolved via `$PATH`. Tests use this to substitute a stub.
+    pub nix_binary: Option<PathBuf>,
+}
+
+impl OverlayBuildSpec {
+    /// Construct a spec for the given (workspace, arch, out_link).
+    pub fn new(workspace_root: PathBuf, arch: Arch, out_link: PathBuf) -> Self {
+        Self {
+            workspace_root,
+            arch,
+            out_link,
+            nix_binary: None,
+        }
+    }
+
+    /// Nix `system` attribute string corresponding to `self.arch`.
+    /// The runtime-overlay flake exposes outputs at
+    /// `packages.<system>.default` for these two systems.
+    pub fn system(&self) -> &'static str {
+        match self.arch {
+            Arch::Aarch64 => "aarch64-linux",
+            Arch::X86_64 => "x86_64-linux",
+        }
+    }
+
+    /// Absolute path to the flake directory (the dir containing
+    /// `flake.nix`). Nix's `path:` URI scheme consumes the dir,
+    /// not the `flake.nix` file.
+    pub fn flake_path(&self) -> PathBuf {
+        self.workspace_root
+            .join("nix")
+            .join("images")
+            .join("runtime-overlay")
+    }
+
+    /// The Nix flake reference used by `nix build`. Pinned to
+    /// the workspace-local path so we don't accidentally fetch
+    /// a published flake when building from source.
+    pub fn flake_reference(&self) -> String {
+        format!(
+            "path:{}#packages.{}.default",
+            self.flake_path().display(),
+            self.system()
+        )
+    }
+
+    /// `nix build` argv, ready to hand to `Command::new` plus
+    /// `.args(argv[1..])`. The orchestrator manages its own
+    /// symlink position via `--out-link <path>`.
+    pub fn argv(&self) -> Vec<String> {
+        let nix = self
+            .nix_binary
+            .as_deref()
+            .map(|p| p.display().to_string())
+            .unwrap_or_else(|| "nix".to_string());
+        vec![
+            nix,
+            "build".to_string(),
+            "--extra-experimental-features".to_string(),
+            "nix-command flakes".to_string(),
+            "--out-link".to_string(),
+            self.out_link.display().to_string(),
+            self.flake_reference(),
+        ]
+    }
+
+    /// Environment variables to thread through to `nix build`.
+    /// `MVM_WORKSPACE_PATH` is the override the flake reads when
+    /// running inside the libkrun-builder VM's sandbox where
+    /// `..` resolution against the store copy doesn't reach the
+    /// workspace — same mechanism the builder-vm flake uses.
+    pub fn env(&self) -> Vec<(String, String)> {
+        vec![(
+            "MVM_WORKSPACE_PATH".to_string(),
+            self.workspace_root.display().to_string(),
+        )]
+    }
+}
+
+/// Drive `nix build` from a spec. Linux-only at runtime —
+/// CLAUDE.md forbids host nix on macOS, and even if the binary
+/// is installed it can't cross-compile to `aarch64-linux` /
+/// `x86_64-linux` without a remote builder. Non-Linux callers
+/// get `HostUnsupported`; W1.4b.3b routes those calls through
+/// the libkrun builder VM.
+///
+/// On success the function:
+///
+/// 1. Verifies the four required files exist at
+///    `<out_link>/{overlay.ext4, overlay.verity, overlay.roothash,
+///    VERSION}`. The runtime-overlay flake's `runCommand`
+///    produces exactly these names.
+/// 2. Reads `VERSION` + `overlay.roothash` and validates them.
+/// 3. Returns a [`RuntimeOverlayArtifact`] pointing at the
+///    nix-store paths the result-symlink resolves to.
+pub fn build_overlay_with_nix(
+    spec: &OverlayBuildSpec,
+) -> Result<RuntimeOverlayArtifact, RuntimeOverlayError> {
+    #[cfg(target_os = "linux")]
+    {
+        run_nix_build(spec)?;
+        validate_built_artifact(spec)
+    }
+    #[cfg(not(target_os = "linux"))]
+    {
+        // Suppress "unused" on non-Linux while keeping a single
+        // public signature across hosts.
+        let _ = spec;
+        Err(RuntimeOverlayError::HostUnsupported {
+            operation: "runtime-overlay nix build",
+            reason: "nix build runs Linux-only; non-Linux callers route through the libkrun builder VM (W1.4b.3b)",
+        })
+    }
+}
+
+#[cfg(target_os = "linux")]
+fn run_nix_build(spec: &OverlayBuildSpec) -> Result<(), RuntimeOverlayError> {
+    let argv = spec.argv();
+    let binary = argv.first().cloned().unwrap_or_else(|| "nix".to_string());
+    let mut cmd = std::process::Command::new(&binary);
+    cmd.args(&argv[1..]);
+    for (k, v) in spec.env() {
+        cmd.env(k, v);
+    }
+    let exec = cmd
+        .output()
+        .map_err(|e| RuntimeOverlayError::NixBuildFailed {
+            reason: format!("spawn `{binary}`: {e}"),
+        })?;
+    if !exec.status.success() {
+        let stderr = String::from_utf8_lossy(&exec.stderr).into_owned();
+        return Err(RuntimeOverlayError::NixBuildFailed {
+            reason: format!("exit {:?}; stderr={stderr}", exec.status.code()),
+        });
+    }
+    Ok(())
+}
+
+#[cfg(target_os = "linux")]
+fn validate_built_artifact(
+    spec: &OverlayBuildSpec,
+) -> Result<RuntimeOverlayArtifact, RuntimeOverlayError> {
+    let dir = &spec.out_link;
+    let overlay_ext4 = dir.join("overlay.ext4");
+    let sidecar = dir.join("overlay.verity");
+    let roothash_file = dir.join("overlay.roothash");
+    let version_file = dir.join("VERSION");
+    for required in [&overlay_ext4, &sidecar, &roothash_file, &version_file] {
+        if !required.is_file() {
+            return Err(RuntimeOverlayError::ArtifactIncomplete {
+                artifact_dir: dir.to_path_buf(),
+                missing: required.clone(),
+                version: read_version_file(&version_file)
+                    .unwrap_or_else(|_| "<unreadable>".to_string()),
+                arch: spec.arch.to_string(),
+            });
+        }
+    }
+    let version = read_version_file(&version_file)?;
+    let roothash = read_and_validate_roothash(&roothash_file)?;
+    Ok(RuntimeOverlayArtifact {
+        overlay_ext4,
+        sidecar,
+        roothash_file,
+        roothash,
+        arch: spec.arch,
+        version,
+    })
 }
 
 #[cfg(test)]
@@ -617,5 +846,136 @@ mod tests {
         let artifact = resolver.resolve(Arch::X86_64).expect("resolve");
         assert_eq!(artifact.arch, Arch::X86_64);
         assert!(artifact.overlay_ext4.to_string_lossy().contains("x86_64"));
+    }
+
+    // =================================================================
+    // Build-spec tests (W1.4b.3a)
+    // =================================================================
+
+    #[test]
+    fn build_spec_system_maps_arch_to_nix_system_string() {
+        let spec = OverlayBuildSpec::new(
+            PathBuf::from("/workspace"),
+            Arch::Aarch64,
+            PathBuf::from("/tmp/result"),
+        );
+        assert_eq!(spec.system(), "aarch64-linux");
+
+        let spec = OverlayBuildSpec::new(
+            PathBuf::from("/workspace"),
+            Arch::X86_64,
+            PathBuf::from("/tmp/result"),
+        );
+        assert_eq!(spec.system(), "x86_64-linux");
+    }
+
+    #[test]
+    fn build_spec_flake_path_points_at_runtime_overlay_dir() {
+        let spec = OverlayBuildSpec::new(
+            PathBuf::from("/workspace"),
+            Arch::Aarch64,
+            PathBuf::from("/tmp/result"),
+        );
+        assert_eq!(
+            spec.flake_path(),
+            PathBuf::from("/workspace/nix/images/runtime-overlay")
+        );
+    }
+
+    #[test]
+    fn build_spec_flake_reference_pins_path_uri_and_system_default() {
+        let spec = OverlayBuildSpec::new(
+            PathBuf::from("/workspace"),
+            Arch::X86_64,
+            PathBuf::from("/tmp/result"),
+        );
+        // Pinned to the workspace-local path so we don't fetch
+        // a published flake on the rare host where nix is happy
+        // to resolve a bare attribute against `nixpkgs`.
+        assert_eq!(
+            spec.flake_reference(),
+            "path:/workspace/nix/images/runtime-overlay#packages.x86_64-linux.default"
+        );
+    }
+
+    #[test]
+    fn build_spec_argv_defaults_to_path_lookup_nix_and_includes_required_flags() {
+        let spec = OverlayBuildSpec::new(
+            PathBuf::from("/workspace"),
+            Arch::Aarch64,
+            PathBuf::from("/tmp/result"),
+        );
+        let argv = spec.argv();
+        // Default nix binary is `nix` (resolved via $PATH).
+        assert_eq!(argv[0], "nix");
+        assert_eq!(argv[1], "build");
+        // Experimental features enable nix-command + flakes
+        // without requiring a contributor's `~/.config/nix/nix.conf`.
+        let pair = argv
+            .windows(2)
+            .find(|w| w[0] == "--extra-experimental-features");
+        assert!(
+            pair.is_some(),
+            "argv must enable nix-command + flakes: {argv:?}"
+        );
+        assert_eq!(pair.unwrap()[1], "nix-command flakes");
+        // --out-link <path>
+        let out = argv.windows(2).find(|w| w[0] == "--out-link");
+        assert!(out.is_some(), "argv must specify --out-link: {argv:?}");
+        assert_eq!(out.unwrap()[1], "/tmp/result");
+        // Final positional is the flake reference.
+        assert_eq!(
+            argv.last().unwrap(),
+            "path:/workspace/nix/images/runtime-overlay#packages.aarch64-linux.default"
+        );
+    }
+
+    #[test]
+    fn build_spec_argv_respects_nix_binary_override() {
+        let spec = OverlayBuildSpec {
+            workspace_root: PathBuf::from("/workspace"),
+            arch: Arch::Aarch64,
+            out_link: PathBuf::from("/tmp/result"),
+            nix_binary: Some(PathBuf::from("/custom/nix-stub")),
+        };
+        let argv = spec.argv();
+        assert_eq!(argv[0], "/custom/nix-stub");
+    }
+
+    #[test]
+    fn build_spec_env_sets_workspace_path_for_sandbox_resolution() {
+        // `MVM_WORKSPACE_PATH` is the env override the
+        // runtime-overlay flake reads so the `..` resolution
+        // against a store copy lands at the right tree when nix
+        // runs inside the libkrun-builder VM sandbox.
+        let spec = OverlayBuildSpec::new(
+            PathBuf::from("/workspace"),
+            Arch::Aarch64,
+            PathBuf::from("/tmp/result"),
+        );
+        let env = spec.env();
+        assert_eq!(env.len(), 1);
+        assert_eq!(env[0].0, "MVM_WORKSPACE_PATH");
+        assert_eq!(env[0].1, "/workspace");
+    }
+
+    #[cfg(not(target_os = "linux"))]
+    #[test]
+    fn build_overlay_with_nix_returns_host_unsupported_on_non_linux() {
+        let spec = OverlayBuildSpec::new(
+            PathBuf::from("/workspace"),
+            Arch::Aarch64,
+            PathBuf::from("/tmp/result"),
+        );
+        let err = build_overlay_with_nix(&spec).unwrap_err();
+        match err {
+            RuntimeOverlayError::HostUnsupported { operation, .. } => {
+                assert!(
+                    operation.contains("runtime-overlay") || operation.contains("nix"),
+                    "expected runtime-overlay or nix in operation; got {operation:?}"
+                );
+            }
+            other => panic!("expected HostUnsupported, got {other:?}"),
+        }
     }
 }

--- a/crates/mvm-build/tests/runtime_overlay_build.rs
+++ b/crates/mvm-build/tests/runtime_overlay_build.rs
@@ -1,0 +1,176 @@
+//! Linux-gated integration test for the runtime-overlay build
+//! orchestrator (plan 74 W1.4b.3a) against the W1.4b.2 flake at
+//! `nix/images/runtime-overlay/`.
+//!
+//! Gates on:
+//!
+//! 1. `#[cfg(target_os = "linux")]` — `nix build` runs Linux-only
+//!    and per CLAUDE.md "Host Nix is never used by mvmctl,"
+//!    macOS contributors don't have it anyway.
+//! 2. `which::which("nix")` — skips cleanly when the contributor
+//!    has no `nix` on `$PATH`. CI lanes that exercise the
+//!    builder-vm flake already have `nix` installed via the
+//!    same `nixpkgs/nixos-25.11` channel.
+//!
+//! These tests build the real artifact and then run the W1.4b.1
+//! resolver over the produced files. End-to-end: the producer
+//! (W1.4b.2 flake) and consumer (W1.4b.1 resolver) agree on the
+//! cache layout. If they disagree on file names or VERSION
+//! content this test fires before contributors hit it at boot.
+
+#![cfg(target_os = "linux")]
+
+use mvm_build::runtime_overlay::{
+    Arch, OverlayBuildSpec, RuntimeOverlayResolver, build_overlay_with_nix,
+};
+use std::path::Path;
+use tempfile::TempDir;
+
+fn skip_if_no_nix() -> bool {
+    if which::which("nix").is_err() {
+        eprintln!(
+            "mvm runtime-overlay build integration test skipped: \
+             nix not on $PATH (install Nix to run this test)"
+        );
+        return true;
+    }
+    false
+}
+
+/// Path to the workspace root from inside an integration test
+/// crate. `CARGO_MANIFEST_DIR` resolves to
+/// `<workspace>/crates/mvm-build` for this crate; the workspace
+/// is two levels up.
+fn workspace_root() -> std::path::PathBuf {
+    let manifest = std::path::PathBuf::from(env!("CARGO_MANIFEST_DIR"));
+    manifest
+        .parent()
+        .and_then(|p| p.parent())
+        .expect("workspace root is two levels above CARGO_MANIFEST_DIR")
+        .to_path_buf()
+}
+
+fn host_arch_or_skip_known() -> Option<Arch> {
+    // The flake builds for both aarch64 and x86_64 Linux. The
+    // host's arch is whichever this binary was compiled for —
+    // and on Linux that matches one of the two flake systems.
+    if cfg!(target_arch = "aarch64") {
+        Some(Arch::Aarch64)
+    } else if cfg!(target_arch = "x86_64") {
+        Some(Arch::X86_64)
+    } else {
+        eprintln!("runtime-overlay build test skipped: host arch is neither aarch64 nor x86_64");
+        None
+    }
+}
+
+#[test]
+fn build_produces_resolver_compatible_artifact() {
+    if skip_if_no_nix() {
+        return;
+    }
+    let Some(arch) = host_arch_or_skip_known() else {
+        return;
+    };
+
+    let workspace = workspace_root();
+    let out_dir = TempDir::new().expect("tempdir");
+    let result_link = out_dir.path().join("result");
+    let spec = OverlayBuildSpec::new(workspace.clone(), arch, result_link.clone());
+
+    let artifact = build_overlay_with_nix(&spec).expect("nix build runtime-overlay");
+    assert_eq!(artifact.arch, arch);
+    assert!(artifact.overlay_ext4.exists());
+    assert!(artifact.sidecar.exists());
+    assert!(artifact.roothash_file.exists());
+    assert_eq!(artifact.roothash.len(), 64);
+    assert!(
+        artifact
+            .roothash
+            .bytes()
+            .all(|b| b.is_ascii_hexdigit() && !b.is_ascii_uppercase())
+    );
+
+    // The resolver expects a cache layout of
+    // `<cache>/runtime-overlay/<version>/<arch>/{overlay.ext4,
+    // overlay.verity, overlay.roothash, VERSION}`. Stage the
+    // nix-built files into that layout and run the resolver to
+    // prove producer + consumer agree end-to-end.
+    let cache = TempDir::new().expect("cache tempdir");
+    let staged = cache
+        .path()
+        .join("runtime-overlay")
+        .join(&artifact.version)
+        .join(arch.as_str());
+    std::fs::create_dir_all(&staged).unwrap();
+    copy_file(&artifact.overlay_ext4, &staged.join("overlay.ext4"));
+    copy_file(&artifact.sidecar, &staged.join("overlay.verity"));
+    copy_file(&artifact.roothash_file, &staged.join("overlay.roothash"));
+    // VERSION file is at the artifact_dir level (next to the
+    // ext4), not duplicated from `roothash_file.parent()`. The
+    // flake produces it as `$out/VERSION` so the resolver sees
+    // it in the same dir.
+    copy_file(&result_link.join("VERSION"), &staged.join("VERSION"));
+
+    let resolver =
+        RuntimeOverlayResolver::new(cache.path().to_path_buf(), artifact.version.clone());
+    let resolved = resolver
+        .resolve(arch)
+        .expect("resolver must accept the freshly-built artifact");
+    assert_eq!(resolved.version, artifact.version);
+    assert_eq!(resolved.roothash, artifact.roothash);
+    assert_eq!(resolved.arch, artifact.arch);
+}
+
+#[test]
+fn build_is_byte_deterministic_for_same_workspace() {
+    // ADR-051's per-version cache hinges on byte-identical
+    // builds against the same workspace producing the same
+    // roothash. Run the build twice and compare overlay.ext4
+    // bytes + roothash.
+    if skip_if_no_nix() {
+        return;
+    }
+    let Some(arch) = host_arch_or_skip_known() else {
+        return;
+    };
+
+    let workspace = workspace_root();
+
+    let first = TempDir::new().unwrap();
+    let first_link = first.path().join("result-1");
+    let first_spec = OverlayBuildSpec::new(workspace.clone(), arch, first_link.clone());
+    let first_artifact = build_overlay_with_nix(&first_spec).expect("first build succeeds");
+
+    let second = TempDir::new().unwrap();
+    let second_link = second.path().join("result-2");
+    let second_spec = OverlayBuildSpec::new(workspace.clone(), arch, second_link.clone());
+    let second_artifact = build_overlay_with_nix(&second_spec).expect("second build succeeds");
+
+    assert_eq!(
+        first_artifact.roothash, second_artifact.roothash,
+        "byte-deterministic invariant: two builds of the same \
+         workspace must produce the same roothash"
+    );
+    let bytes_a = std::fs::read(&first_artifact.overlay_ext4).unwrap();
+    let bytes_b = std::fs::read(&second_artifact.overlay_ext4).unwrap();
+    assert_eq!(
+        bytes_a.len(),
+        bytes_b.len(),
+        "overlay.ext4 must have the same size across builds"
+    );
+    assert_eq!(
+        bytes_a, bytes_b,
+        "byte-deterministic invariant: overlay.ext4 must be \
+         byte-identical across builds (ADR-051 verity cache)"
+    );
+}
+
+fn copy_file(src: &Path, dst: &Path) {
+    let bytes = std::fs::read(src).unwrap_or_else(|e| {
+        panic!("read {src:?}: {e}");
+    });
+    std::fs::write(dst, bytes).unwrap_or_else(|e| {
+        panic!("write {dst:?}: {e}");
+    });
+}


### PR DESCRIPTION
**Stacks on #240 (W1.4b.2).** Base is
`feat/plan74-w1-overlay-flake`; once that merges, this PR
auto-rebases.

## Summary

Bridges W1.4b.2's flake (the *producer*) with W1.4b.1's
resolver (the *consumer*). Adds the Rust orchestrator that
drives `nix build` against the runtime-overlay flake and
validates the output matches the resolver's cache layout
contract. End-to-end: producer + consumer now have an
executable bridge.

## New surface

`mvm_build::runtime_overlay`:

- `OverlayBuildSpec { workspace_root, arch, out_link, nix_binary }`
  — pure data; argv + env separable so callers driving
  `nix build` *inside* the libkrun-builder VM (W1.4b.3b's
  wiring) can plumb the same shape through.
- `.system()` — `Arch` → `aarch64-linux` / `x86_64-linux`.
- `.flake_path()` — `<workspace>/nix/images/runtime-overlay`.
- `.flake_reference()` — `path:<flake>#packages.<system>.default`.
  Pinned to a `path:` URI so we don't accidentally fetch a
  published flake.
- `.argv()` — full `nix build` argv with
  `--extra-experimental-features "nix-command flakes"` and
  `--out-link`.
- `.env()` — `MVM_WORKSPACE_PATH`, the override the flake
  reads inside the libkrun-builder sandbox.
- `build_overlay_with_nix(spec)` — Linux: shells out + validates
  + returns `RuntimeOverlayArtifact`. Non-Linux:
  `HostUnsupported`.

## New error variants

- `RuntimeOverlayError::NixBuildFailed { reason }` — stderr
  included for debugging.
- `RuntimeOverlayError::HostUnsupported { operation, reason }`
  — Linux-only routing.

## Tests

Cross-platform unit (7 new):
- System / flake-path / flake-reference / argv (defaults + nix
  binary override) / env (`MVM_WORKSPACE_PATH`) / non-Linux
  `HostUnsupported`.

Linux-gated integration (2 new, gated on
`#[cfg(target_os = \"linux\")]` + `which::which(\"nix\")`):

- `build_produces_resolver_compatible_artifact` — runs an
  actual `nix build` against the workspace's runtime-overlay
  flake, then stages output into the resolver's cache layout
  and runs `RuntimeOverlayResolver::resolve` over it. Asserts
  producer + consumer agree on file names + VERSION format +
  roothash format.
- `build_is_byte_deterministic_for_same_workspace` — two
  independent `nix build` invocations produce byte-identical
  overlay.ext4 and identical roothashes. **ADR-051's verity
  cache invariant now tested end-to-end against the real
  build pipeline.** This test plus W1.4b.2's flake-side
  determinism flags plus W1.4a's Rust-side constants are now
  mutually reinforcing.

## Verification

- [x] `cargo test -p mvm-build --lib runtime_overlay` — 22/22.
- [x] `cargo test --workspace --no-fail-fast` — clean apart
      from one pre-existing flake in
      `mvm-core::config::tests::test_mvm_cache_dir_env_override`
      (concurrent env-var mutation; passes in isolation;
      unrelated to this PR).
- [x] `cargo clippy --workspace --all-targets -- -D warnings` —
      zero warnings.
- [ ] Linux CI lane runs the integration tests when `nix` is
      on `$PATH`.

## Out of scope (later W1.4b PRs)

- Backend wiring (attach overlay drive + thread
  `mvm.runtime_roothash=` into cmdline) — W1.4b.3b.
- `mvm-verity-init` extension to validate the second roothash
  and bind-mount at `/sysroot/mvm/runtime` — W1.4b.3b.
- `mkGuest` refactor to drop agent / shim / runner from
  per-image closures — W1.4b.3c.
- Cache-install step (copy from nix store to
  `~/.cache/mvm/runtime-overlay/<version>/<arch>/`) — W1.4b.3b.
- Routing macOS calls through the libkrun builder VM —
  W1.4b.3b.

## Stack snapshot

| PR | Branch | Base | Subject |
| --- | --- | --- | --- |
| #221 | `feat/plan74-w0` | `main` | W0 + ADRs 048-051 + Plan 74 |
| #225 | `feat/plan74-w1-skeleton` | `main` | W1.1 |
| #229 | `feat/plan74-w1-layers` | `feat/plan74-w1-skeleton` | W1.2 |
| #233 | `feat/plan74-w1-unpack` | `main` | W1.3a |
| #235 | `feat/plan74-w1-ext4` | `feat/plan74-w1-unpack` | W1.3b |
| #237 | `feat/plan74-w1-verity` | `feat/plan74-w1-ext4` | W1.4a |
| #238 | `feat/plan74-w1-overlay-resolver` | `feat/plan74-w1-verity` | W1.4b.1 |
| #240 | `feat/plan74-w1-overlay-flake` | `feat/plan74-w1-overlay-resolver` | W1.4b.2 |
| **this** | `feat/plan74-w1-overlay-builder` | `feat/plan74-w1-overlay-flake` | W1.4b.3a |

🤖 Generated with [Claude Code](https://claude.com/claude-code)