### PR TITLE
chore(release): v0.16.0 version bump

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3044,7 +3044,7 @@ checksum = "6800badb6cb2082ffd7b6a67e6125bb39f18782f793520caee8cb8846be06112"
 
 [[package]]
 name = "libkrun-sys"
-version = "0.15.2"
+version = "0.16.0"
 dependencies = [
  "bindgen",
  "libc",
@@ -3250,7 +3250,7 @@ checksum = "1d87ecb2933e8aeadb3e3a02b828fed80a7528047e68b4f424523a0981a3a084"
 
 [[package]]
 name = "mvm"
-version = "0.15.2"
+version = "0.16.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3280,7 +3280,7 @@ dependencies = [
 
 [[package]]
 name = "mvm-backend"
-version = "0.15.2"
+version = "0.16.0"
 dependencies = [
  "anyhow",
  "block2",
@@ -3312,7 +3312,7 @@ dependencies = [
 
 [[package]]
 name = "mvm-build"
-version = "0.15.2"
+version = "0.16.0"
 dependencies = [
  "anyhow",
  "chrono",
@@ -3344,7 +3344,7 @@ dependencies = [
 
 [[package]]
 name = "mvm-cli"
-version = "0.15.2"
+version = "0.16.0"
 dependencies = [
  "anyhow",
  "assert_cmd",
@@ -3393,7 +3393,7 @@ dependencies = [
 
 [[package]]
 name = "mvm-core"
-version = "0.15.2"
+version = "0.16.0"
 dependencies = [
  "aes-gcm",
  "aho-corasick",
@@ -3425,7 +3425,7 @@ dependencies = [
 
 [[package]]
 name = "mvm-guest"
-version = "0.15.2"
+version = "0.16.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3449,7 +3449,7 @@ dependencies = [
 
 [[package]]
 name = "mvm-guest-helpers"
-version = "0.15.2"
+version = "0.16.0"
 dependencies = [
  "anyhow",
  "hickory-proto 0.26.1",
@@ -3465,7 +3465,7 @@ dependencies = [
 
 [[package]]
 name = "mvm-hostd"
-version = "0.15.2"
+version = "0.16.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3505,7 +3505,7 @@ dependencies = [
 
 [[package]]
 name = "mvm-mcp"
-version = "0.15.2"
+version = "0.16.0"
 dependencies = [
  "anyhow",
  "serde",
@@ -3516,7 +3516,7 @@ dependencies = [
 
 [[package]]
 name = "mvm-oci"
-version = "0.15.2"
+version = "0.16.0"
 dependencies = [
  "async-trait",
  "hex",
@@ -3538,7 +3538,7 @@ dependencies = [
 
 [[package]]
 name = "mvm-sdk"
-version = "0.15.2"
+version = "0.16.0"
 dependencies = [
  "base64 0.22.1",
  "flate2",
@@ -3563,11 +3563,11 @@ dependencies = [
 
 [[package]]
 name = "mvm-sdk-macros"
-version = "0.15.2"
+version = "0.16.0"
 
 [[package]]
 name = "mvm-storage"
-version = "0.15.2"
+version = "0.16.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3583,7 +3583,7 @@ dependencies = [
 
 [[package]]
 name = "mvm-verify"
-version = "0.15.2"
+version = "0.16.0"
 dependencies = [
  "base64 0.22.1",
  "ed25519-dalek",
@@ -3594,7 +3594,7 @@ dependencies = [
 
 [[package]]
 name = "mvm-vm-host"
-version = "0.15.2"
+version = "0.16.0"
 dependencies = [
  "anyhow",
  "ed25519-dalek",
@@ -3613,7 +3613,7 @@ dependencies = [
 
 [[package]]
 name = "mvmctl"
-version = "0.15.2"
+version = "0.16.0"
 dependencies = [
  "anyhow",
  "assert_cmd",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -124,7 +124,7 @@ resolver = "3"
 # functionally different software. Bumping the minor signals "0.x
 # breaking changes" without prematurely committing to a 1.0 stability
 # promise.
-version = "0.15.2"
+version = "0.16.0"
 edition = "2024"
 rust-version = "1.85"
 license = "Apache-2.0"
@@ -290,33 +290,33 @@ tree-sitter-typescript = "0.23.2"
 # here because member crates can't override that on a workspace-inherited
 # dependency unless the workspace entry already carries it. The root binary
 # opts back into user-facing defaults through its own `[features]` block.
-mvm-core = { path = "crates/mvm-core", version = "0.15.1" }
-mvm-guest = { path = "crates/mvm-guest", version = "0.15.1" }
-mvm-build = { path = "crates/mvm-build", version = "0.15.1", default-features = false }
-mvm = { path = "crates/mvm", version = "0.15.1", default-features = false }
-mvm-oci = { path = "crates/mvm-oci", version = "0.15.1" }
-mvm-storage = { path = "crates/mvm-storage", version = "0.15.1" }
-mvm-cli = { path = "crates/mvm-cli", version = "0.15.1", default-features = false }
-mvm-hostd = { path = "crates/mvm-hostd", version = "0.15.1" }
+mvm-core = { path = "crates/mvm-core", version = "0.16.0" }
+mvm-guest = { path = "crates/mvm-guest", version = "0.16.0" }
+mvm-build = { path = "crates/mvm-build", version = "0.16.0", default-features = false }
+mvm = { path = "crates/mvm", version = "0.16.0", default-features = false }
+mvm-oci = { path = "crates/mvm-oci", version = "0.16.0" }
+mvm-storage = { path = "crates/mvm-storage", version = "0.16.0" }
+mvm-cli = { path = "crates/mvm-cli", version = "0.16.0", default-features = false }
+mvm-hostd = { path = "crates/mvm-hostd", version = "0.16.0" }
 
 # plan 60 Phase 5 — build-time SDK port from ../mvmforge.
-mvm-sdk = { path = "crates/mvm-sdk", version = "0.15.1" }
-mvm-sdk-macros = { path = "crates/mvm-sdk-macros", version = "0.15.1" }
-mvm-mcp = { path = "crates/mvm-mcp", version = "0.15.1" }
+mvm-sdk = { path = "crates/mvm-sdk", version = "0.16.0" }
+mvm-sdk-macros = { path = "crates/mvm-sdk-macros", version = "0.16.0" }
+mvm-mcp = { path = "crates/mvm-mcp", version = "0.16.0" }
 # Plan 57 W1 — libkrun FFI bindings split out of mvm-providers so the
 # bindgen + libclang build cost is isolated from the Apple-VZ objc2
 # stack. Default feature set is empty; consumers wanting real FFI
 # enable `libkrun-sys` on a host with libkrun installed.
-libkrun-sys = { path = "crates/deps/libkrun-sys", version = "0.15.1" }
+libkrun-sys = { path = "crates/deps/libkrun-sys", version = "0.16.0" }
 # Plan 97 Phase B — type-safe interface to `mvm-vz-supervisor`. No FFI,
 # Linux-safe (compiles everywhere; `Platform::has_vz()` short-circuits
 # on non-macOS).
-mvm-backend = { path = "crates/mvm-backend", version = "0.15.1", default-features = false }
+mvm-backend = { path = "crates/mvm-backend", version = "0.16.0", default-features = false }
 
 # Plan 73 Followup B.2.x — builder-VM egress allowlist proxy.
 # mvm-host-vm-init spawns this as a subprocess before the
 # installer + tears it down after.
-mvm-egress-proxy = { path = "crates/mvm-egress-proxy", version = "0.15.1" }
+mvm-egress-proxy = { path = "crates/mvm-egress-proxy", version = "0.16.0" }
 
 # Plan 113 / ADR-064 §Decision 5 — A2 confinement helper (seccompiler +
 # landlock). Consumed by the per-VM `mvm-firecracker-bridge` sidecar.


### PR DESCRIPTION
Version bump for the **v0.16.0** release (the first working, asset-publishing release in a while). `git cliff --bumped-version` → v0.16.0 (minor, matching this round's feature additions).

## What's in 0.16.0 (since v0.15.2)
- Install/download experience: `install.sh`, Homebrew tap, kernel-download docs, `reference/releases.md`
- Release pipeline: decoupled (binary ships even if Nix images fail), pruned dead image jobs, security-lane repoint
- Bundled default microVM image (Plan 158, dual dev/prod)
- …plus everything else merged to main since v0.15.2

## Note
The Justfile's `mvm-*`-only version sed misses non-`mvm-` internal crates — this bump also moves the `mvm`, `mvm-sdk-macros`, `libkrun-sys` (vendored, `version.workspace = true`), and `mvm-egress-proxy` pins, which all inherit the workspace version. (Worth fixing the Justfile recipe separately.)

This PR is just the bump so Linux CI validates it; the `v0.16.0` **tag** (which triggers release.yml → crates.io publish + the Homebrew tap push) is the deliberate next step after this merges.