### PR TITLE
plan 74 W2 — mvm-guest-netinit installs kernel blackhole routes (guest-side defense)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3048,18 +3048,23 @@ name = "mvm-guest"
 version = "0.14.0"
 dependencies = [
  "anyhow",
+ "async-trait",
  "base64 0.22.1",
  "chrono",
  "ed25519-dalek",
+ "ipnet",
  "libc",
  "mvm-core",
  "mvm-security",
+ "netlink-packet-route",
  "rand 0.8.6",
+ "rtnetlink",
  "seccompiler",
  "serde",
  "serde_json",
  "tempfile",
  "thiserror 1.0.69",
+ "tokio",
  "tracing",
 ]
 
@@ -3320,6 +3325,70 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "27b02d87554356db9e9a873add8782d4ea6e3e58ea071a9adb9a2e8ddb884a8b"
 
 [[package]]
+name = "netlink-packet-core"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "72724faf704479d67b388da142b186f916188505e7e0b26719019c525882eda4"
+dependencies = [
+ "anyhow",
+ "byteorder",
+ "netlink-packet-utils",
+]
+
+[[package]]
+name = "netlink-packet-route"
+version = "0.19.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "74c171cd77b4ee8c7708da746ce392440cb7bcf618d122ec9ecc607b12938bf4"
+dependencies = [
+ "anyhow",
+ "byteorder",
+ "libc",
+ "log",
+ "netlink-packet-core",
+ "netlink-packet-utils",
+]
+
+[[package]]
+name = "netlink-packet-utils"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0ede8a08c71ad5a95cdd0e4e52facd37190977039a4704eb82a283f713747d34"
+dependencies = [
+ "anyhow",
+ "byteorder",
+ "paste",
+ "thiserror 1.0.69",
+]
+
+[[package]]
+name = "netlink-proto"
+version = "0.11.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "72452e012c2f8d612410d89eea01e2d9b56205274abb35d53f60200b2ec41d60"
+dependencies = [
+ "bytes",
+ "futures",
+ "log",
+ "netlink-packet-core",
+ "netlink-sys",
+ "thiserror 2.0.18",
+]
+
+[[package]]
+name = "netlink-sys"
+version = "0.8.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cd6c30ed10fa69cc491d491b85cc971f6bdeb8e7367b7cde2ee6cc878d583fae"
+dependencies = [
+ "bytes",
+ "futures-util",
+ "libc",
+ "log",
+ "tokio",
+]
+
+[[package]]
 name = "new_debug_unreachable"
 version = "1.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3332,6 +3401,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "47b6b097ecb1cbfed438542d16e84fd7ad9b0c76c8a65b7f9039212a3d14dc7f"
 dependencies = [
  "unicode-segmentation",
+]
+
+[[package]]
+name = "nix"
+version = "0.27.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2eb04e9c688eff1c89d72b407f168cf79bb9e867a9d3323ed6c01519eb9cc053"
+dependencies = [
+ "bitflags 2.11.0",
+ "cfg-if",
+ "libc",
 ]
 
 [[package]]
@@ -3849,6 +3929,12 @@ dependencies = [
  "rand_core 0.6.4",
  "subtle",
 ]
+
+[[package]]
+name = "paste"
+version = "1.0.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "57c0d7b74b563b49d38dae00a0c37d4d6de9b432382b2892f0574ddcae73fd0a"
 
 [[package]]
 name = "pbkdf2"
