### PR TITLE
fix(mkFunctionService): function workload PID 1 must idle, not be the runner (Plan 120 Task 4)

### DIFF
--- a/.github/workflows/publish-npm.yml
+++ b/.github/workflows/publish-npm.yml
@@ -1,0 +1,89 @@
+name: Publish SDK to npm
+
+# Publishes the TypeScript SDK (sdks/typescript, package `mvm-sdk`) to npm.
+#
+# Trigger:
+#   - automatically when a GitHub Release is published (same event as
+#     publish-crates.yml / publish-pypi.yml, so all three ship at one
+#     version — see the version-vs-tag guard below);
+#   - manually via workflow_dispatch (dry_run=true does `npm publish
+#     --dry-run`, no upload — rehearse before the first real publish).
+#
+# Auth: NPM_TOKEN repo secret (a granular automation token with publish
+# rights on `mvm-sdk`). Provenance is attested via OIDC. See
+# specs/runbooks/publish-sdks.md.
+
+on:
+  release:
+    types: [published]
+  workflow_dispatch:
+    inputs:
+      dry_run:
+        description: "npm publish --dry-run only; no upload"
+        required: true
+        default: true
+        type: boolean
+
+concurrency:
+  group: publish-npm
+  cancel-in-progress: false
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    permissions:
+      id-token: write # npm provenance via OIDC
+      contents: read
+    defaults:
+      run:
+        working-directory: sdks/typescript
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: "22"
+          registry-url: "https://registry.npmjs.org"
+
+      - name: Check token
+        if: ${{ github.event_name == 'release' || !inputs.dry_run }}
+        run: |
+          if [ -z "${NODE_AUTH_TOKEN:-}" ]; then
+            echo "::error::Missing NPM_TOKEN secret."
+            exit 1
+          fi
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+
+      # Version coupling: refuse to publish an SDK whose version doesn't
+      # match the release tag (the SDK emits IR the same-version toolchain
+      # consumes). GITHUB_REF_NAME is read as a shell env var, never
+      # interpolated into the script — no workflow injection.
+      - name: Assert SDK version matches the release tag
+        if: github.event_name == 'release'
+        run: |
+          set -euo pipefail
+          sdk_ver=$(node -p "require('./package.json').version")
+          tag="${GITHUB_REF_NAME#v}"
+          echo "sdk=$sdk_ver tag=$tag"
+          if [ "$sdk_ver" != "$tag" ]; then
+            echo "::error::sdks/typescript/package.json version ($sdk_ver) != release tag ($tag). Bump it in the release commit."
+            exit 1
+          fi
+
+      - name: Install + build
+        run: |
+          npm ci
+          npm run build
+
+      - name: Publish to npm (dry-run)
+        if: ${{ github.event_name == 'workflow_dispatch' && inputs.dry_run }}
+        run: npm publish --provenance --access public --dry-run
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+
+      - name: Publish to npm
+        if: ${{ github.event_name == 'release' || !inputs.dry_run }}
+        run: npm publish --provenance --access public
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/.github/workflows/publish-pypi.yml
+++ b/.github/workflows/publish-pypi.yml
@@ -1,0 +1,73 @@
+name: Publish SDK to PyPI
+
+# Publishes the Python SDK (sdks/python, package `mvm`) to PyPI.
+#
+# Trigger:
+#   - automatically when a GitHub Release is published (same event that
+#     drives publish-crates.yml, so the SDK ships at the same version as
+#     the toolchain — see the version-vs-tag guard below);
+#   - manually via workflow_dispatch (dry_run=true builds + checks only,
+#     no upload — use this to rehearse before the first real publish).
+#
+# Auth: PyPI Trusted Publishing (OIDC) — no long-lived token. Configure a
+# trusted publisher on PyPI first (see specs/runbooks/publish-sdks.md):
+#   project `mvm` → Publishing → add GitHub publisher
+#   (owner tinylabscom, repo mvm, workflow publish-pypi.yml, environment pypi).
+# New projects use a "pending publisher" so the first publish creates the
+# project under OIDC with no token.
+
+on:
+  release:
+    types: [published]
+  workflow_dispatch:
+    inputs:
+      dry_run:
+        description: "Build + validate only; skip the PyPI upload"
+        required: true
+        default: true
+        type: boolean
+
+concurrency:
+  group: publish-pypi
+  cancel-in-progress: false
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    environment: pypi
+    permissions:
+      id-token: write # OIDC for Trusted Publishing
+      contents: read
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+
+      # Version coupling: the SDK emits IR that the same-version toolchain
+      # consumes (launch.json `toolchain_version` == mvmctl CARGO_PKG_VERSION).
+      # Refuse to publish an SDK whose version doesn't match the release tag.
+      - name: Assert SDK version matches the release tag
+        if: github.event_name == 'release'
+        run: |
+          set -euo pipefail
+          sdk_ver=$(grep -E '^version' sdks/python/pyproject.toml | head -1 | sed -E 's/.*"([^"]+)".*/\1/')
+          tag="${GITHUB_REF_NAME#v}"
+          echo "sdk=$sdk_ver tag=$tag"
+          if [ "$sdk_ver" != "$tag" ]; then
+            echo "::error::sdks/python/pyproject.toml version ($sdk_ver) != release tag ($tag). Bump it in the release commit."
+            exit 1
+          fi
+
+      - name: Build sdist + wheel
+        run: |
+          python -m pip install --upgrade build
+          python -m build sdks/python --outdir dist
+          ls -l dist
+
+      - name: Publish to PyPI (Trusted Publishing)
+        if: ${{ github.event_name == 'release' || !inputs.dry_run }}
+        uses: pypa/gh-action-pypi-publish@release/v1
+        with:
+          packages-dir: dist

--- a/crates/mvm-cli/examples/agent_invoke.rs
+++ b/crates/mvm-cli/examples/agent_invoke.rs
@@ -1,0 +1,46 @@
+//! Throwaway: drive a real `RunEntrypoint` against a running function
+//! workload microVM by name — the in-VM acceptance `mvmctl invoke` covers
+//! but which needs the template lifecycle. Mirrors `dispatch_inner` in
+//! `commands/vm/invoke.rs`: connect, `send_run_entrypoint`, collect stdout.
+//!
+//! The wrapper reads stdin as JSON `[args, kwargs]`; for `greet(name)` we
+//! send `[["<name>"], {}]` and expect the JSON-encoded return `"hello <name>"`.
+//!
+//!   cargo run -p mvm-cli --example agent_invoke -- <vm-name> [name]
+
+use std::cell::RefCell;
+
+fn main() -> anyhow::Result<()> {
+    let vm = std::env::args()
+        .nth(1)
+        .ok_or_else(|| anyhow::anyhow!("usage: agent_invoke <vm-name> [name]"))?;
+    let name = std::env::args().nth(2).unwrap_or_else(|| "ari".to_string());
+
+    // [args, kwargs] = [["<name>"], {}]. `{name:?}` quotes+escapes the
+    // string into valid JSON for ordinary names.
+    let payload = format!("[[{name:?}], {{}}]").into_bytes();
+
+    let transport = mvm::vsock_transport::for_vm(&vm)?;
+    let mut stream = transport.connect(mvm_guest::vsock::GUEST_AGENT_PORT)?;
+
+    let stdout = RefCell::new(Vec::<u8>::new());
+    let stderr = RefCell::new(Vec::<u8>::new());
+    let terminal =
+        mvm_guest::vsock::send_run_entrypoint(&mut stream, payload, 30, |event| match event {
+            mvm_guest::vsock::EntrypointEvent::Stdout { chunk } => {
+                stdout.borrow_mut().extend_from_slice(chunk)
+            }
+            mvm_guest::vsock::EntrypointEvent::Stderr { chunk } => {
+                stderr.borrow_mut().extend_from_slice(chunk)
+            }
+            _ => {}
+        })?;
+
+    println!("STDOUT: {}", String::from_utf8_lossy(&stdout.borrow()));
+    let err = stderr.borrow();
+    if !err.is_empty() {
+        println!("STDERR: {}", String::from_utf8_lossy(&err));
+    }
+    println!("TERMINAL: {terminal:?}");
+    Ok(())
+}

--- a/crates/mvm-cli/src/commands/vm/invoke.rs
+++ b/crates/mvm-cli/src/commands/vm/invoke.rs
@@ -5,7 +5,7 @@
 //! Distinct from `mvmctl exec` (dev-only, arbitrary shell). `invoke`
 //! is the production-safe call surface — it dispatches the
 //! `RunEntrypoint` vsock verb, which the guest agent serves only by
-//! spawning the program named in `/etc/mvm/entrypoint`. There is no
+//! spawning the program named in `/etc/mvm/runner`. There is no
 //! shell, no argv override, and no env injection beyond what the
 //! wrapper template defined at image build time.
 //!

--- a/crates/mvm-guest/src/bin/mvm-guest-agent.rs
+++ b/crates/mvm-guest/src/bin/mvm-guest-agent.rs
@@ -1111,7 +1111,7 @@ fn shell_quote_for_sh(s: &str) -> String {
 // ============================================================================
 // RunEntrypoint handler — ADR-007 / plan 41 W2.
 //
-// Boot-time validates `/etc/mvm/entrypoint`, holds the resolved fd open in a
+// Boot-time validates `/etc/mvm/runner`, holds the resolved fd open in a
 // `OnceLock` for the agent's lifetime, and serializes per-VM concurrency
 // through a mutex. Each call gets its own TMPDIR (mode 0700, removed on
 // drop) so transient state never leaks between calls.
@@ -1430,7 +1430,7 @@ fn run_before_stop_hook() {
     }
 }
 
-/// Validate `/etc/mvm/entrypoint` at agent boot. The result is stashed in
+/// Validate `/etc/mvm/runner` at agent boot. The result is stashed in
 /// `VALIDATED_ENTRYPOINT`. On failure, log a single line — the agent stays
 /// up; only `RunEntrypoint` requests fail with `EntrypointInvalid`.
 ///

--- a/crates/mvm-guest/src/entrypoint.rs
+++ b/crates/mvm-guest/src/entrypoint.rs
@@ -1,4 +1,4 @@
-//! Boot-time validation of `/etc/mvm/entrypoint`. ADR-007 / plan 41 W2.
+//! Boot-time validation of `/etc/mvm/runner`. ADR-007 / plan 41 W2.
 //!
 //! `RunEntrypoint` runs only the program named by this marker file. The
 //! agent reads the marker once at boot, resolves it through `realpath`,
