### PR TITLE
feat(backend): port apple_container CoW per-instance rootfs onto VzBackend (Plan 177 Phase 2, PR1)

### DIFF
--- a/crates/mvm-backend/src/base/cow.rs
+++ b/crates/mvm-backend/src/base/cow.rs
@@ -13,7 +13,7 @@
 //! the clone's blocks and never touch the template.
 
 use std::io;
-use std::path::Path;
+use std::path::{Path, PathBuf};
 
 use anyhow::{Context, Result};
 
@@ -186,6 +186,50 @@ fn libc_eopnotsupp() -> i32 {
     libc::ENOTSUP
 }
 
+/// Per-instance rootfs path for `vm_name`: `<vm_state_dir>/rootfs.ext4`. Each
+/// running VM owns its own writable copy so the hypervisor can attach it
+/// writable without conflicting with sibling instances, and the source template
+/// stays pristine. Shared by every backend that needs per-instance ownership
+/// (Plan 53 Plan D / Plan 177 AVF convergence).
+pub fn instance_rootfs_path(vm_name: &str) -> Result<PathBuf> {
+    Ok(mvm_core::config::vm_state_dir(vm_name).join("rootfs.ext4"))
+}
+
+/// Materialize the per-instance rootfs for `vm_name` from `source_rootfs` and
+/// return its absolute path. No-op if the source is already the per-instance
+/// path (a re-start). Otherwise removes any stale per-instance file from a prior
+/// failed run, then CoW-clones the source via [`clone_rootfs_for_instance`].
+pub fn prepare_instance_rootfs(vm_name: &str, source_rootfs: &str) -> Result<PathBuf> {
+    let instance_path = instance_rootfs_path(vm_name)?;
+    prepare_instance_rootfs_inner(&instance_path, source_rootfs)
+}
+
+/// Inner implementation that takes the instance path directly, so tests don't
+/// mutate `HOME` / `MVM_DATA_DIR`.
+pub fn prepare_instance_rootfs_inner(instance_path: &Path, source_rootfs: &str) -> Result<PathBuf> {
+    let source_path = Path::new(source_rootfs);
+    if source_path == instance_path {
+        // Already the per-instance copy — nothing to clone.
+        return Ok(instance_path.to_path_buf());
+    }
+    if instance_path.exists() {
+        std::fs::remove_file(instance_path).with_context(|| {
+            format!(
+                "removing stale per-instance rootfs at {}",
+                instance_path.display()
+            )
+        })?;
+    }
+    let strategy = clone_rootfs_for_instance(source_path, instance_path)?;
+    tracing::info!(
+        ?strategy,
+        source = %source_path.display(),
+        instance = %instance_path.display(),
+        "prepared per-instance rootfs",
+    );
+    Ok(instance_path.to_path_buf())
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -202,6 +246,29 @@ mod tests {
         assert!(is_unsupported(&einval));
         assert!(is_unsupported(&enotty));
         assert!(!is_unsupported(&other));
+    }
+
+    #[test]
+    fn prepare_instance_rootfs_inner_clones_into_the_per_instance_path() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let src = dir.path().join("golden.ext4");
+        std::fs::write(&src, b"golden").unwrap();
+        let instance = dir.path().join("inst").join("rootfs.ext4");
+        let out = prepare_instance_rootfs_inner(&instance, src.to_str().unwrap()).expect("clone");
+        assert_eq!(out, instance);
+        assert!(instance.exists());
+        // Writing the per-instance clone must not tamper the source template.
+        std::fs::write(&instance, b"changed").unwrap();
+        assert_eq!(std::fs::read(&src).unwrap(), b"golden");
+    }
+
+    #[test]
+    fn prepare_instance_rootfs_inner_is_noop_when_source_is_the_instance() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let inst = dir.path().join("rootfs.ext4");
+        std::fs::write(&inst, b"x").unwrap();
+        let out = prepare_instance_rootfs_inner(&inst, inst.to_str().unwrap()).expect("noop");
+        assert_eq!(out, inst);
     }
 
     /// On macOS with an APFS-backed `TMPDIR` (the default), `clonefile`

