### PR TITLE
docs(sdks): refresh Python README + add TypeScript README

### DIFF
--- a/sdks/python/README.md
+++ b/sdks/python/README.md
@@ -1,16 +1,15 @@
 # mvm — Python SDK
 
-Declarative microVM workloads for Python. Decorate a function or describe a
-workload, and the `mvmforge` host CLI emits a Nix flake plus a launch plan
-that [`mvm`](https://gomicrovm.com/) can boot.
+Declare a microVM workload in Python. Write a function, decorate it, and the
+`mvmctl` toolchain bakes it into a Nix-built Firecracker / libkrun microVM
+image and boots it — no Dockerfile, no SSH, no agent code in your app.
 
 ```sh
 pip install mvm
 ```
 
-The host CLI (`mvmforge`, written in Rust) is distributed separately. The
-Python SDK ships only the authoring + runtime surfaces that the host
-subprocesses to.
+`mvmctl` (the Rust host CLI) is distributed separately and does the building,
+booting, and signing. This package is the **authoring** surface it reads.
 
 ## Quick start
 
@@ -18,43 +17,99 @@ subprocesses to.
 # app.py
 import mvm as mv
 
-@mv.func(
-    name="adder",
-    image=mv.nix_packages(["python312"]),
-    resources=mv.resources(cpu_cores=1, memory_mb=256, rootfs_size_mb=512),
-)
+@mv.func(name="adder")
 def add(a: int, b: int) -> int:
     return a + b
 ```
 
 ```sh
-mvmforge emit app.py        # canonical IR
-mvmforge compile app.py     # flake.nix + launch.json
-mvmforge up app.py          # boot under mvm (dev only)
+mvmctl compile app.py     # parse the script (no execution) → flake.nix + launch plan
+mvmctl up --flake .       # build the image and boot the microVM
 ```
 
-## Three surfaces
+`@mv.func` is the one-liner: it declares the workload, the app, and a function
+entrypoint with sane defaults (`nix_packages(["python312"])`, 1 vCPU / 256 MB /
+512 MB rootfs). For full control, declare the pieces explicitly:
 
-| Surface | Purpose |
+```python
+import mvm as mv
+
+mv.workload(id="hello")
+
+@mv.app(
+    name="hello",
+    source=mv.local_path("."),
+    image=mv.nix_packages(["python312"]),
+    resources=mv.resources(cpu_cores=1, memory_mb=256, rootfs_size_mb=512),
+    env={"API_KEY": mv.secret("api-key")},
+    before_start=mv.hook("export TZ=UTC"),
+    after_start=mv.hook(["curl", "-fsS", "http://localhost:8080/health"]),
+)
+def main(name: str) -> str:
+    return f"hello {name}"
+```
+
+## How it builds
+
+`mvmctl compile` reads your file **statically** — the decorator and the
+`import mvm` line are parsed as data, never executed, so nothing in your module
+runs on the host. At image-build time the decorator and the `import mvm` line
+are **stripped** from the bundled source, so the guest runs your plain function
+with no SDK dependency inside the microVM.
+
+You can also emit the canonical Workload IR in-process, for inspection or tests:
+
+```python
+import mvm as mv
+print(mv.emit_json())     # the IR mvmctl would produce
+```
+
+## Lifecycle hooks
+
+Four hook points, each a shell string or an argv list (or a list of them).
+Addons contribute their own hooks, merged at compile time:
+
+| Hook | Runs |
 | --- | --- |
-| **Authoring** | `@mv.app`, `@mv.func`, `mv.workload(...)`, factories for image / network / resources / deps. |
-| **Runtime** | `f.remote(...)` and `mv.session(...)` — host-side calls into a function-entrypoint VM. **Dev-only by design.** |
-| **Sandbox** | `mv.Sandbox`, `Process`, `FileEntry` — typed lifecycle handles over local mvm sandbox primitives. **Dev-only.** |
+| `before_build` | in the builder VM, before the image is assembled |
+| `before_start` | in the guest, before the entrypoint |
+| `after_start`  | in the guest, after the entrypoint is up |
+| `before_stop`  | in the guest, on shutdown |
 
-The runtime SDK exists to assist build-time emission and dev-time
-introspection. Production microVMs are observed via `mvmctl logs` and output
-streams; no host-side `.remote()` calls.
+## Building blocks
+
+| Helper | Purpose |
+| --- | --- |
+| `mv.nix_packages([...])`, `mv.python_image(...)`, `mv.node_image(...)` | base image |
+| `mv.resources(cpu_cores=, memory_mb=, rootfs_size_mb=)` | per-VM budget |
+| `mv.network(...)`, `mv.egress(...)` | egress policy (default-deny) |
+| `mv.python_deps(...)`, `mv.node_deps(...)` | dependencies, installed into a sealed, audited volume |
+| `mv.secret("name")`, `mv.literal("v")` | env values — secrets resolve on the host, never baked into the image |
+
+## Dev-only runtime
+
+`f.remote(...)` / `mv.session(...)` call into a running function-VM, and
+`mv.Sandbox` wraps local sandbox primitives. These are **development**
+conveniences for build-time emission and introspection. Production microVMs are
+observed through `mvmctl` output streams — there are no host-side `.remote()`
+calls on the prod path.
 
 ## Optional extras
 
 ```sh
-pip install 'mvm[schema]'   # pydantic-based schema auto-derivation
+pip install 'mvm[schema]'   # pydantic-based schema derivation from type hints
 ```
 
-## Documentation
+## Versioning
 
-Full documentation: https://mvmforge-docs.pages.dev/sdks/python/
+The SDK version tracks the `mvmctl` toolchain version: a workload emitted by
+`mvm` X.Y.Z is consumed by `mvmctl` X.Y.Z. Install matching versions.
+
+## Links
+
+- Source & issues: https://github.com/tinylabscom/mvm
+- TypeScript SDK: [`@runmvm/mvm`](https://www.npmjs.com/package/@runmvm/mvm)
 
 ## License
 
-Apache-2.0
+Apache-2.0 — see [LICENSE](./LICENSE).

--- a/sdks/typescript/README.md
+++ b/sdks/typescript/README.md
@@ -1,0 +1,98 @@
+# @runmvm/mvm — TypeScript SDK
+
+Declare a microVM workload in TypeScript. Describe an app, and the `mvmctl`
+toolchain bakes it into a Nix-built Firecracker / libkrun microVM image and
+boots it — no Dockerfile, no SSH, no agent code in your app.
+
+```sh
+npm install @runmvm/mvm
+```
+
+`mvmctl` (the Rust host CLI) is distributed separately and does the building,
+booting, and signing. This package is the **authoring** surface it reads.
+
+## Quick start
+
+```ts
+// app.ts
+import * as mvm from "@runmvm/mvm";
+
+mvm.workload({ id: "hello" });
+
+export const greet = mvm.app({
+  image: mvm.node_image({ node: "22" }),
+  resources: mvm.resources({ cpu: 1, memory_mb: 256 }),
+})((name: string): string => `hello ${name}`);
+```
+
+```sh
+mvmctl compile app.ts     # parse the file (no execution) → flake.nix + launch plan
+mvmctl up --flake .       # build the image and boot the microVM
+```
+
+`mvm.app({...})` is higher-order: it records the declaration and returns the
+function unchanged, so the same file runs normally under `tsx` / `node` and is
+also read statically by `mvmctl compile`.
+
+## How it builds
+
+`mvmctl compile` reads your file **statically** — the `mvm.app({...})` call and
+the `import` are parsed as data, never executed, so nothing in your module runs
+on the host. At image-build time the framework call and the `@runmvm/mvm` import
+are **stripped** from the bundled source, so the guest runs your plain function
+with no SDK dependency inside the microVM.
+
+You can also emit the canonical Workload IR in-process, for inspection or tests:
+
+```ts
+import * as mvm from "@runmvm/mvm";
+console.log(mvm.emitJson());   // the IR mvmctl would produce
+```
+
+## Lifecycle hooks
+
+Four hook points, each a shell string or an argv list, passed as kwargs to
+`mvm.app({...})`. Addons contribute their own hooks, merged at compile time:
+
+| Hook | Runs |
+| --- | --- |
+| `before_build` | in the builder VM, before the image is assembled |
+| `before_start` | in the guest, before the entrypoint |
+| `after_start`  | in the guest, after the entrypoint is up |
+| `before_stop`  | in the guest, on shutdown |
+
+```ts
+mvm.app({
+  image: mvm.node_image({ node: "22" }),
+  env: { API_KEY: mvm.secret("api-key") },
+  before_start: mvm.hook("export TZ=UTC"),
+  after_start: mvm.hook(["curl", "-fsS", "http://localhost:8080/health"]),
+})((name: string) => `hello ${name}`);
+```
+
+## Building blocks
+
+| Helper | Purpose |
+| --- | --- |
+| `mvm.nix_packages([...])`, `mvm.node_image({...})`, `mvm.python_image({...})` | base image |
+| `mvm.resources({ cpu, memory_mb, rootfs_size_mb })` | per-VM budget |
+| `mvm.network({ mode, ports })` | egress policy (default `none`) |
+| `mvm.secret("name")`, `mvm.literal("v")` | env values — secrets resolve on the host, never baked into the image |
+| `mvm.entrypoint({...})`, `mvm.entrypoint_function({...})` | explicit / multi-function entrypoints |
+
+The IR types (`Workload`, `App`, `Resources`, …) are re-exported, so
+`import { Workload } from "@runmvm/mvm"` works directly.
+
+## Versioning
+
+The SDK version tracks the `mvmctl` toolchain version: a workload emitted by
+`@runmvm/mvm` X.Y.Z is consumed by `mvmctl` X.Y.Z. Install matching versions.
+
+## Links
+
+- Source & issues: https://github.com/tinylabscom/mvm
+- Python SDK: [`mvm`](https://pypi.org/project/mvm/)
+
+## License
+
+Apache-2.0


### PR DESCRIPTION
Both SDK packages are now public (`mvm` on PyPI, `@runmvm/mvm` on npm), and the README is what each registry renders on the package page.

- **Python** (`sdks/python/README.md`): the old README referenced the deprecated `mvmforge` host CLI and dead docs URLs. Rewritten against the real surface — `mvmctl compile`/`up`, `@mv.func` / `@mv.app`, the four lifecycle hooks, the build-time decorator-strip, and the dev-only runtime caveat.
- **TypeScript** (`sdks/typescript/README.md`): **new** — mirrors the Python one for `@runmvm/mvm` (`mvm.workload` + `mvm.app({...})(fn)`, `node_image`/`python_image`, hooks, `emitJson()`).

Examples are checked against the actual exports and the real `mvmctl` verbs (`compile <entry>`, `up --flake`). npm/PyPI are immutable per published version, so these render starting from the **next** version bump.