### PR TITLE
plan(89) W3 part 8: Install variant dispatch in persistent path

### DIFF
--- a/crates/mvm-build/src/persistent_builder.rs
+++ b/crates/mvm-build/src/persistent_builder.rs
@@ -552,12 +552,22 @@ impl crate::builder_vm::BuilderVm for PersistentBuilderVm {
     ) -> Result<crate::builder_vm::BuilderArtifacts, crate::builder_vm::BuilderVmError> {
         use crate::builder_vm::{BuilderArtifacts, BuilderJob, BuilderVmError};
 
+        // Plan 89 W3 part 8 — Install variant routes through the
+        // same dispatch wire but stages the install spec instead
+        // of a cmd.sh, and the guest's run_install_job_at writes
+        // sealed-volume sidecars (result.json + content/ + sbom +
+        // fetch.log + cve.json) into the per-dispatch out/ dir.
+        // Host reads them back via finalize_install_dispatch.
+        if let BuilderJob::Install { spec_path } = job {
+            return self.run_install_dispatch(spec_path, mounts);
+        }
+
         let (flake_ref, attr_path) = match job {
             BuilderJob::Flake {
                 flake_ref,
                 attr_path,
             } => (flake_ref.as_str(), attr_path.as_str()),
-            BuilderJob::Install { .. } => return Err(BuilderVmError::NotYetImplemented),
+            BuilderJob::Install { .. } => unreachable!("handled above"),
         };
 
         let job_id = stage_flake_dispatch_job(&self.session.job_dir, flake_ref, attr_path)
@@ -614,6 +624,121 @@ impl crate::builder_vm::BuilderVm for PersistentBuilderVm {
             accessible: None,
         })
     }
+}
+
+#[cfg(feature = "builder-vm")]
+impl PersistentBuilderVm {
+    /// Plan 89 W3 part 8 — `BuilderJob::Install` arm of
+    /// [`BuilderVm::run_build`]. Copies the host-side install spec
+    /// into a per-dispatch dir under `<session.job_dir>/<job_id>/`,
+    /// submits a `BuilderJob::Install` with the in-guest path, then
+    /// — on a clean dispatch — hands `mounts.artifact_out` to
+    /// `finalize_install_job` so the caller sees the same
+    /// `BuilderArtifacts::InstallVolume` shape the single-shot path
+    /// returns.
+    fn run_install_dispatch(
+        &self,
+        host_spec_path: &Path,
+        mounts: &crate::builder_vm::BuilderMounts,
+    ) -> Result<crate::builder_vm::BuilderArtifacts, crate::builder_vm::BuilderVmError> {
+        use crate::builder_vm::{BuilderArtifacts, BuilderJob, BuilderVmError};
+
+        let job_id =
+            stage_install_dispatch_job(&self.session.job_dir, host_spec_path).map_err(|e| {
+                BuilderVmError::ExtractionFailed(format!(
+                    "staging persistent install dispatch job: {e}"
+                ))
+            })?;
+
+        // The in-guest spec path the dispatch loop reads.
+        // `<JOB_DIR>/<job_id>/install_spec.json` where JOB_DIR=`/job`
+        // is the convention `mvm-builder-init`'s dispatch loop
+        // resolves against.
+        let in_guest_spec_path = PathBuf::from(format!("/job/{}/install_spec.json", job_id));
+
+        let supervisor = PersistentBuilderSupervisor::new(&self.session.dispatch_socket_path)
+            .with_frame_read_timeout(Duration::from_secs(60));
+        let outcome = supervisor
+            .submit(
+                BuilderJob::Install {
+                    spec_path: in_guest_spec_path,
+                },
+                job_id.clone(),
+            )
+            .map_err(|e| BuilderVmError::NixBuildFailed(format!("persistent dispatch: {e}")))?;
+        if outcome.exit_code != 0 {
+            return Err(BuilderVmError::NixBuildFailed(format!(
+                "persistent install dispatch exit {} — stderr tail:\n{}",
+                outcome.exit_code, outcome.stderr_tail
+            )));
+        }
+
+        // The guest wrote result.json + sealed-volume sidecars into
+        // <session.job_dir>/<job_id>/out/. Copy the whole dir into
+        // mounts.artifact_out so the downstream finalize_install_job
+        // (Plan 73 Followup B.2) reads from the canonical path the
+        // single-shot caller hands it.
+        let dispatch_out_dir = artifact_dir_for(&self.session.job_dir, &job_id);
+        std::fs::create_dir_all(&mounts.artifact_out).map_err(|e| {
+            BuilderVmError::ExtractionFailed(format!(
+                "creating {}: {e}",
+                mounts.artifact_out.display()
+            ))
+        })?;
+        copy_dir_recursive(&dispatch_out_dir, &mounts.artifact_out).map_err(|e| {
+            BuilderVmError::ExtractionFailed(format!(
+                "copying install artifacts {} → {}: {e}",
+                dispatch_out_dir.display(),
+                mounts.artifact_out.display()
+            ))
+        })?;
+
+        Ok(BuilderArtifacts::InstallVolume {
+            volume_dir: mounts.artifact_out.clone(),
+            result_json_path: mounts.artifact_out.join("result.json"),
+        })
+    }
+}
+
+/// Stage a per-dispatch install job under `<session_job_dir>/<job_id>/`:
+/// create the out/ subdir (mirror of [`stage_flake_dispatch_job`]'s
+/// convention) and copy the caller's install spec into
+/// `<job_id>/install_spec.json`. Returns the `job_id` the host passes
+/// as `BuilderRequest::Run::job_dir_relpath`.
+#[cfg(feature = "builder-vm")]
+fn stage_install_dispatch_job(
+    session_job_dir: &Path,
+    host_spec_path: &Path,
+) -> std::io::Result<String> {
+    let job_id = uuid::Uuid::new_v4().to_string();
+    let sub = session_job_dir.join(&job_id);
+    let artifact_dir = sub.join(ARTIFACT_SUBDIR);
+    std::fs::create_dir_all(&artifact_dir)?;
+    let dst_spec = sub.join("install_spec.json");
+    std::fs::copy(host_spec_path, &dst_spec)?;
+    Ok(job_id)
+}
+
+/// Cheap recursive copy. Used by the install dispatch to move the
+/// per-dispatch out/ contents into the caller's
+/// `mounts.artifact_out` so the downstream `finalize_install_job`
+/// (single-shot path) sees the same shape it would for a fresh-
+/// VM build. Doesn't try to be clever about symlinks — the install
+/// pipeline emits plain files + dirs.
+#[cfg(feature = "builder-vm")]
+fn copy_dir_recursive(src: &Path, dst: &Path) -> std::io::Result<()> {
+    std::fs::create_dir_all(dst)?;
+    for entry in std::fs::read_dir(src)? {
+        let entry = entry?;
+        let entry_dst = dst.join(entry.file_name());
+        let ty = entry.file_type()?;
+        if ty.is_dir() {
+            copy_dir_recursive(&entry.path(), &entry_dst)?;
+        } else if ty.is_file() {
+            std::fs::copy(entry.path(), &entry_dst)?;
+        }
+    }
+    Ok(())
 }
 
 #[cfg(test)]
