### PR TITLE
plan(89) W1: production-grade fixture flake + tolerate inner-build failure

### DIFF
--- a/scripts/plan-89-baseline.sh
+++ b/scripts/plan-89-baseline.sh
@@ -12,15 +12,28 @@
 # rest of Plan 89 is not worth shipping. Run this on both platforms
 # and check the summary in.
 #
+# Why the default flake is the W1 fixture, not a real image build:
+# `mvm-builder-init` writes boot-timings.json BEFORE exec'ing
+# cmd.sh — so the boot fan-out we want to measure
+# (init_start_ms → job_start_ms) is captured regardless of whether
+# the inner `nix build` succeeds. The fixture flake at
+# `tests/fixtures/plan-89-baseline/` deliberately throws at
+# evaluation time: it has no inputs, no network fetch, no nixpkgs
+# eval cost, and produces no artifacts. That isolates the
+# measurement to the builder VM boot dance — the actual thing Plan
+# 89 is debating amortizing. Point `--flake` at a real user flake
+# if you want to measure end-to-end wall-clock instead.
+#
 # Usage:
-#   ./scripts/plan-89-baseline.sh                       # 5 runs, default flake
+#   ./scripts/plan-89-baseline.sh                       # 5 runs, fixture flake
 #   ./scripts/plan-89-baseline.sh --runs 10
 #   ./scripts/plan-89-baseline.sh --flake ./my-flake
 #   ./scripts/plan-89-baseline.sh --out /tmp/baseline.md
 #
 # Prerequisites:
-#   - `mvmctl dev up` works on this host (ur-seed installed; libkrun
-#     on macOS or KVM on Linux; gvproxy/passt installed per platform).
+#   - `mvmctl dev up` works on this host (ur-seed installed and a
+#     local dev image staged; libkrun on macOS or KVM on Linux;
+#     gvproxy/passt installed per platform).
 #   - `jq` on PATH.
 #
 # Output: `specs/notes/plan-89-baseline.md` (default).
@@ -28,7 +41,7 @@
 set -euo pipefail
 
 RUNS=5
