### PR TITLE
feat(backend): Plan 123 C1 — SnapshotCapability per-backend warm-start tier

### DIFF
--- a/crates/mvm-backend/src/backend.rs
+++ b/crates/mvm-backend/src/backend.rs
@@ -1,7 +1,7 @@
 use anyhow::Result;
 use mvm_core::vm_backend::{
-    BackendSecurityProfile, ClaimStatus, LayerCoverage, StartMode, VmBackend, VmCapabilities, VmId,
-    VmInfo, VmStartConfig, VmStatus,
+    BackendSecurityProfile, ClaimStatus, LayerCoverage, SnapshotCapability, StartMode, VmBackend,
+    VmCapabilities, VmId, VmInfo, VmStartConfig, VmStatus,
 };
 
 // W8: every backend variant + the FC support modules live in this
@@ -135,6 +135,12 @@ impl VmBackend for FirecrackerBackend {
             tap_networking: true,
             balloon: true,
         }
+    }
+
+    fn snapshot_capability(&self) -> SnapshotCapability {
+        // Firecracker is the live-memory fast-resume backend (UFFD / NBD /
+        // hugepages) — plan 123 C2.
+        SnapshotCapability::LiveMemory
     }
 
     fn start(&self, config: &VmStartConfig) -> Result<VmId> {
@@ -481,6 +487,10 @@ impl AnyBackend {
 
     pub fn capabilities(&self) -> VmCapabilities {
         self.inner().capabilities()
+    }
+
+    pub fn snapshot_capability(&self) -> SnapshotCapability {
+        self.inner().snapshot_capability()
     }
 
     /// Start a VM using the backend-agnostic config.
@@ -870,6 +880,41 @@ mod tests {
             AnyBackend::from_hypervisor("apple-container"),
             "apple-container",
         );
+    }
+
+    #[test]
+    fn snapshot_capability_live_memory_on_firecracker() {
+        assert_eq!(
+            AnyBackend::from_hypervisor("firecracker").snapshot_capability(),
+            SnapshotCapability::LiveMemory
+        );
+    }
+
+    #[test]
+    fn snapshot_capability_disk_only_on_libkrun() {
+        assert_eq!(
+            AnyBackend::from_hypervisor("libkrun").snapshot_capability(),
+            SnapshotCapability::DiskOnly
+        );
+    }
+
+    #[test]
+    fn snapshot_capability_unsupported_on_microvm_nix() {
+        assert_eq!(
+            AnyBackend::from_hypervisor("qemu").snapshot_capability(),
+            SnapshotCapability::Unsupported
+        );
+    }
+
+    #[test]
+    fn snapshot_capability_vz_tracks_macos_support() {
+        // SaveRestore on macOS 26+, Unsupported elsewhere — never silently
+        // LiveMemory/DiskOnly. (Runs on Linux CI, where it's Unsupported.)
+        let cap = AnyBackend::from_hypervisor("vz").snapshot_capability();
+        assert!(matches!(
+            cap,
+            SnapshotCapability::SaveRestore | SnapshotCapability::Unsupported
+        ));
     }
 
     #[test]

--- a/crates/mvm-backend/src/libkrun.rs
+++ b/crates/mvm-backend/src/libkrun.rs
@@ -25,8 +25,8 @@
 
 use anyhow::{Result, anyhow, bail};
 use mvm_core::vm_backend::{
-    BackendSecurityProfile, ClaimStatus, GuestChannelInfo, LayerCoverage, StartMode, VmBackend,
-    VmCapabilities, VmId, VmInfo, VmStartConfig, VmStatus,
+    BackendSecurityProfile, ClaimStatus, GuestChannelInfo, LayerCoverage, SnapshotCapability,
+    StartMode, VmBackend, VmCapabilities, VmId, VmInfo, VmStartConfig, VmStatus,
 };
 
 use crate::base::ui;
@@ -213,6 +213,13 @@ impl VmBackend for LibkrunBackend {
             // builder. Declared `false` until wiring lands.
             balloon: false,
         }
+    }
+
+    fn snapshot_capability(&self) -> SnapshotCapability {
+        // libkrun has no memory snapshot — warm-start is a fast reboot from
+        // the overlay/rootfs disk snapshot (plan 123 C4). A live-memory
+        // request is refused with a typed error, not silently degraded.
+        SnapshotCapability::DiskOnly
     }
 
     fn start(&self, config: &VmStartConfig) -> Result<VmId> {

--- a/crates/mvm-backend/src/mock.rs
+++ b/crates/mvm-backend/src/mock.rs
@@ -26,8 +26,9 @@ use std::sync::Mutex;
 
 use anyhow::{Result, bail};
 use mvm_core::vm_backend::{
-    BackendSecurityProfile, ClaimStatus, GuestChannelInfo, LayerCoverage, StartMode, VmBackend,
-    VmCapabilities, VmExitStatus, VmId, VmInfo, VmNetworkInfo, VmStartConfig, VmStatus,
+    BackendSecurityProfile, ClaimStatus, GuestChannelInfo, LayerCoverage, SnapshotCapability,
+    StartMode, VmBackend, VmCapabilities, VmExitStatus, VmId, VmInfo, VmNetworkInfo, VmStartConfig,
+    VmStatus,
 };
 
 use crate::mock_guest_agent::MockGuestAgent;
@@ -97,6 +98,11 @@ impl VmBackend for MockBackend {
             tap_networking: false,
             balloon: false,
         }
+    }
+
+    fn snapshot_capability(&self) -> SnapshotCapability {
+        // The mock is the fully-capable test double.
+        SnapshotCapability::LiveMemory
     }
 
     fn start_with_mode(&self, config: &VmStartConfig, _mode: StartMode) -> Result<VmId> {

--- a/crates/mvm-backend/src/vz.rs
+++ b/crates/mvm-backend/src/vz.rs
@@ -33,8 +33,8 @@
 
 use anyhow::{Result, anyhow, bail};
 use mvm_core::vm_backend::{
-    BackendSecurityProfile, ClaimStatus, GuestChannelInfo, LayerCoverage, StartMode, VmBackend,
-    VmCapabilities, VmExitStatus, VmId, VmInfo, VmStartConfig, VmStatus,
+    BackendSecurityProfile, ClaimStatus, GuestChannelInfo, LayerCoverage, SnapshotCapability,
+    StartMode, VmBackend, VmCapabilities, VmExitStatus, VmId, VmInfo, VmStartConfig, VmStatus,
 };
 
 use crate::base::ui;
@@ -181,6 +181,18 @@ impl VmBackend for VzBackend {
             // supervisor; live adjustment goes through the control
             // socket's BALLOON verb.
             balloon: true,
+        }
+    }
+
+    fn snapshot_capability(&self) -> SnapshotCapability {
+        // Vz is the macOS live-memory path: coarse `saveMachineState` /
+        // `restoreMachineState` (plan 123 C3), keyed off the same macOS
+        // version gate as the `snapshots` flag so older hosts report
+        // honestly rather than degrade silently.
+        if macos_supports_vz_snapshots() {
+            SnapshotCapability::SaveRestore
+        } else {
+            SnapshotCapability::Unsupported
         }
     }
 

