### PR TITLE
Plan 74 W2 — guest-health → host readiness (ServicesStarting / ServicesReady) + Degraded plan

### DIFF
--- a/crates/mvm-backend/src/mock_guest_agent.rs
+++ b/crates/mvm-backend/src/mock_guest_agent.rs
@@ -309,6 +309,15 @@ fn dispatch(req: GuestRequest, next_token: &AtomicU64) -> GuestResponse {
             &requested_capabilities,
         ),
 
+        // ── Integration status (ADR-050 §3 / plan 74 W2) ────────────
+        // Mock VMs have no integrations to report. Returning an empty
+        // list lets the host's services-ready poll transition straight
+        // to `ServicesReady` rather than timing out on a "verb not
+        // implemented" error from the catch-all arm below.
+        GuestRequest::IntegrationStatus => GuestResponse::IntegrationStatusReport {
+            integrations: Vec::new(),
+        },
+
         // ── Filesystem verbs ────────────────────────────────────────
         GuestRequest::FsWrite { content, .. } => GuestResponse::FsResult(FsResult::Write {
             bytes_written: content.len() as u64,

--- a/crates/mvm-cli/src/commands/vm/readiness.rs
+++ b/crates/mvm-cli/src/commands/vm/readiness.rs
@@ -8,7 +8,15 @@
 //! unregistered VMs degrade silently with a `tracing::warn` /
 //! `tracing::debug` rather than aborting the launch or shutdown.
 
+use std::time::{Duration, Instant};
+
+use mvm::vsock_transport::{self, VsockTransport};
 use mvm_core::domain::instance::InstanceReadiness;
+use mvm_guest::integrations::{IntegrationStateReport, IntegrationStatus};
+use mvm_guest::vsock::{
+    GUEST_AGENT_PORT, GuestCapability, GuestRequest, GuestResponse, negotiate_protocol,
+    send_request,
+};
 
 /// Persist a host-observed readiness milestone on the VM's registry
 /// entry. Best-effort:
@@ -51,5 +59,163 @@ pub(super) fn record_vm_readiness(vm_name: &str, readiness: InstanceReadiness) {
     }
     if let Err(e) = reg.save(&path) {
         tracing::warn!(err = %e, vm = vm_name, "failed to save VM name registry");
+    }
+}
+
+/// One snapshot of guest integration health observed by the host.
+/// Built from a single `GuestRequest::IntegrationStatus` round-trip so
+/// the host-side transitions are deterministic — there's no "partial
+/// view" where the snapshot has some services missing from the report.
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct ServicesHealthSnapshot {
+    /// Names of services whose status is anything other than
+    /// `IntegrationStatus::Active`. Sorted for stable readiness
+    /// payloads (the host then renders them into
+    /// `InstanceReadiness::ServicesStarting { pending }`).
+    pending: Vec<String>,
+}
+
+fn classify_services_snapshot(reports: &[IntegrationStateReport]) -> ServicesHealthSnapshot {
+    let mut pending: Vec<String> = reports
+        .iter()
+        .filter(|r| !matches!(r.status, IntegrationStatus::Active))
+        .map(|r| r.name.clone())
+        .collect();
+    pending.sort();
+    ServicesHealthSnapshot { pending }
+}
+
+/// Query guest integration status via the standard `mvm::vsock_transport`
+/// abstraction. Performs the ADR-050 / plan 74 W1 hello prelude on
+/// each connection so the agent dispatches the operational request.
+fn query_services_via_transport(vm_name: &str) -> anyhow::Result<Vec<IntegrationStateReport>> {
+    let transport: Box<dyn VsockTransport> = vsock_transport::for_vm(vm_name)?;
+    let mut stream = transport.connect(GUEST_AGENT_PORT)?;
+    let _ = negotiate_protocol(&mut stream, vec![GuestCapability::IntegrationStatus])?;
+    let resp = send_request(&mut stream, &GuestRequest::IntegrationStatus)?;
+    match resp {
+        GuestResponse::IntegrationStatusReport { integrations } => Ok(integrations),
+        GuestResponse::Error { message } => {
+            anyhow::bail!("guest integration status error: {message}")
+        }
+        other => anyhow::bail!("unexpected response to IntegrationStatus: {other:?}"),
+    }
+}
+
+/// Block until every guest integration reports `Active`, or `timeout`
+/// elapses. Updates the registry's readiness on every transition the
+/// host observes: each tick recomputes a `ServicesHealthSnapshot` and
+/// records either `InstanceReadiness::ServicesStarting { pending }` or
+/// `InstanceReadiness::ServicesReady`.
+///
+/// Best-effort:
+/// - Transport / RPC errors `tracing::debug` and retry on the next
+///   tick (a still-booting agent commonly fails the first few
+///   polls).
+/// - On timeout, the function returns leaving readiness at whatever
+///   the last successful poll observed — `mvmctl ls --json` then
+///   surfaces exactly which services blocked.
+/// - VMs with no integrations transition to `ServicesReady`
+///   immediately (the mock backend exercises this in
+///   `mvm_backend::mock_guest_agent::dispatch`).
+///
+/// # Future: `Degraded` (ADR-050 §3)
+///
+/// Detecting `Degraded { unhealthy }` requires polling *after*
+/// `ServicesReady`. Three follow-up paths are possible — see the
+/// "Plan: `Degraded` follow-up" section of the W2-services-health
+/// PR body. None of them are wired here; once `ServicesReady` fires,
+/// this function returns.
+pub(super) fn wait_for_services_ready(vm_name: &str, timeout: Duration) {
+    let deadline = Instant::now() + timeout;
+    let poll_interval = Duration::from_secs(1);
+    let mut last_snapshot: Option<ServicesHealthSnapshot> = None;
+
+    loop {
+        match query_services_via_transport(vm_name) {
+            Ok(reports) => {
+                let snapshot = classify_services_snapshot(&reports);
+                let readiness = if snapshot.pending.is_empty() {
+                    InstanceReadiness::ServicesReady
+                } else {
+                    InstanceReadiness::ServicesStarting {
+                        pending: snapshot.pending.clone(),
+                    }
+                };
+                // Only record when the snapshot changed, to avoid
+                // thrashing the registry file every tick when nothing
+                // moved. The first successful poll always records,
+                // since `last_snapshot` is `None`.
+                if last_snapshot.as_ref() != Some(&snapshot) {
+                    record_vm_readiness(vm_name, readiness);
+                    last_snapshot = Some(snapshot.clone());
+                }
+                if snapshot.pending.is_empty() {
+                    return;
+                }
+            }
+            Err(e) => {
+                tracing::debug!(
+                    err = %e,
+                    vm = vm_name,
+                    "services-ready poll failed; will retry"
+                );
+            }
+        }
+
+        if Instant::now() >= deadline {
+            tracing::debug!(
+                vm = vm_name,
+                "services-ready poll timed out; leaving readiness at last-known state"
+            );
+            return;
+        }
+        std::thread::sleep(poll_interval);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use mvm_guest::integrations::IntegrationStateReport;
+
+    fn report(name: &str, status: IntegrationStatus) -> IntegrationStateReport {
+        IntegrationStateReport {
+            name: name.to_string(),
+            status,
+            last_checkpoint_at: None,
+            state_size_bytes: 0,
+            health: None,
+        }
+    }
+
+    #[test]
+    fn snapshot_empty_list_has_no_pending() {
+        let snap = classify_services_snapshot(&[]);
+        assert!(snap.pending.is_empty());
+    }
+
+    #[test]
+    fn snapshot_all_active_has_no_pending() {
+        let reports = vec![
+            report("postgres", IntegrationStatus::Active),
+            report("redis", IntegrationStatus::Active),
+        ];
+        let snap = classify_services_snapshot(&reports);
+        assert!(snap.pending.is_empty());
+    }
+
+    #[test]
+    fn snapshot_collects_non_active_into_pending_and_sorts() {
+        let reports = vec![
+            report("redis", IntegrationStatus::Active),
+            report("worker", IntegrationStatus::Starting),
+            report("postgres", IntegrationStatus::Pending),
+            report("queue", IntegrationStatus::Paused),
+            report("api", IntegrationStatus::Error("502".to_string())),
+        ];
+        let snap = classify_services_snapshot(&reports);
+        // Sorted alphabetically for stable readiness payloads.
+        assert_eq!(snap.pending, vec!["api", "postgres", "queue", "worker"]);
     }
 }

--- a/crates/mvm-cli/src/commands/vm/up.rs
+++ b/crates/mvm-cli/src/commands/vm/up.rs
@@ -957,6 +957,7 @@ pub(in crate::commands) fn run(_cli: &Cli, args: Args, cfg: &MvmConfig) -> Resul
         build_mode,
         workload_ir_path: args.from_workload_ir.as_deref(),
         up_json: args.up_json,
+        services_health_timeout_secs: cfg.effective_services_health_timeout_secs(),
     })?;
 
     // Plan 73 Followup H-live: after a successful boot, emit a
