### PR TITLE
docs(refactor-status): mark Plan 178 DONE (run-family merged)

### DIFF
--- a/specs/REFACTOR-STATUS.md
+++ b/specs/REFACTOR-STATUS.md
@@ -197,7 +197,7 @@ PLAN 177 — Backend consolidation (8→4)           🟡 Phase 1 DONE; Phase 2 
   [ ] Phase 2 (GATED on Plan 152 WS-B + save/pause merge): AVF convergence
       onto supervisor vz + shared console transport + drop apple-container
 
-PLAN 178 — CLI surface consolidation (~56→~28)   🟢 groups done; run-family deferred  (ADR-077)
+PLAN 178 — CLI surface consolidation (~56→~28)   ✅ DONE (dir-purity deferred)  (ADR-077)
   [x] lock tree (D1–D6) + hide internal subprocess commands
   [x] vm group (14 single-VM verbs)
   [x] ops group (metrics/bench/config/mcp)


### PR DESCRIPTION
Plan 178's checklist already ticks the run-family merge (exec→run, Task 7, merged in #768), but the status line still read "🟢 groups done; run-family deferred". All Plan 178 workstreams have landed — mark it ✅ DONE, keeping the deferred dir-purity note.

Keeps `specs/REFACTOR-STATUS.md` in sync with what's on `main` after #765–#768.