### PR TITLE
perf(builder): persist Nix flake eval-cache across builder VM runs

### DIFF
--- a/crates/mvm-build/src/libkrun_builder.rs
+++ b/crates/mvm-build/src/libkrun_builder.rs
@@ -869,15 +869,22 @@ set -eu
 FLAKE_REF='{flake_ref}'
 ATTR_PATH='{attr_path}'
 
-# Point HOME and Nix's cache/state dirs at the writable tmpfs (`/tmp`).
-# The rootfs is mounted `ro`, so nix tries `~/.cache/nix` and bails
-# with "creating directory '//.cache/nix': Read-only file system"
-# when HOME stays at the default `/`. /tmp is tmpfs, lives only for
-# this VM's lifetime — fine for a single-shot build.
+# Point HOME at writable tmpfs (`/tmp`) to satisfy code paths that
+# write to `~/...` (the rootfs is mounted `ro`; nix would otherwise
+# bail with "creating directory '//.cache/nix': Read-only file
+# system"). XDG_CACHE_HOME lives on the persistent `/nix-store`
+# disk so Nix's eval-cache-v5, tarball-cache, and binary-cache-v6
+# survive across builds — cold flake eval is the long pole on
+# warm-store rebuilds, and these caches reclaim it. `/nix-store`
+# is the ext4 root for the persistent virtio-blk device; it sits
+# alongside the overlay upperdir (`/nix-store/upper`) at the
+# disk's top level, so writes here don't pollute the Nix store
+# namespace. XDG_STATE_HOME stays on tmpfs: it only holds profile
+# generations, which one-shot build VMs don't use.
 export HOME=/tmp
-export XDG_CACHE_HOME=/tmp/.cache
+export XDG_CACHE_HOME=/nix-store/.cache
 export XDG_STATE_HOME=/tmp/.local/state
-mkdir -p /tmp/.cache /tmp/.local/state
+mkdir -p /nix-store/.cache /tmp/.local/state
 
 # CA certs for TLS to cache.nixos.org / api.github.com.
 export CURL_CA_BUNDLE=/etc/ssl/certs/ca-bundle.crt
@@ -1917,6 +1924,7 @@ mod tests {
         assert!(cmd.contains("max-jobs = auto"));
         assert!(cmd.contains("cores = 0"));
         assert!(cmd.contains("auto-optimise-store = true"));
+        assert!(cmd.contains("XDG_CACHE_HOME=/nix-store/.cache"));
         assert!(cmd.contains("printf '%s\\n' \"$NIX_OUT\" > /job/store-path"));
     }
 


### PR DESCRIPTION
## Summary

cmd.sh previously pointed `XDG_CACHE_HOME` at `/tmp/.cache` (tmpfs), so every build paid the full cold-eval cost — re-evaluating the flake from scratch and re-fetching every flake input tarball even when the closure was already in the persistent `/nix` store. This moves `XDG_CACHE_HOME` to `/nix-store/.cache` (on the persistent virtio-blk disk), so Nix's `eval-cache-v5`, tarball-cache, and `binary-cache-v6` survive across builds.

## Why `/nix-store/.cache`?

`/nix-store` is the ext4 mount root of the persistent virtio-blk device (`/dev/vdb`). The `/nix` overlay sits on top of it (with `/nix-store/upper` as upperdir and the rootfs's seed `/nix/store` as lowerdir). Writing the cache to `/nix-store/.cache` puts it on the same persistent disk but **outside** the Nix store namespace, so it doesn't interfere with `nix-store --verify` or with the overlay's lowerdir/upperdir bookkeeping.

## Why not also move HOME / XDG_STATE_HOME?

- `HOME=/tmp` stays — needed for code paths that write to `~/...` directly, and there's nothing useful for one-shot VMs to persist in `$HOME` once XDG cache is rehomed.
- `XDG_STATE_HOME=/tmp/.local/state` stays — Nix only puts profile generations there. One-shot build VMs don't use profiles, so persisting them would just accumulate dead state.

## Concurrency note

If two builder VMs run simultaneously on the same host (e.g. parallel `mvmctl dev up` across worktrees), they share the same persistent disk image, so the eval-cache sqlite files are now contended. SQLite WAL handles single-writer / multi-reader fine, but two parallel writers can deadlock. This is the same shared-disk concurrency posture that already existed for the Nix store itself — no new failure mode, just a slightly larger contention surface. If it bites in practice, the next step is per-instance overlay for the cache dir.

## Sequencing with #367

This branch was cut from `main` before #367 (auto-optimise-store) merged. The two patches touch different parts of cmd.sh (NIX_CONFIG vs. XDG env vars) and won't conflict syntactically. Whichever lands second will need to add the other PR's test assertion to the same test function — trivial rebase.

## Test plan

- [x] `cargo test -p mvm-build --features builder-vm` — 283/283 pass, new assertion locks in `XDG_CACHE_HOME=/nix-store/.cache`
- [x] `cargo clippy -p mvm-build --features builder-vm --all-targets -- -D warnings` — clean
- [x] `cargo test` (workspace root, default features, matches CI test job) — 92/92 pass
- [x] `cargo clippy --all-targets -- -D warnings` (matches CI lint job) — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)