### PR TITLE
stage0: refresh init.sh header for set_root boot path

### DIFF
--- a/crates/mvm-build/src/stage0/init.sh
+++ b/crates/mvm-build/src/stage0/init.sh
@@ -1,11 +1,11 @@
 #!/bin/sh
 # PID 1 of the Stage 0 bootstrap VM.
 #
-# Boots inside a libkrunfw kernel against an in-memory initramfs
-# (built by `mvm_build::stage0::build_initramfs`). The initramfs
-# carries busybox + nix-portable + this script. There is no rootfs
-# ext4 disk: the kernel decompresses the initramfs to a tmpfs and
-# runs `/init` (this file) directly.
+# libkrun mounts a host directory (materialized by
+# `mvm_build::stage0::materialize_root_dir`) as the guest root over
+# virtiofs (`krun_set_root`) and boots libkrunfw's bundled
+# TSI-patched kernel transparently. The root dir carries busybox +
+# nix-portable + this script; `krun_set_exec` runs `/init` as PID 1.
 #
 # Job: build the in-repo `nix/images/builder-vm` flake into a
 # kernel + rootfs.ext4 and write them to the `/out` virtio-fs share.
@@ -16,7 +16,7 @@
 set -eu
 
 # busybox installs itself as every applet via this command. The
-# initramfs has /bin/busybox as a real file and every other tool
+# root dir has /bin/busybox as a real file and every other tool
 # (sh, mount, ip, udhcpc, …) as a symlink to it. `--install -s`
 # materializes those symlinks under /bin so PATH lookups resolve
 # without needing the host to pre-populate them.


### PR DESCRIPTION
## Summary

Follow-up to #414 (stage0 root-dir dispatch) and #413 (init.sh
connect-timeout tweak). After both landed, init.sh's header
docstring was still describing the cpio initramfs boot path and
referenced the now-deleted `mvm_build::stage0::build_initramfs`
function.

This was meant to land as part of #413's rebase, but #413 was
merged before the docstring fix made it onto the branch.

## Changes

- Header (lines 4-8): describe the actual delivery mechanism — host directory mounted as guest root via virtiofs (`krun_set_root`), libkrunfw bundled kernel used transparently, `/init` invoked via `krun_set_exec`.
- busybox-install comment (line 19): "root dir" instead of "initramfs".

Pure documentation; no behavior change.

## Test plan

- [x] Substring-checking tests in `crates/mvm-build/src/stage0.rs` (`init_script_is_embedded_and_nonempty`) still pass — they look for `#!/bin/sh`, `ip link set eth0 up`, and `nix-portable`, all preserved.
- [x] `shellcheck crates/mvm-build/src/stage0/init.sh` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)