### PR TITLE
plan 74 W1.4b.3c — mkGuest overlay-aware rootfs (ADR-051)

### DIFF
--- a/nix/lib/mk-guest.nix
+++ b/nix/lib/mk-guest.nix
@@ -235,11 +235,27 @@ let
     # us but can't talk to us. We never block on it — if the agent
     # fails to start, the entrypoint still runs and the lack of
     # agent shows up in `mvmctl status`.
-    if [ -x /usr/local/bin/mvm-guest-agent ]; then
+    #
+    # Plan 74 W1.4b (ADR-051) — when the mvm runtime overlay is
+    # attached, `mvm-verity-init` bind-mounts it at /mvm/runtime
+    # before switch_root, so /mvm/runtime/agent is the canonical
+    # binary location. Prefer it over the baked-in copy at
+    # /usr/local/bin/mvm-guest-agent (which a future PR drops
+    # entirely once every backend attaches the overlay). Both
+    # paths are exec-tested so a half-attached overlay (directory
+    # present, agent missing) still falls through to the baked-in
+    # path rather than booting agent-less.
+    MVM_AGENT_BIN=
+    if [ -x /mvm/runtime/agent ]; then
+      MVM_AGENT_BIN=/mvm/runtime/agent
+    elif [ -x /usr/local/bin/mvm-guest-agent ]; then
+      MVM_AGENT_BIN=/usr/local/bin/mvm-guest-agent
+    fi
+    if [ -n "$MVM_AGENT_BIN" ]; then
       /bin/busybox setsid /bin/busybox setpriv \
         --reuid=${toString agentUid} --regid=${toString agentUid} \
         --clear-groups --no-new-privs \
-        -- /usr/local/bin/mvm-guest-agent &
+        -- "$MVM_AGENT_BIN" &
     fi
 
     # Stage 3 — hostname + console. /dev/console is what the
@@ -255,6 +271,27 @@ let
     # is the host-side gate).
     if [ -e /etc/mvm/variant ] && [ "$(/bin/busybox cat /etc/mvm/variant)" = "dev" ]; then
       exec </dev/console >/dev/console 2>&1
+    fi
+
+    # Stage 4.5 — Plan 74 W1.4b (ADR-051) — mvm runtime overlay env.
+    # When the overlay is mounted (verity boot path), surface its
+    # presence + SDK-library paths to the entrypoint via env
+    # variables. Per-language path vars (PYTHONPATH, NODE_PATH)
+    # are prepended so they take precedence over a user's existing
+    # value; an empty existing value leaves no trailing colon.
+    # Setting these unconditionally on the overlay-mounted path
+    # gives a stable contract for SDK addons (ADR-049 vsock hooks)
+    # without per-image opt-in. The dev/legacy path (no overlay)
+    # leaves the env untouched so existing flakes keep their
+    # current behaviour.
+    if [ -d /mvm/runtime ] && [ -e /mvm/runtime/VERSION ]; then
+      export MVM_RUNTIME_OVERLAY=1
+      if [ -d /mvm/runtime/sdk-py ]; then
+        export PYTHONPATH="/mvm/runtime/sdk-py''${PYTHONPATH:+:''${PYTHONPATH}}"
+      fi
+      if [ -d /mvm/runtime/sdk-ts ]; then
+        export NODE_PATH="/mvm/runtime/sdk-ts''${NODE_PATH:+:''${NODE_PATH}}"
+      fi
     fi
 
     # Source the entrypoint script. Rendered at build time so the
@@ -347,6 +384,20 @@ let
     mkdir -p "$out"/{bin,sbin,etc,proc,sys,dev,tmp,run,var,root,home,nix/store,etc/mvm}
     chmod 1777 "$out/tmp"
     chmod 0755 "$out/run"
+
+    # Plan 74 W1.4b — the mvm runtime overlay (ADR-051) is
+    # bind-mounted at /mvm/runtime by `mvm-verity-init` before
+    # switch_root. The directory must exist in the rootfs so the
+    # bind-mount has a target. Mode 0755 (owner root); the overlay
+    # itself is mounted read-only over it, so contents can't be
+    # written by the guest regardless. Outside the verity-boot
+    # path (dev-mode VMs that don't run `mvm-verity-init`) the
+    # directory is empty — /init below falls back to the baked-in
+    # agent. `/mvm/` is reserved (admission-time check in W1.4b.3d
+    # rejects OCI images that carry content under this path).
+    mkdir -p "$out/mvm/runtime"
+    chmod 0755 "$out/mvm"
+    chmod 0755 "$out/mvm/runtime"
 
     # busybox + applet symlinks. busybox --install -s would do this
     # at runtime; we pre-bake the links so the rootfs has no first-
