### PR TITLE
feat(mvm-vz): VirtioFsShare.read_only — Plan 97 VzBuilderVm enabler

### DIFF
--- a/crates/mvm-vz-supervisor/Sources/mvm-vz-supervisor/Config.swift
+++ b/crates/mvm-vz-supervisor/Sources/mvm-vz-supervisor/Config.swift
@@ -196,12 +196,14 @@ struct DiskConfig: Decodable, StrictKeys {
 struct VirtioFsShare: Decodable, StrictKeys {
     let tag: String
     let hostPath: String
+    let readOnly: Bool
 
-    static let knownKeys: Set<String> = ["tag", "host_path"]
+    static let knownKeys: Set<String> = ["tag", "host_path", "read_only"]
 
     enum CodingKeys: String, CodingKey {
         case tag
         case hostPath = "host_path"
+        case readOnly = "read_only"
     }
 
     init(from decoder: Decoder) throws {
@@ -209,6 +211,7 @@ struct VirtioFsShare: Decodable, StrictKeys {
         let c = try decoder.container(keyedBy: CodingKeys.self)
         self.tag = try c.decode(String.self, forKey: .tag)
         self.hostPath = try c.decode(String.self, forKey: .hostPath)
+        self.readOnly = try c.decode(Bool.self, forKey: .readOnly)
     }
 }
 

--- a/crates/mvm-vz-supervisor/Sources/mvm-vz-supervisor/Supervisor.swift
+++ b/crates/mvm-vz-supervisor/Sources/mvm-vz-supervisor/Supervisor.swift
@@ -252,7 +252,7 @@ final class Supervisor: NSObject, VZVirtualMachineDelegate {
                 let single = VZSingleDirectoryShare(
                     directory: VZSharedDirectory(
                         url: URL(fileURLWithPath: share.hostPath),
-                        readOnly: false
+                        readOnly: share.readOnly
                     )
                 )
                 let device = VZVirtioFileSystemDeviceConfiguration(tag: share.tag)

--- a/crates/mvm-vz/src/lib.rs
+++ b/crates/mvm-vz/src/lib.rs
@@ -204,6 +204,18 @@ pub struct VirtioFsShare {
     pub tag: String,
     /// Host directory exported into the guest.
     pub host_path: String,
+    /// Whether the share is mounted read-only inside the guest.
+    /// The Swift supervisor threads this onto
+    /// `VZSharedDirectory(readOnly:)`, so a `true` here is enforced
+    /// by Vz itself — the guest can't remount it rw.
+    ///
+    /// Required (no default) so Plan 97 §"Volumes and host-path
+    /// mounts" admission decisions are explicit rather than
+    /// inheriting the per-language default. The builder VM mounts
+    /// `/work` and `/job` read-only and `/out` read-write; workload
+    /// microVMs default to no shares at all and so don't usually
+    /// touch this field.
+    pub read_only: bool,
 }
 
 #[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
@@ -492,6 +504,57 @@ mod tests {
     fn mac_string_roundtrips_lowercase() {
         let mac = MacAddress::parse("0A:BB:CC:DD:EE:FF").unwrap();
         assert_eq!(mac.to_string_lowercase(), "0a:bb:cc:dd:ee:ff");
+    }
+
+    #[test]
+    fn virtio_fs_share_read_only_roundtrips_through_json() {
+        // The Swift supervisor threads `read_only` onto
+        // `VZSharedDirectory(readOnly:)`, so the wire format must
+        // carry the field as `read_only` (snake_case) to match the
+        // strict-keys decoder in Config.swift.
+        let mut cfg = minimal_config();
+        cfg.virtio_fs = vec![
+            VirtioFsShare {
+                tag: "work".into(),
+                host_path: "/tmp/work".into(),
+                read_only: true,
+            },
+            VirtioFsShare {
+                tag: "out".into(),
+                host_path: "/tmp/out".into(),
+                read_only: false,
+            },
+        ];
+        let json = cfg.to_json().expect("serialize");
+        assert!(json.contains("\"read_only\":true"), "got: {json}");
+        assert!(json.contains("\"read_only\":false"), "got: {json}");
+        let back: SupervisorConfig = serde_json::from_str(&json).expect("roundtrip parses");
+        assert_eq!(back.virtio_fs.len(), 2);
+        assert!(back.virtio_fs[0].read_only);
+        assert!(!back.virtio_fs[1].read_only);
+    }
+
+    #[test]
+    fn virtio_fs_share_rejects_missing_read_only_field() {
+        // The Swift supervisor's StrictKeys decoder also requires
+        // the field. Mirror that on the Rust side so a stale JSON
+        // producer can't ship a share whose read-only-ness depends
+        // on whichever decoder runs first.
+        let json = r#"{"tag":"work","host_path":"/tmp/work"}"#;
+        let err =
+            serde_json::from_str::<VirtioFsShare>(json).expect_err("missing read_only must reject");
+        assert!(
+            err.to_string().contains("read_only"),
+            "error mentions the missing field: {err}"
+        );
+    }
+
+    #[test]
+    fn virtio_fs_share_rejects_unknown_field() {
+        let json = r#"{"tag":"work","host_path":"/tmp/work","read_only":true,"rogue":1}"#;
+        let err = serde_json::from_str::<VirtioFsShare>(json)
+            .expect_err("deny_unknown_fields must reject");
+        assert!(err.to_string().contains("rogue"), "got: {err}");
     }
 
     #[test]


### PR DESCRIPTION
## What landed

Adds \`read_only: bool\` to \`VirtioFsShare\` on both sides of the Vz supervisor JSON boundary. Required field (no default) so admission decisions are explicit rather than inheriting a per-language default that picks one wrong choice.

- \`crates/mvm-vz/src/lib.rs\`: \`VirtioFsShare\` gains \`pub read_only: bool\`
- \`crates/mvm-vz-supervisor/Sources/mvm-vz-supervisor/Config.swift\`: Swift decoder adds \`readOnly: Bool\` + \`\"read_only\"\` to \`knownKeys\` + matching \`CodingKeys\`
- \`crates/mvm-vz-supervisor/Sources/mvm-vz-supervisor/Supervisor.swift\`: threads \`share.readOnly\` onto \`VZSharedDirectory(readOnly:)\` so Vz itself enforces the mount — the guest can't remount rw

## Why this is the first VzBuilderVm slice

The next Plan 97 Phase C slice is \`VzBuilderBackend\` (the second \`VmBackendForBuilder\` impl, parallel to \`LibkrunBuilderBackend\`). It needs to mount \`/work\` and \`/job\` **read-only** while \`/out\` stays writable. The existing Vz config plumbing relayed every share to \`VZSharedDirectory(readOnly: false)\` unconditionally, so the builder couldn't enforce that.

## Verification

- \`cargo fmt --all -- --check\` ✓
- \`cargo clippy --workspace --all-targets -- -D warnings\` ✓
- \`cargo test --workspace\` ✓ (clean first run; mvm-vz now at 13 lib tests, +3 new covering the new field)
- Swift supervisor rebuilds cleanly via the build.rs hook (visible in the pre-commit log)

Three new unit tests:
- roundtrip through JSON (\`read_only=true\` and \`false\` surface with snake_case key)
- missing \`read_only\` field rejected — Rust mirrors the Swift \`StrictKeys\` decoder so a stale producer can't ship a share whose read-only-ness depends on which decoder runs first
- unknown field rejected (regression guard on \`#[serde(deny_unknown_fields)]\` scoped to \`VirtioFsShare\`)

## Stack

Standalone PR off main. No stack yet; sets up the seam for the upcoming \`VzBuilderBackend\` PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)