### PR TITLE
feat(build): Plan 107 A1a — HostVmRequest protocol + LibkrunPersistentHostVm rename

### DIFF
--- a/crates/mvm-build/Cargo.toml
+++ b/crates/mvm-build/Cargo.toml
@@ -70,7 +70,7 @@ thiserror = "1"
 tokio.workspace = true
 toml.workspace = true
 tracing.workspace = true
-# Plan 89 W2 — `builder_protocol::{BuilderRequest,BuilderResponse}`
+# Plan 89 W2 — `builder_protocol::{HostVmRequest,HostVmResponse}`
 # carry a `JobId(Uuid)` to disambiguate concurrent dispatches over
 # the persistent VM channel. Existing mvm-core / mvm-cli call sites
 # already pull in the same version.

--- a/crates/mvm-build/src/builder_protocol.rs
+++ b/crates/mvm-build/src/builder_protocol.rs
@@ -1,32 +1,38 @@
-//! Plan 89 W2 — wire types for the persistent builder VM's vsock
-//! dispatch channel.
+//! Wire types for the long-lived host VM's vsock dispatch channel.
 //!
-//! Plan 89 (`specs/plans/89-persistent-builder-vm.md`) replaces the
-//! boot-per-job dance with a boot-once-per-`mvmctl dev`-session
-//! dance. Inside that long-lived VM, the host dispatches
-//! [`BuilderRequest`]s over vsock and receives [`BuilderResponse`]s
-//! back. The persistent VM's dispatch loop is a host↔guest channel
-//! and inherits the existing `AuthenticatedFrame` envelope (see
-//! [`mvm_core::security::AuthenticatedFrame`]) — no new key material
-//! is introduced.
+//! Plan 89 (`specs/plans/89-persistent-builder-vm.md`) introduced a
+//! boot-once-per-`mvmctl dev`-session dance: the host dispatched
+//! Nix-build jobs over vsock into a persistent libkrun VM. Plan 107
+//! A1 (`specs/plans/107-plan-100-w6-approach-a.md`) generalises that
+//! channel into a backend-agnostic dispatch surface — the same
+//! long-lived libkrun VM will serve both Nix builds (existing) and
+//! Firecracker workload spawns (W6's nested execution path, A2.2).
+//! Hence the rename `BuilderRequest`/`BuilderResponse` →
+//! [`HostVmRequest`]/[`HostVmResponse`] and the new
+//! `Workload*` variants stubbed below (payloads land in A2.2;
+//! the guest-side arm panics with `unimplemented!()` until then).
+//!
+//! The channel inherits the existing `AuthenticatedFrame` envelope
+//! (see [`mvm_core::security::AuthenticatedFrame`]) — no new key
+//! material is introduced.
 //!
 //! ## Scope of this module across PRs
 //!
-//! - **W2 part 1 (shipped):** wire types ([`BuilderRequest`],
-//!   [`BuilderResponse`], [`JobTimings`], [`BootTimingsWire`]),
+//! - **W2 part 1 (shipped):** wire types ([`HostVmRequest`],
+//!   [`HostVmResponse`], [`JobTimings`], [`BootTimingsWire`]),
 //!   serde derives with `#[serde(deny_unknown_fields)]`, unit tests
 //!   for serde roundtrip and unknown-field rejection, fuzz target.
 //! - **W2 part 2 (this PR):** [`BUILDER_DISPATCH_PORT`] reserved on
 //!   the libkrun builder VM, host-side reader helpers
-//!   [`read_builder_response`] / [`read_builder_response_from_socket`]
+//!   [`read_host_vm_response`] / [`read_host_vm_response_from_socket`]
 //!   with explicit no-response handling
-//!   ([`BuilderResponseRead::EmptyEof`] / [`BuilderResponseRead::Timeout`])
+//!   ([`HostVmResponseRead::EmptyEof`] / [`HostVmResponseRead::Timeout`])
 //!   so the legacy file-based result path remains the fallback while
 //!   the guest-side send code is unwired.
 //! - **W2 part 3 (next):** modify `mvm-builder-init` to send
-//!   [`BuilderResponse::Result`] on exit, wire the host's
+//!   [`HostVmResponse::Result`] on exit, wire the host's
 //!   single-shot path (`LibkrunBuilderVm::run_build`) to call
-//!   [`read_builder_response_from_socket`] before falling back to
+//!   [`read_host_vm_response_from_socket`] before falling back to
 //!   `<job_dir>/result`. That PR exercises the cold-boot VM exiting
 //!   through the new code path end-to-end.
 //! - **W3 (after):** dispatch loop and persistent mode.
@@ -36,8 +42,8 @@
 //! Framing reuses [`mvm_guest::vsock::read_frame`] /
 //! [`mvm_guest::vsock::write_frame`], which enforce a pre-deserialize
 //! `MAX_FRAME_SIZE` of 256 KiB (`crates/mvm-guest/src/vsock.rs:65`).
-//! That bound is amply sufficient for [`BuilderRequest`] — its
-//! largest variant ([`BuilderRequest::Run`]) carries a
+//! That bound is amply sufficient for [`HostVmRequest`] — its
+//! largest variant ([`HostVmRequest::Run`]) carries a
 //! [`crate::builder_vm::BuilderJob`] whose variants are tiny
 //! (`Flake { flake_ref: String, attr_path: String }` and
 //! `Install { spec_path: PathBuf }`, both fitting in a few hundred
@@ -58,8 +64,8 @@ use uuid::Uuid;
 use crate::builder_vm::BuilderJob;
 
 /// Per-dispatch identifier the host stamps before sending a
-/// [`BuilderRequest::Run`] and the guest echoes in the matching
-/// [`BuilderResponse::Result`]. `Uuid` v4 because the host
+/// [`HostVmRequest::Run`] and the guest echoes in the matching
+/// [`HostVmResponse::Result`]. `Uuid` v4 because the host
 /// generates these; the guest only ever validates that the response
 /// `job_id` matches the request it's correlating.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
@@ -85,6 +91,36 @@ impl std::fmt::Display for JobId {
     }
 }
 
+/// Per-workload identifier the host stamps when starting a nested
+/// Firecracker workload microVM inside the long-lived libkrun host
+/// VM. Mirrors [`JobId`]'s shape but lives in its own newtype so the
+/// dispatch loop can keep build jobs and workloads in separate
+/// tables without conflating identifiers.
+///
+/// Stubbed in Plan 107 A1; consumers are scaffolded in A2.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(transparent)]
+pub struct WorkloadId(pub Uuid);
+
+impl WorkloadId {
+    /// Mint a fresh workload id. Used by the host's dispatch path.
+    pub fn new() -> Self {
+        Self(Uuid::new_v4())
+    }
+}
+
+impl Default for WorkloadId {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl std::fmt::Display for WorkloadId {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        self.0.fmt(f)
+    }
+}
+
 /// Inbound message sent host → guest over the persistent VM's
 /// dispatch vsock port. Tagged-enum on the wire; every variant
 /// carries `#[serde(deny_unknown_fields)]` so a future host
