### PR TITLE
Build builder VM image via local Stage 0

### DIFF
--- a/crates/mvm-build/src/libkrun_builder.rs
+++ b/crates/mvm-build/src/libkrun_builder.rs
@@ -105,7 +105,7 @@ pub const GUEST_JOB_DIR: &str = "/job";
 /// `/out` virtio-fs mount, and tears the VM down. No persistent
 /// state on the struct; the `/nix`-store image lives on the host
 /// filesystem and survives across invocations.
-#[derive(Debug, Clone, Copy)]
+#[derive(Debug, Clone)]
 pub struct LibkrunBuilderVm {
     /// Guest vCPU count. See [`DEFAULT_VCPUS`].
     pub vcpus: u8,
@@ -114,6 +114,15 @@ pub struct LibkrunBuilderVm {
     /// Persistent `/nix`-store image size in MiB (sparse cap).
     /// See [`DEFAULT_NIX_STORE_MIB`].
     pub nix_store_mib: u32,
+    /// Optional caller-supplied bootstrap image. When set, `run_build`
+    /// boots from this kernel/rootfs/cmdline instead of looking up the
+    /// builder VM image in `~/.cache/mvm/builder-vm/<arch>/`.
+    ///
+    /// This is the Stage 0 escape from the chicken-and-egg on source
+    /// checkouts: a local dev image that contains `/sbin/mvm-builder-init`
+    /// can build the real builder VM image without downloading a
+    /// published builder-VM artifact.
+    pub image_override: Option<BuilderVmImage>,
 }
 
 impl Default for LibkrunBuilderVm {
@@ -122,6 +131,7 @@ impl Default for LibkrunBuilderVm {
             vcpus: DEFAULT_VCPUS,
             memory_mib: DEFAULT_MEMORY_MIB,
             nix_store_mib: DEFAULT_NIX_STORE_MIB,
+            image_override: None,
         }
     }
 }
