### PR TITLE
feat(plan-166): QEMU workload runtime backend (Phase 2)

### DIFF
--- a/.github/workflows/architecture.yml
+++ b/.github/workflows/architecture.yml
@@ -85,6 +85,14 @@ jobs:
   #      `mvm-secrets-dispatcher`). These UDS listeners are VM-local
   #      broker/signer helpers spawned by the supervisor for a single
   #      workload, not multi-tenant control-plane servers.
+  #   9. QEMU workload host-side vsock bridge
+  #      (`crates/mvm-backend/src/qemu.rs`). QEMU's virtio-vsock speaks
+  #      real AF_VSOCK, but the shared agent client connects to the
+  #      per-port Unix-domain socket libkrun/Firecracker expose; the
+  #      QEMU backend binds that UDS and splices each connection to the
+  #      guest's `AF_VSOCK(cid, GUEST_AGENT_PORT)`. Per-VM developer
+  #      substrate (same family as the in-guest addon vsock bridge,
+  #      category 7), not a control-plane server. Plan 166 Phase 2.
   #
   # The in-guest vsock agent in `mvm-guest` is also excluded — it
   # runs *inside* the microVM, not on the host.
@@ -186,6 +194,7 @@ jobs:
               --glob '!crates/deps/libkrun-sys/src/gvproxy.rs' \
               --glob '!crates/mvm-backend/src/mock_guest_agent.rs' \
               --glob '!crates/mvm-guest-helpers/src/addon_vsock_bridge.rs' \
+              --glob '!crates/mvm-backend/src/qemu.rs' \
               -e "$PATTERNS" \
               crates/ src/ \
               || true)

--- a/crates/mvm-backend/src/backend.rs
+++ b/crates/mvm-backend/src/backend.rs
@@ -17,6 +17,7 @@ use crate::image::RuntimeVolume;
 use crate::libkrun::LibkrunBackend;
 use crate::microvm::{DriveFile, FlakeRunConfig};
 use crate::mock::MockBackend;
+use crate::qemu::QemuBackend;
 use crate::vz::VzBackend;
 use crate::{firecracker, microvm, microvm_nix};
 
