### PR TITLE
plan 74 W1.4b.7 — auto-fetch overlay on `mvmctl up` cache miss (ADR-051)

### DIFF
--- a/crates/mvm-build/src/runtime_overlay.rs
+++ b/crates/mvm-build/src/runtime_overlay.rs
@@ -902,6 +902,65 @@ pub fn download_runtime_overlay(
     )
 }
 
+/// Documented env var that disables the auto-fetch fallback in
+/// [`resolve_or_fetch_runtime_overlay`]. When set to anything
+/// non-empty, an `ArtifactIncomplete` or `VersionMismatch`
+/// surfaces as the raw resolver error instead of triggering a
+/// download. Useful for airgapped environments + CI runners
+/// where the operator wants to pre-populate the cache.
+const AUTOFETCH_DISABLE_ENV: &str = "MVM_OVERLAY_AUTOFETCH_OFF";
+
+/// Resolve the runtime overlay from the local cache, auto-
+/// fetching from the published GitHub Release if a cache miss
+/// shows up. Designed for the `mvmctl up` hot path so callers
+/// don't have to babysit "is the overlay cached for this
+/// mvmctl version + arch?".
+///
+/// Fetch fires on two outcomes:
+/// - [`RuntimeOverlayError::ArtifactIncomplete`] — at least one
+///   of the four files is missing.
+/// - [`RuntimeOverlayError::VersionMismatch`] — the cached
+///   `VERSION` file disagrees with `expected_version`. Stale
+///   overlay from an older mvmctl; refetch under the new tag.
+///
+/// Every other resolver error fails through (`InvalidRoothash`,
+/// `InvalidVersionFile`, `Io`). Those signal *something is
+/// already wrong* with what's on disk — silently overwriting on
+/// auto-fetch could hide tamper attempts.
+///
+/// Honors `MVM_OVERLAY_AUTOFETCH_OFF=1` for airgapped operators
+/// who want misses to surface verbatim instead of triggering
+/// network I/O.
+pub fn resolve_or_fetch_runtime_overlay(
+    cache_root: &Path,
+    version: &str,
+    arch: Arch,
+) -> Result<RuntimeOverlayArtifact, RuntimeOverlayError> {
+    let resolver = RuntimeOverlayResolver::new(cache_root.to_path_buf(), version.to_string());
+    match resolver.resolve(arch) {
+        Ok(artifact) => Ok(artifact),
+        Err(e @ RuntimeOverlayError::ArtifactIncomplete { .. })
+        | Err(e @ RuntimeOverlayError::VersionMismatch { .. }) => {
+            if autofetch_disabled() {
+                return Err(e);
+            }
+            tracing::info!(
+                "Runtime overlay not in cache (reason: {e}); fetching from \
+                 release for v{version} ({arch})..."
+            );
+            download_runtime_overlay(version, arch, cache_root)
+        }
+        Err(other) => Err(other),
+    }
+}
+
+fn autofetch_disabled() -> bool {
+    matches!(
+        std::env::var(AUTOFETCH_DISABLE_ENV).ok().as_deref(),
+        Some(v) if !v.is_empty()
+    )
+}
+
 /// HTTP GET the per-release `sha256sum`-format checksums file and
 /// return a `name -> hex-digest` map for the artifacts we need.
 /// Filenames that aren't in `wanted` are dropped; any name in
@@ -2154,5 +2213,208 @@ short  bar.ext4
         let mut h = Sha256::new();
         h.update(bytes);
         format!("{:x}", h.finalize())
