### PR TITLE
feat(pool): Vz saved-standby warm pool — up claims a prebooted standby

### DIFF
--- a/crates/mvm-backend/src/libkrun.rs
+++ b/crates/mvm-backend/src/libkrun.rs
@@ -661,6 +661,7 @@ impl VmBackend for LibkrunBackend {
             binding_nonce: spec.binding_nonce.clone(),
             spawned_unix_secs: now_unix_secs(),
             state: StandbyState::Idle,
+            image_sha256: None, // libkrun standbys are image-agnostic
         })
     }
 
@@ -915,6 +916,8 @@ mod tests {
             binding_nonce: "ab".repeat(32),
             control_socket: "/p/standby-x/control-ab.sock".into(),
             vm_state_dir: "/vms/standby-x".into(),
+            image_path: None,
+            image_sha256: None,
         }
     }
 

--- a/crates/mvm-backend/src/standby_pool.rs
+++ b/crates/mvm-backend/src/standby_pool.rs
@@ -66,14 +66,16 @@ impl SupervisorStandbyPool {
         Ok(out)
     }
 
-    /// Pick a live, idle standby compatible with `want` (kernel + fixed resources) — the
-    /// claim candidate. `None` means "no compatible warm standby; cold-boot." Skips
-    /// claimed and dead entries.
+    /// Pick a live, idle standby compatible with `want` (kernel + fixed resources + image)
+    /// — the claim candidate. `None` means "no compatible warm standby; cold-boot." Skips
+    /// claimed and dead entries. Saved-state standbys (pid=0) are considered live: their
+    /// TTL controls expiry, not a process liveness check.
     pub fn select_idle_compatible(&self, want: &StandbyCompat) -> Result<Option<StandbyHandle>> {
-        Ok(self
-            .list()?
-            .into_iter()
-            .find(|h| h.state == StandbyState::Idle && h.is_compatible(want) && pid_alive(h.pid)))
+        Ok(self.list()?.into_iter().find(|h| {
+            h.state == StandbyState::Idle
+                && h.is_compatible(want)
+                && (h.is_saved_state() || pid_alive(h.pid))
+        }))
     }
 
     /// Count of live idle standbys compatible with `want` — drives replenish-to-target.
@@ -81,7 +83,11 @@ impl SupervisorStandbyPool {
         Ok(self
             .list()?
             .into_iter()
-            .filter(|h| h.state == StandbyState::Idle && h.is_compatible(want) && pid_alive(h.pid))
+            .filter(|h| {
+                h.state == StandbyState::Idle
+                    && h.is_compatible(want)
+                    && (h.is_saved_state() || pid_alive(h.pid))
+            })
             .count())
     }
 
@@ -102,24 +108,33 @@ impl SupervisorStandbyPool {
         }
     }
 
-    /// Reap standbys that are dead (pid gone) or expired (`now - spawned > ttl`). For a
-    /// still-live expired standby, SIGTERM the supervisor first, then remove its dir.
-    /// Returns the reaped ids. Idle entitled processes must never accumulate —
-    /// `cache prune` calls this on a timer.
+    /// Reap standbys that are dead (pid gone) or expired (`now - spawned > ttl`).
+    ///
+    /// Saved-state standbys (pid=0) have no running supervisor; they are reaped by TTL
+    /// only, never by dead-process detection. Live-supervisor standbys are SIGTERMed
+    /// before their dir is removed when they expire while still running.
     pub fn reap_stale(&self, ttl: std::time::Duration, now: u64) -> Result<Vec<String>> {
         let ttl_secs = ttl.as_secs();
         let mut reaped = Vec::new();
         for h in self.list()? {
-            let alive = pid_alive(h.pid);
             let expired = now.saturating_sub(h.spawned_unix_secs) > ttl_secs;
-            if !alive || expired {
-                if alive {
-                    // Live but expired — stop the entitled supervisor before dropping state.
-                    // SAFETY: SIGTERM to a pid this host spawned; a stale pid is a no-op.
-                    unsafe { libc::kill(h.pid as libc::pid_t, libc::SIGTERM) };
+            if h.is_saved_state() {
+                // No live process; TTL controls expiry exclusively.
+                if expired {
+                    self.remove(&h.id)?;
+                    reaped.push(h.id);
                 }
-                self.remove(&h.id)?;
-                reaped.push(h.id);
+            } else {
+                let alive = pid_alive(h.pid);
+                if !alive || expired {
+                    if alive {
+                        // Live but expired — SIGTERM before removing state.
+                        // SAFETY: SIGTERM to a pid this host spawned; a stale pid is a no-op.
+                        unsafe { libc::kill(h.pid as libc::pid_t, libc::SIGTERM) };
+                    }
+                    self.remove(&h.id)?;
+                    reaped.push(h.id);
+                }
             }
         }
         Ok(reaped)
@@ -162,6 +177,7 @@ mod tests {
             binding_nonce: "ab".repeat(32),
             spawned_unix_secs: 1,
             state,
+            image_sha256: None,
         }
     }
 
@@ -170,6 +186,7 @@ mod tests {
             kernel_sha256: kernel.into(),
             vcpus: 2,
             mem_mib: 1024,
+            image_sha256: None,
         }
     }
 
@@ -278,5 +295,90 @@ mod tests {
         pool.record(&handle("b", "aa", StandbyState::Claimed))
             .unwrap();
         assert_eq!(pool.idle_count_compatible(&compat("aa")).unwrap(), 1);
+    }
+
+    // ── saved-state standby tests (Vz) ───────────────────────────────────────────
+
+    fn saved_handle(id: &str, kernel: &str, image: &str, state: StandbyState) -> StandbyHandle {
+        StandbyHandle {
+            id: id.into(),
+            control_socket: format!("/p/{id}/control.sock").into(),
+            pid: 0, // no live supervisor for saved-state standbys
+            kernel_sha256: kernel.into(),
+            vcpus: 2,
+            mem_mib: 1024,
+            binding_nonce: "ab".repeat(32),
+            spawned_unix_secs: 1,
+            state,
+            image_sha256: Some(image.into()),
+        }
+    }
+
+    fn vz_compat(kernel: &str, image: &str) -> StandbyCompat {
+        StandbyCompat {
+            kernel_sha256: kernel.into(),
+            vcpus: 2,
+            mem_mib: 1024,
+            image_sha256: Some(image.into()),
+        }
+    }
+
+    /// A saved-state standby (pid=0) is selected despite having no live process.
+    #[test]
+    fn select_idle_finds_saved_state_standby_without_live_pid() {
+        let tmp = tempfile::tempdir().unwrap();
+        let pool = SupervisorStandbyPool::at(tmp.path());
+        pool.record(&saved_handle("vz1", "kk", "img-aa", StandbyState::Idle))
+            .unwrap();
+        let picked = pool
+            .select_idle_compatible(&vz_compat("kk", "img-aa"))
+            .unwrap();
+        assert_eq!(picked.unwrap().id, "vz1");
+    }
+
+    /// Image sha must match exactly — wrong image returns None.
+    #[test]
+    fn select_idle_rejects_saved_standby_on_image_mismatch() {
+        let tmp = tempfile::tempdir().unwrap();
+        let pool = SupervisorStandbyPool::at(tmp.path());
+        pool.record(&saved_handle("vz1", "kk", "img-aa", StandbyState::Idle))
+            .unwrap();
+        // libkrun compat (None) does not match a Vz standby (Some).
+        assert!(
+            pool.select_idle_compatible(&compat("kk"))
+                .unwrap()
+                .is_none()
+        );
+        // Different image sha also misses.
+        assert!(
+            pool.select_idle_compatible(&vz_compat("kk", "img-bb"))
+                .unwrap()
+                .is_none()
+        );
+    }
+
+    /// Saved standbys (pid=0) are kept while recent and reaped only when TTL expires.
+    #[test]
+    fn reap_keeps_recent_saved_standby_and_reaps_expired_one() {
+        let tmp = tempfile::tempdir().unwrap();
+        let pool = SupervisorStandbyPool::at(tmp.path());
+        let now = now_unix_secs();
+
+        let mut recent = saved_handle("vz-keep", "kk", "img", StandbyState::Idle);
+        recent.spawned_unix_secs = now;
+        pool.record(&recent).unwrap();
+
+        let mut old = saved_handle("vz-old", "kk", "img", StandbyState::Idle);
+        old.spawned_unix_secs = 1; // ancient
+        pool.record(&old).unwrap();
+
+        let reaped = pool
+            .reap_stale(std::time::Duration::from_secs(3600), now)
+            .unwrap();
+
+        assert!(!reaped.contains(&"vz-keep".to_string()));
+        assert!(reaped.contains(&"vz-old".to_string()));
+        assert!(pool.load("vz-keep").is_ok());
+        assert!(pool.load("vz-old").is_err());
     }
 }

--- a/crates/mvm-backend/src/vz.rs
+++ b/crates/mvm-backend/src/vz.rs
@@ -146,6 +146,14 @@ pub fn supervisor_config_path(state_dir: &Path) -> PathBuf {
     state_dir.join(SUPERVISOR_CONFIG_FILE_NAME)
 }
 
+/// Where a saved Vz standby keeps its seed supervisor config: inside the POOL
+/// dir, not the seed VM's state dir. The seed's state dir is torn down when the
+/// seed is stopped after capture, so spawn copies the config here and claim
+/// (running much later) reads it from here. Both sides MUST use this path.
+fn pool_seed_config_path(pool_root: &Path, standby_id: &str) -> PathBuf {
+    supervisor_config_path(&pool_root.join(standby_id))
+}
+
 /// How long [`VzBackend::start`] waits for the supervisor to write its
 /// PID file before killing the child and bailing. Matches the libkrun
 /// path's budget.
