### PR TITLE
feat(plan-169): backend-agnostic agent-RPC transport — fs/cp (proc/exec to follow)

### DIFF
--- a/crates/mvm-cli/src/commands/vm/cp.rs
+++ b/crates/mvm-cli/src/commands/vm/cp.rs
@@ -122,7 +122,6 @@ fn copy_host_to_guest(host: &Path, vm: &str, guest_path: &str, args: &Args) -> R
     if !args.force && guest_exists(vm, guest_path)? {
         bail!("Guest destination {vm}:{guest_path} exists; pass --force to overwrite");
     }
-    let dir = super::fs::instance_dir_for(vm)?;
     let req = GuestRequest::FsWrite {
         path: guest_path.to_string(),
         content,
@@ -134,7 +133,7 @@ fn copy_host_to_guest(host: &Path, vm: &str, guest_path: &str, args: &Args) -> R
     // before dispatch so a failure on the wire still leaves an
     // audit trail of "host tried to write to this guest path".
     super::shared::emit_vsock_rpc_audit(vm, &req);
-    match unwrap_fs(mvm_guest::vsock::send_fs_request(&dir, req)?)? {
+    match unwrap_fs(super::fs::fs_request(vm, req)?)? {
         FsResult::Write { bytes_written } => {
             mvm_core::audit_emit!(
                 VmFileCopy,
@@ -182,7 +181,6 @@ fn copy_guest_to_host(vm: &str, guest_path: &str, host: &Path, args: &Args) -> R
             )
         })?;
     }
-    let dir = super::fs::instance_dir_for(vm)?;
     let req = GuestRequest::FsRead {
         path: guest_path.to_string(),
         offset: None,
@@ -191,7 +189,7 @@ fn copy_guest_to_host(vm: &str, guest_path: &str, host: &Path, args: &Args) -> R
     };
     // Plan 74 W2 / Plan 51 W6 — inbound vsock RPC audit.
     super::shared::emit_vsock_rpc_audit(vm, &req);
-    match unwrap_fs(mvm_guest::vsock::send_fs_request(&dir, req)?)? {
+    match unwrap_fs(super::fs::fs_request(vm, req)?)? {
         FsResult::Read { content, .. } => {
             if content.len() as u64 != stat.size {
                 bail!(
@@ -266,14 +264,13 @@ fn parse_endpoint(raw: &str) -> Result<Endpoint> {
 }
 
 fn guest_exists(vm: &str, path: &str) -> Result<bool> {
-    let dir = super::fs::instance_dir_for(vm)?;
     let req = GuestRequest::FsStat {
         path: path.to_string(),
         follow_symlinks: false,
     };
     // Plan 74 W2 / Plan 51 W6 — inbound vsock RPC audit.
     super::shared::emit_vsock_rpc_audit(vm, &req);
-    match mvm_guest::vsock::send_fs_request(&dir, req)? {
+    match super::fs::fs_request(vm, req)? {
         FsResult::Stat(_) => Ok(true),
         FsResult::Error {
             kind: mvm_guest::vsock::FsErrorKind::NotFound,
@@ -285,14 +282,13 @@ fn guest_exists(vm: &str, path: &str) -> Result<bool> {
 }
 
 fn guest_stat(vm: &str, path: &str) -> Result<mvm_guest::vsock::FsStat> {
-    let dir = super::fs::instance_dir_for(vm)?;
     let req = GuestRequest::FsStat {
         path: path.to_string(),
         follow_symlinks: true,
     };
     // Plan 74 W2 / Plan 51 W6 — inbound vsock RPC audit.
     super::shared::emit_vsock_rpc_audit(vm, &req);
-    match unwrap_fs(mvm_guest::vsock::send_fs_request(&dir, req)?)? {
+    match unwrap_fs(super::fs::fs_request(vm, req)?)? {
         FsResult::Stat(stat) => Ok(stat),
         other => bail!("Unexpected FsResult variant for Stat: {:?}", other),
     }

--- a/crates/mvm-cli/src/commands/vm/fs.rs
+++ b/crates/mvm-cli/src/commands/vm/fs.rs
@@ -13,7 +13,6 @@ use anyhow::{Context, Result, bail};
 use clap::{Args as ClapArgs, Subcommand};
 use std::io::{Read, Write};
 
-use mvm_backend::microvm;
 use mvm_core::naming::validate_vm_name;
 use mvm_core::user_config::MvmConfig;
 use mvm_guest::vsock::{FsResult, GuestRequest};
@@ -163,19 +162,22 @@ pub(in crate::commands) fn run(_cli: &Cli, args: Args, _cfg: &MvmConfig) -> Resu
     }
 }
 
-pub(super) fn instance_dir_for(name: &str) -> Result<String> {
+/// Send an FS RPC to `name`'s guest agent over the backend-aware transport
+/// (Plan 169). `vsock_transport::for_vm` picks the right socket per VMM —
+/// Firecracker's `v.sock`, or the per-port UNIX socket libkrun/QEMU expose
+/// — so `mvmctl fs`/`cp` work regardless of which backend launched the VM.
+/// The `--hypervisor mock` fast path (a mock agent at the VM dir's
+/// `runtime/v.sock`) stays ahead of the probe since `for_vm` is unaware of
+/// the in-memory mock backend.
+pub(super) fn fs_request(name: &str, req: GuestRequest) -> Result<FsResult> {
     validate_vm_name(name).with_context(|| format!("Invalid VM name: {:?}", name))?;
-    // Plan 66 W3: if a mock VM is registered at
-    // `<mvm_data_dir>/mock-vms/<name>/runtime/v.sock`, route to it
-    // directly. The check is filesystem-based — production code
-    // never reaches the mock-vms path because `MockBackend` only
-    // populates it under `--hypervisor mock`. Falls through to the
-    // Lima-era resolver when no mock is in play.
     let mock_dir = mvm_backend::MockBackend::vm_dir(name);
     if mock_dir.join("runtime").join("v.sock").exists() {
-        return Ok(mock_dir.to_string_lossy().into_owned());
+        return mvm_guest::vsock::send_fs_request(&mock_dir.to_string_lossy(), req);
     }
-    microvm::resolve_running_vm_dir(name)
+    let mut stream =
+        mvm::vsock_transport::for_vm(name)?.connect(mvm_guest::vsock::GUEST_AGENT_PORT)?;
+    mvm_guest::vsock::send_fs_request_on(&mut stream, req)
 }
 
 fn unwrap_fs(result: FsResult) -> Result<FsResult> {
@@ -186,7 +188,6 @@ fn unwrap_fs(result: FsResult) -> Result<FsResult> {
 }
 
 fn cmd_read(name: &str, path: &str, offset: u64, length: u64) -> Result<()> {
-    let dir = instance_dir_for(name)?;
     let req = GuestRequest::FsRead {
         path: path.to_string(),
         offset: if offset == 0 { None } else { Some(offset) },
@@ -195,7 +196,7 @@ fn cmd_read(name: &str, path: &str, offset: u64, length: u64) -> Result<()> {
     };
     // Plan 74 W2 / Plan 51 W6 — inbound vsock RPC audit.
     super::shared::emit_vsock_rpc_audit(name, &req);
-    let result = unwrap_fs(mvm_guest::vsock::send_fs_request(&dir, req)?)?;
+    let result = unwrap_fs(fs_request(name, req)?)?;
     match result {
         FsResult::Read { content, .. } => {
             std::io::stdout().write_all(&content)?;
@@ -213,7 +214,6 @@ fn cmd_write(
     create_parents: bool,
     follow_symlinks: bool,
 ) -> Result<()> {
-    let dir = instance_dir_for(name)?;
     let bytes = match content {
         Some(s) => s.into_bytes(),
         None => {
@@ -231,7 +231,7 @@ fn cmd_write(
     };
     // Plan 74 W2 / Plan 51 W6 — inbound vsock RPC audit.
     super::shared::emit_vsock_rpc_audit(name, &req);
-    let result = unwrap_fs(mvm_guest::vsock::send_fs_request(&dir, req)?)?;
+    let result = unwrap_fs(fs_request(name, req)?)?;
     match result {
         FsResult::Write { bytes_written } => {
             eprintln!("wrote {} bytes", bytes_written);
@@ -243,14 +243,13 @@ fn cmd_write(
 }
 
 fn cmd_ls(name: &str, path: &str, json: bool) -> Result<()> {
-    let dir = instance_dir_for(name)?;
     let req = GuestRequest::FsList {
         path: path.to_string(),
         follow_symlinks: true,
     };
     // Plan 74 W2 / Plan 51 W6 — inbound vsock RPC audit.
     super::shared::emit_vsock_rpc_audit(name, &req);
-    let result = unwrap_fs(mvm_guest::vsock::send_fs_request(&dir, req)?)?;
+    let result = unwrap_fs(fs_request(name, req)?)?;
     match result {
         FsResult::List { entries, truncated } => {
             if json {
@@ -286,14 +285,13 @@ fn cmd_ls(name: &str, path: &str, json: bool) -> Result<()> {
 }
 
 fn cmd_stat(name: &str, path: &str, follow_symlinks: bool, json: bool) -> Result<()> {
-    let dir = instance_dir_for(name)?;
     let req = GuestRequest::FsStat {
         path: path.to_string(),
         follow_symlinks,
     };
     // Plan 74 W2 / Plan 51 W6 — inbound vsock RPC audit.
     super::shared::emit_vsock_rpc_audit(name, &req);
-    let result = unwrap_fs(mvm_guest::vsock::send_fs_request(&dir, req)?)?;
+    let result = unwrap_fs(fs_request(name, req)?)?;
     match result {
         FsResult::Stat(s) => {
             if json {
@@ -314,7 +312,6 @@ fn cmd_stat(name: &str, path: &str, follow_symlinks: bool, json: bool) -> Result
 }
 
 fn cmd_mkdir(name: &str, path: &str, mode: u32, parents: bool) -> Result<()> {
-    let dir = instance_dir_for(name)?;
     let req = GuestRequest::FsMkdir {
         path: path.to_string(),
         mode,
@@ -322,7 +319,7 @@ fn cmd_mkdir(name: &str, path: &str, mode: u32, parents: bool) -> Result<()> {
     };
     // Plan 74 W2 / Plan 51 W6 — inbound vsock RPC audit.
     super::shared::emit_vsock_rpc_audit(name, &req);
-    let result = unwrap_fs(mvm_guest::vsock::send_fs_request(&dir, req)?)?;
+    let result = unwrap_fs(fs_request(name, req)?)?;
     match result {
         FsResult::Mkdir => {
             mvm_core::audit_emit!(VmFsMutate, vm: name, "op=mkdir path={path} mode={mode:o} parents={parents}");
@@ -333,7 +330,6 @@ fn cmd_mkdir(name: &str, path: &str, mode: u32, parents: bool) -> Result<()> {
 }
 
 fn cmd_rm(name: &str, path: &str, recursive: bool) -> Result<()> {
-    let dir = instance_dir_for(name)?;
     let req = GuestRequest::FsRemove {
         path: path.to_string(),
         recursive,
@@ -341,7 +337,7 @@ fn cmd_rm(name: &str, path: &str, recursive: bool) -> Result<()> {
     };
     // Plan 74 W2 / Plan 51 W6 — inbound vsock RPC audit.
     super::shared::emit_vsock_rpc_audit(name, &req);
-    let result = unwrap_fs(mvm_guest::vsock::send_fs_request(&dir, req)?)?;
+    let result = unwrap_fs(fs_request(name, req)?)?;
     match result {
         FsResult::Remove { entries_removed } => {
             eprintln!("removed {} entries", entries_removed);
@@ -353,7 +349,6 @@ fn cmd_rm(name: &str, path: &str, recursive: bool) -> Result<()> {
 }
 
 fn cmd_mv(name: &str, from: &str, to: &str) -> Result<()> {
-    let dir = instance_dir_for(name)?;
     let req = GuestRequest::FsMove {
         from: from.to_string(),
         to: to.to_string(),
@@ -361,7 +356,7 @@ fn cmd_mv(name: &str, from: &str, to: &str) -> Result<()> {
     };
     // Plan 74 W2 / Plan 51 W6 — inbound vsock RPC audit.
     super::shared::emit_vsock_rpc_audit(name, &req);
-    let result = unwrap_fs(mvm_guest::vsock::send_fs_request(&dir, req)?)?;
+    let result = unwrap_fs(fs_request(name, req)?)?;
     match result {
         FsResult::Move => {
             mvm_core::audit_emit!(VmFsMutate, vm: name, "op=mv from={from} to={to}");

--- a/crates/mvm-guest/src/vsock.rs
+++ b/crates/mvm-guest/src/vsock.rs
@@ -2411,8 +2411,19 @@ pub fn send_fs_request(instance_dir: &str, req: GuestRequest) -> Result<FsResult
             | GuestRequest::FsMove { .. }
     ));
     let mut stream = connect(instance_dir, DEFAULT_TIMEOUT_SECS)?;
-    require_capabilities(&mut stream, &[GuestCapability::FilesystemRpc])?;
-    let resp = send_request(&mut stream, &req)?;
+    send_fs_request_on(&mut stream, req)
+}
+
+/// Dispatch a single FS RPC on an already-connected stream and return the
+/// `FsResult`. The backend-agnostic entry point: the host CLI obtains the
+/// stream from `mvm::vsock_transport::for_vm(name)` (which resolves the
+/// right socket per backend — Firecracker's `v.sock`, or the per-port UNIX
+/// socket libkrun/QEMU expose), so `fs`/`cp` work regardless of which VMM
+/// launched the VM (Plan 169). `send_fs_request` is the dir-based wrapper
+/// over this for callers that still pass an instance dir (mvmd, mock).
+pub fn send_fs_request_on(stream: &mut UnixStream, req: GuestRequest) -> Result<FsResult> {
+    require_capabilities(stream, &[GuestCapability::FilesystemRpc])?;
+    let resp = send_request(stream, &req)?;
     match resp {
         GuestResponse::FsResult(r) => Ok(r),
         GuestResponse::Error { message } => bail!("Guest FS RPC transport error: {}", message),

--- a/specs/plans/166-qemu-dev-builder-backend.md
+++ b/specs/plans/166-qemu-dev-builder-backend.md
@@ -150,7 +150,8 @@ AF_VSOCK↔UNIX bridge.
 - [x] TCG boot emits a loud Tier-3 banner (mirrors Docker fallback); qemu `security_profile` notes "unaudited vs ADR-002".
 
 ### Deferred follow-ups (Phase 2)
-- [ ] `mvmctl ls` / `down` aren't QEMU-backend-aware (they query one backend; a QEMU VM's `qemu.pid` isn't listed — same multi-backend limitation libkrun has). Wire a backend-agnostic VM registry.
+- [x] `mvmctl ls` / `down` backend-aware (PR #675): `AnyBackend::for_started_vm` (pid-marker dispatch) + `list_all` aggregation; `ls` shows the real backend, `down` stops per-VM. Fixed the latent libkrun-invisible gap too.
+- [ ] `mvmctl fs` / `proc` / `exec` / `cp` / `diff` resolve the agent vsock socket the Firecracker way (`<dir>/runtime/v.sock`) instead of the backend-aware `vsock_transport::for_vm`, so they fail against QEMU (and libkrun). → **Plan 169** (cross-backend agent-RPC transport unification). `wait` / `boot-report` already work.
 - [ ] mvmd `--prod` Tier 2/3 refusal (above).
 
 ## Phase 3: provisioning, docs, and the firecracker arch bug

--- a/specs/plans/169-agent-rpc-backend-agnostic-transport.md
+++ b/specs/plans/169-agent-rpc-backend-agnostic-transport.md
@@ -1,0 +1,91 @@
+# Plan 169 — Backend-agnostic agent-RPC transport (`fs`/`proc`/`exec`/`cp`/`diff`)
+
+## Status: IN PROGRESS (2026-06-07). `fs` + `cp` migrated + box-verified on QEMU; `proc`/`exec`/`diff` remaining. Surfaced by Plan 166 Phase 2 box verification.
+
+> **Cross-backend, not QEMU-specific.** The QEMU workload runtime (Plan 166
+> Phase 2, PR #671/#675) is the trigger, but the gap is in the shared
+> host↔guest agent-RPC layer and equally affects **libkrun**. This is its
+> own plan precisely because it changes a shared API used by every backend
+> (and consumed by mvmd), so it wants a focused review separate from Plan 166.
+
+## Problem
+
+The agent-RPC CLI verbs resolve the guest vsock socket the **Firecracker**
+way — `<instance_dir>/runtime/v.sock` — instead of through the
+backend-aware `mvm::vsock_transport::for_vm(name)`. So they fail against a
+QEMU (or libkrun) workload, whose agent is reached over a per-port UNIX
+socket at `mvm_core::config::vm_vsock_port_socket(name, port)` (for QEMU,
+the `__qemu-vsock-bridge` binds it; for libkrun, the supervisor does).
+
+Observed on the box (Plan 166 Phase 2): `mvmctl fs ls <qemu-vm> /` →
+`Vsock socket not found at /root/microvm/vms/<name>/runtime/v.sock`.
+
+`mvmctl wait` and `mvmctl boot-report` already work against QEMU because
+they take the right path: `for_vm(name)?.connect(GUEST_AGENT_PORT)` + the
+stream-based framing primitives. The fix is to make the rest do the same.
+
+## Root cause
+
+`crates/mvm-guest/src/vsock.rs` exposes ~8 **dir-based** wrappers that each
+call `connect(instance_dir)` → `connect_to(vsock_uds_path(instance_dir))` →
+`<instance_dir>/runtime/v.sock`:
+
+- `send_fs_request(instance_dir, req) -> FsResult`
+- `send_proc_request(instance_dir, req) -> ProcResult`
+- `send_proc_wait(instance_dir, pid_token, …, on_event)` (streaming)
+- `send_run_entrypoint(instance_dir, …)` (streaming; `exec`/`invoke`)
+- `query_worker_status` / `query_integration_status` / `query_probe_status` /
+  `query_fs_diff(instance_dir)`
+
+The **framing primitives are already stream-based and `pub`**:
+`connect_to` / `connect_to_port`, `write_frame` / `read_frame`,
+`send_request`, `require_capabilities`. There are also `*_at(uds_path)`
+variants for some queries — a precedent for explicit-path entry points.
+
+CLI callers: `commands/vm/{fs,proc,exec,cp,diff}.rs` (+ `invoke.rs`).
+`fs.rs` (7) / `proc.rs` (6) / `cp.rs` (4) call the dir-based wrappers;
+`fs::instance_dir_for` → `microvm::resolve_running_vm_dir` is the FC-only
+resolver feeding them.
+
+## Approach
+
+Mirror what `wait` does: obtain a connected stream from
+`vsock_transport::for_vm(name)` (which already probes apple-container →
+libkrun-socket → firecracker, and the libkrun-socket probe matches the QEMU
+bridge socket), then drive the stream-based primitives.
+
+- [x] **`mvm-guest::vsock`**: `send_fs_request_on(stream, req)` added; dir-based
+  `send_fs_request` delegates to it (FC/mock/mvmd dir callers unchanged).
+  (`send_proc_request_on` / `send_proc_wait_on` / `send_run_entrypoint_on`
+  still to add for the proc/exec slice.)
+- [x] **`mvmctl fs`**: `fs_request(name, req)` helper routes through
+  `for_vm(name)?.connect(GUEST_AGENT_PORT)?` + `send_fs_request_on`, keeping
+  the mock fast path ahead of the probe. All 7 verbs migrated; the dead
+  `instance_dir_for`/`microvm` import dropped.
+- [x] **`mvmctl cp`**: routed through `fs::fs_request`.
+- [ ] **`mvmctl proc`**: add `send_proc_request_on` / `send_proc_wait_on`;
+  route `proc.rs` (its own `instance_dir_for`) through `for_vm`.
+- [ ] **`mvmctl exec` / `invoke`**: route `send_run_entrypoint` through
+  `for_vm` (confirm exec's current mechanism first).
+- [ ] **`mvmctl diff`**: route `query_fs_diff` through `for_vm` (or its
+  `_at` variant fed by the resolved socket path).
+- [ ] Keep the mock-VM fast path (`MockBackend::vm_dir/.../runtime/v.sock`)
+  working — `for_vm` doesn't know mock; either add a mock probe to `for_vm`
+  or keep the mock check ahead of the `for_vm` call in each command.
+
+## Verification
+
+- [ ] Unit: `for_vm` selects the libkrun/QEMU socket for a marker-resolved
+  VM; the `*_on` framing round-trips against a mock stream.
+- [ ] Box (x86_64): `mvmctl up --hypervisor qemu` then `fs ls` / `fs read` /
+  `proc list` / `cp` succeed against the live QEMU workload (agent over the
+  `__qemu-vsock-bridge`).
+- [ ] Regression: the same verbs still work against Firecracker + mock
+  (`--hypervisor mock`) + the mvmd dir-based callers compile unchanged.
+- [ ] `cargo nextest` + clippy + nightly fmt + `check-spec-numbers`.
+
+## Non-goals
+
+- New agent RPCs or wire-format changes — pure transport-resolution.
+- Changing the mvmd-side dir-based callers (they keep the dir API).
+- The mvmd `--prod` Tier-2/3 admission gate (tracked in Plan 166 / mvmd).


### PR DESCRIPTION
## Plan 169 — backend-agnostic agent-RPC transport

Surfaced by Plan 166 Phase 2 box verification: `mvmctl fs`/`cp`/`proc`/`exec`/`diff` resolved the guest vsock socket the **Firecracker** way (`<dir>/runtime/v.sock`) instead of the backend-aware `mvm::vsock_transport::for_vm(name)`, so they failed against a **QEMU** (or **libkrun**) workload whose agent is a per-port UNIX socket (`vm_vsock_port_socket`). `mvmctl wait`/`boot-report` already work because they take the right path.

This PR does the `fs` + `cp` slice (most-used verbs) + lands the plan; `proc`/`exec`/`diff` are plan checkboxes using the same established pattern.

### Changes
- **`mvm-guest::vsock`**: add `send_fs_request_on(stream, req)`; the dir-based `send_fs_request` now delegates to it (Firecracker / mock / mvmd dir callers unchanged). Mirrors the existing `start_port_forward_on` precedent.
- **`mvmctl fs`**: `fs_request(name, req)` helper = `for_vm(name)?.connect(GUEST_AGENT_PORT)?` + `send_fs_request_on`, with the `--hypervisor mock` fast path kept ahead of the probe (`for_vm` is mock-unaware). All 7 verbs migrated; the now-dead `instance_dir_for` + `microvm` import dropped.
- **`mvmctl cp`**: routed through `fs::fs_request`.
- **`specs/plans/169`**: the cross-backend plan (fs/cp `[x]`; proc/exec/diff `[ ]`). Plan 166 follow-ups updated (`ls`/`down` `[x]` via #675; the agent-RPC gap → Plan 169).

### Testing
- clippy + nightly fmt clean (mvm-guest + mvm-cli).
- ⏳ Box: `mvmctl fs ls` / `fs read` / `cp` against a live QEMU workload (via the `__qemu-vsock-bridge`); regression against Firecracker + `--hypervisor mock`. Running before merge.

`proc`/`exec`/`diff` follow the identical `*_on` + `for_vm` pattern (tracked in Plan 169).