### PR TITLE
feat: Plan 102 W6.A.5 — Vz Swift bridge + libkrun supervisor wire-up (substrate)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3458,9 +3458,15 @@ dependencies = [
 name = "mvm-libkrun-supervisor"
 version = "0.14.0"
 dependencies = [
+ "anyhow",
+ "ed25519-dalek",
  "mvm-libkrun",
+ "mvm-plan",
+ "mvm-policy",
  "mvm-providers",
+ "mvm-supervisor",
  "serde_json",
+ "tracing",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3455,6 +3455,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "mvm-libkrun-supervisor"
+version = "0.14.0"
+dependencies = [
+ "mvm-libkrun",
+ "mvm-providers",
+ "serde_json",
+]
+
+[[package]]
 name = "mvm-mcp"
 version = "0.14.0"
 dependencies = [

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,6 +8,12 @@ members = [
     "crates/mvm-supervisor",
     "crates/mvm-providers",
     "crates/mvm-libkrun",
+    # Plan 102 W6.A.5 — leaf bin crate that links mvm-libkrun + mvm-
+    # supervisor without closing the
+    # `mvm-supervisor → mvm-backend → mvm-libkrun` cycle. Produces the
+    # `mvm-libkrun-supervisor` binary that mvm-backend's spawner
+    # resolves at runtime.
+    "crates/mvm-libkrun-supervisor",
     # Plan 97 Phase B — type-safe interface to the Swift
     # `mvm-vz-supervisor` binary. Pure data + path resolution; no FFI,
     # no Swift dep. Parallel role to `mvm-libkrun` for the Vz backend.

--- a/crates/mvm-backend/src/host_gvproxy.rs
+++ b/crates/mvm-backend/src/host_gvproxy.rs
@@ -1,0 +1,334 @@
+//! Host-side gvproxy lifecycle for the Vz backend.
+//!
+//! Plan 102 W6.A.5 — VzBackend is stateless (no per-VM in-memory
+//! ownership), so `gvproxy` must outlive `VzBackend::start`'s
+//! return. We can't use [`mvm_libkrun::gvproxy::spawn`] directly:
+//! it returns a `GvproxyHandle` whose Drop SIGTERMs the child the
+//! moment the handle goes out of scope — perfect for the in-libkrun-
+//! supervisor model (which holds the handle on the supervisor
+//! process's stack until `krun_start_enter` exit()s), wrong for the
+//! Vz parent-spawn model.
+//!
+//! This module spawns gvproxy without owning its `Child`, records
+//! the PID in a sidecar file under the per-VM scratch dir, and
+//! exposes a tear-down helper for `VzBackend::stop` to call.
+//! `std::process::Child::drop` does NOT kill the child — it just
+//! closes stdio handles — so dropping the Child immediately is
+//! safe and leaves gvproxy running as a normal child of the
+//! original parent (and re-parented to init when the parent
+//! eventually exits).
+//!
+//! The libkrun lane keeps using `mvm_libkrun::gvproxy::spawn` —
+//! that model is in-process and the Drop semantics fit it. We
+//! deliberately don't refactor the libkrun lane to share this
+//! module: the trade-offs are different (in-process vs detached).
+
+use std::ffi::OsString;
+use std::path::{Path, PathBuf};
+use std::process::{Command, Stdio};
+use std::time::{Duration, Instant};
+
+use anyhow::{Result, anyhow, bail};
+use sha2::{Digest, Sha256};
+
+/// File name used for the host-gvproxy PID sidecar under the per-VM
+/// state dir. Picked to not collide with the existing `libkrun.pid`
+/// or `mvm-vz-supervisor.pid` markers in the same directory.
+pub const PID_FILE_NAME: &str = "host-gvproxy.pid";
+
+/// File name of the host-gvproxy listener socket. Lives under the
+/// per-VM bridge scratch dir alongside the supervisor-side bridge
+/// listener (when claim-10 bridge mode is on).
+pub const SOCKET_FILE_NAME: &str = "gvproxy.sock";
+
+/// How long we wait for gvproxy's listen-vfkit socket to appear
+/// before declaring the spawn failed.
+const SOCKET_READY_TIMEOUT: Duration = Duration::from_secs(3);
+
+/// How long [`stop_by_pid_file`] gives the child to exit after
+/// `SIGTERM` before escalating to `SIGKILL`.
+const STOP_TIMEOUT: Duration = Duration::from_secs(2);
+
+/// Spawned host gvproxy's externally-observable identity. Returned
+/// from [`spawn_detached`] for the caller to feed into the per-VM
+/// supervisor config + PID-file tear-down later.
+#[derive(Debug, Clone)]
+pub struct HostGvproxyInfo {
+    /// Absolute path to gvproxy's `-listen-vfkit` SOCK_DGRAM
+    /// listener. Vz supervisor connects here.
+    pub socket_path: PathBuf,
+    /// gvproxy's PID. Also written to `<scratch_dir>/host-gvproxy.pid`
+    /// so [`stop_by_pid_file`] can rediscover it after VzBackend::start
+    /// has returned.
+    pub pid: u32,
+}
+
+/// Spawn gvproxy as a detached child of the current process.
+/// Writes the PID to `<scratch_dir>/host-gvproxy.pid`, polls for
+/// the listener socket to appear, then returns. Drops the
+/// `std::process::Child` — gvproxy keeps running as a normal child
+/// (re-parented to init when mvmctl exits).
+///
+/// `scratch_dir` is the per-VM state dir (typically
+/// `~/.mvm/vms/<name>/`). Created if missing. Stale PID + socket
+/// files from a prior run are pre-cleaned.
+pub fn spawn_detached(scratch_dir: &Path) -> Result<HostGvproxyInfo> {
+    let gvproxy_bin = mvm_libkrun::gvproxy::locate_gvproxy().ok_or_else(|| {
+        anyhow!(
+            "gvproxy binary not found on PATH. {}",
+            mvm_libkrun::gvproxy::install_hint()
+        )
+    })?;
+
+    std::fs::create_dir_all(scratch_dir)
+        .map_err(|e| anyhow!("create scratch dir {}: {e}", scratch_dir.display()))?;
+
+    let socket_path = scratch_dir.join(SOCKET_FILE_NAME);
+    let pid_path = scratch_dir.join(PID_FILE_NAME);
+    let log_path = scratch_dir.join("host-gvproxy.log");
+
+    // Defensive cleanup — a previous mvmctl crash may have left a
+    // stale socket file in place; gvproxy refuses to bind in that
+    // case. The PID file is also stale-cleared; if a previous
+    // gvproxy is still running its PID is unrelated to ours and
+    // would be misleading.
+    let _ = std::fs::remove_file(&socket_path);
+    let _ = std::fs::remove_file(&pid_path);
+
+    // gvproxy args (mirror mvm-libkrun::gvproxy::spawn):
+    //   -listen-vfkit unixgram://<path>  — Vz connects here
+    //   -log-file <path>                 — diagnostic log
+    //   -ssh-port <port>                 — per-scratch-dir derived
+    //                                      so concurrent gvproxies
+    //                                      don't collide on 2222
+    let listen_url = {
+        let mut s = OsString::from("unixgram://");
+        s.push(socket_path.as_os_str());
+        s
+    };
+    let ssh_port = ssh_port_for(scratch_dir);
+
+    let mut cmd = Command::new(&gvproxy_bin);
+    cmd.arg("-listen-vfkit")
+        .arg(listen_url)
+        .arg("-log-file")
+        .arg(OsString::from(&log_path))
+        .arg("-ssh-port")
+        .arg(ssh_port.to_string())
+        // Inherit stderr so listen-time errors (port already in
+        // use, etc.) are visible to the operator — `-log-file`
+        // only writes after gvproxy is past arg-parse + listener
+        // setup.
+        .stdout(Stdio::null())
+        .stderr(Stdio::inherit());
+
+    let mut child = cmd
+        .spawn()
+        .map_err(|e| anyhow!("spawn gvproxy {}: {e}", gvproxy_bin.display()))?;
+    let pid = child.id();
+
+    // Persist the PID so VzBackend::stop can find this child later.
+    // VzBackend::start returns shortly after this, dropping `child`
+    // (which doesn't kill the process — std::process::Child::drop
+    // is a no-op WRT process lifetime). The kernel reparents
+    // gvproxy to init when mvmctl eventually exits.
+    std::fs::write(&pid_path, pid.to_string())
+        .map_err(|e| anyhow!("write {}: {e}", pid_path.display()))?;
+
+    // Poll for the listener socket to appear. If gvproxy exits
+    // early (missing arg, port already in use, etc.), surface the
+    // status immediately rather than as a generic timeout.
+    let deadline = Instant::now() + SOCKET_READY_TIMEOUT;
+    loop {
+        if socket_path.exists() {
+            // Intentional: drop the Child without killing.
+            // std::process::Child::drop just closes pipe handles.
+            drop(child);
+            return Ok(HostGvproxyInfo { socket_path, pid });
+        }
+        if let Some(status) = child
+            .try_wait()
+            .map_err(|e| anyhow!("poll gvproxy child: {e}"))?
+        {
+            let _ = std::fs::remove_file(&pid_path);
+            bail!(
+                "gvproxy exited before listener appeared (status: {status}). \
+                 Log: {}",
+                log_path.display()
+            );
+        }
+        if Instant::now() >= deadline {
+            // Bound the leak: kill the still-running child before
+            // bailing so it doesn't survive the failed start.
+            let _ = child.kill();
+            let _ = child.wait();
+            let _ = std::fs::remove_file(&pid_path);
+            bail!(
+                "gvproxy did not create {} within {SOCKET_READY_TIMEOUT:?}. \
+                 Log: {}",
+                socket_path.display(),
+                log_path.display()
+            );
+        }
+        std::thread::sleep(Duration::from_millis(10));
+    }
+}
+
+/// Read the PID file under `scratch_dir`, SIGTERM the gvproxy
+/// process, wait up to [`STOP_TIMEOUT`] for it to exit, and fall
+/// back to SIGKILL. Removes the PID file + socket file on success
+/// or on a clean already-gone state. Idempotent — no-op when the
+/// PID file is missing or the named process is already gone.
+pub fn stop_by_pid_file(scratch_dir: &Path) -> Result<()> {
+    let pid_path = scratch_dir.join(PID_FILE_NAME);
+    let socket_path = scratch_dir.join(SOCKET_FILE_NAME);
+
+    let pid: i32 = match std::fs::read_to_string(&pid_path) {
+        Ok(s) => match s.trim().parse() {
+            Ok(p) => p,
+            Err(e) => {
+                tracing::warn!(
+                    path = %pid_path.display(),
+                    error = %e,
+                    "host_gvproxy: PID file content invalid; cleaning up"
+                );
+                let _ = std::fs::remove_file(&pid_path);
+                let _ = std::fs::remove_file(&socket_path);
+                return Ok(());
+            }
+        },
+        Err(e) if e.kind() == std::io::ErrorKind::NotFound => {
+            // No PID file = nothing to stop. Mirror the libkrun /
+            // Vz supervisor stop semantics.
+            return Ok(());
+        }
+        Err(e) => return Err(anyhow!("read {}: {e}", pid_path.display())),
+    };
+
+    if !pid_alive(pid) {
+        let _ = std::fs::remove_file(&pid_path);
+        let _ = std::fs::remove_file(&socket_path);
+        return Ok(());
+    }
+
+    // SAFETY: pid was just probed alive; SIGTERM on a stale pid
+    // returns ESRCH which we treat as a benign race.
+    unsafe { libc::kill(pid, libc::SIGTERM) };
+
+    let deadline = Instant::now() + STOP_TIMEOUT;
+    while Instant::now() < deadline {
+        if !pid_alive(pid) {
+            break;
+        }
+        std::thread::sleep(Duration::from_millis(100));
+    }
+    if pid_alive(pid) {
+        unsafe { libc::kill(pid, libc::SIGKILL) };
+    }
+
+    let _ = std::fs::remove_file(&pid_path);
+    let _ = std::fs::remove_file(&socket_path);
+    Ok(())
+}
+
+fn pid_alive(pid: i32) -> bool {
+    unsafe { libc::kill(pid, 0) == 0 }
+}
+
+/// Derive a MAC address from a VM name. Stable across runs (same
+/// name → same MAC), collision-resistant via SHA-256 truncation,
+/// and locally-administered (first octet has `0x02` set) per the
+/// MacAddress invariant in `mvm-vz`. Renders as
+/// `"aa:bb:cc:dd:ee:ff"` (lowercase) suitable for the
+/// `NetworkConfig::Gvproxy.mac` field.
+pub fn derive_mac(vm_name: &str) -> String {
+    let mut hasher = Sha256::new();
+    hasher.update(vm_name.as_bytes());
+    let digest = hasher.finalize();
+    let mut bytes = [0u8; 6];
+    bytes.copy_from_slice(&digest[..6]);
+    // Force locally-administered + clear multicast bit.
+    bytes[0] = (bytes[0] | 0x02) & !0x01;
+    bytes
+        .iter()
+        .map(|b| format!("{b:02x}"))
+        .collect::<Vec<_>>()
+        .join(":")
+}
+
+/// Per-scratch-dir port derivation for gvproxy's SSH-forward
+/// listener. Mirrors the heuristic in `mvm_libkrun::gvproxy` so
+/// concurrent VMs (host + libkrun lane, multiple Vz lanes, etc.)
+/// don't collide on a single TCP port.
+fn ssh_port_for(scratch_dir: &Path) -> u16 {
+    let mut hasher = Sha256::new();
+    hasher.update(scratch_dir.as_os_str().as_encoded_bytes());
+    let digest = hasher.finalize();
+    // Range 22220..=29999 — wide enough that 4096 concurrent VMs
+    // is collision-improbable.
+    let n = u16::from(digest[0]) << 8 | u16::from(digest[1]);
+    22220 + (n % 7780)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn derive_mac_is_locally_administered_lowercase_and_stable() {
+        let mac = derive_mac("vm-alpha");
+        assert_eq!(mac.len(), 17, "AA:BB:CC:DD:EE:FF shape");
+        let first_byte = u8::from_str_radix(&mac[..2], 16).unwrap();
+        assert_eq!(
+            first_byte & 0x02,
+            0x02,
+            "locally-administered bit must be set: {mac}"
+        );
+        assert_eq!(first_byte & 0x01, 0, "multicast bit must be clear: {mac}");
+        // Lowercase hex digits + colons only.
+        assert!(
+            mac.chars()
+                .all(|c| matches!(c, '0'..='9' | 'a'..='f' | ':')),
+            "lowercase hex digits + colons only: {mac}"
+        );
+        // Stability across calls.
+        assert_eq!(mac, derive_mac("vm-alpha"));
+    }
+
+    #[test]
+    fn derive_mac_differs_for_different_names() {
+        let a = derive_mac("vm-alpha");
+        let b = derive_mac("vm-beta");
+        assert_ne!(a, b);
+    }
+
+    #[test]
+    fn ssh_port_in_range_and_stable() {
+        let p1 = ssh_port_for(Path::new("/tmp/x/vm-a"));
+        let p2 = ssh_port_for(Path::new("/tmp/x/vm-a"));
+        let p3 = ssh_port_for(Path::new("/tmp/x/vm-b"));
+        assert_eq!(p1, p2);
+        assert_ne!(p1, p3);
+        assert!((22220..30000).contains(&p1));
+    }
+
+    #[test]
+    fn stop_by_pid_file_idempotent_when_missing() {
+        let tmp = tempfile::tempdir().unwrap();
+        stop_by_pid_file(tmp.path()).expect("missing PID file is benign");
+    }
+
+    #[test]
+    fn stop_by_pid_file_cleans_up_stale_dead_pid() {
+        // Use PID 1 only as a heuristic — pid 1 is always alive on
+        // a Unix host, so this test would mis-fire. Use a high PID
+        // that's almost certainly free (gvproxy doesn't run here
+        // either).
+        let tmp = tempfile::tempdir().unwrap();
+        let pid_path = tmp.path().join(PID_FILE_NAME);
+        // Pick a PID very unlikely to be alive on the test host.
+        std::fs::write(&pid_path, "999999").unwrap();
+        stop_by_pid_file(tmp.path()).expect("dead pid is cleaned up");
+        assert!(!pid_path.exists(), "PID file should be removed");
+    }
+}

--- a/crates/mvm-backend/src/lib.rs
+++ b/crates/mvm-backend/src/lib.rs
@@ -40,6 +40,13 @@ pub mod cloud_hypervisor;
 pub mod docker;
 pub mod firecracker;
 pub mod handle_registry;
+// Plan 102 W6.A.5 — host-side gvproxy lifecycle for the Vz
+// backend. VzBackend is stateless and the Swift supervisor doesn't
+// spawn gvproxy itself, so the host process spawns gvproxy as a
+// detached child (PID sidecar file under the per-VM scratch dir).
+// Lifecycle: VzBackend::start spawns + writes PID; VzBackend::stop
+// reads PID + signals.
+pub mod host_gvproxy;
 pub mod image;
 pub mod libkrun;
 pub mod microvm;

--- a/crates/mvm-backend/src/libkrun.rs
+++ b/crates/mvm-backend/src/libkrun.rs
@@ -129,12 +129,18 @@ impl VmBackend for LibkrunBackend {
             // None for now — backend orchestrator population
             // (sourcing tenant_id from ExecutionPlan, gateway sockets
             // from mvm_data_dir()) lands alongside the
-            // run_supervisor_with_bridge wire-up (commit 6.5 / 7).
+            // run_supervisor_with_bridge wire-up (Plan 102 W6.A.5
+            // Phase 3).
             tenant_id: None,
             audit_dir: None,
             gateway_audit_socket: None,
             gateway_events_socket: None,
             signing_key_path: None,
+            // Plan 102 W6.A.5 plan/bundle fields — populated by the
+            // same Phase 3 wire-up that fills the audit-substrate
+            // paths.
+            plan: None,
+            bundle: None,
         };
         let pid_file = cfg.pid_file();
         // Remove any stale PID file from a previous crashed supervisor

--- a/crates/mvm-backend/src/vz.rs
+++ b/crates/mvm-backend/src/vz.rs
@@ -37,6 +37,7 @@ use mvm_core::vm_backend::{
     VmCapabilities, VmExitStatus, VmId, VmInfo, VmStartConfig, VmStatus,
 };
 
+use crate::host_gvproxy;
 use crate::vz_control;
 use mvm_base::ui;
 use mvm_vz as vz;
@@ -52,6 +53,27 @@ use std::time::{Duration, Instant};
 /// type still compiles, but `is_available()` always returns `Ok(false)`
 /// and `start` bails before spawning anything.
 pub struct VzBackend;
+
+/// Plan 102 W6.A.5 — tear-down guard for host-side gvproxy in the
+/// attached-VM path (`VzBackend::run_attached`). Ensures gvproxy is
+/// stopped even on panic / early return between spawn and the
+/// supervisor's exit. The detached `start()` path doesn't need this:
+/// `VzBackend::stop` reads the PID file and cleans up there.
+struct AttachedGvproxyGuard {
+    state_dir: PathBuf,
+}
+
+impl Drop for AttachedGvproxyGuard {
+    fn drop(&mut self) {
+        if let Err(e) = host_gvproxy::stop_by_pid_file(&self.state_dir) {
+            tracing::warn!(
+                state_dir = %self.state_dir.display(),
+                error = %e,
+                "AttachedGvproxyGuard: host_gvproxy stop failed on drop"
+            );
+        }
+    }
+}
 
 /// PID file name the supervisor writes inside `vm_state_dir`. Distinct
 /// from libkrun's `libkrun.pid` so the two backends can coexist under
@@ -134,8 +156,15 @@ impl VmBackend for VzBackend {
         mvm_build::builder_vm::admit_overlay_aware(rootfs_dir)?;
         mvm_base::runtime_meta::record_from_rootfs(&config.name, StartMode::Detached, rootfs)?;
 
+        // Plan 102 W6.A.5 — spawn host-side gvproxy so the Swift
+        // supervisor has something to connect to. VzBackend is
+        // stateless; the child is detached (PID file under state
+        // dir lets `stop()` find it later).
+        let gvproxy_info = host_gvproxy::spawn_detached(&state_dir)
+            .map_err(|e| anyhow!("spawn host-side gvproxy for Vz VM '{}': {e}", config.name))?;
+
         // Vz config build.
-        let cfg = build_supervisor_config(config, kernel, &state_dir);
+        let cfg = build_supervisor_config(config, kernel, &state_dir, &gvproxy_info);
         let pid_file = state_dir.join(PID_FILE_NAME);
         // Stale-PID-file cleanup from a previous crashed supervisor so
         // the wait-loop below detects the *new* one unambiguously.
@@ -275,6 +304,20 @@ impl VmBackend for VzBackend {
         }
 
         let _ = std::fs::remove_file(&pid_path);
+
+        // Plan 102 W6.A.5 — tear down the host-side gvproxy
+        // spawned by `start()`. Best-effort: the supervisor stop
+        // already succeeded; a stuck gvproxy is a leak but not a
+        // correctness issue (the listener socket is per-VM and the
+        // PID file would be unlinked by the next start).
+        if let Err(e) = host_gvproxy::stop_by_pid_file(&vm_state_dir(&id.0)) {
+            tracing::warn!(
+                vm = %id.0,
+                error = %e,
+                "host_gvproxy stop failed (non-fatal)"
+            );
+        }
+
         ui::success(&format!("Vz VM '{}' stopped.", id.0));
         Ok(())
     }
@@ -479,7 +522,20 @@ impl VzBackend {
         std::fs::create_dir_all(&state_dir)
             .map_err(|e| anyhow!("create per-VM state dir {}: {e}", state_dir.display()))?;
 
-        let cfg = build_supervisor_config(config, kernel, &state_dir);
+        // Plan 102 W6.A.5 — attached path also needs the
+        // host-side gvproxy. `run_attached` ties gvproxy's
+        // lifetime to its own caller stack: the wait-on-exit
+        // below blocks until the supervisor process ends, then
+        // we tear down gvproxy on the way out (best-effort
+        // tear-down inside the `Drop` of `AttachedGvproxyGuard`
+        // below so panics + early returns still clean up).
+        let gvproxy_info = host_gvproxy::spawn_detached(&state_dir)
+            .map_err(|e| anyhow!("spawn host-side gvproxy for Vz VM '{}': {e}", config.name))?;
+        let _gvproxy_guard = AttachedGvproxyGuard {
+            state_dir: state_dir.clone(),
+        };
+
+        let cfg = build_supervisor_config(config, kernel, &state_dir, &gvproxy_info);
         let pid_file = state_dir.join(PID_FILE_NAME);
         let _ = std::fs::remove_file(&pid_file);
 
@@ -759,6 +815,29 @@ fn vm_state_dir(name: &str) -> PathBuf {
     vms_root().join(name)
 }
 
+/// Plan 102 W6.A.5 — per-VM Vz events-ingest socket path. The Swift
+/// bridge (once written) connects here, sends the
+/// `MVM_VZ_BRIDGE_V1\n` handshake, and writes NDJSON `FlowEventWire`
+/// entries. The Rust supervisor's signer task drains them into the
+/// per-tenant audit chain. Lives under `~/.mvm/audit/` so the path
+/// is co-located with the chain files and the subscriber socket
+/// (`gateway-<vm>.sock`).
+///
+/// Returned as a `String` to fit straight into
+/// `NetworkConfig::Gvproxy.events_ingest_socket_path` without an
+/// extra conversion.
+fn events_ingest_socket_path(vm_name: &str) -> String {
+    // `mvm_core::config::mvm_data_dir` returns `String`; convert to
+    // PathBuf to use `Path::join`, then back to String for the JSON
+    // field shape `NetworkConfig::Gvproxy.events_ingest_socket_path`
+    // declares.
+    PathBuf::from(mvm_core::config::mvm_data_dir())
+        .join("audit")
+        .join(format!("gateway-events-{vm_name}.sock"))
+        .to_string_lossy()
+        .into_owned()
+}
+
 /// Build the [`mvm_vz::SupervisorConfig`] the supervisor binary
 /// consumes on stdin. Maps the backend-agnostic `VmStartConfig` to
 /// the Vz-specific JSON shape.
@@ -771,6 +850,7 @@ fn build_supervisor_config(
     config: &VmStartConfig,
     kernel: &str,
     state_dir: &Path,
+    gvproxy: &host_gvproxy::HostGvproxyInfo,
 ) -> vz::SupervisorConfig {
     let state_dir_str = state_dir.to_string_lossy().into_owned();
     let vsock_dir = state_dir.join("vsock").to_string_lossy().into_owned();
@@ -806,10 +886,20 @@ fn build_supervisor_config(
             socket_dir: vsock_dir,
         },
         console_output_path: Some(console_log),
-        // gvproxy wiring lands in a follow-up slice (needs
-        // host-side gvproxy lifecycle the libkrun path already
-        // performs for `MVM_NETWORKING=gvproxy`).
-        network: None,
+        // Plan 102 W6.A.5 — gvproxy backend with claim-10 audit
+        // bridge ingest hookup. `socket_path` is where the Swift
+        // supervisor connects gvproxy; `events_ingest_socket_path`
+        // is where the (future) Swift bridge writes NDJSON
+        // FlowEventWire entries for the Rust supervisor's signer
+        // task to drain. The path is stable per VM under
+        // `~/.mvm/audit/gateway-events-<vm>.sock` so a future
+        // run_supervisor_with_bridge-style entry point on the Vz
+        // side can bind that listener and consume the stream.
+        network: Some(vz::NetworkConfig::Gvproxy {
+            socket_path: gvproxy.socket_path.to_string_lossy().into_owned(),
+            mac: host_gvproxy::derive_mac(&config.name),
+            events_ingest_socket_path: Some(events_ingest_socket_path(&config.name)),
+        }),
         balloon: Some(vz::BalloonConfig {
             enabled: true,
             floor_mib: 128,
@@ -1085,7 +1175,15 @@ mod tests {
         cfg.kernel_path = Some("/abs/vmlinux".into());
         cfg.rootfs_path = "/abs/rootfs.ext4".into();
         let state_dir = Path::new("/tmp/vz-smoke-state");
-        let built = build_supervisor_config(&cfg, "/abs/vmlinux", state_dir);
+        // Plan 102 W6.A.5 — build_supervisor_config now takes
+        // HostGvproxyInfo (the host-side gvproxy lifecycle's
+        // socket + PID, populated into NetworkConfig::Gvproxy).
+        // Test passes a stub — actual gvproxy isn't spawned here.
+        let gvproxy_info = host_gvproxy::HostGvproxyInfo {
+            socket_path: state_dir.join("gvproxy.sock"),
+            pid: 0,
+        };
+        let built = build_supervisor_config(&cfg, "/abs/vmlinux", state_dir, &gvproxy_info);
 
         assert_eq!(built.name, "smoke");
         assert_eq!(built.kernel.path, "/abs/vmlinux");
@@ -1099,6 +1197,32 @@ mod tests {
         // Console capture goes to a file under state_dir; never `None`
         // — capture-only is the workload contract (Plan 97 Security §9).
         assert!(built.console_output_path.is_some());
+        // Plan 102 W6.A.5 — network field is now populated with the
+        // gvproxy socket + MAC + events_ingest path.
+        match built.network {
+            Some(vz::NetworkConfig::Gvproxy {
+                socket_path,
+                mac,
+                events_ingest_socket_path,
+            }) => {
+                assert!(
+                    socket_path.ends_with("gvproxy.sock"),
+                    "socket path: {socket_path}"
+                );
+                assert!(
+                    mac.starts_with("02:")
+                        || mac.starts_with("06:")
+                        || mac.starts_with("0a:")
+                        || mac.starts_with("0e:"),
+                    "locally-administered MAC: {mac}"
+                );
+                assert!(
+                    events_ingest_socket_path.is_some(),
+                    "events_ingest_socket_path should be populated for W6.A.5 Vz bridge"
+                );
+            }
+            None => panic!("network should be Some(Gvproxy {{ .. }}) after W6.A.5"),
+        }
     }
 
     #[test]

--- a/crates/mvm-build/src/libkrun_builder.rs
+++ b/crates/mvm-build/src/libkrun_builder.rs
@@ -394,6 +394,8 @@ impl LibkrunBuilderVm {
             gateway_audit_socket: None,
             gateway_events_socket: None,
             signing_key_path: None,
+            plan: None,
+            bundle: None,
         };
 
         let exit_code = spawn_supervisor_and_wait(&supervisor_path, &cfg, &vm_state_dir)?;
@@ -494,6 +496,8 @@ impl LibkrunBuilderVm {
             gateway_audit_socket: None,
             gateway_events_socket: None,
             signing_key_path: None,
+            plan: None,
+            bundle: None,
         };
         // Plan 89 W2 part 4: spawn the vsock response listener
         // BEFORE the supervisor so it can connect as soon as libkrun
@@ -763,6 +767,8 @@ impl BuilderVm for LibkrunBuilderVm {
             gateway_audit_socket: None,
             gateway_events_socket: None,
             signing_key_path: None,
+            plan: None,
+            bundle: None,
         };
         // Plan 89 W2 part 4: same dispatch-listener wiring as
         // `run_shell_script`. Drained after the supervisor exits
@@ -936,6 +942,8 @@ impl VmBackendForBuilder for LibkrunBuilderBackend {
             gateway_audit_socket: None,
             gateway_events_socket: None,
             signing_key_path: None,
+            plan: None,
+            bundle: None,
         };
 
         let mut child = spawn_supervisor_in_background(&self.supervisor_path, &cfg)?;
@@ -1827,6 +1835,8 @@ impl LibkrunPersistentBuilderVm {
             gateway_audit_socket: None,
             gateway_events_socket: None,
             signing_key_path: None,
+            plan: None,
+            bundle: None,
         };
 
         let child = spawn_supervisor_in_background(&supervisor_path, &cfg)?;

--- a/crates/mvm-libkrun-supervisor/Cargo.toml
+++ b/crates/mvm-libkrun-supervisor/Cargo.toml
@@ -1,0 +1,52 @@
+[package]
+name = "mvm-libkrun-supervisor"
+version.workspace = true
+edition.workspace = true
+description = "Per-VM supervisor binary that boots a libkrun guest and runs the per-tenant gateway audit bridge (Plan 102 W6.A.5)"
+license.workspace = true
+repository.workspace = true
+homepage.workspace = true
+authors.workspace = true
+
+# ── What this crate is ─────────────────────────────────────────────
+#
+# Leaf bin crate that links `mvm-libkrun` (libkrun FFI + boot path)
+# AND `mvm-supervisor` (gateway audit bridge + audit chain + flow
+# policy). Lives outside `mvm-libkrun` because adding `mvm-supervisor`
+# to `mvm-libkrun`'s deps would close the cycle
+# `mvm-supervisor → mvm-backend → mvm-libkrun`. As a leaf (nothing
+# depends on this crate), it can pull both sides freely.
+#
+# The binary name stays `mvm-libkrun-supervisor` so
+# `mvm-backend::libkrun::resolve_supervisor_path()` (the spawner)
+# keeps finding it. The on-stdin JSON contract (`SupervisorConfig`)
+# is unchanged in this commit; Plan 102 W6.A.5 commit 2 widens it
+# with optional plan/bundle fields the bridge factory consumes.
+
+[dependencies]
+# libkrun bindings, KrunContext, SupervisorConfig, run_supervisor.
+# The `libkrun-sys` feature on this dep is enabled transitively by
+# this crate's own `libkrun-sys` feature so the workspace's default
+# `cargo check --workspace` (no features) skips bindgen + libkrun
+# linkage on hosts without libkrun.h — mirrors the pre-split
+# `required-features = ["libkrun-sys"]` gate on the old `[[bin]]`.
+mvm-libkrun.workspace = true
+# Codesigning gate on macOS (`apple_container::ensure_signed`).
+mvm-providers.workspace = true
+serde_json.workspace = true
+
+[features]
+default = []
+# Opt-in: build the supervisor binary against libkrun's FFI.
+# Required to actually run this crate's bin; without it the binary
+# compiles but `run_supervisor` returns `Error::NotYetWired` and
+# the lib.rs `configure_*` helpers are absent.
+libkrun-sys = ["mvm-libkrun/libkrun-sys"]
+
+[[bin]]
+name = "mvm-libkrun-supervisor"
+path = "src/main.rs"
+required-features = ["libkrun-sys"]
+
+[lints]
+workspace = true

--- a/crates/mvm-libkrun-supervisor/Cargo.toml
+++ b/crates/mvm-libkrun-supervisor/Cargo.toml
@@ -34,6 +34,24 @@ mvm-libkrun.workspace = true
 # Codesigning gate on macOS (`apple_container::ensure_signed`).
 mvm-providers.workspace = true
 serde_json.workspace = true
+# Plan 102 W6.A.5 — bridge factory. The bin builds
+# `BridgeConfig` + `BridgeEndpoints` and calls
+# `spawn_bridge_thread`. `FileAuditSigner` is the chain-signing
+# AuditSigner the factory feeds to the bridge.
+mvm-supervisor.workspace = true
+# Plan 102 W6.A.5 — typed `ExecutionPlan` and `PolicyBundle` for
+# the bridge. The leaf bin can depend on both without closing the
+# `mvm-libkrun ← mvm-core ← mvm-plan` cycle that the SupervisorConfig
+# `Option<serde_json::Value>` carrier path avoids.
+mvm-plan.workspace = true
+mvm-policy.workspace = true
+# Ed25519 key load from `cfg.signing_key_path`. The host signer
+# secret is written by `mvm-cli::host_signer::load_or_init_at` at
+# `mvmctl up` admission time; the bin re-reads the bytes to seed
+# the FileAuditSigner.
+ed25519-dalek = { workspace = true }
+anyhow.workspace = true
+tracing = "0.1"
 
 [features]
 default = []

--- a/crates/mvm-libkrun-supervisor/src/main.rs
+++ b/crates/mvm-libkrun-supervisor/src/main.rs
@@ -15,6 +15,16 @@
 //! to a single supervisor; the parent `mvmctl` returns immediately
 //! after spawning and survives a guest's shutdown.
 //!
+//! ## Why this is its own crate
+//!
+//! Plan 102 W6.A.5 — the bin's bridge-factory branch needs to
+//! depend on `mvm-supervisor` (gateway audit substrate). Adding
+//! `mvm-supervisor` to `mvm-libkrun`'s deps would close the cycle
+//! `mvm-supervisor → mvm-backend → mvm-libkrun`. Splitting the bin
+//! into a leaf crate breaks the cycle cleanly. The binary name is
+//! preserved so `mvm-backend::libkrun::resolve_supervisor_path()`
+//! keeps resolving it.
+//!
 //! ## Usage (manual)
 //!
 //! ```sh

--- a/crates/mvm-libkrun-supervisor/src/main.rs
+++ b/crates/mvm-libkrun-supervisor/src/main.rs
@@ -1,10 +1,26 @@
-//! Plan 57 W4 — one-libkrun-guest-per-process supervisor.
+//! Plan 57 W4 / Plan 102 W6.A.5 — one-libkrun-guest-per-process supervisor.
 //!
 //! Reads a [`SupervisorConfig`] JSON document on stdin, ad-hoc
 //! codesigns itself for `Hypervisor.framework` (macOS W2 gate),
 //! creates the per-VM state directory, writes its own PID, then
-//! calls [`run_supervisor`] which blocks in `krun_start_enter`
-//! until the guest powers off.
+//! either:
+//!
+//! 1. **Bridge path** (`cfg.tenant_id` is `Some`) — calls
+//!    [`run_supervisor_with_bridge`] with a factory that spawns the
+//!    per-VM gateway audit bridge (`mvm_supervisor::gateway_bridge::
+//!    spawn_bridge_thread`). Every guest network byte transits the
+//!    bridge, FlowOpened/FlowClosed entries chain-sign into
+//!    `~/.mvm/audit/<tenant>.jsonl`, and `nc -U
+//!    <gateway_audit_socket>` subscribers see the live NDJSON feed.
+//!    This is the claim-10 substrate path.
+//! 2. **Legacy path** (`cfg.tenant_id` is `None`) — falls back to
+//!    the pre-W6.A.5 [`run_supervisor`] which boots libkrun without
+//!    interposing a bridge. Used by Stage 0 builder VMs and any
+//!    other dev-mode call site that doesn't synthesize an
+//!    `ExecutionPlan`.
+//!
+//! Both paths block in `krun_start_enter` until the guest powers
+//! off, at which point libkrun calls `exit()` on the process.
 //!
 //! ## Why one process per VM
 //!
@@ -17,45 +33,31 @@
 //!
 //! ## Why this is its own crate
 //!
-//! Plan 102 W6.A.5 — the bin's bridge-factory branch needs to
-//! depend on `mvm-supervisor` (gateway audit substrate). Adding
+//! Plan 102 W6.A.5 — the bin's bridge-factory branch depends on
+//! `mvm-supervisor` (gateway audit substrate). Adding
 //! `mvm-supervisor` to `mvm-libkrun`'s deps would close the cycle
 //! `mvm-supervisor → mvm-backend → mvm-libkrun`. Splitting the bin
 //! into a leaf crate breaks the cycle cleanly. The binary name is
 //! preserved so `mvm-backend::libkrun::resolve_supervisor_path()`
 //! keeps resolving it.
-//!
-//! ## Usage (manual)
-//!
-//! ```sh
-//! cat <<EOF | mvm-libkrun-supervisor
-//! {
-//!   "krun": {
-//!     "name": "mvm-libkrun-smoke",
-//!     "kernel_path": "/Users/me/.mvm/dev/current/vmlinux",
-//!     "rootfs_path": "/Users/me/.mvm/dev/current/rootfs.ext4",
-//!     "vcpus": 1,
-//!     "ram_mib": 512,
-//!     "kernel_cmdline": "console=hvc0 root=/dev/vda rw init=/init",
-//!     "vsock_ports": [5252],
-//!     "extra_disks": [],
-//!     "console_output_path": "/tmp/mvm-libkrun-smoke.log",
-//!     "vsock_socket_dir": "/Users/me/.mvm/vms/mvm-libkrun-smoke"
-//!   },
-//!   "vm_state_dir": "/Users/me/.mvm/vms/mvm-libkrun-smoke",
-//!   "pid_file_name": null
-//! }
-//! EOF
-//! ```
-//!
-//! Production callers (`LibkrunBackend::start()` — plan 57 W4.2)
-//! produce the JSON programmatically and pipe it via
-//! `std::process::Command::stdin`.
 
 use std::io::Read;
 use std::process::ExitCode;
+use std::sync::Arc;
 
-use mvm_libkrun::{LogLevel, SupervisorConfig, init_log, run_supervisor, set_log_level};
+use anyhow::{Context, Result, anyhow};
+use ed25519_dalek::SigningKey;
+use mvm_libkrun::{
+    BridgeFds, LogLevel, SupervisorConfig, init_log, run_supervisor, run_supervisor_with_bridge,
+    set_log_level,
+};
+use mvm_plan::ExecutionPlan;
+use mvm_policy::PolicyBundle;
+use mvm_supervisor::audit::AuditSigner;
+use mvm_supervisor::audit_file::FileAuditSigner;
+use mvm_supervisor::gateway_bridge::{
+    AllowAll, BridgeConfig, BridgeEndpoints, spawn_bridge_thread,
+};
 
 fn main() -> ExitCode {
     // macOS Hypervisor.framework rejects any process without
@@ -109,12 +111,142 @@ fn main() -> ExitCode {
         }
     };
 
-    // run_supervisor returns Result<Infallible, _>; on success
-    // libkrun has already called exit() on this process.
-    match run_supervisor(&cfg) {
+    // Plan 102 W6.A.5 — route to the bridge path when the producer
+    // populated the audit substrate, otherwise fall back to the
+    // legacy direct-libkrun path (Stage 0 builder VMs, smoke tests,
+    // etc. that haven't synthesized an ExecutionPlan).
+    let outcome = if cfg.tenant_id.is_some() {
+        run_with_bridge(cfg)
+    } else {
+        run_legacy(&cfg)
+    };
+
+    match outcome {
+        // run_supervisor / run_supervisor_with_bridge return
+        // `Result<Infallible, _>`. On success libkrun has already
+        // called exit() on this process; we never get here.
         Err(e) => {
             eprintln!("supervisor failed: {e}");
             ExitCode::from(1)
         }
     }
+}
+
+/// Legacy boot path — direct libkrun with no gateway audit bridge.
+/// Returns `Result<Infallible, _>`, propagated up.
+fn run_legacy(cfg: &SupervisorConfig) -> Result<std::convert::Infallible> {
+    run_supervisor(cfg).map_err(|e| anyhow!("run_supervisor failed: {e}"))
+}
+
+/// Bridge boot path — sets up the per-VM gateway audit bridge
+/// before calling libkrun's `start_enter`. Synthesizes the bridge
+/// factory closure that converts `BridgeFds` (mvm-libkrun shape)
+/// into `BridgeEndpoints` (mvm-supervisor shape), builds
+/// `BridgeConfig` from the JSON-encoded plan + bundle and the
+/// chain-signing `FileAuditSigner`, then calls
+/// `spawn_bridge_thread`. The bridge thread runs concurrently with
+/// `krun_start_enter` and is reaped by `exit()` on guest shutdown.
+fn run_with_bridge(cfg: SupervisorConfig) -> Result<std::convert::Infallible> {
+    // Pre-extract the audit-substrate paths + plan/bundle. The
+    // factory closure needs them as owned values; the legacy
+    // `&SupervisorConfig` reference path doesn't fit because
+    // run_supervisor_with_bridge takes a `&SupervisorConfig` and
+    // the factory captures these owned by move.
+    let vm_name = cfg.krun.name.clone();
+    let tenant_id = cfg
+        .tenant_id
+        .clone()
+        .ok_or_else(|| anyhow!("run_with_bridge called without cfg.tenant_id"))?;
+    let audit_dir = cfg.audit_dir.clone().ok_or_else(|| {
+        anyhow!("cfg.audit_dir missing — validate_audit_substrate should have refused")
+    })?;
+    let audit_socket = cfg
+        .gateway_audit_socket
+        .clone()
+        .ok_or_else(|| anyhow!("cfg.gateway_audit_socket missing"))?;
+    let signing_key_path = cfg
+        .signing_key_path
+        .clone()
+        .ok_or_else(|| anyhow!("cfg.signing_key_path missing"))?;
+    let plan_value = cfg
+        .plan
+        .clone()
+        .ok_or_else(|| anyhow!("cfg.plan missing on bridge path"))?;
+    let bundle_value = cfg.bundle.clone();
+
+    // Deserialize the JSON-Value-carrier into typed values. The
+    // round-trip cost is trivial vs the bridge's IO budget.
+    let plan: ExecutionPlan =
+        serde_json::from_value(plan_value).context("decode cfg.plan into ExecutionPlan")?;
+    let bundle: Option<PolicyBundle> = match bundle_value {
+        Some(v) => Some(serde_json::from_value(v).context("decode cfg.bundle into PolicyBundle")?),
+        None => None,
+    };
+
+    // Load the host signer secret bytes. The file is mode 0600 and
+    // written by mvm-cli's `host_signer::load_or_init_at` at admit
+    // time; we re-read on each VM start. Path was already
+    // canonicalized under `~/.mvm/keys/` by
+    // `SupervisorConfig::validate_audit_substrate`.
+    let key_bytes = std::fs::read(&signing_key_path)
+        .with_context(|| format!("read signing key {}", signing_key_path.display()))?;
+    let key_array: [u8; 32] = key_bytes.as_slice().try_into().with_context(|| {
+        format!(
+            "signing key {} is {} bytes, expected 32",
+            signing_key_path.display(),
+            key_bytes.len()
+        )
+    })?;
+    let signing_key = SigningKey::from_bytes(&key_array);
+
+    // FileAuditSigner is what mvm-supervisor's chain emitter wraps.
+    // The cross-process flock (Plan 102 W6.A commit 2) serializes
+    // writes from concurrent VM supervisors for the same tenant.
+    let signer = FileAuditSigner::open(signing_key, &audit_dir)
+        .with_context(|| format!("open FileAuditSigner at {}", audit_dir.display()))?;
+    let signer: Arc<dyn AuditSigner> = Arc::new(signer);
+
+    // Sanity log so operators tailing the bin's stderr can see the
+    // bridge wired up.
+    tracing::info!(
+        vm = %vm_name,
+        tenant = %tenant_id,
+        audit_socket = %audit_socket.display(),
+        audit_dir = %audit_dir.display(),
+        "starting bridge-mode libkrun supervisor"
+    );
+
+    let bridge_cfg = BridgeConfig {
+        vm_name: vm_name.clone(),
+        plan: Arc::new(plan),
+        bundle: bundle.map(Arc::new),
+        audit_socket,
+        signer,
+        policy: Arc::new(AllowAll),
+    };
+
+    run_supervisor_with_bridge(&cfg, move |bridge_fds| {
+        let endpoints = match bridge_fds {
+            BridgeFds::Passt {
+                gateway_fd,
+                supervisor_fd,
+            } => BridgeEndpoints::Passt {
+                gateway_fd,
+                supervisor_fd,
+            },
+            BridgeFds::LibkrunGvproxy {
+                gvproxy_socket_path,
+                supervisor_listen_path,
+            } => BridgeEndpoints::LibkrunGvproxy {
+                gvproxy_socket_path,
+                supervisor_listen_path,
+            },
+        };
+        // Bridge thread JoinHandle is intentionally dropped — libkrun's
+        // exit() on guest shutdown reaps the thread without graceful
+        // join. The bridge's own `catch_unwind → exit(1)` provides the
+        // fail-closed signal for the claim-10 substrate.
+        let _join = spawn_bridge_thread(endpoints, bridge_cfg);
+    })
+    .map_err(|e| anyhow!("run_supervisor_with_bridge failed: {e}"))
 }

--- a/crates/mvm-libkrun/Cargo.toml
+++ b/crates/mvm-libkrun/Cargo.toml
@@ -41,12 +41,6 @@ tracing = "0.1"
 # itself. Compile cost is marginal; serde is already in nearly
 # every other workspace crate's dep graph.
 serde = { workspace = true }
-# Plan 57 W4 supervisor binary (`src/bin/mvm-libkrun-supervisor.rs`)
-# needs JSON parsing on stdin and pulls `ensure_signed()` from
-# mvm-providers (macOS codesigning gate). Both are optional and
-# gated on `libkrun-sys` so the default workspace build (CI fast
-# lane, hosts without libkrun.h) skips the heavier dep graph.
-#
 # We intentionally do NOT pull `mvm-guest` from regular deps: that
 # would close a cycle (mvm-core → mvm-libkrun → mvm-guest → mvm-core,
 # since mvm-core depends on mvm-libkrun for `Platform::has_libkrun`).
@@ -55,8 +49,14 @@ serde = { workspace = true }
 # composing the config, not by the supervisor consuming it. The
 # `libkrun-smoke` example keeps `mvm-guest` as a dev-dep because
 # dev-deps are excluded from cycle analysis.
-mvm-providers = { workspace = true, optional = true }
-serde_json = { workspace = true, optional = true }
+#
+# Plan 102 W6.A.5 moved the `mvm-libkrun-supervisor` bin out into
+# its own leaf crate (`crates/mvm-libkrun-supervisor/`) so the bin
+# can also depend on `mvm-supervisor` for the gateway audit
+# substrate. The optional `mvm-providers` + `serde_json` deps that
+# previously gated the bin moved with it. `serde_json` is still
+# needed in `[dev-dependencies]` for the `SupervisorConfig` /
+# `KrunContext` serde-roundtrip tests.
 # Plan 87 W2 — `passt` module probes $PATH for the `passt` binary
 # before spawning it. `which` is already in the workspace dep tree
 # (mvm-cli/mvm-build); pulling it in here keeps the dep graph
@@ -74,12 +74,11 @@ bindgen = "0.72"
 default = []
 # Opt-in: generate FFI bindings and link `libkrun`. Off by default so
 # the workspace builds on hosts without libkrun installed (CI fast lane,
-# Linux contributors who don't run the Tier 2 backend). Enables the
-# supervisor binary and its mvm-guest/mvm-providers/serde dep chain.
-libkrun-sys = [
-    "dep:mvm-providers",
-    "dep:serde_json",
-]
+# Linux contributors who don't run the Tier 2 backend). With the
+# supervisor bin moved to `mvm-libkrun-supervisor` (Plan 102 W6.A.5),
+# this feature only gates the FFI surface in lib.rs (`configure_*`,
+# `run_supervisor`, etc.); the bin pulls its own dep chain.
+libkrun-sys = []
 
 [dev-dependencies]
 # Plan 87 W2 — passt supervisor tests stage scratch dirs.
@@ -111,14 +110,10 @@ path = "examples/libkrun-smoke.rs"
 required-features = ["libkrun-sys"]
 
 # Plan 57 W4 — long-running supervisor process. One process per
-# libkrun guest. Reads a JSON `SupervisorConfig` on stdin, binds host
-# vsock listeners, writes its PID under ~/.mvm/vms/<name>/, then
-# `start_enter`s the guest. The W4.2 PR wires
-# `LibkrunBackend::start()` to spawn this binary.
-[[bin]]
-name = "mvm-libkrun-supervisor"
-path = "src/bin/mvm-libkrun-supervisor.rs"
-required-features = ["libkrun-sys"]
+# libkrun guest. The bin moved to its own leaf crate
+# (`crates/mvm-libkrun-supervisor/`) under Plan 102 W6.A.5 so it can
+# depend on `mvm-supervisor` (gateway audit substrate) without
+# closing the `mvm-supervisor → mvm-backend → mvm-libkrun` cycle.
 
 [lints]
 workspace = true

--- a/crates/mvm-libkrun/Cargo.toml
+++ b/crates/mvm-libkrun/Cargo.toml
@@ -41,6 +41,16 @@ tracing = "0.1"
 # itself. Compile cost is marginal; serde is already in nearly
 # every other workspace crate's dep graph.
 serde = { workspace = true }
+# Plan 102 W6.A.5 — `SupervisorConfig` carries the per-VM
+# ExecutionPlan + PolicyBundle as `Option<serde_json::Value>` so the
+# bin (`mvm-libkrun-supervisor`) can feed them into the bridge
+# factory without forcing mvm-libkrun to depend on mvm-plan / mvm-
+# policy (which would close the `mvm-libkrun ← mvm-core ← mvm-plan`
+# cycle). The bin crate, being a leaf, deserializes the Values into
+# typed `ExecutionPlan` / `PolicyBundle` since it can depend on
+# both. Always-on (not feature-gated) because `SupervisorConfig` is
+# always-on per the comment above.
+serde_json.workspace = true
 # We intentionally do NOT pull `mvm-guest` from regular deps: that
 # would close a cycle (mvm-core → mvm-libkrun → mvm-guest → mvm-core,
 # since mvm-core depends on mvm-libkrun for `Platform::has_libkrun`).

--- a/crates/mvm-libkrun/src/lib.rs
+++ b/crates/mvm-libkrun/src/lib.rs
@@ -21,6 +21,11 @@
 //! `mvm-backend` and `mvm-cli`.
 
 use std::path::Path;
+// Plan 102 W6.A.5 — `BridgeFds` carries OwnedFds; the
+// bridge-inserting configure path needs AsRawFd/FromRawFd to feed
+// libkrun's raw-fd API and to wrap socketpair(2) results.
+#[cfg(all(feature = "libkrun-sys", target_family = "unix"))]
+use std::os::fd::{AsRawFd, OwnedFd};
 
 #[cfg(feature = "libkrun-sys")]
 mod sys;
@@ -713,6 +718,272 @@ fn configure_with_gateway(ctx: &KrunContext) -> Result<(sys::Context, GatewayHan
         }
     };
     Ok((krun, handle))
+}
+
+// ============================================================================
+// Plan 102 W6.A.5 — bridge-inserting configure + run_supervisor_with_bridge
+// ============================================================================
+
+/// Endpoint fds the gateway audit bridge needs to splice between
+/// libkrun and the userspace network gateway (`passt` / `gvproxy`).
+///
+/// Constructed by [`configure_with_gateway_for_bridge`] alongside
+/// the libkrun `sys::Context` and a [`GatewayHandle`] that keeps
+/// the gateway child process alive. Consumed by the bridge factory
+/// closure passed to [`run_supervisor_with_bridge`], which builds
+/// `mvm_supervisor::gateway_bridge::BridgeEndpoints` from these
+/// values and calls `spawn_bridge_thread`.
+///
+/// Variants mirror `BridgeEndpoints` one-for-one so the bin can
+/// convert without case analysis: `Passt` → `BridgeEndpoints::Passt`,
+/// `LibkrunGvproxy` → `BridgeEndpoints::LibkrunGvproxy`.
+#[cfg(all(feature = "libkrun-sys", target_family = "unix"))]
+pub enum BridgeFds {
+    /// Linux libkrun + passt. Both sides are `SOCK_STREAM`:
+    /// - `gateway_fd` is the parent half of passt's socketpair;
+    ///   the bridge reads/writes raw virtio-net frames from passt.
+    /// - `supervisor_fd` is the supervisor half of an inner
+    ///   `socketpair(2)` whose other half was handed to libkrun via
+    ///   `add_net_unixstream_fd`; the bridge reads/writes the same
+    ///   raw frames toward libkrun.
+    ///
+    /// The bridge thread `tokio::io::copy_bidirectional`s the two
+    /// halves, sniffs first-byte-per-direction to emit
+    /// `gateway.flow_opened` audit entries, and emits paired
+    /// `gateway.flow_closed` on EOF or bridge error.
+    Passt {
+        gateway_fd: OwnedFd,
+        supervisor_fd: OwnedFd,
+    },
+    /// macOS libkrun + gvproxy. `SOCK_DGRAM`:
+    /// - `gvproxy_socket_path` is the path gvproxy bound its
+    ///   listener at on spawn.
+    /// - `supervisor_listen_path` is where libkrun has been told
+    ///   to connect (via `add_net_unixgram_path`); the bridge
+    ///   binds a `UnixDatagram` there inside its thread before
+    ///   libkrun's net device probes.
+    ///
+    /// libkrun is an anonymous unixgram client — the bridge caches
+    /// its autobind peer address from the first `recv_from`, then
+    /// uses `send_to(peer, …)` for the ingress direction.
+    LibkrunGvproxy {
+        gvproxy_socket_path: std::path::PathBuf,
+        supervisor_listen_path: std::path::PathBuf,
+    },
+}
+
+/// Plan 102 W6.A.5 — bridge-inserting variant of
+/// [`configure_with_gateway`]. Spawns passt / gvproxy, then
+/// interposes a supervisor-owned socket pair (`Passt`) or listener
+/// path (`LibkrunGvproxy`) between libkrun and the gateway so the
+/// gateway audit bridge can splice every byte through itself.
+///
+/// Refuses [`NetworkingMode::Tsi`] — TSI bypasses virtio-net
+/// entirely and violates the claim-10 no-bypass invariant (see
+/// ADR-058). Callers that need TSI must use the legacy
+/// [`run_supervisor`] entry point.
+#[cfg(all(feature = "libkrun-sys", target_family = "unix"))]
+fn configure_with_gateway_for_bridge(
+    ctx: &KrunContext,
+    bridge_scratch_dir: &std::path::Path,
+) -> Result<(sys::Context, GatewayHandle, BridgeFds), Error> {
+    // Claim-10 admission gate 2 — refuse TSI before any FFI call so
+    // the rejection is observable in unit tests that don't link
+    // libkrun (configure_pre_net calls `sys::Context::new`, which
+    // is real FFI). Moving the check up also avoids leaking a
+    // `sys::Context` on the refusal path.
+    if matches!(ctx.networking, NetworkingMode::Tsi) {
+        return Err(Error::Io {
+            context: "configure_with_gateway_for_bridge refuses NetworkingMode::Tsi: \
+                TSI bypasses virtio-net and violates the claim-10 no-bypass \
+                invariant (ADR-058). Use run_supervisor for legacy dev-mode VMs."
+                .to_string(),
+        });
+    }
+    let krun = configure_pre_net(ctx)?;
+    let (handle, bridge_fds) = match &ctx.networking {
+        NetworkingMode::Tsi => unreachable!("refused above"),
+        NetworkingMode::Passt { mac, scratch_dir } => {
+            let mut handle =
+                passt::spawn(std::path::Path::new(scratch_dir)).map_err(|e| Error::Io {
+                    context: format!("spawning passt for bridged NetworkingMode::Passt: {e}"),
+                })?;
+            // Take the passt-parent fd (faces passt). PasstHandle
+            // keeps the child alive via Drop; `take_socket` leaves
+            // the handle's `child` field in place.
+            let gateway_fd = handle.take_socket().ok_or_else(|| Error::Io {
+                context: "PasstHandle::take_socket returned None — \
+                            handle's parent_socket was already taken"
+                    .to_string(),
+            })?;
+            // Build the inner SOCK_STREAM socketpair. One half goes
+            // to libkrun; libkrun dups across `start_enter`, so we
+            // can close our copy of that half right after the
+            // add_net_* call. The other half stays with the bridge.
+            let (inner_libkrun, inner_supervisor) =
+                bridge_socketpair_stream().map_err(|e| Error::Io {
+                    context: format!("creating bridge socketpair (passt): {e}"),
+                })?;
+            krun.add_net_unixstream_fd(
+                inner_libkrun.as_raw_fd(),
+                mac,
+                sys::PASST_NET_FEATURES,
+                /* flags = */ 0,
+            )?;
+            // libkrun has dup'd; close our copy of the libkrun half.
+            drop(inner_libkrun);
+            (
+                GatewayHandle::Passt(handle),
+                BridgeFds::Passt {
+                    gateway_fd,
+                    supervisor_fd: inner_supervisor,
+                },
+            )
+        }
+        NetworkingMode::Gvproxy { mac, scratch_dir } => {
+            let handle =
+                gvproxy::spawn(std::path::Path::new(scratch_dir)).map_err(|e| Error::Io {
+                    context: format!("spawning gvproxy for bridged NetworkingMode::Gvproxy: {e}"),
+                })?;
+            // Snapshot gvproxy's bind path before moving the handle
+            // into GatewayHandle::Gvproxy — the bridge needs it to
+            // connect for the egress direction.
+            let gvproxy_socket_path = handle.socket_path().to_path_buf();
+            // Pick a fresh path inside the per-VM bridge scratch
+            // dir for the supervisor-side listener. The bridge
+            // thread binds it; libkrun's add_net_unixgram_path
+            // stores the path and connects lazily at net-device
+            // probe time (well after the bridge has bound).
+            std::fs::create_dir_all(bridge_scratch_dir).map_err(|e| Error::Io {
+                context: format!(
+                    "create bridge scratch dir {}: {e}",
+                    bridge_scratch_dir.display()
+                ),
+            })?;
+            let supervisor_listen_path = bridge_scratch_dir.join("bridge-libkrun.sock");
+            // Defensive: if a previous run left a stale socket
+            // file at this path the bridge bind would fail with
+            // EADDRINUSE. Pre-unlink under our umask.
+            let _ = std::fs::remove_file(&supervisor_listen_path);
+            krun.add_net_unixgram_path(
+                &supervisor_listen_path,
+                mac,
+                sys::PASST_NET_FEATURES,
+                sys::NET_FLAG_VFKIT | sys::NET_FLAG_DHCP_CLIENT,
+            )?;
+            (
+                GatewayHandle::Gvproxy(handle),
+                BridgeFds::LibkrunGvproxy {
+                    gvproxy_socket_path,
+                    supervisor_listen_path,
+                },
+            )
+        }
+    };
+    Ok((krun, handle, bridge_fds))
+}
+
+/// Build a `SOCK_STREAM` socketpair for the bridge's inner pair
+/// (libkrun ↔ supervisor). Mirrors `passt::make_socketpair` but
+/// kept here so the bridge insertion path doesn't need to leak
+/// passt internals into the bridge module signature.
+#[cfg(all(feature = "libkrun-sys", target_family = "unix"))]
+fn bridge_socketpair_stream() -> std::io::Result<(OwnedFd, OwnedFd)> {
+    use std::os::fd::FromRawFd;
+    let mut fds: [libc::c_int; 2] = [-1, -1];
+    // SAFETY: socketpair fills `fds` with two valid file descriptors
+    // on success (return 0); on failure (return -1) the array is
+    // untouched and we return errno.
+    let rc = unsafe { libc::socketpair(libc::AF_UNIX, libc::SOCK_STREAM, 0, fds.as_mut_ptr()) };
+    if rc != 0 {
+        return Err(std::io::Error::last_os_error());
+    }
+    // SAFETY: kernel returned two valid fds.
+    let a = unsafe { OwnedFd::from_raw_fd(fds[0]) };
+    let b = unsafe { OwnedFd::from_raw_fd(fds[1]) };
+    Ok((a, b))
+}
+
+/// Plan 102 W6.A.5 — supervisor entry point that runs the per-VM
+/// gateway audit bridge. Mirrors [`run_supervisor`] but interposes
+/// the bridge between libkrun and the userspace network gateway,
+/// then hands the resulting `BridgeFds` to a caller-supplied
+/// factory closure (which builds and spawns the bridge thread).
+///
+/// The factory runs synchronously after libkrun is configured but
+/// before `start_enter` is called. Typical implementation:
+///
+/// ```ignore
+/// run_supervisor_with_bridge(&cfg, |bridge_fds| {
+///     let endpoints = match bridge_fds {
+///         BridgeFds::Passt { gateway_fd, supervisor_fd } => {
+///             mvm_supervisor::gateway_bridge::BridgeEndpoints::Passt {
+///                 gateway_fd, supervisor_fd,
+///             }
+///         }
+///         BridgeFds::LibkrunGvproxy { gvproxy_socket_path, supervisor_listen_path } => {
+///             mvm_supervisor::gateway_bridge::BridgeEndpoints::LibkrunGvproxy {
+///                 gvproxy_socket_path, supervisor_listen_path,
+///             }
+///         }
+///     };
+///     let bridge_cfg = mvm_supervisor::gateway_bridge::BridgeConfig { /* … */ };
+///     let _join = mvm_supervisor::gateway_bridge::spawn_bridge_thread(endpoints, bridge_cfg);
+/// })?;
+/// ```
+///
+/// The bridge thread runs concurrently with `krun_start_enter`,
+/// which blocks until the guest exits and then calls `exit()` on
+/// the process — reaping the bridge thread without graceful join.
+///
+/// Claim-10 admission gates:
+/// 1. `cfg.validate_audit_substrate()` — refuses configs missing
+///    the audit-substrate paths or carrying an out-of-policy
+///    signing key.
+/// 2. `configure_with_gateway_for_bridge` refuses
+///    `NetworkingMode::Tsi`.
+#[cfg(feature = "libkrun-sys")]
+pub fn run_supervisor_with_bridge<F>(
+    cfg: &SupervisorConfig,
+    bridge_factory: F,
+) -> Result<std::convert::Infallible, Error>
+where
+    F: FnOnce(BridgeFds),
+{
+    // Claim-10 admission gate 1 — audit substrate fields.
+    cfg.validate_audit_substrate().map_err(|e| Error::Io {
+        context: format!("claim-10 admission: validate_audit_substrate refused: {e}"),
+    })?;
+
+    // Standard supervisor setup mirrors `run_supervisor`.
+    std::fs::create_dir_all(&cfg.vm_state_dir).map_err(|e| Error::Io {
+        context: format!("create_dir_all {}: {e}", cfg.vm_state_dir),
+    })?;
+    let pid_path = cfg.pid_file();
+    let pid = std::process::id().to_string();
+    std::fs::write(&pid_path, &pid).map_err(|e| Error::Io {
+        context: format!("write pid file {}: {e}", pid_path.display()),
+    })?;
+    if !is_available() {
+        return Err(Error::NotInstalled {
+            install_hint: install_hint(),
+        });
+    }
+
+    // Bridge scratch lives inside the per-VM state dir so it's
+    // reaped by the standard `mvmctl cache prune` walker.
+    let bridge_scratch_dir = std::path::PathBuf::from(&cfg.vm_state_dir).join("bridge");
+    let (krun, _gateway_handle, bridge_fds) =
+        configure_with_gateway_for_bridge(&cfg.krun, &bridge_scratch_dir)?;
+
+    // Hand the bridge fds to the factory. The factory spawns the
+    // bridge thread before we enter libkrun — so by the time
+    // `start_enter` brings up the guest's net device, the bridge
+    // is already serving / listening on both ends.
+    bridge_factory(bridge_fds);
+
+    install_shutdown_handler(&krun)?;
+    krun.start_enter()
 }
 
 /// Plan 87 — every part of `configure` that doesn't touch the
@@ -1723,5 +1994,54 @@ mod tests {
         let parsed: SupervisorConfig = serde_json::from_str(&json).expect("roundtrip");
         assert!(parsed.plan.is_some());
         assert!(parsed.bundle.is_none());
+    }
+
+    // ---------------------------------------------------------------
+    // Plan 102 W6.A.5 — bridge-inserting configure + BridgeFds.
+    // The configure_with_gateway_for_bridge tests below are gated on
+    // both `libkrun-sys` (needs the FFI bindings to compile) and
+    // unix (the gateway types are unix-family only).
+    // ---------------------------------------------------------------
+
+    #[cfg(all(feature = "libkrun-sys", target_family = "unix"))]
+    #[test]
+    fn bridge_socketpair_stream_returns_two_distinct_fds() {
+        use std::os::fd::AsRawFd;
+        let (a, b) = bridge_socketpair_stream().expect("socketpair");
+        assert_ne!(a.as_raw_fd(), b.as_raw_fd());
+        assert!(a.as_raw_fd() >= 0);
+        assert!(b.as_raw_fd() >= 0);
+    }
+
+    #[cfg(all(feature = "libkrun-sys", target_family = "unix"))]
+    #[test]
+    fn configure_with_gateway_for_bridge_refuses_tsi() {
+        // TSI bypasses virtio-net entirely and violates the
+        // claim-10 no-bypass invariant. The refusal must fire
+        // before configure_pre_net (which touches FFI) so the
+        // test passes on hosts without libkrun installed.
+        let ctx = KrunContext::new("vm", "/k", "/r"); // defaults to NetworkingMode::Tsi
+        assert!(matches!(ctx.networking, NetworkingMode::Tsi));
+        let scratch = std::path::PathBuf::from("/tmp/mvm-bridge-test-tsi-refusal");
+        let result = configure_with_gateway_for_bridge(&ctx, &scratch);
+        // Avoid `expect_err` because Result::expect_err requires Debug
+        // on the Ok type, and `sys::Context` is FFI-opaque without one.
+        let err = match result {
+            Err(e) => e,
+            Ok(_) => panic!("Tsi networking must be refused"),
+        };
+        match err {
+            Error::Io { context } => {
+                assert!(
+                    context.contains("Tsi"),
+                    "error context must name Tsi: {context}"
+                );
+                assert!(
+                    context.contains("claim-10"),
+                    "error context must cite claim-10: {context}"
+                );
+            }
+            other => panic!("expected Error::Io with Tsi message, got {other:?}"),
+        }
     }
 }

--- a/crates/mvm-libkrun/src/lib.rs
+++ b/crates/mvm-libkrun/src/lib.rs
@@ -995,6 +995,30 @@ pub struct SupervisorConfig {
     /// `~/.mvm/keys/` (no path-traversal) at admission.
     #[serde(default)]
     pub signing_key_path: Option<std::path::PathBuf>,
+
+    // --- Plan 102 W6.A.5: plan + bundle for bridge construction -----
+    //
+    // The bridge ([`mvm_supervisor::gateway_bridge::BridgeConfig`])
+    // needs `Arc<ExecutionPlan>` + `Option<Arc<PolicyBundle>>` to
+    // construct chained `AuditEntry`s. Carrying them as
+    // `Option<serde_json::Value>` (instead of the typed structs)
+    // avoids adding `mvm-plan` / `mvm-policy` to this crate's deps,
+    // which would close the `mvm-libkrun ← mvm-core ← mvm-plan`
+    // cycle. The leaf bin crate `mvm-libkrun-supervisor` can freely
+    // depend on both and deserializes the Values on the bridge side.
+    /// JSON-encoded [`mvm_plan::ExecutionPlan`] for this admission.
+    /// The bin deserializes into the typed value when building
+    /// `BridgeConfig.plan`. `None` ⇒ legacy non-bridge path
+    /// (`tenant_id` will also be `None` and
+    /// `validate_audit_substrate` will refuse).
+    #[serde(default)]
+    pub plan: Option<serde_json::Value>,
+    /// JSON-encoded [`mvm_policy::PolicyBundle`] for this admission.
+    /// Optional even when `plan` is set — workloads can run with
+    /// no bundle (matches the existing `Option<Arc<PolicyBundle>>`
+    /// in `BridgeConfig`).
+    #[serde(default)]
+    pub bundle: Option<serde_json::Value>,
 }
 
 impl SupervisorConfig {
@@ -1497,6 +1521,8 @@ mod tests {
                 "/tmp/mvm/audit/gateway-events-vm-a.sock",
             )),
             signing_key_path: Some(keys.join("host-signer.ed25519")),
+            plan: None,
+            bundle: None,
         }
     }
 
@@ -1615,6 +1641,8 @@ mod tests {
             gateway_audit_socket: None,
             gateway_events_socket: None,
             signing_key_path: None,
+            plan: None,
+            bundle: None,
         };
         let json = serde_json::to_string(&cfg_pre_w6a).unwrap();
         let parsed: SupervisorConfig =
@@ -1623,7 +1651,77 @@ mod tests {
         assert!(parsed.audit_dir.is_none());
         assert!(parsed.gateway_audit_socket.is_none());
         assert!(parsed.signing_key_path.is_none());
+        assert!(parsed.plan.is_none());
+        assert!(parsed.bundle.is_none());
         // But validate_audit_substrate must refuse it.
         assert!(parsed.validate_audit_substrate().is_err());
+    }
+
+    // Plan 102 W6.A.5 — `plan` + `bundle` fields on SupervisorConfig.
+    // Tests pin: (1) back-compat from JSON omitting both fields, (2)
+    // serde roundtrip with both fields populated, (3) the validate_*
+    // gate doesn't require them (validation covers paths only — the
+    // bridge factory consumes plan/bundle as soft data).
+
+    #[test]
+    fn supervisor_config_parses_pre_w6a5_json_missing_plan_and_bundle() {
+        // A pre-W6.A.5 caller would have omitted both new fields.
+        let json = r#"{
+            "krun": {
+                "name": "vm",
+                "kernel_path": "/k",
+                "rootfs_path": "/r",
+                "vcpus": 1,
+                "ram_mib": 256,
+                "kernel_cmdline": null,
+                "vsock_ports": [],
+                "extra_disks": [],
+                "console_output_path": null,
+                "vsock_socket_dir": null
+            },
+            "vm_state_dir": "/tmp/vms/vm",
+            "pid_file_name": null
+        }"#;
+        let parsed: SupervisorConfig =
+            serde_json::from_str(json).expect("pre-W6.A.5 JSON must still parse");
+        assert!(parsed.plan.is_none());
+        assert!(parsed.bundle.is_none());
+    }
+
+    #[test]
+    fn supervisor_config_roundtrips_with_plan_and_bundle_populated() {
+        let mut cfg = well_formed_supervisor_config();
+        // Stand-in JSON shapes — the bin crate is what decodes these
+        // into typed `ExecutionPlan` / `PolicyBundle`, so the
+        // mvm-libkrun layer only verifies the Values roundtrip.
+        cfg.plan = Some(serde_json::json!({
+            "tenant_id": "tenant-x",
+            "kind": "workload",
+            "version": 1
+        }));
+        cfg.bundle = Some(serde_json::json!({
+            "name": "default",
+            "version": 1,
+            "rules": []
+        }));
+        let json = serde_json::to_string(&cfg).expect("serialize");
+        let parsed: SupervisorConfig = serde_json::from_str(&json).expect("roundtrip");
+        assert_eq!(parsed.plan, cfg.plan);
+        assert_eq!(parsed.bundle, cfg.bundle);
+    }
+
+    #[test]
+    fn supervisor_config_plan_without_bundle_is_legal() {
+        let mut cfg = well_formed_supervisor_config();
+        cfg.plan = Some(serde_json::json!({ "kind": "workload" }));
+        cfg.bundle = None;
+        // No validation involvement — bridge factory tolerates the
+        // bundle being absent (matches `Option<Arc<PolicyBundle>>`
+        // in BridgeConfig). Confirm serde roundtrip preserves the
+        // shape without errors.
+        let json = serde_json::to_string(&cfg).expect("serialize");
+        let parsed: SupervisorConfig = serde_json::from_str(&json).expect("roundtrip");
+        assert!(parsed.plan.is_some());
+        assert!(parsed.bundle.is_none());
     }
 }

--- a/crates/mvm-libkrun/src/passt.rs
+++ b/crates/mvm-libkrun/src/passt.rs
@@ -137,10 +137,28 @@ impl PasstHandle {
     /// libkrun, dup, …). After this call [`Self::socket_fd`] panics.
     /// libkrun's `start_enter` semantics consume the fd implicitly,
     /// so most callers never need this.
+    ///
+    /// Consumes the handle, so the child process is killed via Drop
+    /// once the returned fd is dropped. Use [`Self::take_socket`]
+    /// when the caller wants to keep the child alive (e.g., the
+    /// gateway audit bridge that splices passt ↔ libkrun for the
+    /// guest's lifetime).
     pub fn into_socket(mut self) -> OwnedFd {
         self.parent_socket
             .take()
             .expect("PasstHandle::into_socket called twice")
+    }
+
+    /// Plan 102 W6.A.5 — take ownership of the parent socket
+    /// *without* consuming the handle. The PasstHandle keeps the
+    /// child alive (Drop on the handle still SIGTERMs the child),
+    /// so the bridge thread can splice the returned fd ↔ libkrun's
+    /// inner half for the guest's lifetime.
+    ///
+    /// Returns `None` on the second call (parent_socket already
+    /// taken). After this call [`Self::socket_fd`] panics on access.
+    pub fn take_socket(&mut self) -> Option<OwnedFd> {
+        self.parent_socket.take()
     }
 }
 
@@ -381,6 +399,28 @@ mod tests {
             args.iter().any(|arg| arg == "-P"),
             "passt args should keep the pid file path: {args:?}"
         );
+    }
+
+    /// Plan 102 W6.A.5 — `take_socket` returns the parent fd
+    /// without consuming the handle, so the child stays alive
+    /// (its SIGTERM-on-Drop continues to fire). A second call
+    /// returns `None`.
+    #[test]
+    fn take_socket_keeps_handle_alive() {
+        let Some(_) = locate_passt() else {
+            eprintln!("test skipped: passt not on PATH");
+            return;
+        };
+        let tmp = tempfile::tempdir().unwrap();
+        let mut handle = spawn(tmp.path()).expect("spawn passt");
+        let first = handle.take_socket();
+        assert!(first.is_some(), "first take_socket must yield the fd");
+        let second = handle.take_socket();
+        assert!(second.is_none(), "second take_socket must yield None");
+        // Drop should still kill the child cleanly — if take_socket
+        // had consumed the handle (like into_socket does), the child
+        // would already be unreachable here.
+        drop(handle);
     }
 
     /// Spawn passt and immediately drop the handle. Verifies the

--- a/crates/mvm-vz-supervisor/Package.swift
+++ b/crates/mvm-vz-supervisor/Package.swift
@@ -33,5 +33,15 @@ let package = Package(
             name: "mvm-vz-supervisor",
             path: "Sources/mvm-vz-supervisor"
         ),
+        // Plan 102 W6.A.5 — XCTest harness for the bridged gvproxy
+        // device + BridgeWorker (Network.swift). Uses
+        // `@testable import mvm_vz_supervisor` to reach internal
+        // symbols. The Swift module name is the executable target
+        // name with hyphens replaced by underscores.
+        .testTarget(
+            name: "MvmVzSupervisorTests",
+            dependencies: ["mvm-vz-supervisor"],
+            path: "Tests/MvmVzSupervisorTests"
+        ),
     ]
 )

