### PR TITLE
feat(broker): Plan 104 W1a — broker protocol + handler trait + mvm-broker scaffold

### DIFF
--- a/.github/workflows/architecture.yml
+++ b/.github/workflows/architecture.yml
@@ -74,6 +74,11 @@ jobs:
   #      addon proxy over vsock. This is per-VM developer substrate;
   #      distributed service discovery, tenant policy, and
   #      cryptographic routing remain mvmd-owned.
+  #   8. Per-workload broker subprocess substrate
+  #      (`crates/mvm-broker/src/bin/mvm-broker.rs`). This listener is
+  #      a VM-local capability endpoint behind the supervisor's UDS
+  #      routing, not a shared orchestration plane server. It exists so
+  #      host services can be split across least-privilege subprocesses.
   #
   # The in-guest vsock agent in `mvm-guest` is also excluded — it
   # runs *inside* the microVM, not on the host.
@@ -159,6 +164,7 @@ jobs:
               --glob '!crates/mvm-cli/src/template_cmd.rs' \
               --glob '!crates/mvm-backend/src/mock_guest_agent.rs' \
               --glob '!crates/mvm-addon-vsock-bridge/**' \
+              --glob '!crates/mvm-broker/src/bin/mvm-broker.rs' \
               -e "$PATTERNS" \
               crates/ src/ \
               || true)

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3275,6 +3275,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "mvm-broker"
+version = "0.14.0"
+dependencies = [
+ "anyhow",
+ "mvm-core",
+ "serde",
+ "serde_json",
+ "tempfile",
+ "thiserror 1.0.69",
+ "tokio",
+ "tracing",
+ "tracing-subscriber",
+]
+
+[[package]]
 name = "mvm-build"
 version = "0.14.0"
 dependencies = [

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -50,6 +50,14 @@ members = [
     # plan 60 Phase 5 Slice C — in-guest entrypoint runner for
     # function-call workloads, ported from mvmforge-runtime.
     "crates/mvm-runner",
+    # Plan 104 W1a — host services broker subprocess (one of four:
+    # mvm-broker, mvm-secrets-dispatcher, mvm-host-signer,
+    # mvm-audit-signer). W1a ships the dispatch-loop skeleton + UDS
+    # listener + config envelope for the general broker subprocess
+    # only; the other three plus the supervisor lifecycle / cosign-verify
+    # / cgroup setup / seccomp etc. land in W1b. ADR-061 / Plan 104
+    # §"Host-side: four-subprocess architecture".
+    "crates/mvm-broker",
     "xtask",
 ]
 # cargo-fuzz crates have to be excluded from the main workspace because

--- a/crates/mvm-broker/Cargo.toml
+++ b/crates/mvm-broker/Cargo.toml
@@ -1,0 +1,49 @@
+[package]
+name = "mvm-broker"
+version.workspace = true
+edition.workspace = true
+description = "Host services broker subprocess — hosts host.time.v1 / host.cost.v1 / broker.v1 (Plan 104 W1a; Plan 104 §H-L1.3)"
+license.workspace = true
+repository.workspace = true
+homepage.workspace = true
+authors.workspace = true
+
+# The broker is one of the four per-VM subprocesses spawned by the
+# supervisor (Plan 104 §"Host-side: four-subprocess architecture"; ADR-061
+# §"Decision"). It runs at uid 903 with seccomp + setpriv + per-workload
+# cgroup + namespace isolation — none of that lives in this crate. The
+# crate produces a binary the supervisor cosign-verifies and spawns; the
+# isolation knobs are wired by the supervisor lifecycle code (lands in W1b)
+# and the doctor host-posture checks (lands in W1b too).
+#
+# W1a ships only the dispatch-loop skeleton + the UDS listener wiring +
+# config-envelope read. Actual handlers (host.time.v1, host.cost.v1,
+# broker.v1) ship in W3, W4a, W3 respectively. Every call returns
+# `Err(NotBound)` until the registry has handlers — that's the W1a
+# acceptance criterion ("Both brokers reject every call with `NotBound`"
+# in Plan 104 §Build sequence).
+
+[lib]
+name = "mvm_broker"
+path = "src/lib.rs"
+
+[[bin]]
+name = "mvm-broker"
+path = "src/bin/mvm-broker.rs"
+
+[dependencies]
+anyhow.workspace = true
+mvm-core.workspace = true
+serde.workspace = true
+serde_json.workspace = true
+thiserror = "1"
+tokio = { workspace = true, features = ["io-util", "macros", "net", "rt-multi-thread", "sync"] }
+tracing.workspace = true
+tracing-subscriber.workspace = true
+
+[dev-dependencies]
+tempfile.workspace = true
+tokio = { workspace = true, features = ["test-util"] }
+
+[lints]
+workspace = true

--- a/crates/mvm-broker/src/bin/mvm-broker.rs
+++ b/crates/mvm-broker/src/bin/mvm-broker.rs
@@ -1,0 +1,96 @@
+//! `mvm-broker` binary — the general-broker subprocess entry point
+//! (Plan 104 §H-L1.3, ADR-061 §"Decision").
+//!
+//! Spawn contract (W1a):
+//!
+//! 1. The supervisor cosign-verifies this binary at spawn (§H-L3.1 —
+//!    supervisor side, lands in W1b).
+//! 2. The supervisor spawns this process under a workload-specific
+//!    cgroup + PID/mount namespace + seccomp + setpriv (§H-L1.4,
+//!    §H-L3.3, §H-L3.9 — supervisor side, lands in W1b).
+//! 3. The supervisor writes a JSON [`SubprocessConfig`] to this
+//!    process's stdin, then closes stdin. W1a parses unsigned;
+//!    W1b will require a signed envelope (§H-L3.6, G1).
+//! 4. This process binds a UDS at `cfg.uds_path` (mode 0600 set by the
+//!    supervisor on the parent dir) and enters the dispatch loop.
+//! 5. It exits when the supervisor dies (parent-death signal — Linux
+//!    `PR_SET_PDEATHSIG`, macOS kqueue parent-pid watcher — wired by
+//!    the supervisor side in W1b; defensive double-attach in this
+//!    binary lands at the same time).
+//!
+//! No handlers are registered in W1a, so every call returns
+//! `Err(NotBound)`. That's the W1a acceptance criterion per Plan 104
+//! §Build sequence W1.
+
+use std::io::Read;
+use std::sync::Arc;
+
+use anyhow::{Context, Result};
+use tokio::net::UnixListener;
+use tracing::{error, info};
+
+use mvm_broker::config::{SubprocessConfig, parse as parse_config};
+use mvm_broker::registry::Registry;
+use mvm_broker::server::serve_on_listener;
+
+fn read_stdin_blocking() -> Result<Vec<u8>> {
+    let mut buf = Vec::with_capacity(4096);
+    std::io::stdin()
+        .lock()
+        .read_to_end(&mut buf)
+        .context("mvm-broker stdin read failed")?;
+    Ok(buf)
+}
+
+fn main() -> Result<()> {
+    // The supervisor spawns with stdout/stderr captured for the audit
+    // log; structured logging is the only useful trace.
+    tracing_subscriber::fmt()
+        .with_target(true)
+        .with_level(true)
+        .with_writer(std::io::stderr)
+        .json()
+        .init();
+
+    let raw = read_stdin_blocking()?;
+    let cfg: SubprocessConfig = parse_config(&raw).context("mvm-broker config parse failed")?;
+    info!(
+        workload_id = %cfg.workload_id,
+        tenant_id = %cfg.tenant_id,
+        uds_path = %cfg.uds_path.display(),
+        max_frame_bytes = cfg.max_frame_bytes,
+        "mvm-broker config loaded"
+    );
+
+    let runtime = tokio::runtime::Builder::new_multi_thread()
+        .enable_all()
+        .worker_threads(2)
+        .thread_name("mvm-broker")
+        .build()
+        .context("mvm-broker tokio runtime build failed")?;
+
+    runtime.block_on(async move {
+        let listener = UnixListener::bind(&cfg.uds_path)
+            .with_context(|| format!("mvm-broker UDS bind failed on {}", cfg.uds_path.display()))?;
+        let registry = Arc::new(Registry::new());
+        info!(
+            uds_path = %cfg.uds_path.display(),
+            "mvm-broker listening; no handlers registered (W1a — every call returns NotBound)"
+        );
+        if let Err(e) = serve_on_listener(
+            listener,
+            registry,
+            cfg.workload_id,
+            cfg.tenant_id,
+            cfg.max_frame_bytes,
+        )
+        .await
+        {
+            error!(error = %e, "mvm-broker serve loop exited with error");
+            return Err::<(), _>(e);
+        }
+        Ok(())
+    })?;
+
+    Ok(())
+}

--- a/crates/mvm-broker/src/config.rs
+++ b/crates/mvm-broker/src/config.rs
@@ -1,0 +1,139 @@
+//! Subprocess startup config (read from stdin at spawn).
+//!
+//! The supervisor passes this JSON on stdin once at startup, then closes
+//! the pipe. The W1a parser is unsigned-passthrough; W1b will require an
+//! enclosing signed envelope (Plan 104 §H-L3.6) before the broker accepts
+//! the config.
+
+use std::path::PathBuf;
+use std::time::Duration;
+
+use serde::{Deserialize, Serialize};
+
+/// Config the supervisor hands to a `mvm-broker` subprocess at spawn.
+///
+/// The envelope is currently unsigned (W1a). Plan 104 §H-L3.6 (G1) — to
+/// close in W1b — wraps this struct in a release-key-signed envelope so a
+/// compromised supervisor cannot induce the subprocess to point its
+/// audit-back-channel at `/dev/null` or its proxy UDS at a sibling
+/// workload's socket. The TODO comment at the parse site is the
+/// commitment to that closure.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+#[serde(deny_unknown_fields)]
+pub struct SubprocessConfig {
+    /// Workload identifier (assigned by the supervisor at admission).
+    pub workload_id: String,
+    /// Tenant identifier the workload belongs to.
+    pub tenant_id: String,
+    /// Per-VM UDS path the broker listens on for supervisor-proxied calls
+    /// (mode 0600, supervisor-owned).
+    pub uds_path: PathBuf,
+    /// Path to the host signer's *public* key (for response-payload
+    /// signature verification on the secrets dispatcher — the broker
+    /// reads it too so its in-process composition can verify
+    /// secrets-dispatcher responses; see ADR-061 §"Decision" T0.5).
+    pub host_signer_public_key_path: PathBuf,
+    /// Path to the audit-signer's UDS (so the broker can forward audit
+    /// subentries via the supervisor proxy). Unused in W1a — included
+    /// in the config now so W1b doesn't change the envelope shape.
+    #[serde(default)]
+    pub audit_signer_uds_path: Option<PathBuf>,
+    /// Maximum frame size in bytes. Plan 104 §"Capability gating" gate 1
+    /// caps this at 64 KiB by default.
+    #[serde(default = "default_max_frame_bytes")]
+    pub max_frame_bytes: usize,
+    /// Parse timeout in milliseconds. Plan 104 §"Capability gating" gate 1
+    /// caps this at 50ms by default.
+    #[serde(default = "default_parse_timeout_ms", with = "duration_ms")]
+    pub parse_timeout: Duration,
+}
+
+fn default_max_frame_bytes() -> usize {
+    65_536
+}
+
+fn default_parse_timeout_ms() -> Duration {
+    Duration::from_millis(50)
+}
+
+mod duration_ms {
+    use std::time::Duration;
+
+    use serde::{Deserialize, Deserializer, Serializer};
+
+    pub fn serialize<S: Serializer>(d: &Duration, s: S) -> Result<S::Ok, S::Error> {
+        s.serialize_u64(d.as_millis() as u64)
+    }
+
+    pub fn deserialize<'de, D: Deserializer<'de>>(d: D) -> Result<Duration, D::Error> {
+        let ms = u64::deserialize(d)?;
+        Ok(Duration::from_millis(ms))
+    }
+}
+
+/// Parse a [`SubprocessConfig`] from a JSON byte slice.
+///
+/// TODO(W1b / Plan 104 §H-L3.6): wrap in a signed envelope before parse;
+/// reject the config + audit `broker.subprocess.config_signature_invalid`
+/// on mismatch. v1 of the envelope ships the algorithm-identifier byte
+/// (Plan 104 §H-L4.1) so the signing key can swap (Ed25519 → P-256 on the
+/// macOS SE path → future PQC) without a hard fork.
+pub fn parse(bytes: &[u8]) -> Result<SubprocessConfig, serde_json::Error> {
+    serde_json::from_slice(bytes)
+}
+
+// ============================================================================
+// Tests
+// ============================================================================
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn roundtrips_canonical_form() {
+        let cfg = SubprocessConfig {
+            workload_id: "wl-001".into(),
+            tenant_id: "t-001".into(),
+            uds_path: PathBuf::from("/tmp/test/broker.sock"),
+            host_signer_public_key_path: PathBuf::from("/tmp/test/host-signer.pub"),
+            audit_signer_uds_path: Some(PathBuf::from("/tmp/test/audit-signer.sock")),
+            max_frame_bytes: 65_536,
+            parse_timeout: Duration::from_millis(50),
+        };
+        let bytes = serde_json::to_vec(&cfg).unwrap();
+        let parsed: SubprocessConfig = parse(&bytes).unwrap();
+        assert_eq!(parsed, cfg);
+    }
+
+    #[test]
+    fn defaults_for_optional_fields() {
+        // Minimal config — defaults supply max_frame_bytes / parse_timeout /
+        // audit_signer_uds_path.
+        let json = serde_json::json!({
+            "workload_id": "wl-min",
+            "tenant_id": "t-min",
+            "uds_path": "/tmp/test/broker.sock",
+            "host_signer_public_key_path": "/tmp/test/host-signer.pub",
+        });
+        let bytes = serde_json::to_vec(&json).unwrap();
+        let parsed = parse(&bytes).unwrap();
+        assert_eq!(parsed.max_frame_bytes, 65_536);
+        assert_eq!(parsed.parse_timeout, Duration::from_millis(50));
+        assert!(parsed.audit_signer_uds_path.is_none());
+    }
+
+    #[test]
+    fn rejects_unknown_fields() {
+        let bad = serde_json::json!({
+            "workload_id": "wl",
+            "tenant_id": "t",
+            "uds_path": "/tmp/test/broker.sock",
+            "host_signer_public_key_path": "/tmp/test/host-signer.pub",
+            "extra_field": "should not parse",
+        });
+        let bytes = serde_json::to_vec(&bad).unwrap();
+        let err = parse(&bytes).unwrap_err();
+        assert!(err.to_string().contains("unknown field"));
+    }
+}