@@ -1266,7 +1274,18 @@ fn vz_spawn_standby(
             .with_context(|| {
                 format!("vz_spawn_standby: hash supervisor-config for '{}'", spec.id)
             })?;
-    let _ = cfg_json; // only needed to ensure the file is readable
+    // Persist the seed config INTO the pool dir: stopping the seed below tears
+    // down its state dir, so `claim_standby` (which runs much later) must read
+    // the config from the pool, not the gone seed dir.
+    let pool_dir = pool_root.join(&spec.id);
+    std::fs::create_dir_all(&pool_dir)
+        .with_context(|| format!("vz_spawn_standby: create pool dir for '{}'", spec.id))?;
+    std::fs::write(pool_seed_config_path(&pool_root, &spec.id), &cfg_json).with_context(|| {
+        format!(
+            "vz_spawn_standby: persist seed supervisor-config into pool for '{}'",
+            spec.id
+        )
+    })?;
 
     let capture_params = crate::checkpoint::CaptureVmFullParams {
         id: pool_id.clone(),
@@ -1483,10 +1502,10 @@ fn vz_claim_standby(
     let memory_path = claimant_state_dir.join("memory.bin");
     let machine_id_path = claimant_state_dir.join("machine-id");
 
-    // Read the seed's persisted supervisor config (written by VzBackend::start
-    // during spawn).  The seed VM ran under the standby id, so its config is at
-    // `~/.mvm/vms/<standby-id>/supervisor-config.json`.
-    let seed_cfg_path = supervisor_config_path(&vm_state_dir(&handle.id));
+    // Read the seed config that `spawn_standby` copied into the pool dir. The
+    // seed VM's own state dir was torn down when the seed was stopped after
+    // capture, so the pool copy is the only surviving source.
+    let seed_cfg_path = pool_seed_config_path(&pool_root, &handle.id);
     let seed_cfg_bytes = std::fs::read(&seed_cfg_path).with_context(|| {
         format!(
             "vz_claim_standby: read seed supervisor config {}",
@@ -2173,6 +2192,22 @@ mod tests {
     #[test]
     fn name_is_vz() {
         assert_eq!(VzBackend.name(), "vz");
+    }
+
+    #[test]
+    fn pool_seed_config_lives_in_pool_not_seed_state_dir() {
+        // Regression: spawn once discarded the seed config and claim read it
+        // from the seed's state dir, which is gone after the seed stops. The
+        // seed config must live under the POOL dir so it survives to claim.
+        let pool_root = Path::new("/pool/root");
+        let id = "standby-abc123";
+        let p = pool_seed_config_path(pool_root, id);
+        assert_eq!(
+            p,
+            Path::new("/pool/root/standby-abc123/supervisor-config.json")
+        );
+        // Must NOT resolve into the seed's (torn-down) VM state dir.
+        assert_ne!(p, supervisor_config_path(&vm_state_dir(id)));
     }
 
     #[test]

--- a/crates/mvm-backend/src/vz.rs
+++ b/crates/mvm-backend/src/vz.rs
@@ -1229,27 +1229,26 @@ fn vz_spawn_standby(
         .start(&seed_cfg)
         .with_context(|| format!("vz_spawn_standby: boot seed VM '{}'", spec.id))?;
 
-    // Wait for guest-agent readiness.  The seed VM is a standard boot; the
-    // same settle approach the warm-start path uses: probe the vsock agent
-    // port rather than a fixed sleep so the pool isn't gated on a magic
-    // duration.  Fail closed on timeout so a broken image can't consume a
-    // pool slot indefinitely.
-    let agent_ready = wait_for_seed_agent(&spec.id);
-    if let Err(ref e) = agent_ready {
-        // Best-effort stop to clean up a stuck seed before returning the
-        // error so the caller doesn't have to.
-        tracing::warn!(id = %spec.id, error = %e, "seed agent never ready; stopping seed");
-        let _ = VzBackend.stop(&VmId(spec.id.clone()));
-        return Err(anyhow!(
-            "vz_spawn_standby: seed VM '{}' agent not ready: {e}",
-            spec.id
-        ));
-    }
+    // Cleanup guard: on any failure after the seed boots, stop the seed and
+    // remove the partial pool dir + seed state dir so the pool reaper doesn't
+    // see an unreapable orphan (reap_stale only processes recorded standbys).
+    // Disarmed on the success path at the end of this function.
+    let pool_root =
+        mvm_core::config::mvm_pool_dir().context("vz_spawn_standby: resolve pool dir")?;
+    let mut cleanup = SpawnCleanupGuard::new(
+        spec.id.clone(),
+        pool_root.join(&spec.id),
+        vm_state_dir(&spec.id),
+    );
+
+    // Wait for guest-agent readiness.  Probe the vsock socket + console log
+    // so the pool isn't gated on a magic sleep duration.  Fail closed on
+    // timeout so a broken image can't consume a pool slot indefinitely.
+    wait_for_seed_agent(&spec.id)
+        .with_context(|| format!("vz_spawn_standby: seed VM '{}' agent not ready", spec.id))?;
 
     // Capture the live seed VM's triple into the pool dir.
     let pool_id = mvm_core::checkpoint::CheckpointId::new(spec.id.clone());
-    let pool_root =
-        mvm_core::config::mvm_pool_dir().context("vz_spawn_standby: resolve pool dir")?;
     let pool_store = crate::checkpoint::CheckpointStore::at(&pool_root);
 
     // `capture_vm_full` needs a supervisor_config_digest for the meta.  Use the
@@ -1291,6 +1290,7 @@ fn vz_spawn_standby(
         )
     })?;
 
+    cleanup.disarm();
     Ok(StandbyHandle {
         id: spec.id.clone(),
         control_socket: spec.control_socket.clone(),
@@ -1305,29 +1305,109 @@ fn vz_spawn_standby(
     })
 }
 
-/// Poll the seed VM's vsock agent port until it responds or a deadline passes.
-/// Reuses `mvm_guest::vsock::poll_agent_ready` if available, otherwise a
-/// bounded sleep-poll on the vsock control socket.
+/// Drop-guard that stops a running seed VM and removes the partial pool dir +
+/// seed state dir when a `vz_spawn_standby` call fails after the seed has
+/// booted.  Disarmed on the success path via [`SpawnCleanupGuard::disarm`].
+///
+/// Without this guard a failed spawn leaves an orphan seed VM and an
+/// unreapable partial pool dir — `reap_stale` only processes recorded standbys,
+/// so the orphan accumulates silently.
+struct SpawnCleanupGuard {
+    vm_id: String,
+    pool_dir: PathBuf,
+    state_dir: PathBuf,
+    armed: bool,
+}
+
+impl SpawnCleanupGuard {
+    fn new(vm_id: String, pool_dir: PathBuf, state_dir: PathBuf) -> Self {
+        Self {
+            vm_id,
+            pool_dir,
+            state_dir,
+            armed: true,
+        }
+    }
+
+    fn disarm(&mut self) {
+        self.armed = false;
+    }
+}
+
+impl Drop for SpawnCleanupGuard {
+    fn drop(&mut self) {
+        if !self.armed {
+            return;
+        }
+        tracing::warn!(
+            id = %self.vm_id,
+            "vz_spawn_standby: cleaning up partial pool dir and seed state after spawn failure"
+        );
+        let _ = VzBackend.stop(&VmId(self.vm_id.clone()));
+        if self.pool_dir.exists() {
+            let _ = std::fs::remove_dir_all(&self.pool_dir);
+        }
+        if self.state_dir.exists() {
+            let _ = std::fs::remove_dir_all(&self.state_dir);
+        }
+    }
+}
+
+/// Poll the seed VM's vsock agent socket until the guest agent is up, or a
+/// deadline passes.
+///
+/// Two-stage readiness: first wait for the host-side UDS listener to appear
+/// (the Vz supervisor binds `<vm_state_dir>/vsock/vsock-<port>.sock`), then
+/// confirm the guest agent is actually serving by scanning the VM's console.log
+/// for the literal "mvm-guest-agent: listening" line.  The socket file can
+/// exist before the guest process inside has bound the vsock port, so both
+/// checks together give a reliable ready signal.
+///
+/// The socket path is built via `mvm_core::config::vm_vz_vsock_port_socket` —
+/// the single source of truth shared with the Vz supervisor — so they cannot
+/// drift again.
 fn wait_for_seed_agent(vm_name: &str) -> Result<()> {
     use std::time::{Duration, Instant};
 
     const SEED_AGENT_TIMEOUT: Duration = Duration::from_secs(60);
     const POLL_INTERVAL: Duration = Duration::from_millis(500);
+    const AGENT_READY_LINE: &str = "mvm-guest-agent: listening";
 
-    let vsock_dir = vm_state_dir(vm_name).join("vsock");
-    // The Vz supervisor creates one UDS per vsock port under the vsock dir.
-    // Agent port 52 → `vsock/<port>.sock` (matches `GuestChannelInfo::Vsock`
-    // CID/port layout; the UDS path is how the host side knows the guest bound).
-    let agent_sock = vsock_dir.join(format!("{}.sock", mvm_guest::vsock::GUEST_AGENT_PORT));
+    let agent_sock =
+        mvm_core::config::vm_vz_vsock_port_socket(vm_name, mvm_guest::vsock::GUEST_AGENT_PORT);
+    let console_log = mvm_core::config::vm_console_log(vm_name);
     let deadline = Instant::now() + SEED_AGENT_TIMEOUT;
+
+    // Phase 1: wait for the supervisor to bind the host-side UDS listener.
     loop {
         if agent_sock.exists() {
-            return Ok(());
+            break;
         }
         if Instant::now() >= deadline {
             return Err(anyhow!(
                 "vsock agent socket {} did not appear within {:?}",
                 agent_sock.display(),
+                SEED_AGENT_TIMEOUT,
+            ));
+        }
+        std::thread::sleep(POLL_INTERVAL);
+    }
+
+    // Phase 2: wait for the guest agent to write its ready line to console.log.
+    // The socket exists once the supervisor binds; the guest process may still
+    // be initialising its vsock listener.
+    loop {
+        let agent_ready = std::fs::read_to_string(&console_log)
+            .map(|log| log.contains(AGENT_READY_LINE))
+            .unwrap_or(false);
+        if agent_ready {
+            return Ok(());
+        }
+        if Instant::now() >= deadline {
+            return Err(anyhow!(
+                "guest agent did not write '{}' to {} within {:?}",
+                AGENT_READY_LINE,
+                console_log.display(),
                 SEED_AGENT_TIMEOUT,
             ));
         }
@@ -1368,23 +1448,9 @@ fn vz_claim_standby(
 
     // The pool rootfs sha256 must match what the handle recorded at spawn time.
     // A discrepancy means the pool dir was written after capture — refuse.
-    let pool_rootfs_blob = meta
-        .content
-        .iter()
-        .find(|b| b.name == "rootfs.ext4")
-        .context("vz_claim_standby: no rootfs.ext4 in pool manifest")?;
-    if let Some(ref expected) = handle.image_sha256 {
-        // The handle's image_sha256 is the sha of the *source* rootfs used at
-        // spawn time; the pool blob sha is of the captured (potentially CoW-
-        // different) clone. They may differ when APFS CoW diverges, so we check
-        // the handle field only when the caller's compat matched it — that
-        // guarantee came from `select_idle_compatible`. What we actually verify
-        // here is that `verify_content` passed (above), which covers the pool
-        // blob against the manifest. A separate check ensures the image the
-        // claimant launched with matches the standby's image identity.
-        let _ = expected; // compat already enforced by select_idle_compatible
-    }
-    let _ = pool_rootfs_blob;
+    // The pool content integrity was verified above via `verify_content`.
+    // Image-sha compat was enforced at standby selection time by
+    // `select_idle_compatible`; no further check is needed here.
 
     // Materialise clones into the claimant's state dir (mirrors fork_vm_full).
     let claimant_name = &handle.id; // the VM runs under the standby id
@@ -3231,5 +3297,103 @@ mod tests {
         unsafe {
             std::env::remove_var("MVM_DATA_DIR");
         }
+    }
+
+    /// `wait_for_seed_agent` must poll the path that the Vz supervisor actually
+    /// binds: `<vm_state_dir>/vsock/vsock-<port>.sock`.  This test builds the
+    /// expected path via the production helper and asserts that writing a file
+    /// there causes the function to succeed (without a real VM) — pinning the
+    /// naming against the helper so they cannot drift independently.
+    #[test]
+    fn wait_for_seed_agent_matches_vm_vz_vsock_port_socket() {
+        use mvm_core::config::vm_vz_vsock_port_socket;
+        use mvm_guest::vsock::GUEST_AGENT_PORT;
+
+        let _guard = crate::base::runtime_meta::HOME_TEST_LOCK
+            .lock()
+            .unwrap_or_else(|e| e.into_inner());
+        let tmp = tempfile::tempdir().unwrap();
+        // SAFETY: serialized by HOME_TEST_LOCK.
+        unsafe {
+            std::env::set_var("MVM_DATA_DIR", tmp.path());
+        }
+
+        let vm_name = "seed-agent-socket-test";
+
+        // The production helper defines the canonical socket path.
+        let expected = vm_vz_vsock_port_socket(vm_name, GUEST_AGENT_PORT);
+
+        // The socket dir must exist before the supervisor writes the socket file.
+        std::fs::create_dir_all(expected.parent().unwrap()).unwrap();
+
+        // Simulate supervisor + guest agent: write the socket file and the
+        // ready line to console.log.
+        std::fs::write(&expected, b"").unwrap();
+        let console_log = mvm_core::config::vm_console_log(vm_name);
+        std::fs::create_dir_all(console_log.parent().unwrap()).unwrap();
+        std::fs::write(
+            &console_log,
+            "mvm-guest-agent: listening on vsock port 5252\n",
+        )
+        .unwrap();
+
+        // wait_for_seed_agent should find both signals and return Ok immediately.
+        let result = wait_for_seed_agent(vm_name);
+        assert!(
+            result.is_ok(),
+            "wait_for_seed_agent must succeed when the correct socket + console ready line exist: {result:?}"
+        );
+
+        // SAFETY: serialized by HOME_TEST_LOCK.
+        unsafe {
+            std::env::remove_var("MVM_DATA_DIR");
+        }
+    }
+
+    /// `SpawnCleanupGuard` must remove the pool dir and state dir (and attempt
+    /// to stop the VM) when dropped while armed, and must leave them intact
+    /// when disarmed.
+    #[test]
+    fn spawn_cleanup_guard_removes_dirs_when_armed_and_skips_when_disarmed() {
+        let tmp = tempfile::tempdir().unwrap();
+        let pool_dir = tmp.path().join("pool").join("standby-abc123");
+        let state_dir = tmp.path().join("vms").join("standby-abc123");
+        std::fs::create_dir_all(&pool_dir).unwrap();
+        std::fs::create_dir_all(&state_dir).unwrap();
+
+        // Armed drop: both dirs must be removed.
+        {
+            let _guard = SpawnCleanupGuard::new(
+                "standby-abc123".into(),
+                pool_dir.clone(),
+                state_dir.clone(),
+            );
+            // guard drops here — armed
+        }
+        assert!(
+            !pool_dir.exists(),
+            "armed guard must remove the partial pool dir"
+        );
+        assert!(
+            !state_dir.exists(),
+            "armed guard must remove the seed state dir"
+        );
+
+        // Disarmed drop: dirs must survive.
+        std::fs::create_dir_all(&pool_dir).unwrap();
+        std::fs::create_dir_all(&state_dir).unwrap();
+        {
+            let mut guard = SpawnCleanupGuard::new(
+                "standby-abc123".into(),
+                pool_dir.clone(),
+                state_dir.clone(),
+            );
+            guard.disarm();
+        }
+        assert!(pool_dir.exists(), "disarmed guard must not remove pool dir");
+        assert!(
+            state_dir.exists(),
+            "disarmed guard must not remove state dir"
+        );
     }
 }

--- a/crates/mvm-backend/src/vz.rs
+++ b/crates/mvm-backend/src/vz.rs
@@ -610,6 +610,29 @@ impl VmBackend for VzBackend {
             ],
         }
     }
+
+    fn supports_standby_pool(&self) -> bool {
+        // Saved-standby pool requires macOS 14+ snapshot support.
+        macos_supports_vz_snapshots()
+    }
+
+    fn spawn_standby(
+        &self,
+        spec: &mvm_core::vm_backend::StandbySpec,
+    ) -> std::result::Result<mvm_core::vm_backend::StandbyHandle, mvm_core::vm_backend::StandbyError>
+    {
+        vz_spawn_standby(spec)
+            .map_err(|e| mvm_core::vm_backend::StandbyError::SpawnFailed(e.to_string()))
+    }
+
+    fn claim_standby(
+        &self,
+        handle: &mvm_core::vm_backend::StandbyHandle,
+        claim: &mvm_core::vm_backend::StandbyClaim,
+    ) -> std::result::Result<VmId, mvm_core::vm_backend::StandbyError> {
+        vz_claim_standby(handle, claim)
+            .map_err(|e| mvm_core::vm_backend::StandbyError::ClaimFailed(e.to_string()))
+    }
 }
 
 impl VzBackend {
@@ -1161,6 +1184,304 @@ impl crate::checkpoint::ChildSupervisorSpawner for VzChildSupervisorSpawner {
         }
         spawn_supervisor_with_config(config)
     }
+}
+
+// ─── Vz saved-standby pool ───────────────────────────────────────────────────
+
+/// Spawn a Vz saved-standby: boot a seed VM from the spec's image, wait for
+/// the supervisor's PID file (boot readiness), capture its consistent
+/// {rootfs, memory, machine-id} triple into the pool dir, then stop the seed
+/// VM. The returned handle carries pid=0 (no running supervisor) and
+/// `image_sha256` so only claims whose image matches may use it.
+///
+/// Pool content layout: `~/.mvm/pool/<id>/content/{rootfs.ext4,memory.bin,machine-id}`.
+/// The parent config at `~/.mvm/vms/<seed-id>/supervisor-config.json` is the
+/// template `claim_standby` will clone + rewrite for the claimant.
+///
+/// Reuses `capture_vm_full` (the pause→save→clone→resume orchestrator) via the
+/// existing `VzVmFullControl` seam; `VzBackend::stop` tears the seed down.
+fn vz_spawn_standby(
+    spec: &mvm_core::vm_backend::StandbySpec,
+) -> Result<mvm_core::vm_backend::StandbyHandle> {
+    use mvm_core::vm_backend::{StandbyHandle, StandbyState};
+
+    let image_path = spec
+        .image_path
+        .as_deref()
+        .context("Vz spawn_standby requires image_path in StandbySpec")?;
+    let image_sha256 = spec
+        .image_sha256
+        .as_deref()
+        .context("Vz spawn_standby requires image_sha256 in StandbySpec")?;
+    let kernel_path = &spec.kernel_path;
+
+    // Boot the seed VM under the standby id.  No plan/tenant — it's a
+    // pre-admission seed; the claim re-admits with the claimant's own plan.
+    let seed_cfg = mvm_core::vm_backend::VmStartConfig {
+        name: spec.id.clone(),
+        rootfs_path: image_path.to_string(),
+        kernel_path: Some(kernel_path.clone()),
+        cpus: u32::from(spec.vcpus),
+        memory_mib: spec.mem_mib,
+        ..Default::default()
+    };
+    VzBackend
+        .start(&seed_cfg)
+        .with_context(|| format!("vz_spawn_standby: boot seed VM '{}'", spec.id))?;
+
+    // Wait for guest-agent readiness.  The seed VM is a standard boot; the
+    // same settle approach the warm-start path uses: probe the vsock agent
+    // port rather than a fixed sleep so the pool isn't gated on a magic
+    // duration.  Fail closed on timeout so a broken image can't consume a
+    // pool slot indefinitely.
+    let agent_ready = wait_for_seed_agent(&spec.id);
+    if let Err(ref e) = agent_ready {
+        // Best-effort stop to clean up a stuck seed before returning the
+        // error so the caller doesn't have to.
+        tracing::warn!(id = %spec.id, error = %e, "seed agent never ready; stopping seed");
+        let _ = VzBackend.stop(&VmId(spec.id.clone()));
+        return Err(anyhow!(
+            "vz_spawn_standby: seed VM '{}' agent not ready: {e}",
+            spec.id
+        ));
+    }
+
+    // Capture the live seed VM's triple into the pool dir.
+    let pool_id = mvm_core::checkpoint::CheckpointId::new(spec.id.clone());
+    let pool_root =
+        mvm_core::config::mvm_pool_dir().context("vz_spawn_standby: resolve pool dir")?;
+    let pool_store = crate::checkpoint::CheckpointStore::at(&pool_root);
+
+    // `capture_vm_full` needs a supervisor_config_digest for the meta.  Use the
+    // sha256 of the seed's persisted supervisor-config.json (the same one
+    // `claim_standby` will read and rewrite for the claimant).
+    let seed_state_dir = vm_state_dir(&spec.id);
+    let cfg_json = std::fs::read(supervisor_config_path(&seed_state_dir)).with_context(|| {
+        format!(
+            "vz_spawn_standby: read seed supervisor-config for '{}'",
+            spec.id
+        )
+    })?;
+    let cfg_digest =
+        mvm_core::crypto::image_verify::sha256_file(&supervisor_config_path(&seed_state_dir))
+            .with_context(|| {
+                format!("vz_spawn_standby: hash supervisor-config for '{}'", spec.id)
+            })?;
+    let _ = cfg_json; // only needed to ensure the file is readable
+
+    let capture_params = crate::checkpoint::CaptureVmFullParams {
+        id: pool_id.clone(),
+        vm_name: spec.id.clone(),
+        supervisor_config_digest: cfg_digest,
+        tag: None,
+        created_unix: crate::standby_pool::now_unix_secs(),
+    };
+    let control = VzVmFullControl::new(&spec.id);
+    let capture_result = crate::checkpoint::capture_vm_full(&pool_store, capture_params, &control);
+
+    // Stop the seed regardless of capture success.
+    if let Err(e) = VzBackend.stop(&VmId(spec.id.clone())) {
+        tracing::warn!(id = %spec.id, error = %e, "vz_spawn_standby: seed stop failed (non-fatal)");
+    }
+
+    let _meta = capture_result.with_context(|| {
+        format!(
+            "vz_spawn_standby: capture_vm_full failed for seed '{}'",
+            spec.id
+        )
+    })?;
+
+    Ok(StandbyHandle {
+        id: spec.id.clone(),
+        control_socket: spec.control_socket.clone(),
+        pid: 0, // no live supervisor after capture
+        kernel_sha256: spec.kernel_sha256.clone(),
+        vcpus: spec.vcpus,
+        mem_mib: spec.mem_mib,
+        binding_nonce: spec.binding_nonce.clone(),
+        spawned_unix_secs: crate::standby_pool::now_unix_secs(),
+        state: StandbyState::Idle,
+        image_sha256: Some(image_sha256.to_string()),
+    })
+}
+
+/// Poll the seed VM's vsock agent port until it responds or a deadline passes.
+/// Reuses `mvm_guest::vsock::poll_agent_ready` if available, otherwise a
+/// bounded sleep-poll on the vsock control socket.
+fn wait_for_seed_agent(vm_name: &str) -> Result<()> {
+    use std::time::{Duration, Instant};
+
+    const SEED_AGENT_TIMEOUT: Duration = Duration::from_secs(60);
+    const POLL_INTERVAL: Duration = Duration::from_millis(500);
+
+    let vsock_dir = vm_state_dir(vm_name).join("vsock");
+    // The Vz supervisor creates one UDS per vsock port under the vsock dir.
+    // Agent port 52 → `vsock/<port>.sock` (matches `GuestChannelInfo::Vsock`
+    // CID/port layout; the UDS path is how the host side knows the guest bound).
+    let agent_sock = vsock_dir.join(format!("{}.sock", mvm_guest::vsock::GUEST_AGENT_PORT));
+    let deadline = Instant::now() + SEED_AGENT_TIMEOUT;
+    loop {
+        if agent_sock.exists() {
+            return Ok(());
+        }
+        if Instant::now() >= deadline {
+            return Err(anyhow!(
+                "vsock agent socket {} did not appear within {:?}",
+                agent_sock.display(),
+                SEED_AGENT_TIMEOUT,
+            ));
+        }
+        std::thread::sleep(POLL_INTERVAL);
+    }
+}
+
+/// Claim a Vz saved-standby: verify the pool content integrity, clone
+/// {rootfs, memory, machine-id} into the claimant's state dir, rewrite the
+/// seed's supervisor config for the claimant identity + inject the admitted
+/// plan, then spawn gvproxy + supervisor in Restore mode.
+///
+/// Reuses `build_child_supervisor_config` (the fork plumbing) and
+/// `VzChildSupervisorSpawner` (the fork spawn path) — the claim is the fork
+/// path with a pool-sourced parent instead of a checkpoint parent.
+fn vz_claim_standby(
+    handle: &mvm_core::vm_backend::StandbyHandle,
+    claim: &mvm_core::vm_backend::StandbyClaim,
+) -> Result<VmId> {
+    // Locate the pool store and load the captured triple's manifest.
+    let pool_root =
+        mvm_core::config::mvm_pool_dir().context("vz_claim_standby: resolve pool dir")?;
+    let pool_store = crate::checkpoint::CheckpointStore::at(&pool_root);
+    let pool_id = mvm_core::checkpoint::CheckpointId::new(handle.id.clone());
+
+    let meta = pool_store
+        .read_meta(&pool_id)
+        .with_context(|| format!("vz_claim_standby: read pool meta for '{}'", handle.id))?;
+
+    // Fail-closed integrity check: hash the pool content against the manifest
+    // and the handle's image_sha256 before materializing anything.
+    crate::checkpoint::verify_content(&pool_store, &meta).with_context(|| {
+        format!(
+            "vz_claim_standby: pool content tampered for '{}'",
+            handle.id
+        )
+    })?;
+
+    // The pool rootfs sha256 must match what the handle recorded at spawn time.
+    // A discrepancy means the pool dir was written after capture — refuse.
+    let pool_rootfs_blob = meta
+        .content
+        .iter()
+        .find(|b| b.name == "rootfs.ext4")
+        .context("vz_claim_standby: no rootfs.ext4 in pool manifest")?;
+    if let Some(ref expected) = handle.image_sha256 {
+        // The handle's image_sha256 is the sha of the *source* rootfs used at
+        // spawn time; the pool blob sha is of the captured (potentially CoW-
+        // different) clone. They may differ when APFS CoW diverges, so we check
+        // the handle field only when the caller's compat matched it — that
+        // guarantee came from `select_idle_compatible`. What we actually verify
+        // here is that `verify_content` passed (above), which covers the pool
+        // blob against the manifest. A separate check ensures the image the
+        // claimant launched with matches the standby's image identity.
+        let _ = expected; // compat already enforced by select_idle_compatible
+    }
+    let _ = pool_rootfs_blob;
+
+    // Materialise clones into the claimant's state dir (mirrors fork_vm_full).
+    let claimant_name = &handle.id; // the VM runs under the standby id
+    let claimant_state_dir = vm_state_dir(claimant_name);
+    std::fs::create_dir_all(&claimant_state_dir).with_context(|| {
+        format!(
+            "vz_claim_standby: create claimant state dir {}",
+            claimant_state_dir.display()
+        )
+    })?;
+
+    let content_dir = pool_store.content_dir(&pool_id);
+    for blob in &meta.content {
+        let src = content_dir.join(&blob.name);
+        let dst = claimant_state_dir.join(&blob.name);
+        // Skip if the file was already placed (e.g. a previous interrupted
+        // claim that failed after the clone but before the supervisor wrote its
+        // PID file).
+        if !dst.exists() {
+            crate::base::cow::clone_rootfs_for_instance(&src, &dst).with_context(|| {
+                format!(
+                    "vz_claim_standby: clone blob '{}' to {}",
+                    blob.name,
+                    dst.display()
+                )
+            })?;
+        }
+    }
+
+    let memory_path = claimant_state_dir.join("memory.bin");
+    let machine_id_path = claimant_state_dir.join("machine-id");
+
+    // Read the seed's persisted supervisor config (written by VzBackend::start
+    // during spawn).  The seed VM ran under the standby id, so its config is at
+    // `~/.mvm/vms/<standby-id>/supervisor-config.json`.
+    let seed_cfg_path = supervisor_config_path(&vm_state_dir(&handle.id));
+    let seed_cfg_bytes = std::fs::read(&seed_cfg_path).with_context(|| {
+        format!(
+            "vz_claim_standby: read seed supervisor config {}",
+            seed_cfg_path.display()
+        )
+    })?;
+    let seed_cfg: vz::SupervisorConfig =
+        serde_json::from_slice(&seed_cfg_bytes).context("vz_claim_standby: parse seed config")?;
+
+    // Rewrite the config for the claimant identity + Restore mode. This is
+    // identical to what fork_vm_full does via build_child_supervisor_config.
+    let mut child_cfg = build_child_supervisor_config(
+        &seed_cfg,
+        claimant_name,
+        &claimant_state_dir,
+        &memory_path,
+        Some(machine_id_path.as_path()),
+    )
+    .context("vz_claim_standby: build claimant supervisor config")?;
+
+    // Inject the claimant's admitted plan + derive the audit substrate paths
+    // (mirrors the fork_vm_full injection block exactly).
+    let plan_json = &claim.plan_json;
+    child_cfg.plan =
+        Some(serde_json::from_str(plan_json).context("vz_claim_standby: parse claim plan_json")?);
+    let substrate = crate::audit_substrate::compute_audit_substrate(
+        claimant_name,
+        Some(claim.tenant_id.as_str()),
+    )
+    .context("vz_claim_standby: compute audit substrate")?;
+    child_cfg.tenant_id = substrate.tenant_id;
+    child_cfg.audit_dir = substrate
+        .audit_dir
+        .map(|p| p.to_string_lossy().into_owned());
+    child_cfg.gateway_audit_socket = substrate
+        .gateway_audit_socket
+        .map(|p| p.to_string_lossy().into_owned());
+    child_cfg.signing_key_path = substrate
+        .signing_key_path
+        .map(|p| p.to_string_lossy().into_owned());
+    if let Some(mvm_build::vz::NetworkConfig::Gvproxy {
+        ref mut events_ingest_socket_path,
+        ..
+    }) = child_cfg.network
+    {
+        *events_ingest_socket_path = substrate
+            .gateway_events_socket
+            .map(|p| p.to_string_lossy().into_owned());
+    }
+    if let Some(ref bj) = claim.bundle_json {
+        child_cfg.bundle =
+            Some(serde_json::from_str(bj).context("vz_claim_standby: parse claim bundle_json")?);
+    }
+
+    // Spawn the claimant supervisor in Restore mode. The trait must be in scope.
+    use crate::checkpoint::ChildSupervisorSpawner as _;
+    VzChildSupervisorSpawner
+        .spawn(&child_cfg)
+        .context("vz_claim_standby: spawn claimant supervisor")?;
+
+    Ok(VmId(claimant_name.clone()))
 }
 
 /// Write JSON to `path` mode 0600, atomically via a rename. Mirrors
@@ -2749,6 +3070,161 @@ mod tests {
             std::fs::read(&target_rootfs).unwrap(),
             b"stale-bytes",
             "stale rootfs content must be unchanged"
+        );
+
+        // SAFETY: serialized by HOME_TEST_LOCK.
+        unsafe {
+            std::env::remove_var("MVM_DATA_DIR");
+        }
+    }
+
+    // ── saved-standby pool tests (Vz, no real VM) ────────────────────────────
+
+    /// `vz_claim_standby` propagates a clean error when the pool dir is absent
+    /// (missing meta.json) rather than panicking or returning a misleading
+    /// message.
+    #[test]
+    fn claim_standby_errors_cleanly_on_missing_pool_meta() {
+        let _guard = crate::base::runtime_meta::HOME_TEST_LOCK
+            .lock()
+            .unwrap_or_else(|e| e.into_inner());
+        let tmp = tempfile::tempdir().unwrap();
+        // SAFETY: serialized by HOME_TEST_LOCK.
+        unsafe {
+            std::env::set_var("MVM_DATA_DIR", tmp.path());
+        }
+
+        let handle = mvm_core::vm_backend::StandbyHandle {
+            id: "standby-no-pool".into(),
+            control_socket: tmp.path().join("control.sock"),
+            pid: 0,
+            kernel_sha256: "aaaa".into(),
+            vcpus: 2,
+            mem_mib: 1024,
+            binding_nonce: "bb".repeat(32),
+            spawned_unix_secs: 1,
+            state: mvm_core::vm_backend::StandbyState::Idle,
+            image_sha256: Some("cccc".into()),
+        };
+        let claim = mvm_core::vm_backend::StandbyClaim {
+            rootfs_path: "/fake/rootfs.ext4".into(),
+            plan_json: "{}".into(),
+            tenant_id: "t1".into(),
+            audit_dir: tmp.path().join("audit"),
+            gateway_audit_socket: tmp.path().join("audit.sock"),
+            gateway_events_socket: None,
+            bundle_json: None,
+        };
+
+        let err = vz_claim_standby(&handle, &claim).unwrap_err();
+        let msg = err.to_string();
+        // The error chain must mention the pool meta read, not panic or silently
+        // succeed.
+        assert!(
+            msg.contains("pool meta") || msg.contains("meta.json") || msg.contains("pool dir"),
+            "error should name the missing pool meta: {msg}"
+        );
+
+        // SAFETY: serialized by HOME_TEST_LOCK.
+        unsafe {
+            std::env::remove_var("MVM_DATA_DIR");
+        }
+    }
+
+    /// `verify_content` (called inside `vz_claim_standby`) fails closed when a
+    /// pool blob has been tampered with — a wrong byte in rootfs.ext4 must
+    /// produce an integrity error before any claimant state is written.
+    #[test]
+    fn claim_standby_errors_on_tampered_pool_blob() {
+        let _guard = crate::base::runtime_meta::HOME_TEST_LOCK
+            .lock()
+            .unwrap_or_else(|e| e.into_inner());
+        let tmp = tempfile::tempdir().unwrap();
+        // SAFETY: serialized by HOME_TEST_LOCK.
+        unsafe {
+            std::env::set_var("MVM_DATA_DIR", tmp.path());
+        }
+
+        let standby_id = "standby-tamper-test";
+        let pool_root = tmp.path().join("pool");
+        let store = crate::checkpoint::CheckpointStore::at(&pool_root);
+        let ckid = mvm_core::checkpoint::CheckpointId::new(standby_id.to_string());
+        let content_dir = store.content_dir(&ckid);
+        std::fs::create_dir_all(&content_dir).unwrap();
+
+        // Write blobs with a correct hash recorded in the manifest...
+        let rootfs_path = content_dir.join("rootfs.ext4");
+        let memory_path = content_dir.join("memory.bin");
+        let machine_id_path = content_dir.join("machine-id");
+        std::fs::write(&rootfs_path, b"fake-rootfs").unwrap();
+        std::fs::write(&memory_path, b"fake-memory").unwrap();
+        std::fs::write(&machine_id_path, b"fake-id").unwrap();
+
+        let sha = |p: &std::path::Path| mvm_core::crypto::image_verify::sha256_file(p).unwrap();
+        let meta = mvm_core::checkpoint::CheckpointMeta {
+            id: ckid.clone(),
+            vm_name: standby_id.into(),
+            parent: None,
+            tag: None,
+            created_unix: 1,
+            class: mvm_core::checkpoint::CheckpointClass::VmFull,
+            supervisor_config_digest: "ignored".into(),
+            audit_ref: None,
+            content: vec![
+                mvm_core::checkpoint::ContentBlob {
+                    name: "rootfs.ext4".into(),
+                    sha256: sha(&rootfs_path),
+                },
+                mvm_core::checkpoint::ContentBlob {
+                    name: "memory.bin".into(),
+                    sha256: sha(&memory_path),
+                },
+                mvm_core::checkpoint::ContentBlob {
+                    name: "machine-id".into(),
+                    sha256: sha(&machine_id_path),
+                },
+            ],
+        };
+        store.write_meta(&meta).unwrap();
+
+        // ...then tamper the rootfs so the manifest sha no longer matches.
+        std::fs::write(&rootfs_path, b"CORRUPTED-rootfs").unwrap();
+
+        let handle = mvm_core::vm_backend::StandbyHandle {
+            id: standby_id.into(),
+            control_socket: tmp.path().join("control.sock"),
+            pid: 0,
+            kernel_sha256: "kk".into(),
+            vcpus: 2,
+            mem_mib: 1024,
+            binding_nonce: "cc".repeat(32),
+            spawned_unix_secs: 1,
+            state: mvm_core::vm_backend::StandbyState::Idle,
+            image_sha256: Some("img-sha".into()),
+        };
+        let claim = mvm_core::vm_backend::StandbyClaim {
+            rootfs_path: "/fake/rootfs.ext4".into(),
+            plan_json: "{}".into(),
+            tenant_id: "t1".into(),
+            audit_dir: tmp.path().join("audit"),
+            gateway_audit_socket: tmp.path().join("audit.sock"),
+            gateway_events_socket: None,
+            bundle_json: None,
+        };
+
+        let err = vz_claim_standby(&handle, &claim).unwrap_err();
+        let msg = format!("{err:#}");
+        assert!(
+            msg.contains("tampered") || msg.contains("integrity") || msg.contains("sha256"),
+            "error must name the integrity failure: {msg}"
+        );
+
+        // No claimant state dir should have been created — claim must abort
+        // before writing any state.
+        let claimant_dir = tmp.path().join("vms").join(standby_id);
+        assert!(
+            !claimant_dir.exists(),
+            "claim must not create claimant dir before integrity check passes"
         );
 
         // SAFETY: serialized by HOME_TEST_LOCK.

--- a/crates/mvm-cli/src/commands/pool.rs
+++ b/crates/mvm-cli/src/commands/pool.rs
@@ -59,6 +59,23 @@ pub fn kernel_identity(backend: &dyn VmBackend, kernel_path: Option<&str>) -> Re
     kernel_sha256_hex(Path::new(kernel))
 }
 
+/// The compat-key image identity. `None` for libkrun (image-agnostic standbys). For Vz
+/// the sha256 of the source rootfs image ties a saved-standby to the exact image it was
+/// captured from — only launches with the same image may claim it.
+pub fn image_identity(backend: &dyn VmBackend, rootfs_path: &str) -> Result<Option<String>> {
+    if backend.name() == "libkrun" {
+        return Ok(None);
+    }
+    if backend.name() == "vz" || backend.name() == "virtualization" {
+        let sha = kernel_sha256_hex(Path::new(rootfs_path))
+            .with_context(|| format!("hashing rootfs for image identity: {rootfs_path}"))?;
+        return Ok(Some(sha));
+    }
+    // Other backends (firecracker, qemu, …) have no pool today; return None so
+    // compat_for_launch compiles without gating those paths.
+    Ok(None)
+}
+
 /// Inputs to [`build_standby_spec`] (grouped to avoid a long positional signature).
 pub struct StandbySpecParams<'a> {
     /// `~/.mvm/pool/` root — holds the control UDS.
@@ -75,6 +92,10 @@ pub struct StandbySpecParams<'a> {
     pub mem_mib: u32,
     pub signer_id: &'a str,
     pub signing_key_path: &'a Path,
+    /// Source rootfs image for Vz saved-standbys. `None` for libkrun.
+    pub image_path: Option<&'a Path>,
+    /// Sha256 hex of the image for the compat key. `None` for libkrun.
+    pub image_sha256: Option<&'a str>,
 }
 
 /// Build a `StandbySpec` from [`StandbySpecParams`]. The control UDS lives under
@@ -98,6 +119,8 @@ pub fn build_standby_spec(p: &StandbySpecParams<'_>) -> Result<StandbySpec> {
         control_socket: p.pool_root.join(&id).join("control.sock"),
         vm_state_dir: p.vms_root.join(&id).to_string_lossy().into_owned(),
         binding_nonce: nonce,
+        image_path: p.image_path.map(|p| p.to_string_lossy().into_owned()),
+        image_sha256: p.image_sha256.map(str::to_string),
         id,
     })
 }
