### PR TITLE
chore(builder-vm-kernel): drop unused dm-verity/conntrack/ext2 from enables

### DIFF
--- a/nix/images/builder-vm/kernel/default.nix
+++ b/nix/images/builder-vm/kernel/default.nix
@@ -28,6 +28,18 @@
 #   would otherwise force `=m`). Everything we need is `=y`. The
 #   rootfs ships no `/lib/modules` tree; mkGuest's
 #   `copy_module_closure` is unused for the builder-VM rootfs.
+#
+# Why no dm-verity / netfilter conntrack:
+#   This is the *builder VM* kernel — a dev-tier image (ADR-002
+#   dev-vs-prod tiers). It boots `root=/dev/vda ro` with no roothash
+#   and never opens a dm-verity device; verified boot is a
+#   workload-kernel concern, and the `veritysetup` the builder ships
+#   only runs `format` (userspace Merkle hashing, no kernel `dm`
+#   target). The egress lockdown (mvm-host-vm-init `network.rs`) is an
+#   OUTPUT owner-match + default-DROP ruleset with no conntrack/state/
+#   mark match. So MD/BLK_DEV_DM/DM_VERITY and the netfilter conntrack
+#   symbols live in `disables`, not `enables`. Audited against
+#   crates/mvm-host-vm-init.
 
 { pkgs }:
 
@@ -48,12 +60,9 @@ let
     "PCI" "PCI_MSI"
 
     # filesystems
-    "BLOCK" "EXT4_FS" "EXT4_USE_FOR_EXT2" "OVERLAY_FS" "FUSE_FS"
+    "BLOCK" "EXT4_FS" "OVERLAY_FS" "FUSE_FS"
     "TMPFS" "TMPFS_POSIX_ACL" "TMPFS_XATTR"
     "DEVTMPFS" "DEVTMPFS_MOUNT" "PROC_FS" "SYSFS"
-
-    # dm-verity (Plan 25 W3 / Claim 3 — verified boot of the rootfs)
-    "MD" "BLK_DEV_DM" "DM_VERITY"
 
     # process basics
     "BINFMT_ELF" "BINFMT_SCRIPT" "FUTEX" "EPOLL" "SIGNALFD"
@@ -71,13 +80,13 @@ let
     # net core
     "NET" "INET" "PACKET" "UNIX" "TCP_CONG_CUBIC"
 
-    # iptables-legacy (egress lockdown, ADR-047 / Plan 73 B.2.y)
+    # iptables-legacy (egress lockdown, ADR-047 / Plan 73 B.2.y).
+    # Only the OUTPUT owner-match + default-DROP ruleset is used
+    # (mvm-host-vm-init `network.rs` install_egress_lockdown): no
+    # conntrack/state/mark match, so those symbols are in `disables`.
     "NETFILTER" "NETFILTER_ADVANCED" "NETFILTER_XTABLES"
-    "NF_CONNTRACK" "NF_DEFRAG_IPV4"
     "IP_NF_IPTABLES" "IP_NF_FILTER" "IP_NF_TARGET_REJECT"
     "NETFILTER_XT_MATCH_OWNER"
-    "NETFILTER_XT_MATCH_STATE" "NETFILTER_XT_MATCH_CONNTRACK"
-    "NETFILTER_XT_MARK"
 
     # NLS (kept minimal — UTF-8 + ASCII only)
     "NLS" "NLS_UTF8" "NLS_ASCII"
@@ -93,6 +102,18 @@ let
     "MODULES"        # everything built-in; no /lib/modules tree
     "MODULE_SIG"     # NOP without MODULES; explicit
     "IPV6"           # builder VM has no v6 path
+
+    # Confirmed-unused in the builder VM (audited against
+    # crates/mvm-host-vm-init). Listed here, not merely absent from
+    # `enables`, so `olddefconfig` actually drops them instead of
+    # leaving a defconfig default `=y`. See the header "Why no
+    # dm-verity / netfilter conntrack" note.
+    "MD" "BLK_DEV_DM" "DM_VERITY"   # no dm-verity device opened; format-only
+    "NF_CONNTRACK" "NF_DEFRAG_IPV4" # egress lockdown is owner-match +
+    "NETFILTER_XT_MATCH_STATE"      # default-DROP only — no conntrack/
+    "NETFILTER_XT_MATCH_CONNTRACK"  # state/mark match invoked
+    "NETFILTER_XT_MARK"
+    "EXT4_USE_FOR_EXT2"             # nothing mounts ext2/ext3; only ext4
 
     # Userspace-visible classes we don't need.
     "DRM" "SOUND" "USB" "WIRELESS" "BT" "FB"


### PR DESCRIPTION
## What

Slim the builder-VM kernel config (`nix/images/builder-vm/kernel/default.nix`)
by moving symbols nothing in the builder-VM runtime uses out of `enables` and
into `disables`. This extends Plan 95's empirical method (previously applied
only to the SoC `disables` clusters) to the `enables` list.

Removed (audited against `crates/mvm-host-vm-init`):

- **`MD` / `BLK_DEV_DM` / `DM_VERITY`** — the builder VM is a dev-tier image that
  boots `root=/dev/vda ro` with no roothash and never opens a dm-verity device.
  Verified boot is a *workload-kernel* concern; the builder only
  `veritysetup format`s sidecars (userspace Merkle hashing, no kernel `dm` target).
- **`NF_CONNTRACK` / `NF_DEFRAG_IPV4` / `NETFILTER_XT_MATCH_STATE` /
  `NETFILTER_XT_MATCH_CONNTRACK` / `NETFILTER_XT_MARK`** — the egress lockdown
  (`network.rs` `install_egress_lockdown`) is an OUTPUT owner-match + default-DROP
  ruleset with no conntrack/state/mark match. Kept `NETFILTER_XT_MATCH_OWNER`.
- **`EXT4_USE_FOR_EXT2`** — nothing mounts ext2/ext3; the only ext4 mount is `/dev/vdb`.

Symbols are moved to `disables` (not merely dropped from `enables`) so
`olddefconfig` actually turns them off instead of leaving a defconfig default `=y`.

## Why these are safe / kept

`VIRTIO_CONSOLE` (backs `console=hvc0`), `HW_RANDOM_VIRTIO` (early entropy/TLS),
`SECCOMP` (nix `filter-syscalls` + Firecracker), and all virtio/fs/namespace/cgroup
symbols are load-bearing and untouched. The change is orthogonal to KVM/virtio/vsock,
so it cannot regress microVM generation.

## Verification

- ✅ **Builds cleanly.** The builder-VM `nix build` produces a valid slim
  Linux 6.12.87 arm64 `Image` (`buildPhase completed`, `olddefconfig` accepted the
  moved `disables`), verified locally across multiple runs via the Vz/libkrun
  Stage-0 build path.
- ⏳ **Boot deferred to CI (Linux/Firecracker).** The slim builder-VM kernel is only
  booted by Firecracker (Linux) or Vz; on macOS, libkrun boots the libkrunfw-bundled
  kernel (the built `vmlinux` is unused there), and the Vz builder path is currently
  blocked by an unrelated bug — see #549. CI's Linux/Firecracker lane exercises the
  real boot + the egress lockdown where it matters at runtime.

## Related

- #549 — Vz builder VM "storage device attachment invalid" (separate, pre-existing;
  blocks local Vz boot verification on macOS).