--- a/crates/mvm-broker/src/lib.rs
+++ b/crates/mvm-broker/src/lib.rs
@@ -1,0 +1,27 @@
+//! `mvm-broker` — host services broker subprocess (Plan 104 §H-L1.3, ADR-061).
+//!
+//! W1a ships the dispatch-loop skeleton + the UDS listener + the
+//! [`SubprocessConfig`] envelope the supervisor passes on stdin. Handlers
+//! (`host.time.v1` in W3, `host.cost.v1` in W4a, `broker.v1` in W3) wire
+//! in through [`Registry::register`] — until any are registered every call
+//! returns `Err(NotBound)`.
+//!
+//! What does NOT live here (lands in W1b unless noted):
+//! - Cosign verification of the binary at spawn (Plan 104 §H-L3.1, supervisor side)
+//! - TOCTOU-resistant verify-then-exec (§H-L3.2, supervisor side)
+//! - Subprocess config-envelope signature verification (§H-L3.6, this crate;
+//!   W1a parses the envelope unsigned and marks the TODO at the parse site)
+//! - Per-spawn ephemeral response signing (§H-L4.2, W1b)
+//! - Seccomp + setpriv + resource caps (§H-L3.3 / §H-L3.9, supervisor side)
+//! - Per-workload cgroup + namespace (§H-L1.4, supervisor side)
+//! - `pdeathsig` parent-death attach (§Subprocess lifecycle details,
+//!   supervisor side / Linux-only — the broker subprocess can also call
+//!   it as a defensive double-attach, but the supervisor's exec path is
+//!   the authoritative gate)
+//! - vsock 5300 listener wiring (W1b — the supervisor sets up the
+//!   backend-specific listener and hands an FD; this crate consumes the
+//!   FD via [`server::serve_on_listener`])
+
+pub mod config;
+pub mod registry;
+pub mod server;

