### PR TITLE
Warm builder /nix store gcroot — stop cap-GC from nuking the kernel (plan 196 WS-1)

### DIFF
--- a/crates/mvm-build/src/builder_vm_runtime.rs
+++ b/crates/mvm-build/src/builder_vm_runtime.rs
@@ -436,6 +436,18 @@ if [ -z "$NIX_OUT" ]; then
 fi
 printf '%s\n' "$NIX_OUT" > /job/store-path
 
+# Pin the just-built closure as a warm GC root so the cap-triggered GC
+# below spares the kernel + runtime base it carries. That GC deletes every
+# unrooted path regardless of age, and a fresh build's kernel/base are
+# reachable only through the transient build root — so without this the next
+# build recompiles the kernel and re-pulls the base closure. A FIXED root
+# name (overwritten each build) keeps only
+# the latest closure warm, so an unchanged kernel derivation is a store hit
+# next build while the store stays bounded. Best-effort; never fails the build.
+mkdir -p /nix/var/nix/gcroots 2>/dev/null || true
+nix-store --add-root /nix/var/nix/gcroots/mvm-warm-latest --indirect -r "$NIX_OUT" >/dev/null 2>&1 \
+  || ln -sfn "$NIX_OUT" /nix/var/nix/gcroots/mvm-warm-latest 2>/dev/null || true
+
 # Copy the artifacts the host expects into /out. A plain mkGuest
 # workload image is a *bare ext4 file* ($NIX_OUT is the rootfs
 # itself; libkrun boots its bundled libkrunfw kernel, so no vmlinux
