### PR TITLE
Plan 74 W3 — control plane / data plane inventory doc

### DIFF
--- a/public/src/content/docs/reference/guest-agent.md
+++ b/public/src/content/docs/reference/guest-agent.md
@@ -27,6 +27,104 @@ The agent communicates using **length-prefixed JSON frames** over vsock (Firecra
 
 Request types: `ping`, `status`, `sleep-prep`, `wake`, and more.
 
+## Control plane and data plane
+
+Plan 74 / ADR-050 §4 splits the agent's wire surface into a
+**control plane** (small, single-frame, bounded requests/responses)
+and a **data plane** (streaming or chunked operations where the
+payload size is dominated by user content, not metadata). The
+distinction is load-bearing for the redaction invariant: data-plane
+payload bytes never appear in audit records, readiness messages,
+progress events, backpressure events, or receipts. The control
+plane is fully tracked in those surfaces; the data plane carries
+hashes and counts only.
+
+Every verb in the table below is also gated by an agent profile
+(see "Profile gate" below) — but the control-plane / data-plane
+split is **orthogonal**. `Exec` (dev-only) is a data-plane verb;
+`Ping` (always available) is control-plane.
+
+### Control-plane verbs
+
+Small bounded JSON in / small bounded JSON out. Maximum response
+frame size is `MAX_FRAME_SIZE = 256 KiB` (`crates/mvm-guest/src/vsock.rs`).
+No streaming. No payload bytes from user processes.
+
+| Verb | Response shape | Notes |
+|---|---|---|
+| `ProtocolHello` | `ProtocolHelloAck` / `ProtocolMismatch` | Required first request in every session (ADR-050 §1, hard cutover). |
+| `Ping` | `Pong` | Reachability probe. Requires `Ping` capability. |
+| `WorkerStatus` | `WorkerStatus { status, last_busy_at }` | Idle/busy sampled from `/proc/loadavg`. |
+| `ReadinessStatus` | `ReadinessStatusReport` | Component-level readiness (see "Readiness model" below). |
+| `IntegrationStatus` | `IntegrationStatusReport { integrations: Vec<…> }` | One per declared integration. Used by `mvmctl ls --json` readiness column (plan 74 W2). |
+| `EntrypointStatus` | `EntrypointStatusReport` | Validation result + warm-pool state. |
+| `ProbeStatus` | `ProbeStatusReport { probes: Vec<ProbeResult> }` | One per declared probe. |
+| `SleepPrep` / `Wake` / `PostRestore` / `CheckpointIntegrations` | Ack | Snapshot lifecycle handshakes. |
+| `UpdateIdleTimeout` | Ack with previous + new values | Adjusts the idle-eviction window. |
+| `MountVolume` / `UnmountVolume` | `MountVolumeResult` (closed enum) | Volume metadata only — no file contents. |
+| `StartPortForward` | `PortForwardStarted { vsock_port, … }` | Sets up a vsock→TCP forwarder. The data plane on that forwarder is byte-for-byte; the *control* plane that asks for it is one frame. |
+| `ProcStart` / `ProcSignal` / `ProcKill` / `ProcList` | `ProcResult` (closed enum) | Process control. `ProcStart` accepts an `argv` up to capped length but does not echo it back. |
+| `FsStat` / `FsList` / `FsMkdir` / `FsRemove` / `FsMove` | `FsResult` (closed enum) | Filesystem metadata. `FsList` truncates at `max_entries` and reports `truncated: true`. |
+| `ConsoleOpen` / `ConsoleClose` / `ConsoleResize` | Ack with vsock port | Allocates a PTY forwarder. The PTY itself runs on a different vsock port — that's the data plane. |
+
+### Data-plane verbs
+
+Streaming, chunked, or potentially-large bounded transfers. Each
+data-plane verb names its frame cap, chunk size, terminal event,
+and backpressure behavior below.
+
+| Verb | Flow | Frame cap | Chunk size | Terminal | Backpressure | Payload in audit? |
+|---|---|---|---|---|---|---|
+| `RunEntrypoint` | Single request → stream of `EntrypointEvent`s | `MAX_FRAME_SIZE` per event | Stdout/stderr drained per agent tick | `Exit { code }` / `Killed { signal }` / `TimedOut` / `Error` | None today (W4 wires the next slice). | No. Hash of stdout/stderr appears in receipts (plan 74 W6); raw bytes do not. |
+| `ProcWait` | Single request → stream of `ProcWaitEvent`s | `MAX_FRAME_SIZE` per event | Stdout/stderr drained per ~50 ms agent tick | `Exit` / `Killed` / `TimedOut` / `Error` | **`Backpressure { reason: OutputConsumerSlow, detail }`** — rising-edge at 75 % of `Caps::max_output_buffer` (16 MiB prod, plan 74 W4). Non-terminal; wait continues. | No. Output streams to the host live; nothing about chunk content goes to audit. |
+| `ProcSendInput` | Bounded request → ack | Request body capped at `Caps::max_stdin_per_call` (1 MiB prod) | Single-frame | `ProcResult::InputAccepted { bytes_accepted }` | Caller-driven — request body fails closed if it exceeds the cap (no implicit truncation). | No. `bytes_accepted` count only; never stdin bytes. |
+| `FsRead` | Single request → `FsResult::Read { content, total_size }` | `MAX_FRAME_SIZE` per response | The agent caps reads at `max_read_bytes` and reports `total_size` so callers detect short reads. Bigger files require multiple requests with offset/length. | Response itself is the terminal | None — bounded by frame cap. | No. `total_size` and offset/length appear in audit; `content` bytes do not. |
+| `FsWrite` | Bounded request → `FsResult::Write { bytes_written }` | Request body capped at the agent's write cap | Single-frame | Response itself is the terminal | Caller-driven — too-large bodies fail closed. | No. Byte count only. |
+| `Exec` / `RunCode` (dev-only) | Single request → `ExecResult { exit_code, stdout, stderr }` | Each captured stream capped by the dev caps; total response bounded by `MAX_FRAME_SIZE` | One-shot capture; no streaming | Response itself is the terminal | None — dev-only, not exercised in prod. | No. Hash of stdout/stderr can be receipted; raw bytes are not audited. |
+| Console PTY traffic | Bidirectional bytes over a dedicated vsock port (`ConsoleOpen` allocates it) | Per-frame cap defined by the console transport, not `MAX_FRAME_SIZE` | TTY-shaped reads | Caller closes (`ConsoleClose`) or PTY exits | None — interactive, not buffered. | No. Console bytes never enter audit. |
+| Port-forward TCP traffic | Bidirectional bytes over the vsock port returned by `StartPortForward` | None — raw TCP | TCP-shaped reads | TCP teardown | None — kernel TCP. | No. Forwarded bytes never enter audit. |
+| Builder output (builder VM only) | Streamed during `mvm-builder-init` builds | Frame cap on the builder vsock channel | Lines / records | Builder's terminal status | None today; builder egress events (plan 74 W8) will surface backpressure. | No. Build logs are stored next to the receipt; raw bytes never get into audit detail strings. |
+
+### Redaction invariant
+
+The following audit / readiness / progress / receipt surfaces are
+guaranteed by ADR-050 §4 / §5 to **never** contain data-plane
+payload bytes. The list is the authoritative one:
+
+- `~/.mvm/audit/<tenant>.jsonl` chain-signed entries.
+  Detail strings carry IDs, hashes, counts, and policy tags — not
+  argv values, env values, stdin, stdout, stderr, file contents,
+  or filesystem paths inside the guest.
+- `InstanceReadiness::ServicesStarting { pending }` /
+  `Degraded { unhealthy }` — both carry only **service names** (the
+  declared integration `name` field). Health-check command output
+  never appears.
+- `ProcWaitEvent::Backpressure { reason, detail }` — the `detail`
+  string is metadata only: byte counts, threshold, cap. Plan 74 W4
+  unit tests pin this.
+- `BackpressureReason::ServiceHealthPending { pending }` — service
+  names only.
+- Receipts written by `mvmctl run` / `mvmctl up` / `mvmctl build`
+  (plan 74 W6) store hashes and metadata. Raw stdout / stderr /
+  stdin / env / argv values are never written.
+- `mvmctl ls --json` rows — the `readiness` and
+  `last_readiness_change_at` fields render directly from the
+  registry; the registry only stores the closed enum + RFC 3339
+  timestamps.
+
+### Exit checks
+
+Plan 74 W3 calls out two contract checks that this section
+underwrites:
+
+1. **No code path advertises an unbounded single-frame response.**
+   Every entry above either names a frame cap or routes through a
+   streaming surface (`ProcWaitEvent` / `EntrypointEvent` / PTY /
+   raw TCP).
+2. **Docs explicitly state that payload bytes are not included in
+   audit or readiness messages.** The "Redaction invariant"
+   subsection is that statement.
+
 ## Profile gate
 
 Every guest image declares an **agent profile** in its


### PR DESCRIPTION
## Summary

Doc-only PR. Adds a "Control plane and data plane" section to \`public/src/content/docs/reference/guest-agent.md\` fulfilling plan 74 W3. Pins which guest-agent verbs are bounded single-frame requests vs. streaming/chunked data paths, names each data-plane verb's frame cap + chunk size + terminal event + backpressure behavior, and locks in the redaction invariant ADR-050 §4 / §5 require.

## Three subsections

- **Control-plane verbs** — 18 bounded JSON-in/out verbs (\`ProtocolHello\` first since #242 made it the required prelude).
- **Data-plane verbs** — streaming / chunked / bounded-large transfers (\`RunEntrypoint\`, \`ProcWait\` with the new \`Backpressure\` from #277, \`ProcSendInput\`, \`FsRead\` / \`FsWrite\`, dev-only \`Exec\` / \`RunCode\`, console PTY, port-forward TCP, builder output). Each row names frame cap, chunk size, terminal event, backpressure, and audit/payload behavior.
- **Redaction invariant** — authoritative list of audit / readiness / progress / receipt surfaces that never carry data-plane payload bytes.

## Plan 74 W3 exit checks (both addressed inline)

1. ✅ No verb advertises an unbounded single-frame response — every data-plane row names either a frame cap (\`MAX_FRAME_SIZE = 256 KiB\`) or a streaming alternative.
2. ✅ Explicit statement that payload bytes don't enter audit / readiness messages — the redaction-invariant subsection is that statement.

## Test plan

- [x] Markdown renders cleanly (matches the existing page's style + heading hierarchy)
- [x] No Rust changes → no \`cargo\` impact
- [ ] CI green (the Astro docs site is built by \`pages.yml\`; this PR is a section addition in an existing file)

## Notes

- Next workstream per the order we settled on after #281: W5 (first-use DX). That's a much bigger UX piece (workflow-scoped \`mvmctl doctor\` checks, three-command happy path, scaffold templates) and touches actual command surfaces. Separate PR sequence.

🤖 Generated with [Claude Code](https://claude.com/claude-code)