### PR TITLE
Plan 93 PR-9 — adaptive vsock readiness-poll backoff (Phase 2 Lever 2)

### DIFF
--- a/crates/mvm-cli/src/commands/shared/vsock.rs
+++ b/crates/mvm-cli/src/commands/shared/vsock.rs
@@ -20,6 +20,16 @@ pub fn wait_for_guest_agent(vm_id: &str, timeout_secs: u64) -> bool {
     let deadline = std::time::Instant::now() + std::time::Duration::from_secs(timeout_secs);
     let transport = AppleContainerTransport::new(vm_id);
 
+    // Plan 93 Phase 2 Lever 2: adaptive backoff instead of a fixed
+    // 500 ms poll. A guest that binds in ~80 ms used to wait up to a
+    // full 500 ms before the next probe noticed; the backoff starts at
+    // 20 ms and grows to the same 500 ms cap, so the common fast-boot
+    // case is detected far sooner while a slow guest still polls at the
+    // old steady cadence. This is a timing change only — the
+    // connect→`negotiate_protocol` ordering (and the
+    // ProtocolHello/Ack contract) is untouched; no RPC is issued before
+    // negotiation succeeds.
+    let mut attempt: u32 = 0;
     while std::time::Instant::now() < deadline {
         if let Ok(mut s) = transport.connect(mvm_guest::vsock::GUEST_AGENT_PORT)
             && mvm_guest::vsock::negotiate_protocol(
@@ -30,7 +40,8 @@ pub fn wait_for_guest_agent(vm_id: &str, timeout_secs: u64) -> bool {
         {
             return true;
         }
-        std::thread::sleep(std::time::Duration::from_millis(500));
+        std::thread::sleep(mvm_guest::vsock::adaptive_backoff(attempt));
+        attempt = attempt.saturating_add(1);
     }
     false
 }

--- a/crates/mvm-guest/src/vsock.rs
+++ b/crates/mvm-guest/src/vsock.rs
@@ -71,6 +71,31 @@ const CONNECT_RETRIES: u32 = 3;
 /// Delay between CONNECT handshake retries.
 const CONNECT_RETRY_DELAY_MS: u64 = 500;
 
+/// Base delay for the adaptive readiness-poll backoff (Plan 93 Phase 2
+/// Lever 2). The first poll after a failed attempt waits this long.
+const ADAPTIVE_BACKOFF_BASE_MS: u64 = 20;
+
+/// Cap for the adaptive readiness-poll backoff — the historical fixed
+/// poll interval. Backoff grows from [`ADAPTIVE_BACKOFF_BASE_MS`] up to
+/// this ceiling so a slow guest still polls at the old steady cadence.
+const ADAPTIVE_BACKOFF_CAP_MS: u64 = 500;
+
+/// Adaptive backoff delay for the `mvmctl up` readiness poll
+/// (Plan 93 Phase 2 Lever 2). `attempt` is 0-based: attempt 0 waits the
+/// base, each subsequent attempt doubles, capped at
+/// [`ADAPTIVE_BACKOFF_CAP_MS`]. This replaces a fixed 500 ms sleep that
+/// cost up to ~480 ms of dead time after a fast-binding guest was
+/// already reachable; the cap preserves the old steady-state cadence
+/// for a slow guest. Pure — the schedule is unit-tested. This changes
+/// *timing only*; it never reorders or skips the protocol/auth steps a
+/// caller performs between polls.
+pub fn adaptive_backoff(attempt: u32) -> Duration {
+    // Saturating shift so a large `attempt` can't overflow; it clamps
+    // to the cap well before the shift would wrap.
+    let scaled = ADAPTIVE_BACKOFF_BASE_MS.saturating_mul(1u64 << attempt.min(16));
+    Duration::from_millis(scaled.min(ADAPTIVE_BACKOFF_CAP_MS))
+}
+
 // ============================================================================
 // Guest agent protocol (JSON over vsock)
 // ============================================================================
@@ -2401,6 +2426,26 @@ pub fn start_port_forward_on(stream: &mut UnixStream, guest_port: u16) -> Result
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn adaptive_backoff_grows_then_caps_and_is_never_zero() {
+        // Doubles from the 20ms base.
+        assert_eq!(adaptive_backoff(0), Duration::from_millis(20));
+        assert_eq!(adaptive_backoff(1), Duration::from_millis(40));
+        assert_eq!(adaptive_backoff(2), Duration::from_millis(80));
+        assert_eq!(adaptive_backoff(3), Duration::from_millis(160));
+        assert_eq!(adaptive_backoff(4), Duration::from_millis(320));
+        // Caps at the historical fixed interval and stays there.
+        assert_eq!(adaptive_backoff(5), Duration::from_millis(500));
+        assert_eq!(adaptive_backoff(6), Duration::from_millis(500));
+        // Large attempt counts can't overflow or drop to zero.
+        assert_eq!(adaptive_backoff(64), Duration::from_millis(500));
+        assert_eq!(adaptive_backoff(u32::MAX), Duration::from_millis(500));
+        // Never busy-spins.
+        for a in 0..40 {
+            assert!(adaptive_backoff(a) >= Duration::from_millis(ADAPTIVE_BACKOFF_BASE_MS));
+        }
+    }
 
     #[test]
     fn test_guest_request_roundtrip() {

--- a/specs/SPRINT.md
+++ b/specs/SPRINT.md
@@ -2402,7 +2402,7 @@ Phase 1 host cross-compile targets **`<arch>-unknown-linux-musl` static**, not g
 - [ ] ~~**PR-7 — two-runner reproducibility CI lane**~~ folds into ADR-064's build-time cross-compile.
 - [ ] ~~**PR-8 — `/nix` warm-reuse contract**~~ re-scoped under ADR-064's single-flake model.
 - [ ] **Phase 1 re-plan** — implement [ADR-064](adrs/064-single-builder-dev-image.md) as the new Phase 1, coordinated with the `specs/prompts/93-phase-1-2-3-fast-secure-dev.md` track (do not race it).
-- [ ] **PR-9 — handshake pipelining + guest bind-first** (Phase 2 Lever 2; keep Ed25519 auth-before-trust).
+- [~] **PR-9 — adaptive readiness poll** (Phase 2 Lever 2). Landed: `adaptive_backoff` + `wait_for_guest_agent` rewired (20ms→500ms cap; cuts up to ~480ms dead time per readiness detection; timing-only, connect→negotiate ordering untouched). Deferred (tracked): the `connect_and_authenticate` combiner and the guest `socket/bind/listen`-first reorder — both touch the sealed-prod Ed25519 auth path / agent main and need a live VM to validate.
 - [ ] **PR-10 — warm pool of supervisors** `--warm-pool-size N` default 0 (Phase 2 Lever 3; guests unbooted until admission; control UDS reuses `deny_unknown_fields` parser + new fuzz target).
 
 ### Deferred (tracked in Plan 93 §deferred follow-ups)


### PR DESCRIPTION
Phase 2 Lever 2 (handshake-path latency), the verifiable + security-neutral core.

## What's here
The `mvmctl up` readiness probe (`wait_for_guest_agent`) slept a **fixed 500 ms** between attempts, so a guest that bound in ~80 ms wasn't noticed for up to ~500 ms. This replaces it with an **adaptive backoff** (20 ms → ×2 → 500 ms cap), cutting up to ~480 ms of dead time per detection on the common fast-boot path while a slow guest still polls at the old steady cadence.

- `mvm-guest`: pure `adaptive_backoff(attempt)` helper (saturating, never-zero, capped) next to the connect constants.
- `mvm-cli`: `wait_for_guest_agent` uses it with an attempt counter.

## Security
**Timing-only change.** The `connect → negotiate_protocol` ordering and the ProtocolHello/Ack contract are untouched; no RPC is issued before negotiation succeeds, so the Ed25519 auth-before-trust invariant (claim 10 / ADR-058) is unaffected.

## Deferred (tracked in Sprint 59)
The `connect_and_authenticate` combiner and the guest `socket/bind/listen`-first reorder — both touch the sealed-prod auth path / agent `main` and need a live VM to validate, so they're held back rather than shipped unverified.

## Tests
`adaptive_backoff` schedule: grows, caps, no overflow at large attempt counts, never zero. Gate clippy/fmt clean.

Builds on the Phase 2 bench substrate (#509) which will measure the win once the live libkrun probe is wired.

🤖 Generated with [Claude Code](https://claude.com/claude-code)