### PR TITLE
feat(network): Plan 123 L3 slice A — libkrun gvproxy/passt NetworkProvider

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3098,6 +3098,7 @@ dependencies = [
  "lzma-rs",
  "mvm-core",
  "mvm-guest",
+ "mvm-network",
  "mvm-sdk",
  "nix 0.29.0",
  "rand 0.8.6",

--- a/crates/mvm-build/Cargo.toml
+++ b/crates/mvm-build/Cargo.toml
@@ -51,6 +51,11 @@ lzma-rs = "0.3"
 
 mvm-core.workspace = true
 mvm-guest.workspace = true
+# plan 123 A/L3 — `LibkrunNetworkProvider` impls the `NetworkProvider`
+# seam. mvm-network deps only mvm-core + mvm-sdk, so this edge is acyclic.
+# Optional + folded into `builder-vm`: the provider is gated with
+# `libkrun_builder`, so a default build pulls neither.
+mvm-network = { workspace = true, optional = true }
 # Plan 73 Followup B.1 — `install_app_deps` reuses
 # `mvm_sdk::compile::deps_audit::{verify_sealed_volume, VolumeError}`
 # for cache-hit verification. The orchestrator owns the cache
@@ -129,7 +134,7 @@ dev-shell = []
 # `mvm-libkrun` FFI crate which itself gates the underlying
 # `libkrun-sys` bindings.
 contributor-bootstrap = []
-builder-vm = ["dep:libkrun-sys"]
+builder-vm = ["dep:libkrun-sys", "dep:mvm-network"]
 
 [lints]
 workspace = true

--- a/crates/mvm-build/src/lib.rs
+++ b/crates/mvm-build/src/lib.rs
@@ -56,6 +56,11 @@ pub mod host_gvproxy;
 #[cfg(feature = "builder-vm")]
 pub mod libkrun_builder;
 
+/// plan 123 Phase A / L3 — the libkrun gvproxy/passt `NetworkProvider` impl.
+/// Gated with `libkrun_builder`: it wraps that module's gateway selection.
+#[cfg(feature = "builder-vm")]
+pub mod libkrun_network_provider;
+
 /// Plan 97 Phase C — Vz-backed builder VM (gated by
 /// `builder-vm` for symmetry with `libkrun_builder`). Implements
 /// the second [`builder_vm::VmBackendForBuilder`] impl alongside

--- a/crates/mvm-build/src/libkrun_network_provider.rs
+++ b/crates/mvm-build/src/libkrun_network_provider.rs
@@ -1,0 +1,137 @@
+//! `LibkrunNetworkProvider` — the mvm-build impl of
+//! [`mvm_network::NetworkProvider`] for the libkrun gvproxy/passt path (macOS
+//! libkrun + Linux libkrun).
+//!
+//! Unlike the Firecracker `BridgeTapNetworkProvider`, which owns a host bridge
+//! + TAP, this provider owns **no host resource**. A libkrun guest's egress is
+//! the in-process gateway bridge reached via gvproxy (macOS) or passt (Linux),
+//! and that gateway's child process + unix sockets are spawned and reaped
+//! *inside the supervisor process* (`mvm-libkrun-supervisor`), not here. So
+//! `provision` is a pure config *selection* — which gateway — and `teardown`
+//! is a no-op. The actual `krun_add_net_*` wiring happens later, when the
+//! supervisor consumes the resolved [`NetworkingPreference`].
+//!
+//! claim-10: the provider only chooses between the two existing gvproxy/passt →
+//! gateway-bridge paths; there is no no-gateway / TSI bypass to select (Plan
+//! 102 W6.A removed TSI). Every guest byte still transits the gateway-bridge
+//! chokepoint, so routing the selection through the trait does not move the
+//! enforcement point.
+//!
+//! Scope (L3 slice A): this is the additive provider only. The two live
+//! selection sites still inline their own choice and **diverge** — the workload
+//! path (`mvm_backend::libkrun::build_supervisor_config`) hardcodes
+//! `cfg!(target_os = "macos")` (per-OS default, ignores `MVM_NETWORKING`),
+//! while the builder path ([`apply_networking_mode`](crate::libkrun_builder))
+//! honors `MVM_NETWORKING` via [`resolve_networking_mode`]. Re-pointing both
+//! through this provider (slice B) must first reconcile that divergence, so it
+//! is deferred rather than silently changing the workload selection.
+
+use mvm_core::network_policy::NetworkPolicy;
+use mvm_core::protocol::vm_backend::VmId;
+use mvm_network::{NetHandle, NetworkError, NetworkProvider, NetworkSpec};
+
+use crate::libkrun_builder::{NetworkingPreference, resolve_networking_mode};
+
+/// libkrun gvproxy/passt network provider (a config producer; owns no host
+/// state — see the module docs).
+pub struct LibkrunNetworkProvider {
+    /// The provider's advertised default — `deny_all()` (claim 10). The
+    /// effective per-VM policy arrives via [`NetworkSpec`] on `provision`.
+    default_policy: NetworkPolicy,
+}
+
+impl LibkrunNetworkProvider {
+    pub fn new() -> Self {
+        Self {
+            default_policy: NetworkPolicy::deny_all(),
+        }
+    }
+
+    /// Stable kind string for a resolved gateway preference — the `tag`
+    /// `provision` mints and the supervisor's config build keys on.
+    fn gateway_kind(pref: NetworkingPreference) -> &'static str {
+        match pref {
+            NetworkingPreference::Gvproxy => "gvproxy",
+            NetworkingPreference::Passt => "passt",
+        }
+    }
+}
+
+impl Default for LibkrunNetworkProvider {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl NetworkProvider for LibkrunNetworkProvider {
+    fn kind(&self) -> &str {
+        "libkrun"
+    }
+
+    fn provision(&self, vm: &VmId, _spec: &NetworkSpec) -> Result<NetHandle, NetworkError> {
+        // Pure selection: resolve the per-OS / MVM_NETWORKING gateway. No host
+        // syscalls — the gvproxy/passt child + krun_add_net_* run later, inside
+        // the supervisor process, from this preference.
+        Ok(NetHandle {
+            vm: vm.clone(),
+            tag: Self::gateway_kind(resolve_networking_mode()).to_string(),
+        })
+    }
+
+    fn policy(&self) -> &NetworkPolicy {
+        &self.default_policy
+    }
+
+    fn teardown(&self, _handle: NetHandle) -> Result<(), NetworkError> {
+        // No host resource to reap: the gateway child + its unix sockets live
+        // inside the supervisor process and Drop on guest exit. Contrast
+        // BridgeTapNetworkProvider, which must cleanup_network_policy + destroy
+        // the TAP here.
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use mvm_core::network_policy::NetworkPolicy;
+    use mvm_core::protocol::vm_backend::VmId;
+    use mvm_network::{NetworkProvider, NetworkSpec};
+
+    #[test]
+    fn provision_tags_handle_with_a_known_gateway() {
+        let provider = LibkrunNetworkProvider::new();
+        let handle = provider
+            .provision(&VmId("vm".to_string()), &NetworkSpec::default())
+            .unwrap();
+        // The tag is the resolved gateway kind; no host resource is provisioned,
+        // so teardown is a clean no-op.
+        assert!(["gvproxy", "passt"].contains(&handle.tag.as_str()));
+        assert_eq!(handle.vm.0, "vm");
+        assert!(provider.teardown(handle).is_ok());
+    }
+
+    #[test]
+    fn gateway_kind_maps_each_preference() {
+        // Deterministic mapping, independent of host OS / MVM_NETWORKING.
+        assert_eq!(
+            LibkrunNetworkProvider::gateway_kind(NetworkingPreference::Gvproxy),
+            "gvproxy"
+        );
+        assert_eq!(
+            LibkrunNetworkProvider::gateway_kind(NetworkingPreference::Passt),
+            "passt"
+        );
+    }
+
+    #[test]
+    fn kind_is_libkrun_policy_is_deny_all_no_separate_enforcer() {
+        let provider = LibkrunNetworkProvider::new();
+        assert_eq!(provider.kind(), "libkrun");
+        // claim-10: advertised default is deny-all, opening egress is opt-in.
+        assert_eq!(*provider.policy(), NetworkPolicy::deny_all());
+        // libkrun's chokepoint is the supervisor's in-process gateway-bridge
+        // FlowPolicy, not a separate EgressEnforcer object → None (default).
+        assert!(provider.egress_enforcer().is_none());
+    }
+}

--- a/crates/mvm-network/src/provider.rs
+++ b/crates/mvm-network/src/provider.rs
@@ -77,10 +77,12 @@ pub trait NetworkProvider: Send + Sync {
     fn teardown(&self, handle: NetHandle) -> Result<(), NetworkError>;
 
     /// The host-egress enforcer this provider drives, if any. `None` (default)
-    /// means the provider self-enforces inside `provision` — the Firecracker
-    /// iptables path (`BridgeTapNetworkProvider`). A libkrun gvproxy/passt
-    /// provider (L3) returns `Some(..)` so the supervisor's firewall/L4/L7
-    /// enforce on the gateway bridge (plan 123 A2).
+    /// means egress is enforced by a mechanism the provider does not own as a
+    /// separate object: the Firecracker `BridgeTapNetworkProvider` self-enforces
+    /// iptables inside `provision`, and the libkrun gvproxy/passt provider (L3)
+    /// relies on the supervisor's in-process gateway-bridge `FlowPolicy`
+    /// chokepoint. A provider returns `Some(..)` only when it drives a distinct
+    /// [`EgressEnforcer`] object (plan 123 A2's `SupervisorEgressEnforcer`).
     fn egress_enforcer(&self) -> Option<&dyn EgressEnforcer> {
         None
     }


### PR DESCRIPTION
L3 slice A. `LibkrunNetworkProvider` impls `mvm_network::NetworkProvider` for the libkrun path — the gvproxy/passt counterpart to L1's Firecracker `BridgeTapNetworkProvider`.

**Key asymmetry vs L1:** libkrun owns **no host resource**. The gvproxy/passt gateway child + unix sockets live *inside the supervisor process* (`mvm-libkrun-supervisor`), so:
- `provision()` is a pure gateway **selection** (`resolve_networking_mode` → `"gvproxy"`/`"passt"` tag) — no host syscalls.
- `teardown()` is a **no-op** (nothing to reap; contrast L1's `cleanup_network_policy` + `tap_destroy`).
- `policy()` = `deny_all()` (claim 10); `egress_enforcer()` = `None`.

**claim-10 intact:** the provider only chooses between the two existing gvproxy/passt → gateway-bridge paths — no no-gateway/TSI bypass exists to select (Plan 102 W6.A removed TSI). Every guest byte still transits the gateway-bridge chokepoint. The trait doc on `egress_enforcer()` is corrected: libkrun's enforcement is the supervisor's in-process gateway-bridge `FlowPolicy`, not a separate `EgressEnforcer` (it had speculated L3 would return `Some`).

**Lives in `mvm-build` (Vz-free)** so the 3 tests **run locally** (unlike L1, whose crate SIGKILLs on macOS codesign): provision-tags-known-gateway + teardown-no-op, `gateway_kind` mapping, kind/deny-all/no-enforcer. TDD (provision test written first, watched fail). `mvm-network` is an optional dep folded into `builder-vm` — a default build pulls neither. clippy `-D warnings` + nightly fmt.

**Deferred — slice B (wire-through):** re-point the two live selection sites through the provider. They currently **diverge** — the workload site (`mvm_backend::libkrun::build_supervisor_config`, `libkrun.rs:107`) hardcodes `cfg!(target_os = "macos")` and **ignores `MVM_NETWORKING`**, while the builder site honors it via `resolve_networking_mode`. Re-pointing both is therefore *not* a faithful no-op refactor (it would change the workload's selection, with a macOS+passt footgun), so it's held for a follow-up that reconciles the divergence first.