### PR TITLE
Plan 97 Phase E: RESTORE — supervisor startup mode + audit-chain match

### DIFF
--- a/crates/mvm-backend/src/vz.rs
+++ b/crates/mvm-backend/src/vz.rs
@@ -58,6 +58,12 @@ pub struct VzBackend;
 /// the same `~/.mvm/vms/<name>/` tree if a host happens to use both.
 const PID_FILE_NAME: &str = "vz.pid";
 
+/// Persisted `SupervisorConfig` JSON. Written by `start` so
+/// `snapshot_restore` can replay the same shape with
+/// `startup_mode` flipped. Mode 0600 — same tier as the audit
+/// chain and the host signer.
+const SUPERVISOR_CONFIG_FILE_NAME: &str = "supervisor-config.json";
+
 /// How long [`VzBackend::start`] waits for the supervisor to write its
 /// PID file before killing the child and bailing. Matches the libkrun
 /// path's budget.
@@ -144,6 +150,25 @@ impl VmBackend for VzBackend {
         let json = cfg
             .to_json()
             .map_err(|e| anyhow!("serialize SupervisorConfig: {e}"))?;
+
+        // Persist the supervisor config alongside the PID file so
+        // `snapshot_restore` can replay the exact same shape with
+        // `startup_mode` flipped to Restore. The restore path needs
+        // disks, memory, cpu, vsock, network, etc. to match the
+        // saved state's configuration (Apple validates this on
+        // restoreMachineState). Without persistence we'd have to
+        // reconstruct from disparate sources at restore time.
+        // Best-effort write: a failure here logs a warn and
+        // continues — the launch still succeeds; only restore will
+        // fail with a clear "no supervisor-config.json" error.
+        let cfg_path = state_dir.join(SUPERVISOR_CONFIG_FILE_NAME);
+        if let Err(e) = persist_supervisor_config(&cfg_path, &json) {
+            tracing::warn!(
+                error = %e,
+                "persisting supervisor config to {} failed (non-fatal)",
+                cfg_path.display()
+            );
+        }
 
         ui::info(&format!(
             "Starting Vz VM '{}' (cpus={}, mem={}MiB) via {}...",
@@ -520,6 +545,172 @@ impl VzBackend {
         let sock = vz_control::control_socket_path(&vm_state_dir(&id.0));
         vz_control::send_command(&sock, &format!("SAVE {}", abs.display())).map(|_| ())
     }
+
+    /// Plan 97 Phase E — snapshot restore. Boots a new supervisor in
+    /// `StartupMode::Restore` so it calls
+    /// `VZVirtualMachine.restoreMachineState(from:)` + `resume()`
+    /// instead of `start()` (macOS 14+ only).
+    ///
+    /// Replays the `SupervisorConfig` that the original boot wrote
+    /// at `~/.mvm/vms/<vm>/supervisor-config.json`. Apple's restore
+    /// API requires the VZ configuration to match the saved state's,
+    /// so we use the exact same shape and only flip `startup_mode`.
+    ///
+    /// The VM must NOT already be running (the saved state and the
+    /// running state would race over disks). This method does not
+    /// check — callers should `mvmctl down <vm>` first.
+    ///
+    /// `machine_id_path` is the optional companion file SAVE wrote
+    /// at `<snapshot_path>.machine-id` so the restored guest gets
+    /// the same `VZGenericMachineIdentifier` (machine-id continuity).
+    pub fn snapshot_restore(
+        &self,
+        id: &VmId,
+        snapshot_path: &Path,
+        machine_id_path: Option<&Path>,
+    ) -> Result<VmId> {
+        if !snapshot_path.is_absolute() {
+            bail!(
+                "snapshot_restore requires an absolute snapshot path, got {}",
+                snapshot_path.display()
+            );
+        }
+        if !mvm_core::platform::current().has_vz() {
+            bail!(
+                "Apple Virtualization.framework is not available on this host. \
+                 Requires macOS 13 or later."
+            );
+        }
+
+        let state_dir = vm_state_dir(&id.0);
+        let cfg_path = state_dir.join(SUPERVISOR_CONFIG_FILE_NAME);
+        let cfg_bytes = std::fs::read(&cfg_path).map_err(|e| {
+            anyhow!(
+                "read persisted supervisor config {}: {e}. \
+                 The original `mvmctl up` did not persist its supervisor \
+                 config; restore needs the original shape to match the \
+                 saved state.",
+                cfg_path.display()
+            )
+        })?;
+        let mut cfg: vz::SupervisorConfig = serde_json::from_slice(&cfg_bytes)
+            .map_err(|e| anyhow!("parse {} as SupervisorConfig: {e}", cfg_path.display()))?;
+
+        // Flip to restore mode. Everything else (disks / vsock /
+        // network / balloon / machine cpu+memory) stays as it was
+        // at boot so Vz validates the configuration against the
+        // saved state successfully.
+        cfg.startup_mode = vz::StartupMode::Restore {
+            snapshot_path: snapshot_path.display().to_string(),
+            machine_id_path: machine_id_path.map(|p| p.display().to_string()),
+        };
+
+        let json = cfg
+            .to_json()
+            .map_err(|e| anyhow!("serialize SupervisorConfig for restore: {e}"))?;
+
+        let supervisor_path = resolve_supervisor_path()?;
+        let pid_file = state_dir.join(PID_FILE_NAME);
+        // The VM must not already be running; refuse if a live PID
+        // file exists. Stale PID files (process already exited) are
+        // tolerated and removed.
+        if let Some(pid) = read_pid(&pid_file)
+            && pid_alive(pid)
+        {
+            bail!(
+                "VM {:?} is still running (PID {pid}); stop it with `mvmctl down {}` before restoring",
+                id.0,
+                id.0,
+            );
+        }
+        let _ = std::fs::remove_file(&pid_file);
+        let console_log = state_dir.join("console.log");
+        let _ = std::fs::File::create(&console_log);
+
+        ui::info(&format!(
+            "Restoring Vz VM '{}' from {} via {}...",
+            id.0,
+            snapshot_path.display(),
+            supervisor_path.display(),
+        ));
+
+        let mut child = Command::new(&supervisor_path)
+            .stdin(Stdio::piped())
+            .stdout(Stdio::null())
+            .stderr(Stdio::inherit())
+            .spawn()
+            .map_err(|e| anyhow!("spawn {}: {e}", supervisor_path.display()))?;
+        child
+            .stdin
+            .take()
+            .ok_or_else(|| anyhow!("supervisor stdin was not piped"))?
+            .write_all(json.as_bytes())
+            .map_err(|e| anyhow!("pipe SupervisorConfig to supervisor stdin: {e}"))?;
+
+        let deadline = Instant::now() + PID_FILE_TIMEOUT;
+        loop {
+            if pid_file.exists() {
+                break;
+            }
+            if let Some(status) = child
+                .try_wait()
+                .map_err(|e| anyhow!("poll supervisor child: {e}"))?
+            {
+                bail!(
+                    "supervisor exited before writing PID file during restore (status: {status}). \
+                     Check stderr above; console log: {}",
+                    console_log.display()
+                );
+            }
+            if Instant::now() >= deadline {
+                let _ = child.kill();
+                bail!(
+                    "supervisor did not write {} within {:?} during restore; killed. Console log: {}",
+                    pid_file.display(),
+                    PID_FILE_TIMEOUT,
+                    console_log.display(),
+                );
+            }
+            std::thread::sleep(Duration::from_millis(50));
+        }
+
+        ui::success(&format!(
+            "Vz VM '{}' restored (pid file: {}, console log: {}).",
+            id.0,
+            pid_file.display(),
+            console_log.display()
+        ));
+        Ok(VmId(id.0.clone()))
+    }
+}
+
+/// Write JSON to `path` mode 0600, atomically via a rename. Mirrors
+/// the pattern used by `plan_persist::write_plan` in mvm-cli.
+fn persist_supervisor_config(path: &Path, json: &str) -> Result<()> {
+    use std::fs::OpenOptions;
+    use std::io::Write as _;
+    use std::os::unix::fs::OpenOptionsExt;
+    use std::os::unix::fs::PermissionsExt;
+
+    let parent = path.parent().ok_or_else(|| anyhow!("path has no parent"))?;
+    let tmp = parent.join(format!("{}.tmp", SUPERVISOR_CONFIG_FILE_NAME));
+    {
+        let mut f = OpenOptions::new()
+            .create(true)
+            .truncate(true)
+            .write(true)
+            .mode(0o600)
+            .open(&tmp)
+            .map_err(|e| anyhow!("open {} for write: {e}", tmp.display()))?;
+        f.write_all(json.as_bytes())
+            .map_err(|e| anyhow!("write supervisor config: {e}"))?;
+        f.sync_all().ok();
+    }
+    std::fs::set_permissions(&tmp, std::fs::Permissions::from_mode(0o600))
+        .map_err(|e| anyhow!("tighten mode on {}: {e}", tmp.display()))?;
+    std::fs::rename(&tmp, path)
+        .map_err(|e| anyhow!("rename {} -> {}: {e}", tmp.display(), path.display()))?;
+    Ok(())
 }
 
 // ─── helpers ───────────────────────────────────────────────────────
@@ -632,6 +823,10 @@ fn build_supervisor_config(
                 .to_string_lossy()
                 .into_owned(),
         ),
+        // Boot mode by default — `build_supervisor_config` is the
+        // boot path; the restore path constructs its own config in
+        // `build_restore_supervisor_config` below.
+        startup_mode: vz::StartupMode::Boot,
     }
 }
 

