### PR TITLE
fix(builder-vm): unblock dev up — busybox, /run/nix-merged, mkfs geometry, reaper

### DIFF
--- a/crates/mvm-builder-init/src/main.rs
+++ b/crates/mvm-builder-init/src/main.rs
@@ -1878,9 +1878,50 @@ mod linux {
         Ok(buf == [0x53, 0xEF])
     }
 
+    /// Return the device size in 4 KiB blocks via
+    /// `/sys/class/block/<basename>/size` (which is the canonical
+    /// 512-byte sector count the kernel uses for mount). Used by
+    /// [`format_ext4`] to avoid mkfs.ext4's `BLKGETSIZE64`-rounding
+    /// mismatch under libkrun virtio-blk.
+    fn device_size_4k_blocks(dev: &str) -> Result<u64, String> {
+        let basename = std::path::Path::new(dev)
+            .file_name()
+            .and_then(|s| s.to_str())
+            .ok_or_else(|| format!("device path {dev} has no basename"))?;
+        let sys_path = format!("/sys/class/block/{basename}/size");
+        let sectors_str = std::fs::read_to_string(&sys_path)
+            .map_err(|e| format!("read {sys_path}: {e}"))?;
+        let sectors: u64 = sectors_str
+            .trim()
+            .parse()
+            .map_err(|e| format!("parse {sys_path} = {sectors_str:?}: {e}"))?;
+        // 1 sector = 512 B, 1 4K block = 8 sectors. Floor-divide so
+        // we never claim more blocks than the device actually has.
+        Ok(sectors / 8)
+    }
+
     fn format_ext4(dev: &str) -> Result<(), String> {
+        // Pass an explicit block count instead of letting mkfs.ext4
+        // query the device size. libkrun's virtio-blk and mkfs.ext4
+        // disagree on the device's block count by exactly 16 4K blocks
+        // (64 KiB) — mkfs rounds UP from `BLKGETSIZE64` to a 64 KiB
+        // boundary; the kernel mount path uses the unrounded size.
+        // Without the explicit count, the freshly-mkfs'd filesystem
+        // claims `block count N+16 exceeds size of device (N blocks)`
+        // and the next `mount` fails with EINVAL. Querying the
+        // canonical size from `/sys/class/block/<dev>/size` (always
+        // matches what `mount` uses) and passing `mkfs.ext4 -b 4096
+        // <dev> <count>` short-circuits mkfs's rounding.
+        let blocks_4k = device_size_4k_blocks(dev)?;
         let status = Command::new("/sbin/mkfs.ext4")
-            .args(["-F", "-q", dev])
+            .args([
+                "-F",
+                "-q",
+                "-b",
+                "4096",
+                dev,
+                &blocks_4k.to_string(),
+            ])
             .status()
             .map_err(|e| format!("spawn /sbin/mkfs.ext4: {e}"))?;
         if !status.success() {

--- a/crates/mvm-builder-init/src/main.rs
+++ b/crates/mvm-builder-init/src/main.rs
@@ -151,7 +151,13 @@ mod linux {
     const NIX_STORE_MOUNT: &str = "/nix-store";
     const NIX_OVERLAY_UPPER: &str = "/nix-store/upper";
     const NIX_OVERLAY_WORK: &str = "/nix-store/work";
-    const NIX_OVERLAY_MERGED: &str = "/nix-merged";
+    /// Plan 95 followup — was `/nix-merged` (rootfs root). The rootfs
+    /// boots `ro`, so `mkdir /nix-merged` failed with EROFS and the
+    /// overlay-mount fell back to seed-copy. `/run` is mounted tmpfs
+    /// by `mount_pseudofs` (mvmctl-init Stage 1), so `mkdir` there
+    /// always succeeds. The mount point is host-side scaffolding —
+    /// the visible mount is the bind-mount onto [`NIX_TARGET`] = `/nix`.
+    const NIX_OVERLAY_MERGED: &str = "/run/nix-merged";
 
     /// Final bind-mount target. The rootfs's `/nix/store` (seed
     /// Nix paths needed by `/bin/sh`, `nix`, etc.) is the overlay

--- a/crates/mvm-builder-init/src/main.rs
+++ b/crates/mvm-builder-init/src/main.rs
@@ -1889,8 +1889,8 @@ mod linux {
             .and_then(|s| s.to_str())
             .ok_or_else(|| format!("device path {dev} has no basename"))?;
         let sys_path = format!("/sys/class/block/{basename}/size");
-        let sectors_str = std::fs::read_to_string(&sys_path)
-            .map_err(|e| format!("read {sys_path}: {e}"))?;
+        let sectors_str =
+            std::fs::read_to_string(&sys_path).map_err(|e| format!("read {sys_path}: {e}"))?;
         let sectors: u64 = sectors_str
             .trim()
             .parse()
@@ -1914,14 +1914,7 @@ mod linux {
         // <dev> <count>` short-circuits mkfs's rounding.
         let blocks_4k = device_size_4k_blocks(dev)?;
         let status = Command::new("/sbin/mkfs.ext4")
-            .args([
-                "-F",
-                "-q",
-                "-b",
-                "4096",
-                dev,
-                &blocks_4k.to_string(),
-            ])
+            .args(["-F", "-q", "-b", "4096", dev, &blocks_4k.to_string()])
             .status()
             .map_err(|e| format!("spawn /sbin/mkfs.ext4: {e}"))?;
         if !status.success() {

--- a/crates/mvm-cli/src/commands/env/apple_container.rs
+++ b/crates/mvm-cli/src/commands/env/apple_container.rs
@@ -3256,17 +3256,31 @@ pub(in crate::commands) struct ReapOutcome {
 /// (Plan 95 doc §Follow-ups FU-2/FU-3 cover the "prevent" side; this
 /// is the "clean up after the fact" side — FU-1).
 ///
-/// Walks each `~/.cache/mvm/builder-vm/vms/<id>/` dir and inspects its
-/// `{supervisor.pid, gvproxy.pid, stage0.pid}` sidecars. For each PID:
-/// - dead → ignore (it's already gone, the sidecar is just stale)
-/// - alive with a non-launchd parent → in-flight dev up; skip the
-///   whole dir (don't touch a live owner's state)
+/// Two scans per VM dir:
+///
+/// 1. **Sidecar PID scan.** Each dir carries a `{builder.pid,
+///    stage0.pid}` sidecar with the supervisor's PID. (Earlier
+///    versions of this function looked for the wrong names
+///    (`supervisor.pid`/`gvproxy.pid`); the actual sidecar names
+///    are `builder.pid` for steady-state and `stage0.pid` for
+///    Stage 0 — fixed after smoke-testing on accumulated state
+///    showed `0` PIDs killed despite live orphans.)
+/// 2. **Argv scan.** `gvproxy` is the supervisor's GRANDCHILD and
+///    writes no sidecar of its own — its argv references the VM
+///    dir's `gvproxy.sock`. The argv scan catches those grandchildren
+///    even after the supervisor is gone. Same for `tail -F` readers
+///    of `console.log`.
+///
+/// For each PID found by either scan:
+/// - dead → ignore
+/// - alive with a non-launchd parent → in-flight dev up; mark dir
+///   as "has a live owner", skip dir removal
 /// - alive with launchd as parent → SIGTERM and count
 ///
 /// Then if no helper in the dir had a live non-launchd parent, the
-/// dir itself is removed. This avoids the over-aggressive
-/// `rm -rf $vm/` of the prototype `/tmp/plan95/reap.sh`, which would
-/// have nuked a live dev up's state dir.
+/// dir is removed. This avoids the over-aggressive `rm -rf $vm/`
+/// of the prototype `/tmp/plan95/reap.sh`, which during validation
+/// nuked a live mvmctl's state dir.
 pub(in crate::commands) fn reap_orphaned_vm_helpers(dry_run: bool) -> Result<ReapOutcome> {
     let vms_root =
         std::path::PathBuf::from(mvm_core::config::mvm_cache_dir()).join("builder-vm/vms");
@@ -3293,28 +3307,56 @@ fn reap_orphaned_vm_helpers_at(vms_root: &std::path::Path, dry_run: bool) -> Res
 
         let mut dir_has_live_owner = false;
         let mut killed_in_dir = 0u64;
+        let mut seen_pids: std::collections::HashSet<i32> = std::collections::HashSet::new();
 
-        for sidecar in ["supervisor.pid", "gvproxy.pid", "stage0.pid"] {
+        // Scan 1 — sidecar files. Steady-state builder VMs write
+        // `builder.pid`; Stage 0 writes `stage0.pid`.
+        for sidecar in ["builder.pid", "stage0.pid"] {
             let pid_file = dir.join(sidecar);
             let Some(pid) = read_pid_file(&pid_file) else {
                 continue;
             };
-            if !pid_is_alive(pid) {
+            if !seen_pids.insert(pid) {
                 continue;
             }
-            if pid_parent(pid) != Some(1) {
-                dir_has_live_owner = true;
-                continue;
-            }
-            if !dry_run {
-                // SIGTERM; ignore the result — the next iteration of
-                // the pruner will catch anything that survived (e.g.
-                // a process that ignored TERM).
-                unsafe {
-                    libc::kill(pid, libc::SIGTERM);
+            match classify_pid(pid) {
+                PidClassification::Dead => {}
+                PidClassification::LiveOwned => dir_has_live_owner = true,
+                PidClassification::Orphan => {
+                    if !dry_run {
+                        unsafe {
+                            libc::kill(pid, libc::SIGTERM);
+                        }
+                    }
+                    killed_in_dir += 1;
                 }
             }
-            killed_in_dir += 1;
+        }
+
+        // Scan 2 — argv scan for grandchildren (gvproxy, tail -F …
+        // console.log). They don't write sidecars but their argv
+        // contains the VM dir basename (the `mvm-stage0-…` or
+        // `mvm-builder-vm-…` id), which is unique on this host.
+        let dir_basename = match dir.file_name().and_then(|s| s.to_str()) {
+            Some(s) => s.to_string(),
+            None => continue,
+        };
+        for pid in pids_referencing(&dir_basename) {
+            if !seen_pids.insert(pid) {
+                continue;
+            }
+            match classify_pid(pid) {
+                PidClassification::Dead => {}
+                PidClassification::LiveOwned => dir_has_live_owner = true,
+                PidClassification::Orphan => {
+                    if !dry_run {
+                        unsafe {
+                            libc::kill(pid, libc::SIGTERM);
+                        }
+                    }
+                    killed_in_dir += 1;
+                }
+            }
         }
 
         outcome.killed += killed_in_dir;
@@ -3331,6 +3373,44 @@ fn reap_orphaned_vm_helpers_at(vms_root: &std::path::Path, dry_run: bool) -> Res
     }
 
     Ok(outcome)
+}
+
+enum PidClassification {
+    Dead,
+    LiveOwned, // alive, parent is something other than launchd → in-flight
+    Orphan,    // alive, parent is launchd PID 1 → SIGTERM-able
+}
+
+fn classify_pid(pid: i32) -> PidClassification {
+    if !pid_is_alive(pid) {
+        return PidClassification::Dead;
+    }
+    match pid_parent(pid) {
+        Some(1) => PidClassification::Orphan,
+        _ => PidClassification::LiveOwned,
+    }
+}
+
+/// Find all PIDs whose argv contains `needle`. Used by the argv-scan
+/// pass to catch grandchildren (gvproxy, console-tail) that don't
+/// write a sidecar file. macOS has no `/proc`, so the portable path
+/// is `pgrep -f <needle>` — argv-substring match.
+fn pids_referencing(needle: &str) -> Vec<i32> {
+    let out = match std::process::Command::new("pgrep")
+        .args(["-f", needle])
+        .output()
+    {
+        Ok(o) => o,
+        Err(_) => return Vec::new(),
+    };
+    if !out.status.success() {
+        return Vec::new();
+    }
+    String::from_utf8_lossy(&out.stdout)
+        .lines()
+        .filter_map(|s| s.trim().parse::<i32>().ok())
+        .filter(|&p| p > 1)
+        .collect()
 }
 
 fn read_pid_file(path: &std::path::Path) -> Option<i32> {
@@ -4543,7 +4623,7 @@ mod reap_orphans_tests {
 
     #[test]
     fn dead_pids_get_their_dirs_swept() {
-        // A VM dir whose `supervisor.pid` references a long-dead PID
+        // A VM dir whose `builder.pid` references a long-dead PID
         // (we use `1` and skip it via read_pid_file's `> 1` guard, so
         // instead use a PID that's very unlikely to be alive). The
         // reaper should remove the dir and count `removed_dirs += 1`
@@ -4554,7 +4634,7 @@ mod reap_orphans_tests {
         std::fs::create_dir_all(&vm).expect("mkdir");
         // pick a PID guaranteed not to exist: 2^31-2 (one less than i32::MAX,
         // outside normal kernel allocation range on macOS/Linux)
-        std::fs::write(vm.join("supervisor.pid"), "2147483646\n").expect("write pid");
+        std::fs::write(vm.join("builder.pid"), "2147483646\n").expect("write pid");
         std::fs::write(vm.join("payload"), vec![0u8; 1024]).expect("write payload");
 
         let out = reap_orphaned_vm_helpers_at(&vms_root, false).expect("reap");
@@ -4566,7 +4646,7 @@ mod reap_orphans_tests {
 
     #[test]
     fn live_owner_preserves_dir_in_dry_run_and_real() {
-        // A VM dir whose `supervisor.pid` references THIS test's PID.
+        // A VM dir whose `builder.pid` references THIS test's PID.
         // The test process's parent is cargo/test runner, not launchd
         // PID 1, so `pid_parent != Some(1)` → reaper marks the dir as
         // "has a live owner" and leaves it alone.
@@ -4575,7 +4655,7 @@ mod reap_orphans_tests {
         let vm = vms_root.join("mvm-stage0-pid-of-self");
         std::fs::create_dir_all(&vm).expect("mkdir");
         let my_pid = std::process::id() as i32;
-        std::fs::write(vm.join("supervisor.pid"), format!("{my_pid}\n")).expect("write pid");
+        std::fs::write(vm.join("builder.pid"), format!("{my_pid}\n")).expect("write pid");
 
         let out = reap_orphaned_vm_helpers_at(&vms_root, false).expect("reap");
         assert_eq!(out.killed, 0, "live owner should not be killed");
@@ -4589,14 +4669,14 @@ mod reap_orphans_tests {
         let vms_root = dir.path().join("vms");
         let vm = vms_root.join("mvm-stage0-dryrun-test");
         std::fs::create_dir_all(&vm).expect("mkdir");
-        std::fs::write(vm.join("supervisor.pid"), "2147483646\n").expect("write pid");
+        std::fs::write(vm.join("builder.pid"), "2147483646\n").expect("write pid");
         std::fs::write(vm.join("payload"), vec![0u8; 256]).expect("write payload");
 
         let out = reap_orphaned_vm_helpers_at(&vms_root, true).expect("dry-run reap");
         // Dry-run still *counts* what it would do, but doesn't mutate.
         assert_eq!(out.removed_dirs, 1);
         assert!(vm.exists(), "dry-run must not remove the dir");
-        assert!(vm.join("supervisor.pid").exists(), "pid file untouched");
+        assert!(vm.join("builder.pid").exists(), "pid file untouched");
     }
 }
 

--- a/nix/images/builder-vm/flake.nix
+++ b/nix/images/builder-vm/flake.nix
@@ -157,6 +157,13 @@
       builderPackages = pkgs: with pkgs; [
         bashInteractive
         coreutils
+        # `pkgsStatic.busybox` for the lightweight utilities that
+        # mvm-builder-init spawns by absolute path — chiefly
+        # `/sbin/udhcpc` (busybox applet) for DHCP on the builder
+        # VM's eth0. Without busybox in `packages`, mkGuest's
+        # symlink loop (nix/lib/mk-guest.nix:770-788) skips it
+        # and `/sbin/udhcpc` doesn't exist → setup_network bails.
+        pkgsStatic.busybox
         gnugrep
         gnused
         gawk


### PR DESCRIPTION
## Summary

Four bug fixes surfaced during Plan 95 end-to-end validation (PR #418).
None of these are kernel-related — they're integration bugs in the
mkGuest ↔ mvm-builder-init contract that the slim-kernel walk turned
up. Each is independently testable; bundled here as one PR because
they were discovered together and they share `dev up` as their gate.

**Net effect on aarch64-darwin:** `dev up` now boots cleanly all the
way through to the nix-build job inside the persistent builder VM,
running for ~47 s before hitting the *pre-existing* `libboost_url`
closure-walk bug (Plan 92 validation list bug #6 — mkGuest-side,
separate PR).

## Fixes

### 1. `pkgsStatic.busybox` added to `builderPackages` (`nix/images/builder-vm/flake.nix`)

mkGuest's symlink loop at `nix/lib/mk-guest.nix:770-788` iterates the
`packages` arg and emits `/sbin/<name>` + `/usr/local/bin/<name>`
symlinks. Without busybox in the list, `/sbin/udhcpc` (busybox
applet) never gets a symlink and `mvm-builder-init::setup_network`'s
`Command::new("/sbin/udhcpc")` bails with "No such file or directory".

### 2. `NIX_OVERLAY_MERGED`: `/nix-merged` → `/run/nix-merged` (`crates/mvm-builder-init/src/main.rs`)

`mvm-builder-init::setup_nix_store` does `mkdir_all(NIX_OVERLAY_MERGED)`
to create the overlay mount target. Rootfs is `ro`, so
`mkdir /nix-merged` fails with EROFS and the overlay-mount falls back
to seed-copy (which can't substitute writable `/nix`). `/run` is
tmpfs (Stage 1 `mount_pseudofs`), so `mkdir` succeeds. The visible
mount is the bind-mount onto `/nix`, so the path move is invisible
to consumers.

### 3. `format_ext4` passes explicit block count to mkfs.ext4 (`crates/mvm-builder-init/src/main.rs`)

mkfs.ext4 and the kernel's mount path disagree on libkrun virtio-blk
device size by exactly 16 4 KiB blocks (64 KiB) — mkfs rounds UP
from `BLKGETSIZE64` to a 64 KiB boundary; mount uses the unrounded
size. Result on every fresh `/dev/vdb`:

```
EXT4-fs (vdb): bad geometry: block count 16777184
               exceeds size of device (16777168 blocks)
setup_nix_store failed: mount /dev/vdb -> /nix-store (ext4):
                        EINVAL: Invalid argument
```

Reproducible across runs. Different runs see different absolute file
sizes (64 GiB − 64 KiB, 64 GiB − 192 KiB, ...) but the mkfs-vs-mount
drift is always 16 blocks.

Fix: read canonical block count from `/sys/class/block/<dev>/size`
(the same source kernel mount uses) and pass explicit `<count>`
positional arg to `mkfs.ext4 -F -q -b 4096 <dev> <count>`.
Short-circuits the rounding.

### 4. `cache prune --reap-orphans` actually finds PIDs now (`crates/mvm-cli/src/commands/env/apple_container.rs`)

Smoke-tested PR #418's FU-1 reap-orphans against accumulated state
from the Plan 95 validation. Output: `Reaped 0 orphaned helper
PID(s) and 7 cache dir(s)` — dir count correct, kill count always 0.
Two bugs:

a. **Sidecar names were wrong** — function looked for `supervisor.pid`
   / `gvproxy.pid` / `stage0.pid`, but actual sidecars are
   `builder.pid` (steady-state) and `stage0.pid` (Stage 0).
b. **Orphaned `gvproxy` is the supervisor's GRANDCHILD** and writes
   no sidecar — invisible to a sidecar-only scan. Added a second
   pass: `pgrep -f <vm-dir-basename>` to catch grandchildren by
   argv match, then `classify_pid` (dead / live-owned / orphan).
   `tail -F …console.log` readers are caught the same way.

New helpers: `PidClassification` enum, `classify_pid`,
`pids_referencing`. Per-dir `HashSet<i32>` dedupes PIDs that show
up in both passes (the sidecar PID's argv also matches the dir
basename).

Re-tested: `Reaped 2 orphaned helper PID(s) and 1 cache dir(s)` —
working.

## Test plan

- [x] `cargo build --workspace` — clean
- [x] `cargo clippy --workspace -- -D warnings` — clean
- [x] `cargo test --package mvm-cli --lib reap_orphans_tests` — 4/4
- [x] `nix flake check --no-build ./nix/images/builder-vm` — passes locally
- [x] `mvmctl cache prune --reap-orphans` — actually kills orphan grandchildren
- [x] `mvmctl dev up` — Stage 0 → promotion → persistent builder VM
      kernel boot → mkfs.ext4 → mount /dev/vdb → overlay /nix → nix
      build job runs for ~47 s (then hits libboost_url, separate bug)
- [ ] CI

## Known remaining blocker (out of scope)

```
nix: error while loading shared libraries: libboost_url.so.1.87.0:
     cannot open shared object file: No such file or directory
```

Plan 92 validation list bug #6 — mkGuest closure-walk doesn't land
all transitive `.so` paths. Affects the rootfs's `/nix/store` seed;
not in this PR. Plan 93/94 WIP likely absorbs it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)