@@ -141,6 +151,13 @@ impl LibkrunBuilderVm {
     /// in one warm store.
     pub fn with_nix_store_mib(mut self, mib: u32) -> Self {
         self.nix_store_mib = mib;
+        self
+    }
+
+    /// Boot from a caller-supplied kernel/rootfs/cmdline instead of
+    /// resolving the builder VM image from `~/.cache/mvm/builder-vm/`.
+    pub fn with_image_override(mut self, image: BuilderVmImage) -> Self {
+        self.image_override = Some(image);
         self
     }
 
@@ -265,8 +282,13 @@ impl BuilderVm for LibkrunBuilderVm {
 
         // 4. Find or initialise the builder VM image (kernel +
         //    rootfs.ext4 + canonical cmdline) the W2 flake
-        //    produces.
-        let image = ensure_builder_vm_image()?;
+        //    produces. Stage 0 callers can provide a bootstrap
+        //    image so a fresh source checkout can build the builder
+        //    image cache without first downloading it.
+        let image = match &self.image_override {
+            Some(image) => image.clone(),
+            None => ensure_builder_vm_image()?,
+        };
 
         // 5. Allocate / locate the persistent `/nix-store`
         //    virtio-blk image. First build on a host pays the
@@ -365,12 +387,23 @@ impl BuilderVm for LibkrunBuilderVm {
 // reads top-down.
 // ─────────────────────────────────────────────────────────────────
 
-/// Resolved builder VM image — the W2 flake output the libkrun
-/// launcher boots into.
-struct BuilderVmImage {
-    kernel_path: PathBuf,
-    rootfs_path: PathBuf,
-    cmdline: String,
+/// Resolved builder VM image — either the W2 flake output the
+/// libkrun launcher boots into, or a caller-supplied Stage 0 image.
+#[derive(Debug, Clone)]
+pub struct BuilderVmImage {
+    pub kernel_path: PathBuf,
+    pub rootfs_path: PathBuf,
+    pub cmdline: String,
+}
+
+impl BuilderVmImage {
+    pub fn new(kernel_path: PathBuf, rootfs_path: PathBuf, cmdline: String) -> Self {
+        Self {
+            kernel_path,
+            rootfs_path,
+            cmdline,
+        }
+    }
 }
 
 /// Parsed `/job/result` written by `mvm-builder-init` (Plan 72 W3).

--- a/crates/mvm-cli/src/commands/env/apple_container.rs
+++ b/crates/mvm-cli/src/commands/env/apple_container.rs
@@ -1914,6 +1914,17 @@ fn bootstrap_builder_vm_image_via_dev_image_stage0(
     Ok(())
 }
 
+#[cfg(not(feature = "builder-vm"))]
+fn bootstrap_builder_vm_image_via_dev_image_stage0(
+    builder_flake_dir: &str,
+    _out_dir: &str,
+) -> Result<()> {
+    anyhow::bail!(
+        "cannot build builder VM image from source checkout at {builder_flake_dir}: \
+         mvm-cli was built without the `builder-vm` feature"
+    )
+}
+
 #[cfg(feature = "builder-vm")]
 fn builder_vm_stage0_bootstrap_plan(
     builder_flake_dir: &str,

--- a/crates/mvm-cli/src/commands/env/apple_container.rs
+++ b/crates/mvm-cli/src/commands/env/apple_container.rs
@@ -1833,6 +1833,13 @@ fn bootstrap_builder_vm_image() -> Result<()> {
             ui::info(&format!("Builder VM image already cached at {out_dir}."));
             Ok(())
         }
+        BuilderVmBootstrapAction::BuildFromSource { flake_dir } => {
+            ui::info(&format!(
+                "Builder VM image not in cache; building locally from {flake_dir}..."
+            ));
+            bootstrap_builder_vm_image_via_dev_image_stage0(&flake_dir, &out_dir)
+                .context("building the source-checkout builder VM image")
+        }
         BuilderVmBootstrapAction::DownloadPublished => {
             ui::info(&format!(
                 "Builder VM image not in cache; downloading published prebuilt for v{}...",
@@ -1843,9 +1850,10 @@ fn bootstrap_builder_vm_image() -> Result<()> {
     }
 }
 
-#[derive(Debug, Clone, Copy, Eq, PartialEq)]
+#[derive(Debug, Clone, Eq, PartialEq)]
 enum BuilderVmBootstrapAction {
     UseCached,
+    BuildFromSource { flake_dir: String },
     DownloadPublished,
 }
 
@@ -1858,14 +1866,91 @@ fn resolve_builder_vm_bootstrap_action(
     }
 
     match builder_flake {
-        Ok(flake_dir) => anyhow::bail!(
-            "builder VM image cache is missing, and this mvmctl was built from a source checkout \
-             with a local builder VM flake at {flake_dir}. Refusing to download a published \
-             builder VM prebuilt because it would mask local changes. Build the builder VM image \
-             from nix/images/builder-vm/flake.nix and populate ~/.cache/mvm/builder-vm/<arch>/{{vmlinux,rootfs.ext4}}."
-        ),
+        Ok(flake_dir) => Ok(BuilderVmBootstrapAction::BuildFromSource { flake_dir }),
         Err(_) => Ok(BuilderVmBootstrapAction::DownloadPublished),
     }
+}
+
+#[cfg(feature = "builder-vm")]
+const STAGE0_BOOTSTRAP_CMDLINE: &str =
+    "console=hvc0 root=/dev/vda ro rootfstype=ext4 init=/sbin/mvm-builder-init";
+
+#[cfg(feature = "builder-vm")]
+fn bootstrap_builder_vm_image_via_dev_image_stage0(
+    builder_flake_dir: &str,
+    out_dir: &str,
+) -> Result<()> {
+    use mvm_build::builder_vm::BuilderVm as _;
+    use mvm_build::libkrun_builder::LibkrunBuilderVm;
+
+    let (kernel, rootfs, source_label) = find_local_fallback_image().ok_or_else(|| {
+        anyhow::anyhow!(
+            "source checkout builder VM cache is missing and no local dev image cache was found \
+             under ~/.mvm/dev/prebuilt/v*/ or ~/.mvm/dev/builds/*/. Refusing to download a \
+             published builder VM prebuilt. Import or build a dev image that contains \
+             /sbin/mvm-builder-init, then retry `mvmctl dev up`."
+        )
+    })?;
+
+    ui::info(&format!(
+        "Using local dev image cache ({source_label}) as Stage 0 bootstrap image."
+    ));
+    let (job, mounts, bootstrap_image) =
+        builder_vm_stage0_bootstrap_plan(builder_flake_dir, out_dir, kernel, rootfs)?;
+
+    LibkrunBuilderVm::default()
+        .with_image_override(bootstrap_image)
+        .run_build(&job, &mounts)
+        .map_err(|e| anyhow::anyhow!("Stage 0 builder VM build: {e}"))?;
+
+    let kernel = format!("{out_dir}/vmlinux");
+    let rootfs = format!("{out_dir}/rootfs.ext4");
+    if !std::path::Path::new(&kernel).is_file() {
+        anyhow::bail!("Stage 0 builder VM build did not produce {kernel}");
+    }
+    if !std::path::Path::new(&rootfs).is_file() {
+        anyhow::bail!("Stage 0 builder VM build did not produce {rootfs}");
+    }
+    Ok(())
+}
+
+#[cfg(feature = "builder-vm")]
+fn builder_vm_stage0_bootstrap_plan(
+    builder_flake_dir: &str,
+    out_dir: &str,
+    bootstrap_kernel: std::path::PathBuf,
+    bootstrap_rootfs: std::path::PathBuf,
+) -> Result<(
+    mvm_build::builder_vm::BuilderJob,
+    mvm_build::builder_vm::BuilderMounts,
+    mvm_build::libkrun_builder::BuilderVmImage,
+)> {
+    use mvm_build::builder_vm::{BuilderJob, BuilderMounts, host_system_linux};
+    use mvm_build::libkrun_builder::BuilderVmImage;
+
+    let workspace_root = std::path::Path::new(builder_flake_dir)
+        .parent()
+        .and_then(|p| p.parent())
+        .and_then(|p| p.parent())
+        .ok_or_else(|| anyhow::anyhow!("Cannot derive workspace root from {builder_flake_dir}"))?
+        .to_path_buf();
+
+    let job = BuilderJob::Flake {
+        flake_ref: "path:/work/nix/images/builder-vm".to_string(),
+        attr_path: format!("packages.{}.default", host_system_linux()),
+    };
+    let mounts = BuilderMounts {
+        flake_src: workspace_root,
+        host_nix_store: None,
+        artifact_out: std::path::PathBuf::from(out_dir),
+    };
+    let bootstrap_image = BuilderVmImage::new(
+        bootstrap_kernel,
+        bootstrap_rootfs,
+        STAGE0_BOOTSTRAP_CMDLINE.to_string(),
+    );
+
+    Ok((job, mounts, bootstrap_image))
 }
 
 /// Download the per-arch Layer 1 builder VM artifacts published by the
@@ -2495,21 +2580,19 @@ mod builder_vm_bootstrap_tests {
     }
 
     #[test]
-    fn builder_vm_bootstrap_source_checkout_refuses_prebuilt_download_on_cache_miss() {
-        let err = resolve_builder_vm_bootstrap_action(
+    fn builder_vm_bootstrap_source_checkout_builds_from_source_on_cache_miss() {
+        let action = resolve_builder_vm_bootstrap_action(
             Ok("/repo/nix/images/builder-vm".to_string()),
             false,
         )
-        .expect_err("source checkout cache miss must not download a published prebuilt");
+        .expect("source checkout cache miss should route to local source build");
 
-        let msg = format!("{err:#}");
-        assert!(msg.contains("source checkout"), "{msg}");
-        assert!(
-            msg.contains("Refusing to download a published builder VM prebuilt"),
-            "{msg}"
+        assert_eq!(
+            action,
+            BuilderVmBootstrapAction::BuildFromSource {
+                flake_dir: "/repo/nix/images/builder-vm".to_string()
+            }
         );
-        assert!(msg.contains("nix/images/builder-vm/flake.nix"), "{msg}");
-        assert!(msg.contains("~/.cache/mvm/builder-vm/<arch>"), "{msg}");
     }
 
     #[test]
@@ -2519,6 +2602,47 @@ mod builder_vm_bootstrap_tests {
                 .expect("installed binaries may use published prebuilts");
 
         assert_eq!(action, BuilderVmBootstrapAction::DownloadPublished);
+    }
+
+    #[test]
+    fn builder_vm_stage0_bootstrap_plan_targets_builder_vm_flake() {
+        let (job, mounts, image) = builder_vm_stage0_bootstrap_plan(
+            "/repo/nix/images/builder-vm",
+            "/cache/builder-vm/aarch64",
+            std::path::PathBuf::from("/dev-cache/vmlinux"),
+            std::path::PathBuf::from("/dev-cache/rootfs.ext4"),
+        )
+        .expect("valid builder flake path should produce a plan");
+
+        match job {
+            mvm_build::builder_vm::BuilderJob::Flake {
+                flake_ref,
+                attr_path,
+            } => {
+                assert_eq!(flake_ref, "path:/work/nix/images/builder-vm");
+                assert!(
+                    attr_path == "packages.aarch64-linux.default"
+                        || attr_path == "packages.x86_64-linux.default",
+                    "unexpected attr path: {attr_path}"
+                );
+            }
+            other => panic!("unexpected stage0 job: {other:?}"),
+        }
+        assert_eq!(mounts.flake_src, std::path::PathBuf::from("/repo"));
+        assert!(mounts.host_nix_store.is_none());
+        assert_eq!(
+            mounts.artifact_out,
+            std::path::PathBuf::from("/cache/builder-vm/aarch64")
+        );
+        assert_eq!(
+            image.kernel_path,
+            std::path::PathBuf::from("/dev-cache/vmlinux")
+        );
+        assert_eq!(
+            image.rootfs_path,
+            std::path::PathBuf::from("/dev-cache/rootfs.ext4")
+        );
+        assert_eq!(image.cmdline, STAGE0_BOOTSTRAP_CMDLINE);
     }
 
     #[test]

--- a/nix/images/builder/flake.nix
+++ b/nix/images/builder/flake.nix
@@ -111,9 +111,36 @@
         nix git gnumake curl jq iproute2 iptables e2fsprogs util-linux procps
       ];
 
+      # Stage 0 bootstrap support: source checkouts must not download
+      # a published builder-VM image. When the real builder-VM cache is
+      # empty, mvmctl can boot an already-cached dev image with
+      # `init=/sbin/mvm-builder-init` and ask it to build
+      # `nix/images/builder-vm`. That requires the dev image to carry
+      # the same PID-1 binary, even though normal `mvmctl dev up`
+      # boots via `/init`.
+      mvmBuilderInitFor = system:
+        let
+          pkgs = import nixpkgs { inherit system; };
+        in
+        pkgs.rustPlatform.buildRustPackage {
+          pname = "mvm-builder-init";
+          version = "0.14.0";
+          src = workspace;
+          cargoLock = {
+            lockFile = workspace + "/Cargo.lock";
+          };
+          buildAndTestSubdir = "crates/mvm-builder-init";
+          doCheck = false;
+          meta = {
+            description = "PID-1 for local builder VM bootstrap";
+            mainProgram = "mvm-builder-init";
+          };
+        };
+
       mkBuilderImage = system:
         let
           pkgs = import nixpkgs { inherit system; };
+          builderInit = mvmBuilderInitFor system;
           # Stock nixpkgs kernel. Pass it to `mkGuest` so the rootfs
           # ships its module tree (`/lib/modules/<kver>/`) and `/init`
           # can `modprobe vmw_vsock_virtio_transport` before the agent
@@ -126,6 +153,10 @@
             entrypoint.shell = "/bin/sh";
             packages = builderPackages pkgs;
             kernel = kernelPkg;
+            extraFiles = {
+              "/sbin/mvm-builder-init" =
+                "${builderInit}/bin/mvm-builder-init";
+            };
           };
           kernelFile =
             if pkgs.stdenv.hostPlatform.isAarch64

--- a/public/src/content/docs/guides/builder-vm.md
+++ b/public/src/content/docs/guides/builder-vm.md
@@ -139,7 +139,7 @@ The builder VM keeps build state warm so repeated builds avoid re-fetching the w
 
 The first build is allowed to be slower because it may bootstrap the builder image and populate the Nix store. Later builds should be dominated by changed inputs.
 
-When `mvmctl` is running from this source checkout, the builder image is local-build only. A populated `~/.cache/mvm/builder-vm/<arch>/` cache can be reused, but a cache miss fails with an actionable error instead of downloading a published builder image. This preserves the contributor invariant that edits under `nix/images/builder-vm/` are reflected by the next local build path and are never masked by release artifacts.
+When `mvmctl` is running from this source checkout, the builder image is local-build only. A populated `~/.cache/mvm/builder-vm/<arch>/` cache can be reused. On cache miss, mvm uses a local dev image that contains `/sbin/mvm-builder-init` as a Stage 0 bootstrap image to build `nix/images/builder-vm/` into the cache. If no suitable local dev image exists, the command fails closed instead of downloading a published builder image. This preserves the contributor invariant that edits under `nix/images/builder-vm/` are reflected by the next local build path and are never masked by release artifacts.
 
 ## Benchmarking Runtime Boot
 

--- a/public/src/content/docs/install/macos.md
+++ b/public/src/content/docs/install/macos.md
@@ -80,7 +80,7 @@ mvmctl init
 mvmctl run
 ```
 
-`mvmctl init` scaffolds the project. On first `mvmctl run`, mvm bootstraps the builder VM if needed, runs `nix build` inside it, and boots the resulting rootfs with the selected macOS runtime backend. Expected runtime cold boot is measured after the image is already built. When developing from this source checkout, the builder VM image is local-build only; mvm will not download a published builder image to hide local flake changes.
+`mvmctl init` scaffolds the project. On first `mvmctl run`, mvm bootstraps the builder VM if needed, runs `nix build` inside it, and boots the resulting rootfs with the selected macOS runtime backend. Expected runtime cold boot is measured after the image is already built. When developing from this source checkout, the builder VM image is local-build only; cache misses build from the local `nix/images/builder-vm/` flake using a local dev image as Stage 0, and mvm will not download a published builder image to hide local flake changes.
 
 ## Troubleshooting
 

--- a/specs/SPRINT.md
+++ b/specs/SPRINT.md
@@ -52,6 +52,7 @@ Recent maintenance:
 - [x] Added builder-VM smoke/failure unit coverage for `dev_build`: the test seam now accepts a fake `BuilderVm`, asserts the flake job and mount shape, proves the path does not probe or invoke host-side Nix, fails closed on builder errors, and gives each staging directory a per-build nonce to avoid same-process collisions.
 - [x] Added CLI-level source-checkout policy coverage for `ensure_dev_image`: source dev flakes now require the sibling builder-VM flake, missing libkrun fails before build dispatch, builder failures refuse published-prebuilt fallback, and the installed/prebuilt path remains available only when no source dev flake is detected.
 - [x] Hardened builder-VM image bootstrap policy: source checkouts may reuse an existing local builder image cache, but cache misses now fail closed instead of downloading published builder-VM prebuilts that could mask local `nix/images/builder-vm/` changes.
+- [x] Added the Stage 0 local builder-image bootstrap path: dev images now carry `/sbin/mvm-builder-init`, `LibkrunBuilderVm` accepts an explicit bootstrap image override, and source-checkout builder-cache misses route to a local `nix/images/builder-vm/` build instead of a network artifact fetch.
 
 ## In-flight workstreams
 


### PR DESCRIPTION
## Summary
- add a `LibkrunBuilderVm` image override so Stage 0 can boot from a local bootstrap image instead of the builder-image cache
- route source-checkout builder-cache misses to a local `nix/images/builder-vm` build using a cached dev image, preserving the no-published-builder-prebuilt invariant
- include `/sbin/mvm-builder-init` in the dev image so it can serve as the Stage 0 bootstrap image when booted with the builder-init cmdline
- update builder VM docs and sprint status

## Tests
- `MVM_DATA_DIR="$PWD/.mvm-test" CARGO_TARGET_DIR="$PWD/.mvm-test/target" CARGO_HOME="$PWD/.mvm-test/cargo" CARGO_BUILD_JOBS=1 cargo test -p mvm-cli builder_vm_bootstrap -- --test-threads=1`
- `MVM_DATA_DIR="$PWD/.mvm-test" CARGO_TARGET_DIR="$PWD/.mvm-test/target" CARGO_HOME="$PWD/.mvm-test/cargo" CARGO_BUILD_JOBS=1 cargo test -p mvm-build libkrun_builder -- --test-threads=1`
- `MVM_DATA_DIR="$PWD/.mvm-test" CARGO_TARGET_DIR="$PWD/.mvm-test/target" CARGO_HOME="$PWD/.mvm-test/cargo" CARGO_BUILD_JOBS=1 cargo check -p mvm-build -p mvm-cli --all-targets`
- `MVM_DATA_DIR="$PWD/.mvm-test" CARGO_TARGET_DIR="$PWD/.mvm-test/target" CARGO_HOME="$PWD/.mvm-test/cargo" CARGO_BUILD_JOBS=1 cargo clippy -p mvm-build -p mvm-cli --all-targets -- -D warnings`
- `MVM_DATA_DIR="$PWD/.mvm-test" CARGO_TARGET_DIR="$PWD/.mvm-test/target" CARGO_HOME="$PWD/.mvm-test/cargo" CARGO_BUILD_JOBS=1 cargo test --workspace`

Nix eval/build was not run from the host; per AGENTS.md that belongs in the builder VM / CI Linux lane.
