### PR TITLE
Plan 74 W2 — InstanceReadiness state model (state-only slice)

### DIFF
--- a/crates/mvm-core/src/domain/instance.rs
+++ b/crates/mvm-core/src/domain/instance.rs
@@ -116,6 +116,115 @@ impl std::fmt::Display for InstanceStatus {
     }
 }
 
+// ============================================================================
+// Runtime readiness (ADR-050 / plan 74 W2)
+// ============================================================================
+//
+// `InstanceStatus` is the coarse lifecycle. `InstanceReadiness` is a
+// finer-grained "is this VM usable yet?" signal that composes alongside
+// it — it does *not* replace the lifecycle enum. A `Running` instance
+// can be `AgentConnecting`, `ServicesStarting`, `ServicesReady`, or
+// `Degraded`; `InstanceStatus` doesn't change for any of these.
+//
+// Readiness is reported by the host-side launch path as it observes
+// each milestone (backend accepted, vsock open, hello negotiated,
+// integration probes green). Persisting it on `InstanceState` lets
+// `mvmctl ls/status --json`, the SDK, and the supervisor render the
+// same wait reason without each re-deriving it from logs.
+
+/// Why a streaming or queued operation is currently throttled.
+///
+/// Closed enum: every reason is named, and drift between host and
+/// guest fails the serde `deny_unknown_fields`-equivalent path
+/// (variants must match). Detail strings carried alongside this enum
+/// in W4 are bounded and redacted — never argv / env / stdin / stdout
+/// / stderr / filesystem paths.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum BackpressureReason {
+    /// Host could not reach the guest agent within the configured
+    /// grace period. Typically resolves on the next probe.
+    GuestAgentUnavailable,
+    /// One or more integration readiness probes are still pending.
+    ServiceHealthPending {
+        /// Names of services whose readiness scripts have not yet
+        /// reported success. Echoed verbatim — never user payload.
+        pending: Vec<String>,
+    },
+    /// The host is not draining the data-plane stream fast enough,
+    /// so the guest is holding back to honor the frame cap.
+    OutputConsumerSlow,
+    /// Bounded input ring is saturated. The producer must wait.
+    InputBufferFull,
+    /// A chunked artifact transfer is paused (typically host disk
+    /// pressure or quota).
+    ArtifactTransferBlocked,
+    /// The shared builder VM is occupied by another build; this
+    /// run is queued behind it.
+    BuilderBusy,
+}
+
+/// Finer-grained "is this VM usable?" state, composed alongside the
+/// coarse [`InstanceStatus`] lifecycle.
+///
+/// `InstanceStatus::Running` means the backend accepted the VM and
+/// it has not stopped. `InstanceReadiness` explains *whether* it is
+/// actually usable: did the agent answer? Are integration probes
+/// green? Is a streaming operation currently throttled?
+///
+/// Readiness transitions are independent of lifecycle transitions —
+/// they do not gate or require `InstanceStatus` to move.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum InstanceReadiness {
+    /// Backend has accepted the launch request. No further signal
+    /// from the guest yet.
+    LaunchAccepted,
+    /// Host is waiting for the guest agent on the assigned vsock
+    /// port.
+    AgentConnecting,
+    /// Guest agent answered protocol hello and capability
+    /// negotiation succeeded.
+    AgentReady,
+    /// Integration readiness probes are running; the listed services
+    /// have not yet reported healthy.
+    ServicesStarting {
+        /// Services whose readiness scripts are still pending.
+        pending: Vec<String>,
+    },
+    /// Every integration's readiness contract is satisfied.
+    ServicesReady,
+    /// At least one previously-ready service has regressed to
+    /// unhealthy.
+    Degraded {
+        /// Services whose health probe has flipped to unhealthy.
+        unhealthy: Vec<String>,
+    },
+    /// A specific runtime resource is saturating; the workload is
+    /// otherwise live.
+    Backpressured {
+        /// Typed reason for the throttle.
+        reason: BackpressureReason,
+    },
+    /// Shutdown sequence has begun.
+    Stopping,
+}
+
+impl std::fmt::Display for InstanceReadiness {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::LaunchAccepted => write!(f, "launch_accepted"),
+            Self::AgentConnecting => write!(f, "agent_connecting"),
+            Self::AgentReady => write!(f, "agent_ready"),
+            Self::ServicesStarting { .. } => write!(f, "services_starting"),
+            Self::ServicesReady => write!(f, "services_ready"),
+            Self::Degraded { .. } => write!(f, "degraded"),
+            Self::Backpressured { .. } => write!(f, "backpressured"),
+            Self::Stopping => write!(f, "stopping"),
+        }
+    }
+}
+
 /// Per-instance network configuration.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct InstanceNet {
