### PR TITLE
fix(builder-vm): guest network bootstrap — static gvproxy fallback + writable resolv.conf (Plan 183 WS-B/C)

### DIFF
--- a/crates/mvm-build/src/bin/mvm-host-vm-init.rs
+++ b/crates/mvm-build/src/bin/mvm-host-vm-init.rs
@@ -2107,23 +2107,11 @@ mod linux {
         // Seeding before udhcpc also means the bind-mount is in place on the
         // Vz path where DHCP fails — the static fallback below gives the IP
         // and the seed covers DNS.
-        std::fs::create_dir_all("/run/mvm").map_err(|e| format!("mkdir /run/mvm: {e}"))?;
-        std::fs::write("/run/mvm/resolv.conf", resolver_seed(&cmdline))
-            .map_err(|e| format!("seed /run/mvm/resolv.conf: {e}"))?;
-        let st = Command::new("/bin/busybox")
-            .args([
-                "mount",
-                "--bind",
-                "/run/mvm/resolv.conf",
-                "/etc/resolv.conf",
-            ])
-            .status()
-            .map_err(|e| format!("spawn mount --bind resolv.conf: {e}"))?;
-        if !st.success() {
-            return Err(format!(
-                "bind-mount resolv.conf exit {}",
-                st.code().unwrap_or(-1)
-            ));
+        // Non-fatal: a failed seed/bind-mount degrades DNS to the baked
+        // resolvers but must not block the iface-up + DHCP below — a
+        // leased-but-degraded guest beats one with no IP at all.
+        if let Err(e) = seed_resolv_conf(&cmdline) {
+            eprintln!("mvm-host-vm-init: resolv.conf seed skipped: {e} (continuing)");
         }
 
         // busybox 1.36.x udhcpc binds a PF_PACKET raw socket to
@@ -2207,6 +2195,31 @@ mod linux {
         } else {
             b"nameserver 192.168.127.1\n"
         }
+    }
+
+    /// Stage the gateway-resolver seed on tmpfs and bind-mount it over
+    /// the baked read-only `/etc/resolv.conf` so udhcpc's script (and
+    /// the lease it carries) can write DNS config through the mount.
+    fn seed_resolv_conf(cmdline: &str) -> Result<(), String> {
+        std::fs::create_dir_all("/run/mvm").map_err(|e| format!("mkdir /run/mvm: {e}"))?;
+        std::fs::write("/run/mvm/resolv.conf", resolver_seed(cmdline))
+            .map_err(|e| format!("seed /run/mvm/resolv.conf: {e}"))?;
+        let st = Command::new("/bin/busybox")
+            .args([
+                "mount",
+                "--bind",
+                "/run/mvm/resolv.conf",
+                "/etc/resolv.conf",
+            ])
+            .status()
+            .map_err(|e| format!("spawn mount --bind resolv.conf: {e}"))?;
+        if !st.success() {
+            return Err(format!(
+                "bind-mount resolv.conf exit {}",
+                st.code().unwrap_or(-1)
+            ));
+        }
+        Ok(())
     }
 
     /// Bring a network interface administratively up via

--- a/crates/mvm-build/src/bin/mvm-host-vm-init.rs
+++ b/crates/mvm-build/src/bin/mvm-host-vm-init.rs
@@ -2094,22 +2094,36 @@ mod linux {
     }
 
     fn setup_network() -> Result<(), String> {
-        // Seed /run/resolv.conf from the fallback before
-        // udhcpc runs. /etc/resolv.conf is a symlink into /run, so
-        // libc resolvers have a usable nameserver list from boot 1
-        // even if DHCP fails (TSI mode, or passt mid-handoff).
-        // Failure here is non-fatal — the symlink might not exist
-        // on an older guest, in which case udhcpc's
-        // own write to /etc/resolv.conf (if -s is set) is the
-        // only path.
-        let fallback = std::path::Path::new("/etc/resolv.conf.fallback");
-        if fallback.is_file() {
-            if let Err(e) = std::fs::copy(fallback, "/run/resolv.conf") {
-                eprintln!(
-                    "mvm-host-vm-init: copy /etc/resolv.conf.fallback -> \
-                     /run/resolv.conf: {e} (continuing — udhcpc may fix it)"
-                );
-            }
+        let cmdline = std::fs::read_to_string("/proc/cmdline").unwrap_or_default();
+
+        // The rootfs mounts ro and /etc/resolv.conf is a baked regular file,
+        // not a /run symlink. busybox's DHCP script writes /etc/resolv.conf
+        // directly and gets EROFS, so leased DNS never lands. Mount a tmpfs-
+        // backed copy over /etc/resolv.conf before udhcpc runs so the script's
+        // write goes to tmpfs. The seed chooses the gateway resolver for the
+        // active VMM's virtual network: gvproxy backends (libkrun, Vz) serve
+        // DNS at 192.168.127.1; QEMU slirp at 10.0.2.3. Both do host-side
+        // resolution and work on any network; baked public resolvers don't.
+        // Seeding before udhcpc also means the bind-mount is in place on the
+        // Vz path where DHCP fails — the static fallback below gives the IP
+        // and the seed covers DNS.
+        std::fs::create_dir_all("/run/mvm").map_err(|e| format!("mkdir /run/mvm: {e}"))?;
+        std::fs::write("/run/mvm/resolv.conf", resolver_seed(&cmdline))
+            .map_err(|e| format!("seed /run/mvm/resolv.conf: {e}"))?;
+        let st = Command::new("/bin/busybox")
+            .args([
+                "mount",
+                "--bind",
+                "/run/mvm/resolv.conf",
+                "/etc/resolv.conf",
+            ])
+            .status()
+            .map_err(|e| format!("spawn mount --bind resolv.conf: {e}"))?;
+        if !st.success() {
+            return Err(format!(
+                "bind-mount resolv.conf exit {}",
+                st.code().unwrap_or(-1)
+            ));
         }
 
         // busybox 1.36.x udhcpc binds a PF_PACKET raw socket to
@@ -2132,13 +2146,6 @@ mod linux {
             );
         }
 
-        // When /etc/udhcpc/default.script exists (passt
-        // path), use it so the DHCP lease
-        // writes /run/resolv.conf with the leased DNS. Older rootfs
-        // builds without the script keep the legacy `-i eth0 -n -q`
-        // shape — udhcpc still sets the IP but resolv.conf stays at
-        // the fallback content.
-        //
         // `/bin/udhcpc` — udhcpc is a busybox applet, and mkGuest
         // installs busybox applet symlinks under `/bin/<applet>`,
         // not `/sbin/`. (Prior `/sbin/udhcpc` hardcoding ENOENTed at
@@ -2154,10 +2161,52 @@ mod linux {
         let status = cmd
             .status()
             .map_err(|e| format!("spawn /bin/udhcpc: {e}"))?;
-        if !status.success() {
+        if dhcp_fallback_applies(&cmdline, status.success()) {
+            // gvproxy's virtual subnet is fixed (192.168.127.0/24, gateway+DNS
+            // at .1, first DHCP client at .3). Each builder VM gets its own
+            // gvproxy instance, so the static address cannot collide.
+            eprintln!(
+                "mvm-host-vm-init: udhcpc exit {} — falling back to static \
+                 gvproxy addressing",
+                status.code().unwrap_or(-1)
+            );
+            mvm_build::guest_net::configure_static(
+                "eth0",
+                "192.168.127.3",
+                "255.255.255.0",
+                "192.168.127.1",
+            )?;
+        } else if !status.success() {
             return Err(format!("udhcpc exit {}", status.code().unwrap_or(-1)));
         }
         Ok(())
+    }
+
+    /// True when a DHCP failure should trigger the static gvproxy fallback.
+    ///
+    /// The QEMU/slirp backend uses a different subnet (10.0.2.x) with its
+    /// own `ip=` autoconfig; applying the gvproxy address there would give
+    /// the wrong gateway and break connectivity. A success exit never needs
+    /// the fallback regardless of backend.
+    fn dhcp_fallback_applies(cmdline: &str, udhcpc_success: bool) -> bool {
+        if udhcpc_success {
+            return false;
+        }
+        !cmdline.split_whitespace().any(|t| t == "mvm.backend=qemu")
+    }
+
+    /// The gateway-local resolver for the active VMM's virtual network.
+    ///
+    /// QEMU user-mode networking serves DNS at 10.0.2.3; the gvproxy
+    /// backends (libkrun, Vz) at 192.168.127.1. Host-side resolution
+    /// through the gateway works on any network — baked public resolvers
+    /// only work where the local network permits direct external UDP/53.
+    fn resolver_seed(cmdline: &str) -> &'static [u8] {
+        if cmdline.split_whitespace().any(|t| t == "mvm.backend=qemu") {
+            b"nameserver 10.0.2.3\n"
+        } else {
+            b"nameserver 192.168.127.1\n"
+        }
     }
 
     /// Encode a Linux interface name into the fixed-size `ifr_name`
@@ -2917,6 +2966,69 @@ mod linux {
             let err = encode_iface_name(&over).expect_err("IFNAMSIZ-byte name rejected");
             assert!(err.contains("IFNAMSIZ"), "err mentions limit: {err}");
             assert!(err.contains(&over), "err includes the offending name");
+        }
+
+        #[test]
+        fn dhcp_fallback_applies_non_qemu_failure() {
+            assert!(dhcp_fallback_applies(
+                "console=hvc0 root=/dev/vda rw",
+                false
+            ));
+        }
+
+        #[test]
+        fn dhcp_fallback_applies_qemu_no_fallback() {
+            // QEMU uses a different subnet; the static gvproxy address must not
+            // be applied there.
+            assert!(!dhcp_fallback_applies(
+                "console=hvc0 mvm.backend=qemu root=/dev/vda",
+                false
+            ));
+        }
+
+        #[test]
+        fn dhcp_fallback_applies_success_no_fallback() {
+            assert!(!dhcp_fallback_applies(
+                "console=hvc0 root=/dev/vda rw",
+                true
+            ));
+        }
+
+        #[test]
+        fn dhcp_fallback_applies_qemu_prefix_not_matched() {
+            // A token that merely starts with "mvm.backend=qemu" must not
+            // match — whole-word only.
+            assert!(dhcp_fallback_applies(
+                "console=hvc0 mvm.backend=qemux root=/dev/vda",
+                false
+            ));
+        }
+
+        #[test]
+        fn resolver_seed_gvproxy_backend() {
+            assert_eq!(
+                resolver_seed("console=hvc0 root=/dev/vda rw"),
+                b"nameserver 192.168.127.1\n"
+            );
+        }
+
+        #[test]
+        fn resolver_seed_qemu_backend() {
+            assert_eq!(
+                resolver_seed("console=hvc0 mvm.backend=qemu root=/dev/vda"),
+                b"nameserver 10.0.2.3\n"
+            );
+        }
+
+        #[test]
+        fn resolver_seed_qemu_token_must_be_whole_word() {
+            // A token that starts with "mvm.backend=qemu" but has trailing
+            // characters is not a match — the seed must stay at gvproxy's
+            // gateway resolver.
+            assert_eq!(
+                resolver_seed("console=hvc0 mvm.backend=qemux root=/dev/vda"),
+                b"nameserver 192.168.127.1\n"
+            );
         }
 
         /// `run_job_streaming` calls the

--- a/crates/mvm-build/src/bin/mvm-host-vm-init.rs
+++ b/crates/mvm-build/src/bin/mvm-host-vm-init.rs
@@ -2209,36 +2209,14 @@ mod linux {
         }
     }
 
-    /// Encode a Linux interface name into the fixed-size `ifr_name`
-    /// byte array used by SIOCG/SIOCSIFFLAGS. Linux caps interface
-    /// names at `IFNAMSIZ` (16) bytes including the NUL terminator,
-    /// so the longest valid input is 15 bytes. Split out from
-    /// [`bring_iface_up`] so the bounds check is unit-testable
-    /// without making a real syscall.
-    fn encode_iface_name(iface: &str) -> Result<[libc::c_char; libc::IFNAMSIZ], String> {
-        let bytes = iface.as_bytes();
-        if bytes.len() >= libc::IFNAMSIZ {
-            return Err(format!(
-                "interface name '{iface}' is {} bytes; Linux IFNAMSIZ caps it at {}",
-                bytes.len(),
-                libc::IFNAMSIZ - 1,
-            ));
-        }
-        let mut buf = [0 as libc::c_char; libc::IFNAMSIZ];
-        for (i, &b) in bytes.iter().enumerate() {
-            buf[i] = b as libc::c_char;
-        }
-        Ok(buf)
-    }
-
     /// Bring a network interface administratively up via
     /// `ioctl(SIOCSIFFLAGS, IFF_UP)`. Equivalent to
     /// `ip link set dev <iface> up`, but issued directly so we
-    /// don't pin a new path-dependency in the ur-seed rootfs and
+    /// don't pin a new path-dependency in the builder rootfs and
     /// the error message names the failing ioctl. Called before
     /// `udhcpc` in [`setup_network`].
     fn bring_iface_up(iface: &str) -> Result<(), String> {
-        let name = encode_iface_name(iface)?;
+        let name = mvm_build::guest_net::encode_iface_name(iface)?;
 
         // SAFETY: socket(2) returns -1 on error (checked) or a
         // valid fd. We close it on every return path below.
@@ -2936,36 +2914,6 @@ mod linux {
             assert!(virtiofs_mount_flags("mvm-bins").contains(MsFlags::MS_RDONLY));
             assert_eq!(virtiofs_mount_flags("out"), MsFlags::empty());
             assert_eq!(virtiofs_mount_flags("job"), MsFlags::empty());
-        }
-
-        #[test]
-        fn encode_iface_name_eth0_pads_with_nul() {
-            let buf = encode_iface_name("eth0").expect("eth0 fits");
-            assert_eq!(buf[0] as u8, b'e');
-            assert_eq!(buf[1] as u8, b't');
-            assert_eq!(buf[2] as u8, b'h');
-            assert_eq!(buf[3] as u8, b'0');
-            assert_eq!(buf[4] as u8, 0, "remainder NUL-padded");
-            assert_eq!(buf[libc::IFNAMSIZ - 1] as u8, 0);
-        }
-
-        #[test]
-        fn encode_iface_name_max_length_succeeds() {
-            // 15 bytes + 1 NUL = exactly IFNAMSIZ.
-            let max = "a".repeat(libc::IFNAMSIZ - 1);
-            let buf = encode_iface_name(&max).expect("15-byte name fits");
-            for byte in buf.iter().take(libc::IFNAMSIZ - 1) {
-                assert_eq!(*byte as u8, b'a');
-            }
-            assert_eq!(buf[libc::IFNAMSIZ - 1] as u8, 0, "NUL terminator");
-        }
-
-        #[test]
-        fn encode_iface_name_too_long_errors() {
-            let over = "a".repeat(libc::IFNAMSIZ);
-            let err = encode_iface_name(&over).expect_err("IFNAMSIZ-byte name rejected");
-            assert!(err.contains("IFNAMSIZ"), "err mentions limit: {err}");
-            assert!(err.contains(&over), "err includes the offending name");
         }
 
         #[test]

--- a/crates/mvm-build/src/bin/stage0-init.rs
+++ b/crates/mvm-build/src/bin/stage0-init.rs
@@ -178,13 +178,7 @@ mod linux {
     fn configure_network_qemu() -> Result<(), String> {
         let iface = find_net_iface().ok_or("no non-loopback interface present")?;
         eprintln!("stage0-init: net config {iface} = 10.0.2.15/24 gw 10.0.2.2 (slirp)");
-        let sock = unsafe { libc::socket(libc::AF_INET, libc::SOCK_DGRAM, 0) };
-        if sock < 0 {
-            return Err(format!("socket: {}", std::io::Error::last_os_error()));
-        }
-        let res = net_ioctls(sock, &iface);
-        unsafe { libc::close(sock) };
-        res
+        mvm_build::guest_net::configure_static(&iface, "10.0.2.15", "255.255.255.0", "10.0.2.2")
     }
 
     /// The non-loopback interface name from `/sys/class/net` (e.g. `ens3`).
@@ -194,79 +188,6 @@ mod linux {
             .filter_map(|e| e.ok())
             .map(|e| e.file_name().to_string_lossy().into_owned())
             .find(|n| n != "lo")
-    }
-
-    /// SAFETY-scoped wrapper: standard `SIOCSIF*` / `SIOCADDRT` ioctls on an
-    /// AF_INET socket with correctly-sized `ifreq`/`rtentry` structs. The
-    /// `as _` casts adapt each request constant to `ioctl`'s request type
-    /// (differs gnu vs musl).
-    fn net_ioctls(sock: libc::c_int, iface: &str) -> Result<(), String> {
-        unsafe {
-            // address
-            let mut ifr = ifreq_for(iface);
-            set_sockaddr_in(&mut ifr.ifr_ifru.ifru_addr, [10, 0, 2, 15]);
-            if libc::ioctl(sock, libc::SIOCSIFADDR as _, &ifr) < 0 {
-                return Err(format!("SIOCSIFADDR: {}", std::io::Error::last_os_error()));
-            }
-            // netmask
-            let mut ifr = ifreq_for(iface);
-            set_sockaddr_in(&mut ifr.ifr_ifru.ifru_netmask, [255, 255, 255, 0]);
-            if libc::ioctl(sock, libc::SIOCSIFNETMASK as _, &ifr) < 0 {
-                return Err(format!(
-                    "SIOCSIFNETMASK: {}",
-                    std::io::Error::last_os_error()
-                ));
-            }
-            // flags |= UP|RUNNING (read-modify-write)
-            let mut ifr = ifreq_for(iface);
-            if libc::ioctl(sock, libc::SIOCGIFFLAGS as _, &mut ifr) < 0 {
-                return Err(format!("SIOCGIFFLAGS: {}", std::io::Error::last_os_error()));
-            }
-            ifr.ifr_ifru.ifru_flags |= (libc::IFF_UP | libc::IFF_RUNNING) as libc::c_short;
-            if libc::ioctl(sock, libc::SIOCSIFFLAGS as _, &ifr) < 0 {
-                return Err(format!("SIOCSIFFLAGS: {}", std::io::Error::last_os_error()));
-            }
-            // default route via 10.0.2.2
-            let mut rt: libc::rtentry = std::mem::zeroed();
-            set_sockaddr_in(&mut rt.rt_dst, [0, 0, 0, 0]);
-            set_sockaddr_in(&mut rt.rt_genmask, [0, 0, 0, 0]);
-            set_sockaddr_in(&mut rt.rt_gateway, [10, 0, 2, 2]);
-            rt.rt_flags = (libc::RTF_UP | libc::RTF_GATEWAY) as libc::c_ushort;
-            if libc::ioctl(sock, libc::SIOCADDRT as _, &rt) < 0 {
-                return Err(format!("SIOCADDRT: {}", std::io::Error::last_os_error()));
-            }
-            Ok(())
-        }
-    }
-
-    fn ifreq_for(iface: &str) -> libc::ifreq {
-        // SAFETY: ifreq is a plain C struct; zeroed is a valid empty request.
-        let mut ifr: libc::ifreq = unsafe { std::mem::zeroed() };
-        for (i, b) in iface.bytes().enumerate().take(libc::IFNAMSIZ - 1) {
-            ifr.ifr_name[i] = b as libc::c_char;
-        }
-        ifr
-    }
-
-    /// Write an IPv4 `sockaddr_in` into a `sockaddr`-typed ioctl field.
-    fn set_sockaddr_in(dst: *mut libc::sockaddr, addr: [u8; 4]) {
-        let sin = libc::sockaddr_in {
-            sin_family: libc::AF_INET as libc::sa_family_t,
-            sin_port: 0,
-            sin_addr: libc::in_addr {
-                s_addr: u32::from_ne_bytes(addr),
-            },
-            sin_zero: [0; 8],
-        };
-        // SAFETY: dst points at a `sockaddr`-sized field; sockaddr_in is the
-        // same 16 bytes. Caller passes a valid, writable field pointer.
-        unsafe {
-            std::ptr::copy_nonoverlapping(
-                &sin as *const libc::sockaddr_in as *const u8,
-                dst as *mut u8,
-                std::mem::size_of::<libc::sockaddr_in>(),
-            );
-        }
     }
 
     /// Diagnostic dump of the guest's network state under QEMU — so a boot log

--- a/crates/mvm-build/src/guest_net.rs
+++ b/crates/mvm-build/src/guest_net.rs
@@ -1,0 +1,224 @@
+//! Shared in-guest network configuration helpers.
+//!
+//! Factored out of `stage0-init` so both builder init binaries
+//! (`stage0-init` and `mvm-host-vm-init`) share one implementation of
+//! the static-IP ioctl sequence instead of two diverging copies.
+//!
+//! The ioctl bodies are gated `#[cfg(target_os = "linux")]`; the pure
+//! address-parsing helpers compile and are unit-tested on every host.
+
+/// Parse a dotted-decimal IPv4 string into a 4-byte array.
+///
+/// Returns `None` if the string is not exactly four decimal octets
+/// separated by dots, or if any octet exceeds 255.
+pub fn parse_ipv4(s: &str) -> Option<[u8; 4]> {
+    let mut parts = s.splitn(5, '.');
+    let a = parts.next()?.parse::<u8>().ok()?;
+    let b = parts.next()?.parse::<u8>().ok()?;
+    let c = parts.next()?.parse::<u8>().ok()?;
+    let d = parts.next()?.parse::<u8>().ok()?;
+    if parts.next().is_some() {
+        return None;
+    }
+    Some([a, b, c, d])
+}
+
+/// Encode an interface name into a NUL-padded `[c_char; IFNAMSIZ]` buffer.
+///
+/// Returns `Err` if the name is too long for Linux's `IFNAMSIZ` limit
+/// (15 bytes of name + 1 NUL terminator = 16 bytes total).
+pub fn encode_iface_name(iface: &str) -> Result<[libc::c_char; libc::IFNAMSIZ], String> {
+    let bytes = iface.as_bytes();
+    if bytes.len() >= libc::IFNAMSIZ {
+        return Err(format!(
+            "interface name '{iface}' is {} bytes; Linux IFNAMSIZ caps it at {}",
+            bytes.len(),
+            libc::IFNAMSIZ - 1,
+        ));
+    }
+    let mut buf = [0 as libc::c_char; libc::IFNAMSIZ];
+    for (i, &b) in bytes.iter().enumerate() {
+        buf[i] = b as libc::c_char;
+    }
+    Ok(buf)
+}
+
+/// Statically configure a guest NIC: assign `addr/netmask` and install a
+/// default route via `gateway`.
+///
+/// Applies the standard `SIOCSIFADDR` / `SIOCSIFNETMASK` / `SIOCSIFFLAGS`
+/// (UP|RUNNING) / `SIOCADDRT` ioctl sequence on an `AF_INET/SOCK_DGRAM`
+/// socket. The gvproxy virtual subnet is fixed (`192.168.127.0/24`, gateway
+/// `.1`, first DHCP client `.3`), and each builder VM gets its own gvproxy
+/// instance, so a static address cannot collide across VMs.
+#[cfg(target_os = "linux")]
+pub fn configure_static(
+    iface: &str,
+    addr: &str,
+    netmask: &str,
+    gateway: &str,
+) -> Result<(), String> {
+    let addr_b = parse_ipv4(addr).ok_or_else(|| format!("bad addr: {addr}"))?;
+    let mask_b = parse_ipv4(netmask).ok_or_else(|| format!("bad netmask: {netmask}"))?;
+    let gw_b = parse_ipv4(gateway).ok_or_else(|| format!("bad gateway: {gateway}"))?;
+
+    // SAFETY: socket(2) returns -1 on error (checked below) or a valid fd.
+    // We close it on every return path.
+    let sock = unsafe { libc::socket(libc::AF_INET, libc::SOCK_DGRAM, 0) };
+    if sock < 0 {
+        return Err(format!(
+            "socket(AF_INET, SOCK_DGRAM) for {iface}: {}",
+            std::io::Error::last_os_error()
+        ));
+    }
+    let res = apply_ioctls(sock, iface, addr_b, mask_b, gw_b);
+    // SAFETY: sock is valid, we own it.
+    unsafe { libc::close(sock) };
+    res
+}
+
+/// Run the SIOCSIF* / SIOCADDRT sequence on an already-opened socket.
+///
+/// Separated so the socket lifetime is clear and the helper stays testable
+/// in isolation (the caller owns open + close).
+#[cfg(target_os = "linux")]
+fn apply_ioctls(
+    sock: libc::c_int,
+    iface: &str,
+    addr: [u8; 4],
+    netmask: [u8; 4],
+    gateway: [u8; 4],
+) -> Result<(), String> {
+    unsafe {
+        // address
+        let mut ifr = ifreq_for(iface);
+        set_sockaddr_in(&mut ifr.ifr_ifru.ifru_addr, addr);
+        if libc::ioctl(sock, libc::SIOCSIFADDR as _, &ifr) < 0 {
+            return Err(format!(
+                "SIOCSIFADDR {iface}: {}",
+                std::io::Error::last_os_error()
+            ));
+        }
+        // netmask
+        let mut ifr = ifreq_for(iface);
+        set_sockaddr_in(&mut ifr.ifr_ifru.ifru_netmask, netmask);
+        if libc::ioctl(sock, libc::SIOCSIFNETMASK as _, &ifr) < 0 {
+            return Err(format!(
+                "SIOCSIFNETMASK {iface}: {}",
+                std::io::Error::last_os_error()
+            ));
+        }
+        // flags: read current then OR in UP|RUNNING
+        let mut ifr = ifreq_for(iface);
+        if libc::ioctl(sock, libc::SIOCGIFFLAGS as _, &mut ifr) < 0 {
+            return Err(format!(
+                "SIOCGIFFLAGS {iface}: {}",
+                std::io::Error::last_os_error()
+            ));
+        }
+        ifr.ifr_ifru.ifru_flags |= (libc::IFF_UP | libc::IFF_RUNNING) as libc::c_short;
+        if libc::ioctl(sock, libc::SIOCSIFFLAGS as _, &ifr) < 0 {
+            return Err(format!(
+                "SIOCSIFFLAGS {iface}: {}",
+                std::io::Error::last_os_error()
+            ));
+        }
+        // default route
+        let mut rt: libc::rtentry = std::mem::zeroed();
+        set_sockaddr_in(&mut rt.rt_dst, [0, 0, 0, 0]);
+        set_sockaddr_in(&mut rt.rt_genmask, [0, 0, 0, 0]);
+        set_sockaddr_in(&mut rt.rt_gateway, gateway);
+        rt.rt_flags = (libc::RTF_UP | libc::RTF_GATEWAY) as libc::c_ushort;
+        if libc::ioctl(sock, libc::SIOCADDRT as _, &rt) < 0 {
+            return Err(format!("SIOCADDRT: {}", std::io::Error::last_os_error()));
+        }
+        Ok(())
+    }
+}
+
+/// Build an `ifreq` with the interface name pre-filled and all other fields
+/// zeroed. Truncates at `IFNAMSIZ - 1` bytes (the kernel enforces the same
+/// limit; `encode_iface_name` validates it before this function is called).
+#[cfg(target_os = "linux")]
+fn ifreq_for(iface: &str) -> libc::ifreq {
+    // SAFETY: ifreq is a plain C struct; zeroed is a valid empty request.
+    let mut ifr: libc::ifreq = unsafe { std::mem::zeroed() };
+    for (i, b) in iface.bytes().enumerate().take(libc::IFNAMSIZ - 1) {
+        ifr.ifr_name[i] = b as libc::c_char;
+    }
+    ifr
+}
+
+/// Write an IPv4 `sockaddr_in` into a `sockaddr`-typed ioctl field in-place.
+#[cfg(target_os = "linux")]
+fn set_sockaddr_in(dst: *mut libc::sockaddr, addr: [u8; 4]) {
+    let sin = libc::sockaddr_in {
+        sin_family: libc::AF_INET as libc::sa_family_t,
+        sin_port: 0,
+        sin_addr: libc::in_addr {
+            s_addr: u32::from_ne_bytes(addr),
+        },
+        sin_zero: [0; 8],
+    };
+    // SAFETY: `dst` points at a `sockaddr`-sized field inside an `ifreq` or
+    // `rtentry` that the caller zeroed and owns. `sockaddr_in` is the same
+    // 16 bytes on all Linux ABI targets.
+    unsafe {
+        std::ptr::copy_nonoverlapping(
+            &sin as *const libc::sockaddr_in as *const u8,
+            dst as *mut u8,
+            std::mem::size_of::<libc::sockaddr_in>(),
+        );
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parse_ipv4_valid_addresses() {
+        assert_eq!(parse_ipv4("192.168.127.1"), Some([192, 168, 127, 1]));
+        assert_eq!(parse_ipv4("10.0.2.15"), Some([10, 0, 2, 15]));
+        assert_eq!(parse_ipv4("0.0.0.0"), Some([0, 0, 0, 0]));
+        assert_eq!(parse_ipv4("255.255.255.0"), Some([255, 255, 255, 0]));
+    }
+
+    #[test]
+    fn parse_ipv4_rejects_malformed() {
+        assert_eq!(parse_ipv4(""), None);
+        assert_eq!(parse_ipv4("192.168.1"), None);
+        assert_eq!(parse_ipv4("192.168.1.1.1"), None);
+        assert_eq!(parse_ipv4("256.0.0.1"), None);
+        assert_eq!(parse_ipv4("notanip"), None);
+        assert_eq!(parse_ipv4("192.168.1.abc"), None);
+    }
+
+    #[test]
+    fn encode_iface_name_eth0_pads_with_nul() {
+        let buf = encode_iface_name("eth0").expect("eth0 fits");
+        assert_eq!(buf[0] as u8, b'e');
+        assert_eq!(buf[1] as u8, b't');
+        assert_eq!(buf[2] as u8, b'h');
+        assert_eq!(buf[3] as u8, b'0');
+        assert_eq!(buf[4] as u8, 0, "remainder NUL-padded");
+        assert_eq!(buf[libc::IFNAMSIZ - 1] as u8, 0);
+    }
+
+    #[test]
+    fn encode_iface_name_max_length_succeeds() {
+        let max = "a".repeat(libc::IFNAMSIZ - 1);
+        let buf = encode_iface_name(&max).expect("15-byte name fits");
+        for byte in buf.iter().take(libc::IFNAMSIZ - 1) {
+            assert_eq!(*byte as u8, b'a');
+        }
+        assert_eq!(buf[libc::IFNAMSIZ - 1] as u8, 0, "NUL terminator");
+    }
+
+    #[test]
+    fn encode_iface_name_too_long_errors() {
+        let over = "a".repeat(libc::IFNAMSIZ);
+        let err = encode_iface_name(&over).expect_err("IFNAMSIZ-byte name rejected");
+        assert!(err.contains("IFNAMSIZ"), "err mentions limit: {err}");
+    }
+}

--- a/crates/mvm-build/src/lib.rs
+++ b/crates/mvm-build/src/lib.rs
@@ -61,6 +61,11 @@ pub mod libkrun_network_provider;
 /// nix-tarball Stage 0 seed on the stock distro kernel + initramfs with
 /// ext4 disks + slirp networking. Linux-only at runtime; compiles
 /// everywhere (the selection only picks it on Linux).
+/// Shared in-guest static-IP helpers: `configure_static` (gated
+/// `cfg(linux)`) plus pure address-parsing/encoding utilities tested
+/// on every host. Consumed by both `stage0-init` and `mvm-host-vm-init`.
+pub mod guest_net;
+
 pub mod qemu_builder;
 
 /// Vz-backed builder VM (gated by `builder-vm` for symmetry with

--- a/specs/REFACTOR-STATUS.md
+++ b/specs/REFACTOR-STATUS.md
@@ -31,7 +31,7 @@ details** below for the workstream-level state.
 - [ ] **PLAN 126** — Dependency reduction · 🟡 ~25%; sigstore/aws-lc/lock-gate remain
 - [ ] **PLAN 177** — Backend consolidation (8→4) · 🟡 Phase 1 done; Phase 2 (AVF convergence) in progress
 - [ ] **PLAN 175** — Firecracker live-memory warm-start · 🔴 not started (live-KVM-gated)
-- [ ] **PLAN 183** — Builder-VM egress posture + network bootstrap · 🟡 WS-A landed; WS-B/C/D remain
+- [ ] **PLAN 183** — Builder-VM egress posture + network bootstrap · 🟡 WS-A/B/C landed; WS-D (E2E proof) remains
 - [x] **PLAN 180** — Strip spec refs from code comments · ✅ (lint-gated, #786)
 
 ## Plan details
@@ -235,9 +235,9 @@ PLAN 183 — Builder-VM egress posture + net boot 🟡 WS-A landed
   read-only baked file so leased DNS never lands.
   [x] WS-A egress posture per arm (boot open; install-arm locked, fail-closed;
       per-job posture in persistent dispatch; drop QEMU-only boot skip) — landed
-  [ ] WS-B Vz DHCP no-lease: static gvproxy fallback (shared stage0 ioctl
-      helpers) + time-boxed datagram-path root cause
-  [ ] WS-C writable /run-bind-mounted resolv.conf seeded with gateway resolver
+  [x] WS-B static gvproxy fallback when DHCP yields no lease — static fallback
+      landed; shared guest_net module; DHCP root cause deferred to WS-D
+  [x] WS-C writable /run-bind-mounted resolv.conf seeded with gateway resolver
   [ ] WS-D cold E2E proof on macOS + claim-11 install gate still locked +
       resume Plan 159 live Vz validation
 

--- a/specs/REFACTOR-STATUS.md
+++ b/specs/REFACTOR-STATUS.md
@@ -226,7 +226,7 @@ PLAN 159 — vz-inspired macOS VZ DX               🟡 152-independent slice sh
   [ ] live Vz WS-2 round-trip validation + fork semantic-A spike — BLOCKED on
       Plan 183 (builder-VM egress lockdown breaks every uncached flake build)
 
-PLAN 183 — Builder-VM egress posture + net boot 🟡 WS-A landed
+PLAN 183 — Builder-VM egress posture + net boot 🟡 WS-A/B/C landed; WS-D (E2E proof) remains
   Diagnosis proven 2026-06-11: boot-time install_egress_lockdown (OUTPUT DROP,
   proxy-uid-only) applied to the whole builder VM and dropped every nix fetch.
   WS-A moves the lockdown to the install arm (fail-closed) + opens egress for

--- a/specs/plans/183-builder-vm-egress-posture-and-dns.md
+++ b/specs/plans/183-builder-vm-egress-posture-and-dns.md
@@ -151,14 +151,14 @@ Per-arm posture keeps the lockdown exactly where the threat is.
 - Modify: `crates/mvm-build/src/bin/stage0-init.rs` (:178-260 — re-export/reuse)
 - Modify: `crates/mvm-build/src/bin/mvm-host-vm-init.rs` (`setup_network` :2185)
 
-- [ ] **B1: lift stage0's static-config ioctls into a shared module.** Move
+- [x] **B1: lift stage0's static-config ioctls into a shared module.** Move
   `configure_network_qemu`'s `ifreq_for` / `SIOCSIFADDR` / `SIOCSIFNETMASK` /
   `SIOCADDRT` plumbing (`stage0-init.rs:178-260`) into
   `mvm_build::guest_net::configure_static(iface, addr, netmask, gateway)`
   (cfg-gated linux like the bins). stage0-init's QEMU arm calls it with
   `10.0.2.15/24 via 10.0.2.2`; no behavior change there. Unit-test the pure parts
   (address parsing/encoding) on the host.
-- [ ] **B2: static fallback in `setup_network`.** When udhcpc exits nonzero on a
+- [x] **B2: static fallback in `setup_network`.** When udhcpc exits nonzero on a
   gvproxy backend, fall back instead of warning-and-continuing:
 
   ```rust
@@ -186,7 +186,7 @@ Per-arm posture keeps the lockdown exactly where the threat is.
   gvproxy's lease table. Outcome: either a fix in `vz_builder.rs` /
   `mvm-vz-supervisor`, or a documented defer with the static fallback as the
   steady-state (record under "deferred follow-ups" below).
-- [ ] **B4: gates + commit** `fix(builder-vm): static gvproxy fallback when DHCP
+- [x] **B4: gates + commit** `fix(builder-vm): static gvproxy fallback when DHCP
   yields no lease`.
 
 ## WS-C — writable resolv.conf seeded with the gateway resolver
@@ -194,37 +194,18 @@ Per-arm posture keeps the lockdown exactly where the threat is.
 **Files:**
 - Modify: `crates/mvm-build/src/bin/mvm-host-vm-init.rs` (`setup_network` :2185)
 
-- [ ] **C1: bind-mount a `/run`-backed resolv.conf before udhcpc.** Replace the
+- [x] **C1: bind-mount a `/run`-backed resolv.conf before udhcpc.** Replace the
   no-op fallback copy (the image bakes no `/etc/resolv.conf.fallback`; the file is
-  a read-only regular file, not a `/run` symlink — both comments are wrong) with:
-
-  ```rust
-  // The rootfs is ro and /etc/resolv.conf is a baked file, so leased
-  // DNS can never land there. Seed a tmpfs copy with the gateway
-  // resolver (gvproxy answers DNS on the virtual gateway address and
-  // forwards via the host's resolver chain — environment-independent,
-  // unlike baked public resolvers) and bind-mount it over /etc so
-  // udhcpc's script and the lease can update it.
-  std::fs::create_dir_all("/run/mvm").map_err(|e| format!("mkdir /run/mvm: {e}"))?;
-  std::fs::write("/run/mvm/resolv.conf", b"nameserver 192.168.127.1\n")
-      .map_err(|e| format!("seed /run/mvm/resolv.conf: {e}"))?;
-  let st = Command::new("/bin/busybox")
-      .args(["mount", "--bind", "/run/mvm/resolv.conf", "/etc/resolv.conf"])
-      .status()
-      .map_err(|e| format!("spawn mount --bind resolv.conf: {e}"))?;
-  if !st.success() {
-      return Err(format!("bind-mount resolv.conf exit {}", st.code().unwrap_or(-1)));
-  }
-  ```
-
-  Run this before `bring_iface_up`/udhcpc so the DHCP script's
-  `> /etc/resolv.conf` writes through the bind-mount onto tmpfs (this also makes
-  the passt path's leased DNS effective on Linux, where the same ro-write failure
-  exists). The QEMU builder arm is untouched (Debian initramfs `ip=` autoconfig).
-- [ ] **C2: delete the stale fallback-copy block + wrong comments** (the
+  a read-only regular file, not a `/run` symlink — both comments are wrong) with a
+  `resolver_seed(cmdline)`-seeded write + busybox bind-mount. *(Deviation from
+  plan text: `resolver_seed` is per-backend — QEMU gets `10.0.2.3`, gvproxy gets
+  `192.168.127.1` — superseding the "QEMU builder arm untouched" clause; the
+  per-backend seed matches stage0's proven values and gives the QEMU builder the
+  correct DNS too.)*
+- [x] **C2: delete the stale fallback-copy block + wrong comments** (the
   `/etc/resolv.conf.fallback` seed at :2194-2203 and the "symlink into /run" /
   "udhcpc still sets the IP" prose).
-- [ ] **C3: gates + commit** `fix(builder-vm): writable gateway-resolver
+- [x] **C3: gates + commit** `fix(builder-vm): writable gateway-resolver
   resolv.conf via /run bind-mount`.
 
 ## WS-D — verification + resume the live Vz validation


### PR DESCRIPTION
## Summary

Plan 183 WS-B + WS-C — the two guest-side defects behind the builder VM's broken networking (WS-A, #800, fixed the egress lockdown; this fixes IP + DNS):

- **WS-B — static gvproxy fallback when DHCP yields no lease.** The Vz builder's `udhcpc` discover gets no reply (`no lease, failing`) so eth0 was never configured. stage0-init's proven static-config ioctl machinery (`SIOCSIFADDR`/`SIOCSIFNETMASK`/flags-UP/`SIOCADDRT`) is lifted into a shared `mvm_build::guest_net` module (stage0's QEMU arm now calls it — pure lift, byte-identical behavior, no second ioctl copy left in the tree). When udhcpc fails on a gvproxy backend, `setup_network` falls back to `192.168.127.3/24` via `192.168.127.1` (gvproxy's fixed subnet; one gvproxy per builder VM, no collision). A pure, tested `dhcp_fallback_applies` guard skips the fallback on `mvm.backend=qemu` (slirp owns 10.0.2.x). The Vz↔gvproxy DHCP datagram root-cause stays tracked (B3 → WS-D).
- **WS-C — writable resolv.conf seeded with the gateway resolver.** `/etc/resolv.conf` is a baked read-only file (`1.1.1.1`/`8.8.8.8`), so busybox's DHCP script died with EROFS and leased DNS never landed — and baked public resolvers only work where the network permits direct external UDP/53. Now: a tmpfs copy is bind-mounted over it *before* udhcpc (so the lease writes through), seeded per backend via a pure `resolver_seed` helper — `192.168.127.1` for the gvproxy backends, `10.0.2.3` for QEMU slirp (stage0 parity; supersedes the plan's "QEMU untouched" sentence, recorded as a deviation note). Seed/bind-mount failure is deliberately non-fatal: DNS degrades to the baked resolvers but iface-up + DHCP still run.
- Dedupe ride-along: `bring_iface_up` now uses the shared `guest_net::encode_iface_name`; the init-local copy + duplicate tests removed.

Review trail: spec review (2 findings, fixed: rollup header drift, encoder dedupe) + adversarial quality review (READY WITH NITS — the ioctl lift verified line-by-line faithful incl. fd lifecycle and pointer-cast soundness; its one substantive nit, making the seed non-fatal so a bind-mount failure can't regress to no-IP, applied as the last commit).

Rollups: plan boxes B1/B2/B4/C1–C3 ticked (B3 deferred to WS-D), REFACTOR-STATUS → WS-A/B/C landed.

Next: WS-D — cold `dev up` E2E proof on macOS (libkrun + Vz legs) + resume the Plan 159 live Vz checkpoint/fork validation.

## Test Plan
- [x] `cargo fmt --all -- --check`, `cargo clippy --workspace -- -D warnings` clean
- [x] `cargo nextest run -p mvm-build` 535/535; workspace run (minus the local mvm-backend codesign quirk) green
- [x] `cargo zigbuild --target aarch64-unknown-linux-musl -p mvm-build --bins --tests` — the cfg(linux) helpers + tests compile for the real target (they execute in Linux CI)
- [x] `check-no-spec-refs-in-comments` clean; full `cargo build -p mvm-cli` embedded-bin cross-compile green
- [ ] Live cold-boot proof on this Vz/libkrun Mac lands with WS-D