### PR TITLE
Plan 74 W2 follow-up — Stopping milestone in mvmctl down + shared readiness helper

### DIFF
--- a/crates/mvm-cli/src/commands/vm/down.rs
+++ b/crates/mvm-cli/src/commands/vm/down.rs
@@ -4,10 +4,12 @@ use anyhow::Result;
 use clap::Args as ClapArgs;
 
 use mvm_backend::backend::AnyBackend;
+use mvm_core::domain::instance::InstanceReadiness;
 use mvm_core::user_config::MvmConfig;
 use mvm_core::vm_backend::VmId;
 
 use super::Cli;
+use super::readiness::record_vm_readiness;
 
 #[derive(ClapArgs, Debug, Clone)]
 pub(in crate::commands) struct Args {
@@ -24,10 +26,26 @@ pub(in crate::commands) fn run(_cli: &Cli, args: Args, _cfg: &MvmConfig) -> Resu
     };
     match args.name.as_deref() {
         Some(n) => {
+            // ADR-050 §3 / plan 74 W2: persist the `Stopping`
+            // readiness milestone BEFORE the backend stop call so a
+            // concurrent `mvmctl ls --json` running during the stop
+            // window sees the in-flight state. On a successful stop
+            // the entry is deregistered below and the milestone goes
+            // away with it; if `backend.stop` fails the milestone
+            // stays at `Stopping`, which is the right signal for
+            // "stop attempted, did not complete — retry or
+            // investigate". Best-effort; no behavior change if the
+            // VM has no registry entry (direct-boot path).
+            record_vm_readiness(n, InstanceReadiness::Stopping);
             let result = backend.stop(&VmId::from(n));
-            // Deregister from the name registry (best-effort)
+            // Deregister from the name registry on success
+            // (best-effort); on failure the entry plus its `Stopping`
+            // readiness stay so the user can see what happened.
             let registry_path = mvm::vm::name_registry::registry_path();
-            if let Ok(mut registry) = mvm::vm::name_registry::VmNameRegistry::load(&registry_path) {
+            if result.is_ok()
+                && let Ok(mut registry) =
+                    mvm::vm::name_registry::VmNameRegistry::load(&registry_path)
+            {
                 registry.deregister(n);
                 let _ = registry.save(&registry_path);
             }

--- a/crates/mvm-cli/src/commands/vm/mod.rs
+++ b/crates/mvm-cli/src/commands/vm/mod.rs
@@ -18,6 +18,7 @@ pub(super) mod plan_builder;
 pub(super) mod policy_resolver;
 pub(super) mod proc;
 pub(super) mod ps;
+pub(super) mod readiness;
 pub(super) mod run_plan;
 pub(super) mod sandbox;
 pub(super) mod session;

--- a/crates/mvm-cli/src/commands/vm/readiness.rs
+++ b/crates/mvm-cli/src/commands/vm/readiness.rs
@@ -1,0 +1,55 @@
+//! Shared host-side readiness milestone emission (ADR-050 §3 /
+//! plan 74 W2).
+//!
+//! Every `mvmctl` subcommand that observes a VM-lifecycle milestone
+//! the user might want to see in `mvmctl ls/ps --json` ends up here.
+//! The function is intentionally best-effort: readiness is
+//! observability, never gating, so registry I/O failures and
+//! unregistered VMs degrade silently with a `tracing::warn` /
+//! `tracing::debug` rather than aborting the launch or shutdown.
+
+use mvm_core::domain::instance::InstanceReadiness;
+
+/// Persist a host-observed readiness milestone on the VM's registry
+/// entry. Best-effort:
+///
+/// - If the registry can't be loaded or saved → `tracing::warn` and
+///   return without bubbling the error.
+/// - If the VM has no registry entry (the launchd-spawned direct-boot
+///   path doesn't always register) → `tracing::debug` and return.
+/// - If the registry update itself fails → `tracing::warn`.
+///
+/// Callers must never rely on this function to gate launch/teardown
+/// — readiness is a downstream display signal, not a control flow.
+pub(super) fn record_vm_readiness(vm_name: &str, readiness: InstanceReadiness) {
+    let path = mvm::vm::name_registry::registry_path();
+    let mut reg = match mvm::vm::name_registry::VmNameRegistry::load(&path) {
+        Ok(r) => r,
+        Err(e) => {
+            tracing::warn!(
+                err = %e,
+                vm = vm_name,
+                "failed to load VM name registry for readiness update"
+            );
+            return;
+        }
+    };
+    let now = mvm_core::time::utc_now();
+    match reg.set_readiness(vm_name, readiness, &now) {
+        Ok(true) => {}
+        Ok(false) => {
+            tracing::debug!(
+                vm = vm_name,
+                "no registry entry for readiness update; skipping"
+            );
+            return;
+        }
+        Err(e) => {
+            tracing::warn!(err = %e, vm = vm_name, "failed to set readiness");
+            return;
+        }
+    }
+    if let Err(e) = reg.save(&path) {
+        tracing::warn!(err = %e, vm = vm_name, "failed to save VM name registry");
+    }
+}

--- a/crates/mvm-cli/src/commands/vm/up.rs
+++ b/crates/mvm-cli/src/commands/vm/up.rs
@@ -59,45 +59,7 @@ impl mvm_plan::BundleResolver for InMemoryBundleResolver {
     }
 }
 
-/// Persist a host-observed readiness milestone (ADR-050 §3 /
-/// plan 74 W2) on the VM's registry entry. Best-effort — readiness
-/// is observability, never gating, so registry I/O failures and
-/// unregistered VMs (e.g. the launchd direct-boot path that doesn't
-/// always register) degrade silently with a debug/warn log rather
-/// than aborting the launch.
-fn record_vm_readiness(vm_name: &str, readiness: InstanceReadiness) {
-    let path = mvm::vm::name_registry::registry_path();
-    let mut reg = match mvm::vm::name_registry::VmNameRegistry::load(&path) {
-        Ok(r) => r,
-        Err(e) => {
-            tracing::warn!(
-                err = %e,
-                vm = vm_name,
-                "failed to load VM name registry for readiness update"
-            );
-            return;
-        }
-    };
-    let now = mvm_core::time::utc_now();
-    match reg.set_readiness(vm_name, readiness, &now) {
-        Ok(true) => {}
-        Ok(false) => {
-            // VM not in registry — common on direct-boot paths.
-            tracing::debug!(
-                vm = vm_name,
-                "no registry entry for readiness update; skipping"
-            );
-            return;
-        }
-        Err(e) => {
-            tracing::warn!(err = %e, vm = vm_name, "failed to set readiness");
-            return;
-        }
-    }
-    if let Err(e) = reg.save(&path) {
-        tracing::warn!(err = %e, vm = vm_name, "failed to save VM name registry");
-    }
-}
+use super::readiness::record_vm_readiness;
 
 /// Build a `PlanArtifact` pin from a verified bundle archive.
 /// Pulls the 64-byte signature out of the `manifest.sig` entry,


### PR DESCRIPTION
## Summary

- Records `InstanceReadiness::Stopping` on the VM's registry entry **before** the `backend.stop` call in `mvmctl down`, so a concurrent `mvmctl ls --json` running during the stop window sees the in-flight state instead of the previous "agent_ready" / "launch_accepted" ghost.
- Tightens the existing deregister to fire only on a successful stop — failed stops now leave the registry row plus its `Stopping` readiness so the user can see what happened and retry, instead of the previous "stop attempted but everything goes silent" behavior.
- Extracts the `record_vm_readiness` helper from `up.rs` into a shared `vm/readiness.rs` module so the next few PRs (guest-health → host readiness, W4 backpressure) can hang off it without duplicating the registry I/O wrapper.

## Files

- **New** `crates/mvm-cli/src/commands/vm/readiness.rs` — same best-effort behavior the helper had in `up.rs`: registry load/save failures `tracing::warn`; unregistered VMs `tracing::debug`; successful updates silent. Readiness is observability, never gating.
- `crates/mvm-cli/src/commands/vm/up.rs` — helper definition removed; replaced with `use super::readiness::record_vm_readiness;`. Three milestone call sites unchanged.
- `crates/mvm-cli/src/commands/vm/mod.rs` — adds `pub(super) mod readiness;`.
- `crates/mvm-cli/src/commands/vm/down.rs` — imports the helper + `InstanceReadiness`, emits `Stopping` before `backend.stop`, gates deregister on stop success.

## Deferred (named in the commit body)

- **Fleet `backend.stop_all` path** — would need to iterate the registry and emit `Stopping` per VM; current code doesn't track per-VM stop outcomes from `stop_all` either, so deferred to a follow-up.
- **`pause` / `resume`** — use a separate `set_paused` flag, not a readiness variant; the `InstanceReadiness` taxonomy doesn't currently model the sealed-snapshot lifecycle.
- **Reaper teardown** — wave-3 supervisor integration not landed.

## Test plan

- [x] `cargo fmt -- --check` clean
- [x] `cargo check --workspace` clean
- [x] `cargo test --workspace --no-fail-fast` exits 0 (the `set_readiness` registry helper itself was already tested in #261; this PR just adds a call site)
- [x] `cargo clippy --workspace --all-targets -- -D warnings` clean
- [ ] CI green on this PR

## Notes

- This is part of a planned three-PR sequence on top of [#261](https://github.com/tinylabscom/mvm/pull/261): **Stopping milestone** (this PR) → guest-health → host readiness → W4 backpressure (`ProcWaitEvent::Backpressure`).
- The behavior change "only deregister on stop success" is *strictly more informative* — previously, a failed stop dropped the registry row and the user lost track of the failed VM. Should be a uniformly positive UX change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)