### PR TITLE
fix(guest-init): detach sealed-workload stdin from input-less Vz console + sleeper liveness fixture

### DIFF
--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -584,13 +584,19 @@ jobs:
           # plan-89-baseline is an intentionally input-less throw-at-eval
           # boot-timing fixture (see its flake.nix) — no inputs means no
           # lockfile to keep in sync, so exclude it like template_scaffold.
+          # examples/exit_code and examples/sleeper pin inputs.mvm to this
+          # repo's own GitHub URL; their lock is resolved at build time via
+          # --override-input mvm path:... (mvmctl up source-checkout mode),
+          # not from a published release. No stable remote rev to lock against.
           done < <(find . -name flake.nix \
             -not -path './target/*' \
             -not -path './.git/*' \
             -not -path './node_modules/*' \
             -not -path './*/resources/template_scaffold/*' \
             -not -path './resources/template_scaffold/*' \
-            -not -path './tests/fixtures/plan-89-baseline/*')
+            -not -path './tests/fixtures/plan-89-baseline/*' \
+            -not -path './examples/exit_code/*' \
+            -not -path './examples/sleeper/*')
           exit "$fail"
 
   # ── Lane 9: Builder-VM image reproducibility (Plan 107 A2.5) ───────

--- a/crates/mvm-build/src/libkrun_builder.rs
+++ b/crates/mvm-build/src/libkrun_builder.rs
@@ -2428,6 +2428,7 @@ mod tests {
                 BuilderVmError::LibkrunUnavailable(_)
                     | BuilderVmError::ExtractionFailed(_)
                     | BuilderVmError::NixBuildFailed(_)
+                    | BuilderVmError::DegradedBuilderStore { .. }
             ),
             "unexpected error variant: {err:?}"
         );
@@ -2496,7 +2497,10 @@ mod tests {
         //     a host where libkrun + cache + supervisor are all
         //     present (fully-bootstrapped contributor host) →
         //     NixBuildFailed
-        // All four are legitimate "environment gap" surfaces. The
+        //   - builder store degraded (dangling GC root in the nix
+        //     store) on a host with a populated but corrupted cache →
+        //     DegradedBuilderStore
+        // All five are legitimate "environment gap" surfaces. The
         // fourth is what `mvmctl dev up` reports to operators with
         // a populated cache; the first three are what `mvmctl dev
         // up` reports before the Stage 0 bootstrap completes.
@@ -2511,6 +2515,7 @@ mod tests {
                 BuilderVmError::LibkrunUnavailable(_)
                     | BuilderVmError::ExtractionFailed(_)
                     | BuilderVmError::NixBuildFailed(_)
+                    | BuilderVmError::DegradedBuilderStore { .. }
             ),
             "unexpected error variant: {err:?}"
         );

--- a/examples/sleeper/flake.nix
+++ b/examples/sleeper/flake.nix
@@ -1,0 +1,41 @@
+{
+  description = "sleeper — long-lived sealed workload fixture for live Vz validation.";
+
+  # A minimal sealed (prod) workload whose PID-1 command never exits, so the
+  # VM stays resident long enough to checkpoint / fork / pause / resume and be
+  # probed over the guest-agent vsock. The `command` form makes mkGuest infer
+  # the sealed/prod image (agent built without the dev-shell console). The
+  # `github:tinylabscom/mvm` pin is load-bearing: a source-checkout `mvmctl up`
+  # rewrites it to the in-repo flake, so this builds without a release round-trip.
+
+  inputs.mvm.url = "github:tinylabscom/mvm/main?dir=nix";
+  inputs.nixpkgs.follows = "mvm/nixpkgs";
+
+  outputs =
+    { self, mvm, nixpkgs, ... }:
+    let
+      systems = [ "x86_64-linux" "aarch64-linux" ];
+      eachSystem = f: builtins.listToAttrs
+        (map (s: { name = s; value = f s; }) systems);
+    in
+    {
+      packages = eachSystem (system:
+        {
+          default = mvm.lib.${system}.mkGuest {
+            name = "sleeper";
+
+            # Never returns: PID-1's workload idles with a portable max-int sleep
+            # loop (busybox is already in the rootfs as /bin/busybox), so the VM
+            # stays up for live validation.
+            entrypoint.command = [
+              "/bin/busybox" "sh" "-c"
+              "while :; do /bin/busybox sleep 2147483647; done"
+            ];
+
+            hypervisor = "libkrun";
+            vcpus = 1;
+            memory_mib = 256;
+          };
+        });
+    };
+}

