### PR TITLE
Plan 97 Phase C PR-B-migrate: BuilderVmRuntime helper + first migration (stage_job_dir)

### DIFF
--- a/crates/mvm-build/src/builder_vm_runtime.rs
+++ b/crates/mvm-build/src/builder_vm_runtime.rs
@@ -1,0 +1,143 @@
+//! Plan 97 §"Phase C seam design" — hypervisor-agnostic builder-VM
+//! orchestration helper.
+//!
+//! [`BuilderVmRuntime`] is the shared orchestration body that both
+//! the libkrun and Vz builder paths route through. It owns the
+//! pieces that aren't tied to a specific VMM:
+//!
+//! - `cmd.sh` emission (Flake jobs) and `install_spec.json` staging
+//!   (Install jobs)
+//! - `/job/result` JSON parsing
+//! - Per-variant artifact finalisation (rootfs path resolution,
+//!   revision hash extraction, install-volume sidecar discovery)
+//! - Nix store image lock acquisition (libkrun-only concern in
+//!   today's runtime; abstracted here for future Vz reuse)
+//! - stderr-tail capture for build-failure diagnostics
+//! - Wall-clock timeout handling
+//!
+//! It does **not** own:
+//!
+//! - Supervisor process lifecycle (lives in the
+//!   [`VmBackendForBuilder`] impl — libkrun's
+//!   `spawn_supervisor_in_background` / Vz's `run_attached`)
+//! - Console-log watching for kernel-panic detection (also lives
+//!   in the impl; surfaces through `BuilderVmExitInfo.panic_line`)
+//! - Hypervisor-specific config translation (KrunContext vs.
+//!   Vz's `SupervisorConfig`)
+//!
+//! Today the helper is a skeleton. Subsequent commits migrate the
+//! concerns above out of `LibkrunBuilderVm.run_build` into here,
+//! one at a time. Each migration commit is independently
+//! verifiable: build + existing tests stay green, and the new
+//! helper methods get their own unit tests.
+
+use crate::builder_vm::VmBackendForBuilder;
+
+/// Hypervisor-agnostic orchestration helper. Holds a reference to
+/// a [`VmBackendForBuilder`] so the actual supervisor spawn /
+/// console-log path / per-VM state directory are routed through
+/// the appropriate VMM without the helper knowing which one.
+///
+/// Lifetime-bound — the helper doesn't own the backend; callers
+/// keep a long-lived backend instance (e.g. `LibkrunBuilderBackend`
+/// constructed once at `LibkrunBuilderVm::run_build` entry) and
+/// hand a borrow to the helper for the duration of one run.
+pub struct BuilderVmRuntime<'a> {
+    backend: &'a dyn VmBackendForBuilder,
+}
+
+impl<'a> BuilderVmRuntime<'a> {
+    /// Construct over an existing backend reference.
+    pub fn new(backend: &'a dyn VmBackendForBuilder) -> Self {
+        Self { backend }
+    }
+
+    /// Borrow the underlying backend. Subsequent migration commits
+    /// expose more targeted methods; this exists today so the
+    /// helper has a way to thread the backend through its yet-to-be-
+    /// migrated methods without re-routing every call site through
+    /// a builder.
+    pub fn backend(&self) -> &dyn VmBackendForBuilder {
+        self.backend
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::builder_vm::{BuilderVmDisk, BuilderVmExitInfo, BuilderVmMount, BuilderVmRunConfig};
+    use std::path::{Path, PathBuf};
+    use std::time::Duration;
+
+    /// Minimal backend that records every call. Same shape as the
+    /// mock in `builder_vm::vm_backend_for_builder_tests`, but
+    /// re-defined here because that mock lives inside `#[cfg(test)]`
+    /// in the sibling module and isn't visible across the module
+    /// boundary. As the helper grows, this fixture grows with it.
+    #[derive(Default)]
+    struct CountingBackend {
+        run_calls: std::sync::atomic::AtomicUsize,
+        console_calls: std::sync::atomic::AtomicUsize,
+    }
+
+    impl VmBackendForBuilder for CountingBackend {
+        fn run_attached_with_mounts(
+            &self,
+            _config: &BuilderVmRunConfig,
+            _mounts: &[BuilderVmMount],
+            _extra_disks: &[BuilderVmDisk],
+            _timeout: Duration,
+        ) -> Result<BuilderVmExitInfo, crate::builder_vm::BuilderVmError> {
+            self.run_calls
+                .fetch_add(1, std::sync::atomic::Ordering::SeqCst);
+            Ok(BuilderVmExitInfo {
+                exit_code: Some(0),
+                panic_line: None,
+            })
+        }
+
+        fn console_log_path(&self, vm_state_dir: &Path) -> PathBuf {
+            self.console_calls
+                .fetch_add(1, std::sync::atomic::Ordering::SeqCst);
+            vm_state_dir.join("console.log")
+        }
+    }
+
+    #[test]
+    fn runtime_borrows_backend_for_lifetime_of_run() {
+        let backend = CountingBackend::default();
+        let runtime = BuilderVmRuntime::new(&backend);
+        // Backend accessor returns the same trait object we passed
+        // in; future helper methods will use it to dispatch.
+        let log = runtime
+            .backend()
+            .console_log_path(Path::new("/tmp/state/foo"));
+        assert_eq!(log, PathBuf::from("/tmp/state/foo/console.log"));
+        assert_eq!(
+            backend
+                .console_calls
+                .load(std::sync::atomic::Ordering::SeqCst),
+            1
+        );
+    }
+
+    #[test]
+    fn runtime_is_zero_cost_to_construct() {
+        // Construction is a single pointer + vtable; no fs / VM /
+        // network ops fire. This test pins that contract — a
+        // subsequent commit that adds expensive setup to
+        // `BuilderVmRuntime::new` would break it.
+        let backend = CountingBackend::default();
+        let _runtime = BuilderVmRuntime::new(&backend);
+        assert_eq!(
+            backend.run_calls.load(std::sync::atomic::Ordering::SeqCst),
+            0
+        );
+        assert_eq!(
+            backend
+                .console_calls
+                .load(std::sync::atomic::Ordering::SeqCst),
+            0
+        );
+    }
+}

--- a/crates/mvm-build/src/builder_vm_runtime.rs
+++ b/crates/mvm-build/src/builder_vm_runtime.rs
@@ -31,7 +31,16 @@
 //! verifiable: build + existing tests stay green, and the new
 //! helper methods get their own unit tests.
 
-use crate::builder_vm::VmBackendForBuilder;
+use std::path::Path;
+
+use crate::builder_vm::{BuilderJob, BuilderVmError, VmBackendForBuilder};
+
+/// Per-job dir filename mvm-builder-init detects to dispatch
+/// through the application-dependency install pipeline (Plan 73
+/// Followup B.2). Migrated from `libkrun_builder.rs` because the
+/// install spec staging is a hypervisor-agnostic concern that
+/// both the libkrun and Vz builder paths need.
+pub const INSTALL_SPEC_FILENAME: &str = "install_spec.json";
 
 /// Hypervisor-agnostic orchestration helper. Holds a reference to
 /// a [`VmBackendForBuilder`] so the actual supervisor spawn /
@@ -60,6 +69,190 @@ impl<'a> BuilderVmRuntime<'a> {
     pub fn backend(&self) -> &dyn VmBackendForBuilder {
         self.backend
     }
+}
+
+/// Stage the per-job dir inside `~/.cache/mvm/builder-vm/jobs/<id>/`
+/// so the in-guest `mvm-builder-init` finds the right artifact
+/// for dispatch:
+///
+/// - [`BuilderJob::Flake`] → writes `cmd.sh` (the in-guest nix-build
+///   script). mvm-builder-init runs it after `/work` `/out` `/job`
+///   virtio-fs shares are mounted.
+/// - [`BuilderJob::Install`] → copies the caller's install-spec JSON
+///   to `<job_dir>/install_spec.json`. mvm-builder-init detects the
+///   filename and dispatches the application-dep install pipeline
+///   (Plan 73 Followup B.2) instead of `cmd.sh`.
+///
+/// Hypervisor-agnostic — the staging produces files in a virtio-fs
+/// share; libkrun and Vz both bind-mount the same host dir, so the
+/// helper doesn't need to know which VMM is on the other end.
+/// Migrated from `libkrun_builder.rs` in Plan 97 Phase C PR-B-migrate.
+pub fn stage_job_dir(job_dir: &Path, job: &BuilderJob) -> Result<(), BuilderVmError> {
+    std::fs::create_dir_all(job_dir).map_err(|e| {
+        BuilderVmError::ExtractionFailed(format!("creating job dir {}: {e}", job_dir.display()))
+    })?;
+
+    let (flake_ref, attr_path) = match job {
+        BuilderJob::Flake {
+            flake_ref,
+            attr_path,
+        } => (flake_ref.as_str(), attr_path.as_str()),
+        BuilderJob::Install { spec_path } => {
+            // Copy the caller's spec into the per-job dir so the
+            // virtio-fs share carries it into the guest at
+            // `/job/install_spec.json`. `mvm-builder-init`
+            // (Plan 73 Followup B.2) detects that filename and
+            // dispatches through the install pipeline instead of
+            // running cmd.sh.
+            let dst = job_dir.join(INSTALL_SPEC_FILENAME);
+            std::fs::copy(spec_path, &dst).map_err(|e| {
+                BuilderVmError::ExtractionFailed(format!(
+                    "copying install spec {} -> {}: {e}",
+                    spec_path.display(),
+                    dst.display()
+                ))
+            })?;
+            return Ok(());
+        }
+    };
+
+    let body = render_flake_cmd_sh(flake_ref, attr_path);
+
+    let cmd_path = job_dir.join("cmd.sh");
+    std::fs::write(&cmd_path, body).map_err(|e| {
+        BuilderVmError::ExtractionFailed(format!("writing {}: {e}", cmd_path.display()))
+    })?;
+    Ok(())
+}
+
+/// Render the `cmd.sh` body the in-guest `mvm-builder-init` runs
+/// for a [`BuilderJob::Flake`]. Inlined as a separate function so
+/// tests can assert the rendered output without touching the
+/// filesystem.
+fn render_flake_cmd_sh(flake_ref: &str, attr_path: &str) -> String {
+    format!(
+        r#"#!/bin/sh
+# mvm-builder-vm cmd.sh — emitted by BuilderVmRuntime (Plan 97
+# Phase C migration; was Plan 72 W4's stage_job_dir).
+# Runs inside the builder VM under `/bin/sh -eu`. The host wires
+# /work (workspace), /out (artifact dir), /job (this dir) as
+# virtio-fs shares; /nix is a persistent virtio-blk overlay
+# handled by mvm-builder-init.
+set -eu
+
+FLAKE_REF='{flake_ref}'
+ATTR_PATH='{attr_path}'
+
+# Point HOME at writable tmpfs (`/tmp`) to satisfy code paths that
+# write to `~/...` (the rootfs is mounted `ro`; nix would otherwise
+# bail with "creating directory '//.cache/nix': Read-only file
+# system"). XDG_CACHE_HOME lives on the persistent `/nix-store`
+# disk so Nix's eval-cache-v5, tarball-cache, and binary-cache-v6
+# survive across builds — cold flake eval is the long pole on
+# warm-store rebuilds, and these caches reclaim it. `/nix-store`
+# is the ext4 root for the persistent virtio-blk device; it sits
+# alongside the overlay upperdir (`/nix-store/upper`) at the
+# disk's top level, so writes here don't pollute the Nix store
+# namespace. XDG_STATE_HOME stays on tmpfs: it only holds profile
+# generations, which one-shot build VMs don't use.
+export HOME=/tmp
+export XDG_CACHE_HOME=/nix-store/.cache
+export XDG_STATE_HOME=/tmp/.local/state
+mkdir -p /nix-store/.cache /tmp/.local/state
+
+# CA certs for TLS to cache.nixos.org / api.github.com.
+export CURL_CA_BUNDLE=/etc/ssl/certs/ca-bundle.crt
+export NIX_SSL_CERT_FILE=/etc/ssl/certs/ca-bundle.crt
+export SSL_CERT_FILE=/etc/ssl/certs/ca-bundle.crt
+
+cd /work
+# `experimental-features` enables nix-command + flakes. `sandbox =
+# false` + `build-users-group =` is mandatory inside the builder
+# VM: there are no `nixbld*` accounts in the rootfs and no kernel
+# user-ns isolation for build sandboxes, so every derivation would
+# otherwise fail with "the group 'nixbld' specified in
+# 'build-users-group' does not exist". The builder VM IS the
+# isolation boundary, so an in-guest sandbox is redundant.
+export NIX_CONFIG="experimental-features = nix-command flakes
+sandbox = false
+build-users-group =
+max-jobs = auto
+cores = 0
+auto-optimise-store = true
+substituters = https://cache.nixos.org/
+trusted-public-keys = cache.nixos.org-1:6NCHdD59X431o0gWypbMrAURkbJ16ZPMQFGspcDShjY="
+# Plan 72 W0's flake convention: workspace-path env var so
+# flakes that reference the workspace root don't depend on
+# relative-path resolution against the store-copied flake dir.
+export MVM_WORKSPACE_PATH=/work
+
+echo "mvm-builder-vm: filesystem space before nix build:" >&2
+df -h /nix /tmp >&2 || true
+
+# `--impure` is what unblocks builds inside the VM when the
+# flake has path inputs; `--no-write-lock-file` keeps the
+# read-only `/work` mount from tripping EROFS.
+# `--print-build-logs --keep-going` dumps every failing build's
+# stderr inline (default nix only prints the last 10 lines and
+# cascades up). We tee stderr to /job/nix-build.log so the host
+# can read the actual root cause when a deep dependency fails.
+set +e
+nix build "${{FLAKE_REF}}#${{ATTR_PATH}}" \
+    --no-link --print-out-paths --no-write-lock-file --impure \
+    --print-build-logs --keep-going \
+    > /job/nix-stdout.log 2> /job/nix-stderr.log
+NIX_RC=$?
+set -e
+NIX_OUT=$(cat /job/nix-stdout.log)
+if [ "$NIX_RC" -ne 0 ]; then
+    echo "mvm-builder-vm: filesystem space after failed nix build:" >&2
+    df -h /nix /tmp >&2 || true
+    echo "nix build exited $NIX_RC; tail of stderr:" >&2
+    tail -200 /job/nix-stderr.log >&2
+    exit $NIX_RC
+fi
+
+if [ -z "$NIX_OUT" ]; then
+    echo "nix build emitted no /nix/store output path" >&2
+    exit 1
+fi
+printf '%s\n' "$NIX_OUT" > /job/store-path
+
+# Copy the artifacts the host expects into /out. We accept
+# either `vmlinux` (the canonical name our flakes use) or
+# `Image` / `bzImage` (raw kernel format names) for
+# robustness across flake conventions.
+if   [ -f "$NIX_OUT/vmlinux" ]; then cp -L "$NIX_OUT/vmlinux" /out/vmlinux
+elif [ -f "$NIX_OUT/Image"   ]; then cp -L "$NIX_OUT/Image"   /out/vmlinux
+elif [ -f "$NIX_OUT/bzImage" ]; then cp -L "$NIX_OUT/bzImage" /out/vmlinux
+fi
+if [ -f "$NIX_OUT/rootfs.ext4" ]; then
+    cp -L "$NIX_OUT/rootfs.ext4" /out/rootfs.ext4
+else
+    echo "no rootfs.ext4 in nix build output at $NIX_OUT" >&2
+    exit 1
+fi
+
+# Permissions for the host-side reader. Ignore failures —
+# virtio-fs may map the uid such that chmod is a no-op.
+chmod 0644 /out/rootfs.ext4 2>/dev/null || true
+[ -f /out/vmlinux ] && chmod 0644 /out/vmlinux 2>/dev/null || true
+"#,
+        flake_ref = shell_single_quote_escape(flake_ref),
+        attr_path = shell_single_quote_escape(attr_path),
+    )
+}
+
+/// Escape a string for inclusion inside `'…'` single quotes in
+/// POSIX shell. The only character that can't appear inside single
+/// quotes is `'` itself; we close the quote, emit `\'`, then
+/// reopen. Standard sh-escape pattern.
+///
+/// Public so external callers that build their own per-job shell
+/// scripts (e.g. `LibkrunBuilderVm::run_shell_script`'s validator)
+/// can reuse the same escape rules.
+pub fn shell_single_quote_escape(s: &str) -> String {
+    s.replace('\'', "'\\''")
 }
 
 #[cfg(test)]

--- a/crates/mvm-build/src/lib.rs
+++ b/crates/mvm-build/src/lib.rs
@@ -7,6 +7,10 @@ pub mod backend;
 /// itself wires in W2 PR 2 and the persistent-VM lifecycle in W3.
 pub mod builder_protocol;
 pub mod builder_vm;
+/// Plan 97 §"Phase C seam design" — hypervisor-agnostic builder-VM
+/// orchestration helper that wraps a `VmBackendForBuilder`
+/// implementation (libkrun today, Vz in PR-C).
+pub mod builder_vm_runtime;
 pub mod cache;
 pub mod firecracker;
 /// Plan 76 Phase 6 — portable signed `.mvm` artifacts. A tar.gz

--- a/crates/mvm-build/src/libkrun_builder.rs
+++ b/crates/mvm-build/src/libkrun_builder.rs
@@ -69,6 +69,13 @@ use crate::builder_vm::{
     BuilderArtifacts, BuilderJob, BuilderMounts, BuilderVm, BuilderVmDisk, BuilderVmError,
     BuilderVmExitInfo, BuilderVmMount, BuilderVmRunConfig, VmBackendForBuilder,
 };
+// Plan 97 Phase C (PR-B-migrate commit 2) — these items previously
+// lived in this file; they migrated to `builder_vm_runtime` so the
+// future VzBuilderVm path can reuse the same staging logic without
+// duplicating ~150 lines. `INSTALL_SPEC_FILENAME` and
+// `shell_single_quote_escape` are imported only inside the test
+// module below; the production path here only needs `stage_job_dir`.
+use crate::builder_vm_runtime::stage_job_dir;
 
 /// Default vCPU count for the builder VM. Nix builds are
 /// embarrassingly parallel at the derivation level; 4 cores is the
@@ -1196,179 +1203,19 @@ fn unique_job_id() -> String {
     format!("{now:013}-{pid}")
 }
 
-/// Filename of the install-spec JSON the host stages for
-/// install jobs. Matches the constant `mvm-builder-init` checks
-/// for inside the VM — keep these in sync.
-pub(crate) const INSTALL_SPEC_FILENAME: &str = "install_spec.json";
+// `INSTALL_SPEC_FILENAME` moved to `crate::builder_vm_runtime` in
+// Plan 97 Phase C PR-B-migrate; the `use` at the top of this file
+// pulls it back in for the existing callers.
 
 /// Filename of the install report `mvm-builder-init` writes into
 /// `artifact_out/` after the install pipeline finishes. The host
 /// reads + parses this to decide whether the install succeeded.
 pub(crate) const INSTALL_RESULT_FILENAME: &str = "result.json";
 
-/// Stage the per-job dir for the given [`BuilderJob`].
-///
-/// - [`BuilderJob::Flake`]: writes `<job_dir>/cmd.sh` with the
-///   `nix build` script the guest's PID 1 dispatches via
-///   `/bin/sh -eu`.
-/// - [`BuilderJob::Install`]: copies the caller's install spec
-///   to `<job_dir>/install_spec.json`. `mvm-builder-init` probes
-///   for this filename first; when present it routes through the
-///   app-deps install pipeline (Plan 73 Followup B.2) instead of
-///   running `cmd.sh`.
-///
-/// The two modes are mutually exclusive — install jobs don't
-/// emit a `cmd.sh`, flake jobs don't emit an install spec.
-fn stage_job_dir(job_dir: &Path, job: &BuilderJob) -> Result<(), BuilderVmError> {
-    std::fs::create_dir_all(job_dir).map_err(|e| {
-        BuilderVmError::ExtractionFailed(format!("creating job dir {}: {e}", job_dir.display()))
-    })?;
-
-    let (flake_ref, attr_path) = match job {
-        BuilderJob::Flake {
-            flake_ref,
-            attr_path,
-        } => (flake_ref.as_str(), attr_path.as_str()),
-        BuilderJob::Install { spec_path } => {
-            // Copy the caller's spec into the per-job dir so the
-            // virtio-fs share carries it into the guest at
-            // `/job/install_spec.json`. `mvm-builder-init`
-            // (Plan 73 Followup B.2) detects that filename and
-            // dispatches through the install pipeline instead of
-            // running cmd.sh.
-            let dst = job_dir.join(INSTALL_SPEC_FILENAME);
-            std::fs::copy(spec_path, &dst).map_err(|e| {
-                BuilderVmError::ExtractionFailed(format!(
-                    "copying install spec {} -> {}: {e}",
-                    spec_path.display(),
-                    dst.display()
-                ))
-            })?;
-            return Ok(());
-        }
-    };
-
-    // Render the `cmd.sh` content. flake_ref and attr_path are
-    // user-controlled; emit them inside `'…'` quoted shell
-    // variables, escaping any embedded `'` with the standard
-    // `'\''` close-quote / escape / open-quote dance.
-    let body = format!(
-        r#"#!/bin/sh
-# mvm-builder-vm cmd.sh — emitted by LibkrunBuilderVm (Plan 72 W4).
-# Runs inside the libkrun builder VM under `/bin/sh -eu`. The
-# host wires /work (workspace), /out (artifact dir), /job (this
-# dir) as virtio-fs shares; /nix is a persistent virtio-blk
-# overlay handled by mvm-builder-init.
-set -eu
-
-FLAKE_REF='{flake_ref}'
-ATTR_PATH='{attr_path}'
-
-# Point HOME at writable tmpfs (`/tmp`) to satisfy code paths that
-# write to `~/...` (the rootfs is mounted `ro`; nix would otherwise
-# bail with "creating directory '//.cache/nix': Read-only file
-# system"). XDG_CACHE_HOME lives on the persistent `/nix-store`
-# disk so Nix's eval-cache-v5, tarball-cache, and binary-cache-v6
-# survive across builds — cold flake eval is the long pole on
-# warm-store rebuilds, and these caches reclaim it. `/nix-store`
-# is the ext4 root for the persistent virtio-blk device; it sits
-# alongside the overlay upperdir (`/nix-store/upper`) at the
-# disk's top level, so writes here don't pollute the Nix store
-# namespace. XDG_STATE_HOME stays on tmpfs: it only holds profile
-# generations, which one-shot build VMs don't use.
-export HOME=/tmp
-export XDG_CACHE_HOME=/nix-store/.cache
-export XDG_STATE_HOME=/tmp/.local/state
-mkdir -p /nix-store/.cache /tmp/.local/state
-
-# CA certs for TLS to cache.nixos.org / api.github.com.
-export CURL_CA_BUNDLE=/etc/ssl/certs/ca-bundle.crt
-export NIX_SSL_CERT_FILE=/etc/ssl/certs/ca-bundle.crt
-export SSL_CERT_FILE=/etc/ssl/certs/ca-bundle.crt
-
-cd /work
-# `experimental-features` enables nix-command + flakes. `sandbox =
-# false` + `build-users-group =` is mandatory inside the builder
-# VM: there are no `nixbld*` accounts in the rootfs and no kernel
-# user-ns isolation for build sandboxes, so every derivation would
-# otherwise fail with "the group 'nixbld' specified in
-# 'build-users-group' does not exist". The builder VM IS the
-# isolation boundary, so an in-guest sandbox is redundant.
-export NIX_CONFIG="experimental-features = nix-command flakes
-sandbox = false
-build-users-group =
-max-jobs = auto
-cores = 0
-auto-optimise-store = true
-substituters = https://cache.nixos.org/
-trusted-public-keys = cache.nixos.org-1:6NCHdD59X431o0gWypbMrAURkbJ16ZPMQFGspcDShjY="
-# Plan 72 W0's flake convention: workspace-path env var so
-# flakes that reference the workspace root don't depend on
-# relative-path resolution against the store-copied flake dir.
-export MVM_WORKSPACE_PATH=/work
-
-echo "mvm-builder-vm: filesystem space before nix build:" >&2
-df -h /nix /tmp >&2 || true
-
-# `--impure` is what unblocks builds inside the VM when the
-# flake has path inputs; `--no-write-lock-file` keeps the
-# read-only `/work` mount from tripping EROFS.
-# `--print-build-logs --keep-going` dumps every failing build's
-# stderr inline (default nix only prints the last 10 lines and
-# cascades up). We tee stderr to /job/nix-build.log so the host
-# can read the actual root cause when a deep dependency fails.
-set +e
-nix build "${{FLAKE_REF}}#${{ATTR_PATH}}" \
-    --no-link --print-out-paths --no-write-lock-file --impure \
-    --print-build-logs --keep-going \
-    > /job/nix-stdout.log 2> /job/nix-stderr.log
-NIX_RC=$?
-set -e
-NIX_OUT=$(cat /job/nix-stdout.log)
-if [ "$NIX_RC" -ne 0 ]; then
-    echo "mvm-builder-vm: filesystem space after failed nix build:" >&2
-    df -h /nix /tmp >&2 || true
-    echo "nix build exited $NIX_RC; tail of stderr:" >&2
-    tail -200 /job/nix-stderr.log >&2
-    exit $NIX_RC
-fi
-
-if [ -z "$NIX_OUT" ]; then
-    echo "nix build emitted no /nix/store output path" >&2
-    exit 1
-fi
-printf '%s\n' "$NIX_OUT" > /job/store-path
-
-# Copy the artifacts the host expects into /out. We accept
-# either `vmlinux` (the canonical name our flakes use) or
-# `Image` / `bzImage` (raw kernel format names) for
-# robustness across flake conventions.
-if   [ -f "$NIX_OUT/vmlinux" ]; then cp -L "$NIX_OUT/vmlinux" /out/vmlinux
-elif [ -f "$NIX_OUT/Image"   ]; then cp -L "$NIX_OUT/Image"   /out/vmlinux
-elif [ -f "$NIX_OUT/bzImage" ]; then cp -L "$NIX_OUT/bzImage" /out/vmlinux
-fi
-if [ -f "$NIX_OUT/rootfs.ext4" ]; then
-    cp -L "$NIX_OUT/rootfs.ext4" /out/rootfs.ext4
-else
-    echo "no rootfs.ext4 in nix build output at $NIX_OUT" >&2
-    exit 1
-fi
-
-# Permissions for the host-side reader. Ignore failures —
-# virtio-fs may map the uid such that chmod is a no-op.
-chmod 0644 /out/rootfs.ext4 2>/dev/null || true
-[ -f /out/vmlinux ] && chmod 0644 /out/vmlinux 2>/dev/null || true
-"#,
-        flake_ref = shell_single_quote_escape(flake_ref),
-        attr_path = shell_single_quote_escape(attr_path),
-    );
-
-    let cmd_path = job_dir.join("cmd.sh");
-    std::fs::write(&cmd_path, body).map_err(|e| {
-        BuilderVmError::ExtractionFailed(format!("writing {}: {e}", cmd_path.display()))
-    })?;
-    Ok(())
-}
+// `stage_job_dir` migrated to `crate::builder_vm_runtime` in Plan 97
+// Phase C PR-B-migrate commit 2. Both libkrun (here) and the
+// future VzBuilderVm path call the same helper, which produces the
+// virtio-fs-share-friendly cmd.sh / install_spec.json.
 
 fn stage_shell_job_dir(job_dir: &Path, script: &str) -> Result<(), BuilderVmError> {
     std::fs::create_dir_all(job_dir).map_err(|e| {
@@ -1381,13 +1228,9 @@ fn stage_shell_job_dir(job_dir: &Path, script: &str) -> Result<(), BuilderVmErro
     Ok(())
 }
 
-/// Escape a string for inclusion inside `'…'` single quotes
-/// in POSIX shell. The only character that can't appear inside
-/// single quotes is `'` itself; we close the quote, emit `\'`,
-/// then reopen. Standard sh-escape pattern.
-fn shell_single_quote_escape(s: &str) -> String {
-    s.replace('\'', "'\\''")
-}
+// `shell_single_quote_escape` migrated to
+// `crate::builder_vm_runtime` in Plan 97 Phase C PR-B-migrate
+// commit 2.
 
 /// Read the last `max_bytes` of `path` into a `String`, replacing any
 /// invalid UTF-8 lossily. Returns `Err` if the file is missing or
@@ -2386,6 +2229,7 @@ impl PersistentVmHandle {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::builder_vm_runtime::{INSTALL_SPEC_FILENAME, shell_single_quote_escape};
     use std::sync::{LazyLock, Mutex};
     use tempfile::TempDir;
 


### PR DESCRIPTION
## Summary

Stacked on #433. First slice of PR-B (the libkrun migration onto the new seam). Two commits:

### Commit 1 — `BuilderVmRuntime` helper skeleton

New file `crates/mvm-build/src/builder_vm_runtime.rs`. Defines the hypervisor-agnostic orchestration helper that holds a `&dyn VmBackendForBuilder`. Today it's a skeleton with a constructor + backend accessor; subsequent commits add ported orchestration methods. Two tests pin the zero-cost-construction contract + the backend accessor's behavior.

### Commit 2 — Migrate `stage_job_dir` into `BuilderVmRuntime`

Moves three items from `libkrun_builder.rs` to `builder_vm_runtime.rs`:

- `stage_job_dir(job_dir, job)` — staging logic for cmd.sh (Flake jobs) and install_spec.json (Install jobs)
- `shell_single_quote_escape(s)` — POSIX shell quote-escape helper used by the cmd.sh body
- `INSTALL_SPEC_FILENAME` constant — the filename `mvm-builder-init` probes for to dispatch through the app-deps install pipeline

`LibkrunBuilderVm::run_build` calls the runtime helper version unchanged via a `use builder_vm_runtime::stage_job_dir` import. The cmd.sh body is byte-identical to the previous output (only the inline comment header changes).

### Why this shape

The two commits are independently verifiable:

- **Commit 1** lands the helper struct + module wiring. Pure addition; no production code paths change. If commit 2 needs a redesign, the helper still has value.
- **Commit 2** is a clean code-move. It exercises the runtime module's exports for the first time and proves the seam is callable from the libkrun path. If you find issues, only this commit needs amending; commit 1's foundation stays.

Future PR-B commits (separate PRs in this stack):

- `/job/result` JSON parsing → `BuilderVmRuntime`
- Per-variant artifact finalisation (`finalize_flake_job`, `finalize_install_job`)
- Panic-detector loop migrated through the `VmBackendForBuilder` seam
- `NixStoreImageLock` + stderr-tail capture

After all five migrations land, `LibkrunBuilderVm::run_build` is a thin orchestrator and `VzBuilderVm` (PR-C) can be wired up with minimal new code.

## Test plan

- [x] `cargo test -p mvm-build --features builder-vm --lib` — 307/307 pass (was 305; +2 new helper tests).
- [x] `cargo clippy --workspace --all-targets -- -D warnings` — clean.
- [x] `cargo fmt --all -- --check` — clean.
- [x] `LibkrunBuilderVm.run_build` flow unchanged — the existing `stage_job_dir` call site uses the migrated symbol via `use`; no other behavior touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)