### PR TITLE
fix(builder-init): bring eth0 up before udhcpc

### DIFF
--- a/crates/mvm-builder-init/src/main.rs
+++ b/crates/mvm-builder-init/src/main.rs
@@ -677,21 +677,23 @@ mod linux {
             }
         }
 
-        // Plan 88 W5: bring eth0 admin-up before udhcpc tries to
-        // broadcast. libkrun's virtio-net device registers eth0 in
-        // the IFF state the kernel boots it in (admin-down for ARM
-        // virt boards by default); without this, udhcpc's first
-        // `sendto()` returns ENETDOWN and the daemon spins on
-        // "Network is down, reopening socket" until the build times
-        // out. busybox `ip link set eth0 up` is the minimal fix.
-        // Failure is non-fatal: if `eth0` is missing entirely (TSI
-        // mode) udhcpc will error out on its own and we surface that.
-        if let Err(e) = Command::new("/sbin/ip")
-            .args(["link", "set", "eth0", "up"])
-            .status()
-        {
+        // busybox 1.36.x udhcpc binds a PF_PACKET raw socket to
+        // `eth0` and `sendto`s a DHCPDISCOVER. virtio-net's eth0
+        // post-probe state is administratively DOWN, so the first
+        // sendto returns ENETDOWN and udhcpc loops forever
+        // ("broadcasting discover" → "Network is down" → reopen
+        // socket). Older udhcpc versions auto-issued
+        // SIOCSIFFLAGS|IFF_UP; modern busybox expects the caller
+        // to. The `/etc/udhcpc/default.script` hook brings the
+        // link up via `ip link set ... up`, but it only fires
+        // after udhcpc gets a lease — which requires the link
+        // already be up. Chicken-and-egg, broken by doing the
+        // ioctl ourselves before spawning udhcpc.
+        if let Err(e) = bring_iface_up("eth0") {
             eprintln!(
-                "mvm-builder-init: ip link set eth0 up: {e} (continuing — udhcpc may still try)"
+                "mvm-builder-init: bring_iface_up eth0 failed: {e} \
+                 (continuing — udhcpc will surface a clearer error \
+                 if the link is genuinely absent)"
             );
         }
 
@@ -714,6 +716,85 @@ mod linux {
             return Err(format!("udhcpc exit {}", status.code().unwrap_or(-1)));
         }
         Ok(())
+    }
+
+    /// Encode a Linux interface name into the fixed-size `ifr_name`
+    /// byte array used by SIOCG/SIOCSIFFLAGS. Linux caps interface
+    /// names at `IFNAMSIZ` (16) bytes including the NUL terminator,
+    /// so the longest valid input is 15 bytes. Split out from
+    /// [`bring_iface_up`] so the bounds check is unit-testable
+    /// without making a real syscall.
+    fn encode_iface_name(iface: &str) -> Result<[libc::c_char; libc::IFNAMSIZ], String> {
+        let bytes = iface.as_bytes();
+        if bytes.len() >= libc::IFNAMSIZ {
+            return Err(format!(
+                "interface name '{iface}' is {} bytes; Linux IFNAMSIZ caps it at {}",
+                bytes.len(),
+                libc::IFNAMSIZ - 1,
+            ));
+        }
+        let mut buf = [0 as libc::c_char; libc::IFNAMSIZ];
+        for (i, &b) in bytes.iter().enumerate() {
+            buf[i] = b as libc::c_char;
+        }
+        Ok(buf)
+    }
+
+    /// Bring a network interface administratively up via
+    /// `ioctl(SIOCSIFFLAGS, IFF_UP)`. Equivalent to
+    /// `ip link set dev <iface> up`, but issued directly so we
+    /// don't pin a new path-dependency in the ur-seed rootfs and
+    /// the error message names the failing ioctl. Called before
+    /// `udhcpc` in [`setup_network`].
+    fn bring_iface_up(iface: &str) -> Result<(), String> {
+        let name = encode_iface_name(iface)?;
+
+        // SAFETY: socket(2) returns -1 on error (checked) or a
+        // valid fd. We close it on every return path below.
+        let sock = unsafe { libc::socket(libc::AF_INET, libc::SOCK_DGRAM, 0) };
+        if sock < 0 {
+            return Err(format!(
+                "socket(AF_INET, SOCK_DGRAM) for {iface}: {}",
+                std::io::Error::last_os_error()
+            ));
+        }
+
+        let result = (|| {
+            // SAFETY: `ifreq` is repr(C); zero-init + per-variant
+            // union assignment is the standard pattern. We read
+            // `ifru_flags` only after SIOCGIFFLAGS populated it.
+            let mut ifr: libc::ifreq = unsafe { std::mem::zeroed() };
+            ifr.ifr_name = name;
+
+            if unsafe { libc::ioctl(sock, libc::SIOCGIFFLAGS, &mut ifr) } < 0 {
+                return Err(format!(
+                    "SIOCGIFFLAGS {iface}: {}",
+                    std::io::Error::last_os_error()
+                ));
+            }
+            // SAFETY: SIOCGIFFLAGS just populated `ifru_flags`, so
+            // reading it is well-defined. Writing the OR'd value back
+            // through the same union variant is also well-defined per
+            // the Rust reference (all variants of `__c_anonymous_ifr_ifru`
+            // are `Copy`).
+            unsafe {
+                let flags = ifr.ifr_ifru.ifru_flags;
+                ifr.ifr_ifru.ifru_flags = flags | (libc::IFF_UP as libc::c_short);
+            }
+            if unsafe { libc::ioctl(sock, libc::SIOCSIFFLAGS, &ifr) } < 0 {
+                return Err(format!(
+                    "SIOCSIFFLAGS {iface} IFF_UP: {}",
+                    std::io::Error::last_os_error()
+                ));
+            }
+            Ok(())
+        })();
+
+        // SAFETY: sock is owned by this function until close.
+        unsafe {
+            libc::close(sock);
+        }
+        result
     }
 
     fn run_job(cmd_sh: &str) -> (i32, String) {
@@ -1013,6 +1094,36 @@ mod linux {
             assert!(virtiofs_mount_flags("work").contains(MsFlags::MS_RDONLY));
             assert_eq!(virtiofs_mount_flags("out"), MsFlags::empty());
             assert_eq!(virtiofs_mount_flags("job"), MsFlags::empty());
+        }
+
+        #[test]
+        fn encode_iface_name_eth0_pads_with_nul() {
+            let buf = encode_iface_name("eth0").expect("eth0 fits");
+            assert_eq!(buf[0] as u8, b'e');
+            assert_eq!(buf[1] as u8, b't');
+            assert_eq!(buf[2] as u8, b'h');
+            assert_eq!(buf[3] as u8, b'0');
+            assert_eq!(buf[4] as u8, 0, "remainder NUL-padded");
+            assert_eq!(buf[libc::IFNAMSIZ - 1] as u8, 0);
+        }
+
+        #[test]
+        fn encode_iface_name_max_length_succeeds() {
+            // 15 bytes + 1 NUL = exactly IFNAMSIZ.
+            let max = "a".repeat(libc::IFNAMSIZ - 1);
+            let buf = encode_iface_name(&max).expect("15-byte name fits");
+            for byte in buf.iter().take(libc::IFNAMSIZ - 1) {
+                assert_eq!(*byte as u8, b'a');
+            }
+            assert_eq!(buf[libc::IFNAMSIZ - 1] as u8, 0, "NUL terminator");
+        }
+
+        #[test]
+        fn encode_iface_name_too_long_errors() {
+            let over = "a".repeat(libc::IFNAMSIZ);
+            let err = encode_iface_name(&over).expect_err("IFNAMSIZ-byte name rejected");
+            assert!(err.contains("IFNAMSIZ"), "err mentions limit: {err}");
+            assert!(err.contains(&over), "err includes the offending name");
         }
     }
 }

