### PR TITLE
Plan 107 A4.a — host-side WorkloadStart/Stop/Status dispatcher (WIP A4)

### DIFF
--- a/crates/mvm-build/src/persistent_builder.rs
+++ b/crates/mvm-build/src/persistent_builder.rs
@@ -45,7 +45,9 @@ use std::time::Duration;
 
 use thiserror::Error;
 
-use crate::builder_protocol::{BootTimingsWire, HostVmRequest, HostVmResponse, JobId, JobTimings};
+use crate::builder_protocol::{
+    BootTimingsWire, HostVmRequest, HostVmResponse, JobId, JobTimings, WorkloadId,
+};
 use crate::builder_vm::BuilderJob;
 
 /// Plan 89 W3 part 14 — host-side hook the persistent dispatch
@@ -140,6 +142,30 @@ pub struct DispatchOutcome {
     pub job_timings: JobTimings,
 }
 
+/// Plan 107 A4 — the spawn config for a nested workload microVM,
+/// the host-side input to [`HostVmRequest::WorkloadStart`]. All
+/// paths are resolved *inside the host VM* (see the protocol doc);
+/// A4's backend branch stages the artifacts into a host-VM share and
+/// fills these with the guest-visible paths.
+#[derive(Debug, Clone)]
+pub struct WorkloadStartParams {
+    pub kernel_path: String,
+    pub rootfs_path: String,
+    pub vsock_socket_dir: String,
+    pub vcpus: u32,
+    pub memory_mib: u32,
+    pub kernel_cmdline_extras: String,
+}
+
+/// Plan 107 A4 — outcome of a successful `WorkloadStart` dispatch:
+/// the host-minted id the guest echoed and the spawned VMM pid
+/// (inside the host VM) the host tracks for lifecycle.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct WorkloadStartOutcome {
+    pub workload_id: WorkloadId,
+    pub pid: u32,
+}
+
 /// Typed error surface for [`PersistentBuilderSupervisor`].
 #[derive(Debug, Error)]
 pub enum PersistentBuilderError {
@@ -182,6 +208,25 @@ pub enum PersistentBuilderError {
     /// mid-flight). Caller should rebuild the supervisor.
     #[error("dispatch mutex poisoned — caller must restart the supervisor")]
     MutexPoisoned,
+
+    /// Plan 107 A4 — the guest returned [`HostVmResponse::WorkloadFailed`]
+    /// for a workload lifecycle request (spawn / stop). Carries the
+    /// guest's failure reason.
+    #[error("workload {workload_id} failed in host VM: {error}")]
+    WorkloadFailed {
+        workload_id: WorkloadId,
+        error: String,
+    },
+
+    /// Plan 107 A4 — the guest answered a workload request with a
+    /// frame of the wrong kind (e.g. a `WorkloadStopped` for a
+    /// `WorkloadStart`). A protocol violation — the dispatch loop is
+    /// corrupted or out of sync.
+    #[error("unexpected response to {expected}: got {got}")]
+    UnexpectedResponse {
+        expected: &'static str,
+        got: &'static str,
+    },
 }
 
 /// Persistent builder VM dispatch supervisor.
@@ -312,6 +357,117 @@ impl PersistentBuilderSupervisor {
         }
     }
 
