### PR TITLE
plan 74 W1.4b — runtime overlay artifact job in release.yml (ADR-051)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -346,8 +346,71 @@ jobs:
             staging/builder-vm-${{ matrix.arch }}.manifest.json
             staging/builder-vm-${{ matrix.arch }}-checksums-sha256.txt
 
+  # Plan 74 W1.4b / ADR-051: the verity-sealed mvm runtime overlay
+  # disk. Attached as `/dev/vdc` at every microVM boot;
+  # `mvm-verity-init` mounts it at `/mvm/runtime` so the guest agent,
+  # seccomp shim, and per-language SDK runtime libraries live in a
+  # single mvm-controlled blob instead of being baked into every
+  # per-image rootfs. Built per-arch from `nix/images/runtime-overlay/`.
+  #
+  # The host-side `RuntimeOverlayResolver`
+  # (`crates/mvm-build/src/runtime_overlay.rs`) installs these into
+  # `~/.cache/mvm/runtime-overlay/<mvmctl-version>/<arch>/` under the
+  # canonical names (`overlay.ext4`, `overlay.verity`,
+  # `overlay.roothash`, `VERSION`); the release artifact names carry
+  # the arch suffix so the combined release-asset pool doesn't
+  # collide between aarch64 and x86_64.
+  runtime-overlay-image:
+    strategy:
+      matrix:
+        include:
+          - arch: aarch64
+            runner: ubuntu-24.04-arm
+          - arch: x86_64
+            runner: ubuntu-latest
+    runs-on: ${{ matrix.runner }}
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Install Nix
+        uses: DeterminateSystems/nix-installer-action@main
+
+      - name: Build runtime overlay image
+        env:
+          ARCH: ${{ matrix.arch }}
+        run: |
+          SYSTEM="${ARCH}-linux"
+          nix build "./nix/images/runtime-overlay#packages.${SYSTEM}.default" \
+            --no-link --print-out-paths > /tmp/store-path.txt
+          STORE_PATH=$(head -1 /tmp/store-path.txt)
+          mkdir -p staging
+          # cp -L so `overlay.*` resolve through nix-store symlinks
+          # into the actual blobs; the artifact uploader doesn't
+          # follow symlinks.
+          cp -L "$STORE_PATH/overlay.ext4"     "staging/runtime-overlay-${ARCH}.ext4"
+          cp -L "$STORE_PATH/overlay.verity"   "staging/runtime-overlay-${ARCH}.verity"
+          cp -L "$STORE_PATH/overlay.roothash" "staging/runtime-overlay-${ARCH}.roothash"
+          cp -L "$STORE_PATH/VERSION"          "staging/runtime-overlay-${ARCH}.VERSION"
+          cd staging
+          sha256sum "runtime-overlay-${ARCH}.ext4" \
+                    "runtime-overlay-${ARCH}.verity" \
+                    "runtime-overlay-${ARCH}.roothash" \
+                    "runtime-overlay-${ARCH}.VERSION" \
+            > "runtime-overlay-${ARCH}-checksums-sha256.txt"
+
+      - name: Upload runtime overlay image artifacts
+        uses: actions/upload-artifact@v7
+        with:
+          name: runtime-overlay-image-${{ matrix.arch }}
+          path: |
+            staging/runtime-overlay-${{ matrix.arch }}.ext4
+            staging/runtime-overlay-${{ matrix.arch }}.verity
+            staging/runtime-overlay-${{ matrix.arch }}.roothash
+            staging/runtime-overlay-${{ matrix.arch }}.VERSION
+            staging/runtime-overlay-${{ matrix.arch }}-checksums-sha256.txt
+
   release:
-    needs: [build, dev-image, builder-image, builder-vm-image, default-microvm]
+    needs: [build, dev-image, builder-image, builder-vm-image, default-microvm, runtime-overlay-image]
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
@@ -452,6 +515,11 @@ jobs:
             artifacts/default-microvm-vmlinux-* \
             artifacts/default-microvm-rootfs-* \
             artifacts/default-microvm-*-checksums-sha256.txt \
