### PR TITLE
fix(network): Plan 123 L3-B — macOS-safe gateway selection + workload honors MVM_NETWORKING

### DIFF
--- a/crates/mvm-backend/src/libkrun.rs
+++ b/crates/mvm-backend/src/libkrun.rs
@@ -110,18 +110,25 @@ fn build_supervisor_config(config: &VmStartConfig, state_dir: &Path) -> Result<S
         .with_cmdline(&cmdline)
         .with_vsock_socket_dir(state_dir.to_string_lossy().into_owned())
         .add_vsock_port(mvm_guest::vsock::GUEST_AGENT_PORT);
-    // Plan 87/88 / ADR-058 — configure the per-OS virtio-net gateway
-    // (macOS → gvproxy, Linux → passt), the same default the builder VM
-    // uses. TSI was removed (Plan 102 W6.A): it bypasses virtio-net, so
-    // the admitted gateway-audit bridge refuses it (claim-10 no-bypass).
-    // KrunContext defaults to TSI, so an unconfigured workload would be
-    // rejected by `run_supervisor_with_bridge`. The supervisor spawns the
-    // gateway from this declared mode.
+    // Plan 87/88 / ADR-058 — configure the virtio-net gateway. TSI was removed
+    // (Plan 102 W6.A): it bypasses virtio-net, so the admitted gateway-audit
+    // bridge refuses it (claim-10 no-bypass). KrunContext defaults to TSI, so an
+    // unconfigured workload would be rejected by `run_supervisor_with_bridge`.
+    // The supervisor spawns the gateway from this declared mode.
+    //
+    // Plan 123 L3-B — select the gateway through the SAME `resolve_networking_mode`
+    // the builder VM uses, so a workload honours `MVM_NETWORKING` consistently
+    // (previously this site hardcoded `cfg!(macos)` and ignored the override).
+    // The default is unchanged (macOS→gvproxy, Linux→passt); an explicit
+    // `MVM_NETWORKING=passt` on macOS resolves to gvproxy (passt is Linux-only).
     let scratch = state_dir.to_string_lossy().into_owned();
-    let krun = if cfg!(target_os = "macos") {
-        krun.with_gvproxy(libkrun_sys::gvproxy::DEFAULT_GUEST_MAC, scratch)
-    } else {
-        krun.with_passt(libkrun_sys::passt::DEFAULT_GUEST_MAC, scratch)
+    let krun = match mvm_build::libkrun_builder::resolve_networking_mode() {
+        mvm_build::libkrun_builder::NetworkingPreference::Gvproxy => {
+            krun.with_gvproxy(libkrun_sys::gvproxy::DEFAULT_GUEST_MAC, scratch)
+        }
+        mvm_build::libkrun_builder::NetworkingPreference::Passt => {
+            krun.with_passt(libkrun_sys::passt::DEFAULT_GUEST_MAC, scratch)
+        }
     };
 
     // User-supplied volumes (--volume / MVM_VOLUMES). A directory share

--- a/crates/mvm-build/src/libkrun_builder.rs
+++ b/crates/mvm-build/src/libkrun_builder.rs
@@ -214,7 +214,23 @@ pub fn resolve_networking_mode() -> NetworkingPreference {
         .map(str::to_ascii_lowercase)
         .as_deref()
     {
-        Some("passt") => NetworkingPreference::Passt,
+        // passt is Linux-only — the Homebrew formula refuses to build on macOS.
+        // An explicit `MVM_NETWORKING=passt` on macOS can't be honoured (the
+        // supervisor would fail to spawn the gateway), so fall back to gvproxy
+        // with a warning rather than hand it an unspawnable gateway. On Linux,
+        // passt is honoured. This keeps `resolve_networking_mode` safe to call
+        // from every gateway-selection site, macOS included.
+        Some("passt") => {
+            if cfg!(target_os = "macos") {
+                tracing::warn!(
+                    "MVM_NETWORKING=passt is not supported on macOS \
+                     (passt is Linux-only); falling back to gvproxy"
+                );
+                NetworkingPreference::Gvproxy
+            } else {
+                NetworkingPreference::Passt
+            }
+        }
         Some("gvproxy") => NetworkingPreference::Gvproxy,
         None | Some("") => default_networking_mode(),
         Some(other) => {
@@ -2202,7 +2218,15 @@ mod tests {
             assert_eq!(resolve_networking_mode(), default_networking_mode());
 
             std::env::set_var("MVM_NETWORKING", " passt ");
-            assert_eq!(resolve_networking_mode(), NetworkingPreference::Passt);
+            // passt is Linux-only (the Homebrew formula refuses to build it on
+            // macOS), so an explicit passt pin is macOS-safe: resolve falls back
+            // to gvproxy with a warning rather than handing the supervisor a
+            // gateway it can't spawn.
+            if cfg!(target_os = "macos") {
+                assert_eq!(resolve_networking_mode(), NetworkingPreference::Gvproxy);
+            } else {
+                assert_eq!(resolve_networking_mode(), NetworkingPreference::Passt);
+            }
 
             std::env::set_var("MVM_NETWORKING", "GVPROXY");
             assert_eq!(resolve_networking_mode(), NetworkingPreference::Gvproxy);


### PR DESCRIPTION
Closes the libkrun gateway-selection divergence L3 slice A flagged.

**Reconcile** — `resolve_networking_mode` is now macOS-safe: `MVM_NETWORKING=passt` on macOS (where passt is Linux-only and won't build) falls back to gvproxy with a warning instead of handing the supervisor an unspawnable gateway. Default unchanged (macOS→gvproxy, Linux→passt); Linux passt honored. **Verified on this Mac** — `resolve_networking_mode_parses_env` now asserts `passt → Gvproxy` on macOS and it passes.

**Re-point** — the workload start site (`mvm_backend::libkrun::build_supervisor_config`) hardcoded `cfg!(target_os = "macos")` and **ignored `MVM_NETWORKING`**, diverging from the builder VM (which honored it). It now goes through the *same* `resolve_networking_mode`, so a workload honors the override consistently — e.g. `MVM_NETWORKING=gvproxy` on Linux now applies to workloads too. **macOS behaviour is unchanged** (the reconcile makes the selection macOS-safe, so the only change is Linux gaining the override). mvm-backend already enables mvm-build's `builder-vm` feature, so the function is reachable.

clippy `-D warnings` on both crates + nightly fmt; the reconcile is locally tested (mvm-backend's binary only SIGKILLs on *run*, so the re-point is compile-verified + rides CI).