### PR TITLE
docs(rollup+sprint): record Vz warm-pool self-replenish (#840)

### DIFF
--- a/specs/REFACTOR-STATUS.md
+++ b/specs/REFACTOR-STATUS.md
@@ -1,6 +1,6 @@
 # Refactor status — rollup checklist
 
-**Last updated: 2026-06-13** (Plan 185 test-isolation sweep advanced; ADR-080 program batch landed: Plans 188/186/187; Plan 189 WS-3 `dev status/down/up --json`; Plan 190 kernel egress close-out; Plan 191 declarative file materialization — ADR-080 P2-full; Plan 159: instant memory fork vm_full productized — admitted child, gvproxy-only invariant; Plan 193 rvproxy network substrate proposed + gvproxy teardown/build-perf findings; Plan 195 builder-VM fingerprint narrowing planned)
+**Last updated: 2026-06-13** (Plan 185 test-isolation sweep advanced; ADR-080 program batch landed: Plans 188/186/187; Plan 189 WS-3 `dev status/down/up --json`; Plan 190 kernel egress close-out; Plan 191 declarative file materialization — ADR-080 P2-full; Plan 159: instant memory fork vm_full productized — admitted child, gvproxy-only invariant; Plan 118: Vz saved-standby warm pool claim live-validated + pool self-replenishes via detached re-warm (#840); Plan 193 rvproxy network substrate proposed + gvproxy teardown/build-perf findings; Plan 195 builder-VM fingerprint narrowing planned)
 
 > MAINTENANCE: keep this file current. Whenever you land, merge, or descope a
 > workstream in any plan below, tick/strike the matching box here in the SAME
@@ -262,6 +262,14 @@ PLAN 118 — Supervisor standby pool              🟡 libkrun + Vz done; FC fol
       torn-down dir). HONEST latency: on the trivially-fast default image
       warm-claim 2.3s ~= cold 2.1s (restoring 512 MiB costs ~a tiny guest's cold
       boot); the reclaim is real for heavy-init workloads, marginal here.
+  [x] Vz pool self-replenishes (#840): after a Vz claim drains the pool, `up`
+      hands the re-warm to a DETACHED `mvmctl pool warm` subprocess (own process
+      group, null stdio, inherits env, via current_exe) — `up` returns at once
+      and the child re-warms only the deficit off the hot path (no second
+      rootfs hash; try_warm_claim already hashed it). Live: claim drained 1→0,
+      detached re-warm refilled to 1. Follow-up (in-code): no pool lock →
+      concurrent claims can overshoot target by ~1 each (ages out via TTL); a
+      pool-dir flock around warm_to_target's read→spawn is the clean fix.
   [ ] Firecracker standby pool (the mvmd-facing deliverable) — gated on FC standby
       follow-up; not blocking current libkrun/Vz use
 

--- a/specs/SPRINT.md
+++ b/specs/SPRINT.md
@@ -2224,6 +2224,8 @@ the parent's plan is not reused.
 
 **2026-06-13: Vz warm pool (saved-standby) live.** `pool warm` boots a seed, captures its memory+rootfs into the pool, stops it (pid=0 saved standby); `up --warm-pool-size N` then claims a compatible standby — "Claimed a warm standby — skipping cold boot" fires, the restored VM is alive and pause/resume-responsive. Latency is workload-dependent: on the trivially-fast default image a warm claim (~2.3 s) matches a cold boot (~2.1 s) because restoring 512 MiB of memory costs about what a tiny guest's cold boot does; the reclaim materializes for heavy-init workloads. Two live-found bugs fixed: the gateway-bridge drainer now decodes the signed plan envelope (not a bare plan), and the seed supervisor-config is persisted into the pool dir (the seed's own dir is torn down at stop).
 
+**2026-06-13: warm pool self-replenishes (#840).** After a Vz claim drains the pool, `up` hands the re-warm to a detached `mvmctl pool warm` subprocess (own process group, null stdio, inherits env) so `up` returns immediately and the pool tops itself back up in the background — making the pool production-usable rather than draining to zero on first claim. The child does the idle-check + rootfs hash off `up`'s hot path. Live: claim drained the pool 1→0, the detached re-warm booted a fresh seed and refilled to 1 idle, `up` never waited. Known follow-up (documented in-code): no pool lock means concurrent claims against the same image can transiently overshoot target by ~1 each (ages out via the standby TTL); a pool-dir flock is the clean fix.
+
 ### Sprint 55 success criteria
 
 - Phase A acceptance: `mvm-vz-supervisor` boots the dev-shell image
@@ -2822,4 +2824,6 @@ a Vz compat with Some(sha) only matches a standby for the same image; libkrun No
 unaffected. `reap_stale` skips liveness for pid=0 entries (TTL-only eviction).
 `mvmctl pool warm --rootfs <path>` is the Vz entry point; doctor reports `vz=true` on
 macOS 14+. All libkrun pool tests pass untouched. 298 mvm-backend lib tests, 974 mvm-cli
-tests, 5117 workspace tests all green.
+tests, 5117 workspace tests all green. Self-replenish landed in #840: a Vz claim that
+drains the pool triggers a detached background `pool warm` re-warm so the pool is
+self-maintaining (claim returns fast; the pool tops itself back up off the hot path).


### PR DESCRIPTION
## Summary

Docs-only. #840 (Vz warm-pool self-replenish) merged with zero docs footprint to avoid rebase-conflict churn against the active parallel session; this closes that gap.

- **REFACTOR-STATUS.md** — PLAN 118 block gains a `[x]` line for the detached background re-warm (self-maintaining pool) with the live result and the in-code concurrent-overshoot follow-up; the glance "Last updated" summary now mentions Plan 118.
- **SPRINT.md** — Sprint 55 live-validation section gains a self-replenish paragraph, and the Plan-118-DONE section notes the pool is self-maintaining rather than draining to zero on first claim.

Both files now reflect the full instant-on stack: builder egress/boot (Plan 183), two-copy fork, instant memory fork (0.91s, #833), warm-pool claim (#836), and self-replenish (#840).

## Test Plan
- [x] Docs-only diff (`specs/` only); no conflict markers; coherent with the merged code