@@ -181,10 +290,45 @@ pub struct InstanceState {
     /// explicitly.
     #[serde(default = "default_auto_resume")]
     pub auto_resume: bool,
+    /// Finer-grained runtime readiness (ADR-050 / plan 74 W2),
+    /// composed alongside `status`. `None` on instances created
+    /// before W2 — legacy state JSON keeps deserializing through
+    /// `#[serde(default)]`.
+    #[serde(default)]
+    pub readiness: Option<InstanceReadiness>,
+    /// RFC 3339 timestamp of the last `readiness` change. `None`
+    /// when `readiness` is `None`.
+    #[serde(default)]
+    pub last_readiness_change_at: Option<String>,
 }
 
 fn default_auto_resume() -> bool {
     true
+}
+
+impl InstanceState {
+    /// Record a readiness transition together with the wall-clock
+    /// timestamp it happened at. Callers pass the timestamp explicitly
+    /// (rather than this calling `Utc::now()` itself) so tests stay
+    /// deterministic and audit emit can bind the same instant to its
+    /// event row.
+    ///
+    /// Readiness transitions are independent of lifecycle transitions
+    /// — this does not validate against `InstanceStatus` and does not
+    /// move the coarse state.
+    pub fn set_readiness(&mut self, readiness: InstanceReadiness, now_rfc3339: impl Into<String>) {
+        self.readiness = Some(readiness);
+        self.last_readiness_change_at = Some(now_rfc3339.into());
+    }
+
+    /// Clear the readiness signal (e.g. on `Destroyed` / record
+    /// cleanup). Sets both `readiness` and `last_readiness_change_at`
+    /// back to `None` so a stale "ServicesReady" never lingers on a
+    /// torn-down record.
+    pub fn clear_readiness(&mut self) {
+        self.readiness = None;
+        self.last_readiness_change_at = None;
+    }
 }
 
 /// Validate that a state transition is allowed.
@@ -312,11 +456,18 @@ mod tests {
             },
             expires_at: Some("2025-01-02T00:00:00Z".to_string()),
             auto_resume: false,
+            readiness: Some(InstanceReadiness::ServicesReady),
+            last_readiness_change_at: Some("2025-01-01T00:00:05Z".to_string()),
         };
 
         let json = serde_json::to_string_pretty(&state).unwrap();
         let parsed: InstanceState = serde_json::from_str(&json).unwrap();
         assert_eq!(parsed.instance_id, "i-a3f7b2c1");
+        assert_eq!(parsed.readiness, Some(InstanceReadiness::ServicesReady));
+        assert_eq!(
+            parsed.last_readiness_change_at.as_deref(),
+            Some("2025-01-01T00:00:05Z")
+        );
         assert_eq!(parsed.status, InstanceStatus::Running);
         assert_eq!(parsed.net.tap_dev, "tn3i5");
         assert_eq!(parsed.role, Role::Gateway);
@@ -366,6 +517,11 @@ mod tests {
         assert!(parsed.tags.is_empty());
         assert_eq!(parsed.expires_at, None);
         assert!(parsed.auto_resume);
+        // ADR-050 / plan 74 W2: readiness fields are absent on
+        // legacy records and default to `None`. The host-side launch
+        // path is what populates them on next start.
+        assert_eq!(parsed.readiness, None);
+        assert_eq!(parsed.last_readiness_change_at, None);
     }
 
     #[test]
