### PR TITLE
Plan 97 Phase C PR-B-migrate: builder_vm_timeout (sixth migration — seam complete)

### DIFF
--- a/crates/mvm-build/src/builder_vm_runtime.rs
+++ b/crates/mvm-build/src/builder_vm_runtime.rs
@@ -32,10 +32,22 @@
 //! helper methods get their own unit tests.
 
 use std::path::{Path, PathBuf};
+use std::time::Duration;
 
 use serde::Deserialize;
 
 use crate::builder_vm::{BuilderArtifacts, BuilderJob, BuilderVmError, VmBackendForBuilder};
+
+/// Wall-clock timeout for a builder VM run when the operator hasn't
+/// overridden it. 30 minutes covers a cold-cache `nix build` of the
+/// project's heaviest derivations on a fresh CI runner without
+/// punishing fast machines.
+pub const DEFAULT_BUILDER_VM_TIMEOUT: Duration = Duration::from_secs(30 * 60);
+
+/// Env var the operator sets to override [`DEFAULT_BUILDER_VM_TIMEOUT`].
+/// Plain integer seconds; zero is rejected so a typo doesn't silently
+/// disable the safety net.
+pub const MVM_BUILDER_VM_TIMEOUT_SECS_ENV: &str = "MVM_BUILDER_VM_TIMEOUT_SECS";
 
 /// Per-job dir filename mvm-builder-init detects to dispatch
 /// through the application-dependency install pipeline (Plan 73
@@ -632,6 +644,37 @@ pub fn shell_job_exit_error(exit_code: i32, stderr_tail: &str) -> BuilderVmError
     ))
 }
 
+/// Resolve the wall-clock timeout for a single builder-VM run.
+/// Reads [`MVM_BUILDER_VM_TIMEOUT_SECS_ENV`] from the host env;
+/// returns [`DEFAULT_BUILDER_VM_TIMEOUT`] when unset.
+///
+/// Both backends (libkrun + Vz) thread the returned [`Duration`] into
+/// their per-VM-run timer so a stuck guest doesn't pin a Cargo job
+/// indefinitely. Migrated from `libkrun_builder.rs` in Plan 97 Phase C
+/// PR-B-migrate (sixth migration). The env var name is intentionally
+/// hypervisor-agnostic; the policy is the same on both paths.
+///
+/// Rejects zero so a typo (`MVM_BUILDER_VM_TIMEOUT_SECS=0`) doesn't
+/// silently disable the timeout. Operators that want "no limit" should
+/// pass a very large value.
+pub fn builder_vm_timeout() -> Result<Duration, BuilderVmError> {
+    let Some(raw) = std::env::var_os(MVM_BUILDER_VM_TIMEOUT_SECS_ENV) else {
+        return Ok(DEFAULT_BUILDER_VM_TIMEOUT);
+    };
+    let raw = raw.to_string_lossy();
+    let secs = raw.parse::<u64>().map_err(|e| {
+        BuilderVmError::ExtractionFailed(format!(
+            "{MVM_BUILDER_VM_TIMEOUT_SECS_ENV} must be an integer number of seconds, got {raw:?}: {e}"
+        ))
+    })?;
+    if secs == 0 {
+        return Err(BuilderVmError::ExtractionFailed(format!(
+            "{MVM_BUILDER_VM_TIMEOUT_SECS_ENV} must be greater than zero"
+        )));
+    }
+    Ok(Duration::from_secs(secs))
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -1155,5 +1198,91 @@ mod tests {
         };
         assert!(msg.contains("exited 137"), "got: {msg}");
         assert!(msg.ends_with("stderr tail:\n"), "got: {msg}");
+    }
+
+    // -----------------------------------------------------------------
+    // builder_vm_timeout — Plan 97 Phase C PR-B-migrate (sixth and
+    // final pre-VzBuilderVm migration). Reads
+    // MVM_BUILDER_VM_TIMEOUT_SECS from the process env; mutation is
+    // serialised through TIMEOUT_ENV_LOCK so concurrent test threads
+    // don't observe each other's writes.
+    // -----------------------------------------------------------------
+
+    use std::sync::{LazyLock, Mutex};
+
+    static TIMEOUT_ENV_LOCK: LazyLock<Mutex<()>> = LazyLock::new(|| Mutex::new(()));
+
+    #[test]
+    fn builder_vm_timeout_defaults_when_unset() {
+        let _lock = TIMEOUT_ENV_LOCK.lock().unwrap();
+        let old = std::env::var_os(MVM_BUILDER_VM_TIMEOUT_SECS_ENV);
+        // SAFETY: tests serialise env mutation via TIMEOUT_ENV_LOCK.
+        unsafe {
+            std::env::remove_var(MVM_BUILDER_VM_TIMEOUT_SECS_ENV);
+        }
+        assert_eq!(builder_vm_timeout().unwrap(), DEFAULT_BUILDER_VM_TIMEOUT);
+        unsafe {
+            match old {
+                Some(v) => std::env::set_var(MVM_BUILDER_VM_TIMEOUT_SECS_ENV, v),
+                None => std::env::remove_var(MVM_BUILDER_VM_TIMEOUT_SECS_ENV),
+            }
+        }
+    }
+
+    #[test]
+    fn builder_vm_timeout_parses_positive_seconds() {
+        let _lock = TIMEOUT_ENV_LOCK.lock().unwrap();
+        let old = std::env::var_os(MVM_BUILDER_VM_TIMEOUT_SECS_ENV);
+        unsafe {
+            std::env::set_var(MVM_BUILDER_VM_TIMEOUT_SECS_ENV, "120");
+        }
+        assert_eq!(
+            builder_vm_timeout().unwrap(),
+            std::time::Duration::from_secs(120)
+        );
+        unsafe {
+            match old {
+                Some(v) => std::env::set_var(MVM_BUILDER_VM_TIMEOUT_SECS_ENV, v),
+                None => std::env::remove_var(MVM_BUILDER_VM_TIMEOUT_SECS_ENV),
+            }
+        }
+    }
+
+    #[test]
+    fn builder_vm_timeout_rejects_zero() {
+        let _lock = TIMEOUT_ENV_LOCK.lock().unwrap();
+        let old = std::env::var_os(MVM_BUILDER_VM_TIMEOUT_SECS_ENV);
+        unsafe {
+            std::env::set_var(MVM_BUILDER_VM_TIMEOUT_SECS_ENV, "0");
+        }
+        let err = builder_vm_timeout().unwrap_err();
+        assert!(format!("{err}").contains("greater than zero"), "got {err}");
+        unsafe {
+            match old {
+                Some(v) => std::env::set_var(MVM_BUILDER_VM_TIMEOUT_SECS_ENV, v),
+                None => std::env::remove_var(MVM_BUILDER_VM_TIMEOUT_SECS_ENV),
+            }
+        }
+    }
+
+    #[test]
+    fn builder_vm_timeout_rejects_non_integer() {
+        let _lock = TIMEOUT_ENV_LOCK.lock().unwrap();
+        let old = std::env::var_os(MVM_BUILDER_VM_TIMEOUT_SECS_ENV);
+        unsafe {
+            std::env::set_var(MVM_BUILDER_VM_TIMEOUT_SECS_ENV, "not-an-integer");
+        }
+        let err = builder_vm_timeout().unwrap_err();
+        let msg = format!("{err}");
+        assert!(msg.contains("must be an integer"), "got: {msg}");
+        // The bad value surfaces in the message so the operator
+        // doesn't have to re-check their env to find the typo.
+        assert!(msg.contains("not-an-integer"), "got: {msg}");
+        unsafe {
+            match old {
+                Some(v) => std::env::set_var(MVM_BUILDER_VM_TIMEOUT_SECS_ENV, v),
+                None => std::env::remove_var(MVM_BUILDER_VM_TIMEOUT_SECS_ENV),
+            }
+        }
     }
 }