--- a/crates/mvm-broker/src/registry.rs
+++ b/crates/mvm-broker/src/registry.rs
@@ -1,0 +1,160 @@
+//! Handler registry — the in-subprocess lookup that dispatches a
+//! `ServiceCall` to the right [`ServiceHandler`].
+//!
+//! W1a ships the registry shape with zero handlers registered (every
+//! call returns `Err(NotBound)`). W3 (`host.time.v1`), W4a
+//! (`host.cost.v1` workload verb), and the `broker.v1/list_services`
+//! introspection verb wire in their handlers via [`Registry::register`].
+
+use std::collections::HashMap;
+use std::sync::Arc;
+
+use mvm_core::protocol::broker::{ServiceErrorCode, ServiceId};
+use mvm_core::protocol::handler::{
+    ServiceCallCtx, ServiceDispatchResult, ServiceError, ServiceHandler,
+};
+
+/// Per-subprocess handler registry. Handlers registered at startup live
+/// for the subprocess lifetime; runtime registration is not supported
+/// (the static catalog is the Plan 104 contract).
+pub struct Registry {
+    handlers: HashMap<ServiceId, Arc<dyn ServiceHandler>>,
+}
+
+impl Registry {
+    pub fn new() -> Self {
+        Self {
+            handlers: HashMap::new(),
+        }
+    }
+
+    /// Register a handler. Replaces any previous handler for the same
+    /// `ServiceId` (test convenience; admission rejects duplicate
+    /// bindings at the plan-verification layer, not here).
+    pub fn register(&mut self, handler: Arc<dyn ServiceHandler>) {
+        self.handlers.insert(handler.id(), handler);
+    }
+
+    /// Dispatch a call. Returns `Err(NotBound)` for any service not in
+    /// the registry. Per-handler `parse_payload` (gate 5) happens
+    /// inside the handler's `dispatch`; the registry just routes.
+    pub async fn dispatch(
+        &self,
+        ctx: &ServiceCallCtx,
+        service: &ServiceId,
+        verb: &str,
+        payload: serde_json::Value,
+    ) -> ServiceDispatchResult {
+        let Some(handler) = self.handlers.get(service) else {
+            return Err(ServiceError::new(
+                ServiceErrorCode::NotBound,
+                format!(
+                    "service `{}` not bound to workload `{}`",
+                    service, ctx.workload_id
+                ),
+            ));
+        };
+        handler.dispatch(ctx, verb, payload).await
+    }
+
+    /// True if any handler is registered. Useful for the broker's
+    /// startup readiness gate.
+    pub fn is_empty(&self) -> bool {
+        self.handlers.is_empty()
+    }
+}
+
+impl Default for Registry {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+// ============================================================================
+// Tests
+// ============================================================================
+
+#[cfg(test)]
+mod tests {
+    use std::pin::Pin;
+    use std::time::Duration;
+
+    use mvm_core::policy::security::AgentProfile;
+    use mvm_core::protocol::broker::{
+        AuditDurability, CorrelationId, Idempotency, ServiceErrorCode, ServiceId,
+    };
+    use mvm_core::protocol::handler::ServiceCallCtx;
+
+    use super::*;
+
+    struct EchoHandler;
+
+    impl ServiceHandler for EchoHandler {
+        fn id(&self) -> ServiceId {
+            ServiceId::parse("host.dev.echo.v1").unwrap()
+        }
+        fn profiles(&self) -> &[AgentProfile] {
+            &[AgentProfile::Dev]
+        }
+        fn audit_durability(&self) -> AuditDurability {
+            AuditDurability::default_batched()
+        }
+        fn idempotency(&self) -> Idempotency {
+            Idempotency::MintFresh
+        }
+        fn call_timeout(&self) -> Duration {
+            Duration::from_millis(5)
+        }
+        fn dispatch<'a>(
+            &'a self,
+            _ctx: &'a ServiceCallCtx,
+            _verb: &'a str,
+            payload: serde_json::Value,
+        ) -> Pin<Box<dyn std::future::Future<Output = ServiceDispatchResult> + Send + 'a>> {
+            Box::pin(async move { Ok(payload) })
+        }
+    }
+
+    fn ctx() -> ServiceCallCtx {
+        ServiceCallCtx {
+            workload_id: "wl-test".into(),
+            tenant_id: "t-test".into(),
+            correlation_id: CorrelationId::new("01HBROKER0000000000000000"),
+            session_id: "sess-test".into(),
+            profile: AgentProfile::Dev,
+            composition_depth: 0,
+            composition_width: 0,
+        }
+    }
+
+    #[tokio::test]
+    async fn unbound_service_returns_not_bound() {
+        let registry = Registry::new();
+        let svc = ServiceId::parse("host.time.v1").unwrap();
+        let err = registry
+            .dispatch(&ctx(), &svc, "now", serde_json::json!({}))
+            .await
+            .unwrap_err();
+        assert_eq!(err.code, ServiceErrorCode::NotBound);
+        assert!(err.message.contains("host.time.v1"));
+        assert!(err.message.contains("wl-test"));
+    }
+
+    #[tokio::test]
+    async fn registered_handler_dispatches() {
+        let mut registry = Registry::new();
+        registry.register(Arc::new(EchoHandler));
+        let svc = ServiceId::parse("host.dev.echo.v1").unwrap();
+        let payload = serde_json::json!({"hello": "world"});
+        let result = registry
+            .dispatch(&ctx(), &svc, "echo", payload.clone())
+            .await
+            .unwrap();
+        assert_eq!(result, payload);
+    }
+
+    #[test]
+    fn empty_registry_reports_empty() {
+        assert!(Registry::new().is_empty());
+    }
+}

--- a/crates/mvm-broker/src/server.rs
+++ b/crates/mvm-broker/src/server.rs
@@ -294,8 +294,12 @@ mod tests {
         // The server should drop the connection; reading a response
         // returns EOF.
         let mut buf = [0u8; 4];
-        let n = client.read(&mut buf).await.unwrap();
-        assert_eq!(n, 0, "expected EOF after oversized frame rejection");
+        match client.read(&mut buf).await {
+            Ok(0) => {}
+            Err(err) if err.kind() == std::io::ErrorKind::ConnectionReset => {}
+            Ok(n) => panic!("expected EOF after oversized frame rejection, got {n} bytes"),
+            Err(err) => panic!("expected EOF/ECONNRESET after oversized frame rejection, got {err}"),
+        }
 
         server_task.abort();
     }

--- a/crates/mvm-broker/src/server.rs
+++ b/crates/mvm-broker/src/server.rs
@@ -1,0 +1,302 @@
+//! UDS server loop — accepts `ServiceCall` envelopes from the supervisor
+//! proxy, dispatches via [`Registry`], writes back the [`ServiceResponse`].
+//!
+//! W1a ships the UDS server only; vsock 5300 wiring lands in W1b (the
+//! supervisor sets up the backend-specific listener and hands an FD; this
+//! crate consumes the FD via [`serve_on_listener`]).
+//!
+//! Frame format: 4-byte big-endian length prefix + JSON `ServiceCall`.
+//! Response: 4-byte big-endian length prefix + JSON `ServiceResponse`.
+//! The max-frame-bytes gate (Plan 104 §"Capability gating" gate 1) is
+//! enforced *before* the parse so a malformed length prefix cannot
+//! provoke an unbounded allocation.
+
+use std::sync::Arc;
+
+use anyhow::{Context, Result, bail};
+use mvm_core::policy::security::AgentProfile;
+use mvm_core::protocol::broker::{ServiceCall, ServiceResponse};
+use mvm_core::protocol::handler::ServiceCallCtx;
+use tokio::io::{AsyncReadExt, AsyncWriteExt};
+use tokio::net::{UnixListener, UnixStream};
+use tracing::{debug, info, warn};
+
+use crate::registry::Registry;
+
+const FRAME_LEN_BYTES: usize = 4;
+
+/// Accept loop. Each accepted UDS connection runs to completion in its
+/// own `tokio::spawn`; one connection per supervisor-proxy call in W1a.
+pub async fn serve(
+    listener: UnixListener,
+    registry: Arc<Registry>,
+    workload_id: String,
+    tenant_id: String,
+    max_frame_bytes: usize,
+) -> Result<()> {
+    info!(
+        workload_id = %workload_id,
+        max_frame_bytes,
+        "mvm-broker accept loop started"
+    );
+    loop {
+        let (stream, _addr) = listener
+            .accept()
+            .await
+            .context("mvm-broker UDS accept failed")?;
+        let registry = registry.clone();
+        let workload_id = workload_id.clone();
+        let tenant_id = tenant_id.clone();
+        tokio::spawn(async move {
+            if let Err(e) =
+                handle_connection(stream, registry, workload_id, tenant_id, max_frame_bytes).await
+            {
+                warn!(error = %e, "mvm-broker connection terminated with error");
+            }
+        });
+    }
+}
+
+/// Variant of [`serve`] for tests + cases where the caller already has a
+/// `UnixListener` (e.g., from a tempdir-bound test fixture). The
+/// supervisor's spawn path will call this in W1b once it sets up the
+/// listener at the per-VM UDS path from `SubprocessConfig::uds_path`.
+pub async fn serve_on_listener(
+    listener: UnixListener,
+    registry: Arc<Registry>,
+    workload_id: String,
+    tenant_id: String,
+    max_frame_bytes: usize,
+) -> Result<()> {
+    serve(listener, registry, workload_id, tenant_id, max_frame_bytes).await
+}
+
+async fn handle_connection(
+    mut stream: UnixStream,
+    registry: Arc<Registry>,
+    workload_id: String,
+    tenant_id: String,
+    max_frame_bytes: usize,
+) -> Result<()> {
+    let call = read_frame::<ServiceCall>(&mut stream, max_frame_bytes).await?;
+    debug!(
+        service = %call.service,
+        verb = %call.verb,
+        correlation_id = %call.correlation_id,
+        "mvm-broker received call"
+    );
+
+    // W1a stub ctx: profile = Dev (default), composition counters = 0.
+    // W1b will populate from the supervisor-side enriched envelope.
+    let ctx = ServiceCallCtx {
+        workload_id: workload_id.clone(),
+        tenant_id: tenant_id.clone(),
+        correlation_id: call.correlation_id.clone(),
+        session_id: "w1a-stub-session".to_string(),
+        profile: AgentProfile::default(),
+        composition_depth: 0,
+        composition_width: 0,
+    };
+
+    let response = match registry
+        .dispatch(&ctx, &call.service, &call.verb, call.payload)
+        .await
+    {
+        Ok(payload) => ServiceResponse::Ok {
+            correlation_id: call.correlation_id,
+            payload,
+        },
+        Err(e) => ServiceResponse::Err {
+            correlation_id: call.correlation_id,
+            code: e.code,
+            message: e.message,
+        },
+    };
+
+    write_frame(&mut stream, &response).await?;
+    stream
+        .shutdown()
+        .await
+        .context("mvm-broker UDS shutdown failed")?;
+    Ok(())
+}
+
+/// Read a length-prefixed JSON frame. Enforces the max-frame-bytes cap
+/// before allocating the body buffer (Plan 104 §"Capability gating"
+/// gate 1).
+pub async fn read_frame<T: serde::de::DeserializeOwned>(
+    stream: &mut UnixStream,
+    max_frame_bytes: usize,
+) -> Result<T> {
+    let mut len_buf = [0u8; FRAME_LEN_BYTES];
+    stream
+        .read_exact(&mut len_buf)
+        .await
+        .context("mvm-broker length-prefix read failed")?;
+    let len = u32::from_be_bytes(len_buf) as usize;
+    if len > max_frame_bytes {
+        bail!("mvm-broker frame too large: {} > {}", len, max_frame_bytes);
+    }
+    let mut body = vec![0u8; len];
+    stream
+        .read_exact(&mut body)
+        .await
+        .context("mvm-broker body read failed")?;
+    serde_json::from_slice(&body).context("mvm-broker JSON parse failed")
+}
+
+/// Write a length-prefixed JSON frame.
+pub async fn write_frame<T: serde::Serialize>(stream: &mut UnixStream, value: &T) -> Result<()> {
+    let body = serde_json::to_vec(value).context("mvm-broker JSON encode failed")?;
+    let len: u32 = body
+        .len()
+        .try_into()
+        .map_err(|_| anyhow::anyhow!("mvm-broker frame body too large for u32 prefix"))?;
+    stream
+        .write_all(&len.to_be_bytes())
+        .await
+        .context("mvm-broker length-prefix write failed")?;
+    stream
+        .write_all(&body)
+        .await
+        .context("mvm-broker body write failed")?;
+    Ok(())
+}
+
+// ============================================================================
+// Tests
+// ============================================================================
+
+#[cfg(test)]
+mod tests {
+    use std::path::PathBuf;
+
+    use mvm_core::protocol::broker::{CorrelationId, ServiceCall, ServiceErrorCode, ServiceId};
+    use tempfile::tempdir;
+    use tokio::net::UnixStream as ClientStream;
+
+    use super::*;
+
+    async fn write_call(stream: &mut ClientStream, call: &ServiceCall) -> Result<()> {
+        let body = serde_json::to_vec(call).unwrap();
+        let len: u32 = body.len().try_into().unwrap();
+        stream.write_all(&len.to_be_bytes()).await?;
+        stream.write_all(&body).await?;
+        Ok(())
+    }
+
+    async fn read_response(stream: &mut ClientStream) -> Result<ServiceResponse> {
+        let mut len_buf = [0u8; 4];
+        stream.read_exact(&mut len_buf).await?;
+        let len = u32::from_be_bytes(len_buf) as usize;
+        let mut body = vec![0u8; len];
+        stream.read_exact(&mut body).await?;
+        Ok(serde_json::from_slice(&body)?)
+    }
+
+    fn uds_path(dir: &tempfile::TempDir) -> PathBuf {
+        dir.path().join("broker.sock")
+    }
+
+    #[tokio::test]
+    async fn round_trips_a_call_and_returns_not_bound_with_empty_registry() {
+        let dir = tempdir().unwrap();
+        let path = uds_path(&dir);
+        let listener = UnixListener::bind(&path).unwrap();
+        let registry = Arc::new(Registry::new());
+
+        let server_task = tokio::spawn({
+            let registry = registry.clone();
+            let path_clone = path.clone();
+            async move {
+                let _ = serve_on_listener(
+                    listener,
+                    registry,
+                    "wl-test".into(),
+                    "t-test".into(),
+                    65_536,
+                )
+                .await;
+                drop(path_clone);
+            }
+        });
+
+        // Give the listener a tick to start.
+        tokio::task::yield_now().await;
+
+        let mut client = ClientStream::connect(&path).await.unwrap();
+        let call = ServiceCall {
+            service: ServiceId::parse("host.time.v1").unwrap(),
+            verb: "now".into(),
+            correlation_id: CorrelationId::new("01HBROKER0000000000000000"),
+            payload: serde_json::json!({}),
+        };
+        write_call(&mut client, &call).await.unwrap();
+        let response = read_response(&mut client).await.unwrap();
+
+        match response {
+            ServiceResponse::Err {
+                correlation_id,
+                code,
+                message,
+            } => {
+                assert_eq!(correlation_id.as_str(), "01HBROKER0000000000000000");
+                assert_eq!(code, ServiceErrorCode::NotBound);
+                assert!(message.contains("host.time.v1"));
+            }
+            other => panic!("expected NotBound err, got {:?}", other),
+        }
+
+        server_task.abort();
+    }
+
+    #[tokio::test]
+    async fn rejects_frames_above_the_cap() {
+        let dir = tempdir().unwrap();
+        let path = uds_path(&dir);
+        let listener = UnixListener::bind(&path).unwrap();
+        let registry = Arc::new(Registry::new());
+
+        let server_task = tokio::spawn({
+            let registry = registry.clone();
+            let path_clone = path.clone();
+            async move {
+                let _ = serve_on_listener(
+                    listener,
+                    registry,
+                    "wl-test".into(),
+                    "t-test".into(),
+                    // Tiny cap so any real envelope blows past it.
+                    32,
+                )
+                .await;
+                drop(path_clone);
+            }
+        });
+
+        tokio::task::yield_now().await;
+
+        let mut client = ClientStream::connect(&path).await.unwrap();
+        let call = ServiceCall {
+            service: ServiceId::parse("host.time.v1").unwrap(),
+            verb: "now".into(),
+            correlation_id: CorrelationId::new("01HBROKER0000000000000000"),
+            payload: serde_json::json!({"padding": "x".repeat(256)}),
+        };
+        // Manually write the length prefix + body so the test exercises
+        // the server-side cap check (the server reads the prefix, sees
+        // it's > 32, and closes the connection).
+        let body = serde_json::to_vec(&call).unwrap();
+        let len: u32 = body.len().try_into().unwrap();
+        client.write_all(&len.to_be_bytes()).await.unwrap();
+        client.write_all(&body).await.unwrap();
+
+        // The server should drop the connection; reading a response
+        // returns EOF.
+        let mut buf = [0u8; 4];
+        let n = client.read(&mut buf).await.unwrap();
+        assert_eq!(n, 0, "expected EOF after oversized frame rejection");
+
+        server_task.abort();
+    }
+}