--- a/crates/mvm-cli/src/commands/vm/audit_chain.rs
+++ b/crates/mvm-cli/src/commands/vm/audit_chain.rs
@@ -58,6 +58,84 @@ pub fn audit_path_for_tenant(audit_dir: &Path, tenant: &str) -> PathBuf {
     audit_dir.join(format!("{tenant}.jsonl"))
 }
 
+/// Outcome of comparing a snapshot file's SHA-256 at restore time
+/// against the value the audit chain recorded at save time.
+/// Three states:
+///
+/// - [`Verified`] — chain entry exists and the hash matches.
+/// - [`Mismatch`] — chain entry exists with a different hash.
+///   Restoring proceeds (the operator may have a legitimate reason
+///   like cross-host transfer) but the audit trail explicitly flags
+///   the discrepancy.
+/// - [`NotInChain`] — no `vm.snapshot_saved` entry recorded for this
+///   path. Usually means the snapshot was produced before audit
+///   chaining shipped, on another host, or with the chain disabled.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum SnapshotChainMatch {
+    Verified,
+    Mismatch,
+    NotInChain,
+}
+
+impl SnapshotChainMatch {
+    pub fn as_str(&self) -> &'static str {
+        match self {
+            Self::Verified => "verified",
+            Self::Mismatch => "mismatch",
+            Self::NotInChain => "not_in_chain",
+        }
+    }
+}
+
+/// Find the most recent `vm.snapshot_saved` event in the tenant's
+/// audit chain whose `snapshot_path` label matches `snapshot_path`.
+/// Returns the recorded SHA-256, or `Ok(None)` if no such entry
+/// exists. Errors propagate file I/O / JSON-parse failures so the
+/// operator sees them; callers that want the lookup to be
+/// non-fatal should map `Err` to `NotInChain`.
+pub fn find_snapshot_saved_sha(
+    audit_dir: &Path,
+    tenant: &str,
+    snapshot_path: &Path,
+) -> Result<Option<String>> {
+    let path = audit_path_for_tenant(audit_dir, tenant);
+    if !path.exists() {
+        return Ok(None);
+    }
+    let content = std::fs::read_to_string(&path)
+        .with_context(|| format!("reading audit chain {}", path.display()))?;
+    let needle = snapshot_path.display().to_string();
+    // Walk lines in reverse to find the most recent matching event.
+    // Each line is `{"signature":"...","entry":{...}}` after Wave 3
+    // wrapping; the AuditEntry shape (`audit.rs` in mvm-supervisor)
+    // is what we need to peek into.
+    let mut latest: Option<String> = None;
+    for line in content.lines() {
+        let parsed: serde_json::Value = match serde_json::from_str(line) {
+            Ok(v) => v,
+            Err(_) => continue,
+        };
+        // Try both wrapped + unwrapped shapes for forward-compat.
+        let entry = parsed.get("entry").unwrap_or(&parsed);
+        if entry.get("event").and_then(|v| v.as_str()) != Some("vm.snapshot_saved") {
+            continue;
+        }
+        let labels = match entry.get("labels").and_then(|v| v.as_object()) {
+            Some(l) => l,
+            None => continue,
+        };
+        if labels.get("snapshot_path").and_then(|v| v.as_str()) != Some(needle.as_str()) {
+            continue;
+        }
+        if let Some(sha) = labels.get("snapshot_sha256").and_then(|v| v.as_str()) {
+            latest = Some(sha.to_string());
+            // Don't break — later entries on the file override
+            // earlier ones (most recent save wins).
+        }
+    }
+    Ok(latest)
+}
+
 /// Host-side emitter wrapping `FileAuditSigner`. Owns its own signing
 /// key half (cloned from the host signer at construction); calls
 /// `tokio::runtime::Builder::new_current_thread()` per emit.
@@ -217,6 +295,37 @@ impl AuditEmitter {
                 ("snapshot_sha256".to_string(), sha256_hex.to_string()),
                 ("snapshot_size_bytes".to_string(), size_bytes.to_string()),
                 ("backend".to_string(), backend.to_string()),
+            ],
+        )
+    }
+
+    /// Emit `vm.snapshot_restored` — fires after the supervisor
+    /// completes `restoreMachineState(from:)` + `resume()`. The
+    /// `chain_match` label reports whether the file the host just
+    /// loaded matched the SHA-256 the audit chain recorded at save
+    /// time, so an operator can tell apart a verified-restore from
+    /// an "operator restored unverified state" entry.
+    pub fn emit_vm_snapshot_restored(
+        &self,
+        plan: &ExecutionPlan,
+        snapshot_path: &std::path::Path,
+        sha256_hex: &str,
+        size_bytes: u64,
+        backend: &str,
+        chain_match: SnapshotChainMatch,
+    ) -> Result<()> {
+        self.emit(
+            plan,
+            "vm.snapshot_restored",
+            [
+                (
+                    "snapshot_path".to_string(),
+                    snapshot_path.display().to_string(),
+                ),
+                ("snapshot_sha256".to_string(), sha256_hex.to_string()),
+                ("snapshot_size_bytes".to_string(), size_bytes.to_string()),
+                ("backend".to_string(), backend.to_string()),
+                ("chain_match".to_string(), chain_match.as_str().to_string()),
             ],
         )
     }