+    }
+
+    // ====================================================================
+    // Plan 74 W1.4b.7 — resolve_or_fetch_runtime_overlay
+    // ====================================================================
+
+    /// Stage a valid four-file overlay under
+    /// `<cache>/runtime-overlay/<version>/<arch>/`. Mirrors the
+    /// helper used by the status tests in the CLI crate; copied
+    /// here so the autofetch tests stay self-contained.
+    fn stage_cache_artifact(cache_root: &Path, version: &str, arch: Arch) {
+        let dir = cache_root
+            .join("runtime-overlay")
+            .join(version)
+            .join(arch.as_str());
+        std::fs::create_dir_all(&dir).unwrap();
+        let roothash = "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef";
+        std::fs::write(dir.join("overlay.ext4"), b"fake-ext4").unwrap();
+        std::fs::write(dir.join("overlay.verity"), b"fake-verity").unwrap();
+        std::fs::write(dir.join("overlay.roothash"), format!("{roothash}\n")).unwrap();
+        std::fs::write(dir.join("VERSION"), format!("{version}\n")).unwrap();
+    }
+
+    /// Stage a fixture-shaped GitHub release dir under the
+    /// upstream tempdir + return the `file://` base URL the
+    /// auto-fetch test must pin via `MVM_OVERLAY_BASE_URL`.
+    fn stage_release_fixture(upstream: &TempDir, version: &str, arch: Arch) -> String {
+        let release_dir = upstream.path().join(format!("v{version}"));
+        std::fs::create_dir_all(&release_dir).unwrap();
+        let names = RuntimeOverlayArtifactNames::for_arch(arch);
+        let ext4 = b"fresh-ext4-from-release";
+        let verity = b"fresh-verity-from-release";
+        let roothash = "abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789";
+        write_fixture(&release_dir, &names.ext4, ext4);
+        write_fixture(&release_dir, &names.verity, verity);
+        write_fixture(
+            &release_dir,
+            &names.roothash,
+            format!("{roothash}\n").as_bytes(),
+        );
+        write_fixture(
+            &release_dir,
+            &names.version,
+            format!("{version}\n").as_bytes(),
+        );
+        let checksums = format!(
+            "{}  {}\n{}  {}\n{}  {}\n{}  {}\n",
+            sha256_hex(ext4),
+            names.ext4,
+            sha256_hex(verity),
+            names.verity,
+            sha256_hex(format!("{roothash}\n").as_bytes()),
+            names.roothash,
+            sha256_hex(format!("{version}\n").as_bytes()),
+            names.version,
+        );
+        write_fixture(&release_dir, &names.checksums, checksums.as_bytes());
+        format!("file://{}", upstream.path().display())
+    }
+
+    #[test]
+    fn resolve_or_fetch_uses_cache_when_present() {
+        let _g = env_test_mutex().lock().unwrap();
+        // No `MVM_OVERLAY_BASE_URL` set — if a download fires
+        // with the default GitHub URL it would either succeed
+        // (network call we don't want in tests) or fail loudly.
+        // Either is the wrong outcome — the cache should serve.
+        unsafe {
+            std::env::remove_var("MVM_OVERLAY_BASE_URL");
+        }
+        let cache = TempDir::new().unwrap();
+        stage_cache_artifact(cache.path(), "9.9.9", Arch::Aarch64);
+        let artifact = resolve_or_fetch_runtime_overlay(cache.path(), "9.9.9", Arch::Aarch64)
+            .expect("cache hit must succeed");
+        assert_eq!(artifact.version, "9.9.9");
+        assert_eq!(artifact.arch, Arch::Aarch64);
+        // The cached fake roothash, not the release fixture one.
+        assert_eq!(
+            artifact.roothash,
+            "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef"
+        );
+    }
+
+    #[test]
+    fn resolve_or_fetch_downloads_when_cache_missing() {
+        let _g = env_test_mutex().lock().unwrap();
+        let upstream = TempDir::new().unwrap();
+        let base_url = stage_release_fixture(&upstream, "9.9.9", Arch::Aarch64);
+        unsafe {
+            std::env::set_var("MVM_OVERLAY_BASE_URL", &base_url);
+        }
+        let cache = TempDir::new().unwrap();
+        // Cache is empty — auto-fetch should fire against the
+        // file:// fixture.
+        let artifact = resolve_or_fetch_runtime_overlay(cache.path(), "9.9.9", Arch::Aarch64);
+        unsafe {
+            std::env::remove_var("MVM_OVERLAY_BASE_URL");
+        }
+        let artifact = artifact.expect("auto-fetch must succeed against fixture");
+        // The roothash matches what the release fixture published,
+        // proving the download path fired (not the cache).
+        assert_eq!(
+            artifact.roothash,
+            "abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789"
+        );
+        // Cache is now populated under canonical names.
+        let installed_dir = cache.path().join("runtime-overlay/9.9.9/aarch64");
+        assert!(installed_dir.join("overlay.ext4").is_file());
+    }
+
+    #[test]
+    fn resolve_or_fetch_downloads_when_cache_has_wrong_version() {
+        let _g = env_test_mutex().lock().unwrap();
+        let upstream = TempDir::new().unwrap();
+        let base_url = stage_release_fixture(&upstream, "9.9.9", Arch::Aarch64);
+        unsafe {
+            std::env::set_var("MVM_OVERLAY_BASE_URL", &base_url);
+        }
+        let cache = TempDir::new().unwrap();
+        // Stage an OLD version under the same path the resolver
+        // walks for 9.9.9, but write a mismatching VERSION
+        // file — that's what triggers VersionMismatch.
+        let dir = cache.path().join("runtime-overlay/9.9.9/aarch64");
+        std::fs::create_dir_all(&dir).unwrap();
+        let roothash = "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef";
+        std::fs::write(dir.join("overlay.ext4"), b"stale-ext4").unwrap();
+        std::fs::write(dir.join("overlay.verity"), b"stale-verity").unwrap();
+        std::fs::write(dir.join("overlay.roothash"), format!("{roothash}\n")).unwrap();
+        std::fs::write(dir.join("VERSION"), b"0.13.0\n").unwrap();
+        let artifact = resolve_or_fetch_runtime_overlay(cache.path(), "9.9.9", Arch::Aarch64);
+        unsafe {
+            std::env::remove_var("MVM_OVERLAY_BASE_URL");
+        }
+        let artifact = artifact.expect("version mismatch must trigger fetch");
+        // Fresh release roothash, not the stale 0.13.0 one.
+        assert_eq!(
+            artifact.roothash,
+            "abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789"
+        );
+    }
+
+    #[test]
+    fn resolve_or_fetch_disabled_via_env_surfaces_resolver_error() {
+        let _g = env_test_mutex().lock().unwrap();
+        // Disable auto-fetch; an empty cache should surface as
+        // `ArtifactIncomplete` rather than trigger a download.
+        unsafe {
+            std::env::set_var("MVM_OVERLAY_AUTOFETCH_OFF", "1");
+        }
+        let cache = TempDir::new().unwrap();
+        let err = resolve_or_fetch_runtime_overlay(cache.path(), "9.9.9", Arch::Aarch64);
+        unsafe {
+            std::env::remove_var("MVM_OVERLAY_AUTOFETCH_OFF");
+        }
+        let err = err.expect_err("must error when auto-fetch is disabled");
+        assert!(
+            matches!(err, RuntimeOverlayError::ArtifactIncomplete { .. }),
+            "{err:?}"
+        );
+    }
+
+    #[test]
+    fn resolve_or_fetch_passes_through_invalid_roothash_without_fetch() {
+        let _g = env_test_mutex().lock().unwrap();
+        // No `MVM_OVERLAY_BASE_URL` — if a download fires the
+        // test panics out via "DownloadFailed". The function
+        // must NOT fetch on a malformed roothash; that signals
+        // something is already wrong on disk.
+        unsafe {
+            std::env::remove_var("MVM_OVERLAY_BASE_URL");
+        }
+        let cache = TempDir::new().unwrap();
+        let dir = cache.path().join("runtime-overlay/9.9.9/aarch64");
+        std::fs::create_dir_all(&dir).unwrap();
+        std::fs::write(dir.join("overlay.ext4"), b"x").unwrap();
+        std::fs::write(dir.join("overlay.verity"), b"x").unwrap();
+        std::fs::write(dir.join("overlay.roothash"), b"not-hex\n").unwrap();
+        std::fs::write(dir.join("VERSION"), b"9.9.9\n").unwrap();
+        let err = resolve_or_fetch_runtime_overlay(cache.path(), "9.9.9", Arch::Aarch64)
+            .expect_err("must surface InvalidRoothash, not auto-fetch over it");
+        assert!(
+            matches!(err, RuntimeOverlayError::InvalidRoothash { .. }),
+            "{err:?}"
+        );
+    }
+
+    #[test]
+    fn autofetch_disabled_recognizes_nonempty_string() {
+        let _g = env_test_mutex().lock().unwrap();
+        unsafe {
+            std::env::set_var("MVM_OVERLAY_AUTOFETCH_OFF", "1");
+        }
+        assert!(autofetch_disabled());
+        unsafe {
+            std::env::set_var("MVM_OVERLAY_AUTOFETCH_OFF", "");
+        }
+        // Empty string isn't disabled — matches the env-var
+        // convention used elsewhere in mvm.
+        assert!(!autofetch_disabled());
+        unsafe {
+            std::env::remove_var("MVM_OVERLAY_AUTOFETCH_OFF");
+        }
+        assert!(!autofetch_disabled());
     }
 }