@@ -1058,6 +1059,15 @@ pub(in crate::commands) struct RunParams<'a> {
     /// generated VM id + the template's `build_mode` through to
     /// subsequent `proc start` / `fs write` / `down` calls.
     pub(super) up_json: bool,
+    /// Resolved services-health wait timeout for ADR-050 §3 / plan 74
+    /// W2 (`InstanceReadiness::ServicesStarting` →
+    /// `InstanceReadiness::ServicesReady`). Comes from
+    /// `MvmConfig::effective_services_health_timeout_secs()` so an
+    /// `MVM_SERVICES_HEALTH_TIMEOUT_SECS` env-var override or a
+    /// `services_health_timeout_secs = N` line in
+    /// `~/.mvm/config.toml` flow through without `cmd_run` itself
+    /// re-reading the config.
+    pub(super) services_health_timeout_secs: u64,
 }
 
 pub(super) fn cmd_run(params: RunParams<'_>) -> Result<()> {
@@ -1093,6 +1103,7 @@ pub(super) fn cmd_run(params: RunParams<'_>) -> Result<()> {
         build_mode,
         workload_ir_path,
         up_json: _up_json,
+        services_health_timeout_secs,
     } = params;
     let _span =
         tracing::info_span!("cmd_run", name = ?name, cpus = ?cpus, memory_mib = ?memory).entered();
@@ -1265,25 +1276,40 @@ pub(super) fn cmd_run(params: RunParams<'_>) -> Result<()> {
         // MVM_DIRECT_BOOT + `--hypervisor mock`.
         mvm_core::audit_emit!(VmStart, vm: &vm_name);
 
-        // Set up port forwarding from MVM_PORTS env var (via vsock)
-        if let Ok(ports_str) = std::env::var("MVM_PORTS")
+        // ADR-050 §3 / plan 74 W2 (services-health): wait for the
+        // guest agent unconditionally, then poll integration health.
+        // The wait was previously gated on `MVM_PORTS` because port
+        // forwarding was the only existing reason to block here. The
+        // gate moved off — every up now records `AgentConnecting` /
+        // `AgentReady` / `ServicesStarting` / `ServicesReady` so
+        // `mvmctl ls --json` shows a useful wait reason for every
+        // VM, not just port-forwarded ones.
+        ui::info("Waiting for guest agent...");
+        record_vm_readiness(&vm_name, InstanceReadiness::AgentConnecting);
+        let agent_ready = wait_for_guest_agent(&vm_name, 30);
+        if agent_ready {
+            record_vm_readiness(&vm_name, InstanceReadiness::AgentReady);
+            let timeout = std::time::Duration::from_secs(services_health_timeout_secs);
+            super::readiness::wait_for_services_ready(&vm_name, timeout);
+        } else {
+            ui::warn("Guest agent not reachable.");
+        }
+
+        // Set up port forwarding from MVM_PORTS env var (via vsock).
+        // Requires the agent — skip silently if the wait above gave
+        // up.
+        if agent_ready
+            && let Ok(ports_str) = std::env::var("MVM_PORTS")
             && !ports_str.is_empty()
         {
-            ui::info("Waiting for guest agent...");
-            record_vm_readiness(&vm_name, InstanceReadiness::AgentConnecting);
-            if wait_for_guest_agent(&vm_name, 30) {
-                record_vm_readiness(&vm_name, InstanceReadiness::AgentReady);
-                for spec in ports_str.split(',') {
-                    if let Some((host, guest)) = spec.split_once(':')
-                        && let (Ok(h), Ok(g)) = (host.parse::<u16>(), guest.parse::<u16>())
-                    {
-                        let _ = request_port_forward(&vm_name, g);
-                        mvm_providers::apple_container::start_port_proxy(&vm_name, h, g);
-                        ui::info(&format!("Forwarding localhost:{h} → guest tcp/{g} (vsock)"));
-                    }
+            for spec in ports_str.split(',') {
+                if let Some((host, guest)) = spec.split_once(':')
+                    && let (Ok(h), Ok(g)) = (host.parse::<u16>(), guest.parse::<u16>())
+                {
+                    let _ = request_port_forward(&vm_name, g);
+                    mvm_providers::apple_container::start_port_proxy(&vm_name, h, g);
+                    ui::info(&format!("Forwarding localhost:{h} → guest tcp/{g} (vsock)"));
                 }
-            } else {
-                ui::warn("Guest agent not reachable — port forwarding unavailable.");
             }
         }
 
@@ -1718,63 +1744,69 @@ pub(super) fn cmd_run(params: RunParams<'_>) -> Result<()> {
 
     // Apple Virtualization VMs live in-process — the process must stay alive.
     if effective_hypervisor == "apple-container" && !detach {
-        // Set up port forwarding via vsock (no guest IP needed).
-        // 1. Wait for guest agent to be ready on `GUEST_AGENT_PORT` (5252)
-        // 2. Tell the agent to start vsock→TCP forwarders for each port
-        // 3. Start host-side TCP→vsock proxies
-        if has_ports {
+        // ADR-050 §3 / plan 74 W2 (services-health): wait for the
+        // guest agent unconditionally (was previously gated on
+        // `has_ports`), then poll integration health. Every Apple
+        // Container up now records `AgentConnecting` / `AgentReady`
+        // / `ServicesStarting` / `ServicesReady`, so `mvmctl ls
+        // --json` shows a useful wait reason for every VM.
+        ui::info("Waiting for guest agent...");
+        record_vm_readiness(&vm_name_owned, InstanceReadiness::AgentConnecting);
+        let agent_ready = wait_for_guest_agent(&vm_name_owned, 30);
+        if agent_ready {
+            record_vm_readiness(&vm_name_owned, InstanceReadiness::AgentReady);
+            let timeout = std::time::Duration::from_secs(services_health_timeout_secs);
+            super::readiness::wait_for_services_ready(&vm_name_owned, timeout);
+        } else {
+            ui::warn("Guest agent not reachable.");
+        }
+
+        // Set up port forwarding via vsock (no guest IP needed) —
+        // requires the agent, so only when the wait above succeeded
+        // AND there are ports to forward.
+        if agent_ready && has_ports {
             let pm_list = parse_port_specs(ports).unwrap_or_default();
 
-            ui::info("Waiting for guest agent...");
-            record_vm_readiness(&vm_name_owned, InstanceReadiness::AgentConnecting);
-            let agent_ready = wait_for_guest_agent(&vm_name_owned, 30);
-            if !agent_ready {
-                ui::warn("Guest agent not reachable — port forwarding unavailable.");
-            } else {
-                record_vm_readiness(&vm_name_owned, InstanceReadiness::AgentReady);
-                // Tell guest agent to start vsock forwarders
-                for pm in &pm_list {
-                    match request_port_forward(&vm_name_owned, pm.guest) {
-                        Ok(vsock_port) => {
-                            ui::info(&format!(
-                                "Guest forwarding vsock:{vsock_port} → tcp/{}",
-                                pm.guest
-                            ));
-                        }
-                        Err(e) => {
-                            ui::warn(&format!(
-                                "Failed to set up guest forwarder for port {}: {e}",
-                                pm.guest
-                            ));
-                        }
+            // Tell guest agent to start vsock forwarders
+            for pm in &pm_list {
+                match request_port_forward(&vm_name_owned, pm.guest) {
+                    Ok(vsock_port) => {
+                        ui::info(&format!(
+                            "Guest forwarding vsock:{vsock_port} → tcp/{}",
+                            pm.guest
+                        ));
+                    }
+                    Err(e) => {
+                        ui::warn(&format!(
+                            "Failed to set up guest forwarder for port {}: {e}",
+                            pm.guest
+                        ));
                     }
                 }
-
-                // Start host-side proxies
-                for pm in &pm_list {
-                    mvm_providers::apple_container::start_port_proxy(
-                        &vm_name_owned,
-                        pm.host,
-                        pm.guest,
-                    );
-                    ui::info(&format!(
-                        "Forwarding localhost:{} → guest tcp/{} (vsock)",
-                        pm.host, pm.guest
-                    ));
-                }
-
-                // Persist port mappings so `ps` can display them
-                let ports_str: Vec<String> = pm_list
-                    .iter()
-                    .map(|p| format!("{}:{}", p.host, p.guest))
-                    .collect();
-                let ports_file = format!(
-                    "{}/.mvm/vms/{}/ports",
-                    std::env::var("HOME").unwrap_or_default(),
-                    vm_name_owned
-                );
-                let _ = std::fs::write(&ports_file, ports_str.join(","));
             }
+
+            // Start host-side proxies
+            for pm in &pm_list {
+                mvm_providers::apple_container::start_port_proxy(&vm_name_owned, pm.host, pm.guest);
+                ui::info(&format!(
+                    "Forwarding localhost:{} → guest tcp/{} (vsock)",
+                    pm.host, pm.guest
+                ));
+            }
+
+            // Persist port mappings so `ps` can display them
+            let ports_str: Vec<String> = pm_list
+                .iter()
+                .map(|p| format!("{}:{}", p.host, p.guest))
+                .collect();
+            let ports_file = format!(
+                "{}/.mvm/vms/{}/ports",
+                std::env::var("HOME").unwrap_or_default(),
+                vm_name_owned
+            );
+            let _ = std::fs::write(&ports_file, ports_str.join(","));
+        } else if !agent_ready && has_ports {
+            ui::warn("Port forwarding unavailable — guest agent not reachable.");
         }
 
         ui::info(&format!(

--- a/crates/mvm-core/src/user_config.rs
+++ b/crates/mvm-core/src/user_config.rs
@@ -39,8 +39,33 @@ pub struct MvmConfig {
     pub metrics_port: Option<u16>,
     /// URL for remote image catalog. None means use bundled catalog only.
     pub catalog_url: Option<String>,
+    /// Maximum wall-clock seconds `mvmctl up` waits for every guest
+    /// integration's readiness probe to flip to `Active` before giving
+    /// up and leaving `InstanceReadiness` at `ServicesStarting {
+    /// pending }` (ADR-050 §3 / plan 74 W2). VMs with no integrations
+    /// transition to `ServicesReady` immediately; this only matters
+    /// for VMs that declare `after_start.sh` health hooks.
+    ///
+    /// Default: 30 seconds. Override via the `MVM_SERVICES_HEALTH_TIMEOUT_SECS`
+    /// environment variable when ad-hoc tuning beats a config edit.
+    pub services_health_timeout_secs: u64,
     /// Security-related operator preferences (`[security]` section).
     pub security: SecurityConfig,
+}
+
+impl MvmConfig {
+    /// Resolve the effective services-health timeout, honoring an
+    /// `MVM_SERVICES_HEALTH_TIMEOUT_SECS` env-var override over the
+    /// config field. Env-var takes precedence so a single shell
+    /// session can stretch the wait without persisting a change.
+    pub fn effective_services_health_timeout_secs(&self) -> u64 {
+        if let Ok(raw) = std::env::var("MVM_SERVICES_HEALTH_TIMEOUT_SECS")
+            && let Ok(n) = raw.trim().parse::<u64>()
+        {
+            return n;
+        }
+        self.services_health_timeout_secs
+    }
 }
 
 impl Default for MvmConfig {
@@ -53,6 +78,7 @@ impl Default for MvmConfig {
             log_format: None,
             metrics_port: None,
             catalog_url: None,
+            services_health_timeout_secs: 30,
             security: SecurityConfig::default(),
         }
     }
@@ -210,6 +236,38 @@ mod tests {
         assert!(cfg.metrics_port.is_none());
         // Security defaults: ack_docker_tier off — banner emits unless suppressed.
         assert!(!cfg.security.ack_docker_tier);
+        // ADR-050 §3 / plan 74 W2 default: 30 s services-health wait.
+        assert_eq!(cfg.services_health_timeout_secs, 30);
+    }
+
+    #[test]
+    fn test_effective_services_health_timeout_honors_env_var_override() {
+        // Save + restore the env var so the test doesn't leak state.
+        let saved = std::env::var("MVM_SERVICES_HEALTH_TIMEOUT_SECS").ok();
+
+        // Clean slate: with no override, the config field wins.
+        // SAFETY: tests are serial in this module and we restore below.
+        unsafe { std::env::remove_var("MVM_SERVICES_HEALTH_TIMEOUT_SECS") };
+        let cfg = MvmConfig {
+            services_health_timeout_secs: 7,
+            ..MvmConfig::default()
+        };
+        assert_eq!(cfg.effective_services_health_timeout_secs(), 7);
+
+        // With a valid override, the env-var value wins.
+        unsafe { std::env::set_var("MVM_SERVICES_HEALTH_TIMEOUT_SECS", "120") };
+        assert_eq!(cfg.effective_services_health_timeout_secs(), 120);
+
+        // Garbage in the env var falls back to the config field
+        // rather than panicking — operator typos do not break boot.
+        unsafe { std::env::set_var("MVM_SERVICES_HEALTH_TIMEOUT_SECS", "not-a-number") };
+        assert_eq!(cfg.effective_services_health_timeout_secs(), 7);
+
+        // Restore the original env value.
+        match saved {
+            Some(v) => unsafe { std::env::set_var("MVM_SERVICES_HEALTH_TIMEOUT_SECS", v) },
+            None => unsafe { std::env::remove_var("MVM_SERVICES_HEALTH_TIMEOUT_SECS") },
+        }
     }
 
     #[test]


### PR DESCRIPTION
## Summary

After `AgentReady` fires in \`mvmctl up\`, the host now polls the guest's \`IntegrationStatus\` every second until every integration reports \`Active\` (or the configured timeout elapses), surfacing the transitions on the VM's registry entry so \`mvmctl ls --json\` shows \`services_starting\` with the pending service names, then \`services_ready\`.

**Unconditional wait** — previously only fired when port forwarding was requested. Lifting the gate means every up records the full chain: \`LaunchAccepted\` → \`AgentConnecting\` → \`AgentReady\` → \`ServicesStarting\` → \`ServicesReady\`, not just port-forwarded VMs.

## Config

New \`MvmConfig.services_health_timeout_secs\` (default **30 s**). Override hierarchy: \`MVM_SERVICES_HEALTH_TIMEOUT_SECS\` env var → config field → default. Garbage env values fall back to the config field rather than panicking.

## What this PR explicitly doesn't do — the \`Degraded\` plan

\`Degraded { unhealthy }\` requires polling *after* \`ServicesReady\`, which is out of scope here. Three follow-up paths, documented in the commit body and in code:

1. **Foreground Ctrl+C-loop polling** — extend the non-detach wait loop in \`mvmctl up\` to keep polling integration health every N seconds. Flips readiness to \`Degraded { unhealthy }\` on any \`Active\` → \`Error\` transition; recovers to \`ServicesReady\` when the service comes back. Covers foreground-attached VMs.
2. **Lazy refresh on \`mvmctl ls\`** — when the user runs \`mvmctl ls\`, ping every running VM's agent, refresh \`IntegrationStatus\`, update the registry, then render. Slower \`ls\` but covers detached / launchd VMs without a daemon.
3. **Reaper-tick refresh** — fold an integration-health poll into the supervisor reaper's per-VM tick when wave 3 lands. Full coverage but biggest change.

Recommendation order: (1) next, (2) after, (3) when wave 3 is in flight.

## Files

- \`crates/mvm-core/src/user_config.rs\` — new field, \`effective_services_health_timeout_secs()\` helper, two new tests.
- \`crates/mvm-cli/src/commands/vm/readiness.rs\` — new \`wait_for_services_ready\` helper with bounded synchronous polling loop. Only writes to the registry when the \`ServicesHealthSnapshot\` *changes*, so the file doesn't thrash every tick when nothing moved. Three classifier unit tests.
- \`crates/mvm-cli/src/commands/vm/up.rs\` — two \`AgentReady\` sites restructured: agent wait lifted out of the port-forward conditional. \`RunParams\` gains \`services_health_timeout_secs\` so \`cmd_run\` doesn't re-read \`MvmConfig\`. Port-forwarding moved to a separate \`if agent_ready && has_ports\` block.
- \`crates/mvm-backend/src/mock_guest_agent.rs\` — new dispatch arm for \`GuestRequest::IntegrationStatus\` returning an empty list. Mock VMs transition straight to \`ServicesReady\` instead of timing out on the catch-all error.

## UX impact

Every \`mvmctl up\` invocation now waits for the guest agent (up to 30 s default) and polls integration health. For VMs with no integrations (including mock-backend) the wait is fast — empty integration list → immediate \`ServicesReady\`. For VMs with integrations, the user gets accurate \`mvmctl ls --json\` output during boot.

\`--detach\` mode still skips the entire wait — detach users opted for fast exit explicitly.

## Test plan

- [x] \`cargo fmt -- --check\` clean
- [x] \`cargo check --workspace\` clean
- [x] \`cargo test --workspace --no-fail-fast\` exits 0 (one new mvm-core test for the env-var override, three new readiness classifier tests)
- [x] \`cargo clippy --workspace --all-targets -- -D warnings\` clean
- [ ] CI green on this PR

## Notes

- Part 2/3 of the three-PR sequence after #263 (\`Stopping\` milestone). Next: W4 backpressure (\`ProcWaitEvent::Backpressure\`).
- Mock backend already had \`ProtocolHello\` dispatch from #242 + a per-connection request loop. This PR only adds the \`IntegrationStatus\` arm; the loop infrastructure handles the new request type without changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)