### PR TITLE
plan 77 W4 — gate download_builder_vm_image behind release-artifact-bootstrap

### DIFF
--- a/crates/mvm-cli/Cargo.toml
+++ b/crates/mvm-cli/Cargo.toml
@@ -76,6 +76,14 @@ contributor-bootstrap = [
     "mvm-backend/contributor-bootstrap",
 ]
 builder-vm = ["mvm-build/builder-vm"]
+# Plan 77 W4: structural enforcement of the "no prebuilt builder VM artifact
+# until release" invariant (see AGENTS.md / CLAUDE.md). When off — the default
+# for every contributor build — `download_builder_vm_image` and its helpers
+# are entirely cfg'd out, so a cache miss with no in-repo flake hard-errors
+# at the source-checkout boundary rather than silently pulling a GitHub
+# release artifact. The feature is only intended to be enabled when cutting
+# an end-user-binary release that legitimately wants the download fallback.
+release-artifact-bootstrap = []
 custom-dns = ["mvm-supervisor/custom-dns"]
 dev-watch = ["dep:notify", "dep:notify-debouncer-mini"]
 manifest-verify = [

--- a/crates/mvm-cli/src/commands/env/apple_container.rs
+++ b/crates/mvm-cli/src/commands/env/apple_container.rs
@@ -1862,14 +1862,43 @@ fn bootstrap_builder_vm_image() -> Result<()> {
             .context("building the source-checkout builder VM image")
         }
         BuilderVmBootstrapAction::DownloadPublished => {
-            ui::info(&format!(
-                "Builder VM image not in cache; downloading published prebuilt for v{}...",
-                env!("CARGO_PKG_VERSION")
-            ));
-            std::fs::create_dir_all(&out_dir)
-                .with_context(|| format!("creating builder-vm cache dir {out_dir}"))?;
-            download_builder_vm_image(arch, &out_dir).context("downloading the builder VM image")
+            perform_builder_vm_download_published(arch, &out_dir)
         }
+    }
+}
+
+/// Plan 77 W4: the only call site that can invoke the published-prebuilt
+/// download path. Gated behind `release-artifact-bootstrap`. Contributor
+/// builds (the default) hit the `cfg(not(...))` arm and bail structurally
+/// — even if the resolver routed here, the function refuses to touch the
+/// network. End-user-binary release builds opt in at compile time.
+///
+/// Extracted from [`bootstrap_builder_vm_image`] specifically so the
+/// fail-closed shape is unit-testable.
+fn perform_builder_vm_download_published(arch: &str, out_dir: &str) -> Result<()> {
+    #[cfg(feature = "release-artifact-bootstrap")]
+    {
+        ui::info(&format!(
+            "Builder VM image not in cache; downloading published prebuilt for v{}...",
+            env!("CARGO_PKG_VERSION")
+        ));
+        std::fs::create_dir_all(out_dir)
+            .with_context(|| format!("creating builder-vm cache dir {out_dir}"))?;
+        download_builder_vm_image(arch, out_dir).context("downloading the builder VM image")
+    }
+    #[cfg(not(feature = "release-artifact-bootstrap"))]
+    {
+        let _ = (arch, out_dir);
+        anyhow::bail!(
+            "Builder VM image is missing and no in-repo builder VM flake \
+             was found. This `mvmctl` binary was built without the \
+             `release-artifact-bootstrap` feature, so it cannot pull a \
+             published prebuilt from GitHub releases (per Plan 77 W4 and \
+             the AGENTS.md / CLAUDE.md invariant). \
+             Run from a source checkout that has \
+             `nix/images/builder-vm/flake.nix`, or rebuild `mvmctl` with \
+             `--features release-artifact-bootstrap` (release-cut binaries only)."
+        );
     }
 }
 
