### PR TITLE
Plan 107 A2.1+A2.2+A2.3 — Firecracker-in-guest launch path

### DIFF
--- a/crates/mvm-build/src/builder_protocol.rs
+++ b/crates/mvm-build/src/builder_protocol.rs
@@ -160,22 +160,44 @@ pub enum HostVmRequest {
     /// shape is identical (`{"kind":"shutdown"}`).
     Shutdown {},
 
-    /// Plan 107 W6 / A2 — start a Firecracker workload microVM
-    /// inside the host VM. Stubbed in A1; the guest-side dispatch
-    /// arm panics with `unimplemented!()` until A2.2 fills in the
-    /// payload (workload kernel + rootfs paths, vsock socket dir,
-    /// vcpus, memory, kernel cmdline extras) and the guest-side
-    /// Firecracker spawn.
+    /// Plan 107 W6 / A2.2 — start a workload microVM inside the
+    /// host VM. The guest's dispatch loop hands this to a
+    /// `WorkloadVmm` backend (Firecracker today; the fields are
+    /// generic microVM concepts, not Firecracker-shaped, so a
+    /// second VMM is a pure addition — see
+    /// `mvm-host-vm-init/src/workload.rs`).
     ///
-    /// The payload carries only the [`WorkloadId`] today so that
-    /// (a) the protocol round-trips end-to-end and (b) A2.2's
-    /// payload extension is additive — `#[serde(deny_unknown_fields)]`
-    /// will reject the A2.2 fields until both sides upgrade in
-    /// lockstep, which is the intended fail-closed behaviour.
+    /// All paths are resolved *inside the host VM* (the guest), not
+    /// on the outer host: `kernel_path` / `rootfs_path` point at
+    /// files the host already staged into a share the guest can
+    /// see, and `vsock_socket_dir` is where the guest creates the
+    /// per-workload state dir + vsock UDS.
     WorkloadStart {
         /// Host-minted identifier the guest echoes in
-        /// [`HostVmResponse::WorkloadStarted`].
+        /// [`HostVmResponse::WorkloadStarted`] and keys the
+        /// per-workload state dir on.
         workload_id: WorkloadId,
+        /// Absolute path (inside the host VM) to the workload
+        /// kernel image the VMM boots.
+        kernel_path: String,
+        /// Absolute path (inside the host VM) to the workload root
+        /// filesystem image, attached as the single root drive.
+        rootfs_path: String,
+        /// Directory (inside the host VM) under which the guest
+        /// creates the workload's vsock UDS. The per-workload state
+        /// dir is derived from `workload_id`; this is the parent
+        /// the VMM's vsock socket lands in.
+        vsock_socket_dir: String,
+        /// Number of vCPUs for the workload microVM.
+        vcpus: u32,
+        /// Guest RAM for the workload microVM, in MiB.
+        memory_mib: u32,
+        /// Extra kernel command-line tokens appended to the VMM's
+        /// base cmdline. The host supplies `root=` / `init=` /
+        /// dm-verity roothash here. A single space-joined string
+        /// (not `Vec<String>`) so the guest's no-serde hand-rolled
+        /// parser stays simple.
+        kernel_cmdline_extras: String,
     },
 
     /// Plan 107 W6 / A2 — stop a running workload microVM. Stubbed
@@ -257,31 +279,45 @@ pub enum HostVmResponse {
     /// something to enforce against.
     Bye {},
 
-    /// Plan 107 W6 / A2 — acknowledgement that a workload microVM
-    /// has booted inside the host VM. Stubbed in A1; A2.2 will
-    /// extend the payload with the workload's vsock CID + first-byte
-    /// readiness timing.
+    /// Plan 107 W6 / A2.2 — acknowledgement that a workload microVM
+    /// has been spawned inside the host VM.
     WorkloadStarted {
         /// Echo of the originating [`HostVmRequest::WorkloadStart::workload_id`].
         workload_id: WorkloadId,
+        /// PID of the spawned VMM process *inside the host VM*. The
+        /// host tracks it for the A4 lifecycle (stop / status /
+        /// crash recovery).
+        pid: u32,
     },
 
-    /// Plan 107 W6 / A2 — acknowledgement that a workload microVM
-    /// has shut down. Stubbed in A1.
+    /// Plan 107 W6 / A2.2 — acknowledgement that a workload microVM
+    /// has shut down and its state dir was cleaned up.
     WorkloadStopped {
         /// Echo of the originating [`HostVmRequest::WorkloadStop::workload_id`].
         workload_id: WorkloadId,
     },
 
-    /// Plan 107 W6 / A2 — workload lifecycle status report. Stubbed
-    /// in A1; A2.2 will replace the placeholder string with a typed
-    /// `WorkloadState` enum (`Booting` / `Running` / `Exited { code }`
-    /// / `Unknown`).
+    /// Plan 107 W6 / A2.2 — workload lifecycle status report.
     WorkloadStatusReport {
         /// Echo of the originating [`HostVmRequest::WorkloadStatus::workload_id`].
         workload_id: WorkloadId,
-        /// Placeholder string — A2.2 replaces with a typed enum.
+        /// One of `"running"`, `"stopped"`, `"not_found"`. A typed
+        /// enum is deferred until the host actually consumes the
+        /// distinction (A4); the closed string set is asserted by
+        /// the guest-side emitter tests.
         status: String,
+    },
+
+    /// Plan 107 W6 / A2.2 — a workload lifecycle operation failed.
+    /// Fail-closed negative path: the guest always sends a typed
+    /// frame (spawn error, state-dir collision, parse failure)
+    /// rather than dropping the connection, so the host can
+    /// distinguish a real failure from a transport EOF.
+    WorkloadFailed {
+        /// Echo of the originating request's `workload_id`.
+        workload_id: WorkloadId,
+        /// Human-readable failure reason for logs / surfacing.
+        error: String,
     },
 }
 
@@ -549,12 +585,18 @@ mod tests {
         });
     }
 
-    // Plan 107 A1 — workload variant round-trips. Stubbed payloads
-    // today; A2.2 extends with the real Firecracker spawn config.
+    // Plan 107 A2.2 — workload variant round-trips with the real
+    // spawn config payload.
 
     fn sample_workload_start() -> HostVmRequest {
         HostVmRequest::WorkloadStart {
             workload_id: WorkloadId(Uuid::nil()),
+            kernel_path: "/job/workload/vmlinux".to_string(),
+            rootfs_path: "/job/workload/rootfs.ext4".to_string(),
+            vsock_socket_dir: "/var/lib/mvm/workloads".to_string(),
+            vcpus: 2,
+            memory_mib: 1024,
+            kernel_cmdline_extras: "root=/dev/vda ro init=/init".to_string(),
         }
     }
 
