### PR TITLE
feat(network): Plan 123 A2.1 — EgressEnforcer seam + supervisor adapter

### DIFF
--- a/crates/mvm-hostd/Cargo.toml
+++ b/crates/mvm-hostd/Cargo.toml
@@ -35,6 +35,9 @@ path = "src/bin/mvm-audit-signer.rs"
 [dependencies]
 mvm-core.workspace = true
 mvm-backend.workspace = true
+# plan 123 A2 — the EgressEnforcer seam this crate's SupervisorEgressEnforcer
+# implements. Acyclic HIGH->LOW: mvm-network deps only mvm-core + mvm-sdk.
+mvm-network.workspace = true
 # `mvm_sdk::compile::deps_audit::verify_sealed_volume` — supervisor
 # admission gate (security claim 9).
 mvm-sdk.workspace = true

--- a/crates/mvm-hostd/src/supervisor/firewall/mod.rs
+++ b/crates/mvm-hostd/src/supervisor/firewall/mod.rs
@@ -24,6 +24,8 @@ use thiserror::Error;
 
 #[cfg(any(target_os = "linux", test))]
 pub mod linux_nft;
+/// plan 123 A2.1 — adapts `FirewallEnforcer` to `mvm_network::EgressEnforcer`.
+pub mod seam;
 
 /// Runtime VM firewall wiring. The TAP interface is the VM-facing
 /// device; the proxy interface is the only allowed egress path.

