### PR TITLE
Pin cryptsetup for verity generation

### DIFF
--- a/nix/images/builder-vm/flake.nix
+++ b/nix/images/builder-vm/flake.nix
@@ -110,6 +110,25 @@
         mvmSrc = workspace;
       };
 
+      # ADR-050 / issue #223 — veritysetup sidecar bytes must not drift
+      # when nixpkgs revs. The OCI-pull path runs `veritysetup format`
+      # inside this builder VM, while the Nix-built baseline runs it in
+      # `nix/images/runtime-overlay/flake.nix`. Both flakes intentionally
+      # pin the same cryptsetup release + tarball hash, and both must be
+      # reviewed together on bump.
+      pinnedCryptsetupVersion = "2.8.6";
+      pinnedCryptsetupSrcHash = "sha256-gAQmX9mTiF0I97Yz2+BWhR3hohAwdhOk693HQ/zO/lo=";
+      pinnedCryptsetupFor = pkgs:
+        pkgs.cryptsetup.overrideAttrs (_old: {
+          version = pinnedCryptsetupVersion;
+          src = pkgs.fetchurl {
+            url =
+              "mirror://kernel/linux/utils/cryptsetup/v${pkgs.lib.versions.majorMinor pinnedCryptsetupVersion}/"
+              + "cryptsetup-${pinnedCryptsetupVersion}.tar.xz";
+            hash = pinnedCryptsetupSrcHash;
+          };
+        });
+
       # Per Plan 72 §W2 — narrower than the dev-shell image.
       # See module-level docs above for the rationale on each.
       #
@@ -155,6 +174,7 @@
         iptables
         e2fsprogs
         util-linux
+        (pinnedCryptsetupFor pkgs) # provides pinned veritysetup
         # Plan 73 Followup B.2 — app-deps install pipeline.
         uv
         pnpm

--- a/nix/images/runtime-overlay/flake.nix
+++ b/nix/images/runtime-overlay/flake.nix
@@ -196,6 +196,24 @@
       overlayVerityHashAlgorithm = "sha256";
       overlayVerityHashBlockSize = 4096;
 
+      # ADR-050 / issue #223 — keep the Nix-built verity baseline on
+      # the exact same cryptsetup release as the builder VM's OCI-pull
+      # path. A nixpkgs bump must not silently change `veritysetup`
+      # output bytes; bump version + hash here and in
+      # `nix/images/builder-vm/flake.nix` together.
+      pinnedCryptsetupVersion = "2.8.6";
+      pinnedCryptsetupSrcHash = "sha256-gAQmX9mTiF0I97Yz2+BWhR3hohAwdhOk693HQ/zO/lo=";
+      pinnedCryptsetupFor = pkgs:
+        pkgs.cryptsetup.overrideAttrs (_old: {
+          version = pinnedCryptsetupVersion;
+          src = pkgs.fetchurl {
+            url =
+              "mirror://kernel/linux/utils/cryptsetup/v${pkgs.lib.versions.majorMinor pinnedCryptsetupVersion}/"
+              + "cryptsetup-${pinnedCryptsetupVersion}.tar.xz";
+            hash = pinnedCryptsetupSrcHash;
+          };
+        });
+
       # Target overlay size: 32 MiB. ADR-051 §"Open questions" pins
       # a hard cap of 32 MiB for the overlay budget; today's
       # contents fit in well under that, but using the cap as the
