### PR TITLE
docs(plans): plan 93 — fast secure dev path follow-ups (planning only)

### DIFF
--- a/specs/SPRINT.md
+++ b/specs/SPRINT.md
@@ -1789,8 +1789,9 @@ don't fall off.
 - ✅ [`plans/88-gvproxy-macos-backend.md`](plans/88-gvproxy-macos-backend.md) — virtio-net via gvproxy on macOS.
 - ✅ [`plans/89-persistent-builder-vm.md`](plans/89-persistent-builder-vm.md) — persistent builder VM (multiple W3 PRs landed).
 - ✅ [`plans/90-gateway-frame-fuzz.md`](plans/90-gateway-frame-fuzz.md) — fuzz coverage for the gateway frame parsers.
-- 🟡 [`plans/91-...`](plans/) — Alpine Stage 0 bootstrap (PR #417 open).
+- 🟡 [`plans/91-stage0-alpine-bootstrap.md`](plans/91-stage0-alpine-bootstrap.md) — Alpine Stage 0 bootstrap (PR #417 open).
 - 🟡 [`plans/92-minimal-builder-vm-kernel.md`](plans/92-minimal-builder-vm-kernel.md) — slim custom kernel via `linuxManualConfig` + `tinyconfig` (committed locally on `worktree-plan-92-stock-kernel`; carried forward by Plan 95's PR).
+- 📝 [`plans/93-fast-secure-dev-path-followups.md`](plans/93-fast-secure-dev-path-followups.md) — **post-Plan-91 follow-ups, planning only.** Phase 0 (PR-A): fingerprint correctness fix in `builder_vm_source_fingerprint` — a shipping security gap independent of Plan 91. Phase 1: fast Layer 2 dev cycles (lazy/split dev shell + cross-compile our crates on host + lazy in-VM nix fetch). Phase 2: sub-200 ms runtime microvm launch (kernel/initrd minimisation, agent-startup parallelism, warm-pool of pre-spawned libkrun supervisors). Phase 3: DX polish (`mvmctl doctor` enrichment, `cache info`, progress UI, public docs, CI reproducibility lane). Targets: sub-30 s warm `mvmctl dev up`, sub-200 ms cold microvm launch, no LONG dev cycles. Not yet started — saved to track direction.
 - 🟡 [`plans/95-builder-vm-kernel-slimming.md`](plans/95-builder-vm-kernel-slimming.md) — **Plan 92 followup.** Aggressive ARM64 SoC platform cluster disables (W3) + permanent `kernel-configfile` flake output for audit (W2). Lands as one PR carrying Plan 92's base commits forward. (W1 "drop microvm.nix input" was dropped post-survey — `nix/lib/` still requires it.)
 
 ### Sprint 54 success criteria

--- a/specs/plans/93-fast-secure-dev-path-followups.md
+++ b/specs/plans/93-fast-secure-dev-path-followups.md
@@ -1,0 +1,311 @@
+# Plan 93 — fast + secure dev path (post-Plan-91 follow-ups)
+
+**Status:** drafted 2026-05-22, planning only. No implementation
+yet — saved to track direction while in-flight work is the
+priority.
+
+**Follows:**
+- [Plan 91](91-stage0-alpine-bootstrap.md) — Stage 0 Alpine
+  bootstrap. The cold-Stage-0 redesign lives there; this plan
+  *does not* re-litigate it.
+- [Plan 77](77-stage0-bootstrap-via-dev-image.md) — Stage 0
+  bootstrap via the cached dev image (the predecessor architecture
+  that #414/#415/#417 supersede).
+
+**Tracks:** sub-30 s `mvmctl dev up` on warm hosts; sub-200 ms
+runtime microvm launch; "no LONG dev cycles" for daily
+contributor work.
+
+## Context
+
+Plan 77 W2/W3/W4 shipped to main (advisory lock, audit emits,
+structural no-prebuilt gate). Plan 91 is the chosen Stage 0
+redesign (Alpine minirootfs + `apk add nix-bin`) and is in flight
+via PR #417 + the already-merged #414/#415.
+
+What's left for "fast + secure mvm dev path":
+
+1. **A shipping fingerprint correctness bug** in
+   `builder_vm_source_fingerprint` (Plan 91 doesn't touch this).
+2. **Slow Layer 2 dev-shell rebuilds** — separate code path from
+   Stage 0, so Plan 91 doesn't address it.
+3. **Sub-200 ms runtime microvm launch** — completely decoupled
+   from Stage 0; lives in `LibkrunBackend::start` + vsock
+   handshake.
+4. **DX polish** for the post-Plan-91 dev loop —
+   `mvmctl doctor`, `cache info`, progress UI, public docs.
+
+User targets that drive this work:
+
+- Sub-30 s end-to-end `mvmctl dev up` on a fresh checkout.
+- Sub-200 ms cold launch for runtime microvms.
+- Fast Layer 2 dev-shell rebuilds — no LONG development cycles.
+- Security top priority — no shortcut breaks the no-prebuilt
+  download invariant, fingerprint binding, audit chain, or
+  ADR-047 egress allowlist.
+- Nix only in the builder VM — host has no Nix; runtime
+  microvms have no Nix; dev VMs eventually have no Nix.
+- No backward compatibility — hard cutover; existing caches blown
+  away on upgrade (per `feedback_no_backcompat_first_version.md`).
+- Source tree must not balloon.
+
+## What this plan does NOT cover
+
+- **Stage 0 architecture** — that's Plan 91 (Alpine minirootfs +
+  `apk add nix-bin`). The trust model, fetch shape, and
+  verification chain are settled there; nothing in this plan
+  contradicts or duplicates it.
+- **Slim kernel** — that's Plan 92/95.
+- **The full sub-30 s cold-first-checkout target** — Plan 91 plus
+  Plan 92's slim kernel are expected to deliver this; this plan
+  contributes the *warm* dev-loop speed, not the cold-checkout
+  number.
+
+## Phase 0 — PR-A: fingerprint correctness fix (immediate, small)
+
+### Why it's urgent independent of Plan 91
+
+`crates/mvm-cli/src/commands/env/apple_container.rs::builder_vm_source_fingerprint`
+hashes only `flake.nix + flake.lock` from `nix/images/builder-vm/`.
+That's a *shipping security bug*: a contributor who edits
+`crates/mvm-builder-init/src/install.rs` and runs `mvmctl dev up`
+gets the cached builder VM from before the edit. Neither flake
+file changed; fingerprint matches; stale image is served.
+
+Plan 91 swaps the Stage 0 bootstrap binary but does not change
+the source fingerprint binding. The bug remains shipping. Either
+this PR lands before Plan 91 (recommended — it's small) or it
+lands as a Plan 91 follow-up; either way, it's distinct work.
+
+### Scope
+
+#### Change 1 — extend `builder_vm_source_fingerprint`
+
+Extend the fingerprint to also walk the Cargo source files that
+compile into the builder VM image:
+
+- workspace `Cargo.lock`
+- `crates/mvm-builder-init/Cargo.toml` + recursive
+  `crates/mvm-builder-init/src/**`
+- `crates/mvm-egress-proxy/Cargo.toml` + recursive
+  `crates/mvm-egress-proxy/src/**`
+
+Deterministic walk (sorted-name traversal via `BTreeMap`). Skip
+`.DS_Store`, `*.swp`, `target/`.
+
+#### Change 2 — `flavor=` field on Stage 0 audit emits
+
+Add a `flavor=current` field to `stage0_boot` and
+`stage0_cache_promoted` detail strings. Today it's a single
+constant; if Plan 91 ever needs a per-bootstrap-variant
+identifier, the audit shape already accommodates it. ~10 lines.
+
+#### Change 3 — no backcompat migration
+
+Per `feedback_no_backcompat_first_version.md`, no v1-cache
+recogniser. The widened fingerprint naturally invalidates
+existing caches; the next `mvmctl dev up` pays one cold Stage 0.
+The existing fingerprint-mismatch UI surface already explains
+the diagnosis to the user.
+
+#### Tests
+
+- Editing `crates/mvm-builder-init/src/foo.rs` changes the
+  fingerprint.
+- Editing `crates/mvm-builder-init/README.md` (or any non-`src`
+  file) does NOT change the fingerprint.
+- Deterministic walk: same fingerprint twice in a row.
+
+### Critical files
+
+- `crates/mvm-cli/src/commands/env/apple_container.rs` —
+  `builder_vm_source_fingerprint`, Stage 0 audit emits.
+- Tests under existing `builder_vm_bootstrap_tests` mod.
+
+### Verification
+
+- `cargo test -p mvm-cli --lib -- builder_vm_bootstrap_tests`
+- `cargo test --workspace` — 0 failures.
+- `cargo clippy --workspace --all-targets -- -D warnings` clean.
+
+PR-A is ~150-250 lines, ships in 1-2 days.
+
+## Phase 1 — fast Layer 2 dev cycles
+
+Decoupled from Stage 0. The dev-shell flake at
+`nix/images/builder/flake.nix` builds the rootfs contributors
+`dev shell` into. Today it pulls rustc + cargo + gcc + busy
+toolchain — minutes warm, 20-40 min cold. This is what
+contributors actually feel daily.
+
+### Levers
+
+1. **Lazy / split dev shell**: monolithic dev shell splits into
+   `dev-minimal` (bash + git + basics, ~50 MiB) and `dev-compile`
+   (rustc + cargo + gcc, on-demand fetch from cache.nixos.org
+   inside the VM). Most workflows only need minimal.
+
+2. **Cross-compile our crates on host**: contributors editing
+   `crates/mvm-cli/` or any workspace crate cross-compile on the
+   host (via `cargo --target aarch64-unknown-linux-gnu` with the
+   appropriate cross sysroot) and bind-mount the binary into the
+   running dev shell. **No dev-shell rebuild needed for our own
+   code edits.** This is the lever that actually delivers "no
+   LONG dev cycles" — day-to-day work bypasses Nix entirely.
+
+   Open question: where does the cross sysroot come from? Plan 91
+   doesn't need one (Alpine's apk supplies the in-VM toolchain).
+   For host cross-compile we'd need either:
+   - A pinned upstream sysroot (e.g., from Linux distro archives,
+     hash-pinned and downloaded on first use — same trust pattern
+     Plan 91 uses for Alpine).
+   - A maintainer-built sysroot hosted somewhere mvm-controlled
+     (but this re-introduces the "mvm-controlled bootstrap binary"
+     concern Plan 91 explicitly rejected).
+
+   Lean: pinned upstream sysroot, fetched lazily, same trust
+   model as Alpine. Decision deferred to implementation.
+
+3. **Lazy Nix fetch inside dev-compile**: when the user does
+   need in-VM compilation, the dev-shell flake uses Nix's
+   substituter as normal. Slow first time per machine, fast
+   after. The in-VM Nix store survives across `dev up`
+   invocations via the persistent virtio-blk image already in
+   place.
+
+### What this does NOT do
+
+- **No host-side Nix store mirror.** Multi-GB mirrors are
+  explicitly out of bounds per user direction ("I don't think we
+  want to store/ship 5 GB around").
+- **No new download infrastructure beyond what Plan 91 already
+  establishes.** The Alpine fetch pattern is the precedent;
+  this phase reuses it.
+
+### Scope
+
+Per-lever: 1-2 weeks. Ships incrementally. Lever 2 is the
+load-bearing one for the user's "no LONG dev cycles" target;
+levers 1 and 3 are cleanup that makes the dev shell smaller and
+the cold case better.
+
+## Phase 2 — sub-200 ms runtime microvm launch
+
+Decoupled entirely from Stage 0 + dev shell. Lives in
+`crates/mvm-backend/src/libkrun.rs::start`, the vsock handshake,
+and `mvm-guest`'s init path. Today `LibkrunBackend::start` is
+1-3 s cold; the target is sub-200 ms.
+
+### Levers
+
+1. **Kernel cmdline + initrd minimisation.** Today's cmdline is
+   conservative. Trim aggressively for runtime microvms (Plan 95's
+   slim kernel work helps here). Initrd may be eliminable
+   entirely for the runtime path.
+
+2. **Guest agent startup parallelism.** Today the agent
+   sequentialises vsock listen + handshake + capability
+   negotiation. Parallelise + pre-bind on the host side. Issue
+   tracking the handshake roundtrip latency is needed.
+
+3. **Warm pool of pre-spawned libkrun supervisors awaiting
+   rootfs attachment.** RAM cost: ~50-100 MiB per warm guest.
+   Trade RAM for cold-start latency. Pool size configurable;
+   `mvmctl up --warm-pool-size N`.
+
+4. **VMM-side memory ballooning at boot.** Defer non-essential
+   page allocation until after the guest is "ready" from the
+   user's perspective. libkrun's balloon API is documented;
+   today we don't use it on the runtime path.
+
+### Scope
+
+Multi-week, multi-PR. Needs a benchmark harness
+(`mvmctl bench microvm-launch` or similar) so progress is
+measurable before any lever lands. Without measurement we'll
+optimise the wrong thing.
+
+## Phase 3 — DX polish (distributed)
+
+These ride alongside the implementation of Phases 0-2 rather
+than landing as a standalone phase.
+
+- **Stage 0 progress feedback** (in Plan 91): one-line progress
+  per step (`Fetching Alpine minirootfs … 0.4 s`,
+  `apk add nix-bin … 1.8 s`, `nix build … 12.3 s`). Cheap; makes
+  perceived speed match actual speed.
+- **`mvmctl cache info`** reports vendored-blob ages,
+  cross-target cache size, assembled rootfs age, last Stage 0
+  fingerprint.
+- **`mvmctl doctor`** reports last Stage 0 timestamp,
+  fingerprint, hit/miss outcome. Diagnoses "why did Stage 0 fire
+  again?" without grep-ing the audit log.
+- **Public docs** at `public/src/content/docs/contributing/`:
+  the new Stage 0 model (Plan 91), edit-rebuild semantics
+  (Phase 1), triage paths. Currently the only docs are inline
+  doc comments.
+- **CI nightly** that runs the cross-compile pipeline (Phase 1
+  lever 2) on two different macOS runners and asserts
+  byte-identical artifacts. Catches reproducibility regressions
+  early.
+- **Vendored-blob audit kind** (`LocalAuditKind::VendorBlobFetched`):
+  emitted on every download + SHA/PGP verify event. Forward-compat
+  with Plan 91 (which already needs an audit event for the Alpine
+  fetch).
+
+## Reproducibility (Phase 1 lever 2)
+
+Inputs to the cross-compiled `mvm-builder-init` / workspace
+binaries output bytes:
+
+1. Rust source files
+2. `Cargo.lock` (pinned)
+3. `rustc` version — pin via `rust-toolchain.toml`
+4. Cross sysroot — manifest-pinned bytes (same as Plan 91's
+   Alpine pin)
+5. Build flags — centralize in workspace `[profile]`; set
+   `RUSTFLAGS=--remap-path-prefix=$PWD=.`
+6. `build.rs` of dependencies — audit for non-determinism
+
+With 1-6 pinned, two contributors on the same OS major version
+produce byte-identical artifacts. Residual risk on different
+macOS major versions — rustc occasionally embeds
+host-version-dependent behavior. Tolerate; fingerprint mismatch
+(PR-A's widened fingerprint catches this) causes one extra cold
+rebuild, not a security issue.
+
+## Considerations summary
+
+| # | Consideration | Lands in |
+|---|---|---|
+| 1 | Egress allowlist regression check | Plan 91 (init refuses install w/o egress proxy) |
+| 2 | Cache schema migration | Skipped (no backcompat) |
+| 3 | `mvm-builder-init` refuses install in flake-only | Plan 91 |
+| 4 | Cross-compile attestation | Phase 1 lever 2 (manifest-pinned sysroot, same shape as Plan 91 Alpine fetch) |
+| 5 | Per-flavor lock | Skipped (Plan 91 retires the flavor concept) |
+| 6 | Audit `flavor=` field | PR-A (Phase 0) |
+| 7 | `cache prune` recogniser update | Plan 91 (clean cutover, no v1 layout to preserve) |
+| 8 | Stage 0 progress feedback | Phase 3 (folded into Plan 91 ship) |
+| 9 | `mvmctl cache info` enrichment | Phase 3 |
+| 10 | `mvmctl doctor` enrichment | Phase 3 |
+| 11 | Docs | Phase 3 |
+| 12 | Plan numbering | Verified — Plan 93 free, Plan 91/92/95 in flight |
+| 13 | CI reproducibility lane | Phase 3 |
+| 14 | Reproducibility for cross-compile | Phase 1 lever 2 |
+| 15 | Layer 2 dev-shell rebuild bottleneck | Phase 1 |
+| 16 | Vendored-blob audit | Phase 3 (forward-compat with Plan 91) |
+
+## Process notes
+
+- This plan was drafted in a session that initially proposed a
+  competing Stage 0 redesign (busybox-static + vendored bytes +
+  host cross-compile of `mvm-builder-init`). That proposal was
+  retracted on discovery of Plan 91, which uses a stronger
+  Alpine-based trust model already in flight. The lesson for
+  future planning sessions: run `git worktree list && gh pr list`
+  before designing in an area, per
+  `feedback_check_inflight_work_before_diagnosing.md` in memory.
+- Plan numbers verified free at draft time via `ls specs/plans/`
+  + `gh pr list --search 'plan 93'`. Per
+  `project_spec_numbering_chaos.md`, re-verify just before any
+  implementation PR lands.


### PR DESCRIPTION
## Summary

Documentation-only PR. Saves a multi-phase plan captured during a planning session — explicitly **planning only, no implementation yet** per the user direction ("I have a bunch of other work in-flight that I want first").

## What's in here

**`specs/plans/93-fast-secure-dev-path-followups.md`** — covers the work that remains for "fast + secure mvm dev path" *after* Plan 91 (Alpine Stage 0 bootstrap) lands:

- **Phase 0 / PR-A** — fingerprint correctness fix in \`builder_vm_source_fingerprint\`. Today's fingerprint hashes only \`flake.nix + flake.lock\` and misses Cargo source edits to \`mvm-builder-init\` / \`mvm-egress-proxy\` — a shipping security gap (stale cached builder VM served when contributor edits Rust source). Independent of Plan 91; safe to land before or alongside it.
- **Phase 1** — fast Layer 2 dev cycles. Lazy/split dev shell + cross-compile our crates on host + lazy in-VM nix fetch. Target: warm \`mvmctl dev up\` sub-5 s, cold \`dev up\` sub-30 s when paired with Plan 91's Alpine bootstrap + Plan 92/95's slim kernel.
- **Phase 2** — sub-200 ms cold runtime microvm launch. Kernel/initrd minimisation, agent-startup parallelism, warm-pool of pre-spawned libkrun supervisors, VMM-side memory ballooning. Lives in \`LibkrunBackend::start\` + vsock handshake; orthogonal to Stage 0 / dev shell.
- **Phase 3** — DX polish. \`mvmctl doctor\` reporting last Stage 0 fingerprint, \`cache info\` per-component breakdown, progress UI, public docs, CI reproducibility lane.

## What this plan explicitly does NOT cover

- **Stage 0 redesign** → [Plan 91](specs/plans/91-stage0-alpine-bootstrap.md). Alpine minirootfs + \`apk add nix-bin\`, in flight via PR #417 building on #414/#415. Plan 93 defers to Plan 91 for the Stage 0 trust model.
- **Slim kernel** → Plan 92/95.

## Process note in the plan

The plan's "Process notes" section captures the lesson from this drafting session: an initial draft proposed a competing busybox-static + vendored-bytes Stage 0 redesign before discovering Plan 91. The lesson — \`git worktree list && gh pr list\` before designing in an area, per \`feedback_check_inflight_work_before_diagnosing.md\` in memory — is preserved in the plan so future planning sessions don't repeat it.

## SPRINT.md

One line added under Sprint 54 ("Builder-VM maturation") tracking the new plan with a 📝 (drafted, not started) status indicator, distinct from 🟡 (in progress) and ✅ (shipped). The Plan 91 line in the same list is also touched to fix a broken filename reference (\`plans/91-...\` → \`plans/91-stage0-alpine-bootstrap.md\`).

## Test plan

- [x] Plan number 93 verified unclaimed (no \`specs/plans/93-*\` exists; no in-flight PR title or branch name claims it).
- [x] Plan content references existing PRs / issues / ADRs / memory entries correctly.
- [x] SPRINT.md entry placed under the most-relevant in-flight sprint (Sprint 54).
- [x] No source code touched; nothing to compile or test.

## Out of scope for this PR

- All implementation. Phases 0-3 are planning only.
- Any cross-reference back from Plan 91 to Plan 93 (Plan 91 is in PR #417, not on \`main\` yet). Can be added when both land.

🤖 Generated with [Claude Code](https://claude.com/claude-code)