### PR TITLE
feat(libkrun): flip Stage 0 default to passt + libkrun-sys default on macOS (Plan 87 PR3)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -274,6 +274,16 @@ anyhow.workspace = true
 
 [target.'cfg(target_os = "macos")'.dependencies]
 objc2-foundation = { version = "0.3", features = ["NSRunLoop", "NSDate", "NSAutoreleasePool"] }
+# Plan 87 W5 — enable mvm-cli's `libkrun-sys` feature on macOS so the
+# `mvmctl` binary's `extract_bundled_kernel()` path is wired by
+# default (libkrun is the macOS hypervisor backend; libkrunfw ships
+# alongside via the same Homebrew tap). Linux CI / runtimes use
+# Firecracker, which doesn't need libkrun headers — the target-gated
+# dep keeps `cargo build` on Ubuntu working without `apt install
+# libkrun-dev` (which doesn't ship a libkrun-dev package today).
+# Cargo features can't be cfg-gated, but target-specific dep entries
+# can; Cargo unions the features across all matching target entries.
+mvm-cli = { workspace = true, default-features = false, features = ["libkrun-sys"] }
 
 [dev-dependencies]
 assert_cmd.workspace = true

--- a/crates/mvm-build/src/libkrun_builder.rs
+++ b/crates/mvm-build/src/libkrun_builder.rs
@@ -117,8 +117,16 @@ pub enum NetworkingPreference {
 }
 
 /// Read `MVM_NETWORKING` from the env. Accepts `tsi` and `passt`
