### PR TITLE
Persist the Stage 0 nix store + make `up` verify the libkrun workload agent

### DIFF
--- a/crates/mvm-build/src/builder_vm_runtime.rs
+++ b/crates/mvm-build/src/builder_vm_runtime.rs
@@ -736,6 +736,29 @@ pub fn acquire_nix_store_image_lock(
     arch: &str,
     size_mib: u64,
 ) -> Result<NixStoreImageLock, BuilderVmError> {
+    acquire_nix_store_image_lock_named(
+        builder_cache_dir,
+        &format!("nix-store-{arch}.img"),
+        size_mib,
+    )
+}
+
+/// Like [`acquire_nix_store_image_lock`] but the image filename is
+/// supplied verbatim instead of derived as `nix-store-<arch>.img`.
+///
+/// Stage 0 (the builder-VM *image* build) uses this to key a dedicated
+/// `nix-store-stage0-<arch>.img` separate from the steady-state
+/// builder's `nix-store-<arch>.img`. Two reasons for the split: the
+/// flock would otherwise serialize a `dev up` bootstrap against any
+/// concurrent `mvmctl build` in another session, and the bootstrap's
+/// kernel/Rust-toolchain closure has no reason to share a store with
+/// user-workload builds. Both images live in the same cache dir and
+/// match `cache info`'s `nix-store-*.img` sparse-footprint report.
+pub fn acquire_nix_store_image_lock_named(
+    builder_cache_dir: &Path,
+    file_name: &str,
+    size_mib: u64,
+) -> Result<NixStoreImageLock, BuilderVmError> {
     use fs2::FileExt;
 
     std::fs::create_dir_all(builder_cache_dir).map_err(|e| {
@@ -744,7 +767,7 @@ pub fn acquire_nix_store_image_lock(
             builder_cache_dir.display()
         ))
     })?;
-    let path = builder_cache_dir.join(format!("nix-store-{arch}.img"));
+    let path = builder_cache_dir.join(file_name);
     let existed_before_open = path.exists();
 
     let file = std::fs::OpenOptions::new()
@@ -1334,6 +1357,59 @@ mod tests {
             guard.path().file_name().and_then(|s| s.to_str()),
             Some("nix-store-aarch64.img")
         );
+    }
+
+    /// fs2's `try_lock_exclusive` can spuriously return `EWOULDBLOCK` on
+    /// a fresh, uncontended path under heavy parallel test load (the
+    /// `reference_fs2_flock_spurious_ewouldblock` flake). Production must
+    /// NOT retry — there a refusal is a real concurrent holder — but a
+    /// test that expects the lock to be FREE retries briefly to absorb
+    /// the spurious failure.
+    fn acquire_named_or_retry(
+        cache_dir: &Path,
+        file_name: &str,
+        size_mib: u64,
+    ) -> NixStoreImageLock {
+        let mut last = String::new();
+        for _ in 0..40 {
+            match acquire_nix_store_image_lock_named(cache_dir, file_name, size_mib) {
+                Ok(g) => return g,
+                Err(e) => {
+                    last = format!("{e}");
+                    std::thread::sleep(std::time::Duration::from_millis(25));
+                }
+            }
+        }
+        panic!("acquire {file_name} never succeeded (last: {last})");
+    }
+
+    #[test]
+    fn acquire_nix_store_image_lock_named_uses_supplied_filename() {
+        // The named variant backs Stage 0's dedicated store image. It
+        // must use the filename verbatim, not re-derive `nix-store-<arch>`.
+        let scratch = tempfile::TempDir::new().unwrap();
+        let cache_dir = scratch.path().join("builder-vm");
+        let guard = acquire_named_or_retry(&cache_dir, "nix-store-stage0-aarch64.img", 64);
+        assert_eq!(
+            guard.path().file_name().and_then(|s| s.to_str()),
+            Some("nix-store-stage0-aarch64.img")
+        );
+        // Matches `cache info`'s `nix-store-*.img` sparse report glob.
+        let n = guard.path().file_name().unwrap().to_string_lossy();
+        assert!(n.starts_with("nix-store-") && n.ends_with(".img"));
+    }
+
+    #[test]
+    fn stage0_and_builder_store_locks_do_not_collide() {
+        // The whole point of the split: a Stage 0 bootstrap and a
+        // steady-state builder build can hold their store locks at the
+        // same time because they key different image files. If they
+        // shared a filename, the second acquire would fail the flock.
+        let scratch = tempfile::TempDir::new().unwrap();
+        let cache_dir = scratch.path().join("builder-vm");
+        let builder = acquire_named_or_retry(&cache_dir, "nix-store-aarch64.img", 64);
+        let stage0 = acquire_named_or_retry(&cache_dir, "nix-store-stage0-aarch64.img", 64);
+        assert_ne!(builder.path(), stage0.path());
     }
 
     #[test]

