### PR TITLE
docs: scrub remaining banned-list competitor names (Modal, Kata, Vercel)

### DIFF
--- a/specs/adrs/007-function-call-entrypoints.md
+++ b/specs/adrs/007-function-call-entrypoints.md
@@ -10,7 +10,7 @@ related: ADR-002 (microVM security posture); ADR-005 (sealed signed builder imag
 ## Status
 
 Proposed. Lays the substrate for `mvmforge`'s function-call SDKs
-(decorationer ADR-0009, plan 0003) to wire a Modal-style
+(decorationer ADR-0009, plan 0003) to wire a remote-function
 `f.remote(...)` call surface onto mvm. Adopting this ADR commits mvm
 to shipping a constrained `RunEntrypoint` verb in production guest
 agents — alongside, not instead of, the dev-only `do_exec` (W4.3).
@@ -26,7 +26,7 @@ unsafe in production by construction — but it leaves no path for
 production workloads that want call-and-return semantics: send args,
 run a baked program, get output.
 
-`mvmforge` (decorationer) wants to add Modal-style function calls:
+`mvmforge` (decorationer) wants to add remote-function function calls:
 decorate a Python or TS function, call it from the host, body runs
 inside the microVM, return value flows back. The user's hard rule
 (captured in CLAUDE.md memory) is that **everything is written at
@@ -179,7 +179,7 @@ Concretely:
 Benefits:
 
 - A clean, prod-safe path for function-call workloads. mvmforge
-  builds Modal-class ergonomics on this; mvm stays language-agnostic.
+  builds remote-function ergonomics on this; mvm stays language-agnostic.
 - Mental hygiene: `mvmctl exec` (dev, arbitrary shell) and
   `mvmctl invoke` (prod, baked entrypoint) are visibly different
   surfaces with different CI gates and different security postures.

--- a/specs/backlog/13-boot-time-optimization.md
+++ b/specs/backlog/13-boot-time-optimization.md
@@ -289,6 +289,6 @@ architectural change worth considering after phases 1-5 are validated.
 - [microvm.nix optimization.nix](https://github.com/microvm-nix/microvm.nix/blob/main/nixos-modules/microvm/optimization.nix) — how microvm.nix optimizes Firecracker boot
 - [Firecracker CI kernel configs](https://github.com/firecracker-microvm/firecracker/tree/main/resources/guest_configs)
 - [Minimizing Linux boot times](https://blog.davidv.dev/posts/minimizing-linux-boot-times/) — 5.94ms kernel-to-userspace with custom init
-- [Kata containers boot fix](https://github.com/kata-containers/runtime/issues/1622) — masking udevd for fast boot
+- Masking udevd for fast boot (technique documented in an external containers-in-VMs runtime's issue tracker)
 - [firecracker-containerd #410](https://github.com/firecracker-microvm/firecracker-containerd/issues/410) — random seed + entropy wait
 - [NixOS: boot without initrd](https://discourse.nixos.org/t/how-to-boot-without-initrd/60082)

--- a/specs/gap-analysis-vs-libkrun.md
+++ b/specs/gap-analysis-vs-libkrun.md
@@ -86,7 +86,7 @@ Ranked by strategic weight, not effort:
 
 ### G1. No Python / TypeScript / Rust SDK shipped yet — biggest adoption gap
 
-libkrun is fundamentally **SDK-shaped**: the install path is `pip install libkrun` or `npm install libkrun`, and three lines of code give you a running VM. mvm is **CLI-shaped**: you `mvmctl up --manifest ./mvm.toml --detach` and then shell out for everything else. The agent-framework audience (LangChain, LlamaIndex, Mastra, Vercel AI SDK) lives in Python and TypeScript and will not adopt a CLI-only tool.
+libkrun is fundamentally **SDK-shaped**: the install path is `pip install libkrun` or `npm install libkrun`, and three lines of code give you a running VM. mvm is **CLI-shaped**: you `mvmctl up --manifest ./mvm.toml --detach` and then shell out for everything else. The agent-framework audience (LangChain, LlamaIndex, Mastra) lives in Python and TypeScript and will not adopt a CLI-only tool.
 
 The good news: the design is already written. Plan 60 Phase 5 specs the full surface (`Sandbox.builder(...)`, `.commands.run(...)`, `.commands.run(..., background=True)`, etc.) and the previous iteration's `mvm-sdk` exists at `../mvmforge/crates/mvmforge-sdk/` ready to port. The bad news: it isn't in this repo's `crates/` and Phase 5 hasn't been started.
 

--- a/specs/plans/15-wasm-container-support.md
+++ b/specs/plans/15-wasm-container-support.md
@@ -14,7 +14,7 @@ mvm currently builds Firecracker microVM images exclusively — NixOS system clo
 
 **Lessons from related projects:**
 - **[libkrun](https://github.com/zerocore-ai/libkrun):** Uses libkrun microVMs (not FC). Key pattern: Rust-native OCI handling via `oci-spec` crate for pulling/pushing images. Their `Rootfs` enum (`Native(PathBuf)` vs `Overlayfs(Vec<PathBuf>)`) is a clean model for our artifact type discrimination. Their `Sandboxfile` YAML config cleanly separates sandbox definitions from build definitions.
-- **[kata-containers](https://github.com/kata-containers/kata-containers):** Containers-in-VMs only (containerd shim). No WASM support — the WASM ecosystem uses separate projects: [runwasi](https://github.com/containerd/runwasi) (containerd WASM shim) and [containerd-wasm-shims](https://github.com/deislabs/containerd-wasm-shims).
+- **An external containers-in-VMs runtime (containerd shim):** Containers-in-VMs only. No WASM support — the WASM ecosystem uses separate projects: [runwasi](https://github.com/containerd/runwasi) (containerd WASM shim) and [containerd-wasm-shims](https://github.com/deislabs/containerd-wasm-shims).
 - **OCI format distinction:** WASM containers should use [OCI artifact media types](https://www.cncf.io/blog/2024/03/12/webassembly-on-kubernetes-from-containers-to-wasm-part-01/) (`application/vnd.wasm.content.layer.v1+wasm`) rather than wrapping `.wasm` in a traditional Docker image with rootfs layers. This is what runwasi/SpinKube expect.
 
 ---

--- a/specs/plans/20-multi-backend-abstraction.md
+++ b/specs/plans/20-multi-backend-abstraction.md
@@ -427,15 +427,15 @@ No new `oci.rs` module needed for Apple Containers — the same ext4 rootfs work
 - **Lima still needed on macOS** — for Nix builds (not in runtime hot path)
 - **Docker on Windows**: guest agent needs unix socket, not vsock (different IPC path)
 - **Memory overhead**: Apple Containers don't return freed pages to host
-- **Kernel compatibility**: Apple Container uses its own kernel (Kata Containers Linux 6.x with vminitd as PID 1); Nix rootfs is designed for Firecracker's kernel. See mitigation below.
+- **Kernel compatibility**: Apple Container uses its own kernel (a container-optimized Linux 6.x from an external containers-in-VMs project, with vminitd as PID 1); Nix rootfs is designed for Firecracker's kernel. See mitigation below.
 
 ## Kernel Compatibility Risk Mitigation
 
-**The problem**: Apple Containers use their own optimized Linux kernel (from Kata Containers project) with `vminitd` (Swift) as PID 1. Our Nix rootfs is designed for Firecracker's minimal kernel with mvm's guest agent as init. Key differences:
+**The problem**: Apple Containers use their own optimized Linux kernel (from an external containers-in-VMs project) with `vminitd` (Swift) as PID 1. Our Nix rootfs is designed for Firecracker's minimal kernel with mvm's guest agent as init. Key differences:
 
 | Concern | Firecracker | Apple Container |
 |---------|------------|-----------------|
-| Kernel | Custom minimal (from Nix) | Kata Containers 6.x (from Apple) |
+| Kernel | Custom minimal (from Nix) | Container-optimized 6.x (from Apple) |
 | PID 1 | mvm guest agent | vminitd (Swift, fixed) |
 | Block devices | `/dev/vda` (virtio-blk) | Likely `/dev/vda` (VZ block) |
 | Network | `eth0` (virtio-net via TAP) | `eth0` or `enp0s*` (VZ net) |

--- a/specs/plans/41-function-call-entrypoints.md
+++ b/specs/plans/41-function-call-entrypoints.md
@@ -1,6 +1,6 @@
 # Plan 41 — function-call entrypoints (mvm side)
 
-> Substrate work for Modal-style `f.remote(...)` semantics. mvmforge
+> Substrate work for remote-function `f.remote(...)` semantics. mvmforge
 > ships the language SDKs and Nix factories (decorationer plan 0003);
 > this plan covers the mvm pieces: a constrained `RunEntrypoint`
 > vsock verb, the `mvmctl invoke` CLI, snapshot integrity, and a flip

--- a/specs/plans/60-mvm-libkrun-migration.md
+++ b/specs/plans/60-mvm-libkrun-migration.md
@@ -45,7 +45,7 @@ The current hand-written skeleton (`mvm-backend::Backend<Sb,Ctx>`, `mvm-builder:
                   │                                       │
                   ▼                                       ▼
    ┌──────────────────────────┐         ┌──────────────────────────┐
-   │  Modal-style decorators   │         │      mvm CLI (mvmctl)    │
+   │  remote-fn decorators    │         │      mvm CLI (mvmctl)    │
    │  + sandbox-runtime API    │         │  init, build, up, exec,  │
    │       (mvm-sdk)           │         │  install, session, …     │
    └──────────────────────────┘         └──────────────────────────┘
@@ -567,13 +567,13 @@ These live in `mvm-supervisor/src/tools/`. The MCP server (Phase 7) exposes the 
 
 ## SDK DX design — Rust + Python + TypeScript, three first-class SDKs
 
-Three SDKs, all first-class, all targeting **libkrun-style runtime + sandbox-runtime API surface** + **Modal-style decorators**. Common Rust core protocol; language-specific surface idiomatic to each ecosystem.
+Three SDKs, all first-class, all targeting **libkrun-style runtime + sandbox-runtime API surface** + **remote-function decorators**. Common Rust core protocol; language-specific surface idiomatic to each ecosystem.
 
 ### Architecture
 ```
                 ┌──────────────────────────────────────┐
                 │        Python SDK (PyPI: mvm)         │
-                │  sandbox runtime + Modal decorators   │
+                │  sandbox runtime + remote-fn decs.    │
                 └──────────────────────────────────────┘
                 ┌──────────────────────────────────────┐
                 │      TypeScript SDK (npm: @mvm/sdk)   │
@@ -887,15 +887,15 @@ Every method present on one is present on the others with semantically-identical
 
 ---
 
-### Style 2 — Declarative SDK (Modal-style decorators)
+### Style 2 — Declarative SDK (remote-function decorators)
 
-#### Python — full Modal-shaped DX
+#### Python — full remote-function-shaped DX
 ```python
 import mvm
 
 app = mvm.App("my-project")
 
-# Image composition (mirrors Modal's Image.debian_slim().pip_install)
+# Image composition (mirrors the reference platform's `Image.debian_slim().pip_install`)
 image = (
     mvm.Image.from_template("worker")
         .add_addon("python")
@@ -923,7 +923,7 @@ def charge(amount: int) -> str:
     r = requests.post("https://api.stripe.com/...", auth=(key, ""))
     return r.json()["id"]
 
-# Class with state — equivalent to Modal's @app.cls
+# Class with state — equivalent to the reference platform's `@app.cls`
 @app.cls(image=image, gpu=None)
 class Worker:
     @mvm.enter()
@@ -1034,12 +1034,12 @@ struct StripeKey;
 async fn charge(amount: u64) -> Result<ChargeId> { /* ... */ }
 ```
 
-### `.local()` vs `.remote()` — Modal's signature trick
+### `.local()` vs `.remote()` — the reference platform's signature trick
 A function decorated with `@app.function` is callable two ways:
 - `f.local(args)` — runs in the calling process (for testing)
 - `f.remote(args)` — packages args, ships them over the wire to a microVM, returns the result
 
-This is the *single* most-loved Modal DX feature. We replicate it in all three SDKs. The wire protocol is the same JSON-RPC `Sandbox.run_function` call underneath.
+This is the *single* most-loved feature of that platform's DX. We replicate it in all three SDKs. The wire protocol is the same JSON-RPC `Sandbox.run_function` call underneath.
 
 ### Tree-sitter analyzability for decorated forms
 The `mvm-tree-sitter` crate (Phase 5) ships grammars for *all three* declarative surfaces (Rust attribute macros, Python `@decorators`, TypeScript decorators). The future AI safety scanner walks any of them.
@@ -1050,13 +1050,13 @@ The `mvm-tree-sitter` crate (Phase 5) ships grammars for *all three* declarative
 - **Phase 9**: All three SDKs go beta with full surface parity tests in `tests/sdk_compat/`
 
 ### ADR
-- ADR-017 (already in catalog) extended: "Modal-style decorators + sandbox-runtime DX, **across Rust + Python + TypeScript**, with shared wire protocol and CI-enforced parity tests."
+- ADR-017 (already in catalog) extended: "Remote-function decorators + sandbox-runtime DX, **across Rust + Python + TypeScript**, with shared wire protocol and CI-enforced parity tests."
 
 ---
 
-## (Legacy) SDK DX design — Modal-style decorators + sandbox-runtime API surface
+## (Legacy) SDK DX design — remote-function decorators + sandbox-runtime API surface
 
-### Definition-time DX (Modal-like, decorator-driven, tree-sitter-friendly)
+### Definition-time DX (remote-function-style, decorator-driven, tree-sitter-friendly)
 
 Users describe their microVM declaratively with attribute macros that expand to data, not behavior. Trivially analyzable by tree-sitter (stable spans, named children) so the future AI safety scanner can audit configurations without running them.
 
@@ -1443,7 +1443,7 @@ Every architecturally-significant decision in this plan **must** be reflected in
 | 019 | Audit-everything coverage matrix | Phase 4 | NEW |
 | 020 | PII redaction tokenization scheme | Phase 6 | NEW |
 | 021 | Addons composability model | Phase 5 + 7b | NEW |
-| 022 | Modal-style decorators + sandbox-runtime DX (multi-language: Rust + Python + TypeScript) | Phase 5 + 7b + 9 | NEW |
+| 022 | Remote-function decorators + sandbox-runtime DX (multi-language: Rust + Python + TypeScript) | Phase 5 + 7b + 9 | NEW |
 | 023 | Long-running session model (tmux-backed) | Phase 7 | NEW |
 | 024 | Computer-use RPC surface | Phase 7b | NEW |
 | 025 | Transparent install/rebuild flow | Phase 7a | NEW |

--- a/specs/plans/81-function-entrypoints-design.md
+++ b/specs/plans/81-function-entrypoints-design.md
@@ -5,7 +5,7 @@
 You asked whether mvm supports "entrypoints" — booting a microVM,
 running something, getting output back. Shell case exists today
 (`mvmctl exec`). The new ask is **language-function entrypoints** in
-the Modal style: decorate a function, call it on the host, body runs
+the remote-function style: decorate a function, call it on the host, body runs
 in a microVM, return value flows back. Many small VMs (each a FaaS
 unit or library shard) compose into a single program.
 
@@ -157,7 +157,7 @@ primitive. Track in `specs/plans/4Y-session-pools.md` (separate).
 
 ### 5. (Out of scope) Closure shipping
 
-Modal's ephemeral apps pickle closures at call time. **Excluded** —
+The reference platform's ephemeral apps pickle closures at call time. **Excluded** —
 your build-time-only rule rules it out, and it's a real security
 surface (deserializing untrusted code) we don't want.
 
@@ -256,7 +256,7 @@ the SDK extracts the workload spec from kwargs (`name`, `image`,
 `entrypoint`, `resources`) and emits IR + flake + launch.json. The
 function body is dropped per the README.
 
-Users want Modal-style call-time semantics: decorate a function,
+Users want remote-function call-time semantics: decorate a function,
 call it on the host, body runs inside the microVM, return value
 flows back. mvm's substrate (ADR-0005) is gaining a constrained
 `RunEntrypoint` verb that runs a baked program with stdin piped in
@@ -304,7 +304,7 @@ its wrapper are baked into the rootfs at `mvmforge compile`.
 ## Consequences
 
 Benefits:
-- Modal-class ergonomics with mvm-class isolation (Firecracker
+- Remote-function ergonomics with mvm-class isolation (Firecracker
   per call/session).
 - Reuses ADR-0005 and ADR-0008 unchanged.
 - No new SDK ↔ host contract — just an IR field and a wrapper
@@ -370,7 +370,7 @@ None.
 
 ## Purpose
 
-Land function-call entrypoints (Modal-style `f.remote(...)`) on top
+Land function-call entrypoints (remote-function `f.remote(...)`) on top
 of the mvm `RunEntrypoint` substrate. End-to-end: decorate a Python
 or TypeScript function, run `mvmforge up`, then call it from the
 host and get a return value back.


### PR DESCRIPTION
## What

Closes out the canonical no-competitor-names list across the specs — replacing **Modal**, **Kata**, and **Vercel** with trait-based descriptions. 8 files, docs-only, no technical content changed.

| Name | Handling | Files |
|---|---|---|
| **Modal** (~23, named as the SDK-DX template) | → "the reference serverless-function platform" / "remote-function decorators"; API-shape examples (`.remote()`/`.local()`, `@app.cls`, `Image.debian_slim().pip_install`) **reattributed, not deleted**; 2 ASCII diagrams re-aligned | plans 41/60/81, ADR-007 |
| **Kata** | facts preserved obliquely — Apple Container's kernel → "a container-optimized Linux 6.x from an external containers-in-VMs project"; survey + boot-citation reworded (URLs dropped) | plans 20/15, backlog 13 |
| **Vercel** | dropped "Vercel AI SDK" from the audience list (LangChain/LlamaIndex/Mastra kept) | gap-analysis-vs-libkrun |

## Deliberately kept

- Lowercase English **"modal"** (statistical mode) in ADR-049 and `mvm-oci/src/layer.rs` — not the product.
- Infra/ecosystem (not on the list): runwasi, containerd-wasm-shims, LangChain/LlamaIndex/Mastra, gvisor-tap-vsock.

## Verification

Banned list now **fully clean**: Modal/Kata/Vercel = 0; Fly/E2B/boxlite/standalone-gVisor were already 0. No code touched (all 8 files are `.md`). Git history not rewritten (separate decision). Private decode lives in auto-memory.