### PR TITLE
fix(builder-vm): scope egress lockdown to the install arm (Plan 183 WS-A)

### DIFF
--- a/crates/mvm-build/src/bin/mvm-host-vm-init.rs
+++ b/crates/mvm-build/src/bin/mvm-host-vm-init.rs
@@ -175,17 +175,6 @@ fn hex_decode_utf8(s: &str) -> Option<String> {
     String::from_utf8(bytes).ok()
 }
 
-/// True when the kernel cmdline carries the `mvm.backend=qemu` marker —
-/// the dev-tier QEMU builder. The host (`qemu_builder`)
-/// adds this token; libkrun/Vz/Firecracker boots don't. Used to skip the
-/// egress lockdown on the dev-tier builder, where it has no security claim
-/// and would only break networked flake builds. Pure over the cmdline
-/// string so it's unit-testable without `/proc`.
-#[cfg(any(target_os = "linux", test))]
-fn dev_tier_builder_from_cmdline(cmdline: &str) -> bool {
-    cmdline.split_whitespace().any(|t| t == "mvm.backend=qemu")
-}
-
 /// Parse the `mvm.uvols=` token out of a kernel cmdline. Format:
 /// `mvm.uvols=<tag>:<hex(path)>:<ro|rw>:<fs|blk>;...`. Best-effort:
 /// malformed entries are skipped rather than failing (a bad mount must
