### PR TITLE
feat(checkpoint): Plan 159 WS-2 PR3 — checkpoint diff + Vz pause/resume (finishes WS-2)

### DIFF
--- a/crates/mvm-backend/src/backend.rs
+++ b/crates/mvm-backend/src/backend.rs
@@ -1068,6 +1068,11 @@ mod tests {
             fc.capabilities().pause_resume,
             "firecracker: capability flag must say pause_resume=true (matches the real impl)"
         );
+        let vz = AnyBackend::from_hypervisor("vz");
+        assert!(
+            vz.capabilities().pause_resume,
+            "vz: capability flag must say pause_resume=true (matches the real impl)"
+        );
     }
 
     // Plan 76 Phase 7 — BackendTier coverage.

--- a/crates/mvm-backend/src/backend.rs
+++ b/crates/mvm-backend/src/backend.rs
@@ -436,7 +436,7 @@ impl AnyBackend {
     /// state-dir marker file, so `down` / `status` dispatch to the VMM that
     /// actually launched it rather than a platform default. The pid-file
     /// backends each drop a distinct marker under `vm_state_dir(name)`:
-    /// QEMU `qemu.pid`, libkrun `libkrun.pid`, Firecracker `fc.pid`.
+    /// QEMU `qemu.pid`, libkrun `libkrun.pid`, Firecracker `fc.pid`, Vz `vz.pid`.
     ///
     /// Returns `None` when no marker is present — the VM isn't one of the
     /// pid-file backends (e.g. Apple Container, which tracks state
@@ -450,6 +450,8 @@ impl AnyBackend {
             Some(Self::Libkrun(LibkrunBackend))
         } else if dir.join("fc.pid").is_file() {
             Some(Self::Firecracker(FirecrackerBackend))
+        } else if dir.join("vz.pid").is_file() {
+            Some(Self::Vz(VzBackend))
         } else {
             None
         }
@@ -886,6 +888,34 @@ mod tests {
             "fc.pid → Firecracker"
         );
         assert!(none.is_none(), "no marker → None");
+    }
+
+    #[test]
+    fn for_started_vm_resolves_vz_by_marker() {
+        let temp = std::path::PathBuf::from(format!(
+            "/tmp/mvmac-fsv-vz-test-{}-{}",
+            std::process::id(),
+            std::time::SystemTime::now()
+                .duration_since(std::time::UNIX_EPOCH)
+                .map(|d| d.as_nanos())
+                .unwrap_or(0)
+        ));
+        let vms = temp.join(".mvm/vms");
+        std::fs::create_dir_all(vms.join("vzvm")).expect("mkdir vm dir");
+        std::fs::write(vms.join("vzvm").join("vz.pid"), "12345").expect("write marker");
+        let saved = std::env::var("HOME").ok();
+        // SAFETY: for_started_vm (HOME consumer) is the only env reader in
+        // this test; restored below.
+        unsafe { std::env::set_var("HOME", &temp) };
+        let result = AnyBackend::for_started_vm("vzvm");
+        unsafe {
+            match saved {
+                Some(v) => std::env::set_var("HOME", v),
+                None => std::env::remove_var("HOME"),
+            }
+        }
+        let _ = std::fs::remove_dir_all(&temp);
+        assert!(matches!(result, Some(AnyBackend::Vz(_))), "vz.pid → Vz");
     }
 
     #[test]

--- a/crates/mvm-backend/src/checkpoint/mod.rs
+++ b/crates/mvm-backend/src/checkpoint/mod.rs
@@ -444,6 +444,117 @@ fn sha256_file_hex(path: &Path) -> Result<String> {
         .with_context(|| format!("hashing {}", path.display()))
 }
 
+/// How blob `name` differs between two checkpoints (B relative to A).
+#[derive(Debug, Clone, Copy, PartialEq, Eq, serde::Serialize)]
+#[serde(rename_all = "snake_case")]
+pub enum BlobStatus {
+    Unchanged,
+    Changed,
+    AddedInB,
+    RemovedFromB,
+}
+
+/// Per-blob delta keyed by content-manifest name.
+#[derive(Debug, Clone, PartialEq, Eq, serde::Serialize)]
+pub struct BlobDelta {
+    pub name: String,
+    pub status: BlobStatus,
+    pub sha_a: Option<String>,
+    pub sha_b: Option<String>,
+}
+
+/// Lineage relationship between the two checkpoints.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, serde::Serialize)]
+#[serde(rename_all = "snake_case")]
+pub enum LineageRelation {
+    BChildOfA,
+    AChildOfB,
+    Same,
+    Unrelated,
+}
+
+/// Structured metadata + manifest diff of two checkpoints (B relative to A).
+/// Byte content is never read — a blob sha256 mismatch is the change signal.
+#[derive(Debug, Clone, PartialEq, Eq, serde::Serialize)]
+pub struct CheckpointDiff {
+    pub a_id: CheckpointId,
+    pub b_id: CheckpointId,
+    pub class_a: CheckpointClass,
+    pub class_b: CheckpointClass,
+    pub vm_name_a: String,
+    pub vm_name_b: String,
+    pub tag_a: Option<String>,
+    pub tag_b: Option<String>,
+    pub created_unix_a: u64,
+    pub created_unix_b: u64,
+    pub supervisor_config_digest_same: bool,
+    pub lineage: LineageRelation,
+    pub blobs: Vec<BlobDelta>,
+}
+
+/// Compare two checkpoint metadata records. Pure — no store/disk access.
+pub fn diff_checkpoints(a: &CheckpointMeta, b: &CheckpointMeta) -> CheckpointDiff {
+    let lineage = if a.id == b.id {
+        LineageRelation::Same
+    } else if b.parent.as_ref() == Some(&a.id) {
+        LineageRelation::BChildOfA
+    } else if a.parent.as_ref() == Some(&b.id) {
+        LineageRelation::AChildOfB
+    } else {
+        LineageRelation::Unrelated
+    };
+
+    let mut names: Vec<&str> = a.content.iter().map(|x| x.name.as_str()).collect();
+    for blob in &b.content {
+        if !names.contains(&blob.name.as_str()) {
+            names.push(blob.name.as_str());
+        }
+    }
+    names.sort_unstable();
+    let sha_in = |m: &CheckpointMeta, name: &str| -> Option<String> {
+        m.content
+            .iter()
+            .find(|x| x.name == name)
+            .map(|x| x.sha256.clone())
+    };
+    let blobs = names
+        .iter()
+        .map(|name| {
+            let sa = sha_in(a, name);
+            let sb = sha_in(b, name);
+            let status = match (&sa, &sb) {
+                (Some(x), Some(y)) if x == y => BlobStatus::Unchanged,
+                (Some(_), Some(_)) => BlobStatus::Changed,
+                (Some(_), None) => BlobStatus::RemovedFromB,
+                (None, Some(_)) => BlobStatus::AddedInB,
+                (None, None) => unreachable!("name came from one of the two manifests"),
+            };
+            BlobDelta {
+                name: name.to_string(),
+                status,
+                sha_a: sa,
+                sha_b: sb,
+            }
+        })
+        .collect();
+
+    CheckpointDiff {
+        a_id: a.id.clone(),
+        b_id: b.id.clone(),
+        class_a: a.class,
+        class_b: b.class,
+        vm_name_a: a.vm_name.clone(),
+        vm_name_b: b.vm_name.clone(),
+        tag_a: a.tag.clone(),
+        tag_b: b.tag.clone(),
+        created_unix_a: a.created_unix,
+        created_unix_b: b.created_unix,
+        supervisor_config_digest_same: a.supervisor_config_digest == b.supervisor_config_digest,
+        lineage,
+        blobs,
+    }
+}
+
 /// Freeze a quiesced VM's rootfs into an immutable fs_quick checkpoint via APFS
 /// copy-on-write. Returns the persisted metadata. Audit binding is the caller's
 /// responsibility (it owns the ExecutionPlan + signer).
