### PR TITLE
feat(network): Plan 123 A2.2 — route supervisor enforce-on-launch through the seam

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3255,6 +3255,7 @@ dependencies = [
  "mvm",
  "mvm-backend",
  "mvm-core",
+ "mvm-network",
  "mvm-sdk",
  "mvm-verify",
  "rand 0.8.6",

--- a/crates/mvm-hostd/src/supervisor/aggregate.rs
+++ b/crates/mvm-hostd/src/supervisor/aggregate.rs
@@ -26,8 +26,10 @@ use mvm_sdk::compile::deps_audit::{VolumeError, verify_sealed_volume};
 use thiserror::Error;
 use tracing::warn;
 
+use mvm_core::network_policy::NetworkPolicy;
 use mvm_core::plan::Variant;
 use mvm_core::policy::{DEFAULT_BODY_CAP_BYTES, EgressPolicy, ToolPolicy};
+use mvm_network::{EgressEnforcer, EgressWiring, EnforcementError};
 
 use crate::supervisor::artifact::{ArtifactCollector, NoopArtifactCollector};
 use crate::supervisor::audit::{AuditSigner, NoopAuditSigner};
@@ -35,6 +37,7 @@ use crate::supervisor::backend::{BackendError, BackendLauncher, NoopBackendLaunc
 use crate::supervisor::circuit_breaker::{CircuitBreaker, InspectorReporter};
 use crate::supervisor::destination::DestinationPolicy;
 use crate::supervisor::egress::{EgressProxy, NoopEgressProxy};
+use crate::supervisor::firewall::seam::SupervisorEgressEnforcer;
 use crate::supervisor::firewall::{
     FirewallEnforcer, FirewallError, FirewallSpec, NoopFirewallEnforcer,
 };
@@ -84,6 +87,9 @@ pub enum SupervisorError {
 
     #[error("firewall error: {0}")]
     Firewall(#[from] FirewallError),
+
+    #[error("egress enforcement error: {0}")]
+    EgressEnforcement(#[from] EnforcementError),
 
     #[error("firewall proxy interface not configured")]
     FirewallProxyIfaceMissing,
@@ -422,10 +428,22 @@ impl Supervisor {
                 .await?;
             return Err(SupervisorError::from(e));
         }
-        if let Err(e) = self.firewall.install_default_deny(&firewall_spec) {
+        // Install host-side default-deny *through the EgressEnforcer seam*
+        // (plan 123 A2.2): the supervisor enforces behind the trait instead of
+        // calling the firewall directly. `SupervisorEgressEnforcer` delegates
+        // to the same `install_default_deny`, so behaviour + the fail-closed
+        // `NotWired` posture are unchanged.
+        let egress_wiring = EgressWiring {
+            vm_id: firewall_spec.vm_id.clone(),
+            tap_iface: firewall_spec.tap_iface.clone(),
+            proxy_iface: firewall_spec.proxy_iface.clone(),
+        };
+        if let Err(e) = SupervisorEgressEnforcer::new(self.firewall.clone())
+            .enforce(&egress_wiring, &NetworkPolicy::deny_all())
+        {
             self.emit_audit_then_fail(&plan, "plan.rejected.firewall", &e.to_string())
                 .await?;
-            return Err(SupervisorError::from(e));
+            return Err(SupervisorError::EgressEnforcement(e));
         }
         self.installed_firewalls
             .insert(plan.plan_id.clone(), firewall_spec);
@@ -1443,7 +1461,10 @@ mod tests {
 
         let result = s.launch(&signed, &[("test", &vk)]).await;
 
-        assert!(matches!(result, Err(SupervisorError::Firewall(_))));
+        // The install now flows through the EgressEnforcer seam (A2.2), so a
+        // firewall failure surfaces as `Egress` — but the underlying
+        // `install_default_deny` is still invoked (asserted below).
+        assert!(matches!(result, Err(SupervisorError::EgressEnforcement(_))));
         assert_eq!(s.state.current(), PlanState::Failed);
         assert_eq!(backend.prepares(), vec![plan.plan_id.clone()]);
         assert!(backend.launches().is_empty());


### PR DESCRIPTION
Plan 123 Phase A lift — **A2.2**: route the supervisor's enforce-on-launch through the `EgressEnforcer` seam (the first *live-path* change after A2.1's additive seam). Builds on #632 (A2.1), now in main.

### What's here
- **`Supervisor::launch`** now installs host default-deny via **`SupervisorEgressEnforcer`** (the A2.1 adapter) instead of calling `FirewallEnforcer::install_default_deny` directly — enforcement now flows *behind the trait*.
- New **`SupervisorError::EgressEnforcement`** variant for the seam path; **spec-derivation errors stay `Firewall`** (distinct from the existing `Egress(String)` egress-proxy variant).

### Security + behavior preserved
- **No behavior change:** the adapter delegates to the same `install_default_deny`, so the rules + the **fail-closed `NotWired` posture** are identical — the underlying `firewall.installs()` assertion in the install-failure test still passes.
- **Tests:** `firewall_install_failure_blocks_backend_launch` now expects `EgressEnforcement`; `invalid_backend_slot_blocks_before_install_and_backend_launch` (spec-derivation failure) **stays `Firewall`** — confirming the two error paths are correctly distinguished.
- Claim-10 catalog witnesses untouched; clippy `-D warnings` + firewall/aggregate tests + nightly fmt green.

### Deferred
- The two `firewall.teardown` sites stay direct for now (one returns `Firewall` and is more entangled) — **A2.3**.
- Then **A3**: widen `EgressEnforcer` for Plan 129's substitution/scan hooks on Plan 141's packet pipeline (the unblock-129 payoff).

Also carries the `mvm-hostd`→`mvm-network` `Cargo.lock` edge that #632 left out (non-fatal; cargo auto-regenerates).
