### PR TITLE
plan-124 Phase A: lean guest agent — drop tokio/rtnetlink (−27 crates)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -87,6 +87,9 @@ jobs:
       - name: mvm-core default build is runtime-free
         run: cargo run -p xtask -- check-core-runtime-free
 
+      - name: mvm-guest agent closure is runtime-free
+        run: cargo run -p xtask -- check-guest-agent-runtime-free
+
   test:
     name: Test
     runs-on: ubuntu-latest

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3202,22 +3202,18 @@ name = "mvm-guest"
 version = "0.16.1"
 dependencies = [
  "anyhow",
- "async-trait",
  "base64 0.22.1",
  "chrono",
  "ed25519-dalek",
  "ipnet",
  "libc",
  "mvm-core",
- "netlink-packet-route",
  "rand 0.8.6",
- "rtnetlink",
  "seccompiler",
  "serde",
  "serde_json",
  "tempfile",
  "thiserror 1.0.69",
- "tokio",
  "tracing",
 ]
 
@@ -3450,70 +3446,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "27b02d87554356db9e9a873add8782d4ea6e3e58ea071a9adb9a2e8ddb884a8b"
 
 [[package]]
-name = "netlink-packet-core"
-version = "0.7.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "72724faf704479d67b388da142b186f916188505e7e0b26719019c525882eda4"
-dependencies = [
- "anyhow",
- "byteorder",
- "netlink-packet-utils",
-]
-
-[[package]]
-name = "netlink-packet-route"
-version = "0.19.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "74c171cd77b4ee8c7708da746ce392440cb7bcf618d122ec9ecc607b12938bf4"
-dependencies = [
- "anyhow",
- "byteorder",
- "libc",
- "log",
- "netlink-packet-core",
- "netlink-packet-utils",
-]
-
-[[package]]
-name = "netlink-packet-utils"
-version = "0.5.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0ede8a08c71ad5a95cdd0e4e52facd37190977039a4704eb82a283f713747d34"
-dependencies = [
- "anyhow",
- "byteorder",
- "paste",
- "thiserror 1.0.69",
-]
-
-[[package]]
-name = "netlink-proto"
-version = "0.11.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "72452e012c2f8d612410d89eea01e2d9b56205274abb35d53f60200b2ec41d60"
-dependencies = [
- "bytes",
- "futures",
- "log",
- "netlink-packet-core",
- "netlink-sys",
- "thiserror 2.0.18",
-]
-
-[[package]]
-name = "netlink-sys"
-version = "0.8.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cd6c30ed10fa69cc491d491b85cc971f6bdeb8e7367b7cde2ee6cc878d583fae"
-dependencies = [
- "bytes",
- "futures-util",
- "libc",
- "log",
- "tokio",
-]
-
-[[package]]
 name = "new_debug_unreachable"
 version = "1.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3526,17 +3458,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "47b6b097ecb1cbfed438542d16e84fd7ad9b0c76c8a65b7f9039212a3d14dc7f"
 dependencies = [
  "unicode-segmentation",
-]
-
-[[package]]
-name = "nix"
-version = "0.27.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2eb04e9c688eff1c89d72b407f168cf79bb9e867a9d3323ed6c01519eb9cc053"
-dependencies = [
- "bitflags 2.11.0",
- "cfg-if",
- "libc",
 ]
 
 [[package]]
@@ -4088,12 +4009,6 @@ dependencies = [
  "rand_core 0.6.4",
  "subtle",
 ]
-
-[[package]]
-name = "paste"
-version = "1.0.15"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "57c0d7b74b563b49d38dae00a0c37d4d6de9b432382b2892f0574ddcae73fd0a"
 
 [[package]]
 name = "pbkdf2"
@@ -4930,24 +4845,6 @@ dependencies = [
  "spki",
  "subtle",
  "zeroize",
-]
-
-[[package]]
-name = "rtnetlink"
-version = "0.14.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b684475344d8df1859ddb2d395dd3dac4f8f3422a1aa0725993cb375fc5caba5"
-dependencies = [
- "futures",
- "log",
- "netlink-packet-core",
- "netlink-packet-route",
- "netlink-packet-utils",
- "netlink-proto",
- "netlink-sys",
- "nix 0.27.1",
- "thiserror 1.0.69",
- "tokio",
 ]
 
 [[package]]

--- a/crates/mvm-guest/Cargo.toml
+++ b/crates/mvm-guest/Cargo.toml
@@ -101,35 +101,25 @@ serde_json.workspace = true
 # typed error variants (ReadinessError, ShutdownError).
 thiserror = "1"
 tracing.workspace = true
-# Plan 74 W2 — the `netinit` module's trait + types + install
-# loop + tests are cross-platform; only `RtnetlinkInstaller`
-# itself is Linux-only. Keeping async-trait + ipnet in the main
-# deps lets the tests run on macOS dev hosts too.
-async-trait.workspace = true
+# Plan 74 W2 — the `netinit` module's `RouteInstaller` trait + types +
+# install loop + tests are cross-platform; only `RawNetlinkInstaller`
+# itself is Linux-only (a synchronous AF_NETLINK socket via libc — Plan
+# 124 A3 dropped the async rtnetlink stack). ipnet stays in the main
+# deps so the cross-platform tests run on macOS dev hosts too.
 ipnet.workspace = true
 
 # seccompiler builds Linux-only — guests are always Linux microVMs,
 # but the workspace also compiles on macOS for CLI development. Gate
 # the dep so `cargo check` on a Mac doesn't try to build it.
+#
+# `mvm-guest-netinit`'s `RawNetlinkInstaller` talks to AF_NETLINK
+# directly through `libc` (already a main dep) — no netlink crate, no
+# async runtime (Plan 124 A3). Nothing extra is needed here.
 [target.'cfg(target_os = "linux")'.dependencies]
 seccompiler = { workspace = true }
-# Plan 74 W2 — `mvm-guest-netinit` uses rtnetlink to install kernel
-# blackhole routes for `MANDATORY_DENY_RANGES`. Linux-only because
-# rtnetlink talks to AF_NETLINK which doesn't exist elsewhere. The
-# host-side mvmctl builds (which include this crate) skip these
-# deps on macOS; the binary itself is only relevant in the guest.
-rtnetlink = { workspace = true }
-tokio = { workspace = true }
-# netlink-packet-route is rtnetlink's wire-format types crate. The
-# RouteType::BlackHole enum the installer uses comes from here.
-netlink-packet-route = "0.19"
 
 [dev-dependencies]
 tempfile.workspace = true
-# Plan 74 W2 — `netinit` module's tests are async (the
-# `RouteInstaller` trait is async). tokio is workspace-shared so
-# the extra dev-dep doesn't pull anything new into the lock.
-tokio = { workspace = true }
 
 [lints]
 workspace = true

--- a/crates/mvm-guest/src/bin/mvm-guest-netinit.rs
+++ b/crates/mvm-guest/src/bin/mvm-guest-netinit.rs
@@ -3,7 +3,8 @@
 //! Run as PID >1, uid 0 inside every microVM at boot, before the
 //! main `mvm-guest-agent` is forked under setpriv. Installs kernel
 //! blackhole routes for `mvm_core::network_policy::MANDATORY_DENY_RANGES`
-//! via rtnetlink — the defense layer that catches:
+//! over a synchronous `NETLINK_ROUTE` socket — the defense layer that
+//! catches:
 //!
 //! - The macOS Apple Container path where `mvm` has no host firewall.
 //! - Any backend where the host iptables/nftables rules don't apply.
@@ -18,8 +19,8 @@
 //!   the kernel message).
 //! - 1 — one or more routes failed to install. `/init` should
 //!   fail-closed and refuse to fork the workload.
-//! - 2 — could not connect to rtnetlink (kernel built without
-//!   `CONFIG_RTNETLINK`, or some other systemic failure). Same
+//! - 2 — could not open/bind the `NETLINK_ROUTE` socket (kernel built
+//!   without netlink, or some other systemic failure). Same
 //!   fail-closed behaviour at `/init`.
 //!
 //! ## Output
@@ -46,12 +47,11 @@
 //! [`Report`]: mvm_guest::netinit::Report
 
 #[cfg(target_os = "linux")]