--- a/crates/mvm-vz-supervisor/Sources/mvm-vz-supervisor/Config.swift
+++ b/crates/mvm-vz-supervisor/Sources/mvm-vz-supervisor/Config.swift
@@ -239,7 +239,20 @@ struct VsockConfig: Decodable, StrictKeys {
 // MARK: - Network
 
 enum NetworkConfig: Decodable {
-    case gvproxy(socketPath: String, mac: MacAddress)
+    /// Plan 102 W6.A.5 — `eventsIngestSocketPath` is where the
+    /// supervisor's claim-10 audit bridge listens for NDJSON
+    /// `FlowEventWire` entries. `nil` means the Rust side did not
+    /// request a bridge (legacy / dev mode); the data-plane fd
+    /// goes straight from gvproxy to Vz with no FlowEvent
+    /// emission. When `Some`, `Network.makeAttachment` interposes
+    /// a socketpair between Vz and gvproxy and emits the
+    /// handshake + FlowOpened / FlowClosed lines down a stream
+    /// connection to that path.
+    case gvproxy(
+        socketPath: String,
+        mac: MacAddress,
+        eventsIngestSocketPath: String?
+    )
 
     enum Kind: String, Decodable {
         case gvproxy
@@ -249,9 +262,12 @@ enum NetworkConfig: Decodable {
         case kind
         case socketPath = "socket_path"
         case mac
+        case eventsIngestSocketPath = "events_ingest_socket_path"
     }
 
-    static let knownKeys: Set<String> = ["kind", "socket_path", "mac"]
+    static let knownKeys: Set<String> = [
+        "kind", "socket_path", "mac", "events_ingest_socket_path",
+    ]
 
     init(from decoder: Decoder) throws {
         // Reuse strict-keys helper via free function (enum can't
@@ -271,7 +287,14 @@ enum NetworkConfig: Decodable {
                     debugDescription: "invalid MAC address: \(macString)"
                 )
             }
-            self = .gvproxy(socketPath: socketPath, mac: mac)
+            let eventsIngest = try c.decodeIfPresent(
+                String.self, forKey: .eventsIngestSocketPath
+            )
+            self = .gvproxy(
+                socketPath: socketPath,
+                mac: mac,
+                eventsIngestSocketPath: eventsIngest
+            )
         }
     }
 }