@@ -144,6 +145,21 @@ impl VmBackend for FirecrackerBackend {
     }
 
     fn start(&self, config: &VmStartConfig) -> Result<VmId> {
+        // Task 2.2 / ADR-072 — fail closed when KVM is absent rather than
+        // letting the Firecracker boot fault deep in the API handshake.
+        // Firecracker is the production runtime and *requires* `/dev/kvm`;
+        // a no-KVM host should use `--hypervisor qemu` for local dev/test
+        // (Tier-3 TCG), never a silent Firecracker fallback. On macOS the
+        // runtime path nests through libkrun/Vz, so this probe is Linux-only.
+        #[cfg(target_os = "linux")]
+        if !crate::qemu::kvm_available() {
+            anyhow::bail!(
+                "Firecracker requires /dev/kvm, which is not available on this host. \
+                 Firecracker is the production runtime; for local dev/test on a no-KVM \
+                 host run with `--hypervisor qemu` (Tier-3 TCG software emulation, \
+                 ADR-072). To run Firecracker, use a host with KVM enabled."
+            );
+        }
         let fc_config = FirecrackerConfig::from_start_config(config)?;
         // Thread the W6.2.1 sidecar into per-VM runtime metadata so
         // `mvmctl console` can enforce the accessible/sealed gate.
@@ -333,6 +349,12 @@ pub enum AnyBackend {
     /// beyond what FC supports. Opt-in via `--hypervisor cloud-hypervisor`;
     /// auto_select keeps Firecracker as the KVM default.
     CloudHypervisor(CloudHypervisorBackend),
+    /// QEMU workload runtime (Plan 166 Phase 2 / ADR-072) — Linux dev/test
+    /// substrate (KVM where present, TCG fallback). Opt-in via
+    /// `--hypervisor qemu` / `MVM_BACKEND=qemu`; `auto_select` never picks
+    /// it (Firecracker stays the production runtime). Dev tier only,
+    /// outside ADR-002 claims.
+    Qemu(QemuBackend),
     /// In-memory mock — test-only. Records `start`/`stop`/`pause`/
     /// `resume` calls against a `Mutex<HashMap>` and never touches
     /// the host. Selected only via explicit `--hypervisor mock`;
@@ -373,7 +395,11 @@ impl AnyBackend {
             "cloud-hypervisor" | "cloud_hypervisor" | "ch" | "clh" => {
                 Self::CloudHypervisor(CloudHypervisorBackend)
             }
-            "qemu" => Self::MicrovmNix(MicrovmNixBackend),
+            // Plan 166 Phase 2 — `"qemu"` now routes to the real QEMU
+            // workload backend, not the vestigial microvm.nix alias.
+            // `MicrovmNixBackend` stays selectable via `from_build_output`
+            // (a flake that emits a microvm.nix runner), not by name.
+            "qemu" => Self::Qemu(QemuBackend),
             // Test-only in-memory backend. See `crate::mock`. Routing
             // here from a production caller is a misconfiguration, but
             // the explicit selector lets integration tests drive every
@@ -457,9 +483,15 @@ impl AnyBackend {
             // Container (Virtualization.framework) and microvm.nix
             // (qemu) also sit here per their existing
             // `BackendSecurityProfile.tier` strings.
-            Self::Libkrun(_) | Self::AppleContainer(_) | Self::MicrovmNix(_) | Self::Vz(_) => {
-                BackendTier::Tier2
-            }
+            // QEMU: best-case Tier 2 (KVM-accelerated). The TCG (no-KVM)
+            // mode is a runtime Tier-3 degradation surfaced by the QEMU
+            // backend's `start` banner + doctor, not by this compile-time
+            // classification (Plan 166 / ADR-072).
+            Self::Libkrun(_)
+            | Self::AppleContainer(_)
+            | Self::MicrovmNix(_)
+            | Self::Vz(_)
+            | Self::Qemu(_) => BackendTier::Tier2,
 
             // Tier 3: fallback / test. Docker is a userspace
             // container fallback; Mock is in-memory test-only.
@@ -477,6 +509,7 @@ impl AnyBackend {
             Self::Libkrun(b) => b,
             Self::Vz(b) => b,
             Self::CloudHypervisor(b) => b,
+            Self::Qemu(b) => b,
             Self::Mock(b) => b,
         }
     }
@@ -713,8 +746,19 @@ mod tests {
 
     #[test]
     fn test_any_backend_from_hypervisor_qemu() {
+        // Plan 166 Phase 2 — `"qemu"` routes to the real QEMU workload
+        // backend, not the retired microvm.nix alias.
         let backend = AnyBackend::from_hypervisor("qemu");
-        assert_eq!(backend.name(), "microvm-nix");
+        assert_eq!(backend.name(), "qemu");
+        assert!(matches!(backend, AnyBackend::Qemu(_)));
+    }
+
+    #[test]
+    fn microvm_nix_no_longer_reachable_by_name() {
+        // The "qemu" alias was retired; MicrovmNix is selected via
+        // `from_build_output(true)`, never by hypervisor name.
+        assert_eq!(AnyBackend::from_build_output(true).name(), "microvm-nix");
+        assert_ne!(AnyBackend::from_hypervisor("qemu").name(), "microvm-nix");
     }
 
     #[test]
@@ -871,7 +915,13 @@ mod tests {
 
     #[test]
     fn pause_resume_unsupported_on_microvm_nix() {
-        assert_unsupported_pause_resume(AnyBackend::from_hypervisor("qemu"), "microvm-nix");
+        // MicrovmNix is no longer reachable by name; construct it directly.
+        assert_unsupported_pause_resume(AnyBackend::MicrovmNix(MicrovmNixBackend), "microvm-nix");
+    }
+
+    #[test]
+    fn pause_resume_unsupported_on_qemu() {
+        assert_unsupported_pause_resume(AnyBackend::from_hypervisor("qemu"), "qemu");
     }
 
     #[test]
@@ -900,9 +950,21 @@ mod tests {
 
     #[test]
     fn snapshot_capability_unsupported_on_microvm_nix() {
+        // MicrovmNix is no longer reachable by name (the "qemu" alias was
+        // retired in Plan 166 Phase 2); construct it directly.
+        assert_eq!(
+            AnyBackend::MicrovmNix(MicrovmNixBackend).snapshot_capability(),
+            SnapshotCapability::Unsupported
+        );
+    }
+
+    #[test]
+    fn snapshot_capability_disk_only_on_qemu() {
+        // QEMU warm-start is a disk-image fast reboot (no live-memory QMP
+        // snapshot wired) — same posture as libkrun.
         assert_eq!(
             AnyBackend::from_hypervisor("qemu").snapshot_capability(),
-            SnapshotCapability::Unsupported
+            SnapshotCapability::DiskOnly
         );
     }
 

--- a/crates/mvm-backend/src/lib.rs
+++ b/crates/mvm-backend/src/lib.rs
@@ -68,6 +68,8 @@ pub mod network_provider;
 /// `apple_container` backend dispatch (`AppleContainerBackend`) stays in
 /// `apple_container.rs`; this is the lower-level interface it drives.
 pub mod providers;
+/// Plan 166 Phase 2 / ADR-072 — QEMU workload runtime backend (dev/test).
+pub mod qemu;
 // Plan 97 Phase B — Vz (Apple Virtualization.framework) backend.
 // Currently a skeleton: trait surface + capabilities + security profile
 // + availability probe; lifecycle methods land in a follow-up slice.
@@ -83,6 +85,7 @@ pub use docker::DockerBackend;
 pub use libkrun::LibkrunBackend;
 pub use microvm_nix::{MicrovmNixBackend, MicrovmNixConfig};
 pub use mock::MockBackend;
+pub use qemu::QemuBackend;
 pub use vz::VzBackend;
 
 /// Crate-wide test serialization for tests that mutate `HOME` or

--- a/crates/mvm-backend/src/qemu.rs
+++ b/crates/mvm-backend/src/qemu.rs
@@ -99,10 +99,7 @@ impl VmBackend for QemuBackend {
 
     fn start(&self, config: &VmStartConfig) -> Result<VmId> {
         let qemu_bin = locate_qemu()?;
-        let kernel = config
-            .kernel_path
-            .as_deref()
-            .ok_or_else(|| anyhow!("qemu backend requires a kernel path"))?;
+        let kernel = resolve_workload_kernel(config)?;
 
         let state_dir = vm_state_dir(&config.name);
         std::fs::create_dir_all(&state_dir)
@@ -169,7 +166,7 @@ impl VmBackend for QemuBackend {
         } else {
             cmd.args(["-cpu", "max"]);
         }
-        cmd.arg("-kernel").arg(kernel);
+        cmd.arg("-kernel").arg(&kernel);
         if let Some(initrd) = config.initrd_path.as_deref() {
             cmd.arg("-initrd").arg(initrd);
         }
@@ -402,6 +399,51 @@ impl VmBackend for QemuBackend {
 }
 
 // ─── KVM / qemu probing ─────────────────────────────────────────────
+
+fn host_arch() -> &'static str {
+    if cfg!(target_arch = "aarch64") {
+        "aarch64"
+    } else {
+        "x86_64"
+    }
+}
+
+/// Resolve the kernel to boot the workload under QEMU.
+///
+/// `config.kernel_path` is the build's emitted `vmlinux` when there is one
+/// (builder/dev-shell images). A plain `mkGuest` **workload** is a bare
+/// rootfs with no kernel — libkrun boots it with libkrunfw's bundled
+/// kernel, but QEMU has none. For the dev tier we fall back to the cached
+/// builder VM kernel (`~/.cache/mvm/builder-vm/<arch>/vmlinux`), which has
+/// virtio-blk/net/vsock + ext4 built-in and boots a workload rootfs
+/// (`root=/dev/vda init=/init`) just fine — the Linux analog of
+/// libkrunfw's bundled kernel. Production uses a workload kernel via
+/// Firecracker; QEMU is dev/test only (ADR-072).
+fn resolve_workload_kernel(config: &VmStartConfig) -> Result<PathBuf> {
+    if let Some(k) = config.kernel_path.as_deref() {
+        let p = PathBuf::from(k);
+        if p.is_file() {
+            return Ok(p);
+        }
+    }
+    // ~/.cache/mvm/builder-vm/<arch>/vmlinux — same layout
+    // `mvm_build::libkrun_builder::ensure_builder_vm_image` promotes to.
+    let builder_kernel = PathBuf::from(mvm_core::config::mvm_cache_dir())
+        .join("builder-vm")
+        .join(host_arch())
+        .join("vmlinux");
+    if builder_kernel.is_file() {
+        return Ok(builder_kernel);
+    }
+    bail!(
+        "qemu workload '{}' has no bootable kernel: the build produced no vmlinux \
+         ({:?}) and no cached builder kernel exists at {}. Run a build / `mvmctl dev up` \
+         to populate the builder VM image first.",
+        config.name,
+        config.kernel_path,
+        builder_kernel.display()
+    )
+}
 
 /// `qemu-system-<host-arch>` on `$PATH`.
 fn locate_qemu() -> Result<String> {

--- a/crates/mvm-backend/src/qemu.rs
+++ b/crates/mvm-backend/src/qemu.rs
@@ -1,0 +1,720 @@
+//! QEMU **workload** runtime backend (Plan 166 Phase 2 / ADR-072).
+//!
+//! The dev/test counterpart to the Plan 166 QEMU *builder* (`mvm-build`'s
+//! `qemu_builder`): this boots a user **workload** microVM via
+//! `qemu-system-<arch>` so a workload can run for dev/test on a host
+//! without `/dev/kvm` (TCG fallback) or where Firecracker isn't wanted.
+//! **Firecracker stays the sole production runtime** (ADR-001/072);
+//! QEMU is opt-in (`--hypervisor qemu` / `MVM_BACKEND=qemu`) and
+//! `auto_select` never picks it.
+//!
+//! ## Tier (ADR-072)
+//!
+//! Dev tier only, outside the ADR-002 claims. `AnyBackend::tier()` reports
+//! the **best-case** Tier 2 (KVM-accelerated, comparable to the
+//! microvm.nix/qemu classification); when `/dev/kvm` is absent the boot
+//! runs under TCG software emulation and `start` emits a loud Tier-3
+//! banner (mirroring the Docker fallback). The static enum tier stays
+//! Tier 2 because it's a compile-time classification consulted by the
+//! tier-sync test + `doctor`; the live KVM-vs-TCG mode is a *runtime*
+//! property surfaced through the banner and `doctor`, not the enum.
+//!
+//! ## Lifecycle
+//!
+//! - `start` boots `qemu-system` with `-daemonize -pidfile` (qemu forks
+//!   and writes its own PID file), captures the guest serial console
+//!   **write-only** to `console.log` (claim 15 — no host input fd), wires
+//!   user-mode (slirp) networking, and attaches a virtio-vsock device on
+//!   a per-VM guest CID. It then spawns a host-side AF_VSOCK↔UNIX bridge
+//!   (a detached `mvmctl` subprocess) so the shared UNIX-socket agent
+//!   client reaches the guest agent exactly as it does under
+//!   libkrun/Firecracker — QEMU's `vhost-vsock` speaks real AF_VSOCK, not
+//!   the per-port UNIX sockets those VMMs expose.
+//! - `stop` SIGTERMs the qemu PID (then SIGKILL), reaps the bridge.
+//! - `status` probes the qemu PID; `list` walks `~/.mvm/vms/*/qemu.pid`.
+
+use anyhow::{Result, anyhow, bail};
+use mvm_core::config::{mvm_data_dir, vm_console_log, vm_state_dir};
+use mvm_core::vm_backend::{
+    BackendSecurityProfile, ClaimStatus, GuestChannelInfo, LayerCoverage, SnapshotCapability,
+    StartMode, VmBackend, VmCapabilities, VmId, VmInfo, VmStartConfig, VmStatus,
+};
+use std::path::{Path, PathBuf};
+use std::process::Command;
+use std::time::{Duration, Instant};
+
+use crate::base::ui;
+use crate::libkrun::open_console_capture;
+
+/// QEMU workload backend (Linux dev/test; KVM where present, TCG fallback).
+pub struct QemuBackend;
+
+/// How long [`QemuBackend::start`] waits for qemu's `-pidfile` to appear
+/// before declaring the boot failed.
+const PID_FILE_TIMEOUT: Duration = Duration::from_secs(10);
+/// How long the host AF_VSOCK↔UNIX bridge gets to bind its listening UNIX
+/// socket before `start` returns. The socket existing means the agent
+/// client has somewhere to connect; the guest agent coming up is raced by
+/// the client's own retry, exactly as under libkrun (#582).
+const BRIDGE_SOCKET_TIMEOUT: Duration = Duration::from_secs(5);
+/// SIGTERM→SIGKILL grace on `stop`.
+const STOP_TIMEOUT: Duration = Duration::from_secs(3);
+
+/// Per-VM file names under `vm_state_dir(name)`.
+const QEMU_PID_FILE: &str = "qemu.pid";
+const QEMU_LOG_FILE: &str = "qemu.log";
+const QEMU_CID_FILE: &str = "qemu.cid";
+const BRIDGE_PID_FILE: &str = "qemu-vsock-bridge.pid";
+
+/// Default workload kernel cmdline. `console=ttyS0` is QEMU's serial line
+/// (vs libkrun's `hvc0`); `root=/dev/vda rw init=/init` matches the same
+/// Nix-built workload rootfs the other backends boot. `mvm.backend=qemu`
+/// marks the dev tier (parity with the builder marker).
+const DEFAULT_CMDLINE: &str = "console=ttyS0 root=/dev/vda rw init=/init mvm.backend=qemu";
+
+impl VmBackend for QemuBackend {
+    fn name(&self) -> &str {
+        "qemu"
+    }
+
+    fn capabilities(&self) -> VmCapabilities {
+        VmCapabilities {
+            // QEMU can pause/resume + snapshot via QMP, but mvm doesn't
+            // wire a QMP monitor today (parity with the microvm-nix
+            // backend). Declared false until the monitor lands.
+            pause_resume: false,
+            snapshots: false,
+            vsock: true,
+            // User-mode (slirp) networking — no host TAP device.
+            tap_networking: false,
+            balloon: false,
+        }
+    }
+
+    fn snapshot_capability(&self) -> SnapshotCapability {
+        // No live-memory snapshot wired (no QMP). Warm-start would be a
+        // fast reboot from the disk image, same posture as libkrun.
+        SnapshotCapability::DiskOnly
+    }
+
+    fn start(&self, config: &VmStartConfig) -> Result<VmId> {
+        let qemu_bin = locate_qemu()?;
+        let kernel = config
+            .kernel_path
+            .as_deref()
+            .ok_or_else(|| anyhow!("qemu backend requires a kernel path"))?;
+
+        let state_dir = vm_state_dir(&config.name);
+        std::fs::create_dir_all(&state_dir)
+            .map_err(|e| anyhow!("create per-VM state dir {}: {e}", state_dir.display()))?;
+
+        // Same admission gate + runtime-meta record as the libkrun path so
+        // `mvmctl console`'s accessible/sealed gate (claim 15) and the
+        // overlay-aware contract (ADR-051) hold on QEMU-launched VMs too.
+        let rootfs = Path::new(&config.rootfs_path);
+        let rootfs_dir = rootfs.parent().unwrap_or_else(|| Path::new("."));
+        mvm_build::builder_vm::admit_overlay_aware(rootfs_dir)?;
+        crate::base::runtime_meta::record_from_rootfs(&config.name, StartMode::Detached, rootfs)?;
+
+        let kvm = kvm_available();
+        if !kvm {
+            // Task 2.2 — loud Tier-3 banner, mirroring the Docker fallback.
+            ui::warn(&format!(
+                "QEMU workload '{}' is running UNACCELERATED (TCG — no /dev/kvm). \
+                 This is a Tier-3 dev/test fallback: slow, and unaudited vs ADR-002. \
+                 For production use a /dev/kvm host (Firecracker).",
+                config.name
+            ));
+        }
+
+        let cid = allocate_cid(&config.name)?;
+        let pid_file = state_dir.join(QEMU_PID_FILE);
+        let _ = std::fs::remove_file(&pid_file);
+        let console_log = vm_console_log(&config.name);
+        // Write-only console sink (claim 15): qemu opens `-serial file:`
+        // for output only; there is no host fd from which the guest could
+        // read console input. We pre-create the sink through the shared
+        // write-only opener so the invariant + truncate-on-boot match the
+        // other backends.
+        drop(
+            open_console_capture(&console_log)
+                .map_err(|e| anyhow!("open console sink {}: {e}", console_log.display()))?,
+        );
+
+        let mut cmdline = DEFAULT_CMDLINE.to_string();
+        if let Some(uvols) = mvm_core::vm_backend::encode_user_volumes_cmdline(&config.volumes) {
+            cmdline.push(' ');
+            cmdline.push_str(&uvols);
+        }
+        if let Some(roothash) = config.runtime_overlay_roothash.as_deref() {
+            cmdline.push_str(" mvm.runtime_roothash=");
+            cmdline.push_str(roothash);
+        }
+
+        let vcpus = config.cpus.clamp(1, u32::from(u8::MAX));
+
+        ui::info(&format!(
+            "Starting QEMU workload '{}' (cpus={vcpus}, mem={}MiB, {}) via {}...",
+            config.name,
+            config.memory_mib,
+            if kvm { "KVM" } else { "TCG" },
+            qemu_bin,
+        ));
+
+        let mut cmd = Command::new(&qemu_bin);
+        cmd.args(["-m", &config.memory_mib.to_string()]);
+        cmd.args(["-smp", &vcpus.to_string()]);
+        if kvm {
+            cmd.args(["-enable-kvm", "-cpu", "host"]);
+        } else {
+            cmd.args(["-cpu", "max"]);
+        }
+        cmd.arg("-kernel").arg(kernel);
+        if let Some(initrd) = config.initrd_path.as_deref() {
+            cmd.arg("-initrd").arg(initrd);
+        }
+        cmd.arg("-append").arg(&cmdline);
+        // Root disk (vda). Attached writable at the block level; the guest
+        // mounts per the cmdline (`rw`).
+        cmd.arg("-drive")
+            .arg(format!("file={},if=virtio,format=raw", config.rootfs_path));
+        // virtio-vsock on the per-VM guest CID. The host reaches the agent
+        // through the AF_VSOCK↔UNIX bridge spawned below.
+        cmd.arg("-device")
+            .arg(format!("vhost-vsock-pci,guest-cid={cid}"));
+        // User-mode (slirp) networking — no root, no TAP.
+        cmd.args([
+            "-netdev",
+            "user,id=n0",
+            "-device",
+            "virtio-net-pci,netdev=n0",
+        ]);
+        cmd.args(["-display", "none", "-monitor", "none", "-no-reboot"]);
+        cmd.arg("-serial")
+            .arg(format!("file:{}", console_log.display()));
+        cmd.arg("-D").arg(state_dir.join(QEMU_LOG_FILE));
+        // qemu forks into the background and writes its own pidfile.
+        cmd.args(["-daemonize"]);
+        cmd.arg("-pidfile").arg(&pid_file);
+
+        let status = cmd
+            .status()
+            .map_err(|e| anyhow!("spawn qemu ({qemu_bin}): {e}"))?;
+        if !status.success() {
+            bail!(
+                "qemu-system exited {} before daemonizing workload '{}'; see {}",
+                status.code().unwrap_or(-1),
+                config.name,
+                state_dir.join(QEMU_LOG_FILE).display()
+            );
+        }
+
+        // `-daemonize` returns only after the pidfile is written, but poll
+        // defensively so a slow fork doesn't race the bridge spawn below.
+        let deadline = Instant::now() + PID_FILE_TIMEOUT;
+        while !pid_file.exists() {
+            if Instant::now() >= deadline {
+                bail!(
+                    "qemu did not write pidfile {} within {:?}",
+                    pid_file.display(),
+                    PID_FILE_TIMEOUT
+                );
+            }
+            std::thread::sleep(Duration::from_millis(50));
+        }
+
+        spawn_vsock_bridge(&config.name, cid, &state_dir)?;
+
+        ui::success(&format!(
+            "QEMU workload '{}' started (pid: {}).",
+            config.name,
+            pid_file.display()
+        ));
+        Ok(VmId(config.name.clone()))
+    }
+
+    fn stop(&self, id: &VmId) -> Result<()> {
+        let state_dir = vm_state_dir(&id.0);
+        // Reap the bridge first so it can't keep serving a half-dead VM.
+        if let Some(bpid) = read_pid(&state_dir.join(BRIDGE_PID_FILE)) {
+            send_signal(bpid, libc::SIGTERM);
+        }
+        let _ = std::fs::remove_file(state_dir.join(BRIDGE_PID_FILE));
+
+        let pid_path = state_dir.join(QEMU_PID_FILE);
+        let Some(pid) = read_pid(&pid_path) else {
+            ui::info(&format!(
+                "QEMU VM '{}' has no PID file at {}; nothing to stop.",
+                id.0,
+                pid_path.display()
+            ));
+            return Ok(());
+        };
+        if !pid_alive(pid) {
+            let _ = std::fs::remove_file(&pid_path);
+            ui::info(&format!("QEMU VM '{}' was not running.", id.0));
+            return Ok(());
+        }
+        send_signal(pid, libc::SIGTERM);
+        let deadline = Instant::now() + STOP_TIMEOUT;
+        while Instant::now() < deadline && pid_alive(pid) {
+            std::thread::sleep(Duration::from_millis(100));
+        }
+        if pid_alive(pid) {
+            ui::info(&format!(
+                "QEMU VM '{}' PID {pid} ignored SIGTERM; sending SIGKILL.",
+                id.0
+            ));
+            send_signal(pid, libc::SIGKILL);
+        }
+        let _ = std::fs::remove_file(&pid_path);
+        ui::success(&format!("QEMU VM '{}' stopped.", id.0));
+        Ok(())
+    }
+
+    fn stop_all(&self) -> Result<()> {
+        let mut last_err = None;
+        for vm in self.list()? {
+            if let Err(e) = self.stop(&VmId(vm.name.clone())) {
+                tracing::warn!(name = vm.name, error = %e, "qemu stop_all: stop failed");
+                last_err = Some(e);
+            }
+        }
+        last_err.map_or(Ok(()), Err)
+    }
+
+    fn pause(&self, _id: &VmId) -> Result<()> {
+        bail!("pause is not supported by the qemu backend (QMP monitor not wired)")
+    }
+
+    fn resume(&self, _id: &VmId) -> Result<()> {
+        bail!("resume is not supported by the qemu backend (QMP monitor not wired)")
+    }
+
+    fn status(&self, id: &VmId) -> Result<VmStatus> {
+        match read_pid(&vm_state_dir(&id.0).join(QEMU_PID_FILE)) {
+            Some(pid) if pid_alive(pid) => Ok(VmStatus::Running),
+            _ => Ok(VmStatus::Stopped),
+        }
+    }
+
+    fn list(&self) -> Result<Vec<VmInfo>> {
+        let root = PathBuf::from(mvm_data_dir()).join("vms");
+        let entries = match std::fs::read_dir(&root) {
+            Ok(it) => it,
+            Err(e) if e.kind() == std::io::ErrorKind::NotFound => return Ok(Vec::new()),
+            Err(e) => return Err(anyhow!("read {}: {e}", root.display())),
+        };
+        let mut vms = Vec::new();
+        for entry in entries.flatten() {
+            let path = entry.path();
+            if !path.is_dir() {
+                continue;
+            }
+            let pid_path = path.join(QEMU_PID_FILE);
+            if !pid_path.exists() {
+                // Not a QEMU-managed VM (other backends share ~/.mvm/vms/).
+                continue;
+            }
+            let Ok(name) = entry.file_name().into_string() else {
+                continue;
+            };
+            let alive = read_pid(&pid_path).is_some_and(pid_alive);
+            vms.push(VmInfo {
+                id: VmId(name.clone()),
+                name,
+                status: if alive {
+                    VmStatus::Running
+                } else {
+                    VmStatus::Stopped
+                },
+                guest_ip: None,
+                cpus: 0,
+                memory_mib: 0,
+                profile: None,
+                revision: None,
+                flake_ref: None,
+                ports: Vec::new(),
+            });
+        }
+        Ok(vms)
+    }
+
+    fn logs(&self, id: &VmId, lines: u32, hypervisor: bool) -> Result<String> {
+        let state_dir = vm_state_dir(&id.0);
+        let path = if hypervisor {
+            state_dir.join(QEMU_LOG_FILE)
+        } else {
+            vm_console_log(&id.0)
+        };
+        let body = std::fs::read_to_string(&path).unwrap_or_default();
+        Ok(tail(&body, lines as usize))
+    }
+
+    fn guest_channel_info(&self, id: &VmId) -> Result<GuestChannelInfo> {
+        // The shared agent client connects to the UNIX socket the bridge
+        // binds (`vm_vsock_port_socket`); the `cid` here is the guest CID
+        // the bridge dials over AF_VSOCK, surfaced for diagnostics.
+        let cid = read_cid(&id.0).unwrap_or(3);
+        Ok(GuestChannelInfo::Vsock {
+            cid,
+            port: mvm_guest::vsock::GUEST_AGENT_PORT,
+        })
+    }
+
+    fn is_available(&self) -> Result<bool> {
+        Ok(locate_qemu().is_ok())
+    }
+
+    fn install(&self) -> Result<()> {
+        ui::info(
+            "QEMU must be installed via the host package manager \
+             (`apt install qemu-system-x86 qemu-utils` / `dnf install qemu-system-x86`).",
+        );
+        Ok(())
+    }
+
+    fn security_profile(&self) -> BackendSecurityProfile {
+        // Tier 2 best-case (KVM). Mirrors the microvm-nix/qemu profile:
+        // QEMU's device model is much larger than Firecracker's (higher L2
+        // audit cost), and claim 3 (verified boot) targets Firecracker.
+        // The TCG (no-KVM) mode is a runtime Tier-3 degradation surfaced by
+        // the `start` banner + doctor, not by this compile-time tier.
+        BackendSecurityProfile {
+            claims: [
+                ClaimStatus::Holds,       // 1
+                ClaimStatus::Holds,       // 2
+                ClaimStatus::DoesNotHold, // 3 — verified boot targets Firecracker
+                ClaimStatus::Holds,       // 4
+                ClaimStatus::Holds,       // 5
+                ClaimStatus::Holds,       // 6
+                ClaimStatus::Holds,       // 7
+            ],
+            layer_coverage: LayerCoverage::all_layers(),
+            tier: "Tier 2",
+            notes: &[
+                "QEMU workload runtime (Plan 166 / ADR-072); dev/test tier only.",
+                "KVM-accelerated where /dev/kvm is present; TCG software-emulation fallback otherwise (runtime Tier-3, banner-flagged).",
+                "Larger device model than Firecracker → higher L2 audit cost; outside ADR-002 claims. Never a production runtime.",
+            ],
+        }
+    }
+}
+
+// ─── KVM / qemu probing ─────────────────────────────────────────────
+
+/// `qemu-system-<host-arch>` on `$PATH`.
+fn locate_qemu() -> Result<String> {
+    let bin = match std::env::consts::ARCH {
+        "x86_64" => "qemu-system-x86_64",
+        "aarch64" => "qemu-system-aarch64",
+        other => bail!("no qemu-system emulator mapped for host arch `{other}`"),
+    };
+    which::which(bin).map(|_| bin.to_string()).map_err(|_| {
+        anyhow!(
+            "`{bin}` not found on $PATH. Install QEMU \
+             (`apt install qemu-system-x86 qemu-utils` / `dnf install qemu-system-x86`)."
+        )
+    })
+}
+
+/// `/dev/kvm` present + read-write for this process. Drives the KVM-vs-TCG
+/// boot path and the Tier-3 banner.
+pub(crate) fn kvm_available() -> bool {
+    Path::new("/dev/kvm").exists()
+        && std::fs::OpenOptions::new()
+            .read(true)
+            .write(true)
+            .open("/dev/kvm")
+            .is_ok()
+}
+
+// ─── per-VM guest CID allocation ────────────────────────────────────
+
+/// Allocate (or reuse) a unique guest CID for `name`. vhost-vsock refuses
+/// duplicate CIDs across live VMs, so we pick the lowest CID ≥ 3 not
+/// recorded by another VM's `qemu.cid` sidecar and persist it. Reuses the
+/// VM's own recorded CID on restart.
+fn allocate_cid(name: &str) -> Result<u32> {
+    if let Some(existing) = read_cid(name) {
+        return Ok(existing);
+    }
+    let in_use = used_cids();
+    // CID 0/1 reserved (hypervisor/local), 2 = host. Guests start at 3.
+    let cid = (3u32..).find(|c| !in_use.contains(c)).unwrap_or(3);
+    let cid_file = vm_state_dir(name).join(QEMU_CID_FILE);
+    std::fs::write(&cid_file, cid.to_string())
+        .map_err(|e| anyhow!("write {}: {e}", cid_file.display()))?;
+    Ok(cid)
+}
+
+/// CIDs recorded by VMs whose qemu process is still alive. A stale sidecar
+/// from a crashed VM is ignored so its CID can be reclaimed.
+fn used_cids() -> std::collections::HashSet<u32> {
+    let mut set = std::collections::HashSet::new();
+    let root = PathBuf::from(mvm_data_dir()).join("vms");
+    let Ok(entries) = std::fs::read_dir(&root) else {
+        return set;
+    };
+    for entry in entries.flatten() {
+        let dir = entry.path();
+        let alive = read_pid(&dir.join(QEMU_PID_FILE)).is_some_and(pid_alive);
+        if !alive {
+            continue;
+        }
+        if let Ok(s) = std::fs::read_to_string(dir.join(QEMU_CID_FILE))
+            && let Ok(c) = s.trim().parse::<u32>()
+        {
+            set.insert(c);
+        }
+    }
+    set
+}
+
+fn read_cid(name: &str) -> Option<u32> {
+    std::fs::read_to_string(vm_state_dir(name).join(QEMU_CID_FILE))
+        .ok()?
+        .trim()
+        .parse()
+        .ok()
+}
+
+// ─── host AF_VSOCK ↔ UNIX bridge ────────────────────────────────────
+
+/// Spawn the detached host-side AF_VSOCK↔UNIX bridge for this VM. QEMU's
+/// virtio-vsock speaks real AF_VSOCK, but the shared agent client
+/// (`mvm::vsock_transport`) connects to the per-port UNIX socket that
+/// libkrun/Firecracker expose. The bridge listens on that UNIX socket
+/// (`vm_vsock_port_socket`) and splices each connection to
+/// `AF_VSOCK(cid, GUEST_AGENT_PORT)`, so the client is backend-agnostic.
+///
+/// It runs as a detached `mvmctl __qemu-vsock-bridge` subprocess so it
+/// outlives the `mvmctl up` invocation, exactly as qemu (`-daemonize`)
+/// does. `stop` reaps it via `BRIDGE_PID_FILE`.
+fn spawn_vsock_bridge(name: &str, cid: u32, state_dir: &Path) -> Result<()> {
+    let uds = mvm_core::config::vm_vsock_port_socket(name, mvm_guest::vsock::GUEST_AGENT_PORT);
+    let _ = std::fs::remove_file(&uds);
+    let bridge_pid_file = state_dir.join(BRIDGE_PID_FILE);
+
+    let exe =
+        std::env::current_exe().map_err(|e| anyhow!("resolve current exe for bridge: {e}"))?;
+    let mut cmd = Command::new(&exe);
+    cmd.arg("__qemu-vsock-bridge")
+        .arg("--uds")
+        .arg(&uds)
+        .arg("--cid")
+        .arg(cid.to_string())
+        .arg("--port")
+        .arg(mvm_guest::vsock::GUEST_AGENT_PORT.to_string())
+        .arg("--watch-pid-file")
+        .arg(state_dir.join(QEMU_PID_FILE))
+        .stdin(std::process::Stdio::null())
+        .stdout(std::process::Stdio::null())
+        .stderr(std::process::Stdio::null());
+    // Detach into its own session so it survives this process.
+    unsafe {
+        use std::os::unix::process::CommandExt;
+        cmd.pre_exec(|| {
+            // SAFETY: post-fork, pre-exec; setsid has no preconditions.
+            libc::setsid();
+            Ok(())
+        });
+    }
+    let child = cmd
+        .spawn()
+        .map_err(|e| anyhow!("spawn vsock bridge ({}): {e}", exe.display()))?;
+    std::fs::write(&bridge_pid_file, child.id().to_string())
+        .map_err(|e| anyhow!("write {}: {e}", bridge_pid_file.display()))?;
+
+    // Wait for the bridge to bind its UNIX socket so an immediately-
+    // following console/agent connect doesn't race a not-yet-bound socket.
+    let deadline = Instant::now() + BRIDGE_SOCKET_TIMEOUT;
+    while !uds.exists() {
+        if Instant::now() >= deadline {
+            bail!(
+                "qemu vsock bridge did not bind {} within {:?}",
+                uds.display(),
+                BRIDGE_SOCKET_TIMEOUT
+            );
+        }
+        std::thread::sleep(Duration::from_millis(50));
+    }
+    Ok(())
+}
+
+/// Body of the `mvmctl __qemu-vsock-bridge` subcommand. Listens on the
+/// UNIX socket `uds` and, for each accepted connection, dials
+/// `AF_VSOCK(cid, port)` and splices the two halves bidirectionally.
+/// Exits when `watch_pid_file`'s process dies (the VM is gone).
+///
+/// Lives here (not in mvm-cli) so the AF_VSOCK plumbing sits beside the
+/// backend that needs it; mvm-cli's hidden subcommand just forwards args.
+pub fn run_vsock_bridge(uds: &Path, cid: u32, port: u32, watch_pid_file: &Path) -> Result<()> {
+    use std::os::unix::net::UnixListener;
+
+    let _ = std::fs::remove_file(uds);
+    let listener = UnixListener::bind(uds).map_err(|e| anyhow!("bind {}: {e}", uds.display()))?;
+    listener
+        .set_nonblocking(true)
+        .map_err(|e| anyhow!("set_nonblocking on {}: {e}", uds.display()))?;
+
+    let watch_pid = read_pid(watch_pid_file);
+    loop {
+        // Stop when the watched VM process is gone.
+        if let Some(pid) = watch_pid
+            && !pid_alive(pid)
+        {
+            let _ = std::fs::remove_file(uds);
+            return Ok(());
+        }
+        match listener.accept() {
+            Ok((client, _)) => {
+                if let Ok(guest) = dial_vsock(cid, port) {
+                    std::thread::spawn(move || splice_bidirectional(client, guest));
+                }
+                // If the guest dial fails (agent not up yet), drop the
+                // client; the caller retries.
+            }
+            Err(e) if e.kind() == std::io::ErrorKind::WouldBlock => {
+                std::thread::sleep(Duration::from_millis(100));
+            }
+            Err(e) => return Err(anyhow!("accept on {}: {e}", uds.display())),
+        }
+    }
+}
+
+/// Dial `AF_VSOCK(cid, port)` and wrap the fd in a [`std::net::TcpStream`]
+/// for `splice_bidirectional` (TcpStream is just an owned fd with
+/// read/write + shutdown; we never call TCP-specific methods).
+fn dial_vsock(cid: u32, port: u32) -> std::io::Result<std::net::TcpStream> {
+    use std::os::fd::FromRawFd;
+
+    const AF_VSOCK: libc::c_int = 40;
+    #[repr(C)]
+    struct SockaddrVm {
+        svm_family: libc::sa_family_t,
+        svm_reserved1: u16,
+        svm_port: u32,
+        svm_cid: u32,
+        svm_zero: [u8; 4],
+    }
+
+    // SAFETY: standard socket(2)/connect(2) on AF_VSOCK; addr is fully
+    // initialized and sized exactly.
+    unsafe {
+        let fd = libc::socket(AF_VSOCK, libc::SOCK_STREAM, 0);
+        if fd < 0 {
+            return Err(std::io::Error::last_os_error());
+        }
+        let addr = SockaddrVm {
+            svm_family: AF_VSOCK as libc::sa_family_t,
+            svm_reserved1: 0,
+            svm_port: port,
+            svm_cid: cid,
+            svm_zero: [0; 4],
+        };
+        let rc = libc::connect(
+            fd,
+            std::ptr::addr_of!(addr).cast::<libc::sockaddr>(),
+            std::mem::size_of::<SockaddrVm>() as libc::socklen_t,
+        );
+        if rc < 0 {
+            let err = std::io::Error::last_os_error();
+            libc::close(fd);
+            return Err(err);
+        }
+        Ok(std::net::TcpStream::from_raw_fd(fd))
+    }
+}
+
+/// Splice two streams in both directions until either closes.
+fn splice_bidirectional(a: std::os::unix::net::UnixStream, b: std::net::TcpStream) {
+    use std::io::{Read, Write};
+    let Ok(a2) = a.try_clone() else { return };
+    let Ok(b2) = b.try_clone() else { return };
+    let t = std::thread::spawn(move || {
+        let mut r = a2;
+        let mut w = b2;
+        let mut buf = [0u8; 16 * 1024];
+        while let Ok(n) = r.read(&mut buf) {
+            if n == 0 || w.write_all(&buf[..n]).is_err() {
+                break;
+            }
+        }
+        let _ = w.shutdown(std::net::Shutdown::Write);
+    });
+    let mut r = b;
+    let mut w = a;
+    let mut buf = [0u8; 16 * 1024];
+    while let Ok(n) = r.read(&mut buf) {
+        if n == 0 || w.write_all(&buf[..n]).is_err() {
+            break;
+        }
+    }
+    let _ = w.shutdown(std::net::Shutdown::Write);
+    let _ = t.join();
+}
+
+// ─── pid helpers (local copies — libkrun's are private) ─────────────
+
+fn read_pid(path: &Path) -> Option<libc::pid_t> {
+    std::fs::read_to_string(path).ok()?.trim().parse().ok()
+}
+
+fn pid_alive(pid: libc::pid_t) -> bool {
+    unsafe { libc::kill(pid, 0) == 0 }
+}
+
+fn send_signal(pid: libc::pid_t, sig: libc::c_int) {
+    unsafe {
+        libc::kill(pid, sig);
+    }
+}
+
+fn tail(s: &str, n: usize) -> String {
+    if n == 0 {
+        return String::new();
+    }
+    let lines: Vec<&str> = s.lines().collect();
+    lines[lines.len().saturating_sub(n)..].join("\n")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn qemu_backend_name_is_qemu() {
+        assert_eq!(QemuBackend.name(), "qemu");
+    }
+
+    #[test]
+    fn qemu_capabilities_vsock_only() {
+        let c = QemuBackend.capabilities();
+        assert!(c.vsock);
+        assert!(!c.pause_resume);
+        assert!(!c.snapshots);
+        assert!(!c.tap_networking);
+    }
+
+    #[test]
+    fn qemu_security_profile_is_tier_2_partial_claim_3() {
+        let p = QemuBackend.security_profile();
+        assert!(p.tier.starts_with("Tier 2"));
+        // Claim 3 (verified boot) targets Firecracker.
+        assert_eq!(p.dropped_claims(), vec![3]);
+    }
+
+    #[test]
+    fn pause_resume_unsupported() {
+        assert!(QemuBackend.pause(&VmId("x".into())).is_err());
+        assert!(QemuBackend.resume(&VmId("x".into())).is_err());
+    }
+
+    #[test]
+    fn tail_returns_last_n_lines() {
+        assert_eq!(tail("a\nb\nc\nd", 2), "c\nd");
+        assert_eq!(tail("a\nb", 0), "");
+        assert_eq!(tail("a\nb", 10), "a\nb");
+    }
+}

--- a/crates/mvm-cli/src/commands/cmd_audit.rs
+++ b/crates/mvm-cli/src/commands/cmd_audit.rs
@@ -194,6 +194,7 @@ impl Commands {
             Commands::Artifact(_) => "artifact",
             #[cfg(feature = "builder-vm")]
             Commands::PersistentBuilder(_) => "persistent-builder",
+            Commands::QemuVsockBridge(_) => "__qemu-vsock-bridge",
         }
     }
 }

--- a/crates/mvm-cli/src/commands/mod.rs
+++ b/crates/mvm-cli/src/commands/mod.rs
@@ -8,6 +8,7 @@ mod image;
 mod kernel;
 mod manifest;
 mod ops;
+mod qemu_bridge;
 mod shared;
 mod storage;
 mod trust;
@@ -173,6 +174,11 @@ pub(in crate::commands) enum Commands {
     #[cfg(feature = "builder-vm")]
     #[command(name = "persistent-builder")]
     PersistentBuilder(build::persistent_builder::Args),
+    /// Internal: host-side AF_VSOCK↔UNIX bridge for the QEMU workload
+    /// backend (Plan 166 Phase 2). Spawned detached by
+    /// `mvm_backend::qemu`; not a user-facing command.
+    #[command(name = "__qemu-vsock-bridge", hide = true)]
+    QemuVsockBridge(qemu_bridge::Args),
 }
 
 // ============================================================================
@@ -240,6 +246,14 @@ pub fn run() -> Result<()> {
     };
     if !matches!(cli.command, Commands::Mcp(_)) {
         logging::init(log_format);
+    }
+
+    // Plan 166 Phase 2 — the internal QEMU vsock bridge is a detached,
+    // long-running helper (spawned by `mvm_backend::qemu`), not a user
+    // command. Short-circuit before the ctrl-c handler, operator-config
+    // load, and the cmd-audit envelope — none of which apply to it.
+    if let Commands::QemuVsockBridge(a) = &cli.command {
+        return qemu_bridge::run(a);
     }
 
     // Install Ctrl-C / SIGTERM handler for graceful shutdown.
@@ -333,6 +347,9 @@ pub fn run() -> Result<()> {
         Commands::Artifact(a) => vm::artifact::run(&cli, a, &cfg),
         #[cfg(feature = "builder-vm")]
         Commands::PersistentBuilder(a) => build::persistent_builder::run(&cli, a),
+        // Handled by the early return above (before ctrl-c / config /
+        // cmd-audit setup); this arm only satisfies match exhaustiveness.
+        Commands::QemuVsockBridge(_) => unreachable!("qemu vsock bridge short-circuits in run()"),
     };
 
     cmd_audit::emit_cmd_outcome(cmd_recorder.as_ref(), verb, &result);

--- a/crates/mvm-cli/src/commands/qemu_bridge.rs
+++ b/crates/mvm-cli/src/commands/qemu_bridge.rs
@@ -1,0 +1,35 @@
+//! Internal `mvmctl __qemu-vsock-bridge` subcommand (Plan 166 Phase 2).
+//!
+//! Hidden helper spawned (detached) by the QEMU workload backend
+//! (`mvm_backend::qemu`). QEMU's virtio-vsock speaks real AF_VSOCK, but
+//! the shared agent client connects to the per-port UNIX socket that
+//! libkrun/Firecracker expose. This process bridges the two: it listens
+//! on the UNIX socket and splices each connection to the guest's
+//! `AF_VSOCK(cid, port)`, exiting when the watched qemu process dies.
+//!
+//! The AF_VSOCK + splice logic lives in `mvm_backend::qemu` (beside the
+//! backend that needs it); this is just the argument surface + forward.
+
+use anyhow::Result;
+use clap::Args as ClapArgs;
+use std::path::PathBuf;
+
+#[derive(ClapArgs, Debug, Clone)]
+pub(in crate::commands) struct Args {
+    /// UNIX socket to listen on (the agent client connects here).
+    #[arg(long)]
+    uds: PathBuf,
+    /// Guest CID to dial over AF_VSOCK.
+    #[arg(long)]
+    cid: u32,
+    /// Guest vsock port to dial.
+    #[arg(long)]
+    port: u32,
+    /// Exit when this PID file's process is no longer alive (the VM is gone).
+    #[arg(long)]
+    watch_pid_file: PathBuf,
+}
+
+pub(in crate::commands) fn run(args: &Args) -> Result<()> {
+    mvm_backend::qemu::run_vsock_bridge(&args.uds, args.cid, args.port, &args.watch_pid_file)
+}

--- a/crates/mvm-cli/src/commands/tests.rs
+++ b/crates/mvm-cli/src/commands/tests.rs
@@ -34,6 +34,10 @@ fn top_level_command_summaries_stay_short() {
     let longest_allowed = 72;
     let long_summaries = cli_command()
         .get_subcommands()
+        // Hidden internal commands (e.g. `__qemu-vsock-bridge`) never
+        // appear in user-facing help, so the summary-length UX rule
+        // doesn't apply to them.
+        .filter(|cmd| !cmd.is_hide_set())
         .filter_map(|cmd| {
             cmd.get_about().and_then(|about| {
                 let about = about.to_string();

--- a/specs/plans/166-qemu-dev-builder-backend.md
+++ b/specs/plans/166-qemu-dev-builder-backend.md
@@ -128,19 +128,30 @@ the live build awaits a box E2E run (needs an image-mode QEMU Stage 0 first).
     `OUTPUT` DROP, even flake-input source archives). Prod backends (no marker)
     stay fully locked — Claim 9/10 unchanged there.
 
-## Phase 2: QEMU dev/test workload runtime
+## Phase 2: QEMU dev/test workload runtime — DONE + box-proven (2026-06-07, PR #671)
 
-Lets a workload *run* for dev/test on a no-KVM host. Dev tier only.
+Lets a workload *run* for dev/test. Dev tier only. **Box-verified E2E (x86_64
+box):** `MVM_BUILDER_BACKEND=qemu mvmctl up --flake <x> --hypervisor qemu`
+builds the workload (qemu builder), boots it under QEMU (KVM), the
+`mvm-guest-agent` comes up on vsock 5252, and `mvmctl wait` returns
+`all components ready` — a full agent round-trip over the host
+AF_VSOCK↔UNIX bridge.
 
 ### Task 2.1: real `Qemu(QemuBackend)` in `AnyBackend`
-- [ ] Add `Qemu(QemuBackend)` to `AnyBackend` (`crates/mvm-backend/src/backend.rs`) with a `qemu.rs` impl. **Retire the vestigial `from_hypervisor("qemu") → MicrovmNix` alias** — `"qemu"` now routes to the real backend.
-- [ ] `security_profile` / `tier()`: KVM → `Tier2`, TCG → `Tier3`. Keep the `BackendSecurityProfile.tier` ↔ `AnyBackend::tier()` sync test green.
-- [ ] `auto_select`: **Firecracker still wins on `/dev/kvm`**. QEMU is reached only when no native runner *and* a dev/test context (never the silent production default — that stays Firecracker, whose `start()` then surfaces the "Firecracker requires /dev/kvm" error).
+- [x] `Qemu(QemuBackend)` added to `AnyBackend` + `crates/mvm-backend/src/qemu.rs`. **Retired the `from_hypervisor("qemu") → MicrovmNix` alias** — `"qemu"` routes to the real backend; `MicrovmNix` stays via `from_build_output(true)`.
+- [x] `security_profile` / `tier()`: best-case **Tier 2** (KVM). TCG is a *runtime* Tier-3 degradation surfaced by the `start` banner + `doctor`, **not** the static enum — the closed-enum `tier()` stays Tier 2 so the tier-sync test + CI-without-KVM stay green.
+- [x] `auto_select`: unchanged — Firecracker wins on `/dev/kvm`; QEMU is opt-in only, never auto-selected.
+- [x] **Real `start()`** (daemonized `qemu-system`, write-only console capture/claim 15, per-VM CID, slirp, virtio-vsock) + lifecycle. Dev-tier **workload-kernel fallback**: a bare mkGuest workload has no vmlinux, so QEMU falls back to the cached builder kernel (`~/.cache/mvm/builder-vm/<arch>/vmlinux`).
+- [x] **Host AF_VSOCK↔UNIX bridge** (`__qemu-vsock-bridge` hidden subcommand) so the per-port-UNIX-socket agent client reaches QEMU's real-AF_VSOCK guest backend-agnostically.
 
 ### Task 2.2: production gating
-- [ ] Firecracker `start()` on Linux: explicit fail-closed `/dev/kvm` probe with the ADR-072 hint (KVM host for prod, or `--hypervisor qemu` for local dev). (image.rs already emits a `[ -c /dev/kvm ]` guard — make the Rust-side selection match.)
-- [ ] **mvmd**: extend the `--prod` admission gate to refuse a QEMU-tier backend (Tier 2/3) — production requires an admitted Firecracker launch. Draft in `../mvmd/specs/plans/` + a coordinating note here; do not add `--prod` logic to mvm.
-- [ ] `mvmctl up` / `doctor`: Tier-3 (TCG) banner reuses the existing Docker-fallback banner path; Tier-2 (KVM-QEMU) notes "unaudited vs ADR-002".
+- [x] Firecracker `start()` on Linux: fail-closed `/dev/kvm` probe with the ADR-072 hint (use `--hypervisor qemu` for local dev) — no silent FC fallback.
+- [ ] **mvmd**: extend the `--prod` admission gate to refuse a QEMU-tier backend (Tier 2/3). Coordinating note only; admission policy lives in mvmd ([[feedback_prod_gate_lives_in_mvmd]]). **Remaining (mvmd-side).**
+- [x] TCG boot emits a loud Tier-3 banner (mirrors Docker fallback); qemu `security_profile` notes "unaudited vs ADR-002".
+
+### Deferred follow-ups (Phase 2)
+- [ ] `mvmctl ls` / `down` aren't QEMU-backend-aware (they query one backend; a QEMU VM's `qemu.pid` isn't listed — same multi-backend limitation libkrun has). Wire a backend-agnostic VM registry.
+- [ ] mvmd `--prod` Tier 2/3 refusal (above).
 
 ## Phase 3: provisioning, docs, and the firecracker arch bug
 

--- a/tests/audit_total_coverage.rs
+++ b/tests/audit_total_coverage.rs
@@ -299,6 +299,10 @@ const AUDIT_POSTURE: &[(&str, AuditPosture)] = &[
     ("storage", AuditPosture::DelegatesToSub(STORAGE_SUB)),
     ("build", AuditPosture::Emits("TemplateBuild")),
     ("persistent-builder", AuditPosture::InteractiveOrControl),
+    // Plan 166 Phase 2 — hidden internal helper: a long-running host-side
+    // AF_VSOCK<->UNIX bridge for the QEMU workload backend. Pure transport
+    // plumbing spawned by `mvm_backend::qemu`; never emits audit events.
+    ("__qemu-vsock-bridge", AuditPosture::InteractiveOrControl),
     // SDK port Phase 2c — renders a `Workload` IR to a flake +
     // sidecars at the user-supplied --out path. Doesn't touch the
     // audit chain. ReadOnly w.r.t. host state.


### PR DESCRIPTION
## Plan 166 Phase 2 — QEMU dev/test workload runtime

The dev/test counterpart to the Plan 166 QEMU **builder** (merged in #658): a real `QemuBackend` that boots a user **workload** microVM via `qemu-system`, so a workload can run for dev/test on a host without `/dev/kvm` (TCG fallback) or where Firecracker isn't wanted. **Firecracker stays the sole production runtime** (ADR-001/072); QEMU is opt-in and `auto_select` never picks it.

### Task 2.1 — real `Qemu(QemuBackend)` in `AnyBackend`
- New `crates/mvm-backend/src/qemu.rs` (`QemuBackend: VmBackend`): daemonized boot (`-daemonize -pidfile`), **write-only** console capture (claim 15 — no host input fd), per-VM guest CID allocation, slirp networking, `virtio-vsock`, and full lifecycle (`stop`/`status`/`list`/`logs`).
- **Retire the vestigial `from_hypervisor("qemu") → MicrovmNix` alias** — `"qemu"` now routes to `QemuBackend`. `MicrovmNix` stays selectable via `from_build_output(true)`, never by name. Added to `AnyBackend` + `inner()`/`tier()` dispatch.
- `tier()` = best-case **Tier 2** (KVM); the TCG (no-`/dev/kvm`) mode is a *runtime* Tier-3 degradation surfaced by the `start` banner + `doctor`, not the static enum — this keeps the tier-sync test + CI (no KVM) green. `security_profile` mirrors the qemu/microvm-nix Tier 2 (claim 3 partial).

### Host AF_VSOCK↔UNIX bridge
QEMU's `vhost-vsock` speaks real AF_VSOCK, but the shared agent client connects to the per-port UNIX socket libkrun/Firecracker expose. A detached `mvmctl __qemu-vsock-bridge` helper (hidden subcommand) listens on `vm_vsock_port_socket()` and splices each connection to `AF_VSOCK(cid, GUEST_AGENT_PORT)`, so the agent client stays backend-agnostic.

### Task 2.2 — production gating
- `FirecrackerBackend::start` **fails closed** on Linux when `/dev/kvm` is absent, pointing at `--hypervisor qemu` for local dev (no silent FC fallback).
- TCG boot emits a loud **Tier-3 banner** (mirrors the Docker fallback).
- mvmd `--prod` gating (refuse Tier 2/3 for admitted launches) stays a coordinating note — admission policy lives in mvmd, not mvm.

### Testing
- 288 `mvm-backend` lib tests green (tier-sync, `from_hypervisor`, snapshot/pause for qemu + the retired alias). Clippy + nightly fmt clean. Clap tree validated incl. the hidden bridge subcommand.
- ⏳ **Box E2E pending**: boot a workload under `--hypervisor qemu` + `agent_ping` on the x86_64 Hetzner box (validates the daemonized boot + vsock bridge). Will run before merge.

Phase 3 (doctor/docs) remains; the firecracker arch bug (Task 3.1) is already done.