### PR TITLE
docs(plan-152): WS-B threading-model decision (Stage 2)

### DIFF
--- a/specs/adrs/056-vz-backend.md
+++ b/specs/adrs/056-vz-backend.md
@@ -220,3 +220,66 @@ Defense-in-depth additions on top of the trait-level requirements:
   Plan 97 §"mvmd integration".
 - **Windows host support via WHP.** Cataloged as a separate
   initiative — see [#428](https://github.com/tinylabscom/mvm/issues/428).
+
+## Addendum (2026-06-07): Rust-native supervisor — threading model (Plan 152 WS-B)
+
+Plan 152 reverses Plan 97's "keep the Swift supervisor" call: the VZ
+supervisor moves to a Rust `[[bin]]` in `mvm-vm-host`, still a separate
+per-VM codesigned process. The entitled-TCB invariant was always about
+process separation, not language — `mvmctl` stays unentitled, the supervisor
+carries `com.apple.security.virtualization` alone. `objc2`,
+`objc2-virtualization`, `block2`, and `dispatch2` are already workspace deps
+(the `apple_container` backend uses them), so the move adds no third-party
+dependency. This addendum records the one decision WS-B was gated on — the
+supervisor's threading model — from which the rest of WS-B follows.
+
+**Decision: a private serial `DispatchQueue` + `VZVirtualMachineDelegate`,
+not a main-thread `CFRunLoop`.** The shipping Swift supervisor already runs
+exactly this shape: one serial `DispatchQueue("mvm.vz.supervisor")` passed to
+`VZVirtualMachine(configuration:queue:)` services the VM, the control socket,
+the vsock proxy, and the SIGTERM/SIGINT sources; the delegate's `guestDidStop`
+/ `didStopWithError` fire on that queue; the start path blocks on a
+`DispatchSemaphore`. Porting it 1:1 — `dispatch2` serial queue,
+`declare_class!` delegate, `block2::RcBlock` completion handlers,
+`QueueBound<Send>` for the `!Send` `Retained` handles — makes the mandatory
+parity matrix a true apples-to-apples comparison of a known-good design,
+which is the risk posture re-implementing a security-sensitive component
+demands.
+
+A main-thread `CFRunLoop` (one reviewed reference's model, and roughly what
+`apple_container` does with NSRunLoop) was rejected. For a one-VM-per-process
+supervisor it pins VZ to the main thread, still needs worker threads for the
+control socket + vsock proxy, forces `main()` to be a runloop pump contending
+with the async I/O runtime for thread ownership, and diverges from the proven
+design for no payoff.
+
+**I/O layer: a tokio current-thread runtime, never blocking accept loops.**
+The control socket and vsock proxy run on a single-threaded tokio reactor
+(`tokio = { features = ["rt", …] }` — `rt`, deliberately not
+`rt-multi-thread`); the dup'd guest vsock fd is driven through `AsyncFd` and
+spliced with `copy_bidirectional`, which gives correct half-close and
+backpressure without a hand-written state machine. tokio is already in the
+workspace lock and `AsyncFd` needs its reactor regardless, so this buys async
+I/O at no new dependency cost. The supervisor then runs two single-purpose
+schedulers: the VZ serial dispatch queue (libdispatch) owns every VZ API
+call; the current-thread tokio reactor owns I/O. tokio tasks hop onto the VZ
+queue only for the VZ calls themselves (`connect(toPort:)`, `pause`/`resume`/
+`save`/`restore`), getting results back over a `oneshot`. `dispatch2`
+`DispatchSource` read sources — a zero-new-dep, even-more-1:1 port of the
+Swift sources — were considered and rejected: they would mean hand-rolling
+the bidirectional splice, the wrong place to economize.
+
+**`unsafe` surface.** Exactly one `unsafe impl Send for QueueBound<Retained<…>>`,
+under the invariant that the wrapped handle is dereferenced only inside a
+closure dispatched onto the VZ serial queue, never from a tokio worker. Each
+`unsafe` block cites that invariant.
+
+Security posture is unchanged from the per-claim table above. The rewrite
+keeps the signed/audited `ExecutionPlan` admission (claim 8), the
+capture-only console lockdown, the resource-cap parity check, and the
+codesigned separate-process entitlement boundary — `apple_container::
+ensure_signed()` is extended to sign the Rust binary with
+`com.apple.security.virtualization`. The Swift crate is deleted only after the
+WS-B parity matrix (boot, vsock round-trip, every control verb, save/restore)
+is green; the entitled-TCB / drop-Swift rationale is the deferred Plan 97
+note, now resolved.

--- a/specs/plans/152-rust-native-vz-and-init-lifecycle-parity.md
+++ b/specs/plans/152-rust-native-vz-and-init-lifecycle-parity.md
@@ -1,11 +1,16 @@
 # Plan 152 — Rust-native `Virtualization.framework` supervisor + guest `/init` lifecycle parity
 
-> **Status (2026-06-05):** Findings recorded; not yet started. **Both
-> gates satisfied — WS-A is unblocked (roadmap S2).** Plan 120 green
+> **Status (2026-06-07):** In progress, staged per workstream.
+> **WS-A** (guest `/init` exit-code + poweroff parity) implemented on
+> `feat/plan-152-wsa-init-exit` — a separate session owns it.
+> **WS-B threading-model decision RESOLVED** (this update): private serial
+> `DispatchQueue` + delegate, tokio current-thread I/O — see the WS-B
+> checkbox below and the ADR-056 addendum. The WS-B Rust-supervisor build
+> follows from it. **Both gates satisfied** — Plan 120 green
 > (`core_demo_e2e` COMPLETE 2026-06-03); Plan 134 (architecture-aware
 > artifact model, slice 1) merged to main (via `feat/artifact-model-impl`,
-> tip `a57f2548`). Boot path is now on main, so the `/init` diff is no
-> longer measured against a moving target.
+> tip `a57f2548`). Boot path is on main, so the `/init` diff is no longer
+> measured against a moving target.
 >
 > **Numbering caveat:** picked 152 as next-after-highest from local
 > `specs/plans/`. Reconcile against open PRs before merge — the
