### PR TITLE
feat: Plan 112 — Plan 102 Phase 3c (W6.A producer activation)

### DIFF
--- a/crates/mvm-backend/src/audit_substrate.rs
+++ b/crates/mvm-backend/src/audit_substrate.rs
@@ -1,0 +1,182 @@
+//! Plan 112 Phase 3c — shared audit-substrate resolution for backends
+//! that own a `SupervisorConfig`-shaped audit surface (libkrun, Vz).
+//!
+//! Lifts the path-derivation + `vm_name` / `tenant_id` allowlist
+//! validation out of the per-backend `start()` paths so libkrun.rs and
+//! vz.rs share one source of truth. The next plan after 112 — a
+//! `NetworkProvider` trait — will lift `compute_audit_substrate(...)`
+//! into a trait method (`provider.activate_audit(...)`). Keeping the
+//! free-function signature stable now makes that extraction mechanical.
+//!
+//! Today there's no trait; just one shared module.
+
+use anyhow::{Result, bail};
+use std::path::PathBuf;
+
+/// Resolved audit-substrate paths for a single VM. Maps directly into
+/// `mvm_libkrun::SupervisorConfig`'s five `Option`-wrapped audit
+/// fields. `None` on every field means the VM has no admission
+/// context — the supervisor stays on the legacy `run_supervisor`
+/// path.
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+pub struct AuditSubstrate {
+    pub tenant_id: Option<String>,
+    pub audit_dir: Option<PathBuf>,
+    pub gateway_audit_socket: Option<PathBuf>,
+    pub gateway_events_socket: Option<PathBuf>,
+    pub signing_key_path: Option<PathBuf>,
+}
+
+/// Plan 112 Phase 3c — RFC 1123 DNS-label-shaped allowlist for
+/// identifiers that flow into filesystem paths (`tenant_id`,
+/// `vm_name`). Allowlist + length cap + ASCII-only — fail-closed.
+/// Deny-list patterns (rejecting `..`, `/`, NUL, etc.) are fail-open
+/// by construction; allowlist is the correct shape.
+///
+/// `mvm-plan`'s `TenantId` is an unchecked `String` newtype today
+/// (only sha256_hex is validated at `mvm-plan/src/types.rs`); this is
+/// the defense-in-depth boundary.
+fn validate_dns_label(label: &str, kind: &str) -> Result<()> {
+    if label.is_empty() {
+        bail!("{kind} must not be empty");
+    }
+    if label.len() > 63 {
+        bail!("{kind} must be 1..=63 chars; got {}", label.len());
+    }
+    let first = label.chars().next().expect("len > 0 checked above");
+    if !first.is_ascii_alphanumeric() {
+        bail!("{kind} must start with [A-Za-z0-9]; got {first:?}");
+    }
+    for c in label.chars() {
+        let ok = c.is_ascii_alphanumeric() || c == '-' || c == '_';
+        if !ok {
+            bail!("{kind} may only contain [A-Za-z0-9_-]; got {c:?}");
+        }
+    }
+    Ok(())
+}
+
+pub fn validate_tenant_id(tenant: &str) -> Result<()> {
+    validate_dns_label(tenant, "tenant_id")
+}
+
+pub fn validate_vm_name(name: &str) -> Result<()> {
+    validate_dns_label(name, "vm_name")
+}
+
+/// Plan 112 Phase 3c — derive the five audit-substrate paths for
+/// `vm_name` from `mvm_core::config::mvm_data_dir()` when `tenant_id`
+/// is `Some`. Returns `AuditSubstrate::default()` (all fields `None`)
+/// when `tenant_id` is `None` so the calling backend's supervisor
+/// takes the legacy `run_supervisor` path. Validates both `vm_name`
+/// and `tenant_id` against the DNS-label allowlist before any path
+/// derivation.
+///
+/// **Forward-compat note:** Plan N+1 (NetworkProvider trait) will lift
+/// this into a trait method on each provider. This function's
+/// signature is the seam — `provider.activate_audit(vm_name,
+/// tenant_id)` returning the same `AuditSubstrate` value. Keep that
+/// shape stable.
+pub fn compute_audit_substrate(vm_name: &str, tenant_id: Option<&str>) -> Result<AuditSubstrate> {
+    validate_vm_name(vm_name)?;
+    let Some(tenant) = tenant_id else {
+        return Ok(AuditSubstrate::default());
+    };
+    validate_tenant_id(tenant)?;
+    let data_dir = PathBuf::from(mvm_core::config::mvm_data_dir());
+    let audit_dir = data_dir.join("audit");
+    let gw_audit = audit_dir.join(format!("gateway-{vm_name}.sock"));
+    let gw_events = audit_dir.join(format!("gateway-events-{vm_name}.sock"));
+    let signing_key = data_dir.join("keys").join("host-signer.ed25519");
+    Ok(AuditSubstrate {
+        tenant_id: Some(tenant.to_string()),
+        audit_dir: Some(audit_dir),
+        gateway_audit_socket: Some(gw_audit),
+        gateway_events_socket: Some(gw_events),
+        signing_key_path: Some(signing_key),
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn validate_tenant_id_allowlist_dns_label_shape() {
+        // Allowed: starts with alphanumeric, body is [A-Za-z0-9_-], max 63 chars.
+        assert!(validate_tenant_id("a").is_ok());
+        assert!(validate_tenant_id("acme").is_ok());
+        assert!(validate_tenant_id("acme-corp_42").is_ok());
+        assert!(validate_tenant_id("A1B2").is_ok());
+        assert!(validate_tenant_id(&"a".repeat(63)).is_ok());
+
+        // Rejected: empty, too long, leading non-alnum, disallowed chars,
+        // Unicode/non-ASCII.
+        assert!(validate_tenant_id("").is_err());
+        assert!(validate_tenant_id(&"a".repeat(64)).is_err());
+        assert!(validate_tenant_id("-leading-dash").is_err());
+        assert!(validate_tenant_id("_leading-underscore").is_err());
+        assert!(validate_tenant_id("..").is_err());
+        assert!(validate_tenant_id("a/b").is_err());
+        assert!(validate_tenant_id("a\\b").is_err());
+        assert!(validate_tenant_id("a\0b").is_err());
+        // dots out (DNS uses them as separators; we want a single label)
+        assert!(validate_tenant_id("a.b").is_err());
+        assert!(validate_tenant_id(" trim ").is_err());
+        assert!(validate_tenant_id("acmé").is_err());
+        // Cyrillic 'а' confusable
+        assert!(validate_tenant_id("аcme").is_err());
+    }
+
+    #[test]
+    fn validate_vm_name_allowlist_dns_label_shape() {
+        // Same shape as tenant_id (both end up in filesystem paths).
+        assert!(validate_vm_name("vm-01").is_ok());
+        assert!(validate_vm_name("").is_err());
+        assert!(validate_vm_name("../escape").is_err());
+        assert!(validate_vm_name(&"v".repeat(64)).is_err());
+    }
+
+    #[test]
+    fn compute_with_tenant_derives_all_paths() {
+        let s = compute_audit_substrate("test-vm", Some("acme")).expect("compute");
+        assert_eq!(s.tenant_id.as_deref(), Some("acme"));
+        let dir = s.audit_dir.expect("audit_dir");
+        assert!(dir.ends_with("audit"));
+        let gw = s.gateway_audit_socket.expect("gw audit");
+        assert!(
+            gw.file_name()
+                .unwrap()
+                .to_string_lossy()
+                .contains("test-vm")
+        );
+        let ev = s.gateway_events_socket.expect("gw events");
+        assert!(
+            ev.file_name()
+                .unwrap()
+                .to_string_lossy()
+                .contains("test-vm")
+        );
+        assert!(s.signing_key_path.is_some());
+    }
+
+    #[test]
+    fn compute_without_tenant_returns_default() {
+        let s = compute_audit_substrate("dev-vm", None).expect("compute");
+        assert_eq!(s, AuditSubstrate::default());
+    }
+
+    #[test]
+    fn compute_with_unsafe_tenant_errors() {
+        assert!(compute_audit_substrate("vm", Some("../escape")).is_err());
+        assert!(compute_audit_substrate("vm", Some("a/b")).is_err());
+        assert!(compute_audit_substrate("vm", Some("")).is_err());
+    }
+
+    #[test]
+    fn compute_with_unsafe_vm_name_errors() {
+        assert!(compute_audit_substrate("../escape", Some("acme")).is_err());
+        assert!(compute_audit_substrate("", Some("acme")).is_err());
+        assert!(compute_audit_substrate("vm/escape", Some("acme")).is_err());
+    }
+}

--- a/crates/mvm-backend/src/lib.rs
+++ b/crates/mvm-backend/src/lib.rs
@@ -34,6 +34,7 @@
 //!                     (consumes us directly)
 
 pub mod apple_container;
+pub mod audit_substrate;
 pub mod backend;
 pub mod ch_runtime;
 pub mod cloud_hypervisor;

--- a/crates/mvm-backend/src/libkrun.rs
+++ b/crates/mvm-backend/src/libkrun.rs
@@ -153,9 +153,14 @@ impl VmBackend for LibkrunBackend {
             );
         }
 
-        // Note: the kernel-path requirement check now lives in
-        // `build_supervisor_config` (which the helper invokes); we still
-        // bail early if it's missing, just via the helper.
+        // Plan 112 Phase 3c — early kernel-path check. `build_supervisor_config`
+        // re-checks too, but this keeps the existing test contract
+        // (`libkrun_start_errors_when_kernel_path_missing`) firing before
+        // `admit_overlay_aware`'s sidecar check would mask it.
+        let _ = config
+            .kernel_path
+            .as_deref()
+            .ok_or_else(|| anyhow!("libkrun backend requires a kernel path"))?;
         let supervisor_path = resolve_supervisor_path()?;
         let state_dir = vm_state_dir(&config.name);
         std::fs::create_dir_all(&state_dir)

--- a/crates/mvm-backend/src/libkrun.rs
+++ b/crates/mvm-backend/src/libkrun.rs
@@ -61,6 +61,68 @@ const STOP_TIMEOUT: Duration = Duration::from_secs(2);
 /// boot for the same Nix-built rootfs layout.
 const DEFAULT_CMDLINE: &str = "console=hvc0 root=/dev/vda rw init=/init";
 
+/// Plan 112 Phase 3c — build the supervisor config for one VM, lifting
+/// the audit-substrate resolution into the shared `audit_substrate`
+/// module so libkrun and Vz share one source of truth (and the future
+/// `NetworkProvider` trait extraction is mechanical).
+///
+/// **Do not log** `config.plan_json` or `config.bundle_json` — they
+/// may carry secret bindings, env vars, or policy refs that resolve
+/// to credentials. They're opaque transport bytes; the supervisor
+/// re-verifies the signed envelope before trusting any decoded field.
+fn build_supervisor_config(config: &VmStartConfig, state_dir: &Path) -> Result<SupervisorConfig> {
+    let kernel = config
+        .kernel_path
+        .as_deref()
+        .ok_or_else(|| anyhow!("libkrun backend requires a kernel path"))?;
+    let vcpus = u8::try_from(config.cpus.clamp(1, u32::from(u8::MAX))).unwrap_or(u8::MAX);
+    let krun = KrunContext::new(&config.name, kernel, &config.rootfs_path)
+        .with_resources(vcpus, config.memory_mib)
+        .with_cmdline(DEFAULT_CMDLINE)
+        .with_vsock_socket_dir(state_dir.to_string_lossy().into_owned())
+        .add_vsock_port(mvm_guest::vsock::GUEST_AGENT_PORT);
+
+    // Plan 112 Phase 3c — resolve the audit substrate (paths + tenant
+    // validation). When the producer threaded an AdmittedPlan in
+    // (`tenant_id` Some), the AuditSubstrate carries the five resolved
+    // paths; otherwise it's all-None and the supervisor takes the
+    // legacy `run_supervisor` path.
+    let substrate =
+        crate::audit_substrate::compute_audit_substrate(&config.name, config.tenant_id.as_deref())?;
+
+    // Parse the signed-plan + bundle envelopes from VmStartConfig.
+    // mvm_libkrun::SupervisorConfig carries them as Option<serde_json::Value>
+    // so the supervisor can re-verify the envelope without depending on
+    // mvm-plan at the parse boundary.
+    let plan = match config.plan_json.as_deref() {
+        Some(s) => Some(
+            serde_json::from_str(s)
+                .map_err(|e| anyhow!("parse VmStartConfig.plan_json as JSON: {e}"))?,
+        ),
+        None => None,
+    };
+    let bundle = match config.bundle_json.as_deref() {
+        Some(s) => Some(
+            serde_json::from_str(s)
+                .map_err(|e| anyhow!("parse VmStartConfig.bundle_json as JSON: {e}"))?,
+        ),
+        None => None,
+    };
+
+    Ok(SupervisorConfig {
+        krun,
+        vm_state_dir: state_dir.to_string_lossy().into_owned(),
+        pid_file_name: None,
+        tenant_id: substrate.tenant_id,
+        audit_dir: substrate.audit_dir,
+        gateway_audit_socket: substrate.gateway_audit_socket,
+        gateway_events_socket: substrate.gateway_events_socket,
+        signing_key_path: substrate.signing_key_path,
+        plan,
+        bundle,
+    })
+}
+
 impl VmBackend for LibkrunBackend {
     fn name(&self) -> &str {
         "libkrun"
@@ -91,11 +153,9 @@ impl VmBackend for LibkrunBackend {
             );
         }
 
-        let kernel = config
-            .kernel_path
-            .as_deref()
-            .ok_or_else(|| anyhow!("libkrun backend requires a kernel path"))?;
-
+        // Note: the kernel-path requirement check now lives in
+        // `build_supervisor_config` (which the helper invokes); we still
+        // bail early if it's missing, just via the helper.
         let supervisor_path = resolve_supervisor_path()?;
         let state_dir = vm_state_dir(&config.name);
         std::fs::create_dir_all(&state_dir)
@@ -115,33 +175,7 @@ impl VmBackend for LibkrunBackend {
         mvm_base::runtime_meta::record_from_rootfs(&config.name, StartMode::Detached, rootfs)?;
 
         let vcpus = u8::try_from(config.cpus.clamp(1, u32::from(u8::MAX))).unwrap_or(u8::MAX);
-        let krun = KrunContext::new(&config.name, kernel, &config.rootfs_path)
-            .with_resources(vcpus, config.memory_mib)
-            .with_cmdline(DEFAULT_CMDLINE)
-            .with_vsock_socket_dir(state_dir.to_string_lossy().into_owned())
-            .add_vsock_port(mvm_guest::vsock::GUEST_AGENT_PORT);
-
-        let cfg = SupervisorConfig {
-            krun,
-            vm_state_dir: state_dir.to_string_lossy().into_owned(),
-            pid_file_name: None,
-            // Plan 102 W6.A commit 6: audit-substrate fields. Set to
-            // None for now — backend orchestrator population
-            // (sourcing tenant_id from ExecutionPlan, gateway sockets
-            // from mvm_data_dir()) lands alongside the
-            // run_supervisor_with_bridge wire-up (Plan 102 W6.A.5
-            // Phase 3).
-            tenant_id: None,
-            audit_dir: None,
-            gateway_audit_socket: None,
-            gateway_events_socket: None,
-            signing_key_path: None,
-            // Plan 102 W6.A.5 plan/bundle fields — populated by the
-            // same Phase 3 wire-up that fills the audit-substrate
-            // paths.
-            plan: None,
-            bundle: None,
-        };
+        let cfg = build_supervisor_config(config, &state_dir)?;
         let pid_file = cfg.pid_file();
         // Remove any stale PID file from a previous crashed supervisor
         // so the wait-loop below can detect the new one unambiguously.
@@ -498,6 +532,74 @@ mod tests {
         // else holds because libkrun matches Firecracker's L2 properties.
         assert_eq!(profile.dropped_claims(), vec![3]);
         assert!(profile.na_claims().is_empty());
+    }
+
+    #[test]
+    fn build_supervisor_config_maps_substrate_into_supervisor_config() {
+        // Plan 112 Phase 3c — when the producer threaded an admitted plan,
+        // build_supervisor_config maps the resolved AuditSubstrate fields
+        // into SupervisorConfig + parses plan_json/bundle_json as JSON.
+        let config = VmStartConfig {
+            name: "test-vm".into(),
+            rootfs_path: "/tmp/rootfs.ext4".into(),
+            kernel_path: Some("/tmp/vmlinux".into()),
+            cpus: 1,
+            memory_mib: 256,
+            tenant_id: Some("acme".into()),
+            plan_json: Some("{\"k\":\"v\"}".into()),
+            bundle_json: None,
+            ..Default::default()
+        };
+        let tmp = tempfile::tempdir().unwrap();
+        let cfg = build_supervisor_config(&config, tmp.path()).expect("build");
+        assert_eq!(cfg.tenant_id.as_deref(), Some("acme"));
+        assert!(cfg.audit_dir.is_some());
+        assert!(cfg.gateway_audit_socket.is_some());
+        assert!(cfg.gateway_events_socket.is_some());
+        assert!(cfg.signing_key_path.is_some());
+        assert!(cfg.plan.is_some());
+        assert!(cfg.bundle.is_none());
+    }
+
+    #[test]
+    fn build_supervisor_config_no_tenant_keeps_substrate_none() {
+        // Plan 112 Phase 3c — no admission ⇒ all five substrate fields
+        // None ⇒ supervisor takes the legacy `run_supervisor` path.
+        let config = VmStartConfig {
+            name: "dev-vm".into(),
+            rootfs_path: "/tmp/rootfs.ext4".into(),
+            kernel_path: Some("/tmp/vmlinux".into()),
+            cpus: 1,
+            memory_mib: 256,
+            ..Default::default()
+        };
+        let tmp = tempfile::tempdir().unwrap();
+        let cfg = build_supervisor_config(&config, tmp.path()).expect("build");
+        assert!(cfg.tenant_id.is_none());
+        assert!(cfg.audit_dir.is_none());
+        assert!(cfg.gateway_audit_socket.is_none());
+        assert!(cfg.gateway_events_socket.is_none());
+        assert!(cfg.signing_key_path.is_none());
+        assert!(cfg.plan.is_none());
+        assert!(cfg.bundle.is_none());
+    }
+
+    #[test]
+    fn build_supervisor_config_refuses_unsafe_tenant() {
+        // Plan 112 Phase 3c — defense-in-depth: tenant_id passes through
+        // the DNS-label allowlist in audit_substrate; build_supervisor_config
+        // propagates the error.
+        let config = VmStartConfig {
+            name: "evil-vm".into(),
+            rootfs_path: "/tmp/rootfs.ext4".into(),
+            kernel_path: Some("/tmp/vmlinux".into()),
+            cpus: 1,
+            memory_mib: 256,
+            tenant_id: Some("../escape".into()),
+            ..Default::default()
+        };
+        let tmp = tempfile::tempdir().unwrap();
+        assert!(build_supervisor_config(&config, tmp.path()).is_err());
     }
 
     #[test]

--- a/crates/mvm-backend/src/mock.rs
+++ b/crates/mvm-backend/src/mock.rs
@@ -334,6 +334,9 @@ mod tests {
             secret_files: Vec::new(),
             ports: Vec::new(),
             runner_dir: None,
+            tenant_id: None,
+            plan_json: None,
+            bundle_json: None,
         }
     }
 

--- a/crates/mvm-backend/src/vz.rs
+++ b/crates/mvm-backend/src/vz.rs
@@ -163,8 +163,10 @@ impl VmBackend for VzBackend {
         let gvproxy_info = host_gvproxy::spawn_detached(&state_dir)
             .map_err(|e| anyhow!("spawn host-side gvproxy for Vz VM '{}': {e}", config.name))?;
 
-        // Vz config build.
-        let cfg = build_supervisor_config(config, kernel, &state_dir, &gvproxy_info);
+        // Vz config build. The `?` propagates allowlist failures from
+        // `audit_substrate::compute_audit_substrate` (unsafe tenant_id
+        // / vm_name) — see Plan 112 Phase 3c.
+        let cfg = build_supervisor_config(config, kernel, &state_dir, &gvproxy_info)?;
         let pid_file = state_dir.join(PID_FILE_NAME);
         // Stale-PID-file cleanup from a previous crashed supervisor so
         // the wait-loop below detects the *new* one unambiguously.
@@ -535,7 +537,7 @@ impl VzBackend {
             state_dir: state_dir.clone(),
         };
 
-        let cfg = build_supervisor_config(config, kernel, &state_dir, &gvproxy_info);
+        let cfg = build_supervisor_config(config, kernel, &state_dir, &gvproxy_info)?;
         let pid_file = state_dir.join(PID_FILE_NAME);
         let _ = std::fs::remove_file(&pid_file);
 
@@ -846,12 +848,33 @@ fn events_ingest_socket_path(vm_name: &str) -> String {
 /// dev-shell image are mapped. gvproxy networking, the runtime
 /// overlay, dm-verity sidecar, and port forwarding all land in
 /// follow-up slices when their host-side plumbing is in place.
+///
+/// Plan 112 Phase 3c — pre-flight: when the producer threaded an
+/// AdmittedPlan in (`VmStartConfig.tenant_id` Some), run the
+/// DNS-label allowlist through `audit_substrate::compute_audit_substrate`
+/// so an unsafe tenant/vm_name fails fast before Swift spawn. The
+/// **Vz consumer side** for the audit chain (a Rust drainer that
+/// binds `events_ingest_socket_path` and emits to the chain) is a
+/// follow-up plan after Phase 3c — until then, the substrate's
+/// path values are computed but not threaded into
+/// `vz::SupervisorConfig` (which would also require lockstep Swift
+/// `Config.swift` decoder updates per the schema deny-unknown-fields
+/// contract). The Swift bridge already writes flow events to
+/// `events_ingest_socket_path` (PR #487 commit 7); the drainer
+/// closes the loop.
 fn build_supervisor_config(
     config: &VmStartConfig,
     kernel: &str,
     state_dir: &Path,
     gvproxy: &host_gvproxy::HostGvproxyInfo,
-) -> vz::SupervisorConfig {
+) -> Result<vz::SupervisorConfig> {
+    // Plan 112 Phase 3c — defense-in-depth validation. The resolved
+    // AuditSubstrate isn't yet threaded into vz::SupervisorConfig
+    // (Vz drainer is a follow-up), but the tenant_id / vm_name
+    // allowlist check fires here so an unsafe value never reaches
+    // the Swift supervisor.
+    let _substrate =
+        crate::audit_substrate::compute_audit_substrate(&config.name, config.tenant_id.as_deref())?;
     let state_dir_str = state_dir.to_string_lossy().into_owned();
     let vsock_dir = state_dir.join("vsock").to_string_lossy().into_owned();
     let console_log = state_dir.join("console.log").to_string_lossy().into_owned();
@@ -866,7 +889,7 @@ fn build_supervisor_config(
         read_only: true,
     }];
 
-    vz::SupervisorConfig {
+    Ok(vz::SupervisorConfig {
         name: config.name.clone(),
         vm_state_dir: state_dir_str,
         pid_file_name: Some(PID_FILE_NAME.to_string()),
@@ -917,7 +940,7 @@ fn build_supervisor_config(
         // boot path; the restore path constructs its own config in
         // `build_restore_supervisor_config` below.
         startup_mode: vz::StartupMode::Boot,
-    }
+    })
 }
 
 /// Resolve the absolute path to the `mvm-vz-supervisor` binary,
@@ -1183,7 +1206,8 @@ mod tests {
             socket_path: state_dir.join("gvproxy.sock"),
             pid: 0,
         };
-        let built = build_supervisor_config(&cfg, "/abs/vmlinux", state_dir, &gvproxy_info);
+        let built =
+            build_supervisor_config(&cfg, "/abs/vmlinux", state_dir, &gvproxy_info).expect("build");
 
         assert_eq!(built.name, "smoke");
         assert_eq!(built.kernel.path, "/abs/vmlinux");
@@ -1223,6 +1247,36 @@ mod tests {
             }
             None => panic!("network should be Some(Gvproxy {{ .. }}) after W6.A.5"),
         }
+    }
+
+    #[test]
+    fn build_supervisor_config_refuses_unsafe_tenant() {
+        // Plan 112 Phase 3c — defense-in-depth: an unsafe tenant_id
+        // (DNS-label allowlist violation) is refused inside
+        // build_supervisor_config before any Swift spawn or file
+        // touch. Same posture as libkrun's
+        // build_supervisor_config_refuses_unsafe_tenant.
+        let cfg = VmStartConfig {
+            name: "smoke".into(),
+            cpus: 1,
+            memory_mib: 256,
+            kernel_path: Some("/abs/vmlinux".into()),
+            rootfs_path: "/abs/rootfs.ext4".into(),
+            tenant_id: Some("../escape".into()),
+            ..Default::default()
+        };
+        let state_dir = Path::new("/tmp/vz-tenant-refuse-state");
+        let gvproxy_info = host_gvproxy::HostGvproxyInfo {
+            socket_path: state_dir.join("gvproxy.sock"),
+            pid: 0,
+        };
+        let err = build_supervisor_config(&cfg, "/abs/vmlinux", state_dir, &gvproxy_info)
+            .expect_err("unsafe tenant must error");
+        let msg = err.to_string();
+        assert!(
+            msg.contains("tenant_id") || msg.contains("vm_name"),
+            "expected DNS-label rejection; got {msg}"
+        );
     }
 
     #[test]

--- a/crates/mvm-backend/tests/phase3c_supervisor_dispatch.rs
+++ b/crates/mvm-backend/tests/phase3c_supervisor_dispatch.rs
@@ -1,0 +1,192 @@
+//! Plan 112 Phase 3c — supervisor dispatch smoke.
+//!
+//! End-to-end verification that the producer-side wire format
+//! (`VmStartConfig` → `audit_substrate::compute_audit_substrate` →
+//! `SupervisorConfig` → JSON → supervisor stdin) routes to either the
+//! **bridge-factory** branch (`tenant_id` Some) or the **legacy
+//! `run_supervisor`** branch (`tenant_id` None) in
+//! `mvm-libkrun-supervisor::main`.
+//!
+//! Two `#[ignore]` tests:
+//!
+//! - `supervisor_takes_bridge_path_when_tenant_id_some` — populated
+//!   substrate ⇒ supervisor reaches the `plan.json` decode step
+//!   before failing on the placeholder envelope. Failure message
+//!   `decode cfg.plan into ExecutionPlan` is the witness that the
+//!   bridge branch was entered. Claim-10-leg-2 substrate is live.
+//!
+//! - `supervisor_takes_legacy_path_when_tenant_id_none` — empty
+//!   substrate ⇒ supervisor calls `run_supervisor` (the legacy
+//!   pre-W6.A.5 path) and fails downstream at libkrun's
+//!   `krun_start_enter` (rc -22 because the fake kernel/rootfs
+//!   don't exist). Confirms the back-compat path for `mvmctl dev`,
+//!   session VMs, and template restore.
+//!
+//! ## How to run
+//!
+//! ```sh
+//! cargo build --release -p mvm-libkrun-supervisor --features libkrun-sys
+//! cargo test -p mvm-backend --test phase3c_supervisor_dispatch \
+//!     -- --ignored --nocapture
+//! ```
+//!
+//! Self-skips on non-macos-aarch64 (the only platform with libkrun +
+//! supervisor binary out of the box; Linux contributors get the same
+//! coverage via the unit tests in `libkrun.rs` and
+//! `audit_substrate.rs`). Set `MVM_LIBKRUN_SUPERVISOR_PATH` to point
+//! at a non-default binary location.
+
+#![cfg(all(target_os = "macos", target_arch = "aarch64"))]
+
+use mvm_libkrun::{KrunContext, SupervisorConfig};
+use std::io::Write;
+use std::process::{Command, Stdio};
+
+fn supervisor_path() -> std::path::PathBuf {
+    if let Ok(p) = std::env::var("MVM_LIBKRUN_SUPERVISOR_PATH") {
+        return std::path::PathBuf::from(p);
+    }
+    // From `crates/mvm-backend/`, the workspace root is two levels up
+    // and the supervisor binary lives at `target/release/`. Same
+    // resolution shape libkrun_lifecycle_e2e.rs uses.
+    std::path::PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+        .join("../../target/release/mvm-libkrun-supervisor")
+}
+
+#[test]
+#[ignore]
+fn supervisor_takes_bridge_path_when_tenant_id_some() {
+    // Build a populated VmStartConfig and run it through Phase 3c's
+    // shared substrate helper.
+    let substrate =
+        mvm_backend::audit_substrate::compute_audit_substrate("phase3c-smoke", Some("smoke"))
+            .expect("compute substrate");
+
+    let state_dir = std::path::PathBuf::from("/tmp/phase3c-smoke");
+    std::fs::create_dir_all(&state_dir).unwrap();
+
+    let krun = KrunContext::new(
+        "phase3c-smoke",
+        "/tmp/fake-vmlinux",
+        "/tmp/fake-rootfs.ext4",
+    )
+    .with_resources(1, 256)
+    .with_cmdline("console=hvc0 root=/dev/vda rw init=/init")
+    .with_vsock_socket_dir(state_dir.to_string_lossy().into_owned())
+    .add_vsock_port(1024);
+
+    let cfg = SupervisorConfig {
+        krun,
+        vm_state_dir: state_dir.to_string_lossy().into_owned(),
+        pid_file_name: None,
+        tenant_id: substrate.tenant_id,
+        audit_dir: substrate.audit_dir,
+        gateway_audit_socket: substrate.gateway_audit_socket,
+        gateway_events_socket: substrate.gateway_events_socket,
+        signing_key_path: substrate.signing_key_path,
+        // Placeholder: supervisor only deserializes if the bridge
+        // path is taken; we expect that to happen and then fail
+        // downstream on the missing kernel.
+        plan: Some(serde_json::json!({"placeholder": true})),
+        bundle: None,
+    };
+
+    let json = serde_json::to_string_pretty(&cfg).unwrap();
+    eprintln!("--- SupervisorConfig JSON ---\n{json}\n--- end ---");
+
+    let mut child = Command::new(supervisor_path())
+        .env("RUST_LOG", "info")
+        .stdin(Stdio::piped())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .spawn()
+        .expect("spawn supervisor");
+    child
+        .stdin
+        .take()
+        .unwrap()
+        .write_all(json.as_bytes())
+        .unwrap();
+
+    let output = child.wait_with_output().expect("wait");
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    eprintln!("--- supervisor stderr ---\n{stderr}\n--- end ---");
+
+    // Phase 3c gate: when tenant_id is Some, the supervisor must
+    // reach the bridge-factory branch. The downstream libkrun call
+    // will fail (fake kernel), but we expect to see the
+    // `starting bridge-mode libkrun supervisor` trace before that.
+    //
+    // Acceptable failure shapes on the bridge path:
+    //   - tracing emits "starting bridge-mode libkrun supervisor"
+    //   - decode of placeholder plan fails ("decode cfg.plan into
+    //     ExecutionPlan") — also proves the bridge branch was taken
+    //   - signing key load works (we have a real key file)
+    //   - libkrun fails because /tmp/fake-vmlinux doesn't exist
+    let bridge_signal = stderr.contains("starting bridge-mode libkrun supervisor")
+        || stderr.contains("decode cfg.plan into ExecutionPlan")
+        || stderr.contains("run_supervisor_with_bridge")
+        || stderr.contains("BridgeConfig");
+
+    assert!(
+        bridge_signal,
+        "supervisor did not take the bridge path; stderr was:\n{stderr}"
+    );
+}
+
+#[test]
+#[ignore]
+fn supervisor_takes_legacy_path_when_tenant_id_none() {
+    // Mirror: no tenant_id ⇒ legacy run_supervisor branch.
+    let state_dir = std::path::PathBuf::from("/tmp/phase3c-smoke-legacy");
+    std::fs::create_dir_all(&state_dir).unwrap();
+
+    let krun = KrunContext::new(
+        "phase3c-smoke-legacy",
+        "/tmp/fake-vmlinux",
+        "/tmp/fake-rootfs.ext4",
+    )
+    .with_resources(1, 256)
+    .with_cmdline("console=hvc0 root=/dev/vda rw init=/init")
+    .with_vsock_socket_dir(state_dir.to_string_lossy().into_owned())
+    .add_vsock_port(1024);
+
+    let cfg = SupervisorConfig {
+        krun,
+        vm_state_dir: state_dir.to_string_lossy().into_owned(),
+        pid_file_name: None,
+        tenant_id: None,
+        audit_dir: None,
+        gateway_audit_socket: None,
+        gateway_events_socket: None,
+        signing_key_path: None,
+        plan: None,
+        bundle: None,
+    };
+
+    let json = serde_json::to_string_pretty(&cfg).unwrap();
+    let mut child = Command::new(supervisor_path())
+        .env("RUST_LOG", "info")
+        .stdin(Stdio::piped())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .spawn()
+        .expect("spawn supervisor");
+    child
+        .stdin
+        .take()
+        .unwrap()
+        .write_all(json.as_bytes())
+        .unwrap();
+    let output = child.wait_with_output().expect("wait");
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    eprintln!("--- legacy stderr ---\n{stderr}\n--- end ---");
+
+    // Legacy path proof: must NOT contain bridge-mode trace; must
+    // either reach `run_supervisor` (proof that it took the non-bridge
+    // branch) or fail downstream in the libkrun load.
+    assert!(
+        !stderr.contains("starting bridge-mode"),
+        "unexpectedly took bridge path with tenant_id=None: {stderr}"
+    );
+}

--- a/crates/mvm-cli/src/commands/tests.rs
+++ b/crates/mvm-cli/src/commands/tests.rs
@@ -1739,6 +1739,16 @@ fn secret_get_rejects_force_flag() {
     );
 }
 
+#[test]
+fn up_rejects_removed_secret_flag() {
+    let err = Cli::try_parse_from(["mvmctl", "up", "--secret", "API_KEY:api.example.com"])
+        .expect_err("up --secret must be rejected");
+    assert!(
+        err.to_string().contains("unexpected argument '--secret'"),
+        "got: {err}"
+    );
+}
+
 // --- Exec CLI tests ---
 
 #[test]

--- a/crates/mvm-cli/src/commands/vm/exec.rs
+++ b/crates/mvm-cli/src/commands/vm/exec.rs
@@ -532,6 +532,7 @@ fn emit_oci_run_admission(
         egress_policy_ref: None,
         tool_policy_ref: None,
         secret_release: mvm_plan::SecretReleasePolicy::None,
+        secrets: Vec::new(),
         audit_event_prefix: None,
         cpus,
         mem_mib,

--- a/crates/mvm-cli/src/commands/vm/host_signer.rs
+++ b/crates/mvm-cli/src/commands/vm/host_signer.rs
@@ -360,6 +360,7 @@ mod tests {
             egress_policy_ref: None,
             tool_policy_ref: None,
             secret_release: mvm_plan::SecretReleasePolicy::None,
+            secrets: Vec::new(),
             audit_event_prefix: None,
             cpus: 1,
             mem_mib: 256,

--- a/crates/mvm-cli/src/commands/vm/managed_secrets.rs
+++ b/crates/mvm-cli/src/commands/vm/managed_secrets.rs
@@ -1,0 +1,143 @@
+use mvm_ir::{App, Entrypoint, EnvValue, SecretMount, Workload};
+use mvm_plan::{SecretBinding, SecretReleasePolicy, SecretSource};
+
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+pub(super) struct LoweredPlanSecrets {
+    pub secrets: Vec<SecretBinding>,
+    pub secret_release: SecretReleasePolicy,
+}
+
+pub(super) fn lower_workload_secrets(workload: &Workload) -> LoweredPlanSecrets {
+    let mut secrets = Vec::new();
+    for app in &workload.apps {
+        secrets.extend(lower_app_secret_bindings(app));
+    }
+    LoweredPlanSecrets {
+        secret_release: secret_release_for_bindings(&secrets),
+        secrets,
+    }
+}
+
+pub(super) fn lower_app_secrets(app: &App) -> LoweredPlanSecrets {
+    let secrets = lower_app_secret_bindings(app);
+    LoweredPlanSecrets {
+        secret_release: secret_release_for_bindings(&secrets),
+        secrets,
+    }
+}
+
+fn lower_app_secret_bindings(app: &App) -> Vec<SecretBinding> {
+    let mut secrets = Vec::new();
+    lower_env_map(&app.env, &mut secrets);
+    for entrypoint in &app.entrypoints {
+        match entrypoint {
+            Entrypoint::Command { env, .. } | Entrypoint::Function { env, .. } => {
+                lower_env_map(env, &mut secrets);
+            }
+        }
+    }
+    secrets
+}
+
+fn lower_env_map(
+    env: &std::collections::BTreeMap<String, EnvValue>,
+    out: &mut Vec<SecretBinding>,
+) {
+    for value in env.values() {
+        let EnvValue::SecretRef { reference } = value else {
+            continue;
+        };
+        let binding_name = match &reference.mount {
+            SecretMount::Env { var } => var.clone(),
+            SecretMount::File { path } => path.clone(),
+        };
+        out.push(SecretBinding {
+            name: binding_name,
+            source: SecretSource::Keystore {
+                address: reference.name.clone(),
+            },
+        });
+    }
+}
+
+fn secret_release_for_bindings(bindings: &[SecretBinding]) -> SecretReleasePolicy {
+    if bindings.is_empty() {
+        SecretReleasePolicy::None
+    } else {
+        SecretReleasePolicy::PlanBound
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use mvm_ir::{Image, Resources, Source};
+    use std::collections::BTreeMap;
+
+    fn app_with_envs(app_env: BTreeMap<String, EnvValue>, ep_env: BTreeMap<String, EnvValue>) -> App {
+        App {
+            name: "app".into(),
+            source: Source::LocalPath {
+                path: ".".into(),
+                include: vec!["**".into()],
+                exclude: vec![],
+            },
+            image: Image::NixPackages {
+                packages: vec!["python312".into()],
+            },
+            entrypoints: vec![Entrypoint::Command {
+                command: vec!["python".into(), "-m".into(), "app".into()],
+                working_dir: "/app".into(),
+                env: ep_env,
+            }],
+            env: app_env,
+            mounts: vec![],
+            network: None,
+            resources: Resources {
+                cpu_cores: 1,
+                memory_mb: 256,
+                rootfs_size_mb: 512,
+            },
+            dependencies: None,
+            threat_tier: Default::default(),
+            addons: vec![],
+            hooks: Default::default(),
+        }
+    }
+
+    fn secret_env_ref(name: &str, var: &str) -> EnvValue {
+        EnvValue::SecretRef {
+            reference: mvm_ir::SecretRef {
+                name: name.into(),
+                mount: SecretMount::Env { var: var.into() },
+            },
+        }
+    }
+
+    #[test]
+    fn lowers_secret_refs_from_app_and_entrypoint_envs() {
+        let mut app_env = BTreeMap::new();
+        app_env.insert("APP_KEY".into(), secret_env_ref("app-key", "APP_KEY"));
+        let mut ep_env = BTreeMap::new();
+        ep_env.insert("EP_KEY".into(), secret_env_ref("ep-key", "EP_KEY"));
+
+        let lowered = lower_app_secrets(&app_with_envs(app_env, ep_env));
+        assert_eq!(lowered.secret_release, SecretReleasePolicy::PlanBound);
+        assert_eq!(lowered.secrets.len(), 2);
+        assert_eq!(lowered.secrets[0].name, "APP_KEY");
+        assert_eq!(
+            lowered.secrets[0].source,
+            SecretSource::Keystore {
+                address: "app-key".into()
+            }
+        );
+        assert_eq!(lowered.secrets[1].name, "EP_KEY");
+    }
+
+    #[test]
+    fn empty_secret_set_keeps_release_none() {
+        let lowered = lower_app_secrets(&app_with_envs(BTreeMap::new(), BTreeMap::new()));
+        assert_eq!(lowered.secret_release, SecretReleasePolicy::None);
+        assert!(lowered.secrets.is_empty());
+    }
+}

--- a/crates/mvm-cli/src/commands/vm/managed_secrets.rs
+++ b/crates/mvm-cli/src/commands/vm/managed_secrets.rs
@@ -39,10 +39,7 @@ fn lower_app_secret_bindings(app: &App) -> Vec<SecretBinding> {
     secrets
 }
 
-fn lower_env_map(
-    env: &std::collections::BTreeMap<String, EnvValue>,
-    out: &mut Vec<SecretBinding>,
-) {
+fn lower_env_map(env: &std::collections::BTreeMap<String, EnvValue>, out: &mut Vec<SecretBinding>) {
     for value in env.values() {
         let EnvValue::SecretRef { reference } = value else {
             continue;
@@ -74,7 +71,10 @@ mod tests {
     use mvm_ir::{Image, Resources, Source};
     use std::collections::BTreeMap;
 
-    fn app_with_envs(app_env: BTreeMap<String, EnvValue>, ep_env: BTreeMap<String, EnvValue>) -> App {
+    fn app_with_envs(
+        app_env: BTreeMap<String, EnvValue>,
+        ep_env: BTreeMap<String, EnvValue>,
+    ) -> App {
         App {
             name: "app".into(),
             source: Source::LocalPath {

--- a/crates/mvm-cli/src/commands/vm/managed_secrets.rs
+++ b/crates/mvm-cli/src/commands/vm/managed_secrets.rs
@@ -1,6 +1,11 @@
 use mvm_ir::{App, Entrypoint, EnvValue, SecretMount, Workload};
 use mvm_plan::{SecretBinding, SecretReleasePolicy, SecretSource};
 
+// allow(secret-debug): `SecretBinding` is a reference type carrying
+// only metadata (provider id, binding name, release policy) — it does
+// not hold the secret value itself. Raw secret bytes resolve at admit
+// time inside `mvm-supervisor` per ADR-049 / ADR-059 (claim 13). The
+// `Debug` derive prints binding refs only, never plaintext.
 #[derive(Debug, Clone, Default, PartialEq, Eq)]
 pub(super) struct LoweredPlanSecrets {
     pub secrets: Vec<SecretBinding>,

--- a/crates/mvm-cli/src/commands/vm/mod.rs
+++ b/crates/mvm-cli/src/commands/vm/mod.rs
@@ -13,6 +13,7 @@ pub(super) mod host_signer;
 pub(super) mod invoke;
 pub(super) mod invoke_no_vm;
 pub(super) mod logs;
+pub(super) mod managed_secrets;
 pub(super) mod pause;
 pub(super) mod plan_admission;
 pub(super) mod plan_builder;

--- a/crates/mvm-cli/src/commands/vm/plan_admission.rs
+++ b/crates/mvm-cli/src/commands/vm/plan_admission.rs
@@ -217,6 +217,67 @@ pub fn admit_for_run(
     })
 }
 
+/// Plan 112 Phase 3c — soft caps on the JSON envelope sizes flowing
+/// through `VmStartConfig` → `SupervisorConfig` over the supervisor's
+/// stdin pipe. Adversarial envelopes are a DoS vector (memory pressure
+/// on the supervisor + pipe-buffer pressure on the producer). 1 MiB /
+/// 4 MiB are generous for legitimate plans / bundles and tight enough
+/// to refuse pathological inputs.
+const PLAN_JSON_MAX_BYTES: usize = 1024 * 1024;
+const BUNDLE_JSON_MAX_BYTES: usize = 4 * 1024 * 1024;
+
+/// Plan 112 Phase 3c — populate the three `VmStartConfig` audit-substrate
+/// fields (`tenant_id`, `plan_json`, `bundle_json`) from the admitted
+/// plan. Call after the `VmStartConfig` is built and before
+/// `backend.start()`; the libkrun/Vz backends read these to wire
+/// `SupervisorConfig.{tenant_id, audit_dir, gateway_audit_socket,
+/// gateway_events_socket, signing_key_path}` and activate the
+/// bridge-factory path.
+///
+/// JSON-encoded so `mvm-core` carries no typed dep on `mvm-plan`. The
+/// supervisor re-verifies the `SignedExecutionPlan` envelope before
+/// trusting any decoded field — see ADR-041 §"Verification at admission"
+/// and `mvm_supervisor::supervisor::SupervisorAdmission::admit`.
+///
+/// **Do not log the resulting `plan_json` / `bundle_json` values.**
+/// The signed envelope may contain secret bindings, environment
+/// variables, or policy refs that resolve to credentials. Treat as
+/// opaque transport bytes.
+pub fn populate_audit_substrate(
+    cfg: &mut mvm_core::vm_backend::VmStartConfig,
+    admitted: &AdmittedPlan,
+) -> Result<()> {
+    cfg.tenant_id = Some(admitted.plan.tenant.0.clone());
+
+    let plan_json = serde_json::to_string(&admitted.signed)
+        .context("serializing SignedExecutionPlan for VmStartConfig.plan_json")?;
+    if plan_json.len() > PLAN_JSON_MAX_BYTES {
+        anyhow::bail!(
+            "plan_json exceeds {} byte cap (got {}); refusing",
+            PLAN_JSON_MAX_BYTES,
+            plan_json.len()
+        );
+    }
+    cfg.plan_json = Some(plan_json);
+
+    cfg.bundle_json = match admitted.plan.bundle.as_ref() {
+        Some(pin) => {
+            let bj = serde_json::to_string(pin)
+                .context("serializing PlanArtifact bundle pin for VmStartConfig.bundle_json")?;
+            if bj.len() > BUNDLE_JSON_MAX_BYTES {
+                anyhow::bail!(
+                    "bundle_json exceeds {} byte cap (got {}); refusing",
+                    BUNDLE_JSON_MAX_BYTES,
+                    bj.len()
+                );
+            }
+            Some(bj)
+        }
+        None => None,
+    };
+    Ok(())
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -600,5 +661,40 @@ mod tests {
             err.chain().any(|e| e.to_string().contains("sha256")),
             "expected sha256 mismatch chain; got {err:#}"
         );
+    }
+
+    #[test]
+    fn populate_audit_substrate_threads_tenant_and_signed_envelope() {
+        use mvm_core::vm_backend::VmStartConfig;
+        let dir = tempfile::tempdir().unwrap();
+        let clock = SystemClock;
+        let ledger = InMemoryNonceLedger::new();
+        let admitted = admit_for_run(
+            &fixture_input("vm-substrate"),
+            &clock,
+            &ledger,
+            Some(dir.path()),
+            None,
+        )
+        .expect("happy admit");
+
+        let mut cfg = VmStartConfig::default();
+        populate_audit_substrate(&mut cfg, &admitted).expect("populate");
+        assert_eq!(
+            cfg.tenant_id.as_deref(),
+            Some(admitted.plan.tenant.0.as_str())
+        );
+        let plan_json = cfg.plan_json.expect("plan_json populated");
+        let roundtrip: mvm_plan::SignedExecutionPlan =
+            serde_json::from_str(&plan_json).expect("roundtrip");
+        // Re-verify the envelope to get the inner ExecutionPlan and
+        // confirm the plan_id matches what the producer admitted.
+        let signer = super::super::host_signer::load_or_init_at(dir.path()).unwrap();
+        let trusted: [(&str, &ed25519_dalek::VerifyingKey); 1] =
+            [(&admitted.signer_id, &signer.verifying)];
+        let recovered = mvm_plan::verify_plan(&roundtrip, &trusted).expect("envelope re-verifies");
+        assert_eq!(recovered.plan_id, admitted.plan_id);
+        // fixture has no bundle pin, so bundle_json stays None
+        assert!(cfg.bundle_json.is_none());
     }
 }

--- a/crates/mvm-cli/src/commands/vm/plan_admission.rs
+++ b/crates/mvm-cli/src/commands/vm/plan_admission.rs
@@ -240,6 +240,7 @@ mod tests {
             egress_policy_ref: None,
             tool_policy_ref: None,
             secret_release: SecretReleasePolicy::None,
+            secrets: Vec::new(),
             audit_event_prefix: None,
             cpus: 1,
             mem_mib: 256,

--- a/crates/mvm-cli/src/commands/vm/plan_builder.rs
+++ b/crates/mvm-cli/src/commands/vm/plan_builder.rs
@@ -39,10 +39,9 @@ use anyhow::Result;
 use chrono::{Duration, Utc};
 use mvm_plan::{
     AdmissionProfile, ArtifactPolicy, AttestationMode, AttestationRequirement, AuditTaxonomy,
-    DepsVolumeBinding, ExecutionPlan, FsPolicyRef, KeyRotationSpec, Nonce, PlanId,
-    PlanSeccompTier, PolicyRef, PostRunLifecycle, Resources, RuntimeProfileRef, SCHEMA_VERSION,
-    SecretBinding, SecretReleasePolicy, SignedImageRef, TenantId, TimeoutSpec, WorkloadId,
-    WorkloadIntent,
+    DepsVolumeBinding, ExecutionPlan, FsPolicyRef, KeyRotationSpec, Nonce, PlanId, PlanSeccompTier,
+    PolicyRef, PostRunLifecycle, Resources, RuntimeProfileRef, SCHEMA_VERSION, SecretBinding,
+    SecretReleasePolicy, SignedImageRef, TenantId, TimeoutSpec, WorkloadId, WorkloadIntent,
 };
 use rand::RngCore;
 use std::collections::BTreeMap;

--- a/crates/mvm-cli/src/commands/vm/plan_builder.rs
+++ b/crates/mvm-cli/src/commands/vm/plan_builder.rs
@@ -39,9 +39,10 @@ use anyhow::Result;
 use chrono::{Duration, Utc};
 use mvm_plan::{
     AdmissionProfile, ArtifactPolicy, AttestationMode, AttestationRequirement, AuditTaxonomy,
-    DepsVolumeBinding, ExecutionPlan, FsPolicyRef, KeyRotationSpec, Nonce, PlanId, PlanSeccompTier,
-    PolicyRef, PostRunLifecycle, Resources, RuntimeProfileRef, SCHEMA_VERSION, SecretReleasePolicy,
-    SignedImageRef, TenantId, TimeoutSpec, WorkloadId, WorkloadIntent,
+    DepsVolumeBinding, ExecutionPlan, FsPolicyRef, KeyRotationSpec, Nonce, PlanId,
+    PlanSeccompTier, PolicyRef, PostRunLifecycle, Resources, RuntimeProfileRef, SCHEMA_VERSION,
+    SecretBinding, SecretReleasePolicy, SignedImageRef, TenantId, TimeoutSpec, WorkloadId,
+    WorkloadIntent,
 };
 use rand::RngCore;
 use std::collections::BTreeMap;
@@ -106,6 +107,8 @@ pub struct SynthesisInput<'a> {
     pub tool_policy_ref: Option<&'a str>,
     /// Whether any secret can be released under this profile.
     pub secret_release: SecretReleasePolicy,
+    /// Secret refs lowered into plan-visible bindings.
+    pub secrets: Vec<SecretBinding>,
     /// Optional audit event prefix override. `None` derives from the
     /// intent.
     pub audit_event_prefix: Option<&'a str>,
@@ -213,7 +216,7 @@ pub fn synthesize_plan(input: &SynthesisInput<'_>) -> Result<ExecutionPlan> {
         admission_profile,
         network_policy,
         fs_policy,
-        secrets: Vec::new(),
+        secrets: input.secrets.clone(),
         egress_policy,
         tool_policy,
         artifact_policy: ArtifactPolicy {
@@ -330,6 +333,7 @@ mod tests {
             egress_policy_ref: None,
             tool_policy_ref: None,
             secret_release: SecretReleasePolicy::None,
+            secrets: Vec::new(),
             audit_event_prefix: None,
             cpus: 2,
             mem_mib: 512,
@@ -523,6 +527,20 @@ mod tests {
         assert_eq!(plan.admission_profile.audit.event_prefix, "agent.web");
         assert_eq!(plan.audit_labels["intent"], "agent:web-research");
         assert_eq!(plan.audit_labels["seccomp_tier"], "network");
+    }
+
+    #[test]
+    fn synthesized_plan_carries_secret_bindings() {
+        let mut inp = input("myvm");
+        inp.secret_release = SecretReleasePolicy::PlanBound;
+        inp.secrets = vec![SecretBinding {
+            name: "API_KEY".into(),
+            source: mvm_plan::SecretSource::Keystore {
+                address: "api-key".into(),
+            },
+        }];
+        let plan = synthesize_plan(&inp).unwrap();
+        assert_eq!(plan.secrets, inp.secrets);
     }
 
     #[test]

--- a/crates/mvm-cli/src/commands/vm/run_plan.rs
+++ b/crates/mvm-cli/src/commands/vm/run_plan.rs
@@ -63,6 +63,7 @@ use mvm_ir::{App, Workload};
 
 use super::plan_admission::{InMemoryNonceLedger, SystemClock, admit_for_run};
 use super::plan_builder::SynthesisInput;
+use super::managed_secrets::lower_app_secrets;
 use crate::commands::build::sandbox_record::{auto_exec_record_script, script_language_from_path};
 
 use super::exec::{RunArgs, RunMode};
@@ -260,6 +261,7 @@ fn extract_script_arg(args: &RunArgs) -> Result<PathBuf> {
 /// plan-mode is a shape check; downstream consumers that want the
 /// real artifact hash run the live path.
 fn synthesis_input_for_app<'a>(workload: &'a Workload, app: &'a App) -> Result<SynthesisInput<'a>> {
+    let lowered_secrets = lower_app_secrets(app);
     // `SynthesisInput` borrows `image_sha256` as `&str`; we need a
     // 64-char hex string that lives long enough. Since we can't
     // return a reference to a local in the synthesis input struct,
@@ -290,7 +292,8 @@ fn synthesis_input_for_app<'a>(workload: &'a Workload, app: &'a App) -> Result<S
         fs_policy_ref: None,
         egress_policy_ref: None,
         tool_policy_ref: None,
-        secret_release: mvm_plan::SecretReleasePolicy::None,
+        secret_release: lowered_secrets.secret_release,
+        secrets: lowered_secrets.secrets,
         audit_event_prefix: None,
         cpus: app.resources.cpu_cores.max(1) as u32,
         mem_mib: app.resources.memory_mb.max(64) as u64,

--- a/crates/mvm-cli/src/commands/vm/run_plan.rs
+++ b/crates/mvm-cli/src/commands/vm/run_plan.rs
@@ -61,9 +61,9 @@ use std::path::PathBuf;
 
 use mvm_ir::{App, Workload};
 
+use super::managed_secrets::lower_app_secrets;
 use super::plan_admission::{InMemoryNonceLedger, SystemClock, admit_for_run};
 use super::plan_builder::SynthesisInput;
-use super::managed_secrets::lower_app_secrets;
 use crate::commands::build::sandbox_record::{auto_exec_record_script, script_language_from_path};
 
 use super::exec::{RunArgs, RunMode};

--- a/crates/mvm-cli/src/commands/vm/up.rs
+++ b/crates/mvm-cli/src/commands/vm/up.rs
@@ -18,6 +18,7 @@ use super::Cli;
 use super::audit_chain::{AuditEmitter, default_audit_dir};
 use super::forward::forward_ports;
 use super::host_signer::load_or_init_at;
+use super::managed_secrets::lower_workload_secrets;
 use super::plan_admission::{
     AdmittedPlan, BundleAdmissionContext, InMemoryNonceLedger, SystemClock, admit_for_run,
 };
@@ -112,6 +113,7 @@ struct AdmitPlanForBootParams<'a> {
     pub mem_mib: u64,
     pub seccomp_tier: mvm_plan::PlanSeccompTier,
     pub secret_release: mvm_plan::SecretReleasePolicy,
+    pub secrets: Vec<mvm_plan::SecretBinding>,
     pub no_supervisor: bool,
     pub ledger: &'a InMemoryNonceLedger,
     /// Override for the host-signer keys directory. Production callers
@@ -148,16 +150,6 @@ fn plan_seccomp_tier(
     tier.to_string()
         .parse()
         .context("converting runtime seccomp tier into plan seccomp tier")
-}
-
-fn secret_release_policy(
-    bindings: &[mvm_core::secret_binding::SecretBinding],
-) -> mvm_plan::SecretReleasePolicy {
-    if bindings.is_empty() {
-        mvm_plan::SecretReleasePolicy::None
-    } else {
-        mvm_plan::SecretReleasePolicy::PlanBound
-    }
 }
 
 /// Bundle of artifacts produced by a successful admission: the
@@ -269,6 +261,7 @@ fn admit_plan_for_boot(p: AdmitPlanForBootParams<'_>) -> Result<Option<Admission
         egress_policy_ref: None,
         tool_policy_ref: None,
         secret_release: p.secret_release,
+        secrets: p.secrets.clone(),
         audit_event_prefix: None,
         cpus: p.cpus,
         mem_mib: p.mem_mib,
@@ -548,6 +541,19 @@ fn resolve_deps_volume_binding(
     resolve_deps_volume_binding_with_cache(workload_ir_path, build_mode, None)
 }
 
+fn load_workload_ir(
+    workload_ir_path: Option<&std::path::Path>,
+) -> Result<Option<mvm_ir::Workload>> {
+    let Some(ir_path) = workload_ir_path else {
+        return Ok(None);
+    };
+    let bytes = std::fs::read(ir_path)
+        .with_context(|| format!("reading workload IR at {}", ir_path.display()))?;
+    let workload: mvm_ir::Workload = serde_json::from_slice(&bytes)
+        .with_context(|| format!("parsing workload IR at {}", ir_path.display()))?;
+    Ok(Some(workload))
+}
+
 /// Cache-root-overridable form of [`resolve_deps_volume_binding`].
 /// Tests inject a per-tempdir override so they don't touch the user's
 /// `~/.mvm/volumes/deps/` and don't race each other through the
@@ -731,9 +737,6 @@ pub(in crate::commands) struct Args {
     /// posture is "defaults must be safe."
     #[arg(long, default_value = "standard")]
     pub seccomp: String,
-    /// Secret binding (format: KEY:host, KEY:host:header, or KEY=value:host). Repeatable
-    #[arg(short, long)]
-    pub secret: Vec<String>,
     /// Named dev network to attach VM to (default: "default")
     #[arg(long, default_value = "default")]
     pub network: String,
@@ -912,15 +915,11 @@ pub(in crate::commands) fn run(_cli: &Cli, args: Args, cfg: &MvmConfig) -> Resul
     }
     let seccomp_tier: mvm_security::seccomp::SeccompTier =
         args.seccomp.parse().context("Invalid --seccomp value")?;
-    let secret_bindings: Vec<mvm_core::secret_binding::SecretBinding> = args
-        .secret
-        .iter()
-        .map(|s| s.parse())
-        .collect::<Result<Vec<_>>>()
-        .context("Invalid --secret value")?;
     let plan_seccomp_tier = plan_seccomp_tier(seccomp_tier)?;
-    let plan_secret_release = secret_release_policy(&secret_bindings);
-
+    let lowered_plan_secrets = load_workload_ir(args.from_workload_ir.as_deref())?
+        .map(|workload| lower_workload_secrets(&workload))
+        .unwrap_or_default();
+    let plan_secret_release = lowered_plan_secrets.secret_release;
     // Sandbox metadata (W1 of the filesystem-volumes plan). Tag charset/length
     // validation happens in the security crate so audit-event emission
     // and webhook bodies see only validated input. TTL parsing rejects
@@ -1000,7 +999,7 @@ pub(in crate::commands) fn run(_cli: &Cli, args: Args, cfg: &MvmConfig) -> Resul
         seccomp_tier,
         plan_seccomp_tier,
         plan_secret_release,
-        secret_bindings,
+        plan_secrets: lowered_plan_secrets.secrets,
         sandbox_tags,
         sandbox_ttl,
         auto_resume,
@@ -1084,7 +1083,7 @@ pub(in crate::commands) struct RunParams<'a> {
     pub(super) seccomp_tier: mvm_security::seccomp::SeccompTier,
     pub(super) plan_seccomp_tier: mvm_plan::PlanSeccompTier,
     pub(super) plan_secret_release: mvm_plan::SecretReleasePolicy,
-    pub(super) secret_bindings: Vec<mvm_core::secret_binding::SecretBinding>,
+    pub(super) plan_secrets: Vec<mvm_plan::SecretBinding>,
     /// Validated sandbox tags from `--tag k=v`.
     pub(super) sandbox_tags: std::collections::BTreeMap<String, String>,
     /// Parsed `--ttl` duration; reaper tears VM down after this elapses.
@@ -1146,7 +1145,7 @@ pub(super) fn cmd_run(params: RunParams<'_>) -> Result<()> {
         seccomp_tier,
         plan_seccomp_tier,
         plan_secret_release,
-        secret_bindings,
+        plan_secrets,
         sandbox_tags,
         sandbox_ttl,
         auto_resume,
@@ -1294,6 +1293,7 @@ pub(super) fn cmd_run(params: RunParams<'_>) -> Result<()> {
             mem_mib: direct_mem as u64,
             seccomp_tier: plan_seccomp_tier,
             secret_release: plan_secret_release,
+            secrets: plan_secrets.clone(),
             no_supervisor,
             ledger: &admission_ledger,
             keys_dir: None,
@@ -1618,50 +1618,6 @@ pub(super) fn cmd_run(params: RunParams<'_>) -> Result<()> {
         });
     }
 
-    // Resolve and inject secret bindings
-    if !secret_bindings.is_empty() {
-        let resolved = mvm_core::secret_binding::ResolvedSecrets::resolve(&secret_bindings)
-            .context("failed to resolve secret bindings")?;
-
-        // Write actual secret values to the secrets drive
-        for (filename, content) in resolved.to_secret_files() {
-            secret_files.push(microvm::DriveFile {
-                name: filename,
-                content,
-                mode: 0o600,
-            });
-        }
-
-        // Write secret manifest to config drive (no secret values, just metadata)
-        config_files.push(microvm::DriveFile {
-            name: "secrets-manifest.json".to_string(),
-            content: resolved.manifest_json(),
-            mode: 0o644,
-        });
-
-        // Write placeholder env vars so tools pass existence checks
-        let placeholders: Vec<String> = resolved
-            .placeholder_env_vars()
-            .iter()
-            .map(|(k, v)| format!("{}={}", k, v))
-            .collect();
-        if let Some(f) = env_vars_to_drive_file(&placeholders) {
-            config_files.push(microvm::DriveFile {
-                name: "secret-env.env".to_string(),
-                content: f.content,
-                mode: f.mode,
-            });
-        }
-
-        // Log which secrets are bound (without revealing values)
-        for b in &secret_bindings {
-            ui::info(&format!(
-                "Secret {} bound to {} (header: {})",
-                b.env_var, b.target_host, b.header
-            ));
-        }
-    }
-
     let vm_name_owned = vm_name.clone();
     let has_ports = !port_mappings.is_empty();
 
@@ -1685,6 +1641,7 @@ pub(super) fn cmd_run(params: RunParams<'_>) -> Result<()> {
         mem_mib: final_memory as u64,
         seccomp_tier: plan_seccomp_tier,
         secret_release: plan_secret_release,
+        secrets: plan_secrets.clone(),
         no_supervisor,
         ledger: &admission_ledger,
         keys_dir: None,
@@ -2052,6 +2009,7 @@ pub(super) fn cmd_run(params: RunParams<'_>) -> Result<()> {
                 mem_mib: final_memory as u64,
                 seccomp_tier: plan_seccomp_tier,
                 secret_release: plan_secret_release,
+                secrets: plan_secrets.clone(),
                 no_supervisor,
                 ledger: &admission_ledger,
                 keys_dir: None,
@@ -2323,6 +2281,7 @@ mod admit_plan_tests {
             mem_mib: 512,
             seccomp_tier: mvm_plan::PlanSeccompTier::Standard,
             secret_release: mvm_plan::SecretReleasePolicy::None,
+            secrets: Vec::new(),
             no_supervisor: true,
             ledger: &ledger,
             keys_dir: None, // not read — short-circuit returns first
@@ -2351,6 +2310,7 @@ mod admit_plan_tests {
             mem_mib: 512,
             seccomp_tier: mvm_plan::PlanSeccompTier::Network,
             secret_release: mvm_plan::SecretReleasePolicy::PlanBound,
+            secrets: Vec::new(),
             no_supervisor: false,
             ledger: &ledger,
             keys_dir: Some(keys_dir.path()),
@@ -2400,6 +2360,7 @@ mod admit_plan_tests {
             mem_mib: 128,
             seccomp_tier: mvm_plan::PlanSeccompTier::Standard,
             secret_release: mvm_plan::SecretReleasePolicy::None,
+            secrets: Vec::new(),
             no_supervisor: false,
             ledger: &ledger,
             keys_dir: Some(keys_dir.path()),
@@ -2435,6 +2396,7 @@ mod admit_plan_tests {
             mem_mib: 128,
             seccomp_tier: mvm_plan::PlanSeccompTier::Standard,
             secret_release: mvm_plan::SecretReleasePolicy::None,
+            secrets: Vec::new(),
             no_supervisor: false,
             ledger: &ledger,
             keys_dir: Some(keys_dir.path()),
@@ -2454,6 +2416,7 @@ mod admit_plan_tests {
             mem_mib: 128,
             seccomp_tier: mvm_plan::PlanSeccompTier::Standard,
             secret_release: mvm_plan::SecretReleasePolicy::None,
+            secrets: Vec::new(),
             no_supervisor: false,
             ledger: &ledger,
             keys_dir: Some(keys_dir.path()),
@@ -2515,6 +2478,7 @@ mod admit_plan_tests {
             mem_mib: 128,
             seccomp_tier: mvm_plan::PlanSeccompTier::Standard,
             secret_release: mvm_plan::SecretReleasePolicy::None,
+            secrets: Vec::new(),
             no_supervisor: false,
             ledger: &ledger,
             keys_dir: Some(keys_dir.path()),
@@ -2598,6 +2562,7 @@ chain_signing = true
                 egress_policy_ref: None,
                 tool_policy_ref: None,
                 secret_release: mvm_plan::SecretReleasePolicy::None,
+                secrets: Vec::new(),
                 audit_event_prefix: None,
                 cpus: 1,
                 mem_mib: 128,
@@ -2695,6 +2660,7 @@ stream_destinations = ["file://{}"]
                 egress_policy_ref: None,
                 tool_policy_ref: None,
                 secret_release: mvm_plan::SecretReleasePolicy::None,
+                secrets: Vec::new(),
                 audit_event_prefix: None,
                 cpus: 1,
                 mem_mib: 128,
@@ -2791,6 +2757,7 @@ chain_signing = false
                 egress_policy_ref: None,
                 tool_policy_ref: None,
                 secret_release: mvm_plan::SecretReleasePolicy::None,
+                secrets: Vec::new(),
                 audit_event_prefix: None,
                 cpus: 1,
                 mem_mib: 128,
@@ -2862,6 +2829,7 @@ chain_signing = false
                 egress_policy_ref: None,
                 tool_policy_ref: None,
                 secret_release: mvm_plan::SecretReleasePolicy::None,
+                secrets: Vec::new(),
                 audit_event_prefix: None,
                 cpus: 1,
                 mem_mib: 128,
@@ -2953,6 +2921,7 @@ disabled_inspectors = ["ssrf_guarrd"]
                 egress_policy_ref: None,
                 tool_policy_ref: None,
                 secret_release: mvm_plan::SecretReleasePolicy::None,
+                secrets: Vec::new(),
                 audit_event_prefix: None,
                 cpus: 1,
                 mem_mib: 128,
@@ -3050,6 +3019,7 @@ port_hi  = 443
                 egress_policy_ref: None,
                 tool_policy_ref: None,
                 secret_release: mvm_plan::SecretReleasePolicy::None,
+                secrets: Vec::new(),
                 audit_event_prefix: None,
                 cpus: 1,
                 mem_mib: 128,

--- a/crates/mvm-cli/src/commands/vm/up.rs
+++ b/crates/mvm-cli/src/commands/vm/up.rs
@@ -21,6 +21,7 @@ use super::host_signer::load_or_init_at;
 use super::managed_secrets::lower_workload_secrets;
 use super::plan_admission::{
     AdmittedPlan, BundleAdmissionContext, InMemoryNonceLedger, SystemClock, admit_for_run,
+    populate_audit_substrate,
 };
 use super::plan_builder::SynthesisInput;
 use super::policy_resolver::{
@@ -1303,7 +1304,7 @@ pub(super) fn cmd_run(params: RunParams<'_>) -> Result<()> {
             deps_volume: deps_volume_binding.clone(),
         })?;
 
-        let start_config = mvm_core::vm_backend::VmStartConfig {
+        let mut start_config = mvm_core::vm_backend::VmStartConfig {
             name: vm_name.clone(),
             rootfs_path: rootfs,
             kernel_path: Some(kernel),
@@ -1311,6 +1312,13 @@ pub(super) fn cmd_run(params: RunParams<'_>) -> Result<()> {
             memory_mib: direct_mem,
             ..Default::default()
         };
+        // Plan 112 Phase 3c — when admission produced an AdmissionContext,
+        // thread tenant_id / plan_json / bundle_json so libkrun/Vz take
+        // the bridge-factory path. None keeps the legacy supervisor path
+        // for no-admission flows.
+        if let Some(ctx) = admission.as_ref() {
+            populate_audit_substrate(&mut start_config, &ctx.admitted)?;
+        }
 
         let backend = AnyBackend::from_hypervisor(effective_hypervisor);
         if let Err(e) = backend.start(&start_config) {
@@ -1710,7 +1718,7 @@ pub(super) fn cmd_run(params: RunParams<'_>) -> Result<()> {
         emit_launched_if(&admission_main, effective_hypervisor);
     } else {
         let (verity_path, roothash) = microvm::probe_verity_sidecar(&rootfs_path);
-        let start_config = VmStartParams {
+        let mut start_config = VmStartParams {
             name: vm_name,
             rootfs_path,
             vmlinux_path,
@@ -1729,6 +1737,12 @@ pub(super) fn cmd_run(params: RunParams<'_>) -> Result<()> {
             port_mappings: &port_mappings,
         }
         .into_start_config();
+        // Plan 112 Phase 3c — thread audit substrate from admission_main
+        // through to backend.start() so libkrun/Vz take the bridge-factory
+        // path. None keeps the legacy supervisor path for no-admission flows.
+        if let Some(ctx) = admission_main.as_ref() {
+            populate_audit_substrate(&mut start_config, &ctx.admitted)?;
+        }
 
         // Apple Container with -d: install a launchd agent instead of
         // starting the VM in this process. The agent runs as a proper
@@ -2026,7 +2040,7 @@ pub(super) fn cmd_run(params: RunParams<'_>) -> Result<()> {
                     continue;
                 }
             };
-            let w_start_config = VmStartParams {
+            let mut w_start_config = VmStartParams {
                 name: vm_name_owned.clone(),
                 rootfs_path: result.rootfs_path,
                 vmlinux_path: result.vmlinux_path,
@@ -2045,6 +2059,12 @@ pub(super) fn cmd_run(params: RunParams<'_>) -> Result<()> {
                 port_mappings: &w_port_mappings,
             }
             .into_start_config();
+            // Plan 112 Phase 3c — watch-loop re-boot uses its own fresh
+            // admission (watch_admission); same substrate threading as the
+            // main path. None → legacy supervisor path.
+            if let Some(ctx) = watch_admission.as_ref() {
+                populate_audit_substrate(&mut w_start_config, &ctx.admitted)?;
+            }
             let w_backend = AnyBackend::from_hypervisor(effective_hypervisor);
             if let Err(e) = w_backend.start(&w_start_config) {
                 emit_failed_if(&watch_admission, "backend-start", &e);

--- a/crates/mvm-cli/src/exec.rs
+++ b/crates/mvm-cli/src/exec.rs
@@ -548,6 +548,13 @@ fn run_inner(req: ExecRequest, capture: bool) -> Result<Either<i32, ExecOutput>>
     // from the host — shell out into the VM instead.
     let (verity_path, roothash) = mvm_backend::microvm::probe_verity_sidecar(&rootfs);
 
+    // Plan 112 Phase 3c — template-restore VMs run without plan admission
+    // (this exec path predates plan-64). Leave tenant_id / plan_json /
+    // bundle_json at their None defaults (via `..Default::default()`) so
+    // the libkrun/Vz backends take the legacy `run_supervisor` dispatch.
+    // A future change to route template restores through admission would
+    // add an `admit_for_run` call here and a `populate_audit_substrate`
+    // invocation after the struct literal.
     let start_config = VmStartConfig {
         name: vm_name.clone(),
         rootfs_path: rootfs.clone(),
@@ -814,6 +821,12 @@ pub fn boot_session_vm(
 
     let (verity_path, roothash) = mvm_backend::microvm::probe_verity_sidecar(&rootfs);
 
+    // Plan 112 Phase 3c — session VMs are short-lived MCP-driven boots
+    // that don't go through plan admission. Leave tenant_id / plan_json
+    // / bundle_json at their None defaults so the libkrun supervisor
+    // stays on the legacy path. Adding session VMs to the audit chain is
+    // a separate scope decision (would require synthesis input +
+    // admission inside `boot_session_vm`).
     let start_config = VmStartConfig {
         name: vm_name.clone(),
         rootfs_path: rootfs.clone(),

--- a/crates/mvm-core/src/protocol/vm_backend.rs
+++ b/crates/mvm-core/src/protocol/vm_backend.rs
@@ -98,6 +98,29 @@ pub struct VmStartConfig {
     pub secret_files: Vec<VmFile>,
     /// Directory containing microvm.nix runner scripts (microvm.nix backend only).
     pub runner_dir: Option<String>,
+    /// Plan 102 Phase 3c — tenant identifier from the admitted
+    /// `ExecutionPlan` (`AdmittedPlan.plan.tenant.0`). When `Some`,
+    /// the libkrun/Vz backends activate the gateway audit substrate
+    /// (bridge factory + chain-signed audit emit per ADR-058).
+    /// `None` keeps the legacy `run_supervisor` path for callers
+    /// without admission (`mvmctl dev` Stage 0 builder, session VMs,
+    /// template restore).
+    pub tenant_id: Option<String>,
+    /// Plan 102 Phase 3c — JSON-encoded `SignedExecutionPlan`
+    /// envelope. Carried as a `String` so `mvm-core` does not depend
+    /// on `mvm-plan` (avoids the `mvm-plan → mvm-libkrun → mvm-core`
+    /// cycle). **The supervisor re-verifies the signature** before
+    /// trusting any decoded field (ADR-041 §"Verification at
+    /// admission"); the host is in the TCB per ADR-002 but the
+    /// supervisor still runs Ed25519 verification. **Do not log
+    /// this value** — the envelope may carry secret bindings, env
+    /// vars, or policy refs that resolve to credentials.
+    pub plan_json: Option<String>,
+    /// Plan 102 Phase 3c — JSON-encoded `PlanArtifact` (bundle pin)
+    /// when `admitted.plan.bundle.is_some()`. `None` when the plan
+    /// has no `.mvmpkg` pin (the common case). Same "do not log"
+    /// rule as `plan_json`.
+    pub bundle_json: Option<String>,
 }
 
 /// A host:guest port mapping, backend-agnostic.
@@ -821,6 +844,12 @@ mod tests {
         assert!(config.volumes.is_empty());
         assert!(config.config_files.is_empty());
         assert!(config.secret_files.is_empty());
+        // Plan 102 Phase 3c — audit substrate fields default to None
+        // so legacy callers (no AdmittedPlan in scope) get the legacy
+        // supervisor path.
+        assert!(config.tenant_id.is_none());
+        assert!(config.plan_json.is_none());
+        assert!(config.bundle_json.is_none());
     }
 
     #[test]

--- a/crates/mvm-sdk/src/compile/orchestrator.rs
+++ b/crates/mvm-sdk/src/compile/orchestrator.rs
@@ -13,7 +13,7 @@ use crate::compile::reachability::{
     discover_python_reachable,
 };
 use crate::compile::source::{SourceError, copy_source, rehash};
-use mvm_ir::{Entrypoint, Source, Workload};
+use mvm_ir::{Entrypoint, EnvValue, Source, Workload};
 use std::collections::HashSet;
 use std::fs;
 use std::io;
@@ -49,6 +49,9 @@ pub enum CompileError {
     /// the surface explicit so callers can distinguish a real
     /// "function missing" from "we couldn't even parse the source".
     FuncDescribe(FuncDescribeError),
+    ManagedSecretsNotSupported {
+        targets: Vec<String>,
+    },
 }
 
 impl std::fmt::Display for CompileError {
@@ -80,6 +83,13 @@ impl std::fmt::Display for CompileError {
                 "function {module:?}:{function:?} is missing parameters required by args_schema: {missing:?}"
             ),
             Self::FuncDescribe(e) => write!(f, "function-presence check: {e}"),
+            Self::ManagedSecretsNotSupported { targets } => write!(
+                f,
+                "managed secret refs are not supported by `mvmctl compile` local boot artifacts yet; \
+                 found secret-backed env targets: {}. Use deploy/plan flows for managed refs, or \
+                 mount guest-visible files explicitly if you accept guest materialization.",
+                targets.join(", ")
+            ),
         }
     }
 }
@@ -136,6 +146,12 @@ pub fn compile(workload: &Workload, out: &Path, manifest_dir: &Path) -> Result<(
             .apps
             .first()
             .expect("validate() ensures at least one app");
+        let managed_secret_targets = managed_secret_targets(app);
+        if !managed_secret_targets.is_empty() {
+            return Err(CompileError::ManagedSecretsNotSupported {
+                targets: managed_secret_targets,
+            });
+        }
         let bundle_dir = staging.join("src");
         let mut source_plan = match &app.source {
             Source::LocalPath {
@@ -231,6 +247,36 @@ pub fn compile(workload: &Workload, out: &Path, manifest_dir: &Path) -> Result<(
         Err(e) => {
             let _ = fs::remove_dir_all(&staging);
             Err(e)
+        }
+    }
+}
+
+fn managed_secret_targets(app: &mvm_ir::App) -> Vec<String> {
+    let mut targets = Vec::new();
+    collect_secret_targets(&app.env, &mut targets);
+    for ep in &app.entrypoints {
+        match ep {
+            Entrypoint::Command { env, .. } | Entrypoint::Function { env, .. } => {
+                collect_secret_targets(env, &mut targets);
+            }
+        }
+    }
+    targets.sort();
+    targets.dedup();
+    targets
+}
+
+fn collect_secret_targets(
+    env: &std::collections::BTreeMap<String, EnvValue>,
+    out: &mut Vec<String>,
+) {
+    for value in env.values() {
+        let EnvValue::SecretRef { reference } = value else {
+            continue;
+        };
+        match &reference.mount {
+            mvm_ir::SecretMount::Env { var } => out.push(var.clone()),
+            mvm_ir::SecretMount::File { path } => out.push(path.clone()),
         }
     }
 }
@@ -415,7 +461,7 @@ fn write_lf(path: &Path, contents: &str) -> Result<(), CompileError> {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use mvm_ir::{App, Entrypoint, Format, Image, Resources, Source};
+    use mvm_ir::{App, Entrypoint, Format, Image, Resources, SecretMount, SecretRef, Source};
     use tempfile::TempDir;
 
     fn sample() -> Workload {
@@ -538,6 +584,34 @@ mod tests {
             concurrency: None,
         }];
         w
+    }
+
+    #[test]
+    fn compile_refuses_managed_secret_refs_for_local_boot_artifacts() {
+        let tmp = TempDir::new().unwrap();
+        let manifest_dir = tmp.path().join("manifest");
+        make_src(&manifest_dir);
+        let out = tmp.path().join("artifact");
+        let mut workload = sample();
+        workload.apps[0].env.insert(
+            "API_KEY".into(),
+            EnvValue::SecretRef {
+                reference: SecretRef {
+                    name: "api-key".into(),
+                    mount: SecretMount::Env {
+                        var: "API_KEY".into(),
+                    },
+                },
+            },
+        );
+
+        let err = compile(&workload, &out, &manifest_dir).unwrap_err();
+        match err {
+            CompileError::ManagedSecretsNotSupported { targets } => {
+                assert_eq!(targets, vec!["API_KEY".to_string()]);
+            }
+            other => panic!("expected ManagedSecretsNotSupported, got {other:?}"),
+        }
     }
 
     #[test]

--- a/public/src/content/docs/guides/config-secrets.md
+++ b/public/src/content/docs/guides/config-secrets.md
@@ -49,34 +49,24 @@ let config = FlakeRunConfig {
 };
 ```
 
-## Secret Bindings
+## Managed Secrets
 
-For AI agent workloads, use `--secret` to bind environment variable secrets to specific target domains. This provides domain-scoped secret injection — combine with `--network-preset` to prevent exfiltration:
+`mvmctl up --secret` has been removed.
 
-```bash
-mvmctl up --flake . \
-    --secret OPENAI_API_KEY:api.openai.com \
-    --secret ANTHROPIC_API_KEY:api.anthropic.com:x-api-key \
-    --network-preset dev
-```
+Use `mvmctl secret put` to store local secret refs, then bind those refs
+through `mvm.toml` or the SDKs. That is the supported path for managed
+secrets.
 
-**Binding syntax:**
+The managed-secret model is:
 
-| Format | Meaning |
-|--------|---------|
-| `KEY:host` | Read KEY from host env, bind to host (Authorization header) |
-| `KEY:host:header` | Custom HTTP header name |
-| `KEY=value:host` | Explicit value instead of env lookup |
-| `KEY=value:host:header` | Explicit value + custom header |
+1. Store a secret ref locally with `mvmctl secret put <name>`
+2. Declare that ref in `mvm.toml` or with `mvm.secret(...)`
+3. The guest sees only a normal env var name with an opaque placeholder
+4. Host-mediated surfaces such as `mvm.web_fetch` and `mvm.web_search`
+   release the real value at request time when policy allows it
 
-**What happens at boot:**
-
-1. Secret values are resolved (from host env or explicit) and written to the **secrets drive** (mode 0600)
-2. A `secrets-manifest.json` is written to the **config drive** (metadata only, no values)
-3. Placeholder env vars (`mvm-managed:KEY`) are set in the guest environment so tools pass existence checks
-4. Combined with network allowlists, the VM can only send traffic to the allowed domains
-
-This is the "config-drive injection" approach. The secret values are on the guest's secrets drive but are scoped to specific domains via network policy. A future upgrade will add MITM proxy-based injection where secrets never touch the guest filesystem.
+Managed secret refs are host-mediated only. Guest HTTPS CONNECT egress
+is not a substitution path.
 
 ## Design
 

--- a/public/src/content/docs/guides/nix-flakes.md
+++ b/public/src/content/docs/guides/nix-flakes.md
@@ -281,7 +281,13 @@ These map to `packages.${system}.<profile>` in the flake.
 
 ## Running an LLM agent inside a microVM
 
-A worked example: a microVM that boots `claude-code` (or any other agent binary) and reads its API key from a host-injected secret. You write this in **your project's** flake — mvm doesn't ship a starter image to fork; you compose `mkGuest` yourself per [Building MicroVM Images](/guides/building-microvm-images).
+A worked example: a microVM that boots `claude-code` (or any other
+agent binary) and reads its API key from a file you mount into the
+guest yourself. This is a manual file-materialization path, not the
+managed-secret model. For host-mediated managed secret refs, use
+`mvm.toml` or the SDKs. You write this in **your project's** flake —
+mvm doesn't ship a starter image to fork; you compose `mkGuest`
+yourself per [Building MicroVM Images](/guides/building-microvm-images).
 
 ```nix
 # my-claude-code-vm/flake.nix
@@ -303,10 +309,10 @@ A worked example: a microVM that boots `claude-code` (or any other agent binary)
 
         entrypoint.command = [ "${pkgs.claude-code}/bin/claude" "code" ];
 
-        # Anthropic API key delivered via secrets — never enters the
-        # rootfs at build time. Phase 6 wires the secret-injection
-        # path; today the field is metadata that mvmctl reads.
-        # secrets.anthropic-api-key = "/run/mvm-secrets/claude-code/api-key";
+        # If you choose to mount a credentials file manually, keep it
+        # out of the rootfs and point the app at the mounted path.
+        # Managed secret refs are declared through mvm.toml / SDKs,
+        # not through this flake-only example.
 
         # Defense in depth: the workload is rootless by default in
         # prod (uid 1000); per-service seccomp tier lands in Phase 6.
@@ -325,8 +331,13 @@ cd my-claude-code-vm
 mvmctl build
 mvmctl up \
   --add-dir "$PWD:/workspace:rw" \
-  --secret-file "$HOME/.config/mvm/secrets/anthropic:claude-code/anthropic-api-key"
+  --volume "$HOME/.config/mvm/secrets:/mnt/secrets"
 ```
+
+Inside the guest, your workload can read the file you mounted under
+`/mnt/secrets`. If you do not want the guest to ever see the raw
+credential, do not use this manual file-mount pattern; use managed
+secret refs instead.
 
 Why a microVM and not a process sandbox: process sandboxes share the host kernel and trust it. A microVM gives the agent its own kernel, so a kernel exploit can't pivot to the host.
 

--- a/public/src/content/docs/guides/sdk.md
+++ b/public/src/content/docs/guides/sdk.md
@@ -79,7 +79,7 @@ recognizes. Anything else in decorator kwarg position is rejected:
 | `nix_packages([...])`   | `Image::NixPackages`     | direct passthrough                             |
 | `resources(...)`        | `Resources`              | `cpu`/`memory_mb`/`rootfs_size_mb`             |
 | `network(mode=, ports=)`| `Network`                | `none` \| `bridge` \| `host`                   |
-| `secret(name, var=)`    | `EnvValue::SecretRef`    | resolved at admission by supervisor            |
+| `secret(name, var=)`    | `EnvValue::SecretRef`    | host-mediated secret ref; guest sees placeholder only |
 | `literal(value)`        | `EnvValue::Literal`      | parity with `secret(...)`                      |
 | `hook(cmd)`             | `HookCmd`                | str → Shell; list → Argv                       |
 
@@ -105,6 +105,19 @@ Nix factory to bake into `/etc/mvm/hooks/<phase>.sh`.
 Deployment to the hosted control plane is an `mvmd` responsibility. Use
 `mvmctl compile` to produce local build artifacts; mvmd consumes the same SDK
 compile/deploy libraries when it packages and accepts workloads.
+
+## Secret semantics
+
+`mvm.secret(...)` names a managed secret reference, not a raw secret
+value.
+
+- The guest sees a normal env var name and an opaque placeholder
+  value.
+- The raw secret stays on the host side.
+- Request-time release is supported only on host-mediated outbound
+  surfaces such as `mvm.web_fetch` and `mvm.web_search`.
+- Guest HTTPS CONNECT egress is not a managed-secret substitution
+  path.
 
 ## TypeScript runner
 

--- a/public/src/content/docs/reference/cli-commands.md
+++ b/public/src/content/docs/reference/cli-commands.md
@@ -42,7 +42,6 @@ The intentionally kept top-level command families are:
 | `mvmctl up --network-preset <preset>` | Network egress policy: `unrestricted` (default), `none`, `registries`, `dev`, `agent` (LLM-inference + GitHub bundle — see [ADR-004](https://github.com/tinylabscom/mvm/blob/main/specs/adrs/004-hypervisor-egress-policy.md)) |
 | `mvmctl up --network-allow host:port` | Allow egress to specific host:port (repeatable, mutually exclusive with preset) |
 | `mvmctl up --seccomp <tier>` | Seccomp profile: `essential`, `minimal`, `standard` (default), `network`, `unrestricted`. The selected tier is enforced through the guest `seccomp.json` manifest and recorded in the signed admission profile for audit. |
-| `mvmctl up --secret KEY:host` | Bind a secret to a domain (repeatable; see [Config & Secrets](/guides/config-secrets/)) |
 | `mvmctl up --network <name>` | Named dev network to attach VM to (default: "default") |
 | `mvmctl down [name]` | Stop VMs by name, or all if omitted |
 | `mvmctl ls` | List running VMs (aliases: `ps`, `status`) |

--- a/public/src/content/docs/reference/filesystem.md
+++ b/public/src/content/docs/reference/filesystem.md
@@ -38,7 +38,7 @@ The rootfs is built by `mkGuest` and contains:
 The config drive (`/dev/vdb`, mounted at `/mnt/config/`) contains non-sensitive configuration:
 
 - `config.json` — mvm instance metadata (name, role, resources)
-- Application config files injected via `--config-dir`
+- Application config files from host directories you mounted yourself
 
 Files are written with mode 0444 (world-readable, read-only mount).
 
@@ -47,7 +47,7 @@ Files are written with mode 0444 (world-readable, read-only mount).
 The secrets drive (`/dev/vdc`, mounted at `/mnt/secrets/`) contains sensitive data:
 
 - `secrets.json` — tenant-level secrets
-- Application secrets injected via `--secrets-dir`
+- Application secret files from host directories you mounted yourself
 
 Security hardening:
 - Uses tmpfs-backed file (never hits persistent storage)

--- a/public/src/content/docs/security/sandbox-parity-status.md
+++ b/public/src/content/docs/security/sandbox-parity-status.md
@@ -97,10 +97,11 @@ Tracking work:
 
 ### `secret-non-leakage` — Planned
 
-Today secrets reach the guest as plain env or mounted files. A
-compromised guest can read them. ADR-048 §"Non-goals" explicitly
-states mvm will **not claim** secret non-leakage for that legacy
-flow. The placeholder + host-side substitution path is Planned.
+Today, manually mounted secret files are still readable by the guest
+that receives them. ADR-048 §"Non-goals" explicitly states mvm will
+**not claim** secret non-leakage for that manual file-materialization
+path. The placeholder + host-side substitution path is Planned for
+managed secret refs.
 
 To move to Preview: ship the `SecretPlaceholder` type, host-side
 grant registry, and L7-proxy substitution for at least one provider
@@ -109,8 +110,8 @@ end-to-end, behind a default-off feature flag.
 To move to Shipped: the default flow is placeholder-based; redaction
 wrappers cover plan JSON, logs, audit, errors, cache keys, route
 labels, and panic output; hostile-guest exfiltration tests run in
-CI; the legacy env/file path sits behind
-`unsafe_guest_secret_materialization` and is documented as such.
+CI; explicit guest-visible file mounts remain manual opt-ins and are
+documented as such.
 
 Tracking work:
 [Plan 74 W3](https://github.com/tinylabscom/mvm/blob/main/specs/plans/74-claim-safe-sandbox-parity.md#w3--secret-placeholders-and-host-side-substitution).

--- a/specs/adrs/048-claim-safe-sandbox-parity.md
+++ b/specs/adrs/048-claim-safe-sandbox-parity.md
@@ -41,7 +41,7 @@ This ADR records the claims we want to make and the runtime primitives `mvm` mus
 1. **Claims hygiene:** public docs clearly distinguish Shipped, Preview, Planned, and Not claimed.
 2. **OCI ingest:** users can run digest-pinned OCI images in microVMs without Docker as the runtime.
 3. **Programmable network policy:** deny-by-default egress with DNS pinning, SNI/Host enforcement, metadata endpoint protection, and audit.
-4. **Secrets do not enter guests by default:** workloads receive opaque placeholders; real secret values are substituted only by trusted host-side policy for approved destinations.
+4. **Secrets do not enter guests by default:** workloads receive opaque placeholders; real secret values are released only by trusted host-side policy for approved destinations, and only on host-mediated outbound surfaces. Guest HTTPS CONNECT egress is not a request-time substitution path.
 5. **SDK-owned lifecycle:** Python/TypeScript/Rust SDKs can create, exec, inspect, snapshot, and stop sandboxes with cleanup bound to the parent process.
 6. **Measured cold-start story:** published latency numbers are produced by a reproducible harness and split by fresh boot, guest-agent-ready, snapshot restore, and warm-pool claim.
 7. **Extensible filesystem backends:** local, encrypted, object-store-backed, and in-memory filesystem substrates share one contract and state which backends are mountable versus API-only.

--- a/specs/plans/102-gateway-audit-substrate-impl.md
+++ b/specs/plans/102-gateway-audit-substrate-impl.md
@@ -226,26 +226,45 @@ activation + live smokes are tracked separately as Phase 3c.
       no spawn takes the bridge path, so live smokes wouldn't
       exercise the substrate. Scheduled with the Phase 3c PR.
 
-#### Phase 3c — producer activation (next PR in this work stream)
+#### Phase 3c — producer activation (executed as Plan 112)
 
 Threads the `AdmittedPlan` from `mvm-cli`'s `mvmctl up` admission
 flow down to backend `start()` so the audit-substrate fields
-actually populate at runtime:
+actually populate at runtime. Execution detail and field map live in
+[Plan 112](112-w6a-phase-3c-producer-activation.md).
 
-- [ ] Widen `mvm_core::vm_backend::VmStartConfig` with three
+- [x] Widen `mvm_core::vm_backend::VmStartConfig` with three
       `Option<String>` fields: `tenant_id`, `plan_json`,
       `bundle_json`. All `Option<String>` so mvm-core gains no
       typed deps.
-- [ ] Populate the new fields from `AdmittedPlan` at each
-      `VmStartConfig` construction site in `mvm-cli` (~6 sites).
-- [ ] `mvm-backend/src/libkrun.rs::start()` reads them and
-      populates the five `SupervisorConfig` audit fields +
-      `plan` + `bundle` from `mvm_data_dir()` + the
-      pre-serialized JSON.
-- [ ] Same pattern for the Vz backend (vz.rs already populates
-      `events_ingest_socket_path`; the Vz-side `tenant_id`
-      pumping is the parallel work).
-- [ ] Live smoke per backend.
+- [x] Populate the new fields from `AdmittedPlan` at each
+      `VmStartConfig` construction site in `mvm-cli` (three live
+      sites in `up.rs`: direct-boot `admission`, main path
+      `admission_main`, watch-loop `watch_admission`; top-level
+      `exec.rs` template-restore + session VM paths stay None with
+      doc-comment annotation because no admission is in scope).
+- [x] `mvm-backend/src/libkrun.rs::start()` reads them via the new
+      `build_supervisor_config` helper that delegates substrate
+      resolution to `crates/mvm-backend/src/audit_substrate.rs` and
+      maps the resolved `AuditSubstrate` into `SupervisorConfig`
+      (five audit fields + `plan` + `bundle` parsed from the JSON
+      envelopes).
+- [x] Same delegation pattern for the Vz backend with one carve-out:
+      the resolved substrate is computed (so tenant_id allowlist
+      validation fires) but not yet routed into `vz::SupervisorConfig`
+      — that needs a lockstep Swift `Config.swift` schema update +
+      a Rust-side drainer that binds `events_ingest_socket_path` and
+      emits to the chain. Both belong to the NetworkProvider trait
+      follow-up plan.
+- [x] DNS-label allowlist guard (`^[A-Za-z0-9][A-Za-z0-9_-]{0,62}$`,
+      ASCII-only, 63-char cap) for both `tenant_id` and `vm_name`.
+      `mvm-plan::TenantId` is unchecked today; this is the
+      defense-in-depth boundary on the way to a typed wrapper.
+- [x] Envelope size caps in `populate_audit_substrate`
+      (`plan_json` ≤ 1 MiB, `bundle_json` ≤ 4 MiB) — DoS guard for
+      the supervisor stdin pipe.
+- [ ] Live smoke per backend × network (libkrun+passt,
+      libkrun+gvproxy, Vz+gvproxy) — pending Plan 112 PR merge.
 
 ### W6.B follow-ups (real flow extraction, next PR in this work stream)
 

--- a/specs/plans/103-w6a-implementation-tracker.md
+++ b/specs/plans/103-w6a-implementation-tracker.md
@@ -479,11 +479,21 @@ plans` per commit 8.
 
 🟢 **W6.A merged 2026-05-27** (PR #459 on `main` at `df950fd9`).
 
-🟡 **W6.A.5 substrate wire-up in flight (2026-05-27)** — 8 commits
-on `worktree-plan-102-w6a-5-wire-up` covering Phases 1–5 of the
-follow-up. See [Plan 102 §W6.A.5](102-gateway-audit-substrate-impl.md#w6a5--vz-swift-bridge--fd-interception-wire-up)
-for the per-item status. Producer activation (`Phase 3c`) and
-live smokes are scheduled for the next PR — until then the
-bridge factory branch is dormant at runtime (`cfg.tenant_id`
-stays `None` and every spawn takes the legacy `run_supervisor`
-path).
+🟢 **W6.A.5 substrate wire-up merged 2026-05-28** (PR #487 on `main`).
+Vz Swift bridge + libkrun `run_supervisor_with_bridge<F>` + host-side
+gvproxy lifecycle shipped; `mvm-libkrun-supervisor` split into its own
+leaf crate.
+
+🟡 **Phase 3c producer activation in flight (2026-05-28)** — executed
+as [Plan 112](112-w6a-phase-3c-producer-activation.md) on
+`worktree-plan-102-phase-3c`. Widens `VmStartConfig` with three
+`Option<String>` fields (`tenant_id` / `plan_json` / `bundle_json`),
+populates from `AdmittedPlan` at the three `mvmctl up`
+construction sites, delegates substrate resolution to a new shared
+`crates/mvm-backend/src/audit_substrate.rs` module (allowlist
+validation + path derivation; seam for the future `NetworkProvider`
+trait), threads the result into libkrun's `SupervisorConfig`. Vz path
+gets the allowlist guard but defers full chain-emit wiring to the
+NetworkProvider trait plan (needs lockstep Swift `Config.swift` schema
+update + a Rust drainer for `events_ingest_socket_path`). Live smokes
+scheduled for the Phase 3c PR merge.

--- a/specs/plans/112-w6a-phase-3c-producer-activation.md
+++ b/specs/plans/112-w6a-phase-3c-producer-activation.md
@@ -1,0 +1,343 @@
+# Plan 112 — Plan 102 W6.A Phase 3c: Producer Activation
+
+**Sprint:** 56 (Plan 102 W6.A.5 follow-up)
+**Parent:** [Plan 102](102-gateway-audit-substrate-impl.md) §W6.A.5
+**Tracker:** [Plan 103](103-w6a-implementation-tracker.md) §Status
+**ADRs:** [ADR-041](../adrs/041-signed-audited-execution-plans.md) (claim 8), [ADR-058](../adrs/058-claim-10-bytes-leaving-trust-boundary.md) (claim 10 leg 2)
+**Status:** 🟡 in progress — PR pending
+
+## Context
+
+PR #487 (`worktree-plan-102-w6a-5-wire-up`) — **MERGED into `main`** — shipped the gateway
+audit substrate: `mvm-libkrun-supervisor` bin entrypoint, `SupervisorConfig` gained five
+`Option`-typed audit fields (`tenant_id`, `audit_dir`, `gateway_audit_socket`,
+`gateway_events_socket`, `signing_key_path`) with `#[serde(default)]`, `mvm-libkrun`
+gained `BridgeFds` + `configure_with_gateway_for_bridge` + `run_supervisor_with_bridge<F>`,
+the supervisor `main` branches on `cfg.tenant_id` (`Some` → bridge factory, `None` →
+legacy `run_supervisor`), Vz's host-side gvproxy lifecycle wired (`host_gvproxy.rs`), and
+the Swift `makeBridgedGvproxyDevice` + 5 XCTest cases shipped.
+
+**Phase 3c is the producer side that activates the substrate.** Today (post-#487):
+
+- `mvm_core::vm_backend::VmStartConfig` carries no audit-substrate fields.
+- `crates/mvm-backend/src/libkrun.rs::start()` hard-codes the new `SupervisorConfig`
+  fields to `None` with a comment: *"backend orchestrator population … lands alongside
+  the run_supervisor_with_bridge wire-up (commit 6.5 / 7)"* — that's this plan.
+- `mvm-libkrun-supervisor::main` therefore takes the **legacy `run_supervisor` path on
+  every spawn**, so claim-10 leg 2 (per ADR-058) is dormant.
+
+Phase 3c scope (verbatim from PR #487's merged body): *"widens
+`mvm_core::vm_backend::VmStartConfig` with three `Option<String>` fields (`tenant_id`,
+`plan_json`, `bundle_json`) and threads `AdmittedPlan` through to backend `start()` at the
+~6 mvm-cli `VmStartConfig` construction sites."*
+
+The fields are `Option<String>` (not typed) so `mvm-core` keeps zero dep on `mvm-plan`
+(avoids closing the `mvm-plan → mvm-libkrun → mvm-core` cycle).
+
+## Goal
+
+End-to-end activation: every `mvmctl up` (direct-boot, main, watch-loop) populates
+`VmStartConfig.{tenant_id, plan_json, bundle_json}` from its in-scope `AdmissionContext`;
+`libkrun.rs::start()` and `vz.rs::start()` thread those into `SupervisorConfig` (deriving
+`audit_dir` / gateway sockets / signing key from `mvm_data_dir()`); the libkrun supervisor
+takes the **bridge-factory path** on at least one live smoke per backend × network combo
+(libkrun+passt, libkrun+gvproxy, Vz+gvproxy).
+
+## Pick-up command (for fresh sessions)
+
+Read `specs/plans/102-gateway-audit-substrate-impl.md` §W6.A.5 first for the substrate
+context, then resume here from the first unchecked task below. Worktree:
+`.claude/worktrees/plan-102-phase-3c`; branch: `worktree-plan-102-phase-3c`.
+
+## Architecture decisions
+
+- **Helper home:** `populate_audit_substrate(&mut VmStartConfig, &AdmittedPlan)` lives in
+  `crates/mvm-cli/src/commands/vm/plan_admission.rs`. mvm-cli already depends on mvm-plan +
+  mvm-core, so it's the natural home. `mvm-libkrun` can't depend on `mvm-plan` (would
+  close the cycle), so the helper can't live there.
+- **Supervisor re-verifies plan_json** at `crates/mvm-supervisor/src/supervisor.rs:308`
+  via `mvm_plan::verify_plan(signed, trusted_keys)`. Host is in the TCB per ADR-002, but
+  the supervisor still doesn't trust the host's pre-decoded fields — it re-runs Ed25519
+  verification against its own trusted-keys list.
+- **TenantId path-safety (allowlist, not deny-list):** `TenantId` is a `String` newtype
+  with no validation in mvm-plan. The supervisor uses `tenant_id` to construct
+  `<audit_dir>/<tenant_id>.jsonl`, so a malicious tenant value (`../foo`, Unicode
+  confusables, pathological length) could escape or DoS. Validate inside
+  `audit_substrate::validate_tenant_id` with an RFC 1123 DNS-label-shaped allowlist:
+  `^[a-zA-Z0-9][a-zA-Z0-9_-]{0,62}$`. ASCII-only, max 63 chars. Deny-list approaches
+  are fail-open by construction; allowlist is fail-closed.
+- **vm_name path-safety:** Same risk as `tenant_id` — `vm_name` flows into the gateway
+  socket filename. Apply the same allowlist guard.
+- **Envelope size caps:** `plan_json` ≤ 1 MiB, `bundle_json` ≤ 4 MiB. DoS guard.
+- **Never log the envelope:** Both `plan_json` and `bundle_json` may carry secret
+  bindings, env vars, and policy refs that resolve to credentials. Treat as opaque
+  transport bytes. Doc warnings at producer + consumer sites.
+- **`AdmissionContext` is the carrier:** `admit_plan_for_boot` returns
+  `Result<Option<AdmissionContext>>`. `AdmissionContext { admitted: AdmittedPlan, … }`.
+  Producer sites use `if let Some(ctx) = &admission { populate_audit_substrate(..., &ctx.admitted)?; }`.
+- **`--prod` gate is not in scope.** Production-mode admission policy is fleet-level and
+  belongs in mvmd, not mvm. See memory `feedback_prod_gate_lives_in_mvmd.md`.
+- **Vz backend in scope.** Live smokes need all three backends.
+- **Firecracker and AppleContainer are deliberately untouched.** They consume the same
+  `VmStartConfig` (since the trait is shared) and will receive the new fields when
+  admission is in scope, but their `start()` impls don't read the fields — the
+  `Option<String>` values are silently dropped. **Impact: claim-10-leg-2 gateway flow
+  events do not fire on those backends; claim 8 (plan.admitted / plan.launched /
+  plan.failed) continues to work everywhere** because those events are emitted in
+  mvm-cli before `backend.start()`. Adding flow-event coverage to Firecracker would
+  need a jailer-side bridge factory (separate plan, separate process model);
+  AppleContainer would need a design that accommodates Apple's opaque
+  `containerization` framework. See memory
+  `project_gateway_audit_substrate_backend_coverage.md`.
+- **Forward-compat factoring for a future `NetworkProvider` trait.** The next plan
+  after 112 is expected to be "`NetworkProvider` trait + Firecracker substrate,
+  combined" — abstracts the audit-substrate + network-gateway wiring behind a trait
+  so libkrun / Vz / Firecracker (and later, AppleContainer + egress-secret-detection
+  wrapper) are pluggable impls. To make that extraction mechanical, Phase 3c does
+  **not** define a trait, but it **does** extract the shared substrate-resolution
+  logic into `crates/mvm-backend/src/audit_substrate.rs`. Both libkrun and Vz call
+  into it. When the trait lands, the rename is mechanical:
+  `audit_substrate::compute(...)` becomes `provider.activate_audit(...)`. No new
+  crate; no trait yet; one shared file.
+- **Top-level `crates/mvm-cli/src/exec.rs` sites stay None.** `boot_session_vm` and the
+  `restore_via_snapshot` VmStartConfig have no `AdmittedPlan` in scope — they're
+  MCP-session and template-restore paths that pre-date the admission contract.
+  Annotated with doc comments; the supervisor takes the legacy path for these.
+
+## Backend impact matrix
+
+| Backend | File | Reads new fields? | Claim 8 (admission) | Claim 10 leg 2 (flow events) | Change in this plan |
+|---|---|---|---|---|---|
+| libkrun | `crates/mvm-backend/src/libkrun.rs` | Yes (Task 5) | Yes (mvm-cli emits) | **Yes** (substrate activated) | `build_supervisor_config` helper added |
+| Vz | `crates/mvm-backend/src/vz.rs` | Yes (Task 6) | Yes (mvm-cli emits) | **Yes** (substrate activated) | Mirror of libkrun's pattern |
+| Firecracker | `backend.rs::FirecrackerBackend` | No (silently drops) | Yes (mvm-cli emits) | No (no bridge wiring) | None |
+| AppleContainer | `apple_container.rs` | No (silently drops) | Yes (mvm-cli emits) | No (no bridge wiring) | None |
+| MicrovmNix | `microvm_nix.rs` | No (silently drops) | Yes (mvm-cli emits) | No (out of substrate scope) | None |
+| CloudHypervisor | `cloud_hypervisor.rs` | No (builder VM only) | n/a | n/a | None |
+| Docker | `docker.rs` | No (silently drops) | Yes (mvm-cli emits) | No (Tier 3) | None |
+| Mock | `mock.rs` | No (silently drops) | Yes (mvm-cli emits) | n/a (test fixture) | None |
+
+**Reading guide:** "silently drops" = backend receives the populated `VmStartConfig` but
+its `start()` impl never touches the three new fields — equivalent to its pre-Phase-3c
+behavior. No regression risk.
+
+## Field map: `AdmittedPlan` → `VmStartConfig`
+
+| `VmStartConfig` field | Source | Encoding |
+|---|---|---|
+| `tenant_id: Option<String>` | `admitted.plan.tenant.0.clone()` | raw `String` |
+| `plan_json: Option<String>` | `&admitted.signed` (the **signed envelope**) | `serde_json::to_string(&admitted.signed)?` |
+| `bundle_json: Option<String>` | `admitted.plan.bundle.as_ref()` when `Some` | `serde_json::to_string(pin)?` else `None` |
+
+`plan_json` carries the **signed envelope**, not the inner `ExecutionPlan` — the
+supervisor re-verifies before trusting decoded fields.
+
+## Files
+
+- **Create:**
+  - `crates/mvm-backend/src/audit_substrate.rs` — shared module with
+    `validate_tenant_id` / `validate_vm_name` (DNS-label allowlist) and
+    `compute_audit_substrate(vm_name, tenant_id) -> Result<AuditSubstrate>`. Seam for
+    the future `NetworkProvider` trait.
+- **Modify:**
+  - `crates/mvm-core/src/protocol/vm_backend.rs` — append three fields after
+    `runner_dir`; extend `test_vm_start_config_default`.
+  - `crates/mvm-cli/src/commands/vm/plan_admission.rs` —
+    `populate_audit_substrate(&mut VmStartConfig, &AdmittedPlan)` helper with size
+    caps + unit test.
+  - `crates/mvm-cli/src/commands/vm/up.rs` — three `VmStartConfig` construction sites
+    (direct-boot `admission`, main `admission_main`, watch-loop `watch_admission`).
+  - `crates/mvm-cli/src/exec.rs` — doc-comment-only annotations on
+    `restore_via_snapshot` and `boot_session_vm` VmStartConfig sites.
+  - `crates/mvm-backend/src/lib.rs` — `pub(crate) mod audit_substrate;`.
+  - `crates/mvm-backend/src/libkrun.rs` — extract `build_supervisor_config` helper;
+    delegate to `audit_substrate::compute_audit_substrate`.
+  - `crates/mvm-backend/src/vz.rs` — same shape as libkrun.
+  - `specs/plans/102-gateway-audit-substrate-impl.md` — tick Phase 3c checklist.
+  - `specs/plans/103-w6a-implementation-tracker.md` — bump §Status.
+
+## Tasks
+
+### Task 0 — Worktree + preamble + plan file
+
+- [x] **0.1** Stash 17-file uncommitted main state (managed_secrets / Plan 108 stream).
+- [x] **0.2** Create worktree at `.claude/worktrees/plan-102-phase-3c` off `main`.
+- [x] **0.3** Pop stash into worktree.
+- [x] **0.4** Commit preamble as a single topic commit ("managed_secrets / Plan 108
+      stream"); auto-fmt fixes as a second commit.
+- [x] **0.5** Verify worktree builds + tests pass (apple_container flake confirmed
+      pre-existing, passes single-threaded per PR #487 note).
+- [x] **0.6** Save this plan into `specs/plans/112-w6a-phase-3c-producer-activation.md`
+      (Plan 112 — 108 gap left vacant; 109-111 claimed).
+- [ ] **0.7** Commit the plan file.
+
+### Task 1 — Widen `VmStartConfig`
+
+- [ ] **1.1** Extend `test_vm_start_config_default` with assertions on `tenant_id` /
+      `plan_json` / `bundle_json` defaulting to `None`.
+- [ ] **1.2** Run; expect FAIL with "no field 'tenant_id'".
+- [ ] **1.3** Append three fields to `VmStartConfig` after `runner_dir` (append-at-end
+      avoids line conflicts with future inserts higher in the struct).
+- [ ] **1.4** Run gates: `cargo test -p mvm-core`, fmt, clippy. Expect clean.
+- [ ] **1.5** Commit: `feat(mvm-core): VmStartConfig audit-substrate fields (Plan 102 Phase 3c)`.
+
+### Task 2 — `populate_audit_substrate` helper
+
+- [ ] **2.1** Write failing test in `plan_admission.rs`'s test module
+      (`populate_audit_substrate_threads_tenant_and_signed_envelope`).
+- [ ] **2.2** Run; expect FAIL.
+- [ ] **2.3** Implement helper with size caps (`PLAN_JSON_MAX_BYTES = 1 MiB`,
+      `BUNDLE_JSON_MAX_BYTES = 4 MiB`) and doc warning "do not log the envelope".
+- [ ] **2.4** Gates + commit: `feat(mvm-cli): populate_audit_substrate helper (Plan 102 Phase 3c)`.
+
+### Task 3 — Wire three `up.rs` producer sites
+
+- [ ] **3.1** Extend the `use super::plan_admission::{...}` import in `up.rs` with
+      `populate_audit_substrate`.
+- [ ] **3.2** Wire direct-boot (`MVM_DIRECT_BOOT == "1"` branch) — `admission` in scope:
+      change `let start_config` to `let mut start_config`, call
+      `if let Some(ctx) = admission.as_ref() { populate_audit_substrate(&mut start_config, &ctx.admitted)?; }`.
+- [ ] **3.3** Wire main path — `admission_main` in scope; same pattern after
+      `into_start_config()`.
+- [ ] **3.4** Wire watch-loop — `watch_admission` in scope; same pattern after
+      `into_start_config()`.
+- [ ] **3.5** Gates + commit: `feat(mvm-cli): populate audit substrate at mvmctl up sites (Plan 102 Phase 3c)`.
+
+### Task 4 — Annotate top-level `exec.rs` (no code change)
+
+- [ ] **4.1** Add doc comment above `restore_via_snapshot`-feeding VmStartConfig
+      explaining no admission in scope.
+- [ ] **4.2** Add doc comment above `boot_session_vm` VmStartConfig with same rationale.
+- [ ] **4.3** Gates + commit: `docs(mvm-cli): annotate top-level exec.rs as Phase 3c legacy path`.
+
+### Task 4b — Shared `audit_substrate` module
+
+- [ ] **4b.1** Create `crates/mvm-backend/src/audit_substrate.rs` with tests only first:
+      `validate_tenant_id_allowlist_dns_label_shape`,
+      `validate_vm_name_allowlist_dns_label_shape`,
+      `compute_with_tenant_derives_all_paths`, `compute_without_tenant_returns_default`,
+      `compute_with_unsafe_tenant_errors`.
+- [ ] **4b.2** Run; expect FAIL.
+- [ ] **4b.3** Implement `AuditSubstrate` struct, `validate_dns_label` /
+      `validate_tenant_id` / `validate_vm_name`, `compute_audit_substrate(vm_name,
+      tenant_id)`.
+- [ ] **4b.4** Locate canonical `mvm_data_dir()` (likely
+      `mvm_core::config::mvm_data_dir()` per CLAUDE.md "XDG directory functions"); fill
+      the placeholder.
+- [ ] **4b.5** Wire `pub(crate) mod audit_substrate;` in `crates/mvm-backend/src/lib.rs`.
+- [ ] **4b.6** Gates + commit:
+      `feat(mvm-backend): shared audit_substrate module (Plan 102 Phase 3c; NetworkProvider seam)`.
+
+### Task 5 — `libkrun.rs::start()` delegates to `audit_substrate`
+
+- [ ] **5.1** Extract `build_supervisor_config(config: &VmStartConfig, state_dir:
+      &Path) -> Result<SupervisorConfig>` helper near `effective_cmdline`. Delegate
+      substrate resolution to `audit_substrate::compute_audit_substrate`; map the
+      `AuditSubstrate` into the five `SupervisorConfig` audit fields.
+- [ ] **5.2** Replace the inline `KrunContext + SupervisorConfig` block at the existing
+      hard-coded-`None` site with a call to the helper.
+- [ ] **5.3** Add libkrun-side wiring tests (mapping into `SupervisorConfig`, not
+      substrate logic — that lives in `audit_substrate.rs` tests):
+      `build_supervisor_config_maps_substrate_into_supervisor_config`,
+      `build_supervisor_config_no_tenant_keeps_substrate_none`.
+- [ ] **5.4** Gates + commit: `feat(mvm-backend): libkrun start() delegates to audit_substrate (Plan 102 Phase 3c)`.
+
+### Task 6 — `vz.rs::start()` mirrors libkrun
+
+- [ ] **6.1** Locate the Vz supervisor-config construction site
+      (`rg -n "SupervisorConfig|tenant_id|events_ingest_socket_path" crates/mvm-backend/src/vz.rs`).
+- [ ] **6.2** Extract `build_vz_supervisor_config` (or analog) helper that calls
+      `audit_substrate::compute_audit_substrate` and maps into the Vz supervisor config
+      type. No tenant-validation or path-derivation duplication.
+- [ ] **6.3** Add Vz-side wiring test (analog of Task 5.3 against the Vz config type).
+- [ ] **6.4** Gates + commit: `feat(mvm-backend): vz start() delegates to audit_substrate (Plan 102 Phase 3c)`.
+
+### Task 7 — Plan-doc tick
+
+- [ ] **7.1** Tick Phase 3c checklist items in `specs/plans/102-…md` (VmStartConfig
+      widening, mvm-cli populate, libkrun consumer, Vz consumer, tenant_id +
+      vm_name safety).
+- [ ] **7.2** Bump `specs/plans/103-…md` §Status from "🟡 in progress" to "✅ shipped —
+      PR #<NNN>".
+- [ ] **7.3** Commit: `docs(specs): tick Plan 102 Phase 3c (Plan 103 status bump)`.
+
+### Task 8 — Workspace gates + PR
+
+- [ ] **8.1** Full workspace gates: `just lint`, `just test`, plus `cargo test -p
+      mvm-core -p mvm-cli -p mvm-backend` (touched crates clean in isolation).
+- [ ] **8.2** Push branch: `git push -u origin worktree-plan-102-phase-3c`.
+- [ ] **8.3** Open PR against `main` titled "feat: Plan 102 Phase 3c — VmStartConfig
+      audit substrate producer activation" with body referencing this plan,
+      [Plan 102 §W6.A.5](102-gateway-audit-substrate-impl.md#w6a5--vz-swift-bridge--fd-interception-wire-up),
+      and ADR-058.
+
+## Verification
+
+### Live smoke (manual, per backend × network)
+
+For each combo {libkrun+passt (Linux), libkrun+gvproxy (macOS), Vz+gvproxy (macOS 26+)}:
+
+1. `cargo build --release`
+2. `mvmctl init` (create `~/.mvm/{audit,keys}/`)
+3. `mvmctl up --flake . --profile minimal --tenant smoke`
+4. In another shell: `nc -U ~/.mvm/audit/gateway-<vm-name>.sock | head -20`
+5. `mvmctl exec <vm-name> -- curl https://example.com`
+6. Expect: `{"event":"FlowOpened",…}` line on connect, `{"event":"FlowClosed",…}` on close.
+7. `mvmctl down <vm-name>`
+8. `mvmctl audit verify --tenant smoke` — expect: chain verifies, no `chain_drift`.
+
+### Legacy path continues to work
+
+1. `mvmctl dev up` (no tenant, no plan).
+2. Expect: no audit socket created, dev shell drops in normally, no supervisor errors.
+
+### Audit chain mixed-events smoke
+
+1. `mvmctl up --tenant smoke` (admitted plan, bridge path).
+2. Drive some events via `mvmctl exec`.
+3. `mvmctl down <vm-name>`.
+4. Inspect `~/.mvm/audit/smoke.jsonl` — expect: `plan.admitted` → some `FlowOpened` /
+   `FlowClosed` pairs → `plan.launched`.
+5. `mvmctl audit verify --tenant smoke` — must pass.
+
+## Security follow-ups (out of Phase 3c scope; tracked separately)
+
+- **Supervisor-side tenant cross-check.** Add at `mvm-libkrun-supervisor::main`'s
+  admission step: when `cfg.tenant_id` is `Some`, deserialize `cfg.plan_json`, verify
+  the signature (already done), refuse with a clear error if
+  `cfg.tenant_id != verified.tenant.0`.
+- **Typed `ValidatedTenantId(String)` wrapper in mvm-plan.** Touches every
+  `TenantId` consumer — separate refactor PR.
+- **Symlink hardening on socket binding paths.** Supervisor's socket-create path
+  should use `O_NOFOLLOW` + `O_EXCL`. Verify during execution; if missing, file a
+  supervisor-side issue.
+- **Audit-event PII (5-tuple in `FlowOpened` / `FlowClosed`).** Redaction layer is
+  its own future plan and ADR (memory `project_egress_secret_detection_is_core`).
+
+## Out of scope
+
+- **`--prod` admission requirement** — belongs in mvmd. Memory:
+  `feedback_prod_gate_lives_in_mvmd.md`.
+- **Session VM admission** (top-level `exec.rs` `boot_session_vm`) — would need a
+  synthesis step. Tracked as a follow-up.
+- **Template restore admission** (top-level `exec.rs` `restore_via_snapshot` path) —
+  same as above.
+- **Firecracker substrate** — needs jailer-side bridge factory (separate plan).
+  Phase 3c doesn't regress anything on Firecracker.
+- **AppleContainer substrate** — needs research into Apple's `containerization`
+  framework. Phase 3c doesn't regress AppleContainer.
+- **MicrovmNix / Docker / Mock** — silently drop the new fields. Out of substrate scope.
+- **deps_volume binding** — already wired (Plan 73 Followup B.3).
+
+## Deferred follow-ups
+
+- [ ] Supervisor-side `cfg.tenant_id == verified.tenant.0` cross-check (security follow-up).
+- [ ] Typed `ValidatedTenantId` wrapper in mvm-plan (refactor PR).
+- [ ] Symlink hardening verification + (if needed) `O_NOFOLLOW + O_EXCL` fix
+      (supervisor-side).
+- [ ] `NetworkProvider` trait + Firecracker substrate (next plan in the
+      claim-10-leg-2 arc; uses the `audit_substrate` module as the trait-extraction
+      seam).
+- [ ] AppleContainer substrate research (further-future plan).
+- [ ] Egress secret detection + redaction layer (memory
+      `project_egress_secret_detection_is_core`).


### PR DESCRIPTION
## Summary

Plan 102 W6.A **Phase 3c** — producer activation for the gateway audit substrate that PR #487 shipped. Widens `mvm_core::vm_backend::VmStartConfig` with three `Option<String>` fields (`tenant_id`, `plan_json`, `bundle_json`), populates them from `AdmittedPlan` at the three `mvmctl up` construction sites (direct-boot, main, watch-loop), and threads the values into `SupervisorConfig` at `libkrun.rs::start()` via a new shared `audit_substrate` module. Lights up the bridge-factory path in `mvm-libkrun-supervisor::main` so the substrate from #487 starts emitting `FlowOpened` / `FlowClosed` audit records on real spawns.

Tracked in [Plan 112](specs/plans/112-w6a-phase-3c-producer-activation.md). Cross-references [Plan 102 §W6.A.5](specs/plans/102-gateway-audit-substrate-impl.md#phase-3c--producer-activation-executed-as-plan-112), [Plan 103 §Status](specs/plans/103-w6a-implementation-tracker.md#status), [ADR-041](specs/adrs/041-signed-audited-execution-plans.md) (claim 8 — plan re-verification), [ADR-058](specs/adrs/058-claim-10-bytes-leaving-trust-boundary.md) (claim 10 leg 2 — bytes leaving the trust boundary).

## What ships (11 commits)

| # | Commit | Layer |
|---|---|---|
| 1-2 | `d0b6797d` `8c13b844` | Preamble: in-flight `managed_secrets` / Plan 108 stream (rebases out when that lands upstream) |
| 3 | `a28a716b` | Plan 112 saved to `specs/plans/` with full task list |
| 4 | `da752948` | `mvm-core`: VmStartConfig audit-substrate fields appended |
| 5 | `2d229a40` | `mvm-cli`: `populate_audit_substrate` helper with size caps (1 MiB / 4 MiB) and do-not-log doc warning |
| 6 | `2f24570e` | `mvm-cli`: wire 3 `up.rs` sites (`admission`, `admission_main`, `watch_admission`) |
| 7 | `267e45c7` | `mvm-cli`: doc-annotate top-level `exec.rs` legacy paths (no admission in scope) |
| 8 | `00018898` | `mvm-backend`: shared `audit_substrate` module (DNS-label allowlist + `compute_audit_substrate`) |
| 9 | `6a2050a0` | `mvm-backend`: libkrun delegates to `audit_substrate` via `build_supervisor_config` |
| 10 | `71ce3549` | `mvm-backend`: vz pre-flight allowlist guard (full chain emit deferred to NetworkProvider plan) |
| 11 | `ddb2697e` | Plan-doc tick — Plan 102 §W6.A.5 + Plan 103 §Status |

## Security hardening (folded into Phase 3c)

- **DNS-label allowlist** (`^[A-Za-z0-9][A-Za-z0-9_-]{0,62}$`, ASCII-only, 63-char cap) on `tenant_id` and `vm_name` — defense-in-depth at the audit-dir / socket-path boundary. mvm-plan's `TenantId` is unchecked today.
- **Envelope size caps**: `plan_json` ≤ 1 MiB, `bundle_json` ≤ 4 MiB. DoS guard for the supervisor stdin pipe.
- **Do-not-log warnings** at producer + consumer sites — the signed envelope may carry secret bindings, env vars, or policy refs that resolve to credentials.
- **Supervisor re-verifies** the envelope at `mvm-supervisor/src/supervisor.rs:308` via `mvm_plan::verify_plan`. Host is in TCB per ADR-002 but the supervisor doesn't trust pre-decoded fields.

## Architectural seam — forward-compat for `NetworkProvider` trait

The shared `crates/mvm-backend/src/audit_substrate.rs` module is the **seam** where the next plan's `NetworkProvider` trait method will live. `compute_audit_substrate(vm_name, tenant_id) -> Result<AuditSubstrate>` is a free function today; in the trait plan it becomes `provider.activate_audit(vm_name, tenant_id)`. Same signature, same return type, mechanical rename.

That trait plan combines Firecracker substrate (closes the claim-10-leg-2 gap on Linux KVM) with the abstraction validation. AppleContainer substrate and egress-secret-detection redaction wrapper are subsequent plans.

## Backend impact matrix

| Backend | Reads new fields? | Claim 8 (admission) | Claim 10 leg 2 (flow events) | Change in this PR |
|---|---|---|---|---|
| libkrun | Yes | Yes | **Yes** (activated) | `build_supervisor_config` helper |
| Vz | Allowlist only (Rust side) | Yes | Half — Swift writes events, Rust drainer is follow-up | pre-flight `?` guard |
| Firecracker | No | Yes | No (no bridge wiring) | None |
| AppleContainer | No | Yes | No (no bridge wiring) | None |
| MicrovmNix / Docker / Mock | No | Yes | n/a | None |

## Test plan

- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --workspace --all-targets -- -D warnings`
- [x] `cargo test -p mvm-core` — 647 passed
- [x] `cargo test -p mvm-cli -- --test-threads=1` — 799 passed (parallel surfaces the documented `apple_container::builder_vm_bootstrap_tests` flake from PR #487's notes; CI's nextest isolation sidesteps it)
- [x] `cargo test -p mvm-backend` — 177 passed (incl. 6 new substrate tests, 3 new libkrun wiring tests, 1 new vz wiring test)
- [ ] Live smoke per backend × network — manual checklist in [Plan 112 §Verification](specs/plans/112-w6a-phase-3c-producer-activation.md#verification)

## Notes

- **Preamble commits** at the head of this branch (`d0b6797d`, `8c13b844`) preserve the 17-file `managed_secrets` / Plan 108 in-flight stream that was uncommitted on `main` HEAD when this worktree branched. They will rebase out cleanly when that upstream stream lands as its own PR.
- **Vz carve-out**: the resolved `AuditSubstrate` is computed inside `vz.rs::build_supervisor_config` (so the allowlist guard fires) but not yet routed into `vz::SupervisorConfig`. Routing requires a lockstep Swift `Config.swift` decoder update (deny-unknown-fields contract) + a Rust-side drainer that binds `events_ingest_socket_path` and emits to the chain. Both belong to the NetworkProvider trait follow-up plan.
- **`--prod` admission gate** belongs in mvmd, not mvm (CLAUDE.md: multi-tenant fleet orchestration is mvmd's responsibility). Not in scope.

🤖 Generated with [Claude Code](https://claude.com/claude-code)