### PR TITLE
Plan 97 Phase C PR-B-migrate: JobResult + read_job_result (second migration)

### DIFF
--- a/crates/mvm-build/src/builder_vm_runtime.rs
+++ b/crates/mvm-build/src/builder_vm_runtime.rs
@@ -33,6 +33,8 @@
 
 use std::path::Path;
 
+use serde::Deserialize;
+
 use crate::builder_vm::{BuilderJob, BuilderVmError, VmBackendForBuilder};
 
 /// Per-job dir filename mvm-builder-init detects to dispatch
@@ -255,6 +257,49 @@ pub fn shell_single_quote_escape(s: &str) -> String {
     s.replace('\'', "'\\''")
 }
 
+/// Parsed `<job_dir>/result` written by `mvm-builder-init` (Plan 72
+/// W3). Shape matches the JSON `mvm-builder-init::linux::write_result`
+/// emits. The guest PID 1 writes this on every code path that reaches
+/// `power_off`; the host-side helper reads it to learn the guest's
+/// exit code and the cmd.sh stderr-tail ringbuffer for diagnostics.
+///
+/// Hypervisor-agnostic: the file lives in the `/job` virtio-fs share,
+/// which both libkrun and Vz attach identically. Migrated from
+/// `libkrun_builder.rs` in Plan 97 Phase C (second migration after
+/// `stage_job_dir`).
+#[derive(Debug, Deserialize)]
+pub struct JobResult {
+    pub exit_code: i32,
+    #[serde(default)]
+    pub stderr_tail: String,
+}
+
+/// Read and parse `<job_dir>/result`. The guest's PID 1 writes this
+/// on every code path that reaches `power_off`; absence here means
+/// the VM crashed before `mvm-builder-init` could finalize.
+///
+/// Error mapping mirrors the original libkrun-side implementation:
+/// missing file → [`BuilderVmError::NixBuildFailed`] (it's almost
+/// always a guest crash mid-build); malformed JSON →
+/// [`BuilderVmError::ExtractionFailed`] (host couldn't extract the
+/// result, regardless of whether the build succeeded).
+pub fn read_job_result(job_dir: &Path) -> Result<JobResult, BuilderVmError> {
+    let path = job_dir.join("result");
+    let body = std::fs::read_to_string(&path).map_err(|e| {
+        BuilderVmError::NixBuildFailed(format!(
+            "guest did not write {}: {e} \
+             (the VM may have crashed before mvm-builder-init could finalize)",
+            path.display()
+        ))
+    })?;
+    serde_json::from_str::<JobResult>(&body).map_err(|e| {
+        BuilderVmError::ExtractionFailed(format!(
+            "parsing {} as JSON: {e}\nbody:\n{body}",
+            path.display()
+        ))
+    })
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -332,5 +377,51 @@ mod tests {
                 .load(std::sync::atomic::Ordering::SeqCst),
             0
         );
+    }
+
+    #[test]
+    fn read_job_result_parses_well_formed_json() {
+        let scratch = tempfile::TempDir::new().unwrap();
+        let job_dir = scratch.path().to_path_buf();
+        std::fs::write(
+            job_dir.join("result"),
+            r#"{"exit_code":0,"stderr_tail":"hello"}"#,
+        )
+        .unwrap();
+        let r = read_job_result(&job_dir).unwrap();
+        assert_eq!(r.exit_code, 0);
+        assert_eq!(r.stderr_tail, "hello");
+    }
+
+    #[test]
+    fn read_job_result_defaults_stderr_tail_when_absent() {
+        // `#[serde(default)]` on stderr_tail. A guest that
+        // exited before writing stderr_tail (rare, but possible
+        // under panic) still parses cleanly.
+        let scratch = tempfile::TempDir::new().unwrap();
+        let job_dir = scratch.path().to_path_buf();
+        std::fs::write(job_dir.join("result"), r#"{"exit_code":2}"#).unwrap();
+        let r = read_job_result(&job_dir).unwrap();
+        assert_eq!(r.exit_code, 2);
+        assert_eq!(r.stderr_tail, "");
+    }
+
+    #[test]
+    fn read_job_result_errors_when_missing() {
+        let scratch = tempfile::TempDir::new().unwrap();
+        let err = read_job_result(scratch.path()).unwrap_err();
+        assert!(matches!(err, BuilderVmError::NixBuildFailed(_)));
+    }
+
+    #[test]
+    fn read_job_result_errors_on_malformed_json() {
+        // New coverage relative to the libkrun-side tests: the
+        // ExtractionFailed arm wasn't exercised before. Pinning it
+        // here means a future change to the error mapping (e.g.
+        // collapsing both arms) breaks visibly.
+        let scratch = tempfile::TempDir::new().unwrap();
+        std::fs::write(scratch.path().join("result"), "{not valid json").unwrap();
+        let err = read_job_result(scratch.path()).unwrap_err();
+        assert!(matches!(err, BuilderVmError::ExtractionFailed(_)));
     }
 }

