### PR TITLE
dev: prefer Apple Container over Libkrun on macOS 26+

### DIFF
--- a/crates/mvm-cli/src/commands/env/dev.rs
+++ b/crates/mvm-cli/src/commands/env/dev.rs
@@ -50,11 +50,24 @@ enum DevBackend {
 }
 
 fn current_backend() -> DevBackend {
+    // Selection order per CLAUDE.md §"Dev mode":
+    //   macOS 26+ Apple Silicon  → Apple Container (preferred)
+    //   older macOS with libkrun → Libkrun (legacy fallback)
+    //   Linux with KVM           → Firecracker / libkrun direct
+    //
+    // Apple Container wins over Libkrun on macOS even when both are
+    // available because it is the documented Stage 0 boundary AND
+    // the build boundary `RuntimeBuildEnv::shell_exec_visible`
+    // routes through (`AppleContainerEnv` in `mvm-base::linux_env`).
+    // Picking Libkrun-the-dev-backend while `LinuxEnv` is
+    // `AppleContainerEnv` leaves the dev VM under one runtime and
+    // the build boundary under another, neither one starting the
+    // other.
     let plat = platform::current();
-    if matches!(plat, Platform::MacOS) && plat.has_libkrun() {
-        DevBackend::Libkrun
-    } else if plat.has_apple_containers() {
+    if plat.has_apple_containers() {
         DevBackend::AppleContainer
+    } else if matches!(plat, Platform::MacOS) && plat.has_libkrun() {
+        DevBackend::Libkrun
     } else if plat.has_kvm() && matches!(plat, Platform::LinuxNative) {
         DevBackend::LinuxKvm
     } else {


### PR DESCRIPTION
## Summary

- `current_backend()` previously preferred `Libkrun` whenever it was installed on macOS, but `LinuxEnv::create_linux_env` always returns `AppleContainerEnv` when Apple Container is available.
- That picked `Libkrun`-the-dev-backend while routing `shell_exec_visible` through Apple Container — two runtimes both wanting the `mvm-dev` name, neither one starting the other.
- Any source-checkout dev-image build then hit the gap: the build boundary was unreachable because nothing had booted it.
- Flip the order so Apple Container wins on macOS 26+ when available; Libkrun stays as the older-macOS fallback. Dev backend and build boundary now agree on the same VM.

This unblocks the source-checkout `BuildFromSource` path that depends on the build boundary actually being up (follow-up PR will add that wiring on top of this change).

## Test plan

- [ ] `cargo check -p mvm-cli` — clean
- [ ] `cargo clippy -p mvm-cli --tests -- -D warnings` — clean
- [ ] On macOS 26+ Apple Silicon with both libkrun and Apple Container installed: `mvmctl dev status` reports `Backend: Apple Container` (previously reported `Libkrun`).
- [ ] On older macOS with only libkrun: `mvmctl dev status` still reports `Backend: Libkrun` (fallback preserved).

🤖 Generated with [Claude Code](https://claude.com/claude-code)