-/// (case-insensitive); anything else falls back to `Tsi` and emits a
-/// debug log so a typo is visible without aborting.
+/// (case-insensitive); anything else falls back to the default and
+/// emits a debug log so a typo is visible without aborting.
+///
+/// Plan 87 W5 / PR3 flipped the default from `Tsi` to `Passt`. TSI is
+/// libkrun's experimental no-network-stack mode; it works for
+/// trivial HTTP but breaks on nix's substituter and source fetches
+/// (HTTP/2 multiplexing, HTTPS redirect chains, the offline-mode
+/// probe — see ADR-055 §"Context"). Passt-backed virtio-net is the
+/// production-ready path. Contributors can still opt back to TSI via
+/// `MVM_NETWORKING=tsi` for debugging.
 pub fn resolve_networking_mode() -> NetworkingPreference {
     match std::env::var("MVM_NETWORKING")
         .ok()
@@ -127,14 +135,14 @@ pub fn resolve_networking_mode() -> NetworkingPreference {
         .map(str::to_ascii_lowercase)
         .as_deref()
     {
-        Some("passt") => NetworkingPreference::Passt,
-        Some("tsi") | None | Some("") => NetworkingPreference::Tsi,
+        Some("tsi") => NetworkingPreference::Tsi,
+        Some("passt") | None | Some("") => NetworkingPreference::Passt,
         Some(other) => {
             tracing::warn!(
                 value = other,
-                "MVM_NETWORKING unrecognised; falling back to TSI (accepted: tsi, passt)"
+                "MVM_NETWORKING unrecognised; falling back to Passt (accepted: tsi, passt)"
             );
-            NetworkingPreference::Tsi
+            NetworkingPreference::Passt
         }
     }
 }
@@ -1501,24 +1509,25 @@ mod tests {
         // SAFETY: tests guarded by ENV_LOCK; env mutation in test
         // process is fine when serialized.
         unsafe {
+            // Plan 87 W5 / PR3: default is Passt; opt out via tsi.
             std::env::remove_var("MVM_NETWORKING");
-            assert_eq!(resolve_networking_mode(), NetworkingPreference::Tsi);
-
-            std::env::set_var("MVM_NETWORKING", "passt");
             assert_eq!(resolve_networking_mode(), NetworkingPreference::Passt);
 
-            std::env::set_var("MVM_NETWORKING", "PASST");
-            assert_eq!(resolve_networking_mode(), NetworkingPreference::Passt);
-
-            std::env::set_var("MVM_NETWORKING", " tsi ");
+            std::env::set_var("MVM_NETWORKING", "tsi");
             assert_eq!(resolve_networking_mode(), NetworkingPreference::Tsi);
+
+            std::env::set_var("MVM_NETWORKING", "TSI");
+            assert_eq!(resolve_networking_mode(), NetworkingPreference::Tsi);
+
+            std::env::set_var("MVM_NETWORKING", " passt ");
+            assert_eq!(resolve_networking_mode(), NetworkingPreference::Passt);
 
             std::env::set_var("MVM_NETWORKING", "");
-            assert_eq!(resolve_networking_mode(), NetworkingPreference::Tsi);
+            assert_eq!(resolve_networking_mode(), NetworkingPreference::Passt);
 
             std::env::set_var("MVM_NETWORKING", "gvproxy");
-            // Unknown value → fall back to TSI without panic.
-            assert_eq!(resolve_networking_mode(), NetworkingPreference::Tsi);
+            // Unknown value → fall back to the default (Passt) without panic.
+            assert_eq!(resolve_networking_mode(), NetworkingPreference::Passt);
 
             std::env::remove_var("MVM_NETWORKING");
         }

--- a/crates/mvm-build/src/libkrun_builder.rs
+++ b/crates/mvm-build/src/libkrun_builder.rs
@@ -103,6 +103,42 @@ pub const GUEST_NIX_DIR: &str = "/nix";
 /// under this path (read-write virtio-fs). Plan 72 W4 wires this.
 pub const GUEST_JOB_DIR: &str = "/job";
 
+/// Plan 87 W3: caller-visible networking-backend preference. Read from
+/// the `MVM_NETWORKING` env var at every VM-launch site. Default
+/// stays Tsi for backward compat; PR3 in Plan 87 flips this once W4
+/// in-VM udhcpc wiring lands and CI installs the host-side deps.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum NetworkingPreference {
+    /// libkrun's built-in TSI (no virtio-net, no DHCP). Default.
+    Tsi,
+    /// virtio-net via passt. Requires libkrun-sys + passt installed on
+    /// the host. The supervisor process spawns passt as a child.
+    Passt,
+}
+
+/// Read `MVM_NETWORKING` from the env. Accepts `tsi` and `passt`
+/// (case-insensitive); anything else falls back to `Tsi` and emits a
+/// debug log so a typo is visible without aborting.
+pub fn resolve_networking_mode() -> NetworkingPreference {
+    match std::env::var("MVM_NETWORKING")
+        .ok()
+        .as_deref()
+        .map(str::trim)
+        .map(str::to_ascii_lowercase)
+        .as_deref()
+    {
+        Some("passt") => NetworkingPreference::Passt,
+        Some("tsi") | None | Some("") => NetworkingPreference::Tsi,
+        Some(other) => {
+            tracing::warn!(
+                value = other,
+                "MVM_NETWORKING unrecognised; falling back to TSI (accepted: tsi, passt)"
+            );
+            NetworkingPreference::Tsi
+        }
+    }
+}
+
 /// Libkrun-backed builder VM driver.
 ///
 /// Configuration only — `run_build` consumes it to spin a per-job
@@ -260,6 +296,20 @@ impl LibkrunBuilderVm {
                 disk.id.as_str(),
                 path_to_str(&disk.path, "extra_disk")?,
                 disk.read_only,
+            );
+        }
+
+        // Plan 87 W3: opt into passt-backed virtio-net when
+        // MVM_NETWORKING=passt. The supervisor spawns the passt child
+        // and logs to <vm_state_dir>/passt.log; libkrun's
+        // `krun_add_net_unixstream` consumes the fd. Without the env
+        // var (or with any other value) we stay on TSI for backward
+        // compat — Plan 87 PR3 flips the default once the W4 in-VM
+        // wiring lands and CI installs passt + libkrunfw.
+        if resolve_networking_mode() == NetworkingPreference::Passt {
+            krun = krun.with_passt(
+                mvm_libkrun::passt::DEFAULT_GUEST_MAC,
+                path_to_str(&vm_state_dir, "vm_state_dir")?,
             );
         }
 