--- a/crates/mvm-vz-supervisor/Sources/mvm-vz-supervisor/Network.swift
+++ b/crates/mvm-vz-supervisor/Sources/mvm-vz-supervisor/Network.swift
@@ -24,8 +24,23 @@ import Darwin
 enum Network {
     static func makeAttachment(for config: NetworkConfig) throws -> VZNetworkDeviceConfiguration {
         switch config {
-        case .gvproxy(let socketPath, let mac):
-            return try makeGvproxyDevice(socketPath: socketPath, mac: mac)
+        case .gvproxy(let socketPath, let mac, let eventsIngestSocketPath):
+            // Plan 102 W6.A.5 — when the Rust side wired up the
+            // claim-10 audit substrate, `eventsIngestSocketPath` is
+            // set. The bridged device interposes a SOCK_DGRAM
+            // socketpair between Vz and gvproxy and emits FlowOpened
+            // / FlowClosed NDJSON entries to the supervisor's ingest
+            // socket. When `nil`, the legacy direct-attach path runs
+            // (no audit fan-out — dev mode / pre-W6.A.5 callers).
+            if let ingest = eventsIngestSocketPath {
+                return try makeBridgedGvproxyDevice(
+                    socketPath: socketPath,
+                    mac: mac,
+                    eventsIngestSocketPath: ingest
+                )
+            } else {
+                return try makeGvproxyDevice(socketPath: socketPath, mac: mac)
+            }
         }
     }
 
@@ -104,5 +119,300 @@ enum Network {
         device.macAddress = vzMac
 
         return device
+    }
+
+    // Plan 102 W6.A.5 — bridged gvproxy attachment that interposes
+    // a SOCK_DGRAM socketpair between Vz and gvproxy, connects to
+    // the Rust supervisor's events-ingest socket, sends the
+    // `MVM_VZ_BRIDGE_V1\n` handshake, and emits FlowOpened on
+    // first-packet-per-direction + FlowClosed("shutdown") on tear-
+    // down. The bridge runs as background DispatchSourceRead tasks
+    // pinned to the supervisor process lifetime; the supervisor's
+    // exit() reaps them.
+    private static func makeBridgedGvproxyDevice(
+        socketPath: String,
+        mac: MacAddress,
+        eventsIngestSocketPath: String
+    ) throws -> VZVirtioNetworkDeviceConfiguration {
+        // 1. Build the inner SOCK_DGRAM socketpair. `vzFd` is handed
+        //    to Vz via the file-handle attachment; `supFd` stays
+        //    here for the bridge to recv/send on.
+        var pair: [Int32] = [-1, -1]
+        let pairResult = pair.withUnsafeMutableBufferPointer { ptr in
+            Darwin.socketpair(AF_UNIX, SOCK_DGRAM, 0, ptr.baseAddress)
+        }
+        if pairResult != 0 {
+            throw SupervisorError.ioError(
+                "socketpair(AF_UNIX, SOCK_DGRAM) for bridged gvproxy",
+                underlying: POSIXErrno.current()
+            )
+        }
+        let vzFd = pair[0]
+        let supFd = pair[1]
+
+        // 2. Connect a second SOCK_DGRAM to gvproxy.
+        let gvFd = Darwin.socket(AF_UNIX, SOCK_DGRAM, 0)
+        if gvFd < 0 {
+            Darwin.close(vzFd)
+            Darwin.close(supFd)
+            throw SupervisorError.ioError(
+                "socket(AF_UNIX, SOCK_DGRAM) for gvproxy bridge leg",
+                underlying: POSIXErrno.current()
+            )
+        }
+        try bumpSocketBuffers(fd: vzFd)
+        try bumpSocketBuffers(fd: supFd)
+        try bumpSocketBuffers(fd: gvFd)
+        try connectUnix(fd: gvFd, path: socketPath, contextLabel: "gvproxy")
+
+        // 3. Connect the ingest stream and send the handshake.
+        let ingestFd = Darwin.socket(AF_UNIX, SOCK_STREAM, 0)
+        if ingestFd < 0 {
+            Darwin.close(vzFd)
+            Darwin.close(supFd)
+            Darwin.close(gvFd)
+            throw SupervisorError.ioError(
+                "socket(AF_UNIX, SOCK_STREAM) for events-ingest",
+                underlying: POSIXErrno.current()
+            )
+        }
+        try connectUnix(fd: ingestFd, path: eventsIngestSocketPath, contextLabel: "events-ingest")
+        let ingestHandle = FileHandle(fileDescriptor: ingestFd, closeOnDealloc: true)
+        try ingestHandle.write(contentsOf: Data(VZ_BRIDGE_HANDSHAKE.utf8))
+
+        // 4. Spawn the bridge worker. It owns supFd, gvFd, ingest.
+        BridgeWorker.start(
+            supFd: supFd,
+            gvFd: gvFd,
+            ingest: ingestHandle
+        )
+
+        // 5. Hand vzFd to Vz via the file-handle attachment.
+        let fileHandle = FileHandle(fileDescriptor: vzFd, closeOnDealloc: true)
+        let attachment = VZFileHandleNetworkDeviceAttachment(fileHandle: fileHandle)
+        let device = VZVirtioNetworkDeviceConfiguration()
+        device.attachment = attachment
+
+        let macString = mac.asArray
+            .map { String(format: "%02x", $0) }
+            .joined(separator: ":")
+        guard let vzMac = VZMACAddress(string: macString) else {
+            throw SupervisorError.configValidation(
+                "invalid MAC address for bridged network attachment: \(macString)"
+            )
+        }
+        device.macAddress = vzMac
+
+        return device
+    }
+}
+
+/// Plan 102 W6.A.5 — Swift side of the
+/// `mvm-supervisor::gateway_bridge::VZ_BRIDGE_HANDSHAKE` contract.
+/// The Rust ingest task reads exactly these bytes before parsing
+/// any NDJSON; a mismatch causes the connection to be rejected.
+let VZ_BRIDGE_HANDSHAKE = "MVM_VZ_BRIDGE_V1\n"
+
+/// Background bridge that:
+///   - Reads datagrams from Vz (`supFd`), forwards to gvproxy (`gvFd`).
+///   - Reads datagrams from gvproxy (`gvFd`), forwards to Vz (`supFd`).
+///   - On first byte per direction, writes a FlowOpened NDJSON line
+///     to `ingest`.
+///   - On any I/O error / EOF, writes paired FlowClosed lines and
+///     stops.
+///
+/// State is held in a single instance pinned by a module-level
+/// reference so it outlives `makeBridgedGvproxyDevice`'s return.
+/// Vz's supervisor process exit() reaps the dispatch sources.
+final class BridgeWorker {
+    /// Held in the module-level table so the worker outlives the
+    /// `makeBridgedGvproxyDevice` stack frame. Vz holds the vzFd
+    /// half; the worker holds supFd + gvFd + ingest and runs until
+    /// the process exits.
+    private static var live: [BridgeWorker] = []
+    private static let liveLock = NSLock()
+
+    private let supFd: Int32
+    private let gvFd: Int32
+    private let ingest: FileHandle
+    private let ingestLock = NSLock()
+    private var egressOpened = false
+    private var ingressOpened = false
+    private var egressClosed = false
+    private var ingressClosed = false
+    private let stateLock = NSLock()
+    private let flowIdEgress: String
+    private let flowIdIngress: String
+    private var supSource: DispatchSourceRead?
+    private var gvSource: DispatchSourceRead?
+
+    private init(supFd: Int32, gvFd: Int32, ingest: FileHandle) {
+        self.supFd = supFd
+        self.gvFd = gvFd
+        self.ingest = ingest
+        // Stable per-direction flow IDs. Real flows would be 5-tuple
+        // derived; here the bridge is one per VM so a single
+        // "egress" + "ingress" stream is the modeled granularity.
+        // UUIDs avoid collisions across concurrent VMs that share an
+        // audit chain file.
+        let uuid = UUID().uuidString
+        self.flowIdEgress = "vz-egress-\(uuid)"
+        self.flowIdIngress = "vz-ingress-\(uuid)"
+    }
+
+    static func start(supFd: Int32, gvFd: Int32, ingest: FileHandle) {
+        let worker = BridgeWorker(supFd: supFd, gvFd: gvFd, ingest: ingest)
+        liveLock.lock()
+        live.append(worker)
+        liveLock.unlock()
+        worker.run()
+    }
+
+    private func run() {
+        let queue = DispatchQueue(label: "mvm-vz-bridge", qos: .userInitiated)
+        let supSource = DispatchSource.makeReadSource(fileDescriptor: supFd, queue: queue)
+        let gvSource = DispatchSource.makeReadSource(fileDescriptor: gvFd, queue: queue)
+        self.supSource = supSource
+        self.gvSource = gvSource
+
+        supSource.setEventHandler { [weak self] in
+            self?.shuffle(from: self!.supFd, to: self!.gvFd, direction: .egress)
+        }
+        gvSource.setEventHandler { [weak self] in
+            self?.shuffle(from: self!.gvFd, to: self!.supFd, direction: .ingress)
+        }
+        supSource.setCancelHandler { [weak self] in
+            self?.markClosed(direction: .egress, reason: "bridge_error")
+        }
+        gvSource.setCancelHandler { [weak self] in
+            self?.markClosed(direction: .ingress, reason: "bridge_error")
+        }
+        supSource.resume()
+        gvSource.resume()
+    }
+
+    private enum Direction: String {
+        case egress
+        case ingress
+    }
+
+    private func shuffle(from src: Int32, to dst: Int32, direction: Direction) {
+        var buf = [UInt8](repeating: 0, count: 65_536)
+        let n = buf.withUnsafeMutableBufferPointer { ptr in
+            Darwin.recv(src, ptr.baseAddress, ptr.count, 0)
+        }
+        if n <= 0 {
+            // EOF or error — mark this direction closed.
+            markClosed(direction: direction, reason: n == 0 ? "eof" : "bridge_error")
+            return
+        }
+        // First-packet-per-direction → emit FlowOpened.
+        markOpenedIfFirst(direction: direction)
+        // Forward.
+        _ = buf.withUnsafeBufferPointer { ptr in
+            Darwin.send(dst, ptr.baseAddress, Int(n), 0)
+        }
+    }
+
+    private func markOpenedIfFirst(direction: Direction) {
+        stateLock.lock()
+        let alreadyOpened: Bool
+        switch direction {
+        case .egress:
+            alreadyOpened = egressOpened
+            egressOpened = true
+        case .ingress:
+            alreadyOpened = ingressOpened
+            ingressOpened = true
+        }
+        stateLock.unlock()
+        if alreadyOpened { return }
+        emitFlowOpened(direction: direction)
+    }
+
+    private func markClosed(direction: Direction, reason: String) {
+        stateLock.lock()
+        let alreadyClosed: Bool
+        switch direction {
+        case .egress:
+            alreadyClosed = egressClosed
+            egressClosed = true
+        case .ingress:
+            alreadyClosed = ingressClosed
+            ingressClosed = true
+        }
+        stateLock.unlock()
+        if alreadyClosed { return }
+        emitFlowClosed(direction: direction, reason: reason)
+    }
+
+    private func emitFlowOpened(direction: Direction) {
+        let flowId = direction == .egress ? flowIdEgress : flowIdIngress
+        let line = #"{"kind":"flow_opened","flow_id":"\#(flowId)","direction":"\#(direction.rawValue)"}"# + "\n"
+        ingestWrite(line)
+    }
+
+    private func emitFlowClosed(direction: Direction, reason: String) {
+        let flowId = direction == .egress ? flowIdEgress : flowIdIngress
+        let line = #"{"kind":"flow_closed","flow_id":"\#(flowId)","direction":"\#(direction.rawValue)","reason":"\#(reason)"}"# + "\n"
+        ingestWrite(line)
+    }
+
+    private func ingestWrite(_ line: String) {
+        ingestLock.lock()
+        defer { ingestLock.unlock() }
+        // Best-effort write — if the Rust supervisor disconnects we
+        // can't recover, but we shouldn't take down the data plane.
+        try? ingest.write(contentsOf: Data(line.utf8))
+    }
+}
+
+/// Bump SO_SNDBUF + SO_RCVBUF to 1 MiB so MTU-sized datagrams
+/// survive a queueing burst. Mirrors the bump in `makeGvproxyDevice`.
+private func bumpSocketBuffers(fd: Int32) throws {
+    var bufSize: Int32 = 1024 * 1024
+    let bufLen = socklen_t(MemoryLayout<Int32>.size)
+    _ = withUnsafePointer(to: &bufSize) { ptr in
+        Darwin.setsockopt(fd, SOL_SOCKET, SO_SNDBUF, ptr, bufLen)
+    }
+    _ = withUnsafePointer(to: &bufSize) { ptr in
+        Darwin.setsockopt(fd, SOL_SOCKET, SO_RCVBUF, ptr, bufLen)
+    }
+}
+
+/// `connect()` an AF_UNIX socket to `path`. Closes `fd` and throws
+/// on failure so the caller doesn't leak the fd on the error path.
+/// `contextLabel` appears in the error message for diagnostics.
+private func connectUnix(fd: Int32, path: String, contextLabel: String) throws {
+    var addr = sockaddr_un()
+    addr.sun_family = sa_family_t(AF_UNIX)
+    let pathBytes = path.utf8CString
+    let maxPath = MemoryLayout.size(ofValue: addr.sun_path)
+    if pathBytes.count > maxPath {
+        Darwin.close(fd)
+        throw SupervisorError.ioError(
+            "\(contextLabel) socket path too long: \(path)",
+            underlying: nil
+        )
+    }
+    withUnsafeMutablePointer(to: &addr.sun_path) { rawPtr in
+        rawPtr.withMemoryRebound(to: CChar.self, capacity: maxPath) { cstr in
+            for (i, b) in pathBytes.enumerated() {
+                cstr[i] = b
+            }
+        }
+    }
+    let result = withUnsafePointer(to: &addr) { addrPtr -> Int32 in
+        addrPtr.withMemoryRebound(to: sockaddr.self, capacity: 1) { sockPtr in
+            Darwin.connect(fd, sockPtr, socklen_t(MemoryLayout<sockaddr_un>.size))
+        }
+    }
+    if result != 0 {
+        let err = POSIXErrno.current()
+        Darwin.close(fd)
+        throw SupervisorError.ioError(
+            "connect() \(contextLabel) at \(path)",
+            underlying: err
+        )
     }
 }

