### PR TITLE
perf(builder): hardlink duplicate paths in builder VM nix store

### DIFF
--- a/crates/mvm-build/src/libkrun_builder.rs
+++ b/crates/mvm-build/src/libkrun_builder.rs
@@ -868,6 +868,7 @@ sandbox = false
 build-users-group =
 max-jobs = auto
 cores = 0
+auto-optimise-store = true
 substituters = https://cache.nixos.org/
 trusted-public-keys = cache.nixos.org-1:6NCHdD59X431o0gWypbMrAURkbJ16ZPMQFGspcDShjY="
 # Plan 72 W0's flake convention: workspace-path env var so
@@ -1870,6 +1871,7 @@ mod tests {
         assert!(cmd.contains("cd /work"));
         assert!(cmd.contains("max-jobs = auto"));
         assert!(cmd.contains("cores = 0"));
+        assert!(cmd.contains("auto-optimise-store = true"));
         assert!(cmd.contains("printf '%s\\n' \"$NIX_OUT\" > /job/store-path"));
     }
 


### PR DESCRIPTION
## Summary

- Adds `auto-optimise-store = true` to the `NIX_CONFIG` heredoc emitted into the builder VM's `cmd.sh` so every `nix-store --add` hardlinks content-identical files at insertion time. Saves space on the persistent virtio-blk `/nix` disk and improves page-cache density across builds.
- One unit-test assertion added to lock the setting in place.

## Why not `keep-outputs` / `keep-derivations`?

Those only influence `nix-collect-garbage`, which the single-shot builder VM never runs. They'd be inert noise, so they're dropped.

## Follow-up sequencing

Plan 87 W3 is about to rework this same `NIX_CONFIG` block (dropping the explicit `substituters = …` line in favor of nix defaults once passt lands). This addition sits on its own line and should rebase cleanly past that work.

## Test plan

- [x] `cargo test -p mvm-build --features builder-vm` (283/283)
- [x] `cargo clippy -p mvm-build --features builder-vm --all-targets -- -D warnings`
- [x] `cargo test` (workspace-root default, matches CI lane)
- [x] `cargo clippy --all-targets -- -D warnings` (workspace-root default, matches CI lane)

🤖 Generated with [Claude Code](https://claude.com/claude-code)