--- a/crates/mvm-build/src/libkrun_builder.rs
+++ b/crates/mvm-build/src/libkrun_builder.rs
@@ -69,13 +69,14 @@ use crate::builder_vm::{
     BuilderArtifacts, BuilderJob, BuilderMounts, BuilderVm, BuilderVmDisk, BuilderVmError,
     BuilderVmExitInfo, BuilderVmMount, BuilderVmRunConfig, VmBackendForBuilder,
 };
-// Plan 97 Phase C (PR-B-migrate commit 2) — these items previously
-// lived in this file; they migrated to `builder_vm_runtime` so the
-// future VzBuilderVm path can reuse the same staging logic without
-// duplicating ~150 lines. `INSTALL_SPEC_FILENAME` and
-// `shell_single_quote_escape` are imported only inside the test
-// module below; the production path here only needs `stage_job_dir`.
-use crate::builder_vm_runtime::stage_job_dir;
+// Plan 97 Phase C migration — these items previously lived in this
+// file; they migrated to `builder_vm_runtime` so the future
+// VzBuilderVm path can reuse the same logic without duplicating it.
+// `INSTALL_SPEC_FILENAME` and `shell_single_quote_escape` are
+// imported only inside the test module below; the production path
+// here uses `stage_job_dir` (PR-B-migrate commit 2) and
+// `read_job_result` (PR-B-migrate commit 3).
+use crate::builder_vm_runtime::{read_job_result, stage_job_dir};
 
 /// Default vCPU count for the builder VM. Nix builds are
 /// embarrassingly parallel at the derivation level; 4 cores is the
@@ -1023,16 +1024,6 @@ fn krun_context_for_image(
     }
 }
 
-/// Parsed `/job/result` written by `mvm-builder-init` (Plan 72 W3).
-/// Shape matches the JSON `mvm-builder-init::linux::write_result`
-/// emits.
-#[derive(Debug, Deserialize)]
-struct JobResult {
-    exit_code: i32,
-    #[serde(default)]
-    stderr_tail: String,
-}
-
 /// Host architecture tag used as a cache-key segment for
 /// per-arch builder VM images. `aarch64` on Apple Silicon /
 /// ARM Linux, `x86_64` everywhere else. Plan 72 W2's flake
@@ -1395,25 +1386,6 @@ struct InstallResultReport {
     /// host-side error message.
     #[serde(default)]
     failure_reason: Option<String>,
-}
-
-/// Read and parse `<job_dir>/result`. The guest's PID 1
-/// writes this on every code path that reaches `power_off`.
-fn read_job_result(job_dir: &Path) -> Result<JobResult, BuilderVmError> {
-    let path = job_dir.join("result");
-    let body = std::fs::read_to_string(&path).map_err(|e| {
-        BuilderVmError::NixBuildFailed(format!(
-            "guest did not write {}: {e} \
-             (the VM may have crashed before mvm-builder-init could finalize)",
-            path.display()
-        ))
-    })?;
-    serde_json::from_str::<JobResult>(&body).map_err(|e| {
-        BuilderVmError::ExtractionFailed(format!(
-            "parsing {} as JSON: {e}\nbody:\n{body}",
-            path.display()
-        ))
-    })
 }
 
 /// Locate the `mvm-libkrun-supervisor` binary. Mirrors the