@@ -1050,5 +1161,106 @@ mod tests {
         assert_eq!(meta.content[0].sha256.len(), 64);
         assert_eq!(meta.tag.as_deref(), Some("gold"));
         assert_eq!(store.read_meta(&meta.id).unwrap(), meta);
+    }
+
+    fn fs_quick_meta(id: &str, vm: &str, parent: Option<&str>, rootfs_sha: &str) -> CheckpointMeta {
+        CheckpointMeta::builder(CheckpointId::new(id), CheckpointClass::FsQuick, vm)
+            .parent(parent.map(CheckpointId::new))
+            .content(vec![ContentBlob {
+                name: "rootfs.ext4".into(),
+                sha256: rootfs_sha.into(),
+            }])
+            .supervisor_config_digest("cfg")
+            .created_unix(10)
+            .build()
+    }
+
+    #[test]
+    fn diff_identical_metas_has_no_changes() {
+        let a = fs_quick_meta("a", "vm", None, "aaaa");
+        let b = fs_quick_meta("b", "vm", None, "aaaa");
+        let d = diff_checkpoints(&a, &b);
+        assert!(d.blobs.iter().all(|x| x.status == BlobStatus::Unchanged));
+        assert!(d.supervisor_config_digest_same);
+        assert_eq!(d.lineage, LineageRelation::Unrelated);
+    }
+
+    #[test]
+    fn diff_detects_changed_blob() {
+        let a = fs_quick_meta("a", "vm", None, "aaaa");
+        let b = fs_quick_meta("b", "vm", None, "bbbb");
+        let d = diff_checkpoints(&a, &b);
+        let rootfs = d.blobs.iter().find(|x| x.name == "rootfs.ext4").unwrap();
+        assert_eq!(rootfs.status, BlobStatus::Changed);
+        assert_eq!(rootfs.sha_a.as_deref(), Some("aaaa"));
+        assert_eq!(rootfs.sha_b.as_deref(), Some("bbbb"));
+    }
+
+    #[test]
+    fn diff_detects_added_and_removed_blobs_cross_class() {
+        let a = fs_quick_meta("a", "vm", None, "aaaa");
+        let b = CheckpointMeta::builder(CheckpointId::new("b"), CheckpointClass::VmFull, "vm")
+            .content(vec![
+                ContentBlob {
+                    name: "rootfs.ext4".into(),
+                    sha256: "aaaa".into(),
+                },
+                ContentBlob {
+                    name: "memory.bin".into(),
+                    sha256: "mmmm".into(),
+                },
+                ContentBlob {
+                    name: "machine-id".into(),
+                    sha256: "iiii".into(),
+                },
+            ])
+            .supervisor_config_digest("cfg")
+            .created_unix(11)
+            .build();
+        let d = diff_checkpoints(&a, &b);
+        assert_eq!(
+            d.blobs
+                .iter()
+                .find(|x| x.name == "memory.bin")
+                .unwrap()
+                .status,
+            BlobStatus::AddedInB
+        );
+        assert_eq!(
+            d.blobs
+                .iter()
+                .find(|x| x.name == "rootfs.ext4")
+                .unwrap()
+                .status,
+            BlobStatus::Unchanged
+        );
+        assert_eq!(d.class_a, CheckpointClass::FsQuick);
+        assert_eq!(d.class_b, CheckpointClass::VmFull);
+        let d2 = diff_checkpoints(&b, &a);
+        assert_eq!(
+            d2.blobs
+                .iter()
+                .find(|x| x.name == "memory.bin")
+                .unwrap()
+                .status,
+            BlobStatus::RemovedFromB
+        );
+    }
+
+    #[test]
+    fn diff_detects_child_lineage() {
+        let a = fs_quick_meta("parent", "vm", None, "aaaa");
+        let b = fs_quick_meta("child", "vm", Some("parent"), "aaaa");
+        assert_eq!(diff_checkpoints(&a, &b).lineage, LineageRelation::BChildOfA);
+        assert_eq!(diff_checkpoints(&b, &a).lineage, LineageRelation::AChildOfB);
+    }
+
+    #[test]
+    fn checkpoint_diff_serializes() {
+        let a = fs_quick_meta("a", "vm", None, "aaaa");
+        let b = fs_quick_meta("b", "vm", None, "bbbb");
+        let json = serde_json::to_string(&diff_checkpoints(&a, &b)).unwrap();
+        assert!(json.contains("rootfs.ext4"));
+        assert!(json.contains("changed"));
     }
 }

--- a/crates/mvm-cli/src/commands/tests.rs
+++ b/crates/mvm-cli/src/commands/tests.rs
@@ -1953,6 +1953,28 @@ fn test_checkpoint_create_defaults_fs_quick() {
 }
 
 #[test]
+fn test_checkpoint_diff_parses() {
+    let cli = Cli::try_parse_from([
+        "mvmctl",
+        "vm",
+        "checkpoint",
+        "diff",
+        "ckpt-a",
+        "ckpt-b",
+        "--json",
+    ])
+    .unwrap();
+    assert!(matches!(
+        cli.command,
+        Commands::Vm(group::Args {
+            action: group::VmCmd::Checkpoint(checkpoint::CheckpointArgs {
+                command: checkpoint::CheckpointCmd::Diff { json: true, .. }
+            })
+        })
+    ));
+}
+
+#[test]
 fn test_snapshot_save_is_gone() {
     assert!(Cli::try_parse_from(["mvmctl", "snapshot", "save", "vm", "--path", "/x"]).is_err());
 }

--- a/crates/mvm-cli/src/commands/vm/checkpoint.rs
+++ b/crates/mvm-cli/src/commands/vm/checkpoint.rs
@@ -82,6 +82,16 @@ pub(in crate::commands) enum CheckpointCmd {
         #[arg(long, value_parser = clap_vm_name)]
         new_id: Option<String>,
     },
+    /// Compare two checkpoints (metadata + content manifest; `b` relative to `a`).
+    Diff {
+        /// Baseline checkpoint id (`a`).
+        a: String,
+        /// Compared checkpoint id (`b`).
+        b: String,
+        /// Output as JSON.
+        #[arg(long)]
+        json: bool,
+    },
 }
 
 pub(in crate::commands) fn run_checkpoint(_cli: &Cli, args: CheckpointArgs) -> Result<()> {
@@ -99,6 +109,7 @@ pub(in crate::commands) fn run_checkpoint(_cli: &Cli, args: CheckpointArgs) -> R
         CheckpointCmd::Ls { json } => ls(json),
         CheckpointCmd::Rm { id } => rm(&id),
         CheckpointCmd::Fork { id, new_id } => fork(&id, new_id),
+        CheckpointCmd::Diff { a, b, json } => diff(&a, &b, json),
     }
 }
 
@@ -371,6 +382,58 @@ fn ls(json: bool) -> Result<()> {
             m.tag.as_deref().unwrap_or("-"),
             m.parent.as_ref().map(|p| p.as_str()).unwrap_or("-"),
         );
