### PR TITLE
feat(plan-169 WS-A): reconcile-on-entry convergence

### DIFF
--- a/crates/mvm-cli/src/commands/cmd_audit.rs
+++ b/crates/mvm-cli/src/commands/cmd_audit.rs
@@ -133,7 +133,7 @@ fn emit_unbound(recorder: &Recorder, event: String, extras: Vec<(String, String)
 
 impl Commands {
     /// Whether this command reads or mutates VM lifecycle state and so
-    /// warrants the cheap reconcile-on-entry convergence pass (Plan 169
+    /// warrants the cheap reconcile-on-entry convergence pass (Plan 170
     /// WS-A / ADR-074). Read-only, VM-agnostic commands (`doctor`, `ls`
     /// of caches, build/compile, config, …) skip it. `reconcile` itself
     /// is excluded — it *is* the convergence pass, run with its own opts.

--- a/crates/mvm-cli/src/commands/cmd_audit.rs
+++ b/crates/mvm-cli/src/commands/cmd_audit.rs
@@ -132,6 +132,29 @@ fn emit_unbound(recorder: &Recorder, event: String, extras: Vec<(String, String)
 }
 
 impl Commands {
+    /// Whether this command reads or mutates VM lifecycle state and so
+    /// warrants the cheap reconcile-on-entry convergence pass (Plan 169
+    /// WS-A / ADR-074). Read-only, VM-agnostic commands (`doctor`, `ls`
+    /// of caches, build/compile, config, …) skip it. `reconcile` itself
+    /// is excluded — it *is* the convergence pass, run with its own opts.
+    pub(super) fn touches_vm_state(&self) -> bool {
+        matches!(
+            self,
+            // Lifecycle mutate/read on the local single-host path.
+            Commands::Up(_)
+                | Commands::Down(_)
+                | Commands::Run(_)
+                | Commands::Console(_)
+                | Commands::Dev(_)
+                | Commands::Pause(_)
+                | Commands::Resume(_)
+                | Commands::Snapshot(_)
+                // `ls` is the local "status" surface — converging first
+                // means stale dead records never show up in the listing.
+                | Commands::Ls(_)
+        )
+    }
+
     /// Canonical clap-subcommand name for this variant. Used as the
     /// `<verb>` slot in `cmd.<verb>.*` audit events. The values
     /// MUST match the names emitted by `clap::Command::get_name()`

--- a/crates/mvm-cli/src/commands/cmd_audit.rs
+++ b/crates/mvm-cli/src/commands/cmd_audit.rs
@@ -169,6 +169,7 @@ impl Commands {
             Commands::Catalog(_) => "catalog",
             Commands::Console(_) => "console",
             Commands::Cache(_) => "cache",
+            Commands::Reconcile(_) => "reconcile",
             Commands::Init(_) => "init",
             Commands::Run(_) => "run",
             Commands::Receipt(_) => "receipt",

--- a/crates/mvm-cli/src/commands/mod.rs
+++ b/crates/mvm-cli/src/commands/mod.rs
@@ -286,6 +286,15 @@ pub fn run() -> Result<()> {
         tracing::warn!("failed to install signal handler: {e}");
     }
 
+    // Plan 169 WS-A / ADR-074 — reconcile-on-entry convergence. For any
+    // state-touching command, cheaply (registry read + pid-liveness stat
+    // only) heal registry/runtime drift before dispatch, so stale records
+    // self-heal instead of surfacing as a confusing failure three layers
+    // down. Fail-open: `converge` never returns an error and we drop the
+    // report — `mvmctl reconcile` is the observable entry point.
+    // `MVM_SKIP_RECONCILE=1` opts out (never set in CI).
+    maybe_converge_on_entry(&cli.command);
+
     // Load operator config once; used as fallback for dev_vm_cpus, dev_vm_mem_gib, cpus, memory.
     let cfg = mvm_core::user_config::load(None);
 
@@ -361,4 +370,18 @@ pub fn run() -> Result<()> {
     cmd_audit::emit_cmd_outcome(cmd_recorder.as_ref(), verb, &result);
 
     with_hints(result)
+}
+
+/// Run the cheap reconcile-on-entry convergence for state-touching
+/// commands (Plan 169 WS-A / ADR-074), unless `MVM_SKIP_RECONCILE=1`.
+/// Fail-open: `converge` collects errors internally and never returns an
+/// `Err`, so this can never block the requested command.
+fn maybe_converge_on_entry(command: &Commands) {
+    if !command.touches_vm_state() {
+        return;
+    }
+    if std::env::var("MVM_SKIP_RECONCILE").as_deref() == Ok("1") {
+        return;
+    }
+    let _ = mvm::vm::reconcile::converge(&mvm::vm::reconcile::ConvergeOpts::default());
 }

--- a/crates/mvm-cli/src/commands/mod.rs
+++ b/crates/mvm-cli/src/commands/mod.rs
@@ -123,6 +123,8 @@ pub(in crate::commands) enum Commands {
     Console(vm::console::Args),
     /// Manage the XDG cache directory (~/.cache/mvm)
     Cache(ops::cache::Args),
+    /// Converge the VM name registry with on-disk runtime state
+    Reconcile(ops::reconcile::Args),
     /// Scaffold a new project
     Init(env::init::Args),
     /// Run one command in a transient microVM
@@ -324,6 +326,7 @@ pub fn run() -> Result<()> {
         Commands::Catalog(a) => catalog::run(&cli, a, &cfg),
         Commands::Console(a) => vm::console::run(&cli, a, &cfg),
         Commands::Cache(a) => ops::cache::run(&cli, a, &cfg),
+        Commands::Reconcile(a) => ops::reconcile::run(&cli, a, &cfg),
         Commands::Init(a) => env::init::run(&cli, a, &cfg),
         Commands::Run(a) => vm::exec::run_secure(&cli, a, &cfg),
         Commands::Receipt(a) => vm::exec::run_receipt(&cli, a, &cfg),

--- a/crates/mvm-cli/src/commands/mod.rs
+++ b/crates/mvm-cli/src/commands/mod.rs
@@ -286,7 +286,7 @@ pub fn run() -> Result<()> {
         tracing::warn!("failed to install signal handler: {e}");
     }
 
-    // Plan 169 WS-A / ADR-074 — reconcile-on-entry convergence. For any
+    // Plan 170 WS-A / ADR-074 — reconcile-on-entry convergence. For any
     // state-touching command, cheaply (registry read + pid-liveness stat
     // only) heal registry/runtime drift before dispatch, so stale records
     // self-heal instead of surfacing as a confusing failure three layers
@@ -373,7 +373,7 @@ pub fn run() -> Result<()> {
 }
 
 /// Run the cheap reconcile-on-entry convergence for state-touching
-/// commands (Plan 169 WS-A / ADR-074), unless `MVM_SKIP_RECONCILE=1`.
+/// commands (Plan 170 WS-A / ADR-074), unless `MVM_SKIP_RECONCILE=1`.
 /// Fail-open: `converge` collects errors internally and never returns an
 /// `Err`, so this can never block the requested command.
 fn maybe_converge_on_entry(command: &Commands) {

--- a/crates/mvm-cli/src/commands/ops/mod.rs
+++ b/crates/mvm-cli/src/commands/ops/mod.rs
@@ -11,6 +11,7 @@ pub(super) mod config;
 pub(super) mod mcp;
 pub(super) mod metrics;
 pub(super) mod network;
+pub(super) mod reconcile;
 pub(super) mod secret;
 
 pub(super) use super::{Cli, shared};

--- a/crates/mvm-cli/src/commands/ops/reconcile.rs
+++ b/crates/mvm-cli/src/commands/ops/reconcile.rs
@@ -1,0 +1,82 @@
+//! `mvmctl reconcile` — explicit registry/runtime convergence pass
+//! (Plan 169 WS-A / ADR-074).
+//!
+//! The same cheap convergence the CLI entry path runs for state-touching
+//! commands, surfaced as an observable verb (sibling to `cache prune`).
+//! `--dry-run` reports drift without healing it; `--json` emits the
+//! `ConvergeReport` for scripting.
+
+use anyhow::Result;
+use clap::Args as ClapArgs;
+
+use mvm::vm::reconcile::{self, ConvergeOpts};
+use mvm_core::user_config::MvmConfig;
+
+use super::Cli;
+use crate::ui;
+
+#[derive(ClapArgs, Debug, Clone)]
+pub(in crate::commands) struct Args {
+    /// Report drift without tearing down state, reaping orphans, or
+    /// deregistering records. The registry on disk is left untouched.
+    #[arg(long)]
+    pub dry_run: bool,
+    /// Emit the convergence report as JSON to stdout.
+    #[arg(long)]
+    pub json: bool,
+}
+
+pub(in crate::commands) fn run(_cli: &Cli, args: Args, _cfg: &MvmConfig) -> Result<()> {
+    let report = reconcile::converge(&ConvergeOpts {
+        dry_run: args.dry_run,
+    });
+
+    if args.json {
+        crate::json_out::emit_json(&report)?;
+        return Ok(());
+    }
+
+    if report.is_clean() {
+        ui::info("Registry is consistent with runtime state. Nothing to reconcile.");
+        return Ok(());
+    }
+
+    let prefix = if args.dry_run { "(dry-run) Would " } else { "" };
+    if !report.dead_process_reaped.is_empty() {
+        ui::info(&format!(
+            "{prefix}tear down {} dead-process record(s): {}",
+            report.dead_process_reaped.len(),
+            report.dead_process_reaped.join(", "),
+        ));
+    }
+    if !report.stale_record_dropped.is_empty() {
+        ui::info(&format!(
+            "{prefix}drop {} stale record(s) (state vanished): {}",
+            report.stale_record_dropped.len(),
+            report.stale_record_dropped.join(", "),
+        ));
+    }
+    if !report.orphan_state_reaped.is_empty() {
+        ui::info(&format!(
+            "{prefix}reap {} orphan state dir(s) (no record): {}",
+            report.orphan_state_reaped.len(),
+            report.orphan_state_reaped.join(", "),
+        ));
+    }
+    for err in &report.errors {
+        ui::warn(&format!("reconcile: {err}"));
+    }
+
+    if args.dry_run {
+        ui::info(&format!(
+            "{} record(s) would be reconciled. Re-run without --dry-run to apply.",
+            report.reconciled_count()
+        ));
+    } else {
+        ui::success(&format!(
+            "Reconciled {} drift item(s).",
+            report.reconciled_count()
+        ));
+    }
+    Ok(())
+}

--- a/crates/mvm-cli/src/commands/ops/reconcile.rs
+++ b/crates/mvm-cli/src/commands/ops/reconcile.rs
@@ -1,5 +1,5 @@
 //! `mvmctl reconcile` — explicit registry/runtime convergence pass
-//! (Plan 169 WS-A / ADR-074).
+//! (Plan 170 WS-A / ADR-074).
 //!
 //! The same cheap convergence the CLI entry path runs for state-touching
 //! commands, surfaced as an observable verb (sibling to `cache prune`).

--- a/crates/mvm-cli/src/commands/tests.rs
+++ b/crates/mvm-cli/src/commands/tests.rs
@@ -2836,7 +2836,7 @@ fn test_session_attach_resume_parses() {
     }
 }
 
-// -------- Plan 169 WS-A: reconcile-on-entry gate --------
+// -------- Plan 170 WS-A: reconcile-on-entry gate --------
 
 fn touches(argv: &[&str]) -> bool {
     Cli::try_parse_from(argv)

--- a/crates/mvm-cli/src/commands/tests.rs
+++ b/crates/mvm-cli/src/commands/tests.rs
@@ -2835,3 +2835,34 @@ fn test_session_attach_resume_parses() {
         _ => panic!("expected session attach"),
     }
 }
+
+// -------- Plan 169 WS-A: reconcile-on-entry gate --------
+
+fn touches(argv: &[&str]) -> bool {
+    Cli::try_parse_from(argv)
+        .unwrap()
+        .command
+        .touches_vm_state()
+}
+
+#[test]
+fn state_touching_commands_trigger_entry_convergence() {
+    // Lifecycle mutate/read commands run the cheap converge pass.
+    assert!(touches(&["mvmctl", "up"]));
+    assert!(touches(&["mvmctl", "down"]));
+    assert!(touches(&["mvmctl", "console", "myvm"]));
+    assert!(touches(&["mvmctl", "pause", "myvm"]));
+    assert!(touches(&["mvmctl", "ls"]));
+    assert!(touches(&["mvmctl", "dev", "status"]));
+}
+
+#[test]
+fn read_only_and_vm_agnostic_commands_skip_entry_convergence() {
+    assert!(!touches(&["mvmctl", "doctor"]));
+    assert!(!touches(&["mvmctl", "catalog", "list"]));
+    assert!(!touches(&["mvmctl", "audit", "tail"]));
+    assert!(!touches(&["mvmctl", "cache", "info"]));
+    // `reconcile` is the convergence verb itself — must not double-run on entry.
+    assert!(!touches(&["mvmctl", "reconcile"]));
+    assert!(!touches(&["mvmctl", "reconcile", "--dry-run"]));
+}

--- a/crates/mvm-cli/src/doctor.rs
+++ b/crates/mvm-cli/src/doctor.rs
@@ -193,7 +193,7 @@ fn stage0_status_check() -> Check {
 }
 
 /// One-line summary of a dry-run convergence report for `doctor`
-/// (Plan 169 WS-A). Pure so it's testable without touching the registry.
+/// (Plan 170 WS-A). Pure so it's testable without touching the registry.
 fn registry_drift_summary(report: &mvm::vm::reconcile::ConvergeReport) -> String {
     let n = report.reconciled_count();
     if n == 0 {
@@ -203,7 +203,7 @@ fn registry_drift_summary(report: &mvm::vm::reconcile::ConvergeReport) -> String
     }
 }
 
-/// Surface registry/runtime drift (Plan 169 WS-A / ADR-074) without
+/// Surface registry/runtime drift (Plan 170 WS-A / ADR-074) without
 /// healing it: a dry-run convergence pass, reported as `clean` or a
 /// count. Informational — drift self-heals at the next state-touching
 /// command, so `ok` is always true.

--- a/crates/mvm-cli/src/doctor.rs
+++ b/crates/mvm-cli/src/doctor.rs
@@ -192,6 +192,31 @@ fn stage0_status_check() -> Check {
     }
 }
 
+/// One-line summary of a dry-run convergence report for `doctor`
+/// (Plan 169 WS-A). Pure so it's testable without touching the registry.
+fn registry_drift_summary(report: &mvm::vm::reconcile::ConvergeReport) -> String {
+    let n = report.reconciled_count();
+    if n == 0 {
+        "clean".to_string()
+    } else {
+        format!("{n} record(s) would be reconciled (run `mvmctl reconcile`)")
+    }
+}
+
+/// Surface registry/runtime drift (Plan 169 WS-A / ADR-074) without
+/// healing it: a dry-run convergence pass, reported as `clean` or a
+/// count. Informational — drift self-heals at the next state-touching
+/// command, so `ok` is always true.
+fn registry_drift_check() -> Check {
+    let report = mvm::vm::reconcile::converge(&mvm::vm::reconcile::ConvergeOpts { dry_run: true });
+    Check {
+        name: "registry drift",
+        category: "platform",
+        ok: true,
+        info: registry_drift_summary(&report),
+    }
+}
+
 pub fn run(json: bool, workflow: Option<DoctorWorkflow>) -> Result<()> {
     // ── Prerequisites (user must install before bootstrap) ───────
     let mut checks = vec![
@@ -251,6 +276,7 @@ pub fn run(json: bool, workflow: Option<DoctorWorkflow>) -> Result<()> {
     checks.push(docker_check(plat));
     checks.push(ts_runner_check());
     checks.push(stage0_status_check());
+    checks.push(registry_drift_check());
 
     checks.push(disk_space_check(false));
 
@@ -2438,6 +2464,20 @@ mod tests {
         // And honestly-`false` backends should not be silently dropped.
         assert_eq!(support.get("docker"), Some(&false));
         assert_eq!(support.get("apple-container"), Some(&false));
+    }
+
+    #[test]
+    fn registry_drift_summary_reports_clean_and_counts() {
+        use mvm::vm::reconcile::ConvergeReport;
+        let clean = ConvergeReport::default();
+        assert_eq!(registry_drift_summary(&clean), "clean");
+
+        let mut drifted = ConvergeReport::default();
+        drifted.dead_process_reaped.push("vm1".to_string());
+        drifted.orphan_state_reaped.push("ghost".to_string());
+        let s = registry_drift_summary(&drifted);
+        assert!(s.starts_with("2 record(s) would be reconciled"), "{s}");
+        assert!(s.contains("mvmctl reconcile"));
     }
 
     #[test]

--- a/crates/mvm-cli/tests/reconcile_cli.rs
+++ b/crates/mvm-cli/tests/reconcile_cli.rs
@@ -1,0 +1,80 @@
+//! CLI surface tests for `mvmctl reconcile` (Plan 169 WS-A).
+
+use assert_cmd::cargo::CommandCargoExt;
+use std::process::Command;
+
+fn mvmctl(args: &[&str]) -> std::process::Output {
+    #[allow(deprecated)]
+    Command::cargo_bin("mvmctl")
+        .expect("locate mvmctl")
+        .args(args)
+        .output()
+        .expect("spawn mvmctl")
+}
+
+#[test]
+fn reconcile_help_lists_dry_run_and_json_flags() {
+    let out = mvmctl(&["reconcile", "--help"]);
+    let stdout = String::from_utf8_lossy(&out.stdout);
+    assert!(
+        out.status.success(),
+        "stderr:\n{}",
+        String::from_utf8_lossy(&out.stderr)
+    );
+    assert!(
+        stdout.contains("--dry-run"),
+        "`mvmctl reconcile --help` missing --dry-run; got:\n{stdout}"
+    );
+    assert!(
+        stdout.contains("--json"),
+        "`mvmctl reconcile --help` missing --json; got:\n{stdout}"
+    );
+}
+
+#[test]
+fn reconcile_appears_in_top_level_help() {
+    let out = mvmctl(&["--help"]);
+    let stdout = String::from_utf8_lossy(&out.stdout);
+    assert!(
+        stdout.contains("reconcile"),
+        "top-level help missing `reconcile`; got:\n{stdout}"
+    );
+}
+
+#[test]
+fn reconcile_rejects_unknown_flag() {
+    let out = mvmctl(&["reconcile", "--bogus"]);
+    assert!(
+        !out.status.success(),
+        "unknown flag must be a clap parse error"
+    );
+}
+
+#[test]
+fn reconcile_dry_run_json_runs_against_isolated_dirs() {
+    // Point all state at throwaway dirs so the run can't touch the host's
+    // real registry. Dry-run + empty registry → clean, valid JSON report.
+    let tmp = tempfile::tempdir().expect("tempdir");
+    let p = |s: &str| tmp.path().join(s).to_string_lossy().into_owned();
+    #[allow(deprecated)]
+    let out = Command::cargo_bin("mvmctl")
+        .expect("locate mvmctl")
+        .args(["reconcile", "--dry-run", "--json"])
+        .env("MVM_SHARE_DIR", p("share"))
+        .env("MVM_DATA_DIR", p("data"))
+        .env("MVM_STATE_DIR", p("state"))
+        .output()
+        .expect("spawn mvmctl");
+    assert!(
+        out.status.success(),
+        "stderr:\n{}",
+        String::from_utf8_lossy(&out.stderr)
+    );
+    let stdout = String::from_utf8_lossy(&out.stdout);
+    let parsed: serde_json::Value =
+        serde_json::from_str(stdout.trim()).unwrap_or_else(|e| panic!("not JSON ({e}):\n{stdout}"));
+    // The ConvergeReport shape: arrays for each classification bucket.
+    assert!(parsed.get("dead_process_reaped").is_some(), "got: {parsed}");
+    assert!(parsed.get("stale_record_dropped").is_some(), "got: {parsed}");
+    assert!(parsed.get("orphan_state_reaped").is_some(), "got: {parsed}");
+}

--- a/crates/mvm-cli/tests/reconcile_cli.rs
+++ b/crates/mvm-cli/tests/reconcile_cli.rs
@@ -75,6 +75,9 @@ fn reconcile_dry_run_json_runs_against_isolated_dirs() {
         serde_json::from_str(stdout.trim()).unwrap_or_else(|e| panic!("not JSON ({e}):\n{stdout}"));
     // The ConvergeReport shape: arrays for each classification bucket.
     assert!(parsed.get("dead_process_reaped").is_some(), "got: {parsed}");
-    assert!(parsed.get("stale_record_dropped").is_some(), "got: {parsed}");
+    assert!(
+        parsed.get("stale_record_dropped").is_some(),
+        "got: {parsed}"
+    );
     assert!(parsed.get("orphan_state_reaped").is_some(), "got: {parsed}");
 }

--- a/crates/mvm-cli/tests/reconcile_cli.rs
+++ b/crates/mvm-cli/tests/reconcile_cli.rs
@@ -1,4 +1,4 @@
-//! CLI surface tests for `mvmctl reconcile` (Plan 169 WS-A).
+//! CLI surface tests for `mvmctl reconcile` (Plan 170 WS-A).
 
 use assert_cmd::cargo::CommandCargoExt;
 use std::process::Command;

--- a/crates/mvm-core/src/policy/audit.rs
+++ b/crates/mvm-core/src/policy/audit.rs
@@ -156,7 +156,7 @@ pub enum LocalAuditKind {
     /// the count and (for small sweeps) the truncated slot hashes.
     SlotPrune,
     /// Reconcile-on-entry convergence healed registry/runtime drift
-    /// (Plan 169 WS-A / ADR-074): a dead-process record was torn down, a
+    /// (Plan 170 WS-A / ADR-074): a dead-process record was torn down, a
     /// stale record dropped, or an orphan state dir reaped. One entry per
     /// healed item; the `detail` field carries `action=<classification>`.
     /// Emitted by `mvmctl reconcile` and the cheap convergence pass run at
@@ -1035,7 +1035,7 @@ mod tests {
     /// the doc comment explaining why they're separate.
     #[test]
     fn registry_reconcile_kind_serializes_snake_case() {
-        // Plan 169 WS-A — the convergence audit kind must serde-roundtrip
+        // Plan 170 WS-A — the convergence audit kind must serde-roundtrip
         // (snake_case per the enum attr) so emission + chain verification
         // stay stable.
         let json = serde_json::to_string(&LocalAuditKind::RegistryReconcile).unwrap();

--- a/crates/mvm-core/src/policy/audit.rs
+++ b/crates/mvm-core/src/policy/audit.rs
@@ -155,6 +155,13 @@ pub enum LocalAuditKind {
     /// `mvmctl cache prune --orphan-builds`. The detail field carries
     /// the count and (for small sweeps) the truncated slot hashes.
     SlotPrune,
+    /// Reconcile-on-entry convergence healed registry/runtime drift
+    /// (Plan 169 WS-A / ADR-074): a dead-process record was torn down, a
+    /// stale record dropped, or an orphan state dir reaped. One entry per
+    /// healed item; the `detail` field carries `action=<classification>`.
+    /// Emitted by `mvmctl reconcile` and the cheap convergence pass run at
+    /// CLI entry for state-touching commands.
+    RegistryReconcile,
     // --- Sandbox SDK foundation (fs/proc/share/pause/TTL/tags) ---
     // The verbs below are state-changing CLI surfaces added by the
     // sandbox-SDK foundation work. Each kind names a single mutation
@@ -1026,6 +1033,17 @@ mod tests {
     /// policy-deny variant. A future maintainer who tries to
     /// collapse them into one kind fails this test and reads
     /// the doc comment explaining why they're separate.
+    #[test]
+    fn registry_reconcile_kind_serializes_snake_case() {
+        // Plan 169 WS-A — the convergence audit kind must serde-roundtrip
+        // (snake_case per the enum attr) so emission + chain verification
+        // stay stable.
+        let json = serde_json::to_string(&LocalAuditKind::RegistryReconcile).unwrap();
+        assert_eq!(json, "\"registry_reconcile\"");
+        let parsed: LocalAuditKind = serde_json::from_str(&json).unwrap();
+        assert_eq!(parsed, LocalAuditKind::RegistryReconcile);
+    }
+
     #[test]
     fn w2_mandatory_deny_is_separate_from_policy_deny() {
         // PartialEq + serialize both establish identity.

--- a/crates/mvm/src/vm/mod.rs
+++ b/crates/mvm/src/vm/mod.rs
@@ -15,6 +15,7 @@ pub mod egress_proxy;
 pub mod instance_snapshot;
 pub mod name_registry;
 pub mod overlay;
+pub mod reconcile;
 pub mod template;
 pub mod vminitd_client;
 pub mod volume_registry;

--- a/crates/mvm/src/vm/reconcile.rs
+++ b/crates/mvm/src/vm/reconcile.rs
@@ -1,4 +1,4 @@
-//! Reconcile-on-entry convergence (Plan 169 WS-A / ADR-074).
+//! Reconcile-on-entry convergence (Plan 170 WS-A / ADR-074).
 //!
 //! The VM name registry (`VmNameRegistry`, `{mvm_share_dir}/vm-names.json`)
 //! is the source of truth; this module converges on-disk runtime reality to

--- a/crates/mvm/src/vm/reconcile.rs
+++ b/crates/mvm/src/vm/reconcile.rs
@@ -100,7 +100,8 @@ pub struct ConvergeReport {
 impl ConvergeReport {
     /// Total drift healed: records dropped plus orphan dirs reaped.
     pub fn reconciled_count(&self) -> usize {
-        self.dead_process_reaped.len() + self.stale_record_dropped.len()
+        self.dead_process_reaped.len()
+            + self.stale_record_dropped.len()
             + self.orphan_state_reaped.len()
     }
 
@@ -643,7 +644,11 @@ mod tests {
 
     #[test]
     fn sweep_run_twice_is_a_no_op() {
-        let mut reg = registry_with(&[("live", "/s/live"), ("dead", "/s/dead"), ("gone", "/s/gone")]);
+        let mut reg = registry_with(&[
+            ("live", "/s/live"),
+            ("dead", "/s/dead"),
+            ("gone", "/s/gone"),
+        ]);
         let world = FakeWorld {
             present: RefCell::new(["/s/live".to_string(), "/s/dead".to_string()].into()),
             alive: RefCell::new(["/s/live".to_string()].into()),
@@ -808,7 +813,8 @@ mod tests {
         let mut reg = VmNameRegistry::default();
         reg.register_with_metadata(RegisterParams::minimal("dead", &dead_dir, "default"))
             .unwrap();
-        reg.save(&crate::vm::name_registry::registry_path()).unwrap();
+        reg.save(&crate::vm::name_registry::registry_path())
+            .unwrap();
 
         let report = converge(&ConvergeOpts::default());
         assert_eq!(report.dead_process_reaped, vec!["dead".to_string()]);
@@ -855,8 +861,12 @@ mod tests {
             .unwrap();
         reg.register_with_metadata(RegisterParams::minimal("dead", &dead_dir, "default"))
             .unwrap();
-        reg.register_with_metadata(RegisterParams::minimal("gone", "/nonexistent/gone", "default"))
-            .unwrap();
+        reg.register_with_metadata(RegisterParams::minimal(
+            "gone",
+            "/nonexistent/gone",
+            "default",
+        ))
+        .unwrap();
         reg.save(&registry_path).unwrap();
 
         let report = converge_at(&registry_path, &vms_root, &ConvergeOpts::default());
@@ -874,7 +884,10 @@ mod tests {
 
         // Idempotent on disk: a second pass is clean and rewrites nothing.
         let again = converge_at(&registry_path, &vms_root, &ConvergeOpts::default());
-        assert!(again.is_clean(), "second converge_at must be clean: {again:?}");
+        assert!(
+            again.is_clean(),
+            "second converge_at must be clean: {again:?}"
+        );
     }
 
     #[test]
@@ -893,7 +906,12 @@ mod tests {
         assert_eq!(report.dead_process_reaped, vec!["dead".to_string()]);
         // Disk + registry untouched.
         assert!(Path::new(&dead_dir).exists());
-        assert!(VmNameRegistry::load(&registry_path).unwrap().lookup("dead").is_some());
+        assert!(
+            VmNameRegistry::load(&registry_path)
+                .unwrap()
+                .lookup("dead")
+                .is_some()
+        );
     }
 
     #[test]

--- a/crates/mvm/src/vm/reconcile.rs
+++ b/crates/mvm/src/vm/reconcile.rs
@@ -1,0 +1,939 @@
+//! Reconcile-on-entry convergence (Plan 169 WS-A / ADR-074).
+//!
+//! The VM name registry (`VmNameRegistry`, `{mvm_share_dir}/vm-names.json`)
+//! is the source of truth; this module converges on-disk runtime reality to
+//! it. A record whose supervisor process is dead has its leftover state torn
+//! down and the record dropped — never adopted (ADR-074): an orphan process
+//! that lost its admission context must not be resurrected outside the
+//! signed-admission path. State dirs with no record are reaped; records whose
+//! state has vanished are dropped. Convergence is idempotent — running it
+//! twice is a no-op.
+//!
+//! Pure-logic-first, mirroring `mvm_hostd::supervisor::reaper::sweep`:
+//! [`classify`] and [`sweep`] take an injected [`RuntimeView`] /
+//! [`ReconcileActions`] and need no real backend, clock, or filesystem.
+//! [`converge`] is the thin real-filesystem adapter the CLI entry path calls.
+//!
+//! **Cheapness is a hard constraint (ADR-074).** Liveness is a `kill(pid, 0)`
+//! stat against the recorded supervisor pid files only — never `pgrep` / `ps`
+//! (which spawn subprocesses), never a VM boot, never Nix. The heavier
+//! helper-PID argv sweep stays in `mvmctl cache prune --reap-orphans`. This
+//! reuses the live-vs-orphan discrimination from `mvm-cli`'s
+//! `env::apple_container` reaper rather than reinventing the policy; the bare
+//! syscall is restated here only because the lower `mvm` crate can't depend on
+//! `mvm-cli`.
+
+use std::collections::BTreeSet;
+use std::path::{Path, PathBuf};
+
+use serde::Serialize;
+
+use crate::vm::name_registry::{VmNameRegistry, VmRegistration};
+
+/// Options controlling a convergence pass.
+#[derive(Debug, Clone, Default)]
+pub struct ConvergeOpts {
+    /// Classify and report drift but perform no teardown, reap, or
+    /// deregister — the on-disk registry and state dirs are left untouched.
+    pub dry_run: bool,
+}
+
+/// One unit of drift between the registry and on-disk runtime reality.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum Drift {
+    /// Record with a live supervisor process, or an intentionally-paused
+    /// record. Nothing to do.
+    Live { name: String },
+    /// Record present with runtime state on disk, but the supervisor
+    /// process is dead. Tear down the leftover state and drop the record.
+    DeadProcessLeftState { name: String },
+    /// Record present but its runtime state dir has vanished. Drop the
+    /// stale record (today this surfaces as a stale `pause` against a
+    /// vanished VM).
+    RecordNoState { name: String },
+    /// A runtime state dir on disk with no registry record and no live
+    /// owning process. Reap it.
+    OrphanStateNoRecord { dir: String },
+}
+
+/// Cheap, side-effect-free observations convergence makes. The real impl
+/// ([`FsRuntimeView`]) is filesystem stat + `kill(pid, 0)`; tests inject a
+/// synthetic view so [`classify`] / [`sweep`] run with no real backend.
+pub trait RuntimeView {
+    /// Does this record's on-disk runtime state still exist?
+    fn state_present(&self, reg: &VmRegistration) -> bool;
+    /// Is the supervisor process recorded in that state alive? Consulted
+    /// only when [`RuntimeView::state_present`] is true.
+    fn process_alive(&self, reg: &VmRegistration) -> bool;
+    /// Basenames of runtime state dirs on disk that have no record in
+    /// `known` **and** no live owning process — i.e. true orphans, safe to
+    /// reap. A dir with a live process is an in-flight or specially-managed
+    /// VM (e.g. the dev VM) and is deliberately excluded.
+    fn orphan_dirs(&self, known: &BTreeSet<String>) -> Vec<String>;
+}
+
+/// The mutating side of convergence, injected so [`sweep`] stays testable.
+pub trait ReconcileActions {
+    /// Tear down a dead-process record's leftover runtime state.
+    fn tear_down(&self, name: &str, reg: &VmRegistration) -> Result<(), String>;
+    /// Reap an orphan state dir (basename) that has no record.
+    fn reap_orphan(&self, dir: &str) -> Result<(), String>;
+}
+
+/// What a convergence pass observed and did. Serializable for
+/// `mvmctl reconcile --json`.
+#[derive(Debug, Clone, Default, Serialize)]
+pub struct ConvergeReport {
+    /// Records left untouched — live or intentionally paused.
+    pub live: Vec<String>,
+    /// Dead-process records whose leftover state was torn down + dropped.
+    pub dead_process_reaped: Vec<String>,
+    /// Records whose state had vanished; the stale record was dropped.
+    pub stale_record_dropped: Vec<String>,
+    /// Orphan state dirs (no record) that were reaped.
+    pub orphan_state_reaped: Vec<String>,
+    /// Non-fatal errors. Fail-open: recorded here, never returned, so a
+    /// bookkeeping hiccup can't block the command that triggered the sweep.
+    pub errors: Vec<String>,
+}
+
+impl ConvergeReport {
+    /// Total drift healed: records dropped plus orphan dirs reaped.
+    pub fn reconciled_count(&self) -> usize {
+        self.dead_process_reaped.len() + self.stale_record_dropped.len()
+            + self.orphan_state_reaped.len()
+    }
+
+    /// No drift healed and no errors — reality already matched the registry.
+    pub fn is_clean(&self) -> bool {
+        self.reconciled_count() == 0 && self.errors.is_empty()
+    }
+}
+
+/// Pure classification: cross-check every record against runtime reality and
+/// enumerate orphan state dirs. No mutation, no I/O of its own — drives off
+/// the injected [`RuntimeView`]. Deterministic order (records sorted by name,
+/// then orphan dirs sorted).
+pub fn classify(registry: &VmNameRegistry, view: &dyn RuntimeView) -> Vec<Drift> {
+    let mut drifts = Vec::new();
+
+    let mut names: Vec<&String> = registry.vms.keys().collect();
+    names.sort();
+    for name in names {
+        let reg = &registry.vms[name];
+        // An intentionally-paused record (sealed snapshot awaiting
+        // `mvmctl resume`) has a dead process by design — never reap it.
+        if reg.paused {
+            drifts.push(Drift::Live { name: name.clone() });
+            continue;
+        }
+        if !view.state_present(reg) {
+            drifts.push(Drift::RecordNoState { name: name.clone() });
+        } else if view.process_alive(reg) {
+            drifts.push(Drift::Live { name: name.clone() });
+        } else {
+            drifts.push(Drift::DeadProcessLeftState { name: name.clone() });
+        }
+    }
+
+    let known: BTreeSet<String> = registry.vms.keys().cloned().collect();
+    let mut orphans = view.orphan_dirs(&known);
+    orphans.sort();
+    orphans.dedup();
+    for dir in orphans {
+        drifts.push(Drift::OrphanStateNoRecord { dir });
+    }
+
+    drifts
+}
+
+/// Apply convergence to an in-memory registry: tear down dead-process
+/// records, drop stale records, reap orphan dirs, and deregister the
+/// reconciled records. Pure of filesystem I/O beyond the injected
+/// `actions` — testable with a fake backend. Mirrors
+/// `mvm_hostd::supervisor::reaper::sweep`.
+///
+/// Idempotent: a second `sweep` over the post-sweep registry + reality
+/// finds no drift (every dropped record is gone, every reaped dir is gone),
+/// so it reports only `Live` and mutates nothing. A failed action keeps its
+/// record so the next pass retries (fail-open — recorded in
+/// `report.errors`, never returned).
+pub fn sweep(
+    registry: &mut VmNameRegistry,
+    view: &dyn RuntimeView,
+    actions: &dyn ReconcileActions,
+    opts: &ConvergeOpts,
+) -> ConvergeReport {
+    let mut report = ConvergeReport::default();
+    let mut to_deregister = Vec::new();
+
+    for drift in classify(registry, view) {
+        match drift {
+            Drift::Live { name } => report.live.push(name),
+            Drift::RecordNoState { name } => {
+                if !opts.dry_run {
+                    to_deregister.push(name.clone());
+                }
+                report.stale_record_dropped.push(name);
+            }
+            Drift::DeadProcessLeftState { name } => {
+                if opts.dry_run {
+                    report.dead_process_reaped.push(name);
+                    continue;
+                }
+                let reg = registry.vms[&name].clone();
+                match actions.tear_down(&name, &reg) {
+                    Ok(()) => {
+                        to_deregister.push(name.clone());
+                        report.dead_process_reaped.push(name);
+                    }
+                    Err(e) => report.errors.push(format!("tear down {name}: {e}")),
+                }
+            }
+            Drift::OrphanStateNoRecord { dir } => {
+                if opts.dry_run {
+                    report.orphan_state_reaped.push(dir);
+                    continue;
+                }
+                match actions.reap_orphan(&dir) {
+                    Ok(()) => report.orphan_state_reaped.push(dir),
+                    Err(e) => report.errors.push(format!("reap orphan {dir}: {e}")),
+                }
+            }
+        }
+    }
+
+    for name in to_deregister {
+        registry.deregister(&name);
+    }
+    report
+}
+
+/// Supervisor pid-file names a per-VM state dir may carry. `pid` is the
+/// Apple-Container dev-VM owner file; `libkrun.pid` / `vz.pid` are the
+/// workload-supervisor files. The first one that exists and points at a
+/// live process marks the dir as having a live owner.
+const PID_FILE_NAMES: &[&str] = &["libkrun.pid", "vz.pid", "pid"];
+
+/// `kill(pid, 0)` existence probe — delivers no signal, just checks the
+/// process is alive. The cheap half of the live-vs-orphan discrimination
+/// (see module docs); the heavier argv/ppid sweep stays in `cache prune`.
+fn pid_is_alive(pid: i32) -> bool {
+    // SAFETY: kill with signal 0 performs only a permission/existence
+    // check and never delivers a signal.
+    unsafe { libc::kill(pid, 0) == 0 }
+}
+
+fn read_pid_file(path: &Path) -> Option<i32> {
+    std::fs::read_to_string(path)
+        .ok()?
+        .trim()
+        .parse::<i32>()
+        .ok()
+        .filter(|&p| p > 1)
+}
+
+/// Does `dir` carry a supervisor pid file pointing at a live process?
+fn dir_has_live_process(dir: &Path) -> bool {
+    PID_FILE_NAMES
+        .iter()
+        .filter_map(|f| read_pid_file(&dir.join(f)))
+        .any(pid_is_alive)
+}
+
+/// Best-effort recursive removal of a state dir. The dead-process
+/// discrimination already ran in [`classify`], so there is no live process
+/// to signal here — only leftover sockets / pid files / `console.log`.
+fn remove_state_dir(dir: &Path) -> Result<(), String> {
+    if !dir.exists() {
+        return Ok(());
+    }
+    std::fs::remove_dir_all(dir).map_err(|e| format!("{}: {e}", dir.display()))
+}
+
+/// Real-filesystem [`RuntimeView`] rooted at a `vms` directory
+/// (`{mvm_data_dir}/vms`). State presence is a `stat`; liveness is
+/// `kill(pid, 0)` on the recorded supervisor pid files — no subprocess
+/// spawn, no VM boot (ADR-074's cheapness budget).
+pub struct FsRuntimeView {
+    vms_root: PathBuf,
+}
+
+impl FsRuntimeView {
+    pub fn new(vms_root: impl Into<PathBuf>) -> Self {
+        Self {
+            vms_root: vms_root.into(),
+        }
+    }
+}
+
+impl RuntimeView for FsRuntimeView {
+    fn state_present(&self, reg: &VmRegistration) -> bool {
+        Path::new(&reg.vm_dir).is_dir()
+    }
+    fn process_alive(&self, reg: &VmRegistration) -> bool {
+        dir_has_live_process(Path::new(&reg.vm_dir))
+    }
+    fn orphan_dirs(&self, known: &BTreeSet<String>) -> Vec<String> {
+        let Ok(entries) = std::fs::read_dir(&self.vms_root) else {
+            return Vec::new();
+        };
+        let mut out = Vec::new();
+        for entry in entries.flatten() {
+            let path = entry.path();
+            if !path.is_dir() {
+                continue;
+            }
+            let Some(name) = path.file_name().and_then(|s| s.to_str()) else {
+                continue;
+            };
+            // Canonical layout is `vms/<name>`, so the dir basename is the
+            // registry key. A dir with a live owner is an in-flight or
+            // specially-managed VM (e.g. the dev VM) — never an orphan.
+            if known.contains(name) || dir_has_live_process(&path) {
+                continue;
+            }
+            out.push(name.to_string());
+        }
+        out
+    }
+}
+
+/// Real-filesystem [`ReconcileActions`] rooted at the same `vms` dir.
+pub struct FsReconcileActions {
+    vms_root: PathBuf,
+}
+
+impl FsReconcileActions {
+    pub fn new(vms_root: impl Into<PathBuf>) -> Self {
+        Self {
+            vms_root: vms_root.into(),
+        }
+    }
+}
+
+impl ReconcileActions for FsReconcileActions {
+    fn tear_down(&self, _name: &str, reg: &VmRegistration) -> Result<(), String> {
+        remove_state_dir(Path::new(&reg.vm_dir))
+    }
+    fn reap_orphan(&self, dir: &str) -> Result<(), String> {
+        remove_state_dir(&self.vms_root.join(dir))
+    }
+}
+
+/// Filesystem adapter over explicit paths — the testable seam under
+/// [`converge`]. Loads the registry, sweeps it against `vms_root`, and
+/// (unless `dry_run`) saves it back when records were dropped. Fail-open:
+/// a load/save error is recorded in the report and the pass still returns
+/// — never an `Err` that could block the calling command (ADR-074).
+///
+/// Does not emit audit; that belongs to the real entry point [`converge`]
+/// so this stays free of process-global state and hermetically testable.
+pub fn converge_at(registry_path: &Path, vms_root: &Path, opts: &ConvergeOpts) -> ConvergeReport {
+    let mut registry = match VmNameRegistry::load(registry_path) {
+        Ok(r) => r,
+        Err(e) => {
+            let mut report = ConvergeReport::default();
+            report
+                .errors
+                .push(format!("load registry {}: {e}", registry_path.display()));
+            return report;
+        }
+    };
+
+    let view = FsRuntimeView::new(vms_root);
+    let actions = FsReconcileActions::new(vms_root);
+    let mut report = sweep(&mut registry, &view, &actions, opts);
+
+    let registry_changed =
+        !report.dead_process_reaped.is_empty() || !report.stale_record_dropped.is_empty();
+    if !opts.dry_run
+        && registry_changed
+        && let Err(e) = registry.save(registry_path)
+    {
+        // The in-memory reconcile already happened; only persistence
+        // failed. Record it and keep going — fail-open.
+        report
+            .errors
+            .push(format!("save registry {}: {e}", registry_path.display()));
+    }
+    report
+}
+
+/// Reconcile the default on-disk registry — the cheap convergence pass the
+/// CLI entry path runs for state-touching commands, and the body of
+/// `mvmctl reconcile`. Never returns an error: drift-healing must never
+/// block the requested command (ADR-074 fail-open). On the non-dry-run
+/// path emits a `RegistryReconcile` audit line per healed item so the
+/// self-heal is observable and `audit verify` still chains.
+pub fn converge(opts: &ConvergeOpts) -> ConvergeReport {
+    let registry_path = crate::vm::name_registry::registry_path();
+    let vms_root = PathBuf::from(mvm_core::config::mvm_data_dir()).join("vms");
+    let report = converge_at(&registry_path, &vms_root, opts);
+    if !opts.dry_run {
+        emit_audit(&report);
+    }
+    report
+}
+
+/// Emit one `RegistryReconcile` audit line per healed item. Best-effort
+/// (the audit layer swallows write failures); consistent with the Stage 0
+/// audit-emit contract (ADR-044).
+fn emit_audit(report: &ConvergeReport) {
+    for name in &report.dead_process_reaped {
+        mvm_core::audit_emit!(RegistryReconcile, vm: name.as_str(), "action=dead_process_left_state");
+    }
+    for name in &report.stale_record_dropped {
+        mvm_core::audit_emit!(RegistryReconcile, vm: name.as_str(), "action=record_no_state");
+    }
+    for dir in &report.orphan_state_reaped {
+        mvm_core::audit_emit!(RegistryReconcile, vm: dir.as_str(), "action=orphan_state_no_record");
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::vm::name_registry::RegisterParams;
+    use std::cell::RefCell;
+    use std::path::Path;
+
+    /// Create `<vms_root>/<name>/` and return its absolute path. With
+    /// `pid` set, write a `libkrun.pid` pointing at that pid.
+    fn make_state_dir(vms_root: &Path, name: &str, pid: Option<i32>) -> String {
+        let dir = vms_root.join(name);
+        std::fs::create_dir_all(&dir).unwrap();
+        if let Some(pid) = pid {
+            std::fs::write(dir.join("libkrun.pid"), pid.to_string()).unwrap();
+        }
+        dir.to_string_lossy().into_owned()
+    }
+
+    /// In-memory [`RuntimeView`] for hermetic classification tests.
+    #[derive(Default)]
+    struct FakeView {
+        /// VM names whose state dir is present.
+        present: BTreeSet<String>,
+        /// VM names whose supervisor process is alive.
+        alive: BTreeSet<String>,
+        /// State-dir basenames on disk (the orphan-scan source set).
+        on_disk: BTreeSet<String>,
+        /// Basenames the view considers to have a live owner (excluded
+        /// from orphan reaping).
+        live_dirs: BTreeSet<String>,
+    }
+
+    impl RuntimeView for FakeView {
+        fn state_present(&self, reg: &VmRegistration) -> bool {
+            self.present.contains(&reg.vm_dir)
+        }
+        fn process_alive(&self, reg: &VmRegistration) -> bool {
+            self.alive.contains(&reg.vm_dir)
+        }
+        fn orphan_dirs(&self, known: &BTreeSet<String>) -> Vec<String> {
+            self.on_disk
+                .iter()
+                .filter(|d| !known.contains(d.as_str()))
+                .filter(|d| !self.live_dirs.contains(d.as_str()))
+                .cloned()
+                .collect()
+        }
+    }
+
+    fn registry_with(names_and_dirs: &[(&str, &str)]) -> VmNameRegistry {
+        let mut reg = VmNameRegistry::default();
+        for (name, dir) in names_and_dirs {
+            reg.register_with_metadata(RegisterParams::minimal(name, dir, "default"))
+                .unwrap();
+        }
+        reg
+    }
+
+    #[test]
+    fn classify_live_record_when_state_present_and_process_alive() {
+        let reg = registry_with(&[("vm1", "/s/vm1")]);
+        let view = FakeView {
+            present: ["/s/vm1".to_string()].into(),
+            alive: ["/s/vm1".to_string()].into(),
+            ..Default::default()
+        };
+        assert_eq!(
+            classify(&reg, &view),
+            vec![Drift::Live {
+                name: "vm1".to_string()
+            }]
+        );
+    }
+
+    #[test]
+    fn classify_dead_process_when_state_present_but_process_dead() {
+        let reg = registry_with(&[("vm1", "/s/vm1")]);
+        let view = FakeView {
+            present: ["/s/vm1".to_string()].into(),
+            ..Default::default()
+        };
+        assert_eq!(
+            classify(&reg, &view),
+            vec![Drift::DeadProcessLeftState {
+                name: "vm1".to_string()
+            }]
+        );
+    }
+
+    #[test]
+    fn classify_record_no_state_when_state_dir_vanished() {
+        let reg = registry_with(&[("vm1", "/s/vm1")]);
+        let view = FakeView::default();
+        assert_eq!(
+            classify(&reg, &view),
+            vec![Drift::RecordNoState {
+                name: "vm1".to_string()
+            }]
+        );
+    }
+
+    #[test]
+    fn classify_orphan_state_dir_with_no_record() {
+        let reg = VmNameRegistry::default();
+        let view = FakeView {
+            on_disk: ["ghost".to_string()].into(),
+            ..Default::default()
+        };
+        assert_eq!(
+            classify(&reg, &view),
+            vec![Drift::OrphanStateNoRecord {
+                dir: "ghost".to_string()
+            }]
+        );
+    }
+
+    #[test]
+    fn classify_skips_orphan_dir_with_live_owner() {
+        // A live, unregistered dir (e.g. the dev VM) is not an orphan.
+        let reg = VmNameRegistry::default();
+        let view = FakeView {
+            on_disk: ["mvm-dev".to_string()].into(),
+            live_dirs: ["mvm-dev".to_string()].into(),
+            ..Default::default()
+        };
+        assert!(classify(&reg, &view).is_empty());
+    }
+
+    #[test]
+    fn classify_treats_paused_record_as_live() {
+        // A paused record's process is dead by design — must never be
+        // reaped even though its state is present and process is absent.
+        let mut reg = registry_with(&[("vm1", "/s/vm1")]);
+        reg.set_paused("vm1", true).unwrap();
+        let view = FakeView {
+            present: ["/s/vm1".to_string()].into(),
+            ..Default::default()
+        };
+        assert_eq!(
+            classify(&reg, &view),
+            vec![Drift::Live {
+                name: "vm1".to_string()
+            }]
+        );
+    }
+
+    /// Mutable fake serving both [`RuntimeView`] and [`ReconcileActions`]
+    /// off one shared world, so a `tear_down` / `reap_orphan` is visible to
+    /// the next `classify` — the setup needed to assert idempotency.
+    #[derive(Default)]
+    struct FakeWorld {
+        present: RefCell<BTreeSet<String>>,
+        alive: RefCell<BTreeSet<String>>,
+        on_disk: RefCell<BTreeSet<String>>,
+        live_dirs: RefCell<BTreeSet<String>>,
+        torn_down: RefCell<Vec<String>>,
+        reaped: RefCell<Vec<String>>,
+        /// vm_dirs whose teardown should fail (drives the retry path).
+        fail_teardown: BTreeSet<String>,
+    }
+
+    impl RuntimeView for FakeWorld {
+        fn state_present(&self, reg: &VmRegistration) -> bool {
+            self.present.borrow().contains(&reg.vm_dir)
+        }
+        fn process_alive(&self, reg: &VmRegistration) -> bool {
+            self.alive.borrow().contains(&reg.vm_dir)
+        }
+        fn orphan_dirs(&self, known: &BTreeSet<String>) -> Vec<String> {
+            self.on_disk
+                .borrow()
+                .iter()
+                .filter(|d| !known.contains(d.as_str()))
+                .filter(|d| !self.live_dirs.borrow().contains(d.as_str()))
+                .cloned()
+                .collect()
+        }
+    }
+
+    impl ReconcileActions for FakeWorld {
+        fn tear_down(&self, _name: &str, reg: &VmRegistration) -> Result<(), String> {
+            if self.fail_teardown.contains(&reg.vm_dir) {
+                return Err("backend down".to_string());
+            }
+            self.present.borrow_mut().remove(&reg.vm_dir);
+            self.torn_down.borrow_mut().push(reg.vm_dir.clone());
+            Ok(())
+        }
+        fn reap_orphan(&self, dir: &str) -> Result<(), String> {
+            self.on_disk.borrow_mut().remove(dir);
+            self.reaped.borrow_mut().push(dir.to_string());
+            Ok(())
+        }
+    }
+
+    #[test]
+    fn sweep_tears_down_dead_process_record_and_deregisters() {
+        let mut reg = registry_with(&[("vm1", "/s/vm1")]);
+        let world = FakeWorld {
+            present: RefCell::new(["/s/vm1".to_string()].into()),
+            ..Default::default()
+        };
+        let report = sweep(&mut reg, &world, &world, &ConvergeOpts::default());
+        assert_eq!(report.dead_process_reaped, vec!["vm1".to_string()]);
+        assert_eq!(*world.torn_down.borrow(), vec!["/s/vm1".to_string()]);
+        assert!(reg.lookup("vm1").is_none(), "record must be deregistered");
+    }
+
+    #[test]
+    fn sweep_drops_stale_record_without_a_teardown_call() {
+        let mut reg = registry_with(&[("vm1", "/s/vm1")]);
+        let world = FakeWorld::default(); // nothing present on disk
+        let report = sweep(&mut reg, &world, &world, &ConvergeOpts::default());
+        assert_eq!(report.stale_record_dropped, vec!["vm1".to_string()]);
+        assert!(world.torn_down.borrow().is_empty());
+        assert!(reg.lookup("vm1").is_none());
+    }
+
+    #[test]
+    fn sweep_reaps_orphan_dir() {
+        let mut reg = VmNameRegistry::default();
+        let world = FakeWorld {
+            on_disk: RefCell::new(["ghost".to_string()].into()),
+            ..Default::default()
+        };
+        let report = sweep(&mut reg, &world, &world, &ConvergeOpts::default());
+        assert_eq!(report.orphan_state_reaped, vec!["ghost".to_string()]);
+        assert_eq!(*world.reaped.borrow(), vec!["ghost".to_string()]);
+    }
+
+    #[test]
+    fn sweep_dry_run_reports_but_mutates_nothing() {
+        let mut reg = registry_with(&[("dead", "/s/dead"), ("gone", "/s/gone")]);
+        let world = FakeWorld {
+            present: RefCell::new(["/s/dead".to_string()].into()),
+            on_disk: RefCell::new(["orphan".to_string()].into()),
+            ..Default::default()
+        };
+        let opts = ConvergeOpts { dry_run: true };
+        let report = sweep(&mut reg, &world, &world, &opts);
+        assert_eq!(report.dead_process_reaped, vec!["dead".to_string()]);
+        assert_eq!(report.stale_record_dropped, vec!["gone".to_string()]);
+        assert_eq!(report.orphan_state_reaped, vec!["orphan".to_string()]);
+        // Nothing actually happened.
+        assert!(world.torn_down.borrow().is_empty());
+        assert!(world.reaped.borrow().is_empty());
+        assert!(reg.lookup("dead").is_some());
+        assert!(reg.lookup("gone").is_some());
+    }
+
+    #[test]
+    fn sweep_run_twice_is_a_no_op() {
+        let mut reg = registry_with(&[("live", "/s/live"), ("dead", "/s/dead"), ("gone", "/s/gone")]);
+        let world = FakeWorld {
+            present: RefCell::new(["/s/live".to_string(), "/s/dead".to_string()].into()),
+            alive: RefCell::new(["/s/live".to_string()].into()),
+            on_disk: RefCell::new(["orphan".to_string()].into()),
+            ..Default::default()
+        };
+
+        let first = sweep(&mut reg, &world, &world, &ConvergeOpts::default());
+        assert_eq!(first.reconciled_count(), 3, "first pass heals all drift");
+
+        // Second pass over the converged world finds nothing to do.
+        let second = sweep(&mut reg, &world, &world, &ConvergeOpts::default());
+        assert!(second.is_clean(), "second pass must be a no-op: {second:?}");
+        assert_eq!(second.live, vec!["live".to_string()]);
+        assert!(second.dead_process_reaped.is_empty());
+        assert!(second.stale_record_dropped.is_empty());
+        assert!(second.orphan_state_reaped.is_empty());
+    }
+
+    #[test]
+    fn sweep_keeps_record_and_records_error_when_teardown_fails() {
+        let mut reg = registry_with(&[("vm1", "/s/vm1")]);
+        let world = FakeWorld {
+            present: RefCell::new(["/s/vm1".to_string()].into()),
+            fail_teardown: ["/s/vm1".to_string()].into(),
+            ..Default::default()
+        };
+        let report = sweep(&mut reg, &world, &world, &ConvergeOpts::default());
+        assert!(report.dead_process_reaped.is_empty());
+        assert_eq!(report.errors.len(), 1, "{report:?}");
+        assert!(report.errors[0].contains("backend down"));
+        // Fail-open + retry-next-pass: the record survives.
+        assert!(reg.lookup("vm1").is_some());
+    }
+
+    // -------- FsRuntimeView / FsReconcileActions (real filesystem) --------
+
+    #[test]
+    fn fs_view_marks_record_live_only_when_pid_is_alive() {
+        let tmp = tempfile::tempdir().unwrap();
+        let root = tmp.path();
+        // Our own pid is guaranteed alive; pid 2^31-1 is guaranteed dead.
+        let live_dir = make_state_dir(root, "live", Some(std::process::id() as i32));
+        let dead_dir = make_state_dir(root, "dead", Some(i32::MAX));
+
+        let view = FsRuntimeView::new(root);
+        let live = RegisterParams::minimal("live", &live_dir, "default");
+        let dead = RegisterParams::minimal("dead", &dead_dir, "default");
+        let mut reg = VmNameRegistry::default();
+        reg.register_with_metadata(live).unwrap();
+        reg.register_with_metadata(dead).unwrap();
+
+        assert!(view.state_present(reg.lookup("live").unwrap()));
+        assert!(view.process_alive(reg.lookup("live").unwrap()));
+        assert!(view.state_present(reg.lookup("dead").unwrap()));
+        assert!(!view.process_alive(reg.lookup("dead").unwrap()));
+    }
+
+    #[test]
+    fn fs_view_record_no_state_when_dir_absent() {
+        let tmp = tempfile::tempdir().unwrap();
+        let view = FsRuntimeView::new(tmp.path());
+        let reg = RegisterParams::minimal("ghost", "/nonexistent/ghost", "default");
+        let mut registry = VmNameRegistry::default();
+        registry.register_with_metadata(reg).unwrap();
+        assert!(!view.state_present(registry.lookup("ghost").unwrap()));
+    }
+
+    #[test]
+    fn fs_view_orphan_dirs_excludes_known_and_live() {
+        let tmp = tempfile::tempdir().unwrap();
+        let root = tmp.path();
+        make_state_dir(root, "registered", Some(i32::MAX));
+        make_state_dir(root, "orphan", Some(i32::MAX)); // dead pid
+        make_state_dir(root, "live-unregistered", Some(std::process::id() as i32));
+
+        let view = FsRuntimeView::new(root);
+        let known: BTreeSet<String> = ["registered".to_string()].into();
+        let orphans = view.orphan_dirs(&known);
+        assert_eq!(orphans, vec!["orphan".to_string()]);
+    }
+
+    #[test]
+    fn fs_actions_tear_down_removes_state_dir() {
+        let tmp = tempfile::tempdir().unwrap();
+        let root = tmp.path();
+        let dir = make_state_dir(root, "vm1", Some(i32::MAX));
+        let actions = FsReconcileActions::new(root);
+        let reg = RegisterParams::minimal("vm1", &dir, "default");
+        let mut registry = VmNameRegistry::default();
+        registry.register_with_metadata(reg).unwrap();
+        actions
+            .tear_down("vm1", registry.lookup("vm1").unwrap())
+            .unwrap();
+        assert!(!Path::new(&dir).exists());
+    }
+
+    #[test]
+    fn fs_actions_reap_orphan_removes_dir_under_root() {
+        let tmp = tempfile::tempdir().unwrap();
+        let root = tmp.path();
+        make_state_dir(root, "orphan", None);
+        let actions = FsReconcileActions::new(root);
+        actions.reap_orphan("orphan").unwrap();
+        assert!(!root.join("orphan").exists());
+    }
+
+    #[test]
+    fn fs_actions_tear_down_absent_dir_is_ok() {
+        let tmp = tempfile::tempdir().unwrap();
+        let actions = FsReconcileActions::new(tmp.path());
+        let reg = RegisterParams::minimal("gone", "/nonexistent/gone", "default");
+        let mut registry = VmNameRegistry::default();
+        registry.register_with_metadata(reg).unwrap();
+        // Idempotent: tearing down already-gone state is a clean no-op.
+        actions
+            .tear_down("gone", registry.lookup("gone").unwrap())
+            .unwrap();
+    }
+
+    // -------- converge (default-path entry + audit emission) --------
+
+    /// RAII env-var setter that restores the previous value on drop, so a
+    /// panicking assertion can't leak `MVM_*` overrides into sibling tests.
+    struct EnvGuard {
+        key: &'static str,
+        prev: Option<String>,
+    }
+    impl EnvGuard {
+        fn set(key: &'static str, val: &str) -> Self {
+            let prev = std::env::var(key).ok();
+            // SAFETY: tests under this block hold DATA_DIR_TEST_LOCK, so no
+            // other thread mutates these vars concurrently.
+            unsafe { std::env::set_var(key, val) };
+            Self { key, prev }
+        }
+    }
+    impl Drop for EnvGuard {
+        fn drop(&mut self) {
+            match &self.prev {
+                Some(v) => unsafe { std::env::set_var(self.key, v) },
+                None => unsafe { std::env::remove_var(self.key) },
+            }
+        }
+    }
+
+    #[test]
+    fn converge_default_heals_drift_and_emits_audit() {
+        let _lock = crate::vm::DATA_DIR_TEST_LOCK.lock().unwrap();
+        let tmp = tempfile::tempdir().unwrap();
+        let share = tmp.path().join("share");
+        let data = tmp.path().join("data");
+        let state = tmp.path().join("state");
+        std::fs::create_dir_all(data.join("vms")).unwrap();
+        let _g1 = EnvGuard::set("MVM_SHARE_DIR", share.to_str().unwrap());
+        let _g2 = EnvGuard::set("MVM_DATA_DIR", data.to_str().unwrap());
+        let _g3 = EnvGuard::set("MVM_STATE_DIR", state.to_str().unwrap());
+
+        // A dead-process record under the relocated vms root + its registry.
+        let vms_root = data.join("vms");
+        let dead_dir = make_state_dir(&vms_root, "dead", Some(i32::MAX));
+        let mut reg = VmNameRegistry::default();
+        reg.register_with_metadata(RegisterParams::minimal("dead", &dead_dir, "default"))
+            .unwrap();
+        reg.save(&crate::vm::name_registry::registry_path()).unwrap();
+
+        let report = converge(&ConvergeOpts::default());
+        assert_eq!(report.dead_process_reaped, vec!["dead".to_string()]);
+
+        // Record deregistered on disk.
+        let reloaded = VmNameRegistry::load(&crate::vm::name_registry::registry_path()).unwrap();
+        assert!(reloaded.lookup("dead").is_none());
+
+        // Audit line emitted to the local log (default path under state dir).
+        let audit = std::fs::read_to_string(state.join("log/audit.jsonl")).unwrap_or_default();
+        assert!(
+            audit.contains("registry_reconcile") && audit.contains("dead_process_left_state"),
+            "expected a registry_reconcile audit line, got: {audit}"
+        );
+    }
+
+    #[test]
+    fn converge_default_is_clean_with_empty_registry() {
+        let _lock = crate::vm::DATA_DIR_TEST_LOCK.lock().unwrap();
+        let tmp = tempfile::tempdir().unwrap();
+        let _g1 = EnvGuard::set("MVM_SHARE_DIR", tmp.path().join("share").to_str().unwrap());
+        let _g2 = EnvGuard::set("MVM_DATA_DIR", tmp.path().join("data").to_str().unwrap());
+        let _g3 = EnvGuard::set("MVM_STATE_DIR", tmp.path().join("state").to_str().unwrap());
+        // No registry file, no vms dir — fail-open, clean report, no panic.
+        let report = converge(&ConvergeOpts::default());
+        assert!(report.is_clean(), "{report:?}");
+    }
+
+    // -------- converge_at (registry load/save adapter) --------
+
+    #[test]
+    fn converge_at_heals_drift_and_persists_registry() {
+        let tmp = tempfile::tempdir().unwrap();
+        let vms_root = tmp.path().join("vms");
+        std::fs::create_dir_all(&vms_root).unwrap();
+        let registry_path = tmp.path().join("vm-names.json");
+
+        let live_dir = make_state_dir(&vms_root, "live", Some(std::process::id() as i32));
+        let dead_dir = make_state_dir(&vms_root, "dead", Some(i32::MAX));
+        make_state_dir(&vms_root, "orphan", Some(i32::MAX)); // dead, no record
+
+        let mut reg = VmNameRegistry::default();
+        reg.register_with_metadata(RegisterParams::minimal("live", &live_dir, "default"))
+            .unwrap();
+        reg.register_with_metadata(RegisterParams::minimal("dead", &dead_dir, "default"))
+            .unwrap();
+        reg.register_with_metadata(RegisterParams::minimal("gone", "/nonexistent/gone", "default"))
+            .unwrap();
+        reg.save(&registry_path).unwrap();
+
+        let report = converge_at(&registry_path, &vms_root, &ConvergeOpts::default());
+        assert_eq!(report.live, vec!["live".to_string()]);
+        assert_eq!(report.dead_process_reaped, vec!["dead".to_string()]);
+        assert_eq!(report.stale_record_dropped, vec!["gone".to_string()]);
+        assert_eq!(report.orphan_state_reaped, vec!["orphan".to_string()]);
+
+        // Persisted: only the live record remains; orphan + dead state gone.
+        let reloaded = VmNameRegistry::load(&registry_path).unwrap();
+        assert_eq!(reloaded.names(), vec!["live"]);
+        assert!(!Path::new(&dead_dir).exists());
+        assert!(!vms_root.join("orphan").exists());
+        assert!(Path::new(&live_dir).exists());
+
+        // Idempotent on disk: a second pass is clean and rewrites nothing.
+        let again = converge_at(&registry_path, &vms_root, &ConvergeOpts::default());
+        assert!(again.is_clean(), "second converge_at must be clean: {again:?}");
+    }
+
+    #[test]
+    fn converge_at_dry_run_leaves_registry_and_disk_untouched() {
+        let tmp = tempfile::tempdir().unwrap();
+        let vms_root = tmp.path().join("vms");
+        std::fs::create_dir_all(&vms_root).unwrap();
+        let registry_path = tmp.path().join("vm-names.json");
+        let dead_dir = make_state_dir(&vms_root, "dead", Some(i32::MAX));
+        let mut reg = VmNameRegistry::default();
+        reg.register_with_metadata(RegisterParams::minimal("dead", &dead_dir, "default"))
+            .unwrap();
+        reg.save(&registry_path).unwrap();
+
+        let report = converge_at(&registry_path, &vms_root, &ConvergeOpts { dry_run: true });
+        assert_eq!(report.dead_process_reaped, vec!["dead".to_string()]);
+        // Disk + registry untouched.
+        assert!(Path::new(&dead_dir).exists());
+        assert!(VmNameRegistry::load(&registry_path).unwrap().lookup("dead").is_some());
+    }
+
+    #[test]
+    fn converge_at_fails_open_on_unreadable_registry() {
+        let tmp = tempfile::tempdir().unwrap();
+        // A directory where a registry file is expected → read_to_string errors.
+        let registry_path = tmp.path().join("vm-names.json");
+        std::fs::create_dir_all(&registry_path).unwrap();
+        let report = converge_at(&registry_path, tmp.path(), &ConvergeOpts::default());
+        assert_eq!(report.errors.len(), 1, "{report:?}");
+        assert!(report.errors[0].contains("load registry"));
+        // Fail-open: no panic, returns a report.
+        assert!(report.live.is_empty());
+    }
+
+    #[test]
+    fn classify_is_deterministic_across_record_and_orphan_order() {
+        let reg = registry_with(&[("beta", "/s/beta"), ("alpha", "/s/alpha")]);
+        let view = FakeView {
+            present: ["/s/alpha".to_string(), "/s/beta".to_string()].into(),
+            alive: ["/s/alpha".to_string(), "/s/beta".to_string()].into(),
+            on_disk: ["zeta".to_string(), "gamma".to_string()].into(),
+            ..Default::default()
+        };
+        assert_eq!(
+            classify(&reg, &view),
+            vec![
+                Drift::Live {
+                    name: "alpha".to_string()
+                },
+                Drift::Live {
+                    name: "beta".to_string()
+                },
+                Drift::OrphanStateNoRecord {
+                    dir: "gamma".to_string()
+                },
+                Drift::OrphanStateNoRecord {
+                    dir: "zeta".to_string()
+                },
+            ]
+        );
+    }
+}

--- a/specs/adrs/074-registry-source-of-truth-convergence.md
+++ b/specs/adrs/074-registry-source-of-truth-convergence.md
@@ -2,13 +2,13 @@
 title: "ADR-074: VM name-registry is the source of truth; converge at CLI entry, not a resident daemon"
 status: Proposed
 date: 2026-06-07
-related: Plan 169 (host-lifecycle convergence + density); ADR-045 (hermetic VM-lifecycle testing); ADR-044 (audit_emit! macro); Plan 140 (snapshot/restore productionization); Plan 99 (Stage 0 reaper / cache prune)
+related: Plan 170 (host-lifecycle convergence + density); ADR-045 (hermetic VM-lifecycle testing); ADR-044 (audit_emit! macro); Plan 140 (snapshot/restore productionization); Plan 99 (Stage 0 reaper / cache prune)
 ---
 
 ## Status
 
-Proposed. Records the architectural posture behind Plan 169; no code lands
-with the ADR. Supersedes nothing — it formalizes a model the codebase already
+Proposed. Records the architectural posture behind Plan 170; WS-A code
+lands in PR #688. Supersedes nothing — it formalizes a model the codebase already
 half-implements (`VmNameRegistry` + `cache prune --reap-orphans` + the TTL
 `reaper`) and makes the resolution rule explicit.
 

--- a/specs/adrs/074-registry-source-of-truth-convergence.md
+++ b/specs/adrs/074-registry-source-of-truth-convergence.md
@@ -1,0 +1,94 @@
+---
+title: "ADR-074: VM name-registry is the source of truth; converge at CLI entry, not a resident daemon"
+status: Proposed
+date: 2026-06-07
+related: Plan 169 (host-lifecycle convergence + density); ADR-045 (hermetic VM-lifecycle testing); ADR-044 (audit_emit! macro); Plan 140 (snapshot/restore productionization); Plan 99 (Stage 0 reaper / cache prune)
+---
+
+## Status
+
+Proposed. Records the architectural posture behind Plan 169; no code lands
+with the ADR. Supersedes nothing — it formalizes a model the codebase already
+half-implements (`VmNameRegistry` + `cache prune --reap-orphans` + the TTL
+`reaper`) and makes the resolution rule explicit.
+
+## Context
+
+mvm's local runtime state lives in two places that can drift apart:
+
+1. The **persistent registry** — `VmNameRegistry` at
+   `{mvm_share_dir}/vm-names.json` (`crates/mvm/src/vm/name_registry.rs`):
+   what mvm *believes* is running.
+2. **On-disk runtime reality** — per-VM state dirs, `libkrun.pid`, vsock
+   sockets, TAP devices (`mvm-core/src/config.rs` helpers): what is *actually*
+   running.
+
+Today the two are reconciled only **manually** (`mvmctl cache prune
+--reap-orphans`) and **lazily** (drift is discovered when a command trips over
+it, then fails). Every recurring stale-state bug in the project's history —
+the libkrun.pid-vs-socket race, the Stage 0 stale-crate bail, the
+degraded-builder-store `dev up` loop, the stale-`pause`-against-a-vanished-VM
+error — is the same root cause: **no component owns making reality match the
+registry, proactively.**
+
+A sibling single-machine sandbox control plane resolves exactly this with a
+"converge persistent-store → runtime on every boot" pass, because it is a
+long-lived daemon. mvm's local path is **one-shot CLI invocations**, so a
+"reconcile on boot" goroutine has no boot to hook. Two questions, then:
+
+- **Which side wins on conflict?**
+- **When does convergence run, given there's no resident process?**
+
+## Decision
+
+**The registry is the source of truth; runtime reality is converged to it.**
+A record with a dead process means "tear the leftovers down and deregister,"
+not "adopt the orphan." Orphan state with no record is reaped. A record
+pointing at vanished state is dropped. Convergence is idempotent — running it
+twice is a no-op.
+
+**Convergence runs at CLI entry for state-touching commands, not in a resident
+daemon.** Any command that reads or mutates VM lifecycle (`up`, `start`,
+`run`, `console`, `down`, `status`, `dev *`, `pause`/`wake`) first runs a
+**cheap** convergence pass (registry read + PID-liveness stat only — never
+spawns a VM, never touches Nix). Read-only, VM-agnostic commands skip it. An
+explicit `mvmctl reconcile` verb exposes the same pass observably, and
+`MVM_SKIP_RECONCILE=1` is the documented escape hatch (never set in CI).
+
+The **resident** reaper loop (`mvm_hostd::supervisor::reaper`) stays where it
+is — spawned by mvmd's supervisor daemon and the MCP dispatcher — and consumes
+the *same* convergence + sweep library. There is exactly one convergence
+implementation; the difference between local and fleet is only *who ticks it*
+(CLI entry vs. daemon timer), never *what it does*.
+
+## Consequences
+
+- **A whole bug class becomes a non-event.** Stale records self-heal at the
+  next state-touching command instead of surfacing as a confusing failure
+  three layers down.
+- **Convergence must be cheap and pure-logic-first** (testable without a real
+  backend, mirroring the existing `reaper::sweep` shape) — otherwise it taxes
+  every CLI invocation. The PID-liveness-only budget is a hard constraint, not
+  a guideline.
+- **It must fail open, not closed.** A convergence error must warn and proceed
+  with the requested command, never block it — a bookkeeping sweep that bricks
+  `mvmctl down` would be worse than the drift it fixes.
+- **Observability:** convergence actions and idle/pressure lifecycle
+  transitions emit to the shared local audit log via `audit_emit!`
+  (consistent with ADR-044 / the Stage 0 audit contract), so density and
+  self-heal behavior are auditable and `audit verify` still chains.
+- **Boundary preserved:** this is host-side lifecycle bookkeeping only. It
+  never touches the guest trust boundary or any of claims 1–15.
+
+## Alternatives considered
+
+- **A resident local daemon that converges on a timer.** Rejected: mvm's local
+  UX is a stateless CLI; a background daemon is a new failure surface, a new
+  thing to install/supervise, and contradicts the one-shot model. mvmd already
+  *is* the resident process for fleet use.
+- **Runtime reality wins (adopt orphans into the registry).** Rejected: an
+  orphan process whose record is gone has lost its admission context
+  (`ExecutionPlan`, audit chain); adopting it would resurrect a workload
+  outside the signed-admission path. Reaping is the only safe direction.
+- **Keep reconciliation manual (`cache prune` only).** Rejected: that is the
+  status quo whose lazy-discovery failure mode this ADR exists to end.

--- a/specs/plans/140-snapshot-restore-productionization.md
+++ b/specs/plans/140-snapshot-restore-productionization.md
@@ -9,6 +9,9 @@ secrets/config disks + unique IP/ID on wake. But the restore path has four
 security-correctness gaps that make it **not production-ready** as written. This
 plan closes the mvm-side gaps. The warm-pool orchestration and wake-time
 admission *policy* live in mvmd — see `../mvmd/specs/plans/53-warm-pool-ms-restore.md`.
+The local single-host *idle-stop / wake / memory-pressure-evict* mechanism that
+*triggers* this sleep/wake machinery (vs. the snapshot correctness gaps below)
+lives in **Plan 169** (host-lifecycle convergence + density).
 
 Backend scope: Firecracker / cloud-hypervisor (`caps.snapshots == true`).
 libkrun + apple-container report `false` — no snapshot there, so the dev/libkrun

--- a/specs/plans/140-snapshot-restore-productionization.md
+++ b/specs/plans/140-snapshot-restore-productionization.md
@@ -11,7 +11,7 @@ plan closes the mvm-side gaps. The warm-pool orchestration and wake-time
 admission *policy* live in mvmd — see `../mvmd/specs/plans/53-warm-pool-ms-restore.md`.
 The local single-host *idle-stop / wake / memory-pressure-evict* mechanism that
 *triggers* this sleep/wake machinery (vs. the snapshot correctness gaps below)
-lives in **Plan 169** (host-lifecycle convergence + density).
+lives in **Plan 170** (host-lifecycle convergence + density).
 
 Backend scope: Firecracker / cloud-hypervisor (`caps.snapshots == true`).
 libkrun + apple-container report `false` — no snapshot there, so the dev/libkrun

--- a/specs/plans/169-host-lifecycle-convergence-and-density.md
+++ b/specs/plans/169-host-lifecycle-convergence-and-density.md
@@ -1,0 +1,192 @@
+# Plan 169 — Host-side lifecycle convergence + single-host density (reconcile / idle-reaper / wake)
+
+> **Status (2026-06-07):** Proposed. No code lands yet. Grounded in a
+> review of an external single-machine sandbox control plane — an
+> MIT-licensed Go service that pairs a container runtime, a reverse proxy,
+> and an embedded SQLite store to run agent workloads behind preview URLs.
+> It is a weaker *isolation* tier than mvm (hardened container isolation,
+> default-off auth, open egress — its own docs say as much), so none of its
+> security model transfers. What does transfer is its **host-daemon
+> lifecycle model**: three background tasks — a boot-time reconciler
+> ("converge the runtime back to the persistent store on every boot"), an
+> idle-timeout **and** host-memory-pressure reaper, and a wake-on-request
+> handler. The external project is **inspiration, not a dependency**; named
+> obliquely per repo policy (the private oblique-reference key lives in
+> auto-memory).
+>
+> **Numbering caveat:** 169 is next-after-highest in local `specs/plans/`
+> (168 tops out). The `check-spec-numbers` Lint gate hard-fails on a
+> duplicate integer prefix — re-confirm 169 is free against open PRs +
+> `main` before merge and renumber if taken. Companion: **ADR-074**
+> (registry-as-source-of-truth; converge at CLI entry, not a resident
+> daemon).
+
+## Context
+
+mvm already owns every *primitive* that lifecycle trio is built from — they are
+just fragmented across crates and never converged into one model, and two of
+the three only run inside mvmd's resident supervisor, never on the plain
+local `mvmctl` path:
+
+| Lifecycle task | mvm primitive that exists today | Gap |
+|---|---|---|
+| reconcile-on-boot | `VmNameRegistry` (`{mvm_share_dir}/vm-names.json`, `crates/mvm/src/vm/name_registry.rs`) + `cache prune --reap-orphans` (`crates/mvm-cli/src/commands/ops/cache.rs`) | Reconciliation is **manual** (`cache prune`) and **lazy** (drift surfaces at use-time, then fails). No automatic convergence pass. |
+| idle/pressure reaper | `mvm_hostd::supervisor::reaper::Reaper` (`crates/mvm-hostd/src/supervisor/reaper.rs`) | TTL-only — keys off `VmRegistration.expires_at` wall-clock. **No idle-activity trigger, no host-memory-pressure eviction.** Spawned only by mvmd's supervisor daemon + the MCP dispatcher (`ops/mcp.rs::spawn_reaper`), never on a bare `mvmctl` invocation. |
+| wake-on-request | `instance_wake()` (`crates/mvm/src/vm/instance/lifecycle.rs:555`) + `VmRegistration.auto_resume` ("connecting to a sleeping VM auto-resumes it") + `sleeping_count` quota (`vm/tenant/quota.rs`) | Wake exists; the **stop-on-idle *trigger* that creates a sleeping VM is missing** — sleep today is only explicit (`mvmctl pause`). No `last_active` timestamp to key idle off. |
+
+The standing pain this addresses is documented across auto-memory: the
+libkrun.pid-vs-socket race in the core_demo chain, the Stage 0 stale-crate
+bail, and the degraded-builder-store loop where `dev up` spins with no
+self-heal and only `rm -rf ~/.cache/mvm/builder-vm` recovers. Every one of
+those is **stale host-side state discovered lazily at use-time**. That model's
+answer — a single idempotent convergence pass that makes the persistent
+registry the source of truth and rebuilds runtime reality to match — is the
+direct structural fix, and the density lever (idle-stop + pressure-evict) is
+the same reaper extended. The user already runs parallel `mvmctl` sessions on
+one Mac (isolated via `MVM_CACHE_DIR`/`MVM_DATA_DIR`), so single-host density
+is a live concern, not a fleet abstraction.
+
+**mvm / mvmd boundary.** Fleet warm-pool orchestration and wake-time
+*admission policy* stay in mvmd (Plan 140 already draws this line;
+`../mvmd/specs/plans/53-warm-pool-ms-restore.md`). This plan delivers only the
+**local single-host mechanism** that lives in this repo: the registry, the
+reaper, the wake trigger, the convergence pass. mvmd consumes the same
+`mvm_hostd::supervisor::reaper` library it already does.
+
+**`mvmctl` is a CLI, not a resident daemon.** That control plane "converges on
+every boot" because it *is* a long-lived process. mvm's local path is one-shot CLI
+invocations. So "converge on boot" maps to **converge at CLI entry for any
+state-touching command** (`up` / `start` / `run` / `console` / `down` /
+`status` / `dev *`) plus an explicit `mvmctl reconcile` verb — not a new
+resident process. ADR-074 records this adaptation.
+
+## Workstreams
+
+### WS-A — Reconcile-on-entry convergence (the core fix)
+
+Make `VmNameRegistry` the source of truth and converge on-disk runtime reality
+to it, cheaply, at the start of every state-touching command.
+
+- [ ] Add `mvm::vm::reconcile::converge(registry, opts) -> ConvergeReport`, a
+      pure-logic-first sweep (testable without a real backend, mirroring
+      `reaper.rs`'s `sweep`): for each `VmRegistration`, classify as
+      `Live` / `DeadProcessLeftState` / `OrphanStateNoRecord` /
+      `RecordNoState`. Liveness check = the registry's runtime artifacts
+      (`vm_libkrun_pid()`, `vm_vsock_port_socket()` / `vm_vz_vsock_port_socket()`
+      from `mvm-core/src/config.rs`) cross-checked against the live PID — reuse
+      the existing live-vs-orphan discrimination in
+      `env::apple_container::reap_orphaned_vm_helpers` rather than reinventing it.
+- [ ] Convergence actions, all idempotent: dead-process records → tear down
+      leftover state + deregister; orphan state dirs with no record → reap
+      (the `cache prune --reap-orphans` logic, lifted into the shared sweep);
+      record pointing at vanished state → drop the stale record (today this
+      surfaces as the "stale `mvmctl pause` against a vanished VM" failure noted
+      in `instance_snapshot.rs:459`).
+- [ ] Wire a **cheap** `converge()` call into CLI entry for state-touching
+      commands behind `MVM_SKIP_RECONCILE=1` (escape hatch, never set in CI).
+      Cheap = registry read + PID liveness stat only; never spawns a VM, never
+      touches Nix. Read-only commands (`--help`, `model *`, `image ls`) skip it.
+- [ ] Add `mvmctl reconcile [--dry-run] [--json]` as the explicit, observable
+      entry point (sibling to `cache prune`). `--json` emits the
+      `ConvergeReport` for scripting; `doctor` gains a one-line "registry
+      drift: N records reconciled / clean" summary.
+- [ ] **Self-heal the degraded-builder-store loop.** `converge()` detects the
+      dangling-GC'd `…-source/flake.nix does not exist` builder state and, with
+      `--repair`, clears `~/.cache/mvm/builder-vm` rather than letting `dev up`
+      spin. Closes the recovery side noted against that failure family.
+
+### WS-B — Activity-driven idle reaper (stop-on-idle)
+
+Extend the TTL reaper from wall-clock-only to TTL **or** idle-timeout, and have
+idle expiry *sleep* (drain/pause) rather than tear down — so the workspace
+persists and WS-C's wake brings it back.
+
+- [ ] Add `last_active: Option<DateTime<Utc>>` to `VmRegistration` (`#[serde(default)]`,
+      backward-compatible — absent = treat as `registered_at`). Touched on every
+      console attach, vsock agent request, and successful `wake`.
+- [ ] Extend `reaper::sweep` with an `IdleSlept { name }` outcome alongside the
+      existing `Reaped`: when `now - last_active > idle_timeout` **and**
+      `auto_resume`, invoke a **sleep** callback (drain-on-sleep / `pause`,
+      the machinery already in `vm/instance/lifecycle.rs` + `instance_snapshot.rs`)
+      instead of teardown. TTL `expires_at` still hard-reaps as today. Keep the
+      ±10 s tick jitter (G6 timing-oracle defense already in `reaper.rs`).
+- [ ] Idle timeout config: `MVM_IDLE_TIMEOUT` env + per-VM tag override
+      (`VmRegistration.tags`), default off on the local path (opt-in), so a plain
+      `mvmctl start` is unchanged unless the user asks for density.
+- [ ] Backend awareness: snapshot-capable backends (FC / CH / Vz —
+      `caps.snapshots`) sleep via drain+snapshot; libkrun / apple-container
+      (no snapshot) sleep via clean stop with the data disk + TAP kept for a
+      cold wake (the disk/TAP retention path already exists —
+      `lifecycle.rs:454/523`). No new snapshot code; this is a *trigger*, not a
+      new sleep mechanism.
+
+### WS-C — Host-memory-pressure reaper (single-host density)
+
+Evict (sleep) the least-recently-active VMs when the host is under RAM
+pressure, so "dozens share one box" works on the user's Mac without manual
+babysitting.
+
+- [ ] Add a pressure-driven sweep to the reaper: read host memory via `sysinfo`
+      (already a dep — `balloon_runtime.rs` uses it), and when free RAM drops
+      below `MVM_HOST_MEM_LOW_WATERMARK`, sleep VMs in `last_active`-ascending
+      order until back above the high watermark. LRU eviction, never kill —
+      sleep + persist, same path as WS-B.
+- [ ] **Reconcile against the existing balloon lever before evicting.** mvm
+      already reclaims guest memory via `BalloonController` / `run_balloon_loop`
+      (`balloon_runtime.rs`). Order of escalation: balloon-reclaim first (cheap,
+      transparent), sleep-evict only when ballooning is exhausted. Document the
+      two-stage policy so they don't fight.
+- [ ] This is the mvm-side mechanism only; mvmd's fleet scheduler may layer its
+      own cross-host policy on top via the same `reaper` library. Note the seam,
+      don't build the fleet side here.
+
+### WS-D — Wake-on-request completion
+
+Close the loop so a slept VM (WS-B/C) comes back on first contact.
+
+- [ ] Audit every guest-contact entry point (`mvmctl console`, vsock agent
+      dispatch, `forward`) to honor `auto_resume`: if the target is slept,
+      `instance_wake()` it, refresh `last_active`, then proceed. `instance_wake`
+      already does fresh secrets/config disks + clock/entropy concerns (Plan 140
+      gaps) — depend on, don't duplicate.
+- [ ] Emit the lifecycle transitions (`vm.slept_idle`, `vm.slept_pressure`,
+      `vm.woke`) to the shared local audit log via `audit_emit!`, consistent
+      with the Stage 0 audit-emit contract — so density behavior is observable
+      and `audit verify` still chains.
+
+## Verification
+
+- [ ] `converge()` unit tests over a synthetic registry: each classification
+      (`Live`/`DeadProcessLeftState`/`OrphanStateNoRecord`/`RecordNoState`) →
+      correct idempotent action; running twice is a no-op (convergence is stable).
+- [ ] Reaper unit tests extended: idle → `IdleSlept` (not `Reaped`); TTL still
+      hard-reaps; pressure sweep evicts LRU-first and stops at the high watermark;
+      `auto_resume=false` is never auto-slept.
+- [ ] Integration (macOS/Vz + libkrun, on this host per auto-memory): start two
+      workloads, force one idle past `MVM_IDLE_TIMEOUT`, assert it sleeps and the
+      other survives; `mvmctl console` the slept one and assert wake; kill a VM's
+      supervisor PID out-of-band and assert the next `mvmctl status` converges the
+      stale record instead of erroring.
+- [ ] `cargo fmt --all -- --check` (nightly per CI), `cargo nextest run
+      --workspace -E 'not package(mvm-backend)'` locally (mvm-backend SIGKILL on
+      macOS codesign — auto-memory), full suite on Linux CI, `cargo clippy
+      --workspace -- -D warnings`, doctests.
+
+## Non-goals
+
+- No fleet/cross-host scheduling — mvmd (Plan 140 / mvmd Plan 53).
+- No new snapshot/restore mechanism — WS-B/C are *triggers* over the existing
+  pause/drain/wake machinery; the four FC restore-correctness gaps stay Plan 140.
+- No resident local daemon. Convergence is a CLI-entry pass (ADR-074). The
+  resident reaper loop remains mvmd's supervisor / the MCP dispatcher.
+- No change to the isolation posture or any of claims 1–15. This is host-side
+  lifecycle bookkeeping; it never touches the guest trust boundary.
+
+## Deferred follow-ups
+
+- [ ] `last_active` could be sharpened from coarse touch-points to real guest
+      activity (vsock byte counters via the Plan 141 packet-observer) — deferred;
+      coarse touch is enough for stop-on-idle v1.
+- [ ] A `warming page` analog for HTTP-preview workloads (the external control
+      plane serves one during cold wake) only matters once mvm grows preview-URL routing — that is
+      mvmd product surface, tracked there, not here.

--- a/specs/plans/170-host-lifecycle-convergence-and-density.md
+++ b/specs/plans/170-host-lifecycle-convergence-and-density.md
@@ -1,6 +1,7 @@
-# Plan 169 — Host-side lifecycle convergence + single-host density (reconcile / idle-reaper / wake)
+# Plan 170 — Host-side lifecycle convergence + single-host density (reconcile / idle-reaper / wake)
 
-> **Status (2026-06-07):** Proposed. No code lands yet. Grounded in a
+> **Status (2026-06-07):** WS-A **implemented** (PR #688); WS-B/C/D
+> Proposed. Grounded in a
 > review of an external single-machine sandbox control plane — an
 > MIT-licensed Go service that pairs a container runtime, a reverse proxy,
 > and an embedded SQLite store to run agent workloads behind preview URLs.
@@ -14,12 +15,12 @@
 > obliquely per repo policy (the private oblique-reference key lives in
 > auto-memory).
 >
-> **Numbering caveat:** 169 is next-after-highest in local `specs/plans/`
-> (168 tops out). The `check-spec-numbers` Lint gate hard-fails on a
-> duplicate integer prefix — re-confirm 169 is free against open PRs +
-> `main` before merge and renumber if taken. Companion: **ADR-074**
-> (registry-as-source-of-truth; converge at CLI entry, not a resident
-> daemon).
+> **Numbering:** renumbered 169 → 170. 169 was claimed by the
+> agent-RPC backend-agnostic-transport plan that merged to `main` first,
+> which would trip the `check-spec-numbers` Lint gate (it hard-fails on a
+> duplicate integer prefix); 170 is the next free number. Companion:
+> **ADR-074** (registry-as-source-of-truth; converge at CLI entry, not a
+> resident daemon).
 
 ## Context
 
@@ -62,38 +63,46 @@ resident process. ADR-074 records this adaptation.
 
 ## Workstreams
 
-### WS-A — Reconcile-on-entry convergence (the core fix)
+### WS-A — Reconcile-on-entry convergence (the core fix) — **DONE (PR #688)**
 
 Make `VmNameRegistry` the source of truth and converge on-disk runtime reality
 to it, cheaply, at the start of every state-touching command.
 
-- [ ] Add `mvm::vm::reconcile::converge(registry, opts) -> ConvergeReport`, a
-      pure-logic-first sweep (testable without a real backend, mirroring
-      `reaper.rs`'s `sweep`): for each `VmRegistration`, classify as
-      `Live` / `DeadProcessLeftState` / `OrphanStateNoRecord` /
-      `RecordNoState`. Liveness check = the registry's runtime artifacts
-      (`vm_libkrun_pid()`, `vm_vsock_port_socket()` / `vm_vz_vsock_port_socket()`
-      from `mvm-core/src/config.rs`) cross-checked against the live PID — reuse
-      the existing live-vs-orphan discrimination in
-      `env::apple_container::reap_orphaned_vm_helpers` rather than reinventing it.
-- [ ] Convergence actions, all idempotent: dead-process records → tear down
-      leftover state + deregister; orphan state dirs with no record → reap
-      (the `cache prune --reap-orphans` logic, lifted into the shared sweep);
-      record pointing at vanished state → drop the stale record (today this
-      surfaces as the "stale `mvmctl pause` against a vanished VM" failure noted
-      in `instance_snapshot.rs:459`).
-- [ ] Wire a **cheap** `converge()` call into CLI entry for state-touching
+- [x] Add `mvm::vm::reconcile` — pure-logic-first `classify`/`sweep`
+      (testable without a real backend, mirroring `reaper.rs`'s `sweep`): for
+      each `VmRegistration`, classify as `Live` / `DeadProcessLeftState` /
+      `RecordNoState`, plus `OrphanStateNoRecord` for unrecorded state dirs.
+      Liveness = `kill(pid, 0)` on the recorded supervisor pid files
+      (`libkrun.pid` / `vz.pid` / `pid`) — the cheap half of the live-vs-orphan
+      discrimination from `env::apple_container::reap_orphaned_vm_helpers`,
+      restated as a bare syscall because the lower `mvm` crate can't depend on
+      `mvm-cli`. Intentionally-paused records are skipped.
+- [x] Convergence actions, all idempotent: dead-process records → tear down
+      leftover state + deregister; orphan state dirs with no record → reap;
+      record pointing at vanished state → drop the stale record (the "stale
+      `mvmctl pause` against a vanished VM" failure family). `converge()` fails
+      open and emits a `RegistryReconcile` audit line per healed item.
+      `FsRuntimeView`/`FsReconcileActions` are the real adapter; `converge_at`
+      is the path-injectable load/save seam.
+- [x] Wire a **cheap** `converge()` call into CLI entry for state-touching
       commands behind `MVM_SKIP_RECONCILE=1` (escape hatch, never set in CI).
       Cheap = registry read + PID liveness stat only; never spawns a VM, never
-      touches Nix. Read-only commands (`--help`, `model *`, `image ls`) skip it.
-- [ ] Add `mvmctl reconcile [--dry-run] [--json]` as the explicit, observable
+      touches Nix. Gated by `Commands::touches_vm_state()`
+      (up/down/run/console/dev/pause/resume/snapshot/ls); read-only / VM-agnostic
+      commands skip it; `reconcile` itself never double-runs.
+- [x] Add `mvmctl reconcile [--dry-run] [--json]` as the explicit, observable
       entry point (sibling to `cache prune`). `--json` emits the
-      `ConvergeReport` for scripting; `doctor` gains a one-line "registry
-      drift: N records reconciled / clean" summary.
+      `ConvergeReport` for scripting; `doctor` gained a one-line "registry
+      drift: N reconciled / clean" summary.
+
+### deferred follow-ups (WS-A)
+
 - [ ] **Self-heal the degraded-builder-store loop.** `converge()` detects the
       dangling-GC'd `…-source/flake.nix does not exist` builder state and, with
       `--repair`, clears `~/.cache/mvm/builder-vm` rather than letting `dev up`
-      spin. Closes the recovery side noted against that failure family.
+      spin. Closes the recovery side noted against that failure family. Deferred
+      from PR #688 — the builder-store probe is heavier than the PID-liveness
+      budget and wants its own slice.
 
 ### WS-B — Activity-driven idle reaper (stop-on-idle)
 

--- a/tests/audit_total_coverage.rs
+++ b/tests/audit_total_coverage.rs
@@ -319,7 +319,7 @@ const AUDIT_POSTURE: &[(&str, AuditPosture)] = &[
     ("audit", AuditPosture::ReadOnly),
     ("network", AuditPosture::DelegatesToSub(NETWORK_SUB)),
     ("cache", AuditPosture::DelegatesToSub(CACHE_SUB)),
-    // Plan 169 WS-A — reconcile-on-entry convergence. The non-dry-run
+    // Plan 170 WS-A — reconcile-on-entry convergence. The non-dry-run
     // path emits one `RegistryReconcile` per healed drift item.
     ("reconcile", AuditPosture::Emits("RegistryReconcile")),
     ("mcp", AuditPosture::InteractiveOrControl),

--- a/tests/audit_total_coverage.rs
+++ b/tests/audit_total_coverage.rs
@@ -319,6 +319,9 @@ const AUDIT_POSTURE: &[(&str, AuditPosture)] = &[
     ("audit", AuditPosture::ReadOnly),
     ("network", AuditPosture::DelegatesToSub(NETWORK_SUB)),
     ("cache", AuditPosture::DelegatesToSub(CACHE_SUB)),
+    // Plan 169 WS-A — reconcile-on-entry convergence. The non-dry-run
+    // path emits one `RegistryReconcile` per healed drift item.
+    ("reconcile", AuditPosture::Emits("RegistryReconcile")),
     ("mcp", AuditPosture::InteractiveOrControl),
     ("secret", AuditPosture::DelegatesToSub(SECRET_SUB)),
     ("attest", AuditPosture::DelegatesToSub(ATTEST_SUB)),
@@ -491,6 +494,7 @@ fn audit_posture_emits_entries_reference_known_audit_kinds() {
         "ManifestTagRemove",
         "NetworkCreate",
         "NetworkRemove",
+        "RegistryReconcile",
         "SecretGet",
         "SecretPut",
         "SecretRm",


### PR DESCRIPTION
Plan 170 (host-lifecycle convergence + density) — the plan/ADR docs **and** Workstream A code, in one PR. Folds in #679 (docs-only), which can now be closed in favor of this.

> **Numbering:** the docs originally landed as Plan 169 in #679, but 169 was claimed by the agent-RPC transport plan that merged to `main` first (`check-spec-numbers` hard-fails on duplicate prefixes). Renumbered the host-lifecycle plan to **170**; ADR-074 is unique and unchanged.

## Docs (cherry-picked from #679, renumbered)

- `specs/plans/170-host-lifecycle-convergence-and-density.md` — WS-A marked done, `--repair` moved to a deferred-followups subsection.
- `specs/adrs/074-registry-source-of-truth-convergence.md` — registry is source of truth; converge at CLI entry, not a resident daemon; fail-open.
- One-line pointer in `specs/plans/140` distinguishing the trigger (170) from the snapshot-correctness gaps (140).

## Code — Workstream A (ADR-074)

- **`mvm::vm::reconcile`** — pure-logic-first convergence, mirroring `reaper::sweep`:
  - `classify()` tags each `VmRegistration` as `Live` / `DeadProcessLeftState` / `RecordNoState`, plus `OrphanStateNoRecord` for unrecorded state dirs. Intentionally-paused records are skipped.
  - `sweep()` applies idempotent actions via injected `RuntimeView`/`ReconcileActions` (no real backend/clock/fs). **Running twice is a no-op** (asserted).
  - `FsRuntimeView`/`FsReconcileActions` are the real adapter; liveness is `kill(pid,0)` on recorded supervisor pid files only — **cheap by construction** (no `pgrep`/`ps` spawn, no VM boot, no Nix), reusing the live-vs-orphan discrimination from the `env::apple_container` reaper.
  - `converge_at()` is the path-injectable load/save seam; `converge()` wraps the default registry, **fails open** (never returns `Err`), and emits a `RegistryReconcile` audit line per healed item (ADR-044), so `audit verify` still chains.
- **`mvmctl reconcile [--dry-run] [--json]`** — explicit, observable pass (sibling to `cache prune`).
- **Reconcile-on-entry wiring** — `Commands::touches_vm_state()` gates a cheap `converge()` before dispatch for `up`/`down`/`run`/`console`/`dev`/`pause`/`resume`/`snapshot`/`ls`; read-only/VM-agnostic verbs skip it; `reconcile` never double-runs. Opt out with `MVM_SKIP_RECONCILE=1`.
- **`mvmctl doctor`** — one-line `registry drift: N reconciled / clean` summary.

## Deferred (tracked in the plan's deferred-followups)

- `mvmctl reconcile --repair` builder-store self-heal (the degraded `…-source/flake.nix` loop) — heavier than the PID-liveness budget; its own slice.
- WS-B (idle reaper), WS-C (memory-pressure reaper), WS-D (wake-on-request completion).

## Tests / gates

TDD throughout. 31 reconcile unit tests (classify / sweep / idempotency / fail-open / Fs adapter / converge_at / converge end-to-end incl. audit), `reconcile_cli.rs`, `touches_vm_state` gate tests, doctor drift-summary test, audit-kind serde roundtrip, audit-posture coverage table.

Green locally: `check-spec-numbers`, `cargo fmt --all -- --check` (nightly), `cargo clippy -- -D warnings`, lib tests + doctests for `mvm`/`mvm-core`/`mvm-cli`, `reconcile_cli`, `audit_total_coverage`, and `audit_emissions_live` (exercises the entry hook on real `up`/`pause`). `mvm-backend` excluded locally (macOS codesign SIGKILL — environmental).