### PR TITLE
Plan 74 W2 follow-up — wire InstanceReadiness through mvmctl up + ls --json

### DIFF
--- a/crates/mvm-cli/src/commands/vm/ps.rs
+++ b/crates/mvm-cli/src/commands/vm/ps.rs
@@ -105,6 +105,11 @@ pub(in crate::commands) fn run(_cli: &Cli, args: Args, _cfg: &MvmConfig) -> Resu
         // JSON output augments the backend `VmInfo` with the metadata
         // we just looked up, so SDK callers (Phase B1) get tags and
         // expiry without a second registry round-trip.
+        // ADR-050 §3 / plan 74 W2: `readiness` and
+        // `last_readiness_change_at` thread through here from the
+        // registry, populated by `mvmctl up`'s launch milestones.
+        // Legacy registry entries that pre-date W2 serialize as
+        // `null` for both fields.
         #[derive(serde::Serialize)]
         struct LsRow<'a> {
             #[serde(flatten)]
@@ -113,6 +118,8 @@ pub(in crate::commands) fn run(_cli: &Cli, args: Args, _cfg: &MvmConfig) -> Resu
             expires_at: Option<&'a str>,
             auto_resume: bool,
             expired: bool,
+            readiness: Option<&'a mvm_core::domain::instance::InstanceReadiness>,
+            last_readiness_change_at: Option<&'a str>,
         }
         let empty_tags: std::collections::BTreeMap<String, String> = Default::default();
         let rows: Vec<LsRow<'_>> = all_vms
@@ -125,6 +132,9 @@ pub(in crate::commands) fn run(_cli: &Cli, args: Args, _cfg: &MvmConfig) -> Resu
                     expires_at: reg.and_then(|r| r.expires_at.as_deref()),
                     auto_resume: reg.map(|r| r.auto_resume).unwrap_or(true),
                     expired: reg.map(is_expired).unwrap_or(false),
+                    readiness: reg.and_then(|r| r.readiness.as_ref()),
+                    last_readiness_change_at: reg
+                        .and_then(|r| r.last_readiness_change_at.as_deref()),
                 }
             })
             .collect();

--- a/crates/mvm-cli/src/commands/vm/up.rs
+++ b/crates/mvm-cli/src/commands/vm/up.rs
@@ -7,6 +7,7 @@ use crate::ui;
 
 use mvm_backend::backend::AnyBackend;
 use mvm_backend::{image, microvm};
+use mvm_core::domain::instance::InstanceReadiness;
 use mvm_core::naming::{validate_flake_ref, validate_template_name, validate_vm_name};
 use mvm_core::user_config::MvmConfig;
 use mvm_core::util::parse_human_size;
@@ -55,6 +56,46 @@ impl mvm_plan::BundleResolver for InMemoryBundleResolver {
         _bundle_sha256: &str,
     ) -> std::result::Result<Vec<u8>, mvm_plan::BundleResolveError> {
         Ok(self.bytes.clone())
+    }
+}
+
+/// Persist a host-observed readiness milestone (ADR-050 §3 /
+/// plan 74 W2) on the VM's registry entry. Best-effort — readiness
+/// is observability, never gating, so registry I/O failures and
+/// unregistered VMs (e.g. the launchd direct-boot path that doesn't
+/// always register) degrade silently with a debug/warn log rather
+/// than aborting the launch.
+fn record_vm_readiness(vm_name: &str, readiness: InstanceReadiness) {
+    let path = mvm::vm::name_registry::registry_path();
+    let mut reg = match mvm::vm::name_registry::VmNameRegistry::load(&path) {
+        Ok(r) => r,
+        Err(e) => {
+            tracing::warn!(
+                err = %e,
+                vm = vm_name,
+                "failed to load VM name registry for readiness update"
+            );
+            return;
+        }
+    };
+    let now = mvm_core::time::utc_now();
+    match reg.set_readiness(vm_name, readiness, &now) {
+        Ok(true) => {}
+        Ok(false) => {
+            // VM not in registry — common on direct-boot paths.
+            tracing::debug!(
+                vm = vm_name,
+                "no registry entry for readiness update; skipping"
+            );
+            return;
+        }
+        Err(e) => {
+            tracing::warn!(err = %e, vm = vm_name, "failed to set readiness");
+            return;
+        }
+    }
+    if let Err(e) = reg.save(&path) {
+        tracing::warn!(err = %e, vm = vm_name, "failed to save VM name registry");
     }
 }
 
