### PR TITLE
docs(specs): Plan 111 — Cardoso gap coordination

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -125,19 +125,38 @@ The `RuntimeBuildEnv` in mvm implements only `ShellEnvironment`. The full `Build
 
 ## Security model
 
-mvm makes ten CI-enforced security claims. Each one is backed by a
-test or a workflow gate; ADR-002 (`specs/adrs/002-microvm-security-posture.md`)
-describes the threat model and `specs/plans/25-microvm-hardening.md`
-sequences the implementation. Claim 8 was added by plan 64
-(`specs/plans/64-supervisor-wiring.md`) — see ADR-041
-(`specs/adrs/041-signed-audited-execution-plans.md`). Claim 9 was added
-by Plan 73 Followup D (CI gate) — see ADR-047
-(`specs/adrs/047-app-deps-audit-pipeline.md`). Claim 10 was added by
-Plan 85 Phase E + F (the user-facing OCI image runner) — see
-`specs/claims/claim-10-oci-image-provenance.md`. (ADR-002's full claim
-table also names two additional cross-cutting claims for signed bundles
-and default-deny network policy; those are tracked there because they
-post-date the CLAUDE.md per-claim summary below.)
+mvm makes thirteen CI-enforced security claims. Each one is backed by
+a test or a workflow gate. **ADR-002
+(`specs/adrs/002-microvm-security-posture.md`) is the source of truth**
+for the claim numbering, threat model, and per-backend tier matrix;
+this section is the summary. Implementation is sequenced in
+`specs/plans/25-microvm-hardening.md`.
+
+Claim lineage:
+
+- Claims 1–7 ship with ADR-002's original posture.
+- Claim 8 was added by plan 64 (`specs/plans/64-supervisor-wiring.md`)
+  — see ADR-041 (`specs/adrs/041-signed-audited-execution-plans.md`).
+- Claim 9 (signed bundles content-addressed) is Sprint 52 W2.
+- Claim 10 (default-deny egress) is Sprint 52 W3.
+- Claim 11 (app-dep volume sealed) was added by ADR-047 / Plan 73
+  Followups A + B.1/B.2/B.3 + C + D
+  (`specs/adrs/047-app-deps-audit-pipeline.md`).
+- Claims 12 + 13 (host services broker — binding-gated dispatch and
+  no raw secret over broker channel) were added by Plan 104 / ADR-059
+  (`specs/adrs/059-host-services-broker.md`) /
+  ADR-049 (`specs/adrs/049-vsock-substitution-service.md`).
+
+A fourteenth property — **OCI image provenance recorded in the
+chain-signed audit log** — has its own claim doc at
+`specs/claims/claim-10-oci-image-provenance.md` and is enforced
+under the claim 8 admission flow; promotion to the ADR-002 numbered
+table is tracked in `specs/plans/111-cardoso-gap-coordination.md`.
+
+Companion docs: the Cardoso minimum-viable-policy mapping lives in
+ADR-002 §"Appendix: Cardoso minimum-viable-policy checklist", and
+the source gap analysis is at
+`specs/research/sandboxes-for-ai-cardoso-gap-analysis.md`.
 
 1. **No host-fs access from a guest beyond explicit shares.** Per-service
    uid (W2.1), seccomp `standard` default (W1.1, W2.4), and `setpriv
@@ -190,7 +209,24 @@ post-date the CLAUDE.md per-claim summary below.)
    (plan 64 W1–W4 — `synthesize_plan`, `host_signer::load_or_init_at`,
    `admit_for_run`, `AuditEmitter`; `xtask check-no-display-on-secret-types`
    protects the host signer's redacted `Debug`).
-9. **Every application-dep volume is hash-locked, attestation-checked,
+9. **Every published bundle is content-addressed, key_id-pinned, and
+   re-verified at fetch and at admit time.** Sprint 52 W2 +
+   admit-time re-verify follow-on. `mvm_plan::bundle::read_and_verify_bundle`
+   + `mvm_plan::bundle::verify_plan_bundle` exercise the
+   rejection ladder on every PR: unknown-key, tampered manifest,
+   key_id mismatch, tampered artifact, missing artifact, unsafe
+   path, schema bump, pin-archive sha256 drift, pin-signature
+   drift. `mvmctl bundle fetch` round-trip + `admit_for_run` tests
+   assert refusal on pin-without-context and pin-archive mismatch.
+10. **No untrusted workload reaches the network unless explicitly
+    admitted by policy.** Sprint 52 W3. `policy_default_is_deny_all`
+    + `test_resolve_network_policy_default_is_deny_all` assert the
+    default-deny posture; `mvmctl up` emits an opt-in warning when
+    the resolved policy is `unrestricted` (escape hatch is
+    `MVM_ACK_UNRESTRICTED_NETWORK=1`, never set in CI). Cardoso-flavoured
+    audit of DNS / vsock control-plane carve-out / Plan 104 broker
+    channels as covert egress is tracked in Plan 111 Workstream A.
+11. **Every application-dep volume is hash-locked, attestation-checked,
    CVE-scanned, SBOM-enumerated, and bound to the workload's audit
    chain.** ADR-047 / Plan 73 Followups A + B.1/B.2/B.3 + C + D wire
    this end-to-end: the builder VM (`mvm-builder-init` +
@@ -215,8 +251,34 @@ post-date the CLAUDE.md per-claim summary below.)
    cloud-hypervisor builder VM) is still gated on Plan 72 W4/W5
    cutover; the CI lane exercises every code path that doesn't
    require a working microVM backend.
