### PR TITLE
fix(firecracker): make the guest agent reachable on live FC boots

### DIFF
--- a/crates/mvm-backend/src/microvm.rs
+++ b/crates/mvm-backend/src/microvm.rs
@@ -374,6 +374,21 @@ fn configure_microvm(state: &MvmState, abs_dir: &str) -> Result<()> {
         ),
     )?;
 
+    // The host-side vsock transport resolves the UDS via `vsock_uds_path`
+    // = `<instance_dir>/runtime/v.sock` (the convention the template/slot
+    // launch and the mock agent also use), but Firecracker binds the UDS
+    // one level up at `<instance_dir>/v.sock`. Expose it under `runtime/`
+    // too — a dangling symlink now, live once InstanceStart binds the
+    // socket. Without this, `wait_for_guest_agent` probes one directory
+    // too deep and every Firecracker boot reports "guest agent not
+    // reachable" even though the agent is up.
+    if let Err(e) = run_in_vm(&format!(
+        "mkdir -p {dir}/runtime && ln -sf ../v.sock {dir}/runtime/v.sock",
+        dir = abs_dir,
+    )) {
+        warn!("failed to expose vsock UDS under runtime/: {e}");
+    }
+
     Ok(())
 }
 

--- a/crates/mvm-backend/src/microvm.rs
+++ b/crates/mvm-backend/src/microvm.rs
@@ -156,6 +156,19 @@ pub fn resolve_running_vm_dir(name: &str) -> Result<String> {
     Ok(format!("{}/{}", abs_vms, name))
 }
 
+/// Firecracker binds the vsock UDS at `<dir>/v.sock`, but the host-side
+/// transport resolves it via `vsock_uds_path` = `<dir>/runtime/v.sock`
+/// (the convention the template/slot launch and the mock agent share).
+/// Expose the socket under `runtime/` so `wait_for_guest_agent` finds it.
+/// Best-effort; a dangling symlink until InstanceStart binds the socket.
+fn expose_vsock_runtime_symlink(dir: &str) {
+    if let Err(e) = run_in_vm(&format!(
+        "mkdir -p {dir}/runtime && ln -sf ../v.sock {dir}/runtime/v.sock"
+    )) {
+        warn!("failed to expose vsock UDS under runtime/: {e}");
+    }
+}
+
 /// Resolve the path to the per-VM serial console log file.
 ///
 /// The host-side netinit-audit emitter
@@ -374,20 +387,7 @@ fn configure_microvm(state: &MvmState, abs_dir: &str) -> Result<()> {
         ),
     )?;
 
-    // The host-side vsock transport resolves the UDS via `vsock_uds_path`
-    // = `<instance_dir>/runtime/v.sock` (the convention the template/slot
-    // launch and the mock agent also use), but Firecracker binds the UDS
-    // one level up at `<instance_dir>/v.sock`. Expose it under `runtime/`
-    // too — a dangling symlink now, live once InstanceStart binds the
-    // socket. Without this, `wait_for_guest_agent` probes one directory
-    // too deep and every Firecracker boot reports "guest agent not
-    // reachable" even though the agent is up.
-    if let Err(e) = run_in_vm(&format!(
-        "mkdir -p {dir}/runtime && ln -sf ../v.sock {dir}/runtime/v.sock",
-        dir = abs_dir,
-    )) {
-        warn!("failed to expose vsock UDS under runtime/: {e}");
-    }
+    expose_vsock_runtime_symlink(abs_dir);
 
     Ok(())
 }
@@ -2072,6 +2072,7 @@ pub fn configure_flake_microvm_with_drives_dir(
             dir = drives_dir,
         ),
     )?;
+    expose_vsock_runtime_symlink(drives_dir);
 
     // Virtio-balloon. Only attached when the workload opted in via
     // `mem_initial`. The device boots pre-inflated to `memory -

--- a/crates/mvm-guest/src/vsock.rs
+++ b/crates/mvm-guest/src/vsock.rs
@@ -1886,7 +1886,13 @@ fn try_connect_once(uds_path: &str, port: u32, timeout_secs: u64) -> Result<Unix
     let timeout = Duration::from_secs(timeout_secs);
 
     // Pre-flight: verify the socket file exists and is actually a socket.