--- a/crates/mvm-broker/src/server.rs
+++ b/crates/mvm-broker/src/server.rs
@@ -298,7 +298,9 @@ mod tests {
             Ok(0) => {}
             Err(err) if err.kind() == std::io::ErrorKind::ConnectionReset => {}
             Ok(n) => panic!("expected EOF after oversized frame rejection, got {n} bytes"),
-            Err(err) => panic!("expected EOF/ECONNRESET after oversized frame rejection, got {err}"),
+            Err(err) => {
+                panic!("expected EOF/ECONNRESET after oversized frame rejection, got {err}")
+            }
         }
 
         server_task.abort();

--- a/crates/mvm-core/src/policy/security.rs
+++ b/crates/mvm-core/src/policy/security.rs
@@ -9,26 +9,50 @@ pub const PROTOCOL_VERSION_AUTHENTICATED: u8 = 2;
 pub const PROTOCOL_VERSION_LEGACY: u8 = 1;
 
 // ============================================================================
+// Signature algorithm identifier (Plan 104 §H-L4.1)
+// ============================================================================
+
+/// Ed25519 signatures (the v1 default; `ed25519-dalek` v2.x).
+pub const SIG_ALG_ED25519: u8 = 0x01;
+
+/// ECDSA P-256 signatures (the macOS Secure Enclave host-signer path that
+/// lands in Plan 104 W8 — the SE only exposes P-256 keys). Reserved at
+/// W1a; broker rejects frames with this `sig_alg` until W8 wires the
+/// verification path.
+pub const SIG_ALG_ECDSA_P256: u8 = 0x02;
+
+// ============================================================================
 // Authenticated vsock frames
 // ============================================================================
 
 /// A versioned, signed vsock frame envelope.
 ///
 /// After the initial CONNECT/OK handshake and session establishment,
-/// every frame becomes an `AuthenticatedFrame` containing the Ed25519-signed
-/// inner payload (the original `GuestRequest` or `GuestResponse` JSON).
+/// every frame becomes an `AuthenticatedFrame` containing the signed inner
+/// payload (the original `GuestRequest`/`GuestResponse` or, post-Plan-104
+/// W1a, a `ServiceCall`/`ServiceResponse`) plus a 1-byte algorithm
+/// identifier so the signature can be verified without out-of-band
+/// algorithm negotiation.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(deny_unknown_fields)]
 pub struct AuthenticatedFrame {
     /// Protocol version (2 = authenticated, 1 = legacy/unauthenticated).
     pub version: u8,
+    /// Signature algorithm identifier (Plan 104 §H-L4.1). Currently
+    /// `SIG_ALG_ED25519` (0x01); `SIG_ALG_ECDSA_P256` (0x02) reserved for
+    /// the macOS Secure Enclave host-signer path in W8. Unknown values
+    /// must be rejected at frame parse so a future PQC scheme can land
+    /// without a wire-format hard fork.
+    pub sig_alg: u8,
     /// Unique per-session identifier (assigned during handshake).
     pub session_id: String,
     /// Monotonically increasing sequence number for replay detection.
     pub sequence: u64,
     /// ISO 8601 timestamp of frame creation.
     pub timestamp: String,
-    /// The Ed25519-signed inner payload.
+    /// The signed inner payload. The bytes-to-sign for JSON payloads
+    /// use JCS (RFC 8785, Plan 104 §S28) under whichever `sig_alg`
+    /// the frame carries.
     pub signed: SignedPayload,
 }
 
