### PR TITLE
Backfill dry_run in run_plan.rs test fixture

### DIFF
--- a/crates/mvm-cli/src/commands/vm/run_plan.rs
+++ b/crates/mvm-cli/src/commands/vm/run_plan.rs
@@ -346,6 +346,7 @@ mod tests {
             mode: Some(RunMode::Plan),
             dev: false,
             prod: false,
+            dry_run: false,
             argv: Vec::new(),
         }
     }


### PR DESCRIPTION
## Summary

- PR #199 added `dry_run: bool` to `RunArgs` but missed the `base_run_args()` fixture in `crates/mvm-cli/src/commands/vm/run_plan.rs:335`.
- That fixture only compiles under `cfg(test)`, so `cargo build` was green but `cargo test --no-run -p mvm-cli` failed on main.
- The break landed because #199's merge-commit CI was the only one to validate the merged result; subsequent merges' CI runs were each cancelled by the next push and never re-validated.

## Test plan

- [x] `cargo test --no-run -p mvm-cli` passes on this branch
- [x] `cargo fmt --check` clean
- [x] `cargo clippy --workspace --all-targets -- -D warnings` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)