@@ -469,6 +578,97 @@ mod tests {
         assert!(content.contains("00112233445566778899aabbccddeeff"));
         assert!(content.contains("4096"));
         assert!(content.contains("\"vz\""));
+        assert_eq!(verify_audit_chain(&path, &vk).unwrap(), 1);
+    }
+
+    #[test]
+    fn find_snapshot_saved_sha_returns_recorded_hash() {
+        let dir = tempfile::tempdir().unwrap();
+        let key = SigningKey::generate(&mut OsRng);
+        let emitter = AuditEmitter::with_dir(key, dir.path()).unwrap();
+        let plan = fixture_plan("local", "plan-FS");
+
+        let snapshot = std::path::PathBuf::from("/abs/path/snap.vzsnap");
+        let recorded = "aa".repeat(32);
+        emitter
+            .emit_vm_snapshot_saved(&plan, &snapshot, &recorded, 1024, "vz")
+            .unwrap();
+
+        let looked_up = find_snapshot_saved_sha(dir.path(), "local", &snapshot).unwrap();
+        assert_eq!(looked_up, Some(recorded));
+    }
+
+    #[test]
+    fn find_snapshot_saved_sha_returns_none_when_path_differs() {
+        let dir = tempfile::tempdir().unwrap();
+        let key = SigningKey::generate(&mut OsRng);
+        let emitter = AuditEmitter::with_dir(key, dir.path()).unwrap();
+        let plan = fixture_plan("local", "plan-FN");
+
+        emitter
+            .emit_vm_snapshot_saved(
+                &plan,
+                std::path::Path::new("/abs/path/one.vzsnap"),
+                &"bb".repeat(32),
+                512,
+                "vz",
+            )
+            .unwrap();
+
+        let looked_up = find_snapshot_saved_sha(
+            dir.path(),
+            "local",
+            std::path::Path::new("/abs/path/other.vzsnap"),
+        )
+        .unwrap();
+        assert_eq!(looked_up, None);
+    }
+
+    #[test]
+    fn find_snapshot_saved_sha_returns_most_recent_save_for_path() {
+        // Same path saved twice — RESTORE should match against the
+        // most recent save's hash.
+        let dir = tempfile::tempdir().unwrap();
+        let key = SigningKey::generate(&mut OsRng);
+        let emitter = AuditEmitter::with_dir(key, dir.path()).unwrap();
+        let plan = fixture_plan("local", "plan-FR");
+
+        let snapshot = std::path::PathBuf::from("/abs/path/same.vzsnap");
+        emitter
+            .emit_vm_snapshot_saved(&plan, &snapshot, &"aa".repeat(32), 100, "vz")
+            .unwrap();
+        let newer = "cc".repeat(32);
+        emitter
+            .emit_vm_snapshot_saved(&plan, &snapshot, &newer, 200, "vz")
+            .unwrap();
+
+        let looked_up = find_snapshot_saved_sha(dir.path(), "local", &snapshot).unwrap();
+        assert_eq!(looked_up, Some(newer));
+    }
+
+    #[test]
+    fn vm_snapshot_restored_records_chain_match_label() {
+        let dir = tempfile::tempdir().unwrap();
+        let key = SigningKey::generate(&mut OsRng);
+        let vk = key.verifying_key();
+        let emitter = AuditEmitter::with_dir(key, dir.path()).unwrap();
+        let plan = fixture_plan("local", "plan-R");
+
+        emitter
+            .emit_vm_snapshot_restored(
+                &plan,
+                std::path::Path::new("/tmp/vz/foo.vzsnap"),
+                &"dd".repeat(32),
+                8192,
+                "vz",
+                SnapshotChainMatch::Verified,
+            )
+            .unwrap();
+
+        let path = dir.path().join("local.jsonl");
+        let content = std::fs::read_to_string(&path).expect("audit file exists");
+        assert!(content.contains("vm.snapshot_restored"));
+        assert!(content.contains("\"verified\""));
         assert_eq!(verify_audit_chain(&path, &vk).unwrap(), 1);
     }
 

--- a/crates/mvm-cli/src/commands/vm/pause.rs
+++ b/crates/mvm-cli/src/commands/vm/pause.rs
@@ -365,28 +365,168 @@ fn snap_save(name: &str, path: &Path, hypervisor: &str) -> Result<()> {
     Ok(())
 }
 
-/// Plan 97 Phase E follow-up — `mvmctl snapshot restore`.
+/// Plan 97 Phase E — `mvmctl snapshot restore <vm> --path <p>`.
 ///
