### PR TITLE
fix(mkGuest): ship virtiofs + fuse module closures (Stage 0 ENODEV)

### DIFF
--- a/nix/lib/mk-guest.nix
+++ b/nix/lib/mk-guest.nix
@@ -774,6 +774,23 @@ let
                 "$src" \
                 "$out/lib/modules/$kver" \
                 "vmw_vsock_virtio_transport"
+              # Stage 0 (`bootstrap_builder_vm_image_via_dev_image_stage0`,
+              # Plan 77 W3) boots this rootfs and mounts `/work`, `/out`,
+              # `/job` as virtio-fs. nixpkgs ships `CONFIG_VIRTIO_FS=m`
+              # and `CONFIG_FUSE_FS=m`, so without the module closure
+              # `mount -t virtiofs` fails with ENODEV and the VM powers
+              # down before `mvm-builder-init` can finalize `/job/result`.
+              # #333 trimmed the closure to vsock-only because that's all
+              # the workload microVM path needed; Stage 0's reuse of this
+              # rootfs landed later and depends on virtio-fs.
+              copy_module_closure \
+                "$src" \
+                "$out/lib/modules/$kver" \
+                "virtiofs"
+              copy_module_closure \
+                "$src" \
+                "$out/lib/modules/$kver" \
+                "fuse"
             done
             break
           fi


### PR DESCRIPTION
## Summary

`mvmctl dev up` is broken on `main`: Stage 0 boots the user's dev image
rootfs, tries to mount `/work`, `/out`, `/job` as virtio-fs, and gets
`ENODEV` because the rootfs ships no `virtiofs` / `fuse` kernel
module closure. The VM powers down before `mvm-builder-init` can
write `/job/result`, and the host surfaces:

```
Stage 0 builder VM build: nix build failed inside builder sandbox:
guest did not write …/result: No such file or directory
(the VM may have crashed before mvm-builder-init could finalize)
```

Console-log on the failing VM (`~/.cache/mvm/builder-vm/vms/mvm-builder-vm-*/console.log`):

```
modprobe: can't load module fuse (kernel/fs/fuse/fuse.ko.xz): No such file or directory
mvm-builder-init: modprobe virtiofs exited 1 (continuing)
…
mvm-builder-init: virtio-fs 'work' -> /work failed: mount virtiofs work -> /work: ENODEV
…
mvm-builder-init: failed to write /job/result: Read-only file system (os error 30)
[    0.265587] reboot: Power down
```

## Root cause

`nix/images/builder/flake.nix` builds the dev image against
`pkgs.linuxPackages.kernel`, which ships `CONFIG_VIRTIO_FS=m` and
`CONFIG_FUSE_FS=m`. mkGuest's module-closure step only copies the
`vmw_vsock_virtio_transport` closure (#333 trimmed the previous
full-tree copy to keep the rootfs <10 MB). Stage 0 then needs to
load `virtiofs` (which depends on `fuse`) to mount its host shares,
finds nothing under `/lib/modules/<kver>/`, and `mount -t virtiofs`
returns `ENODEV`.

The #333 trim was correct in isolation — the workload microVM path
doesn't need virtio-fs. Stage 0's reuse of this rootfs landed later
(Plan 77 W3) and is the path that now requires the extra closures.

## Fix

Add `virtiofs` and `fuse` `copy_module_closure` calls alongside the
existing vsock one in `nix/lib/mk-guest.nix`. `fuse` is also a
transitive dep of `virtiofs`, but naming it explicitly documents
the requirement and gives an immediate signal if a future kernel
reshuffles the dep graph.

Module size impact: ~100 KiB compressed (`virtiofs.ko` + `fuse.ko`
+ deps), well inside #110's <10 MB envelope.

## User action

Anyone with an existing dev image cache needs to invalidate it:

```sh
rm -rf ~/.mvm/dev/current
```

then re-run `mvmctl dev up` so Stage 0 boots a rootfs that has the
modules baked in.

## Test plan

- [x] `cargo clippy --workspace --all-targets -- -D warnings` — zero warnings.
- [x] `cargo fmt --all -- --check` — clean.
- [x] `cargo test --workspace` — the 2 pre-existing failures
  (`builder_cache_status_reports_source_provenance_drift` /
  `_source_cache_hit_without_paths`) reproduce identically on
  `main` HEAD `8041e2c7` without this patch (#422's fingerprint
  expansion added `Cargo.lock`/crate-dirs to the hash without
  updating the tempdir-based test fixture). The 1800 s timeout
  on `libkrun_builder::tests::run_build_surfaces_environment_gaps_on_clean_input`
  is also reproducible on `main` and unrelated to this change.
- [ ] **Live `mvmctl dev up`** on macOS arm64 — pending user
  validation after `rm -rf ~/.mvm/dev/current`. The fix is in
  Nix shell code that only runs at rootfs-build time, so I cannot
  exercise the runtime path inside the CI matrix without a real
  libkrun build.

🤖 Generated with [Claude Code](https://claude.com/claude-code)