### PR TITLE
docs(CLAUDE.md): require cargo fmt --all for workspace fmt checks

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -216,9 +216,22 @@ sequence in `specs/plans/25-microvm-hardening.md`.
 No task is done without tests. Before marking any feature complete:
 
 ```bash
-cargo test --workspace              # all tests must pass
+cargo fmt --all -- --check           # workspace-wide fmt; --all matters
+cargo test --workspace               # all tests must pass
 cargo clippy --workspace -- -D warnings  # zero warnings
 ```
+
+**Always pass `--all` to `cargo fmt`.** Without it, fmt only checks the
+manifest crate (whichever one the manifest points at), silently missing
+drift in every other workspace member. CI runs `cargo fmt --all --
+--check`; if you only check the local crate, the merge will still fail.
+The pre-commit hook at `.githooks/pre-commit` auto-fixes with `cargo
+fmt --all` and re-stages — `just install-hooks` wires
+`core.hooksPath` to `.githooks/` so it fires on every commit.
+
+The Justfile recipes wrap this correctly: `just fmt-check`, `just
+clippy`, `just lint` (both), `just ci` (lint + test). Prefer those over
+raw cargo invocations.
 
 Every new module, type, or function needs test coverage:
 - Types: serde roundtrip, default values


### PR DESCRIPTION
## Summary

Bare \`cargo fmt -- --check\` only checks the manifest crate; drift in every other workspace member slips through silently. CI runs \`cargo fmt --all -- --check\`, so a local check that omits \`--all\` will pass while CI fails — exactly the drift that bounced #426's first push.

Updated the \`## Testing\` checklist to spell \`--all\` out, and point at:
- The existing \`.githooks/pre-commit\` that auto-fixes with \`cargo fmt --all\` and re-stages (run \`just install-hooks\` to wire \`core.hooksPath\`).
- The Justfile recipes (\`just fmt-check\`, \`just clippy\`, \`just lint\`, \`just ci\`) that wrap the right flags so contributors and agent sessions don't have to remember them.

## What this does NOT change

- No code changes.
- No new tooling. The hook, recipes, and CI invocation already exist; this is purely the contributor-guidance doc catching up.

## Test plan

- [x] \`cargo fmt --all -- --check\` clean
- [x] \`cargo clippy --workspace -- -D warnings\` not run (docs-only)
- [x] No code paths touched

🤖 Generated with [Claude Code](https://claude.com/claude-code)