### PR TITLE
docs: Plan 183 — builder-VM egress posture + guest network bootstrap

### DIFF
--- a/specs/REFACTOR-STATUS.md
+++ b/specs/REFACTOR-STATUS.md
@@ -31,6 +31,7 @@ details** below for the workstream-level state.
 - [ ] **PLAN 126** — Dependency reduction · 🟡 ~25%; sigstore/aws-lc/lock-gate remain
 - [ ] **PLAN 177** — Backend consolidation (8→4) · 🟡 Phase 1 done; Phase 2 (AVF convergence) in progress
 - [ ] **PLAN 175** — Firecracker live-memory warm-start · 🔴 not started (live-KVM-gated)
+- [ ] **PLAN 183** — Builder-VM egress posture + network bootstrap · 🔴 diagnosed + plan landed; blocks every cold/new-dep macOS flake build
 - [x] **PLAN 180** — Strip spec refs from code comments · ✅ (lint-gated, #786)
 
 ## Plan details
@@ -202,6 +203,24 @@ PLAN 159 — vz-inspired macOS VZ DX               🟡 152-independent slice sh
       hoisted to mvm_hostd::audit (mvmd-reachable library API); mvm-cli shimmed
   [ ] WS-5 D verb renames; curl|sh installer; --json remainder
   [ ] signed delta-image distribution (unowned — needs a home)
+  [ ] live Vz WS-2 round-trip validation + fork semantic-A spike — BLOCKED on
+      Plan 183 (builder-VM egress lockdown breaks every uncached flake build)
+
+PLAN 183 — Builder-VM egress posture + net boot 🔴 diagnosed; plan landed
+  Diagnosis proven 2026-06-11 (controlled A/B in one dev-up run: Stage 0
+  fetched the full closure; the builder VM minutes later could not resolve):
+  boot-time install_egress_lockdown (OUTPUT DROP, proxy-uid-only) applies to
+  the whole builder VM and drops every nix fetch — active since iptables-legacy
+  landed (f184b17d, 2026-06-05); the dev-tier skip is QEMU-only. Plus: Vz
+  builder gets no DHCP lease (eth0 unconfigured), and /etc/resolv.conf is a
+  read-only baked file so leased DNS never lands.
+  [ ] WS-A egress posture per arm (boot open; install-arm locked, fail-closed;
+      per-job posture in persistent dispatch; drop QEMU-only boot skip)
+  [ ] WS-B Vz DHCP no-lease: static gvproxy fallback (shared stage0 ioctl
+      helpers) + time-boxed datagram-path root cause
+  [ ] WS-C writable /run-bind-mounted resolv.conf seeded with gateway resolver
+  [ ] WS-D cold E2E proof on macOS + claim-11 install gate still locked +
+      resume Plan 159 live Vz validation
 
 PLAN 124 — Lean guest agent                     🟡 ~65%
   [x] A1/A3 drop tokio+rtnetlink (-27 crates)

--- a/specs/SPRINT.md
+++ b/specs/SPRINT.md
@@ -2154,8 +2154,17 @@ Sealed-workload `/init` on Vz now detaches stdin from the input-less
 console (`< /dev/null`), closing the foot-gun where a workload's PID 1
 hit EOF ~5 s after boot and triggered a kernel reboot. `examples/sleeper`
 is the designated long-lived fixture for live Vz round-trip validation.
-Live bringup + fork semantic-A spike are the tracked next step (best-
-effort; gated on host Vz flakiness).
+
+The first live bringup attempt (2026-06-11) hit a different, pre-existing
+wall before boot: the builder VM's boot-time egress lockdown (OUTPUT DROP,
+proxy-uid-only — active since iptables-legacy landed on 2026-06-05) drops
+every nix fetch, so any cold or new-dep flake build on macOS fails with
+"Could not resolve host". Diagnosed end-to-end (Stage 0 fetches fine; the
+builder VM on the same host cannot resolve) and opened as **Plan 183**
+(`specs/plans/183-builder-vm-egress-posture-and-dns.md`): scope the
+lockdown to the install arm, add a static-gvproxy fallback for the Vz
+builder's DHCP no-lease, make resolv.conf writable. Live bringup + fork
+semantic-A spike resume as Plan 183 WS-D.
 
 ### Sprint 55 success criteria
 