@@ -1878,6 +1890,25 @@ mod tests {
         let meta_idx = body.find("mvm-meta.json").expect("meta block present");
         let gc_idx = body.find("nix-collect-garbage").expect("gc present");
         assert!(gc_idx > meta_idx, "GC tail must follow output emission");
+
+        // A fixed-name warm gcroot must pin the just-built closure so the
+        // cap-triggered GC spares the kernel + base it contains. It must root
+        // $NIX_OUT, use the bounded fixed name, and be registered BEFORE the GC.
+        let warm_idx = body
+            .find("/nix/var/nix/gcroots/mvm-warm-latest")
+            .expect("warm gcroot present");
+        assert!(
+            body.contains("--add-root /nix/var/nix/gcroots/mvm-warm-latest"),
+            "warm gcroot must use nix-store --add-root in:\n{body}"
+        );
+        assert!(
+            body.contains("ln -sfn \"$NIX_OUT\" /nix/var/nix/gcroots/mvm-warm-latest"),
+            "warm gcroot must fall back to an ln symlink of $NIX_OUT in:\n{body}"
+        );
+        assert!(
+            warm_idx < gc_idx,
+            "warm gcroot must be registered before the GC tail"
+        );
         unsafe {
             match old {
                 Some(v) => std::env::set_var(MVM_BUILDER_STORE_GC_GIB_ENV, v),

--- a/specs/plans/196-warm-builder-store-kernel-cache.md
+++ b/specs/plans/196-warm-builder-store-kernel-cache.md
@@ -51,38 +51,34 @@ crossing the 24 GiB cap (or with `MVM_BUILDER_STORE_GC_GIB` lowered to force the
 GC); confirm the kernel is a store hit on the second build (no
 `CC`/`LD vmlinux` lines in `~/.cache/mvm/builder-vm/jobs/<id>/nix-stderr.log`).
 
-## WS-2 — Hash-keyed kernel prebuilt outside the nix store (robust + cross-worktree)
+## WS-2 — Hash-keyed kernel prebuilt outside the nix store — DESCOPED (redundant)
 
-Defense-in-depth: a content-addressed kernel artifact at
-`~/.cache/mvm/kernels/<config-hash>/<arch>/vmlinux`, **outside** any nix store,
-so the kernel survives a full store wipe/GC and is shared across worktrees and
-machines. Key = `hash(base.nix .config + builder delta + arch + kernel-source-rev)`;
-the builder-vm flake already exposes standalone `builder-kernel` /
-`workload-kernel` / `kernel-configfile` outputs to derive it from.
+**Original idea:** a content-addressed kernel artifact at
+`~/.cache/mvm/kernels/<config-hash>/<arch>/vmlinux` outside any nix store, so the
+kernel survives a store wipe/GC and is shared across worktrees.
 
-**Open design fork (needs a call before building):** how the prebuilt kernel is
-*injected* back into a build.
-- (i) **Separate-file load** — keep loading `vmlinux` as a host file path
-  (workload microVMs already do this) and source it from the prebuilt cache,
-  bypassing the in-VM kernel derivation entirely. Cleanest, but only applies
-  where the kernel is loaded separately (not the libkrun bundled-kernel path).
-- (ii) **Store seed** — `nix-store --import` the prebuilt kernel closure into the
-  in-VM store before the build so nix sees it as already-realised. Works
-  everywhere but reintroduces a store dependency (and the closure must carry a
-  valid signature or be imported with `--no-check-sigs`).
+**Why descoped — it duplicates caching that already exists.** Tracing the loader:
 
-WS-1 makes the *steady-state* kernel recompile go away on its own; WS-2 is the
-cross-worktree / post-wipe win. Sequence WS-2 after WS-1 lands and the fork is
-decided.
+- **Builder-VM kernel** is *already* a host-file prebuilt. `ensure_builder_vm_image`
+  (`crates/mvm-build/src/libkrun_builder.rs:1231`) loads `vmlinux` directly from
+  `~/.cache/mvm/builder-vm/<arch>/vmlinux` — compiled once in Stage 0, cached as a
+  host file, shared across worktrees (one `~/.cache/mvm`), loaded at VM launch, never
+  recompiled at runtime. That cache *is* WS-2 mechanism (i) for the builder kernel.
+- **Workload kernel** (realized inside the builder VM for user image builds) is
+  covered by WS-1: the warm gcroot keeps it from the cap-GC, so an unchanged
+  derivation is a store hit.
 
-- [ ] Decide injection mechanism (i) vs (ii).
-- [ ] Derive + plumb the config-hash key (`nix/images/builder-vm/flake.nix`,
-      `crates/mvm-backend/src/artifacts/artifact.rs` already carries a kernel hash).
-- [ ] Copy-out after realise; lookup + inject before build
-      (`crates/mvm-build/src/libkrun_builder.rs` `ensure_builder_vm_image` /
-      `krun_context_for_image`).
-- [ ] Cache-dir helper via `mvm-core::config` (never inline `$HOME`).
-- [ ] Tests: key stability, hit/miss, injection roundtrip.
+A separate `~/.cache/mvm/kernels/` nar cache would re-implement these. Reuse-first /
+YAGNI (CLAUDE.md) says don't.
+
+**Residual gap (only build if measured):** a *fresh or `rm -rf`-wiped* builder store
+rebuilds the workload kernel once and re-pulls the base closure. If that specific
+cost is shown to bite (e.g. the degraded-store recovery path,
+[[reference_degraded_builder_store_dev_up_loops]]), the minimal fix is seeding a
+fresh store from the artifacts already on the host — not a new kernel-nar cache.
+Defer until WS-1 is live-verified and a real gap is measured.
+
+- [x] ~~Decide injection mechanism~~ → descoped; existing caches cover both kernels.
 
 ## Out of scope
 

--- a/specs/plans/196-warm-builder-store-kernel-cache.md
+++ b/specs/plans/196-warm-builder-store-kernel-cache.md
@@ -1,0 +1,91 @@
+# Plan 196 — Warm builder /nix store + hash-keyed kernel prebuilt
+
+**Goal:** stop cold builder-VM bring-up from recompiling the guest/workload
+kernel and re-downloading the ~600 MiB base closure. This is where bring-up
+time actually lives — not the egress gateway (ADR-082 §"Explicitly not a
+performance decision").
+
+## Root cause (confirmed)
+
+The builder VM's persistent `/nix` store (`~/.cache/mvm/builder-vm/nix-store-<arch>.img`)
+runs a post-build cap-triggered GC: when the store exceeds 24 GiB
+(`DEFAULT_BUILDER_STORE_GC_GIB`), the build script runs
+`nix-collect-garbage --delete-older-than 14d`
+(`crates/mvm-build/src/builder_vm_runtime.rs` `render_flake_cmd_sh`, ~L485).
+
+`--delete-older-than 14d` only bounds which *profile generations* are removed.
+It does **not** spare a store path that has no GC root. After a build, the
+kernel binary and the nixpkgs base closure are reachable only through the
+build's transient `result` root; once the cap fires, the sweep treats them as
+garbage. The *next* cold build then recompiles the kernel (3–10 min) and
+re-pulls the base closure (~600 MiB). Builds stay warm only until the store
+first crosses 24 GiB.
+
+Nix-store *persistence itself already exists and works* (persistent ext4
+virtio-blk image, lazy format, overlay mount, seeded DB, auto-GC) — the gap is
+the GC discarding the warm kernel/base, plus the absence of any kernel cache
+that survives a store wipe.
+
+## WS-1 — Warm gcroot for the latest build closure (the surgical fix)
+
+Pin the just-built closure as a **fixed-name** GC root so the cap-triggered GC
+spares the kernel binary + runtime base it contains. A fixed name
+(`/nix/var/nix/gcroots/mvm-warm-latest`, overwritten every build) keeps only the
+*latest* closure warm, so the store stays bounded while an unchanged kernel
+derivation becomes a store hit instead of a recompile.
+
+- [x] In `render_flake_cmd_sh`, after `$NIX_OUT` is captured and written to
+      `/job/store-path`, register `/nix/var/nix/gcroots/mvm-warm-latest` →
+      `$NIX_OUT` (symlink under `gcroots/` is a valid root; `nix-store --add-root`
+      idiom with an `ln -sfn` fallback for robustness). Best-effort, never fails
+      the build.
+- [x] Comment explains *why* (cap-GC sweeps unrooted-but-recent paths; fixed
+      name keeps the store bounded). No spec/PR refs in the comment.
+- [x] Extend `render_flake_cmd_sh_embeds_gc_tail_with_default_cap` (or a sibling
+      test) to assert: the warm-gcroot line is rendered, roots `$NIX_OUT`, uses
+      the fixed `mvm-warm-latest` name, and is emitted *before* the GC tail.
+- [x] `cargo nextest run -p mvm-build` green; `cargo fmt --all`; clippy clean.
+
+**Verification (live, on this macOS-26 Vz box) — PENDING:** build a dev-shell image twice
+crossing the 24 GiB cap (or with `MVM_BUILDER_STORE_GC_GIB` lowered to force the
+GC); confirm the kernel is a store hit on the second build (no
+`CC`/`LD vmlinux` lines in `~/.cache/mvm/builder-vm/jobs/<id>/nix-stderr.log`).
+
+## WS-2 — Hash-keyed kernel prebuilt outside the nix store (robust + cross-worktree)
+
+Defense-in-depth: a content-addressed kernel artifact at
+`~/.cache/mvm/kernels/<config-hash>/<arch>/vmlinux`, **outside** any nix store,
+so the kernel survives a full store wipe/GC and is shared across worktrees and
+machines. Key = `hash(base.nix .config + builder delta + arch + kernel-source-rev)`;
+the builder-vm flake already exposes standalone `builder-kernel` /
+`workload-kernel` / `kernel-configfile` outputs to derive it from.
+
+**Open design fork (needs a call before building):** how the prebuilt kernel is
+*injected* back into a build.
+- (i) **Separate-file load** — keep loading `vmlinux` as a host file path
+  (workload microVMs already do this) and source it from the prebuilt cache,
+  bypassing the in-VM kernel derivation entirely. Cleanest, but only applies
+  where the kernel is loaded separately (not the libkrun bundled-kernel path).
+- (ii) **Store seed** — `nix-store --import` the prebuilt kernel closure into the
+  in-VM store before the build so nix sees it as already-realised. Works
+  everywhere but reintroduces a store dependency (and the closure must carry a
+  valid signature or be imported with `--no-check-sigs`).
+
+WS-1 makes the *steady-state* kernel recompile go away on its own; WS-2 is the
+cross-worktree / post-wipe win. Sequence WS-2 after WS-1 lands and the fork is
+decided.
+
+- [ ] Decide injection mechanism (i) vs (ii).
+- [ ] Derive + plumb the config-hash key (`nix/images/builder-vm/flake.nix`,
+      `crates/mvm-backend/src/artifacts/artifact.rs` already carries a kernel hash).
+- [ ] Copy-out after realise; lookup + inject before build
+      (`crates/mvm-build/src/libkrun_builder.rs` `ensure_builder_vm_image` /
+      `krun_context_for_image`).
+- [ ] Cache-dir helper via `mvm-core::config` (never inline `$HOME`).
+- [ ] Tests: key stability, hit/miss, injection roundtrip.
+
+## Out of scope
+
+- The egress gateway (ADR-082 owns that; explicitly not a perf lever).
+- Nix-store persistence mechanics (already shipped).
+- Changing the 24 GiB cap default (orthogonal; WS-1 fixes the symptom without it).


### PR DESCRIPTION
## What

The builder VM's persistent `/nix` store runs a cap-triggered
`nix-collect-garbage --delete-older-than 14d` once it crosses 24 GiB. That
flag only bounds *profile generations* — it deletes every store path with no
GC root, regardless of age. After a build, the kernel binary and the nixpkgs
base closure are reachable only through the build's transient `result` root,
so the sweep discards them. The next cold build then recompiles the kernel
(3–10 min) and re-pulls ~600 MiB. Builds stay warm only until the store first
crosses the cap.

This pins the just-built closure under a **fixed-name** gcroot
(`/nix/var/nix/gcroots/mvm-warm-latest`, overwritten each build) so the GC
spares the kernel + runtime base it carries. An unchanged kernel derivation
becomes a store hit on the next build; the fixed name keeps only the *latest*
closure warm, so the store stays bounded.

This is the confirmed root cause of slow cold bring-up — not the egress
gateway (ADR-082 §"Explicitly not a performance decision"). Nix-store
persistence already works; the gap was the GC discarding the warm kernel/base.

## Scope

Plan 196 WS-1 (`specs/plans/196-warm-builder-store-kernel-cache.md`). WS-2 (a
content-addressed kernel prebuilt cache outside the nix store, for the
cross-worktree / post-wipe win) is scoped in the plan with an open
injection-mechanism fork, sequenced after this lands.

## Test

Unit: `render_flake_cmd_sh_embeds_gc_tail_with_default_cap` extended to assert
the warm gcroot roots `$NIX_OUT`, uses the bounded fixed name, and is
registered before the GC tail. `cargo nextest run -p mvm-build` green (535),
fmt + clippy clean.

Live cross-cap build verification on the macOS-26 Vz box is still pending
(noted in the plan).