### PR TITLE
docs(plan-129): record clean-room recipe e2e (QEMU green) + FC-leg follow-ups

### DIFF
--- a/specs/REFACTOR-STATUS.md
+++ b/specs/REFACTOR-STATUS.md
@@ -23,7 +23,7 @@ details** below for the workstream-level state.
 - [x] **PLAN 170** — Host lifecycle convergence · ✅ mvm-side (density → mvmd)
 - [x] **PLAN 153** — CLI directory split · ✅ (subsumed into Plan 178)
 - [x] **PLAN 178** — CLI surface consolidation (~56→~28) · ✅ (dir-purity deferred)
-- [ ] **PLAN 129** — Secrets / SigV4 substitution · 🟢 declared + undeclared landed; SigV4/HMAC forward-path signing landed (bind-checked, key-never-leaves); FC agent reachability fixed (#793) — live FC egress e2e is the remaining step
+- [ ] **PLAN 129** — Secrets / SigV4 substitution · 🟢 clean-room recipe e2e GREEN on QEMU (real key at httpbin, placeholder-only guest, 2026-06-11); SigV4/HMAC forward-path signing landed (bind-checked, key-never-leaves); FC leg blocked: endpoint spawn is qemu-only + FC flake-kernel gap
 - [ ] **PLAN 152** — Rust-native VZ supervisor · 🟢 native objc2, Swift deleted; WS-C/D separate workstreams
 - [ ] **PLAN 159** — vz-inspired macOS VZ DX · 🟡 warm pool + checkpoint/fork shipped; WS-5 D + delta-image remain
 - [ ] **PLAN 123** — Network / storage / warm-start · 🟢 Phase A/B done; C2/C3 (FC/Vz warm-start) gated
@@ -42,7 +42,7 @@ PLAN 169 — Backend-agnostic agent RPC           ✅ DONE
 PLAN 166 — QEMU Linux dev/test backend          ✅ DONE (Phase 2)
 PLAN 165 — Sealed-prod interactivity (claim 15) ✅ DONE
 
-PLAN 129 — Secrets / SigV4 substitution         🟢 declared + undeclared (box-validated on QEMU); SDK-free http terminator (#735/#744) + Stage 2 https/name-constrained-CA (#761) landed; FC kernel blocker fixed (#763); FC guest-agent reachability fixed + box-validated (#793) — live FC egress e2e is the remaining step
+PLAN 129 — Secrets / SigV4 substitution         🟢 clean-room recipe e2e GREEN on QEMU 2026-06-11 (secret set → build compile → up → invoke --attach; httpbin reflects the real key, guest holds placeholder only); SDK-free http terminator (#735/#744) + Stage 2 https/name-constrained-CA (#761) landed; FC boots (#793) but its egress leg is blocked: endpoint spawn is qemu-only (`should_thread_signed_plan`) + FC flake-kernel gap — see plan §"Deferred follow-ups"
   [x] keyholder, resolver, binding store, `secret set`
   [x] host substitution endpoint (UDS + AF_VSOCK)
   [x] SigV4 canonical-request builder
@@ -65,16 +65,19 @@ PLAN 129 — Secrets / SigV4 substitution         🟢 declared + undeclared (bo
   [x] redirect mechanism box-validated: nft prerouting iifname<tap> REDIRECT + SO_ORIGINAL_DST (Task 0')
   [x] FC wiring: EgressRedirect (nft TAP redirect) + wire_egress_substitution + stop_vm reap — Task 5 — PR #744 (merged)
       (mechanism corrected: FC=TAP+nft NAT, not passt/skuid; passt path deferred to libkrun)
-  [ ] live SDK-free FC box e2e — Task 6 — in progress on the dev-kvm box.
-      (prompt: specs/prompts/129-fc-bringup-debug.md). Kernel blocker (published
-      x86_64 bzImage→ELF vmlinux, #746) FIXED — PR #763 (mvm_build::fc_kernel
-      auto-extracts at boot); local secret-launch glue DONE (#745). FC
-      guest-agent reachability FIXED + box-validated (`up` exit 0): the host
-      transport resolved the vsock UDS at <dir>/runtime/v.sock but FC bound it
-      at <dir>/v.sock, and the connect pre-flight rejected symlinked UDSes
-      (symlink_metadata) — fixed by exposing the UDS under runtime/ + making
-      the pre-flight follow symlinks (also fixes the template path's symlink).
-      Remaining: run the secret-substitution egress e2e itself.
+  [ ] live SDK-free FC box e2e — Task 6 — clean-room recipe e2e ran 2026-06-11
+      (prompt: specs/prompts/129-fc-bringup-debug.md). QEMU leg GREEN end-to-end:
+      `secret set` → `build compile` (artifacts clean of the value) → `up`
+      (endpoint spawned, guest env = placeholder only) → `invoke --attach`
+      (httpbin reflects `Bearer REALKEY-…`, the real credential). FC leg: boots
+      (#793) but spawns NO endpoint — `should_thread_signed_plan` threads the
+      plan onto the backend config only for qemu, so FC never sees plan_json;
+      plus mkGuest flake builds emit no vmlinux and the FC boot path assumes
+      `{build_dir}/vmlinux` (hand-staged bzImage as box workaround). Both
+      recorded as plan-129 deferred follow-ups, with two more: the spawned
+      endpoint runs without the audit Recorder (no `secret.substituted` entry
+      in a live run), and `invoke`'s empty-stdin default violates the
+      `[args, kwargs]` wire contract.
   [x] Stage 2 S2.1–S2.6: name-constrained per-VM CA (crypto::egress_ca) + host
       cert/key split + kernel-cmdline cert + placeholder-env delivery (mvm.egress_ca /
       mvm.secret_env) + SNI-gated TLS terminator (terminate bound / splice unbound,

--- a/specs/plans/129-secrets-subsystem.md
+++ b/specs/plans/129-secrets-subsystem.md
@@ -128,11 +128,62 @@ endpoint validation above**); this ties them on a real QEMU guest.
    >   substitute → real http forward → destination echo — is validated on a live
    >   QEMU guest.** "A raw secret never enters the microVM" is proven end-to-end.
 
+### Clean-room recipe e2e (2026-06-11, dev-kvm)
+
+The full **user-facing recipe** was re-proven from a fresh isolated env
+(`MVM_DATA_DIR`/`MVM_CACHE_DIR` clean-room) on the box, using only the
+documented verbs — no test harness, no pre-seeded state:
+
+1. `mvmctl secret set echo-key --host httpbin.org --type bearer --value -`
+   (marker `REALKEY-7f3a9c2e`) → `secret.set` audited, write-only, encrypted
+   at rest.
+2. `mvmctl build compile examples/python/secret-egress/app.py --out <dir>` →
+   artifacts carry the `API_KEY → echo-key` binding and are **clean of the
+   real value** (grep-verified).
+3. `mvmctl up --hypervisor qemu --flake <dir>` → plan admitted with secrets,
+   `mvm-substitution-endpoint` spawned, guest env holds **only**
+   `API_KEY=mvm-secret-<hex>` (`substitution-env.json` verified).
+4. `echo "[[], {}]" | mvmctl invoke <vm> --attach --stdin -` → httpbin.org
+   reflects `"Authorization": "Bearer REALKEY-7f3a9c2e"` (the **real**
+   credential, real external destination over the internet) while the guest
+   never held it. Audit chain carries the full
+   `plan.admitted → plan.launched → cmd.invoke.completed` lifecycle.
+
+The same recipe on `--hypervisor firecracker` boots (after #793) but spawns
+**no endpoint** — see the new follow-ups below.
+
 ### Deferred follow-ups (surfaced by the local-launch e2e)
 
 - [x] **SSRF resolver hardcodes port 443 → broke http egress forwards** —
       FIXED in PR #755 (forwarder resolves + SSRF-filters itself, pins the safe
       IPs on the URL's real port via `resolve_to_addrs`). This closed the e2e.
+- [ ] **FC endpoint gap, precisely located:** `should_thread_signed_plan`
+      (`mvm-cli/src/commands/vm/up.rs`) threads the admitted plan onto the
+      backend config only for `qemu` (or `MVM_GATEWAY_BRIDGE=1`), and the
+      endpoint spawn keys off `config.plan_json` — so Firecracker can never
+      spawn the substitution endpoint today. Closing it = thread the plan for
+      `firecracker` + add an FC endpoint-spawn arm (terminator-backend
+      decision: QEMU→passt vs FC).
+- [ ] **FC `up --flake` workload-kernel gap:** mkGuest flake builds emit only
+      `rootfs.ext4`; the FC boot path assumes `{build_dir}/vmlinux` exists and
+      fails with `preparing FC-loadable kernel … No such file or directory`.
+      `--kernel-source download` feeds only the Stage-0 builder, not the
+      workload boot. (libkrun materializes its bundled kernel centrally; QEMU
+      boots the downloaded bzImage.) FC needs the same central
+      kernel-resolution fallback. Box workaround: hand-stage the
+      default-microvm bzImage into the build dir (`ensure_fc_loadable_kernel`
+      extracts the ELF from it).
+- [ ] **Per-substitution audit not wired in the spawned endpoint:** the
+      `SubstitutionService` audit `Recorder` (`secret.substituted` /
+      `placeholder_dropped`) is optional, and the per-VM endpoint `up` spawns
+      runs without it — a live substituting invoke leaves no substitution
+      event in the chain-signed log. Wire the Recorder into the spawn path.
+- [ ] **`invoke` empty-stdin default violates the wire contract:** default
+      stdin is empty, but the wrapper requires a JSON `[args, kwargs]`
+      payload → a bare `invoke --attach` fails with `JSONDecodeError`. Default
+      to `[[], {}]` when no stdin is given (and fix the stale
+      `mvmctl compile` → `mvmctl build compile` docstring in
+      `examples/python/secret-egress/app.py`).
 - [ ] **Forward proxy + `https`/`CONNECT`** — standard clients tunnel `https`
       through `HTTP_PROXY` via `CONNECT`, hiding headers from the proxy, so
       substitution only works for `http`/absolute-form today. TLS-destination


### PR DESCRIPTION
## What

Records the 2026-06-11 dev-kvm clean-room validation of the Plan 129 egress-substitution recipe, and the four follow-ups it surfaced.

**QEMU leg — GREEN end-to-end with the documented verbs only:**
1. `secret set echo-key --host httpbin.org --type bearer` (marker key)
2. `build compile` — artifacts carry the binding, clean of the real value
3. `up --hypervisor qemu --flake <out>` — endpoint spawned, guest env = `mvm-secret-<hex>` placeholder only
4. `invoke --attach` — httpbin.org reflects `Authorization: Bearer REALKEY-…` (the real credential) from a guest that never held it

**FC leg — boots (#793) but cannot substitute today.** New deferred follow-ups recorded in the plan doc:
- `should_thread_signed_plan` threads the plan onto the backend config only for qemu → FC never spawns the endpoint
- FC `up --flake` workload-kernel gap: mkGuest emits no vmlinux; FC boot path assumes `{build_dir}/vmlinux`
- spawned endpoint runs without the audit Recorder → no `secret.substituted` entry in a live run
- `invoke` empty-stdin default violates the `[args, kwargs]` wire contract

Docs only; REFACTOR-STATUS glance + detail synced in the same change.