@@ -782,5 +907,59 @@ mod tests {
         );
         assert_eq!(extract_nix_store_hash("/nix/store/-bad"), None);
         assert_eq!(extract_nix_store_hash("not-a-store-path"), None);
+    }
+
+    // -----------------------------------------------------------
+    // Plan 89 W3 part 8 — install dispatch helpers
+    // -----------------------------------------------------------
+
+    #[cfg(feature = "builder-vm")]
+    #[test]
+    fn stage_install_dispatch_job_copies_spec_and_creates_out_dir() {
+        let scratch = tempfile::tempdir().expect("tempdir");
+        let session_job_dir = scratch.path().join("session");
+        std::fs::create_dir_all(&session_job_dir).unwrap();
+
+        // Caller's host-side spec: pin the bytes so we can assert
+        // the copy is byte-identical.
+        let host_spec_path = scratch.path().join("source-spec.json");
+        let spec_body = br#"{"language":"python","lockfile_relative_path":"uv.lock","source_mount":"/work","gate":"prod"}"#;
+        std::fs::write(&host_spec_path, spec_body).unwrap();
+
+        let job_id = stage_install_dispatch_job(&session_job_dir, &host_spec_path).expect("stage");
+
+        let staged_spec = session_job_dir.join(&job_id).join("install_spec.json");
+        assert!(staged_spec.is_file(), "{}", staged_spec.display());
+        let staged_body = std::fs::read(&staged_spec).unwrap();
+        assert_eq!(&staged_body, spec_body);
+
+        let out_dir = artifact_dir_for(&session_job_dir, &job_id);
+        assert!(out_dir.is_dir(), "expected out/ at {}", out_dir.display());
+    }
+
+    #[cfg(feature = "builder-vm")]
+    #[test]
+    fn copy_dir_recursive_copies_files_and_subdirs() {
+        let scratch = tempfile::tempdir().expect("tempdir");
+        let src = scratch.path().join("src");
+        let dst = scratch.path().join("dst");
+        std::fs::create_dir_all(src.join("nested")).unwrap();
+        std::fs::write(src.join("a.txt"), b"alpha").unwrap();
+        std::fs::write(src.join("nested/b.txt"), b"beta").unwrap();
+
+        copy_dir_recursive(&src, &dst).expect("copy");
+
+        assert_eq!(std::fs::read(dst.join("a.txt")).unwrap(), b"alpha");
+        assert_eq!(std::fs::read(dst.join("nested/b.txt")).unwrap(), b"beta");
+    }
+
+    #[cfg(feature = "builder-vm")]
+    #[test]
+    fn copy_dir_recursive_rejects_missing_src() {
+        let scratch = tempfile::tempdir().expect("tempdir");
+        let src = scratch.path().join("does-not-exist");
+        let dst = scratch.path().join("dst");
+        let err = copy_dir_recursive(&src, &dst).expect_err("missing src");
+        assert_eq!(err.kind(), std::io::ErrorKind::NotFound);
     }
 }