@@ -213,7 +231,7 @@
           {
             nativeBuildInputs = [
               pkgs.e2fsprogs
-              pkgs.cryptsetup # provides veritysetup
+              (pinnedCryptsetupFor pkgs) # provides pinned veritysetup
               pkgs.coreutils
             ];
             passthru = {

--- a/specs/SPRINT.md
+++ b/specs/SPRINT.md
@@ -127,6 +127,10 @@ landed with regression tests; `cargo test --workspace` and
       `veritysetup format` with `--data-block-size=1024` and a pinned
       zero salt, emits `rootfs.{ext4,verity,roothash}`
       deterministically.
+      Follow-up #223 pins cryptsetup/veritysetup 2.8.6 by release
+      tarball hash in both the builder-VM OCI-pull path and the
+      Nix-built runtime-overlay baseline so nixpkgs bumps cannot
+      silently change sidecar bytes.
 - [x] **W3.2** Apple Container backend gained `VerityConfig` +
       `start_with_verity()`; opens the rootfs read-only, attaches
       the sidecar at `/dev/vdb`, attaches the verity initramfs via

--- a/specs/adrs/050-oci-image-verity-posture.md
+++ b/specs/adrs/050-oci-image-verity-posture.md
@@ -174,10 +174,11 @@ Option B is on the spectrum of that.
 
 ## Open questions
 
-- **`veritysetup` versioning.** Sidecar format is stable across
-  recent `cryptsetup` releases, but pin the version in the
-  builder-VM flake to avoid silent regeneration drift across
-  builds.
+- **`veritysetup` versioning.** Resolved by #223: both
+  `nix/images/builder-vm/flake.nix` and
+  `nix/images/runtime-overlay/flake.nix` pin cryptsetup 2.8.6 by
+  release tarball hash so `veritysetup format` cannot drift
+  silently on nixpkgs bumps.
 - **Image-size DoS at pull time.** A malicious registry could
   serve a 100 GB manifest. Layer-size + total-rootfs caps belong
   in Plan 74 W1's R10 (OCI layer unpack attack surface)

--- a/tests/nix_flake_structure.rs
+++ b/tests/nix_flake_structure.rs
@@ -296,6 +296,70 @@ fn runtime_overlay_flake_stages_netinit_binary() {
     );
 }
 
+/// ADR-050 / issue #223 — the OCI-pull verity path runs
+/// `veritysetup format` inside the builder VM, while the Nix-built
+/// runtime-overlay baseline runs it in the runtime-overlay flake.
+/// Both must use the same explicit cryptsetup release pin so a
+/// nixpkgs bump cannot silently change sidecar bytes. The live
+/// Linux integration test `seal_is_byte_deterministic_for_identical_rootfs_bytes`
+/// verifies byte-identical sidecars for fixed input bytes when
+/// `veritysetup` is present; this structural guard verifies the
+/// two Nix closures consume the same pinned toolchain.
+#[test]
+fn cryptsetup_pin_is_shared_by_builder_vm_and_runtime_overlay() {
+    let builder_path = nix_dir()
+        .join("images")
+        .join("builder-vm")
+        .join("flake.nix");
+    let runtime_path = nix_dir()
+        .join("images")
+        .join("runtime-overlay")
+        .join("flake.nix");
+    let builder = fs::read_to_string(&builder_path)
+        .unwrap_or_else(|e| panic!("nix/images/builder-vm/flake.nix must be present: {e}"));
+    let runtime = fs::read_to_string(&runtime_path)
+        .unwrap_or_else(|e| panic!("nix/images/runtime-overlay/flake.nix must be present: {e}"));
+
+    for (name, content) in [
+        ("builder-vm flake", builder.as_str()),
+        ("runtime-overlay flake", runtime.as_str()),
+    ] {
+        assert!(
+            content.contains("pinnedCryptsetupVersion = \"2.8.6\""),
+            "{name} must pin cryptsetup 2.8.6 explicitly for ADR-050 / #223"
+        );
+        assert!(
+            content.contains(
+                "pinnedCryptsetupSrcHash = \"sha256-gAQmX9mTiF0I97Yz2+BWhR3hohAwdhOk693HQ/zO/lo=\""
+            ),
+            "{name} must pin the cryptsetup 2.8.6 release tarball hash"
+        );
+        assert!(
+            content.contains("pinnedCryptsetupFor = pkgs:"),
+            "{name} must expose a pinned cryptsetup helper instead of using raw pkgs.cryptsetup"
+        );
+        assert!(
+            content.contains("pkgs.cryptsetup.overrideAttrs"),
+            "{name} must override cryptsetup source/version, not only document the desired version"
+        );
+        assert!(
+            content.contains("cryptsetup-${pinnedCryptsetupVersion}.tar.xz"),
+            "{name} must fetch the exact cryptsetup release tarball named by the pin"
+        );
+    }
+
+    assert!(
+        builder.contains("(pinnedCryptsetupFor pkgs) # provides pinned veritysetup"),
+        "builder VM packages must include the pinned cryptsetup package so OCI-pull \
+         verity generation runs the pinned veritysetup binary"
+    );
+    assert!(
+        runtime.contains("(pinnedCryptsetupFor pkgs) # provides pinned veritysetup"),
+        "runtime-overlay nativeBuildInputs must use the pinned cryptsetup package so \
+         the Nix-built verity baseline matches the builder VM"
+    );
+}
+
 #[test]
 fn flake_lock_pins_microvm_input_by_hash() {
     // The flake.lock must exist and pin the microvm.nix input by


### PR DESCRIPTION
## Summary
- pin cryptsetup/veritysetup 2.8.6 by release tarball hash in the builder VM flake
- use the same pin in the runtime-overlay verity baseline
- add a structural test that enforces the shared pin/version/hash contract
- update ADR-050 and the sprint notes to record the #223 resolution

Closes #223

## Verification
- cargo test --test nix_flake_structure cryptsetup_pin_is_shared_by_builder_vm_and_runtime_overlay
- cargo test --test nix_flake_structure
- cargo test -p mvm-build --test oci_verity_sealing
- cargo check --workspace
- cargo clippy --workspace -- -D warnings
- cargo run -p xtask -- check-spec-numbers
- cargo run -p xtask -- check-adr-coverage
- cargo test --workspace
- git diff --check

Note: I did not run Nix eval/build locally because repo instructions require Nix work inside the project builder VM; CI should cover the Linux/Nix lanes.