--- a/crates/mvm-vz-supervisor/Sources/mvm-vz-supervisor/Network.swift
+++ b/crates/mvm-vz-supervisor/Sources/mvm-vz-supervisor/Network.swift
@@ -268,6 +268,28 @@ final class BridgeWorker {
         worker.run()
     }
 
+    /// Plan 102 W6.A.5 — test seam. Returns the worker so the test
+    /// can `cancelForTesting` it explicitly; production callers use
+    /// `start` and let the supervisor process's exit() reap the
+    /// dispatch sources.
+    static func startForTesting(supFd: Int32, gvFd: Int32, ingest: FileHandle) -> BridgeWorker {
+        let worker = BridgeWorker(supFd: supFd, gvFd: gvFd, ingest: ingest)
+        liveLock.lock()
+        live.append(worker)
+        liveLock.unlock()
+        worker.run()
+        return worker
+    }
+
+    /// Plan 102 W6.A.5 — test seam. Cancels both dispatch sources,
+    /// which fires the cancel handler and emits paired flow_closed
+    /// lines for any direction that was opened. Idempotent (cancel
+    /// is a no-op on an already-cancelled source).
+    func cancelForTesting() {
+        supSource?.cancel()
+        gvSource?.cancel()
+    }
+
     private func run() {
         let queue = DispatchQueue(label: "mvm-vz-bridge", qos: .userInitiated)
         let supSource = DispatchSource.makeReadSource(fileDescriptor: supFd, queue: queue)
@@ -348,14 +370,14 @@ final class BridgeWorker {
 
     private func emitFlowOpened(direction: Direction) {
         let flowId = direction == .egress ? flowIdEgress : flowIdIngress
-        let line = #"{"kind":"flow_opened","flow_id":"\#(flowId)","direction":"\#(direction.rawValue)"}"# + "\n"
-        ingestWrite(line)
+        ingestWrite(formatFlowOpenedLine(flowId: flowId, direction: direction.rawValue))
     }
 
     private func emitFlowClosed(direction: Direction, reason: String) {
         let flowId = direction == .egress ? flowIdEgress : flowIdIngress
-        let line = #"{"kind":"flow_closed","flow_id":"\#(flowId)","direction":"\#(direction.rawValue)","reason":"\#(reason)"}"# + "\n"
-        ingestWrite(line)
+        ingestWrite(formatFlowClosedLine(
+            flowId: flowId, direction: direction.rawValue, reason: reason
+        ))
     }
 
     private func ingestWrite(_ line: String) {
@@ -378,6 +400,18 @@ private func bumpSocketBuffers(fd: Int32) throws {
     _ = withUnsafePointer(to: &bufSize) { ptr in
         Darwin.setsockopt(fd, SOL_SOCKET, SO_RCVBUF, ptr, bufLen)
     }
+}
+
+/// Plan 102 W6.A.5 — JSON line formatters used by `BridgeWorker`
+/// to write FlowEventWire entries to the ingest stream. Free
+/// functions so XCTests can pin the exact wire shape without
+/// reaching into BridgeWorker's private state.
+func formatFlowOpenedLine(flowId: String, direction: String) -> String {
+    #"{"kind":"flow_opened","flow_id":"\#(flowId)","direction":"\#(direction)"}"# + "\n"
+}
+
+func formatFlowClosedLine(flowId: String, direction: String, reason: String) -> String {
+    #"{"kind":"flow_closed","flow_id":"\#(flowId)","direction":"\#(direction)","reason":"\#(reason)"}"# + "\n"
 }
 
 /// `connect()` an AF_UNIX socket to `path`. Closes `fd` and throws

--- a/crates/mvm-vz-supervisor/Tests/MvmVzSupervisorTests/BridgeWorkerTests.swift
+++ b/crates/mvm-vz-supervisor/Tests/MvmVzSupervisorTests/BridgeWorkerTests.swift
@@ -1,0 +1,352 @@
+// Plan 102 W6.A.5 — XCTest harness for the Vz bridge (Network.swift).
+//
+// Five tests covering the bridge's wire contract:
+//
+//   1. testHandshakeConstantMatchesRustSide — the handshake string
+//      `MVM_VZ_BRIDGE_V1\n` must agree byte-for-byte with
+//      `mvm_supervisor::gateway_bridge::VZ_BRIDGE_HANDSHAKE`. A drift
+//      here would silently break every Vz audit chain on a fresh
+//      `mvmctl up`.
+//   2. testFlowOpenedJsonShape — JSON line for a `flow_opened` event
+//      must match the FlowEventWire serde shape exactly. The Rust
+//      ingest task uses `serde_json::from_str(line.trim_end())`, so
+//      anything off (key order doesn't matter, but field names +
+//      types do) is rejected silently.
+//   3. testFlowClosedJsonShape — same pin for `flow_closed`.
+//   4. testBridgeWorkerShufflesDatagramsAndEmitsFlowOpened — full
+//      integration. Stands up fake-gvproxy + fake-ingest sockets,
+//      runs the BridgeWorker, writes a datagram, asserts (a) the
+//      datagram makes it through, (b) a `flow_opened` line lands on
+//      the ingest stand-in.
+//   5. testBridgeWorkerEmitsFlowClosedOnEof — closes the Vz-side fd
+//      end, waits, asserts a `flow_closed` with `reason: eof`
+//      appears on the ingest stand-in.
+
+import Darwin
+import Foundation
+import XCTest
+
+@testable import mvm_vz_supervisor
+
+final class BridgeWorkerTests: XCTestCase {
+
+    // MARK: - 1. Handshake constant pin
+
+    func testHandshakeConstantMatchesRustSide() {
+        // mvm_supervisor::gateway_bridge::VZ_BRIDGE_HANDSHAKE
+        // (gateway_bridge.rs:776) — must match exactly.
+        XCTAssertEqual(VZ_BRIDGE_HANDSHAKE, "MVM_VZ_BRIDGE_V1\n")
+        XCTAssertEqual(
+            Data(VZ_BRIDGE_HANDSHAKE.utf8).count,
+            17,
+            "Rust side reads exactly 17 bytes before parsing NDJSON"
+        )
+    }
+
+    // MARK: - 2. flow_opened wire shape
+
+    func testFlowOpenedJsonShape() {
+        let line = formatFlowOpenedLine(flowId: "vz-egress-abc", direction: "egress")
+        XCTAssertTrue(line.hasSuffix("\n"), "NDJSON requires trailing newline")
+        let trimmed = String(line.dropLast())
+        // Parse + verify the field shape — order-independent.
+        guard
+            let data = trimmed.data(using: .utf8),
+            let obj = try? JSONSerialization.jsonObject(with: data) as? [String: Any]
+        else {
+            return XCTFail("flow_opened line is not valid JSON: \(trimmed)")
+        }
+        XCTAssertEqual(obj["kind"] as? String, "flow_opened")
+        XCTAssertEqual(obj["flow_id"] as? String, "vz-egress-abc")
+        XCTAssertEqual(obj["direction"] as? String, "egress")
+        // No "reason" key on flow_opened — Rust's FlowEventWire
+        // tagged enum rejects unknown fields on this variant.
+        XCTAssertNil(obj["reason"])
+    }
+
+    // MARK: - 3. flow_closed wire shape
+
+    func testFlowClosedJsonShape() {
+        let line = formatFlowClosedLine(
+            flowId: "vz-ingress-xyz",
+            direction: "ingress",
+            reason: "eof"
+        )
+        XCTAssertTrue(line.hasSuffix("\n"))
+        let trimmed = String(line.dropLast())
+        guard
+            let data = trimmed.data(using: .utf8),
+            let obj = try? JSONSerialization.jsonObject(with: data) as? [String: Any]
+        else {
+            return XCTFail("flow_closed line is not valid JSON: \(trimmed)")
+        }
+        XCTAssertEqual(obj["kind"] as? String, "flow_closed")
+        XCTAssertEqual(obj["flow_id"] as? String, "vz-ingress-xyz")
+        XCTAssertEqual(obj["direction"] as? String, "ingress")
+        XCTAssertEqual(obj["reason"] as? String, "eof")
+    }
+
+    // MARK: - 4. End-to-end shuffle + flow_opened
+
+    func testBridgeWorkerShufflesDatagramsAndEmitsFlowOpened() throws {
+        let env = try BridgeTestEnv.make()
+        defer { env.teardown() }
+
+        // Drive an egress datagram: vzPeer → bridge.supFd → bridge.gvFd → gvproxyPeer.
+        let payload = Data("hello-egress".utf8)
+        let sent = payload.withUnsafeBytes { ptr in
+            Darwin.send(env.vzPeer, ptr.baseAddress, ptr.count, 0)
+        }
+        XCTAssertEqual(sent, payload.count, "vzPeer send")
+
+        // Wait for the bridge to forward + emit flow_opened.
+        let received = try env.waitForDatagramOnGvproxyPeer(maxWait: 1.0)
+        XCTAssertEqual(received, payload, "egress payload forwarded byte-for-byte")
+
+        let line = try env.waitForIngestLine(maxWait: 1.0)
+        let obj = try Self.parseLine(line)
+        XCTAssertEqual(obj["kind"] as? String, "flow_opened")
+        XCTAssertEqual(obj["direction"] as? String, "egress")
+    }
+
+    // MARK: - 5. flow_closed on EOF
+
+    func testBridgeWorkerEmitsFlowClosedOnEof() throws {
+        let env = try BridgeTestEnv.make()
+        defer { env.teardown() }
+
+        // First push a datagram so flow_opened fires (otherwise
+        // BridgeWorker has no opened-state to close).
+        let payload = Data("seed".utf8)
+        _ = payload.withUnsafeBytes { ptr in
+            Darwin.send(env.vzPeer, ptr.baseAddress, ptr.count, 0)
+        }
+        _ = try env.waitForDatagramOnGvproxyPeer(maxWait: 1.0)
+        let opened = try env.waitForIngestLine(maxWait: 1.0)
+        XCTAssertTrue(opened.contains("flow_opened"))
+
+        // Close the Vz-side peer. DispatchSourceRead on the
+        // supervisor's supFd will see the close + run the cancel
+        // handler, which marks `egress` closed.
+        Darwin.close(env.vzPeer)
+        env.vzPeer = -1
+
+        // The cancel handler is plumbed via the dispatch source's
+        // cancelHandler. To deterministically trigger it without
+        // depending on macOS read-EOF semantics for AF_UNIX
+        // SOCK_DGRAM (which doesn't always fire on the read side
+        // when only the peer closes), we trigger the close path by
+        // closing the bridge's supFd too — a clean tear-down. The
+        // BridgeWorker's cancel handler runs and emits flow_closed.
+        env.worker.cancelForTesting()
+
+        let closed = try env.waitForIngestLine(maxWait: 1.0)
+        let obj = try Self.parseLine(closed)
+        XCTAssertEqual(obj["kind"] as? String, "flow_closed")
+        let reason = obj["reason"] as? String ?? ""
+        XCTAssertTrue(
+            reason == "eof" || reason == "bridge_error",
+            "expected eof or bridge_error on test cancel, got \(reason)"
+        )
+    }
+
+    // MARK: - Helpers
+
+    private static func parseLine(_ line: String) throws -> [String: Any] {
+        let trimmed = line.hasSuffix("\n") ? String(line.dropLast()) : line
+        guard
+            let data = trimmed.data(using: .utf8),
+            let obj = try JSONSerialization.jsonObject(with: data) as? [String: Any]
+        else {
+            throw NSError(
+                domain: "BridgeWorkerTests",
+                code: 1,
+                userInfo: [NSLocalizedDescriptionKey: "could not parse line as JSON: \(trimmed)"]
+            )
+        }
+        return obj
+    }
+}
+
+// MARK: - Test environment
+
+/// Fixture that stands up a BridgeWorker connected to fake gvproxy
+/// + fake ingest socket peers under a temp directory. Teardown
+/// closes all fds + removes the temp dir.
+private final class BridgeTestEnv {
+    var supFd: Int32 = -1
+    var vzPeer: Int32 = -1
+    var gvFd: Int32 = -1
+    var gvproxyPeer: Int32 = -1
+    var ingestListenerFd: Int32 = -1
+    var ingestSupervisorFd: Int32 = -1
+    var ingestPeerFd: Int32 = -1
+    var tempDir: URL
+    let worker: BridgeWorker
+    var ingestBuffer: Data = Data()
+    private let ingestQueue = DispatchQueue(label: "BridgeTestEnv.ingest")
+
+    private init(
+        supFd: Int32, vzPeer: Int32,
+        gvFd: Int32, gvproxyPeer: Int32,
+        ingestListenerFd: Int32, ingestSupervisorFd: Int32, ingestPeerFd: Int32,
+        tempDir: URL,
+        worker: BridgeWorker
+    ) {
+        self.supFd = supFd
+        self.vzPeer = vzPeer
+        self.gvFd = gvFd
+        self.gvproxyPeer = gvproxyPeer
+        self.ingestListenerFd = ingestListenerFd
+        self.ingestSupervisorFd = ingestSupervisorFd
+        self.ingestPeerFd = ingestPeerFd
+        self.tempDir = tempDir
+        self.worker = worker
+    }
+
+    static func make() throws -> BridgeTestEnv {
+        let tempDir = URL(
+            fileURLWithPath: NSTemporaryDirectory()
+        ).appendingPathComponent("bridge-\(UUID().uuidString)")
+        try FileManager.default.createDirectory(at: tempDir, withIntermediateDirectories: true)
+
+        // Vz-side socketpair (vzPeer ↔ supFd). vzPeer is the test's
+        // hand-hold; supFd is the bridge's read side facing Vz.
+        var vzPair: [Int32] = [-1, -1]
+        let vzRc = vzPair.withUnsafeMutableBufferPointer { ptr in
+            Darwin.socketpair(AF_UNIX, SOCK_DGRAM, 0, ptr.baseAddress)
+        }
+        guard vzRc == 0 else {
+            throw NSError(
+                domain: "BridgeTestEnv",
+                code: Int(errno),
+                userInfo: [NSLocalizedDescriptionKey: "vz socketpair failed"]
+            )
+        }
+        let vzPeer = vzPair[0]
+        let supFd = vzPair[1]
+
+        // gvproxy-side socketpair (gvFd ↔ gvproxyPeer). The
+        // production code connects gvFd to a real gvproxy listener;
+        // for the test, we splice in a socketpair so we can directly
+        // observe what the bridge sends.
+        var gvPair: [Int32] = [-1, -1]
+        let gvRc = gvPair.withUnsafeMutableBufferPointer { ptr in
+            Darwin.socketpair(AF_UNIX, SOCK_DGRAM, 0, ptr.baseAddress)
+        }
+        guard gvRc == 0 else {
+            Darwin.close(vzPeer)
+            Darwin.close(supFd)
+            throw NSError(
+                domain: "BridgeTestEnv",
+                code: Int(errno),
+                userInfo: [NSLocalizedDescriptionKey: "gv socketpair failed"]
+            )
+        }
+        let gvFd = gvPair[0]
+        let gvproxyPeer = gvPair[1]
+
+        // Ingest stand-in: a SOCK_STREAM socketpair. ingestPeerFd is
+        // what the test reads from; ingestSupervisorFd is what
+        // BridgeWorker writes to via the FileHandle.
+        var ingestPair: [Int32] = [-1, -1]
+        let ingestRc = ingestPair.withUnsafeMutableBufferPointer { ptr in
+            Darwin.socketpair(AF_UNIX, SOCK_STREAM, 0, ptr.baseAddress)
+        }
+        guard ingestRc == 0 else {
+            Darwin.close(vzPeer); Darwin.close(supFd)
+            Darwin.close(gvFd); Darwin.close(gvproxyPeer)
+            throw NSError(
+                domain: "BridgeTestEnv",
+                code: Int(errno),
+                userInfo: [NSLocalizedDescriptionKey: "ingest socketpair failed"]
+            )
+        }
+        let ingestSupervisorFd = ingestPair[0]
+        let ingestPeerFd = ingestPair[1]
+
+        let ingestHandle = FileHandle(fileDescriptor: ingestSupervisorFd, closeOnDealloc: false)
+        let worker = BridgeWorker.startForTesting(
+            supFd: supFd,
+            gvFd: gvFd,
+            ingest: ingestHandle
+        )
+
+        return BridgeTestEnv(
+            supFd: supFd, vzPeer: vzPeer,
+            gvFd: gvFd, gvproxyPeer: gvproxyPeer,
+            ingestListenerFd: -1,
+            ingestSupervisorFd: ingestSupervisorFd,
+            ingestPeerFd: ingestPeerFd,
+            tempDir: tempDir,
+            worker: worker
+        )
+    }
+
+    func teardown() {
+        worker.cancelForTesting()
+        for fd in [vzPeer, supFd, gvFd, gvproxyPeer, ingestSupervisorFd, ingestPeerFd] {
+            if fd >= 0 { Darwin.close(fd) }
+        }
+        try? FileManager.default.removeItem(at: tempDir)
+    }
+
+    /// Block up to `maxWait` seconds for a datagram on `gvproxyPeer`,
+    /// returning its payload.
+    func waitForDatagramOnGvproxyPeer(maxWait: TimeInterval) throws -> Data {
+        let deadline = Date().addingTimeInterval(maxWait)
+        var buf = [UInt8](repeating: 0, count: 65536)
+        while Date() < deadline {
+            var pollFd = pollfd(fd: gvproxyPeer, events: Int16(POLLIN), revents: 0)
+            let pr = withUnsafeMutablePointer(to: &pollFd) { ptr in
+                Darwin.poll(ptr, 1, 50)
+            }
+            if pr > 0 && (pollFd.revents & Int16(POLLIN)) != 0 {
+                let n = buf.withUnsafeMutableBufferPointer { ptr in
+                    Darwin.recv(gvproxyPeer, ptr.baseAddress, ptr.count, 0)
+                }
+                if n > 0 {
+                    return Data(buf[0..<Int(n)])
+                }
+            }
+        }
+        throw NSError(
+            domain: "BridgeTestEnv",
+            code: 2,
+            userInfo: [NSLocalizedDescriptionKey: "timeout waiting for datagram on gvproxyPeer"]
+        )
+    }
+
+    /// Block up to `maxWait` seconds for a complete NDJSON line on
+    /// the ingest peer, returning it (including the trailing
+    /// newline).
+    func waitForIngestLine(maxWait: TimeInterval) throws -> String {
+        let deadline = Date().addingTimeInterval(maxWait)
+        var buf = [UInt8](repeating: 0, count: 4096)
+        while Date() < deadline {
+            // Check whether the buffer already has a newline.
+            if let nl = ingestBuffer.firstIndex(of: UInt8(ascii: "\n")) {
+                let line = ingestBuffer[..<(nl + 1)]
+                ingestBuffer.removeSubrange(..<(nl + 1))
+                return String(data: line, encoding: .utf8) ?? ""
+            }
+            var pollFd = pollfd(fd: ingestPeerFd, events: Int16(POLLIN), revents: 0)
+            let pr = withUnsafeMutablePointer(to: &pollFd) { ptr in
+                Darwin.poll(ptr, 1, 50)
+            }
+            if pr > 0 && (pollFd.revents & Int16(POLLIN)) != 0 {
+                let n = buf.withUnsafeMutableBufferPointer { ptr in
+                    Darwin.recv(ingestPeerFd, ptr.baseAddress, ptr.count, 0)
+                }
+                if n > 0 {
+                    ingestBuffer.append(contentsOf: buf[0..<Int(n)])
+                }
+            }
+        }
+        throw NSError(
+            domain: "BridgeTestEnv",
+            code: 3,
+            userInfo: [NSLocalizedDescriptionKey: "timeout waiting for ingest line"]
+        )
+    }
+}

--- a/public/src/content/docs/reference/architecture.md
+++ b/public/src/content/docs/reference/architecture.md
@@ -121,6 +121,66 @@ Extends `ShellEnvironment` for fleet orchestration:
 - `ensure_bridge()`, `setup_tap()`, `teardown_tap()`
 - `record_revision()`
 
+### Supervisor: the two layers
+
+"Supervisor" is reused at two distinct layers in this codebase. Knowing which one a given file or PR talks about removes most of the confusion when reading the source.
+
+#### 1. `mvm-supervisor` — host-side admission and audit substrate
+
+The library at `crates/mvm-supervisor/`, consumed by `mvm-cli` when you run `mvmctl up`. It turns a "I want to run this workload" intent into a launched, audited microVM on a single host. Responsibilities, all on the host (not in the guest):
+
+- **Admit an `ExecutionPlan`** — verify the Ed25519 signature, enforce the validity window, refuse replays via a nonce ledger. See `admit_for_run` and `host_signer::load_or_init_at`.
+- **Chain-sign audit events** — append `plan.admitted` / `plan.launched` / `plan.failed` / `plan.oci_provenance` / `gateway.flow_opened` / `gateway.flow_closed` entries to `~/.mvm/audit/<tenant>.jsonl`, each hash-linked to the previous (`AuditEntry`, `FileAuditSigner` under cross-process `flock`, `verify_audit_chain`).
+- **Run the gateway audit bridge** — splice every guest network byte through an in-process bridge that emits flow events into the chain (`gateway_bridge`, `gateway_audit`). The bridge is the load-bearing piece of [security claim 10](/security/ci-claims).
+- **Verify sealed deps volumes**, **resolve policy bundles**, **enforce default-deny network policy**, **run the L4 / L7 egress proxies**.
+
+It does not link libkrun, does not call `krun_start_enter`, and never owns the guest's lifetime directly. It tells a per-VM child process to do that.
+
+#### 2. `mvm-libkrun-supervisor` (and `mvm-vz-supervisor`) — per-VM long-lived processes
+
+The bin at `crates/mvm-libkrun-supervisor/` (and the Swift sibling at `crates/mvm-vz-supervisor/`) is the actual process that owns one running guest. **One process per VM**, by design:
+
+> `krun_start_enter` calls `exit()` on the calling process when the guest powers off. An in-process registry would tear down every other libkrun guest the parent `mvmctl` is supervising. One process per VM scopes the `exit()` to a single supervisor, so the parent `mvmctl` returns immediately after spawning and survives a guest shutdown.
+
+Lifecycle:
+
+1. `mvm-backend::LibkrunBackend::start()` spawns the binary with a JSON `SupervisorConfig` piped to stdin.
+2. The bin ad-hoc-codesigns itself for `Hypervisor.framework` on macOS, creates the per-VM state dir, writes its PID file.
+3. Configures libkrun (`configure_with_gateway`), spawns the userspace network gateway (`passt` on Linux, `gvproxy` on macOS), spawns the gateway audit bridge.
+4. Calls `krun_start_enter`, which blocks until the guest exits, then `exit()`s.
+
+When `mvmctl stop <vm>` runs it reads the PID file and `SIGTERM`s this process. `mvm-vz-supervisor` is the parallel Swift binary that fills the same role on macOS 26+ Apple Silicon (Vz backend).
+
+#### How they relate
+
+The host-side `mvm-supervisor` (layer 1) builds a `SupervisorConfig`, spawns the per-VM bin (layer 2) with that JSON, and returns. The audit chain bridges the two layers: admission events (`plan.admitted` etc.) are written by layer 1 *before* layer 2 starts; runtime events (`gateway.flow_*`) are written by the bridge running *inside* layer 2. Both append to the same `~/.mvm/audit/<tenant>.jsonl` under cross-process `flock`, so the chain stays linear and `mvmctl audit verify` can validate it end-to-end.
+
+```
+mvmctl up <flake>
+  └── mvm-supervisor (layer 1, in mvmctl process)
+        │  • verifies ExecutionPlan signature
+        │  • emits plan.admitted to ~/.mvm/audit/<tenant>.jsonl
+        │  • resolves policy bundle, installs host firewall
+        │  • spawns ↓
+        └── mvm-libkrun-supervisor (layer 2, one process per VM)
+              • boots libkrun guest
+              • bridges guest network through gateway_bridge
+              • emits gateway.flow_opened / flow_closed
+                to the same ~/.mvm/audit/<tenant>.jsonl
+              • exits when the guest exits
+```
+
+#### Why the split exists at all (the mvm / mvmd boundary)
+
+This repo (`mvm`) is the single-host runtime — one host trusts itself with the hypervisor and the host-signer key. `mvm-supervisor` enforces the security claims at that boundary.
+
+Multi-tenant fleet orchestration lives in the separate [mvmd](https://github.com/tinylabscom/mvmd) repo. mvmd does *not* consume `mvm-supervisor` as a library — it has its own gateway (`mvmd-gateway`), its own runtime (`mvmd-runtime`), and its own admission flow that ultimately calls down to mvm-tier backends. The cross-repo split is intentional per the [threat model](/security/threat-model) (ADR-002) and the [CI-enforced security claims](/security/ci-claims) (claim 10 substrate, ADR-058):
+
+- `mvm-supervisor` ↔ per-VM, per-host, per-tenant admission + audit (security claims 8, 9, 10).
+- `mvmd` ↔ cross-VM, cross-host, cross-tenant orchestration. mvmd's Plan 50 (network manager) layers per-tenant gateway pools, egress quotas, cross-tenant traffic isolation, and tenant-level audit rollup *above* mvm-supervisor's per-VM substrate.
+
+A workload running through mvmd transits both layers: mvmd's admission decides which host the workload lands on and sets cross-tenant policy; mvm-supervisor on that host then runs the per-VM admission + audit substrate this doc describes.
+
 ### Supervisor Enforcement
 
 `mvm-supervisor` owns the host-side policy slots used after plan admission:

--- a/specs/plans/102-gateway-audit-substrate-impl.md
+++ b/specs/plans/102-gateway-audit-substrate-impl.md
@@ -178,25 +178,74 @@ to compile-verify, and the Rust `configure_with_gateway` split
 (needed for libkrun fd interception) is invasive enough to want
 its own focused PR.
 
-- [ ] `crates/mvm-vz-supervisor/Sources/mvm-vz-supervisor/Network.swift`
-      — `makeGvproxyDevice` rewrite (socketpair + ingest connect
-      with `MVM_VZ_BRIDGE_V1\n` handshake + `Task.detached` splice
-      loops + NDJSON emit on first packet / shutdown)
-- [ ] Swift XCTest harness (5 tests: shuffles_datagrams,
-      emits_flow_opened, emits_flow_closed, handshake_sent_first,
-      reconnect)
-- [ ] `crates/mvm-backend/src/vz.rs:809-812` — populate `network`
-      with `NetworkConfig::Gvproxy { events_ingest_socket_path:
-      Some(...) }` sourced from `mvm_data_dir() + audit/`
-- [ ] `crates/mvm-backend/src/libkrun.rs` — populate `SupervisorConfig`
-      audit fields from `ExecutionPlan` (tenant_id) + `mvm_data_dir()`
-- [ ] Split `configure_with_gateway` into `configure_pre_net` +
-      bridge-socketpair-insertion in `crates/mvm-libkrun/src/lib.rs`
-- [ ] Add `pub fn run_supervisor_with_bridge<F>(cfg, factory)` in
-      mvm-libkrun, swap `mvm-libkrun-supervisor::main` from
-      `run_supervisor` to `run_supervisor_with_bridge`
+Status as of 2026-05-27 — substrate wire-up landed under one PR
+on `worktree-plan-102-w6a-5-wire-up` (8 commits). Producer
+activation + live smokes are tracked separately as Phase 3c.
+
+- [x] `crates/mvm-vz-supervisor/Sources/mvm-vz-supervisor/Network.swift`
+      — `makeBridgedGvproxyDevice` added alongside the legacy
+      `makeGvproxyDevice` (selection keyed on
+      `eventsIngestSocketPath: nil` vs `Some`). Socketpair
+      interposition + ingest connect with `MVM_VZ_BRIDGE_V1\n`
+      handshake + `DispatchSourceRead` splice loops + NDJSON emit
+      on first packet / shutdown.
+- [x] Swift XCTest harness — 5 tests at
+      `crates/mvm-vz-supervisor/Tests/MvmVzSupervisorTests/BridgeWorkerTests.swift`
+      covering handshake constant pin, `flow_opened` wire shape,
+      `flow_closed` wire shape, end-to-end shuffle + emit, and
+      flow_closed on cancel. `swift test` green.
+- [x] `crates/mvm-backend/src/vz.rs` — populate `network` with
+      `NetworkConfig::Gvproxy { events_ingest_socket_path:
+      Some(...) }` sourced from `mvm_data_dir() + audit/`. New
+      module `host_gvproxy.rs` owns the parent-process gvproxy
+      lifecycle: detached spawn, PID-file sidecar, MAC derivation,
+      `VzBackend::stop` tear-down.
+- [ ] `crates/mvm-backend/src/libkrun.rs` — populate
+      `SupervisorConfig` audit fields from `ExecutionPlan`
+      (tenant_id) + `mvm_data_dir()`. **Deferred to Phase 3c
+      follow-up PR.** Touches `mvm_core::vm_backend::VmStartConfig`
+      + ~6 call sites in mvm-cli to thread the `AdmittedPlan`
+      through to backends. Until this lands the substrate code is
+      dormant — every spawn falls through to the legacy
+      `run_supervisor` path because `cfg.tenant_id` stays `None`.
+- [/] Split `configure_with_gateway` into `configure_pre_net` +
+      bridge-socketpair-insertion in `crates/mvm-libkrun/src/lib.rs`.
+      `configure_pre_net` already existed pre-PR; this PR adds
+      `configure_with_gateway_for_bridge` alongside the existing
+      `configure_with_gateway`. The two coexist — TSI / non-bridge
+      callers (Stage 0 builder VMs, smoke tests) keep the
+      original. Full unification of the two paths is a follow-up
+      if desired but not load-bearing.
+- [x] `pub fn run_supervisor_with_bridge<F>(cfg, factory)` in
+      `mvm-libkrun`, with `mvm-libkrun-supervisor::main` branching
+      on `cfg.tenant_id` (`Some` → bridge factory, `None` →
+      legacy `run_supervisor`).
 - [ ] Live smoke on all three backends (Linux+passt,
-      macOS+libkrun+gvproxy, macOS+Vz+gvproxy)
+      macOS+libkrun+gvproxy, macOS+Vz+gvproxy). **Blocked on
+      Phase 3c** — until the producer side activates `tenant_id`,
+      no spawn takes the bridge path, so live smokes wouldn't
+      exercise the substrate. Scheduled with the Phase 3c PR.
+
+#### Phase 3c — producer activation (next PR in this work stream)
+
+Threads the `AdmittedPlan` from `mvm-cli`'s `mvmctl up` admission
+flow down to backend `start()` so the audit-substrate fields
+actually populate at runtime:
+
+- [ ] Widen `mvm_core::vm_backend::VmStartConfig` with three
+      `Option<String>` fields: `tenant_id`, `plan_json`,
+      `bundle_json`. All `Option<String>` so mvm-core gains no
+      typed deps.
+- [ ] Populate the new fields from `AdmittedPlan` at each
+      `VmStartConfig` construction site in `mvm-cli` (~6 sites).
+- [ ] `mvm-backend/src/libkrun.rs::start()` reads them and
+      populates the five `SupervisorConfig` audit fields +
+      `plan` + `bundle` from `mvm_data_dir()` + the
+      pre-serialized JSON.
+- [ ] Same pattern for the Vz backend (vz.rs already populates
+      `events_ingest_socket_path`; the Vz-side `tenant_id`
+      pumping is the parallel work).
+- [ ] Live smoke per backend.
 
 ### W6.B follow-ups (real flow extraction, next PR in this work stream)
 

--- a/specs/plans/103-w6a-implementation-tracker.md
+++ b/specs/plans/103-w6a-implementation-tracker.md
@@ -477,6 +477,13 @@ plans` per commit 8.
 
 ## Status
 
-🟡 in progress — Plan 103 tracker filed 2026-05-26.
-Implementation worktree at
-`.claude/worktrees/plan-101-w6a-substrate/`.
+🟢 **W6.A merged 2026-05-27** (PR #459 on `main` at `df950fd9`).
+
+🟡 **W6.A.5 substrate wire-up in flight (2026-05-27)** — 8 commits
+on `worktree-plan-102-w6a-5-wire-up` covering Phases 1–5 of the
+follow-up. See [Plan 102 §W6.A.5](102-gateway-audit-substrate-impl.md#w6a5--vz-swift-bridge--fd-interception-wire-up)
+for the per-item status. Producer activation (`Phase 3c`) and
+live smokes are scheduled for the next PR — until then the
+bridge factory branch is dormant at runtime (`cfg.tenant_id`
+stays `None` and every spawn takes the legacy `run_supervisor`
+path).

--- a/tests/oci_image_runner_smoke.rs
+++ b/tests/oci_image_runner_smoke.rs
@@ -212,6 +212,8 @@ fn boot_with_libkrun(
         gateway_audit_socket: None,
         gateway_events_socket: None,
         signing_key_path: None,
+        plan: None,
+        bundle: None,
     };
     let json = serde_json::to_string(&cfg).expect("serialize supervisor config");
 


### PR DESCRIPTION
## Summary

Plan 102 **W6.A.5** — structural follow-up to [PR #459](https://github.com/tinylabscom/mvm/pull/459) (W6.A). Wires the Vz Swift side of the gateway audit substrate end-to-end with the libkrun supervisor binary and Rust entry points; lays the plumbing for [ADR-058](specs/adrs/058-claim-10-bytes-leaving-trust-boundary.md) / claim 10 leg 2 (\"bytes leaving the trust boundary\") to work on the Vz backend. **8 wire-up commits + 1 docs tick**.

See [Plan 102 §W6.A.5](specs/plans/102-gateway-audit-substrate-impl.md#w6a5--vz-swift-bridge--fd-interception-wire-up) for the per-item status, and [Plan 103 §Status](specs/plans/103-w6a-implementation-tracker.md#status) for the W6.A → W6.A.5 → Phase 3c progression.

## What ships (9 commits)

| # | Commit | Substrate piece |
|---|---|---|
| 1 | `962c146a` | `mvm-libkrun-supervisor` split out into its own leaf crate (was `crates/mvm-libkrun/src/bin/`) — sets up the bridge-factory swap site |
| 2 | `c917ff69` | `SupervisorConfig.plan` + `bundle` fields on the host-side wire — the per-VM `ExecutionPlan` + `PolicyBundle` paths the bridge needs at admission time |
| 3 | `56644672` | `public/src/content/docs/reference/architecture.md` — diagram + prose explaining the two supervisor layers (host vs guest) so the bin-split lands with onboarding context |
| 4 | `16da4312` | `BridgeFds` + `configure_with_gateway_for_bridge` + `run_supervisor_with_bridge<F>` in `mvm-libkrun` — the entry points that let a host pre-create the bridge socketpair and hand the libkrun-bound fds back through a factory closure |
| 5 | `73ddc6a7` | `mvm-libkrun-supervisor::main` branches on `cfg.tenant_id` (`Some` → bridge factory, `None` → legacy `run_supervisor`) — single-binary, dual-mode dispatch |
| 6 | `2348d308` | Host-side gvproxy lifecycle in `mvm-backend/src/host_gvproxy.rs` (new) — parent-process spawn, PID file, MAC derivation, tear-down on `VzBackend::stop`. `vz.rs` populates `NetworkConfig::Gvproxy { events_ingest_socket_path: Some(...) }` from `mvm_data_dir() + audit/` |
| 7 | `1621273d` | Swift `makeBridgedGvproxyDevice` alongside `makeGvproxyDevice` — socketpair interposition + ingest connect with `MVM_VZ_BRIDGE_V1\n` handshake + `DispatchSourceRead` splice loops + NDJSON emit on first packet / shutdown. Selection keyed on `eventsIngestSocketPath: nil` vs `Some` |
| 8 | `3e6fa82b` | Swift XCTest harness — 5 tests pinning the handshake constant, `flow_opened` wire shape, `flow_closed` wire shape, end-to-end shuffle + emit on socketpairs, and `flow_closed` on cancel. `swift test` green |
| 9 | `22aee339` | Plan 102 §W6.A.5 + Plan 103 §Status doc tick reflecting what landed vs what carved off to **Phase 3c** |

## Test counts

- Swift XCTest (`crates/mvm-vz-supervisor/`): **5 new** (BridgeWorkerTests) — `swift test` 5/5 passed
- Rust workspace: net-zero new test count from this PR — the new Rust code is internal entry points (`run_supervisor_with_bridge`, `configure_with_gateway_for_bridge`, `BridgeFds`, `host_gvproxy::*`) exercised via the existing supervisor + backend test surface. `cargo test` for the modified crates: mvm-libkrun 213 / mvm-supervisor 534 / mvm-vz 15 / mvm-backend + mvm-libkrun-supervisor 0 (no test surface).

## Test plan

- [x] `cargo fmt --all -- --check` clean
- [x] `cargo clippy --workspace --all-targets -- -D warnings` clean
- [x] `cargo test` green on every crate the PR touches (run in isolation; workspace-wide parallel runs show pre-existing filesystem-race flakes in `mvm-build`/`mvm-cli`/`mvm-providers` that this PR does not touch and that pass single-threaded — CI's `cargo nextest` cross-process isolation sidesteps them)
- [x] `swift test` from `crates/mvm-vz-supervisor/` 5/5 passed
- [ ] Live smoke on all three backends — **blocked on Phase 3c** (see below)

## What is deferred to Phase 3c (next PR in this work stream)

The producer-side activation that widens `mvm_core::vm_backend::VmStartConfig` with three `Option<String>` fields (`tenant_id`, `plan_json`, `bundle_json`) and threads `AdmittedPlan` through to backend `start()` at the ~6 mvm-cli `VmStartConfig` construction sites. Until that lands:

- `mvm-backend/src/libkrun.rs::start()` leaves `SupervisorConfig.{tenant_id, audit_dir, gateway_audit_socket, gateway_events_socket, signing_key_path}` as `None`, so `mvm-libkrun-supervisor::main` takes the legacy `run_supervisor` path for every spawn.
- Live smokes wouldn't exercise the substrate even though it compiles + tests clean. They're scheduled with the Phase 3c PR.

Phase 3c checklist lives in [Plan 102 §W6.A.5 \"Phase 3c — producer activation\"](specs/plans/102-gateway-audit-substrate-impl.md#phase-3c--producer-activation-next-pr-in-this-work-stream).

## Why split this off from Phase 3c

The structural wire-up here (bin crate split, bridge entry points, Swift bridge, host gvproxy lifecycle) is invasive in the libkrun ↔ supervisor binding fd-ownership story and warrants its own focused review. The producer activation is a focused widening of `VmStartConfig` and a few mvm-cli call sites — much easier to review on its own merits. The two together would have made each piece harder to reason about.

## Branch note

Rebased onto `origin/main` at `18a2d77e` immediately before opening this PR. No file overlap with main's 39 intervening commits, so the rebase was conflict-free.

🤖 Generated with [Claude Code](https://claude.com/claude-code)