--- a/crates/mvm-builder-init/src/main.rs
+++ b/crates/mvm-builder-init/src/main.rs
@@ -775,20 +775,40 @@ mod linux {
                     (code, tail, ms)
                 }
             }
-            crate::builder_request::BuilderJob::Install { .. } => {
-                // Install pipeline dispatch in the persistent VM
-                // is W3 part 5 work — Plan 73's sealed-volume
-                // invariants need extra thought against the
-                // long-lived VM model. For W3 part 3, fail closed
-                // with a structured error so the host sees a real
-                // Result with a meaningful exit_code.
-                (
-                    3,
-                    "Install variant via persistent dispatch not yet wired \
-                     (Plan 89 W3 part 5)"
-                        .to_string(),
-                    0,
-                )
+            crate::builder_request::BuilderJob::Install { spec_path } => {
+                // Plan 89 W3 part 8: route Install dispatches
+                // through the existing single-shot pipeline with
+                // per-dispatch paths. The host (PersistentBuilderVm)
+                // stages `<session.job_dir>/<job_id>/install_spec.json`
+                // and passes `/job/<job_dir_relpath>/install_spec.json`
+                // as the wire `spec_path`. The output (result.json +
+                // sealed volume sidecars) lands in `/job/<job_id>/out`
+                // so the host reads them back via the same per-
+                // dispatch out_dir convention as the Flake path.
+                let out_dir = format!("{JOB_DIR}/{job_dir_relpath}/out");
+                let job_subdir = format!("{JOB_DIR}/{job_dir_relpath}");
+                let started = Instant::now();
+                run_install_job_at(&spec_path, &job_subdir, &out_dir);
+                let ms = u64::try_from(started.elapsed().as_millis()).unwrap_or(u64::MAX);
+                // The install pipeline writes its own typed result
+                // (result.json) — exit code on the wire is just a
+                // dispatch-level signal that the install ran. The
+                // host's PersistentBuilderVm reads result.json for
+                // the real outcome. We pass 0 if result.json was
+                // emitted at all; the host's parser will decode it
+                // and surface installer_exit_code.
+                let result_path = format!("{out_dir}/result.json");
+                let exit_code = if Path::new(&result_path).is_file() {
+                    0
+                } else {
+                    2
+                };
+                let tail = if exit_code == 0 {
+                    String::new()
+                } else {
+                    format!("install pipeline did not emit {result_path}")
+                };
+                (exit_code, tail, ms)
             }
         };
         let response = crate::dispatch_response::DispatchResponse {
@@ -867,6 +887,20 @@ mod linux {
     /// via the *presence* of result.json. Anything that prevents
     /// us from writing result.json gets logged + falls through.
     fn run_install_job(spec_path: &str) {
+        run_install_job_at(spec_path, JOB_DIR, OUT_DIR);
+    }
+
+    /// Plan 89 W3 part 8 — install dispatch with explicit
+    /// `job_dir` and `out_dir`. Single-shot uses the legacy
+    /// `JOB_DIR` / `OUT_DIR` constants; persistent dispatch
+    /// passes the per-dispatch `/job/<job_id>` paths so concurrent
+    /// dispatches don't clobber each other's outputs (V1 is
+    /// serialized so the clobber risk is theoretical, but the
+    /// per-dispatch layout removes the question entirely and
+    /// matches the persistent flake path's
+    /// `<session.job_dir>/<job_id>/out/` convention from W3
+    /// part 6/7).
+    fn run_install_job_at(spec_path: &str, job_dir: &str, out_dir: &str) {
         use crate::install::{
             InstallContext, InstallError, RESULT_FILENAME, SystemCommandRunner, run_install,
         };
@@ -877,7 +911,7 @@ mod linux {
             Ok(b) => b,
             Err(e) => {
                 eprintln!("mvm-builder-init: read {spec_path}: {e}");
-                write_install_failure(2, &format!("read install spec: {e}"));
+                write_install_failure_at(out_dir, 2, &format!("read install spec: {e}"));
                 return;
             }
         };
@@ -885,10 +919,22 @@ mod linux {
             Ok(s) => s,
             Err(e) => {
                 eprintln!("mvm-builder-init: parse {spec_path}: {e}");
-                write_install_failure(2, &format!("parse install spec: {e}"));
+                write_install_failure_at(out_dir, 2, &format!("parse install spec: {e}"));
                 return;
             }
         };
+
+        // Persistent dispatch may pass a per-dispatch out_dir that
+        // doesn't exist yet (the host pre-stages it, but defensive
+        // `create_dir_all` is cheap and saves us from a race where
+        // the host's mkdir hasn't reached the guest's view of the
+        // virtio-fs share yet).
+        if let Err(e) = std::fs::create_dir_all(out_dir) {
+            eprintln!("mvm-builder-init: create_dir_all {out_dir}: {e}");
+            // Fall through; write_install_failure_at will try to
+            // write into the dir and the host will see whatever
+            // partial state results.
+        }
 
         let runner = SystemCommandRunner;
         // Plan 73 Followup B.2.x: the production proxy lifecycle
@@ -899,8 +945,8 @@ mod linux {
         let mut proxy = ChildProxyLifecycle::default_binary();
         let ctx = InstallContext {
             spec: &spec,
-            job_dir: Path::new(JOB_DIR),
-            out_dir: Path::new(OUT_DIR),
+            job_dir: Path::new(job_dir),
+            out_dir: Path::new(out_dir),
             runner: &runner,
             extra_path: None,
             proxy: &mut proxy,
@@ -911,7 +957,8 @@ mod linux {
                 eprintln!(
                     "mvm-builder-init: installer `{program}` not on PATH — builder VM is missing required tools"
                 );
-                write_install_failure(
+                write_install_failure_at(
+                    out_dir,
                     127,
                     &format!("installer `{program}` not on PATH inside builder VM"),
                 );
@@ -919,19 +966,19 @@ mod linux {
             }
             Err(InstallError::Io(why)) => {
                 eprintln!("mvm-builder-init: install pipeline IO: {why}");
-                write_install_failure(2, &format!("install pipeline IO: {why}"));
+                write_install_failure_at(out_dir, 2, &format!("install pipeline IO: {why}"));
                 return;
             }
         };
 
-        // Write the typed report into /out — the host reads it
-        // from `artifact_out/result.json` post-power-off. Plan 73
+        // Write the typed report into out_dir — the host reads it
+        // from `<out_dir>/result.json` post-power-off. Plan 73
         // Followup B.2's contract: result.json lives next to the
         // four sealed-volume artifacts so a single virtio-fs
         // share carries everything the host needs. Hand-rolled
         // JSON via InstallReport::to_json so we don't pull
         // serde_json into the init binary's closure.
-        let path = format!("{OUT_DIR}/{RESULT_FILENAME}");
+        let path = format!("{out_dir}/{RESULT_FILENAME}");
         if let Err(e) = std::fs::write(&path, format!("{}\n", report.to_json())) {
             eprintln!("mvm-builder-init: failed to write {path}: {e}");
         }
@@ -943,6 +990,13 @@ mod linux {
     /// [`crate::install::InstallReport::to_json`] so the host's
     /// parser doesn't need a separate code path.
     fn write_install_failure(exit_code: i32, reason: &str) {
+        write_install_failure_at(OUT_DIR, exit_code, reason);
+    }
+
+    /// Plan 89 W3 part 8 — install-failure writer with explicit
+    /// `out_dir`. Single-shot uses `OUT_DIR`; persistent dispatch
+    /// passes the per-dispatch `/job/<job_id>/out`.
+    fn write_install_failure_at(out_dir: &str, exit_code: i32, reason: &str) {
         use crate::install::{
             CONTENT_SUBDIR, CVE_FILENAME, FETCH_LOG_FILENAME, RESULT_FILENAME, SBOM_FILENAME,
         };
@@ -952,13 +1006,13 @@ mod linux {
         // host's parser sees installer_exit_code != 0 and refuses
         // to seal the volume.
         let body = format!(
-            r#"{{"installer_exit_code":{exit_code},"sbom_emitted":false,"cve_emitted":false,"language":"unknown","gate":"unknown","content_path":"{OUT_DIR}/{CONTENT_SUBDIR}","sbom_path":"{OUT_DIR}/{SBOM_FILENAME}","fetch_log_path":"{OUT_DIR}/{FETCH_LOG_FILENAME}","cve_path":"{OUT_DIR}/{CVE_FILENAME}","failure_reason":"{escaped}"}}"#,
+            r#"{{"installer_exit_code":{exit_code},"sbom_emitted":false,"cve_emitted":false,"language":"unknown","gate":"unknown","content_path":"{out_dir}/{CONTENT_SUBDIR}","sbom_path":"{out_dir}/{SBOM_FILENAME}","fetch_log_path":"{out_dir}/{FETCH_LOG_FILENAME}","cve_path":"{out_dir}/{CVE_FILENAME}","failure_reason":"{escaped}"}}"#,
         );
-        let path = format!("{OUT_DIR}/{RESULT_FILENAME}");
-        // Best-effort: if /out isn't mounted (the install-spec
-        // dispatch ran before virtio-fs came up), at least try
-        // /job so the host has *somewhere* to pick up the failure
-        // signal.
+        let path = format!("{out_dir}/{RESULT_FILENAME}");
+        // Best-effort: if `out_dir` isn't writable (the install-spec
+        // dispatch ran before virtio-fs came up, or the persistent-
+        // dispatch out_dir doesn't exist yet), at least try /job so
+        // the host has *somewhere* to pick up the failure signal.
         if let Err(e) = std::fs::write(&path, format!("{body}\n")) {
             eprintln!("mvm-builder-init: failed to write {path}: {e}");
             let fallback = format!("{JOB_DIR}/{RESULT_FILENAME}");


### PR DESCRIPTION
## Summary

Wires Plan 73's app-deps install pipeline through the persistent VM. `mvmctl deps install` (and any other caller that builds an `Install` BuilderJob through `dev_build`) now routes through the persistent supervisor when a session is active — same default-on behavior + silent fallback as the Flake path from W3 part 7.

## What changed

### Guest side (`mvm-builder-init`)

- `run_install_job` split into a thin wrapper + `run_install_job_at(spec_path, job_dir, out_dir)`. Single-shot passes the legacy `JOB_DIR`/`OUT_DIR`; persistent dispatch passes per-dispatch `/job/<job_dir_relpath>` paths so concurrent dispatches don't clobber outputs.
- `write_install_failure` split the same way for the failure-path result.json.
- **Dispatch loop's Install arm**: actually dispatches now. Calls `run_install_job_at(&spec_path, &job_subdir, &out_dir)`. Wire `exit_code` reports whether result.json was written; the typed `installer_exit_code` inside result.json is what the host parses for the real outcome.

### Host side (`mvm_build::persistent_builder`)

- `PersistentBuilderVm::run_build` dispatches `BuilderJob::Install` through new `run_install_dispatch` helper:
  1. Stages spec into `<session.job_dir>/<job_id>/install_spec.json` via new `stage_install_dispatch_job`.
  2. Submits `BuilderJob::Install { spec_path: "/job/<job_id>/install_spec.json" }` (in-guest path).
  3. Copies per-dispatch `out/` contents into `mounts.artifact_out` via new `copy_dir_recursive` so the downstream `finalize_install_job` sees the same shape it would for a fresh-VM build.
  4. Returns `BuilderArtifacts::InstallVolume { volume_dir, result_json_path }`.

## Tests added (3 new, 11 total)

- `stage_install_dispatch_job_copies_spec_and_creates_out_dir` — host-side staging is byte-identical + out/ pre-created.
- `copy_dir_recursive_copies_files_and_subdirs` — defensive recursion smoke test.
- `copy_dir_recursive_rejects_missing_src` — `io::ErrorKind::NotFound` clean error path.

End-to-end (real builder VM + real `uv pip install` / `pnpm install`) requires `mvmctl persistent-builder start` + a working dev image — manual smoke once both are bootstrapped.

## Test plan

- [x] `cargo test --workspace --features builder-vm` clean.
- [x] `cargo build -p mvm-cli --no-default-features` clean (feature gating preserved).
- [x] `cargo clippy --workspace --all-targets -- -D warnings` clean.
- [x] `cargo fmt --all -- --check` clean.
- [x] All xtask lint gates clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)