--- a/crates/mvm-backend/src/base/cow.rs
+++ b/crates/mvm-backend/src/base/cow.rs
@@ -189,8 +189,7 @@ fn libc_eopnotsupp() -> i32 {
 /// Per-instance rootfs path for `vm_name`: `<vm_state_dir>/rootfs.ext4`. Each
 /// running VM owns its own writable copy so the hypervisor can attach it
 /// writable without conflicting with sibling instances, and the source template
-/// stays pristine. Shared by every backend that needs per-instance ownership
-/// (Plan 53 Plan D / Plan 177 AVF convergence).
+/// stays pristine. Shared by every backend that needs per-instance ownership.
 pub fn instance_rootfs_path(vm_name: &str) -> Result<PathBuf> {
     Ok(mvm_core::config::vm_state_dir(vm_name).join("rootfs.ext4"))
 }

--- a/crates/mvm-backend/src/vz.rs
+++ b/crates/mvm-backend/src/vz.rs
@@ -232,12 +232,11 @@ impl VmBackend for VzBackend {
         mvm_build::builder_vm::admit_overlay_aware(rootfs_dir)?;
         crate::base::runtime_meta::record_from_rootfs(&config.name, StartMode::Detached, rootfs)?;
 
-        // Per-instance rootfs (Plan 53 Plan D / Plan 177 AVF convergence). A
-        // non-verity image gets a CoW clone so each VM owns a *writable* root —
-        // pristine template, multi-instance isolation, and the foundation the
-        // checkpoint/fork/warm-pool features build on. A verity/sealed image
-        // stays the read-only golden rootfs (dm-verity requires an immutable,
-        // read-only backing). APFS CoW makes the clone O(1).
+        // A non-verity image gets a CoW clone so each VM owns a writable root:
+        // pristine template, multi-instance isolation, and a clean substrate
+        // for features that require per-instance disk ownership. A verity/sealed
+        // image stays on the read-only golden rootfs because dm-verity requires
+        // an immutable backing. APFS CoW makes the clone O(1).
         let sealed = config.verity_path.is_some();
         let mut launch_config = config.clone();
         if !sealed {
@@ -247,15 +246,15 @@ impl VmBackend for VzBackend {
                     .into_owned();
         }
 
-        // Plan 102 W6.A.5 — spawn host-side gvproxy so the supervisor has
-        // something to connect to. VzBackend is stateless; the child is detached
+        // Spawn host-side gvproxy so the supervisor has something to connect to.
+        // VzBackend is stateless; the child is detached
         // (PID file under state dir lets `stop()` find it later).
         let gvproxy_info = host_gvproxy::spawn_detached(&state_dir)
             .map_err(|e| anyhow!("spawn host-side gvproxy for Vz VM '{}': {e}", config.name))?;
 
         // Vz config build. The `?` propagates allowlist failures from
-        // `audit_substrate::compute_audit_substrate` (unsafe tenant_id
-        // / vm_name) — see Plan 112 Phase 3c.
+        // `audit_substrate::compute_audit_substrate` for unsafe tenant_id /
+        // vm_name values.
         let mut cfg = build_supervisor_config(&launch_config, kernel, &state_dir, &gvproxy_info)?;
         // Attach the rootfs writable for the per-instance clone; verity/sealed
         // stays read-only (the builder defaults read-only).
@@ -1202,7 +1201,7 @@ fn vz_cmdline_with_user_volumes(config: &VmStartConfig) -> String {
 
 /// Best-effort removal of the per-instance rootfs clone on teardown. A verity
 /// VM never created one (it ran the read-only golden), so a missing file is
-/// normal. Mirrors the Apple-container path's cleanup (Plan 53 Plan D).
+/// normal. Mirrors the Apple-container path's cleanup.
 fn remove_instance_rootfs(vm_name: &str) {
     if let Ok(path) = crate::base::cow::instance_rootfs_path(vm_name)
         && path.exists()

--- a/crates/mvm-backend/src/vz.rs
+++ b/crates/mvm-backend/src/vz.rs
@@ -224,21 +224,44 @@ impl VmBackend for VzBackend {
         // Record runtime metadata so `mvmctl console` / status RPCs
         // can find the artifacts after start. Matches the libkrun path
         // line-for-line.
+        // The admission gate + runtime_meta read the *source* (golden) rootfs
+        // sidecar; the per-instance clone below is a CoW copy under a different
+        // name, so its sidecar lives next to the source.
         let rootfs = Path::new(&config.rootfs_path);
         let rootfs_dir = rootfs.parent().unwrap_or_else(|| Path::new("."));
         mvm_build::builder_vm::admit_overlay_aware(rootfs_dir)?;
         crate::base::runtime_meta::record_from_rootfs(&config.name, StartMode::Detached, rootfs)?;
 
-        // Spawn host-side gvproxy so the Swift supervisor has something
-        // to connect to. VzBackend is stateless; the child is detached
+        // Per-instance rootfs (Plan 53 Plan D / Plan 177 AVF convergence). A
+        // non-verity image gets a CoW clone so each VM owns a *writable* root —
+        // pristine template, multi-instance isolation, and the foundation the
+        // checkpoint/fork/warm-pool features build on. A verity/sealed image
+        // stays the read-only golden rootfs (dm-verity requires an immutable,
+        // read-only backing). APFS CoW makes the clone O(1).
+        let sealed = config.verity_path.is_some();
+        let mut launch_config = config.clone();
+        if !sealed {
+            launch_config.rootfs_path =
+                crate::base::cow::prepare_instance_rootfs(&config.name, &config.rootfs_path)?
+                    .to_string_lossy()
+                    .into_owned();
+        }
+
+        // Plan 102 W6.A.5 — spawn host-side gvproxy so the supervisor has
+        // something to connect to. VzBackend is stateless; the child is detached
         // (PID file under state dir lets `stop()` find it later).
         let gvproxy_info = host_gvproxy::spawn_detached(&state_dir)
             .map_err(|e| anyhow!("spawn host-side gvproxy for Vz VM '{}': {e}", config.name))?;
 
         // Vz config build. The `?` propagates allowlist failures from
         // `audit_substrate::compute_audit_substrate` (unsafe tenant_id
-        // / vm_name).
-        let cfg = build_supervisor_config(config, kernel, &state_dir, &gvproxy_info)?;
+        // / vm_name) — see Plan 112 Phase 3c.
+        let mut cfg = build_supervisor_config(&launch_config, kernel, &state_dir, &gvproxy_info)?;
+        // Attach the rootfs writable for the per-instance clone; verity/sealed
+        // stays read-only (the builder defaults read-only).
+        if !sealed && let Some(disk) = cfg.disks.iter_mut().find(|d| d.id == "rootfs") {
+            disk.read_only = false;
+        }
 
         // Spawn the `mvm-vz-drainer` sibling between gvproxy and the Vz
         // VM boot. Closes the Vz audit carve-out: the drainer binds
@@ -378,6 +401,7 @@ impl VmBackend for VzBackend {
                 id.0
             ));
             let _ = std::fs::remove_file(&pid_path);
+            remove_instance_rootfs(&id.0);
             return Ok(());
         }
 
@@ -402,6 +426,7 @@ impl VmBackend for VzBackend {
         }
 
         let _ = std::fs::remove_file(&pid_path);
+        remove_instance_rootfs(&id.0);
 
         // Tear down the host-side gvproxy spawned by `start()`.
         // Best-effort: the supervisor stop
@@ -1173,6 +1198,22 @@ fn vz_cmdline_with_user_volumes(config: &VmStartConfig) -> String {
         cmdline.push_str(&uvols);
     }
     cmdline
+}
+
+/// Best-effort removal of the per-instance rootfs clone on teardown. A verity
+/// VM never created one (it ran the read-only golden), so a missing file is
+/// normal. Mirrors the Apple-container path's cleanup (Plan 53 Plan D).
+fn remove_instance_rootfs(vm_name: &str) {
+    if let Ok(path) = crate::base::cow::instance_rootfs_path(vm_name)
+        && path.exists()
+        && let Err(e) = std::fs::remove_file(&path)
+    {
+        tracing::warn!(
+            path = %path.display(),
+            error = %e,
+            "failed to remove per-instance rootfs clone"
+        );
+    }
 }
 
 fn build_supervisor_config(


### PR DESCRIPTION
First PR of Plan 177 **Phase 2** (AVF convergence, ADR-076 — gate cleared by Plan 152 WS-B + #740). Tasks 6+7.

## Task 6 — delta audit
Of the three behaviors ADR-076 said to port from `apple_container` onto `VzBackend`:
- `admit_overlay_aware` — already in `vz.rs`.
- `runtime_meta` recording — already in `vz.rs`.
- **CoW per-instance rootfs clone — the real gap** (and a core capability, not something to descope).

Notably, `vz`'s `read_only: true` rootfs was a *workaround* for not cloning per-instance (Apple VZ refuses one writable disk shared across VMs), **not** a sealed-image choice — `vz` doesn't do dm-verity (ADR-056: claim 3 DoesNotHold for `vz`).

## Task 7 — port
- Lift `prepare_instance_rootfs` / `instance_rootfs_path` into shared **`base::cow`** (with tests) — the per-instance-ownership seam any backend reuses.
- **`VzBackend::start`** CoW-clones the rootfs per instance and attaches it **writable for non-verity** images: pristine template, multi-instance isolation, and the foundation the **checkpoint/fork/warm-pool** features build on (Plan 159, which already uses `clone_rootfs_for_instance`). **Verity/sealed** images keep the read-only golden rootfs (dm-verity needs an immutable backing). APFS CoW makes the clone O(1).
- **`VzBackend::stop`** removes the per-instance clone (mirrors `apple_container`).

`apple_container.rs` is intentionally **left untouched** — its now-redundant private copies of these helpers are removed wholesale in **Task 9** (the next PR, which deletes the file). Keeps this PR focused and minimizes edits in a crate whose tests can't run locally.

## Verification
- Local: nightly `fmt --check`, `cargo build -p mvm-backend`, `cargo clippy -p mvm-backend -- -D warnings` — all clean.
- The `mvm-backend` test binary SIGKILLs locally (macOS codesign/amfid), so the new `base::cow` tests run on **Linux CI**.
- **Recommended live check:** a hardware `mvmctl up` on macOS-26 (`--backend vz`) to confirm the writable per-instance rootfs boots + that two concurrent VMs from one template don't conflict.

## Next in Phase 2
- **PR2 — Task 8:** shared libkrun+vz supervisor console transport (preserve claim 15).
- **PR3 — Task 9+10:** delete `apple_container`, flip `vz` to macOS-26 auto-default, repoint `auto_select`/`from_hypervisor`, docs.