+    /// Plan 107 A4 — dispatch a [`HostVmRequest::WorkloadStart`] to
+    /// the host VM, which spawns the workload microVM (Firecracker)
+    /// inside itself. Mints a fresh [`WorkloadId`], returns the
+    /// echoed id + spawned VMM pid on success, or
+    /// [`PersistentBuilderError::WorkloadFailed`] if the guest
+    /// refused. Workload requests get a single reply (no streaming),
+    /// so this uses [`Self::dispatch_single_response`] rather than the
+    /// build-job [`Self::dispatch`] streaming loop.
+    pub fn submit_workload_start(
+        &self,
+        params: WorkloadStartParams,
+    ) -> Result<WorkloadStartOutcome, PersistentBuilderError> {
+        let _guard = self
+            .dispatch_mutex
+            .lock()
+            .map_err(|_| PersistentBuilderError::MutexPoisoned)?;
+        let workload_id = WorkloadId::new();
+        let request = HostVmRequest::WorkloadStart {
+            workload_id,
+            kernel_path: params.kernel_path,
+            rootfs_path: params.rootfs_path,
+            vsock_socket_dir: params.vsock_socket_dir,
+            vcpus: params.vcpus,
+            memory_mib: params.memory_mib,
+            kernel_cmdline_extras: params.kernel_cmdline_extras,
+        };
+        match self.dispatch_single_response(&request)? {
+            HostVmResponse::WorkloadStarted {
+                workload_id: got,
+                pid,
+            } => Ok(WorkloadStartOutcome {
+                workload_id: got,
+                pid,
+            }),
+            HostVmResponse::WorkloadFailed { workload_id, error } => {
+                Err(PersistentBuilderError::WorkloadFailed { workload_id, error })
+            }
+            other => Err(PersistentBuilderError::UnexpectedResponse {
+                expected: "workload_started",
+                got: response_kind(&other),
+            }),
+        }
+    }
+
+    /// Plan 107 A4 — dispatch a [`HostVmRequest::WorkloadStop`] and
+    /// confirm the guest tore the workload down.
+    pub fn submit_workload_stop(
+        &self,
+        workload_id: WorkloadId,
+    ) -> Result<(), PersistentBuilderError> {
+        let _guard = self
+            .dispatch_mutex
+            .lock()
+            .map_err(|_| PersistentBuilderError::MutexPoisoned)?;
+        let request = HostVmRequest::WorkloadStop { workload_id };
+        match self.dispatch_single_response(&request)? {
+            HostVmResponse::WorkloadStopped { .. } => Ok(()),
+            HostVmResponse::WorkloadFailed { workload_id, error } => {
+                Err(PersistentBuilderError::WorkloadFailed { workload_id, error })
+            }
+            other => Err(PersistentBuilderError::UnexpectedResponse {
+                expected: "workload_stopped",
+                got: response_kind(&other),
+            }),
+        }
+    }
+
+    /// Plan 107 A4 — dispatch a [`HostVmRequest::WorkloadStatus`].
+    /// Returns the guest's status string (`"running"` / `"stopped"`
+    /// / `"not_found"`).
+    pub fn submit_workload_status(
+        &self,
+        workload_id: WorkloadId,
+    ) -> Result<String, PersistentBuilderError> {
+        let _guard = self
+            .dispatch_mutex
+            .lock()
+            .map_err(|_| PersistentBuilderError::MutexPoisoned)?;
+        let request = HostVmRequest::WorkloadStatus { workload_id };
+        match self.dispatch_single_response(&request)? {
+            HostVmResponse::WorkloadStatusReport { status, .. } => Ok(status),
+            HostVmResponse::WorkloadFailed { workload_id, error } => {
+                Err(PersistentBuilderError::WorkloadFailed { workload_id, error })
+            }
+            other => Err(PersistentBuilderError::UnexpectedResponse {
+                expected: "workload_status_report",
+                got: response_kind(&other),
+            }),
+        }
+    }
+
+    /// Connect, write `request`, and read exactly one response frame.
+    /// Used by the workload lifecycle calls, which (unlike build-job
+    /// dispatch) expect a single reply rather than a stderr stream +
+    /// terminating Result. A clean EOF before any frame is a
+    /// [`PersistentBuilderError::PrematureEof`] (guest crashed).
+    fn dispatch_single_response(
+        &self,
+        request: &HostVmRequest,
+    ) -> Result<HostVmResponse, PersistentBuilderError> {
+        let mut stream = self.connect()?;
+        let _ = stream.set_read_timeout(Some(self.frame_read_timeout));
+        let _ = stream.set_write_timeout(Some(self.frame_read_timeout));
+        mvm_guest::vsock::write_frame(&mut stream, request)
+            .map_err(|e| std::io::Error::other(e.to_string()))?;
+        match read_next_response(&mut stream, self.frame_read_timeout)? {
+            Some(resp) => Ok(resp),
+            None => Err(PersistentBuilderError::PrematureEof { chunks: 0 }),
+        }
+    }
+
     /// Send a [`HostVmRequest::Shutdown`] to the guest's dispatch
     /// loop and wait for the matching [`HostVmResponse::Bye`].
     /// Consumes `self` because the supervisor is one-shot after