--- a/specs/adrs/054-ur-seed-stage0-bootstrap.md
+++ b/specs/adrs/054-ur-seed-stage0-bootstrap.md
@@ -92,6 +92,19 @@ The release mirror is populated only when a release is explicitly
 cut. Until then, contributors with no prior mvm state use
 `import-ur-seed` against a manually-built tarball.
 
+**Corollary — no in-development republish.** A bug fix that lands
+in any binary baked into the ur-seed (`mvm-builder-init`, ur-seed
+init scripts, etc.) does NOT trigger an ur-seed release republish.
+Contributors who want the fix on their own host rebuild the ur-seed
+locally and `mvmctl dev import-ur-seed --from <tarball>` it; the
+release mirror moves on its own cadence, tied to a prod release
+cut. Same hermetic-build principle as ADR-046's contributor path:
+the published artifact has a trust/signature lifecycle that should
+not be churned by routine bug fixes, and the "is this artifact
+prod-blessed or dev-WIP?" line stays clean. PR descriptions and
+follow-up checklists for ur-seed-baked-binary fixes should reflect
+the local-rebuild path, not a release republish.
+
 ### Stage 0 fallback order
 
 `bootstrap_builder_vm_image_via_*_stage0` selection:


### PR DESCRIPTION
## Summary

