### PR TITLE
fix(stage0): cap nix --max-jobs at 1 to keep kernel compile in RAM

### DIFF
--- a/crates/mvm-build/src/stage0.rs
+++ b/crates/mvm-build/src/stage0.rs
@@ -614,6 +614,26 @@ mod tests {
         );
     }
 
+    /// Regression for the 2026-05-25 `mvmctl dev up` failure where
+    /// the Stage 0 nix build OOM-killed the slim Linux kernel
+    /// compile at `HOSTCC scripts/basic/fixdep`. With Alpine nix's
+    /// default `max-jobs = auto`, four heavy derivations
+    /// (mvm-builder-init, mvm-egress-proxy, mvm-guest-agent, linux)
+    /// ran concurrently and the combined working set exceeded the
+    /// 16 GiB guest RAM / 14 GiB `/nix` tmpfs envelope. Serializing
+    /// derivations with `--max-jobs 1` keeps peak memory under the
+    /// per-derivation ~5-6 GiB observation recorded in
+    /// `libkrun_builder.rs:92-99`.
+    #[test]
+    fn init_script_caps_nix_derivation_parallelism() {
+        assert!(
+            INIT_SCRIPT.contains("--max-jobs 1"),
+            "init script must serialize Stage 0 nix derivations \
+             (`--max-jobs 1`) so parallel kernel + Rust builds don't \
+             blow the guest RAM / /nix-tmpfs envelope"
+        );
+    }
+
     #[test]
     fn cache_dir_is_under_home() {
         let path = stage0_cache_dir();

--- a/crates/mvm-build/src/stage0/init.sh
+++ b/crates/mvm-build/src/stage0/init.sh
@@ -169,10 +169,22 @@ echo "stage0-init: building ${FLAKE_REF}" >&2
 # caps substituter HTTP connect waits at 30s so an unreachable
 # mirror fails over fast instead of stalling the whole build behind
 # the OS-default TCP timeout (~75-120s).
+#
+# --max-jobs 1 caps derivation parallelism inside Stage 0. With
+# Alpine nix's default `max-jobs = auto`, four heavy derivations
+# (mvm-builder-init, mvm-egress-proxy, mvm-guest-agent, the slim
+# Linux kernel) run concurrently and the combined working set
+# exceeds the 16 GiB guest RAM / 14 GiB `/nix` tmpfs envelope —
+# SIGKILL at `HOSTCC scripts/basic/fixdep`. libkrun_builder.rs:92-99
+# records the peak-per-derivation observation (~5-6 GiB), which fits
+# one at a time but not in parallel. Per-derivation parallelism stays
+# at the default (cores = nproc) so the kernel compile still uses
+# all 4 vCPUs.
 set +e
 nix build "$FLAKE_REF" \
     --extra-experimental-features "nix-command flakes" \
     --option connect-timeout 30 \
+    --max-jobs 1 \
     --no-link --no-write-lock-file --impure \
     --print-out-paths --print-build-logs \
     > /tmp/store-path 2> /out/nix-stderr.log


### PR DESCRIPTION
## Summary

After #444 the dev image cache is invalidated (`rm -rf ~/.mvm/dev/current`) and `mvmctl dev up` falls through to the Alpine root-dir Stage 0 path (`crates/mvm-build/src/stage0/init.sh`, Plan 91). That path OOM-kills the slim Linux kernel compile at the very first C build step:

```
stage0-init: building path:/work/nix/images/builder-vm#packages.aarch64-linux.default
stage0-init: nix build exited 137 (see /out/nix-stderr.log)
…
linux>   GEN     Makefile
linux>   HOSTCC  scripts/basic/fixdep
Killed
```

`137 = 128 + 9` → SIGKILL → OOM.

## Root cause

Alpine's nix package defaults to `max-jobs = auto`, so four heavy derivations run concurrently inside Stage 0:

```
mvm-builder-init> Running phase: unpackPhase
mvm-egress-proxy> Running phase: unpackPhase
mvm-guest-agent>  Running phase: unpackPhase
linux>            …
```

The guest envelope:
- VM RAM = 16 GiB (`crates/mvm-build/src/libkrun_builder.rs::DEFAULT_MEMORY_MIB`)
- `/nix` is a **tmpfs** capped at 14 GiB (`stage0/init.sh:114`), backed by guest RAM

That leaves ~2 GiB for the kernel + init + every parallel builder. gcc working memory alone exceeds it as soon as the kernel compile starts in parallel with the three Rust crate builds.

`libkrun_builder.rs:92-99` already records the per-derivation peak at ~5-6 GiB — fits one at a time, not in parallel.

## Fix

Add `--max-jobs 1` to the Stage 0 `nix build` invocation. Derivations build sequentially within a single ~5-6 GiB envelope. Per-derivation parallelism stays at the default (`cores = nproc`) so the kernel compile still uses all 4 vCPUs.

After Stage 0 produces the steady-state builder VM image, the libkrun builder takes over with its own larger envelope (persistent virtio-blk `/nix` store, not tmpfs) where `max-jobs = auto` remains correct.

## Tradeoff

Cold-boot Stage 0 is now strictly sequential. Slower than the parallel-OOM run that completed nothing.

## Test plan

- [x] `cargo fmt --all -- --check` — clean.
- [x] `cargo clippy --workspace --all-targets -- -D warnings` — zero warnings (42 s).
- [x] `cargo test -p mvm-build --lib stage0::tests` — 14/14 pass, including the new `init_script_caps_nix_derivation_parallelism` regression that pins `--max-jobs 1` in `INIT_SCRIPT`.
- [x] Pre-existing main test failures (`builder_cache_status_reports_source_*`, `libkrun_builder::tests::run_build_surfaces_environment_gaps_on_clean_input`) reproduce identically on main HEAD `fa354202` without this patch — same caveat as #444.
- [ ] Live `mvmctl dev up` on macOS arm64 — pending user validation after another `rm -rf ~/.mvm/dev/current`. The fix is in shell embedded via `include_str!` and only exercises end-to-end against a real libkrun Stage 0 boot.

🤖 Generated with [Claude Code](https://claude.com/claude-code)