+    }
+    Ok(())
+}
+
+fn diff(a: &str, b: &str, json: bool) -> Result<()> {
+    let id_a = validated_checkpoint_id(a)?;
+    let id_b = validated_checkpoint_id(b)?;
+    let store = CheckpointStore::open();
+    let meta_a = store
+        .read_meta(&id_a)
+        .with_context(|| format!("reading checkpoint {a:?}"))?;
+    let meta_b = store
+        .read_meta(&id_b)
+        .with_context(|| format!("reading checkpoint {b:?}"))?;
+    let d = mvm_backend::checkpoint::diff_checkpoints(&meta_a, &meta_b);
+
+    if json {
+        crate::json_out::emit_json(&d)?;
+        return Ok(());
+    }
+
+    use mvm_backend::checkpoint::{BlobStatus, LineageRelation};
+    ui::info(&format!("checkpoint diff: {a} -> {b}"));
+    if d.class_a != d.class_b {
+        ui::info(&format!(
+            "  class: {} -> {}",
+            class_str(d.class_a),
+            class_str(d.class_b)
+        ));
+    }
+    if d.vm_name_a != d.vm_name_b {
+        ui::info(&format!("  vm:    {} -> {}", d.vm_name_a, d.vm_name_b));
+    }
+    if !d.supervisor_config_digest_same {
+        ui::info("  supervisor config: changed");
+    }
+    let rel = match d.lineage {
+        LineageRelation::BChildOfA => format!("{b} is a child of {a}"),
+        LineageRelation::AChildOfB => format!("{a} is a child of {b}"),
+        LineageRelation::Same => "same checkpoint id".to_string(),
+        LineageRelation::Unrelated => "no direct lineage".to_string(),
+    };
+    ui::info(&format!("  lineage: {rel}"));
+    println!("{:<20} STATUS", "BLOB");
+    for blob in &d.blobs {
+        let status = match blob.status {
+            BlobStatus::Unchanged => "unchanged",
+            BlobStatus::Changed => "changed",
+            BlobStatus::AddedInB => "added",
+            BlobStatus::RemovedFromB => "removed",
+        };
+        println!("{:<20} {}", blob.name, status);
     }
     Ok(())
 }

--- a/crates/mvm-cli/src/commands/vm/pause.rs
+++ b/crates/mvm-cli/src/commands/vm/pause.rs
@@ -22,8 +22,10 @@ use mvm::vm::instance_snapshot::{
     CannedIO, FirecrackerIO, SnapshotIO, VsockPostRestoreSignal, pause_and_seal,
     signal_post_restore, verify_and_resume,
 };
+use mvm_backend::backend::AnyBackend;
 use mvm_core::naming::validate_vm_name;
 use mvm_core::user_config::MvmConfig;
+use mvm_core::vm_backend::VmId;
 
 use super::Cli;
 use super::shared::clap_vm_name;
@@ -52,6 +54,12 @@ pub(in crate::commands) struct ResumeArgs {
     /// `firecracker`. See `pause --help` for the `mock` variant.
     #[arg(long, default_value = "firecracker")]
     pub hypervisor: String,
+}
+
+/// A running VM whose state dir carries a `vz.pid` marker is a Vz VM — it gets
+/// native vCPU pause/resume rather than the Firecracker snapshot-seal path.
+fn is_vz_vm(name: &str) -> bool {
+    matches!(AnyBackend::for_started_vm(name), Some(AnyBackend::Vz(_)))
 }
 
 /// Pick the `SnapshotIO` impl matching the hypervisor selector.
