### PR TITLE
Plan 97 Phase C PR-B-migrate: NixStoreImageLock (fourth migration)

### DIFF
--- a/crates/mvm-build/src/builder_vm_runtime.rs
+++ b/crates/mvm-build/src/builder_vm_runtime.rs
@@ -31,7 +31,7 @@
 //! verifiable: build + existing tests stay green, and the new
 //! helper methods get their own unit tests.
 
-use std::path::Path;
+use std::path::{Path, PathBuf};
 
 use serde::Deserialize;
 
@@ -472,6 +472,129 @@ pub fn finalize_install_job(artifact_out: &Path) -> Result<BuilderArtifacts, Bui
     })
 }
 
+/// Host-side exclusive lock on the persistent `/nix-store` sparse image.
+///
+/// The builder VM attaches this file as a writable virtio-blk device;
+/// the guest's `mvm-builder-init` mounts it as ext4 at `/nix-store`.
+/// Two independent guests mounting the same ext4 image read-write can
+/// corrupt the filesystem, so the host holds an exclusive `flock` for
+/// the full VM lifetime.
+///
+/// `_file: std::fs::File` is **load-bearing** — dropping the guard
+/// releases the lock. Callers must keep the guard alive until the
+/// supervisor exits and all artifact reads are done. The seam design
+/// in Plan 97 §"Phase C seam design" calls this out explicitly because
+/// an underscore-prefixed field reads as inert; it isn't.
+///
+/// Hypervisor-agnostic: both libkrun and Vz attach the same image
+/// path as a virtio-blk device. Migrated from `libkrun_builder.rs` in
+/// Plan 97 Phase C PR-B-migrate (fourth migration after
+/// `finalize_flake_job` / `finalize_install_job`).
+#[derive(Debug)]
+pub struct NixStoreImageLock {
+    path: PathBuf,
+    _file: std::fs::File,
+}
+
+impl NixStoreImageLock {
+    /// Path to the locked image file. Callers pass this into the
+    /// hypervisor as the `virtio-blk` device backing.
+    pub fn path(&self) -> &Path {
+        &self.path
+    }
+}
+
+/// Find or create the persistent `<builder_cache_dir>/nix-store-<arch>.img`
+/// sparse image and hold an exclusive host-side lock on it.
+///
+/// `builder_cache_dir` is the host-side root the builder VM uses for
+/// shared state — callers compute this themselves (typically
+/// `~/.cache/mvm/builder-vm/`) so the helper stays free of
+/// `mvm_core::config` lookups. The directory is created if missing.
+///
+/// `arch` only appears in the filename (`nix-store-<arch>.img`) so
+/// multi-arch hosts can keep one image per arch in the same cache.
+///
+/// `size_mib` is the sparse cap — the file consumes only the bytes
+/// the in-VM ext4 actually writes. Caller-controlled because dev
+/// hosts may want a smaller cap than CI runners.
+///
+/// Returns a [`NixStoreImageLock`] guard. Dropping it releases the
+/// lock — see the type docs.
+pub fn acquire_nix_store_image_lock(
+    builder_cache_dir: &Path,
+    arch: &str,
+    size_mib: u64,
+) -> Result<NixStoreImageLock, BuilderVmError> {
+    use fs2::FileExt;
+
+    std::fs::create_dir_all(builder_cache_dir).map_err(|e| {
+        BuilderVmError::ExtractionFailed(format!(
+            "creating builder cache dir {}: {e}",
+            builder_cache_dir.display()
+        ))
+    })?;
+    let path = builder_cache_dir.join(format!("nix-store-{arch}.img"));
+    let existed_before_open = path.exists();
+
+    let file = std::fs::OpenOptions::new()
+        .read(true)
+        .write(true)
+        .create(true)
+        .truncate(false)
+        .open(&path)
+        .map_err(|e| BuilderVmError::ExtractionFailed(format!("open {}: {e}", path.display())))?;
+
+    file.try_lock_exclusive().map_err(|e| {
+        BuilderVmError::ExtractionFailed(format!(
+            "nix-store image {} is already attached by another builder VM process; \
+             wait for the running `mvmctl build` / `mvmctl deps install` to finish and retry: {e}",
+            path.display()
+        ))
+    })?;
+
+    // Allocate a sparse file: open with O_CREAT, seek to size-1,
+    // write a zero byte. The filesystem records the size but
+    // doesn't allocate the blocks until something writes them
+    // (true on APFS + ext4). Avoids paying multi-GiB at provision
+    // time for a store that may never fill up.
+    let size_bytes = size_mib.checked_mul(1024 * 1024).ok_or_else(|| {
+        BuilderVmError::ExtractionFailed(format!(
+            "nix-store size_mib overflowed multiplying to bytes: {size_mib}"
+        ))
+    })?;
+
+    let current_len = file.metadata().map_err(|e| {
+        BuilderVmError::ExtractionFailed(format!("metadata {}: {e}", path.display()))
+    })?;
+    if current_len.len() == 0 {
+        file.set_len(size_bytes).map_err(|e| {
+            if !existed_before_open {
+                let _ = std::fs::remove_file(&path);
+            }
+            BuilderVmError::ExtractionFailed(format!(
+                "set_len({size_bytes}) on {}: {e}",
+                path.display()
+            ))
+        })?;
+    }
+
+    let current_len = file.metadata().map_err(|e| {
+        BuilderVmError::ExtractionFailed(format!("metadata {}: {e}", path.display()))
+    })?;
+    if current_len.len() == 0 {
+        if !existed_before_open {
+            let _ = std::fs::remove_file(&path);
+        }
+        return Err(BuilderVmError::ExtractionFailed(format!(
+            "nix-store image {} stayed empty after sparse allocation",
+            path.display()
+        )));
+    }
+
+    Ok(NixStoreImageLock { path, _file: file })
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -872,5 +995,78 @@ mod tests {
             BuilderVmError::ExtractionFailed(msg) => assert!(msg.contains("parsing"), "got {msg}"),
             other => panic!("wrong variant: {other:?}"),
         }
+    }
+
+    // -----------------------------------------------------------------
+    // Tests migrated from libkrun_builder.rs alongside NixStoreImageLock
+    // and acquire_nix_store_image_lock (Plan 97 Phase C PR-B-migrate
+    // commit 5). The new signature takes the cache dir as a &Path arg,
+    // so the XDG_CACHE_HOME env hack from the old tests is gone — each
+    // test passes a fresh TempDir path directly and runs without
+    // process-wide env mutation.
+    // -----------------------------------------------------------------
+
+    #[test]
+    fn acquire_nix_store_image_lock_creates_sparse_file_once() {
+        // Sparse file allocates the logical size but consumes ~no disk
+        // blocks. `set_len` is what asks the FS to record the size. A
+        // later acquisition finds the existing file and returns its
+        // path without retouching.
+        let scratch = tempfile::TempDir::new().unwrap();
+        let cache_dir = scratch.path().join("builder-vm");
+        let guard = acquire_nix_store_image_lock(&cache_dir, "x86_64", 256).unwrap();
+        let path = guard.path().to_path_buf();
+        assert!(path.is_file());
+        assert_eq!(std::fs::metadata(&path).unwrap().len(), 256 * 1024 * 1024);
+        drop(guard);
+        // Second acquisition is idempotent.
+        let guard2 = acquire_nix_store_image_lock(&cache_dir, "x86_64", 256).unwrap();
+        let path2 = guard2.path().to_path_buf();
+        assert_eq!(path, path2);
+        drop(guard2);
+    }
+
+    #[test]
+    fn acquire_nix_store_image_lock_refuses_concurrent_writer() {
+        let scratch = tempfile::TempDir::new().unwrap();
+        let cache_dir = scratch.path().join("builder-vm");
+
+        let first = acquire_nix_store_image_lock(&cache_dir, "x86_64", 256).unwrap();
+        let err = acquire_nix_store_image_lock(&cache_dir, "x86_64", 256).unwrap_err();
+        let msg = format!("{err}");
+        assert!(
+            msg.contains("already attached by another builder VM process"),
+            "unexpected error: {msg}"
+        );
+        drop(first);
+
+        acquire_nix_store_image_lock(&cache_dir, "x86_64", 256)
+            .expect("lock should be available after first guard drops");
+    }
+
+    #[test]
+    fn acquire_nix_store_image_lock_filename_carries_arch() {
+        // Multi-arch hosts can keep one image per arch in the same
+        // cache. Pin the filename convention so a future refactor that
+        // collapses the arch out of the path doesn't silently break it.
+        let scratch = tempfile::TempDir::new().unwrap();
+        let cache_dir = scratch.path().join("builder-vm");
+        let guard = acquire_nix_store_image_lock(&cache_dir, "aarch64", 64).unwrap();
+        assert_eq!(
+            guard.path().file_name().and_then(|s| s.to_str()),
+            Some("nix-store-aarch64.img")
+        );
+    }
+
+    #[test]
+    fn acquire_nix_store_image_lock_creates_missing_cache_dir() {
+        // `create_dir_all` is part of the contract — callers pass the
+        // computed `~/.cache/mvm/builder-vm/` path and expect it to be
+        // created on demand.
+        let scratch = tempfile::TempDir::new().unwrap();
+        let cache_dir = scratch.path().join("not").join("yet").join("created");
+        let guard = acquire_nix_store_image_lock(&cache_dir, "x86_64", 16).unwrap();
+        assert!(guard.path().is_file());
+        assert!(cache_dir.is_dir());
     }
 }