@@ -1251,6 +1292,7 @@ pub(super) fn cmd_run(params: RunParams<'_>) -> Result<()> {
             return Err(e);
         }
         emit_launched_if(&admission, effective_hypervisor);
+        record_vm_readiness(&vm_name, InstanceReadiness::LaunchAccepted);
 
         // Plan 37 §6 — match the main path's VmStart LocalAudit emit
         // (line ~1114). Without this the launchd-spawned direct-boot
@@ -1266,7 +1308,9 @@ pub(super) fn cmd_run(params: RunParams<'_>) -> Result<()> {
             && !ports_str.is_empty()
         {
             ui::info("Waiting for guest agent...");
+            record_vm_readiness(&vm_name, InstanceReadiness::AgentConnecting);
             if wait_for_guest_agent(&vm_name, 30) {
+                record_vm_readiness(&vm_name, InstanceReadiness::AgentReady);
                 for spec in ports_str.split(',') {
                     if let Some((host, guest)) = spec.split_once(':')
                         && let (Ok(h), Ok(g)) = (host.parse::<u16>(), guest.parse::<u16>())
@@ -1705,6 +1749,7 @@ pub(super) fn cmd_run(params: RunParams<'_>) -> Result<()> {
             return Err(e);
         }
         emit_launched_if(&admission_main, effective_hypervisor);
+        record_vm_readiness(&vm_name_owned, InstanceReadiness::LaunchAccepted);
     }
 
     mvm_core::audit_emit!(VmStart, vm: &vm_name_owned);
@@ -1719,10 +1764,12 @@ pub(super) fn cmd_run(params: RunParams<'_>) -> Result<()> {
             let pm_list = parse_port_specs(ports).unwrap_or_default();
 
             ui::info("Waiting for guest agent...");
+            record_vm_readiness(&vm_name_owned, InstanceReadiness::AgentConnecting);
             let agent_ready = wait_for_guest_agent(&vm_name_owned, 30);
             if !agent_ready {
                 ui::warn("Guest agent not reachable — port forwarding unavailable.");
             } else {
+                record_vm_readiness(&vm_name_owned, InstanceReadiness::AgentReady);
                 // Tell guest agent to start vsock forwarders
                 for pm in &pm_list {
                     match request_port_forward(&vm_name_owned, pm.guest) {
@@ -1950,6 +1997,7 @@ pub(super) fn cmd_run(params: RunParams<'_>) -> Result<()> {
                 ));
             } else {
                 emit_launched_if(&watch_admission, effective_hypervisor);
+                record_vm_readiness(&vm_name_owned, InstanceReadiness::LaunchAccepted);
                 mvm_core::audit_emit!(VmStart, vm: &vm_name_owned);
                 ui::success(&format!("VM '{}' rebooted.", vm_name_owned));
             }

--- a/crates/mvm/src/vm/name_registry.rs
+++ b/crates/mvm/src/vm/name_registry.rs
@@ -1,4 +1,5 @@
 use anyhow::{Context, Result, bail};
+use mvm_core::domain::instance::InstanceReadiness;
 use serde::{Deserialize, Serialize};
 use std::collections::{BTreeMap, HashMap};
 use std::path::{Path, PathBuf};
@@ -46,6 +47,18 @@ pub struct VmRegistration {
     /// W1 / A4.
     #[serde(default)]
     pub paused: bool,
+    /// Finer-grained host-observed readiness (ADR-050 §3 / plan 74
+    /// W2). Updated by `mvmctl up` as each launch milestone is
+    /// reached (`LaunchAccepted` → `AgentConnecting` → `AgentReady`,
+    /// with the rest of the taxonomy wiring in subsequent PRs).
+    /// `None` on legacy records and on VMs that haven't yet been
+    /// touched by a readiness-aware launch path.
+    #[serde(default)]
+    pub readiness: Option<InstanceReadiness>,
+    /// RFC 3339 timestamp of the last `readiness` change. Paired
+    /// with `readiness` — both are `Some` or both are `None`.
+    #[serde(default)]
+    pub last_readiness_change_at: Option<String>,
 }
 
 fn default_auto_resume() -> bool {
@@ -113,6 +126,8 @@ impl VmNameRegistry {
                 expires_at: params.expires_at,
                 auto_resume: params.auto_resume,
                 paused: false,
+                readiness: None,
+                last_readiness_change_at: None,
             },
         );
         Ok(())
@@ -139,6 +154,43 @@ impl VmNameRegistry {
         match self.vms.get_mut(name) {
             Some(reg) => {
                 reg.paused = paused;
+                Ok(true)
+            }
+            None => Ok(false),
+        }
+    }
+
+    /// Record a host-observed readiness milestone (ADR-050 §3 /
+    /// plan 74 W2). Returns `Ok(true)` if updated, `Ok(false)` if
+    /// the name is unknown. Updates both `readiness` and
+    /// `last_readiness_change_at` atomically; callers pass the
+    /// timestamp explicitly so test fixtures stay deterministic.
+    pub fn set_readiness(
+        &mut self,
+        name: &str,
+        readiness: InstanceReadiness,
+        now_rfc3339: impl Into<String>,
+    ) -> Result<bool> {
+        match self.vms.get_mut(name) {
+            Some(reg) => {
+                reg.readiness = Some(readiness);
+                reg.last_readiness_change_at = Some(now_rfc3339.into());
+                Ok(true)
+            }
+            None => Ok(false),
+        }
+    }
+
+    /// Clear the readiness signal (record teardown / `mvmctl down`).
+    /// Returns `Ok(true)` if updated, `Ok(false)` if the name is
+    /// unknown. Both `readiness` and `last_readiness_change_at` reset
+    /// to `None` so a torn-down record never carries a stale
+    /// "ServicesReady" ghost.
+    pub fn clear_readiness(&mut self, name: &str) -> Result<bool> {
+        match self.vms.get_mut(name) {
+            Some(reg) => {
+                reg.readiness = None;
+                reg.last_readiness_change_at = None;
                 Ok(true)
             }
             None => Ok(false),
@@ -503,5 +555,106 @@ mod tests {
         assert!(r.tags.is_empty());
         assert!(r.expires_at.is_none());
         assert!(r.auto_resume);
+        // ADR-050 / plan 74 W2 readiness fields default cleanly on
+        // legacy records that pre-date the field. mvm-cli `ls --json`
+        // emits them as `null` on legacy rows.
+        assert_eq!(r.readiness, None);
+        assert_eq!(r.last_readiness_change_at, None);
+    }
+
+    // -------- Readiness milestones (ADR-050 §3 / plan 74 W2) --------
+
+    #[test]
+    fn set_readiness_returns_false_for_unknown_vm() {
+        let mut reg = VmNameRegistry::default();
+        assert!(
+            !reg.set_readiness(
+                "ghost",
+                InstanceReadiness::AgentReady,
+                "2025-01-01T00:00:00Z"
+            )
+            .unwrap()
+        );
+    }
+
+    #[test]
+    fn set_readiness_updates_both_fields_atomically() {
+        let mut reg = VmNameRegistry::default();
+        reg.register("vm1", "/tmp/vm1", "default", None, 0).unwrap();
+        assert_eq!(reg.lookup("vm1").unwrap().readiness, None);
+
+        assert!(
+            reg.set_readiness(
+                "vm1",
+                InstanceReadiness::LaunchAccepted,
+                "2025-01-01T00:00:00Z"
+            )
+            .unwrap()
+        );
+        let r = reg.lookup("vm1").unwrap();
+        assert_eq!(r.readiness, Some(InstanceReadiness::LaunchAccepted));
+        assert_eq!(
+            r.last_readiness_change_at.as_deref(),
+            Some("2025-01-01T00:00:00Z")
+        );
+
+        // Successive transitions overwrite both fields together.
+        assert!(
+            reg.set_readiness("vm1", InstanceReadiness::AgentReady, "2025-01-01T00:00:05Z")
+                .unwrap()
+        );
+        let r = reg.lookup("vm1").unwrap();
+        assert_eq!(r.readiness, Some(InstanceReadiness::AgentReady));
+        assert_eq!(
+            r.last_readiness_change_at.as_deref(),
+            Some("2025-01-01T00:00:05Z")
+        );
+    }
+
+    #[test]
+    fn clear_readiness_resets_both_fields() {
+        let mut reg = VmNameRegistry::default();
+        reg.register("vm1", "/tmp/vm1", "default", None, 0).unwrap();
+        reg.set_readiness("vm1", InstanceReadiness::AgentReady, "2025-01-01T00:00:00Z")
+            .unwrap();
+
+        assert!(reg.clear_readiness("vm1").unwrap());
+        let r = reg.lookup("vm1").unwrap();
+        assert_eq!(r.readiness, None);
+        assert_eq!(r.last_readiness_change_at, None);
+
+        // Clearing an unknown VM returns Ok(false), no error.
+        assert!(!reg.clear_readiness("ghost").unwrap());
+    }
+
+    #[test]
+    fn readiness_roundtrip_through_registry_save_load() {
+        let tmp = tempfile::tempdir().unwrap();
+        let path = tmp.path().join("vm-names.json");
+
+        let mut reg = VmNameRegistry::default();
+        reg.register("vm1", "/tmp/vm1", "default", None, 0).unwrap();
+        reg.set_readiness(
+            "vm1",
+            InstanceReadiness::ServicesStarting {
+                pending: vec!["postgres".to_string()],
+            },
+            "2025-01-01T00:00:00Z",
+        )
+        .unwrap();
+        reg.save(&path).unwrap();
+
+        let loaded = VmNameRegistry::load(&path).unwrap();
+        let r = loaded.lookup("vm1").unwrap();
+        assert_eq!(
+            r.readiness,
+            Some(InstanceReadiness::ServicesStarting {
+                pending: vec!["postgres".to_string()]
+            })
+        );
+        assert_eq!(
+            r.last_readiness_change_at.as_deref(),
+            Some("2025-01-01T00:00:00Z")
+        );
     }
 }


### PR DESCRIPTION
## Summary

Builds on #256 to make the readiness state model observable end-to-end:
- `VmNameRegistry` carries `readiness` + `last_readiness_change_at` with `#[serde(default)]` for backward compat (legacy `~/.mvm/vm-names.json` keeps loading).
- `mvmctl up` writes three host-observed milestones at all three start sites: **`LaunchAccepted`** after `backend.start`, then **`AgentConnecting`** / **`AgentReady`** around the existing port-forward agent wait.
- `mvmctl ls/ps --json` rows surface both fields alongside the existing tags/expiry/auto-resume.

## What's in scope

- `VmRegistration` extension with two new fields (serde defaults).
- `VmNameRegistry::set_readiness(name, readiness, now)` + `clear_readiness(name)` — match the existing `set_paused` / `set_expires_at` Result\<bool\> shape (Ok(false) on unknown VM).
- Best-effort `record_vm_readiness` helper in `up.rs` — readiness is observability, never gating, so registry I/O failures degrade silently with `tracing::warn`/`debug`.
- `LsRow` injection in `ps.rs` for `--json` output. Legacy rows emit `null` for both fields; struct variants (`ServicesStarting`, `Degraded`, `Backpressured`) come through with their full nested JSON shape.

## What's deferred (named in the commit body)

- `Stopping` milestone in `mvmctl down` (touches a different command).
- `ServicesStarting` / `ServicesReady` from polling guest-side integration health via `IntegrationStatus` (host-side polling isn't wired in `up.rs` today).
- `Degraded` from the same health probe flipping unhealthy.
- `Backpressured` — comes with W4 per-operation `ProcWaitEvent::Backpressure`.
- Human-readable readiness column in `ls/ps` table mode (`--json` only for now).

## Notes

- Direct-boot launchd path (line ~1253) doesn't always register the VM in `VmNameRegistry`. The `record_vm_readiness` helper logs `debug` and moves on in that case — no aborted launches.
- The agent-wait milestones only fire when port forwarding is requested, since that's the only existing host-side reason to wait. Other launches stop at `LaunchAccepted` until the W2-follow-up's follow-up wires unconditional agent reachability into `up.rs`.

## Test plan

- [x] `cargo fmt -- --check` clean
- [x] `cargo check --workspace` clean
- [x] `cargo test --workspace --no-fail-fast` exits 0 (4 new readiness tests in `mvm::vm::name_registry` plus the existing legacy-compat test extended)
- [x] `cargo clippy --workspace --all-targets -- -D warnings` clean
- [ ] CI green on this PR
- [ ] Manual smoke: `mvmctl up --hypervisor mock --name r1 ...` then `mvmctl ls --json` shows `"readiness": "launch_accepted"` and `"last_readiness_change_at": "..."` — deferred until I can run against a non-OOM macOS dev surface

🤖 Generated with [Claude Code](https://claude.com/claude-code)