@@ -92,16 +128,16 @@ impl std::fmt::Display for JobId {
 /// instead of silently dropping fields.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(tag = "kind", rename_all = "snake_case", deny_unknown_fields)]
-pub enum BuilderRequest {
+pub enum HostVmRequest {
     /// Dispatch a single build into the running VM. The host has
     /// already staged the job dir contents (cmd.sh / install_spec /
     /// etc.) under `job_dir_relpath`, which is a relative path
     /// inside the `/job` virtio-fs share. The guest exec's the job,
-    /// streams `stderr` via [`BuilderResponse::StderrChunk`], and
-    /// terminates the round with [`BuilderResponse::Result`].
+    /// streams `stderr` via [`HostVmResponse::StderrChunk`], and
+    /// terminates the round with [`HostVmResponse::Result`].
     Run {
         /// Host-generated identifier echoed in every
-        /// [`BuilderResponse`] for this dispatch.
+        /// [`HostVmResponse`] for this dispatch.
         job_id: JobId,
         /// The job to execute. Same shape as the single-shot
         /// path's `BuilderJob`; the guest's dispatch loop converts
@@ -123,24 +159,57 @@ pub enum BuilderRequest {
     /// no-op on unit variants of internally-tagged enums. Wire
     /// shape is identical (`{"kind":"shutdown"}`).
     Shutdown {},
+
+    /// Plan 107 W6 / A2 — start a Firecracker workload microVM
+    /// inside the host VM. Stubbed in A1; the guest-side dispatch
+    /// arm panics with `unimplemented!()` until A2.2 fills in the
+    /// payload (workload kernel + rootfs paths, vsock socket dir,
+    /// vcpus, memory, kernel cmdline extras) and the guest-side
+    /// Firecracker spawn.
+    ///
+    /// The payload carries only the [`WorkloadId`] today so that
+    /// (a) the protocol round-trips end-to-end and (b) A2.2's
+    /// payload extension is additive — `#[serde(deny_unknown_fields)]`
+    /// will reject the A2.2 fields until both sides upgrade in
+    /// lockstep, which is the intended fail-closed behaviour.
+    WorkloadStart {
+        /// Host-minted identifier the guest echoes in
+        /// [`HostVmResponse::WorkloadStarted`].
+        workload_id: WorkloadId,
+    },
+
+    /// Plan 107 W6 / A2 — stop a running workload microVM. Stubbed
+    /// in A1; A2.2 wires the guest-side SIGTERM/wait/cleanup path.
+    WorkloadStop {
+        /// Echo of the matching [`HostVmRequest::WorkloadStart::workload_id`].
+        workload_id: WorkloadId,
+    },
+
+    /// Plan 107 W6 / A2 — query a workload microVM's lifecycle
+    /// status. Stubbed in A1; A2.2 wires the guest-side check
+    /// (process alive, vsock reachable, etc.).
+    WorkloadStatus {
+        /// Echo of the matching [`HostVmRequest::WorkloadStart::workload_id`].
+        workload_id: WorkloadId,
+    },
 }
 
 /// Outbound message sent guest → host over the same vsock conn.
 /// Every variant carries the originating `job_id` (except
-/// [`BuilderResponse::Bye`]) so the host can demux concurrent
+/// [`HostVmResponse::Bye`]) so the host can demux concurrent
 /// dispatches in V2+ — V1 serializes via the supervisor's dispatch
 /// mutex (Plan 89 §Concurrency), but the wire is shaped for the
 /// looser case so V2 doesn't break compatibility.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(tag = "kind", rename_all = "snake_case", deny_unknown_fields)]
-pub enum BuilderResponse {
+pub enum HostVmResponse {
     /// A line of stderr from the running job. Sent as soon as the
     /// guest reads it; the host plumbs these into its existing
     /// `<vm_state_dir>/console.log` capture so debugging UX stays
     /// uniform across single-shot and persistent modes. The
     /// trailing newline is stripped by the guest.
     StderrChunk {
-        /// Echo of the [`BuilderRequest::Run::job_id`] this chunk
+        /// Echo of the [`HostVmRequest::Run::job_id`] this chunk
         /// belongs to.
         job_id: JobId,
         /// One line of stderr (no trailing `\n`).
@@ -151,7 +220,7 @@ pub enum BuilderResponse {
     /// host releases the dispatch mutex and returns control to its
     /// caller.
     Result {
-        /// Echo of the [`BuilderRequest::Run::job_id`].
+        /// Echo of the [`HostVmRequest::Run::job_id`].
         job_id: JobId,
         /// Process exit code from the inner build command. Zero
         /// means success; non-zero is a build failure (not a
@@ -168,7 +237,7 @@ pub enum BuilderResponse {
         /// subsequent dispatches in the same persistent VM session
         /// see `None` — there is no second cold boot to time.
         ///
-        /// `Box` keeps the [`BuilderResponse`] enum's stack size
+        /// `Box` keeps the [`HostVmResponse`] enum's stack size
         /// dominated by the common [`Self::StderrChunk`] variant
         /// instead of the heavy 11-field [`BootTimingsWire`] —
         /// clippy's `large_enum_variant` lint. Wire shape is
@@ -179,14 +248,41 @@ pub enum BuilderResponse {
         job_timings: JobTimings,
     },
 
-    /// Graceful acknowledgement of [`BuilderRequest::Shutdown`].
+    /// Graceful acknowledgement of [`HostVmRequest::Shutdown`].
     /// Sent right before the guest's dispatch loop returns and the
     /// VM powers off.
     ///
     /// Empty struct variant for the same reason as
-    /// [`BuilderRequest::Shutdown`] — gives `deny_unknown_fields`
+    /// [`HostVmRequest::Shutdown`] — gives `deny_unknown_fields`
     /// something to enforce against.
     Bye {},
+
+    /// Plan 107 W6 / A2 — acknowledgement that a workload microVM
+    /// has booted inside the host VM. Stubbed in A1; A2.2 will
+    /// extend the payload with the workload's vsock CID + first-byte
+    /// readiness timing.
+    WorkloadStarted {
+        /// Echo of the originating [`HostVmRequest::WorkloadStart::workload_id`].
+        workload_id: WorkloadId,
+    },
+
+    /// Plan 107 W6 / A2 — acknowledgement that a workload microVM
+    /// has shut down. Stubbed in A1.
+    WorkloadStopped {
+        /// Echo of the originating [`HostVmRequest::WorkloadStop::workload_id`].
+        workload_id: WorkloadId,
+    },
+
+    /// Plan 107 W6 / A2 — workload lifecycle status report. Stubbed
+    /// in A1; A2.2 will replace the placeholder string with a typed
+    /// `WorkloadState` enum (`Booting` / `Running` / `Exited { code }`
+    /// / `Unknown`).
+    WorkloadStatusReport {
+        /// Echo of the originating [`HostVmRequest::WorkloadStatus::workload_id`].
+        workload_id: WorkloadId,
+        /// Placeholder string — A2.2 replaces with a typed enum.
+        status: String,
+    },
 }
 
 /// Per-dispatch timings, in milliseconds. Independent of
@@ -195,7 +291,7 @@ pub enum BuilderResponse {
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Default, Serialize, Deserialize)]
 #[serde(deny_unknown_fields)]
 pub struct JobTimings {
-    /// Time between the host writing the [`BuilderRequest::Run`]
+    /// Time between the host writing the [`HostVmRequest::Run`]
     /// frame and the guest's dispatch loop reading it.
     pub dispatch_ms: u64,
     /// Time spent inside the build subprocess proper (between
@@ -240,7 +336,7 @@ pub struct BootTimingsWire {
 // Host-side reader (W2 part 2)
 // ============================================================================
 
-/// Outcome of trying to read a [`BuilderResponse`] from a builder
+/// Outcome of trying to read a [`HostVmResponse`] from a builder
 /// VM's vsock dispatch socket. Modelled explicitly because the
 /// "guest exited without sending anything" case is a normal,
 /// non-error outcome during the W2 part 2 → W2 part 3 transition
@@ -248,9 +344,9 @@ pub struct BootTimingsWire {
 /// images will continue not to send for some time after part 3
 /// lands).
 #[derive(Debug)]
-pub enum BuilderResponseRead {
+pub enum HostVmResponseRead {
     /// A complete, well-formed response arrived.
-    Frame(BuilderResponse),
+    Frame(HostVmResponse),
     /// The connection was opened but the guest closed it without
     /// sending any bytes (clean EOF). Callers should fall back to
     /// the legacy file-based result path.
@@ -265,42 +361,42 @@ pub enum BuilderResponseRead {
 
 /// Connect to the libkrun-managed Unix socket for
 /// [`mvm_guest::builder_agent::BUILDER_DISPATCH_PORT`] and read
-/// one framed [`BuilderResponse`] within `timeout`.
+/// one framed [`HostVmResponse`] within `timeout`.
 ///
 /// The framing reader reuses [`mvm_guest::vsock::read_frame`],
 /// which enforces the same 256 KiB pre-deserialize cap
-/// [`BuilderResponse`] inherits — see this module's header docs
+/// [`HostVmResponse`] inherits — see this module's header docs
 /// for the F8 amendment correction.
 ///
 /// `socket_path` is `<vm_state_dir>/vsock-<BUILDER_DISPATCH_PORT>.sock`
 /// — the file libkrun creates when the krun context is configured
 /// via `add_vsock_port(BUILDER_DISPATCH_PORT)` (Plan 89 W2 part 2).
-pub fn read_builder_response_from_socket(
+pub fn read_host_vm_response_from_socket(
     socket_path: &std::path::Path,
     timeout: std::time::Duration,
-) -> std::io::Result<BuilderResponseRead> {
+) -> std::io::Result<HostVmResponseRead> {
     use std::os::unix::net::UnixStream;
     let mut stream = UnixStream::connect(socket_path)?;
     stream.set_read_timeout(Some(timeout))?;
-    Ok(read_builder_response(&mut stream))
+    Ok(read_host_vm_response(&mut stream))
 }
 
-/// Read one framed [`BuilderResponse`] from any `UnixStream`-like
-/// stream. Returns [`BuilderResponseRead::EmptyEof`] on clean EOF
-/// before any bytes arrive, [`BuilderResponseRead::Timeout`] on
+/// Read one framed [`HostVmResponse`] from any `UnixStream`-like
+/// stream. Returns [`HostVmResponseRead::EmptyEof`] on clean EOF
+/// before any bytes arrive, [`HostVmResponseRead::Timeout`] on
 /// `WouldBlock`/`TimedOut`, and propagates other I/O or serde
 /// failures by reading them as Timeout-equivalent (the caller's
 /// fallback path is the same — we don't want a corrupted/partial
 /// frame to fail the whole build when the file-based path still
 /// has the authoritative answer).
 ///
-/// Separated from [`read_builder_response_from_socket`] so unit
+/// Separated from [`read_host_vm_response_from_socket`] so unit
 /// tests can drive the wire with a `UnixStream::pair()` without
 /// going through libkrun. The two layers compose: the
 /// `from_socket` variant is `connect` + this.
-pub fn read_builder_response(stream: &mut std::os::unix::net::UnixStream) -> BuilderResponseRead {
-    match mvm_guest::vsock::read_frame::<BuilderResponse>(stream) {
-        Ok(resp) => BuilderResponseRead::Frame(resp),
+pub fn read_host_vm_response(stream: &mut std::os::unix::net::UnixStream) -> HostVmResponseRead {
+    match mvm_guest::vsock::read_frame::<HostVmResponse>(stream) {
+        Ok(resp) => HostVmResponseRead::Frame(resp),
         Err(e) => {
             // anyhow::Error chains the io::Error underneath when
             // read_exact failed. Walk the chain to classify.
@@ -308,10 +404,10 @@ pub fn read_builder_response(stream: &mut std::os::unix::net::UnixStream) -> Bui
             if let Some(io_err) = src.and_then(|s| s.downcast_ref::<std::io::Error>()) {
                 match io_err.kind() {
                     std::io::ErrorKind::UnexpectedEof => {
-                        return BuilderResponseRead::EmptyEof;
+                        return HostVmResponseRead::EmptyEof;
                     }
                     std::io::ErrorKind::WouldBlock | std::io::ErrorKind::TimedOut => {
-                        return BuilderResponseRead::Timeout;
+                        return HostVmResponseRead::Timeout;
                     }
                     _ => {}
                 }
@@ -319,22 +415,22 @@ pub fn read_builder_response(stream: &mut std::os::unix::net::UnixStream) -> Bui
             // Default to Timeout so callers always have a fallback
             // path. Logging the underlying error is the caller's
             // responsibility.
-            BuilderResponseRead::Timeout
+            HostVmResponseRead::Timeout
         }
     }
 }
 
-/// Write one framed [`BuilderResponse`] to a `UnixStream`. Mirror
-/// of [`read_builder_response`] — exists so unit tests of the
+/// Write one framed [`HostVmResponse`] to a `UnixStream`. Mirror
+/// of [`read_host_vm_response`] — exists so unit tests of the
 /// reader can produce real wire bytes via the same framing
 /// `mvm-builder-init` will use in W2 part 3 (with the
 /// host-vs-builder-init split, the actual guest emit will hand-roll
 /// the JSON to keep builder-init's dep tree small). The pair-test
 /// using this writer + the reader is the regression we want to lock
 /// in now so the guest emit lands against a known-good host reader.
-pub fn write_builder_response(
+pub fn write_host_vm_response(
     stream: &mut std::os::unix::net::UnixStream,
-    response: &BuilderResponse,
+    response: &HostVmResponse,
 ) -> std::io::Result<()> {
     mvm_guest::vsock::write_frame(stream, response)
         .map_err(|e| std::io::Error::other(e.to_string()))
@@ -345,8 +441,8 @@ mod tests {
     use super::*;
     use std::path::PathBuf;
 
-    fn sample_run() -> BuilderRequest {
-        BuilderRequest::Run {
+    fn sample_run() -> HostVmRequest {
+        HostVmRequest::Run {
             job_id: JobId(Uuid::nil()),
             job: BuilderJob::Flake {
                 flake_ref: "path:/work".to_string(),
@@ -356,8 +452,8 @@ mod tests {
         }
     }
 
-    fn sample_install_run() -> BuilderRequest {
-        BuilderRequest::Run {
+    fn sample_install_run() -> HostVmRequest {
+        HostVmRequest::Run {
             job_id: JobId::new(),
             job: BuilderJob::Install {
                 spec_path: PathBuf::from("/job/install_spec.json"),
@@ -366,8 +462,8 @@ mod tests {
         }
     }
 
-    fn sample_result() -> BuilderResponse {
-        BuilderResponse::Result {
+    fn sample_result() -> HostVmResponse {
+        HostVmResponse::Result {
             job_id: JobId(Uuid::nil()),
             exit_code: 0,
             stderr_tail: "warning: foo\nwarning: bar".to_string(),
@@ -404,28 +500,28 @@ mod tests {
     }
 
     #[test]
-    fn builder_request_run_roundtrips() {
+    fn host_vm_request_run_roundtrips() {
         roundtrip(&sample_run());
     }
 
     #[test]
-    fn builder_request_install_run_roundtrips() {
+    fn host_vm_request_install_run_roundtrips() {
         roundtrip(&sample_install_run());
     }
 
     #[test]
-    fn builder_request_shutdown_roundtrips() {
-        roundtrip(&BuilderRequest::Shutdown {});
+    fn host_vm_request_shutdown_roundtrips() {
+        roundtrip(&HostVmRequest::Shutdown {});
     }
 
     #[test]
-    fn builder_response_result_roundtrips() {
+    fn host_vm_response_result_roundtrips() {
         roundtrip(&sample_result());
     }
 
     #[test]
-    fn builder_response_bye_roundtrips() {
-        roundtrip(&BuilderResponse::Bye {});
+    fn host_vm_response_bye_roundtrips() {
+        roundtrip(&HostVmResponse::Bye {});
     }
 
     #[test]
@@ -436,21 +532,145 @@ mod tests {
         // a true unit variant would have produced — single `kind`
         // field, no extras.
         assert_eq!(
-            serde_json::to_string(&BuilderRequest::Shutdown {}).unwrap(),
+            serde_json::to_string(&HostVmRequest::Shutdown {}).unwrap(),
             r#"{"kind":"shutdown"}"#
         );
         assert_eq!(
-            serde_json::to_string(&BuilderResponse::Bye {}).unwrap(),
+            serde_json::to_string(&HostVmResponse::Bye {}).unwrap(),
             r#"{"kind":"bye"}"#
         );
     }
 
     #[test]
-    fn builder_response_stderr_chunk_roundtrips() {
-        roundtrip(&BuilderResponse::StderrChunk {
+    fn host_vm_response_stderr_chunk_roundtrips() {
+        roundtrip(&HostVmResponse::StderrChunk {
             job_id: JobId::new(),
             line: "[mvm] nix build: 12/47 derivations".to_string(),
         });
+    }
+
+    // Plan 107 A1 — workload variant round-trips. Stubbed payloads
+    // today; A2.2 extends with the real Firecracker spawn config.
+
+    fn sample_workload_start() -> HostVmRequest {
+        HostVmRequest::WorkloadStart {
+            workload_id: WorkloadId(Uuid::nil()),
+        }
+    }
+
+    #[test]
+    fn workload_id_serializes_as_bare_uuid_string() {
+        let id = WorkloadId(Uuid::nil());
+        let json = serde_json::to_string(&id).expect("serialize");
+        assert_eq!(json, "\"00000000-0000-0000-0000-000000000000\"");
+    }
+
+    #[test]
+    fn host_vm_request_workload_start_roundtrips() {
+        roundtrip(&sample_workload_start());
+    }
+
+    #[test]
+    fn host_vm_request_workload_stop_roundtrips() {
+        roundtrip(&HostVmRequest::WorkloadStop {
+            workload_id: WorkloadId(Uuid::nil()),
+        });
+    }
+
+    #[test]
+    fn host_vm_request_workload_status_roundtrips() {
+        roundtrip(&HostVmRequest::WorkloadStatus {
+            workload_id: WorkloadId(Uuid::nil()),
+        });
+    }
+
+    #[test]
+    fn host_vm_response_workload_started_roundtrips() {
+        roundtrip(&HostVmResponse::WorkloadStarted {
+            workload_id: WorkloadId(Uuid::nil()),
+        });
+    }
+
+    #[test]
+    fn host_vm_response_workload_stopped_roundtrips() {
+        roundtrip(&HostVmResponse::WorkloadStopped {
+            workload_id: WorkloadId(Uuid::nil()),
+        });
+    }
+
+    #[test]
+    fn host_vm_response_workload_status_report_roundtrips() {
+        roundtrip(&HostVmResponse::WorkloadStatusReport {
+            workload_id: WorkloadId(Uuid::nil()),
+            status: "booting".to_string(),
+        });
+    }
+
+    #[test]
+    fn workload_variants_emit_snake_case_kind_tags() {
+        // Wire stability — the host and guest agree on these
+        // snake_case strings. Wire-format breaks here mean an
+        // upgrade-order bug in production.
+        assert_eq!(
+            serde_json::to_value(sample_workload_start()).unwrap()["kind"],
+            "workload_start"
+        );
+        assert_eq!(
+            serde_json::to_value(HostVmRequest::WorkloadStop {
+                workload_id: WorkloadId(Uuid::nil())
+            })
+            .unwrap()["kind"],
+            "workload_stop"
+        );
+        assert_eq!(
+            serde_json::to_value(HostVmRequest::WorkloadStatus {
+                workload_id: WorkloadId(Uuid::nil())
+            })
+            .unwrap()["kind"],
+            "workload_status"
+        );
+        assert_eq!(
+            serde_json::to_value(HostVmResponse::WorkloadStarted {
+                workload_id: WorkloadId(Uuid::nil())
+            })
+            .unwrap()["kind"],
+            "workload_started"
+        );
+    }
+
+    #[test]
+    fn deny_unknown_fields_rejects_extra_workload_start_field() {
+        // Plan 107 A1: A2.2 will extend WorkloadStart with the real
+        // Firecracker spawn payload (kernel, rootfs, vcpus, memory).
+        // The fail-closed contract is that an old guest seeing a new
+        // host's extended payload rejects with deny_unknown_fields
+        // rather than silently launching with default config.
+        let bad = serde_json::json!({
+            "kind": "workload_start",
+            "workload_id": "00000000-0000-0000-0000-000000000000",
+            "future_field": 42,
+        });
+        let res: Result<HostVmRequest, _> = serde_json::from_value(bad);
+        assert!(
+            res.is_err(),
+            "deny_unknown_fields must reject future_field on workload_start, got {:?}",
+            res
+        );
+    }
+
+    #[test]
+    fn deny_unknown_fields_rejects_extra_workload_started_field() {
+        let bad = serde_json::json!({
+            "kind": "workload_started",
+            "workload_id": "00000000-0000-0000-0000-000000000000",
+            "future_field": "rogue",
+        });
+        let res: Result<HostVmResponse, _> = serde_json::from_value(bad);
+        assert!(
+            res.is_err(),
+            "deny_unknown_fields must reject future_field on workload_started, got {:?}",
+            res
+        );
     }
 
     #[test]
@@ -483,7 +703,7 @@ mod tests {
             "job_dir_relpath": "z",
             "future_field": 42,
         });
-        let res: Result<BuilderRequest, _> = serde_json::from_value(bad);
+        let res: Result<HostVmRequest, _> = serde_json::from_value(bad);
         assert!(
             res.is_err(),
             "deny_unknown_fields should have rejected future_field, got {:?}",
@@ -497,7 +717,7 @@ mod tests {
             "kind": "bye",
             "future_field": "noisy",
         });
-        let res: Result<BuilderResponse, _> = serde_json::from_value(bad);
+        let res: Result<HostVmResponse, _> = serde_json::from_value(bad);
         assert!(
             res.is_err(),
             "deny_unknown_fields should have rejected future_field on Bye, got {:?}",
@@ -566,25 +786,25 @@ mod tests {
     }
 
     #[test]
-    fn read_builder_response_roundtrips_through_unix_stream_pair() {
+    fn read_host_vm_response_roundtrips_through_unix_stream_pair() {
         // W2 part 2 host-side wire: when the guest sends a
-        // BuilderResponse over the dispatch socket, the host
+        // HostVmResponse over the dispatch socket, the host
         // reader should decode it byte-for-byte. Pair of
         // UnixStreams stands in for the libkrun-managed socket.
         use std::os::unix::net::UnixStream;
         let (mut a, mut b) = UnixStream::pair().expect("socketpair");
         let response = sample_result();
-        write_builder_response(&mut a, &response).expect("write");
+        write_host_vm_response(&mut a, &response).expect("write");
         drop(a); // signal EOF after the single frame
-        let read = read_builder_response(&mut b);
+        let read = read_host_vm_response(&mut b);
         match read {
-            BuilderResponseRead::Frame(got) => assert_eq!(got, response),
+            HostVmResponseRead::Frame(got) => assert_eq!(got, response),
             other => panic!("expected Frame, got {other:?}"),
         }
     }
 
     #[test]
-    fn read_builder_response_returns_empty_eof_on_clean_close() {
+    fn read_host_vm_response_returns_empty_eof_on_clean_close() {
         // The W2 part 2 → W2 part 3 transition expects this: the
         // host opens a vsock conn, but no guest send code is wired
         // yet, so the conn closes without bytes. Reader must signal
@@ -593,14 +813,14 @@ mod tests {
         use std::os::unix::net::UnixStream;
         let (a, mut b) = UnixStream::pair().expect("socketpair");
         drop(a);
-        match read_builder_response(&mut b) {
-            BuilderResponseRead::EmptyEof => {}
+        match read_host_vm_response(&mut b) {
+            HostVmResponseRead::EmptyEof => {}
             other => panic!("expected EmptyEof, got {other:?}"),
         }
     }
 
     #[test]
-    fn read_builder_response_returns_timeout_when_peer_idle() {
+    fn read_host_vm_response_returns_timeout_when_peer_idle() {
         // Reader's set_read_timeout(...) elapses without the peer
         // writing anything. Classify as Timeout (not Err) so the
         // caller's fallback path runs the same as EmptyEof.
@@ -609,14 +829,14 @@ mod tests {
         let (_a, mut b) = UnixStream::pair().expect("socketpair");
         b.set_read_timeout(Some(Duration::from_millis(50)))
             .expect("set_read_timeout");
-        match read_builder_response(&mut b) {
-            BuilderResponseRead::Timeout => {}
+        match read_host_vm_response(&mut b) {
+            HostVmResponseRead::Timeout => {}
             other => panic!("expected Timeout, got {other:?}"),
         }
     }
 
     #[test]
-    fn read_builder_response_handles_streamed_chunks() {
+    fn read_host_vm_response_handles_streamed_chunks() {
         // Guest writes a Result preceded by a StderrChunk over the
         // same conn; the reader picks up the first frame. This
         // documents that the reader reads ONE frame and stops —
@@ -624,16 +844,16 @@ mod tests {
         // dispatch loop reads many).
         use std::os::unix::net::UnixStream;
         let (mut a, mut b) = UnixStream::pair().expect("socketpair");
-        let chunk = BuilderResponse::StderrChunk {
+        let chunk = HostVmResponse::StderrChunk {
             job_id: JobId(Uuid::nil()),
             line: "[mvm] building".to_string(),
         };
         let final_result = sample_result();
-        write_builder_response(&mut a, &chunk).expect("chunk");
-        write_builder_response(&mut a, &final_result).expect("result");
+        write_host_vm_response(&mut a, &chunk).expect("chunk");
+        write_host_vm_response(&mut a, &final_result).expect("result");
         drop(a);
-        match read_builder_response(&mut b) {
-            BuilderResponseRead::Frame(got) => assert_eq!(got, chunk),
+        match read_host_vm_response(&mut b) {
+            HostVmResponseRead::Frame(got) => assert_eq!(got, chunk),
             other => panic!("expected first frame to be the chunk, got {other:?}"),
         }
     }

--- a/crates/mvm-build/src/builder_vm.rs
+++ b/crates/mvm-build/src/builder_vm.rs
@@ -86,7 +86,7 @@ pub struct BuilderMounts {
 ///
 /// `Serialize`/`Deserialize` + `#[serde(deny_unknown_fields)]` were
 /// added by Plan 89 W2 so `BuilderJob` can ride inside
-/// [`crate::builder_protocol::BuilderRequest::Run`] over the
+/// [`crate::builder_protocol::HostVmRequest::Run`] over the
 /// vsock-framed dispatch channel.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(deny_unknown_fields)]

--- a/crates/mvm-build/src/lib.rs
+++ b/crates/mvm-build/src/lib.rs
@@ -19,7 +19,7 @@ pub mod firecracker;
 pub mod packed_artifact;
 /// Plan 89 W3 part 1 — host-side scaffold for the persistent
 /// builder VM's dispatch supervisor. Spawning the actual libkrun
-/// VM lives in W3 part 2 (`LibkrunPersistentBuilderVm`); this
+/// VM lives in W3 part 2 (`LibkrunPersistentHostVm`); this
 /// module owns the dispatch wire over the socket libkrun creates.
 pub mod persistent_builder;
 /// Plan 85 Phase B — OCI-unpacked tree to ext4 rootfs image.

--- a/crates/mvm-build/src/libkrun_builder.rs
+++ b/crates/mvm-build/src/libkrun_builder.rs
@@ -1206,7 +1206,7 @@ fn resolve_supervisor_path() -> Result<PathBuf, BuilderVmError> {
 /// Plan 89 W3 part 4 — spawn the supervisor with the given
 /// `cfg` piped to its stdin, return the live `Child` *without*
 /// waiting on it. Persistent-VM callers
-/// ([`LibkrunPersistentBuilderVm::start`]) consume the child via
+/// ([`LibkrunPersistentHostVm::start`]) consume the child via
 /// [`PersistentVmHandle`]; the single-shot
 /// [`spawn_supervisor_and_wait`] calls this then runs the wait
 /// loop on top.
@@ -1313,7 +1313,7 @@ fn spawn_supervisor_and_wait(
 }
 
 /// Plan 89 W2 part 4 — spawn a background thread that reads the
-/// `BuilderResponse::Result` frame `mvm-builder-init` sends over
+/// `HostVmResponse::Result` frame `mvm-builder-init` sends over
 /// AF_VSOCK port [`mvm_guest::builder_agent::BUILDER_DISPATCH_PORT`]
 /// right before reboot (W2 part 3). Returns a `Receiver` the caller
 /// drains after the supervisor exits via [`log_vsock_response_outcome`].
@@ -1334,12 +1334,12 @@ fn spawn_supervisor_and_wait(
 #[cfg(feature = "builder-vm")]
 pub fn spawn_vsock_response_listener(
     vm_state_dir: &Path,
-) -> std::sync::mpsc::Receiver<crate::builder_protocol::BuilderResponseRead> {
+) -> std::sync::mpsc::Receiver<crate::builder_protocol::HostVmResponseRead> {
     use std::os::unix::net::UnixStream;
     use std::sync::mpsc;
     use std::time::{Duration, Instant};
 
-    use crate::builder_protocol::{BuilderResponseRead, read_builder_response};
+    use crate::builder_protocol::{HostVmResponseRead, read_host_vm_response};
 
     let (tx, rx) = mpsc::channel();
     let socket_path = vm_state_dir.join(format!(
@@ -1356,12 +1356,12 @@ pub fn spawn_vsock_response_listener(
             let start = Instant::now();
             let result = loop {
                 if start.elapsed() > connect_deadline {
-                    break BuilderResponseRead::Timeout;
+                    break HostVmResponseRead::Timeout;
                 }
                 match UnixStream::connect(&socket_path) {
                     Ok(mut stream) => {
                         let _ = stream.set_read_timeout(Some(read_timeout));
-                        break read_builder_response(&mut stream);
+                        break read_host_vm_response(&mut stream);
                     }
                     Err(_) => std::thread::sleep(poll_interval),
                 }
@@ -1388,13 +1388,13 @@ pub fn spawn_vsock_response_listener(
 /// signal.
 #[cfg(feature = "builder-vm")]
 pub fn log_vsock_response_outcome(
-    rx: std::sync::mpsc::Receiver<crate::builder_protocol::BuilderResponseRead>,
+    rx: std::sync::mpsc::Receiver<crate::builder_protocol::HostVmResponseRead>,
     file_exit_code: Option<i32>,
 ) {
-    use crate::builder_protocol::{BuilderResponse, BuilderResponseRead};
+    use crate::builder_protocol::{HostVmResponse, HostVmResponseRead};
 
     match rx.recv_timeout(std::time::Duration::from_secs(5)) {
-        Ok(BuilderResponseRead::Frame(BuilderResponse::Result {
+        Ok(HostVmResponseRead::Frame(HostVmResponse::Result {
             exit_code,
             job_timings,
             boot_timings,
@@ -1404,7 +1404,7 @@ pub fn log_vsock_response_outcome(
                 vsock_exit_code = exit_code,
                 build_ms = job_timings.build_ms,
                 boot_timings_present = boot_timings.is_some(),
-                "received BuilderResponse::Result via vsock dispatch channel (W2 part 3)"
+                "received HostVmResponse::Result via vsock dispatch channel (W2 part 3)"
             );
             if let Some(file_code) = file_exit_code
                 && file_code != exit_code
@@ -1417,19 +1417,19 @@ pub fn log_vsock_response_outcome(
                 );
             }
         }
-        Ok(BuilderResponseRead::Frame(other)) => {
+        Ok(HostVmResponseRead::Frame(other)) => {
             tracing::debug!(
                 ?other,
                 "vsock dispatch: non-Result frame ignored in single-shot"
             );
         }
-        Ok(BuilderResponseRead::EmptyEof) => {
+        Ok(HostVmResponseRead::EmptyEof) => {
             tracing::debug!(
                 "vsock dispatch: guest closed without sending — \
                  pre-W2-part-3 image, expected"
             );
         }
-        Ok(BuilderResponseRead::Timeout) => {
+        Ok(HostVmResponseRead::Timeout) => {
             tracing::debug!("vsock dispatch: receive thread timed out");
         }
         Err(_) => {
@@ -1678,7 +1678,7 @@ fn path_to_str<'a>(p: &'a Path, field: &str) -> Result<&'a str, BuilderVmError> 
 }
 
 // ============================================================
-// Plan 89 W3 part 4 — LibkrunPersistentBuilderVm
+// Plan 89 W3 part 4 — LibkrunPersistentHostVm
 // ============================================================
 
 /// Filename of the marker the host stages under `<job_dir>/` to
@@ -1694,7 +1694,7 @@ pub const DISPATCH_SOCK_MARKER: &str = "dispatch.sock.marker";
 /// produces a different shape of dispatch: instead of running a
 /// single cmd.sh / install_spec and powering off, the guest
 /// detects `<job_dir>/<DISPATCH_SOCK_MARKER>` and enters the
-/// dispatch loop that reads `BuilderRequest` frames over
+/// dispatch loop that reads `HostVmRequest` frames over
 /// AF_VSOCK port [`mvm_guest::builder_agent::BUILDER_DISPATCH_PORT`].
 ///
 /// The caller pairs this with a `PersistentBuilderSupervisor`
@@ -1709,7 +1709,7 @@ pub const DISPATCH_SOCK_MARKER: &str = "dispatch.sock.marker";
 ///   part 8 — security amendments F2/F7).
 #[cfg(feature = "builder-vm")]
 #[derive(Debug, Clone)]
-pub struct LibkrunPersistentBuilderVm {
+pub struct LibkrunPersistentHostVm {
     vcpus: u8,
     memory_mib: u32,
     nix_store_mib: u32,
@@ -1720,7 +1720,7 @@ pub struct LibkrunPersistentBuilderVm {
 }
 
 #[cfg(feature = "builder-vm")]
-impl LibkrunPersistentBuilderVm {
+impl LibkrunPersistentHostVm {
     /// Construct a persistent builder VM rooted at `workspace_root`.
     /// Defaults match [`LibkrunBuilderVm::default`] for vCPUs / RAM /
     /// nix-store image size.
@@ -1762,7 +1762,7 @@ impl LibkrunPersistentBuilderVm {
     /// return a handle whose `dispatch_socket_path` the W3 part 1
     /// supervisor connects to. The returned `Child` is alive
     /// until either the guest dispatch loop processes a
-    /// `BuilderRequest::Shutdown` (clean exit) or the caller
+    /// `HostVmRequest::Shutdown` (clean exit) or the caller
     /// invokes [`PersistentVmHandle::kill`].
     pub fn start(&self) -> Result<PersistentVmHandle, BuilderVmError> {
         if !mvm_libkrun::is_available() {
@@ -1920,7 +1920,7 @@ impl PersistentVmHandle {
     /// Per-VM job directory bound at `/job` inside the guest.
     /// Hosts stage per-dispatch artifacts (`<job_dir_relpath>/cmd.sh`,
     /// per-dispatch install specs, etc.) here before sending the
-    /// matching `BuilderRequest::Run`.
+    /// matching `HostVmRequest::Run`.
     pub fn job_dir(&self) -> &Path {
         &self.job_dir
     }
@@ -1932,7 +1932,7 @@ impl PersistentVmHandle {
     }
 
     /// Block until the supervisor child exits. Normal way to
-    /// reach this is the supervisor sending `BuilderRequest::Shutdown`,
+    /// reach this is the supervisor sending `HostVmRequest::Shutdown`,
     /// the guest dispatch loop processing it + replying `Bye`,
     /// then `mvm-builder-init` calling `reboot(RB_POWER_OFF)`,
     /// then libkrun's `krun_start_enter` returning, then the
@@ -2637,7 +2637,7 @@ mod tests {
     }
 
     // -----------------------------------------------------------
-    // Plan 89 W3 part 4 — LibkrunPersistentBuilderVm
+    // Plan 89 W3 part 4 — LibkrunPersistentHostVm
     // -----------------------------------------------------------
 
     #[test]
@@ -2686,7 +2686,7 @@ mod tests {
         // Same vcpus / memory / nix-store defaults so users moving
         // from single-shot to persistent don't see surprise
         // resource shifts.
-        let vm = LibkrunPersistentBuilderVm::new(std::env::temp_dir());
+        let vm = LibkrunPersistentHostVm::new(std::env::temp_dir());
         assert_eq!(vm.vcpus, DEFAULT_VCPUS);
         assert_eq!(vm.memory_mib, DEFAULT_MEMORY_MIB);
         assert_eq!(vm.nix_store_mib, DEFAULT_NIX_STORE_MIB);
@@ -2694,7 +2694,7 @@ mod tests {
 
     #[test]
     fn persistent_vm_with_setters_override_defaults() {
-        let vm = LibkrunPersistentBuilderVm::new(std::env::temp_dir())
+        let vm = LibkrunPersistentHostVm::new(std::env::temp_dir())
             .with_vcpus(2)
             .with_memory_mib(2048)
             .with_nix_store_mib(8192);
@@ -2715,7 +2715,7 @@ mod tests {
                 .map(|d| d.as_nanos())
                 .unwrap_or(0)
         ));
-        let vm = LibkrunPersistentBuilderVm::new(&nonexistent);
+        let vm = LibkrunPersistentHostVm::new(&nonexistent);
         match vm.start() {
             Err(BuilderVmError::ExtractionFailed(msg)) => {
                 assert!(msg.contains("workspace_root"), "msg: {msg}");

--- a/crates/mvm-build/src/persistent_builder.rs
+++ b/crates/mvm-build/src/persistent_builder.rs
@@ -8,11 +8,11 @@
 //! inside an active `mvmctl dev` session — submit a
 //! [`crate::builder_vm::BuilderJob`] via [`Self::submit`]; the
 //! supervisor serializes it to a
-//! [`crate::builder_protocol::BuilderRequest::Run`], writes the
+//! [`crate::builder_protocol::HostVmRequest::Run`], writes the
 //! frame over the socket, then reads back streamed
-//! [`crate::builder_protocol::BuilderResponse::StderrChunk`] frames
+//! [`crate::builder_protocol::HostVmResponse::StderrChunk`] frames
 //! followed by a terminating
-//! [`crate::builder_protocol::BuilderResponse::Result`].
+//! [`crate::builder_protocol::HostVmResponse::Result`].
 //!
 //! ## Scope of this PR (W3 part 1)
 //!
@@ -23,7 +23,7 @@
 //!   driving the wire end-to-end via `UnixListener::pair`-style
 //!   mocks in `crates/mvm-build/tests/persistent_builder_supervisor.rs`.
 //! - **Out:** spawning the actual libkrun VM
-//!   ([`crate::libkrun_builder::LibkrunPersistentBuilderVm`] lands
+//!   ([`crate::libkrun_builder::LibkrunPersistentHostVm`] lands
 //!   in W3 part 2 alongside builder-init's dispatch-loop emit);
 //!   `mvmctl dev up` auto-start of the supervisor (W3 part 3);
 //!   per-job namespace isolation (W3 part 4); per-dispatch audit
@@ -33,8 +33,8 @@
 //!
 //! Per Plan 89 §Concurrency, V1 is one in-flight dispatch per
 //! supervisor. The dispatch mutex guards the socket so two
-//! concurrent submits don't interleave their `BuilderRequest` /
-//! `BuilderResponse` frames on the same connection. V2+ parallel
+//! concurrent submits don't interleave their `HostVmRequest` /
+//! `HostVmResponse` frames on the same connection. V2+ parallel
 //! dispatch (per-job overlay namespaces + per-job vsock conns) is
 //! an explicit non-goal of this plan.
 
@@ -45,9 +45,7 @@ use std::time::Duration;
 
 use thiserror::Error;
 
-use crate::builder_protocol::{
-    BootTimingsWire, BuilderRequest, BuilderResponse, JobId, JobTimings,
-};
+use crate::builder_protocol::{BootTimingsWire, HostVmRequest, HostVmResponse, JobId, JobTimings};
 use crate::builder_vm::BuilderJob;
 
 /// Plan 89 W3 part 14 — host-side hook the persistent dispatch
@@ -75,11 +73,11 @@ use crate::builder_vm::BuilderJob;
 /// security-scan F5 calls out:
 ///
 /// - [`Self::dispatched`] — fires after the supervisor writes
-///   the `BuilderRequest::Run` frame and before it starts
+///   the `HostVmRequest::Run` frame and before it starts
 ///   collecting responses. Records the start of the
 ///   `job_id`-tagged sub-chain.
 /// - [`Self::completed`] — fires after a successful
-///   `BuilderResponse::Result` (exit_code is whatever the build
+///   `HostVmResponse::Result` (exit_code is whatever the build
 ///   produced; non-zero exits are still "completed" from the
 ///   dispatch supervisor's POV).
 /// - [`Self::failed`] — fires when the supervisor surfaces a
@@ -129,7 +127,7 @@ const DEFAULT_DISPATCH_TIMEOUT: Duration = Duration::from_secs(60 * 60);
 const DEFAULT_FRAME_READ_TIMEOUT: Duration = Duration::from_secs(30);
 
 /// The completed outcome of one dispatched job. Mirrors the wire
-/// shape of [`BuilderResponse::Result`] plus an in-process
+/// shape of [`HostVmResponse::Result`] plus an in-process
 /// accumulation of the stderr chunks that streamed in before the
 /// terminating Result.
 #[derive(Debug, Clone)]
@@ -172,7 +170,7 @@ pub enum PersistentBuilderError {
     JobIdMismatch { request: JobId, response: JobId },
 
     /// Guest closed the connection before sending a terminating
-    /// [`BuilderResponse::Result`]. Could mean kernel panic, OOM
+    /// [`HostVmResponse::Result`]. Could mean kernel panic, OOM
     /// kill of the build process, or a logic bug in the dispatch
     /// loop. Distinguished from [`Self::SocketUnreachable`] because
     /// the *connection* was established and partial output was
@@ -192,7 +190,7 @@ pub enum PersistentBuilderError {
 /// — the libkrun-managed Unix socket that proxies to AF_VSOCK port
 /// [`mvm_guest::builder_agent::BUILDER_DISPATCH_PORT`] inside the
 /// guest. The owner of the persistent VM (W3 part 2 will spawn it
-/// from `LibkrunPersistentBuilderVm`) constructs this supervisor
+/// from `LibkrunPersistentHostVm`) constructs this supervisor
 /// once the VM is up, then hands the result to whatever submits
 /// jobs (W3 part 3 wires `mvmctl build` to it from inside a dev
 /// session).
@@ -255,7 +253,7 @@ impl PersistentBuilderSupervisor {
 
     /// Dispatch one [`BuilderJob`] into the persistent VM and
     /// block until the guest sends back a terminating
-    /// [`BuilderResponse::Result`]. Holds the dispatch mutex for
+    /// [`HostVmResponse::Result`]. Holds the dispatch mutex for
     /// the duration (V1 = serialized).
     ///
     /// `job_dir_relpath` is the path inside the `/job` virtio-fs
@@ -274,11 +272,11 @@ impl PersistentBuilderSupervisor {
 
         let job_id = JobId::new();
         // Snapshot the job + relpath for the audit emit before
-        // moving them into the BuilderRequest::Run variant; the
+        // moving them into the HostVmRequest::Run variant; the
         // dispatch loop then consumes the request.
         let job_for_audit = job.clone();
         let relpath_for_audit = job_dir_relpath.clone();
-        let request = BuilderRequest::Run {
+        let request = HostVmRequest::Run {
             job_id,
             job,
             job_dir_relpath,
@@ -314,8 +312,8 @@ impl PersistentBuilderSupervisor {
         }
     }
 
-    /// Send a [`BuilderRequest::Shutdown`] to the guest's dispatch
-    /// loop and wait for the matching [`BuilderResponse::Bye`].
+    /// Send a [`HostVmRequest::Shutdown`] to the guest's dispatch
+    /// loop and wait for the matching [`HostVmResponse::Bye`].
     /// Consumes `self` because the supervisor is one-shot after
     /// shutdown — the VM will power off and the socket goes away.
     pub fn shutdown(self) -> Result<(), PersistentBuilderError> {
@@ -324,7 +322,7 @@ impl PersistentBuilderSupervisor {
             .lock()
             .map_err(|_| PersistentBuilderError::MutexPoisoned)?;
 
-        let request = BuilderRequest::Shutdown {};
+        let request = HostVmRequest::Shutdown {};
         let mut stream = self.connect()?;
         mvm_guest::vsock::write_frame(&mut stream, &request)
             .map_err(|e| std::io::Error::other(e.to_string()))?;
@@ -346,7 +344,7 @@ impl PersistentBuilderSupervisor {
 
     fn dispatch(
         &self,
-        request: &BuilderRequest,
+        request: &HostVmRequest,
         request_job_id: JobId,
     ) -> Result<DispatchOutcome, PersistentBuilderError> {
         let started = std::time::Instant::now();
@@ -366,7 +364,7 @@ impl PersistentBuilderSupervisor {
             }
             let response = read_next_response(&mut stream, self.frame_read_timeout)?;
             match response {
-                Some(BuilderResponse::StderrChunk { job_id, line }) => {
+                Some(HostVmResponse::StderrChunk { job_id, line }) => {
                     if job_id != request_job_id {
                         return Err(PersistentBuilderError::JobIdMismatch {
                             request: request_job_id,
@@ -375,7 +373,7 @@ impl PersistentBuilderSupervisor {
                     }
                     stderr_chunks.push(line);
                 }
-                Some(BuilderResponse::Result {
+                Some(HostVmResponse::Result {
                     job_id,
                     exit_code,
                     stderr_tail,
@@ -397,9 +395,24 @@ impl PersistentBuilderSupervisor {
                         job_timings,
                     });
                 }
-                Some(BuilderResponse::Bye {}) => {
+                Some(HostVmResponse::Bye {}) => {
                     // Bye in the middle of a dispatch is unexpected —
                     // treat as premature EOF.
+                    return Err(PersistentBuilderError::PrematureEof {
+                        chunks: stderr_chunks.len(),
+                    });
+                }
+                Some(HostVmResponse::WorkloadStarted { .. })
+                | Some(HostVmResponse::WorkloadStopped { .. })
+                | Some(HostVmResponse::WorkloadStatusReport { .. }) => {
+                    // Plan 107 A1: workload responses on the build-job
+                    // dispatch path are a protocol violation. The
+                    // guest-side workload arm is `unimplemented!()`
+                    // until A2.2, so this branch cannot fire today;
+                    // when A2 lands, workload responses will flow on a
+                    // dedicated channel (A3 vsock-proxy hop), not this
+                    // one. Treat as premature EOF for now — the host
+                    // can't recover from a wire mismatch.
                     return Err(PersistentBuilderError::PrematureEof {
                         chunks: stderr_chunks.len(),
                     });
@@ -415,15 +428,15 @@ impl PersistentBuilderSupervisor {
     }
 }
 
-/// Read the next [`BuilderResponse`] from `stream`. Returns
+/// Read the next [`HostVmResponse`] from `stream`. Returns
 /// `Ok(None)` on clean EOF and `Err(_)` on any I/O or framing
 /// failure. Module-private because the supervisor is the only
 /// caller that needs the "Option-on-EOF" semantics.
 fn read_next_response(
     stream: &mut UnixStream,
     _read_timeout: Duration,
-) -> Result<Option<BuilderResponse>, PersistentBuilderError> {
-    match mvm_guest::vsock::read_frame::<BuilderResponse>(stream) {
+) -> Result<Option<HostVmResponse>, PersistentBuilderError> {
+    match mvm_guest::vsock::read_frame::<HostVmResponse>(stream) {
         Ok(resp) => Ok(Some(resp)),
         Err(e) => {
             let src = e.source();
@@ -542,7 +555,7 @@ pub fn artifact_dir_for(session_job_dir: &Path, job_id: &str) -> PathBuf {
 /// Stage a per-dispatch cmd.sh + output subdir under
 /// `<session_job_dir>/<job_id>/`. Returns the relative path
 /// (just `<job_id>`) that the host passes as
-/// `BuilderRequest::Run::job_dir_relpath` and the guest dispatch
+/// `HostVmRequest::Run::job_dir_relpath` and the guest dispatch
 /// loop resolves under `/job/`. cmd.sh:
 ///
 /// 1. Runs `nix build` against `<flake_ref>#<attr>`, captures the
@@ -818,7 +831,7 @@ impl PersistentBuilderVm {
 /// create the out/ subdir (mirror of [`stage_flake_dispatch_job`]'s
 /// convention) and copy the caller's install spec into
 /// `<job_id>/install_spec.json`. Returns the `job_id` the host passes
-/// as `BuilderRequest::Run::job_dir_relpath`.
+/// as `HostVmRequest::Run::job_dir_relpath`.
 #[cfg(feature = "builder-vm")]
 fn stage_install_dispatch_job(
     session_job_dir: &Path,

--- a/crates/mvm-build/src/pipeline/vsock_builder.rs
+++ b/crates/mvm-build/src/pipeline/vsock_builder.rs
@@ -3,7 +3,7 @@ use std::os::unix::net::UnixStream;
 use std::time::{Duration, Instant};
 
 use anyhow::{Context, Result, anyhow};
-use mvm_guest::builder_agent::{BuilderRequest, BuilderResponse};
+use mvm_guest::builder_agent::{HostVmRequest, HostVmResponse};
 
 fn builder_agent_port() -> u32 {
     std::env::var("MVM_BUILDER_AGENT_PORT")
@@ -38,7 +38,7 @@ pub fn build_via_vsock(
         return Err(anyhow!("vsock CONNECT failed: {}", line.trim()));
     }
 
-    let req = BuilderRequest::Build {
+    let req = HostVmRequest::Build {
         flake_ref: flake_ref.to_string(),
         attr: attr.to_string(),
         timeout_secs: Some(timeout_secs),
@@ -64,10 +64,10 @@ pub fn build_via_vsock(
         if trimmed.is_empty() {
             continue;
         }
-        let resp: BuilderResponse = serde_json::from_str(trimmed)
+        let resp: HostVmResponse = serde_json::from_str(trimmed)
             .with_context(|| format!("invalid builder response: {}", trimmed))?;
         match resp {
-            BuilderResponse::Log { line } => {
+            HostVmResponse::Log { line } => {
                 if !line.is_empty() {
                     tracing::debug!(target: "mvm::build", "[builder-agent] {}", line);
                     if recent_logs.len() >= MAX_LOG_LINES {
@@ -76,8 +76,8 @@ pub fn build_via_vsock(
                     recent_logs.push(line);
                 }
             }
-            BuilderResponse::Ok { out_path } => return Ok(out_path),
-            BuilderResponse::Err { message } => {
+            HostVmResponse::Ok { out_path } => return Ok(out_path),
+            HostVmResponse::Err { message } => {
                 if recent_logs.is_empty() {
                     return Err(anyhow!("nix build failed: {}", message));
                 }
@@ -89,7 +89,7 @@ pub fn build_via_vsock(
                     log_tail
                 ));
             }
-            BuilderResponse::Pong => continue,
+            HostVmResponse::Pong => continue,
         }
     }
 }
@@ -146,7 +146,7 @@ fn ping_once(vsock_uds: &str) -> Result<()> {
         return Err(anyhow!("vsock CONNECT failed: {}", line.trim()));
     }
 
-    let req = BuilderRequest::Ping;
+    let req = HostVmRequest::Ping;
     {
         let s = reader.get_mut();
         writeln!(s, "{}", serde_json::to_string(&req)?)?;
@@ -155,11 +155,11 @@ fn ping_once(vsock_uds: &str) -> Result<()> {
 
     let mut resp_line = String::new();
     reader.read_line(&mut resp_line)?;
-    let resp: BuilderResponse = serde_json::from_str(resp_line.trim())
+    let resp: HostVmResponse = serde_json::from_str(resp_line.trim())
         .with_context(|| format!("invalid ping response: {}", resp_line.trim()))?;
     match resp {
-        BuilderResponse::Pong => Ok(()),
-        BuilderResponse::Err { message } => Err(anyhow!("builder agent ping failed: {}", message)),
+        HostVmResponse::Pong => Ok(()),
+        HostVmResponse::Err { message } => Err(anyhow!("builder agent ping failed: {}", message)),
         other => Err(anyhow!("unexpected ping response: {:?}", other)),
     }
 }

--- a/crates/mvm-build/src/vz_builder.rs
+++ b/crates/mvm-build/src/vz_builder.rs
@@ -633,7 +633,7 @@ impl BuilderVm for VzBuilderVm {
         //    flake / install jobs (the guest communicates results
         //    via the `/job` virtio-fs share, not vsock); the
         //    dispatch port (Plan 89 W2) is a persistent-VM concern
-        //    that lives on the long-lived `LibkrunPersistentBuilderVm`
+        //    that lives on the long-lived `LibkrunPersistentHostVm`
         //    path and doesn't apply here.
         let (kernel_path, kernel_cmdline) = match &image {
             BuilderVmImage::Rootfs {
@@ -848,11 +848,11 @@ fn workspace_root_from_manifest_dir() -> Option<PathBuf> {
 // VzPersistentBuilderVm — Plan 98 Slice 2A.
 // ──────────────────────────────────────────────────────────────────
 //
-// Parallel of [`libkrun_builder::LibkrunPersistentBuilderVm`]. Same
-// dispatch-loop semantics (vsock-framed `BuilderRequest::Run` from the
+// Parallel of [`libkrun_builder::LibkrunPersistentHostVm`]. Same
+// dispatch-loop semantics (vsock-framed `HostVmRequest::Run` from the
 // host-side [`crate::persistent_builder::PersistentBuilderSupervisor`]
 // → in-guest `mvm-builder-init` runs cmd.sh / install_spec.json →
-// `BuilderResponse::Result` back over the same vsock), only the host
+// `HostVmResponse::Result` back over the same vsock), only the host
 // VMM differs. Locked decision §5 of Plan 98: keep the drivers
 // parallel rather than collapse them behind a trait — mirrors the
 // one-shot pattern shipped by Plan 97 Phase C.
@@ -934,7 +934,7 @@ impl VzPersistentBuilderVm {
     /// through the dispatch socket that
     /// [`VzPersistentVmHandle::dispatch_socket_path`] points at.
     ///
-    /// Layered like [`LibkrunPersistentBuilderVm::start`]:
+    /// Layered like [`LibkrunPersistentHostVm::start`]:
     /// pre-flight checks (Vz available, workspace dir exists,
     /// supervisor binary resolvable) → image + nix-store lock
     /// acquisition → state dir + job dir staging →
@@ -1250,7 +1250,7 @@ impl VzPersistentVmHandle {
 
     /// Per-VM job directory bound at `/job` (and `/out`) inside the
     /// guest. Hosts stage per-dispatch artifacts here before
-    /// sending the matching `BuilderRequest::Run`.
+    /// sending the matching `HostVmRequest::Run`.
     pub fn job_dir(&self) -> &Path {
         &self.job_dir
     }
@@ -1262,7 +1262,7 @@ impl VzPersistentVmHandle {
     }
 
     /// Block until the supervisor child exits. Normal way to reach
-    /// this is the supervisor receiving `BuilderRequest::Shutdown`,
+    /// this is the supervisor receiving `HostVmRequest::Shutdown`,
     /// the guest dispatch loop processing it + replying `Bye`, then
     /// `mvm-builder-init` calling `reboot(RB_POWER_OFF)`, then the
     /// Vz supervisor exiting `main`. Consumes the child; subsequent

--- a/crates/mvm-build/tests/persistent_builder_supervisor.rs
+++ b/crates/mvm-build/tests/persistent_builder_supervisor.rs
@@ -14,7 +14,7 @@ use std::path::Path;
 use std::time::Duration;
 
 use mvm_build::builder_protocol::{
-    BootTimingsWire, BuilderRequest, BuilderResponse, JobId, JobTimings,
+    BootTimingsWire, HostVmRequest, HostVmResponse, JobId, JobTimings,
 };
 use mvm_build::builder_vm::BuilderJob;
 use mvm_build::persistent_builder::{
@@ -24,7 +24,7 @@ use mvm_build::persistent_builder::{
 
 /// Spawn a fake guest dispatch loop on `socket_path`. The closure
 /// is invoked with each accepted connection and is responsible for
-/// reading any incoming `BuilderRequest`, writing responses, and
+/// reading any incoming `HostVmRequest`, writing responses, and
 /// dropping the stream. Returns the listener thread handle —
 /// callers `join` after asserting the supervisor outcome.
 fn spawn_fake_guest<F>(socket_path: &Path, handler: F) -> std::thread::JoinHandle<()>
@@ -63,13 +63,12 @@ fn submit_round_trips_request_and_result_with_no_stderr_chunks() {
     let socket = dispatch_socket_path(scratch.path());
 
     let guest = spawn_fake_guest(&socket, |mut conn| {
-        let request: BuilderRequest =
-            mvm_guest::vsock::read_frame(&mut conn).expect("read request");
+        let request: HostVmRequest = mvm_guest::vsock::read_frame(&mut conn).expect("read request");
         let job_id = match &request {
-            BuilderRequest::Run { job_id, .. } => *job_id,
+            HostVmRequest::Run { job_id, .. } => *job_id,
             other => panic!("expected Run, got {other:?}"),
         };
-        let response = BuilderResponse::Result {
+        let response = HostVmResponse::Result {
             job_id,
             exit_code: 0,
             stderr_tail: String::new(),
@@ -112,23 +111,22 @@ fn submit_streams_stderr_chunks_then_collects_terminating_result() {
     let socket = dispatch_socket_path(scratch.path());
 
     let guest = spawn_fake_guest(&socket, |mut conn| {
-        let request: BuilderRequest =
-            mvm_guest::vsock::read_frame(&mut conn).expect("read request");
+        let request: HostVmRequest = mvm_guest::vsock::read_frame(&mut conn).expect("read request");
         let job_id = match &request {
-            BuilderRequest::Run { job_id, .. } => *job_id,
+            HostVmRequest::Run { job_id, .. } => *job_id,
             other => panic!("expected Run, got {other:?}"),
         };
         for line in ["building", "building 2/3", "building 3/3"] {
             mvm_guest::vsock::write_frame(
                 &mut conn,
-                &BuilderResponse::StderrChunk {
+                &HostVmResponse::StderrChunk {
                     job_id,
                     line: line.to_string(),
                 },
             )
             .expect("write chunk");
         }
-        let result = BuilderResponse::Result {
+        let result = HostVmResponse::Result {
             job_id,
             exit_code: 0,
             stderr_tail: "building 3/3".to_string(),
@@ -178,7 +176,7 @@ fn submit_returns_premature_eof_when_guest_closes_without_result() {
     let socket = dispatch_socket_path(scratch.path());
 
     let guest = spawn_fake_guest(&socket, |mut conn| {
-        let _: BuilderRequest = mvm_guest::vsock::read_frame(&mut conn).expect("read request");
+        let _: HostVmRequest = mvm_guest::vsock::read_frame(&mut conn).expect("read request");
         // Drop conn -> EOF.
     });
 
@@ -211,8 +209,8 @@ fn submit_detects_job_id_mismatch_in_result() {
     let socket = dispatch_socket_path(scratch.path());
 
     let guest = spawn_fake_guest(&socket, |mut conn| {
-        let _: BuilderRequest = mvm_guest::vsock::read_frame(&mut conn).expect("read request");
-        let bogus = BuilderResponse::Result {
+        let _: HostVmRequest = mvm_guest::vsock::read_frame(&mut conn).expect("read request");
+        let bogus = HostVmResponse::Result {
             job_id: JobId::new(),
             exit_code: 0,
             stderr_tail: String::new(),
@@ -242,16 +240,15 @@ fn submit_detects_job_id_mismatch_in_result() {
 #[test]
 fn shutdown_writes_shutdown_request_and_consumes_bye() {
     // Lifecycle path: caller invokes shutdown(); supervisor sends
-    // BuilderRequest::Shutdown; guest replies with Bye; supervisor
+    // HostVmRequest::Shutdown; guest replies with Bye; supervisor
     // returns cleanly.
     let scratch = tempfile::tempdir().expect("tempdir");
     let socket = dispatch_socket_path(scratch.path());
 
     let guest = spawn_fake_guest(&socket, |mut conn| {
-        let request: BuilderRequest =
-            mvm_guest::vsock::read_frame(&mut conn).expect("read request");
-        assert!(matches!(request, BuilderRequest::Shutdown {}));
-        mvm_guest::vsock::write_frame(&mut conn, &BuilderResponse::Bye {}).expect("write bye");
+        let request: HostVmRequest = mvm_guest::vsock::read_frame(&mut conn).expect("read request");
+        assert!(matches!(request, HostVmRequest::Shutdown {}));
+        mvm_guest::vsock::write_frame(&mut conn, &HostVmResponse::Bye {}).expect("write bye");
     });
 
     let supervisor =
@@ -318,13 +315,12 @@ fn submit_with_audit_sink_emits_dispatched_then_completed_on_success() {
     let socket = dispatch_socket_path(scratch.path());
 
     let guest = spawn_fake_guest(&socket, |mut conn| {
-        let request: BuilderRequest =
-            mvm_guest::vsock::read_frame(&mut conn).expect("read request");
+        let request: HostVmRequest = mvm_guest::vsock::read_frame(&mut conn).expect("read request");
         let job_id = match &request {
-            BuilderRequest::Run { job_id, .. } => *job_id,
+            HostVmRequest::Run { job_id, .. } => *job_id,
             other => panic!("expected Run, got {other:?}"),
         };
-        let response = BuilderResponse::Result {
+        let response = HostVmResponse::Result {
             job_id,
             exit_code: 0,
             stderr_tail: String::new(),
@@ -380,7 +376,7 @@ fn submit_with_audit_sink_emits_dispatched_then_failed_on_premature_eof() {
     // Guest accepts and immediately closes — supervisor surfaces
     // PrematureEof, audit sink should see dispatched + failed.
     let guest = spawn_fake_guest(&socket, |mut conn| {
-        let _request: BuilderRequest =
+        let _request: HostVmRequest =
             mvm_guest::vsock::read_frame(&mut conn).expect("read request");
         drop(conn);
     });
@@ -422,15 +418,14 @@ fn submit_without_audit_sink_emits_nothing() {
     let socket = dispatch_socket_path(scratch.path());
 
     let guest = spawn_fake_guest(&socket, |mut conn| {
-        let request: BuilderRequest =
-            mvm_guest::vsock::read_frame(&mut conn).expect("read request");
+        let request: HostVmRequest = mvm_guest::vsock::read_frame(&mut conn).expect("read request");
         let job_id = match &request {
-            BuilderRequest::Run { job_id, .. } => *job_id,
+            HostVmRequest::Run { job_id, .. } => *job_id,
             other => panic!("expected Run, got {other:?}"),
         };
         mvm_guest::vsock::write_frame(
             &mut conn,
-            &BuilderResponse::Result {
+            &HostVmResponse::Result {
                 job_id,
                 exit_code: 0,
                 stderr_tail: String::new(),

--- a/crates/mvm-build/tests/vsock_response_listener.rs
+++ b/crates/mvm-build/tests/vsock_response_listener.rs
@@ -14,7 +14,7 @@ use std::os::unix::net::UnixListener;
 use std::time::Duration;
 
 use mvm_build::builder_protocol::{
-    BootTimingsWire, BuilderResponse, BuilderResponseRead, JobId, JobTimings,
+    BootTimingsWire, HostVmResponse, HostVmResponseRead, JobId, JobTimings,
 };
 use mvm_build::libkrun_builder::spawn_vsock_response_listener;
 
@@ -31,13 +31,13 @@ fn spawn_vsock_response_listener_decodes_guest_response() {
     // at the path libkrun would create — that's what the host-side
     // spawn_vsock_response_listener's retry loop connects to. From
     // a separate thread, accept the connection and write a framed
-    // BuilderResponse. The listener helper's receiver should yield
+    // HostVmResponse. The listener helper's receiver should yield
     // Frame(...).
     let scratch = tempfile::tempdir().expect("tempdir");
     let socket_path = socket_path_in(scratch.path());
     let listener = UnixListener::bind(&socket_path).expect("bind unix socket");
 
-    let response = BuilderResponse::Result {
+    let response = HostVmResponse::Result {
         job_id: JobId::default(),
         exit_code: 0,
         stderr_tail: "ok".to_string(),
@@ -76,7 +76,7 @@ fn spawn_vsock_response_listener_decodes_guest_response() {
     guest_thread.join().expect("guest thread");
 
     match received {
-        BuilderResponseRead::Frame(got) => assert_eq!(got, expected),
+        HostVmResponseRead::Frame(got) => assert_eq!(got, expected),
         other => panic!("expected Frame, got {other:?}"),
     }
 }
@@ -104,7 +104,7 @@ fn spawn_vsock_response_listener_yields_empty_eof_when_no_send() {
     guest_thread.join().expect("guest thread");
 
     match received {
-        BuilderResponseRead::EmptyEof => {}
+        HostVmResponseRead::EmptyEof => {}
         other => panic!("expected EmptyEof, got {other:?}"),
     }
 }

--- a/crates/mvm-builder-init/Cargo.toml
+++ b/crates/mvm-builder-init/Cargo.toml
@@ -36,13 +36,13 @@ serde_json.workspace = true
 # Plan 89 W2 part 3 — the cross-validation test in
 # `dispatch_response::tests::dispatch_response_parses_as_typed_builder_response`
 # deserializes our hand-rolled JSON as
-# `mvm_build::builder_protocol::BuilderResponse` to pin the two
+# `mvm_build::builder_protocol::HostVmResponse` to pin the two
 # wire shapes together. Dev-only; doesn't pull mvm-build into the
 # production rootfs.
 mvm-build.workspace = true
 # Plan 89 W3 part 2 — same rationale: the cross-validation test in
 # `builder_request::tests::parses_what_mvm_build_serializes_with_serde`
-# constructs typed `mvm_build::builder_protocol::BuilderRequest`
+# constructs typed `mvm_build::builder_protocol::HostVmRequest`
 # values via `JobId(Uuid::nil())`. Dev-only.
 uuid.workspace = true
 

--- a/crates/mvm-builder-init/src/builder_request.rs
+++ b/crates/mvm-builder-init/src/builder_request.rs
@@ -1,8 +1,8 @@
-//! Plan 89 W3 part 2 — hand-rolled parser for `BuilderRequest`
+//! Plan 89 W3 part 2 — hand-rolled parser for `HostVmRequest`
 //! JSON, the wire-format the persistent builder VM's dispatch loop
 //! reads off vsock.
 //!
-//! Mirror of `mvm_build::builder_protocol::BuilderRequest` on the
+//! Mirror of `mvm_build::builder_protocol::HostVmRequest` on the
 //! host side. Cross-platform on purpose — the parser sees coverage
 //! from `cargo test` on every developer host so the wire shape
 //! stays in lock-step with the host's serde-derived encoding
@@ -66,9 +66,9 @@ pub enum BuilderJob {
     },
 }
 
-/// In-guest mirror of `mvm_build::builder_protocol::BuilderRequest`.
+/// In-guest mirror of `mvm_build::builder_protocol::HostVmRequest`.
 #[derive(Debug, Clone, PartialEq, Eq)]
-pub enum BuilderRequest {
+pub enum HostVmRequest {
     Run {
         job_id: String,
         job: BuilderJob,
@@ -85,7 +85,7 @@ pub enum ParseError {
     MissingKind,
     /// `"kind"` was present but neither `"run"` nor `"shutdown"`.
     UnknownKind(String),
-    /// `BuilderRequest::Run` was missing a required field.
+    /// `HostVmRequest::Run` was missing a required field.
     MissingRunField(&'static str),
     /// `Run.job` had neither `"Flake"` nor `"Install"`.
     UnknownJobVariant,
@@ -96,12 +96,12 @@ pub enum ParseError {
 impl fmt::Display for ParseError {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
-            Self::NotUtf8(e) => write!(f, "BuilderRequest body not UTF-8: {e}"),
-            Self::MissingKind => write!(f, "BuilderRequest missing `kind` discriminator"),
-            Self::UnknownKind(k) => write!(f, "BuilderRequest unknown kind `{k}`"),
-            Self::MissingRunField(name) => write!(f, "BuilderRequest::Run missing `{name}`"),
+            Self::NotUtf8(e) => write!(f, "HostVmRequest body not UTF-8: {e}"),
+            Self::MissingKind => write!(f, "HostVmRequest missing `kind` discriminator"),
+            Self::UnknownKind(k) => write!(f, "HostVmRequest unknown kind `{k}`"),
+            Self::MissingRunField(name) => write!(f, "HostVmRequest::Run missing `{name}`"),
             Self::UnknownJobVariant => {
-                write!(f, "BuilderRequest::Run job is neither Flake nor Install")
+                write!(f, "HostVmRequest::Run job is neither Flake nor Install")
             }
             Self::MissingJobField(name) => write!(f, "BuilderJob missing `{name}`"),
         }
@@ -110,27 +110,27 @@ impl fmt::Display for ParseError {
 
 impl std::error::Error for ParseError {}
 
-/// Parse a JSON-encoded `BuilderRequest` body (no length prefix —
+/// Parse a JSON-encoded `HostVmRequest` body (no length prefix —
 /// the caller has already framed). Tolerant of insignificant
 /// whitespace between JSON tokens because serde's writer may emit
 /// either compact or pretty output (we test against compact, but
 /// don't want to fail closed on pretty just to be safe).
-pub fn parse(bytes: &[u8]) -> Result<BuilderRequest, ParseError> {
+pub fn parse(bytes: &[u8]) -> Result<HostVmRequest, ParseError> {
     let text = std::str::from_utf8(bytes).map_err(ParseError::NotUtf8)?;
     let kind = find_string_value(text, "kind").ok_or(ParseError::MissingKind)?;
     match kind.as_str() {
-        "shutdown" => Ok(BuilderRequest::Shutdown),
+        "shutdown" => Ok(HostVmRequest::Shutdown),
         "run" => parse_run(text),
         other => Err(ParseError::UnknownKind(other.to_string())),
     }
 }
 
-fn parse_run(text: &str) -> Result<BuilderRequest, ParseError> {
+fn parse_run(text: &str) -> Result<HostVmRequest, ParseError> {
     let job_id = find_string_value(text, "job_id").ok_or(ParseError::MissingRunField("job_id"))?;
     let job_dir_relpath = find_string_value(text, "job_dir_relpath")
         .ok_or(ParseError::MissingRunField("job_dir_relpath"))?;
     let job = parse_job(text)?;
-    Ok(BuilderRequest::Run {
+    Ok(HostVmRequest::Run {
         job_id,
         job,
         job_dir_relpath,
@@ -180,7 +180,7 @@ fn contains_object_marker(text: &str, key: &str) -> bool {
 /// by optional whitespace and a `"..."`-delimited string. Doesn't
 /// walk the JSON tree, so if `"key"` appears twice at different
 /// nesting levels the first match wins. Sufficient for the closed
-/// `BuilderRequest` shape: each key (`kind`, `job_id`,
+/// `HostVmRequest` shape: each key (`kind`, `job_id`,
 /// `job_dir_relpath`, `flake_ref`, `attr_path`, `spec_path`) only
 /// appears once in any valid request.
 fn find_string_value(text: &str, key: &str) -> Option<String> {
@@ -254,7 +254,7 @@ mod tests {
     fn parses_shutdown() {
         assert_eq!(
             parse(SAMPLE_SHUTDOWN.as_bytes()).unwrap(),
-            BuilderRequest::Shutdown
+            HostVmRequest::Shutdown
         );
     }
 
@@ -262,7 +262,7 @@ mod tests {
     fn parses_flake_run() {
         let parsed = parse(SAMPLE_FLAKE_RUN.as_bytes()).unwrap();
         match parsed {
-            BuilderRequest::Run {
+            HostVmRequest::Run {
                 job_id,
                 job,
                 job_dir_relpath,
@@ -288,7 +288,7 @@ mod tests {
     fn parses_install_run() {
         let parsed = parse(SAMPLE_INSTALL_RUN.as_bytes()).unwrap();
         match parsed {
-            BuilderRequest::Run { job_id, job, .. } => {
+            HostVmRequest::Run { job_id, job, .. } => {
                 assert_eq!(job_id, "00000000-0000-0000-0000-000000000002");
                 match job {
                     BuilderJob::Install { spec_path } => {
@@ -305,7 +305,7 @@ mod tests {
     fn decodes_escapes_in_string_values() {
         let json = r#"{"kind":"run","job_id":"x","job":{"Flake":{"flake_ref":"line1\nline2\\back\"quote","attr_path":"y"}},"job_dir_relpath":"z"}"#;
         let parsed = parse(json.as_bytes()).unwrap();
-        if let BuilderRequest::Run {
+        if let HostVmRequest::Run {
             job: BuilderJob::Flake { flake_ref, .. },
             ..
         } = parsed
@@ -354,13 +354,13 @@ mod tests {
     }
 
     /// **The cross-validation test.** What the host's serde-derived
-    /// writer (`mvm_build::builder_protocol::BuilderRequest` →
+    /// writer (`mvm_build::builder_protocol::HostVmRequest` →
     /// `mvm_guest::vsock::write_frame`) emits must parse cleanly
     /// via this hand-rolled parser. Any schema drift on either side
     /// trips this test and that's the signal to resync.
     #[test]
     fn parses_what_mvm_build_serializes_with_serde() {
-        use mvm_build::builder_protocol::{BuilderRequest as HostReq, JobId};
+        use mvm_build::builder_protocol::{HostVmRequest as HostReq, JobId};
         use mvm_build::builder_vm::BuilderJob as HostJob;
 
         // Flake run
@@ -375,7 +375,7 @@ mod tests {
         let json = serde_json::to_vec(&req).expect("serialize");
         let parsed = parse(&json).expect("parse");
         match parsed {
-            BuilderRequest::Run {
+            HostVmRequest::Run {
                 job_id,
                 job,
                 job_dir_relpath,
@@ -406,7 +406,7 @@ mod tests {
         };
         let json = serde_json::to_vec(&req).expect("serialize");
         let parsed = parse(&json).expect("parse");
-        if let BuilderRequest::Run {
+        if let HostVmRequest::Run {
             job: BuilderJob::Install { spec_path },
             ..
         } = parsed
@@ -420,6 +420,6 @@ mod tests {
         let req = HostReq::Shutdown {};
         let json = serde_json::to_vec(&req).expect("serialize");
         let parsed = parse(&json).expect("parse");
-        assert_eq!(parsed, BuilderRequest::Shutdown);
+        assert_eq!(parsed, HostVmRequest::Shutdown);
     }
 }

--- a/crates/mvm-builder-init/src/dispatch_response.rs
+++ b/crates/mvm-builder-init/src/dispatch_response.rs
@@ -1,5 +1,5 @@
 //! Plan 89 W2 part 3 — hand-rolled JSON for the
-//! `BuilderResponse::Result` wire frame builder-init sends right
+//! `HostVmResponse::Result` wire frame builder-init sends right
 //! before reboot.
 //!
 //! ## Why hand-roll
@@ -7,9 +7,9 @@
 //! `mvm-builder-init` keeps a ≤ 1.5 MiB rootfs size budget
 //! (Plan 72 §W3) and deliberately does not pull `serde_json`
 //! (`Cargo.toml` comment at the deps section). The host-side
-//! consumer (`mvm_build::builder_protocol::BuilderResponse::Result`)
+//! consumer (`mvm_build::builder_protocol::HostVmResponse::Result`)
 //! is a typed serde enum; this module mirrors its wire shape
-//! exactly so the host's `serde_json::from_slice::<BuilderResponse>`
+//! exactly so the host's `serde_json::from_slice::<HostVmResponse>`
 //! parses what we emit. The `builder_response_matches_typed_serde`
 //! test below uses `mvm-build` as a dev-dep to pin the two sides
 //! together — if anyone tweaks either struct, that test breaks
@@ -17,7 +17,7 @@
 //!
 //! ## Single-shot caveats
 //!
-//! `BuilderResponse::Result` carries a `job_id: JobId(Uuid)` and a
+//! `HostVmResponse::Result` carries a `job_id: JobId(Uuid)` and a
 //! `job_timings: JobTimings { dispatch_ms, build_ms, teardown_ms }`.
 //! In single-shot mode there is no incoming dispatch with an id and
 //! no remote-dispatch round-trip to time, so:
@@ -25,7 +25,7 @@
 //! - `job_id` is the nil UUID
 //!   (`00000000-0000-0000-0000-000000000000`). The host's
 //!   single-shot caller knows to ignore it; persistent dispatch
-//!   (W3) will populate it from the `BuilderRequest::Run` it
+//!   (W3) will populate it from the `HostVmRequest::Run` it
 //!   correlates against.
 //! - `dispatch_ms` and `teardown_ms` are `0`. Only `build_ms`
 //!   carries a meaningful value, measured by the caller as
@@ -39,21 +39,21 @@ use crate::boot_timings::BootTimings;
 pub(crate) const NIL_JOB_ID: &str = "00000000-0000-0000-0000-000000000000";
 
 /// Owned snapshot of the data needed to hand-roll a
-/// `BuilderResponse::Result` JSON frame. The producer (the linux
+/// `HostVmResponse::Result` JSON frame. The producer (the linux
 /// module's `run` path for single-shot, or the W3 dispatch loop)
 /// gathers these fields after the inner build returns.
 #[derive(Debug, Clone)]
 pub(crate) struct DispatchResponse {
-    /// UUID-string echoed from the incoming `BuilderRequest::Run`.
+    /// UUID-string echoed from the incoming `HostVmRequest::Run`.
     /// Single-shot callers pass [`NIL_JOB_ID`]; persistent
     /// dispatch echoes the host-generated id from
-    /// `BuilderRequest::Run::job_id`.
+    /// `HostVmRequest::Run::job_id`.
     pub job_id: String,
     pub exit_code: i32,
     pub stderr_tail: String,
     /// Cold-boot phase timings. `Some` on the first response a
     /// persistent VM emits (matches the host-side
-    /// `BuilderResponse::Result::boot_timings: Option<...>`
+    /// `HostVmResponse::Result::boot_timings: Option<...>`
     /// semantics); `None` on subsequent dispatches in the same
     /// session — there's no second cold boot to time. Single-shot
     /// always passes `Some`.
@@ -62,7 +62,7 @@ pub(crate) struct DispatchResponse {
 }
 
 impl DispatchResponse {
-    /// Render as the exact wire JSON `mvm_build::builder_protocol::BuilderResponse::Result`
+    /// Render as the exact wire JSON `mvm_build::builder_protocol::HostVmResponse::Result`
     /// deserializes from. Field order matches the serde-derived
     /// internally-tagged enum encoding (`"kind"` first, then the
     /// variant's struct fields in declaration order).
@@ -86,22 +86,22 @@ impl DispatchResponse {
     }
 }
 
-/// Plan 89 W3 part 3 — wire JSON for `BuilderResponse::Bye`,
-/// the dispatch loop's acknowledgement of `BuilderRequest::Shutdown`.
+/// Plan 89 W3 part 3 — wire JSON for `HostVmResponse::Bye`,
+/// the dispatch loop's acknowledgement of `HostVmRequest::Shutdown`.
 /// Static body; no fields to escape.
 pub(crate) fn bye_json() -> &'static str {
     r#"{"kind":"bye"}"#
 }
 
-/// Plan 89 W3 part 9 — wire JSON for `BuilderResponse::StderrChunk`,
+/// Plan 89 W3 part 9 — wire JSON for `HostVmResponse::StderrChunk`,
 /// one frame per stderr line the dispatch loop streams back to the
 /// host while a build is running. Matches the serde-derived shape in
-/// `mvm_build::builder_protocol::BuilderResponse::StderrChunk`
+/// `mvm_build::builder_protocol::HostVmResponse::StderrChunk`
 /// (`{"kind":"stderr_chunk","job_id":"...","line":"..."}`); the
 /// cross-validation test below pins it.
 ///
 /// `line` must already have its trailing `\n` stripped — the host's
-/// `mvm_build::builder_protocol::BuilderResponse::StderrChunk` docs
+/// `mvm_build::builder_protocol::HostVmResponse::StderrChunk` docs
 /// commit to that.
 pub(crate) fn stderr_chunk_json(job_id: &str, line: &str) -> String {
     let mut out = String::with_capacity(64 + job_id.len() + line.len());
@@ -232,11 +232,11 @@ mod tests {
 
     #[test]
     fn bye_json_matches_typed_builder_response_bye() {
-        let typed: mvm_build::builder_protocol::BuilderResponse =
+        let typed: mvm_build::builder_protocol::HostVmResponse =
             serde_json::from_str(bye_json()).expect("parse");
         assert!(matches!(
             typed,
-            mvm_build::builder_protocol::BuilderResponse::Bye {}
+            mvm_build::builder_protocol::HostVmResponse::Bye {}
         ));
     }
 
@@ -248,10 +248,10 @@ mod tests {
         let job_id = "01234567-89ab-cdef-0123-456789abcdef";
         let line = "[mvm] nix build: 12/47 derivations";
         let json = stderr_chunk_json(job_id, line);
-        let typed: mvm_build::builder_protocol::BuilderResponse =
-            serde_json::from_str(&json).expect("must parse as typed BuilderResponse");
+        let typed: mvm_build::builder_protocol::HostVmResponse =
+            serde_json::from_str(&json).expect("must parse as typed HostVmResponse");
         match typed {
-            mvm_build::builder_protocol::BuilderResponse::StderrChunk {
+            mvm_build::builder_protocol::HostVmResponse::StderrChunk {
                 job_id: got_id,
                 line: got_line,
             } => {
@@ -278,7 +278,7 @@ mod tests {
     }
 
     /// **The cross-validation test.** Hand-rolled JSON must
-    /// deserialize as `mvm_build::builder_protocol::BuilderResponse`
+    /// deserialize as `mvm_build::builder_protocol::HostVmResponse`
     /// with `Result` variant carrying the expected fields. Bumps
     /// either struct's shape (renames, additions, type changes)
     /// trip this test, which is the signal to re-sync.
@@ -292,10 +292,10 @@ mod tests {
             build_ms: 1234,
         };
         let json = resp.to_json();
-        let typed: mvm_build::builder_protocol::BuilderResponse =
-            serde_json::from_str(&json).expect("must parse as typed BuilderResponse");
+        let typed: mvm_build::builder_protocol::HostVmResponse =
+            serde_json::from_str(&json).expect("must parse as typed HostVmResponse");
         match typed {
-            mvm_build::builder_protocol::BuilderResponse::Result {
+            mvm_build::builder_protocol::HostVmResponse::Result {
                 job_id,
                 exit_code,
                 stderr_tail,

--- a/crates/mvm-builder-init/src/main.rs
+++ b/crates/mvm-builder-init/src/main.rs
@@ -73,14 +73,14 @@ use std::process::ExitCode;
 #[allow(dead_code)]
 mod boot_timings;
 /// Plan 89 W3 part 2 — hand-rolled parser for the
-/// `BuilderRequest` wire shape the persistent builder VM's
+/// `HostVmRequest` wire shape the persistent builder VM's
 /// dispatch loop reads off vsock. Cross-platform; the W3 part 3
 /// Linux dispatch loop calls into it after reading the framed
 /// body. Tested against the host's serde-derived encoding so
 /// schema drift on either side is loud.
 #[allow(dead_code)]
 mod builder_request;
-/// Plan 89 W2 part 3 — hand-rolled `BuilderResponse::Result`
+/// Plan 89 W2 part 3 — hand-rolled `HostVmResponse::Result`
 /// JSON. Cross-platform (testable on macOS) so the wire shape can
 /// be validated against `mvm_build::builder_protocol`'s typed
 /// serde via a dev-dep test, without dragging serde_json into the
@@ -606,7 +606,7 @@ mod linux {
 
         // Plan 89 W3 part 3 dispatch: if the host staged a
         // `dispatch.sock.marker` in /job, this VM is persistent
-        // (host-side `LibkrunPersistentBuilderVm`, W3 part 4).
+        // (host-side `LibkrunPersistentHostVm`, W3 part 4).
         // Enter the dispatch loop instead of single-shot. Marker
         // absent (the default) preserves the existing cmd.sh /
         // install_spec flows exactly.
@@ -618,7 +618,7 @@ mod linux {
             });
             // Snapshot the cold-boot timings — the dispatch loop's
             // first response carries this; subsequent responses
-            // see None (per Plan 89's BuilderResponse::Result
+            // see None (per Plan 89's HostVmResponse::Result
             // semantics).
             let cold_boot_timings = match timings.lock() {
                 Ok(t) => Some(t.clone()),
@@ -679,8 +679,8 @@ mod linux {
         });
         write_result(code, &tail);
         // Plan 89 W2 part 3: best-effort vsock send of the
-        // `BuilderResponse::Result` frame the host's
-        // `mvm_build::builder_protocol::read_builder_response_from_socket`
+        // `HostVmResponse::Result` frame the host's
+        // `mvm_build::builder_protocol::read_host_vm_response_from_socket`
         // is waiting for. Runs BEFORE write_boot_timings so the
         // timings snapshot we send mirrors what hits the filesystem.
         // Any failure logs and falls through to power_off — the
@@ -719,7 +719,7 @@ mod linux {
 
     /// Plan 89 W2 part 3 — listen on `AF_VSOCK` port
     /// [`BUILDER_DISPATCH_PORT`] and write a single framed
-    /// `BuilderResponse::Result` to the first connection that
+    /// `HostVmResponse::Result` to the first connection that
     /// arrives within `ACCEPT_TIMEOUT_SECS` seconds. Best-effort:
     /// any failure (no host connection, socket setup error, write
     /// error) is logged to stderr and the boot continues to
@@ -728,7 +728,7 @@ mod linux {
     /// Wire shape is hand-rolled by
     /// [`crate::dispatch_response::DispatchResponse::to_json`]; the
     /// cross-validation test in that module pins the output against
-    /// `mvm_build::builder_protocol::BuilderResponse` so the host
+    /// `mvm_build::builder_protocol::HostVmResponse` so the host
     /// deserializer parses what we emit.
     ///
     /// AF_VSOCK constants are inlined rather than going through
@@ -757,7 +757,7 @@ mod linux {
     const SO_RCVTIMEO: i32 = 20;
     const VMADDR_CID_ANY: u32 = 0xFFFF_FFFF;
 
-    /// W3 part 3 cap on a single inbound `BuilderRequest` body.
+    /// W3 part 3 cap on a single inbound `HostVmRequest` body.
     /// Matches `mvm_guest::vsock::MAX_FRAME_SIZE` (256 KiB) — the
     /// host's `read_frame` enforces the same bound on its side, so
     /// a body above this size couldn't have been written by a
@@ -929,10 +929,10 @@ mod linux {
     /// Plan 89 W3 part 3 — dispatch loop entry point. Called from
     /// `run` when `/job/dispatch.sock.marker` is present (the host
     /// stages the marker when spawning a long-lived
-    /// `LibkrunPersistentBuilderVm`, W3 part 4). Opens a long-lived
+    /// `LibkrunPersistentHostVm`, W3 part 4). Opens a long-lived
     /// AF_VSOCK listener on [`BUILDER_DISPATCH_PORT`], reads one
-    /// `BuilderRequest` per accepted connection, dispatches the
-    /// inner job, writes back a `BuilderResponse::Result`, and
+    /// `HostVmRequest` per accepted connection, dispatches the
+    /// inner job, writes back a `HostVmResponse::Result`, and
     /// repeats until a `Shutdown` request triggers a clean exit.
     ///
     /// `cold_boot_timings` carries the BootTimings snapshot taken
@@ -948,7 +948,7 @@ mod linux {
         // No accept timeout — the dispatch loop is persistent and
         // blocks waiting for the supervisor's next submit. The
         // outer `mvmctl dev down` signals shutdown via a
-        // `BuilderRequest::Shutdown` frame on a fresh connection.
+        // `HostVmRequest::Shutdown` frame on a fresh connection.
         let Some(listen_fd) = open_dispatch_listener_fd(None) else {
             eprintln!("mvm-builder-init: dispatch loop: listener setup failed");
             return 1;
@@ -979,7 +979,7 @@ mod linux {
                 }
             };
             match request {
-                crate::builder_request::BuilderRequest::Run {
+                crate::builder_request::HostVmRequest::Run {
                     job_id,
                     job,
                     job_dir_relpath,
@@ -995,7 +995,7 @@ mod linux {
                         eprintln!("mvm-builder-init: dispatch loop: write Result failed mid-frame");
                     }
                 }
-                crate::builder_request::BuilderRequest::Shutdown => {
+                crate::builder_request::HostVmRequest::Shutdown => {
                     eprintln!("mvm-builder-init: dispatch loop: shutdown requested");
                     let bye = crate::dispatch_response::bye_json();
                     if !write_frame(&mut conn, bye.as_bytes()) {
@@ -1094,9 +1094,9 @@ mod linux {
 
     /// Run one dispatched job: locate cmd.sh under
     /// `/job/<job_dir_relpath>/cmd.sh`, exec it, stream every
-    /// stderr line back to `conn` as a `BuilderResponse::StderrChunk`
+    /// stderr line back to `conn` as a `HostVmResponse::StderrChunk`
     /// frame, capture the exit code + stderr tail. Returns the wire
-    /// JSON for the final `BuilderResponse::Result` ready to frame
+    /// JSON for the final `HostVmResponse::Result` ready to frame
     /// and write back.
     ///
     /// `conn` is the same vsock connection the request arrived on;
@@ -1889,15 +1889,15 @@ mod linux {
     /// Plan 89 W3 part 9 — same as [`run_job`] but invokes
     /// `on_line` for each stderr line as it arrives. Used by the
     /// persistent dispatch loop to frame each line as a
-    /// `BuilderResponse::StderrChunk` and write it to the active
-    /// vsock conn before the final `BuilderResponse::Result`. The
+    /// `HostVmResponse::StderrChunk` and write it to the active
+    /// vsock conn before the final `HostVmResponse::Result`. The
     /// callback runs on this thread between line reads, so a slow
     /// host can backpressure the build's stderr stream — the
     /// host's vsock conn is the natural rate-limiter and we don't
     /// need a separate buffer thread.
     ///
     /// The trailing `\n` is stripped from each line (the typed
-    /// `BuilderResponse::StderrChunk` docs commit to that).
+    /// `HostVmResponse::StderrChunk` docs commit to that).
     /// `STDERR_TAIL_LINES` of trailing context is still buffered
     /// for the final Result frame's `stderr_tail`, matching the
     /// single-shot path's contract.

--- a/crates/mvm-cli/src/commands/build/mod.rs
+++ b/crates/mvm-cli/src/commands/build/mod.rs
@@ -6,12 +6,12 @@
 pub(super) mod build;
 pub(super) mod compile;
 /// Plan 89 W3 part 5 — `mvmctl persistent-builder` user-facing
-/// verb. Wires the host-side `LibkrunPersistentBuilderVm` and
+/// verb. Wires the host-side `LibkrunPersistentHostVm` and
 /// `PersistentBuilderSupervisor` together via three subcommands
 /// (start / submit / stop) so contributors can exercise the
 /// dispatch path end-to-end without going through `mvmctl dev up`.
 /// Gated on the `builder-vm` feature because the host-side types
-/// it dispatches into (`LibkrunPersistentBuilderVm` etc.) only
+/// it dispatches into (`LibkrunPersistentHostVm` etc.) only
 /// exist with that feature — `mvm-cli`'s default features include
 /// it, so production builds always have this verb.
 #[cfg(feature = "builder-vm")]

--- a/crates/mvm-cli/src/commands/build/persistent_builder.rs
+++ b/crates/mvm-cli/src/commands/build/persistent_builder.rs
@@ -1,7 +1,7 @@
 //! Plan 89 W3 part 5 — `mvmctl persistent-builder` CLI verb.
 //!
 //! Wires the W3 parts 1-4 pieces (host-side
-//! `LibkrunPersistentBuilderVm` + `PersistentBuilderSupervisor`
+//! `LibkrunPersistentHostVm` + `PersistentBuilderSupervisor`
 //! + the in-guest dispatch loop) into a user-facing command.
 //! Three subcommands:
 //!
@@ -10,9 +10,9 @@
 //!   subsequent `submit` / `stop` calls find it.
 //! - **`submit --flake <path>`** — dispatches one
 //!   `BuilderJob::Flake` into the running VM, blocks for the
-//!   `BuilderResponse::Result`, prints the outcome. Re-stages
+//!   `HostVmResponse::Result`, prints the outcome. Re-stages
 //!   `cmd.sh` under the running VM's job dir per-call.
-//! - **`stop`** — sends `BuilderRequest::Shutdown` to the dispatch
+//! - **`stop`** — sends `HostVmRequest::Shutdown` to the dispatch
 //!   loop, waits for the supervisor child to exit cleanly.
 //!
 //! This is deliberately separate from `mvmctl dev up`. Plan 89's
@@ -20,7 +20,7 @@
 //! supervisor) lands in a follow-up to avoid colliding with the
 //! ur-seed work in flight on `mvmctl dev`. Once both stacks are
 //! merged, `mvmctl dev up` becomes a thin caller of the same
-//! `LibkrunPersistentBuilderVm::start()` this verb invokes.
+//! `LibkrunPersistentHostVm::start()` this verb invokes.
 //!
 //! ## Session state
 //!
@@ -45,10 +45,10 @@ use anyhow::{Context, Result, bail};
 use clap::{Args as ClapArgs, Subcommand};
 use serde::{Deserialize, Serialize};
 
-use mvm_build::builder_protocol::BuilderResponseRead;
+use mvm_build::builder_protocol::HostVmResponseRead;
 use mvm_build::builder_vm::BuilderJob;
 use mvm_build::libkrun_builder::{
-    DISPATCH_SOCK_MARKER, LibkrunPersistentBuilderVm, PersistentVmHandle,
+    DISPATCH_SOCK_MARKER, LibkrunPersistentHostVm, PersistentVmHandle,
 };
 use mvm_build::persistent_builder::{DispatchOutcome, PersistentBuilderSupervisor};
 
@@ -69,7 +69,7 @@ pub enum Sub {
     /// Dispatch one flake build into the running persistent VM
     /// and print the outcome.
     Submit(SubmitArgs),
-    /// Send `BuilderRequest::Shutdown` to the persistent VM and
+    /// Send `HostVmRequest::Shutdown` to the persistent VM and
     /// wait for it to power off cleanly.
     Stop(StopArgs),
     /// Print the current session record (if any).
@@ -188,10 +188,10 @@ fn run_start(args: StartArgs) -> Result<()> {
         None => std::env::current_dir().context("resolving current dir for --workspace")?,
     };
 
-    let vm = LibkrunPersistentBuilderVm::new(&workspace);
+    let vm = LibkrunPersistentHostVm::new(&workspace);
     let handle = vm
         .start()
-        .context("spawning persistent builder VM (LibkrunPersistentBuilderVm::start)")?;
+        .context("spawning persistent builder VM (LibkrunPersistentHostVm::start)")?;
 
     let supervisor_pid = handle_pid(&handle);
     let record = SessionRecord {
@@ -557,7 +557,7 @@ fn handle_pid(handle: &PersistentVmHandle) -> u32 {
 #[allow(dead_code)]
 const _MARKER_CONST: &str = DISPATCH_SOCK_MARKER;
 #[allow(dead_code)]
-fn _force_read_use(r: BuilderResponseRead) -> BuilderResponseRead {
+fn _force_read_use(r: HostVmResponseRead) -> HostVmResponseRead {
     r
 }
 

--- a/crates/mvm-core/src/policy/security.rs
+++ b/crates/mvm-core/src/policy/security.rs
@@ -107,7 +107,7 @@ pub struct SessionHelloAck {
 /// (`SecurityPolicy::dev_defaults`).
 ///
 /// **Builder uses a different protocol.** `mvm-builder-agent`'s wire
-/// type is `BuilderRequest`, not `GuestRequest`; the `Builder`
+/// type is `HostVmRequest`, not `GuestRequest`; the `Builder`
 /// profile is reserved for any future `GuestRequest` variant that
 /// only makes sense during a build. No current variant is
 /// `BuilderOnly`, so the value is wire-stable but unused for the
@@ -124,7 +124,7 @@ pub enum AgentProfile {
     Dev,
     /// Builder-VM agent. Reserved for `BuilderOnly`-classified verbs
     /// when the builder protocol moves to `GuestRequest`; today the
-    /// builder agent speaks `BuilderRequest` exclusively.
+    /// builder agent speaks `HostVmRequest` exclusively.
     Builder,
 }
 

--- a/crates/mvm-guest/README.md
+++ b/crates/mvm-guest/README.md
@@ -7,7 +7,7 @@ Vsock protocol definitions and integration management for guest-side agents runn
 | Module | Purpose |
 |--------|---------|
 | `vsock` | Guest control protocol: `GuestRequest`/`GuestResponse`, host-bound protocol: `HostBoundRequest`/`HostBoundResponse` |
-| `builder_agent` | Ephemeral builder VM protocol: `BuilderRequest`/`BuilderResponse` |
+| `builder_agent` | Host-VM dispatch protocol: `HostVmRequest`/`HostVmResponse` |
 | `integrations` | Integration manifest system: `IntegrationManifest`, `IntegrationEntry`, health checks |
 
 ## Wire Protocol

--- a/crates/mvm-guest/fuzz/Cargo.toml
+++ b/crates/mvm-guest/fuzz/Cargo.toml
@@ -30,7 +30,7 @@ path = ".."
 path = "../../mvm-core"
 
 # Plan 89 W2 — `fuzz_builder_request` covers the
-# `BuilderRequest`/`BuilderResponse` payloads in
+# `HostVmRequest`/`HostVmResponse` payloads in
 # `mvm-build::builder_protocol`. mvm-build depends on mvm-guest, so
 # this is fine direction-wise; the fuzz crate is already detached
 # from the workspace (see [workspace] above).

--- a/crates/mvm-guest/fuzz/fuzz_targets/fuzz_builder_request.rs
+++ b/crates/mvm-guest/fuzz/fuzz_targets/fuzz_builder_request.rs
@@ -2,12 +2,12 @@
 //
 // Mirror of fuzz_guest_request.rs / fuzz_authenticated_frame.rs:
 // arbitrary bytes are fed straight into
-// `serde_json::from_slice::<BuilderRequest>` and
-// `serde_json::from_slice::<BuilderResponse>`. We're asserting only
+// `serde_json::from_slice::<HostVmRequest>` and
+// `serde_json::from_slice::<HostVmResponse>`. We're asserting only
 // that the deserializer never panics — every parse failure must be a
 // typed `serde_json::Error`, not an unwind. The signed-envelope layer
 // (`AuthenticatedFrame`) is fuzzed separately by fuzz_authed_path.rs;
-// this target covers only the inner BuilderRequest / BuilderResponse
+// this target covers only the inner HostVmRequest / HostVmResponse
 // payloads.
 //
 // The seed corpus directory at
@@ -23,9 +23,9 @@
 #![no_main]
 
 use libfuzzer_sys::fuzz_target;
-use mvm_build::builder_protocol::{BuilderRequest, BuilderResponse};
+use mvm_build::builder_protocol::{HostVmRequest, HostVmResponse};
 
 fuzz_target!(|data: &[u8]| {
-    let _ = serde_json::from_slice::<BuilderRequest>(data);
-    let _ = serde_json::from_slice::<BuilderResponse>(data);
+    let _ = serde_json::from_slice::<HostVmRequest>(data);
+    let _ = serde_json::from_slice::<HostVmResponse>(data);
 });

--- a/crates/mvm-guest/src/bin/mvm-builder-agent.rs
+++ b/crates/mvm-guest/src/bin/mvm-builder-agent.rs
@@ -4,7 +4,7 @@ use std::os::fd::{FromRawFd, RawFd};
 use std::process::{Command, Stdio};
 
 use mvm_guest::builder_agent::{
-    BuilderRequest, BuilderResponse, load_security_policy, validate_build_attr, validate_flake_ref,
+    HostVmRequest, HostVmResponse, load_security_policy, validate_build_attr, validate_flake_ref,
 };
 
 const AF_VSOCK: i32 = 40;
@@ -44,12 +44,12 @@ fn handle_client(fd: RawFd) {
                 if line_trim.is_empty() {
                     continue;
                 }
-                let req = match serde_json::from_str::<BuilderRequest>(line_trim) {
+                let req = match serde_json::from_str::<HostVmRequest>(line_trim) {
                     Ok(req) => req,
                     Err(e) => {
                         write_resp(
                             &mut reader,
-                            BuilderResponse::Err {
+                            HostVmResponse::Err {
                                 message: format!("parse error: {}", e),
                             },
                         );
@@ -58,10 +58,10 @@ fn handle_client(fd: RawFd) {
                 };
 
                 match req {
-                    BuilderRequest::Ping => {
-                        write_resp(&mut reader, BuilderResponse::Pong);
+                    HostVmRequest::Ping => {
+                        write_resp(&mut reader, HostVmResponse::Pong);
                     }
-                    BuilderRequest::Build {
+                    HostVmRequest::Build {
                         flake_ref,
                         attr,
                         timeout_secs,
@@ -72,7 +72,7 @@ fn handle_client(fd: RawFd) {
                         {
                             write_resp(
                                 &mut reader,
-                                BuilderResponse::Err {
+                                HostVmResponse::Err {
                                     message: "build rejected: access.build is disabled by security policy".to_string(),
                                 },
                             );
@@ -83,7 +83,7 @@ fn handle_client(fd: RawFd) {
                         if let Err(e) = validate_flake_ref(&flake_ref) {
                             write_resp(
                                 &mut reader,
-                                BuilderResponse::Err {
+                                HostVmResponse::Err {
                                     message: format!("invalid flake_ref: {}", e),
                                 },
                             );
@@ -94,7 +94,7 @@ fn handle_client(fd: RawFd) {
                         if let Err(e) = validate_build_attr(&attr) {
                             write_resp(
                                 &mut reader,
-                                BuilderResponse::Err {
+                                HostVmResponse::Err {
                                     message: format!("invalid build attr: {}", e),
                                 },
                             );
@@ -105,7 +105,7 @@ fn handle_client(fd: RawFd) {
                         if let Err(e) = run_build(&mut reader, &flake_ref, &attr, timeout) {
                             write_resp(
                                 &mut reader,
-                                BuilderResponse::Err {
+                                HostVmResponse::Err {
                                     message: format!("agent error: {}", e),
                                 },
                             );
@@ -118,7 +118,7 @@ fn handle_client(fd: RawFd) {
     }
 }
 
-fn write_resp(reader: &mut BufReader<std::fs::File>, resp: BuilderResponse) {
+fn write_resp(reader: &mut BufReader<std::fs::File>, resp: HostVmResponse) {
     let writer = reader.get_mut();
     if let Err(e) = writeln!(
         writer,
@@ -147,11 +147,11 @@ fn ensure_mount(
     if !output.status.success() {
         let stderr = String::from_utf8_lossy(&output.stderr);
         let msg = format!("mount {} -> {} failed: {}", dev, mountpoint, stderr);
-        write_resp(reader, BuilderResponse::Log { line: msg.clone() });
+        write_resp(reader, HostVmResponse::Log { line: msg.clone() });
         return Err(anyhow::anyhow!("{}", msg));
     }
     let msg = format!("mounted {} -> {}", dev, mountpoint);
-    write_resp(reader, BuilderResponse::Log { line: msg });
+    write_resp(reader, HostVmResponse::Log { line: msg });
     Ok(())
 }
 
@@ -212,7 +212,7 @@ fn ensure_nix(reader: &mut BufReader<std::fs::File>) -> anyhow::Result<()> {
 
     write_resp(
         reader,
-        BuilderResponse::Log {
+        HostVmResponse::Log {
             line: "Nix not found, installing (single-user)...".to_string(),
         },
     );
@@ -230,7 +230,7 @@ fn ensure_nix(reader: &mut BufReader<std::fs::File>) -> anyhow::Result<()> {
     for line in &lines[start..] {
         write_resp(
             reader,
-            BuilderResponse::Log {
+            HostVmResponse::Log {
                 line: format!("[nix-install] {}", line),
             },
         );
@@ -249,7 +249,7 @@ fn ensure_nix(reader: &mut BufReader<std::fs::File>) -> anyhow::Result<()> {
     match find_nix_bin() {
         Some(path) => {
             let msg = format!("Nix installed at {}", path);
-            write_resp(reader, BuilderResponse::Log { line: msg });
+            write_resp(reader, HostVmResponse::Log { line: msg });
         }
         None => {
             // Log what we can find in /nix for diagnostics.
@@ -307,7 +307,7 @@ fn run_build(
     let nix_path = nix_path_prefix();
     write_resp(
         reader,
-        BuilderResponse::Log {
+        HostVmResponse::Log {
             line: format!("nix PATH: {}", nix_path),
         },
     );
@@ -349,7 +349,7 @@ fn run_build(
             last_store_path = Some(line.clone());
         }
         log_lines.push(line.clone());
-        write_resp(reader, BuilderResponse::Log { line });
+        write_resp(reader, HostVmResponse::Log { line });
     }
 
     let status = child.wait()?;
@@ -389,7 +389,7 @@ fn run_build(
     if let Err(e) = std::fs::write("/build-out/build.log", log_lines.join("\n")) {
         eprintln!("failed to write build log: {e}");
     }
-    write_resp(reader, BuilderResponse::Ok { out_path });
+    write_resp(reader, HostVmResponse::Ok { out_path });
     Ok(())
 }
 

--- a/crates/mvm-guest/src/builder_agent.rs
+++ b/crates/mvm-guest/src/builder_agent.rs
@@ -6,7 +6,7 @@ use serde::{Deserialize, Serialize};
 
 /// Incoming request from host to the builder agent (guest side, via vsock/serial).
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
-pub enum BuilderRequest {
+pub enum HostVmRequest {
     /// Build a flake attribute with an optional timeout (seconds).
     Build {
         flake_ref: String,
@@ -22,7 +22,7 @@ pub const BUILDER_AGENT_PORT: u32 = 21470;
 
 /// Vsock port used by Plan 89's persistent builder VM dispatch
 /// channel. Separate from [`BUILDER_AGENT_PORT`] (the legacy guest-
-/// listener used by [`BuilderRequest::Build`] / [`BuilderRequest::Ping`]
+/// listener used by [`HostVmRequest::Build`] / [`HostVmRequest::Ping`]
 /// above) because the Plan 89 wire (`mvm_build::builder_protocol`)
 /// is a different protocol with different semantics — the two
 /// channels coexist while the legacy path is in use elsewhere.
@@ -30,13 +30,13 @@ pub const BUILDER_AGENT_PORT: u32 = 21470;
 /// W2 part 2: this port is added to the libkrun builder VM's vsock
 /// config; the host opens the corresponding Unix-socket-proxy at
 /// `<vm_state_dir>/vsock-21471.sock` to receive
-/// [`mvm_build::builder_protocol::BuilderResponse`] frames from the
+/// [`mvm_build::builder_protocol::HostVmResponse`] frames from the
 /// guest. The guest-side send code lands in W2 part 3.
 pub const BUILDER_DISPATCH_PORT: u32 = 21471;
 
 /// Outgoing responses/log frames from the builder agent.
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
-pub enum BuilderResponse {
+pub enum HostVmResponse {
     /// Build succeeded; artifact root placed in /build-out.
     Ok { out_path: String },
     /// Build failed.
@@ -114,17 +114,17 @@ pub fn load_security_policy() -> Result<Option<mvm_core::security::SecurityPolic
     Ok(Some(policy))
 }
 
-fn log_frame(line: &str) -> BuilderResponse {
-    BuilderResponse::Log {
+fn log_frame(line: &str) -> HostVmResponse {
+    HostVmResponse::Log {
         line: line.to_string(),
     }
 }
 
 /// Run the requested build using nix inside the guest and stage artifacts into /build-out.
-pub fn handle_request(req: BuilderRequest) -> Result<BuilderResponse> {
+pub fn handle_request(req: HostVmRequest) -> Result<HostVmResponse> {
     match req {
-        BuilderRequest::Ping => Ok(BuilderResponse::Pong),
-        BuilderRequest::Build {
+        HostVmRequest::Ping => Ok(HostVmResponse::Pong),
+        HostVmRequest::Build {
             flake_ref,
             attr,
             timeout_secs,
@@ -133,7 +133,7 @@ pub fn handle_request(req: BuilderRequest) -> Result<BuilderResponse> {
 
             let out_mount = Path::new("/build-out");
             if !out_mount.is_dir() {
-                return Ok(BuilderResponse::Err {
+                return Ok(HostVmResponse::Err {
                     message: "/build-out missing or not a directory".into(),
                 });
             }
@@ -172,7 +172,7 @@ pub fn handle_request(req: BuilderRequest) -> Result<BuilderResponse> {
             }
 
             if !output.status.success() {
-                return Ok(BuilderResponse::Err {
+                return Ok(HostVmResponse::Err {
                     message: format!("nix build failed (exit {}): {}", output.status, build_cmd),
                 });
             }
@@ -200,12 +200,12 @@ pub fn handle_request(req: BuilderRequest) -> Result<BuilderResponse> {
                 .output()
                 .with_context(|| "failed to copy build artifacts")?;
             if !copy_out.status.success() {
-                return Ok(BuilderResponse::Err {
+                return Ok(HostVmResponse::Err {
                     message: format!("failed to copy artifacts: exit {}", copy_out.status),
                 });
             }
 
-            Ok(BuilderResponse::Ok { out_path })
+            Ok(HostVmResponse::Ok { out_path })
         }
     }
 }
@@ -216,13 +216,13 @@ mod tests {
 
     #[test]
     fn serde_round_trip() {
-        let req = BuilderRequest::Build {
+        let req = HostVmRequest::Build {
             flake_ref: ".".into(),
             attr: "packages.aarch64-linux.tenant-worker".into(),
             timeout_secs: Some(123),
         };
         let json = serde_json::to_string(&req).unwrap();
-        let back: BuilderRequest = serde_json::from_str(&json).unwrap();
+        let back: HostVmRequest = serde_json::from_str(&json).unwrap();
         assert_eq!(req, back);
     }
 

--- a/crates/mvm-guest/src/vsock.rs
+++ b/crates/mvm-guest/src/vsock.rs
@@ -730,7 +730,7 @@ impl GuestRequest {
     /// - `SealedProd` allows only `ProdSafe`.
     /// - `Dev` allows `ProdSafe` and `DevOnly` (a superset).
     /// - `Builder` allows only `BuilderOnly` — today the builder
-    ///   agent speaks `BuilderRequest`, so `GuestRequest` reaching
+    ///   agent speaks `HostVmRequest`, so `GuestRequest` reaching
     ///   a `Builder`-profile agent is a configuration error.
     pub fn allowed_in(&self, profile: AgentProfile) -> bool {
         matches!(

--- a/specs/plans/107-plan-100-w6-approach-a.md
+++ b/specs/plans/107-plan-100-w6-approach-a.md
@@ -47,31 +47,82 @@ Goal: split the persistent-VM framing layer so the same long-lived
 libkrun VM can serve Nix builds (existing) and Firecracker workload
 spawns (new).
 
-- [ ] **A1.1** Extract a `HostVmRequest` / `HostVmResponse` framing
+Split into two PRs (discovered during A1 implementation — the crate
+rename in A1.3 turned out to drag the Stage 0 byte-scan + kernel
+cmdline path migration along with it, materially heavier than the
+protocol rename. A1a ships the cheap half today; A1b ships the
+Stage 0 migration on its own with full attention).
+
+#### A1a — Protocol type rename + struct rename
+
+- [x] **A1.1** Extract a `HostVmRequest` / `HostVmResponse` framing
       layer from `crates/mvm-build/src/builder_protocol.rs`. Today's
       `BuilderRequest::Run { job }` becomes one variant of a
       backend-agnostic message; add `WorkloadStart`, `WorkloadStop`,
       `WorkloadStatus` siblings (payload shapes deferred to A2.2).
-- [ ] **A1.2** Generalise `LibkrunPersistentBuilderVm` →
+      Adds a `WorkloadId` newtype mirroring `JobId`.
+- [x] **A1.2** Generalise `LibkrunPersistentBuilderVm` →
       `LibkrunPersistentHostVm`. Location: keep in `mvm-build` for
       this slice (cheapest); revisit splitting into a dedicated
       `mvm-host-vm` crate in A5 if the API surface grows beyond
       what fits next to the builder code. Hard rename per the
       no-backcompat memory — no `LibkrunPersistentBuilderVm`
       alias.
-- [ ] **A1.3** Rename `mvm-builder-init` → `mvm-host-vm-init`. The
-      guest-side dispatch loop branches on request kind: Nix builds
-      (existing arm, unchanged behaviour) vs. workload spawn (new
-      arm, stubbed with `unimplemented!()` until A2.2 fills it in).
-- [ ] **A1.4** Hermetic protocol tests — same shape as Plan 89's
+- [x] **A1.4** Hermetic protocol tests — same shape as Plan 89's
       builder-protocol round-trip tests, extended for the workload
       variants. Tampered-frame rejection paths included
-      (`#[serde(deny_unknown_fields)]` carries over).
+      (`#[serde(deny_unknown_fields)]` carries over). 9 new tests
+      covering `WorkloadId` serialization, all 6 new
+      request/response variants round-tripping, wire-kind tag
+      stability, and `deny_unknown_fields` rejection on new
+      variants.
 
-Exit: a `cargo test --workspace` green PR that adds the new
-variants without changing runtime behaviour. The new arm in
-`mvm-host-vm-init` is a stub; existing Nix-build flow round-trips
-identically through the renamed protocol.
+Exit (A1a): `cargo test --workspace` green; existing Nix-build
+flow round-trips identically through the renamed protocol; new
+workload variants reachable through the type system. Guest-side
+dispatch arm for workloads lands with A1b's crate rename.
+
+#### A1b — Crate rename `mvm-builder-init` → `mvm-host-vm-init` <a id="a1b-rationale"></a>
+
+The crate's binary name `mvm-builder-init` is baked into the Stage
+0 rootfs at `/sbin/mvm-builder-init`. Several host code paths scan
+the rootfs for that exact byte sequence to validate Stage 0
+compatibility (`crates/mvm-cli/src/commands/env/apple_container.rs`
+lines 24, 1047, 1122, 2268, 2317, 2562, 2744). Renaming the binary
+in lockstep means:
+
+- Kernel cmdline `init=/sbin/mvm-builder-init` changes everywhere
+  it appears.
+- Host rootfs-scan byte strings change at all seven call sites
+  above.
+- All cached rootfs images become Stage 0-incompatible until
+  rebuilt — `mvmctl dev up` users see a fail-closed rebuild prompt
+  on first run after upgrade.
+
+- [ ] **A1.3.crate** Rename crate dir + `Cargo.toml` `package.name`
+      + `[[bin]] name` + workspace members entry. Update
+      `mvm_builder_init` → `mvm_host_vm_init` across all Rust
+      imports (~30 call sites).
+- [ ] **A1.3.stage0** Update the Stage 0 byte-scan constants +
+      kernel cmdline + rootfs path everywhere — seven sites in
+      `apple_container.rs` plus any other `/sbin/mvm-builder-init`
+      literal in the tree.
+- [ ] **A1.3.nix** Update Nix flakes that copy the binary into
+      the rootfs: `nix/lib/mk-guest.nix`,
+      `nix/images/builder/flake.nix`,
+      `nix/images/builder-vm/flake.nix`.
+- [ ] **A1.3.ci** Update `.github/workflows/ci.yml` paths.
+- [ ] **A1.3.docs** Update `CLAUDE.md` and any spec docs that
+      reference the active surface (not historical specs).
+- [ ] **A1.3.guest-arm** Guest-side dispatch loop branches on
+      request kind: Nix builds (existing arm, unchanged behaviour)
+      vs. workload spawn (new arm, stubbed with `unimplemented!()`
+      until A2.2 fills it in).
+
+Exit (A1b): `cargo test --workspace` green; `mvmctl dev up` boots
+a freshly-built rootfs through the renamed binary; cached
+pre-rename rootfs images fail-closed with an actionable rebuild
+prompt; live-KVM smoke (cold) green.
 
 ### Phase A2 — Firecracker-in-guest launch path
 


### PR DESCRIPTION
## Summary

Plan 107 A1a — generalises the long-lived host VM's vsock dispatch
channel so the same persistent libkrun VM can serve both Nix build
dispatches (existing) and Firecracker workload spawns (Plan 100 W6's
nested execution path, landing in A2.2).

Renames the protocol surface:

- `BuilderRequest` / `BuilderResponse` → `HostVmRequest` / `HostVmResponse` (wire-format variant tags unchanged: `run`, `shutdown`, `stderr_chunk`, `result`, `bye`).
- `BuilderResponseRead` → `HostVmResponseRead`; `read_builder_response*` → `read_host_vm_response*`; `write_builder_response` → `write_host_vm_response`.
- `LibkrunPersistentBuilderVm` → `LibkrunPersistentHostVm` (struct + impl). Hard rename per the no-backcompat memory; no alias, no shim.

Adds the workload dispatch surface (stubs — payloads grow in A2.2):

- `WorkloadId(Uuid)` newtype mirroring `JobId`.
- `HostVmRequest::{WorkloadStart, WorkloadStop, WorkloadStatus}` — payloads carry only `workload_id` today.
- `HostVmResponse::{WorkloadStarted, WorkloadStopped, WorkloadStatusReport}` — same shape.
- `#[serde(deny_unknown_fields)]` on every new variant so A2.2's payload extensions enforce lockstep upgrade.
- `persistent_builder` build-job dispatch loop gets explicit arms for the new workload responses, treated as protocol violations on the build channel (the workload response stream is A3's nesting hop, not this socket).

9 new hermetic tests in `builder_protocol::tests` (round-trip + wire-tag-stability + deny_unknown_fields rejection for the new variants). Total protocol test count now 29, all green locally.

## Scope guard — A1.3 deferred to A1b

The original A1 description bundled the `mvm-builder-init` crate rename (→ `mvm-host-vm-init`) with the protocol rename. During implementation it surfaced that the crate's binary name is baked into the Stage 0 rootfs at `/sbin/mvm-builder-init` and scanned byte-for-byte by host code at seven call sites in `apple_container.rs` to validate Stage 0 compatibility. The crate rename therefore drags the Stage 0 byte-scan + kernel cmdline path migration with it and would invalidate every cached rootfs image.

Plan 107 amended in this PR to split A1 → A1a (this PR — protocol + struct rename, low-risk) + A1b (follow-up — crate rename + Stage 0 migration, focused PR).

## Test plan

- [x] `cargo check --workspace` green
- [x] `cargo clippy --workspace --all-targets -- -D warnings` green
- [x] `cargo test -p mvm-build --lib builder_protocol::` — 29/29 pass
- [x] `cargo test --workspace --no-fail-fast` — 2 pre-existing flakes unrelated to this surface (`apple_container::dev_status_image_tests::status_image_reports_versioned_prebuilt_when_current_missing` reads from real `~/.mvm/dev/current/` instead of test tmp dir; `lifecycle_hooks::tests::poll_readiness_succeeds_after_initial_failures` is a script-timing sensitivity). My diff is mechanical type renames + new pure variants + new tests, categorically incapable of breaking ext4 probing or guest lifecycle polling.

🤖 Generated with [Claude Code](https://claude.com/claude-code)