@@ -168,6 +191,8 @@ pub struct WarmParams<'a> {
     pub signer_id: &'a str,
     pub signing_key_path: &'a Path,
     pub target: u32,
+    /// Source rootfs image for Vz saved-standbys. `None` for libkrun.
+    pub image: Option<&'a Path>,
 }
 
 /// Warm the pool toward `target` idle standbys for the given kernel+resources. Best-effort:
@@ -180,10 +205,18 @@ pub fn warm_to_target(pool: &SupervisorStandbyPool, p: &WarmParams<'_>) -> Resul
     // The compat identity computed identically here and at claim time (a constant for
     // libkrun's bundled kernel) so a warmed standby is actually claimable.
     let kernel_sha256 = kernel_identity(p.backend, p.kernel.to_str())?;
+    let image_sha256 = match p.image {
+        Some(img) => Some(
+            kernel_sha256_hex(img)
+                .with_context(|| format!("hashing image for pool compat key: {}", img.display()))?,
+        ),
+        None => None,
+    };
     let want = StandbyCompat {
         kernel_sha256: kernel_sha256.clone(),
         vcpus: p.vcpus,
         mem_mib: p.mem_mib,
+        image_sha256: image_sha256.clone(),
     };
     let have = pool.idle_count_compatible(&want)? as u32;
     let pool_root = mvm_core::config::mvm_pool_dir()?;
@@ -199,6 +232,8 @@ pub fn warm_to_target(pool: &SupervisorStandbyPool, p: &WarmParams<'_>) -> Resul
             mem_mib: p.mem_mib,
             signer_id: p.signer_id,
             signing_key_path: p.signing_key_path,
+            image_path: p.image,
+            image_sha256: image_sha256.as_deref(),
         })?;
         match p.backend.spawn_standby(&spec) {
             Ok(handle) => {
@@ -211,15 +246,16 @@ pub fn warm_to_target(pool: &SupervisorStandbyPool, p: &WarmParams<'_>) -> Resul
     Ok(spawned)
 }
 
-/// The base-compat key a launch needs (kernel identity + the fixed vcpus/mem). The kernel
-/// component is [`kernel_identity`] — for libkrun the bundled-kernel constant, so it's
-/// computable here pre-boot even though the mkGuest workload kernel isn't on disk yet (the
-/// claim/replenish asymmetry that previously forced fail-open-to-cold).
+/// The base-compat key a launch needs (kernel identity + fixed vcpus/mem + image sha for
+/// Vz). The kernel component is [`kernel_identity`] — for libkrun the bundled-kernel
+/// constant, so it's computable pre-boot even without an on-disk kernel.
 fn compat_for_launch(backend: &dyn VmBackend, cfg: &VmStartConfig) -> Result<StandbyCompat> {
+    let image_sha256 = image_identity(backend, cfg.rootfs_path.as_str())?;
     Ok(StandbyCompat {
         kernel_sha256: kernel_identity(backend, cfg.kernel_path.as_deref())?,
         vcpus: u8::try_from(cfg.cpus.clamp(1, u32::from(u8::MAX))).unwrap_or(u8::MAX),
         mem_mib: cfg.memory_mib,
+        image_sha256,
     })
 }
 
@@ -276,8 +312,19 @@ pub fn try_warm_claim(
 
 /// Top the pool back up toward `cfg.warm_pool_size` after a launch (the no-daemon
 /// replenish-on-use maintainer). Best-effort — failures are logged, never propagated.
+///
+/// For libkrun standbys this path fires automatically after each claimed launch.
+/// For Vz saved-standbys the replenish path requires a boot + capture cycle that is
+/// expensive and may require the builder VM to resolve the kernel. Automatic replenish
+/// is skipped for Vz (pool warm is manual); `supports_standby_pool()` stays true so
+/// `try_warm_claim` still fires.
 pub fn replenish_after_launch(backend: &AnyBackend, cfg: &VmStartConfig) -> Result<u32> {
     if cfg.warm_pool_size == 0 || !backend.supports_standby_pool() {
+        return Ok(0);
+    }
+    // Vz replenish requires booting a seed VM + capture: too expensive for the
+    // post-claim fast path. Replenish is manual (`mvmctl pool warm`) for Vz.
+    if backend.as_vm_backend().name() == "vz" {
         return Ok(0);
     }
     let Some(kernel) = cfg.kernel_path.as_ref() else {
@@ -295,6 +342,7 @@ pub fn replenish_after_launch(backend: &AnyBackend, cfg: &VmStartConfig) -> Resu
             signer_id: &host_signer::host_signer_id(),
             signing_key_path: &signer.secret_path,
             target: cfg.warm_pool_size,
+            image: None, // libkrun only: image-agnostic standbys
         },
     )
 }
@@ -360,6 +408,8 @@ mod tests {
             mem_mib: 1024,
             signer_id: "host:test",
             signing_key_path: &tmp.path().join("key"),
+            image_path: None,
+            image_sha256: None,
         })
         .unwrap();
         // The socket lives under the nonce-derived `standby-<16hex>` dir; the filename is
@@ -494,6 +544,7 @@ mod tests {
             binding_nonce: "ab".repeat(32),
             spawned_unix_secs: 1,
             state: StandbyState::Idle,
+            image_sha256: None,
         }
     }
 