@@ -2246,7 +2275,13 @@ fn promote_builder_vm_stage0_cache(
 /// downloads with a fallback at the `mvm-build` consumer
 /// (`ensure_builder_vm_image` uses the canonical Plan 72 §W2 cmdline
 /// when `cmdline.txt` is missing).
-#[allow(dead_code)]
+///
+/// Plan 77 W4: gated behind `release-artifact-bootstrap`. Contributor
+/// builds (default) never compile this in, so the "no flake + cache
+/// miss" branch in [`bootstrap_builder_vm_image`] has no escape hatch
+/// and surfaces a hard error. End-user-binary release builds opt in
+/// at compile time via `--features release-artifact-bootstrap`.
+#[cfg(feature = "release-artifact-bootstrap")]
 fn download_builder_vm_image(arch: &str, cache_dir: &str) -> Result<()> {
     let version = env!("CARGO_PKG_VERSION");
     let names = builder_vm_artifact_names(arch);
@@ -2309,8 +2344,9 @@ fn download_builder_vm_image(arch: &str, cache_dir: &str) -> Result<()> {
 /// Per-arch artifact filenames the release workflow's
 /// `builder-vm-image` job uploads. Pure function — no I/O, no
 /// network — so the unit test can verify naming matches the
-/// release.yml side without touching the network.
-#[allow(dead_code)]
+/// release.yml side without touching the network. Gated together
+/// with [`download_builder_vm_image`] (Plan 77 W4).
+#[cfg(any(feature = "release-artifact-bootstrap", test))]
 struct BuilderVmArtifactNames {
     kernel: String,
     rootfs: String,
@@ -2319,7 +2355,7 @@ struct BuilderVmArtifactNames {
     checksums: String,
 }
 
-#[allow(dead_code)]
+#[cfg(any(feature = "release-artifact-bootstrap", test))]
 fn builder_vm_artifact_names(arch: &str) -> BuilderVmArtifactNames {
     BuilderVmArtifactNames {
         kernel: format!("builder-vm-vmlinux-{arch}"),
@@ -2885,6 +2921,38 @@ mod builder_vm_bootstrap_tests {
                 .expect("installed binaries may use published prebuilts");
 
         assert_eq!(action, BuilderVmBootstrapAction::DownloadPublished);
+    }
+
+    /// Plan 77 W4: even when the resolver routes to `DownloadPublished`,
+    /// a contributor build (no `release-artifact-bootstrap` feature) must
+    /// refuse to invoke the download path and surface a clear structural
+    /// error. This locks the AGENTS.md / CLAUDE.md "no prebuilt builder
+    /// VM artifact" invariant into the type system rather than runtime
+    /// branch order. The companion sibling under
+    /// `#[cfg(feature = "release-artifact-bootstrap")]` would need a
+    /// network mock; we cover the structural-failure side here because
+    /// it's the one contributors hit.
+    #[cfg(not(feature = "release-artifact-bootstrap"))]
+    #[test]
+    fn perform_builder_vm_download_published_bails_without_feature() {
+        let err = perform_builder_vm_download_published("aarch64", "/tmp/mvm-w4-test-out")
+            .expect_err("download must refuse without release-artifact-bootstrap");
+        let msg = format!("{err:#}");
+        assert!(
+            msg.contains("release-artifact-bootstrap"),
+            "error must name the feature flag: {msg}"
+        );
+        assert!(
+            msg.contains("nix/images/builder-vm/flake.nix"),
+            "error must point at the source-checkout remediation: {msg}"
+        );
+        // Critically: the bail must happen before any directory creation.
+        // Otherwise a contributor running on a shared host could pollute
+        // `/tmp/...` even when the gate is "closed".
+        assert!(
+            !std::path::Path::new("/tmp/mvm-w4-test-out").exists(),
+            "structural failure must not touch the filesystem"
+        );
     }
 
     #[test]

--- a/specs/SPRINT.md
+++ b/specs/SPRINT.md
@@ -57,6 +57,7 @@ Recent maintenance:
 - [x] Bound source-checkout builder-image cache reuse to a SHA-256 fingerprint of `nix/images/builder-vm/{flake.nix,flake.lock}`, so stale but structurally valid builder caches are rebuilt instead of masking local source changes.
 - [x] Added source-built builder-cache artifact digest metadata; source checkout cache hits now require the fingerprint and cached `vmlinux` / `rootfs.ext4` / optional `cmdline.txt` digests to match before reuse.
 - [x] Added safe source-checkout builder-cache diagnostics; verbose output now reports non-sensitive cache decision reason codes such as `hit`, `fingerprint_mismatch`, and `artifact_digest_mismatch`.
+- [x] Plan 77 W4: gated `download_builder_vm_image` and its helpers behind the off-by-default `release-artifact-bootstrap` feature so contributor builds cannot reach the published-prebuilt path at compile time, with `perform_builder_vm_download_published_bails_without_feature` locking the structural-failure shape into the test suite.
 
 ## In-flight workstreams
 


### PR DESCRIPTION
## Summary

- Adds an off-by-default `release-artifact-bootstrap` feature in `crates/mvm-cli/Cargo.toml`.
- Gates `download_builder_vm_image` and its helpers (`BuilderVmArtifactNames`, `builder_vm_artifact_names`) behind it.
- Extracts the `DownloadPublished` arm of `bootstrap_builder_vm_image` into a small testable function (`perform_builder_vm_download_published`) that fails closed at the source-checkout boundary when the feature is off.
- Adds `perform_builder_vm_download_published_bails_without_feature` to pin the structural-failure shape.

## Why

The AGENTS.md / CLAUDE.md invariant — **"no prebuilt builder VM artifact, ever — until release"** — was previously a runtime convention. The resolver could route a contributor build to `BuilderVmBootstrapAction::DownloadPublished`, which then called `download_builder_vm_image` and 404'd against a release that doesn't exist yet (we haven't cut one with a builder-VM artifact, by design — see PR #280 / the rescued plan doc in #293).

This PR moves the invariant into the type system: contributor builds physically cannot reach the download path. The feature is the only opt-in, intended for end-user-binary release cuts.

## How

- `download_builder_vm_image` switches from `#[allow(dead_code)]` to `#[cfg(feature = "release-artifact-bootstrap")]`.
- `BuilderVmArtifactNames` + `builder_vm_artifact_names` use `#[cfg(any(feature = "release-artifact-bootstrap", test))]` so the existing `builder_vm_artifact_names_match_release_workflow` test (a pure naming-contract check, no network) keeps running in default-feature builds.
- The `DownloadPublished` arm is extracted into a function with two `cfg`-gated bodies: feature on preserves the existing call; feature off bails before touching the filesystem with a message that names the feature flag and points at the source-checkout remediation path (\`nix/images/builder-vm/flake.nix\`).
- One new test under \`#[cfg(not(feature = "release-artifact-bootstrap"))]\` asserts the bail message + the filesystem invariant (no directory created on the way to bailing).

## Test plan

- [x] \`cargo test -p mvm-cli --lib -- builder_vm_bootstrap_tests\` (default) — 21 pass incl. the new fail-closed test
- [x] \`cargo test -p mvm-cli --lib --features release-artifact-bootstrap -- builder_vm_bootstrap_tests\` — 20 pass (the new test is correctly cfg'd out)
- [x] \`cargo test --workspace\` — 0 failures
- [x] \`cargo clippy --workspace --all-targets -- -D warnings\` clean on default features
- [x] \`cargo clippy -p mvm-cli --all-targets --features release-artifact-bootstrap -- -D warnings\` clean

## Out of scope

This is W4 from the rescued plan doc (PR #293's \`specs/plans/77-stage0-bootstrap-via-dev-image.md\`). W2 (advisory lock) and W3 (audit emit to \`~/.mvm/audit/stage0.jsonl\`) are separate follow-ups.

🤖 Generated with [Claude Code](https://claude.com/claude-code)