### PR TITLE
fix(vz): reap the restore-spawned gvproxy on restore failure (+ item-4 subsumed)

### DIFF
--- a/crates/mvm-backend/src/vz.rs
+++ b/crates/mvm-backend/src/vz.rs
@@ -953,6 +953,11 @@ fn restore_with_spawn(
             "snapshot_restore failed; removing cloned rootfs to allow retry"
         );
         let _ = std::fs::remove_file(&target_rootfs);
+        // `snapshot_restore` spawns a fresh gvproxy before the supervisor; a
+        // restore that dies after that spawn leaves the sidecar running with
+        // its PID file in place, which the next retry's spawn would orphan.
+        // Reap it here so a failed restore frees its own resources.
+        let _ = host_gvproxy::stop_by_pid_file(&vm_state_dir(target_vm));
     }
 
     restore_result
@@ -2673,6 +2678,12 @@ mod tests {
         let target_rootfs = state_dir.join("rootfs.ext4");
         write_supervisor_config(&state_dir, "restore-cleanup-vm", &target_rootfs);
 
+        // Stand in for the gvproxy `snapshot_restore` spawns before the
+        // supervisor: a PID file naming a dead process. A failed restore must
+        // reap it so a retry doesn't orphan the sidecar.
+        let gvproxy_pid = state_dir.join("host-gvproxy.pid");
+        std::fs::write(&gvproxy_pid, "2147483647").unwrap();
+
         let backend = VzBackend;
         let err = restore_with_spawn(
             &backend,
@@ -2692,6 +2703,11 @@ mod tests {
         assert!(
             !target_rootfs.exists(),
             "cloned rootfs must be removed after restore failure"
+        );
+        // The orphaned gvproxy PID file must have been reaped.
+        assert!(
+            !gvproxy_pid.exists(),
+            "gvproxy pid file must be reaped after restore failure"
         );
 
         // SAFETY: serialized by HOME_TEST_LOCK.

--- a/specs/plans/183-builder-vm-egress-posture-and-dns.md
+++ b/specs/plans/183-builder-vm-egress-posture-and-dns.md
@@ -307,9 +307,18 @@ Two independent defects blocked `mvmctl up --flake <workload> --hypervisor vz`:
   fixed: `snapshot_restore` spawns gvproxy via `host_gvproxy::spawn_detached`
   when config has Gvproxy network; `restore_with_spawn` removes the cloned
   rootfs on any post-clone failure and errors actionably on pre-existing target.
-- [ ] restore-failure leaks the freshly-spawned gvproxy (supervisor never
+- [x] restore-failure leaks the freshly-spawned gvproxy (supervisor never
   wrote its PID, the sidecar lingers; the retry orphans it) — reap the
   sidecar on the restore error path, consistent with `start()`'s behavior.
+  fixed: `restore_with_spawn`'s error arm now also calls
+  `host_gvproxy::stop_by_pid_file` after removing the cloned rootfs.
+- [x] Vz template memory snapshots (Plan 123 C2/C3) — SUBSUMED by the Plan 118
+  Vz warm pool, not built separately. A warm saved-standby IS a per-image memory
+  snapshot pre-warmed and instantly claimed; `up`'s legacy
+  `restore_from_template_snapshot` arm stays Firecracker-only and is unreachable
+  on Vz (no Vz template-snapshot *save* path exists, so `snapshot_info` is always
+  `None` there → the arm never fires). Building a parallel Vz template-restore
+  path would duplicate the warm pool for marginal benefit.
 - [x] Vz two-copy fork: `checkpoint fork --boot` admits the child under a fresh
   plan (claim 8), passes the instance rootfs path so `prepare_instance_rootfs`
   returns early (no clobber), resource shape: flags > parent plan > defaults, and


### PR DESCRIPTION
## Summary

The last open piece of the AVF instant-on polish batch: a retry-safety gap in Vz `vm_full` restore.

`snapshot_restore` spawns a fresh host gvproxy before the supervisor (the original died when the source VM stopped). If the restore then fails *after* that spawn — supervisor never writes its PID — the sidecar lingers with its PID file in place, and the next retry's `spawn_detached` orphans it. `restore_with_spawn`'s error arm already removed the cloned rootfs to allow a clean retry; now it also reaps the sidecar via `host_gvproxy::stop_by_pid_file`, mirroring `start()`'s `AttachedGvproxyGuard`.

Test: `restore_failure_removes_cloned_rootfs` extended to plant a gvproxy PID file (dead pid) and assert it's reaped alongside the cloned rootfs.

**Also recorded (docs only):** Vz template memory snapshots (Plan 123 C2/C3) are **subsumed by the Plan 118 Vz warm pool**, not built as a separate path. A warm saved-standby *is* a per-image memory snapshot pre-warmed and instantly claimed; `up`'s legacy `restore_from_template_snapshot` arm stays Firecracker-only and is unreachable on Vz (no Vz template-snapshot *save* path → `snapshot_info` is always `None` there → the arm never fires). A parallel Vz template-restore path would duplicate the warm pool for marginal benefit. The remaining DX-parity polish (verb/`--json` parity, curl|sh installer, cached fast-boot default, TTL eviction) is owned by the in-flight Plans 189/159 — left to that session, not duplicated here.

## Test Plan
- [x] `cargo test -p mvm-backend --lib vz::tests::restore` 3/3 (incl. the extended reap assertion)
- [x] fmt / clippy `-D warnings` (mvm-backend) / `check-no-spec-refs-in-comments` clean