### PR TITLE
fix(stage0): surface real nix-build errors when /dev/null is missing

### DIFF
--- a/crates/mvm-build/src/stage0.rs
+++ b/crates/mvm-build/src/stage0.rs
@@ -556,6 +556,64 @@ mod tests {
         );
     }
 
+    /// Regression for the 2026-05-21 `mvmctl dev up` failure where
+    /// `nix build` exited 1 and the init's error handler then
+    /// printed `/init: line 156: can't create /dev/null: nonexistent
+    /// directory` — masking the real nix-build error because the
+    /// `tail … 2>/dev/null` redirect tried to open a missing
+    /// `/dev/null` in libkrun's set_root container mode.
+    ///
+    /// Two invariants this PR establishes:
+    ///   1. The script `mknod`s `/dev/null` early so subsequent
+    ///      `2>/dev/null` redirects in any other tool still work.
+    ///   2. The script's own error handlers never use `2>/dev/null`
+    ///      themselves — even if (1) fails for some other reason,
+    ///      the nix-build error reaches the console.
+    #[test]
+    fn init_script_protects_against_missing_dev_null() {
+        assert!(
+            INIT_SCRIPT.contains("mknod /dev/null c 1 3"),
+            "init script must mknod /dev/null with major=1 minor=3 to \
+             survive libkrun set_root quirks where /dev/null is absent"
+        );
+        assert!(
+            INIT_SCRIPT.contains("[ -c /dev/null ]"),
+            "init script must gate the mknod on `[ -c /dev/null ]` so \
+             a well-populated /dev doesn't trip the mknod"
+        );
+        // Comments (lines starting with `#` after optional leading
+        // whitespace) reference the bad pattern by name to explain
+        // why it's avoided. The test only cares about live code.
+        for (i, line) in INIT_SCRIPT.lines().enumerate() {
+            let trimmed = line.trim_start();
+            if trimmed.starts_with('#') || trimmed.is_empty() {
+                continue;
+            }
+            assert!(
+                !line.contains("2>/dev/null"),
+                "init script line {} uses `2>/dev/null` in live code:\n\
+                 \n  {}\n\n\
+                 That's the pattern that masked the real nix-build \
+                 failure when /dev/null was missing in libkrun \
+                 set_root mode — replace with an `[ -r FILE ]` guard.",
+                i + 1,
+                line
+            );
+        }
+    }
+
+    /// Catch a regression in the boot-time /dev probe — if it
+    /// disappears, the next debugging session loses its primary
+    /// diagnostic for /dev/null absence.
+    #[test]
+    fn init_script_logs_dev_probe_at_boot() {
+        assert!(
+            INIT_SCRIPT.contains("/dev probe:"),
+            "init script must log a /dev probe so we can see whether \
+             /dev/null was already there or had to be mknod'd"
+        );
+    }
+
     #[test]
     fn cache_dir_is_under_home() {
         let path = stage0_cache_dir();

--- a/crates/mvm-build/src/stage0/init.sh
+++ b/crates/mvm-build/src/stage0/init.sh
@@ -28,6 +28,27 @@ mountpoint -q /dev  || mount -t devtmpfs devtmpfs /dev || true
 mountpoint -q /tmp  || mount -t tmpfs    -o mode=1777 tmpfs /tmp
 mountpoint -q /run  || mount -t tmpfs    -o mode=0755 tmpfs /run
 
+# `/dev/null` insurance. Observed (2026-05-21): some Stage 0 runs
+# under libkrun's set_root container mode reach userspace with
+# `/dev/random` + `/dev/urandom` present but `/dev/null` missing,
+# which then breaks every downstream `2>/dev/null` redirect — and
+# the init script's error handlers were exactly the consumers of
+# that pattern, so the actual nix-build failure got masked behind
+# "/init: line N: can't create /dev/null: nonexistent directory".
+# `mknod` with the standard major=1/minor=3 nodes /dev/null
+# explicitly; the `|| true` makes it a no-op when libkrun already
+# populated the node. Belt-and-suspenders — the error-handler
+# rewrite below also drops `2>/dev/null` so even a *failed* mknod
+# doesn't lose nix's actual stderr next time.
+[ -c /dev/null ] || { mknod /dev/null c 1 3 && chmod 0666 /dev/null; } || true
+
+# Console-visible /dev probe. Gives us evidence on every Stage 0
+# run about whether /dev/null was already there (the mknod was a
+# no-op) or absent (mknod created it / failed). Cheap; the
+# alternative is debugging the next masked failure blind.
+echo "stage0-init: /dev probe:" >&2
+ls -la /dev/null /dev/random /dev/urandom /dev/zero 2>&1 | sed 's/^/  /' >&2 || true
+
 # Bring eth0 up explicitly before udhcpc. busybox 1.36.x udhcpc
 # does not auto-up the interface — sendto returns ENETDOWN and
 # udhcpc loops forever. The libkrun virtio-net device is admin-DOWN
@@ -103,7 +124,13 @@ apk --no-progress update                              > /out/apk-update.log  2>&
 APK_RC=$?
 if [ "$APK_RC" -ne 0 ]; then
   echo "stage0-init: apk update exited $APK_RC (see /out/apk-update.log)" >&2
-  tail -40 /out/apk-update.log >&2 2>/dev/null || true
+  # `[ -r ]` test instead of the old `2>/dev/null` pattern: a
+  # missing `/dev/null` would itself make the redirect fail with
+  # "can't create /dev/null: nonexistent directory" and mask the
+  # real apk error. See the /dev/null insurance block at the top.
+  if [ -r /out/apk-update.log ]; then
+    tail -40 /out/apk-update.log >&2
+  fi
   exit "$APK_RC"
 fi
 apk --no-progress add nix git ca-certificates xz      > /out/apk-add.log     2>&1
@@ -111,7 +138,9 @@ APK_RC=$?
 set -e
 if [ "$APK_RC" -ne 0 ]; then
   echo "stage0-init: apk add exited $APK_RC (see /out/apk-add.log)" >&2
-  tail -40 /out/apk-add.log >&2 2>/dev/null || true
+  if [ -r /out/apk-add.log ]; then
+    tail -40 /out/apk-add.log >&2
+  fi
   exit "$APK_RC"
 fi
 
@@ -153,7 +182,16 @@ set -e
 if [ "$NIX_RC" -ne 0 ]; then
   echo "stage0-init: nix build exited $NIX_RC (see /out/nix-stderr.log)" >&2
   echo "stage0-init: === nix-stderr.log tail (last 80 lines) ===" >&2
-  tail -80 /out/nix-stderr.log >&2 2>/dev/null || echo "stage0-init: (could not read /out/nix-stderr.log)" >&2
+  # `[ -r ]` rather than the old `tail ... 2>/dev/null` so a missing
+  # `/dev/null` (observed at least once on libkrun set_root mode)
+  # doesn't mask the real nix error. The /dev/null insurance block
+  # at the top of this script is the primary fix; this is the
+  # belt-and-suspenders second layer.
+  if [ -r /out/nix-stderr.log ]; then
+    tail -80 /out/nix-stderr.log >&2
+  else
+    echo "stage0-init: (could not read /out/nix-stderr.log)" >&2
+  fi
   echo "stage0-init: === end nix-stderr.log ===" >&2
   exit "$NIX_RC"
 fi


### PR DESCRIPTION
## What happened (2026-05-21)

While smoke-testing the just-merged PR #420 fix stack, `mvmctl dev up` failed with this on Stage 0:

```
stage0-init: nix build exited 1 (see /out/nix-stderr.log)
stage0-init: === nix-stderr.log tail (last 80 lines) ===
/init: line 156: can't create /dev/null: nonexistent directory
stage0-init: (could not read /out/nix-stderr.log)
stage0-init: === end nix-stderr.log ===
```

The interesting bit isn't `nix build exited 1` — it's that the init's own error handler couldn't tell us *why*. Line 156 was:

```sh
tail -80 /out/nix-stderr.log >&2 2>/dev/null || echo "..." >&2
```

busybox sh tried to open `/dev/null` for the redirect, got `ENOENT`, and emitted "can't create /dev/null: nonexistent directory" (the specific busybox-sh wording for ENOENT on a redirect target). The `|| echo` fallback fired, `tail` was skipped, and **nix's actual stderr never reached the console**. We were flying blind on the real failure.

## Why `/dev/null` was missing

Stage 0 boots under libkrun's `krun_set_root` container mode. In that mode libkrun's in-VM init pre-mounts `/proc`, `/sys`, and `/dev` before our init.sh becomes PID 1 — so init.sh's `mountpoint -q /dev || mount -t devtmpfs ...` is skipped on the success path. `udhcpc` + `apk` both succeeded in the failed run (they read `/dev/random` + `/dev/urandom`), so libkrun's pre-mount populated those nodes. But `/dev/null` specifically was missing — possibly a TSI-patched libkrunfw kernel quirk, possibly a transient init race I haven't been able to fully pin. A parallel session running at the same time *didn't* hit this. Feels like a libkrun-state edge case, not a hard invariant.

## Fix — belt-and-suspenders in `init.sh`

1. **`mknod /dev/null c 1 3` insurance.** Right after the pseudofs mount block: `[ -c /dev/null ] || mknod ...` creates the character device with standard major/minor numbers. No-op when libkrun already populated it; transparent recovery when not.

2. **`/dev` probe at boot.** Diagnostic `ls -la /dev/{null,random,urandom,zero}` logged to stderr on every Stage 0 run, so the next reproduction tells us which nodes libkrun started with vs. which we had to create.

3. **Error handlers drop `2>/dev/null`.** Three call sites (`apk update` failure, `apk add` failure, `nix build` failure) switched from `tail ... 2>/dev/null || ...` to `if [ -r FILE ]; then tail ...; fi`. Even if (1) somehow fails on a future run, nix's actual stderr still reaches the console.

**(3) is the load-bearing fix** — (1) and (2) are diagnostic bonuses.

## Tests

Three new asserts on `INIT_SCRIPT` in `crates/mvm-build/src/stage0.rs`:

| Test | What it pins |
|---|---|
| `init_script_protects_against_missing_dev_null` | mknod fallback present + zero `2>/dev/null` in live code (scanner skips comment lines that describe the bad pattern) |
| `init_script_logs_dev_probe_at_boot` | the `/dev probe:` diagnostic isn't silently lost in a future refactor |
| (existing) `init_script_is_embedded_and_nonempty` | unchanged |

- `cargo test -p mvm-build --tests` → 237 + 13 + 23 + … all pass
- `cargo clippy -p mvm-build --tests -- -D warnings` → clean
- `cargo fmt --check` → clean

## What this does NOT do

It doesn't explain *why* `/dev/null` was missing in the failing run. The next reproduction's `/dev probe:` output will tell us:
- `/dev/null` already present → something else broke nix-build, and the new error-handler chain surfaces nix's actual stderr.
- `/dev/null` absent → confirms the libkrun set_root edge case and the `mknod` recovery picks it up (we'd see `c 1 3` in the probe).

Either way, the next failure is debuggable — which is the real point of this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)