### PR TITLE
Plan 107 A3 — vsock nesting hop (WIP: A3.a forwarder core + A3.b listener)

### DIFF
--- a/crates/mvm-build/src/libkrun_builder.rs
+++ b/crates/mvm-build/src/libkrun_builder.rs
@@ -1853,7 +1853,14 @@ impl LibkrunPersistentHostVm {
             .add_virtio_fs("work", path_to_str(&self.workspace_root, "workspace_root")?)
             .add_virtio_fs("out", path_to_str(&job_dir, "job_dir")?)
             .add_virtio_fs("job", path_to_str(&job_dir, "job_dir")?)
-            .add_vsock_port(mvm_guest::builder_agent::BUILDER_DISPATCH_PORT);
+            .add_vsock_port(mvm_guest::builder_agent::BUILDER_DISPATCH_PORT)
+            // Plan 107 A3 — the workload-vsock nesting hop. The
+            // in-host-VM forwarder listens here; the outer host reaches
+            // a workload's Firecracker vsock via
+            // `<vm_state_dir>/vsock-21472.sock`. libkrun registers
+            // vsock ports at launch, so this must be added up front
+            // even though workloads start later (A4).
+            .add_vsock_port(mvm_guest::builder_agent::WORKLOAD_FORWARD_PORT);
 
         krun = apply_networking_mode(krun, &vm_state_dir)?;
 

--- a/crates/mvm-guest/src/builder_agent.rs
+++ b/crates/mvm-guest/src/builder_agent.rs
@@ -45,6 +45,21 @@ pub const BUILDER_DISPATCH_PORT: u32 = 21471;
 /// on each side catch divergence.
 pub const WORKLOAD_FORWARD_PORT: u32 = 21472;
 
+/// Plan 107 A3 — encode the workload-forward multiplex handshake the
+/// in-host-VM forwarder reads before splicing: a u32-BE length prefix
+/// followed by UTF-8 `"<workload_id> <port>"`. The host's
+/// `NestingHopTransport` writes this on connect; the guest side
+/// (`mvm_host_vm_init::workload_proxy::read_handshake`) parses it.
+/// Both pin the exact byte layout by test (the guest can't reference
+/// this crate), so this is the single host-side definition.
+pub fn encode_workload_forward_handshake(workload_id: &str, port: u32) -> Vec<u8> {
+    let body = format!("{workload_id} {port}");
+    let mut out = Vec::with_capacity(4 + body.len());
+    out.extend_from_slice(&(body.len() as u32).to_be_bytes());
+    out.extend_from_slice(body.as_bytes());
+    out
+}
+
 /// Outgoing responses/log frames from the builder agent.
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 pub enum HostVmResponse {
@@ -224,6 +239,23 @@ pub fn handle_request(req: HostVmRequest) -> Result<HostVmResponse> {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn workload_forward_port_literal_is_21472() {
+        // Pin the host-side port; the guest hardcodes the same literal
+        // (it can't depend on this crate). Divergence breaks the hop.
+        assert_eq!(WORKLOAD_FORWARD_PORT, 21472);
+    }
+
+    #[test]
+    fn workload_forward_handshake_byte_layout_is_pinned() {
+        // u32-BE length prefix + UTF-8 "<id> <port>". The guest's
+        // `workload_proxy::encode_handshake` asserts the *same* bytes
+        // for the same input, so the two implementations can't drift.
+        let bytes = encode_workload_forward_handshake("ab", 5);
+        // body "ab 5" = 4 bytes.
+        assert_eq!(bytes, vec![0, 0, 0, 4, b'a', b'b', b' ', b'5']);
+    }
 
     #[test]
     fn serde_round_trip() {

--- a/crates/mvm-guest/src/builder_agent.rs
+++ b/crates/mvm-guest/src/builder_agent.rs
@@ -34,6 +34,17 @@ pub const BUILDER_AGENT_PORT: u32 = 21470;
 /// guest. The guest-side send code lands in W2 part 3.
 pub const BUILDER_DISPATCH_PORT: u32 = 21471;
 
+/// Plan 107 A3 — AF_VSOCK port the in-host-VM workload forwarder
+/// listens on (the nesting hop). Registered on the persistent host
+/// VM's libkrun vsock config alongside [`BUILDER_DISPATCH_PORT`]; the
+/// host opens `<vm_state_dir>/vsock-21472.sock` and the forwarder
+/// multiplexes per workload (see
+/// `mvm_host_vm_init::workload_proxy`). Must stay in lock-step with
+/// the guest's hardcoded `WORKLOAD_FORWARD_PORT` (the guest init
+/// deliberately doesn't depend on `mvm-guest`); the literal-pin tests
+/// on each side catch divergence.
+pub const WORKLOAD_FORWARD_PORT: u32 = 21472;
+
 /// Outgoing responses/log frames from the builder agent.
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 pub enum HostVmResponse {

--- a/crates/mvm-host-vm-init/src/main.rs
+++ b/crates/mvm-host-vm-init/src/main.rs
@@ -101,6 +101,13 @@ mod proxy;
 /// signal-based stop/status helpers are Linux-only.
 #[allow(dead_code)]
 mod workload;
+/// Plan 107 A3 — in-host-VM vsock forwarder (the nesting hop). The
+/// cross-platform CONNECT+splice core is unit-tested on every host;
+/// the AF_VSOCK listener wiring (A3.b) is Linux-only. `unix`-gated
+/// because it uses `UnixStream` (the crate is inert on Windows).
+#[cfg(unix)]
+#[allow(dead_code)]
+mod workload_proxy;
 
 fn main() -> ExitCode {
     #[cfg(target_os = "linux")]

--- a/crates/mvm-host-vm-init/src/main.rs
+++ b/crates/mvm-host-vm-init/src/main.rs
@@ -801,13 +801,14 @@ mod linux {
         fn close(fd: i32) -> i32;
     }
 
-    /// Open + bind + listen an AF_VSOCK socket on
-    /// [`BUILDER_DISPATCH_PORT`]. Returns the listening fd or
-    /// `None` on any setup failure (with stderr breadcrumb).
-    /// `accept_timeout_secs = Some(n)` applies `SO_RCVTIMEO` so
-    /// subsequent `accept()` calls bound the wait at `n`s; `None`
-    /// means accept blocks until a peer connects.
-    fn open_dispatch_listener_fd(accept_timeout_secs: Option<i64>) -> Option<i32> {
+    /// Open + bind + listen an AF_VSOCK socket on `port`. Returns the
+    /// listening fd or `None` on any setup failure (with stderr
+    /// breadcrumb). `accept_timeout_secs = Some(n)` applies
+    /// `SO_RCVTIMEO` so subsequent `accept()` calls bound the wait at
+    /// `n`s; `None` means accept blocks until a peer connects. Used
+    /// for both the dispatch port (21471) and the Plan 107 A3
+    /// workload-forward port (21472).
+    fn open_vsock_listener_fd(port: u32, accept_timeout_secs: Option<i64>) -> Option<i32> {
         let listen_fd = unsafe { socket(AF_VSOCK, SOCK_STREAM, 0) };
         if listen_fd < 0 {
             eprintln!("mvm-host-vm-init: vsock: socket() failed");
@@ -816,7 +817,7 @@ mod linux {
         let addr = SockAddrVm {
             svm_family: AF_VSOCK as u16,
             svm_reserved1: 0,
-            svm_port: BUILDER_DISPATCH_PORT,
+            svm_port: port,
             svm_cid: VMADDR_CID_ANY,
             svm_zero: [0; 4],
         };
@@ -828,7 +829,7 @@ mod linux {
             )
         };
         if rc < 0 {
-            eprintln!("mvm-host-vm-init: vsock: bind() failed on port {BUILDER_DISPATCH_PORT}");
+            eprintln!("mvm-host-vm-init: vsock: bind() failed on port {port}");
             unsafe { close(listen_fd) };
             return None;
         }
@@ -876,6 +877,49 @@ mod linux {
         unsafe { std::fs::File::from_raw_fd(conn_fd) }
     }
 
+    /// Plan 107 A3 — the workload-vsock forwarder listener. Binds the
+    /// AF_VSOCK [`crate::workload_proxy::WORKLOAD_FORWARD_PORT`] and
+    /// loops accepting outer-host connections, handing each to
+    /// [`crate::workload_proxy::handle_forward_conn`] on its own
+    /// thread (the handler reads the multiplex handshake, resolves the
+    /// named workload's `v.sock`, and splices). Runs for the VM's
+    /// lifetime; spawned as a background thread at dispatch-loop entry.
+    /// Never returns under normal operation.
+    fn run_forward_listener() {
+        use std::os::fd::FromRawFd;
+        use std::os::unix::net::UnixStream;
+        use std::path::Path;
+
+        let Some(listen_fd) =
+            open_vsock_listener_fd(crate::workload_proxy::WORKLOAD_FORWARD_PORT, None)
+        else {
+            eprintln!("mvm-host-vm-init: forward listener: setup failed (nesting hop disabled)");
+            return;
+        };
+        eprintln!(
+            "mvm-host-vm-init: forward listener ready on AF_VSOCK port {}",
+            crate::workload_proxy::WORKLOAD_FORWARD_PORT
+        );
+        loop {
+            let Some(conn_fd) = accept_one(listen_fd) else {
+                eprintln!("mvm-host-vm-init: forward listener: accept failed (retrying)");
+                continue;
+            };
+            std::thread::spawn(move || {
+                // The accepted fd is an AF_VSOCK SOCK_STREAM socket;
+                // UnixStream only touches its read/write/clone, so
+                // wrapping it is sound (address family is irrelevant).
+                let inbound = unsafe { UnixStream::from_raw_fd(conn_fd) };
+                if let Err(e) = crate::workload_proxy::handle_forward_conn(
+                    inbound,
+                    Path::new(crate::workload::WORKLOAD_STATE_BASE),
+                ) {
+                    eprintln!("mvm-host-vm-init: forward conn ended: {e}");
+                }
+            });
+        }
+    }
+
     /// Write a length-prefixed (u32 BE) frame on an existing conn.
     /// Mirrors `mvm_guest::vsock::write_frame`. Returns `true` on
     /// successful full-frame write. Doesn't close — caller owns
@@ -915,7 +959,9 @@ mod linux {
 
     fn send_dispatch_response_via_vsock(payload: &crate::dispatch_response::DispatchResponse) {
         const ACCEPT_TIMEOUT_SECS: i64 = 10;
-        let Some(listen_fd) = open_dispatch_listener_fd(Some(ACCEPT_TIMEOUT_SECS)) else {
+        let Some(listen_fd) =
+            open_vsock_listener_fd(BUILDER_DISPATCH_PORT, Some(ACCEPT_TIMEOUT_SECS))
+        else {
             return;
         };
         let Some(conn_fd) = accept_one(listen_fd) else {
@@ -962,7 +1008,14 @@ mod linux {
         // blocks waiting for the supervisor's next submit. The
         // outer `mvmctl dev down` signals shutdown via a
         // `HostVmRequest::Shutdown` frame on a fresh connection.
-        let Some(listen_fd) = open_dispatch_listener_fd(None) else {
+        // Plan 107 A3 — bring up the workload-vsock forwarder before
+        // the dispatch loop. It runs for the VM's lifetime on its own
+        // AF_VSOCK port, bridging the outer host to each workload's
+        // Firecracker v.sock. Failure here is non-fatal: builds still
+        // dispatch; only the nesting hop is unavailable (logged).
+        std::thread::spawn(run_forward_listener);
+
+        let Some(listen_fd) = open_vsock_listener_fd(BUILDER_DISPATCH_PORT, None) else {
             eprintln!("mvm-host-vm-init: dispatch loop: listener setup failed");
             return 1;
         };

--- a/crates/mvm-host-vm-init/src/workload_proxy.rs
+++ b/crates/mvm-host-vm-init/src/workload_proxy.rs
@@ -1,0 +1,330 @@
+//! Plan 107 A3 — in-host-VM vsock forwarder (the nesting hop).
+//!
+//! The outer host can't reach a workload microVM's vsock directly:
+//! the workload's Firecracker runs *inside* this host VM and exposes
+//! its vsock as a Unix-domain socket at
+//! `/var/lib/mvm/workloads/<id>/v.sock` (Firecracker hybrid-vsock).
+//! This module bridges that gap.
+//!
+//! ## The hop
+//!
+//! ```text
+//! outer host
+//!   → host-VM AF_VSOCK port WORKLOAD_FORWARD_PORT  (libkrun UDS)
+//!     → [this forwarder, inside the host VM]
+//!       → workload Firecracker v.sock UDS  (CONNECT <port>\n / OK)
+//!         → workload guest agent (vsock port, e.g. 5252)
+//! ```
+//!
+//! ## Why one fixed port + a handshake (not a port per workload)
+//!
+//! libkrun registers its vsock ports when the host VM is *launched*
+//! (`krun_add_vsock_port2`); ports can't be added per workload at
+//! runtime. So the host VM exposes a single [`WORKLOAD_FORWARD_PORT`]
+//! and the forwarder multiplexes: each inbound connection opens with
+//! a length-prefixed `"<workload_id> <port>"` handshake naming which
+//! workload + which guest port to reach. The forwarder resolves the
+//! workload's `v.sock`, speaks Firecracker's hybrid-vsock CONNECT
+//! handshake, then splices bytes both ways.
+//!
+//! ## No serde
+//!
+//! Same size-budget rationale as the rest of `mvm-host-vm-init`: the
+//! handshake is hand-parsed, the CONNECT line hand-rolled. The
+//! cross-platform core ([`handle_forward_conn`] and helpers) is
+//! exercised by `cargo test` on every host against a fake `v.sock`
+//! server — no VM required; only the AF_VSOCK listener (A3.b) is
+//! Linux-only.
+
+#![cfg(unix)]
+
+use std::io::{self, Read, Write};
+use std::net::Shutdown;
+use std::os::unix::net::UnixStream;
+use std::path::Path;
+
+/// Fixed AF_VSOCK port the forwarder listens on inside the host VM,
+/// registered at host-VM launch alongside the dispatch port (21471).
+pub const WORKLOAD_FORWARD_PORT: u32 = 21472;
+
+/// Upper bound on the inbound handshake body. A handshake is just
+/// `"<uuid> <port>"`, so this is generous; anything larger is junk.
+const MAX_HANDSHAKE_BYTES: usize = 256;
+
+/// Upper bound on a single CONNECT response line from Firecracker.
+const MAX_CONNECT_LINE_BYTES: usize = 64;
+
+/// Parse the inbound multiplex handshake: a u32-BE length prefix
+/// followed by a UTF-8 body `"<workload_id> <port>"`. Returns the
+/// workload id and the guest vsock port to reach.
+fn read_handshake<R: Read>(conn: &mut R) -> io::Result<(String, u32)> {
+    let mut len_buf = [0u8; 4];
+    conn.read_exact(&mut len_buf)?;
+    let len = u32::from_be_bytes(len_buf) as usize;
+    if len == 0 || len > MAX_HANDSHAKE_BYTES {
+        return Err(io::Error::new(
+            io::ErrorKind::InvalidData,
+            format!("forward handshake length {len} out of range"),
+        ));
+    }
+    let mut body = vec![0u8; len];
+    conn.read_exact(&mut body)?;
+    let text = String::from_utf8(body)
+        .map_err(|e| io::Error::new(io::ErrorKind::InvalidData, e.to_string()))?;
+    let (id, port_str) = text.split_once(' ').ok_or_else(|| {
+        io::Error::new(io::ErrorKind::InvalidData, "forward handshake missing port")
+    })?;
+    if id.is_empty() {
+        return Err(io::Error::new(
+            io::ErrorKind::InvalidData,
+            "forward handshake empty workload_id",
+        ));
+    }
+    let port: u32 = port_str.trim().parse().map_err(|_| {
+        io::Error::new(
+            io::ErrorKind::InvalidData,
+            "forward handshake port is not a u32",
+        )
+    })?;
+    Ok((id.to_string(), port))
+}
+
+/// Read one `\n`-terminated line byte-by-byte (no buffering, so we
+/// never over-read into the post-handshake byte stream). Caps at
+/// `max` bytes.
+fn read_line_unbuffered<R: Read>(conn: &mut R, max: usize) -> io::Result<String> {
+    let mut out = Vec::new();
+    let mut byte = [0u8; 1];
+    loop {
+        let n = conn.read(&mut byte)?;
+        if n == 0 {
+            break; // EOF before newline
+        }
+        if byte[0] == b'\n' {
+            break;
+        }
+        out.push(byte[0]);
+        if out.len() > max {
+            return Err(io::Error::new(
+                io::ErrorKind::InvalidData,
+                "CONNECT response line too long",
+            ));
+        }
+    }
+    String::from_utf8(out).map_err(|e| io::Error::new(io::ErrorKind::InvalidData, e.to_string()))
+}
+
+/// Open the workload's Firecracker hybrid-vsock UDS and request the
+/// given guest port via the `CONNECT <port>\n` / `OK ...` handshake.
+/// Returns the connected stream positioned at the start of the raw
+/// guest byte stream.
+fn connect_firecracker_vsock(uds_path: &Path, port: u32) -> io::Result<UnixStream> {
+    let mut stream = UnixStream::connect(uds_path)?;
+    // Firecracker hybrid-vsock expects `CONNECT <port>\n` (writeln!
+    // appends exactly the `\n` terminator the protocol wants).
+    writeln!(stream, "CONNECT {port}")?;
+    stream.flush()?;
+    let line = read_line_unbuffered(&mut stream, MAX_CONNECT_LINE_BYTES)?;
+    // Firecracker answers "OK <assigned_host_port>" on success.
+    if !line.starts_with("OK") {
+        return Err(io::Error::new(
+            io::ErrorKind::ConnectionRefused,
+            format!("firecracker vsock CONNECT {port} rejected: {:?}", line),
+        ));
+    }
+    Ok(stream)
+}
+
+/// Copy bytes both directions between `a` and `b` until either side
+/// closes, half-closing the peer's write side on each EOF so the
+/// other copy unblocks. Returns when both directions are drained.
+fn splice_bidirectional(a: UnixStream, b: UnixStream) -> io::Result<()> {
+    let mut a_read = a.try_clone()?;
+    let mut a_write = a;
+    let mut b_read = b.try_clone()?;
+    let mut b_write = b;
+
+    let pump = std::thread::spawn(move || {
+        let _ = io::copy(&mut a_read, &mut b_write);
+        let _ = b_write.shutdown(Shutdown::Write);
+    });
+    let _ = io::copy(&mut b_read, &mut a_write);
+    let _ = a_write.shutdown(Shutdown::Write);
+    let _ = pump.join();
+    Ok(())
+}
+
+/// Handle one inbound forwarder connection end-to-end: read the
+/// multiplex handshake, resolve the named workload's `v.sock` under
+/// `base`, CONNECT to the requested guest port, and splice.
+///
+/// `inbound` is the accepted hop connection — a host-VM AF_VSOCK
+/// socket in production (wrapped as a [`UnixStream`], which only
+/// touches the fd's read/write/clone, agnostic to address family),
+/// or a [`UnixStream`] pair in tests. `base` is the per-workload
+/// state base dir (`/var/lib/mvm/workloads` in production).
+pub fn handle_forward_conn(mut inbound: UnixStream, base: &Path) -> io::Result<()> {
+    let (workload_id, port) = read_handshake(&mut inbound)?;
+    // Fail closed on a workload_id that could escape the base dir.
+    // Real ids are host-minted UUIDs (no `/`, no `..`).
+    if workload_id.contains('/') || workload_id.contains("..") {
+        return Err(io::Error::new(
+            io::ErrorKind::InvalidData,
+            format!("forward handshake unsafe workload_id: {workload_id:?}"),
+        ));
+    }
+    let vsock_uds = base.join(&workload_id).join("v.sock");
+    let upstream = connect_firecracker_vsock(&vsock_uds, port)?;
+    splice_bidirectional(inbound, upstream)
+}
+
+/// Encode the multiplex handshake the way [`read_handshake`] parses
+/// it: a u32-BE length prefix + `"<workload_id> <port>"`. Exposed so
+/// the host-side `NestingHopTransport` (A3.c) and the tests share one
+/// definition of the wire shape.
+pub fn encode_handshake(workload_id: &str, port: u32) -> Vec<u8> {
+    let body = format!("{workload_id} {port}");
+    let mut out = Vec::with_capacity(4 + body.len());
+    out.extend_from_slice(&(body.len() as u32).to_be_bytes());
+    out.extend_from_slice(body.as_bytes());
+    out
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::io::{Read, Write};
+    use std::os::unix::net::UnixListener;
+    use std::path::PathBuf;
+
+    fn write_handshake(stream: &mut UnixStream, id: &str, port: u32) {
+        stream.write_all(&encode_handshake(id, port)).unwrap();
+    }
+
+    #[test]
+    fn handshake_round_trips_through_encode_and_read() {
+        let bytes = encode_handshake("00000000-0000-0000-0000-000000000001", 5252);
+        let mut cursor = io::Cursor::new(bytes);
+        let (id, port) = read_handshake(&mut cursor).unwrap();
+        assert_eq!(id, "00000000-0000-0000-0000-000000000001");
+        assert_eq!(port, 5252);
+    }
+
+    #[test]
+    fn read_handshake_rejects_bad_inputs() {
+        // zero length
+        let mut z = io::Cursor::new(0u32.to_be_bytes().to_vec());
+        assert!(read_handshake(&mut z).is_err());
+        // over cap
+        let mut big = io::Cursor::new(((MAX_HANDSHAKE_BYTES as u32) + 1).to_be_bytes().to_vec());
+        assert!(read_handshake(&mut big).is_err());
+        // missing port (no space)
+        let body = b"justanid";
+        let mut buf = (body.len() as u32).to_be_bytes().to_vec();
+        buf.extend_from_slice(body);
+        assert!(read_handshake(&mut io::Cursor::new(buf)).is_err());
+        // non-numeric port
+        let body = b"id xyz";
+        let mut buf = (body.len() as u32).to_be_bytes().to_vec();
+        buf.extend_from_slice(body);
+        assert!(read_handshake(&mut io::Cursor::new(buf)).is_err());
+    }
+
+    /// Spawn a fake Firecracker hybrid-vsock server at `uds_path`:
+    /// accept one connection, read the `CONNECT <port>\n` line, reply
+    /// `ok_line`, then run `after(stream)` (e.g. echo). Returns the
+    /// join handle + the CONNECT port it observed (via a channel).
+    fn fake_vsock_server(
+        uds_path: PathBuf,
+        ok_line: &'static str,
+        echo: bool,
+    ) -> (
+        std::thread::JoinHandle<()>,
+        std::sync::mpsc::Receiver<String>,
+    ) {
+        let (tx, rx) = std::sync::mpsc::channel();
+        let listener = UnixListener::bind(&uds_path).unwrap();
+        let h = std::thread::spawn(move || {
+            let (mut conn, _) = listener.accept().unwrap();
+            // Read the CONNECT line byte-by-byte.
+            let line = read_line_unbuffered(&mut conn, 64).unwrap();
+            let _ = tx.send(line);
+            conn.write_all(ok_line.as_bytes()).unwrap();
+            conn.flush().unwrap();
+            if echo {
+                let mut buf = [0u8; 1024];
+                loop {
+                    match conn.read(&mut buf) {
+                        Ok(0) | Err(_) => break,
+                        Ok(n) => {
+                            if conn.write_all(&buf[..n]).is_err() {
+                                break;
+                            }
+                        }
+                    }
+                }
+            }
+        });
+        (h, rx)
+    }
+
+    #[test]
+    fn connect_firecracker_vsock_speaks_connect_and_accepts_ok() {
+        let tmp = tempfile::tempdir().unwrap();
+        let uds = tmp.path().join("v.sock");
+        let (server, port_rx) = fake_vsock_server(uds.clone(), "OK 1024\n", false);
+        let stream = connect_firecracker_vsock(&uds, 5252).expect("connect ok");
+        drop(stream);
+        let observed = port_rx.recv().unwrap();
+        assert_eq!(observed, "CONNECT 5252");
+        server.join().unwrap();
+    }
+
+    #[test]
+    fn connect_firecracker_vsock_rejects_non_ok() {
+        let tmp = tempfile::tempdir().unwrap();
+        let uds = tmp.path().join("v.sock");
+        let (server, _rx) = fake_vsock_server(uds.clone(), "ERR no such port\n", false);
+        let err = connect_firecracker_vsock(&uds, 5252).unwrap_err();
+        assert_eq!(err.kind(), io::ErrorKind::ConnectionRefused);
+        server.join().unwrap();
+    }
+
+    #[test]
+    fn handle_forward_conn_splices_end_to_end() {
+        let tmp = tempfile::tempdir().unwrap();
+        let base = tmp.path();
+        let id = "00000000-0000-0000-0000-00000000abcd";
+        std::fs::create_dir_all(base.join(id)).unwrap();
+        let uds = base.join(id).join("v.sock");
+        let (server, port_rx) = fake_vsock_server(uds, "OK 1024\n", true);
+
+        let (mut client, inbound) = UnixStream::pair().unwrap();
+        let base_owned = base.to_path_buf();
+        let fwd = std::thread::spawn(move || handle_forward_conn(inbound, &base_owned));
+
+        // Drive the hop from the outer-host side.
+        write_handshake(&mut client, id, 5252);
+        client.write_all(b"ping over the hop").unwrap();
+        client.shutdown(Shutdown::Write).unwrap();
+        let mut echoed = Vec::new();
+        client.read_to_end(&mut echoed).unwrap();
+
+        assert_eq!(echoed, b"ping over the hop");
+        assert_eq!(port_rx.recv().unwrap(), "CONNECT 5252");
+        fwd.join().unwrap().expect("forward conn ok");
+        server.join().unwrap();
+    }
+
+    #[test]
+    fn handle_forward_conn_rejects_path_traversal_id() {
+        let tmp = tempfile::tempdir().unwrap();
+        let (mut client, inbound) = UnixStream::pair().unwrap();
+        let base = tmp.path().to_path_buf();
+        let fwd = std::thread::spawn(move || handle_forward_conn(inbound, &base));
+        write_handshake(&mut client, "../../etc", 5252);
+        let _ = client.shutdown(Shutdown::Write);
+        let res = fwd.join().unwrap();
+        assert!(res.is_err(), "path-traversal workload_id must fail closed");
+    }
+}

--- a/crates/mvm-host-vm-init/src/workload_proxy.rs
+++ b/crates/mvm-host-vm-init/src/workload_proxy.rs
@@ -212,6 +212,16 @@ mod tests {
     }
 
     #[test]
+    fn handshake_byte_layout_matches_host_encoder() {
+        // The host side (`mvm_guest::builder_agent::
+        // encode_workload_forward_handshake`) pins the *same* literal
+        // bytes for this input. Keeping both pinned to the identical
+        // layout is how the two no-shared-dep encoders stay in sync.
+        let bytes = encode_handshake("ab", 5);
+        assert_eq!(bytes, vec![0, 0, 0, 4, b'a', b'b', b' ', b'5']);
+    }
+
+    #[test]
     fn handshake_round_trips_through_encode_and_read() {
         let bytes = encode_handshake("00000000-0000-0000-0000-000000000001", 5252);
         let mut cursor = io::Cursor::new(bytes);

--- a/crates/mvm-host-vm-init/src/workload_proxy.rs
+++ b/crates/mvm-host-vm-init/src/workload_proxy.rs
@@ -202,6 +202,16 @@ mod tests {
     }
 
     #[test]
+    fn workload_forward_port_literal_is_21472() {
+        // The guest init deliberately doesn't depend on `mvm-guest`,
+        // so this literal must stay in lock-step with the host side
+        // (`mvm_guest::builder_agent::WORKLOAD_FORWARD_PORT`). If the
+        // host changes the port, this pin fails and points at the
+        // resync — same tactic as the dispatch-port pin.
+        assert_eq!(WORKLOAD_FORWARD_PORT, 21472);
+    }
+
+    #[test]
     fn handshake_round_trips_through_encode_and_read() {
         let bytes = encode_handshake("00000000-0000-0000-0000-000000000001", 5252);
         let mut cursor = io::Cursor::new(bytes);

--- a/crates/mvm/src/vsock_transport.rs
+++ b/crates/mvm/src/vsock_transport.rs
@@ -161,6 +161,59 @@ impl VsockTransport for VsockProxyTransport {
     }
 }
 
+/// Connects through the Plan 107 A3 nesting hop: the outer host
+/// reaches a workload microVM's vsock *via* the long-lived libkrun
+/// host VM. The hop socket is the host VM's libkrun UDS for
+/// [`mvm_guest::builder_agent::WORKLOAD_FORWARD_PORT`]
+/// (`<vm_state_dir>/vsock-21472.sock`). On connect, the host writes a
+/// `<workload_id> <port>` handshake and the in-host-VM forwarder
+/// (`mvm_host_vm_init::workload_proxy`) multiplexes the stream to that
+/// workload's Firecracker `v.sock`. The workload guest agent is
+/// unchanged — it still sees vsock CID 3, just one nesting level in.
+pub struct NestingHopTransport {
+    hop_socket_path: PathBuf,
+    workload_id: String,
+}
+
+impl NestingHopTransport {
+    pub fn new(hop_socket_path: impl Into<PathBuf>, workload_id: impl Into<String>) -> Self {
+        Self {
+            hop_socket_path: hop_socket_path.into(),
+            workload_id: workload_id.into(),
+        }
+    }
+
+    /// Build the hop transport for a host VM whose libkrun vsock
+    /// sockets live under `vm_state_dir`, targeting `workload_id`. The
+    /// forward-port socket name mirrors libkrun's `vsock-<port>.sock`
+    /// convention.
+    pub fn for_host_vm(vm_state_dir: impl Into<PathBuf>, workload_id: impl Into<String>) -> Self {
+        let dir: PathBuf = vm_state_dir.into();
+        let hop = dir.join(format!(
+            "vsock-{}.sock",
+            mvm_guest::builder_agent::WORKLOAD_FORWARD_PORT
+        ));
+        Self::new(hop, workload_id)
+    }
+}
+
+impl VsockTransport for NestingHopTransport {
+    fn connect(&self, port: u32) -> Result<UnixStream> {
+        let mut stream = UnixStream::connect(&self.hop_socket_path).with_context(|| {
+            format!(
+                "Failed to connect to nesting hop at {}",
+                self.hop_socket_path.display()
+            )
+        })?;
+        let handshake =
+            mvm_guest::builder_agent::encode_workload_forward_handshake(&self.workload_id, port);
+        stream
+            .write_all(&handshake)
+            .with_context(|| "Failed to write nesting-hop handshake")?;
+        Ok(stream)
+    }
+}
+
 /// Pick a transport for a VM by name.
 ///
 /// Probes Apple Container first by attempting a real connect to the
@@ -238,5 +291,61 @@ mod tests {
             msg.contains("/tmp/no-such-libkrun-vm"),
             "error didn't mention socket dir: {msg}"
         );
+    }
+
+    #[test]
+    fn nesting_hop_for_host_vm_derives_forward_socket_path() {
+        let t = NestingHopTransport::for_host_vm("/tmp/vm-state", "wl-1");
+        assert_eq!(
+            t.hop_socket_path,
+            PathBuf::from("/tmp/vm-state/vsock-21472.sock")
+        );
+        assert_eq!(t.workload_id, "wl-1");
+    }
+
+    #[test]
+    fn nesting_hop_connect_error_mentions_hop_path() {
+        let t = NestingHopTransport::new("/tmp/no-such-hop-21472.sock", "wl-1");
+        let err = t
+            .connect(mvm_guest::vsock::GUEST_AGENT_PORT)
+            .expect_err("should fail to connect");
+        let msg = err.to_string();
+        assert!(
+            msg.contains("nesting hop") && msg.contains("/tmp/no-such-hop-21472.sock"),
+            "error didn't mention hop path: {msg}"
+        );
+    }
+
+    #[test]
+    fn nesting_hop_writes_handshake_on_connect() {
+        use std::io::Read;
+        use std::os::unix::net::UnixListener;
+
+        let dir = tempfile::tempdir().unwrap();
+        let hop = dir.path().join("vsock-21472.sock");
+        let listener = UnixListener::bind(&hop).unwrap();
+        let server = std::thread::spawn(move || {
+            let (mut conn, _) = listener.accept().unwrap();
+            let mut len = [0u8; 4];
+            conn.read_exact(&mut len).unwrap();
+            let n = u32::from_be_bytes(len) as usize;
+            let mut body = vec![0u8; n];
+            conn.read_exact(&mut body).unwrap();
+            (len.to_vec(), body)
+        });
+
+        let t = NestingHopTransport::new(&hop, "wl-abc");
+        let _stream = t.connect(5252).expect("connect + handshake");
+
+        let (len, body) = server.join().unwrap();
+        // The bytes on the wire must be exactly what the shared
+        // host-side encoder produces (which the guest forwarder
+        // parses) — pins the hop wire shape end-to-end.
+        let mut expected =
+            mvm_guest::builder_agent::encode_workload_forward_handshake("wl-abc", 5252);
+        let expected_body = expected.split_off(4);
+        assert_eq!(len, expected, "length prefix mismatch");
+        assert_eq!(body, expected_body, "handshake body mismatch");
+        assert_eq!(String::from_utf8(body).unwrap(), "wl-abc 5252");
     }
 }


### PR DESCRIPTION
## Plan 107 Phase A3 — vsock nesting hop (DRAFT, in progress)

Lets the outer host reach a workload microVM's vsock *through* the long-lived libkrun host VM:

```
outer host → host-VM AF_VSOCK port 21472 → [in-host-VM forwarder] → workload Firecracker v.sock UDS → workload agent
```

**Design constraint:** libkrun registers vsock ports at host-VM *launch*, so the host VM exposes a single fixed `WORKLOAD_FORWARD_PORT` (21472) and the forwarder multiplexes per workload via a `<workload_id> <port>` handshake.

### Landed so far
- **A3.a** — forwarder **core** (`workload_proxy.rs`): handshake parse, Firecracker hybrid-vsock `CONNECT`/`OK`, bidirectional splice, path-traversal fail-closed. **7 hermetic tests** (incl. full end-to-end relay against a fake `v.sock` server) — no VM needed.
- **A3.b** — wire it into the running host VM: `WORKLOAD_FORWARD_PORT` host-side const (`mvm-guest`), libkrun registers it on the persistent host VM, and a Linux AF_VSOCK `run_forward_listener` (spawned at dispatch-loop entry) hands each connection to the core on its own thread.

### Remaining (this PR)
- **A3.c** — host-side `NestingHopTransport` in `vsock_transport.rs` (prepends `encode_handshake`) + route the proxy through the hop.
- **A3.d** — bounded `Semaphore` guardrail (A3.4) + audit-parity assertion (A3.3).
- **A3.5** — cross-hop framing/tamper/oversize hermetic tests; mark ready.

Live cross-hop boot stays deferred to **A4.5** (no nested KVM in CI). The Linux-only listener is validated here by the Lint + Test lanes (both compile `target_os="linux"`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)