### PR TITLE
chore(vsock): delete dead VsockProxyTransport

### DIFF
--- a/crates/mvm/src/vsock_transport.rs
+++ b/crates/mvm/src/vsock_transport.rs
@@ -143,36 +143,6 @@ impl VsockTransport for VzTransport {
     }
 }
 
-/// Connects through the daemon-managed mode-0700 proxy Unix socket.
-///
-/// Used for cross-process access in dev — the `mvmctl dev` daemon
-/// owns the framework-side VM and exposes a per-VM Unix socket where
-/// each new connection writes the destination vsock port as a
-/// 4-byte little-endian prefix and the daemon then forwards bytes
-/// to the framework. Mode-0700 is the security boundary.
-pub struct VsockProxyTransport {
-    proxy_path: String,
-}
-
-impl VsockProxyTransport {
-    pub fn new(proxy_path: impl Into<String>) -> Self {
-        Self {
-            proxy_path: proxy_path.into(),
-        }
-    }
-}
-
-impl VsockTransport for VsockProxyTransport {
-    fn connect(&self, port: u32) -> Result<UnixStream> {
-        let mut stream = UnixStream::connect(&self.proxy_path)
-            .with_context(|| format!("Failed to connect to vsock proxy at {}", &self.proxy_path))?;
-        stream
-            .write_all(&port.to_le_bytes())
-            .with_context(|| "Failed to write vsock proxy port prefix")?;
-        Ok(stream)
-    }
-}
-
 /// Connects through the nesting hop: the outer host
 /// reaches a workload microVM's vsock *via* the long-lived libkrun
 /// host VM. The hop socket is the host VM's libkrun UDS for
@@ -254,26 +224,6 @@ pub fn for_vm(vm_name: &str) -> Result<Box<dyn VsockTransport>> {
 #[cfg(test)]
 mod tests {
     use super::*;
-
-    #[test]
-    fn proxy_transport_writes_port_prefix() {
-        // socketpair acts as a stand-in for the daemon's listening
-        // proxy socket: the "client" side of VsockProxyTransport
-        // should write the port bytes immediately on connect.
-        // We can't actually drive `connect()` here because the
-        // proxy_path needs to be a real filesystem socket; this test
-        // only exercises construction + the public surface so the
-        // factory contract has a regression net even on hosts where
-        // `tempfile` + UDS listeners would be flaky in CI.
-        let t = VsockProxyTransport::new("/tmp/mvm-proxy-does-not-exist.sock");
-        let err = t
-            .connect(mvm_guest::vsock::GUEST_AGENT_PORT)
-            .expect_err("should fail to connect");
-        assert!(
-            err.to_string().contains("vsock proxy"),
-            "error didn't mention proxy: {err}"
-        );
-    }
 
     #[test]
     fn firecracker_transport_constructs_with_instance_dir() {


### PR DESCRIPTION
## Summary

`VsockProxyTransport` was the cross-process dev-VM daemon proxy-socket transport. The Plan 177 AVF convergence (#806/#814) retired the `mvmctl dev` in-process daemon — the dev VM now connects through the vz supervisor's per-port socket via `VzTransport`. That left `VsockProxyTransport` with **zero remaining callers** (only its own struct, impl, and unit test).

This removes all three. The `std::io::Write` import stays — the nesting-hop transport still uses it.

## Verification

- `git grep VsockProxyTransport` → no remaining references.
- `cargo build -p mvm` + `cargo clippy -p mvm --all-targets` clean.
- `cargo fmt --all --check` (nightly) clean.
- The 8 `vsock_transport` unit tests still pass.

Pure dead-code deletion; no behavior change.