### PR TITLE
fix(mvm-guest): unflake run_shutdown_hook_succeeds_for_fast_script under concurrent test load

### DIFF
--- a/crates/mvm-guest/src/lifecycle_hooks.rs
+++ b/crates/mvm-guest/src/lifecycle_hooks.rs
@@ -290,11 +290,24 @@ mod tests {
         assert!(matches!(err, ReadinessError::ScriptMissing { .. }));
     }
 
+    // Grace period for the "fast script" tests below. Previously
+    // 2s, which sounds generous but doesn't survive concurrent
+    // workspace test load on macOS hosts — shell startup + fork +
+    // exec routinely exceeds 2s when ~80 test binaries run in
+    // parallel under `cargo test --workspace`, and the test then
+    // fails with `GraceExceeded` instead of the expected
+    // `expect("clean shutdown")`. 30s is well past anything a
+    // legitimate concurrent-load shell takes (typically <2s even
+    // under heavy load) while still bounding the test's worst
+    // case so a regression in the run-shutdown-hook path doesn't
+    // hang CI indefinitely.
+    const FAST_SCRIPT_GRACE: Duration = Duration::from_secs(30);
+
     #[test]
     fn run_shutdown_hook_succeeds_for_fast_script() {
         let tmp = tempfile::tempdir().unwrap();
         let s = write_script(tmp.path(), "stop.sh", "#!/bin/sh\nexit 0\n");
-        run_shutdown_hook(&s, Duration::from_secs(2), Duration::from_millis(50))
+        run_shutdown_hook(&s, FAST_SCRIPT_GRACE, Duration::from_millis(50))
             .expect("clean shutdown");
     }
 
@@ -302,8 +315,7 @@ mod tests {
     fn run_shutdown_hook_reports_non_zero_exit() {
         let tmp = tempfile::tempdir().unwrap();
         let s = write_script(tmp.path(), "stop.sh", "#!/bin/sh\nexit 7\n");
-        let err =
-            run_shutdown_hook(&s, Duration::from_secs(2), Duration::from_millis(50)).unwrap_err();
+        let err = run_shutdown_hook(&s, FAST_SCRIPT_GRACE, Duration::from_millis(50)).unwrap_err();
         match err {
             ShutdownError::NonZeroExit { code, .. } => assert_eq!(code, Some(7)),
             other => panic!("expected NonZeroExit, got {other:?}"),


### PR DESCRIPTION
## Summary

Lift the \"fast script\" tests' grace period in
`lifecycle_hooks::tests` from 2s to 30s via a shared
`FAST_SCRIPT_GRACE` constant, so the test stops flaking
when `cargo test --workspace` runs ~80 test binaries in
parallel and shell startup pushes past 2s.

## The bug

Two tests use `Duration::from_secs(2)` as the grace period:

- `run_shutdown_hook_succeeds_for_fast_script` — observed
  failing in **every** plan-74 W1 PR's
  `cargo test --workspace` run when alongside the rest of the
  suite; passes in isolation.
- `run_shutdown_hook_reports_non_zero_exit` — same shape; not
  observed flaking yet but vulnerable to the same race.

Failure looks like:

```text
thread 'lifecycle_hooks::tests::run_shutdown_hook_succeeds_for_fast_script'
  panicked at crates/mvm-guest/src/lifecycle_hooks.rs:298:14:
clean shutdown: GraceExceeded {
  script: \".../stop.sh\", grace: 2s
}
```

## Fix

`const FAST_SCRIPT_GRACE: Duration = Duration::from_secs(30);`
shared by the two tests that exercise the success path. The
30s value is well past anything a legitimate concurrent-load
shell takes (typically <2s even under heavy load) while still
bounding the worst case so a regression in the
run-shutdown-hook path doesn't hang CI indefinitely.

The `run_shutdown_hook_kills_after_grace_deadline` test
deliberately uses a tight 200ms grace + 5s `sleep` to exercise
the timeout path — that stays unchanged.

## Verification

- [x] `cargo test -p mvm-guest --lib lifecycle_hooks` — 8/8 pass.

## Why a standalone fixup vs in the plan-74 stack

The plan-74 W1 stack has 9 open PRs touching `mvm-build`,
`mvm-oci`, and `mvm-guest`. This flake is in `mvm-guest` (a
shared crate); fixing it on a stand-alone branch off `main`
means the fix lands without waiting for the plan-74 PRs to
merge, and every subsequent PR's `cargo test --workspace` lane
stops flagging the same unrelated failure.

🤖 Generated with [Claude Code](https://claude.com/claude-code)