@@ -588,6 +630,7 @@ mod tests {
     fn host_vm_response_workload_started_roundtrips() {
         roundtrip(&HostVmResponse::WorkloadStarted {
             workload_id: WorkloadId(Uuid::nil()),
+            pid: 4242,
         });
     }
 
@@ -602,7 +645,15 @@ mod tests {
     fn host_vm_response_workload_status_report_roundtrips() {
         roundtrip(&HostVmResponse::WorkloadStatusReport {
             workload_id: WorkloadId(Uuid::nil()),
-            status: "booting".to_string(),
+            status: "running".to_string(),
+        });
+    }
+
+    #[test]
+    fn host_vm_response_workload_failed_roundtrips() {
+        roundtrip(&HostVmResponse::WorkloadFailed {
+            workload_id: WorkloadId(Uuid::nil()),
+            error: "spawn /usr/bin/firecracker: No such file or directory".to_string(),
         });
     }
 
@@ -631,23 +682,38 @@ mod tests {
         );
         assert_eq!(
             serde_json::to_value(HostVmResponse::WorkloadStarted {
-                workload_id: WorkloadId(Uuid::nil())
+                workload_id: WorkloadId(Uuid::nil()),
+                pid: 1,
             })
             .unwrap()["kind"],
             "workload_started"
+        );
+        assert_eq!(
+            serde_json::to_value(HostVmResponse::WorkloadFailed {
+                workload_id: WorkloadId(Uuid::nil()),
+                error: "boom".to_string(),
+            })
+            .unwrap()["kind"],
+            "workload_failed"
         );
     }
 
     #[test]
     fn deny_unknown_fields_rejects_extra_workload_start_field() {
-        // Plan 107 A1: A2.2 will extend WorkloadStart with the real
-        // Firecracker spawn payload (kernel, rootfs, vcpus, memory).
-        // The fail-closed contract is that an old guest seeing a new
-        // host's extended payload rejects with deny_unknown_fields
-        // rather than silently launching with default config.
+        // A *complete* A2.2 payload plus one extra field — exercises
+        // deny_unknown_fields specifically (not a missing-field
+        // error). The fail-closed contract: a future host shipping a
+        // new field against an old guest is rejected rather than
+        // silently launching with the field dropped.
         let bad = serde_json::json!({
             "kind": "workload_start",
             "workload_id": "00000000-0000-0000-0000-000000000000",
+            "kernel_path": "/job/workload/vmlinux",
+            "rootfs_path": "/job/workload/rootfs.ext4",
+            "vsock_socket_dir": "/var/lib/mvm/workloads",
+            "vcpus": 2,
+            "memory_mib": 1024,
+            "kernel_cmdline_extras": "root=/dev/vda ro",
             "future_field": 42,
         });
         let res: Result<HostVmRequest, _> = serde_json::from_value(bad);
@@ -663,12 +729,29 @@ mod tests {
         let bad = serde_json::json!({
             "kind": "workload_started",
             "workload_id": "00000000-0000-0000-0000-000000000000",
+            "pid": 7,
             "future_field": "rogue",
         });
         let res: Result<HostVmResponse, _> = serde_json::from_value(bad);
         assert!(
             res.is_err(),
             "deny_unknown_fields must reject future_field on workload_started, got {:?}",
+            res
+        );
+    }
+
+    #[test]
+    fn deny_unknown_fields_rejects_extra_workload_failed_field() {
+        let bad = serde_json::json!({
+            "kind": "workload_failed",
+            "workload_id": "00000000-0000-0000-0000-000000000000",
+            "error": "boom",
+            "future_field": true,
+        });
+        let res: Result<HostVmResponse, _> = serde_json::from_value(bad);
+        assert!(
+            res.is_err(),
+            "deny_unknown_fields must reject future_field on workload_failed, got {:?}",
             res
         );
     }

--- a/crates/mvm-build/src/persistent_builder.rs
+++ b/crates/mvm-build/src/persistent_builder.rs
@@ -404,15 +404,14 @@ impl PersistentBuilderSupervisor {
                 }
                 Some(HostVmResponse::WorkloadStarted { .. })
                 | Some(HostVmResponse::WorkloadStopped { .. })
-                | Some(HostVmResponse::WorkloadStatusReport { .. }) => {
-                    // Plan 107 A1: workload responses on the build-job
-                    // dispatch path are a protocol violation. The
-                    // guest-side workload arm is `unimplemented!()`
-                    // until A2.2, so this branch cannot fire today;
-                    // when A2 lands, workload responses will flow on a
-                    // dedicated channel (A3 vsock-proxy hop), not this
-                    // one. Treat as premature EOF for now — the host
-                    // can't recover from a wire mismatch.
+                | Some(HostVmResponse::WorkloadStatusReport { .. })
+                | Some(HostVmResponse::WorkloadFailed { .. }) => {
+                    // Plan 107 A2: workload responses on the build-job
+                    // dispatch path are a protocol violation. Workload
+                    // lifecycle responses flow on a dedicated channel
+                    // (A3 vsock-proxy hop), not this build-dispatch
+                    // conn. Treat as premature EOF — the host can't
+                    // recover from a wire mismatch.
                     return Err(PersistentBuilderError::PrematureEof {
                         chunks: stderr_chunks.len(),
                     });

--- a/crates/mvm-host-vm-init/src/builder_request.rs
+++ b/crates/mvm-host-vm-init/src/builder_request.rs
@@ -75,18 +75,24 @@ pub enum HostVmRequest {
         job_dir_relpath: String,
     },
     Shutdown,
-    /// Plan 107 W6 / A2 — start a Firecracker workload microVM
-    /// inside the host VM. Payload carries only the workload id
-    /// today; A2.2 extends with the spawn config (kernel, rootfs,
-    /// vcpus, memory, kernel cmdline extras).
+    /// Plan 107 W6 / A2.2 — start a workload microVM inside the host
+    /// VM. Carries the spawn config the `WorkloadVmm` backend
+    /// (Firecracker today) needs. Fields mirror
+    /// `mvm_build::builder_protocol::HostVmRequest::WorkloadStart`.
     WorkloadStart {
         workload_id: String,
+        kernel_path: String,
+        rootfs_path: String,
+        vsock_socket_dir: String,
+        vcpus: u32,
+        memory_mib: u32,
+        kernel_cmdline_extras: String,
     },
-    /// Plan 107 W6 / A2 — stop a running workload microVM.
+    /// Plan 107 W6 / A2.2 — stop a running workload microVM.
     WorkloadStop {
         workload_id: String,
     },
-    /// Plan 107 W6 / A2 — query a workload microVM's status.
+    /// Plan 107 W6 / A2.2 — query a workload microVM's status.
     WorkloadStatus {
         workload_id: String,
     },
@@ -106,6 +112,11 @@ pub enum ParseError {
     UnknownJobVariant,
     /// `Run.job.<variant>` was missing a required field.
     MissingJobField(&'static str),
+    /// A workload request was missing a required field.
+    MissingWorkloadField(&'static str),
+    /// A numeric workload field (`vcpus` / `memory_mib`) was absent
+    /// or not a base-10 integer.
+    BadNumber(&'static str),
 }
 
 impl fmt::Display for ParseError {
@@ -119,6 +130,12 @@ impl fmt::Display for ParseError {
                 write!(f, "HostVmRequest::Run job is neither Flake nor Install")
             }
             Self::MissingJobField(name) => write!(f, "BuilderJob missing `{name}`"),
+            Self::MissingWorkloadField(name) => {
+                write!(f, "HostVmRequest workload missing `{name}`")
+            }
+            Self::BadNumber(name) => {
+                write!(f, "HostVmRequest workload field `{name}` is not an integer")
+            }
         }
     }
 }
@@ -136,9 +153,7 @@ pub fn parse(bytes: &[u8]) -> Result<HostVmRequest, ParseError> {
     match kind.as_str() {
         "shutdown" => Ok(HostVmRequest::Shutdown),
         "run" => parse_run(text),
-        "workload_start" => parse_workload(text, |workload_id| HostVmRequest::WorkloadStart {
-            workload_id,
-        }),
+        "workload_start" => parse_workload_start(text),
         "workload_stop" => parse_workload(text, |workload_id| HostVmRequest::WorkloadStop {
             workload_id,
         }),
@@ -149,13 +164,44 @@ pub fn parse(bytes: &[u8]) -> Result<HostVmRequest, ParseError> {
     }
 }
 
+/// Parse the id-only workload variants (`workload_stop` /
+/// `workload_status`).
 fn parse_workload(
     text: &str,
     ctor: impl FnOnce(String) -> HostVmRequest,
 ) -> Result<HostVmRequest, ParseError> {
-    let workload_id =
-        find_string_value(text, "workload_id").ok_or(ParseError::MissingRunField("workload_id"))?;
+    let workload_id = find_string_value(text, "workload_id")
+        .ok_or(ParseError::MissingWorkloadField("workload_id"))?;
     Ok(ctor(workload_id))
+}
+
+/// Parse `workload_start`, which carries the full spawn config.
+/// Mirrors `mvm_build::builder_protocol::HostVmRequest::WorkloadStart`.
+fn parse_workload_start(text: &str) -> Result<HostVmRequest, ParseError> {
+    let workload_id = find_string_value(text, "workload_id")
+        .ok_or(ParseError::MissingWorkloadField("workload_id"))?;
+    let kernel_path = find_string_value(text, "kernel_path")
+        .ok_or(ParseError::MissingWorkloadField("kernel_path"))?;
+    let rootfs_path = find_string_value(text, "rootfs_path")
+        .ok_or(ParseError::MissingWorkloadField("rootfs_path"))?;
+    let vsock_socket_dir = find_string_value(text, "vsock_socket_dir")
+        .ok_or(ParseError::MissingWorkloadField("vsock_socket_dir"))?;
+    let vcpus = find_u32_value(text, "vcpus").ok_or(ParseError::BadNumber("vcpus"))?;
+    let memory_mib =
+        find_u32_value(text, "memory_mib").ok_or(ParseError::BadNumber("memory_mib"))?;
+    // `kernel_cmdline_extras` may legitimately be empty, so an empty
+    // string is fine; only a *missing* key is an error.
+    let kernel_cmdline_extras = find_string_value(text, "kernel_cmdline_extras")
+        .ok_or(ParseError::MissingWorkloadField("kernel_cmdline_extras"))?;
+    Ok(HostVmRequest::WorkloadStart {
+        workload_id,
+        kernel_path,
+        rootfs_path,
+        vsock_socket_dir,
+        vcpus,
+        memory_mib,
+        kernel_cmdline_extras,
+    })
 }
 
 fn parse_run(text: &str) -> Result<HostVmRequest, ParseError> {
@@ -227,6 +273,27 @@ fn find_string_value(text: &str, key: &str) -> Option<String> {
         // don't handle it here.
         if let Some(stripped) = rest.strip_prefix('"') {
             return Some(decode_json_string(stripped));
+        }
+        search_from = after;
+    }
+    None
+}
+
+/// Find a JSON unsigned-integer value for the given key. Scans for
+/// `"key":`, skips whitespace, and parses the leading run of ASCII
+/// digits as a `u32`. Returns `None` if the key is absent, the
+/// value isn't a bare number, or it overflows `u32`. Sufficient for
+/// the closed workload payload (`vcpus`, `memory_mib`), which serde
+/// emits as bare JSON numbers.
+fn find_u32_value(text: &str, key: &str) -> Option<u32> {
+    let needle = format!("\"{key}\":");
+    let mut search_from = 0;
+    while let Some(idx) = text[search_from..].find(&needle) {
+        let after = search_from + idx + needle.len();
+        let rest = text[after..].trim_start();
+        let digits: String = rest.chars().take_while(|c| c.is_ascii_digit()).collect();
+        if !digits.is_empty() {
+            return digits.parse::<u32>().ok();
         }
         search_from = after;
     }
@@ -454,5 +521,140 @@ mod tests {
         let json = serde_json::to_vec(&req).expect("serialize");
         let parsed = parse(&json).expect("parse");
         assert_eq!(parsed, HostVmRequest::Shutdown);
+    }
+
+    const SAMPLE_WORKLOAD_START: &str = r#"{"kind":"workload_start","workload_id":"00000000-0000-0000-0000-000000000009","kernel_path":"/job/workload/vmlinux","rootfs_path":"/job/workload/rootfs.ext4","vsock_socket_dir":"/var/lib/mvm/workloads","vcpus":2,"memory_mib":1024,"kernel_cmdline_extras":"root=/dev/vda ro init=/init"}"#;
+
+    #[test]
+    fn parses_workload_start_full_payload() {
+        match parse(SAMPLE_WORKLOAD_START.as_bytes()).unwrap() {
+            HostVmRequest::WorkloadStart {
+                workload_id,
+                kernel_path,
+                rootfs_path,
+                vsock_socket_dir,
+                vcpus,
+                memory_mib,
+                kernel_cmdline_extras,
+            } => {
+                assert_eq!(workload_id, "00000000-0000-0000-0000-000000000009");
+                assert_eq!(kernel_path, "/job/workload/vmlinux");
+                assert_eq!(rootfs_path, "/job/workload/rootfs.ext4");
+                assert_eq!(vsock_socket_dir, "/var/lib/mvm/workloads");
+                assert_eq!(vcpus, 2);
+                assert_eq!(memory_mib, 1024);
+                assert_eq!(kernel_cmdline_extras, "root=/dev/vda ro init=/init");
+            }
+            other => panic!("expected WorkloadStart, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn parses_workload_stop_and_status() {
+        let stop = r#"{"kind":"workload_stop","workload_id":"abc"}"#;
+        assert_eq!(
+            parse(stop.as_bytes()).unwrap(),
+            HostVmRequest::WorkloadStop {
+                workload_id: "abc".to_string()
+            }
+        );
+        let status = r#"{"kind":"workload_status","workload_id":"abc"}"#;
+        assert_eq!(
+            parse(status.as_bytes()).unwrap(),
+            HostVmRequest::WorkloadStatus {
+                workload_id: "abc".to_string()
+            }
+        );
+    }
+
+    #[test]
+    fn rejects_workload_start_missing_field() {
+        // Drop `rootfs_path`.
+        let json = r#"{"kind":"workload_start","workload_id":"x","kernel_path":"/k","vsock_socket_dir":"/d","vcpus":1,"memory_mib":64,"kernel_cmdline_extras":""}"#;
+        match parse(json.as_bytes()).unwrap_err() {
+            ParseError::MissingWorkloadField("rootfs_path") => {}
+            other => panic!("got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn rejects_workload_start_non_numeric_vcpus() {
+        // `vcpus` is a string, not a bare number.
+        let json = r#"{"kind":"workload_start","workload_id":"x","kernel_path":"/k","rootfs_path":"/r","vsock_socket_dir":"/d","vcpus":"two","memory_mib":64,"kernel_cmdline_extras":""}"#;
+        match parse(json.as_bytes()).unwrap_err() {
+            ParseError::BadNumber("vcpus") => {}
+            other => panic!("got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn workload_start_accepts_empty_cmdline_extras() {
+        let json = r#"{"kind":"workload_start","workload_id":"x","kernel_path":"/k","rootfs_path":"/r","vsock_socket_dir":"/d","vcpus":1,"memory_mib":64,"kernel_cmdline_extras":""}"#;
+        match parse(json.as_bytes()).unwrap() {
+            HostVmRequest::WorkloadStart {
+                kernel_cmdline_extras,
+                ..
+            } => assert_eq!(kernel_cmdline_extras, ""),
+            other => panic!("got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn find_u32_value_handles_present_absent_and_overflow() {
+        assert_eq!(find_u32_value(r#"{"vcpus": 4}"#, "vcpus"), Some(4));
+        assert_eq!(find_u32_value(r#"{"vcpus":0}"#, "vcpus"), Some(0));
+        assert_eq!(find_u32_value(r#"{"other":4}"#, "vcpus"), None);
+        // > u32::MAX
+        assert_eq!(find_u32_value(r#"{"vcpus":4294967296}"#, "vcpus"), None);
+    }
+
+    /// Cross-validation for the workload variants — what the host's
+    /// serde writer emits must parse via this hand-rolled parser.
+    #[test]
+    fn parses_workload_start_serialized_by_mvm_build() {
+        use mvm_build::builder_protocol::{HostVmRequest as HostReq, WorkloadId};
+
+        let req = HostReq::WorkloadStart {
+            workload_id: WorkloadId(uuid::Uuid::nil()),
+            kernel_path: "/job/workload/vmlinux".to_string(),
+            rootfs_path: "/job/workload/rootfs.ext4".to_string(),
+            vsock_socket_dir: "/var/lib/mvm/workloads".to_string(),
+            vcpus: 4,
+            memory_mib: 2048,
+            kernel_cmdline_extras: "root=/dev/vda ro".to_string(),
+        };
+        let json = serde_json::to_vec(&req).expect("serialize");
+        match parse(&json).expect("parse") {
+            HostVmRequest::WorkloadStart {
+                workload_id,
+                kernel_path,
+                rootfs_path,
+                vsock_socket_dir,
+                vcpus,
+                memory_mib,
+                kernel_cmdline_extras,
+            } => {
+                assert_eq!(workload_id, "00000000-0000-0000-0000-000000000000");
+                assert_eq!(kernel_path, "/job/workload/vmlinux");
+                assert_eq!(rootfs_path, "/job/workload/rootfs.ext4");
+                assert_eq!(vsock_socket_dir, "/var/lib/mvm/workloads");
+                assert_eq!(vcpus, 4);
+                assert_eq!(memory_mib, 2048);
+                assert_eq!(kernel_cmdline_extras, "root=/dev/vda ro");
+            }
+            other => panic!("got {other:?}"),
+        }
+
+        // Stop + status round-trip through serde too.
+        let stop = HostReq::WorkloadStop {
+            workload_id: WorkloadId(uuid::Uuid::nil()),
+        };
+        let json = serde_json::to_vec(&stop).expect("serialize");
+        assert_eq!(
+            parse(&json).expect("parse"),
+            HostVmRequest::WorkloadStop {
+                workload_id: "00000000-0000-0000-0000-000000000000".to_string()
+            }
+        );
     }
 }

--- a/crates/mvm-host-vm-init/src/dispatch_response.rs
+++ b/crates/mvm-host-vm-init/src/dispatch_response.rs
@@ -113,12 +113,60 @@ pub(crate) fn stderr_chunk_json(job_id: &str, line: &str) -> String {
     out
 }
 
+/// Plan 107 A2.2 — wire JSON for `HostVmResponse::WorkloadStarted`
+/// (`{"kind":"workload_started","workload_id":"...","pid":N}`).
+/// Mirrors the serde-derived field order; the cross-validation test
+/// below pins it against the typed enum.
+pub(crate) fn workload_started_json(workload_id: &str, pid: u32) -> String {
+    let mut out = String::with_capacity(80 + workload_id.len());
+    out.push_str(r#"{"kind":"workload_started","workload_id":""#);
+    push_json_string(&mut out, workload_id);
+    out.push_str(r#"","pid":"#);
+    out.push_str(&pid.to_string());
+    out.push('}');
+    out
+}
+
+/// Plan 107 A2.2 — wire JSON for `HostVmResponse::WorkloadStopped`.
+pub(crate) fn workload_stopped_json(workload_id: &str) -> String {
+    let mut out = String::with_capacity(64 + workload_id.len());
+    out.push_str(r#"{"kind":"workload_stopped","workload_id":""#);
+    push_json_string(&mut out, workload_id);
+    out.push_str(r#""}"#);
+    out
+}
+
+/// Plan 107 A2.2 — wire JSON for
+/// `HostVmResponse::WorkloadStatusReport`.
+pub(crate) fn workload_status_report_json(workload_id: &str, status: &str) -> String {
+    let mut out = String::with_capacity(80 + workload_id.len() + status.len());
+    out.push_str(r#"{"kind":"workload_status_report","workload_id":""#);
+    push_json_string(&mut out, workload_id);
+    out.push_str(r#"","status":""#);
+    push_json_string(&mut out, status);
+    out.push_str(r#""}"#);
+    out
+}
+
+/// Plan 107 A2.2 — wire JSON for `HostVmResponse::WorkloadFailed`,
+/// the fail-closed negative path (spawn / collision / parse error).
+pub(crate) fn workload_failed_json(workload_id: &str, error: &str) -> String {
+    let mut out = String::with_capacity(80 + workload_id.len() + error.len());
+    out.push_str(r#"{"kind":"workload_failed","workload_id":""#);
+    push_json_string(&mut out, workload_id);
+    out.push_str(r#"","error":""#);
+    push_json_string(&mut out, error);
+    out.push_str(r#""}"#);
+    out
+}
+
 /// JSON string-escape per RFC 8259 §7. Inlined rather than calling
 /// the existing `json_escape` in `main.rs` because that one is
 /// `#[cfg(target_os = "linux")]`-gated under the linux module —
 /// this module is cross-platform so `cargo test` on macOS hosts
-/// can exercise the roundtrip.
-fn push_json_string(out: &mut String, s: &str) {
+/// can exercise the roundtrip. `pub(crate)` so [`crate::workload`]
+/// reuses the same escaper for the Firecracker config JSON.
+pub(crate) fn push_json_string(out: &mut String, s: &str) {
     for c in s.chars() {
         match c {
             '"' => out.push_str("\\\""),
@@ -315,5 +363,57 @@ mod tests {
             }
             other => panic!("expected Result variant, got {other:?}"),
         }
+    }
+
+    /// Plan 107 A2.2 — every workload-lifecycle emitter must
+    /// deserialize as the typed `HostVmResponse` variant with the
+    /// expected fields. Drift on either side trips this.
+    #[test]
+    fn workload_emitters_parse_as_typed_builder_response() {
+        use mvm_build::builder_protocol::{HostVmResponse, WorkloadId};
+
+        let id = "00000000-0000-0000-0000-000000000000";
+
+        match serde_json::from_str(&workload_started_json(id, 4242)).unwrap() {
+            HostVmResponse::WorkloadStarted { workload_id, pid } => {
+                assert_eq!(workload_id, WorkloadId(uuid::Uuid::nil()));
+                assert_eq!(pid, 4242);
+            }
+            other => panic!("expected WorkloadStarted, got {other:?}"),
+        }
+
+        match serde_json::from_str(&workload_stopped_json(id)).unwrap() {
+            HostVmResponse::WorkloadStopped { workload_id } => {
+                assert_eq!(workload_id, WorkloadId(uuid::Uuid::nil()));
+            }
+            other => panic!("expected WorkloadStopped, got {other:?}"),
+        }
+
+        match serde_json::from_str(&workload_status_report_json(id, "running")).unwrap() {
+            HostVmResponse::WorkloadStatusReport {
+                workload_id,
+                status,
+            } => {
+                assert_eq!(workload_id, WorkloadId(uuid::Uuid::nil()));
+                assert_eq!(status, "running");
+            }
+            other => panic!("expected WorkloadStatusReport, got {other:?}"),
+        }
+
+        match serde_json::from_str(&workload_failed_json(id, "spawn failed: ENOENT")).unwrap() {
+            HostVmResponse::WorkloadFailed { workload_id, error } => {
+                assert_eq!(workload_id, WorkloadId(uuid::Uuid::nil()));
+                assert_eq!(error, "spawn failed: ENOENT");
+            }
+            other => panic!("expected WorkloadFailed, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn workload_failed_escapes_control_chars_in_error() {
+        let json = workload_failed_json(NIL_JOB_ID, "oops:\n\"quoted\"\tbad");
+        let parsed: serde_json::Value = serde_json::from_str(&json).expect("must parse");
+        assert_eq!(parsed["kind"], "workload_failed");
+        assert_eq!(parsed["error"], "oops:\n\"quoted\"\tbad");
     }
 }

--- a/crates/mvm-host-vm-init/src/main.rs
+++ b/crates/mvm-host-vm-init/src/main.rs
@@ -95,6 +95,12 @@ mod install_spec;
 mod network;
 #[allow(dead_code)]
 mod proxy;
+/// Plan 107 A2.2 / A2.3 — spawn a workload microVM inside the host
+/// VM via a `WorkloadVmm` backend (Firecracker today). Cross-platform
+/// trait + state-dir/lifecycle logic (tested on macOS); the
+/// signal-based stop/status helpers are Linux-only.
+#[allow(dead_code)]
+mod workload;
 
 fn main() -> ExitCode {
     #[cfg(target_os = "linux")]
@@ -1006,30 +1012,82 @@ mod linux {
                     drop(conn);
                     break;
                 }
-                // Plan 107 A1b — workload arms reach the guest-side
-                // dispatcher but the Firecracker-in-guest spawn path
-                // doesn't exist yet (A2.2). Until A2.2 lands, the
-                // host-side dispatch path (PersistentBuilderSupervisor
-                // in mvm-build/persistent_builder.rs) only sends `Run`
-                // and `Shutdown` requests, so these arms are
-                // unreachable in production. If a future host slice
-                // accidentally sends a Workload* before the guest is
-                // ready, panic loudly so the regression is caught at
-                // boot rather than silently dropped on the floor.
-                crate::builder_request::HostVmRequest::WorkloadStart { workload_id } => {
-                    unimplemented!(
-                        "mvm-host-vm-init: WorkloadStart received for workload_id={workload_id}; Firecracker-in-guest spawn path lands in Plan 107 A2.2"
-                    );
+                // Plan 107 A2.2 — spawn / stop / query a Firecracker
+                // workload microVM inside the host VM. All three reply
+                // with a typed frame (incl. the fail-closed
+                // `WorkloadFailed` on error) so the host never has to
+                // distinguish a real failure from a transport EOF.
+                crate::builder_request::HostVmRequest::WorkloadStart {
+                    workload_id,
+                    kernel_path,
+                    rootfs_path,
+                    vsock_socket_dir,
+                    vcpus,
+                    memory_mib,
+                    kernel_cmdline_extras,
+                } => {
+                    let cfg = crate::workload::WorkloadSpawnConfig {
+                        workload_id: workload_id.clone(),
+                        kernel_path,
+                        rootfs_path,
+                        vsock_socket_dir,
+                        vcpus,
+                        memory_mib,
+                        kernel_cmdline_extras,
+                    };
+                    let frame = match crate::workload::start_workload(
+                        &crate::workload::FirecrackerVmm,
+                        &cfg,
+                    ) {
+                        Ok(pid) => {
+                            crate::dispatch_response::workload_started_json(&workload_id, pid)
+                        }
+                        Err(e) => {
+                            eprintln!(
+                                "mvm-host-vm-init: dispatch loop: WorkloadStart {workload_id} failed: {e}"
+                            );
+                            crate::dispatch_response::workload_failed_json(
+                                &workload_id,
+                                &e.to_string(),
+                            )
+                        }
+                    };
+                    if !write_frame(&mut conn, frame.as_bytes()) {
+                        eprintln!(
+                            "mvm-host-vm-init: dispatch loop: write WorkloadStart reply failed"
+                        );
+                    }
                 }
                 crate::builder_request::HostVmRequest::WorkloadStop { workload_id } => {
-                    unimplemented!(
-                        "mvm-host-vm-init: WorkloadStop received for workload_id={workload_id}; Firecracker-in-guest stop path lands in Plan 107 A2.2"
-                    );
+                    let base = std::path::Path::new(crate::workload::WORKLOAD_STATE_BASE);
+                    let frame = match crate::workload::stop_workload(base, &workload_id) {
+                        Ok(()) => crate::dispatch_response::workload_stopped_json(&workload_id),
+                        Err(e) => {
+                            eprintln!(
+                                "mvm-host-vm-init: dispatch loop: WorkloadStop {workload_id} failed: {e}"
+                            );
+                            crate::dispatch_response::workload_failed_json(
+                                &workload_id,
+                                &e.to_string(),
+                            )
+                        }
+                    };
+                    if !write_frame(&mut conn, frame.as_bytes()) {
+                        eprintln!(
+                            "mvm-host-vm-init: dispatch loop: write WorkloadStop reply failed"
+                        );
+                    }
                 }
                 crate::builder_request::HostVmRequest::WorkloadStatus { workload_id } => {
-                    unimplemented!(
-                        "mvm-host-vm-init: WorkloadStatus received for workload_id={workload_id}; Firecracker-in-guest status path lands in Plan 107 A2.2"
-                    );
+                    let base = std::path::Path::new(crate::workload::WORKLOAD_STATE_BASE);
+                    let status = crate::workload::workload_status(base, &workload_id);
+                    let frame =
+                        crate::dispatch_response::workload_status_report_json(&workload_id, status);
+                    if !write_frame(&mut conn, frame.as_bytes()) {
+                        eprintln!(
+                            "mvm-host-vm-init: dispatch loop: write WorkloadStatus reply failed"
+                        );
+                    }
                 }
             }
             // Conn drops at end of iteration; the host's read on

--- a/crates/mvm-host-vm-init/src/workload.rs
+++ b/crates/mvm-host-vm-init/src/workload.rs
@@ -1,0 +1,453 @@
+//! Plan 107 A2.2 / A2.3 — spawn a workload microVM *inside* the
+//! host VM on `WorkloadStart` dispatch.
+//!
+//! ## No VMM lock-in
+//!
+//! Everything VMM-specific (the config-file format, the binary
+//! path, the spawn argv) lives behind the [`WorkloadVmm`] trait.
+//! [`FirecrackerVmm`] is the only impl today and the only type that
+//! names Firecracker; the dispatch loop, the wire protocol, and the
+//! state-dir / process lifecycle are all VMM-agnostic. A second
+//! backend (cloud-hypervisor, qemu-microvm) is a pure addition: a
+//! new `WorkloadVmm` impl, no other changes. Mirrors the host-side
+//! hypervisor-backend split in `mvm-backend/`.
+//!
+//! ## No serde
+//!
+//! Same rationale as [`crate::dispatch_response`] /
+//! [`crate::builder_request`]: the Plan 72 §W3 ≤ 1.5 MiB budget
+//! keeps `serde_json` out of the production rootfs, so
+//! [`FirecrackerVmm::render_config`] hand-rolls the Firecracker
+//! `--config-file` JSON. The `render_config_is_valid_json` test
+//! parses the output with a dev-only `serde_json` to keep it honest.
+
+use crate::dispatch_response::push_json_string;
+use std::fs;
+use std::io;
+use std::path::{Path, PathBuf};
+use std::process::Command;
+
+/// Canonical base dir (inside the host VM) for per-workload state.
+/// The host passes this as `WorkloadStart.vsock_socket_dir` in
+/// production; the id-only `WorkloadStop` / `WorkloadStatus`
+/// requests key off it (they carry no base). A4 formalises the
+/// host→guest contract; A2 treats this const as the convention.
+pub const WORKLOAD_STATE_BASE: &str = "/var/lib/mvm/workloads";
+
+/// Path the Firecracker binary is baked at by the builder-vm flake
+/// (Plan 107 A2.1 — `nix/images/builder-vm/flake.nix`).
+pub const FIRECRACKER_BIN: &str = "/usr/bin/firecracker";
+
+/// Base kernel cmdline every Firecracker workload boots with;
+/// `kernel_cmdline_extras` (root=/init=/dm-verity roothash) is
+/// appended by the host.
+const FC_BASE_CMDLINE: &str = "console=ttyS0 reboot=k panic=1 pci=off";
+
+/// Guest CID the workload microVM's vsock is addressed at — mirrors
+/// `mvm_guest::vsock::GUEST_CID` (hardcoded here because the guest
+/// init deliberately doesn't depend on `mvm-guest`; see Cargo.toml).
+const GUEST_CID: u32 = 3;
+
+/// Generic (VMM-agnostic) spawn config — the post-parse form of
+/// `mvm_build::builder_protocol::HostVmRequest::WorkloadStart`.
+#[derive(Debug, Clone)]
+pub struct WorkloadSpawnConfig {
+    pub workload_id: String,
+    pub kernel_path: String,
+    pub rootfs_path: String,
+    /// Base dir under which the per-workload state dir is created.
+    pub vsock_socket_dir: String,
+    pub vcpus: u32,
+    pub memory_mib: u32,
+    pub kernel_cmdline_extras: String,
+}
+
+/// A VMM that can launch a workload microVM inside the host VM.
+/// The swap seam that keeps mvm from being locked into Firecracker.
+pub trait WorkloadVmm {
+    /// Stable name for logs / status (e.g. `"firecracker"`).
+    fn name(&self) -> &'static str;
+    /// Render the VMM's config-file contents for this workload. The
+    /// state dir supplies VMM-agnostic paths (vsock UDS, etc.).
+    fn render_config(&self, cfg: &WorkloadSpawnConfig, state: &WorkloadStateDir) -> String;
+    /// Build the spawn command (binary + args) given the written
+    /// config-file path. `Command` is cross-platform, so this is
+    /// assertable in tests without spawning.
+    fn command(&self, config_path: &Path) -> Command;
+}
+
+/// Firecracker backend. The only type that names Firecracker.
+#[derive(Debug, Clone, Copy, Default)]
+pub struct FirecrackerVmm;
+
+impl WorkloadVmm for FirecrackerVmm {
+    fn name(&self) -> &'static str {
+        "firecracker"
+    }
+
+    fn render_config(&self, cfg: &WorkloadSpawnConfig, state: &WorkloadStateDir) -> String {
+        let boot_args = if cfg.kernel_cmdline_extras.is_empty() {
+            FC_BASE_CMDLINE.to_string()
+        } else {
+            format!("{FC_BASE_CMDLINE} {}", cfg.kernel_cmdline_extras)
+        };
+        let vsock_uds = state.vsock_path();
+        let vsock_uds = vsock_uds.to_string_lossy();
+
+        // Hand-rolled to mirror `mvm_build::firecracker`'s
+        // `--config-file` shape: boot-source + a single root drive +
+        // machine-config + vsock. Field order is cosmetic (the
+        // Firecracker config parser is order-insensitive).
+        let mut out = String::with_capacity(512);
+        out.push_str(r#"{"boot-source":{"kernel_image_path":""#);
+        push_json_string(&mut out, &cfg.kernel_path);
+        out.push_str(r#"","boot_args":""#);
+        push_json_string(&mut out, &boot_args);
+        out.push_str(r#""},"drives":[{"drive_id":"rootfs","path_on_host":""#);
+        push_json_string(&mut out, &cfg.rootfs_path);
+        out.push_str(
+            r#"","is_root_device":true,"is_read_only":false}],"machine-config":{"vcpu_count":"#,
+        );
+        out.push_str(&cfg.vcpus.to_string());
+        out.push_str(r#","mem_size_mib":"#);
+        out.push_str(&cfg.memory_mib.to_string());
+        out.push_str(r#"},"vsock":{"vsock_id":"vsock0","guest_cid":"#);
+        out.push_str(&GUEST_CID.to_string());
+        out.push_str(r#","uds_path":""#);
+        push_json_string(&mut out, &vsock_uds);
+        out.push_str(r#""}}"#);
+        out
+    }
+
+    fn command(&self, config_path: &Path) -> Command {
+        let mut cmd = Command::new(FIRECRACKER_BIN);
+        cmd.arg("--config-file").arg(config_path);
+        cmd
+    }
+}
+
+/// Per-workload state dir (Plan 107 A2.3):
+/// `<base>/<workload_id>/` holding `config.json`, `fc.pid`,
+/// `fc.stdout.log`, `fc.stderr.log`, and the `v.sock` vsock UDS.
+///
+/// On creation the leaf dir uses `create_dir` (not `create_dir_all`)
+/// so a duplicate `workload_id` fails closed as a collision. The
+/// `Drop` impl removes the dir so a panic mid-spawn doesn't leak;
+/// [`WorkloadStateDir::persist`] disarms that once the workload is
+/// successfully running and the dir must outlive this scope.
+#[derive(Debug)]
+pub struct WorkloadStateDir {
+    path: PathBuf,
+    cleanup_on_drop: bool,
+}
+
+impl WorkloadStateDir {
+    /// Create `<base>/<workload_id>/`. Fails closed if the leaf
+    /// already exists (workload-id collision).
+    pub fn create(base: &Path, workload_id: &str) -> io::Result<Self> {
+        fs::create_dir_all(base)?;
+        let path = base.join(workload_id);
+        // `create_dir` (not `_all`) so an existing dir → AlreadyExists.
+        fs::create_dir(&path)?;
+        Ok(Self {
+            path,
+            cleanup_on_drop: true,
+        })
+    }
+
+    pub fn path(&self) -> &Path {
+        &self.path
+    }
+    pub fn config_path(&self) -> PathBuf {
+        self.path.join("config.json")
+    }
+    pub fn pid_path(&self) -> PathBuf {
+        self.path.join("fc.pid")
+    }
+    pub fn stdout_path(&self) -> PathBuf {
+        self.path.join("fc.stdout.log")
+    }
+    pub fn stderr_path(&self) -> PathBuf {
+        self.path.join("fc.stderr.log")
+    }
+    pub fn vsock_path(&self) -> PathBuf {
+        self.path.join("v.sock")
+    }
+
+    /// Disarm `Drop` cleanup — the workload spawned successfully, so
+    /// the dir must persist for the host to reach `v.sock` / `fc.pid`.
+    pub fn persist(mut self) -> PathBuf {
+        self.cleanup_on_drop = false;
+        self.path.clone()
+    }
+}
+
+impl Drop for WorkloadStateDir {
+    fn drop(&mut self) {
+        if self.cleanup_on_drop {
+            let _ = fs::remove_dir_all(&self.path);
+        }
+    }
+}
+
+/// Remove a per-workload state dir. Idempotent-ish: a missing dir is
+/// not an error (already cleaned). Used by `WorkloadStop` and as the
+/// final step of [`stop_workload`].
+pub fn cleanup_state_dir(base: &Path, workload_id: &str) -> io::Result<()> {
+    let dir = base.join(workload_id);
+    match fs::remove_dir_all(&dir) {
+        Ok(()) => Ok(()),
+        Err(e) if e.kind() == io::ErrorKind::NotFound => Ok(()),
+        Err(e) => Err(e),
+    }
+}
+
+/// Spawn a workload microVM via `vmm`, returning the spawned PID.
+/// Creates the state dir, writes the rendered config, redirects the
+/// VMM's stdout/stderr to log files, spawns, and records the PID.
+/// On any failure the [`WorkloadStateDir`] `Drop` cleans up; on
+/// success the dir is persisted for the host to reach.
+pub fn start_workload(vmm: &dyn WorkloadVmm, cfg: &WorkloadSpawnConfig) -> io::Result<u32> {
+    let base = PathBuf::from(&cfg.vsock_socket_dir);
+    let state = WorkloadStateDir::create(&base, &cfg.workload_id)?;
+
+    let config_json = vmm.render_config(cfg, &state);
+    fs::write(state.config_path(), config_json)?;
+
+    let stdout = fs::File::create(state.stdout_path())?;
+    let stderr = fs::File::create(state.stderr_path())?;
+
+    let config_path = state.config_path();
+    let mut cmd = vmm.command(&config_path);
+    cmd.stdin(std::process::Stdio::null())
+        .stdout(stdout)
+        .stderr(stderr);
+
+    // spawn() returns immediately; the VMM runs as a long-lived
+    // child of the dispatch loop. We never wait() on it — lifecycle
+    // is tracked via the PID file + signals (stop_workload).
+    let child = cmd.spawn()?;
+    let pid = child.id();
+    fs::write(state.pid_path(), pid.to_string())?;
+
+    // Success — keep the state dir.
+    let _ = state.persist();
+    Ok(pid)
+}
+
+/// SIGTERM the workload's VMM, wait a short grace, fall back to
+/// SIGKILL, then remove the state dir. Linux-only (signal syscalls).
+#[cfg(target_os = "linux")]
+pub fn stop_workload(base: &Path, workload_id: &str) -> io::Result<()> {
+    use std::time::Duration;
+
+    let pid_path = base.join(workload_id).join("fc.pid");
+    if let Ok(pid) = fs::read_to_string(&pid_path).map(|s| s.trim().parse::<i32>()) {
+        if let Ok(pid) = pid {
+            // SIGTERM, then poll up to ~2s for the process to exit.
+            unsafe { libc::kill(pid, libc::SIGTERM) };
+            let mut exited = false;
+            for _ in 0..40 {
+                if unsafe { libc::kill(pid, 0) } != 0 {
+                    exited = true;
+                    break;
+                }
+                std::thread::sleep(Duration::from_millis(50));
+            }
+            if !exited {
+                unsafe { libc::kill(pid, libc::SIGKILL) };
+            }
+        }
+    }
+    cleanup_state_dir(base, workload_id)
+}
+
+/// Report a workload's lifecycle status: `"not_found"` (no state
+/// dir), `"running"` (PID alive and vsock UDS present), or
+/// `"stopped"`. Linux-only (PID liveness via `kill(pid, 0)`).
+#[cfg(target_os = "linux")]
+pub fn workload_status(base: &Path, workload_id: &str) -> &'static str {
+    let dir = base.join(workload_id);
+    if !dir.exists() {
+        return "not_found";
+    }
+    let alive = fs::read_to_string(dir.join("fc.pid"))
+        .ok()
+        .and_then(|s| s.trim().parse::<i32>().ok())
+        .map(|pid| unsafe { libc::kill(pid, 0) } == 0)
+        .unwrap_or(false);
+    if alive && dir.join("v.sock").exists() {
+        "running"
+    } else {
+        "stopped"
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn sample_cfg(base: &Path, id: &str) -> WorkloadSpawnConfig {
+        WorkloadSpawnConfig {
+            workload_id: id.to_string(),
+            kernel_path: "/job/workload/vmlinux".to_string(),
+            rootfs_path: "/job/workload/rootfs.ext4".to_string(),
+            vsock_socket_dir: base.to_string_lossy().into_owned(),
+            vcpus: 2,
+            memory_mib: 1024,
+            kernel_cmdline_extras: "root=/dev/vda ro init=/init".to_string(),
+        }
+    }
+
+    #[test]
+    fn render_config_is_valid_json_with_expected_values() {
+        let tmp = tempfile::tempdir().unwrap();
+        let state = WorkloadStateDir::create(tmp.path(), "wl1").unwrap();
+        let cfg = sample_cfg(tmp.path(), "wl1");
+        let json = FirecrackerVmm.render_config(&cfg, &state);
+
+        let v: serde_json::Value = serde_json::from_str(&json).expect("valid JSON");
+        assert_eq!(
+            v["boot-source"]["kernel_image_path"],
+            "/job/workload/vmlinux"
+        );
+        assert_eq!(
+            v["boot-source"]["boot_args"],
+            "console=ttyS0 reboot=k panic=1 pci=off root=/dev/vda ro init=/init"
+        );
+        assert_eq!(v["drives"][0]["path_on_host"], "/job/workload/rootfs.ext4");
+        assert_eq!(v["drives"][0]["is_root_device"], true);
+        assert_eq!(v["drives"][0]["is_read_only"], false);
+        assert_eq!(v["machine-config"]["vcpu_count"], 2);
+        assert_eq!(v["machine-config"]["mem_size_mib"], 1024);
+        assert_eq!(v["vsock"]["guest_cid"], 3);
+        assert_eq!(
+            v["vsock"]["uds_path"],
+            state.vsock_path().to_string_lossy().as_ref()
+        );
+    }
+
+    #[test]
+    fn render_config_base_cmdline_when_no_extras() {
+        let tmp = tempfile::tempdir().unwrap();
+        let state = WorkloadStateDir::create(tmp.path(), "wl1").unwrap();
+        let mut cfg = sample_cfg(tmp.path(), "wl1");
+        cfg.kernel_cmdline_extras = String::new();
+        let json = FirecrackerVmm.render_config(&cfg, &state);
+        let v: serde_json::Value = serde_json::from_str(&json).unwrap();
+        assert_eq!(
+            v["boot-source"]["boot_args"],
+            "console=ttyS0 reboot=k panic=1 pci=off"
+        );
+    }
+
+    #[test]
+    fn firecracker_command_is_config_file_invocation() {
+        let cmd = FirecrackerVmm.command(Path::new("/some/config.json"));
+        assert_eq!(cmd.get_program(), FIRECRACKER_BIN);
+        let args: Vec<_> = cmd
+            .get_args()
+            .map(|a| a.to_string_lossy().into_owned())
+            .collect();
+        assert_eq!(args, vec!["--config-file", "/some/config.json"]);
+        assert_eq!(FirecrackerVmm.name(), "firecracker");
+    }
+
+    #[test]
+    fn state_dir_create_files_and_drop_cleanup() {
+        let tmp = tempfile::tempdir().unwrap();
+        let dir_path;
+        {
+            let state = WorkloadStateDir::create(tmp.path(), "wl1").unwrap();
+            dir_path = state.path().to_path_buf();
+            assert!(dir_path.is_dir());
+            fs::write(state.config_path(), "{}").unwrap();
+            assert!(state.config_path().exists());
+            // state drops here without persist() → cleanup.
+        }
+        assert!(!dir_path.exists(), "Drop must remove the un-persisted dir");
+    }
+
+    #[test]
+    fn state_dir_persist_disarms_cleanup() {
+        let tmp = tempfile::tempdir().unwrap();
+        let state = WorkloadStateDir::create(tmp.path(), "wl1").unwrap();
+        let path = state.persist();
+        assert!(path.is_dir(), "persisted dir must survive the scope");
+    }
+
+    #[test]
+    fn state_dir_create_detects_collision() {
+        let tmp = tempfile::tempdir().unwrap();
+        let first = WorkloadStateDir::create(tmp.path(), "dup").unwrap();
+        let second = WorkloadStateDir::create(tmp.path(), "dup");
+        assert!(
+            matches!(&second, Err(e) if e.kind() == io::ErrorKind::AlreadyExists),
+            "duplicate workload_id must fail closed, got {second:?}"
+        );
+        // The first guard must still own (and on drop clean) its dir;
+        // the failed second create must not have removed it.
+        assert!(first.path().is_dir());
+    }
+
+    #[test]
+    fn cleanup_state_dir_is_ok_when_missing() {
+        let tmp = tempfile::tempdir().unwrap();
+        cleanup_state_dir(tmp.path(), "never-created").expect("missing dir is not an error");
+    }
+
+    /// Seam test — `start_workload` drives any `WorkloadVmm` without
+    /// naming Firecracker. A fake VMM that spawns `/bin/true` (or a
+    /// no-op on Windows) proves the lifecycle is VMM-agnostic.
+    struct FakeVmm;
+    impl WorkloadVmm for FakeVmm {
+        fn name(&self) -> &'static str {
+            "fake"
+        }
+        fn render_config(&self, _cfg: &WorkloadSpawnConfig, _state: &WorkloadStateDir) -> String {
+            r#"{"fake":true}"#.to_string()
+        }
+        fn command(&self, _config_path: &Path) -> Command {
+            // A trivially-spawnable, immediately-exiting program,
+            // resolved via PATH so it works on Linux and macOS
+            // (`/bin/true` doesn't exist on macOS).
+            if cfg!(windows) {
+                let mut c = Command::new("cmd");
+                c.args(["/C", "exit", "0"]);
+                c
+            } else {
+                Command::new("true")
+            }
+        }
+    }
+
+    #[test]
+    fn start_workload_drives_arbitrary_vmm() {
+        let tmp = tempfile::tempdir().unwrap();
+        let cfg = sample_cfg(tmp.path(), "wl-seam");
+        let pid = start_workload(&FakeVmm, &cfg).expect("spawn fake vmm");
+        assert!(pid > 0);
+
+        let dir = tmp.path().join("wl-seam");
+        assert!(dir.join("config.json").exists());
+        assert_eq!(
+            fs::read_to_string(dir.join("config.json")).unwrap(),
+            r#"{"fake":true}"#
+        );
+        assert!(dir.join("fc.pid").exists());
+        assert!(dir.join("fc.stdout.log").exists());
+        assert!(dir.join("fc.stderr.log").exists());
+        // Persisted on success — must outlive start_workload.
+        assert!(dir.is_dir());
+    }
+
+    #[test]
+    fn start_workload_cleans_up_on_collision() {
+        let tmp = tempfile::tempdir().unwrap();
+        let cfg = sample_cfg(tmp.path(), "wl-dup");
+        // Pre-create the leaf so create() collides.
+        fs::create_dir_all(tmp.path().join("wl-dup")).unwrap();
+        let err = start_workload(&FakeVmm, &cfg).unwrap_err();
+        assert_eq!(err.kind(), io::ErrorKind::AlreadyExists);
+    }
+}

--- a/nix/images/builder-vm/flake.nix
+++ b/nix/images/builder-vm/flake.nix
@@ -174,6 +174,16 @@
         iptables
         e2fsprogs
         util-linux
+        # Plan 107 A2.1 — the host VM spawns one Firecracker
+        # workload microVM per `WorkloadStart` dispatch inside
+        # itself (Approach A, ADR-057). Sourced from the pinned
+        # nixpkgs above — an upstream Nix package, never an
+        # mvm-published prebuilt (ADR-046 source-checkout rule).
+        # mkGuest's symlink loop also lands it at /sbin/firecracker
+        # and /usr/local/bin/firecracker; the `extraFiles` entry
+        # below pins the exact /usr/bin/firecracker path the guest
+        # hardcodes (`FirecrackerVmm` in mvm-host-vm-init).
+        firecracker
         (pinnedCryptsetupFor pkgs) # provides pinned veritysetup
         # Plan 73 Followup B.2 — app-deps install pipeline.
         uv
@@ -302,6 +312,14 @@
             # production build.
             "/sbin/mvm-egress-proxy" =
               "${egressProxy}/bin/mvm-egress-proxy";
+            # Plan 107 A2.1 — pin the exact path the guest's
+            # `FirecrackerVmm` spawns (`/usr/bin/firecracker`).
+            # `firecracker` is also in `packages` above (for the
+            # full closure + the /sbin + /usr/local/bin symlinks
+            # mkGuest adds); this entry guarantees the canonical
+            # /usr/bin path regardless of mkGuest's symlink targets.
+            "/usr/bin/firecracker" =
+              "${pkgs.firecracker}/bin/firecracker";
           };
         };
 

--- a/specs/SPRINT.md
+++ b/specs/SPRINT.md
@@ -2174,7 +2174,10 @@ Plan 100 W1 — implementation tracker (Plan 105). First slice: env-gated `MVM_L
 - [ ] **W6 dispatch flip** — brainstorm in [Plan 106](plans/106-plan-100-w6-dispatch-flip.md) (decision locked 2026-05-27 on Approach A: shared libkrun host VM, Firecracker per workload). Executable phases A1–A6 tracked in [Plan 107](plans/107-plan-100-w6-approach-a.md).
   - [x] **A1a** — protocol type rename (`BuilderRequest`/`Response` → `HostVmRequest`/`Response`) + `LibkrunPersistentBuilderVm` → `LibkrunPersistentHostVm` + new workload stub variants + 9 hermetic tests. Shipped in PR #503.
   - [x] **A1b** — crate rename (`mvm-builder-init` → `mvm-host-vm-init`) + Stage 0 byte-scan migration (`/sbin/mvm-host-vm-init` + 15 sites in `apple_container.rs`) + Nix flake updates + guest-side workload arms with `unimplemented!()` stubs until A2.2. Shipped in PR #506. Cached pre-rename rootfs images fail-closed on first `mvmctl dev up` after merge.
-  - [ ] **A2** (next) — Firecracker-in-guest launch path: bake Firecracker into the builder-vm rootfs (A2.1), spawn it from the `WorkloadStart` arm (A2.2), per-workload state dir at `/var/lib/mvm/workloads/<id>/` (A2.3), live CI smoke (A2.4), reproducibility double-build (A2.5).
+  - [ ] **A2** — Firecracker-in-guest launch path.
+    - [x] **A2.1 + A2.2 + A2.3** — bake `firecracker` into the builder-vm rootfs at `/usr/bin/firecracker`; `WorkloadStart` arm spawns a workload microVM via a `WorkloadVmm` trait (no VMM lock-in — `FirecrackerVmm` is the only Firecracker-aware type, spawns `firecracker --config-file`); per-workload state dir at `/var/lib/mvm/workloads/<id>/` with collision-detect + `Drop` cleanup; `WorkloadFailed` fail-closed response. Hermetic tests only (no live KVM).
+    - [ ] **A2.4** — live nested-KVM CI smoke.
+    - [ ] **A2.5** — `nix/images/builder-vm/` reproducibility double-build.
   - [ ] **A3 / A4 / A5 / A6** — vsock proxy nesting hop / `mvmctl up` wires the path / retire direct-Firecracker / docs + claim rewording. Each its own PR per Plan 107.
 - [ ] **W4 / W5 / W7 / W8** — gated on Plan 107 A4 landing.
 

--- a/specs/plans/107-plan-100-w6-approach-a.md
+++ b/specs/plans/107-plan-100-w6-approach-a.md
@@ -139,22 +139,32 @@ prompt; live-KVM smoke (cold) green.
 Goal: the host VM can spawn a Firecracker workload microVM inside
 itself on dispatch.
 
-- [ ] **A2.1** Bake Firecracker into the builder-vm rootfs
+- [x] **A2.1** Bake Firecracker into the builder-vm rootfs
       (`nix/images/builder-vm/`). Today the rootfs contains
       busybox + Nix + build tools; W6 adds the Firecracker binary
       from a verified upstream (Nix-checksummed per ADR-046's
       "source-checkout builds never depend on mvm-published
-      artifacts" rule).
-- [ ] **A2.2** Guest-side: `mvm-host-vm-init`'s `WorkloadStart`
-      arm spawns Firecracker with the workload's kernel + rootfs +
-      virtio config (passed in the request payload). The payload
-      shape mirrors `BuildVmPlan` from Plan 98 — kernel path,
-      rootfs path, vsock socket dir, vcpus, memory, kernel cmdline
-      extras.
-- [ ] **A2.3** Per-workload state dir inside the host VM:
-      `/var/lib/mvm/workloads/<workload_id>/` for Firecracker
-      sockets, PID files, console logs. Cleaned up on
-      `WorkloadStop`.
+      artifacts" rule). Shipped: `firecracker` added to
+      `builderPackages` + an `extraFiles` symlink pins the exact
+      `/usr/bin/firecracker` path the guest spawns.
+- [x] **A2.2** Guest-side: `mvm-host-vm-init`'s `WorkloadStart`
+      arm spawns a workload microVM with the workload's kernel +
+      rootfs + virtio config (passed in the request payload). The
+      payload carries kernel path, rootfs path, vsock socket dir,
+      vcpus, memory, kernel cmdline extras (generic microVM
+      concepts, not Firecracker-shaped). **No VMM lock-in**: a
+      `WorkloadVmm` trait (`workload.rs`) isolates the config-file
+      format / binary / argv; `FirecrackerVmm` is the only
+      Firecracker-aware type, so a second backend is a pure
+      addition. `WorkloadFailed` added to the response enum as the
+      fail-closed negative path. Spawns via `firecracker
+      --config-file …`.
+- [x] **A2.3** Per-workload state dir inside the host VM:
+      `/var/lib/mvm/workloads/<workload_id>/` holding `config.json`,
+      `fc.pid`, `fc.stdout.log`, `fc.stderr.log`, and the `v.sock`
+      vsock UDS. Collision-detecting create (fail-closed on a
+      duplicate id), `Drop` cleanup so a panic mid-spawn doesn't
+      leak, explicit cleanup on `WorkloadStop`.
 - [ ] **A2.4** Live smoke on a Linux + nested-KVM CI runner
       (Ubuntu, nested KVM enabled by default on GHA): send
       `WorkloadStart` to the host VM, assert Firecracker boots


### PR DESCRIPTION
## Summary

Plan 107 **Phase A2** (Approach A — shared libkrun host VM, one workload
microVM per dispatch *inside* it). Makes the host VM actually spawn a
workload microVM on `WorkloadStart`, replacing the A1b `unimplemented!()`
arms. Plan doc: `specs/plans/107-plan-100-w6-approach-a.md` §Phase A2.

Ships **A2.1 + A2.2 + A2.3** together — they're tightly coupled (no point
baking Firecracker without spawning it). **No live KVM here** — that's
A2.4; everything below is covered by hermetic tests.

## No VMM lock-in

A `WorkloadVmm` trait (`crates/mvm-host-vm-init/src/workload.rs`) isolates
every VMM-specific detail — config-file format, binary path, spawn argv.
`FirecrackerVmm` is the **only** type that names Firecracker; the dispatch
loop, the wire protocol, and the state-dir/process lifecycle are all
VMM-agnostic. A second backend (cloud-hypervisor, qemu-microvm) is a pure
addition — proven by a `FakeVmm` seam test that drives `start_workload`
without naming Firecracker. Mirrors the host-side hypervisor-backend split
in `mvm-backend/`. The wire payload fields are generic microVM concepts
(kernel/rootfs/vcpus/mem/vsock/cmdline), not Firecracker-shaped.

## What's in each commit

- **A2.1** (`feat(builder-vm)`) — bake `firecracker` into the builder-vm
  rootfs from pinned nixpkgs (upstream Nix pkg, no mvm prebuilt — ADR-046).
  Added to `builderPackages` + an `extraFiles` symlink pinning the exact
  `/usr/bin/firecracker` path the guest spawns. The flake hash changes;
  the `builder-vm-image-linux` CI lane prints the rootfs sha256 (no stored
  golden) so it rebaselines automatically.
- **A2.2 + A2.3** (`feat(host-vm-init)`) — coupled (state dir is the
  spawn's storage; the extended guest parser makes the old arms
  non-exhaustive), so one commit to keep each commit compiling:
  - **Wire** (`mvm-build/builder_protocol.rs`): `WorkloadStart` carries the
    spawn config; `WorkloadStarted` carries the spawned `pid`;
    **`WorkloadFailed`** added as the fail-closed negative path (typed
    frame, never a bare EOF).
  - **Guest** (no production serde): hand-rolled `parse_workload_start` +
    `find_u32_value`; hand-rolled `workload_{started,stopped,status_report,
    failed}_json` emitters; `workload.rs` with the `WorkloadVmm` trait,
    `FirecrackerVmm` (`firecracker --config-file …`), and `WorkloadStateDir`
    (collision-detecting create + `Drop` cleanup so a panic mid-spawn
    doesn't leak; `persist()` disarms on success), plus start/stop/status.
  - **State dir** `/var/lib/mvm/workloads/<id>/` → `config.json`, `fc.pid`,
    `fc.stdout.log`, `fc.stderr.log`, `v.sock`.
- **docs** — tick A2.1/A2.2/A2.3 in Plan 107 + SPRINT.md.

## Tests (hermetic)

- Host protocol: round-trip + `kind`-tag stability + `deny_unknown_fields`
  for the extended `WorkloadStart` and new `WorkloadFailed`.
- Guest parser: `parse_workload_start` full-payload, missing-field /
  bad-number rejection, `find_u32_value` edge cases, cross-validation
  against the host's serde output.
- Guest emitters: each parses back as the typed `HostVmResponse`.
- `workload.rs`: `render_config` → valid JSON with expected values;
  `command` → `/usr/bin/firecracker --config-file …`; state-dir create →
  Drop cleanup, persist disarms, **collision fails closed**; `FakeVmm`
  seam test proves no-lock-in.

`cargo fmt --all`, `cargo clippy --workspace --all-targets -- -D warnings`,
and `cargo test --workspace` all green (3 pre-existing `mvm-guest::
entrypoint` failures are macOS-host uid/gid environment issues that also
fail on `main` and pass on Linux CI — untouched by this PR).

## Out of scope (follow-ups)
A2.4 live nested-KVM smoke · A2.5 reproducibility double-build · A3 vsock
proxy nesting hop · A4 `mvmctl up` wiring.

🤖 Generated with [Claude Code](https://claude.com/claude-code)