### PR TITLE
builder-vm: in-guest iptables default-deny (Plan 73 Followup B.2.y / ADR-047)

### DIFF
--- a/crates/mvm-builder-init/src/main.rs
+++ b/crates/mvm-builder-init/src/main.rs
@@ -75,6 +75,8 @@ mod install;
 #[allow(dead_code)]
 mod install_spec;
 #[allow(dead_code)]
+mod network;
+#[allow(dead_code)]
 mod proxy;
 
 fn main() -> ExitCode {
@@ -242,6 +244,28 @@ mod linux {
         // we don't abort the build for them.
         let _ = track_b.join();
         let _ = track_c.join();
+
+        // In-guest egress lockdown — Plan 73 Followup B.2.y /
+        // ADR-047 defense-in-depth. Installs iptables OUTPUT
+        // default-deny + proxy-uid-only ACCEPT so a build step
+        // that ignores HTTP_PROXY env vars cannot bypass
+        // `mvm-egress-proxy`. FATAL on failure — without these
+        // rules the builder VM's egress allowlist is unenforced
+        // and ADR-002's Claim 9 transitive trust onto the
+        // builder VM has no defense layer. (Note: this is
+        // installed even when `setup_network()` failed, because
+        // the rules don't depend on a working IP address —
+        // offline builds still need the policy in place in case
+        // a substituter URL is reached via cache rather than
+        // network.)
+        if let Err(e) = crate::network::install_egress_lockdown(
+            &crate::network::SystemIptables,
+            crate::network::PROXY_UID,
+        ) {
+            eprintln!("mvm-builder-init: egress lockdown FAILED (fatal): {e}");
+            write_result(2, &format!("egress lockdown failed: {e}"));
+            return power_off();
+        }
 
         // Plan 73 Followup B.2 dispatch: install jobs hand the init
         // binary a structured spec rather than a shell script. We

--- a/crates/mvm-builder-init/src/network.rs
+++ b/crates/mvm-builder-init/src/network.rs
@@ -1,0 +1,192 @@
+//! In-guest egress lockdown — Plan 73 Followup B.2.y / ADR-047.
+//!
+//! Defense-in-depth on top of `mvm-egress-proxy`: even if a
+//! build step ignores `HTTP_PROXY` / `HTTPS_PROXY` env vars, its
+//! packets get DROPped before leaving the VM because of an
+//! `OUTPUT`-chain default-deny rule. Only loopback traffic (so
+//! the in-VM proxy is reachable from `localhost:8443`) and
+//! outbound traffic owned by the proxy's uid are allowed out.
+//!
+//! Called from `mvm-builder-init`'s boot sequence after the
+//! basic `setup_network()`. Failure is **fatal** — without the
+//! lockdown, the builder VM's egress allowlist is unenforced and
+//! ADR-002's Claim 9 transitive trust onto the builder VM has no
+//! defense layer.
+
+use std::process::Command;
+
+/// Dedicated uid the in-VM `mvm-egress-proxy` runs under. The
+/// iptables `--uid-owner` rule keys off this value, so it must
+/// match the uid the proxy actually executes as
+/// (`crates/mvm-builder-init/src/proxy.rs` passes the same
+/// constant to `Command::uid` before exec). Picked between
+/// `mk-guest.nix`'s `entrypointUid` (default 1000) and
+/// `agentUid` (default 1900) to avoid collisions.
+pub const PROXY_UID: u32 = 1801;
+
+/// Adapter trait so unit tests can inject a recording / failing
+/// fake without binding a real iptables runtime. Each call
+/// corresponds to one iptables invocation.
+pub trait IptablesRunner {
+    fn run(&self, args: &[&str]) -> Result<(), String>;
+}
+
+/// Production runner — shells out to `iptables` on `$PATH`. The
+/// builder-vm rootfs ships busybox iptables via the flake's
+/// `builderPackages` set.
+pub struct SystemIptables;
+
+impl IptablesRunner for SystemIptables {
+    fn run(&self, args: &[&str]) -> Result<(), String> {
+        let output = Command::new("iptables")
+            .args(args)
+            .output()
+            .map_err(|e| format!("spawn iptables {args:?}: {e}"))?;
+        if !output.status.success() {
+            return Err(format!(
+                "iptables {args:?} exited {} (stderr: {})",
+                output.status,
+                String::from_utf8_lossy(&output.stderr).trim(),
+            ));
+        }
+        Ok(())
+    }
+}
+
+/// Install the three `OUTPUT`-chain rules that lock down egress
+/// to the proxy uid only. Order matters:
+///
+/// 1. Loopback ACCEPT — the proxy listens on `127.0.0.1:8443`
+///    and must remain reachable from other guest processes.
+/// 2. Owner-match ACCEPT — only the proxy's uid gets outbound.
+/// 3. Default-deny — set the `OUTPUT` chain's policy to DROP so
+///    anything that doesn't match the prior ACCEPTs is dropped.
+///
+/// Returns an error on the first rule that fails to install. A
+/// partial-install state is left behind on failure (e.g., rules
+/// 1 and 2 installed but policy not yet flipped) — the caller
+/// must treat the error as fatal and refuse to run the workload,
+/// because that partial state is more permissive than the
+/// pre-call baseline (no rules) and just leaving it in place
+/// would let unrestricted egress continue.
+pub fn install_egress_lockdown(
+    runner: &dyn IptablesRunner,
+    proxy_uid: u32,
+) -> Result<(), String> {
+    let uid_str = proxy_uid.to_string();
+    runner.run(&["-A", "OUTPUT", "-o", "lo", "-j", "ACCEPT"])?;
+    runner.run(&[
+        "-A",
+        "OUTPUT",
+        "-m",
+        "owner",
+        "--uid-owner",
+        &uid_str,
+        "-j",
+        "ACCEPT",
+    ])?;
+    runner.run(&["-P", "OUTPUT", "DROP"])?;
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::cell::RefCell;
+
+    struct RecordingRunner {
+        invocations: RefCell<Vec<Vec<String>>>,
+        fail_at: Option<usize>,
+    }
+
+    impl RecordingRunner {
+        fn new() -> Self {
+            Self {
+                invocations: RefCell::new(Vec::new()),
+                fail_at: None,
+            }
+        }
+
+        fn fail_at(idx: usize) -> Self {
+            Self {
+                invocations: RefCell::new(Vec::new()),
+                fail_at: Some(idx),
+            }
+        }
+    }
+
+    impl IptablesRunner for RecordingRunner {
+        fn run(&self, args: &[&str]) -> Result<(), String> {
+            let mut invocations = self.invocations.borrow_mut();
+            let idx = invocations.len();
+            invocations.push(args.iter().map(|s| s.to_string()).collect());
+            if Some(idx) == self.fail_at {
+                Err(format!("forced failure at invocation {idx}"))
+            } else {
+                Ok(())
+            }
+        }
+    }
+
+    #[test]
+    fn emits_three_rules_in_order() {
+        let runner = RecordingRunner::new();
+        install_egress_lockdown(&runner, 1801).expect("happy path");
+        let invocations = runner.invocations.borrow();
+        assert_eq!(invocations.len(), 3);
+
+        // Rule 1: loopback ACCEPT.
+        assert!(invocations[0].iter().any(|a| a == "-o"));
+        assert!(invocations[0].iter().any(|a| a == "lo"));
+        assert!(invocations[0].iter().any(|a| a == "ACCEPT"));
+
+        // Rule 2: owner-match ACCEPT for our uid.
+        assert!(invocations[1].iter().any(|a| a == "--uid-owner"));
+        assert!(invocations[1].iter().any(|a| a == "1801"));
+        assert!(invocations[1].iter().any(|a| a == "ACCEPT"));
+
+        // Rule 3: OUTPUT chain default policy DROP.
+        assert!(invocations[2].iter().any(|a| a == "-P"));
+        assert!(invocations[2].iter().any(|a| a == "OUTPUT"));
+        assert!(invocations[2].iter().any(|a| a == "DROP"));
+    }
+
+    #[test]
+    fn stops_at_first_failure() {
+        let runner = RecordingRunner::fail_at(0);
+        let result = install_egress_lockdown(&runner, 1801);
+        assert!(result.is_err());
+        assert_eq!(runner.invocations.borrow().len(), 1);
+    }
+
+    #[test]
+    fn stops_at_middle_failure() {
+        let runner = RecordingRunner::fail_at(1);
+        let result = install_egress_lockdown(&runner, 1801);
+        assert!(result.is_err());
+        assert_eq!(
+            runner.invocations.borrow().len(),
+            2,
+            "rule 2 attempted, rule 3 (DROP policy) not reached",
+        );
+    }
+
+    #[test]
+    fn uses_provided_uid() {
+        let runner = RecordingRunner::new();
+        install_egress_lockdown(&runner, 9999).expect("happy path");
+        assert!(
+            runner.invocations.borrow()[1].iter().any(|a| a == "9999"),
+            "uid passed through to --uid-owner",
+        );
+    }
+
+    #[test]
+    fn proxy_uid_constant_avoids_known_uids() {
+        // 0 = root (would defeat the rule); 1000 = mkGuest's
+        // default entrypointUid; 1900 = its default agentUid.
+        assert_ne!(PROXY_UID, 0);
+        assert_ne!(PROXY_UID, 1000);
+        assert_ne!(PROXY_UID, 1900);
+    }
+}

--- a/crates/mvm-builder-init/src/network.rs
+++ b/crates/mvm-builder-init/src/network.rs
@@ -69,10 +69,7 @@ impl IptablesRunner for SystemIptables {
 /// because that partial state is more permissive than the
 /// pre-call baseline (no rules) and just leaving it in place
 /// would let unrestricted egress continue.
-pub fn install_egress_lockdown(
-    runner: &dyn IptablesRunner,
-    proxy_uid: u32,
-) -> Result<(), String> {
+pub fn install_egress_lockdown(runner: &dyn IptablesRunner, proxy_uid: u32) -> Result<(), String> {
     let uid_str = proxy_uid.to_string();
     runner.run(&["-A", "OUTPUT", "-o", "lo", "-j", "ACCEPT"])?;
     runner.run(&[

--- a/crates/mvm-builder-init/src/proxy.rs
+++ b/crates/mvm-builder-init/src/proxy.rs
@@ -34,6 +34,8 @@
 //! around the allowlist. Tracked as B.2.y in plan 73.
 
 use std::net::{SocketAddr, TcpStream};
+#[cfg(target_os = "linux")]
+use std::os::unix::process::CommandExt;
 use std::path::PathBuf;
 use std::process::{Child, Command, Stdio};
 use std::time::{Duration, Instant};
@@ -113,6 +115,14 @@ impl ProxyLifecycle for ChildProxyLifecycle {
         // informational, not contractually consumed.
         cmd.stdout(Stdio::null());
         cmd.stderr(Stdio::inherit());
+        // Drop to the dedicated low-priv uid that the in-VM
+        // iptables OUTPUT rule matches (Plan 73 Followup B.2.y).
+        // Without this the proxy inherits PID 1's uid (root) and
+        // the `--uid-owner` rule wouldn't match, so the lockdown
+        // would block the proxy too. Linux-only: macOS dev/test
+        // builds don't run the lockdown.
+        #[cfg(target_os = "linux")]
+        cmd.uid(crate::network::PROXY_UID);
         let child = cmd
             .spawn()
             .map_err(|e| format!("spawn `{}`: {e}", self.program.display()))?;

--- a/nix/images/builder-vm/flake.nix
+++ b/nix/images/builder-vm/flake.nix
@@ -52,8 +52,14 @@
   #   persistent `/nix` store) + util-linux (`mount`, `umount`,
   #   `losetup`).
   # - iproute2 (used by `udhcpc` and friends; small).
-  # - **No** `iptables` / `procps`-interactive / `less` per the
-  #   plan's slimming directive.
+  # - iptables — Plan 73 Followup B.2.y / ADR-047 defense-in-
+  #   depth: `mvm-builder-init` installs an OUTPUT-chain
+  #   default-deny + uid-owner ACCEPT for `mvm-egress-proxy`
+  #   (uid 1801), so a build step that ignores `HTTP_PROXY`
+  #   cannot reach upstream. See
+  #   `crates/mvm-builder-init/src/network.rs`.
+  # - **No** `procps`-interactive / `less` per the plan's
+  #   slimming directive.
   # - `mvm-builder-init` mounted at `/sbin/mvm-builder-init` via
   #   `extraFiles`. The kernel cmdline (`cmdline.txt` output)
   #   sets `init=/sbin/mvm-builder-init` so this becomes PID 1.
@@ -143,6 +149,10 @@
         curl
         jq
         iproute2
+        # iptables — installed at boot by mvm-builder-init's
+        # network::install_egress_lockdown (Plan 73 Followup
+        # B.2.y / ADR-047). FATAL if absent.
+        iptables
         e2fsprogs
         util-linux
         # Plan 73 Followup B.2 — app-deps install pipeline.


### PR DESCRIPTION
## Summary

Closes the second half of Plan 73 Followup B.2 / ADR-047: B.2.x shipped `mvm-egress-proxy` (the in-guest allowlist proxy that filters CONNECT targets). This PR adds B.2.y — **iptables defense-in-depth** so the proxy is no longer the sole enforcement layer.

Three `OUTPUT`-chain rules installed at boot by `mvm-builder-init`:

1. **Loopback ACCEPT** — proxy listens on `127.0.0.1:8443`; must remain reachable.
2. **Owner-match ACCEPT** — only the proxy's uid (`PROXY_UID = 1801`) gets outbound.
3. **Default-deny** — `OUTPUT` chain policy set to `DROP` so anything else is dropped.

A build step that ignores `HTTPS_PROXY` env vars now hits the iptables drop, not just the proxy's `parse_connect_target` filter.

## Changes

- `crates/mvm-builder-init/src/network.rs` (new): `IptablesRunner` trait + `SystemIptables` impl + `install_egress_lockdown(runner, proxy_uid)`. The trait keeps tests platform-neutral; production calls the `iptables` binary inside the VM.
- `crates/mvm-builder-init/src/main.rs`: wire the lockdown into `linux::run()` after `setup_network()`. **Fatal on failure** (the proxy is dead code if the lockdown can't install — failing closed is the only safe option). `udhcpc` itself remains non-fatal (offline builds still work; the lockdown doesn't depend on a working IP address).
- `crates/mvm-builder-init/src/proxy.rs`: drop to `PROXY_UID` via `Command::uid` before `exec` so the `--uid-owner` rule actually matches the proxy. Linux-only via `cfg(target_os)`; macOS dev/test builds spawn normally.
- `nix/images/builder-vm/flake.nix`: add `iptables` to the rootfs package set; update the slimming-directive comment to note iptables is now in by design.

## Test plan

- [x] `cargo check -p mvm-builder-init` — clean
- [x] `cargo test -p mvm-builder-init network::` — 5/5 pass:
  - `emits_three_rules_in_order` — loopback → uid-owner → DROP, in that order, args verified
  - `stops_at_first_failure` — iptables error on rule 1 propagates
  - `stops_at_middle_failure` — partial-install state surfaces, rule 3 not attempted
  - `uses_provided_uid` — `--uid-owner 9999` round-trips
  - `proxy_uid_constant_avoids_known_uids` — `PROXY_UID` ≠ 0 / 1000 / 1900 (root / entrypoint / agent)
- [x] `cargo clippy -p mvm-builder-init --tests -- -D warnings` — clean
- [ ] E2E test inside a booted builder VM (from non-proxy uid: `curl pypi.org` blocked; from proxy uid: succeeds) — gated on Plan 77's Stage 0 bootstrap delivering a workable builder VM end-to-end.

## Notes

`PROXY_UID = 1801` is picked between `mk-guest.nix`'s `entrypointUid` default (1000) and `agentUid` default (1900) to avoid collisions. The constant lives in `network.rs` and is referenced from `proxy.rs` for the `Command::uid` drop, so the rule and the runtime uid can't drift.

🤖 Generated with [Claude Code](https://claude.com/claude-code)