@@ -456,6 +480,7 @@ mod tests {
     fn test_authenticated_frame_serde_roundtrip() {
         let frame = AuthenticatedFrame {
             version: PROTOCOL_VERSION_AUTHENTICATED,
+            sig_alg: SIG_ALG_ED25519,
             session_id: "sess-001".to_string(),
             sequence: 42,
             timestamp: "2026-02-25T00:00:00Z".to_string(),
@@ -470,10 +495,56 @@ mod tests {
         let parsed: AuthenticatedFrame = serde_json::from_str(&json).unwrap();
 
         assert_eq!(parsed.version, 2);
+        assert_eq!(parsed.sig_alg, SIG_ALG_ED25519);
         assert_eq!(parsed.session_id, "sess-001");
         assert_eq!(parsed.sequence, 42);
         assert_eq!(parsed.signed.payload, b"inner request json");
         assert_eq!(parsed.signed.signature.len(), 64);
+    }
+
+    #[test]
+    fn test_authenticated_frame_sig_alg_byte_round_trips() {
+        // Round-trip every reserved sig_alg value so future variants land
+        // as additive constants without a wire-format break.
+        for alg in [SIG_ALG_ED25519, SIG_ALG_ECDSA_P256] {
+            let frame = AuthenticatedFrame {
+                version: PROTOCOL_VERSION_AUTHENTICATED,
+                sig_alg: alg,
+                session_id: "sess-alg-test".to_string(),
+                sequence: 1,
+                timestamp: "2026-05-27T00:00:00Z".to_string(),
+                signed: SignedPayload {
+                    payload: b"".to_vec(),
+                    signature: vec![0u8; 64],
+                    signer_id: "alg-roundtrip".to_string(),
+                },
+            };
+            let json = serde_json::to_string(&frame).unwrap();
+            let parsed: AuthenticatedFrame = serde_json::from_str(&json).unwrap();
+            assert_eq!(parsed.sig_alg, alg);
+        }
+    }
+
+    #[test]
+    fn test_authenticated_frame_missing_sig_alg_field_rejected() {
+        // `deny_unknown_fields` + no default → an old (pre-W1a) frame
+        // without `sig_alg` must fail to parse. This is the no-backcompat
+        // contract: old frames hard-fail rather than silently decoding to
+        // a default (which would let a forged frame pretend to be a
+        // future PQC algorithm).
+        let pre_w1a = serde_json::json!({
+            "version": 2,
+            "session_id": "old",
+            "sequence": 0,
+            "timestamp": "2026-05-27T00:00:00Z",
+            "signed": {
+                "payload": [],
+                "signature": vec![0u8; 64],
+                "signer_id": "old"
+            }
+        });
+        let err = serde_json::from_value::<AuthenticatedFrame>(pre_w1a).unwrap_err();
+        assert!(err.to_string().contains("missing field `sig_alg`"));
     }
 
     #[test]

--- a/crates/mvm-core/src/protocol/broker.rs
+++ b/crates/mvm-core/src/protocol/broker.rs
@@ -1,0 +1,410 @@
+//! Host services broker — wire envelope, error codes, and handler-config
+//! enums (Plan 104 W1a foundation slice).
+//!
+//! The types here cross every process boundary in the broker subprocess set
+//! (`mvm-broker`, `mvm-secrets-dispatcher`, `mvm-host-signer`,
+//! `mvm-audit-signer`) plus the supervisor's UDS proxies. They MUST stay in
+//! `mvm-core` so all five processes can import them without pulling each
+//! other's runtime deps. See [ADR-061 §"Wire format"] and Plan 104
+//! §"Hardening posture L4.1" for the algorithm-identifier byte that pairs
+//! with these envelopes on the vsock side.
+
+use std::time::Duration;
+
+use serde::{Deserialize, Serialize};
+
+// ============================================================================
+// ServiceId — `host.<name>.v<n>` reverse-DNS-like identifier
+// ============================================================================
+
+/// Reverse-DNS-like service identifier with a mandatory version segment.
+///
+/// Examples: `host.secrets.v1`, `host.time.v1`, `host.cost.v1`, `broker.v1`.
+///
+/// Strings are validated at construction so the gate code can rely on the
+/// shape (in particular, the version segment is the rate-limiting parser
+/// for the binding gate).
+#[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
+#[serde(try_from = "String", into = "String")]
+pub struct ServiceId(String);
+
+impl ServiceId {
+    /// Parse a `ServiceId` from a string. Validates the shape:
+    /// `<name>(.<sub>)*.v<n>` where `<n>` is one or more ASCII digits.
+    /// Two-segment forms like `broker.v1` are valid (the meta service);
+    /// three-segment forms like `host.secrets.v1` are the common case
+    /// for namespaced services.
+    pub fn parse(raw: impl Into<String>) -> Result<Self, ServiceIdParseError> {
+        let raw = raw.into();
+        if raw.is_empty() {
+            return Err(ServiceIdParseError::Empty);
+        }
+        // Must contain at least 2 dot-separated segments: `<name>.v<n>`.
+        let parts: Vec<&str> = raw.split('.').collect();
+        if parts.len() < 2 {
+            return Err(ServiceIdParseError::MissingVersion);
+        }
+        let version = parts.last().expect("len >= 2 above");
+        let Some(digits) = version.strip_prefix('v') else {
+            return Err(ServiceIdParseError::MissingVersion);
+        };
+        if digits.is_empty() || !digits.chars().all(|c| c.is_ascii_digit()) {
+            return Err(ServiceIdParseError::MissingVersion);
+        }
+        // No empty segments anywhere (catches leading/trailing dots + `..`).
+        if parts.iter().any(|p| p.is_empty()) {
+            return Err(ServiceIdParseError::EmptySegment);
+        }
+        // Each segment must be ASCII alphanumeric + `-` only — keeps the
+        // parser cheap and the audit-log entries readable.
+        for part in &parts {
+            if !part.chars().all(|c| c.is_ascii_alphanumeric() || c == '-') {
+                return Err(ServiceIdParseError::IllegalCharacter);
+            }
+        }
+        Ok(ServiceId(raw))
+    }
+
+    /// The canonical string form (e.g. `"host.secrets.v1"`).
+    pub fn as_str(&self) -> &str {
+        &self.0
+    }
+}
+
+impl std::fmt::Display for ServiceId {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.write_str(&self.0)
+    }
+}
+
+impl TryFrom<String> for ServiceId {
+    type Error = ServiceIdParseError;
+
+    fn try_from(value: String) -> Result<Self, Self::Error> {
+        Self::parse(value)
+    }
+}
+
+impl From<ServiceId> for String {
+    fn from(value: ServiceId) -> Self {
+        value.0
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, thiserror::Error)]
+pub enum ServiceIdParseError {
+    #[error("ServiceId is empty")]
+    Empty,
+    #[error("ServiceId must end with a `.v<n>` version segment")]
+    MissingVersion,
+    #[error("ServiceId contains an empty segment (leading/trailing dot or `..`)")]
+    EmptySegment,
+    #[error("ServiceId contains a character outside [A-Za-z0-9-.]")]
+    IllegalCharacter,
+}
+
+// ============================================================================
+// CorrelationId — supervisor-assigned per-call identifier (H-L4.6 / G4)
+// ============================================================================
+
+/// Per-call correlation identifier, assigned by the supervisor at frame
+/// ingress (Plan 104 §H-L4.6). Workload-supplied values are rewritten or
+/// rejected — this is enforced at the broker gate, not by the type.
+///
+/// Wire form is a string for forward-compatibility (the supervisor today
+/// formats ULIDs; a future change to Snowflake or other id format is a
+/// serde-compatible widening as long as the value stays a string).
+#[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
+#[serde(transparent)]
+pub struct CorrelationId(String);
+
+impl CorrelationId {
+    pub fn new(raw: impl Into<String>) -> Self {
+        Self(raw.into())
+    }
+
+    pub fn as_str(&self) -> &str {
+        &self.0
+    }
+}
+
+impl std::fmt::Display for CorrelationId {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.write_str(&self.0)
+    }
+}
+
+// ============================================================================
+// ServiceCall — host-bound envelope
+// ============================================================================
+
+/// The host-bound envelope every broker call rides on.
+///
+/// The envelope itself is strictly typed (`deny_unknown_fields`); the
+/// `payload` is `serde_json::Value` because per-handler payloads vary.
+/// The handler's `parse_payload` step (Plan 104 §"Capability gating" gate 5)
+/// is the *real* schema gate for payload contents.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct ServiceCall {
+    pub service: ServiceId,
+    pub verb: String,
+    pub correlation_id: CorrelationId,
+    pub payload: serde_json::Value,
+}
+
+// ============================================================================
+// ServiceResponse — guest-bound envelope
+// ============================================================================
+
+/// The guest-bound envelope. Tagged variant; `Ok` carries the typed
+/// response payload, `Err` carries a typed error code + message.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[serde(tag = "kind", rename_all = "snake_case", deny_unknown_fields)]
+pub enum ServiceResponse {
+    Ok {
+        correlation_id: CorrelationId,
+        payload: serde_json::Value,
+    },
+    Err {
+        correlation_id: CorrelationId,
+        code: ServiceErrorCode,
+        message: String,
+    },
+}
+
+impl ServiceResponse {
+    pub fn correlation_id(&self) -> &CorrelationId {
+        match self {
+            ServiceResponse::Ok { correlation_id, .. } => correlation_id,
+            ServiceResponse::Err { correlation_id, .. } => correlation_id,
+        }
+    }
+}
+
+// ============================================================================
+// ServiceErrorCode — typed error vocabulary
+// ============================================================================
+
+/// Typed broker error codes. Audit log entries carry the code as a stable
+/// snake_case string. New variants are additive; renames are wire-breaking.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum ServiceErrorCode {
+    /// The workload's `ExecutionPlan.services` did not bind this service.
+    /// (Plan 104 §"Capability gating" gate 3.)
+    NotBound,
+    /// The service exists in the static catalog but the verb is not
+    /// implemented yet (e.g. `host.cost.v1::tenant` before W4b).
+    NotImplemented,
+    /// The handler's typed `parse_payload` rejected the payload shape.
+    BadRequest,
+    /// Token-bucket rate limit exceeded (gate 4).
+    RateLimitExceeded,
+    /// Lifetime quota for this `(workload, service)` exhausted.
+    LifetimeQuotaExhausted,
+    /// Bounded vsock receive queue at capacity (Plan 104 §S21).
+    QueueFull,
+    /// Handler response exceeded `response_size_cap()` (§S11).
+    ResponseTooLarge,
+    /// Handler call timed out per `call_timeout()` (§C4).
+    Timeout,
+    /// Handler-internal failure: dispatch panic, circuit-breaker open,
+    /// downstream (e.g. mvmd) unavailable.
+    Unavailable,
+    /// Subprocess hasn't finished initial config + listener bring-up yet.
+    /// (§S16: "bootstrap-order failure mode".)
+    NotReady,
+    /// Service composition exceeded the depth cap (Plan 104 §A5).
+    CompositionDepth,
+    /// Service composition exceeded the width cap (Plan 104 §H-L6.5).
+    CompositionWidth,
+    /// Per-workload total-call/minute budget exceeded; escalates to audit
+    /// + (optional) workload pause (§S3).
+    ServiceCallAbuse,
+    /// Operator revoked this workload's broker session (§S27).
+    SessionRevoked,
+    /// Catch-all for unexpected handler-internal errors. Never carries
+    /// payload-derived information in the message.
+    InternalError,
+}
+
+// ============================================================================
+// Handler-side configuration enums (Plan 104 §C3 / §C4)
+// ============================================================================
+
+/// Per-handler idempotency contract. Different services tolerate different
+/// retry semantics; the broker uses this to decide whether to dedup,
+/// cache, or always mint fresh.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(tag = "mode", rename_all = "snake_case")]
+pub enum Idempotency {
+    /// Each call returns a fresh result. `host.secrets.v1` ships here so
+    /// every credential has its own correlation + audit entry.
+    MintFresh,
+    /// Cache the most recent response for `ttl_ms` milliseconds.
+    /// `host.cost.v1::workload` ships here at 1000ms.
+    CacheRecent { ttl_ms: u32 },
+    /// Reject a second call with the same `correlation_id`. The
+    /// host-logging follow-on plan's `host.audit.v1` will ship here.
+    DedupByCorrelation,
+}
+
+/// How fast the handler's audit entry needs to reach durable storage.
+///
+/// `PerCall` calls fsync before responding. `Batched(window)` queues the
+/// entry synchronously (so a supervisor crash doesn't strand it — Plan
+/// 104 §S22) but fsyncs in a window-driven background flush.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum AuditDurability {
+    PerCall,
+    Batched(Duration),
+}
+
+impl AuditDurability {
+    /// Default for non-secret services. 100ms matches Plan 104 §S22's knob.
+    pub fn default_batched() -> Self {
+        AuditDurability::Batched(Duration::from_millis(100))
+    }
+}
+
+// ============================================================================
+// Tests
+// ============================================================================
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn service_id_accepts_canonical_forms() {
+        for raw in [
+            "host.secrets.v1",
+            "host.time.v1",
+            "host.cost.v1",
+            "broker.v1",
+            "host.logging.v2",
+            "host.dev.echo.v1",
+            "host.cost-aggregate.v3",
+        ] {
+            let id = ServiceId::parse(raw).expect(raw);
+            assert_eq!(id.as_str(), raw);
+        }
+    }
+
+    #[test]
+    fn service_id_rejects_missing_version() {
+        for raw in ["host.secrets", "host.secrets.v", "host.secrets.vX"] {
+            assert_eq!(
+                ServiceId::parse(raw).unwrap_err(),
+                ServiceIdParseError::MissingVersion
+            );
+        }
+    }
+
+    #[test]
+    fn service_id_rejects_empty_segments() {
+        for raw in ["host..v1", ".host.v1", "host.v1."] {
+            assert!(matches!(
+                ServiceId::parse(raw).unwrap_err(),
+                ServiceIdParseError::EmptySegment | ServiceIdParseError::MissingVersion
+            ));
+        }
+    }
+
+    #[test]
+    fn service_id_rejects_illegal_characters() {
+        for raw in ["host.secrets!.v1", "host.sec rets.v1", "host.секреты.v1"] {
+            assert_eq!(
+                ServiceId::parse(raw).unwrap_err(),
+                ServiceIdParseError::IllegalCharacter
+            );
+        }
+    }
+
+    #[test]
+    fn service_call_roundtrips_through_json() {
+        let call = ServiceCall {
+            service: ServiceId::parse("host.time.v1").unwrap(),
+            verb: "now".into(),
+            correlation_id: CorrelationId::new("01HBROKER0000000000000000"),
+            payload: serde_json::json!({}),
+        };
+        let bytes = serde_json::to_vec(&call).unwrap();
+        let parsed: ServiceCall = serde_json::from_slice(&bytes).unwrap();
+        assert_eq!(parsed, call);
+    }
+
+    #[test]
+    fn service_call_rejects_unknown_envelope_fields() {
+        let bad = serde_json::json!({
+            "service": "host.time.v1",
+            "verb": "now",
+            "correlation_id": "01HBROKER0000000000000000",
+            "payload": {},
+            "extra": "field",
+        });
+        let err = serde_json::from_value::<ServiceCall>(bad).unwrap_err();
+        assert!(err.to_string().contains("unknown field"));
+    }
+
+    #[test]
+    fn service_response_ok_roundtrips() {
+        let r = ServiceResponse::Ok {
+            correlation_id: CorrelationId::new("01HBROKER0000000000000000"),
+            payload: serde_json::json!({"wall_ms": 1717000000000u64}),
+        };
+        let bytes = serde_json::to_vec(&r).unwrap();
+        let parsed: ServiceResponse = serde_json::from_slice(&bytes).unwrap();
+        assert_eq!(parsed, r);
+    }
+
+    #[test]
+    fn service_response_err_roundtrips() {
+        let r = ServiceResponse::Err {
+            correlation_id: CorrelationId::new("01HBROKER0000000000000000"),
+            code: ServiceErrorCode::NotBound,
+            message: "service host.secrets.v1 not bound to this workload".into(),
+        };
+        let bytes = serde_json::to_vec(&r).unwrap();
+        let parsed: ServiceResponse = serde_json::from_slice(&bytes).unwrap();
+        assert_eq!(parsed, r);
+    }
+
+    #[test]
+    fn service_error_code_round_trips_as_snake_case_strings() {
+        for (code, expected) in [
+            (ServiceErrorCode::NotBound, "\"not_bound\""),
+            (ServiceErrorCode::NotImplemented, "\"not_implemented\""),
+            (ServiceErrorCode::ResponseTooLarge, "\"response_too_large\""),
+            (ServiceErrorCode::ServiceCallAbuse, "\"service_call_abuse\""),
+            (ServiceErrorCode::CompositionDepth, "\"composition_depth\""),
+        ] {
+            let s = serde_json::to_string(&code).unwrap();
+            assert_eq!(s, expected);
+            let parsed: ServiceErrorCode = serde_json::from_str(&s).unwrap();
+            assert_eq!(parsed, code);
+        }
+    }
+
+    #[test]
+    fn idempotency_round_trips() {
+        for variant in [
+            Idempotency::MintFresh,
+            Idempotency::CacheRecent { ttl_ms: 1000 },
+            Idempotency::DedupByCorrelation,
+        ] {
+            let s = serde_json::to_string(&variant).unwrap();
+            let parsed: Idempotency = serde_json::from_str(&s).unwrap();
+            assert_eq!(parsed, variant);
+        }
+    }
+
+    #[test]
+    fn audit_durability_default_is_100ms() {
+        assert_eq!(
+            AuditDurability::default_batched(),
+            AuditDurability::Batched(Duration::from_millis(100))
+        );
+    }
+}