@@ -37,12 +37,20 @@ pub struct EntrypointPolicy {
 }
 
 impl EntrypointPolicy {
-    /// Production policy: read `/etc/mvm/entrypoint`; resolved binary
+    /// Production policy: read `/etc/mvm/runner`; resolved binary
     /// must live under `/usr/lib/mvm/wrappers/` on the same filesystem
     /// as `/usr`, owned root, mode 0755.
+    ///
+    /// The marker is `/etc/mvm/runner`, NOT `/etc/mvm/entrypoint`:
+    /// `/etc/mvm/entrypoint` is PID 1's boot command (a shell script
+    /// `/init` sources), which can't double as a bare-absolute-path
+    /// marker. Function workloads write `/etc/mvm/runner` =
+    /// `/usr/lib/mvm/wrappers/runner`; command workloads omit it and the
+    /// (non-fatal) marker read fails benignly since they never call
+    /// `RunEntrypoint`.
     pub fn production() -> Self {
         Self {
-            marker_path: PathBuf::from("/etc/mvm/entrypoint"),
+            marker_path: PathBuf::from("/etc/mvm/runner"),
             allowed_prefix: PathBuf::from("/usr/lib/mvm/wrappers/"),
             same_fs_as: Some(PathBuf::from("/usr")),
             required_mode: 0o755,
@@ -1081,7 +1089,7 @@ mod tests {
     #[test]
     fn test_production_policy_constants() {
         let p = EntrypointPolicy::production();
-        assert_eq!(p.marker_path, PathBuf::from("/etc/mvm/entrypoint"));
+        assert_eq!(p.marker_path, PathBuf::from("/etc/mvm/runner"));
         assert_eq!(p.allowed_prefix, PathBuf::from("/usr/lib/mvm/wrappers/"));
         assert_eq!(p.same_fs_as, Some(PathBuf::from("/usr")));
         assert_eq!(p.required_mode, 0o755);

--- a/crates/mvm-guest/src/entrypoint.rs
+++ b/crates/mvm-guest/src/entrypoint.rs
@@ -698,11 +698,19 @@ pub(crate) fn set_no_core_dumps() {
 fn dup_above_fd3(original: &std::fs::File) -> std::io::Result<std::os::fd::OwnedFd> {
     use std::os::fd::{AsRawFd, FromRawFd, OwnedFd};
     let raw = original.as_raw_fd();
-    // F_DUPFD_CLOEXEC: dup to lowest fd >= 4, with CLOEXEC set on the
-    // new fd. CLOEXEC is fine here: the kernel reads the ELF from
-    // this fd during the same `execve` syscall, before CLOEXEC fires.
+    // F_DUPFD (NOT CLOEXEC): the dup must survive `execve` so an
+    // interpreter-script runner works. A shebang runner makes the kernel
+    // re-exec `<interp> /proc/self/fd/<n>`; a CLOEXEC fd is closed across
+    // that second execve, so the interpreter can't reopen the script
+    // (ENOENT — the `mvmctl invoke` failure mode). Leaving CLOEXEC clear
+    // lets the interpreter reopen /proc/self/fd/<n>, which still resolves
+    // to the SAME boot-validated inode the agent holds open — so TOCTOU
+    // safety is preserved, not weakened. The fd is read-only to a
+    // world-readable (0555) wrapper, so leaking it into the runner + its
+    // children grants nothing. ELF runners are unaffected (the kernel
+    // reads the image during the first execve). ADR-007 hardened-exec note.
     // SAFETY: fcntl is async-signal-safe; arguments are validated.
-    let new_raw = unsafe { libc::fcntl(raw, libc::F_DUPFD_CLOEXEC, 4) };
+    let new_raw = unsafe { libc::fcntl(raw, libc::F_DUPFD, 4) };
     if new_raw < 0 {
         return Err(std::io::Error::last_os_error());
     }

--- a/crates/mvm-guest/src/entrypoint.rs
+++ b/crates/mvm-guest/src/entrypoint.rs
@@ -39,7 +39,9 @@ pub struct EntrypointPolicy {
 impl EntrypointPolicy {
     /// Production policy: read `/etc/mvm/runner`; resolved binary
     /// must live under `/usr/lib/mvm/wrappers/` on the same filesystem
-    /// as `/usr`, owned root, mode 0755.
+    /// as `/usr`, owned root, mode 0555. (Read-only: mkGuest's rootfs
+    /// hardening pass strips owner-write from baked files, and the agent
+    /// binary itself is 0555 — owner-write would be the anomaly here.)
     ///
     /// The marker is `/etc/mvm/runner`, NOT `/etc/mvm/entrypoint`:
     /// `/etc/mvm/entrypoint` is PID 1's boot command (a shell script
@@ -53,7 +55,7 @@ impl EntrypointPolicy {
             marker_path: PathBuf::from("/etc/mvm/runner"),
             allowed_prefix: PathBuf::from("/usr/lib/mvm/wrappers/"),
             same_fs_as: Some(PathBuf::from("/usr")),
-            required_mode: 0o755,
+            required_mode: 0o555,
             required_uid: 0,
             required_gid: 0,
         }
@@ -989,8 +991,8 @@ mod tests {
 
     #[test]
     fn test_validate_happy_path() {
-        let (tmp, marker, wrapper) = make_tree(0o755, b"#!/bin/sh\necho ok\n");
-        let policy = test_policy(marker, tmp.path().join("usr/lib/mvm/wrappers"), 0o755);
+        let (tmp, marker, wrapper) = make_tree(0o555, b"#!/bin/sh\necho ok\n");
+        let policy = test_policy(marker, tmp.path().join("usr/lib/mvm/wrappers"), 0o555);
         let validated = policy.validate().expect("validate should succeed");
         assert_eq!(validated.resolved, std::fs::canonicalize(&wrapper).unwrap());
     }
@@ -1036,11 +1038,11 @@ mod tests {
     #[test]
     fn test_validate_wrong_mode() {
         let (tmp, marker, _wrapper) = make_tree(0o644, b"#!/bin/sh\n");
-        let policy = test_policy(marker, tmp.path().join("usr/lib/mvm/wrappers"), 0o755);
+        let policy = test_policy(marker, tmp.path().join("usr/lib/mvm/wrappers"), 0o555);
         match policy.validate() {
             Err(ValidationError::WrongMode { mode, required, .. }) => {
                 assert_eq!(mode, 0o644);
-                assert_eq!(required, 0o755);
+                assert_eq!(required, 0o555);
             }
             other => panic!("expected WrongMode, got {other:?}"),
         }
@@ -1092,7 +1094,7 @@ mod tests {
         assert_eq!(p.marker_path, PathBuf::from("/etc/mvm/runner"));
         assert_eq!(p.allowed_prefix, PathBuf::from("/usr/lib/mvm/wrappers/"));
         assert_eq!(p.same_fs_as, Some(PathBuf::from("/usr")));
-        assert_eq!(p.required_mode, 0o755);
+        assert_eq!(p.required_mode, 0o555);
         assert_eq!(p.required_uid, 0);
         assert_eq!(p.required_gid, 0);
     }

--- a/crates/mvm-guest/src/vsock.rs
+++ b/crates/mvm-guest/src/vsock.rs
@@ -149,7 +149,7 @@ pub enum GuestRequest {
     /// piped in and stdout/stderr captured. ADR-007 / plan 41 W1.
     ///
     /// This is the production-safe call surface. The agent reads the
-    /// entrypoint path from `/etc/mvm/entrypoint` at boot, validates
+    /// entrypoint path from `/etc/mvm/runner` at boot, validates
     /// it (verity-partition, mode, ownership), and that resolved
     /// path is the only program `RunEntrypoint` will spawn. There is
     /// no argv override, no shell, no env injection beyond what the
@@ -597,7 +597,7 @@ pub struct ReadinessReport {
     /// Vsock listener bound and accepting. Always `Ready` if the
     /// agent could respond at all.
     pub control_plane: ComponentState,
-    /// `/etc/mvm/entrypoint` validation result. Gates `RunEntrypoint`
+    /// `/etc/mvm/runner` validation result. Gates `RunEntrypoint`
     /// — a request submitted while `Starting` returns
     /// `RunEntrypointError::NotReady`.
     pub entrypoint: ComponentState,
@@ -866,7 +866,7 @@ pub enum GuestResponse {
     /// Result of an `EntrypointStatus` query. ADR-007 / plan 41 W5.
     ///
     /// `ok = true` means the agent successfully validated
-    /// `/etc/mvm/entrypoint` at boot and will serve `RunEntrypoint`.
+    /// `/etc/mvm/runner` at boot and will serve `RunEntrypoint`.
     /// `ok = false` means validation failed — `path` carries the
     /// resolved path attempt (or the marker contents if resolution
     /// itself failed) and `detail` carries a human-readable reason.
@@ -1438,7 +1438,7 @@ pub enum RunEntrypointError {
     /// than `EntrypointInvalid` (which would imply a permanent
     /// failure). Hosts should poll readiness, not retry blindly.
     NotReady,
-    /// `/etc/mvm/entrypoint` is missing, fails validation
+    /// `/etc/mvm/runner` is missing, fails validation
     /// (symlink crossing FS, wrong perms, off the verity
     /// partition), or otherwise can't be loaded. Reported per-call
     /// even though the validation runs at agent boot.

--- a/crates/mvm-ir/src/workload.rs
+++ b/crates/mvm-ir/src/workload.rs
@@ -195,7 +195,8 @@ pub enum Entrypoint {
         env: BTreeMap<String, EnvValue>,
     },
     /// Function-call entrypoint (plan 0003 / ADR-0009): a baked
-    /// per-language wrapper at `/etc/mvm/entrypoint` reads stdin,
+    /// per-language wrapper at `/usr/lib/mvm/wrappers/runner` (named by
+    /// the agent marker `/etc/mvm/runner`) reads stdin,
     /// dispatches `module:function` per the declared `format`, writes
     /// the return on stdout. The host SDK calls
     /// `mvmctl invoke <workload> --stdin <encoded>` to invoke.

--- a/crates/mvm-sdk/src/compile/flake.rs
+++ b/crates/mvm-sdk/src/compile/flake.rs
@@ -59,8 +59,8 @@ pub fn build_flake_nix(workload: &Workload) -> Result<String, serde_json::Error>
       buildPreStart = pkgs: appPkg:
         pkgs.writeShellScript "${{launch.workload_id}}-prestart" ''
           set -eu
-          mkdir -p "$(dirname ${{launch.entrypoint.working_dir}})"
-          ln -sfn ${{appPkg}} ${{launch.entrypoint.working_dir}}
+          ${{pkgs.coreutils}}/bin/mkdir -p "$(${{pkgs.coreutils}}/bin/dirname ${{launch.entrypoint.working_dir}})"
+          ${{pkgs.coreutils}}/bin/ln -sfn ${{appPkg}} ${{launch.entrypoint.working_dir}}
         '';
       isFunction = launch.entrypoint.kind == "function";
       # Per ADR-0010 §3 (Option A, amended 2026-05-06): factories live

--- a/crates/mvm-sdk/src/compile/mod.rs
+++ b/crates/mvm-sdk/src/compile/mod.rs
@@ -51,6 +51,7 @@ pub mod mvm_pin;
 pub mod orchestrator;
 pub mod reachability;
 pub mod source;
+pub mod strip_framework;
 
 pub use archive::{ArchiveError, archive_dir};
 pub use deps::{DepsError, validate_lockfiles};

--- a/crates/mvm-sdk/src/compile/orchestrator.rs
+++ b/crates/mvm-sdk/src/compile/orchestrator.rs
@@ -23,6 +23,9 @@ use std::path::{Path, PathBuf};
 pub enum CompileError {
     OutputExistsNotDir(PathBuf),
     Staging(io::Error),
+    /// Stripping build-time framework constructs (`import mvm` /
+    /// `@mvm.*`) from the bundled source failed.
+    StripFramework(io::Error),
     Render(serde_json::Error),
     Write(io::Error),
     Source(SourceError),
@@ -65,6 +68,7 @@ impl std::fmt::Display for CompileError {
                 )
             }
             Self::Staging(e) => write!(f, "atomic staging failed: {e}"),
+            Self::StripFramework(e) => write!(f, "stripping framework constructs failed: {e}"),
             Self::Render(e) => write!(f, "rendering artifact failed: {e}"),
             Self::Write(e) => write!(f, "writing artifact failed: {e}"),
             Self::Source(e) => write!(f, "source bundling failed: {e}"),
@@ -228,6 +232,16 @@ pub fn compile(workload: &Workload, out: &Path, manifest_dir: &Path) -> Result<(
             check_function_presence(&bundle_dir, lang, &app.entrypoints)?;
             prune_unreachable(&bundle_dir, &reachable, lang.extensions())
                 .map_err(CompileError::Source)?;
+            // B: the @mvm.app decorator is build-time metadata (already
+            // lowered to IR above). Strip `import mvm` + `@mvm.*` from the
+            // bundled source so the guest runtime never needs the SDK — the
+            // wrapper imports the user module to dispatch, and the decorator
+            // returned the function unchanged anyway. Python only for now;
+            // Node strip is analogous (tree-sitter-typescript) when wired.
+            if lang == Language::Python {
+                crate::compile::strip_framework::strip_python(&bundle_dir)
+                    .map_err(CompileError::StripFramework)?;
+            }
             source_plan = rehash(&bundle_dir).map_err(CompileError::Source)?;
         }
 

--- a/crates/mvm-sdk/src/compile/strip_framework.rs
+++ b/crates/mvm-sdk/src/compile/strip_framework.rs
@@ -1,0 +1,200 @@
+//! Strip build-time framework constructs from the bundled Python source.
+//!
+//! The `@mvm.app(...)` decorator is compile-time metadata — `compile`
+//! has already lowered it to IR by the time we bundle — and the decorator
+//! returns the wrapped function unchanged. So the guest runtime must NOT
+//! need the `mvm` SDK: the wrapper imports the user module to dispatch the
+//! function, and a stray `import mvm` would fail in a rootfs that
+//! deliberately doesn't ship the SDK. Removing `import mvm` and every
+//! `@mvm.*` decorator from the bundled tree keeps the SDK out of the guest
+//! entirely (authoring still uses the published SDK on the host).
+//!
+//! Tree-sitter only — no Python is executed. Unparseable files are left
+//! untouched (the reachability/presence passes already ran on them).
+
+use std::fs;
+use std::path::Path;
+
+use tree_sitter::{Node, Parser};
+
+/// Walk every `.py` file under `bundle_dir` and rewrite it without
+/// `mvm` imports / `@mvm.*` decorators. Idempotent; only writes files
+/// that actually change.
+pub fn strip_python(bundle_dir: &Path) -> std::io::Result<()> {
+    let mut stack = vec![bundle_dir.to_path_buf()];
+    while let Some(dir) = stack.pop() {
+        for entry in fs::read_dir(&dir)? {
+            let path = entry?.path();
+            if path.is_dir() {
+                stack.push(path);
+            } else if path.extension().is_some_and(|e| e == "py") {
+                let src = fs::read(&path)?;
+                if let Some(rewritten) = strip_source(&src) {
+                    fs::write(&path, rewritten)?;
+                }
+            }
+        }
+    }
+    Ok(())
+}
+
+/// Return the source with `mvm` imports + `@mvm.*` decorators removed,
+/// or `None` if nothing matched / the file didn't parse cleanly.
+fn strip_source(source: &[u8]) -> Option<Vec<u8>> {
+    let mut parser = Parser::new();
+    parser
+        .set_language(&tree_sitter_python::LANGUAGE.into())
+        .ok()?;
+    let tree = parser.parse(source, None)?;
+    let root = tree.root_node();
+    if root.has_error() {
+        return None; // don't risk mangling a file we can't parse
+    }
+
+    let mut ranges: Vec<(usize, usize)> = Vec::new();
+    collect_ranges(root, source, &mut ranges);
+    if ranges.is_empty() {
+        return None;
+    }
+
+    // Remove whole lines, last-first so earlier byte offsets stay valid.
+    ranges.sort_by(|a, b| b.0.cmp(&a.0));
+    let mut out = source.to_vec();
+    for (start, end) in ranges {
+        // Expand to the start of the line (decorators/imports sit at
+        // column 0 at module scope, but be defensive about indentation).
+        let mut line_start = start;
+        while line_start > 0 && out[line_start - 1] != b'\n' {
+            line_start -= 1;
+        }
+        // Expand past the node's last line, including its trailing newline.
+        let mut line_end = end;
+        while line_end < out.len() && out[line_end] != b'\n' {
+            line_end += 1;
+        }
+        if line_end < out.len() {
+            line_end += 1; // consume the newline
+        }
+        out.drain(line_start..line_end);
+    }
+    Some(out)
+}
+
+/// Collect byte ranges of nodes to delete: `import mvm` /
+/// `from mvm import …` statements and `@mvm.*` decorators.
+fn collect_ranges(node: Node, source: &[u8], ranges: &mut Vec<(usize, usize)>) {
+    match node.kind() {
+        "import_statement" | "import_from_statement" => {
+            if imports_mvm(node, source) {
+                ranges.push((node.start_byte(), node.end_byte()));
+                return;
+            }
+        }
+        "decorator" => {
+            if decorator_is_mvm(node, source) {
+                ranges.push((node.start_byte(), node.end_byte()));
+                return;
+            }
+        }
+        _ => {}
+    }
+    let mut cursor = node.walk();
+    for child in node.children(&mut cursor) {
+        collect_ranges(child, source, ranges);
+    }
+}
+
+/// True if the import statement brings in the top-level `mvm` module —
+/// `import mvm`, `import mvm as m`, or `from mvm[.x] import …`. A module
+/// merely *prefixed* `mvm` (e.g. `mvmfoo`) is left alone.
+fn imports_mvm(node: Node, source: &[u8]) -> bool {
+    let mut cursor = node.walk();
+    for child in node.children(&mut cursor) {
+        match child.kind() {
+            // `import mvm` / `import mvm as m`: dotted_name or aliased_import.
+            "dotted_name" => {
+                if dotted_root_is_mvm(child, source) {
+                    return true;
+                }
+            }
+            "aliased_import" => {
+                if let Some(name) = child.child_by_field_name("name")
+                    && dotted_root_is_mvm(name, source)
+                {
+                    return true;
+                }
+            }
+            // `from mvm import …`: the module name is the field `module_name`.
+            _ => {
+                if child.kind() == "dotted_name" || node.kind() == "import_from_statement" {
+                    if let Some(m) = node.child_by_field_name("module_name")
+                        && dotted_root_is_mvm(m, source)
+                    {
+                        return true;
+                    }
+                }
+            }
+        }
+    }
+    false
+}
+
+/// First dotted segment equals `mvm` exactly.
+fn dotted_root_is_mvm(node: Node, source: &[u8]) -> bool {
+    node.utf8_text(source)
+        .map(|t| t == "mvm" || t.starts_with("mvm."))
+        .unwrap_or(false)
+}
+
+/// True for `@mvm`, `@mvm.app`, `@mvm.anything(...)`.
+fn decorator_is_mvm(node: Node, source: &[u8]) -> bool {
+    // Decorator text is `@<expr>`; strip the `@` and check the callee root.
+    node.utf8_text(source)
+        .map(|t| {
+            let body = t.trim_start_matches('@').trim_start();
+            body == "mvm" || body.starts_with("mvm.") || body.starts_with("mvm(")
+        })
+        .unwrap_or(false)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn strip(s: &str) -> String {
+        String::from_utf8(strip_source(s.as_bytes()).unwrap_or_else(|| s.as_bytes().to_vec()))
+            .unwrap()
+    }
+
+    #[test]
+    fn strips_import_and_decorator_keeps_function() {
+        let src = "import mvm\n\n\n@mvm.app(image=mvm.python_image(python=\"3.12\"))\ndef greet(name):\n    return f\"hello {name}\"\n";
+        let out = strip(src);
+        assert!(!out.contains("import mvm"));
+        assert!(!out.contains("@mvm.app"));
+        assert!(out.contains("def greet(name):"));
+        assert!(out.contains("return f\"hello {name}\""));
+    }
+
+    #[test]
+    fn strips_from_import() {
+        let out = strip("from mvm import app\ndef f():\n    return 1\n");
+        assert!(!out.contains("from mvm"));
+        assert!(out.contains("def f():"));
+    }
+
+    #[test]
+    fn leaves_unrelated_imports_and_lookalikes() {
+        let src = "import os\nimport mvmfoo\ndef f():\n    return os.getpid()\n";
+        // Nothing to strip → None → unchanged.
+        assert!(strip_source(src.as_bytes()).is_none());
+    }
+
+    #[test]
+    fn strips_multiline_decorator() {
+        let src = "import mvm\n@mvm.app(\n    image=mvm.python_image(python=\"3.12\"),\n    resources=mvm.resources(cpu=1, memory_mb=256),\n)\ndef greet(name: str) -> str:\n    return f\"hello {name}\"\n";
+        let out = strip(src);
+        assert!(!out.contains("mvm"));
+        assert!(out.contains("def greet(name: str) -> str:"));
+    }
+}

--- a/crates/mvm-sdk/src/compile/strip_framework.rs
+++ b/crates/mvm-sdk/src/compile/strip_framework.rs
@@ -58,7 +58,7 @@ fn strip_source(source: &[u8]) -> Option<Vec<u8>> {
     }
 
     // Remove whole lines, last-first so earlier byte offsets stay valid.
-    ranges.sort_by(|a, b| b.0.cmp(&a.0));
+    ranges.sort_by_key(|&(start, _)| std::cmp::Reverse(start));
     let mut out = source.to_vec();
     for (start, end) in ranges {
         // Expand to the start of the line (decorators/imports sit at
@@ -84,17 +84,13 @@ fn strip_source(source: &[u8]) -> Option<Vec<u8>> {
 /// `from mvm import …` statements and `@mvm.*` decorators.
 fn collect_ranges(node: Node, source: &[u8], ranges: &mut Vec<(usize, usize)>) {
     match node.kind() {
-        "import_statement" | "import_from_statement" => {
-            if imports_mvm(node, source) {
-                ranges.push((node.start_byte(), node.end_byte()));
-                return;
-            }
+        "import_statement" | "import_from_statement" if imports_mvm(node, source) => {
+            ranges.push((node.start_byte(), node.end_byte()));
+            return;
         }
-        "decorator" => {
-            if decorator_is_mvm(node, source) {
-                ranges.push((node.start_byte(), node.end_byte()));
-                return;
-            }
+        "decorator" if decorator_is_mvm(node, source) => {
+            ranges.push((node.start_byte(), node.end_byte()));
+            return;
         }
         _ => {}
     }
@@ -108,35 +104,20 @@ fn collect_ranges(node: Node, source: &[u8], ranges: &mut Vec<(usize, usize)>) {
 /// `import mvm`, `import mvm as m`, or `from mvm[.x] import …`. A module
 /// merely *prefixed* `mvm` (e.g. `mvmfoo`) is left alone.
 fn imports_mvm(node: Node, source: &[u8]) -> bool {
-    let mut cursor = node.walk();
-    for child in node.children(&mut cursor) {
-        match child.kind() {
-            // `import mvm` / `import mvm as m`: dotted_name or aliased_import.
-            "dotted_name" => {
-                if dotted_root_is_mvm(child, source) {
-                    return true;
-                }
-            }
-            "aliased_import" => {
-                if let Some(name) = child.child_by_field_name("name")
-                    && dotted_root_is_mvm(name, source)
-                {
-                    return true;
-                }
-            }
-            // `from mvm import …`: the module name is the field `module_name`.
-            _ => {
-                if child.kind() == "dotted_name" || node.kind() == "import_from_statement" {
-                    if let Some(m) = node.child_by_field_name("module_name")
-                        && dotted_root_is_mvm(m, source)
-                    {
-                        return true;
-                    }
-                }
-            }
-        }
+    // `from mvm import …` carries the module on the `module_name` field.
+    if let Some(m) = node.child_by_field_name("module_name") {
+        return dotted_root_is_mvm(m, source);
     }
-    false
+    // `import mvm`, `import mvm as m`, `import a, mvm` → scan the name
+    // children (`dotted_name` / `aliased_import`).
+    let mut cursor = node.walk();
+    node.children(&mut cursor).any(|child| match child.kind() {
+        "dotted_name" => dotted_root_is_mvm(child, source),
+        "aliased_import" => child
+            .child_by_field_name("name")
+            .is_some_and(|n| dotted_root_is_mvm(n, source)),
+        _ => false,
+    })
 }
 
 /// First dotted segment equals `mvm` exactly.

--- a/examples/python/hello-app/requirements.txt
+++ b/examples/python/hello-app/requirements.txt
@@ -1,0 +1,11 @@
+# Runtime Python dependencies for this workload, one per line.
+#
+# Installed at build time inside the builder VM by the default
+# `before_build` hook (`pip install -r requirements.txt`) and baked into
+# the workload rootfs — never on the host, never at boot. Override by
+# declaring your own `before_build` in `@mvm.app(...)`.
+#
+# `mvm` itself is intentionally absent: the `@mvm.app` decorator is
+# build-time metadata that `mvmctl compile` strips from the bundled
+# source, so the guest never imports the SDK. hello-app has no other
+# runtime dependencies; add yours below.

--- a/nix/lib/factories/README.md
+++ b/nix/lib/factories/README.md
@@ -71,7 +71,10 @@ Returns the `{ extraFiles, servicePackages, service }` triple a
 downstream `mkGuest` composition layer consumes.
 
 `extraFiles` always contains:
-- `/etc/mvm/entrypoint` → `/usr/lib/mvm/wrappers/runner`
+- `/etc/mvm/runner` → the agent marker; contents are the absolute path
+  `/usr/lib/mvm/wrappers/runner` the guest agent execs per `RunEntrypoint`
+  (kept distinct from `/etc/mvm/entrypoint`, which is PID 1's idle boot
+  command — see `mvm_guest::entrypoint`).
 - `/usr/lib/mvm/wrappers/runner` → the language's wrapper script
   (cold-tier `oneshot.*` or warm-tier `longrunning.*` depending on
   `concurrency`).

--- a/nix/lib/factories/languages/python.nix
+++ b/nix/lib/factories/languages/python.nix
@@ -22,6 +22,16 @@ let
 in
 {
   language = "python";
-  runnerScript = builtins.readFile runnerSource;
+  # Stamp the nix interpreter into the shebang. The wrapper source carries
+  # `#!/usr/bin/env python3`, but the busybox workload rootfs has no
+  # /usr/bin/env, so the agent's per-call exec of the runner would fail
+  # `not found`. `pkgs.python3` is in `servicePackages` below, so its
+  # store path is in the rootfs closure. oneshot.py is stdlib-only on the
+  # JSON path (msgpack/jsonschema are lazy best-effort imports), so a bare
+  # python3 shebang suffices — no writePython3/library plumbing.
+  runnerScript =
+    let raw = builtins.readFile runnerSource; in
+    builtins.replaceStrings
+      [ "#!/usr/bin/env python3" ] [ "#!${pkgs.python3}/bin/python3" ] raw;
   servicePackages = [ pkgs.python3 ];
 }

--- a/nix/lib/factories/mkFunctionService.nix
+++ b/nix/lib/factories/mkFunctionService.nix
@@ -152,6 +152,16 @@ in
       content = lang.runnerScript;
       mode = "0755";
     };
+    # Agent marker for per-call RunEntrypoint (mvm_guest::entrypoint
+    # EntrypointPolicy). SEPARATE from /etc/mvm/entrypoint, which is PID
+    # 1's idle boot command (a #!/bin/sh script /init sources) and can't
+    # double as a bare-absolute-path marker. The agent reads THIS file,
+    # requires its contents be an absolute path under
+    # /usr/lib/mvm/wrappers/, and execs the resolved binary per call.
+    "/etc/mvm/runner" = {
+      content = "/usr/lib/mvm/wrappers/runner\n";
+      mode = "0644";
+    };
     "/etc/mvm/wrapper.json" = {
       content = wrapperJson;
       mode = "0644";

--- a/nix/lib/factories/mkFunctionService.nix
+++ b/nix/lib/factories/mkFunctionService.nix
@@ -199,8 +199,8 @@ in
     '';
     preStart = pkgs.writeShellScript "${workloadId}-prestart" ''
       set -eu
-      mkdir -p "$(dirname ${sourcePath})"
-      ln -sfn ${appPkg} ${sourcePath}
+      ${pkgs.coreutils}/bin/mkdir -p "$(${pkgs.coreutils}/bin/dirname ${sourcePath})"
+      ${pkgs.coreutils}/bin/ln -sfn ${appPkg} ${sourcePath}
     '';
     env = { };
   };

--- a/nix/lib/factories/mkFunctionService.nix
+++ b/nix/lib/factories/mkFunctionService.nix
@@ -148,9 +148,13 @@ in
     # runner: it returns/can't-exec, /init falls through to `sleep 5`, and
     # the kernel reboots at ~5s — killing the workload before the host can
     # reach the agent. The runner stays below for the agent to invoke.
+    # Mode 0555 (read-only): the rootfs hardening pass strips owner-write
+    # anyway, and the agent's EntrypointPolicy requires exactly 0555
+    # (matching the agent binary's own mode). Declaring it here keeps the
+    # baked mode honest instead of relying on the strip pass.
     "/usr/lib/mvm/wrappers/runner" = {
       content = lang.runnerScript;
-      mode = "0755";
+      mode = "0555";
     };
     # Agent marker for per-call RunEntrypoint (mvm_guest::entrypoint
     # EntrypointPolicy). SEPARATE from /etc/mvm/entrypoint, which is PID

--- a/nix/lib/factories/mkFunctionService.nix
+++ b/nix/lib/factories/mkFunctionService.nix
@@ -140,10 +140,14 @@ let
 in
 {
   extraFiles = {
-    "/etc/mvm/entrypoint" = {
-      content = "/usr/lib/mvm/wrappers/runner";
-      mode = "0644";
-    };
+    # NOTE: do NOT write /etc/mvm/entrypoint here. The function workload's
+    # PID 1 must be the *idle* bootScript (`exec sleep infinity`) that the
+    # compile path passes via mkGuest `entrypoint.command` — the agent then
+    # execs the runner per call over vsock RunEntrypoint. Baking the runner
+    # AS the entrypoint (it used to live here) made PID 1 the one-shot
+    # runner: it returns/can't-exec, /init falls through to `sleep 5`, and
+    # the kernel reboots at ~5s — killing the workload before the host can
+    # reach the agent. The runner stays below for the agent to invoke.
     "/usr/lib/mvm/wrappers/runner" = {
       content = lang.runnerScript;
       mode = "0755";

--- a/sdks/typescript/package.json
+++ b/sdks/typescript/package.json
@@ -1,6 +1,9 @@
 {
-  "name": "mvm-sdk",
+  "name": "@runmvm/mvm",
   "version": "0.14.0",
+  "publishConfig": {
+    "access": "public"
+  },
   "description": "TypeScript SDK for declaring mvm microVM workloads. SDK port Phase 6 — mirror of the Python SDK at sdks/python/.",
   "type": "module",
   "main": "./dist/index.js",

--- a/sdks/typescript/src/index.ts
+++ b/sdks/typescript/src/index.ts
@@ -10,7 +10,7 @@
  * can validate identically through:
  *
  *   - The in-process SDK (this module): user writes
- *     `import * as mvm from "mvm-sdk"; export const greet =
+ *     `import * as mvm from "@runmvm/mvm"; export const greet =
  *      mvm.app({...})((name: string) => ...)` and runs `tsc + node` /
  *     `tsx` to emit IR via `mvm.emitJson()`.
  *   - The AST-walking compiler: `mvmctl compile app.ts` reads the same
@@ -49,7 +49,7 @@ import type {
 } from "./ir/workload.js";
 
 // Re-export the codegen output so callers `import { Workload } from
-// "mvm-sdk"` directly rather than reaching into the `ir/` sub-path.
+// "@runmvm/mvm"` directly rather than reaching into the `ir/` sub-path.
 export * from "./ir/workload.js";
 
 // Sandbox SDK (Phase 7c + 7f + Plan 73 Followup H-live). Imperative

--- a/specs/research/function-runner-nix-artifact-followup.md
+++ b/specs/research/function-runner-nix-artifact-followup.md
@@ -1,98 +1,174 @@
-# Follow-up: the function-service runner should be a nix-built artifact (per language)
+# Follow-up: make `mvmctl invoke` work on a function workload
 
-**Status:** proposed (2026-06-02). Companion to the `mkFunctionService`
-entrypoint-override fix (drop `/etc/mvm/entrypoint = runner` so PID 1 is
-the idle bootScript) — that unblocks Plan 120 Task 4 (boot→ping). This
-note covers the *remaining* layer needed for actual function **invocation**
-(`mvmctl invoke`), which the boot fix alone does not address.
+**Status:** spec (2026-06-02). Companion to the boot→ping fixes in this
+PR (#537). Those got the function workload to **boot and answer `Ping`**
+(Plan 120 Task 4). This note covers the *remaining* layer — actual
+function **invocation** (`mvmctl invoke` → vsock `RunEntrypoint`), which
+boot→ping does not exercise. Grounded in the live trace + the agent code
+(`crates/mvm-guest/src/entrypoint.rs`, `bin/mvm-guest-agent.rs`).
 
-## The remaining problem
+## What the boot→ping trace revealed
 
-`/usr/lib/mvm/wrappers/runner` is the wrapper the **agent** execs per
-`RunEntrypoint` call. It is currently baked by inlining a raw script:
+With the workload finally staying up, the agent logs at boot:
+
+```
+mvm-guest-agent: entrypoint validation failed at boot:
+  entrypoint marker contents not absolute: #!/bin/sh
+  /nix/store/…-greet-boot; RunEntrypoint requests will return EntrypointInvalid
+```
+
+So there are **two** independent invoke blockers, in priority order:
+
+### 1. (primary) `/etc/mvm/entrypoint` is overloaded — marker vs boot command
+
+`/etc/mvm/entrypoint` has two *incompatible* consumers:
+
+- **`/init`** (`nix/lib/mk-guest.nix`) **sources** it as PID 1's boot
+  command. For a function workload that's the idle `funcBootScript`
+  (`exec sleep infinity`) — a `#!/bin/sh` script.
+- **The agent** (`EntrypointPolicy::production()`,
+  `entrypoint.rs:43`) reads it as a **marker whose contents must be a
+  bare absolute path** to the per-call runner under
+  `/usr/lib/mvm/wrappers/`, then `RunEntrypoint` execs *that* per call.
+
+One file cannot be both a shell script and a bare path. The history
+proves the conflict is fundamental, not a bug:
+
+- **Before #537:** `mkFunctionService` wrote `/etc/mvm/entrypoint =
+  /usr/lib/mvm/wrappers/runner` (a bare path). The agent marker was
+  *valid* — but PID 1 became the one-shot runner → reboot.
+- **After #537:** `/etc/mvm/entrypoint` is the idle bootScript. PID 1 is
+  correct — but the agent marker is now a script → `NotAbsolute` →
+  `EntrypointInvalid`.
+
+The two requirements move in opposite directions on the same file. **They
+must be different files.**
+
+Note the agent's boot validation is **non-fatal** (`init_entrypoint_validation`,
+`mvm-guest-agent.rs:1440` — logs one line, agent stays up, only
+`RunEntrypoint` fails). Command (non-function) workloads never call
+`RunEntrypoint`, so they tolerate a missing/failed marker. The marker is
+therefore a *function-workload* concept.
+
+### 2. (secondary) the runner isn't executable in the rootfs
+
+`/usr/lib/mvm/wrappers/runner` is what the agent execs per call. It's
+baked by inlining the raw wrapper bytes:
 
 ```nix
 # nix/lib/factories/languages/python.nix
-runnerSource  = if concurrency == null then ../../../wrappers/python/oneshot.py
-                else ../../../wrappers/python/longrunning.py;
-runnerScript  = builtins.readFile runnerSource;   # ← verbatim string
+runnerScript = builtins.readFile ../../../wrappers/python/oneshot.py;
 # nix/lib/factories/mkFunctionService.nix
 "/usr/lib/mvm/wrappers/runner" = { content = lang.runnerScript; mode = "0755"; };
 ```
 
-`readFile` ships the script's bytes **unmodified**, so its shebang ships
-unmodified too. `nix/wrappers/python/oneshot.py` starts with
-`#!/usr/bin/env python3`; the busybox workload rootfs has **no
-`/usr/bin/env`**, so any direct exec of the runner fails `not found`.
-(`nix/wrappers/node/*.mjs` has the same shape; node infers ESM and the
-README expects `node /usr/lib/mvm/wrappers/runner`.) Two further breaks:
+`readFile` ships the bytes verbatim, so `oneshot.py`'s
+`#!/usr/bin/env python3` ships verbatim — and the busybox workload rootfs
+has **no `/usr/bin/env`**, so a direct exec fails `not found`. (Even once
+the marker points here, this is the next failure.)
 
-1. **Mode.** Declared `0755`, but a later read-only pass in the rootfs
-   build strips owner-write → the baked file is `555`, while the agent's
-   entrypoint policy requires `0o755` (`crates/mvm-guest/src/entrypoint.rs:48`)
-   → `RunEntrypoint` returns `EntrypointInvalid`.
-2. **PATH/deps.** Even with a working interpreter, the wrapper relies on
-   the guest's ambient `PATH` and on `python3`/libs being resolvable.
+## Design
 
-All three are exactly what nix builds solve by construction. The codebase
-already says so: `mkFunctionService.nix:15-18` documents the inlined
-wrappers as a **stopgap** "until [a] follow-up PR replaces the inlined
-script with the compiled `mvm-runner` binary."
+### Decouple the marker from the boot command (fixes blocker 1)
 
-## Proposal: nix owns the runner, dispatched by the language registry
+Keep `/etc/mvm/entrypoint` as PID 1's boot command (unchanged — `/init`
+keeps sourcing it). Give the agent its **own** marker file:
 
-The language registry (`nix/lib/factories/languages/<lang>.nix`) already
-returns `{ language, runnerScript, servicePackages }`. Change `runnerScript`
-from a **raw string** to a **nix-built artifact** (a store path), and have
-`mkFunctionService` install it via `source = <store path>` (which preserves
-nix's shebang + the store's `555` mode) instead of `content = <string>`.
+- New file `/etc/mvm/runner`, contents = `/usr/lib/mvm/wrappers/runner\n`
+  (a bare absolute path). Written only by `mkFunctionService` (only
+  function workloads have a runner).
+- `EntrypointPolicy::production().marker_path` → `/etc/mvm/runner`.
 
-Per language, in `nix/lib/factories/languages/`:
+Command workloads have no `/etc/mvm/runner`; the agent's marker read
+fails benignly (`ReadMarker`, already non-fatal) instead of the current
+misleading `NotAbsolute` on the boot script — strictly clearer.
 
-- **python.nix** — build the wrapper with `pkgs.writers.writePython3`
-  (or `makeWrapper`) so nix stamps `#!${pkgs.python3}/bin/python3` and puts
-  the runtime libs on `PYTHONPATH`:
-  ```nix
-  runner = pkgs.writers.writePython3 "mvm-runner"
-             { libraries = [ ]; flakeIgnore = [ ... ]; }
-             (builtins.readFile ../../../wrappers/python/${variant}.py);
-  ```
-- **node.nix** — `pkgs.writeShellApplication`/`makeWrapper` that execs
-  `${pkgs.nodejs}/bin/node <wrapper.mjs>` (the registry already pins
-  `servicePackages = [ pkgs.nodejs ]`).
-- Future languages add their own registry entry the same way — the
-  interpreter + builder live with the language, not in `mkFunctionService`.
+### Fix the runner shebang (fixes blocker 2) — shebang rewrite, not a full artifact
 
-Then `mkFunctionService.nix`:
+`oneshot.py` is **stdlib-only on the JSON path** (`msgpack`/`jsonschema`
+are lazy, best-effort imports — see `_decode_msgpack`, `_validate_against_schema`).
+`pkgs.python3` is already baked via the registry's `servicePackages`, so
+its store path is in the rootfs closure. The minimal correct fix is to
+stamp the nix interpreter into the shebang — no `writePython3`, no
+library plumbing:
+
 ```nix
-"/usr/lib/mvm/wrappers/runner" = { source = lang.runner; };   # was: content = lang.runnerScript;
+# nix/lib/factories/languages/python.nix
+runnerScript =
+  let raw = builtins.readFile runnerSource; in
+  builtins.replaceStrings
+    [ "#!/usr/bin/env python3" ] [ "#!${pkgs.python3}/bin/python3" ] raw;
 ```
-(`source` defaults to mode `0755` in mkGuest's extraFiles; nix's store
-file is `555`, which is the correct hardened mode for a read-only wrapper.)
 
-## Also: relax the agent's mode requirement to 0o555
+`mkFunctionService` keeps `content = lang.runnerScript; mode = "0755"`.
+`mkGuest`'s `install -m 0755` lands it at exactly 0755 in the rootfs
+(`mk-guest.nix:558`), owned root by the rootfs build.
 
-`crates/mvm-guest/src/entrypoint.rs:48` requires `required_mode: 0o755`.
-A nix-built wrapper (like the agent binary itself, mk-guest.nix:676
-"mode 0555 so the agent can't rewrite itself") is `0o555` — read-only is
-the *more* hardened mode. Change the policy to accept/require `0o555`
-(no owner-write) and update the `entrypoint.rs` unit tests
-(`test_policy(..., 0o755)` → `0o555`). This removes the 555-vs-755
-conflict at its source instead of forcing the wrapper writable.
+**Mode reconciliation is a non-issue** (correcting the earlier draft):
+`install -m 0755` *sets* the mode regardless of the nix store's `555`,
+so the baked runner is 0755 and already matches the agent's
+`required_mode: 0o755`. No agent-policy change, no `0o555` relaxation.
 
-## End state (the documented direction)
+#### Node
 
-The cleanest finish is the compiled, language-agnostic **`mvm-runner`**
-Rust binary baked at `/usr/lib/mvm/wrappers/runner` like the agent — no
-shebang, no interpreter, mode handled by nix, the per-language dispatch
-done in Rust. The `writePython3`/`makeWrapper` step above is the interim
-that makes `invoke` work today; the binary is the eventual replacement.
+`oneshot.mjs` is ESM and needs the `node` runtime — a shebang rewrite
+alone won't do (a shebang'd file with no `.mjs` extension loads as
+CommonJS and the ESM syntax fails). Install two files via the registry
+instead, keeping `mkFunctionService` language-generic by having the
+registry return a set of runner files rather than one string:
+
+```nix
+# node.nix contributes:
+#   /usr/lib/mvm/wrappers/runner.mjs  (content = the wrapper, mode 0644)
+#   /usr/lib/mvm/wrappers/runner      (content = "#!${runtimeShell}\n
+#                                       exec ${nodejs}/bin/node \
+#                                       /usr/lib/mvm/wrappers/runner.mjs \"$@\"",
+#                                       mode 0755)
+```
+
+The marker still points at `/usr/lib/mvm/wrappers/runner`; the shell shim
+is the executable the agent validates and execs. `${pkgs.nodejs}` is
+already in `servicePackages`, so its closure is in the rootfs.
+
+To support both shapes cleanly, change the registry contract from
+`runnerScript` (one string) to `runnerFiles` (a `{ "<rel-path>" = {
+content/source; mode }; }` attrset that `mkFunctionService` merges into
+`extraFiles` under `/usr/lib/mvm/wrappers/`). Python contributes one
+entry, node two.
+
+## Files to change
+
+- `crates/mvm-guest/src/entrypoint.rs` — `marker_path` →
+  `/etc/mvm/runner`; update `test_production_policy_constants` and the
+  module doc-comment. `required_mode` stays `0o755`.
+- `crates/mvm-guest/src/bin/mvm-guest-agent.rs`,
+  `crates/mvm-guest/src/vsock.rs` — comments naming `/etc/mvm/entrypoint`
+  as the marker → `/etc/mvm/runner`.
+- `nix/lib/factories/languages/{python,node}.nix` — fix the python
+  shebang; node contributes the shim + `.mjs`; switch the registry
+  contract to `runnerFiles`.
+- `nix/lib/factories/mkFunctionService.nix` — install `lang.runnerFiles`
+  under `/usr/lib/mvm/wrappers/`; add the `/etc/mvm/runner` marker
+  (`content = "/usr/lib/mvm/wrappers/runner\n"`).
 
 ## Acceptance
 
-- `mvmctl invoke hello-app --input name='ari'` returns `hello ari` against
-  a running function workload (the agent execs the runner, the runner
-  dispatches `greet`, returns the encoded string) — the part Plan 120
-  Task 4's boot→ping acceptance does **not** cover.
-- The runner's baked shebang resolves inside the rootfs (no `/usr/bin/env`
-  dependency); `RunEntrypoint` no longer returns `EntrypointInvalid`.
+- `mvmctl invoke hello-app --input name='ari'` returns `hello ari`
+  against a running function workload: agent boot logs `entrypoint
+  validated at /usr/lib/mvm/wrappers/runner`, `RunEntrypoint` execs the
+  runner, the runner dispatches `greet` and returns the encoded string.
+- The runner's baked shebang resolves inside the rootfs (no
+  `/usr/bin/env` dependency); `RunEntrypoint` no longer returns
+  `EntrypointInvalid`.
+- Boot→ping (Task 4) still green — `/etc/mvm/entrypoint` is untouched,
+  so PID 1 still idles.
+
+## Why not the compiled `mvm-runner` binary now
+
+`mkFunctionService.nix:15-18` documents the eventual end state: a
+compiled, language-agnostic `mvm-runner` Rust binary at
+`/usr/lib/mvm/wrappers/runner` (no shebang, no interpreter, dispatch in
+Rust). That's the clean finish, but it's a larger build-system change.
+The shebang rewrite + marker decouple above makes `invoke` work today
+against the existing audited wrappers; the binary is the later
+replacement, and the marker decoupling it needs is identical.

--- a/specs/research/function-runner-nix-artifact-followup.md
+++ b/specs/research/function-runner-nix-artifact-followup.md
@@ -1,0 +1,98 @@
+# Follow-up: the function-service runner should be a nix-built artifact (per language)
+
+**Status:** proposed (2026-06-02). Companion to the `mkFunctionService`
+entrypoint-override fix (drop `/etc/mvm/entrypoint = runner` so PID 1 is
+the idle bootScript) — that unblocks Plan 120 Task 4 (boot→ping). This
+note covers the *remaining* layer needed for actual function **invocation**
+(`mvmctl invoke`), which the boot fix alone does not address.
+
+## The remaining problem
+
+`/usr/lib/mvm/wrappers/runner` is the wrapper the **agent** execs per
+`RunEntrypoint` call. It is currently baked by inlining a raw script:
+
+```nix
+# nix/lib/factories/languages/python.nix
+runnerSource  = if concurrency == null then ../../../wrappers/python/oneshot.py
+                else ../../../wrappers/python/longrunning.py;
+runnerScript  = builtins.readFile runnerSource;   # ← verbatim string
+# nix/lib/factories/mkFunctionService.nix
+"/usr/lib/mvm/wrappers/runner" = { content = lang.runnerScript; mode = "0755"; };
+```
+
+`readFile` ships the script's bytes **unmodified**, so its shebang ships
+unmodified too. `nix/wrappers/python/oneshot.py` starts with
+`#!/usr/bin/env python3`; the busybox workload rootfs has **no
+`/usr/bin/env`**, so any direct exec of the runner fails `not found`.
+(`nix/wrappers/node/*.mjs` has the same shape; node infers ESM and the
+README expects `node /usr/lib/mvm/wrappers/runner`.) Two further breaks:
+
+1. **Mode.** Declared `0755`, but a later read-only pass in the rootfs
+   build strips owner-write → the baked file is `555`, while the agent's
+   entrypoint policy requires `0o755` (`crates/mvm-guest/src/entrypoint.rs:48`)
+   → `RunEntrypoint` returns `EntrypointInvalid`.
+2. **PATH/deps.** Even with a working interpreter, the wrapper relies on
+   the guest's ambient `PATH` and on `python3`/libs being resolvable.
+
+All three are exactly what nix builds solve by construction. The codebase
+already says so: `mkFunctionService.nix:15-18` documents the inlined
+wrappers as a **stopgap** "until [a] follow-up PR replaces the inlined
+script with the compiled `mvm-runner` binary."
+
+## Proposal: nix owns the runner, dispatched by the language registry
+
+The language registry (`nix/lib/factories/languages/<lang>.nix`) already
+returns `{ language, runnerScript, servicePackages }`. Change `runnerScript`
+from a **raw string** to a **nix-built artifact** (a store path), and have
+`mkFunctionService` install it via `source = <store path>` (which preserves
+nix's shebang + the store's `555` mode) instead of `content = <string>`.
+
+Per language, in `nix/lib/factories/languages/`:
+
+- **python.nix** — build the wrapper with `pkgs.writers.writePython3`
+  (or `makeWrapper`) so nix stamps `#!${pkgs.python3}/bin/python3` and puts
+  the runtime libs on `PYTHONPATH`:
+  ```nix
+  runner = pkgs.writers.writePython3 "mvm-runner"
+             { libraries = [ ]; flakeIgnore = [ ... ]; }
+             (builtins.readFile ../../../wrappers/python/${variant}.py);
+  ```
+- **node.nix** — `pkgs.writeShellApplication`/`makeWrapper` that execs
+  `${pkgs.nodejs}/bin/node <wrapper.mjs>` (the registry already pins
+  `servicePackages = [ pkgs.nodejs ]`).
+- Future languages add their own registry entry the same way — the
+  interpreter + builder live with the language, not in `mkFunctionService`.
+
+Then `mkFunctionService.nix`:
+```nix
+"/usr/lib/mvm/wrappers/runner" = { source = lang.runner; };   # was: content = lang.runnerScript;
+```
+(`source` defaults to mode `0755` in mkGuest's extraFiles; nix's store
+file is `555`, which is the correct hardened mode for a read-only wrapper.)
+
+## Also: relax the agent's mode requirement to 0o555
+
+`crates/mvm-guest/src/entrypoint.rs:48` requires `required_mode: 0o755`.
+A nix-built wrapper (like the agent binary itself, mk-guest.nix:676
+"mode 0555 so the agent can't rewrite itself") is `0o555` — read-only is
+the *more* hardened mode. Change the policy to accept/require `0o555`
+(no owner-write) and update the `entrypoint.rs` unit tests
+(`test_policy(..., 0o755)` → `0o555`). This removes the 555-vs-755
+conflict at its source instead of forcing the wrapper writable.
+
+## End state (the documented direction)
+
+The cleanest finish is the compiled, language-agnostic **`mvm-runner`**
+Rust binary baked at `/usr/lib/mvm/wrappers/runner` like the agent — no
+shebang, no interpreter, mode handled by nix, the per-language dispatch
+done in Rust. The `writePython3`/`makeWrapper` step above is the interim
+that makes `invoke` work today; the binary is the eventual replacement.
+
+## Acceptance
+
+- `mvmctl invoke hello-app --input name='ari'` returns `hello ari` against
+  a running function workload (the agent execs the runner, the runner
+  dispatches `greet`, returns the encoded string) — the part Plan 120
+  Task 4's boot→ping acceptance does **not** cover.
+- The runner's baked shebang resolves inside the rootfs (no `/usr/bin/env`
+  dependency); `RunEntrypoint` no longer returns `EntrypointInvalid`.

--- a/specs/research/function-runner-nix-artifact-followup.md
+++ b/specs/research/function-runner-nix-artifact-followup.md
@@ -169,12 +169,47 @@ entry, node two.
 - Boot→ping (Task 4) still green — `/etc/mvm/entrypoint` is untouched,
   so PID 1 still idles.
 
-## Why not the compiled `mvm-runner` binary now
+## The runner MUST be a binary, not a shebang script (fexecve finding)
 
-`mkFunctionService.nix:15-18` documents the eventual end state: a
-compiled, language-agnostic `mvm-runner` Rust binary at
-`/usr/lib/mvm/wrappers/runner` (no shebang, no interpreter, dispatch in
-Rust). That's the clean finish, but it's a larger build-system change.
-The shebang rewrite + marker decouple above makes `invoke` work today
-against the existing audited wrappers; the binary is the later
-replacement, and the marker decoupling it needs is identical.
+Live `RunEntrypoint` (via the `agent_invoke` example) got the agent to
+exec the runner — then failed:
+
+```
+/nix/store/…/python3: can't open file '/proc/self/fd/6': No such file or directory
+Exit { code: 2 }
+```
+
+Root cause: `entrypoint.rs::execute` execs the validated runner via
+`/proc/self/fd/<n>` — its boot-validated, **CLOEXEC** fd, held open to
+defeat TOCTOU between validation and spawn. For an **ELF binary** the
+kernel reads the image from that fd during `execve` (before CLOEXEC
+fires) — fine. For a **shebang script**, the kernel reads `#!…/python3`
+and performs a *second* `execve("…/python3", ["python3", "/proc/self/fd/6"])`;
+the CLOEXEC fd is closed across that re-exec, so the interpreter can't
+reopen the script. **Interpreter scripts fundamentally can't ride the
+TOCTOU-safe fd-exec path.** So the marker decouple + shebang rewrite +
+0555 mode get the runner *selected and exec'd*, but a script runner
+can't complete the exec.
+
+Two ways forward:
+
+1. **Compiled launcher binary (recommended; the documented end state).**
+   A tiny per-language ELF at `/usr/lib/mvm/wrappers/runner` that
+   `execve`s `${python3}/bin/python3 /usr/lib/mvm/wrappers/oneshot.py`
+   (interpreter + script by absolute path — both on the verity RO rootfs,
+   so no TOCTOU). The launcher is ELF, so the agent's fd-exec works
+   unchanged. Build-system work: cross-compile aarch64-musl + bake (like
+   the guest agent). `mkFunctionService.nix:15-18` already names this.
+2. **Non-CLOEXEC exec fd in the agent.** Clear CLOEXEC on the dup in
+   `dup_above_fd3`/`spawn_path` so the fd survives the shebang re-exec and
+   the interpreter can reopen `/proc/self/fd/<n>`. One-line-ish, but it
+   changes ADR-007's hardened exec semantics (the validation fd leaks
+   into the runner + its children — harmless for a world-readable RO
+   wrapper, but a deliberate posture change that belongs in the ADR).
+
+Either way, more invoke layers may follow (wrapper.json module/function
+correctness, `import <module>` resolution against `working_dir`) — this
+is a multi-step bring-up like the boot path was. The `agent_invoke`
+example (`crates/mvm-cli/examples/agent_invoke.rs`) drives a real
+`RunEntrypoint` against an `up --flake` VM by name, so each layer can be
+validated without the template lifecycle.

--- a/specs/research/function-runner-nix-artifact-followup.md
+++ b/specs/research/function-runner-nix-artifact-followup.md
@@ -104,10 +104,16 @@ runnerScript =
 `mkGuest`'s `install -m 0755` lands it at exactly 0755 in the rootfs
 (`mk-guest.nix:558`), owned root by the rootfs build.
 
-**Mode reconciliation is a non-issue** (correcting the earlier draft):
-`install -m 0755` *sets* the mode regardless of the nix store's `555`,
-so the baked runner is 0755 and already matches the agent's
-`required_mode: 0o755`. No agent-policy change, no `0o555` relaxation.
+**Mode: the agent must require 0555.** The live trace showed the baked
+runner is `555`, not `755` (`runner has mode 555 (must be 755)`):
+mkGuest's rootfs hardening pass strips owner-write from baked files —
+`install -m 0755` does not survive it — and the agent binary itself is
+`555`. So set `EntrypointPolicy.required_mode = 0o555` (read-only is the
+*more* hardened mode) and declare the runner at `mode = "0555"` so the
+baked mode is honest rather than relying on the strip pass. (The original
+draft's `0o555` instinct was right; an intermediate "install -m forces
+0755, no relaxation needed" reasoning was wrong — it missed the strip
+pass, and the live trace caught it.)
 
 #### Node
 
@@ -139,8 +145,8 @@ entry, node two.
 ## Files to change
 
 - `crates/mvm-guest/src/entrypoint.rs` — `marker_path` →
-  `/etc/mvm/runner`; update `test_production_policy_constants` and the
-  module doc-comment. `required_mode` stays `0o755`.
+  `/etc/mvm/runner`; `required_mode` → `0o555`; update the mode-sensitive
+  unit tests and the module doc-comment.
 - `crates/mvm-guest/src/bin/mvm-guest-agent.rs`,
   `crates/mvm-guest/src/vsock.rs` — comments naming `/etc/mvm/entrypoint`
   as the marker → `/etc/mvm/runner`.

--- a/specs/research/function-runner-nix-artifact-followup.md
+++ b/specs/research/function-runner-nix-artifact-followup.md
@@ -169,7 +169,46 @@ entry, node two.
 - Boot→ping (Task 4) still green — `/etc/mvm/entrypoint` is untouched,
   so PID 1 still idles.
 
-## The runner MUST be a binary, not a shebang script (fexecve finding)
+## Invoke bring-up status (live, 2026-06-03)
+
+Function `invoke` had never run E2E. Driving real `RunEntrypoint`s (via
+the `agent_invoke` example) against an `up --flake` VM, each fix peeled
+the next layer:
+
+1. ✅ **Marker decouple** — `/etc/mvm/runner`; agent finds the runner.
+2. ✅ **Mode 0555** — agent accepts it.
+3. ✅ **Shebang** — `#!${python3}`; nix interpreter launches.
+4. ✅ **CLOEXEC drop** (chosen over the compiled launcher; §below) — the
+   script runner now execs; python runs `oneshot.py`.
+5. ⛔ **SDK import (current frontier).** `oneshot.py` imports the user
+   module (`app`), whose top-level `import mvm` fails:
+   `ModuleNotFoundError: No module named 'mvm'`. The mvm Python SDK isn't
+   in the function rootfs.
+
+   **Good news that makes this the likely-last layer:** the SDK has zero
+   runtime deps (`pyproject` `dependencies = []`) and every module
+   `import mvm` pulls (`_dsl`/`_ir`/`_remote`/`_session`/`_sandbox`/
+   `_runtime`) is stdlib-only — so it imports cleanly under the bare
+   `python3` already in the rootfs. And `@mvm.app(...)` returns `fn`
+   unchanged (`_dsl.py:288`), so `getattr(module, "greet")` is the plain
+   function → `greet("ari")` → `"hello ari"`.
+
+   **Remaining work — bake the SDK into the function rootfs.** Design
+   choice (not yet made):
+   - **System-path bake (cleanest):** the mvm flake exposes the SDK as a
+     pure-python package; the factory adds it to the rootfs python env /
+     a `PYTHONPATH` the wrapper honors. Needs the SDK source reachable
+     from `nix/` (it lives at `sdks/python`, outside the flake root).
+   - **Bundle into `/app`:** `compile` stages `sdks/python/mvm` into the
+     source bundle (`orchestrator.rs` `src/`). Faithful + simple, but
+     per-app copy and must survive the Plan-0007 reachability prune.
+   - **Runtime shim:** a tiny baked `mvm` exposing just the decorator API
+     as runtime no-ops. Smallest, but duplicates the SDK surface.
+
+   After this, watch for further layers: the decorator's `_ir`
+   construction at import time, and the encoded-return round-trip.
+
+## The runner MUST be a binary, or drop CLOEXEC (fexecve finding)
 
 Live `RunEntrypoint` (via the `agent_invoke` example) got the agent to
 exec the runner — then failed:

--- a/specs/runbooks/publish-sdks.md
+++ b/specs/runbooks/publish-sdks.md
@@ -17,21 +17,26 @@ commit that bumps the toolchain.
 These claim public names and configure credentials; they can't be
 automated from the repo.
 
-### 1. Names — already claimed by Tinylabs
+### 1. Names + orgs
 
-As of 2026-06-03 both projects exist and are owned by Tinylabs:
+- **PyPI: `mvm`** under the **`runmvm`** PyPI org. The project already
+  exists (latest `0.1.2`; history 0.1.0–0.1.2) — manage it from the
+  `runmvm` org. The distribution name stays `mvm` and the import stays
+  `import mvm` (PyPI orgs don't scope names).
+- **npm: `@runmvm/mvm`** — a **scoped** package under the **`runmvm`**
+  npm org. This is a rename from the old unscoped `mvm-sdk` (latest
+  `0.1.2`), so `@runmvm/mvm` is a fresh package: the first publish
+  creates it under the org. TS import becomes `from "@runmvm/mvm"`.
+  Optionally retire the old name: `npm deprecate mvm-sdk "moved to
+  @runmvm/mvm"`.
 
-- PyPI **`mvm`** — latest `0.1.2` (history: 0.1.0, 0.1.1, 0.1.2).
-- npm **`mvm-sdk`** — latest `0.1.2`.
-
-So there's nothing to claim. Local is `0.14.0`, which is **not** on either
-registry, so publishing it is a clean bump (no duplicate-version
-rejection) that catches the registries up to the toolchain. Re-check
-anytime:
+Local is `0.14.0`, not on either registry, so the first publish is a
+clean bump (no duplicate-version rejection) that aligns the registries
+with the toolchain. Re-check anytime:
 
 ```sh
 curl -s https://pypi.org/pypi/mvm/json | python3 -c 'import sys,json;print(json.load(sys.stdin)["info"]["version"])'
-curl -s https://registry.npmjs.org/mvm-sdk | python3 -c 'import sys,json;print(json.load(sys.stdin)["dist-tags"]["latest"])'
+curl -s https://registry.npmjs.org/@runmvm/mvm | python3 -c 'import sys,json;print(json.load(sys.stdin).get("dist-tags",{}).get("latest","(unpublished)"))'
 ```
 
 ### 2. PyPI — Trusted Publishing (no token)
@@ -51,11 +56,17 @@ you want required reviewers gating publishes. If you'd rather not use
 trusted publishing, drop a `PYPI_API_TOKEN` secret and swap the publish
 step to `with: { password: ${{ secrets.PYPI_API_TOKEN }} }`.
 
-### 3. npm — automation token
+### 3. npm — org + automation token
 
-- Create the package owner/org and a **granular automation token** with
-  publish rights on `mvm-sdk` (npm → Access Tokens → Granular).
+- Ensure the **`runmvm`** npm org exists and your account is a member
+  with publish rights.
+- Create a **granular automation token** scoped to publish under
+  `@runmvm/*` (npm → Access Tokens → Granular → Packages and scopes →
+  `@runmvm`).
 - Add it as repo secret **`NPM_TOKEN`** (Settings → Secrets → Actions).
+- The package is scoped, so the publish must be public — the workflow
+  passes `--access public` and `package.json` sets
+  `publishConfig.access = public`.
 
 ## Rehearse (safe, no upload)
 
@@ -85,7 +96,7 @@ together at one version:
 3. Verify:
    ```sh
    pip index versions mvm        # or: pip install mvm==0.15.0
-   npm view mvm-sdk version
+   npm view @runmvm/mvm version
    ```
 
 ## Notes

--- a/specs/runbooks/publish-sdks.md
+++ b/specs/runbooks/publish-sdks.md
@@ -17,32 +17,39 @@ commit that bumps the toolchain.
 These claim public names and configure credentials; they can't be
 automated from the repo.
 
-### 1. Confirm the names are available / yours
+### 1. Names — already claimed by Tinylabs
+
+As of 2026-06-03 both projects exist and are owned by Tinylabs:
+
+- PyPI **`mvm`** — latest `0.1.2` (history: 0.1.0, 0.1.1, 0.1.2).
+- npm **`mvm-sdk`** — latest `0.1.2`.
+
+So there's nothing to claim. Local is `0.14.0`, which is **not** on either
+registry, so publishing it is a clean bump (no duplicate-version
+rejection) that catches the registries up to the toolchain. Re-check
+anytime:
 
 ```sh
-curl -s -o /dev/null -w '%{http_code}\n' https://pypi.org/pypi/mvm/json        # 404 = available
-curl -s -o /dev/null -w '%{http_code}\n' https://registry.npmjs.org/mvm-sdk    # 404 = available
+curl -s https://pypi.org/pypi/mvm/json | python3 -c 'import sys,json;print(json.load(sys.stdin)["info"]["version"])'
+curl -s https://registry.npmjs.org/mvm-sdk | python3 -c 'import sys,json;print(json.load(sys.stdin)["dist-tags"]["latest"])'
 ```
-
-If `mvm` is taken on PyPI, rename the project in `sdks/python/pyproject.toml`
-(e.g. `mvm-sdk` to match npm) and update `[tool.hatch.build.targets.wheel]
-packages` only if the import package name changes (it should stay `mvm`).
 
 ### 2. PyPI — Trusted Publishing (no token)
 
-On PyPI → your account → **Publishing** → **Add a pending publisher**:
+The `mvm` project already exists, so add a **regular** trusted publisher
+to it: PyPI → project `mvm` → **Manage** → **Publishing** → **Add a new
+publisher** (GitHub):
 
-- PyPI Project Name: `mvm`
 - Owner: `tinylabscom`
 - Repository: `mvm`
 - Workflow name: `publish-pypi.yml`
 - Environment: `pypi`
 
-(A "pending publisher" lets the very first run create the project under
-OIDC — no API token ever stored. After the first publish it becomes a
-normal trusted publisher.) Also create a repo **Environment** named
-`pypi` (Settings → Environments) if you want required reviewers on
-publishes.
+(No API token is stored — the workflow authenticates via OIDC.) Also
+create a repo **Environment** named `pypi` (Settings → Environments) if
+you want required reviewers gating publishes. If you'd rather not use
+trusted publishing, drop a `PYPI_API_TOKEN` secret and swap the publish
+step to `with: { password: ${{ secrets.PYPI_API_TOKEN }} }`.
 
 ### 3. npm — automation token
 

--- a/specs/runbooks/publish-sdks.md
+++ b/specs/runbooks/publish-sdks.md
@@ -1,0 +1,93 @@
+# Runbook: publishing the mvm SDKs (PyPI + npm)
+
+Publishes the Python SDK (`sdks/python`, package **`mvm`**) and the
+TypeScript SDK (`sdks/typescript`, package **`mvm-sdk`**) to PyPI and
+npm. Driven by `.github/workflows/publish-pypi.yml` and
+`publish-npm.yml`, alongside the existing `publish-crates.yml`.
+
+**Why these ship coupled to the toolchain:** the SDK emits the Workload
+IR that the *same-version* `mvmctl` consumes (`launch.json`
+`toolchain_version` == mvmctl `CARGO_PKG_VERSION`). Both workflows refuse
+to publish unless the SDK version equals the release tag, so a published
+SDK can never drift from the toolchain. Bump the SDK versions in the same
+commit that bumps the toolchain.
+
+## One-time setup (manual — outward-facing, do these first)
+
+These claim public names and configure credentials; they can't be
+automated from the repo.
+
+### 1. Confirm the names are available / yours
+
+```sh
+curl -s -o /dev/null -w '%{http_code}\n' https://pypi.org/pypi/mvm/json        # 404 = available
+curl -s -o /dev/null -w '%{http_code}\n' https://registry.npmjs.org/mvm-sdk    # 404 = available
+```
+
+If `mvm` is taken on PyPI, rename the project in `sdks/python/pyproject.toml`
+(e.g. `mvm-sdk` to match npm) and update `[tool.hatch.build.targets.wheel]
+packages` only if the import package name changes (it should stay `mvm`).
+
+### 2. PyPI — Trusted Publishing (no token)
+
+On PyPI → your account → **Publishing** → **Add a pending publisher**:
+
+- PyPI Project Name: `mvm`
+- Owner: `tinylabscom`
+- Repository: `mvm`
+- Workflow name: `publish-pypi.yml`
+- Environment: `pypi`
+
+(A "pending publisher" lets the very first run create the project under
+OIDC — no API token ever stored. After the first publish it becomes a
+normal trusted publisher.) Also create a repo **Environment** named
+`pypi` (Settings → Environments) if you want required reviewers on
+publishes.
+
+### 3. npm — automation token
+
+- Create the package owner/org and a **granular automation token** with
+  publish rights on `mvm-sdk` (npm → Access Tokens → Granular).
+- Add it as repo secret **`NPM_TOKEN`** (Settings → Secrets → Actions).
+
+## Rehearse (safe, no upload)
+
+Run each workflow via **Actions → Run workflow** with `dry_run: true`:
+
+- PyPI: builds sdist+wheel, runs the version guard, **skips upload**.
+- npm: `npm ci && npm run build && npm publish --dry-run` (no upload).
+
+Fix anything that fails here before a real release.
+
+## Publish (real)
+
+Publishing is tied to a GitHub Release so crates + PyPI + npm go out
+together at one version:
+
+1. Bump versions in the **same commit**:
+   - `sdks/python/pyproject.toml` `version`
+   - `sdks/typescript/package.json` `version`
+   - the workspace/toolchain version (`Cargo.toml`) — keep all three equal.
+2. Tag + release:
+   ```sh
+   gh release create v0.15.0 --generate-notes
+   ```
+   The `release: published` event fans out to `publish-crates.yml`,
+   `publish-pypi.yml`, and `publish-npm.yml`. Each asserts its package
+   version equals `0.15.0` and refuses otherwise.
+3. Verify:
+   ```sh
+   pip index versions mvm        # or: pip install mvm==0.15.0
+   npm view mvm-sdk version
+   ```
+
+## Notes
+
+- Both packages are pure (Python: zero runtime deps, hatchling; TS: tsc →
+  `dist`), so there's nothing platform-specific to matrix.
+- The SDKs are **host authoring tools** — they are never installed into a
+  workload guest (the `@mvm.app` decorator is stripped from the bundled
+  source at compile, see `crates/mvm-sdk/src/compile/strip_framework.rs`).
+- For contributors working from a source checkout, prefer the editable
+  install over the published package so the SDK always matches local
+  HEAD (see the development guide).

--- a/tests/factory_shape.nix
+++ b/tests/factory_shape.nix
@@ -47,7 +47,7 @@ let
       ok =
         out ? extraFiles
         && lib.isAttrs out.extraFiles
-        && (out.extraFiles ? "/etc/mvm/entrypoint")
+        && (out.extraFiles ? "/etc/mvm/runner")
         && (out.extraFiles ? "/usr/lib/mvm/wrappers/runner")
         && out ? servicePackages
         && lib.isList out.servicePackages


### PR DESCRIPTION
## The bug (Plan 120 Task 4 blocker)

The libkrun core demo's `up → vsock Ping` step intermittently failed with `Guest agent not reachable`. Root-caused (via `MVM_KRUN_LOG=trace`) to the **workload's PID 1 exiting at ~5s** → kernel reboot (`reboot: Failed to start orderly reboot`):

```
/init: /etc/mvm/entrypoint: line 1: /usr/lib/mvm/wrappers/runner: not found
mvm: /etc/mvm/entrypoint returned without exec — kernel will panic
```

A **function** workload's PID 1 is supposed to be the *idle* bootScript (`exec sleep infinity`) that the compile path passes via mkGuest `entrypoint.command` (`crates/mvm-sdk/src/compile/flake.rs:140`); the **agent** then execs the runner *per call* over vsock `RunEntrypoint`. But `mkFunctionService` *also* wrote `/etc/mvm/entrypoint = /usr/lib/mvm/wrappers/runner` in its `extraFiles`, and that override won — so PID 1 became the one-shot runner, whose `#!/usr/bin/env python3` shebang doesn't resolve in the busybox rootfs (no `/usr/bin/env`). `/init` fell through to `sleep 5` and the kernel rebooted at ~5s.

The "flakiness" was a **race**: the agent forks into the background (mk-guest.nix) and answers `Ping` during the ~5s window before reboot — so the demo "passed" only when the host pinged in first.

## The fix

Drop the `/etc/mvm/entrypoint` entry from `mkFunctionService.nix` `extraFiles`. The idle bootScript stands as PID 1 → the VM stays up → the agent answers `Ping` reliably. The runner stays at `/usr/lib/mvm/wrappers/runner` for the agent to exec per call.

Verified by code analysis: `funcBootScript` = `buildPreStart` (mkdir+ln, safe) → `/etc/mvm/hooks/before_start.sh` (baked 0755, `set -eu; export FOO=1`, exits 0) → `exec sleep infinity`.

## Validation status

Live end-to-end validation (`dev up → compile → up → agent_ping at t=20s`) was **blocked by a concurrent session holding the shared builder-store flock** (`nix-store-aarch64.img` already attached) — environmental, not the fix. The Plan 120 owner can do the final live boot→ping confirmation on a quiet host.

## Follow-up (separate, for `mvmctl invoke`)

`specs/research/function-runner-nix-artifact-followup.md` — the runner is still inlined verbatim, so its shebang/mode break actual function invocation. Make it a per-language nix-built artifact (Python `writePython3`, Node `makeWrapper`), install via `source=` (preserves nix's 555 mode), and relax the agent's `required_mode` `0o755`→`0o555`. This PR fixes boot→ping (Task 4); the follow-up fixes `invoke`.