### PR TITLE
fix(libkrun): pass NET_FLAG_VFKIT for gvproxy + Cargo + DX

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -287,7 +287,14 @@ objc2-foundation = { version = "0.3", features = ["NSRunLoop", "NSDate", "NSAuto
 # libkrun-dev` (which doesn't ship a libkrun-dev package today).
 # Cargo features can't be cfg-gated, but target-specific dep entries
 # can; Cargo unions the features across all matching target entries.
-mvm-cli = { workspace = true, default-features = false, features = ["libkrun-sys"] }
+#
+# `builder-vm` must be repeated here because the base entry at line 272
+# sets `default-features = false`, which strips mvm-cli's `default =
+# ["builder-vm"]`. Without it, `extract_libkrunfw_kernel()` resolves to
+# the `#[cfg(all(feature = "builder-vm", not(feature = "libkrun-sys")))]`
+# bail-stub and Stage 0 falls back to the ur-seed kernel (known to
+# kernel-oops; see comment at apple_container.rs:~2870).
+mvm-cli = { workspace = true, default-features = false, features = ["builder-vm", "libkrun-sys"] }
 
 [dev-dependencies]
 assert_cmd.workspace = true

--- a/crates/mvm-libkrun/src/gvproxy.rs
+++ b/crates/mvm-libkrun/src/gvproxy.rs
@@ -219,11 +219,16 @@ pub fn spawn(scratch_dir: &Path) -> Result<GvproxyHandle, GvproxyError> {
         .arg(OsString::from(&log_path))
         .arg("-ssh-port")
         .arg(ssh_port.to_string())
-        // Redirect stdout/stderr to /dev/null — gvproxy's `-log-file`
-        // captures what we need and any spillover noise on stderr
-        // pollutes the supervisor's own diagnostic stream.
-        .stdout(std::process::Stdio::null())
-        .stderr(std::process::Stdio::null());
+        // Inherit stdout/stderr so gvproxy's startup-failure mode (e.g.
+        // "listen tcp 127.0.0.1:<port>: bind: address already in use" when
+        // another gvproxy still holds the SSH-forward port) is visible
+        // to the operator. `-log-file` only writes once gvproxy is past
+        // arg-parse and listener setup — pre-listen failures go to stderr
+        // only, so dropping them to /dev/null leaves the supervisor
+        // reporting a bare "exited before listener appeared" with no
+        // underlying reason.
+        .stdout(std::process::Stdio::inherit())
+        .stderr(std::process::Stdio::inherit());
 
     let mut child = cmd.spawn().map_err(GvproxyError::Spawn)?;
 


### PR DESCRIPTION
## Summary

- Pass `NET_FLAG_VFKIT` when calling `krun_add_net_unixgram` for the Gvproxy backend. libkrun.h documents this as required for gvproxy in vfkit mode (`-listen-vfkit …`); without it gvproxy receives the connection but drops every frame as malformed and the guest virtio-net link never comes up.
- Add `mvm-cli`'s `builder-vm` feature to the macOS-only target dep entry in the root `Cargo.toml`. Combined with the existing `default-features = false`, the macOS build was getting `{libkrun-sys}` only, dropping the `builder-vm` default. The consequence was `extract_libkrunfw_kernel()` resolving to its bail-stub, Stage 0 falling back to the ur-seed kernel instead of the libkrunfw-bundled TSI-patched one.
- Three DX gaps surfaced while debugging the above, fixed in the same PR:
  - `MVM_KRUN_LOG={off,error,warn,info,debug,trace}` env var on `mvm-libkrun-supervisor` to route libkrun's internal logger to stderr via `krun_init_log`.
  - `gvproxy::spawn` no longer redirects child stdout/stderr to `/dev/null` — `-log-file` only catches messages emitted **after** the listener is set up, so pre-listener failures (e.g. an orphan gvproxy still holding `127.0.0.1:2222`) were lost; the supervisor would report a bare "exited before listener appeared" with no underlying reason.
  - `init_log()` wrapper around `krun_init_log` alongside the existing `set_log_level`, exposing the modern API.

## Background

Discovered while bringing up the `mvmctl dev up` pipeline end-to-end on macOS aarch64. With these fixes, libkrun reports the virtio-net device fully wired on the host side (`mmio[net] set_irq_line: 42`, `net::unixgram` buffer allocation). However the guest kernel still does **not** enumerate the device — no `mmio[net] activate event` in libkrun's debug trace, no `virtio_net` registration in dmesg. That points at an upstream libkrun FDT / device-tree emission gap on aarch64-macOS rather than anything mvm controls; will be filed as a separate upstream issue against `containers/libkrun`.

## Test plan

- [x] `cargo test -p mvm-libkrun --features libkrun-sys` (23/23 pass)
- [x] `cargo clippy --features mvm-cli/libkrun-sys --workspace -- -D warnings` clean
- [x] `cargo build --features mvm-cli/libkrun-sys` clean
- [ ] (post-merge) Re-run `mvmctl dev up` once the upstream libkrun DTB issue is resolved to confirm the end-to-end pipeline.

🤖 Generated with [Claude Code](https://claude.com/claude-code)