### PR TITLE
Plan 74 W5 slice 5 — sidebar surfaces First-Use Happy Paths above the deeper docs

### DIFF
--- a/public/astro.config.mjs
+++ b/public/astro.config.mjs
@@ -40,8 +40,12 @@ export default defineConfig({
       sidebar: [
         {
           label: "Getting Started",
+          // Order: shortest path to "it's running" first, deep
+          // background later (plan 74 W5 — "run your first thing
+          // before architecture / threat-model detail").
           items: [
             { label: "Installation", slug: "getting-started/installation" },
+            { label: "First-Use Happy Paths", slug: "getting-started/happy-paths" },
             { label: "Quick Start", slug: "getting-started/quickstart" },
             { label: "Your First MicroVM", slug: "getting-started/first-microvm" },
             { label: "Connect an LLM", slug: "getting-started/connect-an-llm" },


### PR DESCRIPTION
## Summary

Reorders the "Getting Started" sidebar so the shortest path to "it's running" appears before broader feature tours or foundation/background reads. Plan 74 W5: *"Reorder getting-started pages so 'run your first thing' comes before architecture and threat-model detail."*

**Before:**
1. Installation
2. Quick Start
3. Your First MicroVM
4. Connect an LLM
5. Nix for mvm

**After:**
1. Installation                 (chicken-and-egg — you need mvm itself first)
2. **First-Use Happy Paths**    ← new entry, points at the doc from #302
3. Quick Start
4. Your First MicroVM
5. Connect an LLM
6. Nix for mvm

The new entry is the five three-command audience flows paired with \`doctor --workflow <name>\` preflights from #288.

## Slice 4 skipped (`--builder host-nix` flag)

Plan 74 W5's three-mode vocabulary (\`managed-builder-vm\` / \`host-nix\` / \`remote-builder\`) directly contradicts CLAUDE.md's load-bearing invariant: *"Host Nix is never used by mvmctl, even when present."* Promoting host-nix to a CLI flag would break the determinism guarantee. Slice 4 is dropped from W5 as obsolete.

## W5 complete after this lands

- #288 — \`doctor --workflow <name>\` audience filter
- #302 — five three-command happy paths doc
- #303 — \`mvmctl init\` sample command + cleanup hint
- (this PR) — sidebar reordering

## Test plan

- [x] Pure docs nav-config change. No \`cargo\` impact.
- [ ] CI green (the \`pages.yml\` Starlight build is the broken-link validator)

🤖 Generated with [Claude Code](https://claude.com/claude-code)