### PR TITLE
Plan 97 Phase C PR-B-migrate: finalize_flake_job + finalize_install_job (third migration)

### DIFF
--- a/crates/mvm-build/src/builder_vm_runtime.rs
+++ b/crates/mvm-build/src/builder_vm_runtime.rs
@@ -35,7 +35,7 @@ use std::path::Path;
 
 use serde::Deserialize;
 
-use crate::builder_vm::{BuilderJob, BuilderVmError, VmBackendForBuilder};
+use crate::builder_vm::{BuilderArtifacts, BuilderJob, BuilderVmError, VmBackendForBuilder};
 
 /// Per-job dir filename mvm-builder-init detects to dispatch
 /// through the application-dependency install pipeline (Plan 73
@@ -300,6 +300,178 @@ pub fn read_job_result(job_dir: &Path) -> Result<JobResult, BuilderVmError> {
     })
 }
 
+/// Filename of the install report `mvm-builder-init` writes into
+/// `artifact_out/` after the install pipeline finishes. The host
+/// reads + parses this to decide whether the install succeeded.
+pub const INSTALL_RESULT_FILENAME: &str = "result.json";
+
+/// Read the last `max_bytes` of `path` into a `String`, replacing any
+/// invalid UTF-8 lossily. Returns `Err` if the file is missing or
+/// unreadable. Used by [`finalize_flake_job`] to surface the tail of
+/// `<job_dir>/nix-stderr.log` (the cmd.sh's nix-build stderr capture)
+/// in the failure path without loading a multi-hundred-KB log into
+/// memory.
+pub fn read_last_bytes_of(path: &Path, max_bytes: u64) -> std::io::Result<String> {
+    use std::io::{Read, Seek, SeekFrom};
+    let mut file = std::fs::File::open(path)?;
+    let len = file.metadata()?.len();
+    let take = max_bytes.min(len);
+    // SeekFrom::End wants i64; max_bytes is bounded to a small constant
+    // at every call site (4 KiB today) so the cast is safe.
+    let offset = i64::try_from(take).unwrap_or(i64::MAX).saturating_neg();
+    file.seek(SeekFrom::End(offset))?;
+    let mut buf = Vec::with_capacity(take as usize);
+    file.read_to_end(&mut buf)?;
+    Ok(String::from_utf8_lossy(&buf).into_owned())
+}
+
+/// Finalize a flake build: read `<job_dir>/result`, validate the
+/// `rootfs.ext4` (and optional `vmlinux`) landed in `artifact_out`,
+/// return a [`BuilderArtifacts::Image`]. Hypervisor-agnostic — the
+/// inputs are all host paths into virtio-fs shares libkrun and Vz
+/// both attach identically.
+pub fn finalize_flake_job(
+    job_dir: &Path,
+    artifact_out: &Path,
+    job_id: &str,
+) -> Result<BuilderArtifacts, BuilderVmError> {
+    let result = read_job_result(job_dir)?;
+    if result.exit_code != 0 {
+        // The 20-line `stderr_tail` in `result` is from the OUTER
+        // cmd.sh (run_job captures cmd.sh's stderr into a 20-line
+        // ringbuffer). That ringbuffer typically only carries the
+        // "nix build exited N; tail of stderr:" preamble — not the
+        // real per-derivation failure. The actual nix-build stderr
+        // is at `<job_dir>/nix-stderr.log` (cmd.sh redirects there
+        // via `2> /job/nix-stderr.log`). Surface its tail so the
+        // operator doesn't have to know the convention.
+        let stderr_log = job_dir.join("nix-stderr.log");
+        let derivation_tail = read_last_bytes_of(&stderr_log, 4 * 1024)
+            .unwrap_or_else(|_| String::from("<nix-stderr.log not present on host>"));
+        return Err(BuilderVmError::NixBuildFailed(format!(
+            "guest cmd.sh exited {} — full log: {}\n\
+             outer stderr tail (cmd.sh ringbuffer):\n{}\n\
+             derivation stderr tail (last 4 KiB of {}):\n{}",
+            result.exit_code,
+            stderr_log.display(),
+            result.stderr_tail,
+            stderr_log.display(),
+            derivation_tail,
+        )));
+    }
+
+    let rootfs_path = artifact_out.join("rootfs.ext4");
+    if !rootfs_path.is_file() {
+        return Err(BuilderVmError::ExtractionFailed(format!(
+            "builder VM exited cleanly but {} was not written",
+            rootfs_path.display()
+        )));
+    }
+    let kernel_path_out = artifact_out.join("vmlinux");
+    let kernel_path = if kernel_path_out.is_file() {
+        Some(kernel_path_out)
+    } else {
+        None
+    };
+
+    Ok(BuilderArtifacts::Image {
+        rootfs_path,
+        kernel_path,
+        revision_hash: read_revision_hash(job_dir).unwrap_or_else(|| job_id.to_string()),
+        lock_hash: None,
+        accessible: None,
+    })
+}
+
+/// Read `<job_dir>/store-path` and extract the leading Nix store hash
+/// from `/nix/store/<hash>-<name>`. Older guest images may not write
+/// the sidecar; those callers fall back to the unique job id.
+pub fn read_revision_hash(job_dir: &Path) -> Option<String> {
+    let body = std::fs::read_to_string(job_dir.join("store-path")).ok()?;
+    extract_nix_store_hash(body.trim()).map(str::to_string)
+}
+
+fn extract_nix_store_hash(store_path: &str) -> Option<&str> {
+    let name = store_path.strip_prefix("/nix/store/")?;
+    let (hash, _rest) = name.split_once('-')?;
+    if hash.is_empty() { None } else { Some(hash) }
+}
+
+/// Parsed shape of `<artifact_out>/result.json` — the install report
+/// `mvm-builder-init::install::InstallReport::to_json` emits. Field
+/// set kept in sync with the writer; an additive change to the writer
+/// (B.2.x egress allowlist diagnostics, for example) needs a matching
+/// `#[serde(default)]` field here.
+#[derive(Debug, Deserialize)]
+pub struct InstallResultReport {
+    pub installer_exit_code: i32,
+    /// Set when `mvm-builder-init` synthesizes a failure report (e.g.
+    /// installer binary missing on PATH). Surfaced in the host-side
+    /// error message.
+    #[serde(default)]
+    pub failure_reason: Option<String>,
+}
+
+/// Finalize an install job (Plan 73 Followup B.2): validate the
+/// install report `mvm-builder-init` wrote to
+/// `<artifact_out>/result.json`, fail closed on
+/// `installer_exit_code != 0`, and return
+/// [`BuilderArtifacts::InstallVolume`] pointing at the directory.
+/// Sealing the volume (via `mvm_sdk::compile::deps_audit::seal_volume`)
+/// and renaming into the deps cache is the orchestrator's job
+/// (`mvm_build::app_deps::install_app_deps`) — keeping it out of the
+/// builder VM means the same code path covers fresh installs and
+/// cache rehydrations.
+pub fn finalize_install_job(artifact_out: &Path) -> Result<BuilderArtifacts, BuilderVmError> {
+    let result_path = artifact_out.join(INSTALL_RESULT_FILENAME);
+    if !result_path.is_file() {
+        return Err(BuilderVmError::ExtractionFailed(format!(
+            "install job VM exited cleanly but {} was not written",
+            result_path.display()
+        )));
+    }
+    let body = std::fs::read_to_string(&result_path).map_err(|e| {
+        BuilderVmError::ExtractionFailed(format!("reading {}: {e}", result_path.display()))
+    })?;
+    let report: InstallResultReport = serde_json::from_str(&body).map_err(|e| {
+        BuilderVmError::ExtractionFailed(format!(
+            "parsing {} as JSON: {e}\nbody:\n{body}",
+            result_path.display()
+        ))
+    })?;
+
+    if report.installer_exit_code != 0 {
+        let reason = report
+            .failure_reason
+            .clone()
+            .unwrap_or_else(|| format!("installer exited {}", report.installer_exit_code));
+        return Err(BuilderVmError::NixBuildFailed(format!(
+            "install pipeline failed inside builder VM: {reason}"
+        )));
+    }
+
+    // The four sealed-volume artifacts must all be present —
+    // mvm-builder-init emits stubs on missing optional tooling
+    // (SBOM / CVE) so absence here means the guest crashed mid-
+    // pipeline. seal_volume would catch this too, but failing
+    // closed at the builder layer pins the error to the right
+    // diagnostic message.
+    for name in ["content", "sbom.cdx.json", "fetch.log", "cve.json"] {
+        let p = artifact_out.join(name);
+        if !p.exists() {
+            return Err(BuilderVmError::ExtractionFailed(format!(
+                "install job VM exited cleanly but sealed-volume artifact {} is missing",
+                p.display()
+            )));
+        }
+    }
+
+    Ok(BuilderArtifacts::InstallVolume {
+        volume_dir: artifact_out.to_path_buf(),
+        result_json_path: result_path,
+    })
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -423,5 +595,282 @@ mod tests {
         std::fs::write(scratch.path().join("result"), "{not valid json").unwrap();
         let err = read_job_result(scratch.path()).unwrap_err();
         assert!(matches!(err, BuilderVmError::ExtractionFailed(_)));
+    }
+
+    // -----------------------------------------------------------------
+    // Tests migrated from libkrun_builder.rs alongside finalize_*
+    // (Plan 97 Phase C PR-B-migrate commit 4).
+    // -----------------------------------------------------------------
+
+    #[test]
+    fn extract_nix_store_hash_parses_output_path() {
+        assert_eq!(
+            extract_nix_store_hash("/nix/store/abc123def4567890-tenant-rootfs"),
+            Some("abc123def4567890")
+        );
+        assert_eq!(extract_nix_store_hash("/tmp/not-store"), None);
+        assert_eq!(extract_nix_store_hash("/nix/store/-missing-hash"), None);
+    }
+
+    #[test]
+    fn finalize_flake_job_uses_store_path_hash_when_present() {
+        let scratch = tempfile::TempDir::new().unwrap();
+        let job_dir = scratch.path().join("job");
+        let artifact_out = scratch.path().join("out");
+        std::fs::create_dir_all(&job_dir).unwrap();
+        std::fs::create_dir_all(&artifact_out).unwrap();
+        std::fs::write(
+            job_dir.join("result"),
+            r#"{"exit_code":0,"stderr_tail":""}"#,
+        )
+        .unwrap();
+        std::fs::write(
+            job_dir.join("store-path"),
+            "/nix/store/deadbeefcafebabe-builder-vm\n",
+        )
+        .unwrap();
+        std::fs::write(artifact_out.join("rootfs.ext4"), b"rootfs").unwrap();
+
+        let artifacts = finalize_flake_job(&job_dir, &artifact_out, "fallback-job-id").unwrap();
+        match artifacts {
+            BuilderArtifacts::Image { revision_hash, .. } => {
+                assert_eq!(revision_hash, "deadbeefcafebabe");
+            }
+            other => panic!("wrong artifact variant: {other:?}"),
+        }
+    }
+
+    #[test]
+    fn finalize_flake_job_falls_back_to_job_id_without_store_path() {
+        let scratch = tempfile::TempDir::new().unwrap();
+        let job_dir = scratch.path().join("job");
+        let artifact_out = scratch.path().join("out");
+        std::fs::create_dir_all(&job_dir).unwrap();
+        std::fs::create_dir_all(&artifact_out).unwrap();
+        std::fs::write(
+            job_dir.join("result"),
+            r#"{"exit_code":0,"stderr_tail":""}"#,
+        )
+        .unwrap();
+        std::fs::write(artifact_out.join("rootfs.ext4"), b"rootfs").unwrap();
+
+        let artifacts = finalize_flake_job(&job_dir, &artifact_out, "fallback-job-id").unwrap();
+        match artifacts {
+            BuilderArtifacts::Image { revision_hash, .. } => {
+                assert_eq!(revision_hash, "fallback-job-id");
+            }
+            other => panic!("wrong artifact variant: {other:?}"),
+        }
+    }
+
+    /// `read_last_bytes_of` returns the trailing `max_bytes` of a
+    /// file. When the file is larger than the cap, we get the *end*,
+    /// not the head — the use case is tailing nix-build stderr where
+    /// the cause-of-death is at the bottom.
+    #[test]
+    fn read_last_bytes_of_returns_trailing_window_when_file_exceeds_cap() {
+        let scratch = tempfile::TempDir::new().unwrap();
+        let path = scratch.path().join("log");
+        let mut body = String::new();
+        for i in 0..2_000 {
+            body.push_str(&format!("line {i}\n"));
+        }
+        std::fs::write(&path, &body).unwrap();
+        let tail = read_last_bytes_of(&path, 200).unwrap();
+        assert!(tail.len() <= 200);
+        assert!(tail.contains("line 1999"), "tail contains the last line");
+        assert!(
+            !tail.contains("line 0\n"),
+            "tail does not include the head: {tail}"
+        );
+    }
+
+    /// Small file: the helper returns the whole file (capped at its
+    /// real length, not the requested max).
+    #[test]
+    fn read_last_bytes_of_returns_entire_file_when_smaller_than_cap() {
+        let scratch = tempfile::TempDir::new().unwrap();
+        let path = scratch.path().join("log");
+        std::fs::write(&path, b"hello world").unwrap();
+        let tail = read_last_bytes_of(&path, 4096).unwrap();
+        assert_eq!(tail, "hello world");
+    }
+
+    /// Missing file surfaces as an `io::Error`; the caller in
+    /// `finalize_flake_job` swallows it into a `<not present>`
+    /// sentinel rather than failing the whole error format.
+    #[test]
+    fn read_last_bytes_of_errors_on_missing_file() {
+        let scratch = tempfile::TempDir::new().unwrap();
+        let err = read_last_bytes_of(&scratch.path().join("missing"), 1024).unwrap_err();
+        assert_eq!(err.kind(), std::io::ErrorKind::NotFound);
+    }
+
+    /// The failure-path error message names the nix-stderr.log path
+    /// AND inlines its tail. Diagnostic-surface fix — before the
+    /// change, callers got the outer cmd.sh ringbuffer only, with no
+    /// hint where the real log lived.
+    #[test]
+    fn finalize_flake_job_failure_includes_nix_stderr_log_path_and_tail() {
+        let scratch = tempfile::TempDir::new().unwrap();
+        let job_dir = scratch.path().join("job");
+        let artifact_out = scratch.path().join("out");
+        std::fs::create_dir_all(&job_dir).unwrap();
+        std::fs::create_dir_all(&artifact_out).unwrap();
+        std::fs::write(
+            job_dir.join("result"),
+            r#"{"exit_code":1,"stderr_tail":"outer-tail"}"#,
+        )
+        .unwrap();
+        // Sentinel string the helper must surface — proves we're
+        // reading from THIS file and not from the outer ringbuffer.
+        std::fs::write(
+            job_dir.join("nix-stderr.log"),
+            "/nix/store/.../cargo-install-hook.sh: line 27: /dev/fd/63: No such file or directory\n",
+        )
+        .unwrap();
+
+        let err = finalize_flake_job(&job_dir, &artifact_out, "job-id").unwrap_err();
+        let msg = match err {
+            BuilderVmError::NixBuildFailed(s) => s,
+            other => panic!("expected NixBuildFailed, got {other:?}"),
+        };
+        assert!(msg.contains("exited 1"), "names exit code: {msg}");
+        let log_path = job_dir.join("nix-stderr.log");
+        assert!(
+            msg.contains(&*log_path.to_string_lossy()),
+            "names the full log path: {msg}"
+        );
+        assert!(
+            msg.contains("/dev/fd/63: No such file or directory"),
+            "inlines the real derivation stderr tail: {msg}"
+        );
+        assert!(
+            msg.contains("outer-tail"),
+            "still includes the outer ringbuffer for context: {msg}"
+        );
+    }
+
+    /// Missing `nix-stderr.log` doesn't crash the formatter — we get
+    /// a clean sentinel instead of an `Err(...)` cascade. Matters for
+    /// very-early failures (e.g. cmd.sh exit before the
+    /// `2> /job/nix-stderr.log` redirect runs).
+    #[test]
+    fn finalize_flake_job_failure_handles_missing_nix_stderr_log_cleanly() {
+        let scratch = tempfile::TempDir::new().unwrap();
+        let job_dir = scratch.path().join("job");
+        let artifact_out = scratch.path().join("out");
+        std::fs::create_dir_all(&job_dir).unwrap();
+        std::fs::create_dir_all(&artifact_out).unwrap();
+        std::fs::write(
+            job_dir.join("result"),
+            r#"{"exit_code":2,"stderr_tail":"no cmd.sh"}"#,
+        )
+        .unwrap();
+
+        let err = finalize_flake_job(&job_dir, &artifact_out, "job-id").unwrap_err();
+        let msg = match err {
+            BuilderVmError::NixBuildFailed(s) => s,
+            other => panic!("expected NixBuildFailed, got {other:?}"),
+        };
+        assert!(
+            msg.contains("<nix-stderr.log not present on host>"),
+            "sentinel surfaces in place of missing log: {msg}"
+        );
+        assert!(
+            msg.contains("no cmd.sh"),
+            "outer tail still surfaces: {msg}"
+        );
+    }
+
+    #[test]
+    fn finalize_install_job_requires_result_json() {
+        // Empty artifact dir → ExtractionFailed pointing at the
+        // missing result.json. Surfaces guest crashes that prevented
+        // mvm-builder-init from finalizing the report.
+        let scratch = tempfile::TempDir::new().unwrap();
+        let err = finalize_install_job(scratch.path()).unwrap_err();
+        assert!(matches!(err, BuilderVmError::ExtractionFailed(_)));
+        assert!(err.to_string().contains("result.json"), "got {err}");
+    }
+
+    #[test]
+    fn finalize_install_job_rejects_nonzero_installer_exit() {
+        let scratch = tempfile::TempDir::new().unwrap();
+        // Populate enough of the layout that the missing-artifacts
+        // check doesn't trip first.
+        std::fs::create_dir_all(scratch.path().join("content")).unwrap();
+        std::fs::write(scratch.path().join("sbom.cdx.json"), b"{}").unwrap();
+        std::fs::write(scratch.path().join("fetch.log"), b"").unwrap();
+        std::fs::write(scratch.path().join("cve.json"), b"{}").unwrap();
+        std::fs::write(
+            scratch.path().join(INSTALL_RESULT_FILENAME),
+            br#"{"installer_exit_code":1,"sbom_emitted":false,"cve_emitted":false,"language":"python","gate":"dev","content_path":"/out/content","sbom_path":"/out/sbom.cdx.json","fetch_log_path":"/out/fetch.log","cve_path":"/out/cve.json","failure_reason":"lockfile not found"}"#,
+        )
+        .unwrap();
+        let err = finalize_install_job(scratch.path()).unwrap_err();
+        match err {
+            BuilderVmError::NixBuildFailed(msg) => {
+                assert!(msg.contains("lockfile not found"), "got {msg}");
+            }
+            other => panic!("wrong variant: {other:?}"),
+        }
+    }
+
+    #[test]
+    fn finalize_install_job_returns_install_volume_on_happy_path() {
+        let scratch = tempfile::TempDir::new().unwrap();
+        std::fs::create_dir_all(scratch.path().join("content")).unwrap();
+        std::fs::write(scratch.path().join("sbom.cdx.json"), b"{}").unwrap();
+        std::fs::write(scratch.path().join("fetch.log"), b"").unwrap();
+        std::fs::write(scratch.path().join("cve.json"), b"{}").unwrap();
+        std::fs::write(
+            scratch.path().join(INSTALL_RESULT_FILENAME),
+            br#"{"installer_exit_code":0,"sbom_emitted":true,"cve_emitted":true,"language":"python","gate":"prod","content_path":"/out/content","sbom_path":"/out/sbom.cdx.json","fetch_log_path":"/out/fetch.log","cve_path":"/out/cve.json"}"#,
+        )
+        .unwrap();
+        let art = finalize_install_job(scratch.path()).unwrap();
+        match art {
+            BuilderArtifacts::InstallVolume {
+                volume_dir,
+                result_json_path,
+            } => {
+                assert_eq!(volume_dir, scratch.path());
+                assert_eq!(
+                    result_json_path,
+                    scratch.path().join(INSTALL_RESULT_FILENAME)
+                );
+            }
+            other => panic!("wrong variant: {other:?}"),
+        }
+    }
+
+    #[test]
+    fn finalize_install_job_rejects_missing_sealed_artifact() {
+        let scratch = tempfile::TempDir::new().unwrap();
+        // result.json says success, but the sealed-volume sidecars
+        // are missing. Fail closed so seal_volume doesn't later
+        // chase a half-populated dir.
+        std::fs::write(
+            scratch.path().join(INSTALL_RESULT_FILENAME),
+            br#"{"installer_exit_code":0,"sbom_emitted":true,"cve_emitted":true,"language":"python","gate":"dev","content_path":"/out/content","sbom_path":"/out/sbom.cdx.json","fetch_log_path":"/out/fetch.log","cve_path":"/out/cve.json"}"#,
+        )
+        .unwrap();
+        let err = finalize_install_job(scratch.path()).unwrap_err();
+        assert!(
+            matches!(err, BuilderVmError::ExtractionFailed(_)),
+            "got {err:?}"
+        );
+    }
+
+    #[test]
+    fn finalize_install_job_rejects_malformed_result_json() {
+        let scratch = tempfile::TempDir::new().unwrap();
+        std::fs::write(scratch.path().join(INSTALL_RESULT_FILENAME), b"{not valid").unwrap();
+        let err = finalize_install_job(scratch.path()).unwrap_err();
+        match err {
+            BuilderVmError::ExtractionFailed(msg) => assert!(msg.contains("parsing"), "got {msg}"),
+            other => panic!("wrong variant: {other:?}"),
+        }
     }
 }

