### PR TITLE
feat(builder-vm): Stage 0 networking defaults to TSI (Plan 91 / ADR-056)

### DIFF
--- a/crates/mvm-build/src/libkrun_builder.rs
+++ b/crates/mvm-build/src/libkrun_builder.rs
@@ -130,12 +130,19 @@ pub enum NetworkingPreference {
 /// default `Tsi` mode in place — keeping the two builder-VM call
 /// sites (shell-job + flake-build) in lockstep. Each gateway uses
 /// `<vm_state_dir>` for its log/socket scratch space.
+///
+/// `is_stage0` flags a Stage 0 (ur-seed) boot. Stage 0 defaults to
+/// TSI because its build is against the ur-seed's pre-staged closure
+/// (ADR-054 §"Ur-seed shape") and doesn't need real network — and
+/// avoiding real network sidesteps the release-frozen ur-seed's
+/// `mvm-builder-init` networking-stack surface (Plan 91 / ADR-056).
 fn apply_networking_mode(
     krun: KrunContext,
     vm_state_dir: &std::path::Path,
+    is_stage0: bool,
 ) -> Result<KrunContext, BuilderVmError> {
     let scratch = path_to_str(vm_state_dir, "vm_state_dir")?;
-    Ok(match resolve_networking_mode() {
+    Ok(match resolve_networking_mode(is_stage0) {
         NetworkingPreference::Tsi => krun,
         NetworkingPreference::Passt => {
             krun.with_passt(mvm_libkrun::passt::DEFAULT_GUEST_MAC, scratch)
@@ -146,15 +153,28 @@ fn apply_networking_mode(
     })
 }
 
-/// Per-host-OS default networking backend.
+/// Default networking backend per launch context.
 ///
-/// macOS → [`Gvproxy`](NetworkingPreference::Gvproxy) because passt
-/// does not build there (the Homebrew formula refuses with "Linux is
-/// required for this software"); everything else (Linux today) →
-/// [`Passt`](NetworkingPreference::Passt). See ADR-055
-/// §"Cross-platform backends" for the rationale.
-pub fn default_networking_mode() -> NetworkingPreference {
-    if cfg!(target_os = "macos") {
+/// Steady-state builder VM (`is_stage0 = false`):
+/// - macOS → [`Gvproxy`](NetworkingPreference::Gvproxy) because passt
+///   doesn't build on macOS (the Homebrew formula refuses with "Linux
+///   is required for this software").
+/// - Other (Linux) → [`Passt`](NetworkingPreference::Passt).
+///
+/// See ADR-055 §"Cross-platform backends" for the rationale.
+///
+/// Stage 0 boot (`is_stage0 = true`, signalled by
+/// [`LibkrunBuilderVm::image_override`] being set):
+/// - [`Tsi`](NetworkingPreference::Tsi) on every host. Stage 0 builds
+///   the in-repo `nix/images/builder-vm/flake.nix` against the
+///   ur-seed's pre-staged closure (ADR-054 §"Ur-seed shape"), so it
+///   doesn't need substituter access. TSI sidesteps the release-frozen
+///   ur-seed's `mvm-builder-init` networking-stack surface — see
+///   Plan 91 / ADR-056 for the full rationale.
+pub fn default_networking_mode(is_stage0: bool) -> NetworkingPreference {
+    if is_stage0 {
+        NetworkingPreference::Tsi
+    } else if cfg!(target_os = "macos") {
         NetworkingPreference::Gvproxy
     } else {
         NetworkingPreference::Passt
@@ -163,18 +183,24 @@ pub fn default_networking_mode() -> NetworkingPreference {
 
 /// Read `MVM_NETWORKING` from the env. Accepts `tsi`, `passt`, and
 /// `gvproxy` (case-insensitive); anything else falls back to the
-/// per-OS default and emits a warning so a typo is visible without
-/// aborting.
+/// per-context default and emits a warning so a typo is visible
+/// without aborting.
 ///
-/// Plan 87 W5 / PR3 flipped the default away from TSI; Plan 88
-/// added the per-OS dispatch (macOS → gvproxy, Linux → passt). TSI
-/// is libkrun's experimental no-network-stack mode; it works for
-/// trivial HTTP but breaks on nix's substituter and source fetches
-/// (HTTP/2 multiplexing, HTTPS redirect chains, the offline-mode
-/// probe — see ADR-055 §"Context"). Contributors can still opt back
-/// to TSI via `MVM_NETWORKING=tsi` for debugging, or pin a specific
-/// gateway across OS via `MVM_NETWORKING=passt` / `=gvproxy`.
-pub fn resolve_networking_mode() -> NetworkingPreference {
+/// `is_stage0` selects the per-context default when the env var is
+/// unset (see [`default_networking_mode`]). The env var, when set,
+/// always wins — `MVM_NETWORKING=gvproxy` boots Stage 0 with gvproxy
+/// even though TSI is the Stage 0 default. Lets a contributor debug
+/// the steady-state networking path against the ur-seed image when
+/// needed.
+///
+/// Plan 87 W5 / PR3 flipped the steady-state default away from TSI;
+/// Plan 88 added the per-OS dispatch (macOS → gvproxy, Linux →
+/// passt). Plan 91 split Stage 0 back to TSI — TSI is libkrun's
+/// experimental no-network-stack mode that works for trivial HTTP
+/// but breaks on nix's substituter and source fetches (HTTP/2
+/// multiplexing, HTTPS redirect chains, the offline-mode probe — see
+/// ADR-055 §"Context"), and Stage 0 doesn't need those.
+pub fn resolve_networking_mode(is_stage0: bool) -> NetworkingPreference {
     match std::env::var("MVM_NETWORKING")
         .ok()
         .as_deref()
@@ -185,13 +211,14 @@ pub fn resolve_networking_mode() -> NetworkingPreference {
         Some("tsi") => NetworkingPreference::Tsi,
         Some("passt") => NetworkingPreference::Passt,
         Some("gvproxy") => NetworkingPreference::Gvproxy,
-        None | Some("") => default_networking_mode(),
+        None | Some("") => default_networking_mode(is_stage0),
         Some(other) => {
-            let fallback = default_networking_mode();
+            let fallback = default_networking_mode(is_stage0);
             tracing::warn!(
                 value = other,
                 fallback = ?fallback,
-                "MVM_NETWORKING unrecognised; falling back to per-OS default (accepted: tsi, passt, gvproxy)"
+                is_stage0,
+                "MVM_NETWORKING unrecognised; falling back to per-context default (accepted: tsi, passt, gvproxy)"
             );
             fallback
         }
@@ -364,7 +391,7 @@ impl LibkrunBuilderVm {
             );
         }
 
-        krun = apply_networking_mode(krun, &vm_state_dir)?;
+        krun = apply_networking_mode(krun, &vm_state_dir, self.image_override.is_some())?;
 
         let cfg = SupervisorConfig {
             krun,
@@ -626,7 +653,7 @@ impl BuilderVm for LibkrunBuilderVm {
         // Plan 89 W2 part 2: same as the flake-build path above.
         .add_vsock_port(mvm_guest::builder_agent::BUILDER_DISPATCH_PORT);
 
-        krun = apply_networking_mode(krun, &vm_state_dir)?;
+        krun = apply_networking_mode(krun, &vm_state_dir, self.image_override.is_some())?;
 
         // 8. Drive the supervisor: pipe `SupervisorConfig` to
         //    stdin and **wait** for the child to exit. Unlike
@@ -1772,44 +1799,112 @@ mod tests {
         // SAFETY: tests guarded by ENV_LOCK; env mutation in test
         // process is fine when serialized.
         unsafe {
-            // Plan 88: default is per-OS — macOS → Gvproxy, others → Passt.
+            // Steady-state context (is_stage0 = false): default is
+            // per-OS — macOS → Gvproxy, others → Passt (Plan 88).
             std::env::remove_var("MVM_NETWORKING");
-            assert_eq!(resolve_networking_mode(), default_networking_mode());
+            assert_eq!(
+                resolve_networking_mode(false),
+                default_networking_mode(false)
+            );
 
             std::env::set_var("MVM_NETWORKING", "tsi");
-            assert_eq!(resolve_networking_mode(), NetworkingPreference::Tsi);
+            assert_eq!(resolve_networking_mode(false), NetworkingPreference::Tsi);
 
             std::env::set_var("MVM_NETWORKING", "TSI");
-            assert_eq!(resolve_networking_mode(), NetworkingPreference::Tsi);
+            assert_eq!(resolve_networking_mode(false), NetworkingPreference::Tsi);
 
             std::env::set_var("MVM_NETWORKING", " passt ");
-            assert_eq!(resolve_networking_mode(), NetworkingPreference::Passt);
+            assert_eq!(resolve_networking_mode(false), NetworkingPreference::Passt);
 
             std::env::set_var("MVM_NETWORKING", "GVPROXY");
-            assert_eq!(resolve_networking_mode(), NetworkingPreference::Gvproxy);
+            assert_eq!(
+                resolve_networking_mode(false),
+                NetworkingPreference::Gvproxy
+            );
 
             std::env::set_var("MVM_NETWORKING", " gvproxy ");
-            assert_eq!(resolve_networking_mode(), NetworkingPreference::Gvproxy);
+            assert_eq!(
+                resolve_networking_mode(false),
+                NetworkingPreference::Gvproxy
+            );
 
             std::env::set_var("MVM_NETWORKING", "");
-            assert_eq!(resolve_networking_mode(), default_networking_mode());
+            assert_eq!(
+                resolve_networking_mode(false),
+                default_networking_mode(false)
+            );
 
-            // Unknown value falls back to the per-OS default without panic.
+            // Unknown value falls back to the per-context default without panic.
             std::env::set_var("MVM_NETWORKING", "vmnet-helper");
-            assert_eq!(resolve_networking_mode(), default_networking_mode());
+            assert_eq!(
+                resolve_networking_mode(false),
+                default_networking_mode(false)
+            );
 
             std::env::remove_var("MVM_NETWORKING");
         }
     }
 
     #[test]
-    fn default_networking_mode_matches_host_os() {
+    fn default_networking_mode_matches_host_os_for_steady_state() {
         let expected = if cfg!(target_os = "macos") {
             NetworkingPreference::Gvproxy
         } else {
             NetworkingPreference::Passt
         };
-        assert_eq!(default_networking_mode(), expected);
+        assert_eq!(default_networking_mode(false), expected);
+    }
+
+    /// Plan 91 / ADR-056: Stage 0 defaults to TSI on every host —
+    /// the ur-seed's pre-staged closure means no substituter fetch
+    /// is needed, and TSI sidesteps the release-frozen ur-seed
+    /// `mvm-builder-init`'s networking-stack surface.
+    #[test]
+    fn default_networking_mode_stage0_is_tsi() {
+        assert_eq!(default_networking_mode(true), NetworkingPreference::Tsi);
+    }
+
+    /// Plan 91 / ADR-056: with `MVM_NETWORKING` unset, Stage 0
+    /// resolves to TSI (regardless of host OS). Steady-state still
+    /// honours the per-OS default.
+    #[test]
+    fn resolve_networking_mode_stage0_defaults_to_tsi() {
+        let _guard = ENV_LOCK.lock().unwrap();
+        // SAFETY: ENV_LOCK serializes env mutation.
+        unsafe {
+            std::env::remove_var("MVM_NETWORKING");
+            assert_eq!(resolve_networking_mode(true), NetworkingPreference::Tsi);
+            // Cross-check: same env state, but steady-state context
+            // still picks the per-OS gateway. Proves the only thing
+            // that flipped is the Stage 0 branch.
+            assert_eq!(
+                resolve_networking_mode(false),
+                default_networking_mode(false)
+            );
+        }
+    }
+
+    /// Plan 91 / ADR-056: `MVM_NETWORKING` always wins. A contributor
+    /// debugging the steady-state networking path against an
+    /// ur-seed-backed Stage 0 boot can set `MVM_NETWORKING=gvproxy`
+    /// and get the previous behaviour back.
+    #[test]
+    fn resolve_networking_mode_env_overrides_stage0_default() {
+        let _guard = ENV_LOCK.lock().unwrap();
+        // SAFETY: ENV_LOCK serializes env mutation.
+        unsafe {
+            std::env::set_var("MVM_NETWORKING", "gvproxy");
+            assert_eq!(resolve_networking_mode(true), NetworkingPreference::Gvproxy);
+
+            std::env::set_var("MVM_NETWORKING", "passt");
+            assert_eq!(resolve_networking_mode(true), NetworkingPreference::Passt);
+
+            // Explicit `tsi` keeps Stage 0 on TSI — same as the new default.
+            std::env::set_var("MVM_NETWORKING", "tsi");
+            assert_eq!(resolve_networking_mode(true), NetworkingPreference::Tsi);
+
+            std::env::remove_var("MVM_NETWORKING");
+        }
     }
 
     #[test]

--- a/specs/adrs/056-stage0-tsi-default.md
+++ b/specs/adrs/056-stage0-tsi-default.md
@@ -1,0 +1,146 @@
+# ADR-056 — Stage 0 defaults to TSI; steady-state builder VM keeps gvproxy/passt
+
+**Status:** accepted 2026-05-19, implements Plan 91. Amends ADR-054 §"Stage 0 fallback order" and ADR-055 §"Cross-platform backends" — the per-OS gvproxy/passt default applies to the steady-state builder VM only; Stage 0 (ur-seed) defaults to TSI.
+
+## Context
+
+Plan 87 / ADR-055 flipped the libkrun networking default from TSI →
+passt (Linux) / gvproxy (macOS) because TSI doesn't support the
+modern HTTP behaviour `nix build` relies on against external
+substituters (HTTP/2 multiplexing, HTTPS redirect chains,
+substituter availability probes). The default flip applies to
+*every* `apply_networking_mode` call site, including the Stage 0
+boot path that uses an ur-seed rootfs as the bootstrap image.
+
+This is correct for the **steady-state** builder VM (every
+`mvmctl build` / `mvmctl deps install` against an arbitrary user
+flake — those routinely fetch from `cache.nixos.org` and friends).
+It is **not** correct for **Stage 0**:
+
+- Stage 0's job is one thing only: `nix build path:/work#packages.$arch-linux.default`
+  against the in-repo `nix/images/builder-vm/flake.nix`.
+- ADR-054 §"Ur-seed shape" guarantees the ur-seed rootfs ships
+  *the full runtime package closure mirroring the steady-state
+  builder VM* pre-staged under `/nix/store`. No external substituter
+  fetch is required to complete the Stage 0 build.
+- Plan 86's original ur-seed-init shell script (still present at
+  `/sbin/ur-seed-init` in every ur-seed rootfs — see
+  `nix/ur-seed/flake.nix`) explicitly uses TSI-mode nix-portable.
+  Plan 86 / ADR-054 demonstrated end-to-end that TSI is sufficient
+  for the ur-seed's specific build.
+
+The cost of inheriting the gvproxy/passt default into Stage 0 is
+real. The ur-seed's release-frozen `mvm-builder-init` carries any
+networking-stack bugs forward into every contributor's bootstrap
+path (PR #382 — busybox 1.36.x udhcpc no longer auto-ups the
+interface, so Stage 0 hangs on `udhcpc: sendto: Network is down`
+because `eth0` is administratively `DOWN` after virtio-net probe).
+Contributors hit a hard hang before the per-OS gvproxy/passt
+default even gets a chance to be useful — the build never reaches
+the point where substituter access would matter.
+
+`MVM_NETWORKING=tsi` exists as an opt-out escape hatch, but
+"contributors must remember to set an env var to make the bootstrap
+not hang" is a poor default. The right move is to recognise that
+Stage 0 and the steady-state builder VM have meaningfully different
+network requirements and treat them as such.
+
+## Decision
+
+**Stage 0 (libkrun + ur-seed) defaults to TSI. Steady-state builder
+VM keeps the per-OS gvproxy/passt default from ADR-055.**
+
+The dispatch happens in `default_networking_mode(is_stage0: bool)`:
+
+| `is_stage0` | `MVM_NETWORKING` | Result |
+| --- | --- | --- |
+| `true` (Stage 0) | unset | **TSI** |
+| `true` (Stage 0) | `tsi` / `passt` / `gvproxy` | explicit override honoured |
+| `false` (steady-state) | unset | per-OS default (gvproxy on macOS, passt on Linux) |
+| `false` (steady-state) | `tsi` / `passt` / `gvproxy` | explicit override honoured |
+
+`MVM_NETWORKING` retains its full meaning in both contexts — it's
+an explicit-override escape hatch, never silently overridden by the
+context default. Contributors who need to debug Stage 0 with real
+networking can set `MVM_NETWORKING=gvproxy` and get the previous
+behaviour back.
+
+The Stage 0 signal is `LibkrunBuilderVm::image_override.is_some()`
+— it's the same signal that already tells the rest of `run_build`
+"boot from a caller-supplied bootstrap image rather than the cached
+builder VM image". `apply_networking_mode` reads this flag from
+the surrounding `LibkrunBuilderVm` context and passes it through.
+
+## Why this is safe
+
+- Stage 0 only ever builds the in-repo builder-vm flake against
+  the bundled closure. ADR-054 §"Ur-seed shape" pins this guarantee
+  (the ur-seed flake mirrors the steady-state builder's runtime
+  packages and stages them into `/nix/store` at rootfs-build time).
+  No substituter fetch is needed in the Stage 0 happy path.
+- If a contributor edits the builder-vm flake to add a dependency
+  the ur-seed doesn't pre-stage, the Stage 0 nix build will fail
+  *with a clear "missing path" error*, not a TSI HTTP corruption
+  failure. The remedy is unambiguous: either add the dep to the
+  ur-seed's `urSeedPackages` set, or set `MVM_NETWORKING=gvproxy`
+  for that build.
+- The steady-state builder VM is unchanged. It rebuilds every
+  `dev up` from the local source, so the eth0-up fix from PR #382
+  takes effect immediately for it — gvproxy / passt remain the
+  right defaults there for arbitrary user flakes against arbitrary
+  substituters.
+- Runtime workload microVMs are unaffected. They're vsock-only per
+  ADR-002 and never go through `apply_networking_mode`.
+
+## Alternatives considered
+
+- **Keep gvproxy/passt as the Stage 0 default, fix the ur-seed
+  binary.** This is the obvious answer once the eth0-up bug is
+  fixed in PR #382 — *and* the ur-seed is rebuilt and re-imported
+  on every contributor host. The release-frozen nature of the
+  ur-seed (`feedback_no_ur_seed_publish_during_dev`) makes that a
+  release-cycle problem, not a routine bug fix. Until then,
+  contributors are blocked. TSI as the Stage 0 default removes
+  the dependency entirely.
+- **Make TSI the universal default for libkrun.** Rejected by ADR-055
+  precisely because the steady-state builder VM and arbitrary user
+  flakes need real network. The split-default approach gets both
+  contexts right.
+- **Require contributors to set `MVM_NETWORKING=tsi` themselves.**
+  Discoverability-poor; doesn't compose well with `mvmctl doctor`
+  output and per-OS install hints. The right defaults should make
+  the common path Just Work.
+
+## Consequences
+
+- **`mvmctl dev up` on a fresh contributor host works without any
+  env var** even when the cached ur-seed predates PR #382's fix.
+  Stage 0 boots in TSI mode, the eth0-up bug never executes,
+  `nix build` against the pre-staged closure runs to completion,
+  the builder-vm image lands in the cache. From the second run on,
+  Stage 0 is skipped entirely (cache hit) and the steady-state
+  builder VM picks up its own (already-fixed) `mvm-builder-init`.
+- **`MVM_NETWORKING` semantics are unchanged.** The override behaves
+  the same in both contexts.
+- **`mvmctl doctor` per-OS gateway probe is unchanged.** It tests
+  the steady-state networking path — which is still
+  gvproxy/passt — and is unaffected by Stage 0's TSI default.
+- **Adds a tiny shape change to two `pub fn`s** in
+  `crates/mvm-build/src/libkrun_builder.rs`:
+  `default_networking_mode(is_stage0: bool)` and
+  `resolve_networking_mode(is_stage0: bool)`. Both are
+  workspace-internal (no external callers per
+  `grep -r 'resolve_networking_mode\|default_networking_mode'`).
+
+## References
+
+- ADR-054 §"Ur-seed shape" — pre-staged closure guarantee.
+- ADR-055 §"Cross-platform backends" — why steady-state needs real network.
+- Plan 87 / Plan 88 — the original TSI → passt/gvproxy flip.
+- Plan 91 — implementation tracker.
+- PR #382 (`fix(builder-init): bring eth0 up before udhcpc`) — fixes
+  the underlying bug for the steady-state path. ADR-056 protects
+  Stage 0 *until* a fresh ur-seed carrying #382 ships on the
+  release cadence.
+- Memory: `feedback_no_ur_seed_publish_during_dev` — release mirror
+  only moves on prod release cuts.

--- a/specs/plans/91-stage0-tsi-default.md
+++ b/specs/plans/91-stage0-tsi-default.md
@@ -1,0 +1,169 @@
+# Plan 91 — Stage 0 networking defaults to TSI
+
+**Owner:** Ari
+**Status:** in progress 2026-05-19
+**Tracks:** ADR-056 (Stage 0 vs steady-state networking defaults).
+**Unblocks:** `mvmctl dev up` on every contributor host whose ur-seed predates PR #382.
+
+## Goal
+
+Stage 0 (libkrun-backed boot from an ur-seed image) defaults to
+TSI mode. Steady-state builder VM keeps the per-OS gvproxy/passt
+default from ADR-055. `MVM_NETWORKING` remains the explicit
+override in both contexts.
+
+Drops one env-var requirement (`MVM_NETWORKING=tsi`) for every
+contributor on every fresh `dev up` until a release cycle ships a
+fresh ur-seed carrying PR #382's eth0-up fix.
+
+## Why
+
+Documented in full in ADR-056. Short version:
+
+- Stage 0's bundled-closure design (ADR-054) means it doesn't need
+  real network. TSI is sufficient.
+- The steady-state builder VM and arbitrary user flakes do need
+  real network. gvproxy/passt remain the right defaults there.
+- The current "everything inherits the gvproxy/passt default"
+  behaviour from Plan 87/88 wedges Stage 0 against the
+  release-frozen ur-seed's buggy `mvm-builder-init` (PR #382).
+  TSI sidesteps the dependency entirely.
+
+## Scope
+
+**In scope (this plan):**
+
+1. `default_networking_mode(is_stage0)` and `resolve_networking_mode(is_stage0)`
+   in `crates/mvm-build/src/libkrun_builder.rs` — split-default per
+   ADR-056's table.
+2. Both `apply_networking_mode` call sites in `run_build` and
+   `run_shell_job` pass `self.image_override.is_some()` as the
+   Stage 0 hint.
+3. Update the in-tree `MVM_NETWORKING` warn-fallback log line to
+   name the chosen default explicitly (so a contributor sees
+   `falling back to TSI (stage 0)` vs `falling back to gvproxy
+   (per-host default)` and doesn't have to guess which one fired).
+4. Tests for both contexts × all four `MVM_NETWORKING` states.
+
+**Out of scope:**
+
+- `mvmctl doctor` rework — the existing per-OS gateway probe tests
+  the steady-state path and is unchanged.
+- Any change to passt or gvproxy themselves.
+- A fresh ur-seed release (see
+  `feedback_no_ur_seed_publish_during_dev`).
+- Runtime microVM networking. Vsock-only per ADR-002, unaffected.
+
+## Implementation
+
+One file, ~30 net-LOC. Function signatures shift but no public
+contract changes — `grep -r 'resolve_networking_mode\|default_networking_mode'`
+finds zero callers outside the file itself.
+
+### Signature change
+
+```rust
+pub fn default_networking_mode(is_stage0: bool) -> NetworkingPreference {
+    if is_stage0 {
+        // Stage 0 builds a single in-repo flake against a pre-staged
+        // closure (ADR-054 §"Ur-seed shape"). No external substituter
+        // fetch needed; TSI is sufficient and sidesteps the
+        // release-frozen ur-seed's `mvm-builder-init` (ADR-056).
+        NetworkingPreference::Tsi
+    } else if cfg!(target_os = "macos") {
+        NetworkingPreference::Gvproxy
+    } else {
+        NetworkingPreference::Passt
+    }
+}
+
+pub fn resolve_networking_mode(is_stage0: bool) -> NetworkingPreference {
+    // `MVM_NETWORKING` always wins, in both contexts. Stage 0
+    // default only kicks in when the env var is unset.
+    match std::env::var("MVM_NETWORKING") … {
+        Some("tsi") => NetworkingPreference::Tsi,
+        Some("passt") => NetworkingPreference::Passt,
+        Some("gvproxy") => NetworkingPreference::Gvproxy,
+        None | Some("") => default_networking_mode(is_stage0),
+        Some(other) => { /* warn + fallback to default_networking_mode(is_stage0) */ }
+    }
+}
+```
+
+### `apply_networking_mode` plumbing
+
+Take `is_stage0: bool` and forward to `resolve_networking_mode`.
+Both call sites in `run_build` and `run_shell_job` pass
+`self.image_override.is_some()` (the existing "this is a Stage 0
+boot" signal).
+
+## Test plan
+
+Unit tests in the existing `tests` module:
+
+- `resolve_networking_mode_steady_state_defaults_match_host_os` — both target_os arms.
+- `resolve_networking_mode_stage0_defaults_to_tsi` — `is_stage0 = true`, env unset, expect TSI on every host.
+- `resolve_networking_mode_env_overrides_in_stage0` — `is_stage0 = true`, env = `gvproxy`, expect gvproxy (proves the explicit override wins).
+- `resolve_networking_mode_env_overrides_in_steady_state` — existing test, adapted.
+- `default_networking_mode_stage0_is_tsi` — pure logic.
+
+All gated on `crate::TEST_ENV_LOCK` (or local mutex) so parallel
+env mutation doesn't race.
+
+## Manual verification
+
+On a contributor host with a pre-PR-#382 ur-seed in
+`~/.cache/mvm/ur-seed/<arch>/`:
+
+```sh
+rm -f ~/.cache/mvm/builder-vm/nix-store-*.img    # if a previous stale image exists
+cargo run --bin mvmctl -- dev up
+```
+
+Expected: Stage 0 boots in TSI, `mvm-builder-init`'s broken
+udhcpc-eth0 path errors immediately with ENODEV (no eth0 in TSI)
+and continues (setup_network is non-fatal), the nix build of
+the builder-vm flake completes against the bundled closure, the
+builder-vm image lands in cache, the second `dev up` skips
+Stage 0 entirely. No `MVM_NETWORKING` env var required.
+
+Cross-check with the old behaviour:
+
+```sh
+MVM_NETWORKING=gvproxy cargo run --bin mvmctl -- dev up
+```
+
+Expected: Stage 0 uses gvproxy (override honoured), hits the same
+hang documented in PR #382 because the cached ur-seed's
+`mvm-builder-init` is the release-frozen broken one. Proves the
+env-var override still works and Stage 0's TSI default is the
+only thing protecting the user from the bug.
+
+## Migration
+
+None. The new default is strictly more permissive on Stage 0 (a
+boot that hangs becomes a boot that succeeds) and identical on
+the steady-state path. No external API surface changes.
+
+## Risk
+
+- **Stage 0 nix build fails on a missing substituter path.**
+  Surface: a contributor edits `nix/images/builder-vm/flake.nix`
+  to add a dep the ur-seed doesn't pre-stage, Stage 0 tries to
+  fetch it in TSI mode, fetch fails. Mitigation: error is "missing
+  path", not "HTTP corruption" — the remedy is to add the dep to
+  the ur-seed's `urSeedPackages` or temporarily set
+  `MVM_NETWORKING=gvproxy` for that one build. Easy to document.
+- **Future Plan that needs network in Stage 0.** This plan doesn't
+  preclude that — set `MVM_NETWORKING=gvproxy` or extend
+  `default_networking_mode` with a third context. The split is
+  semantic, not structural.
+
+## References
+
+- ADR-056 — decision record.
+- ADR-054 — ur-seed bundled closure.
+- ADR-055 — original TSI → gvproxy/passt flip.
+- PR #382 — `mvm-builder-init` eth0-up fix (Stage 0 default of TSI
+  is a coverage layer until that fix ships in a fresh ur-seed).
+- Memory: `feedback_no_ur_seed_publish_during_dev`.


### PR DESCRIPTION
## Summary

Splits the libkrun networking default into two contexts:

| Context | Default | Rationale |
|---|---|---|
| **Stage 0** (ur-seed boot) | **TSI** | Builds in-repo `nix/images/builder-vm/flake.nix` against the ur-seed's pre-staged closure (ADR-054 §"Ur-seed shape"). No substituter access needed. Sidesteps the release-frozen ur-seed's `mvm-builder-init` networking-stack surface. |
| **Steady-state builder VM** | per-OS gvproxy / passt (unchanged) | User flakes against arbitrary substituters. Plan 87/88 / ADR-055 reasoning is unchanged. |

`MVM_NETWORKING` retains its full meaning in both contexts — it's an explicit-override escape hatch, never silently overridden by the context default.

## Why now

Every contributor whose cached ur-seed (`~/.cache/mvm/ur-seed/<arch>/`) predates PR #382's eth0-up fix gets a hard hang on `dev up`:

```
INFO[0000] waiting for clients...   ← gvproxy idle
udhcpc: sendto: Network is down     ← ur-seed's mvm-builder-init can't up eth0
udhcpc: read error: Network is down, reopening socket  (loops forever)
```

Per the no-republish-during-dev policy (ADR-054 §"Acquisition policy" + `feedback_no_ur_seed_publish_during_dev`), the release-frozen ur-seed gets refreshed on the prod release cadence, not in response to in-development fixes. Without a fresh ur-seed, the fix in #382 doesn't reach contributors.

`MVM_NETWORKING=tsi` is an opt-out escape hatch, but "remember to set an env var" is a poor default. Stage 0 doesn't *need* real network — only the steady-state path does — so flipping Stage 0's default to TSI gets every contributor unblocked without touching ur-seed release cadence.

## What changed

Code (1 file, +135 / -37):

- `default_networking_mode(is_stage0: bool)` — `true` → TSI; `false` → per-OS gvproxy/passt.
- `resolve_networking_mode(is_stage0: bool)` — env var wins; falls back to the new context-aware default.
- `apply_networking_mode(..., is_stage0: bool)` — both call sites pass `self.image_override.is_some()` (the existing Stage 0 signal).

Docs:

- `specs/adrs/056-stage0-tsi-default.md` — decision record. Amends ADR-054 §"Stage 0 fallback order" and ADR-055 §"Cross-platform backends".
- `specs/plans/91-stage0-tsi-default.md` — implementation tracker.

## Test plan

- [x] `cargo build -p mvm-build` — clean
- [x] `cargo clippy --workspace --features builder-vm -- -D warnings` — clean
- [x] `cargo test --workspace --features builder-vm` — no regressions
- [x] 5 unit tests pass (2 adapted + 3 new):
  - `default_networking_mode_matches_host_os_for_steady_state`
  - `default_networking_mode_stage0_is_tsi`
  - `resolve_networking_mode_parses_env` (steady-state coverage of all 4 env states)
  - `resolve_networking_mode_stage0_defaults_to_tsi` — env unset, Stage 0 → TSI
  - `resolve_networking_mode_env_overrides_stage0_default` — `MVM_NETWORKING` wins
- [ ] End-to-end `mvmctl dev up` on macOS Apple Silicon with a pre-PR-#382 ur-seed in cache — should now boot Stage 0 in TSI mode and complete without `MVM_NETWORKING=tsi`. (Will verify locally once this is merged.)

## Scope & non-changes

**In scope:** Stage 0 default. Steady-state builder VM default is unchanged. `MVM_NETWORKING` semantics are unchanged.

**Out of scope:** Runtime workload microVMs (vsock-only per ADR-002, never go through `apply_networking_mode`). `mvmctl doctor` per-OS gateway probe (tests the steady-state path; unaffected). Any change to the ur-seed itself (release-frozen by design).

## References

- Plan 91 — implementation tracker (new).
- ADR-056 — decision record (new).
- ADR-054 §"Ur-seed shape" — pre-staged-closure guarantee.
- ADR-055 §"Cross-platform backends" — why steady-state needs real network.
- PR #382 (`fix(builder-init): bring eth0 up before udhcpc`) — fixes the underlying bug for the steady-state path. ADR-056 protects Stage 0 *until* a fresh ur-seed carrying #382 ships on the release cadence.
- Memory: `feedback_no_ur_seed_publish_during_dev` — release mirror only moves on prod release cuts.

🤖 Generated with [Claude Code](https://claude.com/claude-code)