### PR TITLE
docs(plan-169): host-side lifecycle convergence + single-host density

### DIFF
--- a/specs/adrs/074-registry-source-of-truth-convergence.md
+++ b/specs/adrs/074-registry-source-of-truth-convergence.md
@@ -1,0 +1,94 @@
+---
+title: "ADR-074: VM name-registry is the source of truth; converge at CLI entry, not a resident daemon"
+status: Proposed
+date: 2026-06-07
+related: Plan 169 (host-lifecycle convergence + density); ADR-045 (hermetic VM-lifecycle testing); ADR-044 (audit_emit! macro); Plan 140 (snapshot/restore productionization); Plan 99 (Stage 0 reaper / cache prune)
+---
+
+## Status
+
+Proposed. Records the architectural posture behind Plan 169; no code lands
+with the ADR. Supersedes nothing — it formalizes a model the codebase already
+half-implements (`VmNameRegistry` + `cache prune --reap-orphans` + the TTL
+`reaper`) and makes the resolution rule explicit.
+
+## Context
+
+mvm's local runtime state lives in two places that can drift apart:
+
+1. The **persistent registry** — `VmNameRegistry` at
+   `{mvm_share_dir}/vm-names.json` (`crates/mvm/src/vm/name_registry.rs`):
+   what mvm *believes* is running.
+2. **On-disk runtime reality** — per-VM state dirs, `libkrun.pid`, vsock
+   sockets, TAP devices (`mvm-core/src/config.rs` helpers): what is *actually*
+   running.
+
+Today the two are reconciled only **manually** (`mvmctl cache prune
+--reap-orphans`) and **lazily** (drift is discovered when a command trips over
+it, then fails). Every recurring stale-state bug in the project's history —
+the libkrun.pid-vs-socket race, the Stage 0 stale-crate bail, the
+degraded-builder-store `dev up` loop, the stale-`pause`-against-a-vanished-VM
+error — is the same root cause: **no component owns making reality match the
+registry, proactively.**
+
+A sibling single-machine sandbox control plane resolves exactly this with a
+"converge persistent-store → runtime on every boot" pass, because it is a
+long-lived daemon. mvm's local path is **one-shot CLI invocations**, so a
+"reconcile on boot" goroutine has no boot to hook. Two questions, then:
+
+- **Which side wins on conflict?**
+- **When does convergence run, given there's no resident process?**
+
+## Decision
+
+**The registry is the source of truth; runtime reality is converged to it.**
+A record with a dead process means "tear the leftovers down and deregister,"
+not "adopt the orphan." Orphan state with no record is reaped. A record
+pointing at vanished state is dropped. Convergence is idempotent — running it
+twice is a no-op.
+
+**Convergence runs at CLI entry for state-touching commands, not in a resident
+daemon.** Any command that reads or mutates VM lifecycle (`up`, `start`,
+`run`, `console`, `down`, `status`, `dev *`, `pause`/`wake`) first runs a
+**cheap** convergence pass (registry read + PID-liveness stat only — never
+spawns a VM, never touches Nix). Read-only, VM-agnostic commands skip it. An
+explicit `mvmctl reconcile` verb exposes the same pass observably, and
+`MVM_SKIP_RECONCILE=1` is the documented escape hatch (never set in CI).
+
+The **resident** reaper loop (`mvm_hostd::supervisor::reaper`) stays where it
+is — spawned by mvmd's supervisor daemon and the MCP dispatcher — and consumes
+the *same* convergence + sweep library. There is exactly one convergence
+implementation; the difference between local and fleet is only *who ticks it*
+(CLI entry vs. daemon timer), never *what it does*.
+
+## Consequences
+
+- **A whole bug class becomes a non-event.** Stale records self-heal at the
+  next state-touching command instead of surfacing as a confusing failure
+  three layers down.
+- **Convergence must be cheap and pure-logic-first** (testable without a real
+  backend, mirroring the existing `reaper::sweep` shape) — otherwise it taxes
+  every CLI invocation. The PID-liveness-only budget is a hard constraint, not
+  a guideline.
+- **It must fail open, not closed.** A convergence error must warn and proceed
+  with the requested command, never block it — a bookkeeping sweep that bricks
+  `mvmctl down` would be worse than the drift it fixes.
+- **Observability:** convergence actions and idle/pressure lifecycle
+  transitions emit to the shared local audit log via `audit_emit!`
+  (consistent with ADR-044 / the Stage 0 audit contract), so density and
+  self-heal behavior are auditable and `audit verify` still chains.
+- **Boundary preserved:** this is host-side lifecycle bookkeeping only. It
+  never touches the guest trust boundary or any of claims 1–15.
+
+## Alternatives considered
+
+- **A resident local daemon that converges on a timer.** Rejected: mvm's local
+  UX is a stateless CLI; a background daemon is a new failure surface, a new
+  thing to install/supervise, and contradicts the one-shot model. mvmd already
+  *is* the resident process for fleet use.
+- **Runtime reality wins (adopt orphans into the registry).** Rejected: an
+  orphan process whose record is gone has lost its admission context
+  (`ExecutionPlan`, audit chain); adopting it would resurrect a workload
+  outside the signed-admission path. Reaping is the only safe direction.
+- **Keep reconciliation manual (`cache prune` only).** Rejected: that is the
+  status quo whose lazy-discovery failure mode this ADR exists to end.