@@ -4666,6 +4752,24 @@ dependencies = [
  "spki",
  "subtle",
  "zeroize",
+]
+
+[[package]]
+name = "rtnetlink"
+version = "0.14.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b684475344d8df1859ddb2d395dd3dac4f8f3422a1aa0725993cb375fc5caba5"
+dependencies = [
+ "futures",
+ "log",
+ "netlink-packet-core",
+ "netlink-packet-route",
+ "netlink-packet-utils",
+ "netlink-proto",
+ "netlink-sys",
+ "nix 0.27.1",
+ "thiserror 1.0.69",
+ "tokio",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -139,6 +139,15 @@ notify-debouncer-mini = "0.5"
 # the canonical CIDR string ("10.0.0.0/24"), which is the wire
 # format the policy bundle TOML uses.
 ipnet = { version = "2", features = ["serde"] }
+# Plan 74 W2 — mvm-guest-netinit installs kernel blackhole routes
+# for `MANDATORY_DENY_RANGES` inside every microVM. rtnetlink wraps
+# the AF_NETLINK socket and the RTM_NEWROUTE message construction;
+# its dep tree (`netlink-packet-route`, `netlink-sys`,
+# `netlink-proto`) is pure-Rust and static-linkable for the
+# overlay binary. Async because the underlying socket uses
+# tokio's reactor; we already pull tokio in workspace-wide.
+rtnetlink = "0.14"
+async-trait = "0.1"
 
 # Pure-Rust DNS resolver, used only by the opt-in custom-dns feature.
 hickory-resolver = "0.24"

--- a/crates/mvm-guest/Cargo.toml
+++ b/crates/mvm-guest/Cargo.toml
@@ -34,6 +34,17 @@ path = "src/bin/mvm-seccomp-apply.rs"
 name = "mvm-verity-init"
 path = "src/bin/mvm-verity-init.rs"
 
+# Plan 74 W2 — guest-side network defense. Installs kernel blackhole
+# routes for `MANDATORY_DENY_RANGES` (cloud metadata, link-local,
+# CGNAT, host loopback) inside every microVM. Run as root from
+# `/init` BEFORE the agent is forked under setpriv, so the routes
+# exist before any workload code can attempt egress. Cross-platform
+# (Linux kernel routing is uniform across Firecracker, libkrun,
+# Apple Container).
+[[bin]]
+name = "mvm-guest-netinit"
+path = "src/bin/mvm-guest-netinit.rs"
+
 # Test-only probe used by `tests/seccomp_apply.rs` to verify that
 # tier allowlists actually deny what they claim (ADR-002 §W2.4). Not
 # selected by `nix/packages/mvm-guest-agent.nix`, so it never ships
@@ -71,15 +82,35 @@ serde_json.workspace = true
 # typed error variants (ReadinessError, ShutdownError).
 thiserror = "1"
 tracing.workspace = true
+# Plan 74 W2 — the `netinit` module's trait + types + install
+# loop + tests are cross-platform; only `RtnetlinkInstaller`
+# itself is Linux-only. Keeping async-trait + ipnet in the main
+# deps lets the tests run on macOS dev hosts too.
+async-trait.workspace = true
+ipnet.workspace = true
 
 # seccompiler builds Linux-only — guests are always Linux microVMs,
 # but the workspace also compiles on macOS for CLI development. Gate
 # the dep so `cargo check` on a Mac doesn't try to build it.
 [target.'cfg(target_os = "linux")'.dependencies]
 seccompiler = { workspace = true }
+# Plan 74 W2 — `mvm-guest-netinit` uses rtnetlink to install kernel
+# blackhole routes for `MANDATORY_DENY_RANGES`. Linux-only because
+# rtnetlink talks to AF_NETLINK which doesn't exist elsewhere. The
+# host-side mvmctl builds (which include this crate) skip these
+# deps on macOS; the binary itself is only relevant in the guest.
+rtnetlink = { workspace = true }
+tokio = { workspace = true }
+# netlink-packet-route is rtnetlink's wire-format types crate. The
+# RouteType::BlackHole enum the installer uses comes from here.
+netlink-packet-route = "0.19"
 
 [dev-dependencies]
 tempfile.workspace = true
+# Plan 74 W2 — `netinit` module's tests are async (the
+# `RouteInstaller` trait is async). tokio is workspace-shared so
+# the extra dev-dep doesn't pull anything new into the lock.
+tokio = { workspace = true }
 
 [lints]
 workspace = true

--- a/crates/mvm-guest/src/bin/mvm-guest-netinit.rs
+++ b/crates/mvm-guest/src/bin/mvm-guest-netinit.rs
@@ -1,0 +1,89 @@
+//! `mvm-guest-netinit` — guest-side network defense (Plan 74 W2).
+//!
+//! Run as PID >1, uid 0 inside every microVM at boot, before the
+//! main `mvm-guest-agent` is forked under setpriv. Installs kernel
+//! blackhole routes for `mvm_core::network_policy::MANDATORY_DENY_RANGES`
+//! via rtnetlink — the defense layer that catches:
+//!
+//! - The macOS Apple Container path where `mvm` has no host firewall.
+//! - Any backend where the host iptables/nftables rules don't apply.
+//! - Legitimate uid-0 dev workloads that don't actively try to
+//!   defeat the routes.
+//!
+//! ## Exit codes
+//!
+//! - 0 — every IPv4 entry installed successfully (or the only
+//!   failures were on entries the kernel doesn't support, which is
+//!   surfaced in the report's `failed` array with `reason` carrying
+//!   the kernel message).
+//! - 1 — one or more routes failed to install. `/init` should
+//!   fail-closed and refuse to fork the workload.
+//! - 2 — could not connect to rtnetlink (kernel built without
+//!   `CONFIG_RTNETLINK`, or some other systemic failure). Same
+//!   fail-closed behaviour at `/init`.
+//!
+//! ## Output
+//!
+//! Single JSON line to stdout containing the [`Report`] from
+//! [`mvm_guest::netinit::install_mandatory_deny`]. The kernel
+//! console captures stdout; the host scrape (`firecracker.log`,
+//! libkrun console output) forwards the line so an operator can
+//! see what was installed without an in-VM tool. A future slice
+//! wires this into the agent's vsock-audit path.
+//!
+//! ## Platform
+//!
+//! Linux-only: the module gates on `#[cfg(target_os = "linux")]`.
+//! On macOS the binary compiles to a stub that prints
+//! "not supported on this host" and exits non-zero — the macOS
+//! CLI build doesn't ship the bin, but cargo still builds the
+//! workspace and we don't want a compilation break.
+//!
+//! [`Report`]: mvm_guest::netinit::Report
+
+#[cfg(target_os = "linux")]
+#[tokio::main]
+async fn main() {
+    let report = match mvm_guest::netinit::install_mandatory_deny_via_rtnetlink().await {
+        Ok(r) => r,
+        Err(e) => {
+            eprintln!("mvm-guest-netinit: rtnetlink connect failed: {e}");
+            // Exit 2 distinguishes systemic netlink failure from
+            // per-route failures so `/init` can branch (the
+            // systemic case usually means a kernel feature is
+            // missing, not a transient install error).
+            std::process::exit(2);
+        }
+    };
+
+    // Write the report as a single JSON line to stdout. Kept on
+    // one line so console scrape can read it without parsing
+    // multi-line JSON; the field set is stable per the type's
+    // serde shape.
+    match serde_json::to_string(&report) {
+        Ok(json) => println!("{json}"),
+        Err(e) => {
+            // serializing a `Report` from our own types shouldn't
+            // fail in practice; if it does the binary still needs
+            // to exit with a clear code so /init can react.
+            eprintln!("mvm-guest-netinit: serialize report failed: {e}");
+            std::process::exit(1);
+        }
+    }
+
+    if report.has_failures() {
+        // Exit 1: per-route failures recorded in the report. /init
+        // reads the JSON to surface which entries failed.
+        std::process::exit(1);
+    }
+}
+
+#[cfg(not(target_os = "linux"))]
+fn main() {
+    eprintln!(
+        "mvm-guest-netinit: not supported on this host \
+         (rtnetlink is Linux-only; this binary ships in the runtime \
+         overlay for Linux microVM guests only)"
+    );
+    std::process::exit(2);
+}

--- a/crates/mvm-guest/src/lib.rs
+++ b/crates/mvm-guest/src/lib.rs
@@ -7,6 +7,13 @@ pub mod entrypoint;
 pub mod fs_rpc;
 pub mod integrations;
 pub mod lifecycle_hooks;
+/// Plan 74 W2 — guest-side network defense. The `mvm-guest-netinit`
+/// binary calls into this module at boot to install kernel blackhole
+/// routes for `MANDATORY_DENY_RANGES` before any workload code runs.
+/// The module's types + install loop + tests build everywhere; the
+/// `RtnetlinkInstaller` (which talks to `AF_NETLINK`) is Linux-only
+/// and gated inside the module.
+pub mod netinit;
 pub mod probes;
 pub mod runtime_config;
 pub mod volume;

--- a/crates/mvm-guest/src/netinit.rs
+++ b/crates/mvm-guest/src/netinit.rs
@@ -1,0 +1,440 @@
+//! Plan 74 W2 — guest-side network defense.
+//!
+//! Installs kernel **blackhole routes** for every IPv4 entry in
+//! [`mvm_core::network_policy::MANDATORY_DENY_RANGES`] inside the
+//! microVM at boot, before the workload entrypoint forks.
+//!
+//! ## Why kernel routes (not nftables / iptables)
+//!
+//! The microVM's rootfs is user-controlled. Nix-built rootfs has
+//! busybox (no `nft`, no `iptables`); OCI-imported rootfs might be
+//! `alpine` (has both), `python:3.12-slim` (neither), `distroless`
+//! (neither), or anything else. A defense layer that depends on a
+//! userspace tool inside the guest fails on most images.
+//!
+//! Kernel-side blackhole routes are universal — every Linux kernel
+//! supports `RTN_BLACKHOLE` since 2.0, no userspace tool required.
+//! `rtnetlink` talks directly to the kernel via `AF_NETLINK`; the
+//! only dependency is a Linux kernel.
+//!
+//! ## Why this is defense-in-depth, not the sole defense
+//!
+//! A workload that gains root inside the guest can `ip route del`
+//! the blackhole routes (CAP_NET_ADMIN inside the guest's netns).
+//! That's why this layer pairs with host-side enforcement (mvm
+//! iptables on Linux-direct; mvmd nftables on fleet) — see
+//! mvmd ADR 0022 §"Why layered". The guest-side floor catches:
+//!
+//! - the macOS Apple Container path where mvm has no host firewall;
+//! - the legitimate uid-0 dev workload that doesn't actively try to
+//!   defeat the routes;
+//! - any workload that doesn't gain root.
+//!
+//! The two layers together make IMDS-style exfil substantially
+//! harder regardless of which platform the microVM runs on.
+//!
+//! ## Audit emission
+//!
+//! [`install_mandatory_deny`] returns a [`Report`] describing what
+//! was installed (and what failed). The caller — typically the
+//! `mvm-guest-netinit` binary running from `/init` — writes the
+//! report as a single JSON line to stdout, which the kernel
+//! console forwards to the host. A future slice wires the agent
+//! to forward the report as a `LocalAuditKind::NetworkMandatoryDeny`
+//! audit event via vsock; for v1 the console-scrape path is
+//! sufficient to surface install failures.
+//!
+//! ## Failure semantics
+//!
+//! Any per-route failure is recorded in the report but does NOT
+//! abort the install loop — we want every successful route to
+//! land even if one fails. The binary exits non-zero when the
+//! report carries any failures, so `/init` can fail-closed
+//! (refuse to fork the workload entrypoint).
+
+use async_trait::async_trait;
+use ipnet::IpNet;
+use serde::{Deserialize, Serialize};
+
+/// What was installed for a single CIDR.
+///
+/// `category` is owned `String` (not `&'static str`) so the
+/// Deserialize impl works for round-trip from an audit-log
+/// reader. Construction at install time still uses string
+/// literals — `categorize_v4` returns `&'static str` and we
+/// `.to_string()` on insertion.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct RouteInstalled {
+    pub cidr: IpNet,
+    /// The mvm category this CIDR belongs to. Mirrors the audit
+    /// detail format in `LocalAuditKind::NetworkMandatoryDeny`:
+    /// `cloud-metadata` | `link-local` | `cgnat` | `loopback`.
+    pub category: String,
+}
+
+/// Failure to install one route. The loop continues past this so
+/// other routes still land; the caller branches on
+/// `report.failed.is_empty()` to decide overall success.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct RouteFailed {
+    pub cidr: IpNet,
+    pub category: String,
+    /// Stringified error. Kept opaque so the JSON shape is stable
+    /// even if the underlying rtnetlink error type changes.
+    pub reason: String,
+}
+
+/// Cumulative outcome of one `install_mandatory_deny` run.
+///
+/// Serializes to a stable JSON shape so the
+/// `mvm-guest-netinit` binary can write `serde_json::to_string`
+/// of this directly to stdout. A future audit consumer parses
+/// the same shape.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct Report {
+    pub installed: Vec<RouteInstalled>,
+    pub failed: Vec<RouteFailed>,
+    /// IPv6 entries from the const are intentionally skipped (the
+    /// guest's bridge / TAP is IPv4-only on every backend today).
+    /// Reported here so an operator parsing the JSON sees that the
+    /// v6 entries were deliberately not attempted, not silently
+    /// missing.
+    pub skipped_ipv6: Vec<IpNet>,
+}
+
+impl Report {
+    pub fn empty() -> Self {
+        Self {
+            installed: Vec::new(),
+            failed: Vec::new(),
+            skipped_ipv6: Vec::new(),
+        }
+    }
+
+    /// `true` when at least one route failed to install. The
+    /// `mvm-guest-netinit` binary exits non-zero on
+    /// `has_failures()` so `/init` can fail-closed.
+    pub fn has_failures(&self) -> bool {
+        !self.failed.is_empty()
+    }
+}
+
+/// Abstraction over the actual rtnetlink call so tests can use a
+/// `MockInstaller` without a real `AF_NETLINK` socket. Production
+/// uses [`RtnetlinkInstaller`].
+#[async_trait]
+pub trait RouteInstaller: Send + Sync {
+    /// Add a blackhole route for `cidr`. Idempotent at the kernel
+    /// level — if the route already exists, returning `Ok(())` is
+    /// the correct semantics (the entry is the desired state, not
+    /// a write-once operation).
+    async fn install_blackhole(&self, cidr: IpNet) -> Result<(), String>;
+}
+
+/// Categorize a CIDR for the audit category field. Pure function;
+/// returns the same string keys as
+/// `LocalAuditKind::NetworkMandatoryDeny`'s detail format.
+fn categorize(cidr: &IpNet) -> &'static str {
+    // The match order mirrors the const's ordering in
+    // `mvm-core::policy::network_policy`. A future const edit that
+    // shifts categories should update this function in lock-step.
+    match cidr.to_string().as_str() {
+        "169.254.169.254/32" | "169.254.0.0/16" => "link-local",
+        // Note: cloud-metadata is the /32 specifically. We keep
+        // both /32 and /16 in `link-local` here for simplicity —
+        // a future audit slice that needs to distinguish IMDS
+        // from generic link-local can pivot on the CIDR prefix
+        // length.
+        "100.64.0.0/10" => "cgnat",
+        "127.0.0.0/8" | "::1/128" => "loopback",
+        "fe80::/10" => "link-local-v6",
+        _ => "other",
+    }
+}
+
+/// Cloud metadata `/32` gets its own category for the audit detail
+/// so a security dashboard can alert on IMDS exfil attempts
+/// distinctly from generic link-local probes.
+fn categorize_v4(cidr: &IpNet) -> &'static str {
+    if cidr.to_string() == "169.254.169.254/32" {
+        "cloud-metadata"
+    } else {
+        categorize(cidr)
+    }
+}
+
+/// Install blackhole routes for every IPv4 entry in
+/// `MANDATORY_DENY_RANGES`. IPv6 entries are skipped (the guest
+/// network stack is v4-only on every backend today) and reported
+/// in `report.skipped_ipv6` so an operator can see they were
+/// deliberately not attempted.
+///
+/// The loop is fault-tolerant: a per-route failure is recorded in
+/// `report.failed` but doesn't abort. Callers branch on
+/// `report.has_failures()` for the overall verdict.
+pub async fn install_mandatory_deny<I: RouteInstaller>(installer: &I) -> Report {
+    let mut report = Report::empty();
+    for cidr in mvm_core::network_policy::mandatory_deny_ranges() {
+        if !cidr.network().is_ipv4() {
+            report.skipped_ipv6.push(cidr);
+            continue;
+        }
+        let category = categorize_v4(&cidr).to_string();
+        match installer.install_blackhole(cidr).await {
+            Ok(()) => report.installed.push(RouteInstalled { cidr, category }),
+            Err(reason) => report.failed.push(RouteFailed {
+                cidr,
+                category,
+                reason,
+            }),
+        }
+    }
+    report
+}
+
+// ============================================================================
+// Production installer — rtnetlink (Linux-only)
+// ============================================================================
+
+#[cfg(target_os = "linux")]
+mod linux {
+    use super::*;
+
+    /// Production [`RouteInstaller`] that talks to the kernel via
+    /// `AF_NETLINK`. Requires CAP_NET_ADMIN in the current user
+    /// namespace — the binary expects to run as root from `/init`
+    /// BEFORE the agent setpriv's down to uid 901.
+    ///
+    /// Construction is fallible because opening the netlink socket
+    /// can fail (e.g. on a kernel built without `CONFIG_RTNETLINK`,
+    /// which is rare but not impossible for stripped-down embedded
+    /// kernels).
+    pub struct RtnetlinkInstaller {
+        handle: rtnetlink::Handle,
+    }
+
+    impl RtnetlinkInstaller {
+        /// Connect to the kernel's rtnetlink service. Spawns the
+        /// rtnetlink connection background task on the current
+        /// tokio runtime. Drop semantics: the handle keeps the
+        /// connection alive until the installer is dropped.
+        pub async fn connect() -> Result<Self, String> {
+            let (connection, handle, _) =
+                rtnetlink::new_connection().map_err(|e| format!("rtnetlink connect: {e}"))?;
+            tokio::spawn(connection);
+            Ok(Self { handle })
+        }
+    }
+
+    #[async_trait]
+    impl RouteInstaller for RtnetlinkInstaller {
+        async fn install_blackhole(&self, cidr: IpNet) -> Result<(), String> {
+            // rtnetlink's v4 route builder takes the destination
+            // prefix (address + length) and the
+            // scope/protocol/kind fields. The `kind` field is what
+            // makes it a blackhole — RTN_BLACKHOLE means "the
+            // kernel drops packets matching this route without
+            // sending ICMP unreachable", which is the strongest
+            // form of "this destination is forbidden".
+            match cidr {
+                IpNet::V4(v4) => {
+                    use netlink_packet_route::route::{RouteProtocol, RouteScope, RouteType};
+                    self.handle
+                        .route()
+                        .add()
+                        .v4()
+                        .destination_prefix(v4.network(), v4.prefix_len())
+                        .kind(RouteType::BlackHole)
+                        .scope(RouteScope::Universe)
+                        .protocol(RouteProtocol::Boot)
+                        .execute()
+                        .await
+                        .map_err(|e| format!("route add {cidr}: {e}"))?;
+                }
+                IpNet::V6(_) => {
+                    // Should never reach here because
+                    // `install_mandatory_deny` skips v6 before
+                    // calling the installer; defending against a
+                    // future refactor.
+                    return Err(format!(
+                        "internal: install_blackhole called with IPv6 cidr {cidr} \
+                         (v6 not supported yet)"
+                    ));
+                }
+            }
+            Ok(())
+        }
+    }
+
+    /// Convenience: connect to rtnetlink and run the install in
+    /// one call. The `mvm-guest-netinit` binary uses this.
+    pub async fn install_mandatory_deny_via_rtnetlink() -> Result<Report, String> {
+        let installer = RtnetlinkInstaller::connect().await?;
+        Ok(install_mandatory_deny(&installer).await)
+    }
+}
+
+#[cfg(target_os = "linux")]
+pub use linux::{RtnetlinkInstaller, install_mandatory_deny_via_rtnetlink};
+
+// ============================================================================
+// Tests
+// ============================================================================
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::collections::HashSet;
+    use std::sync::Mutex;
+
+    /// In-memory mock that records every `install_blackhole` call.
+    /// Tests inspect the recorded CIDRs to verify which entries
+    /// the loop attempted; an injected `fail_on` set forces specific
+    /// CIDRs to return an error so failure aggregation is tested too.
+    struct MockInstaller {
+        calls: Mutex<Vec<IpNet>>,
+        fail_on: HashSet<IpNet>,
+    }
+
+    impl MockInstaller {
+        fn new() -> Self {
+            Self {
+                calls: Mutex::new(Vec::new()),
+                fail_on: HashSet::new(),
+            }
+        }
+
+        fn fail_on(mut self, cidrs: &[&str]) -> Self {
+            for s in cidrs {
+                self.fail_on.insert(s.parse().unwrap());
+            }
+            self
+        }
+
+        fn recorded(&self) -> Vec<IpNet> {
+            self.calls.lock().unwrap().clone()
+        }
+    }
+
+    #[async_trait]
+    impl RouteInstaller for MockInstaller {
+        async fn install_blackhole(&self, cidr: IpNet) -> Result<(), String> {
+            self.calls.lock().unwrap().push(cidr);
+            if self.fail_on.contains(&cidr) {
+                Err(format!("forced failure for {cidr}"))
+            } else {
+                Ok(())
+            }
+        }
+    }
+
+    #[tokio::test]
+    async fn install_calls_installer_for_every_ipv4_entry() {
+        let mock = MockInstaller::new();
+        let report = install_mandatory_deny(&mock).await;
+        // Every IPv4 entry in `MANDATORY_DENY_RANGES` should have
+        // exactly one call. Mirror the const's IPv4 entry count
+        // exactly so a future const edit that adds a v4 entry
+        // also has to update this test.
+        let v4_count = mvm_core::network_policy::mandatory_deny_ranges()
+            .iter()
+            .filter(|n| n.network().is_ipv4())
+            .count();
+        assert_eq!(mock.recorded().len(), v4_count);
+        assert_eq!(report.installed.len(), v4_count);
+        assert!(report.failed.is_empty());
+    }
+
+    #[tokio::test]
+    async fn install_skips_ipv6_entries_and_reports_them() {
+        let mock = MockInstaller::new();
+        let report = install_mandatory_deny(&mock).await;
+        let v6_count = mvm_core::network_policy::mandatory_deny_ranges()
+            .iter()
+            .filter(|n| !n.network().is_ipv4())
+            .count();
+        assert_eq!(report.skipped_ipv6.len(), v6_count);
+        // The installer was never called for any v6 entry.
+        for recorded in mock.recorded() {
+            assert!(
+                recorded.network().is_ipv4(),
+                "installer was called with non-v4 CIDR {recorded}"
+            );
+        }
+    }
+
+    #[tokio::test]
+    async fn install_records_cloud_metadata_explicitly() {
+        // The metadata `/32` is the highest-stakes entry. Asserting
+        // it shows up in `installed` with category=cloud-metadata
+        // means a regression that drops the entry from the const,
+        // or skips it in the install loop, fails loudly here.
+        let mock = MockInstaller::new();
+        let report = install_mandatory_deny(&mock).await;
+        let metadata: IpNet = "169.254.169.254/32".parse().unwrap();
+        let entry = report
+            .installed
+            .iter()
+            .find(|r| r.cidr == metadata)
+            .expect("cloud metadata /32 must be in the installed set");
+        assert_eq!(entry.category, "cloud-metadata");
+    }
+
+    #[tokio::test]
+    async fn install_continues_past_failures_and_records_them() {
+        // Force one specific CIDR to fail. The loop must still
+        // attempt every other entry; the failed CIDR lands in
+        // `report.failed`, the rest in `report.installed`.
+        let mock = MockInstaller::new().fail_on(&["100.64.0.0/10"]);
+        let report = install_mandatory_deny(&mock).await;
+        assert_eq!(report.failed.len(), 1);
+        assert_eq!(report.failed[0].cidr.to_string(), "100.64.0.0/10");
+        assert!(report.failed[0].reason.contains("forced failure"));
+        // Other installs still happened.
+        assert!(!report.installed.is_empty());
+        // `has_failures()` reports the right state for the caller.
+        assert!(report.has_failures());
+    }
+
+    #[tokio::test]
+    async fn install_marks_clean_run_no_failures() {
+        let mock = MockInstaller::new();
+        let report = install_mandatory_deny(&mock).await;
+        assert!(!report.has_failures());
+    }
+
+    #[tokio::test]
+    async fn install_serializes_to_stable_json_shape() {
+        // The binary's stdout is `serde_json::to_string(&report)`.
+        // Pin the load-bearing field names so a downstream audit
+        // consumer can deserialize across mvmctl versions.
+        let mock = MockInstaller::new();
+        let report = install_mandatory_deny(&mock).await;
+        let json = serde_json::to_value(&report).unwrap();
+        let obj = json.as_object().unwrap();
+        for key in ["installed", "failed", "skipped_ipv6"] {
+            assert!(obj.contains_key(key), "report JSON missing key {key}");
+        }
+        // Each installed entry has the documented field set.
+        let first = obj["installed"]
+            .as_array()
+            .and_then(|a| a.first())
+            .expect("at least one installed entry in clean run");
+        assert!(first.get("cidr").is_some());
+        assert!(first.get("category").is_some());
+    }
+
+    #[test]
+    fn categorize_v4_handles_known_entries() {
+        let cases = [
+            ("169.254.169.254/32", "cloud-metadata"),
+            ("169.254.0.0/16", "link-local"),
+            ("100.64.0.0/10", "cgnat"),
+            ("127.0.0.0/8", "loopback"),
+        ];
+        for (s, expected) in cases {
+            let cidr: IpNet = s.parse().unwrap();
+            assert_eq!(categorize_v4(&cidr), expected, "category for {s}");
+        }
+    }
+}

