### PR TITLE
feat(libkrun): per-OS network backend + doctor probe (Plan 88 W3 + W4)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -18,14 +18,17 @@ Lima was the historical macOS host abstraction. It was removed on 2026-05-14 (Pl
 `mvmctl dev up` and the libkrun-backed builder VM need three Homebrew packages installed:
 
 ```sh
-brew install libkrun libkrunfw passt
+brew install slp/krun/libkrun slp/krun/libkrunfw slp/krun/gvproxy
 ```
 
 - `libkrun` — the in-process VMM. `mvm-libkrun-supervisor` links against it.
 - `libkrunfw` — bundles the TSI-patched Linux kernel libkrun's guests boot. Plan 86 / Plan 72 W5.D bullet 10 — `mvm-libkrun::extract_bundled_kernel()` pulls the kernel out of the dylib's `.rodata` at runtime.
-- `passt` — userspace network gateway providing virtio-net to the guest. Plan 87 / ADR-055 made this the default networking backend (`MVM_NETWORKING=passt`); `MVM_NETWORKING=tsi` opts back to libkrun's experimental TSI mode for debugging.
+- `gvproxy` — userspace virtio-net gateway. Plan 88 / ADR-055 §"Cross-platform backends" — passt is Linux-only, so macOS dispatches to gvproxy via libkrun's `krun_add_net_unixgram` path. `MVM_NETWORKING` unset → per-OS default (macOS=gvproxy, Linux=passt); `=tsi` opts back to libkrun's experimental no-network-stack mode for debugging.
 
-`mvmctl doctor` probes all three and emits install hints for whichever are missing.
+On Linux contributor hosts swap `gvproxy` for `passt` from the distro
+package manager (or build passt from source — see ADR-055 references).
+
+`mvmctl doctor` probes the right gateway per OS and emits install hints when missing.
 
 ## Architecture
 

--- a/crates/mvm-build/src/libkrun_builder.rs
+++ b/crates/mvm-build/src/libkrun_builder.rs
@@ -103,30 +103,77 @@ pub const GUEST_NIX_DIR: &str = "/nix";
 /// under this path (read-write virtio-fs). Plan 72 W4 wires this.
 pub const GUEST_JOB_DIR: &str = "/job";
 
-/// Plan 87 W3: caller-visible networking-backend preference. Read from
-/// the `MVM_NETWORKING` env var at every VM-launch site. Default
-/// stays Tsi for backward compat; PR3 in Plan 87 flips this once W4
-/// in-VM udhcpc wiring lands and CI installs the host-side deps.
+/// Caller-visible networking-backend preference. Read from
+/// the `MVM_NETWORKING` env var at every VM-launch site.
+///
+/// Plan 87 introduced `Passt` (virtio-net via the userspace passt
+/// gateway). Plan 88 added `Gvproxy` for macOS, where passt does not
+/// build (`vmsplice`/namespace primitives are Linux-only — see
+/// ADR-055 §"Cross-platform backends").
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum NetworkingPreference {
-    /// libkrun's built-in TSI (no virtio-net, no DHCP). Default.
+    /// libkrun's built-in TSI (no virtio-net, no DHCP).
     Tsi,
-    /// virtio-net via passt. Requires libkrun-sys + passt installed on
-    /// the host. The supervisor process spawns passt as a child.
+    /// virtio-net via passt. Linux-only. Requires libkrun-sys + the
+    /// `passt` binary on `$PATH`. The supervisor process spawns
+    /// passt as a child and hands its fd to libkrun.
     Passt,
+    /// virtio-net via gvproxy. macOS default; works on Linux too.
+    /// Requires libkrun-sys + the `gvproxy` binary on `$PATH`. The
+    /// supervisor spawns gvproxy with `-listen-vfkit unixgram://…`
+    /// and libkrun connects to the listener path.
+    Gvproxy,
 }
 
-/// Read `MVM_NETWORKING` from the env. Accepts `tsi` and `passt`
-/// (case-insensitive); anything else falls back to the default and
-/// emits a debug log so a typo is visible without aborting.
+/// Apply the resolved [`NetworkingPreference`] to a [`KrunContext`].
+/// Dispatches `with_passt`, `with_gvproxy`, or leaves the context's
+/// default `Tsi` mode in place — keeping the two builder-VM call
+/// sites (shell-job + flake-build) in lockstep. Each gateway uses
+/// `<vm_state_dir>` for its log/socket scratch space.
+fn apply_networking_mode(
+    krun: KrunContext,
+    vm_state_dir: &std::path::Path,
+) -> Result<KrunContext, BuilderVmError> {
+    let scratch = path_to_str(vm_state_dir, "vm_state_dir")?;
+    Ok(match resolve_networking_mode() {
+        NetworkingPreference::Tsi => krun,
+        NetworkingPreference::Passt => {
+            krun.with_passt(mvm_libkrun::passt::DEFAULT_GUEST_MAC, scratch)
+        }
+        NetworkingPreference::Gvproxy => {
+            krun.with_gvproxy(mvm_libkrun::gvproxy::DEFAULT_GUEST_MAC, scratch)
+        }
+    })
+}
+
+/// Per-host-OS default networking backend.
 ///
-/// Plan 87 W5 / PR3 flipped the default from `Tsi` to `Passt`. TSI is
-/// libkrun's experimental no-network-stack mode; it works for
+/// macOS → [`Gvproxy`](NetworkingPreference::Gvproxy) because passt
+/// does not build there (the Homebrew formula refuses with "Linux is
+/// required for this software"); everything else (Linux today) →
+/// [`Passt`](NetworkingPreference::Passt). See ADR-055
+/// §"Cross-platform backends" for the rationale.
+pub fn default_networking_mode() -> NetworkingPreference {
+    if cfg!(target_os = "macos") {
+        NetworkingPreference::Gvproxy
+    } else {
+        NetworkingPreference::Passt
+    }
+}
+
+/// Read `MVM_NETWORKING` from the env. Accepts `tsi`, `passt`, and
+/// `gvproxy` (case-insensitive); anything else falls back to the
+/// per-OS default and emits a warning so a typo is visible without
+/// aborting.
+///
+/// Plan 87 W5 / PR3 flipped the default away from TSI; Plan 88
+/// added the per-OS dispatch (macOS → gvproxy, Linux → passt). TSI
+/// is libkrun's experimental no-network-stack mode; it works for
 /// trivial HTTP but breaks on nix's substituter and source fetches
 /// (HTTP/2 multiplexing, HTTPS redirect chains, the offline-mode
-/// probe — see ADR-055 §"Context"). Passt-backed virtio-net is the
-/// production-ready path. Contributors can still opt back to TSI via
-/// `MVM_NETWORKING=tsi` for debugging.
+/// probe — see ADR-055 §"Context"). Contributors can still opt back
+/// to TSI via `MVM_NETWORKING=tsi` for debugging, or pin a specific
+/// gateway across OS via `MVM_NETWORKING=passt` / `=gvproxy`.
 pub fn resolve_networking_mode() -> NetworkingPreference {
     match std::env::var("MVM_NETWORKING")
         .ok()
@@ -136,13 +183,17 @@ pub fn resolve_networking_mode() -> NetworkingPreference {
         .as_deref()
     {
         Some("tsi") => NetworkingPreference::Tsi,
-        Some("passt") | None | Some("") => NetworkingPreference::Passt,
+        Some("passt") => NetworkingPreference::Passt,
+        Some("gvproxy") => NetworkingPreference::Gvproxy,
+        None | Some("") => default_networking_mode(),
         Some(other) => {
+            let fallback = default_networking_mode();
             tracing::warn!(
                 value = other,
-                "MVM_NETWORKING unrecognised; falling back to Passt (accepted: tsi, passt)"
+                fallback = ?fallback,
+                "MVM_NETWORKING unrecognised; falling back to per-OS default (accepted: tsi, passt, gvproxy)"
             );
-            NetworkingPreference::Passt
+            fallback
         }
     }
 }
@@ -307,19 +358,7 @@ impl LibkrunBuilderVm {
             );
         }
 
-        // Plan 87 W3: opt into passt-backed virtio-net when
-        // MVM_NETWORKING=passt. The supervisor spawns the passt child
-        // and logs to <vm_state_dir>/passt.log; libkrun's
-        // `krun_add_net_unixstream` consumes the fd. Without the env
-        // var (or with any other value) we stay on TSI for backward
-        // compat — Plan 87 PR3 flips the default once the W4 in-VM
-        // wiring lands and CI installs passt + libkrunfw.
-        if resolve_networking_mode() == NetworkingPreference::Passt {
-            krun = krun.with_passt(
-                mvm_libkrun::passt::DEFAULT_GUEST_MAC,
-                path_to_str(&vm_state_dir, "vm_state_dir")?,
-            );
-        }
+        krun = apply_networking_mode(krun, &vm_state_dir)?;
 
         let cfg = SupervisorConfig {
             krun,
@@ -568,17 +607,7 @@ impl BuilderVm for LibkrunBuilderVm {
         .add_virtio_fs("out", path_to_str(&mounts.artifact_out, "artifact_out")?)
         .add_virtio_fs("job", path_to_str(&job_dir, "job_dir")?);
 
-        // Plan 87 W3: same env-var opt-in as the shell-job path. See
-        // `LibkrunBuilderVm::dispatch_shell_job` for the rationale —
-        // when `MVM_NETWORKING=passt` is set the supervisor spawns
-        // passt and libkrun consumes its socket fd. Default stays TSI
-        // until PR3 flips it.
-        if resolve_networking_mode() == NetworkingPreference::Passt {
-            krun = krun.with_passt(
-                mvm_libkrun::passt::DEFAULT_GUEST_MAC,
-                path_to_str(&vm_state_dir, "vm_state_dir")?,
-            );
-        }
+        krun = apply_networking_mode(krun, &vm_state_dir)?;
 
         // 8. Drive the supervisor: pipe `SupervisorConfig` to
         //    stdin and **wait** for the child to exit. Unlike
@@ -1511,9 +1540,9 @@ mod tests {
         // SAFETY: tests guarded by ENV_LOCK; env mutation in test
         // process is fine when serialized.
         unsafe {
-            // Plan 87 W5 / PR3: default is Passt; opt out via tsi.
+            // Plan 88: default is per-OS — macOS → Gvproxy, others → Passt.
             std::env::remove_var("MVM_NETWORKING");
-            assert_eq!(resolve_networking_mode(), NetworkingPreference::Passt);
+            assert_eq!(resolve_networking_mode(), default_networking_mode());
 
             std::env::set_var("MVM_NETWORKING", "tsi");
             assert_eq!(resolve_networking_mode(), NetworkingPreference::Tsi);
@@ -1524,15 +1553,31 @@ mod tests {
             std::env::set_var("MVM_NETWORKING", " passt ");
             assert_eq!(resolve_networking_mode(), NetworkingPreference::Passt);
 
-            std::env::set_var("MVM_NETWORKING", "");
-            assert_eq!(resolve_networking_mode(), NetworkingPreference::Passt);
+            std::env::set_var("MVM_NETWORKING", "GVPROXY");
+            assert_eq!(resolve_networking_mode(), NetworkingPreference::Gvproxy);
 
-            std::env::set_var("MVM_NETWORKING", "gvproxy");
-            // Unknown value → fall back to the default (Passt) without panic.
-            assert_eq!(resolve_networking_mode(), NetworkingPreference::Passt);
+            std::env::set_var("MVM_NETWORKING", " gvproxy ");
+            assert_eq!(resolve_networking_mode(), NetworkingPreference::Gvproxy);
+
+            std::env::set_var("MVM_NETWORKING", "");
+            assert_eq!(resolve_networking_mode(), default_networking_mode());
+
+            // Unknown value falls back to the per-OS default without panic.
+            std::env::set_var("MVM_NETWORKING", "vmnet-helper");
+            assert_eq!(resolve_networking_mode(), default_networking_mode());
 
             std::env::remove_var("MVM_NETWORKING");
         }
+    }
+
+    #[test]
+    fn default_networking_mode_matches_host_os() {
+        let expected = if cfg!(target_os = "macos") {
+            NetworkingPreference::Gvproxy
+        } else {
+            NetworkingPreference::Passt
+        };
+        assert_eq!(default_networking_mode(), expected);
     }
 
     #[test]

--- a/crates/mvm-cli/src/doctor.rs
+++ b/crates/mvm-cli/src/doctor.rs
@@ -214,7 +214,7 @@ pub fn run(json: bool, workflow: Option<DoctorWorkflow>) -> Result<()> {
     checks.push(kvm_check(plat, false));
     checks.push(apple_container_check(plat));
     checks.push(libkrun_check(plat));
-    checks.push(passt_check(plat));
+    checks.push(network_backend_check(plat));
     checks.push(docker_check(plat));
     checks.push(ts_runner_check());
 
@@ -651,29 +651,55 @@ fn docker_check(plat: Platform) -> Check {
     }
 }
 
-/// `passt` host-side availability — Plan 87 W5. Probes `$PATH` for
-/// the passt binary; surfaces the version when present and the
-/// install hint when missing. `ok: true` regardless — passt is only
-/// strictly required when `MVM_NETWORKING=passt` (the default after
-/// Plan 87 PR3). The TSI fallback still works without it.
+/// Userspace network-gateway host-side availability — Plan 87 W5 +
+/// Plan 88 W4. Probes `$PATH` for the gateway binary the host's
+/// libkrun build defaults to: `passt` on Linux, `gvproxy` on macOS
+/// (passt does not build on macOS — see ADR-055 §"Cross-platform
+/// backends"). Surfaces the version when present and the install
+/// hint when missing. `ok: true` regardless: TSI mode
+/// (`MVM_NETWORKING=tsi`) still works without either gateway.
 ///
 /// Skipped on Windows (no native libkrun port either; the whole
-/// libkrun + passt stack is macOS / Linux).
+/// libkrun + virtio-net stack is macOS / Linux).
 #[cfg(target_family = "unix")]
-fn passt_check(plat: Platform) -> Check {
+fn network_backend_check(plat: Platform) -> Check {
     if plat.is_windows() {
         return Check {
-            name: "passt",
+            name: "network-backend",
             category: "platform",
             ok: true,
             info: "n/a (no native Windows port)".to_string(),
         };
     }
-    match mvm_libkrun::passt::locate_passt() {
+    if cfg!(target_os = "macos") {
+        return gateway_check(
+            "gvproxy",
+            mvm_libkrun::gvproxy::locate_gvproxy(),
+            mvm_libkrun::gvproxy::install_hint(),
+        );
+    }
+    gateway_check(
+        "passt",
+        mvm_libkrun::passt::locate_passt(),
+        mvm_libkrun::passt::install_hint(),
+    )
+}
+
+/// Shared probe body for the per-OS userspace gateway. Returns a
+/// `Check` row with the version (when the binary supports
+/// `--version`) or the install hint (when missing). `ok: true`
+/// regardless — `MVM_NETWORKING=tsi` is a documented escape hatch.
+#[cfg(target_family = "unix")]
+fn gateway_check(
+    name: &'static str,
+    located: Option<std::path::PathBuf>,
+    install_hint: &str,
+) -> Check {
+    match located {
         Some(path) => {
-            // Best-effort version probe — `passt --version` writes to
-            // stdout on Linux and macOS (Homebrew build). Failure is
-            // not fatal; we surface "available" without a version.
+            // Best-effort version probe. passt prints to stdout;
+            // gvproxy 0.7+ recognises `--version` (older builds
+            // exit nonzero, which we silently fall through on).
             let version = std::process::Command::new(&path)
                 .arg("--version")
                 .output()
@@ -696,21 +722,20 @@ fn passt_check(plat: Platform) -> Check {
                 None => format!("available at {}", path.display()),
             };
             Check {
-                name: "passt",
+                name,
                 category: "platform",
                 ok: true,
                 info,
             }
         }
         None => Check {
-            name: "passt",
+            name,
             category: "platform",
-            ok: true, // Optional; only strictly needed for MVM_NETWORKING=passt.
+            ok: true, // Optional; only strictly needed for MVM_NETWORKING != tsi.
             info: format!(
-                "not available ({}) — required for the default `MVM_NETWORKING=passt` \
-                 libkrun networking path; set `MVM_NETWORKING=tsi` to opt back to \
-                 libkrun's built-in TSI mode while you install it",
-                mvm_libkrun::passt::install_hint()
+                "not available ({install_hint}) — required for the default \
+                 libkrun virtio-net path; set `MVM_NETWORKING=tsi` to opt back \
+                 to libkrun's built-in TSI mode while you install it"
             ),
         },
     }
@@ -718,12 +743,12 @@ fn passt_check(plat: Platform) -> Check {
 
 /// Windows stub — keeps the call site cfg-free.
 #[cfg(not(target_family = "unix"))]
-fn passt_check(_plat: Platform) -> Check {
+fn network_backend_check(_plat: Platform) -> Check {
     Check {
-        name: "passt",
+        name: "network-backend",
         category: "platform",
         ok: true,
-        info: "n/a (no Unix passt port on this OS)".to_string(),
+        info: "n/a (no Unix libkrun port on this OS)".to_string(),
     }
 }
 


### PR DESCRIPTION
## Summary

Plan 88 W3 + W4 — wires the per-OS userspace network gateway dispatch on top of the W1+W2 FFI + supervisor (#362, just merged).

- **W3** (`mvm-build`): `NetworkingPreference::Gvproxy` + `default_networking_mode()` per-OS (macOS → Gvproxy, Linux → Passt). `MVM_NETWORKING=gvproxy` accepted explicitly; unset / unknown falls back to the per-OS default. Both call sites in `LibkrunBuilderVm` (shell-job + flake-build) share one `apply_networking_mode()` helper. TSI remains the documented escape hatch.
- **W4** (`mvm-cli` doctor): `passt_check` → `network_backend_check` — probes `gvproxy` on macOS, `passt` on Linux. Surfaces per-OS install hint when missing. `ok: true` regardless.
- **Docs**: CLAUDE.md "Host dependencies (macOS)" now points at `brew install slp/krun/{libkrun,libkrunfw,gvproxy}` with the passt-Linux-only caveat called out.

Plan: `specs/plans/88-gvproxy-macos-backend.md` (PR2 of the W1+W2 / W3+W4 / W5 / W6 sequence)
ADR: `specs/adrs/055-passt-virtio-net.md` §"Cross-platform backends"

## Test plan

- [x] `cargo build --workspace --all-features` clean
- [x] `cargo test --workspace --all-features --no-fail-fast` — all green; new tests `default_networking_mode_matches_host_os` + `resolve_networking_mode_parses_env` cover the parser + per-OS default
- [x] `cargo clippy --workspace --all-features -- -D warnings` — clean
- [ ] Plan 88 W5 smoke (`cargo run -- dev up` on macOS with default `MVM_NETWORKING` unset) — follow-up PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)