@@ -520,6 +571,13 @@ let
     # W6.1.1 placeholder sh script. `mvmctl status` reads this;
     # production deployments should refuse to boot a "stub" image.
     agentBinary = "real";
+    # Plan 74 W1.4b (ADR-051) — the rootfs carries a `/mvm/runtime`
+    # bind-mount target and the /init script prefers the overlay
+    # agent at `/mvm/runtime/agent` over the baked-in
+    # `/usr/local/bin/mvm-guest-agent`. Admission-time gates can
+    # refuse to boot a workload whose rootfs is not overlay-aware
+    # (e.g. an old cached template predating W1.4b.3c).
+    overlayAware = true;
   };
 in
 rootfsImage.overrideAttrs (old: {

--- a/nix/tests/mk-guest-eval.nix
+++ b/nix/tests/mk-guest-eval.nix
@@ -163,4 +163,18 @@ in
   agent_binary_is_real = (meta shellGuest).agentBinary == "real"
     && (meta commandGuest).agentBinary == "real"
     && (meta servicesGuest).agentBinary == "real";
+
+  # ── Plan 74 W1.4b (ADR-051) — runtime overlay awareness ───────
+  #
+  # Every image built by mkGuest must advertise that its rootfs
+  # carries the `/mvm/runtime` bind-mount target and that the
+  # init script prefers the overlay-provided agent. A future PR
+  # that drops the overlay-aware code path (e.g. reverting the
+  # /init agent-resolution block) flips this metadata to `false`
+  # before the boot regression surfaces, giving CI a tight signal
+  # for the load-bearing invariant.
+
+  overlay_aware_metadata_set_on_shell = (meta shellGuest).overlayAware == true;
+  overlay_aware_metadata_set_on_command = (meta commandGuest).overlayAware == true;
+  overlay_aware_metadata_set_on_services = (meta servicesGuest).overlayAware == true;
 }

--- a/tests/nix_flake_structure.rs
+++ b/tests/nix_flake_structure.rs
@@ -180,6 +180,54 @@ fn mk_guest_eval_assertions_all_pass_when_nix_available() {
     );
 }
 
