### PR TITLE
chore(mvm-vz): silence build.rs cargo:warning on successful Swift builds

### DIFF
--- a/crates/mvm-vz/build.rs
+++ b/crates/mvm-vz/build.rs
@@ -73,25 +73,19 @@ fn main() {
     let profile = std::env::var("PROFILE").unwrap_or_else(|_| "debug".to_string());
     let build_script = supervisor_root.join("tools/build.sh");
 
-    println!(
-        "cargo:warning=mvm-vz: building Swift supervisor ({profile}) via {}",
-        build_script.display()
-    );
-
-    // Capture stdout + stderr explicitly. The earlier `.status()`
-    // version inherited the parent's stderr, where cargo silently
-    // swallows everything that isn't prefixed `cargo:warning=`.
-    // When `swift build` fails, that meant the actual swift
-    // diagnostic vanished — the build.rs only saw the exit code
-    // and emitted a generic "see `tools/build.sh` manually" hint.
-    // CI hit this on macos-latest with no way to recover the
-    // underlying error from the captured log.
+    // Capture stdout + stderr explicitly so the failure path below
+    // can re-emit them. The earlier `.status()` version inherited
+    // the parent's stderr, where cargo silently swallows everything
+    // that isn't prefixed `cargo:warning=` — when `swift build`
+    // failed, the actual swift diagnostic vanished and the build.rs
+    // only saw an exit code. CI hit this on macos-latest with no
+    // way to recover the underlying error from the captured log.
     //
-    // Switching to `.output()` lets us re-emit every output line
-    // as a `cargo:warning=...` so the swift / codesign / shell
-    // error is visible in any cargo build log: interactive
-    // contributor, CI log, `cargo build --quiet`. Build still does
-    // not fail the cargo build on swift failure (see below).
+    // The success path stays silent: every workspace build fires
+    // this script, so echoing the supervisor build progress as
+    // `cargo:warning=` lines polluted every interactive build with
+    // ~15 warning lines per cargo invocation. The binary's mtime
+    // moving is the real success signal.
     let output = Command::new(&build_script)
         .arg(&profile)
         .current_dir(&supervisor_root)
@@ -99,15 +93,7 @@ fn main() {
 
     match output {
         Ok(out) if out.status.success() => {
-            // tools/build.sh prints the signed binary path on stdout;
-            // surface that + the success marker.
-            for line in String::from_utf8_lossy(&out.stdout).lines() {
-                println!("cargo:warning=mvm-vz: swift stdout: {line}");
-            }
-            for line in String::from_utf8_lossy(&out.stderr).lines() {
-                println!("cargo:warning=mvm-vz: swift stderr: {line}");
-            }
-            println!("cargo:warning=mvm-vz: Swift supervisor build OK");
+            // Silent on success — see the rationale block above.
         }
         Ok(out) => {
             // Non-zero exit: surface every line of stdout + stderr


### PR DESCRIPTION
## What landed

\`cargo build\` in this workspace fires the \`mvm-vz/build.rs\` script every time, which in turn runs \`tools/build.sh\` to (re)build the Swift supervisor. The script was emitting ~15 \`cargo:warning=\` lines per invocation on success — a pre-announce, every line of swift's stdout, every line of swift's stderr, and a \"build OK\" marker. Since \`cargo:warning=\` lines surface in every interactive build, a plain \`cargo run\` polluted the terminal with yellow warnings for what was a clean success.

This PR keeps the **failure-path** emission — that's the whole reason the script switched from \`.status()\` to \`.output()\` in the first place: when \`swift build\` fails, cargo silently swallows non-\`cargo:warning=\` lines from a build script's child process, so CI needed the per-line re-emission to surface the actual swift diagnostic. The failure path stays loud; the success path goes silent.

Also kept (rare, actionable):
- \`MVM_VZ_SKIP_SUPERVISOR_BUILD\` opt-out announcement
- \`swift\` not found on PATH (Xcode CLT missing)
- spawn failure on \`tools/build.sh\`

## Verification

- \`cargo build -p mvm-vz\` → zero \`cargo:warning=\` lines on success ✓
- \`cargo fmt --all -- --check\` ✓
- \`cargo clippy --workspace --all-targets -- -D warnings\` ✓
- Tests untouched (no test changes; the file is build-script only)

Net: -27 / +13 lines in \`crates/mvm-vz/build.rs\`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)