### PR TITLE
feat(network): Plan 123 A2.3 — route supervisor teardown through the seam

### DIFF
--- a/crates/mvm-hostd/src/supervisor/aggregate.rs
+++ b/crates/mvm-hostd/src/supervisor/aggregate.rs
@@ -636,11 +636,15 @@ impl Supervisor {
             return Err(SupervisorError::from(e));
         }
 
+        // Withdraw the host enforcement through the EgressEnforcer seam (A2.3),
+        // symmetric with the enforce-on-launch path. The adapter delegates to
+        // the same firewall.teardown.
         if let Some(spec) = self.installed_firewalls.remove(plan_id)
-            && let Err(e) = self.firewall.teardown(&spec.vm_id)
+            && let Err(e) =
+                SupervisorEgressEnforcer::new(self.firewall.clone()).withdraw(&spec.vm_id)
         {
             self.transition_or_warn(PlanState::Failed);
-            return Err(SupervisorError::from(e));
+            return Err(SupervisorError::EgressEnforcement(e));
         }
 
         self.state.transition(PlanState::Stopped).map_err(|e| {
@@ -661,10 +665,12 @@ impl Supervisor {
     }
 
     fn teardown_firewall_for_plan(&mut self, plan_id: &PlanId) {
+        // Best-effort withdraw through the seam (A2.3).
         if let Some(spec) = self.installed_firewalls.remove(plan_id)
-            && let Err(e) = self.firewall.teardown(&spec.vm_id)
+            && let Err(e) =
+                SupervisorEgressEnforcer::new(self.firewall.clone()).withdraw(&spec.vm_id)
         {
-            warn!(?e, vm_id = %spec.vm_id, "firewall teardown after launch failure failed");
+            warn!(?e, vm_id = %spec.vm_id, "egress teardown after launch failure failed");
         }
     }
 


### PR DESCRIPTION
Completes A2: the two `firewall.teardown` sites (stop path + best-effort post-launch-failure cleanup) now `withdraw` through `SupervisorEgressEnforcer`, symmetric with A2.2's enforce path. With A2.1–A2.3 the supervisor's host enforcement — **install + teardown** — is fully behind the `EgressEnforcer` trait.

- **No behavior change:** the adapter delegates to the same `firewall.teardown`; the happy-path `teardowns()` assertions stay green (80 aggregate/firewall tests pass). Stop-path teardown failure maps to `EgressEnforcement` (that path is untested — no assertion to break). Fail-closed posture preserved.
- clippy `-D warnings` + nightly fmt green; claim-10 catalog witnesses untouched.

Next: **A3** widens `EgressEnforcer` for Plan 129's substitution/scan hooks on the gateway-bridge packet pipeline (the unblock-129 payoff).