@@ -269,16 +274,21 @@ Replace `crates/mvm-vz-supervisor/` (Swift) with a Rust binary using
 `objc2-virtualization`, kept as a separate per-VM codesigned process.
 ~70% of the substrate is already shared Rust (exploration verdict).
 
-- [ ] **Threading-model decision (do this first).** Evaluate the simplest
-      viable shape: the supervisor process's **main thread runs the VM's
-      `CFRunLoop`**, `block2::RcBlock` completion handlers write a terminal
-      atomic + `CFRunLoopStop`, SIGINT→stop — no `declare_class!` delegate,
-      no `QueueBound<Send>`, no dispatch-queue plumbing (proven viable by
-      the minimal two-backend reference for a one-VM-per-process model).
-      Compare against the private-serial-queue model (this plan's original
-      Findings) on one axis: cleanly servicing the control socket + vsock
-      proxy on **worker threads** while a runloop owns the main thread.
-      Pick one and record the rationale; the rest of WS-B follows from it.
+- [x] **Threading-model decision (resolved 2026-06-07 — ADR-056 addendum).**
+      **Private serial `DispatchQueue` + `VZVirtualMachineDelegate`, NOT
+      main-thread `CFRunLoop`** — a 1:1 port of the shipping Swift supervisor
+      (one serial queue services VM + control socket + vsock proxy + signal
+      sources; delegate fires `guestDidStop`/`didStopWithError` on it; start
+      blocks on a terminal signal). `CFRunLoop`-on-main was rejected: it pins
+      VZ to main, still needs worker threads for control/vsock, and forces
+      `main()` into a runloop pump that contends with the I/O runtime — no
+      payoff for one-VM-per-process, and it diverges from the proven design
+      the parity matrix must compare against. I/O (control socket + vsock
+      proxy) runs on a **single-threaded tokio reactor** (`rt`, not
+      `rt-multi-thread`; `AsyncFd` + `copy_bidirectional`), hopping onto the
+      VZ serial queue only for VZ API calls via `QueueBound<Send>` (one
+      `unsafe impl Send`, deref'd only inside dispatched closures). Rationale
+      in `specs/adrs/056-vz-backend.md` §"Addendum … threading model".
 - [ ] New `[[bin]]` `mvm-vz-supervisor` in `mvm-vm-host`, sibling to
       `mvm-libkrun-supervisor` / `mvm-vz-drainer`, cfg-gated macOS. Reads
       the same `SupervisorConfig` JSON on stdin.
@@ -300,10 +310,12 @@ Replace `crates/mvm-vz-supervisor/` (Swift) with a Rust binary using
       Vz; delete the `mvm-vz-drainer` + `BridgeEndpoints::VzIngest` NDJSON
       path (Plan 141 Q10). Reuses 141's backend-agnostic
       `Observer`/`gateway_bridge` core unchanged (ADR-064 §8).
-- [ ] Lifecycle: **per the threading-model decision above** — either the
-      main-thread `CFRunLoop` shape, or a private serial dispatch queue +
-      `declare_class!` delegate + `QueueBound<Send>` for the non-`Send`
-      `Retained` handles. `RcBlock` completion handlers either way.
+- [ ] Lifecycle (per the resolved threading decision): a private serial
+      `dispatch2` queue passed to `VZVirtualMachine`, a `declare_class!`
+      `VZVirtualMachineDelegate` writing the write-once terminal slot,
+      `QueueBound<Send>` for the non-`Send` `Retained` handles, and
+      `block2::RcBlock` completion handlers. Main thread blocks on the
+      terminal signal; SIGTERM/SIGINT → `requestStop`.
 - [ ] Reimplement `VsockProxy.swift` in Rust: per-port UDS listeners at
       `<socketDir>/vsock-<port>.sock` (mode 0700) ↔
       `VZVirtioSocketDevice.connect(toPort:)`, fd→`dup`→`AsyncFd`. Mine


### PR DESCRIPTION
## Plan 152 — Stage 2 (WS-B threading-model decision; design only, no rewrite)

Resolves the one fork WS-B was gated on. **Decision: a private serial
`DispatchQueue` + `VZVirtualMachineDelegate` — a 1:1 port of the shipping
Swift supervisor — NOT a main-thread `CFRunLoop`.** Control socket + vsock
proxy run on a single-threaded tokio reactor (`rt`, not `rt-multi-thread`;
`AsyncFd` + `copy_bidirectional`), hopping onto the VZ serial queue for VZ
API calls via a single bounded `unsafe impl Send for QueueBound`.

### Why serial-queue, not CFRunLoop
The shipping Swift supervisor already runs exactly this shape — one serial
queue services the VM, the control socket, the vsock proxy, and the signal
sources; the delegate fires on it; the start path blocks on a semaphore.
Porting it 1:1 makes the mandatory parity matrix a true apples-to-apples
comparison of a known-good design — the right posture for a security-sensitive
rewrite. `CFRunLoop`-on-main pins VZ to the main thread, still needs worker
threads for control/vsock, and forces `main()` into a runloop pump contending
with the I/O runtime — no payoff for one-VM-per-process.

### Why tokio current-thread for I/O
tokio is already in the workspace lock and `AsyncFd` needs its reactor
regardless, so async I/O is free here; `copy_bidirectional` gives correct
half-close + backpressure without a hand-written splice. `dispatch2`
`DispatchSource` (zero-new-dep, even-more-1:1) was rejected — it would mean
hand-rolling the splice, the wrong place to economize.

### Changes (docs only)
- **ADR-056**: addendum recording the decision, the I/O split, the bounded
  `unsafe`/`QueueBound` surface, and that security posture is unchanged
  (claim 8 admission, capture-only console, resource-cap parity, codesigned
  separate-process entitlement all preserved).
- **Plan 152**: threading checkbox marked resolved; Lifecycle bullet pinned
  to the chosen path; Status header updated.

### Sequencing
WS-A (guest `/init` exit-code + poweroff) is implemented on a separate branch
owned by another session. Stage 3 (the WS-B Swift→Rust rewrite) builds on
this decision and lands behind the parity gate before the Swift crate is
deleted.