### PR TITLE
fix(checkpoint): clippy unnecessary_literal_unwrap in resource-shape test

### DIFF
--- a/crates/mvm-cli/src/commands/vm/checkpoint.rs
+++ b/crates/mvm-cli/src/commands/vm/checkpoint.rs
@@ -1194,10 +1194,10 @@ mod tests {
 
         let user_cfg = mvm_core::user_config::load(None);
         let final_cpus = flag_cpus.or(plan_cpus).unwrap_or(user_cfg.default_cpus);
-        let final_mem_mib = match flag_mem {
-            Some(s) => mvm_core::util::parse_human_size(s).unwrap(),
-            None => plan_mem.unwrap_or(user_cfg.default_memory_mib),
-        };
+        let final_mem_mib = flag_mem
+            .map(|s| mvm_core::util::parse_human_size(s).unwrap())
+            .or(plan_mem)
+            .unwrap_or(user_cfg.default_memory_mib);
         assert_eq!(final_cpus, 8);
         assert_eq!(final_mem_mib, 1024);
     }


### PR DESCRIPTION
`resource_shape_flags_override_plan` resolved final memory with a `match` whose dead `None` arm called `plan_mem.unwrap_or(...)` on a known-`Some` binding, tripping `clippy::unnecessary_literal_unwrap` under `cargo clippy --all-targets`.

Folds the resolution into the same `.map().or().unwrap_or()` shape the sibling `cpus` line already uses — semantically identical (flag wins → plan → default), more idiomatic, and clippy-clean.

Latent today (CI's pinned clippy doesn't flag it yet); surfaced under local clippy 1.95.0 and would block CI on a clippy bump. Verified: the test passes and `clippy --all-targets` is fully clean.