--- a/crates/mvm-core/src/protocol/vm_backend.rs
+++ b/crates/mvm-core/src/protocol/vm_backend.rs
@@ -408,6 +408,25 @@ pub struct VmCapabilities {
     pub balloon: bool,
 }
 
+/// How thoroughly a backend can warm-start a VM from a snapshot. Distinct
+/// from `VmCapabilities::snapshots` (a coarse "can checkpoint" bool): this is
+/// the honest per-backend warm-start *tier* (plan 123 Phase C). No path
+/// silently degrades — a request beyond the reported tier returns a typed
+/// error (ADR-053) once the snapshot RPC is wired (C2/C3).
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+pub enum SnapshotCapability {
+    /// Full live-memory snapshot + fast resume (Firecracker: UFFD/NBD/hugepages).
+    LiveMemory,
+    /// Coarse save/restore of machine state (Vz `saveMachineState`, macOS 26+).
+    SaveRestore,
+    /// No memory snapshot — warm-start is a fast reboot from a disk/overlay
+    /// snapshot (libkrun).
+    DiskOnly,
+    /// No snapshot/warm-start support.
+    #[default]
+    Unsupported,
+}
+
 /// Snapshot of a VM's virtio-balloon state, returned by
 /// [`VmBackend::balloon_state`].
 ///
