### PR TITLE
feat(pool): Vz warm pool self-replenishes via a detached re-warm

### DIFF
--- a/crates/mvm-cli/src/commands/pool.rs
+++ b/crates/mvm-cli/src/commands/pool.rs
@@ -339,9 +339,17 @@ pub fn replenish_after_launch(backend: &AnyBackend, cfg: &VmStartConfig) -> Resu
     if cfg.warm_pool_size == 0 || !backend.supports_standby_pool() {
         return Ok(0);
     }
-    // Vz replenish requires booting a seed VM + capture: too expensive for the
-    // post-claim fast path. Replenish is manual (`mvmctl pool warm`) for Vz.
+    // Vz replenish boots a seed VM + captures its memory (~seconds) — far too
+    // slow to run inline on the post-launch path. Hand the whole job to a
+    // DETACHED `mvmctl pool warm` subprocess so `up` returns immediately. The
+    // child does the idle-count check + rootfs hash itself (off the hot path,
+    // so `up` doesn't re-hash a multi-hundred-MB rootfs `try_warm_claim`
+    // already hashed) and re-warms only the deficit toward `target` — a spawn
+    // against an already-full pool is a cheap no-op, not an over-warm. Two
+    // races against the same image can still transiently overshoot target by
+    // one per concurrent launch; the surplus ages out via the standby TTL.
     if backend.as_vm_backend().name() == "vz" {
+        spawn_detached_rewarm(&cfg.rootfs_path, cfg.warm_pool_size)?;
         return Ok(0);
     }
     let Some(kernel) = cfg.kernel_path.as_ref() else {
@@ -365,6 +373,29 @@ pub fn replenish_after_launch(backend: &AnyBackend, cfg: &VmStartConfig) -> Resu
     Ok(result.spawned)
 }
 
+/// Hand a Vz pool re-warm to a detached `mvmctl pool warm` subprocess so it
+/// outlives the `up` that triggered it. The child inherits our environment
+/// (MVM_DATA_DIR / cache / supervisor path), runs with no stdio, and is moved
+/// into its own process group so a Ctrl-C on `up` doesn't take it down.
+/// `pool warm` is idempotent toward the target, so a spurious spawn is a cheap
+/// no-op rather than an over-warm.
+fn spawn_detached_rewarm(rootfs_path: &str, target: u32) -> Result<()> {
+    use std::os::unix::process::CommandExt;
+    use std::process::{Command, Stdio};
+
+    let exe =
+        std::env::current_exe().context("resolve mvmctl path for background pool replenish")?;
+    Command::new(exe)
+        .args(["pool", "warm", &target.to_string(), "--rootfs", rootfs_path])
+        .stdin(Stdio::null())
+        .stdout(Stdio::null())
+        .stderr(Stdio::null())
+        .process_group(0)
+        .spawn()
+        .context("spawn detached pool warm for background replenish")?;
+    Ok(())
+}
+
 fn hex_lower(bytes: &[u8]) -> String {
     use std::fmt::Write;
     bytes
@@ -378,6 +409,7 @@ fn hex_lower(bytes: &[u8]) -> String {
 #[cfg(test)]
 mod tests {
     use super::*;
+
     use mvm_core::vm_backend::{
         StandbyError, StandbyHandle, StandbyState, StartMode, VmCapabilities, VmInfo,
         VmStartConfig, VmStatus,


### PR DESCRIPTION
## Summary

Makes the Vz warm pool **self-maintaining**. Before this, `replenish_after_launch` was a no-op for Vz (a synchronous seed boot + memory capture would add seconds to every `up`), so a pool drained to zero on the first claim and never refilled — half a feature.

Now, after a Vz launch with `warm_pool_size > 0`, `up` hands the re-warm to a **detached `mvmctl pool warm <target> --rootfs <cfg.rootfs_path>` subprocess** (own process group via `process_group(0)`, null stdio, inherits env). `up` returns immediately; the pool tops itself back up in the background. The child does the idle-count check and the rootfs hash *itself* — deliberately off `up`'s hot path, so `up` doesn't re-hash a multi-hundred-MB rootfs that `try_warm_claim` already hashed — and `warm_to_target` re-warms only the deficit, so a spawn against an already-full pool is a cheap no-op rather than an over-warm.

`cfg.rootfs_path` is exactly the image the claim just matched, so the re-warm produces a standby with the same compat key — refilling the slot that was drained.

## Live validation (this host)

`pool warm 1` → 1 idle. `up --hypervisor vz --warm-pool-size 1` → **"Claimed a warm standby — skipping cold boot"**, pool 1→0, `up` returns immediately. The detached `mvmctl pool warm` (own PID, outlived `up`) booted a fresh seed, captured it, and the pool was back to **1 idle** — fully self-replenished without slowing `up`.

## Review notes (adversarial review: READY WITH NITS, both addressed)

- **Hot-path latency** (the substantive nit): the first cut checked the idle count + hashed the rootfs in the parent, adding ~0.24–0.5s to `up`'s return on top of the hash `try_warm_claim` already does. Restructured to hand everything to the detached child → zero added hot-path work.
- **Concurrent over-warm**: `SupervisorStandbyPool` has no lock, so two concurrent claims against the same image can each spawn a re-warm and transiently overshoot `target` by one per launch (bounded by N; surplus ages out via the standby TTL). Documented in-code; a pool-dir flock around `warm_to_target`'s read→spawn span is the clean follow-up (it also tightens manual concurrent `pool warm`, so it's broader than this change). Not a blocker.
- Detached lifecycle (`process_group(0)` + null stdio, reparents to init, no zombie), env inheritance, and `current_exe()` resolution all verified sound and matching repo precedent (`host_gvproxy::spawn_detached`, `current_exe` in vz.rs/libkrun.rs).

## Test Plan
- [x] fmt / clippy `-D warnings` (mvm-cli) / `check-no-spec-refs-in-comments` clean
- [x] `cargo nextest run -p mvm-cli` 979/979
- [x] Live: warm → claim → background self-replenish to target (above)