@@ -527,26 +516,6 @@ mod tests {
     #[test]
     fn parse_user_volumes_cmdline_absent_is_empty() {
         assert!(parse_user_volumes_cmdline("console=hvc0 root=/dev/vda rw").is_empty());
-    }
-
-    #[test]
-    fn dev_tier_marker_detected_for_qemu_backend() {
-        assert!(dev_tier_builder_from_cmdline(
-            "console=ttyS0 root=/dev/vda ro init=/sbin/mvm-host-vm-init mvm.backend=qemu net.ifnames=0"
-        ));
-    }
-
-    #[test]
-    fn dev_tier_marker_absent_for_prod_backends() {
-        // libkrun/Vz/Firecracker boots carry no `mvm.backend=qemu` — the
-        // egress lockdown stays mandatory there.
-        assert!(!dev_tier_builder_from_cmdline(
-            "console=hvc0 root=/dev/vda ro init=/sbin/mvm-host-vm-init"
-        ));
-        // Substring-but-not-token must not match (no `mvm.backend=qemufoo`).
-        assert!(!dev_tier_builder_from_cmdline(
-            "console=hvc0 mvm.backend=qemubuilder"
-        ));
     }
 
     #[test]
@@ -897,75 +866,11 @@ mod linux {
         let _ = track_b.join();
         let _ = track_c.join();
 
-        // In-guest egress lockdown — defense-in-depth. Installs
-        // iptables OUTPUT default-deny + proxy-uid-only ACCEPT so a
-        // build step that ignores HTTP_PROXY env vars cannot bypass
-        // `mvm-egress-proxy`. FATAL on failure — without these
-        // rules the builder VM's egress allowlist is unenforced
-        // and the egress claim's transitive trust onto the
-        // builder VM has no defense layer. (Note: this is
-        // installed even when `setup_network()` failed, because
-        // the rules don't depend on a working IP address —
-        // offline builds still need the policy in place in case
-        // a substituter URL is reached via cache rather than
-        // network.)
-        // The QEMU builder is a dev-tier substrate with NO security
-        // claims. The egress lockdown is an egress-enforcement defense
-        // for the prod (libkrun / Firecracker) builder; on the dev-tier
-        // QEMU builder it would only break networked flake builds — nix
-        // can't reach substituters or fetch flake-input sources under
-        // `OUTPUT` DROP, because a flake `cmd.sh` runs with no proxy (the
-        // proxy path is install-pipeline only). Skip it for
-        // `mvm.backend=qemu` so slirp gives nix open egress; every prod
-        // backend stays locked.
-        let qemu_dev_tier = crate::dev_tier_builder_from_cmdline(
-            &std::fs::read_to_string("/proc/cmdline").unwrap_or_default(),
-        );
-        if qemu_dev_tier {
-            eprintln!(
-                "mvm-host-vm-init: egress lockdown SKIPPED — dev-tier QEMU builder \
-                 (mvm.backend=qemu); ADR-072: no security claims, dev only"
-            );
-        } else if let Err(e) = crate::network::install_egress_lockdown(
-            &crate::network::SystemIptables,
-            crate::network::PROXY_UID,
-        ) {
-            // In the Stage 0 bootstrap context the
-            // libkrunfw-bundled kernel ships without netfilter — both
-            // `iptables-nft` and `iptables-legacy` bail with "table
-            // does not exist" or "protocol not supported" at the first
-            // rule install. The egress lockdown is defense-in-depth
-            // for the deps-install pipeline (untrusted code
-            // running in the steady-state builder VM). Stage 0 only
-            // runs flake builds — `nix build` against a pinned
-            // `path:/work#…` reference — where Nix's own fixed-output
-            // derivation hashes carry the integrity guarantee. We
-            // log + continue rather than fail closed.
-            //
-            // The steady-state builder VM image (built by Stage 0 via
-            // the in-repo TSI-patched kernel under
-            // `nix/images/builder-vm/kernel/`) carries netfilter, so
-            // this fallback only triggers in Stage 0 — the audit
-            // signal still distinguishes the two contexts.
-            if egress_error_indicates_no_netfilter(&e) {
-                eprintln!(
-                    "mvm-host-vm-init: egress lockdown SKIPPED (kernel lacks netfilter — \
-                     Stage 0 / libkrunfw-bundled-kernel context): {e}"
-                );
-            } else {
-                eprintln!("mvm-host-vm-init: egress lockdown FAILED (fatal): {e}");
-                write_result(2, &format!("egress lockdown failed: {e}"));
-                return power_off();
-            }
-        }
-
         // Fork the guest agent under setpriv so the builder/dev VM runs
-        // the *same* agent every workload VM does
-        // (vsock 5252). After the egress lockdown so the agent comes up
-        // behind the same egress floor; non-fatal so a missing agent or
-        // spawn failure never wedges PID 1 — the builder protocol is the
-        // primary job, the agent is additive (mirrors the workload /init,
-        // which also never blocks on the agent).
+        // the *same* agent every workload VM does (vsock 5252). Non-fatal
+        // so a missing agent or spawn failure never wedges PID 1 — the
+        // builder protocol is the primary job, the agent is additive
+        // (mirrors the workload /init, which also never blocks on the agent).
         fork_guest_agent();
 
         // Dispatch: if the host staged a
@@ -1618,22 +1523,30 @@ mod linux {
         job_dir_relpath: &str,
         cold_boot_timings: Option<BootTimings>,
     ) -> String {
-        // Flush + re-install the egress
-        // lockdown before every dispatch. A previous build that
-        // mutated iptables (whether via a CAP_NET_ADMIN leak or
-        // because we haven't shipped the cap drop yet) loses its
-        // changes here. Fail closed: if iptables is broken we
-        // refuse the dispatch — that's safer than running a
-        // build against a chain whose state we no longer trust.
-        if let Err(e) = crate::network::reapply_egress_lockdown(
-            &crate::network::SystemIptables,
-            crate::network::PROXY_UID,
-        ) {
-            eprintln!("mvm-host-vm-init: dispatch loop: iptables baseline re-apply failed: {e}");
+        // Set per-job egress posture before dispatch. Install jobs lock
+        // egress (reset + uid-only ACCEPT) so untrusted dep code can't
+        // reach the network directly; flake-build jobs open egress so
+        // nix can fetch substitutes and pinned inputs without a proxy.
+        // Both belts: the install arm also locks at its own entry (defense
+        // in depth), but the outer reset here ensures a prior flake job's
+        // open chain never leaks into a following install and vice versa.
+        let posture_result = match &job {
+            crate::builder_request::BuilderJob::Install { .. } => {
+                crate::network::reapply_egress_lockdown(
+                    &crate::network::SystemIptables,
+                    crate::network::PROXY_UID,
+                )
+            }
+            crate::builder_request::BuilderJob::Flake { .. } => {
+                crate::network::open_egress(&crate::network::SystemIptables)
+            }
+        };
+        if let Err(e) = posture_result {
+            eprintln!("mvm-host-vm-init: dispatch loop: egress posture failed: {e}");
             let response = crate::dispatch_response::DispatchResponse {
                 job_id,
                 exit_code: 126,
-                stderr_tail: format!("iptables baseline re-apply failed: {e}"),
+                stderr_tail: format!("egress posture failed: {e}"),
                 boot_timings: cold_boot_timings,
                 build_ms: 0,
             };
@@ -1886,6 +1799,7 @@ mod linux {
             runner: &runner,
             extra_path: None,
             proxy: &mut proxy,
+            iptables: &crate::network::SystemIptables,
         };
         let report = match run_install(ctx) {
             Ok(r) => r,
@@ -1903,6 +1817,11 @@ mod linux {
             Err(InstallError::Io(why)) => {
                 eprintln!("mvm-host-vm-init: install pipeline IO: {why}");
                 write_install_failure_at(out_dir, 2, &format!("install pipeline IO: {why}"));
+                return;
+            }
+            Err(InstallError::EgressLockdown(e)) => {
+                eprintln!("mvm-host-vm-init: egress lockdown failed (fatal): {e}");
+                write_install_failure_at(out_dir, 2, &format!("egress lockdown failed: {e}"));
                 return;
             }
         };
@@ -1953,18 +1872,6 @@ mod linux {
         }
     }
 
-    /// Detect the "kernel ships without netfilter / iptables
-    /// tables" error pattern. Matches both the iptables-nft Protocol
-    /// not supported and the iptables-legacy "Table does not exist /
-    /// do you need to insmod?" surfaces. A future netlink-based check
-    /// would be more robust, but this regex-of-substrings catches the
-    /// only two error shapes the libkrunfw-bundled kernel produces.
-    fn egress_error_indicates_no_netfilter(err: &str) -> bool {
-        err.contains("Table does not exist")
-            || err.contains("Failed to initialize nft")
-            || err.contains("Protocol not supported")
-    }
-
     fn mount_pseudofs() -> Result<(), String> {
         // Standard init filesystems. libkrun's kernel mounts
         // devtmpfs (and sometimes /proc /sys) before handing off to
@@ -1976,12 +1883,10 @@ mod linux {
         mount_fs_idempotent("devtmpfs", "/dev", "devtmpfs")?;
         mount_fs_idempotent("tmpfs", "/tmp", "tmpfs")?;
         // `/run` must be a tmpfs so iptables-legacy can write
-        // `/run/xtables.lock`. The rootfs is mounted ro, so a missing
-        // `/run` tmpfs makes `install_egress_lockdown` bail with
+        // `/run/xtables.lock`. The rootfs is mounted ro, so without this
+        // `install_egress_lockdown` (called from the install arm) bails with
         // "Read-only file system" at the first `iptables -A` call.
-        // mkGuest's /init does the equivalent for the dev image's
-        // boot path; we replicate it here for the mvm-host-vm-init
-        // path.
+        // mkGuest's /init does the equivalent for the dev image's boot path.
         mount_fs_idempotent("tmpfs", "/run", "tmpfs")?;
         // `/dev/shm` (tmpfs) is required by libfaketime's `sem_open`:
         // `make-ext4-fs.nix` runs `mkfs.ext4` under faketime for

--- a/crates/mvm-build/src/bin/mvm-host-vm-init.rs
+++ b/crates/mvm-build/src/bin/mvm-host-vm-init.rs
@@ -1505,6 +1505,25 @@ mod linux {
         }
     }
 
+    /// Set the iptables OUTPUT posture for the given job kind before
+    /// dispatch. Install jobs lock egress (flush + uid-only ACCEPT)
+    /// so untrusted dep code can't reach the network directly; flake
+    /// jobs open egress so nix can fetch substitutes without a proxy.
+    /// Separated from `execute_dispatched_job` so the mapping is
+    /// directly testable — the match is the policy, and an inversion
+    /// would be silent without a unit test pinning the sequences.
+    fn apply_job_posture(
+        job: &crate::builder_request::BuilderJob,
+        ip: &dyn crate::network::IptablesRunner,
+    ) -> Result<(), String> {
+        match job {
+            crate::builder_request::BuilderJob::Install { .. } => {
+                crate::network::reapply_egress_lockdown(ip, crate::network::PROXY_UID)
+            }
+            crate::builder_request::BuilderJob::Flake { .. } => crate::network::open_egress(ip),
+        }
+    }
+
     /// Run one dispatched job: locate cmd.sh under
     /// `/job/<job_dir_relpath>/cmd.sh`, exec it, stream every
     /// stderr line back to `conn` as a `HostVmResponse::StderrChunk`
@@ -1523,24 +1542,11 @@ mod linux {
         job_dir_relpath: &str,
         cold_boot_timings: Option<BootTimings>,
     ) -> String {
-        // Set per-job egress posture before dispatch. Install jobs lock
-        // egress (reset + uid-only ACCEPT) so untrusted dep code can't
-        // reach the network directly; flake-build jobs open egress so
-        // nix can fetch substitutes and pinned inputs without a proxy.
-        // Both belts: the install arm also locks at its own entry (defense
-        // in depth), but the outer reset here ensures a prior flake job's
-        // open chain never leaks into a following install and vice versa.
-        let posture_result = match &job {
-            crate::builder_request::BuilderJob::Install { .. } => {
-                crate::network::reapply_egress_lockdown(
-                    &crate::network::SystemIptables,
-                    crate::network::PROXY_UID,
-                )
-            }
-            crate::builder_request::BuilderJob::Flake { .. } => {
-                crate::network::open_egress(&crate::network::SystemIptables)
-            }
-        };
+        // Set per-job egress posture before dispatch. The install arm
+        // also locks at its own entry for defense in depth, but this
+        // outer reset ensures a prior flake job's open chain never
+        // leaks into a following install and vice versa.
+        let posture_result = apply_job_posture(&job, &crate::network::SystemIptables);
         if let Err(e) = posture_result {
             eprintln!("mvm-host-vm-init: dispatch loop: egress posture failed: {e}");
             let response = crate::dispatch_response::DispatchResponse {
@@ -3272,6 +3278,114 @@ mod linux {
             std::fs::create_dir(&store).expect("create store");
             std::fs::create_dir(store.join("abc123-some-pkg")).expect("create closure path");
             assert!(!nix_store_needs_seed(base.path()));
+        }
+
+        // --- apply_job_posture tests ---
+
+        struct RecordingIp {
+            calls: std::cell::RefCell<Vec<Vec<String>>>,
+            fail_at: Option<usize>,
+        }
+
+        impl RecordingIp {
+            fn new() -> Self {
+                Self {
+                    calls: std::cell::RefCell::new(Vec::new()),
+                    fail_at: None,
+                }
+            }
+            fn fail_at(idx: usize) -> Self {
+                Self {
+                    calls: std::cell::RefCell::new(Vec::new()),
+                    fail_at: Some(idx),
+                }
+            }
+        }
+
+        impl crate::network::IptablesRunner for RecordingIp {
+            fn run(&self, args: &[&str]) -> Result<(), String> {
+                let mut calls = self.calls.borrow_mut();
+                let idx = calls.len();
+                calls.push(args.iter().map(|s| s.to_string()).collect());
+                if Some(idx) == self.fail_at {
+                    Err(format!("forced failure at {idx}"))
+                } else {
+                    Ok(())
+                }
+            }
+        }
+
+        fn install_job() -> crate::builder_request::BuilderJob {
+            crate::builder_request::BuilderJob::Install {
+                spec_path: "/job/spec.json".to_string(),
+            }
+        }
+
+        fn flake_job() -> crate::builder_request::BuilderJob {
+            crate::builder_request::BuilderJob::Flake {
+                flake_ref: "path:/work".to_string(),
+                attr_path: "packages.aarch64-linux.default".to_string(),
+            }
+        }
+
+        #[test]
+        fn apply_job_posture_install_emits_flush_then_three_lockdown_rules() {
+            let ip = RecordingIp::new();
+            apply_job_posture(&install_job(), &ip).expect("happy path");
+            let calls = ip.calls.borrow();
+            // flush + 3 rules = 4 invocations
+            assert_eq!(calls.len(), 4);
+            assert_eq!(calls[0], vec!["-F".to_string(), "OUTPUT".to_string()]);
+            assert_eq!(
+                calls[1],
+                vec![
+                    "-A".to_string(),
+                    "OUTPUT".to_string(),
+                    "-o".to_string(),
+                    "lo".to_string(),
+                    "-j".to_string(),
+                    "ACCEPT".to_string(),
+                ]
+            );
+            assert!(calls[2].iter().any(|a| a == "--uid-owner"));
+            assert!(
+                calls[2]
+                    .iter()
+                    .any(|a| a == &crate::network::PROXY_UID.to_string())
+            );
+            assert!(calls[2].iter().any(|a| a == "ACCEPT"));
+            assert_eq!(
+                calls[3],
+                vec!["-P".to_string(), "OUTPUT".to_string(), "DROP".to_string()]
+            );
+        }
+
+        #[test]
+        fn apply_job_posture_flake_emits_flush_then_accept_policy() {
+            let ip = RecordingIp::new();
+            apply_job_posture(&flake_job(), &ip).expect("happy path");
+            let calls = ip.calls.borrow();
+            assert_eq!(calls.len(), 2);
+            assert_eq!(calls[0], vec!["-F".to_string(), "OUTPUT".to_string()]);
+            assert_eq!(
+                calls[1],
+                vec!["-P".to_string(), "OUTPUT".to_string(), "ACCEPT".to_string()]
+            );
+        }
+
+        #[test]
+        fn apply_job_posture_install_propagates_error() {
+            // Fail at invocation 0 (the flush) — error surfaces immediately.
+            let ip = RecordingIp::fail_at(0);
+            let result = apply_job_posture(&install_job(), &ip);
+            assert!(result.is_err(), "posture error must propagate");
+        }
+
+        #[test]
+        fn apply_job_posture_flake_propagates_error() {
+            let ip = RecordingIp::fail_at(0);
+            let result = apply_job_posture(&flake_job(), &ip);
+            assert!(result.is_err(), "posture error must propagate");
         }
     }
 }

--- a/crates/mvm-build/src/bin/mvm-host-vm-init/install.rs
+++ b/crates/mvm-build/src/bin/mvm-host-vm-init/install.rs
@@ -244,6 +244,10 @@ pub enum InstallError {
     /// `installer_exit_code`); a missing installer is a builder-VM
     /// configuration bug, not a user's lockfile issue.
     InstallerMissing { program: String },
+    /// iptables OUTPUT lockdown failed. A builder whose kernel can't
+    /// enforce the lockdown refuses install jobs — the deps-install
+    /// egress policy is the whole point of this arm.
+    EgressLockdown(String),
 }
 
 impl std::fmt::Display for InstallError {
@@ -253,6 +257,7 @@ impl std::fmt::Display for InstallError {
             Self::InstallerMissing { program } => {
                 write!(f, "installer `{program}` not on PATH inside the builder VM")
             }
+            Self::EgressLockdown(e) => write!(f, "egress lockdown failed: {e}"),
         }
     }
 }
@@ -276,6 +281,10 @@ pub struct InstallContext<'a> {
     /// [`crate::proxy::ChildProxyLifecycle`]; tests use
     /// [`crate::proxy::NoopProxyLifecycle`] or a fake.
     pub proxy: &'a mut dyn ProxyLifecycle,
+    /// iptables runner used to install the egress lockdown at entry.
+    /// Production passes [`crate::network::SystemIptables`]; tests inject
+    /// a recording or failing fake to verify fail-closed behavior.
+    pub iptables: &'a dyn crate::network::IptablesRunner,
 }
 
 /// Public entry point. Run the install pipeline for the spec in
@@ -310,7 +319,16 @@ pub fn run_install(ctx: InstallContext<'_>) -> Result<InstallReport, InstallErro
         runner,
         extra_path,
         proxy,
+        iptables,
     } = ctx;
+
+    // Lock egress before any dep tooling or proxy spawn. Untrusted
+    // dependency code must not reach the network except through the
+    // allowlist proxy. Fail closed: if the kernel can't enforce the
+    // lockdown, this install is refused entirely.
+    crate::network::install_egress_lockdown(iptables, crate::network::PROXY_UID)
+        .map_err(InstallError::EgressLockdown)?;
+
     fs::create_dir_all(out_dir)
         .map_err(|e| InstallError::Io(format!("create {}: {e}", out_dir.display())))?;
     let content_dir = out_dir.join(CONTENT_SUBDIR);
@@ -793,6 +811,56 @@ mod tests {
         }
     }
 
+    /// Fake iptables runner that always succeeds (no real iptables).
+    struct PassIptables;
+    impl crate::network::IptablesRunner for PassIptables {
+        fn run(&self, _args: &[&str]) -> Result<(), String> {
+            Ok(())
+        }
+    }
+
+    /// Fake iptables runner that always fails.
+    struct FailIptables;
+    impl crate::network::IptablesRunner for FailIptables {
+        fn run(&self, _args: &[&str]) -> Result<(), String> {
+            Err("iptables not available".to_string())
+        }
+    }
+
+    /// Recording iptables runner: captures each invocation; optionally
+    /// fails at a given call index (0-based). Mirrors the pattern from
+    /// the `network` module's tests.
+    struct RecordingIptables {
+        calls: std::cell::RefCell<Vec<Vec<String>>>,
+        fail_at: Option<usize>,
+    }
+
+    impl RecordingIptables {
+        fn new() -> Self {
+            Self {
+                calls: std::cell::RefCell::new(Vec::new()),
+                fail_at: None,
+            }
+        }
+
+        fn calls(&self) -> Vec<Vec<String>> {
+            self.calls.borrow().clone()
+        }
+    }
+
+    impl crate::network::IptablesRunner for RecordingIptables {
+        fn run(&self, args: &[&str]) -> Result<(), String> {
+            let mut calls = self.calls.borrow_mut();
+            let idx = calls.len();
+            calls.push(args.iter().map(|s| s.to_string()).collect());
+            if Some(idx) == self.fail_at {
+                Err(format!("forced failure at invocation {idx}"))
+            } else {
+                Ok(())
+            }
+        }
+    }
+
     /// Convenience: run_install against the stub runner + a fake
     /// proxy, returning both the install report and the proxy's
     /// observed start/stop events. Keeps test arms readable.
@@ -802,6 +870,16 @@ mod tests {
         out_dir: &Path,
         runner: &dyn CommandRunner,
     ) -> (Result<InstallReport, InstallError>, Vec<&'static str>) {
+        run_install_with_fakes_and_iptables(spec, job_dir, out_dir, runner, &PassIptables)
+    }
+
+    fn run_install_with_fakes_and_iptables<'a>(
+        spec: &'a InstallSpec,
+        job_dir: &'a Path,
+        out_dir: &'a Path,
+        runner: &'a dyn CommandRunner,
+        iptables: &'a dyn crate::network::IptablesRunner,
+    ) -> (Result<InstallReport, InstallError>, Vec<&'static str>) {
         let mut proxy = FakeProxy::ok();
         let ctx = InstallContext {
             spec,
@@ -810,6 +888,7 @@ mod tests {
             runner,
             extra_path: None,
             proxy: &mut proxy,
+            iptables,
         };
         let report = run_install(ctx);
         let events = proxy.events();
@@ -1035,6 +1114,7 @@ mod tests {
             runner: &runner,
             extra_path: None,
             proxy: &mut proxy,
+            iptables: &PassIptables,
         };
         let err = run_install(ctx).unwrap_err();
         match err {
@@ -1081,5 +1161,62 @@ mod tests {
         assert_eq!(json_escape("a\\b"), "a\\\\b");
         assert_eq!(json_escape("a\nb"), "a\\nb");
         assert_eq!(json_escape("\x01"), "\\u0001");
+    }
+
+    #[test]
+    fn egress_lockdown_failure_refuses_install_before_proxy_or_installer() {
+        // A failing iptables runner → EgressLockdown error, and neither the
+        // proxy nor the installer must have run (fail-closed: lockdown
+        // first, nothing else if it can't be enforced).
+        let tmp = tempfile::tempdir().unwrap();
+        let runner = StubRunner::new(&["uv", "cyclonedx-py", "pip-audit"]);
+        let iptables = FailIptables;
+        let (result, events) = run_install_with_fakes_and_iptables(
+            &ok_spec(),
+            &tmp.path().join("job"),
+            tmp.path(),
+            &runner,
+            &iptables,
+        );
+        assert!(
+            matches!(result, Err(InstallError::EgressLockdown(_))),
+            "expected EgressLockdown, got {result:?}",
+        );
+        // Proxy must not have started — we refused before reaching it.
+        assert!(events.is_empty(), "proxy events must be empty: {events:?}");
+        // Installer must not have run.
+        assert!(
+            runner.calls().is_empty(),
+            "installer must not run: {:?}",
+            runner.calls()
+        );
+    }
+
+    #[test]
+    fn egress_lockdown_invoked_before_proxy_on_success() {
+        // A recording iptables runner → verify the lockdown was invoked
+        // exactly once (3 calls: loopback ACCEPT, uid-owner ACCEPT, DROP
+        // policy) before the proxy start event.
+        let tmp = tempfile::tempdir().unwrap();
+        let runner = StubRunner::new(&["uv", "cyclonedx-py", "pip-audit"]);
+        let iptables = RecordingIptables::new();
+        let (result, events) = run_install_with_fakes_and_iptables(
+            &ok_spec(),
+            &tmp.path().join("job"),
+            tmp.path(),
+            &runner,
+            &iptables,
+        );
+        assert!(result.is_ok(), "expected success, got {result:?}");
+        // Three iptables invocations from install_egress_lockdown.
+        assert_eq!(
+            iptables.calls().len(),
+            3,
+            "expected 3 lockdown rules, got {}",
+            iptables.calls().len(),
+        );
+        // Proxy and installer ran.
+        assert_eq!(events, vec!["start", "stop"]);
+        assert!(!runner.calls().is_empty());
     }
 }

--- a/crates/mvm-build/src/bin/mvm-host-vm-init/network.rs
+++ b/crates/mvm-build/src/bin/mvm-host-vm-init/network.rs
@@ -85,6 +85,15 @@ pub fn install_egress_lockdown(runner: &dyn IptablesRunner, proxy_uid: u32) -> R
     Ok(())
 }
 
+/// Reset the OUTPUT chain to open egress for a trusted flake-build
+/// dispatch. The inner `nix build` fetches substitutes and pinned
+/// flake inputs directly (no proxy), so the chain must not filter it.
+pub fn open_egress(runner: &dyn IptablesRunner) -> Result<(), String> {
+    runner.run(&["-F", "OUTPUT"])?;
+    runner.run(&["-P", "OUTPUT", "ACCEPT"])?;
+    Ok(())
+}
+
 /// Re-install the egress lockdown from a known-good in-binary recipe.
 ///
 /// `install_egress_lockdown` runs once at boot. In the persistent
@@ -201,6 +210,33 @@ mod tests {
         assert!(
             runner.invocations.borrow()[1].iter().any(|a| a == "9999"),
             "uid passed through to --uid-owner",
+        );
+    }
+
+    #[test]
+    fn open_egress_emits_flush_then_accept_policy() {
+        let runner = RecordingRunner::new();
+        open_egress(&runner).expect("happy path");
+        let invocations = runner.invocations.borrow();
+        assert_eq!(invocations.len(), 2);
+        // 1: flush OUTPUT chain.
+        assert_eq!(invocations[0], vec!["-F".to_string(), "OUTPUT".to_string()],);
+        // 2: set OUTPUT policy ACCEPT.
+        assert_eq!(
+            invocations[1],
+            vec!["-P".to_string(), "OUTPUT".to_string(), "ACCEPT".to_string()],
+        );
+    }
+
+    #[test]
+    fn open_egress_propagates_flush_failure() {
+        let runner = RecordingRunner::fail_at(0);
+        let result = open_egress(&runner);
+        assert!(result.is_err());
+        assert_eq!(
+            runner.invocations.borrow().len(),
+            1,
+            "only the flush was attempted before the error",
         );
     }
 

--- a/crates/mvm-build/src/bin/mvm-host-vm-init/network.rs
+++ b/crates/mvm-build/src/bin/mvm-host-vm-init/network.rs
@@ -7,10 +7,11 @@
 //! the in-VM proxy is reachable from `localhost:8443`) and
 //! outbound traffic owned by the proxy's uid are allowed out.
 //!
-//! Called from `mvm-host-vm-init`'s boot sequence after the
-//! basic `setup_network()`. Failure is **fatal** — without the
-//! lockdown, the builder VM's egress allowlist is unenforced and
-//! the transitive trust onto the builder VM has no defense layer.
+//! Two call sites, two postures: the install arm locks egress at
+//! entry (fail-closed — untrusted dep code must not reach the network
+//! directly); the persistent dispatch loop sets posture per job kind
+//! before each dispatch (install → locked, flake build → open so nix
+//! can fetch substitutes and pinned inputs without a proxy).
 
 use std::process::Command;
 
@@ -96,13 +97,12 @@ pub fn open_egress(runner: &dyn IptablesRunner) -> Result<(), String> {
 
 /// Re-install the egress lockdown from a known-good in-binary recipe.
 ///
-/// `install_egress_lockdown` runs once at boot. In the persistent
-/// builder VM jobs share the kernel's iptables state across
+/// Called at the start of each install dispatch in the persistent
+/// builder VM. Jobs share the kernel's iptables state across
 /// dispatches — a build that runs `iptables -I OUTPUT 1 -j
 /// ACCEPT` (or exploits a `CAP_NET_ADMIN` leak via the new mount
 /// namespace from `unshare --mount`) poisons every subsequent
-/// job. The persistent dispatch loop calls this between
-/// dispatches to reset the chain.
+/// job, so the dispatch loop resets the chain before each one.
 ///
 /// Implementation: flush the OUTPUT chain, then re-install the 3
 /// baseline rules. Cheap (~10 ms per the plan's estimate) and

--- a/nix/images/builder-vm/flake.nix
+++ b/nix/images/builder-vm/flake.nix
@@ -157,18 +157,17 @@
       # CycloneDX-1.5 empty stub when the tool isn't on PATH and logs
       # a warning.
       #
-      # The egress side is closed: the builder VM runs
-      # `mvm-egress-proxy`, embedded in mvmctl at its own build time
-      # and baked into the rootfs via `hostBinExtraFiles` (read from
-      # `MVM_HOST_BIN_DIR` under `--impure`) at the install path
-      # declared in `nix/lib/mvm-host-binaries.nix`.
-      # `mvm-host-vm-init::install::run_install` spawns it
-      # before the installer + injects `HTTPS_PROXY` /
-      # `HTTP_PROXY` on `uv` / `pnpm`'s env. The proxy refuses
-      # anything outside the four allowed hostnames:
-      # `pypi.org`, `files.pythonhosted.org`,
+      # Egress posture is per-arm. The flake-build arm (`nix build`)
+      # runs with open egress so nix can fetch substitutes and pinned
+      # flake inputs directly. The install arm (`uv` / `pnpm`) locks
+      # egress at its entry via iptables OUTPUT default-deny + proxy-uid
+      # ACCEPT, so untrusted dependency code can only reach the network
+      # through `mvm-egress-proxy` (embedded in mvmctl and baked into
+      # the rootfs via `hostBinExtraFiles`). The proxy refuses anything
+      # outside `pypi.org`, `files.pythonhosted.org`,
       # `registry.npmjs.org`, `objects.githubusercontent.com`.
-      # Complementary iptables drop-rule defense-in-depth runs too.
+      # The persistent dispatch loop resets the chain per job kind so
+      # jobs cannot leak posture from one dispatch to the next.
       builderPackages = pkgs: with pkgs; [
         bashInteractive
         coreutils

--- a/specs/REFACTOR-STATUS.md
+++ b/specs/REFACTOR-STATUS.md
@@ -31,7 +31,7 @@ details** below for the workstream-level state.
 - [ ] **PLAN 126** — Dependency reduction · 🟡 ~25%; sigstore/aws-lc/lock-gate remain
 - [ ] **PLAN 177** — Backend consolidation (8→4) · 🟡 Phase 1 done; Phase 2 (AVF convergence) in progress
 - [ ] **PLAN 175** — Firecracker live-memory warm-start · 🔴 not started (live-KVM-gated)
-- [ ] **PLAN 183** — Builder-VM egress posture + network bootstrap · 🔴 diagnosed + plan landed; blocks every cold/new-dep macOS flake build
+- [ ] **PLAN 183** — Builder-VM egress posture + network bootstrap · 🟡 WS-A landed; WS-B/C/D remain
 - [x] **PLAN 180** — Strip spec refs from code comments · ✅ (lint-gated, #786)
 
 ## Plan details
@@ -218,16 +218,15 @@ PLAN 159 — vz-inspired macOS VZ DX               🟡 152-independent slice sh
   [ ] live Vz WS-2 round-trip validation + fork semantic-A spike — BLOCKED on
       Plan 183 (builder-VM egress lockdown breaks every uncached flake build)
 
-PLAN 183 — Builder-VM egress posture + net boot 🔴 diagnosed; plan landed
-  Diagnosis proven 2026-06-11 (controlled A/B in one dev-up run: Stage 0
-  fetched the full closure; the builder VM minutes later could not resolve):
-  boot-time install_egress_lockdown (OUTPUT DROP, proxy-uid-only) applies to
-  the whole builder VM and drops every nix fetch — active since iptables-legacy
-  landed (f184b17d, 2026-06-05); the dev-tier skip is QEMU-only. Plus: Vz
-  builder gets no DHCP lease (eth0 unconfigured), and /etc/resolv.conf is a
+PLAN 183 — Builder-VM egress posture + net boot 🟡 WS-A landed
+  Diagnosis proven 2026-06-11: boot-time install_egress_lockdown (OUTPUT DROP,
+  proxy-uid-only) applied to the whole builder VM and dropped every nix fetch.
+  WS-A moves the lockdown to the install arm (fail-closed) + opens egress for
+  flake-build dispatches; the QEMU-only boot skip is deleted. Plus (WS-B/C):
+  Vz builder gets no DHCP lease (eth0 unconfigured), and /etc/resolv.conf is a
   read-only baked file so leased DNS never lands.
-  [ ] WS-A egress posture per arm (boot open; install-arm locked, fail-closed;
-      per-job posture in persistent dispatch; drop QEMU-only boot skip)
+  [x] WS-A egress posture per arm (boot open; install-arm locked, fail-closed;
+      per-job posture in persistent dispatch; drop QEMU-only boot skip) — landed
   [ ] WS-B Vz DHCP no-lease: static gvproxy fallback (shared stage0 ioctl
       helpers) + time-boxed datagram-path root cause
   [ ] WS-C writable /run-bind-mounted resolv.conf seeded with gateway resolver

--- a/specs/plans/183-builder-vm-egress-posture-and-dns.md
+++ b/specs/plans/183-builder-vm-egress-posture-and-dns.md
@@ -92,7 +92,7 @@ Per-arm posture keeps the lockdown exactly where the threat is.
   tier token only if nothing else consumes `mvm.backend=qemu`; verify with rg first)
 - Modify: `nix/images/builder-vm/flake.nix` (egress comment block ~:160)
 
-- [ ] **A1: add `open_egress` to `network.rs` with tests.** New function beside
+- [x] **A1: add `open_egress` to `network.rs` with tests.** New function beside
   `install_egress_lockdown`:
 
   ```rust
@@ -108,14 +108,14 @@ Per-arm posture keeps the lockdown exactly where the threat is.
 
   Tests (same `RecordingRunner` pattern as the existing module tests): exact
   invocation sequence; first-call failure propagates.
-- [ ] **A2: remove the boot-time lockdown.** Delete the
+- [x] **A2: remove the boot-time lockdown.** Delete the
   `qemu_dev_tier`/`install_egress_lockdown` block from `run()`
   (`mvm-host-vm-init.rs` ~:900-960) including the
   `egress_error_indicates_no_netfilter` Stage-0 fallback branch it guards (keep the
   helper only if the install-arm path still needs it — it does not: the steady-state
   builder kernel carries netfilter, and the install arm must fail closed). Delete
   `dev_tier_builder_from_cmdline` (:185) and its tests; it has no remaining callers.
-- [ ] **A3: lock at install-arm entry.** At the top of `run_install`
+- [x] **A3: lock at install-arm entry.** At the top of `run_install`
   (`install.rs:305`), before the egress proxy spawn and any dep tooling runs:
 
   ```rust
@@ -129,17 +129,17 @@ Per-arm posture keeps the lockdown exactly where the threat is.
   Add the `EgressLockdown(String)` variant to `InstallError` (fail-closed: a builder
   whose kernel can't enforce the lockdown refuses install jobs). Unit-test via the
   existing `run_install_with_fakes` seam (inject a failing runner → install refuses).
-- [ ] **A4: per-job posture in the persistent dispatch loop.** At the ~:1628
+- [x] **A4: per-job posture in the persistent dispatch loop.** At the ~:1628
   `reapply_egress_lockdown` site, set posture by job kind instead of
   unconditionally re-locking: install dispatch → `reapply_egress_lockdown`,
   flake-build dispatch → `open_egress`. Failure stays a hard refusal of the
   dispatched job either way.
-- [ ] **A5: drop the QEMU boot-skip remnants + fix comments.** Remove the
+- [x] **A5: drop the QEMU boot-skip remnants + fix comments.** Remove the
   `mvm.builder-tier` skip prose from the builder flake's egress comment block and
   describe the per-arm posture instead. In `qemu_builder.rs:142` keep
   `mvm.backend=qemu` only if `rg "mvm.backend"` shows another consumer (stage0's
   backend detection does consume it — verify before touching).
-- [ ] **A6: gates.** `cargo fmt --all -- --check`,
+- [x] **A6: gates.** `cargo fmt --all -- --check`,
   `cargo clippy --workspace -- -D warnings`,
   `cargo nextest run -p mvm-build`, then commit
   `fix(builder-vm): scope egress lockdown to the install arm`.


### PR DESCRIPTION
## Summary

Plan 183 WS-A. The builder VM's iptables egress lockdown (`OUTPUT` policy `DROP`, loopback + proxy-UID only) installed at PID-1 boot, so the inner `nix build` — which runs with no proxy env — could fetch nothing: every cold or new-dep macOS flake build died with `Could not resolve host` (active since iptables-legacy made the rules actually apply, 2026-06-05; diagnosis in `specs/plans/183-builder-vm-egress-posture-and-dns.md`).

The lockdown's intent is defense-in-depth for the deps-install pipeline (untrusted dependency code whose only legitimate egress is `mvm-egress-proxy`). This PR moves it exactly there:

- **Boot no longer locks.** The one-shot flake-build arm runs with nix's normal open egress (Linux default `OUTPUT ACCEPT`).
- **Install arm locks at entry, fail-closed.** `run_install` calls `install_egress_lockdown` as its first action — before the proxy spawn and any dep tooling — and a builder that can't enforce it refuses install jobs (`InstallError::EgressLockdown`). The iptables runner is threaded through `InstallContext`, so tests inject fakes.
- **Persistent dispatch loop sets posture per job kind** via a pure `apply_job_posture` helper: install → `reapply_egress_lockdown`, flake build → `open_egress` (new). Posture failure hard-refuses the job. Cross-job leak is closed in both directions, and the install arm's entry lock is the second belt.
- **QEMU-only boot skip deleted** (`dev_tier_builder_from_cmdline`, the netfilter-absence escape hatch) — dead with no boot lockdown. `mvm.backend=qemu` stays on the cmdline (stage0-init consumes it).
- Builder-flake egress comment + module docs rewritten to describe the per-arm posture.

Tests: posture-mapping sequences pinned per arm (4 tests, exact iptables invocations), install-refusal-before-side-effects + lockdown-before-proxy ordering (2 tests), `open_egress` sequence + failure propagation (2 tests). Adversarial final review traced one-shot/persistent install paths, both job orderings, and error paths — no path runs dep-install code with open egress.

Rollups: plan WS-A boxes ticked, REFACTOR-STATUS PLAN 183 → 🟡 WS-A landed.

WS-B (Vz DHCP no-lease fallback) and WS-C (writable resolv.conf) follow separately.

## Test Plan
- [x] `cargo fmt --all -- --check`, `cargo clippy --workspace -- -D warnings` clean
- [x] `cargo nextest run -p mvm-build` green; workspace run (minus the known local mvm-backend codesign quirk) green
- [x] `cargo zigbuild --target aarch64-unknown-linux-musl -p mvm-build --tests` — the cfg(linux) posture tests compile; they execute in Linux CI
- [x] `check-no-spec-refs-in-comments` clean; full `cargo build -p mvm-cli` (embedded-bin cross-compile) green
- [ ] Cold `dev up` E2E fetch-inside-builder proof lands with WS-D (needs WS-B/C for the Vz leg)