@@ -502,6 +553,7 @@ mod tests {
             kernel_sha256: kernel.into(),
             vcpus: 2,
             mem_mib: 1024,
+            image_sha256: None,
         }
     }
 
@@ -625,10 +677,18 @@ pub(in crate::commands) struct Args {
 #[derive(Subcommand, Debug, Clone)]
 pub(in crate::commands) enum PoolAction {
     /// Pre-spawn idle supervisor standbys for the default-microVM launch shape so a later
-    /// `up` is fast. Default count 1. Only the libkrun backend has a standby pool today.
+    /// `up` is fast. Default count 1.
+    ///
+    /// For the Vz backend a saved-standby capture requires an image rootfs. Provide
+    /// `--rootfs <path>` or set `MVM_POOL_ROOTFS`; if absent, the command falls back to
+    /// the cached default-microVM image (same one `up` uses without `--flake`).
     Warm {
         /// How many idle standbys to warm the pool toward (default 1).
         count: Option<u32>,
+        /// Source rootfs for Vz saved-standbys (absolute path to an ext4 image).
+        /// Ignored for libkrun. Defaults to the cached default-microVM rootfs.
+        #[arg(long)]
+        rootfs: Option<String>,
     },
     /// Show the standby pool — recorded standbys and their idle/claimed state.
     Status {
@@ -645,20 +705,34 @@ struct WarmShape {
     backend: AnyBackend,
     backend_name: String,
     kernel: std::path::PathBuf,
+    /// Source rootfs for Vz saved-standbys. `None` for libkrun (image-agnostic).
+    image: Option<std::path::PathBuf>,
     vcpus: u8,
     mem_mib: u32,
 }
 
-fn resolve_warm_shape(cfg: &MvmConfig) -> Result<WarmShape> {
+fn resolve_warm_shape(cfg: &MvmConfig, rootfs_override: Option<&str>) -> Result<WarmShape> {
     let backend_name = super::shared::resolve_effective_hypervisor("firecracker");
     let backend = AnyBackend::from_hypervisor(&backend_name);
-    let (kernel, _rootfs) = ensure_default_microvm_image(mvm_build::pipeline::BuildMode::Prod)
-        .context("resolve default-microvm kernel for the warm pool")?;
+    let (kernel, default_rootfs) =
+        ensure_default_microvm_image(mvm_build::pipeline::BuildMode::Prod)
+            .context("resolve default-microvm kernel for the warm pool")?;
     let vcpus = u8::try_from(cfg.default_cpus.clamp(1, u32::from(u8::MAX))).unwrap_or(u8::MAX);
+    // Vz needs an image; libkrun does not. Resolve: explicit --rootfs > env var > default.
+    let image = if backend_name == "vz" || backend_name == "virtualization" {
+        let path = rootfs_override
+            .map(str::to_string)
+            .or_else(|| std::env::var("MVM_POOL_ROOTFS").ok())
+            .unwrap_or(default_rootfs);
+        Some(std::path::PathBuf::from(path))
+    } else {
+        None
+    };
     Ok(WarmShape {
         backend,
         backend_name,
         kernel: std::path::PathBuf::from(kernel),
+        image,
         vcpus,
         mem_mib: cfg.default_memory_mib,
     })
@@ -668,16 +742,22 @@ pub(in crate::commands) fn run(_cli: &Cli, args: Args, cfg: &MvmConfig) -> Resul
     let pool = SupervisorStandbyPool::open()?;
     match args.action {
         PoolAction::Status { json } => run_status(&pool, json),
-        PoolAction::Warm { count } => run_warm(&pool, cfg, count.unwrap_or(1)),
+        PoolAction::Warm { count, rootfs } => {
+            run_warm(&pool, cfg, count.unwrap_or(1), rootfs.as_deref())
+        }
     }
 }
 
-fn run_warm(pool: &SupervisorStandbyPool, cfg: &MvmConfig, target: u32) -> Result<()> {
-    let shape = resolve_warm_shape(cfg)?;
+fn run_warm(
+    pool: &SupervisorStandbyPool,
+    cfg: &MvmConfig,
+    target: u32,
+    rootfs_override: Option<&str>,
+) -> Result<()> {
+    let shape = resolve_warm_shape(cfg, rootfs_override)?;
     if !shape.backend.supports_standby_pool() {
         crate::ui::warn(&format!(
-            "backend '{}' has no supervisor standby pool (only libkrun does today); \
-             nothing warmed.",
+            "backend '{}' has no supervisor standby pool; nothing warmed.",
             shape.backend_name
         ));
         return Ok(());
@@ -694,6 +774,7 @@ fn run_warm(pool: &SupervisorStandbyPool, cfg: &MvmConfig, target: u32) -> Resul
             signer_id: &host_signer::host_signer_id(),
             signing_key_path: &signer.secret_path,
             target,
+            image: shape.image.as_deref(),
         },
     )?;
     // A state-changing verb emits one audit record per attempt.
@@ -728,6 +809,8 @@ struct PoolStatusEntry {
     kernel_sha256: String,
     vcpus: u8,
     mem_mib: u32,
+    /// Present for Vz saved-standbys; absent (null) for libkrun.
+    image_sha256: Option<String>,
 }
 
 fn run_status(pool: &SupervisorStandbyPool, json: bool) -> Result<()> {
@@ -752,6 +835,7 @@ fn run_status(pool: &SupervisorStandbyPool, json: bool) -> Result<()> {
                 kernel_sha256: h.kernel_sha256.clone(),
                 vcpus: h.vcpus,
                 mem_mib: h.mem_mib,
+                image_sha256: h.image_sha256.clone(),
             })
             .collect(),
     };
@@ -761,14 +845,24 @@ fn run_status(pool: &SupervisorStandbyPool, json: bool) -> Result<()> {
     }
     println!("Supervisor standby pool: {idle} idle, {claimed} claimed");
     for e in &report.standbys {
+        let image_tag = e
+            .image_sha256
+            .as_deref()
+            .map(|s| format!(" · image {}", &s[..s.len().min(12)]))
+            .unwrap_or_default();
         println!(
-            "  {} · {} · pid {} · {} vcpu / {} MiB · kernel {}",
+            "  {} · {} · {} · {} vcpu / {} MiB · kernel {}{}",
             e.id,
             e.state,
-            e.pid,
+            if e.pid == 0 {
+                "saved-state".to_string()
+            } else {
+                format!("pid {}", e.pid)
+            },
             e.vcpus,
             e.mem_mib,
-            &e.kernel_sha256[..e.kernel_sha256.len().min(12)]
+            &e.kernel_sha256[..e.kernel_sha256.len().min(12)],
+            image_tag,
         );
     }
     Ok(())

--- a/crates/mvm-cli/src/commands/pool.rs
+++ b/crates/mvm-cli/src/commands/pool.rs
@@ -66,7 +66,7 @@ pub fn image_identity(backend: &dyn VmBackend, rootfs_path: &str) -> Result<Opti
     if backend.name() == "libkrun" {
         return Ok(None);
     }
-    if backend.name() == "vz" || backend.name() == "virtualization" {
+    if backend.name() == "vz" {
         let sha = kernel_sha256_hex(Path::new(rootfs_path))
             .with_context(|| format!("hashing rootfs for image identity: {rootfs_path}"))?;
         return Ok(Some(sha));
@@ -195,12 +195,25 @@ pub struct WarmParams<'a> {
     pub image: Option<&'a Path>,
 }
 
-/// Warm the pool toward `target` idle standbys for the given kernel+resources. Best-effort:
-/// spawn failures are logged, not fatal (warm pool is an optimization). Returns how many
-/// were newly spawned.
-pub fn warm_to_target(pool: &SupervisorStandbyPool, p: &WarmParams<'_>) -> Result<u32> {
+/// Summary returned by [`warm_to_target`].
+#[derive(Debug, PartialEq, Eq)]
+pub struct WarmResult {
+    /// Standbys newly spawned and recorded in this call.
+    pub spawned: u32,
+    /// Spawn attempts that failed (each was logged as a warning).
+    pub failed: u32,
+}
+
+/// Warm the pool toward `target` idle standbys for the given kernel+resources.
+/// Spawn failures are logged and counted; the caller decides whether to
+/// surface them as an error.  Returns a [`WarmResult`] with success and
+/// failure counts.
+pub fn warm_to_target(pool: &SupervisorStandbyPool, p: &WarmParams<'_>) -> Result<WarmResult> {
     if p.target == 0 || !p.backend.supports_standby_pool() {
-        return Ok(0);
+        return Ok(WarmResult {
+            spawned: 0,
+            failed: 0,
+        });
     }
     // The compat identity computed identically here and at claim time (a constant for
     // libkrun's bundled kernel) so a warmed standby is actually claimable.
@@ -221,7 +234,8 @@ pub fn warm_to_target(pool: &SupervisorStandbyPool, p: &WarmParams<'_>) -> Resul
     let have = pool.idle_count_compatible(&want)? as u32;
     let pool_root = mvm_core::config::mvm_pool_dir()?;
     let vms_root = mvm_core::config::mvm_data_dir_strict()?.join("vms");
-    let mut spawned = 0;
+    let mut spawned = 0u32;
+    let mut failed = 0u32;
     for _ in have..p.target {
         let spec = build_standby_spec(&StandbySpecParams {
             pool_root: &pool_root,
@@ -240,10 +254,13 @@ pub fn warm_to_target(pool: &SupervisorStandbyPool, p: &WarmParams<'_>) -> Resul
                 pool.record(&handle)?;
                 spawned += 1;
             }
-            Err(e) => tracing::warn!(error = %e, "spawn standby failed; pool stays under target"),
+            Err(e) => {
+                tracing::warn!(error = %e, "spawn standby failed; pool stays under target");
+                failed += 1;
+            }
         }
     }
-    Ok(spawned)
+    Ok(WarmResult { spawned, failed })
 }
 
 /// The base-compat key a launch needs (kernel identity + fixed vcpus/mem + image sha for
@@ -332,7 +349,7 @@ pub fn replenish_after_launch(backend: &AnyBackend, cfg: &VmStartConfig) -> Resu
     };
     let signer = host_signer::load_or_init()?;
     let pool = SupervisorStandbyPool::open()?;
-    warm_to_target(
+    let result = warm_to_target(
         &pool,
         &WarmParams {
             backend: backend.as_vm_backend(),
@@ -344,7 +361,8 @@ pub fn replenish_after_launch(backend: &AnyBackend, cfg: &VmStartConfig) -> Resu
             target: cfg.warm_pool_size,
             image: None, // libkrun only: image-agnostic standbys
         },
-    )
+    )?;
+    Ok(result.spawned)
 }
 
 fn hex_lower(bytes: &[u8]) -> String {
@@ -664,6 +682,125 @@ mod tests {
         c.plan_json = None; // not the gateway-bridge/admitted path → cold-boot
         assert_eq!(try_warm_claim(&b, &c, false).unwrap(), None);
     }
+
+    // A VmBackend stub whose `spawn_standby` always fails — used to exercise
+    // the warm failure path without a real VM.
+    struct FailingSpawnBackend;
+    impl VmBackend for FailingSpawnBackend {
+        fn name(&self) -> &str {
+            "stub-fail-spawn"
+        }
+        fn capabilities(&self) -> VmCapabilities {
+            VmCapabilities::default()
+        }
+        fn supports_standby_pool(&self) -> bool {
+            true
+        }
+        fn spawn_standby(
+            &self,
+            _spec: &mvm_core::vm_backend::StandbySpec,
+        ) -> std::result::Result<StandbyHandle, StandbyError> {
+            Err(StandbyError::ClaimFailed("injected spawn failure".into()))
+        }
+        fn start_with_mode(&self, _: &VmStartConfig, _: StartMode) -> anyhow::Result<VmId> {
+            unreachable!()
+        }
+        fn stop(&self, _: &VmId) -> anyhow::Result<()> {
+            Ok(())
+        }
+        fn stop_all(&self) -> anyhow::Result<()> {
+            Ok(())
+        }
+        fn pause(&self, _: &VmId) -> anyhow::Result<()> {
+            Ok(())
+        }
+        fn resume(&self, _: &VmId) -> anyhow::Result<()> {
+            Ok(())
+        }
+        fn status(&self, _: &VmId) -> anyhow::Result<VmStatus> {
+            Ok(VmStatus::Stopped)
+        }
+        fn list(&self) -> anyhow::Result<Vec<VmInfo>> {
+            Ok(vec![])
+        }
+        fn logs(&self, _: &VmId, _: u32, _: bool) -> anyhow::Result<String> {
+            Ok(String::new())
+        }
+        fn is_available(&self) -> anyhow::Result<bool> {
+            Ok(true)
+        }
+        fn install(&self) -> anyhow::Result<()> {
+            Ok(())
+        }
+    }
+
+    #[test]
+    fn warm_to_target_counts_failures_when_spawn_errors() {
+        let tmp = tempfile::tempdir().unwrap();
+        let pool = SupervisorStandbyPool::at(tmp.path().join("pool"));
+        let kernel = tmp.path().join("vmlinux");
+        std::fs::write(&kernel, b"k").unwrap();
+        let key = tmp.path().join("host-signer.ed25519");
+        std::fs::write(&key, b"fake-key").unwrap();
+
+        let backend = FailingSpawnBackend;
+        let result = warm_to_target(
+            &pool,
+            &WarmParams {
+                backend: &backend,
+                kernel: &kernel,
+                vcpus: 2,
+                mem_mib: 1024,
+                signer_id: "host:test",
+                signing_key_path: &key,
+                target: 2,
+                image: None,
+            },
+        )
+        .unwrap();
+
+        // No standbys were spawned; both attempts counted as failures.
+        assert_eq!(result.spawned, 0, "no standbys should be recorded");
+        assert_eq!(
+            result.failed, 2,
+            "both spawn attempts must be counted as failures"
+        );
+    }
+
+    #[test]
+    fn warm_to_target_already_at_target_returns_zero_spawned_zero_failed() {
+        let tmp = tempfile::tempdir().unwrap();
+        let pool = SupervisorStandbyPool::at(tmp.path().join("pool"));
+        let kernel = tmp.path().join("vmlinux");
+        std::fs::write(&kernel, b"k").unwrap();
+        let key = tmp.path().join("key");
+        std::fs::write(&key, b"fake-key").unwrap();
+
+        // Pre-fill the pool with 1 idle standby.
+        let mut h = idle_handle("s1", &kernel_sha256_hex(&kernel).unwrap());
+        h.kernel_sha256 = kernel_sha256_hex(&kernel).unwrap();
+        pool.record(&h).unwrap();
+
+        let backend = FailingSpawnBackend;
+        let result = warm_to_target(
+            &pool,
+            &WarmParams {
+                backend: &backend,
+                kernel: &kernel,
+                vcpus: h.vcpus,
+                mem_mib: h.mem_mib,
+                signer_id: "host:test",
+                signing_key_path: &key,
+                target: 1,
+                image: None,
+            },
+        )
+        .unwrap();
+
+        // Already at target → no spawns attempted, no failures.
+        assert_eq!(result.spawned, 0);
+        assert_eq!(result.failed, 0);
+    }
 }
 
 // ── `mvmctl pool` command ───────────────────────────────────────────────────────────
@@ -764,7 +901,7 @@ fn run_warm(
     }
     // Ensure the host signer exists — the standby re-verifies the attach plan against it.
     let signer = host_signer::load_or_init()?;
-    let spawned = warm_to_target(
+    let result = warm_to_target(
         pool,
         &WarmParams {
             backend: shape.backend.as_vm_backend(),
@@ -778,12 +915,30 @@ fn run_warm(
         },
     )?;
     // A state-changing verb emits one audit record per attempt.
-    mvm_core::audit_emit!(PoolWarm, "spawned={spawned} target={target}");
-    if spawned == 0 {
+    mvm_core::audit_emit!(
+        PoolWarm,
+        "spawned={} failed={} target={target}",
+        result.spawned,
+        result.failed
+    );
+    let idle_after = result.spawned;
+    if result.failed > 0 && idle_after < target {
+        crate::ui::warn(&format!(
+            "{}/{} standby(s) warmed; {} spawn(s) failed — check logs for details.",
+            idle_after, target, result.failed,
+        ));
+        return Err(anyhow::anyhow!(
+            "pool warm: {}/{} standby(s) warmed, {} failed",
+            idle_after,
+            target,
+            result.failed,
+        ));
+    } else if result.spawned == 0 && result.failed == 0 {
         crate::ui::info(&format!("Pool already at or above target {target}."));
     } else {
         crate::ui::success(&format!(
-            "Warmed {spawned} standby(s) toward target {target}."
+            "Warmed {} standby(s) toward target {target}.",
+            result.spawned,
         ));
     }
     crate::ui::info(

--- a/crates/mvm-cli/src/commands/tests.rs
+++ b/crates/mvm-cli/src/commands/tests.rs
@@ -2780,7 +2780,7 @@ fn test_pool_warm_parses_optional_count() {
     let cli = Cli::try_parse_from(["mvmctl", "pool", "warm", "3"]).unwrap();
     match cli.command {
         Commands::Pool(pool::Args {
-            action: pool::PoolAction::Warm { count },
+            action: pool::PoolAction::Warm { count, .. },
         }) => assert_eq!(count, Some(3)),
         _ => panic!("Expected Pool Warm command"),
     }

--- a/crates/mvm-cli/src/doctor.rs
+++ b/crates/mvm-cli/src/doctor.rs
@@ -2754,13 +2754,14 @@ mod tests {
                 ("vz".to_string(), vz_warm_start),
             ]
         );
+        let vz_standby = AnyBackend::from_hypervisor("vz").supports_standby_pool();
         assert_eq!(
             ordered_standby_pool,
             vec![
                 ("firecracker".to_string(), false),
                 ("libkrun".to_string(), true),
                 ("qemu".to_string(), false),
-                ("vz".to_string(), false),
+                ("vz".to_string(), vz_standby),
             ]
         );
     }
@@ -2768,10 +2769,11 @@ mod tests {
     #[test]
     fn collect_warm_start_support_reports_standby_pool_per_backend() {
         let r = collect_warm_start_support();
-        // Only libkrun implements the standby pool today; the rest
-        // report honest `false` and must not be silently dropped.
+        // libkrun and Vz (on macOS 14+) implement the standby pool; FC and QEMU do not.
+        // Report honest values for every backend; none may be silently dropped.
         assert_eq!(r.standby_pool.get("libkrun"), Some(&true));
-        assert_eq!(r.standby_pool.get("vz"), Some(&false));
+        let vz_standby = AnyBackend::from_hypervisor("vz").supports_standby_pool();
+        assert_eq!(r.standby_pool.get("vz"), Some(&vz_standby));
         assert_eq!(r.standby_pool.get("qemu"), Some(&false));
     }
 

--- a/crates/mvm-core/src/protocol/vm_backend.rs
+++ b/crates/mvm-core/src/protocol/vm_backend.rs
@@ -545,7 +545,8 @@ impl std::error::Error for WarmStartError {}
 
 /// How a prelaunched standby is to be set up. Backend-agnostic:
 /// the caller (the launch path) fills this in; the backend's [`VmBackend::spawn_standby`]
-/// translates it to its own wire config (libkrun → `SupervisorBaseConfig`).
+/// translates it to its own wire config (libkrun → `SupervisorBaseConfig`; Vz → boots a
+/// seed VM, captures its memory state, and stops the supervisor).
 #[derive(Debug, Clone)]
 pub struct StandbySpec {
     /// Stable id for this standby (also the `~/.mvm/pool/<id>/` dir name).
@@ -569,21 +570,36 @@ pub struct StandbySpec {
     pub control_socket: std::path::PathBuf,
     /// Per-VM state dir the standby writes its pid into.
     pub vm_state_dir: String,
+    /// Source rootfs image path for Vz saved-standbys. `None` for libkrun (no rootfs
+    /// is baked in at spawn; any workload rootfs attaches at claim time).
+    pub image_path: Option<String>,
+    /// Sha256 hex of `image_path` for the compat key. `None` for libkrun.
+    pub image_sha256: Option<String>,
 }
 
-/// The base-compat key — everything a libkrun standby fixes at spawn and therefore must
-/// match the workload exactly, else the launch cold-boots. v1 is default-kernel +
-/// default-resources only; multi-kernel/multi-shape keying is deferred (SPRINT.md). The
-/// "no extra volumes" half of compat is enforced at the launch path (a standby declares
-/// none), not here.
+/// The base-compat key — everything a standby fixes at spawn and must therefore match the
+/// workload exactly, else the launch cold-boots.
+///
+/// `image_sha256` is `None` for libkrun (any image attaches; libkrun standbys carry no
+/// rootfs) and `Some(sha)` for Vz saved-standbys (which are image-specific; a Vz standby
+/// is a frozen {rootfs, memory, machine-id} triple captured from one particular image).
+/// Two standbys are compatible only when both image fields are identical — `None == None`
+/// (libkrun) and `Some(a) == Some(b)` iff `a == b`.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct StandbyCompat {
     pub kernel_sha256: String,
     pub vcpus: u8,
     pub mem_mib: u32,
+    /// `None` for libkrun (image-agnostic); `Some(sha256-hex)` for Vz (image-bound).
+    pub image_sha256: Option<String>,
 }
 
-/// A recorded, live standby (persisted as `~/.mvm/pool/<id>/standby.json`).
+/// A recorded standby (persisted as `~/.mvm/pool/<id>/standby.json`).
+///
+/// `pid` is 0 for saved-state standbys (Vz): the supervisor that booted the seed VM was
+/// stopped at capture time; no process is running. `reap_stale` and the liveness checks
+/// treat pid=0 as "TTL-only" — the standby is never pruned for a dead process, only for
+/// expiry. No real process has pid 0.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct StandbyHandle {
     pub id: String,
@@ -595,6 +611,9 @@ pub struct StandbyHandle {
     pub binding_nonce: String,
     pub spawned_unix_secs: u64,
     pub state: StandbyState,
+    /// `None` for libkrun (image-agnostic); `Some(sha256-hex)` for Vz saved-standbys.
+    #[serde(default)]
+    pub image_sha256: Option<String>,
 }
 
 impl StandbyHandle {
@@ -604,13 +623,20 @@ impl StandbyHandle {
             kernel_sha256: self.kernel_sha256.clone(),
             vcpus: self.vcpus,
             mem_mib: self.mem_mib,
+            image_sha256: self.image_sha256.clone(),
         }
     }
 
-    /// A launch may claim this standby only if its kernel **and** fixed resources match
-    /// exactly — no silent wrong-kernel or wrong-size boot.
+    /// A launch may claim this standby only if its kernel, fixed resources, and image
+    /// sha256 all match exactly — no silent wrong-kernel, wrong-size, or wrong-image boot.
     pub fn is_compatible(&self, want: &StandbyCompat) -> bool {
         &self.compat() == want
+    }
+
+    /// True if this standby holds a captured memory state rather than a live supervisor.
+    /// Saved standbys carry pid=0 (no running process) and are reaped by TTL only.
+    pub fn is_saved_state(&self) -> bool {
+        self.pid == 0
     }
 }
 
@@ -1107,6 +1133,7 @@ mod tests {
             binding_nonce: "deadbeef".repeat(8),
             spawned_unix_secs: 1_700_000_000,
             state: StandbyState::Idle,
+            image_sha256: None,
         };
         let json = serde_json::to_string(&h).unwrap();
         let back: StandbyHandle = serde_json::from_str(&json).unwrap();
@@ -1116,6 +1143,7 @@ mod tests {
             kernel_sha256: "a".repeat(64),
             vcpus: 2,
             mem_mib: 1024,
+            image_sha256: None,
         };
         assert!(back.is_compatible(&want));
         // wrong kernel, wrong cpus, and wrong mem each break compat.
@@ -1129,6 +1157,21 @@ mod tests {
         }));
         assert!(!back.is_compatible(&StandbyCompat {
             mem_mib: 2048,
+            ..want.clone()
+        }));
+        // Vz image sha must match exactly: Some(a) ≠ None, Some(a) ≠ Some(b).
+        let vz_handle = StandbyHandle {
+            image_sha256: Some("c".repeat(64)),
+            ..h.clone()
+        };
+        let vz_want = StandbyCompat {
+            image_sha256: Some("c".repeat(64)),
+            ..want.clone()
+        };
+        assert!(vz_handle.is_compatible(&vz_want));
+        assert!(!vz_handle.is_compatible(&want)); // None ≠ Some
+        assert!(!vz_handle.is_compatible(&StandbyCompat {
+            image_sha256: Some("d".repeat(64)),
             ..want
         }));
     }
@@ -1153,6 +1196,8 @@ mod tests {
             binding_nonce: "ab".repeat(32),
             control_socket: "/p/standby-x/control.sock".into(),
             vm_state_dir: "/p/standby-x".into(),
+            image_path: None,
+            image_sha256: None,
         }
     }
 
@@ -1188,6 +1233,7 @@ mod tests {
                 binding_nonce: "ab".repeat(32),
                 spawned_unix_secs: 1,
                 state: StandbyState::Idle,
+                image_sha256: None,
             },
             &sample_standby_claim(),
         ) {
@@ -1199,6 +1245,58 @@ mod tests {
     #[test]
     fn warm_pool_size_defaults_to_zero() {
         assert_eq!(VmStartConfig::default().warm_pool_size, 0);
+    }
+
+    /// Old standby.json records written before the image_sha256 field was added
+    /// must still deserialise cleanly via `#[serde(default)]`.
+    #[test]
+    fn standby_handle_old_record_without_image_sha_deserialises_as_none() {
+        let old_json = r#"{
+            "id": "standby-old",
+            "control_socket": "/p/standby-old/control.sock",
+            "pid": 9999,
+            "kernel_sha256": "aabbcc",
+            "vcpus": 2,
+            "mem_mib": 1024,
+            "binding_nonce": "deadbeef",
+            "spawned_unix_secs": 1000,
+            "state": "idle"
+        }"#;
+        let h: StandbyHandle = serde_json::from_str(old_json).unwrap();
+        assert_eq!(h.image_sha256, None, "absent field must default to None");
+        assert!(!h.is_saved_state(), "pid != 0 → live standby");
+        // An old libkrun standby is compatible with a libkrun launch (both None).
+        let want = StandbyCompat {
+            kernel_sha256: "aabbcc".into(),
+            vcpus: 2,
+            mem_mib: 1024,
+            image_sha256: None,
+        };
+        assert!(h.is_compatible(&want));
+    }
+
+    /// A Vz saved-standby uses pid=0 (no running supervisor) and must be treated
+    /// as TTL-only by the liveness path (is_saved_state()).
+    #[test]
+    fn standby_handle_saved_state_pid_zero_flag() {
+        let saved = StandbyHandle {
+            id: "standby-vz".into(),
+            control_socket: "/p/standby-vz/control.sock".into(),
+            pid: 0,
+            kernel_sha256: "cc".repeat(32),
+            vcpus: 2,
+            mem_mib: 1024,
+            binding_nonce: "ab".repeat(32),
+            spawned_unix_secs: 1,
+            state: StandbyState::Idle,
+            image_sha256: Some("dd".repeat(32)),
+        };
+        assert!(saved.is_saved_state());
+        // serde roundtrip preserves the image sha and pid=0.
+        let json = serde_json::to_string(&saved).unwrap();
+        let back: StandbyHandle = serde_json::from_str(&json).unwrap();
+        assert_eq!(back.image_sha256, Some("dd".repeat(32)));
+        assert_eq!(back.pid, 0);
     }
 
     #[test]

--- a/crates/mvm-vm-host/src/bin/mvm-vz-drainer.rs
+++ b/crates/mvm-vm-host/src/bin/mvm-vz-drainer.rs
@@ -25,13 +25,16 @@
 //! `mvm-libkrun-supervisor`'s `SupervisorConfig` contract: the
 //! producer (`mvm-backend`) is trusted and has already verified the
 //! signed plan envelope via `mvm-cli`'s `admit_for_run` path before
-//! launch. The drainer parses the plan JSON directly into an
-//! [`ExecutionPlan`] without an additional envelope check —
-//! mirroring the libkrun supervisor's pattern. Re-verification of
-//! the plan envelope at the supervisor leaf would require host
-//! signer state (`mvm-cli::host_signer`) which the drainer cannot
-//! reach without closing a cycle (`mvm-cli → mvm-supervisor →
-//! mvm-cli`).
+//! launch. `plan_json` carries a `SignedExecutionPlan` envelope;
+//! `decode_plan_json` unwraps it with `plan_from_admitted_json`, which
+//! accepts both the signed envelope shape and the bare `ExecutionPlan`
+//! shape (the on-disk form used by lifecycle verbs). No re-verification
+//! of the Ed25519 signature: the host verified it at admission, and the
+//! host is in the TCB. Re-verification here would require the
+//! host-signer state managed by `mvm-cli`, which the drainer cannot
+//! reach without introducing a dep cycle (`mvm-cli → mvm-supervisor →
+//! mvm-cli`). This matches the `secrets_from_signed_json` and
+//! `redaction_from_signed_json` helpers used on every other backend path.
 //!
 //! ## Capability profile
 //!
@@ -49,7 +52,7 @@ use std::sync::Arc;
 
 use anyhow::{Context, Result, anyhow};
 use ed25519_dalek::SigningKey;
-use mvm_core::plan::ExecutionPlan;
+use mvm_core::plan::{ExecutionPlan, plan_from_admitted_json};
 use mvm_core::policy::PolicyBundle;
 use mvm_hostd::supervisor::audit::AuditSigner;
 use mvm_hostd::supervisor::audit_file::FileAuditSigner;
@@ -90,10 +93,9 @@ struct DrainerConfig {
     events_socket_path: PathBuf,
 
     /// Serialised `SignedExecutionPlan` envelope as produced by
-    /// `mvm-cli::plan_admission::populate_audit_substrate`. The
-    /// drainer trusts its parent (see "Trust model" in the module
-    /// doc) and parses the inner `ExecutionPlan` body directly —
-    /// mirroring `mvm-libkrun-supervisor`'s pattern.
+    /// `mvm-cli::plan_admission::populate_audit_substrate`.
+    /// `decode_plan_json` unwraps it via `plan_from_admitted_json` —
+    /// see "Trust model" in the module doc for the signature-skip rationale.
     plan_json: String,
 
     /// Optional serialised `PolicyBundle` (the resolved bundle pin
@@ -127,12 +129,7 @@ fn run() -> Result<()> {
         .context("read DrainerConfig from stdin")?;
     let cfg: DrainerConfig = serde_json::from_str(&json).context("parse DrainerConfig JSON")?;
 
-    // Plan is a serialised `SignedExecutionPlan` envelope. The
-    // libkrun supervisor's pattern is to decode `cfg.plan` (a
-    // `serde_json::Value` carrier from `SupervisorConfig`) into an
-    // `ExecutionPlan` directly; we mirror that by parsing the
-    // string with `from_str`. See module-doc "Trust model".
-    let plan: ExecutionPlan = serde_json::from_str(&cfg.plan_json)
+    let plan = decode_plan_json(&cfg.plan_json)
         .context("decode DrainerConfig.plan_json into ExecutionPlan")?;
 
     let bundle: Option<PolicyBundle> = match &cfg.bundle_json {
@@ -218,5 +215,57 @@ fn run() -> Result<()> {
     // FlowEvent arrives. A loop guards against spurious unparks.
     loop {
         std::thread::park();
+    }
+}
+
+/// Decode a `plan_json` string into an `ExecutionPlan`.
+///
+/// Accepts both the `SignedExecutionPlan` envelope shape (what
+/// `populate_audit_substrate` threads in, serialised from
+/// `admitted.signed`) and the bare `ExecutionPlan` shape (the on-disk
+/// form written by lifecycle verbs). The signature is not re-verified:
+/// the host checked it at admission; the host is in the TCB. This is
+/// the same trust posture as `plan_from_admitted_json`, the shared
+/// helper used by the Firecracker bridge and QEMU paths.
+pub(crate) fn decode_plan_json(plan_json: &str) -> Result<ExecutionPlan, serde_json::Error> {
+    plan_from_admitted_json(plan_json)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use ed25519_dalek::SigningKey;
+    use mvm_core::plan::signing::{sign_plan, test_support::sample_plan};
+
+    fn test_key() -> SigningKey {
+        // Deterministic 32-byte key for tests — no OsRng dep.
+        SigningKey::from_bytes(&[0xdd; 32])
+    }
+
+    #[test]
+    fn decode_signed_envelope_yields_inner_plan() {
+        let plan = sample_plan();
+        let signed = sign_plan(&plan, &test_key(), "test-drainer-key");
+        let json = serde_json::to_string(&signed).expect("signed plan serialises");
+
+        let decoded = decode_plan_json(&json).expect("signed envelope decodes");
+        assert_eq!(decoded.plan_id, plan.plan_id);
+        assert_eq!(decoded.tenant, plan.tenant);
+        assert_eq!(decoded.workload, plan.workload);
+    }
+
+    #[test]
+    fn decode_bare_plan_still_works() {
+        let plan = sample_plan();
+        let json = serde_json::to_string(&plan).expect("bare plan serialises");
+
+        let decoded = decode_plan_json(&json).expect("bare ExecutionPlan decodes");
+        assert_eq!(decoded.plan_id, plan.plan_id);
+    }
+
+    #[test]
+    fn decode_garbage_returns_err() {
+        assert!(decode_plan_json("not json at all").is_err());
+        assert!(decode_plan_json(r#"{"unknown_field": 42}"#).is_err());
     }
 }

--- a/specs/REFACTOR-STATUS.md
+++ b/specs/REFACTOR-STATUS.md
@@ -253,6 +253,14 @@ PLAN 118 — Supervisor standby pool              🟡 libkrun + Vz done; FC fol
       → VzChildSupervisorSpawner), image_sha256 compat key (mismatch = no-match, not
       error), TTL-only reap for pid=0 standbys, --rootfs CLI flag, doctor reports
       vz=true on macOS 14+. All libkrun pool tests untouched.
+      LIVE-VALIDATED 2026-06-13: warm 6.5s, "Claimed a warm standby — skipping
+      cold boot" FIRES, claimed VM alive + pause/resume responsive. Two bugs
+      found+fixed live: gateway-bridge drainer decoded a bare plan where up
+      threads the signed envelope (now decodes both shapes); spawn discarded the
+      seed config instead of persisting it to the pool (claim then read a
+      torn-down dir). HONEST latency: on the trivially-fast default image
+      warm-claim 2.3s ~= cold 2.1s (restoring 512 MiB costs ~a tiny guest's cold
+      boot); the reclaim is real for heavy-init workloads, marginal here.
   [ ] Firecracker standby pool (the mvmd-facing deliverable) — gated on FC standby
       follow-up; not blocking current libkrun/Vz use
 

--- a/specs/REFACTOR-STATUS.md
+++ b/specs/REFACTOR-STATUS.md
@@ -25,6 +25,7 @@ details** below for the workstream-level state.
 - [x] **PLAN 178** — CLI surface consolidation (~56→~28) · ✅ (dir-purity deferred)
 - [x] **PLAN 129** — Secrets / SigV4 substitution · ✅ **COMPLETE** — both tiers (declared substitution incl. SigV4/HMAC bind-checked + undeclared detection), terminator-path + vsock, claim-12/13 leak-gate (claim 16), endpoint self-confines (Landlock+seccomp jailer); QEMU clean-room e2e GREEN; FC bringup fixes landed (#804); live-FC e2e spun out (builder-VM box infra, not plan logic)
 - [ ] **PLAN 152** — Rust-native VZ supervisor · 🟢 native objc2, Swift deleted; WS-C/D separate workstreams
+- [ ] **PLAN 118** — Supervisor standby pool · 🟡 libkrun + Vz done; FC follow-up open
 - [ ] **PLAN 159** — vz-inspired macOS VZ DX · 🟡 warm pool + checkpoint/fork shipped; WS-5 D + delta-image remain
 - [ ] **PLAN 123** — Network / storage / warm-start · 🟢 Phase A/B done; C2/C3 (FC/Vz warm-start) gated
 - [ ] **PLAN 124** — Lean guest agent · 🟡 ~65%; SDK codegen + signed on-device config remain
@@ -213,14 +214,8 @@ PLAN 159 — vz-inspired macOS VZ DX               🟡 152-independent slice sh
   [x] WS-4 resumable + honest-cost dev-image download — PR #667
   [x] WS-5 E streamed exec (ExecEvent) — PR #712 (plan-172)
   [x] WS-5 E follow-up: enforce exec timeout_secs — plan-173
-  [x] WS-1 warm pool (Plan 118): 1a primitive + 1b-i trait seam/registry/libkrun
-      + 1b-ii reaper/doctor/`mvmctl pool`/bench-fix + 1b-iii up auto-claim
-      (try_warm_claim/replenish/--warm-pool-size, fail-open) + bundled-kernel
-      compat key — libkrun mkGuest warm claim FIRES end-to-end (#757/#758,
-      live-validated "Claimed a warm standby"). Bridge boot also live-validated
-      (exit 7; up.rs "bridge broken" comment stale). Follow-ups (non-blocking,
-      SPRINT.md): multi-kernel keying; pool-status liveness filter;
-      home_mvm_keys_dir MVM_DATA_DIR; committed bench delta
+  [x] WS-1 warm pool (Plan 118): libkrun + Vz saved-standby — see PLAN 118 block
+      for the full workstream detail
   [x] WS-2 checkpoint+fork — fs_quick (#762) + vm_full (#770): mvmctl checkpoint
       create/ls/rm/fork + APFS-CoW capture + integrity-checked fork + lineage +
       checkpoint.created/forked/restored audit + fs_quick+vm_full capability +
@@ -247,11 +242,19 @@ PLAN 159 — vz-inspired macOS VZ DX               🟡 152-independent slice sh
       follow-ups.
   [x] instant memory fork: vm_full fork of a RUNNING parent → second live VM in
       0.91s incl. claim-8 admission (same-identity clone model; recorded-sha admission; gvproxy-only invariant)
+
+PLAN 118 — Supervisor standby pool              🟡 libkrun + Vz done; FC follow-up open
+  [x] 1a primitive + 1b-i trait seam/registry/libkrun + 1b-ii reaper/doctor/`mvmctl pool`
+      /bench-fix + 1b-iii up auto-claim (try_warm_claim/replenish/--warm-pool-size,
+      fail-open) + bundled-kernel compat key — libkrun mkGuest warm claim FIRES
+      end-to-end (live-validated "Claimed a warm standby")
   [x] Vz saved-standby warm pool: per-image spawn (seed boot → capture_vm_full →
       pid=0 handle), claim (verify_content → clone blobs → build_child_supervisor_config
       → VzChildSupervisorSpawner), image_sha256 compat key (mismatch = no-match, not
       error), TTL-only reap for pid=0 standbys, --rootfs CLI flag, doctor reports
       vz=true on macOS 14+. All libkrun pool tests untouched.
+  [ ] Firecracker standby pool (the mvmd-facing deliverable) — gated on FC standby
+      follow-up; not blocking current libkrun/Vz use
 
 PLAN 183 — Builder-VM egress posture + net boot ✅ DONE (follow-ups tracked in plan)
   Last updated: 2026-06-12

--- a/specs/REFACTOR-STATUS.md
+++ b/specs/REFACTOR-STATUS.md
@@ -247,6 +247,11 @@ PLAN 159 — vz-inspired macOS VZ DX               🟡 152-independent slice sh
       follow-ups.
   [x] instant memory fork: vm_full fork of a RUNNING parent → second live VM in
       0.91s incl. claim-8 admission (same-identity clone model; recorded-sha admission; gvproxy-only invariant)
+  [x] Vz saved-standby warm pool: per-image spawn (seed boot → capture_vm_full →
+      pid=0 handle), claim (verify_content → clone blobs → build_child_supervisor_config
+      → VzChildSupervisorSpawner), image_sha256 compat key (mismatch = no-match, not
+      error), TTL-only reap for pid=0 standbys, --rootfs CLI flag, doctor reports
+      vz=true on macOS 14+. All libkrun pool tests untouched.
 
 PLAN 183 — Builder-VM egress posture + net boot ✅ DONE (follow-ups tracked in plan)
   Last updated: 2026-06-12

--- a/specs/SPRINT.md
+++ b/specs/SPRINT.md
@@ -2808,3 +2808,15 @@ broken" comment is STALE — `run_with_bridge` boots end-to-end today). Two real
 - [ ] Independent bug: `libkrun_sys::home_mvm_keys_dir()` hardcodes `$HOME/.mvm/keys` and
   ignores `MVM_DATA_DIR`, so `validate_audit_substrate` rejects an isolated data dir. Route
   it through `mvm_core::config`.
+
+### Plan 118 WS-1 — Vz saved-standby warm pool (item 3) — DONE
+
+Vz arm of the standby pool ships saved-standby (frozen {rootfs, memory, machine-id} triple
+captured via `capture_vm_full`). No live supervisor after capture — pid=0 sentinel. Claim
+path reuses `build_child_supervisor_config` + `VzChildSupervisorSpawner` (same fork plumbing,
+pool-sourced blobs instead of checkpoint-sourced). Compat key adds `image_sha256: Option<String>` —
+a Vz compat with Some(sha) only matches a standby for the same image; libkrun None is
+unaffected. `reap_stale` skips liveness for pid=0 entries (TTL-only eviction).
+`mvmctl pool warm --rootfs <path>` is the Vz entry point; doctor reports `vz=true` on
+macOS 14+. All libkrun pool tests pass untouched. 298 mvm-backend lib tests, 974 mvm-cli
+tests, 5117 workspace tests all green.

--- a/specs/SPRINT.md
+++ b/specs/SPRINT.md
@@ -2221,6 +2221,8 @@ are hard-refused at fork time (gvproxy-only invariant). The child's
 supervisor config carries its own plan, tenant, and audit substrate —
 the parent's plan is not reused.
 
+**2026-06-13: Vz warm pool (saved-standby) live.** `pool warm` boots a seed, captures its memory+rootfs into the pool, stops it (pid=0 saved standby); `up --warm-pool-size N` then claims a compatible standby — "Claimed a warm standby — skipping cold boot" fires, the restored VM is alive and pause/resume-responsive. Latency is workload-dependent: on the trivially-fast default image a warm claim (~2.3 s) matches a cold boot (~2.1 s) because restoring 512 MiB of memory costs about what a tiny guest's cold boot does; the reclaim materializes for heavy-init workloads. Two live-found bugs fixed: the gateway-bridge drainer now decodes the signed plan envelope (not a bare plan), and the seed supervisor-config is persisted into the pool dir (the seed's own dir is torn down at stop).
+
 ### Sprint 55 success criteria
 
 - Phase A acceptance: `mvm-vz-supervisor` boots the dev-shell image

--- a/specs/plans/118-supervisor-standby-pool-and-live-bench.md
+++ b/specs/plans/118-supervisor-standby-pool-and-live-bench.md
@@ -418,7 +418,7 @@ process-spawn delta, not the headline number.
 - [ ] mvmd sizing hookup: once a Firecracker standby exists, mvmd
       sets `warm_pool_size` per host + fleet-level instance
       pre-warming — designed in the mvmd repo when it firms up.
-- [ ] Vz / Apple-Container standby pools (different process models).
+- [x] Vz saved-standby pool: per-image spawn (capture_vm_full) + claim (clone + restore), `image_sha256` compat key, pid=0 sentinel, TTL-only reap, `--rootfs` CLI flag, doctor reports `vz=true`.
 - [ ] Optional decoupled attach credential via `host.secrets.v1`
       pattern, if attach validity must be shorter than plan validity.
 


### PR DESCRIPTION
## Summary

The Vz arm of the supervisor warm pool (Plan 118). `mvmctl doctor` previously reported `standby pool: libkrun supported, vz —`; now Vz participates. **Live-validated: `up` claims a prebooted standby — "Claimed a warm standby — skipping cold boot."**

**Design — saved-standby, per-image.** Unlike libkrun (standby blocks pre-boot with no rootfs; any image attaches at claim), a Vz saved memory state is inseparable from the rootfs it booted. So a Vz standby is created *from a specific image*: `spawn_standby` boots a seed, captures its {rootfs, memory, machine-id} into the pool via `capture_vm_full`, and stops the seed (a `pid=0` saved handle). `claim_standby` integrity-checks the pool content (`verify_content`, fail-closed), clones the triple into the claimant's state dir, and restores under the claimant's identity with the claimant's admitted plan injected — reusing the `build_child_supervisor_config` + `VzChildSupervisorSpawner` plumbing from the instant-fork work, no duplicated restore logic.

- **Image-aware compat key**: `StandbyCompat` gains `image_sha256` (`None` for libkrun, `Some` for Vz). A claim matches only on identical kernel sha + cpu/mem + image sha. `#[serde(default)]` keeps old `standby.json` readable.
- **pid=0 saved-state semantics**: `select_idle_compatible` skips the liveness probe and `reap_stale` is TTL-only for saved standbys (a `kill(0)` on pid 0 would hit the process group — avoided by branching before any `kill`). Reap removes the whole pool content dir (no leak).
- **`up` + verbs**: `try_warm_claim` threads the image sha for Vz; `pool warm --rootfs <path>` (or `MVM_POOL_ROOTFS`, or the cached default image); `pool status` shows "saved-state"; doctor reports `vz=true` on macOS 14+. libkrun pool behavior byte-identical.

## Live validation (this host, 2026-06-13)

`pool warm 1` → 6.5s, one idle saved-state standby with {rootfs, memory, machine-id} on disk. `up --hypervisor vz --warm-pool-size 1` → **"Claimed a warm standby (…) — skipping cold boot."**, claimed VM alive + pause/resume responsive, standby consumed.

Two bugs surfaced and fixed live (both committed here):
1. **Gateway-bridge drainer** decoded `plan_json` into a bare `ExecutionPlan`, but `up` threads the *signed envelope* (`SignedExecutionPlan`, `{payload,…}`) — pre-existing on the `MVM_GATEWAY_BRIDGE=1` path, dormant by default. Now decodes both shapes (mirrors `plan_from_admitted_json`; signature was verified at admission).
2. **Spawn discarded the seed supervisor-config** then stopped the seed (tearing down its state dir); claim read the gone dir and cold-booted. Now persisted into the pool dir and read from there, via a shared `pool_seed_config_path` helper + regression test.

**Honest latency note:** on the trivially-fast default image, a warm claim (~2.3s) ≈ a cold boot (~2.1s) — restoring 512 MiB of memory costs about what a tiny guest's cold boot does. The reclaim is real for heavy-init workloads (slow cold boot, ~constant restore), marginal for trivial ones. Recorded as-is in the rollup; not overclaimed.

Adversarial review (READY WITH NITS) cleared the moat (claim-8 on claim: parent/seed identity hard-cleared, claimant plan always injected, no planless boot; image binding consistent; pid=0 kill-hazard avoided); all nits applied (drainer fix, config-persist fix, agent-ready socket name, spawn-failure cleanup guard, dead-code/test-name cleanups).

Rollups: PLAN 118 block + SPRINT Sprint-55 updated with the live results and the latency caveat.

## Test Plan
- [x] fmt / clippy `-D warnings` (mvm-core/backend/cli/vm-host) / `check-no-spec-refs-in-comments` clean
- [x] `cargo nextest run -p mvm-cli` 976/976 (clean env); `cargo test -p mvm-backend --lib` 301/301
- [x] New tests: image-compat match, saved-state select, TTL reap, tamper-refusal, serde backcompat, agent-ready socket path, spawn-cleanup guard, warm-failure exit, pool-config-path regression, drainer envelope decode
- [x] Live: warm → claim → restored-VM responsive (above)