### PR TITLE
fix(mkGuest): skip addon-dns bake for builder VM (Stage 0 OOM unblocker)

### DIFF
--- a/nix/images/builder-vm/flake.nix
+++ b/nix/images/builder-vm/flake.nix
@@ -281,6 +281,16 @@
         in
         (libFor { inherit system; }).mkGuest {
           name = "mvm-builder-vm";
+          # Skip the addon-dns bake. The builder VM's PID 1 is
+          # `mvm-builder-init` (set via `extraFiles` + the
+          # `init=/sbin/mvm-builder-init` kernel cmdline), so
+          # mkGuest's initScript-side addon-dns activation block
+          # never runs and the binary would just sit unused at
+          # /usr/local/bin/mvm-addon-dns. The win is in Stage 0:
+          # not building `mvm-addon-dns` removes a parallel rustc
+          # run that competed with the kernel compile and pushed
+          # the tmpfs-bound build into OOM territory.
+          bakeAddonDns = false;
           # mkGuest requires an entrypoint declaration. At runtime
           # the kernel cmdline sets `init=/sbin/mvm-builder-init`,
           # so mkGuest's entrypoint is vestigial — but we still

--- a/nix/lib/mk-guest.nix
+++ b/nix/lib/mk-guest.nix
@@ -78,6 +78,17 @@ in
 , dev            ? null
 , uids           ? null   # { agent = <int>; entrypoint = <int>; } — see below
 , extraFiles     ? { }
+# Whether to bake the `mvm-addon-dns` binary into the rootfs at
+# `/usr/local/bin/mvm-addon-dns`. The default (`true`) matches the
+# "always install + no-op when zone empty" contract that workload
+# microVMs rely on (see `specs/contracts/local-addon-dns.md`).
+# Builder/utility VMs whose `/init` doesn't run mkGuest's addon-dns
+# activation block (e.g. `nix/images/builder-vm/`, which substitutes
+# `mvm-builder-init` as PID 1) should pass `bakeAddonDns = false` to
+# skip the Rust compile of `mvm-addon-dns` during their rootfs build
+# — a meaningful saving in Stage 0 where the build runs on tmpfs and
+# competes with the kernel compile for memory.
+, bakeAddonDns   ? true
 # Optional kernel package. When set, mkGuest copies its module
 # tree (`/lib/modules/<kver>/`) into the rootfs and `/init` runs
 # `modprobe vmw_vsock_virtio_transport` before forking the agent.
@@ -670,11 +681,19 @@ let
     cp ${mvmGuestNetinitBinary} "$out/usr/local/bin/mvm-guest-netinit"
     chmod 0555 "$out/usr/local/bin/mvm-guest-netinit"
 
-    # In-guest addon DNS resolver. Baked into every rootfs so /init
-    # can spawn it without a build-time mkGuest flag; activation is
-    # gated at boot on the presence of a zone file (see initScript).
-    cp ${mvmAddonDnsBinary} "$out/usr/local/bin/mvm-addon-dns"
-    chmod 0555 "$out/usr/local/bin/mvm-addon-dns"
+    # In-guest addon DNS resolver. Baked into every workload rootfs
+    # so /init can spawn it without a build-time mkGuest flag;
+    # activation is gated at boot on the presence of a zone file
+    # (see initScript). Gated on the `bakeAddonDns` arg so VMs whose
+    # `/init` doesn't run mkGuest's addon-dns activation block (e.g.
+    # `nix/images/builder-vm/`) can skip the Rust compile — the
+    # binary would never get invoked there, and on tmpfs-bound Stage
+    # 0 builds the parallel rustc run for it pushes the kernel
+    # compile into OOM territory.
+    ${if bakeAddonDns then ''
+      cp ${mvmAddonDnsBinary} "$out/usr/local/bin/mvm-addon-dns"
+      chmod 0555 "$out/usr/local/bin/mvm-addon-dns"
+    '' else ""}
 
     # Kernel modules. `/init` `modprobe`s vsock before forking the
     # agent (default nixpkgs kernel ships AF_VSOCK as `=m`); without


### PR DESCRIPTION
## Summary

`mkGuest` unconditionally bakes `mvm-addon-dns` into every rootfs, per the "always-install + no-op when zone empty" contract in `specs/contracts/local-addon-dns.md`. Correct for *workload* microVMs (where mkGuest's initScript runs the addon-dns activation block). **Wrong** for the *builder VM*: its PID 1 is `mvm-builder-init`, not mkGuest's initScript, so the activation block never runs and the binary sits unused at `/usr/local/bin/mvm-addon-dns`.

The cost of carrying that unused binary is real: a full rustc compile of `mvm-addon-dns` runs in parallel with the kernel compile, `mvm-builder-init`, and `mvm-egress-proxy` during Stage 0. On Stage 0's tmpfs budget (14 GiB `/nix` cap + 16 GiB total VM RAM, from PR #418 and PR #421), the four-way parallel build blew past the cap and the OOM killer took rustc → `stage0-init: nix build exited 137` with no useful stderr.

## Fix

Two lines:

- `nix/lib/mk-guest.nix` — `bakeAddonDns ? true` parameter; gates the `cp ${mvmAddonDnsBinary}` line at the rootfs-tree builder. Default preserves the workload contract.
- `nix/images/builder-vm/flake.nix` — passes `bakeAddonDns = false`.

## Validation

- `cargo build --workspace` — clean
- `cargo clippy --workspace -- -D warnings` — clean
- `nix flake check --no-build ./nix/images/builder-vm` — passes
- **`mvmctl dev up` walks the full pipeline:** Stage 0 completes in 7m 9s (no OOM), promotion passes, persistent builder VM kernel boots, ext4 geometry recovery fires (PR #420), `/dev/vdb` mounts cleanly, nix DB loads from `/nix-path-registration` (PR #420), inner nix build runs for 115s. **Fails at the next layer's blocker** — `mvm-guest-agent-0.14.0.drv` build inside the persistent builder VM exits 1; that's separate scope (per-derivation log lives inside the VM's `/nix/store`, can't be read from the host without mounting `nix-store-aarch64.img`).

## Scope

Strictly the builder VM. Workload microVM rootfs assembly is unchanged — `bakeAddonDns` defaults to `true`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)