### PR TITLE
docs(specs): Plan 104 hardened host services broker + ADR-059

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,111 @@
+# Security Policy
+
+mvm is security-critical infrastructure. We take vulnerability reports seriously and ask researchers to follow coordinated disclosure.
+
+## Reporting a vulnerability
+
+**Do not** open a public GitHub issue for a security vulnerability.
+
+Report to: **security@tinylabs.com** (PGP key fingerprint published at <https://github.com/tinylabscom/mvm/security/advisories> when the GitHub advisory channel is enabled).
+
+Please include:
+
+- Affected mvm version(s) and platform(s) (macOS / Linux, arch, kernel version).
+- Reproduction steps or proof-of-concept code.
+- Your assessment of impact (confidentiality / integrity / availability) and the affected security claim (per [ADR-002 §"Security claims"](specs/adrs/002-microvm-security-posture.md)).
+- Whether you've shared the finding with anyone else and on what timeline.
+
+We acknowledge within **2 business days**.
+
+## Our commitments
+
+- **Acknowledgement:** within 2 business days.
+- **Triage + severity assessment:** within 5 business days (CVSS v3.1 + impact-on-claims rubric).
+- **Fix + advisory publication target** (under coordinated disclosure):
+  - **Critical** (claim-breaking — see ADR-002's live claim list): 14 days.
+  - **High** (mitigated by other layer but defense-in-depth weakened): 30 days.
+  - **Medium / Low:** 90 days.
+- **CVE assignment:** we request CVE IDs from the GitHub CNA or MITRE for any vulnerability rated Medium or higher.
+- **Credit:** by default we credit the reporter in the advisory; reporters can request anonymity.
+
+We will keep the reporter informed of progress at least weekly.
+
+## Coordinated disclosure
+
+The default disclosure window is **90 days** from acknowledgement to public advisory, or sooner if a fix is shipped earlier. We extend the window only with reporter agreement and a documented reason (e.g., a dependency CVE requires upstream coordination).
+
+If we cannot meet a 90-day window, we will negotiate an extension before day 75 with a concrete fix-availability ETA.
+
+## What's in scope
+
+Security-relevant code:
+
+- All four broker subprocesses (`mvm-broker`, `mvm-secrets-dispatcher`, `mvm-host-signer`, `mvm-audit-signer`) — see [Plan 104 §Hardening posture](specs/plans/104-host-services-broker.md#hardening-posture-layers-111).
+- The per-VM supervisor (`crates/mvm-supervisor/`).
+- The guest agent (`crates/mvm-guest/`).
+- The CLI surface (`mvmctl`) including `mvmctl up`, `mvmctl run`, `mvmctl image pull`, `mvmctl deps`, `mvmctl audit`, `mvmctl host-key`, `mvmctl services`, `mvmctl doctor`.
+- Audit chain integrity / verifier (`mvmctl audit verify`).
+- The signed-`ExecutionPlan` admission ceremony (per [ADR-041](specs/adrs/041-signed-audited-execution-plans.md)).
+- The OCI image runner (per [claim 10](specs/claims/claim-10-oci-image-provenance.md)).
+- The app-deps audit pipeline (per [ADR-047](specs/adrs/047-app-deps-audit-pipeline.md)).
+
+## What's out of scope
+
+- Vulnerabilities in upstream dependencies — please report those to the upstream project. We track their CVE surface per [ADR-059 §"Dependency CVE surface"](specs/adrs/059-host-services-broker.md#dependency-cve-surface) and will refresh our affected-version list per release. If an upstream CVE materially affects us, we coordinate with upstream and ship a doctor-refusal version of `mvmctl` once a fixed upstream is available.
+- Physical attacks on the host (cold-boot DRAM, DMA via Thunderbolt/PCIe, chip-off, hardware tampering) — per ADR-002 these are out of scope; the trust model assumes the host owner controls physical access.
+- Theoretical attacks without a reproducible exploit (we'll triage them but lower-priority).
+- Best-practice suggestions without a vulnerability ("you should use X instead of Y") — please open a GitHub Discussion instead.
+
+## How we ship fixes
+
+1. **Patch developed on a private branch** (security advisory draft on GitHub if applicable; otherwise local).
+2. **Patch reviewed** by at least two maintainers; for any patch touching the four broker subprocess crates or the audit-signer, the [CODEOWNERS](.github/CODEOWNERS) policy requires a second reviewer who didn't write the patch.
+3. **Patch released** under a new mvm version on the standard release pipeline. The release artefacts go through the hardening lanes per [Plan 104 W9](specs/plans/104-host-services-broker.md) — cosign signature, Sigstore/Rekor transparency entry, in-toto attestation, per-binary reproducibility-double-build.
+4. **Public advisory published** on GitHub Security Advisories simultaneously with or after the release tag, including:
+   - Affected versions.
+   - CVE ID (if assigned).
+   - CVSS score.
+   - Description of the issue, the security claim it touched, and what an attacker could have done.
+   - Description of the fix.
+   - Upgrade instructions.
+   - Credits.
+5. **Sigstore/Rekor log entry** for the patched binary is publicly searchable. The transparency log lets downstream users verify the fix was actually shipped, not just promised.
+
+## Verifying a release
+
+Every mvm release publishes:
+
+- **Cosign signatures** for each binary (`mvm-supervisor`, `mvmctl`, `mvm-broker`, `mvm-secrets-dispatcher`, `mvm-host-signer`, `mvm-audit-signer`). Public key shipped in `mvm-release-public-keys.json` in the release tarball.
+- **Sigstore / Rekor transparency log entry** per binary, queryable by `cosign tree --tag <release>`.
+- **In-toto attestation** documenting the build provenance (steps + materials + products).
+- **SLSA provenance** at build level.
+- **SHA-256 + SHA-512 checksums** for each artefact, signed under the cosign key.
+
+Verification command (will be added to a `tools/verify-release.sh` helper in Plan 104 W9):
+
+```sh
+cosign verify-blob --key mvm-release-public-keys.json \
+                   --signature mvm-supervisor-<version>.sig \
+                   mvm-supervisor-<version>
+cosign tree --tag <version>          # confirm Rekor entry exists
+# in-toto verification per https://in-toto.io/Specs/ instructions
+```
+
+## Hardening status by claim
+
+Each of mvm's published security claims (currently 1–10; ADR-059 proposes two more on merge) is backed by a CI gate. The current claim → gate mapping is documented in [CLAUDE.md §"Security model"](CLAUDE.md#security-model) and per-claim files in [specs/claims/](specs/claims/).
+
+A vulnerability that breaks a claim is **Critical** by definition.
+
+## Acknowledgements
+
+We thank the following researchers for responsible disclosures:
+
+_(none yet — placeholder for future credits)_
+
+## See also
+
+- [ADR-002 — microvm security posture](specs/adrs/002-microvm-security-posture.md) — the master security claim list and threat model.
+- [ADR-059 — host services broker](specs/adrs/059-host-services-broker.md) — the architecture of the broker subprocess set and the narrowed insider-threat clause.
+- [Plan 104 — host services broker](specs/plans/104-host-services-broker.md) — the hardening implementation specifics (Layers 1–11).
+- [threat model 02 — host services broker](specs/threat-models/02-host-services-broker.md) — STRIDE walk for the broker.

--- a/specs/SPRINT.md
+++ b/specs/SPRINT.md
@@ -2039,25 +2039,29 @@ See [Plan 101 W11–W14](plans/101-in-guest-volume-encryption-and-gateway-audit.
 
 ### Why this sprint
 
-Today secrets reach microVMs by mounting a sealed ext4 drive at `/mnt/secrets` at boot; ADR-048 tags this `unsafe_guest_secret_materialization` and declines to claim non-leakage. ADR-049 already committed to a vsock side-channel for secret substitution but stubs it. This sprint generalizes ADR-049's mechanism into a **host services broker** with `host.secrets.v1` running in a **dedicated subprocess** (production-ready isolation per industry analogues — AWS STS, Vault, K8s SA tokens) — and ships `host.time.v1` + `host.cost.v1` in the in-process general broker to validate the substrate works for more than one service. The out-of-process handler substrate ships in v1 with secrets as its first consumer; future addon services reuse it without protocol change. Designed for **extensibility** — Cargo feature flags per service, versioned ServiceIds with parallel-version support, service composition across the process boundary, JSON wire format consistent with existing `GuestRequest` / `HostBoundRequest` channels.
+Today secrets reach microVMs by mounting a sealed ext4 drive at `/mnt/secrets` at boot; ADR-048 tags this `unsafe_guest_secret_materialization` and declines to claim non-leakage. ADR-049 already committed to a vsock side-channel for secret substitution but stubs it. This sprint generalizes ADR-049's mechanism into a **host services broker** built on a **four-subprocess architecture** (per Plan 104 §Hardening posture L1): `mvm-broker` (uid 903, general handlers), `mvm-secrets-dispatcher` (uid 902, `host.secrets.v1`), `mvm-host-signer` (uid 904, host-signer key isolation), and `mvm-audit-signer` (uid 905, sole audit-chain writer). Each subprocess runs under seccomp + setpriv + per-workload cgroup + namespace isolation. The supervisor becomes a pure launcher + admission controller + IPC router; the host signer key is never loaded into the supervisor's address space, and the audit chain-signing key is never loaded into anything but `mvm-audit-signer`. Designed for **highest-defensible security** — hardware-enclave host signer (W8, Apple SE + Linux TPM 2.0), per-binary cosign + TOCTOU-resistant exec + config-signing, per-spawn subprocess response keys, algorithm-identifier byte for crypto agility, audit-log encryption at rest with TPM-derived keys, Sigstore/in-toto supply-chain transparency, threat-model expanded to include software insider attacks. Cost: roughly 3–4 sprints of work where the original draft was 1.
 
 ### Workstream breakdown
 
-- [ ] **W1 — Broker substrate + secrets-subprocess scaffolding** (envelope, registry, two vsock listeners per VM — port 5300 general + port 5301 secrets, `mvm-secrets-dispatcher` new crate, supervisor subprocess lifecycle, UDS proxy code path; no handlers yet)
-- [ ] **W2 — `ExecutionPlan.services` + admission wiring** (schema + registry assembly + `EventCategory::ServiceCall` + rate-limit/lifetime-quota/circuit-breaker)
-- [ ] **W3 — `host.time.v1`** (handler in general broker + `broker.v1/list_services` + delete `HostBoundRequest::QueryHostTime`)
-- [ ] **W4a — `host.cost.v1` workload-scope** (handler in general broker; no mvmd dep)
-- [ ] **W4b — `host.cost.v1` cross-tenant via mvmd** (depends on mvmd Plan 51 W1+W2+W3; mvmd-response validation)
-- [ ] **W5 — `host.secrets.v1` inside the secrets subprocess** (ADR-049 implementation; delete `KeystoreReleaser` stubs; inter-call memory hygiene; subprocess seccomp + setpriv + uid 902)
-- [ ] **W6 — Fuzz + CI** (`fuzz_service_call.rs`, `xtask check-handler-*` lints, cross-backend test matrix, subprocess crash isolation tests)
+- [ ] **W1 — Four-subprocess infrastructure substrate** (envelope, registry, two vsock listeners per VM — port 5300 general + port 5301 secrets; four new crates: `mvm-broker`, `mvm-secrets-dispatcher`, `mvm-host-signer`, `mvm-audit-signer`; supervisor subprocess lifecycle for all four; UDS proxy code paths; cosign-verify + TOCTOU-resistant exec + config-signing per subprocess; per-workload cgroup + namespace isolation; resource caps; binary hardening; doctor host-posture checks; KSM/THP off; `fido_touch_required()` stub on `mvmctl up --prod`)
+- [ ] **W2 — `ExecutionPlan.services` + admission wiring + audit-signer wiring** (schema bump 4→5; registry assembly; `EventCategory::ServiceCall` routed through `mvm-audit-signer`; `O_APPEND` audit FD + dir-immutable; chain-head persistence; at-rest encryption; time-source integrity; rate-limit / lifetime-quota / circuit-breaker; session-key rotation; operator-action audit entries)
+- [ ] **W3 — `host.time.v1`** (handler in `mvm-broker` + `broker.v1/list_services` + delete `HostBoundRequest::QueryHostTime`)
+- [ ] **W4a — `host.cost.v1` workload-scope** (handler in `mvm-broker`; no mvmd dep)
+- [ ] **W4b — `host.cost.v1` cross-tenant via mvmd** (depends on mvmd Plan 52 W1+W2+W3; mvmd-response validation; tenant-level secret quotas; mvmd identity pinning)
+- [ ] **W5 — `host.secrets.v1` inside `mvm-secrets-dispatcher`** (ADR-049 implementation; per-spawn response signing; seccomp policy compliance tests; side-channel audit via dudect/CTGrind; latency floor; `KeystoreReleaser` stubs deleted)
+- [ ] **W6 — Fuzz + CI + mutation testing** (`fuzz_service_call.rs`, UDS-proxy fuzz, `xtask check-handler-*` + `xtask check-subprocess-fd-inheritance` lints, `cargo-mutants` lane, cross-backend test matrix, hostile-subprocess test per subprocess kind)
 - [ ] **W7 — ADR-049 §W3 SDK matrix** (Python + TS + Rust hook libraries; splittable per language)
+- [ ] **W8 — Hardware-enclave host signer** (Apple Secure Enclave on macOS + Linux TPM 2.0; algorithm-identifier byte enables P-256; `mvmctl host-key rotate` ceremony + TPM monotonic counter for rollback resistance; audit-encryption key migration to TPM/SE-derived master; software fallback retained with loud doctor downgrade)
+- [ ] **W9 — Supply chain + release hardening** (Sigstore/Rekor transparency log entries per subprocess release; in-toto attestations alongside SLSA; per-binary hermetic + reproducibility-double-build lane; CODEOWNERS + branch protection; `cargo-mutants` lane; crypto-crate pinning + `deny.toml` + RFC-8785 JCS conformance)
+- [ ] **W10 — Documentation + threat model** (`specs/threat-models/02-host-services-broker.md` STRIDE walk per service; `SECURITY.md` CVE response runbook; `docs/security/{audit-fields,deployment-modes}.md`; operator runbook; CLAUDE.md update)
+- [ ] **W11 — Operator FIDO ceremony full implementation** (may slip to Sprint 58 follow-on; Yubikey-touch on `mvmctl up --prod`; encrypted-USB fallback for non-FIDO hosts; doctor probes; `mvmctl host-key rotate` requires FIDO touch)
 
 ### Cross-repo dependency (mvmd)
 
-- [ ] mvmd **Plan 51** — host services cross-VM endpoints (`../mvmd/specs/plans/51-host-services-cross-vm-endpoints.md`)
-- [ ] mvmd **ADR-0022** — mvmd as cross-VM delegate (`../mvmd/specs/adrs/0022-mvmd-host-services-delegation.md`)
+- [ ] mvmd **Plan 52** — host services cross-VM endpoints (`../mvmd/specs/plans/52-host-services-cross-vm-endpoints.md`)
+- [ ] mvmd **ADR-0023** — mvmd as cross-VM delegate (`../mvmd/specs/adrs/0023-mvmd-host-services-delegation.md`)
 
-mvmd Plan 51 W1+W2+W3 must land before mvm W4b opens; mvm W1–W4a + W5 + W6 + W7 have no mvmd dep and land in parallel.
+mvmd Plan 52 W1+W2+W3 must land before mvm W4b opens; mvm W1–W4a + W5–W11 have no mvmd dep and land in parallel.
 
 ### Security claims under this sprint
 
@@ -2065,19 +2069,28 @@ Two new claims proposed in ADR-059 (numbers TBD — Sprint 56 holds claim 10):
 - Every host-side service is bound to a signed `ExecutionPlan.services` entry, enforced before dispatch, audited via the chain.
 - No raw secret value crosses the broker channel; `host.secrets.v1` returns destination-bound, time-bound signed credentials only.
 
+ADR-059 additionally documents the narrowing of ADR-002's "malicious host" out-of-scope clause: physical attacks (cold-boot, DMA, hardware tampering) remain out of scope, but *software* insider attacks (shell access to the host by an unauthorized operator) are newly in scope thanks to L1 process isolation + L2 hardware-enclave keys + L5 at-rest audit encryption.
+
 ### Sprint 57 success criteria
 
 - [ ] `ExecutionPlan.services` schema landed and signature-verified at admission (`SCHEMA_VERSION` bumped 4→5).
-- [ ] General broker listens on vsock 5300, dispatches `host.time.v1` / `host.cost.v1` / `broker.v1`.
-- [ ] `mvm-secrets-dispatcher` subprocess listens on vsock 5301, dispatches `host.secrets.v1` only; runs at uid 902 with seccomp `standard` + setpriv.
+- [ ] All four subprocesses (`mvm-broker`, `mvm-secrets-dispatcher`, `mvm-host-signer`, `mvm-audit-signer`) cosign-verified at spawn, configured via signed JSON config, running under per-arch seccomp + setpriv + per-workload cgroup + namespace isolation.
+- [ ] `mvm-broker` listens on vsock 5300; dispatches `host.time.v1` / `host.cost.v1` / `broker.v1`.
+- [ ] `mvm-secrets-dispatcher` listens on vsock 5301; dispatches `host.secrets.v1` only.
+- [ ] `mvm-host-signer` is the sole holder of the host signer key; supervisor signs plans via UDS RPC. HW-enclave path live on macOS SE + Linux TPM 2.0 (W8); software-fallback row in doctor.
+- [ ] `mvm-audit-signer` is the sole writer to `~/.mvm/audit/<tenant>.jsonl`; sole holder of the audit chain-signing key; `O_APPEND` FD + dir-immutable + chain-head persistence + at-rest AEAD encryption all enforced.
 - [ ] `host.secrets.v1` returns destination-bound signed credentials per ADR-049 with JCS-canonicalized signing; `KeystoreReleaser` stubs deleted.
-- [ ] Subprocess crash isolation verified: kill subprocess → supervisor survives, workload sees `Err(Unavailable)`; kill supervisor → subprocess exits cleanly via pdeathsig.
+- [ ] Subprocess crash isolation verified for each kind: kill any subprocess → supervisor survives, workload sees `Err(Unavailable)`; kill supervisor → all four subprocesses exit cleanly via pdeathsig/kqueue.
 - [ ] `HostBoundRequest::QueryHostTime` deleted; internal caller migrated to broker.
-- [ ] `fuzz_service_call.rs` ≥5min/PR in CI; `xtask check-handler-*` lints block orphans.
+- [ ] `fuzz_service_call.rs` ≥5min/PR in CI; UDS-proxy fuzz lane; `xtask check-handler-*` + `xtask check-subprocess-fd-inheritance` lints block orphans; `cargo-mutants` lane catches mutation escapes.
 - [ ] Cross-backend test matrix green on libkrun / Firecracker / Apple Container / vz; **both ports listen on all four backends** (vz requires new `VZVirtioSocketListener` Swift class).
-- [ ] mvmd Plan 51 endpoints live (iroh ALPN, signed catalog responses); mvm W4b green; cross-tenant authz refused; malformed-mvmd-response rejected.
+- [ ] Per-binary reproducibility-double-build lane green for all four subprocesses; Sigstore/Rekor entries present for the release artefacts; in-toto attestations alongside SLSA.
+- [ ] mvmd Plan 52 endpoints live (iroh ALPN, signed catalog responses); mvm W4b green; cross-tenant authz refused; malformed-mvmd-response rejected; tenant-level secret-quota enforced; mvmd identity pin enforced.
 - [ ] ADR-049 §W3 SDK matrix complete in Python + TS + Rust; hostile-guest tests green; S25 placeholder-egress backstop in gvproxy/passt detects and drops `mvm-secret://` patterns.
-- [ ] Falsifiability: throwaway `host.dev.echo.v1` lands in one handler file (in-process) without touching envelope/registry/auth; out-of-process variant exercises the secrets-dispatcher substrate pattern.
+- [ ] `mvmctl doctor` refuses admission on weak hosts (KASLR, KPTI, SMEP/SMAP, Spectre-v2, LSM, KSM, THP, etc.) and on known-affected vsock CVE versions; `--insecure-host` audits + warns.
+- [ ] `mvmctl up --prod` invokes `fido_touch_required()` stub (audits `operator.fido.unverified`); W11 full FIDO ceremony lands within the sprint or slips with explicit Sprint-58 ticket.
+- [ ] `specs/threat-models/02-host-services-broker.md` published; `SECURITY.md` CVE response runbook updated; CLAUDE.md security model updated to reference Plan 104 + new claim numbers.
+- [ ] Falsifiability: throwaway `host.dev.echo.v1` lands in one handler file (in-process in `mvm-broker`) without touching envelope/registry/auth; out-of-process variant exercises the subprocess substrate pattern.
 
 ### Non-goals (explicit)
 

--- a/specs/adrs/059-host-services-broker.md
+++ b/specs/adrs/059-host-services-broker.md
@@ -1,0 +1,188 @@
+# ADR-059 — Host services broker over vsock
+
+- **Status:** Proposed
+- **Date:** 2026-05-27
+- **Owner:** MVM Project
+- **Related:** [ADR-002 microvm security posture](002-microvm-security-posture.md), [ADR-041 signed audited execution plans](041-signed-audited-execution-plans.md), [ADR-047 app deps audit pipeline](047-app-deps-audit-pipeline.md), [ADR-048 claim-safe sandbox parity](048-claim-safe-sandbox-parity.md), [ADR-049 secret substitution mechanism](049-secret-substitution-mechanism.md), [ADR-053 guest protocol versioning and readiness](053-guest-protocol-versioning-and-readiness.md), [ADR-055 passt virtio-net](055-passt-virtio-net.md), [ADR-058 claim-10 bytes leaving trust boundary](058-claim-10-bytes-leaving-trust-boundary.md), mvmd [ADR-0023 mvmd host services delegation](../../../mvmd/specs/adrs/0023-mvmd-host-services-delegation.md), [Plan 104 host services broker](../plans/104-host-services-broker.md), [threat model 02 host services broker](../threat-models/02-host-services-broker.md)
+
+## Context
+
+Today, anything a microVM needs from the host arrives one of two ways:
+
+1. **Boot-time only** — read-only ext4 drive mounted at `/mnt/secrets` (`mvmctl up --volume host_dir:/mnt/secrets`). ADR-048 tags this `unsafe_guest_secret_materialization` and declines a non-leakage claim.
+2. **A small fixed-verb reverse channel** — `HostBoundRequest` on vsock port 53 carries `WakeInstance`, `QueryInstanceStatus`, `QueryHostTime`. Each new verb is a code change to an enum.
+
+ADR-049 committed to a vsock side-channel for secret substitution as v1's secrets mechanism, but stubbed the implementation. What's needed is broader than secrets: a **host-side services layer** microVMs call at runtime — secrets, time, cost, and (later) logging / audit / monitoring — with one auth model, one capability model, one audit chain, one extension point that supports built-in and addon-provided services without protocol churn.
+
+This ADR records the architectural decisions for that broker. Plan 104 carries the implementation specifics.
+
+## Decision
+
+Ship a **host services broker** with the following committed shape:
+
+### Architecture: four-subprocess design
+
+The supervisor is a pure launcher + admission controller + IPC router. Four per-VM subprocesses share zero address space with the supervisor and zero address space with one another:
+
+| Subprocess | UID | Role | Listens on |
+| --- | --- | --- | --- |
+| `mvm-broker` | 903 | General handlers: `host.time.v1`, `host.cost.v1`, `broker.v1` | vsock 5300 + per-VM UDS |
+| `mvm-secrets-dispatcher` | 902 | `host.secrets.v1` only | vsock 5301 + per-VM UDS |
+| `mvm-host-signer` | 904 | Sole holder of the host signer key; signs plans + signed credentials via UDS RPC | per-VM UDS only |
+| `mvm-audit-signer` | 905 | Sole writer to `~/.mvm/audit/<tenant>.jsonl`; sole holder of the audit chain-signing key | per-VM UDS only |
+
+Each subprocess runs under seccomp + setpriv + per-workload cgroup v2 + PID/mount namespaces. Each binary is cosign-verified at spawn with TOCTOU-resistant mmap-then-`fexecve`. Each subprocess's startup config is a JSON envelope signed under the same release-time key as the binary; subprocess refuses to start unless config signature verifies. Each subprocess has its own per-spawn ephemeral keypair and signs every response it produces; the supervisor verifies the signature before relaying. See [Plan 104 §Hardening posture](../plans/104-host-services-broker.md#hardening-posture-layers-111) for the per-subprocess hardening matrix.
+
+### Protocol
+
+- **Two vsock ports per VM:** 5300 (general broker) + 5301 (secrets).
+- **Wire format:** 4-byte big-endian length-prefixed JSON; payload is `serde_json::Value` wrapped in `ServiceCall` / `ServiceResponse` envelopes with `#[serde(deny_unknown_fields)]`.
+- **Authentication:** `AuthenticatedFrame` (Ed25519 + session id + sequence) on both ports from day one, with a 1-byte **algorithm-identifier** in the frame header (`0x01=Ed25519`, `0x02=ECDSA-P256` for the macOS SE host-signer path; reserved for future PQC).
+- **Signed payloads:** JCS-canonicalized per RFC 8785 (`serde_jcs`).
+- **No CBOR.** Decided 2026-05-26 (Plan 104 §T3) in favor of JSON for SDK-matrix friction and `jq` debuggability.
+
+### Five-rule capability gating
+
+Every call traverses, in order: (1) schema gate (size, depth, parse timeout), (2) authentication gate (`AuthenticatedFrame` verify, replay rejection), (3) binding gate (`ExecutionPlan.services` lookup), (4) profile + rate-limit + quota gate, (5) handler-specific policy (typed `parse_payload` with `deny_unknown_fields`; destination-URL match for `host.secrets.v1`). Gates 1–4 run in the supervisor; gate 5 runs in the subprocess that owns the service. See Plan 104 §"Capability gating" for the full failure-mode walk.
+
+### Audit chain
+
+`EventCategory::ServiceCall` extends `mvm-audit-signer`'s entry set. Every dispatch — allowed or denied — emits one entry: `(service, verb, outcome, correlation_id)`. Payload content is never logged (ADR-053 §4 redaction invariant). Operator actions (`mvmctl services revoke`, `mvmctl host-key rotate`, `mvmctl audit verify`, `mvmctl up --insecure-host`) emit chain-signed entries via `mvm-audit-signer`. Chain entries are JCS-canonical, self-contained, `O_APPEND`-only on a dir-immutable FS, with `chain_head` persisted to a second location on every append. Per-tenant ChaCha20-Poly1305 encryption at rest, key derived from a TPM/SE-bound master (Layer 5).
+
+### Cross-VM via mvmd
+
+Cross-VM data goes through mvmd-agent's existing iroh ALPN transport (`crates/mvmd-agent/src/transport.rs`) with new typed `AgentRequest` variants — NOT a new HTTP route, NOT raw QUIC+mTLS. Cross-tenant authorization happens mvmd-side via tenant-scoped-authz (ADR-0008). The mvmd-side work lives in [mvmd Plan 52 + ADR-0023](../../../mvmd/specs/adrs/0023-mvmd-host-services-delegation.md). The supervisor pins mvmd's public key at `~/.mvm/keys/mvmd-pubkey`; admission refuses without a pin.
+
+### `ExecutionPlan` schema bump 4 → 5
+
+`ExecutionPlan` gains a `services: Vec<ServiceBinding>` field. Old (v4) plans hard-fail at verification per the project's no-backcompat rule; no shim, no silent default. `crates/mvm-plan/src/plan.rs:45` `SCHEMA_VERSION: u32 = 4` becomes `5`. Migration: any in-flight v4 plans must be re-synthesized + re-signed under v5 to keep running.
+
+## Implementation choices
+
+These are pinned-now-so-they-don't-drift:
+
+| Concern | Crate / mechanism | Why |
+| --- | --- | --- |
+| Signing | `ed25519-dalek` v2.x | RustCrypto, constant-time verified |
+| Canonical JSON | `serde_jcs` (pin exact version; CI runs RFC 8785 conformance corpus on every PR) | Required for cross-implementation signature verification |
+| AEAD for audit-at-rest | `chacha20poly1305` (RustCrypto, audited) | Audit logs at rest under H-L5.4 |
+| TPM (Linux) | `tpm2-tss` (Intel) | Linux host-signer key isolation under H-L2.1 |
+| Secure Enclave (macOS) | Swift bridge to `SecKeyCreateRandomKey` with `kSecAttrTokenIDSecureEnclave` (P-256) | macOS host-signer key isolation under H-L2.1 |
+| Constant-time comparisons | `subtle::ConstantTimeEq` | H-L4.5; CI grep lint enforces |
+| Seccomp filters | `seccompiler` | Per-arch (x86_64 + aarch64) deny-lists under H-L3.3 |
+| FIDO (W11) | `webauthn-authenticator-rs` | Operator FIDO ceremony under G2 / H-L11.6 |
+
+All crates are present in `deny.toml` with advisory + license enforcement.
+
+## Deployment modes
+
+The broker is invoked in three deployment modes. Threats and mitigations apply differently:
+
+| Mode | Description | Threats in scope | Notes |
+| --- | --- | --- | --- |
+| **single-dev** | A developer running `mvmctl` on their laptop | Hostile guest workload; hostile network for mvmd path | Insider threat NOT in scope (developer is the operator) |
+| **CI** | A CI runner executing `mvmctl up` from a PR or branch | Above + hostile-PR insider (PR author cannot be trusted with prod credentials) | `mvmctl up --prod` should be gated by the FIDO ceremony (W11); CI auto-runs are `--no-prod` |
+| **fleet (multi-tenant via mvmd)** | mvmd-orchestrated workloads across many hosts | Above + hostile mvmd-agent (S15), hostile multi-tenant (S4), hostile-network for mvmd transport, hostile insider with host shell (newly in-scope per §Threat model below) | Full hardening stack including W8 hardware enclave |
+
+`mvmctl doctor` surfaces which mode the current host is operating in.
+
+## Dependency CVE surface
+
+The broker's isolation rests on vsock + the underlying VMM + kernel paths. Each is a CVE surface we must respond to. The doctor command refuses admission on known-affected versions; the affected-version list ships in `mvmctl` and is refreshed per release.
+
+| Dependency | Surface | Doctor check |
+| --- | --- | --- |
+| Linux kernel `vhost-vsock` | Guest-to-host channel | Refuse admission on known-vulnerable kernel versions |
+| Firecracker `virtio-vsock` | Linux runtime path | Refuse admission on known-vulnerable Firecracker versions |
+| libkrun `virtio-vsock` | macOS-as-host runtime path | Refuse admission on known-vulnerable libkrun versions |
+| cloud-hypervisor `virtio-vsock` | Builder VM path on macOS | Refuse admission on known-vulnerable cloud-hypervisor versions |
+| Apple `vz` virtio sockets | macOS 26+ Apple Silicon runtime + builder | Refuse admission on macOS versions with known Apple-vz CVEs |
+| gvproxy / passt | Userspace virtio-net gateway (egress secret backstop in S25) | Refuse admission on known-affected gateway versions |
+| `ed25519-dalek`, `serde_json`, `serde_jcs`, `chacha20poly1305`, `tpm2-tss` | Crypto + parsing | `cargo deny` advisory + license gate on every PR |
+
+A vsock CVE = emergency host upgrade required. The response posture is documented in `SECURITY.md`'s CVE response runbook (W10).
+
+## Considered and rejected threats
+
+Named here so future readers don't re-litigate:
+
+- **Subprocess-restart accumulation attack.** Concern: attacker induces 3 restarts to harvest ephemeral subprocess response keys. **Dismissed:** no traffic encryption to decrypt; per-spawn keys give the attacker no cryptographic leverage; 3 keys per workload is far below cryptanalytic accumulation threshold.
+- **Workload-set correlation IDs as a forensic-trail attack.** Concern: workload sets a `correlation_id` matching another workload's known sequence to confuse the audit chain. **Mitigated** (H-L4.6 / G4) by having the supervisor assign correlation IDs at frame ingress; workload-supplied IDs are rewritten or rejected.
+- **PFS-via-broker-encryption.** Considered adding AEAD on the broker channel for forward secrecy. **Dismissed:** vsock is a host-local process-to-process channel; there is no network attacker against whom PFS would help. Adding AEAD here is security theater against the actual threat (memory-resident-key extraction).
+
+## Threat model
+
+ADR-002's "malicious host" out-of-scope clause is **narrowed**, not removed.
+
+**Physical attacks remain out of scope:** cold-boot DRAM extraction, DMA via Thunderbolt/PCIe, hardware tampering (chip-off, side-channel power analysis), unauthorized firmware flashing. ADR-002 still applies to these.
+
+**Software insider attacks are newly in scope** thanks to the L1+L2+L5 hardening:
+
+- **Host signer key extraction by shell-on-host attacker** — defeated by H-L1.1 (key never loaded into the supervisor) + H-L2.1 (key never extractable from HW enclave on enclave-equipped hosts).
+- **Audit chain forgery by shell-on-host attacker** — defeated by H-L1.2 (chain-signing key isolated to `mvm-audit-signer`) + H-L5.1 (O_APPEND-only FD) + H-L5.2 (anti-rollback chain-head persistence).
+- **Audit log content extraction by shell-on-host attacker** — defeated by H-L5.4 (per-tenant ChaCha20-Poly1305 at rest, key derived from TPM/SE master).
+- **Secret extraction from process memory by shell-on-host attacker** — defeated by H-L1.4 (per-workload cgroup + PID/mount namespace) + H-L3.9 (`PR_SET_DUMPABLE=0` / `PT_DENY_ATTACH` + mlock) + H-L3.11 (anti-debug startup check refuses to run under ptrace).
+
+On **non-enclave hosts** (no Apple SE, no Linux TPM), the host signer is **trust-on-first-use (TOFU)**: whatever's on disk after first run is "the" key, and an attacker who wipes the host before first run can mint their own. `mvmctl doctor` surfaces this as a security-claim downgrade. Honest naming, not a hidden flaw.
+
+## Security claims (proposed numbers — assigned at write-time against ADR-002's live list)
+
+Sprint 56 holds claim 10 (bytes leaving trust boundary). This ADR proposes the next two claims; final numbers are assigned in the same PR as ADR-002 is updated.
+
+> **Claim N (proposed).** Every host-side service the broker exposes is bound to a signed `ExecutionPlan.services` binding, enforced before handler dispatch, and audited via the chain-signed log. A tampered binding fails plan verification; an unbound call is refused with an audited deny. Tested by the W2 security regression set (`service_call_denied_when_unbound`, `service_call_denied_outside_profile`).
+
+> **Claim N+1 (proposed).** No raw secret value crosses the broker channel. `host.secrets.v1` returns destination-bound, time-bound signed credentials only. Raw secret bytes never leave `mvm-host-signer`'s process boundary (under H-L2.1 / Layer 2 hardware enclave, never the host's address space at all). Tested by the W5 security regression set + ADR-049 hostile-guest matrix.
+
+## Consequences
+
+**Positive:**
+
+- TCB minimization: a supervisor UAF no longer extracts host signer keys, audit signing keys, or in-flight credentials.
+- Threat-model expansion: software insider attacks newly in scope.
+- Extensibility: built-in handlers and v2 addon handlers share one substrate; new services land without protocol churn.
+- Observability: every call audited; operator actions audited; `broker.v1/list_services` exposes the runtime catalog.
+- Falsifiability: a fourth service `host.dev.echo.v1` can land in one handler file without touching envelope, registry, or auth — verified at W6.
+
+**Negative:**
+
+- Scope: roughly 3–4 sprints of work where the original draft was 1.
+- Operational surface: four new subprocess binaries per VM; new doctor checks; new release-pipeline lanes (cosign, Sigstore, in-toto, reproducibility-per-binary).
+- Single points of availability: `mvm-host-signer` and `mvm-audit-signer` are now load-bearing for admission and audit respectively; restart-with-backoff is the v1 mitigation, with m-of-n quorum deferred.
+- Schema breakage: `ExecutionPlan` v4 plans hard-fail at v5; no shim. Operators must re-synthesize.
+- Cross-backend complexity: the vz (Apple Silicon) backend needs a new `VZVirtioSocketListener` Swift class — substantial sub-task.
+- Hardware-enclave dependency (W8): macOS SE + Linux TPM 2.0 integration is first-time work in `mvm`; software fallback retained but flagged as a downgrade.
+
+## Non-goals
+
+These are out of scope for v1 and named here so they don't quietly become assumed-covered. Future plans are listed where relevant.
+
+- **Streaming responses.** Envelope is request/response only in v1. `host.monitoring.v1` deferred.
+- **Addon-provided handlers shipping in v1.** v1 ships only the substrate; v2 ships actual addons.
+- **`unsafe_guest_tls_inspection`** (the proxy-with-CA path from ADR-049). Ships separately.
+- **Non-HTTP secret substitution.** ADR-049 already declares out of scope.
+- **m-of-n quorum for host signer key rotation.** Operationally heavy. Future plan once W11 FIDO ceremony exists.
+- **Hybrid Ed25519 + Dilithium signatures (PQC).** The algorithm-identifier byte (H-L4.1) is sufficient preparation; full hybrid signing waits until CRQC pressure is real.
+- **Remote attestation of workload identity** (TPM PCR-bound workload signing). Research-grade; existing signed-`ExecutionPlan` + cosigned-image sufficient.
+- **Full memory-snapshot encryption** for paused workloads. Realistic threat (disk-imaging the snapshot file) mitigated by host FDE (operator's responsibility).
+- **Detection / alerting** (G10). Audit logs are forensics, not detection. `host.alert.v1` reserved as a future broker service in the host-logging follow-on plan.
+- **Disaster recovery / key escrow** (G11). Lost host signer / TPM / audit-signer keys = workloads broken; no recovery in v1. Operator-held escrow signed under operator FIDO key is the right shape but a major operational lift. Future plan once W11 lands FIDO.
+- **Supervisor split** (admission verifier + IPC router as separate processes). v1 supervisor remains the single launcher + IPC router + admission controller. Deferred to v2.
+- **Cross-VM cost aggregation across tenants.** `host.cost.v1::tenant` is single-tenant.
+- **Audit log rotation strategy concrete triggers** (size, age). Deferred to the host-logging follow-up plan / ADR-060; the continuity invariant (rotated-file last-entry hash = active-file first prev_hash) *is* in scope under H-L6.2.
+
+## Reuse
+
+- `AuthenticatedFrame` framing in `crates/mvm-guest/src/vsock.rs` — reused with an added algorithm-identifier byte (H-L4.1).
+- `EventCategory` enum + chain-signed JSONL audit — reused; one new variant `ServiceCall`; chain-signing moves into `mvm-audit-signer`.
+- `AgentProfile` enum — reused as the first capability gate.
+- `ProtocolHello` capability negotiation (ADR-053) — reused; `GuestCapability::ServicesBroker` added.
+- `ExecutionPlan.secrets: Vec<SecretBinding>` and `SecretReleasePolicy` — reused as policy blob for `host.secrets.v1`.
+- Supervisor's per-workload cost accumulators — reused by `host.cost.v1` (W4a builds them; they don't exist today).
+
+## See also
+
+- [Plan 104 — host services broker](../plans/104-host-services-broker.md) for the implementation specifics (build sequence, critical files, verification set, hardening posture L1–L11).
+- [threat model 02 — host services broker](../threat-models/02-host-services-broker.md) for the STRIDE walk per service.
+- [ADR-049 — secret substitution mechanism](049-secret-substitution-mechanism.md) for the secrets-specific design that lands as `host.secrets.v1`.
+- [mvmd ADR-0023 — mvmd host services delegation](../../../mvmd/specs/adrs/0023-mvmd-host-services-delegation.md) for the cross-VM trust model.
+- [ADR-002 §Out of scope](002-microvm-security-posture.md#out-of-scope) — the "malicious host" clause this ADR narrows.

--- a/specs/plans/104-host-services-broker.md
+++ b/specs/plans/104-host-services-broker.md
@@ -52,45 +52,111 @@ Intended outcome: after this plan lands, ADR-049's substitution service exists a
 - **Why JSON not CBOR.** v1 has no genuinely binary payload (signed credentials base64 cleanly into a `credential_b64` field; time/cost are ints; list_services is strings). JSON wins on debuggability (`jq` works), cross-language story (every SDK ecosystem has a robust JSON parser; the W7 ADR-049 hook matrix avoids CBOR-library-quality friction), and consistency with the existing `GuestRequest` / `HostBoundRequest` JSON discipline in `crates/mvm-guest/src/vsock.rs`. If a future service ships actual binary, the field can be base64-in-JSON — 33% overhead on that *one field* at ~500-byte typical payloads is negligible.
 - **Why two ports + secrets-in-subprocess (T4 production-ready isolation).** The supervisor's general-broker dispatcher and the secrets dispatcher share zero code paths and zero address space. A logic bug in the schema/dispatcher/quota path of the general broker cannot reach the secrets subprocess's memory or registry. This is the production-ready isolation pattern (industry analogues: AWS STS, HashiCorp Vault, Kubernetes ServiceAccount token controllers — all out-of-process). Same envelope + handler trait + audit chain, different runtime processes.
 
-### Host-side: two-process architecture
+### Host-side: four-subprocess architecture
 
-The supervisor hosts the **general broker** (in-process); a separate **secrets subprocess** hosts `host.secrets.v1` only. Both run for the lifetime of the guest.
+> The earlier draft of this section described a two-process design
+> (supervisor in-process broker + secrets subprocess). It has been
+> superseded by the four-subprocess design below per §Hardening
+> posture Layer 1. The two-process design is preserved in commit
+> history; the four-process design is the v1 target.
 
-**General broker (in-process, in `mvm-supervisor`):**
+The supervisor is a pure launcher + admission controller + IPC router.
+Four per-VM subprocesses share zero address space with the supervisor
+and zero address space with one another. Each runs for the lifetime of
+the guest, dies when the supervisor dies (via `PR_SET_PDEATHSIG` on
+Linux or kqueue parent-pid watcher on macOS), and is restart-on-crash
+up to three times per workload lifetime (after which the workload
+pauses for operator review). See §Hardening posture L1 for the
+isolation rationale and L3 for the per-subprocess hardening that
+applies uniformly across all four.
 
-- New module `crates/mvm-supervisor/src/services/` with:
-  - `broker.rs` — `ServiceBroker { listener: VsockListener, registry: ServiceRegistry, secrets_uds: Option<UnixStream> }`. Listens on port 5300. For in-process handlers, dispatches directly; for `host.secrets.v1` calls (which arrive on port 5301, not 5300 — but the secrets subprocess also goes through the binding-gate check via the supervisor before forwarding), the supervisor proxies.
-  - `registry.rs` — `ServiceRegistry { handlers: HashMap<ServiceId, HandlerRef> }` where `HandlerRef::InProcess(Arc<dyn ServiceHandler>)` or `HandlerRef::OutOfProcess(UdsProxy)`. Built at plan-admission time.
-  - `handler.rs` — the `ServiceHandler` trait:
-    ```rust
-    #[async_trait]
-    pub trait ServiceHandler: Send + Sync {
-        fn id(&self) -> ServiceId;
-        fn profiles(&self) -> &[AgentProfile];
-        fn audit_durability(&self) -> AuditDurability;  // PerCall | Batched(Duration)
-        fn response_size_cap(&self) -> usize;           // default 64 KiB
-        fn idempotency(&self) -> Idempotency;           // see §C3
-        fn call_timeout(&self) -> Duration;             // see §C4
-        async fn dispatch(&self, ctx: &ServiceCallCtx, verb: &str, payload: serde_json::Value)
-            -> Result<serde_json::Value, ServiceError>;
-    }
-    ```
-  - `host_time.rs`, `host_cost.rs` — in-process handlers.
-  - `mvmd_client.rs` — `MvmdClient` trait for cross-VM data.
-  - `circuit_breaker.rs` — per-handler health tracking (see §Security S13).
-  - `quota.rs` — token-bucket + lifetime caps (see §Security).
-  - `secrets_proxy.rs` — UDS client to the secrets subprocess. Wire format: same `ServiceCall`/`ServiceResponse` envelope. The supervisor performs gates 1–4 *before* forwarding; the secrets subprocess performs gate 5 + dispatch.
+**`mvm-broker` (uid 903 — general broker subprocess):**
 
-**Secrets subprocess (`mvm-secrets-dispatcher` binary, NEW):**
+- New crate `crates/mvm-broker/` producing a binary spawned by the
+  supervisor per VM. Hosts `HostTimeV1Handler`, `HostCostV1Handler`,
+  `BrokerV1Handler` (the introspection `list_services` verb).
+- Listens on **vsock port 5300** directly (the supervisor sets up
+  the listener via the backend-specific mechanism — see W1) AND on
+  per-VM UDS `~/.mvm/vms/<vm>/services/broker.sock` for
+  supervisor-proxied calls (mode 0600, supervisor-owned).
+- Hosts the `ServiceHandler` trait registry for in-process handlers.
+  For composed calls that cross into `host.secrets.v1`, the broker
+  proxies to the secrets dispatcher via UDS (the composition
+  boundary crosses two process boundaries: broker ↔ supervisor ↔
+  secrets dispatcher).
 
-- New crate `crates/mvm-secrets-dispatcher/` producing a binary spawned by the supervisor per VM.
-- Binary listens on **vsock port 5301** directly (the supervisor sets up the listener via the backend-specific mechanism — see W1) AND on a per-VM Unix-domain socket at `~/.mvm/vms/<vm>/services/secrets.sock` for supervisor-proxied calls (mode 0600, supervisor-owned).
-- Runs under uid 902, seccomp `standard` (W2.4 profile, no `do_exec`), `setpriv --bounding-set=-all --no-new-privs`. Configured via supervisor-set environment + read-only mount of `~/.mvm/keys/host-signer.pub` (verification only — the signing key stays in the supervisor).
-- Hosts ONLY `host.secrets.v1`. No other services. Cannot register additional handlers at runtime.
-- Audit entries from the secrets subprocess are sent to the supervisor over the UDS for chain-signing — the supervisor is the only writer to `~/.mvm/audit/<tenant>.jsonl`. The subprocess holds no audit key material.
-- Dies when the supervisor dies (subprocess inherits supervisor's lifetime via `prctl(PR_SET_PDEATHSIG)` on Linux / equivalent on macOS).
+**`mvm-secrets-dispatcher` (uid 902 — secrets subprocess):**
 
-**Why two processes is mandatory, not optional:** the secrets subprocess's address space is fully isolated from the general broker's. A use-after-free, integer overflow, or logic bug in the general broker's schema/auth/binding/quota code cannot reach the credential-minting code, the keystore policy state, or the in-flight grant table. This is the answer to "control plane compromise = security concern."
+- New crate `crates/mvm-secrets-dispatcher/` producing a binary
+  spawned by the supervisor per VM. Hosts ONLY `host.secrets.v1`;
+  cannot register additional handlers at runtime.
+- Listens on **vsock port 5301** directly + per-VM UDS
+  `~/.mvm/vms/<vm>/services/secrets.sock` for supervisor-proxied
+  calls (mode 0600).
+- Read-only access to the host signer *public* key for verifying
+  responses returned to it from `mvm-host-signer`. Holds no
+  host-signing key material.
+
+**`mvm-host-signer` (uid 904 — host-signing subprocess):**
+
+- New crate `crates/mvm-host-signer/` producing a binary spawned by
+  the supervisor per VM. Holds the host signer key (software path
+  in W1; HW-enclave path in W8 per Layer 2).
+- Listens on per-VM UDS `~/.mvm/vms/<vm>/services/host-signer.sock`
+  for typed "sign this hash" RPCs from the supervisor (admission
+  ceremony) and from `mvm-secrets-dispatcher` (signed-credential
+  generation per ADR-049).
+- No network, no FS beyond the UDS + the enclave handle (W8) or
+  fallback key file (W1).
+
+**`mvm-audit-signer` (uid 905 — audit-chain-signing subprocess):**
+
+- New crate `crates/mvm-audit-signer/` producing a binary spawned
+  by the supervisor per VM. Sole writer to
+  `~/.mvm/audit/<tenant>.jsonl`; sole holder of the audit
+  chain-signing key.
+- Listens on per-VM UDS
+  `~/.mvm/vms/<vm>/services/audit-signer.sock` for typed
+  `EventCategory::*` entries from the supervisor and (via
+  supervisor proxy) the other subprocesses.
+- JCS-canonicalizes entries, computes `prev_hash`, signs, appends
+  via an `O_APPEND` FD (H-L5.1) with dir-immutable enforcement.
+  Persists `chain_head` to a secondary location on every entry
+  (H-L5.2). Per-tenant ChaCha20-Poly1305 encryption at rest
+  (H-L5.4).
+
+**Supervisor (the orchestrator that remains):**
+
+- Module `crates/mvm-supervisor/src/services/` holds the four UDS
+  proxy clients (`broker_proxy.rs`, `secrets_proxy.rs`,
+  `host_signer_proxy.rs`, `audit_signer_proxy.rs`), the
+  registry assembly logic, circuit breakers, quotas, the
+  `MvmdClient` trait, and the `ServiceHandler` trait definition
+  (the trait is in `mvm-core` so all subprocesses can implement
+  it). Supervisor itself implements no `ServiceHandler` — those
+  live in the broker / secrets dispatcher subprocesses.
+
+```rust
+#[async_trait]
+pub trait ServiceHandler: Send + Sync {
+    fn id(&self) -> ServiceId;
+    fn profiles(&self) -> &[AgentProfile];
+    fn audit_durability(&self) -> AuditDurability;  // PerCall | Batched(Duration)
+    fn response_size_cap(&self) -> usize;           // default 64 KiB
+    fn idempotency(&self) -> Idempotency;           // see §C3
+    fn call_timeout(&self) -> Duration;             // see §C4
+    async fn dispatch(&self, ctx: &ServiceCallCtx, verb: &str, payload: serde_json::Value)
+        -> Result<serde_json::Value, ServiceError>;
+}
+```
+
+**Why four processes is mandatory, not optional:** see §Hardening
+posture L1. Short version: a supervisor UAF previously exfiltrated
+the host signer key (compromising all future plans), let a logic
+bug forge audit entries (compromising forensic integrity), and let
+a parser bug pivot into the credential-minting code. With four
+subprocesses each in their own seccomp + setpriv + cgroup +
+namespace compartment, none of these pivots survive.
 
 ### ExecutionPlan schema change
 
@@ -111,7 +177,7 @@ Existing `secrets: Vec<SecretBinding>` stays — it's the **policy blob** for th
 
 ### Capability gating — five sequential rules
 
-Before any handler dispatch, a call traverses five rules in order. **They are sequential, not isolated within a single process** — for the general broker, all five run in the same supervisor task, in the same address space, parsing with the same `serde_json` parser, against state co-located in one process. **Process-level isolation only exists for `host.secrets.v1` calls**, which cross the UDS boundary to the secrets subprocess (gate 5 runs there in a separate address space; gates 1–4 still run in the supervisor — see §"Host-side: two-process architecture").
+Before any handler dispatch, a call traverses five rules in order. **They are sequential, not isolated within a single process** — for the general broker, all five run in the same supervisor task, in the same address space, parsing with the same `serde_json` parser, against state co-located in one process. **Process-level isolation only exists for `host.secrets.v1` calls**, which cross the UDS boundary to the secrets subprocess (gate 5 runs there in a separate address space; gates 1–4 still run in the supervisor — see §"Host-side: four-subprocess architecture").
 
 1. **Schema gate** — `serde_json` parse of the envelope with `deny_unknown_fields`; 64 KiB max frame size enforced *before* parse; recursion cap 8; 50ms parse timeout. **Note:** `deny_unknown_fields` covers only the outer envelope (`service`, `verb`, `correlation_id`, `payload`) — the `payload` itself is `serde_json::Value`, which is dynamically typed and **does not get `deny_unknown_fields` at envelope-parse time**. The typed second-stage parse via `ServiceHandler::parse_payload` (gate 5 prerequisite) is the *real* payload schema gate. See §S19.
 2. **Authentication gate** — `AuthenticatedFrame` Ed25519 verify against workload session key (minted at plan admission, discarded at workload stop). Monotonic-sequence replay rejection.
@@ -176,7 +242,7 @@ Extensibility is designed in along seven orthogonal axes:
 
 ### A4 — Out-of-process handler substrate (v1 ships it; the secrets subprocess is its first consumer)
 
-The out-of-process handler substrate has a **mandatory v1 consumer**: the secrets dispatcher (see §"Host-side: two-process architecture"). This kills the "speculative substrate, no v1 consumer" criticism — every line of the proxy substrate is exercised by the security-critical secrets path on every workload start.
+The out-of-process handler substrate has a **mandatory v1 consumer**: the secrets dispatcher (see §"Host-side: four-subprocess architecture"). This kills the "speculative substrate, no v1 consumer" criticism — every line of the proxy substrate is exercised by the security-critical secrets path on every workload start.
 
 **Substrate (v1):**
 - The supervisor's broker dispatches `HandlerRef::OutOfProcess(UdsProxy)` for any handler registered with an out-of-process reference. The proxy uses the same `ServiceCall`/`ServiceResponse` envelope over a per-VM Unix-domain socket at `~/.mvm/vms/<vm>/services/<service_id>.sock` (mode 0600, supervisor-owned).
@@ -210,31 +276,64 @@ The out-of-process handler substrate has a **mandatory v1 consumer**: the secret
 
 Each wave is independently mergeable and leaves `cargo test --workspace && cargo clippy -- -D warnings` green. **Check off as completed.**
 
-- [ ] **W1 — Broker substrate + secrets-subprocess scaffolding** *(no mvmd dep)*
-  - [ ] `ServiceCall` / `ServiceResponse` envelope types in `crates/mvm-supervisor/src/services/broker.rs` (JSON via `serde_json`)
-  - [ ] `ServiceId`, `ServiceErrorCode`, `ServiceCallCtx` newtypes
+- [ ] **W1 — Four-subprocess infrastructure substrate** *(no mvmd dep; ~3× the baseline W1 scope per §Hardening posture L1+L3)*
+  - [ ] `ServiceCall` / `ServiceResponse` envelope types in `crates/mvm-broker/src/protocol.rs` (JSON via `serde_json`)
+  - [ ] `ServiceId`, `ServiceErrorCode`, `ServiceCallCtx` newtypes (`mvm-core` so all subprocesses can share)
   - [ ] `ServiceHandler` trait + `ServiceRegistry` with `HandlerRef::{InProcess, OutOfProcess}` discriminator
+  - [ ] **Algorithm-identifier byte in `AuthenticatedFrame`** (H-L4.1) — wire change; `0x01=Ed25519`, `0x02=ECDSA-P256` reserved for W8
+  - [ ] **Per-spawn ephemeral keypair + response signing per subprocess** (H-L4.2)
+  - [ ] **Supervisor-assigned correlation IDs at frame ingress** (H-L4.6)
   - [ ] **Two vsock listeners per VM (per backend; NOT uniform "wire it in"):**
-    - [ ] **libkrun** — bind ports 5300 + 5301 via `add_vsock_port2(port, host_path, listen=true)` in `crates/mvm-libkrun/src/sys.rs`; general-broker task reads 5300, secrets subprocess reads 5301
-    - [ ] **Firecracker** — bind via the in-process `Supervisor` struct in `crates/mvm-supervisor/src/supervisor.rs` (no separate per-VM binary)
+    - [ ] **libkrun** — bind ports 5300 + 5301 via `add_vsock_port2(port, host_path, listen=true)` in `crates/mvm-libkrun/src/sys.rs`; `mvm-broker` subprocess reads 5300, `mvm-secrets-dispatcher` reads 5301
+    - [ ] **Firecracker** — bind via the in-process `Supervisor` struct in `crates/mvm-supervisor/src/supervisor.rs`; supervisor passes accepted FDs to the respective subprocesses
     - [ ] **Apple Container** — host-as-listener path parallel to libkrun's, both ports
-    - [ ] **vz (Apple Silicon)** — *new Swift work:* `VZVirtioSocketListener` class added to `crates/mvm-vz-supervisor/Sources/mvm-vz-supervisor/` with `shouldAcceptNewConnection` plumbing, relays accepted sockets for BOTH ports to their respective listeners via host-side UDS. **The Swift supervisor has no listener path today** (`VsockProxy.swift` is host-as-client only). Substantial sub-task.
-  - [ ] **`crates/mvm-secrets-dispatcher/` NEW crate** — binary spawned by supervisor per VM; listens on per-VM UDS `~/.mvm/vms/<vm>/services/secrets.sock` (mode 0600) for supervisor-proxied calls, and on vsock 5301 via the backend-set listener for direct guest calls. Uid 902, seccomp `standard`, `setpriv --bounding-set=-all --no-new-privs`. Read-only access to host signer *public* key only.
-  - [ ] Supervisor subprocess lifecycle: spawn at VM admission, attach via `PR_SET_PDEATHSIG` (Linux) / equivalent on macOS so subprocess dies with supervisor. Restart-on-crash with backoff (max 3 restarts per workload lifetime; beyond → audit `secrets.subprocess.crashed_repeatedly` and workload pause).
-  - [ ] `crates/mvm-supervisor/src/services/secrets_proxy.rs` — UDS client that forwards `ServiceCall` to the subprocess after gates 1–4
-  - [ ] Both brokers reject every call with `NotBound` (no handlers registered yet; the secrets subprocess ships its stub-handler scaffolding in W1)
-  - [ ] Service composition `ServiceCallContext::invoke` API with depth cap (composition crosses the process boundary if the composed service is out-of-process; tested via stub handler)
+    - [ ] **vz (Apple Silicon)** — *new Swift work:* `VZVirtioSocketListener` class added to `crates/mvm-vz-supervisor/Sources/mvm-vz-supervisor/` with `shouldAcceptNewConnection` plumbing, relays accepted sockets for BOTH ports to their respective subprocesses via host-side UDS. **The Swift supervisor has no listener path today** (`VsockProxy.swift` is host-as-client only). Substantial sub-task.
+  - [ ] **`crates/mvm-broker/` NEW crate** (H-L1.3) — general broker subprocess, uid 903, hosts `host.time.v1` / `host.cost.v1` / `broker.v1`; listens on vsock 5300 + per-VM UDS `~/.mvm/vms/<vm>/services/broker.sock` (mode 0600). Seccomp `standard` per H-L3.3, setpriv `--bounding-set=-all --no-new-privs`.
+  - [ ] **`crates/mvm-secrets-dispatcher/` NEW crate** — secrets subprocess, uid 902; listens on vsock 5301 + per-VM UDS `~/.mvm/vms/<vm>/services/secrets.sock` (mode 0600). Read-only access to host signer *public* key only.
+  - [ ] **`crates/mvm-host-signer/` NEW crate** (H-L1.1) — host-signer subprocess, uid 904; listens on per-VM UDS `~/.mvm/vms/<vm>/services/host-signer.sock` for typed "sign this hash" RPCs from supervisor. Holds the host signer key (software path in W1; HW-enclave path lands in W8).
+  - [ ] **`crates/mvm-audit-signer/` NEW crate** (H-L1.2) — audit-signer subprocess, uid 905; sole writer to `~/.mvm/audit/<tenant>.jsonl`; sole holder of audit chain-signing key. Listens on per-VM UDS `~/.mvm/vms/<vm>/services/audit-signer.sock` for typed entries.
+  - [ ] **Cosign-verify every subprocess binary at spawn** (H-L3.1); refuse-to-spawn on mismatch; audit `<subprocess>.signature_invalid`
+  - [ ] **TOCTOU-resistant verify-then-exec** (H-L3.2) — mmap + verify + `fexecve` / `posix_spawn`-with-FD
+  - [ ] **Subprocess config-signing** (H-L3.6) — supervisor signs config JSON before passing on stdin; subprocess refuses to start unless signature verifies
+  - [ ] **Explicit seccomp policy per subprocess** (H-L3.3) via `seccompiler`, per-arch (x86_64 + aarch64)
+  - [ ] **macOS sandbox profile per subprocess** (H-L3.4) via `sandbox_init_with_parameters`
+  - [ ] **Resource caps on every subprocess** (H-L3.9): `RLIMIT_CORE=0`, `RLIMIT_AS`, `mlockall(MCL_FUTURE)`, `PR_SET_DUMPABLE=0` / `PT_DENY_ATTACH`, `PR_SET_THP_DISABLE`
+  - [ ] **Binary hardening flags + per-binary reproducibility lane** (H-L3.10): PIE + RELRO + canaries + FORTIFY_SOURCE=3; CI-asserted via `checksec`
+  - [ ] **Static-link + W^X + no `dlopen` + anti-debug** (H-L3.11)
+  - [ ] **No-shared-FDs invariant + CI lint `xtask check-subprocess-fd-inheritance`** (H-L3.8)
+  - [ ] **Per-workload cgroup + namespace isolation** for the four-subprocess set (H-L1.4)
+  - [ ] **CPU pinning** of each subprocess to a separate core where available (H-L7.4); doctor flags downgrade
+  - [ ] Supervisor subprocess lifecycle for all four subprocesses: spawn at VM admission, attach via `PR_SET_PDEATHSIG` (Linux) / kqueue-monitored parent-pid watcher (macOS). Restart-on-crash with backoff (100ms, 500ms, 2s), max 3 restarts per workload lifetime; beyond → audit `<subprocess>.crashed_repeatedly` and workload pause.
+  - [ ] **Subprocess slow-start detection** (H-L7.3): `BROKER_SUBPROCESS_START_DEADLINE_MS=2000`; refuse workload on breach
+  - [ ] **Admission blocks until all four subprocesses healthy** (H-L5.7) — no in-supervisor audit buffer
+  - [ ] `crates/mvm-supervisor/src/services/{broker_proxy.rs, secrets_proxy.rs, host_signer_proxy.rs, audit_signer_proxy.rs}` — UDS clients forwarding to each subprocess
+  - [ ] **Zeroize at every proxy buffer** (H-L3.7) — `zeroize::Zeroizing<Vec<u8>>` on forward + return paths
+  - [ ] All proxies reject every call with `NotBound` (no handlers registered yet; subprocesses ship stub-handler scaffolding in W1)
+  - [ ] Service composition `ServiceCallContext::invoke` API with depth cap (composition crosses the process boundary; tested via stub handler) + **width cap** (H-L6.5)
   - [ ] Cargo feature flags: `service-host-secrets`, `service-host-time`, `service-host-cost`, `service-host-cost-mvmd`, `service-broker-meta`
-  - [ ] Tests: envelope serde roundtrip (JSON), `deny_unknown_fields` on envelope rejection, `AuthenticatedFrame` happy path, replay rejection, length-prefix tampering rejection, frame > 64 KiB rejection, recursion cap rejection, parse timeout, composition depth cap (including cross-process), **subprocess crash isolation (kill subprocess mid-call; supervisor survives; workload sees `Err(Unavailable)`)**, **supervisor crash teardown (kill supervisor; subprocess exits cleanly via pdeathsig)**, cross-backend listener attaches and accepts on all four backends, **both ports**
-- [ ] **W2 — ExecutionPlan + admission wiring** *(no mvmd dep)*
-  - [ ] Add `services: Vec<ServiceBinding>` + `ServiceBinding` + `ServicePolicy` + `ServiceQuotas` to `crates/mvm-plan/src/plan.rs`
+  - [ ] **`mvmctl doctor` host-posture checks** (H-L7.2): KASLR, KPTI, SMEP/SMAP, Spectre-v2, LSM, `unprivileged_userns_clone=0`, `dmesg_restrict=1`, macOS SIP+AMFI+kext; refuse admission on weak hosts; `--insecure-host` audits + warns
+  - [ ] **KSM off + THP off doctor enforcement** (H-L7.1)
+  - [ ] **Constant-time comparisons via `subtle::ConstantTimeEq`** (H-L4.5) on all security-byte comparisons; CI grep lint
+  - [ ] **`fido_touch_required()` stub** (G2 → H-L11.6) — `mvmctl up --prod` calls it, today no-ops + audits `operator.fido.unverified`; full impl in W11
+  - [ ] Tests: envelope serde roundtrip (JSON), `deny_unknown_fields` on envelope rejection, `AuthenticatedFrame` happy path with algorithm-identifier byte, replay rejection, length-prefix tampering rejection, frame > 64 KiB rejection, recursion cap rejection, parse timeout, composition depth + width caps (including cross-process), subprocess crash isolation per-subprocess (kill any subprocess mid-call; supervisor survives; workload sees `Err(Unavailable)`), supervisor crash teardown (kill supervisor; all four subprocesses exit cleanly via pdeathsig/kqueue), cross-backend listener attaches and accepts on all four backends, both ports, cosign-verify rejects tampered binary, config-signing rejects tampered config, FD-inheritance lint catches stray FD, supervisor-side response-signature verify rejects stub-subprocess forgery (H-L9.1 hostile-subprocess test per subprocess kind), `subprocess_set_ready` barrier blocks admission until all four up, slow-start detection refuses workload
+- [ ] **W2 — ExecutionPlan + admission wiring + audit-signer wiring** *(no mvmd dep)*
+  - [ ] Add `services: Vec<ServiceBinding>` + `ServiceBinding` + `ServicePolicy` + `ServiceQuotas` to `crates/mvm-plan/src/plan.rs`; bump `SCHEMA_VERSION` 4→5 (no shim per no-backcompat rule)
   - [ ] Update synthesis (`plan_builder.rs:216`)
+  - [ ] **Admission ceremony rewired to call `mvm-host-signer` for plan signing** (H-L1.1) — supervisor no longer reads the host signer key directly
   - [ ] Extend `admit_for_run` to assemble per-VM `ServiceRegistry`; refuse admission for unsupported service IDs (clear error listing them)
   - [ ] Per-handler typed `Policy` parsing via the `parse_policy` trait method
-  - [ ] Add `EventCategory::ServiceCall` to `audit_recorder.rs`
+  - [ ] **`mvm-audit-signer` receives typed `EventCategory::ServiceCall` entries over UDS; JCS-canonicalizes + chain-signs + appends** (H-L1.2)
+  - [ ] **`O_APPEND` audit-chain FD + dir-immutable enforcement** (H-L5.1): `chattr +a` (Linux) / `UF_APPEND` (macOS); test asserts `lseek` returns EBADF
+  - [ ] **Anti-rollback chain-head persistence** (H-L5.2): persist `chain_head` to `~/.mvm/audit/HEAD` (fsync'd) or kernel keyring on every entry
+  - [ ] **Audit-log encryption at rest** (H-L5.4): per-tenant ChaCha20-Poly1305 key (software KDF in W2; TPM/SE-derived in W8)
+  - [ ] **Time-source integrity** (H-L5.5): use TPM monotonic counter or kernel boottime as integrity anchor; emit `audit.clock.jump_detected` on backward jumps
+  - [ ] **Operator-action audit entries** (H-L6.1) — every privileged `mvmctl` invocation emits a chain-signed entry
+  - [ ] **Audit fsync-failure → workload pause policy** (H-L6.6)
   - [ ] Token-bucket rate-limit + lifetime-quota + in-flight cap implementation in `quota.rs`
+  - [ ] **Tenant-level secret call quota** stub in supervisor (H-L6.3); full mvmd-enforced cap lands in W4b
+  - [ ] **Per-call ephemeral session-key rotation** (H-L4.3): `BROKER_SESSION_REKEY_CALLS=1000` / `BROKER_SESSION_REKEY_MS=60000`
   - [ ] Circuit breaker in `circuit_breaker.rs`
-  - [ ] Tests: plan synthesis + verification with bindings, audit-chain entry shape, unknown-binding rejection at admission, lifetime quota exhaustion, circuit breaker opens after N failures, in-flight cap enforced, bootstrap-order (workload calls broker before broker ready) returns `NotReady`
+  - [ ] Tests: plan synthesis + verification with bindings, audit-chain entry shape (JCS-canonical), unknown-binding rejection at admission, lifetime quota exhaustion, circuit breaker opens after N failures, in-flight cap enforced, bootstrap-order (workload calls broker before broker ready) returns `NotReady`, audit chain head persisted to second location, `O_APPEND` audit FD rejects `lseek`, encryption-at-rest roundtrip, clock-jump backward detected and audited, session-key rotation triggers correctly
 - [ ] **W3 — `host.time.v1`** *(no mvmd dep)*
   - [ ] Implement `HostTimeV1Handler`
   - [ ] Add `broker.v1/list_services` introspection verb (returns bound services + verbs + deprecation flags)
@@ -254,18 +353,21 @@ Each wave is independently mergeable and leaves `cargo test --workspace && cargo
   - [ ] Implement `host.cost.v1::tenant` verb
   - [ ] Per-tenant catalog intersection at admission (§A7)
   - [ ] Tests: positive aggregation against mock client, cross-tenant authz denial, mvmd-unavailable → `ServiceErrorCode::Unavailable` (no stale data), forged workload-id rejected, malformed mvmd response rejected, tenant catalog intersection refuses out-of-catalog binding
-- [ ] **W5 — `host.secrets.v1`** *(no mvmd dep; ADR-049 implementation; runs inside the secrets subprocess)*
+- [ ] **W5 — `host.secrets.v1` inside the secrets-dispatcher subprocess** *(no mvmd dep; ADR-049 implementation; security-gated review per H-L9.5)*
   - [ ] Implement `HostSecretsV1Handler` per ADR-049 §"Substitution flow" — **inside `crates/mvm-secrets-dispatcher/`, NOT in mvm-supervisor**
-  - [ ] Wire the supervisor's `secrets_proxy.rs` to forward gates-1-4-passed calls to the subprocess; subprocess does gate 5 + dispatch
-  - [ ] Audit subentries flow from subprocess back to supervisor over UDS; supervisor chain-signs and appends
-  - [ ] Destination-URL match against `allowed_destinations`
-  - [ ] Signed-credential generation
+  - [ ] Wire the supervisor's `secrets_proxy.rs` to forward gates-1-4-passed calls to the subprocess; subprocess does gate 5 + dispatch + response-sign (H-L4.2)
+  - [ ] Audit subentries flow from subprocess back to supervisor over UDS; supervisor routes to `mvm-audit-signer` (H-L1.2); audit-signer chain-signs and appends
+  - [ ] Destination-URL match against `allowed_destinations` using `subtle::ConstantTimeEq` (H-L4.5)
+  - [ ] Signed-credential generation (JCS-canonical bytes via `serde_jcs` per H-L11.2; Ed25519 v1, P-256 reserved for W8)
   - [ ] `audit_durability() = PerCall`
   - [ ] **Delete** `KeystoreReleaser`, `NoopKeystoreReleaser`, `LiveKeystoreReleaser` stubs (no shim)
   - [ ] Plumb existing `ExecutionPlan.secrets` field as handler's policy blob
   - [ ] `zeroize::Zeroize` impl on secret-bearing payload types
   - [ ] Inter-call memory-state hygiene (no leak from call N to call N+1)
-  - [ ] Tests: positive substitution, destination-deny, expired grant, unknown grant, replay, audit-subentry shape, ADR-049 hostile-guest matrix (raw socket bypass, substitution replay, library bypass), inter-call state hygiene
+  - [ ] **Seccomp policy compliance tests** (H-L3.3): assert denied syscalls return EPERM (`process_vm_readv`, `ptrace`, `kcmp`, `pidfd_open`, `userfaultfd`, `bpf`, `perf_event_open`)
+  - [ ] **Side-channel / timing audit** (H-L9.4): run `dudect` or `CTGrind` against secret-handling code paths; document results in PR description
+  - [ ] **Latency floor** (S26): pad response to `BROKER_SECRETS_LATENCY_FLOOR_MS=5` regardless of cache state
+  - [ ] Tests: positive substitution, destination-deny, expired grant, unknown grant, replay, audit-subentry shape (JCS-canonical), ADR-049 hostile-guest matrix (raw socket bypass, substitution replay, library bypass), inter-call state hygiene, latency floor holds warm + cold, hostile-subprocess test stub returns wrong-signature response and supervisor rejects (H-L9.1)
 - [ ] **W6 — Fuzz + CI** *(no mvmd dep)*
   - [ ] Add `crates/mvm-guest/fuzz/fuzz_service_call.rs` per ADR-002 §W4.2
   - [ ] Wire into existing `cargo-fuzz` lane (≥5min/PR)
@@ -283,45 +385,137 @@ Each wave is independently mergeable and leaves `cargo test --workspace && cargo
   - [ ] Built-in `aws` credential adapter (SigV4) in all three
   - [ ] Deterministic S3 `ListBuckets` SigV4 tests proving placeholders resolve before signing
   - [ ] ADR-049's hostile-guest tests in all three SDKs
+- [ ] **W8 — Hardware-enclave host signer** *(largest new wave; security-gated review per H-L9.5; macOS-SE + Linux-TPM in parallel)*
+  - [ ] macOS: Apple Secure Enclave integration in `crates/mvm-host-signer` via `SecKeyCreateRandomKey` with `kSecAttrTokenIDSecureEnclave` (P-256); Swift bridge
+  - [ ] Linux: TPM 2.0 integration via `tpm2-tss` (RSA-2048 or ECDSA-P256 depending on TPM capability)
+  - [ ] Algorithm-identifier byte enables P-256 (`0x02`) on the SE path
+  - [ ] Fallback: kernel keyring (Linux) or filesystem mode 0600 (universal); only with `--insecure-host-signer-software-fallback` flag; surfaced in doctor as a downgrade
+  - [ ] **Host signer key rotation ceremony** + **TPM monotonic counter for rollback resistance** (H-L2.2); rotation increments embed in admission audit entries
+  - [ ] **`mvmctl host-key rotate`** CLI verb; emits `operator.host_key_rotation` audit entry; rotates through dedicated `mvmctl services revoke <workload>` flow for in-flight workloads
+  - [ ] **At-rest audit encryption key migration** (H-L5.4) — the per-tenant audit-encryption key derived from TPM/SE-bound master
+  - [ ] Doctor reports the active host-signer backend + downgrade state on a dedicated row
+  - [ ] Tests: enclave keygen + sign + verify on macOS SE, Linux TPM round-trip on `tpm2-emulator` in CI, monotonic counter increments on rotation, fallback path explicitly downgraded in doctor, key migration from software → enclave under no-backcompat (re-sign all running plans or refuse-to-resume), side-channel audit re-run on enclave path
+- [ ] **W9 — Supply chain + release hardening** *(no mvmd dep; spans CI workflow files)*
+  - [ ] **Sigstore / Rekor transparency log entries** per subprocess release (H-L8.1)
+  - [ ] **In-toto attestations** alongside SLSA provenance (H-L8.2) for each subprocess binary
+  - [ ] **Hermetic, network-isolated build lane** for each subprocess binary inside the existing claim-9 sealed-volume pattern (H-L8.3)
+  - [ ] **Per-subprocess reproducibility-double-build CI lane** (H-L3.10 extension); fails on byte-divergence
+  - [ ] **CODEOWNERS + branch protection** for the four subprocess crates + `crates/mvm-supervisor/src/services/` + ADR-059 (H-L9.6)
+  - [ ] **`xtask check-subprocess-fd-inheritance`** lint (H-L3.8) added to `xtask` workspace; CI gate
+  - [ ] **`cargo-mutants` mutation-testing lane** (H-L9.2) targeting security-critical functions in the four subprocess crates + supervisor services module
+  - [ ] **Crypto-crate pinning + `deny.toml` enforcement** (H-L11.2): `ed25519-dalek` v2.x, `serde_jcs` (exact version + RFC 8785 corpus test in CI), `chacha20poly1305` (RustCrypto), `tpm2-tss`, `subtle`
+  - [ ] Tests: cosign-verify rejects an unsigned subprocess binary, Sigstore log entry retrievable for a release artifact, hermetic build lane refuses to compile with network access, mutation testing surfaces a regression on a known-bad mutation
+- [ ] **W10 — Documentation + threat model** *(no mvmd dep; doc-only)*
+  - [ ] `specs/threat-models/02-host-services-broker.md` (H-L10.1) — STRIDE per service (host.secrets.v1, host.time.v1, host.cost.v1, broker.v1); cross-VM threats (mvmd path) included
+  - [ ] `SECURITY.md` updated with CVE response runbook (H-L10.2): reporting channel, SLA, coordinated disclosure policy
+  - [ ] `docs/security/audit-fields.md` (H-L10.3 / H-L5.6) — PII invariant; allowed field types; audit entry schema reference
+  - [ ] `docs/security/deployment-modes.md` (H-L11.3) — single-dev / CI / fleet threat differentiation
+  - [ ] Operator runbook for subprocess crash investigation, audit chain verification, key rotation
+  - [ ] CLAUDE.md security model section updated to reference Plan 104's new subprocesses and claim numbers
+- [ ] **W11 — Operator FIDO ceremony full implementation** *(may slip to Sprint 58 follow-on if W1–W10 fills Sprint 57)*
+  - [ ] Wire `fido_touch_required()` (stub from W1 / H-L11.6) into a real `webauthn-authenticator-rs` / platform-FIDO API path on `mvmctl up --prod`
+  - [ ] Fallback for hosts without FIDO: operator-key-on-encrypted-USB (passphrase + key file); audited downgrade
+  - [ ] Doctor probes FIDO availability + reports
+  - [ ] `mvmctl host-key rotate` requires FIDO touch (consistency with W8 rotation ceremony)
+  - [ ] Tests: FIDO touch happy-path on USB-touch fixture, fallback rejects without passphrase, doctor reports correct availability
 
 ## Critical files to create or modify
 
-**New:**
-- `crates/mvm-supervisor/src/services/{mod.rs, broker.rs, registry.rs, handler.rs, host_time.rs, host_cost.rs, mvmd_client.rs, circuit_breaker.rs, quota.rs, secrets_proxy.rs}` (note: `host_secrets.rs` moves to the dispatcher crate; the supervisor only holds the UDS proxy)
-- `crates/mvm-secrets-dispatcher/` — **NEW crate**, binary `mvm-secrets-dispatcher`, hosts `HostSecretsV1Handler`, listens on vsock 5301 + per-VM UDS, runs under uid 902 + seccomp + setpriv
+**New crates (four subprocesses + their UDS protocol):**
+- `crates/mvm-broker/` — **NEW crate** (H-L1.3), binary `mvm-broker`, general-broker subprocess at uid 903; hosts `HostTimeV1Handler`, `HostCostV1Handler`, `BrokerV1Handler`; listens on vsock 5300 + per-VM UDS `~/.mvm/vms/<vm>/services/broker.sock`
+- `crates/mvm-secrets-dispatcher/` — **NEW crate**, binary `mvm-secrets-dispatcher`, secrets subprocess at uid 902; hosts `HostSecretsV1Handler`; listens on vsock 5301 + per-VM UDS `~/.mvm/vms/<vm>/services/secrets.sock`
+- `crates/mvm-host-signer/` — **NEW crate** (H-L1.1), binary `mvm-host-signer`, host-signer subprocess at uid 904; holds the host signer key (software in W1, HW-enclave in W8); listens on per-VM UDS `~/.mvm/vms/<vm>/services/host-signer.sock`
+- `crates/mvm-audit-signer/` — **NEW crate** (H-L1.2), binary `mvm-audit-signer`, audit-signer subprocess at uid 905; sole writer to `~/.mvm/audit/<tenant>.jsonl`; sole holder of audit chain-signing key; listens on per-VM UDS `~/.mvm/vms/<vm>/services/audit-signer.sock`
+
+**New supervisor-side proxy + glue:**
+- `crates/mvm-supervisor/src/services/{mod.rs, registry.rs, broker_proxy.rs, secrets_proxy.rs, host_signer_proxy.rs, audit_signer_proxy.rs, mvmd_client.rs, circuit_breaker.rs, quota.rs}` — UDS clients + subprocess lifecycle; supervisor no longer hosts in-process handlers or holds keys
+
+**New guest + SDK + tooling:**
 - `crates/mvm-guest/src/services.rs`
 - `crates/mvm-sdk/src/services/{mod.rs, client.rs, host_secrets.rs, host_time.rs, host_cost.rs}`
 - `crates/mvm-guest/fuzz/fuzz_service_call.rs`
 - `crates/mvm-cli/src/commands/services.rs` (see §C2)
+- `crates/mvm-cli/src/commands/host_key.rs` — `mvmctl host-key rotate` (W8)
+- `crates/xtask/src/check_subprocess_fd_inheritance.rs` (H-L3.8)
 - `specs/adrs/059-host-services-broker.md`
+- `specs/threat-models/02-host-services-broker.md` (H-L10.1)
+- `docs/security/audit-fields.md`, `docs/security/deployment-modes.md`
 
 **Modify:**
-- `crates/mvm-plan/src/plan.rs` — `services`, `ServiceBinding`, `ServicePolicy`, `ServiceQuotas` types
-- `crates/mvm-plan/src/plan_builder.rs:216` — synthesize binding set instead of `Vec::new()`
-- `crates/mvm-supervisor/src/audit_recorder.rs` — add `EventCategory::ServiceCall`
+- `crates/mvm-plan/src/plan.rs` — `services`, `ServiceBinding`, `ServicePolicy`, `ServiceQuotas` types; **`SCHEMA_VERSION` 4→5**
+- `crates/mvm-plan/src/plan_builder.rs:216` — synthesize binding set instead of `Vec::new()`; admission ceremony now calls `mvm-host-signer` over UDS for plan signing (H-L1.1) — supervisor never reads the host signer key directly
+- `crates/mvm-core/src/protocol.rs` (or new `crates/mvm-core/src/broker_protocol.rs`) — `ServiceCall`, `ServiceResponse`, `ServiceId`, `ServiceErrorCode` shared by all subprocesses
+- `crates/mvm-core/src/signing.rs` — **algorithm-identifier byte in `AuthenticatedFrame`** (H-L4.1)
+- `crates/mvm-supervisor/src/audit_recorder.rs` — refactor: supervisor *enqueues* typed audit entries to `mvm-audit-signer` over UDS; subprocess holds the chain-signing key and is the only writer (H-L1.2)
 - `crates/mvm-guest/src/vsock.rs` — `GuestCapability::ServicesBroker`, port 5300, `ProtocolHello` capability; **remove** `HostBoundRequest::QueryHostTime` (W3)
 - `crates/mvm-supervisor/src/keystore.rs` — **delete** in W5
+- `crates/mvm-supervisor/src/host_signer.rs` — **delete** the in-process signing path in W2 (moves to `mvm-host-signer` subprocess); supervisor retains only the `host_signer_proxy.rs` UDS client
 - `crates/mvm-supervisor/src/lib.rs` — `pub mod services;`
-- `crates/mvm-libkrun/src/bin/mvm-libkrun-supervisor.rs` — start broker task (libkrun backend)
-- `crates/mvm-supervisor/src/supervisor.rs` and the Firecracker dispatch path in `crates/mvm/src/vm/` — Firecracker uses the in-process `Supervisor` struct (no separate per-VM binary); the broker is a task spawned by that struct's lifecycle
-- `crates/mvm-vz-supervisor/Sources/mvm-vz-supervisor/` — **new Swift listener class** (`VZVirtioSocketListener` + `shouldAcceptNewConnection`); host-side UDS relay to the Rust broker task. The existing `VsockProxy.swift` is host-as-client only and doesn't cover this
+- `crates/mvm-libkrun/src/bin/mvm-libkrun-supervisor.rs` — spawn + supervise the four subprocesses with cosign-verify (H-L3.1), TOCTOU-resistant exec (H-L3.2), config-signing (H-L3.6), per-workload cgroup setup (H-L1.4), resource caps (H-L3.9), CPU pinning (H-L7.4); start listener tasks for both vsock ports
+- `crates/mvm-supervisor/src/supervisor.rs` and the Firecracker dispatch path in `crates/mvm/src/vm/` — Firecracker uses the in-process `Supervisor` struct; the four subprocesses are spawned by that struct's lifecycle (same pattern as libkrun)
+- `crates/mvm-vz-supervisor/Sources/mvm-vz-supervisor/` — **new Swift listener class** (`VZVirtioSocketListener` + `shouldAcceptNewConnection`); host-side UDS relay to the four Rust subprocesses. The existing `VsockProxy.swift` is host-as-client only and doesn't cover this
 - Apple Container backend entry — host-as-listener path parallel to libkrun's
 - `crates/mvm-supervisor/src/cost.rs` (NEW) — per-workload cost accumulators built in W4a (does not exist today)
-- `.github/workflows/ci.yml` — fuzz lane + cross-backend test matrix lane
-- `crates/mvm-supervisor/Cargo.toml` — `service-*` feature flags
+- `crates/mvm-cli/src/doctor.rs` — new posture checks: KASLR / KPTI / SMEP-SMAP / Spectre-v2 / LSM / `unprivileged_userns_clone` / `dmesg_restrict` / macOS SIP+AMFI+kext (H-L7.2); KSM + THP off (H-L7.1); FIDO availability (W11); CPU spare-core (H-L7.4); host-signer backend + downgrade (W8)
+- `.github/workflows/ci.yml` — fuzz lane + cross-backend test matrix lane + mutation testing (H-L9.2) + per-subprocess reproducibility lane (H-L3.10/H-L8.3) + Sigstore/Rekor lane (H-L8.1) + in-toto attestation lane (H-L8.2) + hermetic-build lane (H-L8.3) + RFC-8785 JCS conformance lane (H-L11.2) + `checksec` lane (H-L3.10)
+- `.github/CODEOWNERS` — entries for the four subprocess crates + supervisor services module + ADR-059 (H-L9.6)
+- `deny.toml` — pin `ed25519-dalek`, `serde_jcs`, `chacha20poly1305`, `tpm2-tss`, `subtle` with allowlist for advisory/license (H-L11.2)
+- `crates/mvm-broker/Cargo.toml` — `service-*` feature flags (moved from supervisor)
+- `crates/mvm-cli/src/main.rs` — `fido_touch_required()` stub for `mvmctl up --prod` (W1 stub; W11 full impl)
+- `CLAUDE.md` security model section — update to reference the four subprocesses + the narrowed "malicious host" clause (W10)
+- `SECURITY.md` — CVE response runbook (W10)
+- `specs/adrs/002-microvm-security-posture.md` — cross-reference ADR-059's narrowing of the "malicious host" clause; add Plan 104's two new claim numbers when assigned at write time
 
 **Update or supersede:**
 - `specs/adrs/049-secret-substitution-mechanism.md` — one-line "Implementation: lands as `host.secrets.v1` in the host services broker (ADR-059, Plan 104)." No semantic change.
 - `specs/plans/74-claim-safe-sandbox-parity.md` §W3 — redirect to Plan 104 W5+W7.
 
-### Subprocess lifecycle details (T4 design)
+### Subprocess lifecycle details
 
-- **Spawn:** at VM admission, the supervisor's `admit_for_run` ceremony spawns `mvm-secrets-dispatcher` via `std::process::Command` with stdin/stdout piped for initial config exchange, then drops the pipes once the subprocess is listening on its UDS.
-- **Configuration:** supervisor passes via stdin a small JSON config (host signer public key path, audit-back-channel UDS path, vsock port 5301, agent profile, allowed bindings from the workload's `ExecutionPlan.services`). After consume, stdin closes.
-- **Audit back-channel:** subprocess writes audit subentries to a supervisor-owned UDS (separate from the call-forwarding UDS). Supervisor chain-signs and appends to `~/.mvm/audit/<tenant>.jsonl`. Subprocess never holds the signing key.
-- **Inheritance:** subprocess's parent is the supervisor; `PR_SET_PDEATHSIG(SIGTERM)` on Linux ensures the subprocess dies if the supervisor dies. macOS equivalent: a kqueue-monitored parent-pid watcher (or libdispatch's `dispatch_source_create(DISPATCH_SOURCE_TYPE_PROC, …)` watching the supervisor's PID).
-- **Restart policy:** if the subprocess crashes, supervisor restarts it with exponential backoff (100ms, 500ms, 2s). After 3 restarts within the workload's lifetime, supervisor stops restarting, audits `secrets.subprocess.crashed_repeatedly`, and triggers a workload pause via Plan 82's harness. The workload sees `Err(Unavailable)` for `host.secrets.v1` calls until resumed (which only happens after operator review).
-- **In-flight call handling on crash:** outstanding correlation IDs return `Err(Unavailable)`. New session keys minted post-restart; old sessions invalidated (consistent with S8 pause/resume semantics).
+The same lifecycle pattern applies uniformly to all four subprocesses
+(`mvm-broker`, `mvm-secrets-dispatcher`, `mvm-host-signer`,
+`mvm-audit-signer`) per §Hardening posture L1. Only the binary name,
+uid, allowed-bindings set, and listening UDS path differ. References
+to "secrets dispatcher" below illustrate the pattern; substitute the
+appropriate subprocess for the other three. Audit-relevant subprocess
+events (`broker.subprocess.crashed_repeatedly`,
+`audit_signer.subprocess.crashed_repeatedly`, etc.) follow the same
+naming convention.
+
+- **Spawn:** at VM admission, the supervisor's `admit_for_run`
+  ceremony spawns each subprocess via `std::process::Command` with
+  stdin piped for initial config exchange (signed config envelope
+  per H-L3.6), then drops stdin once the subprocess is listening on
+  its UDS. Cosign verification (H-L3.1) + TOCTOU-resistant exec
+  (H-L3.2) precede every spawn.
+- **Configuration:** supervisor passes via stdin a signed JSON
+  config (host signer public-key location, audit-back-channel UDS
+  path, vsock port assignment, agent profile, allowed bindings from
+  the workload's `ExecutionPlan.services`). After consume, stdin
+  closes.
+- **Audit back-channel:** subprocesses other than `mvm-audit-signer`
+  write audit subentries to a supervisor-owned UDS; the supervisor
+  forwards them to `mvm-audit-signer`, which JCS-canonicalizes,
+  computes `prev_hash`, signs with the audit chain-signing key, and
+  appends to `~/.mvm/audit/<tenant>.jsonl`. No subprocess other than
+  `mvm-audit-signer` holds the audit chain-signing key.
+- **Inheritance:** each subprocess's parent is the supervisor;
+  `PR_SET_PDEATHSIG(SIGTERM)` on Linux ensures the subprocess dies
+  if the supervisor dies. macOS equivalent: a kqueue-monitored
+  parent-pid watcher (or libdispatch's
+  `dispatch_source_create(DISPATCH_SOURCE_TYPE_PROC, …)` watching
+  the supervisor's PID).
+- **Restart policy:** if any subprocess crashes, supervisor restarts
+  it with exponential backoff (100ms, 500ms, 2s). After 3 restarts
+  within the workload's lifetime, supervisor stops restarting,
+  audits `<subprocess>.crashed_repeatedly`, and triggers a workload
+  pause via Plan 82's harness. The workload sees `Err(Unavailable)`
+  for the affected service's calls until resumed (which only
+  happens after operator review).
+- **In-flight call handling on crash:** outstanding correlation IDs
+  return `Err(Unavailable)`. New session keys minted post-restart;
+  old sessions invalidated (consistent with S8 pause/resume
+  semantics).
 
 ## Reuse — existing pieces this plan leans on
 
@@ -390,6 +584,79 @@ Each wave is independently mergeable and leaves `cargo test --workspace && cargo
 - [ ] `supervisor_crash_subprocess_exits_via_pdeathsig` (W1)  ← T4 (lifecycle)
 - [ ] `secrets_subprocess_uid_902_seccomp_setpriv_enforced` (W5)  ← T4 (privilege confinement)
 - [ ] Fuzz lane: `fuzz_service_call.rs` ≥5min/PR (W6)
+
+**Hardening-layer regression set (Layers 1–11; gates per the
+respective wave):**
+- [ ] `host_signer_subprocess_uid_904_isolated` (W1)  ← H-L1.1
+- [ ] `audit_signer_subprocess_uid_905_sole_writer` (W1)  ← H-L1.2
+- [ ] `broker_subprocess_uid_903_isolated` (W1)  ← H-L1.3
+- [ ] `per_workload_cgroup_namespace_enforced` (W1)  ← H-L1.4
+- [ ] `host_signer_enclave_keygen_macos_se` (W8)  ← H-L2.1
+- [ ] `host_signer_enclave_keygen_linux_tpm` (W8)  ← H-L2.1
+- [ ] `host_signer_rotation_monotonic_counter_advances` (W8)  ← H-L2.2
+- [ ] `host_signer_rollback_attack_refused_via_counter` (W8)  ← H-L2.2
+- [ ] `cosign_verify_rejects_tampered_subprocess_binary` (W1)  ← H-L3.1
+- [ ] `verify_then_exec_toctou_window_closed` (W1)  ← H-L3.2
+- [ ] `seccomp_policy_denies_process_vm_readv_etc` (W5)  ← H-L3.3
+- [ ] `macos_sandbox_profile_denies_unauth_fd_access` (W1)  ← H-L3.4
+- [ ] `seccomp_per_arch_x86_64_aarch64_match` (W6)  ← H-L3.5
+- [ ] `config_signing_rejects_tampered_subprocess_config` (W1)  ← H-L3.6
+- [ ] `secrets_proxy_buffers_zeroized_on_drop` (W1)  ← H-L3.7
+- [ ] `xtask_check_subprocess_fd_inheritance` (W9)  ← H-L3.8
+- [ ] `subprocess_rlimit_core_zero_enforced` (W1)  ← H-L3.9
+- [ ] `subprocess_rlimit_as_enforced` (W1)  ← H-L3.9
+- [ ] `subprocess_mlock_secret_pages_present` (W5)  ← H-L3.9
+- [ ] `subprocess_pr_set_dumpable_zero_or_pt_deny_attach` (W1)  ← H-L3.9
+- [ ] `subprocess_checksec_pie_relro_canaries_fortify` (W9)  ← H-L3.10
+- [ ] `subprocess_reproducibility_double_build_byte_identical` (W9)  ← H-L3.10
+- [ ] `subprocess_static_linked_no_dlopen` (W1)  ← H-L3.11
+- [ ] `subprocess_w_xor_x_after_init` (W1)  ← H-L3.11
+- [ ] `subprocess_anti_debug_refuses_under_ptrace` (W1)  ← H-L3.11
+- [ ] `authenticated_frame_alg_id_byte_roundtrip` (W1)  ← H-L4.1
+- [ ] `subprocess_response_signature_verified_by_supervisor` (W1)  ← H-L4.2
+- [ ] `stub_subprocess_wrong_signature_response_rejected` (W6)  ← H-L4.2 / H-L9.1
+- [ ] `session_key_rotated_after_n_calls` (W2)  ← H-L4.3
+- [ ] `session_key_rotated_after_m_ms` (W2)  ← H-L4.3
+- [ ] `mvmd_tls_pinned_to_tls_1_3_chacha_x25519` (W4b)  ← H-L4.4
+- [ ] `constant_time_session_id_comparison` (W1)  ← H-L4.5
+- [ ] `constant_time_correlation_id_comparison` (W1)  ← H-L4.5
+- [ ] `constant_time_destination_url_match` (W5)  ← H-L4.5
+- [ ] `supervisor_assigned_correlation_ids_rewrite_workload_input` (W1)  ← H-L4.6 / G4
+- [ ] `audit_chain_fd_is_o_append_only` (W2)  ← H-L5.1
+- [ ] `audit_chain_dir_immutable_chattr_a_or_uf_append` (W2)  ← H-L5.1
+- [ ] `chain_head_persisted_to_secondary_location` (W2)  ← H-L5.2
+- [ ] `worm_audit_volume_append_only_enforced` (W2)  ← H-L5.3
+- [ ] `audit_log_encryption_at_rest_per_tenant_aead_roundtrip` (W2)  ← H-L5.4
+- [ ] `audit_log_encryption_key_derived_from_tpm_se_master` (W8)  ← H-L5.4
+- [ ] `clock_jump_backward_detected_and_audited` (W2)  ← H-L5.5
+- [ ] `correlation_id_contains_no_pii_lint` (W2)  ← H-L5.6
+- [ ] `admission_blocks_until_four_subprocesses_healthy` (W1)  ← H-L5.7 / G3
+- [ ] `operator_action_audit_entry_emitted_for_each_privileged_cli` (W2)  ← H-L6.1
+- [ ] `audit_chain_rotation_continuity_prev_hash_match` (W2)  ← H-L6.2
+- [ ] `tenant_secret_quota_enforced_across_workloads` (W4b)  ← H-L6.3
+- [ ] `mvmd_identity_pin_missing_refuses_admission` (W4b)  ← H-L6.4
+- [ ] `composition_width_cap_enforced` (W1)  ← H-L6.5
+- [ ] `audit_fsync_failure_triggers_workload_pause` (W2)  ← H-L6.6
+- [ ] `doctor_refuses_admission_on_ksm_or_thp_enabled` (W1)  ← H-L7.1
+- [ ] `doctor_refuses_admission_on_weak_kernel_posture` (W1)  ← H-L7.2
+- [ ] `subprocess_slow_start_refuses_workload` (W1)  ← H-L7.3
+- [ ] `cpu_pinning_separates_subprocesses_from_supervisor_core` (W1)  ← H-L7.4
+- [ ] `sigstore_rekor_log_entry_present_for_subprocess_release` (W9)  ← H-L8.1
+- [ ] `in_toto_attestation_present_alongside_slsa` (W9)  ← H-L8.2
+- [ ] `hermetic_build_lane_refuses_network_access` (W9)  ← H-L8.3
+- [ ] `hostile_subprocess_test_each_kind_rejected` (W6)  ← H-L9.1
+- [ ] `cargo_mutants_no_security_function_escapes` (W9)  ← H-L9.2
+- [ ] `fuzz_uds_proxy_read_loop` (W6)  ← H-L9.3
+- [ ] `side_channel_timing_audit_dudect_passes` (W5/W8)  ← H-L9.4
+- [ ] `codeowners_require_security_reviewer_on_subprocess_crates` (W9)  ← H-L9.5 / H-L9.6
+- [ ] `snapshot_restore_respawns_subprocesses_fresh_keys` (W1)  ← H-L11.1 / G6
+- [ ] `crypto_crate_pinning_deny_toml_enforced` (W9)  ← H-L11.2 / G7
+- [ ] `serde_jcs_rfc8785_conformance_corpus_passes` (W9)  ← H-L11.2
+- [ ] `deployment_mode_doctor_row_correct` (W1)  ← H-L11.3 / G8
+- [ ] `doctor_refuses_admission_on_known_vsock_cve_version` (W1)  ← H-L11.4 / G9
+- [ ] `host_signer_software_fallback_doctor_downgrade_row` (W1)  ← H-L11.5 / G5
+- [ ] `fido_touch_required_stub_audits_unverified` (W1)  ← H-L11.6 / G2 stub
+- [ ] `fido_touch_required_full_enforcement` (W11)  ← G2 full
 
 **Manual falsifiability check (post-W7):**
 - [ ] Add a fourth service `host.dev.echo.v1` in a throwaway branch. Single new handler file + one registry line + `ServiceBinding` entry. If it requires touching the envelope, registry, or auth path, the design failed and v1 needs redesign before the host-logging follow-up plan starts.
@@ -508,10 +775,394 @@ Two new claims for the broker (numbers to be assigned in ADR-059 against ADR-002
 
 ### Surfaces that don't expand
 
-- No new host process / daemon / uid / persistent socket on disk in v1. (v2 addons add per-addon uid 902 + per-VM UDS, in a separate plan.)
-- Trust boundary unchanged — supervisor was already trusted.
+- New host subprocesses in v1: `mvm-host-signer` (uid 904), `mvm-audit-signer` (uid 905), `mvm-broker` (uid 903), `mvm-secrets-dispatcher` (uid 902). All per-VM, supervised by the per-VM supervisor, killed via parent-death signal. See §"Hardening posture" for the rationale (TCB minimization across four discrete process boundaries).
+- Trust boundary narrowed (see §"Hardening posture, threat model expansion"). ADR-002's "malicious host" out-of-scope clause is preserved for *physical* attacks (cold-boot, DMA, hardware tampering) but narrowed for *software* insider attacks under the Layer-1/2/5 hardening.
 - Egress policy unchanged — broker is host↔guest only.
 - `prod-agent-no-exec` unchanged — no broker verb is code-execution-shaped.
+
+## Hardening posture (Layers 1–11)
+
+This section consolidates the hardening commitments that take the
+broker from "subprocess-isolated secrets" (the baseline §Architecture
+above) to "as tight as practical for v1." Each layer answers a
+specific failure mode; each item names the threat it addresses and
+the cost it carries. The build sequence (W1–W11) realises these
+layers; §Critical files lists the artefacts; §Verification names the
+tests.
+
+### Layer 1 — Process isolation (TCB minimization)
+
+The baseline puts everything except `host.secrets.v1` in the
+supervisor. A supervisor UAF therefore exfiltrates the host signer
+key, can forge audit entries, can mint plans with arbitrary
+bindings, and can lie to mvmd about the workload identity.
+Hardening splits these out:
+
+- **H-L1.1 — `mvm-host-signer` subprocess (uid 904).** Host signer
+  Ed25519/P-256 key never loaded into the supervisor; supervisor
+  sends typed "sign this hash" RPCs over a per-VM UDS. New crate
+  `crates/mvm-host-signer/`. Subprocess inherits only the UDS FD +
+  a read-only mmap of the host signer public key for self-check;
+  cosign-verified at spawn (H-L3.1) with TOCTOU-resistant
+  verify-then-exec (H-L3.2).
+- **H-L1.2 — `mvm-audit-signer` subprocess (uid 905).** Sole writer
+  to `~/.mvm/audit/<tenant>.jsonl`, sole holder of the audit
+  chain-signing key, sole computer of `prev_hash`. Supervisor sends
+  typed entries; signer JCS-canonicalizes, signs, appends. New crate
+  `crates/mvm-audit-signer/`.
+- **H-L1.3 — `mvm-broker` subprocess (uid 903).** General broker
+  (port 5300, the `host.time.v1` / `host.cost.v1` / `broker.v1`
+  handlers) split out of the supervisor. Supervisor becomes pure
+  launcher + admission controller + IPC router. New crate
+  `crates/mvm-broker/`. (`host.secrets.v1` continues to live in
+  `crates/mvm-secrets-dispatcher/` per the baseline.)
+- **H-L1.4 — Per-workload cgroup + namespace isolation for the
+  subprocess set.** Each workload's four subprocesses share a
+  workload-specific cgroup v2 with strict memory / CPU / PID / IO
+  limits; each subprocess additionally gets its own PID namespace +
+  mount namespace (read-only-bind everything outside the per-VM UDS
+  dir). macOS approximations: `sandbox_init_with_parameters` per
+  subprocess + `posix_spawnattr_setpgroup` for resource grouping.
+- **H-L1.5 — Supervisor split deferred to v2.** Supervisor's
+  remaining responsibilities (admission verification, IPC routing,
+  subprocess lifecycle) stay co-located in v1. Splitting further is
+  worth tracking; defer.
+
+### Layer 2 — Hardware-backed key material
+
+- **H-L2.1 — Hardware-enclave host signer key.** macOS: Apple
+  Secure Enclave (P-256; wire `sig_alg=0x02`) via
+  `SecKeyCreateRandomKey` + `kSecAttrTokenIDSecureEnclave`. Linux:
+  TPM 2.0 via `tpm2-tss` (RSA-2048 or ECDSA-P256 depending on TPM
+  capability). Fallback: kernel keyring (Linux) or filesystem mode
+  0600 (universal) — only with an explicit downgrade flag, surfaced
+  in `mvmctl doctor` as a security-claim downgrade. Lands in W8.
+- **H-L2.2 — TPM monotonic counter for host signer key rotation.**
+  Each key rotation increments a TPM-backed monotonic counter; the
+  value embeds in admission audit entries. Defeats key-rollback
+  attacks where an attacker reinstalls a previously-leaked key.
+  Requires H-L2.1.
+
+### Layer 3 — Subprocess + binary hardening
+
+- **H-L3.1 — Cosign-verify every subprocess binary at spawn.**
+  Signature pinned against a release-time public key bundled with
+  `mvmctl`. Refuse-to-spawn on mismatch; audit
+  `<subprocess>.signature_invalid`. Applies to all four
+  subprocesses, not only the secrets dispatcher.
+- **H-L3.2 — TOCTOU-resistant verify-then-exec.** Open the binary
+  read-only, mmap, verify the mmap'd bytes, then `fexecve` (Linux)
+  / `posix_spawn` with FD (macOS). Narrows the
+  verify-then-replace window from "any wall-clock interval" to the
+  kernel's syscall handoff.
+- **H-L3.3 — Explicit seccomp policy in ADR-059 (not "standard").**
+  Allow-list: `read`, `write`, `recvmsg`, `sendmsg`, `poll`,
+  `epoll_wait`, `clock_gettime`, `exit`, `exit_group`,
+  `rt_sigreturn`, `futex`, `mmap`/`munmap` (anon only), `brk`,
+  `mprotect` (no PROT_EXEC after init). **Explicitly denied:**
+  `process_vm_readv`/`process_vm_writev`, `ptrace`, `kcmp`,
+  `pidfd_open`, `userfaultfd`, `bpf`, `perf_event_open`. Per-arch
+  (x86_64 + aarch64) syscall numbers via `seccompiler`.
+- **H-L3.4 — macOS sandbox profile equivalent.** Without this the
+  hardening is Linux-only. Per-subprocess profile via
+  `sandbox_init_with_parameters` enumerating allowed system services
+  (`mach`, `file-read*` on the per-VM dir, `network-outbound` deny);
+  `EXC_GUARD` for unauthorized FD usage.
+- **H-L3.5 — Multi-arch seccomp explicit, CI-tested.** Per-arch
+  deny-list expressed in `seccompiler`; CI-tested on x86_64 +
+  aarch64 (existing project matrix).
+- **H-L3.6 — Subprocess config-signing (G1).** Supervisor's spawn
+  passes a JSON config to subprocess stdin (audit-back-channel UDS,
+  vsock port, allowed bindings). The config envelope is signed
+  under the same release-time key as the binary (H-L3.1);
+  subprocess refuses to start unless config signature verifies.
+  Closes "supervisor-survives-long-enough-to-poison-config" path.
+- **H-L3.7 — Zeroize at supervisor's `secrets_proxy.rs` buffers.**
+  UDS proxy uses `zeroize::Zeroizing<Vec<u8>>` for forward +
+  return buffers. Return-path bytes contain signed-credential
+  payload briefly between dispatcher response and vsock send.
+- **H-L3.8 — No shared FDs / no shared memory invariant.** CI lint
+  `xtask check-subprocess-fd-inheritance` parses the spawn call
+  site; subprocess inherits only its UDS sockets + the host signer
+  public-key FD; everything else closed via `close_range` after
+  fork.
+- **H-L3.9 — Resource caps on every subprocess.**
+  `RLIMIT_CORE=0` (no core dumps with secrets), `RLIMIT_AS` and
+  cgroup memory cap, `mlock`/`mlockall(MCL_FUTURE)` on
+  secret-bearing pages, `prctl(PR_SET_DUMPABLE, 0)` (Linux) /
+  `PT_DENY_ATTACH` (macOS), `prctl(PR_SET_THP_DISABLE, 1)` for
+  secret arena.
+- **H-L3.10 — Binary hardening flags + reproducibility lane.**
+  PIE + RELRO (full) + stack canaries + `-D_FORTIFY_SOURCE=3` +
+  `-fstack-clash-protection`. CI-asserted via `checksec`. Each
+  subprocess binary gets its own reproducibility-double-build lane
+  (claim-7 reproducibility extended per-binary).
+- **H-L3.11 — Static-link + W^X + no `dlopen` + anti-debug.**
+  musl-static on Linux; libSystem on macOS. `mprotect(…,
+  PROT_EXEC|PROT_READ)` at startup; `PROT_NONE` for everything
+  thereafter (no JIT). Startup check: refuse-to-run if
+  `/proc/self/status:TracerPid != 0` (Linux) /
+  `PT_DENY_ATTACH` invocation succeeds before any sensitive code
+  runs (macOS).
+
+### Layer 4 — Protocol + cryptography
+
+- **H-L4.1 — Algorithm-identifier byte in `AuthenticatedFrame`.**
+  Adds 1 byte to the frame header. v1 ships `0x01=Ed25519` and
+  `0x02=ECDSA-P256` (the macOS SE host-signer path). Lets us swap
+  algorithm (Ed448, PQC scheme) later without a hard fork.
+- **H-L4.2 — Subprocess response signing.** Each subprocess gets
+  its own per-spawn ephemeral keypair (never persisted). Every
+  `ServiceResponse` is signed by the subprocess's key before
+  crossing the UDS; the supervisor verifies before relaying to the
+  guest. Two-key chain (subprocess → supervisor) prevents
+  stub-subprocess forgery even if cosign verify (H-L3.1) had a hole.
+- **H-L4.3 — Per-call ephemeral session-key rotation.** Workload
+  session key rotates every `BROKER_SESSION_REKEY_CALLS=1000` or
+  every `BROKER_SESSION_REKEY_MS=60000`. Limits value of a
+  session-key compromise to a small window.
+- **H-L4.4 — TLS-1.3-only + single suite to mvmd.** Pin TLS 1.3,
+  ChaCha20-Poly1305-SHA256, X25519, ALPN matching our protocol.
+  No downgrade, no negotiation flexibility.
+- **H-L4.5 — Constant-time comparisons.** All
+  workload-controllable-byte-string comparisons use
+  `subtle::ConstantTimeEq` (session IDs, correlation IDs,
+  destination URLs, audit-chain hashes). CI grep lints `==`/`!=`
+  on known security-byte types.
+- **H-L4.6 — Supervisor-assigned correlation IDs (G4).** Supervisor
+  assigns correlation IDs at frame ingress and rewrites or rejects
+  workload-supplied ones. Prevents a workload from forging another
+  workload's correlation sequence for audit-trail confusion.
+
+### Layer 5 — Audit chain integrity + confidentiality
+
+- **H-L5.1 — `O_APPEND` audit chain FD + dir-immutable.**
+  Audit-signer subprocess holds an `O_APPEND` FD to the audit
+  JSONL; `chattr +a` on the directory on Linux, `UF_APPEND` on
+  macOS. Test asserts FD has `O_APPEND` and `lseek` returns EBADF.
+- **H-L5.2 — Anti-rollback chain-head persistence.** `chain_head`
+  persisted to a second location on every entry (`~/.mvm/audit/HEAD`
+  fsync'd file or kernel keyring entry). Tampering with the JSONL
+  fails the secondary check.
+- **H-L5.3 — WORM backing for audit logs.** Append-only mount
+  where the FS supports it (Linux `chattr +a` enforced; macOS
+  `UF_APPEND`). Periodic snapshot to immutable cloud storage is a
+  follow-on plan (S3 Object Lock-equivalent — named but not
+  in this scope).
+- **H-L5.4 — Audit log encryption at rest.** Per-tenant
+  ChaCha20-Poly1305 key derived from a TPM/SE-bound master
+  (H-L2.1). Today disk-image-theft = audit log plaintext readable;
+  with this, theft yields ciphertext. The chain-sign protects
+  integrity separately.
+- **H-L5.5 — Time-source integrity for audit timestamps.** Use TPM
+  monotonic counter or kernel boottime as integrity anchor; flag
+  clock jumps in audit (`audit.clock.jump_detected`). Defends
+  against NTP-poisoning-driven log backdating.
+- **H-L5.6 — No PII in correlation IDs.** Documented invariant.
+  ULIDs are time-ordered + random; never derived from
+  user-identifiable data.
+- **H-L5.7 — Admission blocks until audit-signer is healthy (G3).**
+  S22 covers post-up durability. Pre-up: admission ceremony
+  refuses to proceed until all four subprocesses report healthy
+  via their respective UDS handshake. No in-supervisor audit
+  buffer that could be lost on early crash.
+
+### Layer 6 — Admission + capability tightening
+
+- **H-L6.1 — Operator-action audit entries.** `mvmctl services
+  revoke`, `mvmctl host-key rotate`, `mvmctl audit verify`,
+  `mvmctl services call` (debug path), `mvmctl up --insecure-host`,
+  and any other privileged invocation emit chain-signed
+  audit entries via `mvm-audit-signer`.
+- **H-L6.2 — Audit log rotation policy named.** Rotated file's
+  last entry hash = active file's first `prev_hash`; doctor flags
+  any chain that fails this continuity invariant. Concrete
+  rotation triggers (size, age) land in the host-logging
+  follow-up plan.
+- **H-L6.3 — Tenant-level secret call quotas.** In addition to
+  per-workload quotas (S12). mvmd-enforced tenant cap so N
+  workloads under one tenant cannot collectively exceed it.
+- **H-L6.4 — mvmd identity pinning explicit.** Pinned in
+  `~/.mvm/keys/mvmd-pubkey` (or in the existing fleet-credential
+  bundle). Doctor flags pin absence. MITM mitigation during
+  initial bootstrap is explicit (the supervisor refuses to talk to
+  mvmd without a pinned key).
+- **H-L6.5 — Composition width cap.** A5's depth cap is in (≤3);
+  add width cap (`BROKER_COMPOSITION_WIDTH=5` — max fan-out
+  sub-invocations per call).
+- **H-L6.6 — Audit fsync failure policy.** Any audit fsync failure
+  → workload pause (not just error to caller); operator review
+  required to resume. Audit-signer subprocess surfaces fsync
+  failures via the UDS audit-back-channel.
+
+### Layer 7 — Host posture + observability
+
+- **H-L7.1 — KSM off + THP off for workload-adjacent memory.**
+  Doctor sets and enforces. Without this, H-L3.7 zeroize has
+  cross-process leaks via shared/merged pages.
+- **H-L7.2 — Doctor enforces host-kernel hardening; refuses
+  admission on weak hosts.** KASLR, KPTI, SMEP/SMAP, Spectre-v2
+  mitigations, LSM available, `kernel.unprivileged_userns_clone=0`,
+  `kernel.dmesg_restrict=1`, macOS SIP+AMFI+kext-loading checks.
+  Refusal mode: `mvmctl up` exits nonzero with a remediation
+  list; overridable only with `--insecure-host` (which itself
+  audits and warns loudly).
+- **H-L7.3 — Subprocess slow-start detection.** If any subprocess
+  exceeds `BROKER_SUBPROCESS_START_DEADLINE_MS=2000`, audit
+  `<subprocess>.slow_start` and refuse the workload. Defends
+  against attacker stalling startup to coincide with another
+  event.
+- **H-L7.4 — CPU side-channel posture.** Pin each subprocess to a
+  CPU core not shared with the supervisor (cpuset where the host
+  has spare cores). Best-effort; doctor flags downgrade on hosts
+  without spare cores.
+
+### Layer 8 — Supply chain + build + release
+
+- **H-L8.1 — Sigstore / Rekor transparency log entry per
+  subprocess release.** Public, append-only ledger of every signed
+  binary. Defense against secretly-signed-compromised builds.
+- **H-L8.2 — In-toto attestations alongside SLSA.** Build
+  provenance with explicit step-by-step materials/products.
+  Complements cosign (identity) and SLSA (metadata).
+- **H-L8.3 — Hermetic, network-isolated build of subprocess
+  binaries.** Explicit (implied by the claim-9 sealed-volume
+  pattern). No network during compile; sealed builder VM at a
+  distinct uid. Each subprocess's reproducibility-double-build
+  lane runs in this hermetic environment.
+
+### Layer 9 — Testing + review process
+
+- **H-L9.1 — Hostile-subprocess test.** Stub subprocess binaries
+  (one per kind: host-signer-stub, audit-signer-stub,
+  broker-stub, secrets-dispatcher-stub) that pass cosign-verify
+  but return wrong-but-well-formed responses. Supervisor MUST
+  reject each for failing the subprocess's response signature
+  (H-L4.2). Tests the H-L4.2 boundary independently for each
+  subprocess kind.
+- **H-L9.2 — Mutation testing on security-critical functions.**
+  `cargo-mutants` lane targeting
+  `crates/mvm-{supervisor,broker,secrets-dispatcher,host-signer,audit-signer}/`.
+  Asserts no mutation passes existing tests — escapes are bugs.
+- **H-L9.3 — Fuzz the UDS proxy specifically.** Existing W6 fuzz
+  extends to the supervisor-side UDS read loop (different code
+  path from vsock framing fuzz).
+- **H-L9.4 — Side-channel / timing audit.** Run `dudect` or
+  `CTGrind` against the secrets dispatcher + host-signer
+  subprocess before W5 / W8 merges. Document the run in W5/W8 PR
+  description.
+- **H-L9.5 — W1, W5, W8 dispatcher review gate.** Mandatory
+  dedicated security reviewer sign-off before merge for the
+  subprocess scaffolding + secrets-dispatcher implementation +
+  hardware-enclave host signer. Extends repo CODEOWNERS pattern.
+- **H-L9.6 — CODEOWNERS + multi-reviewer requirement.** Branch
+  protection requires a second reviewer for
+  `crates/mvm-secrets-dispatcher/`, `crates/mvm-host-signer/`,
+  `crates/mvm-audit-signer/`, `crates/mvm-broker/`,
+  `crates/mvm-supervisor/src/services/`, and ADR-059.
+
+### Layer 10 — Documentation + threat model
+
+- **H-L10.1 — Threat model document distinct from ADR-059.**
+  `specs/threat-models/02-host-services-broker.md` walks STRIDE
+  per service (host.secrets.v1, host.time.v1, host.cost.v1,
+  broker.v1) with mitigations cross-referenced. ADR-059 stays a
+  decision record; the STRIDE walk lives separately.
+- **H-L10.2 — CVE response runbook.** `SECURITY.md` says: where
+  to report, our SLA, coordinated disclosure policy,
+  fix-and-publish workflow, public Sigstore/Rekor entry policy.
+- **H-L10.3 — PII invariant documented** in
+  `docs/security/audit-fields.md` and inline in the chain entry
+  type.
+
+### Layer 11 — Snapshot + restore + recovery semantics (Round-4 gaps)
+
+- **H-L11.1 — Snapshot + restore re-handshake protocol (G6).** On
+  workload restore: re-spawn all four subprocesses with fresh
+  ephemeral keys; old session keys treated as revoked per S8.
+  Stale subprocess state across PID reuse is not preserved.
+- **H-L11.2 — Cryptographic-crate pinning (G7).** ADR-059
+  §"Implementation choices" pins exact crates + versions:
+  `ed25519-dalek` v2.x (constant-time verified), `serde_jcs`
+  (pin exact version; CI runs RFC 8785 conformance corpus on
+  every PR), `chacha20poly1305` (RustCrypto, audited),
+  `tpm2-tss` (Intel) for Linux TPM path, `subtle` for
+  constant-time comparisons (H-L4.5). All present in `deny.toml`
+  for advisory + license enforcement.
+- **H-L11.3 — Deployment-mode threat differentiation (G8).**
+  ADR-059 §"Deployment modes" maps single-dev / CI / fleet mode
+  → applicable threats so users know which mitigations are
+  load-bearing for their use. Doctor surfaces which mode the
+  current host is operating in.
+- **H-L11.4 — Vsock CVE surface enumeration (G9).** ADR-059
+  §"Dependency CVE surface" enumerates KVM vhost-vsock,
+  Firecracker, libkrun, cloud-hypervisor, Apple vz vsock by name
+  with stated response posture: "a vsock CVE → emergency host
+  upgrade required; doctor refuses admission on known-affected
+  kernel/VMM versions; affected-version list shipped in `mvmctl`
+  and refreshed per release."
+- **H-L11.5 — Honest TOFU naming (G5).** ADR-059 explicitly says
+  the host signer is TOFU on non-enclave hosts; doctor flags the
+  downgrade.
+- **H-L11.6 — Operator FIDO ceremony stub (G2).** `mvmctl up
+  --prod` runs a `fido_touch_required()` gate that today no-ops
+  + audits `operator.fido.unverified` with a loud warning. Full
+  FIDO2/Yubikey-touch ceremony lands in W11.
+
+### Tightening deliberately not folded into v1
+
+Named here so future readers don't assume they were missed:
+
+- **m-of-n quorum for host signer key rotation.** Operationally
+  heavy; single-operator rotation with audit acceptable for v1.
+  Named as a future plan.
+- **Hybrid Ed25519 + Dilithium signatures.** PQC matters when CRQC
+  arrives; the algorithm-identifier byte (H-L4.1) is sufficient
+  preparation.
+- **Remote attestation of workload identity** (TPM PCR-bound
+  workload signing). Research-grade; existing signed-`ExecutionPlan`
+  + cosigned-image sufficient.
+- **Full memory-snapshot encryption.** Adds significant complexity
+  to snapshot/resume; the realistic threat (disk-imaging the
+  snapshot file) is mitigated by host FDE (operator's
+  responsibility).
+- **mvmd as redundant audit-chain anchor on every entry.** Latency
+  cost too high; C7-pinned `chain_head` polling is sufficient.
+- **PFS-via-broker-encryption.** Vsock channel is host-local; no
+  network attacker. Adding AEAD here is security theater against
+  the actual threat.
+- **Detection / alerting** (G10). Audit logs are forensics, not
+  detection. `host.alert.v1` reserved as a future broker service
+  in the host-logging follow-on plan.
+- **Disaster recovery / key escrow** (G11). Operator-held escrow
+  signed under operator FIDO key is the right shape but a major
+  operational lift. Future plan.
+- **Subprocess-restart accumulation attack** (G12). Considered:
+  no traffic encryption to decrypt; per-spawn keys give attacker
+  no cryptographic leverage. Named and dismissed in ADR-059
+  §"Considered and rejected threats" so a future reader doesn't
+  re-litigate.
+
+### Threat-model expansion this hardening buys
+
+With H-L1.1, H-L1.2, H-L2.1, H-L5.4, and H-L1.4 in:
+
+> **In scope (new):** A hostile host *operator* (insider) with
+> shell access who is not authorized to read workload secrets.
+> With HW-enclave host signer (H-L2.1), at-rest audit encryption
+> (H-L5.4), and key-isolation subprocesses (H-L1.1, H-L1.2),
+> shell access to the host no longer yields the host signer key,
+> the audit-signing key, or the audit log plaintext. Workload
+> secrets are still mediated by `host.secrets.v1`'s
+> destination-bound signed credentials (claim-Y design); insider
+> with shell can request the broker to mint credentials but
+> cannot extract them from process memory thanks to the seccomp
+> + setpriv + mlock + cgroup compartment.
+
+ADR-002's existing "malicious host" out-of-scope clause needs an
+update: it remains true for *physical* host attacks (cold-boot,
+DMA, hardware tampering) but is now narrowed for *software*
+insider attacks. ADR-059 carries the cross-reference.
 
 ## mvmd-side extension — Plan 52 + ADR-0023 (drafts, to be written to mvmd repo on approval)
 
@@ -675,7 +1326,7 @@ Current plan defaults to the first interpretation. Pin it or change it.
 Original draft used CBOR. Switched to JSON because v1 has no genuinely binary payload, the W7 ADR-049 SDK matrix (Python `cbor2` / TS `cbor-x` / Rust `ciborium`) introduces real cross-language friction, `jq` debuggability is real over project lifetime, and the existing `GuestRequest` / `HostBoundRequest` channels already use JSON in `crates/mvm-guest/src/vsock.rs` — consistency. Future binary payloads use base64-in-JSON on the specific field; 33% overhead on one field at ~500-byte typical payloads is negligible. Trade-off acknowledged: COSE-based signing (RFC 8152) would mandate CBOR; ADR-049's signing scheme is Ed25519-on-bytes (not COSE), so JSON is fine. JCS (RFC 8785 — JSON Canonicalization Scheme) is used for the bytes-to-sign when signing JSON payloads.
 
 **T4 — `host.secrets.v1` runs in a dedicated subprocess (DECIDED 2026-05-26).**
-Resolved by §"Host-side: two-process architecture" above. The general broker (port 5300, in-process) and the secrets dispatcher (port 5301, separate subprocess at uid 902 with seccomp + setpriv) share zero code paths and zero address space. A use-after-free in the general broker's dispatcher cannot reach the credential-minting code, the grant table, or the keystore policy state in the secrets subprocess. This is the production-ready isolation pattern (industry analogues: AWS STS, HashiCorp Vault, Kubernetes ServiceAccount token controllers — all out-of-process credential issuers). Cost: ~50% W1+W5 scope growth — a new crate (`mvm-secrets-dispatcher`), subprocess lifecycle in the supervisor, UDS proxy code path. Justified because (a) the user stated control-plane compromise as a security concern, (b) this gives A4 a concrete v1 consumer (see T5), (c) split-task→split-process migration later is more painful under the no-backcompat rule.
+Resolved by §"Host-side: four-subprocess architecture" above. The general broker (port 5300, in-process) and the secrets dispatcher (port 5301, separate subprocess at uid 902 with seccomp + setpriv) share zero code paths and zero address space. A use-after-free in the general broker's dispatcher cannot reach the credential-minting code, the grant table, or the keystore policy state in the secrets subprocess. This is the production-ready isolation pattern (industry analogues: AWS STS, HashiCorp Vault, Kubernetes ServiceAccount token controllers — all out-of-process credential issuers). Cost: ~50% W1+W5 scope growth — a new crate (`mvm-secrets-dispatcher`), subprocess lifecycle in the supervisor, UDS proxy code path. Justified because (a) the user stated control-plane compromise as a security concern, (b) this gives A4 a concrete v1 consumer (see T5), (c) split-task→split-process migration later is more painful under the no-backcompat rule.
 
 **T5 — A4 substrate ships in v1 with secrets as its first consumer (DECIDED 2026-05-26).**
 Resolved by §A4 rewrite above. The "speculative substrate with no v1 consumer" criticism dissolves — the v1 consumer of the out-of-process handler substrate IS the secrets dispatcher (T4). Every line of the UDS proxy code is exercised by the security-critical secrets path on every workload start. v2 third-party addons reuse the *same* substrate when they land: same wire envelope, same handler trait, same audit flow, same subprocess pattern. The substrate's design is informed by the secrets dispatcher's real requirements, not a hypothetical addon's. This pattern of "ship the abstraction along with its first real consumer, defer hypothetical consumers to v2" is the right discipline.
@@ -705,6 +1356,13 @@ Resolved above in §C7 — the chain entry format must be (1) append-only canoni
 - **R7 — JSON encoding crates.** `serde_json` for the wire envelope (already in-tree), `serde_jcs` (or equivalent) for canonical signing bytes (RFC 8785). Existing `cargo-deny` lane catches regressions. **No CBOR libraries needed** — ciborium dropped from the dependency closure when T3 settled on JSON.
 - **R8 — Cross-backend behavioral divergence.** Vsock semantics differ across libkrun, Firecracker, Apple Container, vz. Mitigation: W6 cross-backend test matrix; backend-specific shims rather than divergent behavior.
 - **R9 — Sprint 56 claim 10 collision.** Sprint 56 owns "claim 10" (bytes leaving trust boundary). Plan 104's broker claims must be assigned different numbers in ADR-059 against the live ADR-002 claim list at write time.
+- **R10 — W1 scope tripled by hardening fold-in.** Originally a 2-subprocess design (supervisor + secrets dispatcher); now four subprocesses (broker, secrets, host-signer, audit-signer) with cosign-verify, config-signing, cgroup/namespace isolation, resource caps, binary-hardening flags. Realistic estimate: W1 is 4–6 weeks of focused work, not 2. Split W1 into W1a (envelope + protocol + first subprocess scaffold) and W1b (remaining subprocesses + lifecycle + hardening) if a single PR becomes unreviewable.
+- **R11 — W8 hardware-enclave wave depends on platform-specific code that doesn't exist in `mvm` today.** macOS SE Swift bridge + Linux TPM 2.0 integration are both first-time additions. If `tpm2-tss` C bindings prove painful or SE-Swift-bridge stability concerns emerge mid-wave, ship v1 with the **software-fallback host signer** + a loud `mvmctl doctor` downgrade row, and land W8 as a Sprint-58 follow-on. The fallback path must be implemented in W1 either way — it's the bridge during W2–W7 even before W8 ships.
+- **R12 — Algorithm-identifier byte (H-L4.1) is a v1 wire commitment.** Once shipped, removing or repurposing the byte is a hard fork. Verify in W1 design review that the byte is in the *right* position in `AuthenticatedFrame` (before any length-prefixed body) so future versions can choose alternative algorithms cleanly.
+- **R13 — Subprocess crash storms vs workload availability.** Three restarts per workload per subprocess = up to 12 subprocess restarts before workload pause. A subprocess hitting a deterministic crash bug (e.g., a malformed mvmd response) could pause many workloads simultaneously across the fleet. Mitigation: per-workload pause + audit-chain alert; W6 mutation testing (H-L9.2) catches most deterministic crash bugs pre-release.
+- **R14 — `mvm-host-signer` subprocess is a new single-point-of-availability.** Supervisor cannot admit plans if `mvm-host-signer` is down; can't sign audit entries if `mvm-audit-signer` is down. v1 mitigation is restart-with-backoff (same as secrets dispatcher); operational consequence is "all admission and all audit blocked during signer recovery." Documented operational behavior; no code-side mitigation in v1 (m-of-n quorum is deferred per §"Tightening deliberately not folded in").
+- **R15 — Cross-backend Swift listener (vz) is the riskiest single sub-task.** The existing `VsockProxy.swift` is host-as-client only — no `VZVirtioSocketListener` `shouldAcceptNewConnection` path exists. New Swift work for two ports + four subprocesses on each accepted connection. Mitigation: land an integration test on the vz backend specifically in W6 before W3 ships, so a vz regression is caught at the matrix gate.
+- **R16 — Operator FIDO ceremony (W11) may not have FIDO hardware on all developer hosts.** Fallback (operator-key-on-encrypted-USB) is realistic but adds a credential-management ceremony to every contributor's workflow. Risk: developer pushback on the `--prod` gate slowing the feedback loop. Mitigation: `mvmctl up` (without `--prod`) doesn't require FIDO; the gate applies only to production-mode launches. `mvmctl up --insecure-host --no-fido` audited downgrade available.
 
 ## Non-goals (explicit)
 
@@ -713,4 +1371,15 @@ Resolved above in §C7 — the chain entry format must be (1) append-only canoni
 - `unsafe_guest_tls_inspection` proxy-with-CA path from ADR-049. Ships separately.
 - Non-HTTP secret substitution. Out of scope per ADR-049 §"Non-HTTP egress."
 - Cross-VM cost aggregation across tenants. `host.cost.v1::tenant` is single-tenant.
-- Audit log rotation strategy. Deferred to the host-logging follow-up plan / ADR-060 (when `host.audit.v1` lands).
+- Audit log rotation strategy concrete triggers (size, age). Deferred to the host-logging follow-up plan / ADR-060 (when `host.audit.v1` lands). Continuity invariant *is* in scope (H-L6.2).
+- **m-of-n quorum for host signer key rotation.** Operationally heavy; single-operator rotation with audit is acceptable for v1. Future plan once W11 FIDO ceremony exists.
+- **Hybrid Ed25519 + Dilithium signatures (PQC).** Algorithm-identifier byte (H-L4.1) is sufficient preparation; full hybrid signing waits until CRQC pressure is real.
+- **Remote attestation of workload identity** (TPM PCR-bound workload signing). Research-grade; existing signed-`ExecutionPlan` + cosigned-image sufficient.
+- **Full memory-snapshot encryption** for paused workloads. Complexity in snapshot/resume; realistic threat (disk-imaging the snapshot file) mitigated by host FDE (operator's responsibility).
+- **mvmd as redundant audit-chain anchor on every entry.** Latency cost too high; C7-pinned `chain_head` polling is sufficient.
+- **PFS-via-broker-encryption.** Vsock channel is host-local process-to-process; no network attacker. Adding AEAD here is security theater against the actual threat. Explicitly *not* added (H-L4 design discussion).
+- **Detection / alerting (G10).** Audit logs are forensics, not detection. `host.alert.v1` is reserved as a future broker service in the host-logging follow-on plan; v1 ships no alerting path.
+- **Disaster recovery / key escrow (G11).** Lost host signer / TPM / audit-signer keys = workloads broken; no recovery in v1. Operator-held escrow signed under operator FIDO key is the right shape but a major operational lift — future plan once W11 lands FIDO.
+- **Subprocess-restart accumulation attack (G12).** Considered and dismissed: no traffic encryption to decrypt; per-spawn keys give attacker no cryptographic leverage. Named in ADR-059 §"Considered and rejected threats" so a future reader doesn't re-litigate.
+- **Supervisor split (admission verifier + IPC router as separate processes).** Deferred to v2. v1 supervisor remains the single launcher + IPC router + admission controller.
+- **Workload-to-workload services (peer discovery, mesh).** Out of scope; `host.peers.v1` is future-only.

--- a/specs/threat-models/02-host-services-broker.md
+++ b/specs/threat-models/02-host-services-broker.md
@@ -1,0 +1,129 @@
+# Threat model 02 — Host services broker over vsock
+
+- **Status:** Proposed
+- **Date:** 2026-05-27
+- **Owner:** MVM Project
+- **Related:** [ADR-002 microvm security posture](../adrs/002-microvm-security-posture.md), [ADR-059 host services broker](../adrs/059-host-services-broker.md), [Plan 104 host services broker](../plans/104-host-services-broker.md), [ADR-049 secret substitution mechanism](../adrs/049-secret-substitution-mechanism.md), [mvmd ADR-0023](../../../mvmd/specs/adrs/0023-mvmd-host-services-delegation.md), [threat model 01 — runtime baseline](01-runtime-baseline.md) (TBD)
+
+This document is the STRIDE walk for the host services broker introduced by ADR-059 / Plan 104. ADR-059 is the decision record (architecture, choices); this document is the structured-threat enumeration with mitigation cross-references.
+
+## Scope
+
+**In scope:**
+
+- The four broker subprocesses (`mvm-broker`, `mvm-secrets-dispatcher`, `mvm-host-signer`, `mvm-audit-signer`) and their per-VM lifecycle.
+- The vsock channel (ports 5300 + 5301) between the guest microVM and the host subprocesses.
+- The per-VM UDS channels between the supervisor and each subprocess.
+- The cross-VM path from the supervisor to mvmd-agent over iroh ALPN, with respect to the four services Plan 104 ships.
+- The `ExecutionPlan.services` admission ceremony and audit chain entries it generates.
+
+**Out of scope** (per ADR-002 and ADR-059):
+
+- Physical attacks on the host (cold-boot DRAM, DMA via Thunderbolt/PCIe, chip-off, side-channel power analysis, unauthorized firmware flashing).
+- Multi-tenant guests (one guest = one workload).
+- Hardware-backed key attestation by the workload itself.
+- Vulnerabilities in the hypervisor's vsock implementation (KVM `vhost-vsock`, Firecracker, libkrun, cloud-hypervisor, Apple `vz`) — these are dependency-CVE-managed per ADR-059 §"Dependency CVE surface."
+
+## Adversary model
+
+Three adversary classes, in order of decreasing access:
+
+| Class | Description | Capabilities |
+| --- | --- | --- |
+| **G — Hostile guest** | A workload running inside a microVM (the primary adversary). Has full control over guest userspace; cannot break out of the VM. | Sends arbitrary bytes to vsock 5300 + 5301; receives responses; observes timing |
+| **N — Hostile network peer** | A network attacker on the path between the supervisor and mvmd-agent. | Observes + tampers with iroh ALPN traffic (mitigated by mvmd identity pinning + TLS 1.3) |
+| **I — Software insider** | An unauthorized human with shell access to the host as some Unix user. **Newly in scope** per ADR-059's narrowing of ADR-002's "malicious host" clause. | Executes arbitrary code on the host; cannot escalate to root if not already root; cannot perform physical attacks |
+
+For each service below, the STRIDE table notes which adversary class the threat applies to in the **Adv.** column.
+
+## Cross-cutting threats (apply to all services)
+
+| ID | STRIDE | Adv. | Threat | Mitigation |
+| --- | --- | --- | --- | --- |
+| X-S1 | S | G | Guest spoofs another workload's session by forging session id | `AuthenticatedFrame` Ed25519/P-256 verify under per-workload session key (minted at admission, discarded at workload stop); session id rotated per H-L4.3 |
+| X-S2 | S | I | Insider runs a fake `mvm-secrets-dispatcher` binary | Cosign-verify at spawn (H-L3.1); TOCTOU-resistant verify-then-`fexecve` (H-L3.2); subprocess config signed under the same release key (H-L3.6) |
+| X-S3 | S | N | mvmd-agent identity spoofed during initial bootstrap | mvmd public key pinned in `~/.mvm/keys/mvmd-pubkey`; admission refuses without pin (H-L6.4) |
+| X-T1 | T | G | Guest tampers with response bytes before guest userspace consumes them | Out of scope at the broker boundary — guest controls its own userspace |
+| X-T2 | T | I | Insider tampers with the audit chain JSONL on disk | `O_APPEND`-only FD held by `mvm-audit-signer` (H-L5.1); dir-immutable (`chattr +a` / `UF_APPEND`); `chain_head` persisted to a second location and verified by `mvmctl audit verify` (H-L5.2); per-tenant AEAD encryption at rest (H-L5.4) means insider sees only ciphertext |
+| X-T3 | T | I | Insider tampers with the host signer key on disk | On enclave-equipped hosts (H-L2.1) the key never leaves the enclave; on non-enclave hosts (TOFU) the key file is mode 0600 + `chattr +i` once written + monotonic-counter (H-L2.2) detects rollback |
+| X-T4 | T | I | Insider modifies a subprocess binary between cosign-verify and exec | TOCTOU-resistant mmap-then-`fexecve` (H-L3.2) narrows the window to a kernel syscall; subprocess refuses to start if its config signature doesn't verify (H-L3.6) |
+| X-R1 | R | G | Guest denies having made a call later | Every dispatch — allowed or denied — emits a chain-signed audit entry with `(service, verb, outcome, correlation_id)` (Plan 104 §Audit chain); audit chain is JCS-canonical and chain-signed (H-L5.1+H-L5.2) |
+| X-R2 | R | I | Insider operator denies having taken a privileged action | Operator actions (`mvmctl services revoke`, `mvmctl host-key rotate`, `mvmctl up --insecure-host`) emit chain-signed entries via `mvm-audit-signer` (H-L6.1) |
+| X-I1 | I | G | Guest reads bytes from another workload's UDS path | Per-VM UDS paths under `~/.mvm/vms/<vm>/services/` with mode 0600; supervisor-owned (uid 0) — guest in the microVM never has host-side FS access regardless |
+| X-I2 | I | G | Guest infers state from response timing | Rate limit applies to read-only services; `host.secrets.v1` pads to latency floor `BROKER_SECRETS_LATENCY_FLOOR_MS=5` (S26); per-workload total-call/minute budget escalates to `ServiceCallAbuse` audit |
+| X-I3 | I | I | Insider reads audit log contents | Per-tenant ChaCha20-Poly1305 at rest, key derived from TPM/SE-bound master (H-L5.4) |
+| X-I4 | I | I | Insider reads in-memory secrets from a running subprocess | Per-workload cgroup + PID/mount namespace (H-L1.4); `mlock` on secret-bearing pages (H-L3.9); `PR_SET_DUMPABLE=0` / `PT_DENY_ATTACH` + anti-debug startup check (H-L3.9, H-L3.11); seccomp denies `process_vm_readv` (H-L3.3) |
+| X-I5 | I | I | Insider extracts host signer key from process memory | On enclave-equipped hosts: key never in process memory (H-L2.1). On non-enclave hosts: key in `mvm-host-signer` process only (H-L1.1), confined by the cgroup + namespace + seccomp + mlock stack |
+| X-D1 | D | G | Guest floods broker with calls to exhaust CPU/memory | Per-`(workload_id, service_id)` token-bucket; in-flight cap; lifetime quota (S12); per-workload broker-CPU budget (`BROKER_CPU_BUDGET_MS_PER_MIN=50`); memory cap (`BROKER_INFLIGHT_MEM_CAP_BYTES=1048576`); bounded vsock receive queue (`BROKER_QUEUE_DEPTH=16`) (S6, S21) |
+| X-D2 | D | G | Guest forces subprocess restart loop | 3-restart cap per workload lifetime; beyond → audit `<subprocess>.crashed_repeatedly` and workload pause (Plan 82 harness) |
+| X-D3 | D | N | mvmd unavailable blocks cross-tenant cost queries | Circuit breaker per handler (S13); `host.cost.v1::tenant` returns `Err(Unavailable)` rather than stale data (R2 in mvmd Plan 52) |
+| X-D4 | D | G | Guest exploits amplification attack (small request → large response) | Per-handler `response_size_cap()` default 64 KiB; `Err(ResponseTooLarge)` + audited (S11) |
+| X-E1 | E | G | Guest exploits a parser bug in the schema gate to elevate within the subprocess | Frame size cap (64 KiB) enforced before parse; recursion cap 8; 50ms parse timeout; `serde_json` is the fuzzed parser (W6 `fuzz_service_call.rs`); subprocess address space is fully isolated from the supervisor's |
+| X-E2 | E | G | Guest exploits a logic bug in the binding-gate to call an unbound service | Binding-gate refuses; `service_call_denied_when_unbound` regression test in W2 |
+| X-E3 | E | I | Insider replaces a subprocess binary and waits for the next workload | Cosign-verify at spawn (H-L3.1) refuses tampered binary; Sigstore/Rekor transparency log (H-L8.1) exposes any secretly-signed builds |
+| X-E4 | E | G | Guest triggers a use-after-free in the general broker that pivots into the secrets dispatcher | Out of scope of the pivot — the four subprocesses share zero address space (Layer 1). A UAF in `mvm-broker`'s parser cannot reach `mvm-secrets-dispatcher`'s grant table |
+
+## Per-service threat walk
+
+### `host.time.v1` (returns wall + monotonic time)
+
+| ID | STRIDE | Adv. | Threat | Mitigation |
+| --- | --- | --- | --- | --- |
+| TIME-I1 | I | G | Wall clock leaks host's NTP-synced time, useful for cross-workload correlation | Considered low-impact; tenant-private fleets already correlate via mvmd. `host.time.v1` returns canonical UTC. |
+| TIME-T1 | T | I | Insider moves host clock backward, making `mvm-audit-signer` log backdated entries | `audit.clock.jump_detected` audit emitted on negative jump (H-L5.5); audit timestamps anchored to TPM monotonic counter or kernel boottime |
+| TIME-D1 | D | G | Guest spams `time/now` calls to consume broker CPU | Token-bucket per workload (X-D1) |
+
+### `host.cost.v1` (workload + tenant verbs)
+
+| ID | STRIDE | Adv. | Threat | Mitigation |
+| --- | --- | --- | --- | --- |
+| COST-S1 | S | G | Workload spoofs workload-id to read another workload's cost | `correlation_id` is supervisor-assigned (H-L4.6); supervisor passes workload-id from its own state, not from workload-supplied data |
+| COST-S2 | S | N | mvmd response forged by network attacker | mvmd identity pinned (H-L6.4); TLS 1.3 + ChaCha20-Poly1305 + X25519 (H-L4.4); mvmd responses parsed with `deny_unknown_fields`; mvmd-signed catalog response (S23) |
+| COST-I1 | I | G | `tenant` verb leaks cross-tenant data | mvmd-side tenant-scoped-authz (ADR-0008); supervisor refuses mvmd response if tenant_id ≠ workload.tenant_id |
+| COST-I2 | I | G | Cost numeric values quantize-leak workload behavior to a multi-step attacker | Considered low-impact for v1; future plan may quantize values to coarse units |
+| COST-D1 | D | N | mvmd slow → blocks broker thread | Per-handler call timeout (`host.cost.v1::tenant=150ms`); circuit breaker after 5 failures (S13) |
+
+### `host.secrets.v1` (signed-credential issuance per ADR-049)
+
+| ID | STRIDE | Adv. | Threat | Mitigation |
+| --- | --- | --- | --- | --- |
+| SECRET-S1 | S | G | Guest replays a stolen signed credential to a different destination | Credentials destination-bound (ADR-049 §"Substitution flow"); supervisor verifies destination-URL match against `allowed_destinations` with `subtle::ConstantTimeEq` (H-L4.5) |
+| SECRET-S2 | S | G | Guest spoofs a substitution placeholder in an outbound HTTP request to extract a credential it shouldn't have | gvproxy/passt detects `mvm-secret://` token pattern in outbound HTTP bytes and **drops the frame**; emits `secret.substitute.bypass_detected` audit (S25) |
+| SECRET-T1 | T | I | Insider tampers with `~/.mvm/keys/host-signer.ed25519` to mint forged credentials | On enclave-equipped hosts (H-L2.1) the key is in HW; key extraction is impossible. On non-enclave hosts the key file is mode 0600 + `chattr +i` once written; TPM monotonic counter (H-L2.2) detects rollback |
+| SECRET-R1 | R | G | Guest denies having received a particular credential | Every `host.secrets.v1` call emits a chain-signed audit entry with `(service, verb, outcome, correlation_id)` and a `destination_url_hash` (no raw URL or credential bytes) |
+| SECRET-I1 | I | G | Raw secret value leaks across the broker channel | **Architectural impossibility:** `host.secrets.v1` never returns raw secret bytes. Returns only destination-bound, time-bound signed credentials. Tested by `host_secrets_v1_signed_payload_jcs_roundtrip` (W5) |
+| SECRET-I2 | I | I | Insider extracts in-flight grant table from `mvm-secrets-dispatcher` memory | Per-workload cgroup + namespace + seccomp + mlock (X-I4); `Zeroize` on all secret-bearing types; inter-call memory hygiene tested |
+| SECRET-I3 | I | G | Guest uses first-call cold-cache vs subsequent-call warm-cache latency oracle on grant presence | Latency floor `BROKER_SECRETS_LATENCY_FLOOR_MS=5` applied regardless of cache state (S26) |
+| SECRET-I4 | I | G | Composing handler (e.g., `host.config.v1` via `ctx.invoke`) accidentally embeds secret in its own response | `xtask check-handler-composition` lint refuses build on any field assigned from a composed-`host.secrets.v1` result (S24) |
+| SECRET-D1 | D | G | Guest exhausts session-key rotation budget | Per-call ephemeral session key rotates every `BROKER_SESSION_REKEY_CALLS=1000` (H-L4.3); rate limit applies to rotation as to any call |
+| SECRET-E1 | E | I | Insider runs a stub `mvm-secrets-dispatcher` that passes cosign-verify but returns wrong-but-well-formed responses | Subprocess response signing (H-L4.2): every response is signed by the subprocess's per-spawn ephemeral key; supervisor verifies. Stub would need to also forge the response signature — closed by `hostile_subprocess_test_each_kind_rejected` (W6 / H-L9.1) |
+
+### `broker.v1` (introspection: `list_services`)
+
+| ID | STRIDE | Adv. | Threat | Mitigation |
+| --- | --- | --- | --- | --- |
+| BROKER-I1 | I | G | Guest enumerates services to discover unbound services and probe for them | Bindings are workload-supplied at admission; `list_services` returns only the workload's bound set. An unbound service is invisible. |
+| BROKER-D1 | D | G | Guest spams `list_services` for amplification | Response size cap 64 KiB (S11); per-handler call timeout |
+
+## Threats by adversary class — summary
+
+**Hostile guest (G):** Capped by the five-rule capability gating (Plan 104 §"Capability gating") + per-handler `parse_payload` + token-bucket quotas + circuit breaker + latency floor + audit chain. The most credible escape path is a parser bug in `serde_json` exploited via the schema gate; W6 fuzz (`fuzz_service_call.rs`) closes this. A pivot from `mvm-broker` to `mvm-secrets-dispatcher` is architecturally impossible (Layer 1).
+
+**Hostile network peer (N):** Limited to the mvmd path. Mitigated by TLS 1.3 + ChaCha20-Poly1305 + X25519 + mvmd identity pinning + signed catalog responses. The supervisor-to-subprocess UDS paths are not network-reachable.
+
+**Software insider (I):** Newly in scope per ADR-059. The L1+L2+L5 hardening (key isolation + HW enclave + at-rest encryption + cgroup/namespace) means shell access yields neither the host signer key, nor the audit chain-signing key, nor the audit log plaintext, nor in-flight secrets. The remaining insider capability is "modify a subprocess binary on disk and wait for the next spawn," which is defeated by cosign-verify + Sigstore/Rekor transparency.
+
+## Open issues / explicitly accepted residual risk
+
+- **Non-enclave hosts retain TOFU posture for the host signer.** Plan 104 §H-L11.5 and ADR-059 §"Threat model" both acknowledge this. `mvmctl doctor` surfaces it as a downgrade row. Mitigation deferred to W8 hardware-enclave integration; software fallback retained for hosts without TPM/SE.
+- **Single-tenant `mvm-audit-signer` per host.** All workloads on a host share the audit-signer subprocess (per-VM still, but one subprocess per VM). A `mvm-audit-signer` UAF affects all entries for that workload — mitigated by the audit-signer subprocess being minimal-code and security-reviewed.
+- **`mvm-host-signer` is a single point of admission availability.** If down, no plans can be signed and no workloads can admit. Restart-with-backoff is the v1 mitigation; m-of-n quorum deferred. Documented operational behavior.
+- **No alerting in v1 (G10).** Audit logs are forensics. Detection-time discovery of a compromise depends on downstream log-shipping which is out of scope.
+- **No disaster recovery for lost keys (G11).** Lost host signer key = broken workloads with no recovery path. Future plan once W11 FIDO ceremony exists.
+
+## See also
+
+- ADR-059 (decision record) for architecture + claims.
+- Plan 104 (implementation specifics) for build sequence + verification.
+- ADR-002 (microvm security posture) for the broader trust model this narrows.
+- ADR-049 (secret substitution mechanism) for the `host.secrets.v1` design.


### PR DESCRIPTION
## Summary

Folds the locked-in security hardening (Layers 1–11) into Plan 104 and ships ADR-059 + threat model 02 + SECURITY.md alongside.

**Architecture pivot:** the broker is now a **four-subprocess design**, not the two-process design in the original draft:

| Subprocess | UID | Role | Listens on |
| --- | --- | --- | --- |
| `mvm-broker` | 903 | `host.time.v1`, `host.cost.v1`, `broker.v1` | vsock 5300 + per-VM UDS |
| `mvm-secrets-dispatcher` | 902 | `host.secrets.v1` only | vsock 5301 + per-VM UDS |
| `mvm-host-signer` | 904 | Sole holder of the host signer key; signs via UDS RPC | per-VM UDS only |
| `mvm-audit-signer` | 905 | Sole writer to audit chain; sole holder of chain-signing key | per-VM UDS only |

The supervisor becomes a pure launcher + admission controller + IPC router. The host signer key is never loaded into the supervisor's address space; the audit chain-signing key never leaves `mvm-audit-signer`.

**Hardening layers folded in:** see Plan 104 §"Hardening posture (Layers 1–11)" for the full matrix. Highlights:

- **L1** — TCB minimization across four subprocesses + per-workload cgroup + namespace
- **L2** — Hardware-enclave host signer in W8 (Apple SE + Linux TPM 2.0); TPM monotonic counter for rotation rollback resistance
- **L3** — Cosign-verify every binary at spawn; TOCTOU-resistant mmap-then-`fexecve`; explicit seccomp policy (per-arch); macOS sandbox profile; signed subprocess config envelope; static-link + W^X + anti-debug
- **L4** — Algorithm-identifier byte in `AuthenticatedFrame`; per-spawn ephemeral subprocess response keys; per-call ephemeral session-key rotation; TLS-1.3-only + single suite to mvmd; constant-time comparisons via `subtle::ConstantTimeEq`; supervisor-assigned correlation IDs
- **L5** — `O_APPEND`-only audit FD + dir-immutable; anti-rollback chain-head persistence; WORM backing; per-tenant AEAD encryption at rest with TPM/SE-derived key; time-source integrity; admission blocks until all four subprocesses healthy
- **L6** — Operator-action audit entries; audit-log rotation continuity invariant; tenant-level secret quotas; mvmd identity pinning; composition width cap; audit fsync-failure → workload pause
- **L7** — KSM + THP off; doctor refuses admission on weak hosts; subprocess slow-start detection; CPU pinning
- **L8** — Sigstore/Rekor transparency log per release; in-toto attestations; hermetic network-isolated build
- **L9** — Hostile-subprocess test per kind; `cargo-mutants` mutation testing; UDS-proxy fuzz; side-channel timing audit (dudect/CTGrind); CODEOWNERS + multi-reviewer requirement
- **L10** — Threat model doc; CVE response runbook; PII invariant documented
- **L11** — Round-4 gaps (G1–G12) folded in or explicitly declined: subprocess config signing (G1), `fido_touch_required()` stub on `mvmctl up --prod` with full impl in W11 (G2), admission blocks until audit-signer healthy (G3), supervisor-assigned correlation IDs (G4), TOFU honesty for non-enclave hosts (G5), snapshot-restore re-handshake (G6), cryptographic-crate pinning (G7), deployment-mode threat differentiation (G8), vsock CVE surface enumeration (G9). G10 (alerting), G11 (DR / key escrow), G12 (restart accumulation) explicitly named as non-goals.

**Build sequence** is now W1–W11 (was W1–W7):
- W8 = hardware-enclave host signer
- W9 = supply chain + release hardening
- W10 = documentation + threat model
- W11 = operator FIDO ceremony (stub in W1, full impl may slip to Sprint 58)

**Threat model expansion:** ADR-002's "malicious host" out-of-scope clause is **narrowed**. Physical attacks remain out of scope. Software insider attacks (shell access to the host by an unauthorized operator) are newly in scope thanks to L1+L2+L5 hardening: shell access no longer yields the host signer key (L1.1+L2.1), the audit signing key (L1.2), the audit log plaintext (L5.4), or in-flight secrets in process memory (L1.4+L3.9+L3.11).

**Two new security claims proposed** in ADR-059 (numbers assigned at write-time against ADR-002's live list; Sprint 56 holds claim 10):
1. Every host-side service is bound to a signed `ExecutionPlan.services` entry, enforced before dispatch, audited via the chain.
2. No raw secret value crosses the broker channel; `host.secrets.v1` returns destination-bound, time-bound signed credentials only.

**Realistic v1 timeline:** 3–4 sprints (originally drafted as 1). Most W8 cost is in keying ceremonies and macOS SE specifics; if W8 slips, v1 can ship with the software-fallback host signer + a loud `mvmctl doctor` downgrade warning, with W8 as a Sprint-58 follow-on.

**Cross-repo dependency:** mvmd Plan 52 + ADR-0023 land in a separate `tinylabscom/mvmd` PR (drafts inline in Plan 104 §"mvmd-side extension"). Numbers reshuffled from 51/0022 → 52/0023 because the mvmd network-policy-enforcement initiative claimed 51/0022 mid-iteration.

## Files changed

```
 SECURITY.md                                    | 111 +++
 specs/SPRINT.md                                |  47 +-
 specs/adrs/059-host-services-broker.md         | 188 ++++
 specs/plans/104-host-services-broker.md        | 827 +++++++++++++++++++-
 specs/threat-models/02-host-services-broker.md | 129 +++
 5 files changed, 1206 insertions(+), 96 deletions(-)
```

## Test plan

Docs-only PR. Verification:

- [x] `just lint` green locally (fmt-check + clippy --workspace --all-targets -- -D warnings)
- [x] All five files render in GitHub markdown preview
- [x] Cross-references between Plan 104 / ADR-059 / threat-model 02 / SECURITY.md resolve correctly
- [ ] Reviewer signs off on the four-subprocess architecture pivot vs the original two-process design
- [ ] Reviewer confirms claim numbering will land against ADR-002's live list at merge time (Sprint 56's claim 10 is preserved; this PR proposes the next two)
- [ ] mvmd companion PR (Plan 52 + ADR-0023) opens before W4b implementation begins

## Notes for reviewer

- The original W1 scope was already the largest wave (~50% bigger than a "normal" wave per Plan 104 T4 note). The hardening fold-in roughly triples it (now four subprocesses, not one). Plan 104 §R10 explicitly suggests splitting W1 into W1a + W1b if a single PR becomes unreviewable.
- The plan-22 modification (`specs/plans/22-agent-sandbox-patterns.md` — scrubbed external-crate names) is parked at `stash@{0}` in this worktree, intended as a separate micro-PR.
- The `fido_touch_required()` v1 stub on `mvmctl up --prod` only emits an audit warning; full enforcement lands in W11. Operators relying on "shell-access ≠ admission rights" need W11 to ship before that property holds.

🤖 Generated with [Claude Code](https://claude.com/claude-code)