--- a/crates/mvm-build/src/libkrun_builder.rs
+++ b/crates/mvm-build/src/libkrun_builder.rs
@@ -63,7 +63,6 @@ use std::sync::{Arc, Mutex};
 use std::time::{Duration, Instant};
 
 use mvm_libkrun::{KrunContext, SupervisorConfig};
-use serde::Deserialize;
 
 use crate::builder_vm::{
     BuilderArtifacts, BuilderJob, BuilderMounts, BuilderVm, BuilderVmDisk, BuilderVmError,
@@ -74,9 +73,11 @@ use crate::builder_vm::{
 // VzBuilderVm path can reuse the same logic without duplicating it.
 // `INSTALL_SPEC_FILENAME` and `shell_single_quote_escape` are
 // imported only inside the test module below; the production path
-// here uses `stage_job_dir` (PR-B-migrate commit 2) and
-// `read_job_result` (PR-B-migrate commit 3).
-use crate::builder_vm_runtime::{read_job_result, stage_job_dir};
+// here uses `stage_job_dir` (commit 2), `read_job_result` (commit 3),
+// and `finalize_flake_job` / `finalize_install_job` (commit 4).
+use crate::builder_vm_runtime::{
+    finalize_flake_job, finalize_install_job, read_job_result, stage_job_dir,
+};
 
 /// Default vCPU count for the builder VM. Nix builds are
 /// embarrassingly parallel at the derivation level; 4 cores is the
@@ -1198,15 +1199,12 @@ fn unique_job_id() -> String {
 // Plan 97 Phase C PR-B-migrate; the `use` at the top of this file
 // pulls it back in for the existing callers.
 
-/// Filename of the install report `mvm-builder-init` writes into
-/// `artifact_out/` after the install pipeline finishes. The host
-/// reads + parses this to decide whether the install succeeded.
-pub(crate) const INSTALL_RESULT_FILENAME: &str = "result.json";
-
-// `stage_job_dir` migrated to `crate::builder_vm_runtime` in Plan 97
-// Phase C PR-B-migrate commit 2. Both libkrun (here) and the
-// future VzBuilderVm path call the same helper, which produces the
-// virtio-fs-share-friendly cmd.sh / install_spec.json.
+// `stage_job_dir`, `shell_single_quote_escape`, `read_job_result`,
+// `JobResult`, `INSTALL_RESULT_FILENAME`, `read_last_bytes_of`,
+// `finalize_flake_job`, `read_revision_hash`, `extract_nix_store_hash`,
+// `finalize_install_job`, and `InstallResultReport` all live in
+// `crate::builder_vm_runtime` so the future VzBuilderVm path can reuse
+// them. Plan 97 Phase C PR-B-migrate commits 2-4.
 
 fn stage_shell_job_dir(job_dir: &Path, script: &str) -> Result<(), BuilderVmError> {
     std::fs::create_dir_all(job_dir).map_err(|e| {
@@ -1217,175 +1215,6 @@ fn stage_shell_job_dir(job_dir: &Path, script: &str) -> Result<(), BuilderVmErro
         BuilderVmError::ExtractionFailed(format!("writing {}: {e}", cmd_path.display()))
     })?;
     Ok(())
-}
-
-// `shell_single_quote_escape` migrated to
-// `crate::builder_vm_runtime` in Plan 97 Phase C PR-B-migrate
-// commit 2.
-
-/// Read the last `max_bytes` of `path` into a `String`, replacing any
-/// invalid UTF-8 lossily. Returns `Err` if the file is missing or
-/// unreadable. Used by `finalize_flake_job` to surface the tail of
-/// `<job_dir>/nix-stderr.log` (the cmd.sh's nix-build stderr capture)
-/// in the failure path without loading a multi-hundred-KB log into
-/// memory.
-fn read_last_bytes_of(path: &Path, max_bytes: u64) -> std::io::Result<String> {
-    use std::io::{Seek, SeekFrom};
-    let mut file = std::fs::File::open(path)?;
-    let len = file.metadata()?.len();
-    let take = max_bytes.min(len);
-    // SeekFrom::End wants i64; max_bytes is bounded to a small constant
-    // at every call site (4 KiB today) so the cast is safe.
-    let offset = i64::try_from(take).unwrap_or(i64::MAX).saturating_neg();
-    file.seek(SeekFrom::End(offset))?;
-    let mut buf = Vec::with_capacity(take as usize);
-    file.read_to_end(&mut buf)?;
-    Ok(String::from_utf8_lossy(&buf).into_owned())
-}
-
-/// Finalize a flake build: read `<job_dir>/result`, validate the
-/// `rootfs.ext4` (and optional `vmlinux`) landed in
-/// `artifact_out`, return a [`BuilderArtifacts::Image`].
-fn finalize_flake_job(
-    job_dir: &Path,
-    artifact_out: &Path,
-    job_id: &str,
-) -> Result<BuilderArtifacts, BuilderVmError> {
-    let result = read_job_result(job_dir)?;
-    if result.exit_code != 0 {
-        // The 20-line `stderr_tail` in `result` is from the OUTER
-        // cmd.sh (run_job captures cmd.sh's stderr into a 20-line
-        // ringbuffer). That ringbuffer typically only carries the
-        // "nix build exited N; tail of stderr:" preamble — not the
-        // real per-derivation failure. The actual nix-build stderr
-        // is at `<job_dir>/nix-stderr.log` (cmd.sh redirects there
-        // via `2> /job/nix-stderr.log`). Surface its tail so the
-        // operator doesn't have to know the convention.
-        let stderr_log = job_dir.join("nix-stderr.log");
-        let derivation_tail = read_last_bytes_of(&stderr_log, 4 * 1024)
-            .unwrap_or_else(|_| String::from("<nix-stderr.log not present on host>"));
-        return Err(BuilderVmError::NixBuildFailed(format!(
-            "guest cmd.sh exited {} — full log: {}\n\
-             outer stderr tail (cmd.sh ringbuffer):\n{}\n\
-             derivation stderr tail (last 4 KiB of {}):\n{}",
-            result.exit_code,
-            stderr_log.display(),
-            result.stderr_tail,
-            stderr_log.display(),
-            derivation_tail,
-        )));
-    }
-
-    let rootfs_path = artifact_out.join("rootfs.ext4");
-    if !rootfs_path.is_file() {
-        return Err(BuilderVmError::ExtractionFailed(format!(
-            "builder VM exited cleanly but {} was not written",
-            rootfs_path.display()
-        )));
-    }
-    let kernel_path_out = artifact_out.join("vmlinux");
-    let kernel_path = if kernel_path_out.is_file() {
-        Some(kernel_path_out)
-    } else {
-        None
-    };
-
-    Ok(BuilderArtifacts::Image {
-        rootfs_path,
-        kernel_path,
-        revision_hash: read_revision_hash(job_dir).unwrap_or_else(|| job_id.to_string()),
-        lock_hash: None,
-        accessible: None,
-    })
-}
-
-/// Read `/job/store-path` and extract the leading Nix store hash
-/// from `/nix/store/<hash>-<name>`. Older guest images may not
-/// write the sidecar; those callers fall back to the unique job id.
-fn read_revision_hash(job_dir: &Path) -> Option<String> {
-    let body = std::fs::read_to_string(job_dir.join("store-path")).ok()?;
-    extract_nix_store_hash(body.trim()).map(str::to_string)
-}
-
-fn extract_nix_store_hash(store_path: &str) -> Option<&str> {
-    let name = store_path.strip_prefix("/nix/store/")?;
-    let (hash, _rest) = name.split_once('-')?;
-    if hash.is_empty() { None } else { Some(hash) }
-}
-
-/// Finalize an install job (Plan 73 Followup B.2): validate the
-/// install report `mvm-builder-init` wrote to
-/// `<artifact_out>/result.json`, fail closed on `installer_exit_code
-/// != 0`, and return [`BuilderArtifacts::InstallVolume`] pointing
-/// at the directory. Sealing the volume (via
-/// `mvm_sdk::compile::deps_audit::seal_volume`) and renaming into
-/// the deps cache is the orchestrator's job
-/// (`mvm_build::app_deps::install_app_deps`) — keeping it out of
-/// the builder VM means the same code path covers fresh installs
-/// and cache rehydrations.
-fn finalize_install_job(artifact_out: &Path) -> Result<BuilderArtifacts, BuilderVmError> {
-    let result_path = artifact_out.join(INSTALL_RESULT_FILENAME);
-    if !result_path.is_file() {
-        return Err(BuilderVmError::ExtractionFailed(format!(
-            "install job VM exited cleanly but {} was not written",
-            result_path.display()
-        )));
-    }
-    let body = std::fs::read_to_string(&result_path).map_err(|e| {
-        BuilderVmError::ExtractionFailed(format!("reading {}: {e}", result_path.display()))
-    })?;
-    let report: InstallResultReport = serde_json::from_str(&body).map_err(|e| {
-        BuilderVmError::ExtractionFailed(format!(
-            "parsing {} as JSON: {e}\nbody:\n{body}",
-            result_path.display()
-        ))
-    })?;
-
-    if report.installer_exit_code != 0 {
-        let reason = report
-            .failure_reason
-            .clone()
-            .unwrap_or_else(|| format!("installer exited {}", report.installer_exit_code));
-        return Err(BuilderVmError::NixBuildFailed(format!(
-            "install pipeline failed inside builder VM: {reason}"
-        )));
-    }
-
-    // The four sealed-volume artifacts must all be present —
-    // mvm-builder-init emits stubs on missing optional tooling
-    // (SBOM / CVE) so absence here means the guest crashed mid-
-    // pipeline. seal_volume would catch this too, but failing
-    // closed at the builder layer pins the error to the right
-    // diagnostic message.
-    for name in ["content", "sbom.cdx.json", "fetch.log", "cve.json"] {
-        let p = artifact_out.join(name);
-        if !p.exists() {
-            return Err(BuilderVmError::ExtractionFailed(format!(
-                "install job VM exited cleanly but sealed-volume artifact {} is missing",
-                p.display()
-            )));
-        }
-    }
-
-    Ok(BuilderArtifacts::InstallVolume {
-        volume_dir: artifact_out.to_path_buf(),
-        result_json_path: result_path,
-    })
-}
-
-/// Parsed shape of `<artifact_out>/result.json` — the install
-/// report `mvm-builder-init::install::InstallReport::to_json`
-/// emits. Field set kept in sync with the writer; an additive
-/// change to the writer (B.2.x egress allowlist diagnostics, for
-/// example) needs a matching `#[serde(default)]` field here.
-#[derive(Debug, Deserialize)]
-struct InstallResultReport {
-    installer_exit_code: i32,
-    /// Set when `mvm-builder-init` synthesizes a failure report
-    /// (e.g. installer binary missing on PATH). Surfaced in the
-    /// host-side error message.
-    #[serde(default)]
-    failure_reason: Option<String>,
 }
 
 /// Locate the `mvm-libkrun-supervisor` binary. Mirrors the
@@ -2470,96 +2299,9 @@ mod tests {
         );
     }
 
-    #[test]
-    fn finalize_install_job_requires_result_json() {
-        // Empty artifact dir → ExtractionFailed pointing at the
-        // missing result.json. Surfaces guest crashes that
-        // prevented mvm-builder-init from finalizing the report.
-        let scratch = TempDir::new().unwrap();
-        let err = finalize_install_job(scratch.path()).unwrap_err();
-        assert!(matches!(err, BuilderVmError::ExtractionFailed(_)));
-        assert!(err.to_string().contains("result.json"), "got {err}");
-    }
-
-    #[test]
-    fn finalize_install_job_rejects_nonzero_installer_exit() {
-        let scratch = TempDir::new().unwrap();
-        // Populate enough of the layout that the missing-artifacts
-        // check doesn't trip first.
-        std::fs::create_dir_all(scratch.path().join("content")).unwrap();
-        std::fs::write(scratch.path().join("sbom.cdx.json"), b"{}").unwrap();
-        std::fs::write(scratch.path().join("fetch.log"), b"").unwrap();
-        std::fs::write(scratch.path().join("cve.json"), b"{}").unwrap();
-        std::fs::write(
-            scratch.path().join(INSTALL_RESULT_FILENAME),
-            br#"{"installer_exit_code":1,"sbom_emitted":false,"cve_emitted":false,"language":"python","gate":"dev","content_path":"/out/content","sbom_path":"/out/sbom.cdx.json","fetch_log_path":"/out/fetch.log","cve_path":"/out/cve.json","failure_reason":"lockfile not found"}"#,
-        )
-        .unwrap();
-        let err = finalize_install_job(scratch.path()).unwrap_err();
-        match err {
-            BuilderVmError::NixBuildFailed(msg) => {
-                assert!(msg.contains("lockfile not found"), "got {msg}");
-            }
-            other => panic!("wrong variant: {other:?}"),
-        }
-    }
-
-    #[test]
-    fn finalize_install_job_returns_install_volume_on_happy_path() {
-        let scratch = TempDir::new().unwrap();
-        std::fs::create_dir_all(scratch.path().join("content")).unwrap();
-        std::fs::write(scratch.path().join("sbom.cdx.json"), b"{}").unwrap();
-        std::fs::write(scratch.path().join("fetch.log"), b"").unwrap();
-        std::fs::write(scratch.path().join("cve.json"), b"{}").unwrap();
-        std::fs::write(
-            scratch.path().join(INSTALL_RESULT_FILENAME),
-            br#"{"installer_exit_code":0,"sbom_emitted":true,"cve_emitted":true,"language":"python","gate":"prod","content_path":"/out/content","sbom_path":"/out/sbom.cdx.json","fetch_log_path":"/out/fetch.log","cve_path":"/out/cve.json"}"#,
-        )
-        .unwrap();
-        let art = finalize_install_job(scratch.path()).unwrap();
-        match art {
-            BuilderArtifacts::InstallVolume {
-                volume_dir,
-                result_json_path,
-            } => {
-                assert_eq!(volume_dir, scratch.path());
-                assert_eq!(
-                    result_json_path,
-                    scratch.path().join(INSTALL_RESULT_FILENAME)
-                );
-            }
-            other => panic!("wrong variant: {other:?}"),
-        }
-    }
-
-    #[test]
-    fn finalize_install_job_rejects_missing_sealed_artifact() {
-        let scratch = TempDir::new().unwrap();
-        // result.json says success, but the sealed-volume sidecars
-        // are missing. Fail closed so seal_volume doesn't later
-        // chase a half-populated dir.
-        std::fs::write(
-            scratch.path().join(INSTALL_RESULT_FILENAME),
-            br#"{"installer_exit_code":0,"sbom_emitted":true,"cve_emitted":true,"language":"python","gate":"dev","content_path":"/out/content","sbom_path":"/out/sbom.cdx.json","fetch_log_path":"/out/fetch.log","cve_path":"/out/cve.json"}"#,
-        )
-        .unwrap();
-        let err = finalize_install_job(scratch.path()).unwrap_err();
-        assert!(
-            matches!(err, BuilderVmError::ExtractionFailed(_)),
-            "got {err:?}"
-        );
-    }
-
-    #[test]
-    fn finalize_install_job_rejects_malformed_result_json() {
-        let scratch = TempDir::new().unwrap();
-        std::fs::write(scratch.path().join(INSTALL_RESULT_FILENAME), b"{not valid").unwrap();
-        let err = finalize_install_job(scratch.path()).unwrap_err();
-        match err {
-            BuilderVmError::ExtractionFailed(msg) => assert!(msg.contains("parsing"), "got {msg}"),
-            other => panic!("wrong variant: {other:?}"),
-        }
-    }
+    // `finalize_install_job_*` test coverage migrated to
+    // `builder_vm_runtime` alongside the function itself. Plan 97
+    // Phase C PR-B-migrate commit 4.
 
     #[test]
     fn run_build_fails_validation_before_reaching_libkrun() {
@@ -2648,190 +2390,10 @@ mod tests {
         );
     }
 
-    // `read_job_result_*` test coverage migrated to
-    // `builder_vm_runtime` alongside the function itself. Plan 97
-    // Phase C PR-B-migrate commit 3.
-
-    #[test]
-    fn extract_nix_store_hash_parses_output_path() {
-        assert_eq!(
-            extract_nix_store_hash("/nix/store/abc123def4567890-tenant-rootfs"),
-            Some("abc123def4567890")
-        );
-        assert_eq!(extract_nix_store_hash("/tmp/not-store"), None);
-        assert_eq!(extract_nix_store_hash("/nix/store/-missing-hash"), None);
-    }
-
-    #[test]
-    fn finalize_flake_job_uses_store_path_hash_when_present() {
-        let scratch = TempDir::new().unwrap();
-        let job_dir = scratch.path().join("job");
-        let artifact_out = scratch.path().join("out");
-        std::fs::create_dir_all(&job_dir).unwrap();
-        std::fs::create_dir_all(&artifact_out).unwrap();
-        std::fs::write(
-            job_dir.join("result"),
-            r#"{"exit_code":0,"stderr_tail":""}"#,
-        )
-        .unwrap();
-        std::fs::write(
-            job_dir.join("store-path"),
-            "/nix/store/deadbeefcafebabe-builder-vm\n",
-        )
-        .unwrap();
-        std::fs::write(artifact_out.join("rootfs.ext4"), b"rootfs").unwrap();
-
-        let artifacts = finalize_flake_job(&job_dir, &artifact_out, "fallback-job-id").unwrap();
-        match artifacts {
-            BuilderArtifacts::Image { revision_hash, .. } => {
-                assert_eq!(revision_hash, "deadbeefcafebabe");
-            }
-            other => panic!("wrong artifact variant: {other:?}"),
-        }
-    }
-
-    #[test]
-    fn finalize_flake_job_falls_back_to_job_id_without_store_path() {
-        let scratch = TempDir::new().unwrap();
-        let job_dir = scratch.path().join("job");
-        let artifact_out = scratch.path().join("out");
-        std::fs::create_dir_all(&job_dir).unwrap();
-        std::fs::create_dir_all(&artifact_out).unwrap();
-        std::fs::write(
-            job_dir.join("result"),
-            r#"{"exit_code":0,"stderr_tail":""}"#,
-        )
-        .unwrap();
-        std::fs::write(artifact_out.join("rootfs.ext4"), b"rootfs").unwrap();
-
-        let artifacts = finalize_flake_job(&job_dir, &artifact_out, "fallback-job-id").unwrap();
-        match artifacts {
-            BuilderArtifacts::Image { revision_hash, .. } => {
-                assert_eq!(revision_hash, "fallback-job-id");
-            }
-            other => panic!("wrong artifact variant: {other:?}"),
-        }
-    }
-
-    /// `read_last_bytes_of` returns the trailing `max_bytes` of a
-    /// file. When the file is larger than the cap, we get the *end*,
-    /// not the head — the use case is tailing nix-build stderr where
-    /// the cause-of-death is at the bottom.
-    #[test]
-    fn read_last_bytes_of_returns_trailing_window_when_file_exceeds_cap() {
-        let scratch = TempDir::new().unwrap();
-        let path = scratch.path().join("log");
-        let mut body = String::new();
-        for i in 0..2_000 {
-            body.push_str(&format!("line {i}\n"));
-        }
-        std::fs::write(&path, &body).unwrap();
-        let tail = read_last_bytes_of(&path, 200).unwrap();
-        assert!(tail.len() <= 200);
-        assert!(tail.contains("line 1999"), "tail contains the last line");
-        assert!(
-            !tail.contains("line 0\n"),
-            "tail does not include the head: {tail}"
-        );
-    }
-
-    /// Small file: the helper returns the whole file (capped at its
-    /// real length, not the requested max).
-    #[test]
-    fn read_last_bytes_of_returns_entire_file_when_smaller_than_cap() {
-        let scratch = TempDir::new().unwrap();
-        let path = scratch.path().join("log");
-        std::fs::write(&path, b"hello world").unwrap();
-        let tail = read_last_bytes_of(&path, 4096).unwrap();
-        assert_eq!(tail, "hello world");
-    }
-
-    /// Missing file surfaces as an `io::Error`; the caller in
-    /// `finalize_flake_job` swallows it into a `<not present>`
-    /// sentinel rather than failing the whole error format.
-    #[test]
-    fn read_last_bytes_of_errors_on_missing_file() {
-        let scratch = TempDir::new().unwrap();
-        let err = read_last_bytes_of(&scratch.path().join("missing"), 1024).unwrap_err();
-        assert_eq!(err.kind(), std::io::ErrorKind::NotFound);
-    }
-
-    /// The failure-path error message names the nix-stderr.log path
-    /// AND inlines its tail. This is the diagnostic-surface fix —
-    /// before the change, callers got the outer cmd.sh ringbuffer
-    /// only, with no hint where the real log lived.
-    #[test]
-    fn finalize_flake_job_failure_includes_nix_stderr_log_path_and_tail() {
-        let scratch = TempDir::new().unwrap();
-        let job_dir = scratch.path().join("job");
-        let artifact_out = scratch.path().join("out");
-        std::fs::create_dir_all(&job_dir).unwrap();
-        std::fs::create_dir_all(&artifact_out).unwrap();
-        std::fs::write(
-            job_dir.join("result"),
-            r#"{"exit_code":1,"stderr_tail":"outer-tail"}"#,
-        )
-        .unwrap();
-        // Sentinel string the helper must surface — proves we're
-        // reading from THIS file and not from the outer ringbuffer.
-        std::fs::write(
-            job_dir.join("nix-stderr.log"),
-            "/nix/store/.../cargo-install-hook.sh: line 27: /dev/fd/63: No such file or directory\n",
-        )
-        .unwrap();
-
-        let err = finalize_flake_job(&job_dir, &artifact_out, "job-id").unwrap_err();
-        let msg = match err {
-            BuilderVmError::NixBuildFailed(s) => s,
-            other => panic!("expected NixBuildFailed, got {other:?}"),
-        };
-        assert!(msg.contains("exited 1"), "names exit code: {msg}");
-        let log_path = job_dir.join("nix-stderr.log");
-        assert!(
-            msg.contains(&*log_path.to_string_lossy()),
-            "names the full log path: {msg}"
-        );
-        assert!(
-            msg.contains("/dev/fd/63: No such file or directory"),
-            "inlines the real derivation stderr tail: {msg}"
-        );
-        assert!(
-            msg.contains("outer-tail"),
-            "still includes the outer ringbuffer for context: {msg}"
-        );
-    }
-
-    /// Missing `nix-stderr.log` doesn't crash the formatter — we get
-    /// a clean sentinel instead of an `Err(...)` cascade. This
-    /// matters for very-early failures (e.g. cmd.sh exit before the
-    /// `2> /job/nix-stderr.log` redirect runs).
-    #[test]
-    fn finalize_flake_job_failure_handles_missing_nix_stderr_log_cleanly() {
-        let scratch = TempDir::new().unwrap();
-        let job_dir = scratch.path().join("job");
-        let artifact_out = scratch.path().join("out");
-        std::fs::create_dir_all(&job_dir).unwrap();
-        std::fs::create_dir_all(&artifact_out).unwrap();
-        std::fs::write(
-            job_dir.join("result"),
-            r#"{"exit_code":2,"stderr_tail":"no cmd.sh"}"#,
-        )
-        .unwrap();
-
-        let err = finalize_flake_job(&job_dir, &artifact_out, "job-id").unwrap_err();
-        let msg = match err {
-            BuilderVmError::NixBuildFailed(s) => s,
-            other => panic!("expected NixBuildFailed, got {other:?}"),
-        };
-        assert!(
-            msg.contains("<nix-stderr.log not present on host>"),
-            "sentinel surfaces in place of missing log: {msg}"
-        );
-        assert!(
-            msg.contains("no cmd.sh"),
-            "outer tail still surfaces: {msg}"
-        );
-    }
+    // `read_job_result_*`, `extract_nix_store_hash_*`,
+    // `finalize_flake_job_*`, `read_last_bytes_of_*` test coverage
+    // migrated to `builder_vm_runtime` alongside the functions
+    // themselves. Plan 97 Phase C PR-B-migrate commits 3-4.
 
     #[test]
     fn acquire_nix_store_image_lock_creates_sparse_file_once() {


### PR DESCRIPTION
## Summary

Third Plan 97 Phase C migration — lifts artifact finalisation out of `LibkrunBuilderVm` (now ~2,950 lines, down ~470 from where it started). **Stacked on #435** ($JobResult / read_job_result), which is stacked on `main`.

This slice migrates the artifact-finalisation layer end-to-end:
- `finalize_flake_job` — rootfs + kernel + revision-hash resolution from a completed builder run
- `finalize_install_job` — install report + sealed-volume validation (Plan 73 Followup B.2 contract)
- Helpers: `INSTALL_RESULT_FILENAME` const, `read_last_bytes_of`, `read_revision_hash`, `extract_nix_store_hash`, `InstallResultReport`

All are pure host-side I/O against the `/job` and `/out` virtio-fs shares — libkrun and Vz attach them identically, so the future `VzBuilderVm` can call these verbatim.

## Changes

- `crates/mvm-build/src/builder_vm_runtime.rs` — adds 7 production items (all `pub` matching `stage_job_dir` / `read_job_result` convention) and 13 unit tests (the originals from libkrun_builder.rs).
- `crates/mvm-build/src/libkrun_builder.rs` — removes the 7 items + their 13 tests; extends the migration use-import to include `finalize_flake_job` and `finalize_install_job`. The two production call sites in `BuilderVm::run_build`'s dispatch are unchanged (use the imported names). `serde::Deserialize` import drops (both `JobResult` and `InstallResultReport` have left).

Net: +468 / −457, two files.

## Test plan

- [x] `cargo test --workspace` — all green
- [x] `cargo test -p mvm-build --features builder-vm` — 308 + sibling-module tests all green
- [x] `cargo clippy --workspace --all-targets -- -D warnings` — clean
- [x] `cargo fmt --all -- --check` — clean
- [x] Test relocation verified via `cargo test -- --list`: 17 tests at `builder_vm_runtime::tests::*`, 0 stragglers at `libkrun_builder::tests::*` for the migrated names

## Next slice

Per Plan 97 §"Phase C seam design", remaining migrations: `NixStoreImageLock` (the load-bearing host-side file lock), stderr-tail capture from the cmd.sh ringbuffer, wall-clock timeout handling. After those, the seam is ready and `VzBuilderVm` (~400 + ~200 lines mount glue) becomes the natural next PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)