- `mvm-builder-init::setup_network` now issues `ioctl(SIOCSIFFLAGS|IFF_UP)` on `eth0` before invoking `udhcpc`, fixing an infinite hang on `mvmctl dev up`.
- busybox 1.36.x udhcpc stopped auto-upping the iface; virtio-net post-probe DOWN state made every `sendto(2)` return `ENETDOWN` and udhcpc looped forever, blocking the guest before it ever emitted a packet. Externally this surfaced as gvproxy stuck on `"waiting for clients..."` — symptom, not cause.
- Issued via libc directly (no new `/sbin/ip` dependency in the ur-seed rootfs, structured errors, no size-budget regression).
- Scope: builder VM only (Stage 0 ur-seed + steady-state builder VM). Runtime microVMs use vsock-only with a different init and are unaffected.

## What changed

1. New `encode_iface_name(iface) -> [c_char; IFNAMSIZ]` — pure bounds-check helper, NUL-pads.
2. New `bring_iface_up(iface)` — opens an `AF_INET SOCK_DGRAM` socket, `SIOCGIFFLAGS` → `| IFF_UP` → `SIOCSIFFLAGS`.
3. `setup_network()` calls `bring_iface_up("eth0")` before the existing udhcpc invocation. Failure is non-fatal (logs and continues) so the existing offline-build path still works.
4. Three unit tests on `encode_iface_name` (gated to `target_os = "linux"` alongside the existing tests).

## Repro / verification

Before this patch, on macOS Apple Silicon, `mvmctl dev up` hangs indefinitely. `~/.cache/mvm/builder-vm/vms/<latest>/console.log` shows:

```
udhcpc: started, v1.36.1
udhcpc: broadcasting discover
udhcpc: sendto: Network is down
udhcpc: read error: Network is down, reopening socket
... (loops forever)
```

After the patch, the ioctl flips IFF_UP before udhcpc spawns, so the PF_PACKET sendto succeeds and udhcpc either gets a lease or fails cleanly (~10s timeout with `-n -q`) — either way the guest proceeds.

## Test plan

- [x] `cargo build -p mvm-builder-init` — clean
- [x] `cargo clippy -p mvm-builder-init -- -D warnings` — clean
- [x] `cargo test -p mvm-builder-init` — 41/41 pass on macOS (existing); the 3 new Linux-gated tests will exercise on CI's Linux lane.
- [ ] End-to-end `mvmctl dev up` on macOS Apple Silicon (contributors rebuild the ur-seed locally + `mvmctl dev import-ur-seed --from <tarball>` to pick the fix up — see ADR-054 §"Acquisition policy", no release publish required or implied).

## Notes

- `mvm-builder-init` is baked into the ur-seed rootfs, which is release-frozen by design (ADR-054 §"Trade-offs"). The ur-seed release mirror is NOT republished as part of merging this fix — that artifact only moves on explicit release cuts (ADR-046 + ADR-054). Contributors who want the fix on their own host rebuild the ur-seed locally and `import-ur-seed` it.
- The `/etc/udhcpc/default.script` hook in the ur-seed flake brings the link up — but only on `bound`/`renew`/`deconfig` actions, which require udhcpc to first get a lease. It can't substitute for an initial `IFF_UP` because of the chicken-and-egg.
- Same bug almost certainly affects the Linux+passt path with the same busybox version, but Linux contributors may have been running an older udhcpc or a distro-side udev rule that masked it. Worth a follow-up audit.
- libc shapes checked against `libc-0.2.186/src/unix/linux_like/`: `ifreq.ifr_name: [c_char; IFNAMSIZ]`, `ifr_ifru.ifru_flags: c_short`, `SIOCGIFFLAGS=0x8913`, `SIOCSIFFLAGS=0x8914`, `IFF_UP=0x1`. All match.

🤖 Generated with [Claude Code](https://claude.com/claude-code)