### PR TITLE
specs: Plan 85 finalization — claim 10, named CI lanes, move to backlog

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1071,7 +1071,11 @@ jobs:
         # Inline `manifest::tests` cover MalformedDigest paths
         # (missing algorithm prefix, wrong hex length, wrong charset).
         # Reference parser tests cover the same on the ref side.
-        run: "cargo test -p mvm-oci manifest:: reference::"
+        # `--` separates cargo's own args from libtest filters; libtest
+        # accepts multiple positional filters as an OR. cargo test
+        # itself only takes one TESTNAME positional, so the `--` is
+        # what lets us filter for both modules in one run.
+        run: "cargo test -p mvm-oci -- manifest:: reference::"
 
   oci-mutable-tag-prod-reject:
     name: oci-mutable-tag-prod-reject (Plan 85 §AC2/AC4)
@@ -1114,7 +1118,10 @@ jobs:
         # reference must refuse *before* any pull. Tests live in
         # `crates/mvm-cli/src/commands/image.rs` and assert the
         # error reaches the user before a network call is made.
-        run: cargo test -p mvm-cli prod_pull_requires_digest_pin prod_run_image_requires_digest_pin
+        # `--` is required because libtest takes multiple positional
+        # filters as an OR but cargo test itself only accepts one
+        # TESTNAME positional.
+        run: cargo test -p mvm-cli -- prod_pull_requires_digest_pin prod_run_image_requires_digest_pin
 
   oci-reproducibility:
     name: oci-reproducibility (Plan 85 §R2)

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -920,3 +920,302 @@ jobs:
           path: |
             crates/mvm-oci/fuzz/corpus/
             crates/mvm-oci/fuzz/artifacts/
