### PR TITLE
Plan 97 Phase C foundation: VmBackendForBuilder trait + LibkrunBuilderBackend impl (no behavior change)

### DIFF
--- a/crates/mvm-build/src/builder_vm.rs
+++ b/crates/mvm-build/src/builder_vm.rs
@@ -372,6 +372,314 @@ impl BuilderVm for StubBuilderVm {
     }
 }
 
+// ============================================================================
+// VmBackendForBuilder — hypervisor-agnostic seam for the builder-VM helper.
+//
+// Plan 97 §"Phase C seam design". This trait is the smaller-than-VmBackend
+// surface that a future `BuilderVmRuntime` helper builds on top of:
+// today `LibkrunBuilderVm` does both the substrate orchestration (cmd.sh
+// emission, /job/result parsing, panic detection, NixStoreImageLock,
+// stderr-tail capture) and the hypervisor-specific spawn/wait. Lifting
+// the substrate out behind this trait lets a future `VzBuilderVm`
+// reuse ~850 lines of orchestration code with only a Vz-side mount
+// glue (~600 lines).
+//
+// This commit lands the trait + supporting types only — no impls yet.
+// Subsequent slices wire it for libkrun (port LibkrunBuilderVm) and
+// Vz (new VzBuilderVm).
+// ============================================================================
+
+/// Per-run configuration the builder helper passes to the underlying
+/// hypervisor. Hypervisor-agnostic — both libkrun and Vz consume it
+/// identically. Plan 97 Phase C seam design §1.
+///
+/// Resources (`vcpus`, `memory_mib`) are caller-supplied; the
+/// backend's resource-cap check enforces a host-side ceiling.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct BuilderVmRunConfig {
+    /// Human-readable VM name. Surfaces in logs + the per-VM state
+    /// dir. Must be a valid mvm VM name (see `mvm_core::naming`).
+    pub name: String,
+    /// Absolute host path to the uncompressed Linux kernel.
+    pub kernel_path: PathBuf,
+    /// Kernel command line. Backend impls thread it onto their
+    /// supervisor's boot loader unchanged.
+    pub kernel_cmdline: String,
+    /// Optional initrd path.
+    pub initrd_path: Option<PathBuf>,
+    /// vCPU count. The libkrun + Vz backends both refuse values
+    /// above their host-determined caps.
+    pub vcpus: u8,
+    /// Guest memory in MiB.
+    pub memory_mib: u32,
+    /// Vsock ports the host wants to dial. Each becomes a per-port
+    /// unix socket under `<vm_state_dir>/vsock/`.
+    pub vsock_ports: Vec<u32>,
+    /// Per-VM state directory. The backend creates it mode 0700 and
+    /// writes its `<backend>.pid`, `console.log`, and vsock socket
+    /// dir inside.
+    pub vm_state_dir: PathBuf,
+}
+
+/// virtio-fs share to attach for the builder run. Maps onto
+/// `libkrun_add_virtiofs` (libkrun) or
+/// `VZVirtioFileSystemDeviceConfiguration` (Vz).
+///
+/// Builder mode is the *only* path that attaches virtio-fs shares
+/// today; workload microVMs default to zero shares per Plan 97
+/// §"Host-path mounts" and refuse unauthorised shares.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct BuilderVmMount {
+    /// Symbolic mount tag the guest uses in `mount -t virtiofs <tag>
+    /// <target>`. Convention: `/work`, `/out`, `/job`.
+    pub tag: String,
+    /// Host directory exported into the guest.
+    pub host_path: PathBuf,
+    /// Whether the share is mounted read-only inside the guest.
+    pub read_only: bool,
+}
+
+/// Additional virtio-blk device beyond the rootfs (e.g. the
+/// persistent Nix store image at `/dev/vdb`).
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct BuilderVmDisk {
+    /// Stable identifier; surfaces in logs only.
+    pub id: String,
+    /// Host path to the raw disk image.
+    pub host_path: PathBuf,
+    /// Whether the device is read-only.
+    pub read_only: bool,
+}
+
+/// Outcome of a single builder-VM run from the perspective of the
+/// hypervisor-agnostic helper. The helper interprets this against
+/// the job's expectations (`exit_code == 0` + no panic = success).
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct BuilderVmExitInfo {
+    /// Guest exit code (Some when the supervisor cleanly returned a
+    /// status; None when the supervisor died before observing the
+    /// guest exit — kernel panic, SIGKILL, etc.).
+    pub exit_code: Option<i32>,
+    /// First matched line of a kernel-panic banner if the host-side
+    /// console-log watcher caught one. None on a clean run. Plan 77
+    /// W6's panic-detector contract — `Child::wait()` cannot detect
+    /// a panicked libkrun guest, so the watcher tails the console
+    /// log and kills the supervisor when it sees the banner.
+    pub panic_line: Option<String>,
+}
+
+/// Hypervisor-agnostic primitive that a `BuilderVmRuntime` helper
+/// builds on top of. Plan 97 §"Phase C seam design".
+///
+/// Both `LibkrunBuilderVm` (today, via the libkrun supervisor) and
+/// the future `VzBuilderVm` (via the `mvm-vz-supervisor`) implement
+/// this trait. The shared orchestration logic — cmd.sh emission,
+/// `/job/result` JSON parsing, `NixStoreImageLock`, kernel-panic
+/// detection on the console log, stderr-tail capture — lives in the
+/// helper and works against `&dyn VmBackendForBuilder` so it doesn't
+/// know which VMM is on the other end.
+///
+/// ## Design rationale
+///
+/// `VmBackend` (in `mvm-core::vm_backend`) is the *workload* runtime
+/// trait — single-shot `start` returning a `VmId`, async stop, etc.
+/// The builder path needs a different shape: foreground spawn, block
+/// until guest exits, return the exit info + panic line. Reusing
+/// `VmBackend` would either bloat its surface or shoehorn the
+/// builder semantics into ill-fitting methods. A dedicated trait
+/// keeps both clean.
+///
+/// ## Implementations (planned)
+///
+/// - `LibkrunBuilderBackend` — `mvm-build/src/libkrun_builder.rs`,
+///   wraps `spawn_supervisor_and_wait` + `wait_with_panic_detector`.
+///   Lands in the next slice (PR-B).
+/// - `VzBuilderBackend` — wraps `VzBackend::run_attached` with
+///   builder-side virtio-fs share configuration. Lands in PR-C.
+pub trait VmBackendForBuilder: Send + Sync {
+    /// Spawn the supervisor for a builder run, attach the given
+    /// virtio-fs shares + extra virtio-blk disks, and block until
+    /// the guest exits. Returns the exit info — exit code plus
+    /// optional panic line captured by the host-side console-log
+    /// watcher.
+    ///
+    /// The supervisor must be killed if `timeout` elapses. Callers
+    /// that want unbounded waits pass `Duration::MAX`.
+    fn run_attached_with_mounts(
+        &self,
+        config: &BuilderVmRunConfig,
+        mounts: &[BuilderVmMount],
+        extra_disks: &[BuilderVmDisk],
+        timeout: std::time::Duration,
+    ) -> Result<BuilderVmExitInfo, BuilderVmError>;
+
+    /// Host-side path of the supervisor's console capture file
+    /// inside `vm_state_dir`. The panic-detector watcher in the
+    /// helper tails this in real time. Returning a path that
+    /// doesn't yet exist is fine — the supervisor creates it ~100 ms
+    /// after spawn, and the watcher's poll loop retries
+    /// `File::open()` until the file appears (Plan 77 W6).
+    fn console_log_path(&self, vm_state_dir: &Path) -> PathBuf;
+}
+
+#[cfg(test)]
+mod vm_backend_for_builder_tests {
+    use super::*;
+    use std::sync::Mutex;
+    use std::time::Duration;
+
+    /// Recorded args from a single `run_attached_with_mounts` call.
+    /// Named so the mock's `invocations` Vec stays under the
+    /// clippy::type_complexity threshold.
+    type RecordedInvocation = (BuilderVmRunConfig, Vec<BuilderVmMount>, Vec<BuilderVmDisk>);
+
+    /// Test mock — records every `run_attached_with_mounts` call and
+    /// returns a programmable `BuilderVmExitInfo`. Exists in this
+    /// module rather than as a workspace-level fixture so the trait
+    /// is exercised at the point of definition. A future
+    /// `BuilderVmRuntime` test suite (PR-B) can move this into a
+    /// `pub(crate)` helper if reused.
+    #[derive(Default)]
+    struct MockBackend {
+        scripted_exit: Option<BuilderVmExitInfo>,
+        scripted_err: Option<BuilderVmError>,
+        invocations: Mutex<Vec<RecordedInvocation>>,
+    }
+
+    impl VmBackendForBuilder for MockBackend {
+        fn run_attached_with_mounts(
+            &self,
+            config: &BuilderVmRunConfig,
+            mounts: &[BuilderVmMount],
+            extra_disks: &[BuilderVmDisk],
+            _timeout: Duration,
+        ) -> Result<BuilderVmExitInfo, BuilderVmError> {
+            self.invocations.lock().unwrap().push((
+                config.clone(),
+                mounts.to_vec(),
+                extra_disks.to_vec(),
+            ));
+            if let Some(err) = &self.scripted_err {
+                // Errors don't have an obvious Clone, so reconstruct
+                // the specific cases the trait emits.
+                return Err(match err {
+                    BuilderVmError::NotYetImplemented => BuilderVmError::NotYetImplemented,
+                    BuilderVmError::SeedKernelPanic {
+                        panic_line,
+                        console_log_path,
+                    } => BuilderVmError::SeedKernelPanic {
+                        panic_line: panic_line.clone(),
+                        console_log_path: console_log_path.clone(),
+                    },
+                    other => BuilderVmError::ExtractionFailed(format!("mock: {other}")),
+                });
+            }
+            Ok(self.scripted_exit.clone().unwrap_or(BuilderVmExitInfo {
+                exit_code: Some(0),
+                panic_line: None,
+            }))
+        }
+
+        fn console_log_path(&self, vm_state_dir: &Path) -> PathBuf {
+            vm_state_dir.join("console.log")
+        }
+    }
+
+    fn fixture_config() -> BuilderVmRunConfig {
+        BuilderVmRunConfig {
+            name: "builder-test".to_string(),
+            kernel_path: PathBuf::from("/tmp/vmlinux"),
+            kernel_cmdline: "console=hvc0".to_string(),
+            initrd_path: None,
+            vcpus: 2,
+            memory_mib: 1024,
+            vsock_ports: vec![5252],
+            vm_state_dir: PathBuf::from("/tmp/mvm-test/builder-test"),
+        }
+    }
+
+    #[test]
+    fn run_attached_records_config_mounts_and_disks() {
+        let backend = MockBackend::default();
+        let cfg = fixture_config();
+        let mount = BuilderVmMount {
+            tag: "/work".to_string(),
+            host_path: PathBuf::from("/host/work"),
+            read_only: true,
+        };
+        let disk = BuilderVmDisk {
+            id: "nix-store".to_string(),
+            host_path: PathBuf::from("/host/nix-store.img"),
+            read_only: false,
+        };
+
+        let info = backend
+            .run_attached_with_mounts(
+                &cfg,
+                std::slice::from_ref(&mount),
+                std::slice::from_ref(&disk),
+                Duration::from_secs(1),
+            )
+            .expect("default mock returns clean exit");
+        assert_eq!(info.exit_code, Some(0));
+        assert!(info.panic_line.is_none());
+
+        let invocations = backend.invocations.lock().unwrap();
+        assert_eq!(invocations.len(), 1);
+        let (recorded_cfg, recorded_mounts, recorded_disks) = &invocations[0];
+        assert_eq!(recorded_cfg, &cfg);
+        assert_eq!(recorded_mounts.as_slice(), std::slice::from_ref(&mount));
+        assert_eq!(recorded_disks.as_slice(), std::slice::from_ref(&disk));
+    }
+
+    #[test]
+    fn console_log_path_lives_inside_state_dir() {
+        let backend = MockBackend::default();
+        let dir = PathBuf::from("/tmp/example/vms/foo");
+        let p = backend.console_log_path(&dir);
+        assert_eq!(p, dir.join("console.log"));
+    }
+
+    #[test]
+    fn exit_info_carries_panic_line() {
+        let backend = MockBackend {
+            scripted_exit: Some(BuilderVmExitInfo {
+                exit_code: None,
+                panic_line: Some("Kernel panic - not syncing: VFS: Unable to mount root fs".into()),
+            }),
+            ..Default::default()
+        };
+        let info = backend
+            .run_attached_with_mounts(&fixture_config(), &[], &[], Duration::from_secs(1))
+            .expect("panic surfaces through the exit info, not an Err");
+        assert_eq!(info.exit_code, None);
+        assert!(info.panic_line.as_deref().unwrap().contains("Kernel panic"));
+    }
+
+    #[test]
+    fn errors_propagate_through_the_trait() {
+        let backend = MockBackend {
+            scripted_err: Some(BuilderVmError::NotYetImplemented),
+            ..Default::default()
+        };
+        let err = backend
+            .run_attached_with_mounts(&fixture_config(), &[], &[], Duration::from_secs(1))
+            .expect_err("scripted error propagates");
+        assert!(matches!(err, BuilderVmError::NotYetImplemented));
+    }
+
+    #[test]
+    fn mock_works_through_dyn_trait_object() {
+        // The helper (PR-B) holds `&dyn VmBackendForBuilder`, so the
+        // trait must be object-safe. This compiles only if it is.
+        let backend: Box<dyn VmBackendForBuilder> = Box::new(MockBackend::default());
+        let info = backend
+            .run_attached_with_mounts(&fixture_config(), &[], &[], Duration::from_secs(1))
+            .unwrap();
+        assert_eq!(info.exit_code, Some(0));
+    }
+}
+
 /// Resolve the host architecture's matching Linux system for flake
 /// attribute construction. Mirrors `mvm-build/src/backend/host.rs`'s
 /// `resolve_build_attribute_host`'s system selection.