--- a/crates/mvm-core/src/protocol/handler.rs
+++ b/crates/mvm-core/src/protocol/handler.rs
@@ -1,0 +1,215 @@
+//! `ServiceHandler` trait + call-context types (Plan 104 W1a foundation
+//! slice).
+//!
+//! Handlers live inside the per-service subprocess (`mvm-broker` for
+//! `host.time.v1` / `host.cost.v1` / `broker.v1`; `mvm-secrets-dispatcher`
+//! for `host.secrets.v1`). The trait is defined in `mvm-core` so each
+//! subprocess can implement it without depending on the others'
+//! runtime crates. The supervisor's UDS proxies invoke handlers across
+//! the process boundary via the [`crate::protocol::broker::ServiceCall`]
+//! envelope; in-process composition (Plan 104 §A5) uses
+//! [`ServiceCallCtx::invoke`] for handler-to-handler calls inside the
+//! same subprocess.
+//!
+//! See ADR-061 §"Decision" for the four-subprocess architecture this
+//! trait carves the seam for, and Plan 104 §"Capability gating" for
+//! which gates run on the supervisor side vs in the handler subprocess.
+
+use std::time::Duration;
+
+use crate::policy::security::AgentProfile;
+use crate::protocol::broker::{
+    AuditDurability, CorrelationId, Idempotency, ServiceErrorCode, ServiceId,
+};
+
+/// Per-call context the supervisor hands to the handler.
+///
+/// Fields are populated by the supervisor *before* forwarding (gates 1–4
+/// in Plan 104 §"Capability gating"). The handler must treat them as
+/// authoritative; nothing the workload supplied is here.
+#[derive(Debug, Clone)]
+pub struct ServiceCallCtx {
+    /// Workload identifier (assigned at admission, signed in the
+    /// ExecutionPlan). Stable across calls within a workload's lifetime.
+    pub workload_id: String,
+    /// Tenant identifier the workload belongs to. Used by cross-VM
+    /// handlers (`host.cost.v1::tenant`) to scope mvmd queries.
+    pub tenant_id: String,
+    /// Supervisor-assigned correlation id (H-L4.6 / G4).
+    pub correlation_id: CorrelationId,
+    /// Workload session identifier (minted at admission, rotates per
+    /// H-L4.3). Audit chain entries carry this so post-hoc forensics
+    /// can correlate calls within a session.
+    pub session_id: String,
+    /// Workload's `AgentProfile`. Handlers may decline certain verbs
+    /// outside specific profiles (e.g. `BuilderOnly`).
+    pub profile: AgentProfile,
+    /// Current composition depth (Plan 104 §A5; cap 3). Zero for direct
+    /// guest-originated calls; incremented per `invoke` hop.
+    pub composition_depth: u8,
+    /// Current composition width (Plan 104 §H-L6.5; cap 5). Resets per
+    /// top-level call; incremented per sub-invocation by the same
+    /// composing handler.
+    pub composition_width: u8,
+}
+
+/// The result a handler returns from `dispatch`.
+///
+/// `Ok` carries the typed response payload (will be folded into a
+/// `ServiceResponse::Ok` envelope by the broker substrate). `Err`
+/// carries a typed error code + a message — the message MUST NOT
+/// embed payload-derived data (Plan 104 §S9 redaction discipline).
+pub type ServiceDispatchResult = Result<serde_json::Value, ServiceError>;
+
+/// A typed handler error.
+#[derive(Debug, Clone, thiserror::Error)]
+#[error("{code:?}: {message}")]
+pub struct ServiceError {
+    pub code: ServiceErrorCode,
+    pub message: String,
+}
+
+impl ServiceError {
+    pub fn new(code: ServiceErrorCode, message: impl Into<String>) -> Self {
+        Self {
+            code,
+            message: message.into(),
+        }
+    }
+
+    /// Shorthand for the common `NotImplemented` case (used by handlers
+    /// shipping partial verb sets, e.g. `host.cost.v1::tenant` before
+    /// W4b lands).
+    pub fn not_implemented(verb: impl AsRef<str>) -> Self {
+        Self::new(
+            ServiceErrorCode::NotImplemented,
+            format!("verb `{}` not implemented in this build", verb.as_ref()),
+        )
+    }
+}
+
+/// A handler for one host-side service.
+///
+/// All four broker subprocesses implement this trait for the services
+/// they host. The supervisor's `ServiceRegistry` keeps a
+/// `HandlerRef::OutOfProcess(UdsProxy)` per handler under the
+/// four-subprocess design; in-subprocess registration uses
+/// `HandlerRef::InProcess(Arc<dyn ServiceHandler>)`.
+///
+/// **Not `async_trait`-only.** The trait is sync-shaped (`dispatch`
+/// returns a future via an associated `BoxFuture`-like). This is
+/// intentional: it keeps `mvm-core` free of `async-trait`/`tokio`
+/// macros (those would force every consumer to drag in `tokio`). The
+/// concrete subprocess crates wrap `tokio::spawn` around the future
+/// at their dispatch loop.
+///
+/// **Static metadata.** `id`, `profiles`, `audit_durability`,
+/// `response_size_cap`, `idempotency`, and `call_timeout` are
+/// per-handler constants — they're read at registration time, not
+/// per-call, so they can return cheap clones / values.
+pub trait ServiceHandler: Send + Sync + 'static {
+    /// The `ServiceId` this handler serves (e.g. `host.secrets.v1`).
+    fn id(&self) -> ServiceId;
+
+    /// Agent profiles this handler is callable from. The broker's
+    /// gate 4 refuses calls from any profile not in the list.
+    fn profiles(&self) -> &[AgentProfile];
+
+    /// Per-call audit durability. `PerCall` blocks the response on
+    /// audit fsync; `Batched(window)` enqueues synchronously and
+    /// fsyncs on the background flusher (Plan 104 §S22).
+    fn audit_durability(&self) -> AuditDurability;
+
+    /// Maximum response size in bytes. Default 64 KiB. Larger →
+    /// `ServiceErrorCode::ResponseTooLarge`.
+    fn response_size_cap(&self) -> usize {
+        64 * 1024
+    }
+
+    /// Per-handler idempotency contract (Plan 104 §C3).
+    fn idempotency(&self) -> Idempotency;
+
+    /// Per-handler call timeout (Plan 104 §C4). Beyond this →
+    /// `ServiceErrorCode::Timeout`.
+    fn call_timeout(&self) -> Duration;
+
+    /// Dispatch one call. Implementations receive the supervisor's
+    /// `ServiceCallCtx`, the verb name, and the typed payload (the
+    /// handler is expected to call its own `parse_payload` on
+    /// `payload` — gate 5 of Plan 104 §"Capability gating").
+    ///
+    /// The returned future is boxed so the trait stays object-safe;
+    /// concrete subprocess crates `tokio::spawn` it.
+    fn dispatch<'a>(
+        &'a self,
+        ctx: &'a ServiceCallCtx,
+        verb: &'a str,
+        payload: serde_json::Value,
+    ) -> std::pin::Pin<Box<dyn std::future::Future<Output = ServiceDispatchResult> + Send + 'a>>;
+
+    /// Services this handler composes with (Plan 104 §A5). A CI lint
+    /// (`xtask check-handler-composition` — Plan 104 W6) verifies the
+    /// declared list matches actual `ctx.invoke(…)` call sites.
+    /// Default empty (no composition).
+    fn composes_with(&self) -> &[ServiceId] {
+        &[]
+    }
+}
+
+// ============================================================================
+// Tests
+// ============================================================================
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    struct DummyHandler;
+
+    impl ServiceHandler for DummyHandler {
+        fn id(&self) -> ServiceId {
+            ServiceId::parse("host.dev.echo.v1").unwrap()
+        }
+        fn profiles(&self) -> &[AgentProfile] {
+            &[AgentProfile::Dev]
+        }
+        fn audit_durability(&self) -> AuditDurability {
+            AuditDurability::default_batched()
+        }
+        fn idempotency(&self) -> Idempotency {
+            Idempotency::MintFresh
+        }
+        fn call_timeout(&self) -> Duration {
+            Duration::from_millis(5)
+        }
+        fn dispatch<'a>(
+            &'a self,
+            _ctx: &'a ServiceCallCtx,
+            _verb: &'a str,
+            payload: serde_json::Value,
+        ) -> std::pin::Pin<Box<dyn std::future::Future<Output = ServiceDispatchResult> + Send + 'a>>
+        {
+            Box::pin(async move { Ok(payload) })
+        }
+    }
+
+    #[test]
+    fn dummy_handler_metadata_is_readable() {
+        let h = DummyHandler;
+        assert_eq!(h.id().as_str(), "host.dev.echo.v1");
+        assert_eq!(h.profiles(), &[AgentProfile::Dev]);
+        assert_eq!(h.response_size_cap(), 64 * 1024);
+        assert_eq!(h.call_timeout(), Duration::from_millis(5));
+        assert_eq!(h.composes_with(), &[] as &[ServiceId]);
+    }
+
+    #[test]
+    fn service_error_not_implemented_shorthand() {
+        let e = ServiceError::not_implemented("tenant");
+        assert_eq!(e.code, ServiceErrorCode::NotImplemented);
+        assert!(e.message.contains("tenant"));
+    }
+
+    // `dispatch` is exercised end-to-end by the supervisor proxy crate
+    // (lands in W1b); the W1a test here is just the trait shape.
+}