--- a/specs/plans/140-snapshot-restore-productionization.md
+++ b/specs/plans/140-snapshot-restore-productionization.md
@@ -9,6 +9,9 @@ secrets/config disks + unique IP/ID on wake. But the restore path has four
 security-correctness gaps that make it **not production-ready** as written. This
 plan closes the mvm-side gaps. The warm-pool orchestration and wake-time
 admission *policy* live in mvmd — see `../mvmd/specs/plans/53-warm-pool-ms-restore.md`.
+The local single-host *idle-stop / wake / memory-pressure-evict* mechanism that
+*triggers* this sleep/wake machinery (vs. the snapshot correctness gaps below)
+lives in **Plan 169** (host-lifecycle convergence + density).
 
 Backend scope: Firecracker / cloud-hypervisor (`caps.snapshots == true`).
 libkrun + apple-container report `false` — no snapshot there, so the dev/libkrun

--- a/specs/plans/169-host-lifecycle-convergence-and-density.md
+++ b/specs/plans/169-host-lifecycle-convergence-and-density.md
@@ -1,0 +1,192 @@
+# Plan 169 — Host-side lifecycle convergence + single-host density (reconcile / idle-reaper / wake)
+
+> **Status (2026-06-07):** Proposed. No code lands yet. Grounded in a
+> review of an external single-machine sandbox control plane — an
+> MIT-licensed Go service that pairs a container runtime, a reverse proxy,
+> and an embedded SQLite store to run agent workloads behind preview URLs.
+> It is a weaker *isolation* tier than mvm (hardened container isolation,
+> default-off auth, open egress — its own docs say as much), so none of its
+> security model transfers. What does transfer is its **host-daemon
+> lifecycle model**: three background tasks — a boot-time reconciler
+> ("converge the runtime back to the persistent store on every boot"), an
+> idle-timeout **and** host-memory-pressure reaper, and a wake-on-request
+> handler. The external project is **inspiration, not a dependency**; named
+> obliquely per repo policy (the private oblique-reference key lives in
+> auto-memory).
+>
+> **Numbering caveat:** 169 is next-after-highest in local `specs/plans/`
+> (168 tops out). The `check-spec-numbers` Lint gate hard-fails on a
+> duplicate integer prefix — re-confirm 169 is free against open PRs +
+> `main` before merge and renumber if taken. Companion: **ADR-074**
+> (registry-as-source-of-truth; converge at CLI entry, not a resident
+> daemon).
+
+## Context
+
+mvm already owns every *primitive* that lifecycle trio is built from — they are
+just fragmented across crates and never converged into one model, and two of
+the three only run inside mvmd's resident supervisor, never on the plain
+local `mvmctl` path:
+
+| Lifecycle task | mvm primitive that exists today | Gap |
+|---|---|---|
+| reconcile-on-boot | `VmNameRegistry` (`{mvm_share_dir}/vm-names.json`, `crates/mvm/src/vm/name_registry.rs`) + `cache prune --reap-orphans` (`crates/mvm-cli/src/commands/ops/cache.rs`) | Reconciliation is **manual** (`cache prune`) and **lazy** (drift surfaces at use-time, then fails). No automatic convergence pass. |
+| idle/pressure reaper | `mvm_hostd::supervisor::reaper::Reaper` (`crates/mvm-hostd/src/supervisor/reaper.rs`) | TTL-only — keys off `VmRegistration.expires_at` wall-clock. **No idle-activity trigger, no host-memory-pressure eviction.** Spawned only by mvmd's supervisor daemon + the MCP dispatcher (`ops/mcp.rs::spawn_reaper`), never on a bare `mvmctl` invocation. |
+| wake-on-request | `instance_wake()` (`crates/mvm/src/vm/instance/lifecycle.rs:555`) + `VmRegistration.auto_resume` ("connecting to a sleeping VM auto-resumes it") + `sleeping_count` quota (`vm/tenant/quota.rs`) | Wake exists; the **stop-on-idle *trigger* that creates a sleeping VM is missing** — sleep today is only explicit (`mvmctl pause`). No `last_active` timestamp to key idle off. |
+
+The standing pain this addresses is documented across auto-memory: the
+libkrun.pid-vs-socket race in the core_demo chain, the Stage 0 stale-crate
+bail, and the degraded-builder-store loop where `dev up` spins with no
+self-heal and only `rm -rf ~/.cache/mvm/builder-vm` recovers. Every one of
+those is **stale host-side state discovered lazily at use-time**. That model's
+answer — a single idempotent convergence pass that makes the persistent
+registry the source of truth and rebuilds runtime reality to match — is the
+direct structural fix, and the density lever (idle-stop + pressure-evict) is
+the same reaper extended. The user already runs parallel `mvmctl` sessions on
+one Mac (isolated via `MVM_CACHE_DIR`/`MVM_DATA_DIR`), so single-host density
+is a live concern, not a fleet abstraction.
+
+**mvm / mvmd boundary.** Fleet warm-pool orchestration and wake-time
+*admission policy* stay in mvmd (Plan 140 already draws this line;
+`../mvmd/specs/plans/53-warm-pool-ms-restore.md`). This plan delivers only the
+**local single-host mechanism** that lives in this repo: the registry, the
+reaper, the wake trigger, the convergence pass. mvmd consumes the same
+`mvm_hostd::supervisor::reaper` library it already does.
+
+**`mvmctl` is a CLI, not a resident daemon.** That control plane "converges on
+every boot" because it *is* a long-lived process. mvm's local path is one-shot CLI
+invocations. So "converge on boot" maps to **converge at CLI entry for any
+state-touching command** (`up` / `start` / `run` / `console` / `down` /
+`status` / `dev *`) plus an explicit `mvmctl reconcile` verb — not a new
+resident process. ADR-074 records this adaptation.
+
+## Workstreams
+
+### WS-A — Reconcile-on-entry convergence (the core fix)
+
+Make `VmNameRegistry` the source of truth and converge on-disk runtime reality
+to it, cheaply, at the start of every state-touching command.
+
+- [ ] Add `mvm::vm::reconcile::converge(registry, opts) -> ConvergeReport`, a
+      pure-logic-first sweep (testable without a real backend, mirroring
+      `reaper.rs`'s `sweep`): for each `VmRegistration`, classify as
+      `Live` / `DeadProcessLeftState` / `OrphanStateNoRecord` /
+      `RecordNoState`. Liveness check = the registry's runtime artifacts
+      (`vm_libkrun_pid()`, `vm_vsock_port_socket()` / `vm_vz_vsock_port_socket()`
+      from `mvm-core/src/config.rs`) cross-checked against the live PID — reuse
+      the existing live-vs-orphan discrimination in
+      `env::apple_container::reap_orphaned_vm_helpers` rather than reinventing it.
+- [ ] Convergence actions, all idempotent: dead-process records → tear down
+      leftover state + deregister; orphan state dirs with no record → reap
+      (the `cache prune --reap-orphans` logic, lifted into the shared sweep);
+      record pointing at vanished state → drop the stale record (today this
+      surfaces as the "stale `mvmctl pause` against a vanished VM" failure noted
+      in `instance_snapshot.rs:459`).
+- [ ] Wire a **cheap** `converge()` call into CLI entry for state-touching
+      commands behind `MVM_SKIP_RECONCILE=1` (escape hatch, never set in CI).
+      Cheap = registry read + PID liveness stat only; never spawns a VM, never
+      touches Nix. Read-only commands (`--help`, `model *`, `image ls`) skip it.
+- [ ] Add `mvmctl reconcile [--dry-run] [--json]` as the explicit, observable
+      entry point (sibling to `cache prune`). `--json` emits the
+      `ConvergeReport` for scripting; `doctor` gains a one-line "registry
+      drift: N records reconciled / clean" summary.
+- [ ] **Self-heal the degraded-builder-store loop.** `converge()` detects the
+      dangling-GC'd `…-source/flake.nix does not exist` builder state and, with
+      `--repair`, clears `~/.cache/mvm/builder-vm` rather than letting `dev up`
+      spin. Closes the recovery side noted against that failure family.
+
+### WS-B — Activity-driven idle reaper (stop-on-idle)
+
+Extend the TTL reaper from wall-clock-only to TTL **or** idle-timeout, and have
+idle expiry *sleep* (drain/pause) rather than tear down — so the workspace
+persists and WS-C's wake brings it back.
+
+- [ ] Add `last_active: Option<DateTime<Utc>>` to `VmRegistration` (`#[serde(default)]`,
+      backward-compatible — absent = treat as `registered_at`). Touched on every
+      console attach, vsock agent request, and successful `wake`.
+- [ ] Extend `reaper::sweep` with an `IdleSlept { name }` outcome alongside the
+      existing `Reaped`: when `now - last_active > idle_timeout` **and**
+      `auto_resume`, invoke a **sleep** callback (drain-on-sleep / `pause`,
+      the machinery already in `vm/instance/lifecycle.rs` + `instance_snapshot.rs`)
+      instead of teardown. TTL `expires_at` still hard-reaps as today. Keep the
+      ±10 s tick jitter (G6 timing-oracle defense already in `reaper.rs`).
+- [ ] Idle timeout config: `MVM_IDLE_TIMEOUT` env + per-VM tag override
+      (`VmRegistration.tags`), default off on the local path (opt-in), so a plain
+      `mvmctl start` is unchanged unless the user asks for density.
+- [ ] Backend awareness: snapshot-capable backends (FC / CH / Vz —
+      `caps.snapshots`) sleep via drain+snapshot; libkrun / apple-container
+      (no snapshot) sleep via clean stop with the data disk + TAP kept for a
+      cold wake (the disk/TAP retention path already exists —
+      `lifecycle.rs:454/523`). No new snapshot code; this is a *trigger*, not a
+      new sleep mechanism.
+
+### WS-C — Host-memory-pressure reaper (single-host density)
+
+Evict (sleep) the least-recently-active VMs when the host is under RAM
+pressure, so "dozens share one box" works on the user's Mac without manual
+babysitting.
+
+- [ ] Add a pressure-driven sweep to the reaper: read host memory via `sysinfo`
+      (already a dep — `balloon_runtime.rs` uses it), and when free RAM drops
+      below `MVM_HOST_MEM_LOW_WATERMARK`, sleep VMs in `last_active`-ascending
+      order until back above the high watermark. LRU eviction, never kill —
+      sleep + persist, same path as WS-B.
+- [ ] **Reconcile against the existing balloon lever before evicting.** mvm
+      already reclaims guest memory via `BalloonController` / `run_balloon_loop`
+      (`balloon_runtime.rs`). Order of escalation: balloon-reclaim first (cheap,
+      transparent), sleep-evict only when ballooning is exhausted. Document the
+      two-stage policy so they don't fight.
+- [ ] This is the mvm-side mechanism only; mvmd's fleet scheduler may layer its
+      own cross-host policy on top via the same `reaper` library. Note the seam,
+      don't build the fleet side here.
+
+### WS-D — Wake-on-request completion
+
+Close the loop so a slept VM (WS-B/C) comes back on first contact.
+
+- [ ] Audit every guest-contact entry point (`mvmctl console`, vsock agent
+      dispatch, `forward`) to honor `auto_resume`: if the target is slept,
+      `instance_wake()` it, refresh `last_active`, then proceed. `instance_wake`
+      already does fresh secrets/config disks + clock/entropy concerns (Plan 140
+      gaps) — depend on, don't duplicate.
+- [ ] Emit the lifecycle transitions (`vm.slept_idle`, `vm.slept_pressure`,
+      `vm.woke`) to the shared local audit log via `audit_emit!`, consistent
+      with the Stage 0 audit-emit contract — so density behavior is observable
+      and `audit verify` still chains.
+
+## Verification
+
+- [ ] `converge()` unit tests over a synthetic registry: each classification
+      (`Live`/`DeadProcessLeftState`/`OrphanStateNoRecord`/`RecordNoState`) →
+      correct idempotent action; running twice is a no-op (convergence is stable).
+- [ ] Reaper unit tests extended: idle → `IdleSlept` (not `Reaped`); TTL still
+      hard-reaps; pressure sweep evicts LRU-first and stops at the high watermark;
+      `auto_resume=false` is never auto-slept.
+- [ ] Integration (macOS/Vz + libkrun, on this host per auto-memory): start two
+      workloads, force one idle past `MVM_IDLE_TIMEOUT`, assert it sleeps and the
+      other survives; `mvmctl console` the slept one and assert wake; kill a VM's
+      supervisor PID out-of-band and assert the next `mvmctl status` converges the
+      stale record instead of erroring.
+- [ ] `cargo fmt --all -- --check` (nightly per CI), `cargo nextest run
+      --workspace -E 'not package(mvm-backend)'` locally (mvm-backend SIGKILL on
+      macOS codesign — auto-memory), full suite on Linux CI, `cargo clippy
+      --workspace -- -D warnings`, doctests.
+
+## Non-goals
+
+- No fleet/cross-host scheduling — mvmd (Plan 140 / mvmd Plan 53).
+- No new snapshot/restore mechanism — WS-B/C are *triggers* over the existing
+  pause/drain/wake machinery; the four FC restore-correctness gaps stay Plan 140.
+- No resident local daemon. Convergence is a CLI-entry pass (ADR-074). The
+  resident reaper loop remains mvmd's supervisor / the MCP dispatcher.
+- No change to the isolation posture or any of claims 1–15. This is host-side
+  lifecycle bookkeeping; it never touches the guest trust boundary.
+
+## Deferred follow-ups
+
+- [ ] `last_active` could be sharpened from coarse touch-points to real guest
+      activity (vsock byte counters via the Plan 141 packet-observer) — deferred;
+      coarse touch is enough for stop-on-idle v1.
+- [ ] A `warming page` analog for HTTP-preview workloads (the external control
+      plane serves one during cold wake) only matters once mvm grows preview-URL routing — that is
+      mvmd product surface, tracked there, not here.


### PR DESCRIPTION
## What

Two new specs, grounded in a review of an external single-machine sandbox control plane — an MIT-licensed Go service pairing a container runtime, a reverse proxy, and an embedded SQLite store. Its **isolation/security** model does not transfer (hardened container isolation, default-off auth, open egress — its own docs say so). Its **host-daemon lifecycle** shape does: a boot-time reconciler (converge runtime → persistent store), an idle-timeout **and** host-memory-pressure reaper, and a wake-on-request handler. (External project named obliquely per repo policy.)

The finding: **mvm already owns every primitive** — `VmNameRegistry`, the TTL `supervisor::reaper`, `instance_wake`/`auto_resume`, `cache prune --reap-orphans` — but they're fragmented, and two of the three only run inside mvmd's resident supervisor, never on the plain `mvmctl` path. Reconciliation is manual + lazy, so the recurring stale-host-state failures (libkrun.pid race, Stage 0 stale-crate bail, degraded-builder-store `dev up` loop) surface at use-time instead of self-healing.

## Files

- **`specs/plans/169-host-lifecycle-convergence-and-density.md`** — WS-A reconcile-at-CLI-entry convergence (+ `mvmctl reconcile`, self-heals the builder-store loop); WS-B activity-driven idle reaper (sleep, not kill); WS-C host-memory-pressure LRU eviction (escalates after the existing balloon lever); WS-D wake-on-request completion. mvm-side mechanism only — fleet policy stays in mvmd (Plan 140 / mvmd Plan 55).
- **`specs/adrs/074-registry-source-of-truth-convergence.md`** — registry wins on conflict (adopting orphans would resurrect a workload outside signed admission); converge at CLI entry, not a resident daemon; fail-open.
- **`specs/plans/140-…md`** — one-line pointer separating the *trigger* (169) from the snapshot *correctness* gaps (140).

## Scope

No code. Both docs **Proposed**. No change to the isolation posture or claims 1–15 — host-side lifecycle bookkeeping only. `xtask check-spec-numbers` clean (169/074 unique).