### PR TITLE
feat(network): Plan 123 Phase A foundation — mvm-network NetworkProvider seam

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3532,6 +3532,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "mvm-network"
+version = "0.16.0"
+dependencies = [
+ "mvm-core",
+ "mvm-sdk",
+ "serde_json",
+]
+
+[[package]]
 name = "mvm-oci"
 version = "0.16.0"
 dependencies = [

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,6 +2,11 @@
 members = [
     "crates/mvm-core",
     "crates/mvm-storage",
+    # plan 123 Phase A — NetworkProvider trait + provisioning/policy seam.
+    # Low seam crate: the TAP/bridge/gvproxy/passt impl stays in mvm-backend
+    # (where the in-VM shell lives) and the WireGuard/Tailscale mesh impl is
+    # mvmd's; both register against this trait.
+    "crates/mvm-network",
     "crates/deps/libkrun-sys",
     # Plan 102 W6.A.5 — leaf bin crate that links mvm-libkrun + mvm-
     # supervisor without closing the
@@ -305,6 +310,7 @@ mvm-build = { path = "crates/mvm-build", version = "0.16.0", default-features = 
 mvm = { path = "crates/mvm", version = "0.16.0", default-features = false }
 mvm-oci = { path = "crates/mvm-oci", version = "0.16.0" }
 mvm-storage = { path = "crates/mvm-storage", version = "0.16.0" }
+mvm-network = { path = "crates/mvm-network", version = "0.16.0" }
 mvm-cli = { path = "crates/mvm-cli", version = "0.16.0", default-features = false }
 mvm-hostd = { path = "crates/mvm-hostd", version = "0.16.0" }
 

--- a/crates/mvm-network/Cargo.toml
+++ b/crates/mvm-network/Cargo.toml
@@ -1,0 +1,21 @@
+[package]
+name = "mvm-network"
+version.workspace = true
+edition.workspace = true
+description = "NetworkProvider trait + provisioning/policy/registry seam for mvm (plan 123 Phase A). The TAP/bridge/gvproxy/passt impl lives in mvm-backend; the WireGuard/Tailscale mesh impl is mvmd's."
+license.workspace = true
+repository.workspace = true
+homepage.workspace = true
+authors.workspace = true
+
+[dependencies]
+mvm-core.workspace = true
+# IR `NetworkMode` the registry resolves (A5). Acyclic: mvm-sdk does not
+# depend on mvm-network; its only mvm-* normal dep is mvm-core.
+mvm-sdk.workspace = true
+
+[dev-dependencies]
+serde_json.workspace = true
+
+[lints]
+workspace = true

--- a/crates/mvm-network/src/lib.rs
+++ b/crates/mvm-network/src/lib.rs
@@ -1,0 +1,26 @@
+//! `NetworkProvider` — the provisioning + policy + teardown seam for one
+//! VM's network (plan 123 Phase A / ADR-064 / ADR-066).
+//!
+//! This crate is the **low seam**: it owns the trait and the policy/registry
+//! types, nothing that needs the in-VM shell. The concrete TAP / bridge /
+//! gvproxy / passt provider stays in `mvm-backend` (where `run_in_vm` and the
+//! `VmSlot` substrate live) and implements this trait; mvmd's WireGuard /
+//! Tailscale mesh provider implements it too. Both register against the
+//! [`registry::NetworkProviderRegistry`], so a `NetworkMode::Custom` mesh
+//! plugs in without a core edit.
+//!
+//! Ingress/egress default-deny (claim 10) is not re-implemented here — the
+//! seam reuses `mvm_core`'s `NetworkPolicy`, whose `Default` is the empty
+//! (deny-all) policy.
+//!
+//! What this crate does **not** yet own: the actual relocation of the
+//! firewall / L4 / L7 / packet-observer machinery out of `mvm-hostd` (those
+//! carry claims-10/12/13 witnesses and move under their own follow-ups), and
+//! the egress-proxy substitution/scan seams plan 129 hangs on. See plan 123
+//! Phase A tasks A1-step-2 / A3 / A4.
+
+pub mod provider;
+pub mod registry;
+
+pub use provider::{NetHandle, NetworkError, NetworkProvider, NetworkSpec};
+pub use registry::NetworkProviderRegistry;

--- a/crates/mvm-network/src/provider.rs
+++ b/crates/mvm-network/src/provider.rs
@@ -1,0 +1,88 @@
+//! The `NetworkProvider` trait and its supporting types.
+
+use mvm_core::policy::policies::NetworkPolicy;
+use mvm_core::protocol::vm_backend::VmId;
+
+/// Host-side description of the network to provision for a VM.
+///
+/// `policy` defaults to `NetworkPolicy::default()` — the empty L4 allow-list,
+/// which the supervisor's gate reads as **deny-all** (claim 10). Opening
+/// egress means adding explicit rules, never flipping a default.
+#[derive(Debug, Clone, Default)]
+pub struct NetworkSpec {
+    pub policy: NetworkPolicy,
+}
+
+/// Opaque teardown handle returned by [`NetworkProvider::provision`].
+#[derive(Debug, Clone)]
+pub struct NetHandle {
+    /// The VM this network belongs to.
+    pub vm: VmId,
+    /// Provider-private teardown tag (tap device name, gvproxy socket path,
+    /// mesh peer id, …) — meaningful only to the provider that minted it.
+    pub tag: String,
+}
+
+/// Errors from network provisioning / teardown / resolution.
+#[derive(Debug)]
+pub enum NetworkError {
+    Provision(String),
+    Teardown(String),
+    /// No provider registered for a `NetworkMode`'s kind — fails closed, never
+    /// a silent default.
+    UnknownProvider {
+        kind: String,
+    },
+}
+
+impl std::fmt::Display for NetworkError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::Provision(m) => write!(f, "network provision failed: {m}"),
+            Self::Teardown(m) => write!(f, "network teardown failed: {m}"),
+            Self::UnknownProvider { kind } => {
+                write!(f, "no NetworkProvider registered for mode kind {kind:?}")
+            }
+        }
+    }
+}
+
+impl std::error::Error for NetworkError {}
+
+/// Provisioning + policy + teardown for one VM's network.
+///
+/// Impls: the mvm-backend TAP/bridge/gvproxy/passt provider (per-OS), mvmd's
+/// WireGuard/Tailscale mesh provider. The provider hides the per-OS gateway
+/// choice (`MVM_NETWORKING`) from callers.
+pub trait NetworkProvider: Send + Sync {
+    /// Stable kind string — `"bridge"` | `"gvproxy"` | `"passt"` |
+    /// `"wireguard"` | … . Matched against a `NetworkMode`'s kind by the
+    /// registry.
+    fn kind(&self) -> &str;
+
+    /// Bring up `vm`'s network per `spec`, returning a teardown handle.
+    fn provision(&self, vm: &VmId, spec: &NetworkSpec) -> Result<NetHandle, NetworkError>;
+
+    /// The enforced policy. Default-deny until explicitly opened (claim 10).
+    fn policy(&self) -> &NetworkPolicy;
+
+    /// Tear the VM's network down, consuming its handle.
+    fn teardown(&self, handle: NetHandle) -> Result<(), NetworkError>;
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn network_spec_default_policy_is_deny_all() {
+        // The empty L4 allow-list is the deny-all encoding (policies.rs):
+        // the supervisor gate denies any flow not matched by an explicit rule.
+        let spec = NetworkSpec::default();
+        assert!(
+            spec.policy.l4.is_empty(),
+            "default NetworkSpec must carry the deny-all (empty) L4 policy"
+        );
+        assert_eq!(spec.policy, NetworkPolicy::default());
+    }
+}

