### PR TITLE
mvmctl cleanup: skip nix-collect-garbage when dev VM is down; strip internal plan refs

### DIFF
--- a/crates/mvm-build/src/libkrun_builder.rs
+++ b/crates/mvm-build/src/libkrun_builder.rs
@@ -788,8 +788,7 @@ fn ensure_builder_vm_image() -> Result<BuilderVmImage, BuilderVmError> {
         return Err(BuilderVmError::ExtractionFailed(format!(
             "builder VM image not found at {}. \
              Populate the cache by running `nix build ./nix/images/builder-vm#packages.{}-linux.default` \
-             on a host with Nix and copying `result/{{vmlinux,rootfs.ext4,cmdline.txt}}` to {}/, \
-             or wait for Plan 72 W5 to wire the Stage 0 bootstrap.",
+             on a host with Nix and copying `result/{{vmlinux,rootfs.ext4,cmdline.txt}}` to {}/.",
             arch_dir.display(),
             host_arch_tag(),
             arch_dir.display(),

--- a/crates/mvm-build/src/pipeline/dev_build.rs
+++ b/crates/mvm-build/src/pipeline/dev_build.rs
@@ -493,7 +493,7 @@ fn dev_build_via_builder_vm(
         tracing::info!(
             session_id = %record.session_id,
             socket = %record.dispatch_socket_path.display(),
-            "Plan 89 W3: routing build through persistent supervisor"
+            "routing build through persistent supervisor"
         );
         let persistent = crate::persistent_builder::PersistentBuilderVm::new(record.clone());
         match dev_build_with_builder_vm(env, flake_ref, profile, mode, &persistent) {

--- a/crates/mvm-cli/src/commands/env/apple_container.rs
+++ b/crates/mvm-cli/src/commands/env/apple_container.rs
@@ -945,7 +945,7 @@ fn ensure_source_checkout_dev_image(
 ) -> Result<(String, String)> {
     if !libkrun_available {
         anyhow::bail!(
-            "libkrun is required to build the dev image from source (Plan 72 W5.C).\n\
+            "libkrun is required to build the dev image from source.\n\
              {install_hint}\n\n\
              Once installed, retry `mvmctl dev up`. If you intend to use the published\n\
              prebuilt instead (no local builds), move or delete\n\
@@ -954,7 +954,7 @@ fn ensure_source_checkout_dev_image(
     }
 
     ui::info(&format!(
-        "Building dev image via libkrun builder VM (Plan 72 W5) from: {flake_dir}"
+        "Building dev image via libkrun builder VM from: {flake_dir}"
     ));
     match build_image(out_dir) {
         Ok((kernel, rootfs)) => {
@@ -1427,9 +1427,9 @@ fn try_fetch_signed_manifest(
     download_file(&bundle_url, &bundle_path).map_err(|e| {
         bump_verify_outcome("network");
         e.context(format!(
-            "Failed to download cosign bundle from {bundle_url}. Plan 36 \
-             requires a manifest's signature to be present alongside the \
-             manifest body — refusing to trust an unsigned manifest."
+            "Failed to download cosign bundle from {bundle_url}. The release \
+             pipeline requires a manifest's signature to be present alongside \
+             the manifest body — refusing to trust an unsigned manifest."
         ))
     })?;
 
@@ -1447,7 +1447,7 @@ fn try_fetch_signed_manifest(
     let manifest = if std::env::var_os("MVM_SKIP_COSIGN_VERIFY").is_some() {
         tracing::warn!(
             "MVM_SKIP_COSIGN_VERIFY set — accepting unverified manifest body. \
-             Plan 36 documents this as an emergency-rotation escape hatch only."
+             This is an emergency-rotation escape hatch only."
         );
         image_verify::parse_manifest(&manifest_bytes)
             .map_err(|e| anyhow::anyhow!("manifest parse failed: {e}"))?
@@ -1587,8 +1587,7 @@ fn try_fetch_revocation_list() -> Result<Option<mvm_security::image_verify::Revo
                     Err(e) => {
                         ui::warn(&format!(
                             "Could not refresh revocation list ({e}) and no fresh cache \
-                             is available; proceeding without recall enforcement. \
-                             Plan 36 §Layer 4."
+                             is available; proceeding without recall enforcement."
                         ));
                         return Ok(None);
                     }
@@ -1651,7 +1650,7 @@ fn try_fetch_revocation_list() -> Result<Option<mvm_security::image_verify::Revo
     .map_err(|e| {
         anyhow::anyhow!(
             "Revocation list signature verification failed: {e}. Refusing to \
-             trust an unverified recall. Plan 36 §Layer 4."
+             trust an unverified recall."
         )
     })?;
     let list: image_verify::RevocationList =
@@ -1707,7 +1706,7 @@ pub fn cmd_dev_import_image(
     let manifest = if std::env::var_os("MVM_SKIP_COSIGN_VERIFY").is_some() {
         ui::warn(
             "MVM_SKIP_COSIGN_VERIFY set — accepting unverified manifest. \
-             Plan 36 documents this as an emergency-rotation escape only.",
+             This is an emergency-rotation escape only.",
         );
         image_verify::parse_manifest(&manifest_bytes)
             .map_err(|e| anyhow::anyhow!("manifest parse failed: {e}"))?
@@ -2081,10 +2080,7 @@ fn find_builder_vm_flake() -> Result<String> {
         return Ok(candidate.to_str().unwrap_or(".").to_string());
     }
 
-    anyhow::bail!(
-        "Builder VM flake not found. Expected at nix/images/builder-vm/flake.nix \
-         (Plan 72 W2 artifact)."
-    )
+    anyhow::bail!("Builder VM flake not found. Expected at nix/images/builder-vm/flake.nix.")
 }
 
 /// Plan 72 W5 — ensure `~/.cache/mvm/builder-vm/<arch>/` contains
@@ -2383,9 +2379,10 @@ impl std::fmt::Display for SeedContractError {
         match self {
             Self::MissingManifest { manifest_path } => write!(
                 f,
-                "Stage 0 seed is missing `manifest.json` at {} — likely built before Plan 77 W5. \
-                 Rebuild the dev image (e.g. `mvmctl dev rebuild`) or import a signed published \
-                 image (`mvmctl dev import-image`) and retry `mvmctl dev up`.",
+                "Stage 0 seed is missing `manifest.json` at {} — likely built before \
+                 the seed-contract requirement landed. Rebuild the dev image \
+                 (e.g. `mvmctl dev rebuild`) or import a signed published image \
+                 (`mvmctl dev import-image`) and retry `mvmctl dev up`.",
                 manifest_path.display()
             ),
             Self::UnreadableManifest {
@@ -2596,9 +2593,9 @@ fn ensure_stage0_seed_manifest(seed_rootfs: &std::path::Path) -> Result<()> {
 /// the artifact + the dev-image fallback.
 #[cfg(feature = "builder-vm")]
 fn bootstrap_builder_vm_image_via_initramfs_stage0(
-    _builder_flake_dir: &str,
+    builder_flake_dir: &str,
     out_dir: &str,
-    _source_fingerprint: &str,
+    source_fingerprint: &str,
 ) -> Result<()> {
     let _stage0_guard = acquire_stage0_lock(out_dir)?;
 
@@ -2617,13 +2614,25 @@ fn bootstrap_builder_vm_image_via_initramfs_stage0(
         initramfs_bytes.len()
     ));
 
+    // The initramfs bootstrap dispatch into libkrun needs
+    // `extract_bundled_kernel`, which lives behind the
+    // `libkrun-sys` Cargo feature and is only linked into the
+    // supervisor binary today (not into mvmctl). Until the
+    // supervisor exposes a kernel-extraction sub-command (or
+    // mvmctl is built with the `libkrun-sys` feature), the only
+    // way to get a Stage 0 seed onto a fresh source checkout is
+    // to import one.
+    let _ = (builder_flake_dir, out_dir, source_fingerprint);
     anyhow::bail!(
-        "Stage 0 needs either a contract-compliant dev image in \
-         ~/.mvm/dev/{{current, prebuilt/v*, builds/*}} OR the new \
-         initramfs Stage 0 dispatch (wired in a follow-up PR). The \
-         initramfs bytes are ready at {}; the dispatch path that \
-         hands them to libkrun via `LibkrunBuilderVm::run_stage0_initramfs` \
-         is the only remaining piece.",
+        "Stage 0 has no seed image to bootstrap from. The initramfs cpio is \
+         ready at {} but the host-side dispatch that would run it is not yet \
+         wired (needs `mvm-libkrun-supervisor` to expose bundled-kernel \
+         extraction). Workarounds:\n\
+         \n\
+         1. Import a previously-built dev image:\n\
+            `mvmctl dev import-image --kernel <vmlinux> --rootfs <rootfs.ext4>`\n\
+         2. Or move/delete `nix/images/builder/flake.nix` so the source-checkout \
+            heuristic stops matching and the published prebuilt is used.",
         cpio_path.display()
     );
 }
@@ -5384,7 +5393,7 @@ mod builder_vm_bootstrap_tests {
         assert_eq!(err.audit_reason(), "seed_contract_missing_manifest");
         let msg = format!("{err}");
         assert!(
-            msg.contains("missing `manifest.json`") && msg.contains("Plan 77 W5"),
+            msg.contains("missing `manifest.json`") && msg.contains("seed-contract requirement"),
             "remediation message must point the user at the fix: {msg}"
         );
     }

--- a/crates/mvm-cli/src/commands/env/cleanup.rs
+++ b/crates/mvm-cli/src/commands/env/cleanup.rs
@@ -75,29 +75,36 @@ pub(in crate::commands) fn run(_cli: &Cli, args: Args, _cfg: &MvmConfig) -> Resu
         ));
     }
 
-    // Step 3: Garbage-collect unreferenced Nix store paths inside the dev VM.
-    ui::info("Running nix-collect-garbage...");
-    match shell::run_in_vm_stdout("nix-collect-garbage -d 2>&1 | tail -3") {
-        Ok(output) => {
-            let trimmed = output.trim();
-            if !trimmed.is_empty() {
-                println!("{trimmed}");
-            }
-        }
-        Err(e) => {
-            // If GC fails (disk too full for daemon), try clearing the Nix
-            // user profile links and retrying once.
-            ui::warn(&format!("nix-collect-garbage failed: {e}"));
-            ui::info("Retrying after clearing Nix profile generations...");
-            let _ = shell::run_in_vm("rm -rf ~/.local/state/nix/profiles/* 2>/dev/null");
-            match shell::run_in_vm_stdout("nix-collect-garbage -d 2>&1 | tail -3") {
-                Ok(output) => {
-                    let trimmed = output.trim();
-                    if !trimmed.is_empty() {
-                        println!("{trimmed}");
-                    }
+    // Step 3: Garbage-collect unreferenced Nix store paths inside
+    // the dev VM. The Nix store lives in the VM, so this step is a
+    // no-op when the dev VM isn't running — surface it as info
+    // (not a warning) so cleanup doesn't look like it failed.
+    if disk_before.is_none() {
+        ui::info("Skipping nix-collect-garbage: dev VM is not running.");
+    } else {
+        ui::info("Running nix-collect-garbage...");
+        match shell::run_in_vm_stdout("nix-collect-garbage -d 2>&1 | tail -3") {
+            Ok(output) => {
+                let trimmed = output.trim();
+                if !trimmed.is_empty() {
+                    println!("{trimmed}");
                 }
-                Err(e2) => ui::warn(&format!("nix-collect-garbage retry failed: {e2}")),
+            }
+            Err(e) => {
+                // If GC fails (disk too full for daemon), try clearing the Nix
+                // user profile links and retrying once.
+                ui::warn(&format!("nix-collect-garbage failed: {e}"));
+                ui::info("Retrying after clearing Nix profile generations...");
+                let _ = shell::run_in_vm("rm -rf ~/.local/state/nix/profiles/* 2>/dev/null");
+                match shell::run_in_vm_stdout("nix-collect-garbage -d 2>&1 | tail -3") {
+                    Ok(output) => {
+                        let trimmed = output.trim();
+                        if !trimmed.is_empty() {
+                            println!("{trimmed}");
+                        }
+                    }
+                    Err(e2) => ui::warn(&format!("nix-collect-garbage retry failed: {e2}")),
+                }
             }
         }
     }

--- a/crates/mvm-cli/src/commands/vm/up.rs
+++ b/crates/mvm-cli/src/commands/vm/up.rs
@@ -602,7 +602,7 @@ fn resolve_deps_volume_binding_with_cache(
     let install = mvm_build::app_deps::install_app_deps(&spec, None).map_err(|e| match e {
         mvm_build::app_deps::InstallError::DriverNotProvided { .. } => anyhow::anyhow!(
             "no cached deps volume for this lockfile; run `mvmctl deps build \
-                 --from-workload-ir {}` first (Plan 73 Followup C)",
+                 --from-workload-ir {}` first",
             ir_path.display()
         ),
         other => anyhow::Error::new(other),

--- a/crates/mvm-cli/src/commands/vm/volume.rs
+++ b/crates/mvm-cli/src/commands/vm/volume.rs
@@ -204,10 +204,7 @@ fn ensure_private_dir(path: &Path) -> Result<()> {
 }
 
 fn remote_stub(op: &str) -> Result<()> {
-    bail!(
-        "{op} --remote not yet implemented; tracking in mvmd Sprint 137 W2 \
-         (companion to mvm Plan 45 §D5). Use the local volume registry for now."
-    )
+    bail!("{op} --remote not yet implemented. Use the local volume registry for now.")
 }
 
 fn validate_volume_name(name: &str) -> Result<()> {


### PR DESCRIPTION
## Summary
Three user-visible fixes pulled out of the persistent-builder stack.

### 1. `mvmctl cleanup` no longer warns when the dev VM is down
The Nix store lives *inside* the dev VM. When the VM isn't running there is no nix-collect-garbage target — printing a warning made cleanup look broken. Step 3 now skips with an `info` line when the disk-usage probe returns `None`.

### 2. `mvmctl dev up` error message is actionable, not misleading
The bootstrap path previously emitted "the new initramfs Stage 0 dispatch (wired in a follow-up PR)" when the source-checkout builder-VM cache was empty *and* no local Stage 0 seed was on disk. Replaced with a concrete two-option workaround:

```
1. Import a previously-built dev image:
   mvmctl dev import-image --kernel <vmlinux> --rootfs <rootfs.ext4>
2. Or move/delete nix/images/builder/flake.nix so the source-checkout
   heuristic stops matching and the published prebuilt is used.
```

The real Stage 0 initramfs dispatch is still pending — it needs `mvm-libkrun-supervisor` to expose bundled-kernel extraction (the supervisor is the only binary linked with `libkrun-sys`). Tracked as future work; not in scope for this PR.

### 3. "Plan NN" references stripped from every user-facing string
`mvmctl info/warn/bail/error/tracing` no longer reference internal plan numbers (Plan 36, Plan 45, Plan 72, Plan 73, Plan 77, Plan 89). Doc comments still use them — those are for contributors. One test case updated to match the new wording.

## Test plan
- [x] `cargo test --workspace` — flaky `mvm_managed_unlock_rejects_tampered_ciphertext` is pre-existing parallel-shared-resource interference (passes in isolation); my changes don't touch that surface.
- [x] `cargo clippy --workspace --all-targets -- -D warnings`
- [x] `cargo fmt --check`

🤖 Generated with [Claude Code](https://claude.com/claude-code)