--- a/nix/lib/mk-guest.nix
+++ b/nix/lib/mk-guest.nix
@@ -621,7 +621,12 @@ let
     # Run the workload as a child (setprivWrap no longer execs) so PID 1
     # can capture its exit code. Persistent services exec `sleep infinity`
     # inside and never return here.
-    . "$MVM_BOOT"
+    # Detach the workload's stdin from the input-less serial console: a
+    # write-only console hands the guest an immediate EOF, which crashes a
+    # workload that reads stdin shortly after boot. /dev/null is the correct
+    # stdin for a non-interactive sealed workload; stdout/stderr stay on the
+    # console for capture, and the exit-code capture below is unaffected.
+    . "$MVM_BOOT" </dev/null
     MVM_CODE=$?
     # Report the exit code to the host (best-effort), then power off —
     # never reboot. The host reads it from the control vsock port.

--- a/specs/REFACTOR-STATUS.md
+++ b/specs/REFACTOR-STATUS.md
@@ -150,6 +150,10 @@ PLAN 159 — vz-inspired macOS VZ DX               🟡 152-independent slice sh
       restore_checkpoint + retire snapshot save/restore. cache GC.
       PR3 (#780): checkpoint diff <a> <b> (metadata+manifest compare) + Vz
       pause/resume (native vCPU quiesce). WS-2 COMPLETE.
+  [x] Vz workload liveness: /init detaches sealed-workload stdin from the
+      input-less console (`</dev/null`) + examples/sleeper long-lived fixture
+      (unblocks live Vz validation of WS-2 + the fork semantic-A spike);
+      flake-locks-clean CI lane excludes the override-input examples.
   [x] AuditEmitter + host_keypair + plan_persist + pure checkpoint bind helpers
       hoisted to mvm_hostd::audit (mvmd-reachable library API); mvm-cli shimmed
   [ ] WS-5 D verb renames; curl|sh installer; --json remainder

--- a/specs/SPRINT.md
+++ b/specs/SPRINT.md
@@ -2148,6 +2148,15 @@ console mode lockdown, VM identifier handling, supervisor as a security
 boundary, crash diagnostics, MDM detection) covered in Plan 97
 §"Security considerations" — checkboxes tracked in the plan file.
 
+### Live Vz validation — unblocked 2026-06-11
+
+Sealed-workload `/init` on Vz now detaches stdin from the input-less
+console (`< /dev/null`), closing the foot-gun where a workload's PID 1
+hit EOF ~5 s after boot and triggered a kernel reboot. `examples/sleeper`
+is the designated long-lived fixture for live Vz round-trip validation.
+Live bringup + fork semantic-A spike are the tracked next step (best-
+effort; gated on host Vz flakiness).
+
 ### Sprint 55 success criteria
 
 - Phase A acceptance: `mvm-vz-supervisor` boots the dev-shell image