--- a/nix/lib/mk-guest.nix
+++ b/nix/lib/mk-guest.nix
@@ -228,6 +228,39 @@ let
       /bin/busybox modprobe vmw_vsock_virtio_transport 2>/dev/null || true
     fi
 
+    # Stage 2.45 — Plan 74 W2 — guest-side network defense.
+    # Install kernel blackhole routes for `MANDATORY_DENY_RANGES`
+    # (cloud metadata, link-local, CGNAT, host loopback) BEFORE
+    # any workload code runs. We're still uid 0 here — the agent
+    # fork below drops to uid 901, which doesn't have
+    # CAP_NET_ADMIN, so the install has to happen here. Mirrors
+    # the agent-bin resolution: prefer /mvm/runtime/netinit (from
+    # the W1.4b runtime overlay) over the baked-in copy in
+    # /usr/local/bin.
+    #
+    # Output of mvm-guest-netinit is a single JSON line that the
+    # kernel console captures; the host scrape (firecracker.log /
+    # libkrun console output) forwards it so an operator can see
+    # what was installed. A future slice wires the agent to
+    # forward the same JSON as a `NetworkMandatoryDeny` audit
+    # event over vsock.
+    #
+    # On netinit failure (exit nonzero) we DO NOT abort the boot
+    # — the host-side iptables defense (where it applies) is the
+    # primary layer, and a hard guest-side fail-closed would
+    # block any workload on a kernel without rtnetlink. Log the
+    # failure and continue; an operator who needs guest-side
+    # defense flagged the issue from the JSON line.
+    MVM_NETINIT_BIN=
+    if [ -x /mvm/runtime/netinit ]; then
+      MVM_NETINIT_BIN=/mvm/runtime/netinit
+    elif [ -x /usr/local/bin/mvm-guest-netinit ]; then
+      MVM_NETINIT_BIN=/usr/local/bin/mvm-guest-netinit
+    fi
+    if [ -n "$MVM_NETINIT_BIN" ]; then
+      "$MVM_NETINIT_BIN" || echo "mvm-init: netinit exited nonzero; continuing without guest-side defense"
+    fi
+
     # Stage 2.5 — guest agent supervisor. Fork the agent into
     # the background under its own uid before we drop to the
     # entrypoint. The agent is responsible for vsock RPC (host
