### PR TITLE
docs(sprint): refresh stale Current Status header (v0.13.0 → v0.16.1)

### DIFF
--- a/specs/SPRINT.md
+++ b/specs/SPRINT.md
@@ -23,16 +23,24 @@ technical, verifiable, and stated explicitly.
 ADR-002 captures the threat model and the seventeen surfaces audited;
 plan 25 sequences the work into six independently-shippable workstreams.
 
-## Current Status (v0.13.0, sprint open)
+## Current Status (v0.16.1)
 
-| Metric           | Value                    |
-| ---------------- | ------------------------ |
-| Workspace crates | 7 + root facade + xtask  |
-| Total tests      | 1 068                    |
-| Clippy warnings  | 0                        |
-| Edition          | 2024 (Rust 1.85+)        |
-| MSRV             | 1.85                     |
-| Binary           | `mvmctl`                 |
+> This file is a **cumulative multi-sprint log** — it opened at Sprint 42
+> (immediately below) and has grown through **Sprint 62**. Recent active work:
+> Sprint 60 (core demo green, in flight), Sprint 61 (app-builder surface,
+> proposed), Sprint 62 (ADR-080 wasm preview → microVM ship, in flight). Read a
+> given sprint's own section for its live status; the table below is the current
+> workspace snapshot, not Sprint 42's.
+
+| Metric           | Value                                  |
+| ---------------- | -------------------------------------- |
+| Version          | v0.16.1                                |
+| Workspace crates | 15 (ADR-066 §1; Plan 121 folded 32→15) |
+| Total tests      | ~4,350 (`cargo nextest`)               |
+| Clippy warnings  | 0                                      |
+| Edition          | 2024 (Rust 1.85+)                      |
+| MSRV             | 1.85                                   |
+| Binary           | `mvmctl`                               |
 
 ## Planning updates
 


### PR DESCRIPTION
## Summary

`specs/SPRINT.md` is a cumulative multi-sprint log that opened at Sprint 42 and now runs through Sprint 62, but its top **Current Status** block was frozen at Sprint-42 reality: `v0.13.0`, a 7-crate / 1,068-test metrics table. A reader hitting the top of the file would think Sprint 42 / v0.13.0 is "current."

This refreshes just that block:
- Version `v0.13.0` → **`v0.16.1`** (matches the latest tag + workspace `Cargo.toml`).
- Crates `7 + facade + xtask` → **15** (ADR-066 §1; Plan 121 folded 32→15).
- Tests `1 068` → **~4,350** (`cargo nextest`).
- Added a note that the file is a cumulative log with recent active work in Sprints 60–62, pointing readers to each sprint's own section for live status.

No sprint content changed — purely the stale snapshot header. Docs-only.