-#[tokio::main]
-async fn main() {
-    let report = match mvm_guest::netinit::install_mandatory_deny_via_rtnetlink().await {
+fn main() {
+    let report = match mvm_guest::netinit::install_mandatory_deny_via_netlink() {
         Ok(r) => r,
         Err(e) => {
-            eprintln!("mvm-guest-netinit: rtnetlink connect failed: {e}");
+            eprintln!("mvm-guest-netinit: netlink socket open failed: {e}");
             // Exit 2 distinguishes systemic netlink failure from
             // per-route failures so `/init` can branch (the
             // systemic case usually means a kernel feature is
@@ -87,7 +87,7 @@ async fn main() {
 fn main() {
     eprintln!(
         "mvm-guest-netinit: not supported on this host \
-         (rtnetlink is Linux-only; this binary ships in the runtime \
+         (AF_NETLINK is Linux-only; this binary ships in the runtime \
          overlay for Linux microVM guests only)"
     );
     std::process::exit(2);

--- a/crates/mvm-guest/src/lib.rs
+++ b/crates/mvm-guest/src/lib.rs
@@ -16,8 +16,8 @@ pub mod lifecycle_hooks;
 /// binary calls into this module at boot to install kernel blackhole
 /// routes for `MANDATORY_DENY_RANGES` before any workload code runs.
 /// The module's types + install loop + tests build everywhere; the
-/// `RtnetlinkInstaller` (which talks to `AF_NETLINK`) is Linux-only
-/// and gated inside the module.
+/// `RawNetlinkInstaller` (a synchronous `AF_NETLINK` socket via libc,
+/// Plan 124 A3) is Linux-only and gated inside the module.
 pub mod netinit;
 pub mod probes;
 /// In-guest entrypoint runtime for function-call workloads (ADR-0009 /

--- a/crates/mvm-guest/src/netinit.rs
+++ b/crates/mvm-guest/src/netinit.rs
@@ -14,8 +14,8 @@
 //!
 //! Kernel-side blackhole routes are universal — every Linux kernel
 //! supports `RTN_BLACKHOLE` since 2.0, no userspace tool required.
-//! `rtnetlink` talks directly to the kernel via `AF_NETLINK`; the
-//! only dependency is a Linux kernel.
+//! We talk directly to the kernel over a synchronous `AF_NETLINK`
+//! socket (Plan 124 A3); the only dependency is a Linux kernel.
 //!
 //! ## Why this is defense-in-depth, not the sole defense
 //!
@@ -52,7 +52,6 @@
 //! report carries any failures, so `/init` can fail-closed
 //! (refuse to fork the workload entrypoint).
 
-use async_trait::async_trait;
 use ipnet::IpNet;
 use serde::{Deserialize, Serialize};
 
@@ -129,7 +128,7 @@ pub struct RouteFailed {
     pub cidr: IpNet,
     pub category: String,
     /// Stringified error. Kept opaque so the JSON shape is stable
-    /// even if the underlying rtnetlink error type changes.
+    /// even if the underlying netlink error representation changes.
     pub reason: String,
 }
 
@@ -168,16 +167,21 @@ impl Report {
     }
 }
 
-/// Abstraction over the actual rtnetlink call so tests can use a
+/// Abstraction over the actual netlink call so tests can use a
 /// `MockInstaller` without a real `AF_NETLINK` socket. Production
-/// uses [`RtnetlinkInstaller`].
-#[async_trait]
+/// uses [`RawNetlinkInstaller`].
+///
+/// Synchronous (Plan 124 A3): the previous `rtnetlink`-backed impl was
+/// `async`, which forced `#[async_trait]` here and dragged `tokio` into
+/// the guest closure for a one-shot, fire-and-wait netlink exchange that
+/// never needed a runtime. The raw installer does a blocking
+/// `send`/`recv` on a socket it owns.
 pub trait RouteInstaller: Send + Sync {
     /// Add a blackhole route for `cidr`. Idempotent at the kernel
     /// level — if the route already exists, returning `Ok(())` is
     /// the correct semantics (the entry is the desired state, not
     /// a write-once operation).
-    async fn install_blackhole(&self, cidr: IpNet) -> Result<(), String>;
+    fn install_blackhole(&self, cidr: IpNet) -> Result<(), String>;
 }
 
 /// Categorize a CIDR for the audit category field. Pure function;
@@ -221,7 +225,7 @@ fn categorize_v4(cidr: &IpNet) -> &'static str {
 /// The loop is fault-tolerant: a per-route failure is recorded in
 /// `report.failed` but doesn't abort. Callers branch on
 /// `report.has_failures()` for the overall verdict.
-pub async fn install_mandatory_deny<I: RouteInstaller>(installer: &I) -> Report {
+pub fn install_mandatory_deny<I: RouteInstaller>(installer: &I) -> Report {
     let mut report = Report::empty();
     for cidr in mvm_core::network_policy::mandatory_deny_ranges() {
         if !cidr.network().is_ipv4() {
@@ -229,7 +233,7 @@ pub async fn install_mandatory_deny<I: RouteInstaller>(installer: &I) -> Report 
             continue;
         }
         let category = categorize_v4(&cidr).to_string();
-        match installer.install_blackhole(cidr).await {
+        match installer.install_blackhole(cidr) {
             Ok(()) => report.installed.push(RouteInstalled { cidr, category }),
             Err(reason) => report.failed.push(RouteFailed {
                 cidr,
@@ -242,89 +246,258 @@ pub async fn install_mandatory_deny<I: RouteInstaller>(installer: &I) -> Report 
 }
 
 // ============================================================================
-// Production installer — rtnetlink (Linux-only)
+// Raw netlink wire format (cross-platform — no socket, pure bytes)
+// ============================================================================
+
+/// Netlink `RTM_NEWROUTE` wire encoding for blackhole routes.
+///
+/// Plan 124 A3 replaced the async `rtnetlink` crate (which dragged
+/// `tokio` and `async-trait` into the guest closure) with a hand-rolled
+/// message over a synchronous `AF_NETLINK` socket. The message is ~36
+/// bytes of stable kernel UAPI; building it needs no dependency. The
+/// encoding
+/// lives off the `cfg(linux)` socket code so its byte layout is
+/// unit-tested on any host — and the module is gated to `linux`-or-`test`
+/// so a macOS production build (where only the Linux installer would call
+/// it) doesn't carry it as dead code.
+///
+/// Constants are duplicated from `<linux/rtnetlink.h>` / `<linux/netlink.h>`
+/// — frozen kernel ABI, never renumbered. `constants_match_libc` (a
+/// Linux-only test) pins each to `libc`'s value so a typo can't slip past
+/// CI even though we don't link a netlink crate.
+#[cfg(any(target_os = "linux", test))]
+mod wire {
+    use std::net::Ipv4Addr;
+
+    /// `RTM_NEWROUTE` — create/modify a routing table entry.
+    pub const RTM_NEWROUTE: u16 = 24;
+    /// `NLM_F_REQUEST` — this message is a request.
+    pub const NLM_F_REQUEST: u16 = 0x01;
+    /// `NLM_F_CREATE` — create the object if it doesn't exist.
+    pub const NLM_F_CREATE: u16 = 0x400;
+    /// `NLM_F_ACK` — ask the kernel for an explicit ACK (an `nlmsgerr`
+    /// with `error == 0`), so the installer can confirm the route landed
+    /// instead of fire-and-forget.
+    pub const NLM_F_ACK: u16 = 0x04;
+    /// `AF_INET` — `rtm_family` for an IPv4 route.
+    pub const AF_INET_U8: u8 = 2;
+    /// `RT_TABLE_MAIN` — the main routing table.
+    pub const RT_TABLE_MAIN: u8 = 254;
+    /// `RTPROT_BOOT` — installed by the boot process (us, from `/init`).
+    pub const RTPROT_BOOT: u8 = 3;
+    /// `RT_SCOPE_UNIVERSE` — global scope (a blackhole applies everywhere).
+    pub const RT_SCOPE_UNIVERSE: u8 = 0;
+    /// `RTN_BLACKHOLE` — drop matching packets, no ICMP unreachable.
+    pub const RTN_BLACKHOLE: u8 = 6;
+    /// `RTA_DST` — the route's destination-prefix attribute.
+    pub const RTA_DST: u16 = 1;
+
+    /// Encode an `RTM_NEWROUTE` netlink message installing a blackhole
+    /// route for `addr/prefix_len`. Pure: returns the exact wire bytes
+    /// the kernel expects on an `AF_NETLINK`/`NETLINK_ROUTE` socket, no
+    /// I/O.
+    ///
+    /// Layout (all multi-byte header fields native-endian per the
+    /// netlink ABI; the `RTA_DST` payload is the address in network
+    /// order): `nlmsghdr`(16) + `rtmsg`(12) + `rtattr`(4) + dst(4) = 36.
+    ///
+    /// `seq` is echoed back in the ACK so the caller can match request
+    /// to reply on a socket it owns exclusively.
+    pub fn encode_blackhole_route_v4(addr: Ipv4Addr, prefix_len: u8, seq: u32) -> Vec<u8> {
+        // Fixed total: no optional attributes, so we can stamp nlmsg_len
+        // up front rather than back-patch it. 16 + 12 + 8.
+        const TOTAL_LEN: u32 = 36;
+        let mut msg = Vec::with_capacity(TOTAL_LEN as usize);
+
+        // struct nlmsghdr — fields are host-endian per the netlink ABI.
+        msg.extend_from_slice(&TOTAL_LEN.to_ne_bytes()); // nlmsg_len
+        msg.extend_from_slice(&RTM_NEWROUTE.to_ne_bytes()); // nlmsg_type
+        msg.extend_from_slice(&(NLM_F_REQUEST | NLM_F_CREATE | NLM_F_ACK).to_ne_bytes()); // nlmsg_flags
+        msg.extend_from_slice(&seq.to_ne_bytes()); // nlmsg_seq
+        msg.extend_from_slice(&0u32.to_ne_bytes()); // nlmsg_pid — 0: kernel fills it
+
+        // struct rtmsg — single-byte fields need no endian handling.
+        msg.push(AF_INET_U8); // rtm_family
+        msg.push(prefix_len); // rtm_dst_len — the prefix being blackholed
+        msg.push(0); // rtm_src_len
+        msg.push(0); // rtm_tos
+        msg.push(RT_TABLE_MAIN); // rtm_table
+        msg.push(RTPROT_BOOT); // rtm_protocol
+        msg.push(RT_SCOPE_UNIVERSE); // rtm_scope
+        msg.push(RTN_BLACKHOLE); // rtm_type — drop, no ICMP unreachable
+        msg.extend_from_slice(&0u32.to_ne_bytes()); // rtm_flags
+
+        // struct rtattr { rta_len, rta_type } + 4-byte IPv4 destination.
+        // The address is already network-order in `octets()`, which is
+        // what the kernel wants in RTA_DST.
+        msg.extend_from_slice(&8u16.to_ne_bytes()); // rta_len = 4 (hdr) + 4 (addr)
+        msg.extend_from_slice(&RTA_DST.to_ne_bytes()); // rta_type
+        msg.extend_from_slice(&addr.octets()); // destination prefix
+
+        debug_assert_eq!(msg.len(), TOTAL_LEN as usize);
+        msg
+    }
+}
+
+#[cfg(any(target_os = "linux", test))]
+use wire::*;
+
+// ============================================================================
+// Production installer — raw netlink (Linux-only)
 // ============================================================================
 
 #[cfg(target_os = "linux")]
 mod linux {
     use super::*;
 
-    /// Production [`RouteInstaller`] that talks to the kernel via
-    /// `AF_NETLINK`. Requires CAP_NET_ADMIN in the current user
-    /// namespace — the binary expects to run as root from `/init`
-    /// BEFORE the agent setpriv's down to uid 901.
+    use std::io;
+    use std::mem::zeroed;
+    use std::os::fd::{AsRawFd, FromRawFd, OwnedFd};
+    use std::sync::atomic::{AtomicU32, Ordering};
+
+    /// `NLMSG_ERROR` — the kernel's ACK/error reply type. Carries an
+    /// `i32` error immediately after its `nlmsghdr`: `0` = success ACK,
+    /// `-errno` = failure.
+    const NLMSG_ERROR: u16 = 2;
+
+    /// Production [`RouteInstaller`] that talks to the kernel directly
+    /// over a `NETLINK_ROUTE` socket — synchronous `sendto`/`recv`, no
+    /// runtime (Plan 124 A3). Requires CAP_NET_ADMIN in the current
+    /// user namespace; the binary runs as root from `/init` BEFORE the
+    /// agent setpriv's down to uid 901.
     ///
-    /// Construction is fallible because opening the netlink socket
-    /// can fail (e.g. on a kernel built without `CONFIG_RTNETLINK`,
-    /// which is rare but not impossible for stripped-down embedded
-    /// kernels).
-    pub struct RtnetlinkInstaller {
-        handle: rtnetlink::Handle,
+    /// Owns the socket fd for its lifetime (`OwnedFd` closes it on
+    /// drop). `seq` numbers requests so each ACK can be matched to its
+    /// send on this exclusively-owned socket.
+    pub struct RawNetlinkInstaller {
+        fd: OwnedFd,
+        seq: AtomicU32,
     }
 
-    impl RtnetlinkInstaller {
-        /// Connect to the kernel's rtnetlink service. Spawns the
-        /// rtnetlink connection background task on the current
-        /// tokio runtime. Drop semantics: the handle keeps the
-        /// connection alive until the installer is dropped.
-        pub async fn connect() -> Result<Self, String> {
-            let (connection, handle, _) =
-                rtnetlink::new_connection().map_err(|e| format!("rtnetlink connect: {e}"))?;
-            tokio::spawn(connection);
-            Ok(Self { handle })
-        }
-    }
-
-    #[async_trait]
-    impl RouteInstaller for RtnetlinkInstaller {
-        async fn install_blackhole(&self, cidr: IpNet) -> Result<(), String> {
-            // rtnetlink's v4 route builder takes the destination
-            // prefix (address + length) and the
-            // scope/protocol/kind fields. The `kind` field is what
-            // makes it a blackhole — RTN_BLACKHOLE means "the
-            // kernel drops packets matching this route without
-            // sending ICMP unreachable", which is the strongest
-            // form of "this destination is forbidden".
-            match cidr {
-                IpNet::V4(v4) => {
-                    use netlink_packet_route::route::{RouteProtocol, RouteScope, RouteType};
-                    self.handle
-                        .route()
-                        .add()
-                        .v4()
-                        .destination_prefix(v4.network(), v4.prefix_len())
-                        .kind(RouteType::BlackHole)
-                        .scope(RouteScope::Universe)
-                        .protocol(RouteProtocol::Boot)
-                        .execute()
-                        .await
-                        .map_err(|e| format!("route add {cidr}: {e}"))?;
-                }
-                IpNet::V6(_) => {
-                    // Should never reach here because
-                    // `install_mandatory_deny` skips v6 before
-                    // calling the installer; defending against a
-                    // future refactor.
-                    return Err(format!(
-                        "internal: install_blackhole called with IPv6 cidr {cidr} \
-                         (v6 not supported yet)"
-                    ));
-                }
+    impl RawNetlinkInstaller {
+        /// Open and bind a `NETLINK_ROUTE` socket. Fallible: the socket
+        /// open can fail on a kernel built without netlink (rare, but
+        /// possible on stripped-down embedded kernels) — the binary
+        /// maps this to a distinct exit code so `/init` can tell a
+        /// systemic netlink failure from a per-route one.
+        pub fn open() -> Result<Self, String> {
+            // SAFETY: socket() with constant args; we check the return.
+            let raw =
+                unsafe { libc::socket(libc::AF_NETLINK, libc::SOCK_RAW, libc::NETLINK_ROUTE) };
+            if raw < 0 {
+                return Err(format!(
+                    "open AF_NETLINK socket: {}",
+                    io::Error::last_os_error()
+                ));
             }
-            Ok(())
+            // SAFETY: raw is a fresh, owned, valid fd (checked >= 0).
+            let fd = unsafe { OwnedFd::from_raw_fd(raw) };
+
+            // Bind with nl_pid = 0 so the kernel assigns a unique port
+            // id; nl_groups = 0 (we send unicast requests, want no
+            // multicast). zeroed() gives nl_pad = 0 as required.
+            let mut addr: libc::sockaddr_nl = unsafe { zeroed() };
+            addr.nl_family = libc::AF_NETLINK as u16;
+            // SAFETY: addr is a valid sockaddr_nl for the bind's len.
+            let rc = unsafe {
+                libc::bind(
+                    fd.as_raw_fd(),
+                    &addr as *const libc::sockaddr_nl as *const libc::sockaddr,
+                    size_of::<libc::sockaddr_nl>() as libc::socklen_t,
+                )
+            };
+            if rc < 0 {
+                return Err(format!(
+                    "bind AF_NETLINK socket: {}",
+                    io::Error::last_os_error()
+                ));
+            }
+            Ok(Self {
+                fd,
+                seq: AtomicU32::new(0),
+            })
+        }
+
+        /// Send one encoded request to the kernel (nl_pid = 0) and wait
+        /// for its ACK. Returns the kernel's `nlmsgerr` code: `0` for
+        /// success, otherwise the positive errno.
+        fn send_and_ack(&self, msg: &[u8]) -> Result<i32, String> {
+            let fd = self.fd.as_raw_fd();
+            let mut dst: libc::sockaddr_nl = unsafe { zeroed() };
+            dst.nl_family = libc::AF_NETLINK as u16; // nl_pid = 0 → the kernel
+            // SAFETY: msg is a valid slice; dst is a valid sockaddr_nl.
+            let sent = unsafe {
+                libc::sendto(
+                    fd,
+                    msg.as_ptr() as *const libc::c_void,
+                    msg.len(),
+                    0,
+                    &dst as *const libc::sockaddr_nl as *const libc::sockaddr,
+                    size_of::<libc::sockaddr_nl>() as libc::socklen_t,
+                )
+            };
+            if sent < 0 {
+                return Err(format!("netlink send: {}", io::Error::last_os_error()));
+            }
+
+            // The ACK is a single NLMSG_ERROR: nlmsghdr(16) + i32 error
+            // + the echoed request header. 1 KiB is ample.
+            let mut buf = [0u8; 1024];
+            // SAFETY: buf is a valid, sized destination.
+            let r = unsafe { libc::recv(fd, buf.as_mut_ptr() as *mut libc::c_void, buf.len(), 0) };
+            if r < 0 {
+                return Err(format!("netlink recv: {}", io::Error::last_os_error()));
+            }
+            let r = r as usize;
+            // Need at least nlmsghdr(16) + error(4) to read the verdict.
+            if r < 20 {
+                return Err(format!("short netlink ACK: {r} bytes"));
+            }
+            let nlmsg_type = u16::from_ne_bytes([buf[4], buf[5]]);
+            if nlmsg_type != NLMSG_ERROR {
+                return Err(format!("unexpected netlink reply type {nlmsg_type}"));
+            }
+            // nlmsgerr.error sits right after the 16-byte nlmsghdr.
+            let err = i32::from_ne_bytes([buf[16], buf[17], buf[18], buf[19]]);
+            Ok(-err) // kernel reports -errno; flip to a positive errno (0 = ACK)
         }
     }
 
-    /// Convenience: connect to rtnetlink and run the install in
-    /// one call. The `mvm-guest-netinit` binary uses this.
-    pub async fn install_mandatory_deny_via_rtnetlink() -> Result<Report, String> {
-        let installer = RtnetlinkInstaller::connect().await?;
-        Ok(install_mandatory_deny(&installer).await)
+    impl RouteInstaller for RawNetlinkInstaller {
+        fn install_blackhole(&self, cidr: IpNet) -> Result<(), String> {
+            let IpNet::V4(v4) = cidr else {
+                // `install_mandatory_deny` skips v6 before calling us;
+                // this defends against a future refactor.
+                return Err(format!(
+                    "internal: install_blackhole called with IPv6 cidr {cidr} (v6 not supported yet)"
+                ));
+            };
+            // Start seq at 1 (0 reads as "no seq" in some tooling).
+            let seq = self.seq.fetch_add(1, Ordering::Relaxed).wrapping_add(1);
+            let msg = encode_blackhole_route_v4(v4.network(), v4.prefix_len(), seq);
+            match self.send_and_ack(&msg)? {
+                0 => Ok(()),
+                // EEXIST: the blackhole is already installed. The route
+                // is desired state, not a write-once op — idempotent Ok.
+                e if e == libc::EEXIST => Ok(()),
+                e => Err(format!(
+                    "route add {cidr}: {}",
+                    io::Error::from_raw_os_error(e)
+                )),
+            }
+        }
+    }
+
+    /// Convenience: open the netlink socket and run the full install.
+    /// The `mvm-guest-netinit` binary uses this.
+    pub fn install_mandatory_deny_via_netlink() -> Result<Report, String> {
+        let installer = RawNetlinkInstaller::open()?;
+        Ok(install_mandatory_deny(&installer))
     }
 }
 
 #[cfg(target_os = "linux")]
-pub use linux::{RtnetlinkInstaller, install_mandatory_deny_via_rtnetlink};
+pub use linux::{RawNetlinkInstaller, install_mandatory_deny_via_netlink};
 
 // ============================================================================
 // Tests
@@ -334,6 +507,7 @@ pub use linux::{RtnetlinkInstaller, install_mandatory_deny_via_rtnetlink};
 mod tests {
     use super::*;
     use std::collections::HashSet;
+    use std::net::Ipv4Addr;
     use std::sync::Mutex;
 
     /// In-memory mock that records every `install_blackhole` call.
@@ -365,9 +539,8 @@ mod tests {
         }
     }
 
-    #[async_trait]
     impl RouteInstaller for MockInstaller {
-        async fn install_blackhole(&self, cidr: IpNet) -> Result<(), String> {
+        fn install_blackhole(&self, cidr: IpNet) -> Result<(), String> {
             self.calls.lock().unwrap().push(cidr);
             if self.fail_on.contains(&cidr) {
                 Err(format!("forced failure for {cidr}"))
@@ -377,10 +550,10 @@ mod tests {
         }
     }
 
-    #[tokio::test]
-    async fn install_calls_installer_for_every_ipv4_entry() {
+    #[test]
+    fn install_calls_installer_for_every_ipv4_entry() {
         let mock = MockInstaller::new();
-        let report = install_mandatory_deny(&mock).await;
+        let report = install_mandatory_deny(&mock);
         // Every IPv4 entry in `MANDATORY_DENY_RANGES` should have
         // exactly one call. Mirror the const's IPv4 entry count
         // exactly so a future const edit that adds a v4 entry
@@ -394,10 +567,10 @@ mod tests {
         assert!(report.failed.is_empty());
     }
 
-    #[tokio::test]
-    async fn install_skips_ipv6_entries_and_reports_them() {
+    #[test]
+    fn install_skips_ipv6_entries_and_reports_them() {
         let mock = MockInstaller::new();
-        let report = install_mandatory_deny(&mock).await;
+        let report = install_mandatory_deny(&mock);
         let v6_count = mvm_core::network_policy::mandatory_deny_ranges()
             .iter()
             .filter(|n| !n.network().is_ipv4())
@@ -412,14 +585,14 @@ mod tests {
         }
     }
 
-    #[tokio::test]
-    async fn install_records_cloud_metadata_explicitly() {
+    #[test]
+    fn install_records_cloud_metadata_explicitly() {
         // The metadata `/32` is the highest-stakes entry. Asserting
         // it shows up in `installed` with category=cloud-metadata
         // means a regression that drops the entry from the const,
         // or skips it in the install loop, fails loudly here.
         let mock = MockInstaller::new();
-        let report = install_mandatory_deny(&mock).await;
+        let report = install_mandatory_deny(&mock);
         let metadata: IpNet = "169.254.169.254/32".parse().unwrap();
         let entry = report
             .installed
@@ -429,13 +602,13 @@ mod tests {
         assert_eq!(entry.category, "cloud-metadata");
     }
 
-    #[tokio::test]
-    async fn install_continues_past_failures_and_records_them() {
+    #[test]
+    fn install_continues_past_failures_and_records_them() {
         // Force one specific CIDR to fail. The loop must still
         // attempt every other entry; the failed CIDR lands in
         // `report.failed`, the rest in `report.installed`.
         let mock = MockInstaller::new().fail_on(&["100.64.0.0/10"]);
-        let report = install_mandatory_deny(&mock).await;
+        let report = install_mandatory_deny(&mock);
         assert_eq!(report.failed.len(), 1);
         assert_eq!(report.failed[0].cidr.to_string(), "100.64.0.0/10");
         assert!(report.failed[0].reason.contains("forced failure"));
@@ -445,20 +618,20 @@ mod tests {
         assert!(report.has_failures());
     }
 
-    #[tokio::test]
-    async fn install_marks_clean_run_no_failures() {
+    #[test]
+    fn install_marks_clean_run_no_failures() {
         let mock = MockInstaller::new();
-        let report = install_mandatory_deny(&mock).await;
+        let report = install_mandatory_deny(&mock);
         assert!(!report.has_failures());
     }
 
-    #[tokio::test]
-    async fn install_serializes_to_stable_json_shape() {
+    #[test]
+    fn install_serializes_to_stable_json_shape() {
         // The binary's stdout is `serde_json::to_string(&report)`.
         // Pin the load-bearing field names so a downstream audit
         // consumer can deserialize across mvmctl versions.
         let mock = MockInstaller::new();
-        let report = install_mandatory_deny(&mock).await;
+        let report = install_mandatory_deny(&mock);
         let json = serde_json::to_value(&report).unwrap();
         let obj = json.as_object().unwrap();
         for key in ["installed", "failed", "skipped_ipv6"] {
@@ -471,6 +644,99 @@ mod tests {
             .expect("at least one installed entry in clean run");
         assert!(first.get("cidr").is_some());
         assert!(first.get("category").is_some());
+    }
+
+    // ────────────────────────────────────────────────────────────
+    // Raw netlink wire-format tests (no socket — pure bytes)
+    // ────────────────────────────────────────────────────────────
+
+    #[test]
+    fn encode_blackhole_route_v4_produces_exact_netlink_bytes() {
+        // The cloud-metadata /32 — highest-stakes entry. Pin every
+        // load-bearing field of the RTM_NEWROUTE message so a wrong
+        // offset, constant, or endianness surfaces here, not as a
+        // silent kernel EINVAL on a host we can't boot in this test.
+        let msg = encode_blackhole_route_v4(Ipv4Addr::new(169, 254, 169, 254), 32, 1);
+
+        assert_eq!(msg.len(), 36, "nlmsghdr(16)+rtmsg(12)+rtattr(4)+dst(4)");
+
+        // nlmsghdr (offsets 0..16)
+        assert_eq!(
+            u32::from_ne_bytes(msg[0..4].try_into().unwrap()),
+            36,
+            "nlmsg_len must equal total message length"
+        );
+        assert_eq!(
+            u16::from_ne_bytes(msg[4..6].try_into().unwrap()),
+            RTM_NEWROUTE,
+            "nlmsg_type"
+        );
+        assert_eq!(
+            u16::from_ne_bytes(msg[6..8].try_into().unwrap()),
+            NLM_F_REQUEST | NLM_F_CREATE | NLM_F_ACK,
+            "nlmsg_flags"
+        );
+        assert_eq!(
+            u32::from_ne_bytes(msg[8..12].try_into().unwrap()),
+            1,
+            "nlmsg_seq is echoed in the ACK"
+        );
+
+        // rtmsg (offsets 16..28)
+        assert_eq!(msg[16], AF_INET_U8, "rtm_family");
+        assert_eq!(msg[17], 32, "rtm_dst_len = prefix");
+        assert_eq!(msg[18], 0, "rtm_src_len");
+        assert_eq!(msg[20], RT_TABLE_MAIN, "rtm_table");
+        assert_eq!(msg[21], RTPROT_BOOT, "rtm_protocol");
+        assert_eq!(msg[22], RT_SCOPE_UNIVERSE, "rtm_scope");
+        assert_eq!(msg[23], RTN_BLACKHOLE, "rtm_type — the blackhole");
+
+        // rtattr RTA_DST (offsets 28..36)
+        assert_eq!(
+            u16::from_ne_bytes(msg[28..30].try_into().unwrap()),
+            8,
+            "rta_len = 4 (header) + 4 (addr)"
+        );
+        assert_eq!(
+            u16::from_ne_bytes(msg[30..32].try_into().unwrap()),
+            RTA_DST,
+            "rta_type"
+        );
+        assert_eq!(
+            &msg[32..36],
+            &[169, 254, 169, 254],
+            "destination address in network byte order"
+        );
+    }
+
+    #[test]
+    fn encode_blackhole_route_v4_carries_prefix_and_addr() {
+        // A /10 (the CGNAT range) — different prefix + address, to prove
+        // the encoder isn't hardcoded to the metadata /32.
+        let msg = encode_blackhole_route_v4(Ipv4Addr::new(100, 64, 0, 0), 10, 7);
+        assert_eq!(msg[17], 10, "rtm_dst_len tracks the supplied prefix");
+        assert_eq!(&msg[32..36], &[100, 64, 0, 0], "destination address");
+        assert_eq!(u32::from_ne_bytes(msg[8..12].try_into().unwrap()), 7, "seq");
+    }
+
+    /// We duplicate the netlink constants from `<linux/rtnetlink.h>`
+    /// rather than depend on a netlink crate (Plan 124 A3 dep budget).
+    /// This Linux-only test pins each one to `libc`'s value so a typo
+    /// can't reach the kernel — it runs on CI, where libc exposes the
+    /// real UAPI numbers. (macOS dev hosts skip it; libc has no netlink.)
+    #[cfg(target_os = "linux")]
+    #[test]
+    fn constants_match_libc() {
+        assert_eq!(RTM_NEWROUTE, libc::RTM_NEWROUTE);
+        assert_eq!(NLM_F_REQUEST, libc::NLM_F_REQUEST as u16);
+        assert_eq!(NLM_F_CREATE, libc::NLM_F_CREATE as u16);
+        assert_eq!(NLM_F_ACK, libc::NLM_F_ACK as u16);
+        assert_eq!(AF_INET_U8, libc::AF_INET as u8);
+        assert_eq!(RT_TABLE_MAIN, libc::RT_TABLE_MAIN);
+        assert_eq!(RTPROT_BOOT, libc::RTPROT_BOOT);
+        assert_eq!(RT_SCOPE_UNIVERSE, libc::RT_SCOPE_UNIVERSE);
+        assert_eq!(RTN_BLACKHOLE, libc::RTN_BLACKHOLE);
+        assert_eq!(RTA_DST, libc::RTA_DST);
     }
 
     // ────────────────────────────────────────────────────────────

--- a/docs/investigations/plan-124-lean-agent-dep-cut.md
+++ b/docs/investigations/plan-124-lean-agent-dep-cut.md
@@ -1,0 +1,78 @@
+# Plan 124 Phase A — the lean guest-agent dep cut (measured)
+
+Measured 2026-06-05 on branch `feat/plan-124a-lean-agent`. Method matches
+[`dep-baseline.md`](dep-baseline.md) (unique packages, not tree lines):
+
+```sh
+cargo tree -p mvm-guest -e no-dev --prefix none --target <triple> \
+  | sed 's/ v[0-9].*//' | sort -u | wc -l
+```
+
+The async stack mvm-guest carried was `cfg(target_os = "linux")`-gated
+(netinit's rtnetlink), so it is **invisible on a macOS host tree** — every
+real number here is on the guest's actual target, `aarch64-unknown-linux-gnu`.
+
+## The cut
+
+| `mvm-guest` no-dev closure (unique crates) | Before (A1, `1cb2c9dc`) | After (A3) | Δ |
+|---|---|---|---|
+| Linux target (`aarch64-unknown-linux-gnu`) | **126** | **99** | **−27** |
+| Host target (`aarch64-apple-darwin`) | 203¹ | 199 | −4 |
+
+¹ host baseline recorded in A1; on the host the only removed crate is
+`async-trait` (+ its proc-macro deps) — the heavy async stack was never on
+the host target.
+
+**Added: 0.** A3 replaced the `rtnetlink` crate with a hand-rolled
+`RTM_NEWROUTE` message over a synchronous `AF_NETLINK` socket using `libc`
+(already a dep) — the brief's proposed `linux-raw-sys` was unnecessary
+(constants are frozen kernel UAPI, inlined and pinned to `libc` by the
+`constants_match_libc` CI test).
+
+The 27 removed crates — the entire `tokio` + `futures` + `netlink`
+ecosystems that `rtnetlink` (async) dragged in:
+
+```
+async-trait byteorder bytes errno futures futures-channel futures-core
+futures-executor futures-io futures-macro futures-sink futures-task
+futures-util mio netlink-packet-core netlink-packet-route
+netlink-packet-utils netlink-proto netlink-sys nix paste rtnetlink
+signal-hook-registry slab socket2 tokio tokio-macros
+```
+
+(The raw `cargo tree | wc -l` the plan literally names drops 285 → 198
+*tree lines* on the Linux target, but that counts a crate once per position
+in the graph — `futures-core` alone appears many times. The 27 figure above
+is unique crates, the meaningful number, and is what `dep-baseline.md`'s
+method reports.)
+
+## Where the cut came from
+
+All of it is A3 (`rtnetlink` → raw netlink). **A1** added only the
+`check-guest-agent-runtime-free` gate (no dep change). **A2** (`serde_json`
+→ hand-rolled vsock codec) was found **not viable** and deferred:
+`serde_json` enters `mvm-guest` transitively via `mvm-core`
+(`serde_json → mvm-core → mvm-guest`) and is load-bearing in 7 guest
+modules + 3 bins, so hand-rolling the vsock codec removes **0 crates** for
+a large, risky rewrite — see plan 124 Task A2 for the full reasoning.
+
+## Invariants
+
+- **Claim 4 (`prod-agent-no-exec`):** untouched. A3 did not modify
+  `src/bin/mvm-guest-agent.rs` or `do_exec` (`git diff 1cb2c9dc..HEAD --
+  src/bin/mvm-guest-agent.rs` is empty); the CI witness is unaffected.
+- **Claim 5 (vsock framing fuzzed):** untouched. A2 deferred → the vsock
+  codec and its two fuzz targets are unchanged.
+- **Claim 10 (`NetworkMandatoryDeny`):** preserved. `RawNetlinkInstaller`
+  installs the same blackhole routes and emits the same `REPORT_MARKER`
+  console-audit line; the `RouteInstaller` trait + install-loop + report
+  shape are behaviourally identical (covered by the same tests, now sync).
+
+## Verification (local, this branch)
+
+- macOS: 236 `mvm-guest` tests pass, clippy `-D warnings` clean, nightly fmt clean.
+- Linux target (`aarch64-unknown-linux-gnu`, rustc 1.96): `cargo check`
+  **and** `cargo clippy -D warnings` clean for `mvm-guest --all-targets`,
+  compiling the `cfg(linux)` `RawNetlinkInstaller` + `constants_match_libc`.
+- Runtime behaviour of the AF_NETLINK install (kernel accepts the message)
+  is exercised by Linux CI / a real KVM host — not runnable on a macOS dev host.

--- a/specs/plans/124-guest-agent-lean-overlay.md
+++ b/specs/plans/124-guest-agent-lean-overlay.md
@@ -26,15 +26,18 @@
 - [x] **Step 2:** `xtask check-guest-agent-runtime-free` mirrors `check-core-runtime-free`: `cargo tree -p mvm-guest -e no-dev --prefix none --locked --target aarch64-unknown-linux-musl`, fails if `{tokio, async-trait, rtnetlink, netlink-packet-route}` appear. Parser unit tests green; the live gate is **RED now** (exit 1, all four present) — the real failing test A3 drives to green.
 - [x] **Step 3 (landed with A3):** the gate is wired into `ci.yml` in the A3 commit — the same commit that flips it green, so no knowingly-red required check ever sat in the tree.
 
-### Task A2: `serde_json` → hand-rolled framing in `vsock`
+### Task A2: `serde_json` → hand-rolled framing in `vsock` — **NOT VIABLE AS WRITTEN (deferred 2026-06-05)**
 
-ADR-066 §9. The wire format is a small fixed set of typed messages; a hand-rolled length-delimited codec removes `serde_json` from the guest. **Claim 5: the fuzz target moves with it, not away.**
+ADR-066 §9 wanted a hand-rolled length-delimited codec to "remove `serde_json` from the guest." **Verified against the worktree: A2 cannot remove `serde_json` from `mvm-guest`'s tree, so its dep-graph benefit is zero.** Two findings:
 
-**Files:** `crates/mvm-guest/src/vsock.rs`; `crates/mvm-guest/fuzz/` (the `GuestRequest`/`AuthenticatedFrame` targets).
+1. **`serde_json` is a *transitive* dep via `mvm-core`** — `cargo tree -i serde_json` shows `serde_json → mvm-core → mvm-guest`. `mvm-core` uses it load-bearingly (signed `ExecutionPlan`/bundle/policy/audit JSON), so it stays in `mvm-guest`'s closure no matter what the guest crate does. Hand-rolling the vsock codec removes **0 crates**.
+2. **`serde_json` is load-bearing in 7 guest modules + 3 bins** (non-test): `vsock`, `worker_protocol`, `integrations`, `probes`, `runtime_config`, `runner/config`, `builder_agent`, plus the agent/builder-agent/netinit bins. Even a full guest-wide de-serde would still leave it in the tree via (1).
 
-- [ ] **Step 1:** Failing tests — every `GuestRequest`/response round-trips through the new codec byte-for-byte; a truncated/oversized/garbage frame is rejected (the fuzz corpus cases as unit tests); `deny_unknown_fields` semantics preserved (unknown tag → reject).
-- [ ] **Step 2:** Implement the codec (tag byte + length-prefixed fields; the existing `AuthenticatedFrame` envelope stays). Repoint the two fuzz harnesses at the new codec — claim 5 must keep covering the parser.
-- [ ] **Step 3:** Drop `serde_json` from `mvm-guest` if no other module needs it (`integrations`/`runtime_config` may — keep only where load-bearing). `cargo tree` delta. Commit.
+**Cost/benefit:** hand-rolling encode/decode for `GuestRequest` (~35 variants) + `GuestResponse` + the `AuthenticatedFrame` envelope, re-implementing serde's `deny_unknown_fields` by hand, and **repointing the claim-5 fuzz targets onto a bespoke parser** — i.e. trading battle-tested serde for hand-written parsing on the security-critical host↔guest boundary claim 5 protects — buys **nothing** in the dep graph and *enlarges* the hand-written attack surface. Net-negative.
+
+**Decision:** deferred. Genuinely shedding `serde_json` from the guest closure is gated on de-serde'ing **`mvm-core`** (a separate, cross-cutting effort, and dubious — `mvm-core` serializes signed plans as JSON by design). Revisit only if/when that lands. The lean-agent win this plan promised is delivered by A1+A3 (the `tokio`/`async-trait`/`rtnetlink` cut); `serde_json` was never removable here.
+
+**Files (if ever revived):** `crates/mvm-guest/src/vsock.rs`; `crates/mvm-guest/fuzz/`.
 
 ### Task A3: `rtnetlink` → `linux-raw-sys` in `netinit`
 
@@ -52,7 +55,7 @@ ADR-066 §9. The wire format is a small fixed set of typed messages; a hand-roll
 
 ### Task A4: confirm the cut
 
-- [ ] **Step 1:** `cargo tree -p mvm-guest -e no-dev | wc -l` total delta recorded (target ~25–35 crates removed); prod-agent binary size before/after. `prod-agent-no-exec` (claim 4) still green — assert `do_exec` absent without `dev-shell`. Commit a `docs/investigations/` note with the numbers (don't silently claim the reduction — show it).
+- [x] **Step 1:** Delta recorded in [`docs/investigations/plan-124-lean-agent-dep-cut.md`](../../docs/investigations/plan-124-lean-agent-dep-cut.md): `mvm-guest`'s Linux no-dev closure went **126 → 99 unique crates (−27, 0 added)** — the whole `tokio`/`futures`/`netlink` ecosystem, right in the ~25–35 target. (The async stack was `cfg(linux)`-gated, so the cut only shows on the guest's real target, not the host.) Claim 4 (`prod-agent-no-exec`) untouched — A3 never touched the agent bin or `do_exec` (empty diff); claim 5 untouched (A2 deferred, vsock + fuzz unchanged); claim 10's `REPORT_MARKER` audit path preserved.
 
 ## Phase B — universal agent (every VM type)
 
@@ -108,7 +111,7 @@ ADR-066 §"survey" — deliver the signed-plan-derived runtime config to the gue
 
 ## Acceptance
 
-- [ ] `mvm-guest` sheds `tokio` + `async-trait` + `serde_json` (guest) + `rtnetlink`; `cargo tree -p mvm-guest -e no-dev` is ~25–35 crates lighter, recorded in a `docs/investigations/` note; prod-agent binary smaller.
+- [x] `mvm-guest` sheds `tokio` + `async-trait` + `rtnetlink` (and the `futures`/`netlink` ecosystems they dragged in) — **−27 unique crates** on the Linux closure (126 → 99), recorded in [`docs/investigations/plan-124-lean-agent-dep-cut.md`](../../docs/investigations/plan-124-lean-agent-dep-cut.md). **`serde_json` is NOT shed** (A2): it enters transitively via `mvm-core`, so it's unremovable from the guest tree — deferred, see Task A2.
 - [ ] Claim 4 (`prod-agent-no-exec`) and claim 5 (vsock fuzz, repointed) stay green; claim 10's netinit audit marker preserved.
 - [ ] The same `mvm-guest-agent` runs in builder/dev (forked by `mvm-host-vm-init`) and workload VMs; `check-guest-agent-in-all-images` enforces it.
 - [ ] The agent runs from the verity-sealed `/mvm/runtime` overlay; a tampered overlay fails the roothash.

--- a/specs/plans/124-guest-agent-lean-overlay.md
+++ b/specs/plans/124-guest-agent-lean-overlay.md
@@ -24,7 +24,7 @@
 
 - [x] **Step 1:** Baseline recorded — `cargo tree -p mvm-guest -e no-dev` = **203 crates** (host target); the async stack (`tokio`/`rtnetlink`/`async-trait`/`netlink-packet-route`) is `cfg(linux)`-gated, so it only surfaces under `--target aarch64-unknown-linux-musl`.
 - [x] **Step 2:** `xtask check-guest-agent-runtime-free` mirrors `check-core-runtime-free`: `cargo tree -p mvm-guest -e no-dev --prefix none --locked --target aarch64-unknown-linux-musl`, fails if `{tokio, async-trait, rtnetlink, netlink-packet-route}` appear. Parser unit tests green; the live gate is **RED now** (exit 1, all four present) — the real failing test A3 drives to green.
-- [ ] **Step 3 (lands with A3):** wire the gate into `ci.yml` in the same commit that makes it pass (no knowingly-red required check in the tree). Coordinate with 128.
+- [x] **Step 3 (landed with A3):** the gate is wired into `ci.yml` in the A3 commit — the same commit that flips it green, so no knowingly-red required check ever sat in the tree.
 
 ### Task A2: `serde_json` → hand-rolled framing in `vsock`
 
@@ -38,13 +38,17 @@ ADR-066 §9. The wire format is a small fixed set of typed messages; a hand-roll
 
 ### Task A3: `rtnetlink` → `linux-raw-sys` in `netinit`
 
-`netinit` configures the guest's interface/routes via `rtnetlink` (async, pulls tokio). Raw netlink over `linux-raw-sys` is a few dozen lines and no_std-friendly.
+`netinit` installs blackhole routes via `rtnetlink` (async, pulls tokio). Raw netlink over a synchronous `AF_NETLINK` socket is a few dozen lines.
 
-**Files:** `crates/mvm-guest/src/netinit.rs`, `bin/mvm-guest-netinit.rs`.
+**Dep deviation (2026-06-05):** the brief said add `linux-raw-sys`. Done **dep-free instead** — the rtnetlink constants are frozen kernel UAPI, so they're inlined (cross-platform, in a `#[cfg(any(target_os = "linux", test))] mod wire`) and the socket syscalls use `libc` (already a dep). Net deps added: **0** (vs +1); removed: 4. `constants_match_libc` (a `cfg(linux)` test) pins each inlined constant to `libc`'s value on CI.
 
-- [ ] **Step 1:** Failing test (gated, needs netns) — netinit brings the interface up + sets the route, asserted via `/proc/net` or a netns probe, with no `rtnetlink`/`tokio`. Also: make `RouteInstaller` a *synchronous* trait (drop `#[async_trait]`) so removing rtnetlink also removes `tokio` + `async-trait`. The cross-platform trait + install-loop + `MockInstaller` tests run on a macOS dev host; the raw-netlink installer itself is `cfg(target_os = "linux")` and rides Linux CI.
-- [ ] **Step 2:** Hand-roll the `RTM_NEWADDR`/`RTM_NEWROUTE` messages over a raw `AF_NETLINK` socket (`linux-raw-sys`). Keep the `NetworkMandatoryDeny` audit marker (claim 10). Drop `tokio` (dep + dev-dep), `async-trait`, `rtnetlink`, `netlink-packet-route` from `Cargo.toml`.
-- [ ] **Step 3:** The A1 gate (`check-guest-agent-runtime-free`) now passes — add its lane to `ci.yml` in this commit. Commit.
+**Scope note:** the current `netinit` only installs `RTM_NEWROUTE` blackholes (the `MANDATORY_DENY_RANGES` floor); it never did `RTM_NEWADDR`/interface-up. A3 is a faithful port of *that* surface — no new interface-config behaviour.
+
+**Files:** `crates/mvm-guest/src/netinit.rs`, `bin/mvm-guest-netinit.rs`, `Cargo.toml`.
+
+- [x] **Step 1:** `RouteInstaller` is now a *synchronous* trait (dropped `#[async_trait]`); `install_mandatory_deny` + `MockInstaller` + the six former `#[tokio::test]`s are sync and green on macOS. TDD RED→GREEN landed on the risky new bit — `encode_blackhole_route_v4` (pure netlink-message byte layout), pinned by `encode_blackhole_route_v4_produces_exact_netlink_bytes` + `…_carries_prefix_and_addr`. The live netns route test stays gated for Linux CI.
+- [x] **Step 2:** `RawNetlinkInstaller` (`cfg(linux)`) opens/binds a `NETLINK_ROUTE` socket and does a blocking `sendto`+`recv` ACK (EEXIST → idempotent Ok), keeping the `REPORT_MARKER` audit path (claim 10). Dropped `tokio` (dep + dev-dep), `async-trait`, `rtnetlink`, `netlink-packet-route` — Cargo.lock shed ~20 crates.
+- [x] **Step 3:** A1 gate (`check-guest-agent-runtime-free`) is GREEN; its lane is wired into `ci.yml` in this commit.
 
 ### Task A4: confirm the cut
 

--- a/specs/plans/124-guest-agent-lean-overlay.md
+++ b/specs/plans/124-guest-agent-lean-overlay.md
@@ -4,9 +4,9 @@
 
 **Goal:** Make the guest agent small, universal, and sealed. Cut its heavy deps (`tokio`→`polling`, `serde_json`→hand-rolled framing, `rtnetlink`→`linux-raw-sys`, drop `async-trait`) — the real dep reduction in the rewrite. Run the *same* `mvm-guest-agent` in every VM type (builder/dev included). Ship it from the verity-sealed runtime overlay (ADR-051). Generate the **SDKs** (data/IR types + the RPC client surface, in every language) from one schema so they can't drift from each other or the core, and hand the runtime config to the guest on a read-only device before vsock is up.
 
-**Architecture:** The agent (`crates/mvm-guest`: `mvm-guest-agent.rs` + `vsock`/`worker_pool`/`netinit`/`fs_rpc`/`process_rpc`/…) is feature-complete but heavy. This plan keeps its behavior and shrinks its closure: the `worker_pool` async runtime, the `vsock` JSON framing, and `netinit`'s netlink are the three weight centers. The universal-agent invariant (ADR-066 §6) and the verity overlay (ADR-051) already exist as designs; this wires them. **Claim 4 (no `do_exec` in prod) and claim 5 (vsock framing fuzzed) are invariants this plan must preserve** — the dev/builder tier runs the `dev-shell`-featured agent (with `do_exec`), prod workloads run the no-exec build, and the new hand-rolled framing keeps its fuzz target.
+**Architecture:** The agent (`crates/mvm-guest`: `mvm-guest-agent.rs` + `vsock`/`worker_pool`/`netinit`/`fs_rpc`/`process_rpc`/…) is feature-complete but heavy. This plan keeps its behavior and shrinks its closure. **Reality check (2026-06-05, verified against the worktree):** the agent's request-serving path is *already* synchronous — `worker_pool.rs`, `vsock.rs`, and `mvm-guest-agent.rs` use `std::thread` + `Mutex`/`Condvar`, with no `tokio` and no `async`. The *only* async surface in the crate is `netinit`'s `rtnetlink` installer, which is the sole reason `tokio` + `async-trait` enter the closure (both `cfg(target_os = "linux")`-gated; `Cargo.toml` attributes them to Plan 74 W2, not the pool). So there are **two** real weight centers, not three: `netinit`'s async netlink (`tokio` + `async-trait` + `rtnetlink` + `netlink-packet-route` — Task A3) and `vsock`'s `serde_json` framing (Task A2). There is no async runtime to remove from `worker_pool`; A1 is therefore a **lock-in gate**, not a rewrite, and `polling` is *not* added (it would be a net dep increase with nothing to remove). Recommended order: **A1 (gate) → A3 (the tokio cut) → A2 (serde_json) → A4 (measure)**. The universal-agent invariant (ADR-066 §6) and the verity overlay (ADR-051) already exist as designs; this wires them. **Claim 4 (no `do_exec` in prod) and claim 5 (vsock framing fuzzed) are invariants this plan must preserve** — the dev/builder tier runs the `dev-shell`-featured agent (with `do_exec`), prod workloads run the no-exec build, and the new hand-rolled framing keeps its fuzz target.
 
-**Tech Stack:** Rust (`mvm-guest`), `polling` (epoll/kqueue), `linux-raw-sys` (raw netlink), the verity initramfs (`mvm-verity-init`), a protocol-codegen step (build script or `xtask`). Net **removes** ~25–35 crates; adds `polling` + `linux-raw-sys` (small, no_std-friendly).
+**Tech Stack:** Rust (`mvm-guest`), `linux-raw-sys` (raw netlink), the verity initramfs (`mvm-verity-init`), a protocol-codegen step (build script or `xtask`). Net **removes** ~25–35 crates; adds only `linux-raw-sys` (small, no_std-friendly). (`polling` was in the original sketch for a "tokio worker pool" that does not exist — the pool is already synchronous `std::thread`; dropped.)
 
 **Prereqs:** 121 (the `mvm-guest` home, the `mvm-host-vm-init` → `mvm-build` bin). The universal-agent invariant is ADR-066 §6; the overlay is ADR-051.
 
@@ -16,16 +16,15 @@
 
 ## Phase A — the lean dep cut
 
-### Task A1: `tokio` → `polling` in `worker_pool`
+### Task A1: runtime-free lock-in gate (was: `tokio` → `polling` in `worker_pool`)
 
-The agent is I/O-bound vsock dispatch; it doesn't need a full async runtime. Replace the `tokio` worker pool with a `polling`-based readiness loop + a small thread pool.
+**Premise corrected 2026-06-05.** The worker pool is *already* synchronous — `worker_pool.rs` is `std::thread` + `Mutex`/`Condvar` with zero `tokio`/`async`; `vsock.rs` and `mvm-guest-agent.rs` likewise. There is no tokio worker pool to convert and `polling` buys nothing. A1 instead delivers the **gate that locks in the property A3 achieves**: `mvm-guest`'s non-dev closure pulls no async runtime. It is RED today (the async stack is present via `netinit`'s rtnetlink) and flips GREEN when A3 lands.
 
-**Files:** `crates/mvm-guest/src/worker_pool.rs`, `worker_protocol.rs`, `bin/mvm-guest-agent.rs`; `Cargo.toml`.
+**Files:** `xtask/src/check_guest_agent_runtime_free.rs` (new), `xtask/src/main.rs`; `.github/workflows/ci.yml` (lane added in the A3 commit, where it goes green).
 
-- [ ] **Step 1:** Record baseline `cargo tree -p mvm-guest -e no-dev | wc -l`.
-- [ ] **Step 2:** Failing test — the worker pool dispatches N concurrent vsock requests and returns all responses (behavioral parity test against the current pool), with no `tokio` in the dep tree.
-- [ ] **Step 3:** Reimplement over `polling` (edge-triggered readiness on the vsock fd) + a fixed worker-thread set; drop `tokio` + `async-trait` from `mvm-guest/Cargo.toml`. Keep the public dispatch API so callers don't churn.
-- [ ] **Step 4:** Tests green; `cargo tree` delta recorded (expect tokio's closure gone — the largest single cut). Commit.
+- [x] **Step 1:** Baseline recorded — `cargo tree -p mvm-guest -e no-dev` = **203 crates** (host target); the async stack (`tokio`/`rtnetlink`/`async-trait`/`netlink-packet-route`) is `cfg(linux)`-gated, so it only surfaces under `--target aarch64-unknown-linux-musl`.
+- [x] **Step 2:** `xtask check-guest-agent-runtime-free` mirrors `check-core-runtime-free`: `cargo tree -p mvm-guest -e no-dev --prefix none --locked --target aarch64-unknown-linux-musl`, fails if `{tokio, async-trait, rtnetlink, netlink-packet-route}` appear. Parser unit tests green; the live gate is **RED now** (exit 1, all four present) — the real failing test A3 drives to green.
+- [ ] **Step 3 (lands with A3):** wire the gate into `ci.yml` in the same commit that makes it pass (no knowingly-red required check in the tree). Coordinate with 128.
 
 ### Task A2: `serde_json` → hand-rolled framing in `vsock`
 
@@ -43,8 +42,9 @@ ADR-066 §9. The wire format is a small fixed set of typed messages; a hand-roll
 
 **Files:** `crates/mvm-guest/src/netinit.rs`, `bin/mvm-guest-netinit.rs`.
 
-- [ ] **Step 1:** Failing test (gated, needs netns) — netinit brings the interface up + sets the route, asserted via `/proc/net` or a netns probe, with no `rtnetlink`/`tokio`.
-- [ ] **Step 2:** Hand-roll the `RTM_NEWADDR`/`RTM_NEWROUTE` messages over a raw `AF_NETLINK` socket (`linux-raw-sys`). Keep the `NetworkMandatoryDeny` audit marker (claim 10). Commit.
+- [ ] **Step 1:** Failing test (gated, needs netns) — netinit brings the interface up + sets the route, asserted via `/proc/net` or a netns probe, with no `rtnetlink`/`tokio`. Also: make `RouteInstaller` a *synchronous* trait (drop `#[async_trait]`) so removing rtnetlink also removes `tokio` + `async-trait`. The cross-platform trait + install-loop + `MockInstaller` tests run on a macOS dev host; the raw-netlink installer itself is `cfg(target_os = "linux")` and rides Linux CI.
+- [ ] **Step 2:** Hand-roll the `RTM_NEWADDR`/`RTM_NEWROUTE` messages over a raw `AF_NETLINK` socket (`linux-raw-sys`). Keep the `NetworkMandatoryDeny` audit marker (claim 10). Drop `tokio` (dep + dev-dep), `async-trait`, `rtnetlink`, `netlink-packet-route` from `Cargo.toml`.
+- [ ] **Step 3:** The A1 gate (`check-guest-agent-runtime-free`) now passes — add its lane to `ci.yml` in this commit. Commit.
 
 ### Task A4: confirm the cut
 

--- a/xtask/src/check_guest_agent_runtime_free.rs
+++ b/xtask/src/check_guest_agent_runtime_free.rs
@@ -1,0 +1,139 @@
+//! `xtask check-guest-agent-runtime-free`
+//!
+//! Plan 124 Phase A. Assert that `mvm-guest`'s non-dev closure pulls no
+//! async runtime — `tokio` — nor the async glue that drags it in
+//! (`async-trait`, and the async `rtnetlink`/`netlink-packet-route`
+//! netlink stack). The agent's request-serving path is synchronous
+//! `std::thread` + `Mutex`/`Condvar` (see `worker_pool.rs`, `vsock.rs`);
+//! the *only* async surface is `netinit`'s rtnetlink installer, which
+//! Phase A Task A3 replaces with synchronous raw netlink over
+//! `linux-raw-sys`. Once A3 lands, this set vanishes and the gate is the
+//! regression backstop that keeps it gone.
+//!
+//! **Target matters.** `tokio`/`rtnetlink`/`netlink-packet-route` are
+//! `cfg(target_os = "linux")` deps (host-side mvmctl builds on macOS skip
+//! them). `cargo tree` resolves for the *host* target by default, so on a
+//! macOS dev host the gated stack is invisible and the gate would pass
+//! vacuously. We pin `--target aarch64-unknown-linux-musl` (the guest's
+//! real target) so the check sees the closure the guest actually links.
+//! `cargo tree` resolves a target's cfg graph without the rustup std
+//! target installed, so this is portable across contributor hosts and CI.
+//!
+//! Sibling of `check-core-runtime-free` (plan 126 B5) — same lockfile-vs-
+//! feature-resolution rationale: `tokio` is legitimately in `Cargo.lock`
+//! (mvm-hostd et al. pull it), so a name-based lockfile check can't
+//! express "not in *this crate's* tree". `cargo tree` can.
+
+use anyhow::{Context, Result, bail};
+use std::path::Path;
+use std::process::Command;
+
+/// The async closure the lean guest agent must not carry (Plan 124 A3).
+/// `tokio` is the runtime; `async-trait` is the async-fn-in-trait glue
+/// the old `RouteInstaller` needed; `rtnetlink`/`netlink-packet-route`
+/// are the async netlink stack that pulled both in.
+const FORBIDDEN: &[&str] = &["tokio", "async-trait", "rtnetlink", "netlink-packet-route"];
+
+/// The guest's real build target. The async stack above is
+/// `cfg(target_os = "linux")`-gated, invisible to a default (host) tree
+/// on a macOS contributor host — pin a Linux target so the gate is real.
+const GUEST_TARGET: &str = "aarch64-unknown-linux-musl";
+
+pub fn run(workspace: &Path) -> Result<()> {
+    let cargo = std::env::var("CARGO").unwrap_or_else(|_| "cargo".to_string());
+    let output = Command::new(&cargo)
+        .current_dir(workspace)
+        .args([
+            "tree",
+            "-p",
+            "mvm-guest",
+            "-e",
+            "no-dev",
+            "--prefix",
+            "none",
+            "--locked",
+            "--target",
+            GUEST_TARGET,
+        ])
+        .output()
+        .context("running `cargo tree -p mvm-guest -e no-dev --target <guest>`")?;
+
+    if !output.status.success() {
+        bail!(
+            "cargo tree failed: {}",
+            String::from_utf8_lossy(&output.stderr).trim()
+        );
+    }
+
+    let tree = String::from_utf8_lossy(&output.stdout);
+    let found = forbidden_hits(&tree, FORBIDDEN);
+
+    if !found.is_empty() {
+        bail!(
+            "check-guest-agent-runtime-free: mvm-guest's non-dev closure pulls the async \
+             networking stack ({}) on {GUEST_TARGET}. Plan 124 A3 replaces netinit's \
+             rtnetlink installer with synchronous raw netlink (linux-raw-sys), which drops \
+             tokio + async-trait. If you're seeing this after A3, the async stack crept back \
+             — keep the agent's request-serving path synchronous.",
+            found.join(", ")
+        );
+    }
+
+    eprintln!(
+        "check-guest-agent-runtime-free: clean (mvm-guest non-dev closure on {GUEST_TARGET} \
+         pulls no tokio/async-trait/rtnetlink)"
+    );
+    Ok(())
+}
+
+/// Parse `cargo tree --prefix none` output (one crate per line, name
+/// first) and return the sorted-unique forbidden crates present. Shared
+/// shape with `check_core_runtime_free` — keyed on the exact crate name
+/// so `tokio-util` never false-positives for `tokio`.
+fn forbidden_hits<'a>(tree: &'a str, forbidden: &[&str]) -> Vec<&'a str> {
+    let mut hits: Vec<&str> = tree
+        .lines()
+        .filter_map(|line| line.split_whitespace().next())
+        .filter(|name| forbidden.contains(name))
+        .collect();
+    hits.sort_unstable();
+    hits.dedup();
+    hits
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn clean_tree_has_no_async_stack() {
+        let tree = "mvm-guest v0.15.2\nanyhow v1.0.99\nlibc v0.2.0\nserde v1.0.0\n";
+        assert!(forbidden_hits(tree, FORBIDDEN).is_empty());
+    }
+
+    #[test]
+    fn tree_with_async_stack_is_flagged() {
+        // What the guest's Linux tree looks like today, pre-A3.
+        let tree = "mvm-guest v0.15.2\nasync-trait v0.1.89 (proc-macro)\nrtnetlink v0.14.1\n\
+                    netlink-packet-route v0.19.0\ntokio v1.49.0\ntokio v1.49.0 (*)\n";
+        assert_eq!(
+            forbidden_hits(tree, FORBIDDEN),
+            vec!["async-trait", "netlink-packet-route", "rtnetlink", "tokio"]
+        );
+    }
+
+    #[test]
+    fn dedups_repeated_tokio_lines() {
+        // `cargo tree` prints `(*)` dedup markers for repeated subtrees;
+        // the parser must collapse them to one hit.
+        let tree = "mvm-guest v0.15.2\ntokio v1.49.0\ntokio v1.49.0 (*)\n";
+        assert_eq!(forbidden_hits(tree, FORBIDDEN), vec!["tokio"]);
+    }
+
+    #[test]
+    fn substring_match_does_not_false_positive() {
+        // `tokio-util`/`tokio-macros` are not `tokio`; key on exact name.
+        let tree = "mvm-guest v0.15.2\ntokio-util v0.7.0\ntokio-macros v2.0.0\n";
+        assert!(forbidden_hits(tree, FORBIDDEN).is_empty());
+    }
+}

--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -8,6 +8,7 @@ mod check_claim_catalog;
 mod check_core_runtime_free;
 mod check_doc_claims;
 mod check_forbidden_deps;
+mod check_guest_agent_runtime_free;
 mod check_mvm_host_binaries_sync;
 mod check_no_display_on_secret_types;
 mod check_no_overclaim;
@@ -46,6 +47,10 @@ fn main() -> Result<()> {
             let workspace = workspace_root();
             check_core_runtime_free::run(&workspace)
         }
+        Some("check-guest-agent-runtime-free") => {
+            let workspace = workspace_root();
+            check_guest_agent_runtime_free::run(&workspace)
+        }
         Some("check-no-overclaim") => {
             let workspace = workspace_root();
             check_no_overclaim::run(&workspace)
@@ -76,7 +81,7 @@ fn main() -> Result<()> {
             gen_stubs::check(&workspace)
         }
         Some(other) => anyhow::bail!(
-            "Unknown xtask: {:?}. Available: gen-man, check-adr-coverage, check-no-display-on-secret-types, check-audit-positional, check-doc-claims, check-forbidden-deps, check-core-runtime-free, check-no-overclaim, check-spec-numbers, check-claim-catalog, check-mvm-host-binaries-sync, perf, build-dev-image, gen-stubs, check-stubs",
+            "Unknown xtask: {:?}. Available: gen-man, check-adr-coverage, check-no-display-on-secret-types, check-audit-positional, check-doc-claims, check-forbidden-deps, check-core-runtime-free, check-guest-agent-runtime-free, check-no-overclaim, check-spec-numbers, check-claim-catalog, check-mvm-host-binaries-sync, perf, build-dev-image, gen-stubs, check-stubs",
             other
         ),
         None => {
@@ -102,6 +107,9 @@ fn main() -> Result<()> {
             );
             eprintln!(
                 "  check-core-runtime-free                 Plan 126 B5: assert mvm-core's default build pulls no tokio"
+            );
+            eprintln!(
+                "  check-guest-agent-runtime-free          Plan 124 A: assert mvm-guest's Linux closure pulls no tokio/async-trait/rtnetlink"
             );
             eprintln!(
                 "  check-no-overclaim                      Plan 75 W0 lint: refuse gated phrases from specs/claims/ outside exempt paths"


### PR DESCRIPTION
Plan 124 Phase A — make the guest agent's dep closure lean. Net result:
**`mvm-guest`'s Linux closure goes 126 → 99 unique crates (−27, 0 added)** —
the entire `tokio` + `futures` + `netlink` ecosystem that async `rtnetlink`
dragged in. Numbers + method in `docs/investigations/plan-124-lean-agent-dep-cut.md`.

## What's here

- **A1 — runtime-free gate.** `xtask check-guest-agent-runtime-free` mirrors
  `check-core-runtime-free`, pinned to the guest's real target
  (`aarch64-unknown-linux-musl`, since the async stack is `cfg(linux)`-gated
  and invisible on a host tree), and fails if `{tokio, async-trait, rtnetlink,
  netlink-packet-route}` re-enter the closure. Wired into the CI Lint job.
- **A3 — the actual cut.** `netinit`'s `RouteInstaller` is now a synchronous
  trait; the production installer (`RawNetlinkInstaller`, `cfg(linux)`) opens a
  `NETLINK_ROUTE` socket and does a blocking `sendto`+`recv` ACK instead of the
  async `rtnetlink` crate. The `RTM_NEWROUTE` message is built as pure bytes in
  a `cfg(any(linux, test))` `wire` module — TDD'd RED→GREEN and pinned by an
  exact-byte-layout test that runs on any host; `constants_match_libc` pins the
  inlined UAPI constants to `libc` on Linux. Dropped `tokio` (dep + dev-dep),
  `async-trait`, `rtnetlink`, `netlink-packet-route`. **Zero deps added** — the
  brief's `linux-raw-sys` was unnecessary (`libc` covers the syscalls).
- **A4 — measured + documented** the cut.

## Premises corrected (recorded in the plan doc)

The plan was written pre-121 and two premises didn't survive the code:
- **A1's "tokio worker pool"** never existed — the pool was already synchronous
  `std::thread`; tokio entered only via netinit. A1 became a lock-in gate.
- **A2 (`serde_json` → hand-rolled vsock codec) is deferred — not viable.**
  `serde_json` enters `mvm-guest` transitively via `mvm-core`
  (`serde_json → mvm-core → mvm-guest`) and is load-bearing in 7 guest modules +
  3 bins, so a hand-rolled codec removes **0 crates** for a large, risky rewrite
  of the claim-5 wire. Genuinely shedding it is gated on de-serde'ing `mvm-core`.

## Invariants

Claim 4 (`prod-agent-no-exec`) untouched — A3 never touched the agent bin or
`do_exec`. Claim 5 (vsock fuzz) untouched — A2 deferred, vsock + fuzz unchanged.
Claim 10 (`NetworkMandatoryDeny`) preserved — same blackhole routes, same
`REPORT_MARKER` console-audit line.

## Verification

- macOS: 236 `mvm-guest` tests pass, clippy `-D warnings` clean, nightly fmt clean.
- Linux target (`aarch64-unknown-linux-gnu`): `cargo check` **and**
  `clippy -D warnings` clean for `mvm-guest --all-targets`, compiling the
  `cfg(linux)` installer + `constants_match_libc`.
- Runtime AF_NETLINK behaviour is exercised by CI / a real KVM host.