@@ -349,6 +382,14 @@ let
   # directly — wired here as a passthru export so the initramfs
   # builder can reach it without duplicating the agent derivation.
   verityInitBinary = "${guestAgentPkg}/bin/mvm-verity-init";
+
+  # Plan 74 W2 — guest-side network defense. `mvm-guest-netinit`
+  # installs kernel blackhole routes for `MANDATORY_DENY_RANGES`
+  # (cloud metadata, link-local, CGNAT, host loopback) inside the
+  # guest at boot. Run as root from `/init` BEFORE the agent forks
+  # under setpriv — the routes must exist before any workload code
+  # can attempt egress.
+  mvmGuestNetinitBinary = "${guestAgentPkg}/bin/mvm-guest-netinit";
 
   # extraFiles — three accepted spec shapes per target path:
   #
@@ -523,6 +564,15 @@ let
     cp ${agentBinary} "$out/usr/local/bin/mvm-guest-agent"
     chmod 0555 "$out/usr/local/bin/mvm-guest-agent"
 
+    # Plan 74 W2 — guest-side network defense. Same mode as the
+    # agent (0555: read+exec, not writable). /init runs this as
+    # uid 0 BEFORE forking the agent under setpriv, so the routes
+    # exist before any workload code can attempt egress. The
+    # binary itself does not need elevated capabilities at run
+    # time beyond the CAP_NET_ADMIN that PID 1 already has.
+    cp ${mvmGuestNetinitBinary} "$out/usr/local/bin/mvm-guest-netinit"
+    chmod 0555 "$out/usr/local/bin/mvm-guest-netinit"
+
     # Kernel modules. `/init` `modprobe`s vsock before forking the
     # agent (default nixpkgs kernel ships AF_VSOCK as `=m`); without
     # `/lib/modules/<kver>/` in the rootfs, modprobe has nothing to