@@ -492,7 +542,7 @@ impl BuilderVm for LibkrunBuilderVm {
         // hvc0 output silently and "supervisor running, then exits 1"
         // is the only observable signal.
         let console_log = vm_state_dir.join("console.log");
-        let krun = KrunContext::new(
+        let mut krun = KrunContext::new(
             &vm_name,
             path_to_str(&image.kernel_path, "kernel_path")?,
             path_to_str(&image.rootfs_path, "rootfs_path")?,
@@ -509,6 +559,18 @@ impl BuilderVm for LibkrunBuilderVm {
         .add_virtio_fs("work", path_to_str(&mounts.flake_src, "flake_src")?)
         .add_virtio_fs("out", path_to_str(&mounts.artifact_out, "artifact_out")?)
         .add_virtio_fs("job", path_to_str(&job_dir, "job_dir")?);
+
+        // Plan 87 W3: same env-var opt-in as the shell-job path. See
+        // `LibkrunBuilderVm::dispatch_shell_job` for the rationale —
+        // when `MVM_NETWORKING=passt` is set the supervisor spawns
+        // passt and libkrun consumes its socket fd. Default stays TSI
+        // until PR3 flips it.
+        if resolve_networking_mode() == NetworkingPreference::Passt {
+            krun = krun.with_passt(
+                mvm_libkrun::passt::DEFAULT_GUEST_MAC,
+                path_to_str(&vm_state_dir, "vm_state_dir")?,
+            );
+        }
 
         // 8. Drive the supervisor: pipe `SupervisorConfig` to
         //    stdin and **wait** for the child to exit. Unlike
@@ -1431,6 +1493,35 @@ mod tests {
         // accidentally reverts the bump fails fast.
         assert_eq!(vm.memory_mib, 8192);
         assert_eq!(vm.nix_store_mib, 65536);
+    }
+
+    #[test]
+    fn resolve_networking_mode_parses_env() {
+        let _guard = ENV_LOCK.lock().unwrap();
+        // SAFETY: tests guarded by ENV_LOCK; env mutation in test
+        // process is fine when serialized.
+        unsafe {
+            std::env::remove_var("MVM_NETWORKING");
+            assert_eq!(resolve_networking_mode(), NetworkingPreference::Tsi);
+
+            std::env::set_var("MVM_NETWORKING", "passt");
+            assert_eq!(resolve_networking_mode(), NetworkingPreference::Passt);
+
+            std::env::set_var("MVM_NETWORKING", "PASST");
+            assert_eq!(resolve_networking_mode(), NetworkingPreference::Passt);
+
+            std::env::set_var("MVM_NETWORKING", " tsi ");
+            assert_eq!(resolve_networking_mode(), NetworkingPreference::Tsi);
+
+            std::env::set_var("MVM_NETWORKING", "");
+            assert_eq!(resolve_networking_mode(), NetworkingPreference::Tsi);
+
+            std::env::set_var("MVM_NETWORKING", "gvproxy");
+            // Unknown value → fall back to TSI without panic.
+            assert_eq!(resolve_networking_mode(), NetworkingPreference::Tsi);
+
+            std::env::remove_var("MVM_NETWORKING");
+        }
     }
 
     #[test]

--- a/crates/mvm-builder-init/src/main.rs
+++ b/crates/mvm-builder-init/src/main.rs
@@ -672,8 +672,37 @@ mod linux {
     }
 
     fn setup_network() -> Result<(), String> {
-        let status = Command::new("/sbin/udhcpc")
-            .args(["-i", "eth0", "-n", "-q"])
+        // Plan 87 W4: seed /run/resolv.conf from the fallback before
+        // udhcpc runs. /etc/resolv.conf is a symlink into /run, so
+        // libc resolvers have a usable nameserver list from boot 1
+        // even if DHCP fails (TSI mode, or passt mid-handoff).
+        // Failure here is non-fatal — the symlink might not exist
+        // on a guest built before Plan 87, in which case udhcpc's
+        // own write to /etc/resolv.conf (if -s is set) is the
+        // only path.
+        let fallback = std::path::Path::new("/etc/resolv.conf.fallback");
+        if fallback.is_file() {
+            if let Err(e) = std::fs::copy(fallback, "/run/resolv.conf") {
+                eprintln!(
+                    "mvm-builder-init: copy /etc/resolv.conf.fallback -> \
+                     /run/resolv.conf: {e} (continuing — udhcpc may fix it)"
+                );
+            }
+        }
+
+        // Plan 87 W4: when /etc/udhcpc/default.script exists (passt
+        // path / ur-seed-built rootfs), use it so the DHCP lease
+        // writes /run/resolv.conf with the leased DNS. Older rootfs
+        // builds without the script keep the legacy `-i eth0 -n -q`
+        // shape — udhcpc still sets the IP but resolv.conf stays at
+        // the fallback content.
+        let script = "/etc/udhcpc/default.script";
+        let mut cmd = Command::new("/sbin/udhcpc");
+        cmd.args(["-i", "eth0", "-n", "-q"]);
+        if std::path::Path::new(script).is_file() {
+            cmd.args(["-s", script]);
+        }
+        let status = cmd
             .status()
             .map_err(|e| format!("spawn /sbin/udhcpc: {e}"))?;
         if !status.success() {

--- a/crates/mvm-libkrun/src/lib.rs
+++ b/crates/mvm-libkrun/src/lib.rs
@@ -280,19 +280,22 @@ pub enum NetworkingMode {
     /// libkrun's built-in TSI backend (no virtio-net, no DHCP).
     #[default]
     Tsi,
-    /// virtio-net via passt. The host-side passt process is owned
-    /// by `mvm-libkrun::passt::PasstSupervisor`; this variant carries
-    /// the parent end of the socketpair libkrun consumes.
+    /// virtio-net via passt. The supervisor process (whichever links
+    /// `libkrun-sys`) spawns a passt child inside `run_supervisor`,
+    /// hands its socket fd to `krun_add_net_unixstream`, and reaps
+    /// passt when libkrun exits. mvmctl (and any other JSON-consuming
+    /// caller) just declares the intent here — the live fd never
+    /// survives JSON serialization, so we keep it out of this struct.
     Passt {
-        /// File descriptor for the unixstream socket libkrun reads
-        /// virtio-net frames from. Caller (typically
-        /// `PasstSupervisor::spawn`) owns the inverse half handed
-        /// to passt. libkrun takes ownership at `start_enter`.
-        socket_fd: i32,
         /// MAC address for the guest's eth0. 6 bytes; the first
         /// octet must have bit 0x02 set (locally-administered) to
         /// avoid colliding with real hardware allocations.
         mac: [u8; 6],
+        /// Host directory where the supervisor stages passt's log
+        /// file (`<scratch_dir>/passt.log`). Typically
+        /// `<vm_state_dir>` so the per-VM artifact set stays
+        /// co-located. The supervisor creates it if absent.
+        scratch_dir: String,
     },
 }
 
@@ -321,10 +324,14 @@ impl KrunContext {
         }
     }
 
-    /// Switch the guest to passt-backed virtio-net. The caller owns the
-    /// `PasstSupervisor` whose `socket_fd` is passed in here. Plan 87.
-    pub fn with_passt(mut self, socket_fd: i32, mac: [u8; 6]) -> Self {
-        self.networking = NetworkingMode::Passt { socket_fd, mac };
+    /// Switch the guest to passt-backed virtio-net. The supervisor
+    /// process owns the passt child; we just declare the intent and
+    /// the destination for passt's log file. Plan 87.
+    pub fn with_passt(mut self, mac: [u8; 6], scratch_dir: impl Into<String>) -> Self {
+        self.networking = NetworkingMode::Passt {
+            mac,
+            scratch_dir: scratch_dir.into(),
+        };
         self
     }
 
@@ -443,14 +450,60 @@ pub fn start(ctx: &KrunContext) -> Result<(), Error> {
 /// Apply every `KrunContext` field to a freshly-allocated libkrun
 /// configuration context. Shared between [`start`] (W1: configure +
 /// drop) and [`start_enter`] (W3: configure + boot).
+///
+/// Plan 87 split this into `configure_pre_net` (everything except
+/// networking) + a per-caller networking decision. `configure` itself
+/// is the TSI-only path used by the spike/smoke binaries; real
+/// consumers go through `run_supervisor`, which owns a passt child
+/// process for the libkrun lifetime via `configure_with_passt`.
 #[cfg(feature = "libkrun-sys")]
 fn configure(ctx: &KrunContext) -> Result<sys::Context, Error> {
+    let krun = configure_pre_net(ctx)?;
+    if matches!(ctx.networking, NetworkingMode::Passt { .. }) {
+        return Err(Error::Io {
+            context: "NetworkingMode::Passt requires the supervisor entry point; \
+                 call `run_supervisor` rather than `start` / `start_enter` directly"
+                .to_string(),
+        });
+    }
+    Ok(krun)
+}
+
+/// Plan 87 W1+W2 — configure() variant that owns a `PasstSupervisor`
+/// for the lifetime of the returned context. Used by [`run_supervisor`]
+/// when `NetworkingMode::Passt` is set. The handle Drop's after libkrun
+/// finishes consuming the fd and the guest exits.
+#[cfg(all(feature = "libkrun-sys", target_family = "unix"))]
+fn configure_with_passt(
+    ctx: &KrunContext,
+) -> Result<(sys::Context, Option<passt::PasstHandle>), Error> {
+    let krun = configure_pre_net(ctx)?;
+    let handle = match &ctx.networking {
+        NetworkingMode::Tsi => None,
+        NetworkingMode::Passt { mac, scratch_dir } => {
+            let handle =
+                passt::spawn(std::path::Path::new(scratch_dir)).map_err(|e| Error::Io {
+                    context: format!("spawning passt for NetworkingMode::Passt: {e}"),
+                })?;
+            krun.add_net_unixstream_fd(
+                handle.socket_fd(),
+                mac,
+                sys::PASST_NET_FEATURES,
+                /* flags = */ 0,
+            )?;
+            Some(handle)
+        }
+    };
+    Ok((krun, handle))
+}
+
+/// Plan 87 — every part of `configure` that doesn't touch the
+/// networking backend. Shared between the plain `configure` path
+/// (TSI-only) and `configure_with_passt`.
+#[cfg(feature = "libkrun-sys")]
+fn configure_pre_net(ctx: &KrunContext) -> Result<sys::Context, Error> {
     let krun = sys::Context::new()?;
     krun.set_vm_config(ctx.vcpus, ctx.ram_mib)?;
-    // ARM64 Linux kernels build as the "Image" format (a flat binary
-    // header + payload, not ELF). libkrun's `RAW` kernel format consumes
-    // them directly. x86_64 bzImage is also `RAW`. ELF-format kernels
-    // (rare outside test fixtures) would need `KernelFormat::Elf`.
     krun.set_kernel(
         Path::new(&ctx.kernel_path),
         sys::KernelFormat::Raw,
@@ -461,66 +514,15 @@ fn configure(ctx: &KrunContext) -> Result<sys::Context, Error> {
     for disk in &ctx.extra_disks {
         krun.add_disk(&disk.id, Path::new(&disk.path), disk.read_only)?;
     }
-    // virtio-fs shares (Plan 72 W4): each entry becomes a
-    // `mount -t virtiofs <tag>` target inside the guest. libkrun
-    // spawns one virtiofsd daemon per share internally.
     for mount in &ctx.virtio_fs_mounts {
         krun.add_virtiofs(&mount.tag, Path::new(&mount.host_path))?;
     }
-    // libkrun's vsock model — refined by plan 57 W4 after a closer
-    // read of `libkrun.h`:
-    //
-    // - TSI (Transparent Socket Impersonation) is auto-enabled when
-    //   no virtio-net device is added. The libkrun README is
-    //   explicit: "TSI for AF_INET and AF_INET6 is automatically
-    //   enabled when no network interface is added to the VM." We
-    //   never call `krun_add_net_*`, so TSI is always on, and the
-    //   virtio-vsock device exists implicitly.
-    //
-    // - `krun_add_vsock` is for *adding a second independent*
-    //   virtio-vsock device, and requires `krun_disable_implicit_vsock`
-    //   first. Because TSI already provides one, naively calling it
-    //   returns `-EEXIST` (verified on libkrun 1.17.4). Do not use
-    //   from mvm's path.
-    //
-    // - **Direction matters.** `krun_add_vsock_port` (no `_2`)
-    //   documents "port that the guest will connect to for IPC" —
-    //   guest is the client, host is the server, host binds the
-    //   listener. `krun_add_vsock_port2(..., listen=true)` flips
-    //   it: "guest expects connections to be initiated from host
-    //   side" — guest is the server, libkrun creates the unix
-    //   socket file as a listener, host processes connect as
-    //   clients. mvm's guest agent always *listens* on
-    //   `GUEST_AGENT_PORT`, so `listen=true` is the right mode for
-    //   every vsock port we register here. The W3.3 PR used
-    //   `add_vsock_port` (no `_2`); that was the wrong direction
-    //   but happened to boot because nothing in the guest actually
-    //   tried to use vsock. W4 corrects it.
     for &port in &ctx.vsock_ports {
         let socket = ctx.vsock_socket_path(port);
         krun.add_vsock_port2(port, &socket, /* listen = */ true)?;
     }
     if let Some(console_path) = &ctx.console_output_path {
         krun.set_console_output(Path::new(console_path))?;
-    }
-    // Plan 87 / ADR-055: networking backend dispatch. TSI is the
-    // default (auto-enabled when no virtio-net device is added);
-    // Passt adds a virtio-net device via krun_add_net_unixstream and
-    // implicitly disables TSI. The two are mutually exclusive at the
-    // libkrun layer.
-    match &ctx.networking {
-        NetworkingMode::Tsi => {
-            // Nothing to do — libkrun enables TSI implicitly when no
-            // virtio-net device is added.
-        }
-        NetworkingMode::Passt { socket_fd, mac } => {
-            krun.add_net_unixstream_fd(
-                *socket_fd,
-                mac,
-                sys::PASST_NET_FEATURES,
-                /* flags = */ 0,
-            )?;
-        }
     }
     Ok(krun)
 }
@@ -700,7 +702,22 @@ pub fn run_supervisor(cfg: &SupervisorConfig) -> Result<std::convert::Infallible
     std::fs::write(&pid_path, &pid).map_err(|e| Error::Io {
         context: format!("write pid file {}: {e}", pid_path.display()),
     })?;
-    start_enter(&cfg.krun)
+
+    if !is_available() {
+        return Err(Error::NotInstalled {
+            install_hint: install_hint(),
+        });
+    }
+
+    // Plan 87 W3: when NetworkingMode::Passt is set, the supervisor
+    // owns the passt child process. `_passt_handle` lives until the
+    // end of this function; libkrun's `start_enter` calls `exit()`
+    // on the success path, so the handle's Drop runs as part of
+    // process teardown when the guest powers off. On error paths
+    // the handle Drops normally and SIGTERMs passt before we return.
+    let (krun, _passt_handle) = configure_with_passt(&cfg.krun)?;
+    install_shutdown_handler(&krun)?;
+    krun.start_enter()
 }
 
 /// Non-FFI-feature stub so callers can reference the function name

--- a/nix/ur-seed/flake.nix
+++ b/nix/ur-seed/flake.nix
@@ -322,6 +322,50 @@
           '';
           urSeedCmdlineFile = pkgs.writeText "cmdline.txt"
             "console=hvc0 root=/dev/vda ro rootfstype=ext4 init=/sbin/ur-seed-init";
+
+          # Plan 87 W4 — busybox udhcpc default script. When
+          # `udhcpc -s /etc/udhcpc/default.script` runs after passt
+          # hands out a DHCP lease, busybox calls this hook with the
+          # action ("deconfig" / "bound" / "renew") in $1 and the
+          # lease fields in env vars ($ip, $mask, $router, $dns, …).
+          # We:
+          #   * bring eth0 up with the leased IP + mask on "bound"/"renew"
+          #   * install the default route via $router
+          #   * write nameservers from $dns into /etc/resolv.conf
+          # /etc is on the read-only rootfs, but /etc/resolv.conf is a
+          # symlink (set up at boot) to /run/resolv.conf — /run is a
+          # tmpfs mvm-builder-init mounts. The dev image flake's
+          # equivalent script (`nix/lib/udhcpc-default.script`) follows
+          # the same shape.
+          udhcpcDefaultScript = pkgs.writeScript "udhcpc-default.script" ''
+            #!/bin/sh
+            set -eu
+            case "$1" in
+              deconfig)
+                ip link set "$interface" up || true
+                ip -4 addr flush dev "$interface" || true
+                ;;
+              renew|bound)
+                ip link set "$interface" up
+                ip -4 addr flush dev "$interface"
+                ip -4 addr add "$ip/$mask" dev "$interface"
+                if [ -n "''${router:-}" ]; then
+                  for r in $router; do
+                    ip -4 route add default via "$r" dev "$interface" || true
+                  done
+                fi
+                # /run is tmpfs (mounted by mvm-builder-init); /etc/resolv.conf
+                # is symlinked there by the rootfs build.
+                : > /run/resolv.conf
+                if [ -n "''${domain:-}" ]; then
+                  printf 'search %s\n' "$domain" >> /run/resolv.conf
+                fi
+                for ns in ''${dns:-}; do
+                  printf 'nameserver %s\n' "$ns" >> /run/resolv.conf
+                done
+                ;;
+            esac
+          '';
         in
         pkgs.runCommand "mvm-ur-seed-${system}"
           {
@@ -419,8 +463,24 @@
             cp ${passwdFile}   $staging/etc/passwd
             cp ${groupFile}    $staging/etc/group
             cp ${nsswitchFile} $staging/etc/nsswitch.conf
-            cp ${resolvFile}   $staging/etc/resolv.conf
             cp ${manifestJson} $staging/etc/mvm-ur-seed.json
+
+            # Plan 87 W4 — resolv.conf is a symlink into /run/resolv.conf
+            # (tmpfs, mounted by mvm-builder-init). Pre-create the symlink
+            # so udhcpc's hook script writes the right file from boot 1.
+            # The static fallback content (1.1.1.1 / 8.8.8.8) is staged
+            # at /etc/resolv.conf.fallback — Plan 87 W4's udhcpc hook
+            # uses it before the DHCP lease lands; the TSI fallback
+            # path also reads it.
+            ln -sf /run/resolv.conf $staging/etc/resolv.conf
+            cp ${resolvFile} $staging/etc/resolv.conf.fallback
+
+            # Plan 87 W4 — busybox udhcpc default hook. Installed
+            # under `/etc/udhcpc/default.script` so
+            # `udhcpc -s /etc/udhcpc/default.script` picks it up.
+            mkdir -p $staging/etc/udhcpc
+            cp ${udhcpcDefaultScript} $staging/etc/udhcpc/default.script
+            chmod +x $staging/etc/udhcpc/default.script
 
             # Kernel modules. mvm-builder-init runs
             # `modprobe virtiofs fuse` before mounting the host shares;

--- a/specs/adrs/055-passt-virtio-net.md
+++ b/specs/adrs/055-passt-virtio-net.md
@@ -1,6 +1,6 @@
 # ADR-055 — libkrun networking via passt + virtio-net
 
-**Status:** proposed 2026-05-18, implements Plan 87.
+**Status:** accepted 2026-05-19, implements Plan 87. Default flipped from TSI → Passt by Plan 87 W5 / PR3 (this PR).
 
 ## Context
 


### PR DESCRIPTION
Stacked on #356 (Plan 87 W3 + W4). Once #356 merges, this PR rebases cleanly onto main.

## Summary

**Default network backend flip:**
- `resolve_networking_mode()` defaults to `Passt` (was `Tsi`). `MVM_NETWORKING=tsi` remains available as the opt-back-to-TSI escape hatch.
- TSI is libkrun's experimental no-network-stack mode — works for the trivial HTTP case, breaks on the patterns nix needs. Passt is the production-ready path (see ADR-055).

**libkrun-sys default-on for the `mvmctl` binary (macOS only):**
- Root `Cargo.toml` adds a target-gated dep entry that enables `mvm-cli/libkrun-sys` on `cfg(target_os = "macos")` only. Linux CI (no `libkrun-dev` package) keeps building cleanly; macOS gets `extract_bundled_kernel()` wired by default so `cargo run -- dev up` doesn't need a manual `--features libkrun-sys`.
- `mvm-cli` library stays opt-in (commit e7a445e5) — only the binary turns it on.
- Closes the PR #351 regression (that one enabled `libkrun-sys` unconditionally and broke Ubuntu CI's `Test` / `Lint` jobs). Target-gating preserves cross-platform CI.

**ADR-055 status:** `proposed` → `accepted`.

## Test plan

- [x] `cargo check --workspace` clean
- [x] `cargo test --workspace --lib` — 226 `mvm-build` tests + 16 `mvm-libkrun` tests pass
- [x] `cargo clippy --workspace -- -D warnings` clean
- [x] `cargo fmt --check` clean
- [x] Updated `resolve_networking_mode_parses_env` covers the new default semantics
- [ ] End-to-end smoke: `cargo run -- dev up` on a host with passt + libkrun + libkrunfw installed (verified manually once #356 merges)

## What's left for Plan 87

- **PR4**: `mvmctl doctor` passt probe + install docs

🤖 Generated with [Claude Code](https://claude.com/claude-code)