### PR TITLE
fix(builder-vm,mkGuest): create /dev/fd symlinks so nixpkgs build hooks work

### DIFF
--- a/crates/mvm-build/src/libkrun_builder.rs
+++ b/crates/mvm-build/src/libkrun_builder.rs
@@ -403,6 +403,17 @@ impl LibkrunBuilderVm {
         let job_id = unique_job_id();
         let job_dir = builder_vm_cache_dir().join("jobs").join(&job_id);
         stage_shell_job_dir(&job_dir, &job.script)?;
+        // Tell the operator up-front where the build's stderr will
+        // land. `/job` is a virtio-fs share into the VM; the guest's
+        // cmd.sh redirects `nix build` stderr into <job_dir>/nix-
+        // stderr.log, which is this exact path on the host. A
+        // contributor watching a long build can `tail -f` it without
+        // waiting for the failure-path formatter (finalize_flake_job)
+        // to surface the same path.
+        tracing::info!(
+            job_dir = %job_dir.display(),
+            "builder VM job dir staged (nix-stderr.log streams here as the build runs)"
+        );
 
         let vm_name = format!("mvm-builder-vm-{job_id}");
         let vm_state_dir = builder_vm_cache_dir().join("vms").join(&vm_name);
@@ -656,6 +667,12 @@ impl BuilderVm for LibkrunBuilderVm {
         let job_id = unique_job_id();
         let job_dir = builder_vm_cache_dir().join("jobs").join(&job_id);
         stage_job_dir(&job_dir, job)?;
+        // Same announcement as the single-shot path — see the
+        // identical block in `LibkrunBuilderVm::run_build`.
+        tracing::info!(
+            job_dir = %job_dir.display(),
+            "builder VM job dir staged (nix-stderr.log streams here as the build runs)"
+        );
 
         // 7. Build the `KrunContext` libkrun consumes. Three
         //    virtio-fs shares (work / out / job), one virtio-blk
@@ -1202,6 +1219,26 @@ fn shell_single_quote_escape(s: &str) -> String {
     s.replace('\'', "'\\''")
 }
 
+/// Read the last `max_bytes` of `path` into a `String`, replacing any
+/// invalid UTF-8 lossily. Returns `Err` if the file is missing or
+/// unreadable. Used by `finalize_flake_job` to surface the tail of
+/// `<job_dir>/nix-stderr.log` (the cmd.sh's nix-build stderr capture)
+/// in the failure path without loading a multi-hundred-KB log into
+/// memory.
+fn read_last_bytes_of(path: &Path, max_bytes: u64) -> std::io::Result<String> {
+    use std::io::{Seek, SeekFrom};
+    let mut file = std::fs::File::open(path)?;
+    let len = file.metadata()?.len();
+    let take = max_bytes.min(len);
+    // SeekFrom::End wants i64; max_bytes is bounded to a small constant
+    // at every call site (4 KiB today) so the cast is safe.
+    let offset = i64::try_from(take).unwrap_or(i64::MAX).saturating_neg();
+    file.seek(SeekFrom::End(offset))?;
+    let mut buf = Vec::with_capacity(take as usize);
+    file.read_to_end(&mut buf)?;
+    Ok(String::from_utf8_lossy(&buf).into_owned())
+}
+
 /// Finalize a flake build: read `<job_dir>/result`, validate the
 /// `rootfs.ext4` (and optional `vmlinux`) landed in
 /// `artifact_out`, return a [`BuilderArtifacts::Image`].
@@ -1212,9 +1249,26 @@ fn finalize_flake_job(
 ) -> Result<BuilderArtifacts, BuilderVmError> {
     let result = read_job_result(job_dir)?;
     if result.exit_code != 0 {
+        // The 20-line `stderr_tail` in `result` is from the OUTER
+        // cmd.sh (run_job captures cmd.sh's stderr into a 20-line
+        // ringbuffer). That ringbuffer typically only carries the
+        // "nix build exited N; tail of stderr:" preamble — not the
+        // real per-derivation failure. The actual nix-build stderr
+        // is at `<job_dir>/nix-stderr.log` (cmd.sh redirects there
+        // via `2> /job/nix-stderr.log`). Surface its tail so the
+        // operator doesn't have to know the convention.
+        let stderr_log = job_dir.join("nix-stderr.log");
+        let derivation_tail = read_last_bytes_of(&stderr_log, 4 * 1024)
+            .unwrap_or_else(|_| String::from("<nix-stderr.log not present on host>"));
         return Err(BuilderVmError::NixBuildFailed(format!(
-            "guest cmd.sh exited {} — stderr tail:\n{}",
-            result.exit_code, result.stderr_tail
+            "guest cmd.sh exited {} — full log: {}\n\
+             outer stderr tail (cmd.sh ringbuffer):\n{}\n\
+             derivation stderr tail (last 4 KiB of {}):\n{}",
+            result.exit_code,
+            stderr_log.display(),
+            result.stderr_tail,
+            stderr_log.display(),
+            derivation_tail,
         )));
     }
 
@@ -2684,6 +2738,126 @@ mod tests {
             }
             other => panic!("wrong artifact variant: {other:?}"),
         }
+    }
+
+    /// `read_last_bytes_of` returns the trailing `max_bytes` of a
+    /// file. When the file is larger than the cap, we get the *end*,
+    /// not the head — the use case is tailing nix-build stderr where
+    /// the cause-of-death is at the bottom.
+    #[test]
+    fn read_last_bytes_of_returns_trailing_window_when_file_exceeds_cap() {
+        let scratch = TempDir::new().unwrap();
+        let path = scratch.path().join("log");
+        let mut body = String::new();
+        for i in 0..2_000 {
+            body.push_str(&format!("line {i}\n"));
+        }
+        std::fs::write(&path, &body).unwrap();
+        let tail = read_last_bytes_of(&path, 200).unwrap();
+        assert!(tail.len() <= 200);
+        assert!(tail.contains("line 1999"), "tail contains the last line");
+        assert!(
+            !tail.contains("line 0\n"),
+            "tail does not include the head: {tail}"
+        );
+    }
+
+    /// Small file: the helper returns the whole file (capped at its
+    /// real length, not the requested max).
+    #[test]
+    fn read_last_bytes_of_returns_entire_file_when_smaller_than_cap() {
+        let scratch = TempDir::new().unwrap();
+        let path = scratch.path().join("log");
+        std::fs::write(&path, b"hello world").unwrap();
+        let tail = read_last_bytes_of(&path, 4096).unwrap();
+        assert_eq!(tail, "hello world");
+    }
+
+    /// Missing file surfaces as an `io::Error`; the caller in
+    /// `finalize_flake_job` swallows it into a `<not present>`
+    /// sentinel rather than failing the whole error format.
+    #[test]
+    fn read_last_bytes_of_errors_on_missing_file() {
+        let scratch = TempDir::new().unwrap();
+        let err = read_last_bytes_of(&scratch.path().join("missing"), 1024).unwrap_err();
+        assert_eq!(err.kind(), std::io::ErrorKind::NotFound);
+    }
+
+    /// The failure-path error message names the nix-stderr.log path
+    /// AND inlines its tail. This is the diagnostic-surface fix —
+    /// before the change, callers got the outer cmd.sh ringbuffer
+    /// only, with no hint where the real log lived.
+    #[test]
+    fn finalize_flake_job_failure_includes_nix_stderr_log_path_and_tail() {
+        let scratch = TempDir::new().unwrap();
+        let job_dir = scratch.path().join("job");
+        let artifact_out = scratch.path().join("out");
+        std::fs::create_dir_all(&job_dir).unwrap();
+        std::fs::create_dir_all(&artifact_out).unwrap();
+        std::fs::write(
+            job_dir.join("result"),
+            r#"{"exit_code":1,"stderr_tail":"outer-tail"}"#,
+        )
+        .unwrap();
+        // Sentinel string the helper must surface — proves we're
+        // reading from THIS file and not from the outer ringbuffer.
+        std::fs::write(
+            job_dir.join("nix-stderr.log"),
+            "/nix/store/.../cargo-install-hook.sh: line 27: /dev/fd/63: No such file or directory\n",
+        )
+        .unwrap();
+
+        let err = finalize_flake_job(&job_dir, &artifact_out, "job-id").unwrap_err();
+        let msg = match err {
+            BuilderVmError::NixBuildFailed(s) => s,
+            other => panic!("expected NixBuildFailed, got {other:?}"),
+        };
+        assert!(msg.contains("exited 1"), "names exit code: {msg}");
+        let log_path = job_dir.join("nix-stderr.log");
+        assert!(
+            msg.contains(&*log_path.to_string_lossy()),
+            "names the full log path: {msg}"
+        );
+        assert!(
+            msg.contains("/dev/fd/63: No such file or directory"),
+            "inlines the real derivation stderr tail: {msg}"
+        );
+        assert!(
+            msg.contains("outer-tail"),
+            "still includes the outer ringbuffer for context: {msg}"
+        );
+    }
+
+    /// Missing `nix-stderr.log` doesn't crash the formatter — we get
+    /// a clean sentinel instead of an `Err(...)` cascade. This
+    /// matters for very-early failures (e.g. cmd.sh exit before the
+    /// `2> /job/nix-stderr.log` redirect runs).
+    #[test]
+    fn finalize_flake_job_failure_handles_missing_nix_stderr_log_cleanly() {
+        let scratch = TempDir::new().unwrap();
+        let job_dir = scratch.path().join("job");
+        let artifact_out = scratch.path().join("out");
+        std::fs::create_dir_all(&job_dir).unwrap();
+        std::fs::create_dir_all(&artifact_out).unwrap();
+        std::fs::write(
+            job_dir.join("result"),
+            r#"{"exit_code":2,"stderr_tail":"no cmd.sh"}"#,
+        )
+        .unwrap();
+
+        let err = finalize_flake_job(&job_dir, &artifact_out, "job-id").unwrap_err();
+        let msg = match err {
+            BuilderVmError::NixBuildFailed(s) => s,
+            other => panic!("expected NixBuildFailed, got {other:?}"),
+        };
+        assert!(
+            msg.contains("<nix-stderr.log not present on host>"),
+            "sentinel surfaces in place of missing log: {msg}"
+        );
+        assert!(
+            msg.contains("no cmd.sh"),
+            "outer tail still surfaces: {msg}"
+        );
     }
 
     #[test]

--- a/crates/mvm-builder-init/src/main.rs
+++ b/crates/mvm-builder-init/src/main.rs
@@ -165,9 +165,110 @@ fn parse_ext4_recorded_size_bytes(sb: &[u8]) -> Option<u64> {
     total_blocks.checked_mul(block_size)
 }
 
+/// Create `/dev/fd → /proc/self/fd` and `/dev/std{in,out,err} →
+/// /proc/self/fd/{0,1,2}` under `dev_root`. Idempotent: any entry that
+/// already exists (file, symlink, or device node) is left untouched —
+/// we never replace whatever the kernel or a prior boot has put there.
+///
+/// `dev_root` is a parameter so this helper is testable under a
+/// `tempfile::tempdir()` without privilege. The targets are written as
+/// absolute `/proc/self/fd/...` strings on purpose: they're consumed
+/// by code running inside the guest Linux VM where `/proc` is the
+/// procfs mount point. The helper itself is cross-platform — symlink
+/// creation works on macOS too — so unit tests run on contributor Macs
+/// in addition to the production Linux build target.
+pub(crate) fn setup_dev_fd_symlinks(dev_root: &std::path::Path) -> Result<(), String> {
+    use std::os::unix::fs::symlink;
+    for (link_name, target) in [
+        ("fd", "/proc/self/fd"),
+        ("stdin", "/proc/self/fd/0"),
+        ("stdout", "/proc/self/fd/1"),
+        ("stderr", "/proc/self/fd/2"),
+    ] {
+        let link = dev_root.join(link_name);
+        // `Path::exists` follows symlinks; `symlink_metadata` does
+        // not. We want "is there anything at this path?", which is
+        // the symlink_metadata question — otherwise a dangling
+        // symlink left over from a prior boot would be treated as
+        // absent and we'd EEXIST on the symlink call.
+        if link.symlink_metadata().is_ok() {
+            continue;
+        }
+        symlink(target, &link)
+            .map_err(|e| format!("symlink {} -> {target}: {e}", link.display()))?;
+    }
+    Ok(())
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    /// `setup_dev_fd_symlinks` lays down all four conventional symlinks
+    /// in an empty /dev so bash process substitution (`< <(...)`)
+    /// finds `/dev/fd/N`. The targets are the `/proc/self/fd` family;
+    /// the symlink_metadata-based skip keeps the helper idempotent on
+    /// reboot. Cross-platform: runs on macOS and Linux.
+    #[test]
+    fn setup_dev_fd_symlinks_creates_all_four_in_empty_dir() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        setup_dev_fd_symlinks(dir.path()).expect("fresh dev_root succeeds");
+        for (name, expected) in [
+            ("fd", "/proc/self/fd"),
+            ("stdin", "/proc/self/fd/0"),
+            ("stdout", "/proc/self/fd/1"),
+            ("stderr", "/proc/self/fd/2"),
+        ] {
+            let link = dir.path().join(name);
+            let target = std::fs::read_link(&link)
+                .unwrap_or_else(|e| panic!("read_link {}: {e}", link.display()));
+            assert_eq!(
+                target.to_string_lossy(),
+                expected,
+                "{name} points at the right /proc/self/fd target"
+            );
+        }
+    }
+
+    /// Idempotency: a pre-existing entry — even a dangling symlink
+    /// left over from a prior boot — is preserved. We never clobber
+    /// what the kernel/initramfs/previous boot staged. Guards
+    /// against, e.g., a future devtmpfs variant that creates
+    /// `/dev/stdin` as a character device.
+    #[test]
+    fn setup_dev_fd_symlinks_is_idempotent_when_already_present() {
+        use std::os::unix::fs::symlink;
+        let dir = tempfile::tempdir().expect("tempdir");
+        symlink("/sentinel", dir.path().join("fd")).expect("pre-stage symlink");
+        setup_dev_fd_symlinks(dir.path()).expect("idempotent run succeeds");
+        assert_eq!(
+            std::fs::read_link(dir.path().join("fd"))
+                .expect("read_link fd")
+                .to_string_lossy(),
+            "/sentinel",
+            "sentinel preserved"
+        );
+        for name in ["stdin", "stdout", "stderr"] {
+            assert!(
+                dir.path().join(name).symlink_metadata().is_ok(),
+                "{name} created on a partially-staged /dev"
+            );
+        }
+    }
+
+    /// A non-existent `dev_root` surfaces as a clean error message
+    /// that names the path. The first failing symlink is enough —
+    /// we don't try to be smart about pre-checking the parent.
+    #[test]
+    fn setup_dev_fd_symlinks_errors_when_dev_root_missing() {
+        let bogus = std::path::PathBuf::from("/this/path/should/not/exist/mvm-dev-fd-test");
+        let err =
+            setup_dev_fd_symlinks(&bogus).expect_err("missing dev_root must error, not panic");
+        assert!(
+            err.contains("/this/path/should/not/exist"),
+            "error names the offending parent path: {err}"
+        );
+    }
 
     #[test]
     fn virtiofs_tag_policy_keeps_only_workspace_read_only() {
@@ -1386,6 +1487,18 @@ mod linux {
         // mkGuest /init mounts this; we replicate for Plan 86.
         let _ = std::fs::create_dir_all("/dev/pts");
         mount_fs_idempotent("devpts", "/dev/pts", "devpts")?;
+        // `/dev/fd → /proc/self/fd` is what bash process substitution
+        // (`< <(...)`, `mapfile -t x < <(...)`) needs to open the
+        // subshell's pipe FD at `/dev/fd/N`. devtmpfs creates device
+        // nodes but never these symlinks; udev/mdev/systemd-tmpfiles
+        // normally do, and we run none of them. Without /dev/fd
+        // nixpkgs's `cargo-install-hook.sh` line 27 fails with
+        // "/dev/fd/63: No such file or directory" and every Rust
+        // derivation in the dev-image closure dies at install time.
+        // `/dev/std{in,out,err}` are conventionally present as well;
+        // we install all four so future hooks that depend on them
+        // don't trip the same surprise.
+        crate::setup_dev_fd_symlinks(Path::new("/dev"))?;
         Ok(())
     }
 

--- a/nix/lib/mk-guest.nix
+++ b/nix/lib/mk-guest.nix
@@ -241,6 +241,20 @@ let
     /bin/busybox mount -t sysfs    sysfs    /sys
     /bin/busybox mount -t devtmpfs devtmpfs /dev
 
+    # /dev/fd → /proc/self/fd is what bash process substitution
+    # (`< <(...)`, `mapfile -t x < <(...)`) needs to open the
+    # subshell's pipe FD at /dev/fd/N. devtmpfs creates device
+    # nodes but never these symlinks; udev/mdev/systemd-tmpfiles
+    # normally do, and we run none of them. Without /dev/fd a
+    # nixpkgs-style build hook fails with "/dev/fd/63: No such
+    # file or directory" — same gap is fixed in mvm-builder-init's
+    # mount_pseudofs(). The four lines are kept symmetric on both
+    # sides on purpose.
+    [ -e /dev/fd ]     || /bin/busybox ln -s /proc/self/fd   /dev/fd
+    [ -e /dev/stdin ]  || /bin/busybox ln -s /proc/self/fd/0 /dev/stdin
+    [ -e /dev/stdout ] || /bin/busybox ln -s /proc/self/fd/1 /dev/stdout
+    [ -e /dev/stderr ] || /bin/busybox ln -s /proc/self/fd/2 /dev/stderr
+
     # Stage 2 — runtime tmpfs. /tmp + /run are RAM so the rootfs
     # stays read-only-leaning; volumes (Phase 2) attach to fixed
     # mountpoints instead.

--- a/specs/SPRINT.md
+++ b/specs/SPRINT.md
@@ -1806,6 +1806,26 @@ don't fall off.
 - Dropping the `microvm.nix` flake input — locally unused in builder-vm but required by `nix/lib/default.nix` for the root flake's NixOS-module path; rework deferred (Plan 95 W1 was dropped post-survey).
 - microvm.nix as a *kernel* or *workload-build* base — explicitly rejected in Plan 95 §Problem and Plan 92 §Decision.
 
+### 2026-05-21 → 2026-05-22 `mvmctl dev up` unblock stack (executor notes)
+
+PRs landed on `main` to walk Stage 0 → persistent builder VM → inner `nix build`:
+
+- ✅ #418 / #419 — early Stage 0 wiring (merged 2026-05-20).
+- ✅ #420 — Plan 96 dev-up followups, including `nix-store --load-db` of seeded /nix/store paths (`a6242604`).
+- ✅ #421 — ext4 geometry recovery + udhcpc path + dev-image flake lock pin.
+- ✅ #422 — builder-VM fingerprint expansion to cover `mvm-builder-init` / `mvm-egress-proxy` / `Cargo.lock` (`155b561f`).
+- ✅ #423 — `mkGuest` skips `addon-dns` bake for the builder VM (Stage 0 OOM mitigation).
+- 🟡 #424 (`worktree-stage0-error-handler`) — `mknod /dev/null` insurance + `/dev` probe at boot + error-handler hardening so the next Stage 0 nix-build failure surfaces its real stderr instead of `can't create /dev/null: nonexistent directory`. All checks green; ready to merge.
+- 🟡 `worktree-dev-fd-symlinks` (PR pending) — adds `/dev/fd → /proc/self/fd` (plus `std{in,out,err}`) at builder-VM boot and in `mkGuest /init`, surfaces `<job_dir>/nix-stderr.log` path + 4 KiB tail on `finalize_flake_job` failure, and prints job dir at dispatch. Closes the `mvm-guest-agent-0.14.0.drv` inner-build failure observed at the very last step of `mvmctl dev up` — every Rust derivation in the dev image's closure was tripping nixpkgs's `cargoInstallHook` line 27 process substitution on a missing `/dev/fd`. Full plan + diagnosis log in [`backlog/42-tracking.md`](backlog/42-tracking.md).
+
+### Carryover follow-ups (pre-existing test breakages on `main`)
+
+Discovered while running `cargo test --workspace --all-features` to gate the dev-fd-symlinks PR. All three reproduce on a freshly-stashed clean `main` checkout; none are caused by the dev-fd-symlinks diff. Each needs its own small follow-up PR.
+
+1. `mvm-build::libkrun_builder::tests::run_build_surfaces_environment_gaps_for_install_variant` — host-environment-dependent. On a macOS contributor host with libkrun installed via Homebrew (which `CLAUDE.md` recommends as the dev-deps install), the test runs the supervisor path past the gap-detection short-circuit and gets `BuilderVmError::NixBuildFailed("supervisor exited with non-zero status (1); ...")` instead of the asserted `LibkrunUnavailable | ExtractionFailed`. Test was written for CI runners that lack libkrun. Fix: gate on a "libkrun absent" probe in the test, or assert the post-spawn `NixBuildFailed` shape too.
+2. `mvm-cli::commands::env::apple_container::dev_status_image_tests::builder_cache_status_reports_source_provenance_drift` — fixture panics with `builder VM source fingerprint missing /var/folders/.../Cargo.lock`. Caused by `155b561f` (PR #422) expanding the fingerprint to require a `Cargo.lock` in the workspace root, but this test fixture builds an isolated temp flake dir without one. Fix: stage an empty `Cargo.lock` (or copy the workspace one) into the fixture's temp workspace root before invoking the fingerprint code.
+3. `mvm-cli::commands::env::apple_container::dev_status_image_tests::builder_cache_status_reports_source_cache_hit_without_paths` — identical cause as (2).
+
 ## Completed Sprints
 
 - [01-foundation.md](sprints/01-foundation.md)

--- a/specs/backlog/42-tracking.md
+++ b/specs/backlog/42-tracking.md
@@ -1,0 +1,13611 @@
+## User
+
+Continue unblocking `mvmctl dev up` on aarch64-darwin. After yesterday's work
+(PRs #418/#419/#420/#421 merged, #423 open) dev up walks the full pipeline
+and fails at the **very last step** — building `mvm-guest-agent-0.14.0.drv`
+_inside_ the persistent builder VM:
+
+    error: Cannot build '/nix/store/<hash>-mvm-guest-agent-0.14.0.drv'.
+           Reason: builder failed with exit code 1.
+
+The host-visible mvmctl log only shows the cascading "Cannot build" — not the
+real stderr of the failed `mvm-guest-agent` build. Build timings show
+`job_start_ms: 187` → `job_end_ms: 115273` (115s of inner build) → power down.
+
+## Suspects (ranked)
+
+1. **NIX_CONFIG not inherited by child nix-build hooks.** Console shows
+   `warning: the group 'nixbld' specified in 'build-users-group' does not
+exist` — but the outer `cmd.sh` sets `build-users-group =` (empty) in
+   NIX_CONFIG. Spawned build-hook workers may be ignoring the parent's
+   NIX_CONFIG and falling back to nixpkgs defaults. Look at how
+   `mvm-builder-init`'s nix invocation propagates config to hooks.
+
+2. **mvm-guest-agent build script needs something the builder VM rootfs
+   lacks** (network, /etc/passwd entry, sandbox features). Check the
+   `crates/mvm-guest-agent` build.rs / Cargo flags vs. the builder-vm
+   builderPackages set.
+
+3. **Inner build OOM.** 115s is a long compile; might be hitting the same
+   tmpfs ceiling. Stage 0 has 14G /nix tmpfs cap + 16G VM RAM; the
+   persistent builder VM has its own virtio-blk /nix-store so this is
+   less likely, but worth ruling out.
+
+## Diagnostic paths
+
+- **Read the per-derivation log.** Lives at
+  `/nix/store/<hash>-mvm-guest-agent-0.14.0.drv.log` inside the persistent
+  builder VM's nix-store. Two ways to get it from outside:
+  a. Mount `~/.cache/mvm/builder-vm/nix-store-aarch64.img` on macOS
+  (ext4fuse / fuse-ext2 — finicky on Apple Silicon, may need
+  a Linux container to read).
+  b. Add host-side vsock receive for the build's stderr stream
+  (referenced as "W2 part 4" in the warning
+  `mvm-builder-init: vsock send: no host connection within 10s
+     (single-shot path; W2 part 4 wired the host receiver)`).
+- **Reproduce the build outside dev up.** `nix build .#mvm-guest-agent` in
+  a Linux VM (or local checkout) might show the same failure with full
+  stderr, faster than another dev up cycle.
+
+## Avoid duplicating
+
+- A `plan-92-stock-kernel` worktree is held with Plan 93/94 WIP for an
+  Alpine builder VM rewrite. Don't pursue that yet — `nix-store --load-db`
+  (PR #420) made it likely unnecessary.
+- A `fingerprint-expansion` worktree appeared yesterday in a parallel
+  session — check it before starting work.
+- PR #423 is the most recent fix; if it merged overnight, the addon-dns
+  Stage 0 OOM is already gone on main.
+
+## Start
+
+`git pull`, `gh pr list`, then read the persistent builder VM console at
+`~/.cache/mvm/builder-vm/vms/mvm-builder-vm-*/console.log` if dev up has
+been run recently. Pick the highest-signal diagnostic path and execute.
+
+## Assistant
+
+<thinking>
+
+</thinking>
+
+I'll follow the plan workflow. Starting with using-superpowers context, then checking in-flight state before dispatching Explore agents.
+
+**Tool Call: Skill**
+Status: Completed
+
+Launching skill: superpowers:systematic-debugging
+
+## Assistant
+
+<thinking>
+
+</thinking>
+
+Starting Phase 1 of systematic debugging — gathering evidence. Checking in-flight work and reading recent builder VM logs in parallel.
+
+**Tool Call: git pull --ff-only 2>&1 | tail -20**
+Status: Completed
+
+Terminal:
+
+```
+There is no tracking information for the current branch.
+Please specify which branch you want to merge with.
+See git-pull(1) for details.
+
+    git pull <remote> <branch>
+
+If you wish to set tracking information for this branch you can do so with:
+
+    git branch --set-upstream-to=origin/<branch> main
+```
+
+**Tool Call: gh pr list --state open --limit 30**
+Status: Completed
+
+Terminal:
+
+```
+423	fix(mkGuest): skip addon-dns bake for builder VM (Stage 0 OOM unblocker)	worktree-skip-addon-dns	OPEN	2026-05-22T05:10:04Z
+422	fix(builder-vm): fingerprint mvm-builder-init / mvm-egress-proxy / Cargo.lock too	worktree-fingerprint-expansion	OPEN	2026-05-22T04:29:17Z
+417	docs: Plan 91 — Stage 0 Alpine bootstrap (supersedes nix-portable)	worktree-plan-91-stage0-nix-portable-fix	OPEN	2026-05-20T03:38:19Z
+```
+
+**Tool Call: git worktree list**
+Status: Completed
+
+Terminal:
+
+```
+/Users/auser/work/tinylabs/mvmco/mvm                                         e646e4df [main]
+/Users/auser/work/tinylabs/mvmco/mvm/.claude/worktrees/fingerprint-expansion 155b561f [worktree-fingerprint-expansion]
+/Users/auser/work/tinylabs/mvmco/mvm/.claude/worktrees/plan-92-stock-kernel  e663abf4 [worktree-plan-92-stock-kernel]
+/Users/auser/work/tinylabs/mvmco/mvm/.claude/worktrees/skip-addon-dns        41c60e1a [worktree-skip-addon-dns]
+```
+
+**Tool Call: ls -la ~/.cache/mvm/builder-vm/vms/ 2>/dev/null**
+Status: Completed
+
+Terminal:
+
+```
+total 0
+drwxr-xr-x@ 4 auser  staff  128 May 21 22:00 .
+drwxr-xr-x@ 7 auser  staff  224 May 21 21:59 ..
+drwxr-xr-x@ 7 auser  staff  224 May 21 22:00 mvm-builder-vm-1779426018614-7835
+drwxr-xr-x@ 5 auser  staff  160 May 21 21:57 mvm-stage0-1779425442918-7835
+```
+
+**Tool Call: git log --oneline -20**
+Status: Completed
+
+Terminal:
+
+```
+e646e4df Merge pull request #420 from tinylabscom/worktree-plan-96-dev-up-followups
+37f0aa9b fix(nix): pin nix/images/runtime-overlay/flake.lock
+a6242604 fix(builder-init): register seeded /nix/store paths in nix DB at boot
+2a3bb286 style(builder-init): apply cargo fmt to ext4 parser regression test
+6f6fd7c9 fix(builder-init,nix): next-layer dev up unblockers — udhcpc path + dev-image flake lock
+d5e795d9 fix(builder-init): unblock dev up — ext4 geometry recovery + correct seed-fallback check
+744bca74 Merge pull request #421 from tinylabscom/worktree-dev-up-unblock
+d50ca7cc style: cargo fmt — collapse mkfs args, inline read_to_string
+90a0ed88 fix(builder-init): pass explicit block count to mkfs.ext4 (libkrun geometry)
+03da9aa7 fix(builder-vm): unblock dev up — busybox, /run/nix-merged, reaper fixes
+ee40b729 Merge pull request #418 from tinylabscom/worktree-plan-95-kernel-slimming
+e99ebf8d Merge pull request #419 from tinylabscom/worktree-cleanup-host-tiers
+c2d7f428 feat(cleanup): host-side --cache / --state / --nuclear tier flags
+575af3b0 fix(kernel): allowImportFromDerivation = false (CI nix flake check)
+326ede3a feat(cache prune): --reap-orphans for orphaned mvmctl helpers (Plan 95 FU-1)
+6648f1b3 style(stage0): apply cargo fmt
+06773162 fix(builder-vm): relax rootfs_contains_builder_init to basename
+e0bd871d build(plan-95): bump /nix tmpfs cap 4G → 14G + VM RAM 8 → 16 GiB
+3a0b601c Revert "build(plan-95): bump DEFAULT_MEMORY_MIB 8 → 16 GiB for Stage 0 headroom"
+70fe10a5 build(plan-95): bump DEFAULT_MEMORY_MIB 8 → 16 GiB for Stage 0 headroom
+```
+
+## Assistant
+
+<thinking>
+
+</thinking>
+
+Three open PRs in parallel sessions. Let me read the recent builder VM console + check what the fingerprint-expansion and skip-addon-dns worktrees are doing.
+
+**Tool Call: ls -la ~/.cache/mvm/builder-vm/vms/mvm-builder-vm-1779426018614-7835/**
+Status: Completed
+
+Terminal:
+
+```
+total 24
+drwxr-xr-x@ 7 auser  staff   224 May 21 22:00 .
+drwxr-xr-x@ 4 auser  staff   128 May 21 22:00 ..
+-rw-r--r--@ 1 auser  staff     5 May 21 22:00 builder.pid
+-rw-r--r--@ 1 auser  staff  6702 May 21 22:02 console.log
+srwxr-xr-x@ 1 auser  staff     0 May 21 22:00 gvproxy.sock
+srwxr-xr-x@ 1 auser  staff     0 May 21 22:00 gvproxy.sock-krun.sock
+srwxr-xr-x@ 1 auser  staff     0 May 21 22:00 vsock-21471.sock
+```
+
+**Tool Call: gh pr view 423 --json title,body,files,commits | head -100**
+Status: Completed
+
+Terminal:
+
+```
+{"body":"## Summary\n\n`mkGuest` unconditionally bakes `mvm-addon-dns` into every rootfs, per the \"always-install + no-op when zone empty\" contract in `specs/contracts/local-addon-dns.md`. Correct for *workload* microVMs (where mkGuest's initScript runs the addon-dns activation block). **Wrong** for the *builder VM*: its PID 1 is `mvm-builder-init`, not mkGuest's initScript, so the activation block never runs and the binary sits unused at `/usr/local/bin/mvm-addon-dns`.\n\nThe cost of carrying that unused binary is real: a full rustc compile of `mvm-addon-dns` runs in parallel with the kernel compile, `mvm-builder-init`, and `mvm-egress-proxy` during Stage 0. On Stage 0's tmpfs budget (14 GiB `/nix` cap + 16 GiB total VM RAM, from PR #418 and PR #421), the four-way parallel build blew past the cap and the OOM killer took rustc → `stage0-init: nix build exited 137` with no useful stderr.\n\n## Fix\n\nTwo lines:\n\n- `nix/lib/mk-guest.nix` — `bakeAddonDns ? true` parameter; gates the `cp ${mvmAddonDnsBinary}` line at the rootfs-tree builder. Default preserves the workload contract.\n- `nix/images/builder-vm/flake.nix` — passes `bakeAddonDns = false`.\n\n## Validation\n\n- `cargo build --workspace` — clean\n- `cargo clippy --workspace -- -D warnings` — clean\n- `nix flake check --no-build ./nix/images/builder-vm` — passes\n- **`mvmctl dev up` walks the full pipeline:** Stage 0 completes in 7m 9s (no OOM), promotion passes, persistent builder VM kernel boots, ext4 geometry recovery fires (PR #420), `/dev/vdb` mounts cleanly, nix DB loads from `/nix-path-registration` (PR #420), inner nix build runs for 115s. **Fails at the next layer's blocker** — `mvm-guest-agent-0.14.0.drv` build inside the persistent builder VM exits 1; that's separate scope (per-derivation log lives inside the VM's `/nix/store`, can't be read from the host without mounting `nix-store-aarch64.img`).\n\n## Scope\n\nStrictly the builder VM. Workload microVM rootfs assembly is unchanged — `bakeAddonDns` defaults to `true`.\n\n🤖 Generated with [Claude Code](https://claude.com/claude-code)","commits":[{"authoredDate":"2026-05-22T05:10:00Z","authors":[{"email":"me@ari.io","id":"MDQ6VXNlcjUyOQ==","login":"auser","name":"Ari"},{"email":"noreply@anthropic.com","id":"MDQ6VXNlcjgxODQ3","login":"claude","name":"Claude Opus 4.7 (1M context)"}],"committedDate":"2026-05-22T05:10:00Z","messageBody":"mkGuest unconditionally baked `mvm-addon-dns` into every rootfs as\nthe \"always-install + no-op when zone empty\" pattern from\n`specs/contracts/local-addon-dns.md`. That made sense for *workload*\nmicroVMs (where /init runs mkGuest's addon-dns activation block and\nspawns the binary on a zone file presence check). It does NOT make\nsense for the *builder VM*: its PID 1 is `mvm-builder-init` (set via\n`extraFiles` at `/sbin/mvm-builder-init` + the `init=/sbin/mvm-builder-init`\nkernel cmdline), so mkGuest's initScript-side activation never runs\nand the binary just sat unused at `/usr/local/bin/mvm-addon-dns`.\n\nStage 0 cost of carrying the unused binary: a full rustc compile of\n`mvm-addon-dns` runs in parallel with the kernel compile and the\n`mvm-builder-init` + `mvm-egress-proxy` compiles. On Stage 0's tmpfs\nbudget (14 GiB /nix cap from PR #418, 16 GiB total VM RAM from\nPR #421), the four-way parallel build pushes intermediate objects\npast the cap and the OOM killer takes a rustc — observed as\n`stage0-init: nix build exited 137` with no useful stderr.\n\nFix is two lines:\n\n- `nix/lib/mk-guest.nix` gains a `bakeAddonDns ? true` parameter\n  that gates the `cp ${mvmAddonDnsBinary}` line at the rootfs-tree\n  builder. Default `true` preserves the existing contract for\n  every workload-microVM caller.\n\n- `nix/images/builder-vm/flake.nix` passes `bakeAddonDns = false`\n  on its mkGuest call.\n\n`mvmAddonDnsBinary` stays in mkGuest's passthru for callers that\nexplicitly want the path (none today, but it's a small surface that\ncosts nothing to keep).\n\n## Validation\n\n- `cargo build --workspace` — clean\n- `cargo clippy --workspace -- -D warnings` — clean\n- `cargo fmt -- --check` — clean\n- `nix flake check --no-build ./nix/images/builder-vm` — passes\n  (Linux systems omitted on darwin)\n- `mvmctl dev up` on aarch64-darwin walks the full pipeline:\n  - Stage 0 completes in 7m 9s (no OOM)\n  - Promotion + persistent builder VM kernel boot\n  - PR #420's geometry recovery: `formatting /dev/vdb (ext4 records\n    68719476736 bytes but device exposes 68719411200 bytes)` →\n    successful r/w mount\n  - PR #420's `nix-store --load-db` at boot: `nix_db_loaded_ms: 185`\n  - Inner nix build dispatched, runs for 115s before the *next*\n    layer's blocker (mvm-guest-agent build failure inside the\n    persistent builder VM — separate scope; mvmctl can't read the\n    per-derivation log from outside the VM)\n\nCo-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>","messageHeadline":"fix(mkGuest): skip addon-dns bake for builder VM (Stage 0 OOM)","oid":"41c60e1a6cca7360532b2705ca28a06af0c7d46f"}],"files":[{"path":"nix/images/builder-vm/flake.nix","additions":10,"deletions":0,"changeType":"MODIFIED"},{"path":"nix/lib/mk-guest.nix","additions":24,"deletions":5,"changeType":"MODIFIED"}],"title":"fix(mkGuest): skip addon-dns bake for builder VM (Stage 0 OOM unblocker)"}
+```
+
+**Tool Call: gh pr view 422 --json title,body,files,commits | head -100**
+Status: Completed
+
+Terminal:
+
+```
+{"body":"## Summary\n\n`builder_vm_source_fingerprint` gates the\n`~/.cache/mvm/builder-vm/<arch>/rootfs.ext4` cache: cache reused when the fingerprint matches, rebuilt (Stage 0) when it doesn't. Pre-this-change it only hashed `nix/images/builder-vm/{flake.nix,flake.lock}`, so any contributor edit to the Rust sources baked into the rootfs went unnoticed and the cache was silently reused with a stale binary.\n\nThis burned the PR #420 dev-loop multiple times. Every iteration of `crates/mvm-builder-init/src/main.rs` required a manual `rm -rf ~/.cache/mvm/builder-vm/aarch64/` to force Stage 0 to rebuild. Stage 0 is ~8 minutes per cycle, so each missed invalidation was an 8-min regression.\n\n## Fix\n\n`nix/images/builder-vm/flake.nix` bakes two Rust binaries into the rootfs via `rustPlatform.buildRustPackage`:\n- `mvmBuilderInitFor system` — consumes `crates/mvm-builder-init/`\n- `mvmEgressProxyFor system` — consumes `crates/mvm-egress-proxy/`\n\nBoth also depend on the workspace `Cargo.lock` for their dep closures. Adding all three to the fingerprint closes the gap.\n\n## Implementation\n\nExtracted three pure helpers from the single-function body so the hashing is testable in isolation:\n\n- `workspace_root_for_builder_flake(flake_dir)` — walks three parents up to find the workspace root, errors cleanly if the flake isn't at `<workspace>/nix/images/builder-vm`.\n- `hash_named_file(hasher, name, path)` — feeds one file into the SHA-256 stream using the existing `{name}\\0{u64-len}\\0{bytes}\\0` discipline, so the new hashing is identical in shape to the original.\n- `hash_dir_recursive(hasher, prefix, dir)` + `walk_source_dir_sorted` — recursive walk that skips `target/` and hidden entries, returns paths in lexicographic order so the hash is deterministic across HFS+, APFS, and ext4 read-order differences. Entries are keyed by their workspace-relative path so moving a file changes the fingerprint.\n\nThe `[crate_name; 2]` list at the call site is the place to update when a future flake change bakes a third Rust binary into the rootfs.\n\n## Tests\n\n10 tests in `mod builder_vm_bootstrap_tests`, all run against a synthetic workspace layout written into a `tempfile::tempdir()`:\n\n| Test | What it asserts |\n|---|---|\n| `..._changes_with_flake_inputs` | flake.nix mutation bumps fingerprint (existing) |\n| `..._changes_with_cargo_lock` | `cargo update`-style change bumps fingerprint |\n| `..._changes_with_mvm_builder_init_source` | **the bug this PR fixes** — editing PID-1 binary's main.rs |\n| `..._changes_with_mvm_egress_proxy_source` | same for egress-proxy binary |\n| `..._changes_when_new_file_added_to_crate` | `git add`-ing a new module bumps the fingerprint |\n| `..._is_deterministic_for_identical_workspace` | same inputs under two tempdirs → same hash (relative-path keying) |\n| `..._ignores_target_dir` | multi-MB cargo build artifacts don't affect the hash |\n| `..._ignores_hidden_files` | `.DS_Store`, `.swp`, etc. don't count |\n| `..._errors_when_cargo_lock_missing` | error names the missing path |\n| `..._errors_when_in_vm_crate_missing` | error names the missing crate |\n\nAll pass; `cargo clippy -p mvm-cli --tests -- -D warnings` clean; `cargo fmt --check` clean.\n\n## Relationship to PR #420\n\n#420 ships fixes in `crates/mvm-builder-init/` — exactly the kind of edit that this fingerprint expansion guards against silent staleness for. Each iteration of #420 surfaced this caching bug. Even if #420 lands without this expansion, the bug remains for the next contributor; this PR is the durable fix.\n\n🤖 Generated with [Claude Code](https://claude.com/claude-code)","commits":[{"authoredDate":"2026-05-22T04:28:47Z","authors":[{"email":"me@ari.io","id":"MDQ6VXNlcjUyOQ==","login":"auser","name":"Ari"},{"email":"noreply@anthropic.com","id":"MDQ6VXNlcjgxODQ3","login":"claude","name":"Claude Opus 4.7 (1M context)"}],"committedDate":"2026-05-22T04:28:47Z","messageBody":"…rgo.lock too\n\n`builder_vm_source_fingerprint` is what gates the\n`~/.cache/mvm/builder-vm/<arch>/rootfs.ext4` cache invalidation:\nthe cache is reused when the fingerprint matches and rebuilt when\nit doesn't. Pre-this-change the fingerprint only covered\n`nix/images/builder-vm/{flake.nix,flake.lock}` — so any contributor\nedit to the *Rust sources* baked into the rootfs went unnoticed.\n\nThe bug burned the PR #420 dev-loop multiple times. Every\niteration of `mvm-builder-init/src/main.rs` (the PID-1 binary the\nbuilder VM boots) required a manual\n`rm -rf ~/.cache/mvm/builder-vm/aarch64/` before the next\n`mvmctl dev up` would pick up the change. Stage 0 is ~8 minutes,\nso each missed cache invalidation was an 8-minute regression.\n\nThe flake builds two Rust binaries into the rootfs via\n`rustPlatform.buildRustPackage` calls:\n  - `mvmBuilderInitFor system` consumes `crates/mvm-builder-init/`\n  - `mvmEgressProxyFor system` consumes `crates/mvm-egress-proxy/`\nBoth also depend on `workspace/Cargo.lock` for their dep closures.\nAdding all three to the fingerprint closes the gap.\n\n## Implementation\n\nExtracted three pure helpers from the existing single-function\nbody so the hashing is testable in isolation:\n  - `workspace_root_for_builder_flake(flake_dir)` — walks three\n    parents up to find the workspace root, errors cleanly if the\n    flake isn't at `<workspace>/nix/images/builder-vm`.\n  - `hash_named_file(hasher, name, path)` — feeds one file into\n    the SHA-256 stream using the existing `{name}\\0{u64-len}\\0\n    {bytes}\\0` discipline, so the new hashing is identical in shape\n    to the original flake-only hashing.\n  - `hash_dir_recursive(hasher, prefix, dir)` + `walk_source_dir_sorted`\n    — recursive walk that skips `target/` (cargo build output) and\n    hidden entries (`.git/`, `.DS_Store`, editor swap files), and\n    returns paths in lexicographic order so the hash is\n    deterministic across HFS+, APFS, and ext4 read-order\n    differences. Entries are keyed by their workspace-relative\n    path so renaming or moving a file changes the fingerprint.\n\nThe `[crate_name; 2]` list at the call site (lines 3590-3601 of\n`apple_container.rs`) is the new place to update when a future\nflake change bakes a third Rust binary into the rootfs.\n\n## Tests\n\n9 new test cases in `mod builder_vm_bootstrap_tests` (one per\ninput source, plus determinism + exclusion + error-path tests).\nAll run against a synthetic workspace layout written into a\n`tempfile::tempdir()`. The existing\n`builder_vm_source_fingerprint_changes_with_flake_inputs` was\nupdated to use the same `write_builder_vm_workspace` helper so\nall tests share one fixture.\n\n- `..._changes_with_flake_inputs` — flake.nix mutation (existing)\n- `..._changes_with_cargo_lock` — simulates `cargo update`\n- `..._changes_with_mvm_builder_init_source` — the bug this PR\n  exists to fix; editing the PID-1 binary's main.rs invalidates\n  the cache.\n- `..._changes_with_mvm_egress_proxy_source` — same for the\n  egress-proxy binary.\n- `..._changes_when_new_file_added_to_crate` — `git add`-ing a\n  new module file under the crate also bumps the fingerprint.\n- `..._is_deterministic_for_identical_workspace` — same inputs\n  laid out under two different `tempdir` roots must produce the\n  same hash; relative-path keying guarantees this.\n- `..._ignores_target_dir` — multi-MB cargo build artifacts\n  under `crates/<x>/target/debug/` must not affect the hash\n  (otherwise every `cargo build` would invalidate the rootfs cache).\n- `..._ignores_hidden_files` — `.DS_Store`, `.swp`, etc. don't\n  count as flake inputs.\n- `..._errors_when_cargo_lock_missing` — hard error names the\n  missing path so a misconfigured workspace doesn't silently\n  fall back to a weaker fingerprint.\n- `..._errors_when_in_vm_crate_missing` — same for missing\n  `crates/mvm-builder-init/`.\n\n10 tests total, all pass; `cargo clippy -p mvm-cli --tests --\n-D warnings` clean; `cargo fmt --check` clean.\n\n## What this means for #420\n\nThe geometry-recovery fix in #420 reformats the persistent\n`/nix-store-aarch64.img` when its ext4 superblock disagrees with\nthe device size — but the *rootfs.ext4* cache is a separate\nartifact. Without this fingerprint expansion, contributor changes\nto #420's `mvm-builder-init` code (the seed-DB loader, the\nnix_store_needs_seed helper, etc.) silently reuse a stale rootfs\nthat doesn't have those changes. This is why the PR #420 dev-loop\nneeded manual `rm -rf ~/.cache/mvm/builder-vm/aarch64/` between\nevery iteration.\n\nThis PR is the durable fix for that dev-loop pain. Independent\nof #420 conceptually but called out in #420's PR description as\nan out-of-scope follow-up.\n\nCo-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>","messageHeadline":"fix(builder-vm): fingerprint mvm-builder-init / mvm-egress-proxy / Ca…","oid":"155b561f7b5c3ac38d46cca4bbda18dabd61ade4"}],"files":[{"path":"crates/mvm-cli/src/commands/env/apple_container.rs","additions":374,"deletions":10,"changeType":"MODIFIED"}],"title":"fix(builder-vm): fingerprint mvm-builder-init / mvm-egress-proxy / Cargo.lock too"}
+```
+
+## Assistant
+
+<thinking>
+
+</thinking>
+
+PR #423 is open and confirms the same mvm-guest-agent build failure. Let me read the console + investigate the inner build invocation path.
+
+**Tool Call: cat ~/.cache/mvm/builder-vm/vms/mvm-builder-vm-1779426018614-7835/console.log**
+Status: Completed
+
+Terminal:
+
+```
+[    0.633839] loop: module loaded
+[    0.636277] virtio_blk virtio6: 1/0/0 default/read/poll queues
+[    0.636469] virtio_blk virtio6: [vda] 2229312 512-byte logical blocks (1.14 GB/1.06 GiB)
+[    0.636822] virtio_blk virtio7: 1/0/0 default/read/poll queues
+[    0.636987] virtio_blk virtio7: [vdb] 134217600 512-byte logical blocks (68.7 GB/64.0 GiB)
+[    0.637708] tun: Universal TUN/TAP device driver, 1.6
+[    0.638160] CAN device driver interface
+[    0.638356] thunder_xcv, ver 1.0
+[    0.638421] thunder_bgx, ver 1.0
+[    0.638487] nicpf, ver 1.0
+[    0.638523] hns3: Hisilicon Ethernet Network Driver for Hip08 Family - version
+[    0.638635] hns3: Copyright (c) 2017 Huawei Corporation.
+[    0.638726] hclge is initializing
+[    0.638765] e1000: Intel(R) PRO/1000 Network Driver
+[    0.638811] e1000: Copyright (c) 1999-2006 Intel Corporation.
+[    0.638873] e1000e: Intel(R) PRO/1000 Network Driver
+[    0.638917] e1000e: Copyright(c) 1999 - 2015 Intel Corporation.
+[    0.638975] igb: Intel(R) Gigabit Ethernet Network Driver
+[    0.639017] igb: Copyright (c) 2007-2014 Intel Corporation.
+[    0.639066] igbvf: Intel(R) Gigabit Virtual Function Network Driver
+[    0.639166] igbvf: Copyright (c) 2009 - 2012 Intel Corporation.
+[    0.639255] sky2: driver version 1.30
+[    0.639388] Intel(R) Wireless WiFi driver for Linux
+[    0.639535] VFIO - User Level meta-driver version: 0.3
+[    0.639642] UDC core: g_mass_storage: couldn't find an available UDC
+[    0.639876] rtc-pl031 a001000.rtc: registered as rtc0
+[    0.639924] rtc-pl031 a001000.rtc: setting system clock to 2026-05-22T05:00:19 UTC (1779426019)
+[    0.640083] i2c_dev: i2c /dev entries driver
+[    0.640253] device-mapper: ioctl: 4.48.0-ioctl (2023-03-01) initialised: dm-devel@lists.linux.dev
+[    0.640399] sdhci: Secure Digital Host Controller Interface driver
+[    0.640454] sdhci: Copyright(c) Pierre Ossman
+[    0.640504] Synopsys Designware Multimedia Card Interface Driver
+[    0.640566] sdhci-pltfm: SDHCI platform and OF driver helper
+[    0.640783] SPI driver st-magn-spi has no spi_device_id for st,lis3mdl-magn
+[    0.640887] SPI driver st-magn-spi has no spi_device_id for st,lsm303agr-magn
+[    0.641012] SPI driver st-magn-spi has no spi_device_id for st,lsm9ds1-magn
+[    0.641120] SPI driver st-magn-spi has no spi_device_id for st,lsm303c-magn
+[    0.641266]  cs_system_cfg: CoreSight Configuration manager initialised
+[    0.641399] gnss: GNSS driver registered with major 508
+[    0.641484] GACT probability NOT on
+[    0.641534] Mirror/redirect action on
+[    0.642026] IPVS: Registered protocols ()
+[    0.642077] IPVS: Connection hash table configured (size=4096, memory=32Kbytes)
+[    0.642218] IPVS: ipvs loaded.
+[    0.642308] NET: Registered PF_PACKET protocol family
+[    0.642385] Bridge firewalling registered
+[    0.642489] can: controller area network core
+[    0.642580] NET: Registered PF_CAN protocol family
+[    0.642664] can: raw protocol
+[    0.642724] can: broadcast manager protocol
+[    0.642778] can: netlink gateway - max_hops=1
+[    0.642872] 8021q: 802.1Q VLAN Support v1.8
+[    0.642945] 9pnet: Installing 9P2000 support
+[    0.643025] Key type dns_resolver registered
+[    0.643159] NET: Registered PF_VSOCK protocol family
+[    0.644283] registered taskstats version 1
+[    0.644409] Loading compiled-in X.509 certificates
+[    0.644938] Demotion targets for Node 0: null
+[    0.645207] Btrfs loaded, zoned=no, fsverity=no
+[    0.645414] input: gpio-keys as /devices/platform/gpio-keys/input/input0
+[    0.645618] cfg80211: Loading compiled-in X.509 certificates for regulatory database
+[    0.645874] Loaded X.509 cert 'sforshee: 00b28ddf47aef9cea7'
+[    0.646025] Loaded X.509 cert 'wens: 61c038651aabdcf94bd0ac7ff06c7248db18c600'
+[    0.646157] platform regulatory.0: Direct firmware load for regulatory.db failed with error -2
+[    0.646269] cfg80211: failed to load regulatory.db
+[    0.646348] clk: Disabling unused clocks
+[    0.646396] PM: genpd: Disabling unused power domains
+[    0.646521] md: Waiting for all devices to be available before autodetect
+[    0.646618] md: If you don't use raid, use raid=noautodetect
+[    0.646718] md: Autodetecting RAID arrays.
+[    0.646775] md: autorun ...
+[    0.646824] md: ... autorun DONE.
+[    0.649335] EXT4-fs (vda): orphan cleanup on readonly fs
+[    0.649449] EXT4-fs (vda): mounted filesystem 44444444-4444-4444-8888-888888888888 ro with ordered data mode. Quota mode: none.
+[    0.649626] VFS: Mounted root (ext4 filesystem) readonly on device 253:0.
+[    0.649774] devtmpfs: mounted
+[    0.649915] Freeing unused kernel memory: 1856K
+[    0.650034] Run /sbin/mvm-builder-init as init process
+mvm-builder-init: pid 1 starting
+mvm-builder-init: /dev (devtmpfs) already mounted (EBUSY) — continuing
+mvm-builder-init: formatting /dev/vdb (ext4 records 68719476736 bytes but device exposes 68719411200 bytes)
+modprobe: can't change directory to '/lib/modules': No such file or directory
+modprobe: can't change directory to '/lib/modules': No such file or directory
+udhcpc: started, v1.36.1
+mvm-builder-init: modprobe fuse exited 1 (continuing)
+mvm-builder-init: modprobe virtiofs exited 1 (continuing)
+/dev/vdb contains a ext4 file system
+	last mounted on / on Fri May 22 02:54:04 2026
+udhcpc: broadcasting discover
+udhcpc: broadcasting select for 192.168.127.3, server 192.168.127.1
+[    0.790246] EXT4-fs (vdb): mounted filesystem 9d6bf2cb-2c19-4d49-be6d-fd0111b4dba4 r/w with ordered data mode. Quota mode: none.
+mvm-builder-init: loading seeded paths into nix DB from /nix-path-registration
+udhcpc: lease of 192.168.127.3 obtained from 192.168.127.1, lease time 3600
+/nix/store/d6qdvwi82xli2wxbfkzadzcaigm2krw8-busybox-static-aarch64-unknown-linux-musl-1.36.1/default.script: line 52: can't create /etc/resolv.conf: Read-only file system
+warning: the group 'nixbld' specified in 'build-users-group' does not exist
+mvm-builder-init: egress lockdown SKIPPED (kernel lacks netfilter — Stage 0 / libkrunfw-bundled-kernel context): iptables ["-A", "OUTPUT", "-o", "lo", "-j", "ACCEPT"] exited exit status: 1 (stderr: iptables: Failed to initialize nft: Protocol not supported)
+mvm-builder-init: vsock send: no host connection within 10s (single-shot path; W2 part 4 wired the host receiver)
+mvm-builder-init: boot-timings={"init_start_ms":0,"pseudofs_ready_ms":0,"nix_device_ready_ms":138,"nix_seeded_ms":null,"nix_mounted_ms":138,"nix_db_loaded_ms":185,"modules_ready_ms":1,"virtiofs_ready_ms":1,"network_ready_ms":163,"job_start_ms":187,"job_end_ms":115273,"poweroff_start_ms":125526}
+[  126.202059] reboot: Power down
+```
+
+**Tool Call: ScheduleWakeup**
+Status: Completed
+
+Next wakeup scheduled for 22:57:00 (in 1848s). Nothing more to do this turn — the harness re-invokes you when the wakeup fires or a task-notification arrives.
+
+## Assistant
+
+<thinking>
+
+</thinking>
+
+I now have strong evidence:
+
+- Boot succeeds (network up at 163ms, nix DB loaded at 185ms)
+- Inner build runs 115s then exits non-zero
+- `warning: the group 'nixbld' specified in 'build-users-group' does not exist` — confirms NIX_CONFIG isn't suppressing this
+- `vsock send: no host connection within 10s` — host receiver is not connecting in time
+- No actual build stderr makes it to console.log
+
+Now dispatching three Explore agents in parallel to investigate the suspects + the vsock log-capture path.
+
+**Tool Call: Investigate inner nix build dispatch**
+Status: Completed
+
+Now let me verify the exact location where NIX_CONFIG is being set in the cmd.sh and look for any override or propagation issues:
+
+Based on my comprehensive investigation, here's the punched-list report on the mvm-builder-init dispatch, nix sandbox setup, and guest-agent build failure:
+
+---
+
+## **FINDINGS: mvm-builder-init nix-build dispatch & sandbox wiring**
+
+### **1. The nix-build invocation site & NIX_CONFIG — THE SMOKING GUN**
+
+**File:** `/Users/auser/work/tinylabs/mvmco/mvm/crates/mvm-build/src/libkrun_builder.rs` **Lines 1103–1117**
+
+The cmd.sh template hardcodes this NIX_CONFIG:
+
+```bash
+export NIX_CONFIG="experimental-features = nix-command flakes
+sandbox = false
+build-users-group =
+max-jobs = auto
+cores = 0
+auto-optimise-store = true
+substituters = https://cache.nixos.org/
+trusted-public-keys = cache.nixos.org-1:6NCHdD59X431o0gWypbMrAURkbJ16ZPMQFGspcDShjY="
+```
+
+**CRITICAL:** Line 1112 explicitly sets `build-users-group =` (empty string) to disable sandbox. **Yet the console warning says:** `warning: the group 'nixbld' specified in 'build-users-group' does not exist`. This is a contradiction—an empty `build-users-group` should NOT cause that warning.
+
+**Hypothesis:** The host-side NIX_CONFIG (inherited from the builder machine's `~/.config/nix/nix.conf` or global `/etc/nix/nix.conf`) is NOT being overridden by the guest's `export NIX_CONFIG=…`. Nix daemon may be reading root's config at boot before the guest process env is set, or the guest's nix-daemon was started with a stale config.
+
+---
+
+### **2. Rootfs passwd/group — nixbld group is NOT created (correct)**
+
+**File:** `/Users/auser/work/tinylabs/mvmco/mvm/nix/lib/mk-guest.nix` **Lines 600–632**
+
+The builder VM's rootfs explicitly creates only:
+
+- `root:x:0:0`
+- `mvm-agent:x:…` (if agentUid != 0)
+- `mvm-worker:x:…` (if entrypointUid != 0 and != agentUid)
+
+**No `nixbld` group is created.** This is correct per the plan (builder VM IS the isolation boundary).
+
+**But the builder-vm flake's rootfs (via mkGuest → nix/lib/mk-guest.nix) doesn't explicitly install nix with any config override either.** The `/etc/nix/nix.conf` file is NOT baked into the rootfs, so the nix package lands with its defaults. If nixpkgs 25.11's nix package ships a default `build-users-group = "nixbld"` in the closure, that will be the effective value unless explicitly overridden at runtime.
+
+---
+
+### **3. mvm-guest-agent build definition (NOT the problem)**
+
+**File:** `/Users/auser/work/tinylabs/mvmco/mvm/nix/packages/mvm-guest-agent.nix` **Lines 47–93**
+
+- pname: `mvm-guest-agent` ✓
+- version: `0.14.0` ✓
+- Source: `mvmSrc` (workspace root) ✓
+- Features: `dev-shell` is **opt-in** (default `withDevShell = false` on line 43); passes `--features mvm-guest/dev-shell` only if `withDevShell = true` (line 69–70) ✓
+- **No build.rs** — the crate has no custom build script; it's pure Rust + dependencies ✓
+- **Cargo.toml** lists `dev-shell` as an empty feature gate (line 68) ✓
+
+The derivation is correctly configured. The failure is NOT in mvm-guest-agent itself; it's in the builder VM's nix environment.
+
+---
+
+### **4. vsock log-receiver wiring — 10-second race condition (confirmed)**
+
+**File:** `/Users/auser/work/tinylabs/mvmco/mvm/crates/mvm-builder-init/src/main.rs` **Lines 803–807**
+
+```rust
+eprintln!(
+    "mvm-builder-init: vsock send: no host connection within {ACCEPT_TIMEOUT_SECS}s \
+     (single-shot path; W2 part 4 wired the host receiver)"
+);
+```
+
+The builder-init tries to open a vsock listener for 10 seconds (line 797: `const ACCEPT_TIMEOUT_SECS: i64 = 10;`). **The error you saw means the host-side receiver on port 21471 (line 646) never connected in time.**
+
+**The real stderr was lost because the receiver wasn't bound when the build started.** The per-derivation logs are in `/job/nix-stderr.log` on the VM's tmpfs, but libkrun can't extract them after power-off if no live connection relayed them.
+
+---
+
+### **5. The real root cause: nix.conf bootstrap**
+
+**File:** `/Users/auser/work/tinylabs/mvmco/mvm/nix/images/builder-vm/flake.nix` — **Line 157** onward
+
+The flake builds the rootfs via `mkBuilderVmRootfs` (line 282) using `libFor { inherit system; }.mkGuest { … }`. The nix package is installed (line 172: `nix`), but **NO `/etc/nix/nix.conf` is baked into extraFiles.**
+
+When nix daemon starts inside the builder VM, it loads config in this order:
+
+1. `/etc/nix/nix.conf` (doesn't exist in our rootfs)
+2. `$NIX_CONF_DIR/nix.conf` (unset in the VM, defaults to `/etc/nix`)
+3. User's `~/.config/nix/nix.conf` (PID 1 is root, no home)
+4. Hardcoded package defaults (whatever nixpkgs 25.11's nix package built with)
+
+**The shell's `export NIX_CONFIG=…` only affects child processes spawned AFTER the export line in the script.** If nix-daemon is already running from boot or if the build invokes `nix` as a subprocess that forks its own daemon, the host machine's config file may be consulted, OR the package defaults (which likely include `build-users-group = "nixbld"` from nixpkgs).
+
+---
+
+## **PUNCH-LIST: Suspicious lines**
+
+| File                                      | Line(s)   | Issue                                                                                                                                                                           |
+| ----------------------------------------- | --------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `crates/mvm-build/src/libkrun_builder.rs` | 1103–1117 | `export NIX_CONFIG` sets `build-users-group =` (correct), but this is SHELL script-level only; doesn't guarantee nix daemon respects it. Check if nix is auto-starting at boot. |
+| `nix/images/builder-vm/flake.nix`         | 157–200   | Builder packages include `nix`, but no `/etc/nix/nix.conf` is created to override defaults. The nixpkgs nix package likely defaults `build-users-group = "nixbld"`.             |
+| `crates/mvm-builder-init/src/main.rs`     | 803–807   | Confirms vsock log receiver timeout; real stderr lost. Host must bind the listener BEFORE VM boot, or use persistent dispatch (W3 part 4).                                      |
+| `nix/lib/mk-guest.nix`                    | 600–632   | Correct: no nixbld group created. But rootfs `/etc/nix/nix.conf` is missing to lock down nix behavior.                                                                          |
+
+---
+
+## **Recommended fix (sketch)**
+
+1. **Bake `/etc/nix/nix.conf` into builder-vm rootfs** with the exact same `build-users-group =` (empty) so nix daemon uses it on startup, not the package default.
+2. **Or:** Ensure nix-daemon is NOT auto-started; force the first `nix build` invocation to read the script's `export NIX_CONFIG` before any daemon fork.
+3. **Verify host vsock receiver is bound BEFORE Stage 0 boots**, so `/job/nix-stderr.log` is streamed to the host in real time (not lost on power-off).
+
+**Tool Call: Investigate guest-agent build requirements**
+Status: Completed
+
+Perfect. I now have all the evidence. Let me write up my findings:
+
+## Summary
+
+I've identified the **root cause** of the 115-second build failure for `nix build .#mvm-guest-agent-0.14.0` in the libkrun builder VM.
+
+### Key Finding
+
+**The `mvm-guest` crate has a transitive dependency on `mvm-libkrun`, which includes a `build.rs` script that requires `libkrun.h` (the C header file for the libkrun library). Inside the builder VM sandbox, this header is unavailable, causing the bindgen invocation to fail after ~115 seconds of Cargo dependency resolution.**
+
+### Evidence
+
+1. **mvm-guest dependency chain:**
+   - `crates/mvm-guest/Cargo.toml` depends on `mvm-core` (workspace)
+   - `mvm-core` depends on `mvm-libkrun` (workspace) at line 16
+   - `mvm-libkrun` has `build-dependencies` that includes `bindgen = "0.72"` (line 71)
+
+2. **mvm-libkrun build.rs behavior:**
+   - `crates/mvm-libkrun/build.rs` (lines 37-74):
+     - When `CARGO_FEATURE_LIBKRUN_SYS` env var is NOT set, the script returns early (line 25)
+     - When the feature IS set, it calls `locate_header()` to find `libkrun.h` at one of three paths: `/opt/homebrew/include/libkrun.h`, `/usr/local/include/libkrun.h`, or `/usr/include/libkrun.h`
+     - If not found, it panics (line 39-45): `"libkrun-sys feature is enabled but libkrun.h was not found"`
+
+3. **Default features:**
+   - `mvm-libkrun` has `default = []` (line 74 in Cargo.toml) — the feature is OFF by default
+   - But when the workspace builds, transitive deps with their defaults enabled can trigger feature unification issues
+
+4. **Successful vs. failing builds:**
+   - `mvm-builder-init` and `mvm-egress-proxy` (which **do** successfully build in the rootfs) use `buildAndTestSubdir = "crates/..."`, which restricts the build to a single crate
+   - `mvm-guest-agent` uses `src = mvmSrc` (the whole workspace) with `cargoLock.lockFile` (line 55), which resolves the full workspace graph but only builds selected binaries
+
+5. **The 115-second delay** = Cargo resolving all 20+ workspace members' dependencies before attempting to build `mvm-guest`. When it reaches `mvm-libkrun`'s build.rs, bindgen tries to invoke `clang` to parse `libkrun.h`, which doesn't exist in the builder VM → build exits with non-zero status.
+
+### Hypothesis
+
+**The build fails because `mvm-libkrun`'s build.rs panics with "libkrun.h was not found" after Cargo spends 115 seconds resolving the full workspace Cargo.lock.** The builder VM's rootfs is intentionally minimal (per `/nix/images/builder-vm/flake.nix` comments) and excludes libkrun development files. Since `libkrun-sys` is not the default feature, it should not activate—but if there's a transitive feature activation or the builder is running without `default-features = false`, the bindgen step will fail.
+
+### Path Forward
+
+To confirm, check:
+
+1. Whether the guest-agent derivation explicitly sets `default-features = false` when calling `rustPlatform.buildRustPackage`
+2. Whether `--offline` mode is enabled in the builder VM (if so, Cargo won't re-resolve features)
+3. The actual build log (if available) for the string "libkrun.h was not found"
+
+**Tool Call: find . -name "_.rs" -path "_/crates/mvm-builder-init/_" -o -name "_.rs" -path "_/crates/mvm-libkrun/_" | head -20**
+Status: Failed
+
+```
+Tool permission request failed: Error: Internal error
+```
+
+**Tool Call: Find `crates/mvm-builder-init/src/**/\*.rs`\*\*
+Status: Completed
+
+crates/mvm-builder-init/src/install.rs
+crates/mvm-builder-init/src/install_spec.rs
+crates/mvm-builder-init/src/proxy.rs
+crates/mvm-builder-init/src/builder_request.rs
+crates/mvm-builder-init/src/dispatch_response.rs
+crates/mvm-builder-init/src/network.rs
+crates/mvm-builder-init/src/boot_timings.rs
+crates/mvm-builder-init/src/main.rs
+
+**Tool Call: Find `crates/mvm-libkrun/src/**/\*.rs`\*\*
+Status: Completed
+
+crates/mvm-libkrun/src/passt.rs
+crates/mvm-libkrun/src/bin/mvm-libkrun-supervisor.rs
+crates/mvm-libkrun/src/gvproxy.rs
+crates/mvm-libkrun/src/sys.rs
+crates/mvm-libkrun/src/lib.rs
+
+**Tool Call: Find `crates/mvm-cli/src/commands/env/*.rs`**
+Status: Completed
+
+crates/mvm-cli/src/commands/env/setup.rs
+crates/mvm-cli/src/commands/env/shell_init.rs
+crates/mvm-cli/src/commands/env/uninstall.rs
+crates/mvm-cli/src/commands/env/init.rs
+crates/mvm-cli/src/commands/env/update.rs
+crates/mvm-cli/src/commands/env/bootstrap.rs
+crates/mvm-cli/src/commands/env/linux_native.rs
+crates/mvm-cli/src/commands/env/doctor.rs
+crates/mvm-cli/src/commands/env/dev.rs
+crates/mvm-cli/src/commands/env/mod.rs
+crates/mvm-cli/src/commands/env/cleanup.rs
+crates/mvm-cli/src/commands/env/apple_container.rs
+
+**Tool Call: Find `nix/images/builder-vm/flake.nix`**
+Status: Completed
+
+nix/images/builder-vm/flake.nix
+
+**Tool Call: Find vsock log-capture path**
+Status: Completed
+
+Perfect! Now I have all the information I need. Let me compile the report:
+
+## Diagnostic Paths Ranked by Feasibility
+
+### Path A: Tap the existing vsock log channel from the host (SLOWEST/BROKEN)
+
+**Feasibility: Very Poor — vsock receiver has 10s timeout and no buffering**
+
+**Vsock Port:** AF_VSOCK port **21471** (`BUILDER_DISPATCH_PORT` in `mvm_guest::builder_agent`)
+
+**Host-side receiver setup** (`crates/mvm-build/src/libkrun_builder.rs:446-452`):
+
+- `spawn_vsock_response_listener()` spawns a background thread BEFORE supervisor startup
+- Thread attempts to connect to `<vm_state_dir>/vsock-21471.sock` (libkrun creates this Unix socket proxy to AF_VSOCK)
+- Connection retry loop: 60-second outer deadline, 100ms poll interval
+- Read timeout: **10 seconds only** (line 1542)
+- Thread receives **one** `BuilderResponseResult` frame (JSON), not streaming
+
+**The log transmission model** (`crates/mvm-builder-init/src/main.rs:796-816`):
+
+- `send_dispatch_response_via_vsock()` is called ONCE after the build completes (W2 part 3)
+- Opens AF_VSOCK listener on port 21471 with **10-second accept timeout** (line 797)
+- **Error message you're seeing comes from here** (line 803-804): `"vsock send: no host connection within 10s (single-shot path; W2 part 4 wired the host receiver)"`
+- Sends a single JSON blob: `{exit_code, stderr_tail, job_timings, boot_timings}`
+- **stderr_tail is bounded to STDERR_TAIL_LINES=20** (captured from the build subprocess stderr, line 1787-1789)
+
+**Per-derivation logs:** The vsock frame does NOT contain per-derivation `.drv.log` files. It only returns the final tail of the build's combined stderr. Nix writes `.drv.log` files into `/nix/store/<hash>.drv.log`, but these are only available on the in-VM ext4 after the VM exits.
+
+**Why it's broken:** The receiver is armed BEFORE the guest even boots. If the guest takes >10s to reach the send point OR if libkrun doesn't proxy the socket in time, the guest times out and logs to stderr instead (the message you're seeing). The data is lost.
+
+---
+
+### Path B: Read `/nix/store/*.drv.log` from the rootfs image after VM exit (FASTEST)
+
+**Feasibility: High — images already exist, ext4 parsing is in-repo**
+
+**Nix store location:**
+
+- Host: `~/.cache/mvm/builder-vm/<arch>/nix-store-<arch>.img` (sparse ext4, 64 GiB cap)
+- Guest: `/nix` (virtio-blk device, mounted by `mvm-builder-init`)
+
+**Example:** `~/.cache/mvm/builder-vm/aarch64-darwin/nix-store-aarch64.img`
+
+**Concrete path:**
+
+- Failed derivation: `/nix/store/<hash>-mvm-guest-agent-0.14.0.drv`
+- Build log file: `/nix/store/<hash>-mvm-guest-agent-0.14.0.drv.log` (lives inside the ext4 image)
+
+**Ext4 parsing infrastructure in-repo** (`crates/mvm-builder-init/src/main.rs`):
+
+- Lines 123-230: `parse_ext4_recorded_size_bytes()` + `read_ext4_superblock()` exist
+- These parse ext4 superblock from the device directly
+- **No existing host-side ext4 extraction utility yet** — `mvm-builder-init` only probes/validates, doesn't read files
+
+**Access method on macOS aarch64-darwin:**
+
+1. **Loopback mount (requires fuse-ext2 or similar)** — not in repo yet
+2. **Raw ext4 fs-level parsing** — would need a Rust ext4 crate or port `parse-ext4.rs` to userspace
+3. **Fallback: Re-run with stdout tee to console** (Path C below)
+
+**Why it's fast:** The image persists after VM exit. Once we have ext4 reading, we can extract the `.drv.log` file with one post-vm-exit read. No dependency on vsock timing.
+
+---
+
+### Path C: Re-run with the inner build's stdout teed to console (PRACTICAL IMMEDIATE FIX)
+
+**Feasibility: Very High — one-line patch, works immediately**
+
+**Current wiring** (`crates/mvm-builder-init/src/main.rs:1790-1832`):
+
+- `run_job_streaming()` spawns nix build via `/bin/sh -eu <cmd_sh>` (line 1805)
+- **Stdout: `Stdio::inherit()`** (line 1806) — goes to PID 1's stdout (libkrun virtio-console)
+- **Stderr: `Stdio::piped()`** (line 1806) — captured for the tail buffer only, not printed
+- Per-line stderr is streamed to vsock via callback `on_line()`
+- **Single-shot `run_job()` passes null callback** (line 1667), so stderr is just buffered, not streamed
+
+**Where nix build runs:**
+
+- Wrapper: `cmd_sh` = `/job/cmd.sh` (staged by host before supervisor spawn)
+- Real nix command inside cmd.sh: probably `nix build --expr '(import /path/to/flake).packages.x86_64-linux.default'`
+
+**One-line diagnostic patch** (apply to `crates/mvm-builder-init/src/main.rs` around line 1654-1667):
+
+```rust
+fn run_job(cmd_sh: &str) -> (i32, String) {
+    // Change this:
+    run_job_streaming(cmd_sh, None, Isolation::Inherit, |_line| {})
+    // To this (tee stderr to virtio-console for one diagnostic run):
+    run_job_streaming(cmd_sh, None, Isolation::Inherit, |line| {
+        eprintln!("[nix-output] {}", line);  // Add this line only
+    })
+}
+```
+
+**Then rebuild and run:**
+
+```bash
+cargo build -p mvm-builder-init --target aarch64-unknown-linux-musl
+# Copy binary to dev-image
+mvmctl dev up
+# Run your build
+```
+
+**Result:** Every stderr line from the nix build will appear in the console.log as `[nix-output] error: Cannot open file…` etc.
+
+---
+
+## Ranking by Speed to Root Cause
+
+1. **Path C (5 minutes)** — Patch, rebuild, re-run. Captures real stderr. Works because stdout already goes to console via `Stdio::inherit()`.
+2. **Path B (requires implementation, then immediate)** — Once ext4 parsing is added to host-side code, can read `.drv.log` files from the image directly without re-running. But needs fs-level ext4 parsing first.
+3. **Path A (broken by design)** — The 10-second vsock timeout and lack of stdout duplication make this a dead-end for the current architecture. The vsock frame is too small and arrives too late.
+
+---
+
+## File Locations (Absolute Paths)
+
+- **Builder init main:** `/Users/auser/work/tinylabs/mvmco/mvm/crates/mvm-builder-init/src/main.rs:1655-1667` (run_job)
+- **Vsock sender:** `/Users/auser/work/tinylabs/mvmco/mvm/crates/mvm-builder-init/src/main.rs:796-816`
+- **Host receiver:** `/Users/auser/work/tinylabs/mvmco/mvm/crates/mvm-build/src/libkrun_builder.rs:1522-1564`
+- **Vsock port definition:** `/Users/auser/work/tinylabs/mvmco/mvm/crates/mvm-builder-init/src/main.rs:646`
+- **Ext4 parsing:** `/Users/auser/work/tinylabs/mvmco/mvm/crates/mvm-builder-init/src/main.rs:146-157`
+- **Nix store image:** `~/.cache/mvm/builder-vm/<arch>/nix-store-<arch>.img`
+- **Console log path:** `<vm_state_dir>/console.log` (set via `KrunContext::with_console_output()`)
+
+**Tool Call: find /Users/auser/work/tinylabs/mvmco/mvm -name "\*.nix" -type f | head -20**
+Status: Failed
+
+```
+Tool permission request failed: Error: Internal error
+```
+
+**Tool Call: Find `/Users/auser/work/tinylabs/mvmco/mvm` `nix/**/\*.nix`\*\*
+Status: Completed
+
+nix/lib/mkFunctionWorkload.nix
+nix/lib/default.nix
+nix/lib/factories/mkFunctionService.nix
+nix/lib/factories/languages/node.nix
+nix/lib/factories/languages/default.nix
+nix/lib/factories/languages/python.nix
+nix/flake.nix
+nix/profiles/minimal.nix
+nix/tests/mk-guest-eval.nix
+nix/packages/mvm-guest-agent.nix
+nix/images/builder/flake.nix
+nix/images/runtime-overlay/flake.nix
+nix/packages/mvm-addon-dns.nix
+nix/lib/mk-guest.nix
+nix/images/builder-vm/kernel/default.nix
+nix/images/builder-vm/flake.nix
+
+**Tool Call: grep "nix\s+build|nix-build|NIX_CONFIG" crates/mvm-builder-init/src**
+Status: Completed
+
+/Users/auser/work/tinylabs/mvmco/mvm/crates/mvm-builder-init/src/main.rs-52-//! Linux-only by design. On macOS / Windows the crate still
+/Users/auser/work/tinylabs/mvmco/mvm/crates/mvm-builder-init/src/main.rs-53-//! compiles (workspace ergonomics) but `main()` prints a hint
+/Users/auser/work/tinylabs/mvmco/mvm/crates/mvm-builder-init/src/main.rs-54-//! and exits 1. mkGuest cross-compiles the real binary against
+crates/mvm-builder-init/src/main.rs:55://! `<arch>-unknown-linux-musl` from a Linux nix-build
+/Users/auser/work/tinylabs/mvmco/mvm/crates/mvm-builder-init/src/main.rs-56-//! environment; that's where the size budget (≤ 1.5 MiB) and
+/Users/auser/work/tinylabs/mvmco/mvm/crates/mvm-builder-init/src/main.rs-57-//! static-link requirement get enforced.
+/Users/auser/work/tinylabs/mvmco/mvm/crates/mvm-builder-init/src/main.rs-58-
+--
+/Users/auser/work/tinylabs/mvmco/mvm/crates/mvm-builder-init/src/main.rs-475- // rule install. The egress lockdown is defense-in-depth
+/Users/auser/work/tinylabs/mvmco/mvm/crates/mvm-builder-init/src/main.rs-476- // for the Plan 73 deps-install pipeline (untrusted code
+/Users/auser/work/tinylabs/mvmco/mvm/crates/mvm-builder-init/src/main.rs-477- // running in the steady-state builder VM). Stage 0 only
+crates/mvm-builder-init/src/main.rs:478: // runs flake builds — `nix build` against a pinned
+crates/mvm-builder-init/src/main.rs-479- / `path:/work#…` reference — where Nix's own fixed-output
+/Users/auser/work/tinylabs/mvmco/mvm/crates/mvm-builder-init/src/main.rs-480- // derivation hashes carry the integrity guarantee. We
+/Users/auser/work/tinylabs/mvmco/mvm/crates/mvm-builder-init/src/main.rs-481- // log + continue rather than fail closed.
+--
+/Users/auser/work/tinylabs/mvmco/mvm/crates/mvm-builder-init/src/main.rs-1430-
+crates/mvm-builder-init/src/main.rs-1431- / PR #420 follow-up: load `/nix-path-registration` (the
+/Users/auser/work/tinylabs/mvmco/mvm/crates/mvm-builder-init/src/main.rs-1432- // standard `make-ext4-fs.nix` manifest) into the persistent
+crates/mvm-builder-init/src/main.rs:1433: // `/nix/var/nix/db` so the in-VM `nix build` knows the
+/Users/auser/work/tinylabs/mvmco/mvm/crates/mvm-builder-init/src/main.rs-1434- // seeded closure is already valid. Without this, nix-daemon
+/Users/auser/work/tinylabs/mvmco/mvm/crates/mvm-builder-init/src/main.rs-1435- // treats every seeded path as missing and re-substitutes
+/Users/auser/work/tinylabs/mvmco/mvm/crates/mvm-builder-init/src/main.rs-1436- // from `cache.nixos.org` — the substituter then overwrites
+--
+crates/mvm-builder-init/src/main.rs-2022- / build: with no entries in the DB, every closure path the
+/Users/auser/work/tinylabs/mvmco/mvm/crates/mvm-builder-init/src/main.rs-2023- /// build references gets re-fetched from `cache.nixos.org`,
+/Users/auser/work/tinylabs/mvmco/mvm/crates/mvm-builder-init/src/main.rs-2024- /// overwriting the seeded path in place — and a concurrent
+crates/mvm-builder-init/src/main.rs:2025: /// nix build-hook worker mid-`dlopen` of the same path's libs
+/Users/auser/work/tinylabs/mvmco/mvm/crates/mvm-builder-init/src/main.rs-2026- /// hits ENOENT during the rename window. Loading the DB makes
+/Users/auser/work/tinylabs/mvmco/mvm/crates/mvm-builder-init/src/main.rs-2027- /// the substituter skip the re-fetch entirely.
+/Users/auser/work/tinylabs/mvmco/mvm/crates/mvm-builder-init/src/main.rs-2028- fn load_seeded_nix_db(
+--
+/Users/auser/work/tinylabs/mvmco/mvm/crates/mvm-builder-init/src/main.rs-2119- /// Detected pre-mount so we can recover with `mkfs.ext4 -F`
+/Users/auser/work/tinylabs/mvmco/mvm/crates/mvm-builder-init/src/main.rs-2120- /// rather than aborting before the build can run. The
+/Users/auser/work/tinylabs/mvmco/mvm/crates/mvm-builder-init/src/main.rs-2121- /// `/nix-store` volume is a cache; reformatting loses nothing
+crates/mvm-builder-init/src/main.rs:2122: /// that can't be rebuilt by the next nix build.
+crates/mvm-builder-init/src/main.rs-2123- fn nix_store_dev_needs_format(dev: &str) -> Result<Option<String>, String> {
+/Users/auser/work/tinylabs/mvmco/mvm/crates/mvm-builder-init/src/main.rs-2124- let sb = read_ext4_superblock(dev)?;
+crates/mvm-builder-init/src/main.rs-2125- let Some(fs_bytes) = crate::parse_ext4_recorded_size_bytes(&sb) else {
+--
+/Users/auser/work/tinylabs/mvmco/mvm/crates/mvm-builder-init/src/dispatch_response.rs-246- #[test]
+/Users/auser/work/tinylabs/mvmco/mvm/crates/mvm-builder-init/src/dispatch_response.rs-247- fn stderr_chunk_json_matches_typed_builder_response() {
+/Users/auser/work/tinylabs/mvmco/mvm/crates/mvm-builder-init/src/dispatch_response.rs-248- let job_id = "01234567-89ab-cdef-0123-456789abcdef";
+crates/mvm-builder-init/src/dispatch_response.rs:249: let line = "[mvm] nix build: 12/47 derivations";
+/Users/auser/work/tinylabs/mvmco/mvm/crates/mvm-builder-init/src/dispatch_response.rs-250- let json = stderr_chunk_json(job_id, line);
+crates/mvm-builder-init/src/dispatch_response.rs-251- let typed: mvm_build::builder_protocol::BuilderResponse =
+crates/mvm-builder-init/src/dispatch_response.rs-252- serde_json::from_str(&json).expect("must parse as typed BuilderResponse");
+
+**Tool Call: grep "build-users-group|nixbld" crates/mvm-builder-init/src**
+Status: Completed
+
+No matches found
+
+**Tool Call: grep "vsock.*send|single-shot.*path" crates/mvm-builder-init/src**
+Status: Completed
+
+/Users/auser/work/tinylabs/mvmco/mvm/crates/mvm-builder-init/src/dispatch*response.rs-33-
+crates/mvm-builder-init/src/dispatch_response.rs-34-use crate::boot_timings::BootTimings;
+/Users/auser/work/tinylabs/mvmco/mvm/crates/mvm-builder-init/src/dispatch_response.rs-35-
+crates/mvm-builder-init/src/dispatch_response.rs:36:/// The nil UUID used by the single-shot path when no incoming
+/Users/auser/work/tinylabs/mvmco/mvm/crates/mvm-builder-init/src/dispatch_response.rs-37-/// dispatch supplied a `job_id`. Persistent-dispatch callers
+/Users/auser/work/tinylabs/mvmco/mvm/crates/mvm-builder-init/src/dispatch_response.rs-38-/// (Plan 89 W3 part 3) echo back the request's id instead.
+crates/mvm-builder-init/src/dispatch_response.rs-39-pub(crate) const NIL_JOB_ID: &str = "00000000-0000-0000-0000-000000000000";
+--
+crates/mvm-builder-init/src/main.rs-571- t.job_end_ms = Some(BootTimings::ms_since(anchor))
+/Users/auser/work/tinylabs/mvmco/mvm/crates/mvm-builder-init/src/main.rs-572- });
+/Users/auser/work/tinylabs/mvmco/mvm/crates/mvm-builder-init/src/main.rs-573- write_result(code, &tail);
+crates/mvm-builder-init/src/main.rs:574: // Plan 89 W2 part 3: best-effort vsock send of the
+crates/mvm-builder-init/src/main.rs-575- / `BuilderResponse::Result` frame the host's
+crates/mvm-builder-init/src/main.rs-576- / `mvm_build::builder_protocol::read_builder_response_from_socket`
+/Users/auser/work/tinylabs/mvmco/mvm/crates/mvm-builder-init/src/main.rs-577- // is waiting for. Runs BEFORE write_boot_timings so the
+--
+/Users/auser/work/tinylabs/mvmco/mvm/crates/mvm-builder-init/src/main.rs-584- Err(*) => {
+/Users/auser/work/tinylabs/mvmco/mvm/crates/mvm-builder-init/src/main.rs-585- eprintln!(
+crates/mvm-builder-init/src/main.rs-586- "mvm-builder-init: boot-timings mutex poisoned; \
+crates/mvm-builder-init/src/main.rs:587: skipping vsock dispatch send"
+/Users/auser/work/tinylabs/mvmco/mvm/crates/mvm-builder-init/src/main.rs-588- );
+/Users/auser/work/tinylabs/mvmco/mvm/crates/mvm-builder-init/src/main.rs-589- stamp(&timings, |t| {
+crates/mvm-builder-init/src/main.rs-590- t.poweroff_start_ms = Some(BootTimings::ms_since(anchor))
+--
+/Users/auser/work/tinylabs/mvmco/mvm/crates/mvm-builder-init/src/main.rs-641- /// Plan 89 W2 part 2 — must match
+crates/mvm-builder-init/src/main.rs-642- / `mvm_guest::builder_agent::BUILDER_DISPATCH_PORT`. Hardcoded
+/Users/auser/work/tinylabs/mvmco/mvm/crates/mvm-builder-init/src/main.rs-643- /// for size-budget reasons; the
+crates/mvm-builder-init/src/main.rs:644: /// `vsock_send_tests::builder_dispatch_port_literal_is_21471`
+/Users/auser/work/tinylabs/mvmco/mvm/crates/mvm-builder-init/src/main.rs-645- /// pinning test below catches divergence.
+crates/mvm-builder-init/src/main.rs-646- const BUILDER_DISPATCH_PORT: u32 = 21471;
+crates/mvm-builder-init/src/main.rs-647- const AF_VSOCK: i32 = 40;
+--
+/Users/auser/work/tinylabs/mvmco/mvm/crates/mvm-builder-init/src/main.rs-800- };
+/Users/auser/work/tinylabs/mvmco/mvm/crates/mvm-builder-init/src/main.rs-801- let Some(conn_fd) = accept_one(listen_fd) else {
+/Users/auser/work/tinylabs/mvmco/mvm/crates/mvm-builder-init/src/main.rs-802- eprintln!(
+crates/mvm-builder-init/src/main.rs:803: "mvm-builder-init: vsock send: no host connection within {ACCEPT_TIMEOUT_SECS}s \
+crates/mvm-builder-init/src/main.rs:804: (single-shot path; W2 part 4 wired the host receiver)"
+/Users/auser/work/tinylabs/mvmco/mvm/crates/mvm-builder-init/src/main.rs-805- );
+/Users/auser/work/tinylabs/mvmco/mvm/crates/mvm-builder-init/src/main.rs-806- unsafe { close(listen_fd) };
+/Users/auser/work/tinylabs/mvmco/mvm/crates/mvm-builder-init/src/main.rs-807- return;
+--
+/Users/auser/work/tinylabs/mvmco/mvm/crates/mvm-builder-init/src/main.rs-809- let mut conn = adopt_conn_fd(conn_fd);
+/Users/auser/work/tinylabs/mvmco/mvm/crates/mvm-builder-init/src/main.rs-810- let json = payload.to_json();
+/Users/auser/work/tinylabs/mvmco/mvm/crates/mvm-builder-init/src/main.rs-811- if !write_frame(&mut conn, json.as_bytes()) {
+crates/mvm-builder-init/src/main.rs:812: eprintln!("mvm-builder-init: vsock send: write failed mid-frame");
+/Users/auser/work/tinylabs/mvmco/mvm/crates/mvm-builder-init/src/main.rs-813- }
+/Users/auser/work/tinylabs/mvmco/mvm/crates/mvm-builder-init/src/main.rs-814- drop(conn);
+/Users/auser/work/tinylabs/mvmco/mvm/crates/mvm-builder-init/src/main.rs-815- unsafe { close(listen_fd) };
+--
+/Users/auser/work/tinylabs/mvmco/mvm/crates/mvm-builder-init/src/main.rs-1144- }
+/Users/auser/work/tinylabs/mvmco/mvm/crates/mvm-builder-init/src/main.rs-1145-
+/Users/auser/work/tinylabs/mvmco/mvm/crates/mvm-builder-init/src/main.rs-1146- #[cfg(test)]
+crates/mvm-builder-init/src/main.rs:1147: mod vsock_send_tests {
+/Users/auser/work/tinylabs/mvmco/mvm/crates/mvm-builder-init/src/main.rs-1148- // Plan 89 W2 part 3 — the in-binary BUILDER_DISPATCH_PORT
+/Users/auser/work/tinylabs/mvmco/mvm/crates/mvm-builder-init/src/main.rs-1149- // const above must stay in sync with
+crates/mvm-builder-init/src/main.rs-1150- / mvm_guest::builder_agent::BUILDER_DISPATCH_PORT (the
+--
+crates/mvm-builder-init/src/main.rs-1786- / `BuilderResponse::StderrChunk` docs commit to that).
+/Users/auser/work/tinylabs/mvmco/mvm/crates/mvm-builder-init/src/main.rs-1787- /// `STDERR_TAIL_LINES` of trailing context is still buffered
+/Users/auser/work/tinylabs/mvmco/mvm/crates/mvm-builder-init/src/main.rs-1788- /// for the final Result frame's `stderr_tail`, matching the
+crates/mvm-builder-init/src/main.rs:1789: /// single-shot path's contract.
+crates/mvm-builder-init/src/main.rs-1790- fn run_job_streaming<F: FnMut(&str)>(
+crates/mvm-builder-init/src/main.rs-1791- cmd_sh: &str,
+crates/mvm-builder-init/src/main.rs-1792- tmpdir: Option<&str>,
+
+**Tool Call: Read crates/mvm-builder-init/src/main.rs (1 - 200)**
+Status: Completed
+
+```
+1	//! mvm-builder-init — PID 1 for the libkrun builder VM.
+2	//!
+3	//! Plan 72 W3 (`specs/plans/72-builder-vm-via-libkrun.md`). Tiny
+4	//! static-linked init that mounts the essentials, brings up the
+5	//! persistent `/nix` store (formatting on first boot), tries to
+6	//! bring the network up, executes `/job/cmd.sh`, writes
+7	//! `/job/result`, and powers off.
+8	//!
+9	//! ## Why this binary, not a shell script
+10	//!
+11	//! Per Plan 72 §W3, the choice between shell and Rust was
+12	//! explicitly debated. Rust won because:
+13	//!
+14	//! - One binary to audit; no `/bin/sh` -> `/usr/bin/sh` -> busybox
+15	//!   hop where each link is a separate Nix store path.
+16	//! - The mount syscalls (overlay/bind mounting the persistent
+17	//!   `/nix-store` over `/nix`) are direct rather than `/sbin/mount`
+18	//!   wrappers, so we get clear errors when something refuses.
+19	//! - We can encode the `/job/result` JSON shape in one place
+20	//!   rather than escape-quoting it across `printf` invocations.
+21	//!
+22	//! ## What runs in here
+23	//!
+24	//! On boot:
+25	//!
+26	//!   1. Mount `/proc`, `/sys`, `/dev`, `/tmp` (the standard init
+27	//!      essentials — busybox-as-PID-1 from `mkGuest` does the
+28	//!      same).
+29	//!   2. Probe `/dev/vdb` for an ext4 superblock; format with
+30	//!      `mkfs.ext4 -F` if blank (first boot on a fresh sparse
+31	//!      virtio-blk image).
+32	//!   3. Mount `/dev/vdb` at `/nix-store`, then mount `/nix` as an
+33	//!      overlay with the rootfs seed as lowerdir and `/nix-store`
+34	//!      as upper/work storage. This lets reads see the baked-in Nix
+35	//!      closure without copying it into the constrained persistent
+36	//!      disk before the first build.
+37	//!   4. Best-effort `udhcpc -i eth0 -n -q` — failure is
+38	//!      non-fatal (offline builds against the seed store still
+39	//!      work; Plan 72 W4's `LibkrunBuilderVm::with_offline()`
+40	//!      formalizes this).
+41	//!   5. Read `/job/cmd.sh`. Exit code 2 + "no cmd.sh" in
+42	//!      `/job/result` if missing.
+43	//!   6. Spawn `/bin/sh -eu /job/cmd.sh`. Capture exit + stderr
+44	//!      tail (last 20 lines, to keep the result file small).
+45	//!   7. Write `/job/result` as `{"exit_code":<i32>,"stderr_tail":<json-string>}`.
+46	//!   8. `sync` + `reboot(RB_POWER_OFF)`. The libkrun host
+47	//!      detects power-off via the shutdown-eventfd
+48	//!      (`krun_get_shutdown_eventfd`).
+49	//!
+50	//! ## Non-Linux build behaviour
+51	//!
+52	//! Linux-only by design. On macOS / Windows the crate still
+53	//! compiles (workspace ergonomics) but `main()` prints a hint
+54	//! and exits 1. mkGuest cross-compiles the real binary against
+55	//! `<arch>-unknown-linux-musl` from a Linux nix-build
+56	//! environment; that's where the size budget (≤ 1.5 MiB) and
+57	//! static-link requirement get enforced.
+58
+59	use std::process::ExitCode;
+60
+61	// Cross-platform modules. The install-spec parser and install
+62	// pipeline runner live here so `cargo test` on macOS exercises the
+63	// dispatch logic via shell stubs without paying for a Linux cross-
+64	// compile. The Linux-only `linux` module composes them with the
+65	// real PID-1 mount / power-off dance.
+66	//
+67	// `allow(dead_code)` because the modules are consumed from
+68	// `linux::run_install_job` on Linux and from `#[cfg(test)]` blocks
+69	// on every host. On non-Linux non-test builds (workspace ergonomics
+70	// + reproducible builds) every public item looks "unused" — clippy
+71	// would flag them otherwise. Real dead code would still surface as
+72	// red because the tests would lose coverage.
+73	#[allow(dead_code)]
+74	mod boot_timings;
+75	/// Plan 89 W3 part 2 — hand-rolled parser for the
+76	/// `BuilderRequest` wire shape the persistent builder VM's
+77	/// dispatch loop reads off vsock. Cross-platform; the W3 part 3
+78	/// Linux dispatch loop calls into it after reading the framed
+79	/// body. Tested against the host's serde-derived encoding so
+80	/// schema drift on either side is loud.
+81	#[allow(dead_code)]
+82	mod builder_request;
+83	/// Plan 89 W2 part 3 — hand-rolled `BuilderResponse::Result`
+84	/// JSON. Cross-platform (testable on macOS) so the wire shape can
+85	/// be validated against `mvm_build::builder_protocol`'s typed
+86	/// serde via a dev-dep test, without dragging serde_json into the
+87	/// production builder-init binary.
+88	#[allow(dead_code)]
+89	mod dispatch_response;
+90	#[allow(dead_code)]
+91	mod install;
+92	#[allow(dead_code)]
+93	mod install_spec;
+94	#[allow(dead_code)]
+95	mod network;
+96	#[allow(dead_code)]
+97	mod proxy;
+98
+99	fn main() -> ExitCode {
+100	    #[cfg(target_os = "linux")]
+101	    {
+102	        linux::run()
+103	    }
+104
+105	    #[cfg(not(target_os = "linux"))]
+106	    {
+107	        eprintln!(
+108	            "mvm-builder-init is Linux-only (PID 1 for the libkrun \
+109	             builder VM). On a developer host this binary is a no-op; \
+110	             mkGuest cross-compiles the real init for \
+111	             <arch>-unknown-linux-musl. See \
+112	             specs/plans/72-builder-vm-via-libkrun.md §W3."
+113	        );
+114	        ExitCode::FAILURE
+115	    }
+116	}
+117
+118	#[cfg(any(target_os = "linux", test))]
+119	fn virtiofs_tag_is_read_only(tag: &str) -> bool {
+120	    tag == "work"
+121	}
+122
+123	/// Bytes from the start of the ext4 superblock that the host-side
+124	/// geometry check reads. The high-32 bits of `s_blocks_count` live
+125	/// at superblock offset `0x150` (336), so 512 is the smallest
+126	/// power-of-two read covering every field the parser inspects.
+127	#[cfg(any(target_os = "linux", test))]
+128	const EXT4_SUPERBLOCK_READ: usize = 512;
+129
+130	/// Parse the ext4 superblock buffer and return the total
+131	/// filesystem size in bytes the superblock asserts, or `None`
+132	/// when the buffer has no valid ext4 magic / a sanity-failing
+133	/// block size.
+134	///
+135	/// Layout (little-endian; offsets relative to the start of the
+136	/// superblock — itself at byte offset 1024 of the partition):
+137	/// - `0x04`  u32 `s_blocks_count_lo`  — low 32 bits of total block count
+138	/// - `0x18`  u32 `s_log_block_size`   — block size = `1024 << this`
+139	/// - `0x38`  u16 `s_magic`            — `0xEF53` for ext{2,3,4}
+140	/// - `0x150` u32 `s_blocks_count_hi`  — high 32 bits (64-bit feature; 0 otherwise)
+141	///
+142	/// Pure function so darwin `cargo test` exercises it without a
+143	/// Linux cross-compile; the file-IO and `BLKGETSIZE64` ioctl that
+144	/// feed it live inside the linux module.
+145	#[cfg(any(target_os = "linux", test))]
+146	fn parse_ext4_recorded_size_bytes(sb: &[u8]) -> Option<u64> {
+147	    if sb.len() < 0x150 + 4 {
+148	        return None;
+149	    }
+150	    // Magic at 0x38 — guard before trusting the other fields.
+151	    if sb[0x38] != 0x53 || sb[0x39] != 0xEF {
+152	        return None;
+153	    }
+154	    let blocks_lo = u32::from_le_bytes(sb[0x04..0x08].try_into().ok()?);
+155	    let log_block_size = u32::from_le_bytes(sb[0x18..0x1c].try_into().ok()?);
+156	    let blocks_hi = u32::from_le_bytes(sb[0x150..0x154].try_into().ok()?);
+157	    // Reject absurd block sizes — ext4 spec allows 1 KiB..64 KiB
+158	    // (log values 0..=6). Anything higher signals a malformed or
+159	    // stale superblock; treat as unformatted.
+160	    if log_block_size > 6 {
+161	        return None;
+162	    }
+163	    let block_size = 1024u64 << log_block_size;
+164	    let total_blocks = (u64::from(blocks_hi) << 32) | u64::from(blocks_lo);
+165	    total_blocks.checked_mul(block_size)
+166	}
+167
+168	#[cfg(test)]
+169	mod tests {
+170	    use super::*;
+171
+172	    #[test]
+173	    fn virtiofs_tag_policy_keeps_only_workspace_read_only() {
+174	        assert!(virtiofs_tag_is_read_only("work"));
+175	        assert!(!virtiofs_tag_is_read_only("out"));
+176	        assert!(!virtiofs_tag_is_read_only("job"));
+177	    }
+178
+179	    /// Build a synthetic ext4 superblock buffer (just the fields
+180	    /// `parse_ext4_recorded_size_bytes` reads).
+181	    fn synth_sb(blocks_lo: u32, blocks_hi: u32, log_block_size: u32) -> Vec<u8> {
+182	        let mut sb = vec![0u8; EXT4_SUPERBLOCK_READ];
+183	        sb[0x04..0x08].copy_from_slice(&blocks_lo.to_le_bytes());
+184	        sb[0x18..0x1c].copy_from_slice(&log_block_size.to_le_bytes());
+185	        sb[0x38] = 0x53;
+186	        sb[0x39] = 0xEF;
+187	        sb[0x150..0x154].copy_from_slice(&blocks_hi.to_le_bytes());
+188	        sb
+189	    }
+190
+191	    #[test]
+192	    fn parse_ext4_size_rejects_buffer_without_magic() {
+193	        let sb = vec![0u8; EXT4_SUPERBLOCK_READ];
+194	        assert_eq!(parse_ext4_recorded_size_bytes(&sb), None);
+195	    }
+196
+197	    #[test]
+198	    fn parse_ext4_size_rejects_short_buffer() {
+199	        let sb = vec![0u8; 64];
+200	        assert_eq!(parse_ext4_recorded_size_bytes(&sb), None);
+```
+
+**Tool Call: grep | head -100 "fn.*dispatch|fn.*run.*job|let.*cmd|execve\(|spawn|Command::new" crates/mvm-builder-init/src/main.rs**
+Status: Completed
+
+348-
+349- // The Linux kernel doesn't pass a PATH to PID 1, so without
+350: // this every `Command::new("iptables")` /
+351: // `Command::new("modprobe")` style spawn relies on the
+352- // child to find its binary — which fails on a stock rootfs
+353- // (Plan 86 / ADR-054). Set a canonical PATH that covers the
+354- // mvm builder VM rootfs layout (busybox at `/bin/*` + extra
+355- // packages at `/sbin/*` + `/usr/local/bin/*`) before any
+356: // spawn site runs. Absolute-path call sites like
+357- // `/sbin/mkfs.ext4` (e2fsprogs, lives at `/sbin/*` via the
+358- // mkGuest packages symlink) and `/bin/udhcpc`,
+--
+361- // `/sbin/udhcpc` would ENOENT — busybox only installs
+362- // applets under `/bin/<applet>`.
+363: // SAFETY: PID 1 is single-threaded until we spawn the fan-out
+364- // tracks below; no other thread can be reading the env yet.
+365- unsafe {
+--
+414- let track_b = {
+415- let timings = Arc::clone(&timings);
+416: std::thread::spawn(move || setup_modules_and_virtiofs(&timings, anchor))
+417- };
+418- let track_c = {
+419- let timings = Arc::clone(&timings);
+420: std::thread::spawn(move || {
+421- if let Err(e) = setup_network() {
+422- eprintln!("mvm-builder-init: setup_network warning (non-fatal): {e}");
+--
+552- }
+553-
+554: let cmd_path = format!("{JOB_DIR}/cmd.sh");
+555- if !Path::new(&cmd_path).exists() {
+556- write_result(2, &format!("missing {cmd_path}"));
+--
+566- });
+567- let job_start_at = Instant::now();
+568: let (code, tail) = run_job(&cmd_path);
+569- let build_ms = u64::try_from(job_start_at.elapsed().as_millis()).unwrap_or(u64::MAX);
+570- stamp(&timings, |t| {
+--
+688- /// subsequent `accept()` calls bound the wait at `n`s; `None`
+689- /// means accept blocks until a peer connects.
+690: fn open_dispatch_listener_fd(accept_timeout_secs: Option<i64>) -> Option<i32> {
+691- let listen_fd = unsafe { socket(AF_VSOCK, SOCK_STREAM, 0) };
+692- if listen_fd < 0 {
+--
+794- }
+795-
+796: fn send_dispatch_response_via_vsock(payload: &crate::dispatch_response::DispatchResponse) {
+797- const ACCEPT_TIMEOUT_SECS: i64 = 10;
+798- let Some(listen_fd) = open_dispatch_listener_fd(Some(ACCEPT_TIMEOUT_SECS)) else {
+--
+822- /// Plan 89 W3 part 3 — dispatch loop entry point. Called from
+823- /// `run` when `/job/dispatch.sock.marker` is present (the host
+824: /// stages the marker when spawning a long-lived
+825- /// `LibkrunPersistentBuilderVm`, W3 part 4). Opens a long-lived
+826- /// AF_VSOCK listener on [`BUILDER_DISPATCH_PORT`], reads one
+--
+838- /// Returns `0` on graceful `Shutdown`, non-zero on listener
+839- /// setup failure (caller `power_off`s either way).
+840: fn run_dispatch_loop(mut cold_boot_timings: Option<BootTimings>) -> i32 {
+841- // No accept timeout — the dispatch loop is persistent and
+842- // blocks waiting for the supervisor's next submit. The
+--
+997- /// the host correlates everything by conn identity, not by job
+998- /// id alone (Plan 89 W3 part 9).
+999: fn execute_dispatched_job(
+1000- conn: &mut std::fs::File,
+1001- job_id: String,
+--
+1028- let (exit_code, stderr_tail, build_ms) = match job {
+1029- crate::builder_request::BuilderJob::Flake { .. } => {
+1030: let cmd_path = format!("{JOB_DIR}/{job_dir_relpath}/cmd.sh");
+1031- if !Path::new(&cmd_path).exists() {
+1032- (2, format!("missing {cmd_path}"), 0)
+--
+1155- // check is overkill; keep it inline.
+1156- #[test]
+1157: fn builder_dispatch_port_literal_is_21471() {
+1158- // Mirror of the function-local const in
+1159- // `send_dispatch_response_via_vsock`. Updating one
+--
+1209- /// via the _presence_ of result.json. Anything that prevents
+1210- /// us from writing result.json gets logged + falls through.
+1211: fn run_install_job(spec_path: &str) {
+1212- run_install_job_at(spec_path, JOB_DIR, OUT_DIR);
+1213- }
+--
+1223- /// `<session.job_dir>/<job_id>/out/` convention from W3
+1224- /// part 6/7).
+1225: fn run_install_job_at(spec_path: &str, job_dir: &str, out_dir: &str) {
+1226- use crate::install::{
+1227- InstallContext, InstallError, RESULT_FILENAME, SystemCommandRunner, run_install,
+--
+1261- let runner = SystemCommandRunner;
+1262- / Plan 73 Followup B.2.x: the production proxy lifecycle
+1263: // spawns `mvm-egress-proxy` from PATH. The builder VM
+1264- // flake installs the binary at `/sbin/mvm-egress-proxy`
+1265- // (alongside `/sbin/mvm-builder-init`), which is on the
+--
+
+[Showing results with pagination = limit: 100]
+
+**Tool Call: Read nix/packages/mvm-guest-agent.nix**
+Status: Completed
+
+```
+1	# `mvm-guest-agent` — the production guest agent binary.
+2	#
+3	# Plan-60 W6.1.2 swaps the W6.1.1 sh-script stub
+4	# (`nix/lib/mk-guest.nix::agentBinary`) for the real Rust binary
+5	# defined at `crates/mvm-guest/src/bin/mvm-guest-agent.rs` (~2400
+6	# LOC of vsock RPC + worker-pool dispatch + integration manifest +
+7	# system metrics). Side-bins `mvm-seccomp-apply` (the per-service
+8	# seccomp shim, ADR-002 §W2.4) and `mvm-verity-init` (the verity-
+9	# initrd PID 1, ADR-002 §W3) ride the same derivation since the
+10	# rootfs needs them too.
+11	#
+12	# ## Build environment
+13	#
+14	# `rustPlatform.buildRustPackage` against the workspace at
+15	# `mvmSrc`. The crate is built with `--package mvm-guest --bins`
+16	# so the workspace's heavier consumers (mvm, mvm-backend,
+17	# libkrun, etc.) don't enter the closure. Cargo still
+18	# resolves and vendors the full workspace lockfile, but only the
+19	# selected crate's deps compile.
+20	#
+21	# ## Cross-targeting
+22	#
+23	# The caller passes `pkgs` for the target system (e.g. on a macOS
+24	# host with nix-darwin's linux-builder configured, the caller
+25	# resolves `pkgs.pkgsCross.aarch64-multiplatform.pkgs` and hands
+26	# it here). For native Linux + KVM the caller's own `pkgs` is
+27	# already the right thing. The W7.x.2 builder VM sets this up
+28	# transparently — `nix build` inside the sandbox runs on Linux,
+29	# so `pkgs` is Linux pkgs.
+30	#
+31	# ## Features
+32	#
+33	# `dev-shell` is opt-in. With it, the agent accepts the `Exec`
+34	# vsock request and shells out arbitrary commands — required for
+35	# `mvmctl exec`/`mvmctl console` against dev images. Without it
+36	# (production), the `Exec` symbol is absent (ADR-002 §W4.3's
+37	# `prod-agent-no-exec` CI gate is what enforces this on the
+38	# release lane).
+39
+40	{ pkgs
+41	, lib
+42	, mvmSrc
+43	, withDevShell ? false
+44	}:
+45
+46	pkgs.rustPlatform.buildRustPackage {
+47	  pname = "mvm-guest-agent";
+48	  version = "0.14.0";
+49
+50	  src = mvmSrc;
+51
+52	  # Workspace's Cargo.lock is the source of truth for every crate
+53	  # we vendor. `buildRustPackage` vendors the closure even though
+54	  # we only build mvm-guest; the unused deps compile zero code.
+55	  cargoLock.lockFile = mvmSrc + "/Cargo.lock";
+56
+57	  # Restrict the build to the mvm-guest binaries. The workspace
+58	  # has heavier members (libkrun via mvm-build, libkrun via
+59	  # mvm-providers, etc.) that aren't in the guest closure.
+60	  cargoBuildFlags = [
+61	    "--package" "mvm-guest"
+62	    "--bin" "mvm-guest-agent"
+63	    "--bin" "mvm-seccomp-apply"
+64	    "--bin" "mvm-verity-init"
+65	    # Plan 74 W2 — guest-side network defense. Installs kernel
+66	    # blackhole routes for `MANDATORY_DENY_RANGES` at boot from
+67	    # `/init` (uid 0) before the main agent forks under setpriv.
+68	    "--bin" "mvm-guest-netinit"
+69	  ] ++ lib.optionals withDevShell [
+70	    "--features" "mvm-guest/dev-shell"
+71	  ];
+72
+73	  # Same selection for the `nix flake check`-equivalent test run.
+74	  # mvm-guest's tests are pure (vsock framing, integration manifest
+75	  # parsing, seccomp filter golden tests) so they run inside the
+76	  # sandbox without privilege.
+77	  cargoTestFlags = [
+78	    "--package" "mvm-guest"
+79	  ];
+80
+81	  # Skip tests by default — they need a Linux build host and the
+82	  # builder VM already runs `nix build` (not `nix flake check`).
+83	  # CI's dedicated test lane covers the Rust test suite directly.
+84	  doCheck = false;
+85
+86	  meta = with lib; {
+87	    description = "mvm guest agent — vsock RPC handler for microVM guests";
+88	    homepage = "https://github.com/tinylabscom/mvm";
+89	    license = licenses.asl20;
+90	    platforms = platforms.linux;
+91	  };
+92	}
+93
+```
+
+**Tool Call: Read crates/mvm-guest-agent/Cargo.toml**
+Status: Failed
+
+```
+File does not exist. Note: your current working directory is /Users/auser/work/tinylabs/mvmco/mvm.
+```
+
+**Tool Call: Find `/Users/auser/work/tinylabs/mvmco/mvm` `crates/mvm-guest-agent/build.rs`**
+Status: Completed
+
+No files found
+
+**Tool Call: Read crates/mvm-builder-init/src/main.rs (1000 - 1099)**
+Status: Completed
+
+```
+1000	        conn: &mut std::fs::File,
+1001	        job_id: String,
+1002	        job: crate::builder_request::BuilderJob,
+1003	        job_dir_relpath: &str,
+1004	        cold_boot_timings: Option<BootTimings>,
+1005	    ) -> String {
+1006	        // Plan 89 W3 part 12 — flush + re-install the egress
+1007	        // lockdown before every dispatch. A previous build that
+1008	        // mutated iptables (whether via a CAP_NET_ADMIN leak or
+1009	        // because we haven't shipped the cap drop yet) loses its
+1010	        // changes here. Fail closed: if iptables is broken we
+1011	        // refuse the dispatch — that's safer than running a
+1012	        // build against a chain whose state we no longer trust.
+1013	        if let Err(e) = crate::network::reapply_egress_lockdown(
+1014	            &crate::network::SystemIptables,
+1015	            crate::network::PROXY_UID,
+1016	        ) {
+1017	            eprintln!("mvm-builder-init: dispatch loop: iptables baseline re-apply failed: {e}");
+1018	            let response = crate::dispatch_response::DispatchResponse {
+1019	                job_id,
+1020	                exit_code: 126,
+1021	                stderr_tail: format!("iptables baseline re-apply failed: {e}"),
+1022	                boot_timings: cold_boot_timings,
+1023	                build_ms: 0,
+1024	            };
+1025	            return response.to_json();
+1026	        }
+1027
+1028	        let (exit_code, stderr_tail, build_ms) = match job {
+1029	            crate::builder_request::BuilderJob::Flake { .. } => {
+1030	                let cmd_path = format!("{JOB_DIR}/{job_dir_relpath}/cmd.sh");
+1031	                if !Path::new(&cmd_path).exists() {
+1032	                    (2, format!("missing {cmd_path}"), 0)
+1033	                } else {
+1034	                    // Plan 89 W3 part 10 — per-job scratch dir
+1035	                    // at `/tmp/<job_id>/`. Pointed at by TMPDIR so
+1036	                    // every tool that honors it (mkstemp, nix
+1037	                    // evaluator, Python tempfile) writes there
+1038	                    // instead of the shared rootfs `/tmp`.
+1039	                    // Cleaned up when `_scratch` goes out of scope
+1040	                    // at the end of this match arm. On creation
+1041	                    // failure (extremely rare — tmpfs full at
+1042	                    // boot, perms surprise), fall through with no
+1043	                    // TMPDIR override and surface the warning in
+1044	                    // the stderr tail — the build is still
+1045	                    // useful, just without per-job tempfile
+1046	                    // isolation.
+1047	                    // Chown to the builder uid (Plan 89 W3 part
+1048	                    // 13) so the dispatched cmd.sh — which runs
+1049	                    // under `setpriv --reuid=BUILDER_UID
+1050	                    // --regid=BUILDER_GID` via
+1051	                    // `Isolation::Unshared` — can write into the
+1052	                    // scratch dir.
+1053	                    let (scratch, tmpdir) = match JobScratch::create(
+1054	                        JOB_SCRATCH_BASE,
+1055	                        &job_id,
+1056	                        Some((BUILDER_UID, BUILDER_GID)),
+1057	                    ) {
+1058	                        Ok(s) => {
+1059	                            let path = s.path().to_string();
+1060	                            (Some(s), Some(path))
+1061	                        }
+1062	                        Err(e) => {
+1063	                            eprintln!(
+1064	                                "mvm-builder-init: dispatch loop: failed to create scratch for {job_id}: {e}"
+1065	                            );
+1066	                            (None, None)
+1067	                        }
+1068	                    };
+1069	                    let started = Instant::now();
+1070	                    let (code, tail) = run_job_streaming(
+1071	                        &cmd_path,
+1072	                        tmpdir.as_deref(),
+1073	                        Isolation::Unshared,
+1074	                        |line| {
+1075	                            let frame = crate::dispatch_response::stderr_chunk_json(&job_id, line);
+1076	                            if !write_frame(conn, frame.as_bytes()) {
+1077	                                // Host probably closed the conn
+1078	                                // (e.g. supervisor went away
+1079	                                // mid-build). Log and keep
+1080	                                // draining stderr so the build's
+1081	                                // exit code is still meaningful —
+1082	                                // the terminal Result write will
+1083	                                // fail loudly back in the
+1084	                                // dispatch loop.
+1085	                                eprintln!(
+1086	                                    "mvm-builder-init: dispatch loop: write StderrChunk failed"
+1087	                                );
+1088	                            }
+1089	                        },
+1090	                    );
+1091	                    let ms = u64::try_from(started.elapsed().as_millis()).unwrap_or(u64::MAX);
+1092	                    // Hold `scratch` until after the build returns
+1093	                    // so its `Drop` cleans up after the
+1094	                    // subprocess. Explicit drop documents the
+1095	                    // ordering for the reader.
+1096	                    drop(scratch);
+1097	                    (code, tail, ms)
+1098	                }
+1099	            }
+```
+
+**Tool Call: grep "fn run_job|bash|sh -eu|nix build|nix-build" crates/mvm-builder-init/src/main.rs**
+Status: Completed
+
+38-//! non-fatal (offline builds against the seed store still
+39-/! work; Plan 72 W4's `LibkrunBuilderVm::with_offline()`
+40-//! formalizes this).
+41-//! 5. Read `/job/cmd.sh`. Exit code 2 + "no cmd.sh" in
+42-//! `/job/result` if missing.
+43://! 6. Spawn `/bin/sh -eu /job/cmd.sh`. Capture exit + stderr
+44-//! tail (last 20 lines, to keep the result file small).
+45-/! 7. Write `/job/result` as `{"exit_code":<i32>,"stderr_tail":<json-string>}`.
+46-//! 8. `sync` + `reboot(RB_POWER_OFF)`. The libkrun host
+47-//! detects power-off via the shutdown-eventfd
+48-//! (`krun_get_shutdown_eventfd`).
+--
+50-//! ## Non-Linux build behaviour
+51-//!
+52-//! Linux-only by design. On macOS / Windows the crate still
+53-//! compiles (workspace ergonomics) but `main()` prints a hint
+54-//! and exits 1. mkGuest cross-compiles the real binary against
+55://! `<arch>-unknown-linux-musl` from a Linux nix-build
+56-//! environment; that's where the size budget (≤ 1.5 MiB) and
+57-//! static-link requirement get enforced.
+58-
+59-use std::process::ExitCode;
+60-
+--
+473- // `iptables-nft` and `iptables-legacy` bail with "table
+474- // does not exist" or "protocol not supported" at the first
+475- // rule install. The egress lockdown is defense-in-depth
+476- // for the Plan 73 deps-install pipeline (untrusted code
+477- // running in the steady-state builder VM). Stage 0 only
+478: // runs flake builds — `nix build` against a pinned
+479- / `path:/work#…` reference — where Nix's own fixed-output
+480- // derivation hashes carry the integrity guarantee. We
+481- // log + continue rather than fail closed.
+482- //
+483- // The steady-state builder VM image (built by Stage 0 via
+--
+1428- t.nix*mounted_ms = Some(BootTimings::ms_since(anchor))
+1429- });
+1430-
+1431- / PR #420 follow-up: load `/nix-path-registration` (the
+1432- // standard `make-ext4-fs.nix` manifest) into the persistent
+1433: // `/nix/var/nix/db` so the in-VM `nix build` knows the
+1434- // seeded closure is already valid. Without this, nix-daemon
+1435- // treats every seeded path as missing and re-substitutes
+1436- // from `cache.nixos.org` — the substituter then overwrites
+1437- // the on-disk path during the rename window, and concurrent
+1438- // build-hook workers `dlopen`ing libs from the same path
+--
+1650- libc::close(sock);
+1651- }
+1652- result
+1653- }
+1654-
+1655: fn run_job(cmd_sh: &str) -> (i32, String) {
+1656- / Single-shot path: no streaming callback, no TMPDIR
+1657- // override (single-shot uses the rootfs's tmpfs `/tmp`
+1658- // directly — the VM is going to power-off, so per-job
+1659- // scratch isolation has no second job to protect), and no
+1660- // unshare wrapping (the VM tear-down already kills any
+--
+1785- /// The trailing `\n` is stripped from each line (the typed
+1786- / `BuilderResponse::StderrChunk` docs commit to that).
+1787- /// `STDERR_TAIL_LINES` of trailing context is still buffered
+1788- /// for the final Result frame's `stderr_tail`, matching the
+1789- /// single-shot path's contract.
+1790: fn run_job_streaming<F: FnMut(&str)>(
+1791- cmd_sh: &str,
+1792- tmpdir: Option<&str>,
+1793- isolation: Isolation,
+1794- mut on_line: F,
+1795- ) -> (i32, String) {
+--
+2020- / The need for this call surfaced as `libboost_url.so.1.87.0:
+2021-    /// cannot open shared object file` during the in-VM dev-image
+2022- / build: with no entries in the DB, every closure path the
+2023- /// build references gets re-fetched from `cache.nixos.org`,
+2024- /// overwriting the seeded path in place — and a concurrent
+2025: /// nix build-hook worker mid-`dlopen` of the same path's libs
+2026- /// hits ENOENT during the rename window. Loading the DB makes
+2027- /// the substituter skip the re-fetch entirely.
+2028- fn load_seeded_nix_db(
+2029- timings: &Arc<Mutex<BootTimings>>,
+2030- anchor: Instant,
+--
+2117- /// ```2118-    ///
+2119-    /// Detected pre-mount so we can recover with`mkfs.ext4 -F`2120-    /// rather than aborting before the build can run. The
+2121-    ///`/nix-store`volume is a cache; reformatting loses nothing
+2122:    /// that can't be rebuilt by the next nix build.
+2123-    fn nix_store_dev_needs_format(dev: &str) -> Result<Option<String>, String> {
+2124-        let sb = read_ext4_superblock(dev)?;
+2125-        let Some(fs_bytes) = crate::parse_ext4_recorded_size_bytes(&sb) else {
+2126-            return Ok(Some("no ext4 superblock".into()));
+2127-        };
+--
+2329-        /// Plan 89 W3 part 9 —`run_job_streaming`calls the
+2330-        /// per-line callback once per stderr line, in order, and
+2331-        /// returns the same`(exit_code, tail)`shape as the
+2332-        /// single-shot`run_job`for the success case.
+2333-        #[test]
+2334:        fn run_job_streaming_emits_each_line_in_order() {
+2335-            // Write a cmd.sh that emits 3 stderr lines and exits 0.
+2336-            let dir = tempfile::tempdir().expect("tempdir");
+2337-            let cmd_path = dir.path().join("cmd.sh");
+2338-            std::fs::write(
+2339-                &cmd_path,
+--
+2357-        }
+2358-
+2359-        /// Plan 89 W3 part 9 — non-zero exit still surfaces all
+2360-        /// streamed lines and a tail bounded by`STDERR_TAIL_LINES`.
+2361-        #[test]
+2362:        fn run_job_streaming_caps_tail_to_stderr_tail_lines() {
+2363-            let dir = tempfile::tempdir().expect("tempdir");
+2364-            let cmd_path = dir.path().join("cmd.sh");
+2365-            // Emit more lines than STDERR_TAIL_LINES (=20) so we
+2366-            // verify the buffer cap, not just streaming.
+2367-            let total = STDERR_TAIL_LINES + 5;
+--
+2394-        /// Plan 89 W3 part 9 — single-shot `run_job`keeps its
+2395-        / pre-streaming semantics: returns the tail without any
+2396-        /// per-line side effect (the streaming variant's callback
+2397-        /// is`|*| {}`).
+2398-        #[test]
+2399:        fn run_job_matches_streaming_for_short_output() {
+2400-            let dir = tempfile::tempdir().expect("tempdir");
+2401-            let cmd_path = dir.path().join("cmd.sh");
+2402-            std::fs::write(&cmd_path, "echo hi >&2\nexit 0\n").expect("write cmd.sh");
+2403-            let (code, tail) = run_job(cmd_path.to_str().unwrap());
+2404-            assert_eq!(code, 0);
+--
+2451-
+2452-        /// Plan 89 W3 part 10 — `run_job_streaming`honors the
+2453-        /// TMPDIR override. cmd.sh echoes the var so we can
+2454-        /// assert the build subprocess saw it.
+2455-        #[test]
+2456:        fn run_job_streaming_threads_tmpdir_through_to_subprocess() {
+2457-            let dir = tempfile::tempdir().expect("tempdir");
+2458-            let cmd_path = dir.path().join("cmd.sh");
+2459-            // The subprocess inherits TMPDIR from its environment;
+2460-            // echo it back via stderr so the test sees it.
+2461-            std::fs::write(&cmd_path, "echo \"tmpdir=$TMPDIR\" >&2\nexit 0\n")
+--
+2475-        /// already had (typically unset inside PID 1). We assert
+2476-        /// the env var is *not* explicitly forced to a value the
+2477-        / test process supplies via`Command::env`, so single-
+2478-        /// shot keeps its pre-part-10 behavior.
+2479-        #[test]
+2480:        fn run_job_streaming_does_not_override_tmpdir_when_none() {
+2481-            let dir = tempfile::tempdir().expect("tempdir");
+2482-            let cmd_path = dir.path().join("cmd.sh");
+2483-            std::fs::write(&cmd_path, "echo \"tmpdir=${TMPDIR-UNSET}\" >&2\nexit 0\n")
+2484-                .expect("write cmd.sh");
+2485-            / SAFETY: this test runs single-threaded in cargo
+--
+2521-        /// CI). The Linux build-VM runs as PID 1 with full caps,
+2522-        /// so the real dispatch path always succeeds; this test
+2523-        /// exercises the wiring on whatever Linux host runs the
+2524-        /// suite.
+2525-        #[test]
+2526:        fn run_job_streaming_unshared_runs_in_fresh_pid_namespace() {
+2527-            use std::process::Stdio;
+2528-            / Fast-path probe: if `unshare --pid --fork --mount
+2529- // --ipc true` fails on this host, skip — the test is
+2530- // exercising correctness of the wiring, not the host's
+2531- // capability set.
+
+**Tool Call: find /Users/auser/work/tinylabs/mvmco/mvm -name "\*.rs" | grep -E "(mvm-libkrun|mvm-cli|mvm-build|mvm-builder-init)" | head -20**
+Status: Completed
+
+Terminal:
+
+```
+/Users/auser/work/tinylabs/mvmco/mvm/crates/mvm-libkrun/build.rs
+/Users/auser/work/tinylabs/mvmco/mvm/crates/mvm-libkrun/examples/libkrun-smoke.rs
+/Users/auser/work/tinylabs/mvmco/mvm/crates/mvm-libkrun/fuzz/fuzz_targets/fuzz_supervisor_config.rs
+/Users/auser/work/tinylabs/mvmco/mvm/crates/mvm-libkrun/src/passt.rs
+/Users/auser/work/tinylabs/mvmco/mvm/crates/mvm-libkrun/src/bin/mvm-libkrun-supervisor.rs
+/Users/auser/work/tinylabs/mvmco/mvm/crates/mvm-libkrun/src/gvproxy.rs
+/Users/auser/work/tinylabs/mvmco/mvm/crates/mvm-libkrun/src/lib.rs
+/Users/auser/work/tinylabs/mvmco/mvm/crates/mvm-libkrun/src/sys.rs
+/Users/auser/work/tinylabs/mvmco/mvm/crates/mvm-guest/src/bin/mvm-builder-agent.rs
+/Users/auser/work/tinylabs/mvmco/mvm/crates/mvm-cli/tests/auto_exec_python_record.rs
+/Users/auser/work/tinylabs/mvmco/mvm/crates/mvm-cli/tests/auto_exec_node_record.rs
+/Users/auser/work/tinylabs/mvmco/mvm/crates/mvm-cli/src/display.rs
+/Users/auser/work/tinylabs/mvmco/mvm/crates/mvm-cli/src/exec.rs
+/Users/auser/work/tinylabs/mvmco/mvm/crates/mvm-cli/src/ui.rs
+/Users/auser/work/tinylabs/mvmco/mvm/crates/mvm-cli/src/lib.rs
+/Users/auser/work/tinylabs/mvmco/mvm/crates/mvm-cli/src/logging.rs
+/Users/auser/work/tinylabs/mvmco/mvm/crates/mvm-cli/src/bootstrap.rs
+/Users/auser/work/tinylabs/mvmco/mvm/crates/mvm-cli/src/update.rs
+/Users/auser/work/tinylabs/mvmco/mvm/crates/mvm-cli/src/config_watcher.rs
+/Users/auser/work/tinylabs/mvmco/mvm/crates/mvm-cli/src/doctor.rs
+```
+
+**Tool Call: grep "cmd\.sh|mvm-guest-agent" crates/mvm-cli/src/commands/env/apple_container.rs**
+Status: Completed
+
+3926-
+3927- // Workspace root for the `/work` virtio-fs share. `find_dev_image_flake()`
+3928- // returns `<workspace>/nix/images/builder`; the workspace itself is
+3929- // three levels up. The dev-shell flake at
+3930- // `nix/images/builder/flake.nix` reads `MVM_WORKSPACE_PATH=/work`
+3931: // (set in the guest's `cmd.sh` by `LibkrunBuilderVm`) under
+3932- // `--impure`, so the flake's `builtins.path` import lands on the
+3933- // mount rather than the store-copied flake dir. Plan 72 W0
+3934- // wired both halves of this.
+3935- let dev_flake = find_dev_image_flake().context(
+3936- "dev-shell flake missing at nix/images/builder/flake.nix; libkrun dispatch needs it as Layer 2 source",
+--
+3941- .and_then(|p| p.parent())
+3942- .ok_or_else(|| anyhow::anyhow!("Cannot derive workspace root from {dev_flake}"))?
+3943- .to_path_buf();
+3944-
+3945- // Inside the guest, `/work` is the workspace mount. The dev-shell
+3946: // flake lives at `/work/nix/images/builder` from the cmd.sh's
+3947- / perspective. `path:` forces Nix's filesystem flake fetcher (not
+3948- // the git fetcher, which would discover `/work/.git` and trip on
+3949- / worktree files whose `gitdir:` redirects point outside the
+3950- // mount).
+3951- let job = BuilderJob::Flake {
+
+**Tool Call: Find `crates/mvm-libkrun/src/*.rs`**
+Status: Completed
+
+crates/mvm-libkrun/src/passt.rs
+crates/mvm-libkrun/src/gvproxy.rs
+crates/mvm-libkrun/src/sys.rs
+crates/mvm-libkrun/src/lib.rs
+
+**Tool Call: Find `/Users/auser/work/tinylabs/mvmco/mvm` `crates/**/Cargo.toml`\*\*
+Status: Completed
+
+crates/mvm-providers/swift/.build/checkouts/swift-protobuf/Sources/protobuf/protobuf/rust/release_crates/Cargo.toml
+crates/mvm-base/Cargo.toml
+crates/mvm-plan/Cargo.toml
+crates/mvm-storage/Cargo.toml
+crates/mvm-mcp/Cargo.toml
+crates/mvm-ir/Cargo.toml
+crates/mvm-policy/Cargo.toml
+crates/mvm-providers/Cargo.toml
+crates/mvm-security/Cargo.toml
+crates/mvm-runner/Cargo.toml
+crates/mvm-sdk-macros/Cargo.toml
+crates/mvm-egress-proxy/Cargo.toml
+crates/mvm-supervisor/Cargo.toml
+crates/mvm/Cargo.toml
+crates/mvm-core/Cargo.toml
+crates/mvm-guest/Cargo.toml
+crates/mvm-backend/Cargo.toml
+crates/mvm-sdk/Cargo.toml
+crates/mvm-oci/fuzz/Cargo.toml
+crates/mvm-addon-vsock-bridge/Cargo.toml
+crates/mvm-addon-dns/Cargo.toml
+crates/mvm-libkrun/Cargo.toml
+crates/mvm-cli/Cargo.toml
+crates/mvm-libkrun/fuzz/Cargo.toml
+crates/mvm-guest/fuzz/Cargo.toml
+crates/mvm-oci/Cargo.toml
+crates/mvm-build/Cargo.toml
+crates/mvm-builder-init/Cargo.toml
+
+**Tool Call: grep "BuilderJob|cmd\.sh|Flake\s\*\{" crates/mvm-libkrun/src/lib.rs**
+Status: Completed
+
+203-/// a symbolic `tag` that the guest mounts via the `virtiofs` filesystem
+204-/// type. libkrun wraps the `virtiofsd` daemon internally — callers
+205-/// declare the share here and libkrun handles the daemon lifecycle.
+206-///
+207-/ Plan 72 W4 uses three of these per builder VM invocation:
+208-///
+209-/// - `tag = "work"` → workspace bind (read-only at the guest mount)
+210-/// - `tag = "out"` → artifact dir (read-write)
+211:/// - `tag = "job"` → per-build job dir with `cmd.sh` / `env` / `result`
+212-///
+213-/// Read/write semantics at the guest are controlled by `mount` flags
+214-/// inside the guest (`mvm-builder-init` mounts each tag with the
+215-/// right flags); libkrun's `krun_add_virtiofs` does not currently
+216-/// expose a `readonly` toggle on the host side.
+217-#[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
+218-pub struct KrunVirtioFs {
+219- /// Symbolic identifier the guest references in `mount -t virtiofs
+
+**Tool Call: grep "nix build|nix-build|BuilderJob::Flake" crates/mvm-cli/src/commands/env/apple_container.rs**
+Status: Completed
+
+761- .with_context(|| format!("removing stale dev-image symlink at {out_dir}"))?;
+762- }
+763- std::fs::create_dir_all(out_dir)
+764- .with_context(|| format!("creating dev-image out dir {out_dir}"))?;
+765- Ok(())
+766-}
+767-
+768-/// Resolve the dev image (kernel + rootfs) to absolute paths.
+769-///
+770-/ In a source checkout: uses the libkrun-backed builder VM
+771:/// (Plan 72 W4/W5 — `LibkrunBuilderVm` runs `nix build` against the
+772-/// dev-shell flake from inside a microVM with a persistent 64 GiB
+773-/// `/nix` store). Libkrun isn't installed → loud error pointing at
+774-/// the install command; **no libkrun fallback for the dev-shell
+775-/// image** (Plan 72 W5.C — the dev-shell rustc closure overflows
+776-/// libkrun's 4 GiB overlay anyway, so a fallback that would
+777-/// just disk-out is worse than an actionable error).
+778-///
+779-/ Outside a source checkout: falls back to the GitHub-release
+780-/// download of a pre-built image.
+781-///
+--
+2039-
+2040-/// Find the dev-image Nix flake directory.
+2041-///
+2042-/// Returns `Ok(path)` only when `nix/images/builder/flake.nix` is present —
+2043-/// that flake is the only one whose `packages.<sys>.default` output
+2044-/// produces the vmlinux + rootfs.ext4 + sidecar shape that
+2045-/ `LibkrunBuilderVm::run_build` extracts from `/out`. The
+2046-/// parent `nix/flake.nix` exposes a library (`lib.mkGuest`) plus an
+2047-/// `internal-minimal-runner` test fixture, neither of which match
+2048-/// that contract — falling back to it earlier yielded a misleading
+2049:/// "double-prefix attribute" `nix build` failure inside the
+2050-/// sandbox. The bail signals `ensure_dev_image` to take the
+2051-/// published-prebuilt download path (W5.1 — hash-verified).
+2052-#[cfg(feature = "builder-vm")]
+2053-fn find_dev_image_flake() -> Result<String> {
+2054- let manifest_dir = env!("CARGO_MANIFEST_DIR");
+2055- let workspace_root = std::path::Path::new(manifest_dir)
+2056- .parent()
+2057- .and_then(|p| p.parent())
+2058- .ok_or_else(|| anyhow::anyhow!("Cannot find workspace root"))?;
+2059-
+--
+3030- use mvm_build::builder_vm::{BuilderJob, BuilderMounts, host_system_linux};
+3031- use mvm_build::libkrun_builder::BuilderVmImage;
+3032-
+3033- let workspace_root = std::path::Path::new(builder_flake_dir)
+3034- .parent()
+3035- .and_then(|p| p.parent())
+3036- .and_then(|p| p.parent())
+3037- .ok_or_else(|| anyhow::anyhow!("Cannot derive workspace root from {builder_flake_dir}"))?
+3038- .to_path_buf();
+3039-
+3040: let job = BuilderJob::Flake {
+3041- flake_ref: "path:/work/nix/images/builder-vm".to_string(),
+3042- attr_path: format!("packages.{}.{attr_name}", host_system_linux()),
+3043- };
+3044- let mounts = BuilderMounts {
+3045- flake_src: workspace_root,
+3046- host_nix_store: None,
+3047- artifact_out: std::path::PathBuf::from(out_dir),
+3048- };
+3049- let bootstrap_image = BuilderVmImage::new(
+3050- bootstrap_kernel,
+--
+3941- .and_then(|p| p.parent())
+3942- .ok_or_else(|| anyhow::anyhow!("Cannot derive workspace root from {dev_flake}"))?
+3943- .to_path_buf();
+3944-
+3945- // Inside the guest, `/work` is the workspace mount. The dev-shell
+3946- // flake lives at `/work/nix/images/builder` from the cmd.sh's
+3947- / perspective. `path:` forces Nix's filesystem flake fetcher (not
+3948- // the git fetcher, which would discover `/work/.git` and trip on
+3949- / worktree files whose `gitdir:` redirects point outside the
+3950- // mount).
+3951: let job = BuilderJob::Flake {
+3952- flake_ref: "path:/work/nix/images/builder".to_string(),
+3953- attr_path: format!("packages.{}.default", host_system_linux()),
+3954- };
+3955- let mounts = BuilderMounts {
+3956- flake_src: workspace_root,
+3957- // libkrun keeps `/nix` on a persistent virtio-blk; no host
+3958- // bind-mount of `/nix/store` is used or wanted (would be a
+3959- // Darwin-x-Linux closure mismatch on macOS anyway).
+3960- host_nix_store: None,
+3961- artifact_out: std::path::PathBuf::from(out_dir),
+--
+4931- let (job, mounts, image) = builder_vm_stage0_bootstrap_plan(
+4932- "/repo/nix/images/builder-vm",
+4933- "/cache/builder-vm/aarch64",
+4934- std::path::PathBuf::from("/dev-cache/vmlinux"),
+4935- std::path::PathBuf::from("/dev-cache/rootfs.ext4"),
+4936- "default",
+4937- )
+4938- .expect("valid builder flake path should produce a plan");
+4939-
+4940- match job {
+4941: mvm_build::builder_vm::BuilderJob::Flake {
+4942- flake_ref,
+4943- attr_path,
+4944- } => {
+4945- assert_eq!(flake_ref, "path:/work/nix/images/builder-vm");
+4946- assert!(
+4947- attr_path == "packages.aarch64-linux.default"
+4948- || attr_path == "packages.x86_64-linux.default",
+4949- "unexpected attr path: {attr_path}"
+4950- );
+4951- }
+--
+4979- let (job, \_mounts, \_image) = builder_vm_stage0_bootstrap_plan(
+4980- "/repo/nix/images/builder-vm",
+4981- "/cache/builder-vm/aarch64",
+4982- std::path::PathBuf::from("/seed/vmlinux"),
+4983- std::path::PathBuf::from("/seed/rootfs.ext4"),
+4984- "stage0-rootfs",
+4985- )
+4986- .expect("valid builder flake path should produce a plan");
+4987-
+4988- match job {
+4989: mvm_build::builder_vm::BuilderJob::Flake { attr_path, .. } => {
+4990- assert!(
+4991- attr_path == "packages.aarch64-linux.stage0-rootfs"
+4992- || attr_path == "packages.x86_64-linux.stage0-rootfs",
+4993- "unexpected attr path: {attr_path}"
+4994- );
+4995- }
+4996- other => panic!("unexpected stage0 job: {other:?}"),
+4997- }
+4998- }
+4999-
+
+**Tool Call: Read crates/mvm-guest/Cargo.toml**
+Status: Completed
+
+```
+1	[package]
+2	name = "mvm-guest"
+3	version.workspace = true
+4	edition.workspace = true
+5	description = "vsock protocol and openclaw connector mapping for mvm"
+6	license.workspace = true
+7	repository.workspace = true
+8	homepage.workspace = true
+9	authors.workspace = true
+10
+11	[[bin]]
+12	name = "mvm-builder-agent"
+13	path = "src/bin/mvm-builder-agent.rs"
+14
+15	[[bin]]
+16	name = "mvm-guest-agent"
+17	path = "src/bin/mvm-guest-agent.rs"
+18
+19	# Exec-shim that compiles a syscall allowlist into a BPF program via
+20	# seccompiler, applies it via prctl, and execve's into the wrapped
+21	# command. mkServiceBlock wraps every guest service launch with this
+22	# shim so per-service seccomp filters are the default. ADR-002 §W2.4.
+23	[[bin]]
+24	name = "mvm-seccomp-apply"
+25	path = "src/bin/mvm-seccomp-apply.rs"
+26
+27	# Early-userspace init (PID 1) that runs from the verity initramfs
+28	# baked by `mkGuest` when `verifiedBoot = true`. Reads the roothash
+29	# from /proc/cmdline, constructs the dm-verity device-mapper target
+30	# via raw ioctls, mounts it, and switch_roots to the real /init.
+31	# Bypasses Firecracker's auto-appended `root=/dev/vda` by owning the
+32	# boot pivot in userspace. ADR-002 §W3.
+33	[[bin]]
+34	name = "mvm-verity-init"
+35	path = "src/bin/mvm-verity-init.rs"
+36
+37	# Plan 74 W2 — guest-side network defense. Installs kernel blackhole
+38	# routes for `MANDATORY_DENY_RANGES` (cloud metadata, link-local,
+39	# CGNAT, host loopback) inside every microVM. Run as root from
+40	# `/init` BEFORE the agent is forked under setpriv, so the routes
+41	# exist before any workload code can attempt egress. Cross-platform
+42	# (Linux kernel routing is uniform across Firecracker, libkrun,
+43	# Apple Container).
+44	[[bin]]
+45	name = "mvm-guest-netinit"
+46	path = "src/bin/mvm-guest-netinit.rs"
+47
+48	# Test-only probe used by `tests/seccomp_apply.rs` to verify that
+49	# tier allowlists actually deny what they claim (ADR-002 §W2.4). Not
+50	# selected by `nix/packages/mvm-guest-agent.nix`, so it never ships
+51	# in the guest closure.
+52	[[bin]]
+53	name = "syscall-probe"
+54	path = "src/bin/syscall-probe.rs"
+55
+56	# Test fixture for the warm-process worker pool (plan 43). Speaks the
+57	# `worker_protocol` framed multi-call loop on stdin/stdout. Behavior
+58	# selectable via `MVM_FAKE_RUNNER_BEHAVIOR` env var so tests can
+59	# exercise crash, recycle, slow, and malformed-frame paths against a
+60	# real child process. Not selected by the production guest closure.
+61	[[bin]]
+62	name = "fake-runner"
+63	path = "tests/bin/fake_runner.rs"
+64	test = false
+65	doctest = false
+66
+67	[features]
+68	dev-shell = []
+69
+70	[dependencies]
+71	mvm-core.workspace = true
+72	mvm-security.workspace = true
+73	anyhow.workspace = true
+74	base64.workspace = true
+75	chrono.workspace = true
+76	ed25519-dalek.workspace = true
+77	libc.workspace = true
+78	rand.workspace = true
+79	serde.workspace = true
+80	serde_json.workspace = true
+81	# Phase 10c — readiness/shutdown hook runner uses thiserror for
+82	# typed error variants (ReadinessError, ShutdownError).
+83	thiserror = "1"
+84	tracing.workspace = true
+85	# Plan 74 W2 — the `netinit` module's trait + types + install
+86	# loop + tests are cross-platform; only `RtnetlinkInstaller`
+87	# itself is Linux-only. Keeping async-trait + ipnet in the main
+88	# deps lets the tests run on macOS dev hosts too.
+89	async-trait.workspace = true
+90	ipnet.workspace = true
+91
+92	# seccompiler builds Linux-only — guests are always Linux microVMs,
+93	# but the workspace also compiles on macOS for CLI development. Gate
+94	# the dep so `cargo check` on a Mac doesn't try to build it.
+95	[target.'cfg(target_os = "linux")'.dependencies]
+96	seccompiler = { workspace = true }
+97	# Plan 74 W2 — `mvm-guest-netinit` uses rtnetlink to install kernel
+98	# blackhole routes for `MANDATORY_DENY_RANGES`. Linux-only because
+99	# rtnetlink talks to AF_NETLINK which doesn't exist elsewhere. The
+100	# host-side mvmctl builds (which include this crate) skip these
+101	# deps on macOS; the binary itself is only relevant in the guest.
+102	rtnetlink = { workspace = true }
+103	tokio = { workspace = true }
+104	# netlink-packet-route is rtnetlink's wire-format types crate. The
+105	# RouteType::BlackHole enum the installer uses comes from here.
+106	netlink-packet-route = "0.19"
+107
+108	[dev-dependencies]
+109	tempfile.workspace = true
+110	# Plan 74 W2 — `netinit` module's tests are async (the
+111	# `RouteInstaller` trait is async). tokio is workspace-shared so
+112	# the extra dev-dep doesn't pull anything new into the lock.
+113	tokio = { workspace = true }
+114
+115	[lints]
+116	workspace = true
+117
+```
+
+**Tool Call: Read crates/mvm-builder-init/Cargo.toml**
+Status: Completed
+
+```
+1	[package]
+2	name = "mvm-builder-init"
+3	version.workspace = true
+4	edition.workspace = true
+5	description = "PID 1 for the libkrun builder VM — mounts /nix, runs /job/cmd.sh, powers off (Plan 72 W3)"
+6	license.workspace = true
+7	repository.workspace = true
+8	homepage.workspace = true
+9	authors.workspace = true
+10
+11	# Linux-only by design — this is the in-VM init for the libkrun
+12	# builder VM (Plan 72 W3). The crate compiles on macOS / Windows
+13	# but produces an inert binary (main() prints a hint and exits 1)
+14	# so workspace builds stay green on developer hosts. mkGuest
+15	# cross-compiles the real binary for `<arch>-unknown-linux-musl`
+16	# from a Linux nix-build environment.
+17
+18	[[bin]]
+19	name = "mvm-builder-init"
+20	path = "src/main.rs"
+21
+22	[target.'cfg(target_os = "linux")'.dependencies]
+23	# Linux mount/reboot syscalls. Kept Linux-only so non-Linux
+24	# workspace builds don't drag in the dep tree.
+25	nix = { version = "0.29", features = ["mount", "reboot", "signal", "ioctl"] }
+26	# libc for SIGTERM / SIGKILL when tearing the egress proxy down
+27	# after the installer exits. Linux-only same as nix above.
+28	libc.workspace = true
+29
+30	[dev-dependencies]
+31	# Test scratch dirs + JSON parsing for assertions against the
+32	# hand-rolled `InstallReport::to_json` output. Production builds
+33	# never see these — they live behind `cfg(test)` only.
+34	tempfile.workspace = true
+35	serde_json.workspace = true
+36	# Plan 89 W2 part 3 — the cross-validation test in
+37	# `dispatch_response::tests::dispatch_response_parses_as_typed_builder_response`
+38	# deserializes our hand-rolled JSON as
+39	# `mvm_build::builder_protocol::BuilderResponse` to pin the two
+40	# wire shapes together. Dev-only; doesn't pull mvm-build into the
+41	# production rootfs.
+42	mvm-build.workspace = true
+43	# Plan 89 W3 part 2 — same rationale: the cross-validation test in
+44	# `builder_request::tests::parses_what_mvm_build_serializes_with_serde`
+45	# constructs typed `mvm_build::builder_protocol::BuilderRequest`
+46	# values via `JobId(Uuid::nil())`. Dev-only.
+47	uuid.workspace = true
+48
+49	[lints]
+50	workspace = true
+51
+52	# Static + tiny per Plan 72 §W3 size budget (≤ 1.5 MiB on
+53	# aarch64-linux). Release profile inherits from workspace; this
+54	# crate doesn't override.
+55
+```
+
+**Tool Call: Read crates/mvm-egress-proxy/Cargo.toml**
+Status: Completed
+
+```
+1	[package]
+2	name = "mvm-egress-proxy"
+3	version.workspace = true
+4	edition.workspace = true
+5	description = "HTTP CONNECT proxy with hostname allowlist for builder-VM egress (Plan 73 Followup B.2.x, ADR-047)"
+6	license.workspace = true
+7	repository.workspace = true
+8	homepage.workspace = true
+9	authors.workspace = true
+10
+11	# This is a Linux-only binary in production — it runs inside the
+12	# libkrun builder VM as the only legal egress path during the
+13	# application-deps install. On macOS / Windows the binary still
+14	# compiles (workspace ergonomics for contributors) but `main()`
+15	# prints a hint and exits 1, mirroring `mvm-builder-init`. The
+16	# allowlist + CONNECT-parser modules are pure-Rust and cross-
+17	# platform so `cargo test` exercises them on every developer host.
+18	#
+19	# No tokio: a CONNECT proxy is one thread per accepted socket
+20	# (`std::net::TcpListener` + `std::thread::spawn`), so we save
+21	# the ~3 MiB closure tokio drags in. mvm-builder-init's size
+22	# budget cares about the init binary, not this one — but keeping
+23	# the proxy slim too means a `nix build` of the builder VM
+24	# rootfs doesn't balloon either.
+25
+26	[[bin]]
+27	name = "mvm-egress-proxy"
+28	path = "src/main.rs"
+29
+30	[lib]
+31	name = "mvm_egress_proxy"
+32	path = "src/lib.rs"
+33
+34	[features]
+35	# Off by default. Tests + dev workflows enable it to point the
+36	# proxy at a test allowlist via `MVM_EGRESS_ALLOWLIST=host1,host2`.
+37	# Production binaries (built without features) ship the four
+38	# ADR-047 hostnames hard-coded — no env-var override at all.
+39	dev-shell = []
+40
+41	[target.'cfg(target_os = "linux")'.dependencies]
+42	# Signal handling for SIGTERM-driven shutdown. Linux-only because
+43	# the binary's main loop only compiles on Linux.
+44	libc.workspace = true
+45
+46	[lints]
+47	workspace = true
+48
+49	[dev-dependencies]
+50	tempfile.workspace = true
+51
+```
+
+**Tool Call: Find `/Users/auser/work/tinylabs/mvmco/mvm` `nix/packages/mvm-builder-init.nix`**
+Status: Completed
+
+No files found
+
+**Tool Call: grep | head -150 "write.*cmd\.sh|export.*NIX|--option|build-users-group|nix build" crates/mvm-libkrun/src/lib.rs**
+Status: Completed
+
+No matches found
+
+**Tool Call: Find `/Users/auser/work/tinylabs/mvmco/mvm` `nix/packages/*.nix`**
+Status: Completed
+
+nix/packages/mvm-guest-agent.nix
+nix/packages/mvm-addon-dns.nix
+
+**Tool Call: Read crates/mvm-builder-init/src/builder_request.rs (1 - 100)**
+Status: Completed
+
+````
+1	//! Plan 89 W3 part 2 — hand-rolled parser for `BuilderRequest`
+2	//! JSON, the wire-format the persistent builder VM's dispatch loop
+3	//! reads off vsock.
+4	//!
+5	//! Mirror of `mvm_build::builder_protocol::BuilderRequest` on the
+6	//! host side. Cross-platform on purpose — the parser sees coverage
+7	//! from `cargo test` on every developer host so the wire shape
+8	//! stays in lock-step with the host's serde-derived encoding
+9	//! without depending on a Linux cross-compile.
+10	//!
+11	//! ## Why hand-roll
+12	//!
+13	//! Same rationale as [`crate::install_spec`] and
+14	//! [`crate::dispatch_response`]: the Plan 72 §W3 size budget caps
+15	//! the static-linked init at ≤ 1.5 MiB, so we don't pull
+16	//! `serde_json` for the handful of wire shapes the dispatch loop
+17	//! reads. The wire shape is closed (two variants, three optional
+18	//! field clusters) and the
+19	//! `parses_what_mvm_build_serializes_with_serde` test pins our
+20	//! parser against the host's typed `serde_json::to_vec` output.
+21	//!
+22	//! ## Wire shape
+23	//!
+24	//! Internally-tagged enum encoding (`#[serde(tag = "kind", rename_all
+25	//! = "snake_case")]`) on the host side. Two variants:
+26	//!
+27	//! ```json
+28	//! {
+29	//!   "kind": "run",
+30	//!   "job_id": "00000000-0000-0000-0000-000000000000",
+31	//!   "job": { "Flake": { "flake_ref": "...", "attr_path": "..." } },
+32	//!   "job_dir_relpath": "..."
+33	//! }
+34	//! ```
+35	//!
+36	//! …or with the install variant:
+37	//!
+38	//! ```json
+39	//! { "kind": "run", "job_id": "...",
+40	//!   "job": { "Install": { "spec_path": "..." } },
+41	//!   "job_dir_relpath": "..." }
+42	//! ```
+43	//!
+44	//! …or:
+45	//!
+46	//! ```json
+47	//! { "kind": "shutdown" }
+48	//! ```
+49	//!
+50	//! `BuilderJob` uses serde's default external tagging on the host
+51	//! side (no `#[serde(tag = "...")]`), which yields the
+52	//! `{"Flake": {...}}` / `{"Install": {...}}` nesting above. This
+53	//! parser walks that exact shape.
+54
+55	use std::fmt;
+56
+57	/// In-guest mirror of `mvm_build::builder_vm::BuilderJob`.
+58	#[derive(Debug, Clone, PartialEq, Eq)]
+59	pub enum BuilderJob {
+60	    Flake {
+61	        flake_ref: String,
+62	        attr_path: String,
+63	    },
+64	    Install {
+65	        spec_path: String,
+66	    },
+67	}
+68
+69	/// In-guest mirror of `mvm_build::builder_protocol::BuilderRequest`.
+70	#[derive(Debug, Clone, PartialEq, Eq)]
+71	pub enum BuilderRequest {
+72	    Run {
+73	        job_id: String,
+74	        job: BuilderJob,
+75	        job_dir_relpath: String,
+76	    },
+77	    Shutdown,
+78	}
+79
+80	#[derive(Debug)]
+81	pub enum ParseError {
+82	    /// Body wasn't valid UTF-8.
+83	    NotUtf8(std::str::Utf8Error),
+84	    /// Couldn't find the `"kind"` discriminator.
+85	    MissingKind,
+86	    /// `"kind"` was present but neither `"run"` nor `"shutdown"`.
+87	    UnknownKind(String),
+88	    /// `BuilderRequest::Run` was missing a required field.
+89	    MissingRunField(&'static str),
+90	    /// `Run.job` had neither `"Flake"` nor `"Install"`.
+91	    UnknownJobVariant,
+92	    /// `Run.job.<variant>` was missing a required field.
+93	    MissingJobField(&'static str),
+94	}
+95
+96	impl fmt::Display for ParseError {
+97	    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+98	        match self {
+99	            Self::NotUtf8(e) => write!(f, "BuilderRequest body not UTF-8: {e}"),
+100	            Self::MissingKind => write!(f, "BuilderRequest missing `kind` discriminator"),
+````
+
+**Tool Call: grep | head -80 "job_dir|staging|prepare|cmd.sh" crates/mvm-libkrun/src/lib.rs**
+Status: Completed
+
+206-///
+207-/ Plan 72 W4 uses three of these per builder VM invocation:
+208-///
+209-/// - `tag = "work"` → workspace bind (read-only at the guest mount)
+210-/// - `tag = "out"` → artifact dir (read-write)
+211:/// - `tag = "job"` → per-build job dir with `cmd.sh` / `env` / `result`
+212-///
+213-/// Read/write semantics at the guest are controlled by `mount` flags
+214-/// inside the guest (`mvm-builder-init` mounts each tag with the
+215-/// right flags); libkrun's `krun_add_virtiofs` does not currently
+216-/// expose a `readonly` toggle on the host side.
+
+**Tool Call: grep -r "cmd\.sh" /Users/auser/work/tinylabs/mvmco/mvm/crates/mvm-libkrun --include="\*.rs" | head -20**
+Status: Completed
+
+Terminal:
+
+```
+/Users/auser/work/tinylabs/mvmco/mvm/crates/mvm-libkrun/src/lib.rs:/// - `tag = "job"`   → per-build job dir with `cmd.sh` / `env` / `result`
+
+
+
+
+```
+
+**Tool Call: Read nix/flake.nix (1 - 200)**
+Status: Completed
+
+```
+1	{
+2	  description = "mvm — microVM library built on microvm.nix (plan 60).";
+3
+4	  # ── This flake is a LIBRARY, not a project ───────────────────────────
+5	  #
+6	  # User projects have their OWN `flake.nix` + `mvm.toml`. Their flake
+7	  # imports `mvm` as an input and consumes the library helpers we
+8	  # expose under `lib.<system>.mkGuest` to declare a microVM image.
+9	  # `mvmctl build` reads the user's `mvm.toml`, follows the `flake`
+10	  # field to their flake.nix, and runs `nix build` against it. Users
+11	  # never edit anything inside this repository.
+12	  #
+13	  # User-side example (lives in *their* project):
+14	  #
+15	  #   # my-app/flake.nix
+16	  #   {
+17	  #     inputs.mvm.url = "github:tinylabscom/mvm";
+18	  #     outputs = { self, mvm, ... }: {
+19	  #       packages.x86_64-linux.default = mvm.lib.x86_64-linux.mkGuest {
+20	  #         name = "my-app";
+21	  #         services.web = {
+22	  #           command = [ "/usr/local/bin/web" ];
+23	  #         };
+24	  #       };
+25	  #     };
+26	  #   }
+27	  #
+28	  #   # my-app/mvm.toml
+29	  #   flake = "."
+30	  #   profile = "default"
+31	  #   vcpus = 1
+32	  #   memory_mib = 256
+33	  #
+34	  # The `mkGuest` library is being ported from the previous iteration
+35	  # in a follow-up wave (Phase 1 W5+); it composes microvm.nix's
+36	  # NixOS module with mvm's security overlay (per-service uids,
+37	  # seccomp tier, dm-verity, read-only `/etc`). The `lib` attribute
+38	  # below is the placeholder that future user flakes will consume.
+39	  #
+40	  # ── Why microvm.nix (ADR-013) ────────────────────────────────────────
+41	  #
+42	  # microvm.nix abstracts Firecracker, Cloud Hypervisor, QEMU, crosvm,
+43	  # kvmtool, and stratovirt as a NixOS module — so adding a hypervisor
+44	  # is a config change here, not a kernel rewrite. Pinned by hash in
+45	  # flake.lock; CI re-audits on every bump (`xtask audit-flake`).
+46	  #
+47	  # Fallback (named in ADR-013): if a per-bump audit of microvm.nix
+48	  # surfaces a security regression we can't accept, revert to the
+49	  # previous iteration's hand-rolled `nix/` tree at `../mvm/nix/`.
+50	  #
+51	  # ── nixosConfigurations.minimal ──────────────────────────────────────
+52	  #
+53	  # The `minimal` configuration below is **internal** — it's the test
+54	  # fixture our Rust smoke tests use to exercise the build/exec path
+55	  # (`tests/nix_flake_structure.rs`, `tests/smoke_libkrun.rs`).
+56	  # It is NOT a starter template for user projects. Users should
+57	  # write their own flake using `lib.mkGuest`; the minimal profile
+58	  # exists so we can boot something in CI without depending on a
+59	  # user-side fixture.
+60
+61	  inputs = {
+62	    nixpkgs.url = "github:NixOS/nixpkgs/nixos-25.11";
+63
+64	    # microvm.nix — the foundation. MIT-licensed; pinned by hash in
+65	    # flake.lock; CI re-audits on every bump (xtask audit-flake).
+66	    microvm = {
+67	      url = "github:microvm-nix/microvm.nix";
+68	      inputs.nixpkgs.follows = "nixpkgs";
+69	    };
+70
+71	    # Workspace root — the Rust crates live one level up from this
+72	    # flake. `mvm-guest-agent.nix` reads `Cargo.lock` from `mvmSrc`,
+73	    # so `mvmSrc = self` was wrong: `self` is the `nix/` subtree of
+74	    # the repo, which doesn't contain `Cargo.lock`. Explicit
+75	    # `path:..` + `flake = false` stages the whole workspace into
+76	    # the store so cargo can see the lockfile and the crates.
+77	    mvm-workspace = {
+78	      url = "path:..";
+79	      flake = false;
+80	    };
+81	  };
+82
+83	  outputs =
+84	    { self
+85	    , nixpkgs
+86	    , microvm
+87	    , mvm-workspace
+88	    , ...
+89	    }:
+90	    let
+91	      systems = [
+92	        # microVM images build only on Linux — no macOS/Darwin output.
+93	        # Cross-builds from macOS need a Linux builder (linux-builder
+94	        # via nix-darwin, or remote nix-daemon). Documented in
+95	        # `specs/runbooks/cross-platform-install.md` (Phase 5).
+96	        "x86_64-linux"
+97	        "aarch64-linux"
+98	      ];
+99
+100	      # Helper: construct a NixOS configuration for the named profile.
+101	      mkProfile = system: profileName: nixpkgs.lib.nixosSystem {
+102	        inherit system;
+103	        modules = [
+104	          microvm.nixosModules.microvm
+105	          (./profiles + "/${profileName}.nix")
+106	        ];
+107	      };
+108
+109	      forAllSystems = nixpkgs.lib.genAttrs systems;
+110
+111	      # ── Library output (USER-FACING) ─────────────────────────────
+112	      #
+113	      # User flakes consume this as `inputs.mvm.lib.<system>.mkGuest`
+114	      # to declare a microVM image. Implementation lives under
+115	      # `./lib/`; the entry point is `./lib/default.nix`.
+116	      # Pass the `mvm-workspace` flake input (the workspace root,
+117	      # one level up from this flake) as `mvmSrc` so
+118	      # `nix/packages/mvm-guest-agent.nix` can resolve
+119	      # `${mvmSrc}/Cargo.lock` — that lockfile is at the workspace
+120	      # root, not under `nix/`, so `mvmSrc = self` (the historical
+121	      # value) failed `nix build` with "Path 'nix/Cargo.lock' does
+122	      # not exist". The flake-input form preserves purity: nix
+123	      # stages the workspace into the store as a regular input
+124	      # snapshot.
+125	      libFor = import ./lib { inherit nixpkgs microvm; mvmSrc = mvm-workspace; };
+126	    in
+127	    {
+128	      # ── User-facing: lib.<system>.mkGuest ────────────────────────
+129	      #
+130	      # User flakes import this as `inputs.mvm.lib.<system>.mkGuest`
+131	      # to declare a microVM image. The shape is intentionally stable
+132	      # so user flakes don't churn when the implementation evolves.
+133	      lib = forAllSystems (system: libFor { inherit system; });
+134
+135	      # ── Internal: nixosConfigurations.minimal ────────────────────
+136	      #
+137	      # Test fixture for our smoke tests (`tests/smoke_libkrun.rs`,
+138	      # `tests/nix_flake_structure.rs`). NOT a starter template —
+139	      # users write their own flake. The `internal` namespace makes
+140	      # the boundary unambiguous so CI lints can grep for it.
+141	      nixosConfigurations.internal-minimal-x86_64-linux =
+142	        mkProfile "x86_64-linux" "minimal";
+143	      nixosConfigurations.internal-minimal-aarch64-linux =
+144	        mkProfile "aarch64-linux" "minimal";
+145
+146	      # Top-level package output mirroring the internal fixture so
+147	      # `nix build .#internal-minimal-runner` works on Linux CI
+148	      # runners. Same INTERNAL boundary — not consumed by user
+149	      # flakes; if you find yourself running this command, you're
+150	      # working on mvm itself, not a user project.
+151	      packages = forAllSystems (system: {
+152	        internal-minimal-runner =
+153	          (mkProfile system "minimal").config.microvm.declaredRunner;
+154	      });
+155	    };
+156	}
+157
+```
+
+**Tool Call: Read nix/images/builder-vm/flake.nix (1 - 200)**
+Status: Completed
+
+```
+1	{
+2	  description = "mvm builder VM image — kernel + rootfs.ext4 with Nix + tools + mvm-builder-init (Plan 72 W2)";
+3
+4	  # ── Why this flake exists ────────────────────────────────────────────
+5	  #
+6	  # Plan 72 (ADR-046) replaces the libkrun-backed builder VM
+7	  # (`nix/images/builder/`, which is actually the dev-shell image
+8	  # despite the name) with a libkrun-direct launcher
+9	  # (`LibkrunBuilderVm`, Plan 72 W1). This flake is the artifact
+10	  # `LibkrunBuilderVm` boots into: a small Linux kernel + ext4
+11	  # rootfs containing Nix + a curated build-tools subset +
+12	  # `mvm-builder-init` (Plan 72 W3) at `/sbin/mvm-builder-init`.
+13	  #
+14	  # `packages.<system>.default` produces `$out/{vmlinux,rootfs.ext4,
+15	  # cmdline.txt,manifest.json}`. CI (Plan 72 W2 release-workflow
+16	  # follow-up) uploads these as `builder-vmlinux-<arch>` and
+17	  # `builder-rootfs-<arch>.ext4` alongside the existing dev-image
+18	  # outputs.
+19	  #
+20	  # Distinct from `nix/images/builder/flake.nix` which produces the
+21	  # dev-shell image (`mvm-dev`) — the rootfs a user `dev shell`s
+22	  # into. The names will reshuffle in Plan 72 W6 hygiene; for now
+23	  # the two flakes coexist and `mvmctl dev up` will pick the right
+24	  # one via `find_builder_vm_flake` / `find_dev_image_flake`.
+25	  #
+26	  # ── Architecture / workspace staging ──────────────────────────────
+27	  #
+28	  # Identical pattern to `nix/images/builder/flake.nix`:
+29	  #
+30	  # - Stage the workspace via `builtins.path` (filter out `target/`,
+31	  #   `.git/`, etc.) so the flake works both on a host running
+32	  #   `nix build` directly and inside the libkrun builder VM's
+33	  #   `path:` URL fetch (W4).
+34	  # - `MVM_WORKSPACE_PATH` env var override for the sandbox case
+35	  #   (avoids the `../../..` resolution-against-store-copy trap
+36	  #   that bit `nix/images/builder/flake.nix` in Plan 72 W0).
+37	  # - Import the parent flake's `nix/lib/` directly (skip flake-
+38	  #   input chain → no path-input lock validation issue).
+39	  #
+40	  # ── Builder VM package set ────────────────────────────────────────
+41	  #
+42	  # Per Plan 72 §W2, narrower than the dev-shell image:
+43	  #
+44	  # - Static busybox (provides `/bin/sh`, `udhcpc`, `sync`, basic
+45	  #   POSIX utilities — small footprint).
+46	  # - Nix (the whole point of the VM).
+47	  # - Bash + coreutils + gnugrep / gnused / gawk / findutils / which
+48	  #   (user's `cmd.sh` is shell, not necessarily POSIX-only).
+49	  # - Git + gnumake + curl + jq (Nix flakes pull from git, builds
+50	  #   often run make / curl, `cmd.sh` may format JSON).
+51	  # - e2fsprogs (`mkfs.ext4` for the first-boot format of the
+52	  #   persistent `/nix` store) + util-linux (`mount`, `umount`,
+53	  #   `losetup`).
+54	  # - iproute2 (used by `udhcpc` and friends; small).
+55	  # - iptables — Plan 73 Followup B.2.y / ADR-047 defense-in-
+56	  #   depth: `mvm-builder-init` installs an OUTPUT-chain
+57	  #   default-deny + uid-owner ACCEPT for `mvm-egress-proxy`
+58	  #   (uid 1801), so a build step that ignores `HTTP_PROXY`
+59	  #   cannot reach upstream. See
+60	  #   `crates/mvm-builder-init/src/network.rs`.
+61	  # - **No** `procps`-interactive / `less` per the plan's
+62	  #   slimming directive.
+63	  # - `mvm-builder-init` mounted at `/sbin/mvm-builder-init` via
+64	  #   `extraFiles`. The kernel cmdline (`cmdline.txt` output)
+65	  #   sets `init=/sbin/mvm-builder-init` so this becomes PID 1.
+66
+67	  inputs = {
+68	    nixpkgs.url = "github:NixOS/nixpkgs/nixos-25.11";
+69	    microvm = {
+70	      url = "github:microvm-nix/microvm.nix";
+71	      inputs.nixpkgs.follows = "nixpkgs";
+72	    };
+73	  };
+74
+75	  outputs =
+76	    { self, nixpkgs, microvm, ... }:
+77	    let
+78	      systems = [ "aarch64-linux" "x86_64-linux" ];
+79	      forAllSystems = nixpkgs.lib.genAttrs systems;
+80
+81	      workspaceRoot =
+82	        let
+83	          envPath = builtins.getEnv "MVM_WORKSPACE_PATH";
+84	        in
+85	        if envPath != "" then /. + envPath else ../../..;
+86
+87	      workspace = builtins.path {
+88	        path = workspaceRoot;
+89	        name = "mvm-workspace";
+90	        filter =
+91	          path: _type:
+92	          let
+93	            base = baseNameOf path;
+94	          in
+95	          !(builtins.elem base [
+96	            "target"
+97	            ".git"
+98	            "result"
+99	            "node_modules"
+100	            ".direnv"
+101	            ".cargo"
+102	            ".claude"
+103	            ".worktrees"
+104	          ])
+105	          && !(nixpkgs.lib.hasPrefix "result-" base);
+106	      };
+107
+108	      libFor = import (workspace + "/nix/lib") {
+109	        inherit nixpkgs microvm;
+110	        mvmSrc = workspace;
+111	      };
+112
+113	      # ADR-050 / issue #223 — veritysetup sidecar bytes must not drift
+114	      # when nixpkgs revs. The OCI-pull path runs `veritysetup format`
+115	      # inside this builder VM, while the Nix-built baseline runs it in
+116	      # `nix/images/runtime-overlay/flake.nix`. Both flakes intentionally
+117	      # pin the same cryptsetup release + tarball hash, and both must be
+118	      # reviewed together on bump.
+119	      pinnedCryptsetupVersion = "2.8.6";
+120	      pinnedCryptsetupSrcHash = "sha256-gAQmX9mTiF0I97Yz2+BWhR3hohAwdhOk693HQ/zO/lo=";
+121	      pinnedCryptsetupFor = pkgs:
+122	        pkgs.cryptsetup.overrideAttrs (_old: {
+123	          version = pinnedCryptsetupVersion;
+124	          src = pkgs.fetchurl {
+125	            url =
+126	              "mirror://kernel/linux/utils/cryptsetup/v${pkgs.lib.versions.majorMinor pinnedCryptsetupVersion}/"
+127	              + "cryptsetup-${pinnedCryptsetupVersion}.tar.xz";
+128	            hash = pinnedCryptsetupSrcHash;
+129	          };
+130	        });
+131
+132	      # Per Plan 72 §W2 — narrower than the dev-shell image.
+133	      # See module-level docs above for the rationale on each.
+134	      #
+135	      # Plan 73 Followup B.2 adds the application-dependency
+136	      # install pipeline (ADR-047): `uv` / `pnpm` drive the
+137	      # installer, `cyclonedx-py` / `pnpm sbom` emit SBOMs, and
+138	      # `pip-audit` / `pnpm audit` run the CVE scan. Each is
+139	      # currently a soft gate — `mvm-builder-init::install`
+140	      # emits a CycloneDX-1.5 empty stub when the SBOM / CVE
+141	      # tool isn't on PATH and logs a warning. B.2.x will
+142	      # hard-gate the SBOM + CVE side once the egress allowlist
+143	      # lands.
+144	      #
+145	      # Plan 73 Followup B.2.x closed the egress side: the
+146	      # builder VM now runs `mvm-egress-proxy` (built via
+147	      # `mvmEgressProxyFor system`, installed at
+148	      # `/sbin/mvm-egress-proxy` via `extraFiles` below).
+149	      # `mvm-builder-init::install::run_install` spawns it
+150	      # before the installer + injects `HTTPS_PROXY` /
+151	      # `HTTP_PROXY` on `uv` / `pnpm`'s env. The proxy refuses
+152	      # anything outside ADR-047's four hostnames:
+153	      # `pypi.org`, `files.pythonhosted.org`,
+154	      # `registry.npmjs.org`, `objects.githubusercontent.com`.
+155	      # Complementary iptables drop-rule defense-in-depth is
+156	      # B.2.y (not in this slice).
+157	      builderPackages = pkgs: with pkgs; [
+158	        bashInteractive
+159	        coreutils
+160	        # `pkgsStatic.busybox` for the lightweight utilities that
+161	        # mvm-builder-init spawns by absolute path — chiefly
+162	        # `/sbin/udhcpc` (busybox applet) for DHCP on the builder
+163	        # VM's eth0. Without busybox in `packages`, mkGuest's
+164	        # symlink loop (nix/lib/mk-guest.nix:770-788) skips it
+165	        # and `/sbin/udhcpc` doesn't exist → setup_network bails.
+166	        pkgsStatic.busybox
+167	        gnugrep
+168	        gnused
+169	        gawk
+170	        findutils
+171	        which
+172	        nix
+173	        git
+174	        gnumake
+175	        curl
+176	        jq
+177	        iproute2
+178	        # iptables — installed at boot by mvm-builder-init's
+179	        # network::install_egress_lockdown (Plan 73 Followup
+180	        # B.2.y / ADR-047). FATAL if absent.
+181	        iptables
+182	        e2fsprogs
+183	        util-linux
+184	        (pinnedCryptsetupFor pkgs) # provides pinned veritysetup
+185	        # Plan 73 Followup B.2 — app-deps install pipeline.
+186	        uv
+187	        pnpm
+188	        # NOTE (Plan 72 W5.D unblock): `python3Packages.cyclonedx-bom`
+189	        # and `python3Packages.pip-audit` are referenced here but not
+190	        # present in nixpkgs-25.11 under those exact attribute names;
+191	        # the Stage 0 nix eval bails with "attribute 'cyclonedx-bom'
+192	        # missing". Commented out until the right attribute name (or
+193	        # a newer nixpkgs pin that has them) lands. Plan 73's
+194	        # deps-volume audit pipeline still works at runtime via the
+195	        # `mvm-egress-proxy` allowlist; the SBOM/CVE tools were a
+196	        # nice-to-have inside the builder VM, not a load-bearing
+197	        # blocker for `mvmctl dev up`.
+198	        # python3Packages.cyclonedx-bom
+199	        # python3Packages.pip-audit
+200	      ];
+```
+
+**Tool Call: Read nix/images/builder-vm/flake.nix (200 - 449)**
+Status: Completed
+
+```
+200	      ];
+201
+202	      # Build `mvm-builder-init` (Plan 72 W3) for the target system.
+203	      # `rustPlatform.buildRustPackage` consumes the workspace's
+204	      # `Cargo.lock` so the dependency closure matches the rest of
+205	      # the workspace — same `nix` crate version we cargo-check on
+206	      # macOS, same nothing-else.
+207	      #
+208	      # `doCheck = false` because the unit tests under
+209	      # `mvm-builder-init::linux::tests` already run in the
+210	      # workspace's `cargo test` CI lane; running them again here
+211	      # would double-pay the closure compute for no extra signal.
+212	      mvmBuilderInitFor = system:
+213	        let
+214	          pkgs = import nixpkgs { inherit system; };
+215	        in
+216	        pkgs.rustPlatform.buildRustPackage {
+217	          pname = "mvm-builder-init";
+218	          version = "0.14.0";
+219	          src = workspace;
+220	          cargoLock = {
+221	            lockFile = workspace + "/Cargo.lock";
+222	          };
+223	          buildAndTestSubdir = "crates/mvm-builder-init";
+224	          doCheck = false;
+225	          meta = {
+226	            description = "PID-1 for the libkrun builder VM (Plan 72 W3)";
+227	            mainProgram = "mvm-builder-init";
+228	          };
+229	        };
+230
+231	      # Build `mvm-egress-proxy` (Plan 73 Followup B.2.x) for the
+232	      # target system. Same `rustPlatform.buildRustPackage` shape
+233	      # as `mvm-builder-init` — the workspace's `Cargo.lock`
+234	      # drives the closure so we don't fork dep versions across
+235	      # the two builder-VM binaries. Tests run in CI's
+236	      # `cargo test --workspace` lane; `doCheck = false` here for
+237	      # the same reason.
+238	      mvmEgressProxyFor = system:
+239	        let
+240	          pkgs = import nixpkgs { inherit system; };
+241	        in
+242	        pkgs.rustPlatform.buildRustPackage {
+243	          pname = "mvm-egress-proxy";
+244	          version = "0.14.0";
+245	          src = workspace;
+246	          cargoLock = {
+247	            lockFile = workspace + "/Cargo.lock";
+248	          };
+249	          buildAndTestSubdir = "crates/mvm-egress-proxy";
+250	          doCheck = false;
+251	          meta = {
+252	            description = "Builder-VM egress allowlist proxy (Plan 73 Followup B.2.x, ADR-047)";
+253	            mainProgram = "mvm-egress-proxy";
+254	          };
+255	        };
+256
+257	      # Canonical kernel cmdline for the builder VM. `LibkrunBuilderVm`
+258	      # (Plan 72 W4) reads this from the cmdline.txt output and
+259	      # passes it to `mvm_libkrun::KrunContext.kernel_cmdline`.
+260	      #
+261	      # - `console=hvc0` — libkrun's virtio-console (no serial).
+262	      # - `root=/dev/vda` — rootfs.ext4 attached as virtio-blk.
+263	      # - `ro` — root is read-only; writes go to the persistent
+264	      #   /nix-store virtio-blk at /dev/vdb (Plan 72 W4 wires it).
+265	      # - `rootfstype=ext4` — skip filesystem auto-detection.
+266	      # - `init=/sbin/mvm-builder-init` — Plan 72 W3 binary as PID 1.
+267	      builderCmdline = "console=hvc0 root=/dev/vda ro rootfstype=ext4 init=/sbin/mvm-builder-init";
+268
+269	      # Rootfs builder. The custom kernel under `./kernel` is built
+270	      # `CONFIG_MODULES=n` (everything in-tree is `=y`), so the
+271	      # rootfs ships no `/lib/modules/<kver>/` tree and mkGuest's
+272	      # kernel arg goes unused — same rootfs whether we're producing
+273	      # the full builder-VM image or the Stage 0 seed.
+274	      # Plan 92 — `specs/plans/92-minimal-builder-vm-kernel.md`.
+275	      mkBuilderVmRootfs =
+276	        system:
+277	        let
+278	          pkgs = import nixpkgs { inherit system; };
+279	          builderInit = mvmBuilderInitFor system;
+280	          egressProxy = mvmEgressProxyFor system;
+281	        in
+282	        (libFor { inherit system; }).mkGuest {
+283	          name = "mvm-builder-vm";
+284	          # mkGuest requires an entrypoint declaration. At runtime
+285	          # the kernel cmdline sets `init=/sbin/mvm-builder-init`,
+286	          # so mkGuest's entrypoint is vestigial — but we still
+287	          # need to declare one to satisfy the type contract.
+288	          entrypoint.shell = "/bin/sh";
+289	          packages = builderPackages pkgs;
+290	          extraFiles = {
+291	            "/sbin/mvm-builder-init" =
+292	              "${builderInit}/bin/mvm-builder-init";
+293	            # Plan 73 Followup B.2.x — egress allowlist proxy.
+294	            # `mvm-builder-init::install::run_install` spawns
+295	            # this from PATH (kernel default PATH includes
+296	            # `/sbin`) before invoking `uv` / `pnpm`. The
+297	            # binary embeds the ADR-047 four-hostname list at
+298	            # compile time; no env-var override path on the
+299	            # production build.
+300	            "/sbin/mvm-egress-proxy" =
+301	              "${egressProxy}/bin/mvm-egress-proxy";
+302	          };
+303	        };
+304
+305	      mkBuilderVmImage = system:
+306	        let
+307	          pkgs = import nixpkgs { inherit system; };
+308	          builderInit = mvmBuilderInitFor system;
+309	          egressProxy = mvmEgressProxyFor system;
+310	          # Slim custom kernel — see `./kernel/default.nix`.
+311	          # `pkgs.linuxManualConfig` over `make tinyconfig` + a
+312	          # narrow `enables` list. `CONFIG_MODULES=n` so the kernel
+313	          # has only what `mvm-builder-init` actually uses built-in
+314	          # — no driver modules tree to ship.
+315	          # Plan 92 — `specs/plans/92-minimal-builder-vm-kernel.md`.
+316	          kernelPkg = import ./kernel { inherit pkgs; };
+317	          rootfs = mkBuilderVmRootfs system;
+318	          kernelFile =
+319	            if pkgs.stdenv.hostPlatform.isAarch64 then "Image" else "bzImage";
+320	        in
+321	        pkgs.runCommand "mvm-builder-vm-image-${system}"
+322	          {
+323	            passthru = {
+324	              inherit rootfs builderInit egressProxy;
+325	              kernel = kernelPkg;
+326	              cmdline = builderCmdline;
+327	            };
+328	          }
+329	          ''
+330	            mkdir -p $out
+331
+332	            # Kernel.
+333	            if [ -f ${kernelPkg}/${kernelFile} ]; then
+334	              cp ${kernelPkg}/${kernelFile} $out/vmlinux
+335	            elif [ -f ${kernelPkg}/Image ]; then
+336	              cp ${kernelPkg}/Image $out/vmlinux
+337	            elif [ -f ${kernelPkg}/bzImage ]; then
+338	              cp ${kernelPkg}/bzImage $out/vmlinux
+339	            else
+340	              echo "kernel package ${kernelPkg} did not produce Image or bzImage" >&2
+341	              ls -la ${kernelPkg} >&2
+342	              exit 1
+343	            fi
+344
+345	            # Rootfs.
+346	            if [ -f ${rootfs} ]; then
+347	              cp ${rootfs} $out/rootfs.ext4
+348	            else
+349	              img=$(find ${rootfs} -maxdepth 1 -name '*.img' -o -name '*.ext4' | head -1)
+350	              if [ -z "$img" ]; then
+351	                echo "mkGuest output at ${rootfs} contains no .img or .ext4 file" >&2
+352	                ls -la ${rootfs} >&2
+353	                exit 1
+354	              fi
+355	              cp "$img" $out/rootfs.ext4
+356	            fi
+357
+358	            chmod 0644 $out/vmlinux $out/rootfs.ext4
+359
+360	            # Canonical kernel cmdline — Plan 72 W4's
+361	            # `LibkrunBuilderVm` reads this and threads it into
+362	            # `mvm_libkrun::KrunContext.kernel_cmdline`. Living next
+363	            # to the kernel makes the binding atomic with the image.
+364	            echo "${builderCmdline}" > $out/cmdline.txt
+365
+366	            # SHA-256 + size manifest, sister to the dev-image's
+367	            # release-artifact pattern. `download_builder_vm_image`
+368	            # (Plan 72 W5) verifies these against the release
+369	            # manifest before extracting.
+370	            kernel_sha=$(sha256sum $out/vmlinux | cut -d' ' -f1)
+371	            rootfs_sha=$(sha256sum $out/rootfs.ext4 | cut -d' ' -f1)
+372	            kernel_size=$(stat -c%s $out/vmlinux)
+373	            rootfs_size=$(stat -c%s $out/rootfs.ext4)
+374	            cat > $out/manifest.json <<MANIFEST
+375	            {
+376	              "name": "mvm-builder-vm",
+377	              "system": "${system}",
+378	              "vmlinux":      { "sha256": "$kernel_sha", "size": $kernel_size },
+379	              "rootfs_ext4":  { "sha256": "$rootfs_sha", "size": $rootfs_size },
+380	              "cmdline": "${builderCmdline}"
+381	            }
+382	            MANIFEST
+383	          '';
+384
+385	      mkBuilderVmStage0Rootfs = system:
+386	        let
+387	          pkgs = import nixpkgs { inherit system; };
+388	          # Stage 0 boots under a different kernel than what nixpkgs
+389	          # ships, so omit the kernel + module tree to avoid
+390	          # misleading modprobe with a foreign kver.
+391	          rootfs = mkBuilderVmRootfs system;
+392	        in
+393	        pkgs.runCommand "mvm-builder-vm-stage0-rootfs-${system}" { } ''
+394	          mkdir -p $out
+395
+396	          if [ -f ${rootfs} ]; then
+397	            cp ${rootfs} $out/rootfs.ext4
+398	          else
+399	            img=$(find ${rootfs} -maxdepth 1 -name '*.img' -o -name '*.ext4' | head -1)
+400	            if [ -z "$img" ]; then
+401	              echo "mkGuest output at ${rootfs} contains no .img or .ext4 file" >&2
+402	              ls -la ${rootfs} >&2
+403	              exit 1
+404	            fi
+405	            cp "$img" $out/rootfs.ext4
+406	          fi
+407
+408	          chmod 0644 $out/rootfs.ext4
+409	          echo "${builderCmdline}" > $out/cmdline.txt
+410
+411	          rootfs_sha=$(sha256sum $out/rootfs.ext4 | cut -d' ' -f1)
+412	          rootfs_size=$(stat -c%s $out/rootfs.ext4)
+413	          cat > $out/manifest.json <<MANIFEST
+414	          {
+415	            "name": "mvm-builder-vm-stage0-rootfs",
+416	            "system": "${system}",
+417	            "rootfs_ext4": { "sha256": "$rootfs_sha", "size": $rootfs_size },
+418	            "cmdline": "${builderCmdline}",
+419	            "stage0_rootfs_only": true
+420	          }
+421	          MANIFEST
+422	        '';
+423	      # Plan 95 W2 — expose the generated kernel `.config` as a
+424	      # standalone flake output so contributors can audit what
+425	      # `make defconfig + enables/disables + olddefconfig` actually
+426	      # produced without temporarily editing this flake. Build with:
+427	      #
+428	      #   nix build .#kernel-configfile -o /tmp/kconfig
+429	      #   grep '=y$' /tmp/kconfig | sort > /tmp/kconfig.y.txt
+430	      #
+431	      # The file is a regular `.config` text file — diffable across
+432	      # `disables` edits to confirm SoC platform clusters are gone.
+433	      mkKernelConfigfile = system:
+434	        let pkgs = import nixpkgs { inherit system; };
+435	        in (import ./kernel { inherit pkgs; }).passthru.configfile;
+436	    in
+437	    {
+438	      packages = forAllSystems (system: {
+439	        default = mkBuilderVmImage system;
+440	        stage0-rootfs = mkBuilderVmStage0Rootfs system;
+441	        kernel-configfile = mkKernelConfigfile system;
+442	      });
+443	    };
+444	}
+445
+```
+
+**Tool Call: grep "mvmGuestAgentFor|mvmBuilderInitFor|mvmEgressProxyFor" /Users/auser/work/tinylabs/mvmco/mvm/nix**
+Status: Completed
+
+Found 2 files
+nix/images/builder-vm/flake.nix
+nix/images/builder/flake.nix
+
+**Tool Call: grep -l "buildRustPackage|mvm-guest|sandbox" /Users/auser/work/tinylabs/mvmco/mvm/nix/lib**
+Status: Completed
+
+Found 1 file
+nix/lib/mk-guest.nix
+
+**Tool Call: Read crates/mvm-guest/src**
+Status: Failed
+
+```
+EISDIR: illegal operation on a directory, read '/Users/auser/work/tinylabs/mvmco/mvm/crates/mvm-guest/src'
+```
+
+**Tool Call: Find `/Users/auser/work/tinylabs/mvmco/mvm` `crates/mvm-guest/src/main.rs`**
+Status: Completed
+
+No files found
+
+**Tool Call: Find `/Users/auser/work/tinylabs/mvmco/mvm` `crates/mvm-guest/build.rs`**
+Status: Completed
+
+No files found
+
+**Tool Call: grep "include_str|include_bytes|env!" /Users/auser/work/tinylabs/mvmco/mvm/crates/mvm-guest**
+Status: Completed
+
+Found 3 files
+crates/mvm-guest/src/vsock.rs
+crates/mvm-guest/tests/worker_pool_warm.rs
+crates/mvm-guest/tests/seccomp_apply.rs
+
+**Tool Call: Find `/Users/auser/work/tinylabs/mvmco/mvm` `crates/mvm-guest/src/bin/*.rs`**
+Status: Completed
+
+crates/mvm-guest/src/bin/syscall-probe.rs
+crates/mvm-guest/src/bin/mvm-builder-agent.rs
+crates/mvm-guest/src/bin/mvm-seccomp-apply.rs
+crates/mvm-guest/src/bin/mvm-verity-init.rs
+crates/mvm-guest/src/bin/mvm-guest-netinit.rs
+crates/mvm-guest/src/bin/mvm-guest-agent.rs
+
+**Tool Call: Read crates/mvm-guest/src/bin/mvm-guest-agent.rs (1 - 50)**
+Status: Completed
+
+````
+1	//! Guest vsock agent — runs inside the microVM, listens on
+2	//! `GUEST_AGENT_PORT` (5252).
+3	//!
+4	//! Handles host-to-guest requests (Ping, WorkerStatus, SleepPrep, Wake, etc.)
+5	//! and reports real system metrics via a background monitoring thread.
+6	//!
+7	//! ## Usage
+8	//!
+9	//! ```text
+10	//! mvm-guest-agent [OPTIONS]
+11	//!
+12	//! Options:
+13	//!   --config <path>            JSON config file (default: /etc/mvm/agent.json)
+14	//!   --port <port>              Vsock port to listen on (default: 5252)
+15	//!   --busy-threshold <float>   Load average threshold for busy (default: 0.1)
+16	//!   --sample-interval <secs>   Monitoring sample interval (default: 5)
+17	//!   --help, -h                 Print usage
+18	//! ```
+19
+20	use std::io::{Read, Write};
+21	use std::mem::size_of;
+22	use std::os::fd::{FromRawFd, RawFd};
+23	use std::path::{Path, PathBuf};
+24	use std::sync::atomic::{AtomicBool, AtomicU8, AtomicU64, Ordering};
+25	use std::sync::{Arc, Mutex, OnceLock};
+26	use std::time::{Duration, SystemTime, UNIX_EPOCH};
+27
+28	use mvm_core::security::AgentProfile;
+29	use mvm_guest::entrypoint::{
+30	    CallCaps, CallOutcome, EntrypointPolicy, PayloadCapStream, ValidatedEntrypoint, execute,
+31	};
+32	use mvm_guest::integrations::{
+33	    self, IntegrationEntry, IntegrationHealthResult, IntegrationStateReport, IntegrationStatus,
+34	};
+35	use mvm_guest::lifecycle_hooks::{self, ReadinessConfig};
+36	use mvm_guest::probes::{self, ProbeEntry, ProbeOutputFormat, ProbeResult};
+37	use mvm_guest::runtime_config::{self, ConcurrencyConfig};
+38	use mvm_guest::vsock::{
+39	    BootTimingReport, ComponentState, EntrypointEvent, FsChange, FsChangeKind, GUEST_AGENT_PORT,
+40	    GuestRequest, GuestResponse, ReadinessReport, RunEntrypointError,
+41	};
+42	use mvm_guest::worker_pool::{DispatchError, DispatchOutcome, WorkerPool};
+43	use mvm_guest::worker_protocol::WorkerOutcome;
+44	use serde::Deserialize;
+45
+46	// ============================================================================
+47	// Configuration
+48	// ============================================================================
+49
+50	const DEFAULT_CONFIG_PATH: &str = "/etc/mvm/agent.json";
+````
+
+**Tool Call: git log --all --oneline -- crates/mvm-guest/ nix/packages/mvm-guest-agent.nix 2>/dev/null | head -20**
+Status: Completed
+
+Terminal:
+
+```
+4ee6605e plan(89) W2 part 2: BUILDER_DISPATCH_PORT + host-side reader helpers (#384)
+72d04747 plan(89) W2 part 2: BUILDER_DISPATCH_PORT + host-side reader helpers
+658853b4 plan(89) W2: vsock dispatch wire types + fuzz target (#380)
+83fcf43f chore: enforce unique spec numbers
+de60cdcb Merge remote-tracking branch 'origin/main' into feat/plan74-w2-netinit-audit
+d51a33f5 Merge pull request #271 from tinylabscom/feat/plan74-w2-default-deny
+e064be38 Merge pull request #298 from tinylabscom/feat/plan74-w2-vsock-rpc-audit
+4ca7514d feat(mvm-guest, mvm-cli): plan 74 W2 — vsock RPC inbound audit (GuestRequest::kind_name + emit helper + cp.rs migration)
+73939c05 feat(mvm-backend, mvm-guest): plan 74 W2 — host-side audit emission for guest netinit
+82f8a875 Merge branch 'feat/plan74-w2-audit-types' into feat/plan74-w2-netinit-audit
+b176c019 feat(mvm-guest): plan 74 W2 — mvm-guest-netinit installs kernel blackhole routes (guest-side defense)
+a7cc2bdb Merge pull request #278 from tinylabscom/feat/plan76-phase4-cli
+4dbe983b feat(mvm-guest,mvm-cli): plan 74 W4 — `ProcWaitEvent::Backpressure` with `OutputConsumerSlow` rising-edge detection (#277)
+e2668155 Plan 76 Phase 4 — `mvmctl wait` + `mvmctl boot-report`
+292fe3b8 feat(mvm-guest,mvm-cli): plan 74 W4 — `ProcWaitEvent::Backpressure` with `OutputConsumerSlow` rising-edge detection
+ca3662d4 Plan 76 Phases 1–3 — CI + rebase cleanup
+390e6141 Plan 76 Phase 3 — defer integration + probe init to background
+2373f8a9 Plan 76 Phase 2 — Default impls for readiness wire types
+c6755677 Plan 76 Phase 2 — early control-plane readiness
+3b5d9e25 Plan 76 Phase 1 — vsock profile gate
+```
+
+**Tool Call: Find `crates/mvm-build/src/**/\*.rs`\*\*
+Status: Completed
+
+crates/mvm-build/src/artifacts.rs
+crates/mvm-build/src/firecracker.rs
+crates/mvm-build/src/backend/ssh.rs
+crates/mvm-build/src/backend/vsock.rs
+crates/mvm-build/src/backend/mod.rs
+crates/mvm-build/src/backend/host.rs
+crates/mvm-build/src/nix/scripts.rs
+crates/mvm-build/src/nix/mod.rs
+crates/mvm-build/src/nix/manifest.rs
+crates/mvm-build/src/template_reuse.rs
+crates/mvm-build/src/cache.rs
+crates/mvm-build/src/pipeline/build.rs
+crates/mvm-build/src/pipeline/mod.rs
+crates/mvm-build/src/pipeline/vsock_builder.rs
+crates/mvm-build/src/pipeline/orchestrator.rs
+crates/mvm-build/src/app_deps_gate.rs
+crates/mvm-build/src/oci_to_rootfs/error.rs
+crates/mvm-build/src/oci_to_rootfs/ext4.rs
+crates/mvm-build/src/oci_to_rootfs/mod.rs
+crates/mvm-build/src/oci_to_rootfs/path_validation.rs
+crates/mvm-build/src/oci_to_rootfs/unpack.rs
+crates/mvm-build/src/oci_to_rootfs/verity.rs
+crates/mvm-build/src/runtime_overlay.rs
+crates/mvm-build/src/app_deps.rs
+crates/mvm-build/src/packed_artifact.rs
+crates/mvm-build/src/rootfs.rs
+crates/mvm-build/src/builder_vm.rs
+crates/mvm-build/src/persistent_builder.rs
+crates/mvm-build/src/pipeline/dev_build.rs
+crates/mvm-build/src/lib.rs
+crates/mvm-build/src/libkrun_builder.rs
+crates/mvm-build/src/stage0.rs
+crates/mvm-build/src/builder_protocol.rs
+
+**Tool Call: grep -r "cmd\.sh" /Users/auser/work/tinylabs/mvmco/mvm/crates/mvm-build --include="\*.rs" -l**
+Status: Failed
+
+```
+Tool permission request failed: Error: Internal error
+```
+
+**Tool Call: grep "nix-path-registration|Cargo.lock" /Users/auser/work/tinylabs/mvmco/mvm/nix**
+Status: Completed
+
+Found 6 files
+nix/images/builder-vm/flake.nix
+nix/packages/mvm-addon-dns.nix
+nix/images/runtime-overlay/flake.nix
+nix/images/builder/flake.nix
+nix/packages/mvm-guest-agent.nix
+nix/flake.nix
+
+**Tool Call: Read Cargo.lock (1 - 100)**
+Status: Completed
+
+```
+1	# This file is automatically @generated by Cargo.
+2	# It is not intended for manual editing.
+3	version = 4
+4
+5	[[package]]
+6	name = "adler2"
+7	version = "2.0.1"
+8	source = "registry+https://github.com/rust-lang/crates.io-index"
+9	checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
+10
+11	[[package]]
+12	name = "aead"
+13	version = "0.5.2"
+14	source = "registry+https://github.com/rust-lang/crates.io-index"
+15	checksum = "d122413f284cf2d62fb1b7db97e02edb8cda96d769b16e443a4f6195e35662b0"
+16	dependencies = [
+17	 "bytes",
+18	 "crypto-common",
+19	 "generic-array",
+20	]
+21
+22	[[package]]
+23	name = "aes"
+24	version = "0.8.4"
+25	source = "registry+https://github.com/rust-lang/crates.io-index"
+26	checksum = "b169f7a6d4742236a0a00c541b845991d0ac43e546831af1249753ab4c3aa3a0"
+27	dependencies = [
+28	 "cfg-if",
+29	 "cipher",
+30	 "cpufeatures 0.2.17",
+31	]
+32
+33	[[package]]
+34	name = "aes-gcm"
+35	version = "0.10.3"
+36	source = "registry+https://github.com/rust-lang/crates.io-index"
+37	checksum = "831010a0f742e1209b3bcea8fab6a8e149051ba6099432c8cb2cc117dec3ead1"
+38	dependencies = [
+39	 "aead",
+40	 "aes",
+41	 "cipher",
+42	 "ctr",
+43	 "ghash",
+44	 "subtle",
+45	]
+46
+47	[[package]]
+48	name = "aes-kw"
+49	version = "0.2.1"
+50	source = "registry+https://github.com/rust-lang/crates.io-index"
+51	checksum = "69fa2b352dcefb5f7f3a5fb840e02665d311d878955380515e4fd50095dd3d8c"
+52	dependencies = [
+53	 "aes",
+54	]
+55
+56	[[package]]
+57	name = "ahash"
+58	version = "0.7.8"
+59	source = "registry+https://github.com/rust-lang/crates.io-index"
+60	checksum = "891477e0c6a8957309ee5c45a6368af3ae14bb510732d2684ffa19af310920f9"
+61	dependencies = [
+62	 "getrandom 0.2.17",
+63	 "once_cell",
+64	 "version_check",
+65	]
+66
+67	[[package]]
+68	name = "aho-corasick"
+69	version = "1.1.4"
+70	source = "registry+https://github.com/rust-lang/crates.io-index"
+71	checksum = "ddd31a130427c27518df266943a5308ed92d4b226cc639f5a8f1002816174301"
+72	dependencies = [
+73	 "memchr",
+74	]
+75
+76	[[package]]
+77	name = "android_system_properties"
+78	version = "0.1.5"
+79	source = "registry+https://github.com/rust-lang/crates.io-index"
+80	checksum = "819e7219dbd41043ac279b19830f2efc897156490d7fd6ea916720117ee66311"
+81	dependencies = [
+82	 "libc",
+83	]
+84
+85	[[package]]
+86	name = "anstream"
+87	version = "0.6.21"
+88	source = "registry+https://github.com/rust-lang/crates.io-index"
+89	checksum = "43d5b281e737544384e969a5ccad3f1cdd24b48086a0fc1b2a5262a26b8f4f4a"
+90	dependencies = [
+91	 "anstyle",
+92	 "anstyle-parse",
+93	 "anstyle-query",
+94	 "anstyle-wincon",
+95	 "colorchoice",
+96	 "is_terminal_polyfill",
+97	 "utf8parse",
+98	]
+99
+100	[[package]]
+```
+
+**Tool Call: Read nix/lib/mk-guest.nix (1 - 150)**
+Status: Completed
+
+```
+1	# mkGuest — busybox-as-PID-1 microVM image builder.
+2	#
+3	# Same flake the user writes is consumed in BOTH dev and production
+4	# builds. The "sealed vs accessible" distinction is encoded by:
+5	#
+6	#   1. The entrypoint shape:
+7	#        entrypoint.shell    = "/bin/sh"           # accessible (dev-style)
+8	#        entrypoint.command  = [ "/usr/local/bin/web" ]   # sealed default
+9	#        entrypoint.services = { … }               # multi-service supervised
+10	#
+11	#   2. The explicit `dev` flag (overrides the entrypoint heuristic):
+12	#        dev = true   # always enables the console + reachable shell
+13	#        dev = false  # never enables console regardless of entrypoint
+14	#
+15	# Inferred default: `dev = (entrypoint ? shell)`. mvmctl reads the
+16	# `passthru.mvm.{accessible, sealed, entrypointKind}` metadata to
+17	# gate `mvmctl console <vm>` host-side; the `/etc/mvm/variant` file
+18	# baked into the rootfs is the in-guest cross-check.
+19	#
+20	# ── Why busybox-as-PID-1, not NixOS+systemd ──
+21	#
+22	# ADR-013 §"Boot-time budget" is the source of truth. The short
+23	# version: NixOS+systemd boots in 1-3 s; Alpine+OpenRC in 300-500 ms;
+24	# busybox-as-PID-1 with custom init approaches the upstream Firecracker
+25	# reference of ~125 ms. The 200ms cold-boot target on Firecracker
+26	# requires the busybox path. The previous iteration of mvm shipped
+27	# this exact strategy.
+28	#
+29	# microvm.nix is still pinned as a flake input (per ADR-013) for its
+30	# hypervisor abstractions and kernel-config helpers, but we DO NOT
+31	# use its NixOS module — that's the systemd-heavy path we're
+32	# explicitly avoiding here.
+33
+34	{ nixpkgs, microvm, mvmSrc }:
+35	{ system }:
+36	let
+37	  pkgs = import nixpkgs { inherit system; };
+38	  lib  = nixpkgs.lib;
+39
+40
+41	  # Static busybox — single binary, every shell utility as an applet.
+42	  # `pkgsStatic` ensures no glibc dynamic-linker hop at /init time
+43	  # (which alone saves ~10ms vs a glibc-linked init).
+44	  busybox = pkgs.pkgsStatic.busybox;
+45
+46	  classifyEntrypoint = ep:
+47	    let
+48	      hasShell    = ep ? shell;
+49	      hasCommand  = ep ? command;
+50	      hasServices = ep ? services;
+51	      forms       = lib.count (b: b) [ hasShell hasCommand hasServices ];
+52	    in
+53	    if forms == 0 then
+54	      throw ''
+55	        mkGuest: entrypoint must declare exactly one of:
+56	          { shell    = "/bin/sh"; }
+57	          { command  = [ "/usr/local/bin/x" ]; }
+58	          { services = { web = { command = … }; … }; }
+59	        Got: ${builtins.toJSON ep}
+60	      ''
+61	    else if forms > 1 then
+62	      throw "mkGuest: entrypoint must declare exactly one form, not several"
+63	    else if hasShell then "shell"
+64	    else if hasCommand then "command"
+65	    else "services";
+66
+67	  # Render a single command list as a quoted shell command line.
+68	  renderCommand = argv:
+69	    lib.concatStringsSep " " (map lib.escapeShellArg argv);
+70	in
+71	{ name
+72	, entrypoint
+73	, services       ? { }
+74	, packages       ? [ ]
+75	, hypervisor     ? "firecracker"
+76	, vcpus          ? 1
+77	, memory_mib     ? 256
+78	, dev            ? null
+79	, uids           ? null   # { agent = <int>; entrypoint = <int>; } — see below
+80	, extraFiles     ? { }
+81	# Optional kernel package. When set, mkGuest copies its module
+82	# tree (`/lib/modules/<kver>/`) into the rootfs and `/init` runs
+83	# `modprobe vmw_vsock_virtio_transport` before forking the agent.
+84	# Required when the kernel ships AF_VSOCK as a module (the default
+85	# nixpkgs `linuxPackages.kernel` config). Without it,
+86	# `mvm-guest-agent`'s `socket(AF_VSOCK, …)` returns EAFNOSUPPORT and
+87	# every host-side surface (`mvmctl console`, `dev shell`, `build`)
+88	# goes dark on a guest booted from that kernel.
+89	, kernel         ? null
+90	}:
+91	let
+92	  entrypointKind = classifyEntrypoint entrypoint;
+93	  isDev =
+94	    if dev == null then entrypointKind == "shell"
+95	    else dev;
+96	  isSealed = !isDev;
+97
+98	  # ── Guest agent build (W6.1.2) ─────────────────────────────────
+99	  #
+100	  # Real Rust binary built from the workspace at `mvmSrc` via
+101	  # `nix/packages/mvm-guest-agent.nix`. Replaces the W6.1.1 sh-stub
+102	  # that previously lived inline here. The W7.x.2 libkrun
+103	  # builder VM is what makes this buildable on hosts without native
+104	  # Linux Nix.
+105	  #
+106	  # The `dev-shell` Cargo feature gates the `do_exec` RPC handler
+107	  # (ADR-002 §W4.3 / `prod-agent-no-exec` CI gate). We tie it to
+108	  # `isDev` here so the same `mkGuest` call:
+109	  #
+110	  #   - Dev image (`entrypoint.shell = ...`, or `dev = true`)
+111	  #     → `do_exec` compiled in → `mvmctl exec`/`mvmctl console` work
+112	  #   - Prod/sealed image (`entrypoint.command`/`services`, or
+113	  #     `dev = false`)
+114	  #     → `do_exec` stripped → CI's symbol-absence gate passes
+115	  #
+116	  # Either way the binary is the production Rust build, not a stub.
+117	  guestAgentPkg = pkgs.callPackage ../packages/mvm-guest-agent.nix {
+118	    inherit mvmSrc;
+119	    withDevShell = isDev;
+120	  };
+121
+122	  # ── mvm-addon-dns — in-guest loopback DNS resolver ─────────────
+123	  #
+124	  # Always baked into the rootfs (the "always-install + no-op when
+125	  # zone empty" pattern from `specs/contracts/local-addon-dns.md`);
+126	  # /init activates it only when a zone file is present, so a guest
+127	  # without addons keeps its baked /etc/resolv.conf byte-for-byte.
+128	  addonDnsPkg = pkgs.callPackage ../packages/mvm-addon-dns.nix {
+129	    inherit mvmSrc;
+130	  };
+131
+132	  # ── Privilege model (uids) ─────────────────────────────────────
+133	  #
+134	  # PID 1 must be uid 0 (kernel requirement); everything we can
+135	  # drop is dropped via `setpriv` before exec. Two configurable
+136	  # uids:
+137	  #
+138	  #   agent       — the host-mediated tool agent (vsock RPC handler).
+139	  #                 Always non-root; never needs privilege.
+140	  #
+141	  #   entrypoint  — the workload the user declared. Defaults differ
+142	  #                 by mode:
+143	  #                   dev = true  → uid 0 (root shell;
+144	  #                                  apt install / mount work)
+145	  #                   dev = false → uid 1000 (rootless workload;
+146	  #                                  defense in depth — ADR-002 W2.1)
+147	  #
+148	  # Override either via `uids = { agent = N; entrypoint = M; }` —
+149	  # e.g. `entrypoint = 1000` forces a rootless dev shell, or
+150	  # `entrypoint = 0` forces a rootful prod workload (rare; usually
+```
+
+**Tool Call: grep "pkgConfig|openssl|libudev|network|sandbox" /Users/auser/work/tinylabs/mvmco/mvm/crates/mvm-guest**
+Status: Completed
+
+Found 10 files
+crates/mvm-guest/src/vsock.rs
+crates/mvm-guest/src/bin/mvm-guest-agent.rs
+crates/mvm-guest/src/netinit.rs
+crates/mvm-guest/src/lib.rs
+crates/mvm-guest/src/bin/mvm-guest-netinit.rs
+crates/mvm-guest/Cargo.toml
+crates/mvm-guest/src/bin/mvm-seccomp-apply.rs
+crates/mvm-guest/src/bin/mvm-builder-agent.rs
+crates/mvm-guest/tests/seccomp_apply.rs
+crates/mvm-guest/src/fs_rpc.rs
+
+**Tool Call: grep -A 50 "^\[dependencies\]" /Users/auser/work/tinylabs/mvmco/mvm/crates/mvm-guest/Cargo.toml | head -60**
+Status: Completed
+
+Terminal:
+
+```
+[dependencies]
+mvm-core.workspace = true
+mvm-security.workspace = true
+anyhow.workspace = true
+base64.workspace = true
+chrono.workspace = true
+ed25519-dalek.workspace = true
+libc.workspace = true
+rand.workspace = true
+serde.workspace = true
+serde_json.workspace = true
+# Phase 10c — readiness/shutdown hook runner uses thiserror for
+# typed error variants (ReadinessError, ShutdownError).
+thiserror = "1"
+tracing.workspace = true
+# Plan 74 W2 — the `netinit` module's trait + types + install
+# loop + tests are cross-platform; only `RtnetlinkInstaller`
+# itself is Linux-only. Keeping async-trait + ipnet in the main
+# deps lets the tests run on macOS dev hosts too.
+async-trait.workspace = true
+ipnet.workspace = true
+
+# seccompiler builds Linux-only — guests are always Linux microVMs,
+# but the workspace also compiles on macOS for CLI development. Gate
+# the dep so `cargo check` on a Mac doesn't try to build it.
+[target.'cfg(target_os = "linux")'.dependencies]
+seccompiler = { workspace = true }
+# Plan 74 W2 — `mvm-guest-netinit` uses rtnetlink to install kernel
+# blackhole routes for `MANDATORY_DENY_RANGES`. Linux-only because
+# rtnetlink talks to AF_NETLINK which doesn't exist elsewhere. The
+# host-side mvmctl builds (which include this crate) skip these
+# deps on macOS; the binary itself is only relevant in the guest.
+rtnetlink = { workspace = true }
+tokio = { workspace = true }
+# netlink-packet-route is rtnetlink's wire-format types crate. The
+# RouteType::BlackHole enum the installer uses comes from here.
+netlink-packet-route = "0.19"
+
+[dev-dependencies]
+tempfile.workspace = true
+# Plan 74 W2 — `netinit` module's tests are async (the
+# `RouteInstaller` trait is async). tokio is workspace-shared so
+# the extra dev-dep doesn't pull anything new into the lock.
+tokio = { workspace = true }
+
+[lints]
+workspace = true
+```
+
+**Tool Call: grep -B5 -A10 "netlink-packet-route\|rtnetlink" /Users/auser/work/tinylabs/mvmco/mvm/Cargo.lock | head -40**
+Status: Completed
+
+Terminal:
+
+```
+ "ed25519-dalek",
+ "ipnet",
+ "libc",
+ "mvm-core",
+ "mvm-security",
+ "netlink-packet-route",
+ "rand 0.8.6",
+ "rtnetlink",
+ "seccompiler",
+ "serde",
+ "serde_json",
+ "tempfile",
+ "thiserror 1.0.69",
+ "tokio",
+ "tracing",
+]
+
+[[package]]
+--
+ "byteorder",
+ "netlink-packet-utils",
+]
+
+[[package]]
+name = "netlink-packet-route"
+version = "0.19.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "74c171cd77b4ee8c7708da746ce392440cb7bcf618d122ec9ecc607b12938bf4"
+dependencies = [
+ "anyhow",
+ "byteorder",
+ "libc",
+ "log",
+ "netlink-packet-core",
+ "netlink-packet-utils",
+--
+ "subtle",
+ "zeroize",
+]
+```
+
+**Tool Call: grep "cmd\.sh|nix build|--option.\*build-users-group" crates/mvm-build/src/nix/scripts.rs**
+Status: Completed
+
+No matches found
+
+**Tool Call: grep "cmd\.sh" crates/mvm-build/src/builder_vm.rs**
+Status: Completed
+
+No matches found
+
+**Tool Call: grep "nix build|--option" crates/mvm-build/src/libkrun_builder.rs**
+Status: Completed
+
+3-//! Plan 72 ADR-046 chose libkrun-direct (on macOS Apple Silicon /
+4-//! Intel) and Firecracker (on Linux) as the replacement for the
+5-//! libkrun-backed builder VM. This module is the libkrun half;
+6-//! W1 → W4 of the migration shipped the launcher end-to-end.
+7-//!
+8-//! ## What `LibkrunBuilderVm` does
+9-//!
+10-//! Given a populated builder VM image cache and `mvm-libkrun-supervisor`
+11://! on PATH, `run_build` runs a one-shot `nix build` against the
+12-//! caller's `BuilderJob` and returns `BuilderArtifacts`. The
+13-/! pipeline (in [`BuilderVm::run_build`]):
+14-//!
+15-//! 1. Validate mounts + job (`validate_mounts`, `validate_job`).
+16-/! 2. Check `mvm_libkrun::is_available()` — bail with install hint
+17-//! if libkrun isn't on the host.
+18-//! 3. Locate `mvm-libkrun-supervisor` (env override / next-to-exe /
+19-//! PATH).
+--
+21-//! `~/.cache/mvm/builder-vm/<arch>/` — vmlinux + rootfs.ext4 +
+22-//! cmdline.txt + manifest.json, the shape Plan 72 W2's flake
+23-//! emits. Populated by Plan 72 W5's `bootstrap_builder_vm_image`
+24-/! (`mvm-cli::commands::env::apple_container`).
+25-//! 5. Allocate / reuse the persistent `/nix-store-<arch>.img`
+26-//! sparse virtio-blk image (64 GiB cap by default; idempotent
+27-//! across invocations so the warm Nix store survives).
+28-//! 6. Stage `<job_dir>/cmd.sh` with the shell-escaped flake_ref +
+29://! attr_path, plus the canonical `nix build` invocation.
+30-/! 7. Build a `KrunContext`: kernel + rootfs + cmdline + per-VM
+31-//! vsock dir + virtio-blk (Nix store) + virtio-fs (work / out /
+32-//! job).
+33-//! 8. Spawn `mvm-libkrun-supervisor`, pipe the `SupervisorConfig`
+34-//! JSON to stdin, **wait** for it to exit (unlike
+35-/! `LibkrunBackend::start` which returns after the PID file
+36-//! appears — the builder is a one-shot).
+37-/! 9. Read `<job_dir>/result` (JSON: `{exit_code, stderr_tail}`)
+--
+47-//! the libkrun builder build with `default-features = false`.
+48-//!
+49-//! ## Not the runtime backend
+50-//!
+51-//! `LibkrunBackend` (`crates/mvm-backend/src/libkrun.rs`) is for
+52-//! running user microVMs; this module is for building them. The
+53-//! two share `mvm-libkrun`'s FFI but compose differently — the
+54-//! builder mounts a workspace + persistent `/nix`-store disk and
+55://! runs a one-shot `nix build`, while the runtime mounts the
+56-//! user's rootfs and runs the user's entrypoint.
+57-
+58-use std::io::{Read, Write};
+59-use std::path::{Path, PathBuf};
+60-use std::process::{Child, Command, Stdio};
+61-use std::sync::atomic::{AtomicBool, Ordering};
+62-use std::sync::{Arc, Mutex};
+63-use std::time::{Duration, Instant};
+--
+68-use crate::builder_vm::{BuilderArtifacts, BuilderJob, BuilderMounts, BuilderVm, BuilderVmError};
+69-
+70-/// Default vCPU count for the builder VM. Nix builds are
+71-/// embarrassingly parallel at the derivation level; 4 cores is the
+72-/// sweet spot on M-series Macs without saturating the host.
+73-pub const DEFAULT_VCPUS: u8 = 4;
+74-
+75-/// Default RAM in MiB. Originally 8 GiB (Plan 72 W5.D bullet 9 —
+76:/// in-VM nix builds peak ~5-6 GiB). Plan 95 raised this to 16 GiB
+77-/// alongside bumping the Stage 0 `/nix` tmpfs `size=` cap in
+78-/ `stage0/init.sh` (4G → 14G): tmpfs is RAM-backed, so the cap
+79-/// can only be honored if the VM has at least that much RAM. The
+80-/// real bottleneck in dev-up validation was the tmpfs cap, not the
+81-/// VM RAM — bumping VM RAM alone is a no-op as long as the
+82-/// `size=` mount option clips earlier. Keep these two in lockstep.
+83-pub const DEFAULT_MEMORY_MIB: u32 = 16384;
+84-
+--
+199- fallback
+200- }
+201- }
+202-}
+203-
+204-/// Libkrun-backed builder VM driver.
+205-///
+206-/// Configuration only — `run_build` consumes it to spin a per-job
+207:/// VM, runs `nix build` inside, extracts the artifacts via the
+208-/// `/out` virtio-fs mount, and tears the VM down. No persistent
+209-/// state on the struct; the `/nix`-store image lives on the host
+210-/// filesystem and survives across invocations.
+211-#[derive(Debug, Clone)]
+212-pub struct LibkrunBuilderVm {
+213- /// Guest vCPU count. See [`DEFAULT_VCPUS`].
+214- pub vcpus: u8,
+215- /// Guest RAM in MiB. See [`DEFAULT_MEMORY_MIB`].
+--
+869- let arch_dir = builder_vm_cache_dir().join(host_arch_tag());
+870- let kernel_path = arch_dir.join("vmlinux");
+871- let rootfs_path = arch_dir.join("rootfs.ext4");
+872- let cmdline_path = arch_dir.join("cmdline.txt");
+873-
+874- if !kernel_path.is_file() || !rootfs_path.is_file() {
+875- return Err(BuilderVmError::ExtractionFailed(format!(
+876- "builder VM image not found at {}. \
+877: Populate the cache by running `nix build ./nix/images/builder-vm#packages.{}-linux.default` \
+878- on a host with Nix and copying `result/{{vmlinux,rootfs.ext4,cmdline.txt}}` to {}/.",
+879- arch_dir.display(),
+880- host_arch_tag(),
+881- arch_dir.display(),
+882- )));
+883- }
+884-
+885- let cmdline = std::fs::read_to_string(&cmdline_path)
+--
+1017-/// Filename of the install report `mvm-builder-init` writes into
+1018-/// `artifact_out/` after the install pipeline finishes. The host
+1019-/// reads + parses this to decide whether the install succeeded.
+1020-pub(crate) const INSTALL_RESULT_FILENAME: &str = "result.json";
+1021-
+1022-/// Stage the per-job dir for the given [`BuilderJob`].
+1023-///
+1024-/ - [`BuilderJob::Flake`]: writes `<job_dir>/cmd.sh` with the
+1025:/// `nix build` script the guest's PID 1 dispatches via
+1026-/// `/bin/sh -eu`.
+1027-/ - [`BuilderJob::Install`]: copies the caller's install spec
+1028-/// to `<job_dir>/install_spec.json`. `mvm-builder-init` probes
+1029-/// for this filename first; when present it routes through the
+1030-/// app-deps install pipeline (Plan 73 Followup B.2) instead of
+1031-/// running `cmd.sh`.
+1032-///
+1033-/// The two modes are mutually exclusive — install jobs don't
+--
+1115-auto-optimise-store = true
+1116-substituters = https://cache.nixos.org/
+1117-trusted-public-keys = cache.nixos.org-1:6NCHdD59X431o0gWypbMrAURkbJ16ZPMQFGspcDShjY="
+1118-# Plan 72 W0's flake convention: workspace-path env var so
+1119-# flakes that reference the workspace root don't depend on
+1120-# relative-path resolution against the store-copied flake dir.
+1121-export MVM_WORKSPACE_PATH=/work
+1122-
+1123:echo "mvm-builder-vm: filesystem space before nix build:" >&2
+1124-df -h /nix /tmp >&2 || true
+1125-
+1126-# `--impure` is what unblocks builds inside the VM when the
+1127-# flake has path inputs; `--no-write-lock-file` keeps the
+1128-# read-only `/work` mount from tripping EROFS.
+1129-# `--print-build-logs --keep-going` dumps every failing build's
+1130-# stderr inline (default nix only prints the last 10 lines and
+1131-# cascades up). We tee stderr to /job/nix-build.log so the host
+1132-# can read the actual root cause when a deep dependency fails.
+1133-set +e
+1134:nix build "${{FLAKE_REF}}#${{ATTR_PATH}}" \
+1135- --no-link --print-out-paths --no-write-lock-file --impure \
+1136- --print-build-logs --keep-going \
+1137- > /job/nix-stdout.log 2> /job/nix-stderr.log
+1138-NIX_RC=$?
+1139-set -e
+1140-NIX_OUT=$(cat /job/nix-stdout.log)
+1141-if [ "$NIX_RC" -ne 0 ]; then
+1142: echo "mvm-builder-vm: filesystem space after failed nix build:" >&2
+1143- df -h /nix /tmp >&2 || true
+1144: echo "nix build exited $NIX_RC; tail of stderr:" >&2
+1145-    tail -200 /job/nix-stderr.log >&2
+1146-    exit $NIX_RC
+1147-fi
+1148-
+1149-if [ -z "$NIX_OUT" ]; then
+1150: echo "nix build emitted no /nix/store output path" >&2
+1151- exit 1
+1152-fi
+1153-printf '%s\n' "$NIX_OUT" > /job/store-path
+1154-
+1155-# Copy the artifacts the host expects into /out. We accept
+1156-# either `vmlinux` (the canonical name our flakes use) or
+1157-# `Image` / `bzImage` (raw kernel format names) for
+1158-# robustness across flake conventions.
+1159-if   [ -f "$NIX_OUT/vmlinux" ]; then cp -L "$NIX_OUT/vmlinux" /out/vmlinux
+1160-elif [ -f "$NIX_OUT/Image" ]; then cp -L "$NIX_OUT/Image"   /out/vmlinux
+1161-elif [ -f "$NIX_OUT/bzImage" ]; then cp -L "$NIX_OUT/bzImage" /out/vmlinux
+1162-fi
+1163-if [ -f "$NIX_OUT/rootfs.ext4" ]; then
+1164- cp -L "$NIX_OUT/rootfs.ext4" /out/rootfs.ext4
+1165-else
+1166: echo "no rootfs.ext4 in nix build output at $NIX_OUT" >&2
+1167- exit 1
+1168-fi
+1169-
+1170-# Permissions for the host-side reader. Ignore failures —
+1171-# virtio-fs may map the uid such that chmod is a no-op.
+1172-chmod 0644 /out/rootfs.ext4 2>/dev/null || true
+1173-[ -f /out/vmlinux ] && chmod 0644 /out/vmlinux 2>/dev/null || true
+1174-"#,
+--
+2184- attr_path: "packages.x86_64-linux.default".to_string(),
+2185- }
+2186- }
+2187-
+2188- #[test]
+2189- fn defaults_match_plan_72_w1() {
+2190- let vm = LibkrunBuilderVm::default();
+2191- assert_eq!(vm.vcpus, 4);
+2192: // Plan 72 W5.D bullet 9: 4 → 8 GiB (in-VM nix builds peak
+2193- / ~5-6 GiB; OOM at lower default). Plan 95: 8 → 16 GiB
+2194- // alongside stage0/init.sh bumping the `/nix` tmpfs `size=`
+2195- // cap to 14G. Hardcoded so a regression on either side
+2196- // fails fast.
+2197- assert_eq!(vm.memory_mib, 16384);
+2198- assert_eq!(vm.nix_store_mib, 65536);
+2199- }
+2200-
+
+**Tool Call: Read crates/mvm-build/src/libkrun_builder.rs (1100 - 1249)**
+Status: Completed
+
+```
+1100	export SSL_CERT_FILE=/etc/ssl/certs/ca-bundle.crt
+1101
+1102	cd /work
+1103	# `experimental-features` enables nix-command + flakes. `sandbox =
+1104	# false` + `build-users-group =` is mandatory inside the builder
+1105	# VM: there are no `nixbld*` accounts in the rootfs and no kernel
+1106	# user-ns isolation for build sandboxes, so every derivation would
+1107	# otherwise fail with "the group 'nixbld' specified in
+1108	# 'build-users-group' does not exist". The builder VM IS the
+1109	# isolation boundary, so an in-guest sandbox is redundant.
+1110	export NIX_CONFIG="experimental-features = nix-command flakes
+1111	sandbox = false
+1112	build-users-group =
+1113	max-jobs = auto
+1114	cores = 0
+1115	auto-optimise-store = true
+1116	substituters = https://cache.nixos.org/
+1117	trusted-public-keys = cache.nixos.org-1:6NCHdD59X431o0gWypbMrAURkbJ16ZPMQFGspcDShjY="
+1118	# Plan 72 W0's flake convention: workspace-path env var so
+1119	# flakes that reference the workspace root don't depend on
+1120	# relative-path resolution against the store-copied flake dir.
+1121	export MVM_WORKSPACE_PATH=/work
+1122
+1123	echo "mvm-builder-vm: filesystem space before nix build:" >&2
+1124	df -h /nix /tmp >&2 || true
+1125
+1126	# `--impure` is what unblocks builds inside the VM when the
+1127	# flake has path inputs; `--no-write-lock-file` keeps the
+1128	# read-only `/work` mount from tripping EROFS.
+1129	# `--print-build-logs --keep-going` dumps every failing build's
+1130	# stderr inline (default nix only prints the last 10 lines and
+1131	# cascades up). We tee stderr to /job/nix-build.log so the host
+1132	# can read the actual root cause when a deep dependency fails.
+1133	set +e
+1134	nix build "${{FLAKE_REF}}#${{ATTR_PATH}}" \
+1135	    --no-link --print-out-paths --no-write-lock-file --impure \
+1136	    --print-build-logs --keep-going \
+1137	    > /job/nix-stdout.log 2> /job/nix-stderr.log
+1138	NIX_RC=$?
+1139	set -e
+1140	NIX_OUT=$(cat /job/nix-stdout.log)
+1141	if [ "$NIX_RC" -ne 0 ]; then
+1142	    echo "mvm-builder-vm: filesystem space after failed nix build:" >&2
+1143	    df -h /nix /tmp >&2 || true
+1144	    echo "nix build exited $NIX_RC; tail of stderr:" >&2
+1145	    tail -200 /job/nix-stderr.log >&2
+1146	    exit $NIX_RC
+1147	fi
+1148
+1149	if [ -z "$NIX_OUT" ]; then
+1150	    echo "nix build emitted no /nix/store output path" >&2
+1151	    exit 1
+1152	fi
+1153	printf '%s\n' "$NIX_OUT" > /job/store-path
+1154
+1155	# Copy the artifacts the host expects into /out. We accept
+1156	# either `vmlinux` (the canonical name our flakes use) or
+1157	# `Image` / `bzImage` (raw kernel format names) for
+1158	# robustness across flake conventions.
+1159	if   [ -f "$NIX_OUT/vmlinux" ]; then cp -L "$NIX_OUT/vmlinux" /out/vmlinux
+1160	elif [ -f "$NIX_OUT/Image"   ]; then cp -L "$NIX_OUT/Image"   /out/vmlinux
+1161	elif [ -f "$NIX_OUT/bzImage" ]; then cp -L "$NIX_OUT/bzImage" /out/vmlinux
+1162	fi
+1163	if [ -f "$NIX_OUT/rootfs.ext4" ]; then
+1164	    cp -L "$NIX_OUT/rootfs.ext4" /out/rootfs.ext4
+1165	else
+1166	    echo "no rootfs.ext4 in nix build output at $NIX_OUT" >&2
+1167	    exit 1
+1168	fi
+1169
+1170	# Permissions for the host-side reader. Ignore failures —
+1171	# virtio-fs may map the uid such that chmod is a no-op.
+1172	chmod 0644 /out/rootfs.ext4 2>/dev/null || true
+1173	[ -f /out/vmlinux ] && chmod 0644 /out/vmlinux 2>/dev/null || true
+1174	"#,
+1175	        flake_ref = shell_single_quote_escape(flake_ref),
+1176	        attr_path = shell_single_quote_escape(attr_path),
+1177	    );
+1178
+1179	    let cmd_path = job_dir.join("cmd.sh");
+1180	    std::fs::write(&cmd_path, body).map_err(|e| {
+1181	        BuilderVmError::ExtractionFailed(format!("writing {}: {e}", cmd_path.display()))
+1182	    })?;
+1183	    Ok(())
+1184	}
+1185
+1186	fn stage_shell_job_dir(job_dir: &Path, script: &str) -> Result<(), BuilderVmError> {
+1187	    std::fs::create_dir_all(job_dir).map_err(|e| {
+1188	        BuilderVmError::ExtractionFailed(format!("creating job dir {}: {e}", job_dir.display()))
+1189	    })?;
+1190	    let cmd_path = job_dir.join("cmd.sh");
+1191	    std::fs::write(&cmd_path, script).map_err(|e| {
+1192	        BuilderVmError::ExtractionFailed(format!("writing {}: {e}", cmd_path.display()))
+1193	    })?;
+1194	    Ok(())
+1195	}
+1196
+1197	/// Escape a string for inclusion inside `'…'` single quotes
+1198	/// in POSIX shell. The only character that can't appear inside
+1199	/// single quotes is `'` itself; we close the quote, emit `\'`,
+1200	/// then reopen. Standard sh-escape pattern.
+1201	fn shell_single_quote_escape(s: &str) -> String {
+1202	    s.replace('\'', "'\\''")
+1203	}
+1204
+1205	/// Finalize a flake build: read `<job_dir>/result`, validate the
+1206	/// `rootfs.ext4` (and optional `vmlinux`) landed in
+1207	/// `artifact_out`, return a [`BuilderArtifacts::Image`].
+1208	fn finalize_flake_job(
+1209	    job_dir: &Path,
+1210	    artifact_out: &Path,
+1211	    job_id: &str,
+1212	) -> Result<BuilderArtifacts, BuilderVmError> {
+1213	    let result = read_job_result(job_dir)?;
+1214	    if result.exit_code != 0 {
+1215	        return Err(BuilderVmError::NixBuildFailed(format!(
+1216	            "guest cmd.sh exited {} — stderr tail:\n{}",
+1217	            result.exit_code, result.stderr_tail
+1218	        )));
+1219	    }
+1220
+1221	    let rootfs_path = artifact_out.join("rootfs.ext4");
+1222	    if !rootfs_path.is_file() {
+1223	        return Err(BuilderVmError::ExtractionFailed(format!(
+1224	            "builder VM exited cleanly but {} was not written",
+1225	            rootfs_path.display()
+1226	        )));
+1227	    }
+1228	    let kernel_path_out = artifact_out.join("vmlinux");
+1229	    let kernel_path = if kernel_path_out.is_file() {
+1230	        Some(kernel_path_out)
+1231	    } else {
+1232	        None
+1233	    };
+1234
+1235	    Ok(BuilderArtifacts::Image {
+1236	        rootfs_path,
+1237	        kernel_path,
+1238	        revision_hash: read_revision_hash(job_dir).unwrap_or_else(|| job_id.to_string()),
+1239	        lock_hash: None,
+1240	        accessible: None,
+1241	    })
+1242	}
+1243
+1244	/// Read `/job/store-path` and extract the leading Nix store hash
+1245	/// from `/nix/store/<hash>-<name>`. Older guest images may not
+1246	/// write the sidecar; those callers fall back to the unique job id.
+1247	fn read_revision_hash(job_dir: &Path) -> Option<String> {
+1248	    let body = std::fs::read_to_string(job_dir.join("store-path")).ok()?;
+1249	    extract_nix_store_hash(body.trim()).map(str::to_string)
+```
+
+**Tool Call: grep -l "mvm-guest-agent|guest.agent" nix**
+Status: Completed
+
+Found 8 files
+nix/lib/mk-guest.nix
+nix/packages/mvm-addon-dns.nix
+nix/images/runtime-overlay/flake.nix
+nix/images/builder/flake.nix
+nix/packages/mvm-guest-agent.nix
+nix/tests/mk-guest-eval.nix
+nix/profiles/minimal.nix
+nix/flake.nix
+
+**Tool Call: Read nix/packages/mvm-guest-agent.nix**
+Status: Completed
+
+```
+1	# `mvm-guest-agent` — the production guest agent binary.
+2	#
+3	# Plan-60 W6.1.2 swaps the W6.1.1 sh-script stub
+4	# (`nix/lib/mk-guest.nix::agentBinary`) for the real Rust binary
+5	# defined at `crates/mvm-guest/src/bin/mvm-guest-agent.rs` (~2400
+6	# LOC of vsock RPC + worker-pool dispatch + integration manifest +
+7	# system metrics). Side-bins `mvm-seccomp-apply` (the per-service
+8	# seccomp shim, ADR-002 §W2.4) and `mvm-verity-init` (the verity-
+9	# initrd PID 1, ADR-002 §W3) ride the same derivation since the
+10	# rootfs needs them too.
+11	#
+12	# ## Build environment
+13	#
+14	# `rustPlatform.buildRustPackage` against the workspace at
+15	# `mvmSrc`. The crate is built with `--package mvm-guest --bins`
+16	# so the workspace's heavier consumers (mvm, mvm-backend,
+17	# libkrun, etc.) don't enter the closure. Cargo still
+18	# resolves and vendors the full workspace lockfile, but only the
+19	# selected crate's deps compile.
+20	#
+21	# ## Cross-targeting
+22	#
+23	# The caller passes `pkgs` for the target system (e.g. on a macOS
+24	# host with nix-darwin's linux-builder configured, the caller
+25	# resolves `pkgs.pkgsCross.aarch64-multiplatform.pkgs` and hands
+26	# it here). For native Linux + KVM the caller's own `pkgs` is
+27	# already the right thing. The W7.x.2 builder VM sets this up
+28	# transparently — `nix build` inside the sandbox runs on Linux,
+29	# so `pkgs` is Linux pkgs.
+30	#
+31	# ## Features
+32	#
+33	# `dev-shell` is opt-in. With it, the agent accepts the `Exec`
+34	# vsock request and shells out arbitrary commands — required for
+35	# `mvmctl exec`/`mvmctl console` against dev images. Without it
+36	# (production), the `Exec` symbol is absent (ADR-002 §W4.3's
+37	# `prod-agent-no-exec` CI gate is what enforces this on the
+38	# release lane).
+39
+40	{ pkgs
+41	, lib
+42	, mvmSrc
+43	, withDevShell ? false
+44	}:
+45
+46	pkgs.rustPlatform.buildRustPackage {
+47	  pname = "mvm-guest-agent";
+48	  version = "0.14.0";
+49
+50	  src = mvmSrc;
+51
+52	  # Workspace's Cargo.lock is the source of truth for every crate
+53	  # we vendor. `buildRustPackage` vendors the closure even though
+54	  # we only build mvm-guest; the unused deps compile zero code.
+55	  cargoLock.lockFile = mvmSrc + "/Cargo.lock";
+56
+57	  # Restrict the build to the mvm-guest binaries. The workspace
+58	  # has heavier members (libkrun via mvm-build, libkrun via
+59	  # mvm-providers, etc.) that aren't in the guest closure.
+60	  cargoBuildFlags = [
+61	    "--package" "mvm-guest"
+62	    "--bin" "mvm-guest-agent"
+63	    "--bin" "mvm-seccomp-apply"
+64	    "--bin" "mvm-verity-init"
+65	    # Plan 74 W2 — guest-side network defense. Installs kernel
+66	    # blackhole routes for `MANDATORY_DENY_RANGES` at boot from
+67	    # `/init` (uid 0) before the main agent forks under setpriv.
+68	    "--bin" "mvm-guest-netinit"
+69	  ] ++ lib.optionals withDevShell [
+70	    "--features" "mvm-guest/dev-shell"
+71	  ];
+72
+73	  # Same selection for the `nix flake check`-equivalent test run.
+74	  # mvm-guest's tests are pure (vsock framing, integration manifest
+75	  # parsing, seccomp filter golden tests) so they run inside the
+76	  # sandbox without privilege.
+77	  cargoTestFlags = [
+78	    "--package" "mvm-guest"
+79	  ];
+80
+81	  # Skip tests by default — they need a Linux build host and the
+82	  # builder VM already runs `nix build` (not `nix flake check`).
+83	  # CI's dedicated test lane covers the Rust test suite directly.
+84	  doCheck = false;
+85
+86	  meta = with lib; {
+87	    description = "mvm guest agent — vsock RPC handler for microVM guests";
+88	    homepage = "https://github.com/tinylabscom/mvm";
+89	    license = licenses.asl20;
+90	    platforms = platforms.linux;
+91	  };
+92	}
+93
+```
+
+**Tool Call: Read nix/images/builder-vm/flake.nix**
+Status: Completed
+
+```
+1	{
+2	  description = "mvm builder VM image — kernel + rootfs.ext4 with Nix + tools + mvm-builder-init (Plan 72 W2)";
+3
+4	  # ── Why this flake exists ────────────────────────────────────────────
+5	  #
+6	  # Plan 72 (ADR-046) replaces the libkrun-backed builder VM
+7	  # (`nix/images/builder/`, which is actually the dev-shell image
+8	  # despite the name) with a libkrun-direct launcher
+9	  # (`LibkrunBuilderVm`, Plan 72 W1). This flake is the artifact
+10	  # `LibkrunBuilderVm` boots into: a small Linux kernel + ext4
+11	  # rootfs containing Nix + a curated build-tools subset +
+12	  # `mvm-builder-init` (Plan 72 W3) at `/sbin/mvm-builder-init`.
+13	  #
+14	  # `packages.<system>.default` produces `$out/{vmlinux,rootfs.ext4,
+15	  # cmdline.txt,manifest.json}`. CI (Plan 72 W2 release-workflow
+16	  # follow-up) uploads these as `builder-vmlinux-<arch>` and
+17	  # `builder-rootfs-<arch>.ext4` alongside the existing dev-image
+18	  # outputs.
+19	  #
+20	  # Distinct from `nix/images/builder/flake.nix` which produces the
+21	  # dev-shell image (`mvm-dev`) — the rootfs a user `dev shell`s
+22	  # into. The names will reshuffle in Plan 72 W6 hygiene; for now
+23	  # the two flakes coexist and `mvmctl dev up` will pick the right
+24	  # one via `find_builder_vm_flake` / `find_dev_image_flake`.
+25	  #
+26	  # ── Architecture / workspace staging ──────────────────────────────
+27	  #
+28	  # Identical pattern to `nix/images/builder/flake.nix`:
+29	  #
+30	  # - Stage the workspace via `builtins.path` (filter out `target/`,
+31	  #   `.git/`, etc.) so the flake works both on a host running
+32	  #   `nix build` directly and inside the libkrun builder VM's
+33	  #   `path:` URL fetch (W4).
+34	  # - `MVM_WORKSPACE_PATH` env var override for the sandbox case
+35	  #   (avoids the `../../..` resolution-against-store-copy trap
+36	  #   that bit `nix/images/builder/flake.nix` in Plan 72 W0).
+37	  # - Import the parent flake's `nix/lib/` directly (skip flake-
+38	  #   input chain → no path-input lock validation issue).
+39	  #
+40	  # ── Builder VM package set ────────────────────────────────────────
+41	  #
+42	  # Per Plan 72 §W2, narrower than the dev-shell image:
+43	  #
+44	  # - Static busybox (provides `/bin/sh`, `udhcpc`, `sync`, basic
+45	  #   POSIX utilities — small footprint).
+46	  # - Nix (the whole point of the VM).
+47	  # - Bash + coreutils + gnugrep / gnused / gawk / findutils / which
+48	  #   (user's `cmd.sh` is shell, not necessarily POSIX-only).
+49	  # - Git + gnumake + curl + jq (Nix flakes pull from git, builds
+50	  #   often run make / curl, `cmd.sh` may format JSON).
+51	  # - e2fsprogs (`mkfs.ext4` for the first-boot format of the
+52	  #   persistent `/nix` store) + util-linux (`mount`, `umount`,
+53	  #   `losetup`).
+54	  # - iproute2 (used by `udhcpc` and friends; small).
+55	  # - iptables — Plan 73 Followup B.2.y / ADR-047 defense-in-
+56	  #   depth: `mvm-builder-init` installs an OUTPUT-chain
+57	  #   default-deny + uid-owner ACCEPT for `mvm-egress-proxy`
+58	  #   (uid 1801), so a build step that ignores `HTTP_PROXY`
+59	  #   cannot reach upstream. See
+60	  #   `crates/mvm-builder-init/src/network.rs`.
+61	  # - **No** `procps`-interactive / `less` per the plan's
+62	  #   slimming directive.
+63	  # - `mvm-builder-init` mounted at `/sbin/mvm-builder-init` via
+64	  #   `extraFiles`. The kernel cmdline (`cmdline.txt` output)
+65	  #   sets `init=/sbin/mvm-builder-init` so this becomes PID 1.
+66
+67	  inputs = {
+68	    nixpkgs.url = "github:NixOS/nixpkgs/nixos-25.11";
+69	    microvm = {
+70	      url = "github:microvm-nix/microvm.nix";
+71	      inputs.nixpkgs.follows = "nixpkgs";
+72	    };
+73	  };
+74
+75	  outputs =
+76	    { self, nixpkgs, microvm, ... }:
+77	    let
+78	      systems = [ "aarch64-linux" "x86_64-linux" ];
+79	      forAllSystems = nixpkgs.lib.genAttrs systems;
+80
+81	      workspaceRoot =
+82	        let
+83	          envPath = builtins.getEnv "MVM_WORKSPACE_PATH";
+84	        in
+85	        if envPath != "" then /. + envPath else ../../..;
+86
+87	      workspace = builtins.path {
+88	        path = workspaceRoot;
+89	        name = "mvm-workspace";
+90	        filter =
+91	          path: _type:
+92	          let
+93	            base = baseNameOf path;
+94	          in
+95	          !(builtins.elem base [
+96	            "target"
+97	            ".git"
+98	            "result"
+99	            "node_modules"
+100	            ".direnv"
+101	            ".cargo"
+102	            ".claude"
+103	            ".worktrees"
+104	          ])
+105	          && !(nixpkgs.lib.hasPrefix "result-" base);
+106	      };
+107
+108	      libFor = import (workspace + "/nix/lib") {
+109	        inherit nixpkgs microvm;
+110	        mvmSrc = workspace;
+111	      };
+112
+113	      # ADR-050 / issue #223 — veritysetup sidecar bytes must not drift
+114	      # when nixpkgs revs. The OCI-pull path runs `veritysetup format`
+115	      # inside this builder VM, while the Nix-built baseline runs it in
+116	      # `nix/images/runtime-overlay/flake.nix`. Both flakes intentionally
+117	      # pin the same cryptsetup release + tarball hash, and both must be
+118	      # reviewed together on bump.
+119	      pinnedCryptsetupVersion = "2.8.6";
+120	      pinnedCryptsetupSrcHash = "sha256-gAQmX9mTiF0I97Yz2+BWhR3hohAwdhOk693HQ/zO/lo=";
+121	      pinnedCryptsetupFor = pkgs:
+122	        pkgs.cryptsetup.overrideAttrs (_old: {
+123	          version = pinnedCryptsetupVersion;
+124	          src = pkgs.fetchurl {
+125	            url =
+126	              "mirror://kernel/linux/utils/cryptsetup/v${pkgs.lib.versions.majorMinor pinnedCryptsetupVersion}/"
+127	              + "cryptsetup-${pinnedCryptsetupVersion}.tar.xz";
+128	            hash = pinnedCryptsetupSrcHash;
+129	          };
+130	        });
+131
+132	      # Per Plan 72 §W2 — narrower than the dev-shell image.
+133	      # See module-level docs above for the rationale on each.
+134	      #
+135	      # Plan 73 Followup B.2 adds the application-dependency
+136	      # install pipeline (ADR-047): `uv` / `pnpm` drive the
+137	      # installer, `cyclonedx-py` / `pnpm sbom` emit SBOMs, and
+138	      # `pip-audit` / `pnpm audit` run the CVE scan. Each is
+139	      # currently a soft gate — `mvm-builder-init::install`
+140	      # emits a CycloneDX-1.5 empty stub when the SBOM / CVE
+141	      # tool isn't on PATH and logs a warning. B.2.x will
+142	      # hard-gate the SBOM + CVE side once the egress allowlist
+143	      # lands.
+144	      #
+145	      # Plan 73 Followup B.2.x closed the egress side: the
+146	      # builder VM now runs `mvm-egress-proxy` (built via
+147	      # `mvmEgressProxyFor system`, installed at
+148	      # `/sbin/mvm-egress-proxy` via `extraFiles` below).
+149	      # `mvm-builder-init::install::run_install` spawns it
+150	      # before the installer + injects `HTTPS_PROXY` /
+151	      # `HTTP_PROXY` on `uv` / `pnpm`'s env. The proxy refuses
+152	      # anything outside ADR-047's four hostnames:
+153	      # `pypi.org`, `files.pythonhosted.org`,
+154	      # `registry.npmjs.org`, `objects.githubusercontent.com`.
+155	      # Complementary iptables drop-rule defense-in-depth is
+156	      # B.2.y (not in this slice).
+157	      builderPackages = pkgs: with pkgs; [
+158	        bashInteractive
+159	        coreutils
+160	        # `pkgsStatic.busybox` for the lightweight utilities that
+161	        # mvm-builder-init spawns by absolute path — chiefly
+162	        # `/sbin/udhcpc` (busybox applet) for DHCP on the builder
+163	        # VM's eth0. Without busybox in `packages`, mkGuest's
+164	        # symlink loop (nix/lib/mk-guest.nix:770-788) skips it
+165	        # and `/sbin/udhcpc` doesn't exist → setup_network bails.
+166	        pkgsStatic.busybox
+167	        gnugrep
+168	        gnused
+169	        gawk
+170	        findutils
+171	        which
+172	        nix
+173	        git
+174	        gnumake
+175	        curl
+176	        jq
+177	        iproute2
+178	        # iptables — installed at boot by mvm-builder-init's
+179	        # network::install_egress_lockdown (Plan 73 Followup
+180	        # B.2.y / ADR-047). FATAL if absent.
+181	        iptables
+182	        e2fsprogs
+183	        util-linux
+184	        (pinnedCryptsetupFor pkgs) # provides pinned veritysetup
+185	        # Plan 73 Followup B.2 — app-deps install pipeline.
+186	        uv
+187	        pnpm
+188	        # NOTE (Plan 72 W5.D unblock): `python3Packages.cyclonedx-bom`
+189	        # and `python3Packages.pip-audit` are referenced here but not
+190	        # present in nixpkgs-25.11 under those exact attribute names;
+191	        # the Stage 0 nix eval bails with "attribute 'cyclonedx-bom'
+192	        # missing". Commented out until the right attribute name (or
+193	        # a newer nixpkgs pin that has them) lands. Plan 73's
+194	        # deps-volume audit pipeline still works at runtime via the
+195	        # `mvm-egress-proxy` allowlist; the SBOM/CVE tools were a
+196	        # nice-to-have inside the builder VM, not a load-bearing
+197	        # blocker for `mvmctl dev up`.
+198	        # python3Packages.cyclonedx-bom
+199	        # python3Packages.pip-audit
+200	      ];
+201
+202	      # Build `mvm-builder-init` (Plan 72 W3) for the target system.
+203	      # `rustPlatform.buildRustPackage` consumes the workspace's
+204	      # `Cargo.lock` so the dependency closure matches the rest of
+205	      # the workspace — same `nix` crate version we cargo-check on
+206	      # macOS, same nothing-else.
+207	      #
+208	      # `doCheck = false` because the unit tests under
+209	      # `mvm-builder-init::linux::tests` already run in the
+210	      # workspace's `cargo test` CI lane; running them again here
+211	      # would double-pay the closure compute for no extra signal.
+212	      mvmBuilderInitFor = system:
+213	        let
+214	          pkgs = import nixpkgs { inherit system; };
+215	        in
+216	        pkgs.rustPlatform.buildRustPackage {
+217	          pname = "mvm-builder-init";
+218	          version = "0.14.0";
+219	          src = workspace;
+220	          cargoLock = {
+221	            lockFile = workspace + "/Cargo.lock";
+222	          };
+223	          buildAndTestSubdir = "crates/mvm-builder-init";
+224	          doCheck = false;
+225	          meta = {
+226	            description = "PID-1 for the libkrun builder VM (Plan 72 W3)";
+227	            mainProgram = "mvm-builder-init";
+228	          };
+229	        };
+230
+231	      # Build `mvm-egress-proxy` (Plan 73 Followup B.2.x) for the
+232	      # target system. Same `rustPlatform.buildRustPackage` shape
+233	      # as `mvm-builder-init` — the workspace's `Cargo.lock`
+234	      # drives the closure so we don't fork dep versions across
+235	      # the two builder-VM binaries. Tests run in CI's
+236	      # `cargo test --workspace` lane; `doCheck = false` here for
+237	      # the same reason.
+238	      mvmEgressProxyFor = system:
+239	        let
+240	          pkgs = import nixpkgs { inherit system; };
+241	        in
+242	        pkgs.rustPlatform.buildRustPackage {
+243	          pname = "mvm-egress-proxy";
+244	          version = "0.14.0";
+245	          src = workspace;
+246	          cargoLock = {
+247	            lockFile = workspace + "/Cargo.lock";
+248	          };
+249	          buildAndTestSubdir = "crates/mvm-egress-proxy";
+250	          doCheck = false;
+251	          meta = {
+252	            description = "Builder-VM egress allowlist proxy (Plan 73 Followup B.2.x, ADR-047)";
+253	            mainProgram = "mvm-egress-proxy";
+254	          };
+255	        };
+256
+257	      # Canonical kernel cmdline for the builder VM. `LibkrunBuilderVm`
+258	      # (Plan 72 W4) reads this from the cmdline.txt output and
+259	      # passes it to `mvm_libkrun::KrunContext.kernel_cmdline`.
+260	      #
+261	      # - `console=hvc0` — libkrun's virtio-console (no serial).
+262	      # - `root=/dev/vda` — rootfs.ext4 attached as virtio-blk.
+263	      # - `ro` — root is read-only; writes go to the persistent
+264	      #   /nix-store virtio-blk at /dev/vdb (Plan 72 W4 wires it).
+265	      # - `rootfstype=ext4` — skip filesystem auto-detection.
+266	      # - `init=/sbin/mvm-builder-init` — Plan 72 W3 binary as PID 1.
+267	      builderCmdline = "console=hvc0 root=/dev/vda ro rootfstype=ext4 init=/sbin/mvm-builder-init";
+268
+269	      # Rootfs builder. The custom kernel under `./kernel` is built
+270	      # `CONFIG_MODULES=n` (everything in-tree is `=y`), so the
+271	      # rootfs ships no `/lib/modules/<kver>/` tree and mkGuest's
+272	      # kernel arg goes unused — same rootfs whether we're producing
+273	      # the full builder-VM image or the Stage 0 seed.
+274	      # Plan 92 — `specs/plans/92-minimal-builder-vm-kernel.md`.
+275	      mkBuilderVmRootfs =
+276	        system:
+277	        let
+278	          pkgs = import nixpkgs { inherit system; };
+279	          builderInit = mvmBuilderInitFor system;
+280	          egressProxy = mvmEgressProxyFor system;
+281	        in
+282	        (libFor { inherit system; }).mkGuest {
+283	          name = "mvm-builder-vm";
+284	          # mkGuest requires an entrypoint declaration. At runtime
+285	          # the kernel cmdline sets `init=/sbin/mvm-builder-init`,
+286	          # so mkGuest's entrypoint is vestigial — but we still
+287	          # need to declare one to satisfy the type contract.
+288	          entrypoint.shell = "/bin/sh";
+289	          packages = builderPackages pkgs;
+290	          extraFiles = {
+291	            "/sbin/mvm-builder-init" =
+292	              "${builderInit}/bin/mvm-builder-init";
+293	            # Plan 73 Followup B.2.x — egress allowlist proxy.
+294	            # `mvm-builder-init::install::run_install` spawns
+295	            # this from PATH (kernel default PATH includes
+296	            # `/sbin`) before invoking `uv` / `pnpm`. The
+297	            # binary embeds the ADR-047 four-hostname list at
+298	            # compile time; no env-var override path on the
+299	            # production build.
+300	            "/sbin/mvm-egress-proxy" =
+301	              "${egressProxy}/bin/mvm-egress-proxy";
+302	          };
+303	        };
+304
+305	      mkBuilderVmImage = system:
+306	        let
+307	          pkgs = import nixpkgs { inherit system; };
+308	          builderInit = mvmBuilderInitFor system;
+309	          egressProxy = mvmEgressProxyFor system;
+310	          # Slim custom kernel — see `./kernel/default.nix`.
+311	          # `pkgs.linuxManualConfig` over `make tinyconfig` + a
+312	          # narrow `enables` list. `CONFIG_MODULES=n` so the kernel
+313	          # has only what `mvm-builder-init` actually uses built-in
+314	          # — no driver modules tree to ship.
+315	          # Plan 92 — `specs/plans/92-minimal-builder-vm-kernel.md`.
+316	          kernelPkg = import ./kernel { inherit pkgs; };
+317	          rootfs = mkBuilderVmRootfs system;
+318	          kernelFile =
+319	            if pkgs.stdenv.hostPlatform.isAarch64 then "Image" else "bzImage";
+320	        in
+321	        pkgs.runCommand "mvm-builder-vm-image-${system}"
+322	          {
+323	            passthru = {
+324	              inherit rootfs builderInit egressProxy;
+325	              kernel = kernelPkg;
+326	              cmdline = builderCmdline;
+327	            };
+328	          }
+329	          ''
+330	            mkdir -p $out
+331
+332	            # Kernel.
+333	            if [ -f ${kernelPkg}/${kernelFile} ]; then
+334	              cp ${kernelPkg}/${kernelFile} $out/vmlinux
+335	            elif [ -f ${kernelPkg}/Image ]; then
+336	              cp ${kernelPkg}/Image $out/vmlinux
+337	            elif [ -f ${kernelPkg}/bzImage ]; then
+338	              cp ${kernelPkg}/bzImage $out/vmlinux
+339	            else
+340	              echo "kernel package ${kernelPkg} did not produce Image or bzImage" >&2
+341	              ls -la ${kernelPkg} >&2
+342	              exit 1
+343	            fi
+344
+345	            # Rootfs.
+346	            if [ -f ${rootfs} ]; then
+347	              cp ${rootfs} $out/rootfs.ext4
+348	            else
+349	              img=$(find ${rootfs} -maxdepth 1 -name '*.img' -o -name '*.ext4' | head -1)
+350	              if [ -z "$img" ]; then
+351	                echo "mkGuest output at ${rootfs} contains no .img or .ext4 file" >&2
+352	                ls -la ${rootfs} >&2
+353	                exit 1
+354	              fi
+355	              cp "$img" $out/rootfs.ext4
+356	            fi
+357
+358	            chmod 0644 $out/vmlinux $out/rootfs.ext4
+359
+360	            # Canonical kernel cmdline — Plan 72 W4's
+361	            # `LibkrunBuilderVm` reads this and threads it into
+362	            # `mvm_libkrun::KrunContext.kernel_cmdline`. Living next
+363	            # to the kernel makes the binding atomic with the image.
+364	            echo "${builderCmdline}" > $out/cmdline.txt
+365
+366	            # SHA-256 + size manifest, sister to the dev-image's
+367	            # release-artifact pattern. `download_builder_vm_image`
+368	            # (Plan 72 W5) verifies these against the release
+369	            # manifest before extracting.
+370	            kernel_sha=$(sha256sum $out/vmlinux | cut -d' ' -f1)
+371	            rootfs_sha=$(sha256sum $out/rootfs.ext4 | cut -d' ' -f1)
+372	            kernel_size=$(stat -c%s $out/vmlinux)
+373	            rootfs_size=$(stat -c%s $out/rootfs.ext4)
+374	            cat > $out/manifest.json <<MANIFEST
+375	            {
+376	              "name": "mvm-builder-vm",
+377	              "system": "${system}",
+378	              "vmlinux":      { "sha256": "$kernel_sha", "size": $kernel_size },
+379	              "rootfs_ext4":  { "sha256": "$rootfs_sha", "size": $rootfs_size },
+380	              "cmdline": "${builderCmdline}"
+381	            }
+382	            MANIFEST
+383	          '';
+384
+385	      mkBuilderVmStage0Rootfs = system:
+386	        let
+387	          pkgs = import nixpkgs { inherit system; };
+388	          # Stage 0 boots under a different kernel than what nixpkgs
+389	          # ships, so omit the kernel + module tree to avoid
+390	          # misleading modprobe with a foreign kver.
+391	          rootfs = mkBuilderVmRootfs system;
+392	        in
+393	        pkgs.runCommand "mvm-builder-vm-stage0-rootfs-${system}" { } ''
+394	          mkdir -p $out
+395
+396	          if [ -f ${rootfs} ]; then
+397	            cp ${rootfs} $out/rootfs.ext4
+398	          else
+399	            img=$(find ${rootfs} -maxdepth 1 -name '*.img' -o -name '*.ext4' | head -1)
+400	            if [ -z "$img" ]; then
+401	              echo "mkGuest output at ${rootfs} contains no .img or .ext4 file" >&2
+402	              ls -la ${rootfs} >&2
+403	              exit 1
+404	            fi
+405	            cp "$img" $out/rootfs.ext4
+406	          fi
+407
+408	          chmod 0644 $out/rootfs.ext4
+409	          echo "${builderCmdline}" > $out/cmdline.txt
+410
+411	          rootfs_sha=$(sha256sum $out/rootfs.ext4 | cut -d' ' -f1)
+412	          rootfs_size=$(stat -c%s $out/rootfs.ext4)
+413	          cat > $out/manifest.json <<MANIFEST
+414	          {
+415	            "name": "mvm-builder-vm-stage0-rootfs",
+416	            "system": "${system}",
+417	            "rootfs_ext4": { "sha256": "$rootfs_sha", "size": $rootfs_size },
+418	            "cmdline": "${builderCmdline}",
+419	            "stage0_rootfs_only": true
+420	          }
+421	          MANIFEST
+422	        '';
+423	      # Plan 95 W2 — expose the generated kernel `.config` as a
+424	      # standalone flake output so contributors can audit what
+425	      # `make defconfig + enables/disables + olddefconfig` actually
+426	      # produced without temporarily editing this flake. Build with:
+427	      #
+428	      #   nix build .#kernel-configfile -o /tmp/kconfig
+429	      #   grep '=y$' /tmp/kconfig | sort > /tmp/kconfig.y.txt
+430	      #
+431	      # The file is a regular `.config` text file — diffable across
+432	      # `disables` edits to confirm SoC platform clusters are gone.
+433	      mkKernelConfigfile = system:
+434	        let pkgs = import nixpkgs { inherit system; };
+435	        in (import ./kernel { inherit pkgs; }).passthru.configfile;
+436	    in
+437	    {
+438	      packages = forAllSystems (system: {
+439	        default = mkBuilderVmImage system;
+440	        stage0-rootfs = mkBuilderVmStage0Rootfs system;
+441	        kernel-configfile = mkKernelConfigfile system;
+442	      });
+443	    };
+444	}
+445
+```
+
+**Tool Call: Read nix/lib/mk-guest.nix (1 - 100)**
+Status: Completed
+
+```
+1	# mkGuest — busybox-as-PID-1 microVM image builder.
+2	#
+3	# Same flake the user writes is consumed in BOTH dev and production
+4	# builds. The "sealed vs accessible" distinction is encoded by:
+5	#
+6	#   1. The entrypoint shape:
+7	#        entrypoint.shell    = "/bin/sh"           # accessible (dev-style)
+8	#        entrypoint.command  = [ "/usr/local/bin/web" ]   # sealed default
+9	#        entrypoint.services = { … }               # multi-service supervised
+10	#
+11	#   2. The explicit `dev` flag (overrides the entrypoint heuristic):
+12	#        dev = true   # always enables the console + reachable shell
+13	#        dev = false  # never enables console regardless of entrypoint
+14	#
+15	# Inferred default: `dev = (entrypoint ? shell)`. mvmctl reads the
+16	# `passthru.mvm.{accessible, sealed, entrypointKind}` metadata to
+17	# gate `mvmctl console <vm>` host-side; the `/etc/mvm/variant` file
+18	# baked into the rootfs is the in-guest cross-check.
+19	#
+20	# ── Why busybox-as-PID-1, not NixOS+systemd ──
+21	#
+22	# ADR-013 §"Boot-time budget" is the source of truth. The short
+23	# version: NixOS+systemd boots in 1-3 s; Alpine+OpenRC in 300-500 ms;
+24	# busybox-as-PID-1 with custom init approaches the upstream Firecracker
+25	# reference of ~125 ms. The 200ms cold-boot target on Firecracker
+26	# requires the busybox path. The previous iteration of mvm shipped
+27	# this exact strategy.
+28	#
+29	# microvm.nix is still pinned as a flake input (per ADR-013) for its
+30	# hypervisor abstractions and kernel-config helpers, but we DO NOT
+31	# use its NixOS module — that's the systemd-heavy path we're
+32	# explicitly avoiding here.
+33
+34	{ nixpkgs, microvm, mvmSrc }:
+35	{ system }:
+36	let
+37	  pkgs = import nixpkgs { inherit system; };
+38	  lib  = nixpkgs.lib;
+39
+40
+41	  # Static busybox — single binary, every shell utility as an applet.
+42	  # `pkgsStatic` ensures no glibc dynamic-linker hop at /init time
+43	  # (which alone saves ~10ms vs a glibc-linked init).
+44	  busybox = pkgs.pkgsStatic.busybox;
+45
+46	  classifyEntrypoint = ep:
+47	    let
+48	      hasShell    = ep ? shell;
+49	      hasCommand  = ep ? command;
+50	      hasServices = ep ? services;
+51	      forms       = lib.count (b: b) [ hasShell hasCommand hasServices ];
+52	    in
+53	    if forms == 0 then
+54	      throw ''
+55	        mkGuest: entrypoint must declare exactly one of:
+56	          { shell    = "/bin/sh"; }
+57	          { command  = [ "/usr/local/bin/x" ]; }
+58	          { services = { web = { command = … }; … }; }
+59	        Got: ${builtins.toJSON ep}
+60	      ''
+61	    else if forms > 1 then
+62	      throw "mkGuest: entrypoint must declare exactly one form, not several"
+63	    else if hasShell then "shell"
+64	    else if hasCommand then "command"
+65	    else "services";
+66
+67	  # Render a single command list as a quoted shell command line.
+68	  renderCommand = argv:
+69	    lib.concatStringsSep " " (map lib.escapeShellArg argv);
+70	in
+71	{ name
+72	, entrypoint
+73	, services       ? { }
+74	, packages       ? [ ]
+75	, hypervisor     ? "firecracker"
+76	, vcpus          ? 1
+77	, memory_mib     ? 256
+78	, dev            ? null
+79	, uids           ? null   # { agent = <int>; entrypoint = <int>; } — see below
+80	, extraFiles     ? { }
+81	# Optional kernel package. When set, mkGuest copies its module
+82	# tree (`/lib/modules/<kver>/`) into the rootfs and `/init` runs
+83	# `modprobe vmw_vsock_virtio_transport` before forking the agent.
+84	# Required when the kernel ships AF_VSOCK as a module (the default
+85	# nixpkgs `linuxPackages.kernel` config). Without it,
+86	# `mvm-guest-agent`'s `socket(AF_VSOCK, …)` returns EAFNOSUPPORT and
+87	# every host-side surface (`mvmctl console`, `dev shell`, `build`)
+88	# goes dark on a guest booted from that kernel.
+89	, kernel         ? null
+90	}:
+91	let
+92	  entrypointKind = classifyEntrypoint entrypoint;
+93	  isDev =
+94	    if dev == null then entrypointKind == "shell"
+95	    else dev;
+96	  isSealed = !isDev;
+97
+98	  # ── Guest agent build (W6.1.2) ─────────────────────────────────
+99	  #
+100	  # Real Rust binary built from the workspace at `mvmSrc` via
+```
+
+**Tool Call: grep "passwd|group|nixbld" nix/lib/mk-guest.nix**
+Status: Completed
+
+156- if uids != null && uids ? entrypoint
+157- then uids.entrypoint
+158- else defaultEntrypointUid;
+159- };
+160-
+161: # GID == UID by convention. /etc/group entries below mirror this.
+162- # Phase 6 (W2.1) introduces per-service derived gids; for the
+163- # Phase 1 W6.1 slice we keep it simple.
+164- agentUid = resolvedUids.agent;
+165- entrypointUid = resolvedUids.entrypoint;
+166-
+167- # Wrap a command-line in `setpriv` when the target uid is non-zero.
+168- #
+169- # **util-linux's setpriv, not busybox's.** `pkgsStatic.busybox`
+170- # ships a stripped setpriv applet that only knows the bare
+171- # `-d / --nnp / --inh-caps / --ambient-caps` flags — `--reuid`,
+172: # `--regid`, and `--clear-groups` come from util-linux's full
+173- # setpriv binary. Invoking `/bin/busybox setpriv --reuid=…`
+174- # fails with `setpriv: unrecognized option: reuid=…`, killing
+175- # /init at stage 2.5 before the guest agent ever forks. The
+176- # Nix store path to util-linux's setpriv is baked in at build
+177- # time and shipped in the rootfs's `/nix/store` closure.
+178- #
+179- # The flag set matches ADR-002 W2.3 (--reuid + --regid +
+180: # --clear-groups + --no-new-privs). uid==0 short-circuits to
+181- # the bare command — no point setpriv-ing to root.
+182- setprivWrap = uid: cmd:
+183- if uid == 0 then cmd
+184- else
+185- "exec ${pkgs.util-linux}/bin/setpriv "
+186-      + "--reuid=${toString uid} --regid=${toString uid} "
+187:      + "--clear-groups --no-new-privs -- ${cmd}";
+188-
+189-  rawEntrypointCmd =
+190-    if entrypointKind == "shell" then
+191-      "${lib.escapeShellArg entrypoint.shell} -i"
+192- else if entrypointKind == "command" then
+--
+340- /bin/busybox chmod 0644 /run/mvm/resolv.conf
+341- /bin/busybox mount --bind /run/mvm/resolv.conf /etc/resolv.conf
+342-
+343- /bin/busybox setsid ${pkgs.util-linux}/bin/setpriv \
+344-        --reuid=${toString agentUid} --regid=${toString agentUid} \
+345:        --clear-groups --no-new-privs \
+346-        --inh-caps=+net_bind_service --ambient-caps=+net_bind_service \
+347-        -- /usr/local/bin/mvm-addon-dns &
+348-    fi
+349-
+350-    # Stage 2.5 — guest agent supervisor. Fork the agent into
+--
+370-    elif [ -x /usr/local/bin/mvm-guest-agent ]; then
+371-      MVM_AGENT_BIN=/usr/local/bin/mvm-guest-agent
+372-    fi
+373-    if [ -n "$MVM_AGENT_BIN" ]; then
+374- # util-linux setpriv — busybox setpriv lacks --reuid /
+375: # --regid / --clear-groups; see `setprivWrap` above for
+376- # the full reasoning. Without this fix the agent never
+377- # forks and vsock port 5252 stays unbound.
+378- /bin/busybox setsid ${pkgs.util-linux}/bin/setpriv \
+379-        --reuid=${toString agentUid} --regid=${toString agentUid} \
+380:        --clear-groups --no-new-privs \
+381-        -- "$MVM_AGENT_BIN" &
+382- fi
+383-
+384- # Stage 3 — hostname + console. /dev/console is what the
+385- # hypervisor wires our virtio-console to; in dev mode we keep
+--
+595- cp ${variantFile} "$out/etc/mvm/variant"
+596- chmod 0444 "$out/etc/mvm/variant"
+597-    cp ${nameFile} "$out/etc/mvm/name"
+598- chmod 0444 "$out/etc/mvm/name"
+599-
+600:    # /etc/passwd + /etc/group provision root (mandatory for PID 1)
+601-    # plus the agent + entrypoint uids resolved at build time.
+602-    # Per ADR-002 W2.2 (Phase 6) these become read-only via bind-
+603-    # mount once the security overlay lands; for W6.1 they're
+604-    # plain mode 0644.
+605-    #
+606-    # When entrypoint uid happens to be 0 (dev-mode default), the
+607-    # entry collapses to the root row — guarded against the
+608-    # duplicate by skipping the second cat. Same for the agent
+609-    # uid in the unlikely override case.
+610:    cat > "$out/etc/passwd" <<EOF
+611- root:x:0:0:root:/root:/bin/sh
+612- EOF
+613- if [ "${toString agentUid}" != "0" ]; then
+614: printf 'mvm-agent:x:${toString agentUid}:${toString agentUid}:mvm guest agent:/var/empty:/bin/false\n' >> "$out/etc/passwd"
+615-    fi
+616-    if [ "${toString entrypointUid}" != "0" ] && [ "${toString entrypointUid}" != "${toString agentUid}" ]; then
+617: printf 'mvm-worker:x:${toString entrypointUid}:${toString entrypointUid}:mvm workload:/home/mvm-worker:/bin/sh\n' >> "$out/etc/passwd"
+618-      mkdir -p "$out/home/mvm-worker"
+619- chmod 0755 "$out/home/mvm-worker"
+620-    fi
+621:    chmod 0644 "$out/etc/passwd"
+622-
+623: cat > "$out/etc/group" <<EOF
+624-    root:x:0:
+625-    EOF
+626-    if [ "${toString agentUid}" != "0" ]; then
+627: printf 'mvm-agent:x:${toString agentUid}:\n' >> "$out/etc/group"
+628- fi
+629- if [ "${toString entrypointUid}" != "0" ] && [ "${toString entrypointUid}" != "${toString agentUid}" ]; then
+630: printf 'mvm-worker:x:${toString entrypointUid}:\n' >> "$out/etc/group"
+631- fi
+632: chmod 0644 "$out/etc/group"
+633-
+634- # Default /etc/resolv.conf and CA cert bundle — needed for any
+635- # guest that talks to the network over TLS (most Nix flake
+636- # fetches reach cache.nixos.org / api.github.com). Cloudflare +
+637- # Google as the canonical no-infra-of-my-own DNS defaults; the
+
+**Tool Call: git log --all --oneline --grep -i "guest.agent\|nixbld\|nix.config\|build.users.group" | head -30**
+Status: Completed
+
+Terminal:
+
+```
+fatal: ambiguous argument 'guest.agent\|nixbld\|nix.config\|build.users.group': unknown revision or path not in the working tree.
+Use '--' to separate paths from revisions, like this:
+'git <command> [<revision>...] -- [<file>...]'
+
+
+```
+
+**Tool Call: grep -C 10 "mvmGuestAgentFor" /Users/auser/work/tinylabs/mvmco/mvm/nix/images/builder-vm/flake.nix 2>/dev/null || echo "Not found in builder-vm"**
+Status: Completed
+
+Terminal:
+
+```
+Not found in builder-vm
+
+
+
+
+
+```
+
+**Tool Call: grep -r "mvmGuestAgentFor\|mvm-guest-agent" /Users/auser/work/tinylabs/mvmco/mvm/nix --include="\*.nix" 2>/dev/null | head -20**
+Status: Completed
+
+Terminal:
+
+```
+/Users/auser/work/tinylabs/mvmco/mvm/nix/images/runtime-overlay/flake.nix:  #    closure stops carrying `mvm-guest-agent`, `mvm-seccomp-apply`,
+/Users/auser/work/tinylabs/mvmco/mvm/nix/images/runtime-overlay/flake.nix:      # `nix/packages/mvm-guest-agent.nix`'s
+/Users/auser/work/tinylabs/mvmco/mvm/nix/images/runtime-overlay/flake.nix:      # `--bin mvm-guest-agent --bin mvm-seccomp-apply --bin mvm-verity-init`
+/Users/auser/work/tinylabs/mvmco/mvm/nix/images/runtime-overlay/flake.nix:        import (workspace + "/nix/packages/mvm-guest-agent.nix") {
+/Users/auser/work/tinylabs/mvmco/mvm/nix/images/runtime-overlay/flake.nix:            cp ${guest}/bin/mvm-guest-agent      "$staging/agent"
+/Users/auser/work/tinylabs/mvmco/mvm/nix/images/builder/flake.nix:  # `nix/packages/mvm-guest-agent.nix` reads `${mvmSrc}/Cargo.lock`
+/Users/auser/work/tinylabs/mvmco/mvm/nix/tests/mk-guest-eval.nix:  # mvm-guest-agent is the stub (W6.1.1) or the real binary
+/Users/auser/work/tinylabs/mvmco/mvm/nix/flake.nix:    # flake. `mvm-guest-agent.nix` reads `Cargo.lock` from `mvmSrc`,
+/Users/auser/work/tinylabs/mvmco/mvm/nix/flake.nix:      # `nix/packages/mvm-guest-agent.nix` can resolve
+/Users/auser/work/tinylabs/mvmco/mvm/nix/packages/mvm-addon-dns.nix:# rootfs alongside `mvm-guest-agent` so every guest carries the binary;
+/Users/auser/work/tinylabs/mvmco/mvm/nix/packages/mvm-guest-agent.nix:# `mvm-guest-agent` — the production guest agent binary.
+/Users/auser/work/tinylabs/mvmco/mvm/nix/packages/mvm-guest-agent.nix:# defined at `crates/mvm-guest/src/bin/mvm-guest-agent.rs` (~2400
+/Users/auser/work/tinylabs/mvmco/mvm/nix/packages/mvm-guest-agent.nix:  pname = "mvm-guest-agent";
+/Users/auser/work/tinylabs/mvmco/mvm/nix/packages/mvm-guest-agent.nix:    "--bin" "mvm-guest-agent"
+/Users/auser/work/tinylabs/mvmco/mvm/nix/lib/mk-guest.nix:# `mvm-guest-agent`'s `socket(AF_VSOCK, …)` returns EAFNOSUPPORT and
+/Users/auser/work/tinylabs/mvmco/mvm/nix/lib/mk-guest.nix:  # `nix/packages/mvm-guest-agent.nix`. Replaces the W6.1.1 sh-stub
+/Users/auser/work/tinylabs/mvmco/mvm/nix/lib/mk-guest.nix:  guestAgentPkg = pkgs.callPackage ../packages/mvm-guest-agent.nix {
+/Users/auser/work/tinylabs/mvmco/mvm/nix/lib/mk-guest.nix:    # /usr/local/bin/mvm-guest-agent (which a future PR drops
+/Users/auser/work/tinylabs/mvmco/mvm/nix/lib/mk-guest.nix:    elif [ -x /usr/local/bin/mvm-guest-agent ]; then
+/Users/auser/work/tinylabs/mvmco/mvm/nix/lib/mk-guest.nix:      MVM_AGENT_BIN=/usr/local/bin/mvm-guest-agent
+```
+
+**Tool Call: git log --all --oneline | grep -iE "guest.agent|nixbld|nix.config|build.users|vsock.log" | head -30**
+Status: Completed
+
+Terminal:
+
+```
+ae18d56b docs(reference/guest-agent): plan 74 W3 — control plane / data plane inventory (#286)
+7bd6cb3d docs(reference/guest-agent): plan 74 W3 — control plane / data plane inventory
+73085f30 Plan 74 W1 — guest-agent protocol hello (hard cutover) (#242)
+b67768f7 feat(mvm-guest,mvm-cli): plan 74 W1 — guest-agent protocol hello + capability negotiation (hard cutover)
+05f956e3 feat(mvm-guest): plan 44 W3 — SIGHUP config reload in guest agent
+4bcdf4e4 feat(guest-agent): W6.1.2 — swap stub for real mvm-guest-agent binary
+c04f26bd fix(dev-vm): run guest agent as root in dev variant so nix builds work (#94)
+22e0aebc fix(security): move vsock guest-agent port out of priv range (ADR-002 §W4.5) (#80)
+4efa8693 feat: vsock retry/timeout, guest agent /bin/sh fix, openclaw template simplification
+f6118a19 refactor(build): remove post-build guest agent injection
+52174bdd feat(build): auto-inject guest agent into rootfs during nix builds
+269e5265 fix(nix): add rust-overlay for edition 2024, validate guest agent end-to-end
+4e8ea23d feat(guest): shared NixOS module for guest agent, scaffold + tests
+```
+
+**Tool Call: find /Users/auser/work/tinylabs/mvmco/mvm/crates/mvm-guest -name "build.rs" -o -name "Cargo.toml" | head -5**
+Status: Completed
+
+Terminal:
+
+```
+/Users/auser/work/tinylabs/mvmco/mvm/crates/mvm-guest/Cargo.toml
+/Users/auser/work/tinylabs/mvmco/mvm/crates/mvm-guest/fuzz/Cargo.toml
+
+
+
+
+```
+
+**Tool Call: Read nix/images/runtime-overlay/flake.nix (1 - 150)**
+Status: Completed
+
+```
+1	{
+2	  description = "mvm runtime overlay disk — verity-sealed ext4 carrying the guest agent + seccomp shim + netinit + runner, mounted at /mvm/runtime in every microVM (ADR-051)";
+3
+4	  # ── Why this flake exists ─────────────────────────────────────────
+5	  #
+6	  # ADR-051 (`specs/adrs/051-mvm-runtime-overlay-disk.md`) introduces
+7	  # a second virtio-blk device that every mvm microVM attaches at
+8	  # boot — Nix-built rootfs and OCI-pulled rootfs alike. The
+9	  # overlay carries the in-VM binaries mvm controls (the guest
+10	  # agent, the per-service seccomp shim, the function-workload
+11	  # runner, and — plan 74 W2 — `mvm-guest-netinit` which installs
+12	  # kernel blackhole routes for `MANDATORY_DENY_RANGES` so OCI-
+13	  # imported workloads get Layer 1 network defense too) plus a
+14	  # placeholder for the per-language SDK runtime libraries that
+15	  # ADR-049's vsock substitution depends on (the libraries
+16	  # themselves land in plan 74 W4; this flake reserves the
+17	  # directory layout today so the boot path is stable).
+18	  #
+19	  # The flake produces, per supported system, a `$out/` containing:
+20	  #
+21	  #   overlay.ext4      — the rootfs the kernel mounts at
+22	  #                       /mvm/runtime via dm-verity. Read-only at
+23	  #                       boot.
+24	  #   overlay.verity    — dm-verity sidecar (Merkle tree).
+25	  #   overlay.roothash  — 64 lowercase hex chars + newline. What
+26	  #                       mvm-verity-init reads from the kernel
+27	  #                       cmdline as `mvm.runtime_roothash=<hex>`.
+28	  #   VERSION           — semver of the producing mvmctl. The
+29	  #                       resolver (`mvm_build::runtime_overlay`,
+30	  #                       plan 74 W1.4b.1) refuses to attach an
+31	  #                       overlay whose VERSION disagrees with the
+32	  #                       running mvmctl's version.
+33	  #
+34	  # The four file names + the per-arch directory layout under
+35	  # `~/.cache/mvm/runtime-overlay/<version>/<arch>/` are the contract
+36	  # `RuntimeOverlayResolver::resolve` enforces. Renaming any of
+37	  # them breaks the resolver test
+38	  # `resolve_returns_artifact_when_all_files_present_and_version_matches`.
+39	  #
+40	  # ── Why a *separate* flake rather than rolling this into
+41	  # `nix/lib/mk-guest.nix` ───────────────────────────────────────────
+42	  #
+43	  # `mkGuest` builds per-image rootfs. The runtime overlay is *one*
+44	  # artifact shared by every microVM mvmctl boots, regardless of
+45	  # what `mkGuest` produces for the rootfs. Splitting the
+46	  # derivation here keeps two properties:
+47	  #
+48	  # 1. The overlay is rebuilt only when mvm bumps the agent /
+49	  #    runner / shim — *not* per user-supplied rootfs. The verity
+50	  #    roothash is content-addressable, so two identical overlays
+51	  #    cache-hit cleanly.
+52	  # 2. Per ADR-051's `mkGuest` refactor (W1.4b.3), the per-image
+53	  #    closure stops carrying `mvm-guest-agent`, `mvm-seccomp-apply`,
+54	  #    `mvm-runner`. Those binaries live here. Net effect: every
+55	  #    Nix-built image shrinks by ~10-15 MB.
+56	  #
+57	  # ── Why this flake doesn't pull in microvm.nix ─────────────────
+58	  #
+59	  # microvm.nix is the NixOS module that turns a system
+60	  # configuration into a Firecracker/Cloud-Hypervisor-bootable
+61	  # rootfs. It's overkill here: the overlay isn't a bootable VM,
+62	  # it's a verity-sealed data disk. We use bare `pkgs.runCommand`
+63	  # + the workspace's binaries + `mkfs.ext4 -d` + `veritysetup
+64	  # format`.
+65	  #
+66	  # ── Determinism ────────────────────────────────────────────────
+67	  #
+68	  # Two builds of this flake against the same workspace state
+69	  # must produce byte-identical `overlay.ext4` + `overlay.verity`
+70	  # + identical `overlay.roothash`. ADR-051's per-version cache
+71	  # depends on this property. We pin every source of mkfs.ext4
+72	  # randomness (UUID, hash_seed, SOURCE_DATE_EPOCH) and every
+73	  # source of veritysetup randomness (salt, data block size, hash
+74	  # algo). Nix's sandbox covers the rest (timestamps,
+75	  # parallelism-induced ordering).
+76	  #
+77	  # ── Cryptsetup version pin (issue #223) ────────────────────────
+78	  #
+79	  # The W3 verity build pins `cryptsetup` via the same nixpkgs
+80	  # commit. The OCI-pull path's seal_with_verity (W1.4a) inherits
+81	  # whatever cryptsetup is on `$PATH` in the builder VM. This
+82	  # flake stays consistent with the W3 derivation by routing
+83	  # through the same `nixpkgs.cryptsetup` attribute. Issue #223
+84	  # tracks tightening this to an explicit version override.
+85
+86	  inputs = {
+87	    nixpkgs.url = "github:NixOS/nixpkgs/nixos-25.11";
+88	  };
+89
+90	  outputs =
+91	    { self, nixpkgs, ... }:
+92	    let
+93	      systems = [ "aarch64-linux" "x86_64-linux" ];
+94	      forAllSystems = nixpkgs.lib.genAttrs systems;
+95
+96	      # Workspace staging — same `MVM_WORKSPACE_PATH` env override
+97	      # the builder-vm flake uses, for the libkrun-builder-VM
+98	      # sandbox case.
+99	      workspaceRoot =
+100	        let
+101	          envPath = builtins.getEnv "MVM_WORKSPACE_PATH";
+102	        in
+103	        if envPath != "" then /. + envPath else ../../..;
+104
+105	      workspace = builtins.path {
+106	        path = workspaceRoot;
+107	        name = "mvm-workspace";
+108	        filter =
+109	          path: _type:
+110	          let
+111	            base = baseNameOf path;
+112	          in
+113	          !(builtins.elem base [
+114	            "target"
+115	            ".git"
+116	            "result"
+117	            "node_modules"
+118	            ".direnv"
+119	            ".cargo"
+120	            ".claude"
+121	            ".worktrees"
+122	          ])
+123	          && !(nixpkgs.lib.hasPrefix "result-" base);
+124	      };
+125
+126	      # mvmctl semver pinned to match
+127	      # `[workspace.package].version` in the root Cargo.toml. The
+128	      # `RuntimeOverlayResolver` rejects an overlay whose VERSION
+129	      # file disagrees with the running mvmctl. Bumping the
+130	      # workspace version requires bumping this string too — keep
+131	      # the two in lock-step or `mvmctl up` admission fails.
+132	      overlayVersion = "0.14.0";
+133
+134	      # mvm-guest binaries — agent + seccomp shim + verity-init.
+135	      # `mvm-verity-init` is the initrd PID 1; it lives in the
+136	      # initramfs cpio.gz, *not* in this overlay. We still build
+137	      # it here because the rustPlatform derivation produces all
+138	      # three binaries from one `--package mvm-guest` build (per
+139	      # `nix/packages/mvm-guest-agent.nix`'s
+140	      # `--bin mvm-guest-agent --bin mvm-seccomp-apply --bin mvm-verity-init`
+141	      # flags); we just don't copy the verity-init binary into the
+142	      # overlay's staging dir.
+143	      mvmGuestFor = system:
+144	        let
+145	          pkgs = import nixpkgs { inherit system; };
+146	        in
+147	        import (workspace + "/nix/packages/mvm-guest-agent.nix") {
+148	          inherit pkgs;
+149	          lib = pkgs.lib;
+150	          mvmSrc = workspace;
+```
+
+**Tool Call: Read nix/packages/mvm-guest-agent.nix**
+Status: Completed
+
+```
+1	# `mvm-guest-agent` — the production guest agent binary.
+2	#
+3	# Plan-60 W6.1.2 swaps the W6.1.1 sh-script stub
+4	# (`nix/lib/mk-guest.nix::agentBinary`) for the real Rust binary
+5	# defined at `crates/mvm-guest/src/bin/mvm-guest-agent.rs` (~2400
+6	# LOC of vsock RPC + worker-pool dispatch + integration manifest +
+7	# system metrics). Side-bins `mvm-seccomp-apply` (the per-service
+8	# seccomp shim, ADR-002 §W2.4) and `mvm-verity-init` (the verity-
+9	# initrd PID 1, ADR-002 §W3) ride the same derivation since the
+10	# rootfs needs them too.
+11	#
+12	# ## Build environment
+13	#
+14	# `rustPlatform.buildRustPackage` against the workspace at
+15	# `mvmSrc`. The crate is built with `--package mvm-guest --bins`
+16	# so the workspace's heavier consumers (mvm, mvm-backend,
+17	# libkrun, etc.) don't enter the closure. Cargo still
+18	# resolves and vendors the full workspace lockfile, but only the
+19	# selected crate's deps compile.
+20	#
+21	# ## Cross-targeting
+22	#
+23	# The caller passes `pkgs` for the target system (e.g. on a macOS
+24	# host with nix-darwin's linux-builder configured, the caller
+25	# resolves `pkgs.pkgsCross.aarch64-multiplatform.pkgs` and hands
+26	# it here). For native Linux + KVM the caller's own `pkgs` is
+27	# already the right thing. The W7.x.2 builder VM sets this up
+28	# transparently — `nix build` inside the sandbox runs on Linux,
+29	# so `pkgs` is Linux pkgs.
+30	#
+31	# ## Features
+32	#
+33	# `dev-shell` is opt-in. With it, the agent accepts the `Exec`
+34	# vsock request and shells out arbitrary commands — required for
+35	# `mvmctl exec`/`mvmctl console` against dev images. Without it
+36	# (production), the `Exec` symbol is absent (ADR-002 §W4.3's
+37	# `prod-agent-no-exec` CI gate is what enforces this on the
+38	# release lane).
+39
+40	{ pkgs
+41	, lib
+42	, mvmSrc
+43	, withDevShell ? false
+44	}:
+45
+46	pkgs.rustPlatform.buildRustPackage {
+47	  pname = "mvm-guest-agent";
+48	  version = "0.14.0";
+49
+50	  src = mvmSrc;
+51
+52	  # Workspace's Cargo.lock is the source of truth for every crate
+53	  # we vendor. `buildRustPackage` vendors the closure even though
+54	  # we only build mvm-guest; the unused deps compile zero code.
+55	  cargoLock.lockFile = mvmSrc + "/Cargo.lock";
+56
+57	  # Restrict the build to the mvm-guest binaries. The workspace
+58	  # has heavier members (libkrun via mvm-build, libkrun via
+59	  # mvm-providers, etc.) that aren't in the guest closure.
+60	  cargoBuildFlags = [
+61	    "--package" "mvm-guest"
+62	    "--bin" "mvm-guest-agent"
+63	    "--bin" "mvm-seccomp-apply"
+64	    "--bin" "mvm-verity-init"
+65	    # Plan 74 W2 — guest-side network defense. Installs kernel
+66	    # blackhole routes for `MANDATORY_DENY_RANGES` at boot from
+67	    # `/init` (uid 0) before the main agent forks under setpriv.
+68	    "--bin" "mvm-guest-netinit"
+69	  ] ++ lib.optionals withDevShell [
+70	    "--features" "mvm-guest/dev-shell"
+71	  ];
+72
+73	  # Same selection for the `nix flake check`-equivalent test run.
+74	  # mvm-guest's tests are pure (vsock framing, integration manifest
+75	  # parsing, seccomp filter golden tests) so they run inside the
+76	  # sandbox without privilege.
+77	  cargoTestFlags = [
+78	    "--package" "mvm-guest"
+79	  ];
+80
+81	  # Skip tests by default — they need a Linux build host and the
+82	  # builder VM already runs `nix build` (not `nix flake check`).
+83	  # CI's dedicated test lane covers the Rust test suite directly.
+84	  doCheck = false;
+85
+86	  meta = with lib; {
+87	    description = "mvm guest agent — vsock RPC handler for microVM guests";
+88	    homepage = "https://github.com/tinylabscom/mvm";
+89	    license = licenses.asl20;
+90	    platforms = platforms.linux;
+91	  };
+92	}
+93
+```
+
+**Tool Call: grep -r "extraBuildInputs\|nativeBuildInputs\|buildInputs" /Users/auser/work/tinylabs/mvmco/mvm/nix/packages --include="\*.nix"**
+Status: Failed
+
+```
+Tool permission request failed: Error: Internal error
+```
+
+**Tool Call: Read crates/mvm-guest/Cargo.toml**
+Status: Completed
+
+```
+1	[package]
+2	name = "mvm-guest"
+3	version.workspace = true
+4	edition.workspace = true
+5	description = "vsock protocol and openclaw connector mapping for mvm"
+6	license.workspace = true
+7	repository.workspace = true
+8	homepage.workspace = true
+9	authors.workspace = true
+10
+11	[[bin]]
+12	name = "mvm-builder-agent"
+13	path = "src/bin/mvm-builder-agent.rs"
+14
+15	[[bin]]
+16	name = "mvm-guest-agent"
+17	path = "src/bin/mvm-guest-agent.rs"
+18
+19	# Exec-shim that compiles a syscall allowlist into a BPF program via
+20	# seccompiler, applies it via prctl, and execve's into the wrapped
+21	# command. mkServiceBlock wraps every guest service launch with this
+22	# shim so per-service seccomp filters are the default. ADR-002 §W2.4.
+23	[[bin]]
+24	name = "mvm-seccomp-apply"
+25	path = "src/bin/mvm-seccomp-apply.rs"
+26
+27	# Early-userspace init (PID 1) that runs from the verity initramfs
+28	# baked by `mkGuest` when `verifiedBoot = true`. Reads the roothash
+29	# from /proc/cmdline, constructs the dm-verity device-mapper target
+30	# via raw ioctls, mounts it, and switch_roots to the real /init.
+31	# Bypasses Firecracker's auto-appended `root=/dev/vda` by owning the
+32	# boot pivot in userspace. ADR-002 §W3.
+33	[[bin]]
+34	name = "mvm-verity-init"
+35	path = "src/bin/mvm-verity-init.rs"
+36
+37	# Plan 74 W2 — guest-side network defense. Installs kernel blackhole
+38	# routes for `MANDATORY_DENY_RANGES` (cloud metadata, link-local,
+39	# CGNAT, host loopback) inside every microVM. Run as root from
+40	# `/init` BEFORE the agent is forked under setpriv, so the routes
+41	# exist before any workload code can attempt egress. Cross-platform
+42	# (Linux kernel routing is uniform across Firecracker, libkrun,
+43	# Apple Container).
+44	[[bin]]
+45	name = "mvm-guest-netinit"
+46	path = "src/bin/mvm-guest-netinit.rs"
+47
+48	# Test-only probe used by `tests/seccomp_apply.rs` to verify that
+49	# tier allowlists actually deny what they claim (ADR-002 §W2.4). Not
+50	# selected by `nix/packages/mvm-guest-agent.nix`, so it never ships
+51	# in the guest closure.
+52	[[bin]]
+53	name = "syscall-probe"
+54	path = "src/bin/syscall-probe.rs"
+55
+56	# Test fixture for the warm-process worker pool (plan 43). Speaks the
+57	# `worker_protocol` framed multi-call loop on stdin/stdout. Behavior
+58	# selectable via `MVM_FAKE_RUNNER_BEHAVIOR` env var so tests can
+59	# exercise crash, recycle, slow, and malformed-frame paths against a
+60	# real child process. Not selected by the production guest closure.
+61	[[bin]]
+62	name = "fake-runner"
+63	path = "tests/bin/fake_runner.rs"
+64	test = false
+65	doctest = false
+66
+67	[features]
+68	dev-shell = []
+69
+70	[dependencies]
+71	mvm-core.workspace = true
+72	mvm-security.workspace = true
+73	anyhow.workspace = true
+74	base64.workspace = true
+75	chrono.workspace = true
+76	ed25519-dalek.workspace = true
+77	libc.workspace = true
+78	rand.workspace = true
+79	serde.workspace = true
+80	serde_json.workspace = true
+81	# Phase 10c — readiness/shutdown hook runner uses thiserror for
+82	# typed error variants (ReadinessError, ShutdownError).
+83	thiserror = "1"
+84	tracing.workspace = true
+85	# Plan 74 W2 — the `netinit` module's trait + types + install
+86	# loop + tests are cross-platform; only `RtnetlinkInstaller`
+87	# itself is Linux-only. Keeping async-trait + ipnet in the main
+88	# deps lets the tests run on macOS dev hosts too.
+89	async-trait.workspace = true
+90	ipnet.workspace = true
+91
+92	# seccompiler builds Linux-only — guests are always Linux microVMs,
+93	# but the workspace also compiles on macOS for CLI development. Gate
+94	# the dep so `cargo check` on a Mac doesn't try to build it.
+95	[target.'cfg(target_os = "linux")'.dependencies]
+96	seccompiler = { workspace = true }
+97	# Plan 74 W2 — `mvm-guest-netinit` uses rtnetlink to install kernel
+98	# blackhole routes for `MANDATORY_DENY_RANGES`. Linux-only because
+99	# rtnetlink talks to AF_NETLINK which doesn't exist elsewhere. The
+100	# host-side mvmctl builds (which include this crate) skip these
+101	# deps on macOS; the binary itself is only relevant in the guest.
+102	rtnetlink = { workspace = true }
+103	tokio = { workspace = true }
+104	# netlink-packet-route is rtnetlink's wire-format types crate. The
+105	# RouteType::BlackHole enum the installer uses comes from here.
+106	netlink-packet-route = "0.19"
+107
+108	[dev-dependencies]
+109	tempfile.workspace = true
+110	# Plan 74 W2 — `netinit` module's tests are async (the
+111	# `RouteInstaller` trait is async). tokio is workspace-shared so
+112	# the extra dev-dep doesn't pull anything new into the lock.
+113	tokio = { workspace = true }
+114
+115	[lints]
+116	workspace = true
+117
+```
+
+**Tool Call: cargo tree --package mvm-guest --depth 2 2>/dev/null | head -80**
+Status: Completed
+
+Terminal:
+
+```
+mvm-guest v0.14.0 (/Users/auser/work/tinylabs/mvmco/mvm/crates/mvm-guest)
+├── anyhow v1.0.102
+├── async-trait v0.1.89 (proc-macro)
+│   ├── proc-macro2 v1.0.106
+│   ├── quote v1.0.44
+│   └── syn v2.0.117
+├── base64 v0.22.1
+├── chrono v0.4.44
+│   ├── iana-time-zone v0.1.65
+│   ├── num-traits v0.2.19
+│   │   [build-dependencies]
+│   └── serde v1.0.228
+├── ed25519-dalek v2.2.0
+│   ├── curve25519-dalek v4.1.3
+│   │   [build-dependencies]
+│   ├── ed25519 v2.2.3
+│   ├── rand_core v0.6.4
+│   ├── sha2 v0.10.9
+│   ├── subtle v2.6.1
+│   └── zeroize v1.8.2
+├── ipnet v2.11.0
+│   └── serde v1.0.228 (*)
+├── libc v0.2.182
+├── mvm-core v0.14.0 (/Users/auser/work/tinylabs/mvmco/mvm/crates/mvm-core)
+│   ├── anyhow v1.0.102
+│   ├── base64 v0.22.1
+│   ├── chrono v0.4.44 (*)
+│   ├── fs2 v0.4.3
+│   ├── ipnet v2.11.0 (*)
+│   ├── mvm-libkrun v0.14.0 (/Users/auser/work/tinylabs/mvmco/mvm/crates/mvm-libkrun)
+│   │   [build-dependencies]
+│   ├── mvm-providers v0.14.0 (/Users/auser/work/tinylabs/mvmco/mvm/crates/mvm-providers)
+│   ├── regex v1.12.3
+│   ├── serde v1.0.228 (*)
+│   ├── serde_json v1.0.149
+│   ├── sha2 v0.10.9 (*)
+│   ├── tempfile v3.26.0
+│   ├── thiserror v1.0.69
+│   ├── tokio v1.49.0
+│   ├── toml v0.8.23
+│   ├── tracing v0.1.44
+│   ├── tracing-subscriber v0.3.22
+│   └── uuid v1.21.0
+├── mvm-security v0.14.0 (/Users/auser/work/tinylabs/mvmco/mvm/crates/mvm-security)
+│   ├── aes-gcm v0.10.3
+│   ├── aho-corasick v1.1.4
+│   ├── anyhow v1.0.102
+│   ├── chrono v0.4.44 (*)
+│   ├── ed25519-dalek v2.2.0 (*)
+│   ├── hmac v0.12.1
+│   ├── keyring v3.6.3
+│   ├── mvm-core v0.14.0 (/Users/auser/work/tinylabs/mvmco/mvm/crates/mvm-core) (*)
+│   ├── rand v0.8.6
+│   ├── regex v1.12.3 (*)
+│   ├── secrecy v0.10.3
+│   ├── serde v1.0.228 (*)
+│   ├── serde_json v1.0.149 (*)
+│   ├── sha2 v0.10.9 (*)
+│   ├── tempfile v3.26.0 (*)
+│   ├── thiserror v1.0.69 (*)
+│   ├── tracing v0.1.44 (*)
+│   └── zeroize v1.8.2 (*)
+├── rand v0.8.6 (*)
+├── serde v1.0.228 (*)
+├── serde_json v1.0.149 (*)
+├── thiserror v1.0.69 (*)
+└── tracing v0.1.44 (*)
+[dev-dependencies]
+├── tempfile v3.26.0 (*)
+└── tokio v1.49.0 (*)
+```
+
+**Tool Call: grep "dev-shell|withDevShell" nix/packages/mvm-guest-agent.nix**
+Status: Completed
+
+30-#
+31-# ## Features
+32-#
+33:# `dev-shell` is opt-in. With it, the agent accepts the `Exec`
+34-# vsock request and shells out arbitrary commands — required for
+35-# `mvmctl exec`/`mvmctl console` against dev images. Without it
+36-# (production), the `Exec` symbol is absent (ADR-002 §W4.3's
+--
+40-{ pkgs
+41-, lib
+42-, mvmSrc
+43:, withDevShell ? false
+44-}:
+45-
+46-pkgs.rustPlatform.buildRustPackage {
+--
+66- # blackhole routes for `MANDATORY_DENY_RANGES` at boot from
+67- # `/init` (uid 0) before the main agent forks under setpriv.
+68- "--bin" "mvm-guest-netinit"
+69: ] ++ lib.optionals withDevShell [
+70: "--features" "mvm-guest/dev-shell"
+71- ];
+72-
+73- # Same selection for the `nix flake check`-equivalent test run.
+
+**Tool Call: find /Users/auser/work/tinylabs/mvmco/mvm -path "*mvm-builder-init*main.rs" -o -path "_mvm-builder-init_" -type d | head -10**
+Status: Completed
+
+Terminal:
+
+```
+/Users/auser/work/tinylabs/mvmco/mvm/crates/mvm-builder-init
+/Users/auser/work/tinylabs/mvmco/mvm/crates/mvm-builder-init/src
+/Users/auser/work/tinylabs/mvmco/mvm/crates/mvm-builder-init/src/main.rs
+/Users/auser/work/tinylabs/mvmco/mvm/target/x86_64-unknown-linux-gnu/debug/.fingerprint/mvm-builder-init-76cefadadb7b5567
+/Users/auser/work/tinylabs/mvmco/mvm/target/aarch64-unknown-linux-gnu/debug/.fingerprint/mvm-builder-init-63f0df521349e516
+/Users/auser/work/tinylabs/mvmco/mvm/target/aarch64-unknown-linux-musl/debug/.fingerprint/mvm-builder-init-40b6d5d628100683
+/Users/auser/work/tinylabs/mvmco/mvm/target/debug/.fingerprint/mvm-builder-init-98f4dfb59e14761e
+/Users/auser/work/tinylabs/mvmco/mvm/target/debug/.fingerprint/mvm-builder-init-34bc5eba0860264b
+/Users/auser/work/tinylabs/mvmco/mvm/target/debug/.fingerprint/mvm-builder-init-40e6636aebb99836
+/Users/auser/work/tinylabs/mvmco/mvm/target/debug/.fingerprint/mvm-builder-init-b626a519e8fb4e3f
+```
+
+**Tool Call: grep | head -50 "stage0|cmd\.sh|nix build" crates/mvm-build/src/stage0.rs**
+Status: Completed
+
+3-//! `init.sh` and mountpoint stubs. libkrun mounts that directory
+4-//! as the guest root over virtiofs (`krun_set_root`), boots
+5-//! libkrunfw's bundled kernel, and runs our `init` (set via
+6-//! `krun_set_exec`). The init script uses Alpine's `apk-tools` to
+7-//! `apk add nix` from Alpine's signed package repos, then runs
+8://! `nix build` against the in-repo `nix/images/builder-vm` flake,
+9-//! emitting kernel + rootfs.ext4 on the `/out` virtio-fs share.
+10-//!
+11-/! Bootstrap surface:
+12-//!
+13-//! 1. **`init.sh`** (embedded via `include_str!`) — the PID-1
+--
+53-use sha2::{Digest, Sha256};
+54-use tar::Archive;
+55-
+56-/// PID-1 shell script. Compiled into the binary so a fresh `mvmctl`
+57-/// can always emit it without consulting the cache or the network.
+58:pub const INIT_SCRIPT: &str = include_str!("stage0/init.sh");
+59-
+60-/// Alpine release version we pin to. Single source of truth for
+61-/// the URL builders below. Bump together with the per-arch
+62-/// SHA-256 pins.
+63-pub const ALPINE_VERSION: &str = "3.22.4";
+--
+75-/// fetch the key from the network (which would itself be an
+76-/// unverified channel). The expected fingerprint is also pinned
+77-/// in [`ALPINE_RELEASE_KEY_FINGERPRINT`]; on verification we
+78-/// confirm the parsed key matches that fingerprint, so swapping
+79-/// the embedded bytes would fail-close too.
+80:pub const ALPINE_RELEASE_KEY_ASC: &[u8] = include_bytes!("stage0/alpine-ncopa-release-key.asc");
+81-
+82-/// Expected fingerprint of [`ALPINE_RELEASE_KEY_ASC`]. RSA primary
+83-/// key, uppercase hex (40 chars, no spaces). Bump only when Alpine
+84-/// rotates the release-signing key — a multi-year cadence.
+85-pub const ALPINE_RELEASE_KEY_FINGERPRINT: &str = "0482D84022F52DF1C4E7CD43293ACD0907D9495A";
+--
+87-/// One downloadable bootstrap asset, pinned by upstream URL +
+88-/// SHA-256, optionally with a PGP detached-signature URL. The
+89-/ cache key is [`Self::cache_filename`].
+90-#[derive(Debug, Clone, Copy)]
+91-pub struct BootstrapAsset {
+92: /// Where the file lands inside [`stage0_cache_dir`].
+93- pub cache_filename: &'static str,
+94- /// Upstream URL. Pinned to a specific version; never moves.
+95- pub url: &'static str,
+96- / SHA-256 of the byte stream at [`Self::url`]. Hex (64 chars).
+97- pub sha256_hex: &'static str,
+--
+179- {
+180- None
+
+[Showing results with pagination = limit: 50]
+
+**Tool Call: cargo tree --package mvm-core --depth 5 2>/dev/null | grep -i "bindgen\|cc\|ffi"**
+Status: Completed
+
+Terminal:
+
+```
+│   └── bindgen v0.72.1
+
+
+
+
+
+```
+
+**Tool Call: cargo tree --package mvm-core 2>/dev/null | grep -B 10 "bindgen"**
+Status: Completed
+
+Terminal:
+
+```
+│   │       └── once_cell v1.21.3
+│   └── which v7.0.3
+│       ├── either v1.15.0
+│       ├── env_home v0.1.0
+│       └── rustix v1.1.4
+│           ├── bitflags v2.11.0
+│           ├── errno v0.3.14
+│           │   └── libc v0.2.182
+│           └── libc v0.2.182
+│   [build-dependencies]
+│   └── bindgen v0.72.1
+```
+
+**Tool Call: cargo tree --package mvm-libkrun --depth 1 2>/dev/null**
+Status: Completed
+
+Terminal:
+
+```
+mvm-libkrun v0.14.0 (/Users/auser/work/tinylabs/mvmco/mvm/crates/mvm-libkrun)
+├── libc v0.2.182
+├── serde v1.0.228
+├── tracing v0.1.44
+└── which v7.0.3
+[build-dependencies]
+└── bindgen v0.72.1
+[dev-dependencies]
+├── mvm-guest v0.14.0 (/Users/auser/work/tinylabs/mvmco/mvm/crates/mvm-guest)
+├── mvm-providers v0.14.0 (/Users/auser/work/tinylabs/mvmco/mvm/crates/mvm-providers)
+├── serde_json v1.0.149
+└── tempfile v3.26.0
+```
+
+**Tool Call: find /Users/auser/work/tinylabs/mvmco/mvm/crates/mvm-libkrun -name "build.rs" -exec cat {} \;**
+Status: Completed
+
+Terminal:
+
+```
+//! Build script for mvm-libkrun.
+//!
+//! When the `libkrun-sys` cargo feature is on:
+//!   1. Probe for `libkrun.h` at the three standard install locations
+//!      (Apple Silicon Homebrew, Intel/manual, Linux distro).
+//!   2. Run `bindgen` to emit Rust FFI bindings into `OUT_DIR/libkrun_sys.rs`.
+//!   3. Emit `cargo:rustc-link-lib=krun` so the linker pulls in the shared
+//!      library.
+//!
+//! When the feature is off, this script is a noop — the workspace builds
+//! cleanly on hosts without libkrun installed.
+
+use std::env;
+use std::path::{Path, PathBuf};
+
+fn main() {
+    println!("cargo:rerun-if-changed=build.rs");
+    println!("cargo:rerun-if-env-changed=MVM_LIBKRUN_HEADER");
+
+    if env::var_os("CARGO_FEATURE_LIBKRUN_SYS").is_none() {
+        // Default build path — no FFI, no link, no bindgen invocation.
+        return;
+    }
+
+    let header = locate_header().unwrap_or_else(|| {
+        panic!(
+            "libkrun-sys feature is enabled but libkrun.h was not found.\n\
+             Checked: {}.\n\
+             Install libkrun (`brew install libkrun` on macOS, distro package on Linux)\n\
+             or point MVM_LIBKRUN_HEADER at the header path.",
+            probe_paths()
+                .iter()
+                .map(|p| p.display().to_string())
+                .collect::<Vec<_>>()
+                .join(", "),
+        )
+    });
+
+    println!("cargo:rerun-if-changed={}", header.display());
+
+    let out_path =
+        PathBuf::from(env::var("OUT_DIR").expect("OUT_DIR set by cargo")).join("libkrun_sys.rs");
+
+    let include_dir = header
+        .parent()
+        .expect("libkrun.h has a parent directory")
+        .to_path_buf();
+
+    bindgen::Builder::default()
+        .header(header.to_string_lossy())
+        .clang_arg(format!("-I{}", include_dir.display()))
+        // Keep the generated surface small — only the symbols we wrap in
+        // sys.rs plus the KRUN_* constants we need at the type level.
+        // Plan 87: also surface NET_FEATURE_*` + `COMPAT_NET_FEATURES`
+        // for the passt virtio-net backend (`krun_add_net_unixstream`'s
+        // `features` arg expects a bitwise-or of those).
+        .allowlist_function("krun_.*")
+        .allowlist_var("KRUN_.*")
+        .allowlist_var("NET_FEATURE_.*")
+        .allowlist_var("COMPAT_NET_FEATURES")
+        .allowlist_var("NET_FLAG_.*")
+        .layout_tests(false)
+        .generate_comments(false)
+        .parse_callbacks(Box::new(bindgen::CargoCallbacks::new()))
+        .generate()
+        .expect("bindgen failed to generate libkrun bindings")
+        .write_to_file(&out_path)
+        .expect("failed to write libkrun bindings");
+
+    // Tell the linker to pull in libkrun. On macOS the dylib is found via
+    // the standard Homebrew library path; on Linux via the distro install.
+    println!("cargo:rustc-link-lib=krun");
+
+    // Make sure the linker can find the dylib next to the header we probed.
+    // Homebrew installs to /opt/homebrew/{include,lib}; the symmetric `lib`
+    // sibling is the right hint without hardcoding paths in every consumer.
+    if let Some(prefix) = include_dir.parent() {
+        let lib_dir = prefix.join("lib");
+        if lib_dir.exists() {
+            println!("cargo:rustc-link-search=native={}", lib_dir.display());
+        }
+    }
+}
+
+fn locate_header() -> Option<PathBuf> {
+    if let Some(override_path) = env::var_os("MVM_LIBKRUN_HEADER") {
+        let p = PathBuf::from(override_path);
+        if p.is_file() {
+            return Some(p);
+        }
+    }
+    probe_paths().into_iter().find(|p| p.is_file())
+}
+
+fn probe_paths() -> Vec<PathBuf> {
+    vec![
+        Path::new("/opt/homebrew/include/libkrun.h").to_path_buf(),
+        Path::new("/usr/local/include/libkrun.h").to_path_buf(),
+        Path::new("/usr/include/libkrun.h").to_path_buf(),
+    ]
+}
+```
+
+**Tool Call: grep -A 10 "\[package.mvm-libkrun\]" /Users/auser/work/tinylabs/mvmco/mvm/Cargo.toml**
+Status: Failed
+
+```
+Tool permission request failed: Error: Internal error
+```
+
+**Tool Call: Read crates/mvm-libkrun/Cargo.toml**
+Status: Completed
+
+```
+1	[package]
+2	name = "mvm-libkrun"
+3	version.workspace = true
+4	edition.workspace = true
+5	description = "Rust bindings for the Red Hat libkrun C library (Linux KVM, macOS HVF)"
+6	license.workspace = true
+7	repository.workspace = true
+8	homepage.workspace = true
+9	authors.workspace = true
+10	build = "build.rs"
+11
+12	# ── What this crate is ─────────────────────────────────────────────
+13	#
+14	# Thin Rust bindings + a safe wrapper around Red Hat libkrun's C API.
+15	# libkrun is a library-style VMM: linked directly into the calling
+16	# binary, no out-of-process daemon. On Linux it uses KVM; on macOS it
+17	# uses Hypervisor.framework. mvm uses it as a Tier 2 microVM backend
+18	# and (post-Plan-71) the builder-VM substrate.
+19	#
+20	# Two build modes:
+21	#
+22	#   * default (no feature) — no FFI, no link to libkrun. `start`/`stop`
+23	#     return `Error::NotYetWired`. The workspace builds cleanly on hosts
+24	#     without libkrun installed.
+25	#
+26	#   * `libkrun-sys` — bindgen-generated FFI + `-lkrun` link. Requires
+27	#     libkrun.h on the host (probed by build.rs at the standard install
+28	#     locations) and a working libkrun shared library at link time.
+29	#
+30	# Plan 57 W1 lands the bindings; W2 adds macOS codesigning entitlements;
+31	# W3 validates an end-to-end boot. This crate stays narrowly focused on
+32	# the FFI surface — backend dispatch lives in mvm-backend.
+33
+34	[dependencies]
+35	libc.workspace = true
+36	tracing = "0.1"
+37	# `serde` is always on (with `derive`) so the `KrunContext`,
+38	# `KrunDisk`, and `SupervisorConfig` types are serializable from
+39	# any consumer — notably `mvm-backend::LibkrunBackend`, which
+40	# builds the supervisor's JSON without ever enabling `libkrun-sys`
+41	# itself. Compile cost is marginal; serde is already in nearly
+42	# every other workspace crate's dep graph.
+43	serde = { workspace = true }
+44	# Plan 57 W4 supervisor binary (`src/bin/mvm-libkrun-supervisor.rs`)
+45	# needs JSON parsing on stdin and pulls `ensure_signed()` from
+46	# mvm-providers (macOS codesigning gate). Both are optional and
+47	# gated on `libkrun-sys` so the default workspace build (CI fast
+48	# lane, hosts without libkrun.h) skips the heavier dep graph.
+49	#
+50	# We intentionally do NOT pull `mvm-guest` from regular deps: that
+51	# would close a cycle (mvm-core → mvm-libkrun → mvm-guest → mvm-core,
+52	# since mvm-core depends on mvm-libkrun for `Platform::has_libkrun`).
+53	# The supervisor receives the vsock port list via the JSON config —
+54	# the symbolic `GUEST_AGENT_PORT` constant is only needed by callers
+55	# composing the config, not by the supervisor consuming it. The
+56	# `libkrun-smoke` example keeps `mvm-guest` as a dev-dep because
+57	# dev-deps are excluded from cycle analysis.
+58	mvm-providers = { workspace = true, optional = true }
+59	serde_json = { workspace = true, optional = true }
+60	# Plan 87 W2 — `passt` module probes $PATH for the `passt` binary
+61	# before spawning it. `which` is already in the workspace dep tree
+62	# (mvm-cli/mvm-build); pulling it in here keeps the dep graph
+63	# uniform and avoids reinventing PATH search.
+64	which.workspace = true
+65
+66	[build-dependencies]
+67	# `bindgen` is required only when the `libkrun-sys` feature is on; we
+68	# still list it unconditionally so the crate manifest reflects the real
+69	# build-time graph. The build script returns early when the feature is
+70	# off, so libclang isn't invoked in the default workspace build.
+71	bindgen = "0.72"
+72
+73	[features]
+74	default = []
+75	# Opt-in: generate FFI bindings and link `libkrun`. Off by default so
+76	# the workspace builds on hosts without libkrun installed (CI fast lane,
+77	# Linux contributors who don't run the Tier 2 backend). Enables the
+78	# supervisor binary and its mvm-guest/mvm-providers/serde dep chain.
+79	libkrun-sys = [
+80	    "dep:mvm-providers",
+81	    "dep:serde_json",
+82	]
+83
+84	[dev-dependencies]
+85	# Plan 87 W2 — passt supervisor tests stage scratch dirs.
+86	tempfile.workspace = true
+87	# The plan 57 W3 smoke example shares `GUEST_AGENT_PORT` with the
+88	# production vsock plumbing.
+89	mvm-guest.workspace = true
+90	# `ensure_signed()` is plan 57 W2's codesigning gate. macOS rejects
+91	# any process that calls `Hypervisor.framework` without
+92	# `com.apple.security.hypervisor`; the smoke binary self-signs on
+93	# first run and re-spawns, same as `mvmctl up --hypervisor
+94	# apple-container` does.
+95	mvm-providers.workspace = true
+96	# Plan 72 W4 prerequisite: unit tests for `KrunContext`'s serde
+97	# shape (incl. the new `virtio_fs_mounts` field with `#[serde(default)]`
+98	# back-compat) exercise the JSON pipe shape the supervisor binary
+99	# carries. serde_json is already an optional regular dep behind
+100	# `libkrun-sys`; listing it again as a dev-dep makes the test build
+101	# independent of feature flags.
+102	serde_json = { workspace = true }
+103
+104	# Plan 57 W3 — manual smoke binary that boots a Nix-built kernel +
+105	# ext4 rootfs via libkrun and blocks until the guest exits. Gated on
+106	# `libkrun-sys` so the example only compiles on hosts with libkrun.h
+107	# present.
+108	[[example]]
+109	name = "libkrun-smoke"
+110	path = "examples/libkrun-smoke.rs"
+111	required-features = ["libkrun-sys"]
+112
+113	# Plan 57 W4 — long-running supervisor process. One process per
+114	# libkrun guest. Reads a JSON `SupervisorConfig` on stdin, binds host
+115	# vsock listeners, writes its PID under ~/.mvm/vms/<name>/, then
+116	# `start_enter`s the guest. The W4.2 PR wires
+117	# `LibkrunBackend::start()` to spawn this binary.
+118	[[bin]]
+119	name = "mvm-libkrun-supervisor"
+120	path = "src/bin/mvm-libkrun-supervisor.rs"
+121	required-features = ["libkrun-sys"]
+122
+123	[lints]
+124	workspace = true
+125
+```
+
+**Tool Call: Read crates/mvm-core/Cargo.toml (1 - 80)**
+Status: Completed
+
+```
+1	[package]
+2	name = "mvm-core"
+3	version.workspace = true
+4	edition.workspace = true
+5	description = "Core types, IDs, config, and utilities for mvm"
+6	license.workspace = true
+7	repository.workspace = true
+8	homepage.workspace = true
+9	authors.workspace = true
+10
+11	[dependencies]
+12	anyhow.workspace = true
+13	base64.workspace = true
+14	chrono.workspace = true
+15	mvm-providers.workspace = true
+16	mvm-libkrun.workspace = true
+17	serde.workspace = true
+18	serde_json.workspace = true
+19	sha2.workspace = true
+20	thiserror = "1"
+21	tokio = { workspace = true, features = ["io-util"] }
+22	toml.workspace = true
+23	tracing.workspace = true
+24	tracing-subscriber.workspace = true
+25	uuid.workspace = true
+26	fs2.workspace = true
+27	regex = "1"
+28	tempfile.workspace = true
+29	# Plan 74 W2 — `mandatory_deny_ranges` parses a small set of
+30	# IPv4/IPv6 CIDRs (cloud metadata endpoint, link-local, CGNAT,
+31	# host loopback). Workspace-pinned (already used by
+32	# `mvm-supervisor::proxy::l4`).
+33	ipnet = { workspace = true }
+34
+35	[lints]
+36	workspace = true
+37
+```
+
+**Tool Call: grep -r "libkrun-sys\|default =" /Users/auser/work/tinylabs/mvmco/mvm/Cargo.toml 2>/dev/null | head -20**
+Status: Completed
+
+Terminal:
+
+```
+/Users/auser/work/tinylabs/mvmco/mvm/Cargo.toml:# enable `libkrun-sys` on a host with libkrun installed.
+/Users/auser/work/tinylabs/mvmco/mvm/Cargo.toml:# Plan 87 W5 — enable mvm-cli's `libkrun-sys` feature on macOS so the
+/Users/auser/work/tinylabs/mvmco/mvm/Cargo.toml:# sets `default-features = false`, which strips mvm-cli's `default =
+/Users/auser/work/tinylabs/mvmco/mvm/Cargo.toml:# the `#[cfg(all(feature = "builder-vm", not(feature = "libkrun-sys")))]`
+/Users/auser/work/tinylabs/mvmco/mvm/Cargo.toml:mvm-cli = { workspace = true, default-features = false, features = ["builder-vm", "libkrun-sys"] }
+/Users/auser/work/tinylabs/mvmco/mvm/Cargo.toml:default = ["builder-vm"]
+```
+
+**Tool Call: cargo build -p mvm-guest --no-default-features 2>&1 | head -5**
+Status: Completed
+
+Terminal:
+
+```
+Command running in background with ID: bymm69imu. Output is being written to: /private/tmp/claude-501/-Users-auser-work-tinylabs-mvmco-mvm/d599fbb0-a81f-481e-87ed-3ca7e59d2625/tasks/bymm69imu.output. You will be notified when it completes. To check interim output, use Read on that file path.
+
+
+```
+
+**Tool Call: Read crates/mvm-builder-init/src/main.rs**
+Status: Failed
+
+```
+File content (48343 tokens) exceeds maximum allowed tokens (25000). Use offset and limit parameters to read specific portions of the file, or search for specific content instead of reading the whole file.
+```
+
+**Tool Call: grep "Command::new.\*nix|vsock_send|VsockListener|add_vsock_port" /Users/auser/work/tinylabs/mvmco/mvm/crates/mvm-builder-init/src**
+Status: Completed
+
+crates/mvm-builder-init/src/main.rs:644: /// `vsock_send_tests::builder_dispatch_port_literal_is_21471`
+crates/mvm-builder-init/src/main.rs:1147: mod vsock_send_tests {
+crates/mvm-builder-init/src/main.rs:2048: let status = Command::new("/sbin/nix-store")
+
+**Tool Call: Read crates/mvm-builder-init/src/main.rs (640 - 739)**
+Status: Completed
+
+```
+640
+641	    /// Plan 89 W2 part 2 — must match
+642	    /// `mvm_guest::builder_agent::BUILDER_DISPATCH_PORT`. Hardcoded
+643	    /// for size-budget reasons; the
+644	    /// `vsock_send_tests::builder_dispatch_port_literal_is_21471`
+645	    /// pinning test below catches divergence.
+646	    const BUILDER_DISPATCH_PORT: u32 = 21471;
+647	    const AF_VSOCK: i32 = 40;
+648	    const SOCK_STREAM: i32 = 1;
+649	    const SOL_SOCKET: i32 = 1;
+650	    const SO_RCVTIMEO: i32 = 20;
+651	    const VMADDR_CID_ANY: u32 = 0xFFFF_FFFF;
+652
+653	    /// W3 part 3 cap on a single inbound `BuilderRequest` body.
+654	    /// Matches `mvm_guest::vsock::MAX_FRAME_SIZE` (256 KiB) — the
+655	    /// host's `read_frame` enforces the same bound on its side, so
+656	    /// a body above this size couldn't have been written by a
+657	    /// well-behaved supervisor anyway.
+658	    const MAX_DISPATCH_BODY_BYTES: u32 = 256 * 1024;
+659
+660	    #[repr(C)]
+661	    struct SockAddrVm {
+662	        svm_family: u16,
+663	        svm_reserved1: u16,
+664	        svm_port: u32,
+665	        svm_cid: u32,
+666	        svm_zero: [u8; 4],
+667	    }
+668
+669	    unsafe extern "C" {
+670	        fn socket(domain: i32, typ: i32, protocol: i32) -> i32;
+671	        fn bind(sockfd: i32, addr: *const core::ffi::c_void, addrlen: u32) -> i32;
+672	        fn listen(sockfd: i32, backlog: i32) -> i32;
+673	        fn accept(sockfd: i32, addr: *mut core::ffi::c_void, addrlen: *mut u32) -> i32;
+674	        fn setsockopt(
+675	            sockfd: i32,
+676	            level: i32,
+677	            optname: i32,
+678	            optval: *const core::ffi::c_void,
+679	            optlen: u32,
+680	        ) -> i32;
+681	        fn close(fd: i32) -> i32;
+682	    }
+683
+684	    /// Open + bind + listen an AF_VSOCK socket on
+685	    /// [`BUILDER_DISPATCH_PORT`]. Returns the listening fd or
+686	    /// `None` on any setup failure (with stderr breadcrumb).
+687	    /// `accept_timeout_secs = Some(n)` applies `SO_RCVTIMEO` so
+688	    /// subsequent `accept()` calls bound the wait at `n`s; `None`
+689	    /// means accept blocks until a peer connects.
+690	    fn open_dispatch_listener_fd(accept_timeout_secs: Option<i64>) -> Option<i32> {
+691	        let listen_fd = unsafe { socket(AF_VSOCK, SOCK_STREAM, 0) };
+692	        if listen_fd < 0 {
+693	            eprintln!("mvm-builder-init: vsock: socket() failed");
+694	            return None;
+695	        }
+696	        let addr = SockAddrVm {
+697	            svm_family: AF_VSOCK as u16,
+698	            svm_reserved1: 0,
+699	            svm_port: BUILDER_DISPATCH_PORT,
+700	            svm_cid: VMADDR_CID_ANY,
+701	            svm_zero: [0; 4],
+702	        };
+703	        let rc = unsafe {
+704	            bind(
+705	                listen_fd,
+706	                &addr as *const SockAddrVm as *const core::ffi::c_void,
+707	                std::mem::size_of::<SockAddrVm>() as u32,
+708	            )
+709	        };
+710	        if rc < 0 {
+711	            eprintln!("mvm-builder-init: vsock: bind() failed on port {BUILDER_DISPATCH_PORT}");
+712	            unsafe { close(listen_fd) };
+713	            return None;
+714	        }
+715	        let rc = unsafe { listen(listen_fd, 1) };
+716	        if rc < 0 {
+717	            eprintln!("mvm-builder-init: vsock: listen() failed");
+718	            unsafe { close(listen_fd) };
+719	            return None;
+720	        }
+721	        if let Some(secs) = accept_timeout_secs {
+722	            let tv = libc::timeval {
+723	                tv_sec: secs,
+724	                tv_usec: 0,
+725	            };
+726	            let rc = unsafe {
+727	                setsockopt(
+728	                    listen_fd,
+729	                    SOL_SOCKET,
+730	                    SO_RCVTIMEO,
+731	                    &tv as *const libc::timeval as *const core::ffi::c_void,
+732	                    std::mem::size_of::<libc::timeval>() as u32,
+733	                )
+734	            };
+735	            if rc < 0 {
+736	                eprintln!("mvm-builder-init: vsock: setsockopt SO_RCVTIMEO failed (continuing)");
+737	            }
+738	        }
+739	        Some(listen_fd)
+```
+
+**Tool Call: grep "fn nix_build|fn run_nix|nix.\*build|single-shot|W2 part 4" /Users/auser/work/tinylabs/mvmco/mvm/crates/mvm-builder-init/src/main.rs**
+Status: Completed
+
+50-//! ## Non-Linux build behaviour
+51-//!
+52-//! Linux-only by design. On macOS / Windows the crate still
+53-//! compiles (workspace ergonomics) but `main()` prints a hint
+54-//! and exits 1. mkGuest cross-compiles the real binary against
+55://! `<arch>-unknown-linux-musl` from a Linux nix-build
+56-//! environment; that's where the size budget (≤ 1.5 MiB) and
+57-//! static-link requirement get enforced.
+58-
+59-use std::process::ExitCode;
+60-
+--
+473- // `iptables-nft` and `iptables-legacy` bail with "table
+474- // does not exist" or "protocol not supported" at the first
+475- // rule install. The egress lockdown is defense-in-depth
+476- // for the Plan 73 deps-install pipeline (untrusted code
+477- // running in the steady-state builder VM). Stage 0 only
+478: // runs flake builds — `nix build` against a pinned
+479- / `path:/work#…` reference — where Nix's own fixed-output
+480- // derivation hashes carry the integrity guarantee. We
+481- // log + continue rather than fail closed.
+482- //
+483- // The steady-state builder VM image (built by Stage 0 via
+484- // the in-repo TSI-patched kernel under
+485: // `nix/images/builder-vm/kernel/`) carries netfilter, so
+486- // this fallback only triggers in Stage 0 — the audit
+487- // signal still distinguishes the two contexts.
+488- if egress*error_indicates_no_netfilter(&e) {
+489- eprintln!(
+490- "mvm-builder-init: egress lockdown SKIPPED (kernel lacks netfilter — \
+--
+498- }
+499-
+500- / Plan 89 W3 part 3 dispatch: if the host staged a
+501- // `dispatch.sock.marker` in /job, this VM is persistent
+502- // (host-side `LibkrunPersistentBuilderVm`, W3 part 4).
+503: // Enter the dispatch loop instead of single-shot. Marker
+504- // absent (the default) preserves the existing cmd.sh /
+505- // install_spec flows exactly.
+506- let dispatch_marker = format!("{JOB_DIR}/dispatch.sock.marker");
+507- if Path::new(&dispatch_marker).exists() {
+508- eprintln!("mvm-builder-init: dispatch marker detected, entering W3 dispatch loop");
+--
+576- / `mvm_build::builder_protocol::read_builder_response_from_socket`
+577- // is waiting for. Runs BEFORE write_boot_timings so the
+578- // timings snapshot we send mirrors what hits the filesystem.
+579- // Any failure logs and falls through to power_off — the
+580- // legacy file-based result path remains authoritative until
+581: // the host wires the vsock receive in W2 part 4.
+582- let timings_snapshot = match timings.lock() {
+583- Ok(t) => t.clone(),
+584- Err(*) => {
+585- eprintln!(
+586- "mvm-builder-init: boot-timings mutex poisoned; \
+--
+631- /// `crates/mvm-guest/src/bin/mvm-builder-agent.rs` exactly.
+632- // -----------------------------------------------------------
+633- // Plan 89 W2 / W3 — AF*VSOCK helpers
+634- // -----------------------------------------------------------
+635- //
+636: // Shared between W2 part 3's single-shot send and W3 part 3's
+637- // dispatch loop. Inlined FFI rather than `nix` because the
+638- // Plan 72 §W3 size budget discourages new dep features; the
+639- // pattern mirrors `mvm-guest/src/bin/mvm-builder-agent.rs`.
+640-
+641- /// Plan 89 W2 part 2 — must match
+--
+799- return;
+800- };
+801- let Some(conn_fd) = accept_one(listen_fd) else {
+802- eprintln!(
+803- "mvm-builder-init: vsock send: no host connection within {ACCEPT_TIMEOUT_SECS}s \
+804: (single-shot path; W2 part 4 wired the host receiver)"
+805- );
+806- unsafe { close(listen_fd) };
+807- return;
+808- };
+809- let mut conn = adopt_conn_fd(conn_fd);
+--
+1097- (code, tail, ms)
+1098- }
+1099- }
+1100- crate::builder_request::BuilderJob::Install { spec_path } => {
+1101- / Plan 89 W3 part 8: route Install dispatches
+1102: // through the existing single-shot pipeline with
+1103- // per-dispatch paths. The host (PersistentBuilderVm)
+1104- // stages `<session.job_dir>/<job_id>/install_spec.json`
+1105- // and passes `/job/<job_dir_relpath>/install_spec.json`
+1106- // as the wire `spec_path`. The output (result.json +
+1107- // sealed volume sidecars) lands in `/job/<job_id>/out`
+--
+1376- // "Read-only file system" at the first `iptables -A` call.
+1377- // mkGuest's /init does the equivalent for the dev image's
+1378- // boot path; we replicate it here for the mvm-builder-init
+1379- // path (Plan 86).
+1380- mount_fs_idempotent("tmpfs", "/run", "tmpfs")?;
+1381: // `/dev/pts` is required by nix's build-sandbox setup: it
+1382- // calls `posix_openpt` which opens `/dev/ptmx`, and that
+1383- // requires devpts to be mounted at `/dev/pts`. Without it
+1384- / nix bails with `error: opening pseudoterminal master:
+1385-        // No such file or directory`. The dev image flake's
+1386- // mkGuest /init mounts this; we replicate for Plan 86.
+--
+1405- stamp(timings, |t| {
+1406- t.nix_device_ready_ms = Some(BootTimings::ms_since(anchor))
+1407- });
+1408-
+1409- / Plan 92: the slim custom kernel under
+1410: // `nix/images/builder-vm/kernel/` builds overlay, vsock,
+1411- // fuse, virtiofs, and the iptables tables as `=y`. No
+1412- // modprobe needed before `mount -t overlay` or `socket(AF_VSOCK)`
+1413- // — the kernel comes up with the subsystems registered.
+1414-
+1415- match mount_nix_overlay() {
+--
+1428- t.nix_mounted_ms = Some(BootTimings::ms_since(anchor))
+1429- });
+1430-
+1431- / PR #420 follow-up: load `/nix-path-registration` (the
+1432- // standard `make-ext4-fs.nix` manifest) into the persistent
+1433: // `/nix/var/nix/db` so the in-VM `nix build` knows the
+1434- // seeded closure is already valid. Without this, nix-daemon
+1435- // treats every seeded path as missing and re-substitutes
+1436- // from `cache.nixos.org` — the substituter then overwrites
+1437- // the on-disk path during the rename window, and concurrent
+1438- // build-hook workers `dlopen`ing libs from the same path
+--
+1652- result
+1653- }
+1654-
+1655- fn run_job(cmd_sh: &str) -> (i32, String) {
+1656- / Single-shot path: no streaming callback, no TMPDIR
+1657: // override (single-shot uses the rootfs's tmpfs `/tmp`
+1658- // directly — the VM is going to power-off, so per-job
+1659- // scratch isolation has no second job to protect), and no
+1660- // unshare wrapping (the VM tear-down already kills any
+1661- // orphan process and reclaims every IPC key + mount). The
+1662- // whole stderr tail still lands in `/job/result` and the
+1663- // host's file-based fallback parses it. Plan 89 W3 part 9
+1664- // added the streaming variant for the persistent dispatch
+1665: // loop; this single-shot wrapper passes a no-op so the
+1666- // two code paths share their `Command`/`wait` logic.
+1667- run_job_streaming(cmd_sh, None, Isolation::Inherit, |\_line| {})
+1668- }
+1669-
+1670- /// Plan 89 W3 part 11 — how the build subprocess relates to
+1671- /// the dispatch loop's process / mount / IPC namespaces.
+1672- ///
+1673- / - [`Isolation::Inherit`]: subprocess runs in the dispatch
+1674: /// loop's namespaces. Used by single-shot (the whole VM
+1675- /// tears down on exit anyway) and by tests that don't have
+1676- /// `CAP_SYS_ADMIN` in their environment (e.g. CI Docker
+1677- /// without `--privileged`).
+1678- / - [`Isolation::Unshared`]: subprocess runs in fresh mount
+1679- /// + pid + ipc namespaces via `unshare --mount --pid --ipc
+--
+1784-    ///
+1785-    /// The trailing `\n`is stripped from each line (the typed
+1786-    /`BuilderResponse::StderrChunk`docs commit to that).
+1787-    ///`STDERR_TAIL_LINES`of trailing context is still buffered
+1788-    /// for the final Result frame's`stderr_tail`, matching the
+1789:    /// single-shot path's contract.
+1790-    fn run_job_streaming<F: FnMut(&str)>(
+1791-        cmd_sh: &str,
+1792-        tmpdir: Option<&str>,
+1793-        isolation: Isolation,
+1794-        mut on_line: F,
+--
+1798-        use std::process::Stdio;
+1799-        // Plan 89 W3 part 11/13 — switch between bare `/bin/sh
+1800- // -eu <cmd>` and the unshare+setpriv wrapped form via
+1801-        // [`build_isolated_command`]. unshare + setpriv both
+1802-        // live in `util-linux`, which is in the builder VM's
+1803:        // rootfs (`nix/images/builder-vm/flake.nix`, package list);
+1804-        / PATH (`/sbin:/usr/sbin:/bin:/usr/bin`) finds them.
+1805-        let mut cmd = build_isolated_command(cmd_sh, isolation);
+1806-        cmd.stdout(Stdio::inherit()).stderr(Stdio::piped());
+1807-        // Plan 89 W3 part 10 — point the dispatched build's
+1808-        // tmpfile machinery at the per-job scratch dir so leftover
+--
+2020-    / The need for this call surfaced as `libboost_url.so.1.87.0:
+2021- /// cannot open shared object file`during the in-VM dev-image
+2022-    / build: with no entries in the DB, every closure path the
+2023-    /// build references gets re-fetched from`cache.nixos.org`,
+2024-    /// overwriting the seeded path in place — and a concurrent
+2025:    /// nix build-hook worker mid-`dlopen`of the same path's libs
+2026-    /// hits ENOENT during the rename window. Loading the DB makes
+2027-    /// the substituter skip the re-fetch entirely.
+2028-    fn load_seeded_nix_db(
+2029-        timings: &Arc<Mutex<BootTimings>>,
+2030-        anchor: Instant,
+--
+2117-    /// ```
+2118-    ///
+2119-    /// Detected pre-mount so we can recover with`mkfs.ext4 -F`2120-    /// rather than aborting before the build can run. The
+2121-    ///`/nix-store`volume is a cache; reformatting loses nothing
+2122:    /// that can't be rebuilt by the next nix build.
+2123-    fn nix_store_dev_needs_format(dev: &str) -> Result<Option<String>, String> {
+2124-        let sb = read_ext4_superblock(dev)?;
+2125-        let Some(fs_bytes) = crate::parse_ext4_recorded_size_bytes(&sb) else {
+2126-            return Ok(Some("no ext4 superblock".into()));
+2127-        };
+--
+2327-        }
+2328-
+2329-        /// Plan 89 W3 part 9 —`run_job_streaming`calls the
+2330-        /// per-line callback once per stderr line, in order, and
+2331-        /// returns the same`(exit_code, tail)`shape as the
+2332:        /// single-shot`run_job`for the success case.
+2333-        #[test]
+2334-        fn run_job_streaming_emits_each_line_in_order() {
+2335-            // Write a cmd.sh that emits 3 stderr lines and exits 0.
+2336-            let dir = tempfile::tempdir().expect("tempdir");
+2337-            let cmd_path = dir.path().join("cmd.sh");
+--
+2389-            assert_eq!(tail_lines.len(), STDERR_TAIL_LINES);
+2390-            assert_eq!(*tail_lines.first().unwrap(), "line6");
+2391-            assert_eq!(*tail_lines.last().unwrap(), &format!("line{total}"));
+2392-        }
+2393-
+2394:        /// Plan 89 W3 part 9 — single-shot`run_job`keeps its
+2395-        / pre-streaming semantics: returns the tail without any
+2396-        /// per-line side effect (the streaming variant's callback
+2397-        /// is`|*| {}`).
+2398- #[test]
+2399- fn run_job_matches_streaming_for_short_output() {
+
+**Tool Call: grep "^[[:space:]]\*fn run_job_streaming|cmd\.stdout|cmd\.stderr|Stdio::|inherit|piped" /Users/auser/work/tinylabs/mvmco/mvm/crates/mvm-builder-init/src/main.rs**
+Status: Completed
+
+1782- /// host's vsock conn is the natural rate-limiter and we don't
+1783- /// need a separate buffer thread.
+1784- ///
+1785- /// The trailing `\n` is stripped from each line (the typed
+1786- / `BuilderResponse::StderrChunk` docs commit to that).
+1787- /// `STDERR_TAIL_LINES` of trailing context is still buffered
+1788- /// for the final Result frame's `stderr_tail`, matching the
+1789- /// single-shot path's contract.
+1790: fn run*job_streaming<F: FnMut(&str)>(
+1791- cmd_sh: &str,
+1792- tmpdir: Option<&str>,
+1793- isolation: Isolation,
+1794- mut on_line: F,
+1795- ) -> (i32, String) {
+1796- use std::collections::VecDeque;
+1797- use std::io::{BufRead, BufReader};
+1798- use std::process::Stdio;
+1799- // Plan 89 W3 part 11/13 — switch between bare `/bin/sh
+1800-        // -eu <cmd>` and the unshare+setpriv wrapped form via
+1801- // [`build_isolated_command`]. unshare + setpriv both
+1802- // live in `util-linux`, which is in the builder VM's
+1803- // rootfs (`nix/images/builder-vm/flake.nix`, package list);
+1804- / PATH (`/sbin:/usr/sbin:/bin:/usr/bin`) finds them.
+1805- let mut cmd = build_isolated_command(cmd_sh, isolation);
+1806: cmd.stdout(Stdio::inherit()).stderr(Stdio::piped());
+1807- // Plan 89 W3 part 10 — point the dispatched build's
+1808- // tmpfile machinery at the per-job scratch dir so leftover
+1809- // tempfiles can't outlive the dispatch. Tools that honor
+1810- // TMPDIR (mkstemp, Python's `tempfile`, Nix's evaluator,
+1811- // `mktemp(1)`) write into `/tmp/<job_id>/` instead of the
+1812- // shared rootfs `/tmp`. Single-shot passes `None` —
+1813- // see [`run_job`].
+1814- if let Some(t) = tmpdir {
+--
+1820- let binary = match isolation {
+1821- Isolation::Inherit => "/bin/sh",
+1822- Isolation::Unshared => "unshare",
+1823- };
+1824- return (127, format!("spawn {binary}: {e}"));
+1825- }
+1826- };
+1827- let Some(stderr) = child.stderr.take() else {
+1828: // Stdio::piped() should always populate child.stderr;
+1829- // if it didn't, fall through to a non-streaming wait so
+1830- // we still return a real exit code.
+1831- let code = child.wait().ok().and_then(|s| s.code()).unwrap_or(-1);
+1832- return (code, String::new());
+1833- };
+1834- let mut tail: VecDeque<String> = VecDeque::with_capacity(STDERR_TAIL_LINES);
+1835- for line in BufReader::new(stderr).lines() {
+1836- let line = match line {
+--
+2326- assert!(err.contains(&over), "err includes the offending name");
+2327- }
+2328-
+2329- /// Plan 89 W3 part 9 — `run_job_streaming` calls the
+2330- /// per-line callback once per stderr line, in order, and
+2331- /// returns the same `(exit_code, tail)` shape as the
+2332- /// single-shot `run_job` for the success case.
+2333- #[test]
+2334: fn run_job_streaming_emits_each_line_in_order() {
+2335- // Write a cmd.sh that emits 3 stderr lines and exits 0.
+2336- let dir = tempfile::tempdir().expect("tempdir");
+2337- let cmd_path = dir.path().join("cmd.sh");
+2338- std::fs::write(
+2339- &cmd_path,
+2340- "echo one >&2\necho two >&2\necho three >&2\nexit 0\n",
+2341- )
+2342- .expect("write cmd.sh");
+--
+2354- let got = collected.into_inner().unwrap();
+2355- assert_eq!(got, vec!["one", "two", "three"]);
+2356- assert_eq!(tail, "one\ntwo\nthree");
+2357- }
+2358-
+2359- /// Plan 89 W3 part 9 — non-zero exit still surfaces all
+2360- /// streamed lines and a tail bounded by `STDERR_TAIL_LINES`.
+2361- #[test]
+2362: fn run_job_streaming_caps_tail_to_stderr_tail_lines() {
+2363- let dir = tempfile::tempdir().expect("tempdir");
+2364- let cmd_path = dir.path().join("cmd.sh");
+2365- // Emit more lines than STDERR_TAIL_LINES (=20) so we
+2366- // verify the buffer cap, not just streaming.
+2367- let total = STDERR_TAIL_LINES + 5;
+2368- let mut script = String::new();
+2369- for i in 1..=total {
+2370- script.push_str(&format!("echo line{i} >&2\n"));
+--
+2448- }
+2449- assert!(!expected.exists(), "Drop wiped nested contents");
+2450- }
+2451-
+2452- /// Plan 89 W3 part 10 — `run_job_streaming` honors the
+2453- /// TMPDIR override. cmd.sh echoes the var so we can
+2454- /// assert the build subprocess saw it.
+2455- #[test]
+2456: fn run_job_streaming_threads_tmpdir_through_to_subprocess() {
+2457- let dir = tempfile::tempdir().expect("tempdir");
+2458- let cmd_path = dir.path().join("cmd.sh");
+2459: // The subprocess inherits TMPDIR from its environment;
+2460- // echo it back via stderr so the test sees it.
+2461- std::fs::write(&cmd_path, "echo \"tmpdir=$TMPDIR\" >&2\nexit 0\n")
+2462- .expect("write cmd.sh");
+2463- let (code, tail) = run_job_streaming(
+2464- cmd_path.to_str().unwrap(),
+2465- Some("/scratch/abc"),
+2466- Isolation::Inherit,
+2467- |*| {},
+2468- );
+2469- assert*eq!(code, 0);
+2470- assert_eq!(tail, "tmpdir=/scratch/abc");
+2471- }
+2472-
+2473- /// Plan 89 W3 part 10 — when `tmpdir` is `None` the
+2474: /// subprocess inherits whatever TMPDIR the dispatch loop
+2475- /// already had (typically unset inside PID 1). We assert
+2476- /// the env var is *not* explicitly forced to a value the
+2477- / test process supplies via `Command::env`, so single-
+2478- /// shot keeps its pre-part-10 behavior.
+2479- #[test]
+2480: fn run_job_streaming_does_not_override_tmpdir_when_none() {
+2481- let dir = tempfile::tempdir().expect("tempdir");
+2482- let cmd_path = dir.path().join("cmd.sh");
+2483- std::fs::write(&cmd_path, "echo \"tmpdir=${TMPDIR-UNSET}\" >&2\nexit 0\n")
+2484- .expect("write cmd.sh");
+2485- / SAFETY: this test runs single-threaded in cargo
+2486- // test's default scheduler for this binary; we set the
+2487- // env var briefly to a known value and then assert the
+2488- // subprocess saw exactly that (not some `/scratch/...`
+2489- // override). Restoring afterward.
+2490- //
+2491- / The point of the assertion: with `tmpdir = None`,
+2492- // `run_job_streaming` doesn't call `.env("TMPDIR", *)`2493-            // — it leaves the parent's env alone.
+2494-            let prior = std::env::var("TMPDIR").ok();
+2495-            unsafe {
+2496:                std::env::set_var("TMPDIR", "/inherited-from-parent");
+2497-            }
+2498-            let (code, tail) =
+2499-                run_job_streaming(cmd_path.to_str().unwrap(), None, Isolation::Inherit, |_| {});
+2500-            // Restore TMPDIR before the assert so a panic still
+2501-            // leaves the parent env clean for other tests.
+2502-            unsafe {
+2503-                match prior {
+2504-                    Some(v) => std::env::set_var("TMPDIR", v),
+2505-                    None => std::env::remove_var("TMPDIR"),
+2506-                }
+2507-            }
+2508-            assert_eq!(code, 0);
+2509:            assert_eq!(tail, "tmpdir=/inherited-from-parent");
+2510-        }
+2511-
+2512-        / Plan 89 W3 part 11 —`Isolation::Unshared`mode wraps
+2513-        /// the build subprocess in`unshare --mount --pid --ipc
+2514- /// --fork`. The cmd.sh reads `/proc/self/status`and
+2515-        / looks for`NSpid:`— under a fresh pid namespace, the
+2516-        /// build sees PID 1 inside its own namespace (the second
+2517-        ///`NSpid`column).
+2518-        ///
+2519-        /// Skipped if`unshare`isn't installed or if the test
+2520-        /// runner lacks`CAP_SYS_ADMIN`(e.g. unprivileged Docker
+2521-        /// CI). The Linux build-VM runs as PID 1 with full caps,
+2522-        /// so the real dispatch path always succeeds; this test
+2523-        /// exercises the wiring on whatever Linux host runs the
+2524-        /// suite.
+2525-        #[test]
+2526:        fn run_job_streaming_unshared_runs_in_fresh_pid_namespace() {
+2527-            use std::process::Stdio;
+2528-            / Fast-path probe: if`unshare --pid --fork --mount
+2529- // --ipc true`fails on this host, skip — the test is
+2530-            // exercising correctness of the wiring, not the host's
+2531-            // capability set.
+2532-            let probe = Command::new("unshare")
+2533-                .args(["--mount", "--pid", "--ipc", "--fork", "true"])
+2534:                .stdout(Stdio::null())
+2535:                .stderr(Stdio::null())
+2536-                .status();
+2537-            let probe_ok = probe.map(|s| s.success()).unwrap_or(false);
+2538-            if !probe_ok {
+2539-                eprintln!(
+2540-                    "skipping unshared test: host lacks unshare or CAP_SYS_ADMIN — \
+2541-                     the Linux build-VM runs as PID 1 with full caps so the real \
+2542-                     dispatch path is unaffected"
+2543-                );
+--
+2584-        }
+2585-
+2586-        /// Plan 89 W3 part 13 — pure argv-shape test for the
+2587-        /// wiring around`build_isolated_command`. Runs on every
+2588- /// host (no spawn, no caps required) so an accidental
+2589- /// reorder of unshare/setpriv flags trips here even when
+2590- /// the host can't actually run the chain.
+2591- #[test]
+2592: fn build_isolated_command_inherit_uses_plain_shell() {
+2593- use std::ffi::OsStr;
+2594- let cmd = build_isolated_command("/job/cmd.sh", Isolation::Inherit);
+2595- assert_eq!(cmd.get_program(), OsStr::new("/bin/sh"));
+2596- let args: Vec<&OsStr> = cmd.get_args().collect();
+2597- assert_eq!(args, vec![OsStr::new("-eu"), OsStr::new("/job/cmd.sh")]);
+2598- }
+2599-
+2600- #[test]
+
+**Tool Call: Read crates/mvm-builder-init/src/main.rs (790 - 849)**
+Status: Completed
+
+```
+790	        if conn.read_exact(&mut body).is_err() {
+791	            return None;
+792	        }
+793	        Some(body)
+794	    }
+795
+796	    fn send_dispatch_response_via_vsock(payload: &crate::dispatch_response::DispatchResponse) {
+797	        const ACCEPT_TIMEOUT_SECS: i64 = 10;
+798	        let Some(listen_fd) = open_dispatch_listener_fd(Some(ACCEPT_TIMEOUT_SECS)) else {
+799	            return;
+800	        };
+801	        let Some(conn_fd) = accept_one(listen_fd) else {
+802	            eprintln!(
+803	                "mvm-builder-init: vsock send: no host connection within {ACCEPT_TIMEOUT_SECS}s \
+804	                 (single-shot path; W2 part 4 wired the host receiver)"
+805	            );
+806	            unsafe { close(listen_fd) };
+807	            return;
+808	        };
+809	        let mut conn = adopt_conn_fd(conn_fd);
+810	        let json = payload.to_json();
+811	        if !write_frame(&mut conn, json.as_bytes()) {
+812	            eprintln!("mvm-builder-init: vsock send: write failed mid-frame");
+813	        }
+814	        drop(conn);
+815	        unsafe { close(listen_fd) };
+816	    }
+817
+818	    // -----------------------------------------------------------
+819	    // Plan 89 W3 part 3 — persistent-VM dispatch loop
+820	    // -----------------------------------------------------------
+821
+822	    /// Plan 89 W3 part 3 — dispatch loop entry point. Called from
+823	    /// `run` when `/job/dispatch.sock.marker` is present (the host
+824	    /// stages the marker when spawning a long-lived
+825	    /// `LibkrunPersistentBuilderVm`, W3 part 4). Opens a long-lived
+826	    /// AF_VSOCK listener on [`BUILDER_DISPATCH_PORT`], reads one
+827	    /// `BuilderRequest` per accepted connection, dispatches the
+828	    /// inner job, writes back a `BuilderResponse::Result`, and
+829	    /// repeats until a `Shutdown` request triggers a clean exit.
+830	    ///
+831	    /// `cold_boot_timings` carries the BootTimings snapshot taken
+832	    /// at dispatch-loop entry. Per Plan 89 spec, only the
+833	    /// supervisor's *first* dispatch in a persistent VM session
+834	    /// gets a populated `boot_timings` field on the wire; subsequent
+835	    /// dispatches see `None`. The first dispatch in this loop
+836	    /// consumes the snapshot via `.take()`.
+837	    ///
+838	    /// Returns `0` on graceful `Shutdown`, non-zero on listener
+839	    /// setup failure (caller `power_off`s either way).
+840	    fn run_dispatch_loop(mut cold_boot_timings: Option<BootTimings>) -> i32 {
+841	        // No accept timeout — the dispatch loop is persistent and
+842	        // blocks waiting for the supervisor's next submit. The
+843	        // outer `mvmctl dev down` signals shutdown via a
+844	        // `BuilderRequest::Shutdown` frame on a fresh connection.
+845	        let Some(listen_fd) = open_dispatch_listener_fd(None) else {
+846	            eprintln!("mvm-builder-init: dispatch loop: listener setup failed");
+847	            return 1;
+848	        };
+849	        eprintln!("mvm-builder-init: dispatch loop ready on AF_VSOCK port {BUILDER_DISPATCH_PORT}");
+```
+
+**Tool Call: find /Users/auser/work/tinylabs/mvmco/mvm/crates/mvm-cli/src/commands -type f -name "\*.rs" | head -20**
+Status: Completed
+
+Terminal:
+
+```
+/Users/auser/work/tinylabs/mvmco/mvm/crates/mvm-cli/src/commands/manifest/export_oci.rs
+/Users/auser/work/tinylabs/mvmco/mvm/crates/mvm-cli/src/commands/manifest/rm.rs
+/Users/auser/work/tinylabs/mvmco/mvm/crates/mvm-cli/src/commands/manifest/ls.rs
+/Users/auser/work/tinylabs/mvmco/mvm/crates/mvm-cli/src/commands/manifest/alias.rs
+/Users/auser/work/tinylabs/mvmco/mvm/crates/mvm-cli/src/commands/manifest/mod.rs
+/Users/auser/work/tinylabs/mvmco/mvm/crates/mvm-cli/src/commands/manifest/tag.rs
+/Users/auser/work/tinylabs/mvmco/mvm/crates/mvm-cli/src/commands/manifest/verify.rs
+/Users/auser/work/tinylabs/mvmco/mvm/crates/mvm-cli/src/commands/manifest/info.rs
+/Users/auser/work/tinylabs/mvmco/mvm/crates/mvm-cli/src/commands/manifest/prune.rs
+/Users/auser/work/tinylabs/mvmco/mvm/crates/mvm-cli/src/commands/bundle/export.rs
+/Users/auser/work/tinylabs/mvmco/mvm/crates/mvm-cli/src/commands/bundle/gc.rs
+/Users/auser/work/tinylabs/mvmco/mvm/crates/mvm-cli/src/commands/bundle/fetch.rs
+/Users/auser/work/tinylabs/mvmco/mvm/crates/mvm-cli/src/commands/bundle/mod.rs
+/Users/auser/work/tinylabs/mvmco/mvm/crates/mvm-cli/src/commands/bundle/install.rs
+/Users/auser/work/tinylabs/mvmco/mvm/crates/mvm-cli/src/commands/catalog.rs
+/Users/auser/work/tinylabs/mvmco/mvm/crates/mvm-cli/src/commands/shared/format.rs
+/Users/auser/work/tinylabs/mvmco/mvm/crates/mvm-cli/src/commands/shared/start.rs
+/Users/auser/work/tinylabs/mvmco/mvm/crates/mvm-cli/src/commands/shared/resolve.rs
+/Users/auser/work/tinylabs/mvmco/mvm/crates/mvm-cli/src/commands/shared/event.rs
+/Users/auser/work/tinylabs/mvmco/mvm/crates/mvm-cli/src/commands/shared/drive.rs
+```
+
+**Tool Call: find /Users/auser/work/tinylabs/mvmco/mvm/crates/mvm-cli/src/commands -name "\*.rs" | xargs grep -l "vsock\|add_vsock\|BUILDER_DISPATCH_PORT" | head -10**
+Status: Completed
+
+Terminal:
+
+```
+/Users/auser/work/tinylabs/mvmco/mvm/crates/mvm-cli/src/commands/shared/mod.rs
+/Users/auser/work/tinylabs/mvmco/mvm/crates/mvm-cli/src/commands/shared/vsock.rs
+/Users/auser/work/tinylabs/mvmco/mvm/crates/mvm-cli/src/commands/env/apple_container.rs
+/Users/auser/work/tinylabs/mvmco/mvm/crates/mvm-cli/src/commands/env/dev.rs
+/Users/auser/work/tinylabs/mvmco/mvm/crates/mvm-cli/src/commands/mod.rs
+/Users/auser/work/tinylabs/mvmco/mvm/crates/mvm-cli/src/commands/vm/session.rs
+/Users/auser/work/tinylabs/mvmco/mvm/crates/mvm-cli/src/commands/vm/up.rs
+/Users/auser/work/tinylabs/mvmco/mvm/crates/mvm-cli/src/commands/vm/invoke_no_vm.rs
+/Users/auser/work/tinylabs/mvmco/mvm/crates/mvm-cli/src/commands/vm/cp.rs
+/Users/auser/work/tinylabs/mvmco/mvm/crates/mvm-cli/src/commands/vm/wait.rs
+```
+
+**Tool Call: Read crates/mvm-cli/src/commands/shared/vsock.rs**
+Status: Completed
+
+````
+1	//! Vsock helpers for talking to the in-guest agent.
+2	//!
+3	//! Routes through `mvm::vsock_transport::AppleContainerTransport`
+4	//! intentionally — these helpers serve `mvmctl up` flows that today
+5	//! only target the Apple Container backend (Firecracker `up` uses a
+6	//! different code path). If/when a Firecracker `up` lands, swap to
+7	//! `vsock_transport::for_vm`.
+8
+9	use anyhow::Result;
+10
+11	use mvm::vsock_transport::{AppleContainerTransport, VsockTransport};
+12
+13	/// Wait for the guest agent to complete the ADR-053 / plan 74 W1
+14	/// protocol hello over vsock. Returns true once the agent has
+15	/// answered `ProtocolHelloAck` (with at least the `Ping` capability)
+16	/// within `timeout_secs`. A `ProtocolMismatch` answer, a transport
+17	/// error, or an unexpected response counts as "not ready yet" and the
+18	/// probe keeps polling until the deadline.
+19	pub fn wait_for_guest_agent(vm_id: &str, timeout_secs: u64) -> bool {
+20	    let deadline = std::time::Instant::now() + std::time::Duration::from_secs(timeout_secs);
+21	    let transport = AppleContainerTransport::new(vm_id);
+22
+23	    while std::time::Instant::now() < deadline {
+24	        if let Ok(mut s) = transport.connect(mvm_guest::vsock::GUEST_AGENT_PORT)
+25	            && mvm_guest::vsock::negotiate_protocol(
+26	                &mut s,
+27	                vec![mvm_guest::vsock::GuestCapability::Ping],
+28	            )
+29	            .is_ok()
+30	        {
+31	            return true;
+32	        }
+33	        std::thread::sleep(std::time::Duration::from_millis(500));
+34	    }
+35	    false
+36	}
+37
+38	/// Tell the guest agent to start a vsock→TCP forwarder for the given port.
+39	pub fn request_port_forward(vm_id: &str, guest_port: u16) -> Result<u32> {
+40	    let transport = AppleContainerTransport::new(vm_id);
+41	    let mut stream = transport.connect(mvm_guest::vsock::GUEST_AGENT_PORT)?;
+42	    mvm_guest::vsock::start_port_forward_on(&mut stream, guest_port)
+43	}
+44
+45	/// Plan 74 W2 / Plan 51 W6 — emit a `LocalAuditKind::NetworkPolicyAllow`
+46	/// audit record for one host→guest vsock RPC. Pairs with
+47	/// `GuestRequest::kind_name()`; the verb name lands in the audit
+48	/// detail as `verb=<kebab-name>`.
+49	///
+50	/// Detail format (mvmd ADR 0022 §"Audit-first principle"):
+51	///
+52	/// ```text
+53	/// scope=rpc,direction=in,kind=vsock,verb=<name>
+54	/// ```
+55	///
+56	/// The `vm` field carries the target VM name. mvmd ADR 0022 §item 2
+57	/// names this as part of the inbound audit story — Plan 37 §6
+58	/// invariant "every state-changing CLI verb emits ≥1 audit" extends
+59	/// to the underlying vsock messages each verb dispatches.
+60	///
+61	/// Pure host-side helper — does not touch the network or the guest;
+62	/// just records the intent. The audit_emit! macro writes to the
+63	/// default audit log path.
+64	///
+65	/// Verbs to migrate (each in a follow-up slice) include `Exec`,
+66	/// `RunEntrypoint`, `RunCode`, `FsRead`/`FsWrite`/`FsList`,
+67	/// `ProcStart`/`ProcSignal`, `MountVolume`/`UnmountVolume`,
+68	/// `ConsoleOpen`. The Ping poll loop in `wait_for_guest_agent`
+69	/// deliberately *doesn't* migrate — every poll iteration would
+70	/// audit-spam (mostly while waiting for the agent to bind), so
+71	/// readiness probes get a separate `AgentReady` LocalAudit event
+72	/// in the `mvmctl up` flow already.
+73	pub fn emit_vsock_rpc_audit(vm_id: &str, request: &mvm_guest::vsock::GuestRequest) {
+74	    let verb = request.kind_name();
+75	    mvm_core::audit_emit!(
+76	        NetworkPolicyAllow,
+77	        vm: vm_id,
+78	        "scope=rpc,direction=in,kind=vsock,verb={verb}",
+79	        verb = verb,
+80	    );
+81	}
+82
+83	#[cfg(test)]
+84	mod tests {
+85	    use super::*;
+86
+87	    /// The detail format string follows the convention pinned
+88	    /// in mvm PR #275 + mvmd ADR 0022. The audit-emit macro
+89	    /// writes to the default audit log path so we can't observe
+90	    /// the record's content directly without log-pointer
+91	    /// plumbing — the contract here is that the function
+92	    /// composes cleanly with every variant.
+93	    #[test]
+94	    fn emit_vsock_rpc_audit_does_not_panic_on_common_verbs() {
+95	        let cases = [
+96	            mvm_guest::vsock::GuestRequest::Ping,
+97	            mvm_guest::vsock::GuestRequest::ReadinessStatus,
+98	            mvm_guest::vsock::GuestRequest::EntrypointStatus,
+99	            mvm_guest::vsock::GuestRequest::FsDiff,
+100	            mvm_guest::vsock::GuestRequest::Exec {
+101	                command: "echo hello".to_string(),
+102	                stdin: None,
+103	                timeout_secs: Some(30),
+104	            },
+105	        ];
+106	        for req in cases {
+107	            emit_vsock_rpc_audit("vm-test", &req);
+108	        }
+109	    }
+110	}
+111
+````
+
+**Tool Call: grep -r "BUILDER_DISPATCH_PORT\|add_vsock_port\|console\.log" /Users/auser/work/tinylabs/mvmco/mvm/crates/mvm-cli/src/commands/env/dev.rs | head -20**
+Status: Completed
+
+Terminal:
+
+```
+(Bash completed with no output)
+
+
+
+
+
+```
+
+**Tool Call: Read crates/mvm-cli/src/commands/env/dev.rs (1 - 100)**
+Status: Completed
+
+```
+1	//! `mvmctl dev` — manage the development environment.
+2	//!
+3	//! Supported local development hosts:
+4	//!
+5	//! - **macOS Apple Silicon with libkrun** → boots the dev VM via
+6	//!   libkrun on Hypervisor.framework and exposes a PTY-over-vsock
+7	//!   console.
+8	//! - **macOS 26+ Apple Silicon without libkrun** →
+9	//!   `super::apple_container` boots a dev VM via Apple
+10	//!   Virtualization.framework and exposes a PTY-over-vsock console.
+11	//! - **native Linux + KVM** → `super::linux_native` treats the host shell as
+12	//!   the dev environment, installs Firecracker + downloads kernel/
+13	//!   rootfs assets, and optionally spawns an interactive subshell.
+14	//!   This is the W8.C path — replaces the W7-deleted Lima
+15	//!   `dev_up`/`dev_down`/`dev_status` helpers.
+16	//!
+17	//! macOS Intel, macOS pre-26, Linux without KVM, WSL2, and native
+18	//! Windows bail with a clear unsupported-platform message. WSL2 with
+19	//! nested KVM and a Hyper-V managed Linux builder are future backend
+20	//! projects, not supported local paths today.
+21
+22	use anyhow::Result;
+23	use clap::{Args as ClapArgs, Subcommand};
+24
+25	use crate::ui;
+26
+27	use mvm_backend::LibkrunBackend;
+28	use mvm_core::platform::{self, Platform};
+29	use mvm_core::user_config::MvmConfig;
+30	use mvm_core::vm_backend::{VmBackend, VmId, VmStartConfig, VmStatus};
+31
+32	use super::super::vm::console;
+33	use super::Cli;
+34	use super::apple_container;
+35	use super::linux_native;
+36
+37	/// Which `mvmctl dev` backend the current host uses.
+38	#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+39	enum DevBackend {
+40	    /// macOS with libkrun — Hypervisor.framework-backed dev VM.
+41	    Libkrun,
+42	    /// macOS 26+ Apple Silicon — Apple Container dev VM.
+43	    AppleContainer,
+44	    /// Native Linux with `/dev/kvm` — host shell is the dev environment;
+45	    /// Firecracker runs natively.
+46	    LinuxKvm,
+47	    /// Neither path is wired today — macOS Intel, macOS pre-26,
+48	    /// Linux without KVM, WSL2, and native Windows.
+49	    Unsupported,
+50	}
+51
+52	fn current_backend() -> DevBackend {
+53	    // Selection order per CLAUDE.md §"Dev mode":
+54	    //   macOS 26+ Apple Silicon  → Apple Container (preferred)
+55	    //   older macOS with libkrun → Libkrun (legacy fallback)
+56	    //   Linux with KVM           → Firecracker / libkrun direct
+57	    //
+58	    // Apple Container wins over Libkrun on macOS even when both are
+59	    // available because it is the documented Stage 0 boundary AND
+60	    // the build boundary `RuntimeBuildEnv::shell_exec_visible`
+61	    // routes through (`AppleContainerEnv` in `mvm-base::linux_env`).
+62	    // Picking Libkrun-the-dev-backend while `LinuxEnv` is
+63	    // `AppleContainerEnv` leaves the dev VM under one runtime and
+64	    // the build boundary under another, neither one starting the
+65	    // other.
+66	    let plat = platform::current();
+67	    if plat.has_apple_containers() {
+68	        DevBackend::AppleContainer
+69	    } else if matches!(plat, Platform::MacOS) && plat.has_libkrun() {
+70	        DevBackend::Libkrun
+71	    } else if plat.has_kvm() && matches!(plat, Platform::LinuxNative) {
+72	        DevBackend::LinuxKvm
+73	    } else {
+74	        DevBackend::Unsupported
+75	    }
+76	}
+77
+78	#[derive(ClapArgs, Debug, Clone)]
+79	pub(in crate::commands) struct Args {
+80	    #[command(subcommand)]
+81	    pub action: Option<DevAction>,
+82	}
+83
+84	#[derive(Subcommand, Debug, Clone)]
+85	pub(in crate::commands) enum DevAction {
+86	    /// Bootstrap and start the dev environment.
+87	    Up {
+88	        /// Number of vCPUs for the dev VM (Apple Container).
+89	        #[arg(long, default_value = "8")]
+90	        cpus: u32,
+91	        /// Memory (GiB) for the dev VM (Apple Container).
+92	        #[arg(long, default_value = "16")]
+93	        memory: u32,
+94	        /// Project directory to cd into inside the VM.
+95	        #[arg(long)]
+96	        project: Option<String>,
+97	        /// Bind a Prometheus metrics endpoint on this port (0 = disabled).
+98	        #[arg(long, default_value = "0")]
+99	        metrics_port: u16,
+100	        /// Reload ~/.mvm/config.toml automatically when it changes.
+```
+
+**Tool Call: grep -n "console.log\|add_vsock\|BUILDER_DISPATCH" /Users/auser/work/tinylabs/mvmco/mvm/crates/mvm-cli/src/commands/env/apple_container.rs | head -20**
+Status: Completed
+
+Terminal:
+
+```
+99:    // console.log does — they are mode 0600 so a same-host other user
+3272:///    of `console.log`.
+3337:        // console.log). They don't write sidecars but their argv
+
+
+
+```
+
+**Tool Call: grep -rn "console.log" /Users/auser/work/tinylabs/mvmco/mvm/crates/mvm-cli/src | head -20**
+Status: Completed
+
+Terminal:
+
+```
+/Users/auser/work/tinylabs/mvmco/mvm/crates/mvm-cli/src/commands/env/apple_container.rs:99:    // console.log does — they are mode 0600 so a same-host other user
+/Users/auser/work/tinylabs/mvmco/mvm/crates/mvm-cli/src/commands/env/apple_container.rs:3272:///    of `console.log`.
+/Users/auser/work/tinylabs/mvmco/mvm/crates/mvm-cli/src/commands/env/apple_container.rs:3337:        // console.log). They don't write sidecars but their argv
+/Users/auser/work/tinylabs/mvmco/mvm/crates/mvm-cli/src/commands/mod.rs:54:    /// Show console logs from a running microVM
+/Users/auser/work/tinylabs/mvmco/mvm/crates/mvm-cli/src/commands/vm/up.rs:1332:            // Parse the console log and emit
+/Users/auser/work/tinylabs/mvmco/mvm/crates/mvm-cli/src/commands/vm/up.rs:1826:            // the same `<vm_dir>/console.log` convention; the
+/Users/auser/work/tinylabs/mvmco/mvm/crates/mvm-cli/src/commands/vm/logs.rs:1://! `mvmctl logs` — show console logs from a running microVM.
+```
+
+**Tool Call: Read crates/mvm-cli/src/commands/vm/logs.rs (1 - 80)**
+Status: Completed
+
+```
+1	//! `mvmctl logs` — show console logs from a running microVM.
+2
+3	use anyhow::{Context, Result};
+4	use clap::Args as ClapArgs;
+5
+6	use mvm_backend::microvm;
+7	use mvm_core::naming::validate_vm_name;
+8	use mvm_core::user_config::MvmConfig;
+9
+10	use super::Cli;
+11	use super::shared::clap_vm_name;
+12
+13	#[derive(ClapArgs, Debug, Clone)]
+14	pub(in crate::commands) struct Args {
+15	    /// Name of the VM
+16	    #[arg(value_parser = clap_vm_name)]
+17	    pub name: String,
+18	    /// Follow log output (like tail -f)
+19	    #[arg(long, short = 'f')]
+20	    pub follow: bool,
+21	    /// Number of lines to show (default 50)
+22	    #[arg(long, short = 'n', default_value = "50")]
+23	    pub lines: u32,
+24	    /// Show Firecracker hypervisor logs instead of guest console output
+25	    #[arg(long)]
+26	    pub hypervisor: bool,
+27	}
+28
+29	pub(in crate::commands) fn run(_cli: &Cli, args: Args, _cfg: &MvmConfig) -> Result<()> {
+30	    validate_vm_name(&args.name).with_context(|| format!("Invalid VM name: {:?}", args.name))?;
+31	    microvm::logs(&args.name, args.follow, args.lines, args.hypervisor)
+32	}
+33
+```
+
+**Tool Call: grep -rn "\.drv\.log\|nix-store-.\*\.img" /Users/auser/work/tinylabs/mvmco/mvm/crates/mvm-builder-init/src | head -20**
+Status: Completed
+
+Terminal:
+
+```
+/Users/auser/work/tinylabs/mvmco/mvm/crates/mvm-builder-init/src/main.rs:2168:    /// is fine: `/nix-store-<arch>.img` is always attached as a
+
+
+
+
+```
+
+**Tool Call: Read Cargo.toml (1 - 150)**
+Status: Completed
+
+```
+1	[workspace]
+2	members = [
+3	    "crates/mvm-core",
+4	    "crates/mvm-security",
+5	    "crates/mvm-storage",
+6	    "crates/mvm-plan",
+7	    "crates/mvm-policy",
+8	    "crates/mvm-supervisor",
+9	    "crates/mvm-providers",
+10	    "crates/mvm-libkrun",
+11	    "crates/mvm-backend",
+12	    "crates/mvm-base",
+13	    "crates/mvm",
+14	    "crates/mvm-build",
+15	    "crates/mvm-guest",
+16	    "crates/mvm-cli",
+17	    "crates/mvm-mcp",
+18	    # plan 74 W1 — OCI image distribution client (registry resolution,
+19	    # manifest fetch, digest verification; layer fetch + ext4 unpack +
+20	    # verity generation land in subsequent W1 PRs). Anonymous-only at
+21	    # W1.1; private auth lands later behind the credential redaction
+22	    # contract from ADR-049. mvmd consumes this crate as a library per
+23	    # ADR-048 §"Runtime Ownership" — keep its dep closure small.
+24	    "crates/mvm-oci",
+25	    # Plan 72 W3 — PID-1 for the libkrun builder VM. Linux-only at
+26	    # runtime; the crate compiles on macOS / Windows as an inert
+27	    # binary so workspace builds stay green for non-Linux contributors.
+28	    "crates/mvm-builder-init",
+29	    # Plan 73 Followup B.2.x — HTTP CONNECT proxy with hostname
+30	    # allowlist for the builder VM's application-deps install.
+31	    # Linux-only at runtime; same workspace-ergonomics rule as
+32	    # mvm-builder-init.
+33	    "crates/mvm-egress-proxy",
+34	    # Local addon developer experience: in-guest addon name resolution
+35	    # and loopback TCP to host-vsock bridge. Distributed service mesh,
+36	    # tenant policy, and cryptographic routing belong in mvmd.
+37	    "crates/mvm-addon-dns",
+38	    "crates/mvm-addon-vsock-bridge",
+39	    # plan 60 Phase 5 — build-time SDK port from ../mvmforge.
+40	    # mvm-ir is the canonical Workload IR; mvm-sdk is the builder
+41	    # surface; mvm-sdk-macros is a placeholder for the proc-macro
+42	    # surface that lands in a Phase 5 follow-on.
+43	    "crates/mvm-ir",
+44	    "crates/mvm-sdk",
+45	    "crates/mvm-sdk-macros",
+46	    # plan 60 Phase 5 Slice C — in-guest entrypoint runner for
+47	    # function-call workloads, ported from mvmforge-runtime.
+48	    "crates/mvm-runner",
+49	    "xtask",
+50	]
+51	# cargo-fuzz crates have to be excluded from the main workspace because
+52	# they depend on libfuzzer-sys, which only builds under cargo-fuzz's
+53	# wrapper (it injects the right linker flags + sanitizer toolchain).
+54	# Plain `cargo build --workspace` would otherwise fail with linker
+55	# errors. ADR-002 §W4.2.
+56	exclude = [
+57	    "crates/mvm-guest/fuzz",
+58	    # Plan 85 §R1 / Phase A.2 — layer-unpack fuzz harness. Same
+59	    # libfuzzer-sys linker-flag constraints as the mvm-guest fuzz
+60	    # crate; CI gate at `.github/workflows/ci.yml::oci-unpack-fuzz`.
+61	    "crates/mvm-oci/fuzz",
+62	    # Plan 88 W6 / ADR-055 §"New untrusted-input surfaces" —
+63	    # supervisor-config JSON fuzz harness. CI gate at
+64	    # `.github/workflows/security.yml::fuzz`.
+65	    "crates/mvm-libkrun/fuzz",
+66	]
+67	resolver = "3"
+68
+69	[workspace.package]
+70	# 0.14.0 — first version after the v1→v2 cutover (2026-05-11).
+71	# v1's final release was 0.13.0 (tag v1-final, branch legacy/v1); the
+72	# v2 rewrite ships under the same project name + binary but is
+73	# functionally different software. Bumping the minor signals "0.x
+74	# breaking changes" without prematurely committing to a 1.0 stability
+75	# promise.
+76	version = "0.14.0"
+77	edition = "2024"
+78	rust-version = "1.85"
+79	license = "Apache-2.0"
+80	repository = "https://github.com/tinylabscom/mvm"
+81	homepage = "https://github.com/tinylabscom/mvm"
+82	authors = ["mvm contributors"]
+83
+84	# Workspace-wide lint policy. Plan-60 Phase 0 exit criterion — every
+85	# crate inherits this via `lints.workspace = true` in its own
+86	# Cargo.toml. CLAUDE.md says "No `clippy::too_many_arguments`: never
+87	# suppress this lint. Refactor into smaller functions or a config/
+88	# params struct." The lint here enforces that workspace-wide so a
+89	# future violator gets blocked at `cargo clippy --workspace --
+90	# -D warnings` instead of slipping through.
+91	[workspace.lints.clippy]
+92	too_many_arguments = "deny"
+93
+94	[workspace.dependencies]
+95	# Async runtime
+96	tokio = { version = "1", features = ["full"] }
+97
+98	# Pattern matching
+99	aho-corasick = "1"
+100	regex = "1"
+101
+102	# Crypto
+103	aes-gcm = "0.10"
+104	base64 = "0.22"
+105	ed25519-dalek = { version = "2", features = ["rand_core"] }
+106	hmac = "0.12"
+107	rand = "0.8"
+108	# `secrecy` wraps secret-carrying types so accidental `Debug`/`Display`
+109	# becomes a compile error. Plan 63 W2 — `SecretBox<T>` pass on every
+110	# `KeyProvider` / `WrappedKey` / snapshot-HMAC-key consumer.
+111	secrecy = { version = "0.10", features = ["serde"] }
+112	sha2 = "0.10"
+113	zeroize = { version = "1", features = ["zeroize_derive"] }
+114
+115	# Serialization
+116	serde = { version = "1", features = ["derive"] }
+117	serde_json = "1"
+118	toml = "0.8"
+119
+120	# CLI
+121	clap = { version = "4", features = ["derive"] }
+122	clap_complete = "4"
+123	clap_mangen = "0.2"
+124	colored = "3"
+125	indicatif = "0.17"
+126	inquire = "0.7"
+127
+128	# Object storage abstraction (used for dev template registry)
+129	opendal = { version = "0.50", features = ["services-s3"] }
+130
+131	# HTTP client (for CLI upgrade)
+132	reqwest = { version = "0.12", features = ["blocking", "json", "rustls-tls"], default-features = false }
+133
+134	# Name generation
+135	names = { version = "0.14", default-features = false }
+136
+137	# Signal handling
+138	ctrlc = "3.4"
+139	libc = "0.2"
+140
+141	# Seccomp BPF compilation (W2.4 — per-service syscall filtering inside
+142	# guests, applied via the `mvm-seccomp-apply` shim before execve into
+143	# the service binary).
+144	seccompiler = "0.5"
+145
+146	# File watching (dev-watch feature only)
+147	notify = "7"
+148	notify-debouncer-mini = "0.5"
+149
+150	# IP/CIDR matching for the L4 egress proxy's allow-list rules.
+```
+
+**Tool Call: find /Users/auser/work/tinylabs/mvmco/mvm -path "_ext4_" -type d | head -10**
+Status: Completed
+
+Terminal:
+
+```
+/Users/auser/work/tinylabs/mvmco/mvm/target/debug/incremental/oci_ext4_materialization-0ld99roez0rah
+/Users/auser/work/tinylabs/mvmco/mvm/target/debug/incremental/oci_ext4_materialization-0ld99roez0rah/s-hinq0t25sq-0bcydj0-cgpeurdps96qjj8aea8kolyrg
+/Users/auser/work/tinylabs/mvmco/mvm/target/debug/incremental/oci_ext4_materialization-1lbr38q0x00cx
+/Users/auser/work/tinylabs/mvmco/mvm/target/debug/incremental/oci_ext4_materialization-1lbr38q0x00cx/s-hioo91aqe7-0dk0jmu-4aekmdqcmwre4n0f0pwxu0rwt
+/Users/auser/work/tinylabs/mvmco/mvm/target/debug/incremental/oci_ext4_materialization-20h1bsavxo5xw
+/Users/auser/work/tinylabs/mvmco/mvm/target/debug/incremental/oci_ext4_materialization-20h1bsavxo5xw/s-hiorshm3rd-0rnhqr7-d5gr0s629tc1c3d4wrdcf8kfe
+/Users/auser/work/tinylabs/mvmco/mvm/target/debug/incremental/oci_ext4_materialization-0k2hoysf6ycnv
+/Users/auser/work/tinylabs/mvmco/mvm/target/debug/incremental/oci_ext4_materialization-0k2hoysf6ycnv/s-hijfpdhi1l-19mivig-0szgrdtlcjhlf4a5697v4h5ih
+/Users/auser/work/tinylabs/mvmco/mvm/target/debug/incremental/oci_ext4_materialization-0k2hoysf6ycnv/s-hijeh53nhi-0i5l5ft-0szgrdtlcjhlf4a5697v4h5ih
+/Users/auser/work/tinylabs/mvmco/mvm/target/debug/incremental/oci_ext4_materialization-007fio84zwgsr
+```
+
+**Tool Call: grep -C 5 "mvm-libkrun" /Users/auser/work/tinylabs/mvmco/mvm/Cargo.toml | grep -A 10 "mvm-cli\|mvm-providers"**
+Status: Completed
+
+Terminal:
+
+```
+    "crates/mvm-providers",
+    "crates/mvm-libkrun",
+    "crates/mvm-backend",
+    "crates/mvm-base",
+    "crates/mvm",
+    "crates/mvm-build",
+    "crates/mvm-guest",
+--
+    # crate; CI gate at `.github/workflows/ci.yml::oci-unpack-fuzz`.
+    "crates/mvm-oci/fuzz",
+    # Plan 88 W6 / ADR-055 §"New untrusted-input surfaces" —
+--
+mvm-providers = { path = "crates/mvm-providers", version = "0.14.0" }
+# Plan 57 W1 — libkrun FFI bindings split out of mvm-providers so the
+# bindgen + libclang build cost is isolated from the Apple-VZ objc2
+# stack. Default feature set is empty; consumers wanting real FFI
+# enable `libkrun-sys` on a host with libkrun installed.
+mvm-libkrun = { path = "crates/mvm-libkrun", version = "0.14.0" }
+mvm-backend = { path = "crates/mvm-backend", version = "0.14.0", default-features = false }
+
+# Plan 73 Followup B.2.x — builder-VM egress allowlist proxy.
+# mvm-builder-init spawns this as a subprocess before the
+# installer + tears it down after.
+--
+```
+
+**Tool Call: Read nix/images/builder-vm/flake.nix (210 - 239)**
+Status: Completed
+
+```
+210	      # workspace's `cargo test` CI lane; running them again here
+211	      # would double-pay the closure compute for no extra signal.
+212	      mvmBuilderInitFor = system:
+213	        let
+214	          pkgs = import nixpkgs { inherit system; };
+215	        in
+216	        pkgs.rustPlatform.buildRustPackage {
+217	          pname = "mvm-builder-init";
+218	          version = "0.14.0";
+219	          src = workspace;
+220	          cargoLock = {
+221	            lockFile = workspace + "/Cargo.lock";
+222	          };
+223	          buildAndTestSubdir = "crates/mvm-builder-init";
+224	          doCheck = false;
+225	          meta = {
+226	            description = "PID-1 for the libkrun builder VM (Plan 72 W3)";
+227	            mainProgram = "mvm-builder-init";
+228	          };
+229	        };
+230
+231	      # Build `mvm-egress-proxy` (Plan 73 Followup B.2.x) for the
+232	      # target system. Same `rustPlatform.buildRustPackage` shape
+233	      # as `mvm-builder-init` — the workspace's `Cargo.lock`
+234	      # drives the closure so we don't fork dep versions across
+235	      # the two builder-VM binaries. Tests run in CI's
+236	      # `cargo test --workspace` lane; `doCheck = false` here for
+237	      # the same reason.
+238	      mvmEgressProxyFor = system:
+239	        let
+```
+
+**Tool Call: find /Users/auser/work/tinylabs/mvmco/mvm -path "_mvm-builder-init/src/ext4_" -o -path "\*ext4.rs" | grep -v target | head -10**
+Status: Completed
+
+Terminal:
+
+```
+/Users/auser/work/tinylabs/mvmco/mvm/crates/mvm-build/src/oci_to_rootfs/ext4.rs
+/Users/auser/work/tinylabs/mvmco/mvm/.claude/worktrees/skip-addon-dns/crates/mvm-build/src/oci_to_rootfs/ext4.rs
+/Users/auser/work/tinylabs/mvmco/mvm/.claude/worktrees/fingerprint-expansion/crates/mvm-build/src/oci_to_rootfs/ext4.rs
+/Users/auser/work/tinylabs/mvmco/mvm/.claude/worktrees/stage0-error-handler/crates/mvm-build/src/oci_to_rootfs/ext4.rs
+/Users/auser/work/tinylabs/mvmco/mvm/.claude/worktrees/plan-92-stock-kernel/crates/mvm-build/src/oci_to_rootfs/ext4.rs
+```
+
+**Tool Call: grep -rn "parse_ext4\|ext4" /Users/auser/work/tinylabs/mvmco/mvm/crates/mvm-builder-init/src/main.rs | head -20**
+Status: Completed
+
+Terminal:
+
+```
+/Users/auser/work/tinylabs/mvmco/mvm/crates/mvm-builder-init/src/main.rs:29://!   2. Probe `/dev/vdb` for an ext4 superblock; format with
+/Users/auser/work/tinylabs/mvmco/mvm/crates/mvm-builder-init/src/main.rs:30://!      `mkfs.ext4 -F` if blank (first boot on a fresh sparse
+/Users/auser/work/tinylabs/mvmco/mvm/crates/mvm-builder-init/src/main.rs:123:/// Bytes from the start of the ext4 superblock that the host-side
+/Users/auser/work/tinylabs/mvmco/mvm/crates/mvm-builder-init/src/main.rs:130:/// Parse the ext4 superblock buffer and return the total
+/Users/auser/work/tinylabs/mvmco/mvm/crates/mvm-builder-init/src/main.rs:132:/// when the buffer has no valid ext4 magic / a sanity-failing
+/Users/auser/work/tinylabs/mvmco/mvm/crates/mvm-builder-init/src/main.rs:146:fn parse_ext4_recorded_size_bytes(sb: &[u8]) -> Option<u64> {
+/Users/auser/work/tinylabs/mvmco/mvm/crates/mvm-builder-init/src/main.rs:157:    // Reject absurd block sizes — ext4 spec allows 1 KiB..64 KiB
+/Users/auser/work/tinylabs/mvmco/mvm/crates/mvm-builder-init/src/main.rs:179:    /// Build a synthetic ext4 superblock buffer (just the fields
+/Users/auser/work/tinylabs/mvmco/mvm/crates/mvm-builder-init/src/main.rs:180:    /// `parse_ext4_recorded_size_bytes` reads).
+/Users/auser/work/tinylabs/mvmco/mvm/crates/mvm-builder-init/src/main.rs:192:    fn parse_ext4_size_rejects_buffer_without_magic() {
+/Users/auser/work/tinylabs/mvmco/mvm/crates/mvm-builder-init/src/main.rs:194:        assert_eq!(parse_ext4_recorded_size_bytes(&sb), None);
+/Users/auser/work/tinylabs/mvmco/mvm/crates/mvm-builder-init/src/main.rs:198:    fn parse_ext4_size_rejects_short_buffer() {
+/Users/auser/work/tinylabs/mvmco/mvm/crates/mvm-builder-init/src/main.rs:200:        assert_eq!(parse_ext4_recorded_size_bytes(&sb), None);
+/Users/auser/work/tinylabs/mvmco/mvm/crates/mvm-builder-init/src/main.rs:204:    fn parse_ext4_size_computes_64gib_default_layout() {
+/Users/auser/work/tinylabs/mvmco/mvm/crates/mvm-builder-init/src/main.rs:205:        // mkfs.ext4 default: 4 KiB blocks (log=2). A 64 GiB
+/Users/auser/work/tinylabs/mvmco/mvm/crates/mvm-builder-init/src/main.rs:209:            parse_ext4_recorded_size_bytes(&sb),
+/Users/auser/work/tinylabs/mvmco/mvm/crates/mvm-builder-init/src/main.rs:215:    fn parse_ext4_size_handles_64bit_feature() {
+/Users/auser/work/tinylabs/mvmco/mvm/crates/mvm-builder-init/src/main.rs:224:            parse_ext4_recorded_size_bytes(&sb),
+/Users/auser/work/tinylabs/mvmco/mvm/crates/mvm-builder-init/src/main.rs:230:    fn parse_ext4_size_rejects_absurd_block_size() {
+/Users/auser/work/tinylabs/mvmco/mvm/crates/mvm-builder-init/src/main.rs:231:        // log=7 → 128 KiB blocks, which mkfs.ext4 never produces;
+```
+
+**Tool Call: grep -rn "21471\|add_vsock\|vsock.\*port" /Users/auser/work/tinylabs/mvmco/mvm/crates/mvm-libkrun/src | head -30**
+Status: Completed
+
+Terminal:
+
+```
+/Users/auser/work/tinylabs/mvmco/mvm/crates/mvm-libkrun/src/bin/mvm-libkrun-supervisor.rs:30://!     "vsock_ports": [5252],
+/Users/auser/work/tinylabs/mvmco/mvm/crates/mvm-libkrun/src/lib.rs:268:    pub vsock_ports: Vec<u32>,
+/Users/auser/work/tinylabs/mvmco/mvm/crates/mvm-libkrun/src/lib.rs:287:    /// Directory on the host where the per-vsock-port Unix socket
+/Users/auser/work/tinylabs/mvmco/mvm/crates/mvm-libkrun/src/lib.rs:290:    /// `vsock-<port>.sock` inside this directory; a sibling host
+/Users/auser/work/tinylabs/mvmco/mvm/crates/mvm-libkrun/src/lib.rs:294:    /// falls back to `/tmp/mvm-libkrun-<name>-vsock-<port>.sock`
+/Users/auser/work/tinylabs/mvmco/mvm/crates/mvm-libkrun/src/lib.rs:399:            vsock_ports: Vec::new(),
+/Users/auser/work/tinylabs/mvmco/mvm/crates/mvm-libkrun/src/lib.rs:426:            vsock_ports: Vec::new(),
+/Users/auser/work/tinylabs/mvmco/mvm/crates/mvm-libkrun/src/lib.rs:462:            vsock_ports: Vec::new(),
+/Users/auser/work/tinylabs/mvmco/mvm/crates/mvm-libkrun/src/lib.rs:522:    /// `<dir>/vsock-<port>.sock`; otherwise falls back to a per-VM
+/Users/auser/work/tinylabs/mvmco/mvm/crates/mvm-libkrun/src/lib.rs:526:    pub fn vsock_socket_path(&self, port: u32) -> std::path::PathBuf {
+/Users/auser/work/tinylabs/mvmco/mvm/crates/mvm-libkrun/src/lib.rs:528:            Some(dir) => std::path::PathBuf::from(dir).join(format!("vsock-{port}.sock")),
+/Users/auser/work/tinylabs/mvmco/mvm/crates/mvm-libkrun/src/lib.rs:530:                "/tmp/mvm-libkrun-{}-vsock-{port}.sock",
+/Users/auser/work/tinylabs/mvmco/mvm/crates/mvm-libkrun/src/lib.rs:549:    /// Append a vsock port the guest agent will listen on.
+/Users/auser/work/tinylabs/mvmco/mvm/crates/mvm-libkrun/src/lib.rs:550:    pub fn add_vsock_port(mut self, port: u32) -> Self {
+/Users/auser/work/tinylabs/mvmco/mvm/crates/mvm-libkrun/src/lib.rs:551:        self.vsock_ports.push(port);
+/Users/auser/work/tinylabs/mvmco/mvm/crates/mvm-libkrun/src/lib.rs:604:/// kernel, rootfs, and vsock-port configuration through the FFI, then
+/Users/auser/work/tinylabs/mvmco/mvm/crates/mvm-libkrun/src/lib.rs:770:    for &port in &ctx.vsock_ports {
+/Users/auser/work/tinylabs/mvmco/mvm/crates/mvm-libkrun/src/lib.rs:771:        let socket = ctx.vsock_socket_path(port);
+/Users/auser/work/tinylabs/mvmco/mvm/crates/mvm-libkrun/src/lib.rs:772:        krun.add_vsock_port2(port, &socket, /* listen = */ true)?;
+/Users/auser/work/tinylabs/mvmco/mvm/crates/mvm-libkrun/src/lib.rs:956:    /// (via `KrunContext::vsock_socket_dir`) the per-port vsock
+/Users/auser/work/tinylabs/mvmco/mvm/crates/mvm-libkrun/src/lib.rs:986:///    `add_vsock_port2(listen=true)` host-listener registration so
+/Users/auser/work/tinylabs/mvmco/mvm/crates/mvm-libkrun/src/lib.rs:1076:            .add_vsock_port(5252);
+/Users/auser/work/tinylabs/mvmco/mvm/crates/mvm-libkrun/src/lib.rs:1080:        assert_eq!(ctx.vsock_ports, vec![5252]);
+/Users/auser/work/tinylabs/mvmco/mvm/crates/mvm-libkrun/src/lib.rs:1219:    fn vsock_socket_path_distinguishes_ports() {
+/Users/auser/work/tinylabs/mvmco/mvm/crates/mvm-libkrun/src/lib.rs:1222:            .add_vsock_port(5252)
+/Users/auser/work/tinylabs/mvmco/mvm/crates/mvm-libkrun/src/lib.rs:1223:            .add_vsock_port(5253);
+/Users/auser/work/tinylabs/mvmco/mvm/crates/mvm-libkrun/src/lib.rs:1260:            "vsock_ports": [],
+/Users/auser/work/tinylabs/mvmco/mvm/crates/mvm-libkrun/src/sys.rs:237:    pub fn add_vsock(&self, tsi_features: u32) -> Result<(), Error> {
+/Users/auser/work/tinylabs/mvmco/mvm/crates/mvm-libkrun/src/sys.rs:238:        check(unsafe { bindings::krun_add_vsock(self.ctx_id, tsi_features) })
+/Users/auser/work/tinylabs/mvmco/mvm/crates/mvm-libkrun/src/sys.rs:241:    pub fn add_vsock_port(&self, port: u32, host_path: &Path) -> Result<(), Error> {
+```
+
+**Tool Call: Read crates/mvm-libkrun/src/lib.rs (768 - 797)**
+Status: Completed
+
+```
+768	        krun.add_virtiofs(&mount.tag, Path::new(&mount.host_path))?;
+769	    }
+770	    for &port in &ctx.vsock_ports {
+771	        let socket = ctx.vsock_socket_path(port);
+772	        krun.add_vsock_port2(port, &socket, /* listen = */ true)?;
+773	    }
+774	    if let Some(console_path) = &ctx.console_output_path {
+775	        krun.set_console_output(Path::new(console_path))?;
+776	    }
+777	    Ok(krun)
+778	}
+779
+780	/// Validate that the boot fields on `ctx` describe exactly one of the
+781	/// supported shapes: (kernel + rootfs), (kernel + initramfs), or
+782	/// (root_dir + guest_entrypoint). Anything else is a programming
+783	/// error — we'd otherwise pass nonsense to libkrun and watch it
+784	/// fail late with an opaque rc.
+785	///
+786	/// Always-on so unit tests can exercise it without the `libkrun-sys`
+787	/// feature. `configure_pre_net` is the only non-test caller and is
+788	/// gated behind that feature, so the dead-code allow keeps the
+789	/// non-feature library build quiet.
+790	#[cfg_attr(not(feature = "libkrun-sys"), allow(dead_code))]
+791	fn validate_boot_config(ctx: &KrunContext) -> Result<(), Error> {
+792	    let has_kernel = ctx.kernel_path.is_some();
+793	    let has_rootfs = ctx.rootfs_path.is_some();
+794	    let has_initramfs = ctx.initramfs_path.is_some();
+795	    let has_root_dir = ctx.root_dir.is_some();
+796	    let has_entry = ctx.guest_entrypoint.is_some();
+797
+```
+
+**Tool Call: grep -rn "21471\|BUILDER_DISPATCH" /Users/auser/work/tinylabs/mvmco/mvm/crates/mvm-cli/src 2>/dev/null | head -30**
+Status: Completed
+
+Terminal:
+
+```
+/Users/auser/work/tinylabs/mvmco/mvm/crates/mvm-cli/src/commands/build/persistent_builder.rs:107:    /// Path libkrun exposes for AF_VSOCK port 21471 proxy. The
+
+
+
+```
+
+**Tool Call: Read crates/mvm-cli/src/commands/build/persistent_builder.rs (1 - 150)**
+Status: Completed
+
+```
+1	//! Plan 89 W3 part 5 — `mvmctl persistent-builder` CLI verb.
+2	//!
+3	//! Wires the W3 parts 1-4 pieces (host-side
+4	//! `LibkrunPersistentBuilderVm` + `PersistentBuilderSupervisor`
+5	//! + the in-guest dispatch loop) into a user-facing command.
+6	//! Three subcommands:
+7	//!
+8	//! - **`start --workspace <path>`** — spawns the long-lived
+9	//!   builder VM and records the dispatch socket path so
+10	//!   subsequent `submit` / `stop` calls find it.
+11	//! - **`submit --flake <path>`** — dispatches one
+12	//!   `BuilderJob::Flake` into the running VM, blocks for the
+13	//!   `BuilderResponse::Result`, prints the outcome. Re-stages
+14	//!   `cmd.sh` under the running VM's job dir per-call.
+15	//! - **`stop`** — sends `BuilderRequest::Shutdown` to the dispatch
+16	//!   loop, waits for the supervisor child to exit cleanly.
+17	//!
+18	//! This is deliberately separate from `mvmctl dev up`. Plan 89's
+19	//! lifecycle binding (`mvmctl dev up` auto-starts the persistent
+20	//! supervisor) lands in a follow-up to avoid colliding with the
+21	//! ur-seed work in flight on `mvmctl dev`. Once both stacks are
+22	//! merged, `mvmctl dev up` becomes a thin caller of the same
+23	//! `LibkrunPersistentBuilderVm::start()` this verb invokes.
+24	//!
+25	//! ## Session state
+26	//!
+27	//! The running VM's dispatch-socket path + supervisor PID get
+28	//! recorded at `~/.mvm/run/persistent-builder.json` so `submit` /
+29	//! `stop` find them across process invocations. The file is mode
+30	//! 0600 to match the ADR-002 W1.5 contract for `~/.mvm/run/`.
+31	//!
+32	//! ## What's deferred
+33	//!
+34	//! - Auto-start from `mvmctl dev up` (post-merge follow-up).
+35	//! - `mvmctl build` routing into the persistent supervisor when a
+36	//!   session is active (W3 part 7+ — `submit` from W3 part 6
+37	//!   now produces real artifacts, so the routing target exists).
+38	//! - Install variant dispatch.
+39	//! - Stderr streaming.
+40
+41	use std::path::PathBuf;
+42	use std::time::Duration;
+43
+44	use anyhow::{Context, Result, bail};
+45	use clap::{Args as ClapArgs, Subcommand};
+46	use serde::{Deserialize, Serialize};
+47
+48	use mvm_build::builder_protocol::BuilderResponseRead;
+49	use mvm_build::builder_vm::BuilderJob;
+50	use mvm_build::libkrun_builder::{
+51	    DISPATCH_SOCK_MARKER, LibkrunPersistentBuilderVm, PersistentVmHandle,
+52	};
+53	use mvm_build::persistent_builder::{DispatchOutcome, PersistentBuilderSupervisor};
+54
+55	use crate::commands::Cli;
+56
+57	#[derive(ClapArgs, Debug, Clone)]
+58	pub struct Args {
+59	    #[command(subcommand)]
+60	    pub command: Sub,
+61	}
+62
+63	#[derive(Subcommand, Debug, Clone)]
+64	pub enum Sub {
+65	    /// Spawn the persistent builder VM and record the session.
+66	    /// The VM keeps running after this command returns; `submit`
+67	    /// dispatches jobs into it and `stop` brings it down.
+68	    Start(StartArgs),
+69	    /// Dispatch one flake build into the running persistent VM
+70	    /// and print the outcome.
+71	    Submit(SubmitArgs),
+72	    /// Send `BuilderRequest::Shutdown` to the persistent VM and
+73	    /// wait for it to power off cleanly.
+74	    Stop(StopArgs),
+75	    /// Print the current session record (if any).
+76	    Status,
+77	}
+78
+79	#[derive(ClapArgs, Debug, Clone)]
+80	pub struct StartArgs {
+81	    /// Host directory bound at `/work` inside the persistent VM.
+82	    /// Defaults to the current working directory.
+83	    #[arg(long)]
+84	    pub workspace: Option<PathBuf>,
+85	}
+86
+87	#[derive(ClapArgs, Debug, Clone)]
+88	pub struct SubmitArgs {
+89	    /// Flake reference to build (e.g. `path:/work#packages.default`).
+90	    #[arg(long)]
+91	    pub flake: String,
+92	    /// Flake attribute path. Defaults to `packages.<host_arch>-linux.default`.
+93	    #[arg(long)]
+94	    pub attr: Option<String>,
+95	}
+96
+97	#[derive(ClapArgs, Debug, Clone)]
+98	pub struct StopArgs {}
+99
+100	/// Persisted at `~/.mvm/run/persistent-builder.json` — single
+101	/// source of truth for `submit` / `stop` to locate a running
+102	/// session.
+103	#[derive(Debug, Serialize, Deserialize)]
+104	struct SessionRecord {
+105	    /// Opaque session ID from `PersistentVmHandle::session_id`.
+106	    session_id: String,
+107	    /// Path libkrun exposes for AF_VSOCK port 21471 proxy. The
+108	    /// supervisor connects here.
+109	    dispatch_socket_path: PathBuf,
+110	    /// Per-VM job dir (bound at `/job` in the guest). `submit`
+111	    /// stages each call's cmd.sh under a fresh
+112	    /// `<job_dir_relpath>` here.
+113	    job_dir: PathBuf,
+114	    /// Workspace bound at `/work` in the guest. Recorded for
+115	    /// `status` output; not load-bearing.
+116	    workspace_root: PathBuf,
+117	    /// PID of the libkrun supervisor child. `stop` uses
+118	    /// `libc::kill(pid, 0)` to check liveness before attempting
+119	    /// shutdown.
+120	    supervisor_pid: u32,
+121	}
+122
+123	fn session_record_path() -> PathBuf {
+124	    let home = std::env::var_os("HOME")
+125	        .map(PathBuf::from)
+126	        .unwrap_or_else(|| PathBuf::from("/tmp"));
+127	    home.join(".mvm")
+128	        .join("run")
+129	        .join("persistent-builder.json")
+130	}
+131
+132	fn write_session_record(record: &SessionRecord) -> Result<()> {
+133	    let path = session_record_path();
+134	    if let Some(parent) = path.parent() {
+135	        std::fs::create_dir_all(parent)
+136	            .with_context(|| format!("creating {}", parent.display()))?;
+137	    }
+138	    let body = serde_json::to_vec_pretty(record).context("serializing session record")?;
+139	    std::fs::write(&path, body).with_context(|| format!("writing {}", path.display()))?;
+140	    #[cfg(unix)]
+141	    {
+142	        use std::os::unix::fs::PermissionsExt;
+143	        let _ = std::fs::set_permissions(&path, std::fs::Permissions::from_mode(0o600));
+144	    }
+145	    Ok(())
+146	}
+147
+148	fn read_session_record() -> Result<SessionRecord> {
+149	    let path = session_record_path();
+150	    let body = std::fs::read(&path).with_context(|| {
+```
+
+**Tool Call: grep -rn "accept.*vsock\|vsock.*accept" /Users/auser/work/tinylabs/mvmco/mvm/crates/mvm-build/src 2>/dev/null | head -20**
+Status: Completed
+
+Terminal:
+
+```
+(Bash completed with no output)
+
+
+
+
+
+```
+
+**Tool Call: find /Users/auser/work/tinylabs/mvmco/mvm/crates/mvm-build/src -name "\*.rs" | head -20**
+Status: Completed
+
+Terminal:
+
+```
+/Users/auser/work/tinylabs/mvmco/mvm/crates/mvm-build/src/cache.rs
+/Users/auser/work/tinylabs/mvmco/mvm/crates/mvm-build/src/pipeline/dev_build.rs
+/Users/auser/work/tinylabs/mvmco/mvm/crates/mvm-build/src/pipeline/build.rs
+/Users/auser/work/tinylabs/mvmco/mvm/crates/mvm-build/src/pipeline/mod.rs
+/Users/auser/work/tinylabs/mvmco/mvm/crates/mvm-build/src/pipeline/vsock_builder.rs
+/Users/auser/work/tinylabs/mvmco/mvm/crates/mvm-build/src/pipeline/orchestrator.rs
+/Users/auser/work/tinylabs/mvmco/mvm/crates/mvm-build/src/template_reuse.rs
+/Users/auser/work/tinylabs/mvmco/mvm/crates/mvm-build/src/nix/manifest.rs
+/Users/auser/work/tinylabs/mvmco/mvm/crates/mvm-build/src/nix/mod.rs
+/Users/auser/work/tinylabs/mvmco/mvm/crates/mvm-build/src/nix/scripts.rs
+/Users/auser/work/tinylabs/mvmco/mvm/crates/mvm-build/src/app_deps_gate.rs
+/Users/auser/work/tinylabs/mvmco/mvm/crates/mvm-build/src/app_deps.rs
+/Users/auser/work/tinylabs/mvmco/mvm/crates/mvm-build/src/builder_vm.rs
+/Users/auser/work/tinylabs/mvmco/mvm/crates/mvm-build/src/lib.rs
+/Users/auser/work/tinylabs/mvmco/mvm/crates/mvm-build/src/stage0.rs
+/Users/auser/work/tinylabs/mvmco/mvm/crates/mvm-build/src/backend/host.rs
+/Users/auser/work/tinylabs/mvmco/mvm/crates/mvm-build/src/backend/mod.rs
+/Users/auser/work/tinylabs/mvmco/mvm/crates/mvm-build/src/backend/vsock.rs
+/Users/auser/work/tinylabs/mvmco/mvm/crates/mvm-build/src/backend/ssh.rs
+/Users/auser/work/tinylabs/mvmco/mvm/crates/mvm-build/src/firecracker.rs
+```
+
+**Tool Call: Read crates/mvm-build/src/backend/vsock.rs (1 - 150)**
+Status: Completed
+
+```
+1	use anyhow::{Result, anyhow};
+2
+3	use mvm_core::build_env::BuildEnvironment;
+4	use mvm_core::instance::InstanceNet;
+5	use mvm_core::pool::PoolSpec;
+6	use mvm_core::tenant::TenantNet;
+7
+8	use super::{BackendBuildResult, BackendParams, BuilderBackend};
+9	use crate::artifacts::extract_artifacts_from_output_disk;
+10	use crate::build::{
+11	    BUILDER_OUTPUT_DISK_MIB, BUILDER_VCPUS, PoolBuildOpts, create_builder_input_disk,
+12	    create_builder_output_disk,
+13	};
+14	use crate::firecracker::{boot_builder_vsock, teardown_builder_for_retry};
+15	use crate::vsock_builder::build_via_vsock;
+16
+17	pub(crate) struct VsockBackend<'a> {
+18	    pub(crate) build_run_dir: &'a str,
+19	    pub(crate) builder_net: &'a InstanceNet,
+20	    pub(crate) tenant_net: &'a TenantNet,
+21	    pub(crate) spec: &'a PoolSpec,
+22	    pub(crate) timeout: u64,
+23	    pub(crate) opts: &'a PoolBuildOpts,
+24	    pub(crate) tenant_id: &'a str,
+25	    pub(crate) pool_id: &'a str,
+26	    builder_pid: Option<u32>,
+27	    out_disk: Option<String>,
+28	    in_disk: Option<String>,
+29	    vsock_uds: Option<String>,
+30	}
+31
+32	impl<'a> VsockBackend<'a> {
+33	    pub(crate) fn new(params: BackendParams<'a>) -> Self {
+34	        Self {
+35	            build_run_dir: params.build_run_dir,
+36	            builder_net: params.builder_net,
+37	            tenant_net: params.tenant_net,
+38	            spec: params.spec,
+39	            timeout: params.timeout,
+40	            opts: params.opts,
+41	            tenant_id: params.tenant_id,
+42	            pool_id: params.pool_id,
+43	            builder_pid: None,
+44	            out_disk: None,
+45	            in_disk: None,
+46	            vsock_uds: None,
+47	        }
+48	    }
+49	}
+50
+51	impl BuilderBackend for VsockBackend<'_> {
+52	    fn prepare(&mut self, env: &dyn BuildEnvironment) -> Result<()> {
+53	        let out_disk = create_builder_output_disk(self.build_run_dir, BUILDER_OUTPUT_DISK_MIB);
+54	        let in_disk = create_builder_input_disk(env, self.build_run_dir, &self.spec.flake_ref)?;
+55	        let vsock_uds = format!("{}/v.sock", self.build_run_dir);
+56	        self.out_disk = Some(out_disk);
+57	        self.in_disk = in_disk;
+58	        self.vsock_uds = Some(vsock_uds);
+59	        Ok(())
+60	    }
+61
+62	    fn boot(&mut self, env: &dyn BuildEnvironment) -> Result<()> {
+63	        let out_disk = self
+64	            .out_disk
+65	            .as_deref()
+66	            .ok_or_else(|| anyhow!("missing out disk before vsock boot"))?;
+67	        let vsock_uds = self
+68	            .vsock_uds
+69	            .as_deref()
+70	            .ok_or_else(|| anyhow!("missing vsock uds before boot"))?;
+71	        let pid = boot_builder_vsock(
+72	            env,
+73	            self.build_run_dir,
+74	            self.builder_net,
+75	            self.tenant_net,
+76	            self.opts.builder_vcpus.unwrap_or(BUILDER_VCPUS),
+77	            self.opts
+78	                .builder_mem_mib
+79	                .unwrap_or(crate::build::BUILDER_MEM_MIB),
+80	            out_disk,
+81	            self.in_disk.as_deref(),
+82	            vsock_uds,
+83	        )?;
+84	        self.builder_pid = Some(pid);
+85	        Ok(())
+86	    }
+87
+88	    fn build(&mut self, _env: &dyn BuildEnvironment) -> Result<()> {
+89	        let system = if cfg!(target_arch = "aarch64") {
+90	            "aarch64-linux"
+91	        } else {
+92	            "x86_64-linux"
+93	        };
+94	        let attr = format!("packages.{system}.tenant-{}", self.spec.role);
+95	        let flake_ref = if self.in_disk.is_some() {
+96	            "/build-in"
+97	        } else {
+98	            &self.spec.flake_ref
+99	        };
+100	        let vsock_uds = self
+101	            .vsock_uds
+102	            .as_deref()
+103	            .ok_or_else(|| anyhow!("missing vsock uds before build"))?;
+104	        build_via_vsock(vsock_uds, flake_ref, &attr, self.timeout)?;
+105	        Ok(())
+106	    }
+107
+108	    fn extract_artifacts(&mut self, env: &dyn BuildEnvironment) -> Result<BackendBuildResult> {
+109	        let out_disk = self
+110	            .out_disk
+111	            .as_deref()
+112	            .ok_or_else(|| anyhow!("missing out disk before extract"))?;
+113	        let revision_hash =
+114	            extract_artifacts_from_output_disk(env, out_disk, self.tenant_id, self.pool_id)?;
+115	        Ok(BackendBuildResult {
+116	            revision_hash,
+117	            lock_hash: None,
+118	        })
+119	    }
+120
+121	    fn teardown(&mut self, env: &dyn BuildEnvironment) -> Result<()> {
+122	        // Important: during `auto` mode we may fall back to another backend using the same run dir.
+123	        // Avoid deleting the run dir here; orchestrator handles final cleanup.
+124	        let _ = self.builder_pid.take();
+125	        teardown_builder_for_retry(env, self.builder_net, self.build_run_dir)?;
+126	        Ok(())
+127	    }
+128	}
+129
+```
+
+**Tool Call: Read crates/mvm-build/src/pipeline/vsock_builder.rs (1 - 150)**
+Status: Completed
+
+```
+1	use std::io::{BufRead, BufReader, Write};
+2	use std::os::unix::net::UnixStream;
+3	use std::time::{Duration, Instant};
+4
+5	use anyhow::{Context, Result, anyhow};
+6	use mvm_guest::builder_agent::{BuilderRequest, BuilderResponse};
+7
+8	fn builder_agent_port() -> u32 {
+9	    std::env::var("MVM_BUILDER_AGENT_PORT")
+10	        .ok()
+11	        .and_then(|s| s.parse::<u32>().ok())
+12	        .unwrap_or(mvm_guest::builder_agent::BUILDER_AGENT_PORT)
+13	}
+14
+15	pub fn build_via_vsock(
+16	    vsock_uds: &str,
+17	    flake_ref: &str,
+18	    attr: &str,
+19	    timeout_secs: u64,
+20	) -> Result<String> {
+21	    wait_for_agent_ready(vsock_uds, timeout_secs.clamp(15, 90))?;
+22
+23	    let mut stream = UnixStream::connect(vsock_uds)
+24	        .with_context(|| format!("failed to connect vsock UDS {}", vsock_uds))?;
+25	    stream
+26	        .set_read_timeout(Some(Duration::from_secs(timeout_secs)))
+27	        .ok();
+28	    stream.set_write_timeout(Some(Duration::from_secs(5))).ok();
+29
+30	    // Firecracker UDS CONNECT handshake.
+31	    writeln!(stream, "CONNECT {}", builder_agent_port())?;
+32	    stream.flush()?;
+33
+34	    let mut reader = BufReader::new(stream);
+35	    let mut line = String::new();
+36	    reader.read_line(&mut line)?;
+37	    if !line.starts_with("OK ") {
+38	        return Err(anyhow!("vsock CONNECT failed: {}", line.trim()));
+39	    }
+40
+41	    let req = BuilderRequest::Build {
+42	        flake_ref: flake_ref.to_string(),
+43	        attr: attr.to_string(),
+44	        timeout_secs: Some(timeout_secs),
+45	    };
+46	    let req_json = serde_json::to_string(&req)?;
+47	    {
+48	        let s = reader.get_mut();
+49	        writeln!(s, "{}", req_json)?;
+50	        s.flush()?;
+51	    }
+52
+53	    let mut resp_line = String::new();
+54	    // Collect recent log lines so we can surface them on build failure.
+55	    let mut recent_logs: Vec<String> = Vec::new();
+56	    const MAX_LOG_LINES: usize = 50;
+57
+58	    loop {
+59	        resp_line.clear();
+60	        if reader.read_line(&mut resp_line)? == 0 {
+61	            return Err(anyhow!("vsock EOF before build response"));
+62	        }
+63	        let trimmed = resp_line.trim();
+64	        if trimmed.is_empty() {
+65	            continue;
+66	        }
+67	        let resp: BuilderResponse = serde_json::from_str(trimmed)
+68	            .with_context(|| format!("invalid builder response: {}", trimmed))?;
+69	        match resp {
+70	            BuilderResponse::Log { line } => {
+71	                if !line.is_empty() {
+72	                    tracing::debug!(target: "mvm::build", "[builder-agent] {}", line);
+73	                    if recent_logs.len() >= MAX_LOG_LINES {
+74	                        recent_logs.remove(0);
+75	                    }
+76	                    recent_logs.push(line);
+77	                }
+78	            }
+79	            BuilderResponse::Ok { out_path } => return Ok(out_path),
+80	            BuilderResponse::Err { message } => {
+81	                if recent_logs.is_empty() {
+82	                    return Err(anyhow!("nix build failed: {}", message));
+83	                }
+84	                let log_tail = recent_logs.join("\n");
+85	                return Err(anyhow!(
+86	                    "nix build failed: {}. Builder output (last {} lines):\n{}",
+87	                    message,
+88	                    recent_logs.len(),
+89	                    log_tail
+90	                ));
+91	            }
+92	            BuilderResponse::Pong => continue,
+93	        }
+94	    }
+95	}
+96
+97	fn wait_for_agent_ready(vsock_uds: &str, max_wait_secs: u64) -> Result<()> {
+98	    let deadline = Instant::now() + Duration::from_secs(max_wait_secs);
+99	    let mut attempts = 0u32;
+100	    loop {
+101	        attempts += 1;
+102	        match ping_once(vsock_uds) {
+103	            Ok(()) => {
+104	                let elapsed =
+105	                    Instant::now().duration_since(deadline - Duration::from_secs(max_wait_secs));
+106	                tracing::info!(
+107	                    elapsed_secs = elapsed.as_secs_f64(),
+108	                    attempts,
+109	                    "builder agent ready"
+110	                );
+111	                return Ok(());
+112	            }
+113	            Err(_) if Instant::now() < deadline => {
+114	                if attempts.is_multiple_of(5) {
+115	                    let remaining = deadline.duration_since(Instant::now());
+116	                    tracing::info!(
+117	                        remaining_secs = remaining.as_secs_f64(),
+118	                        "waiting for builder agent"
+119	                    );
+120	                }
+121	                std::thread::sleep(Duration::from_millis(400));
+122	            }
+123	            Err(e) => {
+124	                return Err(anyhow!(
+125	                    "builder vsock agent did not become ready in {}s: {}",
+126	                    max_wait_secs,
+127	                    e
+128	                ));
+129	            }
+130	        }
+131	    }
+132	}
+133
+134	fn ping_once(vsock_uds: &str) -> Result<()> {
+135	    let mut stream = UnixStream::connect(vsock_uds)
+136	        .with_context(|| format!("failed to connect vsock UDS {}", vsock_uds))?;
+137	    stream.set_read_timeout(Some(Duration::from_secs(2))).ok();
+138	    stream.set_write_timeout(Some(Duration::from_secs(2))).ok();
+139	    writeln!(stream, "CONNECT {}", builder_agent_port())?;
+140	    stream.flush()?;
+141
+142	    let mut reader = BufReader::new(stream);
+143	    let mut line = String::new();
+144	    reader.read_line(&mut line)?;
+145	    if !line.starts_with("OK ") {
+146	        return Err(anyhow!("vsock CONNECT failed: {}", line.trim()));
+147	    }
+148
+149	    let req = BuilderRequest::Ping;
+150	    {
+```
+
+**Tool Call: find /Users/auser/work/tinylabs/mvmco/mvm/crates -name "_libkrun_builder_" -o -name "*libkrun*builder\*" | grep -v target | head -10**
+Status: Completed
+
+Terminal:
+
+```
+/Users/auser/work/tinylabs/mvmco/mvm/crates/mvm-build/src/libkrun_builder.rs
+
+
+
+
+```
+
+**Tool Call: Read crates/mvm-build/src/libkrun_builder.rs (1 - 200)**
+Status: Completed
+
+```
+1	//! Libkrun-backed builder VM.
+2	//!
+3	//! Plan 72 ADR-046 chose libkrun-direct (on macOS Apple Silicon /
+4	//! Intel) and Firecracker (on Linux) as the replacement for the
+5	//! libkrun-backed builder VM. This module is the libkrun half;
+6	//! W1 → W4 of the migration shipped the launcher end-to-end.
+7	//!
+8	//! ## What `LibkrunBuilderVm` does
+9	//!
+10	//! Given a populated builder VM image cache and `mvm-libkrun-supervisor`
+11	//! on PATH, `run_build` runs a one-shot `nix build` against the
+12	//! caller's `BuilderJob` and returns `BuilderArtifacts`. The
+13	//! pipeline (in [`BuilderVm::run_build`]):
+14	//!
+15	//! 1. Validate mounts + job (`validate_mounts`, `validate_job`).
+16	//! 2. Check `mvm_libkrun::is_available()` — bail with install hint
+17	//!    if libkrun isn't on the host.
+18	//! 3. Locate `mvm-libkrun-supervisor` (env override / next-to-exe /
+19	//!    PATH).
+20	//! 4. Read the builder VM image from
+21	//!    `~/.cache/mvm/builder-vm/<arch>/` — vmlinux + rootfs.ext4 +
+22	//!    cmdline.txt + manifest.json, the shape Plan 72 W2's flake
+23	//!    emits. Populated by Plan 72 W5's `bootstrap_builder_vm_image`
+24	//!    (`mvm-cli::commands::env::apple_container`).
+25	//! 5. Allocate / reuse the persistent `/nix-store-<arch>.img`
+26	//!    sparse virtio-blk image (64 GiB cap by default; idempotent
+27	//!    across invocations so the warm Nix store survives).
+28	//! 6. Stage `<job_dir>/cmd.sh` with the shell-escaped flake_ref +
+29	//!    attr_path, plus the canonical `nix build` invocation.
+30	//! 7. Build a `KrunContext`: kernel + rootfs + cmdline + per-VM
+31	//!    vsock dir + virtio-blk (Nix store) + virtio-fs (work / out /
+32	//!    job).
+33	//! 8. Spawn `mvm-libkrun-supervisor`, pipe the `SupervisorConfig`
+34	//!    JSON to stdin, **wait** for it to exit (unlike
+35	//!    `LibkrunBackend::start` which returns after the PID file
+36	//!    appears — the builder is a one-shot).
+37	//! 9. Read `<job_dir>/result` (JSON: `{exit_code, stderr_tail}`)
+38	//!    that `mvm-builder-init` wrote.
+39	//! 10. Validate the artifact dir now contains `rootfs.ext4` (and
+40	//!     optionally `vmlinux`); return `BuilderArtifacts`.
+41	//!
+42	//! ## Feature gate
+43	//!
+44	//! Gated behind `builder-vm`. Default-off until
+45	//! Plan 72 W5.B / W5.C cutover flips `ensure_dev_image` to dispatch
+46	//! through `LibkrunBuilderVm`. Library consumers that don't need
+47	//! the libkrun builder build with `default-features = false`.
+48	//!
+49	//! ## Not the runtime backend
+50	//!
+51	//! `LibkrunBackend` (`crates/mvm-backend/src/libkrun.rs`) is for
+52	//! running user microVMs; this module is for building them. The
+53	//! two share `mvm-libkrun`'s FFI but compose differently — the
+54	//! builder mounts a workspace + persistent `/nix`-store disk and
+55	//! runs a one-shot `nix build`, while the runtime mounts the
+56	//! user's rootfs and runs the user's entrypoint.
+57
+58	use std::io::{Read, Write};
+59	use std::path::{Path, PathBuf};
+60	use std::process::{Child, Command, Stdio};
+61	use std::sync::atomic::{AtomicBool, Ordering};
+62	use std::sync::{Arc, Mutex};
+63	use std::time::{Duration, Instant};
+64
+65	use mvm_libkrun::{KrunContext, SupervisorConfig};
+66	use serde::Deserialize;
+67
+68	use crate::builder_vm::{BuilderArtifacts, BuilderJob, BuilderMounts, BuilderVm, BuilderVmError};
+69
+70	/// Default vCPU count for the builder VM. Nix builds are
+71	/// embarrassingly parallel at the derivation level; 4 cores is the
+72	/// sweet spot on M-series Macs without saturating the host.
+73	pub const DEFAULT_VCPUS: u8 = 4;
+74
+75	/// Default RAM in MiB. Originally 8 GiB (Plan 72 W5.D bullet 9 —
+76	/// in-VM nix builds peak ~5-6 GiB). Plan 95 raised this to 16 GiB
+77	/// alongside bumping the Stage 0 `/nix` tmpfs `size=` cap in
+78	/// `stage0/init.sh` (4G → 14G): tmpfs is RAM-backed, so the cap
+79	/// can only be honored if the VM has at least that much RAM. The
+80	/// real bottleneck in dev-up validation was the tmpfs cap, not the
+81	/// VM RAM — bumping VM RAM alone is a no-op as long as the
+82	/// `size=` mount option clips earlier. Keep these two in lockstep.
+83	pub const DEFAULT_MEMORY_MIB: u32 = 16384;
+84
+85	/// Default size of the persistent `/nix`-store virtio-blk image,
+86	/// in MiB. 64 GiB sparse — the file only consumes the bytes the
+87	/// in-VM ext4 actually writes, but capacity caps growth so a
+88	/// runaway build can't fill the host disk.
+89	pub const DEFAULT_NIX_STORE_MIB: u32 = 65536;
+90
+91	/// Where the workspace gets mounted inside the builder VM
+92	/// (read-only virtio-fs). Plan 72 W4 wires this.
+93	pub const GUEST_WORK_DIR: &str = "/work";
+94
+95	/// Where artifacts get extracted inside the builder VM (read-write
+96	/// virtio-fs). Plan 72 W4 wires this.
+97	pub const GUEST_OUT_DIR: &str = "/out";
+98
+99	/// Where the persistent Nix store lives inside the builder VM. The
+100	/// `mvm-builder-init` PID-1 (Plan 72 W3) bind-mounts the virtio-blk
+101	/// device at this path before exec-ing the build script.
+102	pub const GUEST_NIX_DIR: &str = "/nix";
+103
+104	/// Where the per-build job spec lives inside the builder VM. The
+105	/// host stages `cmd.sh`, `env`, and the eventual `result` file
+106	/// under this path (read-write virtio-fs). Plan 72 W4 wires this.
+107	pub const GUEST_JOB_DIR: &str = "/job";
+108
+109	/// Caller-visible networking-backend preference. Read from
+110	/// the `MVM_NETWORKING` env var at every VM-launch site.
+111	///
+112	/// Plan 87 introduced `Passt` (virtio-net via the userspace passt
+113	/// gateway). Plan 88 added `Gvproxy` for macOS, where passt does not
+114	/// build (`vmsplice`/namespace primitives are Linux-only — see
+115	/// ADR-055 §"Cross-platform backends").
+116	#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+117	pub enum NetworkingPreference {
+118	    /// libkrun's built-in TSI (no virtio-net, no DHCP).
+119	    Tsi,
+120	    /// virtio-net via passt. Linux-only. Requires libkrun-sys + the
+121	    /// `passt` binary on `$PATH`. The supervisor process spawns
+122	    /// passt as a child and hands its fd to libkrun.
+123	    Passt,
+124	    /// virtio-net via gvproxy. macOS default; works on Linux too.
+125	    /// Requires libkrun-sys + the `gvproxy` binary on `$PATH`. The
+126	    /// supervisor spawns gvproxy with `-listen-vfkit unixgram://…`
+127	    /// and libkrun connects to the listener path.
+128	    Gvproxy,
+129	}
+130
+131	/// Apply the resolved [`NetworkingPreference`] to a [`KrunContext`].
+132	/// Dispatches `with_passt`, `with_gvproxy`, or leaves the context's
+133	/// default `Tsi` mode in place — keeping the two builder-VM call
+134	/// sites (shell-job + flake-build) in lockstep. Each gateway uses
+135	/// `<vm_state_dir>` for its log/socket scratch space.
+136	fn apply_networking_mode(
+137	    krun: KrunContext,
+138	    vm_state_dir: &std::path::Path,
+139	) -> Result<KrunContext, BuilderVmError> {
+140	    let scratch = path_to_str(vm_state_dir, "vm_state_dir")?;
+141	    Ok(match resolve_networking_mode() {
+142	        NetworkingPreference::Tsi => krun,
+143	        NetworkingPreference::Passt => {
+144	            krun.with_passt(mvm_libkrun::passt::DEFAULT_GUEST_MAC, scratch)
+145	        }
+146	        NetworkingPreference::Gvproxy => {
+147	            krun.with_gvproxy(mvm_libkrun::gvproxy::DEFAULT_GUEST_MAC, scratch)
+148	        }
+149	    })
+150	}
+151
+152	/// Per-host-OS default networking backend.
+153	///
+154	/// macOS → [`Gvproxy`](NetworkingPreference::Gvproxy) because passt
+155	/// does not build there (the Homebrew formula refuses with "Linux is
+156	/// required for this software"); everything else (Linux today) →
+157	/// [`Passt`](NetworkingPreference::Passt). See ADR-055
+158	/// §"Cross-platform backends" for the rationale.
+159	pub fn default_networking_mode() -> NetworkingPreference {
+160	    if cfg!(target_os = "macos") {
+161	        NetworkingPreference::Gvproxy
+162	    } else {
+163	        NetworkingPreference::Passt
+164	    }
+165	}
+166
+167	/// Read `MVM_NETWORKING` from the env. Accepts `tsi`, `passt`, and
+168	/// `gvproxy` (case-insensitive); anything else falls back to the
+169	/// per-OS default and emits a warning so a typo is visible without
+170	/// aborting.
+171	///
+172	/// Plan 87 W5 / PR3 flipped the default away from TSI; Plan 88
+173	/// added the per-OS dispatch (macOS → gvproxy, Linux → passt). TSI
+174	/// is libkrun's experimental no-network-stack mode; it works for
+175	/// trivial HTTP but breaks on nix's substituter and source fetches
+176	/// (HTTP/2 multiplexing, HTTPS redirect chains, the offline-mode
+177	/// probe — see ADR-055 §"Context"). Contributors can still opt back
+178	/// to TSI via `MVM_NETWORKING=tsi` for debugging, or pin a specific
+179	/// gateway across OS via `MVM_NETWORKING=passt` / `=gvproxy`.
+180	pub fn resolve_networking_mode() -> NetworkingPreference {
+181	    match std::env::var("MVM_NETWORKING")
+182	        .ok()
+183	        .as_deref()
+184	        .map(str::trim)
+185	        .map(str::to_ascii_lowercase)
+186	        .as_deref()
+187	    {
+188	        Some("tsi") => NetworkingPreference::Tsi,
+189	        Some("passt") => NetworkingPreference::Passt,
+190	        Some("gvproxy") => NetworkingPreference::Gvproxy,
+191	        None | Some("") => default_networking_mode(),
+192	        Some(other) => {
+193	            let fallback = default_networking_mode();
+194	            tracing::warn!(
+195	                value = other,
+196	                fallback = ?fallback,
+197	                "MVM_NETWORKING unrecognised; falling back to per-OS default (accepted: tsi, passt, gvproxy)"
+198	            );
+199	            fallback
+200	        }
+```
+
+**Tool Call: grep -n "add_vsock_port\|BUILDER_DISPATCH\|vsock.\*socket" /Users/auser/work/tinylabs/mvmco/mvm/crates/mvm-build/src/libkrun_builder.rs | head -40**
+Status: Completed
+
+Terminal:
+
+```
+354:            .with_vsock_socket_dir(path_to_str(&vm_state_dir, "vm_state_dir")?)
+420:            .with_vsock_socket_dir(path_to_str(&vm_state_dir, "vm_state_dir")?)
+429:            .add_vsock_port(mvm_guest::builder_agent::BUILDER_DISPATCH_PORT);
+684:            .with_vsock_socket_dir(path_to_str(&vm_state_dir, "vm_state_dir")?)
+693:            .add_vsock_port(mvm_guest::builder_agent::BUILDER_DISPATCH_PORT);
+1504:/// AF_VSOCK port [`mvm_guest::builder_agent::BUILDER_DISPATCH_PORT`]
+1534:        mvm_guest::builder_agent::BUILDER_DISPATCH_PORT
+1903:/// AF_VSOCK port [`mvm_guest::builder_agent::BUILDER_DISPATCH_PORT`].
+2018:            .with_vsock_socket_dir(path_to_str(&vm_state_dir, "vm_state_dir")?)
+2027:            .add_vsock_port(mvm_guest::builder_agent::BUILDER_DISPATCH_PORT);
+2096:    /// Path libkrun uses for the per-VM state (vsock sockets,
+2105:    /// proxies to AF_VSOCK [`mvm_guest::builder_agent::BUILDER_DISPATCH_PORT`]
+2111:            mvm_guest::builder_agent::BUILDER_DISPATCH_PORT
+```
+
+**Tool Call: Read crates/mvm-build/src/libkrun_builder.rs (425 - 464)**
+Status: Completed
+
+```
+425	            )
+426	            .add_virtio_fs("work", path_to_str(&job.work_dir, "work_dir")?)
+427	            .add_virtio_fs("out", path_to_str(&job.artifact_out, "artifact_out")?)
+428	            .add_virtio_fs("job", path_to_str(&job_dir, "job_dir")?)
+429	            .add_vsock_port(mvm_guest::builder_agent::BUILDER_DISPATCH_PORT);
+430
+431	        for disk in &job.extra_disks {
+432	            krun = krun.add_disk(
+433	                disk.id.as_str(),
+434	                path_to_str(&disk.path, "extra_disk")?,
+435	                disk.read_only,
+436	            );
+437	        }
+438
+439	        krun = apply_networking_mode(krun, &vm_state_dir)?;
+440
+441	        let cfg = SupervisorConfig {
+442	            krun,
+443	            vm_state_dir: path_to_str(&vm_state_dir, "vm_state_dir")?.to_string(),
+444	            pid_file_name: Some("builder.pid".to_string()),
+445	        };
+446	        // Plan 89 W2 part 4: spawn the vsock response listener
+447	        // BEFORE the supervisor so it can connect as soon as libkrun
+448	        // creates the dispatch socket. Drained after the supervisor
+449	        // exits — see `log_vsock_response_outcome` for the
+450	        // cross-validation contract.
+451	        let vsock_rx = spawn_vsock_response_listener(&vm_state_dir);
+452	        let exit_code = spawn_supervisor_and_wait(&supervisor_path, &cfg, &vm_state_dir)?;
+453	        if exit_code != 0 {
+454	            log_vsock_response_outcome(vsock_rx, None);
+455	            return Err(BuilderVmError::NixBuildFailed(format!(
+456	                "supervisor exited with non-zero status ({exit_code}); \
+457	                 guest stderr at {}",
+458	                vm_state_dir.display()
+459	            )));
+460	        }
+461
+462	        let result = read_job_result(&job_dir)?;
+463	        log_vsock_response_outcome(vsock_rx, Some(result.exit_code));
+464	        if result.exit_code != 0 {
+```
+
+**Tool Call: grep -n "fn spawn_vsock_response_listener\|fn log_vsock_response_outcome" /Users/auser/work/tinylabs/mvmco/mvm/crates/mvm-build/src/libkrun_builder.rs**
+Status: Completed
+
+Terminal:
+
+```
+1522:pub fn spawn_vsock_response_listener(
+1577:pub fn log_vsock_response_outcome(
+
+
+
+
+```
+
+**Tool Call: Read crates/mvm-build/src/libkrun_builder.rs (1500 - 1619)**
+Status: Completed
+
+```
+1500	}
+1501
+1502	/// Plan 89 W2 part 4 — spawn a background thread that reads the
+1503	/// `BuilderResponse::Result` frame `mvm-builder-init` sends over
+1504	/// AF_VSOCK port [`mvm_guest::builder_agent::BUILDER_DISPATCH_PORT`]
+1505	/// right before reboot (W2 part 3). Returns a `Receiver` the caller
+1506	/// drains after the supervisor exits via [`log_vsock_response_outcome`].
+1507	///
+1508	/// The thread starts BEFORE the supervisor so it can connect as
+1509	/// soon as libkrun creates `<vm_state_dir>/vsock-21471.sock` —
+1510	/// before the guest's listener exists, `UnixStream::connect` would
+1511	/// return `ENOENT`/`ECONNREFUSED`, hence the retry loop with a 60-second
+1512	/// outer deadline. Once connected, the thread reads with a 10-second
+1513	/// read deadline so an unresponsive guest doesn't leak the thread
+1514	/// indefinitely.
+1515	///
+1516	/// Pre-W2-part-3 cached dev images won't send a response at all;
+1517	/// the legacy `<job_dir>/result` file path remains authoritative
+1518	/// for the build's exit code. This helper's job is purely
+1519	/// observational: log what arrives, warn on mismatch against the
+1520	/// file, never gate the build on the vsock outcome.
+1521	#[cfg(feature = "builder-vm")]
+1522	pub fn spawn_vsock_response_listener(
+1523	    vm_state_dir: &Path,
+1524	) -> std::sync::mpsc::Receiver<crate::builder_protocol::BuilderResponseRead> {
+1525	    use std::os::unix::net::UnixStream;
+1526	    use std::sync::mpsc;
+1527	    use std::time::{Duration, Instant};
+1528
+1529	    use crate::builder_protocol::{BuilderResponseRead, read_builder_response};
+1530
+1531	    let (tx, rx) = mpsc::channel();
+1532	    let socket_path = vm_state_dir.join(format!(
+1533	        "vsock-{}.sock",
+1534	        mvm_guest::builder_agent::BUILDER_DISPATCH_PORT
+1535	    ));
+1536
+1537	    std::thread::Builder::new()
+1538	        .name("vsock-builder-response".to_string())
+1539	        .spawn(move || {
+1540	            let connect_deadline = Duration::from_secs(60);
+1541	            let poll_interval = Duration::from_millis(100);
+1542	            let read_timeout = Duration::from_secs(10);
+1543	            let start = Instant::now();
+1544	            let result = loop {
+1545	                if start.elapsed() > connect_deadline {
+1546	                    break BuilderResponseRead::Timeout;
+1547	                }
+1548	                match UnixStream::connect(&socket_path) {
+1549	                    Ok(mut stream) => {
+1550	                        let _ = stream.set_read_timeout(Some(read_timeout));
+1551	                        break read_builder_response(&mut stream);
+1552	                    }
+1553	                    Err(_) => std::thread::sleep(poll_interval),
+1554	                }
+1555	            };
+1556	            // The receiver may have been dropped already (caller hit
+1557	            // its recv_timeout before the thread finished). That's
+1558	            // fine — the response was observational anyway.
+1559	            let _ = tx.send(result);
+1560	        })
+1561	        .expect("std::thread::Builder::spawn never fails on unix");
+1562
+1563	    rx
+1564	}
+1565
+1566	/// Drain the listener from [`spawn_vsock_response_listener`] with a
+1567	/// bounded wait and log the outcome. If `file_exit_code` is `Some`,
+1568	/// cross-validate against the vsock-reported exit code and warn on
+1569	/// mismatch (but never propagate as an error — the file is the
+1570	/// authoritative source until W3 reverses the polarity).
+1571	///
+1572	/// The 5-second `recv_timeout` past supervisor exit is enough for
+1573	/// the read-deadline-bounded thread to deliver any in-flight
+1574	/// response; longer waits would hurt UX without buying meaningful
+1575	/// signal.
+1576	#[cfg(feature = "builder-vm")]
+1577	pub fn log_vsock_response_outcome(
+1578	    rx: std::sync::mpsc::Receiver<crate::builder_protocol::BuilderResponseRead>,
+1579	    file_exit_code: Option<i32>,
+1580	) {
+1581	    use crate::builder_protocol::{BuilderResponse, BuilderResponseRead};
+1582
+1583	    match rx.recv_timeout(std::time::Duration::from_secs(5)) {
+1584	        Ok(BuilderResponseRead::Frame(BuilderResponse::Result {
+1585	            exit_code,
+1586	            job_timings,
+1587	            boot_timings,
+1588	            ..
+1589	        })) => {
+1590	            tracing::info!(
+1591	                vsock_exit_code = exit_code,
+1592	                build_ms = job_timings.build_ms,
+1593	                boot_timings_present = boot_timings.is_some(),
+1594	                "received BuilderResponse::Result via vsock dispatch channel (W2 part 3)"
+1595	            );
+1596	            if let Some(file_code) = file_exit_code
+1597	                && file_code != exit_code
+1598	            {
+1599	                tracing::warn!(
+1600	                    file_exit_code = file_code,
+1601	                    vsock_exit_code = exit_code,
+1602	                    "vsock dispatch and <job_dir>/result disagree on exit_code; \
+1603	                     file value is authoritative pre-W3"
+1604	                );
+1605	            }
+1606	        }
+1607	        Ok(BuilderResponseRead::Frame(other)) => {
+1608	            tracing::debug!(
+1609	                ?other,
+1610	                "vsock dispatch: non-Result frame ignored in single-shot"
+1611	            );
+1612	        }
+1613	        Ok(BuilderResponseRead::EmptyEof) => {
+1614	            tracing::debug!(
+1615	                "vsock dispatch: guest closed without sending — \
+1616	                 pre-W2-part-3 image, expected"
+1617	            );
+1618	        }
+1619	        Ok(BuilderResponseRead::Timeout) => {
+```
+
+**Tool Call: grep -n "console.log\|console_output" /Users/auser/work/tinylabs/mvmco/mvm/crates/mvm-libkrun/src/lib.rs | head -20**
+Status: Completed
+
+Terminal:
+
+```
+286:    pub console_output_path: Option<String>,
+402:            console_output_path: None,
+429:            console_output_path: None,
+465:            console_output_path: None,
+585:    pub fn with_console_output(mut self, path: impl Into<String>) -> Self {
+586:        self.console_output_path = Some(path.into());
+774:    if let Some(console_path) = &ctx.console_output_path {
+775:        krun.set_console_output(Path::new(console_path))?;
+1262:            "console_output_path": null,
+```
+
+**Tool Call: Read crates/mvm-builder-init/src/main.rs (1800 - 1829)**
+Status: Completed
+
+```
+1800	        // -eu <cmd>` and the unshare+setpriv wrapped form via
+1801	        // [`build_isolated_command`]. unshare + setpriv both
+1802	        // live in `util-linux`, which is in the builder VM's
+1803	        // rootfs (`nix/images/builder-vm/flake.nix`, package list);
+1804	        // PATH (`/sbin:/usr/sbin:/bin:/usr/bin`) finds them.
+1805	        let mut cmd = build_isolated_command(cmd_sh, isolation);
+1806	        cmd.stdout(Stdio::inherit()).stderr(Stdio::piped());
+1807	        // Plan 89 W3 part 10 — point the dispatched build's
+1808	        // tmpfile machinery at the per-job scratch dir so leftover
+1809	        // tempfiles can't outlive the dispatch. Tools that honor
+1810	        // TMPDIR (mkstemp, Python's `tempfile`, Nix's evaluator,
+1811	        // `mktemp(1)`) write into `/tmp/<job_id>/` instead of the
+1812	        // shared rootfs `/tmp`. Single-shot passes `None` —
+1813	        // see [`run_job`].
+1814	        if let Some(t) = tmpdir {
+1815	            cmd.env("TMPDIR", t);
+1816	        }
+1817	        let mut child = match cmd.spawn() {
+1818	            Ok(c) => c,
+1819	            Err(e) => {
+1820	                let binary = match isolation {
+1821	                    Isolation::Inherit => "/bin/sh",
+1822	                    Isolation::Unshared => "unshare",
+1823	                };
+1824	                return (127, format!("spawn {binary}: {e}"));
+1825	            }
+1826	        };
+1827	        let Some(stderr) = child.stderr.take() else {
+1828	            // Stdio::piped() should always populate child.stderr;
+1829	            // if it didn't, fall through to a non-streaming wait so
+```
+
+## Assistant
+
+<thinking>
+
+</thinking>
+
+Three strong findings. Now I need to verify Agent 2's hypothesis (libkrun-sys feature pulled in transitively) before writing the plan.
+
+**Tool Call: Read crates/mvm-libkrun/build.rs**
+Status: Completed
+
+```
+1	//! Build script for mvm-libkrun.
+2	//!
+3	//! When the `libkrun-sys` cargo feature is on:
+4	//!   1. Probe for `libkrun.h` at the three standard install locations
+5	//!      (Apple Silicon Homebrew, Intel/manual, Linux distro).
+6	//!   2. Run `bindgen` to emit Rust FFI bindings into `OUT_DIR/libkrun_sys.rs`.
+7	//!   3. Emit `cargo:rustc-link-lib=krun` so the linker pulls in the shared
+8	//!      library.
+9	//!
+10	//! When the feature is off, this script is a noop — the workspace builds
+11	//! cleanly on hosts without libkrun installed.
+12
+13	use std::env;
+14	use std::path::{Path, PathBuf};
+15
+16	fn main() {
+17	    println!("cargo:rerun-if-changed=build.rs");
+18	    println!("cargo:rerun-if-env-changed=MVM_LIBKRUN_HEADER");
+19
+20	    if env::var_os("CARGO_FEATURE_LIBKRUN_SYS").is_none() {
+21	        // Default build path — no FFI, no link, no bindgen invocation.
+22	        return;
+23	    }
+24
+25	    let header = locate_header().unwrap_or_else(|| {
+26	        panic!(
+27	            "libkrun-sys feature is enabled but libkrun.h was not found.\n\
+28	             Checked: {}.\n\
+29	             Install libkrun (`brew install libkrun` on macOS, distro package on Linux)\n\
+30	             or point MVM_LIBKRUN_HEADER at the header path.",
+31	            probe_paths()
+32	                .iter()
+33	                .map(|p| p.display().to_string())
+34	                .collect::<Vec<_>>()
+35	                .join(", "),
+36	        )
+37	    });
+38
+39	    println!("cargo:rerun-if-changed={}", header.display());
+40
+41	    let out_path =
+42	        PathBuf::from(env::var("OUT_DIR").expect("OUT_DIR set by cargo")).join("libkrun_sys.rs");
+43
+44	    let include_dir = header
+45	        .parent()
+46	        .expect("libkrun.h has a parent directory")
+47	        .to_path_buf();
+48
+49	    bindgen::Builder::default()
+50	        .header(header.to_string_lossy())
+51	        .clang_arg(format!("-I{}", include_dir.display()))
+52	        // Keep the generated surface small — only the symbols we wrap in
+53	        // sys.rs plus the KRUN_* constants we need at the type level.
+54	        // Plan 87: also surface NET_FEATURE_*` + `COMPAT_NET_FEATURES`
+55	        // for the passt virtio-net backend (`krun_add_net_unixstream`'s
+56	        // `features` arg expects a bitwise-or of those).
+57	        .allowlist_function("krun_.*")
+58	        .allowlist_var("KRUN_.*")
+59	        .allowlist_var("NET_FEATURE_.*")
+60	        .allowlist_var("COMPAT_NET_FEATURES")
+61	        .allowlist_var("NET_FLAG_.*")
+62	        .layout_tests(false)
+63	        .generate_comments(false)
+64	        .parse_callbacks(Box::new(bindgen::CargoCallbacks::new()))
+65	        .generate()
+66	        .expect("bindgen failed to generate libkrun bindings")
+67	        .write_to_file(&out_path)
+68	        .expect("failed to write libkrun bindings");
+69
+70	    // Tell the linker to pull in libkrun. On macOS the dylib is found via
+71	    // the standard Homebrew library path; on Linux via the distro install.
+72	    println!("cargo:rustc-link-lib=krun");
+73
+74	    // Make sure the linker can find the dylib next to the header we probed.
+75	    // Homebrew installs to /opt/homebrew/{include,lib}; the symmetric `lib`
+76	    // sibling is the right hint without hardcoding paths in every consumer.
+77	    if let Some(prefix) = include_dir.parent() {
+78	        let lib_dir = prefix.join("lib");
+79	        if lib_dir.exists() {
+80	            println!("cargo:rustc-link-search=native={}", lib_dir.display());
+81	        }
+82	    }
+83	}
+84
+85	fn locate_header() -> Option<PathBuf> {
+86	    if let Some(override_path) = env::var_os("MVM_LIBKRUN_HEADER") {
+87	        let p = PathBuf::from(override_path);
+88	        if p.is_file() {
+89	            return Some(p);
+90	        }
+91	    }
+92	    probe_paths().into_iter().find(|p| p.is_file())
+93	}
+94
+95	fn probe_paths() -> Vec<PathBuf> {
+96	    vec![
+97	        Path::new("/opt/homebrew/include/libkrun.h").to_path_buf(),
+98	        Path::new("/usr/local/include/libkrun.h").to_path_buf(),
+99	        Path::new("/usr/include/libkrun.h").to_path_buf(),
+100	    ]
+101	}
+102
+```
+
+**Tool Call: Read crates/mvm-libkrun/Cargo.toml**
+Status: Completed
+
+```
+1	[package]
+2	name = "mvm-libkrun"
+3	version.workspace = true
+4	edition.workspace = true
+5	description = "Rust bindings for the Red Hat libkrun C library (Linux KVM, macOS HVF)"
+6	license.workspace = true
+7	repository.workspace = true
+8	homepage.workspace = true
+9	authors.workspace = true
+10	build = "build.rs"
+11
+12	# ── What this crate is ─────────────────────────────────────────────
+13	#
+14	# Thin Rust bindings + a safe wrapper around Red Hat libkrun's C API.
+15	# libkrun is a library-style VMM: linked directly into the calling
+16	# binary, no out-of-process daemon. On Linux it uses KVM; on macOS it
+17	# uses Hypervisor.framework. mvm uses it as a Tier 2 microVM backend
+18	# and (post-Plan-71) the builder-VM substrate.
+19	#
+20	# Two build modes:
+21	#
+22	#   * default (no feature) — no FFI, no link to libkrun. `start`/`stop`
+23	#     return `Error::NotYetWired`. The workspace builds cleanly on hosts
+24	#     without libkrun installed.
+25	#
+26	#   * `libkrun-sys` — bindgen-generated FFI + `-lkrun` link. Requires
+27	#     libkrun.h on the host (probed by build.rs at the standard install
+28	#     locations) and a working libkrun shared library at link time.
+29	#
+30	# Plan 57 W1 lands the bindings; W2 adds macOS codesigning entitlements;
+31	# W3 validates an end-to-end boot. This crate stays narrowly focused on
+32	# the FFI surface — backend dispatch lives in mvm-backend.
+33
+34	[dependencies]
+35	libc.workspace = true
+36	tracing = "0.1"
+37	# `serde` is always on (with `derive`) so the `KrunContext`,
+38	# `KrunDisk`, and `SupervisorConfig` types are serializable from
+39	# any consumer — notably `mvm-backend::LibkrunBackend`, which
+40	# builds the supervisor's JSON without ever enabling `libkrun-sys`
+41	# itself. Compile cost is marginal; serde is already in nearly
+42	# every other workspace crate's dep graph.
+43	serde = { workspace = true }
+44	# Plan 57 W4 supervisor binary (`src/bin/mvm-libkrun-supervisor.rs`)
+45	# needs JSON parsing on stdin and pulls `ensure_signed()` from
+46	# mvm-providers (macOS codesigning gate). Both are optional and
+47	# gated on `libkrun-sys` so the default workspace build (CI fast
+48	# lane, hosts without libkrun.h) skips the heavier dep graph.
+49	#
+50	# We intentionally do NOT pull `mvm-guest` from regular deps: that
+51	# would close a cycle (mvm-core → mvm-libkrun → mvm-guest → mvm-core,
+52	# since mvm-core depends on mvm-libkrun for `Platform::has_libkrun`).
+53	# The supervisor receives the vsock port list via the JSON config —
+54	# the symbolic `GUEST_AGENT_PORT` constant is only needed by callers
+55	# composing the config, not by the supervisor consuming it. The
+56	# `libkrun-smoke` example keeps `mvm-guest` as a dev-dep because
+57	# dev-deps are excluded from cycle analysis.
+58	mvm-providers = { workspace = true, optional = true }
+59	serde_json = { workspace = true, optional = true }
+60	# Plan 87 W2 — `passt` module probes $PATH for the `passt` binary
+61	# before spawning it. `which` is already in the workspace dep tree
+62	# (mvm-cli/mvm-build); pulling it in here keeps the dep graph
+63	# uniform and avoids reinventing PATH search.
+64	which.workspace = true
+65
+66	[build-dependencies]
+67	# `bindgen` is required only when the `libkrun-sys` feature is on; we
+68	# still list it unconditionally so the crate manifest reflects the real
+69	# build-time graph. The build script returns early when the feature is
+70	# off, so libclang isn't invoked in the default workspace build.
+71	bindgen = "0.72"
+72
+73	[features]
+74	default = []
+75	# Opt-in: generate FFI bindings and link `libkrun`. Off by default so
+76	# the workspace builds on hosts without libkrun installed (CI fast lane,
+77	# Linux contributors who don't run the Tier 2 backend). Enables the
+78	# supervisor binary and its mvm-guest/mvm-providers/serde dep chain.
+79	libkrun-sys = [
+80	    "dep:mvm-providers",
+81	    "dep:serde_json",
+82	]
+83
+84	[dev-dependencies]
+85	# Plan 87 W2 — passt supervisor tests stage scratch dirs.
+86	tempfile.workspace = true
+87	# The plan 57 W3 smoke example shares `GUEST_AGENT_PORT` with the
+88	# production vsock plumbing.
+89	mvm-guest.workspace = true
+90	# `ensure_signed()` is plan 57 W2's codesigning gate. macOS rejects
+91	# any process that calls `Hypervisor.framework` without
+92	# `com.apple.security.hypervisor`; the smoke binary self-signs on
+93	# first run and re-spawns, same as `mvmctl up --hypervisor
+94	# apple-container` does.
+95	mvm-providers.workspace = true
+96	# Plan 72 W4 prerequisite: unit tests for `KrunContext`'s serde
+97	# shape (incl. the new `virtio_fs_mounts` field with `#[serde(default)]`
+98	# back-compat) exercise the JSON pipe shape the supervisor binary
+99	# carries. serde_json is already an optional regular dep behind
+100	# `libkrun-sys`; listing it again as a dev-dep makes the test build
+101	# independent of feature flags.
+102	serde_json = { workspace = true }
+103
+104	# Plan 57 W3 — manual smoke binary that boots a Nix-built kernel +
+105	# ext4 rootfs via libkrun and blocks until the guest exits. Gated on
+106	# `libkrun-sys` so the example only compiles on hosts with libkrun.h
+107	# present.
+108	[[example]]
+109	name = "libkrun-smoke"
+110	path = "examples/libkrun-smoke.rs"
+111	required-features = ["libkrun-sys"]
+112
+113	# Plan 57 W4 — long-running supervisor process. One process per
+114	# libkrun guest. Reads a JSON `SupervisorConfig` on stdin, binds host
+115	# vsock listeners, writes its PID under ~/.mvm/vms/<name>/, then
+116	# `start_enter`s the guest. The W4.2 PR wires
+117	# `LibkrunBackend::start()` to spawn this binary.
+118	[[bin]]
+119	name = "mvm-libkrun-supervisor"
+120	path = "src/bin/mvm-libkrun-supervisor.rs"
+121	required-features = ["libkrun-sys"]
+122
+123	[lints]
+124	workspace = true
+125
+```
+
+**Tool Call: Read crates/mvm-core/Cargo.toml**
+Status: Completed
+
+```
+1	[package]
+2	name = "mvm-core"
+3	version.workspace = true
+4	edition.workspace = true
+5	description = "Core types, IDs, config, and utilities for mvm"
+6	license.workspace = true
+7	repository.workspace = true
+8	homepage.workspace = true
+9	authors.workspace = true
+10
+11	[dependencies]
+12	anyhow.workspace = true
+13	base64.workspace = true
+14	chrono.workspace = true
+15	mvm-providers.workspace = true
+16	mvm-libkrun.workspace = true
+17	serde.workspace = true
+18	serde_json.workspace = true
+19	sha2.workspace = true
+20	thiserror = "1"
+21	tokio = { workspace = true, features = ["io-util"] }
+22	toml.workspace = true
+23	tracing.workspace = true
+24	tracing-subscriber.workspace = true
+25	uuid.workspace = true
+26	fs2.workspace = true
+27	regex = "1"
+28	tempfile.workspace = true
+29	# Plan 74 W2 — `mandatory_deny_ranges` parses a small set of
+30	# IPv4/IPv6 CIDRs (cloud metadata endpoint, link-local, CGNAT,
+31	# host loopback). Workspace-pinned (already used by
+32	# `mvm-supervisor::proxy::l4`).
+33	ipnet = { workspace = true }
+34
+35	[lints]
+36	workspace = true
+37
+```
+
+**Tool Call: Read crates/mvm-guest/Cargo.toml**
+Status: Completed
+
+```
+1	[package]
+2	name = "mvm-guest"
+3	version.workspace = true
+4	edition.workspace = true
+5	description = "vsock protocol and openclaw connector mapping for mvm"
+6	license.workspace = true
+7	repository.workspace = true
+8	homepage.workspace = true
+9	authors.workspace = true
+10
+11	[[bin]]
+12	name = "mvm-builder-agent"
+13	path = "src/bin/mvm-builder-agent.rs"
+14
+15	[[bin]]
+16	name = "mvm-guest-agent"
+17	path = "src/bin/mvm-guest-agent.rs"
+18
+19	# Exec-shim that compiles a syscall allowlist into a BPF program via
+20	# seccompiler, applies it via prctl, and execve's into the wrapped
+21	# command. mkServiceBlock wraps every guest service launch with this
+22	# shim so per-service seccomp filters are the default. ADR-002 §W2.4.
+23	[[bin]]
+24	name = "mvm-seccomp-apply"
+25	path = "src/bin/mvm-seccomp-apply.rs"
+26
+27	# Early-userspace init (PID 1) that runs from the verity initramfs
+28	# baked by `mkGuest` when `verifiedBoot = true`. Reads the roothash
+29	# from /proc/cmdline, constructs the dm-verity device-mapper target
+30	# via raw ioctls, mounts it, and switch_roots to the real /init.
+31	# Bypasses Firecracker's auto-appended `root=/dev/vda` by owning the
+32	# boot pivot in userspace. ADR-002 §W3.
+33	[[bin]]
+34	name = "mvm-verity-init"
+35	path = "src/bin/mvm-verity-init.rs"
+36
+37	# Plan 74 W2 — guest-side network defense. Installs kernel blackhole
+38	# routes for `MANDATORY_DENY_RANGES` (cloud metadata, link-local,
+39	# CGNAT, host loopback) inside every microVM. Run as root from
+40	# `/init` BEFORE the agent is forked under setpriv, so the routes
+41	# exist before any workload code can attempt egress. Cross-platform
+42	# (Linux kernel routing is uniform across Firecracker, libkrun,
+43	# Apple Container).
+44	[[bin]]
+45	name = "mvm-guest-netinit"
+46	path = "src/bin/mvm-guest-netinit.rs"
+47
+48	# Test-only probe used by `tests/seccomp_apply.rs` to verify that
+49	# tier allowlists actually deny what they claim (ADR-002 §W2.4). Not
+50	# selected by `nix/packages/mvm-guest-agent.nix`, so it never ships
+51	# in the guest closure.
+52	[[bin]]
+53	name = "syscall-probe"
+54	path = "src/bin/syscall-probe.rs"
+55
+56	# Test fixture for the warm-process worker pool (plan 43). Speaks the
+57	# `worker_protocol` framed multi-call loop on stdin/stdout. Behavior
+58	# selectable via `MVM_FAKE_RUNNER_BEHAVIOR` env var so tests can
+59	# exercise crash, recycle, slow, and malformed-frame paths against a
+60	# real child process. Not selected by the production guest closure.
+61	[[bin]]
+62	name = "fake-runner"
+63	path = "tests/bin/fake_runner.rs"
+64	test = false
+65	doctest = false
+66
+67	[features]
+68	dev-shell = []
+69
+70	[dependencies]
+71	mvm-core.workspace = true
+72	mvm-security.workspace = true
+73	anyhow.workspace = true
+74	base64.workspace = true
+75	chrono.workspace = true
+76	ed25519-dalek.workspace = true
+77	libc.workspace = true
+78	rand.workspace = true
+79	serde.workspace = true
+80	serde_json.workspace = true
+81	# Phase 10c — readiness/shutdown hook runner uses thiserror for
+82	# typed error variants (ReadinessError, ShutdownError).
+83	thiserror = "1"
+84	tracing.workspace = true
+85	# Plan 74 W2 — the `netinit` module's trait + types + install
+86	# loop + tests are cross-platform; only `RtnetlinkInstaller`
+87	# itself is Linux-only. Keeping async-trait + ipnet in the main
+88	# deps lets the tests run on macOS dev hosts too.
+89	async-trait.workspace = true
+90	ipnet.workspace = true
+91
+92	# seccompiler builds Linux-only — guests are always Linux microVMs,
+93	# but the workspace also compiles on macOS for CLI development. Gate
+94	# the dep so `cargo check` on a Mac doesn't try to build it.
+95	[target.'cfg(target_os = "linux")'.dependencies]
+96	seccompiler = { workspace = true }
+97	# Plan 74 W2 — `mvm-guest-netinit` uses rtnetlink to install kernel
+98	# blackhole routes for `MANDATORY_DENY_RANGES`. Linux-only because
+99	# rtnetlink talks to AF_NETLINK which doesn't exist elsewhere. The
+100	# host-side mvmctl builds (which include this crate) skip these
+101	# deps on macOS; the binary itself is only relevant in the guest.
+102	rtnetlink = { workspace = true }
+103	tokio = { workspace = true }
+104	# netlink-packet-route is rtnetlink's wire-format types crate. The
+105	# RouteType::BlackHole enum the installer uses comes from here.
+106	netlink-packet-route = "0.19"
+107
+108	[dev-dependencies]
+109	tempfile.workspace = true
+110	# Plan 74 W2 — `netinit` module's tests are async (the
+111	# `RouteInstaller` trait is async). tokio is workspace-shared so
+112	# the extra dev-dep doesn't pull anything new into the lock.
+113	tokio = { workspace = true }
+114
+115	[lints]
+116	workspace = true
+117
+```
+
+**Tool Call: Read crates/mvm-guest-agent/Cargo.toml**
+Status: Failed
+
+```
+File does not exist. Note: your current working directory is /Users/auser/work/tinylabs/mvmco/mvm.
+```
+
+**Tool Call: Read nix/packages/mvm-guest-agent.nix**
+Status: Completed
+
+```
+1	# `mvm-guest-agent` — the production guest agent binary.
+2	#
+3	# Plan-60 W6.1.2 swaps the W6.1.1 sh-script stub
+4	# (`nix/lib/mk-guest.nix::agentBinary`) for the real Rust binary
+5	# defined at `crates/mvm-guest/src/bin/mvm-guest-agent.rs` (~2400
+6	# LOC of vsock RPC + worker-pool dispatch + integration manifest +
+7	# system metrics). Side-bins `mvm-seccomp-apply` (the per-service
+8	# seccomp shim, ADR-002 §W2.4) and `mvm-verity-init` (the verity-
+9	# initrd PID 1, ADR-002 §W3) ride the same derivation since the
+10	# rootfs needs them too.
+11	#
+12	# ## Build environment
+13	#
+14	# `rustPlatform.buildRustPackage` against the workspace at
+15	# `mvmSrc`. The crate is built with `--package mvm-guest --bins`
+16	# so the workspace's heavier consumers (mvm, mvm-backend,
+17	# libkrun, etc.) don't enter the closure. Cargo still
+18	# resolves and vendors the full workspace lockfile, but only the
+19	# selected crate's deps compile.
+20	#
+21	# ## Cross-targeting
+22	#
+23	# The caller passes `pkgs` for the target system (e.g. on a macOS
+24	# host with nix-darwin's linux-builder configured, the caller
+25	# resolves `pkgs.pkgsCross.aarch64-multiplatform.pkgs` and hands
+26	# it here). For native Linux + KVM the caller's own `pkgs` is
+27	# already the right thing. The W7.x.2 builder VM sets this up
+28	# transparently — `nix build` inside the sandbox runs on Linux,
+29	# so `pkgs` is Linux pkgs.
+30	#
+31	# ## Features
+32	#
+33	# `dev-shell` is opt-in. With it, the agent accepts the `Exec`
+34	# vsock request and shells out arbitrary commands — required for
+35	# `mvmctl exec`/`mvmctl console` against dev images. Without it
+36	# (production), the `Exec` symbol is absent (ADR-002 §W4.3's
+37	# `prod-agent-no-exec` CI gate is what enforces this on the
+38	# release lane).
+39
+40	{ pkgs
+41	, lib
+42	, mvmSrc
+43	, withDevShell ? false
+44	}:
+45
+46	pkgs.rustPlatform.buildRustPackage {
+47	  pname = "mvm-guest-agent";
+48	  version = "0.14.0";
+49
+50	  src = mvmSrc;
+51
+52	  # Workspace's Cargo.lock is the source of truth for every crate
+53	  # we vendor. `buildRustPackage` vendors the closure even though
+54	  # we only build mvm-guest; the unused deps compile zero code.
+55	  cargoLock.lockFile = mvmSrc + "/Cargo.lock";
+56
+57	  # Restrict the build to the mvm-guest binaries. The workspace
+58	  # has heavier members (libkrun via mvm-build, libkrun via
+59	  # mvm-providers, etc.) that aren't in the guest closure.
+60	  cargoBuildFlags = [
+61	    "--package" "mvm-guest"
+62	    "--bin" "mvm-guest-agent"
+63	    "--bin" "mvm-seccomp-apply"
+64	    "--bin" "mvm-verity-init"
+65	    # Plan 74 W2 — guest-side network defense. Installs kernel
+66	    # blackhole routes for `MANDATORY_DENY_RANGES` at boot from
+67	    # `/init` (uid 0) before the main agent forks under setpriv.
+68	    "--bin" "mvm-guest-netinit"
+69	  ] ++ lib.optionals withDevShell [
+70	    "--features" "mvm-guest/dev-shell"
+71	  ];
+72
+73	  # Same selection for the `nix flake check`-equivalent test run.
+74	  # mvm-guest's tests are pure (vsock framing, integration manifest
+75	  # parsing, seccomp filter golden tests) so they run inside the
+76	  # sandbox without privilege.
+77	  cargoTestFlags = [
+78	    "--package" "mvm-guest"
+79	  ];
+80
+81	  # Skip tests by default — they need a Linux build host and the
+82	  # builder VM already runs `nix build` (not `nix flake check`).
+83	  # CI's dedicated test lane covers the Rust test suite directly.
+84	  doCheck = false;
+85
+86	  meta = with lib; {
+87	    description = "mvm guest agent — vsock RPC handler for microVM guests";
+88	    homepage = "https://github.com/tinylabscom/mvm";
+89	    license = licenses.asl20;
+90	    platforms = platforms.linux;
+91	  };
+92	}
+93
+```
+
+## Assistant
+
+<thinking>
+
+</thinking>
+
+Let me verify Agent 3's claim about `run_job` and check how the inner build's stderr is routed.
+
+**Tool Call: Read crates/mvm-builder-init/src/main.rs (1640 - 1839)**
+Status: Completed
+
+```
+1640	                return Err(format!(
+1641	                    "SIOCSIFFLAGS {iface} IFF_UP: {}",
+1642	                    std::io::Error::last_os_error()
+1643	                ));
+1644	            }
+1645	            Ok(())
+1646	        })();
+1647
+1648	        // SAFETY: sock is owned by this function until close.
+1649	        unsafe {
+1650	            libc::close(sock);
+1651	        }
+1652	        result
+1653	    }
+1654
+1655	    fn run_job(cmd_sh: &str) -> (i32, String) {
+1656	        // Single-shot path: no streaming callback, no TMPDIR
+1657	        // override (single-shot uses the rootfs's tmpfs `/tmp`
+1658	        // directly — the VM is going to power-off, so per-job
+1659	        // scratch isolation has no second job to protect), and no
+1660	        // unshare wrapping (the VM tear-down already kills any
+1661	        // orphan process and reclaims every IPC key + mount). The
+1662	        // whole stderr tail still lands in `/job/result` and the
+1663	        // host's file-based fallback parses it. Plan 89 W3 part 9
+1664	        // added the streaming variant for the persistent dispatch
+1665	        // loop; this single-shot wrapper passes a no-op so the
+1666	        // two code paths share their `Command`/`wait` logic.
+1667	        run_job_streaming(cmd_sh, None, Isolation::Inherit, |_line| {})
+1668	    }
+1669
+1670	    /// Plan 89 W3 part 11 — how the build subprocess relates to
+1671	    /// the dispatch loop's process / mount / IPC namespaces.
+1672	    ///
+1673	    /// - [`Isolation::Inherit`]: subprocess runs in the dispatch
+1674	    ///   loop's namespaces. Used by single-shot (the whole VM
+1675	    ///   tears down on exit anyway) and by tests that don't have
+1676	    ///   `CAP_SYS_ADMIN` in their environment (e.g. CI Docker
+1677	    ///   without `--privileged`).
+1678	    /// - [`Isolation::Unshared`]: subprocess runs in fresh mount
+1679	    ///   + pid + ipc namespaces via `unshare --mount --pid --ipc
+1680	    ///   --fork`, then drops to the unprivileged builder uid via
+1681	    ///   `setpriv --reuid --regid --clear-groups` (Plan 89 W3
+1682	    ///   part 13). The pid namespace turns orphan-cleanup into a
+1683	    ///   single namespace-exit; the mount namespace lets future
+1684	    ///   parts bind-mount `/dev/shm` etc. per-job without bleeding
+1685	    ///   state into the shared rootfs; the IPC namespace prevents
+1686	    ///   SysV/POSIX IPC keys leaking across jobs; the uid drop
+1687	    ///   prevents a malicious build from remounting / killing
+1688	    ///   outside its pid ns / loading a kernel module via the root
+1689	    ///   privileges the dispatch loop has as PID 1.
+1690	    ///
+1691	    /// Network namespace is intentionally *not* unshared — the
+1692	    /// per-VM iptables baseline (Plan 73 Followup B.2.y) already
+1693	    /// gates egress through the proxy, and the build needs the
+1694	    /// proxy reachable. W3 part 12 re-applies that baseline per
+1695	    /// dispatch, which closes the F7 finding without breaking
+1696	    /// proxy access.
+1697	    #[derive(Debug, Clone, Copy, PartialEq, Eq)]
+1698	    enum Isolation {
+1699	        Inherit,
+1700	        Unshared,
+1701	    }
+1702
+1703	    /// Plan 89 W3 part 13 — unprivileged uid the dispatched build
+1704	    /// runs as inside the persistent VM. Picked above the
+1705	    /// `mvm-agent` (1900) / `mvm-worker` (1000) / `mvm-egress-
+1706	    /// proxy` (1801) uids the rest of the rootfs reserves so the
+1707	    /// builder identity doesn't collide with any existing service.
+1708	    ///
+1709	    /// No `/etc/passwd` entry: the build runs as a bare numeric
+1710	    /// uid, and `setpriv --clear-groups` (below) means no NSS
+1711	    /// lookup is needed for supplementary groups either. Tools
+1712	    /// that try `getlogin()` / `getpwuid()` get `None`; the build
+1713	    /// is expected to be a flake / install pipeline that doesn't
+1714	    /// rely on its own username.
+1715	    const BUILDER_UID: u32 = 902;
+1716	    const BUILDER_GID: u32 = 902;
+1717
+1718	    /// Plan 89 W3 part 13 — assemble the `Command` for one
+1719	    /// dispatched job per the requested isolation. Split out from
+1720	    /// [`run_job_streaming`] so the argv shape is testable
+1721	    /// without spawning (the spawn integration test in
+1722	    /// `run_job_streaming_unshared_runs_in_fresh_pid_namespace`
+1723	    /// probes for unshare + CAP_SYS_ADMIN; this pure builder lets
+1724	    /// tests pin the wire on every host).
+1725	    fn build_isolated_command(cmd_sh: &str, isolation: Isolation) -> Command {
+1726	        match isolation {
+1727	            Isolation::Inherit => {
+1728	                let mut c = Command::new("/bin/sh");
+1729	                c.args(["-eu", cmd_sh]);
+1730	                c
+1731	            }
+1732	            Isolation::Unshared => {
+1733	                // Order matters: unshare runs first (still uid 0
+1734	                // with `CAP_SYS_ADMIN` so the namespace setup
+1735	                // works), then setpriv drops uid inside the new
+1736	                // namespaces, then exec /bin/sh.
+1737	                //
+1738	                // `--clear-groups` strips supplementary groups
+1739	                // entirely; the build doesn't belong to any. We
+1740	                // intentionally do not use `--init-groups`
+1741	                // because there is no `/etc/passwd` entry for
+1742	                // the builder uid — initgroups(3) would fail the
+1743	                // NSS lookup. Numeric `--reuid`/`--regid` work
+1744	                // without NSS.
+1745	                //
+1746	                // `--bounding-set=-all` strips the entire
+1747	                // capability bounding set (claim 1 — matches the
+1748	                // existing `setpriv --bounding-set=-all
+1749	                // --no-new-privs` pattern). After this, the
+1750	                // build process cannot regain any caps even via
+1751	                // setuid binaries.
+1752	                let reuid = format!("--reuid={BUILDER_UID}");
+1753	                let regid = format!("--regid={BUILDER_GID}");
+1754	                let mut c = Command::new("unshare");
+1755	                c.args([
+1756	                    "--mount",
+1757	                    "--pid",
+1758	                    "--ipc",
+1759	                    "--fork",
+1760	                    "setpriv",
+1761	                    &reuid,
+1762	                    &regid,
+1763	                    "--clear-groups",
+1764	                    "--bounding-set=-all",
+1765	                    "--no-new-privs",
+1766	                    "/bin/sh",
+1767	                    "-eu",
+1768	                    cmd_sh,
+1769	                ]);
+1770	                c
+1771	            }
+1772	        }
+1773	    }
+1774
+1775	    /// Plan 89 W3 part 9 — same as [`run_job`] but invokes
+1776	    /// `on_line` for each stderr line as it arrives. Used by the
+1777	    /// persistent dispatch loop to frame each line as a
+1778	    /// `BuilderResponse::StderrChunk` and write it to the active
+1779	    /// vsock conn before the final `BuilderResponse::Result`. The
+1780	    /// callback runs on this thread between line reads, so a slow
+1781	    /// host can backpressure the build's stderr stream — the
+1782	    /// host's vsock conn is the natural rate-limiter and we don't
+1783	    /// need a separate buffer thread.
+1784	    ///
+1785	    /// The trailing `\n` is stripped from each line (the typed
+1786	    /// `BuilderResponse::StderrChunk` docs commit to that).
+1787	    /// `STDERR_TAIL_LINES` of trailing context is still buffered
+1788	    /// for the final Result frame's `stderr_tail`, matching the
+1789	    /// single-shot path's contract.
+1790	    fn run_job_streaming<F: FnMut(&str)>(
+1791	        cmd_sh: &str,
+1792	        tmpdir: Option<&str>,
+1793	        isolation: Isolation,
+1794	        mut on_line: F,
+1795	    ) -> (i32, String) {
+1796	        use std::collections::VecDeque;
+1797	        use std::io::{BufRead, BufReader};
+1798	        use std::process::Stdio;
+1799	        // Plan 89 W3 part 11/13 — switch between bare `/bin/sh
+1800	        // -eu <cmd>` and the unshare+setpriv wrapped form via
+1801	        // [`build_isolated_command`]. unshare + setpriv both
+1802	        // live in `util-linux`, which is in the builder VM's
+1803	        // rootfs (`nix/images/builder-vm/flake.nix`, package list);
+1804	        // PATH (`/sbin:/usr/sbin:/bin:/usr/bin`) finds them.
+1805	        let mut cmd = build_isolated_command(cmd_sh, isolation);
+1806	        cmd.stdout(Stdio::inherit()).stderr(Stdio::piped());
+1807	        // Plan 89 W3 part 10 — point the dispatched build's
+1808	        // tmpfile machinery at the per-job scratch dir so leftover
+1809	        // tempfiles can't outlive the dispatch. Tools that honor
+1810	        // TMPDIR (mkstemp, Python's `tempfile`, Nix's evaluator,
+1811	        // `mktemp(1)`) write into `/tmp/<job_id>/` instead of the
+1812	        // shared rootfs `/tmp`. Single-shot passes `None` —
+1813	        // see [`run_job`].
+1814	        if let Some(t) = tmpdir {
+1815	            cmd.env("TMPDIR", t);
+1816	        }
+1817	        let mut child = match cmd.spawn() {
+1818	            Ok(c) => c,
+1819	            Err(e) => {
+1820	                let binary = match isolation {
+1821	                    Isolation::Inherit => "/bin/sh",
+1822	                    Isolation::Unshared => "unshare",
+1823	                };
+1824	                return (127, format!("spawn {binary}: {e}"));
+1825	            }
+1826	        };
+1827	        let Some(stderr) = child.stderr.take() else {
+1828	            // Stdio::piped() should always populate child.stderr;
+1829	            // if it didn't, fall through to a non-streaming wait so
+1830	            // we still return a real exit code.
+1831	            let code = child.wait().ok().and_then(|s| s.code()).unwrap_or(-1);
+1832	            return (code, String::new());
+1833	        };
+1834	        let mut tail: VecDeque<String> = VecDeque::with_capacity(STDERR_TAIL_LINES);
+1835	        for line in BufReader::new(stderr).lines() {
+1836	            let line = match line {
+1837	                Ok(l) => l,
+1838	                // Treat a partial UTF-8 / I/O failure as end-of-stream
+1839	                // — the child's exit code is still the authoritative
+```
+
+**Tool Call: Read crates/mvm-builder-init/src/main.rs (780 - 839)**
+Status: Completed
+
+```
+780	        }
+781	        let frame_len = u32::from_be_bytes(len_buf);
+782	        if frame_len > MAX_DISPATCH_BODY_BYTES {
+783	            eprintln!(
+784	                "mvm-builder-init: dispatch: frame too large ({frame_len} > \
+785	                 {MAX_DISPATCH_BODY_BYTES})"
+786	            );
+787	            return None;
+788	        }
+789	        let mut body = vec![0u8; frame_len as usize];
+790	        if conn.read_exact(&mut body).is_err() {
+791	            return None;
+792	        }
+793	        Some(body)
+794	    }
+795
+796	    fn send_dispatch_response_via_vsock(payload: &crate::dispatch_response::DispatchResponse) {
+797	        const ACCEPT_TIMEOUT_SECS: i64 = 10;
+798	        let Some(listen_fd) = open_dispatch_listener_fd(Some(ACCEPT_TIMEOUT_SECS)) else {
+799	            return;
+800	        };
+801	        let Some(conn_fd) = accept_one(listen_fd) else {
+802	            eprintln!(
+803	                "mvm-builder-init: vsock send: no host connection within {ACCEPT_TIMEOUT_SECS}s \
+804	                 (single-shot path; W2 part 4 wired the host receiver)"
+805	            );
+806	            unsafe { close(listen_fd) };
+807	            return;
+808	        };
+809	        let mut conn = adopt_conn_fd(conn_fd);
+810	        let json = payload.to_json();
+811	        if !write_frame(&mut conn, json.as_bytes()) {
+812	            eprintln!("mvm-builder-init: vsock send: write failed mid-frame");
+813	        }
+814	        drop(conn);
+815	        unsafe { close(listen_fd) };
+816	    }
+817
+818	    // -----------------------------------------------------------
+819	    // Plan 89 W3 part 3 — persistent-VM dispatch loop
+820	    // -----------------------------------------------------------
+821
+822	    /// Plan 89 W3 part 3 — dispatch loop entry point. Called from
+823	    /// `run` when `/job/dispatch.sock.marker` is present (the host
+824	    /// stages the marker when spawning a long-lived
+825	    /// `LibkrunPersistentBuilderVm`, W3 part 4). Opens a long-lived
+826	    /// AF_VSOCK listener on [`BUILDER_DISPATCH_PORT`], reads one
+827	    /// `BuilderRequest` per accepted connection, dispatches the
+828	    /// inner job, writes back a `BuilderResponse::Result`, and
+829	    /// repeats until a `Shutdown` request triggers a clean exit.
+830	    ///
+831	    /// `cold_boot_timings` carries the BootTimings snapshot taken
+832	    /// at dispatch-loop entry. Per Plan 89 spec, only the
+833	    /// supervisor's *first* dispatch in a persistent VM session
+834	    /// gets a populated `boot_timings` field on the wire; subsequent
+835	    /// dispatches see `None`. The first dispatch in this loop
+836	    /// consumes the snapshot via `.take()`.
+837	    ///
+838	    /// Returns `0` on graceful `Shutdown`, non-zero on listener
+839	    /// setup failure (caller `power_off`s either way).
+```
+
+**Tool Call: grep -n "run_job" /Users/auser/work/tinylabs/mvmco/mvm/crates/mvm-builder-init/src/main.rs**
+Status: Completed
+
+568: let (code, tail) = run*job(&cmd_path);
+1070: let (code, tail) = run_job_streaming(
+1655: fn run_job(cmd_sh: &str) -> (i32, String) {
+1667: run_job_streaming(cmd_sh, None, Isolation::Inherit, |\_line| {})
+1720: /// [`run_job_streaming`] so the argv shape is testable
+1722: /// `run_job_streaming_unshared_runs_in_fresh_pid_namespace`
+1775: /// Plan 89 W3 part 9 — same as [`run_job`] but invokes
+1790: fn run_job_streaming<F: FnMut(&str)>(
+1813: // see [`run_job`].
+2329: /// Plan 89 W3 part 9 — `run_job_streaming` calls the
+2332: /// single-shot `run_job` for the success case.
+2334: fn run_job_streaming_emits_each_line_in_order() {
+2345: let (code, tail) = run_job_streaming(
+2362: fn run_job_streaming_caps_tail_to_stderr_tail_lines() {
+2376: let (code, tail) = run_job_streaming(
+2394: /// Plan 89 W3 part 9 — single-shot `run_job` keeps its
+2399: fn run_job_matches_streaming_for_short_output() {
+2403: let (code, tail) = run_job(cmd_path.to_str().unwrap());
+2452: /// Plan 89 W3 part 10 — `run_job_streaming` honors the
+2456: fn run_job_streaming_threads_tmpdir_through_to_subprocess() {
+2463: let (code, tail) = run_job_streaming(
+2480: fn run_job_streaming_does_not_override_tmpdir_when_none() {
+2492: // `run_job_streaming` doesn't call `.env("TMPDIR", *)`
+2499: run*job_streaming(cmd_path.to_str().unwrap(), None, Isolation::Inherit, |*| {});
+2526: fn run_job_streaming_unshared_runs_in_fresh_pid_namespace() {
+2562: let (code, tail) = run_job_streaming(
+
+**Tool Call: grep -n | head -40 "CARGO_FEATURE_LIBKRUN_SYS|libkrun-sys" /Users/auser/work/tinylabs/mvmco/mvm/crates**
+Status: Completed
+
+crates/mvm-build/src/libkrun_builder.rs:120: /// virtio-net via passt. Linux-only. Requires libkrun-sys + the
+crates/mvm-build/src/libkrun_builder.rs:125: /// Requires libkrun-sys + the `gvproxy` binary on `$PATH`. The
+crates/mvm-build/src/libkrun_builder.rs:1381: Install via `cargo install --path crates/mvm-libkrun --features libkrun-sys` \
+crates/mvm-build/src/app_deps.rs:289:/// libkrun-sys onto every CI runner.
+crates/mvm-build/Cargo.toml:90:# `libkrun-sys` bindings.
+crates/mvm-backend/src/libkrun.rs:438: Install it via `cargo install --path crates/mvm-libkrun --features libkrun-sys` \
+crates/mvm-backend/tests/libkrun_lifecycle_e2e.rs:29://! cargo build -p mvm-libkrun --bin mvm-libkrun-supervisor --features libkrun-sys
+crates/mvm-libkrun/src/sys.rs:3://! Only compiled when the `libkrun-sys` feature is on. The wrappers
+crates/mvm-libkrun/src/lib.rs:14://! - **`libkrun-sys`** — bindgen-generated FFI from `libkrun.h` plus
+crates/mvm-libkrun/src/lib.rs:25:#[cfg(feature = "libkrun-sys")]
+crates/mvm-libkrun/src/lib.rs:28:#[cfg(feature = "libkrun-sys")]
+crates/mvm-libkrun/src/lib.rs:67: /// Built without the `libkrun-sys` feature — the FFI bindings are
+crates/mvm-libkrun/src/lib.rs:69: /// with `--features libkrun-sys` on a host where libkrun is
+crates/mvm-libkrun/src/lib.rs:102: Rebuild with `--features libkrun-sys` on a host with libkrun installed."
+crates/mvm-libkrun/src/lib.rs:120:/// returns `true`, a build without the `libkrun-sys` feature will still
+crates/mvm-libkrun/src/lib.rs:233:/// that consume each field live in [`sys`] under the `libkrun-sys`
+crates/mvm-libkrun/src/lib.rs:329: /// `libkrun-sys`) spawns a passt child inside `run_supervisor`,
+crates/mvm-libkrun/src/lib.rs:602:/// **Plan 57 W1 scope.** With the `libkrun-sys` feature enabled, this
+crates/mvm-libkrun/src/lib.rs:619: #[cfg(not(feature = "libkrun-sys"))]
+crates/mvm-libkrun/src/lib.rs:626: #[cfg(feature = "libkrun-sys")]
+crates/mvm-libkrun/src/lib.rs:641:#[cfg(feature = "libkrun-sys")]
+crates/mvm-libkrun/src/lib.rs:659:#[cfg(all(feature = "libkrun-sys", target_family = "unix"))]
+crates/mvm-libkrun/src/lib.rs:674:#[cfg(all(feature = "libkrun-sys", target_family = "unix"))]
+crates/mvm-libkrun/src/lib.rs:721:#[cfg(feature = "libkrun-sys")]
+crates/mvm-libkrun/src/lib.rs:786:/// Always-on so unit tests can exercise it without the `libkrun-sys`
+crates/mvm-libkrun/src/lib.rs:790:#[cfg_attr(not(feature = "libkrun-sys"), allow(dead_code))]
+crates/mvm-libkrun/src/lib.rs:831:#[cfg(feature = "libkrun-sys")]
+crates/mvm-libkrun/src/lib.rs:861:/// Without the `libkrun-sys` feature, returns [`Error::NotYetWired`].
+crates/mvm-libkrun/src/lib.rs:868: #[cfg(not(feature = "libkrun-sys"))]
+crates/mvm-libkrun/src/lib.rs:875: #[cfg(feature = "libkrun-sys")]
+crates/mvm-libkrun/src/lib.rs:910:#[cfg(feature = "libkrun-sys")]
+crates/mvm-libkrun/src/lib.rs:949:/// without ever turning on `libkrun-sys` itself — the supervisor
+crates/mvm-libkrun/src/lib.rs:995:/// Without the `libkrun-sys` feature, returns [`Error::NotYetWired`].
+crates/mvm-libkrun/src/lib.rs:996:#[cfg(feature = "libkrun-sys")]
+crates/mvm-libkrun/src/lib.rs:1026:#[cfg(not(feature = "libkrun-sys"))]
+crates/mvm-libkrun/src/lib.rs:1029: tracking: "specs/plans/57-libkrun-spike.md W4 — rebuild with --features libkrun-sys",
+crates/mvm-libkrun/src/lib.rs:1303: /// the `libkrun-sys` feature.
+crates/mvm-libkrun/fuzz/Cargo.toml:26:# `libkrun-sys` is intentionally NOT enabled — the supervisor config
+crates/mvm-libkrun/examples/libkrun-smoke.rs:5://! cargo build --example libkrun-smoke -p mvm-libkrun --features libkrun-sys
+crates/mvm-libkrun/build.rs:3://! When the `libkrun-sys` cargo feature is on:
+
+[Showing results with pagination = limit: 40]
+
+## Assistant
+
+<thinking>
+
+</thinking>
+
+Let me check what happens to the tail after the job, and check what calls run_job at line 568.
+
+**Tool Call: Read crates/mvm-builder-init/src/main.rs (540 - 639)**
+Status: Completed
+
+```
+540	            stamp(&timings, |t| {
+541	                t.job_start_ms = Some(BootTimings::ms_since(anchor))
+542	            });
+543	            run_install_job(&install_spec_path);
+544	            stamp(&timings, |t| {
+545	                t.job_end_ms = Some(BootTimings::ms_since(anchor))
+546	            });
+547	            stamp(&timings, |t| {
+548	                t.poweroff_start_ms = Some(BootTimings::ms_since(anchor))
+549	            });
+550	            write_boot_timings(&timings);
+551	            return power_off();
+552	        }
+553
+554	        let cmd_path = format!("{JOB_DIR}/cmd.sh");
+555	        if !Path::new(&cmd_path).exists() {
+556	            write_result(2, &format!("missing {cmd_path}"));
+557	            stamp(&timings, |t| {
+558	                t.poweroff_start_ms = Some(BootTimings::ms_since(anchor))
+559	            });
+560	            write_boot_timings(&timings);
+561	            return power_off();
+562	        }
+563
+564	        stamp(&timings, |t| {
+565	            t.job_start_ms = Some(BootTimings::ms_since(anchor))
+566	        });
+567	        let job_start_at = Instant::now();
+568	        let (code, tail) = run_job(&cmd_path);
+569	        let build_ms = u64::try_from(job_start_at.elapsed().as_millis()).unwrap_or(u64::MAX);
+570	        stamp(&timings, |t| {
+571	            t.job_end_ms = Some(BootTimings::ms_since(anchor))
+572	        });
+573	        write_result(code, &tail);
+574	        // Plan 89 W2 part 3: best-effort vsock send of the
+575	        // `BuilderResponse::Result` frame the host's
+576	        // `mvm_build::builder_protocol::read_builder_response_from_socket`
+577	        // is waiting for. Runs BEFORE write_boot_timings so the
+578	        // timings snapshot we send mirrors what hits the filesystem.
+579	        // Any failure logs and falls through to power_off — the
+580	        // legacy file-based result path remains authoritative until
+581	        // the host wires the vsock receive in W2 part 4.
+582	        let timings_snapshot = match timings.lock() {
+583	            Ok(t) => t.clone(),
+584	            Err(_) => {
+585	                eprintln!(
+586	                    "mvm-builder-init: boot-timings mutex poisoned; \
+587	                     skipping vsock dispatch send"
+588	                );
+589	                stamp(&timings, |t| {
+590	                    t.poweroff_start_ms = Some(BootTimings::ms_since(anchor))
+591	                });
+592	                write_boot_timings(&timings);
+593	                return power_off();
+594	            }
+595	        };
+596	        send_dispatch_response_via_vsock(&crate::dispatch_response::DispatchResponse {
+597	            // Single-shot has no incoming request to correlate
+598	            // against; the nil UUID is the documented sentinel
+599	            // (see `dispatch_response::NIL_JOB_ID`).
+600	            job_id: crate::dispatch_response::NIL_JOB_ID.to_string(),
+601	            exit_code: code,
+602	            stderr_tail: tail,
+603	            boot_timings: Some(timings_snapshot),
+604	            build_ms,
+605	        });
+606	        stamp(&timings, |t| {
+607	            t.poweroff_start_ms = Some(BootTimings::ms_since(anchor))
+608	        });
+609	        write_boot_timings(&timings);
+610	        power_off()
+611	    }
+612
+613	    /// Plan 89 W2 part 3 — listen on `AF_VSOCK` port
+614	    /// [`BUILDER_DISPATCH_PORT`] and write a single framed
+615	    /// `BuilderResponse::Result` to the first connection that
+616	    /// arrives within `ACCEPT_TIMEOUT_SECS` seconds. Best-effort:
+617	    /// any failure (no host connection, socket setup error, write
+618	    /// error) is logged to stderr and the boot continues to
+619	    /// `power_off`.
+620	    ///
+621	    /// Wire shape is hand-rolled by
+622	    /// [`crate::dispatch_response::DispatchResponse::to_json`]; the
+623	    /// cross-validation test in that module pins the output against
+624	    /// `mvm_build::builder_protocol::BuilderResponse` so the host
+625	    /// deserializer parses what we emit.
+626	    ///
+627	    /// AF_VSOCK constants are inlined rather than going through
+628	    /// `nix` because the size-budget comment in this crate's
+629	    /// Cargo.toml (Plan 72 §W3 — ≤ 1.5 MiB) discourages new dep
+630	    /// features. The pattern mirrors
+631	    /// `crates/mvm-guest/src/bin/mvm-builder-agent.rs` exactly.
+632	    // -----------------------------------------------------------
+633	    // Plan 89 W2 / W3 — AF_VSOCK helpers
+634	    // -----------------------------------------------------------
+635	    //
+636	    // Shared between W2 part 3's single-shot send and W3 part 3's
+637	    // dispatch loop. Inlined FFI rather than `nix` because the
+638	    // Plan 72 §W3 size budget discourages new dep features; the
+639	    // pattern mirrors `mvm-guest/src/bin/mvm-builder-agent.rs`.
+```
+
+**Tool Call: Read crates/mvm-builder-init/src/main.rs (1050 - 1139)**
+Status: Completed
+
+```
+1050	                    // --regid=BUILDER_GID` via
+1051	                    // `Isolation::Unshared` — can write into the
+1052	                    // scratch dir.
+1053	                    let (scratch, tmpdir) = match JobScratch::create(
+1054	                        JOB_SCRATCH_BASE,
+1055	                        &job_id,
+1056	                        Some((BUILDER_UID, BUILDER_GID)),
+1057	                    ) {
+1058	                        Ok(s) => {
+1059	                            let path = s.path().to_string();
+1060	                            (Some(s), Some(path))
+1061	                        }
+1062	                        Err(e) => {
+1063	                            eprintln!(
+1064	                                "mvm-builder-init: dispatch loop: failed to create scratch for {job_id}: {e}"
+1065	                            );
+1066	                            (None, None)
+1067	                        }
+1068	                    };
+1069	                    let started = Instant::now();
+1070	                    let (code, tail) = run_job_streaming(
+1071	                        &cmd_path,
+1072	                        tmpdir.as_deref(),
+1073	                        Isolation::Unshared,
+1074	                        |line| {
+1075	                            let frame = crate::dispatch_response::stderr_chunk_json(&job_id, line);
+1076	                            if !write_frame(conn, frame.as_bytes()) {
+1077	                                // Host probably closed the conn
+1078	                                // (e.g. supervisor went away
+1079	                                // mid-build). Log and keep
+1080	                                // draining stderr so the build's
+1081	                                // exit code is still meaningful —
+1082	                                // the terminal Result write will
+1083	                                // fail loudly back in the
+1084	                                // dispatch loop.
+1085	                                eprintln!(
+1086	                                    "mvm-builder-init: dispatch loop: write StderrChunk failed"
+1087	                                );
+1088	                            }
+1089	                        },
+1090	                    );
+1091	                    let ms = u64::try_from(started.elapsed().as_millis()).unwrap_or(u64::MAX);
+1092	                    // Hold `scratch` until after the build returns
+1093	                    // so its `Drop` cleans up after the
+1094	                    // subprocess. Explicit drop documents the
+1095	                    // ordering for the reader.
+1096	                    drop(scratch);
+1097	                    (code, tail, ms)
+1098	                }
+1099	            }
+1100	            crate::builder_request::BuilderJob::Install { spec_path } => {
+1101	                // Plan 89 W3 part 8: route Install dispatches
+1102	                // through the existing single-shot pipeline with
+1103	                // per-dispatch paths. The host (PersistentBuilderVm)
+1104	                // stages `<session.job_dir>/<job_id>/install_spec.json`
+1105	                // and passes `/job/<job_dir_relpath>/install_spec.json`
+1106	                // as the wire `spec_path`. The output (result.json +
+1107	                // sealed volume sidecars) lands in `/job/<job_id>/out`
+1108	                // so the host reads them back via the same per-
+1109	                // dispatch out_dir convention as the Flake path.
+1110	                let out_dir = format!("{JOB_DIR}/{job_dir_relpath}/out");
+1111	                let job_subdir = format!("{JOB_DIR}/{job_dir_relpath}");
+1112	                let started = Instant::now();
+1113	                run_install_job_at(&spec_path, &job_subdir, &out_dir);
+1114	                let ms = u64::try_from(started.elapsed().as_millis()).unwrap_or(u64::MAX);
+1115	                // The install pipeline writes its own typed result
+1116	                // (result.json) — exit code on the wire is just a
+1117	                // dispatch-level signal that the install ran. The
+1118	                // host's PersistentBuilderVm reads result.json for
+1119	                // the real outcome. We pass 0 if result.json was
+1120	                // emitted at all; the host's parser will decode it
+1121	                // and surface installer_exit_code.
+1122	                let result_path = format!("{out_dir}/result.json");
+1123	                let exit_code = if Path::new(&result_path).is_file() {
+1124	                    0
+1125	                } else {
+1126	                    2
+1127	                };
+1128	                let tail = if exit_code == 0 {
+1129	                    String::new()
+1130	                } else {
+1131	                    format!("install pipeline did not emit {result_path}")
+1132	                };
+1133	                (exit_code, tail, ms)
+1134	            }
+1135	        };
+1136	        let response = crate::dispatch_response::DispatchResponse {
+1137	            job_id,
+1138	            exit_code,
+1139	            stderr_tail,
+```
+
+**Tool Call: grep -n | head -30 "job/result|job/cmd|writeln.\*result|/job/" /Users/auser/work/tinylabs/mvmco/mvm/crates/mvm-builder-init/src/main.rs**
+Status: Completed
+
+6://! bring the network up, executes `/job/cmd.sh`, writes
+7://! `/job/result`, and powers off.
+19://! - We can encode the `/job/result` JSON shape in one place
+41://! 5. Read `/job/cmd.sh`. Exit code 2 + "no cmd.sh" in
+42://! `/job/result` if missing.
+43://! 6. Spawn `/bin/sh -eu /job/cmd.sh`. Capture exit + stderr
+45://! 7. Write `/job/result` as `{"exit_code":<i32>,"stderr_tail":<json-string>}`.
+309: /// Per-job command staging dir (`/job/cmd.sh`, `/job/env`,
+310: /// `/job/result`). Mounted via virtio-fs from the host
+332: /// Max stderr lines we capture into `/job/result`. Keeps
+339: /// B.2). When `/job/install_spec.json` is present the init
+341: /// of dispatching `/job/cmd.sh`. The two modes are mutually
+823: /// `run` when `/job/dispatch.sock.marker` is present (the host
+989: /// `/job/<job_dir_relpath>/cmd.sh`, exec it, stream every
+1105: // and passes `/job/<job_dir_relpath>/install_spec.json`
+1107: // sealed volume sidecars) lands in `/job/<job_id>/out`
+1181: /// `/job/boot-timings.json` and mirror a one-line summary to
+1201: /// Drive the install pipeline against `/job/install_spec.json`.
+1202: /// Emits `/job/result.json` (the typed report — distinct from
+1203: /// `/job/result`, which the flake-build path writes); the host
+1218: /// passes the per-dispatch `/job/<job_id>` paths so concurrent
+1320: /// passes the per-dispatch `/job/<job_id>/out`.
+1481: // `/job/cmd.sh` if `/job` was supplied. Per-share errors
+1662: // whole stderr tail still lands in `/job/result` and the
+1855: /// Write `/job/result` as JSON. Hand-rolled rather than
+2594: let cmd = build_isolated_command("/job/cmd.sh", Isolation::Inherit);
+2597: assert_eq!(args, vec![OsStr::new("-eu"), OsStr::new("/job/cmd.sh")]);
+2603: let cmd = build_isolated_command("/job/cmd.sh", Isolation::Unshared);
+2620: assert_eq!(&args[10..], &["/bin/sh", "-eu", "/job/cmd.sh"]);
+
+**Tool Call: grep -n | head -40 "cmd.sh|nix build|cmd_path" /Users/auser/work/tinylabs/mvmco/mvm/crates/mvm-build/src/libkrun_builder.rs**
+Status: Completed
+
+11://! on PATH, `run_build` runs a one-shot `nix build` against the
+28://! 6. Stage `<job_dir>/cmd.sh` with the shell-escaped flake_ref +
+29://! attr_path, plus the canonical `nix build` invocation.
+55://! runs a one-shot `nix build`, while the runtime mounts the
+76:/// in-VM nix builds peak ~5-6 GiB). Plan 95 raised this to 16 GiB
+105:/// host stages `cmd.sh`, `env`, and the eventual `result` file
+207:/// VM, runs `nix build` inside, extracts the artifacts via the
+300: /// script — no `/job/cmd.sh` staging, no `/job/result` parsing,
+378: /// boundary. The script is staged as `/job/cmd.sh`; `/work`
+653: // `cmd.sh`; install jobs get `install_spec.json`.
+676: // failures of the in-VM cmd.sh / mvm-builder-init produce a
+877: Populate the cache by running `nix build ./nix/images/builder-vm#packages.{}-linux.default` \
+1024:/// - [`BuilderJob::Flake`]: writes `<job_dir>/cmd.sh` with the
+1025:/// `nix build` script the guest's PID 1 dispatches via
+1031:/// running `cmd.sh`.
+1034:/// emit a `cmd.sh`, flake jobs don't emit an install spec.
+1051: // running cmd.sh.
+1064: // Render the `cmd.sh` content. flake_ref and attr_path are
+1070:# mvm-builder-vm cmd.sh — emitted by LibkrunBuilderVm (Plan 72 W4).
+1123:echo "mvm-builder-vm: filesystem space before nix build:" >&2
+1134:nix build "${{FLAKE_REF}}#${{ATTR_PATH}}" \
+1142: echo "mvm-builder-vm: filesystem space after failed nix build:" >&2
+1144: echo "nix build exited $NIX_RC; tail of stderr:" >&2
+1150: echo "nix build emitted no /nix/store output path" >&2
+1166: echo "no rootfs.ext4 in nix build output at $NIX_OUT" >&2
+1179: let cmd_path = job_dir.join("cmd.sh");
+1180: std::fs::write(&cmd_path, body).map_err(|e| {
+1181: BuilderVmError::ExtractionFailed(format!("writing {}: {e}", cmd_path.display()))
+1190: let cmd_path = job_dir.join("cmd.sh");
+1191: std::fs::write(&cmd_path, script).map_err(|e| {
+1192: BuilderVmError::ExtractionFailed(format!("writing {}: {e}", cmd_path.display()))
+1216: "guest cmd.sh exited {} — stderr tail:\n{}",
+1891:/// instead of running the single-shot `cmd.sh` / `install_spec`
+1900:/// single cmd.sh / install_spec and powering off, the guest
+2051:/// of the single-shot cmd.sh / install_spec flow. The marker
+2116: /// Hosts stage per-dispatch artifacts (`<job_dir_relpath>/cmd.sh`,
+2192: // Plan 72 W5.D bullet 9: 4 → 8 GiB (in-VM nix builds peak
+2396: // `<job_dir>/install_spec.json` rather than `cmd.sh`. The
+2409: // No cmd.sh is emitted for install jobs.
+2411: !job_dir.join("cmd.sh").exists(),
+
+[Showing results with pagination = limit: 40]
+
+## Assistant
+
+<thinking>
+
+</thinking>
+
+Let me read the cmd.sh template to see what stderr capture happens inside.
+
+**Tool Call: Read crates/mvm-build/src/libkrun_builder.rs (1060 - 1234)**
+Status: Completed
+
+```
+1060	            return Ok(());
+1061	        }
+1062	    };
+1063
+1064	    // Render the `cmd.sh` content. flake_ref and attr_path are
+1065	    // user-controlled; emit them inside `'…'` quoted shell
+1066	    // variables, escaping any embedded `'` with the standard
+1067	    // `'\''` close-quote / escape / open-quote dance.
+1068	    let body = format!(
+1069	        r#"#!/bin/sh
+1070	# mvm-builder-vm cmd.sh — emitted by LibkrunBuilderVm (Plan 72 W4).
+1071	# Runs inside the libkrun builder VM under `/bin/sh -eu`. The
+1072	# host wires /work (workspace), /out (artifact dir), /job (this
+1073	# dir) as virtio-fs shares; /nix is a persistent virtio-blk
+1074	# overlay handled by mvm-builder-init.
+1075	set -eu
+1076
+1077	FLAKE_REF='{flake_ref}'
+1078	ATTR_PATH='{attr_path}'
+1079
+1080	# Point HOME at writable tmpfs (`/tmp`) to satisfy code paths that
+1081	# write to `~/...` (the rootfs is mounted `ro`; nix would otherwise
+1082	# bail with "creating directory '//.cache/nix': Read-only file
+1083	# system"). XDG_CACHE_HOME lives on the persistent `/nix-store`
+1084	# disk so Nix's eval-cache-v5, tarball-cache, and binary-cache-v6
+1085	# survive across builds — cold flake eval is the long pole on
+1086	# warm-store rebuilds, and these caches reclaim it. `/nix-store`
+1087	# is the ext4 root for the persistent virtio-blk device; it sits
+1088	# alongside the overlay upperdir (`/nix-store/upper`) at the
+1089	# disk's top level, so writes here don't pollute the Nix store
+1090	# namespace. XDG_STATE_HOME stays on tmpfs: it only holds profile
+1091	# generations, which one-shot build VMs don't use.
+1092	export HOME=/tmp
+1093	export XDG_CACHE_HOME=/nix-store/.cache
+1094	export XDG_STATE_HOME=/tmp/.local/state
+1095	mkdir -p /nix-store/.cache /tmp/.local/state
+1096
+1097	# CA certs for TLS to cache.nixos.org / api.github.com.
+1098	export CURL_CA_BUNDLE=/etc/ssl/certs/ca-bundle.crt
+1099	export NIX_SSL_CERT_FILE=/etc/ssl/certs/ca-bundle.crt
+1100	export SSL_CERT_FILE=/etc/ssl/certs/ca-bundle.crt
+1101
+1102	cd /work
+1103	# `experimental-features` enables nix-command + flakes. `sandbox =
+1104	# false` + `build-users-group =` is mandatory inside the builder
+1105	# VM: there are no `nixbld*` accounts in the rootfs and no kernel
+1106	# user-ns isolation for build sandboxes, so every derivation would
+1107	# otherwise fail with "the group 'nixbld' specified in
+1108	# 'build-users-group' does not exist". The builder VM IS the
+1109	# isolation boundary, so an in-guest sandbox is redundant.
+1110	export NIX_CONFIG="experimental-features = nix-command flakes
+1111	sandbox = false
+1112	build-users-group =
+1113	max-jobs = auto
+1114	cores = 0
+1115	auto-optimise-store = true
+1116	substituters = https://cache.nixos.org/
+1117	trusted-public-keys = cache.nixos.org-1:6NCHdD59X431o0gWypbMrAURkbJ16ZPMQFGspcDShjY="
+1118	# Plan 72 W0's flake convention: workspace-path env var so
+1119	# flakes that reference the workspace root don't depend on
+1120	# relative-path resolution against the store-copied flake dir.
+1121	export MVM_WORKSPACE_PATH=/work
+1122
+1123	echo "mvm-builder-vm: filesystem space before nix build:" >&2
+1124	df -h /nix /tmp >&2 || true
+1125
+1126	# `--impure` is what unblocks builds inside the VM when the
+1127	# flake has path inputs; `--no-write-lock-file` keeps the
+1128	# read-only `/work` mount from tripping EROFS.
+1129	# `--print-build-logs --keep-going` dumps every failing build's
+1130	# stderr inline (default nix only prints the last 10 lines and
+1131	# cascades up). We tee stderr to /job/nix-build.log so the host
+1132	# can read the actual root cause when a deep dependency fails.
+1133	set +e
+1134	nix build "${{FLAKE_REF}}#${{ATTR_PATH}}" \
+1135	    --no-link --print-out-paths --no-write-lock-file --impure \
+1136	    --print-build-logs --keep-going \
+1137	    > /job/nix-stdout.log 2> /job/nix-stderr.log
+1138	NIX_RC=$?
+1139	set -e
+1140	NIX_OUT=$(cat /job/nix-stdout.log)
+1141	if [ "$NIX_RC" -ne 0 ]; then
+1142	    echo "mvm-builder-vm: filesystem space after failed nix build:" >&2
+1143	    df -h /nix /tmp >&2 || true
+1144	    echo "nix build exited $NIX_RC; tail of stderr:" >&2
+1145	    tail -200 /job/nix-stderr.log >&2
+1146	    exit $NIX_RC
+1147	fi
+1148
+1149	if [ -z "$NIX_OUT" ]; then
+1150	    echo "nix build emitted no /nix/store output path" >&2
+1151	    exit 1
+1152	fi
+1153	printf '%s\n' "$NIX_OUT" > /job/store-path
+1154
+1155	# Copy the artifacts the host expects into /out. We accept
+1156	# either `vmlinux` (the canonical name our flakes use) or
+1157	# `Image` / `bzImage` (raw kernel format names) for
+1158	# robustness across flake conventions.
+1159	if   [ -f "$NIX_OUT/vmlinux" ]; then cp -L "$NIX_OUT/vmlinux" /out/vmlinux
+1160	elif [ -f "$NIX_OUT/Image"   ]; then cp -L "$NIX_OUT/Image"   /out/vmlinux
+1161	elif [ -f "$NIX_OUT/bzImage" ]; then cp -L "$NIX_OUT/bzImage" /out/vmlinux
+1162	fi
+1163	if [ -f "$NIX_OUT/rootfs.ext4" ]; then
+1164	    cp -L "$NIX_OUT/rootfs.ext4" /out/rootfs.ext4
+1165	else
+1166	    echo "no rootfs.ext4 in nix build output at $NIX_OUT" >&2
+1167	    exit 1
+1168	fi
+1169
+1170	# Permissions for the host-side reader. Ignore failures —
+1171	# virtio-fs may map the uid such that chmod is a no-op.
+1172	chmod 0644 /out/rootfs.ext4 2>/dev/null || true
+1173	[ -f /out/vmlinux ] && chmod 0644 /out/vmlinux 2>/dev/null || true
+1174	"#,
+1175	        flake_ref = shell_single_quote_escape(flake_ref),
+1176	        attr_path = shell_single_quote_escape(attr_path),
+1177	    );
+1178
+1179	    let cmd_path = job_dir.join("cmd.sh");
+1180	    std::fs::write(&cmd_path, body).map_err(|e| {
+1181	        BuilderVmError::ExtractionFailed(format!("writing {}: {e}", cmd_path.display()))
+1182	    })?;
+1183	    Ok(())
+1184	}
+1185
+1186	fn stage_shell_job_dir(job_dir: &Path, script: &str) -> Result<(), BuilderVmError> {
+1187	    std::fs::create_dir_all(job_dir).map_err(|e| {
+1188	        BuilderVmError::ExtractionFailed(format!("creating job dir {}: {e}", job_dir.display()))
+1189	    })?;
+1190	    let cmd_path = job_dir.join("cmd.sh");
+1191	    std::fs::write(&cmd_path, script).map_err(|e| {
+1192	        BuilderVmError::ExtractionFailed(format!("writing {}: {e}", cmd_path.display()))
+1193	    })?;
+1194	    Ok(())
+1195	}
+1196
+1197	/// Escape a string for inclusion inside `'…'` single quotes
+1198	/// in POSIX shell. The only character that can't appear inside
+1199	/// single quotes is `'` itself; we close the quote, emit `\'`,
+1200	/// then reopen. Standard sh-escape pattern.
+1201	fn shell_single_quote_escape(s: &str) -> String {
+1202	    s.replace('\'', "'\\''")
+1203	}
+1204
+1205	/// Finalize a flake build: read `<job_dir>/result`, validate the
+1206	/// `rootfs.ext4` (and optional `vmlinux`) landed in
+1207	/// `artifact_out`, return a [`BuilderArtifacts::Image`].
+1208	fn finalize_flake_job(
+1209	    job_dir: &Path,
+1210	    artifact_out: &Path,
+1211	    job_id: &str,
+1212	) -> Result<BuilderArtifacts, BuilderVmError> {
+1213	    let result = read_job_result(job_dir)?;
+1214	    if result.exit_code != 0 {
+1215	        return Err(BuilderVmError::NixBuildFailed(format!(
+1216	            "guest cmd.sh exited {} — stderr tail:\n{}",
+1217	            result.exit_code, result.stderr_tail
+1218	        )));
+1219	    }
+1220
+1221	    let rootfs_path = artifact_out.join("rootfs.ext4");
+1222	    if !rootfs_path.is_file() {
+1223	        return Err(BuilderVmError::ExtractionFailed(format!(
+1224	            "builder VM exited cleanly but {} was not written",
+1225	            rootfs_path.display()
+1226	        )));
+1227	    }
+1228	    let kernel_path_out = artifact_out.join("vmlinux");
+1229	    let kernel_path = if kernel_path_out.is_file() {
+1230	        Some(kernel_path_out)
+1231	    } else {
+1232	        None
+1233	    };
+1234
+```
+
+**Tool Call: Read crates/mvm-build/src/libkrun_builder.rs (1480 - 1599)**
+Status: Completed
+
+```
+1480	        DEFAULT_PANIC_POLL_INTERVAL,
+1481	        Some(timeout),
+1482	    ) {
+1483	        Ok(WaitOutcome::Clean(code)) => Ok(code),
+1484	        Ok(WaitOutcome::KernelPanic {
+1485	            panic_line,
+1486	            console_log_path,
+1487	        }) => Err(BuilderVmError::SeedKernelPanic {
+1488	            panic_line,
+1489	            console_log_path,
+1490	        }),
+1491	        Ok(WaitOutcome::Timeout) => Err(BuilderVmError::NixBuildFailed(format!(
+1492	            "builder VM exceeded {} seconds wall-clock; killed. Console log at {}/console.log.",
+1493	            timeout.as_secs(),
+1494	            vm_state_dir.display(),
+1495	        ))),
+1496	        Err(e) => Err(BuilderVmError::ExtractionFailed(format!(
+1497	            "wait on supervisor child: {e}"
+1498	        ))),
+1499	    }
+1500	}
+1501
+1502	/// Plan 89 W2 part 4 — spawn a background thread that reads the
+1503	/// `BuilderResponse::Result` frame `mvm-builder-init` sends over
+1504	/// AF_VSOCK port [`mvm_guest::builder_agent::BUILDER_DISPATCH_PORT`]
+1505	/// right before reboot (W2 part 3). Returns a `Receiver` the caller
+1506	/// drains after the supervisor exits via [`log_vsock_response_outcome`].
+1507	///
+1508	/// The thread starts BEFORE the supervisor so it can connect as
+1509	/// soon as libkrun creates `<vm_state_dir>/vsock-21471.sock` —
+1510	/// before the guest's listener exists, `UnixStream::connect` would
+1511	/// return `ENOENT`/`ECONNREFUSED`, hence the retry loop with a 60-second
+1512	/// outer deadline. Once connected, the thread reads with a 10-second
+1513	/// read deadline so an unresponsive guest doesn't leak the thread
+1514	/// indefinitely.
+1515	///
+1516	/// Pre-W2-part-3 cached dev images won't send a response at all;
+1517	/// the legacy `<job_dir>/result` file path remains authoritative
+1518	/// for the build's exit code. This helper's job is purely
+1519	/// observational: log what arrives, warn on mismatch against the
+1520	/// file, never gate the build on the vsock outcome.
+1521	#[cfg(feature = "builder-vm")]
+1522	pub fn spawn_vsock_response_listener(
+1523	    vm_state_dir: &Path,
+1524	) -> std::sync::mpsc::Receiver<crate::builder_protocol::BuilderResponseRead> {
+1525	    use std::os::unix::net::UnixStream;
+1526	    use std::sync::mpsc;
+1527	    use std::time::{Duration, Instant};
+1528
+1529	    use crate::builder_protocol::{BuilderResponseRead, read_builder_response};
+1530
+1531	    let (tx, rx) = mpsc::channel();
+1532	    let socket_path = vm_state_dir.join(format!(
+1533	        "vsock-{}.sock",
+1534	        mvm_guest::builder_agent::BUILDER_DISPATCH_PORT
+1535	    ));
+1536
+1537	    std::thread::Builder::new()
+1538	        .name("vsock-builder-response".to_string())
+1539	        .spawn(move || {
+1540	            let connect_deadline = Duration::from_secs(60);
+1541	            let poll_interval = Duration::from_millis(100);
+1542	            let read_timeout = Duration::from_secs(10);
+1543	            let start = Instant::now();
+1544	            let result = loop {
+1545	                if start.elapsed() > connect_deadline {
+1546	                    break BuilderResponseRead::Timeout;
+1547	                }
+1548	                match UnixStream::connect(&socket_path) {
+1549	                    Ok(mut stream) => {
+1550	                        let _ = stream.set_read_timeout(Some(read_timeout));
+1551	                        break read_builder_response(&mut stream);
+1552	                    }
+1553	                    Err(_) => std::thread::sleep(poll_interval),
+1554	                }
+1555	            };
+1556	            // The receiver may have been dropped already (caller hit
+1557	            // its recv_timeout before the thread finished). That's
+1558	            // fine — the response was observational anyway.
+1559	            let _ = tx.send(result);
+1560	        })
+1561	        .expect("std::thread::Builder::spawn never fails on unix");
+1562
+1563	    rx
+1564	}
+1565
+1566	/// Drain the listener from [`spawn_vsock_response_listener`] with a
+1567	/// bounded wait and log the outcome. If `file_exit_code` is `Some`,
+1568	/// cross-validate against the vsock-reported exit code and warn on
+1569	/// mismatch (but never propagate as an error — the file is the
+1570	/// authoritative source until W3 reverses the polarity).
+1571	///
+1572	/// The 5-second `recv_timeout` past supervisor exit is enough for
+1573	/// the read-deadline-bounded thread to deliver any in-flight
+1574	/// response; longer waits would hurt UX without buying meaningful
+1575	/// signal.
+1576	#[cfg(feature = "builder-vm")]
+1577	pub fn log_vsock_response_outcome(
+1578	    rx: std::sync::mpsc::Receiver<crate::builder_protocol::BuilderResponseRead>,
+1579	    file_exit_code: Option<i32>,
+1580	) {
+1581	    use crate::builder_protocol::{BuilderResponse, BuilderResponseRead};
+1582
+1583	    match rx.recv_timeout(std::time::Duration::from_secs(5)) {
+1584	        Ok(BuilderResponseRead::Frame(BuilderResponse::Result {
+1585	            exit_code,
+1586	            job_timings,
+1587	            boot_timings,
+1588	            ..
+1589	        })) => {
+1590	            tracing::info!(
+1591	                vsock_exit_code = exit_code,
+1592	                build_ms = job_timings.build_ms,
+1593	                boot_timings_present = boot_timings.is_some(),
+1594	                "received BuilderResponse::Result via vsock dispatch channel (W2 part 3)"
+1595	            );
+1596	            if let Some(file_code) = file_exit_code
+1597	                && file_code != exit_code
+1598	            {
+1599	                tracing::warn!(
+```
+
+## Assistant
+
+<thinking>
+
+</thinking>
+
+Massive find: `/job` is a virtio-fs share, so `/job/nix-stderr.log` is on the **host filesystem**. The real build stderr should already be on disk. Let me find the job_dir.
+
+**Tool Call: grep -n | head -30 "job_dir|nix-stderr\.log|builder.*job.*dir" /Users/auser/work/tinylabs/mvmco/mvm/crates/mvm-build/src/libkrun_builder.rs**
+Status: Completed
+
+28://! 6. Stage `<job_dir>/cmd.sh` with the shell-escaped flake_ref +
+37://! 9. Read `<job_dir>/result` (JSON: `{exit_code, stderr_tail}`)
+259: pub job_dir: PathBuf,
+404: let job_dir = builder_vm_cache_dir().join("jobs").join(&job_id);
+405: stage_shell_job_dir(&job_dir, &job.script)?;
+428: .add_virtio_fs("job", path_to_str(&job_dir, "job_dir")?)
+462: let result = read_job_result(&job_dir)?;
+472: job_dir,
+657: let job_dir = builder_vm_cache_dir().join("jobs").join(&job_id);
+658: stage_job_dir(&job_dir, job)?;
+692: .add_virtio_fs("job", path_to_str(&job_dir, "job_dir")?)
+731: // Flake jobs read `<job_dir>/result` (legacy shape);
+735: BuilderJob::Flake { .. } => finalize_flake_job(&job_dir, &mounts.artifact_out, &job_id),
+1024:/// - [`BuilderJob::Flake`]: writes `<job_dir>/cmd.sh` with the
+1028:/// to `<job_dir>/install_spec.json`. `mvm-builder-init` probes
+1035:fn stage_job_dir(job_dir: &Path, job: &BuilderJob) -> Result<(), BuilderVmError> {
+1036: std::fs::create_dir_all(job_dir).map_err(|e| {
+1037: BuilderVmError::ExtractionFailed(format!("creating job dir {}: {e}", job_dir.display()))
+1052: let dst = job_dir.join(INSTALL_SPEC_FILENAME);
+1137: > /job/nix-stdout.log 2> /job/nix-stderr.log
+1145: tail -200 /job/nix-stderr.log >&2
+1179: let cmd_path = job_dir.join("cmd.sh");
+1186:fn stage_shell_job_dir(job_dir: &Path, script: &str) -> Result<(), BuilderVmError> {
+1187: std::fs::create_dir_all(job_dir).map_err(|e| {
+1188: BuilderVmError::ExtractionFailed(format!("creating job dir {}: {e}", job_dir.display()))
+1190: let cmd_path = job_dir.join("cmd.sh");
+1205:/// Finalize a flake build: read `<job_dir>/result`, validate the
+1209: job_dir: &Path,
+1213: let result = read_job_result(job_dir)?;
+1238: revision_hash: read_revision_hash(job_dir).unwrap_or_else(|| job_id.to_string()),
+
+[Showing results with pagination = limit: 30]
+
+**Tool Call: find ~/.cache/mvm -name "nix-stderr.log" -o -name "nix-stdout.log" -o -name "result" -o -name "cmd.sh" 2>/dev/null | head -30**
+Status: Completed
+
+Terminal:
+
+```
+/Users/auser/.cache/mvm/builder-vm/jobs/1779303829911-20106/nix-stdout.log
+/Users/auser/.cache/mvm/builder-vm/jobs/1779303829911-20106/result
+/Users/auser/.cache/mvm/builder-vm/jobs/1779303829911-20106/nix-stderr.log
+/Users/auser/.cache/mvm/builder-vm/jobs/1779303829911-20106/cmd.sh
+/Users/auser/.cache/mvm/builder-vm/jobs/1779315171950-64485/result
+/Users/auser/.cache/mvm/builder-vm/jobs/1779315171950-64485/cmd.sh
+/Users/auser/.cache/mvm/builder-vm/jobs/1779344465141-91896/nix-stdout.log
+/Users/auser/.cache/mvm/builder-vm/jobs/1779344465141-91896/result
+/Users/auser/.cache/mvm/builder-vm/jobs/1779344465141-91896/nix-stderr.log
+/Users/auser/.cache/mvm/builder-vm/jobs/1779344465141-91896/cmd.sh
+/Users/auser/.cache/mvm/builder-vm/jobs/1779426018614-7835/nix-stdout.log
+/Users/auser/.cache/mvm/builder-vm/jobs/1779426018614-7835/result
+/Users/auser/.cache/mvm/builder-vm/jobs/1779426018614-7835/nix-stderr.log
+/Users/auser/.cache/mvm/builder-vm/jobs/1779426018614-7835/cmd.sh
+/Users/auser/.cache/mvm/builder-vm/jobs/1779315634351-8232/result
+/Users/auser/.cache/mvm/builder-vm/jobs/1779315634351-8232/cmd.sh
+/Users/auser/.cache/mvm/builder-vm/jobs/1779315344207-96219/result
+/Users/auser/.cache/mvm/builder-vm/jobs/1779315344207-96219/cmd.sh
+/Users/auser/.cache/mvm/builder-vm/jobs/1779312031119-51903/cmd.sh
+/Users/auser/.cache/mvm/builder-vm/jobs/1779321113493-68292/result
+/Users/auser/.cache/mvm/builder-vm/jobs/1779321113493-68292/cmd.sh
+/Users/auser/.cache/mvm/builder-vm/jobs/1779311880856-93520/cmd.sh
+/Users/auser/.cache/mvm/builder-vm/jobs/1779418247134-70382/result
+/Users/auser/.cache/mvm/builder-vm/jobs/1779418247134-70382/cmd.sh
+/Users/auser/.cache/mvm/builder-vm/jobs/1779418443602-26130/nix-stdout.log
+/Users/auser/.cache/mvm/builder-vm/jobs/1779418443602-26130/result
+/Users/auser/.cache/mvm/builder-vm/jobs/1779418443602-26130/nix-stderr.log
+/Users/auser/.cache/mvm/builder-vm/jobs/1779418443602-26130/cmd.sh
+/Users/auser/.cache/mvm/builder-vm/jobs/1779388217942-71549/nix-stdout.log
+/Users/auser/.cache/mvm/builder-vm/jobs/1779388217942-71549/result
+```
+
+**Tool Call: find ~/.cache/mvm -type d 2>/dev/null | head -40**
+Status: Completed
+
+Terminal:
+
+```
+/Users/auser/.cache/mvm
+/Users/auser/.cache/mvm/default-microvm
+/Users/auser/.cache/mvm/docker-nix-store
+/Users/auser/.cache/mvm/builder-vm
+/Users/auser/.cache/mvm/builder-vm/jobs
+/Users/auser/.cache/mvm/builder-vm/jobs/1779303829911-20106
+/Users/auser/.cache/mvm/builder-vm/jobs/1779315171950-64485
+/Users/auser/.cache/mvm/builder-vm/jobs/1779344465141-91896
+/Users/auser/.cache/mvm/builder-vm/jobs/1779426018614-7835
+/Users/auser/.cache/mvm/builder-vm/jobs/1779315634351-8232
+/Users/auser/.cache/mvm/builder-vm/jobs/1779315344207-96219
+/Users/auser/.cache/mvm/builder-vm/jobs/1779312031119-51903
+/Users/auser/.cache/mvm/builder-vm/jobs/1779321113493-68292
+/Users/auser/.cache/mvm/builder-vm/jobs/1779311880856-93520
+/Users/auser/.cache/mvm/builder-vm/jobs/1779418247134-70382
+/Users/auser/.cache/mvm/builder-vm/jobs/1779418443602-26130
+/Users/auser/.cache/mvm/builder-vm/jobs/1779388217942-71549
+/Users/auser/.cache/mvm/builder-vm/aarch64
+/Users/auser/.cache/mvm/builder-vm/vms
+/Users/auser/.cache/mvm/builder-vm/vms/mvm-builder-vm-1779426018614-7835
+/Users/auser/.cache/mvm/builder-vm/vms/mvm-stage0-1779425442918-7835
+/Users/auser/.cache/mvm/stage0
+/Users/auser/.cache/mvm/stage0/root
+/Users/auser/.cache/mvm/stage0/root/proc
+/Users/auser/.cache/mvm/stage0/root/home
+/Users/auser/.cache/mvm/stage0/root/usr
+/Users/auser/.cache/mvm/stage0/root/usr/bin
+/Users/auser/.cache/mvm/stage0/root/usr/libexec
+/Users/auser/.cache/mvm/stage0/root/usr/libexec/nix
+/Users/auser/.cache/mvm/stage0/root/usr/libexec/git-core
+/Users/auser/.cache/mvm/stage0/root/usr/libexec/git-core/mergetools
+/Users/auser/.cache/mvm/stage0/root/usr/sbin
+/Users/auser/.cache/mvm/stage0/root/usr/local
+/Users/auser/.cache/mvm/stage0/root/usr/local/bin
+/Users/auser/.cache/mvm/stage0/root/usr/local/lib
+/Users/auser/.cache/mvm/stage0/root/usr/local/share
+/Users/auser/.cache/mvm/stage0/root/usr/local/share/ca-certificates
+/Users/auser/.cache/mvm/stage0/root/usr/lib
+/Users/auser/.cache/mvm/stage0/root/usr/lib/modules-load.d
+/Users/auser/.cache/mvm/stage0/root/usr/lib/sysctl.d
+```
+
+## Assistant
+
+<thinking>
+
+</thinking>
+
+The job directory matching the failed run exists with nix-stderr.log. Reading it now.
+
+**Tool Call: ls -la ~/.cache/mvm/builder-vm/jobs/1779426018614-7835/**
+Status: Completed
+
+Terminal:
+
+```
+total 544
+drwxr-xr-x@  7 auser  staff     224 May 21 22:02 .
+drwxr-xr-x@ 14 auser  staff     448 May 21 22:00 ..
+-rw-------@  1 auser  staff     265 May 21 22:02 boot-timings.json
+-rw-r--r--@  1 auser  staff    4449 May 21 22:00 cmd.sh
+-rw-------@  1 auser  staff  221787 May 21 22:02 nix-stderr.log
+-rw-------@  1 auser  staff       0 May 21 22:00 nix-stdout.log
+-rw-------@  1 auser  staff    1172 May 21 22:02 result
+```
+
+**Tool Call: cat ~/.cache/mvm/builder-vm/jobs/1779426018614-7835/result**
+Status: Completed
+
+Terminal:
+
+```
+{"exit_code":1,"stderr_tail":"error: Cannot build '/nix/store/xgb1qixn4z5k8dg2dyq8skijl3gk86q0-mvm-guest-agent-0.14.0.drv'.\n       Reason: builder failed with exit code 1.\n       Output paths:\n         /nix/store/0f3qx9mff0wzz96ir217y7a6yjpb7c10-mvm-guest-agent-0.14.0\nerror: Cannot build '/nix/store/zbljc67m83cfdri4swi4f1lcl0616jab-mvm-rootfs-tree-mvm-dev.drv'.\n       Reason: 3 dependencies failed.\n       Output paths:\n         /nix/store/dlr7q784j7wlahxyfkd3hh2nifh75qfl-mvm-rootfs-tree-mvm-dev\nerror: Cannot build '/nix/store/607gi922yn2hf74lbk6g606dyb5jphmz-closure-info.drv'.\n       Reason: 1 dependency failed.\n       Output paths:\n         /nix/store/bqhmg06s7hlwv55mgqimnmxkx5hgny6z-closure-info\nerror: Cannot build '/nix/store/5vskxd1prday8d8irjsx0fs4jqcl0zjf-ext4-fs.img.drv'.\n       Reason: 2 dependencies failed.\n       Output paths:\n         /nix/store/a4ijzwy8360bqydxhyq84530z75shfp3-ext4-fs.img\nerror: Cannot build '/nix/store/nh82bkm8agjhayfgnshl4909lzhvcw47-mvm-dev-image-aarch64-linux.drv'.\n       Reason: 1 dependency failed.\n       Output paths:\n         /nix/store/l8q0avr98yzpn9ndwygi8fwgn43x8l4b-mvm-dev-image-aarch64-linux"}
+```
+
+**Tool Call: cat ~/.cache/mvm/builder-vm/jobs/1779426018614-7835/cmd.sh | head -50**
+Status: Completed
+
+Terminal:
+
+```
+#!/bin/sh
+# mvm-builder-vm cmd.sh — emitted by LibkrunBuilderVm (Plan 72 W4).
+# Runs inside the libkrun builder VM under `/bin/sh -eu`. The
+# host wires /work (workspace), /out (artifact dir), /job (this
+# dir) as virtio-fs shares; /nix is a persistent virtio-blk
+# overlay handled by mvm-builder-init.
+set -eu
+
+FLAKE_REF='path:/work/nix/images/builder'
+ATTR_PATH='packages.aarch64-linux.default'
+
+# Point HOME at writable tmpfs (`/tmp`) to satisfy code paths that
+# write to `~/...` (the rootfs is mounted `ro`; nix would otherwise
+# bail with "creating directory '//.cache/nix': Read-only file
+# system"). XDG_CACHE_HOME lives on the persistent `/nix-store`
+# disk so Nix's eval-cache-v5, tarball-cache, and binary-cache-v6
+# survive across builds — cold flake eval is the long pole on
+# warm-store rebuilds, and these caches reclaim it. `/nix-store`
+# is the ext4 root for the persistent virtio-blk device; it sits
+# alongside the overlay upperdir (`/nix-store/upper`) at the
+# disk's top level, so writes here don't pollute the Nix store
+# namespace. XDG_STATE_HOME stays on tmpfs: it only holds profile
+# generations, which one-shot build VMs don't use.
+export HOME=/tmp
+export XDG_CACHE_HOME=/nix-store/.cache
+export XDG_STATE_HOME=/tmp/.local/state
+mkdir -p /nix-store/.cache /tmp/.local/state
+
+# CA certs for TLS to cache.nixos.org / api.github.com.
+export CURL_CA_BUNDLE=/etc/ssl/certs/ca-bundle.crt
+export NIX_SSL_CERT_FILE=/etc/ssl/certs/ca-bundle.crt
+export SSL_CERT_FILE=/etc/ssl/certs/ca-bundle.crt
+
+cd /work
+# `experimental-features` enables nix-command + flakes. `sandbox =
+# false` + `build-users-group =` is mandatory inside the builder
+# VM: there are no `nixbld*` accounts in the rootfs and no kernel
+# user-ns isolation for build sandboxes, so every derivation would
+# otherwise fail with "the group 'nixbld' specified in
+# 'build-users-group' does not exist". The builder VM IS the
+# isolation boundary, so an in-guest sandbox is redundant.
+export NIX_CONFIG="experimental-features = nix-command flakes
+sandbox = false
+build-users-group =
+max-jobs = auto
+cores = 0
+auto-optimise-store = true
+substituters = https://cache.nixos.org/
+trusted-public-keys = cache.nixos.org-1:6NCHdD59X431o0gWypbMrAURkbJ16ZPMQFGspcDShjY="
+# Plan 72 W0's flake convention: workspace-path env var so
+```
+
+**Tool Call: Read /Users/auser/.cache/mvm/builder-vm/jobs/1779426018614-7835/nix-stderr.log**
+Status: Failed
+
+```
+File content (135775 tokens) exceeds maximum allowed tokens (25000). Use offset and limit parameters to read specific portions of the file, or search for specific content instead of reading the whole file.
+```
+
+## Assistant
+
+<thinking>
+
+</thinking>
+
+Reading the actual stderr (220KB file) to find the first failure.
+
+**Tool Call: grep -n | head -60 "error:|failed|Error" /Users/auser/.cache/mvm/builder-vm/jobs/1779426018614-7835/nix-stderr.log**
+Status: Completed
+
+2481:error: Cannot build '/nix/store/wlz51805gfrr9i16j74zwc5qfyspjd9l-mvm-builder-init-0.14.0.drv'.
+2482: Reason: builder failed with exit code 1.
+2700:error: Cannot build '/nix/store/1cvwrb5lhv5dd3c4dlygk0d0ynpxp24k-mvm-addon-dns-0.14.0.drv'.
+2701: Reason: builder failed with exit code 1.
+2712:error: Cannot build '/nix/store/xgb1qixn4z5k8dg2dyq8skijl3gk86q0-mvm-guest-agent-0.14.0.drv'.
+2713: Reason: builder failed with exit code 1.
+2716:error: Cannot build '/nix/store/zbljc67m83cfdri4swi4f1lcl0616jab-mvm-rootfs-tree-mvm-dev.drv'.
+2717: Reason: 3 dependencies failed.
+2720:error: Cannot build '/nix/store/607gi922yn2hf74lbk6g606dyb5jphmz-closure-info.drv'.
+2721: Reason: 1 dependency failed.
+2724:error: Cannot build '/nix/store/5vskxd1prday8d8irjsx0fs4jqcl0zjf-ext4-fs.img.drv'.
+2725: Reason: 2 dependencies failed.
+2728:error: Cannot build '/nix/store/nh82bkm8agjhayfgnshl4909lzhvcw47-mvm-dev-image-aarch64-linux.drv'.
+2729: Reason: 1 dependency failed.
+
+**Tool Call: grep -n -A 5 -B 2 | head -80 "mvm-guest-agent" /Users/auser/.cache/mvm/builder-vm/jobs/1779426018614-7835/nix-stderr.log**
+Status: Completed
+
+283- /nix/store/wlz51805gfrr9i16j74zwc5qfyspjd9l-mvm-builder-init-0.14.0.drv
+284- /nix/store/x0xji6am55zraxc988msfdis7b9wf8gb-mvm-name.drv
+285: /nix/store/xgb1qixn4z5k8dg2dyq8skijl3gk86q0-mvm-guest-agent-0.14.0.drv
+286- /nix/store/zbljc67m83cfdri4swi4f1lcl0616jab-mvm-rootfs-tree-mvm-dev.drv
+287- /nix/store/607gi922yn2hf74lbk6g606dyb5jphmz-closure-info.drv
+288- /nix/store/5vskxd1prday8d8irjsx0fs4jqcl0zjf-ext4-fs.img.drv
+289- /nix/store/nh82bkm8agjhayfgnshl4909lzhvcw47-mvm-dev-image-aarch64-linux.drv
+290-these 692 paths will be fetched (554.94 MiB download, 2697.06 MiB unpacked):
+--
+2339-building '/nix/store/1cvwrb5lhv5dd3c4dlygk0d0ynpxp24k-mvm-addon-dns-0.14.0.drv'...
+2340-building '/nix/store/wlz51805gfrr9i16j74zwc5qfyspjd9l-mvm-builder-init-0.14.0.drv'...
+2341:building '/nix/store/xgb1qixn4z5k8dg2dyq8skijl3gk86q0-mvm-guest-agent-0.14.0.drv'...
+2342-mvm-addon-dns> Running phase: unpackPhase
+2343-mvm-addon-dns> unpacking source archive /nix/store/f79lc74pmfb1smhgzzicvk227vyw71yx-mvm-workspace
+2344-mvm-builder-init> Running phase: unpackPhase
+2345-mvm-builder-init> unpacking source archive /nix/store/f79lc74pmfb1smhgzzicvk227vyw71yx-mvm-workspace
+2346:mvm-guest-agent> Running phase: unpackPhase
+2347:mvm-guest-agent> unpacking source archive /nix/store/f79lc74pmfb1smhgzzicvk227vyw71yx-mvm-workspace
+2348-mvm-addon-dns> source root is mvm-workspace
+2349-mvm-builder-init> source root is mvm-workspace
+2350-mvm-addon-dns> Executing cargoSetupPostUnpackHook
+2351-mvm-builder-init> Executing cargoSetupPostUnpackHook
+2352:mvm-guest-agent> source root is mvm-workspace
+2353:mvm-guest-agent> Executing cargoSetupPostUnpackHook
+2354-mvm-addon-dns> Finished cargoSetupPostUnpackHook
+2355-mvm-addon-dns> Running phase: patchPhase
+2356:mvm-guest-agent> Finished cargoSetupPostUnpackHook
+2357-mvm-addon-dns> Executing cargoSetupPostPatchHook
+2358-mvm-addon-dns> Validating consistency between /nix/var/nix/builds/nix-138-2958138556/mvm-workspace/Cargo.lock and /nix/var/nix/builds/nix-138-2958138556/cargo-vendor-dir/Cargo.lock
+2359-mvm-addon-dns> Finished cargoSetupPostPatchHook
+2360:mvm-guest-agent> Running phase: patchPhase
+2361-mvm-addon-dns> Running phase: updateAutotoolsGnuConfigScriptsPhase
+2362:mvm-guest-agent> Executing cargoSetupPostPatchHook
+2363:mvm-guest-agent> Validating consistency between /nix/var/nix/builds/nix-138-2958138558/mvm-workspace/Cargo.lock and /nix/var/nix/builds/nix-138-2958138558/cargo-vendor-dir/Cargo.lock
+2364:mvm-guest-agent> Finished cargoSetupPostPatchHook
+2365:mvm-guest-agent> Running phase: updateAutotoolsGnuConfigScriptsPhase
+2366-mvm-builder-init> Finished cargoSetupPostUnpackHook
+2367:mvm-guest-agent> Running phase: configurePhase
+2368-mvm-addon-dns> Running phase: configurePhase
+2369-mvm-builder-init> Running phase: patchPhase
+2370-mvm-builder-init> Executing cargoSetupPostPatchHook
+2371-mvm-builder-init> Validating consistency between /nix/var/nix/builds/nix-138-2958138557/mvm-workspace/Cargo.lock and /nix/var/nix/builds/nix-138-2958138557/cargo-vendor-dir/Cargo.lock
+2372:mvm-guest-agent> Running phase: buildPhase
+2373-mvm-builder-init> Finished cargoSetupPostPatchHook
+2374-mvm-addon-dns> Running phase: buildPhase
+2375-mvm-builder-init> Running phase: updateAutotoolsGnuConfigScriptsPhase
+2376:mvm-guest-agent> Executing cargoBuildHook
+2377-mvm-addon-dns> Executing cargoBuildHook
+2378:mvm-guest-agent> cargoBuildHook flags: -j 4 --target aarch64-unknown-linux-gnu --offline --profile release --package mvm-guest --bin mvm-guest-agent --bin mvm-seccomp-apply --bin mvm-verity-init --bin mvm-guest-netinit --features mvm-guest/dev-shell
+2379-mvm-addon-dns> cargoBuildHook flags: -j 4 --target aarch64-unknown-linux-gnu --offline --profile release --package mvm-addon-dns --bin mvm-addon-dns
+2380-mvm-builder-init> Running phase: configurePhase
+2381-mvm-builder-init> Running phase: buildPhase
+2382-mvm-builder-init> Executing cargoBuildHook
+2383-mvm-builder-init> /nix/var/nix/builds/nix-138-2958138557/mvm-workspace/crates/mvm-builder-init /nix/var/nix/builds/nix-138-2958138557/mvm-workspace
+--
+2387-mvm-builder-init> Compiling cfg-if v1.0.4
+2388-mvm-builder-init> Compiling bitflags v2.11.0
+2389:mvm-guest-agent> Compiling proc-macro2 v1.0.106
+2390:mvm-guest-agent> Compiling unicode-ident v1.0.24
+2391-mvm-addon-dns> Compiling proc-macro2 v1.0.106
+2392-mvm-addon-dns> Compiling quote v1.0.44
+2393-mvm-addon-dns> Compiling unicode-ident v1.0.24
+2394-mvm-addon-dns> Compiling libc v0.2.182
+2395:mvm-guest-agent> Compiling quote v1.0.44
+2396:mvm-guest-agent> Compiling libc v0.2.182
+2397-mvm-builder-init> Compiling nix v0.29.0
+2398:mvm-guest-agent> Compiling cfg-if v1.0.4
+2399-mvm-addon-dns> Compiling serde_core v1.0.228
+2400:mvm-guest-agent> Compiling version_check v0.9.5
+2401:mvm-guest-agent> Compiling typenum v1.20.0
+2402-mvm-addon-dns> Compiling stable_deref_trait v1.2.1
+2403-mvm-addon-dns> Compiling cfg-if v1.0.4
+2404-mvm-addon-dns> Compiling serde v1.0.228
+2405:mvm-guest-agent> Compiling generic-array v0.14.7
+2406:mvm-guest-agent> Compiling serde_core v1.0.228
+2407-mvm-addon-dns> Compiling portable-atomic v1.13.1
+2408-mvm-addon-dns> Compiling syn v2.0.117
+2409:mvm-guest-agent> Compiling syn v2.0.117
+2410-mvm-addon-dns> Compiling critical-section v1.2.0
+2411-mvm-addon-dns> Compiling smallvec v1.15.1
+
+[Showing results with pagination = limit: 80]
+
+## Assistant
+
+<thinking>
+
+</thinking>
+
+Three derivations failing in parallel. Need to see the actual error reason — searching for the real cause.
+
+**Tool Call: Read /Users/auser/.cache/mvm/builder-vm/jobs/1779426018614-7835/nix-stderr.log (2430 - 2529)**
+Status: Completed
+
+```
+2430	mvm-guest-agent>    Compiling rand_core v0.6.4
+2431	mvm-guest-agent>    Compiling crypto-common v0.1.7
+2432	mvm-guest-agent>    Compiling pin-project-lite v0.2.16
+2433	mvm-guest-agent>    Compiling subtle v2.6.1
+2434	mvm-addon-dns>    Compiling version_check v0.9.5
+2435	mvm-addon-dns>    Compiling writeable v0.6.2
+2436	mvm-guest-agent>    Compiling once_cell v1.21.3
+2437	mvm-addon-dns>    Compiling rand_core v0.10.1
+2438	mvm-guest-agent>    Compiling glob v0.3.3
+2439	mvm-addon-dns>    Compiling getrandom v0.4.1
+2440	mvm-addon-dns>    Compiling memchr v2.8.0
+2441	mvm-guest-agent>    Compiling parking_lot_core v0.9.12
+2442	mvm-addon-dns>    Compiling generic-array v0.14.7
+2443	mvm-guest-agent>    Compiling log v0.4.29
+2444	mvm-addon-dns>    Compiling minimal-lexical v0.2.1
+2445	mvm-guest-agent>    Compiling clang-sys v1.8.1
+2446	mvm-addon-dns>    Compiling icu_normalizer_data v2.1.1
+2447	mvm-guest-agent>    Compiling thiserror v1.0.69
+2448	mvm-addon-dns>    Compiling regex-syntax v0.8.10
+2449	mvm-guest-agent>    Compiling prettyplease v0.2.37
+2450	mvm-addon-dns>    Compiling icu_properties_data v2.1.2
+2451	mvm-guest-agent>    Compiling smallvec v1.15.1
+2452	mvm-guest-agent>    Compiling anyhow v1.0.102
+2453	mvm-addon-dns>    Compiling pin-project-lite v0.2.16
+2454	mvm-addon-dns>    Compiling nom v7.1.3
+2455	mvm-guest-agent>    Compiling tracing-core v0.1.36
+2456	mvm-addon-dns>    Compiling libloading v0.8.9
+2457	mvm-guest-agent>    Compiling cpufeatures v0.2.17
+2458	mvm-guest-agent>    Compiling regex-syntax v0.8.10
+2459	mvm-guest-agent>    Compiling minimal-lexical v0.2.1
+2460	mvm-guest-agent>    Compiling bitflags v2.11.0
+2461	mvm-guest-agent>    Compiling scopeguard v1.2.0
+2462	mvm-guest-agent>    Compiling lock_api v0.4.14
+2463	mvm-guest-agent>    Compiling libloading v0.8.9
+2464	mvm-guest-agent>    Compiling nom v7.1.3
+2465	mvm-addon-dns>    Compiling synstructure v0.13.2
+2466	mvm-addon-dns>    Compiling regex-automata v0.4.14
+2467	mvm-addon-dns>    Compiling typenum v1.20.0
+2468	mvm-guest-agent>    Compiling regex-automata v0.4.14
+2469	mvm-addon-dns>    Compiling either v1.15.0
+2470	mvm-addon-dns>    Compiling bindgen v0.72.1
+2471	mvm-builder-init> warning: `mvm-builder-init` (bin "mvm-builder-init") generated 1 warning
+2472	mvm-builder-init>     Finished `release` profile [optimized] target(s) in 7.11s
+2473	mvm-builder-init> /nix/var/nix/builds/nix-138-2958138557/mvm-workspace
+2474	mvm-builder-init> Executing cargoInstallPostBuildHook
+2475	mvm-builder-init> Finished cargoInstallPostBuildHook
+2476	mvm-builder-init> Finished cargoBuildHook
+2477	mvm-builder-init> Running phase: installPhase
+2478	mvm-builder-init> Executing cargoInstallHook
+2479	mvm-builder-init> /nix/store/0aw41026hlzvkg7pjl8wqqbs8vpf3dda-cargo-install-hook.sh/nix-support/setup-hook: line 27: /dev/fd/63: No such file or directory
+2480	mvm-addon-dns>    Compiling rustix v1.1.4
+2481	error: Cannot build '/nix/store/wlz51805gfrr9i16j74zwc5qfyspjd9l-mvm-builder-init-0.14.0.drv'.
+2482	       Reason: builder failed with exit code 1.
+2483	       Output paths:
+2484	         /nix/store/sbx7yw3c9jnviliv61mhcajc64y7a1k7-mvm-builder-init-0.14.0
+2485	mvm-addon-dns>    Compiling zerofrom-derive v0.1.6
+2486	mvm-addon-dns>    Compiling yoke-derive v0.8.1
+2487	mvm-addon-dns>    Compiling zerovec-derive v0.11.2
+2488	mvm-guest-agent>    Compiling serde_derive v1.0.228
+2489	mvm-guest-agent>    Compiling thiserror-impl v1.0.69
+2490	mvm-addon-dns>    Compiling serde_derive v1.0.228
+2491	mvm-guest-agent>    Compiling errno v0.3.14
+2492	mvm-addon-dns>    Compiling displaydoc v0.2.5
+2493	mvm-addon-dns>    Compiling zerofrom v0.1.6
+2494	mvm-guest-agent>    Compiling block-buffer v0.10.4
+2495	mvm-guest-agent>    Compiling bindgen v0.72.1
+2496	mvm-addon-dns>    Compiling yoke v0.8.1
+2497	mvm-guest-agent>    Compiling futures-core v0.3.32
+2498	mvm-guest-agent>    Compiling either v1.15.0
+2499	mvm-addon-dns>    Compiling tracing-attributes v0.1.31
+2500	mvm-addon-dns>    Compiling zerovec v0.11.5
+2501	mvm-guest-agent>    Compiling paste v1.0.15
+2502	mvm-guest-agent>    Compiling rustix v1.1.4
+2503	mvm-guest-agent>    Compiling futures-sink v0.3.32
+2504	mvm-guest-agent>    Compiling futures-channel v0.3.32
+2505	mvm-guest-agent>    Compiling itertools v0.11.0
+2506	mvm-guest-agent>    Compiling digest v0.10.7
+2507	mvm-addon-dns>    Compiling zerotrie v0.2.3
+2508	mvm-guest-agent>    Compiling signal-hook-registry v1.4.8
+2509	mvm-guest-agent>    Compiling parking_lot v0.12.5
+2510	mvm-addon-dns>    Compiling tinystr v0.8.2
+2511	mvm-addon-dns>    Compiling potential_utf v0.1.4
+2512	mvm-guest-agent>    Compiling regex v1.12.3
+2513	mvm-addon-dns>    Compiling icu_locale_core v2.1.1
+2514	mvm-addon-dns>    Compiling icu_collections v2.1.1
+2515	mvm-guest-agent>    Compiling cexpr v0.6.0
+2516	mvm-guest-agent>    Compiling tracing-attributes v0.1.31
+2517	mvm-addon-dns>    Compiling regex v1.12.3
+2518	mvm-addon-dns>    Compiling tracing v0.1.44
+2519	mvm-addon-dns>    Compiling icu_provider v2.1.1
+2520	mvm-guest-agent>    Compiling tokio-macros v2.6.0
+2521	mvm-addon-dns>    Compiling itertools v0.11.0
+2522	mvm-guest-agent>    Compiling futures-macro v0.3.32
+2523	mvm-addon-dns>    Compiling cexpr v0.6.0
+2524	mvm-guest-agent>    Compiling aho-corasick v1.1.4
+2525	mvm-guest-agent>    Compiling mio v1.1.1
+2526	mvm-guest-agent>    Compiling socket2 v0.6.2
+2527	mvm-addon-dns>    Compiling aho-corasick v1.1.4
+2528	mvm-addon-dns>    Compiling zmij v1.0.21
+2529	mvm-guest-agent>    Compiling rustc-hash v2.1.1
+```
+
+**Tool Call: grep -n -A 5 -B 2 | head -60 "no space|disk full|out of memory|killed|signal:|cannot allocate|ENOMEM|ENOSPC|panic|SIGKILL|SIGSEGV|rustc.\*error|linker" /Users/auser/.cache/mvm/builder-vm/jobs/1779426018614-7835/nix-stderr.log**
+Status: Completed
+
+No matches found
+
+## Assistant
+
+<thinking>
+
+</thinking>
+
+**Found the root cause.** Line 2479: `cargo-install-hook.sh line 27: /dev/fd/63: No such file or directory`. The builder VM's `/dev/fd` symlink is missing. Confirming this hits all three derivations.
+
+**Tool Call: grep -n "/dev/fd|install-hook" /Users/auser/.cache/mvm/builder-vm/jobs/1779426018614-7835/nix-stderr.log**
+Status: Completed
+
+343: /nix/store/0aw41026hlzvkg7pjl8wqqbs8vpf3dda-cargo-install-hook.sh
+1044:copying path '/nix/store/0aw41026hlzvkg7pjl8wqqbs8vpf3dda-cargo-install-hook.sh' from 'https://cache.nixos.org'...
+2479:mvm-builder-init> /nix/store/0aw41026hlzvkg7pjl8wqqbs8vpf3dda-cargo-install-hook.sh/nix-support/setup-hook: line 27: /dev/fd/63: No such file or directory
+2699:mvm-addon-dns> /nix/store/0aw41026hlzvkg7pjl8wqqbs8vpf3dda-cargo-install-hook.sh/nix-support/setup-hook: line 27: /dev/fd/63: No such file or directory
+2711:mvm-guest-agent> /nix/store/0aw41026hlzvkg7pjl8wqqbs8vpf3dda-cargo-install-hook.sh/nix-support/setup-hook: line 27: /dev/fd/63: No such file or directory
+
+**Tool Call: grep -n "/dev/fd|symlink._proc|mkpseudo|mount._/dev" /Users/auser/work/tinylabs/mvmco/mvm/crates/mvm-builder-init/src/main.rs**
+Status: Completed
+
+1371: mount_fs_idempotent("devtmpfs", "/dev", "devtmpfs")?;
+1383: // requires devpts to be mounted at `/dev/pts`. Without it
+1388: mount_fs_idempotent("devpts", "/dev/pts", "devpts")?;
+1684: /// parts bind-mount `/dev/shm` etc. per-job without bleeding
+1907: /// pre-mounts some of `/proc`, `/sys`, `/dev` depending on
+
+**Tool Call: grep -n | head -40 "mount_pseudofs|pseudofs|/dev|/proc|/sys|setup_dev|mount\b.\*devtmpfs|devtmpfs" /Users/auser/work/tinylabs/mvmco/mvm/crates/mvm-builder-init/src/main.rs**
+Status: Completed
+
+26://! 1. Mount `/proc`, `/sys`, `/dev`, `/tmp` (the standard init
+29://! 2. Probe `/dev/vdb` for an ext4 superblock; format with
+32://! 3. Mount `/dev/vdb` at `/nix-store`, then mount `/nix` as an
+238: /// stale 64 GiB ext4 image got re-attached to a `/dev/vdb`
+269: /// `/dev/vdb` by `LibkrunBuilderVm` (Plan 72 W4 will wire
+271: const NIX*STORE_DEV: &str = "/dev/vdb";
+283: /// by `mount_pseudofs` (mvmctl-init Stage 1), so `mkdir` there
+381: // every subsequent phase needs /proc, /sys, /dev to be
+383: if let Err(e) = mount_pseudofs() {
+384: eprintln!("mvm-builder-init: mount_pseudofs failed: {e}");
+385: write_result(2, &format!("mount_pseudofs failed: {e}"));
+393: t.pseudofs_ready_ms = Some(BootTimings::ms_since(anchor))
+397: // after pseudofs. They share no state with each other
+400: // Track A (this thread): /dev/vdb format → mount → seed
+1348: /// every other init step. /proc, /sys, /dev, /tmp must be
+1363: fn mount_pseudofs() -> Result<(), String> {
+1365: // devtmpfs (and sometimes /proc /sys) before handing off to
+1369: mount_fs_idempotent("proc", "/proc", "proc")?;
+1370: mount_fs_idempotent("sysfs", "/sys", "sysfs")?;
+1371: mount_fs_idempotent("devtmpfs", "/dev", "devtmpfs")?;
+1381: // `/dev/pts` is required by nix's build-sandbox setup: it
+1382: // calls `posix_openpt` which opens `/dev/ptmx`, and that
+1383: // requires devpts to be mounted at `/dev/pts`. Without it
+1387: let * = std::fs::create_dir_all("/dev/pts");
+1388: mount_fs_idempotent("devpts", "/dev/pts", "devpts")?;
+1393: /// /dev/vdb format (first boot only) → mount → overlay-mount
+1684: /// parts bind-mount `/dev/shm` etc. per-job without bleeding
+1907: /// pre-mounts some of `/proc`, `/sys`, `/dev` depending on
+2108: /// Decide whether `/dev/vdb` needs (re)formatting before
+2182: /// `/sys/class/block/<basename>/size` (which is the canonical
+2191: let sys_path = format!("/sys/class/block/{basename}/size");
+2212: // canonical size from `/sys/class/block/<dev>/size` (always
+2514: /// --fork`. The cmd.sh reads `/proc/self/status` and
+2559: /proc/self/status >&2\nexit 0\n",
+
+## Assistant
+
+<thinking>
+
+</thinking>
+
+Confirmed — same error at line 27 of cargo-install-hook.sh for all three derivations. The builder VM's `/dev/fd` symlink is missing. Let me read mount_pseudofs to confirm what's there and what's missing.
+
+**Tool Call: Read crates/mvm-builder-init/src/main.rs (1348 - 1407)**
+Status: Completed
+
+```
+1348	    /// every other init step. /proc, /sys, /dev, /tmp must be
+1349	    /// available before module loading, device probing, or virtio-fs
+1350	    /// mounting; nothing else fans out concurrently with this.
+1351	    /// Plan 86 — detect the "kernel ships without netfilter / iptables
+1352	    /// tables" error pattern. Matches both the iptables-nft Protocol
+1353	    /// not supported and the iptables-legacy "Table does not exist /
+1354	    /// do you need to insmod?" surfaces. A future netlink-based check
+1355	    /// would be more robust, but this regex-of-substrings catches the
+1356	    /// only two error shapes the libkrunfw-bundled kernel produces.
+1357	    fn egress_error_indicates_no_netfilter(err: &str) -> bool {
+1358	        err.contains("Table does not exist")
+1359	            || err.contains("Failed to initialize nft")
+1360	            || err.contains("Protocol not supported")
+1361	    }
+1362
+1363	    fn mount_pseudofs() -> Result<(), String> {
+1364	        // Standard init filesystems. libkrun's kernel mounts
+1365	        // devtmpfs (and sometimes /proc /sys) before handing off to
+1366	        // init, so EBUSY here means "already mounted by an earlier
+1367	        // stage" — that's success for our purposes. Anything else
+1368	        // is fatal.
+1369	        mount_fs_idempotent("proc", "/proc", "proc")?;
+1370	        mount_fs_idempotent("sysfs", "/sys", "sysfs")?;
+1371	        mount_fs_idempotent("devtmpfs", "/dev", "devtmpfs")?;
+1372	        mount_fs_idempotent("tmpfs", "/tmp", "tmpfs")?;
+1373	        // `/run` must be a tmpfs so iptables-legacy can write
+1374	        // `/run/xtables.lock`. The rootfs is mounted ro, so a missing
+1375	        // `/run` tmpfs makes `install_egress_lockdown` bail with
+1376	        // "Read-only file system" at the first `iptables -A` call.
+1377	        // mkGuest's /init does the equivalent for the dev image's
+1378	        // boot path; we replicate it here for the mvm-builder-init
+1379	        // path (Plan 86).
+1380	        mount_fs_idempotent("tmpfs", "/run", "tmpfs")?;
+1381	        // `/dev/pts` is required by nix's build-sandbox setup: it
+1382	        // calls `posix_openpt` which opens `/dev/ptmx`, and that
+1383	        // requires devpts to be mounted at `/dev/pts`. Without it
+1384	        // nix bails with `error: opening pseudoterminal master:
+1385	        // No such file or directory`. The dev image flake's
+1386	        // mkGuest /init mounts this; we replicate for Plan 86.
+1387	        let _ = std::fs::create_dir_all("/dev/pts");
+1388	        mount_fs_idempotent("devpts", "/dev/pts", "devpts")?;
+1389	        Ok(())
+1390	    }
+1391
+1392	    /// Plan 76 Phase 5: serial chain that gates job execution.
+1393	    /// /dev/vdb format (first boot only) → mount → overlay-mount
+1394	    /// rootfs `/nix` with persistent upper/work dirs → bind-mount
+1395	    /// over /nix. Each step depends on the previous, so this stays
+1396	    /// single-threaded inside.
+1397	    fn setup_nix_store(timings: &Arc<Mutex<BootTimings>>, anchor: Instant) -> Result<(), String> {
+1398	        std::fs::create_dir_all(NIX_STORE_MOUNT)
+1399	            .map_err(|e| format!("create {NIX_STORE_MOUNT}: {e}"))?;
+1400	        if let Some(reason) = nix_store_dev_needs_format(NIX_STORE_DEV)? {
+1401	            eprintln!("mvm-builder-init: formatting {NIX_STORE_DEV} ({reason})");
+1402	            format_ext4(NIX_STORE_DEV)?;
+1403	        }
+1404	        mount_fs(NIX_STORE_DEV, NIX_STORE_MOUNT, "ext4")?;
+1405	        stamp(timings, |t| {
+1406	            t.nix_device_ready_ms = Some(BootTimings::ms_since(anchor))
+1407	        });
+```
+
+**Tool Call: curl -s "https://raw.githubusercontent.com/NixOS/nixpkgs/master/pkgs/build-support/rust/hooks/cargo-install-hook.sh" 2>/dev/null | head -40**
+Status: Completed
+
+Terminal:
+
+```
+cargoInstallPostBuildHook() {
+    echo "Executing cargoInstallPostBuildHook"
+
+    releaseDir=target/@targetSubdirectory@/$cargoBuildType
+    tmpDir="${releaseDir}-tmp";
+
+    mkdir -p $tmpDir
+    cp -r ${releaseDir}/* $tmpDir/
+    bins=$(find $tmpDir \
+      -maxdepth 1 \
+      -type f \
+      -executable ! \( -regex ".*\.\(so.[0-9.]+\|so\|a\|dylib\)" \))
+
+    echo "Finished cargoInstallPostBuildHook"
+}
+
+cargoInstallHook() {
+    echo "Executing cargoInstallHook"
+
+    runHook preInstall
+
+    # rename the output dir to a architecture independent one
+
+    releaseDir=target/@targetSubdirectory@/$cargoBuildType
+    tmpDir="${releaseDir}-tmp";
+
+    mapfile -t targets < <(find "$NIX_BUILD_TOP" -type d | grep "${tmpDir}$")
+    for target in "${targets[@]}"; do
+      rm -rf "$target/../../${cargoBuildType}"
+      ln -srf "$target" "$target/../../"
+    done
+    mkdir -p $out/bin $out/lib
+
+    xargs -r cp -t $out/bin <<< $bins
+    find $tmpDir \
+      -maxdepth 1 \
+      -regex ".*\.\(so.[0-9.]+\|so\|a\|dylib\)" \
+      -print0 | xargs -r -0 cp -t $out/lib
+
+    # If present, copy any .dSYM directories for debugging on darwin
+```
+
+## Assistant
+
+<thinking>
+
+</thinking>
+
+Confirmed. Now let me verify no worktree is already fixing this, and check whether the same `/dev/fd` issue would affect the dev image's /init too.
+
+**Tool Call: git log --all --oneline --since="2 days ago" | head -30**
+Status: Completed
+
+Terminal:
+
+```
+31a436dd fix(stage0): surface real nix-build errors when /dev/null is missing
+41c60e1a fix(mkGuest): skip addon-dns bake for builder VM (Stage 0 OOM)
+e646e4df Merge pull request #420 from tinylabscom/worktree-plan-96-dev-up-followups
+155b561f fix(builder-vm): fingerprint mvm-builder-init / mvm-egress-proxy / Cargo.lock too
+37f0aa9b fix(nix): pin nix/images/runtime-overlay/flake.lock
+a6242604 fix(builder-init): register seeded /nix/store paths in nix DB at boot
+2a3bb286 style(builder-init): apply cargo fmt to ext4 parser regression test
+6f6fd7c9 fix(builder-init,nix): next-layer dev up unblockers — udhcpc path + dev-image flake lock
+d5e795d9 fix(builder-init): unblock dev up — ext4 geometry recovery + correct seed-fallback check
+744bca74 Merge pull request #421 from tinylabscom/worktree-dev-up-unblock
+d50ca7cc style: cargo fmt — collapse mkfs args, inline read_to_string
+90a0ed88 fix(builder-init): pass explicit block count to mkfs.ext4 (libkrun geometry)
+03da9aa7 fix(builder-vm): unblock dev up — busybox, /run/nix-merged, reaper fixes
+2bbdbfe4 fix(builder-init): unblock dev up — ext4 geometry recovery + correct seed-fallback check
+ee40b729 Merge pull request #418 from tinylabscom/worktree-plan-95-kernel-slimming
+e99ebf8d Merge pull request #419 from tinylabscom/worktree-cleanup-host-tiers
+c2d7f428 feat(cleanup): host-side --cache / --state / --nuclear tier flags
+575af3b0 fix(kernel): allowImportFromDerivation = false (CI nix flake check)
+326ede3a feat(cache prune): --reap-orphans for orphaned mvmctl helpers (Plan 95 FU-1)
+6648f1b3 style(stage0): apply cargo fmt
+06773162 fix(builder-vm): relax rootfs_contains_builder_init to basename
+e0bd871d build(plan-95): bump /nix tmpfs cap 4G → 14G + VM RAM 8 → 16 GiB
+3a0b601c Revert "build(plan-95): bump DEFAULT_MEMORY_MIB 8 → 16 GiB for Stage 0 headroom"
+70fe10a5 build(plan-95): bump DEFAULT_MEMORY_MIB 8 → 16 GiB for Stage 0 headroom
+79e26c32 kernel(plan-95 W3): expand SoC disables + record orphan-process FUs
+c7d8855c stage0/init.sh: mount tmpfs over /nix before apk add (case-sensitivity fix)
+ba8c3c8e stage0/init.sh: export MVM_WORKSPACE_PATH=/work for the in-VM nix build
+aa5db0e8 stage0: replace nix-portable bootstrap with Alpine minirootfs (Plan 91 W1+W2)
+172c95f0 kernel(plan-95 W3): disable ARM64 SoC platform clusters
+4e7e9b2a kernel(plan-95 W2): expose generated .config as kernel-configfile flake output
+```
+
+**Tool Call: grep -l "/dev/fd|symlink.\*proc/self|dev.fd" /Users/auser/work/tinylabs/mvmco/mvm**
+Status: Completed
+
+No files found
+
+**Tool Call: grep -n "mkdir._/dev|ln._-s.*fd|ln.*proc/self/fd|/proc/self/fd" /Users/auser/work/tinylabs/mvmco/mvm/nix/lib/mk-guest.nix**
+Status: Completed
+
+No matches found
+
+**Tool Call: cat ~/.cache/mvm/builder-vm/jobs/1779426018614-7835/boot-timings.json**
+Status: Completed
+
+Terminal:
+
+```
+{"init_start_ms":0,"pseudofs_ready_ms":0,"nix_device_ready_ms":138,"nix_seeded_ms":null,"nix_mounted_ms":138,"nix_db_loaded_ms":185,"modules_ready_ms":1,"virtiofs_ready_ms":1,"network_ready_ms":163,"job_start_ms":187,"job_end_ms":115273,"poweroff_start_ms":125526}
+
+```
+
+## Assistant
+
+<thinking>
+
+</thinking>
+
+Worktree on stage0 has a related `/dev/null` fix. Let me check it briefly + confirm no one's fixing /dev/fd.
+
+**Tool Call: git show --stat 31a436dd 2>&1 | head -30**
+Status: Completed
+
+Terminal:
+
+````
+commit 31a436dde13fa2359ae25a808a39d280d8df51c2
+Author: Ari <me@ari.io>
+Date:   Thu May 21 22:41:28 2026 -0700
+
+    fix(stage0): surface real nix-build errors when /dev/null is missing
+
+    ## What happened (2026-05-21)
+
+    A `mvmctl dev up` smoke test against the just-merged PR #420 fix
+    stack failed with this on the Stage 0 console:
+
+    ```
+    stage0-init: nix build exited 1 (see /out/nix-stderr.log)
+    stage0-init: === nix-stderr.log tail (last 80 lines) ===
+    /init: line 156: can't create /dev/null: nonexistent directory
+    stage0-init: (could not read /out/nix-stderr.log)
+    stage0-init: === end nix-stderr.log ===
+    ```
+
+    The interesting part isn't `nix build exited 1` — it's that the
+    script's own error handler couldn't tell us *why*. The line at
+    `/init: line 156` is:
+
+    ```sh
+    tail -80 /out/nix-stderr.log >&2 2>/dev/null || echo "..." >&2
+    ```
+
+    busybox sh tried to open `/dev/null` for the redirect, got ENOENT,
+    and emitted "can't create /dev/null: nonexistent directory" (the
+    specific busybox-sh wording for ENOENT on a redirect target). The
+````
+
+**Tool Call: git branch --all --contains 31a436dd 2>&1 | head -10**
+Status: Completed
+
+Terminal:
+
+```
++ worktree-stage0-error-handler
+  remotes/origin/worktree-stage0-error-handler
+
+
+
+```
+
+**Tool Call: grep -n | head -20 "mount_pseudofs|mount_fs_idempotent" /Users/auser/work/tinylabs/mvmco/mvm/crates/mvm-builder-init/src/main.rs**
+Status: Completed
+
+283: /// by `mount_pseudofs` (mvmctl-init Stage 1), so `mkdir` there
+383: if let Err(e) = mount_pseudofs() {
+384: eprintln!("mvm-builder-init: mount_pseudofs failed: {e}");
+385: write_result(2, &format!("mount_pseudofs failed: {e}"));
+1363: fn mount_pseudofs() -> Result<(), String> {
+1369: mount_fs_idempotent("proc", "/proc", "proc")?;
+1370: mount_fs_idempotent("sysfs", "/sys", "sysfs")?;
+1371: mount_fs_idempotent("devtmpfs", "/dev", "devtmpfs")?;
+1372: mount_fs_idempotent("tmpfs", "/tmp", "tmpfs")?;
+1380: mount_fs_idempotent("tmpfs", "/run", "tmpfs")?;
+1388: mount_fs_idempotent("devpts", "/dev/pts", "devpts")?;
+1911: fn mount_fs_idempotent(source: &str, target: &str, fstype: &str) -> Result<(), String> {
+
+## Assistant
+
+<thinking>
+
+</thinking>
+
+Phase 1 (root cause investigation) complete. I have the smoking gun: `mount_pseudofs()` doesn't create `/dev/fd → /proc/self/fd`, and nixpkgs's `cargoInstallHook` uses bash process substitution. The design is straightforward enough to write directly without a Plan agent.
+
+**Tool Call: Write /Users/auser/.claude/plans/continue\-unblocking\-mvmctl\-dev\-agile\-rivest.md**
+Status: Completed
+
+Diff: /Users/auser/.claude/plans/continue-unblocking-mvmctl-dev-agile-rivest.md
+
+```
+# Plan — Unblock `mvmctl dev up` at the inner `nix build` layer
+
+## Context
+
+After PRs #418/#419/#420/#421 merged on `main` and PR #423 (`worktree-skip-addon-dns`,
+open) unblocks Stage 0 OOM, `mvmctl dev up` on aarch64-darwin walks all the way through
+Stage 0 → persistent builder VM boot → ext4 geometry recovery → nix DB load (185 ms) →
+network up via gvproxy (163 ms) → inner `nix build` dispatch — then fails after 115 s
+of compilation with `error: Cannot build '/nix/store/<hash>-mvm-guest-agent-0.14.0.drv'`.
+
+The user-visible host log only showed the cascading "Cannot build" messages, with no
+underlying reason. The actual stderr was already on the host filesystem the whole
+time: `/job` is mounted into the builder VM as a virtio-fs share, the cmd.sh
+template redirects `nix build`'s stderr to `/job/nix-stderr.log`, and that path is
+`~/.cache/mvm/builder-vm/jobs/<job_id>/nix-stderr.log` on the host
+(`crates/mvm-build/src/libkrun_builder.rs:404-405,428`). Reading it gives the
+real failure, repeated three times — once per parallel derivation:
+
+```
+
+mvm-builder-init> /nix/store/.../cargo-install-hook.sh/nix-support/setup-hook:
+line 27: /dev/fd/63: No such file or directory
+mvm-addon-dns> (same)
+mvm-guest-agent> (same)
+
+````
+
+Line 27 of nixpkgs's `cargo-install-hook.sh` is:
+
+```sh
+mapfile -t targets < <(find "$NIX_BUILD_TOP" -type d | grep "${tmpDir}$")
+````
+
+That is bash process substitution. For `<(...)` to work the shell opens
+`/dev/fd/N` against the subshell's pipe FD; that path only resolves when
+`/dev/fd` is a symlink to `/proc/self/fd` (the standard Linux convention,
+normally created by udev/mdev/systemd, never by `devtmpfs` itself).
+
+The builder VM's `mount_pseudofs()`
+(`crates/mvm-builder-init/src/main.rs:1363-1390`) mounts `/proc`, `/sys`,
+`/dev` (devtmpfs), `/tmp`, `/run`, `/dev/pts` — and stops there. It never
+creates `/dev/fd → /proc/self/fd`, so process substitution in every
+`cargoInstallHook` invocation fails with ENOENT on `/dev/fd/63`. Since
+`mvm-builder-init`, `mvm-addon-dns`, and `mvm-guest-agent` are all
+Rust derivations built by `rustPlatform.buildRustPackage`, **every** derivation in the
+dev image's closure trips the same hook, and the whole dev image build fails.
+
+Diagnostic gap: `BuilderVmError::NixBuildFailed`
+(`crates/mvm-build/src/libkrun_builder.rs:1214-1219`) only surfaces the
+20-line `result.stderr_tail` from `mvm-builder-init::run_job`, which captures
+the OUTER `cmd.sh`'s stderr — not the real `/job/nix-stderr.log`. That's why
+PR #423's author concluded the per-derivation log was "inside the VM's
+nix-store, can't be read from the host without mounting nix-store-aarch64.img".
+It is in fact already on the host; we just don't say so.
+
+## Approach
+
+Single small PR off `main` in a fresh worktree. Two changes plus tests:
+
+1. **Create `/dev/fd` (and `/dev/std{in,out,err}`) symlinks at boot** so bash
+   process substitution works inside the builder VM's nix-build environment.
+
+2. **Surface the host-side `nix-stderr.log` path on builder-VM build
+   failure**, so the next failure is one `cat` away — no debugger archaeology.
+
+Both changes are scoped to the BUILDER VM (`mvm-builder-init` PID 1) and the
+host-side error formatter (`mvm-build`). The user-facing dev image's own
+`mkGuest` /init is OUT OF SCOPE — if `mvmctl dev shell` later hits the same
+ENOENT once the build completes, that gets a separate trivial follow-up.
+
+PR #422 (fingerprint expansion) and PR #423 (skip-addon-dns) are
+independently mergeable; this PR conflicts with neither.
+
+## Files to modify
+
+### `crates/mvm-builder-init/src/main.rs`
+
+`mount_pseudofs()` at lines 1363-1390 — after the `devpts` mount, add a
+`setup_dev_fd_symlinks()` call that creates four symlinks under `/dev`:
+
+| symlink       | target            | why                                        |
+| ------------- | ----------------- | ------------------------------------------ |
+| `/dev/fd`     | `/proc/self/fd`   | bash `<(...)` opens `/dev/fd/N`. Required. |
+| `/dev/stdin`  | `/proc/self/fd/0` | conventional, used by some scripts.        |
+| `/dev/stdout` | `/proc/self/fd/1` | conventional.                              |
+| `/dev/stderr` | `/proc/self/fd/2` | conventional.                              |
+
+Implementation shape (extract a testable helper):
+
+```rust
+fn setup_dev_fd_symlinks(dev_root: &Path) -> Result<(), String> {
+    use std::os::unix::fs::symlink;
+    // Idempotent: skip the symlink if it already exists. devtmpfs's
+    // /dev/std{in,out,err} can appear as character devices on some
+    // kernels; we never replace a pre-existing entry.
+    for (link_name, target) in [
+        ("fd",     "/proc/self/fd"),
+        ("stdin",  "/proc/self/fd/0"),
+        ("stdout", "/proc/self/fd/1"),
+        ("stderr", "/proc/self/fd/2"),
+    ] {
+        let link = dev_root.join(link_name);
+        if link.exists() { continue; }
+        symlink(target, &link)
+            .map_err(|e| format!("symlink {} -> {target}: {e}", link.display()))?;
+    }
+    Ok(())
+}
+```
+
+Then in `mount_pseudofs()` after line 1388:
+
+```rust
+setup_dev_fd_symlinks(Path::new("/dev"))?;
+```
+
+### `crates/mvm-build/src/libkrun_builder.rs`
+
+`finalize_flake_job()` at lines 1208-1219 — on non-zero exit, read
+`<job_dir>/nix-stderr.log` (if it exists, bounded by size — say last 4 KiB)
+and include it in the `NixBuildFailed` message along with the file path:
+
+```rust
+if result.exit_code != 0 {
+    let stderr_path = job_dir.join("nix-stderr.log");
+    let derivation_tail = read_last_bytes_of(&stderr_path, 4 * 1024)
+        .unwrap_or_else(|_| String::from("<nix-stderr.log not present>"));
+    return Err(BuilderVmError::NixBuildFailed(format!(
+        "guest cmd.sh exited {} — host log: {}\n\
+         outer stderr tail:\n{}\n\
+         derivation stderr tail (last 4 KiB of {}):\n{}",
+        result.exit_code,
+        stderr_path.display(),
+        result.stderr_tail,
+        stderr_path.display(),
+        derivation_tail,
+    )));
+}
+```
+
+(Implementation note: keep `read_last_bytes_of` a small pure helper in
+the same file — opens the file, seeks `SeekFrom::End(-N.min(filesize))`,
+reads to end, returns `String::from_utf8_lossy(...).to_string()`. Don't
+load the whole 220 KB log into memory.)
+
+## Tests
+
+`crates/mvm-builder-init/src/main.rs` — under `#[cfg(test)] mod tests`:
+
+- `setup_dev_fd_symlinks_creates_all_four_in_empty_dir` — `tempdir()`, run
+  helper, assert each of `fd`, `stdin`, `stdout`, `stderr` is a symlink with
+  the expected target via `std::fs::read_link`.
+- `setup_dev_fd_symlinks_is_idempotent_when_already_present` — pre-create
+  one of the symlinks with a sentinel target, run helper, assert the
+  sentinel is preserved (we never clobber).
+- `setup_dev_fd_symlinks_errors_when_dev_root_missing` — pass a non-existent
+  path, assert a clean error message naming the missing parent.
+
+`crates/mvm-build/src/libkrun_builder.rs` — extend the existing
+`finalize_flake_job` tests (or add a sibling module if the helpers aren't
+currently tested):
+
+- `finalize_flake_job_includes_nix_stderr_log_path_and_tail_on_failure` —
+  stage a tempdir with a fake `result` (`exit_code: 1`, dummy
+  `stderr_tail`) and a `nix-stderr.log` containing a known string;
+  assert the returned `BuilderVmError::NixBuildFailed` message contains
+  the file path and the known string.
+- `finalize_flake_job_handles_missing_nix_stderr_log_cleanly` — same as
+  above without the log file; assert the message contains the path and
+  a `<not present>` sentinel rather than panicking.
+
+## Verification
+
+End-to-end on aarch64-darwin:
+
+1. `cargo test --workspace -- mount_pseudofs setup_dev_fd_symlinks finalize_flake_job`
+   → all new tests green.
+2. `cargo clippy --workspace -- -D warnings` → clean.
+3. `cargo fmt -- --check` → clean.
+4. `cargo build --workspace` → clean.
+5. **Invalidate rootfs cache** (PR #422 isn't merged yet, so the rootfs
+   fingerprint doesn't yet hash `crates/mvm-builder-init/src/main.rs`):
+   `rm -rf ~/.cache/mvm/builder-vm/aarch64/rootfs.ext4`
+6. `mvmctl dev up` → Stage 0 → persistent builder VM → inner nix build
+   completes → dev image lands → dev shell drops in. The 115-s
+   compilation now finishes successfully (`mvm-guest-agent`,
+   `mvm-builder-init`, `mvm-addon-dns` derivations all install
+   cleanly).
+7. On a subsequent intentional failure (e.g. break a flake input
+   temporarily), confirm the host-side error names
+   `~/.cache/mvm/builder-vm/jobs/<job_id>/nix-stderr.log` and shows
+   the last 4 KiB.
+
+## Out of scope (named explicitly)
+
+- The user-facing dev image's `mkGuest` initScript (`nix/lib/mk-guest.nix`).
+  It has its own `/dev` setup; if `mvmctl dev shell` later hits the same
+  process-substitution ENOENT, that's a one-line follow-up there. Don't
+  preempt — handle it if/when it surfaces.
+- Streaming per-derivation logs over vsock during the build (W2 part 4 /
+  W3 streaming path). The file-based path is sufficient once the host
+  message names the file.
+- PR #422 (`fingerprint-expansion`) is an independent dev-loop quality
+  improvement; merge order doesn't matter.
+- PR #423 (`skip-addon-dns`) is the predecessor that gets Stage 0 across
+  the line; merge order doesn't matter for this PR's logic, but #423
+  should land first to keep the smoke-test path uncluttered.
+- The `plan-92-stock-kernel` worktree (Plan 93/94 Alpine builder VM)
+  remains paused per the user memory; this fix is well inside the libkrun
+  builder VM approach and unaffected.
+
+## Key file locations (for executor convenience)
+
+- Builder VM init mount setup:
+  `crates/mvm-builder-init/src/main.rs:1363-1390` (`mount_pseudofs`)
+- Outer cmd.sh template that writes `nix-stderr.log`:
+  `crates/mvm-build/src/libkrun_builder.rs:1068-1183`
+- Host-side error formatter:
+  `crates/mvm-build/src/libkrun_builder.rs:1208-1219`
+  (`finalize_flake_job`)
+- Job dir location on host:
+  `crates/mvm-build/src/libkrun_builder.rs:404-405` (single-shot) and
+  `:657-658` (persistent) — both
+  `builder_vm_cache_dir().join("jobs").join(&job_id)`
+- Failure evidence used to confirm the diagnosis (this run):
+  `~/.cache/mvm/builder-vm/jobs/1779426018614-7835/nix-stderr.log`
+  lines 2479, 2699, 2711 — same `/dev/fd/63: No such file or directory`
+  error in `cargo-install-hook.sh` for all three derivations.
+
+```
+
+
+## Assistant
+
+<thinking>
+
+</thinking>
+
+Saving a brief diagnostic-path memory before exiting plan mode.
+
+**Tool Call: Write /Users/auser/.claude/projects/\-Users\-auser\-work\-tinylabs\-mvmco\-mvm/memory/reference\_builder\_vm\_nix\_stderr\_log.md**
+Status: Completed
+
+Diff: /Users/auser/.claude/projects/-Users-auser-work-tinylabs-mvmco-mvm/memory/reference_builder_vm_nix_stderr_log.md
+```
+
+---
+
+name: reference-builder-vm-nix-stderr-log
+description: Real per-derivation nix-build stderr from a failed mvmctl dev up is on the HOST filesystem at ~/.cache/mvm/builder-vm/jobs/<job_id>/nix-stderr.log
+metadata:
+type: reference
+
+---
+
+When `mvmctl dev up` fails at the inner `nix build` step with the unhelpful
+`error: Cannot build '/nix/store/<hash>-<pkg>.drv'. Reason: builder failed
+with exit code 1.` message, the **real** stderr (full 220 KB, every
+parallel derivation's compile output) is already on the host filesystem:
+
+```
+~/.cache/mvm/builder-vm/jobs/<timestamp-pid>/
+  ├── cmd.sh             # the script that ran inside the VM
+  ├── nix-stdout.log     # nix build stdout
+  ├── nix-stderr.log     # nix build stderr ← what you want
+  ├── result             # {exit_code, stderr_tail} JSON
+  └── boot-timings.json
+```
+
+Why: `/job` is a virtio-fs share from host → builder VM. The cmd.sh
+template (`crates/mvm-build/src/libkrun_builder.rs::stage_flake_job_dir`)
+redirects `nix build` stderr to `/job/nix-stderr.log` inside the VM,
+which is `<job_dir>/nix-stderr.log` on the host.
+
+Job dir = `builder_vm_cache_dir().join("jobs").join(&job_id)`, see
+`crates/mvm-build/src/libkrun_builder.rs:404-405` (single-shot) and
+`:657-658` (persistent).
+
+The VM's per-derivation `/nix/store/<hash>.drv.log` files exist too but
+need ext4 image mounting to read. **You almost never need them — the
+upstream cause is in `nix-stderr.log`.**
+
+This is also what the "single-shot path; W2 part 4 wired the host
+receiver" console.log warning is referring to — that vsock channel is
+the secondary streaming path, the file is the primary durable record.
+
+```
+
+
+**Tool Call: Edit /Users/auser/.claude/projects/\-Users\-auser\-work\-tinylabs\-mvmco\-mvm/memory/MEMORY.md**
+Status: Failed
+
+```
+
+<tool_use_error>File has not been read yet. Read it first before writing to it.</tool_use_error>
+
+```
+
+**Tool Call: ToolSearch**
+Status: Completed
+
+Tool: ExitPlanMode
+
+**Tool Call: Read /Users/auser/.claude/projects/-Users-auser-work-tinylabs-mvmco-mvm/memory/MEMORY.md**
+Status: Completed
+
+```
+
+1 - [Builder tools never live on the host](feedback_builder_tools_on_host.md) — nix/firecracker/flake checks must route through the builder VM; no host-side probe branches.
+2 - [Builder VM is a first-class mvm feature](feedback_builder_vm_is_core_feature.md) — bugs inside the builder VM are code defects in this repo, not the user's infra.
+3 - [mvmforge is being merged into mvm and deprecated](project_mvmforge_sibling_repo.md) — SDK ports into this repo; the cross-repo boundary in ADR-007/008/011 is abandoned.
+4 - [All SDK work lives in one crate called mvm-sdk](feedback_sdk_crate_layout.md) — nest IR, builder, compile, addon, decorator, runtime under crates/mvm-sdk; no split crates.
+5 - [Decorator compile does not run user code on the host](feedback_decorator_does_not_run_on_host.md) — `@mvm.app()` is parsed statically; user code only executes inside the microVM as its baked entrypoint.
+6 - [SDK Workload IR splits into mvm-side and mvmd-side fields](project_mvm_mvmd_split.md) — image/entrypoint/source/deps go to mvm; resources/network go to mvmd; `mvmctl deploy` ships both halves.
+7 - [Python SDK exposes only `mvm`; mvmd helpers live under `mvm`](feedback_single_python_surface.md) — user-facing import is `mvm` only; the IR split is internal.
+8 - [Invoke uses --input name=value; modes have --dev / --prod aliases](feedback_input_flag_and_mode_aliases.md) — function args via `--input`; verb defaults aliased as `--dev`/`--prod`.
+9 - [Application deps install inside a builder microVM into a hash-tagged volume](project_app_deps_via_volume.md) — pip/npm never runs on the host; lockfile-keyed cache; volume mounts RO at boot.
+10 - [Application dependency auditing — SBOM + fetch log + CVE + attestations](project_app_deps_audit_pipeline.md) — every deps volume carries an SBOM, fetch log, attestation set, CVE scan; all bound to the volume hash and admission audit chain (proposed claim 9).
+11 - [No backwards compatibility — this is the first version](feedback_no_backcompat_first_version.md) — hard renames; drop all shims, deprecation paths, alias layers, byte-identity corpora past the port itself.
+12 - [Lifecycle hooks use before*/after* names and stack from addons](feedback_lifecycle_hooks_naming_and_addon_hooks.md) — four hooks `before_build` / `before_start` / `after_start` / `before_stop`; addons carry their own hooks merged at compile time.
+13 - [Never mention smolvm in repo text files or content](feedback_no_smolvm_in_repo.md) — keep that name out of SPRINT.md, plans, ADRs, code comments, commit messages.
+14 - [Always work in a git worktree, never the main checkout](feedback_always_use_git_worktrees.md) — user runs parallel sessions; share `.git/` via worktrees so they don't race the index/stash.
+15 - [Replace a problematic dep, don't stack workarounds](feedback_replace_over_workaround.md) — when a third-party dep causes repeated friction, propose architectural replacement, not hack-stacks; vendoring as a bounded bridge is OK.
+16 - [Builder VM via libkrun shipped; microsandbox fully removed (commit b02a5e8)](project_builder_vm_being_replaced.md) — Plan 72 W0-W6 done; Stage 0 on macOS is Apple Container, on Linux is libkrun directly; microsandbox is gone.
+17 - [libkrun integration gotchas](reference_libkrun_gotchas.md) — Homebrew tap is `slp/krun`, cmdline must say `console=hvc0`, `add_vsock_port2(listen=true)` is the right vsock mode, `start_enter` calls `exit()` so one supervisor per VM, SIGTERM handling is brittle under `Command::spawn`. Saves an hour of re-discovery.
+18 - [microsandbox is GONE — Stage 0 is Apple Container (macOS) / libkrun](project_stage0_via_docker.md) — removed in commit b02a5e8; zero codebase hits; never reference it as current behavior.
+19 - [mvm-oci is OCI import/export, not the microsandbox replacement](project_mvm_oci_role.md) — Plan 75's prose can mislead; libkrun + other backends replace microsandbox; mvm-oci is the user-facing OCI ingest/export feature.
+20 - [Plan 72 W5.D end-to-end fix list](project_plan72_w5d_endtoend_fixes.md) — nine sequential bugs from kernel-panic to RAM cap that block `mvmctl dev up`; surface order matters, read `<vm_state_dir>/console.log` first.
+21 - [Spec numbering has no CI uniqueness gate](project_spec_numbering_chaos.md) — parallel-session PRs regularly land at duplicate plan/ADR numbers on `main`; check open PRs + main before claiming a slot, don't unilaterally renumber others' work.
+22 - [Lima is fully removed (2026-05-14)](project_lima_removed.md) — no `--lima` flag, no `vm/lima.rs`, no fallback; remaining `limactl` call sites in `lifecycle.rs`/`image.rs`/`linux_env.rs` docstrings are legacy debt to delete, not preserve.
+23 - [Dev builder VM ≠ prod runtime — different security tiers](feedback_dev_vm_vs_prod_security_tiers.md) — Stage 0 / `dev up` doesn't need hardened kernel/verified boot; security claims apply to workload microVMs + prod-deps builder mode.
+24 - [No prebuilt builder VM artifact, ever — until release](feedback_no_prebuilt_builder_vm_artifact.md) — builder VM image is local-build only on contributor hosts; `bootstrap_builder_vm_image` must not download, no artifact is published until a release is explicitly cut.
+25 - [Stage 0 audit emit + cache prune contract](project_stage0_audit_and_cache_prune_contract.md) — `stage0_*` events land in the shared local audit log (not a separate file), pre-`Stage0Boot` failures are not audited, `cache prune` respects the stage0 lock.
+26 - [Never propose external build-cache providers (Cachix, attic, etc.)](feedback_no_external_cache_providers.md) — hermetic builds; ADR-046 forbids prebuilt-dependence on the contributor path; supply-chain boundary.
+27 - [Check in-flight worktrees and PRs before diagnosing a failure](feedback_check_inflight_work_before_diagnosing.md) — parallel sessions are usually already on it; `git worktree list` + `gh pr list` first.
+28 - [Avoid force-push races with user-driven merges](feedback_avoid_force_push_race_with_merge.md) — re-check PR state right before force-push; user often clicks merge from the UI simultaneously, stranding pushed commits on a closed branch.
+29 - [ur-seed is a dead concept — treat as never-existed](feedback_ur_seed_is_dead.md) — never propose/document/reference; do not touch specs/adrs/054 or specs/plans/86; in-flight branches are deleting it from main.
+30
+
+```
+
+**Tool Call: Edit /Users/auser/.claude/projects/\-Users\-auser\-work\-tinylabs\-mvmco\-mvm/memory/MEMORY.md**
+Status: Completed
+
+Diff: /Users/auser/.claude/projects/-Users-auser-work-tinylabs-mvmco-mvm/memory/MEMORY.md
+```
+
+- [microsandbox is GONE — Stage 0 is Apple Container (macOS) / libkrun](project_stage0_via_docker.md) — removed in commit b02a5e8; zero codebase hits; never reference it as current behavior.
+- [mvm-oci is OCI import/export, not the microsandbox replacement](project_mvm_oci_role.md) — Plan 75's prose can mislead; libkrun + other backends replace microsandbox; mvm-oci is the user-facing OCI ingest/export feature.
+- [Plan 72 W5.D end-to-end fix list](project_plan72_w5d_endtoend_fixes.md) — nine sequential bugs from kernel-panic to RAM cap that block `mvmctl dev up`; surface order matters, read `<vm_state_dir>/console.log` first.
+- [Builder VM inner-build stderr is at ~/.cache/mvm/builder-vm/jobs/<id>/nix-stderr.log](reference_builder_vm_nix_stderr_log.md) — `/job` is a virtio-fs share, real per-derivation errors are on the host the whole time.
+- [Spec numbering has no CI uniqueness gate](project_spec_numbering_chaos.md) — parallel-session PRs regularly land at duplicate plan/ADR numbers on `main`; check open PRs + main before claiming a slot, don't unilaterally renumber others' work.
+- [Lima is fully removed (2026-05-14)](project_lima_removed.md) — no `--lima` flag, no `vm/lima.rs`, no fallback; remaining `limactl` call sites in `lifecycle.rs`/`image.rs`/`linux_env.rs` docstrings are legacy debt to delete, not preserve.
+- [Dev builder VM ≠ prod runtime — different security tiers](feedback_dev_vm_vs_prod_security_tiers.md) — Stage 0 / `dev up` doesn't need hardened kernel/verified boot; security claims apply to workload microVMs + prod-deps builder mode.
+
+```
+
+
+## Assistant
+
+Root cause found: the builder VM's `mount_pseudofs()` never creates `/dev/fd → /proc/self/fd`, so nixpkgs's `cargoInstallHook` line 27 (`mapfile -t targets < <(find ...)` — bash process substitution) fails with `/dev/fd/63: No such file or directory` for every Rust derivation in the dev-image closure. Confirmed in `~/.cache/mvm/builder-vm/jobs/1779426018614-7835/nix-stderr.log` lines 2479, 2699, 2711 (same error, three derivations).
+
+**Tool Call: Ready to code?**
+Status: Canceled
+
+# Plan — Unblock `mvmctl dev up` at the inner `nix build` layer
+
+## Context
+
+After PRs #418/#419/#420/#421 merged on `main` and PR #423 (`worktree-skip-addon-dns`,
+open) unblocks Stage 0 OOM, `mvmctl dev up` on aarch64-darwin walks all the way through
+Stage 0 → persistent builder VM boot → ext4 geometry recovery → nix DB load (185 ms) →
+network up via gvproxy (163 ms) → inner `nix build` dispatch — then fails after 115 s
+of compilation with `error: Cannot build '/nix/store/<hash>-mvm-guest-agent-0.14.0.drv'`.
+
+The user-visible host log only showed the cascading "Cannot build" messages, with no
+underlying reason. The actual stderr was already on the host filesystem the whole
+time: `/job` is mounted into the builder VM as a virtio-fs share, the cmd.sh
+template redirects `nix build`'s stderr to `/job/nix-stderr.log`, and that path is
+`~/.cache/mvm/builder-vm/jobs/<job_id>/nix-stderr.log` on the host
+(`crates/mvm-build/src/libkrun_builder.rs:404-405,428`). Reading it gives the
+real failure, repeated three times — once per parallel derivation:
+
+```
+
+mvm-builder-init> /nix/store/.../cargo-install-hook.sh/nix-support/setup-hook:
+line 27: /dev/fd/63: No such file or directory
+mvm-addon-dns> (same)
+mvm-guest-agent> (same)
+
+````
+
+Line 27 of nixpkgs's `cargo-install-hook.sh` is:
+
+```sh
+mapfile -t targets < <(find "$NIX_BUILD_TOP" -type d | grep "${tmpDir}$")
+````
+
+That is bash process substitution. For `<(...)` to work the shell opens
+`/dev/fd/N` against the subshell's pipe FD; that path only resolves when
+`/dev/fd` is a symlink to `/proc/self/fd` (the standard Linux convention,
+normally created by udev/mdev/systemd, never by `devtmpfs` itself).
+
+The builder VM's `mount_pseudofs()`
+(`crates/mvm-builder-init/src/main.rs:1363-1390`) mounts `/proc`, `/sys`,
+`/dev` (devtmpfs), `/tmp`, `/run`, `/dev/pts` — and stops there. It never
+creates `/dev/fd → /proc/self/fd`, so process substitution in every
+`cargoInstallHook` invocation fails with ENOENT on `/dev/fd/63`. Since
+`mvm-builder-init`, `mvm-addon-dns`, and `mvm-guest-agent` are all
+Rust derivations built by `rustPlatform.buildRustPackage`, **every** derivation in the
+dev image's closure trips the same hook, and the whole dev image build fails.
+
+Diagnostic gap: `BuilderVmError::NixBuildFailed`
+(`crates/mvm-build/src/libkrun_builder.rs:1214-1219`) only surfaces the
+20-line `result.stderr_tail` from `mvm-builder-init::run_job`, which captures
+the OUTER `cmd.sh`'s stderr — not the real `/job/nix-stderr.log`. That's why
+PR #423's author concluded the per-derivation log was "inside the VM's
+nix-store, can't be read from the host without mounting nix-store-aarch64.img".
+It is in fact already on the host; we just don't say so.
+
+## Approach
+
+Single small PR off `main` in a fresh worktree. Two changes plus tests:
+
+1. **Create `/dev/fd` (and `/dev/std{in,out,err}`) symlinks at boot** so bash
+   process substitution works inside the builder VM's nix-build environment.
+
+2. **Surface the host-side `nix-stderr.log` path on builder-VM build
+   failure**, so the next failure is one `cat` away — no debugger archaeology.
+
+Both changes are scoped to the BUILDER VM (`mvm-builder-init` PID 1) and the
+host-side error formatter (`mvm-build`). The user-facing dev image's own
+`mkGuest` /init is OUT OF SCOPE — if `mvmctl dev shell` later hits the same
+ENOENT once the build completes, that gets a separate trivial follow-up.
+
+PR #422 (fingerprint expansion) and PR #423 (skip-addon-dns) are
+independently mergeable; this PR conflicts with neither.
+
+## Files to modify
+
+### `crates/mvm-builder-init/src/main.rs`
+
+`mount_pseudofs()` at lines 1363-1390 — after the `devpts` mount, add a
+`setup_dev_fd_symlinks()` call that creates four symlinks under `/dev`:
+
+| symlink       | target            | why                                        |
+| ------------- | ----------------- | ------------------------------------------ |
+| `/dev/fd`     | `/proc/self/fd`   | bash `<(...)` opens `/dev/fd/N`. Required. |
+| `/dev/stdin`  | `/proc/self/fd/0` | conventional, used by some scripts.        |
+| `/dev/stdout` | `/proc/self/fd/1` | conventional.                              |
+| `/dev/stderr` | `/proc/self/fd/2` | conventional.                              |
+
+Implementation shape (extract a testable helper):
+
+```rust
+fn setup_dev_fd_symlinks(dev_root: &Path) -> Result<(), String> {
+    use std::os::unix::fs::symlink;
+    // Idempotent: skip the symlink if it already exists. devtmpfs's
+    // /dev/std{in,out,err} can appear as character devices on some
+    // kernels; we never replace a pre-existing entry.
+    for (link_name, target) in [
+        ("fd",     "/proc/self/fd"),
+        ("stdin",  "/proc/self/fd/0"),
+        ("stdout", "/proc/self/fd/1"),
+        ("stderr", "/proc/self/fd/2"),
+    ] {
+        let link = dev_root.join(link_name);
+        if link.exists() { continue; }
+        symlink(target, &link)
+            .map_err(|e| format!("symlink {} -> {target}: {e}", link.display()))?;
+    }
+    Ok(())
+}
+```
+
+Then in `mount_pseudofs()` after line 1388:
+
+```rust
+setup_dev_fd_symlinks(Path::new("/dev"))?;
+```
+
+### `crates/mvm-build/src/libkrun_builder.rs`
+
+`finalize_flake_job()` at lines 1208-1219 — on non-zero exit, read
+`<job_dir>/nix-stderr.log` (if it exists, bounded by size — say last 4 KiB)
+and include it in the `NixBuildFailed` message along with the file path:
+
+```rust
+if result.exit_code != 0 {
+    let stderr_path = job_dir.join("nix-stderr.log");
+    let derivation_tail = read_last_bytes_of(&stderr_path, 4 * 1024)
+        .unwrap_or_else(|_| String::from("<nix-stderr.log not present>"));
+    return Err(BuilderVmError::NixBuildFailed(format!(
+        "guest cmd.sh exited {} — host log: {}\n\
+         outer stderr tail:\n{}\n\
+         derivation stderr tail (last 4 KiB of {}):\n{}",
+        result.exit_code,
+        stderr_path.display(),
+        result.stderr_tail,
+        stderr_path.display(),
+        derivation_tail,
+    )));
+}
+```
+
+(Implementation note: keep `read_last_bytes_of` a small pure helper in
+the same file — opens the file, seeks `SeekFrom::End(-N.min(filesize))`,
+reads to end, returns `String::from_utf8_lossy(...).to_string()`. Don't
+load the whole 220 KB log into memory.)
+
+## Tests
+
+`crates/mvm-builder-init/src/main.rs` — under `#[cfg(test)] mod tests`:
+
+- `setup_dev_fd_symlinks_creates_all_four_in_empty_dir` — `tempdir()`, run
+  helper, assert each of `fd`, `stdin`, `stdout`, `stderr` is a symlink with
+  the expected target via `std::fs::read_link`.
+- `setup_dev_fd_symlinks_is_idempotent_when_already_present` — pre-create
+  one of the symlinks with a sentinel target, run helper, assert the
+  sentinel is preserved (we never clobber).
+- `setup_dev_fd_symlinks_errors_when_dev_root_missing` — pass a non-existent
+  path, assert a clean error message naming the missing parent.
+
+`crates/mvm-build/src/libkrun_builder.rs` — extend the existing
+`finalize_flake_job` tests (or add a sibling module if the helpers aren't
+currently tested):
+
+- `finalize_flake_job_includes_nix_stderr_log_path_and_tail_on_failure` —
+  stage a tempdir with a fake `result` (`exit_code: 1`, dummy
+  `stderr_tail`) and a `nix-stderr.log` containing a known string;
+  assert the returned `BuilderVmError::NixBuildFailed` message contains
+  the file path and the known string.
+- `finalize_flake_job_handles_missing_nix_stderr_log_cleanly` — same as
+  above without the log file; assert the message contains the path and
+  a `<not present>` sentinel rather than panicking.
+
+## Verification
+
+End-to-end on aarch64-darwin:
+
+1. `cargo test --workspace -- mount_pseudofs setup_dev_fd_symlinks finalize_flake_job`
+   → all new tests green.
+2. `cargo clippy --workspace -- -D warnings` → clean.
+3. `cargo fmt -- --check` → clean.
+4. `cargo build --workspace` → clean.
+5. **Invalidate rootfs cache** (PR #422 isn't merged yet, so the rootfs
+   fingerprint doesn't yet hash `crates/mvm-builder-init/src/main.rs`):
+   `rm -rf ~/.cache/mvm/builder-vm/aarch64/rootfs.ext4`
+6. `mvmctl dev up` → Stage 0 → persistent builder VM → inner nix build
+   completes → dev image lands → dev shell drops in. The 115-s
+   compilation now finishes successfully (`mvm-guest-agent`,
+   `mvm-builder-init`, `mvm-addon-dns` derivations all install
+   cleanly).
+7. On a subsequent intentional failure (e.g. break a flake input
+   temporarily), confirm the host-side error names
+   `~/.cache/mvm/builder-vm/jobs/<job_id>/nix-stderr.log` and shows
+   the last 4 KiB.
+
+## Out of scope (named explicitly)
+
+- The user-facing dev image's `mkGuest` initScript (`nix/lib/mk-guest.nix`).
+  It has its own `/dev` setup; if `mvmctl dev shell` later hits the same
+  process-substitution ENOENT, that's a one-line follow-up there. Don't
+  preempt — handle it if/when it surfaces.
+- Streaming per-derivation logs over vsock during the build (W2 part 4 /
+  W3 streaming path). The file-based path is sufficient once the host
+  message names the file.
+- PR #422 (`fingerprint-expansion`) is an independent dev-loop quality
+  improvement; merge order doesn't matter.
+- PR #423 (`skip-addon-dns`) is the predecessor that gets Stage 0 across
+  the line; merge order doesn't matter for this PR's logic, but #423
+  should land first to keep the smoke-test path uncluttered.
+- The `plan-92-stock-kernel` worktree (Plan 93/94 Alpine builder VM)
+  remains paused per the user memory; this fix is well inside the libkrun
+  builder VM approach and unaffected.
+
+## Key file locations (for executor convenience)
+
+- Builder VM init mount setup:
+  `crates/mvm-builder-init/src/main.rs:1363-1390` (`mount_pseudofs`)
+- Outer cmd.sh template that writes `nix-stderr.log`:
+  `crates/mvm-build/src/libkrun_builder.rs:1068-1183`
+- Host-side error formatter:
+  `crates/mvm-build/src/libkrun_builder.rs:1208-1219`
+  (`finalize_flake_job`)
+- Job dir location on host:
+  `crates/mvm-build/src/libkrun_builder.rs:404-405` (single-shot) and
+  `:657-658` (persistent) — both
+  `builder_vm_cache_dir().join("jobs").join(&job_id)`
+- Failure evidence used to confirm the diagnosis (this run):
+  `~/.cache/mvm/builder-vm/jobs/1779426018614-7835/nix-stderr.log`
+  lines 2479, 2699, 2711 — same `/dev/fd/63: No such file or directory`
+  error in `cargo-install-hook.sh` for all three derivations.
+
+## User
+
+Are there security items we should consider here? Why do we have this? Are there other items we should consider?
+
+Your out of scope:
+
+1. What is the deal here? What do you recommend?
+2. Oh should we consider streaming per-derivation log? What do we need to support that? Is it important?
+3. -- what do we do here?
+4. Can you merge this PR?
+5. What do we need to do here?
+
+## Assistant
+
+<thinking>
+
+</thinking>
+
+Good questions — let me work through each.
+
+## Security considerations
+
+The `/dev/fd → /proc/self/fd` symlink is **not** a new attack surface. `/proc/self/fd` is per-process: each process sees only its own FDs. The symlink in `/dev` is just a name; what it resolves to is determined by the resolving process's PID at lookup time, which is the build itself.
+
+What _is_ worth noting:
+
+- **The failing path is the persistent builder VM's dispatch loop**, which uses `Isolation::Unshared` + `setpriv --reuid=902 --regid=902 --clear-groups --bounding-set=-all --no-new-privs` (`crates/mvm-builder-init/src/main.rs:1752-1769`). The build runs as uid 902 in fresh pid/mount/ipc namespaces. /dev/fd doesn't change that posture.
+- **Single-shot path runs as uid 0** (`Isolation::Inherit`) because the whole VM tears down after one job. Pre-existing — the comment at line 1656-1666 owns it. Not made worse by /dev/fd.
+- **Security claim 1** ("no host-fs access beyond explicit shares") is preserved: /proc/self/fd points at the guest's own FDs, never host FDs.
+
+**Why we have this gap at all:** the builder VM rootfs is busybox + devtmpfs with no udev/mdev/systemd. devtmpfs creates device _nodes_ (vda, vdb, tty0, …) but never creates the conventional symlinks. Normal Linux distros run udev or systemd-tmpfiles after devtmpfs to add `/dev/fd`, `/dev/std{in,out,err}`, `/dev/shm`, `/dev/core`, etc. We don't.
+
+**Other items worth considering:**
+
+- **`/dev/shm`** — some build hooks use POSIX shared memory; we don't have it, but nothing's hit that yet.
+- **`/dev/core` → `/proc/kcore`** — for core-dump tooling. Not needed.
+- **`mvm-guest`'s `setpriv` path doesn't have a `/etc/passwd` entry for uid 902** (`main.rs:1709-1716` documents this). NSS lookups fail. We've accepted that.
+- **Audit emit:** does this builder VM's failure get audited? The `mvm-supervisor` audit chain (claim 8) applies to workload-microVM admission, not builder-VM dispatch. Builder-VM failures are dev diagnostics — no audit obligation.
+
+## Answering each "out of scope" question
+
+**1. mkGuest /init lacks the same symlinks — what's the deal?**
+
+The same `/dev/fd` gap exists in the user-facing dev image. Once we land this fix and `mvmctl dev up` builds the dev image successfully, `mvmctl dev shell` boots it via mkGuest's initScript (`nix/lib/mk-guest.nix:600-632`). That initScript does its own /dev setup and (grep confirms) has zero `/proc/self/fd` references. So the very next interactive operation that uses process substitution inside the dev shell will fail.
+
+**Recommendation: fix both in this PR.** It's identical intent in two places — mvm-builder-init.rs and mk-guest.nix's initScript. Pulling them apart into separate PRs invites drift. Different from my plan's "out of scope" — I'd revise that.
+
+**2. Streaming per-derivation logs — important?**
+
+**Not important.** The file-based path is already on the host as the build runs (`/job` is virtio-fs, writes land on host immediately). A `tail -f ~/.cache/mvm/builder-vm/jobs/<id>/nix-stderr.log` from a second terminal works _today_ with zero new infra. The only gap is that the host CLI doesn't tell users where to tail.
+
+Cheaper fix: have `mvmctl dev up` print the job_dir path at dispatch time (one tracing::info call near `libkrun_builder.rs:404-405`). Saves the streaming protocol design entirely. Don't build streaming.
+
+**3. PRs #422 / #423 — what do we do?**
+
+Recommend landing in this order:
+
+1. **#423 first** (skip-addon-dns) — gets Stage 0 across the line. Without it, we can't even test this PR.
+2. **#422 next** (fingerprint expansion) — makes mvm-builder-init edits actually re-roll the rootfs cache. Without it, this PR's testers will burn 8-min Stage 0 cycles each time they hit the cache.
+3. **This PR** rebased off main with both above merged.
+
+Independent of correctness, this is iteration-speed ordering.
+
+**4. Can I merge #423?**
+
+Technically yes (`gh pr merge 423 --squash`). I shouldn't without you confirming explicitly — merging is shared-state. If you want me to: I'll first check CI green on #423, then squash-merge. Say the word.
+
+**5. `plan-92-stock-kernel` worktree — what to do?**
+
+Memory says "held with Plan 93/94 WIP, don't pursue yet, PR #420 made it likely unnecessary." Since #420 shipped and the libkrun path is reaching the dispatch layer, that worktree's premise is weakening — but it's not actively wrong. I'd **leave it parked** until we either (a) merge this PR and confirm dev up completes end-to-end, at which point it can be deleted, or (b) hit a fresh libkrun-specific blocker, at which point Alpine becomes a real fallback again. No action right now.
+
+---
+
+Want me to revise the plan to fold mkGuest's initScript fix in, and add the "print job_dir on dispatch" line? Also happy to check #423's CI and merge it if you give the go-ahead.
+
+## User
+
+What do you think? What do you recommend?
+
+## Assistant
+
+<thinking>
+
+</thinking>
+
+User asked clarifying questions I answered; their next move is pending. In plan mode + waiting on the merge-authorization and scope-revision question, so I can't act on the irreversible items. I can do read-only prep so I'm ready when they respond.
+
+**Tool Call: gh pr view 423 --json mergeable,mergeStateStatus,statusCheckRollup --jq '{mergeable, mergeStateStatus, checks: [.statusCheckRollup[] | {name, conclusion, status}] | unique}' 2>&1 | head -60**
+Status: Failed
+
+```
+Tool permission request failed: Error: Internal error
+```
+
+**Tool Call: gh pr view 422 --json mergeable,mergeStateStatus,statusCheckRollup --jq '{mergeable, mergeStateStatus, checks: [.statusCheckRollup[] | {name, conclusion, status}] | unique}' 2>&1 | head -60**
+Status: Failed
+
+```
+<tool_use_error>Cancelled: parallel tool call Bash(gh pr view 423 --json mergeable,mergeSta…) errored</tool_use_error>
+```
+
+**Tool Call: grep -n | head -50 "initScript|/init\b|mount._-t|mkdir._-p.\*/dev|/dev/pts|/dev/null|/dev/fd" /Users/auser/work/tinylabs/mvmco/mvm/nix/lib/mk-guest.nix**
+Status: Failed
+
+```
+<tool_use_error>Cancelled: parallel tool call Bash(gh pr view 423 --json mergeable,mergeSta…) errored</tool_use_error>
+```
+
+## Assistant
+
+<thinking>
+
+</thinking>
+
+Tool call hit an internal error and cancelled the batch. Retrying serially with just the local read.
+
+**Tool Call: grep -n | head -60 "initScript|/init\b|mount._-t|mkdir._-p.\*/dev|/dev/pts|/dev/null|/dev/fd" /Users/auser/work/tinylabs/mvmco/mvm/nix/lib/mk-guest.nix**
+Status: Completed
+
+42: # `pkgsStatic` ensures no glibc dynamic-linker hop at /init time
+82:# tree (`/lib/modules/<kver>/`) into the rootfs and `/init` runs
+126: # /init activates it only when a zone file is present, so a guest
+175: # /init at stage 2.5 before the guest agent ever forks. The
+211: # /init — our PID 1. Pure POSIX shell; busybox provides every
+223: initScript = pkgs.writeScript "mvm-init" ''
+225: # mvm /init — busybox PID 1 (plan 60 / ADR-013).
+229: /bin/busybox mount -t proc proc /proc
+230: /bin/busybox mount -t sysfs sysfs /sys
+231: /bin/busybox mount -t devtmpfs devtmpfs /dev
+236: /bin/busybox mount -t tmpfs -o mode=1777,nosuid,nodev tmpfs /tmp
+237: /bin/busybox mount -t tmpfs -o mode=0755,nosuid,nodev tmpfs /run
+248: /bin/busybox modprobe vmw_vsock_virtio_transport 2>/dev/null || true
+387: /bin/busybox hostname "$(/bin/busybox cat /etc/mvm/name 2>/dev/null || echo mvm)"
+432:  # Render the entrypoint as a shell-sourced fragment. /init does
+479:  # guest at boot. Run as root from `/init` BEFORE the agent forks
+486:  # the pre-rewrite upstream resolver snapshot. Activated by /init
+544:  # /init script touches resolves through /bin/* symlinks pointing
+568:    # directory is empty — /init below falls back to the baked-in
+583:    # /sbin/init is what the kernel actually execs at boot (when
+584:    # there's no init=/init kernel param). We point both at our
+586:    cp ${initScript} "$out/init"
+587: chmod 0500 "$out/init"
+588:    ln -sf /init "$out/sbin/init"
+591: # /init sources it. Mode 0500 so non-root processes in the guest
+650: # mvm-guest-agent — installed under /usr/local/bin so /init can
+665: # agent (0555: read+exec, not writable). /init runs this as
+673: # In-guest addon DNS resolver. Baked into every rootfs so /init
+675: # gated at boot on the presence of a zone file (see initScript).
+679: # Kernel modules. `/init` `modprobe`s vsock before forking the
+813: # every backend. Custom /init + trimmed kernel + direct vmlinux
+833: # bind-mount target and the /init script prefers the overlay
+
+## Assistant
+
+<thinking>
+
+</thinking>
+
+**Tool Call: Read nix/lib/mk-guest.nix (223 - 297)**
+Status: Completed
+
+```
+223	  initScript = pkgs.writeScript "mvm-init" ''
+224	    #!/bin/sh
+225	    # mvm /init — busybox PID 1 (plan 60 / ADR-013).
+226
+227	    # Stage 1 — kernel pseudofs. Required before anything else
+228	    # can read /proc/self or write to /dev/console.
+229	    /bin/busybox mount -t proc     proc     /proc
+230	    /bin/busybox mount -t sysfs    sysfs    /sys
+231	    /bin/busybox mount -t devtmpfs devtmpfs /dev
+232
+233	    # Stage 2 — runtime tmpfs. /tmp + /run are RAM so the rootfs
+234	    # stays read-only-leaning; volumes (Phase 2) attach to fixed
+235	    # mountpoints instead.
+236	    /bin/busybox mount -t tmpfs -o mode=1777,nosuid,nodev tmpfs /tmp
+237	    /bin/busybox mount -t tmpfs -o mode=0755,nosuid,nodev tmpfs /run
+238
+239	    # Stage 2.25 — vsock kernel modules. Stock nixpkgs kernel ships
+240	    # AF_VSOCK as `=m`; without modprobe the agent's
+241	    # `socket(AF_VSOCK, …)` returns EAFNOSUPPORT. modprobe-ing
+242	    # `vmw_vsock_virtio_transport` pulls in `vsock` +
+243	    # `vmw_vsock_virtio_transport_common` via modules.dep. Silently
+244	    # skipped when `/lib/modules` is absent — e.g. on a future kernel
+245	    # that ships VSOCK=y, or when `mkGuest` was called without the
+246	    # `kernel` argument.
+247	    if [ -d /lib/modules ]; then
+248	      /bin/busybox modprobe vmw_vsock_virtio_transport 2>/dev/null || true
+249	    fi
+250
+251	    # Stage 2.45 — Plan 74 W2 — guest-side network defense.
+252	    # Install kernel blackhole routes for `MANDATORY_DENY_RANGES`
+253	    # (cloud metadata, link-local, CGNAT, host loopback) BEFORE
+254	    # any workload code runs. We're still uid 0 here — the agent
+255	    # fork below drops to uid 901, which doesn't have
+256	    # CAP_NET_ADMIN, so the install has to happen here. Mirrors
+257	    # the agent-bin resolution: prefer /mvm/runtime/netinit (from
+258	    # the W1.4b runtime overlay) over the baked-in copy in
+259	    # /usr/local/bin.
+260	    #
+261	    # Output of mvm-guest-netinit is a single JSON line that the
+262	    # kernel console captures; the host scrape (firecracker.log /
+263	    # libkrun console output) forwards it so an operator can see
+264	    # what was installed. A future slice wires the agent to
+265	    # forward the same JSON as a `NetworkMandatoryDeny` audit
+266	    # event over vsock.
+267	    #
+268	    # On netinit failure (exit nonzero) we DO NOT abort the boot
+269	    # — the host-side iptables defense (where it applies) is the
+270	    # primary layer, and a hard guest-side fail-closed would
+271	    # block any workload on a kernel without rtnetlink. Log the
+272	    # failure and continue; an operator who needs guest-side
+273	    # defense flagged the issue from the JSON line.
+274	    MVM_NETINIT_BIN=
+275	    if [ -x /mvm/runtime/netinit ]; then
+276	      MVM_NETINIT_BIN=/mvm/runtime/netinit
+277	    elif [ -x /usr/local/bin/mvm-guest-netinit ]; then
+278	      MVM_NETINIT_BIN=/usr/local/bin/mvm-guest-netinit
+279	    fi
+280	    if [ -n "$MVM_NETINIT_BIN" ]; then
+281	      "$MVM_NETINIT_BIN" || echo "mvm-init: netinit exited nonzero; continuing without guest-side defense"
+282	    fi
+283
+284	    # Stage 2.48 — local addon DNS bootstrap.
+285	    #
+286	    # The "always-install + no-op when zone empty" pattern from
+287	    # `specs/contracts/local-addon-dns.md`: the addon DNS binary is
+288	    # baked into every rootfs but only activated when a zone file
+289	    # was baked at /etc/mvm/addon_dns_zone.json (via mkGuest's
+290	    # `extraFiles`) or staged on the config-disk path before init
+291	    # runs. Guests without addons skip this block entirely, so
+292	    # /etc/resolv.conf stays byte-for-byte the build-time default.
+293	    #
+294	    # When activated, we:
+295	    #   1. Copy the zone file into /run/mvm so reloads (SIGHUP) and
+296	    #      runtime-only edits land on tmpfs, not in the read-only
+297	    #      rootfs.
+```
+
+## Assistant
+
+<thinking>
+
+</thinking>
+
+Confirmed: mkGuest's initScript (`nix/lib/mk-guest.nix:223-237`) mounts the same minimal /proc + /sys + devtmpfs + /tmp + /run set with no `/dev/fd` symlink — identical gap to `mvm-builder-init::mount_pseudofs`. So the "fold both into one PR" recommendation from my prior message stands.
+
+Three of my questions to the user are still open (mkGuest scope, print-job_dir line, merge #423), and they're all irreversible-ish — plan revision is mid-flight, and merging needs explicit go-ahead. Waiting per the loop's "irreversible → don't act" rule.
+
+**Tool Call: ScheduleWakeup**
+Status: Completed
+
+Next wakeup scheduled for 23:46:00 (in 1804s). Nothing more to do this turn — the harness re-invokes you when the wakeup fires or a task-notification arrives.
+
+## Assistant
+
+<thinking>
+
+</thinking>
+
+Here's my recommendation in priority order:
+
+**Fold both /dev/fd fixes into one PR.** mkGuest's initScript (`nix/lib/mk-guest.nix:229-237`) has identical gap to `mvm-builder-init::mount_pseudofs`. Different layer, same bug, same diff intent. Splitting invites drift; the combined PR is still small (~10 LOC of new code + a shared helper or duplicated 4-line block + 4 tests). Update the plan's "out of scope" to "in scope (parallel fix)."
+
+**Add the `job_dir` print on dispatch.** One `tracing::info!` near `libkrun_builder.rs:404-405` saying `"builder VM job dir: {path} (nix-stderr.log lands here as the build runs)"`. Costs nothing, kills the "log is inside the VM" misconception that already burned PR #423's author.
+
+**Merge order: #423 → #422 → this PR.** #423 is the immediate unblocker for Stage 0; #422 ensures the next mvm-builder-init iteration doesn't silently reuse a stale rootfs. This PR rebases off main with both above.
+
+**Skip vsock streaming.** File-based path is durable, already on host, virtio-fs writes land instantly. `tail -f` from a second terminal works today. Streaming infra would be ceremony for the same outcome.
+
+**Leave `plan-92-stock-kernel` parked.** If this PR lands and `mvmctl dev up` completes end-to-end, delete the worktree then. Don't delete prematurely.
+
+**Security:** no real concerns. `/dev/fd → /proc/self/fd` is process-scoped, doesn't expose host fs, doesn't change uid posture. Worth one sentence in the PR description noting the symlink semantics so reviewers don't pattern-match it to a vulnerability shape.
+
+**My ask for authorization:**
+
+1. **Update the plan file** to fold mkGuest + the job_dir print line in? (My call, but you're driving — just say yes and I'll revise.)
+2. **Merge #423?** I'll check CI green first and squash-merge. Need an explicit "yes, merge it."
+3. **After plan-revise + #423 merge, exit plan mode and start the worktree?** Or do you want to review the revised plan first?
+
+## User
+
+1. Yes please do
+2. Yes, please mergit it
+3. I want you to start the worktree and go forward with this plan
+
+## Assistant
+
+<thinking>
+
+</thinking>
+
+Updating the plan, then merging #423, then creating the worktree.
+
+**Tool Call: Edit /Users/auser/.claude/plans/continue\-unblocking\-mvmctl\-dev\-agile\-rivest.md**
+Status: Completed
+
+Diff: /Users/auser/.claude/plans/continue-unblocking-mvmctl-dev-agile-rivest.md
+
+```
+
+## Approach
+
+Single small PR off `main` (rebased onto #423 once that lands). Four changes
+plus tests:
+
+1. **Create `/dev/fd` (and `/dev/std{in,out,err}`) symlinks at boot** in the
+   **builder VM** so bash process substitution works inside the nix-build
+   environment. (`crates/mvm-builder-init/src/main.rs::mount_pseudofs`)
+
+2. **Same symlinks in the user-facing dev image's `mkGuest` initScript** —
+   identical gap (`nix/lib/mk-guest.nix:229-237` does an equivalent minimal
+   /proc + /sys + devtmpfs mount and never creates the symlinks). Folding
+   this in keeps the two surfaces from drifting; the next user who runs
+   `mvmctl dev shell` and uses process substitution in their shell will hit
+   the same ENOENT we're fixing in the builder.
+
+3. **Surface the host-side `nix-stderr.log` path on builder-VM build
+   failure** so the next failure is one `cat` away — no debugger
+   archaeology. (`crates/mvm-build/src/libkrun_builder.rs::finalize_flake_job`)
+
+4. **Print the job dir at dispatch time** — one `tracing::info!` near the
+   `stage_*_job_dir(&job_dir, …)` call so users can `tail -f` the log while
+   the build runs. Costs nothing, kills the "log is inside the VM, can't
+   reach it" misconception. (`crates/mvm-build/src/libkrun_builder.rs:404`
+   and `:657`)
+
+PR #422 (fingerprint expansion) and PR #423 (skip-addon-dns) are
+independently mergeable; this PR conflicts with neither. Merge order:
+#423 → #422 → this PR.
+
+## Files to modify
+
+```
+
+**Tool Call: Edit /Users/auser/.claude/plans/continue\-unblocking\-mvmctl\-dev\-agile\-rivest.md**
+Status: Completed
+
+Diff: /Users/auser/.claude/plans/continue-unblocking-mvmctl-dev-agile-rivest.md
+
+```
+setup_dev_fd_symlinks(Path::new("/dev"))?;
+```
+
+### `nix/lib/mk-guest.nix`
+
+`initScript` at lines 223-237 — after the existing devtmpfs mount at line 231,
+inline the same four symlinks. Pure busybox-sh, idempotent via `-e` test:
+
+```sh
+# /dev/fd → /proc/self/fd is what bash process substitution needs
+# (`< <(...)` opens /dev/fd/N). devtmpfs doesn't create it; udev/mdev
+# normally do. Without it nixpkgs build hooks (and any user-script
+# using <(...)) fail with "/dev/fd/N: No such file or directory".
+[ -e /dev/fd ]     || /bin/busybox ln -s /proc/self/fd   /dev/fd
+[ -e /dev/stdin ]  || /bin/busybox ln -s /proc/self/fd/0 /dev/stdin
+[ -e /dev/stdout ] || /bin/busybox ln -s /proc/self/fd/1 /dev/stdout
+[ -e /dev/stderr ] || /bin/busybox ln -s /proc/self/fd/2 /dev/stderr
+```
+
+No new test framework — covered by the existing `nix flake check` and the
+end-to-end `mvmctl dev up` smoke. The shell logic is small enough to
+review by inspection.
+
+### `crates/mvm-build/src/libkrun_builder.rs`
+
+**Two edits.**
+
+**(a) Print the job dir at dispatch.** Near the existing `stage_flake_job_dir`
+call at line 405 (single-shot) and `stage_job_dir` at line 658 (persistent),
+emit one info-level trace:
+
+```rust
+tracing::info!(
+    job_dir = %job_dir.display(),
+    "builder VM job dir staged (nix-stderr.log streams here as the build runs)"
+);
+```
+
+**(b) Surface `nix-stderr.log` path + tail on failure.** `finalize_flake_job()`
+at lines 1208-1219 — on non-zero exit, read `<job_dir>/nix-stderr.log` (if
+it exists, bounded by size — say last 4 KiB) and include it in the
+`NixBuildFailed` message along with the file path:
+
+```rust
+if result.exit_code != 0 {
+    let stderr_path = job_dir.join("nix-stderr.log");
+    let derivation_tail = read_last_bytes_of(&stderr_path, 4 * 1024)
+```
+
+**Tool Call: Edit /Users/auser/.claude/plans/continue\-unblocking\-mvmctl\-dev\-agile\-rivest.md**
+Status: Completed
+
+Diff: /Users/auser/.claude/plans/continue-unblocking-mvmctl-dev-agile-rivest.md
+
+```
+
+## Out of scope (named explicitly)
+
+- Streaming per-derivation logs over vsock during the build (W2 part 4 /
+  W3 streaming path). The file-based path is sufficient now that the
+  dispatch log names the path up-front and the failure message includes
+  the tail.
+- `/dev/shm`, `/dev/core`, `/dev/log`, and other conventional symlinks
+  that udev/systemd would create. No build hook has hit them yet; add
+  them when something does.
+- The `plan-92-stock-kernel` worktree (Plan 93/94 Alpine builder VM)
+  remains parked per the user memory. If this PR lands and `mvmctl dev
+  up` completes end-to-end, the worktree can be deleted; until then,
+  leave it alone.
+
+## Key file locations (for executor convenience)
+
+```
+
+**Tool Call: Exited Plan Mode**
+Status: Completed
+
+# Plan — Unblock `mvmctl dev up` at the inner `nix build` layer
+
+## Context
+
+After PRs #418/#419/#420/#421 merged on `main` and PR #423 (`worktree-skip-addon-dns`,
+open) unblocks Stage 0 OOM, `mvmctl dev up` on aarch64-darwin walks all the way through
+Stage 0 → persistent builder VM boot → ext4 geometry recovery → nix DB load (185 ms) →
+network up via gvproxy (163 ms) → inner `nix build` dispatch — then fails after 115 s
+of compilation with `error: Cannot build '/nix/store/<hash>-mvm-guest-agent-0.14.0.drv'`.
+
+The user-visible host log only showed the cascading "Cannot build" messages, with no
+underlying reason. The actual stderr was already on the host filesystem the whole
+time: `/job` is mounted into the builder VM as a virtio-fs share, the cmd.sh
+template redirects `nix build`'s stderr to `/job/nix-stderr.log`, and that path is
+`~/.cache/mvm/builder-vm/jobs/<job_id>/nix-stderr.log` on the host
+(`crates/mvm-build/src/libkrun_builder.rs:404-405,428`). Reading it gives the
+real failure, repeated three times — once per parallel derivation:
+
+```
+mvm-builder-init> /nix/store/.../cargo-install-hook.sh/nix-support/setup-hook:
+  line 27: /dev/fd/63: No such file or directory
+mvm-addon-dns>    (same)
+mvm-guest-agent>  (same)
+```
+
+Line 27 of nixpkgs's `cargo-install-hook.sh` is:
+
+```sh
+mapfile -t targets < <(find "$NIX_BUILD_TOP" -type d | grep "${tmpDir}$")
+```
+
+That is bash process substitution. For `<(...)` to work the shell opens
+`/dev/fd/N` against the subshell's pipe FD; that path only resolves when
+`/dev/fd` is a symlink to `/proc/self/fd` (the standard Linux convention,
+normally created by udev/mdev/systemd, never by `devtmpfs` itself).
+
+The builder VM's `mount_pseudofs()`
+(`crates/mvm-builder-init/src/main.rs:1363-1390`) mounts `/proc`, `/sys`,
+`/dev` (devtmpfs), `/tmp`, `/run`, `/dev/pts` — and stops there. It never
+creates `/dev/fd → /proc/self/fd`, so process substitution in every
+`cargoInstallHook` invocation fails with ENOENT on `/dev/fd/63`. Since
+`mvm-builder-init`, `mvm-addon-dns`, and `mvm-guest-agent` are all
+Rust derivations built by `rustPlatform.buildRustPackage`, **every** derivation in the
+dev image's closure trips the same hook, and the whole dev image build fails.
+
+Diagnostic gap: `BuilderVmError::NixBuildFailed`
+(`crates/mvm-build/src/libkrun_builder.rs:1214-1219`) only surfaces the
+20-line `result.stderr_tail` from `mvm-builder-init::run_job`, which captures
+the OUTER `cmd.sh`'s stderr — not the real `/job/nix-stderr.log`. That's why
+PR #423's author concluded the per-derivation log was "inside the VM's
+nix-store, can't be read from the host without mounting nix-store-aarch64.img".
+It is in fact already on the host; we just don't say so.
+
+## Approach
+
+Single small PR off `main` (rebased onto #423 once that lands). Four changes
+plus tests:
+
+1. **Create `/dev/fd` (and `/dev/std{in,out,err}`) symlinks at boot** in the
+   **builder VM** so bash process substitution works inside the nix-build
+   environment. (`crates/mvm-builder-init/src/main.rs::mount_pseudofs`)
+
+2. **Same symlinks in the user-facing dev image's `mkGuest` initScript** —
+   identical gap (`nix/lib/mk-guest.nix:229-237` does an equivalent minimal
+   /proc + /sys + devtmpfs mount and never creates the symlinks). Folding
+   this in keeps the two surfaces from drifting; the next user who runs
+   `mvmctl dev shell` and uses process substitution in their shell will hit
+   the same ENOENT we're fixing in the builder.
+
+3. **Surface the host-side `nix-stderr.log` path on builder-VM build
+   failure** so the next failure is one `cat` away — no debugger
+   archaeology. (`crates/mvm-build/src/libkrun_builder.rs::finalize_flake_job`)
+
+4. **Print the job dir at dispatch time** — one `tracing::info!` near the
+   `stage_*_job_dir(&job_dir, …)` call so users can `tail -f` the log while
+   the build runs. Costs nothing, kills the "log is inside the VM, can't
+   reach it" misconception. (`crates/mvm-build/src/libkrun_builder.rs:404`
+   and `:657`)
+
+PR #422 (fingerprint expansion) and PR #423 (skip-addon-dns) are
+independently mergeable; this PR conflicts with neither. Merge order:
+#423 → #422 → this PR.
+
+## Files to modify
+
+### `crates/mvm-builder-init/src/main.rs`
+
+`mount_pseudofs()` at lines 1363-1390 — after the `devpts` mount, add a
+`setup_dev_fd_symlinks()` call that creates four symlinks under `/dev`:
+
+| symlink       | target            | why                                        |
+| ------------- | ----------------- | ------------------------------------------ |
+| `/dev/fd`     | `/proc/self/fd`   | bash `<(...)` opens `/dev/fd/N`. Required. |
+| `/dev/stdin`  | `/proc/self/fd/0` | conventional, used by some scripts.        |
+| `/dev/stdout` | `/proc/self/fd/1` | conventional.                              |
+| `/dev/stderr` | `/proc/self/fd/2` | conventional.                              |
+
+Implementation shape (extract a testable helper):
+
+```rust
+fn setup_dev_fd_symlinks(dev_root: &Path) -> Result<(), String> {
+    use std::os::unix::fs::symlink;
+    // Idempotent: skip the symlink if it already exists. devtmpfs's
+    // /dev/std{in,out,err} can appear as character devices on some
+    // kernels; we never replace a pre-existing entry.
+    for (link_name, target) in [
+        ("fd",     "/proc/self/fd"),
+        ("stdin",  "/proc/self/fd/0"),
+        ("stdout", "/proc/self/fd/1"),
+        ("stderr", "/proc/self/fd/2"),
+    ] {
+        let link = dev_root.join(link_name);
+        if link.exists() { continue; }
+        symlink(target, &link)
+            .map_err(|e| format!("symlink {} -> {target}: {e}", link.display()))?;
+    }
+    Ok(())
+}
+```
+
+Then in `mount_pseudofs()` after line 1388:
+
+```rust
+setup_dev_fd_symlinks(Path::new("/dev"))?;
+```
+
+### `nix/lib/mk-guest.nix`
+
+`initScript` at lines 223-237 — after the existing devtmpfs mount at line 231,
+inline the same four symlinks. Pure busybox-sh, idempotent via `-e` test:
+
+```sh
+# /dev/fd → /proc/self/fd is what bash process substitution needs
+# (`< <(...)` opens /dev/fd/N). devtmpfs doesn't create it; udev/mdev
+# normally do. Without it nixpkgs build hooks (and any user-script
+# using <(...)) fail with "/dev/fd/N: No such file or directory".
+[ -e /dev/fd ]     || /bin/busybox ln -s /proc/self/fd   /dev/fd
+[ -e /dev/stdin ]  || /bin/busybox ln -s /proc/self/fd/0 /dev/stdin
+[ -e /dev/stdout ] || /bin/busybox ln -s /proc/self/fd/1 /dev/stdout
+[ -e /dev/stderr ] || /bin/busybox ln -s /proc/self/fd/2 /dev/stderr
+```
+
+No new test framework — covered by the existing `nix flake check` and the
+end-to-end `mvmctl dev up` smoke. The shell logic is small enough to
+review by inspection.
+
+### `crates/mvm-build/src/libkrun_builder.rs`
+
+**Two edits.**
+
+**(a) Print the job dir at dispatch.** Near the existing `stage_flake_job_dir`
+call at line 405 (single-shot) and `stage_job_dir` at line 658 (persistent),
+emit one info-level trace:
+
+```rust
+tracing::info!(
+    job_dir = %job_dir.display(),
+    "builder VM job dir staged (nix-stderr.log streams here as the build runs)"
+);
+```
+
+**(b) Surface `nix-stderr.log` path + tail on failure.** `finalize_flake_job()`
+at lines 1208-1219 — on non-zero exit, read `<job_dir>/nix-stderr.log` (if
+it exists, bounded by size — say last 4 KiB) and include it in the
+`NixBuildFailed` message along with the file path:
+
+```rust
+if result.exit_code != 0 {
+    let stderr_path = job_dir.join("nix-stderr.log");
+    let derivation_tail = read_last_bytes_of(&stderr_path, 4 * 1024)
+        .unwrap_or_else(|_| String::from("<nix-stderr.log not present>"));
+    return Err(BuilderVmError::NixBuildFailed(format!(
+        "guest cmd.sh exited {} — host log: {}\n\
+         outer stderr tail:\n{}\n\
+         derivation stderr tail (last 4 KiB of {}):\n{}",
+        result.exit_code,
+        stderr_path.display(),
+        result.stderr_tail,
+        stderr_path.display(),
+        derivation_tail,
+    )));
+}
+```
+
+(Implementation note: keep `read_last_bytes_of` a small pure helper in
+the same file — opens the file, seeks `SeekFrom::End(-N.min(filesize))`,
+reads to end, returns `String::from_utf8_lossy(...).to_string()`. Don't
+load the whole 220 KB log into memory.)
+
+## Tests
+
+`crates/mvm-builder-init/src/main.rs` — under `#[cfg(test)] mod tests`:
+
+- `setup_dev_fd_symlinks_creates_all_four_in_empty_dir` — `tempdir()`, run
+  helper, assert each of `fd`, `stdin`, `stdout`, `stderr` is a symlink with
+  the expected target via `std::fs::read_link`.
+- `setup_dev_fd_symlinks_is_idempotent_when_already_present` — pre-create
+  one of the symlinks with a sentinel target, run helper, assert the
+  sentinel is preserved (we never clobber).
+- `setup_dev_fd_symlinks_errors_when_dev_root_missing` — pass a non-existent
+  path, assert a clean error message naming the missing parent.
+
+`crates/mvm-build/src/libkrun_builder.rs` — extend the existing
+`finalize_flake_job` tests (or add a sibling module if the helpers aren't
+currently tested):
+
+- `finalize_flake_job_includes_nix_stderr_log_path_and_tail_on_failure` —
+  stage a tempdir with a fake `result` (`exit_code: 1`, dummy
+  `stderr_tail`) and a `nix-stderr.log` containing a known string;
+  assert the returned `BuilderVmError::NixBuildFailed` message contains
+  the file path and the known string.
+- `finalize_flake_job_handles_missing_nix_stderr_log_cleanly` — same as
+  above without the log file; assert the message contains the path and
+  a `<not present>` sentinel rather than panicking.
+
+## Verification
+
+End-to-end on aarch64-darwin:
+
+1. `cargo test --workspace -- mount_pseudofs setup_dev_fd_symlinks finalize_flake_job`
+   → all new tests green.
+2. `cargo clippy --workspace -- -D warnings` → clean.
+3. `cargo fmt -- --check` → clean.
+4. `cargo build --workspace` → clean.
+5. **Invalidate rootfs cache** (PR #422 isn't merged yet, so the rootfs
+   fingerprint doesn't yet hash `crates/mvm-builder-init/src/main.rs`):
+   `rm -rf ~/.cache/mvm/builder-vm/aarch64/rootfs.ext4`
+6. `mvmctl dev up` → Stage 0 → persistent builder VM → inner nix build
+   completes → dev image lands → dev shell drops in. The 115-s
+   compilation now finishes successfully (`mvm-guest-agent`,
+   `mvm-builder-init`, `mvm-addon-dns` derivations all install
+   cleanly).
+7. On a subsequent intentional failure (e.g. break a flake input
+   temporarily), confirm the host-side error names
+   `~/.cache/mvm/builder-vm/jobs/<job_id>/nix-stderr.log` and shows
+   the last 4 KiB.
+
+## Out of scope (named explicitly)
+
+- Streaming per-derivation logs over vsock during the build (W2 part 4 /
+  W3 streaming path). The file-based path is sufficient now that the
+  dispatch log names the path up-front and the failure message includes
+  the tail.
+- `/dev/shm`, `/dev/core`, `/dev/log`, and other conventional symlinks
+  that udev/systemd would create. No build hook has hit them yet; add
+  them when something does.
+- The `plan-92-stock-kernel` worktree (Plan 93/94 Alpine builder VM)
+  remains parked per the user memory. If this PR lands and `mvmctl dev
+up` completes end-to-end, the worktree can be deleted; until then,
+  leave it alone.
+
+## Key file locations (for executor convenience)
+
+- Builder VM init mount setup:
+  `crates/mvm-builder-init/src/main.rs:1363-1390` (`mount_pseudofs`)
+- Outer cmd.sh template that writes `nix-stderr.log`:
+  `crates/mvm-build/src/libkrun_builder.rs:1068-1183`
+- Host-side error formatter:
+  `crates/mvm-build/src/libkrun_builder.rs:1208-1219`
+  (`finalize_flake_job`)
+- Job dir location on host:
+  `crates/mvm-build/src/libkrun_builder.rs:404-405` (single-shot) and
+  `:657-658` (persistent) — both
+  `builder_vm_cache_dir().join("jobs").join(&job_id)`
+- Failure evidence used to confirm the diagnosis (this run):
+  `~/.cache/mvm/builder-vm/jobs/1779426018614-7835/nix-stderr.log`
+  lines 2479, 2699, 2711 — same `/dev/fd/63: No such file or directory`
+  error in `cargo-install-hook.sh` for all three derivations.
+
+## Assistant
+
+<thinking>
+
+</thinking>
+
+**Tool Call: ToolSearch**
+Status: Completed
+
+Tool: TaskCreate
+
+Tool: TaskUpdate
+
+Tool: TaskList
+
+## Assistant
+
+<thinking>
+
+</thinking>
+
+**Tool Call: gh pr view 423 --json mergeable,mergeStateStatus,statusCheckRollup 2>&1 | head -100**
+Status: Completed
+
+Terminal:
+
+```
+{"mergeStateStatus":"UNKNOWN","mergeable":"UNKNOWN","statusCheckRollup":[{"__typename":"CheckRun","completedAt":"2026-05-22T05:10:19Z","conclusion":"SUCCESS","detailsUrl":"https://github.com/tinylabscom/mvm/actions/runs/26269640751/job/77320161895","name":"Invariant","startedAt":"2026-05-22T05:10:10Z","status":"COMPLETED","workflowName":"Architecture invariants"},{"__typename":"CheckRun","completedAt":"2026-05-22T05:11:43Z","conclusion":"SUCCESS","detailsUrl":"https://github.com/tinylabscom/mvm/actions/runs/26269638861/job/77320157293","name":"Lint (fmt + clippy + adr-coverage)","startedAt":"2026-05-22T05:10:07Z","status":"COMPLETED","workflowName":"CI"},{"__typename":"CheckRun","completedAt":"2026-05-22T05:13:37Z","conclusion":"SUCCESS","detailsUrl":"https://github.com/tinylabscom/mvm/actions/runs/26269638861/job/77320157291","name":"Test","startedAt":"2026-05-22T05:10:07Z","status":"COMPLETED","workflowName":"CI"},{"__typename":"CheckRun","completedAt":"2026-05-22T05:11:41Z","conclusion":"SUCCESS","detailsUrl":"https://github.com/tinylabscom/mvm/actions/runs/26269638861/job/77320157315","name":"Sealed-prod vsock allowlist (plan 76 Phase 1)","startedAt":"2026-05-22T05:10:07Z","status":"COMPLETED","workflowName":"CI"},{"__typename":"CheckRun","completedAt":"2026-05-22T05:11:22Z","conclusion":"SUCCESS","detailsUrl":"https://github.com/tinylabscom/mvm/actions/runs/26269638861/job/77320157365","name":"MCP server stdio roundtrip (plan 32 / Proposal A)","startedAt":"2026-05-22T05:10:07Z","status":"COMPLETED","workflowName":"CI"},{"__typename":"CheckRun","completedAt":"2026-05-22T05:11:22Z","conclusion":"SUCCESS","detailsUrl":"https://github.com/tinylabscom/mvm/actions/runs/26269638861/job/77320157343","name":"app-deps-audit (ADR-047 claim 9 / Plan 73 Followup D)","startedAt":"2026-05-22T05:10:07Z","status":"COMPLETED","workflowName":"CI"},{"__typename":"CheckRun","completedAt":"2026-05-22T05:10:35Z","conclusion":"SUCCESS","detailsUrl":"https://github.com/tinylabscom/mvm/actions/runs/26269638861/job/77320157290","name":"Nix flake check (Linux eval)","startedAt":"2026-05-22T05:10:07Z","status":"COMPLETED","workflowName":"CI"},{"__typename":"CheckRun","completedAt":"2026-05-22T05:10:05Z","conclusion":"SKIPPED","detailsUrl":"https://github.com/tinylabscom/mvm/actions/runs/26269638861/job/77320157520","name":"Apple (release-only)","startedAt":"2026-05-22T05:10:05Z","status":"COMPLETED","workflowName":"CI"},{"__typename":"CheckRun","completedAt":"2026-05-22T05:10:16Z","conclusion":"SUCCESS","detailsUrl":"https://github.com/tinylabscom/mvm/actions/runs/26269638861/job/77320157311","name":"libkrun (macOS Apple Silicon)","startedAt":"2026-05-22T05:10:08Z","status":"COMPLETED","workflowName":"CI"},{"__typename":"CheckRun","completedAt":"2026-05-22T05:16:18Z","conclusion":"SUCCESS","detailsUrl":"https://github.com/tinylabscom/mvm/actions/runs/26269638861/job/77320157340","name":"cloud-hypervisor (Linux x86_64)","startedAt":"2026-05-22T05:10:07Z","status":"COMPLETED","workflowName":"CI"},{"__typename":"CheckRun","completedAt":"2026-05-22T05:10:16Z","conclusion":"SUCCESS","detailsUrl":"https://github.com/tinylabscom/mvm/actions/runs/26269638861/job/77320157386","name":"oci-layer-unpack-fuzz (Plan 85 §R1)","startedAt":"2026-05-22T05:10:07Z","status":"COMPLETED","workflowName":"CI"},{"__typename":"CheckRun","completedAt":"2026-05-22T05:14:47Z","conclusion":"SUCCESS","detailsUrl":"https://github.com/tinylabscom/mvm/actions/runs/26269638861/job/77320454767","name":"E2E Tests","startedAt":"2026-05-22T05:13:39Z","status":"COMPLETED","workflowName":"CI"}]}
+```
+
+## Assistant
+
+<thinking>
+
+</thinking>
+
+All 12 checks green on #423. Squash-merging it now.
+
+**Tool Call: gh pr merge 423 --squash --delete-branch 2>&1 | head -20**
+Status: Completed
+
+Terminal:
+
+```
+failed to delete local branch worktree-skip-addon-dns: failed to run git: error: cannot delete branch 'worktree-skip-addon-dns' used by worktree at '/Users/auser/work/tinylabs/mvmco/mvm/.claude/worktrees/skip-addon-dns'
+
+```
+
+## Assistant
+
+<thinking>
+
+</thinking>
+
+Merge to remote succeeded. Now checking if I can clean up the worktree (user runs parallel sessions; want to verify it's safe).
+
+**Tool Call: cd /Users/auser/work/tinylabs/mvmco/mvm/.claude/worktrees/skip-addon-dns && git status --short && echo "---HEAD---" && git log -1 --oneline**
+Status: Completed
+
+Terminal:
+
+```
+---HEAD---
+41c60e1a fix(mkGuest): skip addon-dns bake for builder VM (Stage 0 OOM)
+
+
+
+```
+
+**Tool Call: gh pr view 423 --json state,mergedAt --jq '{state, mergedAt}' 2>&1**
+Status: Completed
+
+Terminal:
+
+```
+{"mergedAt":"2026-05-22T06:18:49Z","state":"MERGED"}
+
+
+
+
+```
+
+## Assistant
+
+<thinking>
+
+</thinking>
+
+PR #423 merged. Leaving the worktree alone (parallel session may be attached). Pulling main, creating my worktree.
+
+**Tool Call: git fetch origin main && git -C /Users/auser/work/tinylabs/mvmco/mvm checkout main 2>&1 | tail -5 && git -C /Users/auser/work/tinylabs/mvmco/mvm merge --ff-only origin/main 2>&1 | tail -5 && git -C /Users/auser/work/tinylabs/mvmco/mvm log --oneline -3**
+Status: Completed
+
+Terminal:
+
+```
+From github.com:tinylabscom/mvm
+ * branch              main       -> FETCH_HEAD
+   e646e4df..8041e2c7  main       -> origin/main
+Already on 'main'
+Fast-forward
+ crates/mvm-cli/src/commands/env/apple_container.rs | 384 ++++++++++++++++++++-
+ nix/images/builder-vm/flake.nix                    |  10 +
+ nix/lib/mk-guest.nix                               |  29 +-
+ 3 files changed, 408 insertions(+), 15 deletions(-)
+8041e2c7 fix(mkGuest): skip addon-dns bake for builder VM (Stage 0 OOM) (#423)
+756f9525 Merge pull request #422 from tinylabscom/worktree-fingerprint-expansion
+e646e4df Merge pull request #420 from tinylabscom/worktree-plan-96-dev-up-followups
+```
+
+## Assistant
+
+<thinking>
+
+</thinking>
+
+Both #422 and #423 landed. Now I have main at `8041e2c7`. Creating my worktree.
+
+**Tool Call: cd /Users/auser/work/tinylabs/mvmco/mvm && git worktree add .claude/worktrees/dev-fd-symlinks -b worktree-dev-fd-symlinks main 2>&1**
+Status: Completed
+
+Terminal:
+
+```
+Preparing worktree (new branch 'worktree-dev-fd-symlinks')
+HEAD is now at 8041e2c7 fix(mkGuest): skip addon-dns bake for builder VM (Stage 0 OOM) (#423)
+
+
+```
+
+**Tool Call: Read .claude/worktrees/dev-fd-symlinks/crates/mvm-builder-init/src/main.rs (1363 - 1397)**
+Status: Completed
+
+```
+1363	    fn mount_pseudofs() -> Result<(), String> {
+1364	        // Standard init filesystems. libkrun's kernel mounts
+1365	        // devtmpfs (and sometimes /proc /sys) before handing off to
+1366	        // init, so EBUSY here means "already mounted by an earlier
+1367	        // stage" — that's success for our purposes. Anything else
+1368	        // is fatal.
+1369	        mount_fs_idempotent("proc", "/proc", "proc")?;
+1370	        mount_fs_idempotent("sysfs", "/sys", "sysfs")?;
+1371	        mount_fs_idempotent("devtmpfs", "/dev", "devtmpfs")?;
+1372	        mount_fs_idempotent("tmpfs", "/tmp", "tmpfs")?;
+1373	        // `/run` must be a tmpfs so iptables-legacy can write
+1374	        // `/run/xtables.lock`. The rootfs is mounted ro, so a missing
+1375	        // `/run` tmpfs makes `install_egress_lockdown` bail with
+1376	        // "Read-only file system" at the first `iptables -A` call.
+1377	        // mkGuest's /init does the equivalent for the dev image's
+1378	        // boot path; we replicate it here for the mvm-builder-init
+1379	        // path (Plan 86).
+1380	        mount_fs_idempotent("tmpfs", "/run", "tmpfs")?;
+1381	        // `/dev/pts` is required by nix's build-sandbox setup: it
+1382	        // calls `posix_openpt` which opens `/dev/ptmx`, and that
+1383	        // requires devpts to be mounted at `/dev/pts`. Without it
+1384	        // nix bails with `error: opening pseudoterminal master:
+1385	        // No such file or directory`. The dev image flake's
+1386	        // mkGuest /init mounts this; we replicate for Plan 86.
+1387	        let _ = std::fs::create_dir_all("/dev/pts");
+1388	        mount_fs_idempotent("devpts", "/dev/pts", "devpts")?;
+1389	        Ok(())
+1390	    }
+1391
+1392	    /// Plan 76 Phase 5: serial chain that gates job execution.
+1393	    /// /dev/vdb format (first boot only) → mount → overlay-mount
+1394	    /// rootfs `/nix` with persistent upper/work dirs → bind-mount
+1395	    /// over /nix. Each step depends on the previous, so this stays
+1396	    /// single-threaded inside.
+1397	    fn setup_nix_store(timings: &Arc<Mutex<BootTimings>>, anchor: Instant) -> Result<(), String> {
+```
+
+## Assistant
+
+<thinking>
+
+</thinking>
+
+Now editing in the worktree. Let me find the existing tests module to match its style.
+
+**Tool Call: grep -n "^#\[cfg\(test\)\]|mod tests|use tempfile" /Users/auser/work/tinylabs/mvmco/mvm/.claude/worktrees/dev-fd-symlinks/crates/mvm-builder-init/src/main.rs**
+Status: Completed
+
+168:#[cfg(test)]
+169:mod tests {
+2244: mod tests {
+
+**Tool Call: Read .claude/worktrees/dev-fd-symlinks/crates/mvm-builder-init/src/main.rs (2300 - 2339)**
+Status: Completed
+
+```
+2300	        fn encode_iface_name_eth0_pads_with_nul() {
+2301	            let buf = encode_iface_name("eth0").expect("eth0 fits");
+2302	            assert_eq!(buf[0] as u8, b'e');
+2303	            assert_eq!(buf[1] as u8, b't');
+2304	            assert_eq!(buf[2] as u8, b'h');
+2305	            assert_eq!(buf[3] as u8, b'0');
+2306	            assert_eq!(buf[4] as u8, 0, "remainder NUL-padded");
+2307	            assert_eq!(buf[libc::IFNAMSIZ - 1] as u8, 0);
+2308	        }
+2309
+2310	        #[test]
+2311	        fn encode_iface_name_max_length_succeeds() {
+2312	            // 15 bytes + 1 NUL = exactly IFNAMSIZ.
+2313	            let max = "a".repeat(libc::IFNAMSIZ - 1);
+2314	            let buf = encode_iface_name(&max).expect("15-byte name fits");
+2315	            for byte in buf.iter().take(libc::IFNAMSIZ - 1) {
+2316	                assert_eq!(*byte as u8, b'a');
+2317	            }
+2318	            assert_eq!(buf[libc::IFNAMSIZ - 1] as u8, 0, "NUL terminator");
+2319	        }
+2320
+2321	        #[test]
+2322	        fn encode_iface_name_too_long_errors() {
+2323	            let over = "a".repeat(libc::IFNAMSIZ);
+2324	            let err = encode_iface_name(&over).expect_err("IFNAMSIZ-byte name rejected");
+2325	            assert!(err.contains("IFNAMSIZ"), "err mentions limit: {err}");
+2326	            assert!(err.contains(&over), "err includes the offending name");
+2327	        }
+2328
+2329	        /// Plan 89 W3 part 9 — `run_job_streaming` calls the
+2330	        /// per-line callback once per stderr line, in order, and
+2331	        /// returns the same `(exit_code, tail)` shape as the
+2332	        /// single-shot `run_job` for the success case.
+2333	        #[test]
+2334	        fn run_job_streaming_emits_each_line_in_order() {
+2335	            // Write a cmd.sh that emits 3 stderr lines and exits 0.
+2336	            let dir = tempfile::tempdir().expect("tempdir");
+2337	            let cmd_path = dir.path().join("cmd.sh");
+2338	            std::fs::write(
+2339	                &cmd_path,
+```
+
+**Tool Call: grep -n "^use \|^extern \|^mod " /Users/auser/work/tinylabs/mvmco/mvm/.claude/worktrees/dev-fd-symlinks/crates/mvm-builder-init/src/main.rs | head -30**
+Status: Completed
+
+Terminal:
+
+```
+59:use std::process::ExitCode;
+74:mod boot_timings;
+82:mod builder_request;
+89:mod dispatch_response;
+91:mod install;
+93:mod install_spec;
+95:mod network;
+97:mod proxy;
+169:mod tests {
+260:mod linux {
+```
+
+**Tool Call: Read .claude/worktrees/dev-fd-symlinks/crates/mvm-builder-init/src/main.rs (2244 - 2303)**
+Status: Completed
+
+```
+2244	    mod tests {
+2245	        use super::*;
+2246
+2247	        #[test]
+2248	        fn json_escape_plain() {
+2249	            assert_eq!(json_escape("hello"), "hello");
+2250	        }
+2251
+2252	        #[test]
+2253	        fn json_escape_quote_and_backslash() {
+2254	            assert_eq!(json_escape(r#"he"llo\world"#), r#"he\"llo\\world"#);
+2255	        }
+2256
+2257	        #[test]
+2258	        fn json_escape_newlines_and_tabs() {
+2259	            assert_eq!(
+2260	                json_escape("line1\nline2\ttab\rcarriage"),
+2261	                "line1\\nline2\\ttab\\rcarriage"
+2262	            );
+2263	        }
+2264
+2265	        #[test]
+2266	        fn json_escape_low_control_codepoint() {
+2267	            // 0x01 is below 0x20 and not specially named — use 
+2268	            assert_eq!(json_escape("\x01"), "\\u0001");
+2269	        }
+2270
+2271	        #[test]
+2272	        fn json_escape_utf8_passes_through() {
+2273	            // Multi-byte UTF-8 must not be escaped: per RFC 8259,
+2274	            // only the named characters and control codepoints
+2275	            // require escaping.
+2276	            assert_eq!(json_escape("naïve résumé 日本語"), "naïve résumé 日本語");
+2277	        }
+2278
+2279	        #[test]
+2280	        fn ext4_magic_constants_match_disk_layout() {
+2281	            // Sanity-check the magic bytes we probe for. ext4
+2282	            // stores `0xEF53` as a 16-bit little-endian integer
+2283	            // at offset 1080 of the device. If this constant ever
+2284	            // drifts (e.g. someone "fixes" the byte order) we want
+2285	            // a CI test failure rather than a runtime mis-detection
+2286	            // that silently re-formats the persistent store.
+2287	            assert_eq!([0x53u8, 0xEFu8], 0xEF53u16.to_le_bytes());
+2288	        }
+2289
+2290	        #[test]
+2291	        fn virtiofs_mount_flags_keep_workspace_read_only() {
+2292	            use nix::mount::MsFlags;
+2293
+2294	            assert!(virtiofs_mount_flags("work").contains(MsFlags::MS_RDONLY));
+2295	            assert_eq!(virtiofs_mount_flags("out"), MsFlags::empty());
+2296	            assert_eq!(virtiofs_mount_flags("job"), MsFlags::empty());
+2297	        }
+2298
+2299	        #[test]
+2300	        fn encode_iface_name_eth0_pads_with_nul() {
+2301	            let buf = encode_iface_name("eth0").expect("eth0 fits");
+2302	            assert_eq!(buf[0] as u8, b'e');
+2303	            assert_eq!(buf[1] as u8, b't');
+```
+
+## Assistant
+
+<thinking>
+
+</thinking>
+
+Now writing the helper + wiring in.
+
+**Tool Call: grep -n "^ use \|^use std::os::unix" /Users/auser/work/tinylabs/mvmco/mvm/.claude/worktrees/dev-fd-symlinks/crates/mvm-builder-init/src/main.rs | head -20**
+Status: Completed
+
+Terminal:
+
+```
+170:    use super::*;
+261:    use std::path::Path;
+262:    use std::process::{Command, ExitCode};
+263:    use std::sync::{Arc, Mutex};
+264:    use std::time::Instant;
+266:    use crate::boot_timings::BootTimings;
+```
+
+**Tool Call: grep -n "tempfile" /Users/auser/work/tinylabs/mvmco/mvm/.claude/worktrees/dev-fd-symlinks/crates/mvm-builder-init/Cargo.toml**
+Status: Completed
+
+Terminal:
+
+```
+34:tempfile.workspace = true
+
+
+
+
+```
+
+## Assistant
+
+<thinking>
+
+</thinking>
+
+**Tool Call: Edit .claude/worktrees/dev\-fd\-symlinks/crates/mvm\-builder\-init/src/main.rs**
+Status: Completed
+
+Diff: /Users/auser/work/tinylabs/mvmco/mvm/.claude/worktrees/dev-fd-symlinks/crates/mvm-builder-init/src/main.rs
+
+```
+        // mkGuest /init mounts this; we replicate for Plan 86.
+        let _ = std::fs::create_dir_all("/dev/pts");
+        mount_fs_idempotent("devpts", "/dev/pts", "devpts")?;
+        // `/dev/fd → /proc/self/fd` is what bash process substitution
+        // (`< <(...)`, `mapfile -t x < <(...)`) needs to open the
+        // subshell's pipe FD at `/dev/fd/N`. devtmpfs creates device
+        // nodes but never these symlinks; udev/mdev/systemd-tmpfiles
+        // normally do, and we run none of them. Without /dev/fd
+        // nixpkgs's `cargo-install-hook.sh` line 27 fails with
+        // "/dev/fd/63: No such file or directory" and every Rust
+        // derivation in the dev-image closure dies at install time.
+        // `/dev/std{in,out,err}` are conventionally present as well;
+        // we install all four so future hooks that depend on them
+        // don't trip the same surprise.
+        setup_dev_fd_symlinks(Path::new("/dev"))?;
+        Ok(())
+    }
+
+    /// Create `/dev/fd → /proc/self/fd` and `/dev/std{in,out,err} →
+    /// /proc/self/fd/{0,1,2}` under `dev_root`. Idempotent: an entry
+    /// that already exists (file, symlink, or device node) is left
+    /// untouched — we never replace whatever the kernel or a prior
+    /// boot has put there.
+    ///
+    /// `dev_root` is a parameter so this helper is testable under a
+    /// `tempfile::tempdir()` without privilege.
+    fn setup_dev_fd_symlinks(dev_root: &Path) -> Result<(), String> {
+        use std::os::unix::fs::symlink;
+        for (link_name, target) in [
+            ("fd", "/proc/self/fd"),
+            ("stdin", "/proc/self/fd/0"),
+            ("stdout", "/proc/self/fd/1"),
+            ("stderr", "/proc/self/fd/2"),
+        ] {
+            let link = dev_root.join(link_name);
+            // `Path::exists` follows symlinks; `symlink_metadata` does
+            // not. We want "is there anything at this path?", which is
+            // the symlink_metadata question — otherwise a dangling
+            // symlink left over from a prior boot would be treated as
+            // absent and we'd EEXIST on the symlink call.
+            if link.symlink_metadata().is_ok() {
+                continue;
+            }
+            symlink(target, &link)
+                .map_err(|e| format!("symlink {} -> {target}: {e}", link.display()))?;
+        }
+        Ok(())
+    }
+
+    /// Plan 76 Phase 5: serial chain that gates job execution.
+    /// /dev/vdb format (first boot only) → mount → overlay-mount
+    /// rootfs `/nix` with persistent upper/work dirs → bind-mount
+```
+
+## Assistant
+
+Now adding the tests next to the existing tests module.
+
+**Tool Call: Edit .claude/worktrees/dev\-fd\-symlinks/crates/mvm\-builder\-init/src/main.rs**
+Status: Completed
+
+Diff: /Users/auser/work/tinylabs/mvmco/mvm/.claude/worktrees/dev-fd-symlinks/crates/mvm-builder-init/src/main.rs
+
+```
+            assert_eq!([0x53u8, 0xEFu8], 0xEF53u16.to_le_bytes());
+        }
+
+        /// `setup_dev_fd_symlinks` lays down all four conventional
+        /// symlinks in an empty /dev so bash process substitution
+        /// (`< <(...)`) finds `/dev/fd/N`. The targets are the
+        /// `/proc/self/fd` family; the symlink_metadata-based skip
+        /// keeps the helper idempotent on reboot.
+        #[test]
+        fn setup_dev_fd_symlinks_creates_all_four_in_empty_dir() {
+            let dir = tempfile::tempdir().expect("tempdir");
+            setup_dev_fd_symlinks(dir.path()).expect("fresh dev_root succeeds");
+            for (name, expected) in [
+                ("fd", "/proc/self/fd"),
+                ("stdin", "/proc/self/fd/0"),
+                ("stdout", "/proc/self/fd/1"),
+                ("stderr", "/proc/self/fd/2"),
+            ] {
+                let link = dir.path().join(name);
+                let target = std::fs::read_link(&link)
+                    .unwrap_or_else(|e| panic!("read_link {}: {e}", link.display()));
+                assert_eq!(
+                    target.to_string_lossy(),
+                    expected,
+                    "{name} points at the right /proc/self/fd target"
+                );
+            }
+        }
+
+        /// Idempotency: a pre-existing entry — even a dangling
+        /// symlink left over from a prior boot — is preserved. We
+        /// never clobber what the kernel/initramfs/previous boot
+        /// staged. This guards against, e.g., a future devtmpfs
+        /// variant that creates `/dev/stdin` as a character device.
+        #[test]
+        fn setup_dev_fd_symlinks_is_idempotent_when_already_present() {
+            use std::os::unix::fs::symlink;
+            let dir = tempfile::tempdir().expect("tempdir");
+            // Pre-stage `/dev/fd` with a sentinel target the helper
+            // must NOT overwrite.
+            symlink("/sentinel", dir.path().join("fd")).expect("pre-stage symlink");
+            setup_dev_fd_symlinks(dir.path()).expect("idempotent run succeeds");
+            assert_eq!(
+                std::fs::read_link(dir.path().join("fd"))
+                    .expect("read_link fd")
+                    .to_string_lossy(),
+                "/sentinel",
+                "sentinel preserved"
+            );
+            // The other three were absent, so the helper still
+            // created them.
+            for name in ["stdin", "stdout", "stderr"] {
+                assert!(
+                    dir.path().join(name).symlink_metadata().is_ok(),
+                    "{name} created on a partially-staged /dev"
+                );
+            }
+        }
+
+        /// A non-existent `dev_root` surfaces as a clean error message
+        /// that names the path. The first failing symlink is enough —
+        /// we don't try to be smart about pre-checking the parent.
+        #[test]
+        fn setup_dev_fd_symlinks_errors_when_dev_root_missing() {
+            let bogus = std::path::PathBuf::from("/this/path/should/not/exist/mvm-dev-fd-test");
+            let err = setup_dev_fd_symlinks(&bogus)
+                .expect_err("missing dev_root must error, not panic");
+            assert!(
+                err.contains("/this/path/should/not/exist"),
+                "error names the offending parent path: {err}"
+            );
+        }
+
+        #[test]
+        fn virtiofs_mount_flags_keep_workspace_read_only() {
+            use nix::mount::MsFlags;
+
+```
+
+**Tool Call: Edit .claude/worktrees/dev\-fd\-symlinks/nix/lib/mk\-guest.nix**
+Status: Failed
+
+```
+<tool_use_error>File has not been read yet. Read it first before writing to it.</tool_use_error>
+```
+
+**Tool Call: Read .claude/worktrees/dev-fd-symlinks/nix/lib/mk-guest.nix (223 - 242)**
+Status: Completed
+
+```
+223	  # utility used here. Boot-time-critical path so kept terse and
+224	  # readable. No bashisms, no externalities beyond busybox applets.
+225	  #
+226	  # Supervision pattern (W6.1):
+227	  #   1. Stage filesystem (proc/sys/dev + tmpfs).
+228	  #   2. Fork the guest agent in background under setpriv→agent uid.
+229	  #   3. Re-attach stdio (dev variant).
+230	  #   4. setpriv→entrypoint uid + exec the workload.
+231	  #
+232	  # PID 1 stays uid 0 (kernel mandate); both children run rootless
+233	  # by default in production (see uids resolution above).
+234	  initScript = pkgs.writeScript "mvm-init" ''
+235	    #!/bin/sh
+236	    # mvm /init — busybox PID 1 (plan 60 / ADR-013).
+237
+238	    # Stage 1 — kernel pseudofs. Required before anything else
+239	    # can read /proc/self or write to /dev/console.
+240	    /bin/busybox mount -t proc     proc     /proc
+241	    /bin/busybox mount -t sysfs    sysfs    /sys
+242	    /bin/busybox mount -t devtmpfs devtmpfs /dev
+```
+
+## Assistant
+
+<thinking>
+
+</thinking>
+
+**Tool Call: Edit .claude/worktrees/dev\-fd\-symlinks/nix/lib/mk\-guest.nix**
+Status: Completed
+
+Diff: /Users/auser/work/tinylabs/mvmco/mvm/.claude/worktrees/dev-fd-symlinks/nix/lib/mk-guest.nix
+
+```
+    /bin/busybox mount -t sysfs    sysfs    /sys
+    /bin/busybox mount -t devtmpfs devtmpfs /dev
+
+    # /dev/fd → /proc/self/fd is what bash process substitution
+    # (`< <(...)`, `mapfile -t x < <(...)`) needs to open the
+    # subshell's pipe FD at /dev/fd/N. devtmpfs creates device
+    # nodes but never these symlinks; udev/mdev/systemd-tmpfiles
+    # normally do, and we run none of them. Without /dev/fd a
+    # nixpkgs-style build hook fails with "/dev/fd/63: No such
+    # file or directory" — same gap is fixed in mvm-builder-init's
+    # mount_pseudofs(). The four lines are kept symmetric on both
+    # sides on purpose.
+    [ -e /dev/fd ]     || /bin/busybox ln -s /proc/self/fd   /dev/fd
+    [ -e /dev/stdin ]  || /bin/busybox ln -s /proc/self/fd/0 /dev/stdin
+    [ -e /dev/stdout ] || /bin/busybox ln -s /proc/self/fd/1 /dev/stdout
+    [ -e /dev/stderr ] || /bin/busybox ln -s /proc/self/fd/2 /dev/stderr
+
+    # Stage 2 — runtime tmpfs. /tmp + /run are RAM so the rootfs
+    # stays read-only-leaning; volumes (Phase 2) attach to fixed
+    # mountpoints instead.
+```
+
+**Tool Call: Read .claude/worktrees/dev-fd-symlinks/crates/mvm-build/src/libkrun_builder.rs (395 - 444)**
+Status: Completed
+
+```
+395	        let supervisor_path = resolve_supervisor_path()?;
+396	        let image = match &self.image_override {
+397	            Some(image) => image.clone(),
+398	            None => ensure_builder_vm_image()?,
+399	        };
+400	        let nix_store_lock =
+401	            acquire_nix_store_image_lock(host_arch_tag(), u64::from(self.nix_store_mib))?;
+402
+403	        let job_id = unique_job_id();
+404	        let job_dir = builder_vm_cache_dir().join("jobs").join(&job_id);
+405	        stage_shell_job_dir(&job_dir, &job.script)?;
+406
+407	        let vm_name = format!("mvm-builder-vm-{job_id}");
+408	        let vm_state_dir = builder_vm_cache_dir().join("vms").join(&vm_name);
+409	        std::fs::create_dir_all(&vm_state_dir).map_err(|e| {
+410	            BuilderVmError::ExtractionFailed(format!(
+411	                "creating builder VM state dir {}: {e}",
+412	                vm_state_dir.display()
+413	            ))
+414	        })?;
+415	        let console_log = vm_state_dir.join("console.log");
+416
+417	        let mut krun = krun_context_for_image(&vm_name, &image)?
+418	            .with_resources(self.vcpus, self.memory_mib)
+419	            .with_console_output(path_to_str(&console_log, "console_log")?)
+420	            .with_vsock_socket_dir(path_to_str(&vm_state_dir, "vm_state_dir")?)
+421	            .add_disk(
+422	                "nix-store",
+423	                path_to_str(nix_store_lock.path(), "nix_store_img")?,
+424	                false,
+425	            )
+426	            .add_virtio_fs("work", path_to_str(&job.work_dir, "work_dir")?)
+427	            .add_virtio_fs("out", path_to_str(&job.artifact_out, "artifact_out")?)
+428	            .add_virtio_fs("job", path_to_str(&job_dir, "job_dir")?)
+429	            .add_vsock_port(mvm_guest::builder_agent::BUILDER_DISPATCH_PORT);
+430
+431	        for disk in &job.extra_disks {
+432	            krun = krun.add_disk(
+433	                disk.id.as_str(),
+434	                path_to_str(&disk.path, "extra_disk")?,
+435	                disk.read_only,
+436	            );
+437	        }
+438
+439	        krun = apply_networking_mode(krun, &vm_state_dir)?;
+440
+441	        let cfg = SupervisorConfig {
+442	            krun,
+443	            vm_state_dir: path_to_str(&vm_state_dir, "vm_state_dir")?.to_string(),
+444	            pid_file_name: Some("builder.pid".to_string()),
+```
+
+**Tool Call: Read .claude/worktrees/dev-fd-symlinks/crates/mvm-build/src/libkrun_builder.rs (650 - 679)**
+Status: Completed
+
+```
+650	            acquire_nix_store_image_lock(host_arch_tag(), u64::from(self.nix_store_mib))?;
+651
+652	        // 6. Stage the per-build job dir. Flake jobs get
+653	        //    `cmd.sh`; install jobs get `install_spec.json`.
+654	        //    `mvm-builder-init` (Plan 72 W3 + Plan 73 Followup
+655	        //    B.2) dispatches based on which file it sees.
+656	        let job_id = unique_job_id();
+657	        let job_dir = builder_vm_cache_dir().join("jobs").join(&job_id);
+658	        stage_job_dir(&job_dir, job)?;
+659
+660	        // 7. Build the `KrunContext` libkrun consumes. Three
+661	        //    virtio-fs shares (work / out / job), one virtio-blk
+662	        //    (Nix store), and the canonical cmdline pinned at the
+663	        //    flake output. The mount layout is identical for
+664	        //    flake + install jobs — the guest decides what to do
+665	        //    with each share based on the staged job files.
+666	        let vm_name = format!("mvm-builder-vm-{job_id}");
+667	        let vm_state_dir = builder_vm_cache_dir().join("vms").join(&vm_name);
+668	        std::fs::create_dir_all(&vm_state_dir).map_err(|e| {
+669	            BuilderVmError::ExtractionFailed(format!(
+670	                "creating builder VM state dir {}: {e}",
+671	                vm_state_dir.display()
+672	            ))
+673	        })?;
+674
+675	        // Route the guest's serial console to a per-VM log file so
+676	        // failures of the in-VM cmd.sh / mvm-builder-init produce a
+677	        // readable transcript. Without this, libkrun discards the
+678	        // hvc0 output silently and "supervisor running, then exits 1"
+679	        // is the only observable signal.
+```
+
+**Tool Call: Read .claude/worktrees/dev-fd-symlinks/crates/mvm-build/src/libkrun_builder.rs (1200 - 1259)**
+Status: Completed
+
+```
+1200	/// then reopen. Standard sh-escape pattern.
+1201	fn shell_single_quote_escape(s: &str) -> String {
+1202	    s.replace('\'', "'\\''")
+1203	}
+1204
+1205	/// Finalize a flake build: read `<job_dir>/result`, validate the
+1206	/// `rootfs.ext4` (and optional `vmlinux`) landed in
+1207	/// `artifact_out`, return a [`BuilderArtifacts::Image`].
+1208	fn finalize_flake_job(
+1209	    job_dir: &Path,
+1210	    artifact_out: &Path,
+1211	    job_id: &str,
+1212	) -> Result<BuilderArtifacts, BuilderVmError> {
+1213	    let result = read_job_result(job_dir)?;
+1214	    if result.exit_code != 0 {
+1215	        return Err(BuilderVmError::NixBuildFailed(format!(
+1216	            "guest cmd.sh exited {} — stderr tail:\n{}",
+1217	            result.exit_code, result.stderr_tail
+1218	        )));
+1219	    }
+1220
+1221	    let rootfs_path = artifact_out.join("rootfs.ext4");
+1222	    if !rootfs_path.is_file() {
+1223	        return Err(BuilderVmError::ExtractionFailed(format!(
+1224	            "builder VM exited cleanly but {} was not written",
+1225	            rootfs_path.display()
+1226	        )));
+1227	    }
+1228	    let kernel_path_out = artifact_out.join("vmlinux");
+1229	    let kernel_path = if kernel_path_out.is_file() {
+1230	        Some(kernel_path_out)
+1231	    } else {
+1232	        None
+1233	    };
+1234
+1235	    Ok(BuilderArtifacts::Image {
+1236	        rootfs_path,
+1237	        kernel_path,
+1238	        revision_hash: read_revision_hash(job_dir).unwrap_or_else(|| job_id.to_string()),
+1239	        lock_hash: None,
+1240	        accessible: None,
+1241	    })
+1242	}
+1243
+1244	/// Read `/job/store-path` and extract the leading Nix store hash
+1245	/// from `/nix/store/<hash>-<name>`. Older guest images may not
+1246	/// write the sidecar; those callers fall back to the unique job id.
+1247	fn read_revision_hash(job_dir: &Path) -> Option<String> {
+1248	    let body = std::fs::read_to_string(job_dir.join("store-path")).ok()?;
+1249	    extract_nix_store_hash(body.trim()).map(str::to_string)
+1250	}
+1251
+1252	fn extract_nix_store_hash(store_path: &str) -> Option<&str> {
+1253	    let name = store_path.strip_prefix("/nix/store/")?;
+1254	    let (hash, _rest) = name.split_once('-')?;
+1255	    if hash.is_empty() { None } else { Some(hash) }
+1256	}
+1257
+1258	/// Finalize an install job (Plan 73 Followup B.2): validate the
+1259	/// install report `mvm-builder-init` wrote to
+```
+
+## Assistant
+
+<thinking>
+
+</thinking>
+
+**Tool Call: grep -n "^#\[cfg\(test\)\]|mod tests|^mod \w+ \{" /Users/auser/work/tinylabs/mvmco/mvm/.claude/worktrees/dev-fd-symlinks/crates/mvm-build/src/libkrun_builder.rs**
+Status: Completed
+
+1670:#[cfg(test)]
+2162:#[cfg(test)]
+2163:mod tests {
+
+**Tool Call: grep -n "finalize_flake_job" /Users/auser/work/tinylabs/mvmco/mvm/.claude/worktrees/dev-fd-symlinks/crates/mvm-build/src/libkrun_builder.rs**
+Status: Completed
+
+735: BuilderJob::Flake { .. } => finalize_flake_job(&job_dir, &mounts.artifact_out, &job_id),
+1208:fn finalize_flake_job(
+2639: fn finalize_flake_job_uses_store_path_hash_when_present() {
+2657: let artifacts = finalize_flake_job(&job_dir, &artifact_out, "fallback-job-id").unwrap();
+2667: fn finalize_flake_job_falls_back_to_job_id_without_store_path() {
+2680: let artifacts = finalize_flake_job(&job_dir, &artifact_out, "fallback-job-id").unwrap();
+
+**Tool Call: grep -n | head -10 "^use tracing|^use std::io|read_job_result|JobResult" /Users/auser/work/tinylabs/mvmco/mvm/.claude/worktrees/dev-fd-symlinks/crates/mvm-build/src/libkrun_builder.rs**
+Status: Completed
+
+58:use std::io::{Read, Write};
+462: let result = read_job_result(&job_dir)?;
+836:struct JobResult {
+1213: let result = read_job_result(job_dir)?;
+1335:fn read_job_result(job_dir: &Path) -> Result<JobResult, BuilderVmError> {
+1344: serde_json::from_str::<JobResult>(&body).map_err(|e| {
+2595: fn read_job_result_parses_well_formed_json() {
+2603: let r = read_job_result(&job_dir).unwrap();
+2609: fn read_job_result_defaults_stderr_tail_when_absent() {
+2616: let r = read_job_result(&job_dir).unwrap();
+
+[Showing results with pagination = limit: 10]
+
+## Assistant
+
+<thinking>
+
+</thinking>
+
+**Tool Call: Read .claude/worktrees/dev-fd-symlinks/crates/mvm-build/src/libkrun_builder.rs (2585 - 2704)**
+Status: Completed
+
+```
+2585	        // x86_64-linux only; the cache-key segment must match
+2586	        // one of those.
+2587	        let tag = host_arch_tag();
+2588	        assert!(
+2589	            tag == "aarch64" || tag == "x86_64",
+2590	            "unexpected arch tag: {tag}"
+2591	        );
+2592	    }
+2593
+2594	    #[test]
+2595	    fn read_job_result_parses_well_formed_json() {
+2596	        let scratch = TempDir::new().unwrap();
+2597	        let job_dir = scratch.path().to_path_buf();
+2598	        std::fs::write(
+2599	            job_dir.join("result"),
+2600	            r#"{"exit_code":0,"stderr_tail":"hello"}"#,
+2601	        )
+2602	        .unwrap();
+2603	        let r = read_job_result(&job_dir).unwrap();
+2604	        assert_eq!(r.exit_code, 0);
+2605	        assert_eq!(r.stderr_tail, "hello");
+2606	    }
+2607
+2608	    #[test]
+2609	    fn read_job_result_defaults_stderr_tail_when_absent() {
+2610	        // `#[serde(default)]` on stderr_tail. A guest that
+2611	        // exited before writing stderr_tail (rare, but possible
+2612	        // under panic) still parses cleanly.
+2613	        let scratch = TempDir::new().unwrap();
+2614	        let job_dir = scratch.path().to_path_buf();
+2615	        std::fs::write(job_dir.join("result"), r#"{"exit_code":2}"#).unwrap();
+2616	        let r = read_job_result(&job_dir).unwrap();
+2617	        assert_eq!(r.exit_code, 2);
+2618	        assert_eq!(r.stderr_tail, "");
+2619	    }
+2620
+2621	    #[test]
+2622	    fn read_job_result_errors_when_missing() {
+2623	        let scratch = TempDir::new().unwrap();
+2624	        let err = read_job_result(scratch.path()).unwrap_err();
+2625	        assert!(matches!(err, BuilderVmError::NixBuildFailed(_)));
+2626	    }
+2627
+2628	    #[test]
+2629	    fn extract_nix_store_hash_parses_output_path() {
+2630	        assert_eq!(
+2631	            extract_nix_store_hash("/nix/store/abc123def4567890-tenant-rootfs"),
+2632	            Some("abc123def4567890")
+2633	        );
+2634	        assert_eq!(extract_nix_store_hash("/tmp/not-store"), None);
+2635	        assert_eq!(extract_nix_store_hash("/nix/store/-missing-hash"), None);
+2636	    }
+2637
+2638	    #[test]
+2639	    fn finalize_flake_job_uses_store_path_hash_when_present() {
+2640	        let scratch = TempDir::new().unwrap();
+2641	        let job_dir = scratch.path().join("job");
+2642	        let artifact_out = scratch.path().join("out");
+2643	        std::fs::create_dir_all(&job_dir).unwrap();
+2644	        std::fs::create_dir_all(&artifact_out).unwrap();
+2645	        std::fs::write(
+2646	            job_dir.join("result"),
+2647	            r#"{"exit_code":0,"stderr_tail":""}"#,
+2648	        )
+2649	        .unwrap();
+2650	        std::fs::write(
+2651	            job_dir.join("store-path"),
+2652	            "/nix/store/deadbeefcafebabe-builder-vm\n",
+2653	        )
+2654	        .unwrap();
+2655	        std::fs::write(artifact_out.join("rootfs.ext4"), b"rootfs").unwrap();
+2656
+2657	        let artifacts = finalize_flake_job(&job_dir, &artifact_out, "fallback-job-id").unwrap();
+2658	        match artifacts {
+2659	            BuilderArtifacts::Image { revision_hash, .. } => {
+2660	                assert_eq!(revision_hash, "deadbeefcafebabe");
+2661	            }
+2662	            other => panic!("wrong artifact variant: {other:?}"),
+2663	        }
+2664	    }
+2665
+2666	    #[test]
+2667	    fn finalize_flake_job_falls_back_to_job_id_without_store_path() {
+2668	        let scratch = TempDir::new().unwrap();
+2669	        let job_dir = scratch.path().join("job");
+2670	        let artifact_out = scratch.path().join("out");
+2671	        std::fs::create_dir_all(&job_dir).unwrap();
+2672	        std::fs::create_dir_all(&artifact_out).unwrap();
+2673	        std::fs::write(
+2674	            job_dir.join("result"),
+2675	            r#"{"exit_code":0,"stderr_tail":""}"#,
+2676	        )
+2677	        .unwrap();
+2678	        std::fs::write(artifact_out.join("rootfs.ext4"), b"rootfs").unwrap();
+2679
+2680	        let artifacts = finalize_flake_job(&job_dir, &artifact_out, "fallback-job-id").unwrap();
+2681	        match artifacts {
+2682	            BuilderArtifacts::Image { revision_hash, .. } => {
+2683	                assert_eq!(revision_hash, "fallback-job-id");
+2684	            }
+2685	            other => panic!("wrong artifact variant: {other:?}"),
+2686	        }
+2687	    }
+2688
+2689	    #[test]
+2690	    fn acquire_nix_store_image_lock_creates_sparse_file_once() {
+2691	        let _lock = ENV_LOCK.lock().unwrap();
+2692	        // Sparse file allocates the logical size but consumes
+2693	        // ~no disk blocks. `set_len` is what asks the FS to
+2694	        // record the size. A later acquisition finds the existing
+2695	        // file and returns its path without retouching.
+2696	        let scratch = TempDir::new().unwrap();
+2697	        // Redirect the cache dir via XDG_CACHE_HOME to keep the
+2698	        // test hermetic — `mvm_core::config::mvm_cache_dir()`
+2699	        // honors the env var.
+2700	        let old = std::env::var("XDG_CACHE_HOME").ok();
+2701	        // SAFETY: tests run single-threaded for env mutation
+2702	        unsafe {
+2703	            std::env::set_var("XDG_CACHE_HOME", scratch.path());
+2704	        }
+```
+
+## Assistant
+
+<thinking>
+
+</thinking>
+
+**Tool Call: Edit .claude/worktrees/dev\-fd\-symlinks/crates/mvm\-build/src/libkrun_builder.rs**
+Status: Completed
+
+Diff: /Users/auser/work/tinylabs/mvmco/mvm/.claude/worktrees/dev-fd-symlinks/crates/mvm-build/src/libkrun_builder.rs
+
+```
+        let job_id = unique_job_id();
+        let job_dir = builder_vm_cache_dir().join("jobs").join(&job_id);
+        stage_shell_job_dir(&job_dir, &job.script)?;
+        // Tell the operator up-front where the build's stderr will
+        // land. `/job` is a virtio-fs share into the VM; the guest's
+        // cmd.sh redirects `nix build` stderr into <job_dir>/nix-
+        // stderr.log, which is this exact path on the host. A
+        // contributor watching a long build can `tail -f` it without
+        // waiting for the failure-path formatter (finalize_flake_job)
+        // to surface the same path.
+        tracing::info!(
+            job_dir = %job_dir.display(),
+            "builder VM job dir staged (nix-stderr.log streams here as the build runs)"
+        );
+
+        let vm_name = format!("mvm-builder-vm-{job_id}");
+        let vm_state_dir = builder_vm_cache_dir().join("vms").join(&vm_name);
+```
+
+**Tool Call: Edit .claude/worktrees/dev\-fd\-symlinks/crates/mvm\-build/src/libkrun_builder.rs**
+Status: Completed
+
+Diff: /Users/auser/work/tinylabs/mvmco/mvm/.claude/worktrees/dev-fd-symlinks/crates/mvm-build/src/libkrun_builder.rs
+
+```
+        let job_id = unique_job_id();
+        let job_dir = builder_vm_cache_dir().join("jobs").join(&job_id);
+        stage_job_dir(&job_dir, job)?;
+        // Same announcement as the single-shot path — see the
+        // identical block in `LibkrunBuilderVm::run_build`.
+        tracing::info!(
+            job_dir = %job_dir.display(),
+            "builder VM job dir staged (nix-stderr.log streams here as the build runs)"
+        );
+
+        // 7. Build the `KrunContext` libkrun consumes. Three
+        //    virtio-fs shares (work / out / job), one virtio-blk
+```
+
+## Assistant
+
+Now adding the read-last-bytes helper and updating `finalize_flake_job`.
+
+**Tool Call: Edit .claude/worktrees/dev\-fd\-symlinks/crates/mvm\-build/src/libkrun_builder.rs**
+Status: Completed
+
+Diff: /Users/auser/work/tinylabs/mvmco/mvm/.claude/worktrees/dev-fd-symlinks/crates/mvm-build/src/libkrun_builder.rs
+
+```
+    s.replace('\'', "'\\''")
+}
+
+/// Read the last `max_bytes` of `path` into a `String`, replacing any
+/// invalid UTF-8 lossily. Returns `Err` if the file is missing or
+/// unreadable. Used by `finalize_flake_job` to surface the tail of
+/// `<job_dir>/nix-stderr.log` (the cmd.sh's nix-build stderr capture)
+/// in the failure path without loading a multi-hundred-KB log into
+/// memory.
+fn read_last_bytes_of(path: &Path, max_bytes: u64) -> std::io::Result<String> {
+    use std::io::{Seek, SeekFrom};
+    let mut file = std::fs::File::open(path)?;
+    let len = file.metadata()?.len();
+    let take = max_bytes.min(len);
+    // SeekFrom::End wants i64; max_bytes is bounded to a small constant
+    // at every call site (4 KiB today) so the cast is safe.
+    let offset = i64::try_from(take).unwrap_or(i64::MAX).saturating_neg();
+    file.seek(SeekFrom::End(offset))?;
+    let mut buf = Vec::with_capacity(take as usize);
+    file.read_to_end(&mut buf)?;
+    Ok(String::from_utf8_lossy(&buf).into_owned())
+}
+
+/// Finalize a flake build: read `<job_dir>/result`, validate the
+/// `rootfs.ext4` (and optional `vmlinux`) landed in
+/// `artifact_out`, return a [`BuilderArtifacts::Image`].
+```
+
+Diff: /Users/auser/work/tinylabs/mvmco/mvm/.claude/worktrees/dev-fd-symlinks/crates/mvm-build/src/libkrun_builder.rs
+
+```
+) -> Result<BuilderArtifacts, BuilderVmError> {
+    let result = read_job_result(job_dir)?;
+    if result.exit_code != 0 {
+        // The 20-line `stderr_tail` in `result` is from the OUTER
+        // cmd.sh (run_job captures cmd.sh's stderr into a 20-line
+        // ringbuffer). That ringbuffer typically only carries the
+        // "nix build exited N; tail of stderr:" preamble — not the
+        // real per-derivation failure. The actual nix-build stderr
+        // is at `<job_dir>/nix-stderr.log` (cmd.sh redirects there
+        // via `2> /job/nix-stderr.log`). Surface its tail so the
+        // operator doesn't have to know the convention.
+        let stderr_log = job_dir.join("nix-stderr.log");
+        let derivation_tail = read_last_bytes_of(&stderr_log, 4 * 1024)
+            .unwrap_or_else(|_| String::from("<nix-stderr.log not present on host>"));
+        return Err(BuilderVmError::NixBuildFailed(format!(
+            "guest cmd.sh exited {} — full log: {}\n\
+             outer stderr tail (cmd.sh ringbuffer):\n{}\n\
+             derivation stderr tail (last 4 KiB of {}):\n{}",
+            result.exit_code,
+            stderr_log.display(),
+            result.stderr_tail,
+            stderr_log.display(),
+            derivation_tail,
+        )));
+    }
+
+```
+
+## Assistant
+
+Now the tests for the new failure formatter and helper.
+
+**Tool Call: Edit .claude/worktrees/dev\-fd\-symlinks/crates/mvm\-build/src/libkrun_builder.rs**
+Status: Completed
+
+Diff: /Users/auser/work/tinylabs/mvmco/mvm/.claude/worktrees/dev-fd-symlinks/crates/mvm-build/src/libkrun_builder.rs
+
+```
+        }
+    }
+
+    /// `read_last_bytes_of` returns the trailing `max_bytes` of a
+    /// file. When the file is larger than the cap, we get the *end*,
+    /// not the head — the use case is tailing nix-build stderr where
+    /// the cause-of-death is at the bottom.
+    #[test]
+    fn read_last_bytes_of_returns_trailing_window_when_file_exceeds_cap() {
+        let scratch = TempDir::new().unwrap();
+        let path = scratch.path().join("log");
+        let mut body = String::new();
+        for i in 0..2_000 {
+            body.push_str(&format!("line {i}\n"));
+        }
+        std::fs::write(&path, &body).unwrap();
+        let tail = read_last_bytes_of(&path, 200).unwrap();
+        assert!(tail.len() <= 200);
+        assert!(tail.contains("line 1999"), "tail contains the last line");
+        assert!(
+            !tail.contains("line 0\n"),
+            "tail does not include the head: {tail}"
+        );
+    }
+
+    /// Small file: the helper returns the whole file (capped at its
+    /// real length, not the requested max).
+    #[test]
+    fn read_last_bytes_of_returns_entire_file_when_smaller_than_cap() {
+        let scratch = TempDir::new().unwrap();
+        let path = scratch.path().join("log");
+        std::fs::write(&path, b"hello world").unwrap();
+        let tail = read_last_bytes_of(&path, 4096).unwrap();
+        assert_eq!(tail, "hello world");
+    }
+
+    /// Missing file surfaces as an `io::Error`; the caller in
+    /// `finalize_flake_job` swallows it into a `<not present>`
+    /// sentinel rather than failing the whole error format.
+    #[test]
+    fn read_last_bytes_of_errors_on_missing_file() {
+        let scratch = TempDir::new().unwrap();
+        let err = read_last_bytes_of(&scratch.path().join("missing"), 1024).unwrap_err();
+        assert_eq!(err.kind(), std::io::ErrorKind::NotFound);
+    }
+
+    /// The failure-path error message names the nix-stderr.log path
+    /// AND inlines its tail. This is the diagnostic-surface fix —
+    /// before the change, callers got the outer cmd.sh ringbuffer
+    /// only, with no hint where the real log lived.
+    #[test]
+    fn finalize_flake_job_failure_includes_nix_stderr_log_path_and_tail() {
+        let scratch = TempDir::new().unwrap();
+        let job_dir = scratch.path().join("job");
+        let artifact_out = scratch.path().join("out");
+        std::fs::create_dir_all(&job_dir).unwrap();
+        std::fs::create_dir_all(&artifact_out).unwrap();
+        std::fs::write(
+            job_dir.join("result"),
+            r#"{"exit_code":1,"stderr_tail":"outer-tail"}"#,
+        )
+        .unwrap();
+        // Sentinel string the helper must surface — proves we're
+        // reading from THIS file and not from the outer ringbuffer.
+        std::fs::write(
+            job_dir.join("nix-stderr.log"),
+            "/nix/store/.../cargo-install-hook.sh: line 27: /dev/fd/63: No such file or directory\n",
+        )
+        .unwrap();
+
+        let err = finalize_flake_job(&job_dir, &artifact_out, "job-id").unwrap_err();
+        let msg = match err {
+            BuilderVmError::NixBuildFailed(s) => s,
+            other => panic!("expected NixBuildFailed, got {other:?}"),
+        };
+        assert!(msg.contains("exited 1"), "names exit code: {msg}");
+        assert!(
+            msg.contains(job_dir.join("nix-stderr.log").to_string_lossy().as_ref()),
+            "names the full log path: {msg}"
+        );
+        assert!(
+            msg.contains("/dev/fd/63: No such file or directory"),
+            "inlines the real derivation stderr tail: {msg}"
+        );
+        assert!(
+            msg.contains("outer-tail"),
+            "still includes the outer ringbuffer for context: {msg}"
+        );
+    }
+
+    /// Missing `nix-stderr.log` doesn't crash the formatter — we get
+    /// a clean sentinel instead of an `Err(...)` cascade. This
+    /// matters for very-early failures (e.g. cmd.sh exit before the
+    /// `2> /job/nix-stderr.log` redirect runs).
+    #[test]
+    fn finalize_flake_job_failure_handles_missing_nix_stderr_log_cleanly() {
+        let scratch = TempDir::new().unwrap();
+        let job_dir = scratch.path().join("job");
+        let artifact_out = scratch.path().join("out");
+        std::fs::create_dir_all(&job_dir).unwrap();
+        std::fs::create_dir_all(&artifact_out).unwrap();
+        std::fs::write(
+            job_dir.join("result"),
+            r#"{"exit_code":2,"stderr_tail":"no cmd.sh"}"#,
+        )
+        .unwrap();
+
+        let err = finalize_flake_job(&job_dir, &artifact_out, "job-id").unwrap_err();
+        let msg = match err {
+            BuilderVmError::NixBuildFailed(s) => s,
+            other => panic!("expected NixBuildFailed, got {other:?}"),
+        };
+        assert!(
+            msg.contains("<nix-stderr.log not present on host>"),
+            "sentinel surfaces in place of missing log: {msg}"
+        );
+        assert!(msg.contains("no cmd.sh"), "outer tail still surfaces: {msg}");
+    }
+
+    #[test]
+    fn acquire_nix_store_image_lock_creates_sparse_file_once() {
+        let _lock = ENV_LOCK.lock().unwrap();
+        // Sparse file allocates the logical size but consumes
+```
+
+**Tool Call: cd /Users/auser/work/tinylabs/mvmco/mvm/.claude/worktrees/dev-fd-symlinks && cargo fmt --all -- --check 2>&1 | tail -20**
+Status: Completed
+
+Terminal:
+
+```
+         );
+-        assert!(msg.contains("no cmd.sh"), "outer tail still surfaces: {msg}");
++        assert!(
++            msg.contains("no cmd.sh"),
++            "outer tail still surfaces: {msg}"
++        );
+     }
+
+     #[test]
+Diff in /Users/auser/work/tinylabs/mvmco/mvm/.claude/worktrees/dev-fd-symlinks/crates/mvm-builder-init/src/main.rs:2392:
+         #[test]
+         fn setup_dev_fd_symlinks_errors_when_dev_root_missing() {
+             let bogus = std::path::PathBuf::from("/this/path/should/not/exist/mvm-dev-fd-test");
+-            let err = setup_dev_fd_symlinks(&bogus)
+-                .expect_err("missing dev_root must error, not panic");
++            let err =
++                setup_dev_fd_symlinks(&bogus).expect_err("missing dev_root must error, not panic");
+             assert!(
+                 err.contains("/this/path/should/not/exist"),
+                 "error names the offending parent path: {err}"
+```
+
+**Tool Call: cargo fmt --all 2>&1 | tail -5**
+Status: Completed
+
+Terminal:
+
+```
+[This command modified 2 files you've previously read: crates/mvm-build/src/libkrun_builder.rs, crates/mvm-builder-init/src/main.rs. Call Read before editing.]
+
+
+```
+
+## Assistant
+
+<thinking>
+
+</thinking>
+
+**Tool Call: git -C /Users/auser/work/tinylabs/mvmco/mvm status --short && echo "---worktree---" && git -C /Users/auser/work/tinylabs/mvmco/mvm/.claude/worktrees/dev-fd-symlinks status --short**
+Status: Completed
+
+Terminal:
+
+```
+---worktree---
+ M crates/mvm-build/src/libkrun_builder.rs
+ M crates/mvm-builder-init/src/main.rs
+ M nix/lib/mk-guest.nix
+
+```
+
+## Assistant
+
+<thinking>
+
+</thinking>
+
+cargo fmt ran from main (which is clean — no changes). I need to apply it in the worktree.
+
+**Tool Call: cargo fmt --all && cargo fmt --all -- --check 2>&1 | tail -10**
+Status: Completed
+
+Terminal:
+
+```
+(Bash completed with no output)
+
+
+
+
+```
+
+## Assistant
+
+<thinking>
+
+</thinking>
+
+**Tool Call: cargo fmt --all && cargo fmt --all -- --check && echo "FMT OK"**
+Status: Completed
+
+Terminal:
+
+```
+FMT OK
+
+
+
+
+```
+
+## Assistant
+
+<thinking>
+
+</thinking>
+
+**Tool Call: pwd && cargo fmt --all -- --check 2>&1 | tail -10; echo "---rc: $?"**
+Status: Completed
+
+Terminal:
+
+```
+/Users/auser/work/tinylabs/mvmco/mvm/.claude/worktrees/dev-fd-symlinks
+---rc: 0
+
+
+
+```
+
+## Assistant
+
+<thinking>
+
+</thinking>
+
+In the worktree. fmt clean. Running clippy + tests.
+
+**Tool Call: cargo clippy --workspace --all-targets -- -D warnings 2>&1 | tail -40**
+Status: Completed
+
+Terminal:
+
+```
+    Checking num_cpus v1.17.0
+    Checking deadpool-runtime v0.1.4
+    Checking mvm-runner v0.14.0 (/Users/auser/work/tinylabs/mvmco/mvm/.claude/worktrees/dev-fd-symlinks/crates/mvm-runner)
+    Checking rand v0.10.1
+    Checking roff v1.1.0
+    Checking mvm-addon-vsock-bridge v0.14.0 (/Users/auser/work/tinylabs/mvmco/mvm/.claude/worktrees/dev-fd-symlinks/crates/mvm-addon-vsock-bridge)
+    Checking mvm-egress-proxy v0.14.0 (/Users/auser/work/tinylabs/mvmco/mvm/.claude/worktrees/dev-fd-symlinks/crates/mvm-egress-proxy)
+    Checking futures v0.3.32
+    Checking hyper v0.14.32
+    Checking deadpool v0.12.3
+    Checking clap_mangen v0.2.33
+    Checking mvm-policy v0.14.0 (/Users/auser/work/tinylabs/mvmco/mvm/.claude/worktrees/dev-fd-symlinks/crates/mvm-policy)
+    Checking mvm-guest v0.14.0 (/Users/auser/work/tinylabs/mvmco/mvm/.claude/worktrees/dev-fd-symlinks/crates/mvm-guest)
+    Checking mvm-storage v0.14.0 (/Users/auser/work/tinylabs/mvmco/mvm/.claude/worktrees/dev-fd-symlinks/crates/mvm-storage)
+    Checking wiremock v0.6.5
+    Checking hickory-proto v0.26.1
+    Checking mvm-sdk-macros v0.14.0 (/Users/auser/work/tinylabs/mvmco/mvm/.claude/worktrees/dev-fd-symlinks/crates/mvm-sdk-macros)
+    Checking mvm-builder-init v0.14.0 (/Users/auser/work/tinylabs/mvmco/mvm/.claude/worktrees/dev-fd-symlinks/crates/mvm-builder-init)
+    Checking mvm-addon-dns v0.14.0 (/Users/auser/work/tinylabs/mvmco/mvm/.claude/worktrees/dev-fd-symlinks/crates/mvm-addon-dns)
+   Compiling async-attributes v1.1.2
+    Checking async-std v1.13.2
+   Compiling basic-cookies v0.1.5
+    Checking async-object-pool v0.1.5
+    Checking httpmock v0.7.0
+    Checking rustls-webpki v0.103.13
+    Checking tokio-rustls v0.26.4
+    Checking rustls-platform-verifier v0.7.0
+    Checking hyper-rustls v0.27.7
+    Checking reqwest v0.12.28
+    Checking reqwest v0.13.3
+    Checking oci-client v0.16.1
+    Checking mvm-build v0.14.0 (/Users/auser/work/tinylabs/mvmco/mvm/.claude/worktrees/dev-fd-symlinks/crates/mvm-build)
+    Checking mvm-oci v0.14.0 (/Users/auser/work/tinylabs/mvmco/mvm/.claude/worktrees/dev-fd-symlinks/crates/mvm-oci)
+    Checking mvm-base v0.14.0 (/Users/auser/work/tinylabs/mvmco/mvm/.claude/worktrees/dev-fd-symlinks/crates/mvm-base)
+    Checking mvm-backend v0.14.0 (/Users/auser/work/tinylabs/mvmco/mvm/.claude/worktrees/dev-fd-symlinks/crates/mvm-backend)
+    Checking mvm v0.14.0 (/Users/auser/work/tinylabs/mvmco/mvm/.claude/worktrees/dev-fd-symlinks/crates/mvm)
+    Checking mvm-supervisor v0.14.0 (/Users/auser/work/tinylabs/mvmco/mvm/.claude/worktrees/dev-fd-symlinks/crates/mvm-supervisor)
+    Checking mvm-cli v0.14.0 (/Users/auser/work/tinylabs/mvmco/mvm/.claude/worktrees/dev-fd-symlinks/crates/mvm-cli)
+    Checking xtask v0.0.0 (/Users/auser/work/tinylabs/mvmco/mvm/.claude/worktrees/dev-fd-symlinks/xtask)
+    Finished `dev` profile [unoptimized + debuginfo] target(s) in 34.85s
+```
+
+## Assistant
+
+Clippy clean. Running tests now.
+
+**Tool Call: cargo test -p mvm-builder-init setup_dev_fd_symlinks -- --nocapture 2>&1 | tail -30**
+Status: Completed
+
+Terminal:
+
+```
+   Compiling cfb-mode v0.8.2
+   Compiling des v0.8.1
+   Compiling ripemd v0.1.3
+   Compiling md-5 v0.10.6
+   Compiling block-padding v0.3.3
+   Compiling nom v8.0.0
+   Compiling buffer-redux v1.1.0
+   Compiling replace_with v0.1.8
+   Compiling home v0.5.12
+   Compiling tokio-rustls v0.26.4
+   Compiling which v6.0.3
+   Compiling hyper-rustls v0.27.7
+   Compiling reqwest v0.12.28
+   Compiling mvm-sdk v0.14.0 (/Users/auser/work/tinylabs/mvmco/mvm/.claude/worktrees/dev-fd-symlinks/crates/mvm-sdk)
+   Compiling objc2-app-kit v0.3.2
+   Compiling pgp v0.17.0
+   Compiling objc2-virtualization v0.3.2
+   Compiling mvm-providers v0.14.0 (/Users/auser/work/tinylabs/mvmco/mvm/.claude/worktrees/dev-fd-symlinks/crates/mvm-providers)
+   Compiling mvm-core v0.14.0 (/Users/auser/work/tinylabs/mvmco/mvm/.claude/worktrees/dev-fd-symlinks/crates/mvm-core)
+   Compiling mvm-security v0.14.0 (/Users/auser/work/tinylabs/mvmco/mvm/.claude/worktrees/dev-fd-symlinks/crates/mvm-security)
+   Compiling mvm-guest v0.14.0 (/Users/auser/work/tinylabs/mvmco/mvm/.claude/worktrees/dev-fd-symlinks/crates/mvm-guest)
+   Compiling mvm-build v0.14.0 (/Users/auser/work/tinylabs/mvmco/mvm/.claude/worktrees/dev-fd-symlinks/crates/mvm-build)
+   Compiling mvm-builder-init v0.14.0 (/Users/auser/work/tinylabs/mvmco/mvm/.claude/worktrees/dev-fd-symlinks/crates/mvm-builder-init)
+    Finished `test` profile [unoptimized + debuginfo] target(s) in 18.22s
+     Running unittests src/main.rs (target/debug/deps/mvm_builder_init-73ff275e7cbf4322)
+
+running 0 tests
+
+test result: ok. 0 passed; 0 failed; 0 ignored; 0 measured; 69 filtered out; finished in 0.00s
+```
+
+**Tool Call: cargo test -p mvm-build read_last_bytes_of finalize_flake_job_failure -- --nocapture 2>&1 | tail -30**
+Status: Completed
+
+Terminal:
+
+```
+error: unexpected argument 'finalize_flake_job_failure' found
+
+Usage: cargo test [OPTIONS] [TESTNAME] [-- [ARGS]...]
+
+For more information, try '--help'.
+```
+
+## Assistant
+
+<thinking>
+
+</thinking>
+
+Test ran 0 — module is `#[cfg(target_os = "linux")]` gated. Let me check structure and fix.
+
+**Tool Call: Read .claude/worktrees/dev-fd-symlinks/crates/mvm-builder-init/src/main.rs (258 - 272)**
+Status: Completed
+
+```
+258
+259	#[cfg(target_os = "linux")]
+260	mod linux {
+261	    use std::path::Path;
+262	    use std::process::{Command, ExitCode};
+263	    use std::sync::{Arc, Mutex};
+264	    use std::time::Instant;
+265
+266	    use crate::boot_timings::BootTimings;
+267
+268	    /// Persistent Nix-store device — virtio-blk attached as
+269	    /// `/dev/vdb` by `LibkrunBuilderVm` (Plan 72 W4 will wire
+270	    /// the `extra_disks` entry).
+271	    const NIX_STORE_DEV: &str = "/dev/vdb";
+272
+```
+
+**Tool Call: Read .claude/worktrees/dev-fd-symlinks/crates/mvm-builder-init/src/main.rs (165 - 194)**
+Status: Completed
+
+```
+165	    total_blocks.checked_mul(block_size)
+166	}
+167
+168	#[cfg(test)]
+169	mod tests {
+170	    use super::*;
+171
+172	    #[test]
+173	    fn virtiofs_tag_policy_keeps_only_workspace_read_only() {
+174	        assert!(virtiofs_tag_is_read_only("work"));
+175	        assert!(!virtiofs_tag_is_read_only("out"));
+176	        assert!(!virtiofs_tag_is_read_only("job"));
+177	    }
+178
+179	    /// Build a synthetic ext4 superblock buffer (just the fields
+180	    /// `parse_ext4_recorded_size_bytes` reads).
+181	    fn synth_sb(blocks_lo: u32, blocks_hi: u32, log_block_size: u32) -> Vec<u8> {
+182	        let mut sb = vec![0u8; EXT4_SUPERBLOCK_READ];
+183	        sb[0x04..0x08].copy_from_slice(&blocks_lo.to_le_bytes());
+184	        sb[0x18..0x1c].copy_from_slice(&log_block_size.to_le_bytes());
+185	        sb[0x38] = 0x53;
+186	        sb[0x39] = 0xEF;
+187	        sb[0x150..0x154].copy_from_slice(&blocks_hi.to_le_bytes());
+188	        sb
+189	    }
+190
+191	    #[test]
+192	    fn parse_ext4_size_rejects_buffer_without_magic() {
+193	        let sb = vec![0u8; EXT4_SUPERBLOCK_READ];
+194	        assert_eq!(parse_ext4_recorded_size_bytes(&sb), None);
+```
+
+## Assistant
+
+<thinking>
+
+</thinking>
+
+Need to move the helper to file scope so tests run cross-platform. Refactoring.
+
+**Tool Call: Edit .claude/worktrees/dev\-fd\-symlinks/crates/mvm\-builder\-init/src/main.rs**
+Status: Completed
+
+Diff: /Users/auser/work/tinylabs/mvmco/mvm/.claude/worktrees/dev-fd-symlinks/crates/mvm-builder-init/src/main.rs
+
+```
+        // `/dev/std{in,out,err}` are conventionally present as well;
+        // we install all four so future hooks that depend on them
+        // don't trip the same surprise.
+        crate::setup_dev_fd_symlinks(Path::new("/dev"))?;
+        Ok(())
+    }
+
+    /// Plan 76 Phase 5: serial chain that gates job execution.
+    /// /dev/vdb format (first boot only) → mount → overlay-mount
+    /// rootfs `/nix` with persistent upper/work dirs → bind-mount
+```
+
+## Assistant
+
+Now adding the helper at file scope (cross-platform) and moving tests up too.
+
+**Tool Call: Read .claude/worktrees/dev-fd-symlinks/crates/mvm-builder-init/src/main.rs (155 - 174)**
+Status: Completed
+
+```
+155	    let log_block_size = u32::from_le_bytes(sb[0x18..0x1c].try_into().ok()?);
+156	    let blocks_hi = u32::from_le_bytes(sb[0x150..0x154].try_into().ok()?);
+157	    // Reject absurd block sizes — ext4 spec allows 1 KiB..64 KiB
+158	    // (log values 0..=6). Anything higher signals a malformed or
+159	    // stale superblock; treat as unformatted.
+160	    if log_block_size > 6 {
+161	        return None;
+162	    }
+163	    let block_size = 1024u64 << log_block_size;
+164	    let total_blocks = (u64::from(blocks_hi) << 32) | u64::from(blocks_lo);
+165	    total_blocks.checked_mul(block_size)
+166	}
+167
+168	#[cfg(test)]
+169	mod tests {
+170	    use super::*;
+171
+172	    #[test]
+173	    fn virtiofs_tag_policy_keeps_only_workspace_read_only() {
+174	        assert!(virtiofs_tag_is_read_only("work"));
+```
+
+**Tool Call: Edit .claude/worktrees/dev\-fd\-symlinks/crates/mvm\-builder\-init/src/main.rs**
+Status: Completed
+
+Diff: /Users/auser/work/tinylabs/mvmco/mvm/.claude/worktrees/dev-fd-symlinks/crates/mvm-builder-init/src/main.rs
+
+```
+    total_blocks.checked_mul(block_size)
+}
+
+/// Create `/dev/fd → /proc/self/fd` and `/dev/std{in,out,err} →
+/// /proc/self/fd/{0,1,2}` under `dev_root`. Idempotent: any entry that
+/// already exists (file, symlink, or device node) is left untouched —
+/// we never replace whatever the kernel or a prior boot has put there.
+///
+/// `dev_root` is a parameter so this helper is testable under a
+/// `tempfile::tempdir()` without privilege. The targets are written as
+/// absolute `/proc/self/fd/...` strings on purpose: they're consumed
+/// by code running inside the guest Linux VM where `/proc` is the
+/// procfs mount point. The helper itself is cross-platform — symlink
+/// creation works on macOS too — so unit tests run on contributor Macs
+/// in addition to the production Linux build target.
+pub(crate) fn setup_dev_fd_symlinks(dev_root: &std::path::Path) -> Result<(), String> {
+    use std::os::unix::fs::symlink;
+    for (link_name, target) in [
+        ("fd", "/proc/self/fd"),
+        ("stdin", "/proc/self/fd/0"),
+        ("stdout", "/proc/self/fd/1"),
+        ("stderr", "/proc/self/fd/2"),
+    ] {
+        let link = dev_root.join(link_name);
+        // `Path::exists` follows symlinks; `symlink_metadata` does
+        // not. We want "is there anything at this path?", which is
+        // the symlink_metadata question — otherwise a dangling
+        // symlink left over from a prior boot would be treated as
+        // absent and we'd EEXIST on the symlink call.
+        if link.symlink_metadata().is_ok() {
+            continue;
+        }
+        symlink(target, &link)
+            .map_err(|e| format!("symlink {} -> {target}: {e}", link.display()))?;
+    }
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+```
+
+## Assistant
+
+Now I need to remove the duplicate tests from the linux module's tests and re-add them in the file-scope tests module.
+
+**Tool Call: Edit .claude/worktrees/dev\-fd\-symlinks/crates/mvm\-builder\-init/src/main.rs**
+Status: Completed
+
+Diff: /Users/auser/work/tinylabs/mvmco/mvm/.claude/worktrees/dev-fd-symlinks/crates/mvm-builder-init/src/main.rs
+
+```
+            assert_eq!([0x53u8, 0xEFu8], 0xEF53u16.to_le_bytes());
+        }
+
+        #[test]
+        fn virtiofs_mount_flags_keep_workspace_read_only() {
+            use nix::mount::MsFlags;
+
+```
+
+**Tool Call: Edit .claude/worktrees/dev\-fd\-symlinks/crates/mvm\-builder\-init/src/main.rs**
+Status: Completed
+
+Diff: /Users/auser/work/tinylabs/mvmco/mvm/.claude/worktrees/dev-fd-symlinks/crates/mvm-builder-init/src/main.rs
+
+```
+mod tests {
+    use super::*;
+
+    /// `setup_dev_fd_symlinks` lays down all four conventional symlinks
+    /// in an empty /dev so bash process substitution (`< <(...)`)
+    /// finds `/dev/fd/N`. The targets are the `/proc/self/fd` family;
+    /// the symlink_metadata-based skip keeps the helper idempotent on
+    /// reboot. Cross-platform: runs on macOS and Linux.
+    #[test]
+    fn setup_dev_fd_symlinks_creates_all_four_in_empty_dir() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        setup_dev_fd_symlinks(dir.path()).expect("fresh dev_root succeeds");
+        for (name, expected) in [
+            ("fd", "/proc/self/fd"),
+            ("stdin", "/proc/self/fd/0"),
+            ("stdout", "/proc/self/fd/1"),
+            ("stderr", "/proc/self/fd/2"),
+        ] {
+            let link = dir.path().join(name);
+            let target = std::fs::read_link(&link)
+                .unwrap_or_else(|e| panic!("read_link {}: {e}", link.display()));
+            assert_eq!(
+                target.to_string_lossy(),
+                expected,
+                "{name} points at the right /proc/self/fd target"
+            );
+        }
+    }
+
+    /// Idempotency: a pre-existing entry — even a dangling symlink
+    /// left over from a prior boot — is preserved. We never clobber
+    /// what the kernel/initramfs/previous boot staged. Guards
+    /// against, e.g., a future devtmpfs variant that creates
+    /// `/dev/stdin` as a character device.
+    #[test]
+    fn setup_dev_fd_symlinks_is_idempotent_when_already_present() {
+        use std::os::unix::fs::symlink;
+        let dir = tempfile::tempdir().expect("tempdir");
+        symlink("/sentinel", dir.path().join("fd")).expect("pre-stage symlink");
+        setup_dev_fd_symlinks(dir.path()).expect("idempotent run succeeds");
+        assert_eq!(
+            std::fs::read_link(dir.path().join("fd"))
+                .expect("read_link fd")
+                .to_string_lossy(),
+            "/sentinel",
+            "sentinel preserved"
+        );
+        for name in ["stdin", "stdout", "stderr"] {
+            assert!(
+                dir.path().join(name).symlink_metadata().is_ok(),
+                "{name} created on a partially-staged /dev"
+            );
+        }
+    }
+
+    /// A non-existent `dev_root` surfaces as a clean error message
+    /// that names the path. The first failing symlink is enough —
+    /// we don't try to be smart about pre-checking the parent.
+    #[test]
+    fn setup_dev_fd_symlinks_errors_when_dev_root_missing() {
+        let bogus = std::path::PathBuf::from("/this/path/should/not/exist/mvm-dev-fd-test");
+        let err =
+            setup_dev_fd_symlinks(&bogus).expect_err("missing dev_root must error, not panic");
+        assert!(
+            err.contains("/this/path/should/not/exist"),
+            "error names the offending parent path: {err}"
+        );
+    }
+
+    #[test]
+    fn virtiofs_tag_policy_keeps_only_workspace_read_only() {
+        assert!(virtiofs_tag_is_read_only("work"));
+        assert!(!virtiofs_tag_is_read_only("out"));
+```
+
+**Tool Call: cargo fmt --all && cargo test -p mvm-builder-init setup_dev_fd 2>&1 | tail -20**
+Status: Completed
+
+Terminal:
+
+```
+   Compiling mvm-builder-init v0.14.0 (/Users/auser/work/tinylabs/mvmco/mvm/.claude/worktrees/dev-fd-symlinks/crates/mvm-builder-init)
+    Finished `test` profile [unoptimized + debuginfo] target(s) in 0.64s
+     Running unittests src/main.rs (target/debug/deps/mvm_builder_init-73ff275e7cbf4322)
+
+running 3 tests
+test tests::setup_dev_fd_symlinks_errors_when_dev_root_missing ... ok
+test tests::setup_dev_fd_symlinks_creates_all_four_in_empty_dir ... ok
+test tests::setup_dev_fd_symlinks_is_idempotent_when_already_present ... ok
+
+test result: ok. 3 passed; 0 failed; 0 ignored; 0 measured; 69 filtered out; finished in 0.00s
+```
+
+## Assistant
+
+Three tests passing. Now the mvm-build tests.
+
+**Tool Call: cargo test -p mvm-build -- read_last_bytes_of finalize_flake_job 2>&1 | tail -20**
+Status: Completed
+
+Terminal:
+
+```
+test result: ok. 0 passed; 0 failed; 0 ignored; 0 measured; 5 filtered out; finished in 0.00s
+
+     Running tests/runtime_overlay_build.rs (target/debug/deps/runtime_overlay_build-26f8ffd7442616f9)
+
+running 0 tests
+
+test result: ok. 0 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.00s
+
+     Running tests/vsock_response_listener.rs (target/debug/deps/vsock_response_listener-bc23cbcd48533b48)
+
+running 0 tests
+
+test result: ok. 0 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.00s
+
+   Doc-tests mvm_build
+
+running 0 tests
+
+test result: ok. 0 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.00s
+```
+
+## Assistant
+
+<thinking>
+
+</thinking>
+
+**Tool Call: cargo test -p mvm-build read_last_bytes_of 2>&1 | grep -E "running|test |result" | head -20**
+Status: Completed
+
+Terminal:
+
+```
+running 0 tests
+test result: ok. 0 passed; 0 failed; 0 ignored; 0 measured; 235 filtered out; finished in 0.00s
+running 0 tests
+test result: ok. 0 passed; 0 failed; 0 ignored; 0 measured; 13 filtered out; finished in 0.00s
+running 0 tests
+test result: ok. 0 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.00s
+running 0 tests
+test result: ok. 0 passed; 0 failed; 0 ignored; 0 measured; 23 filtered out; finished in 0.00s
+running 0 tests
+test result: ok. 0 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.00s
+running 0 tests
+test result: ok. 0 passed; 0 failed; 0 ignored; 0 measured; 8 filtered out; finished in 0.00s
+running 0 tests
+test result: ok. 0 passed; 0 failed; 0 ignored; 0 measured; 5 filtered out; finished in 0.00s
+running 0 tests
+test result: ok. 0 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.00s
+running 0 tests
+test result: ok. 0 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.00s
+```
+
+## Assistant
+
+<thinking>
+
+</thinking>
+
+**Tool Call: cargo test -p mvm-build finalize_flake_job_uses_store_path_hash 2>&1 | grep -E "running|test |result|error" | head -20**
+Status: Completed
+
+Terminal:
+
+```
+running 0 tests
+test result: ok. 0 passed; 0 failed; 0 ignored; 0 measured; 235 filtered out; finished in 0.00s
+running 0 tests
+test result: ok. 0 passed; 0 failed; 0 ignored; 0 measured; 13 filtered out; finished in 0.00s
+running 0 tests
+test result: ok. 0 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.00s
+running 0 tests
+test result: ok. 0 passed; 0 failed; 0 ignored; 0 measured; 23 filtered out; finished in 0.00s
+running 0 tests
+test result: ok. 0 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.00s
+running 0 tests
+test result: ok. 0 passed; 0 failed; 0 ignored; 0 measured; 8 filtered out; finished in 0.00s
+running 0 tests
+test result: ok. 0 passed; 0 failed; 0 ignored; 0 measured; 5 filtered out; finished in 0.00s
+running 0 tests
+test result: ok. 0 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.00s
+running 0 tests
+test result: ok. 0 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.00s
+```
+
+## Assistant
+
+<thinking>
+
+</thinking>
+
+**Tool Call: Read .claude/worktrees/dev-fd-symlinks/crates/mvm-build/src/libkrun_builder.rs (1 - 90)**
+Status: Completed
+
+```
+1	//! Libkrun-backed builder VM.
+2	//!
+3	//! Plan 72 ADR-046 chose libkrun-direct (on macOS Apple Silicon /
+4	//! Intel) and Firecracker (on Linux) as the replacement for the
+5	//! libkrun-backed builder VM. This module is the libkrun half;
+6	//! W1 → W4 of the migration shipped the launcher end-to-end.
+7	//!
+8	//! ## What `LibkrunBuilderVm` does
+9	//!
+10	//! Given a populated builder VM image cache and `mvm-libkrun-supervisor`
+11	//! on PATH, `run_build` runs a one-shot `nix build` against the
+12	//! caller's `BuilderJob` and returns `BuilderArtifacts`. The
+13	//! pipeline (in [`BuilderVm::run_build`]):
+14	//!
+15	//! 1. Validate mounts + job (`validate_mounts`, `validate_job`).
+16	//! 2. Check `mvm_libkrun::is_available()` — bail with install hint
+17	//!    if libkrun isn't on the host.
+18	//! 3. Locate `mvm-libkrun-supervisor` (env override / next-to-exe /
+19	//!    PATH).
+20	//! 4. Read the builder VM image from
+21	//!    `~/.cache/mvm/builder-vm/<arch>/` — vmlinux + rootfs.ext4 +
+22	//!    cmdline.txt + manifest.json, the shape Plan 72 W2's flake
+23	//!    emits. Populated by Plan 72 W5's `bootstrap_builder_vm_image`
+24	//!    (`mvm-cli::commands::env::apple_container`).
+25	//! 5. Allocate / reuse the persistent `/nix-store-<arch>.img`
+26	//!    sparse virtio-blk image (64 GiB cap by default; idempotent
+27	//!    across invocations so the warm Nix store survives).
+28	//! 6. Stage `<job_dir>/cmd.sh` with the shell-escaped flake_ref +
+29	//!    attr_path, plus the canonical `nix build` invocation.
+30	//! 7. Build a `KrunContext`: kernel + rootfs + cmdline + per-VM
+31	//!    vsock dir + virtio-blk (Nix store) + virtio-fs (work / out /
+32	//!    job).
+33	//! 8. Spawn `mvm-libkrun-supervisor`, pipe the `SupervisorConfig`
+34	//!    JSON to stdin, **wait** for it to exit (unlike
+35	//!    `LibkrunBackend::start` which returns after the PID file
+36	//!    appears — the builder is a one-shot).
+37	//! 9. Read `<job_dir>/result` (JSON: `{exit_code, stderr_tail}`)
+38	//!    that `mvm-builder-init` wrote.
+39	//! 10. Validate the artifact dir now contains `rootfs.ext4` (and
+40	//!     optionally `vmlinux`); return `BuilderArtifacts`.
+41	//!
+42	//! ## Feature gate
+43	//!
+44	//! Gated behind `builder-vm`. Default-off until
+45	//! Plan 72 W5.B / W5.C cutover flips `ensure_dev_image` to dispatch
+46	//! through `LibkrunBuilderVm`. Library consumers that don't need
+47	//! the libkrun builder build with `default-features = false`.
+48	//!
+49	//! ## Not the runtime backend
+50	//!
+51	//! `LibkrunBackend` (`crates/mvm-backend/src/libkrun.rs`) is for
+52	//! running user microVMs; this module is for building them. The
+53	//! two share `mvm-libkrun`'s FFI but compose differently — the
+54	//! builder mounts a workspace + persistent `/nix`-store disk and
+55	//! runs a one-shot `nix build`, while the runtime mounts the
+56	//! user's rootfs and runs the user's entrypoint.
+57
+58	use std::io::{Read, Write};
+59	use std::path::{Path, PathBuf};
+60	use std::process::{Child, Command, Stdio};
+61	use std::sync::atomic::{AtomicBool, Ordering};
+62	use std::sync::{Arc, Mutex};
+63	use std::time::{Duration, Instant};
+64
+65	use mvm_libkrun::{KrunContext, SupervisorConfig};
+66	use serde::Deserialize;
+67
+68	use crate::builder_vm::{BuilderArtifacts, BuilderJob, BuilderMounts, BuilderVm, BuilderVmError};
+69
+70	/// Default vCPU count for the builder VM. Nix builds are
+71	/// embarrassingly parallel at the derivation level; 4 cores is the
+72	/// sweet spot on M-series Macs without saturating the host.
+73	pub const DEFAULT_VCPUS: u8 = 4;
+74
+75	/// Default RAM in MiB. Originally 8 GiB (Plan 72 W5.D bullet 9 —
+76	/// in-VM nix builds peak ~5-6 GiB). Plan 95 raised this to 16 GiB
+77	/// alongside bumping the Stage 0 `/nix` tmpfs `size=` cap in
+78	/// `stage0/init.sh` (4G → 14G): tmpfs is RAM-backed, so the cap
+79	/// can only be honored if the VM has at least that much RAM. The
+80	/// real bottleneck in dev-up validation was the tmpfs cap, not the
+81	/// VM RAM — bumping VM RAM alone is a no-op as long as the
+82	/// `size=` mount option clips earlier. Keep these two in lockstep.
+83	pub const DEFAULT_MEMORY_MIB: u32 = 16384;
+84
+85	/// Default size of the persistent `/nix`-store virtio-blk image,
+86	/// in MiB. 64 GiB sparse — the file only consumes the bytes the
+87	/// in-VM ext4 actually writes, but capacity caps growth so a
+88	/// runaway build can't fill the host disk.
+89	pub const DEFAULT_NIX_STORE_MIB: u32 = 65536;
+90
+```
+
+**Tool Call: Read .claude/worktrees/dev-fd-symlinks/crates/mvm-build/src/libkrun_builder.rs (2155 - 2174)**
+Status: Completed
+
+```
+2155	        &self.vm_state_dir
+2156	    }
+2157
+2158	    /// Host-side path of the libkrun-managed Unix socket that
+2159	    /// proxies to AF_VSOCK [`mvm_guest::builder_agent::BUILDER_DISPATCH_PORT`]
+2160	    /// inside the guest. The W3 part 1
+2161	    /// `PersistentBuilderSupervisor::new` takes this directly.
+2162	    pub fn dispatch_socket_path(&self) -> PathBuf {
+2163	        self.vm_state_dir.join(format!(
+2164	            "vsock-{}.sock",
+2165	            mvm_guest::builder_agent::BUILDER_DISPATCH_PORT
+2166	        ))
+2167	    }
+2168
+2169	    /// Per-VM job directory bound at `/job` inside the guest.
+2170	    /// Hosts stage per-dispatch artifacts (`<job_dir_relpath>/cmd.sh`,
+2171	    /// per-dispatch install specs, etc.) here before sending the
+2172	    /// matching `BuilderRequest::Run`.
+2173	    pub fn job_dir(&self) -> &Path {
+2174	        &self.job_dir
+```
+
+**Tool Call: cargo test -p mvm-build --features builder-vm finalize_flake_job 2>&1 | grep -E "running|test |result|error\[" | head -20**
+Status: Completed
+
+Terminal:
+
+```
+running 4 tests
+test libkrun_builder::tests::finalize_flake_job_falls_back_to_job_id_without_store_path ... ok
+test libkrun_builder::tests::finalize_flake_job_failure_handles_missing_nix_stderr_log_cleanly ... ok
+test libkrun_builder::tests::finalize_flake_job_failure_includes_nix_stderr_log_path_and_tail ... ok
+test libkrun_builder::tests::finalize_flake_job_uses_store_path_hash_when_present ... ok
+test result: ok. 4 passed; 0 failed; 0 ignored; 0 measured; 292 filtered out; finished in 0.00s
+running 0 tests
+test result: ok. 0 passed; 0 failed; 0 ignored; 0 measured; 13 filtered out; finished in 0.00s
+running 0 tests
+test result: ok. 0 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.00s
+running 0 tests
+test result: ok. 0 passed; 0 failed; 0 ignored; 0 measured; 23 filtered out; finished in 0.00s
+running 0 tests
+test result: ok. 0 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.00s
+running 0 tests
+test result: ok. 0 passed; 0 failed; 0 ignored; 0 measured; 8 filtered out; finished in 0.00s
+running 0 tests
+test result: ok. 0 passed; 0 failed; 0 ignored; 0 measured; 5 filtered out; finished in 0.00s
+running 0 tests
+test result: ok. 0 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.00s
+```
+
+## Assistant
+
+All four `finalize_flake_job` tests pass with `--features builder-vm`. Now let me also test the read_last_bytes_of tests:
+
+**Tool Call: cargo test -p mvm-build --features builder-vm read_last_bytes_of 2>&1 | grep -E "running|test |result" | head -10**
+Status: Completed
+
+Terminal:
+
+```
+running 3 tests
+test libkrun_builder::tests::read_last_bytes_of_errors_on_missing_file ... ok
+test libkrun_builder::tests::read_last_bytes_of_returns_entire_file_when_smaller_than_cap ... ok
+test libkrun_builder::tests::read_last_bytes_of_returns_trailing_window_when_file_exceeds_cap ... ok
+test result: ok. 3 passed; 0 failed; 0 ignored; 0 measured; 293 filtered out; finished in 0.00s
+running 0 tests
+test result: ok. 0 passed; 0 failed; 0 ignored; 0 measured; 13 filtered out; finished in 0.00s
+running 0 tests
+test result: ok. 0 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.00s
+running 0 tests
+```
+
+## Assistant
+
+All 7 new tests passing. Running the full workspace test suite + clippy with the feature enabled.
+
+**Tool Call: cargo test --workspace --all-features 2>&1 | tail -15**
+Status: Completed
+
+Terminal:
+
+```
+     |
+     = note: multiple `impl`s satisfying `Cow<'_, str>: AsRef<_>` found in the following crates: `alloc`, `typed_path`:
+             - impl<T> AsRef<T> for Cow<'_, T>
+               where T: ToOwned, T: ?Sized;
+             - impl<T> AsRef<typed_path::common::utf8::path::Utf8Path<T>> for Cow<'_, str>
+               where for<'enc> T: typed_path::common::utf8::Utf8Encoding<'enc>;
+help: consider specifying the generic argument
+     |
+2817 |             msg.contains::<&T>(job_dir.join("nix-stderr.log").to_string_lossy().as_ref()),
+     |                         ++++++
+
+   Compiling mvm-backend v0.14.0 (/Users/auser/work/tinylabs/mvmco/mvm/.claude/worktrees/dev-fd-symlinks/crates/mvm-backend)
+For more information about this error, try `rustc --explain E0283`.
+error: could not compile `mvm-build` (lib test) due to 2 previous errors
+warning: build failed, waiting for other jobs to finish...
+```
+
+## Assistant
+
+<thinking>
+
+</thinking>
+
+Ambiguous `.as_ref()` with `typed_path` in deps. Disambiguating.
+
+**Tool Call: Edit .claude/worktrees/dev\-fd\-symlinks/crates/mvm\-build/src/libkrun_builder.rs**
+Status: Completed
+
+Diff: /Users/auser/work/tinylabs/mvmco/mvm/.claude/worktrees/dev-fd-symlinks/crates/mvm-build/src/libkrun_builder.rs
+
+```
+            other => panic!("expected NixBuildFailed, got {other:?}"),
+        };
+        assert!(msg.contains("exited 1"), "names exit code: {msg}");
+        let log_path = job_dir.join("nix-stderr.log");
+        assert!(
+            msg.contains(&*log_path.to_string_lossy()),
+            "names the full log path: {msg}"
+        );
+        assert!(
+```
+
+**Tool Call: cargo test --workspace --all-features 2>&1 | grep -E "^error|^warning._error|test result|FAILED|passed; ._ failed" | tail -30**
+Status: Canceled
+
+Terminal:
+
+```
+
+
+
+
+
+```
+
+## User
+
+continue
+
+**Tool Call: cargo test --workspace --all-features 2>&1 | grep -E "^error|^warning._error|test result|FAILED|passed; ._ failed" | tail -30**
+Status: Failed
+
+```
+Exit code 144
+```
+
+## Assistant
+
+<thinking>
+
+</thinking>
+
+**Tool Call: cargo test --workspace --all-features 2>&1 | tee /tmp/cargo-test-output.log | tail -40; echo "---rc $?"**
+Status: Canceled
+
+Terminal:
+
+```
+
+
+
+
+
+```
+
+## User
+
+Kill the other cargo commands for this project as I think there's a race condition to acquire the cargo lock and then rerun the tests
+
+## Assistant
+
+<thinking>
+
+</thinking>
+
+**Tool Call: ps -ax -o pid,etime,command | grep -E "cargo|rustc|nix-store" | grep -v grep | head -30**
+Status: Completed
+
+Terminal:
+
+```
+21655 01-12:42:23 /Users/auser/.cargo/bin/pest-language-server
+55792       06:02 cargo test --workspace --all-features
+68250       04:34 rustc --crate-name prost --edition=2021 /Users/auser/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/prost-0.14.3/src/lib.rs --error-format=json --json=diagnostic-rendered-ansi,artifacts,future-incompat --crate-type lib --emit=dep-info,metadata,link -C embed-bitcode=no -C debuginfo=2 -C split-debuginfo=unpacked --cfg feature="default" --cfg feature="derive" --cfg feature="std" --check-cfg cfg(docsrs,test) --check-cfg cfg(feature, values("default", "derive", "no-recursion-limit", "std")) -C metadata=7f01b76913555b49 -C extra-filename=-0367132c80ba38cb --out-dir /Users/auser/work/tinylabs/mvmco/mvm/target/debug/deps -L dependency=/Users/auser/work/tinylabs/mvmco/mvm/target/debug/deps --extern bytes=/Users/auser/work/tinylabs/mvmco/mvm/target/debug/deps/libbytes-9a9e3a6b11620b8a.rmeta --extern prost_derive=/Users/auser/work/tinylabs/mvmco/mvm/target/debug/deps/libprost_derive-72781147290a6808.dylib --cap-lints allow
+68988       04:19 rustc --crate-name tls_codec --edition=2021 /Users/auser/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/tls_codec-0.4.2/src/lib.rs --error-format=json --json=diagnostic-rendered-ansi,artifacts,future-incompat --crate-type lib --emit=dep-info,metadata,link -C embed-bitcode=no -C debuginfo=2 -C split-debuginfo=unpacked --warn=unexpected_cfgs --check-cfg cfg(fuzzing) --cfg feature="derive" --cfg feature="std" --cfg feature="tls_codec_derive" --check-cfg cfg(docsrs,test) --check-cfg cfg(feature, values("arbitrary", "conditional_deserialization", "default", "derive", "mls", "serde", "std", "tls_codec_derive")) -C metadata=917cf9803c825935 -C extra-filename=-dbf8d3d54c6bf4cc --out-dir /Users/auser/work/tinylabs/mvmco/mvm/target/debug/deps -L dependency=/Users/auser/work/tinylabs/mvmco/mvm/target/debug/deps --extern tls_codec_derive=/Users/auser/work/tinylabs/mvmco/mvm/target/debug/deps/libtls_codec_derive-473cf2e434eb8e33.dylib --extern zeroize=/Users/auser/work/tinylabs/mvmco/mvm/target/debug/deps/libzeroize-cb0fd3695b45c45c.rmeta --cap-lints allow
+71103       03:50 rustc --crate-name proc_macro_error --edition=2018 /Users/auser/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/proc-macro-error-1.0.4/src/lib.rs --error-format=json --json=diagnostic-rendered-ansi,artifacts,future-incompat --crate-type lib --emit=dep-info,metadata,link -C embed-bitcode=no --cfg feature="default" --cfg feature="syn" --cfg feature="syn-error" --check-cfg cfg(docsrs,test) --check-cfg cfg(feature, values("default", "syn", "syn-error")) -C metadata=1f753d337bf396b1 -C extra-filename=-a46464782b44907b --out-dir /Users/auser/work/tinylabs/mvmco/mvm/target/debug/deps -L dependency=/Users/auser/work/tinylabs/mvmco/mvm/target/debug/deps --extern proc_macro_error_attr=/Users/auser/work/tinylabs/mvmco/mvm/target/debug/deps/libproc_macro_error_attr-befc7505f1e6515b.dylib --extern proc_macro2=/Users/auser/work/tinylabs/mvmco/mvm/target/debug/deps/libproc_macro2-6747e5a55e220fcb.rmeta --extern quote=/Users/auser/work/tinylabs/mvmco/mvm/target/debug/deps/libquote-642bf102cf441c89.rmeta --extern syn=/Users/auser/work/tinylabs/mvmco/mvm/target/debug/deps/libsyn-9ccf270f9112ca8a.rmeta --cap-lints allow --cfg use_fallback
+76731       01:56 rustc --crate-name serde_with --edition=2021 /Users/auser/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/serde_with-3.17.0/src/lib.rs --error-format=json --json=diagnostic-rendered-ansi,artifacts,future-incompat --crate-type lib --emit=dep-info,metadata,link -C embed-bitcode=no -C debuginfo=2 -C split-debuginfo=unpacked --warn=rust_2018_idioms --warn=variant_size_differences --warn=unused_import_braces --warn=unused_extern_crates --warn=unexpected_cfgs --warn=trivial_numeric_casts --warn=trivial_casts --warn=clippy::semicolon_if_nothing_returned --warn=clippy::redundant_closure_for_method_calls --warn=missing_docs --warn=rustdoc::missing_crate_level_docs --allow=clippy::manual-unwrap-or-default --allow=clippy::explicit_auto_deref --warn=clippy::doc_markdown --warn=clippy::default_trait_access --warn=clippy::cloned_instead_of_copied --check-cfg cfg(tarpaulin) --check-cfg cfg(tarpaulin_include) --cfg feature="alloc" --cfg feature="base64" --cfg feature="default" --cfg feature="json" --cfg feature="macros" --cfg feature="std" --check-cfg cfg(docsrs,test) --check-cfg cfg(feature, values("alloc", "base64", "chrono", "chrono_0_4", "default", "guide", "hashbrown_0_14", "hashbrown_0_15", "hashbrown_0_16", "hex", "indexmap", "indexmap_1", "indexmap_2", "json", "macros", "schemars_0_8", "schemars_0_9", "schemars_1", "smallvec_1", "std", "time_0_3")) -C metadata=a658ad67ae9613a9 -C extra-filename=-efbc3933fd1a3087 --out-dir /Users/auser/work/tinylabs/mvmco/mvm/target/debug/deps -L dependency=/Users/auser/work/tinylabs/mvmco/mvm/target/debug/deps --extern base64=/Users/auser/work/tinylabs/mvmco/mvm/target/debug/deps/libbase64-d7e11b5d985cc70b.rmeta --extern serde_core=/Users/auser/work/tinylabs/mvmco/mvm/target/debug/deps/libserde_core-e4e38e9d475d8b16.rmeta --extern serde_json=/Users/auser/work/tinylabs/mvmco/mvm/target/debug/deps/libserde_json-0ef1d80c679bdc4d.rmeta --extern serde_with_macros=/Users/auser/work/tinylabs/mvmco/mvm/target/debug/deps/libserde_with_macros-4559ede2c53d42de.dylib --cap-lints allow
+79284       01:23 rustc --crate-name oci_spec --edition=2021 /Users/auser/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/oci-spec-0.9.0/src/lib.rs --error-format=json --json=diagnostic-rendered-ansi,artifacts,future-incompat --crate-type lib --emit=dep-info,metadata,link -C embed-bitcode=no -C debuginfo=2 -C split-debuginfo=unpacked --cfg feature="default" --cfg feature="distribution" --cfg feature="image" --cfg feature="runtime" --check-cfg cfg(docsrs,test) --check-cfg cfg(feature, values("default", "distribution", "image", "proptests", "quickcheck", "runtime")) -C metadata=c861c83419090b91 -C extra-filename=-c168b8e18a0343a6 --out-dir /Users/auser/work/tinylabs/mvmco/mvm/target/debug/deps -L dependency=/Users/auser/work/tinylabs/mvmco/mvm/target/debug/deps --extern const_format=/Users/auser/work/tinylabs/mvmco/mvm/target/debug/deps/libconst_format-400efe7976efbd49.rmeta --extern derive_builder=/Users/auser/work/tinylabs/mvmco/mvm/target/debug/deps/libderive_builder-812943b2d2d7dc89.rmeta --extern getset=/Users/auser/work/tinylabs/mvmco/mvm/target/debug/deps/libgetset-7b55efd26af04ea8.dylib --extern regex=/Users/auser/work/tinylabs/mvmco/mvm/target/debug/deps/libregex-371aa937d5128be5.rmeta --extern serde=/Users/auser/work/tinylabs/mvmco/mvm/target/debug/deps/libserde-7bd654656e843a22.rmeta --extern serde_json=/Users/auser/work/tinylabs/mvmco/mvm/target/debug/deps/libserde_json-0ef1d80c679bdc4d.rmeta --extern strum=/Users/auser/work/tinylabs/mvmco/mvm/target/debug/deps/libstrum-8b92174147bb9d00.rmeta --extern strum_macros=/Users/auser/work/tinylabs/mvmco/mvm/target/debug/deps/libstrum_macros-aa49cf4a69373d9e.dylib --extern thiserror=/Users/auser/work/tinylabs/mvmco/mvm/target/debug/deps/libthiserror-a96130da51f1a04c.rmeta --cap-lints allow
+79732       01:16 rustc --crate-name hickory_proto --edition=2021 /Users/auser/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/hickory-proto-0.24.4/src/lib.rs --error-format=json --json=diagnostic-rendered-ansi,artifacts,future-incompat --crate-type lib --emit=dep-info,metadata,link -C embed-bitcode=no -C debuginfo=2 -C split-debuginfo=unpacked --warn=unexpected_cfgs --check-cfg cfg(nightly) --cfg feature="tokio" --cfg feature="tokio-runtime" --check-cfg cfg(docsrs,test) --check-cfg cfg(feature, values("backtrace", "bytes", "default", "dns-over-h3", "dns-over-https", "dns-over-https-rustls", "dns-over-native-tls", "dns-over-openssl", "dns-over-quic", "dns-over-rustls", "dns-over-tls", "dnssec", "dnssec-openssl", "dnssec-ring", "h2", "h3", "h3-quinn", "http", "js-sys", "mdns", "native-certs", "native-tls", "openssl", "quinn", "ring", "rustls", "rustls-pemfile", "serde", "serde-config", "socket2", "testing", "text-parsing", "tokio", "tokio-native-tls", "tokio-openssl", "tokio-runtime", "tokio-rustls", "wasm-bindgen", "wasm-bindgen-crate", "webpki-roots")) -C metadata=55ea12024930fe4c -C extra-filename=-502bde3e4f740504 --out-dir /Users/auser/work/tinylabs/mvmco/mvm/target/debug/deps -L dependency=/Users/auser/work/tinylabs/mvmco/mvm/target/debug/deps --extern async_trait=/Users/auser/work/tinylabs/mvmco/mvm/target/debug/deps/libasync_trait-f6f4694e505991ba.dylib --extern cfg_if=/Users/auser/work/tinylabs/mvmco/mvm/target/debug/deps/libcfg_if-55e86337588f87e2.rmeta --extern data_encoding=/Users/auser/work/tinylabs/mvmco/mvm/target/debug/deps/libdata_encoding-b6adb28134cc6a9a.rmeta --extern enum_as_inner=/Users/auser/work/tinylabs/mvmco/mvm/target/debug/deps/libenum_as_inner-f151749594cc8c78.dylib --extern futures_channel=/Users/auser/work/tinylabs/mvmco/mvm/target/debug/deps/libfutures_channel-18c8448e1908808a.rmeta --extern futures_io=/Users/auser/work/tinylabs/mvmco/mvm/target/debug/deps/libfutures_io-183415fbd58b194c.rmeta --extern futures_util=/Users/auser/work/tinylabs/mvmco/mvm/target/debug/deps/libfutures_util-3b7788b159d1ffea.rmeta --extern idna=/Users/auser/work/tinylabs/mvmco/mvm/target/debug/deps/libidna-2614ff5df0213e05.rmeta --extern ipnet=/Users/auser/work/tinylabs/mvmco/mvm/target/debug/deps/libipnet-eee675a0ba6a4c91.rmeta --extern once_cell=/Users/auser/work/tinylabs/mvmco/mvm/target/debug/deps/libonce_cell-aa7b1933bafa5eda.rmeta --extern rand=/Users/auser/work/tinylabs/mvmco/mvm/target/debug/deps/librand-480aafb26437005a.rmeta --extern thiserror=/Users/auser/work/tinylabs/mvmco/mvm/target/debug/deps/libthiserror-f65c4f401e527d33.rmeta --extern tinyvec=/Users/auser/work/tinylabs/mvmco/mvm/target/debug/deps/libtinyvec-dc6205ad6469b72b.rmeta --extern tokio=/Users/auser/work/tinylabs/mvmco/mvm/target/debug/deps/libtokio-7c8333489ddbc65c.rmeta --extern tracing=/Users/auser/work/tinylabs/mvmco/mvm/target/debug/deps/libtracing-25938c2b75fa4a7a.rmeta --extern url=/Users/auser/work/tinylabs/mvmco/mvm/target/debug/deps/liburl-ad52e9b407733f62.rmeta --cap-lints allow
+81670       00:34 rustc --crate-name snafu --edition=2018 /Users/auser/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/snafu-0.8.9/src/lib.rs --error-format=json --json=diagnostic-rendered-ansi,artifacts,future-incompat --crate-type lib --emit=dep-info,metadata,link -C embed-bitcode=no -C debuginfo=2 -C split-debuginfo=unpacked --cfg feature="alloc" --cfg feature="default" --cfg feature="futures" --cfg feature="futures-core-crate" --cfg feature="pin-project" --cfg feature="rust_1_61" --cfg feature="rust_1_65" --cfg feature="rust_1_81" --cfg feature="std" --check-cfg cfg(docsrs,test) --check-cfg cfg(feature, values("alloc", "backtrace", "backtraces-impl-backtrace-crate", "default", "futures", "futures-core-crate", "futures-crate", "guide", "internal-dev-dependencies", "pin-project", "rust_1_61", "rust_1_65", "rust_1_81", "std", "unstable-core-error", "unstable-provider-api", "unstable-try-trait")) -C metadata=6f6fb13b48d1ba99 -C extra-filename=-ffae708f85f4d54a --out-dir /Users/auser/work/tinylabs/mvmco/mvm/target/debug/deps -L dependency=/Users/auser/work/tinylabs/mvmco/mvm/target/debug/deps --extern futures_core_crate=/Users/auser/work/tinylabs/mvmco/mvm/target/debug/deps/libfutures_core-087e04d66812378f.rmeta --extern pin_project=/Users/auser/work/tinylabs/mvmco/mvm/target/debug/deps/libpin_project-d1ea43adbde4e53e.rmeta --extern snafu_derive=/Users/auser/work/tinylabs/mvmco/mvm/target/debug/deps/libsnafu_derive-b932ff903c3534ba.dylib --cap-lints allow
+82351       00:20 rustc --crate-name mvm_addon_dns --edition=2024 crates/mvm-addon-dns/src/lib.rs --error-format=json --json=diagnostic-rendered-ansi,artifacts,future-incompat --emit=dep-info,link -C embed-bitcode=no -C debuginfo=2 -C split-debuginfo=unpacked --deny=clippy::too_many_arguments --test --check-cfg cfg(docsrs,test) --check-cfg cfg(feature, values()) -C metadata=1885bbe80a7f3be0 -C extra-filename=-da5804eefa6890e7 --out-dir /Users/auser/work/tinylabs/mvmco/mvm/target/debug/deps -C incremental=/Users/auser/work/tinylabs/mvmco/mvm/target/debug/incremental -L dependency=/Users/auser/work/tinylabs/mvmco/mvm/target/debug/deps --extern anyhow=/Users/auser/work/tinylabs/mvmco/mvm/target/debug/deps/libanyhow-ac6699f41f5e23f3.rlib --extern hickory_proto=/Users/auser/work/tinylabs/mvmco/mvm/target/debug/deps/libhickory_proto-047ce53583b2c73a.rlib --extern mvm_core=/Users/auser/work/tinylabs/mvmco/mvm/target/debug/deps/libmvm_core-57e6928f4dbb5108.rlib --extern serde=/Users/auser/work/tinylabs/mvmco/mvm/target/debug/deps/libserde-7bd654656e843a22.rlib --extern serde_json=/Users/auser/work/tinylabs/mvmco/mvm/target/debug/deps/libserde_json-0ef1d80c679bdc4d.rlib --extern tempfile=/Users/auser/work/tinylabs/mvmco/mvm/target/debug/deps/libtempfile-86ce932fe58105da.rlib --extern tokio=/Users/auser/work/tinylabs/mvmco/mvm/target/debug/deps/libtokio-7c8333489ddbc65c.rlib --extern tracing=/Users/auser/work/tinylabs/mvmco/mvm/target/debug/deps/libtracing-25938c2b75fa4a7a.rlib --extern tracing_subscriber=/Users/auser/work/tinylabs/mvmco/mvm/target/debug/deps/libtracing_subscriber-422c88632877c3f9.rlib -L native=/opt/homebrew/lib
+82764       00:13 rustc --crate-name mvm_addon_dns --edition=2024 crates/mvm-addon-dns/src/bin/mvm-addon-dns.rs --error-format=json --json=diagnostic-rendered-ansi,artifacts,future-incompat --emit=dep-info,link -C embed-bitcode=no -C debuginfo=2 -C split-debuginfo=unpacked --deny=clippy::too_many_arguments --test --check-cfg cfg(docsrs,test) --check-cfg cfg(feature, values()) -C metadata=aa7e7aea4931464f -C extra-filename=-0aaa4dfdf3c863ea --out-dir /Users/auser/work/tinylabs/mvmco/mvm/target/debug/deps -C incremental=/Users/auser/work/tinylabs/mvmco/mvm/target/debug/incremental -L dependency=/Users/auser/work/tinylabs/mvmco/mvm/target/debug/deps --extern anyhow=/Users/auser/work/tinylabs/mvmco/mvm/target/debug/deps/libanyhow-ac6699f41f5e23f3.rlib --extern hickory_proto=/Users/auser/work/tinylabs/mvmco/mvm/target/debug/deps/libhickory_proto-047ce53583b2c73a.rlib --extern mvm_addon_dns=/Users/auser/work/tinylabs/mvmco/mvm/target/debug/deps/libmvm_addon_dns-f4abfd97bce9e3c5.rlib --extern mvm_core=/Users/auser/work/tinylabs/mvmco/mvm/target/debug/deps/libmvm_core-57e6928f4dbb5108.rlib --extern serde=/Users/auser/work/tinylabs/mvmco/mvm/target/debug/deps/libserde-7bd654656e843a22.rlib --extern serde_json=/Users/auser/work/tinylabs/mvmco/mvm/target/debug/deps/libserde_json-0ef1d80c679bdc4d.rlib --extern tempfile=/Users/auser/work/tinylabs/mvmco/mvm/target/debug/deps/libtempfile-86ce932fe58105da.rlib --extern tokio=/Users/auser/work/tinylabs/mvmco/mvm/target/debug/deps/libtokio-7c8333489ddbc65c.rlib --extern tracing=/Users/auser/work/tinylabs/mvmco/mvm/target/debug/deps/libtracing-25938c2b75fa4a7a.rlib --extern tracing_subscriber=/Users/auser/work/tinylabs/mvmco/mvm/target/debug/deps/libtracing_subscriber-422c88632877c3f9.rlib -L native=/opt/homebrew/lib
+82772       00:12 rustc --crate-name mvm_runner --edition=2024 crates/mvm-runner/src/main.rs --error-format=json --json=diagnostic-rendered-ansi,artifacts,future-incompat --emit=dep-info,link -C embed-bitcode=no -C debuginfo=2 -C split-debuginfo=unpacked --deny=clippy::too_many_arguments --test --check-cfg cfg(docsrs,test) --check-cfg cfg(feature, values()) -C metadata=afbcf2bfe751b4c0 -C extra-filename=-d9639e60c225a1ce --out-dir /Users/auser/work/tinylabs/mvmco/mvm/target/debug/deps -C incremental=/Users/auser/work/tinylabs/mvmco/mvm/target/debug/incremental -L dependency=/Users/auser/work/tinylabs/mvmco/mvm/target/debug/deps --extern mvm_runner=/Users/auser/work/tinylabs/mvmco/mvm/target/debug/deps/libmvm_runner-7e08a732979036cd.rlib --extern serde=/Users/auser/work/tinylabs/mvmco/mvm/target/debug/deps/libserde-7bd654656e843a22.rlib --extern serde_json=/Users/auser/work/tinylabs/mvmco/mvm/target/debug/deps/libserde_json-0ef1d80c679bdc4d.rlib --extern tempfile=/Users/auser/work/tinylabs/mvmco/mvm/target/debug/deps/libtempfile-86ce932fe58105da.rlib
+82830       00:12 rustc --crate-name mvm_runner --edition=2024 crates/mvm-runner/src/main.rs --error-format=json --json=diagnostic-rendered-ansi,artifacts,future-incompat --crate-type bin --emit=dep-info,link -C embed-bitcode=no -C debuginfo=2 -C split-debuginfo=unpacked --deny=clippy::too_many_arguments --check-cfg cfg(docsrs,test) --check-cfg cfg(feature, values()) -C metadata=670adf0a378ee4a7 -C extra-filename=-cfee1f05942e79de --out-dir /Users/auser/work/tinylabs/mvmco/mvm/target/debug/deps -C incremental=/Users/auser/work/tinylabs/mvmco/mvm/target/debug/incremental -L dependency=/Users/auser/work/tinylabs/mvmco/mvm/target/debug/deps --extern mvm_runner=/Users/auser/work/tinylabs/mvmco/mvm/target/debug/deps/libmvm_runner-7e08a732979036cd.rlib --extern serde=/Users/auser/work/tinylabs/mvmco/mvm/target/debug/deps/libserde-7bd654656e843a22.rlib --extern serde_json=/Users/auser/work/tinylabs/mvmco/mvm/target/debug/deps/libserde_json-0ef1d80c679bdc4d.rlib
+82844       00:08 rustc --crate-name end_to_end --edition=2024 crates/mvm-runner/tests/end_to_end.rs --error-format=json --json=diagnostic-rendered-ansi,artifacts,future-incompat --emit=dep-info,link -C embed-bitcode=no -C debuginfo=2 -C split-debuginfo=unpacked --deny=clippy::too_many_arguments --test --check-cfg cfg(docsrs,test) --check-cfg cfg(feature, values()) -C metadata=498a24736f13d923 -C extra-filename=-3858b763e7944f78 --out-dir /Users/auser/work/tinylabs/mvmco/mvm/target/debug/deps -C incremental=/Users/auser/work/tinylabs/mvmco/mvm/target/debug/incremental -L dependency=/Users/auser/work/tinylabs/mvmco/mvm/target/debug/deps --extern mvm_runner=/Users/auser/work/tinylabs/mvmco/mvm/target/debug/deps/libmvm_runner-7e08a732979036cd.rlib --extern serde=/Users/auser/work/tinylabs/mvmco/mvm/target/debug/deps/libserde-7bd654656e843a22.rlib --extern serde_json=/Users/auser/work/tinylabs/mvmco/mvm/target/debug/deps/libserde_json-0ef1d80c679bdc4d.rlib --extern tempfile=/Users/auser/work/tinylabs/mvmco/mvm/target/debug/deps/libtempfile-86ce932fe58105da.rlib
+83098       00:04 rustc --crate-name replay_protection --edition=2024 crates/mvm-plan/tests/replay_protection.rs --error-format=json --json=diagnostic-rendered-ansi,artifacts,future-incompat --emit=dep-info,link -C embed-bitcode=no -C debuginfo=2 -C split-debuginfo=unpacked --deny=clippy::too_many_arguments --test --check-cfg cfg(docsrs,test) --check-cfg cfg(feature, values()) -C metadata=75157860def39ff9 -C extra-filename=-9805f1102d9369a3 --out-dir /Users/auser/work/tinylabs/mvmco/mvm/target/debug/deps -C incremental=/Users/auser/work/tinylabs/mvmco/mvm/target/debug/incremental -L dependency=/Users/auser/work/tinylabs/mvmco/mvm/target/debug/deps --extern anyhow=/Users/auser/work/tinylabs/mvmco/mvm/target/debug/deps/libanyhow-ac6699f41f5e23f3.rlib --extern base64=/Users/auser/work/tinylabs/mvmco/mvm/target/debug/deps/libbase64-d7e11b5d985cc70b.rlib --extern chrono=/Users/auser/work/tinylabs/mvmco/mvm/target/debug/deps/libchrono-e4bca29a7c0afd80.rlib --extern ed25519_dalek=/Users/auser/work/tinylabs/mvmco/mvm/target/debug/deps/libed25519_dalek-c259c48385903902.rlib --extern mvm_core=/Users/auser/work/tinylabs/mvmco/mvm/target/debug/deps/libmvm_core-57e6928f4dbb5108.rlib --extern mvm_plan=/Users/auser/work/tinylabs/mvmco/mvm/target/debug/deps/libmvm_plan-d3bc79438c750f3a.rlib --extern rand=/Users/auser/work/tinylabs/mvmco/mvm/target/debug/deps/librand-480aafb26437005a.rlib --extern serde=/Users/auser/work/tinylabs/mvmco/mvm/target/debug/deps/libserde-7bd654656e843a22.rlib --extern serde_json=/Users/auser/work/tinylabs/mvmco/mvm/target/debug/deps/libserde_json-0ef1d80c679bdc4d.rlib --extern sha2=/Users/auser/work/tinylabs/mvmco/mvm/target/debug/deps/libsha2-1a4a744b209ae0f0.rlib --extern tar=/Users/auser/work/tinylabs/mvmco/mvm/target/debug/deps/libtar-19d9008aabb14112.rlib --extern tempfile=/Users/auser/work/tinylabs/mvmco/mvm/target/debug/deps/libtempfile-86ce932fe58105da.rlib --extern thiserror=/Users/auser/work/tinylabs/mvmco/mvm/target/debug/deps/libthiserror-f65c4f401e527d33.rlib -L native=/opt/homebrew/lib
+```
+
+## Assistant
+
+<thinking>
+
+</thinking>
+
+One cargo (PID 55792) + many rustc children. Killing them all.
+
+**Tool Call: pkill -9 -f "cargo test" ; pkill -9 -f "/Users/auser/work/tinylabs/mvmco/mvm/target/debug" ; sleep 2 ; ps -ax -o pid,etime,command | grep -E "cargo|rustc" | grep -v grep | grep -v "pest-language-server" | head -5 && echo "---remaining: $(ps -ax | grep -cE 'cargo|rustc' )"**
+Status: Completed
+
+Terminal:
+
+```
+---remaining: 4
+
+
+
+
+```
+
+## Assistant
+
+<thinking>
+
+</thinking>
+
+**Tool Call: ps -ax -o pid,command | grep -E "cargo|rustc" | grep -v grep | grep -v pest-language-server**
+Status: Completed
+
+Terminal:
+
+```
+(Bash completed with no output)
+
+
+
+
+```
+
+## Assistant
+
+Clean. Re-running tests from the worktree.
+
+**Tool Call: pwd && cargo test --workspace --all-features 2>&1 | tail -50**
+Status: Completed
+
+Terminal:
+
+```
+Command running in background with ID: b105mcr2i. Output is being written to: /private/tmp/claude-501/-Users-auser-work-tinylabs-mvmco-mvm/d599fbb0-a81f-481e-87ed-3ca7e59d2625/tasks/b105mcr2i.output. You will be notified when it completes. To check interim output, use Read on that file path.
+```
+
+## Assistant
+
+<thinking>
+
+</thinking>
+
+Tests are running in the background; the harness will notify me when they complete. While we wait, let me note progress: I've made the code changes, fmt and clippy are clean, and the targeted tests (3 symlink + 4 finalize_flake_job + 3 read_last_bytes_of = 10 new tests) all passed. The remaining task is to confirm the full `cargo test --workspace --all-features` is clean before committing — once that finishes I'll show the result and then check in with you before pushing/opening the PR.
+
+---
+
+## Resumed session — 2026-05-22 (post-freeze pickup)
+
+The previous session froze before its background `cargo test --workspace --all-features` (id `b105mcr2i`) returned. This session resumed from a clean conversation; uncommitted changes in `.claude/worktrees/dev-fd-symlinks/` were still in place (3 files, 303 insertions / 2 deletions). PR #424 (`worktree-stage0-error-handler`) was open and CI-green.
+
+### State check at pickup
+
+- `git -C .claude/worktrees/dev-fd-symlinks status` — clean tree HEAD at `8041e2c7` (same as `main` after #423 landed), uncommitted diff as expected.
+- `gh pr list` — open: #424 (Stage 0 error handler) + #417 (Plan 91 docs). PRs #418/#419/#420/#421/#422/#423 all merged.
+- `gh pr checks 424` — all 11 required checks pass; `mergeStateStatus: CLEAN`, `mergeable: MERGEABLE`.
+
+### Targeted test re-run (worktree, with uncommitted changes)
+
+- `cargo test -p mvm-builder-init setup_dev_fd_symlinks` — 3 / 3 passed.
+- `cargo test -p mvm-build --features builder-vm --lib libkrun_builder::tests::finalize_flake_job` and `libkrun_builder::tests::read_last_bytes_of` filters — 5 / 5 new + 2 / 2 pre-existing passed.
+- `cargo fmt --check` — clean.
+- `cargo clippy -p mvm-build --features builder-vm --tests -- -D warnings` — clean.
+- `cargo clippy -p mvm-builder-init --tests -- -D warnings` — clean.
+
+### Full workspace test
+
+Re-launched as background task `bz6z0mhlr`. Failed with exit code 101. Output reviewed (4759 lines). **3 test failures** isolated:
+
+1. `mvm-build::libkrun_builder::tests::run_build_surfaces_environment_gaps_for_install_variant` — host-environment-dependent. Asserts the error variant is `LibkrunUnavailable` or `ExtractionFailed`, but on a macOS host with libkrun installed via Homebrew (per CLAUDE.md host-deps), `LibkrunBuilderVm::run_build` proceeds past the gap-detection and dies further down with `NixBuildFailed("supervisor exited with non-zero status (1); ...")`. Written for CI runners that lack libkrun.
+
+2. `mvm-cli::commands::env::apple_container::dev_status_image_tests::builder_cache_status_reports_source_provenance_drift` (apple_container.rs:4664).
+3. `mvm-cli::commands::env::apple_container::dev_status_image_tests::builder_cache_status_reports_source_cache_hit_without_paths` (apple_container.rs:4637).
+
+Both (2) and (3) panic with `builder VM source fingerprint missing /var/folders/.../Cargo.lock`. Caused by `155b561f fix(builder-vm): fingerprint mvm-builder-init / mvm-egress-proxy / Cargo.lock too` (PR #422, merged 2026-05-21) — the source fingerprint now requires `Cargo.lock` to be present in the workspace root, but these test fixtures construct an isolated temp flake dir without a `Cargo.lock`.
+
+### Failure isolation — confirmed pre-existing on `main`
+
+`git stash push` to drop the uncommitted diff, then re-ran the failing tests on clean `worktree-dev-fd-symlinks` (HEAD = `main`):
+
+- `cargo test -p mvm-build --features builder-vm --lib libkrun_builder::tests::run_build_surfaces_environment_gaps_for_install_variant` — FAILED (panic at `:2384:9` with `NixBuildFailed("install pipeline failed inside builder VM: parse install spec: install_spec.json is missing required field language")`). Same assertion broken; inner error string differs because the supervisor path advances slightly further with a clean tree, but the test's variant assertion fails in both runs.
+- `cargo test -p mvm-cli --lib builder_cache_status_reports_source` — both fixtures FAIL with the identical `Cargo.lock missing` panic.
+
+Verdict: all 3 failures pre-exist on `main`. None are caused by the dev-fd-symlinks diff. `git stash pop` to restore changes.
+
+### Plan-vs-reality deltas (close-out notes)
+
+- Plan said two `finalize_flake_job` failure-path tests. Landed both (path + tail / missing-log sentinel) plus three `read_last_bytes_of` helper tests for completeness (trailing window, full-file under cap, missing-file error). Total new tests: 8 (3 symlink + 2 finalize + 3 helper).
+- Plan called `read_last_bytes_of` a "small pure helper"; implemented as `fn read_last_bytes_of(path: &Path, max_bytes: u64) -> std::io::Result<String>` with `SeekFrom::End(-take.min(filesize))` semantics, lossy UTF-8 decode. Test coverage matches plan's stated guarantee ("don't load the whole 220 KB log into memory").
+- All three "Files to modify" sections landed as written. `setup_dev_fd_symlinks` exposes `pub(crate)` (vs. private) so the test module can call it through `crate::setup_dev_fd_symlinks`. Idempotency uses `symlink_metadata().is_ok()` instead of `Path::exists()` (the latter follows symlinks and would treat a dangling symlink from a prior boot as absent — a real concern after a kernel update).
+
+### Decision
+
+Ready to commit, push, and open the PR for `worktree-dev-fd-symlinks`. The 3 pre-existing failures get flagged in `SPRINT.md` (Sprint 54 — Builder-VM maturation) as carryover follow-ups, NOT held against this PR.
+
+After the dev-fd-symlinks PR is open, merge PR #424 per user's instruction at session start ("Can you merge PR #424 when you're done"). #424 is independent of dev-fd-symlinks (different file scope: `stage0.rs` init script vs. builder-VM `mount_pseudofs` + libkrun_builder failure formatter).


### PR DESCRIPTION
## Summary

Every Rust derivation in the dev-image closure (`mvm-guest-agent`, `mvm-builder-init`, `mvm-addon-dns`) was dying at install time with:

```
/nix/store/.../cargo-install-hook.sh: line 27: /dev/fd/63: No such file or directory
```

Line 27 of nixpkgs's `cargo-install-hook.sh` is `mapfile -t targets < <(find ...)` — bash process substitution. For `<(...)` to work the shell opens `/dev/fd/N` against the subshell's pipe FD, which requires `/dev/fd` to be a symlink to `/proc/self/fd`. devtmpfs creates the device nodes, never the symlinks; udev/mdev/systemd-tmpfiles normally would — and we run none of those.

Builder VM (`mvm-builder-init::mount_pseudofs`) and `mkGuest`'s `/init` both mount `/proc` + `/sys` + `devtmpfs` + `/dev/pts` and stop. Now both also stage `/dev/fd → /proc/self/fd` and `/dev/std{in,out,err} → /proc/self/fd/{0,1,2}` right after the devpts mount. Idempotent via `symlink_metadata().is_ok()` (not `Path::exists()`, which follows symlinks and would treat a dangling leftover from a prior boot as absent).

Also surfaces the real failure for the next inner-build failure:
- `finalize_flake_job` formatter now names the full path to `<job_dir>/nix-stderr.log` and inlines its last 4 KiB
- Dispatch emits an info-level trace with the job dir up-front so a contributor can tail-f the log while the build runs

## Why this matters

After PRs #418/#419/#420/#421/#422/#423 landed, `mvmctl dev up` on aarch64-darwin walked the full Stage 0 → persistent builder VM → inner `nix build` pipeline — only to fail at the very last step. The host-visible mvmctl log only showed `error: Cannot build '/nix/store/<hash>-mvm-guest-agent-0.14.0.drv'`. The actual stderr was already on the host filesystem at `~/.cache/mvm/builder-vm/jobs/<job_id>/nix-stderr.log` (the `/job` virtio-fs share writes there via cmd.sh's stderr redirect), but the error formatter never pointed at it.

Full plan + diagnosis log in `specs/backlog/42-tracking.md`.

## Tests (all green)

- `cargo test -p mvm-builder-init setup_dev_fd_symlinks` — 3/3:
  - `creates_all_four_in_empty_dir`
  - `is_idempotent_when_already_present` (pre-staged sentinel symlink preserved)
  - `errors_when_dev_root_missing`
- `cargo test -p mvm-build --features builder-vm --lib libkrun_builder::tests::read_last_bytes_of` — 3/3:
  - `returns_trailing_window_when_file_exceeds_cap`
  - `returns_entire_file_when_smaller_than_cap`
  - `errors_on_missing_file`
- `cargo test -p mvm-build --features builder-vm --lib libkrun_builder::tests::finalize_flake_job` — 4/4 (2 new + 2 pre-existing):
  - `failure_includes_nix_stderr_log_path_and_tail`
  - `failure_handles_missing_nix_stderr_log_cleanly`
- `cargo fmt --check` — clean
- `cargo clippy -p mvm-build --features builder-vm --tests -- -D warnings` — clean
- `cargo clippy -p mvm-builder-init --tests -- -D warnings` — clean

## Test plan

- [x] Targeted unit tests for the 4 new code paths + 8 new test cases
- [ ] End-to-end `mvmctl dev up` on aarch64-darwin (do after #424 merges so the Stage 0 error-handler hardening is in place)
- [ ] On an intentional inner-build failure, confirm `BuilderVmError::NixBuildFailed` names the host-side `nix-stderr.log` path and shows the last 4 KiB

## Out of scope

- Streaming per-derivation logs over vsock during the build (the file-based path is sufficient now that dispatch names the path up-front)
- `/dev/shm`, `/dev/core`, `/dev/log` and other conventional symlinks udev/systemd would create — no build hook has hit them yet
- The 3 pre-existing test failures on `main` (libkrun-env-dependent `run_build_surfaces_environment_gaps_for_install_variant`, two `Cargo.lock`-missing fingerprint fixtures) — tracked as carryover follow-ups in `SPRINT.md` Sprint 54

🤖 Generated with [Claude Code](https://claude.com/claude-code)