### PR TITLE
Add supervisor assembly builders

### DIFF
--- a/crates/mvm-supervisor/src/lib.rs
+++ b/crates/mvm-supervisor/src/lib.rs
@@ -73,7 +73,10 @@ pub use audit_recorder::{
     EventCategory, Recorder, RecorderError, UNBOUND_IMAGE_NAME, UNBOUND_IMAGE_SHA256,
     UNBOUND_PLAN_ID,
 };
-pub use backend::{BackendError, BackendLauncher, NoopBackendLauncher};
+pub use backend::{
+    BackendError, BackendLaunchSpec, BackendLauncher, FirecrackerRunConfigLauncher,
+    NoopBackendLauncher,
+};
 #[cfg(target_os = "macos")]
 pub use balloon::VmPressureLevelSource;
 pub use balloon::{

--- a/crates/mvm-supervisor/src/supervisor.rs
+++ b/crates/mvm-supervisor/src/supervisor.rs
@@ -207,6 +207,68 @@ impl Supervisor {
         Self::default()
     }
 
+    /// Wire the backend launcher slot. The launcher owns backend
+    /// runtime metadata and must implement `prepare_launch()` without
+    /// starting tenant code; [`Supervisor::launch`] installs firewall
+    /// policy from that metadata before calling `launch()`.
+    pub fn with_backend_launcher(mut self, backend: Arc<dyn BackendLauncher>) -> Self {
+        self.backend = backend;
+        self
+    }
+
+    /// Wire a prebuilt egress proxy slot.
+    pub fn with_egress_proxy(mut self, egress: Arc<dyn EgressProxy>) -> Self {
+        self.egress = egress;
+        self
+    }
+
+    /// Wire a prebuilt tool gate slot.
+    pub fn with_tool_gate_slot(mut self, tool_gate: Arc<dyn ToolGate>) -> Self {
+        self.tool_gate = tool_gate;
+        self
+    }
+
+    /// Wire a prebuilt keystore releaser slot.
+    pub fn with_keystore_releaser(mut self, keystore: Arc<dyn KeystoreReleaser>) -> Self {
+        self.keystore = keystore;
+        self
+    }
+
+    /// Wire a prebuilt audit signer slot.
+    pub fn with_audit_signer(mut self, audit: Arc<dyn AuditSigner>) -> Self {
+        self.audit = audit;
+        self
+    }
+
+    /// Wire a prebuilt artifact collector slot.
+    pub fn with_artifact_collector(mut self, artifact: Arc<dyn ArtifactCollector>) -> Self {
+        self.artifact = artifact;
+        self
+    }
+
+    /// Wire the platform firewall enforcer slot. The default
+    /// [`NoopFirewallEnforcer`] fails closed until a real enforcer is
+    /// supplied.
+    pub fn with_firewall_enforcer(mut self, firewall: Arc<dyn FirewallEnforcer>) -> Self {
+        self.firewall = firewall;
+        self
+    }
+
+    /// Configure the supervisor-owned proxy interface that VM TAP
+    /// traffic is allowed to reach. Identifier validation still runs
+    /// inside [`Supervisor::launch`] before any firewall backend sees
+    /// the derived rule set.
+    pub fn with_firewall_proxy_iface(mut self, iface: impl Into<String>) -> Self {
+        self.firewall_proxy_iface = Some(iface.into());
+        self
+    }
+
+    /// Inject a clock, primarily for deterministic admission tests.
+    pub fn with_clock(mut self, clock: Arc<dyn Clock>) -> Self {
+        self.clock = clock;
+        self
+    }
+
     /// Drive a workload's launch lifecycle: verify the signed plan,
     /// walk the state machine, request the backend launch.
     ///
@@ -1144,17 +1206,16 @@ mod tests {
     }
 
     fn make_supervisor_with_backend(b: Arc<MockBackend>) -> Supervisor {
-        let mut s = Supervisor::new();
-        s.backend = b;
-        s.firewall = Arc::new(MockFirewall::new());
-        s.firewall_proxy_iface = Some("mvmtun0".to_string());
         // Default to a clock inside the sample plan's window so
-        // happy-path tests don't depend on the wall clock.
-        s.clock = fixed_clock_inside_window();
-        // Capture audit entries by default so tests can assert
-        // admission audit (B19) without each test re-wiring the slot.
-        s.audit = Arc::new(crate::audit::CapturingAuditSigner::new());
-        s
+        // happy-path tests don't depend on the wall clock. Capture
+        // audit entries by default so tests can assert admission
+        // audit (B19) without each test re-wiring the slot.
+        Supervisor::new()
+            .with_backend_launcher(b)
+            .with_firewall_enforcer(Arc::new(MockFirewall::new()))
+            .with_firewall_proxy_iface("mvmtun0")
+            .with_clock(fixed_clock_inside_window())
+            .with_audit_signer(Arc::new(crate::audit::CapturingAuditSigner::new()))
     }
 
     /// Like `make_supervisor_with_backend` but exposes the
@@ -1164,12 +1225,12 @@ mod tests {
         b: Arc<MockBackend>,
     ) -> (Supervisor, Arc<crate::audit::CapturingAuditSigner>) {
         let audit = Arc::new(crate::audit::CapturingAuditSigner::new());
-        let mut s = Supervisor::new();
-        s.backend = b;
-        s.firewall = Arc::new(MockFirewall::new());
-        s.firewall_proxy_iface = Some("mvmtun0".to_string());
-        s.clock = fixed_clock_inside_window();
-        s.audit = audit.clone();
+        let s = Supervisor::new()
+            .with_backend_launcher(b)
+            .with_firewall_enforcer(Arc::new(MockFirewall::new()))
+            .with_firewall_proxy_iface("mvmtun0")
+            .with_clock(fixed_clock_inside_window())
+            .with_audit_signer(audit.clone());
         (s, audit)
     }
 
@@ -1177,9 +1238,37 @@ mod tests {
         b: Arc<MockBackend>,
         firewall: Arc<MockFirewall>,
     ) -> Supervisor {
-        let mut s = make_supervisor_with_backend(b);
-        s.firewall = firewall;
-        s
+        make_supervisor_with_backend(b).with_firewall_enforcer(firewall)
+    }
+
+    #[tokio::test]
+    async fn builder_slots_launch_without_public_field_mutation() {
+        let plan = sample_plan();
+        let (signed, _sk, vk) = sign_sample(&plan);
+        let backend = Arc::new(MockBackend::new());
+        let firewall = Arc::new(MockFirewall::new());
+        let audit = Arc::new(crate::audit::CapturingAuditSigner::new());
+        let mut s = Supervisor::new()
+            .with_backend_launcher(backend.clone())
+            .with_firewall_enforcer(firewall.clone())
+            .with_firewall_proxy_iface("mvmtun0")
+            .with_clock(fixed_clock_inside_window())
+            .with_audit_signer(audit.clone());
+
+        s.launch(&signed, &[("test", &vk)]).await.unwrap();
+
+        assert_eq!(s.state.current(), PlanState::Running);
+        assert_eq!(backend.prepares(), vec![plan.plan_id.clone()]);
+        assert_eq!(backend.launches(), vec![plan.plan_id.clone()]);
+        assert_eq!(firewall.installs(), vec![sample_firewall_spec()]);
+        assert_eq!(
+            audit
+                .entries()
+                .iter()
+                .map(|e| e.event.as_str())
+                .collect::<Vec<_>>(),
+            vec!["plan.admitted", "plan.running"]
+        );
     }
 
     #[tokio::test]

--- a/public/src/content/docs/reference/architecture.md
+++ b/public/src/content/docs/reference/architecture.md
@@ -128,6 +128,7 @@ Extends `ShellEnvironment` for fleet orchestration:
 - `L4Gate` evaluates policy-bundle `[[network.l4]]` rows with default-deny semantics
 - `BackendLauncher::prepare_launch()` returns backend-owned runtime slot metadata before tenant launch, without starting tenant code
 - `FirecrackerRunConfigLauncher` adapts a prebuilt Firecracker `FlakeRunConfig` into the supervisor backend slot, exposing its `VmSlot` during preparation and calling `run_from_build()` only after firewall install
+- `Supervisor::with_*` assembly methods wire backend, policy, audit, artifact, and firewall slots without bypassing the launch-time firewall validation gate
 - `FirewallSpec::from_vm_slot()` derives VM identity and TAP device from backend runtime `VmSlot` metadata, then validates identifiers before any platform rule generation
 - `FirewallEnforcer` installs per-VM default-deny host firewall rules before backend launch and tears them down on failed launch or stop
 - `LinuxNftFirewall` generates VM-scoped nftables tables that only allow TAP traffic to the supervisor proxy interface

--- a/specs/SPRINT.md
+++ b/specs/SPRINT.md
@@ -1069,6 +1069,7 @@ sweep (32 / 16 / 18).
 | 60 | Phase 3 Slice C follow-on — `FirewallSpec::from_vm_slot` derives VM identity/TAP from Firecracker runtime `VmSlot` metadata and supervisor launch validates specs before firewall install or backend dispatch | `d252f92` |
 | 60 | Phase 3 Slice C follow-on — `BackendLauncher::prepare_launch` returns runtime `VmSlot` metadata before tenant launch; `Supervisor::launch` now derives firewall specs from that backend slot plus the supervisor proxy interface | `ab4a792` |
 | 60 | Phase 3 Slice C follow-on — `FirecrackerRunConfigLauncher` adapts prebuilt Firecracker `FlakeRunConfig` into the supervisor `BackendLauncher` slot without starting tenant code during `prepare_launch` | `bd084f7` |
+| 60 | Phase 3 Slice C follow-on — `Supervisor::with_*` assembly methods wire backend, policy, audit, artifact, and firewall slots without public-field mutation while preserving launch-time firewall validation | `PR pending` |
 | 60 | Phase 3 follow-on — `up.rs::admit_plan_for_boot` calls `resolve_supervisor_components`; typed audit-chain `error_class` per failure mode | `ac87e8d` |
 | 60 | Phase 3 follow-on — `slots_from_bundle` delegates to `build_inspector_chain`, picking up SsrfGuard / SecretsScanner / InjectionGuard / PiiRedactor + honoring `disabled_inspectors` | `bf8079a` |
 | 60 | Phase 3 follow-on — `LiveArtifactCollector::from_policy(&bundle.artifact)` (NotImplemented carries `capture_paths` count + retention) | `72f272f` |


### PR DESCRIPTION
## Summary

Adds explicit `Supervisor::with_*` assembly methods for wiring backend, egress, tool gate, keystore, audit, artifact, firewall, proxy interface, and test clock slots without direct public-field mutation.

Also re-exports `BackendLaunchSpec` and `FirecrackerRunConfigLauncher` from `mvm-supervisor` so the next CLI/hostd bridge can assemble the supervisor from a prebuilt Firecracker run config.

## Security

The new assembly methods do not weaken launch ordering. Firewall proxy interface strings are still validated during `Supervisor::launch` through `FirewallSpec::from_vm_slot(...).validate()` before any firewall backend receives rules or the backend launch path starts tenant code.

## Validation

- `cargo fmt --check`
- `cargo test -p mvm-supervisor builder_slots_launch_without_public_field_mutation -- --test-threads=1`
- `cargo test -p mvm-supervisor supervisor::tests -- --test-threads=1`
- `cargo test -p mvm-supervisor backend -- --test-threads=1`
- `cargo clippy -p mvm-supervisor --all-targets -- -D warnings`
- `git diff --check`
