### PR TITLE
feat(cli): mvmctl dev down --json (Plan 189 WS-3)

### DIFF
--- a/crates/mvm-cli/src/commands/env/dev.rs
+++ b/crates/mvm-cli/src/commands/env/dev.rs
@@ -209,6 +209,9 @@ pub(in crate::commands) enum DevAction {
         /// next `dev up` rebuilds from local source.
         #[arg(long)]
         reset: bool,
+        /// Emit a machine-readable JSON result instead of text.
+        #[arg(long)]
+        json: bool,
     },
     /// Open a shell in the running dev VM.
     Shell {
@@ -433,8 +436,12 @@ fn cmd_dev_libkrun(
 /// recover cleanly. The current-backend stop is the primary
 /// surface; the other-backend stop is best-effort (logged but not
 /// surfaced as a hard error).
-fn cmd_dev_libkrun_down() -> Result<()> {
+fn cmd_dev_libkrun_down(json: bool) -> Result<bool> {
     let id = VmId(dev_vz::DEV_VM_NAME.to_string());
+    let was_running = matches!(
+        LibkrunBackend.status(&id),
+        Ok(VmStatus::Running | VmStatus::Starting | VmStatus::Paused)
+    );
     // Best-effort stop of the Vz side too (no-op if not running;
     // status check + stop is cheap).
     if let Ok(VmStatus::Running | VmStatus::Starting | VmStatus::Paused) = VzBackend.status(&id)
@@ -442,7 +449,43 @@ fn cmd_dev_libkrun_down() -> Result<()> {
     {
         tracing::warn!(error = %e, "best-effort Vz dev VM stop failed during libkrun dev down");
     }
-    LibkrunBackend.stop(&id)
+    LibkrunBackend.stop(&id)?;
+    if !json && was_running {
+        ui::success("Dev VM stopped.");
+    }
+    Ok(was_running)
+}
+
+/// Stable backend identifier for the JSON lifecycle reports.
+fn dev_backend_report_name(backend: DevBackend) -> &'static str {
+    match backend {
+        DevBackend::Vz => "vz",
+        DevBackend::Libkrun => "libkrun",
+        DevBackend::LinuxKvm => "linux-native",
+        DevBackend::Unsupported => "unsupported",
+    }
+}
+
+/// `dev down --reset`: drop the host-backed Nix-store overlay disk so the
+/// next `dev up` starts from an empty store. Returns whether a disk was
+/// actually removed. Prints human notes only when `!json`.
+fn reset_nix_store_overlay(json: bool) -> bool {
+    let nix_disk = format!("{}/dev/nix-store.img", mvm_core::config::mvm_data_dir());
+    match std::fs::remove_file(&nix_disk) {
+        Ok(()) => {
+            if !json {
+                ui::info("Cleared host-backed Nix store; next `dev up` will mkfs a fresh one.");
+            }
+            true
+        }
+        Err(e) if e.kind() == std::io::ErrorKind::NotFound => false,
+        Err(e) => {
+            if !json {
+                ui::warn(&format!("Could not remove {nix_disk}: {e}"));
+            }
+            false
+        }
+    }
 }
 
 fn cmd_dev_libkrun_status(json: bool) -> Result<()> {
@@ -546,37 +589,28 @@ pub(in crate::commands) fn run(_cli: &Cli, args: Args, cfg: &MvmConfig) -> Resul
                 DevBackend::Unsupported => bail_no_dev_backend(),
             }
         }
-        DevAction::Down { reset } => {
-            let result = match backend {
-                DevBackend::Libkrun => cmd_dev_libkrun_down(),
-                DevBackend::Vz => dev_vz::cmd_dev_vz_down(),
-                DevBackend::LinuxKvm => linux_native::cmd_dev_linux_native_down(),
+        DevAction::Down { reset, json } => {
+            let was_running = match backend {
+                DevBackend::Libkrun => cmd_dev_libkrun_down(json),
+                DevBackend::Vz => dev_vz::cmd_dev_vz_down(json),
+                DevBackend::LinuxKvm => linux_native::cmd_dev_linux_native_down(json),
                 // Nothing to stop on unsupported hosts. The gc-root
                 // cleanup below still runs.
-                DevBackend::Unsupported => Ok(()),
+                DevBackend::Unsupported => Ok(false),
+            }?;
+            let reset_done = if reset {
+                reset_nix_store_overlay(json)
+            } else {
+                false
             };
-            if reset {
-                // `--reset` additionally drops the host-backed Nix
-                // store overlay disk. Useful for "make `dev up` start
-                // from a truly empty store" — e.g. after a corrupting
-                // crash, or to reproduce a first-boot scenario.
-                // Without this flag, the build cache survives `down`,
-                // which is the right default (rebuilds are cheap, the
-                // closure isn't).
-                let nix_disk = format!("{}/dev/nix-store.img", mvm_core::config::mvm_data_dir());
-                match std::fs::remove_file(&nix_disk) {
-                    Ok(()) => {
-                        ui::info(
-                            "Cleared host-backed Nix store; next `dev up` will mkfs a fresh one.",
-                        );
-                    }
-                    Err(e) if e.kind() == std::io::ErrorKind::NotFound => {}
-                    Err(e) => {
-                        ui::warn(&format!("Could not remove {nix_disk}: {e}"));
-                    }
-                }
+            if json {
+                return crate::json_out::emit_json(&dev_vz::build_dev_down_json(
+                    dev_backend_report_name(backend),
+                    was_running,
+                    reset_done,
+                ));
             }
-            result
+            Ok(())
         }
         DevAction::Shell { project: _project } => match backend {
             DevBackend::Libkrun => {
@@ -643,10 +677,10 @@ pub(in crate::commands) fn run(_cli: &Cli, args: Args, cfg: &MvmConfig) -> Resul
             // start over," so a stop failure here shouldn't block the
             // re-up).
             let _ = match backend {
-                DevBackend::Libkrun => cmd_dev_libkrun_down(),
-                DevBackend::Vz => dev_vz::cmd_dev_vz_down(),
-                DevBackend::LinuxKvm => linux_native::cmd_dev_linux_native_down(),
-                DevBackend::Unsupported => Ok(()),
+                DevBackend::Libkrun => cmd_dev_libkrun_down(false),
+                DevBackend::Vz => dev_vz::cmd_dev_vz_down(false),
+                DevBackend::LinuxKvm => linux_native::cmd_dev_linux_native_down(false),
+                DevBackend::Unsupported => Ok(false),
             };
 
             // Clear cached dev image

--- a/crates/mvm-cli/src/commands/env/dev_vz.rs
+++ b/crates/mvm-cli/src/commands/env/dev_vz.rs
@@ -216,7 +216,9 @@ pub(in crate::commands) fn dev_vsock_proxy_path() -> String {
 
 /// Stop the dev VM by reaping its detached Vz supervisor via the PID
 /// file under the stable state dir.
-pub(super) fn cmd_dev_vz_down() -> Result<()> {
+/// Stop the Vz dev VM. Returns whether a live VM was reaped. Prints the
+/// human result line only when `!json` (the dispatch emits the JSON form).
+pub(super) fn cmd_dev_vz_down(json: bool) -> Result<bool> {
     #[cfg(feature = "builder-vm")]
     {
         let state_dir = mvm_build::vz_builder::persistent_vz_state_dir(DEV_VM_SESSION_ID);
@@ -224,17 +226,21 @@ pub(super) fn cmd_dev_vz_down() -> Result<()> {
         // Drop the per-VM vsock dir so a stale socket can't fool the
         // liveness probe on the next `dev status`.
         let _ = std::fs::remove_dir_all(state_dir.join("vsock"));
-        if was_running {
-            ui::success("Dev VM stopped.");
-        } else {
-            ui::info("Dev VM is not running.");
+        if !json {
+            if was_running {
+                ui::success("Dev VM stopped.");
+            } else {
+                ui::info("Dev VM is not running.");
+            }
         }
-        Ok(())
+        Ok(was_running)
     }
     #[cfg(not(feature = "builder-vm"))]
     {
-        ui::info("Dev VM is not running.");
-        Ok(())
+        if !json {
+            ui::info("Dev VM is not running.");
+        }
+        Ok(false)
     }
 }
 
@@ -527,6 +533,38 @@ pub(super) fn build_dev_status_json_vmless(
         guest_kernel: None,
         dev_image: None,
         builder_cache: None,
+    }
+}
+
+/// Machine-readable result of a `dev down` (and, later, `dev up`)
+/// lifecycle mutation, so scripts can branch on the outcome.
+#[derive(Debug, Serialize, PartialEq, Eq)]
+pub(super) struct DevLifecycleJson {
+    pub schema_version: u8,
+    pub backend: &'static str,
+    pub action: &'static str,
+    /// `stopped` (a live VM was reaped) or `not-running` (nothing to stop).
+    pub outcome: &'static str,
+    /// `true` only when `dev down --reset` also dropped the Nix-store overlay.
+    #[serde(skip_serializing_if = "std::ops::Not::not")]
+    pub reset: bool,
+}
+
+pub(super) fn build_dev_down_json(
+    backend: &'static str,
+    was_running: bool,
+    reset: bool,
+) -> DevLifecycleJson {
+    DevLifecycleJson {
+        schema_version: 1,
+        backend,
+        action: "down",
+        outcome: if was_running {
+            "stopped"
+        } else {
+            "not-running"
+        },
+        reset,
     }
 }
 
@@ -4405,6 +4443,30 @@ mod dev_status_image_tests {
         assert!(!json.contains("\"vm_name\""));
         assert!(!json.contains("\"dev_image\""));
         assert!(!json.contains("\"builder_cache\""));
+    }
+
+    #[test]
+    fn dev_down_json_reports_stopped_and_omits_reset_when_false() {
+        let report = build_dev_down_json("vz", true, false);
+        assert_eq!(report.schema_version, 1);
+        assert_eq!(report.backend, "vz");
+        assert_eq!(report.action, "down");
+        assert_eq!(report.outcome, "stopped");
+        let json = crate::json_out::to_json_string(&report).expect("serialize");
+        assert!(json.contains("\"action\": \"down\""));
+        assert!(json.contains("\"outcome\": \"stopped\""));
+        // `reset` defaults false and is skipped, not serialized as false.
+        assert!(!json.contains("\"reset\""));
+    }
+
+    #[test]
+    fn dev_down_json_reports_not_running_and_reset() {
+        let report = build_dev_down_json("libkrun", false, true);
+        assert_eq!(report.outcome, "not-running");
+        assert!(report.reset);
+        let json = crate::json_out::to_json_string(&report).expect("serialize");
+        assert!(json.contains("\"outcome\": \"not-running\""));
+        assert!(json.contains("\"reset\": true"));
     }
 }
 

--- a/crates/mvm-cli/src/commands/env/linux_native.rs
+++ b/crates/mvm-cli/src/commands/env/linux_native.rs
@@ -66,13 +66,16 @@ pub(super) fn cmd_dev_linux_native(open_shell: bool) -> Result<()> {
 /// On Linux there is no separate dev VM to stop — the host shell is
 /// the environment. Function returns `Ok(())` so the caller's
 /// gc-root cleanup (in `super::dev`) still runs unconditionally.
-pub(super) fn cmd_dev_linux_native_down() -> Result<()> {
-    ui::info(
-        "Nothing to stop on Linux+KVM — the host is the dev environment. \
-         (mvmctl-managed microVMs are still running; use `mvmctl down <name>` \
-         to stop those individually or `mvmctl down --all`.)",
-    );
-    Ok(())
+pub(super) fn cmd_dev_linux_native_down(json: bool) -> Result<bool> {
+    if !json {
+        ui::info(
+            "Nothing to stop on Linux+KVM — the host is the dev environment. \
+             (mvmctl-managed microVMs are still running; use `mvmctl down <name>` \
+             to stop those individually or `mvmctl down --all`.)",
+        );
+    }
+    // No managed dev VM on a native-KVM host; nothing was running.
+    Ok(false)
 }
 
 /// `mvmctl dev shell` on Linux+KVM. Spawns an interactive `bash -i`.

--- a/crates/mvm-cli/src/commands/tests.rs
+++ b/crates/mvm-cli/src/commands/tests.rs
@@ -2998,8 +2998,30 @@ fn test_init_scaffold_with_prompt_flag() {
 
 #[test]
 fn test_dev_down_parses() {
-    let cli = Cli::try_parse_from(["mvmctl", "dev", "down"]);
-    assert!(cli.is_ok());
+    let cli = Cli::try_parse_from(["mvmctl", "dev", "down"]).unwrap();
+    match cli.command {
+        Commands::Dev(dev::Args {
+            action: Some(DevAction::Down { reset, json }),
+        }) => {
+            assert!(!reset);
+            assert!(!json, "bare `dev down` defaults to text output");
+        }
+        _ => panic!("Expected Dev Down command"),
+    }
+}
+
+#[test]
+fn test_dev_down_json_and_reset_flags_parse() {
+    let cli = Cli::try_parse_from(["mvmctl", "dev", "down", "--reset", "--json"]).unwrap();
+    match cli.command {
+        Commands::Dev(dev::Args {
+            action: Some(DevAction::Down { reset, json }),
+        }) => {
+            assert!(reset);
+            assert!(json);
+        }
+        _ => panic!("Expected Dev Down command"),
+    }
 }
 
 #[test]

--- a/specs/REFACTOR-STATUS.md
+++ b/specs/REFACTOR-STATUS.md
@@ -396,9 +396,9 @@ PLAN 177 — Backend consolidation (8→4)           ✅ DONE — both phases me
 PLAN 189 — VZ DX parity (post-convergence)        🟡 in progress  (ADR-076 §"Out of scope")
   Spun out of Plan 177's deferred DX-parity follow-on; sibling of Plan 159 (owns
   only the additive parity slice, cross-refs 159/140/148 for primitives).
-  [x] WS-3 first slice: `dev status --json` (versioned, privacy-safe DevStatusJson;
-      all 4 dispatch arms; serde + CLI-parse tests; verified on macOS-26)
-  [ ] WS-3 remaining: dev up/down --json, snapshot/checkpoint --json, linux-native detail
+  [x] WS-3: `dev status --json` + `dev down --json` (versioned, privacy-safe;
+      all dispatch arms; down handlers return was_running; serde + CLI-parse tests)
+  [ ] WS-3 remaining: dev up --json, snapshot/checkpoint --json, linux-native detail
   [ ] WS-1 save/restore verbs · WS-2 cached fast-boot default · WS-4 base pinning
   [ ] WS-1 surface save/restore verbs (gated by snapshot_capability tier)
   [ ] WS-2 cached fast-boot as the default vz boot posture

--- a/specs/plans/189-vz-dx-parity.md
+++ b/specs/plans/189-vz-dx-parity.md
@@ -89,8 +89,14 @@ WS-2 / Plan 140 — add `--json` there, don't fork).
       linux-native / unsupported) via a pure `build_dev_status_json[_vmless]`
       builder; serde + privacy + CLI-parse tests; manually verified on
       macOS-26. Reuses the cache-inspect JSON sub-structs.
-- [ ] `dev up --json` / `dev down --json` — emit a small lifecycle result
-      (backend, vm_name, action, outcome) so scripts can branch on boot/teardown.
+- [x] **`dev down --json`** — `DevLifecycleJson { schema_version, backend,
+      action, outcome, reset? }`; `outcome` is `stopped`/`not-running`, `reset`
+      appears only when `--reset` actually dropped the Nix-store overlay. The
+      down handlers now return `was_running` (presentation moved to the
+      dispatch); serde + CLI-parse tests; verified on macOS-26.
+- [ ] `dev up --json` — emit `{action: "up", outcome: started/already-running}`
+      after boot; implies `--no-shell` (the default path is interactive). Its
+      own slice (the up path is heavier + branches through build/boot/shell).
 - [ ] snapshot/checkpoint `--json` — add to the Plan 159/140 verbs in place
       (don't duplicate the primitive); WS-1 (`save`/`restore`) lands its own.
 - [ ] linux-native richer `--json` — today it collapses to a single `state`


### PR DESCRIPTION
Continues Plan 189 WS-3 (`--json` coverage for vz dev lifecycle verbs) — after `dev status --json` (#827), this adds the machine-readable result to `dev down`.

## Shape
`DevLifecycleJson { schema_version: 1, backend, action: "down", outcome, reset? }`:
- `outcome` — `stopped` (a live VM was reaped) or `not-running`.
- `reset` — serialized only when `--reset` actually dropped the Nix-store overlay (skipped otherwise, not emitted as `false`).

## Refactor (a quality improvement)
The per-backend down handlers now return `was_running` instead of `Result<()>`:
- vz already had it (`stop_persistent_vz_by_pid_file` returns the bool);
- libkrun derives it from a pre-stop status check;
- linux-native / unsupported are always `not-running`.

The human `stopped`/`not-running` line and the `--reset` notice moved from the handlers to the dispatch, so `--json` emits clean JSON (and the `--reset` block is extracted into a small `reset_nix_store_overlay(json) -> bool` helper). The Rebuild flow (which reuses the down handlers) updated to match.

## Tests
Builder tests (stopped+reset-omitted / not-running+reset) + CLI-parse (`--json`, `--reset --json`, bare default). Verified the real output on macOS-26.

`dev up --json` is deferred to its own slice (the up path is heavier + interactive). Verified against `clippy --all-targets`, `--tests`, `--no-default-features -D warnings`, nightly fmt.