@@ -424,6 +580,20 @@ impl PersistentBuilderSupervisor {
                 }
             }
         }
+    }
+}
+
+/// The wire `kind` tag of a response, for `UnexpectedResponse`
+/// diagnostics. Mirrors the serde `rename_all = "snake_case"` tags.
+fn response_kind(resp: &HostVmResponse) -> &'static str {
+    match resp {
+        HostVmResponse::StderrChunk { .. } => "stderr_chunk",
+        HostVmResponse::Result { .. } => "result",
+        HostVmResponse::Bye {} => "bye",
+        HostVmResponse::WorkloadStarted { .. } => "workload_started",
+        HostVmResponse::WorkloadStopped { .. } => "workload_stopped",
+        HostVmResponse::WorkloadStatusReport { .. } => "workload_status_report",
+        HostVmResponse::WorkloadFailed { .. } => "workload_failed",
     }
 }
 

--- a/crates/mvm-build/tests/persistent_builder_supervisor.rs
+++ b/crates/mvm-build/tests/persistent_builder_supervisor.rs
@@ -14,12 +14,12 @@ use std::path::Path;
 use std::time::Duration;
 
 use mvm_build::builder_protocol::{
-    BootTimingsWire, HostVmRequest, HostVmResponse, JobId, JobTimings,
+    BootTimingsWire, HostVmRequest, HostVmResponse, JobId, JobTimings, WorkloadId,
 };
 use mvm_build::builder_vm::BuilderJob;
 use mvm_build::persistent_builder::{
     BuilderAuditSink, DispatchOutcome, PersistentBuilderError, PersistentBuilderSupervisor,
-    dispatch_socket_path,
+    WorkloadStartParams, dispatch_socket_path,
 };
 
 /// Spawn a fake guest dispatch loop on `socket_path`. The closure
