### PR TITLE
chore(release): bump 0.14.0 → 0.15.0 (v0.15.0)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,32 @@ uses [SemVer](https://semver.org/) once it reaches 1.0.
 
 ## [Unreleased]
 
+## [0.15.0] — 2026-06-03
+
 ### Added
+
+- **Architecture-aware artifact model (Plan 134).** `GuestArch`/
+  `KernelFormat` in `mvm-core`; `MicrovmBackend` + data-driven
+  `BackendCompat` matrix + the `artifacts` module in `mvm-backend`;
+  `NixMicrovmBuilder` adapter; static `ArtifactValidator` +
+  `FirecrackerConfigWriter`; `mvmctl artifact model-inspect|
+  model-validate|model-config|model-build`.
+- **`mvmctl invoke` works end-to-end** (function workloads return their
+  encoded result over vsock `RunEntrypoint`). The build-time `@mvm.app`
+  decorator is stripped from the bundled source at compile time, so the
+  guest never imports the SDK.
+- **SDK publish workflows** — PyPI (`mvm`) + npm (`@runmvm/mvm`),
+  release-triggered with a version==tag guard.
+- **Stage 0 builder-VM nix-store persistence** across `dev up` runs.
+
+### Fixed
+
+- **Function-workload boot** is genuinely stable: PID 1 (the idle
+  bootScript at `/etc/mvm/boot`) no longer aborts on a bare `mkdir`, so
+  the VM stays up instead of rebooting at ~5s (previously boot→ping only
+  "passed" via the agent answering inside that window).
+- OCI→ext4 materialization is byte-deterministic on e2fsprogs ≥1.47
+  (`-O ^orphan_file`), restoring the ADR-050 verity-cache invariant.
 
 - **Plan 63 Phase 2 — encryption everywhere.** Closed in six
   workstreams (commits `b9e4e64`, `1ea9352`, `f7e39a7`, `a30f866`,
@@ -218,5 +243,6 @@ has a tracking pointer; none is silently broken.
   See [`MIGRATING-FROM-V1.md`](MIGRATING-FROM-V1.md) §"Feature parity
   status" for the per-feature delta.
 
-[Unreleased]: https://github.com/tinylabscom/mvm/compare/v0.14.0...HEAD
+[Unreleased]: https://github.com/tinylabscom/mvm/compare/v0.15.0...HEAD
+[0.15.0]: https://github.com/tinylabscom/mvm/compare/v0.14.0...v0.15.0
 [0.14.0]: https://github.com/tinylabscom/mvm/releases/tag/v0.14.0

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3234,7 +3234,7 @@ checksum = "1d87ecb2933e8aeadb3e3a02b828fed80a7528047e68b4f424523a0981a3a084"
 
 [[package]]
 name = "mvm"
-version = "0.14.0"
+version = "0.15.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3268,7 +3268,7 @@ dependencies = [
 
 [[package]]
 name = "mvm-addon-dns"
-version = "0.14.0"
+version = "0.15.0"
 dependencies = [
  "anyhow",
  "hickory-proto 0.26.1",
@@ -3283,7 +3283,7 @@ dependencies = [
 
 [[package]]
 name = "mvm-addon-vsock-bridge"
-version = "0.14.0"
+version = "0.15.0"
 dependencies = [
  "anyhow",
  "libc",
@@ -3298,7 +3298,7 @@ dependencies = [
 
 [[package]]
 name = "mvm-audit-signer"
-version = "0.14.0"
+version = "0.15.0"
 dependencies = [
  "anyhow",
  "base64 0.22.1",
@@ -3319,7 +3319,7 @@ dependencies = [
 
 [[package]]
 name = "mvm-backend"
-version = "0.14.0"
+version = "0.15.0"
 dependencies = [
  "anyhow",
  "ext4-view",
@@ -3345,7 +3345,7 @@ dependencies = [
 
 [[package]]
 name = "mvm-base"
-version = "0.14.0"
+version = "0.15.0"
 dependencies = [
  "anyhow",
  "colored",
@@ -3366,7 +3366,7 @@ dependencies = [
 
 [[package]]
 name = "mvm-broker"
-version = "0.14.0"
+version = "0.15.0"
 dependencies = [
  "anyhow",
  "mvm-core",
@@ -3381,7 +3381,7 @@ dependencies = [
 
 [[package]]
 name = "mvm-build"
-version = "0.14.0"
+version = "0.15.0"
 dependencies = [
  "anyhow",
  "chrono",
@@ -3413,7 +3413,7 @@ dependencies = [
 
 [[package]]
 name = "mvm-cli"
-version = "0.14.0"
+version = "0.15.0"
 dependencies = [
  "anyhow",
  "assert_cmd",
@@ -3467,7 +3467,7 @@ dependencies = [
 
 [[package]]
 name = "mvm-core"
-version = "0.14.0"
+version = "0.15.0"
 dependencies = [
  "anyhow",
  "base64 0.22.1",
@@ -3492,7 +3492,7 @@ dependencies = [
 
 [[package]]
 name = "mvm-egress-proxy"
-version = "0.14.0"
+version = "0.15.0"
 dependencies = [
  "libc",
  "tempfile",
@@ -3500,7 +3500,7 @@ dependencies = [
 
 [[package]]
 name = "mvm-firecracker-bridge"
-version = "0.14.0"
+version = "0.15.0"
 dependencies = [
  "anyhow",
  "ed25519-dalek",
@@ -3519,7 +3519,7 @@ dependencies = [
 
 [[package]]
 name = "mvm-guest"
-version = "0.14.0"
+version = "0.15.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3544,7 +3544,7 @@ dependencies = [
 
 [[package]]
 name = "mvm-host-signer"
-version = "0.14.0"
+version = "0.15.0"
 dependencies = [
  "anyhow",
  "ed25519-dalek",
@@ -3562,7 +3562,7 @@ dependencies = [
 
 [[package]]
 name = "mvm-host-vm-init"
-version = "0.14.0"
+version = "0.15.0"
 dependencies = [
  "libc",
  "mvm-build",
@@ -3574,7 +3574,7 @@ dependencies = [
 
 [[package]]
 name = "mvm-ir"
-version = "0.14.0"
+version = "0.15.0"
 dependencies = [
  "mvm-guest",
  "schemars 0.8.22",
@@ -3585,7 +3585,7 @@ dependencies = [
 
 [[package]]
 name = "mvm-jailer-lite"
-version = "0.14.0"
+version = "0.15.0"
 dependencies = [
  "ctor",
  "landlock",
@@ -3597,7 +3597,7 @@ dependencies = [
 
 [[package]]
 name = "mvm-libkrun"
-version = "0.14.0"
+version = "0.15.0"
 dependencies = [
  "bindgen",
  "libc",
@@ -3613,7 +3613,7 @@ dependencies = [
 
 [[package]]
 name = "mvm-libkrun-supervisor"
-version = "0.14.0"
+version = "0.15.0"
 dependencies = [
  "anyhow",
  "ed25519-dalek",
@@ -3628,7 +3628,7 @@ dependencies = [
 
 [[package]]
 name = "mvm-mcp"
-version = "0.14.0"
+version = "0.15.0"
 dependencies = [
  "anyhow",
  "serde",
@@ -3639,7 +3639,7 @@ dependencies = [
 
 [[package]]
 name = "mvm-oci"
-version = "0.14.0"
+version = "0.15.0"
 dependencies = [
  "async-trait",
  "hex",
@@ -3661,7 +3661,7 @@ dependencies = [
 
 [[package]]
 name = "mvm-plan"
-version = "0.14.0"
+version = "0.15.0"
 dependencies = [
  "anyhow",
  "base64 0.22.1",
@@ -3679,7 +3679,7 @@ dependencies = [
 
 [[package]]
 name = "mvm-policy"
-version = "0.14.0"
+version = "0.15.0"
 dependencies = [
  "chrono",
  "ed25519-dalek",
@@ -3695,7 +3695,7 @@ dependencies = [
 
 [[package]]
 name = "mvm-providers"
-version = "0.14.0"
+version = "0.15.0"
 dependencies = [
  "block2",
  "dispatch2",
@@ -3709,7 +3709,7 @@ dependencies = [
 
 [[package]]
 name = "mvm-runner"
-version = "0.14.0"
+version = "0.15.0"
 dependencies = [
  "libc",
  "serde",
@@ -3719,7 +3719,7 @@ dependencies = [
 
 [[package]]
 name = "mvm-sdk"
-version = "0.14.0"
+version = "0.15.0"
 dependencies = [
  "base64 0.22.1",
  "flate2",
@@ -3744,11 +3744,11 @@ dependencies = [
 
 [[package]]
 name = "mvm-sdk-macros"
-version = "0.14.0"
+version = "0.15.0"
 
 [[package]]
 name = "mvm-security"
-version = "0.14.0"
+version = "0.15.0"
 dependencies = [
  "aes-gcm",
  "aho-corasick",
@@ -3774,7 +3774,7 @@ dependencies = [
 
 [[package]]
 name = "mvm-storage"
-version = "0.14.0"
+version = "0.15.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3790,7 +3790,7 @@ dependencies = [
 
 [[package]]
 name = "mvm-supervisor"
-version = "0.14.0"
+version = "0.15.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3826,7 +3826,7 @@ dependencies = [
 
 [[package]]
 name = "mvm-vz"
-version = "0.14.0"
+version = "0.15.0"
 dependencies = [
  "serde",
  "serde_json",
@@ -3834,7 +3834,7 @@ dependencies = [
 
 [[package]]
 name = "mvm-vz-drainer"
-version = "0.14.0"
+version = "0.15.0"
 dependencies = [
  "anyhow",
  "ed25519-dalek",
@@ -3849,7 +3849,7 @@ dependencies = [
 
 [[package]]
 name = "mvmctl"
-version = "0.14.0"
+version = "0.15.0"
 dependencies = [
  "anyhow",
  "assert_cmd",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -131,7 +131,7 @@ resolver = "3"
 # functionally different software. Bumping the minor signals "0.x
 # breaking changes" without prematurely committing to a 1.0 stability
 # promise.
-version = "0.14.0"
+version = "0.15.0"
 edition = "2024"
 rust-version = "1.85"
 license = "Apache-2.0"
@@ -297,56 +297,56 @@ tree-sitter-typescript = "0.23.2"
 # here because member crates can't override that on a workspace-inherited
 # dependency unless the workspace entry already carries it. The root binary
 # opts back into user-facing defaults through its own `[features]` block.
-mvm-core = { path = "crates/mvm-core", version = "0.14.0" }
-mvm-guest = { path = "crates/mvm-guest", version = "0.14.0" }
-mvm-build = { path = "crates/mvm-build", version = "0.14.0", default-features = false }
-mvm = { path = "crates/mvm", version = "0.14.0", default-features = false }
-mvm-base = { path = "crates/mvm-base", version = "0.14.0" }
-mvm-oci = { path = "crates/mvm-oci", version = "0.14.0" }
-mvm-security = { path = "crates/mvm-security", version = "0.14.0" }
-mvm-storage = { path = "crates/mvm-storage", version = "0.14.0" }
-mvm-plan = { path = "crates/mvm-plan", version = "0.14.0" }
-mvm-policy = { path = "crates/mvm-policy", version = "0.14.0" }
-mvm-supervisor = { path = "crates/mvm-supervisor", version = "0.14.0" }
-mvm-cli = { path = "crates/mvm-cli", version = "0.14.0", default-features = false }
+mvm-core = { path = "crates/mvm-core", version = "0.15.0" }
+mvm-guest = { path = "crates/mvm-guest", version = "0.15.0" }
+mvm-build = { path = "crates/mvm-build", version = "0.15.0", default-features = false }
+mvm = { path = "crates/mvm", version = "0.15.0", default-features = false }
+mvm-base = { path = "crates/mvm-base", version = "0.15.0" }
+mvm-oci = { path = "crates/mvm-oci", version = "0.15.0" }
+mvm-security = { path = "crates/mvm-security", version = "0.15.0" }
+mvm-storage = { path = "crates/mvm-storage", version = "0.15.0" }
+mvm-plan = { path = "crates/mvm-plan", version = "0.15.0" }
+mvm-policy = { path = "crates/mvm-policy", version = "0.15.0" }
+mvm-supervisor = { path = "crates/mvm-supervisor", version = "0.15.0" }
+mvm-cli = { path = "crates/mvm-cli", version = "0.15.0", default-features = false }
 
 # plan 60 Phase 5 — build-time SDK port from ../mvmforge.
-mvm-ir = { path = "crates/mvm-ir", version = "0.14.0" }
-mvm-sdk = { path = "crates/mvm-sdk", version = "0.14.0" }
-mvm-sdk-macros = { path = "crates/mvm-sdk-macros", version = "0.14.0" }
-mvm-mcp = { path = "crates/mvm-mcp", version = "0.14.0" }
-mvm-providers = { path = "crates/mvm-providers", version = "0.14.0" }
+mvm-ir = { path = "crates/mvm-ir", version = "0.15.0" }
+mvm-sdk = { path = "crates/mvm-sdk", version = "0.15.0" }
+mvm-sdk-macros = { path = "crates/mvm-sdk-macros", version = "0.15.0" }
+mvm-mcp = { path = "crates/mvm-mcp", version = "0.15.0" }
+mvm-providers = { path = "crates/mvm-providers", version = "0.15.0" }
 # Plan 57 W1 — libkrun FFI bindings split out of mvm-providers so the
 # bindgen + libclang build cost is isolated from the Apple-VZ objc2
 # stack. Default feature set is empty; consumers wanting real FFI
 # enable `libkrun-sys` on a host with libkrun installed.
-mvm-libkrun = { path = "crates/mvm-libkrun", version = "0.14.0" }
+mvm-libkrun = { path = "crates/mvm-libkrun", version = "0.15.0" }
 # Plan 97 Phase B — type-safe interface to `mvm-vz-supervisor`. No FFI,
 # Linux-safe (compiles everywhere; `Platform::has_vz()` short-circuits
 # on non-macOS).
-mvm-vz = { path = "crates/mvm-vz", version = "0.14.0" }
-mvm-backend = { path = "crates/mvm-backend", version = "0.14.0", default-features = false }
+mvm-vz = { path = "crates/mvm-vz", version = "0.15.0" }
+mvm-backend = { path = "crates/mvm-backend", version = "0.15.0", default-features = false }
 
 # Plan 73 Followup B.2.x — builder-VM egress allowlist proxy.
 # mvm-host-vm-init spawns this as a subprocess before the
 # installer + tears it down after.
-mvm-egress-proxy = { path = "crates/mvm-egress-proxy", version = "0.14.0" }
+mvm-egress-proxy = { path = "crates/mvm-egress-proxy", version = "0.15.0" }
 
 # Plan 113 / ADR-064 §Decision 5 — A2 confinement helper (seccompiler +
 # landlock). Consumed by the per-VM `mvm-firecracker-bridge` sidecar.
-mvm-jailer-lite = { path = "crates/mvm-jailer-lite", version = "0.14.0" }
+mvm-jailer-lite = { path = "crates/mvm-jailer-lite", version = "0.15.0" }
 
 # Plan 113 §Task 10 / ADR-064 — per-VM Vz drainer binary crate. Leaf
 # entry consumed by `mvm-backend::vz::start()` (Task 11) via fork+exec;
 # no other workspace member links it as a library.
-mvm-vz-drainer = { path = "crates/mvm-vz-drainer", version = "0.14.0" }
+mvm-vz-drainer = { path = "crates/mvm-vz-drainer", version = "0.15.0" }
 
 # Plan 113 §Task 12 / ADR-064 — per-VM Firecracker bridge sidecar binary
 # crate. Leaf entry resolved by Task 13's `FirecrackerBackend` at runtime
 # (fork+exec, never linked as a library). Linux-only at runtime; the
 # crate's `src/main.rs` cfg-gates the body so `cargo check --workspace`
 # stays green on macOS / Windows contributor hosts.
-mvm-firecracker-bridge = { path = "crates/mvm-firecracker-bridge", version = "0.14.0" }
+mvm-firecracker-bridge = { path = "crates/mvm-firecracker-bridge", version = "0.15.0" }
 
 # Dev dependencies
 assert_cmd = "2"

--- a/sdks/python/pyproject.toml
+++ b/sdks/python/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "mvm"
-version = "0.14.0"
+version = "0.15.0"
 description = "Declarative microVM workloads for Python — author once, emit a Nix flake, boot under mvm."
 readme = "README.md"
 requires-python = ">=3.10"

--- a/sdks/typescript/package-lock.json
+++ b/sdks/typescript/package-lock.json
@@ -1,12 +1,12 @@
 {
-  "name": "mvm-sdk",
-  "version": "0.14.0",
+  "name": "@runmvm/mvm",
+  "version": "0.15.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
-      "name": "mvm-sdk",
-      "version": "0.14.0",
+      "name": "@runmvm/mvm",
+      "version": "0.15.0",
       "license": "Apache-2.0",
       "devDependencies": {
         "@types/node": "22.7.5",

--- a/sdks/typescript/package.json
+++ b/sdks/typescript/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@runmvm/mvm",
-  "version": "0.14.0",
+  "version": "0.15.0",
   "publishConfig": {
     "access": "public"
   },

--- a/specs/runbooks/publish-sdks.md
+++ b/specs/runbooks/publish-sdks.md
@@ -30,7 +30,7 @@ automated from the repo.
   Optionally retire the old name: `npm deprecate mvm-sdk "moved to
   @runmvm/mvm"`.
 
-Local is `0.14.0`, not on either registry, so the first publish is a
+Local is `0.15.0`, not on either registry, so the first publish is a
 clean bump (no duplicate-version rejection) that aligns the registries
 with the toolchain. Re-check anytime:
 


### PR DESCRIPTION
Version bump for the **v0.15.0** release (the first since the v1→v2 cutover at 0.14.0).

## What
- Workspace version + internal dep pins → `0.15.0` (`Cargo.toml`), `Cargo.lock` regenerated.
- Python SDK `mvm` → `0.15.0` (`pyproject.toml`).
- TypeScript SDK `@runmvm/mvm` → `0.15.0` (`package.json` + `package-lock.json`).
- `CHANGELOG.md` `[0.15.0]` section; publish runbook updated.

`toolchain_version` follows automatically (`TOOLCHAIN_VERSION = env!("CARGO_PKG_VERSION")`; the `launch.json` test asserts against the const). The `mvm-vz`/`supervisor` `"0.14.0"` literals are test inputs, and the doc references to `0.14.0` are historical (the cutover version) — left intact.

## Release trigger (after this merges)
`gh release create v0.15.0` fires `release: published` → `publish-crates` + `publish-pypi` + `publish-npm`, each guarding `version == tag`. **Irreversible publish — held for explicit go.**