### PR TITLE
feat(cli): mvmctl dev status --json (Plan 189 WS-3 first slice)

### DIFF
--- a/crates/mvm-cli/src/commands/env/dev.rs
+++ b/crates/mvm-cli/src/commands/env/dev.rs
@@ -217,7 +217,11 @@ pub(in crate::commands) enum DevAction {
         project: Option<String>,
     },
     /// Show dev environment status.
-    Status,
+    Status {
+        /// Emit a machine-readable JSON report instead of text.
+        #[arg(long)]
+        json: bool,
+    },
     /// Inspect dev caches without rebuilding or booting.
     Cache {
         #[command(subcommand)]
@@ -441,7 +445,7 @@ fn cmd_dev_libkrun_down() -> Result<()> {
     LibkrunBackend.stop(&id)
 }
 
-fn cmd_dev_libkrun_status() -> Result<()> {
+fn cmd_dev_libkrun_status(json: bool) -> Result<()> {
     let id = VmId(dev_vz::DEV_VM_NAME.to_string());
     let status = LibkrunBackend.status(&id)?;
     let state = match status {
@@ -451,6 +455,11 @@ fn cmd_dev_libkrun_status() -> Result<()> {
         VmStatus::Paused => "paused",
         VmStatus::Failed { .. } => "failed",
     };
+    if json {
+        // libkrun has no in-guest kernel probe here; the dev-image +
+        // builder caches are backend-agnostic, so report them too.
+        return crate::json_out::emit_json(&dev_vz::build_dev_status_json("libkrun", state, None));
+    }
     ui::info("Backend:  libkrun (Hypervisor.framework)");
     ui::info(&format!("VM:       {}", dev_vz::DEV_VM_NAME));
     ui::info(&format!("Status:   {state}"));
@@ -596,11 +605,17 @@ pub(in crate::commands) fn run(_cli: &Cli, args: Args, cfg: &MvmConfig) -> Resul
             DevBackend::LinuxKvm => linux_native::cmd_dev_linux_native_shell(),
             DevBackend::Unsupported => bail_no_dev_backend(),
         },
-        DevAction::Status => match backend {
-            DevBackend::Libkrun => cmd_dev_libkrun_status(),
-            DevBackend::Vz => dev_vz::cmd_dev_vz_status(),
-            DevBackend::LinuxKvm => linux_native::cmd_dev_linux_native_status(),
+        DevAction::Status { json } => match backend {
+            DevBackend::Libkrun => cmd_dev_libkrun_status(json),
+            DevBackend::Vz => dev_vz::cmd_dev_vz_status(json),
+            DevBackend::LinuxKvm => linux_native::cmd_dev_linux_native_status(json),
             DevBackend::Unsupported => {
+                if json {
+                    return crate::json_out::emit_json(&dev_vz::build_dev_status_json_vmless(
+                        "unsupported",
+                        "unsupported",
+                    ));
+                }
                 ui::info(
                     "Dev environment: not configured on this host (Vz dev VM \
                      unavailable and native /dev/kvm missing). WSL2 nested KVM and \

--- a/crates/mvm-cli/src/commands/env/dev_vz.rs
+++ b/crates/mvm-cli/src/commands/env/dev_vz.rs
@@ -239,46 +239,26 @@ pub(super) fn cmd_dev_vz_down() -> Result<()> {
 }
 
 /// Show dev VM status.
-pub(super) fn cmd_dev_vz_status() -> Result<()> {
+pub(super) fn cmd_dev_vz_status(json: bool) -> Result<()> {
     let running = is_vz_dev_running();
+    let state = if running { "running" } else { "stopped" };
+    let kernel = if running { probe_dev_vm_kernel() } else { None };
+
+    if json {
+        return crate::json_out::emit_json(&build_dev_status_json("vz", state, kernel));
+    }
+
     ui::info("Backend:  Vz (Apple Virtualization.framework)");
     ui::info(&format!("Dev VM:   {DEV_VM_NAME}"));
-    ui::info(&format!(
-        "Status:   {}",
-        if running { "running" } else { "stopped" }
-    ));
-
-    #[cfg(feature = "builder-vm")]
-    if running && let Ok(mut stream) = dev_vm_guest_agent_connect() {
-        // Inbound vsock RPC audit.
-        super::super::shared::emit_vsock_rpc_audit(
-            DEV_VM_NAME,
-            &mvm_guest::vsock::GuestRequest::Exec {
-                command: "uname -r".to_string(),
-                stdin: None,
-                timeout_secs: Some(5),
-            },
-        );
-        // Best-effort kernel probe via streaming exec.
-        let mut out_buf: Vec<u8> = Vec::new();
-        if mvm_guest::vsock::send_exec_streaming(&mut stream, "uname -r", None, Some(5), |event| {
-            if let mvm_guest::vsock::ExecEvent::Stdout { chunk } = event {
-                out_buf.extend_from_slice(chunk);
-            }
-        })
-        .is_ok()
-        {
-            ui::info(&format!(
-                "  Kernel:  {}",
-                String::from_utf8_lossy(&out_buf).trim()
-            ));
-        }
+    ui::info(&format!("Status:   {state}"));
+    if let Some(kernel) = &kernel {
+        ui::info(&format!("  Kernel:  {kernel}"));
     }
 
     if let Some(image) = resolve_dev_status_image() {
         ui::info("  Image:   cached");
         if let Some(kernel_path) = image.kernel_path {
-            ui::info(&format!("  Kernel:  {kernel_path}"));
+            ui::info(&format!("  Image kernel: {kernel_path}"));
         }
         ui::info(&format!("  Rootfs:  {}", image.rootfs_path));
     } else {
@@ -294,6 +274,37 @@ pub(super) fn cmd_dev_vz_status() -> Result<()> {
     ));
 
     Ok(())
+}
+
+/// Best-effort `uname -r` over the dev VM's guest agent. `None` when the
+/// agent isn't reachable (VM down/booting) or the `builder-vm` feature
+/// (which carries the guest-agent transport) is off.
+#[cfg(feature = "builder-vm")]
+fn probe_dev_vm_kernel() -> Option<String> {
+    let mut stream = dev_vm_guest_agent_connect().ok()?;
+    // Inbound vsock RPC audit.
+    super::super::shared::emit_vsock_rpc_audit(
+        DEV_VM_NAME,
+        &mvm_guest::vsock::GuestRequest::Exec {
+            command: "uname -r".to_string(),
+            stdin: None,
+            timeout_secs: Some(5),
+        },
+    );
+    let mut out_buf: Vec<u8> = Vec::new();
+    mvm_guest::vsock::send_exec_streaming(&mut stream, "uname -r", None, Some(5), |event| {
+        if let mvm_guest::vsock::ExecEvent::Stdout { chunk } = event {
+            out_buf.extend_from_slice(chunk);
+        }
+    })
+    .ok()?;
+    let kernel = String::from_utf8_lossy(&out_buf).trim().to_string();
+    (!kernel.is_empty()).then_some(kernel)
+}
+
+#[cfg(not(feature = "builder-vm"))]
+fn probe_dev_vm_kernel() -> Option<String> {
+    None
 }
 
 /// Inspect dev caches without booting, rebuilding, or exposing local
@@ -393,15 +404,15 @@ struct DevCacheInspectJson {
     builder_cache: BuilderVmCacheJson,
 }
 
-#[derive(Debug, Serialize)]
-struct DevImageCacheJson {
+#[derive(Debug, Serialize, PartialEq, Eq)]
+pub(super) struct DevImageCacheJson {
     state: &'static str,
     kernel: &'static str,
     rootfs: &'static str,
 }
 
-#[derive(Debug, Serialize)]
-struct BuilderVmCacheJson {
+#[derive(Debug, Serialize, PartialEq, Eq)]
+pub(super) struct BuilderVmCacheJson {
     kind: &'static str,
     state: &'static str,
     reason_code: &'static str,
@@ -436,18 +447,87 @@ fn dev_image_cache_summary(image: Option<&DevStatusImage>) -> DevImageCacheSumma
 fn dev_cache_inspect_json(summary: &DevCacheInspectSummary) -> Result<String> {
     let output = DevCacheInspectJson {
         schema_version: 1,
-        dev_image: DevImageCacheJson {
-            state: summary.dev_image.state,
-            kernel: summary.dev_image.kernel,
-            rootfs: summary.dev_image.rootfs,
-        },
-        builder_cache: BuilderVmCacheJson {
-            kind: summary.builder_cache.cache_kind,
-            state: summary.builder_cache.state.label(),
-            reason_code: summary.builder_cache.reason_code,
-        },
+        dev_image: dev_image_cache_json(&summary.dev_image),
+        builder_cache: builder_vm_cache_json(&summary.builder_cache),
     };
     serde_json::to_string_pretty(&output).context("serializing dev cache inspection JSON")
+}
+
+fn dev_image_cache_json(summary: &DevImageCacheSummary) -> DevImageCacheJson {
+    DevImageCacheJson {
+        state: summary.state,
+        kernel: summary.kernel,
+        rootfs: summary.rootfs,
+    }
+}
+
+fn builder_vm_cache_json(summary: &BuilderVmCacheStatusSummary) -> BuilderVmCacheJson {
+    BuilderVmCacheJson {
+        kind: summary.cache_kind,
+        state: summary.state.label(),
+        reason_code: summary.reason_code,
+    }
+}
+
+/// Machine-readable `mvmctl dev status --json` shape. Privacy-safe like
+/// the cache-inspect report: cache fields say `present`/`missing`/`cached`,
+/// never a local artifact path or digest. `guest_kernel` carries the
+/// running guest's probed `uname -r` (a version string, not a path) only
+/// when the VM answers — distinct from `dev_image.kernel`, which reports
+/// whether the *cached image* ships a kernel artifact.
+#[derive(Debug, Serialize, PartialEq, Eq)]
+pub(super) struct DevStatusJson {
+    pub schema_version: u8,
+    pub backend: &'static str,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub vm_name: Option<&'static str>,
+    pub state: &'static str,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub guest_kernel: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub dev_image: Option<DevImageCacheJson>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub builder_cache: Option<BuilderVmCacheJson>,
+}
+
+/// Build the status report for a VM-backed dev backend (vz / libkrun):
+/// resolves the backend-agnostic dev-image + builder-VM cache state and
+/// attaches the caller-probed `kernel` (vz only; `None` elsewhere).
+pub(super) fn build_dev_status_json(
+    backend: &'static str,
+    state: &'static str,
+    guest_kernel: Option<String>,
+) -> DevStatusJson {
+    DevStatusJson {
+        schema_version: 1,
+        backend,
+        vm_name: Some(DEV_VM_NAME),
+        state,
+        guest_kernel,
+        dev_image: Some(dev_image_cache_json(&dev_image_cache_summary(
+            resolve_dev_status_image().as_ref(),
+        ))),
+        builder_cache: Some(builder_vm_cache_json(
+            &resolve_builder_vm_cache_status_summary(),
+        )),
+    }
+}
+
+/// Report for a backend with no managed dev VM (linux-native host shell,
+/// or an unsupported host): no VM, no image/builder cache.
+pub(super) fn build_dev_status_json_vmless(
+    backend: &'static str,
+    state: &'static str,
+) -> DevStatusJson {
+    DevStatusJson {
+        schema_version: 1,
+        backend,
+        vm_name: None,
+        state,
+        guest_kernel: None,
+        dev_image: None,
+        builder_cache: None,
+    }
 }
 
 fn resolve_builder_vm_cache_status_summary() -> BuilderVmCacheStatusSummary {
@@ -4272,6 +4352,59 @@ mod dev_status_image_tests {
         assert!(!json.contains("sha256"));
         assert!(!json.contains("rootfs.ext4"));
         assert!(!json.contains("vmlinux"));
+    }
+
+    #[test]
+    fn dev_status_json_is_versioned_and_privacy_safe() {
+        // A VM-backed report carries the backend, the fixed dev VM name,
+        // the state, and a guest-probed kernel version — but never a local
+        // artifact path or digest (same privacy floor as cache-inspect).
+        let report = build_dev_status_json("vz", "running", Some("6.1.0-mvm".to_string()));
+        assert_eq!(report.schema_version, 1);
+        assert_eq!(report.backend, "vz");
+        assert_eq!(report.vm_name, Some(DEV_VM_NAME));
+        assert_eq!(report.state, "running");
+        assert_eq!(report.guest_kernel.as_deref(), Some("6.1.0-mvm"));
+        assert!(report.dev_image.is_some());
+        assert!(report.builder_cache.is_some());
+
+        let json = crate::json_out::to_json_string(&report).expect("serialize");
+        assert!(json.contains("\"backend\": \"vz\""));
+        assert!(json.contains("\"state\": \"running\""));
+        assert!(json.contains("\"guest_kernel\": \"6.1.0-mvm\""));
+        // No absolute paths / image filenames / digests leak.
+        assert!(!json.contains("/Users"));
+        assert!(!json.contains("/private/tmp"));
+        assert!(!json.contains("rootfs.ext4"));
+        assert!(!json.contains("vmlinux"));
+        assert!(!json.contains("sha256"));
+    }
+
+    #[test]
+    fn dev_status_json_stopped_omits_kernel() {
+        // A stopped VM has no guest to probe; `guest_kernel` is skipped, not null.
+        let report = build_dev_status_json("vz", "stopped", None);
+        assert_eq!(report.state, "stopped");
+        assert!(report.guest_kernel.is_none());
+        let json = crate::json_out::to_json_string(&report).expect("serialize");
+        assert!(!json.contains("\"guest_kernel\""));
+    }
+
+    #[test]
+    fn dev_status_json_vmless_omits_vm_and_caches() {
+        // Host-native / unsupported hosts have no managed dev VM: vm_name,
+        // dev_image, and builder_cache are absent (not null).
+        let report = build_dev_status_json_vmless("linux-native", "ready");
+        assert_eq!(report.backend, "linux-native");
+        assert_eq!(report.state, "ready");
+        assert!(report.vm_name.is_none());
+        assert!(report.dev_image.is_none());
+        assert!(report.builder_cache.is_none());
+        let json = crate::json_out::to_json_string(&report).expect("serialize");
+        assert!(json.contains("\"backend\": \"linux-native\""));
+        assert!(!json.contains("\"vm_name\""));
+        assert!(!json.contains("\"dev_image\""));
+        assert!(!json.contains("\"builder_cache\""));
     }
 }
 

--- a/crates/mvm-cli/src/commands/env/linux_native.rs
+++ b/crates/mvm-cli/src/commands/env/linux_native.rs
@@ -88,10 +88,26 @@ pub(super) fn cmd_dev_linux_native_shell() -> Result<()> {
 
 /// `mvmctl dev status` on Linux+KVM. One-screen summary: KVM,
 /// Firecracker binary, kernel/rootfs presence.
-pub(super) fn cmd_dev_linux_native_status() -> Result<()> {
+pub(super) fn cmd_dev_linux_native_status(json: bool) -> Result<()> {
     let has_kvm = std::path::Path::new("/dev/kvm").exists();
     let fc_installed = firecracker::is_installed().unwrap_or(false);
     let has_assets = firecracker::has_base_assets().unwrap_or(false);
+
+    if json {
+        // Host-native dev env: no managed VM. Collapse readiness into a
+        // single state so the report shares the dev-status schema.
+        let state = if !has_kvm {
+            "no-kvm"
+        } else if fc_installed && has_assets {
+            "ready"
+        } else {
+            "not-ready"
+        };
+        return crate::json_out::emit_json(&super::dev_vz::build_dev_status_json_vmless(
+            "linux-native",
+            state,
+        ));
+    }
 
     ui::status_header();
     ui::status_line("Platform:", "Linux + KVM");

--- a/crates/mvm-cli/src/commands/tests.rs
+++ b/crates/mvm-cli/src/commands/tests.rs
@@ -3010,8 +3010,24 @@ fn test_dev_shell_parses() {
 
 #[test]
 fn test_dev_status_parses() {
-    let cli = Cli::try_parse_from(["mvmctl", "dev", "status"]);
-    assert!(cli.is_ok());
+    let cli = Cli::try_parse_from(["mvmctl", "dev", "status"]).unwrap();
+    match cli.command {
+        Commands::Dev(dev::Args {
+            action: Some(DevAction::Status { json }),
+        }) => assert!(!json, "bare `dev status` defaults to text output"),
+        _ => panic!("Expected Dev Status command"),
+    }
+}
+
+#[test]
+fn test_dev_status_json_flag_parses() {
+    let cli = Cli::try_parse_from(["mvmctl", "dev", "status", "--json"]).unwrap();
+    match cli.command {
+        Commands::Dev(dev::Args {
+            action: Some(DevAction::Status { json }),
+        }) => assert!(json, "`--json` requests machine-readable output"),
+        _ => panic!("Expected Dev Status command"),
+    }
 }
 
 #[test]

--- a/specs/REFACTOR-STATUS.md
+++ b/specs/REFACTOR-STATUS.md
@@ -1,6 +1,6 @@
 # Refactor status — rollup checklist
 
-**Last updated: 2026-06-12** (Plan 185 test-isolation sweep advanced; ADR-080 program batch landed: Plans 188/186/187)
+**Last updated: 2026-06-12** (Plan 185 test-isolation sweep advanced; ADR-080 program batch landed: Plans 188/186/187; Plan 189 WS-3 `dev status --json`)
 
 > MAINTENANCE: keep this file current. Whenever you land, merge, or descope a
 > workstream in any plan below, tick/strike the matching box here in the SAME
@@ -33,7 +33,7 @@ details** below for the workstream-level state.
 - [ ] **PLAN 182** — Trait hygiene + backend catalog · 🟡 code+docs done locally; aggregate workspace-test SIGKILL remains
 - [ ] **PLAN 184** — Backend descriptor registry · 🔴 not started
 - [ ] **PLAN 185** — Idiomatic Rust hygiene audit · 🟢 shared TestEnv expanded into mvm-cli/mvm-build; guest hook tests de-shelled
-- [ ] **PLAN 189** — VZ DX parity (post-convergence) · 🔴 scoped, not started — save/restore verbs, cached fast-boot default, --json coverage, base pinning (spun out of 177; sibling of 159)
+- [ ] **PLAN 189** — VZ DX parity (post-convergence) · 🟡 in progress — WS-3 `dev status --json` landed; remaining: save/restore verbs, cached fast-boot default, more --json coverage, base pinning (spun out of 177; sibling of 159)
 - [ ] **PLAN 175** — Firecracker live-memory warm-start · 🔴 not started (live-KVM-gated)
 - [x] **PLAN 183** — Builder-VM egress posture + network bootstrap · ✅ (E2E-proven 2026-06-12; Vz checkpoint-integration follow-ups tracked in the plan)
 - [x] **PLAN 180** — Strip spec refs from code comments · ✅ (lint-gated, #786)
@@ -393,9 +393,13 @@ PLAN 177 — Backend consolidation (8→4)           ✅ DONE — both phases me
       validation of already-merged code (vz boot path already exercised by Plan 152
       parity gate + Plan 159 workload-liveness); not a blocker for DONE.
 
-PLAN 189 — VZ DX parity (post-convergence)        🔴 scoped, not started  (ADR-076 §"Out of scope")
+PLAN 189 — VZ DX parity (post-convergence)        🟡 in progress  (ADR-076 §"Out of scope")
   Spun out of Plan 177's deferred DX-parity follow-on; sibling of Plan 159 (owns
   only the additive parity slice, cross-refs 159/140/148 for primitives).
+  [x] WS-3 first slice: `dev status --json` (versioned, privacy-safe DevStatusJson;
+      all 4 dispatch arms; serde + CLI-parse tests; verified on macOS-26)
+  [ ] WS-3 remaining: dev up/down --json, snapshot/checkpoint --json, linux-native detail
+  [ ] WS-1 save/restore verbs · WS-2 cached fast-boot default · WS-4 base pinning
   [ ] WS-1 surface save/restore verbs (gated by snapshot_capability tier)
   [ ] WS-2 cached fast-boot as the default vz boot posture
   [ ] WS-3 --json coverage across vz lifecycle verbs

--- a/specs/plans/189-vz-dx-parity.md
+++ b/specs/plans/189-vz-dx-parity.md
@@ -15,8 +15,8 @@
 > §"Out of scope" deferred this as "the DX-parity follow-on … its own plan
 > after Plan 177 lands." Plan 177 landed 2026-06-12.
 
-> **Status: 🔴 scoped, not started.** Spun out of [Plan 177](./177-backend-consolidation.md)
-> §"deferred follow-ups".
+> **Status: 🟡 in progress.** Spun out of [Plan 177](./177-backend-consolidation.md)
+> §"deferred follow-ups". WS-3 first slice landed: `dev status --json`.
 
 **Goal:** Bring the converged single `vz` Apple-Virtualization.framework path to
 DX parity with the reference embeddable-sandbox SDK — the table-stakes floor
@@ -72,10 +72,30 @@ the vz boot surface, not just the dev image.
 Machine-readable output for the vz lifecycle verbs so the surface is scriptable
 (mirrors Plan 168's `--json` work on the bootstrap/download verbs).
 
-- [ ] inventory which vz/dev verbs lack `--json` (`dev status`, `vm save`,
-      etc.); define the JSON schema per verb.
-- [ ] wire `--json` through the same emitter Plan 168 established; serde
-      roundtrip tests per shape.
+**Inventory (audit done):** the shared emitter is `crate::json_out::{emit_json,
+to_json_string}` (pretty, newline-terminated, no envelope). `dev cache inspect`
+already has `--json` and sets the privacy floor — cache fields report
+`present`/`missing`/`cached`, never a local artifact path or digest. Dev/vz
+lifecycle verbs lacking `--json`: `dev status` (done below), `dev up`,
+`dev down`, and the snapshot/checkpoint verbs (those route through Plan 159
+WS-2 / Plan 140 — add `--json` there, don't fork).
+
+- [x] **`dev status --json`** — versioned (`schema_version: 1`), privacy-safe
+      `DevStatusJson { backend, vm_name?, state, guest_kernel?, dev_image?,
+      builder_cache? }`. `guest_kernel` is the running guest's probed `uname -r`
+      (skipped when the VM is down), deliberately distinct from
+      `dev_image.kernel` (present/missing of the cached image's kernel
+      artifact). Wired through all four dispatch arms (vz / libkrun /
+      linux-native / unsupported) via a pure `build_dev_status_json[_vmless]`
+      builder; serde + privacy + CLI-parse tests; manually verified on
+      macOS-26. Reuses the cache-inspect JSON sub-structs.
+- [ ] `dev up --json` / `dev down --json` — emit a small lifecycle result
+      (backend, vm_name, action, outcome) so scripts can branch on boot/teardown.
+- [ ] snapshot/checkpoint `--json` — add to the Plan 159/140 verbs in place
+      (don't duplicate the primitive); WS-1 (`save`/`restore`) lands its own.
+- [ ] linux-native richer `--json` — today it collapses to a single `state`
+      (`ready`/`not-ready`/`no-kvm`); surface the kvm/firecracker/assets detail
+      as a typed shape if a Linux consumer needs it.
 - [ ] acceptance: every vz lifecycle verb has a documented `--json` form with
       a stable schema + test.
 


### PR DESCRIPTION
First slice of Plan 189 (VZ DX parity, spun out of Plan 177) — WS-3 `--json` coverage.

Adds a machine-readable `--json` form to `mvmctl dev status`, mirroring the existing `dev cache inspect --json`.

## Shape (`DevStatusJson`)
- `schema_version: 1` (versioned for stability).
- `backend` (`vz`/`libkrun`/`linux-native`/`unsupported`), `vm_name?`, `state`.
- `guest_kernel?` — the **running guest's** probed `uname -r`, skipped when the VM is down. Deliberately distinct from `dev_image.kernel`, which reports whether the **cached image** ships a kernel artifact (a naming collision a test caught → disambiguated).
- `dev_image?` + `builder_cache?` — the backend-agnostic caches.
- **Privacy-safe** like cache-inspect: cache fields say `present`/`missing`/`cached`, never a local path or digest (asserted by test).

## Implementation
- Wired through all four `dev status` dispatch arms via a pure `build_dev_status_json` / `build_dev_status_json_vmless` builder, reusing the cache-inspect JSON sub-structs (extracted small helpers, no duplication) and the shared `crate::json_out` emitter.
- `linux-native` collapses readiness to a single `state` (`ready`/`not-ready`/`no-kvm`); richer Linux detail noted as a WS-3 follow-on.
- `probe_dev_vm_kernel` is `builder-vm`-feature-gated (returns `None` without it).

## Tests
serde + privacy (no paths leak) + `guest_kernel`-omitted-when-stopped + vmless-omits-vm/caches + CLI-parse (`--json` true / bare false). Manually verified the real output on macOS-26 (clean JSON, no paths, `guest_kernel` correctly omitted when stopped).

## Plan docs
Fleshed out Plan 189 WS-3 with the who-calls audit + remaining verbs (`dev up/down --json`, snapshot/checkpoint via 159/140, linux-native detail); flipped Plan 189 to 🟡 in REFACTOR-STATUS.