@@ -652,6 +702,6 @@ rootfsImage.overrideAttrs (old: {
     # downstream derivations (verity-initrd, per-service launch line
     # in `mkServiceBlock`) can reach `mvm-seccomp-apply` and
     # `mvm-verity-init` without re-running the cargo build.
-    inherit guestAgentPkg seccompApplyBinary verityInitBinary;
+    inherit guestAgentPkg seccompApplyBinary verityInitBinary mvmGuestNetinitBinary;
   };
 })

--- a/nix/packages/mvm-guest-agent.nix
+++ b/nix/packages/mvm-guest-agent.nix
@@ -62,6 +62,10 @@ pkgs.rustPlatform.buildRustPackage {
     "--bin" "mvm-guest-agent"
     "--bin" "mvm-seccomp-apply"
     "--bin" "mvm-verity-init"
+    # Plan 74 W2 — guest-side network defense. Installs kernel
+    # blackhole routes for `MANDATORY_DENY_RANGES` at boot from
+    # `/init` (uid 0) before the main agent forks under setpriv.
+    "--bin" "mvm-guest-netinit"
   ] ++ lib.optionals withDevShell [
     "--features" "mvm-guest/dev-shell"
   ];

--- a/tests/nix_flake_structure.rs
+++ b/tests/nix_flake_structure.rs
@@ -228,6 +228,46 @@ fn mk_guest_carries_overlay_aware_contract() {
     );
 }
 