@@ -2676,39 +2648,9 @@ mod tests {
         );
     }
 
-    #[test]
-    fn read_job_result_parses_well_formed_json() {
-        let scratch = TempDir::new().unwrap();
-        let job_dir = scratch.path().to_path_buf();
-        std::fs::write(
-            job_dir.join("result"),
-            r#"{"exit_code":0,"stderr_tail":"hello"}"#,
-        )
-        .unwrap();
-        let r = read_job_result(&job_dir).unwrap();
-        assert_eq!(r.exit_code, 0);
-        assert_eq!(r.stderr_tail, "hello");
-    }
-
-    #[test]
-    fn read_job_result_defaults_stderr_tail_when_absent() {
-        // `#[serde(default)]` on stderr_tail. A guest that
-        // exited before writing stderr_tail (rare, but possible
-        // under panic) still parses cleanly.
-        let scratch = TempDir::new().unwrap();
-        let job_dir = scratch.path().to_path_buf();
-        std::fs::write(job_dir.join("result"), r#"{"exit_code":2}"#).unwrap();
-        let r = read_job_result(&job_dir).unwrap();
-        assert_eq!(r.exit_code, 2);
-        assert_eq!(r.stderr_tail, "");
-    }
-
-    #[test]
-    fn read_job_result_errors_when_missing() {
-        let scratch = TempDir::new().unwrap();
-        let err = read_job_result(scratch.path()).unwrap_err();
-        assert!(matches!(err, BuilderVmError::NixBuildFailed(_)));
-    }
+    // `read_job_result_*` test coverage migrated to
+    // `builder_vm_runtime` alongside the function itself. Plan 97
+    // Phase C PR-B-migrate commit 3.
 
     #[test]
     fn extract_nix_store_hash_parses_output_path() {


### PR DESCRIPTION
## Summary

Continues the Plan 97 Phase C lift-and-shift from `LibkrunBuilderVm` (~3,300 lines) into the hypervisor-agnostic `BuilderVmRuntime` helper. This is the **second** migration after #434 moved `stage_job_dir`.

This slice migrates the `/job/result` JSON contract with `mvm-builder-init`:
- `JobResult` struct (exit code + stderr tail)
- `read_job_result(job_dir)` parser

Both are pure host-side I/O against a virtio-fs share, identically attached by libkrun and a future Vz builder — zero VMM-specific logic.

## Changes

- `crates/mvm-build/src/builder_vm_runtime.rs` — adds `JobResult` (pub fields) + `read_job_result`. New test pinning the `ExtractionFailed` arm on malformed JSON (the libkrun-side suite never exercised this branch).
- `crates/mvm-build/src/libkrun_builder.rs` — removes the local copies; imports the migrated names. Two production call sites (`run_build` and `finalize_flake_job`) and three duplicate tests deleted.

Visibility chosen to match `stage_job_dir`'s convention (`pub`): `LibkrunBuilderVm` is gated behind `--features builder-vm`, so `pub(crate)` items it consumes appear dead in the default build. `pub` sidesteps the dead-code lint and prepares the items for cross-crate `VzBuilderVm` consumption.

## Test plan

- [x] `cargo test --workspace` — all green
- [x] `cargo test -p mvm-build --features builder-vm` — 308 + sibling-module tests all green
- [x] `cargo clippy --workspace --all-targets -- -D warnings` — clean
- [x] `cargo fmt --all -- --check` — clean

## Next slice

Per Plan 97 §"Phase C seam design", the remaining migrations in order are: per-variant artifact finalisation (`finalize_flake_job`, install-volume sidecar discovery), `NixStoreImageLock`, stderr-tail capture, wall-clock timeout handling.

🤖 Generated with [Claude Code](https://claude.com/claude-code)