-10. **Every `mvmctl run --image <oci-ref>` admission records the OCI
-    image provenance in the chain-signed audit log.** Plan 85 Phase E
+12. **Every host-side service the broker exposes is bound to a signed
+    `ExecutionPlan.services` binding, enforced before handler
+    dispatch, and audited via the chain-signed log.** Plan 104 W2 /
+    ADR-059. `service_call_denied_when_unbound` +
+    `service_call_denied_outside_profile` +
+    `audit_chain_contains_service_call_entries` +
+    `audit_chain_carries_no_payload_bytes` exercise the rejection
+    ladder. `xtask check-handler-adr-coverage` +
+    `xtask check-handler-policy-schema` +
+    `xtask check-handler-composition` lint the handler registry.
+    `fuzz_service_call.rs` (Plan 104 W6) exercises the dispatch
+    surface.
+13. **No raw secret value crosses the broker channel.**
+    `host.secrets.v1` returns destination-bound, time-bound signed
+    credentials only; raw secret bytes never leave the supervisor's
+    address space. Plan 104 W5 / ADR-049 / ADR-059.
+    `host_secrets_v1_denied_outside_allowed_destinations` +
+    `zeroize_drop_zeros_secret_bytes` +
+    `handler_inter_call_memory_hygiene` +
+    `host_secrets_v1_signed_payload_jcs_roundtrip` +
+    `secrets_subprocess_cannot_reach_supervisor_memory` +
+    `placeholder_in_outbound_request_dropped_and_audited`
+    (S25 backstop) tests; ADR-049 hostile-guest matrix in W7.
+14. **Every `mvmctl run --image <oci-ref>` admission records the OCI
+    image provenance in the chain-signed audit log.** Tracked as a
+    standalone claim doc at
+    `specs/claims/claim-10-oci-image-provenance.md`; promotion to
+    the ADR-002 numbered table is queued in Plan 111. Plan 85 Phase E
     + F wire the user-facing OCI image runner to the same audit chain
     that backs claim 8 — see `specs/claims/claim-10-oci-image-provenance.md`.
     `mvmctl image pull` materializes the layer set in `mvm-oci`'s