--- a/crates/mvm-network/src/registry.rs
+++ b/crates/mvm-network/src/registry.rs
@@ -1,0 +1,132 @@
+//! Resolves an IR `NetworkMode` to a registered [`NetworkProvider`].
+//!
+//! The WireGuard/Tailscale mesh providers themselves are mvmd's — this crate
+//! only exports the registry seam so a `NetworkMode::Custom { provider }`
+//! routes to whatever mvmd registered, without a core edit. The built-in
+//! `None`/`Bridge`/`Host` modes resolve to a provider of the matching kind.
+
+use std::collections::HashMap;
+use std::sync::Arc;
+
+use mvm_sdk::ir::NetworkMode;
+
+use crate::provider::{NetworkError, NetworkProvider};
+
+/// Maps a `NetworkMode` to its provider. Unregistered kinds fail closed with
+/// [`NetworkError::UnknownProvider`] — never a silent default.
+#[derive(Default)]
+pub struct NetworkProviderRegistry {
+    providers: HashMap<String, Arc<dyn NetworkProvider>>,
+}
+
+impl NetworkProviderRegistry {
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Register a provider under its `kind()`. A later registration with the
+    /// same kind replaces the earlier one.
+    pub fn register(&mut self, provider: Arc<dyn NetworkProvider>) {
+        self.providers.insert(provider.kind().to_string(), provider);
+    }
+
+    /// Resolve the provider for `mode`. Built-ins map to their kind string;
+    /// `Custom` routes by its `provider`.
+    pub fn resolve(&self, mode: &NetworkMode) -> Result<&Arc<dyn NetworkProvider>, NetworkError> {
+        let kind = mode_kind(mode);
+        self.providers
+            .get(kind)
+            .ok_or_else(|| NetworkError::UnknownProvider {
+                kind: kind.to_string(),
+            })
+    }
+}
+
+/// The provider-kind string a `NetworkMode` selects.
+fn mode_kind(mode: &NetworkMode) -> &str {
+    match mode {
+        NetworkMode::None => "none",
+        NetworkMode::Bridge => "bridge",
+        NetworkMode::Host => "host",
+        NetworkMode::Custom { provider, .. } => provider.as_str(),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::provider::{NetHandle, NetworkSpec};
+    use mvm_core::policy::policies::NetworkPolicy;
+    use mvm_core::protocol::vm_backend::VmId;
+
+    struct StubProvider {
+        kind: String,
+        policy: NetworkPolicy,
+    }
+
+    impl NetworkProvider for StubProvider {
+        fn kind(&self) -> &str {
+            &self.kind
+        }
+        fn provision(&self, vm: &VmId, _spec: &NetworkSpec) -> Result<NetHandle, NetworkError> {
+            Ok(NetHandle {
+                vm: vm.clone(),
+                tag: format!("{}-tag", self.kind),
+            })
+        }
+        fn policy(&self) -> &NetworkPolicy {
+            &self.policy
+        }
+        fn teardown(&self, _handle: NetHandle) -> Result<(), NetworkError> {
+            Ok(())
+        }
+    }
+
+    fn stub(kind: &str) -> Arc<dyn NetworkProvider> {
+        Arc::new(StubProvider {
+            kind: kind.into(),
+            policy: NetworkPolicy::default(),
+        })
+    }
+
+    #[test]
+    fn registry_resolves_builtin_and_custom_modes() {
+        let mut reg = NetworkProviderRegistry::new();
+        reg.register(stub("bridge"));
+        reg.register(stub("wireguard"));
+
+        assert_eq!(reg.resolve(&NetworkMode::Bridge).unwrap().kind(), "bridge");
+        let custom = NetworkMode::Custom {
+            provider: "wireguard".into(),
+            config: serde_json::json!({ "peer": "x" }),
+        };
+        assert_eq!(reg.resolve(&custom).unwrap().kind(), "wireguard");
+    }
+
+    #[test]
+    fn registry_rejects_unregistered_custom_provider() {
+        let reg = NetworkProviderRegistry::new();
+        let custom = NetworkMode::Custom {
+            provider: "tailscale".into(),
+            config: serde_json::json!({}),
+        };
+        // Can't `{:?}` the Ok side (a trait object isn't Debug), so branch
+        // explicitly and format the error via Display.
+        match reg.resolve(&custom) {
+            Err(NetworkError::UnknownProvider { kind }) => assert_eq!(kind, "tailscale"),
+            Err(e) => panic!("expected UnknownProvider, got {e}"),
+            Ok(_) => panic!("expected UnknownProvider, got Ok"),
+        }
+    }
+
+    #[test]
+    fn network_mode_custom_roundtrips_json() {
+        let mode = NetworkMode::Custom {
+            provider: "wireguard".into(),
+            config: serde_json::json!({ "endpoint": "1.2.3.4:51820" }),
+        };
+        let json = serde_json::to_string(&mode).unwrap();
+        let back: NetworkMode = serde_json::from_str(&json).unwrap();
+        assert_eq!(mode, back);
+    }
+}

--- a/crates/mvm-sdk/src/deploy.rs
+++ b/crates/mvm-sdk/src/deploy.rs
@@ -215,10 +215,12 @@ pub fn build_mvmd_spec(workload: &Workload) -> MvmdSpec {
         rootfs_size_mb: app.resources.rootfs_size_mb,
     };
     let network = app.network.as_ref().map(|n| NetworkSpec {
-        mode: match n.mode {
+        mode: match &n.mode {
             crate::ir::NetworkMode::None => "none".into(),
             crate::ir::NetworkMode::Bridge => "bridge".into(),
             crate::ir::NetworkMode::Host => "host".into(),
+            // A custom mesh deploys under its provider's name (wireguard, …).
+            crate::ir::NetworkMode::Custom { provider, .. } => provider.clone(),
         },
         ports: n
             .ports

--- a/crates/mvm-sdk/src/ir/workload.rs
+++ b/crates/mvm-sdk/src/ir/workload.rs
@@ -484,12 +484,25 @@ pub enum NetworkDns {
     Resolver { host: String, port: u16 },
 }
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize, JsonSchema)]
+// `Copy`/`Eq` dropped when the open `Custom` variant arrived: its owned
+// `String` + `serde_json::Value` (Value isn't `Eq`) can't be either. Same
+// shape as `MountSource`.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize, JsonSchema)]
 #[serde(rename_all = "snake_case")]
 pub enum NetworkMode {
     None,
     Bridge,
     Host,
+    /// Open extension point: a mesh/VPN network resolved by a registered
+    /// `NetworkProvider` (WireGuard, Tailscale, …). `config` is the
+    /// provider's own schema; the IR doesn't interpret it, so a mesh plugs
+    /// in without a core-enum edit. The guest's `netinit` reads a `Custom`
+    /// config off the config-device. mvm builds none of the mesh logic — the
+    /// impl is mvmd's; this is only the seam. See plan 123 A5.
+    Custom {
+        provider: String,
+        config: serde_json::Value,
+    },
 }
 
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize, JsonSchema)]