-FLAKE="nix/images/runtime-overlay"
+FLAKE="tests/fixtures/plan-89-baseline"
 OUT="specs/notes/plan-89-baseline.md"
 
 while [[ $# -gt 0 ]]; do
@@ -49,7 +62,6 @@ command -v mvmctl >/dev/null || { echo "missing mvmctl on PATH — run from repo
 
 JOBS_DIR="${HOME}/.cache/mvm/builder-vm/jobs"
 TMPDIR_RUN="$(mktemp -d)"
-trap 'rm -rf "${TMPDIR_RUN}"' EXIT
 
 OS="$(uname -s)"
 ARCH="$(uname -m)"
@@ -73,21 +85,42 @@ PHASES=(
   job_start_ms
 )
 
+# Snapshot existing job dirs so we can identify per-run dirs by
+# "appeared since BEFORE" rather than relying on mtime sort, which
+# breaks when the builder VM tears down a dir or several runs
+# complete inside a single mtime second.
+JOBS_BEFORE="$(mktemp)"
+trap 'rm -rf "${TMPDIR_RUN}" "${JOBS_BEFORE}"' EXIT
+ls -1 "${JOBS_DIR}" 2>/dev/null | sort >"${JOBS_BEFORE}" || true
+
 for i in $(seq 1 "${RUNS}"); do
   echo "--- run ${i}/${RUNS} ---" >&2
   BEFORE="$(date +%s)"
-  if ! mvmctl build --flake "${FLAKE}" >"${TMPDIR_RUN}/run-${i}.out" 2>&1; then
-    echo "run ${i} failed — log at ${TMPDIR_RUN}/run-${i}.out" >&2
-    echo "first 40 lines:" >&2
+  # We deliberately tolerate non-zero exit: with the W1 fixture flake
+  # the inner `nix build` is expected to fail (throw at eval), and
+  # boot-timings.json is written by builder-init BEFORE cmd.sh runs.
+  # The only "real failure" we care about is missing timings.
+  mvmctl build --flake "${FLAKE}" >"${TMPDIR_RUN}/run-${i}.out" 2>&1 || true
+  AFTER="$(date +%s)"
+  WALL=$(( AFTER - BEFORE ))
+  # Find the job dir this run created: the only entry in JOBS_DIR
+  # that wasn't there before the loop started.
+  JOBS_NOW="$(mktemp)"
+  ls -1 "${JOBS_DIR}" 2>/dev/null | sort >"${JOBS_NOW}" || true
+  NEW_JOB_NAME="$(comm -13 "${JOBS_BEFORE}" "${JOBS_NOW}" | tail -1)"
+  cp "${JOBS_NOW}" "${JOBS_BEFORE}"
+  rm -f "${JOBS_NOW}"
+  if [[ -z "${NEW_JOB_NAME}" ]]; then
+    echo "run ${i}: no new job dir appeared under ${JOBS_DIR}" >&2
+    echo "first 40 lines of build output:" >&2
     head -40 "${TMPDIR_RUN}/run-${i}.out" >&2
     exit 1
   fi
-  AFTER="$(date +%s)"
-  WALL=$(( AFTER - BEFORE ))
-  # Most recently modified job dir = this run's.
-  JOB_DIR="$(ls -1dt "${JOBS_DIR}"/* 2>/dev/null | head -1 || true)"
-  if [[ -z "${JOB_DIR}" || ! -f "${JOB_DIR}/boot-timings.json" ]]; then
-    echo "run ${i}: missing boot-timings.json — got JOB_DIR=${JOB_DIR}" >&2
+  JOB_DIR="${JOBS_DIR}/${NEW_JOB_NAME}"
+  if [[ ! -f "${JOB_DIR}/boot-timings.json" ]]; then
+    echo "run ${i}: ${JOB_DIR}/boot-timings.json missing — builder VM probably crashed before init wrote it" >&2
+    echo "first 40 lines of build output:" >&2
+    head -40 "${TMPDIR_RUN}/run-${i}.out" >&2
     exit 1
   fi
   cp "${JOB_DIR}/boot-timings.json" "${TMPDIR_RUN}/timings-${i}.json"

--- a/specs/notes/plan-89-baseline.md
+++ b/specs/notes/plan-89-baseline.md
@@ -12,9 +12,16 @@ plan on this number exceeding ~500 ms on both platforms.
   place — the harness only appends; it doesn't rewrite the doc.
 
   To run:
-    ./scripts/plan-89-baseline.sh                 # default: 5 runs against nix/images/runtime-overlay
+    ./scripts/plan-89-baseline.sh                 # default: 5 runs against tests/fixtures/plan-89-baseline
     ./scripts/plan-89-baseline.sh --runs 10
-    ./scripts/plan-89-baseline.sh --flake ./nix/images/builder
+    ./scripts/plan-89-baseline.sh --flake ./my-flake
+
+  The default flake at tests/fixtures/plan-89-baseline is
+  intentionally a throw-on-eval flake — see its description for
+  rationale. The harness tolerates the inner `nix build` failing
+  because boot-timings.json is written BEFORE cmd.sh runs, so all
+  the boot fan-out phases the plan cares about
+  (init_start_ms → job_start_ms) are captured regardless.
 
   After both macOS and Linux runs are in, fill out §Decision below.
 -->

--- a/tests/fixtures/plan-89-baseline/flake.nix
+++ b/tests/fixtures/plan-89-baseline/flake.nix
@@ -1,0 +1,20 @@
+{
+  description = "Plan 89 W1 baseline fixture — minimal flake used by scripts/plan-89-baseline.sh to trigger a builder VM cold boot. The harness measures boot fan-out (init_start_ms through job_start_ms), which mvm-builder-init writes to /job/boot-timings.json BEFORE exec'ing cmd.sh. So the flake itself doesn't need to produce a valid mvmctl build output — it just needs to exist as a syntactically valid flake at a path mvmctl will dispatch into the builder VM. The harness reads boot-timings.json regardless of whether the inner `nix build` succeeded, exactly because nothing we measure happens after job_start_ms.";
+
+  # Deliberately no inputs — we don't want to fetch nixpkgs or
+  # microvm.nix. Any input adds cold-cache download time on the first
+  # run that has nothing to do with what W1 is measuring.
+
+  outputs = _: {
+    # Throw at evaluation time. nix-build inside the builder VM will
+    # fail fast with this message; mvmctl will report build failure.
+    # The harness inspects boot-timings.json (always written by
+    # builder-init before cmd.sh runs) and ignores the build exit
+    # code. That keeps the fixture down to zero dependencies and the
+    # measurement isolated to the boot fan-out the plan cares about.
+    packages.aarch64-linux.default = throw
+      "plan-89-w1-baseline fixture: intentionally fails evaluation. The harness in scripts/plan-89-baseline.sh reads boot-timings.json from the job dir regardless of build outcome — see flake description for rationale.";
+    packages.x86_64-linux.default = throw
+      "plan-89-w1-baseline fixture: intentionally fails evaluation. The harness in scripts/plan-89-baseline.sh reads boot-timings.json from the job dir regardless of build outcome — see flake description for rationale.";
+  };
+}


### PR DESCRIPTION
## Summary

Fixes two real defects in the W1 harness I shipped in #375:

1. **Default flake was wrong.** It pointed at `nix/images/runtime-overlay`, which produces `overlay.ext4` instead of the `vmlinux + rootfs.ext4` shape `mvmctl build` expects. The inner `nix build` fails before any measurement is taken. I caught this trying to actually run the harness on macOS.

2. **Harness aborted on inner-build failure.** `mvm-builder-init` writes `boot-timings.json` *before* exec'ing `cmd.sh`, so the boot fan-out (`init_start_ms → job_start_ms`) is captured regardless of whether the inner `nix build` succeeds. The old harness threw away that signal.

Both fixed in lockstep:

- **New `tests/fixtures/plan-89-baseline/flake.nix`** — zero inputs (no `nixpkgs` fetch, no `microvm.nix`), `packages.<system>.default` throws at evaluation time. Inner `nix build` fails fast and deterministically. No nixpkgs eval cost contaminates the measurement.
- **Harness changes:**
  - Default `--flake` switched to the fixture path.
  - `mvmctl build`'s non-zero exit is no longer fatal; only missing `boot-timings.json` is.
  - Job-dir identification switched from `ls -1dt | head -1` to "appeared since loop start" via `comm(1)`, so multiple runs that complete inside one mtime second are still correctly attributed.
  - Header comment + notes-doc preamble explain the rationale.

## Why a throw-on-eval fixture, not a real working flake

Per Plan 89 §Problem, the boot fan-out (`pseudofs_ready_ms` through `network_ready_ms` and stamped at `job_start_ms`) is paid by `mvm-builder-init` before `cmd.sh` ever runs. The fixture exists to trigger a builder VM boot — nothing more. A real working flake would add cold-cache nixpkgs download time + warm-cache nixpkgs eval time, neither of which is what W1 wants to measure.

If you want end-to-end wall-clock measurement (boot fan-out + real Nix build), pass `--flake ./my-real-flake` instead of the default.

## What this PR doesn't fix

The host still needs a bootstrapped local dev image at `~/.mvm/dev/prebuilt/v*/` or `~/.mvm/dev/builds/*/` to boot a builder VM at all. The source-checkout invariant in CLAUDE.md refuses to download a published prebuilt; `cargo xtask build-dev-image` (host nix path) or `mvmctl dev import-image` is the unblock. That's host setup, not a harness bug.

## Test plan

- [x] `bash -n scripts/plan-89-baseline.sh` clean.
- [x] `shellcheck` clean except SC2012 (`ls` for job-dir enumeration — UUIDs, not adversarial filenames).
- [ ] Reviewer-run: actually exercise the harness on macOS + Linux once dev image is bootstrapped, commit `specs/notes/plan-89-baseline.md` as a follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)