### PR TITLE
fix(mk-guest): use util-linux setpriv (busybox applet doesn't support --reuid)

### DIFF
--- a/nix/lib/mk-guest.nix
+++ b/nix/lib/mk-guest.nix
@@ -155,15 +155,25 @@ let
   entrypointUid = resolvedUids.entrypoint;
 
   # Wrap a command-line in `setpriv` when the target uid is non-zero.
-  # busybox provides setpriv from util-linux applets; the flags here
-  # match ADR-002 W2.3 (--reuid + --regid + --no-new-privs) so the
-  # privilege drop is consistent with the planned Phase 6 hardening.
-  # uid==0 short-circuits to the bare command — no point setpriv-ing
-  # to root.
+  #
+  # **util-linux's setpriv, not busybox's.** `pkgsStatic.busybox`
+  # ships a stripped setpriv applet that only knows the bare
+  # `-d / --nnp / --inh-caps / --ambient-caps` flags — `--reuid`,
+  # `--regid`, and `--clear-groups` come from util-linux's full
+  # setpriv binary. Invoking `/bin/busybox setpriv --reuid=…`
+  # fails with `setpriv: unrecognized option: reuid=…`, killing
+  # /init at stage 2.5 before the guest agent ever forks. The
+  # Nix store path to util-linux's setpriv is baked in at build
+  # time and shipped in the rootfs's `/nix/store` closure.
+  #
+  # The flag set matches ADR-002 W2.3 (--reuid + --regid +
+  # --clear-groups + --no-new-privs). uid==0 short-circuits to
+  # the bare command — no point setpriv-ing to root.
   setprivWrap = uid: cmd:
     if uid == 0 then cmd
     else
-      "exec /bin/busybox setpriv --reuid=${toString uid} --regid=${toString uid} "
+      "exec ${pkgs.util-linux}/bin/setpriv "
+      + "--reuid=${toString uid} --regid=${toString uid} "
       + "--clear-groups --no-new-privs -- ${cmd}";
 
   rawEntrypointCmd =
@@ -285,7 +295,11 @@ let
       MVM_AGENT_BIN=/usr/local/bin/mvm-guest-agent
     fi
     if [ -n "$MVM_AGENT_BIN" ]; then
-      /bin/busybox setsid /bin/busybox setpriv \
+      # util-linux setpriv — busybox setpriv lacks --reuid /
+      # --regid / --clear-groups; see `setprivWrap` above for
+      # the full reasoning. Without this fix the agent never
+      # forks and vsock port 5252 stays unbound.
+      /bin/busybox setsid ${pkgs.util-linux}/bin/setpriv \
         --reuid=${toString agentUid} --regid=${toString agentUid} \
         --clear-groups --no-new-privs \
         -- "$MVM_AGENT_BIN" &


### PR DESCRIPTION
## Summary

`pkgsStatic.busybox`'s `setpriv` applet is the stripped upstream version — it only knows `-d / --nnp / --inh-caps / --ambient-caps`. `--reuid`, `--regid`, and `--clear-groups` come from **util-linux's full setpriv binary**, not from busybox.

The init script invoked `/bin/busybox setpriv --reuid=…` in two places:

- `setprivWrap` (the helper that wraps the entrypoint at the configured uid)
- The stage-2.5 agent fork

In both cases busybox printed `setpriv: unrecognized option: reuid=…` and exited.

### Downstream symptoms

- `/init` died at stage 2.5
- Guest agent never forked
- Vsock port 5252 stayed unbound
- Every host-side `VZVirtioSocketDevice.connectToPort:` returned `"Connection reset by peer"` because nothing was listening
- `mvmctl dev shell` and `RuntimeBuildEnv::shell_exec_visible` both failed with `Failed to read response length: failed to fill whole buffer`
- Plan 77's Stage 0 source-checkout build path also failed (it needs the cached dev image to boot far enough for `nix build` to run)

### Repro

```bash
$ tail /Users/auser/.mvm/vms/mvm-dev/console.log
…
setpriv: unrecognized option: reuid=990
/bin/sh: can't access tty; job control turned off
```

### Fix

Substitute `${pkgs.util-linux}/bin/setpriv` directly via Nix store-path interpolation in both call sites. `util-linux` is already in the rootfs's package set (line 111 of `nix/images/builder/flake.nix`), so this just resolves the existing closure entry to the right binary instead of relying on a busybox applet that doesn't ship the flags we need.

Comment block at `setprivWrap` rewritten to match actual behaviour — the previous claim "busybox provides setpriv from util-linux applets" was incorrect for `pkgsStatic.busybox` and is what hid the bug for so long.

## Test plan

- [ ] Rebuild the dev image (`mvmctl dev up` post-merge or via the source-checkout BuildFromSource path), then check `/Users/auser/.mvm/vms/mvm-dev/console.log` — no setpriv errors should appear; the agent's "control plane ready" line should be present.
- [ ] `mvmctl dev shell --command "id"` should now return uid 0 (or whatever the entrypoint uid is configured to), confirming the entrypoint setpriv wrap works.
- [ ] `mvmctl dev status` should show the agent reachable (not just the proxy reachable).

🤖 Generated with [Claude Code](https://claude.com/claude-code)