### PR TITLE
docs: add cross-plan REFACTOR-STATUS rollup checklist

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -484,3 +484,4 @@ macOS / Linux Host
 - Active sprint spec: `specs/SPRINT.md`
 - Completed sprints archived to: `specs/backlog/` (e.g. `specs/backlog/01-foundation.md`)
 - When a sprint is completed, rename `specs/SPRINT.md` to `specs/backlog/<NN>-<name>.md` and create a new `specs/SPRINT.md` for the next sprint
+- `specs/REFACTOR-STATUS.md` is the cross-plan rollup checklist. Keep it ticked in the same change whenever a plan workstream lands, merges, or is descoped. It is an index, not source of truth — if it disagrees with a `specs/plans/` doc, the plan doc wins.

--- a/specs/REFACTOR-STATUS.md
+++ b/specs/REFACTOR-STATUS.md
@@ -1,0 +1,65 @@
+# Refactor status — rollup checklist
+
+**Last updated: 2026-06-07**
+
+> MAINTENANCE: keep this file current. Whenever you land, merge, or descope a
+> workstream in any plan below, tick/strike the matching box here in the SAME
+> change and bump the "Last updated" date. This is a hand-maintained rollup of
+> the per-plan checkboxes in `specs/plans/` and `specs/SPRINT.md` — it is a
+> quick index, not the source of truth. If it disagrees with a plan doc, the
+> plan doc wins; fix this file.
+
+## Plans
+
+```
+PLAN 121 — Crate consolidation (32→15)          ✅ DONE
+PLAN 169 — Backend-agnostic agent RPC           ✅ DONE
+PLAN 166 — QEMU Linux dev/test backend          ✅ DONE (Phase 2)
+PLAN 165 — Sealed-prod interactivity (claim 15) ✅ DONE
+
+PLAN 129 — Secrets / SigV4 substitution         🟡 ~95%
+  [x] keyholder, resolver, binding store, `secret set`
+  [x] host substitution endpoint (UDS)
+  [x] SigV4 canonical-request builder
+  [x] in-guest substitution client + forward-proxy
+  [x] claim-13 audit (secret.substituted)
+  [ ] forward-path signing integration
+  [ ] guest-init wiring
+  [ ] Python/TS SDK toolchain integration
+  [ ] real-microVM boot validation (KVM box)
+
+PLAN 152 — Rust-native VZ supervisor            🟡 design locked
+  [x] WS-A exit channel (vsock + PID-1 helper) — PR #698 (merged)
+  [x] WS-B threading decision (serial queue) — PR #697
+  [ ] WS-B the actual Swift→Rust rewrite (~1,450 LOC)
+  [ ] WS-C snapshot/restore + fork
+  [ ] WS-D nested KVM (/dev/kvm in guest)
+  [ ] WS-E VZ-config hardening
+
+PLAN 124 — Lean guest agent                     🟡 ~65%
+  [x] A1/A3 drop tokio+rtnetlink (-27 crates)
+  [x] B universal agent in all images
+  [x] C1 verity-sealed runtime overlay
+  [x] D1.0/D1.1 schema SSOT
+  [ ] D1.2/D1.3 SDK codegen
+  [ ] E signed on-device config
+
+PLAN 170 — Host lifecycle convergence           🟡 ~25%
+  [x] WS-A reconcile-on-entry — PR #688
+  [ ] WS-B idle reaper — PR #696 (open)
+  [ ] WS-C pressure reaper
+  [ ] WS-D wake-on-request
+
+PLAN 126 — Dependency reduction                 🔴 ~10%
+  [x] A1 re-baseline
+  [x] B5 drop tokio from mvm-core (PR-1)
+  [ ] B1/B2/B4 prune sigstore/opendal/aws-lc
+  [ ] C1/D1 unify + lock gate
+
+PLAN 153 — CLI directory split                  🔴 NOT STARTED
+```
+
+## Security claims
+
+15/15 shipped, none regressed (`specs/claims/catalog.md`, gated by
+`xtask check-claim-catalog`).


### PR DESCRIPTION
## What

Adds `specs/REFACTOR-STATUS.md` — a single hand-maintained checklist rolling up the in-flight refactor across all active plans (121/124/126/129/152/153/165/166/169/170), with done/todo boxes per workstream and the 15/15 security-claim status.

Adds one line to `CLAUDE.md` → Sprint Management instructing every session to keep the rollup ticked in the same change a workstream lands/merges/is descoped, with `specs/plans/` docs as the source of truth on any disagreement.

## Why

We're mid-refactor across many parallel sessions/worktrees and there was no single at-a-glance status. This is a quick index so any contributor or agent can see where things stand without crawling every plan doc.

## Note

The checklist is an *index*, not the source of truth — the MAINTENANCE header and the CLAUDE.md line both say the per-plan checkboxes win on conflict. Snapshot date in the file is 2026-06-07; #698 (Plan 152 WS-A) is already reflected as merged.