--- a/crates/mvm-build/src/libkrun_builder.rs
+++ b/crates/mvm-build/src/libkrun_builder.rs
@@ -74,9 +74,11 @@ use crate::builder_vm::{
 // `INSTALL_SPEC_FILENAME` and `shell_single_quote_escape` are
 // imported only inside the test module below; the production path
 // here uses `stage_job_dir` (commit 2), `read_job_result` (commit 3),
-// and `finalize_flake_job` / `finalize_install_job` (commit 4).
+// `finalize_flake_job` / `finalize_install_job` (commit 4), and
+// `NixStoreImageLock` / `acquire_nix_store_image_lock` (commit 5).
 use crate::builder_vm_runtime::{
-    finalize_flake_job, finalize_install_job, read_job_result, stage_job_dir,
+    NixStoreImageLock, acquire_nix_store_image_lock, finalize_flake_job, finalize_install_job,
+    read_job_result, stage_job_dir,
 };
 
 /// Default vCPU count for the builder VM. Nix builds are
@@ -409,8 +411,11 @@ impl LibkrunBuilderVm {
             Some(image) => image.clone(),
             None => ensure_builder_vm_image()?,
         };
-        let nix_store_lock =
-            acquire_nix_store_image_lock(host_arch_tag(), u64::from(self.nix_store_mib))?;
+        let nix_store_lock = acquire_nix_store_image_lock(
+            &builder_vm_cache_dir(),
+            host_arch_tag(),
+            u64::from(self.nix_store_mib),
+        )?;
 
         let job_id = unique_job_id();
         let job_dir = builder_vm_cache_dir().join("jobs").join(&job_id);
@@ -669,8 +674,11 @@ impl BuilderVm for LibkrunBuilderVm {
         //    virtio-blk image. First build on a host pays the
         //    sparse-allocate cost; subsequent builds reuse the
         //    warm Nix store.
-        let nix_store_lock =
-            acquire_nix_store_image_lock(host_arch_tag(), u64::from(self.nix_store_mib))?;
+        let nix_store_lock = acquire_nix_store_image_lock(
+            &builder_vm_cache_dir(),
+            host_arch_tag(),
+            u64::from(self.nix_store_mib),
+        )?;
 
         // 6. Stage the per-build job dir. Flake jobs get
         //    `cmd.sh`; install jobs get `install_spec.json`.
@@ -1080,105 +1088,6 @@ fn ensure_builder_vm_image() -> Result<BuilderVmImage, BuilderVmError> {
         .to_string();
 
     Ok(BuilderVmImage::new(kernel_path, rootfs_path, cmdline))
-}
-
-#[derive(Debug)]
-struct NixStoreImageLock {
-    path: PathBuf,
-    _file: std::fs::File,
-}
-
-impl NixStoreImageLock {
-    fn path(&self) -> &Path {
-        &self.path
-    }
-}
-
-/// Find or create the persistent `/nix-store` sparse image and hold
-/// an exclusive host-side lock on it.
-///
-/// libkrun attaches this file as a writable virtio-blk device; the
-/// guest's `mvm-builder-init` then mounts it as ext4 at `/nix-store`.
-/// Two independent guests mounting the same ext4 image read-write can
-/// corrupt the filesystem, so callers must keep the returned guard in
-/// scope for the full VM lifetime (spawn supervisor, wait for poweroff,
-/// and read result artifacts). Dropping the guard releases the lock.
-///
-/// `size_mib` is the sparse cap — the file consumes only the bytes the
-/// in-VM ext4 actually writes. Caller-controlled because dev hosts may
-/// want a smaller cap than CI runners.
-fn acquire_nix_store_image_lock(
-    arch: &str,
-    size_mib: u64,
-) -> Result<NixStoreImageLock, BuilderVmError> {
-    use fs2::FileExt;
-
-    let dir = builder_vm_cache_dir();
-    std::fs::create_dir_all(&dir).map_err(|e| {
-        BuilderVmError::ExtractionFailed(format!(
-            "creating builder cache dir {}: {e}",
-            dir.display()
-        ))
-    })?;
-    let path = dir.join(format!("nix-store-{arch}.img"));
-    let existed_before_open = path.exists();
-
-    let file = std::fs::OpenOptions::new()
-        .read(true)
-        .write(true)
-        .create(true)
-        .truncate(false)
-        .open(&path)
-        .map_err(|e| BuilderVmError::ExtractionFailed(format!("open {}: {e}", path.display())))?;
-
-    file.try_lock_exclusive().map_err(|e| {
-        BuilderVmError::ExtractionFailed(format!(
-            "nix-store image {} is already attached by another builder VM process; \
-             wait for the running `mvmctl build` / `mvmctl deps install` to finish and retry: {e}",
-            path.display()
-        ))
-    })?;
-
-    // Allocate a sparse file: open with O_CREAT, seek to size-1,
-    // write a zero byte. The filesystem records the size but
-    // doesn't allocate the blocks until something writes them
-    // (true on APFS + ext4). Avoids paying multi-GiB at provision
-    // time for a store that may never fill up.
-    let size_bytes = size_mib.checked_mul(1024 * 1024).ok_or_else(|| {
-        BuilderVmError::ExtractionFailed(format!(
-            "nix-store size_mib overflowed multiplying to bytes: {size_mib}"
-        ))
-    })?;
-
-    let current_len = file.metadata().map_err(|e| {
-        BuilderVmError::ExtractionFailed(format!("metadata {}: {e}", path.display()))
-    })?;
-    if current_len.len() == 0 {
-        file.set_len(size_bytes).map_err(|e| {
-            if !existed_before_open {
-                let _ = std::fs::remove_file(&path);
-            }
-            BuilderVmError::ExtractionFailed(format!(
-                "set_len({size_bytes}) on {}: {e}",
-                path.display()
-            ))
-        })?;
-    }
-
-    let current_len = file.metadata().map_err(|e| {
-        BuilderVmError::ExtractionFailed(format!("metadata {}: {e}", path.display()))
-    })?;
-    if current_len.len() == 0 {
-        if !existed_before_open {
-            let _ = std::fs::remove_file(&path);
-        }
-        return Err(BuilderVmError::ExtractionFailed(format!(
-            "nix-store image {} stayed empty after sparse allocation",
-            path.display()
-        )));
-    }
-
-    Ok(NixStoreImageLock { path, _file: file })
 }
 
 /// Monotonic per-process job ID. Combines a UNIX timestamp
@@ -1863,8 +1772,11 @@ impl LibkrunPersistentBuilderVm {
         // persistent VM is up would otherwise corrupt the shared
         // ext4. Held inside the handle; released on drop / kill /
         // wait_for_shutdown.
-        let nix_store_lock =
-            acquire_nix_store_image_lock(host_arch_tag(), u64::from(self.nix_store_mib))?;
+        let nix_store_lock = acquire_nix_store_image_lock(
+            &builder_vm_cache_dir(),
+            host_arch_tag(),
+            u64::from(self.nix_store_mib),
+        )?;
 
         let session_id = unique_job_id();
         let job_dir = builder_vm_cache_dir().join("jobs").join(&session_id);
@@ -2391,74 +2303,10 @@ mod tests {
     }
 
     // `read_job_result_*`, `extract_nix_store_hash_*`,
-    // `finalize_flake_job_*`, `read_last_bytes_of_*` test coverage
-    // migrated to `builder_vm_runtime` alongside the functions
-    // themselves. Plan 97 Phase C PR-B-migrate commits 3-4.
-
-    #[test]
-    fn acquire_nix_store_image_lock_creates_sparse_file_once() {
-        let _lock = ENV_LOCK.lock().unwrap();
-        // Sparse file allocates the logical size but consumes
-        // ~no disk blocks. `set_len` is what asks the FS to
-        // record the size. A later acquisition finds the existing
-        // file and returns its path without retouching.
-        let scratch = TempDir::new().unwrap();
-        // Redirect the cache dir via XDG_CACHE_HOME to keep the
-        // test hermetic — `mvm_core::config::mvm_cache_dir()`
-        // honors the env var.
-        let old = std::env::var("XDG_CACHE_HOME").ok();
-        // SAFETY: tests run single-threaded for env mutation
-        unsafe {
-            std::env::set_var("XDG_CACHE_HOME", scratch.path());
-        }
-        let guard = acquire_nix_store_image_lock("x86_64", 256).unwrap();
-        let path = guard.path().to_path_buf();
-        assert!(path.is_file());
-        assert_eq!(std::fs::metadata(&path).unwrap().len(), 256 * 1024 * 1024);
-        drop(guard);
-        // Second acquisition is idempotent.
-        let guard2 = acquire_nix_store_image_lock("x86_64", 256).unwrap();
-        let path2 = guard2.path().to_path_buf();
-        assert_eq!(path, path2);
-        drop(guard2);
-        // Restore the previous env so we don't leak into the
-        // rest of the test suite.
-        unsafe {
-            match old {
-                Some(v) => std::env::set_var("XDG_CACHE_HOME", v),
-                None => std::env::remove_var("XDG_CACHE_HOME"),
-            }
-        }
-    }
-
-    #[test]
-    fn acquire_nix_store_image_lock_refuses_concurrent_writer() {
-        let _lock = ENV_LOCK.lock().unwrap();
-        let scratch = TempDir::new().unwrap();
-        let old = std::env::var("XDG_CACHE_HOME").ok();
-        unsafe {
-            std::env::set_var("XDG_CACHE_HOME", scratch.path());
-        }
-
-        let first = acquire_nix_store_image_lock("x86_64", 256).unwrap();
-        let err = acquire_nix_store_image_lock("x86_64", 256).unwrap_err();
-        let msg = format!("{err}");
-        assert!(
-            msg.contains("already attached by another builder VM process"),
-            "unexpected error: {msg}"
-        );
-        drop(first);
-
-        acquire_nix_store_image_lock("x86_64", 256)
-            .expect("lock should be available after first guard drops");
-
-        unsafe {
-            match old {
-                Some(v) => std::env::set_var("XDG_CACHE_HOME", v),
-                None => std::env::remove_var("XDG_CACHE_HOME"),
-            }
-        }
-    }
+    // `finalize_flake_job_*`, `read_last_bytes_of_*`,
+    // `acquire_nix_store_image_lock_*` test coverage migrated to
+    // `builder_vm_runtime` alongside the functions themselves.
+    // Plan 97 Phase C PR-B-migrate commits 3-5.
 
     #[test]
     fn ensure_builder_vm_image_requires_cmdline_txt() {


### PR DESCRIPTION
## What landed

Fourth Plan 97 Phase C migration. Lifts the host-side persistent `/nix-store` image lock out of `LibkrunBuilderVm` into the shared `BuilderVmRuntime` helper:

- `NixStoreImageLock` struct — pub, with `pub fn path() -> &Path`
- `acquire_nix_store_image_lock(builder_cache_dir, arch, size_mib)` — pub
- 4 unit tests (2 migrated + 2 new)

The new signature takes `builder_cache_dir: &Path` as a parameter so the helper stays free of `mvm_core::config` lookups (matches the shape of the prior migrations — caller composes the path, helper does the work). `libkrun_builder.rs` continues to compute the cache dir via its existing `builder_vm_cache_dir()` helper at the 3 call sites.

The `_file: std::fs::File` field is load-bearing — the type-level doc comment names this explicitly per Plan 97 §"Phase C seam design" so an underscore-prefixed field doesn't read as inert.

## Why the test signature change

The libkrun-side tests redirected the cache dir through `XDG_CACHE_HOME` (via `unsafe { env::set_var }` under a shared `ENV_LOCK`). Because the new signature takes the cache dir as `&Path`, each migrated test now passes a fresh `TempDir` directly with no process-wide env mutation — removes one source of the test-order flakiness the previous PR-B migration flagged. Two new tests pin the filename convention (`nix-store-<arch>.img`) and the create-missing-cache-dir contract.

## Verification

Run from inside the worktree, not main:

- `cargo fmt --all -- --check` ✓
- `cargo clippy --workspace --all-targets -- -D warnings` ✓
- `cargo test -p mvm-build --features builder-vm` — 310 lib + 51 integration ✓ on the second run (first run hit the same env-mutating `libkrun_builder` order-dependent flake the third migration saw; targeted re-run of the flaked test in isolation passes deterministically on this branch and on the base)
- 23 `builder_vm_runtime::tests::*` (up from 19 on the base; +4 NixStoreImageLock tests)
- 0 `acquire_nix_store_image_lock_*` stragglers in `libkrun_builder::tests::*`

## Stack

\`\`\`
main
└── worktree-job-result-migrate (#435, open)
    └── worktree-finalize-migrate (#436, open)
        └── worktree-nix-store-lock-migrate ← this PR
\`\`\`

When #435 → #436 → this each merge, GitHub auto-retargets the next link down to main.

After this lands, two more migrations remain before the seam is ready and `VzBuilderVm` becomes the next PR:
1. stderr-tail capture from the cmd.sh ringbuffer
2. wall-clock timeout handling

🤖 Generated with [Claude Code](https://claude.com/claude-code)