### PR TITLE
fix(libkrun): enable libkrun-sys by default for mvmctl binary

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -311,7 +311,13 @@ which.workspace = true
 # libkrun isn't installed on the host, so a default-features binary works
 # everywhere. Library consumers (mvmd) that want a lean closure build with
 # `default-features = false`.
-default = ["builder-vm"]
+default = ["builder-vm", "libkrun-sys"]
+# Plan 86 / Plan 72 W5.D bullet 10: extract libkrunfw's bundled
+# TSI-patched kernel at runtime. Wired here on the root `mvmctl`
+# binary by default so the contributor `cargo run -- dev up` path
+# reaches `extract_bundled_kernel`. `mvm-cli` keeps it as an
+# opt-in library feature (library consumers don't link libkrunfw).
+libkrun-sys = ["mvm-cli/libkrun-sys"]
 contributor-bootstrap = [
     "mvm/contributor-bootstrap",
     "mvm-backend/contributor-bootstrap",


### PR DESCRIPTION
## Summary

Plan 86 / Plan 72 W5.D bullet 10 added `extract_bundled_kernel()` calling libkrunfw's `krunfw_get_kernel` C API. That call site is the only path to a known-good TSI-patched kernel on macOS — the in-repo port (`nix/images/builder-vm/kernel/`) applies to nixpkgs 6.12.87 cleanly but kernel-oops's at `tsi_release` on socket close.

`mvm-cli` keeps `libkrun-sys` as an opt-in library feature (commit e7a445e5) so mvmd and other library consumers don't pull libkrunfw headers. The root `mvmctl` binary has no such constraint — every contributor `cargo run -- dev up` needs the FFI live. This adds `libkrun-sys` to the root `default` feature so the binary path is wired end-to-end without a manual `--features libkrun-sys` flag.

## Test plan

- [x] `cargo build` (default features) — clean
- [x] `cargo run -- dev up` reaches `extract_bundled_kernel` (visible in `[mvm] Extracted libkrunfw kernel (22675456 bytes)` log line)
- [x] libkrunfw kernel boots in libkrun without the SP/PC alignment exception the in-repo TSI port hit
- [x] `mvm-builder-init` runs through pseudofs mounts → /nix-store seed → cmd.sh dispatch

🤖 Generated with [Claude Code](https://claude.com/claude-code)