+            artifacts/runtime-overlay-*.ext4 \
+            artifacts/runtime-overlay-*.verity \
+            artifacts/runtime-overlay-*.roothash \
+            artifacts/runtime-overlay-*.VERSION \
+            artifacts/runtime-overlay-*-checksums-sha256.txt \
             sbom.cdx.json \
             sbom.cdx.json.bundle
 


### PR DESCRIPTION
## Summary

- Adds a `runtime-overlay-image` job to `.github/workflows/release.yml` that builds the W1.4b.2 overlay flake per-arch (`aarch64-linux`, `x86_64-linux`), stages the four output files with arch-suffixed names, emits a sha256 checksum file, and uploads them as a workflow artifact.
- Wires the `release` job to include the new artifacts in `needs:` and ship them via `gh release create`, so every tagged release publishes per-arch overlay assets to GitHub Releases alongside the existing dev/builder/builder-vm/default-microvm images.

## Why this slice

Without this job, the runtime overlay only exists in source-checkout builds via `RuntimeOverlayResolver`'s nix-build orchestrator (W1.4b.3a/.3b.1). **An installed `mvmctl` has no path to populate the overlay cache** — meaning the entire W1.4b feature (six PRs of stacked work) stays inaccessible to anyone running an installed binary. This is the missing producer-side wiring that closes the loop.

## Naming contract with `RuntimeOverlayResolver`

The host-side resolver expects the four files under canonical names in `~/.cache/mvm/runtime-overlay/<version>/<arch>/`:

| Canonical name (cache) | Release artifact name |
|---|---|
| `overlay.ext4` | `runtime-overlay-${ARCH}.ext4` |
| `overlay.verity` | `runtime-overlay-${ARCH}.verity` |
| `overlay.roothash` | `runtime-overlay-${ARCH}.roothash` |
| `VERSION` | `runtime-overlay-${ARCH}.VERSION` |

The arch suffix exists purely to keep the combined release-asset pool collision-free. A follow-up `download_runtime_overlay` function (separate PR) renames them back to the canonical names when materializing into the cache.

## Scope (deliberate deferrals)

- **Host-side download function.** Intentionally a separate PR; keeps each slice's blast radius small. Until then, developers can manually drop the four files into the cache to test end-to-end on an installed `mvmctl`.
- **Signed image manifest (plan 36).** The existing dev/builder image jobs call `scripts/generate-image-manifest.sh` for cosign-keyless signatures. That script is currently absent from the repo (referenced but not tracked), so this PR doesn't add manifest generation to the overlay either — the SHA-256 checksums file plus the verity sealing (overlay.roothash baked into the kernel cmdline) provide the integrity story. Adding cosign manifests is a follow-up once the existing manifest script returns.

## Test plan

- [x] `python3 -c 'yaml.safe_load(...)'` — release.yml parses cleanly.
- [x] `actionlint .github/workflows/release.yml` — no new findings.
- [x] `cargo build --workspace --tests` — clean (defensive; no Rust code changed).
- [x] `cargo fmt --all -- --check` — clean.
- [ ] Live tag-driven release dry-run (gated on the W1.4b.2 flake reaching main via the parent stack).

## Stack

This PR sits on top of:

1. W1.4b.1 — host-side runtime-overlay artifact resolver (#238)
2. W1.4b.2 — runtime-overlay flake producing per-arch verity-sealed ext4
3. W1.4b.3a — Rust orchestrator for the runtime-overlay nix build
4. W1.4b.3b.1 — install_overlay_into_cache (atomic stage-then-rename)
5. W1.4b.3b.2 — mvm-verity-init runtime-overlay extension
6. W1.4b.3b.3a — Firecracker wiring for the runtime overlay (#254)
7. W1.4b.3c — mkGuest overlay-aware rootfs (#257)

GitHub will retarget this PR's base as each parent merges to main.

Refs: ADR-051 §"Implementation Plan" (release pipeline bullet), specs/plans/74-claim-safe-sandbox-parity.md §W1.4b.

🤖 Generated with [Claude Code](https://claude.com/claude-code)