--- a/crates/mvm-build/src/builder_vm_runtime.rs
+++ b/crates/mvm-build/src/builder_vm_runtime.rs
@@ -1,0 +1,143 @@
+//! Plan 97 §"Phase C seam design" — hypervisor-agnostic builder-VM
+//! orchestration helper.
+//!
+//! [`BuilderVmRuntime`] is the shared orchestration body that both
+//! the libkrun and Vz builder paths route through. It owns the
+//! pieces that aren't tied to a specific VMM:
+//!
+//! - `cmd.sh` emission (Flake jobs) and `install_spec.json` staging
+//!   (Install jobs)
+//! - `/job/result` JSON parsing
+//! - Per-variant artifact finalisation (rootfs path resolution,
+//!   revision hash extraction, install-volume sidecar discovery)
+//! - Nix store image lock acquisition (libkrun-only concern in
+//!   today's runtime; abstracted here for future Vz reuse)
+//! - stderr-tail capture for build-failure diagnostics
+//! - Wall-clock timeout handling
+//!
+//! It does **not** own:
+//!
+//! - Supervisor process lifecycle (lives in the
+//!   [`VmBackendForBuilder`] impl — libkrun's
+//!   `spawn_supervisor_in_background` / Vz's `run_attached`)
+//! - Console-log watching for kernel-panic detection (also lives
+//!   in the impl; surfaces through `BuilderVmExitInfo.panic_line`)
+//! - Hypervisor-specific config translation (KrunContext vs.
+//!   Vz's `SupervisorConfig`)
+//!
+//! Today the helper is a skeleton. Subsequent commits migrate the
+//! concerns above out of `LibkrunBuilderVm.run_build` into here,
+//! one at a time. Each migration commit is independently
+//! verifiable: build + existing tests stay green, and the new
+//! helper methods get their own unit tests.
+
+use crate::builder_vm::VmBackendForBuilder;
+
+/// Hypervisor-agnostic orchestration helper. Holds a reference to
+/// a [`VmBackendForBuilder`] so the actual supervisor spawn /
+/// console-log path / per-VM state directory are routed through
+/// the appropriate VMM without the helper knowing which one.
+///
+/// Lifetime-bound — the helper doesn't own the backend; callers
+/// keep a long-lived backend instance (e.g. `LibkrunBuilderBackend`
+/// constructed once at `LibkrunBuilderVm::run_build` entry) and
+/// hand a borrow to the helper for the duration of one run.
+pub struct BuilderVmRuntime<'a> {
+    backend: &'a dyn VmBackendForBuilder,
+}
+
+impl<'a> BuilderVmRuntime<'a> {
+    /// Construct over an existing backend reference.
+    pub fn new(backend: &'a dyn VmBackendForBuilder) -> Self {
+        Self { backend }
+    }
+
+    /// Borrow the underlying backend. Subsequent migration commits
+    /// expose more targeted methods; this exists today so the
+    /// helper has a way to thread the backend through its yet-to-be-
+    /// migrated methods without re-routing every call site through
+    /// a builder.
+    pub fn backend(&self) -> &dyn VmBackendForBuilder {
+        self.backend
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::builder_vm::{BuilderVmDisk, BuilderVmExitInfo, BuilderVmMount, BuilderVmRunConfig};
+    use std::path::{Path, PathBuf};
+    use std::time::Duration;
+
+    /// Minimal backend that records every call. Same shape as the
+    /// mock in `builder_vm::vm_backend_for_builder_tests`, but
+    /// re-defined here because that mock lives inside `#[cfg(test)]`
+    /// in the sibling module and isn't visible across the module
+    /// boundary. As the helper grows, this fixture grows with it.
+    #[derive(Default)]
+    struct CountingBackend {
+        run_calls: std::sync::atomic::AtomicUsize,
+        console_calls: std::sync::atomic::AtomicUsize,
+    }
+
+    impl VmBackendForBuilder for CountingBackend {
+        fn run_attached_with_mounts(
+            &self,
+            _config: &BuilderVmRunConfig,
+            _mounts: &[BuilderVmMount],
+            _extra_disks: &[BuilderVmDisk],
+            _timeout: Duration,
+        ) -> Result<BuilderVmExitInfo, crate::builder_vm::BuilderVmError> {
+            self.run_calls
+                .fetch_add(1, std::sync::atomic::Ordering::SeqCst);
+            Ok(BuilderVmExitInfo {
+                exit_code: Some(0),
+                panic_line: None,
+            })
+        }
+
+        fn console_log_path(&self, vm_state_dir: &Path) -> PathBuf {
+            self.console_calls
+                .fetch_add(1, std::sync::atomic::Ordering::SeqCst);
+            vm_state_dir.join("console.log")
+        }
+    }
+
+    #[test]
+    fn runtime_borrows_backend_for_lifetime_of_run() {
+        let backend = CountingBackend::default();
+        let runtime = BuilderVmRuntime::new(&backend);
+        // Backend accessor returns the same trait object we passed
+        // in; future helper methods will use it to dispatch.
+        let log = runtime
+            .backend()
+            .console_log_path(Path::new("/tmp/state/foo"));
+        assert_eq!(log, PathBuf::from("/tmp/state/foo/console.log"));
+        assert_eq!(
+            backend
+                .console_calls
+                .load(std::sync::atomic::Ordering::SeqCst),
+            1
+        );
+    }
+
+    #[test]
+    fn runtime_is_zero_cost_to_construct() {
+        // Construction is a single pointer + vtable; no fs / VM /
+        // network ops fire. This test pins that contract — a
+        // subsequent commit that adds expensive setup to
+        // `BuilderVmRuntime::new` would break it.
+        let backend = CountingBackend::default();
+        let _runtime = BuilderVmRuntime::new(&backend);
+        assert_eq!(
+            backend.run_calls.load(std::sync::atomic::Ordering::SeqCst),
+            0
+        );
+        assert_eq!(
+            backend
+                .console_calls
+                .load(std::sync::atomic::Ordering::SeqCst),
+            0
+        );
+    }
+}

--- a/crates/mvm-build/src/builder_vm_runtime.rs
+++ b/crates/mvm-build/src/builder_vm_runtime.rs
@@ -31,7 +31,16 @@
 //! verifiable: build + existing tests stay green, and the new
 //! helper methods get their own unit tests.
 
-use crate::builder_vm::VmBackendForBuilder;
+use std::path::Path;
+
+use crate::builder_vm::{BuilderJob, BuilderVmError, VmBackendForBuilder};
+
+/// Per-job dir filename mvm-builder-init detects to dispatch
+/// through the application-dependency install pipeline (Plan 73
+/// Followup B.2). Migrated from `libkrun_builder.rs` because the
+/// install spec staging is a hypervisor-agnostic concern that
+/// both the libkrun and Vz builder paths need.
+pub const INSTALL_SPEC_FILENAME: &str = "install_spec.json";
 
 /// Hypervisor-agnostic orchestration helper. Holds a reference to
 /// a [`VmBackendForBuilder`] so the actual supervisor spawn /
@@ -60,6 +69,190 @@ impl<'a> BuilderVmRuntime<'a> {
     pub fn backend(&self) -> &dyn VmBackendForBuilder {
         self.backend
     }
+}
+
+/// Stage the per-job dir inside `~/.cache/mvm/builder-vm/jobs/<id>/`
+/// so the in-guest `mvm-builder-init` finds the right artifact
+/// for dispatch:
+///
+/// - [`BuilderJob::Flake`] → writes `cmd.sh` (the in-guest nix-build
+///   script). mvm-builder-init runs it after `/work` `/out` `/job`
+///   virtio-fs shares are mounted.
+/// - [`BuilderJob::Install`] → copies the caller's install-spec JSON
+///   to `<job_dir>/install_spec.json`. mvm-builder-init detects the
+///   filename and dispatches the application-dep install pipeline
+///   (Plan 73 Followup B.2) instead of `cmd.sh`.
+///
+/// Hypervisor-agnostic — the staging produces files in a virtio-fs
+/// share; libkrun and Vz both bind-mount the same host dir, so the
+/// helper doesn't need to know which VMM is on the other end.
+/// Migrated from `libkrun_builder.rs` in Plan 97 Phase C PR-B-migrate.
+pub fn stage_job_dir(job_dir: &Path, job: &BuilderJob) -> Result<(), BuilderVmError> {
+    std::fs::create_dir_all(job_dir).map_err(|e| {
+        BuilderVmError::ExtractionFailed(format!("creating job dir {}: {e}", job_dir.display()))
+    })?;
+
+    let (flake_ref, attr_path) = match job {
+        BuilderJob::Flake {
+            flake_ref,
+            attr_path,
+        } => (flake_ref.as_str(), attr_path.as_str()),
+        BuilderJob::Install { spec_path } => {
+            // Copy the caller's spec into the per-job dir so the
+            // virtio-fs share carries it into the guest at
+            // `/job/install_spec.json`. `mvm-builder-init`
+            // (Plan 73 Followup B.2) detects that filename and
+            // dispatches through the install pipeline instead of
+            // running cmd.sh.
+            let dst = job_dir.join(INSTALL_SPEC_FILENAME);
+            std::fs::copy(spec_path, &dst).map_err(|e| {
+                BuilderVmError::ExtractionFailed(format!(
+                    "copying install spec {} -> {}: {e}",
+                    spec_path.display(),
+                    dst.display()
+                ))
+            })?;
+            return Ok(());
+        }
+    };
+
+    let body = render_flake_cmd_sh(flake_ref, attr_path);
+
+    let cmd_path = job_dir.join("cmd.sh");
+    std::fs::write(&cmd_path, body).map_err(|e| {
+        BuilderVmError::ExtractionFailed(format!("writing {}: {e}", cmd_path.display()))
+    })?;
+    Ok(())
+}
+
+/// Render the `cmd.sh` body the in-guest `mvm-builder-init` runs
+/// for a [`BuilderJob::Flake`]. Inlined as a separate function so
+/// tests can assert the rendered output without touching the
+/// filesystem.
+fn render_flake_cmd_sh(flake_ref: &str, attr_path: &str) -> String {
+    format!(
+        r#"#!/bin/sh
+# mvm-builder-vm cmd.sh — emitted by BuilderVmRuntime (Plan 97
+# Phase C migration; was Plan 72 W4's stage_job_dir).
+# Runs inside the builder VM under `/bin/sh -eu`. The host wires
+# /work (workspace), /out (artifact dir), /job (this dir) as
+# virtio-fs shares; /nix is a persistent virtio-blk overlay
+# handled by mvm-builder-init.
+set -eu
+
+FLAKE_REF='{flake_ref}'
+ATTR_PATH='{attr_path}'
+
+# Point HOME at writable tmpfs (`/tmp`) to satisfy code paths that
+# write to `~/...` (the rootfs is mounted `ro`; nix would otherwise
+# bail with "creating directory '//.cache/nix': Read-only file
+# system"). XDG_CACHE_HOME lives on the persistent `/nix-store`
+# disk so Nix's eval-cache-v5, tarball-cache, and binary-cache-v6
+# survive across builds — cold flake eval is the long pole on
+# warm-store rebuilds, and these caches reclaim it. `/nix-store`
+# is the ext4 root for the persistent virtio-blk device; it sits
+# alongside the overlay upperdir (`/nix-store/upper`) at the
+# disk's top level, so writes here don't pollute the Nix store
+# namespace. XDG_STATE_HOME stays on tmpfs: it only holds profile
+# generations, which one-shot build VMs don't use.
+export HOME=/tmp
+export XDG_CACHE_HOME=/nix-store/.cache
+export XDG_STATE_HOME=/tmp/.local/state
+mkdir -p /nix-store/.cache /tmp/.local/state
+
+# CA certs for TLS to cache.nixos.org / api.github.com.
+export CURL_CA_BUNDLE=/etc/ssl/certs/ca-bundle.crt
+export NIX_SSL_CERT_FILE=/etc/ssl/certs/ca-bundle.crt
+export SSL_CERT_FILE=/etc/ssl/certs/ca-bundle.crt
+
+cd /work
+# `experimental-features` enables nix-command + flakes. `sandbox =
+# false` + `build-users-group =` is mandatory inside the builder
+# VM: there are no `nixbld*` accounts in the rootfs and no kernel
+# user-ns isolation for build sandboxes, so every derivation would
+# otherwise fail with "the group 'nixbld' specified in
+# 'build-users-group' does not exist". The builder VM IS the
+# isolation boundary, so an in-guest sandbox is redundant.
+export NIX_CONFIG="experimental-features = nix-command flakes
+sandbox = false
+build-users-group =
+max-jobs = auto
+cores = 0
+auto-optimise-store = true
+substituters = https://cache.nixos.org/
+trusted-public-keys = cache.nixos.org-1:6NCHdD59X431o0gWypbMrAURkbJ16ZPMQFGspcDShjY="
+# Plan 72 W0's flake convention: workspace-path env var so
+# flakes that reference the workspace root don't depend on
+# relative-path resolution against the store-copied flake dir.
+export MVM_WORKSPACE_PATH=/work
+
+echo "mvm-builder-vm: filesystem space before nix build:" >&2
+df -h /nix /tmp >&2 || true
+
+# `--impure` is what unblocks builds inside the VM when the
+# flake has path inputs; `--no-write-lock-file` keeps the
+# read-only `/work` mount from tripping EROFS.
+# `--print-build-logs --keep-going` dumps every failing build's
+# stderr inline (default nix only prints the last 10 lines and
+# cascades up). We tee stderr to /job/nix-build.log so the host
+# can read the actual root cause when a deep dependency fails.
+set +e
+nix build "${{FLAKE_REF}}#${{ATTR_PATH}}" \
+    --no-link --print-out-paths --no-write-lock-file --impure \
+    --print-build-logs --keep-going \
+    > /job/nix-stdout.log 2> /job/nix-stderr.log
+NIX_RC=$?
+set -e
+NIX_OUT=$(cat /job/nix-stdout.log)
+if [ "$NIX_RC" -ne 0 ]; then
+    echo "mvm-builder-vm: filesystem space after failed nix build:" >&2
+    df -h /nix /tmp >&2 || true
+    echo "nix build exited $NIX_RC; tail of stderr:" >&2
+    tail -200 /job/nix-stderr.log >&2
+    exit $NIX_RC
+fi
+
+if [ -z "$NIX_OUT" ]; then
+    echo "nix build emitted no /nix/store output path" >&2
+    exit 1
+fi
+printf '%s\n' "$NIX_OUT" > /job/store-path
+
+# Copy the artifacts the host expects into /out. We accept
+# either `vmlinux` (the canonical name our flakes use) or
+# `Image` / `bzImage` (raw kernel format names) for
+# robustness across flake conventions.
+if   [ -f "$NIX_OUT/vmlinux" ]; then cp -L "$NIX_OUT/vmlinux" /out/vmlinux
+elif [ -f "$NIX_OUT/Image"   ]; then cp -L "$NIX_OUT/Image"   /out/vmlinux
+elif [ -f "$NIX_OUT/bzImage" ]; then cp -L "$NIX_OUT/bzImage" /out/vmlinux
+fi
+if [ -f "$NIX_OUT/rootfs.ext4" ]; then
+    cp -L "$NIX_OUT/rootfs.ext4" /out/rootfs.ext4
+else
+    echo "no rootfs.ext4 in nix build output at $NIX_OUT" >&2
+    exit 1
+fi
+
+# Permissions for the host-side reader. Ignore failures —
+# virtio-fs may map the uid such that chmod is a no-op.
+chmod 0644 /out/rootfs.ext4 2>/dev/null || true
+[ -f /out/vmlinux ] && chmod 0644 /out/vmlinux 2>/dev/null || true
+"#,
+        flake_ref = shell_single_quote_escape(flake_ref),
+        attr_path = shell_single_quote_escape(attr_path),
+    )
+}
+
+/// Escape a string for inclusion inside `'…'` single quotes in
+/// POSIX shell. The only character that can't appear inside single
+/// quotes is `'` itself; we close the quote, emit `\'`, then
+/// reopen. Standard sh-escape pattern.
+///
+/// Public so external callers that build their own per-job shell
+/// scripts (e.g. `LibkrunBuilderVm::run_shell_script`'s validator)
+/// can reuse the same escape rules.
+pub fn shell_single_quote_escape(s: &str) -> String {
+    s.replace('\'', "'\\''")
 }
 
 #[cfg(test)]

--- a/crates/mvm-build/src/lib.rs
+++ b/crates/mvm-build/src/lib.rs
@@ -7,6 +7,10 @@ pub mod backend;
 /// itself wires in W2 PR 2 and the persistent-VM lifecycle in W3.
 pub mod builder_protocol;
 pub mod builder_vm;
+/// Plan 97 §"Phase C seam design" — hypervisor-agnostic builder-VM
+/// orchestration helper that wraps a `VmBackendForBuilder`
+/// implementation (libkrun today, Vz in PR-C).
+pub mod builder_vm_runtime;
 pub mod cache;
 pub mod firecracker;
 /// Plan 76 Phase 6 — portable signed `.mvm` artifacts. A tar.gz

--- a/crates/mvm-build/src/libkrun_builder.rs
+++ b/crates/mvm-build/src/libkrun_builder.rs
@@ -65,7 +65,10 @@ use std::time::{Duration, Instant};
 use mvm_libkrun::{KrunContext, SupervisorConfig};
 use serde::Deserialize;
 
-use crate::builder_vm::{BuilderArtifacts, BuilderJob, BuilderMounts, BuilderVm, BuilderVmError};
+use crate::builder_vm::{
+    BuilderArtifacts, BuilderJob, BuilderMounts, BuilderVm, BuilderVmDisk, BuilderVmError,
+    BuilderVmExitInfo, BuilderVmMount, BuilderVmRunConfig, VmBackendForBuilder,
+};
 
 /// Default vCPU count for the builder VM. Nix builds are
 /// embarrassingly parallel at the derivation level; 4 cores is the
@@ -761,6 +764,173 @@ impl BuilderVm for LibkrunBuilderVm {
         // `~/.cache/mvm/builder-vm/jobs/` past N days. No-op
         // until W6 picks the retention policy.
         Ok(())
+    }
+}
+
+// ─────────────────────────────────────────────────────────────────
+// LibkrunBuilderBackend — Plan 97 Phase C, first refactor slice.
+//
+// This is the hypervisor-agnostic seam's libkrun-flavored impl.
+// Wraps `spawn_supervisor_in_background` + `wait_with_panic_detector_until`
+// + the KrunContext-building pattern from `LibkrunBuilderVm::run_build`.
+// Today nothing in production uses it — `LibkrunBuilderVm::run_build`
+// stays as-is. The follow-up slice introduces a `BuilderVmRuntime`
+// helper that takes `&dyn VmBackendForBuilder` and migrates
+// `run_build` to use it; this struct is what plugs into that helper
+// for the libkrun backend.
+//
+// Lives in the same file as the private helpers it calls
+// (`resolve_supervisor_path`, `ensure_builder_vm_image`,
+// `krun_context_for_image`, `apply_networking_mode`, `path_to_str`,
+// `spawn_supervisor_in_background`, `wait_with_panic_detector_until`,
+// `WaitOutcome`, `DEFAULT_PANIC_POLL_INTERVAL`). Putting it here
+// avoids widening those helpers' visibility for a single new caller.
+// ─────────────────────────────────────────────────────────────────
+
+/// Plan 97 §"Phase C seam design" — libkrun-flavored impl of the
+/// hypervisor-agnostic [`VmBackendForBuilder`] primitive trait.
+///
+/// Holds the resolved supervisor binary path and the cached
+/// builder VM image (kernel + rootfs + cmdline). Construction
+/// eagerly resolves both so a missing prerequisite surfaces at
+/// `new()`-time rather than mid-build.
+///
+/// `LibkrunBuilderVm::run_build` does not yet use this — the
+/// follow-up slice (PR-B-2) introduces `BuilderVmRuntime` and
+/// flips the migration. Today it exists so PR-C (`VzBuilderVm`)
+/// has a worked example of how to wrap a hypervisor-specific
+/// supervisor behind the seam.
+pub struct LibkrunBuilderBackend {
+    supervisor_path: PathBuf,
+    image: BuilderVmImage,
+}
+
+impl LibkrunBuilderBackend {
+    /// Resolve the supervisor binary + builder VM image eagerly.
+    /// Surfaces "supervisor binary missing" / "builder image not
+    /// installed" at the call site rather than at first run.
+    pub fn new() -> Result<Self, BuilderVmError> {
+        let supervisor_path = resolve_supervisor_path()?;
+        let image = ensure_builder_vm_image()?;
+        Ok(Self {
+            supervisor_path,
+            image,
+        })
+    }
+
+    /// Test seam — caller supplies the supervisor path + image
+    /// directly so unit tests can construct a backend without
+    /// touching the host's libkrun install or the image cache.
+    /// Used by the construction test below; the future
+    /// `BuilderVmRuntime` test suite will reuse this pattern.
+    pub fn with_supervisor_and_image(supervisor_path: PathBuf, image: BuilderVmImage) -> Self {
+        Self {
+            supervisor_path,
+            image,
+        }
+    }
+}
+
+impl VmBackendForBuilder for LibkrunBuilderBackend {
+    fn run_attached_with_mounts(
+        &self,
+        config: &BuilderVmRunConfig,
+        mounts: &[BuilderVmMount],
+        extra_disks: &[BuilderVmDisk],
+        timeout: Duration,
+    ) -> Result<BuilderVmExitInfo, BuilderVmError> {
+        // Same refusal posture as run_build's step 2: a missing
+        // shared library is the most-common failure mode and an
+        // early surface keeps the supervisor spawn from producing
+        // a confusing rc -2.
+        if !mvm_libkrun::is_available() {
+            return Err(BuilderVmError::LibkrunUnavailable(format!(
+                "libkrun shared library not found on host. {}",
+                mvm_libkrun::install_hint()
+            )));
+        }
+
+        std::fs::create_dir_all(&config.vm_state_dir).map_err(|e| {
+            BuilderVmError::ExtractionFailed(format!(
+                "creating builder VM state dir {}: {e}",
+                config.vm_state_dir.display()
+            ))
+        })?;
+
+        let console_log = self.console_log_path(&config.vm_state_dir);
+
+        // KrunContext construction — same shape as run_build's
+        // step 7, but parameterised on the trait's hypervisor-
+        // agnostic config. Builds top-down (resources first, then
+        // disks, then mounts, then vsock ports, then networking)
+        // because libkrun's builder methods consume `self` by value.
+        let mut krun = krun_context_for_image(&config.name, &self.image)?
+            .with_resources(config.vcpus, config.memory_mib)
+            .with_console_output(path_to_str(&console_log, "console_log")?)
+            .with_vsock_socket_dir(path_to_str(&config.vm_state_dir, "vm_state_dir")?);
+        for disk in extra_disks {
+            krun = krun.add_disk(
+                disk.id.clone(),
+                path_to_str(&disk.host_path, "extra_disk_path")?,
+                disk.read_only,
+            );
+        }
+        for mount in mounts {
+            // libkrun's add_virtio_fs takes only (tag, host_path) —
+            // every share is RW from the guest's perspective. The
+            // `BuilderVmMount::read_only` flag is currently ignored
+            // on this backend; Vz's impl will honour it via
+            // VZSharedDirectory's `readOnly:` parameter (Plan 97
+            // §"Host-path mounts").
+            krun = krun.add_virtio_fs(
+                mount.tag.clone(),
+                path_to_str(&mount.host_path, "mount_host_path")?,
+            );
+        }
+        for port in &config.vsock_ports {
+            krun = krun.add_vsock_port(*port);
+        }
+        krun = apply_networking_mode(krun, &config.vm_state_dir)?;
+
+        let cfg = SupervisorConfig {
+            krun,
+            vm_state_dir: path_to_str(&config.vm_state_dir, "vm_state_dir")?.to_string(),
+            pid_file_name: Some("builder.pid".to_string()),
+        };
+
+        let mut child = spawn_supervisor_in_background(&self.supervisor_path, &cfg)?;
+        // Same wait + panic-detection shape `spawn_supervisor_and_wait`
+        // uses, but we surface the panic line via the seam's exit
+        // info instead of an Err so the future BuilderVmRuntime
+        // helper can decide whether the job's expectations were
+        // met (Plan 77 W6 §"Concurrent panic detector").
+        match wait_with_panic_detector_until(
+            &mut child,
+            Some(&console_log),
+            DEFAULT_PANIC_POLL_INTERVAL,
+            Some(timeout),
+        ) {
+            Ok(WaitOutcome::Clean(code)) => Ok(BuilderVmExitInfo {
+                exit_code: Some(code),
+                panic_line: None,
+            }),
+            Ok(WaitOutcome::KernelPanic { panic_line, .. }) => Ok(BuilderVmExitInfo {
+                exit_code: None,
+                panic_line: Some(panic_line),
+            }),
+            Ok(WaitOutcome::Timeout) => Err(BuilderVmError::NixBuildFailed(format!(
+                "builder VM exceeded {} seconds wall-clock; killed. Console log at {}.",
+                timeout.as_secs(),
+                console_log.display(),
+            ))),
+            Err(e) => Err(BuilderVmError::ExtractionFailed(format!(
+                "wait on supervisor child: {e}"
+            ))),
+        }
+    }
+
+    fn console_log_path(&self, vm_state_dir: &Path) -> PathBuf {
+        vm_state_dir.join("console.log")
     }
 }
 