@@ -86,6 +94,19 @@ fn snapshot_io_for(hypervisor: &str, vm_name: &str) -> Result<Box<dyn SnapshotIO
 
 pub(in crate::commands) fn run_pause(_cli: &Cli, args: PauseArgs, _cfg: &MvmConfig) -> Result<()> {
     validate_vm_name(&args.name).with_context(|| format!("Invalid VM name: {:?}", args.name))?;
+    if is_vz_vm(&args.name) {
+        AnyBackend::Vz(mvm_backend::vz::VzBackend)
+            .pause(&VmId::from(args.name.as_str()))
+            .with_context(|| format!("pausing Vz VM {:?}", args.name))?;
+        let registry_path = mvm::vm::name_registry::registry_path();
+        if let Ok(mut registry) = mvm::vm::name_registry::VmNameRegistry::load(&registry_path) {
+            let _ = registry.set_paused(&args.name, true);
+            let _ = registry.save(&registry_path);
+        }
+        println!("{}: paused (vz, vCPUs quiesced)", args.name);
+        mvm_core::audit_emit!(WorkloadSleep, vm: &args.name, "backend=vz");
+        return Ok(());
+    }
     let io = snapshot_io_for(&args.hypervisor, &args.name)?;
 
     let sidecar =
@@ -112,6 +133,20 @@ pub(in crate::commands) fn run_resume(
     _cfg: &MvmConfig,
 ) -> Result<()> {
     validate_vm_name(&args.name).with_context(|| format!("Invalid VM name: {:?}", args.name))?;
+    if is_vz_vm(&args.name) {
+        AnyBackend::Vz(mvm_backend::vz::VzBackend)
+            .resume(&VmId::from(args.name.as_str()))
+            .with_context(|| format!("resuming Vz VM {:?}", args.name))?;
+        let registry_path = mvm::vm::name_registry::registry_path();
+        if let Ok(mut registry) = mvm::vm::name_registry::VmNameRegistry::load(&registry_path) {
+            let _ = registry.set_paused(&args.name, false);
+            let _ = registry.touch_last_active(&args.name, mvm_core::time::utc_now());
+            let _ = registry.save(&registry_path);
+        }
+        println!("{}: resumed (vz, vCPUs running)", args.name);
+        mvm_core::audit_emit!(WorkloadWake, vm: &args.name, "backend=vz");
+        return Ok(());
+    }
     // For resume the VM may not yet be running — the snapshot
     // restore path is what brings it back. We still need a
     // Firecracker socket the orchestrator can talk to. v1
@@ -261,4 +296,21 @@ fn snap_rm(name: &str) -> Result<()> {
     println!("{}: snapshot removed", name);
     mvm_core::audit_emit!(SnapshotDelete, vm: name);
     Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn is_vz_vm_true_for_vz_marker() {
+        let tmp = tempfile::tempdir().unwrap();
+        unsafe { std::env::set_var("HOME", tmp.path()) };
+        let dir = mvm_core::config::vm_state_dir("vzvm");
+        std::fs::create_dir_all(&dir).unwrap();
+        std::fs::write(dir.join("vz.pid"), "1").unwrap();
+        assert!(is_vz_vm("vzvm"));
+        assert!(!is_vz_vm("nope"));
+        unsafe { std::env::remove_var("HOME") };
+    }
 }

--- a/specs/notes/plan-159-ws2-pr3-diff-pause-resume-design.md
+++ b/specs/notes/plan-159-ws2-pr3-diff-pause-resume-design.md
@@ -1,0 +1,125 @@
+# Plan 159 WS-2 PR3 — `checkpoint diff` + Vz `pause/resume` (design)
+
+**Date:** 2026-06-11
+**Status:** design approved; ready for implementation-plan authoring
+**Finishes:** Plan 159 WS-2. Builds on the merged checkpoint subsystem —
+fs_quick (#762), vm_full (#770), AuditEmitter hoist (#775).
+
+## Goal
+
+Close out WS-2 with the two remaining items: a `mvmctl checkpoint diff <a> <b>`
+comparison and wiring `mvmctl pause/resume` to the Vz backend (today the CLI
+pause/resume is Firecracker-snapshot-sealing only).
+
+## Decision (from the brainstorm)
+
+`mvmctl pause <vz-vm>` = **lightweight vCPU quiesce** (semantic A): dispatch to
+`VzBackend::pause()`/`resume()` (the native PAUSE/RESUME control verbs; the VM
+stays resident in memory, no disk write). Firecracker keeps its existing
+sealed-snapshot pause **unchanged**. "Seal a Vz snapshot to disk" stays
+`checkpoint create --class vm_full`. Clean split: **pause = quiesce,
+checkpoint = seal.**
+
+## Part A — `mvmctl checkpoint diff <a> <b>`
+
+### What it compares (zero byte reads)
+Reads both `CheckpointMeta` via `CheckpointStore::read_meta`. Compares:
+- **Header**: `class`, `vm_name`, `tag`, `created_unix` (newer/older),
+  `supervisor_config_digest` (same/changed).
+- **Lineage**: whether `b` is a child of `a` (`b.parent == a.id`), the reverse,
+  or unrelated.
+- **Content manifest** (the heart): per-blob keyed by `ContentBlob.name` —
+  **unchanged** (same sha256), **changed** (different sha256), **added** /
+  **removed** (present in only one side). A blob sha256 mismatch is the
+  realistic "this changed" signal; we deliberately do NOT byte-diff the
+  multi-GB opaque ext4 / memory images. Cross-class diffs (fs_quick ↔ vm_full)
+  naturally surface `memory.bin` / `machine-id` as added/removed.
+
+### Shape (library-first)
+- **`mvm-backend::checkpoint`** (pure, testable): `diff_checkpoints(a: &CheckpointMeta,
+  b: &CheckpointMeta) -> CheckpointDiff`. `CheckpointDiff` is a structured value:
+  header field deltas + a `Vec<BlobDelta { name, status: Unchanged|Changed|AddedInB|RemovedFromB, sha_a: Option<String>, sha_b: Option<String> }>` + a lineage relation enum. No I/O — the CLI reads the two metas and passes them in.
+- **CLI** (`commands/vm/checkpoint.rs`): a `Diff { a, b, json }` subcommand that
+  validates the two ids, reads both metas from the store, calls
+  `diff_checkpoints`, and renders: a human summary + per-blob table by default,
+  or `serde_json` of `CheckpointDiff` under `--json`.
+- **No `--verify-content`** — YAGNI; `verify_content` is the separate on-disk
+  integrity check and isn't part of a metadata diff.
+
+## Part B — Vz `pause`/`resume` wiring
+
+### Change 1: backend resolution
+`AnyBackend::for_started_vm(name)` (in `mvm-backend/src/backend.rs`) probes
+`fc.pid`/`qemu.pid`/`libkrun.pid` markers but NOT `vz.pid`. Add the `vz.pid`
+arm so a running Vz VM resolves to `VzBackend` (the const is
+`vz::PID_FILE_NAME = "vz.pid"`). This is the missing seam — without it Vz VMs
+return `None` and fall through to a platform default.
+
+### Change 2: CLI dispatch
+`run_pause` / `run_resume` (in `commands/vm/pause.rs`) resolve the running VM's
+backend via `for_started_vm`, then dispatch:
+- **Firecracker / mock** → the existing `snapshot_io_for` →
+  `pause_and_seal` / `verify_and_resume` path, **unchanged**. Preserves FC's
+  sealed-snapshot semantics (HMAC envelope, epoch/vmstate/mem sidecar) and the
+  mock `CannedIO` test path.
+- **Vz** → `backend.pause(&VmId(name))` / `backend.resume(&VmId(name))` — the
+  native PAUSE/RESUME control verbs (lightweight vCPU quiesce).
+
+Both paths keep:
+- `VmNameRegistry::set_paused(name, true|false)` + `touch_last_active` on resume.
+- The `WorkloadSleep` / `WorkloadWake` audit emit.
+
+The Vz resume path does **NOT** fire the FC post-restore signal
+(`signal_post_restore`): the guest never left memory on a vCPU quiesce, so there
+is nothing to remount/restart. That signal is specific to FC's sealed-snapshot
+cold-ish restore.
+
+### Capability gate
+Dispatch consults `backend.capabilities().pause_resume`; a backend reporting
+`false` yields a clear "backend X does not support pause/resume" error rather
+than a confusing fall-through. Vz reports `pause_resume: true`.
+
+## Error handling
+
+- `checkpoint diff` with a missing id → clean "checkpoint `<id>` not found"
+  (validate ids with the existing `validated_checkpoint_id`). The two ids may be
+  any class/lineage; the diff is **directional** — it presents `b` relative to
+  `a` (so swapping the args flips Added↔Removed), but neither needs to be the
+  other's parent.
+- `pause`/`resume` when `for_started_vm` returns `None` → "VM `<name>` is not
+  running (no backend marker)".
+- resolved backend with `pause_resume == false` → the capability error above.
+- Vz pause on an already-paused VM → surface the supervisor's control-socket
+  response (the PAUSE verb is effectively idempotent at the control layer).
+
+## Testing
+
+- **diff (pure, host-side):** `diff_checkpoints` over hand-built `CheckpointMeta`
+  pairs — identical metas (no deltas), one changed blob, an added blob, a
+  removed blob, cross-class (fs_quick vs vm_full), and a child-vs-parent lineage
+  pair. Serde roundtrip of `CheckpointDiff`. CLI parse test for
+  `checkpoint diff a b [--json]`.
+- **pause/resume:** unit — `for_started_vm` resolves a `vz.pid` marker dir to
+  `VzBackend` (write a temp `vz.pid`, assert the variant). Dispatch routing via
+  the existing mock/`CannedIO` seam where reachable; CLI parse tests for
+  `pause`/`resume`. The live Vz pause→resume round-trip is the one
+  not-host-mockable piece (same constraint as PR1/PR2) — covered by the
+  unit-level dispatch + a manual-validation note, not a blocker.
+
+## Scope guard (YAGNI)
+
+Two focused features, mostly host-side-testable. Out of scope: byte-level
+content diff; `--verify-content` on diff; any change to Firecracker's
+sealed-snapshot pause; a generic "drop FC sealing" refactor (semantic C, rejected).
+
+## Crate placement
+
+- `diff_checkpoints` + `CheckpointDiff`/`BlobDelta` → `mvm-backend/src/checkpoint/mod.rs`
+- `vz.pid` arm → `mvm-backend/src/backend.rs` (`for_started_vm`)
+- `checkpoint diff` subcommand + render → `mvm-cli/src/commands/vm/checkpoint.rs`
+- `run_pause`/`run_resume` backend dispatch → `mvm-cli/src/commands/vm/pause.rs`
+
+## Rollup
+
+On merge, flip `specs/REFACTOR-STATUS.md` PLAN 159 WS-2 from `[~]` to `[x]`
+(checkpoint diff + pause/resume wiring land; WS-2 complete), bump the date.

--- a/specs/notes/plan-159-ws2-pr3-implementation.md
+++ b/specs/notes/plan-159-ws2-pr3-implementation.md
@@ -1,0 +1,496 @@
+# Plan 159 WS-2 PR3 — `checkpoint diff` + Vz `pause/resume` — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Finish Plan 159 WS-2 — add `mvmctl checkpoint diff <a> <b>` (metadata + manifest comparison) and wire `mvmctl pause/resume` to the Vz backend (native vCPU quiesce), leaving Firecracker's sealed-snapshot pause untouched.
+
+**Architecture:** A pure `diff_checkpoints(meta_a, meta_b) -> CheckpointDiff` in `mvm-backend::checkpoint` (the CLI reads both metas and renders). For pause/resume: add a `vz.pid` arm to `AnyBackend::for_started_vm`, then branch `run_pause`/`run_resume` — a resolved Vz VM dispatches to `VzBackend::pause()`/`resume()`; everything else keeps the existing `snapshot_io_for` seal path.
+
+**Tech Stack:** Rust 2024, serde, clap. Reuses the merged checkpoint subsystem (`CheckpointStore`/`CheckpointMeta`/`ContentBlob`), `AnyBackend`/`VmId`, the `vz_control` PAUSE/RESUME verbs.
+
+**Design doc:** `specs/notes/plan-159-ws2-pr3-diff-pause-resume-design.md`
+**Worktree:** `../mvm-159-ws2pr3` (branch `feat/plan-159-ws2-pr3`).
+
+**Standing rules:** library-first (pure helper in mvm-backend, CLI thin); no `clippy::too_many_arguments` suppression; no spec/PR/plan refs in code comments; no `Co-Authored-By`; `cargo fmt --all`; clippy `-D warnings`. `mvm-backend` SIGKILLs under nextest on this macOS host — use plain `cargo test` for targeted runs; known `HOME_TEST_LOCK`/fs2-flock flakes pass single-threaded.
+
+**Ground-truth pins:**
+- `CheckpointMeta { id: CheckpointId, class: CheckpointClass, vm_name: String, tag: Option<String>, parent: Option<CheckpointId>, created_unix: u64, content: Vec<ContentBlob>, supervisor_config_digest: String, audit_ref: Option<String> }`; `ContentBlob { name: String, sha256: String }`. `CheckpointClass { FsQuick, VmFull }` (serde `rename_all = "snake_case"`). `CheckpointId::new(s)` / `.as_str()`. `CheckpointStore::open()` / `.read_meta(&id) -> Result<CheckpointMeta>`.
+- `AnyBackend::for_started_vm(name) -> Option<AnyBackend>` (probes `qemu.pid`/`libkrun.pid`/`fc.pid`); `AnyBackend::Vz(VzBackend)` variant exists; `VzBackend` is a unit struct; `AnyBackend::pause/resume` forward to the inner `VmBackend`. `VzBackend::pause/resume` send `PAUSE`/`RESUME` via `vz_control`. `vz::PID_FILE_NAME = "vz.pid"`. `VmId::from(&str)`.
+- `mvm-cli/.../vm/checkpoint.rs`: `CheckpointCmd` enum (`Create/Restore/Ls/Rm/Fork`), `run_checkpoint` dispatch, `validated_checkpoint_id`, `ls(json)`, imports `CheckpointStore`, `class_str` from `mvm_hostd::audit::bind`, `crate::json_out::emit_json`, `crate::ui`.
+- `mvm-cli/.../vm/pause.rs`: `PauseArgs`/`ResumeArgs` (`name`, `--hypervisor` default `firecracker`), `run_pause`/`run_resume`, `snapshot_io_for`, registry `set_paused`/`touch_last_active`, `mvm_core::audit_emit!(WorkloadSleep/WorkloadWake, ...)`, `signal_post_restore`.
+
+---
+
+## File Structure
+
+| File | Change |
+|------|--------|
+| `crates/mvm-backend/src/checkpoint/mod.rs` | `diff_checkpoints` + `CheckpointDiff`/`BlobDelta`/`BlobStatus`/`LineageRelation` |
+| `crates/mvm-backend/src/backend.rs` | `vz.pid` arm in `for_started_vm` |
+| `crates/mvm-cli/src/commands/vm/checkpoint.rs` | `Diff { a, b, json }` subcommand + `diff()` render |
+| `crates/mvm-cli/src/commands/vm/pause.rs` | Vz dispatch branch in `run_pause`/`run_resume` |
+| `crates/mvm-cli/src/commands/tests.rs` (or the checkpoint/pause test modules) | parse tests |
+| `specs/REFACTOR-STATUS.md`, `specs/plans/159-vz-inspired-macos-dx.md` | flip WS-2 to done |
+
+---
+
+## Task 1: `diff_checkpoints` pure helper (mvm-backend)
+
+**Files:**
+- Modify: `crates/mvm-backend/src/checkpoint/mod.rs`
+
+- [ ] **Step 1: Write the failing tests** — add to the `#[cfg(test)] mod tests`:
+
+```rust
+    fn fs_quick_meta(id: &str, vm: &str, parent: Option<&str>, rootfs_sha: &str) -> CheckpointMeta {
+        use mvm_core::checkpoint::ContentBlob;
+        CheckpointMeta::builder(CheckpointId::new(id), CheckpointClass::FsQuick, vm)
+            .parent(parent.map(CheckpointId::new))
+            .content(vec![ContentBlob { name: "rootfs.ext4".into(), sha256: rootfs_sha.into() }])
+            .supervisor_config_digest("cfg")
+            .created_unix(10)
+            .build()
+    }
+
+    #[test]
+    fn diff_identical_metas_has_no_changes() {
+        let a = fs_quick_meta("a", "vm", None, "aaaa");
+        let b = fs_quick_meta("b", "vm", None, "aaaa");
+        let d = diff_checkpoints(&a, &b);
+        assert!(d.blobs.iter().all(|x| x.status == BlobStatus::Unchanged));
+        assert!(d.supervisor_config_digest_same);
+        assert_eq!(d.lineage, LineageRelation::Unrelated);
+    }
+
+    #[test]
+    fn diff_detects_changed_blob() {
+        let a = fs_quick_meta("a", "vm", None, "aaaa");
+        let b = fs_quick_meta("b", "vm", None, "bbbb");
+        let d = diff_checkpoints(&a, &b);
+        let rootfs = d.blobs.iter().find(|x| x.name == "rootfs.ext4").unwrap();
+        assert_eq!(rootfs.status, BlobStatus::Changed);
+        assert_eq!(rootfs.sha_a.as_deref(), Some("aaaa"));
+        assert_eq!(rootfs.sha_b.as_deref(), Some("bbbb"));
+    }
+
+    #[test]
+    fn diff_detects_added_and_removed_blobs_cross_class() {
+        use mvm_core::checkpoint::ContentBlob;
+        let a = fs_quick_meta("a", "vm", None, "aaaa"); // rootfs only
+        let b = CheckpointMeta::builder(CheckpointId::new("b"), CheckpointClass::VmFull, "vm")
+            .content(vec![
+                ContentBlob { name: "rootfs.ext4".into(), sha256: "aaaa".into() },
+                ContentBlob { name: "memory.bin".into(), sha256: "mmmm".into() },
+                ContentBlob { name: "machine-id".into(), sha256: "iiii".into() },
+            ])
+            .supervisor_config_digest("cfg")
+            .created_unix(11)
+            .build();
+        let d = diff_checkpoints(&a, &b);
+        let mem = d.blobs.iter().find(|x| x.name == "memory.bin").unwrap();
+        assert_eq!(mem.status, BlobStatus::AddedInB);
+        let rootfs = d.blobs.iter().find(|x| x.name == "rootfs.ext4").unwrap();
+        assert_eq!(rootfs.status, BlobStatus::Unchanged);
+        assert_eq!(d.class_a, CheckpointClass::FsQuick);
+        assert_eq!(d.class_b, CheckpointClass::VmFull);
+        // swapping flips added→removed
+        let d2 = diff_checkpoints(&b, &a);
+        let mem2 = d2.blobs.iter().find(|x| x.name == "memory.bin").unwrap();
+        assert_eq!(mem2.status, BlobStatus::RemovedFromB);
+    }
+
+    #[test]
+    fn diff_detects_child_lineage() {
+        let a = fs_quick_meta("parent", "vm", None, "aaaa");
+        let b = fs_quick_meta("child", "vm", Some("parent"), "aaaa");
+        assert_eq!(diff_checkpoints(&a, &b).lineage, LineageRelation::BChildOfA);
+        assert_eq!(diff_checkpoints(&b, &a).lineage, LineageRelation::AChildOfB);
+    }
+
+    #[test]
+    fn checkpoint_diff_serializes() {
+        let a = fs_quick_meta("a", "vm", None, "aaaa");
+        let b = fs_quick_meta("b", "vm", None, "bbbb");
+        let json = serde_json::to_string(&diff_checkpoints(&a, &b)).unwrap();
+        assert!(json.contains("rootfs.ext4"));
+        assert!(json.contains("changed"));
+    }
+```
+
+- [ ] **Step 2: Run to verify it fails** — `cargo test -p mvm-backend --lib checkpoint::tests::diff 2>&1 | tail -12` → types/fn absent.
+
+- [ ] **Step 3: Implement** — add to `checkpoint/mod.rs` (the file already imports `mvm_core::checkpoint::{...}` and `serde`-derives elsewhere; add `Serialize` use if needed):
+
+```rust
+use mvm_core::checkpoint::{CheckpointClass, CheckpointId, CheckpointMeta};
+use serde::Serialize;
+
+/// How blob `name` differs between two checkpoints (B relative to A).
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize)]
+#[serde(rename_all = "snake_case")]
+pub enum BlobStatus {
+    Unchanged,
+    Changed,
+    AddedInB,
+    RemovedFromB,
+}
+
+/// Per-blob delta keyed by content-manifest name.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+pub struct BlobDelta {
+    pub name: String,
+    pub status: BlobStatus,
+    pub sha_a: Option<String>,
+    pub sha_b: Option<String>,
+}
+
+/// Lineage relationship between the two checkpoints.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize)]
+#[serde(rename_all = "snake_case")]
+pub enum LineageRelation {
+    /// B's parent is A.
+    BChildOfA,
+    /// A's parent is B.
+    AChildOfB,
+    /// Same checkpoint id.
+    Same,
+    /// No direct parent link.
+    Unrelated,
+}
+
+/// Structured metadata + manifest diff of two checkpoints (B relative to A).
+/// Byte content is never read — a blob sha256 mismatch is the change signal.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+pub struct CheckpointDiff {
+    pub a_id: CheckpointId,
+    pub b_id: CheckpointId,
+    pub class_a: CheckpointClass,
+    pub class_b: CheckpointClass,
+    pub vm_name_a: String,
+    pub vm_name_b: String,
+    pub tag_a: Option<String>,
+    pub tag_b: Option<String>,
+    pub created_unix_a: u64,
+    pub created_unix_b: u64,
+    pub supervisor_config_digest_same: bool,
+    pub lineage: LineageRelation,
+    pub blobs: Vec<BlobDelta>,
+}
+
+/// Compare two checkpoint metadata records. Pure — no store/disk access.
+pub fn diff_checkpoints(a: &CheckpointMeta, b: &CheckpointMeta) -> CheckpointDiff {
+    let lineage = if a.id == b.id {
+        LineageRelation::Same
+    } else if b.parent.as_ref() == Some(&a.id) {
+        LineageRelation::BChildOfA
+    } else if a.parent.as_ref() == Some(&b.id) {
+        LineageRelation::AChildOfB
+    } else {
+        LineageRelation::Unrelated
+    };
+
+    // Union of blob names, stable-sorted, each classified by side membership.
+    let mut names: Vec<&str> = a.content.iter().map(|x| x.name.as_str()).collect();
+    for blob in &b.content {
+        if !names.contains(&blob.name.as_str()) {
+            names.push(blob.name.as_str());
+        }
+    }
+    names.sort_unstable();
+    let sha_in = |m: &CheckpointMeta, name: &str| -> Option<String> {
+        m.content.iter().find(|x| x.name == name).map(|x| x.sha256.clone())
+    };
+    let blobs = names
+        .iter()
+        .map(|name| {
+            let sa = sha_in(a, name);
+            let sb = sha_in(b, name);
+            let status = match (&sa, &sb) {
+                (Some(x), Some(y)) if x == y => BlobStatus::Unchanged,
+                (Some(_), Some(_)) => BlobStatus::Changed,
+                (Some(_), None) => BlobStatus::RemovedFromB,
+                (None, Some(_)) => BlobStatus::AddedInB,
+                (None, None) => unreachable!("name came from one of the two manifests"),
+            };
+            BlobDelta { name: name.to_string(), status, sha_a: sa, sha_b: sb }
+        })
+        .collect();
+
+    CheckpointDiff {
+        a_id: a.id.clone(),
+        b_id: b.id.clone(),
+        class_a: a.class,
+        class_b: b.class,
+        vm_name_a: a.vm_name.clone(),
+        vm_name_b: b.vm_name.clone(),
+        tag_a: a.tag.clone(),
+        tag_b: b.tag.clone(),
+        created_unix_a: a.created_unix,
+        created_unix_b: b.created_unix,
+        supervisor_config_digest_same: a.supervisor_config_digest == b.supervisor_config_digest,
+        lineage,
+        blobs,
+    }
+}
+```
+(If `CheckpointId`/`CheckpointClass`/`CheckpointMeta`/`Serialize` are already imported at the top of the file, don't duplicate the `use`.)
+
+- [ ] **Step 4: Run to verify pass** — `cargo test -p mvm-backend --lib checkpoint::tests 2>&1 | tail -12` → all green.
+- [ ] **Step 5: Commit**
+```bash
+git add crates/mvm-backend/src/checkpoint/mod.rs
+git commit -m "feat(checkpoint): diff_checkpoints pure metadata+manifest comparison"
+```
+
+---
+
+## Task 2: `mvmctl checkpoint diff` subcommand (mvm-cli)
+
+**Files:**
+- Modify: `crates/mvm-cli/src/commands/vm/checkpoint.rs`
+
+- [ ] **Step 1: Write the failing parse test** — add to the checkpoint tests module (mirror the existing `test_checkpoint_*_parses` in `commands/tests.rs`; check where those live and add there):
+
+```rust
+    #[test]
+    fn test_checkpoint_diff_parses() {
+        let cli = Cli::try_parse_from(["mvmctl","checkpoint","diff","ckpt-a","ckpt-b","--json"]).unwrap();
+        assert!(matches!(cli.command,
+            Commands::Checkpoint(vm::checkpoint::CheckpointArgs {
+                command: vm::checkpoint::CheckpointCmd::Diff { json: true, .. } })));
+    }
+```
+
+- [ ] **Step 2: Run to verify it fails** — `cargo test -p mvm-cli test_checkpoint_diff_parses 2>&1 | tail -8` → no `Diff` variant.
+
+- [ ] **Step 3: Implement** — add the `Diff` variant to `CheckpointCmd` (after `Fork`):
+```rust
+    /// Compare two checkpoints (metadata + content manifest; `b` relative to `a`).
+    Diff {
+        /// Baseline checkpoint id (`a`).
+        a: String,
+        /// Compared checkpoint id (`b`).
+        b: String,
+        /// Output as JSON.
+        #[arg(long)]
+        json: bool,
+    },
+```
+Add the dispatch arm in `run_checkpoint`:
+```rust
+        CheckpointCmd::Diff { a, b, json } => diff(&a, &b, json),
+```
+Add the handler (uses `diff_checkpoints` + the existing `validated_checkpoint_id`, `CheckpointStore`, `class_str`, `crate::json_out::emit_json`, `crate::ui`):
+```rust
+fn diff(a: &str, b: &str, json: bool) -> Result<()> {
+    let id_a = validated_checkpoint_id(a)?;
+    let id_b = validated_checkpoint_id(b)?;
+    let store = CheckpointStore::open();
+    let meta_a = store
+        .read_meta(&id_a)
+        .with_context(|| format!("reading checkpoint {a:?}"))?;
+    let meta_b = store
+        .read_meta(&id_b)
+        .with_context(|| format!("reading checkpoint {b:?}"))?;
+    let d = mvm_backend::checkpoint::diff_checkpoints(&meta_a, &meta_b);
+
+    if json {
+        crate::json_out::emit_json(&d)?;
+        return Ok(());
+    }
+
+    use mvm_backend::checkpoint::{BlobStatus, LineageRelation};
+    ui::info(&format!("checkpoint diff: {a} -> {b}"));
+    if d.class_a != d.class_b {
+        ui::info(&format!("  class: {} -> {}", class_str(d.class_a), class_str(d.class_b)));
+    }
+    if d.vm_name_a != d.vm_name_b {
+        ui::info(&format!("  vm:    {} -> {}", d.vm_name_a, d.vm_name_b));
+    }
+    if !d.supervisor_config_digest_same {
+        ui::info("  supervisor config: changed");
+    }
+    let rel = match d.lineage {
+        LineageRelation::BChildOfA => format!("{b} is a child of {a}"),
+        LineageRelation::AChildOfB => format!("{a} is a child of {b}"),
+        LineageRelation::Same => "same checkpoint id".to_string(),
+        LineageRelation::Unrelated => "no direct lineage".to_string(),
+    };
+    ui::info(&format!("  lineage: {rel}"));
+    println!("{:<20} STATUS", "BLOB");
+    for blob in &d.blobs {
+        let status = match blob.status {
+            BlobStatus::Unchanged => "unchanged",
+            BlobStatus::Changed => "changed",
+            BlobStatus::AddedInB => "added",
+            BlobStatus::RemovedFromB => "removed",
+        };
+        println!("{:<20} {}", blob.name, status);
+    }
+    Ok(())
+}
+```
+(`mvm_backend::checkpoint::diff_checkpoints`/`BlobStatus`/`LineageRelation` are pub from Task 1. `class_str` is already imported from `mvm_hostd::audit::bind`. Add a `use anyhow::Context;` if `with_context` isn't already in scope — the file imports `anyhow::{Context, Result, bail}` per the ground-truth, so it is.)
+
+- [ ] **Step 4: Run to verify pass** — `cargo test -p mvm-cli test_checkpoint_diff_parses 2>&1 | tail -8`; `cargo build -p mvm-cli 2>&1 | tail -3`; `cargo clippy -p mvm-cli -- -D warnings 2>&1 | tail -6`.
+- [ ] **Step 5: Commit**
+```bash
+git add crates/mvm-cli/src/commands/vm/checkpoint.rs crates/mvm-cli/src/commands/tests.rs
+git commit -m "feat(cli): mvmctl checkpoint diff <a> <b>"
+```
+
+---
+
+## Task 3: `vz.pid` arm in `for_started_vm` (mvm-backend)
+
+**Files:**
+- Modify: `crates/mvm-backend/src/backend.rs`
+
+- [ ] **Step 1: Write the failing test** — add to `backend.rs` tests (set `MVM_DATA_DIR` to a temp dir, write a `vz.pid`, assert the variant; match the file's existing env-lock idiom if present):
+
+```rust
+    #[test]
+    fn for_started_vm_resolves_vz_by_marker() {
+        let tmp = tempfile::tempdir().unwrap();
+        // SAFE in tests; config reads MVM_DATA_DIR at call time.
+        unsafe { std::env::set_var("MVM_DATA_DIR", tmp.path()) };
+        let dir = mvm_core::config::vm_state_dir("vzvm");
+        std::fs::create_dir_all(&dir).unwrap();
+        std::fs::write(dir.join("vz.pid"), "12345").unwrap();
+        assert!(matches!(AnyBackend::for_started_vm("vzvm"), Some(AnyBackend::Vz(_))));
+        unsafe { std::env::remove_var("MVM_DATA_DIR") };
+    }
+```
+(If the file's existing `for_started_vm` test — the ground-truth mentioned `for_started_vm_resolves_owning_backend_by_marker` — uses a serial env-lock guard, reuse it.)
+
+- [ ] **Step 2: Run to verify it fails** — `cargo test -p mvm-backend --lib for_started_vm_resolves_vz 2>&1 | tail -8` → currently returns `None` (no vz arm) → assert fails.
+
+- [ ] **Step 3: Implement** — in `for_started_vm`, add the `vz.pid` arm after the `fc.pid` branch:
+```rust
+        } else if dir.join("fc.pid").is_file() {
+            Some(Self::Firecracker(FirecrackerBackend))
+        } else if dir.join("vz.pid").is_file() {
+            Some(Self::Vz(VzBackend))
+        } else {
+            None
+        }
+```
+Update the doc comment listing markers to include `Vz vz.pid`.
+
+- [ ] **Step 4: Run to verify pass** — `cargo test -p mvm-backend --lib for_started_vm 2>&1 | tail -8` → both the new vz test + the existing marker test pass.
+- [ ] **Step 5: Commit**
+```bash
+git add crates/mvm-backend/src/backend.rs
+git commit -m "feat(backend): for_started_vm resolves Vz by vz.pid marker"
+```
+
+---
+
+## Task 4: Vz dispatch in `run_pause`/`run_resume` (mvm-cli)
+
+**Files:**
+- Modify: `crates/mvm-cli/src/commands/vm/pause.rs`
+
+The Vz VM dispatches to native `pause()`/`resume()` (vCPU quiesce); Firecracker/mock keep the existing seal path. A small testable predicate isolates the routing decision.
+
+- [ ] **Step 1: Write the failing test** — add to pause.rs tests: the routing predicate resolves a `vz.pid` VM to the Vz path:
+```rust
+    #[test]
+    fn is_vz_vm_true_for_vz_marker() {
+        let tmp = tempfile::tempdir().unwrap();
+        unsafe { std::env::set_var("MVM_DATA_DIR", tmp.path()) };
+        let dir = mvm_core::config::vm_state_dir("vzvm");
+        std::fs::create_dir_all(&dir).unwrap();
+        std::fs::write(dir.join("vz.pid"), "1").unwrap();
+        assert!(is_vz_vm("vzvm"));
+        assert!(!is_vz_vm("nope"));
+        unsafe { std::env::remove_var("MVM_DATA_DIR") };
+    }
+```
+(Match the file's env-lock idiom if its tests use one.)
+
+- [ ] **Step 2: Run to verify it fails** — `cargo test -p mvm-cli is_vz_vm_true_for_vz_marker 2>&1 | tail -8` → `is_vz_vm` absent.
+
+- [ ] **Step 3: Implement.** Add imports at the top of pause.rs: `use mvm_backend::AnyBackend;` and `use mvm_core::vm_backend::VmId;` (confirm the exact paths — `AnyBackend` is re-exported from `mvm_backend`; `VmId` is `mvm_core::vm_backend::VmId` or `mvm_core::protocol::vm_backend::VmId` — match how other CLI files import it). Add the predicate + the Vz branches:
+
+```rust
+/// A running VM whose state dir carries a `vz.pid` marker is a Vz VM — it gets
+/// native vCPU pause/resume rather than the Firecracker snapshot-seal path.
+fn is_vz_vm(name: &str) -> bool {
+    matches!(AnyBackend::for_started_vm(name), Some(AnyBackend::Vz(_)))
+}
+```
+In `run_pause`, before the `snapshot_io_for` line, branch:
+```rust
+    if is_vz_vm(&args.name) {
+        AnyBackend::Vz(mvm_backend::vz::VzBackend)
+            .pause(&VmId::from(args.name.as_str()))
+            .with_context(|| format!("pausing Vz VM {:?}", args.name))?;
+        let registry_path = mvm::vm::name_registry::registry_path();
+        if let Ok(mut registry) = mvm::vm::name_registry::VmNameRegistry::load(&registry_path) {
+            let _ = registry.set_paused(&args.name, true);
+            let _ = registry.save(&registry_path);
+        }
+        println!("{}: paused (vz, vCPUs quiesced)", args.name);
+        mvm_core::audit_emit!(WorkloadSleep, vm: &args.name, "backend=vz");
+        return Ok(());
+    }
+```
+In `run_resume`, before the `snapshot_io_for` line, branch (note: NO `signal_post_restore` — the guest never left memory):
+```rust
+    if is_vz_vm(&args.name) {
+        AnyBackend::Vz(mvm_backend::vz::VzBackend)
+            .resume(&VmId::from(args.name.as_str()))
+            .with_context(|| format!("resuming Vz VM {:?}", args.name))?;
+        let registry_path = mvm::vm::name_registry::registry_path();
+        if let Ok(mut registry) = mvm::vm::name_registry::VmNameRegistry::load(&registry_path) {
+            let _ = registry.set_paused(&args.name, false);
+            let _ = registry.touch_last_active(&args.name, mvm_core::time::utc_now());
+            let _ = registry.save(&registry_path);
+        }
+        println!("{}: resumed (vz, vCPUs running)", args.name);
+        mvm_core::audit_emit!(WorkloadWake, vm: &args.name, "backend=vz");
+        return Ok(());
+    }
+```
+(`AnyBackend::Vz(VzBackend).pause(...)` uses the `AnyBackend::pause` forwarder. Alternatively call `mvm_backend::vz::VzBackend.pause(&id)` directly via the `VmBackend` trait — pick whichever resolves cleanly; `AnyBackend` is already imported for `is_vz_vm`. If calling the trait method directly needs `use mvm_core::vm_backend::VmBackend;` in scope, add it.)
+
+Update the `PauseArgs`/`ResumeArgs` `--hypervisor` doc to note Vz VMs are auto-detected and quiesced (no `--hypervisor vz` needed).
+
+- [ ] **Step 4: Run to verify pass** — `cargo test -p mvm-cli is_vz_vm 2>&1 | tail -8`; `cargo build -p mvm-cli 2>&1 | tail -3`; `cargo clippy -p mvm-cli -- -D warnings 2>&1 | tail -8`. Confirm the existing FC/mock pause tests still pass: `cargo test -p mvm-cli --lib pause 2>&1 | tail -8`.
+- [ ] **Step 5: Commit**
+```bash
+git add crates/mvm-cli/src/commands/vm/pause.rs
+git commit -m "feat(cli): pause/resume dispatch Vz VMs to native vCPU quiesce"
+```
+
+---
+
+## Task 5: Gates + rollup + PR
+
+- [ ] **Step 1: Workspace gates.**
+```bash
+cargo fmt --all && cargo fmt --all -- --check
+cargo clippy --workspace -- -D warnings 2>&1 | tail -20
+cargo nextest run --workspace -E 'not package(mvm-backend)' 2>&1 | tail -20
+cargo test -p mvm-backend checkpoint:: 2>&1 | tail -6     # plain cargo test (nextest SIGKILLs mvm-backend)
+cargo test -p mvm-backend for_started_vm 2>&1 | tail -4
+cargo test --workspace --doc 2>&1 | tail -10
+```
+Fix REAL failures in the new code. Known `HOME_TEST_LOCK`/fs2-flock + degraded-builder-store flakes pass single-threaded / are pre-existing — confirm, don't chase.
+
+- [ ] **Step 2: Flip WS-2 to done.** In `specs/REFACTOR-STATUS.md`, change the PLAN 159 `WS-2 checkpoint+fork` line from `[~]` to `[x]` and update its tail from `Remaining: checkpoint diff + pause/resume wiring (PR3)` to note both landed (PR3) — WS-2 complete. Bump `**Last updated:**` to 2026-06-11. In `specs/plans/159-vz-inspired-macos-dx.md`, tick the WS-2 `checkpoint diff` + `pause/resume` items.
+
+- [ ] **Step 3: Commit + push + open PR** (controller runs final review + finishing-a-development-branch).
+```bash
+git add specs/REFACTOR-STATUS.md specs/plans/159-vz-inspired-macos-dx.md
+git commit -m "docs(plan-159): WS-2 complete — checkpoint diff + Vz pause/resume"
+```
+
+---
+
+## Notes for the implementer
+- `diff_checkpoints` is pure (no store access) — fully unit-tested. The CLI reads the two metas and renders.
+- The Vz pause/resume native path can't be unit-tested end-to-end (it hits a live control socket); the routing (`is_vz_vm` / `for_started_vm` vz arm) IS unit-tested. The live pause→resume round-trip is a manual-validation note, not a blocker (same constraint as PR1/PR2).
+- Do NOT touch the Firecracker/mock seal path — it stays exactly as-is; Vz is an additive branch before it.
+- No process-artifact refs in code comments; reuse `validated_checkpoint_id`, `class_str`, `for_started_vm`, the registry + `audit_emit!` helpers.

--- a/tests/audit_total_coverage.rs
+++ b/tests/audit_total_coverage.rs
@@ -177,6 +177,7 @@ const CHECKPOINT_SUB: &[(&str, AuditPosture)] = &[
     ("create", AuditPosture::Emits("CheckpointCreated")),
     ("restore", AuditPosture::Emits("CheckpointRestored")),
     ("fork", AuditPosture::Emits("CheckpointForked")),
+    ("diff", AuditPosture::ReadOnly),
     ("ls", AuditPosture::ReadOnly),
     ("rm", AuditPosture::ReadOnly),
 ];


### PR DESCRIPTION
The final slice of Plan 159 WS-2: a `checkpoint diff` comparison and wiring `mvmctl pause/resume` to the Vz backend. Builds on fs_quick (#762), vm_full (#770), the AuditEmitter hoist (#775). **Completes WS-2.**

## What landed
- **`mvmctl checkpoint diff <a> <b>`** — pure `diff_checkpoints(meta_a, meta_b) -> CheckpointDiff` in `mvm-backend::checkpoint` (header fields + per-blob manifest deltas keyed by name: unchanged/changed/added/removed + lineage relation). Zero byte reads — a blob sha256 mismatch is the change signal. CLI renders a human summary + per-blob table, or `--json`. `b` is presented relative to `a` (swapping flips added↔removed).
- **Vz `pause`/`resume`** — added the `vz.pid` arm to `AnyBackend::for_started_vm`; `run_pause`/`run_resume` dispatch a running Vz VM to native `VzBackend::pause()`/`resume()` (lightweight vCPU quiesce — VM stays resident, no disk write). **Firecracker's sealed-snapshot pause path is byte-identical/untouched**; Vz resume does **not** fire the FC post-restore signal (the guest never left memory). Registry `set_paused` + `WorkloadSleep`/`WorkloadWake` audit on both. Semantic: **pause = quiesce, checkpoint = seal.**

## Test plan
- [x] Pure host-side: 5 `diff_checkpoints` tests (identical, changed, added/removed cross-class with swap, lineage, serde); `for_started_vm` resolves `vz.pid` → Vz; `is_vz_vm`; Vz in the pause_resume capability test; `checkpoint diff` parse + `audit_total_coverage` (`diff` = ReadOnly).
- [x] `cargo fmt --all --check`, `cargo clippy --workspace -D warnings` (zero), workspace nextest + doctests green; FC/mock pause path unchanged (pure-addition diff).
- [ ] Live Vz pause→resume round-trip (the one not-host-mockable bit; manual, same constraint as PR1/PR2).

Design + plan: `specs/notes/plan-159-ws2-pr3-diff-pause-resume-design.md`, `specs/notes/plan-159-ws2-pr3-implementation.md`.