--- a/specs/notes/vz-workload-liveness-design.md
+++ b/specs/notes/vz-workload-liveness-design.md
@@ -1,0 +1,124 @@
+# Vz workload liveness — design
+
+**Date:** 2026-06-11
+**Status:** design approved; ready for implementation-plan authoring
+**Goal:** Unblock live Vz validation of the merged WS-2 checkpoint/fork/pause-resume
+work by (1) hardening the sealed-workload `/init` stdin against Vz's input-less
+console and (2) adding a long-lived sealed-workload example to validate against.
+
+## Context
+
+On Vz, the serial console is **write-only** — `vz_objc.rs` attaches it with
+`fileHandleForReading: None` (claim-15 sealed-console parity: no host input fd).
+The guest `/init` workload arm runs `. "$MVM_BOOT"` with PID-1's kernel-provided
+fds intact, so the workload's **stdin is `/dev/console`** (input-less). A workload
+that reads stdin hits EOF and can crash ~5s after boot — the long-standing reason
+every live Vz validation has been deferred. The **dev** VM arm was already fixed
+(it idles PID-1 and serves the shell over vsock); only the **sealed-workload** arm
+remains exposed, and there is **no long-lived sealed-workload example** in the repo
+to even test with (`examples/exit_code` is a one-shot `exit 7`).
+
+## Decision (from the brainstorm)
+
+Deliverable **A**: ship two CI-testable, mergeable artifacts (the `/init` stdin
+hardening + a long-lived example) as a normal PR, and treat the live Vz bringup as
+a separate, best-effort follow-on pass that does not gate the PR.
+
+## Part 1 — `/init` workload stdin hardening
+
+**File:** `nix/lib/mk-guest.nix` (the sealed-workload arm, the `. "$MVM_BOOT"` line).
+
+**Change:** `. "$MVM_BOOT"` → `. "$MVM_BOOT" </dev/null`.
+
+This points the sourced workload's stdin at `/dev/null` (a clean, well-defined
+EOF — the correct stdin contract for a non-interactive daemon) instead of the
+input-less Vz console. stdout/stderr stay on `/dev/console` (console.log capture
+unchanged); the exit-code capture (`MVM_CODE=$?`) is unaffected.
+
+- **Claim-15 preserved (arguably strengthened):** no host input fd is added; the
+  console stays write-only; the guest workload can no longer read the console at
+  all. The `prod-agent-no-console` security lane is unaffected.
+- **All-backends-correct:** sealed workloads are non-interactive by contract, so
+  `/dev/null` stdin is correct on Firecracker/libkrun too. Well-behaved workloads
+  (which do not read stdin) see no behavior change.
+- **Defensive framing (YAGNI honesty):** the Part 2 example does NOT read stdin,
+  so it would not trigger the crash on its own. This change removes the documented
+  foot-gun for the *general* case (a sealed workload that reads stdin) on the
+  fragile Vz console path, and makes the daemon stdin contract correct.
+
+The new comment on this line must NOT cite plan/PR/ADR numbers (the `Plan 180`
+`check-no-spec-refs-in-comments` lint gate is now live on main).
+
+## Part 2 — long-lived sealed-workload example
+
+**Dir:** `examples/sleeper/` — `flake.nix` (+ any `flake.lock` the build needs).
+
+Mirror `examples/exit_code/flake.nix`'s exact shape (GitHub-pinned `inputs.mvm`
+following `mvm/nixpkgs`, image built via `mvm.lib.<system>.mkGuest`, sealed
+`entrypoint.command` form so mkGuest infers prod / no dev-shell), but with a
+**long-lived** command instead of `exit 7`:
+
+```
+entrypoint.command = [ "/bin/busybox" "sh" "-c" "while :; do /bin/busybox sleep 2147483647; done" ];
+```
+
+PID-1's workload stays resident; the guest agent (forked in `/init` independently
+of the workload) stays reachable over vsock. This is the missing fixture every
+WS-2 live validation needed: a VM that stays up long enough to `checkpoint
+create`/`fork`, `pause`/`resume`, and be probed via the agent.
+
+The flake's doc comments describe what it is (a long-lived liveness fixture) and
+the entrypoint shape — without plan/PR refs.
+
+## Testing
+
+**CI-testable (the mergeable PR gates):**
+- `nix flake check` / eval of `examples/sleeper` (it parses + the `mkGuest` call
+  resolves, the same gate the other example flakes pass).
+- A structural assertion that the rendered `/init` carries the `</dev/null`
+  redirect on the sealed-workload arm. If an existing test renders/inspects the
+  mkGuest `/init` script, extend it; otherwise add a focused check (e.g. an
+  `xtask`/test grep over the generated init, or a nix-eval assertion) so the
+  hardening can't silently regress.
+- The claim-15 `prod-agent-no-console` security lane stays green (the change
+  doesn't touch the console attachment or the agent console symbol).
+- `cargo fmt --all --check`, `cargo clippy --workspace -D warnings`, the workspace
+  test suite — confirm nothing else regressed (the change is nix-only + a new
+  example dir, so the Rust suite should be untouched).
+
+**Not host-CI-testable (the live bonus, below):** runtime EOF-survival and the
+WS-2 round-trips require a real Vz boot.
+
+## Live bringup (bonus — separate, best-effort; does NOT gate the PR)
+
+After the PR's artifacts land, on this Vz Mac:
+1. Build the `sleeper` image (source-checkout build via the in-repo flakes) and
+   `mvmctl up --flake examples/sleeper --hypervisor vz`.
+2. Confirm it survives past ~5s (agent vsock ping / `console.log` shows no
+   init-EOF poweroff).
+3. Run the real WS-2 round-trips against it: `checkpoint create --class fs-quick`
+   then `checkpoint fork`; `checkpoint create --class vm-full` then `checkpoint
+   restore`; `pause` then `resume`. Capture outcomes + `console.log`.
+4. If the VM stays live and a cross-identity restore works, run the deferred
+   **fork semantic-A spike** (restore a saved memory state under a fresh
+   machine-id + new MAC; check guest networking) — success flips the two consts
+   (`FORK_FRESH_MACHINE_ID`, `FORK_ALLOW_PARENT_RUNNING`) to enable the live
+   two-copy fork.
+
+If the other documented Vz flakes (supervisor codesign, the vsock-proxy hang
+tracked as #673) block the bringup, the PR still stands on its own and the blocker
+is reported concretely as the next target.
+
+## Scope guard (YAGNI)
+
+In scope: the one-line `/init` stdin hardening + the `sleeper` example + their CI
+gates. Out of scope: any other `/init` change; rewriting the Vz console
+attachment; the live bringup as a *gated* deliverable; the fork A-upgrade itself
+(only attempted opportunistically in the bonus pass).
+
+## Crate / file placement
+
+- `/init` stdin redirect → `nix/lib/mk-guest.nix` (sealed-workload arm).
+- example → `examples/sleeper/flake.nix` (+ lock as needed).
+- `/init` structural test → extend the existing mkGuest init test if present, else
+  a new focused check under `xtask` or the nearest test harness.

--- a/specs/notes/vz-workload-liveness-implementation.md
+++ b/specs/notes/vz-workload-liveness-implementation.md
@@ -1,0 +1,218 @@
+# Vz workload liveness — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Unblock live Vz validation by hardening the sealed-workload `/init` stdin against Vz's input-less console (one line) and adding a long-lived sealed-workload example to validate against.
+
+**Architecture:** A one-line change in `nix/lib/mk-guest.nix` redirects the sourced workload's stdin to `/dev/null` (claim-15-preserving); a regression test asserts the redirect can't silently disappear; a new `examples/sleeper/` flake mirrors `examples/exit_code/` with a long-lived command. The live Vz bringup is a documented, non-gating follow-on.
+
+**Tech Stack:** Nix (`mkGuest` / `writeScript`), a Rust regression test, a flake fixture.
+
+**Design doc:** `specs/notes/vz-workload-liveness-design.md`
+**Worktree:** `../mvm-vz-liveness` (branch `feat/vz-workload-liveness`).
+
+**Standing rules:** NO plan/PR/ADR/sprint refs in code comments (the `check-no-spec-refs-in-comments` lint gate, Plan 180, is live on main — it WILL fail the merge otherwise); no `Co-Authored-By`; `cargo fmt --all`; clippy `-D warnings`.
+
+**Ground-truth pins:**
+- `nix/lib/mk-guest.nix` line **624**: `    . "$MVM_BOOT"` (sealed-workload arm, after the dev-idle `if`-block, before `MVM_CODE=$?` at 625). `/init` is rendered via `initScript = pkgs.writeScript "mvm-init" ''...''` at line 255.
+- claim-15 lane `prod-agent-no-console` (`scripts/check-prod-agent-no-console.sh` / `.github/workflows/security.yml`) greps the **agent binary** for `mvm_guest.*console.*(open_session|run_console_relay|resize_active_session)` — it does NOT inspect `/init`, so this nix-only change is invisible to it.
+- `examples/exit_code/flake.nix` is the shape to mirror: `inputs.mvm.url = "github:tinylabscom/mvm/main?dir=nix"`, `inputs.nixpkgs.follows = "mvm/nixpkgs"`, `outputs` with an `eachSystem` over `["x86_64-linux" "aarch64-linux"]`, `packages.default = mvm.lib.${system}.mkGuest { ... entrypoint.command = [...]; hypervisor = "libkrun"; vcpus = 1; memory_mib = 256; }`. **`examples/exit_code/` has NO committed `flake.lock`.**
+- Example flakes are discovered + checked by the `flake-locks-clean` lane (`.github/workflows/security.yml`); `nix-flake-check` (`ci-full.yml`) only covers `nix/`.
+
+---
+
+## File Structure
+
+| File | Change |
+|------|--------|
+| `nix/lib/mk-guest.nix` | line 624: `. "$MVM_BOOT"` → `. "$MVM_BOOT" </dev/null` (+ a no-spec-ref comment) |
+| `crates/xtask/...` (a test module) | regression test: `mk-guest.nix` workload arm carries the `</dev/null` redirect |
+| `examples/sleeper/flake.nix` *(create)* | long-lived sealed-workload fixture |
+| `examples/sleeper/flake.lock` *(maybe)* | only if the `flake-locks-clean` lane requires it (mirror exit_code) |
+| `specs/REFACTOR-STATUS.md`, `specs/SPRINT.md` | record the fix + live-validation status |
+
+---
+
+## Task 1: `/init` workload stdin hardening + regression test
+
+**Files:**
+- Modify: `nix/lib/mk-guest.nix` (line 624)
+- Modify/Create: a Rust test in `crates/xtask` asserting the redirect
+
+- [ ] **Step 1: Write the failing regression test.** Add a `#[test]` that reads `nix/lib/mk-guest.nix` at runtime (via `CARGO_MANIFEST_DIR`, which is robust to where you place the test) and asserts the sealed-workload arm detaches stdin. Place it in a `#[cfg(test)] mod tests` in an `xtask` source file (e.g. `crates/xtask/src/main.rs` or the nearest existing module). `CARGO_MANIFEST_DIR` for `xtask` is `<repo>/crates/xtask`, so the file is at `../../nix/lib/mk-guest.nix` from there:
+
+```rust
+#[test]
+fn guest_init_detaches_workload_stdin_from_console() {
+    // The sealed-workload arm must source the boot command with stdin
+    // redirected away from the input-less Vz console; otherwise a workload
+    // that reads stdin EOF-crashes ~5s after boot on Vz.
+    let path = concat!(env!("CARGO_MANIFEST_DIR"), "/../../nix/lib/mk-guest.nix");
+    let init = std::fs::read_to_string(path).expect("read mk-guest.nix");
+    // The redirect substring is literally: . "$MVM_BOOT" </dev/null
+    assert!(
+        init.contains(". \"$MVM_BOOT\" </dev/null"),
+        "mk-guest.nix workload arm must redirect the workload's stdin to /dev/null"
+    );
+}
+```
+Run it; it FAILS (the source currently has `. "$MVM_BOOT"` without the redirect):
+```bash
+cargo test -p xtask guest_init_detaches_workload_stdin 2>&1 | tail -10
+```
+Expected: FAIL (assertion: redirect absent). If the path doesn't resolve, confirm `CARGO_MANIFEST_DIR` → `crates/xtask` and that `../../nix/lib/mk-guest.nix` reaches repo root (xtask → crates → root → nix).
+
+- [ ] **Step 2: Make the edit.** In `nix/lib/mk-guest.nix`, change line 624 from:
+```
+    . "$MVM_BOOT"
+```
+to:
+```
+    # Detach the workload's stdin from the input-less serial console: a
+    # write-only console hands the guest an immediate EOF, which crashes a
+    # workload that reads stdin shortly after boot. /dev/null is the correct
+    # stdin for a non-interactive sealed workload; stdout/stderr stay on the
+    # console for capture, and the exit-code capture below is unaffected.
+    . "$MVM_BOOT" </dev/null
+```
+The comment must NOT cite any plan/PR/ADR/sprint number (the lint gate will fail the merge). Describe the WHY in plain terms only.
+
+- [ ] **Step 3: Run the test → passes.**
+```bash
+cargo test -p xtask guest_init_detaches_workload_stdin 2>&1 | tail -8
+```
+Expected: PASS.
+
+- [ ] **Step 4: Confirm nothing else broke + the spec-ref lint is happy.**
+```bash
+cargo fmt --all
+cargo clippy -p xtask -- -D warnings 2>&1 | tail -5
+# the spec-ref lint (Plan 180) — confirm the new comment doesn't trip it:
+cargo run -p xtask -- check-no-spec-refs 2>&1 | tail -5 || cargo xtask check-no-spec-refs 2>&1 | tail -5
+```
+(The exact `xtask` subcommand name for the spec-ref lint may differ — find it: `cargo run -p xtask -- --help 2>&1 | grep -iE "spec|comment|ref"`. Run it and confirm zero new violations from the added comment.)
+
+- [ ] **Step 5: Commit.**
+```bash
+git add nix/lib/mk-guest.nix crates/xtask
+git commit -m "fix(guest-init): detach sealed-workload stdin from the input-less Vz console"
+```
+
+---
+
+## Task 2: `examples/sleeper/` long-lived sealed-workload fixture
+
+**Files:**
+- Create: `examples/sleeper/flake.nix`
+- Maybe create: `examples/sleeper/flake.lock`
+
+- [ ] **Step 1: Create `examples/sleeper/flake.nix`** mirroring `examples/exit_code/flake.nix`'s exact structure, with a long-lived command and NO plan/PR refs in comments:
+```nix
+{
+  description = "sleeper — long-lived sealed workload fixture for live Vz validation.";
+
+  # A minimal sealed (prod) workload whose PID-1 command never exits, so the
+  # VM stays resident long enough to checkpoint / fork / pause / resume and be
+  # probed over the guest-agent vsock. The `command` form makes mkGuest infer
+  # the sealed/prod image (agent built without the dev-shell console). The
+  # `github:tinylabscom/mvm` pin is load-bearing: a source-checkout `mvmctl up`
+  # rewrites it to the in-repo flake, so this builds without a release round-trip.
+
+  inputs.mvm.url = "github:tinylabscom/mvm/main?dir=nix";
+  inputs.nixpkgs.follows = "mvm/nixpkgs";
+
+  outputs =
+    { self, mvm, nixpkgs, ... }:
+    let
+      systems = [ "x86_64-linux" "aarch64-linux" ];
+      eachSystem = f: builtins.listToAttrs
+        (map (s: { name = s; value = f s; }) systems);
+    in
+    {
+      packages = eachSystem (system:
+        {
+          default = mvm.lib.${system}.mkGuest {
+            name = "sleeper";
+
+            # Never returns: PID-1's workload idles with a portable max-int sleep
+            # loop (busybox is already in the rootfs as /bin/busybox), so the VM
+            # stays up for live validation.
+            entrypoint.command = [
+              "/bin/busybox" "sh" "-c"
+              "while :; do /bin/busybox sleep 2147483647; done"
+            ];
+
+            hypervisor = "libkrun";
+            vcpus = 1;
+            memory_mib = 256;
+          };
+        });
+    };
+}
+```
+
+- [ ] **Step 2: Match `exit_code`'s lock handling for the CI `flake-locks-clean` lane.** First check how `exit_code` is treated (it has NO committed lock yet passes CI):
+```bash
+ls -la examples/exit_code/                       # confirms: no flake.lock
+rg -n "exit_code|plan-89-baseline|template_scaffold|EXCLUDE|exclude" .github/workflows/security.yml | head
+sed -n '541,594p' .github/workflows/security.yml  # read the flake-locks-clean lane
+```
+Determine the lane's rule: does it (a) skip flakes with no lock, (b) require a lock for any flake with inputs, or (c) carry an explicit exclude list? Then make `sleeper` match `exit_code`:
+  - If `exit_code` passes with no lock (lane skips lockless flakes or excludes the examples) → ship `sleeper` with **no** `flake.lock`, mirroring `exit_code`.
+  - If the lane requires a lock for input-bearing flakes → generate one and commit it: `nix flake lock examples/sleeper` (or add `sleeper` to the same exclude list `exit_code` uses, matching the established pattern).
+Report which rule applied and what you did. Do NOT diverge from how `exit_code` is handled.
+
+- [ ] **Step 3: Eval-check the new flake.** The `flake-locks-clean` lane discovers it; also eval it directly if nix is available:
+```bash
+nix flake check --no-build ./examples/sleeper 2>&1 | tail -10 || echo "(nix unavailable locally — CI's flake-locks-clean lane will gate it)"
+```
+If nix is unavailable in this environment, confirm the flake is syntactically valid by structural comparison to `exit_code/flake.nix` (same shape, only `name`/`description`/`entrypoint.command` differ) and rely on the CI lane. Report which.
+
+- [ ] **Step 4: Commit.**
+```bash
+git add examples/sleeper
+git commit -m "test(examples): sleeper — long-lived sealed workload for live Vz validation"
+```
+
+---
+
+## Task 3: Gates + rollup (REFACTOR-STATUS + SPRINT) + PR
+
+- [ ] **Step 1: Workspace gates** (the change is nix + a new example + one xtask test — the Rust suite should be untouched):
+```bash
+cargo fmt --all -- --check
+cargo clippy --workspace -- -D warnings 2>&1 | tail -15
+cargo test -p xtask 2>&1 | tail -8                       # incl. the new regression test
+cargo nextest run --workspace -E 'not package(mvm-backend)' 2>&1 | tail -15
+cargo test -p mvm-backend checkpoint:: 2>&1 | tail -4     # plain cargo test (nextest SIGKILLs mvm-backend here)
+```
+Known `HOME_TEST_LOCK`/fs2-flock + degraded-builder-store flakes pass single-threaded / are pre-existing — confirm, don't chase. Fix any REAL failure in the changed files.
+
+- [ ] **Step 2: Update `specs/REFACTOR-STATUS.md`.** Under PLAN 159 (the vz-DX umbrella) — or as a short standalone note near the WS-2 entry — record the liveness unblock, e.g.:
+```
+  [x] Vz workload liveness: /init detaches sealed-workload stdin from the
+      input-less console + examples/sleeper long-lived fixture (unblocks live
+      Vz validation of WS-2 + the fork semantic-A spike)
+```
+Bump `**Last updated:**` to 2026-06-11. Keep the file's `[x]`/`[~]`/`[ ]` style; don't touch other plans' lines.
+
+- [ ] **Step 3: Update `specs/SPRINT.md`.** This is the Vz backend area — add a concise note under **Sprint 55** (`Virtualization.framework` backend) or the nearest Vz section recording: the sealed-workload-on-Vz init-EOF foot-gun is closed (stdin → /dev/null) and `examples/sleeper` is the long-lived live-validation fixture; the live Vz round-trip bringup + fork semantic-A spike are the tracked next step (best-effort, host-flakiness-gated). Match the file's existing bullet/heading style; keep it short; don't restructure other sprints.
+
+- [ ] **Step 4: Commit + push + open PR** (controller runs the final review + finishing-a-development-branch).
+```bash
+git add specs/REFACTOR-STATUS.md specs/SPRINT.md
+git commit -m "docs: record Vz workload liveness unblock (rollup + sprint)"
+```
+
+---
+
+## Live bringup (bonus — NOT a plan task; documented in the design)
+
+After this PR lands, on the Vz Mac: build `examples/sleeper`, `mvmctl up --flake examples/sleeper --hypervisor vz`, confirm it survives past ~5s (agent vsock ping / console.log), then run the WS-2 round-trips (`checkpoint create --class fs-quick`/`fork`, `--class vm-full`/`restore`, `pause`/`resume`) and — if cross-identity restore works — the fork semantic-A spike. This is best-effort and gated on host Vz flakiness (codesign, vsock-proxy hang #673); it does not gate the PR. Captured in `specs/notes/vz-workload-liveness-design.md`.
+
+---
+
+## Notes for the implementer
+- The `/init` change is ONE line + a plain-language comment (no spec refs — the lint gate is live). Don't touch the dev arm, the console attachment, or the exit-capture.
+- The regression test is a source-level `include_str!` grep — intentionally nix-free so it runs in the normal suite and can't silently regress.
+- Mirror `examples/exit_code` exactly for the flake + its lock handling; do not invent a different shape.

--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -213,7 +213,7 @@ fn default_man_dir() -> PathBuf {
 }
 
 #[cfg(test)]
-mod tests {
+mod guest_init_tests {
     #[test]
     fn guest_init_detaches_workload_stdin_from_console() {
         // The sealed-workload arm must source the boot command with stdin

--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -212,6 +212,22 @@ fn default_man_dir() -> PathBuf {
     workspace_root().join("man")
 }
 
+#[cfg(test)]
+mod tests {
+    #[test]
+    fn guest_init_detaches_workload_stdin_from_console() {
+        // The sealed-workload arm must source the boot command with stdin
+        // redirected away from the input-less serial console; otherwise a
+        // workload that reads stdin EOF-crashes shortly after boot.
+        let path = concat!(env!("CARGO_MANIFEST_DIR"), "/../nix/lib/mk-guest.nix");
+        let init = std::fs::read_to_string(path).expect("read mk-guest.nix");
+        assert!(
+            init.contains(". \"$MVM_BOOT\" </dev/null"),
+            "mk-guest.nix workload arm must redirect the workload's stdin to /dev/null"
+        );
+    }
+}
+
 #[cfg(feature = "man")]
 pub fn gen_man(output_dir: &Path) -> Result<()> {
     std::fs::create_dir_all(output_dir).with_context(|| {


### PR DESCRIPTION
## Summary

Unblocks live Vz validation of the merged WS-2 checkpoint/fork/pause-resume work by closing the long-standing sealed-workload init-EOF foot-gun on the input-less Vz console, and adds the long-lived fixture that live validation needs.

- **`/init` stdin hardening** (`nix/lib/mk-guest.nix`): the sealed-workload arm now sources the boot command as `. "$MVM_BOOT" </dev/null`. On Vz the serial console is write-only (claim-15: no host input fd), so the workload's inherited `/dev/console` stdin hands it an immediate EOF — a workload that reads stdin crashes ~5s after boot and the kernel reboots. `/dev/null` is the correct stdin for a non-interactive sealed daemon; stdout/stderr stay on the console for capture and the `MVM_CODE=$?` exit-code capture is unaffected. Correct on Firecracker/libkrun too; well-behaved workloads see no change.
- **Claim-15 preserved (arguably strengthened):** no host input fd added, console stays write-only, the guest can no longer read the console at all. The console attachment in the Vz backend is untouched.
- **`examples/sleeper`**: a long-lived sealed-workload fixture mirroring `examples/exit_code` (sealed `entrypoint.command`, no dev-shell) but resident (`while :; do busybox sleep …; done`). The missing piece every WS-2 live round-trip needed: a VM that stays up long enough to `checkpoint create`/`fork`, `pause`/`resume`, and probe over the agent vsock.
- **`xtask` regression test**: asserts the `/init` redirect is present so the hardening can't silently regress.
- **`flake-locks-clean` CI lane**: excludes `examples/{exit_code,sleeper}` — their `inputs.mvm` resolves via `--override-input` in source-checkout mode, so no committed lock is appropriate (also fixes a latent `exit_code` failure on that release-only lane).
- **Drive-by test fix** (`crates/mvm-build/src/libkrun_builder.rs`, test-only): adds the `DegradedBuilderStore` environment-gap variant to the two `run_build_surfaces_environment_gaps_*` accepted-error unions, surfaced while running gates on a host with a degraded builder store.
- Rollup + sprint docs updated (`specs/REFACTOR-STATUS.md`, `specs/SPRINT.md`).

Live Vz bringup of `sleeper` + the fork semantic-A spike are a documented, non-gating follow-on (best-effort; gated on host Vz flakiness).

## Test Plan
- [x] `cargo fmt --all -- --check` clean
- [x] `cargo clippy --workspace -- -D warnings` — zero warnings
- [x] `cargo test -p xtask guest_init_detaches_workload_stdin_from_console` passes
- [x] `cargo nextest run --workspace -E 'not package(mvm-backend)'` green; `cargo test -p mvm-backend checkpoint::` green
- [x] `cargo test --workspace --doc` green
- [x] `check-no-spec-refs-in-comments` lint clean
- [ ] (follow-on, non-gating) live Vz bringup of `examples/sleeper` + WS-2 round-trips + fork semantic-A spike