--- a/crates/mvm-cli/src/commands/vm/up.rs
+++ b/crates/mvm-cli/src/commands/vm/up.rs
@@ -32,6 +32,54 @@ use super::shared::{
     wait_for_guest_agent,
 };
 
+/// Plan 74 W1.4b.7 — when the rootfs boot is verity-protected,
+/// resolve (or auto-fetch) the runtime overlay artifact for the
+/// running mvmctl version + host arch and return the three
+/// values the backend gate needs to attach `/dev/vdc` + `/dev/vdd`
+/// and thread `mvm.runtime_roothash=…` into the cmdline.
+///
+/// Verity off ⇒ no overlay (verity-init is the only consumer of
+/// the overlay drives; attaching them with no init to mount them
+/// would just reserve virtio slots for nothing). All-three-None.
+///
+/// Verity on ⇒ try cache first; on miss or version-mismatch the
+/// underlying `resolve_or_fetch_runtime_overlay` downloads from
+/// the published GitHub Release. On *any* failure (network down,
+/// `MVM_OVERLAY_AUTOFETCH_OFF=1` set with an empty cache, malformed
+/// on-disk roothash) we log a warning and fall back to all-None.
+/// The legacy boot path (verity-only, no overlay) still works —
+/// the workload just won't see the overlay-provided SDK paths.
+/// An operator who *requires* the overlay should run
+/// `mvmctl overlay fetch` ahead of time or read the warning and
+/// retry.
+fn resolve_runtime_overlay_for_boot(
+    verity_path: Option<&str>,
+) -> (Option<String>, Option<String>, Option<String>) {
+    if verity_path.is_none() {
+        return (None, None, None);
+    }
+    let arch = mvm_build::runtime_overlay::Arch::host();
+    let version = env!("CARGO_PKG_VERSION");
+    let cache_root = std::path::PathBuf::from(mvm_core::config::mvm_cache_dir());
+    match mvm_build::runtime_overlay::resolve_or_fetch_runtime_overlay(&cache_root, version, arch) {
+        Ok(a) => (
+            Some(a.overlay_ext4.to_string_lossy().into_owned()),
+            Some(a.sidecar.to_string_lossy().into_owned()),
+            Some(a.roothash),
+        ),
+        Err(e) => {
+            tracing::warn!(
+                error = %e,
+                "Runtime overlay unavailable — booting without /mvm/runtime. \
+                 SDK addons in the overlay won't be reachable from this workload. \
+                 Run `mvmctl overlay fetch` to populate the cache, or unset \
+                 MVM_OVERLAY_AUTOFETCH_OFF if the auto-fetch was disabled."
+            );
+            (None, None, None)
+        }
+    }
+}
+
 /// Inputs for [`admit_plan_for_boot`]. Grouped so the helper avoids
 /// the workspace `clippy::too_many_arguments = "deny"` ceiling and so
 /// future callers (W5 policy slots) can extend the shape without
