### PR TITLE
feat: Plan 123 Slice 3 (a)+(b) — de-conflate bundle_json + wire the tenant PolicyBundle to the bridge

### DIFF
--- a/crates/mvm-cli/src/commands/ops/bench_probe.rs
+++ b/crates/mvm-cli/src/commands/ops/bench_probe.rs
@@ -129,7 +129,7 @@ pub fn boot_measure_once(vm_name: &str) -> Result<BootMarks> {
         memory_mib: 512,
         ..Default::default()
     };
-    populate_audit_substrate(&mut cfg, &admitted)?;
+    populate_audit_substrate(&mut cfg, &admitted, None)?;
 
     let backend = mvm_backend::LibkrunBackend;
     let start = Instant::now();

--- a/crates/mvm-cli/src/commands/vm/plan_admission.rs
+++ b/crates/mvm-cli/src/commands/vm/plan_admission.rs
@@ -50,6 +50,7 @@ use mvm_core::plan::{
     ExecutionPlan, NonceStore, PlanId, PlanValidityError, SignedExecutionPlan, check_window,
     sign_plan, verify_plan, verify_plan_bundle,
 };
+use mvm_core::policy::PolicyBundle;
 use std::sync::Mutex;
 
 use super::host_signer::host_signer_id;
@@ -246,6 +247,7 @@ const BUNDLE_JSON_MAX_BYTES: usize = 4 * 1024 * 1024;
 pub fn populate_audit_substrate(
     cfg: &mut mvm_core::vm_backend::VmStartConfig,
     admitted: &AdmittedPlan,
+    policy_bundle: Option<&PolicyBundle>,
 ) -> Result<()> {
     cfg.tenant_id = Some(admitted.plan.tenant.0.clone());
 
@@ -260,10 +262,17 @@ pub fn populate_audit_substrate(
     }
     cfg.plan_json = Some(plan_json);
 
-    cfg.bundle_json = match admitted.plan.bundle.as_ref() {
-        Some(pin) => {
-            let bj = serde_json::to_string(pin)
-                .context("serializing PlanArtifact bundle pin for VmStartConfig.bundle_json")?;
+    // `bundle_json` carries the resolved tenant **PolicyBundle** (network /
+    // egress / tool policy) that the supervisor's L4 gate + observers consume.
+    // It is NOT the ExecutionPlan's `.mvmpkg` artifact pin
+    // (`admitted.plan.bundle`, a `PlanArtifact` — content-addressed
+    // kernel/rootfs, verified separately at admit time via `verify_plan_bundle`).
+    // Feeding the pin here was a conflation the supervisor's PolicyBundle decode
+    // would reject. `None` until a policy-bundle source is wired (Slice 3 (b)).
+    cfg.bundle_json = match policy_bundle {
+        Some(bundle) => {
+            let bj = serde_json::to_string(bundle)
+                .context("serializing PolicyBundle for VmStartConfig.bundle_json")?;
             if bj.len() > BUNDLE_JSON_MAX_BYTES {
                 anyhow::bail!(
                     "bundle_json exceeds {} byte cap (got {}); refusing",
@@ -844,7 +853,7 @@ mod tests {
         .expect("happy admit");
 
         let mut cfg = VmStartConfig::default();
-        populate_audit_substrate(&mut cfg, &admitted).expect("populate");
+        populate_audit_substrate(&mut cfg, &admitted, None).expect("populate");
         assert_eq!(
             cfg.tenant_id.as_deref(),
             Some(admitted.plan.tenant.0.as_str())
@@ -862,6 +871,53 @@ mod tests {
         assert_eq!(recovered.plan_id, admitted.plan_id);
         // fixture has no bundle pin, so bundle_json stays None
         assert!(cfg.bundle_json.is_none());
+    }
+
+    #[test]
+    fn bundle_json_carries_a_policy_bundle_not_the_artifact_pin() {
+        // Slice 3 (a) de-conflation: bundle_json is the tenant PolicyBundle the
+        // supervisor's L4 gate + observers consume — sourced from the
+        // policy_bundle arg, NOT from `admitted.plan.bundle` (the .mvmpkg
+        // PlanArtifact pin, a different bundle verified separately).
+        use mvm_core::vm_backend::VmStartConfig;
+        let dir = tempfile::tempdir().unwrap();
+        let clock = SystemClock;
+        let ledger = InMemoryNonceLedger::new();
+        let admitted = admit_for_run(
+            &fixture_input("vm-policy-bundle"),
+            &clock,
+            &ledger,
+            Some(dir.path()),
+            None,
+        )
+        .expect("happy admit");
+
+        let bundle = mvm_core::policy::PolicyBundle {
+            schema_version: mvm_core::policy::SCHEMA_VERSION,
+            bundle_id: mvm_core::policy::PolicyId("test".into()),
+            bundle_version: 1,
+            network: Default::default(),
+            egress: Default::default(),
+            pii: Default::default(),
+            tool: Default::default(),
+            artifact: Default::default(),
+            keys: Default::default(),
+            audit: Default::default(),
+            tenant_overlays: std::collections::BTreeMap::new(),
+        };
+
+        let mut cfg = VmStartConfig::default();
+        populate_audit_substrate(&mut cfg, &admitted, Some(&bundle)).expect("populate");
+        let bj = cfg.bundle_json.expect("bundle_json populated");
+        let roundtrip: mvm_core::policy::PolicyBundle =
+            serde_json::from_str(&bj).expect("bundle_json deserializes as a PolicyBundle");
+        assert_eq!(roundtrip, bundle);
+
+        // No policy bundle → None (the de-conflated default; a pinned artifact
+        // no longer leaks into this field).
+        let mut cfg2 = VmStartConfig::default();
+        populate_audit_substrate(&mut cfg2, &admitted, None).expect("populate none");
+        assert!(cfg2.bundle_json.is_none());
     }
 
     // ───────────────────────────────────────────────────────────────

--- a/crates/mvm-cli/src/commands/vm/policy_resolver.rs
+++ b/crates/mvm-cli/src/commands/vm/policy_resolver.rs
@@ -401,6 +401,38 @@ pub fn resolve_supervisor_components_with_dir(
     }
 }
 
+/// Load the tenant `PolicyBundle` a plan resolves to, for delivery to the
+/// supervisor's L4 gate + observers via `VmStartConfig.bundle_json` (plan 123
+/// Slice 3 (b)). `None` for a local-default plan — no per-tenant policy, so the
+/// bridge enforces mandatory-deny only. Errors identically to
+/// [`resolve_supervisor_components`] on a missing or malformed bundle, so
+/// admission fails closed before boot.
+pub fn resolve_policy_bundle(
+    plan: &ExecutionPlan,
+) -> Result<Option<mvm_core::policy::PolicyBundle>, ResolveError> {
+    resolve_policy_bundle_with_dir(plan, &default_policy_dir())
+}
+
+/// Test seam for [`resolve_policy_bundle`] — same, with a caller-supplied
+/// policy-bundle base dir instead of `$HOME/.mvm/policies`.
+pub fn resolve_policy_bundle_with_dir(
+    plan: &ExecutionPlan,
+    base_dir: &std::path::Path,
+) -> Result<Option<mvm_core::policy::PolicyBundle>, ResolveError> {
+    let PolicyRef(network) = &plan.network_policy;
+    let FsPolicyRef(fs) = &plan.fs_policy;
+    let PolicyRef(egress) = &plan.egress_policy;
+    let PolicyRef(tool) = &plan.tool_policy;
+
+    match classify_plan_refs(network, fs, egress, tool)? {
+        RefShape::LocalDefault => Ok(None),
+        RefShape::TenantWorkload { tenant, workload } => Ok(Some(load_tenant_workload(
+            base_dir, network, tenant, workload,
+        )?)),
+        RefShape::Unrecognized => unreachable!("classify_plan_refs handled Unrecognized"),
+    }
+}
+
 fn noop_slots() -> ResolvedSlots {
     ResolvedSlots {
         network: Box::new(NoopL4Gate),
@@ -1419,6 +1451,39 @@ disabled_inspectors = [{list}]
 [audit]
 "#,
         )
+    }
+
+    #[test]
+    fn resolve_policy_bundle_loads_for_a_tenant_workload_plan() {
+        // Slice 3 (b): a tenant:workload plan resolves to the on-disk
+        // PolicyBundle the supervisor's L4 gate + observers consume.
+        let tmp = tempfile::tempdir().unwrap();
+        write_bundle(
+            tmp.path(),
+            "acme",
+            "web-worker",
+            &fixture_bundle_with_tool_allow("web_search"),
+        );
+        let mut plan = fixture_plan();
+        set_all_refs(&mut plan, "acme:web-worker");
+
+        let bundle = resolve_policy_bundle_with_dir(&plan, tmp.path())
+            .expect("resolve ok")
+            .expect("a tenant:workload plan yields a bundle");
+        let expected =
+            mvm_core::policy::toml_loader::load_bundle_from_path(tmp.path(), "acme", "web-worker")
+                .unwrap();
+        assert_eq!(bundle, expected);
+    }
+
+    #[test]
+    fn resolve_policy_bundle_is_none_for_local_default() {
+        // A local-default plan has no per-tenant policy → None (the bridge
+        // enforces mandatory-deny only); the policy dir is never touched.
+        let plan = fixture_plan();
+        let result = resolve_policy_bundle_with_dir(&plan, std::path::Path::new("/nonexistent"))
+            .expect("resolve ok");
+        assert!(result.is_none());
     }
 
     #[test]

--- a/crates/mvm-cli/src/commands/vm/up.rs
+++ b/crates/mvm-cli/src/commands/vm/up.rs
@@ -1393,7 +1393,7 @@ pub(super) fn cmd_run(params: RunParams<'_>) -> Result<()> {
         // the bridge-factory path. None keeps the legacy supervisor path
         // for no-admission flows.
         if let Some(ctx) = admission.as_ref() {
-            populate_audit_substrate(&mut start_config, &ctx.admitted)?;
+            populate_audit_substrate(&mut start_config, &ctx.admitted, None)?;
             // Plan 113 §Task 13 — Firecracker bridge sidecar reads
             // plan.json + bundle.json from the per-VM state dir at
             // spawn time. Stash them now (mode 0600, tmp+rename).
@@ -1874,7 +1874,7 @@ pub(super) fn cmd_run(params: RunParams<'_>) -> Result<()> {
             .map(|v| v == "1")
             .unwrap_or(false);
         if gateway_bridge_enabled && let Some(ctx) = admission_main.as_ref() {
-            populate_audit_substrate(&mut start_config, &ctx.admitted)?;
+            populate_audit_substrate(&mut start_config, &ctx.admitted, None)?;
             // Plan 113 §Task 13 — stash plan.json + bundle.json for the
             // Firecracker bridge sidecar to read at spawn time.
             stash_plan_for_bridge(&start_config)?;
@@ -2254,7 +2254,7 @@ pub(super) fn cmd_run(params: RunParams<'_>) -> Result<()> {
             // admission (watch_admission); same substrate threading as the
             // main path. None → legacy supervisor path.
             if let Some(ctx) = watch_admission.as_ref() {
-                populate_audit_substrate(&mut w_start_config, &ctx.admitted)?;
+                populate_audit_substrate(&mut w_start_config, &ctx.admitted, None)?;
                 // Plan 113 §Task 13 — re-stash plan.json + bundle.json
                 // for the Firecracker bridge sidecar on every watch-loop
                 // re-boot; the prior admission's files are stale.

--- a/crates/mvm-cli/src/commands/vm/up.rs
+++ b/crates/mvm-cli/src/commands/vm/up.rs
@@ -25,8 +25,8 @@ use super::plan_admission::{
 };
 use super::plan_builder::SynthesisInput;
 use super::policy_resolver::{
-    LOCAL_DEFAULT, ResolveError, resolve_supervisor_components,
-    resolve_supervisor_components_with_dir,
+    LOCAL_DEFAULT, ResolveError, resolve_policy_bundle, resolve_policy_bundle_with_dir,
+    resolve_supervisor_components, resolve_supervisor_components_with_dir,
 };
 use super::shared::{
     VmStartParams, VolumeSpec, clap_flake_ref, clap_port_spec, clap_vm_name, clap_volume_spec,
@@ -34,6 +34,7 @@ use super::shared::{
     parse_volume_spec, ports_to_drive_file, read_dir_to_drive_files, request_port_forward,
     resolve_flake_ref, resolve_network_policy, vm_volume_from_spec_validated, wait_for_guest_agent,
 };
+use mvm_core::policy::PolicyBundle;
 
 /// Inputs for [`admit_plan_for_boot`]. Grouped so the helper avoids
 /// the workspace `clippy::too_many_arguments = "deny"` ceiling and so
@@ -191,6 +192,9 @@ fn plan_seccomp_tier(
 pub(super) struct AdmissionContext {
     pub(super) admitted: AdmittedPlan,
     pub(super) emitter: AuditEmitter,
+    /// The resolved tenant `PolicyBundle` (Slice 3 (b)) the bridge enforces
+    /// per-tenant L4 egress against; `None` for a local-default plan.
+    pub(super) policy_bundle: Option<PolicyBundle>,
 }
 
 // allow(secret-debug): hand-written Debug elides the AuditEmitter's
@@ -387,7 +391,22 @@ fn admit_plan_for_boot(p: AdmitPlanForBootParams<'_>) -> Result<Option<Admission
     // loudly *now* instead of silently passing through with Noops.
     emit_policy_resolved(&admitted.plan, &emitter, resolved.slots_mode);
 
-    Ok(Some(AdmissionContext { admitted, emitter }))
+    // Slice 3 (b) — load the resolved tenant PolicyBundle (None for a
+    // local-default plan) so populate_audit_substrate can deliver it to the
+    // bridge for per-tenant L4 egress enforcement. resolve_policy_for_admission
+    // above already validated the refs, so a well-formed bundle won't surface a
+    // new error class here.
+    let policy_bundle = match p.policy_dir {
+        Some(dir) => resolve_policy_bundle_with_dir(&admitted.plan, dir),
+        None => resolve_policy_bundle(&admitted.plan),
+    }
+    .context("loading the tenant policy bundle for the bridge")?;
+
+    Ok(Some(AdmissionContext {
+        admitted,
+        emitter,
+        policy_bundle,
+    }))
 }
 
 #[derive(Debug)]
@@ -1393,7 +1412,7 @@ pub(super) fn cmd_run(params: RunParams<'_>) -> Result<()> {
         // the bridge-factory path. None keeps the legacy supervisor path
         // for no-admission flows.
         if let Some(ctx) = admission.as_ref() {
-            populate_audit_substrate(&mut start_config, &ctx.admitted, None)?;
+            populate_audit_substrate(&mut start_config, &ctx.admitted, ctx.policy_bundle.as_ref())?;
             // Plan 113 §Task 13 — Firecracker bridge sidecar reads
             // plan.json + bundle.json from the per-VM state dir at
             // spawn time. Stash them now (mode 0600, tmp+rename).
@@ -1874,7 +1893,7 @@ pub(super) fn cmd_run(params: RunParams<'_>) -> Result<()> {
             .map(|v| v == "1")
             .unwrap_or(false);
         if gateway_bridge_enabled && let Some(ctx) = admission_main.as_ref() {
-            populate_audit_substrate(&mut start_config, &ctx.admitted, None)?;
+            populate_audit_substrate(&mut start_config, &ctx.admitted, ctx.policy_bundle.as_ref())?;
             // Plan 113 §Task 13 — stash plan.json + bundle.json for the
             // Firecracker bridge sidecar to read at spawn time.
             stash_plan_for_bridge(&start_config)?;
@@ -2254,7 +2273,11 @@ pub(super) fn cmd_run(params: RunParams<'_>) -> Result<()> {
             // admission (watch_admission); same substrate threading as the
             // main path. None → legacy supervisor path.
             if let Some(ctx) = watch_admission.as_ref() {
-                populate_audit_substrate(&mut w_start_config, &ctx.admitted, None)?;
+                populate_audit_substrate(
+                    &mut w_start_config,
+                    &ctx.admitted,
+                    ctx.policy_bundle.as_ref(),
+                )?;
                 // Plan 113 §Task 13 — re-stash plan.json + bundle.json
                 // for the Firecracker bridge sidecar on every watch-loop
                 // re-boot; the prior admission's files are stale.


### PR DESCRIPTION
Completes the bundle-content delivery that activates Slice 3's per-tenant L4 egress enforcement.

## (a) De-conflate `bundle_json` — carry the PolicyBundle, not the artifact pin
`populate_audit_substrate` serialized `admitted.plan.bundle` (a `PlanArtifact` *pin* — the `.mvmpkg` content-addressed kernel/rootfs) into `bundle_json`, but the supervisor decodes `bundle_json` as a **`PolicyBundle`** (tenant network/egress/tool policy). Two different "bundle" concepts — the decode would crash if a pin ever arrived (dormant only because `admitted.plan.bundle` is always `None`). The artifact pin is verified separately at admit time via `verify_plan_bundle`; it never needed to reach the supervisor. Now `populate_audit_substrate` takes `Option<&PolicyBundle>` and serializes that.

## (b) Wire a real PolicyBundle source
`resolve_policy_bundle` loads the tenant `PolicyBundle` a plan resolves to (`~/.mvm/policies/<tenant>/<workload>.toml` via the existing `load_tenant_workload`); `None` for a local-default plan. `admit_plan_for_boot` stashes it on `AdmissionContext.policy_bundle`; the three `up.rs` call sites thread it to `bundle_json`.

**Chain now live end-to-end:**
```
mvmctl up (tenant:workload) → resolve_policy_bundle → AdmissionContext
  → bundle_json → SupervisorConfig.bundle → BridgeConfig.bundle
  → Slice 3 (#649) resolve → L4Policy → L4PolicyScan  (enforces under mandatory-deny)
```
A **local-default** plan → `None` → mandatory-deny only (no behaviour change). Missing/malformed bundle → admission fails closed (as before).

TDD throughout: de-conflation round-trip test + 2 `resolve_policy_bundle` tests; 29 mvm-cli admit/resolve tests green; clippy `-D warnings` + nightly fmt. Full admission→boot→enforcement still wants a libkrun E2E lane (can't run on macOS) — the logic is unit-covered per stage.