--- a/crates/mvm-hostd/src/supervisor/firewall/seam.rs
+++ b/crates/mvm-hostd/src/supervisor/firewall/seam.rs
@@ -1,0 +1,123 @@
+//! `SupervisorEgressEnforcer` — adapts the supervisor's [`FirewallEnforcer`]
+//! to the low [`mvm_network::EgressEnforcer`] seam (plan 123 A2.1).
+//!
+//! Pure plumbing: it maps the seam's `EgressWiring` onto a [`FirewallSpec`]
+//! and delegates `enforce`→`install_default_deny`, `withdraw`→`teardown`,
+//! translating [`FirewallError`] into `EnforcementError` so the fail-closed
+//! `NotWired` posture survives the seam. A2.1 introduces this adapter *without
+//! changing any live call path*; A2.2 reroutes `Supervisor::launch` through it.
+
+use std::sync::Arc;
+
+use mvm_core::network_policy::NetworkPolicy;
+use mvm_network::{EgressEnforcer, EgressWiring, EnforcementError};
+
+use super::{FirewallEnforcer, FirewallError, FirewallSpec};
+
+/// Drives the host nftables firewall behind the `EgressEnforcer` seam.
+pub struct SupervisorEgressEnforcer {
+    firewall: Arc<dyn FirewallEnforcer>,
+}
+
+impl SupervisorEgressEnforcer {
+    pub fn new(firewall: Arc<dyn FirewallEnforcer>) -> Self {
+        Self { firewall }
+    }
+}
+
+impl EgressEnforcer for SupervisorEgressEnforcer {
+    fn enforce(
+        &self,
+        wiring: &EgressWiring,
+        _policy: &NetworkPolicy,
+    ) -> Result<(), EnforcementError> {
+        // The firewall installs a fixed default-deny on the TAP regardless of
+        // policy; the policy's allow-rules are the L4/L7 layer's job (A2.2+),
+        // so `_policy` is reserved on the seam, not silently dropped.
+        let spec = FirewallSpec::new(&wiring.vm_id, &wiring.tap_iface, &wiring.proxy_iface);
+        self.firewall
+            .install_default_deny(&spec)
+            .map_err(firewall_to_enforcement)
+    }
+
+    fn withdraw(&self, vm_id: &str) -> Result<(), EnforcementError> {
+        self.firewall
+            .teardown(vm_id)
+            .map_err(firewall_to_enforcement)
+    }
+}
+
+fn firewall_to_enforcement(err: FirewallError) -> EnforcementError {
+    match err {
+        FirewallError::NotWired => EnforcementError::NotWired,
+        FirewallError::InvalidSpec { field, value } => {
+            EnforcementError::Rejected(format!("{field}: {value:?}"))
+        }
+        FirewallError::Backend(m) => EnforcementError::Backend(m),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::super::NoopFirewallEnforcer;
+    use super::*;
+    use std::sync::Mutex;
+
+    fn wiring() -> EgressWiring {
+        EgressWiring {
+            vm_id: "vm-a".into(),
+            tap_iface: "tap0".into(),
+            proxy_iface: "eth0".into(),
+        }
+    }
+
+    /// Records forwarded calls so we can assert the adapter passes the wiring
+    /// through intact.
+    #[derive(Default)]
+    struct RecordingFirewall {
+        installed: Mutex<Vec<FirewallSpec>>,
+        torn_down: Mutex<Vec<String>>,
+    }
+    impl FirewallEnforcer for RecordingFirewall {
+        fn install_default_deny(&self, spec: &FirewallSpec) -> Result<(), FirewallError> {
+            self.installed.lock().unwrap().push(spec.clone());
+            Ok(())
+        }
+        fn teardown(&self, vm_id: &str) -> Result<(), FirewallError> {
+            self.torn_down.lock().unwrap().push(vm_id.to_string());
+            Ok(())
+        }
+    }
+
+    #[test]
+    fn adapter_forwards_wiring_to_firewall() {
+        let fw = Arc::new(RecordingFirewall::default());
+        let enforcer = SupervisorEgressEnforcer::new(fw.clone());
+
+        enforcer
+            .enforce(&wiring(), &NetworkPolicy::deny_all())
+            .unwrap();
+        let installed = fw.installed.lock().unwrap();
+        assert_eq!(installed.len(), 1);
+        assert_eq!(installed[0], FirewallSpec::new("vm-a", "tap0", "eth0"));
+        drop(installed);
+
+        enforcer.withdraw("vm-a").unwrap();
+        assert_eq!(&*fw.torn_down.lock().unwrap(), &["vm-a".to_string()]);
+    }
+
+    #[test]
+    fn adapter_preserves_fail_closed_not_wired() {
+        // A Noop firewall must surface as NotWired through the seam — never a
+        // silent success that would boot a VM with open host egress.
+        let enforcer = SupervisorEgressEnforcer::new(Arc::new(NoopFirewallEnforcer));
+        assert!(matches!(
+            enforcer.enforce(&wiring(), &NetworkPolicy::deny_all()),
+            Err(EnforcementError::NotWired)
+        ));
+        assert!(matches!(
+            enforcer.withdraw("vm-a"),
+            Err(EnforcementError::NotWired)
+        ));
+    }
+}

--- a/crates/mvm-network/src/enforcement.rs
+++ b/crates/mvm-network/src/enforcement.rs
@@ -1,0 +1,109 @@
+//! `EgressEnforcer` — the low seam the host-side egress enforcement (the
+//! mvm-hostd supervisor's nftables default-deny, and later L4/L7) sits behind
+//! (plan 123 Phase A, task A2).
+//!
+//! This crate stays low (it depends only on `mvm-core` / `mvm-sdk`), so the
+//! actual enforcement — `nft` shell-out, the L4 gate, the L7 proxy — can't
+//! move down here; those need `tokio` and `mvm-hostd` internals. So the seam
+//! is just the *contract*: it names what an enforcer does over the same
+//! `mvm_core::network_policy::NetworkPolicy` the [`NetworkSpec`] already
+//! carries (whose `Default` is `deny_all()` — claim 10). The concrete impl
+//! (`SupervisorEgressEnforcer`) lives in mvm-hostd and adapts the existing
+//! `FirewallEnforcer`.
+//!
+//! [`NetworkSpec`]: crate::NetworkSpec
+
+use mvm_core::network_policy::NetworkPolicy;
+
+/// Per-VM wiring an egress enforcer needs to scope its rules — the same three
+/// fields as mvm-hostd's `FirewallSpec`, lifted into this low crate so the
+/// supervisor can convert without a downward dependency. `tap_iface` is the
+/// VM-facing device; `proxy_iface` is the only permitted egress path.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct EgressWiring {
+    pub vm_id: String,
+    pub tap_iface: String,
+    pub proxy_iface: String,
+}
+
+/// Errors from egress enforcement. Mirrors the host firewall's failure modes
+/// so the fail-closed posture survives the seam.
+#[derive(Debug)]
+pub enum EnforcementError {
+    /// No real enforcer is wired (a Noop slot). Fail closed — never boot a VM
+    /// with silent host egress.
+    NotWired,
+    /// The wiring/policy was rejected before any backend apply (e.g. an unsafe
+    /// interface name).
+    Rejected(String),
+    /// The platform backend (nftables, …) failed to apply.
+    Backend(String),
+}
+
+impl std::fmt::Display for EnforcementError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::NotWired => write!(f, "egress enforcer not wired (fail closed)"),
+            Self::Rejected(m) => write!(f, "egress wiring rejected: {m}"),
+            Self::Backend(m) => write!(f, "egress enforcement backend failed: {m}"),
+        }
+    }
+}
+
+impl std::error::Error for EnforcementError {}
+
+/// The seam the supervisor's host-egress enforcement sits behind. Object-safe
+/// and dependency-light. A [`NetworkProvider`](crate::NetworkProvider) that
+/// doesn't self-enforce in `provision` (e.g. the future libkrun gvproxy/passt
+/// provider) returns one of these from `egress_enforcer()`, and the supervisor
+/// drives it; the Firecracker provider self-enforces (iptables in `provision`)
+/// and returns `None`.
+pub trait EgressEnforcer: Send + Sync {
+    /// Install host-side default-deny enforcement scoped to `wiring`. `policy`
+    /// is the admitted egress policy (its `Default` is `deny_all()`); the
+    /// firewall layer installs a fixed default-deny regardless, so the
+    /// policy's allow-rules are the L4/L7 layer's job (A2.2+) — `policy` is
+    /// threaded now so that widening doesn't change the signature.
+    fn enforce(
+        &self,
+        wiring: &EgressWiring,
+        policy: &NetworkPolicy,
+    ) -> Result<(), EnforcementError>;
+
+    /// Remove the VM-scoped enforcement.
+    fn withdraw(&self, vm_id: &str) -> Result<(), EnforcementError>;
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    struct NoopEnforcer;
+    impl EgressEnforcer for NoopEnforcer {
+        fn enforce(
+            &self,
+            _wiring: &EgressWiring,
+            _policy: &NetworkPolicy,
+        ) -> Result<(), EnforcementError> {
+            Err(EnforcementError::NotWired)
+        }
+        fn withdraw(&self, _vm_id: &str) -> Result<(), EnforcementError> {
+            Err(EnforcementError::NotWired)
+        }
+    }
+
+    #[test]
+    fn noop_enforcer_fails_closed() {
+        let e = NoopEnforcer;
+        let wiring = EgressWiring {
+            vm_id: "vm".into(),
+            tap_iface: "tap0".into(),
+            proxy_iface: "eth0".into(),
+        };
+        assert!(matches!(
+            e.enforce(&wiring, &NetworkPolicy::deny_all()),
+            Err(EnforcementError::NotWired)
+        ));
+        assert!(matches!(e.withdraw("vm"), Err(EnforcementError::NotWired)));
+    }
+}