@@ -1596,6 +1644,8 @@ pub(super) fn cmd_run(params: RunParams<'_>) -> Result<()> {
         // restored VM boots through dm-verity when the template was
         // built with `verifiedBoot = true`. ADR-002 §W3.2.
         let (verity_path, roothash) = microvm::probe_verity_sidecar(&rootfs_path);
+        let (runtime_overlay_path, runtime_overlay_verity_path, runtime_overlay_roothash) =
+            resolve_runtime_overlay_for_boot(verity_path.as_deref());
         let run_config = microvm::FlakeRunConfig {
             name: vm_name,
             slot,
@@ -1604,9 +1654,9 @@ pub(super) fn cmd_run(params: RunParams<'_>) -> Result<()> {
             rootfs_path,
             verity_path,
             roothash,
-            runtime_overlay_path: None,
-            runtime_overlay_verity_path: None,
-            runtime_overlay_roothash: None,
+            runtime_overlay_path,
+            runtime_overlay_verity_path,
+            runtime_overlay_roothash,
             revision_hash,
             flake_ref: source_flake,
             profile: source_profile,
@@ -1643,7 +1693,15 @@ pub(super) fn cmd_run(params: RunParams<'_>) -> Result<()> {
         emit_launched_if(&admission_main, effective_hypervisor);
     } else {
         let (verity_path, roothash) = microvm::probe_verity_sidecar(&rootfs_path);
-        let start_config = VmStartParams {
+        // Plan 74 W1.4b.7 — when verity is on, resolve (or
+        // auto-fetch) the runtime overlay before constructing
+        // the start config. The triple is consumed by the
+        // Firecracker backend gate (W1.4b.3b.3a); if any value
+        // is `None` the backend falls back to the legacy
+        // verity-only boot.
+        let (runtime_overlay_path, runtime_overlay_verity_path, runtime_overlay_roothash) =
+            resolve_runtime_overlay_for_boot(verity_path.as_deref());
+        let mut start_config = VmStartParams {
             name: vm_name,
             rootfs_path,
             vmlinux_path,
@@ -1662,6 +1720,9 @@ pub(super) fn cmd_run(params: RunParams<'_>) -> Result<()> {
             port_mappings: &port_mappings,
         }
         .into_start_config();
+        start_config.runtime_overlay_path = runtime_overlay_path;
+        start_config.runtime_overlay_verity_path = runtime_overlay_verity_path;
+        start_config.runtime_overlay_roothash = runtime_overlay_roothash;
 
         // Apple Container with -d: install a launchd agent instead of
         // starting the VM in this process. The agent runs as a proper


### PR DESCRIPTION
## Summary

- Closes the user-visible loop on the runtime overlay story: `mvmctl up` against a verity template now resolves (or auto-fetches) the overlay automatically. Operators no longer need to run `mvmctl overlay fetch` as a prerequisite.
- New `mvm_build::runtime_overlay::resolve_or_fetch_runtime_overlay` helper — tries the cache first, downloads on miss or version-mismatch, fails through on tamper-shaped errors.
- New `MVM_OVERLAY_AUTOFETCH_OFF` env var for airgapped operators + CI runners.
- Wired into both `VmStartConfig` construction sites in `crates/mvm-cli/src/commands/vm/up.rs` (snapshot fast-path and main start path), gated on verity being on.
- Fail-soft on auto-fetch errors with a clear warning + actionable next step — the legacy verity-only boot still works.

## Failure policy

| Cache state | `AUTOFETCH_OFF` set | Behaviour |
|---|---|---|
| Hit | any | Use cache (no network) |
| Miss / wrong version | unset | Auto-fetch from GitHub release |
| Miss / wrong version | set | Surface `ArtifactIncomplete` raw |
| Malformed (invalid roothash, etc.) | any | Surface `Invalid*` error, no fetch |

Verity off ⇒ short-circuit to all-None (no overlay consumer exists without `mvm-verity-init`).

On any auto-fetch failure in the `mvmctl up` path, we log `tracing::warn!(...)` and fall back to the legacy verity-only boot. Operators who *require* the overlay see the warning and can `mvmctl overlay fetch` manually.

## Why fail-soft (not fail-hard) on auto-fetch errors

A user running `mvmctl up` against an old template that pre-dates the W1.4b.3c mkGuest refactor doesn't need the overlay — their `/init` will fall back to `/usr/local/bin/mvm-guest-agent`. Hard-failing the boot on a network blip would surprise those operators. The warning is loud enough that an operator on a *new* template will notice and retry; a *legacy* template owner can ignore it.

The proper "this workload requires overlay" gate will land with the admission slice that consumes the `overlayAware = true` passthru metadata (separate PR, needs a sidecar file so the host can read it without re-evaluating Nix).

## Test plan

- [x] 6 new tests in `mvm-build::runtime_overlay::tests` cover every fetch branch + the disable env + the no-fetch-on-tamper invariant.
- [x] `cargo test --workspace --lib --bins --tests` — clean.
- [x] `cargo clippy --workspace --all-targets -- -D warnings` — clean.
- [x] `cargo fmt --all -- --check` — clean.
- [ ] Live-VM regression on a verity-on Firecracker host with a cold cache — gated on the parent stack reaching main.

## Stack

This PR sits on top of (deepest first):

1. W1.4b.1 — runtime-overlay artifact resolver (#238)
2. W1.4b.2 — runtime-overlay flake
3. W1.4b.3a — Rust orchestrator
4. W1.4b.3b.1 — install_overlay_into_cache
5. W1.4b.3b.2 — mvm-verity-init overlay extension
6. W1.4b.3b.3a — Firecracker overlay wiring (#254)
7. W1.4b.3c — mkGuest overlay-aware rootfs (#257)
8. W1.4b — runtime-overlay release-pipeline job (#258)
9. W1.4b.4 — download_runtime_overlay (#260)
10. W1.4b.5 — `mvmctl overlay fetch` CLI (#262)
11. W1.4b.6 — `mvmctl overlay status` CLI (#264)

GitHub will retarget this PR's base as each parent merges to main.

Refs: ADR-051, specs/plans/74-claim-safe-sandbox-parity.md §W1.4b.

🤖 Generated with [Claude Code](https://claude.com/claude-code)