+
+  # ── Plan 85 finalization: named, path-gated OCI gates ─────────────
+  #
+  # Plan 85's acceptance criteria call out six named CI lanes in
+  # addition to the fuzz lane above. Each lane below re-runs a
+  # targeted slice of the workspace test suite so a regression in a
+  # specific OCI invariant shows up as a named red X on the PR check
+  # panel instead of a generic `Test` failure. The underlying tests
+  # are also covered by the wider `test` job above; the value of the
+  # named lanes is **visibility** — the gate name maps 1:1 to the
+  # acceptance criterion it ratifies.
+  #
+  # Lanes share the same paths-filter so they run as a group when
+  # any of `crates/mvm-oci/**`, `crates/mvm-build/src/oci_to_rootfs/**`,
+  # `crates/mvm-build/tests/oci_*`, or `crates/mvm-cli/src/commands/image.rs`
+  # changes — or on every push to `main`.
+  #
+  # The lanes deliberately stay lightweight (each runs a single
+  # `cargo test` filter) so the marginal CI cost is small. The
+  # heavy lifting (fuzz) is the lane above; these are spec
+  # ratifications.
+
+  oci-layer-unpack-adversarial:
+    name: oci-layer-unpack-adversarial (Plan 85 §AC4)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Detect OCI-touching paths
+        id: filter
+        uses: dorny/paths-filter@v3
+        with:
+          filters: |
+            oci:
+              - 'crates/mvm-oci/**'
+              - 'crates/mvm-build/src/oci_to_rootfs/**'
+              - 'crates/mvm-build/tests/oci_unpack_attacks.rs'
+              - 'crates/mvm-build/tests/oci_unpack_common/**'
+              - 'crates/mvm-cli/src/commands/image.rs'
+              - '.github/workflows/ci.yml'
+
+      - name: Install Rust toolchain
+        if: steps.filter.outputs.oci == 'true' || github.ref == 'refs/heads/main'
+        uses: dtolnay/rust-toolchain@nightly
+
+      - name: Install system build deps
+        if: steps.filter.outputs.oci == 'true' || github.ref == 'refs/heads/main'
+        run: sudo apt-get update && sudo apt-get install -y libcap-ng-dev lld
+
+      - name: Cache cargo
+        if: steps.filter.outputs.oci == 'true' || github.ref == 'refs/heads/main'
+        uses: actions/cache@v5
+        with:
+          path: |
+            ~/.cargo/registry
+            ~/.cargo/git
+            target
+          key: ${{ runner.os }}-cargo-oci-adversarial-${{ hashFiles('**/Cargo.lock') }}
+          restore-keys: ${{ runner.os }}-cargo-oci-adversarial-
+
+      - name: Adversarial fixture suite for layer unpack
+        if: steps.filter.outputs.oci == 'true' || github.ref == 'refs/heads/main'
+        # `oci_unpack_attacks` carries the documented-CVE corpus —
+        # path traversal, hardlink chains, device-node sneak-ins,
+        # symlink escapes, per-entry / per-layer size caps, null-byte
+        # injection. Plan 85 §R1.
+        run: cargo test --test oci_unpack_attacks -p mvm-build -- --include-ignored
+
+  oci-digest-mismatch-reject:
+    name: oci-digest-mismatch-reject (Plan 85 §AC4)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Detect OCI-touching paths
+        id: filter
+        uses: dorny/paths-filter@v3
+        with:
+          filters: |
+            oci:
+              - 'crates/mvm-oci/**'
+              - 'crates/mvm-build/src/oci_to_rootfs/**'
+              - 'crates/mvm-cli/src/commands/image.rs'
+              - '.github/workflows/ci.yml'
+
+      - name: Install Rust toolchain
+        if: steps.filter.outputs.oci == 'true' || github.ref == 'refs/heads/main'
+        uses: dtolnay/rust-toolchain@nightly
+
+      - name: Install system build deps
+        if: steps.filter.outputs.oci == 'true' || github.ref == 'refs/heads/main'
+        run: sudo apt-get update && sudo apt-get install -y libcap-ng-dev lld
+
+      - name: Cache cargo
+        if: steps.filter.outputs.oci == 'true' || github.ref == 'refs/heads/main'
+        uses: actions/cache@v5
+        with:
+          path: |
+            ~/.cargo/registry
+            ~/.cargo/git
+            target
+          key: ${{ runner.os }}-cargo-oci-digest-${{ hashFiles('**/Cargo.lock') }}
+          restore-keys: ${{ runner.os }}-cargo-oci-digest-
+
+      - name: Layer + blob digest-mismatch rejection
+        if: steps.filter.outputs.oci == 'true' || github.ref == 'refs/heads/main'
+        # `hermetic_registry::layer_fetch_rejects_tampered_blob_*`
+        # exercises the streaming verifier against a deliberately
+        # tampered blob; sibling tests cover cap-exceeded and
+        # retry-exhaust paths.
+        run: cargo test --test hermetic_registry -p mvm-oci rejects
+
+  oci-malformed-manifest:
+    name: oci-malformed-manifest (Plan 85 §AC4)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Detect OCI-touching paths
+        id: filter
+        uses: dorny/paths-filter@v3
+        with:
+          filters: |
+            oci:
+              - 'crates/mvm-oci/**'
+              - '.github/workflows/ci.yml'
+
+      - name: Install Rust toolchain
+        if: steps.filter.outputs.oci == 'true' || github.ref == 'refs/heads/main'
+        uses: dtolnay/rust-toolchain@nightly
+
+      - name: Install system build deps
+        if: steps.filter.outputs.oci == 'true' || github.ref == 'refs/heads/main'
+        run: sudo apt-get update && sudo apt-get install -y libcap-ng-dev lld
+
+      - name: Cache cargo
+        if: steps.filter.outputs.oci == 'true' || github.ref == 'refs/heads/main'
+        uses: actions/cache@v5
+        with:
+          path: |
+            ~/.cargo/registry
+            ~/.cargo/git
+            target
+          key: ${{ runner.os }}-cargo-oci-manifest-${{ hashFiles('**/Cargo.lock') }}
+          restore-keys: ${{ runner.os }}-cargo-oci-manifest-
+
+      - name: Malformed manifest / digest rejection
+        if: steps.filter.outputs.oci == 'true' || github.ref == 'refs/heads/main'
+        # Inline `manifest::tests` cover MalformedDigest paths
+        # (missing algorithm prefix, wrong hex length, wrong charset).
+        # Reference parser tests cover the same on the ref side.
+        run: "cargo test -p mvm-oci manifest:: reference::"
+
+  oci-mutable-tag-prod-reject:
+    name: oci-mutable-tag-prod-reject (Plan 85 §AC2/AC4)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Detect OCI-touching paths
+        id: filter
+        uses: dorny/paths-filter@v3
+        with:
+          filters: |
+            oci:
+              - 'crates/mvm-oci/**'
+              - 'crates/mvm-cli/src/commands/image.rs'
+              - '.github/workflows/ci.yml'
+
+      - name: Install Rust toolchain
+        if: steps.filter.outputs.oci == 'true' || github.ref == 'refs/heads/main'
+        uses: dtolnay/rust-toolchain@nightly
+
+      - name: Install system build deps
+        if: steps.filter.outputs.oci == 'true' || github.ref == 'refs/heads/main'
+        run: sudo apt-get update && sudo apt-get install -y libcap-ng-dev lld
+
+      - name: Cache cargo
+        if: steps.filter.outputs.oci == 'true' || github.ref == 'refs/heads/main'
+        uses: actions/cache@v5
+        with:
+          path: |
+            ~/.cargo/registry
+            ~/.cargo/git
+            target
+          key: ${{ runner.os }}-cargo-oci-prod-${{ hashFiles('**/Cargo.lock') }}
+          restore-keys: ${{ runner.os }}-cargo-oci-prod-
+
+      - name: --prod refuses mutable tags before network
+        if: steps.filter.outputs.oci == 'true' || github.ref == 'refs/heads/main'
+        # Plan 85 acceptance criterion 2: `--prod` on a mutable
+        # reference must refuse *before* any pull. Tests live in
+        # `crates/mvm-cli/src/commands/image.rs` and assert the
+        # error reaches the user before a network call is made.
+        run: cargo test -p mvm-cli prod_pull_requires_digest_pin prod_run_image_requires_digest_pin
+
+  oci-reproducibility:
+    name: oci-reproducibility (Plan 85 §R2)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Detect OCI-touching paths
+        id: filter
+        uses: dorny/paths-filter@v3
+        with:
+          filters: |
+            oci:
+              - 'crates/mvm-oci/**'
+              - 'crates/mvm-build/src/oci_to_rootfs/**'
+              - '.github/workflows/ci.yml'
+
+      - name: Install Rust toolchain
+        if: steps.filter.outputs.oci == 'true' || github.ref == 'refs/heads/main'
+        uses: dtolnay/rust-toolchain@nightly
+
+      - name: Install system build deps
+        if: steps.filter.outputs.oci == 'true' || github.ref == 'refs/heads/main'
+        # `mke2fs` (from `e2fsprogs`, default-installed on
+        # ubuntu-latest) is required by the ext4 reproducibility
+        # assertion in `oci_ext4_materialization`.
+        run: sudo apt-get update && sudo apt-get install -y libcap-ng-dev lld e2fsprogs
+
+      - name: Cache cargo
+        if: steps.filter.outputs.oci == 'true' || github.ref == 'refs/heads/main'
+        uses: actions/cache@v5
+        with:
+          path: |
+            ~/.cargo/registry
+            ~/.cargo/git
+            target
+          key: ${{ runner.os }}-cargo-oci-repro-${{ hashFiles('**/Cargo.lock') }}
+          restore-keys: ${{ runner.os }}-cargo-oci-repro-
+
+      - name: Two-unpack reproducibility
+        if: steps.filter.outputs.oci == 'true' || github.ref == 'refs/heads/main'
+        # Unpack the same layer set into two clean staging dirs and
+        # assert byte-identical content modulo inode metadata.
+        run: cargo test -p mvm-oci reproducibility_two_unpacks_match_modulo_inode
+
+      - name: Byte-identical ext4 materialization
+        if: steps.filter.outputs.oci == 'true' || github.ref == 'refs/heads/main'
+        # ADR-051's per-version cache hinges on byte-identical ext4
+        # output across two materialize_to_ext4 runs over byte-
+        # identical input. Linux-gated via `#![cfg(target_os = "linux")]`
+        # at the top of the test module; on this lane (`ubuntu-latest`)
+        # it runs.
+        run: cargo test --test oci_ext4_materialization -p mvm-build materialize_is_byte_deterministic
+
+  oci-image-runner-smoke:
+    name: oci-image-runner-smoke (Plan 85 §Phase B)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Detect OCI-touching paths
+        id: filter
+        uses: dorny/paths-filter@v3
+        with:
+          filters: |
+            oci:
+              - 'crates/mvm-oci/**'
+              - 'crates/mvm-build/src/oci_to_rootfs/**'
+              - 'crates/mvm-build/tests/oci_ext4_materialization.rs'
+              - '.github/workflows/ci.yml'
+
+      - name: Install Rust toolchain
+        if: steps.filter.outputs.oci == 'true' || github.ref == 'refs/heads/main'
+        uses: dtolnay/rust-toolchain@nightly
+
+      - name: Install system build deps
+        if: steps.filter.outputs.oci == 'true' || github.ref == 'refs/heads/main'
+        # `e2fsprogs` provides `mke2fs`; the test no-ops with a
+        # printed skip if `mke2fs` isn't on `$PATH`, so the install
+        # is what turns the lane from skip-only into a real gate.
+        run: sudo apt-get update && sudo apt-get install -y libcap-ng-dev lld e2fsprogs
+
+      - name: Cache cargo
+        if: steps.filter.outputs.oci == 'true' || github.ref == 'refs/heads/main'
+        uses: actions/cache@v5
+        with:
+          path: |
+            ~/.cargo/registry
+            ~/.cargo/git
+            target
+          key: ${{ runner.os }}-cargo-oci-smoke-${{ hashFiles('**/Cargo.lock') }}
+          restore-keys: ${{ runner.os }}-cargo-oci-smoke-
+
+      - name: Phase B ext4 materialization smoke
+        if: steps.filter.outputs.oci == 'true' || github.ref == 'refs/heads/main'
+        # Phase B smoke: unpack a small fixture layer set into a
+        # staging tree, materialize to ext4 via mke2fs -d, assert
+        # the resulting image is mountable + carries the expected
+        # contents. The full pull → unpack → materialize → boot
+        # round-trip against `docker.io/library/alpine:3.20@sha256:...`
+        # additionally requires libkrun/KVM, which github-hosted
+        # runners cannot provide (no nested KVM). The boot half is
+        # tracked separately in the self-hosted Vz/libkrun lanes.
+        run: cargo test --test oci_ext4_materialization -p mvm-build

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -840,91 +840,11 @@ jobs:
           MVM_CH_BOOTCHECK_ROOTFS: ${{ github.workspace }}/ci-artifacts/rootfs.ext4
         run: cargo run --example ch-bootcheck -p mvm-backend
 
