### PR TITLE
ci(security): green the mechanically-fixable nightly lanes

### DIFF
--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -70,7 +70,7 @@ jobs:
         # Ignored advisories must mirror deny.toml's `[advisories].ignore`.
         # cargo-audit doesn't read deny.toml; CLI flags are the
         # discoverable way to keep the two tools in sync.
-        run: cargo audit --ignore RUSTSEC-2025-0057 --ignore RUSTSEC-2024-0384 --ignore RUSTSEC-2025-0119 --ignore RUSTSEC-2023-0071 --ignore RUSTSEC-2024-0370 --ignore RUSTSEC-2026-0009
+        run: cargo audit --ignore RUSTSEC-2025-0057 --ignore RUSTSEC-2024-0384 --ignore RUSTSEC-2025-0119 --ignore RUSTSEC-2023-0071 --ignore RUSTSEC-2024-0370 --ignore RUSTSEC-2026-0009 --ignore RUSTSEC-2025-0052 --ignore RUSTSEC-2024-0436
 
   # ── Lane 2: Production-agent symbol contract ─────────────────────
   # ADR-002 §W4.3 + ADR-007 §W5 — combined contract on the production
@@ -150,6 +150,10 @@ jobs:
 
       - name: Install Rust toolchain
         uses: dtolnay/rust-toolchain@nightly
+
+      # build.rs cross-compiles the embedded host-vm binaries (Plan 115 /
+      # ADR-065); without zig + cargo-zigbuild the mvmctl build panics.
+      - uses: ./.github/actions/install-zigbuild
 
       - name: Build A
         run: cargo build --release --locked --bin mvmctl --features template-registry-s3,dev-watch,custom-dns,manifest-verify
@@ -343,6 +347,10 @@ jobs:
       - name: Install Rust toolchain
         uses: dtolnay/rust-toolchain@nightly
 
+      # build.rs cross-compiles the embedded host-vm binaries (Plan 115 /
+      # ADR-065); without zig + cargo-zigbuild the mvmctl build panics.
+      - uses: ./.github/actions/install-zigbuild
+
       - name: Run hash-verify tests
         run: cargo test -p mvm-cli --lib hash_verify_tests
 
@@ -511,74 +519,17 @@ jobs:
             fi
             mv "$d/flake.lock.original" "$d/flake.lock"
             echo "::endgroup::"
+          # plan-89-baseline is an intentionally input-less throw-at-eval
+          # boot-timing fixture (see its flake.nix) — no inputs means no
+          # lockfile to keep in sync, so exclude it like template_scaffold.
           done < <(find . -name flake.nix \
             -not -path './target/*' \
             -not -path './.git/*' \
             -not -path './node_modules/*' \
             -not -path './*/resources/template_scaffold/*' \
-            -not -path './resources/template_scaffold/*')
+            -not -path './resources/template_scaffold/*' \
+            -not -path './tests/fixtures/plan-89-baseline/*')
           exit "$fail"
-
-  # ── Lane 8: Builder image reproducibility (plan 36 §Layer 0) ───────
-  # Build the new mvm-builder-prod sealed image twice and assert the
-  # outputs are byte-identical. Catches non-determinism (timestamps in
-  # compressed layers, embedded host paths, builder-host nonces) that
-  # would silently break the cosign-signed manifest's nix_store_hash
-  # field. Heavy (~10 min for the double build), so PR-skipped — runs
-  # on release-tag pushes, the nightly schedule, and workflow_dispatch
-  # only. The mvmctl binary's reproducibility lane (above) covers PR
-  # feedback for the cheap case.
-  builder-image-reproducibility:
-    name: Builder image reproducibility (plan 36 §Layer 0)
-    if: github.event_name != 'pull_request'
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v6
-
-      - name: Install Nix
-        uses: DeterminateSystems/nix-installer-action@main
-
-      - name: Build A
-        run: |
-          set -euo pipefail
-          nix build "./nix/images/builder#packages.x86_64-linux.builder" \
-            --no-link --print-out-paths > /tmp/path-a.txt
-          out=$(head -1 /tmp/path-a.txt)
-          # Hash the contents under stable relative names so the
-          # store path component (which encodes input-hash, not output)
-          # doesn't pollute the comparison.
-          ( cd "$out" && sha256sum rootfs.ext4 rootfs.verity rootfs.roothash vmlinux ) > /tmp/hash-a.txt
-          cat /tmp/hash-a.txt
-
-      - name: Build B (force rebuild)
-        run: |
-          set -euo pipefail
-          nix build "./nix/images/builder#packages.x86_64-linux.builder" \
-            --rebuild --no-link --print-out-paths > /tmp/path-b.txt
-          out=$(head -1 /tmp/path-b.txt)
-          ( cd "$out" && sha256sum rootfs.ext4 rootfs.verity rootfs.roothash vmlinux ) > /tmp/hash-b.txt
-          cat /tmp/hash-b.txt
-
-      - name: Compare hashes
-        run: |
-          set -euo pipefail
-          if ! diff -q /tmp/hash-a.txt /tmp/hash-b.txt > /dev/null; then
-            echo "::error::Builder image is non-deterministic — two clean builds produced different artifacts" >&2
-            echo "Plan 36 §Layer 0 requires the sealed builder image to reproduce byte-for-byte so the" >&2
-            echo "cosign-signed manifest's nix_store_hash and per-artifact sha256 fields are stable." >&2
-            echo >&2
-            echo "Build A:" >&2
-            cat /tmp/hash-a.txt >&2
-            echo >&2
-            echo "Build B:" >&2
-            cat /tmp/hash-b.txt >&2
-            echo >&2
-            echo "Diff:" >&2
-            diff -u /tmp/hash-a.txt /tmp/hash-b.txt >&2 || true
-            exit 1
-          fi
-          echo "ok: builder image reproduces byte-identically across two clean builds"
-          cat /tmp/hash-a.txt
 
   # ── Lane 9: Builder-VM image reproducibility (Plan 107 A2.5) ───────
   # Build the `nix/images/builder-vm` image twice and assert the four

