### PR TITLE
perf(pool): warm claim reuses the admission image sha (drops the redundant rootfs hash)

### DIFF
--- a/crates/mvm-cli/src/commands/pool.rs
+++ b/crates/mvm-cli/src/commands/pool.rs
@@ -266,8 +266,21 @@ pub fn warm_to_target(pool: &SupervisorStandbyPool, p: &WarmParams<'_>) -> Resul
 /// The base-compat key a launch needs (kernel identity + fixed vcpus/mem + image sha for
 /// Vz). The kernel component is [`kernel_identity`] — for libkrun the bundled-kernel
 /// constant, so it's computable pre-boot even without an on-disk kernel.
-fn compat_for_launch(backend: &dyn VmBackend, cfg: &VmStartConfig) -> Result<StandbyCompat> {
-    let image_sha256 = image_identity(backend, cfg.rootfs_path.as_str())?;
+/// Build the compat key for a launch. `image_sha256_override` lets the caller
+/// hand in a rootfs sha already computed elsewhere (claim-8 admission hashes
+/// the rootfs to mint `ExecutionPlan.image.sha256` — the exact same bytes), so
+/// the image-bound backends skip a redundant full-rootfs hash on the launch hot
+/// path. It is the identical value `image_identity` would produce; `None` falls
+/// back to hashing. libkrun is image-agnostic and ignores the override.
+fn compat_for_launch(
+    backend: &dyn VmBackend,
+    cfg: &VmStartConfig,
+    image_sha256_override: Option<&str>,
+) -> Result<StandbyCompat> {
+    let image_sha256 = match image_sha256_override {
+        Some(sha) if backend.name() == "vz" => Some(sha.to_string()),
+        _ => image_identity(backend, cfg.rootfs_path.as_str())?,
+    };
     Ok(StandbyCompat {
         kernel_sha256: kernel_identity(backend, cfg.kernel_path.as_deref())?,
         vcpus: u8::try_from(cfg.cpus.clamp(1, u32::from(u8::MAX))).unwrap_or(u8::MAX),
@@ -289,6 +302,7 @@ pub fn try_warm_claim(
     backend: &AnyBackend,
     cfg: &VmStartConfig,
     user_named: bool,
+    admitted_image_sha256: Option<&str>,
 ) -> Result<Option<VmId>> {
     if cfg.warm_pool_size == 0
         || user_named
@@ -301,7 +315,9 @@ pub fn try_warm_claim(
         // No admitted plan threaded in → not the bridge path → cold-boot.
         return Ok(None);
     };
-    let want = compat_for_launch(backend.as_vm_backend(), cfg)?;
+    // Reuse the rootfs sha claim-8 admission already computed (same bytes) so
+    // the claim decision doesn't re-hash the whole rootfs on the launch path.
+    let want = compat_for_launch(backend.as_vm_backend(), cfg, admitted_image_sha256)?;
     let rootfs = cfg.rootfs_path.clone();
     let bundle_json = cfg.bundle_json.clone();
     let pool = SupervisorStandbyPool::open()?;
@@ -682,13 +698,16 @@ mod tests {
         let b = AnyBackend::from_hypervisor("libkrun");
         let mut c = eligible_cfg();
         c.warm_pool_size = 0;
-        assert_eq!(try_warm_claim(&b, &c, false).unwrap(), None);
+        assert_eq!(try_warm_claim(&b, &c, false, None).unwrap(), None);
     }
 
     #[test]
     fn try_warm_claim_cold_when_user_named() {
         let b = AnyBackend::from_hypervisor("libkrun");
-        assert_eq!(try_warm_claim(&b, &eligible_cfg(), true).unwrap(), None);
+        assert_eq!(
+            try_warm_claim(&b, &eligible_cfg(), true, None).unwrap(),
+            None
+        );
     }
 
     #[test]
@@ -704,7 +723,7 @@ mod tests {
             kind: VmVolumeKind::DirShare,
             encrypted: false,
         }];
-        assert_eq!(try_warm_claim(&b, &c, false).unwrap(), None);
+        assert_eq!(try_warm_claim(&b, &c, false, None).unwrap(), None);
     }
 
     #[test]
@@ -712,7 +731,7 @@ mod tests {
         let b = AnyBackend::from_hypervisor("libkrun");
         let mut c = eligible_cfg();
         c.plan_json = None; // not the gateway-bridge/admitted path → cold-boot
-        assert_eq!(try_warm_claim(&b, &c, false).unwrap(), None);
+        assert_eq!(try_warm_claim(&b, &c, false, None).unwrap(), None);
     }
 
     // A VmBackend stub whose `spawn_standby` always fails — used to exercise

--- a/crates/mvm-cli/src/commands/vm/up.rs
+++ b/crates/mvm-cli/src/commands/vm/up.rs
@@ -2123,22 +2123,31 @@ pub(super) fn cmd_run(params: RunParams<'_>) -> Result<()> {
         // Try a warm-pool claim first (auto-named + bridge-admitted
         // launches only; fail-open to cold boot). A claimed VM runs under its standby-id,
         // so rebind `vm_name_owned` for all downstream (agent wait, audit, readiness, stop).
-        let claimed: Option<String> =
-            match super::super::pool::try_warm_claim(&backend, &start_config, name.is_some()) {
-                Ok(Some(id)) => {
-                    ui::info(&format!(
-                        "Claimed a warm standby ({}) — skipping cold boot.",
-                        id.0
-                    ));
-                    Some(id.0)
-                }
-                Ok(None) => None,
-                Err(e) => {
-                    // try_warm_claim itself erroring (pool I/O, etc.) must not fail the launch.
-                    tracing::warn!(error = %e, "warm-claim attempt errored; cold-booting");
-                    None
-                }
-            };
+        // Hand the claim the rootfs sha admission already computed so it doesn't
+        // re-hash the rootfs to build the image compat key.
+        let admitted_image_sha = admission_main
+            .as_ref()
+            .map(|ctx| ctx.admitted.plan.image.sha256.clone());
+        let claimed: Option<String> = match super::super::pool::try_warm_claim(
+            &backend,
+            &start_config,
+            name.is_some(),
+            admitted_image_sha.as_deref(),
+        ) {
+            Ok(Some(id)) => {
+                ui::info(&format!(
+                    "Claimed a warm standby ({}) — skipping cold boot.",
+                    id.0
+                ));
+                Some(id.0)
+            }
+            Ok(None) => None,
+            Err(e) => {
+                // try_warm_claim itself erroring (pool I/O, etc.) must not fail the launch.
+                tracing::warn!(error = %e, "warm-claim attempt errored; cold-booting");
+                None
+            }
+        };
         match claimed {
             Some(name) => vm_name_owned = name,
             None => {


### PR DESCRIPTION
## Summary

The warm-claim decision (`try_warm_claim` → `compat_for_launch` → `image_identity`) hashed the entire rootfs to build the image compat key — duplicating the sha256 that **claim-8 admission already computed** for `ExecutionPlan.image.sha256` on the same `up`. That's a second multi-hundred-MB hash on the launch hot path for every eligible Vz `up`.

Fix: `compat_for_launch` gains an `image_sha256_override` param; `up` threads the admitted plan's `image.sha256` into `try_warm_claim`. For Vz the override is used directly; `None` falls back to hashing; libkrun stays image-agnostic (ignores it).

**Correctness — the override is byte-identical to what `image_identity` produces**, verified:
- admission: `mvm_core::crypto::image_verify::sha256_file` → `format!("{:x}", Sha256::finalize())`
- `image_identity` (vz): `kernel_sha256_hex` → `hex_lower(Sha256::digest(bytes))`

Both are lowercase-hex sha256 of the same file bytes (whole-file vs streamed read doesn't change the digest), so the compat match is unchanged. The standby's stored `image_sha256` (computed via `image_identity` at warm time) still matches.

This is the dependency-free form of the cleaner-contract idea from the WS-2 coordination thread: rather than coupling the compat key to the cached-artifact *fingerprint* (which would tie this to the in-flight `dev_vz.rs` helpers **and** weaken the byte-identity guarantee — a fingerprint is a source key, not an output-byte identity), it reuses the byte sha admission already computes. Full claim-8 byte-identity preserved, zero coupling to the WS-2 boot-decision layer.

## Scope / coordination

Touches only `crates/mvm-cli/src/commands/pool.rs` and the warm-hook lines in `up.rs` — **not** `dev.rs` / `dev_vz.rs` / the backend. No collision with Plan 189 WS-2 (cached fast-boot default).

## Live validation

`pool warm 1` → 1 idle → `up --warm-pool-size 1` → **"Claimed a warm standby — skipping cold boot"** still fires (compat matched via the reused sha) → pool drained 1→0 → background self-replenish refilled to 1.

## Test Plan
- [x] fmt / clippy `-D warnings` (mvm-cli) / `check-no-spec-refs-in-comments` clean
- [x] `cargo nextest run -p mvm-cli` warm/pool/claim subset green (test callers updated to `None`)
- [x] Live: warm → claim → self-replenish (above)