### PR TITLE
feat(dev): `dev up --json` lifecycle envelope (plan 189 WS-3)

### DIFF
--- a/crates/mvm-cli/src/commands/env/dev.rs
+++ b/crates/mvm-cli/src/commands/env/dev.rs
@@ -202,6 +202,10 @@ pub(in crate::commands) enum DevAction {
         /// or /mnt (system mounts stay read-only).
         #[arg(long, short = 'v', value_parser = clap_volume_spec)]
         volume: Vec<String>,
+        /// Emit a machine-readable JSON result after boot instead of text.
+        /// Implies non-interactive (`--no-shell`); chrome goes to stderr.
+        #[arg(long, conflicts_with = "shell")]
+        json: bool,
     },
     /// Stop the development VM.
     Down {
@@ -394,7 +398,7 @@ fn cmd_dev_libkrun(
     memory_gib: u32,
     open_shell: bool,
     volumes: &[VmVolume],
-) -> Result<()> {
+) -> Result<&'static str> {
     let backend = LibkrunBackend;
     let id = VmId(dev_vz::DEV_VM_NAME.to_string());
 
@@ -406,7 +410,7 @@ fn cmd_dev_libkrun(
         if open_shell {
             console::console_interactive(dev_vz::DEV_VM_NAME)?;
         }
-        return Ok(());
+        return Ok("already-running");
     }
 
     ui::progress("Starting dev environment via libkrun...");
@@ -428,7 +432,7 @@ fn cmd_dev_libkrun(
     if open_shell {
         console::console_interactive(dev_vz::DEV_VM_NAME)?;
     }
-    Ok(())
+    Ok("started")
 }
 
 /// `dev down` is best-effort over both backends so a user who switched
@@ -530,6 +534,7 @@ pub(in crate::commands) fn run(_cli: &Cli, args: Args, cfg: &MvmConfig) -> Resul
         shell: true,
         no_shell: false,
         volume: Vec::new(),
+        json: false,
     });
 
     // `current_backend()` honours `MVM_BUILDER_BACKEND=vz` / `--builder vz`
@@ -546,7 +551,16 @@ pub(in crate::commands) fn run(_cli: &Cli, args: Args, cfg: &MvmConfig) -> Resul
             shell,
             no_shell,
             volume,