--- a/specs/plans/183-builder-vm-egress-posture-and-dns.md
+++ b/specs/plans/183-builder-vm-egress-posture-and-dns.md
@@ -1,0 +1,262 @@
+# Plan 183 — Builder-VM egress posture + guest network bootstrap
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development
+> to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Unblock networked flake builds in the libkrun/Vz builder VM (broken since
+2026-06-05) by scoping the in-guest egress lockdown to the deps-install arm instead of
+the whole VM, and harden the builder guest's IP/DNS bootstrap (Vz DHCP no-lease,
+read-only resolv.conf).
+
+**Architecture:** Move `install_egress_lockdown` from PID-1 boot to the install-arm
+entry (and per-dispatch in the persistent loop), so the flake-build arm has nix's
+normal open egress while untrusted dep installs stay uid-locked. Add a static-IP
+fallback (gvproxy's fixed subnet) when DHCP yields no lease, and make
+`/etc/resolv.conf` writable via a `/run` bind-mount seeded with the per-backend
+gateway resolver.
+
+**Tech stack:** Rust (`mvm-build`: `mvm-host-vm-init`, `stage0-init`), iptables-legacy
+(x_tables), busybox udhcpc, gvproxy.
+
+---
+
+## Diagnosis (proven 2026-06-11 on the macOS-26 Vz/libkrun dev host)
+
+Every cold or new-dep `mvmctl up --flake` / `dev up` build on macOS fails with
+`Could not resolve host: …` inside the builder VM. Three independent defects, ranked:
+
+1. **Egress lockdown applies to the whole builder VM (primary).**
+   `mvm-host-vm-init`'s PID-1 boot sequence (`run()`,
+   `crates/mvm-build/src/bin/mvm-host-vm-init.rs:929`) installs
+   `network::install_egress_lockdown` — `OUTPUT` policy `DROP` with only
+   loopback + `PROXY_UID` accepts (`crates/mvm-build/src/bin/mvm-host-vm-init/network.rs:71-86`).
+   The inner `nix build` runs with no proxy env (the proxy path is install-pipeline
+   only), so every fetch — DNS first — is dropped. The rules existed earlier but
+   silently failed to install until `f184b17d` (2026-06-05) put `iptables-legacy` in
+   the rootfs (the kernel is x_tables); from the next image rebuild on, the lockdown
+   *actually applies*. It stayed masked while builds hit the promoted store; the first
+   build needing an uncached fetch (the guest agent's new TLS-CA crates) exposed it.
+   `53ea0859` (same day) added a dev-tier skip — but keyed on `mvm.backend=qemu`
+   only, and macOS has no QEMU tier: the macOS dev-tier builders are libkrun/Vz.
+   Controlled A/B from one `dev up` run: Stage 0 (no lockdown — `stage0-init`, not
+   `mvm-host-vm-init`) fetched the full builder-image closure from cache.nixos.org;
+   minutes later the builder VM on the same host could not resolve `github.com`.
+
+2. **Vz builder gets no DHCP lease (independent of 1).**
+   Vz builder console: `udhcpc: broadcasting discover` ×3 → `no lease, failing` →
+   `setup_network warning (non-fatal): udhcpc exit 1` → eth0 never configured → no
+   network at all. The libkrun builder on the same host leases `192.168.127.3` from
+   `192.168.127.1` fine, so gvproxy itself serves DHCP; the loss is specific to the
+   Vz supervisor's unixgram datagram path.
+
+3. **`/etc/resolv.conf` is read-only, so leased DNS never lands.**
+   libkrun builder console: busybox's in-store `default.script` →
+   `can't create /etc/resolv.conf: Read-only file system`. The rootfs mounts `ro`
+   and `/etc/resolv.conf` is a baked regular file (`nameserver 1.1.1.1`/`8.8.8.8`),
+   not the `/run` symlink `setup_network`'s comments assume
+   (`crates/mvm-build/src/bin/mvm-host-vm-init.rs:2185-2247`). The guest is pinned to
+   external resolvers instead of the gateway resolver the lease provides — masked
+   today by defect 1, but a correctness bug on its own (Stage 0 uses
+   `192.168.127.1`, proven; `stage0-init.rs:292-304`).
+
+Out of scope: mvmd's Firecracker/jailer builder (separate substrate), the QEMU
+builder's `ip=` autoconfig path (working, box-proven), gvproxy upstream changes.
+
+## Design decision — per-arm egress posture
+
+The lockdown's stated intent (builder flake comment, ADR-047/claim-11 context) is
+defense-in-depth for the **deps-install pipeline** — untrusted dependency code whose
+only legitimate egress is `mvm-egress-proxy`. The flake-build arm is nix fetching
+pinned sources/substitutes — its egress is nix's standard model and must be open.
+
+**Chosen:** install the lockdown at the **install-arm entry** (fail-closed), not at
+boot; in the persistent dispatch loop set the posture **per job kind** (install →
+locked, flake build → open). The QEMU-only boot skip becomes dead and is removed —
+one posture mechanism, no per-backend special case.
+
+**Rejected:** extending the `mvm.backend=qemu`-style boot skip to libkrun/Vz
+(tier-keyed whole-VM skip). That would unbreak flake builds but drop claim-11
+defense-in-depth for installs on macOS dev hosts, where deps sealing still runs.
+Per-arm posture keeps the lockdown exactly where the threat is.
+
+---
+
+## WS-A — egress posture per arm
+
+**Files:**
+- Modify: `crates/mvm-build/src/bin/mvm-host-vm-init/network.rs`
+- Modify: `crates/mvm-build/src/bin/mvm-host-vm-init.rs` (boot `run()` ~:900-960,
+  persistent dispatch ~:1628, `dev_tier_builder_from_cmdline` :185)
+- Modify: `crates/mvm-build/src/bin/mvm-host-vm-init/install.rs` (`run_install` :305)
+- Modify: `crates/mvm-build/src/qemu_builder.rs` (:142 cmdline — drop the now-unused
+  tier token only if nothing else consumes `mvm.backend=qemu`; verify with rg first)
+- Modify: `nix/images/builder-vm/flake.nix` (egress comment block ~:160)
+
+- [ ] **A1: add `open_egress` to `network.rs` with tests.** New function beside
+  `install_egress_lockdown`:
+
+  ```rust
+  /// Reset the OUTPUT chain to open egress for a trusted flake-build
+  /// dispatch. The inner `nix build` fetches substitutes and pinned
+  /// flake inputs directly (no proxy), so the chain must not filter it.
+  pub fn open_egress(runner: &dyn IptablesRunner) -> Result<(), String> {
+      runner.run(&["-F", "OUTPUT"])?;
+      runner.run(&["-P", "OUTPUT", "ACCEPT"])?;
+      Ok(())
+  }
+  ```
+
+  Tests (same `RecordingRunner` pattern as the existing module tests): exact
+  invocation sequence; first-call failure propagates.
+- [ ] **A2: remove the boot-time lockdown.** Delete the
+  `qemu_dev_tier`/`install_egress_lockdown` block from `run()`
+  (`mvm-host-vm-init.rs` ~:900-960) including the
+  `egress_error_indicates_no_netfilter` Stage-0 fallback branch it guards (keep the
+  helper only if the install-arm path still needs it — it does not: the steady-state
+  builder kernel carries netfilter, and the install arm must fail closed). Delete
+  `dev_tier_builder_from_cmdline` (:185) and its tests; it has no remaining callers.
+- [ ] **A3: lock at install-arm entry.** At the top of `run_install`
+  (`install.rs:305`), before the egress proxy spawn and any dep tooling runs:
+
+  ```rust
+  crate::network::install_egress_lockdown(
+      &crate::network::SystemIptables,
+      crate::network::PROXY_UID,
+  )
+  .map_err(InstallError::EgressLockdown)?;
+  ```
+
+  Add the `EgressLockdown(String)` variant to `InstallError` (fail-closed: a builder
+  whose kernel can't enforce the lockdown refuses install jobs). Unit-test via the
+  existing `run_install_with_fakes` seam (inject a failing runner → install refuses).
+- [ ] **A4: per-job posture in the persistent dispatch loop.** At the ~:1628
+  `reapply_egress_lockdown` site, set posture by job kind instead of
+  unconditionally re-locking: install dispatch → `reapply_egress_lockdown`,
+  flake-build dispatch → `open_egress`. Failure stays a hard refusal of the
+  dispatched job either way.
+- [ ] **A5: drop the QEMU boot-skip remnants + fix comments.** Remove the
+  `mvm.builder-tier` skip prose from the builder flake's egress comment block and
+  describe the per-arm posture instead. In `qemu_builder.rs:142` keep
+  `mvm.backend=qemu` only if `rg "mvm.backend"` shows another consumer (stage0's
+  backend detection does consume it — verify before touching).
+- [ ] **A6: gates.** `cargo fmt --all -- --check`,
+  `cargo clippy --workspace -- -D warnings`,
+  `cargo nextest run -p mvm-build`, then commit
+  `fix(builder-vm): scope egress lockdown to the install arm`.
+
+## WS-B — Vz builder DHCP no-lease + static-IP fallback
+
+**Files:**
+- Create: `crates/mvm-build/src/guest_net.rs` (shared in-guest ioctl helpers)
+- Modify: `crates/mvm-build/src/bin/stage0-init.rs` (:178-260 — re-export/reuse)
+- Modify: `crates/mvm-build/src/bin/mvm-host-vm-init.rs` (`setup_network` :2185)
+
+- [ ] **B1: lift stage0's static-config ioctls into a shared module.** Move
+  `configure_network_qemu`'s `ifreq_for` / `SIOCSIFADDR` / `SIOCSIFNETMASK` /
+  `SIOCADDRT` plumbing (`stage0-init.rs:178-260`) into
+  `mvm_build::guest_net::configure_static(iface, addr, netmask, gateway)`
+  (cfg-gated linux like the bins). stage0-init's QEMU arm calls it with
+  `10.0.2.15/24 via 10.0.2.2`; no behavior change there. Unit-test the pure parts
+  (address parsing/encoding) on the host.
+- [ ] **B2: static fallback in `setup_network`.** When udhcpc exits nonzero on a
+  gvproxy backend, fall back instead of warning-and-continuing:
+
+  ```rust
+  if !status.success() {
+      eprintln!(
+          "mvm-host-vm-init: udhcpc exit {} — falling back to static \
+           gvproxy addressing",
+          status.code().unwrap_or(-1)
+      );
+      mvm_build::guest_net::configure_static(
+          "eth0", "192.168.127.3", "255.255.255.0", "192.168.127.1",
+      )?;
+  }
+  ```
+
+  gvproxy's virtual subnet is fixed (`192.168.127.0/24`, gateway+resolver `.1`,
+  first DHCP client `.3`), and each builder VM has its own gvproxy instance, so the
+  static address cannot collide. This makes the Vz builder networked **now** without
+  waiting on the datagram-path root cause.
+- [ ] **B3: root-cause the Vz DHCP loss (investigation, time-boxed).** Reproduce with
+  `host_gvproxy::spawn_detached` + `-debug` (add the flag pass-through behind an env
+  var if absent), capture whether the DHCPDISCOVER frames reach gvproxy at all on
+  the Vz unixgram socket vs libkrun's. Suspects: vfkit handshake framing on the
+  supervisor's datagram attachment, MAC mismatch between the supervisor config and
+  gvproxy's lease table. Outcome: either a fix in `vz_builder.rs` /
+  `mvm-vz-supervisor`, or a documented defer with the static fallback as the
+  steady-state (record under "deferred follow-ups" below).
+- [ ] **B4: gates + commit** `fix(builder-vm): static gvproxy fallback when DHCP
+  yields no lease`.
+
+## WS-C — writable resolv.conf seeded with the gateway resolver
+
+**Files:**
+- Modify: `crates/mvm-build/src/bin/mvm-host-vm-init.rs` (`setup_network` :2185)
+
+- [ ] **C1: bind-mount a `/run`-backed resolv.conf before udhcpc.** Replace the
+  no-op fallback copy (the image bakes no `/etc/resolv.conf.fallback`; the file is
+  a read-only regular file, not a `/run` symlink — both comments are wrong) with:
+
+  ```rust
+  // The rootfs is ro and /etc/resolv.conf is a baked file, so leased
+  // DNS can never land there. Seed a tmpfs copy with the gateway
+  // resolver (gvproxy answers DNS on the virtual gateway address and
+  // forwards via the host's resolver chain — environment-independent,
+  // unlike baked public resolvers) and bind-mount it over /etc so
+  // udhcpc's script and the lease can update it.
+  std::fs::create_dir_all("/run/mvm").map_err(|e| format!("mkdir /run/mvm: {e}"))?;
+  std::fs::write("/run/mvm/resolv.conf", b"nameserver 192.168.127.1\n")
+      .map_err(|e| format!("seed /run/mvm/resolv.conf: {e}"))?;
+  let st = Command::new("/bin/busybox")
+      .args(["mount", "--bind", "/run/mvm/resolv.conf", "/etc/resolv.conf"])
+      .status()
+      .map_err(|e| format!("spawn mount --bind resolv.conf: {e}"))?;
+  if !st.success() {
+      return Err(format!("bind-mount resolv.conf exit {}", st.code().unwrap_or(-1)));
+  }
+  ```
+
+  Run this before `bring_iface_up`/udhcpc so the DHCP script's
+  `> /etc/resolv.conf` writes through the bind-mount onto tmpfs (this also makes
+  the passt path's leased DNS effective on Linux, where the same ro-write failure
+  exists). The QEMU builder arm is untouched (Debian initramfs `ip=` autoconfig).
+- [ ] **C2: delete the stale fallback-copy block + wrong comments** (the
+  `/etc/resolv.conf.fallback` seed at :2194-2203 and the "symlink into /run" /
+  "udhcpc still sets the IP" prose).
+- [ ] **C3: gates + commit** `fix(builder-vm): writable gateway-resolver
+  resolv.conf via /run bind-mount`.
+
+## WS-D — verification + resume the live Vz validation
+
+- [ ] **D1: cold E2E on this host (the exact scenario that failed).**
+  `MVM_CACHE_DIR=/tmp/p183-cache MVM_DATA_DIR=/tmp/p183-data cargo run -- dev up`
+  → Stage 0 builds the image, then the **builder VM** build fetches (watch
+  `<cache>/builder-vm/jobs/<id>/nix-stderr.log` for `copying path …` instead of
+  `Could not resolve host`). Repeat with `--builder vz` to prove the Vz leg
+  (static fallback or fixed DHCP).
+- [ ] **D2: deps-install gate still locked.** Run the claim-11 CI-lane local
+  equivalents (`cargo nextest run -p mvm-build app_deps`,
+  `mvmctl deps inspect` fixture flow) and assert the install arm refuses when the
+  lockdown cannot install (new A3 test) — the posture change must not loosen
+  claim-11's witness set.
+- [ ] **D3: resume the deferred live Vz WS-2 validation (Plan 159 bonus).** With the
+  builder networked: `mvmctl up --flake examples/sleeper --hypervisor vz
+  --accept-tier2-isolation`, confirm the VM survives past ~5 s (the merged /init
+  stdin fix), then run `vm checkpoint create --class fs-quick` + `fork`,
+  `create --class vm-full` + `restore`, `pause`/`resume`, and attempt the fork
+  semantic-A spike (fresh machine-id + MAC → flip `FORK_FRESH_MACHINE_ID` /
+  `FORK_ALLOW_PARENT_RUNNING` if guest networking survives). Record outcomes in
+  Plan 159's notes.
+- [ ] **D4: rollups.** Tick this plan's boxes + update `specs/REFACTOR-STATUS.md`
+  (PLAN 183 section) + `specs/SPRINT.md` (Sprint 55 live-Vz-validation note) in the
+  same change as each workstream lands.
+
+### deferred follow-ups
+
+- [ ] Vz DHCP datagram-path root cause, if B3 ends in the documented defer.
+- [ ] Persistent Vz builder (`VzPersistentBuilderVm`) still runs `network: None`;
+  wire gvproxy when that path leaves scaffold status.
+- [ ] `mvmctl doctor` line surfacing the in-builder egress posture + last builder
+  network bootstrap outcome (lease vs static vs none), so this class of failure is
+  diagnosable without console archaeology.


### PR DESCRIPTION
## Summary

Opens **Plan 183** (`specs/plans/183-builder-vm-egress-posture-and-dns.md`): the diagnosis and fix-plan for why every cold or new-dep `mvmctl up --flake` / `dev up` build on macOS currently fails with `Could not resolve host` inside the builder VM.

**Diagnosis (proven live 2026-06-11, controlled A/B in a single `dev up` run):**
- The boot-time egress lockdown (`OUTPUT` policy `DROP`, loopback + proxy-UID only) applies to the **whole builder VM**, so the inner `nix build` — which runs with no proxy env — can't fetch anything, DNS included. The rules existed earlier but silently failed to install until iptables-legacy landed (`f184b17d`, 2026-06-05); from the next image rebuild on they actually apply. The dev-tier skip added the same day is keyed on `mvm.backend=qemu` only — and macOS has no QEMU tier; its dev-tier builders are libkrun/Vz. Stage 0 (different init, no lockdown) fetched the entire builder-image closure from cache.nixos.org minutes before the builder VM on the same host failed to resolve `github.com`.
- Independent second defect: the **Vz builder gets no DHCP lease** (`udhcpc: no lease, failing` → eth0 unconfigured → no network at all), while the libkrun builder leases fine from the same gvproxy.
- Third: `/etc/resolv.conf` is a **read-only baked file** (`1.1.1.1`/`8.8.8.8`), so busybox's DHCP script can't land the leased gateway resolver (`can't create /etc/resolv.conf: Read-only file system`).

**Plan:** per-arm egress posture (boot open; install-arm locked, fail-closed; per-job posture in the persistent dispatch loop — keeps claim-11 defense-in-depth exactly where the untrusted code runs), static-gvproxy fallback when DHCP yields no lease (reusing Stage 0's ioctl helpers), `/run`-bind-mounted resolv.conf seeded with the gateway resolver, then cold-E2E proof + resumption of the Plan 159 live Vz WS-2 validation.

Also updates `specs/REFACTOR-STATUS.md` (PLAN 183 section + glance line + Plan 159 blocked note) and `specs/SPRINT.md` (Sprint 55 live-Vz-validation section records the blocker + plan).

Docs-only — no code changes.

## Test Plan
- [x] Docs-only diff (`specs/` only)
- [x] Plan follows the checkbox format; all code blocks are real implementations against current `main` file:line anchors