--- a/crates/mvm-build/src/libkrun_builder.rs
+++ b/crates/mvm-build/src/libkrun_builder.rs
@@ -76,10 +76,12 @@ use crate::builder_vm::{
 // here uses `stage_job_dir` (commit 2), `read_job_result` (commit 3),
 // `finalize_flake_job` / `finalize_install_job` (commit 4),
 // `NixStoreImageLock` / `acquire_nix_store_image_lock` (commit 5),
-// and `supervisor_exit_error` / `shell_job_exit_error` (commit 6).
+// `supervisor_exit_error` / `shell_job_exit_error` (commit 6), and
+// `builder_vm_timeout` (commit 7 — last pre-VzBuilderVm migration).
 use crate::builder_vm_runtime::{
-    NixStoreImageLock, acquire_nix_store_image_lock, finalize_flake_job, finalize_install_job,
-    read_job_result, shell_job_exit_error, stage_job_dir, supervisor_exit_error,
+    NixStoreImageLock, acquire_nix_store_image_lock, builder_vm_timeout, finalize_flake_job,
+    finalize_install_job, read_job_result, shell_job_exit_error, stage_job_dir,
+    supervisor_exit_error,
 };
 
 /// Default vCPU count for the builder VM. Nix builds are
@@ -1620,24 +1622,6 @@ fn find_panic_line_in(buf: &[u8]) -> Option<String> {
     Some(line)
 }
 
-fn builder_vm_timeout() -> Result<Duration, BuilderVmError> {
-    let Some(raw) = std::env::var_os("MVM_BUILDER_VM_TIMEOUT_SECS") else {
-        return Ok(Duration::from_secs(30 * 60));
-    };
-    let raw = raw.to_string_lossy();
-    let secs = raw.parse::<u64>().map_err(|e| {
-        BuilderVmError::ExtractionFailed(format!(
-            "MVM_BUILDER_VM_TIMEOUT_SECS must be an integer number of seconds, got {raw:?}: {e}"
-        ))
-    })?;
-    if secs == 0 {
-        return Err(BuilderVmError::ExtractionFailed(
-            "MVM_BUILDER_VM_TIMEOUT_SECS must be greater than zero".to_string(),
-        ));
-    }
-    Ok(Duration::from_secs(secs))
-}
-
 /// Render a Path as a `&str` or surface a clear error if it
 /// contains non-UTF-8 bytes. libkrun's C API takes
 /// `*const c_char`; rejecting non-UTF-8 here pins the failure
@@ -2330,28 +2314,8 @@ mod tests {
         }
     }
 