+            json,
         } => {
+            // `--json` emits a machine-readable result on stdout, so route
+            // all `[mvm]` chrome (incl. the deep build progress) to stderr
+            // and never open an interactive shell.
+            if json {
+                // Process-global flag; both `mvm::ui` and the `crate::ui`
+                // mirror honor it, so all chrome routes to stderr.
+                mvm::ui::set_chrome_to_stderr(true);
+            }
             // CLI flag wins; otherwise fall back to per-user config defaults.
             let effective_cpus = if cpus == 8 { cfg.dev_vm_cpus } else { cpus };
             let effective_mem = if memory == 16 {
@@ -558,8 +572,8 @@ pub(in crate::commands) fn run(_cli: &Cli, args: Args, cfg: &MvmConfig) -> Resul
             // which needs a real terminal. Without one (CI, scripts, the
             // core_demo test — stdin is redirected) `console_interactive`'s
             // openpty() fails. Boot the VM and return instead; `dev shell`
-            // attaches later once a TTY is present.
-            let want_shell = effective_up_shell(shell, no_shell);
+            // attaches later once a TTY is present. `--json` forces this off.
+            let want_shell = !json && effective_up_shell(shell, no_shell);
             let open_shell = want_shell && std::io::IsTerminal::is_terminal(&std::io::stdin());
             if want_shell && !open_shell {
                 ui::info(
@@ -574,7 +588,7 @@ pub(in crate::commands) fn run(_cli: &Cli, args: Args, cfg: &MvmConfig) -> Resul
             // non-fatal — see `sweep_orphaned_vm_helpers_on_startup`.
             dev_vz::sweep_orphaned_vm_helpers_on_startup();
 
-            match backend {
+            let outcome = match backend {
                 DevBackend::Libkrun => {
                     cmd_dev_libkrun(effective_cpus, effective_mem, open_shell, &dev_volumes)
                 }
@@ -586,8 +600,15 @@ pub(in crate::commands) fn run(_cli: &Cli, args: Args, cfg: &MvmConfig) -> Resul
                     warn_dev_volumes_unsupported(&dev_volumes, "native Linux/KVM");
                     linux_native::cmd_dev_linux_native(open_shell)
                 }
-                DevBackend::Unsupported => bail_no_dev_backend(),
+                DevBackend::Unsupported => return bail_no_dev_backend(),
+            }?;
+            if json {
+                return crate::json_out::emit_json(&dev_vz::build_dev_up_json(
+                    dev_backend_report_name(backend),
+                    outcome,
+                ));
             }
+            Ok(())
         }
         DevAction::Down { reset, json } => {
             let was_running = match backend {
@@ -697,15 +718,15 @@ pub(in crate::commands) fn run(_cli: &Cli, args: Args, cfg: &MvmConfig) -> Resul
             let dev_volumes = resolve_dev_volumes(&volume)?;
             match backend {
                 DevBackend::Libkrun => {
-                    cmd_dev_libkrun(effective_cpus, effective_mem, shell, &dev_volumes)
+                    cmd_dev_libkrun(effective_cpus, effective_mem, shell, &dev_volumes).map(|_| ())
                 }
                 DevBackend::Vz => {
                     warn_dev_volumes_unsupported(&dev_volumes, "Vz");
-                    dev_vz::cmd_dev_vz(effective_cpus, effective_mem, shell)
+                    dev_vz::cmd_dev_vz(effective_cpus, effective_mem, shell).map(|_| ())
                 }
                 DevBackend::LinuxKvm => {
                     warn_dev_volumes_unsupported(&dev_volumes, "native Linux/KVM");
-                    linux_native::cmd_dev_linux_native(shell)
+                    linux_native::cmd_dev_linux_native(shell).map(|_| ())
                 }
                 DevBackend::Unsupported => bail_no_dev_backend(),
             }

--- a/crates/mvm-cli/src/commands/env/dev_vz.rs
+++ b/crates/mvm-cli/src/commands/env/dev_vz.rs
@@ -100,16 +100,17 @@ pub(in crate::commands) fn is_vz_dev_running() -> bool {
 /// Boot the dev VM via the Vz supervisor, optionally opening an
 /// interactive console.
 #[cfg(feature = "builder-vm")]
-pub(super) fn cmd_dev_vz(cpus: u32, memory_gib: u32, open_shell: bool) -> Result<()> {
+pub(super) fn cmd_dev_vz(cpus: u32, memory_gib: u32, open_shell: bool) -> Result<&'static str> {
     ui::progress("Starting dev environment via Vz (Virtualization.framework)...");
 
     if is_vz_dev_running() {
         if open_shell {
             ui::progress("Dev VM already running. Opening shell...");
-            return console_interactive(DEV_VM_NAME);
+            console_interactive(DEV_VM_NAME)?;
+        } else {
+            ui::progress("Dev VM already running.");
         }
-        ui::progress("Dev VM already running.");
-        return Ok(());
+        return Ok("already-running");
     }
 
     // Reap a dead-but-not-reaped supervisor from a prior session so the
@@ -182,11 +183,11 @@ pub(super) fn cmd_dev_vz(cpus: u32, memory_gib: u32, open_shell: bool) -> Result
         let _ = console_interactive(DEV_VM_NAME);
     }
 
-    Ok(())
+    Ok("started")
 }
 
 #[cfg(not(feature = "builder-vm"))]
-pub(super) fn cmd_dev_vz(_cpus: u32, _memory_gib: u32, _open_shell: bool) -> Result<()> {
+pub(super) fn cmd_dev_vz(_cpus: u32, _memory_gib: u32, _open_shell: bool) -> Result<&'static str> {
     anyhow::bail!(
         "the dev VM is built locally via the builder VM, but this mvmctl was \
          compiled without the `builder-vm` feature."
@@ -548,6 +549,18 @@ pub(super) struct DevLifecycleJson {
     /// `true` only when `dev down --reset` also dropped the Nix-store overlay.
     #[serde(skip_serializing_if = "std::ops::Not::not")]
     pub reset: bool,
+}
+
+pub(super) fn build_dev_up_json(backend: &'static str, outcome: &'static str) -> DevLifecycleJson {
+    DevLifecycleJson {
+        schema_version: 1,
+        backend,
+        action: "up",
+        // `started` (booted + agent reachable), `already-running`, or
+        // `host-native` (Linux KVM: the host shell is the dev env).
+        outcome,
+        reset: false,
+    }
 }
 
 pub(super) fn build_dev_down_json(
@@ -4467,6 +4480,22 @@ mod dev_status_image_tests {
         let json = crate::json_out::to_json_string(&report).expect("serialize");
         assert!(json.contains("\"outcome\": \"not-running\""));
         assert!(json.contains("\"reset\": true"));
+    }
+
+    #[test]
+    fn dev_up_json_reports_outcome_and_omits_reset() {
+        let started = build_dev_up_json("vz", "started");
+        assert_eq!(started.action, "up");
+        assert_eq!(started.outcome, "started");
+        assert_eq!(started.backend, "vz");
+        let json = crate::json_out::to_json_string(&started).expect("serialize");
+        assert!(json.contains("\"action\": \"up\""));
+        assert!(json.contains("\"outcome\": \"started\""));
+        // `reset` is down-only; the up shape never emits it.
+        assert!(!json.contains("\"reset\""));
+
+        let already = build_dev_up_json("libkrun", "already-running");
+        assert_eq!(already.outcome, "already-running");
     }
 }
 

--- a/crates/mvm-cli/src/commands/env/linux_native.rs
+++ b/crates/mvm-cli/src/commands/env/linux_native.rs
@@ -33,7 +33,7 @@ use mvm_backend::firecracker;
 /// Bootstraps the host-side Firecracker prerequisites and prints a
 /// summary. With `open_shell`, spawns a fresh `bash -i` after setup
 /// so the user lands in a shell with the dev environment ready.
-pub(super) fn cmd_dev_linux_native(open_shell: bool) -> Result<()> {
+pub(super) fn cmd_dev_linux_native(open_shell: bool) -> Result<&'static str> {
     if !firecracker::is_installed()? {
         ui::info("Firecracker not installed — installing...");
         firecracker::install()?;
@@ -58,7 +58,9 @@ pub(super) fn cmd_dev_linux_native(open_shell: bool) -> Result<()> {
     if open_shell {
         spawn_subshell()?;
     }
-    Ok(())
+    // The host shell is the dev environment on native Linux/KVM; there is
+    // no managed VM to "start".
+    Ok("host-native")
 }
 
 /// `mvmctl dev down` on Linux+KVM.

--- a/crates/mvm-cli/src/commands/tests.rs
+++ b/crates/mvm-cli/src/commands/tests.rs
@@ -3025,6 +3025,24 @@ fn test_dev_down_json_and_reset_flags_parse() {
 }
 
 #[test]
+fn test_dev_up_json_flag_parses() {
+    let cli = Cli::try_parse_from(["mvmctl", "dev", "up", "--json"]).unwrap();
+    match cli.command {
+        Commands::Dev(dev::Args {
+            action: Some(DevAction::Up { json, .. }),
+        }) => assert!(json),
+        _ => panic!("Expected Dev Up command"),
+    }
+}
+
+#[test]
+fn test_dev_up_json_conflicts_with_shell() {
+    // `--json` is non-interactive by definition; `--shell` must be rejected.
+    let res = Cli::try_parse_from(["mvmctl", "dev", "up", "--json", "--shell"]);
+    assert!(res.is_err(), "`dev up --json --shell` must conflict");
+}
+
+#[test]
 fn test_dev_shell_parses() {
     let cli = Cli::try_parse_from(["mvmctl", "dev", "shell"]);
     assert!(cli.is_ok());

--- a/specs/REFACTOR-STATUS.md
+++ b/specs/REFACTOR-STATUS.md
@@ -1,6 +1,6 @@
 # Refactor status — rollup checklist
 
-**Last updated: 2026-06-13** (Plan 185 test-isolation sweep advanced; ADR-080 program batch landed: Plans 188/186/187; Plan 189 WS-3 `dev status --json`; Plan 190 kernel egress close-out; Plan 191 declarative file materialization — ADR-080 P2-full; Plan 159: instant memory fork vm_full productized — admitted child, gvproxy-only invariant; Plan 193 rvproxy network substrate proposed + gvproxy teardown/build-perf findings)
+**Last updated: 2026-06-13** (Plan 185 test-isolation sweep advanced; ADR-080 program batch landed: Plans 188/186/187; Plan 189 WS-3 `dev status/down/up --json`; Plan 190 kernel egress close-out; Plan 191 declarative file materialization — ADR-080 P2-full; Plan 159: instant memory fork vm_full productized — admitted child, gvproxy-only invariant; Plan 193 rvproxy network substrate proposed + gvproxy teardown/build-perf findings)
 
 > MAINTENANCE: keep this file current. Whenever you land, merge, or descope a
 > workstream in any plan below, tick/strike the matching box here in the SAME
@@ -403,9 +403,10 @@ PLAN 177 — Backend consolidation (8→4)           ✅ DONE — both phases me
 PLAN 189 — VZ DX parity (post-convergence)        🟡 in progress  (ADR-076 §"Out of scope")
   Spun out of Plan 177's deferred DX-parity follow-on; sibling of Plan 159 (owns
   only the additive parity slice, cross-refs 159/140/148 for primitives).
-  [x] WS-3: `dev status --json` + `dev down --json` (versioned, privacy-safe;
-      all dispatch arms; down handlers return was_running; serde + CLI-parse tests)
-  [ ] WS-3 remaining: dev up --json, snapshot/checkpoint --json, linux-native detail
+  [x] WS-3: `dev status/down/up --json` (versioned, privacy-safe; all dispatch
+      arms; lifecycle handlers return outcome; up forces chrome→stderr +
+      conflicts_with shell; serde + CLI-parse + conflict tests)
+  [ ] WS-3 remaining: snapshot/checkpoint --json, linux-native richer detail
   [ ] WS-1 save/restore verbs · WS-2 cached fast-boot default · WS-4 base pinning
   [ ] WS-1 surface save/restore verbs (gated by snapshot_capability tier)
   [ ] WS-2 cached fast-boot as the default vz boot posture

--- a/specs/plans/189-vz-dx-parity.md
+++ b/specs/plans/189-vz-dx-parity.md
@@ -16,7 +16,7 @@
 > after Plan 177 lands." Plan 177 landed 2026-06-12.
 
 > **Status: 🟡 in progress.** Spun out of [Plan 177](./177-backend-consolidation.md)
-> §"deferred follow-ups". WS-3 first slice landed: `dev status --json`.
+> §"deferred follow-ups". WS-3 lifecycle verbs landed: `dev status/down/up --json`.
 
 **Goal:** Bring the converged single `vz` Apple-Virtualization.framework path to
 DX parity with the reference embeddable-sandbox SDK — the table-stakes floor
@@ -94,9 +94,14 @@ WS-2 / Plan 140 — add `--json` there, don't fork).
       appears only when `--reset` actually dropped the Nix-store overlay. The
       down handlers now return `was_running` (presentation moved to the
       dispatch); serde + CLI-parse tests; verified on macOS-26.
-- [ ] `dev up --json` — emit `{action: "up", outcome: started/already-running}`
-      after boot; implies `--no-shell` (the default path is interactive). Its
-      own slice (the up path is heavier + branches through build/boot/shell).
+- [x] **`dev up --json`** — `DevLifecycleJson { schema_version, backend,
+      action: "up", outcome, reset: false }`; `outcome` is
+      `started`/`already-running` (vz/libkrun) or `host-native` (linux-KVM,
+      where the host *is* the dev env). `--json` is non-interactive: it forces
+      chrome to stderr, suppresses the shell, and `conflicts_with = "shell"`.
+      The up handlers now return the outcome string (presentation moved to the
+      dispatch, mirroring `dev down`); serde + CLI-parse + conflict tests;
+      verified on macOS-26 via the Plan 177 cold-build smoke.
 - [ ] snapshot/checkpoint `--json` — add to the Plan 159/140 verbs in place
       (don't duplicate the primitive); WS-1 (`save`/`restore`) lands its own.
 - [ ] linux-native richer `--json` — today it collapses to a single `state`


### PR DESCRIPTION
Completes the `dev` lifecycle-verb `--json` coverage (Plan 189 WS-3), joining the already-landed `dev status --json` and `dev down --json`.

## What

`mvmctl dev up --json` emits the shared `DevLifecycleJson` envelope after the up path resolves:

```json
{ "schema_version": 1, "backend": "vz", "action": "up", "outcome": "started", "reset": false }
```

- `outcome` = `started` / `already-running` on the managed-VM backends (vz, libkrun); `host-native` on Linux+KVM, where the host *is* the dev environment and there's no VM to boot.
- `--json` is **non-interactive by construction**: routes `[mvm]` chrome to stderr (stdout carries only the envelope), suppresses the shell, and is `conflicts_with = "shell"` at the clap layer.
- The up handlers now return the outcome string; the dispatch owns presentation — mirroring the `dev down` refactor.

## Tests

- serde shape + privacy floor (no paths), `reset` omitted/false
- CLI-parse (`dev up --json` → `json=true`; bare `dev up` → `json=false`)
- `dev up --json --shell` rejected (conflict)
- Live macOS-26: validated through the Plan 177 cold-build smoke (boot → `status` running → `down` reaped).

Plan 189 WS-3 + REFACTOR-STATUS rollup updated in the same commit.