@@ -373,6 +529,255 @@ mod tests {
         assert_eq!(InstanceStatus::Running.to_string(), "running");
         assert_eq!(InstanceStatus::Sleeping.to_string(), "sleeping");
         assert_eq!(InstanceStatus::Destroyed.to_string(), "destroyed");
+    }
+
+    // ---------------- InstanceReadiness / BackpressureReason ----------------
+    //
+    // ADR-050 / plan 74 W2. Lock the wire shape of every readiness
+    // and backpressure variant — these become a JSON contract the
+    // moment `mvmctl ls/status --json`, the SDK, and the supervisor
+    // consume them, so a serde rename or variant tweak is a breaking
+    // change. The tests below pin both the unit variants and the
+    // struct variants (with their field names) and confirm every
+    // case round-trips through JSON unchanged.
+
+    #[test]
+    fn test_instance_readiness_unit_variants_serde_roundtrip() {
+        for (variant, expected) in [
+            (InstanceReadiness::LaunchAccepted, "\"launch_accepted\""),
+            (InstanceReadiness::AgentConnecting, "\"agent_connecting\""),
+            (InstanceReadiness::AgentReady, "\"agent_ready\""),
+            (InstanceReadiness::ServicesReady, "\"services_ready\""),
+            (InstanceReadiness::Stopping, "\"stopping\""),
+        ] {
+            let json = serde_json::to_string(&variant).unwrap();
+            assert_eq!(
+                json, expected,
+                "{:?} did not serialize to {}",
+                variant, expected
+            );
+            let parsed: InstanceReadiness = serde_json::from_str(&json).unwrap();
+            assert_eq!(parsed, variant);
+        }
+    }
+
+    #[test]
+    fn test_instance_readiness_struct_variants_serde_roundtrip() {
+        let services_starting = InstanceReadiness::ServicesStarting {
+            pending: vec!["postgres".to_string(), "redis".to_string()],
+        };
+        let json = serde_json::to_string(&services_starting).unwrap();
+        assert_eq!(
+            json,
+            r#"{"services_starting":{"pending":["postgres","redis"]}}"#
+        );
+        let parsed: InstanceReadiness = serde_json::from_str(&json).unwrap();
+        assert_eq!(parsed, services_starting);
+
+        let degraded = InstanceReadiness::Degraded {
+            unhealthy: vec!["postgres".to_string()],
+        };
+        let json = serde_json::to_string(&degraded).unwrap();
+        assert_eq!(json, r#"{"degraded":{"unhealthy":["postgres"]}}"#);
+        let parsed: InstanceReadiness = serde_json::from_str(&json).unwrap();
+        assert_eq!(parsed, degraded);
+
+        let backpressured = InstanceReadiness::Backpressured {
+            reason: BackpressureReason::OutputConsumerSlow,
+        };
+        let json = serde_json::to_string(&backpressured).unwrap();
+        assert_eq!(
+            json,
+            r#"{"backpressured":{"reason":"output_consumer_slow"}}"#
+        );
+        let parsed: InstanceReadiness = serde_json::from_str(&json).unwrap();
+        assert_eq!(parsed, backpressured);
+    }
+
+    #[test]
+    fn test_backpressure_reason_unit_variants_serde_roundtrip() {
+        for (variant, expected) in [
+            (
+                BackpressureReason::GuestAgentUnavailable,
+                "\"guest_agent_unavailable\"",
+            ),
+            (
+                BackpressureReason::OutputConsumerSlow,
+                "\"output_consumer_slow\"",
+            ),
+            (BackpressureReason::InputBufferFull, "\"input_buffer_full\""),
+            (
+                BackpressureReason::ArtifactTransferBlocked,
+                "\"artifact_transfer_blocked\"",
+            ),
+            (BackpressureReason::BuilderBusy, "\"builder_busy\""),
+        ] {
+            let json = serde_json::to_string(&variant).unwrap();
+            assert_eq!(
+                json, expected,
+                "{:?} did not serialize to {}",
+                variant, expected
+            );
+            let parsed: BackpressureReason = serde_json::from_str(&json).unwrap();
+            assert_eq!(parsed, variant);
+        }
+    }
+
+    #[test]
+    fn test_backpressure_reason_service_health_pending_roundtrip() {
+        let reason = BackpressureReason::ServiceHealthPending {
+            pending: vec!["postgres".to_string()],
+        };
+        let json = serde_json::to_string(&reason).unwrap();
+        assert_eq!(
+            json,
+            r#"{"service_health_pending":{"pending":["postgres"]}}"#
+        );
+        let parsed: BackpressureReason = serde_json::from_str(&json).unwrap();
+        assert_eq!(parsed, reason);
+    }
+
+    #[test]
+    fn test_instance_readiness_display_omits_inner_payload() {
+        // `Display` is the renderer for human progress output and
+        // status tables — it must stay short, never echo `pending` /
+        // `unhealthy` / `reason` payloads (those are read off the
+        // JSON shape, not the display string).
+        assert_eq!(
+            InstanceReadiness::ServicesStarting {
+                pending: vec!["postgres".to_string()]
+            }
+            .to_string(),
+            "services_starting"
+        );
+        assert_eq!(
+            InstanceReadiness::Degraded {
+                unhealthy: vec!["redis".to_string()]
+            }
+            .to_string(),
+            "degraded"
+        );
+        assert_eq!(
+            InstanceReadiness::Backpressured {
+                reason: BackpressureReason::OutputConsumerSlow
+            }
+            .to_string(),
+            "backpressured"
+        );
+    }
+
+    #[test]
+    fn test_set_readiness_records_transition_with_timestamp() {
+        let mut state = InstanceState {
+            instance_id: "i-test".to_string(),
+            pool_id: "workers".to_string(),
+            tenant_id: "acme".to_string(),
+            status: InstanceStatus::Running,
+            net: InstanceNet {
+                tap_dev: "tn3i5".to_string(),
+                mac: "02:fc:00:03:00:05".to_string(),
+                guest_ip: "10.240.3.5".to_string(),
+                gateway_ip: "10.240.3.1".to_string(),
+                cidr: 24,
+            },
+            role: Role::Worker,
+            revision_hash: None,
+            firecracker_pid: None,
+            last_started_at: None,
+            last_stopped_at: None,
+            idle_metrics: IdleMetrics::default(),
+            healthy: None,
+            last_health_check_at: None,
+            manual_override_until: None,
+            config_version: None,
+            secrets_epoch: None,
+            entered_running_at: None,
+            entered_warm_at: None,
+            last_busy_at: None,
+            tags: BTreeMap::new(),
+            expires_at: None,
+            auto_resume: true,
+            readiness: None,
+            last_readiness_change_at: None,
+        };
+
+        state.set_readiness(InstanceReadiness::AgentReady, "2025-01-01T00:00:00Z");
+        assert_eq!(state.readiness, Some(InstanceReadiness::AgentReady));
+        assert_eq!(
+            state.last_readiness_change_at.as_deref(),
+            Some("2025-01-01T00:00:00Z")
+        );
+
+        // Successive transitions overwrite both fields together —
+        // never leaving a stale timestamp paired with a fresh state.
+        state.set_readiness(InstanceReadiness::ServicesReady, "2025-01-01T00:00:05Z");
+        assert_eq!(state.readiness, Some(InstanceReadiness::ServicesReady));
+        assert_eq!(
+            state.last_readiness_change_at.as_deref(),
+            Some("2025-01-01T00:00:05Z")
+        );
+
+        // Tearing down clears both — a destroyed record never carries
+        // a "ServicesReady" ghost from its previous life.
+        state.clear_readiness();
+        assert_eq!(state.readiness, None);
+        assert_eq!(state.last_readiness_change_at, None);
+
+        // `set_readiness` accepts both owned and borrowed timestamps.
+        let now = String::from("2025-01-01T00:00:10Z");
+        state.set_readiness(InstanceReadiness::Stopping, now.as_str());
+        assert_eq!(
+            state.last_readiness_change_at.as_deref(),
+            Some(now.as_str())
+        );
+    }
+
+    /// `InstanceStatus` transitions are independent of readiness.
+    /// Setting / clearing readiness must not call `validate_transition`
+    /// or otherwise touch the coarse lifecycle field.
+    #[test]
+    fn test_set_readiness_does_not_touch_lifecycle_status() {
+        let mut state = InstanceState {
+            instance_id: "i-test".to_string(),
+            pool_id: "workers".to_string(),
+            tenant_id: "acme".to_string(),
+            status: InstanceStatus::Running,
+            net: InstanceNet {
+                tap_dev: "tn3i5".to_string(),
+                mac: "02:fc:00:03:00:05".to_string(),
+                guest_ip: "10.240.3.5".to_string(),
+                gateway_ip: "10.240.3.1".to_string(),
+                cidr: 24,
+            },
+            role: Role::Worker,
+            revision_hash: None,
+            firecracker_pid: None,
+            last_started_at: None,
+            last_stopped_at: None,
+            idle_metrics: IdleMetrics::default(),
+            healthy: None,
+            last_health_check_at: None,
+            manual_override_until: None,
+            config_version: None,
+            secrets_epoch: None,
+            entered_running_at: None,
+            entered_warm_at: None,
+            last_busy_at: None,
+            tags: BTreeMap::new(),
+            expires_at: None,
+            auto_resume: true,
+            readiness: None,
+            last_readiness_change_at: None,
+        };
+
+        state.set_readiness(
+            InstanceReadiness::Degraded {
+                unhealthy: vec!["postgres".to_string()],
+            },
+            "2025-01-01T00:00:00Z",
+        );
+        // Degraded readiness must not move the lifecycle out of Running.
+        assert_eq!(state.status, InstanceStatus::Running);
     }
 
     // ------------- VolumeMode / VolumeAttach / WorkloadClass -------------


### PR DESCRIPTION
## Summary

- Adds `InstanceReadiness` and `BackpressureReason` enums from ADR-050 §3 / plan 74 W2, plus a `readiness` + `last_readiness_change_at` pair on `InstanceState` with `#[serde(default)]` so legacy `instance.json` records keep deserializing.
- **State model only** — CLI surface (`mvmctl ls/status --json`, `mvmctl up` progress milestones, `VmInfo` integration) lands in a follow-up. Scoping this PR small to stay reviewable and avoid stepping on parallel sessions touching the same CLI files.
- Helper API: `InstanceState::set_readiness(readiness, now_rfc3339)` (timestamp passed explicitly so tests stay deterministic) and `clear_readiness()` for record teardown.
- Readiness transitions are independent of `InstanceStatus` — verified by a regression test (\`test_set_readiness_does_not_touch_lifecycle_status\`).
- Display impl on `InstanceReadiness` emits only the variant name (never `pending` / `unhealthy` / `reason` payload), pinning the "human renderer never echoes payload" contract from ADR-050.

## What's in scope

- `BackpressureReason` (6 variants — closed enum, snake_case wire form).
- `InstanceReadiness` (8 variants — closed enum, includes `Backpressured { reason }` per the deliberate retain-as-variant call).
- `InstanceState.readiness` + `.last_readiness_change_at` with serde defaults.
- `InstanceState::set_readiness` / `::clear_readiness` helpers.
- 7 new tests + 2 extended existing tests (serde roundtrip per variant, payload-free Display, helper behavior, legacy JSON backward compat).

## What's deferred

- `VmInfo` readiness field (local CLI listing).
- `mvmctl ls/status --json` readiness rendering.
- `mvmctl up` readiness milestone emission.
- Mapping the guest-side `ReadinessConfig` / `ReadinessError` (already in `mvm-guest/src/lifecycle_hooks.rs`) into host-side readiness transitions.
- W4 (typed `BackpressureReason` per-operation event on `ProcWaitEvent`) — separate workstream.

## Test plan

- [x] `cargo fmt -- --check` clean
- [x] `cargo check --workspace` clean
- [x] `cargo test -p mvm-core --lib` — 546 tests pass (7 new readiness tests + 2 extended legacy-compat tests)
- [x] `cargo clippy --workspace --all-targets -- -D warnings` clean
- [ ] CI green on this PR
- [ ] Follow-up PR wires CLI surface + `mvmctl up` milestones

## Notes

- ADR-050 §3 already specifies this taxonomy verbatim; this PR is the implementation. No ADR amendment needed.
- Backward compatibility is load-bearing: mvmd's stored `instance.json` records (and any local persisted state) keep deserializing with `readiness = None`.
- `Display` for `InstanceReadiness` deliberately drops the inner payload — that's the renderer contract from ADR-050 ("never echoes pending / unhealthy / reason content in human strings"). Structured consumers read off the JSON shape instead.

🤖 Generated with [Claude Code](https://claude.com/claude-code)