### PR TITLE
Slim the microVM kernel (−54% driver objects) + fix builder-VM loopback

### DIFF
--- a/crates/mvm-build/src/bin/mvm-host-vm-init.rs
+++ b/crates/mvm-build/src/bin/mvm-host-vm-init.rs
@@ -2096,6 +2096,20 @@ mod linux {
     fn setup_network() -> Result<(), String> {
         let cmdline = std::fs::read_to_string("/proc/cmdline").unwrap_or_default();
 
+        // The kernel creates `lo` administratively DOWN. Until it's up,
+        // 127.0.0.0/8 has no route and every guest-internal loopback
+        // service — the egress forward proxy, addon-dns — fails to bind
+        // with EADDRNOTAVAIL. Bring it up first, independent of eth0/DHCP:
+        // a network:None builder VM has no eth0 at all yet still needs
+        // working loopback. Non-fatal, mirroring the eth0 bring-up below.
+        if let Err(e) = bring_iface_up("lo") {
+            eprintln!(
+                "mvm-host-vm-init: bring_iface_up lo failed: {e} \
+                 (continuing — guest-internal loopback services \
+                 will be unreachable)"
+            );
+        }
+
         // The rootfs mounts ro and /etc/resolv.conf is a baked regular file,
         // not a /run symlink. busybox's DHCP script writes /etc/resolv.conf
         // directly and gets EROFS, so leased DNS never lands. Mount a tmpfs-

--- a/nix/images/builder-vm/kernel/base.nix
+++ b/nix/images/builder-vm/kernel/base.nix
@@ -123,6 +123,31 @@ let
     # Storage / device classes that have no virtio path.
     "MTD" "PARPORT" "ATA" "SCSI" "INFINIBAND"
     "STAGING" "MEDIA_SUPPORT"
+
+    # Device-driver *menus* with no hardware behind them under libkrun /
+    # Firecracker. defconfig enables each as a whole menu, and disabling
+    # the protocol stack alone (SOUND/WIRELESS/USB above) leaves the
+    # device subtree compiling — the umbrella menu symbol gates the
+    # drivers/<x>/ directory, so it must go too. Each parent cascades its
+    # vendor subtree via olddefconfig. We carry only VIRTIO_NET; every
+    # vendor NIC, WLAN, WWAN, and CAN driver is dead weight.
+    "ETHERNET"             # drivers/net/ethernet — keep NETDEVICES + VIRTIO_NET
+    "WLAN" "WWAN" "CAN"    # drivers/net/{wireless,wwan,can}
+    "USB_SUPPORT"          # USB host + gadget umbrella (CONFIG_USB only hit hosts)
+    "HID_SUPPORT"          # no virtio-input/HID; console is hvc0 + vsock
+    "RC_CORE"              # remote-control core + the keymap blob it builds
+    "IIO"                  # industrial-I/O sensors
+    "XEN"                  # never a Xen guest
+    "MMC" "MMC_BLOCK"      # no SD/eMMC behind virtio
+    "REGULATOR" "POWER_SUPPLY" "THERMAL"  # SoC power plumbing defconfig drags in
+    "NEW_LEDS" "LEDS_CLASS"
+  ] ++ pkgs.lib.optionals (kernelArch == "arm64") [
+    # arm64 boots from the FDT libkrun / Firecracker hand us; ACPI is
+    # never consulted, so drop the ACPICA interpreter and the whole
+    # drivers/acpi tree (~390 files). x86 keeps ACPI deliberately — it
+    # has no devicetree fallback and the hypervisor presents an ACPI/MADT
+    # for SMP bringup, so disabling it there would not boot.
+    "ACPI"
   ];
 
   # Realize a `.config` from base + the caller's deltas. `runCommandCC`


### PR DESCRIPTION
## Summary

Two changes from chasing a slow, driver-heavy kernel build in the builder VM. Independent and separately revertable.

### 1. Slim the microVM kernel (`nix/images/builder-vm/kernel/base.nix`)

`make defconfig` + `CONFIG_MODULES=n` was compiling whole driver subsystems we have no hardware for under libkrun / Firecracker. The old disable list turned off the *protocol stacks* (`USB`/`WIRELESS`/`SOUND`) but left the *device-menu umbrellas* on — and the umbrella symbol, not the stack, gates the `drivers/<x>/` directory, so the device trees still compiled.

Disable the device-menu umbrellas (`ETHERNET`, `WLAN`, `WWAN`, `CAN`, `USB_SUPPORT`, `HID_SUPPORT`, `RC_CORE`, `IIO`, `XEN`, `MMC`, `REGULATOR`, `POWER_SUPPLY`, `THERMAL`, `LEDS`), and drop `ACPI` on **arm64 only** (it boots from the FDT libkrun/Firecracker pass; x86 keeps ACPI for SMP bringup).

Driver objects: **2,995 → 1,393 (−54%)**. Ethernet, wireless, acpi, usb, iio, xen, can, mmc, thermal, regulator subsystems go to 0.

### 2. Bring loopback up in the builder VM (`mvm-host-vm-init`)

`setup_network` brought up `eth0` but never `lo`, so `127.0.0.0/8` had no route and the egress forward proxy / addon-dns failed to bind `127.0.0.1` with `EADDRNOTAVAIL`. The workload guest's mkGuest `/init` already brings `lo` up; mirror it in the builder init, before and independent of eth0/DHCP — a network:None builder VM has no eth0 yet still needs working loopback. Pre-existing bug, surfaced while validating the kernel change.

## Validation

Cold builder-VM build under Vz on macOS 26 (Apple Silicon):

- Kernel compiles clean: `LD vmlinux` + arm64 `Image`, buildPhase 4m9s, no ACPI/FDT fallout.
- Dev VM boots (`dev up` rc=0); guest console: EXT4 mounts over virtio-blk, init runs, agent reaches vsock (`control plane ready`), clean teardown.
- `forward proxy failed to start`: 1 → **0**; `bring_iface_up lo failed`: **0** (lo up clean).

## Notes

- `drivers/media` still emits ~115 empty `AR built-in.a` archive steps (Kbuild descends the tree; `MEDIA_SUPPORT` is re-selected to `=y`) but **zero `CC` compiles** — no build-time cost.
- Not a bring-up-speed change: cold builds are compile-bound, warm builds are a cache hit. This trims the compile, not the architecture.