--- a/specs/adrs/002-microvm-security-posture.md
+++ b/specs/adrs/002-microvm-security-posture.md
@@ -389,3 +389,48 @@ uid because of a use case we didn't foresee):
   discourse (e.g. <https://emirb.github.io/blog/microvm-2026/>);
   the same defense-in-depth pattern is used by Fly.io Sprites,
   AWS Lambda SnapStart, Vercel Sandbox, and Kata Containers.
+
+## Appendix: Cardoso minimum-viable-policy checklist
+
+Maps Cardoso's five-bullet "minimum viable policy" from
+[A field guide to sandboxes for AI][cardoso] (2026-01-05) to mvm's
+posture against the 13 CI-enforced claims in §"The CI-enforced
+claims." Source-of-truth gap analysis at
+[`specs/research/sandboxes-for-ai-cardoso-gap-analysis.md`](../research/sandboxes-for-ai-cardoso-gap-analysis.md);
+workstream tracker at
+[`specs/plans/111-cardoso-gap-coordination.md`](../plans/111-cardoso-gap-coordination.md).
+
+[cardoso]: https://www.luiscardoso.dev/blog/sandboxes-for-ai
+
+| Cardoso bullet | mvm status | Mechanism / claim | Evidence |
+|---|---|---|---|
+| Default-deny outbound, then allowlist (or policy proxy) | **pass** | **claim 10** | `policy_default_is_deny_all`; `test_resolve_network_policy_default_is_deny_all`; `mvmctl up` warns on `unrestricted` policy with explicit env opt-out. DNS / broker / vsock carve-out audit tracked in Plan 111 Workstream A. |
+| No long-lived credentials; short-lived scoped tokens | **pass** | **claim 8** + **claim 13** | G4 validity window + nonce on signed `ExecutionPlan`; Plan 104 `host.secrets.v1` returns destination-bound, time-bound signed credentials; raw secret bytes never leave the supervisor's address space. |
+| Workspace-only filesystem; no host mounts beyond explicit shares | **pass** | **claim 1** | Per-service uid; seccomp `standard`; setpriv `--no-new-privs`; read-only bind-mounts on `/etc/{passwd,group,nsswitch.conf}`. |
+| Resource limits: CPU / memory / disk / timeouts / PIDs | **partial** | CPU + memory + disk wired; `ExecutionPlan.resources` scaffolded; `timeout_seconds` / `pid_limit` not populated | Plan 37 §3.3 to be extended; ADR-041 schema table to be amended (Plan 111 Workstream C). |
+| Observability — log process tree, network egress, failures | **pass** | **claim 8** + **claim 10** + **claim 12** | Chain-signed `~/.mvm/audit/<tenant>.jsonl`; `mvmctl audit verify` exits non-zero on tampering; service-call entries via `audit_chain_contains_service_call_entries`. |
+
+### Beyond Cardoso's minimum
+
+Properties mvm enforces that Cardoso's framework does not ask for.
+Listed here for the audit-cleanly reader.
+
+| Property | mvm status | Mechanism / claim |
+|---|---|---|
+| Hermetic builds — host environment never influences artifact | **pass** | "No host Nix, ever" (CLAUDE.md); source-checkout builds never depend on mvm-published artifacts (ADR-046) |
+| Signed admission-checked execution plans | **pass** | claim 8 |
+| Signed re-verified content-addressed bundles | **pass** | claim 9 |
+| Hash-locked, SBOM-bound, CVE-scanned, attested dependency volumes | **pass** | claim 11 (ADR-047) |
+| dm-verity rootfs that panics on tamper | **pass** | claim 3 |
+| Reproducibility double-build of host code | **pass** | claim 7 |
+| Production guest agent ships without `do_exec` | **pass** | claim 4 |
+| Host-side broker dispatch is binding-gated and audited | **pass** | claim 12 (Plan 104 / ADR-059) |
+| No raw secret crosses the broker channel | **pass** | claim 13 (Plan 104 / ADR-049 / ADR-059) |
+
+### Cardoso three-question summary
+
+| Question | mvm answer |
+|---|---|
+| What is shared between this code and the host? | KVM `/dev/kvm` ioctls (Linux); Hypervisor.framework calls (macOS Vz / libkrun); vsock for control plane + brokered host services (binding-gated per claim 12); one explicit virtio-fs share per declared mount. Host filesystem is never ambient. |
+| What can the code touch? | Whatever the signed `ExecutionPlan` admits: declared shares, declared egress allowlist (claim 10), declared volumes, declared `host.*` brokered services (claim 12 binding). No raw devices. No host process namespace. No host network namespace. |
+| What survives between runs? | Volumes the plan declares persistent (sealed deps volumes are RO and hash-locked per claim 11). Everything else is ephemeral by default. Snapshot/restore on workload microVMs not yet exposed — see Plan 111 Workstream B. SDK workload hooks (`before_build` / `before_start` / `after_start` / `before_stop` in `crates/mvm-sdk/src/compile/hooks.rs`) shape what runs at launch, not what survives across launches. |

--- a/specs/plans/111-cardoso-gap-coordination.md
+++ b/specs/plans/111-cardoso-gap-coordination.md
@@ -1,0 +1,306 @@
+# Plan 111 — Cardoso gap coordination
+
+**Source post:** Luis Cardoso, [A field guide to sandboxes for AI](https://www.luiscardoso.dev/blog/sandboxes-for-ai), 2026-01-05.
+**Companion docs:** [`specs/research/sandboxes-for-ai-cardoso-gap-analysis.md`](../research/sandboxes-for-ai-cardoso-gap-analysis.md) (raw audit) · [`specs/adrs/002-microvm-security-posture.md` §"Appendix: Cardoso minimum-viable-policy checklist"](../adrs/002-microvm-security-posture.md) (per-claim mapping).
+
+## Goal
+
+Make mvm's public posture audit-cleanly against Cardoso's
+boundary × policy × lifecycle rubric **by amending existing plans
+and ADRs** rather than standing up a parallel tracker. The raw
+research lives at `specs/research/`; the per-claim checklist lives
+in ADR-002. This plan is the coordination tracker for the
+follow-up edits.
+
+## Why this is a coordination plan, not a new feature plan
+
+A first-pass analysis assumed many gaps were unowned. A verification
+pass found that most of them already have owning plans or ADRs.
+Each Cardoso concern maps onto an existing target:
+
+| Cardoso concern | Owning plan / ADR | Verified status |
+|---|---|---|
+| Default-deny egress | **ADR-002 claim 10** + Plan 34 + Plan 79 | CI-claimed via `policy_default_is_deny_all` + `test_resolve_network_policy_default_is_deny_all`. Cardoso's specific holes (DNS, vsock carve-out, broker channels) need audit against the existing gate. |
+| VM-level snapshot / restore | **Plan 65** (`VmBackend::snapshot/restore` trait) | Trait scaffolded; cross-claim interactions not enumerated. |
+| Paused-pool / warm-pool | None (Plan 43 is in-guest warm-process pools — different layer) | True gap. |
+| Resource limits in `ExecutionPlan` (timeout / PID) | **Plan 37** + ADR-041 | `resources` field scaffolded; `timeout_seconds` / `pid_limit` not populated. |
+| GPU stance | **ADR-002 §"Per-backend tier matrix"** | Posture allows Cloud Hypervisor as Tier-1 peer for VFIO / GPU. No backend ships VFIO today. Treated as future; no current GPU dependency. |
+| Cold-start measurement | **Plan 74** (already names "measured cold-starts") | Named; no benchmark lane yet. |
+| README workload-shape + mvmctl/mvmd split | None (README) | True gap. Docs work. |
+| Plan 104 framing as policy-proxy | **Plan 104 + ADR-059 + ADR-049** | Claim 12 + claim 13 already implement binding-gated dispatch + no-raw-secret broker — the Cardoso "policy proxy" framing is largely already true. One-paragraph framing tweak. |
+| TCB inventory | Distributed across ADR-002 + ADR-055 + ADR-061 | Consolidation into ADR-002 is the work. |
+| Threat-model vocabulary | **ADR-002 §"Threat model"** | Verified: not in flight in any active worktree against this section (`mvm-security-threat-model` is 10+ commits stale; `mvm-threat-model-02` adds a STRIDE doc for the broker, does not touch ADR-002's threat-model section). Safe to proceed. |
+| **CLAUDE.md stale claim list** | **CLAUDE.md §"Security model"** | Lists 10 claims; ADR-002 has 13. CLAUDE.md claims 1–8 align; CLAUDE.md claim 9 (app-dep) = ADR-002 claim 11; CLAUDE.md claim 10 (OCI) not yet a numbered ADR-002 claim. Reconciliation needed. |
+
+That table is the actual work plan. Workstreams below convert each
+row into a concrete edit target.
+
+## Non-goals
+
+- Standing up a parallel security-claims taxonomy. ADR-002 is the
+  source of truth; CLAUDE.md is the summary. This plan reconciles
+  them.
+- Reopening the multi-tenant scope decision. ADR-002 puts
+  multi-tenant guests out of scope; mvmd owns multi-tenancy. This
+  plan adds a README signal so external readers see the split up
+  front.
+- Hardware-backed attestation (SEV-SNP/TDX). ADR-002 already
+  excludes this. Aligned with Cardoso's framing; no work here.
+- Wasm / V8 isolate boundary. Cardoso routes "tool calling" to
+  those boundaries; not our shape.
+- Shipping GPU support now. ADR-002 allows the posture (Cloud
+  Hypervisor as Tier-1 peer); we don't depend on GPU today.
+  Workstream D is filed as future / deferred.
+
+## Security implications and cross-claim interactions
+
+Surfaced during the analysis; preserved here because they remain
+binding for the sub-plans below. Each item names the workstream
+that must own it.
+
+- **Snapshot/restore × five other claims** — entropy reuse;
+  claim 8 admission-vs-continuation semantics; claim 3 dm-verity
+  re-check at restore; claim 7 reproducibility carve-out; audit
+  chain branching policy. *Owner: Workstream B (Plan 65
+  amendment).*
+- **GPU passthrough × claim 11** — model weights as deps. If/when
+  Workstream D is reopened, claim 11 either extends to cover model
+  weights or a new claim is added. *Owner: Workstream D (deferred).*
+- **Egress claim 10 has three subtle holes** — DNS as
+  side-channel; Plan 104 broker channels as covert egress; vsock
+  control plane as egress requiring explicit carve-out. *Owner:
+  Workstream A.*
+- **Resource-limit additions are hard backwards-incompatibility** —
+  mandatory `timeout_seconds` / `pid_limit` invalidates every
+  existing signed plan. Per memory
+  `feedback_no_backcompat_first_version` that is policy; flag in
+  the PR description. *Owner: Workstream C.*
+- **Threat-model vocabulary needs a fourth category for deps** —
+  Cardoso's hostile / semi-trusted / trusted misses "audited
+  semi-trusted." *Owner: Workstream G.*
+- **Disclosure trade-off** — publishing the gap analysis + the
+  Cardoso checklist + the TCB inventory is a deliberate disclosure;
+  ADR-002 and the claim table are already public. State this in
+  the plan rationale; do not soften.
+- **mvmd alignment before publishing the multi-tenant signal** —
+  Workstream F must sync with mvmd maintainers (or read current
+  mvmd ADRs) before the README rewrite ships.
+
+## Workstreams
+
+Every workstream names its **target file** so this remains a
+coordination tracker rather than a parallel tracker.
+
+### A — Default-deny egress: close Cardoso's three holes, sync CLAUDE.md
+
+Target: `specs/plans/34-egress-l7-proxy.md` (amend) +
+`specs/plans/79-*` (extend if needed) + `CLAUDE.md` (sync claim
+list).
+
+- [ ] Read ADR-002 claim 10 evidence (`policy_default_is_deny_all`,
+      `test_resolve_network_policy_default_is_deny_all`) to confirm
+      what's actually gated.
+- [ ] Audit DNS handling: does the default-deny policy cover UDP/53,
+      or does it slip through?
+- [ ] Audit Plan 104 broker channels: are `host.*` vsock services
+      treated as egress for policy purposes? If not, document why
+      (binding-gated dispatch is the answer per claim 12) or extend
+      the CI gate to assert.
+- [ ] Confirm vsock control-plane port allowlist is explicit (W1.3
+      per CLAUDE.md is the existing gate).
+- [ ] Extend Plan 34's CI lane (if missing) so a default plan
+      refuses DNS to non-allowlisted resolvers, not just TCP.
+- [x] Sync CLAUDE.md §"Security model" with ADR-002's 13-claim
+      table. *Landed in this plan's PR.*
+
+### B — VM-level snapshot/restore: amend Plan 65 with cross-claim interactions
+
+Target: `specs/plans/65-*.md` (existing snapshot/restore trait
+plan).
+
+- [ ] **Decision** to make before amending: ship snapshot on
+      Firecracker workload microVMs, drop it, or defer it. Default
+      recommendation: ship, with the security sub-bullets below.
+- [ ] Amend Plan 65 with §"Cross-claim interactions" enumerating:
+      entropy reseed at resume (virtio-rng / vsock entropy delivery
+      before vCPU unfreeze); claim 8 admission policy
+      (continuation-within-G4 vs re-admission; default reject if
+      G4 expired); claim 3 dm-verity re-check or snapshot-hash
+      verification at restore; claim 7 reproducibility carve-out
+      (workload-runtime non-determinism is expected under restore);
+      audit chain branching policy (default reject;
+      `verify_audit_chain` learns to reject diverged chains).
+- [ ] Decide warm-pool stance in the same plan or carve it out as a
+      Plan 65 follow-up.
+
+### C — Resource-limit completeness: extend Plan 37 + ADR-041
+
+Target: `specs/plans/37-*.md` + `specs/adrs/041-signed-audited-execution-plans.md`.
+
+- [ ] Audit `crates/mvm-plan/src/plan.rs` to confirm the `Resources`
+      field shape today.
+- [ ] Extend Plan 37 §3.3 with mandatory `timeout_seconds` and
+      `pid_limit` fields; the planner errors if absent.
+- [ ] Amend ADR-041 schema table with the new fields. The
+      backwards-incompatibility is documented in the PR description;
+      no migration shim per memory
+      `feedback_no_backcompat_first_version`.
+- [ ] Wire enforcement: cgroup PID cap on Firecracker; document
+      Vz / libkrun parity (or non-parity) per backend.
+- [ ] Update the ADR-002 Cardoso checklist row for "resource
+      limits" from **partial** to **pass** once these land.
+
+### D — GPU stance: deferred future item
+
+**Status: future / deferred.** No current GPU dependency.
+ADR-002 §"Per-backend tier matrix" already lists Cloud Hypervisor
+as Tier-1 peer "selected over Firecracker when a workload needs
+VFIO / GPU passthrough or virtio-fs." The posture is allowed; we
+don't ship the backend today and won't unless a user need surfaces.
+
+Recorded so it doesn't get lost; not actively scheduled.
+
+If this is ever reopened:
+
+- Verify ADR-013 §"Cloud Hypervisor" and Plan 54 status (Plan 54's
+  "door closed" framing may be stale relative to ADR-002 line 307).
+- Pick the implementation path: Cloud Hypervisor + VFIO; hybrid
+  "GPU service outside mvm"; or silent gap.
+- **Prerequisite (not a follow-up):** extend claim 11 (app-dep
+  audit) to cover model weights, or add a claim 14 for "model
+  assets sealed and attestation-checked." Either is fine; pick
+  in the reopening plan.
+- Update ADR-055 cross-backend invariants with the GPU-passthrough
+  isolation requirements (IOMMU, device firmware trust posture).
+
+### E — Cold-start measurement: extend Plan 74
+
+Target: `specs/plans/74-*.md`.
+
+- [ ] Add a perf lane that measures `mvmctl up <image>` → guest
+      PID 1 active per backend (libkrun macOS, Firecracker Linux,
+      Vz macOS 26+ AS).
+- [ ] Publish numbers in README + docs.
+- [ ] Re-measure after Workstream B if snapshot ships.
+
+### F — README workload-shape + mvm/mvmd split
+
+Target: `README.md` (no existing plan home; smallest workstream).
+
+- [ ] Rewrite README first paragraph: name target shapes
+      (devbox + code-interpreter); name pending shape (RL — depends
+      on Workstream B); name non-goals (tool calling = Wasm;
+      GPU = deferred per Workstream D); state host trust assumption
+      (host trusted, workload bytes hostile or model-generated);
+      name mvmctl single-tenant vs mvmd multi-tenant split.
+- [ ] Sync with mvmd maintainers (or read current mvmd ADRs/specs)
+      before publishing the multi-tenant signal.
+
+### G — Threat-model vocabulary: proceed (no in-flight conflict)
+
+Target: `specs/adrs/002-microvm-security-posture.md` §"Threat
+model."
+
+Verified: `mvm-threat-model-02` adds a STRIDE doc for the host
+services broker; does not touch ADR-002 §threat model.
+`mvm-security-threat-model` is 10+ commits stale and effectively
+abandoned. Safe to proceed.
+
+- [ ] Add a short section to ADR-002 §"Threat model" adopting
+      Cardoso's hostile / semi-trusted / trusted vocabulary plus
+      an explicit fourth category for "audited semi-trusted"
+      (pinned + SBOM + attestation + CVE-scanned dependencies per
+      claim 11). State: workload bytes hostile, deps audited
+      semi-trusted, host trusted, multi-tenant guests out of scope.
+
+### H — Plan 104 framing: one-paragraph Cardoso citation
+
+Target: `specs/plans/104-*.md` narrative + `specs/adrs/059-*.md`
+§Discussion.
+
+- [ ] Claim 12 + claim 13 already cover the binding-gated dispatch
+      + no-raw-secret properties. Add one paragraph to Plan 104
+      narrative and ADR-059 §Discussion explicitly naming the
+      connection to Cardoso's policy-proxy / brokered-syscall
+      pattern. No code change.
+- [ ] If we want explicit per-request scope-check in
+      `host.secrets.v1` beyond what binding-gating already
+      provides, add a follow-up bullet to Plan 104 W5; otherwise
+      close.
+
+### I — TCB inventory: consolidate into ADR-002
+
+Target: `specs/adrs/002-microvm-security-posture.md` (new
+§"Trusted computing base inventory" — cross-links to ADR-055 +
+ADR-061).
+
+- [ ] Add a §"Trusted computing base inventory" table to ADR-002
+      enumerating libkrun (C), libkrunfw kernel, passt / gvproxy
+      (C / Go), Firecracker (Rust), guest kernel, host kernel,
+      `mvm-libkrun-supervisor`, `mvm-supervisor`,
+      `mvm-guest-agent`, vsock host proxy, `mvm-builder-init`,
+      dm-verity sidecar, host signer, audit emitter. Each row:
+      language, review status, fuzz coverage, upstream tracking.
+- [ ] Cross-link from ADR-055 §"New untrusted-input surfaces" and
+      ADR-061 §"Implementation choices."
+
+### J — Persist analysis + checklist + this plan
+
+Target: `specs/research/sandboxes-for-ai-cardoso-gap-analysis.md`
++ `specs/adrs/002-microvm-security-posture.md` §"Appendix:
+Cardoso minimum-viable-policy checklist" + this file
+(`specs/plans/111-cardoso-gap-coordination.md`).
+
+- [x] Write `specs/research/sandboxes-for-ai-cardoso-gap-analysis.md`.
+- [x] Append §"Appendix: Cardoso minimum-viable-policy checklist"
+      to ADR-002.
+- [x] Write this plan at `specs/plans/111-cardoso-gap-coordination.md`.
+
+## Build sequence
+
+1. **J + part of A** (this PR) — persist the research note, the ADR-002
+   appendix, this plan, and the CLAUDE.md security-model sync.
+2. **A remainder** — audit Cardoso's egress holes (DNS, broker, vsock
+   carve-out) against the existing claim-10 CI gate; extend Plan 34
+   if anything is missing.
+3. **C** — extend Plan 37 + ADR-041 for timeout / PID. Small.
+4. **G** — Cardoso threat-model vocabulary in ADR-002.
+5. **H + I + F** — docs-only sweeps. Can parallelize.
+6. **E** — cold-start numbers via Plan 74.
+7. **B** — snapshot decision + Plan 65 amendment.
+8. **D** — deferred future. Reopen only if a GPU workload need
+   surfaces.
+
+## Verification
+
+- After J: `ls specs/research/` shows the new file; ADR-002 has the
+  appendix; this plan exists at `specs/plans/111-…md`; CLAUDE.md
+  §security claims reflects ADR-002's 13-claim table.
+- After A remainder: CI exercises DNS in the default-deny check;
+  broker channels and vsock control plane are documented as
+  carve-outs.
+- After C: every `ExecutionPlan` carries timeout + PID limits or
+  documents per-backend exception.
+- After all docs-only workstreams: a reader handed Cardoso's post,
+  ADR-002, the research note, and this plan can answer his
+  three-question model about mvm.
+
+## Success criteria
+
+- [x] CLAUDE.md §"Security model" reflects ADR-002's 13 claims
+      with correct numbering. *Landed in this PR.*
+- [x] ADR-002 has §"Appendix: Cardoso minimum-viable-policy
+      checklist." *Landed in this PR.*
+- [x] `specs/research/sandboxes-for-ai-cardoso-gap-analysis.md`
+      exists and is cited from ADR-002. *Landed in this PR.*
+- [ ] ADR-002 has §"Trusted computing base inventory" appendix
+      (Workstream I).
+- [ ] README first paragraph names target shape + host trust
+      posture + mvmctl/mvmd split (Workstream F).
+- [ ] Plan 65 §"Cross-claim interactions" enumerates the five
+      snapshot security implications (Workstream B).
+- [ ] Snapshot decision made and reflected (Workstream B).
+- [ ] At least one published cold-start number per backend
+      (Workstream E).
+- GPU / Cloud Hypervisor decision is *deferred* (Workstream D);
+  not a blocking success criterion.

--- a/specs/research/sandboxes-for-ai-cardoso-gap-analysis.md
+++ b/specs/research/sandboxes-for-ai-cardoso-gap-analysis.md
@@ -1,0 +1,158 @@
+# Sandboxes for AI — Cardoso gap analysis
+
+**Source:** Luis Cardoso, [A field guide to sandboxes for AI](https://www.luiscardoso.dev/blog/sandboxes-for-ai), 2026-01-05.
+**Analysed:** 2026-05-28.
+**Companion docs:** [ADR-002 §"Cardoso minimum-viable-policy checklist"](../adrs/002-microvm-security-posture.md) (checklist + three-question summary) and [Plan 111 — Cardoso gap coordination](../plans/111-cardoso-gap-coordination.md) (workstream tracker).
+
+This file captures the raw audit of mvm's public posture against Cardoso's
+three-decision model (boundary × policy × lifecycle) and his "minimum viable
+policy" checklist, so it can be cited from ADRs and plans without re-deriving
+it. ADR-002 carries the canonical checklist; the plan carries the workstream
+list. This research note is the why and how.
+
+## TL;DR
+
+mvm sits exactly where Cardoso's decision table sends "AI coding
+agent + shell + don't fully trust the code": **Firecracker microVM
+on Linux KVM, libkrun on macOS, Apple Container on macOS 26+ AS**,
+with Cloud Hypervisor as a Tier-1 peer for VFIO / GPU workloads.
+On the *boundary* axis we are aligned. On the *policy* axis we
+**meet or over-deliver** vs his minimum viable policy: default-deny
+egress is already claim 10; signed `ExecutionPlan` (claim 8), sealed
+bundles (claim 9), sealed deps volumes (claim 11), no-raw-secret
+broker (claim 13) sit above his floor. The remaining policy gap is
+`timeout_seconds` + `pid_limit` on `ExecutionPlan`. On the *VM
+lifecycle* axis we under-deliver: Plan 65 scaffolds snapshot/restore
+trait but the cross-claim semantics are not enumerated, and there
+is no warm-pool. SDK workload hooks (different axis) are fully
+present. Open gaps for the AI-positioning reader: GPU implementation
+(posture allowed but backend not enabled — deferred, no current
+GPU dependency), published cold-start numbers, README workload-shape
+taxonomy.
+
+## Where Cardoso's framework and mvm's claims align
+
+| Cardoso position | mvm's matching mechanism |
+|---|---|
+| "Shell + package managers + don't fully trust code → microVM" | Firecracker on Linux KVM; libkrun / Apple Container on macOS; Cloud Hypervisor as Tier-1 peer (ADR-002 §"Per-backend tier matrix"). |
+| Firecracker's "intentionally boring" device model: net / block / vsock / console | Inherited unchanged. |
+| Jailer = chroot + namespaces + cgroups + privilege drop + 24-syscall / 30-ioctl seccomp | Inherited from Firecracker on Linux. On the libkrun host side: one `mvm-libkrun-supervisor` per VM with fuzzed `SupervisorConfig` parser (claim 5 + Plan 88 W6). |
+| "MicroVM still needs strong policy or it's a high-powered exfil box" | Explicit shares only (claim 1) + signed `ExecutionPlan` admission (claim 8) + sealed deps volumes (claim 11) + default-deny egress (claim 10). |
+| Workspace-only filesystem; no ambient host mounts | Claim 1. |
+| "Observability — sandboxes without telemetry become incident-response theater" | Chain-signed audit log; `mvmctl audit verify` exits non-zero on tampering. Service-call entries per claim 12 (Plan 104 / ADR-059). |
+| Default-deny egress + allowlist | Claim 10 — `policy_default_is_deny_all` + `test_resolve_network_policy_default_is_deny_all`. |
+| No long-lived credentials | Claim 8 G4 validity window + claim 13 destination-bound + time-bound credentials (Plan 104 / ADR-049 / ADR-059). |
+| Policy proxy / brokered syscall pattern | Claim 12 binding-gated dispatch + claim 13 no-raw-secret broker. |
+| libkrun named for "local agents on macOS/ARM64 are a first-class workflow" | Entire macOS path is libkrun (Vz on 26+ AS for builds). |
+| "Embedded VMM → treat the VMM process itself as part of your TCB" | `mvm-libkrun-supervisor` is exactly this pattern. |
+| Hardware-backed isolation a "different threat model" | ADR-002 explicitly puts hardware-backed key attestation out of scope. |
+| "Multi-tenant changes everything" | Multi-tenant guests out of scope; mvmd handles fleet. |
+
+## Where mvm goes beyond Cardoso's minimum-viable-policy
+
+Properties mvm enforces that Cardoso's framework does not ask for:
+
+- **Signed, admission-checked execution plans** (claim 8): Ed25519 host
+  signer, G4 validity window, replay-store, audit chain.
+- **Signed content-addressed bundles** re-verified at fetch and admit
+  (claim 9).
+- **Sealed dependency volumes with SBOM + CVE + attestation**
+  (claim 11, ADR-047): hash-locked deps; `--prod` fails closed on
+  high/critical CVEs; `mvmctl deps inspect` exposes sealed sidecars
+  without a VM spawn.
+- **dm-verity'd rootfs that panics on tamper** (claim 3): kernel
+  panics before userspace on a flipped data block.
+- **`prod-agent-no-exec` CI symbol-absence gate** (claim 4):
+  production guest agent ships without `do_exec`.
+- **Host-side broker with binding-gated dispatch + audit** (claim 12,
+  Plan 104 / ADR-059).
+- **No raw secret over broker channel** (claim 13, ADR-049).
+- **Cargo deny + reproducibility double-build** (claim 7).
+- **Hermetic builds — no host Nix, no host artifact dependency**
+  (ADR-046 invariant): host environment never influences the artifact;
+  source-checkout builds never depend on mvm-published artifacts.
+
+## Gaps Cardoso's framework still exposes
+
+Ordered by external-credibility impact.
+
+1. **CLAUDE.md is out of date.** Lists 10 claims; ADR-002 has 13.
+   CLAUDE.md claims 1–8 align with ADR-002 1–8; CLAUDE.md claim 9
+   (app-dep audit) maps to ADR-002 **claim 11**; CLAUDE.md claim 10
+   (OCI provenance) is not yet a numbered ADR-002 claim. ADR-002
+   adds claims 9 (signed bundles), 10 (default-deny egress), 12
+   (broker binding-gated dispatch), 13 (no-raw-secret broker channel)
+   that CLAUDE.md doesn't enumerate.
+   *Workstream A* in Plan 111.
+2. **VM-level snapshot/restore cross-claim semantics unwritten.**
+   Plan 65 scaffolds the `VmBackend::snapshot` / `restore` trait but
+   the cross-claim interactions are unaddressed:
+   - **Entropy reuse.** Restored VM continues from post-boot RNG
+     state; repeated restores produce duplicate randomness.
+     Mitigation: reseed `/dev/urandom` via virtio-rng or vsock-
+     delivered entropy before vCPU unfreeze.
+   - **Claim 8 admission vs continuation.** Signed `ExecutionPlan`
+     was admitted once with G4 validity window + nonce; restore
+     must define continuation-within-window vs re-admit semantics.
+   - **Claim 3 dm-verity re-check.** Verified boot runs once;
+     snapshot bypassing boot path skips re-verification unless
+     snapshot file is hash-pinned and verified at resume.
+   - **Claim 7 reproducibility carve-out.** Snapshots inject
+     workload-runtime non-determinism the double-build can't
+     reproduce; the claim must explicitly carve out restore-time
+     delta.
+   - **Audit chain integrity.** Two restores from one snapshot
+     produce two divergent chains rooted at the same parent;
+     `verify_audit_chain` must reject or explicitly support
+     branching.
+   *Workstream B* in Plan 111.
+3. **GPU implementation gap.** ADR-002 §"Per-backend tier matrix"
+   already lists Cloud Hypervisor as Tier-1 peer for VFIO / GPU
+   passthrough; the posture is allowed. No backend currently ships
+   VFIO. *Workstream D — deferred, no current GPU dependency.*
+4. **No published cold-start number.** E2B, Modal, Daytona, Vercel
+   Sandbox all publish one. Plan 74 names this work. *Workstream E*
+   in Plan 111.
+5. **Workload-shape taxonomy missing from README positioning.**
+   Cardoso's devbox / code-interpreter / tool-calling / RL split is
+   becoming field vocabulary. mvm doesn't slot itself. *Workstream F*
+   in Plan 111.
+6. **Multi-tenant story split across two repos without README
+   signal.** Cardoso routes "multi-tenant SaaS" to microVMs —
+   readers will land on mvm assuming we ship that. Need to name
+   mvmctl single-tenant vs mvmd multi-tenant up front. *Workstream F*
+   in Plan 111.
+7. **Threat-model vocabulary drift.** Cardoso uses hostile /
+   semi-trusted / trusted explicitly; ADR-002 doesn't reconcile to
+   those words. Third-party dependencies need a fourth category
+   ("audited semi-trusted") since claim 11 treats them as pinned +
+   SBOM + attested + CVE-scanned. *Workstream G* in Plan 111.
+8. **TCB inventory** distributed across ADR-002 §"Trust layers
+   (Matryoshka model)" + ADR-055 §"New untrusted-input surfaces" +
+   ADR-061 §"Implementation choices." No single readable
+   enumeration. *Workstream I* in Plan 111.
+9. **Plan 104 is Cardoso's policy-proxy pattern but doesn't say
+   so.** Claim 12 + claim 13 implement binding-gated dispatch and
+   no-raw-secret broker — the framing matches Cardoso's policy
+   proxy. One-paragraph citation tweak. *Workstream H* in Plan 111.
+10. **Resource-limit completeness.** Cardoso names CPU / memory /
+    disk / timeouts / PIDs. `ExecutionPlan.resources` is scaffolded;
+    `timeout_seconds` and `pid_limit` are not populated.
+    *Workstream C* in Plan 111.
+
+## Cardoso's three-question model applied to mvm
+
+| Question | mvm answer |
+|---|---|
+| What is shared between this code and the host? | KVM `/dev/kvm` ioctls (Linux); Hypervisor.framework calls (macOS Vz / libkrun); vsock for control plane + brokered host services (binding-gated per claim 12); one explicit virtio-fs share per declared mount. Host filesystem is never ambient. |
+| What can the code touch? | Whatever the signed `ExecutionPlan` admits: declared shares, declared egress allowlist (claim 10), declared volumes, declared `host.*` brokered services (claim 12 binding). No raw devices. No host process namespace. No host network namespace. |
+| What survives between runs? | Volumes the plan declares persistent (sealed deps volumes are RO and hash-locked per claim 11). Everything else is ephemeral by default. Snapshot/restore on workload microVMs not yet exposed — see Workstream B in Plan 111. SDK workload hooks (`before_build` / `before_start` / `after_start` / `before_stop` in `crates/mvm-sdk/src/compile/hooks.rs`) shape what runs at launch, not what survives across launches. |
+
+## Disclosure trade-off
+
+Publishing this gap analysis, the ADR-002 Cardoso checklist, and (in
+Workstream I) a consolidated TCB inventory is a deliberate disclosure.
+ADR-002 and the claim table are already public; this extends the same
+posture. External scrutiny improves the system. The author of the
+source post would call this an instance of "treat profiles as code:
+version them, test them, and expect them to evolve."


### PR DESCRIPTION
## Summary

- **Audit:** mvm's posture vs Luis Cardoso, [*A field guide to sandboxes for AI*](https://www.luiscardoso.dev/blog/sandboxes-for-ai) (2026-01-05). Boundary axis aligned (Firecracker / libkrun / Vz, CH as Tier-1 peer); policy axis meets or exceeds his minimum viable policy; VM-lifecycle axis under-delivered (Plan 65 trait scaffolded, cross-claim semantics unwritten).
- **CLAUDE.md ↔ ADR-002 reconciled:** §"Security model" was 10 claims; ADR-002 has 13. Renumbered with ADR-002 as source of truth. Adds claim 9 (signed bundles, Sprint 52 W2), claim 10 (default-deny egress, Sprint 52 W3), claims 12 + 13 (host services broker — Plan 104 / ADR-059 / ADR-049). OCI provenance is now claim 14, pointing at its standalone claim doc pending promotion.
- **Coordination tracker, not a parallel tracker:** Plan 111 maps each Cardoso concern onto its owning plan/ADR (34, 65, 37, 41, 74, 104, etc.) so we flatten TODOs into existing work. Workstream D (GPU / Cloud Hypervisor) deferred — no current GPU dependency. Workstream G (threat-model vocabulary) verified unblocked; neither active threat-model worktree conflicts.

## Files

- `specs/research/sandboxes-for-ai-cardoso-gap-analysis.md` (new) — raw audit, citable from ADRs/plans
- `specs/adrs/002-microvm-security-posture.md` (appendix) — Cardoso minimum-viable-policy checklist + three-question summary + "Beyond Cardoso's minimum" table
- `specs/plans/111-cardoso-gap-coordination.md` (new) — workstream tracker with concrete edit targets in existing plans/ADRs
- `CLAUDE.md` — §"Security model" synced to ADR-002's 13-claim numbering

## Test plan

Docs-only PR; no code or CI gates change.

- [ ] Verify Cardoso checklist renders correctly in the ADR-002 appendix table
- [ ] Verify CLAUDE.md claim numbering matches ADR-002 §"The CI-enforced claims" 1-to-1 (claims 1–13; the appendix paragraph + claim 14 for OCI provenance pending promotion)
- [ ] Verify `specs/plans/111` cross-links resolve (research note + ADR-002 appendix)
- [ ] Confirm no overlap with in-flight threat-model worktrees (`mvm-threat-model-02` STRIDE doc is broker-scoped; `mvm-security-threat-model` is stale)

🤖 Generated with [Claude Code](https://claude.com/claude-code)