--- a/specs/plans/123-network-storage-warmstart.md
+++ b/specs/plans/123-network-storage-warmstart.md
@@ -16,6 +16,8 @@
 
 ## Phase A — `NetworkProvider` (new crate `mvm-network`)
 
+> **Status (2026-06-04, branch `feat/plan-123a-network`):** the **additive seam** is landed and verified — the `mvm-network` crate + `NetworkProvider` trait + default-deny policy (A1 step 1, A2 step 1) and the IR `NetworkMode::Custom` + registry (A5). The **claims-gated relocations are deferred** (A1 step 2 full move, A2 step 2 enforce, A3, A4): they lift the firewall / L4 / L7 / packet-observer machinery out of `mvm-hostd`, which carries the claim-10/12/13 witnesses + `xtask check-claim-catalog`, so each must move with its witness rather than be rushed. Tracked in the deferred follow-ups.
+
 ### Task A1: create `mvm-network` + the trait
 
 ADR-064 generalized to provisioning. One seam an external consumer (mvmd) and the backends extend.
@@ -33,15 +35,16 @@ ADR-064 generalized to provisioning. One seam an external consumer (mvmd) and th
       fn teardown(&self, h: NetHandle) -> Result<()>;
   }
   ```
-- [ ] **Step 2:** Move the existing provisioning (`mvm-backend/network.rs`, the bridge/TAP/gvproxy/passt wiring) into `mvm-network` behind `provision`/`teardown`; re-point callers. Workspace builds.
-- [ ] **Step 3:** Commit.
+  - [x] **Step 1 done:** `NetworkProvider` (kind/provision/policy/teardown) + `NetworkSpec`/`NetHandle`/`NetworkError` in `crates/mvm-network/src/provider.rs`. `policy()` returns `mvm_core`'s `NetworkPolicy` (reused, not a new `EgressPolicy`). The crate is the 17th workspace member.
+- [ ] **Step 2 — DEFERRED:** the existing provisioning is shell-coupled (`mvm-backend/network.rs` calls `run_in_vm_visible` + `VmSlot`), so the trait is the low seam and the impl stays in `mvm-backend`. Writing that impl + re-pointing callers + lifting the `mvm-hostd` firewall/proxy is the claims-gated move (see status note) — follow-up.
+- [x] **Step 3:** Committed `4af31a45`.
 
 ### Task A2: default-deny ingress **and** egress
 
 Claim 10 is egress default-deny today; ADR-066 §"NetworkProvider owns … both ingress and egress" extends it.
 
-- [ ] **Step 1:** Failing tests — `EgressPolicy::default()` denies all; an unresolved policy denies (`policy_default_is_deny_all` style); ingress mirrors it. Keep the `MVM_ACK_UNRESTRICTED_NETWORK` escape + warning (never in CI).
-- [ ] **Step 2:** Implement the resolve + enforce (DNS allow-list + L4 filter in the gvproxy/passt bridge — the in-line wrap, not a native API; see `reference_gvproxy_passt_no_native_flow_api`). Tests green. Commit.
+- [x] **Step 1:** `network_spec_default_policy_is_deny_all` asserts `NetworkSpec::default().policy` is the empty (deny-all) `NetworkPolicy` — the seam's default fails closed (claim 10). (No new `EgressPolicy` type; reuses the existing claim-10 policy.)
+- [ ] **Step 2 — DEFERRED:** the resolve + enforce (DNS allow-list + L4 filter in the gvproxy/passt bridge, the in-line wrap) lives in `mvm-hostd`'s machinery + the `MVM_ACK_UNRESTRICTED_NETWORK` escape — part of the claims-gated lift. Follow-up.
 
 ### Task A3: the egress proxy with the 129 seams
 
@@ -58,10 +61,10 @@ Claim 10 is egress default-deny today; ADR-066 §"NetworkProvider owns … both 
 
 The IR `NetworkMode` is a closed enum (`None`/`Bridge`/`Host`) — a mesh/VPN mode can't be expressed without a core edit. Same fix as `MountSource::External`: add an open `Custom { provider, config }` + a `NetworkProvider`-registry lookup. **WireGuard/Tailscale themselves are mvmd's** (the control-plane mesh); this plan only exports the *seam* so mvmd registers a `WireGuardNetworkProvider`, expresses it in the IR, and the guest's `netinit` (124) consumes the config delivered on the config-device (124 E1). mvm builds none of the mesh logic.
 
-**Files:** `crates/mvm-ir/src/workload.rs` (`NetworkMode` ~line 489); `crates/mvm-network` (the registry).
+**Files:** `crates/mvm-sdk/src/ir/workload.rs:489` (`NetworkMode` — post-121 home, not `mvm-ir`); `crates/mvm-network/src/registry.rs`.
 
-- [ ] **Step 1:** Failing test — `NetworkMode::Custom { provider: "wireguard", config }` round-trips; an unregistered provider errors `UnknownNetworkProvider`; the built-in `None`/`Bridge`/`Host` still resolve.
-- [ ] **Step 2:** Add the open variant + the registry lookup (built-ins stay); `netinit` reads a `Custom` config from the config-device. mvmd's WireGuard/Tailscale impl is a separate mvmd plan. Commit.
+- [x] **Step 1:** `network_mode_custom_roundtrips_json` (serde), `registry_resolves_builtin_and_custom_modes`, `registry_rejects_unregistered_custom_provider` (→ `NetworkError::UnknownProvider`). Built-in `None`/`Bridge`/`Host` resolve by kind.
+- [x] **Step 2:** Added the open `Custom { provider, config }` variant (dropping `Copy`/`Eq`; one match in `deploy.rs` fixed) + `NetworkProviderRegistry`. The guest `netinit` reading a `Custom` config off the config-device is plan 124's (E1); mvmd's WireGuard/Tailscale impl is a separate mvmd plan. Committed `4af31a45`.
 
 ## Phase B — `StorageProvider` (`mvm-storage`)
 
@@ -145,6 +148,11 @@ The wireable macOS live-memory path. Coarser than UFFD (a full save/restore), bu
 
 ### deferred follow-ups
 
+- [ ] **Phase A claims-gated lift (A1 step 2, A2 step 2, A3, A4).** With the `mvm-network` seam landed, relocate the concrete machinery behind it — *each move carrying its claim witness*, so `xtask check-claim-catalog` stays green:
+  - the mvm-backend TAP/bridge/gvproxy/passt provider impl of `NetworkProvider` (re-point `mvm-backend/src/network.rs` callers).
+  - the firewall (`mvm-hostd/.../firewall/`) + L4 (`proxy/l4.rs`, `L4Policy::deny_all`) + L7 (`l7_proxy.rs`) enforce path, plus the `MVM_ACK_UNRESTRICTED_NETWORK` escape (claim 10).
+  - A3 egress proxy with the 129 `substitution_stage` + `scan_stage` hooks, built on Plan 141's shipped packet-observer pipeline (`mvm-hostd/.../network/{mod,packet,pipeline}.rs` — `Observer::on_packet`/`Verdict`).
+  - A4 DNS sink-hole + flow audit to the shared chain-signed log.
 - [ ] Cloud-Hypervisor snapshot parity (if CH stays a backend).
 - [ ] Soften the gap-analysis "live-memory resume" line to the per-backend matrix (Firecracker + Vz live-memory; libkrun disk-only).
 - [ ] The diff-snapshot fast-resume on Vz (UFFD-equivalent) — VZ's save/restore is coarse; a faster macOS path is its own investigation.


### PR DESCRIPTION
Plan 123 **Phase A foundation** (the `NetworkProvider` seam), executed as the 123a split. Tests + clippy `-D warnings` + nightly rustfmt green; full workspace builds.

### What's here
- New **17th crate `mvm-network`** (A1): the `NetworkProvider` trait (kind/provision/policy/teardown) + `NetworkSpec`/`NetHandle`/`NetworkError` + a `NetworkProviderRegistry` that routes an IR `NetworkMode` to its provider, failing closed with `UnknownProvider`.
- **A2** — default-deny: `NetworkSpec::default().policy` is the empty (deny-all) `mvm_core::NetworkPolicy` (claim 10 reused, not a new `EgressPolicy`).
- **A5** — open IR `NetworkMode::Custom { provider, config }` so a WireGuard/Tailscale mesh (impl is mvmd's) plugs in without a core edit. Dropping `Copy`/`Eq` (the variant holds owned data; `serde_json::Value` isn't `Eq`) rippled to exactly one `match` (`deploy.rs`), now `Custom`-aware. mvm-sdk 301/301.

### Why this is foundation-only (deferred, tracked in `specs/plans/123-…md`)
The existing provisioning is shell-coupled (`mvm-backend/network.rs` → `run_in_vm_visible` + `VmSlot`), so the trait is the **low seam** and the concrete impl stays in `mvm-backend`. The remaining **claims-gated lift** — the mvm-backend TAP/bridge/gvproxy/passt provider impl (A1 step 2), the firewall/L4/L7 enforce path (A2 step 2), the egress-proxy 129 seams (A3), DNS/flow audit (A4) — relocates the **claim-10/12/13 witnesses** out of `mvm-hostd` and must move *witness-by-witness* so `xtask check-claim-catalog` stays green. Not rushed into this PR.