-    #[test]
-    fn builder_vm_timeout_defaults_and_rejects_zero() {
-        let _lock = ENV_LOCK.lock().unwrap();
-        let old = std::env::var("MVM_BUILDER_VM_TIMEOUT_SECS").ok();
-        unsafe {
-            std::env::remove_var("MVM_BUILDER_VM_TIMEOUT_SECS");
-        }
-        assert_eq!(builder_vm_timeout().unwrap(), Duration::from_secs(30 * 60));
-
-        unsafe {
-            std::env::set_var("MVM_BUILDER_VM_TIMEOUT_SECS", "0");
-        }
-        let err = builder_vm_timeout().unwrap_err();
-        assert!(format!("{err}").contains("greater than zero"), "got {err}");
-
-        unsafe {
-            match old {
-                Some(v) => std::env::set_var("MVM_BUILDER_VM_TIMEOUT_SECS", v),
-                None => std::env::remove_var("MVM_BUILDER_VM_TIMEOUT_SECS"),
-            }
-        }
-    }
+    // `builder_vm_timeout_*` tests migrated to `builder_vm_runtime`
+    // alongside the function. Plan 97 Phase C PR-B-migrate commit 7.
 
     #[test]
     fn unique_job_id_includes_pid_and_timestamp() {


### PR DESCRIPTION
## What landed

Sixth and **final pre-VzBuilderVm** Plan 97 Phase C migration. Lifts the wall-clock timeout reader out of \`LibkrunBuilderVm\` into the shared \`BuilderVmRuntime\` helper:

- \`pub fn builder_vm_timeout() -> Result<Duration, BuilderVmError>\`
- \`pub const DEFAULT_BUILDER_VM_TIMEOUT\` (30 minutes)
- \`pub const MVM_BUILDER_VM_TIMEOUT_SECS_ENV\` (\"MVM_BUILDER_VM_TIMEOUT_SECS\")
- 4 unit tests (defaults-when-unset, parses positive seconds, rejects zero, rejects non-integer)

The env var name is hypervisor-agnostic on purpose — Vz inherits the same operator switch. Exposing the env var name and default as public constants lets \`mvmctl doctor\` / docs reference them without re-deriving the string. Naming the bad value in the parse-error message is new coverage relative to the libkrun-side test.

Test mutation is serialised via a module-local \`TIMEOUT_ENV_LOCK\` (\`LazyLock<Mutex<()>>\`) — separate from the existing \`libkrun_builder\` \`ENV_LOCK\` because they live in different modules and only this one touches the timeout env var.

## Phase C seam — feature-complete after this lands

\`\`\`
stage_job_dir                                   (#434, merged)
read_job_result + JobResult                     (#435)
finalize_flake_job + finalize_install_job + 5   (#436)
NixStoreImageLock + acquire fn                  (#437)
supervisor_exit_error + shell_job_exit_error    (#438)
builder_vm_timeout                              (this PR)
\`\`\`

After this, the seam is ready and \`VzBuilderVm\` (~400 + ~200 lines per the Plan 97 estimate) becomes the natural next slice — its impl writes only what's Vz-specific (\`SupervisorConfig\` JSON, virtio-fs share attachment via the Swift supervisor) and reuses every \`BuilderVmRuntime\` helper above verbatim.

## Verification

Run from inside the worktree, not main:

- \`cargo fmt --all -- --check\` ✓
- \`cargo clippy --workspace --all-targets -- -D warnings\` ✓
- \`cargo test -p mvm-build --features builder-vm\` — 316 lib + 51 integration ✓, clean first try
- 26 → 30 \`builder_vm_runtime::tests::*\` (+4 new)
- 0 \`builder_vm_timeout_*\` stragglers in \`libkrun_builder::tests::*\`

## Stack

\`\`\`
main
└── #435 worktree-job-result-migrate
    └── #436 worktree-finalize-migrate
        └── #437 worktree-nix-store-lock-migrate
            └── #438 worktree-stderr-tail-migrate
                └── worktree-timeout-migrate ← this PR (seam complete)
\`\`\`

🤖 Generated with [Claude Code](https://claude.com/claude-code)