### PR TITLE
fix(builder-init): unblock dev up — ext4 geometry recovery + correct seed-fallback check

### DIFF
--- a/crates/mvm-build/src/builder_protocol.rs
+++ b/crates/mvm-build/src/builder_protocol.rs
@@ -223,6 +223,11 @@ pub struct BootTimingsWire {
     pub nix_device_ready_ms: Option<u64>,
     pub nix_seeded_ms: Option<u64>,
     pub nix_mounted_ms: Option<u64>,
+    /// Plan 96: `/nix-path-registration` loaded into
+    /// `/nix/var/nix/db` so the in-VM `nix build` skips
+    /// re-substituting seeded paths. `None` on subsequent boots
+    /// where the marker is present and registration is skipped.
+    pub nix_db_loaded_ms: Option<u64>,
     pub modules_ready_ms: Option<u64>,
     pub virtiofs_ready_ms: Option<u64>,
     pub network_ready_ms: Option<u64>,
@@ -372,6 +377,7 @@ mod tests {
                 nix_device_ready_ms: Some(18),
                 nix_seeded_ms: None,
                 nix_mounted_ms: Some(220),
+                nix_db_loaded_ms: Some(225),
                 modules_ready_ms: Some(35),
                 virtiofs_ready_ms: Some(48),
                 network_ready_ms: Some(250),
@@ -544,6 +550,7 @@ mod tests {
             \"nix_device_ready_ms\":18,\
             \"nix_seeded_ms\":null,\
             \"nix_mounted_ms\":220,\
+            \"nix_db_loaded_ms\":225,\
             \"modules_ready_ms\":35,\
             \"virtiofs_ready_ms\":48,\
             \"network_ready_ms\":250,\
@@ -554,6 +561,7 @@ mod tests {
             serde_json::from_str(init_json).expect("must parse builder-init JSON shape");
         assert_eq!(parsed.init_start_ms, Some(0));
         assert_eq!(parsed.nix_seeded_ms, None);
+        assert_eq!(parsed.nix_db_loaded_ms, Some(225));
         assert_eq!(parsed.poweroff_start_ms, Some(8410));
     }
 

--- a/crates/mvm-build/tests/persistent_builder_supervisor.rs
+++ b/crates/mvm-build/tests/persistent_builder_supervisor.rs
@@ -45,6 +45,7 @@ fn sample_boot_timings() -> BootTimingsWire {
         nix_device_ready_ms: Some(15),
         nix_seeded_ms: None,
         nix_mounted_ms: Some(180),
+        nix_db_loaded_ms: Some(185),
         modules_ready_ms: Some(25),
         virtiofs_ready_ms: Some(35),
         network_ready_ms: Some(190),

--- a/crates/mvm-build/tests/vsock_response_listener.rs
+++ b/crates/mvm-build/tests/vsock_response_listener.rs
@@ -47,6 +47,7 @@ fn spawn_vsock_response_listener_decodes_guest_response() {
             nix_device_ready_ms: Some(15),
             nix_seeded_ms: None,
             nix_mounted_ms: Some(180),
+            nix_db_loaded_ms: Some(185),
             modules_ready_ms: Some(25),
             virtiofs_ready_ms: Some(35),
             network_ready_ms: Some(190),

--- a/crates/mvm-builder-init/Cargo.toml
+++ b/crates/mvm-builder-init/Cargo.toml
@@ -22,7 +22,7 @@ path = "src/main.rs"
 [target.'cfg(target_os = "linux")'.dependencies]
 # Linux mount/reboot syscalls. Kept Linux-only so non-Linux
 # workspace builds don't drag in the dep tree.
-nix = { version = "0.29", features = ["mount", "reboot", "signal"] }
+nix = { version = "0.29", features = ["mount", "reboot", "signal", "ioctl"] }
 # libc for SIGTERM / SIGKILL when tearing the egress proxy down
 # after the installer exits. Linux-only same as nix above.
 libc.workspace = true

--- a/crates/mvm-builder-init/src/boot_timings.rs
+++ b/crates/mvm-builder-init/src/boot_timings.rs
@@ -52,6 +52,12 @@ pub(crate) struct BootTimings {
     pub nix_seeded_ms: Option<u64>,
     /// `/nix-store` bind-mounted over `/nix`.
     pub nix_mounted_ms: Option<u64>,
+    /// `/nix-path-registration` loaded into `/nix/var/nix/db` so
+    /// nix-daemon skips re-substituting the seeded closure. `None`
+    /// on subsequent boots where the sentinel
+    /// (`/nix-store/.seed-db-loaded`) is present and registration
+    /// is skipped.
+    pub nix_db_loaded_ms: Option<u64>,
     /// `fuse` + `virtiofs` kernel modules loaded.
     pub modules_ready_ms: Option<u64>,
     /// All virtio-fs shares (`job`, `out`, `work`) mounted.
@@ -105,6 +111,7 @@ impl BootTimings {
         );
         Self::push_field(&mut out, "nix_seeded_ms", self.nix_seeded_ms, false);
         Self::push_field(&mut out, "nix_mounted_ms", self.nix_mounted_ms, false);
+        Self::push_field(&mut out, "nix_db_loaded_ms", self.nix_db_loaded_ms, false);
         Self::push_field(&mut out, "modules_ready_ms", self.modules_ready_ms, false);
         Self::push_field(&mut out, "virtiofs_ready_ms", self.virtiofs_ready_ms, false);
         Self::push_field(&mut out, "network_ready_ms", self.network_ready_ms, false);
@@ -168,6 +175,7 @@ mod tests {
             nix_device_ready_ms: Some(18),
             nix_seeded_ms: None,
             nix_mounted_ms: Some(220),
+            nix_db_loaded_ms: Some(225),
             modules_ready_ms: Some(35),
             virtiofs_ready_ms: Some(48),
             network_ready_ms: Some(250),
@@ -186,6 +194,7 @@ mod tests {
              \"nix_device_ready_ms\":18,\
              \"nix_seeded_ms\":null,\
              \"nix_mounted_ms\":220,\
+             \"nix_db_loaded_ms\":225,\
              \"modules_ready_ms\":35,\
              \"virtiofs_ready_ms\":48,\
              \"network_ready_ms\":250,\
@@ -197,13 +206,15 @@ mod tests {
 
     #[test]
     fn to_json_emits_null_for_missing_phases() {
-        // Cold-tier second boot: no seed, no network (offline).
+        // Cold-tier second boot: no seed, no network (offline),
+        // DB already loaded on prior boot so skipped.
         let t = BootTimings {
             init_start_ms: Some(0),
             pseudofs_ready_ms: Some(7),
             nix_device_ready_ms: Some(11),
             nix_seeded_ms: None,
             nix_mounted_ms: Some(15),
+            nix_db_loaded_ms: None,
             modules_ready_ms: Some(22),
             virtiofs_ready_ms: Some(30),
             network_ready_ms: None,
@@ -213,6 +224,7 @@ mod tests {
         };
         let json = t.to_json();
         assert!(json.contains("\"nix_seeded_ms\":null"), "got {json}");
+        assert!(json.contains("\"nix_db_loaded_ms\":null"), "got {json}");
         assert!(json.contains("\"network_ready_ms\":null"), "got {json}");
     }
 
@@ -228,6 +240,7 @@ mod tests {
             nix_device_ready_ms: Some(18),
             nix_seeded_ms: None,
             nix_mounted_ms: Some(220),
+            nix_db_loaded_ms: Some(225),
             modules_ready_ms: Some(35),
             virtiofs_ready_ms: Some(48),
             network_ready_ms: Some(250),

--- a/crates/mvm-builder-init/src/main.rs
+++ b/crates/mvm-builder-init/src/main.rs
@@ -120,13 +120,139 @@ fn virtiofs_tag_is_read_only(tag: &str) -> bool {
     tag == "work"
 }
 
+/// Bytes from the start of the ext4 superblock that the host-side
+/// geometry check reads. The high-32 bits of `s_blocks_count` live
+/// at superblock offset `0x150` (336), so 512 is the smallest
+/// power-of-two read covering every field the parser inspects.
+#[cfg(any(target_os = "linux", test))]
+const EXT4_SUPERBLOCK_READ: usize = 512;
+
+/// Parse the ext4 superblock buffer and return the total
+/// filesystem size in bytes the superblock asserts, or `None`
+/// when the buffer has no valid ext4 magic / a sanity-failing
+/// block size.
+///
+/// Layout (little-endian; offsets relative to the start of the
+/// superblock — itself at byte offset 1024 of the partition):
+/// - `0x04`  u32 `s_blocks_count_lo`  — low 32 bits of total block count
+/// - `0x18`  u32 `s_log_block_size`   — block size = `1024 << this`
+/// - `0x38`  u16 `s_magic`            — `0xEF53` for ext{2,3,4}
+/// - `0x150` u32 `s_blocks_count_hi`  — high 32 bits (64-bit feature; 0 otherwise)
+///
+/// Pure function so darwin `cargo test` exercises it without a
+/// Linux cross-compile; the file-IO and `BLKGETSIZE64` ioctl that
+/// feed it live inside the linux module.
+#[cfg(any(target_os = "linux", test))]
+fn parse_ext4_recorded_size_bytes(sb: &[u8]) -> Option<u64> {
+    if sb.len() < 0x150 + 4 {
+        return None;
+    }
+    // Magic at 0x38 — guard before trusting the other fields.
+    if sb[0x38] != 0x53 || sb[0x39] != 0xEF {
+        return None;
+    }
+    let blocks_lo = u32::from_le_bytes(sb[0x04..0x08].try_into().ok()?);
+    let log_block_size = u32::from_le_bytes(sb[0x18..0x1c].try_into().ok()?);
+    let blocks_hi = u32::from_le_bytes(sb[0x150..0x154].try_into().ok()?);
+    // Reject absurd block sizes — ext4 spec allows 1 KiB..64 KiB
+    // (log values 0..=6). Anything higher signals a malformed or
+    // stale superblock; treat as unformatted.
+    if log_block_size > 6 {
+        return None;
+    }
+    let block_size = 1024u64 << log_block_size;
+    let total_blocks = (u64::from(blocks_hi) << 32) | u64::from(blocks_lo);
+    total_blocks.checked_mul(block_size)
+}
+
 #[cfg(test)]
 mod tests {
+    use super::*;
+
     #[test]
     fn virtiofs_tag_policy_keeps_only_workspace_read_only() {
-        assert!(super::virtiofs_tag_is_read_only("work"));
-        assert!(!super::virtiofs_tag_is_read_only("out"));
-        assert!(!super::virtiofs_tag_is_read_only("job"));
+        assert!(virtiofs_tag_is_read_only("work"));
+        assert!(!virtiofs_tag_is_read_only("out"));
+        assert!(!virtiofs_tag_is_read_only("job"));
+    }
+
+    /// Build a synthetic ext4 superblock buffer (just the fields
+    /// `parse_ext4_recorded_size_bytes` reads).
+    fn synth_sb(blocks_lo: u32, blocks_hi: u32, log_block_size: u32) -> Vec<u8> {
+        let mut sb = vec![0u8; EXT4_SUPERBLOCK_READ];
+        sb[0x04..0x08].copy_from_slice(&blocks_lo.to_le_bytes());
+        sb[0x18..0x1c].copy_from_slice(&log_block_size.to_le_bytes());
+        sb[0x38] = 0x53;
+        sb[0x39] = 0xEF;
+        sb[0x150..0x154].copy_from_slice(&blocks_hi.to_le_bytes());
+        sb
+    }
+
+    #[test]
+    fn parse_ext4_size_rejects_buffer_without_magic() {
+        let sb = vec![0u8; EXT4_SUPERBLOCK_READ];
+        assert_eq!(parse_ext4_recorded_size_bytes(&sb), None);
+    }
+
+    #[test]
+    fn parse_ext4_size_rejects_short_buffer() {
+        let sb = vec![0u8; 64];
+        assert_eq!(parse_ext4_recorded_size_bytes(&sb), None);
+    }
+
+    #[test]
+    fn parse_ext4_size_computes_64gib_default_layout() {
+        // mkfs.ext4 default: 4 KiB blocks (log=2). A 64 GiB
+        // filesystem records 16_777_216 blocks.
+        let sb = synth_sb(16_777_216, 0, 2);
+        assert_eq!(
+            parse_ext4_recorded_size_bytes(&sb),
+            Some(64u64 * 1024 * 1024 * 1024),
+        );
+    }
+
+    #[test]
+    fn parse_ext4_size_handles_64bit_feature() {
+        // 20 TiB needs the high-32-bit block count (64bit feature).
+        // 20 TiB with 4 KiB blocks = 20 * 2^40 / 2^12 = 5 * 2^30
+        // blocks, which overflows u32 — `blocks_hi` carries the top bit.
+        let total_blocks: u64 = 5 * (1u64 << 30);
+        let blocks_lo = (total_blocks & 0xFFFF_FFFF) as u32;
+        let blocks_hi = (total_blocks >> 32) as u32;
+        let sb = synth_sb(blocks_lo, blocks_hi, 2);
+        assert_eq!(
+            parse_ext4_recorded_size_bytes(&sb),
+            Some(20u64 * 1024 * 1024 * 1024 * 1024),
+        );
+    }
+
+    #[test]
+    fn parse_ext4_size_rejects_absurd_block_size() {
+        // log=7 → 128 KiB blocks, which mkfs.ext4 never produces;
+        // signals a stale / corrupt superblock.
+        let sb = synth_sb(1024, 0, 7);
+        assert_eq!(parse_ext4_recorded_size_bytes(&sb), None);
+    }
+
+    /// Regression for the May 2026 `mvmctl dev up` failure: a
+    /// stale 64 GiB ext4 image got re-attached to a `/dev/vdb`
+    /// libkrun exposed as 64 GiB − 64 KiB. The kernel rejected
+    /// mount with `EINVAL: bad geometry: block count 16777216
+    /// exceeds size of device (16777200 blocks)`. The pre-mount
+    /// check in [`linux::nix_store_dev_needs_format`] compares
+    /// the recorded FS size against the device size and reformats
+    /// on mismatch; this test pins the underlying arithmetic so
+    /// the comparison `fs_bytes > device_bytes` does what the
+    /// kernel does.
+    #[test]
+    fn parse_ext4_size_reports_oversize_filesystem() {
+        let fs_bytes = parse_ext4_recorded_size_bytes(&synth_sb(16_777_216, 0, 2))
+            .expect("valid superblock");
+        let device_bytes = 16_777_200u64 * 4096; // 64 GiB - 64 KiB
+        assert!(
+            fs_bytes > device_bytes,
+            "recorded FS ({fs_bytes}) must exceed device ({device_bytes}) for the bug to reproduce"
+        );
     }
 }
 
@@ -1250,8 +1376,8 @@ mod linux {
     fn setup_nix_store(timings: &Arc<Mutex<BootTimings>>, anchor: Instant) -> Result<(), String> {
         std::fs::create_dir_all(NIX_STORE_MOUNT)
             .map_err(|e| format!("create {NIX_STORE_MOUNT}: {e}"))?;
-        if !is_ext4_formatted(NIX_STORE_DEV)? {
-            eprintln!("mvm-builder-init: formatting {NIX_STORE_DEV} (first boot)");
+        if let Some(reason) = nix_store_dev_needs_format(NIX_STORE_DEV)? {
+            eprintln!("mvm-builder-init: formatting {NIX_STORE_DEV} ({reason})");
             format_ext4(NIX_STORE_DEV)?;
         }
         mount_fs(NIX_STORE_DEV, NIX_STORE_MOUNT, "ext4")?;
@@ -1788,23 +1914,30 @@ mod linux {
         bind_mount(NIX_OVERLAY_MERGED, NIX_TARGET)
     }
 
-    fn seed_nix_store(timings: &Arc<Mutex<BootTimings>>, anchor: Instant) -> Result<(), String> {
-        let needs_seed = match std::fs::read_dir(NIX_STORE_MOUNT) {
-            Ok(entries) => {
-                let mut any_non_lf = false;
-                for entry in entries {
-                    if let Ok(entry) = entry
-                        && entry.file_name() != "lost+found"
-                    {
-                        any_non_lf = true;
-                        break;
-                    }
-                }
-                !any_non_lf
-            }
+    /// Returns true when the persistent Nix store at `path` has not
+    /// yet been seeded from the rootfs's `/nix`.
+    ///
+    /// The seeded marker is a non-empty `store/` subdirectory. mkGuest
+    /// always populates `/nix/store/HASH-*` in the rootfs, so any
+    /// successful seed leaves `store/` non-empty in `/nix-store`.
+    ///
+    /// The previous "any entry other than lost+found" heuristic
+    /// false-positived once [`mount_nix_overlay`] had pre-created
+    /// `upper/` and `work/` on a freshly-formatted volume: an
+    /// overlay-mount failure would route through `seed_nix_store`,
+    /// the seed would be skipped (upper/ and work/ counted as "not
+    /// lost+found"), and the subsequent bind-mount put an empty
+    /// `/nix-store` over `/nix` — every `/sbin/<pkg>` symlink
+    /// dangled and the first spawn failed with `ENOENT`.
+    fn nix_store_needs_seed(path: &Path) -> bool {
+        match std::fs::read_dir(path.join("store")) {
+            Ok(mut entries) => entries.next().is_none(),
             Err(_) => true,
-        };
-        if !needs_seed {
+        }
+    }
+
+    fn seed_nix_store(timings: &Arc<Mutex<BootTimings>>, anchor: Instant) -> Result<(), String> {
+        if !nix_store_needs_seed(Path::new(NIX_STORE_MOUNT)) {
             return Ok(());
         }
 
@@ -1858,24 +1991,81 @@ mod linux {
         .map_err(|e| format!("mount virtiofs {tag} -> {target}: {e}"))
     }
 
-    /// Probe the ext4 magic at offset 0x438 (the superblock's
-    /// `s_magic` field). Returns `Ok(false)` for a blank disk;
-    /// `Ok(true)` for a formatted one; `Err` only when the device
-    /// itself isn't readable (which is fatal — we couldn't mount
-    /// it anyway).
-    fn is_ext4_formatted(dev: &str) -> Result<bool, String> {
+    /// Offset of the ext4 primary superblock inside the partition
+    /// (`SUPERBLOCK_OFFSET` in fs/ext4/ext4.h).
+    const EXT4_SUPERBLOCK_OFFSET: u64 = 1024;
+
+    /// Decide whether `/dev/vdb` needs (re)formatting before
+    /// mounting. Returns `Some(reason)` on first boot (no ext4
+    /// magic) and on stale-geometry mismatches where the recorded
+    /// filesystem extends past the actual block-device end. Such
+    /// volumes mount with `EINVAL` in the kernel:
+    ///
+    /// ```text
+    /// EXT4-fs (vdb): bad geometry: block count <fs> exceeds
+    ///                 size of device (<dev> blocks)
+    /// ```
+    ///
+    /// Detected pre-mount so we can recover with `mkfs.ext4 -F`
+    /// rather than aborting before the build can run. The
+    /// `/nix-store` volume is a cache; reformatting loses nothing
+    /// that can't be rebuilt by the next nix build.
+    fn nix_store_dev_needs_format(dev: &str) -> Result<Option<String>, String> {
+        let sb = read_ext4_superblock(dev)?;
+        let Some(fs_bytes) = crate::parse_ext4_recorded_size_bytes(&sb) else {
+            return Ok(Some("no ext4 superblock".into()));
+        };
+        let dev_bytes = block_device_size_bytes(dev)?;
+        if fs_bytes > dev_bytes {
+            return Ok(Some(format!(
+                "ext4 records {fs_bytes} bytes but device exposes {dev_bytes} bytes"
+            )));
+        }
+        Ok(None)
+    }
+
+    /// Read the first [`crate::EXT4_SUPERBLOCK_READ`] bytes of the
+    /// superblock from `dev`. Returns a short buffer (truncated to
+    /// the actual byte count read) when the device is too small —
+    /// the parser treats short reads as "no ext4".
+    fn read_ext4_superblock(dev: &str) -> Result<Vec<u8>, String> {
         use std::fs::File;
         use std::io::{Read, Seek, SeekFrom};
         let mut f = File::open(dev).map_err(|e| format!("open {dev}: {e}"))?;
-        if f.seek(SeekFrom::Start(1080)).is_err() {
-            return Ok(false);
+        f.seek(SeekFrom::Start(EXT4_SUPERBLOCK_OFFSET))
+            .map_err(|e| format!("seek superblock on {dev}: {e}"))?;
+        let mut buf = vec![0u8; crate::EXT4_SUPERBLOCK_READ];
+        let mut read = 0;
+        while read < buf.len() {
+            match f.read(&mut buf[read..]) {
+                Ok(0) => break,
+                Ok(n) => read += n,
+                Err(e) if e.kind() == std::io::ErrorKind::Interrupted => continue,
+                Err(e) => return Err(format!("read superblock on {dev}: {e}")),
+            }
         }
-        let mut buf = [0u8; 2];
-        if f.read_exact(&mut buf).is_err() {
-            return Ok(false);
-        }
-        // ext4 magic: 0xEF53 stored little-endian.
-        Ok(buf == [0x53, 0xEF])
+        buf.truncate(read);
+        Ok(buf)
+    }
+
+    // BLKGETSIZE64 = _IOR(0x12, 114, size_t). `nix::ioctl_read!`
+    // generates the same `(2<<30) | (size_of::<u64>()<<16) | (0x12<<8) | 114`
+    // request value (`0x80081272` on 64-bit Linux) used by util-linux.
+    nix::ioctl_read!(blkgetsize64, 0x12, 114, u64);
+
+    /// Query a block device's size in bytes via `BLKGETSIZE64`.
+    /// Linux block devices only — regular files return EINVAL, which
+    /// is fine: `/nix-store-<arch>.img` is always attached as a
+    /// virtio-blk device inside the builder VM.
+    fn block_device_size_bytes(dev: &str) -> Result<u64, String> {
+        use std::os::unix::io::AsRawFd;
+        let f = std::fs::File::open(dev).map_err(|e| format!("open {dev}: {e}"))?;
+        let mut size: u64 = 0;
+        // SAFETY: `blkgetsize64` writes a single u64. `f` outlives the
+        // call; the fd is valid for the duration.
+        unsafe { blkgetsize64(f.as_raw_fd(), &mut size as *mut u64) }
+            .map_err(|e| format!("ioctl BLKGETSIZE64 on {dev}: {e}"))?;
+        Ok(size)
     }
 
     /// Return the device size in 4 KiB blocks via
@@ -2340,6 +2530,51 @@ mod linux {
             let meta = std::fs::metadata(base.path().join(job_id)).expect("stat");
             assert_eq!(meta.uid(), uid);
             assert_eq!(meta.gid(), gid);
+        }
+
+        #[test]
+        fn nix_store_needs_seed_when_path_missing() {
+            let base = tempfile::tempdir().expect("tempdir");
+            assert!(nix_store_needs_seed(&base.path().join("does-not-exist")));
+        }
+
+        #[test]
+        fn nix_store_needs_seed_when_store_dir_absent() {
+            let base = tempfile::tempdir().expect("tempdir");
+            std::fs::create_dir(base.path().join("lost+found")).expect("create lost+found");
+            assert!(nix_store_needs_seed(base.path()));
+        }
+
+        /// Regression: `mount_nix_overlay` pre-creates `upper/` and
+        /// `work/` before attempting the overlay mount. If that mount
+        /// fails, the fallback path used to see the volume as "already
+        /// seeded" (any non-`lost+found` entry counted) and skip the
+        /// copy, leaving `/nix` empty after bind-mount. The corrected
+        /// check looks at `store/` instead, so overlay scaffolding
+        /// does not confuse the seeder.
+        #[test]
+        fn nix_store_needs_seed_when_only_overlay_scaffolding_present() {
+            let base = tempfile::tempdir().expect("tempdir");
+            std::fs::create_dir(base.path().join("upper")).expect("create upper");
+            std::fs::create_dir(base.path().join("work")).expect("create work");
+            std::fs::create_dir(base.path().join("lost+found")).expect("create lost+found");
+            assert!(nix_store_needs_seed(base.path()));
+        }
+
+        #[test]
+        fn nix_store_needs_seed_when_store_dir_is_empty() {
+            let base = tempfile::tempdir().expect("tempdir");
+            std::fs::create_dir(base.path().join("store")).expect("create store");
+            assert!(nix_store_needs_seed(base.path()));
+        }
+
+        #[test]
+        fn nix_store_does_not_need_seed_when_store_has_entries() {
+            let base = tempfile::tempdir().expect("tempdir");
+            let store = base.path().join("store");
+            std::fs::create_dir(&store).expect("create store");
+            std::fs::create_dir(store.join("abc123-some-pkg")).expect("create closure path");
+            assert!(!nix_store_needs_seed(base.path()));
         }
     }
 }

--- a/crates/mvm-builder-init/src/main.rs
+++ b/crates/mvm-builder-init/src/main.rs
@@ -290,6 +290,22 @@ mod linux {
     /// lowerdir; persistent writes land in [`NIX_OVERLAY_UPPER`].
     const NIX_TARGET: &str = "/nix";
 
+    /// Standard nixpkgs path-registration manifest, emitted by
+    /// `nixos/lib/make-ext4-fs.nix` (which mkGuest uses). Lists
+    /// every store path baked into the rootfs along with its
+    /// SHA-256, size, and references — exactly the wire shape
+    /// `nix-store --load-db` consumes from stdin. Sits at the
+    /// rootfs root (not under `/nix/`) and is mounted read-only.
+    const NIX_PATH_REGISTRATION: &str = "/nix-path-registration";
+
+    /// Sentinel file inside the persistent `/nix-store` we touch
+    /// after [`load_seeded_nix_db`] runs, so subsequent boots can
+    /// skip the (idempotent but slow) re-registration. Lives next
+    /// to `/nix-store/store/` and `/nix-store/var/` — neither path
+    /// the standard Nix store inspects, so the marker is invisible
+    /// to nix-daemon.
+    const NIX_DB_LOADED_MARKER: &str = "/nix-store/.seed-db-loaded";
+
     /// Per-job command staging dir (`/job/cmd.sh`, `/job/env`,
     /// `/job/result`). Mounted via virtio-fs from the host
     /// (`LibkrunBuilderVm` declares the `job` tag — see Plan 72 W4).
@@ -1412,6 +1428,21 @@ mod linux {
             t.nix_mounted_ms = Some(BootTimings::ms_since(anchor))
         });
 
+        // PR #420 follow-up: load `/nix-path-registration` (the
+        // standard `make-ext4-fs.nix` manifest) into the persistent
+        // `/nix/var/nix/db` so the in-VM `nix build` knows the
+        // seeded closure is already valid. Without this, nix-daemon
+        // treats every seeded path as missing and re-substitutes
+        // from `cache.nixos.org` — the substituter then overwrites
+        // the on-disk path during the rename window, and concurrent
+        // build-hook workers `dlopen`ing libs from the same path
+        // hit ENOENT. Idempotent + non-fatal so a missing or
+        // unparseable manifest still boots — at most regresses to
+        // the pre-fix substituter race.
+        if let Err(e) = load_seeded_nix_db(timings, anchor) {
+            eprintln!("mvm-builder-init: load_seeded_nix_db warning (non-fatal): {e}");
+        }
+
         Ok(())
     }
 
@@ -1971,6 +2002,72 @@ mod linux {
         }
         stamp(timings, |t| {
             t.nix_seeded_ms = Some(BootTimings::ms_since(anchor))
+        });
+        Ok(())
+    }
+
+    /// Register the seeded store paths in the persistent
+    /// `/nix/var/nix/db` so nix-daemon doesn't treat them as
+    /// missing and re-substitute over the on-disk copies.
+    ///
+    /// Reads the standard nixpkgs manifest at
+    /// [`NIX_PATH_REGISTRATION`] (emitted by
+    /// `nixos/lib/make-ext4-fs.nix`) and pipes it to
+    /// `nix-store --load-db`. Marked done with a sentinel at
+    /// [`NIX_DB_LOADED_MARKER`] so subsequent boots skip the
+    /// (idempotent but ~100ms) re-registration.
+    ///
+    /// The need for this call surfaced as `libboost_url.so.1.87.0:
+    /// cannot open shared object file` during the in-VM dev-image
+    /// build: with no entries in the DB, every closure path the
+    /// build references gets re-fetched from `cache.nixos.org`,
+    /// overwriting the seeded path in place — and a concurrent
+    /// nix build-hook worker mid-`dlopen` of the same path's libs
+    /// hits ENOENT during the rename window. Loading the DB makes
+    /// the substituter skip the re-fetch entirely.
+    fn load_seeded_nix_db(
+        timings: &Arc<Mutex<BootTimings>>,
+        anchor: Instant,
+    ) -> Result<(), String> {
+        if Path::new(NIX_DB_LOADED_MARKER).exists() {
+            return Ok(());
+        }
+        if !Path::new(NIX_PATH_REGISTRATION).is_file() {
+            return Err(format!(
+                "{NIX_PATH_REGISTRATION} not present — rootfs predates the \
+                 make-ext4-fs.nix manifest convention; substituter race \
+                 will recur"
+            ));
+        }
+
+        eprintln!(
+            "mvm-builder-init: loading seeded paths into nix DB from {NIX_PATH_REGISTRATION}"
+        );
+        let manifest = std::fs::File::open(NIX_PATH_REGISTRATION)
+            .map_err(|e| format!("open {NIX_PATH_REGISTRATION}: {e}"))?;
+        let status = Command::new("/sbin/nix-store")
+            .arg("--load-db")
+            .stdin(manifest)
+            .status()
+            .map_err(|e| format!("spawn /sbin/nix-store --load-db: {e}"))?;
+        if !status.success() {
+            return Err(format!(
+                "nix-store --load-db exit {}",
+                status.code().unwrap_or(-1)
+            ));
+        }
+
+        // Best-effort sentinel so we skip on next boot. Failure is
+        // non-fatal — worst case we re-run the idempotent load.
+        if let Err(e) = std::fs::write(NIX_DB_LOADED_MARKER, b"") {
+            eprintln!(
+                "mvm-builder-init: could not write {NIX_DB_LOADED_MARKER}: {e} \
+                 (continuing — next boot will re-load the DB)"
+            );
+        }
+
+        stamp(timings, |t| {
+            t.nix_db_loaded_ms = Some(BootTimings::ms_since(anchor))
         });
         Ok(())
     }

--- a/crates/mvm-builder-init/src/main.rs
+++ b/crates/mvm-builder-init/src/main.rs
@@ -335,10 +335,15 @@ mod linux {
         // `Command::new("modprobe")` style spawn relies on the
         // child to find its binary — which fails on a stock rootfs
         // (Plan 86 / ADR-054). Set a canonical PATH that covers the
-        // mvm builder VM rootfs layout (busybox + extra packages in
-        // /sbin + /usr/local/bin) before any spawn site runs.
-        // Absolute-path call sites (`/sbin/mkfs.ext4`, `/sbin/udhcpc`)
-        // are unaffected.
+        // mvm builder VM rootfs layout (busybox at `/bin/*` + extra
+        // packages at `/sbin/*` + `/usr/local/bin/*`) before any
+        // spawn site runs. Absolute-path call sites like
+        // `/sbin/mkfs.ext4` (e2fsprogs, lives at `/sbin/*` via the
+        // mkGuest packages symlink) and `/bin/udhcpc`,
+        // `/bin/busybox` (busybox applets, live at `/bin/*` via the
+        // mkGuest busybox install) are unaffected. Hardcoding
+        // `/sbin/udhcpc` would ENOENT — busybox only installs
+        // applets under `/bin/<applet>`.
         // SAFETY: PID 1 is single-threaded until we spawn the fan-out
         // tracks below; no other thread can be reading the env yet.
         unsafe {
@@ -1514,15 +1519,23 @@ mod linux {
         // builds without the script keep the legacy `-i eth0 -n -q`
         // shape — udhcpc still sets the IP but resolv.conf stays at
         // the fallback content.
+        //
+        // `/bin/udhcpc` — udhcpc is a busybox applet, and mkGuest
+        // installs busybox applet symlinks under `/bin/<applet>`,
+        // not `/sbin/`. (Plan 96 / PR #420 follow-up: prior
+        // `/sbin/udhcpc` hardcoding ENOENTed at every boot, which
+        // `setup_network` swallowed as non-fatal — leaving the
+        // builder VM with no DHCP-assigned IP and the inner nix
+        // build unable to reach `cache.nixos.org`.)
         let script = "/etc/udhcpc/default.script";
-        let mut cmd = Command::new("/sbin/udhcpc");
+        let mut cmd = Command::new("/bin/udhcpc");
         cmd.args(["-i", "eth0", "-n", "-q"]);
         if std::path::Path::new(script).is_file() {
             cmd.args(["-s", script]);
         }
         let status = cmd
             .status()
-            .map_err(|e| format!("spawn /sbin/udhcpc: {e}"))?;
+            .map_err(|e| format!("spawn /bin/udhcpc: {e}"))?;
         if !status.success() {
             return Err(format!("udhcpc exit {}", status.code().unwrap_or(-1)));
         }

--- a/crates/mvm-builder-init/src/main.rs
+++ b/crates/mvm-builder-init/src/main.rs
@@ -246,8 +246,8 @@ mod tests {
     /// kernel does.
     #[test]
     fn parse_ext4_size_reports_oversize_filesystem() {
-        let fs_bytes = parse_ext4_recorded_size_bytes(&synth_sb(16_777_216, 0, 2))
-            .expect("valid superblock");
+        let fs_bytes =
+            parse_ext4_recorded_size_bytes(&synth_sb(16_777_216, 0, 2)).expect("valid superblock");
         let device_bytes = 16_777_200u64 * 4096; // 64 GiB - 64 KiB
         assert!(
             fs_bytes > device_bytes,

--- a/nix/images/builder/flake.lock
+++ b/nix/images/builder/flake.lock
@@ -1,0 +1,65 @@
+{
+  "nodes": {
+    "microvm": {
+      "inputs": {
+        "nixpkgs": [
+          "nixpkgs"
+        ],
+        "spectrum": "spectrum"
+      },
+      "locked": {
+        "lastModified": 1778505275,
+        "narHash": "sha256-NUBO+o/ZasfzS/oB4pFLXWQa9Oc/Uoz6qWpSWMb/GUk=",
+        "owner": "microvm-nix",
+        "repo": "microvm.nix",
+        "rev": "dae3578b2bc38722430f0e586e07f57385b52ef8",
+        "type": "github"
+      },
+      "original": {
+        "owner": "microvm-nix",
+        "repo": "microvm.nix",
+        "type": "github"
+      }
+    },
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1778430510,
+        "narHash": "sha256-Ti+ZBvW6yrWWAg2szExVTwCd4qOJ3KlVr1tFHfyfi8Q=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "8fd9daa3db09ced9700431c5b7ad0e8ba199b575",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixos-25.11",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "microvm": "microvm",
+        "nixpkgs": "nixpkgs"
+      }
+    },
+    "spectrum": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1772189877,
+        "narHash": "sha256-i1p90Rgssb//aNiTDFq46ZG/fk3LmyRLChtp/9lddyA=",
+        "ref": "refs/heads/main",
+        "rev": "fe39e122d898f66e89ffa17d4f4209989ccb5358",
+        "revCount": 1255,
+        "type": "git",
+        "url": "https://spectrum-os.org/git/spectrum"
+      },
+      "original": {
+        "type": "git",
+        "url": "https://spectrum-os.org/git/spectrum"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/nix/images/runtime-overlay/flake.lock
+++ b/nix/images/runtime-overlay/flake.lock
@@ -1,0 +1,27 @@
+{
+  "nodes": {
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1778430510,
+        "narHash": "sha256-Ti+ZBvW6yrWWAg2szExVTwCd4qOJ3KlVr1tFHfyfi8Q=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "8fd9daa3db09ced9700431c5b7ad0e8ba199b575",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixos-25.11",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "nixpkgs": "nixpkgs"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}


### PR DESCRIPTION
## Summary

Rebased onto current `main` (`744bca74`) after PR #421 (`worktree-dev-up-unblock`) merged with overlapping unblockers from different angles. This PR keeps the still-needed work; redundant pieces are noted below.

5 commits on top of `main`:

1. `d5e795d9` — ext4 geometry recovery + correct seed-fallback check
2. `6f6fd7c9` — `/bin/udhcpc` + `nix/images/builder/flake.lock`
3. `2a3bb286` — cargo fmt fixup
4. `a6242604` — register seeded `/nix/store` paths in nix DB at boot
5. `37f0aa9b` — pin `nix/images/runtime-overlay/flake.lock` (follow-up #1)

## Overlap with merged PR #421

| Bug | This PR | PR #421 (merged) | Status |
|---|---|---|---|
| `/sbin/udhcpc` ENOENT | `/bin/udhcpc` Rust change | `pkgsStatic.busybox` added to `builderPackages` | Both fix it; #421's flake-level fix establishes the pattern. Mine is harmless (both `/bin/udhcpc` and `/sbin/udhcpc` exist after #421). |
| EXT4 EINVAL bad geometry | Detect mismatch at boot, reformat | Pass explicit block count to `mkfs.ext4` from `/sys/class/block/<dev>/size` | **Complementary** — #421 prevents on fresh format; this PR recovers from stale volumes (in-the-wild 64 GiB-64 KiB files from older code paths). Defense-in-depth. |
| Overlay `mkdir` on RO rootfs | Not addressed | Moved `NIX_OVERLAY_MERGED` to `/run/nix-merged` | **#421 only** — my seed-fallback fix is now defensive code for a path that no longer triggers in normal flow. Still correct. |
| Buggy seed-fallback "is empty?" check | New `nix_store_needs_seed` checks `store/` non-empty | Not addressed | **This PR only** — defense for the overlay-fallback path, still correct. |
| `nix/images/builder/flake.lock` missing | Added | Not addressed | **This PR only** — still needed for the in-VM dev-image build. |
| `nix/images/runtime-overlay/flake.lock` missing | Added | Not addressed | **This PR only** — same issue for the Plan 74 runtime-overlay build path. |
| Substituter overwrites seeded paths → libboost ENOENT | `load_seeded_nix_db` + `BootTimingsWire.nix_db_loaded_ms` | Not addressed | **This PR only** — registers `/nix-path-registration` in nix DB so substituters skip re-fetching seeded paths. |

## Validation

- `cargo check --workspace` → ✅
- `cargo test -p mvm-builder-init --tests` → 69 passed
- `cargo test -p mvm-build --tests` → 271 passed across binaries
- `cargo clippy -p mvm-builder-init -p mvm-build --tests -- -D warnings` → clean
- Tests pass cleanly on the rebased branch

## Out-of-scope follow-ups (not in this PR)

- **`builder_vm_source_fingerprint` expansion** to cover `crates/mvm-builder-init/src/`, `crates/mvm-egress-proxy/src/`, and `Cargo.lock` — currently only hashes `flake.nix`+`flake.lock`, so contributor edits to the in-VM PID-1 binary silently reuse the cached rootfs. This burned the dev-loop multiple times during PR development. Worth its own focused PR with new tests against the existing fingerprint test fixture.

## End-to-end smoke test pending

A parallel session ran `mvmctl dev up` while this branch was still being assembled. The orphan `mvm-libkrun-supervisor` from that run is still on the host (no parent process; `mvmctl cache prune --reap-orphans` from Plan 95 FU-1 will clean it). Once cleared, an end-to-end run should show `loading seeded paths into nix DB from /nix-path-registration` in the steady-state console log and no `libboost_url.so` ENOENT.

🤖 Generated with [Claude Code](https://claude.com/claude-code)