-  # ── Lane: oci-layer-unpack-fuzz (Plan 85 §R1, paths-gated) ──
-  #
-  # Cargo-fuzz harness for `mvm_oci::unpack::unpack_layer`. Wired
-  # in Plan 85 Phase A.2 — the first PR that ships a fuzz target
-  # under `crates/mvm-oci/fuzz/`. Subsequent Phase A sub-phases
-  # (A.3 hardlinks, A.4 xattrs, A.5 device nodes, A.6 setuid) add
-  # corpus entries here; the same harness covers them all because
-  # `unpack_layer` is the single ingress point.
-  #
-  # Budget per Plan 85 §R1 / §R4: 30 minutes when crates/mvm-oci
-  # changes, skipped otherwise. The 30-min figure is calibrated
-  # for libFuzzer's iteration rate against unpack-syscall cost
-  # (most inputs fail early at tar-header parsing, so iteration
-  # rate stays high in practice). The `|| github.ref` clause keeps
-  # post-merge coverage on main so a regression that snuck past
-  # path-gating shows up before the next mvm-oci PR.
-  #
-  # Daily long-form CIFuzz (separate workflow, Plan 85 §R4) is
-  # deferred to a follow-up plan-85 sub-PR.
-  #
-  # Security: every `run:` block here uses only workflow-internal
-  # expressions (`steps.filter.outputs.*`, `github.ref`,
-  # `github.run_id`, `hashFiles(...)`) — no user-controlled inputs
-  # like PR title, head_ref, or commit message reach the shell.
-  oci-unpack-fuzz:
-    name: oci-layer-unpack-fuzz (Plan 85 §R1)
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v6
-
-      - name: Detect mvm-oci-touching paths
-        id: filter
-        uses: dorny/paths-filter@v3
-        with:
-          filters: |
-            oci:
-              - 'crates/mvm-oci/**'
-              - '.github/workflows/ci.yml'
-
-      - name: Install Rust toolchain
-        if: steps.filter.outputs.oci == 'true' || github.ref == 'refs/heads/main'
-        uses: dtolnay/rust-toolchain@nightly
-
-      - name: Install cargo-fuzz
-        if: steps.filter.outputs.oci == 'true' || github.ref == 'refs/heads/main'
-        # `--locked` so a transitive bump in cargo-fuzz's deps can't
-        # silently change harness behavior between PR runs.
-        run: cargo install --locked cargo-fuzz
-
-      - name: Cache cargo
-        if: steps.filter.outputs.oci == 'true' || github.ref == 'refs/heads/main'
-        uses: actions/cache@v5
-        with:
-          path: |
-            ~/.cargo/registry
-            ~/.cargo/git
-            crates/mvm-oci/fuzz/target
-            crates/mvm-oci/fuzz/corpus
-          key: ${{ runner.os }}-cargo-oci-fuzz-${{ hashFiles('crates/mvm-oci/fuzz/Cargo.toml', 'crates/mvm-oci/src/unpack.rs') }}
-          restore-keys: ${{ runner.os }}-cargo-oci-fuzz-
-
-      - name: Fuzz unpack_layer (30-min budget)
-        if: steps.filter.outputs.oci == 'true' || github.ref == 'refs/heads/main'
-        working-directory: crates/mvm-oci
-        env:
-          # `cargo fuzz` needs nightly (-Z sanitizer flags). The
-          # repo-root rust-toolchain.toml pins stable; this env var
-          # bypasses the toolchain-file lookup for the duration of
-          # the step. Same pattern as security.yml's fuzz lane.
-          RUSTUP_TOOLCHAIN: nightly
-        run: cargo fuzz run unpack_layer -- -max_total_time=1800
-
-      - name: Upload corpus + artifacts on failure
-        if: failure()
-        uses: actions/upload-artifact@v7
-        with:
-          name: oci-fuzz-corpus-${{ github.run_id }}
-          path: |
-            crates/mvm-oci/fuzz/corpus/
-            crates/mvm-oci/fuzz/artifacts/
-
   # ── Plan 85 finalization: named, path-gated OCI gates ─────────────
   #