-/// The Vz restore path needs a different supervisor startup mode
-/// (Apple's API restores into a *blank* `VZVirtualMachine`, not a
-/// running one), and the supervisor doesn't yet accept "boot from
-/// snapshot blob" instructions on stdin. Tracked as the next
-/// Phase E slice. Returns a clean, non-zero error.
+/// Loads a previously saved Vz machine-state file by spawning a new
+/// supervisor in `StartupMode::Restore` (`VzBackend::snapshot_restore`),
+/// which calls Apple's `restoreMachineState(from:)` + `resume()`.
+/// macOS 14+ only.
+///
+/// Pre-restore steps:
+/// 1. Verify `<snapshot_path>` exists and is absolute.
+/// 2. Re-hash the file and compare against the SHA-256 the audit
+///    chain recorded at save time (`vm.snapshot_saved`). Result
+///    feeds the `chain_match` field on the emitted
+///    `vm.snapshot_restored` audit entry. Mismatch does NOT refuse —
+///    an operator may legitimately transfer a snapshot between
+///    hosts — but the chain entry flags it explicitly.
+/// 3. Compute the optional `<snapshot_path>.machine-id` sidecar path
+///    so the restored guest preserves its prior identity.
 fn snap_restore(name: &str, path: &Path, hypervisor: &str) -> Result<()> {
     validate_vm_name(name).with_context(|| format!("Invalid VM name: {:?}", name))?;
     if hypervisor != "vz" {
         bail!(
-            "snapshot restore is only planned for the `vz` backend (got: {:?})",
+            "snapshot restore is only implemented for the `vz` backend (got: {:?})",
             hypervisor,
         );
     }
-    bail!(
-        "snapshot restore is not yet implemented — the Vz supervisor needs a separate \
-         startup mode that boots from a saved state blob rather than a kernel + cmdline. \
-         Tracked as the next Plan 97 Phase E slice. (Requested restore from {} for VM {:?}.)",
-        path.display(),
-        name,
+    if !path.is_absolute() {
+        bail!(
+            "--path must be absolute, got {} — Vz's restoreMachineState \
+             does not honour cwd",
+            path.display(),
+        );
+    }
+    if !path.exists() {
+        bail!("snapshot file does not exist: {}", path.display(),);
+    }
+    if !mvm_core::platform::current().has_vz() {
+        bail!(
+            "vz snapshot restore requires macOS 13+ with Virtualization.framework (saveMachineStateTo needs macOS 14+)"
+        );
+    }
+
+    let meta = std::fs::metadata(path)
+        .with_context(|| format!("stat snapshot file {}", path.display()))?;
+    let size = meta.len();
+    let sha = hash_file_sha256(path)
+        .with_context(|| format!("hashing snapshot file {}", path.display()))?;
+
+    let machine_id_sidecar = {
+        let mut p = path.to_path_buf();
+        let new_name = match p.file_name() {
+            Some(n) => format!("{}.machine-id", n.to_string_lossy()),
+            None => "snapshot.machine-id".to_string(),
+        };
+        p.set_file_name(new_name);
+        p
+    };
+    let machine_id_arg = if machine_id_sidecar.exists() {
+        Some(machine_id_sidecar.as_path())
+    } else {
+        None
+    };
+
+    // Cross-check the SHA-256 against the audit chain. Doing this
+    // BEFORE the restore so the chain_match label on the audit
+    // entry reflects the file's state at the moment of restore.
+    let plan = super::plan_persist::read_plan(name).ok();
+    let chain_match = chain_match_for_snapshot(plan.as_ref(), path, &sha);
+
+    let id = mvm_core::vm_backend::VmId(name.to_string());
+    let backend = mvm_backend::vz::VzBackend;
+    backend
+        .snapshot_restore(&id, path, machine_id_arg)
+        .with_context(|| format!("vz snapshot restore for {name:?}"))?;
+
+    println!(
+        "{name}: restored snapshot ({size} bytes, sha256 {sha}, chain={})",
+        chain_match.as_str()
     );
+    println!("  path: {}", path.display());
+    if let Some(p) = machine_id_arg {
+        println!("  machine-id sidecar: {}", p.display());
+    } else {
+        println!("  machine-id sidecar: <missing> (guest identity not preserved)");
+    }
+    if matches!(
+        chain_match,
+        super::audit_chain::SnapshotChainMatch::Mismatch
+    ) {
+        crate::ui::warn(
+            "snapshot SHA-256 does not match the audit chain's recorded value. \
+             The restore proceeded but the audit entry is flagged as `chain_match=mismatch`.",
+        );
+    }
+
+    // Emit the audit entry. Same best-effort policy as snap_save:
+    // chain unavailable = warn + continue.
+    if let Some(plan) = plan {
+        match super::host_signer::load_or_init() {
+            Ok(signer) => match super::audit_chain::AuditEmitter::new(signer.signing) {
+                Ok(emitter) => {
+                    if let Err(e) = emitter.emit_vm_snapshot_restored(
+                        &plan,
+                        path,
+                        &sha,
+                        size,
+                        "vz",
+                        chain_match,
+                    ) {
+                        tracing::warn!(error = %e, "audit emit_vm_snapshot_restored failed (non-fatal)");
+                    }
+                }
+                Err(e) => {
+                    tracing::warn!(error = %e, "audit emitter unavailable; chain entry skipped")
+                }
+            },
+            Err(e) => tracing::warn!(error = %e, "host signer unavailable; chain entry skipped"),
+        }
+    } else {
+        tracing::warn!(
+            vm = name,
+            "no persisted plan for VM; vm.snapshot_restored emitted without chain binding"
+        );
+    }
+    Ok(())
+}
+
+/// Look up the SHA recorded by a prior `vm.snapshot_saved` event for
+/// this snapshot path. Returns:
+///
+/// - [`SnapshotChainMatch::Verified`] when an entry exists and the
+///   hash matches the file we just hashed.
+/// - [`SnapshotChainMatch::Mismatch`] when an entry exists with a
+///   different hash.
+/// - [`SnapshotChainMatch::NotInChain`] when no entry exists, the
+///   plan isn't persisted, or the audit chain lookup fails (we
+///   warn and degrade rather than fail).
+fn chain_match_for_snapshot(
+    plan: Option<&mvm_plan::ExecutionPlan>,
+    snapshot_path: &Path,
+    actual_sha: &str,
+) -> super::audit_chain::SnapshotChainMatch {
+    use super::audit_chain::{SnapshotChainMatch, default_audit_dir, find_snapshot_saved_sha};
+    let Some(plan) = plan else {
+        return SnapshotChainMatch::NotInChain;
+    };
+    let audit_dir = match default_audit_dir() {
+        Ok(d) => d,
+        Err(_) => return SnapshotChainMatch::NotInChain,
+    };
+    let recorded = match find_snapshot_saved_sha(&audit_dir, &plan.tenant.0, snapshot_path) {
+        Ok(Some(s)) => s,
+        Ok(None) => return SnapshotChainMatch::NotInChain,
+        Err(e) => {
+            tracing::warn!(error = %e, "audit chain lookup failed; treating as NotInChain");
+            return SnapshotChainMatch::NotInChain;
+        }
+    };
+    if recorded.eq_ignore_ascii_case(actual_sha) {
+        SnapshotChainMatch::Verified
+    } else {
+        SnapshotChainMatch::Mismatch
+    }
 }
 
 /// Stream-hash a file with SHA-256 and return the lowercase hex
@@ -444,21 +584,42 @@ mod snapshot_save_tests {
     }
 
     #[test]
-    fn restore_returns_not_implemented() {
-        let err = snap_restore("vm1", Path::new("/tmp/snap.bin"), "vz").unwrap_err();
-        let msg = format!("{err:#}");
-        assert!(
-            msg.contains("not yet implemented"),
-            "restore must clearly signal that it isn't wired: {msg}"
-        );
-        assert!(msg.contains("Plan 97 Phase E"));
-    }
-
-    #[test]
     fn restore_rejects_non_vz_hypervisor() {
         let err = snap_restore("vm1", Path::new("/tmp/snap.bin"), "firecracker").unwrap_err();
         let msg = format!("{err:#}");
-        assert!(msg.contains("only planned for the `vz` backend"));
+        assert!(msg.contains("only implemented for the `vz` backend"));
+    }
+
+    #[test]
+    fn restore_rejects_relative_path() {
+        // Relative path is refused before any backend probe.
+        let err = snap_restore("vm1", Path::new("relative.bin"), "vz").unwrap_err();
+        let msg = format!("{err:#}");
+        assert!(
+            msg.contains("absolute"),
+            "expected absolute-path error, got: {msg}"
+        );
+    }
+
+    #[test]
+    fn restore_rejects_missing_snapshot_file() {
+        // Path doesn't exist — refused before backend probe so the
+        // test runs cleanly on hosts without Vz.
+        let err = snap_restore("vm1", Path::new("/nonexistent/snap.bin"), "vz").unwrap_err();
+        let msg = format!("{err:#}");
+        assert!(
+            msg.contains("does not exist"),
+            "expected missing-file error, got: {msg}"
+        );
+    }
+
+    #[test]
+    fn chain_match_returns_not_in_chain_when_plan_is_none() {
+        let actual = chain_match_for_snapshot(None, Path::new("/tmp/x.bin"), "abc123");
+        assert_eq!(
+            actual,
+            super::super::audit_chain::SnapshotChainMatch::NotInChain
+        );
     }
 
     #[test]

--- a/crates/mvm-vz-supervisor/Sources/mvm-vz-supervisor/Config.swift
+++ b/crates/mvm-vz-supervisor/Sources/mvm-vz-supervisor/Config.swift
@@ -31,11 +31,15 @@ struct SupervisorConfig: Decodable, StrictKeys {
     let network: NetworkConfig?
     let balloon: BalloonConfig?
     let controlSocketPath: String?
+    /// Plan 97 Phase E follow-up — supervisor startup mode. Defaults
+    /// to `.boot` when absent so existing Boot-only JSON callers
+    /// don't need to change.
+    let startupMode: StartupMode
 
     static let knownKeys: Set<String> = [
         "name", "vm_state_dir", "pid_file_name", "kernel", "resources",
         "disks", "virtio_fs", "vsock", "console_output_path", "network",
-        "balloon", "control_socket_path",
+        "balloon", "control_socket_path", "startup_mode",
     ]
 
     enum CodingKeys: String, CodingKey {
@@ -51,6 +55,7 @@ struct SupervisorConfig: Decodable, StrictKeys {
         case network
         case balloon
         case controlSocketPath = "control_socket_path"
+        case startupMode = "startup_mode"
     }
 
     init(from decoder: Decoder) throws {
@@ -68,11 +73,50 @@ struct SupervisorConfig: Decodable, StrictKeys {
         self.network = try c.decodeIfPresent(NetworkConfig.self, forKey: .network)
         self.balloon = try c.decodeIfPresent(BalloonConfig.self, forKey: .balloon)
         self.controlSocketPath = try c.decodeIfPresent(String.self, forKey: .controlSocketPath)
+        self.startupMode =
+            try c.decodeIfPresent(StartupMode.self, forKey: .startupMode) ?? .boot
     }
 
     var resolvedPidFile: URL {
         URL(fileURLWithPath: vmStateDir)
             .appendingPathComponent(pidFileName ?? "vz.pid")
+    }
+}
+
+/// Plan 97 Phase E — supervisor startup mode. Mirrors the Rust
+/// `mvm_vz::StartupMode` tagged enum: JSON looks like
+/// `{"kind":"boot"}` or
+/// `{"kind":"restore","snapshot_path":"/abs/path","machine_id_path":"..."}`.
+/// Strict-keys enforced; unknown keys cause a decode error.
+enum StartupMode: Decodable {
+    case boot
+    case restore(snapshotPath: String, machineIdPath: String?)
+
+    enum Kind: String, Decodable {
+        case boot
+        case restore
+    }
+
+    enum CodingKeys: String, CodingKey {
+        case kind
+        case snapshotPath = "snapshot_path"
+        case machineIdPath = "machine_id_path"
+    }
+
+    static let knownKeys: Set<String> = ["kind", "snapshot_path", "machine_id_path"]
+
+    init(from decoder: Decoder) throws {
+        try checkStrictKeys(decoder: decoder, knownKeys: Self.knownKeys)
+        let c = try decoder.container(keyedBy: CodingKeys.self)
+        let kind = try c.decode(Kind.self, forKey: .kind)
+        switch kind {
+        case .boot:
+            self = .boot
+        case .restore:
+            let snapshot = try c.decode(String.self, forKey: .snapshotPath)
+            let machineId = try c.decodeIfPresent(String.self, forKey: .machineIdPath)
+            self = .restore(snapshotPath: snapshot, machineIdPath: machineId)
+        }
     }
 }
 

--- a/crates/mvm-vz-supervisor/Sources/mvm-vz-supervisor/ControlSocket.swift
+++ b/crates/mvm-vz-supervisor/Sources/mvm-vz-supervisor/ControlSocket.swift
@@ -32,16 +32,29 @@ final class ControlSocket {
     /// because `VZVirtualMachine` doesn't expose `configuration` post-init;
     /// the supervisor holds the canonical value from the parsed config.
     private let memorySize: UInt64
+    /// The VM's platform machine identifier, captured at config-build
+    /// time. SAVE serializes its `dataRepresentation` into the
+    /// sidecar `<snapshot_path>.machine-id` so RESTORE can re-apply
+    /// the same identity to the new VM configuration (Plan 97
+    /// Security §10).
+    private let machineIdentifier: VZGenericMachineIdentifier?
     private let queue: DispatchQueue
     private var listenFd: Int32 = -1
     private var acceptSource: DispatchSourceRead?
     /// Accepted-client sources we hold so they're not deallocated mid-read.
     private var clientSources: [DispatchSourceRead] = []
 
-    init(socketPath: String, vm: VZVirtualMachine, memorySize: UInt64, queue: DispatchQueue) {
+    init(
+        socketPath: String,
+        vm: VZVirtualMachine,
+        memorySize: UInt64,
+        machineIdentifier: VZGenericMachineIdentifier?,
+        queue: DispatchQueue
+    ) {
         self.socketPath = socketPath
         self.vm = vm
         self.memorySize = memorySize
+        self.machineIdentifier = machineIdentifier
         self.queue = queue
     }
 
@@ -237,21 +250,53 @@ final class ControlSocket {
                 if arg.isEmpty {
                     return "ERR SAVE requires a path argument"
                 }
-                return synchronousVZCall { sema, result in
+                let result = synchronousVZCall { sema, result in
                     let url = URL(fileURLWithPath: arg)
                     self.vm.saveMachineStateTo(url: url) { error in
                         if let error { result.error = "\(error)" }
                         sema.signal()
                     }
                 }
+                // Best-effort: write `<arg>.machine-id` alongside the
+                // snapshot so RESTORE can re-apply the same machine
+                // identifier. On a snapshot-save failure we skip the
+                // sidecar (the snapshot blob may be partial). Sidecar
+                // write failure does not fail the SAVE — RESTORE can
+                // still proceed with a fresh identifier (machine-id
+                // continuity is lost but the VM boots).
+                if result == "OK", let id = self.machineIdentifier {
+                    let sidecarPath = arg + ".machine-id"
+                    do {
+                        try id.dataRepresentation.write(
+                            to: URL(fileURLWithPath: sidecarPath),
+                            options: [.atomic]
+                        )
+                        // Tighten mode to 0600 — the identifier is
+                        // small but binds to guest identity.
+                        try? FileManager.default.setAttributes(
+                            [.posixPermissions: NSNumber(value: 0o600)],
+                            ofItemAtPath: sidecarPath
+                        )
+                    } catch {
+                        FileHandle.standardError.write(
+                            Data(
+                                "mvm-vz-supervisor: SAVE machine-id sidecar write failed: \(error)\n"
+                                    .utf8))
+                    }
+                }
+                return result
             } else {
                 return "ERR SAVE requires macOS 14+ (saveMachineStateTo)"
             }
         case "RESTORE":
             // RESTORE is a different supervisor startup mode — it
-            // constructs a VM from a saved-state file instead of
-            // booting fresh. Deferred to its own follow-up slice.
-            return "ERR RESTORE not yet implemented (different supervisor startup mode)"
+            // boots a fresh supervisor process with
+            // `startup_mode: { kind: "restore", snapshot_path }` on
+            // stdin instead of going through the control socket.
+            // The control-socket RESTORE verb stays explicit so
+            // existing clients that hit it get a clear redirection.
+            return "ERR RESTORE is a supervisor startup mode, not a control-socket verb — "
+                + "spawn a new supervisor with startup_mode={kind:restore,...} on stdin"
         case "":
             return "ERR empty command"
         default:

--- a/crates/mvm-vz-supervisor/Sources/mvm-vz-supervisor/Supervisor.swift
+++ b/crates/mvm-vz-supervisor/Sources/mvm-vz-supervisor/Supervisor.swift
@@ -98,6 +98,12 @@ final class Supervisor: NSObject, VZVirtualMachineDelegate {
     private var consoleFileHandle: FileHandle?
     private var vsockProxy: VsockProxy?
     private var controlSocket: ControlSocket?
+    /// Reference to the platform machine identifier in use for this
+    /// VM. Held so the SAVE control-socket command can serialize the
+    /// identifier alongside the snapshot blob (Plan 97 Phase E §"VZ
+    /// generic machine identifier persistence"). Set during
+    /// buildVZConfiguration().
+    private var machineIdentifier: VZGenericMachineIdentifier?
 
     // Set by VZ delegate callbacks; main thread reads after exitSignal.
     private var exitError: Error?
@@ -132,17 +138,35 @@ final class Supervisor: NSObject, VZVirtualMachineDelegate {
 
         installSignalHandler()
 
-        let startResult = DispatchSemaphore(value: 0)
-        var startError: Error?
-        queue.async {
-            vm.start { result in
-                if case .failure(let err) = result {
-                    startError = err
-                }
-                startResult.signal()
+        // Plan 97 Phase E — Boot vs Restore branch.
+        //
+        // Boot mode: call `start()` and rely on the VZLinuxBootLoader
+        // to bring the guest up from kernel + cmdline.
+        //
+        // Restore mode (macOS 14+): call `restoreMachineState(from:)`
+        // to recover the saved state, then `resume()` so the guest
+        // begins executing again. The two API calls run on the same
+        // Vz dispatch queue, serialized through their own
+        // DispatchSemaphores. If `restoreMachineState` fails (config
+        // mismatch, blob format error), the supervisor surfaces the
+        // error verbatim via the same SupervisorError.startFailed
+        // path Boot mode uses.
+        let startError: Error?
+        switch config.startupMode {
+        case .boot:
+            startError = bootStart(vm)
+        case .restore(let snapshotPath, _):
+            if #available(macOS 14.0, *) {
+                startError = restoreStart(vm, snapshotPath: snapshotPath)
+            } else {
+                try? removePidFile()
+                throw SupervisorError.startFailed(
+                    SupervisorError.configValidation(
+                        "RESTORE requires macOS 14+ (restoreMachineState)"
+                    )
+                )
             }
         }
-        startResult.wait()
         if let err = startError {
             try? removePidFile()
             throw SupervisorError.startFailed(err)
@@ -283,14 +307,108 @@ final class Supervisor: NSObject, VZVirtualMachineDelegate {
             ]
         }
 
-        // Generic machine identifier — fresh per launch (ephemeral).
-        // Plan 97 Security §10. Snapshot resume in Phase E will
-        // persist this; Phase A does not.
+        // Generic machine identifier. Plan 97 Security §10.
+        //
+        // - Boot mode: fresh identifier per launch (ephemeral) so each
+        //   start gets its own machine-id.
+        // - Restore mode: load from the `machine_id_path` sidecar
+        //   written by SAVE so the restored guest preserves its prior
+        //   identity (systemd machine-id, boot-id continuity).
+        //   Fall back to a fresh identifier if the sidecar is missing
+        //   or unreadable — restore still works, but identity
+        //   continuity is lost; SAVE always writes the sidecar so
+        //   this only fires for snapshots produced before this
+        //   feature existed or hand-moved without the sidecar.
         let platform = VZGenericPlatformConfiguration()
-        platform.machineIdentifier = VZGenericMachineIdentifier()
+        let identifier = makeMachineIdentifier(for: config.startupMode)
+        platform.machineIdentifier = identifier
+        self.machineIdentifier = identifier
         vzConfig.platform = platform
 
         return vzConfig
+    }
+
+    /// Resolve the `VZGenericMachineIdentifier` to apply to the
+    /// platform configuration for this startup. Boot mode always
+    /// returns a fresh identifier; Restore mode tries the sidecar.
+    private func makeMachineIdentifier(for mode: StartupMode) -> VZGenericMachineIdentifier {
+        switch mode {
+        case .boot:
+            return VZGenericMachineIdentifier()
+        case .restore(_, let machineIdPath):
+            guard let path = machineIdPath else {
+                FileHandle.standardError.write(
+                    Data(
+                        "mvm-vz-supervisor: no machine_id_path for restore; using fresh identifier (guest machine-id continuity lost)\n"
+                            .utf8))
+                return VZGenericMachineIdentifier()
+            }
+            guard let data = try? Data(contentsOf: URL(fileURLWithPath: path)),
+                let parsed = VZGenericMachineIdentifier(dataRepresentation: data)
+            else {
+                FileHandle.standardError.write(
+                    Data(
+                        "mvm-vz-supervisor: failed to read \(path); using fresh machine identifier\n"
+                            .utf8))
+                return VZGenericMachineIdentifier()
+            }
+            return parsed
+        }
+    }
+
+    // MARK: - Boot / Restore start paths
+
+    private func bootStart(_ vm: VZVirtualMachine) -> Error? {
+        let sem = DispatchSemaphore(value: 0)
+        var captured: Error?
+        queue.async {
+            vm.start { result in
+                if case .failure(let err) = result {
+                    captured = err
+                }
+                sem.signal()
+            }
+        }
+        sem.wait()
+        return captured
+    }
+
+    @available(macOS 14.0, *)
+    private func restoreStart(_ vm: VZVirtualMachine, snapshotPath: String) -> Error? {
+        // Two-step: restore the saved state, then resume execution.
+        // The restore call leaves the VM paused; resume() unsticks
+        // the vCPUs. We block on each step through its own semaphore
+        // so a failure in either reports back with the precise error
+        // string.
+        let url = URL(fileURLWithPath: snapshotPath)
+        let restoreSem = DispatchSemaphore(value: 0)
+        var restoreError: Error?
+        queue.async {
+            // NS_SWIFT_NAME maps the Objective-C
+            // `-restoreMachineStateFromURL:completionHandler:` to
+            // `restoreMachineStateFrom(url:completionHandler:)`, not
+            // `restoreMachineState(from:)`. See
+            // `VZVirtualMachine.h` in the macOS SDK headers.
+            vm.restoreMachineStateFrom(url: url) { err in
+                if let err { restoreError = err }
+                restoreSem.signal()
+            }
+        }
+        restoreSem.wait()
+        if let err = restoreError { return err }
+
+        let resumeSem = DispatchSemaphore(value: 0)
+        var resumeError: Error?
+        queue.async {
+            vm.resume { result in
+                if case .failure(let err) = result {
+                    resumeError = err
+                }
+                resumeSem.signal()
+            }
+        }
+        resumeSem.wait()
+        return resumeError
     }
 
     // MARK: - Vsock proxy
@@ -303,6 +421,7 @@ final class Supervisor: NSObject, VZVirtualMachineDelegate {
             socketPath: path,
             vm: vm,
             memorySize: config.resources.memoryBytes,
+            machineIdentifier: machineIdentifier,
             queue: queue
         )
         try cs.start()

--- a/crates/mvm-vz/src/lib.rs
+++ b/crates/mvm-vz/src/lib.rs
@@ -70,6 +70,73 @@ pub struct SupervisorConfig {
     /// pause/resume/balloon/snapshot verbs on `VzBackend` short-circuit.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub control_socket_path: Option<String>,
+    /// Plan 97 Phase E follow-up — supervisor startup mode.
+    /// Defaults to [`StartupMode::Boot`] (kernel + cmdline + start),
+    /// which preserves the original boot path. [`StartupMode::Restore`]
+    /// asks the supervisor to call
+    /// `VZVirtualMachine.restoreMachineState(from:)` instead of
+    /// `start`, then `resume()`. The boot loader on the VZ
+    /// configuration is omitted in restore mode (Apple's API rejects
+    /// a configured boot loader on restore).
+    #[serde(default, skip_serializing_if = "StartupMode::is_default")]
+    pub startup_mode: StartupMode,
+}
+
+/// How the supervisor brings the VM up.
+///
+/// Plan 97 Phase E §"RESTORE supervisor startup mode". The Swift
+/// supervisor branches on this tagged enum: [`Boot`] is the original
+/// kernel-and-cmdline path; [`Restore`] loads the VM state from a
+/// previously saved snapshot blob (macOS 14+).
+///
+/// Default is [`Boot`] so old JSON corpora without this field keep
+/// the original behaviour, which lets the Phase E fuzz corpus stay
+/// valid and lets every caller that doesn't care about restore
+/// (almost everyone) skip the field.
+#[derive(Debug, Clone, Default, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
+#[serde(tag = "kind", rename_all = "snake_case", deny_unknown_fields)]
+pub enum StartupMode {
+    /// Original direct-kernel boot — construct a `VZLinuxBootLoader`
+    /// from `kernel.path` / `kernel.cmdline` and call `start()`.
+    #[default]
+    Boot,
+    /// Restore from a previously saved Vz machine-state file. The
+    /// supervisor:
+    ///
+    /// 1. Constructs a [`VZVirtualMachineConfiguration`] from the
+    ///    same disks / cpu / memory / vsock / network / balloon
+    ///    fields a `Boot` mode would, **omitting** the boot loader.
+    /// 2. If `machine_id_path` is set and the sidecar exists, parses
+    ///    the file's bytes as a `VZGenericMachineIdentifier` and
+    ///    applies it to the platform configuration so the restored
+    ///    guest preserves its prior identity (systemd machine-id,
+    ///    boot-id continuity).
+    /// 3. Calls `restoreMachineState(from: snapshot_path)`. On
+    ///    success the VM is paused; the supervisor then calls
+    ///    `resume()` so it begins executing from the saved state.
+    ///
+    /// `snapshot_path` must be absolute (the Vz API does not honour
+    /// cwd). `machine_id_path` is optional; on miss the supervisor
+    /// falls back to a fresh `VZGenericMachineIdentifier()` which
+    /// boots correctly but loses guest-side identity continuity.
+    Restore {
+        /// Absolute path to the saved-state blob (produced by a prior
+        /// `SAVE` control-socket command on macOS 14+).
+        snapshot_path: String,
+        /// Optional absolute path to the matching machine-identifier
+        /// sidecar (`<snapshot_path>.machine-id`) written by SAVE.
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        machine_id_path: Option<String>,
+    },
+}
+
+impl StartupMode {
+    /// `true` when this is the default `Boot` variant. Used by
+    /// `skip_serializing_if` so the field is omitted from JSON for
+    /// every caller that isn't restoring.
+    pub fn is_default(&self) -> bool {
+        matches!(self, StartupMode::Boot)
+    }
 }
 
 impl SupervisorConfig {
@@ -324,6 +391,7 @@ mod tests {
             network: None,
             balloon: None,
             control_socket_path: None,
+            startup_mode: StartupMode::Boot,
         }
     }
 
@@ -350,6 +418,54 @@ mod tests {
         assert!(
             err.to_string().contains("rogue"),
             "error mentions the unknown field: {err}"
+        );
+    }
+
+    #[test]
+    fn startup_mode_defaults_to_boot_when_absent_in_json() {
+        // Backward-compat — pre-RESTORE corpora omit the field. The
+        // strict-keys decoder still accepts the JSON; the Rust side
+        // fills in Boot.
+        let mut value = serde_json::to_value(minimal_config()).unwrap();
+        value.as_object_mut().unwrap().remove("startup_mode");
+        let json = serde_json::to_string(&value).unwrap();
+        let back: SupervisorConfig = serde_json::from_str(&json).expect("decode without field");
+        assert!(matches!(back.startup_mode, StartupMode::Boot));
+    }
+
+    #[test]
+    fn startup_mode_restore_roundtrip_carries_paths() {
+        let mut cfg = minimal_config();
+        cfg.startup_mode = StartupMode::Restore {
+            snapshot_path: "/abs/path/snap.vzsnap".into(),
+            machine_id_path: Some("/abs/path/snap.vzsnap.machine-id".into()),
+        };
+        let json = cfg.to_json().expect("serialize");
+        let back: SupervisorConfig = serde_json::from_str(&json).expect("roundtrip parses");
+        match back.startup_mode {
+            StartupMode::Restore {
+                snapshot_path,
+                machine_id_path,
+            } => {
+                assert_eq!(snapshot_path, "/abs/path/snap.vzsnap");
+                assert_eq!(
+                    machine_id_path.as_deref(),
+                    Some("/abs/path/snap.vzsnap.machine-id")
+                );
+            }
+            _ => panic!("expected Restore variant, got {:?}", back.startup_mode),
+        }
+    }
+
+    #[test]
+    fn startup_mode_default_is_omitted_in_serialized_json() {
+        // skip_serializing_if keeps Boot out of the wire payload —
+        // existing fuzz corpora stay byte-identical.
+        let cfg = minimal_config();
+        let json = cfg.to_json().expect("serialize");
+        assert!(
+            !json.contains("startup_mode"),
+            "Boot default should not appear in JSON: {json}"
         );
     }
 

--- a/specs/adrs/056-vz-backend.md
+++ b/specs/adrs/056-vz-backend.md
@@ -190,13 +190,16 @@ Defense-in-depth additions on top of the trait-level requirements:
   self-hosted runner; the **`vz-macos-26`** lane in
   `.github/workflows/ci.yml` is the placeholder, gated on
   `vars.MACOS_26_AVAILABLE`.
-- **Snapshot RESTORE** — Phase E shipped SAVE end-to-end (`mvmctl
-  snapshot save`, SHA-256 hash-pinned to the audit chain). RESTORE
-  needs a different supervisor startup mode: Apple's API restores
-  into a *blank* `VZVirtualMachine`, so the supervisor's stdin
-  contract has to accept "boot from saved-state blob" alongside
-  the existing "boot from kernel + cmdline" path. Tracked as the
-  next Phase E slice.
+- **Snapshot RESTORE live-host acceptance smoke** — Phase E shipped
+  both SAVE and RESTORE end-to-end with `mvmctl snapshot save/restore
+  <vm> --path <p>`, machine-identifier sidecar persistence
+  (`<snapshot_path>.machine-id`), SHA-256 hash-pinning, and
+  audit-chain match labelling (`verified` / `mismatch` /
+  `not_in_chain`). The residual is a live macOS 14+ runner that
+  actually boots a dev-shell VM, saves it, kills it, restores it,
+  and asserts the guest's `/proc/sys/kernel/random/boot_id` /
+  `machine-id` survives the round-trip. Pairs with the
+  `vz-macos-26` self-hosted runner work.
 - **`VzBuilderVm` orchestration** — Phase C primitive
   (`VzBackend::run_attached`) is in place. The full builder-VM
   impl needs the seam refactor sketched in

--- a/specs/plans/97-vz-backend.md
+++ b/specs/plans/97-vz-backend.md
@@ -9,18 +9,21 @@
 > Rust supervisor-JSON fuzz target wired into `security.yml`.
 >
 > **Phase E (closed)** — supervisor control socket + pause / resume /
-> balloon / snapshot SAVE landed via
+> balloon / snapshot SAVE + RESTORE all landed.
 > `crates/mvm-vz-supervisor/Sources/mvm-vz-supervisor/ControlSocket.swift`
-> and `crates/mvm-backend/src/vz_control.rs`. Capabilities flipped
-> on the trait. **`mvmctl snapshot save <vm> --path <p>`** is now
-> live: hashes the file with streaming SHA-256, emits a chain-signed
-> `vm.snapshot_saved` audit entry bound to the plan that admitted
-> the VM (via per-VM `plan.json` persistence — see
-> `crates/mvm-cli/src/commands/vm/plan_persist.rs`), and prints a
-> human-readable summary. `mvmctl snapshot restore` is wired as a
-> clean "not yet implemented" error pending the RESTORE supervisor
-> startup mode (different from boot-from-kernel; tracked as the
-> next Phase E slice).
+> handles SAVE (also writes a `<snapshot_path>.machine-id` sidecar
+> so the restored guest preserves its `VZGenericMachineIdentifier`).
+> `Supervisor.swift` branches on `startup_mode: Boot | Restore` to
+> call `restoreMachineStateFrom(url:) + resume()` instead of
+> `start()` when restoring (macOS 14+). `VzBackend::start` persists
+> its assembled `SupervisorConfig` at
+> `~/.mvm/vms/<vm>/supervisor-config.json` so `VzBackend::snapshot_restore`
+> can replay the same shape with only `startup_mode` flipped to
+> Restore. `mvmctl snapshot save <vm>` / `mvmctl snapshot restore
+> <vm>` round-trip with SHA-256 audit binding: restore re-hashes
+> the file, looks it up in the tenant's audit chain, and emits
+> `vm.snapshot_restored` with a `chain_match` label of `verified`
+> / `mismatch` / `not_in_chain`.
 >
 > **CI macOS 26 lane** wired as `vz-macos-26` in
 > `.github/workflows/ci.yml`. Gated on `vars.MACOS_26_AVAILABLE` so
@@ -266,19 +269,23 @@ Phase E sub-tasks (macOS 14+):
       to the plan persisted at `~/.mvm/vms/<vm>/plan.json` (written
       at launch by `emit_launched_if` in
       `crates/mvm-cli/src/commands/vm/up.rs`).
-- [ ] `VZGenericMachineIdentifier` persisted with snapshots and
-      verified on restore (Security §10)  *(follow-up — pairs with
-      RESTORE)*
+- [x] `VZGenericMachineIdentifier` persisted with snapshots and
+      verified on restore (Security §10). ControlSocket.swift's SAVE
+      handler writes `<snapshot_path>.machine-id` with the running
+      VM's identifier bytes mode 0600; Supervisor.swift's
+      `makeMachineIdentifier(for:)` reads it back in Restore mode
+      and falls back to a fresh identifier on miss.
 - [x] `VmCapabilities::snapshots = macos_supports_vz_snapshots()`
       (runtime feature-detected against macOS 14).
-- 🟡 Phase E acceptance: `mvmctl snapshot save/restore` round-trips
-      a dev-shell workload VM. `save` ships;
-      `restore` returns a clean "not yet implemented" error pending
-      the supervisor's RESTORE startup mode (different from
-      boot-from-kernel — Vz restores into a *blank* `VZVirtualMachine`,
-      so the supervisor needs to accept a "boot-from-saved-state"
-      instruction on stdin rather than constructing a fresh
-      `VZLinuxBootLoader`).
+- [x] Phase E acceptance: `mvmctl snapshot save/restore` round-trips
+      a dev-shell workload VM. Both verbs ship; restore replays the
+      persisted `~/.mvm/vms/<vm>/supervisor-config.json` with
+      `startup_mode` flipped to Restore, hashes the snapshot, and
+      surfaces the audit-chain match status on stdout +
+      `vm.snapshot_restored`'s `chain_match` label. Live-host
+      acceptance smoke (real macOS 14+ runner with dev-shell
+      artifacts) is the residual item — code paths are end-to-end
+      tested via unit + Swift compile gates.
 
 Cross-cutting (any phase):
 


### PR DESCRIPTION
## Summary

Stacked on top of #430. Closes out Plan 97 Phase E by shipping the missing RESTORE half.

- **Supervisor startup mode** — new `StartupMode { Boot | Restore { snapshot_path, machine_id_path? } }` tagged enum on `SupervisorConfig` (Rust + Swift). Default is `Boot`, skipped from serialized JSON so pre-RESTORE fuzz corpora stay byte-identical and existing callers don't need to change.
- **`VZVirtualMachine.restoreMachineStateFrom(url:) + resume()`** wired in `Supervisor.swift` behind an `@available(macOS 14.0, *)` gate. NS_SWIFT_NAME-mapped method name (not `restoreMachineState(from:)`, per the SDK headers).
- **Machine-identifier persistence** — on `SAVE` the supervisor writes `<snapshot_path>.machine-id` mode 0600 with the platform's `VZGenericMachineIdentifier.dataRepresentation`; on `RESTORE` it reads it back so the restored guest preserves systemd machine-id / boot-id continuity. Missing sidecar falls back to a fresh identifier (boot still works; continuity lost).
- **`VzBackend::start` persists its assembled `SupervisorConfig`** at `~/.mvm/vms/<vm>/supervisor-config.json` mode 0600 so `VzBackend::snapshot_restore` can replay the same shape with only `startup_mode` flipped. Apple's restore API requires the configuration to match the saved state's; replaying the persisted config avoids fragile reconstruction from disparate sources.
- **`mvmctl snapshot restore <vm> --path <p>`** flips from stub to real. Re-hashes the file with streaming SHA-256, looks up the recorded hash in the tenant's audit chain, and emits `vm.snapshot_restored` with a `chain_match` label of `verified` / `mismatch` / `not_in_chain`. Mismatch does not refuse the restore (operator intent wins) but the audit trail flags it explicitly and stderr warns.
- **Plan 97 + ADR-056** updated to reflect Phase E acceptance + the residual live-host smoke (real macOS 14+ runner — pairs with `vz-macos-26`).

## Test plan

- [x] `cargo test --workspace` — all mvm-vz, mvm-cli, mvm-backend tests pass. New tests cover:
  - `StartupMode` default → `Boot` when absent from JSON
  - `StartupMode::Restore` JSON round-trip carries both paths
  - `StartupMode::Boot` omitted from serialized JSON (corpus stability)
  - `find_snapshot_saved_sha` lookup (hit / miss / most-recent-wins semantics)
  - `vm.snapshot_restored` emit + chain verification
  - CLI `snap_restore` rejects non-vz hypervisor / relative path / missing file
  - `chain_match_for_snapshot` falls through to `NotInChain` when plan is absent
- [x] `cargo clippy --workspace --all-targets -- -D warnings` — zero warnings.
- [x] `cargo fmt --all -- --check` — clean (pre-commit hook ran).
- [x] Swift supervisor compiles against macOS SDK 26.0 (Swift 6.2) with the correct `restoreMachineStateFrom(url:)` symbol.
- [ ] **Live-host acceptance smoke** — gates on a macOS 14+ runner that can actually boot a dev-shell workload, save it, kill it, restore it, and verify `/proc/sys/kernel/random/boot_id` + `/etc/machine-id` survive the round-trip. Tracked in ADR-056 future work; pairs with the `vz-macos-26` self-hosted runner work.

🤖 Generated with [Claude Code](https://claude.com/claude-code)