### PR TITLE
feat(network): Plan 123 A3.1 — SubstitutionStage + ScanStage egress seams (no-op)

### DIFF
--- a/crates/mvm-hostd/src/supervisor/network/mod.rs
+++ b/crates/mvm-hostd/src/supervisor/network/mod.rs
@@ -44,6 +44,8 @@ pub mod flow_byte_log;
 pub mod latency;
 pub mod packet;
 pub mod pipeline;
+/// plan 123 A3 — Plan 129 substitution/scan egress-proxy seams.
+pub mod stages;
 
 /// Maximum number of observers per VM. ADR-064 §Decision: hard cap of 8
 /// (each observer is a synchronous callback in the signer task's hot path;

--- a/crates/mvm-hostd/src/supervisor/network/stages.rs
+++ b/crates/mvm-hostd/src/supervisor/network/stages.rs
@@ -1,0 +1,95 @@
+//! Plan 129 egress-proxy seams (plan 123 Phase A / A3): two pluggable stages
+//! on the per-packet egress path. **No-op by default** — Plan 129 supplies the
+//! real handlers later. These are designed to run *inside*
+//! `run_packet_pipeline` (the claim-10 egress chokepoint every guest byte
+//! transits), so they are never a bypass.
+//!
+//! A3.1 (this) introduces the seam: the traits + no-op defaults. A3.2 wires
+//! them into the pipeline runner + the gateway bridge (substitution maps to the
+//! existing `Verdict::Modify` rebuild path; a scan `Drop` maps to the same
+//! fail-closed kill the observers use).
+
+use crate::supervisor::network::PacketCtx;
+use crate::supervisor::network::packet::ParsedPacket;
+
+/// Outcome of the scan stage. `Pass` forwards the packet; `Drop` kills the
+/// flow — the same fail-closed path as `Verdict::Drop`.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ScanOutcome {
+    Pass,
+    Drop,
+}
+
+/// Rewrites outbound L4 payload bytes when a secret binding applies (Plan 129
+/// substitution). The default is pass-through.
+pub trait SubstitutionStage: Send + Sync {
+    /// Stable identifier for audit / metrics.
+    fn name(&self) -> &'static str;
+
+    /// Return `Some(new_payload)` to rewrite the outbound L4 payload, or `None`
+    /// to pass it through unchanged.
+    fn substitute(&self, _ctx: &PacketCtx<'_>, _pkt: &ParsedPacket<'_>) -> Option<Vec<u8>> {
+        None
+    }
+}
+
+/// Observes the outbound payload and may request a drop (Plan 129 leak-scan).
+/// The default observes nothing and always passes.
+pub trait ScanStage: Send + Sync {
+    /// Stable identifier for audit / metrics.
+    fn name(&self) -> &'static str;
+
+    fn scan(&self, _ctx: &PacketCtx<'_>, _pkt: &ParsedPacket<'_>) -> ScanOutcome {
+        ScanOutcome::Pass
+    }
+}
+
+/// Default no-op substitution: never rewrites.
+pub struct NoopSubstitution;
+
+impl SubstitutionStage for NoopSubstitution {
+    fn name(&self) -> &'static str {
+        "noop-substitution"
+    }
+}
+
+/// Default no-op scan: never drops.
+pub struct NoopScan;
+
+impl ScanStage for NoopScan {
+    fn name(&self) -> &'static str {
+        "noop-scan"
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::supervisor::network::FlowDirection;
+    use crate::supervisor::network::packet::{FiveTuple, L4Proto};
+
+    #[test]
+    fn noop_stages_pass_through_and_never_drop() {
+        let pkt = ParsedPacket {
+            five_tuple: FiveTuple {
+                proto: L4Proto::Tcp,
+                src_ip: "10.0.0.2".parse().unwrap(),
+                dst_ip: "1.1.1.1".parse().unwrap(),
+                src_port: 5000,
+                dst_port: 443,
+            },
+            l4_payload: b"hello-SECRET",
+            raw_frame: b"hello-SECRET",
+        };
+        let ctx = PacketCtx {
+            vm_name: "vm",
+            tenant: "t",
+            direction: FlowDirection::Egress,
+            flow_id: "vm-egress",
+        };
+        // No binding applies → no rewrite; scan never drops. This is the
+        // claim-10-safe default posture before Plan 129 plugs in real handlers.
+        assert_eq!(NoopSubstitution.substitute(&ctx, &pkt), None);
+        assert_eq!(NoopScan.scan(&ctx, &pkt), ScanOutcome::Pass);
+    }
+}


### PR DESCRIPTION
Plan 123 Phase A lift — **A3.1**: introduce the Plan 129 egress-proxy seam, additively (no-op by default), where the design verdict says it belongs.

### What's here
- New `network/stages.rs`: **`SubstitutionStage`** (rewrite outbound L4 payload when a secret binding applies; default pass-through) + **`ScanStage`** (observe + maybe `Drop`; default pass) + `ScanOutcome`, with no-op defaults `NoopSubstitution`/`NoopScan`.
- Lives in **mvm-hostd next to the Plan 141 packet pipeline** (the traits operate on `ParsedPacket`/`PacketCtx`, mvm-hostd types) — not low `mvm-network`.

### Why here (claim-10)
The design confirmed the 129 hooks must attach **inside `run_packet_pipeline`** — the live egress chokepoint every guest byte transits (`gateway_bridge.rs`), per the libkrun-supervisor's own "claim-10 substrate path" doc — **not** the L7 inspector chain, which is off the default byte path (`NoopEgressProxy`) and therefore bypassable. A3.1 only introduces the seam; **A3.2** wires it into the pipeline (substitute→`Verdict::Modify`, scan `Drop`→the existing fail-closed kill).

### Verification
clippy `-D warnings` + a real no-op-behaviour test (no binding → no rewrite; scan → Pass) + **8 pipeline guard tests stay green** (the new module doesn't perturb the `Observer`/`Verdict` pipeline) + nightly fmt.