### PR TITLE
fix(nix): close builder-VM workspace-filter gaps that OOM'd dev up

### DIFF
--- a/nix/images/builder-vm/flake.nix
+++ b/nix/images/builder-vm/flake.nix
@@ -84,26 +84,14 @@
         in
         if envPath != "" then /. + envPath else ../../..;
 
-      workspace = builtins.path {
-        path = workspaceRoot;
-        name = "mvm-workspace";
-        filter =
-          path: _type:
-          let
-            base = baseNameOf path;
-          in
-          !(builtins.elem base [
-            "target"
-            ".git"
-            "result"
-            "node_modules"
-            ".direnv"
-            ".cargo"
-            ".claude"
-            ".worktrees"
-          ])
-          && !(nixpkgs.lib.hasPrefix "result-" base);
-      };
+      # Filter list lives at nix/lib/workspace-filter.nix so the three
+      # flakes that ingest the host workspace (this one, builder/,
+      # runtime-overlay/) stay aligned with .gitignore in one place.
+      workspace =
+        (import (workspaceRoot + "/nix/lib/workspace-filter.nix") {
+          inherit (nixpkgs) lib;
+        })
+        { inherit workspaceRoot; };
 
       libFor = import (workspace + "/nix/lib") {
         inherit nixpkgs microvm;

--- a/nix/images/builder-vm/flake.nix
+++ b/nix/images/builder-vm/flake.nix
@@ -158,7 +158,12 @@
         findutils
         which
         nix
-        git
+        # gitMinimal drops perl/sendmail/gui/manpages (~20 MB). git is
+        # only invoked here by nix's `github:` substituter/fetcher; the
+        # core porcelain that needs is intact in the minimal build.
+        # `mvm-builder-init` does not shell to git (grep -rn '"git"' in
+        # crates/mvm-builder-init/).
+        gitMinimal
         gnumake
         curl
         jq

--- a/nix/images/builder/flake.nix
+++ b/nix/images/builder/flake.nix
@@ -77,26 +77,14 @@
           envPath = builtins.getEnv "MVM_WORKSPACE_PATH";
         in
         if envPath != "" then /. + envPath else ../../..;
-      workspace = builtins.path {
-        path = workspaceRoot;
-        name = "mvm-workspace";
-        filter =
-          path: _type:
-          let
-            base = baseNameOf path;
-          in
-          !(builtins.elem base [
-            "target"
-            ".git"
-            "result"
-            "node_modules"
-            ".direnv"
-            ".cargo"
-            ".claude"
-            ".worktrees"
-          ])
-          && !(nixpkgs.lib.hasPrefix "result-" base);
-      };
+      # Filter list lives at nix/lib/workspace-filter.nix so the three
+      # flakes that ingest the host workspace (this one, builder-vm/,
+      # runtime-overlay/) stay aligned with .gitignore in one place.
+      workspace =
+        (import (workspaceRoot + "/nix/lib/workspace-filter.nix") {
+          inherit (nixpkgs) lib;
+        })
+        { inherit workspaceRoot; };
 
       # Import the parent flake's library code directly. `nix/lib/`
       # lives at `${workspace}/nix/lib`; its `default.nix` returns

--- a/nix/images/runtime-overlay/flake.nix
+++ b/nix/images/runtime-overlay/flake.nix
@@ -102,26 +102,14 @@
         in
         if envPath != "" then /. + envPath else ../../..;
 
-      workspace = builtins.path {
-        path = workspaceRoot;
-        name = "mvm-workspace";
-        filter =
-          path: _type:
-          let
-            base = baseNameOf path;
-          in
-          !(builtins.elem base [
-            "target"
-            ".git"
-            "result"
-            "node_modules"
-            ".direnv"
-            ".cargo"
-            ".claude"
-            ".worktrees"
-          ])
-          && !(nixpkgs.lib.hasPrefix "result-" base);
-      };
+      # Filter list lives at nix/lib/workspace-filter.nix so the three
+      # flakes that ingest the host workspace (this one, builder/,
+      # builder-vm/) stay aligned with .gitignore in one place.
+      workspace =
+        (import (workspaceRoot + "/nix/lib/workspace-filter.nix") {
+          inherit (nixpkgs) lib;
+        })
+        { inherit workspaceRoot; };
 
       # mvmctl semver pinned to match
       # `[workspace.package].version` in the root Cargo.toml. The

--- a/nix/lib/workspace-filter.nix
+++ b/nix/lib/workspace-filter.nix
@@ -1,0 +1,50 @@
+# Single source of truth for filtering the host workspace tree into
+# the Nix store when building images. Used by:
+#
+#   nix/images/builder-vm/flake.nix
+#   nix/images/builder/flake.nix
+#   nix/images/runtime-overlay/flake.nix
+#
+# Maintenance: the excluded basenames here must stay aligned with the
+# root .gitignore. The two serve different purposes — .gitignore
+# honors path prefixes and negation; this filter matches basenames —
+# so they are not auto-derived. When you add a directory to
+# .gitignore that names something anywhere in the tree (a new build
+# artifact, a new tool's scratch dir), add its basename here too.
+
+{ lib }:
+
+{ workspaceRoot, name ? "mvm-workspace" }:
+builtins.path {
+  inherit name;
+  path = workspaceRoot;
+  filter =
+    path: _type:
+    let
+      base = baseNameOf path;
+    in
+    !(builtins.elem base [
+      # Build artifacts (Rust / Node / Astro / Nix outputs).
+      "target"
+      "result"
+      "node_modules"
+      ".direnv"
+      ".cargo"
+      "dist"
+      ".astro"
+      "dev-prebuilt"
+      # Test / generated outputs.
+      ".mvm-test"
+      "graphify-out"
+      ".ur-seed-result"
+      "nixos.qcow2"
+      # VCS / agent / worktree / tooling scratch.
+      ".git"
+      ".claude"
+      ".worktrees"
+      ".playwright-mcp"
+      # Secrets (host-side; the in-VM key path is ~/.mvm/keys).
+      "keys"
+    ])
+    && !(lib.hasPrefix "result-" base);
+}


### PR DESCRIPTION
## Summary

- Fixes the OOM that blocked `cargo run -- dev up`: Stage 0 was ingesting ~25 GB of the host workspace into the 14 GiB tmpfs-backed `/nix` store. The previous suspect (`target/`, 4.7 GB) was already excluded — the actual culprits were `.gitignore` entries that had drifted out of the three flake-local filter lists, chiefly `.mvm-test/` at **18 GB**.
- Extracts the workspace filter to `nix/lib/workspace-filter.nix` as the single source of truth. Three flakes (`builder-vm`, `builder`, `runtime-overlay`) now import it instead of carrying duplicate inline lists — this kills the three-way drift that produced the gap.
- New exclusions vs. the prior list: `.mvm-test`, `dist`, `.astro`, `dev-prebuilt`, `graphify-out`, `.ur-seed-result`, `nixos.qcow2`, `.playwright-mcp`, `keys`.
- Swaps `git` → `gitMinimal` in the builder VM closure (~20 MB save). `mvm-builder-init` does not shell to a git binary; git is only here for nix's `github:` substituter/fetcher.

Effective workspace ingest should drop from ~25 GB to ~5 GB, well under the Stage 0 tmpfs cap.

## Why not auto-derive from .gitignore

The negation rules at `.gitignore:30-31,37-38` re-include `crates/mvm-cli/src/commands/{build,env}/` paths that some global gitignores blanket-ignore. Mechanically mirroring `.gitignore` via `nix-gitignore` would silently lose those negations and break the build. The new file has a comment explaining the parity discipline.

## Test plan

- [ ] `cargo run -- dev up` from a cold cache (`rm -rf ~/.cache/mvm/builder-vm/`) completes without OOM
- [ ] Stage 0 `df -h /nix /tmp` log lines show `/nix` Used well below the 14 GiB cap
- [ ] `ls -lh ~/.cache/mvm/builder-vm/*/rootfs.ext4` — record baseline size for follow-up slim-down work
- [ ] All three flakes still evaluate (`nix flake check` in each `nix/images/*/` dir)
- [ ] `just lint && just ci` clean

## Follow-up

Per-package closure breakdown (`nix path-info -rSh`) on the resulting rootfs will inform the next round of slim-down: investigating whether `coreutils`/`gnugrep`/`gnused`/`gawk`/`findutils`/`which` are actually in the closure or already evicted by the busybox symlink-overwrite, and whether `uv`/`pnpm` can be lazy-fetched on first `install` call instead of baked in.