@@ -451,4 +451,180 @@ fn submit_without_audit_sink_emits_nothing() {
     // No sink, no panic, no recorded events. The test passes if
     // we get here cleanly — the supervisor's `Option<sink>`
     // branches don't dereference None.
+}
+
+// ── Plan 107 A4 — workload lifecycle dispatch ───────────────────
+
+fn sample_workload_params() -> WorkloadStartParams {
+    WorkloadStartParams {
+        kernel_path: "/job/workload/vmlinux".to_string(),
+        rootfs_path: "/job/workload/rootfs.ext4".to_string(),
+        vsock_socket_dir: "/var/lib/mvm/workloads".to_string(),
+        vcpus: 2,
+        memory_mib: 1024,
+        kernel_cmdline_extras: "root=/dev/vda ro".to_string(),
+    }
+}
+
+#[test]
+fn submit_workload_start_round_trips_started() {
+    let scratch = tempfile::tempdir().expect("tempdir");
+    let socket = dispatch_socket_path(scratch.path());
+
+    let guest = spawn_fake_guest(&socket, |mut conn| {
+        let request: HostVmRequest = mvm_guest::vsock::read_frame(&mut conn).expect("read request");
+        let workload_id = match &request {
+            HostVmRequest::WorkloadStart {
+                workload_id,
+                vcpus,
+                memory_mib,
+                ..
+            } => {
+                assert_eq!(*vcpus, 2);
+                assert_eq!(*memory_mib, 1024);
+                *workload_id
+            }
+            other => panic!("expected WorkloadStart, got {other:?}"),
+        };
+        let response = HostVmResponse::WorkloadStarted {
+            workload_id,
+            pid: 4242,
+        };
+        mvm_guest::vsock::write_frame(&mut conn, &response).expect("write response");
+    });
+
+    let supervisor =
+        PersistentBuilderSupervisor::new(&socket).with_frame_read_timeout(Duration::from_secs(1));
+    let outcome = supervisor
+        .submit_workload_start(sample_workload_params())
+        .expect("workload start");
+    guest.join().expect("guest");
+    assert_eq!(outcome.pid, 4242);
+}
+
+#[test]
+fn submit_workload_start_surfaces_workload_failed() {
+    let scratch = tempfile::tempdir().expect("tempdir");
+    let socket = dispatch_socket_path(scratch.path());
+
+    let guest = spawn_fake_guest(&socket, |mut conn| {
+        let request: HostVmRequest = mvm_guest::vsock::read_frame(&mut conn).expect("read request");
+        let workload_id = match &request {
+            HostVmRequest::WorkloadStart { workload_id, .. } => *workload_id,
+            other => panic!("expected WorkloadStart, got {other:?}"),
+        };
+        let response = HostVmResponse::WorkloadFailed {
+            workload_id,
+            error: "spawn /usr/bin/firecracker: ENOENT".to_string(),
+        };
+        mvm_guest::vsock::write_frame(&mut conn, &response).expect("write response");
+    });
+
+    let supervisor =
+        PersistentBuilderSupervisor::new(&socket).with_frame_read_timeout(Duration::from_secs(1));
+    let err = supervisor
+        .submit_workload_start(sample_workload_params())
+        .expect_err("must surface WorkloadFailed");
+    guest.join().expect("guest");
+    match err {
+        PersistentBuilderError::WorkloadFailed { error, .. } => {
+            assert!(error.contains("ENOENT"), "error lost: {error}");
+        }
+        other => panic!("expected WorkloadFailed, got {other:?}"),
+    }
+}
+
+#[test]
+fn submit_workload_start_rejects_unexpected_response() {
+    let scratch = tempfile::tempdir().expect("tempdir");
+    let socket = dispatch_socket_path(scratch.path());
+
+    let guest = spawn_fake_guest(&socket, |mut conn| {
+        let _req: HostVmRequest = mvm_guest::vsock::read_frame(&mut conn).expect("read request");
+        // Wrong kind for a WorkloadStart.
+        mvm_guest::vsock::write_frame(&mut conn, &HostVmResponse::Bye {}).expect("write response");
+    });
+
+    let supervisor =
+        PersistentBuilderSupervisor::new(&socket).with_frame_read_timeout(Duration::from_secs(1));
+    let err = supervisor
+        .submit_workload_start(sample_workload_params())
+        .expect_err("must reject wrong-kind response");
+    guest.join().expect("guest");
+    match err {
+        PersistentBuilderError::UnexpectedResponse { expected, got } => {
+            assert_eq!(expected, "workload_started");
+            assert_eq!(got, "bye");
+        }
+        other => panic!("expected UnexpectedResponse, got {other:?}"),
+    }
+}
+
+#[test]
+fn submit_workload_start_premature_eof_when_guest_closes() {
+    let scratch = tempfile::tempdir().expect("tempdir");
+    let socket = dispatch_socket_path(scratch.path());
+
+    let guest = spawn_fake_guest(&socket, |mut conn| {
+        // Read the request, then close without replying (guest crash).
+        let _req: HostVmRequest = mvm_guest::vsock::read_frame(&mut conn).expect("read request");
+        drop(conn);
+    });
+
+    let supervisor =
+        PersistentBuilderSupervisor::new(&socket).with_frame_read_timeout(Duration::from_secs(1));
+    let err = supervisor
+        .submit_workload_start(sample_workload_params())
+        .expect_err("must surface PrematureEof");
+    guest.join().expect("guest");
+    assert!(matches!(err, PersistentBuilderError::PrematureEof { .. }));
+}
+
+#[test]
+fn submit_workload_stop_and_status_round_trip() {
+    // Stop → WorkloadStopped → Ok(())
+    let scratch = tempfile::tempdir().expect("tempdir");
+    let socket = dispatch_socket_path(scratch.path());
+    let wid = WorkloadId::new();
+    let guest =
+        spawn_fake_guest(&socket, move |mut conn| {
+            match mvm_guest::vsock::read_frame::<HostVmRequest>(&mut conn).expect("read") {
+                HostVmRequest::WorkloadStop { workload_id } => {
+                    mvm_guest::vsock::write_frame(
+                        &mut conn,
+                        &HostVmResponse::WorkloadStopped { workload_id },
+                    )
+                    .expect("write");
+                }
+                other => panic!("expected WorkloadStop, got {other:?}"),
+            }
+        });
+    let supervisor =
+        PersistentBuilderSupervisor::new(&socket).with_frame_read_timeout(Duration::from_secs(1));
+    supervisor.submit_workload_stop(wid).expect("stop ok");
+    guest.join().expect("guest");
+
+    // Status → WorkloadStatusReport{status} → Ok(status)
+    let scratch2 = tempfile::tempdir().expect("tempdir");
+    let socket2 = dispatch_socket_path(scratch2.path());
+    let guest2 = spawn_fake_guest(&socket2, |mut conn| {
+        let workload_id =
+            match mvm_guest::vsock::read_frame::<HostVmRequest>(&mut conn).expect("read") {
+                HostVmRequest::WorkloadStatus { workload_id } => workload_id,
+                other => panic!("expected WorkloadStatus, got {other:?}"),
+            };
+        mvm_guest::vsock::write_frame(
+            &mut conn,
+            &HostVmResponse::WorkloadStatusReport {
+                workload_id,
+                status: "running".to_string(),
+            },
+        )
+        .expect("write");
+    });
+    let supervisor2 =
+        PersistentBuilderSupervisor::new(&socket2).with_frame_read_timeout(Duration::from_secs(1));
+    let status = supervisor2.submit_workload_status(wid).expect("status ok");
+    guest2.join().expect("guest");
+    assert_eq!(status, "running");
 }


