### PR TITLE
plan-124 Phase B: universal agent — builder VM forks mvm-guest-agent

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -90,6 +90,9 @@ jobs:
       - name: mvm-guest agent closure is runtime-free
         run: cargo run -p xtask -- check-guest-agent-runtime-free
 
+      - name: guest agent forked in every bootable image
+        run: cargo run -p xtask -- check-guest-agent-in-all-images
+
   test:
     name: Test
     runs-on: ubuntu-latest

--- a/crates/mvm-build/src/bin/mvm-host-vm-init.rs
+++ b/crates/mvm-build/src/bin/mvm-host-vm-init.rs
@@ -300,9 +300,114 @@ pub(crate) fn setup_dev_fd_symlinks(dev_root: &std::path::Path) -> Result<(), St
     Ok(())
 }
 
+// ============================================================================
+// Guest-agent fork (Plan 124 B1 / ADR-066 §6 — the universal-agent invariant)
+// ============================================================================
+//
+// The builder/dev VM bakes `mvm-guest-agent` (mkGuest, via the
+// `entrypoint.shell = "/bin/sh"` → dev-shell build) but PID 1 here never
+// forked it, so vsock port 5252 stayed unbound on builder/dev VMs — only
+// workload VMs ran the agent. B1 makes this init fork the agent under
+// setpriv exactly as the workload `/init` does (nix/lib/mk-guest.nix), so
+// the *same* agent runs in every VM type. The argv construction + binary
+// resolution are pure (cross-platform-testable); the spawn itself is in
+// `linux::run`.
+
+#[cfg(any(target_os = "linux", test))]
+use std::path::{Path, PathBuf};
+#[cfg(any(target_os = "linux", test))]
+use std::process::Command;
+
+/// The uid the guest agent is dropped to via setpriv. The agent is a
+/// long-lived RPC service, not a build step, so it gets its own uid —
+/// distinct from build commands' `BUILDER_UID` (902). Mirrors the
+/// workload `/init` fork in `nix/lib/mk-guest.nix` (ADR-002 W4.5).
+#[cfg(any(target_os = "linux", test))]
+const AGENT_UID: u32 = 990;
+
+/// Candidate paths for the baked `mvm-guest-agent`, in preference order.
+/// The verity runtime overlay (ADR-051), when attached, bind-mounts the
+/// agent at `/mvm/runtime/agent`; prefer it over the rootfs-baked copy.
+/// Same order the workload `/init` probes.
+#[cfg(any(target_os = "linux", test))]
+const AGENT_BIN_CANDIDATES: [&str; 2] = ["/mvm/runtime/agent", "/usr/local/bin/mvm-guest-agent"];
+
+/// Resolve which agent binary to launch: the first candidate `is_exec`
+/// reports runnable. `is_exec` is injected so the preference order is
+/// unit-testable without a filesystem (production passes a real
+/// executable check). `None` — neither present — means the VM boots
+/// agent-less, which is non-fatal and surfaced in `mvmctl status`,
+/// exactly as the workload path treats a missing agent.
+#[cfg(any(target_os = "linux", test))]
+fn resolve_agent_binary(is_exec: impl Fn(&Path) -> bool) -> Option<PathBuf> {
+    AGENT_BIN_CANDIDATES
+        .iter()
+        .map(Path::new)
+        .find(|p| is_exec(p))
+        .map(Path::to_path_buf)
+}
+
+/// Build the `setpriv` command that forks the guest agent under the agent
+/// uid. Mirrors the workload `/init` invocation in `nix/lib/mk-guest.nix`:
+/// `setpriv --reuid --regid --clear-groups --no-new-privs -- <agent>`. No
+/// `--bounding-set=-all` — unlike a build step the agent keeps the default
+/// bounding set (the reference + ADR-002 W4.5 do not strip it here).
+#[cfg(any(target_os = "linux", test))]
+fn agent_spawn_command(agent_bin: &Path) -> Command {
+    let mut c = Command::new("setpriv");
+    c.arg(format!("--reuid={AGENT_UID}"))
+        .arg(format!("--regid={AGENT_UID}"))
+        .arg("--clear-groups")
+        .arg("--no-new-privs")
+        .arg("--")
+        .arg(agent_bin);
+    c
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    // ── Plan 124 B1: guest-agent fork (universal-agent invariant) ──
+
+    #[test]
+    fn agent_spawn_command_mirrors_workload_init_setpriv() {
+        let cmd = agent_spawn_command(Path::new("/usr/local/bin/mvm-guest-agent"));
+        assert_eq!(cmd.get_program().to_str().unwrap(), "setpriv");
+        let args: Vec<&str> = cmd.get_args().map(|a| a.to_str().unwrap()).collect();
+        assert_eq!(
+            args,
+            [
+                "--reuid=990",
+                "--regid=990",
+                "--clear-groups",
+                "--no-new-privs",
+                "--",
+                "/usr/local/bin/mvm-guest-agent",
+            ]
+        );
+    }
+
+    #[test]
+    fn resolve_agent_binary_prefers_runtime_overlay() {
+        // Both present → the verity overlay path wins (ADR-051).
+        let got = resolve_agent_binary(|_| true);
+        assert_eq!(got, Some(PathBuf::from("/mvm/runtime/agent")));
+    }
+
+    #[test]
+    fn resolve_agent_binary_falls_back_to_baked_copy() {
+        // Overlay absent, baked copy present → the rootfs copy.
+        let got = resolve_agent_binary(|p| p == Path::new("/usr/local/bin/mvm-guest-agent"));
+        assert_eq!(got, Some(PathBuf::from("/usr/local/bin/mvm-guest-agent")));
+    }
+
+    #[test]
+    fn resolve_agent_binary_none_when_neither_present() {
+        // Neither present → boot agent-less (non-fatal, surfaced in status).
+        let got = resolve_agent_binary(|_| false);
+        assert_eq!(got, None);
+    }
 
     /// `setup_dev_fd_symlinks` lays down all four conventional symlinks
     /// in an empty /dev so bash process substitution (`< <(...)`)
@@ -605,6 +710,58 @@ mod linux {
     /// don't carry an install_spec.json.
     const INSTALL_SPEC_FILENAME: &str = "install_spec.json";
 
+    /// Plan 124 B1 — fork `mvm-guest-agent` under setpriv to the agent
+    /// uid, mirroring the workload `/init` (`nix/lib/mk-guest.nix`). Best
+    /// effort: a missing binary or spawn error logs and returns so PID 1
+    /// proceeds to the builder dispatch loop. The agent supervises vsock
+    /// RPC on port 5252; without it the host can boot the builder VM but
+    /// can't reach the agent — exactly the pre-B1 state this fixes.
+    fn fork_guest_agent() {
+        use std::os::unix::process::CommandExt;
+
+        let Some(agent_bin) = crate::resolve_agent_binary(is_executable) else {
+            eprintln!(
+                "mvm-host-vm-init: no mvm-guest-agent found at {:?}; booting agent-less",
+                crate::AGENT_BIN_CANDIDATES
+            );
+            return;
+        };
+        let mut cmd = crate::agent_spawn_command(&agent_bin);
+        // New session so the agent isn't in PID 1's signal / controlling-
+        // terminal group — the workload /init uses `setsid` for the same
+        // reason. stdio is inherited so the agent's logs reach the console.
+        unsafe {
+            cmd.pre_exec(|| {
+                // SAFETY: async-signal-safe, no allocation, runs in the
+                // forked child before execve.
+                libc::setsid();
+                Ok(())
+            });
+        }
+        match cmd.spawn() {
+            Ok(child) => eprintln!(
+                "mvm-host-vm-init: forked mvm-guest-agent pid={} from {}",
+                child.id(),
+                agent_bin.display()
+            ),
+            Err(e) => eprintln!(
+                "mvm-host-vm-init: failed to fork mvm-guest-agent from {}: {e}; booting agent-less",
+                agent_bin.display()
+            ),
+        }
+    }
+
+    /// `[ -x <path> ]` — exists and is executable. Picks the agent binary
+    /// (overlay vs baked) the same way the workload /init's shell test does.
+    fn is_executable(p: &Path) -> bool {
+        use std::os::unix::ffi::OsStrExt;
+        let Ok(c) = std::ffi::CString::new(p.as_os_str().as_bytes()) else {
+            return false;
+        };
+        // SAFETY: `c` is a valid NUL-terminated C string for access() to read.
+        unsafe { libc::access(c.as_ptr(), libc::X_OK) == 0 }
+    }
+
     pub fn run() -> ExitCode {
         eprintln!("mvm-host-vm-init: pid 1 starting");
 
@@ -758,6 +915,15 @@ mod linux {
                 return power_off();
             }
         }
+
+        // Plan 124 B1 / ADR-066 §6 — fork the guest agent under setpriv so
+        // the builder/dev VM runs the *same* agent every workload VM does
+        // (vsock 5252). After the egress lockdown so the agent comes up
+        // behind the same egress floor; non-fatal so a missing agent or
+        // spawn failure never wedges PID 1 — the builder protocol is the
+        // primary job, the agent is additive (mirrors the workload /init,
+        // which also never blocks on the agent).
+        fork_guest_agent();
 
         // Plan 89 W3 part 3 dispatch: if the host staged a
         // `dispatch.sock.marker` in /job, this VM is persistent

--- a/specs/plans/124-guest-agent-lean-overlay.md
+++ b/specs/plans/124-guest-agent-lean-overlay.md
@@ -65,8 +65,10 @@ ADR-066 §6. The builder/dev VM bakes the agent (via mkGuest) but PID 1 (`mvm-ho
 
 **Files:** `crates/mvm-build/src/bin/mvm-host-vm-init.rs` (post-121).
 
-- [ ] **Step 1:** Failing test — `mvm-host-vm-init` startup spawns `mvm-guest-agent` under setpriv to the agent uid (assert the child is launched + reachable on vsock 5252 in a gated boot test). The dev/builder tier runs the `dev-shell` agent (with `do_exec` — a dev-tier VM, ADR-002 tier matrix).
-- [ ] **Step 2:** Fork it alongside the builder protocol + the PTY console; the agent and the build path coexist (mkGuest's workload `/init` already does both). Commit.
+Agent uid is **990** (CLAUDE.md's "901" is stale — the live `nix/lib/mk-guest.nix` workload fork uses 990); vsock port 5252; binary at `/mvm/runtime/agent` (verity overlay, ADR-051) or `/usr/local/bin/mvm-guest-agent` (baked), same preference order the workload `/init` probes.
+
+- [x] **Step 1:** TDD'd the testable core (cross-platform, runs on macOS): `agent_spawn_command` builds the exact workload-`/init` setpriv argv (`setpriv --reuid=990 --regid=990 --clear-groups --no-new-privs -- <agent>`); `resolve_agent_binary` prefers the overlay path then the baked copy, `None` (agent-less, non-fatal) when neither. 4 tests, RED→GREEN. (The live "reachable on vsock 5252" boot assertion stays gated for a real builder-VM boot — CI / KVM host.)
+- [x] **Step 2:** `fork_guest_agent()` (in `mod linux`) resolves the binary via a real `[ -x ]` (`libc::access` X_OK), spawns it under setpriv with `pre_exec` → `setsid` (new session, like the workload `/init`'s `setsid`), and is called from `run()` **after the egress lockdown, before the dispatch loop** — non-fatal, so a missing agent never wedges PID 1. The agent coexists with the builder dispatch protocol (the fork is a detached background child; PID 1 continues to the loop). The builder/dev tier already bakes the `dev-shell` agent (`entrypoint.shell = "/bin/sh"` → `withDevShell = true`), so no agent-build change is needed. **Verified:** 111 macOS bin tests green; `cargo zigbuild --target aarch64-unknown-linux-musl` produces a static ELF with `fork_guest_agent`/`is_executable` compiled+linked (the `cfg(linux)` path builds for the real guest target).
 
 ### Task B2: `xtask check-guest-agent-in-all-images`
 

--- a/specs/plans/124-guest-agent-lean-overlay.md
+++ b/specs/plans/124-guest-agent-lean-overlay.md
@@ -74,8 +74,8 @@ Agent uid is **990** (CLAUDE.md's "901" is stale — the live `nix/lib/mk-guest.
 
 The enforcement gate from ADR-066 §6.
 
-- [ ] **Step 1:** Failing test — the lint fails when a bootable image's launch path omits the agent. Enumerate the images (mkGuest workload, builder-vm, dev) and assert each forks `mvm-guest-agent`.
-- [ ] **Step 2:** Implement the `xtask` check; wire into `ci.yml` (coordinate with 128). Commit.
+- [x] **Step 1:** `launcher_forks_agent` + unit tests (`present_marker_passes`, `missing_marker_is_flagged`, `every_declared_launcher_has_a_distinct_marker`) — the lint fails when a launcher drops its agent-fork marker. The two distinct **launch mechanisms** are enumerated (not three — "dev" rides one of these): mkGuest `/init` (`nix/lib/mk-guest.nix`, marker `MVM_AGENT_BIN`) for workload + dev-shell images, and `mvm-host-vm-init` (marker `fork_guest_agent`) for the builder VM's PID 1.
+- [x] **Step 2:** `xtask check-guest-agent-in-all-images` implemented (source-grep tripwire, sibling of `check-claim-catalog`/`check-guest-agent-runtime-free`); wired into the `ci.yml` Lint job. Live gate GREEN now that B1 added the builder-VM fork. Commit.
 
 ## Phase C — runtime overlay (ADR-051)
 

--- a/xtask/src/check_guest_agent_in_all_images.rs
+++ b/xtask/src/check_guest_agent_in_all_images.rs
@@ -1,0 +1,106 @@
+//! `xtask check-guest-agent-in-all-images`
+//!
+//! Plan 124 B2 / ADR-066 §6 — the universal-agent invariant. Every
+//! bootable mvm image must fork `mvm-guest-agent` in its launch path, so
+//! the *same* agent runs in every VM type (workload, dev, builder). This
+//! gate is the tripwire: if a launcher's agent-fork is deleted, the
+//! corresponding marker vanishes and CI fails here.
+//!
+//! There are two distinct launch mechanisms:
+//!   1. **mkGuest `/init`** (`nix/lib/mk-guest.nix`) — the workload and
+//!      dev-shell images. Forks the agent via `setpriv … -- "$MVM_AGENT_BIN"`.
+//!   2. **`mvm-host-vm-init`** — PID 1 of the libkrun builder VM. Forks
+//!      the agent via `fork_guest_agent()` (Plan 124 B1).
+//!
+//! Source-grep, not a build: the launch paths are a Nix shell script and
+//! a `cfg(linux)` Rust binary, neither of which this gate can execute on
+//! a contributor host. Same shape as `check-claim-catalog` (witness must
+//! exist) and `check-guest-agent-runtime-free`.
+
+use anyhow::{Context, Result, bail};
+use std::path::Path;
+
+/// `(image launch path, file relative to workspace, marker proving the
+/// agent is forked there)`. The marker is chosen to be specific to the
+/// fork mechanism — removing the fork removes the marker.
+const AGENT_LAUNCHERS: &[(&str, &str, &str)] = &[
+    // mkGuest's /init resolves the agent into `$MVM_AGENT_BIN` and execs
+    // it under setpriv; the var exists only in the agent-fork block.
+    (
+        "workload + dev-shell microVM (mkGuest /init)",
+        "nix/lib/mk-guest.nix",
+        "MVM_AGENT_BIN",
+    ),
+    // The builder VM's PID 1 forks the agent via this fn (Plan 124 B1).
+    (
+        "builder VM PID 1 (mvm-host-vm-init)",
+        "crates/mvm-build/src/bin/mvm-host-vm-init.rs",
+        "fork_guest_agent",
+    ),
+];
+
+pub fn run(workspace: &Path) -> Result<()> {
+    let mut missing: Vec<String> = Vec::new();
+
+    for (desc, rel, marker) in AGENT_LAUNCHERS {
+        let path = workspace.join(rel);
+        let content = std::fs::read_to_string(&path)
+            .with_context(|| format!("reading agent launcher {rel} ({desc})"))?;
+        if !launcher_forks_agent(&content, marker) {
+            missing.push(format!("{desc} — `{rel}` no longer contains `{marker}`"));
+        }
+    }
+
+    if !missing.is_empty() {
+        bail!(
+            "check-guest-agent-in-all-images: a bootable image's launch path no longer forks \
+             mvm-guest-agent (ADR-066 §6 universal-agent invariant):\n  - {}\n\
+             Every VM type (workload, dev, builder) must run the agent — restore the fork or \
+             update this gate's marker if the launch mechanism was deliberately rewritten.",
+            missing.join("\n  - ")
+        );
+    }
+
+    eprintln!(
+        "check-guest-agent-in-all-images: clean ({} launch paths fork mvm-guest-agent)",
+        AGENT_LAUNCHERS.len()
+    );
+    Ok(())
+}
+
+/// A launcher forks the agent iff its source carries the fork marker.
+fn launcher_forks_agent(content: &str, marker: &str) -> bool {
+    content.contains(marker)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn present_marker_passes() {
+        let src = r#"MVM_AGENT_BIN=/usr/local/bin/mvm-guest-agent
+            setpriv --reuid=990 -- "$MVM_AGENT_BIN" &"#;
+        assert!(launcher_forks_agent(src, "MVM_AGENT_BIN"));
+    }
+
+    #[test]
+    fn missing_marker_is_flagged() {
+        // A launcher that boots straight to the entrypoint, no agent fork.
+        let src = "exec /usr/bin/myapp";
+        assert!(!launcher_forks_agent(src, "fork_guest_agent"));
+    }
+
+    #[test]
+    fn every_declared_launcher_has_a_distinct_marker() {
+        // Guards the table itself: no copy-paste duplicate (file, marker).
+        let mut seen = std::collections::HashSet::new();
+        for (_, rel, marker) in AGENT_LAUNCHERS {
+            assert!(
+                seen.insert((*rel, *marker)),
+                "duplicate launcher ({rel}, {marker})"
+            );
+        }
+        assert_eq!(AGENT_LAUNCHERS.len(), 2, "workload/dev-shell + builder VM");
+    }
+}

--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -8,6 +8,7 @@ mod check_claim_catalog;
 mod check_core_runtime_free;
 mod check_doc_claims;
 mod check_forbidden_deps;
+mod check_guest_agent_in_all_images;
 mod check_guest_agent_runtime_free;
 mod check_mvm_host_binaries_sync;
 mod check_no_display_on_secret_types;
@@ -51,6 +52,10 @@ fn main() -> Result<()> {
             let workspace = workspace_root();
             check_guest_agent_runtime_free::run(&workspace)
         }
+        Some("check-guest-agent-in-all-images") => {
+            let workspace = workspace_root();
+            check_guest_agent_in_all_images::run(&workspace)
+        }
         Some("check-no-overclaim") => {
             let workspace = workspace_root();
             check_no_overclaim::run(&workspace)
@@ -81,7 +86,7 @@ fn main() -> Result<()> {
             gen_stubs::check(&workspace)
         }
         Some(other) => anyhow::bail!(
-            "Unknown xtask: {:?}. Available: gen-man, check-adr-coverage, check-no-display-on-secret-types, check-audit-positional, check-doc-claims, check-forbidden-deps, check-core-runtime-free, check-guest-agent-runtime-free, check-no-overclaim, check-spec-numbers, check-claim-catalog, check-mvm-host-binaries-sync, perf, build-dev-image, gen-stubs, check-stubs",
+            "Unknown xtask: {:?}. Available: gen-man, check-adr-coverage, check-no-display-on-secret-types, check-audit-positional, check-doc-claims, check-forbidden-deps, check-core-runtime-free, check-guest-agent-runtime-free, check-guest-agent-in-all-images, check-no-overclaim, check-spec-numbers, check-claim-catalog, check-mvm-host-binaries-sync, perf, build-dev-image, gen-stubs, check-stubs",
             other
         ),
         None => {
@@ -110,6 +115,9 @@ fn main() -> Result<()> {
             );
             eprintln!(
                 "  check-guest-agent-runtime-free          Plan 124 A: assert mvm-guest's Linux closure pulls no tokio/async-trait/rtnetlink"
+            );
+            eprintln!(
+                "  check-guest-agent-in-all-images         Plan 124 B: assert every bootable image's launch path forks mvm-guest-agent"
             );
             eprintln!(
                 "  check-no-overclaim                      Plan 75 W0 lint: refuse gated phrases from specs/claims/ outside exempt paths"


### PR DESCRIPTION
Plan 124 Phase B — the universal-agent invariant (ADR-066 §6): the *same*
`mvm-guest-agent` runs in every VM type. Before this, the builder/dev VM
baked the agent but its PID 1 (`mvm-host-vm-init`) never forked it, so
vsock 5252 stayed unbound there — only workload VMs ran the agent.

## B1 — `mvm-host-vm-init` forks `mvm-guest-agent`

Mirrors the workload `/init` (`nix/lib/mk-guest.nix`):
`setpriv --reuid=990 --regid=990 --clear-groups --no-new-privs -- <agent>`,
preferring the verity-overlay path (`/mvm/runtime/agent`, ADR-051) over the
baked copy (`/usr/local/bin/mvm-guest-agent`). Agent uid **990** (CLAUDE.md's
901 is stale vs the live nix).

- `agent_spawn_command` / `resolve_agent_binary` are pure and
  cross-platform-tested (4 tests, RED→GREEN).
- `fork_guest_agent` (`mod linux`) resolves via `libc::access` X_OK and
  spawns under setpriv with `pre_exec`→`setsid`, called from `run()` after
  the egress lockdown and before the dispatch loop. **Non-fatal**: a missing
  agent or spawn error logs and PID 1 continues — the builder protocol is the
  primary job, the agent is additive (matches the workload /init never
  blocking on it). The builder/dev tier already bakes the `dev-shell` agent.

## B2 — `check-guest-agent-in-all-images` gate

A CI tripwire (sibling of `check-claim-catalog` / `check-guest-agent-runtime-free`)
asserting every bootable image's launch path forks the agent. Source-grep,
since the launch paths are a Nix shell script and a `cfg(linux)` Rust binary.
Two launch mechanisms enumerated: mkGuest `/init` (`MVM_AGENT_BIN`) for
workload + dev-shell, and `mvm-host-vm-init` (`fork_guest_agent`) for the
builder VM. Wired into the Lint job; live gate is GREEN.

## Verification

- 111 macOS `mvm-host-vm-init` tests + 3 gate unit tests pass; clippy
  `-D warnings` clean; nightly fmt clean.
- `cargo zigbuild --target aarch64-unknown-linux-musl` links the `cfg(linux)`
  `fork_guest_agent` into a static guest ELF (plain `cargo check --target`
  can't — `mvm-build` has a C build-dep with no cross gcc on the dev host).
- The live "agent reachable on vsock 5252" assertion stays gated for a real
  builder-VM boot (CI / KVM host).