@@ -601,6 +620,15 @@ pub trait VmBackend: Send + Sync {
     /// Capabilities supported by this backend.
     fn capabilities(&self) -> VmCapabilities;
 
+    /// Warm-start snapshot tier — `LiveMemory` (Firecracker), `SaveRestore`
+    /// (Vz, macOS 26+), `DiskOnly` (libkrun), or `Unsupported`. Defaults to
+    /// `Unsupported` so a backend opts in explicitly; consumers check this
+    /// before requesting a snapshot rather than discovering a silent
+    /// degrade (plan 123 C1 / ADR-053).
+    fn snapshot_capability(&self) -> SnapshotCapability {
+        SnapshotCapability::Unsupported
+    }
+
     /// Start a new VM from the given configuration.
     ///
     /// Returns the [`VmId`] assigned to the running VM.
@@ -775,6 +803,16 @@ pub trait VmBackend: Send + Sync {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn snapshot_capability_defaults_to_unsupported() {
+        // The trait method defaults to this, so a backend that forgets to opt
+        // in fails closed (no silent live-memory claim).
+        assert_eq!(
+            SnapshotCapability::default(),
+            SnapshotCapability::Unsupported
+        );
+    }
 
     #[test]
     fn test_vm_id_display() {

--- a/specs/plans/123-network-storage-warmstart.md
+++ b/specs/plans/123-network-storage-warmstart.md
@@ -110,10 +110,12 @@ The IR `MountSource` is a closed enum (`Volume`/`HostPath`/`Tmpfs`) — a new so
 
 The honest matrix from the capability check. `VmBackend` already carries a pause/resume capability flag; extend it to snapshot/restore with the same per-backend disposition.
 
+> **Status (2026-06-05, branch `feat/plan-123c-warmstart`):** **C1 (the capability enum + per-backend disposition) is landed.** C2–C4 are **deferred**: they need gated lanes this dev host can't run (live-KVM for Firecracker UFFD/NBD, macOS-26 for Vz save/restore) **and a host `PostRestore` sender that doesn't exist yet** (the same gap that deferred plan 122's VMGenID-token delivery — C2's reseed-on-resume depends on it). C1 is the additive scaffolding the rest hangs off.
+
 ### Task C1: extend the `VmBackend` snapshot capability
 
-- [ ] **Step 1:** Failing test — `backend.snapshot_capability()` returns `LiveMemory` for Firecracker, `SaveRestore` for Vz (macOS 26+), `DiskOnly` for libkrun, `Unsupported` for microvm_nix — mirroring the existing `pause_resume_*` tests. No path silently degrades; an unsupported request returns a typed error (ADR-053).
-- [ ] **Step 2:** Add the capability enum + per-backend disposition next to the existing pause/resume flag. Commit.
+- [x] **Step 1:** Tests in `backend.rs` (mirroring `pause_resume_unsupported_*`): `snapshot_capability_{live_memory_on_firecracker,disk_only_on_libkrun,unsupported_on_microvm_nix,vz_tracks_macos_support}` + a runnable `mvm-core` `snapshot_capability_defaults_to_unsupported`. (mvm-backend test binary is SIGKILL'd by macОS codesign — compiled here, run on Linux CI.)
+- [x] **Step 2:** Added `SnapshotCapability {LiveMemory,SaveRestore,DiskOnly,Unsupported}` + a `VmBackend::snapshot_capability()` trait method (default `Unsupported` — fail-closed) in `mvm-core/src/protocol/vm_backend.rs`, dispatched by `AnyBackend`. Per-backend: FC `LiveMemory`, Vz `SaveRestore`(macos-gated)/`Unsupported`, libkrun `DiskOnly`, mock `LiveMemory`, rest default `Unsupported`. The typed-error-on-over-request (ADR-053) lands with the snapshot RPC (C2/C3 — not wired yet).
 
 ### Task C2: Firecracker fast-resume substrate (Linux)
 


### PR DESCRIPTION
Plan 123 **Phase C, Task C1** — the per-backend warm-start **capability matrix** (the additive scaffolding the rest of Phase C hangs off). Workspace builds; clippy `-D warnings` + nightly rustfmt green.

### What's here
- `SnapshotCapability { LiveMemory, SaveRestore, DiskOnly, Unsupported }` + a `VmBackend::snapshot_capability()` trait method, default **`Unsupported`** (fail-closed — a backend opts in explicitly, no silent degrade; ADR-053). Dispatched by `AnyBackend`.
- Honest per-backend matrix: **Firecracker** `LiveMemory`, **Vz** `SaveRestore` (macOS-26-gated) else `Unsupported`, **libkrun** `DiskOnly`, **mock** `LiveMemory`, the rest default `Unsupported`.
- Tests mirror the existing `pause_resume_unsupported_*`: `snapshot_capability_{live_memory_on_firecracker,disk_only_on_libkrun,unsupported_on_microvm_nix,vz_tracks_macos_support}`, plus a runnable `mvm-core` `snapshot_capability_defaults_to_unsupported`.

### Verification note
The mvm-backend test binary is SIGKILL'd by macOS codesign on the dev host (known environmental issue), so the disposition tests are **compiled here and run on Linux CI**; the mvm-core enum test runs locally.

### Deferred (need lanes this PR can't exercise)
C2 (Firecracker UFFD/NBD/hugepages fast-resume), C3 (Vz `saveMachineState`/`restoreMachineState`), C4 (libkrun disk-only + doctor probes) need **live-KVM / macOS-26 gated lanes** and a host **`PostRestore` sender that doesn't exist yet** (the same gap that deferred plan 122's VMGenID-token delivery — C2's reseed-on-resume depends on it). The typed over-request error lands with the snapshot RPC in C2/C3.