--- a/crates/mvm-build/src/libkrun_builder.rs
+++ b/crates/mvm-build/src/libkrun_builder.rs
@@ -79,9 +79,9 @@ use crate::builder_vm::{
 // `supervisor_exit_error` / `shell_job_exit_error` (commit 6), and
 // `builder_vm_timeout` (commit 7 — last pre-VzBuilderVm migration).
 use crate::builder_vm_runtime::{
-    NixStoreImageLock, acquire_nix_store_image_lock, builder_vm_timeout, finalize_flake_job,
-    finalize_install_job, read_job_result, shell_job_exit_error, stage_job_dir,
-    supervisor_exit_error,
+    NixStoreImageLock, acquire_nix_store_image_lock, acquire_nix_store_image_lock_named,
+    builder_vm_timeout, finalize_flake_job, finalize_install_job, read_job_result,
+    shell_job_exit_error, stage_job_dir, supervisor_exit_error,
 };
 
 /// Default vCPU count for the builder VM. Nix builds are
@@ -90,13 +90,12 @@ use crate::builder_vm_runtime::{
 pub const DEFAULT_VCPUS: u8 = 4;
 
 /// Default RAM in MiB. Originally 8 GiB (Plan 72 W5.D bullet 9 —
-/// in-VM nix builds peak ~5-6 GiB). Plan 95 raised this to 16 GiB
-/// alongside bumping the Stage 0 `/nix` tmpfs `size=` cap in
-/// `stage0/init.sh` (4G → 14G): tmpfs is RAM-backed, so the cap
-/// can only be honored if the VM has at least that much RAM. The
-/// real bottleneck in dev-up validation was the tmpfs cap, not the
-/// VM RAM — bumping VM RAM alone is a no-op as long as the
-/// `size=` mount option clips earlier. Keep these two in lockstep.
+/// in-VM nix builds peak ~5-6 GiB). Raised to 16 GiB for headroom
+/// when several derivations' build working sets overlap. Before the
+/// persistent-store cutover this also had to cover a 14 GiB in-RAM
+/// `/nix` tmpfs in `stage0/init.sh`; the Stage 0 store now lives on a
+/// virtio-blk ext4 disk (`nix-store-stage0-<arch>.img`), so this RAM
+/// only has to cover the compiles themselves, not the store.
 pub const DEFAULT_MEMORY_MIB: u32 = 16384;
 
 /// Default size of the persistent `/nix`-store virtio-blk image,
@@ -325,10 +324,19 @@ impl LibkrunBuilderVm {
     }
 
     /// libkrun-side Stage 0 boot. Drives a self-contained `RootDir`
-    /// guest — no `/job/cmd.sh` staging, no `/job/result` parsing, no
-    /// `/nix-store` virtio-blk. The guest's `/init` reads `/work` and
-    /// writes the steady-state builder VM artifacts to `/out`, then
-    /// powers off cleanly.
+    /// guest — no `/job/cmd.sh` staging, no `/job/result` parsing. The
+    /// guest's `/init` reads `/work` and writes the steady-state builder
+    /// VM artifacts to `/out`, then powers off cleanly.
+    ///
+    /// Attaches a dedicated persistent `nix-store-stage0-<arch>.img` as
+    /// the guest's only virtio-blk device (`/dev/vda` — Stage 0 has no
+    /// block rootfs, its root is virtio-fs via `krun_set_root`). The
+    /// guest mounts it at `/nix` (formatting on first boot), so the slim
+    /// kernel + Rust host binaries are built once and reused across
+    /// `dev up` runs instead of recompiled into a throwaway tmpfs every
+    /// time. ext4 is case-sensitive, which is also why the old in-RAM
+    /// tmpfs existed (APFS case-insensitivity breaks Nix substitution) —
+    /// the disk keeps that property and adds persistence.
     ///
     /// On success the caller still validates that the expected artifacts
     /// (`vmlinux`, `rootfs.ext4`) landed in `artifact_out`; this only
@@ -378,6 +386,19 @@ impl LibkrunBuilderVm {
 
         let supervisor_path = resolve_supervisor_path()?;
 
+        // Persistent, host-locked Nix store for the image build. Sparse
+        // image, formatted in-guest on first boot; survives across
+        // `dev up` runs so the slim kernel + Rust toolchain closure are
+        // built once. Dedicated filename (not the builder's
+        // `nix-store-<arch>.img`) so the flock never contends with a
+        // concurrent `mvmctl build`. The guard must outlive the
+        // supervisor — bound here, dropped at function end.
+        let nix_store_lock = acquire_nix_store_image_lock_named(
+            &builder_vm_cache_dir(),
+            &stage0_nix_store_image_name(),
+            u64::from(self.nix_store_mib),
+        )?;
+
         let job_id = unique_job_id();
         let vm_name = format!("mvm-stage0-{job_id}");
         let vm_state_dir = builder_vm_cache_dir().join("vms").join(&vm_name);
@@ -393,6 +414,14 @@ impl LibkrunBuilderVm {
             .with_resources(self.vcpus, self.memory_mib)
             .with_console_output(path_to_str(&console_log, "console_log")?)
             .with_vsock_socket_dir(path_to_str(&vm_state_dir, "vm_state_dir")?)
+            // Persistent /nix store. The only block device on a RootDir
+            // guest, so it enumerates as /dev/vda; init.sh formats it on
+            // first boot and mounts it at /nix.
+            .add_disk(
+                "nix-store",
+                path_to_str(nix_store_lock.path(), "nix_store_img")?,
+                false,
+            )
             .add_virtio_fs("work", path_to_str(workspace_dir, "workspace_dir")?)
             .add_virtio_fs("out", path_to_str(artifact_out, "artifact_out")?)
             // /mvm-bins inside the guest — init.sh sets MVM_HOST_BIN_DIR to
@@ -1154,6 +1183,17 @@ pub(crate) fn host_arch_tag() -> &'static str {
 /// function does not touch the filesystem.
 pub(crate) fn builder_vm_cache_dir() -> PathBuf {
     PathBuf::from(mvm_core::config::mvm_cache_dir()).join("builder-vm")
+}
+
+/// Filename of Stage 0's dedicated persistent Nix-store image,
+/// `nix-store-stage0-<arch>.img`. Distinct from the steady-state
+/// builder's `nix-store-<arch>.img` so a `dev up` bootstrap and a
+/// concurrent `mvmctl build` never contend on the same flock — see
+/// [`acquire_nix_store_image_lock_named`]. Lives in
+/// [`builder_vm_cache_dir`] and matches `cache info`'s
+/// `nix-store-*.img` sparse-footprint report.
+pub(crate) fn stage0_nix_store_image_name() -> String {
+    format!("nix-store-stage0-{}.img", host_arch_tag())
 }
 
 /// Find the builder VM image (kernel + rootfs + cmdline) in
@@ -2096,10 +2136,9 @@ mod tests {
         let vm = LibkrunBuilderVm::default();
         assert_eq!(vm.vcpus, 4);
         // Plan 72 W5.D bullet 9: 4 → 8 GiB (in-VM nix builds peak
-        // ~5-6 GiB; OOM at lower default). Plan 95: 8 → 16 GiB
-        // alongside stage0/init.sh bumping the `/nix` tmpfs `size=`
-        // cap to 14G. Hardcoded so a regression on either side
-        // fails fast.
+        // ~5-6 GiB; OOM at lower default). Later raised to 16 GiB for
+        // overlapping build working sets. Hardcoded so a regression on
+        // either side fails fast.
         assert_eq!(vm.memory_mib, 16384);
         assert_eq!(vm.nix_store_mib, 65536);
     }
@@ -2549,6 +2588,19 @@ mod tests {
             tag == "aarch64" || tag == "x86_64",
             "unexpected arch tag: {tag}"
         );
+    }
+
+    #[test]
+    fn stage0_nix_store_image_name_is_arch_keyed_and_distinct_from_builder() {
+        let name = stage0_nix_store_image_name();
+        // `cache info` globs `nix-store-*.img` for its sparse report;
+        // stay inside that glob so the Stage 0 store is surfaced too.
+        assert!(name.starts_with("nix-store-stage0-"), "got {name}");
+        assert!(name.ends_with(".img"), "got {name}");
+        assert!(name.contains(host_arch_tag()), "got {name}");
+        // Must NOT collide with the steady-state builder store filename,
+        // or the two flocks would serialize against each other.
+        assert_ne!(name, format!("nix-store-{}.img", host_arch_tag()));
     }
 
     // `read_job_result_*`, `extract_nix_store_hash_*`,

--- a/crates/mvm-build/src/stage0.rs
+++ b/crates/mvm-build/src/stage0.rs
@@ -773,18 +773,77 @@ mod tests {
     /// compile at `HOSTCC scripts/basic/fixdep`. With Alpine nix's
     /// default `max-jobs = auto`, four heavy derivations
     /// (mvm-host-vm-init, mvm-egress-proxy, mvm-guest-agent, linux)
-    /// ran concurrently and the combined working set exceeded the
-    /// 16 GiB guest RAM / 14 GiB `/nix` tmpfs envelope. Serializing
-    /// derivations with `--max-jobs 1` keeps peak memory under the
-    /// per-derivation ~5-6 GiB observation recorded in
-    /// `libkrun_builder.rs:92-99`.
+    /// ran concurrently and the combined build working set exceeded
+    /// the guest RAM envelope. Serializing derivations with
+    /// `--max-jobs 1` keeps peak memory under the per-derivation
+    /// ~5-6 GiB observation recorded in `libkrun_builder.rs`. (The
+    /// store moved off the in-RAM tmpfs onto a virtio-blk ext4 disk in
+    /// the persistent-store cutover, but the compiles still need the
+    /// headroom, so the cap stays.)
     #[test]
     fn init_script_caps_nix_derivation_parallelism() {
         assert!(
             INIT_SCRIPT.contains("--max-jobs 1"),
             "init script must serialize Stage 0 nix derivations \
-             (`--max-jobs 1`) so parallel kernel + Rust builds don't \
-             blow the guest RAM / /nix-tmpfs envelope"
+             (`--max-jobs 1`) so parallel kernel + Rust build working \
+             sets don't blow the guest RAM envelope"
+        );
+    }
+
+    /// The persistent-store cutover (replacing the in-RAM tmpfs `/nix`
+    /// with a host-backed ext4 virtio-blk image) so a `dev up`
+    /// rebuild reuses the slim kernel + Rust toolchain closure instead
+    /// of recompiling it every time. Pins the load-bearing shape of the
+    /// init script's new `/nix` provisioning.
+    #[test]
+    fn init_script_mounts_persistent_ext4_nix_store() {
+        // The throwaway tmpfs `/nix` is gone. (Other tmpfs mounts —
+        // /tmp, /run — remain, so assert specifically on `/nix`.)
+        assert!(
+            !INIT_SCRIPT.contains("tmpfs /nix"),
+            "init script must no longer mount a tmpfs over /nix"
+        );
+        // e2fsprogs gives mkfs.ext4, installed before /nix is mounted.
+        assert!(
+            INIT_SCRIPT.contains("add e2fsprogs"),
+            "init script must apk-add e2fsprogs for first-boot mkfs.ext4"
+        );
+        // Format-vs-mount is decided by PROBING for an ext4 superblock
+        // with e2fsck (in the e2fsprogs CORE package — dumpe2fs is not),
+        // never by try-mount-then-reformat. A geometry-EINVAL on a disk
+        // that already holds a store must not be read as "blank" and
+        // wipe the warm cache (that was the store-losing bug). Pin the
+        // probe so a refactor can't reintroduce blind reformatting.
+        assert!(
+            INIT_SCRIPT.contains("e2fsck -fy \"$NIX_DEV\""),
+            "init script must probe for an existing ext4 store with e2fsck before formatting"
+        );
+        assert!(
+            INIT_SCRIPT.contains("PROBE_RC") && INIT_SCRIPT.contains("-ge 8"),
+            "init script must format only when the probe finds no superblock (e2fsck rc >= 8)"
+        );
+        // First boot formats the sparse disk with an explicit 4K block
+        // count SIZED UNDER the device: libkrunfw's Stage 0 kernel
+        // over-reports the virtio-blk size, so a fs sized to the kernel
+        // view reads back too large next boot and `mount` EINVALs. The
+        // margin (`- 2048`) keeps the fs strictly inside the real device.
+        assert!(
+            INIT_SCRIPT.contains("mkfs.ext4 -F -q -b 4096"),
+            "init script must format the store disk with an explicit 4K block count"
+        );
+        assert!(
+            INIT_SCRIPT.contains("SECTORS / 8 - 2048"),
+            "init script must size the fs under the kernel-reported device (over-report margin)"
+        );
+        assert!(
+            INIT_SCRIPT.contains("/sys/class/block/"),
+            "init script must read the device size from /sys/class/block"
+        );
+        // Mount the detected device at /nix as ext4 (case-sensitive,
+        // the property the tmpfs originally provided).
+        assert!(
+            INIT_SCRIPT.contains("mount -t ext4 \"$NIX_DEV\" /nix"),
+            "init script must mount the persistent ext4 store at /nix"
         );
     }
 

--- a/crates/mvm-build/src/stage0/init.sh
+++ b/crates/mvm-build/src/stage0/init.sh
@@ -96,40 +96,18 @@ if ! mountpoint -q /mvm-bins; then
   exit 66
 fi
 
-# libkrun's set_root mode backs the guest root with virtio-fs
-# from the host's macOS APFS, which is case-insensitive by
-# default. Several Nix derivations contain files that only differ
-# by case (e.g. the Linux kernel headers ship `xt_connmark.h` and
-# `xt_CONNMARK.h` in the same directory). Substitution from
-# cache.nixos.org fails with `creating file '...xt_CONNMARK.h':
-# File exists` on APFS — the second file collides with the first.
-#
-# Fix: mount tmpfs over /nix BEFORE `apk add nix` runs, so the
-# nix package's closure (and every subsequent `nix-build`
-# substitution) lives on case-sensitive in-memory storage.
-# Mounting after apk would leave the nix binary on APFS and
-# break the case-sensitive guarantee for substitutions.
-#
-# Size cap: 14 GiB. The original 4 GiB assumed a ~600 MB closure
-# (builder-VM rootfs only). With Plan 95's slim-kernel + the Rust
-# binaries (`mvm-host-vm-init`, `mvm-egress-proxy`) building in the
-# same VM, the working set runs:
-#   kernel intermediates (~3 GiB) +
-#   rustc-wrapper substitute closure (~2 GiB) +
-#   Rust build artifacts (~5–8 GiB)
-# 14 GiB leaves headroom. Memory budget is paid from the libkrun
-# guest's RAM allocation (DEFAULT_MEMORY_MIB in
-# crates/mvm-build/src/libkrun_builder.rs) — keep that ≥ this cap.
-mount -t tmpfs -o size=14G,mode=0755 tmpfs /nix
-mkdir -p /nix/store /nix/var/nix /nix/var/log/nix
-
-# Install Nix from Alpine's signed package repos. `apk-tools`
-# verifies the signed APKINDEX against /etc/apk/keys/ (the
-# Alpine release-signing keys shipped in the minirootfs) and
+# Install the toolchain from Alpine's signed package repos.
+# `apk-tools` verifies the signed APKINDEX against /etc/apk/keys/
+# (the Alpine release-signing keys shipped in the minirootfs) and
 # each package's signature before installation.
-echo "stage0-init: installing nix + dependencies via apk..." >&2
+#
+# e2fsprogs (mkfs.ext4) goes in FIRST, before /nix is mounted: it
+# formats the persistent store disk on first boot, and apk writes to
+# the Alpine root (virtio-fs), not /nix, so it's available regardless
+# of /nix state.
+echo "stage0-init: apk update + installing e2fsprogs (mkfs.ext4 for the /nix disk)..." >&2
 set +e
-apk --no-progress update                              > /out/apk-update.log  2>&1
+apk --no-progress update                              > /out/apk-update.log       2>&1
 APK_RC=$?
 if [ "$APK_RC" -ne 0 ]; then
   echo "stage0-init: apk update exited $APK_RC (see /out/apk-update.log)" >&2
@@ -142,7 +120,101 @@ if [ "$APK_RC" -ne 0 ]; then
   fi
   exit "$APK_RC"
 fi
-apk --no-progress add nix git ca-certificates xz      > /out/apk-add.log     2>&1
+apk --no-progress add e2fsprogs                       > /out/apk-add-e2fsprogs.log 2>&1
+APK_RC=$?
+set -e
+if [ "$APK_RC" -ne 0 ]; then
+  echo "stage0-init: apk add e2fsprogs exited $APK_RC (see /out/apk-add-e2fsprogs.log)" >&2
+  if [ -r /out/apk-add-e2fsprogs.log ]; then
+    tail -40 /out/apk-add-e2fsprogs.log >&2
+  fi
+  exit "$APK_RC"
+fi
+
+# Persistent /nix store on a host-backed ext4 virtio-blk image
+# (`nix-store-stage0-<arch>.img`, attached by
+# LibkrunBuilderVm::run_stage0_impl). This replaces the former in-RAM
+# tmpfs for two reasons:
+#
+#   1. Case-sensitivity. libkrun's set_root backs the guest root with
+#      virtio-fs over macOS APFS, which is case-insensitive. Several
+#      Nix derivations ship files differing only by case (e.g. kernel
+#      headers `xt_connmark.h` / `xt_CONNMARK.h`); substitution from
+#      cache.nixos.org fails with `File exists` on APFS. ext4 is
+#      case-sensitive, so it solves this exactly as tmpfs did.
+#   2. Persistence. Unlike a tmpfs that evaporates at poweroff, the
+#      disk survives across `dev up` runs — the slim kernel + Rust host
+#      binaries (the multi-minute derivations) are built once and
+#      reused instead of recompiled into a throwaway store every time.
+#
+# Stage 0's guest root is virtio-fs (no block rootfs), so this disk is
+# the only virtio-blk device — `/dev/vda`. Scan a few names anyway so
+# a future second disk doesn't silently shift the target.
+NIX_DEV=
+for cand in /dev/vda /dev/vdb /dev/vdc /dev/vdd; do
+  if [ -b "$cand" ]; then NIX_DEV="$cand"; break; fi
+done
+if [ -z "$NIX_DEV" ]; then
+  echo "stage0-init: no virtio-blk device found for the persistent /nix store; aborting." >&2
+  exit 67
+fi
+echo "stage0-init: persistent /nix store on $NIX_DEV" >&2
+
+# Decide format-vs-mount by PROBING for an ext4 superblock, never by
+# try-mount-then-reformat. A mount can fail for a geometry reason (see
+# the margin note below) on a disk that already holds a populated
+# store; reading that EINVAL as "blank disk" and reformatting would
+# wipe the warm cache — the exact opposite of persistence. Mirrors
+# mvm-host-vm-init::nix_store_dev_needs_format (superblock probe).
+NIX_DEV_BASE="${NIX_DEV#/dev/}"
+# Decide format-vs-mount by PROBING for an ext4 superblock with e2fsck,
+# never by try-mount-then-reformat. (e2fsck is in the e2fsprogs core
+# package — same one mkfs.ext4 comes from; dumpe2fs/resize2fs live in
+# the separate e2fsprogs-extra, which Alpine's minirootfs doesn't carry.)
+# e2fsck exit codes: 0 clean, 1-2 errors fixed, 4 errors left, 8+ the
+# superblock couldn't be opened (no ext4). So >=8 ⇒ blank disk ⇒ format;
+# 0-7 ⇒ a real store ⇒ it's already been fsck'd, just mount it. A mount
+# that later EINVALs must NEVER be read as "blank" and reformatted — that
+# wipes the warm cache. Mirrors mvm-host-vm-init::nix_store_dev_needs_format.
+# `set +e` around the probe: e2fsck returns non-zero on a fresh (zeroed)
+# disk — rc 8, "no superblock" — and a bare non-zero command under
+# `set -eu` would abort init.sh right here (the bug that left the store
+# empty). Capture the code instead and branch on it.
+set +e
+e2fsck -fy "$NIX_DEV" > /out/stage0-nix-probe.log 2>&1
+PROBE_RC=$?
+set -e
+if [ "$PROBE_RC" -ge 8 ]; then
+  # First boot (no superblock): format. Size the fs ~8 MiB UNDER the
+  # kernel-reported device. libkrunfw's Stage 0 kernel over-reports the
+  # virtio-blk size vs the real backing file by ~64 KiB (16 4K-blocks),
+  # and the host trims the sparse image by another ~128 KiB on first
+  # close — so a fs sized to /sys/class/block/<dev>/size reads back
+  # LARGER than the device on the next boot and `mount` EINVALs (that was
+  # the store-wiping bug). The margin keeps the fs strictly inside the
+  # real device across boots. (mvm-host-vm-init's builder-rootfs kernel
+  # reports the exact size, so it needs no margin.)
+  SECTORS="$(cat "/sys/class/block/${NIX_DEV_BASE}/size")"
+  BLOCKS_4K=$(( SECTORS / 8 - 2048 ))
+  echo "stage0-init: formatting $NIX_DEV ext4 ($BLOCKS_4K 4K-blocks, first boot)" >&2
+  mkfs.ext4 -F -q -b 4096 "$NIX_DEV" "$BLOCKS_4K"
+else
+  echo "stage0-init: reusing existing persistent /nix store on $NIX_DEV (e2fsck rc=$PROBE_RC)" >&2
+fi
+if ! mount -t ext4 "$NIX_DEV" /nix 2>> /out/stage0-nix-mount.log; then
+  echo "stage0-init: /nix mount failed; aborting (see /out/stage0-nix-mount.log)." >&2
+  if [ -r /out/stage0-nix-mount.log ]; then
+    tail -5 /out/stage0-nix-mount.log >&2
+  fi
+  exit 68
+fi
+mkdir -p /nix/store /nix/var/nix /nix/var/log/nix
+
+# Install Nix now that /nix is the case-sensitive ext4 store, so its
+# install-time store writes land on the persistent disk.
+echo "stage0-init: installing nix + dependencies via apk..." >&2
+set +e
+apk --no-progress add nix git ca-certificates xz      > /out/apk-add.log           2>&1
 APK_RC=$?
 set -e
 if [ "$APK_RC" -ne 0 ]; then
@@ -186,13 +258,15 @@ echo "stage0-init: building ${FLAKE_REF}" >&2
 # --max-jobs 1 caps derivation parallelism inside Stage 0. With
 # Alpine nix's default `max-jobs = auto`, four heavy derivations
 # (mvm-host-vm-init, mvm-egress-proxy, mvm-guest-agent, the slim
-# Linux kernel) run concurrently and the combined working set
-# exceeds the 16 GiB guest RAM / 14 GiB `/nix` tmpfs envelope —
-# SIGKILL at `HOSTCC scripts/basic/fixdep`. libkrun_builder.rs:92-99
+# Linux kernel) run concurrently and their combined build working
+# set exceeds the guest RAM envelope — SIGKILL at `HOSTCC
+# scripts/basic/fixdep`. (The store now lives on the persistent ext4
+# disk rather than a RAM tmpfs, so it no longer competes for that
+# RAM — but the compiles themselves still do.) libkrun_builder.rs
 # records the peak-per-derivation observation (~5-6 GiB), which fits
 # one at a time but not in parallel. Per-derivation parallelism stays
 # at the default (cores = nproc) so the kernel compile still uses
-# all 4 vCPUs.
+# all vCPUs.
 set +e
 nix build "$FLAKE_REF" \
     --extra-experimental-features "nix-command flakes" \

--- a/crates/mvm-cli/src/commands/vm/up.rs
+++ b/crates/mvm-cli/src/commands/vm/up.rs
@@ -1832,6 +1832,45 @@ pub(super) fn cmd_run(params: RunParams<'_>) -> Result<()> {
 
     mvm_core::audit_emit!(VmStart, vm: &vm_name_owned);
 
+    // libkrun / firecracker launch a detached supervisor daemon, so `up`
+    // returns after launch (unlike apple-container below, which blocks
+    // in-process). Verify the guest agent here anyway: without it, `up
+    // --hypervisor libkrun` exits 0 the instant the daemon spawns — never
+    // checking that the guest actually booted and the agent answered —
+    // so a real boot failure passes silently and `core_demo_e2e`'s
+    // boot→ping proof is hollow (it only watches for this exact warning).
+    // `--detach` opts out (fire-and-forget, like the apple-container
+    // launchd path). apple-container keeps its own wait in its block.
+    if matches!(effective_hypervisor, "libkrun" | "firecracker") && !detach {
+        ui::info("Waiting for guest agent...");
+        record_vm_readiness(&vm_name_owned, InstanceReadiness::AgentConnecting);
+        if wait_for_guest_agent(&vm_name_owned, 30) {
+            record_vm_readiness(&vm_name_owned, InstanceReadiness::AgentReady);
+            if let Err(e) = mvm_backend::netinit_audit::emit_for_vm(&vm_name_owned) {
+                tracing::debug!(
+                    vm = %vm_name_owned,
+                    error = %e,
+                    "netinit audit emit skipped (best-effort)"
+                );
+            }
+        } else {
+            // A non-detached `up` means "bring the workload up and confirm
+            // it" — a daemon that spawned but whose agent never answered
+            // within the boot timeout has failed. Stop the orphaned daemon
+            // and exit non-zero so the failure is unmissable. (Exit code,
+            // not the warning string: `ui::warn` routes to stdout by
+            // default, which a stderr-only check would miss; `ui::error`
+            // below keeps the message on stderr regardless.)
+            ui::error("Guest agent not reachable.");
+            let _ = backend.stop(&mvm_core::vm_backend::VmId(vm_name_owned.clone()));
+            let err = anyhow::anyhow!(
+                "guest agent for '{vm_name_owned}' not reachable within 30s of boot"
+            );
+            emit_failed_if(&admission_main, "agent-unreachable", &err);
+            return Err(err);
+        }
+    }
+
     // Apple Virtualization VMs live in-process — the process must stay alive.
     if effective_hypervisor == "apple-container" && !detach {
         // ADR-053 §3 / plan 74 W2 (services-health): wait for the


### PR DESCRIPTION
Two fixes that came out of getting the core demo's `dev up → compile → up → vsock ping` spine working end-to-end on libkrun.

## 1. Persist the Stage 0 nix store (`bf932721`)

Stage 0's `/nix` was a throwaway 14 GiB RAM tmpfs, so every `dev up` rebuild recompiled the slim kernel + Rust host binaries from an empty store (the bespoke derivations aren't on cache.nixos.org). Back it with a host-backed ext4 virtio-blk image (`nix-store-stage0-<arch>.img`): ext4 is case-sensitive (the only reason the tmpfs existed — APFS case collisions in Nix substitution) and survives poweroff, so the multi-minute derivations build once and get reused.

- Dedicated flock (`acquire_nix_store_image_lock_named`) so Stage 0 never contends with a concurrent `mvmctl build`.
- `init.sh`: e2fsck-probe for an ext4 superblock (format only when there is none — never reformat a populated store); format ~8 MiB **under** the kernel-reported device size, because libkrunfw's Stage 0 kernel over-reports the virtio-blk size by 64 KiB — a fs sized to `/sys` reads back larger than the device next boot and `mount` EINVALs (the store-wiping bug).

Validated live (isolated A/B): fresh run does the full kernel build (4112 `CC` lines); warm run reuses the store with 0 `CC`.

## 2. `up` verifies the guest agent on libkrun/firecracker (`ce40cbe9`)

`up` only ran `wait_for_guest_agent` on the apple-container / direct-boot paths. For `up --hypervisor libkrun --flake` it daemonized and returned 0 the instant the supervisor spawned — never checking the guest booted or the agent answered. That made `core_demo_e2e`'s boot→ping proof **hollow**: a silent workload-boot failure would pass.

Now `up` waits for the agent on libkrun/firecracker (non-detached); on timeout it stops the orphan daemon and returns an error (exit non-zero — the `up.success` the test asserts). Verified live: `up --flake` prints `Waiting for guest agent...`, confirms the v0.14.0 agent over vsock, and exits 0.

## Notes / follow-ups (not in this PR)

- The libkrun **workload** microVM's `console.log` is empty (plain-Image kernel, no hvc0) — cosmetic, not a boot failure; verify the workload via `examples/agent_ping`.
- `cargo test core_demo_e2e` can hang on a busy macOS host (libtest buffering); the decomposed `mvmctl` steps run fine.
- `dev up` rebuilds the dev-shell image (~7 min) every run on `artifact_digest_mismatch`.