### PR TITLE
plan(89) W3 part 12: iptables baseline re-apply per dispatch

### DIFF
--- a/crates/mvm-builder-init/src/main.rs
+++ b/crates/mvm-builder-init/src/main.rs
@@ -834,6 +834,28 @@ mod linux {
         job_dir_relpath: &str,
         cold_boot_timings: Option<BootTimings>,
     ) -> String {
+        // Plan 89 W3 part 12 — flush + re-install the egress
+        // lockdown before every dispatch. A previous build that
+        // mutated iptables (whether via a CAP_NET_ADMIN leak or
+        // because we haven't shipped the cap drop yet) loses its
+        // changes here. Fail closed: if iptables is broken we
+        // refuse the dispatch — that's safer than running a
+        // build against a chain whose state we no longer trust.
+        if let Err(e) = crate::network::reapply_egress_lockdown(
+            &crate::network::SystemIptables,
+            crate::network::PROXY_UID,
+        ) {
+            eprintln!("mvm-builder-init: dispatch loop: iptables baseline re-apply failed: {e}");
+            let response = crate::dispatch_response::DispatchResponse {
+                job_id,
+                exit_code: 126,
+                stderr_tail: format!("iptables baseline re-apply failed: {e}"),
+                boot_timings: cold_boot_timings,
+                build_ms: 0,
+            };
+            return response.to_json();
+        }
+
         let (exit_code, stderr_tail, build_ms) = match job {
             crate::builder_request::BuilderJob::Flake { .. } => {
                 let cmd_path = format!("{JOB_DIR}/{job_dir_relpath}/cmd.sh");

--- a/crates/mvm-builder-init/src/network.rs
+++ b/crates/mvm-builder-init/src/network.rs
@@ -86,6 +86,35 @@ pub fn install_egress_lockdown(runner: &dyn IptablesRunner, proxy_uid: u32) -> R
     Ok(())
 }
 
+/// Plan 89 W3 part 12 — re-install the egress lockdown from a
+/// known-good in-binary recipe.
+///
+/// `install_egress_lockdown` runs once at boot. In the persistent
+/// builder VM jobs share the kernel's iptables state across
+/// dispatches — a build that runs `iptables -I OUTPUT 1 -j
+/// ACCEPT` (or exploits a `CAP_NET_ADMIN` leak via the new mount
+/// namespace from `unshare --mount`) poisons every subsequent
+/// job. The persistent dispatch loop calls this between
+/// dispatches to reset the chain.
+///
+/// Implementation: flush the OUTPUT chain, then re-install the 3
+/// baseline rules. Cheap (~10 ms per the plan's estimate) and
+/// deterministic. The OUTPUT chain's *policy* survives `-F`, so
+/// the brief window between flush and rule re-install is fail-
+/// closed if the policy was DROP already; `install_egress_lockdown`
+/// re-asserts the policy to DROP regardless.
+///
+/// On any rule failure the chain is left in whatever partial
+/// state the failure produced. Callers should treat the error as
+/// a hard signal that iptables is broken and refuse to run the
+/// dispatched job — that's safer than letting a possibly-too-
+/// permissive chain reach the build. See the F7 entry in the
+/// Plan 89 security-scan findings table.
+pub fn reapply_egress_lockdown(runner: &dyn IptablesRunner, proxy_uid: u32) -> Result<(), String> {
+    runner.run(&["-F", "OUTPUT"])?;
+    install_egress_lockdown(runner, proxy_uid)
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -185,5 +214,63 @@ mod tests {
         assert_ne!(PROXY_UID, 0);
         assert_ne!(PROXY_UID, 1000);
         assert_ne!(PROXY_UID, 1900);
+    }
+
+    /// Plan 89 W3 part 12 — re-apply emits one flush then the
+    /// three baseline rules, in that order. Catches the case
+    /// where someone reorders to install-then-flush (which would
+    /// wipe what they just installed).
+    #[test]
+    fn reapply_flushes_then_reinstalls() {
+        let runner = RecordingRunner::new();
+        reapply_egress_lockdown(&runner, 1801).expect("happy path");
+        let invocations = runner.invocations.borrow();
+        assert_eq!(invocations.len(), 4, "expected -F + 3 baseline rules");
+
+        // 1: flush OUTPUT chain.
+        assert!(invocations[0].iter().any(|a| a == "-F"));
+        assert!(invocations[0].iter().any(|a| a == "OUTPUT"));
+
+        // 2-4: identical to the install_egress_lockdown sequence
+        // — re-uses the same code path.
+        assert!(invocations[1].iter().any(|a| a == "-o"));
+        assert!(invocations[1].iter().any(|a| a == "lo"));
+        assert!(invocations[2].iter().any(|a| a == "--uid-owner"));
+        assert!(invocations[2].iter().any(|a| a == "1801"));
+        assert!(invocations[3].iter().any(|a| a == "-P"));
+        assert!(invocations[3].iter().any(|a| a == "DROP"));
+    }
+
+    /// Plan 89 W3 part 12 — a flush failure short-circuits before
+    /// the re-install runs. The caller is supposed to fail closed
+    /// on the returned Err; this test pins the "we don't continue
+    /// past flush" guarantee.
+    #[test]
+    fn reapply_stops_at_flush_failure() {
+        let runner = RecordingRunner::fail_at(0);
+        let result = reapply_egress_lockdown(&runner, 1801);
+        assert!(result.is_err());
+        assert_eq!(
+            runner.invocations.borrow().len(),
+            1,
+            "only the flush was attempted",
+        );
+    }
+
+    /// Plan 89 W3 part 12 — if any of the install rules fails
+    /// after the flush, the chain ends up in a partial state.
+    /// `reapply_egress_lockdown` surfaces the error so the
+    /// dispatch loop can refuse the next job. We pin the
+    /// invocation count so we know the partial state is exactly
+    /// "flushed + one rule installed" (rule 2 attempted, rule 3
+    /// not reached).
+    #[test]
+    fn reapply_stops_at_install_failure() {
+        // fail_at(2) skips invocation 0 (flush) and 1 (loopback
+        // accept), and fails invocation 2 (owner-match accept).
+        let runner = RecordingRunner::fail_at(2);
+        let result = reapply_egress_lockdown(&runner, 1801);
+        assert!(result.is_err());
+        assert_eq!(runner.invocations.borrow().len(), 3);
     }
 }


### PR DESCRIPTION
## Summary
- Third slice of per-job isolation (security-scan F7). The persistent dispatch loop calls `network::reapply_egress_lockdown` before every cmd.sh: flush the OUTPUT chain, then re-install the 3 baseline rules.
- A build that mutated iptables (whether via `iptables -I OUTPUT 1 -j ACCEPT` or by exploiting a CAP_NET_ADMIN leak through the new mount namespace from W3 part 11's `unshare --mount`) loses its mutation here. The next job sees the same chain that boot installed.
- Fail closed: if iptables is broken the dispatch loop refuses the job with exit code 126 and a typed `stderr_tail` — safer than running against a chain whose state we no longer trust.

## Cost
~10 ms per dispatch (one extra `iptables -F OUTPUT` plus the existing three `-A`s). Independent of build duration so relative overhead shrinks as builds get longer.

## Test plan
- [x] `cargo test -p mvm-builder-init` — 3 new `RecordingRunner`-driven tests pin flush-then-install order, short-circuit on flush failure, and short-circuit on mid-install failure (63 passing total).
- [x] `cargo clippy --workspace --all-targets -- -D warnings`
- [x] `cargo fmt --check`

## Follow-up
- W3 part 13: `setuid` drop to `builder:builder` (uid 902).

🤖 Generated with [Claude Code](https://claude.com/claude-code)