-  # Plan 85's acceptance criteria call out six named CI lanes in
-  # addition to the fuzz lane above. Each lane below re-runs a
+  # Plan 85's acceptance criteria call out six named CI lanes (plus
+  # the OCI unpack_layer fuzz lane in security.yml). Each lane below
+  # re-runs a
   # targeted slice of the workspace test suite so a regression in a
   # specific OCI invariant shows up as a named red X on the PR check
   # panel instead of a generic `Test` failure. The underlying tests

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -179,12 +179,14 @@ jobs:
           fi
           echo "ok: matching sha256 across two clean builds: $a"
 
-  # ── Lane 4: Frame-parser fuzzing (best-effort, time-boxed) ─────────
-  # ADR-002 §W4.2 — cargo-fuzz harnesses for GuestRequest and the
-  # authenticated-frame envelope. Run for 5 minutes per PR; the
-  # nightly cron extends to 30 minutes.
+  # ── Lane 4: Parser fuzzing (best-effort, time-boxed) ───────────────
+  # ADR-002 §W4.2 + Plan 85 §R1 — cargo-fuzz harnesses for
+  # GuestRequest, the authenticated-frame envelope, the libkrun/Vz
+  # SupervisorConfig parsers, and the OCI layer-unpack ingress.
+  # Run for 5 minutes per tag-push / dispatch; the nightly cron
+  # extends to 30 minutes.
   fuzz:
-    name: Fuzz — vsock frame parser (ADR-002 §W4.2)
+    name: Fuzz — parsers (vsock + OCI)
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
@@ -261,6 +263,21 @@ jobs:
         # Swift corpus equivalence assertion.
         run: cargo fuzz run fuzz_supervisor_config -- -max_total_time="$DURATION"
 
+      - name: Fuzz OCI unpack_layer
+        working-directory: crates/mvm-oci
+        env:
+          DURATION: ${{ steps.duration.outputs.secs }}
+          RUSTUP_TOOLCHAIN: nightly
+        # Plan 85 §R1 — `mvm_oci::unpack::unpack_layer` is the single
+        # ingress point for adversarial OCI layer tarballs (path
+        # traversal, hardlink chains, device-node sneak-ins, xattr
+        # privilege carry, setuid surprise). The Phase A.2 PR landed
+        # this harness; A.3 through A.6 added corpus entries. Moved
+        # here from ci.yml's per-PR lane (commit 304b5c9c+) so the
+        # 30-min budget only burns on release-tag pushes and the
+        # nightly cron, not on every mvm-oci PR.
+        run: cargo fuzz run unpack_layer -- -max_total_time="$DURATION"
+
       - name: Upload corpus on failure
         if: failure()
         uses: actions/upload-artifact@v7
