### PR TITLE
feat(plan-166): backend-aware ls/down for QEMU (and libkrun) VMs

### DIFF
--- a/crates/mvm-backend/src/backend.rs
+++ b/crates/mvm-backend/src/backend.rs
@@ -458,6 +458,50 @@ impl AnyBackend {
         Self::Firecracker(FirecrackerBackend)
     }
 
+    /// Resolve the backend that owns an already-started VM by its per-VM
+    /// state-dir marker file, so `down` / `status` dispatch to the VMM that
+    /// actually launched it rather than a platform default. The pid-file
+    /// backends each drop a distinct marker under `vm_state_dir(name)`:
+    /// QEMU `qemu.pid`, libkrun `libkrun.pid`, Firecracker `fc.pid`.
+    ///
+    /// Returns `None` when no marker is present — the VM isn't one of the
+    /// pid-file backends (e.g. Apple Container / Docker, which track state
+    /// out-of-band) or doesn't exist. Callers fall back to the platform
+    /// default in that case.
+    pub fn for_started_vm(name: &str) -> Option<Self> {
+        let dir = mvm_core::config::vm_state_dir(name);
+        if dir.join("qemu.pid").is_file() {
+            Some(Self::Qemu(QemuBackend))
+        } else if dir.join("libkrun.pid").is_file() {
+            Some(Self::Libkrun(LibkrunBackend))
+        } else if dir.join("fc.pid").is_file() {
+            Some(Self::Firecracker(FirecrackerBackend))
+        } else {
+            None
+        }
+    }
+
+    /// Aggregate the running-VM listing across every backend that can be
+    /// probed on this host (best-effort; a backend that errors is skipped).
+    /// Single source of truth for `mvmctl ls` and `mvmctl down` (no-arg) so
+    /// a VM started under any VMM — including QEMU and libkrun — is visible
+    /// and stoppable, not just whichever backend the CLI defaulted to.
+    pub fn list_all() -> Vec<VmInfo> {
+        let mut vms = Vec::new();
+        for backend in [
+            Self::Qemu(QemuBackend),
+            Self::Libkrun(LibkrunBackend),
+            Self::Firecracker(FirecrackerBackend),
+            Self::AppleContainer(AppleContainerBackend),
+            Self::Docker(DockerBackend),
+        ] {
+            if let Ok(found) = backend.list() {
+                vms.extend(found);
+            }
+        }
+        vms
+    }
+
     /// Plan 76 Phase 7 — isolation tier of this backend. Used by
     /// `mvmctl up` to refuse silent Tier 2 downgrades on
     /// production-like launches, and by `mvmctl doctor` to surface
@@ -846,6 +890,53 @@ mod tests {
             }
         }
         let _ = std::fs::remove_dir_all(&temp);
+    }
+
+    #[test]
+    fn for_started_vm_resolves_owning_backend_by_marker() {
+        // A started VM's owning backend is resolved from its state-dir pid
+        // marker so `down`/`status`/`ls` dispatch to the right VMM.
+        let temp = std::path::PathBuf::from(format!(
+            "/tmp/mvmac-fsv-test-{}-{}",
+            std::process::id(),
+            std::time::SystemTime::now()
+                .duration_since(std::time::UNIX_EPOCH)
+                .map(|d| d.as_nanos())
+                .unwrap_or(0)
+        ));
+        let vms = temp.join(".mvm/vms");
+        for (name, marker) in [("q1", "qemu.pid"), ("l1", "libkrun.pid"), ("f1", "fc.pid")] {
+            std::fs::create_dir_all(vms.join(name)).expect("mkdir vm dir");
+            std::fs::write(vms.join(name).join(marker), "123").expect("write marker");
+        }
+        let saved = std::env::var("HOME").ok();
+        // SAFETY: for_started_vm (HOME consumer) is the only env reader in
+        // this test; restored below.
+        unsafe { std::env::set_var("HOME", &temp) };
+
+        let q = AnyBackend::for_started_vm("q1");
+        let l = AnyBackend::for_started_vm("l1");
+        let f = AnyBackend::for_started_vm("f1");
+        let none = AnyBackend::for_started_vm("does-not-exist");
+
+        unsafe {
+            match saved {
+                Some(v) => std::env::set_var("HOME", v),
+                None => std::env::remove_var("HOME"),
+            }
+        }
+        let _ = std::fs::remove_dir_all(&temp);
+
+        assert!(matches!(q, Some(AnyBackend::Qemu(_))), "qemu.pid → Qemu");
+        assert!(
+            matches!(l, Some(AnyBackend::Libkrun(_))),
+            "libkrun.pid → Libkrun"
+        );
+        assert!(
+            matches!(f, Some(AnyBackend::Firecracker(_))),
+            "fc.pid → Firecracker"
+        );
+        assert!(none.is_none(), "no marker → None");
     }
 
     #[test]

