### PR TITLE
specs: Sprint 56 — symmetric builder VM + claim 10 (in-guest volume encryption + gateway audit)

### DIFF
--- a/specs/SPRINT.md
+++ b/specs/SPRINT.md
@@ -1949,6 +1949,47 @@ boundary, crash diagnostics, MDM detection) covered in Plan 97
   on every dimension that matters).
 - Live VM migration across hosts.
 
+## Sprint 56 — Symmetric trust boundary + claim 10 (proposed)  [`adrs/057-symmetric-builder-vm.md`](adrs/057-symmetric-builder-vm.md) | [`plans/100-symmetric-builder-vm-rollout.md`](plans/100-symmetric-builder-vm-rollout.md) | [`adrs/058-claim-10-bytes-leaving-trust-boundary.md`](adrs/058-claim-10-bytes-leaving-trust-boundary.md) | [`plans/101-in-guest-volume-encryption-and-gateway-audit.md`](plans/101-in-guest-volume-encryption-and-gateway-audit.md)
+
+### Why this sprint
+
+Two structural gaps in the current trust story:
+
+1. Linux host's userland is in the TCB; macOS host's isn't (asymmetric trust). The same `mvmctl` should give the same claim posture on both. See [ADR-057](adrs/057-symmetric-builder-vm.md).
+2. RW tenant volumes are plaintext while mounted; gateway traffic is unaudited. A compromised host can read tenant data and exfil silently — both invisible to the audit chain. Plan 63 / ADR-042 cover host-side snapshot crypto + secret store, but not the in-use mount surface. See [ADR-058](adrs/058-claim-10-bytes-leaving-trust-boundary.md).
+
+### W1 — Symmetric builder VM  🟡 proposed
+
+See [Plan 100](plans/100-symmetric-builder-vm-rollout.md). Lifts claim 1 ("no host-fs access from a guest") to true-on-both-OSes via identical builder-VM TCB. Retires the direct-Firecracker-on-Linux path.
+
+### W2 — Volume confidentiality (claim 10 leg 1)  🟡 proposed
+
+See [Plan 101 W1–W5](plans/101-in-guest-volume-encryption-and-gateway-audit.md). LUKS-in-guest + ExecutionPlan-delivered wrapped keys. Distinct from Plan 63's host-side snapshot crypto; this covers the in-use mount surface.
+
+### W3 — Audited gateway traffic (claim 10 leg 2)  🟡 proposed
+
+See [Plan 101 W6–W10](plans/101-in-guest-volume-encryption-and-gateway-audit.md). gvproxy + passt emit flow events into the audit chain. Sample-rate aggregation keeps audit volume sane.
+
+### W4 — Crypto attestability (claim 10 leg 3)  🟡 proposed
+
+See [Plan 101 W11–W14](plans/101-in-guest-volume-encryption-and-gateway-audit.md). Key fingerprints + `mvmctl doctor claim_10` row + docs. New `claim-10-audit-tamper` CI gate.
+
+### Sprint 56 success criteria
+
+- New `claim-10-audit-tamper` CI job gates every PR.
+- `mvmctl doctor` reports both claim 1 (symmetric TCB) and claim 10 (in-guest crypto + flow audit) as green.
+- Threat-model test (a host process attempting to read the volume backing file mid-workload) confirms ciphertext-at-rest.
+- Builder VM lifecycle is identical on macOS and Linux; direct-Firecracker code path retired.
+- ADR-002 claim list extends from 1–9 to 1–10; CLAUDE.md security model updated.
+
+### Non-goals (explicit)
+
+- TLS termination / L7 packet inspection.
+- Host filesystem encryption (FDE is user's concern).
+- Hardware-backed key attestation (still future).
+- Reintroducing Lima (removed 2026-05-14; symmetric posture achieved via `mvm-libkrun` on both hosts).
+- Per-byte network audit (Plan 101 W8 aggregates).
+
 ## Completed Sprints
 
 - [01-foundation.md](sprints/01-foundation.md)

--- a/specs/adrs/057-symmetric-builder-vm.md
+++ b/specs/adrs/057-symmetric-builder-vm.md
@@ -1,0 +1,49 @@
+# ADR-057 — Symmetric builder VM across hosts
+
+**Status:** Proposed
+**Sprint:** 56 (W1)
+**Plan:** [Plan 100](../plans/100-symmetric-builder-vm-rollout.md)
+
+## Context
+
+Today's execution paths are asymmetric across host operating systems:
+
+- macOS: `Host → libkrun Linux VM (builder/runner) → Firecracker microVM`
+- Linux: `Host → Firecracker microVM (direct on host KVM)`
+
+Builder-backend dispatch lives at `crates/mvm-build/src/builder_backend_select.rs:86-91` (`resolve_builder_backend()`). On Linux, the host's userland sits in the TCB for every workload because workload microVMs share Linux's host kernel and a host process can `ptrace` Firecracker or read its `/proc/<pid>/mem` without ever crossing a hypervisor boundary. On macOS the same operations would first require breaching the libkrun Linux VM that sits between mvmctl and the workload — a different threat tier.
+
+This asymmetry undermines the security claims listed in ADR-002. Claim 1 ("no host-fs access from a guest beyond explicit shares") is meaningful only relative to the host being trusted not to peek. ADR-002 explicitly carves out "a malicious host" as out-of-scope, granting the host the hypervisor and the private build keys — but no more. On Linux today the host has more capability than the carve-out grants it, by virtue of running the workload directly. On macOS, it doesn't. The claim should hold uniformly.
+
+## Decision
+
+Workload microVMs always run inside a builder VM, regardless of host OS:
+
+- macOS keeps the libkrun-based builder VM it already has.
+- Linux gains a libkrun-based builder VM with nested KVM. Execution becomes: `Host KVM → libkrun Linux builder VM (nested KVM) → Firecracker workload microVM`.
+
+The signing identity is established inside the builder VM on both hosts. The host userland is no longer in the TCB on either; the host's role narrows to "owns the hypervisor process and the private build-key escrow, nothing else."
+
+## Consequences
+
+- **Boot-time cost.** A small Linux builder VM cold-starts on `mvmctl up` / first `mvmctl run` on Linux contributors. Reused across workloads in a single `mvmctl dev` session; the marginal cost across N workloads tends to zero. Plan 100 W0 measures the cold-start delta.
+- **Trust-claim uplift.** Claim 1 ("no host-fs access from a guest beyond explicit shares") becomes true on both OSes via identical mechanism. Claims 2, 3, 4, 5, 8, 9 inherit the strengthened TCB.
+- **Code simplification.** One execution model replaces two. The `mvm-backend/firecracker.rs` direct-launch path retires.
+- **Performance.** Nested KVM on Linux is well-supported in mainline kernels (`kvm-intel.nested=1`, `kvm-amd.nested=1` — default-on on most distros since ~5.10). Overhead is single-digit percent on hot paths.
+- **Doctor probe needed.** Some hosts (cloud Linux runners, container hosts, locked-down corporate workstations) disable nested virtualization. `mvmctl doctor` must detect and report.
+
+## Rejected alternatives
+
+- **Stay asymmetric.** Uneven trust story; can't make a uniform claim 1. Code paths diverge further over time.
+- **Reintroduce Lima for Linux symmetry.** Reverses the 2026-05-14 Lima removal for cosmetic symmetry; brings back YAML lifecycle, ssh-only access, and image distribution complexity. The trust property is independent of Lima — `mvm-libkrun` on Linux gives the same property cleanly without the abstraction debt.
+
+## Open questions
+
+- Builder VM cold-start latency on Linux CI runners. Plan 100 W0 measures this against the current Firecracker-direct baseline.
+- Nested KVM availability on cloud Linux hosts. Some cloud hypervisors disable nested virt by default (or expose it via per-VM capabilities). Doctor probe + clear failure mode required.
+
+## References
+
+- [ADR-001](001-firecracker-only.md) — Firecracker-only execution (needs update for nested model)
+- [ADR-002](002-microvm-security-posture.md) — microVM security posture (claim 1 reworded by Plan 100 W8)
+- [Plan 100](../plans/100-symmetric-builder-vm-rollout.md) — implementation rollout

--- a/specs/adrs/058-claim-10-bytes-leaving-trust-boundary.md
+++ b/specs/adrs/058-claim-10-bytes-leaving-trust-boundary.md
@@ -25,6 +25,9 @@ This ADR narrows ADR-002's "out of scope: a malicious host" carve-out. The new p
 
 Adversary capability assumed: read access to host filesystem and host network namespace. Not assumed: kernel module load, hypervisor hijack, signer key exfiltration (those are ADR-002's still-out-of-scope tier).
 
+**Adjacent surface — not addressed here, named so readers don't expect it:** inbound TLS termination is mvmd's concern, not mvm's. mvmd manages tenant certs at its multi-tenant edge and is the natural place to terminate inbound TLS. Workload-level TLS (the user's own HTTPS listener inside the microVM) stays encrypted end-to-end. This ADR's threat model is *outbound exfil from the workload*, not *inbound eavesdrop or auth* — different threat model, different ADR if/when it gets one.
+
+
 ## Decision
 
 Add claim 10 to ADR-002's CI-enforced security claims, in three legs.
@@ -47,10 +50,9 @@ Every key fingerprint, key rotation, and key-unwrap-failure event lands in the a
 
 ## Out of scope (named, like ADR-002)
 
-- **TLS termination / L7 packet inspection.** Different threat model (needs decryption, key material).
 - **Host filesystem encryption (FDE).** That's the user's concern — full-disk encryption protects host backups; this ADR protects per-volume at-rest exposure during active workload runs.
-- **Hardware-backed key attestation.** Post claim-10 future work.
-- **Per-byte traffic audit.** Aggregated flow_bytes only ([Plan 101](../plans/101-in-guest-volume-encryption-and-gateway-audit.md) W8).
+- **Per-byte traffic audit.** Aggregated `flow_bytes` only ([Plan 101](../plans/101-in-guest-volume-encryption-and-gateway-audit.md) W8).
+- **Audit metadata at rest.** The chain itself (5-tuples, byte counts, key fingerprints) is plaintext on host disk under `~/.mvm/audit/<tenant>.jsonl`. Tenant *data* is encrypted; tenant *behavior metadata* is not. Future claim 10.1 candidate; not in this sprint.
 
 ## Consequences
 

--- a/specs/adrs/058-claim-10-bytes-leaving-trust-boundary.md
+++ b/specs/adrs/058-claim-10-bytes-leaving-trust-boundary.md
@@ -1,0 +1,69 @@
+# ADR-058 — Claim 10: bytes leaving the trust boundary are encrypted, attested, and audited
+
+**Status:** Proposed
+**Sprint:** 56 (W2, W3, W4)
+**Plan:** [Plan 101](../plans/101-in-guest-volume-encryption-and-gateway-audit.md)
+
+## Context
+
+ADR-002 §"Out of scope" today carves out *a malicious host* — "mvmctl trusts the host with the hypervisor and private build keys." That carve-out is correct as stated, but the current implementation is too permissive: it grants the host more capability than the threat model requires.
+
+Specifically:
+
+- **RW tenant volumes are plaintext.** `mvmctl volume create` produces an AES-256-GCM archive (`crates/mvm-security/src/secret_store.rs`) that protects the volume's host-side file at rest *when locked*. But once a volume is opened and mounted into a guest, the backing storage on the host is decrypted ext4 / virtiofs. A host process with read access to the volume directory can read every byte the workload is writing or reading.
+- **Gateway flows are not in the audit chain.** `crates/mvm-core/src/policy/audit.rs` (`LocalAuditKind` enum) has plan/admission events and Stage 0 boot events, but no flow events. gvproxy (macOS) and passt (Linux) handle all guest network I/O at the host level; neither emits attested flow metadata. A compromised host can route, log, or exfil any traffic with no record landing in the chain.
+- **App-deps volumes have integrity, not confidentiality.** dm-verity-sealed deps volumes (claim 9, [Plan 73](../plans/73-app-deps-audit-pipeline.md) / [ADR-047](047-app-deps-audit-pipeline.md)) prove "what's on disk hasn't been tampered with." They don't hide what's on disk. Different property.
+
+Result: a host whose userland (not kernel — that's a different threat tier) has been compromised can read tenant data and silently exfil network traffic, and nothing in the audit chain notices.
+
+## Threat model
+
+This ADR narrows ADR-002's "out of scope: a malicious host" carve-out. The new posture:
+
+- **Still trusted:** the hypervisor binary, the host kernel, the host signer's private key. Compromise of any of these defeats mvmctl's isolation by definition; out of scope here as in ADR-002.
+- **No longer trusted (this ADR):** the host userland's *passive* read access. A user-space process on the host should not be able to (a) read tenant volume bytes at rest, or (b) exfil tenant network traffic, *without that fact being attested in the audit chain.*
+
+Adversary capability assumed: read access to host filesystem and host network namespace. Not assumed: kernel module load, hypervisor hijack, signer key exfiltration (those are ADR-002's still-out-of-scope tier).
+
+## Decision
+
+Add claim 10 to ADR-002's CI-enforced security claims, in three legs.
+
+### Leg 1 — Volume confidentiality
+
+Every RW tenant volume is dm-crypt / LUKS-2 inside the guest. The host's view of the volume backing store is ciphertext at all times, even while the workload is running.
+
+Key delivery: the signed `ExecutionPlan` carries a `Vec<EncryptedVolumeKey>` — per-volume symmetric keys, each wrapped under the tenant's pubkey. The mvm-supervisor never sees plaintext key material; it materializes the wrapped keys to an in-VM ramfs (never to host disk) and hands the ramfs path to the guest initramfs via kernel cmdline. The guest unwraps inside the VM using the tenant private key, escrowed by mvmd (cross-repo dep).
+
+### Leg 2 — Network traffic audit
+
+gvproxy (macOS) and passt (Linux) are wrapped with a control-socket listener that streams per-flow events to `mvm-supervisor`. Events: `flow_opened`, `flow_closed`, aggregated `flow_bytes` (every N seconds or on close), and `flow_policy_decision` (every deny / allow). All events land in the chained `~/.mvm/audit/<tenant>.jsonl`. The existing `mvm_supervisor::verify_audit_chain` mechanism extends to flow events with no schema break beyond the new enum variants.
+
+No L7 inspection. No TLS termination. Only connection metadata and byte counts.
+
+### Leg 3 — Crypto state attestability
+
+Every key fingerprint, key rotation, and key-unwrap-failure event lands in the audit chain. `mvmctl audit verify` covers volume-key events alongside flow events alongside the existing plan events. A new CI lane `claim-10-audit-tamper` exercises tamper detection: emit a known sequence, byte-flip one entry, assert `mvmctl audit verify` exits non-zero.
+
+## Out of scope (named, like ADR-002)
+
+- **TLS termination / L7 packet inspection.** Different threat model (needs decryption, key material).
+- **Host filesystem encryption (FDE).** That's the user's concern — full-disk encryption protects host backups; this ADR protects per-volume at-rest exposure during active workload runs.
+- **Hardware-backed key attestation.** Post claim-10 future work.
+- **Per-byte traffic audit.** Aggregated flow_bytes only ([Plan 101](../plans/101-in-guest-volume-encryption-and-gateway-audit.md) W8).
+
+## Consequences
+
+- `ExecutionPlan` grows: `volume_keys: Vec<EncryptedVolumeKey>` and `network_audit: NetworkAuditConfig` fields. PROTOCOL_VERSION bump in `crates/mvm-core/src/protocol/protocol.rs`.
+- mvmd cross-repo work: tenant root key, key derivation, rotation policy. Tracked as Plan 101 W5.
+- `mvmctl doctor` gains a `claim_10` row reporting LUKS-in-guest active + gateway audit emitting + audit chain valid.
+- New CI lane: `claim-10-audit-tamper` byte-flip test gates every PR.
+- Performance: dm-crypt overhead measurable on hot-path volume reads. Plan 101 W14 validates within threshold; backs out if pathological.
+
+## References
+
+- [ADR-002](002-microvm-security-posture.md) — microVM security posture (claim list extends to 10)
+- [ADR-041](041-signed-audited-execution-plans.md) — claim 8, signed ExecutionPlans (volume keys ride this signing path)
+- [ADR-047](047-app-deps-audit-pipeline.md) — claim 9, app-deps audit (analogous structure for the audit chain extension)
+- [ADR-055](055-cross-platform-backends.md) — gvproxy / passt gateway choice
+- [Plan 101](../plans/101-in-guest-volume-encryption-and-gateway-audit.md) — implementation rollout

--- a/specs/plans/100-symmetric-builder-vm-rollout.md
+++ b/specs/plans/100-symmetric-builder-vm-rollout.md
@@ -1,0 +1,55 @@
+# Plan 100 — Symmetric builder VM rollout
+
+**Sprint:** 56 (W1)
+**ADR:** [ADR-057](../adrs/057-symmetric-builder-vm.md)
+**Status:** Proposed
+
+## Goal
+
+Bring Linux up to the macOS execution model: workload microVMs always run inside a libkrun-launched Linux builder VM, regardless of host OS. Retire the direct-Firecracker-on-Linux path so claim 1 ("no host-fs access from a guest beyond explicit shares") holds uniformly.
+
+## Wave breakdown
+
+- [ ] **W0 — Feasibility prototype.** libkrun-on-Linux boot, nested-KVM smoke, measured cold-start time vs current Firecracker-direct path. Throw-away branch. Exit criteria: a workload microVM boots end-to-end inside a libkrun builder VM on a Linux runner; cold-start latency measured and within budget (target: <2× current direct-launch on the first workload, ~0 marginal on subsequent workloads in the same `mvmctl dev` session).
+
+- [ ] **W1 — Backend dispatch.** Extend `resolve_builder_backend()` (`crates/mvm-build/src/builder_backend_select.rs:86-91`) so Linux returns `LibkrunBuilderVm` instead of falling through to direct Firecracker. Gate behind `MVM_LINUX_BUILDER_VM=1` env var for the rollout window so we can flip it on/off without a recompile.
+
+- [ ] **W2 — Image distribution on Linux.** Ensure `nix/images/builder-vm/` builds on Linux contributor hosts (currently exercised mostly via macOS). No mvm-published prebuilt artifact — source-checkout-only per CLAUDE.md ("source-checkout builds never depend on mvm-published artifacts"). Validate `nix build .#builder-vm` from a Linux contributor host.
+
+- [ ] **W3 — Doctor probe.** Add `linux_nested_kvm_available()` to `mvmctl doctor`. Detect via `/sys/module/kvm_intel/parameters/nested` or `/sys/module/kvm_amd/parameters/nested`; report degraded mode if either is `0` / `N`. Emit install hint pointing to the kernel-module parameter fix.
+
+- [ ] **W4 — Integration tests.** Live-KVM smoke on Linux exercises the builder-VM path, not the direct-Firecracker path. Both must boot a workload microVM end-to-end (signed ExecutionPlan, dm-verity rootfs, audit chain entries). Add a regression test that fails if `MVM_LINUX_BUILDER_VM=1` ever silently falls back to direct.
+
+- [ ] **W5 — Cross-cut: ExecutionPlan/supervisor.** Confirm signed-plan flow and audit chain work identically through the nested layer. Plan signature verification, audit chain append, nonce replay-store — all must work when the supervisor runs inside the builder VM rather than on the host. No new event types needed; same `plan.admitted` / `plan.launched` / `plan.failed` chain. Add a test that asserts identical audit-event payloads on macOS vs Linux for the same workload spec.
+
+- [ ] **W6 — Migration: retire direct-Firecracker path on Linux.** Delete the host-side direct-launch code in `crates/mvm-backend/src/firecracker.rs` once W4 is green and `MVM_LINUX_BUILDER_VM=1` is the default. The supervisor + workload microVM still use Firecracker — just launched from inside the builder VM, not from the host. Flip the env-var default to "on" and remove the gate.
+
+- [ ] **W7 — Docs.** Update the architecture diagram in `CLAUDE.md` (currently shows `Linux Host -> Firecracker microVM`; becomes `Linux Host -> libkrun Linux VM -> Firecracker microVM`). Update `specs/adrs/001-firecracker-only.md` to reflect nested execution. Cross-reference ADR-057 from ADR-002.
+
+- [ ] **W8 — Claim posture update.** Reword ADR-002 claim 1: "...via identical builder-VM TCB on macOS and Linux." Add a CI gate in `.github/workflows/security.yml` that asserts no code path on Linux launches Firecracker without a builder VM ancestor process (grep-based or process-tree check inside the integration test).
+
+## Critical files
+
+- `crates/mvm-build/src/builder_backend_select.rs` (W1: backend dispatch)
+- `crates/mvm-backend/src/firecracker.rs` (W6: direct-launch path retires)
+- `crates/mvm-backend/src/libkrun.rs` (path used by Linux post-rollout)
+- `crates/mvm-libkrun/` (W0/W4: nested KVM enablement)
+- `crates/mvm-cli/src/commands/doctor.rs` (W3: probe)
+- `nix/images/builder-vm/flake.nix` (W2: Linux build validation)
+- `CLAUDE.md` (W7: architecture diagram + Linux host dependencies section)
+- `specs/adrs/002-microvm-security-posture.md` (W8: claim 1 reword)
+- `specs/adrs/001-firecracker-only.md` (W7: cross-ref nested model)
+- `.github/workflows/security.yml` (W8: CI gate)
+
+## Out of scope
+
+- Apple Container backend (separate ADR-056 / Sprint 55 work).
+- Vz backend (separate Sprint 55 work).
+- Hardware-virt detection on cloud runners beyond the W3 doctor probe.
+
+## Verification
+
+- W0 prototype attaches measured cold-start numbers to this plan as a follow-up comment.
+- W4 integration tests pass on the `linux` and `macos-14` CI lanes with `MVM_LINUX_BUILDER_VM=1`.
+- W6 deletes >0 lines from `mvm-backend/src/firecracker.rs` direct-launch path; `cargo build --workspace` still green.
+- W8 CI gate green on a clean PR; goes red if a developer adds a code path that bypasses the builder VM.

--- a/specs/plans/101-in-guest-volume-encryption-and-gateway-audit.md
+++ b/specs/plans/101-in-guest-volume-encryption-and-gateway-audit.md
@@ -1,0 +1,78 @@
+# Plan 101 — Claim 10: in-guest volume encryption + gateway audit
+
+**Sprint:** 56 (W2, W3, W4)
+**ADR:** [ADR-058](../adrs/058-claim-10-bytes-leaving-trust-boundary.md)
+**Status:** Proposed
+
+## Goal
+
+Add a CI-enforced security claim 10 to ADR-002: bytes leaving the trust boundary are encrypted at rest, attested through the audit chain, and undetectable network exfil is impossible. Three legs (volume confidentiality, gateway audit, crypto attestability), 14 waves total.
+
+## Wave breakdown
+
+### Leg 1 — Volume confidentiality
+
+- [ ] **W1 — LUKS-in-guest substrate.** Add `cryptsetup` to the guest initramfs (via `nix/images/builder-vm/` initramfs builder). Add a new `mvm-luks-init` binary alongside the existing `mvm-verity-init`. `mvm-luks-init` reads a key file path from kernel cmdline (`mvm.luks_keys=/run/keys/...`), unlocks one or more LUKS-2 volumes via `/dev/disk/by-id/`, and exits before pivot-root.
+
+- [ ] **W2 — ExecutionPlan schema.** Add `volume_keys: Vec<EncryptedVolumeKey>` to `crates/mvm-plan/src/plan.rs`. Each `EncryptedVolumeKey` carries `{ volume_id, wrapped_key: Vec<u8>, kdf_params, integrity_tag }`. Wrap under tenant pubkey at deploy time, sign the surrounding plan with the host signer. Extend `mvm_plan::verify_plan` to validate the wrapped-key envelope before admission. Bump `PROTOCOL_VERSION` in `crates/mvm-core/src/protocol/protocol.rs`.
+
+- [ ] **W3 — Supervisor wiring.** `mvm-supervisor` materializes wrapped keys to an in-VM ramfs at `/run/mvm/keys/` (never on host disk) and points `mvm-luks-init` at them via kernel cmdline. Extend `xtask check-no-display-on-secret-types` to cover the new `EncryptedVolumeKey` type so accidental `Debug` / `Display` impls fail CI.
+
+- [ ] **W4 — mvm-storage backend.** Storage backend recognizes `VolumeAttach { encryption: Some(EncryptionConfig) }` (extend `VolumeAttach` in `crates/mvm-core/src/protocol/protocol.rs:65-79`). On create, emit a LUKS-2 header sidecar at `~/.mvm/volumes/<id>/header.luks2`; on attach, validate the sidecar matches the wrapped key in the plan.
+
+- [ ] **W5 — Cross-repo gate (mvmd).** Coordinate with mvmd: tenant root key derivation (HKDF from tenant secret), per-volume key wrapping API, rotation policy. Tracked as the cross-repo dependency for Sprint 56. mvm side ships with a `mvmctl deploy --tenant-key-source <path>` fallback for local-dev / single-tenant flows that bypass mvmd.
+
+### Leg 2 — Gateway traffic audit
+
+- [ ] **W6 — Gateway audit substrate.** Wrap gvproxy (macOS) and passt (Linux) with a control-socket listener that streams flow events to `mvm-supervisor`. gvproxy wiring lands in the area already TODO'd at `crates/mvm-backend/src/vz.rs:809-811`; passt wiring extends the existing `PasstHandle` in `crates/mvm-libkrun/sys`. Socket path: `~/.mvm/audit/gateway-<instance>.sock` (mode 0700, supervisor-only).
+
+- [ ] **W7 — Audit event schema.** Extend `LocalAuditKind` in `crates/mvm-core/src/policy/audit.rs` with `flow_opened`, `flow_closed`, `flow_bytes`, `flow_policy_decision`. Each variant carries `{ instance_id, tenant_id, 5-tuple, bytes_sent, bytes_recv, started_at, ended_at }`. Hash-chain integrity preserved — new variants don't break existing `verify_audit_chain`.
+
+- [ ] **W8 — Sample-rate / aggregation policy.** Per-byte audit is too noisy; emit aggregated `flow_bytes` on flow close + every 30s for long-lived flows. Configurable per tenant in the `NetworkAuditConfig` ExecutionPlan field. Default: 30s.
+
+- [ ] **W9 — CLI surface.** `mvmctl audit traffic --tenant X --since Y --format json` to surface flow events without re-parsing JSONL by hand. Extend `mvmctl audit verify` to validate the chain across all event kinds (plan + Stage 0 + flow + volume-key).
+
+- [ ] **W10 — CI tamper gate.** New job `claim-10-audit-tamper` in `.github/workflows/security.yml`: emit a known sequence of flow events into a temp audit log, byte-flip one entry, assert `mvmctl audit verify` exits non-zero. Run on every PR.
+
+### Leg 3 — Crypto state attestability
+
+- [ ] **W11 — Key-fingerprint events.** Add `volume_key_bound`, `volume_key_rotated`, `volume_unwrap_failed` to `LocalAuditKind`. Chain entries on every key event. Surfaces in `mvmctl audit verify`.
+
+- [ ] **W12 — Doctor probe.** New `claim_10` row in `mvmctl doctor`: reports (a) LUKS-in-guest substrate present in current builder VM image, (b) gateway audit socket connectable, (c) most-recent audit chain valid. Each leg fail-closed with actionable error.
+
+- [ ] **W13 — Docs.** Add claim 10 to CLAUDE.md security model (extending the existing 1–9 list). Reference ADR-058 + Plan 101. Update `public/src/content/docs/guides/security.md` (if it exists) with the new threat model.
+
+- [ ] **W14 — Performance validation.** Measure dm-crypt overhead on hot-path volume reads (random 4K reads, sequential 1M reads). Document threshold (target: <10% on random, <5% on sequential). Back out the leg or re-evaluate KDF/cipher choice if pathological.
+
+## Critical files
+
+- `crates/mvm-plan/src/plan.rs` (W2: ExecutionPlan schema)
+- `crates/mvm-core/src/protocol/protocol.rs` (W2: PROTOCOL_VERSION bump; W4: VolumeAttach extension)
+- `crates/mvm-core/src/policy/audit.rs` (W7, W11: event-kind extensions)
+- `crates/mvm-supervisor/` (W3: key materialization; W6: gateway socket)
+- `crates/mvm-storage/` (W4: LUKS header sidecar)
+- `crates/mvm-libkrun/` (W6: passt wrapper)
+- `crates/mvm-backend/src/vz.rs` (W6: gvproxy wrapper)
+- `crates/mvm-cli/src/commands/audit.rs` (W9: new subcommand)
+- `crates/mvm-cli/src/commands/doctor.rs` (W12: claim_10 row)
+- `nix/images/builder-vm/` (W1: initramfs additions for `mvm-luks-init`)
+- `CLAUDE.md` (W13: claim 10 in security model)
+- `specs/adrs/002-microvm-security-posture.md` (W13: claim list extension)
+- `.github/workflows/security.yml` (W10: tamper-gate CI lane)
+
+## Out of scope
+
+- TLS termination / L7 packet inspection (different threat tier).
+- Host filesystem encryption (user's FDE concern, not mvm's).
+- Hardware-backed key attestation (post claim-10 future work).
+- Per-byte traffic audit (W8 aggregates to keep audit volume sane).
+
+## Verification
+
+- W1: `mvmctl dev shell` followed by `cryptsetup --version` returns a version string inside the workload.
+- W2: PROTOCOL_VERSION incremented; a downgraded mvmd refuses the new plan with a clear error.
+- W6: `nc -U ~/.mvm/audit/gateway-<instance>.sock` shows a stream of flow events while a workload makes outbound HTTP.
+- W9: `mvmctl audit traffic --tenant X` returns a JSON array of flow events for a recent workload run.
+- W10: CI lane green on the PR introducing the test; goes red if a developer breaks chain validation.
+- W12: `mvmctl doctor` reports `claim_10 ✓` on a clean install; reports `claim_10 ✗ (LUKS substrate missing)` if `mvm-luks-init` is removed from the builder VM image.
+- W14: benchmark numbers attached as a follow-up comment to this plan.

--- a/specs/plans/101-in-guest-volume-encryption-and-gateway-audit.md
+++ b/specs/plans/101-in-guest-volume-encryption-and-gateway-audit.md
@@ -44,6 +44,10 @@ Add a CI-enforced security claim 10 to ADR-002: bytes leaving the trust boundary
 
 - [ ] **W14 — Performance validation.** Measure dm-crypt overhead on hot-path volume reads (random 4K reads, sequential 1M reads). Document threshold (target: <10% on random, <5% on sequential). Back out the leg or re-evaluate KDF/cipher choice if pathological.
 
+### Cross-leg
+
+- [ ] **W15 — Hypervisor guest-memory pinning.** Add `mlockall` to libkrun and Firecracker launch wrappers to prevent host swap of guest plaintext. Without this, claim 10 leg 1 (volume confidentiality) has a residual gap: if a host runs with swap enabled, plaintext volume contents currently resident in the guest page cache can land on host swap files. `mvmctl doctor` probe warns if host swap is active without memory locking. libkrun pins guest memory by default on macOS; Firecracker on Linux needs explicit `mlockall` at launch.
+
 ## Critical files
 
 - `crates/mvm-plan/src/plan.rs` (W2: ExecutionPlan schema)
@@ -51,10 +55,11 @@ Add a CI-enforced security claim 10 to ADR-002: bytes leaving the trust boundary
 - `crates/mvm-core/src/policy/audit.rs` (W7, W11: event-kind extensions)
 - `crates/mvm-supervisor/` (W3: key materialization; W6: gateway socket)
 - `crates/mvm-storage/` (W4: LUKS header sidecar)
-- `crates/mvm-libkrun/` (W6: passt wrapper)
+- `crates/mvm-libkrun/` (W6: passt wrapper; W15: mlockall on launch)
 - `crates/mvm-backend/src/vz.rs` (W6: gvproxy wrapper)
+- `crates/mvm-backend/src/firecracker.rs` (W15: mlockall on launch)
 - `crates/mvm-cli/src/commands/audit.rs` (W9: new subcommand)
-- `crates/mvm-cli/src/commands/doctor.rs` (W12: claim_10 row)
+- `crates/mvm-cli/src/commands/doctor.rs` (W12: claim_10 row; W15: host-swap probe)
 - `nix/images/builder-vm/` (W1: initramfs additions for `mvm-luks-init`)
 - `CLAUDE.md` (W13: claim 10 in security model)
 - `specs/adrs/002-microvm-security-posture.md` (W13: claim list extension)
@@ -76,3 +81,4 @@ Add a CI-enforced security claim 10 to ADR-002: bytes leaving the trust boundary
 - W10: CI lane green on the PR introducing the test; goes red if a developer breaks chain validation.
 - W12: `mvmctl doctor` reports `claim_10 ✓` on a clean install; reports `claim_10 ✗ (LUKS substrate missing)` if `mvm-luks-init` is removed from the builder VM image.
 - W14: benchmark numbers attached as a follow-up comment to this plan.
+- W15: `mvmctl doctor` reports `claim_10_no_swap_leak ✓` on a host with swap disabled or `mlockall` succeeded; reports `✗` (with actionable error) on a host where swap is active and memory locking failed.


### PR DESCRIPTION
## Summary

Spec-only PR opening Sprint 56. Two structural trust-story gaps named via four new spec files; no implementation here.

**Thread 1 — Symmetric trust boundary**
- [ADR-057](specs/adrs/057-symmetric-builder-vm.md) — symmetric builder VM across hosts
- [Plan 100](specs/plans/100-symmetric-builder-vm-rollout.md) — rollout (W0–W8 checkboxes)

Linux today routes \`Host → Firecracker (direct on host KVM)\`; the host's userland is in the TCB for every workload. macOS goes through libkrun. Plan 100 brings Linux up to the macOS execution model (\`Host KVM → libkrun Linux VM → Firecracker workload microVM\`) so claim 1 ("no host-fs access from a guest beyond explicit shares") holds uniformly via identical builder-VM TCB.

**Thread 2 — Claim 10**
- [ADR-058](specs/adrs/058-claim-10-bytes-leaving-trust-boundary.md) — claim 10: bytes leaving the trust boundary are encrypted, attested, audited
- [Plan 101](specs/plans/101-in-guest-volume-encryption-and-gateway-audit.md) — in-guest volume encryption + gateway audit (W1–W14 checkboxes, three legs)

Today RW tenant volumes are plaintext while mounted; gateway flows are not in the audit chain. Plan 63 / ADR-042 cover host-side snapshot crypto + secret store — that's complementary, not overlapping. Plan 101 covers the in-use mount surface (LUKS-in-guest with ExecutionPlan-delivered wrapped keys) and network egress audit (per-flow events from gvproxy/passt into the chained audit log).

**SPRINT.md update** — Sprint 56 block (W1–W4, all 🟡 proposed) referencing the new ADRs/plans.

## Why these two together

Both narrow the "host is trusted" carve-out in ADR-002 from the same direction. Symmetric builder VM keeps the host's userland out of the TCB regardless of OS; claim 10 keeps it out of tenant data even when the host disk and network are observable. Different mechanisms, same threat-model narrowing.

## Out of scope for this PR

- Implementation of any wave. Each wave lands as its own PR.
- mvmd cross-repo work (Plan 101 W5).
- TLS termination / L7 inspection (named explicitly out in ADR-058).
- Reintroducing Lima (named explicitly out in ADR-057).

## Test plan

- [ ] Reviewer confirms numbering (ADR-057/058, Plan 100/101) doesn't collide with anything in flight.
- [ ] Reviewer confirms Plan 101 scope is distinct from already-shipped Plan 63 (host-side) — see ADR-058 §Context for the explicit boundary call-out.
- [ ] No code touched; \`cargo test --workspace\` not required for this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)