+/// Plan 74 W1.4b (ADR-051) — `mkGuest` must carry the overlay-
+/// aware contract in its rootfs + /init script. We can't easily
+/// build the rootfs without Nix on the host, but the source of
+/// truth is a single file we can scan for the three load-bearing
+/// signals. A regression that removes any of them surfaces as a
+/// failing test on every PR's `cargo test`, before the overlay
+/// boot regression is observable in a live VM.
+///
+/// What gets checked:
+/// 1. The rootfs tree creates `/mvm/runtime` (the bind-mount
+///    target). Without this, the verity-init bind-mount fails at
+///    boot and the agent never starts.
+/// 2. The /init script prefers `/mvm/runtime/agent` over the
+///    baked-in copy. Without this, the overlay-attached agent
+///    isn't used.
+/// 3. The mvmMeta passthru carries `overlayAware = true`. Without
+///    this, admission-time gates can't enforce overlay-aware
+///    rootfs as a precondition.
+#[test]
+fn mk_guest_carries_overlay_aware_contract() {
+    let path = nix_dir().join("lib").join("mk-guest.nix");
+    let content = fs::read_to_string(&path)
+        .unwrap_or_else(|e| panic!("nix/lib/mk-guest.nix must be present: {e}"));
+
+    assert!(
+        content.contains("mkdir -p \"$out/mvm/runtime\""),
+        "mk-guest.nix must create /mvm/runtime in the rootfs as the \
+         ADR-051 bind-mount target. Missing the `mkdir -p \"$out/mvm/runtime\"` \
+         line means the verity-init bind-mount target is missing and the \
+         agent never starts."
+    );
+
+    assert!(
+        content.contains("/mvm/runtime/agent"),
+        "mk-guest.nix /init must reference /mvm/runtime/agent (ADR-051). \
+         Without this resolution path the overlay-attached agent isn't \
+         exec'd and the rootfs falls back to the baked-in copy on every \
+         boot — defeating the W1.4b refactor."
+    );
+
+    assert!(
+        content.contains("overlayAware = true"),
+        "mk-guest.nix mvmMeta passthru must declare `overlayAware = true` \
+         (Plan 74 W1.4b / ADR-051). Admission-time gates read this to \
+         refuse boot of cached pre-W1.4b templates."
+    );
+}
+
 #[test]
 fn flake_lock_pins_microvm_input_by_hash() {
     // The flake.lock must exist and pin the microvm.nix input by


### PR DESCRIPTION
## Summary

- Adds the `/mvm/runtime` bind-mount target to every mvm-built rootfs so the W1.4b runtime overlay (ADR-051) actually has somewhere to land at boot.
- Updates the rootfs `/init` script to prefer `/mvm/runtime/agent` over the baked-in `/usr/local/bin/mvm-guest-agent`, and to export `MVM_RUNTIME_OVERLAY=1` + `PYTHONPATH` / `NODE_PATH` for SDK addons before sourcing `/etc/mvm/entrypoint`.
- Surfaces `passthru.mvm.overlayAware = true` so admission-time gates can refuse cached pre-W1.4b templates.
- Locked-in by three new `mk-guest-eval.nix` boolean assertions (run under `cargo test mk_guest_eval_assertions_…` when Nix is available) and one new Rust-side source-grep guard (`mk_guest_carries_overlay_aware_contract`) that runs on every PR regardless of Nix availability.

## Why this slice (and what's deferred)

ADR-051's eventual state is that mkGuest *drops* `mvm-guest-agent`, `mvm-seccomp-apply`, and `mvm-runner` from the per-image closure entirely — the overlay carries them. **This PR is the bridging slice**: the rootfs becomes overlay-aware (supports both paths) without breaking the dev flow where the overlay isn't attached yet (libkrun + Apple Container backends still in flight).

The followup that drops the baked-in agent lands only once every backend reliably attaches the overlay — until then the fallback to `/usr/local/bin/mvm-guest-agent` is load-bearing for non-Firecracker dev boots.

## What this PR does not do

- Drop the baked-in agent from the per-image closure (followup; gated on all backends attaching the overlay).
- Implement the `/mvm/` reservation admission check on OCI unpack (that's W1.4b.3d / W1.3 layer-unpack work).
- Wire libkrun or Apple Container to attach the overlay (W1.4b.3b.3.b/.3c).

## Test plan

- [x] `nix eval --json --file nix/tests/mk-guest-eval.nix` — all 20 assertions return `true` (17 pre-existing + 3 new).
- [x] `cargo test --test nix_flake_structure` — 5 pass (1 new + 4 pre-existing; the eval-based test ran successfully on the local Nix host).
- [x] `cargo test --workspace --lib --bins --tests` — clean (no new failures).
- [x] `cargo clippy --workspace --all-targets -- -D warnings` — clean.
- [x] `cargo fmt --all -- --check` — clean.
- [ ] Live-VM boot regression on Firecracker + verity-attached overlay (deferred — depends on the install-into-cache producer + backend wiring all reaching main).

## Stack

This PR sits on top of:

1. W1.4b.1 — host-side runtime-overlay artifact resolver (#238)
2. W1.4b.2 — runtime-overlay flake producing per-arch verity-sealed ext4
3. W1.4b.3a — Rust orchestrator for the runtime-overlay nix build
4. W1.4b.3b.1 — install_overlay_into_cache (atomic stage-then-rename)
5. W1.4b.3b.2 — mvm-verity-init runtime-overlay extension
6. W1.4b.3b.3a — Firecracker wiring for the runtime overlay (#254)

GitHub will retarget this PR's base as each parent merges to main.

Refs: ADR-051 (mvm runtime overlay disk) §"Refactor consequences for mkGuest", specs/plans/74-claim-safe-sandbox-parity.md §W1.4b.

🤖 Generated with [Claude Code](https://claude.com/claude-code)