### PR DESCRIPTION
## Plan 107 Phase A4 — `mvmctl up` wiring (DRAFT, first slice)

A4 is the big phase (branch `FirecrackerBackend::start`, session-scoped host-VM lifecycle, stage workload artifacts into the host VM, doctor, live smoke). This first slice lands the **foundational host-side dispatcher** that the backend branch (A4.1) will call.

### A4.a — workload-lifecycle dispatcher
`PersistentBuilderSupervisor` (host end of the persistent host VM's dispatch socket) gains:
- `submit_workload_start(WorkloadStartParams) -> WorkloadStartOutcome` — mints a `WorkloadId`, sends `HostVmRequest::WorkloadStart`, returns the echoed id + spawned VMM pid; maps `WorkloadFailed` → typed error.
- `submit_workload_stop` / `submit_workload_status`.
- shared `dispatch_single_response` (workload requests get exactly one reply — no stderr stream, unlike build dispatch).
- new `WorkloadStartParams` / `WorkloadStartOutcome` types + `PersistentBuilderError::{WorkloadFailed, UnexpectedResponse}`.

**5 hermetic tests** over the existing mock-guest `UnixListener` harness: start round-trip, `WorkloadFailed` surfaced, wrong-kind response rejected, premature-EOF on guest crash, stop+status round-trip. 13/13 `persistent_builder_supervisor` tests pass; fmt + clippy clean.

### Remaining A4 (next slices)
- **A4.1/A4.2** — branch `FirecrackerBackend::start`: when `linux_builder_vm_requested()`, obtain a session `LibkrunPersistentHostVm` handle + `submit_workload_start` instead of forking Firecracker directly; env unset keeps the direct path.
- **A4.3** — session-scoped host-VM lifecycle + crash recovery; **artifact staging** (workload kernel/rootfs into a host-VM virtio-fs share, guest-visible paths in the `WorkloadStartParams`).
- **A4.4** — doctor "host VM running, pid N" line.
- **A4.5** — live nested-KVM smoke (the genuine cross-hop boot deferred from A2.4/A3).

🤖 Generated with [Claude Code](https://claude.com/claude-code)