--- a/crates/mvm-network/src/lib.rs
+++ b/crates/mvm-network/src/lib.rs
@@ -19,8 +19,10 @@
 //! the egress-proxy substitution/scan seams plan 129 hangs on. See plan 123
 //! Phase A tasks A1-step-2 / A3 / A4.
 
+pub mod enforcement;
 pub mod provider;
 pub mod registry;
 
+pub use enforcement::{EgressEnforcer, EgressWiring, EnforcementError};
 pub use provider::{NetHandle, NetworkError, NetworkProvider, NetworkSpec};
 pub use registry::NetworkProviderRegistry;

--- a/crates/mvm-network/src/provider.rs
+++ b/crates/mvm-network/src/provider.rs
@@ -3,6 +3,8 @@
 use mvm_core::network_policy::NetworkPolicy;
 use mvm_core::protocol::vm_backend::VmId;
 
+use crate::enforcement::EgressEnforcer;
+
 /// Host-side description of the network to provision for a VM.
 ///
 /// `policy` is the per-VM host egress policy the provider enforces (iptables
@@ -73,6 +75,15 @@ pub trait NetworkProvider: Send + Sync {
 
     /// Tear the VM's network down, consuming its handle.
     fn teardown(&self, handle: NetHandle) -> Result<(), NetworkError>;
+
+    /// The host-egress enforcer this provider drives, if any. `None` (default)
+    /// means the provider self-enforces inside `provision` — the Firecracker
+    /// iptables path (`BridgeTapNetworkProvider`). A libkrun gvproxy/passt
+    /// provider (L3) returns `Some(..)` so the supervisor's firewall/L4/L7
+    /// enforce on the gateway bridge (plan 123 A2).
+    fn egress_enforcer(&self) -> Option<&dyn EgressEnforcer> {
+        None
+    }
 }
 
 #[cfg(test)]


### PR DESCRIPTION
Plan 123 Phase A lift — **A2.1**: introduce the `EgressEnforcer` seam so the supervisor's host-egress enforcement sits behind the `NetworkProvider` layer, **purely additively** (no live call path changes yet).

### What's here
- **`mvm-network/src/enforcement.rs` (new, low crate):** the `EgressEnforcer` trait + `EgressWiring` + `EnforcementError`, over the same `mvm_core::network_policy::NetworkPolicy` the `NetworkSpec` carries (whose `Default` is `deny_all()`, claim 10). No new deps; no I/O.
- **`NetworkProvider::egress_enforcer()`** — defaulted to `None` (the Firecracker provider self-enforces in `provision`; a future libkrun provider returns `Some(..)`). Existing impls compile unchanged.
- **`mvm-hostd` `SupervisorEgressEnforcer`** — adapts the existing `FirewallEnforcer` to the seam (`EgressWiring`→`FirewallSpec`; `enforce`→`install_default_deny`, `withdraw`→`teardown`), translating `FirewallError` so the fail-closed `NotWired` posture survives. `mvm-hostd` gains an **acyclic** `mvm-network` dep (HIGH→LOW).

### Security + verification
- **No live path changed** — `Supervisor::launch`'s `install_default_deny` call is untouched (rerouting it through the seam is A2.2).
- **Claim-10 intact:** the two catalog witnesses (`policy_default_is_deny_all`, `test_resolve_network_policy_default_is_deny_all`) live in mvm-core/mvm-cli and aren't touched; `xtask check-claim-catalog` stays green by construction.
- All **25 mvm-hostd firewall tests** (existing witnesses + 2 new adapter tests) pass; mvm-network 5/5 (incl. `noop_enforcer_fails_closed`); clippy `-D warnings` + nightly rustfmt clean.

### Next (A2.2)
Reroute `Supervisor::launch` through `provider.egress_enforcer()`, then A3 widens `EgressEnforcer` for Plan 129's substitution/scan hooks on Plan 141's packet pipeline.
