### PR TITLE
docs(adrs): Plan 109 W4 ADRs + Plan 110 playbook

### DIFF
--- a/specs/adrs/060-pid0-portability-boundary.md
+++ b/specs/adrs/060-pid0-portability-boundary.md
@@ -2,7 +2,7 @@
 
 **Status**: Proposed
 **Date**: 2026-05-28
-**Cross-refs**: ADR-002 (security posture), ADR-053 (guest protocol versioning & readiness), ADR-055 (passt virtio-net), ADR-059 (host services broker), Plan 109 (guest control-layer dep-reduction + encryption design), Plan 25 (microVM hardening), Plan 64 (signed execution plans), Plan 104 (host services broker)
+**Cross-refs**: ADR-002 (security posture), ADR-053 (guest protocol versioning & readiness), ADR-055 (passt virtio-net), ADR-059 (host services broker), ADR-061 (broker hardening), ADR-062 (broker rescope — drop secrets, add host.audit.v1), Plan 109 (guest control-layer dep-reduction + encryption design), Plan 25 (microVM hardening), Plan 64 (signed execution plans), Plan 104 (host services broker)
 
 ## Context
 
@@ -32,7 +32,7 @@ The pid0 control surface is the set of guest-side processes the host's control p
 The pid0 control surface is **distinct from**:
 
 - The workload itself (defined in the user's `mkGuest { entrypoint = ...; }` flake; runs as a child of the agent on `RunEntrypoint`).
-- The host services broker (ADR-059 / Plan 104) — `mvm-secrets-dispatcher` and the general broker live on the **host**, not the guest. The guest is a *client* of the broker via additional vsock ports (5300, 5301), but the broker is not part of the pid0 contract.
+- The host services broker (ADR-059 / ADR-061 / ADR-062 / Plan 104) — the broker's 3 subprocesses (`mvm-broker`, `mvm-host-signer`, `mvm-audit-signer`) live on the **host**, not the guest. The guest is a *client* of the broker via vsock port `:5300`, but the broker is not part of the pid0 contract. (Pre-ADR-062 designs referenced a separate secrets channel on `:5301`; that port and `mvm-secrets-dispatcher` are gone as of ADR-062.)
 
 ### 2. Transport contract
 
@@ -127,7 +127,7 @@ Any language change at the boundary MUST preserve these *byte-identically*. See 
 
 ## Out of scope
 
-- The host-side broker (ADR-059 / Plan 104) and its ports `:5300` / `:5301`. The broker is host-side; the guest's *client* code that calls into the broker is in `mvm-sdk`, not the agent, and is not part of the pid0 contract.
+- The host-side broker (ADR-059 / ADR-061 / ADR-062 / Plan 104) and its port `:5300` (pre-ADR-062 `:5301` is removed). The broker is host-side; the guest's *client* code that calls into the broker is in `mvm-sdk`, not the agent, and is not part of the pid0 contract.
 - The encrypted-vsock design (Plan 109 W3, Noise_NK). Encryption is forward-looking and will land via a separate ADR or as an addendum to this one once Plan 109's W3 design doc commits.
 - The control-plane-vs-data-plane partition. Forthcoming separate ADR (Plan 109 W4a).
 

--- a/specs/adrs/060-pid0-portability-boundary.md
+++ b/specs/adrs/060-pid0-portability-boundary.md
@@ -1,0 +1,150 @@
+# ADR 060 - pid0 Portability Boundary
+
+**Status**: Proposed
+**Date**: 2026-05-28
+**Cross-refs**: ADR-002 (security posture), ADR-053 (guest protocol versioning & readiness), ADR-055 (passt virtio-net), ADR-059 (host services broker), Plan 109 (guest control-layer dep-reduction + encryption design), Plan 25 (microVM hardening), Plan 64 (signed execution plans), Plan 104 (host services broker)
+
+## Context
+
+mvm runs guest workloads across multiple hypervisor backends: **Firecracker** (Linux KVM, production tier 1), **libkrun** (Linux KVM + macOS HVF), **Apple Virtualization.framework / Vz** (macOS 26+ Apple Silicon, ADR-056), **Cloud Hypervisor** (Linux KVM alternative), **Apple Container** (macOS), **Docker** (tier 3 fallback), plus Mock for testing.
+
+The guest-side init layer (pid 1 → `mvm-verity-init` → `switch_root` → minimal init → `mvm-guest-agent`) is structurally identical across backends today *by convention*, not by contract. ADR-053 introduced a guest protocol hello + readiness state machine, and Plan 64 / claim 8 wired a signed `ExecutionPlan` admission path. Neither names the broader **pid0 control surface** the agent must provide on every backend — i.e. what every backend's guest must satisfy for the host's control plane to work uniformly.
+
+Today the convention is implicit. It's documented across CLAUDE.md, scattered code comments in `crates/mvm-guest/`, the verity-init kernel cmdline contract, and the per-backend supervisor wiring. New backends (e.g. the Vz path in ADR-056 / Plan 98, or Cloud Hypervisor in Plan 54) have to re-derive what "this thing is a valid mvm guest" means by reading existing implementations. That's brittle and invites drift.
+
+The motivating question (raised by Plan 109's exploration of Zig vs lean-Rust v2 alternatives at the boundary): **if pid0 is the portability boundary across hypervisors, what does any pid0 implementation — Rust today, lean-Rust v2 future, hypothetical Zig replacement — have to do to be a valid mvm guest?**
+
+This ADR makes the contract explicit. It does **not** mandate a language; it does **not** specify which binaries provide the contract; it does **not** change any current backend's behavior. It documents the invariants every backend's guest must satisfy and gives future contributors a single document to consult before adding a backend or proposing a guest rewrite.
+
+## Decision
+
+mvm treats the **pid0 control surface** — the guest-side code that runs at boot and serves the host's control plane — as a backend-agnostic contract with the following shape.
+
+### 1. What "pid0 control surface" means
+
+The pid0 control surface is the set of guest-side processes the host's control plane talks to or depends on, namely:
+
+- The init binary (`mvm-verity-init` today in the verity-initrd path; whatever pid 1 is after `switch_root`).
+- One-shot pre-workload binaries (`mvm-guest-netinit` today — blackhole-route installer).
+- The long-lived control-plane agent (`mvm-guest-agent` today, uid 901, listens on vsock `:5252`).
+- Any addon binaries that are part of the minimum boot sequence (`mvm-addon-dns`, `mvm-addon-vsock-bridge` when enabled).
+
+The pid0 control surface is **distinct from**:
+
+- The workload itself (defined in the user's `mkGuest { entrypoint = ...; }` flake; runs as a child of the agent on `RunEntrypoint`).
+- The host services broker (ADR-059 / Plan 104) — `mvm-secrets-dispatcher` and the general broker live on the **host**, not the guest. The guest is a *client* of the broker via additional vsock ports (5300, 5301), but the broker is not part of the pid0 contract.
+
+### 2. Transport contract
+
+Every backend MUST provide:
+
+- **Virtio-vsock** with a stable CID assignment for the guest. The host uses CID 2 (loopback); the guest uses CID 3 by convention. Backends that abstract the CID space (libkrun's in-process VSOCK proxy, Vz's vsock API, Cloud Hypervisor's vsock device) MUST expose the guest end as a Unix-domain socket the host supervisor can bind for incoming connections.
+- **A length-prefixed JSON framing** carried inside vsock streams, with `AuthenticatedFrame` (Ed25519 + session id + monotonic sequence) wrapping every payload (ADR-002 §W4.1, claim 5, `crates/mvm-core/src/policy/security.rs`).
+- **No alternate control transport.** Backends MUST NOT route control-plane traffic over virtio-net, virtio-fs, block devices, or any side channel. The vsock-only invariant is load-bearing for claim 1 (no host-fs access beyond explicit shares) and ADR-058 (no virtio-net bypass).
+
+If a backend cannot satisfy vsock with this framing, it is not a valid mvm backend and must defer to the Mock or Docker tier until it can.
+
+### 3. Boot handshake contract
+
+The guest agent MUST implement the protocol-hello sequence from ADR-053:
+
+- First message in every session: `ProtocolHello` carrying `protocol_version`, `min_supported_protocol_version`, `agent_version`, `supported_capabilities` (see `crates/mvm-guest/src/vsock.rs:77+`).
+- Mismatch returns a typed `ProtocolMismatch` before any other dispatch.
+- No `Ping`-style compatibility shim. Old guests must be rebuilt; old hosts must be upgraded.
+
+The agent MUST emit `ReadinessStatus` events tracking the components named in ADR-053 §3:
+`control_plane`, `entrypoint`, `warm_pool`, `integrations`, `probes`, `volumes`. Components not applicable to a given image report as `not_present`, not as `failed`.
+
+### 4. Lifecycle states
+
+The pid0 control surface MUST move through these named states in this order:
+
+1. **boot** — kernel-userspace handover; `mvm-verity-init` setting up dm-verity (if verity-enabled), then `switch_root`.
+2. **netinit** — `mvm-guest-netinit` (or equivalent) installing mandatory deny routes per Plan 74 W2 / claim 1; exits before agent starts.
+3. **agent-listen** — `mvm-guest-agent` (or equivalent) bound to vsock `:5252` and serving `ProtocolHello`.
+4. **ready** — agent has emitted `ReadinessStatus { control_plane: ready, ... }`; host may dispatch any ProdSafe verb.
+5. **workload** — `RunEntrypoint` has spawned the workload as a child of the agent; entrypoint events stream to host.
+6. **drain** — host issued shutdown; agent stops accepting new work, drains in-flight RPCs, signals workload `SIGTERM` then `SIGKILL`.
+7. **shutdown** — agent exits cleanly; init reaps; backend tears down VM.
+
+States 1–3 are **mandatory**; 4–7 may overlap or be condensed for non-interactive workloads but ordering must hold.
+
+### 5. What pid0 MUST NOT do
+
+- **No host-fs assumptions.** The guest MUST NOT assume any path on the host is visible. Volume mounts arrive via `MountVolume` RPC (virtio-fs share) explicitly bound at runtime — never inferred from environment, never hardcoded.
+- **No SSH.** Per CLAUDE.md "no SSH in microVMs, ever" — no sshd, no SSH keys, no SSH users in any rootfs. Console PTY (dev-mode) goes through vsock, not SSH.
+- **No shell-out beyond audited verbs.** The agent must not exec arbitrary binaries on uid-0-ish behalf of the host outside the `ProcStart` / `RunEntrypoint` paths that emit `LocalAuditKind::NetworkPolicyAllow` audit events (claim 8). `do_exec` and friends are stripped in sealed-prod builds (claim 4).
+- **No broad seccomp escape.** The agent runs under `setpriv --bounding-set=-all --no-new-privs` with the W2.4 standard profile. A pid0 implementation may not require a permissive seccomp profile or `CAP_SYS_ADMIN` beyond what verity-init needs for dm-verity setup.
+- **No bypass of `AuthenticatedFrame`.** Every host↔guest control-plane message is signed and replay-protected. Backends MUST NOT introduce an out-of-band control channel that skips signature verification.
+
+### 6. Cross-platform constraints
+
+- **musl-static** binaries. Glibc-linked binaries don't run reliably in minimal initramfs / NixOS-without-glibc setups and break the verity-initrd path. Every pid0-class binary must build static-musl for `x86_64-linux` and `aarch64-linux`.
+- **Kernel cmdline contract** is a stable surface (ADR-002 §W3, Plan 27 / claim 3):
+  - `mvm.roothash=<64-hex>` — required if verity-enabled.
+  - `mvm.runtime_roothash=<64-hex>` — required if runtime-overlay verity is in use.
+  - `console=hvc0` — required for libkrun (per memory `reference_libkrun_gotchas`).
+  - `init=/init` — points at the verity-init or minimal-init pid1.
+  - Additional flags introduced by backends MUST follow the `mvm.*` prefix and document the change in this ADR.
+- **No host Nix dependency.** Per CLAUDE.md "Host Nix is never used by mvmctl, even when present" — the guest must boot from an image built inside a builder VM, never from a host-Nix evaluation.
+
+### 7. Audit chain integration
+
+Every RPC dispatch in the pid0 control surface MUST emit a `LocalAuditKind::NetworkPolicyAllow` audit event (Plan 51 W6 / Plan 37 §6) carrying the verb name via `GuestRequest::kind_name()`. The supervisor's `AuditEmitter` is the only writer to `~/.mvm/audit/<tenant>.jsonl`; a pid0 implementation that bypasses this is invalid.
+
+This is the same invariant as Plan 109 §I1 (control-plane audit chain stays intact).
+
+### 8. Language neutrality (explicit non-goal)
+
+This ADR does **not** mandate any specific implementation language. The current Rust implementation satisfies the contract; future lean-Rust-v2 or Zig alternatives explored under Plan 109 satisfy it equally as long as they meet sections 1–7.
+
+The contract surfaces are:
+
+- The vsock framing format (`AuthenticatedFrame`).
+- The `GuestRequest` / `GuestResponse` / `GuestCapability` enum variants.
+- The `ProtocolHello` semantics.
+- The audit-emit invariant.
+- The cmdline contract.
+
+Any language change at the boundary MUST preserve these *byte-identically*. See ADR-063 (boundary-language-policy) for when non-Rust implementations are permitted at all.
+
+## Consequences
+
+**Positive:**
+
+- New backends have a single document to consult. Adding Cloud Hypervisor, future ARM hypervisors, or alternative macOS paths becomes a checklist exercise against sections 1–7.
+- Future agent rewrites (lean Rust v2 per Plan 109's recommendation; Zig if evidence supports it) have an explicit contract to satisfy, not an implicit one to reverse-engineer.
+- The Plan 104 host services broker is unambiguously *not* part of pid0. Cross-reference confusion about "what's in the boundary" resolves.
+
+**Negative:**
+
+- Codifies status quo before all of it is exercised across every backend. Vz (Plan 98) and Cloud Hypervisor (Plan 54) are still in flight; this ADR will need an amendment if their work surfaces a contract gap.
+- The musl-static + no-glibc constraint excludes some library choices that would otherwise be natural in Rust (e.g. `mio` works under glibc but is unproven under all musl matrices). This is a known tradeoff per Plan 109 §"Honest uncertainties."
+
+**Neutral:**
+
+- Does not change any current binary's behavior. Documentation-only ADR establishing what the existing system already does, plus the explicit promise it will keep doing it.
+
+## Out of scope
+
+- The host-side broker (ADR-059 / Plan 104) and its ports `:5300` / `:5301`. The broker is host-side; the guest's *client* code that calls into the broker is in `mvm-sdk`, not the agent, and is not part of the pid0 contract.
+- The encrypted-vsock design (Plan 109 W3, Noise_NK). Encryption is forward-looking and will land via a separate ADR or as an addendum to this one once Plan 109's W3 design doc commits.
+- The control-plane-vs-data-plane partition. Forthcoming separate ADR (Plan 109 W4a).
+
+## References
+
+- ADR-002 (microVM security posture, claims 1-10)
+- ADR-053 (guest protocol hello + readiness)
+- ADR-055 (passt virtio-net / gvproxy)
+- ADR-058 (no virtio-net bypass, claim 10)
+- ADR-059 (host services broker over vsock — adjacent, not part of pid0)
+- Plan 25 (microVM hardening workstreams)
+- Plan 64 (signed execution plans, claim 8 wiring)
+- Plan 74 W2 (mandatory deny routes, blackhole installer)
+- Plan 104 (host services broker implementation)
+- Plan 109 (guest control-layer dep-reduction + encryption design — this ADR is W4b)
+- `crates/mvm-guest/src/bin/mvm-guest-agent.rs` (current pid0 agent implementation)
+- `crates/mvm-guest/src/bin/mvm-verity-init.rs` (current verity-init implementation)
+- `crates/mvm-guest/src/bin/mvm-guest-netinit.rs` (current netinit implementation)
+- `crates/mvm-guest/src/vsock.rs` (`GuestRequest`, `ProtocolHello`, framing)
+- `crates/mvm-core/src/policy/security.rs` (`AuthenticatedFrame`)

--- a/specs/adrs/063-boundary-language-policy.md
+++ b/specs/adrs/063-boundary-language-policy.md
@@ -1,0 +1,114 @@
+# ADR 063 - Boundary Language Policy
+
+**Status**: Proposed
+**Date**: 2026-05-28
+**Cross-refs**: ADR-002 (security posture), ADR-060 (pid0 portability boundary), Plan 109 (guest control-layer dep-reduction + encryption design), Sprint 42 §Track E (Zig evaluation gates)
+
+## Context
+
+mvm's guest-side control surface (pid0 — agent, init, netinit, addon binaries) is Rust today, with a heavy transitive dependency tree at the boundary: `tokio`, `serde_json`, `ed25519-dalek`, `rtnetlink`, `seccompiler`, and hundreds of indirect crates. Sprint 42's Dependency Reduction Roadmap added a **Track E** that gates any Zig adoption behind two rules:
+
+1. Do not introduce Zig for broad protocol-heavy replacements (`oci-client`, `pgp`) without a written tradeoff note covering native toolchain cost, cross-platform CI complexity, auditability, and risk reduction.
+2. If Zig is evaluated at all, constrain it to narrow ABI shims or parser islands where the native surface is small and stable.
+
+Track E names the gates but doesn't formalize them as a project-level policy. As Plan 109 runs the first concrete evaluation (a Zig vs lean-Rust-v2 A/B on `mvm-guest-netinit`), the team needs an ADR that the *next* contributor — or AI session — can consult without having to re-derive the discipline.
+
+This ADR codifies the policy. It is deliberately framed broadly as "boundary language policy" — not "Zig policy" — so that the doc has value even if Plan 109's measurements reject Zig and the project stays Rust-only. The point is the rule, not the language.
+
+## Decision
+
+mvm's default boundary language is **Rust**. Adoption of any other language at the boundary requires evidence and is gated as below.
+
+### 1. Default: Rust everywhere at the boundary
+
+Every binary that runs in the guest's blast radius (pid0 control surface per ADR-060: init, netinit, agent, in-boot addons) and every host-side binary that participates in the audit chain or signs material is **Rust by default**.
+
+The default is not negotiable case-by-case. Adopting a non-Rust binary requires the explicit process in §3.
+
+### 2. First path for dependency reduction: lean Rust v2
+
+Before considering a non-Rust language for any boundary binary, the team MUST evaluate whether the dep-reduction goal can be met within Rust. The "lean Rust v2" discipline:
+
+- Replace `tokio` with `polling` + a small hand-rolled executor for binaries where async/await ergonomics are not load-bearing.
+- Replace `serde_json` with hand-rolled per-variant parsers (or `nanoserde`) where the wire surface is small and stable.
+- Replace `rtnetlink` / `netlink-packet-route` with `linux-raw-sys` + manual netlink for one-shot or narrow netlink usage.
+- Replace heavy proc-macro derive chains with minimal-derive alternatives or inline implementations where reasonable.
+- Existing precedent: `mvm-egress-proxy` (libc only, no tokio) demonstrates the discipline already shipping in this repo.
+
+Plan 109's measurement framework (`specs/research/agent-evolution-tradeoff-note.md`) establishes the rubric for sizing this path. Subsequent dep-reduction proposals should use the same rubric so results are comparable.
+
+### 3. Where non-Rust may be considered
+
+Non-Rust languages MAY be proposed for boundary code only when **all** of the following hold:
+
+- The binary has a **narrow ABI surface** (a small, stable set of syscalls or wire variants). Examples that qualify: a netlink-route installer, a virtio-vsock diagnostics probe, an ObjC/Swift bridge to a closed-source host framework (Apple Vz). Examples that do not qualify: anything with broad protocol stacks (OCI, PGP, OpenAPI, async runtimes).
+- The binary is **not driving the audit chain**. Anything that emits to `~/.mvm/audit/<tenant>.jsonl` or computes/verifies signatures over `ExecutionPlan` material stays Rust. The audit chain is single-language by design (claim 8).
+- The native language materially reduces the **supply-chain attack surface or boundary footprint**, with measurement evidence per Plan 109's rubric — not opinion.
+
+Non-Rust languages MUST NOT be proposed for:
+
+- Broad protocol stacks (OCI, PGP, OpenAPI, sigstore, OAuth, etc.).
+- Async runtimes (`tokio` replacements). Building an event loop in another language is a workaround for "tokio is large" that re-creates the same async substrate without solving the underlying issue.
+- Anything that interacts with the audit chain.
+- Anything whose wire types are defined in `mvm-core` and shared across host/guest. The protocol stays Rust-canonical (Plan 109 §D2); any non-Rust implementation consumes a Rust-derived schema and round-trips byte-identically.
+
+### 4. Required deliverables per non-Rust adoption
+
+Any PR proposing a non-Rust boundary binary MUST include, before any prototype merge:
+
+1. **Tradeoff note** in `specs/research/<topic>-tradeoff-note.md`. Template: `specs/research/agent-evolution-tradeoff-note.md` (Plan 109 W1). Symmetric analysis of the non-Rust path AND a lean-Rust-v2 alternative. Cover: toolchain cost, CI complexity, auditability, supply-chain surface comparison, maintenance/contributor-pool impact.
+2. **Measurement comparison** with the lean-Rust v2 baseline against the rubric in Plan 109 W2/W2′. Primary metrics: dep-tree LoC reaching the boundary, transitive crate / module count + advisory exposure, stripped binary size, compile time, fuzz parity, reproducibility (claim 7), CI cost delta.
+3. **Fuzz harness** equivalent to the existing `cargo-fuzz` targets covering the binary's parser surface. The non-Rust fuzzer must run in CI on the same PR cadence.
+4. **Reproducible-build proof** — byte-identical rebuilds on `aarch64-linux` and `x86_64-linux` musl-static. Claim 7's invariant doesn't get a language carve-out.
+5. **Supply-chain attestation** equivalent to `cargo-deny` / `cargo-audit`: a documented inventory of every external dependency (stdlib modules, compiler version, transitive includes) and a CI gate that fails on yanked / advisory-flagged inputs.
+6. **Schema parity test** (per ADR-060 §8): the non-Rust binary consumes the Rust-canonical wire types and the build fails if the Rust types drift.
+
+Each deliverable is **a CI gate**, not a discretionary review item. Without all six, the PR is not mergeable regardless of measurement outcome.
+
+### 5. Reversibility
+
+Any non-Rust boundary binary MUST be kept side-by-side with the existing Rust implementation until the non-Rust path is proven across at least one full release cycle. The default kernel cmdline path selects the Rust binary; the non-Rust binary is opt-in via flake option. This is Plan 109's I4 invariant generalized.
+
+Adoption is then a separate PR that flips the default. Removal of the Rust binary is a *third* PR, no earlier than one release cycle after the default flip. The transition is irreversible only at that point.
+
+### 6. Apple VZ ObjC/Swift shim — explicit carve-out
+
+`mvm-vz-supervisor` (Plan 98 / ADR-056) uses Swift to bridge to Apple's closed-source Virtualization.framework. This is an existing exception that predates this ADR and is grandfathered. Any future Apple-framework integration MAY use Swift or ObjC under the same scoping discipline as §3 — narrow, framework-mandated, not part of the audit chain — but MUST still satisfy §4's deliverables.
+
+## Consequences
+
+**Positive:**
+
+- Future contributors and AI sessions have a single document explaining when Zig (or any non-Rust language) is acceptable at the boundary. No need to re-derive the discipline from Track E plus folklore.
+- The lean-Rust-v2 path becomes the explicit first move for any dep-reduction proposal, not a runner-up considered after a more exotic option.
+- The six-deliverable bar (§4) makes prototype-to-adoption a measurable process, not a tribal-knowledge decision.
+
+**Negative:**
+
+- The deliverable bar may slow legitimate experimentation. Mitigation: tradeoff notes and prototypes can be authored cheaply (Plan 109 demonstrates this); only *adoption* requires the full bar.
+- The schema-parity requirement (§3 "Rust-canonical types") forces hand-mirroring or codegen for any non-Rust implementation. Engineering cost is real and called out in Plan 109's analysis. Accepted.
+- Codifies a status-quo bias toward Rust. This is intentional — the team is Rust-first and the audit chain is Rust-anchored. Lowering the bar would re-introduce the toolchain-tax compounding that Plan 109 §"Systems-design recommendation" specifically identifies as the strongest argument against multi-language sprawl.
+
+**Neutral:**
+
+- Does not retroactively bless or revoke any existing non-Rust code. The Vz Swift shim is grandfathered (§6); there is no other non-Rust code at the boundary today.
+- Does not commit the team to evaluating any particular non-Rust language. Plan 109's Zig prototype is the first evaluation; nothing here commits to a second.
+
+## Alternatives considered
+
+**Alt 1: prohibit non-Rust at the boundary entirely.** Rejected because the Apple Vz Swift shim is load-bearing and the framework is closed-source. A blanket prohibition would either force re-implementation of Vz support in Rust (technically infeasible — Apple's framework requires Swift/ObjC) or block macOS Apple-Silicon support. A scoped policy is the workable middle.
+
+**Alt 2: allow non-Rust freely, gate only by code review.** Rejected because boundary code reaches every microVM and supply-chain hygiene compounds. Discretionary review provides no consistent floor; the six-deliverable bar gives one.
+
+**Alt 3: enumerate permitted languages (Rust, Zig, Swift) by name.** Rejected because it overcommits to today's set. The current text scopes by *constraints* (narrow ABI surface, not in audit chain, schema parity to mvm-core), which any future language candidate must satisfy. If a fourth language ever becomes a candidate, this ADR applies without amendment.
+
+## References
+
+- ADR-002 (microVM security posture, claims 1-10)
+- ADR-060 (pid0 portability boundary — what the boundary binaries must do regardless of language)
+- ADR-056 (Vz backend — grandfathered Swift shim, see §6)
+- Plan 98 (Vz builder VM — Swift supervisor wiring)
+- Plan 109 (guest control-layer dep-reduction + encryption design — this ADR is W4c)
+- `specs/research/agent-evolution-tradeoff-note.md` (Plan 109 W1 — template for §4.1)
+- `specs/SPRINT.md` Sprint 42 Track E (origin of the Zig evaluation gates this ADR codifies)
+- `deny.toml` (existing Rust supply-chain policy this ADR generalizes)

--- a/specs/plans/110-plan-109-w2-w5-execution-playbook.md
+++ b/specs/plans/110-plan-109-w2-w5-execution-playbook.md
@@ -2,7 +2,7 @@
 
 Status: ready (drop-in for a fresh AI session)
 Created: 2026-05-28
-Related: Plan 109 (the parent plan), ADR-060 (pid0 portability boundary), ADR-063 (boundary language policy), Sprint 57
+Related: Plan 109 (the parent plan), ADR-060 (pid0 portability boundary), ADR-063 (boundary language policy), Sprint 58
 
 ## What this plan is
 
@@ -20,7 +20,7 @@ The new session MUST read these in order before making any edits. Each item reso
 - [ ] [`specs/adrs/063-boundary-language-policy.md`](../adrs/063-boundary-language-policy.md) — §4 lists six required deliverables you must produce alongside any non-Rust adoption (only relevant for W2 Zig, not W2′).
 - [ ] `crates/mvm-guest/src/bin/mvm-guest-netinit.rs` + `crates/mvm-guest/src/netinit.rs` — the baseline Rust binary (~87 LoC main + ~100 LoC support) you're porting. **Stays canonical**; W2/W2′ are additions, not replacements.
 - [ ] `crates/mvm-core/src/protocol/vm_backend.rs` — the `VmCapabilities` struct + `BackendSecurityProfile` that W5's capability matrix derives from.
-- [ ] [`specs/SPRINT.md`](../SPRINT.md) Sprint 57 — where Plan 109 lives in sprint tracking. Update the workstream checkboxes there as you complete pieces.
+- [ ] [`specs/SPRINT.md`](../SPRINT.md) Sprint 58 — where Plan 109 lives in sprint tracking. Update the workstream checkboxes there as you complete pieces.
 
 ## Scope discipline (non-negotiable)
 
@@ -74,7 +74,7 @@ W5 + W2′ can run in parallel if the session is aggressive; W2 should wait unti
 - [ ] Optionally add `vsock_encryption_support: bool` to `VmCapabilities` (likely missing — Plan 109 W3 anticipates needing it). Default `true` wherever `vsock: true`.
 - [ ] Smoke checks: `cargo fmt --all -- --check` + `cargo test --workspace --no-run`.
 - [ ] Commit. Suggested message: `docs(reference): provider capability matrix (Plan 109 W5)`.
-- [ ] Update `specs/SPRINT.md` Sprint 57's success-criteria checkbox for W5.
+- [ ] Update `specs/SPRINT.md` Sprint 58's success-criteria checkbox for W5.
 - [ ] Stop. Let the user review before pressing into W2′.
 
 ---
@@ -130,7 +130,7 @@ That's it. No `tokio`, no `rtnetlink`, no `netlink-packet-route`, no `serde_json
 
 - [ ] Smoke checks: `cargo fmt --all -- --check` + `cargo test --workspace --no-run` + `cargo test -p mvm-guest-netinit-lean` (the parity test if on Linux).
 - [ ] Commit. Suggested message: `feat(mvm-guest-netinit-lean): W2′ lean Rust v2 prototype (Plan 109)`.
-- [ ] Update Sprint 57 W2′ checkbox.
+- [ ] Update Sprint 58 W2′ checkbox.
 - [ ] Stop at a natural checkpoint and let the user review before pressing into W2.
 
 ---
@@ -182,7 +182,7 @@ The Zig binary must consume Rust-canonical types. Cheapest approach:
 - [ ] **Do not propose adopting the Zig binary as the default.** Plan 109's expected outcome is Outcome B (lean Rust v2 wins).
 - [ ] **Do not delete or gate the Rust baseline.** Both binaries stay side-by-side per I4.
 - [ ] Commit. Suggested message: `feat(zig): W2 Zig netinit prototype + measurements (Plan 109)`.
-- [ ] Update Sprint 57 W2 checkbox.
+- [ ] Update Sprint 58 W2 checkbox.
 
 ---
 

--- a/specs/plans/110-plan-109-w2-w5-execution-playbook.md
+++ b/specs/plans/110-plan-109-w2-w5-execution-playbook.md
@@ -1,0 +1,236 @@
+# Plan 110 — Plan 109 W2 / W2′ / W5 execution playbook
+
+Status: ready (drop-in for a fresh AI session)
+Created: 2026-05-28
+Related: Plan 109 (the parent plan), ADR-060 (pid0 portability boundary), ADR-063 (boundary language policy), Sprint 57
+
+## What this plan is
+
+This is **not a normal implementation plan**. It is a self-contained execution prompt for a fresh AI session picking up Plan 109's three non-blocked workstreams (W5, W2′, W2). The parent plan ([Plan 109](109-zig-pid0-exploration.md)) holds the strategy and rationale; this plan holds the executable steps with checkboxes so the user can reference the file path instead of pasting a 1500-word prompt every session.
+
+The three workstreams covered here are intentionally the ones that do **not** require coordination with the parallel "secrets work over vsock" session (Plan 104 / ADR-059). The deferred workstreams (W3 vsock encryption design, W4a control-plane-vs-data-plane ADR, W6 ADR-002 threat-model delta) are listed in §"Anti-patterns" so the new session knows to stay out of them.
+
+## Read first (before touching anything)
+
+The new session MUST read these in order before making any edits. Each item resolves a specific question the session will otherwise re-derive:
+
+- [ ] [`specs/plans/109-zig-pid0-exploration.md`](109-zig-pid0-exploration.md) (branch `worktree-plan-109-zig-pid0-exploration`, HEAD `9cdde6a0`) — the parent plan. Focus on §"Systems-design recommendation" (it's positional — lean Rust v2 is the primary track), §"Process lineage", §"Workstreams W2 + W2′", §W5. The plan was originally drafted as Plan 105; the renumbering note at the top explains why. **Use "Plan 109" in all new work.**
+- [ ] [`specs/research/agent-evolution-tradeoff-note.md`](../research/agent-evolution-tradeoff-note.md) (branch `worktree-plan-109-w1-tradeoff-note`, HEAD `958b0714`) — the W1 deliverable. The measurement rubric in §"Shared verification + measurement" is what your prototypes must produce numbers for. §"Vsock surface — broader than the agent control channel" explains why your work touches only the agent channel, not the broker.
+- [ ] [`specs/adrs/060-pid0-portability-boundary.md`](../adrs/060-pid0-portability-boundary.md) — §8 (language neutrality) tells you what byte-identical contract your prototypes must preserve.
+- [ ] [`specs/adrs/063-boundary-language-policy.md`](../adrs/063-boundary-language-policy.md) — §4 lists six required deliverables you must produce alongside any non-Rust adoption (only relevant for W2 Zig, not W2′).
+- [ ] `crates/mvm-guest/src/bin/mvm-guest-netinit.rs` + `crates/mvm-guest/src/netinit.rs` — the baseline Rust binary (~87 LoC main + ~100 LoC support) you're porting. **Stays canonical**; W2/W2′ are additions, not replacements.
+- [ ] `crates/mvm-core/src/protocol/vm_backend.rs` — the `VmCapabilities` struct + `BackendSecurityProfile` that W5's capability matrix derives from.
+- [ ] [`specs/SPRINT.md`](../SPRINT.md) Sprint 57 — where Plan 109 lives in sprint tracking. Update the workstream checkboxes there as you complete pieces.
+
+## Scope discipline (non-negotiable)
+
+- [ ] **Don't touch W3, W4a, or W6.** Those workstreams are deliberately deferred pending coordination with the secrets-work session. W3 is the vsock encryption design (Noise_NK); W4a is the control-plane-vs-data-plane ADR; W6 is ADR-002 threat-model edits. Any encryption design, any ADR-002 edit, any "control plane vs data plane" framing must wait.
+- [ ] **Don't claim new plan or ADR slot numbers without verification.** Slot 105 was lost to a renumbering race mid-conversation. When this session needs any new spec file with a number, re-verify with `gh pr list --state all --search "plan-NNN OR adr-NNN"` + `git ls-tree --name-only origin/main:specs/plans/` + `git ls-tree --name-only origin/main:specs/adrs/` immediately before commit. Don't unilaterally renumber other sessions' work.
+- [ ] **`mvm-guest-agent` stays untouched.** This session is about the netinit prototype (one-shot, no process supervision) and the capability matrix (doc-only). The agent is explicitly out of scope per Plan 109's non-goals.
+- [ ] **All current Plan 109 branches are unpushed.** The user reviews and decides when to push and how to stage PRs. Don't push without instruction.
+
+## Worktree workflow (required)
+
+Per the user's standing instruction, all work happens in git worktrees, never in the main checkout. Use the `EnterWorktree` tool. One worktree per workstream:
+
+- [ ] `worktree-plan-109-w5-capability-matrix` — for W5
+- [ ] `worktree-plan-109-w2-prime-lean-rust-netinit` — for W2′
+- [ ] `worktree-plan-109-w2-zig-netinit` — for W2
+
+Each worktree branches from the latest Plan 109 commit so cross-references resolve. To branch a worktree from a non-default base: from inside any current worktree or the main checkout, run
+
+```bash
+git worktree add -b <branch-name> .claude/worktrees/<dir-name> worktree-plan-109-w4-adrs
+```
+
+(or whichever Plan 109 branch is latest at the time), then `EnterWorktree(path=...)` to switch the session into it.
+
+## Recommended sequencing
+
+Start with **W5** (smallest, fully unblocked, gives the user a quick win + something to review). Then **W2′** (the primary track per Plan 109's recommendation). Then **W2** (the comparison check).
+
+W5 + W2′ can run in parallel if the session is aggressive; W2 should wait until W2′ has numbers so the comparison column exists.
+
+---
+
+## W5 — Provider capability matrix
+
+**Worktree**: `worktree-plan-109-w5-capability-matrix`
+**Deliverable**: `specs/reference/provider-capabilities.md` (new doc).
+**Estimated effort**: ~1 hour.
+
+### Steps
+
+- [ ] Create the worktree, branch from `worktree-plan-109-w4-adrs` HEAD (or latest Plan 109 branch).
+- [ ] Read `crates/mvm-core/src/protocol/vm_backend.rs`. Find the `VmCapabilities` struct and the `AnyBackend` enum (or equivalent backend-dispatch type).
+- [ ] Draft `specs/reference/provider-capabilities.md` with:
+  - [ ] **Columns**: vsock, virtiofs, snapshotting, egress control, attestation, rosetta, gpu, nested virt, **vsock-encryption-support** (new — informs Plan 109 W3 feasibility; values are "yes" for any backend whose vsock transport supports plaintext byte streams, which is all of them — encryption is application-level Noise_NK on top, not a backend property).
+  - [ ] **Rows**: Firecracker, Cloud Hypervisor, libkrun (Linux), libkrun (macOS), Apple VZ, Apple Container, Docker, Mock.
+  - [ ] One brief sentence per row about the backend's role / production tier.
+  - [ ] One brief sentence per column about what the capability means.
+- [ ] **Code-of-truth check**: every column maps 1:1 to a field on `VmCapabilities`; every row maps 1:1 to a variant on `AnyBackend`.
+- [ ] If a column has no field: add the field to `VmCapabilities` (one-line struct change + bool default + update each backend's profile builder).
+- [ ] If a row has no variant: the matrix is wrong, don't add a phantom row.
+- [ ] Optionally add `vsock_encryption_support: bool` to `VmCapabilities` (likely missing — Plan 109 W3 anticipates needing it). Default `true` wherever `vsock: true`.
+- [ ] Smoke checks: `cargo fmt --all -- --check` + `cargo test --workspace --no-run`.
+- [ ] Commit. Suggested message: `docs(reference): provider capability matrix (Plan 109 W5)`.
+- [ ] Update `specs/SPRINT.md` Sprint 57's success-criteria checkbox for W5.
+- [ ] Stop. Let the user review before pressing into W2′.
+
+---
+
+## W2′ — Lean Rust v2 netinit prototype
+
+**Worktree**: `worktree-plan-109-w2-prime-lean-rust-netinit`
+**Deliverable**: new crate `crates/mvm-guest-netinit-lean/` producing a binary behaviorally identical to `mvm-guest-netinit` but with a dramatically smaller dep tree.
+**Estimated effort**: 2–4 days.
+
+### Dependencies allowed
+
+- [ ] `polling` (smol team's epoll/kqueue abstraction)
+- [ ] `linux-raw-sys` (auto-generated kernel header bindings)
+- [ ] `libc`
+
+That's it. No `tokio`, no `rtnetlink`, no `netlink-packet-route`, no `serde_json` (the marker JSON output is small and stable enough to hand-format).
+
+### Behavior contract (preserved byte-identically per ADR-060 §8)
+
+- [ ] Install AF_NETLINK socket; send RTM_NEWROUTE messages installing blackhole routes for `MANDATORY_DENY_RANGES`. Copy or `pub use` the constant from `crates/mvm-guest/src/netinit.rs`; do not redefine.
+- [ ] Emit the `__MVM_NETINIT_REPORT__` marker JSON to stdout. Format must match the baseline byte-for-byte.
+- [ ] Exit codes: 0 = success, 1 = some routes failed, 2 = systemic rtnetlink failure.
+
+### Validation harness
+
+- [ ] Add a workspace-level integration test (`tests/netinit_parity.rs` or similar in the new crate): spawn both `mvm-guest-netinit` and `mvm-guest-netinit-lean` on the same kernel (Linux only — gated `#[cfg(target_os = "linux")]`); diff stdout/stderr/exit-code. Must be identical.
+- [ ] Fuzz harness: `cargo-fuzz` target on the netlink reply parser surface. Mirror the existing harness style in `crates/mvm-guest/fuzz/fuzz_targets/`.
+- [ ] Reproducible build: build the binary twice (same source, same toolchain) and confirm byte-identical (claim 7's invariant).
+
+### Measurement (the headline question per Plan 109 §D1)
+
+- [ ] Produce a section in `specs/research/netinit-prototype-measurements.md` populating the rubric:
+  - [ ] Dep-tree LoC reaching the boundary
+  - [ ] Transitive crate count + advisory exposure
+  - [ ] Stripped binary size (musl, aarch64 + x86_64)
+  - [ ] Compile time cold + warm
+  - [ ] Behavioral parity (pass/fail vs baseline)
+  - [ ] Schema parity (pass/fail vs `mvm-core` types)
+  - [ ] Fuzz time-to-first-crash on adversarial corpora
+  - [ ] Memory ceiling under stress (100k route attempts)
+  - [ ] Reproducibility (byte-identical rebuilds)
+  - [ ] CI cost delta vs baseline
+- [ ] Three columns in the measurements table: **baseline Rust** / **lean Rust v2** / (Zig column reserved for W2).
+
+### Workspace integration
+
+- [ ] Add `crates/mvm-guest-netinit-lean` to the root `Cargo.toml`'s `[workspace] members`.
+- [ ] Don't change any other crate's `Cargo.toml`.
+- [ ] Don't make the dev image cmdline switch to use this binary yet. Keep Rust baseline as default per Plan 109 §I4 (reversibility invariant). Both binaries sit side-by-side.
+
+### Wrap-up
+
+- [ ] Smoke checks: `cargo fmt --all -- --check` + `cargo test --workspace --no-run` + `cargo test -p mvm-guest-netinit-lean` (the parity test if on Linux).
+- [ ] Commit. Suggested message: `feat(mvm-guest-netinit-lean): W2′ lean Rust v2 prototype (Plan 109)`.
+- [ ] Update Sprint 57 W2′ checkbox.
+- [ ] Stop at a natural checkpoint and let the user review before pressing into W2.
+
+---
+
+## W2 — Zig netinit prototype
+
+**Worktree**: `worktree-plan-109-w2-zig-netinit`
+**Prerequisite**: W2′ must have committed measurements first so the comparison column exists.
+**Deliverable**: `zig/mvm-guest-netinit/` directory with `build.zig` + Zig source.
+**Estimated effort**: 2–4 days.
+
+### Adoption gate
+
+ADR-063 §4 lists six deliverables required before any non-Rust adoption. **The prototype builds them up; adoption is a separate later decision, not part of this session.** The plan's expected outcome (per §"Expected outcome + branches") is Outcome B — lean Rust v2 wins — and the Zig binary stays as evidence in tree, not as the shipping artifact.
+
+### Layout
+
+- [ ] Top-level `zig/mvm-guest-netinit/` directory with its own `build.zig`.
+- [ ] **Do NOT** put Zig under `crates/` (cargo would try to recurse).
+- [ ] Pin a Zig version in the `build.zig` comments (Zig is pre-1.0; pin the exact minor).
+- [ ] Use musl-static cross-compile for `aarch64-linux` and `x86_64-linux`.
+
+### Behavior contract (identical to W2′)
+
+- [ ] Same AF_NETLINK + RTM_NEWROUTE installation for `MANDATORY_DENY_RANGES`.
+- [ ] Same `__MVM_NETINIT_REPORT__` marker (byte-for-byte).
+- [ ] Same exit codes (0 / 1 / 2).
+
+### Schema parity test (ADR-063 §3, ADR-060 §8, Plan 109 §D2)
+
+The Zig binary must consume Rust-canonical types. Cheapest approach:
+
+- [ ] Emit the report-marker JSON Schema from the Rust side: `schemars` derive on the report struct + a one-shot binary in the lean crate (`bin/emit_netinit_schema.rs`) that dumps the schema as JSON.
+- [ ] `build.zig` invokes that emitter; parses the resulting JSON Schema; generates Zig type definitions at build time.
+- [ ] If the Rust types drift, the Zig build fails. This is the contract-preservation mechanism Plan 109 §D2 requires.
+
+### Fuzz + reproducibility
+
+- [ ] AFL++ instrumentation on the Zig netlink parser. Document the invocation in `zig/mvm-guest-netinit/README.md`.
+- [ ] Reproducible build: byte-identical rebuilds, same as W2′.
+
+### Measurement
+
+- [ ] Fill in the third column of `specs/research/netinit-prototype-measurements.md`.
+- [ ] Compare against W2′ on every rubric row.
+
+### Stop discipline
+
+- [ ] **Do not propose adopting the Zig binary as the default.** Plan 109's expected outcome is Outcome B (lean Rust v2 wins).
+- [ ] **Do not delete or gate the Rust baseline.** Both binaries stay side-by-side per I4.
+- [ ] Commit. Suggested message: `feat(zig): W2 Zig netinit prototype + measurements (Plan 109)`.
+- [ ] Update Sprint 57 W2 checkbox.
+
+---
+
+## Reporting cadence
+
+- [ ] After W5: stop. Report commits, files, smoke-check results. Don't chain into W2′ without confirmation.
+- [ ] After W2′: stop. Report measurements table state (which rubric items have numbers, which are TODO).
+- [ ] After W2: stop. Report the final three-column measurements table + a one-sentence recommendation (lean Rust v2 wins / Zig wins / inconclusive — matching Plan 109's §"Expected outcome + branches" framing).
+
+## Expected session output
+
+By end of this session:
+
+- [ ] `worktree-plan-109-w5-capability-matrix` branch with `specs/reference/provider-capabilities.md` committed, optionally a `vsock_encryption_support` field added to `VmCapabilities`.
+- [ ] `worktree-plan-109-w2-prime-lean-rust-netinit` branch with `crates/mvm-guest-netinit-lean/` committed, parity test committed, fuzz target committed, first two columns populated in `specs/research/netinit-prototype-measurements.md`.
+- [ ] `worktree-plan-109-w2-zig-netinit` branch with `zig/mvm-guest-netinit/` committed, schema-parity test committed, AFL harness committed, third column populated in the measurements doc.
+
+All three branches **unpushed**. The user reviews and decides when to push and how to stage PRs.
+
+## Anti-patterns to avoid
+
+- [ ] Touching `crates/mvm-guest/src/bin/mvm-guest-agent.rs` (out of scope — Plan 109 explicitly defers agent rewrite).
+- [ ] Writing the W3 encryption design doc (deferred, waiting for secrets session coordination).
+- [ ] Editing `specs/adrs/002-microvm-security-posture.md` (deferred per W6).
+- [ ] Drafting a control-plane-vs-data-plane ADR (deferred per W4a).
+- [ ] Claiming new plan or ADR slot numbers without re-verifying against current `main` + open PRs.
+- [ ] Using "Plan 105" in any new commit message, file content, or cross-reference — Plan 109 is canonical.
+- [ ] Stacking all three workstreams into one branch / one commit. One worktree per workstream; one PR per worktree later.
+- [ ] Making the dev image cmdline switch to W2′ or W2 binaries by default — both prototypes stay opt-in via flake option per I4.
+- [ ] Removing the Rust baseline netinit binary — it stays canonical until at least one release cycle past any default flip (ADR-063 §5).
+
+## Cross-references
+
+- [`Sprint 42 §Track E`](../SPRINT.md#track-e--zig-evaluation-gates) — origin of the Zig evaluation gates Plan 109 implements.
+- [`Plan 104`](104-host-services-broker.md) + [`ADR-059`](../adrs/059-host-services-broker.md) — adjacent vsock surface; broker is host-side and out of pid0 scope per ADR-060.
+- [`ADR-002`](../adrs/002-microvm-security-posture.md) — 10 security claims; your work must not regress any of them (I1/I2/I3/I4 in Plan 109 capture the specifics).
+- `crates/mvm-egress-proxy/` — existing precedent for "lean Rust" discipline (libc only, no tokio). Read before W2′ if unfamiliar with no-tokio Rust binaries.
+
+## Open uncertainties (call out in measurements, don't work around)
+
+- **`polling` at agent scale**: proven for one-shot binaries (this prototype), unproven for the agent's 33-variant dispatcher + long-lived loop + warm-pool state. W2′ only calibrates the boundary-binary case; flag any musl-static netlink surprises in the measurements doc rather than working around them.
+- **`schemars` for the marker schema**: if the Rust report struct doesn't currently derive `Serialize`, you may need to add it. Keep the addition minimal — don't refactor the struct.
+- **Zig version**: pin the version at first commit; document upgrade policy in `zig/mvm-guest-netinit/README.md`. Floating Zig versions break claim 7 reproducibility.
+
+## Session start checklist
+
+- [ ] Read all seven items in §"Read first" before any edits.
+- [ ] Confirm Plan 109 is canonical (not Plan 105 — that slot belongs to a different plan on main).
+- [ ] Confirm three Plan 109 branches exist locally and are unpushed (`git branch -a | grep plan-109`).
+- [ ] Confirm slot 110 is this playbook (don't claim a different slot for it).
+- [ ] Start with W5.


### PR DESCRIPTION
## Summary
Combines the W4 ADRs and the Plan 110 playbook into one PR direct to main, since their previous stacked PRs (#491 + #492) merged into orphaned base branches when #489 merged first.

**ADR-060 — pid0 portability boundary** (150 lines): formalizes what every backend's guest control surface must satisfy regardless of language or backend. Vsock-only transport, `AuthenticatedFrame` framing, `ProtocolHello` handshake, seven named lifecycle states, pid0 prohibitions, musl-static cmdline contract, audit-chain integration. Explicit non-goal: does not mandate a language. The broker references reflect ADR-062's post-rescope state (broker host-side on `:5300` only; `:5301` and `mvm-secrets-dispatcher` gone).

**ADR-063 — boundary language policy** (114 lines): codifies Sprint 42 Track E's Zig evaluation gates as a project-level policy. Default = Rust; lean Rust v2 is the always-applicable first dep-reduction path; non-Rust opt-in with six required deliverables. Apple Vz Swift shim grandfathered.

**Plan 110 — Plan 109 W2/W2'/W5 execution playbook** (236 lines): self-contained checkbox-driven execution prompt for a fresh AI session picking up Plan 109's three non-blocked workstreams. Replaces a 1500-word handoff prompt. Explicitly defers W3 (vsock encryption design), W4a (control-plane-vs-data-plane ADR), W6 (ADR-002 threat-model delta).

ADR-060 and ADR-063 slot-verified free against `origin/main` at push time. Plan 110 slot-verified at draft time. Re-verify with `gh pr list` + `git ls-tree --name-only origin/main:specs/{adrs,plans}/` before final merge.

## Test plan
- [x] `cargo fmt --all -- --check` (passes — doc-only)
- [ ] Reviewer reads **ADR-060 §5** (pid0 prohibitions) — match actual intent?
- [ ] Reviewer reads **ADR-063 §3** + §4 — non-Rust bar and six deliverables appropriate?
- [ ] Reviewer reads **Plan 110** §"Read first" + §"Anti-patterns" — playbook accurate?
- [ ] Cross-refs to ADR-002, 053, 055, 056, 059, 060, 061, 062, 063, Plan 98, 104, 109 render correctly
- [ ] Confirm all three slot numbers (ADR-060, ADR-063, Plan 110) still uncontested at merge time

🤖 Generated with [Claude Code](https://claude.com/claude-code)