@@ -3340,4 +3510,49 @@ mod tests {
     // invariant grep against `crates/` source. The grep excludes
     // `**/tests/**` by design — that's where mock-server patterns
     // for test scaffolding belong.
+
+    // ---------------------------------------------------------------
+    // Plan 97 §"Phase C seam design" — LibkrunBuilderBackend impl
+    //
+    // Construction-shape tests only. Exercising `run_attached_with_mounts`
+    // requires libkrun + the builder image + an actual supervisor
+    // child, which is the integration-test surface; unit-level
+    // assertions cover the trait wiring + the `console_log_path`
+    // contract.
+    // ---------------------------------------------------------------
+
+    #[test]
+    fn libkrun_builder_backend_with_supervisor_and_image_stores_paths() {
+        let supervisor = PathBuf::from("/tmp/mvm-test-supervisor");
+        let image = BuilderVmImage::Rootfs {
+            kernel_path: PathBuf::from("/tmp/vmlinux"),
+            rootfs_path: PathBuf::from("/tmp/rootfs.ext4"),
+            cmdline: "console=hvc0".to_string(),
+        };
+        let backend = LibkrunBuilderBackend::with_supervisor_and_image(supervisor.clone(), image);
+        assert_eq!(backend.supervisor_path, supervisor);
+        match &backend.image {
+            BuilderVmImage::Rootfs { kernel_path, .. } => {
+                assert_eq!(kernel_path, &PathBuf::from("/tmp/vmlinux"));
+            }
+            other => panic!("expected Rootfs variant, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn libkrun_builder_backend_console_log_lives_under_vm_state_dir() {
+        let backend = LibkrunBuilderBackend::with_supervisor_and_image(
+            PathBuf::from("/tmp/supervisor"),
+            BuilderVmImage::Rootfs {
+                kernel_path: PathBuf::from("/tmp/k"),
+                rootfs_path: PathBuf::from("/tmp/r"),
+                cmdline: String::new(),
+            },
+        );
+        let dir = PathBuf::from("/tmp/state/builder-foo");
+        let log = backend.console_log_path(&dir);
+        assert_eq!(log, dir.join("console.log"));
+        // Trait-object safety: confirm the impl satisfies `&dyn ...`.
+        let _erased: &dyn VmBackendForBuilder = &backend;
+    }
 }

--- a/crates/mvm-build/src/libkrun_builder.rs
+++ b/crates/mvm-build/src/libkrun_builder.rs
@@ -69,6 +69,13 @@ use crate::builder_vm::{
     BuilderArtifacts, BuilderJob, BuilderMounts, BuilderVm, BuilderVmDisk, BuilderVmError,
     BuilderVmExitInfo, BuilderVmMount, BuilderVmRunConfig, VmBackendForBuilder,
 };
+// Plan 97 Phase C (PR-B-migrate commit 2) — these items previously
+// lived in this file; they migrated to `builder_vm_runtime` so the
+// future VzBuilderVm path can reuse the same staging logic without
+// duplicating ~150 lines. `INSTALL_SPEC_FILENAME` and
+// `shell_single_quote_escape` are imported only inside the test
+// module below; the production path here only needs `stage_job_dir`.
+use crate::builder_vm_runtime::stage_job_dir;
 
 /// Default vCPU count for the builder VM. Nix builds are
 /// embarrassingly parallel at the derivation level; 4 cores is the
@@ -1196,179 +1203,19 @@ fn unique_job_id() -> String {
     format!("{now:013}-{pid}")
 }
 
-/// Filename of the install-spec JSON the host stages for
-/// install jobs. Matches the constant `mvm-builder-init` checks
-/// for inside the VM — keep these in sync.
-pub(crate) const INSTALL_SPEC_FILENAME: &str = "install_spec.json";
+// `INSTALL_SPEC_FILENAME` moved to `crate::builder_vm_runtime` in
+// Plan 97 Phase C PR-B-migrate; the `use` at the top of this file
+// pulls it back in for the existing callers.
 
 /// Filename of the install report `mvm-builder-init` writes into
 /// `artifact_out/` after the install pipeline finishes. The host
 /// reads + parses this to decide whether the install succeeded.
 pub(crate) const INSTALL_RESULT_FILENAME: &str = "result.json";
 
-/// Stage the per-job dir for the given [`BuilderJob`].
-///
-/// - [`BuilderJob::Flake`]: writes `<job_dir>/cmd.sh` with the
-///   `nix build` script the guest's PID 1 dispatches via
-///   `/bin/sh -eu`.
-/// - [`BuilderJob::Install`]: copies the caller's install spec
-///   to `<job_dir>/install_spec.json`. `mvm-builder-init` probes
-///   for this filename first; when present it routes through the
-///   app-deps install pipeline (Plan 73 Followup B.2) instead of
-///   running `cmd.sh`.
-///
-/// The two modes are mutually exclusive — install jobs don't
-/// emit a `cmd.sh`, flake jobs don't emit an install spec.
-fn stage_job_dir(job_dir: &Path, job: &BuilderJob) -> Result<(), BuilderVmError> {
-    std::fs::create_dir_all(job_dir).map_err(|e| {
-        BuilderVmError::ExtractionFailed(format!("creating job dir {}: {e}", job_dir.display()))
-    })?;
-
-    let (flake_ref, attr_path) = match job {
-        BuilderJob::Flake {
-            flake_ref,
-            attr_path,
-        } => (flake_ref.as_str(), attr_path.as_str()),
-        BuilderJob::Install { spec_path } => {
-            // Copy the caller's spec into the per-job dir so the
-            // virtio-fs share carries it into the guest at
-            // `/job/install_spec.json`. `mvm-builder-init`
-            // (Plan 73 Followup B.2) detects that filename and
-            // dispatches through the install pipeline instead of
-            // running cmd.sh.
-            let dst = job_dir.join(INSTALL_SPEC_FILENAME);
-            std::fs::copy(spec_path, &dst).map_err(|e| {
-                BuilderVmError::ExtractionFailed(format!(
-                    "copying install spec {} -> {}: {e}",
-                    spec_path.display(),
-                    dst.display()
-                ))
-            })?;
-            return Ok(());
-        }
-    };
-
-    // Render the `cmd.sh` content. flake_ref and attr_path are
-    // user-controlled; emit them inside `'…'` quoted shell
-    // variables, escaping any embedded `'` with the standard
-    // `'\''` close-quote / escape / open-quote dance.
-    let body = format!(
-        r#"#!/bin/sh
-# mvm-builder-vm cmd.sh — emitted by LibkrunBuilderVm (Plan 72 W4).
-# Runs inside the libkrun builder VM under `/bin/sh -eu`. The
-# host wires /work (workspace), /out (artifact dir), /job (this
-# dir) as virtio-fs shares; /nix is a persistent virtio-blk
-# overlay handled by mvm-builder-init.
-set -eu
-
-FLAKE_REF='{flake_ref}'
-ATTR_PATH='{attr_path}'
-
-# Point HOME at writable tmpfs (`/tmp`) to satisfy code paths that
-# write to `~/...` (the rootfs is mounted `ro`; nix would otherwise
-# bail with "creating directory '//.cache/nix': Read-only file
-# system"). XDG_CACHE_HOME lives on the persistent `/nix-store`
-# disk so Nix's eval-cache-v5, tarball-cache, and binary-cache-v6
-# survive across builds — cold flake eval is the long pole on
-# warm-store rebuilds, and these caches reclaim it. `/nix-store`
-# is the ext4 root for the persistent virtio-blk device; it sits
-# alongside the overlay upperdir (`/nix-store/upper`) at the
-# disk's top level, so writes here don't pollute the Nix store
-# namespace. XDG_STATE_HOME stays on tmpfs: it only holds profile
-# generations, which one-shot build VMs don't use.
-export HOME=/tmp
-export XDG_CACHE_HOME=/nix-store/.cache
-export XDG_STATE_HOME=/tmp/.local/state
-mkdir -p /nix-store/.cache /tmp/.local/state
-
-# CA certs for TLS to cache.nixos.org / api.github.com.
-export CURL_CA_BUNDLE=/etc/ssl/certs/ca-bundle.crt
-export NIX_SSL_CERT_FILE=/etc/ssl/certs/ca-bundle.crt
-export SSL_CERT_FILE=/etc/ssl/certs/ca-bundle.crt
-
-cd /work
-# `experimental-features` enables nix-command + flakes. `sandbox =
-# false` + `build-users-group =` is mandatory inside the builder
-# VM: there are no `nixbld*` accounts in the rootfs and no kernel
-# user-ns isolation for build sandboxes, so every derivation would
-# otherwise fail with "the group 'nixbld' specified in
-# 'build-users-group' does not exist". The builder VM IS the
-# isolation boundary, so an in-guest sandbox is redundant.
-export NIX_CONFIG="experimental-features = nix-command flakes
-sandbox = false
-build-users-group =
-max-jobs = auto
-cores = 0
-auto-optimise-store = true
-substituters = https://cache.nixos.org/
-trusted-public-keys = cache.nixos.org-1:6NCHdD59X431o0gWypbMrAURkbJ16ZPMQFGspcDShjY="
-# Plan 72 W0's flake convention: workspace-path env var so
-# flakes that reference the workspace root don't depend on
-# relative-path resolution against the store-copied flake dir.
-export MVM_WORKSPACE_PATH=/work
-
-echo "mvm-builder-vm: filesystem space before nix build:" >&2
-df -h /nix /tmp >&2 || true
-
-# `--impure` is what unblocks builds inside the VM when the
-# flake has path inputs; `--no-write-lock-file` keeps the
-# read-only `/work` mount from tripping EROFS.
-# `--print-build-logs --keep-going` dumps every failing build's
-# stderr inline (default nix only prints the last 10 lines and
-# cascades up). We tee stderr to /job/nix-build.log so the host
-# can read the actual root cause when a deep dependency fails.
-set +e
-nix build "${{FLAKE_REF}}#${{ATTR_PATH}}" \
-    --no-link --print-out-paths --no-write-lock-file --impure \
-    --print-build-logs --keep-going \
-    > /job/nix-stdout.log 2> /job/nix-stderr.log
-NIX_RC=$?
-set -e
-NIX_OUT=$(cat /job/nix-stdout.log)
-if [ "$NIX_RC" -ne 0 ]; then
-    echo "mvm-builder-vm: filesystem space after failed nix build:" >&2
-    df -h /nix /tmp >&2 || true
-    echo "nix build exited $NIX_RC; tail of stderr:" >&2
-    tail -200 /job/nix-stderr.log >&2
-    exit $NIX_RC
-fi
-
-if [ -z "$NIX_OUT" ]; then
-    echo "nix build emitted no /nix/store output path" >&2
-    exit 1
-fi
-printf '%s\n' "$NIX_OUT" > /job/store-path
-
-# Copy the artifacts the host expects into /out. We accept
-# either `vmlinux` (the canonical name our flakes use) or
-# `Image` / `bzImage` (raw kernel format names) for
-# robustness across flake conventions.
-if   [ -f "$NIX_OUT/vmlinux" ]; then cp -L "$NIX_OUT/vmlinux" /out/vmlinux
-elif [ -f "$NIX_OUT/Image"   ]; then cp -L "$NIX_OUT/Image"   /out/vmlinux
-elif [ -f "$NIX_OUT/bzImage" ]; then cp -L "$NIX_OUT/bzImage" /out/vmlinux
-fi
-if [ -f "$NIX_OUT/rootfs.ext4" ]; then
-    cp -L "$NIX_OUT/rootfs.ext4" /out/rootfs.ext4
-else
-    echo "no rootfs.ext4 in nix build output at $NIX_OUT" >&2
-    exit 1
-fi
-
-# Permissions for the host-side reader. Ignore failures —
-# virtio-fs may map the uid such that chmod is a no-op.
-chmod 0644 /out/rootfs.ext4 2>/dev/null || true
-[ -f /out/vmlinux ] && chmod 0644 /out/vmlinux 2>/dev/null || true
-"#,
-        flake_ref = shell_single_quote_escape(flake_ref),
-        attr_path = shell_single_quote_escape(attr_path),
-    );
-
-    let cmd_path = job_dir.join("cmd.sh");
-    std::fs::write(&cmd_path, body).map_err(|e| {
-        BuilderVmError::ExtractionFailed(format!("writing {}: {e}", cmd_path.display()))
-    })?;
-    Ok(())
-}
+// `stage_job_dir` migrated to `crate::builder_vm_runtime` in Plan 97
+// Phase C PR-B-migrate commit 2. Both libkrun (here) and the
+// future VzBuilderVm path call the same helper, which produces the
+// virtio-fs-share-friendly cmd.sh / install_spec.json.
 
 fn stage_shell_job_dir(job_dir: &Path, script: &str) -> Result<(), BuilderVmError> {
     std::fs::create_dir_all(job_dir).map_err(|e| {
@@ -1381,13 +1228,9 @@ fn stage_shell_job_dir(job_dir: &Path, script: &str) -> Result<(), BuilderVmErro
     Ok(())
 }
 
-/// Escape a string for inclusion inside `'…'` single quotes
-/// in POSIX shell. The only character that can't appear inside
-/// single quotes is `'` itself; we close the quote, emit `\'`,
-/// then reopen. Standard sh-escape pattern.
-fn shell_single_quote_escape(s: &str) -> String {
-    s.replace('\'', "'\\''")
-}
+// `shell_single_quote_escape` migrated to
+// `crate::builder_vm_runtime` in Plan 97 Phase C PR-B-migrate
+// commit 2.
 
 /// Read the last `max_bytes` of `path` into a `String`, replacing any
 /// invalid UTF-8 lossily. Returns `Err` if the file is missing or
@@ -2386,6 +2229,7 @@ impl PersistentVmHandle {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::builder_vm_runtime::{INSTALL_SPEC_FILENAME, shell_single_quote_escape};
     use std::sync::{LazyLock, Mutex};
     use tempfile::TempDir;
 


### PR DESCRIPTION
## Summary

Stacked on #430. Lands the **trait surface + libkrun-flavored impl** of the hypervisor-agnostic builder-VM seam from Plan 97 §"Phase C seam design". Foundation for the follow-up `BuilderVmRuntime` helper + the eventual `VzBuilderVm`.

**Purely additive — no production code paths change.** `LibkrunBuilderVm.run_build()` is untouched; the new impl is exercised only by `#[cfg(test)]` construction-shape tests.

### What lands

**`VmBackendForBuilder` trait** in `mvm-build/src/builder_vm.rs`:

```rust
pub trait VmBackendForBuilder: Send + Sync {
    fn run_attached_with_mounts(
        &self,
        config: &BuilderVmRunConfig,
        mounts: &[BuilderVmMount],   // virtio-fs (/work, /out, /job)
        extra_disks: &[BuilderVmDisk], // virtio-blk (nix store image)
        timeout: Duration,
    ) -> Result<BuilderVmExitInfo, BuilderVmError>;

    fn console_log_path(&self, vm_state_dir: &Path) -> PathBuf;
}
```

Plus the supporting types: `BuilderVmRunConfig`, `BuilderVmMount`, `BuilderVmDisk`, `BuilderVmExitInfo`. Mock backend + 5 tests covering invocation recording, console-log path shape, panic-line plumbing, error propagation, and dyn-trait object-safety.

**`LibkrunBuilderBackend` impl** in `mvm-build/src/libkrun_builder.rs` (gated on the `builder-vm` feature, like the rest of that file). Wraps the existing private helpers in the same file (`resolve_supervisor_path`, `ensure_builder_vm_image`, `krun_context_for_image`, `apply_networking_mode`, `spawn_supervisor_in_background`, `wait_with_panic_detector_until`). Two construction-shape tests cover the impl's path resolution + dyn-trait object-safety.

### Design choices worth highlighting

- **`BuilderVmExitInfo` surfaces panic lines as a field, not an Err.** The host-side console-log watcher's catch (Plan 77 W6) becomes data the future helper can interpret against job expectations, not an unconditional failure. Timeouts still map to `Err(NixBuildFailed)` because they're recoverable only at the orchestrator level.
- **`BuilderVmMount.read_only` is honored on Vz, ignored on libkrun.** libkrun's `add_virtio_fs` is RW-only; Vz's `VZSharedDirectory` has a `readOnly:` flag. The trait carries the field so the seam doesn't lose Vz's capability.
- **Backend is constructed eagerly** (resolves supervisor path + builder image at `new()`-time) so prerequisite-missing errors surface at the call site rather than mid-build.
- **Lives in the same file as the private helpers it calls** — avoids widening private visibility for one new consumer.

### What's next (separate PRs)

- **PR-B-migrate**: introduce `BuilderVmRuntime` helper that takes `&dyn VmBackendForBuilder` + lift the shared orchestration out of `LibkrunBuilderVm.run_build` (cmd.sh emission, `/job/result` parsing, `NixStoreImageLock`, panic-detector loop, stderr-tail). Risky — touches the working libkrun builder path.
- **PR-C**: ship `VzBuilderVm` using the helper. Reuses the lifted orchestration with only a Vz-side mount glue. Wires `MVM_BUILDER_BACKEND=vz` dispatch + Stage 0 audit emit + cache-prune contract.

Both subsequent PRs target the trait surface defined here without modification.

## Test plan

- [x] `cargo test -p mvm-build --lib vm_backend_for_builder` — 5/5 pass (trait + types).
- [x] `cargo test -p mvm-build --features builder-vm --lib libkrun_builder_backend` — 2/2 pass (impl).
- [x] `cargo test -p mvm-build --features builder-vm --lib` — 305/305 pass (full mvm-build suite, no regressions).
- [x] `cargo clippy --workspace --all-targets -- -D warnings` — clean.
- [x] `cargo clippy -p mvm-build --features builder-vm --all-targets -- -D warnings` — clean.
- [x] `cargo fmt --all -- --check` — clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)