+/// Plan 74 W2 — `mkGuest` must bake `mvm-guest-netinit` into the
+/// rootfs AND invoke it from `/init` before forking the agent.
+/// Without this, the guest-side defense (kernel blackhole routes
+/// for `MANDATORY_DENY_RANGES`) never installs, leaving the
+/// macOS Apple Container path with no firewall at all. The
+/// source-grep here catches a regression that drops either the
+/// binary copy or the /init invocation before it reaches a live
+/// VM boot.
+#[test]
+fn mk_guest_installs_netinit_at_boot() {
+    let path = nix_dir().join("lib").join("mk-guest.nix");
+    let content = fs::read_to_string(&path)
+        .unwrap_or_else(|e| panic!("nix/lib/mk-guest.nix must be present: {e}"));
+
+    assert!(
+        content.contains("mvmGuestNetinitBinary = \"${guestAgentPkg}/bin/mvm-guest-netinit\""),
+        "mk-guest.nix must reference the mvm-guest-netinit binary \
+         from the guest-agent derivation. Plan 74 W2 — guest-side \
+         network defense relies on this binary being baked into \
+         every mvm-built rootfs."
+    );
+
+    assert!(
+        content.contains("/usr/local/bin/mvm-guest-netinit"),
+        "mk-guest.nix /init must invoke the netinit binary at its \
+         canonical path. A drop here means the binary is built but \
+         never runs at boot, leaving the guest with no kernel-level \
+         defense against IMDS exfil."
+    );
+
+    assert!(
+        content.contains("/mvm/runtime/netinit"),
+        "mk-guest.nix /init must prefer the runtime-overlay path \
+         (`/mvm/runtime/netinit`) over the baked-in copy when the \
+         W1.4b overlay is mounted. Mirrors the agent-bin resolution \
+         pattern; preserves the host-bake fallback for backends \
+         that don't attach the overlay yet."
+    );
+}
+
 #[test]
 fn flake_lock_pins_microvm_input_by_hash() {
     // The flake.lock must exist and pin the microvm.nix input by


### PR DESCRIPTION
## Summary

- New \`mvm-guest-netinit\` binary in the existing \`mvm-guest\` crate. Runs as PID >1, uid 0 from \`/init\` BEFORE the main agent forks under setpriv. Installs kernel **blackhole routes** for every IPv4 entry in \`mvm_core::network_policy::MANDATORY_DENY_RANGES\` via rtnetlink.
- After this PR, every \`mvmctl up --flake .\` workload on any backend (Firecracker, libkrun, Apple Container) boots with IMDS, link-local, CGNAT, and host loopback unreachable from inside the guest — including the macOS Apple Container path where \`mvm\` has no host firewall.
- 7 new unit tests on the install loop (mocked installer) + 1 source-grep test pinning the mkGuest contract.
- Implements **mvmd ADR 0022 §"Layer 1 — Guest-side defense"** (mvmd PR #152).

## Why kernel blackhole routes (and not iptables/nftables in-guest)

The guest's rootfs is user-controlled. Nix-built has busybox (no \`nft\`, no \`iptables\`); OCI-imported varies — \`python:3.12-slim\` has neither, \`alpine\` has both, \`distroless\` has nothing. A defense that depends on a userspace tool inside the guest fails on most images. Kernel \`RTN_BLACKHOLE\` is universal — every Linux kernel supports it, no userspace tool required. \`rtnetlink\` talks directly to \`AF_NETLINK\`.

## Architecture: where this layer sits

This is **Layer 1** of the five-layer model in mvmd ADR 0022:

| Layer | Lives in | Threat surface |
|---|---|---|
| **1. Guest-side defense** | **\`mvm-guest-netinit\` (this PR)** | **Cross-platform L3 floor; catches kernel routes inside the guest's namespace** |
| 2. Pool-node L3 | mvmd-agent | Per-tenant nftables on the bridge / tenant netns |
| 3. DNS pinning | mvmd-supervisor | DNS rebinding, TOCTOU resolver poisoning |
| 4. L7 egress proxy | mvmd-supervisor | HTTP Host abuse, HTTPS SNI mismatch |
| 5. VPC firewall | mvmd-gateway | Provider-level defense |

Defense-in-depth: a workload that gains root inside the guest can \`ip route del\` the blackhole routes, but Layer 2 (host iptables on Linux-direct via mvm PR #273; nftables on mvmd pool nodes via mvmd Plan 51 W2) catches that case.

## Failure semantics

\`/init\` does **not** fail-closed on netinit errors today: a hard guest-side fail-closed would block any workload on a kernel without rtnetlink. The host-side iptables defense (mvm PR #273) is the primary layer where it applies; this layer is defense-in-depth. The JSON line on the console is the operator signal.

A future slice wires the agent to forward the \`Report\` over vsock as a \`LocalAuditKind::NetworkMandatoryDeny\` event (the audit kind reserved by mvm PR #275).

## Test plan

- [x] \`cargo test -p mvm-guest --lib netinit\` — 7 new tests pass:
  - install_calls_installer_for_every_ipv4_entry
  - install_skips_ipv6_entries_and_reports_them
  - install_records_cloud_metadata_explicitly
  - install_continues_past_failures_and_records_them
  - install_marks_clean_run_no_failures
  - install_serializes_to_stable_json_shape
  - categorize_v4_handles_known_entries
- [x] \`cargo test --test nix_flake_structure mk_guest_installs_netinit_at_boot\` — passes.
- [x] \`cargo test --workspace --lib --bins --tests\` — clean.
- [x] \`cargo clippy --workspace --all-targets -- -D warnings\` — clean.
- [x] \`cargo fmt --all -- --check\` — clean.
- [ ] Live-VM regression on aarch64 Linux + KVM with IMDS reachable from the host network. Gated on the parent stack reaching main.

## Stack

This PR sits on top of:

1. W2 default-deny data model (#271) — provides \`MANDATORY_DENY_RANGES\`.

GitHub retargets to main on parent merge.

## Out of scope (separate slices)

- **Audit emission via vsock**. The binary prints JSON to stdout (kernel console); the agent doesn't yet forward as a structured \`NetworkMandatoryDeny\` event.
- **OCI/overlay path**. mkGuest bakes the binary into Nix-built rootfs; the W1.4b runtime overlay also needs to copy it to \`/mvm/runtime/netinit\` so OCI-imported workloads get the defense too. Lands when W1.4b overlay-flake work reaches main + a follow-up PR.
- **IPv6 entries**. Guest network is IPv4-only on every backend today; v6 entries are intentionally skipped and reported in \`report.skipped_ipv6\`. Wires in when a backend gains v6 routing.

Refs: mvmd ADR 0022 §"Layer 1 — Guest-side defense", mvmd Plan 51 §"Audit-first principle", mvm PRs #271 / #273 / #275.

🤖 Generated with [Claude Code](https://claude.com/claude-code)