-    match std::fs::symlink_metadata(uds_path) {
+    // Follow symlinks (`metadata`, not `symlink_metadata`): both the
+    // Firecracker default-image and template launch paths expose the vsock
+    // UDS at `<dir>/runtime/v.sock` as a symlink to the socket Firecracker
+    // actually binds, so the pre-flight must resolve through it — otherwise
+    // it sees the symlink's own file type and wrongly rejects a connectable
+    // socket.
+    match std::fs::metadata(uds_path) {
         Err(e) => bail!("Vsock socket not found at {}: {}", uds_path, e),
         Ok(m) if !m.file_type().is_socket() => {
             bail!(

--- a/specs/REFACTOR-STATUS.md
+++ b/specs/REFACTOR-STATUS.md
@@ -40,11 +40,16 @@ PLAN 129 — Secrets / SigV4 substitution         🟢 declared + undeclared (bo
   [x] redirect mechanism box-validated: nft prerouting iifname<tap> REDIRECT + SO_ORIGINAL_DST (Task 0')
   [x] FC wiring: EgressRedirect (nft TAP redirect) + wire_egress_substitution + stop_vm reap — Task 5 — PR #744 (merged)
       (mechanism corrected: FC=TAP+nft NAT, not passt/skuid; passt path deferred to libkrun)
-  [ ] live SDK-free FC box e2e — Task 6 — DEFERRED to a bringup/debug session
+  [ ] live SDK-free FC box e2e — Task 6 — in progress on the dev-kvm box.
       (prompt: specs/prompts/129-fc-bringup-debug.md). Kernel blocker (published
       x86_64 bzImage→ELF vmlinux, #746) FIXED — PR #763 (mvm_build::fc_kernel
-      auto-extracts at boot); local secret-launch glue DONE (#745). Remaining
-      gate: FC guest-agent reachability (live-debug on the dev-kvm box)
+      auto-extracts at boot); local secret-launch glue DONE (#745). FC
+      guest-agent reachability FIXED + box-validated (`up` exit 0): the host
+      transport resolved the vsock UDS at <dir>/runtime/v.sock but FC bound it
+      at <dir>/v.sock, and the connect pre-flight rejected symlinked UDSes
+      (symlink_metadata) — fixed by exposing the UDS under runtime/ + making
+      the pre-flight follow symlinks (also fixes the template path's symlink).
+      Remaining: run the secret-substitution egress e2e itself.
   [x] Stage 2 S2.1–S2.6: name-constrained per-VM CA (crypto::egress_ca) + host
       cert/key split + kernel-cmdline cert + placeholder-env delivery (mvm.egress_ca /
       mvm.secret_env) + SNI-gated TLS terminator (terminate bound / splice unbound,


### PR DESCRIPTION
## Problem
On a real `/dev/kvm` Firecracker boot, `mvmctl up --hypervisor firecracker` always failed with **"guest agent not reachable within 30s"** and auto-stopped the VM — even though the guest agent was up and listening on vsock 5252.

## Root cause (two bugs, both latent until a live FC boot)
1. **Wrong UDS path.** The host transport resolves the agent UDS via `vsock_uds_path` = `<instance_dir>/runtime/v.sock` (the convention the template/slot launch and the mock agent share), but the default-image FC config binds it at `<instance_dir>/v.sock` — one level up. So `wait_for_guest_agent` probed a path that didn't exist.
2. **Pre-flight rejected symlinks.** `try_connect_once` used `std::fs::symlink_metadata` (lstat) for its `is_socket` pre-flight, so a UDS exposed as a *symlink* was rejected as "not a socket" before any connect — which also silently broke the **template path** (microvm.rs already symlinks `{runtime_dir}/v.sock`).

## Fix
- Expose the FC vsock UDS under `runtime/` via a shared `expose_vsock_runtime_symlink` helper, called from both `/vsock` config sites.
- Make the connect pre-flight follow symlinks (`metadata`, not `symlink_metadata`).

## Validation
Confirmed on the dev-KVM box: agent listens on 5252; before the fix a manual vsock `CONNECT` returned `OK` but the Rust transport bailed at the pre-flight; **after the fix `mvmctl up --hypervisor firecracker` returns exit 0 — agent reachable**. This unblocks the Plan 129 live SDK-free egress e2e.