--- a/deny.toml
+++ b/deny.toml
@@ -72,6 +72,15 @@ ignore = [
     # we don't expose that surface. Re-evaluate when time v0.4
     # ships with the bound.
     { id = "RUSTSEC-2026-0009", reason = "time stack-exhaustion DoS; transitive via sigstore→openidconnect→serde_with; no untrusted-time-string parsing surface in mvmctl; audited 2026-05-01" },
+    # `async-std` discontinued. DEV-DEPENDENCY ONLY: pulled via httpmock
+    # (test HTTP mock) → async-object-pool → async-std. Absent from every
+    # shipped artifact (mvmctl, guest agents, supervisors); no production
+    # surface. Follow-up: migrate httpmock → wiremock to drop it entirely.
+    { id = "RUSTSEC-2025-0052", reason = "async-std discontinued; DEV-ONLY via httpmock test mock; absent from all shipped artifacts; audited 2026-06-03" },
+    # `paste` unmaintained. Build-time proc-macro only — produces no
+    # runtime code in the shipped binary, same class as proc-macro-error
+    # above. No runtime/IO surface.
+    { id = "RUSTSEC-2024-0436", reason = "paste unmaintained; build-time proc-macro, no runtime surface; audited 2026-06-03" },
 ]
 
 # ── Licenses ──────────────────────────────────────────────────────


### PR DESCRIPTION
The nightly **Security** workflow has been red across ~6 independent root causes (push/PR CI is unaffected). This PR clears the cleanly-fixable subset and removes one obsolete lane. It deliberately does **not** force-green the lanes whose underlying content is genuinely missing — those are tracked below.

## Fixed
- **cargo-deny / cargo-audit** — two new *unmaintained* advisories triaged with dated rationale (kept `unmaintained = deny`):
  - `RUSTSEC-2025-0052` (async-std discontinued) — **dev-only** via `httpmock`, absent from every shipped artifact.
  - `RUSTSEC-2024-0436` (paste) — build-time proc-macro, no runtime surface.
  - Mirrored into the `cargo-audit --ignore` list per the in-file contract.
- **hash-verify + reproducibility** — adopt the existing `./.github/actions/install-zigbuild` composite action. `build.rs` has required zig + cargo-zigbuild since Plan 115 / ADR-065; `ci.yml` installs it everywhere, these lanes never did.
- **flake-locks-clean** — exclude `tests/fixtures/plan-89-baseline`, an intentionally input-less throw-at-eval fixture (no inputs ⇒ no lock to sync).

## Deleted (obsolete)
- **builder-image-reproducibility** — builds `nix/images/builder`, which **Plan 115 (#514) removed** when it consolidated to the single builder-vm image. `builder-vm-image-reproducibility` is its successor.

## ⚠️ Deliberately NOT touched — real work, needs decisions (not in this PR)
- **🔴 prod-agent symbol contract** calls `scripts/check-prod-agent-no-exec.sh`, which **never existed in git history**. `ci-full.yml` says this check now lives *only* in `security.yml`. **Net: claim 4 (no `do_exec`, W4.3) + ADR-007 W5 are currently enforced NOWHERE.** This must be *implemented*, not deleted — highest priority follow-up.
- **verified-boot + sealed-prod** build `nix/images/default-tenant`, a flake that never existed (known gap).
- **builder-vm-image-reproducibility** needs the ADR-065 `MVM_HOST_BIN_DIR` contract wired (build host bins + `--impure`); no working pattern to mirror, needs a real CI run to verify.

After this lands, the nightly goes from 10 red → 3 red, and the 3 remaining reds are *truthful* (they correctly signal missing enforcement) rather than noise.