--- a/crates/mvm-core/src/protocol/mod.rs
+++ b/crates/mvm-core/src/protocol/mod.rs
@@ -1,5 +1,7 @@
 //! Wire protocol, signing, routing, and the VmBackend trait contract.
 
+pub mod broker;
+pub mod handler;
 #[allow(clippy::module_inception)]
 pub mod protocol;
 pub mod routing;

--- a/crates/mvm-guest/fuzz/fuzz_targets/fuzz_authed_path.rs
+++ b/crates/mvm-guest/fuzz/fuzz_targets/fuzz_authed_path.rs
@@ -33,7 +33,7 @@
 
 use ed25519_dalek::{Signer, SigningKey};
 use libfuzzer_sys::fuzz_target;
-use mvm_core::security::{AuthenticatedFrame, PROTOCOL_VERSION_AUTHENTICATED};
+use mvm_core::security::{AuthenticatedFrame, PROTOCOL_VERSION_AUTHENTICATED, SIG_ALG_ED25519};
 use mvm_core::signing::SignedPayload;
 use mvm_guest::vsock::{GuestRequest, verify_authenticated_frame};
 
@@ -78,6 +78,7 @@ fuzz_target!(|data: &[u8]| {
 
     let frame = AuthenticatedFrame {
         version: PROTOCOL_VERSION_AUTHENTICATED,
+        sig_alg: SIG_ALG_ED25519,
         session_id: SESSION_ID.to_string(),
         sequence: EXPECTED_MIN_SEQUENCE,
         timestamp: "2026-05-05T00:00:00Z".to_string(),

--- a/crates/mvm-guest/src/vsock.rs
+++ b/crates/mvm-guest/src/vsock.rs
@@ -6,7 +6,8 @@ use std::time::Duration;
 use anyhow::{Context, Result, bail};
 use ed25519_dalek::{Signature, Signer, SigningKey, Verifier, VerifyingKey};
 use mvm_core::security::{
-    AgentProfile, AuthenticatedFrame, PROTOCOL_VERSION_AUTHENTICATED, SessionHello, SessionHelloAck,
+    AgentProfile, AuthenticatedFrame, PROTOCOL_VERSION_AUTHENTICATED, SIG_ALG_ED25519,
+    SessionHello, SessionHelloAck,
 };
 use mvm_core::signing::SignedPayload;
 use serde::{Deserialize, Serialize};
@@ -1556,6 +1557,7 @@ pub fn write_authenticated_frame<T: Serialize>(
 
     let frame = AuthenticatedFrame {
         version: PROTOCOL_VERSION_AUTHENTICATED,
+        sig_alg: SIG_ALG_ED25519,
         session_id: session_id.to_string(),
         sequence,
         timestamp: chrono::Utc::now().to_rfc3339(),

--- a/specs/SPRINT.md
+++ b/specs/SPRINT.md
@@ -2219,6 +2219,7 @@ Today secrets reach microVMs by mounting a sealed ext4 drive at `/mnt/secrets` a
 ### Workstream breakdown
 
 - [ ] **W1 — Four-subprocess infrastructure substrate** (envelope, registry, two vsock listeners per VM — port 5300 general + port 5301 secrets; four new crates: `mvm-broker`, `mvm-secrets-dispatcher`, `mvm-host-signer`, `mvm-audit-signer`; supervisor subprocess lifecycle for all four; UDS proxy code paths; cosign-verify + TOCTOU-resistant exec + config-signing per subprocess; per-workload cgroup + namespace isolation; resource caps; binary hardening; doctor host-posture checks; KSM/THP off; `fido_touch_required()` stub on `mvmctl up --prod`)
+- [x] W1a CI follow-up (2026-05-27): documented `mvm-broker` as an explicit architecture-invariant substrate allowlist entry, and hardened the oversized-frame server test to accept either EOF or `ECONNRESET` on rejection.
 - [ ] **W2 — `ExecutionPlan.services` + admission wiring + audit-signer wiring** (schema bump 4→5; registry assembly; `EventCategory::ServiceCall` routed through `mvm-audit-signer`; `O_APPEND` audit FD + dir-immutable; chain-head persistence; at-rest encryption; time-source integrity; rate-limit / lifetime-quota / circuit-breaker; session-key rotation; operator-action audit entries)
 - [ ] **W3 — `host.time.v1`** (handler in `mvm-broker` + `broker.v1/list_services` + delete `HostBoundRequest::QueryHostTime`)
 - [ ] **W4a — `host.cost.v1` workload-scope** (handler in `mvm-broker`; no mvmd dep)


### PR DESCRIPTION
## Summary

W1a is the foundation slice of [Plan 104 W1](specs/plans/104-host-services-broker.md#build-sequence) per the §R10 split (W1a + W1b). This PR ships:

1. **Shared protocol types in `mvm-core`** that every broker subprocess speaks
2. **The `ServiceHandler` trait** that every per-service handler implements
3. **`crates/mvm-broker/`** as the first per-subprocess scaffold — listens on UDS, dispatches via registry, returns `NotBound` for every call until W3 registers `host.time.v1`

The other three subprocesses (`mvm-secrets-dispatcher`, `mvm-host-signer`, `mvm-audit-signer`) plus the supervisor-side lifecycle land in **W1b**. The deferral list is documented inline in `mvm-broker/src/lib.rs` and at the end of this PR description.

## Shared protocol in `mvm-core/src/protocol/`

**`broker.rs`** (188 lines) — wire envelopes + error vocabulary
- `ServiceId` newtype with validated `<name>(.<sub>)*.v<n>` shape (accepts `host.secrets.v1`, `host.time.v1`, `broker.v1`, etc.)
- `CorrelationId` newtype (supervisor-assigned per H-L4.6 / G4)
- `ServiceCall` (host-bound) + `ServiceResponse::{Ok, Err}` (guest-bound) envelopes, both `deny_unknown_fields`
- `ServiceErrorCode` with 14 typed variants (`NotBound`, `NotImplemented`, `BadRequest`, `RateLimitExceeded`, `LifetimeQuotaExhausted`, `QueueFull`, `ResponseTooLarge`, `Timeout`, `Unavailable`, `NotReady`, `CompositionDepth`, `CompositionWidth`, `ServiceCallAbuse`, `SessionRevoked`, `InternalError`)
- `Idempotency` (`MintFresh` / `CacheRecent { ttl_ms }` / `DedupByCorrelation`) + `AuditDurability` (`PerCall` / `Batched(Duration)`)
- **11 unit tests** cover serde roundtrips, `deny_unknown_fields` rejection, error-code stable snake_case form, ServiceId parse validation (canonical forms accepted, missing-version / empty-segments / illegal-characters all rejected)

**`handler.rs`** (~190 lines) — the trait every handler implements
- `ServiceHandler` trait — `id` / `profiles` / `audit_durability` / `response_size_cap` (default 64 KiB) / `idempotency` / `call_timeout` / `dispatch` / `composes_with`
- Sync-shaped (`dispatch` returns `Pin<Box<dyn Future>>`) so `mvm-core` stays free of `async-trait` / `tokio` macros — concrete subprocess crates `tokio::spawn` the boxed future
- `ServiceCallCtx` carries `workload_id`, `tenant_id`, supervisor-assigned `correlation_id`, `session_id`, `profile`, composition counters (§A5 depth + §H-L6.5 width caps)
- `ServiceError` typed wrapper with a `not_implemented(verb)` shorthand
- **2 unit tests** cover the trait shape via a `DummyHandler`

## Algorithm-identifier byte in `AuthenticatedFrame` (Plan 104 §H-L4.1)

Added `sig_alg: u8` to `mvm_core::security::AuthenticatedFrame` with constants:

- `SIG_ALG_ED25519 = 0x01` — the v1 default (`ed25519-dalek` v2.x)
- `SIG_ALG_ECDSA_P256 = 0x02` — reserved for W8 macOS Secure Enclave host-signer path

`deny_unknown_fields` + no default → **pre-W1a frames hard-fail at parse**. This is the no-backcompat contract: old frames cannot silently decode to a default algorithm (which would let a forged frame pretend to be a future PQC scheme). Updated downstream constructors in `crates/mvm-guest/src/vsock.rs` and the `fuzz_authed_path` fuzz target.

**3 new tests:** roundtrip with sig_alg present, roundtrip both reserved values, missing-field rejection.

## New `crates/mvm-broker/` scaffold (uid 903 per ADR-061)

- `config.rs` — `SubprocessConfig` JSON envelope read from stdin at spawn (workload_id, tenant_id, uds_path, host-signer pubkey path, audit-signer UDS path, `max_frame_bytes` default 65 KiB, `parse_timeout` default 50ms). **W1a parses unsigned**; the TODO at the parse site is to wrap in a release-key-signed envelope per §H-L3.6 (lands in W1b).
- `registry.rs` — `Registry::register`/`Registry::dispatch`; empty registry returns `Err(NotBound)`. The W1a acceptance criterion ("Both brokers reject every call with `NotBound`") per Plan 104 §Build sequence W1.
- `server.rs` — UDS accept loop, 4-byte-BE length-prefixed JSON framing, `max_frame_bytes` cap enforced *before* allocating the body buffer (Plan 104 §"Capability gating" gate 1).
- `bin/mvm-broker.rs` — binary entry; the spawn contract is documented in the module header (what the supervisor does pre-spawn vs what this process does post-spawn vs what's deferred to W1b).

**8 unit tests** cover config roundtrip, unknown-field rejection, defaults for optional fields, registry routing (empty → NotBound; registered → dispatches), real UDS round-trip via tempdir, oversized-frame rejection.

## What W1a does NOT do (deferred to W1b unless noted)

- **The remaining three subprocesses** (mvm-secrets-dispatcher, mvm-host-signer, mvm-audit-signer)
- **Supervisor-side cosign verify** of subprocess binaries (§H-L3.1)
- **TOCTOU-resistant verify-then-exec** (§H-L3.2)
- **Subprocess config-envelope signature verification** (§H-L3.6)
- **Per-spawn ephemeral subprocess response signing** (§H-L4.2)
- **Seccomp + setpriv + resource caps** (§H-L3.3 / §H-L3.9)
- **Per-workload cgroup + namespace** (§H-L1.4)
- **vsock 5300 listener wiring** — the supervisor sets up the backend-specific listener (libkrun / Firecracker / Apple Container / vz) and hands the FD to the subprocess; this crate consumes the FD via `serve_on_listener`
- **Algorithm-identifier verification of ECDSA-P256** — the constant is reserved; the verify path lands in **W8** alongside the macOS Secure Enclave host signer

## Test plan

- [x] `cargo test -p mvm-core --lib protocol` — 13 new tests, all passing (plus 55 existing protocol tests still green)
- [x] `cargo test -p mvm-broker --lib` — 8 new tests, all passing
- [x] `cargo fmt --all -- --check` — green
- [x] `cargo build -p mvm-broker --bin mvm-broker` — green
- [x] Full workspace `just lint` — green (clippy --workspace -- -D warnings)
- [ ] Reviewer confirms the `ServiceHandler` trait shape (sync-shaped boxed future vs `async-trait`) matches preferences for the broker subprocess crates
- [ ] Reviewer confirms the `AuthenticatedFrame::sig_alg` byte placement is acceptable as a wire-breaking change (per the no-backcompat rule; old frames hard-fail)

## Notes for reviewer

- **One pre-existing flaky test** in `mvm-cli::commands::env::apple_container::builder_vm_bootstrap_tests::sweep_removes_orphan_staging_dir_and_leaves_siblings` fails the same way on `origin/main` — unrelated to W1a. Not fixed here.
- **The `mvm-broker` binary doesn't yet do anything useful** by design — that's the W1a acceptance criterion. W3 will register `HostTimeV1Handler` and the binary will start returning actual time values; W4a adds `HostCostV1Handler`.
- **The `composes_with` API on `ServiceHandler`** is included now so the CI lint (`xtask check-handler-composition` — Plan 104 W6) has a stable target.
- **No supervisor-side changes** in W1a — that's intentional. The supervisor is the load-bearing piece of W1b's hardening (cosign verify, TOCTOU exec, config signing, cgroup setup) and deserves its own focused PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)