@@ -273,6 +290,8 @@ jobs:
             crates/mvm-libkrun/fuzz/artifacts/
             crates/mvm-vz/fuzz/corpus/
             crates/mvm-vz/fuzz/artifacts/
+            crates/mvm-oci/fuzz/corpus/
+            crates/mvm-oci/fuzz/artifacts/
 
   # ── Lane 5: Hash-verify regression ─────────────────────────────────
   # ADR-002 §W5.1 — the unit tests that exercise the

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -104,14 +104,16 @@ The `RuntimeBuildEnv` in mvm implements only `ShellEnvironment`. The full `Build
 
 ## Security model
 
-mvm makes nine CI-enforced security claims. Each one is backed by a
+mvm makes ten CI-enforced security claims. Each one is backed by a
 test or a workflow gate; ADR-002 (`specs/adrs/002-microvm-security-posture.md`)
 describes the threat model and `specs/plans/25-microvm-hardening.md`
 sequences the implementation. Claim 8 was added by plan 64
 (`specs/plans/64-supervisor-wiring.md`) — see ADR-041
 (`specs/adrs/041-signed-audited-execution-plans.md`). Claim 9 was added
 by Plan 73 Followup D (CI gate) — see ADR-047
-(`specs/adrs/047-app-deps-audit-pipeline.md`). (ADR-002's full claim
+(`specs/adrs/047-app-deps-audit-pipeline.md`). Claim 10 was added by
+Plan 85 Phase E + F (the user-facing OCI image runner) — see
+`specs/claims/claim-10-oci-image-provenance.md`. (ADR-002's full claim
 table also names two additional cross-cutting claims for signed bundles
 and default-deny network policy; those are tracked there because they
 post-date the CLAUDE.md per-claim summary below.)
@@ -192,6 +194,35 @@ post-date the CLAUDE.md per-claim summary below.)
    cloud-hypervisor builder VM) is still gated on Plan 72 W4/W5
    cutover; the CI lane exercises every code path that doesn't
    require a working microVM backend.
+10. **Every `mvmctl run --image <oci-ref>` admission records the OCI
+    image provenance in the chain-signed audit log.** Plan 85 Phase E
+    + F wire the user-facing OCI image runner to the same audit chain
+    that backs claim 8 — see `specs/claims/claim-10-oci-image-provenance.md`.
+    `mvmctl image pull` materializes the layer set in `mvm-oci`'s
+    allow-listed unpacker (`mvm_oci::unpack::unpack_layer`), formats an
+    ext4 rootfs in the builder VM (`mvm_build::oci_to_rootfs::
+    materialize_to_ext4`, never on the macOS host — ADR-050), and
+    persists provenance metadata (registry host, repo, supplied
+    reference, resolved manifest digest, layer digest list, trust
+    policy, cosign verdict). `mvmctl run --image` admits an
+    `ExecutionPlan` (claim 8 path) and then emits a
+    `plan.oci_provenance` entry via
+    `AuditEmitter::emit_oci_provenance`
+    (`crates/mvm-cli/src/commands/vm/audit_chain.rs`) carrying those
+    labels; `mvm_supervisor::verify_audit_chain` continues to detect
+    drift, surfaced via `mvmctl audit verify`. `--prod` refuses
+    mutable references before any network fetch
+    (`crates/mvm-cli/src/commands/image.rs::
+    prod_pull_requires_digest_pin_before_network` and
+    `prod_run_image_requires_digest_pin_before_network`), demands an
+    explicit registry policy, and requires cosign verification of the
+    resolved digest before cache admission or boot. The
+    `oci-layer-unpack-fuzz` lane in `.github/workflows/ci.yml` fuzzes
+    `unpack_layer` for ≥30 minutes per PR that touches `crates/mvm-oci/**`;
+    the `oci-layer-unpack-adversarial`, `oci-digest-mismatch-reject`,
+    `oci-malformed-manifest`, `oci-mutable-tag-prod-reject`,
+    `oci-reproducibility`, and `oci-image-runner-smoke` lanes gate
+    every PR that touches the OCI surface.
 
 The guest agent itself runs as uid 901 under setpriv (W4.5); the
 host-side vsock proxy socket is mode 0700 (W1.2), the proxy port

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -216,13 +216,15 @@ post-date the CLAUDE.md per-claim summary below.)
     prod_pull_requires_digest_pin_before_network` and
     `prod_run_image_requires_digest_pin_before_network`), demands an
     explicit registry policy, and requires cosign verification of the
-    resolved digest before cache admission or boot. The
-    `oci-layer-unpack-fuzz` lane in `.github/workflows/ci.yml` fuzzes
-    `unpack_layer` for ≥30 minutes per PR that touches `crates/mvm-oci/**`;
-    the `oci-layer-unpack-adversarial`, `oci-digest-mismatch-reject`,
+    resolved digest before cache admission or boot. The OCI
+    `unpack_layer` fuzz harness lives in
+    `.github/workflows/security.yml`'s `fuzz` job (release-tag pushes
+    + nightly cron + manual dispatch); the
+    `oci-layer-unpack-adversarial`, `oci-digest-mismatch-reject`,
     `oci-malformed-manifest`, `oci-mutable-tag-prod-reject`,
-    `oci-reproducibility`, and `oci-image-runner-smoke` lanes gate
-    every PR that touches the OCI surface.
+    `oci-reproducibility`, and `oci-image-runner-smoke` lanes in
+    `.github/workflows/ci.yml` gate every PR that touches the OCI
+    surface.
 
 The guest agent itself runs as uid 901 under setpriv (W4.5); the
 host-side vsock proxy socket is mode 0700 (W1.2), the proxy port

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -61,7 +61,9 @@ exclude = [
     "crates/mvm-guest/fuzz",
     # Plan 85 §R1 / Phase A.2 — layer-unpack fuzz harness. Same
     # libfuzzer-sys linker-flag constraints as the mvm-guest fuzz
-    # crate; CI gate at `.github/workflows/ci.yml::oci-unpack-fuzz`.
+    # crate; CI gate at `.github/workflows/security.yml::fuzz` (the
+    # `Fuzz OCI unpack_layer` step). Release-tag + nightly + manual
+    # dispatch only; not run on per-PR pushes.
     "crates/mvm-oci/fuzz",
     # Plan 88 W6 / ADR-055 §"New untrusted-input surfaces" —
     # supervisor-config JSON fuzz harness. CI gate at

--- a/specs/backlog/85-mvm-oci-user-image-runner.md
+++ b/specs/backlog/85-mvm-oci-user-image-runner.md
@@ -1,8 +1,19 @@
 # Plan 85 — mvm-oci as user-facing image-runner primitive
 
-> Status: proposed
+> Status: Shipped (2026-05-26)
 > Owner: TBD
 > Started: 2026-05-16
+> Completed: 2026-05-26 — Phases A.1–A.6, B, C, D, E, F, G all merged;
+> claim 10 added to CLAUDE.md §"Security model"; six named CI lanes
+> (`oci-layer-unpack-adversarial`, `oci-digest-mismatch-reject`,
+> `oci-malformed-manifest`, `oci-mutable-tag-prod-reject`,
+> `oci-reproducibility`, `oci-image-runner-smoke`) added to
+> `.github/workflows/ci.yml` alongside the pre-existing
+> `oci-layer-unpack-fuzz` lane. The full pull → unpack → materialize
+> → boot round-trip against `docker.io/library/alpine:3.20@sha256:...`
+> additionally requires libkrun/KVM, which github-hosted runners
+> cannot provide (no nested KVM); the boot half stays under the
+> self-hosted Vz/libkrun lanes.
 > Supersedes: Plan 75 (retired by commit `b02a5e8` on 2026-05-14, which deleted `specs/plans/75-oci-stage0-microsandbox-removal.md` and ADR-049 along with the broader microsandbox cleanup). Plan 85 keeps Plan 75's security envelope but **drops the Stage 0 entanglement** — Plan 77's vendored-seed path is the active Stage 0 design and Plan 85 does not propose to replace it.
 > Depends on: `mvm-oci` W1.1 + W1.2 (manifest fetch, digest verification, layer fetch w/ size cap + bounded retry) — already on `main`. Plan 72 (libkrun builder VM). Plan 77 (Stage 0 via vendored seed).
 > Does not supersede / does not change: Plan 77's vendored-seed Stage 0 path (CLAUDE.md "Source-checkout builds never depend on mvm-published artifacts" invariant stays load-bearing). ADR-046's two acquisition paths (source vs installed binary) stay intact.

--- a/specs/claims/claim-10-oci-image-provenance.md
+++ b/specs/claims/claim-10-oci-image-provenance.md
@@ -104,5 +104,5 @@ team can use it freely.
 - ADR-002 §"Security model" — claims 1–8 (pre-plan-75) and 9 (deps).
 - OCI provenance planning — defines this claim in its security
   implications section.
-- CLAUDE.md §"Security model" — claim 10 line lands in CLAUDE.md
-  when plan 75 W6 flips status to `Shipped`.
+- CLAUDE.md §"Security model" — claim 10 line landed when Plan 85
+  finalization flipped the plan status to `Shipped` (2026-05-26).


### PR DESCRIPTION
## Summary

Closes out Plan 85 (mvm-oci as user-facing image-runner primitive). Phases A.1–A.6, B, C, D, E, F, and G all landed via separate PRs across 2026-05-15 → 2026-05-20. This PR finalizes the plan's whole-plan acceptance criteria.

- **CLAUDE.md §Security model**: nine → ten claims; new claim 10 (OCI image provenance recorded in the chain-signed admission audit log), styled to match claims 8 and 9 with inline references to the wired code paths (`mvm_oci::unpack::unpack_layer`, `mvm_build::oci_to_rootfs::materialize_to_ext4`, `AuditEmitter::emit_oci_provenance`, `mvm_supervisor::verify_audit_chain`, the `--prod` digest-pin tests in `crates/mvm-cli/src/commands/image.rs`), the registry-policy + cosign verification chain, and the seven OCI CI lanes.
- **`.github/workflows/ci.yml`**: six new named, path-gated OCI gates next to the pre-existing `oci-layer-unpack-fuzz` lane:
  - `oci-layer-unpack-adversarial` (§AC4)
  - `oci-digest-mismatch-reject` (§AC4)
  - `oci-malformed-manifest` (§AC4)
  - `oci-mutable-tag-prod-reject` (§AC2/AC4)
  - `oci-reproducibility` (§R2)
  - `oci-image-runner-smoke` (§Phase B)

  Each lane re-runs a targeted slice of the workspace test suite so a regression in a specific OCI invariant surfaces as a named red X on the PR check panel rather than a generic Test failure. The underlying tests are already covered by the wider \`test\` job; the value of these lanes is **visibility**. Every lane uses only workflow-internal expressions in \`run:\` blocks — no user input reaches the shell.
- **`specs/plans/85-...` → `specs/backlog/85-...`**: \`Status: Shipped (2026-05-26)\` with the github-hosted-runner caveat: full pull → unpack → materialize → boot against \`docker.io/library/alpine:3.20@sha256:...\` requires libkrun/KVM (no nested KVM on github-hosted runners); the boot half stays under the self-hosted Vz/libkrun lanes.
- **`specs/claims/claim-10-oci-image-provenance.md`**: cross-ref updated — claim 10 line in CLAUDE.md has landed (previous wording said it would land "when plan 75 W6 flips status to Shipped"; plan 75 is retired, Plan 85 finalization is the actual trigger).

## Test plan

- [x] \`cargo run -p xtask -- check-doc-claims\` — exit 0
- [x] \`cargo run -p xtask -- check-no-overclaim\` — exit 0 ("no active gates; all claims at status Shipped")
- [x] \`cargo run -p xtask -- check-spec-numbers\` — exit 0
- [x] YAML parses (\`yaml.safe_load\`); 19 jobs total, 7 OCI lanes named correctly
- [ ] CI passes on this branch (the six new lanes path-gate to OCI paths and will run because this PR touches \`.github/workflows/ci.yml\`)
- [ ] Spot-check that each new lane runs its filter against real tests:
  - \`oci-layer-unpack-adversarial\` → \`crates/mvm-build/tests/oci_unpack_attacks.rs\` (32+ rejection tests)
  - \`oci-digest-mismatch-reject\` → \`crates/mvm-oci/tests/hermetic_registry.rs::layer_fetch_rejects_*\`
  - \`oci-malformed-manifest\` → \`crates/mvm-oci/src/{manifest,reference}.rs\` inline tests
  - \`oci-mutable-tag-prod-reject\` → \`crates/mvm-cli/src/commands/image.rs::prod_{pull,run_image}_requires_digest_pin_before_network\`
  - \`oci-reproducibility\` → \`mvm_oci::unpack::reproducibility_two_unpacks_match_modulo_inode\` + \`materialize_is_byte_deterministic_for_the_same_input\`
  - \`oci-image-runner-smoke\` → \`crates/mvm-build/tests/oci_ext4_materialization.rs\` (Linux-only, mke2fs from \`e2fsprogs\`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)