### PR TITLE
feat(secrets): Plan 129 Phase A — SecretRef auth_type + allowed_hosts + binding validation

### DIFF
--- a/crates/mvm-cli/src/commands/vm/managed_secrets.rs
+++ b/crates/mvm-cli/src/commands/vm/managed_secrets.rs
@@ -115,6 +115,8 @@ mod tests {
             reference: mvm_sdk::ir::SecretRef {
                 name: name.into(),
                 mount: SecretMount::Env { var: var.into() },
+                auth_type: mvm_sdk::ir::AuthType::Bearer,
+                allowed_hosts: vec!["api.example.com".into()],
             },
         }
     }

--- a/crates/mvm-sdk/schema/error-codes.json
+++ b/crates/mvm-sdk/schema/error-codes.json
@@ -34,8 +34,8 @@
       "description": "Source.kind names a variant reserved but not implemented in v0 (nix_derivation, oci_image).",
       "applicable_fields": ["apps[*].source.kind"]
     },
-    "E_SECRETS_NOT_IMPLEMENTED": {
-      "description": "SecretRef is not supported in v0; the secrets subsystem awaits a dedicated ADR.",
+    "E_SECRET_WITHOUT_BINDING": {
+      "description": "A SecretRef declares no allowed_hosts. An unbound secret could be substituted toward any destination the egress endpoint reaches, so it is refused (claim 12). Add hosts, e.g. [\"api.example.com\"] or [\"*.example.com\"].",
       "applicable_fields": ["apps[*].env.*", "apps[*].entrypoint.env.*"]
     },
     "E_PERSIST_DEFERRED": {

--- a/crates/mvm-sdk/src/compile/explain.rs
+++ b/crates/mvm-sdk/src/compile/explain.rs
@@ -285,7 +285,7 @@ mod tests {
             entries.iter().map(|e| e.code.as_str()).collect();
         let ir_codes = [
             ErrorCode::FunctionNotFound,
-            ErrorCode::SecretsNotImplemented,
+            ErrorCode::SecretWithoutBinding,
             ErrorCode::AddonLockfileMissing,
             ErrorCode::UnsupportedLanguage,
             ErrorCode::AddonNotFound,

--- a/crates/mvm-sdk/src/compile/orchestrator.rs
+++ b/crates/mvm-sdk/src/compile/orchestrator.rs
@@ -651,6 +651,8 @@ mod tests {
                     mount: SecretMount::Env {
                         var: "API_KEY".into(),
                     },
+                    auth_type: crate::ir::AuthType::Bearer,
+                    allowed_hosts: vec!["api.openai.com".into()],
                 },
             },
         );

--- a/crates/mvm-sdk/src/decorator/python.rs
+++ b/crates/mvm-sdk/src/decorator/python.rs
@@ -656,7 +656,7 @@ import mvm
     image=mvm.python_image(python="3.12"),
     env={
         "MODEL_PATH": "/data/model.pt",
-        "API_KEY": mvm.secret("api-key"),
+        "API_KEY": mvm.secret("api-key", type="bearer", hosts=["api.openai.com"]),
     },
 )
 def greet(): pass
@@ -670,6 +670,8 @@ def greet(): pass
         match env.get("API_KEY") {
             Some(EnvValue::SecretRef { reference }) => {
                 assert_eq!(reference.name, "api-key");
+                assert_eq!(reference.auth_type, crate::ir::AuthType::Bearer);
+                assert_eq!(reference.allowed_hosts, ["api.openai.com"]);
                 match &reference.mount {
                     SecretMount::Env { var } => assert_eq!(var, "api-key"),
                     other => panic!("expected Env mount, got {other:?}"),

--- a/crates/mvm-sdk/src/decorator/typescript.rs
+++ b/crates/mvm-sdk/src/decorator/typescript.rs
@@ -687,7 +687,7 @@ export const greet = mvm.app({
   image: mvm.python_image({ python: "3.12" }),
   env: {
     "MODEL_PATH": "/data/model.pt",
-    "API_KEY": mvm.secret("api-key"),
+    "API_KEY": mvm.secret("api-key", { type: "bearer", hosts: ["api.openai.com"] }),
   },
 })(() => "x");
 "#;
@@ -700,6 +700,8 @@ export const greet = mvm.app({
         match env.get("API_KEY") {
             Some(EnvValue::SecretRef { reference }) => {
                 assert_eq!(reference.name, "api-key");
+                assert_eq!(reference.auth_type, crate::ir::AuthType::Bearer);
+                assert_eq!(reference.allowed_hosts, ["api.openai.com"]);
                 match &reference.mount {
                     SecretMount::Env { var } => assert_eq!(var, "api-key"),
                     other => panic!("expected Env mount, got {other:?}"),

--- a/crates/mvm-sdk/src/decorator/value.rs
+++ b/crates/mvm-sdk/src/decorator/value.rs
@@ -11,8 +11,8 @@ use std::collections::BTreeMap;
 use std::path::{Path, PathBuf};
 
 use crate::ir::{
-    App, Dependencies, Entrypoint, EnvValue, Format, HookCmd, Hooks, Image, Mount, Network,
-    NetworkEgress, NetworkMode, NodeTool, PortForward, PortProto, PythonTool, Resources,
+    App, AuthType, Dependencies, Entrypoint, EnvValue, Format, HookCmd, Hooks, Image, Mount,
+    Network, NetworkEgress, NetworkMode, NodeTool, PortForward, PortProto, PythonTool, Resources,
     SecretMount, SecretRef, Source, Workload,
 };
 
@@ -638,12 +638,20 @@ fn helper_to_env_value(v: Value, path: &Path, line: usize) -> Result<EnvValue, P
                 }
             };
             let mount_var = pop_string_kwarg(&mut kwargs, "var");
+            // Plan 129 A1 — the reference declares HOW (auth_type) and WHERE
+            // (allowed_hosts) the secret is used on egress. `type` is required
+            // (no sensible default); an empty `hosts` is caught at validation as
+            // an unbound secret (claim 12), so it stays optional here.
+            let auth_type = parse_auth_type(pop_string_kwarg(&mut kwargs, "type"), path, line)?;
+            let allowed_hosts = pop_string_list_kwarg(&mut kwargs, "hosts");
             Ok(EnvValue::SecretRef {
                 reference: SecretRef {
                     name: secret_name.clone(),
                     mount: SecretMount::Env {
                         var: mount_var.unwrap_or(secret_name),
                     },
+                    auth_type,
+                    allowed_hosts,
                 },
             })
         }
@@ -774,6 +782,46 @@ fn pop_string_kwarg(map: &mut BTreeMap<String, Value>, key: &str) -> Option<Stri
     match map.remove(key) {
         Some(Value::Str(s)) => Some(s),
         _ => None,
+    }
+}
+
+/// Pop a list-of-strings kwarg (e.g. `mvm.secret(hosts=[...])`). Absent or the
+/// wrong shape yields an empty Vec; non-string list items are dropped. Emptiness
+/// is a policy concern caught at validation, not a parse error.
+fn pop_string_list_kwarg(map: &mut BTreeMap<String, Value>, key: &str) -> Vec<String> {
+    match map.remove(key) {
+        Some(Value::List(items)) => items
+            .into_iter()
+            .filter_map(|v| match v {
+                Value::Str(s) => Some(s),
+                _ => None,
+            })
+            .collect(),
+        _ => Vec::new(),
+    }
+}
+
+/// Parse the `mvm.secret(type=...)` kwarg into an [`AuthType`]. Required — a
+/// secret with no declared auth type can't be used by the keyholder.
+fn parse_auth_type(raw: Option<String>, path: &Path, line: usize) -> Result<AuthType, ParseError> {
+    match raw.as_deref() {
+        Some("sigv4") => Ok(AuthType::Sigv4),
+        Some("hmac") => Ok(AuthType::Hmac),
+        Some("bearer") => Ok(AuthType::Bearer),
+        Some("basic") => Ok(AuthType::Basic),
+        Some(other) => Err(ParseError::HelperBadKwarg {
+            path: path.to_path_buf(),
+            line,
+            helper: "mvm.secret".to_string(),
+            kwarg: "type".to_string(),
+            detail: format!("unknown auth type {other:?}; expected sigv4 | hmac | bearer | basic"),
+        }),
+        None => Err(ParseError::HelperMissingKwarg {
+            path: path.to_path_buf(),
+            line,
+            helper: "mvm.secret".to_string(),
+            kwarg: "type",
+        }),
     }
 }
 

--- a/crates/mvm-sdk/src/ir/error_codes.rs
+++ b/crates/mvm-sdk/src/ir/error_codes.rs
@@ -11,7 +11,7 @@ pub enum ErrorCode {
     EmptyApps,
     MultiAppDeferred,
     SourceKindDeferred,
-    SecretsNotImplemented,
+    SecretWithoutBinding,
     PersistDeferred,
     NetworkPortsWithNone,
     CompileOutputExistsNotDir,
@@ -80,7 +80,7 @@ impl ErrorCode {
             Self::EmptyApps => "E_EMPTY_APPS",
             Self::MultiAppDeferred => "E_MULTI_APP_DEFERRED",
             Self::SourceKindDeferred => "E_SOURCE_KIND_DEFERRED",
-            Self::SecretsNotImplemented => "E_SECRETS_NOT_IMPLEMENTED",
+            Self::SecretWithoutBinding => "E_SECRET_WITHOUT_BINDING",
             Self::PersistDeferred => "E_PERSIST_DEFERRED",
             Self::NetworkPortsWithNone => "E_NETWORK_PORTS_WITH_NONE",
             Self::CompileOutputExistsNotDir => "E_COMPILE_OUTPUT_EXISTS_NOT_DIR",
@@ -165,7 +165,7 @@ mod tests {
             ErrorCode::EmptyApps,
             ErrorCode::MultiAppDeferred,
             ErrorCode::SourceKindDeferred,
-            ErrorCode::SecretsNotImplemented,
+            ErrorCode::SecretWithoutBinding,
             ErrorCode::PersistDeferred,
             ErrorCode::NetworkPortsWithNone,
             ErrorCode::CompileOutputExistsNotDir,
@@ -223,8 +223,8 @@ mod tests {
 
     #[test]
     fn serializes_as_plain_string() {
-        let json = serde_json::to_string(&ErrorCode::SecretsNotImplemented).unwrap();
-        assert_eq!(json, "\"E_SECRETS_NOT_IMPLEMENTED\"");
+        let json = serde_json::to_string(&ErrorCode::SecretWithoutBinding).unwrap();
+        assert_eq!(json, "\"E_SECRET_WITHOUT_BINDING\"");
     }
 
     // The upstream `all_codes_match_registry` test cross-checked the

--- a/crates/mvm-sdk/src/ir/mod.rs
+++ b/crates/mvm-sdk/src/ir/mod.rs
@@ -27,8 +27,8 @@ pub use hooks::{HookCmd, Hooks};
 pub use validate::{ValidationError, validate};
 pub use version::{IR_MAJOR, IR_MINOR, VersionError, validate_schema_version};
 pub use workload::{
-    App, Concurrency, Dependencies, Entrypoint, EnvValue, Format, HostPort, Image, InProcessMode,
-    JsonSchemaShape, Mount, MountMode, MountSource, Network, NetworkDns, NetworkEgress,
-    NetworkMode, NodeTool, PortForward, PortProto, PythonTool, Resources, SecretMount, SecretRef,
-    Source, Volume, WarmProcessConfig, Workload,
+    App, AuthType, Concurrency, Dependencies, Entrypoint, EnvValue, Format, HostPort, Image,
+    InProcessMode, JsonSchemaShape, Mount, MountMode, MountSource, Network, NetworkDns,
+    NetworkEgress, NetworkMode, NodeTool, PortForward, PortProto, PythonTool, Resources,
+    SecretMount, SecretRef, Source, Volume, WarmProcessConfig, Workload, host_matches,
 };

--- a/crates/mvm-sdk/src/ir/validate.rs
+++ b/crates/mvm-sdk/src/ir/validate.rs
@@ -646,16 +646,23 @@ fn validate_source(source: &Source, base: &str, errors: &mut Vec<ValidationError
 
 fn validate_env(env: &BTreeMap<String, EnvValue>, base: &str, errors: &mut Vec<ValidationError>) {
     for (key, value) in env {
-        if matches!(value, EnvValue::SecretRef { .. }) {
+        // Plan 129 A2 — a SecretRef is admitted once it declares a destination
+        // binding. claim 12: a secret with no allowed_hosts could be substituted
+        // toward any host the egress endpoint reaches, so refuse the unbound one.
+        // `auth_type` is a typed enum (always valid); `name` is required by the
+        // decorator that produces it.
+        if let EnvValue::SecretRef { reference } = value
+            && reference.allowed_hosts.is_empty()
+        {
             errors.push(ValidationError {
-                code: ErrorCode::SecretsNotImplemented,
+                code: ErrorCode::SecretWithoutBinding,
                 path: format!("{base}.{key}"),
-                detail: "SecretRef env values are not supported until the secrets \
-                         subsystem ADR lands. \
-                         Hint: for the v0 boot path, materialize secrets out-of-band \
-                         (e.g. mount via `mounts=[mv.mount(...)]` from a pre-provisioned \
-                         volume) and read them from disk inside the wrapper."
-                    .to_string(),
+                detail: format!(
+                    "secret {:?} declares no allowed_hosts — an unbound secret is a \
+                     claim-12 violation. Add hosts (e.g. [\"api.example.com\"] or \
+                     [\"*.example.com\"]).",
+                    reference.name
+                ),
             });
         }
     }

--- a/crates/mvm-sdk/src/ir/workload.rs
+++ b/crates/mvm-sdk/src/ir/workload.rs
@@ -399,14 +399,47 @@ pub enum EnvValue {
     },
 }
 
-// allow(secret-debug): metadata-only — `name` is a secret-store key (not
-// the secret value), `mount` is a delivery shape (env-var name or file
-// path). No secret bytes ever live in this struct.
+// allow(secret-debug): metadata-only — `name` is a secret-store key (not the
+// secret value), `mount` is a delivery shape (env-var name or file path), and
+// `auth_type`/`allowed_hosts` say how + where the secret is used on egress. No
+// secret bytes ever live in this struct.
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize, JsonSchema)]
 #[serde(deny_unknown_fields)]
 pub struct SecretRef {
     pub name: String,
     pub mount: SecretMount,
+    /// How the keyholder uses the secret on egress (signer vs injector) — Plan
+    /// 129 / ADR-067 §4.
+    pub auth_type: AuthType,
+    /// The hosts the substituted credential may reach — the claim-12 binding.
+    /// Supports `*.` subdomain wildcards (see [`host_matches`]). An empty list
+    /// is an unbound secret, rejected at validation (`SecretWithoutBinding`).
+    pub allowed_hosts: Vec<String>,
+}
+
+/// How a secret authenticates an outbound request, so the keyholder picks the
+/// right path: `Sigv4`/`Hmac` are *signed* (the key never leaves the signer);
+/// `Bearer`/`Basic` are *injected* credentials. Plan 129 / ADR-067 §4.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize, JsonSchema)]
+#[serde(rename_all = "snake_case")]
+pub enum AuthType {
+    Sigv4,
+    Hmac,
+    Bearer,
+    Basic,
+}
+
+/// Whether `host` is permitted by an `allowed_hosts` `pattern`. Exact match, or
+/// a `*.suffix` wildcard that matches any subdomain of `suffix` at any depth but
+/// NOT the apex `suffix` itself — the leading dot stops a registrable lookalike
+/// (`*.example.com` rejects `evilexample.com`). Case-insensitive.
+pub fn host_matches(pattern: &str, host: &str) -> bool {
+    let pattern = pattern.to_ascii_lowercase();
+    let host = host.to_ascii_lowercase();
+    match pattern.strip_prefix("*.") {
+        Some(suffix) => host.ends_with(&format!(".{suffix}")),
+        None => pattern == host,
+    }
 }
 
 // allow(secret-debug): metadata-only — variants carry the env-var name
@@ -625,5 +658,39 @@ mod tests {
     #[test]
     fn has_declared_entrypoint_false_for_empty_entrypoints() {
         assert!(!app_with(vec![]).has_declared_entrypoint());
+    }
+
+    #[test]
+    fn secret_ref_carries_auth_type_and_hosts_never_bytes() {
+        // Plan 129 A1: the reference says HOW the secret is used (auth_type, so
+        // the keyholder picks signer vs injector) and WHERE it may go
+        // (allowed_hosts — the claim-12 binding). Still no bytes.
+        let r: SecretRef = serde_json::from_str(
+            r#"{"name":"openai","mount":{"kind":"env","var":"OPENAI_API_KEY"},"auth_type":"bearer","allowed_hosts":["api.openai.com"]}"#,
+        )
+        .unwrap();
+        assert_eq!(r.auth_type, AuthType::Bearer);
+        assert_eq!(r.allowed_hosts, ["api.openai.com"]);
+        // deny_unknown_fields keeps a stray "value" out — no secret bytes in the IR.
+        assert!(
+            serde_json::from_str::<SecretRef>(
+                r#"{"name":"x","mount":{"kind":"env","var":"X"},"value":"sk-..."}"#
+            )
+            .is_err()
+        );
+    }
+
+    #[test]
+    fn host_matches_handles_wildcards_and_lookalikes() {
+        // Exact match.
+        assert!(host_matches("api.openai.com", "api.openai.com"));
+        assert!(!host_matches("api.openai.com", "evil.com"));
+        // `*.` matches any subdomain depth, case-insensitively…
+        assert!(host_matches("*.example.com", "api.example.com"));
+        assert!(host_matches("*.example.com", "a.b.example.com"));
+        assert!(host_matches("API.Example.COM", "api.example.com"));
+        // …but NOT the apex, and the leading dot guards a registrable lookalike.
+        assert!(!host_matches("*.example.com", "example.com"));
+        assert!(!host_matches("*.example.com", "evilexample.com"));
     }
 }

--- a/crates/mvm-sdk/tests/validate.rs
+++ b/crates/mvm-sdk/tests/validate.rs
@@ -1,7 +1,7 @@
 use mvm_sdk::ir::{
-    App, Concurrency, Entrypoint, EnvValue, ErrorCode, Format, HostPort, Image, InProcessMode,
-    Network, NetworkEgress, NetworkMode, PortForward, PortProto, Resources, SecretMount, SecretRef,
-    Source, Volume, WarmProcessConfig, Workload, validate,
+    App, AuthType, Concurrency, Entrypoint, EnvValue, ErrorCode, Format, HostPort, Image,
+    InProcessMode, Network, NetworkEgress, NetworkMode, PortForward, PortProto, Resources,
+    SecretMount, SecretRef, Source, Volume, WarmProcessConfig, Workload, validate,
 };
 
 fn base_app() -> App {
@@ -113,7 +113,9 @@ fn rejects_reserved_source_kinds() {
 }
 
 #[test]
-fn rejects_secret_ref_in_app_env() {
+fn admits_secret_ref_with_a_binding() {
+    // Plan 129 A2 — a SecretRef that declares allowed_hosts is admitted (the
+    // SecretsNotImplemented gate is gone).
     let mut w = base_workload();
     w.apps[0].env.insert(
         "TOKEN".to_string(),
@@ -123,16 +125,17 @@ fn rejects_secret_ref_in_app_env() {
                 mount: SecretMount::Env {
                     var: "TOKEN".to_string(),
                 },
+                auth_type: AuthType::Bearer,
+                allowed_hosts: vec!["api.example.com".to_string()],
             },
         },
     );
-    let errs = validate(&w).unwrap_err();
-    assert_eq!(errs[0].code, ErrorCode::SecretsNotImplemented);
-    assert_eq!(errs[0].path, ".apps[0].env.TOKEN");
+    assert!(validate(&w).is_ok());
 }
 
 #[test]
-fn rejects_secret_ref_in_entrypoint_env() {
+fn rejects_unbound_secret_ref() {
+    // claim 12 — a secret with no allowed_hosts is unbound; refuse it.
     let mut w = base_workload();
     let env = match &mut w.apps[0].entrypoints[0] {
         Entrypoint::Command { env, .. } => env,
@@ -146,11 +149,13 @@ fn rejects_secret_ref_in_entrypoint_env() {
                 mount: SecretMount::File {
                     path: "/run/k".to_string(),
                 },
+                auth_type: AuthType::Bearer,
+                allowed_hosts: vec![],
             },
         },
     );
     let errs = validate(&w).unwrap_err();
-    assert_eq!(errs[0].code, ErrorCode::SecretsNotImplemented);
+    assert_eq!(errs[0].code, ErrorCode::SecretWithoutBinding);
     assert_eq!(errs[0].path, ".apps[0].entrypoint.env.KEY");
 }
 


### PR DESCRIPTION
Starts **Plan 129 (Secrets subsystem)** — the payoff of the A3 substitution/scan seam landed this session. Phase A is the IR contract (123-independent).

**A1 — `SecretRef` says how + where, still no bytes.** Adds `auth_type: AuthType {Sigv4,Hmac,Bearer,Basic}` (so the keyholder picks signer vs injector) + `allowed_hosts: Vec<String>` (the claim-12 destination binding, with `*.` subdomain wildcards via a new `host_matches` helper). `deny_unknown_fields` keeps a stray `"value"` out. The decorator (Python + TS) now parses `type` (required) + `hosts` from `mvm.secret(...)`. **`mount` stays** as the guest-side *placeholder* delivery (per the egress-substitution model — flagged + agreed).

**A2 — lift the not-implemented gate.** Replaces the `SecretsNotImplemented` hard reject with the binding check: a `SecretRef` with `allowed_hosts` validates; an empty list is refused as **`SecretWithoutBinding`** (an unbound secret is a claim-12 violation). Dropped the dead code + renamed its `error-codes.json` entry.

308 mvm-sdk tests green (new serde + `host_matches` wildcard tests incl. the `evilexample.com` lookalike + apex-not-matched cases; rewritten admit/reject-unbound tests; updated decorator + orchestrator fixtures). clippy `-D warnings` + nightly fmt.

Next: **B** (`SecretResolver` + `mvmctl secret set`) and **C** (keyholder: SigV4/HMAC signer + bearer/basic injector) — both fully local. **D–E** wire into the A3 `SubstitutionStage`/`ScanStage` on main.