### PR TITLE
test(mvm-build,mvm-cli): make 3 host-/fixture-broken tests run anywhere

### DIFF
--- a/crates/mvm-build/src/libkrun_builder.rs
+++ b/crates/mvm-build/src/libkrun_builder.rs
@@ -2369,11 +2369,22 @@ mod tests {
     #[test]
     fn run_build_surfaces_environment_gaps_for_install_variant() {
         // Plan 73 Followup B.2 wires the Install variant — passing
-        // input validation no longer trips NotYetImplemented. With
-        // a CI runner that doesn't carry libkrun + the supervisor
-        // binary, run_build now surfaces the same environment-gap
-        // shape as the Flake variant. Asserts the wiring proceeds
-        // past validation rather than short-circuiting.
+        // input validation no longer trips NotYetImplemented. Two
+        // host shapes can hit this code path:
+        //
+        // - CI runner without libkrun: `run_build` short-circuits at
+        //   the supervisor-binary lookup with `LibkrunUnavailable`
+        //   (or `ExtractionFailed` if an earlier I/O step fails).
+        // - Contributor host with libkrun installed via Homebrew (per
+        //   `CLAUDE.md` host-deps): the supervisor actually spawns
+        //   against the stub `{}` install spec, which the in-VM
+        //   pipeline rejects because the spec is missing required
+        //   fields (`language`, …) — surfacing as `NixBuildFailed`.
+        //
+        // Both outcomes prove the wiring proceeds past validation
+        // rather than short-circuiting on `NotYetImplemented`, which
+        // is what this test exists to guarantee. The test must NOT
+        // require a specific host environment.
         let scratch = TempDir::new().unwrap();
         let spec_path = scratch.path().join("spec.json");
         std::fs::write(&spec_path, b"{}").unwrap();
@@ -2382,9 +2393,15 @@ mod tests {
             .run_build(&BuilderJob::Install { spec_path }, &mounts)
             .unwrap_err();
         assert!(
+            !matches!(err, BuilderVmError::NotYetImplemented),
+            "Install variant must not short-circuit on NotYetImplemented: {err:?}"
+        );
+        assert!(
             matches!(
                 err,
-                BuilderVmError::LibkrunUnavailable(_) | BuilderVmError::ExtractionFailed(_)
+                BuilderVmError::LibkrunUnavailable(_)
+                    | BuilderVmError::ExtractionFailed(_)
+                    | BuilderVmError::NixBuildFailed(_)
             ),
             "unexpected error variant: {err:?}"
         );

--- a/crates/mvm-cli/src/commands/env/apple_container.rs
+++ b/crates/mvm-cli/src/commands/env/apple_container.rs
@@ -4297,10 +4297,7 @@ mod dev_status_image_tests {
         std::fs::write(workspace_root.join("Cargo.lock"), "# stub Cargo.lock\n")
             .expect("write Cargo.lock");
         for crate_name in ["mvm-builder-init", "mvm-egress-proxy"] {
-            let src = workspace_root
-                .join("crates")
-                .join(crate_name)
-                .join("src");
+            let src = workspace_root.join("crates").join(crate_name).join("src");
             std::fs::create_dir_all(&src).expect("mkdir crate src");
             std::fs::write(
                 src.parent().unwrap().join("Cargo.toml"),

--- a/crates/mvm-cli/src/commands/env/apple_container.rs
+++ b/crates/mvm-cli/src/commands/env/apple_container.rs
@@ -4281,6 +4281,36 @@ mod dev_status_image_tests {
         std::fs::write(dir.join("flake.lock"), "{\"nodes\":{}}").expect("write lock");
     }
 
+    /// Stage the workspace prerequisites that `builder_vm_source_fingerprint`
+    /// (post-PR #422) reads in addition to the flake dir itself:
+    /// `Cargo.lock` at the workspace root + stub `mvm-builder-init` and
+    /// `mvm-egress-proxy` crate dirs. Without this, any test that calls
+    /// the fingerprint helper against a fresh tempdir-rooted flake at
+    /// `<tmp>/nix/images/builder-vm` blows up with
+    /// `builder VM source fingerprint missing <tmp>/Cargo.lock`.
+    ///
+    /// Matches `builder_vm_bootstrap_tests::write_builder_vm_workspace`
+    /// in shape; lives here as well because the two test mods are
+    /// independent and we don't want to plumb a cross-mod helper just
+    /// for two callers.
+    fn write_builder_vm_workspace_prereqs(workspace_root: &std::path::Path) {
+        std::fs::write(workspace_root.join("Cargo.lock"), "# stub Cargo.lock\n")
+            .expect("write Cargo.lock");
+        for crate_name in ["mvm-builder-init", "mvm-egress-proxy"] {
+            let src = workspace_root
+                .join("crates")
+                .join(crate_name)
+                .join("src");
+            std::fs::create_dir_all(&src).expect("mkdir crate src");
+            std::fs::write(
+                src.parent().unwrap().join("Cargo.toml"),
+                format!("[package]\nname = \"{crate_name}\"\nversion = \"0.0.0\"\n"),
+            )
+            .expect("write Cargo.toml");
+            std::fs::write(src.join("main.rs"), "fn main() {}\n").expect("write main.rs");
+        }
+    }
+
     #[test]
     fn status_image_prefers_launchd_image_paths() {
         let _lock = ENV_LOCK.lock().unwrap();
@@ -4633,6 +4663,7 @@ mod dev_status_image_tests {
         let cache_root = tmp.path().join("cache");
         let cache = cache_root.join("builder-vm/testarch");
         write_builder_vm_flake(&flake);
+        write_builder_vm_workspace_prereqs(tmp.path());
         write_valid_builder_cache_artifacts(&cache);
         let fingerprint = builder_vm_source_fingerprint(flake.to_str().unwrap()).unwrap();
         write_builder_vm_source_fingerprint(&cache, &fingerprint).unwrap();
@@ -4660,6 +4691,7 @@ mod dev_status_image_tests {
         let cache_root = tmp.path().join("cache");
         let cache = cache_root.join("builder-vm/testarch");
         write_builder_vm_flake(&flake);
+        write_builder_vm_workspace_prereqs(tmp.path());
         write_valid_builder_cache_artifacts(&cache);
         let fingerprint = builder_vm_source_fingerprint(flake.to_str().unwrap()).unwrap();
         write_builder_vm_source_fingerprint(&cache, &fingerprint).unwrap();


### PR DESCRIPTION
## Summary

Three tests on \`main\` were broken on a contributor macOS host but green on CI. None of them was exercising the code path the assertion expected.

### 1. \`libkrun_builder::tests::run_build_surfaces_environment_gaps_for_install_variant\`

Asserted \`LibkrunUnavailable | ExtractionFailed\` — only what a CI runner without libkrun sees. On any host with libkrun installed via Homebrew (which \`CLAUDE.md\` host-deps tells contributors to do), \`run_build\` spawned the supervisor against the stub \`{}\` install spec and returned \`NixBuildFailed\` from the in-VM parser:

\`\`\`
NixBuildFailed(\"install pipeline failed inside builder VM: parse install spec: install_spec.json is missing required field language\")
\`\`\`

Both the libkrun-absent and libkrun-present outcomes prove what the test exists to guarantee — *wiring proceeds past validation, no \`NotYetImplemented\` short-circuit*. Assertion broadened to accept all three post-validation variants and explicitly reject \`NotYetImplemented\`.

### 2. & 3. \`dev_status_image_tests::builder_cache_status_reports_source_*\`

Both constructed a tempdir-rooted flake at \`<tmp>/nix/images/builder-vm\` and called \`builder_vm_source_fingerprint\`. Since PR #422 expanded the fingerprint to hash the workspace \`Cargo.lock\` + \`mvm-builder-init\` + \`mvm-egress-proxy\` crate dirs, both fixtures panicked with:

\`\`\`
builder VM source fingerprint missing /var/folders/.../Cargo.lock
\`\`\`

Added \`write_builder_vm_workspace_prereqs\` in the same test mod (matches the shape of \`builder_vm_bootstrap_tests::write_builder_vm_workspace\`) and call it before the fingerprint helper in both fixtures.

## Verification

On \`main\` HEAD \`60c173f6\` **before** the patch:

\`\`\`
test libkrun_builder::tests::run_build_surfaces_environment_gaps_for_install_variant ... FAILED
test commands::env::apple_container::dev_status_image_tests::builder_cache_status_reports_source_cache_hit_without_paths ... FAILED
test commands::env::apple_container::dev_status_image_tests::builder_cache_status_reports_source_provenance_drift ... FAILED
\`\`\`

**After** the patch (this branch):

\`\`\`
test libkrun_builder::tests::run_build_surfaces_environment_gaps_for_install_variant ... ok
test commands::env::apple_container::dev_status_image_tests::builder_cache_status_reports_source_cache_hit_without_paths ... ok
test commands::env::apple_container::dev_status_image_tests::builder_cache_status_reports_source_provenance_drift ... ok

test result: ok. 3 passed; 0 failed
\`\`\`

- \`cargo fmt --check\` — clean
- \`cargo clippy -p mvm-build --features builder-vm --tests -- -D warnings\` — clean
- \`cargo clippy -p mvm-cli --tests -- -D warnings\` — clean

## Why this matters

CI was green because GitHub Actions runners don't have libkrun installed and (per \`CLAUDE.md\`) the host \`Cargo.lock\` is present in the checkout. Both gaps masked test fixtures that didn't actually exercise what they claimed to. A contributor running \`cargo test --workspace --all-features\` on a properly-set-up dev host would see all three fail — and historically, several of us did, then chased the failures up the wrong tree.

Tracked in \`SPRINT.md\` Sprint 54 \"Carryover follow-ups\" (added by PR #425); this PR closes all three line items.

## Test plan

- [x] All 3 broken tests pass on macOS-aarch64 with libkrun installed
- [x] Targeted clippy + fmt clean
- [ ] CI green (workspace test re-run after merge will confirm CI still sees the assertion shapes it was happy with)

🤖 Generated with [Claude Code](https://claude.com/claude-code)