--- a/crates/mvm-backend/src/qemu.rs
+++ b/crates/mvm-backend/src/qemu.rs
@@ -220,7 +220,18 @@ impl VmBackend for QemuBackend {
             std::thread::sleep(Duration::from_millis(50));
         }
 
-        spawn_vsock_bridge(&config.name, cid, &state_dir)?;
+        // If the bridge can't come up, the already-daemonized qemu would be
+        // orphaned (a failed `start` won't be followed by `stop`). Roll back:
+        // kill qemu + drop the pid/cid sidecars so a retry re-allocates a CID
+        // instead of pinning the (possibly conflicting) one this attempt wrote.
+        if let Err(e) = spawn_vsock_bridge(&config.name, cid, &state_dir) {
+            if let Some(pid) = read_pid(&pid_file) {
+                send_signal(pid, libc::SIGTERM);
+            }
+            let _ = std::fs::remove_file(&pid_file);
+            let _ = std::fs::remove_file(state_dir.join(QEMU_CID_FILE));
+            return Err(e);
+        }
 
         ui::success(&format!(
             "QEMU workload '{}' started (pid: {}).",
@@ -233,7 +244,11 @@ impl VmBackend for QemuBackend {
     fn stop(&self, id: &VmId) -> Result<()> {
         let state_dir = vm_state_dir(&id.0);
         // Reap the bridge first so it can't keep serving a half-dead VM.
-        if let Some(bpid) = read_pid(&state_dir.join(BRIDGE_PID_FILE)) {
+        // Guard on liveness so a stale pidfile (crash without cleanup) whose
+        // PID the OS has since recycled isn't signalled by mistake.
+        if let Some(bpid) = read_pid(&state_dir.join(BRIDGE_PID_FILE))
+            && pid_alive(bpid)
+        {
             send_signal(bpid, libc::SIGTERM);
         }
         let _ = std::fs::remove_file(state_dir.join(BRIDGE_PID_FILE));
@@ -481,6 +496,33 @@ fn allocate_cid(name: &str) -> Result<u32> {
     if let Some(existing) = read_cid(name) {
         return Ok(existing);
     }
+    // Serialize the scan→pick→write across concurrent `mvmctl up
+    // --hypervisor qemu` so two VMs can't pick the same CID in the window
+    // before either qemu has daemonized (vhost-vsock refuses duplicate live
+    // CIDs). A held `flock` on a shared lock file under the vms root is the
+    // cheapest cross-process mutex; it's released when `_lock` (the open
+    // file description) drops at function return.
+    use std::os::fd::AsRawFd;
+    let vms_root = PathBuf::from(mvm_data_dir()).join("vms");
+    std::fs::create_dir_all(&vms_root)
+        .map_err(|e| anyhow!("create {}: {e}", vms_root.display()))?;
+    let lock_path = vms_root.join(".qemu-cid-alloc.lock");
+    let _lock = std::fs::OpenOptions::new()
+        .create(true)
+        .write(true)
+        .truncate(false)
+        .open(&lock_path)
+        .map_err(|e| anyhow!("open cid lock {}: {e}", lock_path.display()))?;
+    // SAFETY: flock(2) on a valid open fd; LOCK_EX blocks until acquired and
+    // is released on close (when `_lock` drops).
+    if unsafe { libc::flock(_lock.as_raw_fd(), libc::LOCK_EX) } != 0 {
+        return Err(anyhow!(
+            "flock cid alloc {}: {}",
+            lock_path.display(),
+            std::io::Error::last_os_error()
+        ));
+    }
+
     let in_use = used_cids();
     // CID 0/1 reserved (hypervisor/local), 2 = host. Guests start at 3.
     let cid = (3u32..).find(|c| !in_use.contains(c)).unwrap_or(3);
@@ -600,12 +642,21 @@ pub fn run_vsock_bridge(uds: &Path, cid: u32, port: u32, watch_pid_file: &Path) 
         .set_nonblocking(true)
         .map_err(|e| anyhow!("set_nonblocking on {}: {e}", uds.display()))?;
 
-    let watch_pid = read_pid(watch_pid_file);
     loop {
-        // Stop when the watched VM process is gone.
-        if let Some(pid) = watch_pid
-            && !pid_alive(pid)
-        {
+        // Stop when the watched VM is gone. Re-read the pidfile each
+        // iteration so a transient partial read at startup doesn't latch
+        // (the old read-once approach could loop forever on a one-off None).
+        // Distinguish the cases: file *missing* or a *dead* pid → the VM is
+        // torn down, exit; file present but momentarily unparseable → treat
+        // as still-alive and retry (don't exit on a transient bad read).
+        let vm_gone = match std::fs::read_to_string(watch_pid_file) {
+            Err(_) => true, // pidfile removed → VM torn down
+            Ok(s) => match s.trim().parse::<libc::pid_t>() {
+                Ok(pid) => !pid_alive(pid),
+                Err(_) => false, // transient empty/partial read → keep serving
+            },
+        };
+        if vm_gone {
             let _ = std::fs::remove_file(uds);
             return Ok(());
         }
@@ -640,6 +691,11 @@ fn dial_vsock(cid: u32, port: u32) -> std::io::Result<std::net::TcpStream> {
         svm_cid: u32,
         svm_zero: [u8; 4],
     }
+    // Pin the wire layout against the kernel uapi `struct sockaddr_vm`
+    // (family u16 + reserved u16 + port u32 + cid u32 + 4-byte pad = 16,
+    // == sizeof(struct sockaddr)). A future field edit that desyncs the
+    // `socklen` passed to connect(2) trips this at compile time.
+    const _: () = assert!(std::mem::size_of::<SockaddrVm>() == 16);
 
     // SAFETY: standard socket(2)/connect(2) on AF_VSOCK; addr is fully
     // initialized and sized exactly.

--- a/crates/mvm-cli/src/commands/vm/down.rs
+++ b/crates/mvm-cli/src/commands/vm/down.rs
@@ -18,14 +18,21 @@ pub(in crate::commands) struct Args {
 }
 
 pub(in crate::commands) fn run(_cli: &Cli, args: Args, _cfg: &MvmConfig) -> Result<()> {
-    // Use Apple Container backend on macOS 26+, otherwise default (Firecracker).
-    let backend = if mvm_core::platform::current().has_apple_containers() {
-        AnyBackend::from_hypervisor("apple-container")
-    } else {
-        AnyBackend::default_backend()
+    // Platform default for VMs with no pid-file marker (Apple Container /
+    // Docker track state out-of-band, so `for_started_vm` returns None).
+    let platform_default = || {
+        if mvm_core::platform::current().has_apple_containers() {
+            AnyBackend::from_hypervisor("apple-container")
+        } else {
+            AnyBackend::default_backend()
+        }
     };
     match args.name.as_deref() {
         Some(n) => {
+            // Dispatch to the backend that actually started this VM
+            // (resolved from its state-dir pid marker) so a QEMU/libkrun
+            // VM is stopped by its own VMM, not the platform default.
+            let backend = AnyBackend::for_started_vm(n).unwrap_or_else(platform_default);
             // ADR-053 §3 / plan 74 W2: persist the `Stopping`
             // readiness milestone BEFORE the backend stop call so a
             // concurrent `mvmctl ls --json` running during the stop
@@ -60,15 +67,33 @@ pub(in crate::commands) fn run(_cli: &Cli, args: Args, _cfg: &MvmConfig) -> Resu
         }
         None => {
             // Plan-38 §"Boundary statement": fleet/multi-VM is mvmd's job.
-            // `mvmctl down` (no args) just stops every running VM.
-            let result = backend.stop_all();
-            let outcome = if result.is_ok() {
+            // `mvmctl down` (no args) just stops every running VM — across
+            // every backend, each dispatched to its owning VMM so QEMU /
+            // libkrun VMs are stopped too (not just the platform default).
+            let registry_path = mvm::vm::name_registry::registry_path();
+            let mut last_err = None;
+            for vm in AnyBackend::list_all() {
+                let backend = AnyBackend::for_started_vm(&vm.name).unwrap_or_else(platform_default);
+                record_vm_readiness(&vm.name, InstanceReadiness::Stopping);
+                match backend.stop(&VmId::from(vm.name.as_str())) {
+                    Ok(()) => {
+                        if let Ok(mut registry) =
+                            mvm::vm::name_registry::VmNameRegistry::load(&registry_path)
+                        {
+                            registry.deregister(&vm.name);
+                            let _ = registry.save(&registry_path);
+                        }
+                    }
+                    Err(e) => last_err = Some(e),
+                }
+            }
+            let outcome = if last_err.is_none() {
                 "stop_all_ok"
             } else {
                 "stop_all_failed"
             };
             mvm_core::audit_emit!(VmStop, "{outcome}");
-            result
+            last_err.map_or(Ok(()), Err)
         }
     }
 }

--- a/crates/mvm-cli/src/commands/vm/ps.rs
+++ b/crates/mvm-cli/src/commands/vm/ps.rs
@@ -40,26 +40,10 @@ pub(in crate::commands) fn run(_cli: &Cli, args: Args, _cfg: &MvmConfig) -> Resu
         tag_filter.insert(k, v);
     }
 
-    let mut all_vms: Vec<VmInfo> = Vec::new();
-
-    // Collect from Apple Container backend
-    let ac_backend = AnyBackend::from_hypervisor("apple-container");
-    if let Ok(vms) = ac_backend.list() {
-        all_vms.extend(vms);
-    }
-
-    // Collect from Docker backend
-    let docker_backend = AnyBackend::from_hypervisor("docker");
-    if let Ok(vms) = docker_backend.list() {
-        all_vms.extend(vms);
-    }
-
-    // Collect from Firecracker backend. Lima is gone (ADR-013) — Firecracker
-    // runs directly on Linux+KVM hosts.
-    let fc_backend = AnyBackend::from_hypervisor("firecracker");
-    if let Ok(vms) = fc_backend.list() {
-        all_vms.extend(vms);
-    }
+    // Aggregate across every backend (QEMU, libkrun, Firecracker, Apple
+    // Container, Docker) so a VM started under any VMM is listed — not just
+    // the platform default. Single source of truth in `AnyBackend::list_all`.
+    let mut all_vms: Vec<VmInfo> = AnyBackend::list_all();
 
     let _ = args.all;
 
@@ -153,16 +137,19 @@ pub(in crate::commands) fn run(_cli: &Cli, args: Args, _cfg: &MvmConfig) -> Resu
         "NAME", "BACKEND", "STATUS", "CPUS", "MEMORY", "PORTS"
     );
     for vm in &all_vms {
-        let backend_name = if vm.flake_ref.as_deref().is_some() {
-            // Determine backend from context
-            if mvm_core::platform::current().has_apple_containers() {
-                "apple-container"
-            } else {
-                "firecracker"
-            }
-        } else {
-            "unknown"
-        };
+        // Prefer the VM's actual owning backend (resolved from its
+        // state-dir pid marker — qemu/libkrun/firecracker); fall back to a
+        // platform guess for the marker-less backends (Apple Container /
+        // Docker) so the column is accurate for pid-file VMMs.
+        let backend_name: String = AnyBackend::for_started_vm(&vm.name)
+            .map(|b| b.name().to_string())
+            .unwrap_or_else(|| {
+                if mvm_core::platform::current().has_apple_containers() {
+                    "apple-container".to_string()
+                } else {
+                    "firecracker".to_string()
+                }
+            });
         let status = format!("{:?}", vm.status);
         let mem = if vm.memory_mib > 0 {
             format!("{}Mi", vm.memory_mib)


### PR DESCRIPTION
## Plan 166 Phase 2 follow-up #1 — backend-aware `ls` / `down`

After Phase 2 (#671) you could `mvmctl up --hypervisor qemu` a workload, but **`mvmctl ls` wouldn't show it and `mvmctl down <name>` couldn't stop it** — those commands queried a single platform-default backend (apple-container on macOS 26, else Firecracker), so a `qemu.pid` VM fell through (had to `pkill`). The same latent gap hid **libkrun** VMs too.

### Changes
- `AnyBackend::for_started_vm(name)` — resolve a started VM's owning backend from its per-VM state-dir pid marker (`qemu.pid` / `libkrun.pid` / `fc.pid`). Marker-less backends (Apple Container / Docker, which track state out-of-band) return `None`; callers fall back to the platform default.
- `AnyBackend::list_all()` — aggregate the running-VM listing across QEMU + libkrun + Firecracker + Apple Container + Docker (best-effort). Single source of truth.
- `mvmctl ls` — uses `list_all()`; the BACKEND column now shows each VM's **real** owning backend (marker-resolved) instead of a platform guess.
- `mvmctl down <name>` — dispatches the stop to the VM's owning backend.
- `mvmctl down` (no name) — stops every VM across all backends, each via its owning VMM (not just the default).

### Testing
- New `for_started_vm_resolves_owning_backend_by_marker` unit test (qemu/libkrun/fc markers + the no-marker None case).
- clippy + nightly fmt clean (mvm-backend + mvm-cli).
- Box re-verification of the full `up --hypervisor qemu` → `ls`/`down` lifecycle follows on this PR.

Part of the Phase 2 completion checklist (review item #1). The mvmd `--prod` Tier-2/3 refusal remains an mvmd-side follow-up.