### PR TITLE
ci: add merge_group triggers (enable merge queue on main)

### DIFF
--- a/.github/workflows/architecture.yml
+++ b/.github/workflows/architecture.yml
@@ -15,6 +15,8 @@ on:
   push:
     branches: [main]
   pull_request:
+  # Required for the merge queue: the Invariant check must run on merge_group.
+  merge_group:
   workflow_dispatch:
 
 concurrency:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,7 +7,10 @@ on:
   # OCI ratification, security, Windows, and release artifact jobs live
   # in release/manual workflows.
   push:
-    branches: ["**"]
+    # Exclude the merge-queue transient branches — covered by merge_group below.
+    branches: ["**", "!gh-readonly-queue/**"]
+  # Required for the merge queue: checks must run against the merge_group event.
+  merge_group:
   workflow_dispatch:
 
 concurrency:


### PR DESCRIPTION
Prerequisite for enabling a merge queue on `main`. The 6 required checks come from **ci.yml** (Lint, Test, MCP, Passt, Nix) and **architecture.yml** (Invariant); a merge queue gates merges on those checks running against the `merge_group` candidate branch, so both must trigger on `merge_group` — otherwise queued PRs never satisfy the checks and deadlock.

- ci.yml: add `merge_group:`; exclude `gh-readonly-queue/**` from `push` to avoid double-running the queue candidate.
- architecture.yml: add `merge_group:` so the Invariant check runs on the candidate.

The merge-queue ruleset is created **after** this lands (so the queue never deadlocks). Workflow-trigger change only.