### PR TITLE
feat(net): MVM_NETWORKING=native gateway flag (ADR-082 Phase 1)

### DIFF
--- a/crates/deps/libkrun-sys/src/gvproxy.rs
+++ b/crates/deps/libkrun-sys/src/gvproxy.rs
@@ -137,8 +137,21 @@ pub fn install_hint() -> &'static str {
     }
 }
 
-/// Probe `$PATH` for `gvproxy`. Returns the absolute path on success.
+/// Locate the host-side vfkit gateway binary to spawn.
+///
+/// `MVM_GATEWAY_BIN`, when set to a non-empty value, overrides the
+/// default — the seam for running an alternate gateway that speaks the
+/// same `-listen-vfkit` unixgram protocol gvproxy does (the in-house
+/// native gateway, selected via `MVM_NETWORKING=native`). The path is
+/// used verbatim; a bad path surfaces as a clear spawn error rather
+/// than silently falling back to `gvproxy`. Unset → probe `$PATH` for
+/// `gvproxy`.
 pub fn locate_gvproxy() -> Option<PathBuf> {
+    if let Some(bin) = std::env::var_os("MVM_GATEWAY_BIN")
+        && !bin.is_empty()
+    {
+        return Some(PathBuf::from(bin));
+    }
     which::which("gvproxy").ok()
 }
 
@@ -456,6 +469,27 @@ mod tests {
     #[test]
     fn locate_gvproxy_is_optional() {
         let _ = locate_gvproxy();
+    }
+
+    /// `MVM_GATEWAY_BIN` overrides the default `gvproxy` lookup — the seam an
+    /// alternate vfkit gateway (the native gateway) is spawned through. An
+    /// empty value is ignored so it falls back to the `$PATH` probe.
+    #[test]
+    fn locate_gvproxy_honors_gateway_bin_override() {
+        let _guard = ENV_LOCK.lock().unwrap();
+        // SAFETY: env mutation serialized by the crate-wide TEST_ENV_LOCK.
+        unsafe {
+            std::env::set_var("MVM_GATEWAY_BIN", "/opt/mvm/native-gateway");
+            assert_eq!(
+                locate_gvproxy(),
+                Some(PathBuf::from("/opt/mvm/native-gateway")),
+                "MVM_GATEWAY_BIN must override the default gvproxy lookup"
+            );
+            std::env::set_var("MVM_GATEWAY_BIN", "");
+            // Empty → ignored; must not return an empty path.
+            assert_ne!(locate_gvproxy(), Some(PathBuf::new()));
+            std::env::remove_var("MVM_GATEWAY_BIN");
+        }
     }
 
     /// A reserved port is in gvproxy's accepted `-ssh-port` range

--- a/crates/mvm-backend/src/libkrun.rs
+++ b/crates/mvm-backend/src/libkrun.rs
@@ -138,6 +138,11 @@ fn krun_context_base(
         mvm_build::libkrun_builder::NetworkingPreference::Passt => {
             krun.with_passt(libkrun_sys::passt::DEFAULT_GUEST_MAC, scratch)
         }
+        // Native reuses the gvproxy vfkit backend; the binary swap happens
+        // in gvproxy::locate_gvproxy via MVM_GATEWAY_BIN.
+        mvm_build::libkrun_builder::NetworkingPreference::Native => {
+            krun.with_gvproxy(libkrun_sys::gvproxy::DEFAULT_GUEST_MAC, scratch)
+        }
     }
 }
 

--- a/crates/mvm-build/src/libkrun_builder.rs
+++ b/crates/mvm-build/src/libkrun_builder.rs
@@ -147,6 +147,14 @@ pub enum NetworkingPreference {
     /// supervisor spawns gvproxy with `-listen-vfkit unixgram://…`
     /// and libkrun connects to the listener path.
     Gvproxy,
+    /// virtio-net via the in-house native gateway. Opt-in only
+    /// (`MVM_NETWORKING=native`); the default never selects it. The
+    /// native gateway speaks the same `-listen-vfkit` unixgram protocol
+    /// as gvproxy, so it reuses the gvproxy vfkit backend wholesale —
+    /// the only difference is the binary, located via `MVM_GATEWAY_BIN`.
+    /// `resolve_networking_mode` falls back to the per-OS default when
+    /// `native` is requested without `MVM_GATEWAY_BIN`.
+    Native,
 }
 
 /// Apply the resolved [`NetworkingPreference`] to a [`KrunContext`].
@@ -163,6 +171,12 @@ fn apply_networking_mode(
             krun.with_passt(libkrun_sys::passt::DEFAULT_GUEST_MAC, scratch)
         }
         NetworkingPreference::Gvproxy => {
+            krun.with_gvproxy(libkrun_sys::gvproxy::DEFAULT_GUEST_MAC, scratch)
+        }
+        // Drop-in: the native gateway speaks the gvproxy vfkit unixgram
+        // protocol, so reuse `with_gvproxy`. The binary swap happens in
+        // `gvproxy::locate_gvproxy` via `MVM_GATEWAY_BIN`.
+        NetworkingPreference::Native => {
             krun.with_gvproxy(libkrun_sys::gvproxy::DEFAULT_GUEST_MAC, scratch)
         }
     })
@@ -182,10 +196,11 @@ pub fn default_networking_mode() -> NetworkingPreference {
     }
 }
 
-/// Read `MVM_NETWORKING` from the env. Accepts `passt` and
-/// `gvproxy` (case-insensitive); anything else falls back to the
+/// Read `MVM_NETWORKING` from the env. Accepts `passt`, `gvproxy`,
+/// and `native` (case-insensitive); anything else falls back to the
 /// per-OS default and emits a warning so a typo is visible without
-/// aborting.
+/// aborting. `native` additionally requires `MVM_GATEWAY_BIN` to name
+/// the gateway binary, or it falls back to the per-OS default too.
 ///
 /// Per-OS dispatch is macOS → gvproxy, Linux → passt. TSI was
 /// removed entirely — it bypassed virtio-net (no host fd to splice),
@@ -220,6 +235,23 @@ pub fn resolve_networking_mode() -> NetworkingPreference {
             }
         }
         Some("gvproxy") => NetworkingPreference::Gvproxy,
+        // The native gateway is located via `MVM_GATEWAY_BIN`. Without it
+        // there is no binary to spawn, so fall back to the per-OS default
+        // with a warning rather than silently spawning the wrong gateway —
+        // same fail-safe shape as the passt-on-macOS fallback above.
+        Some("native") => {
+            if std::env::var_os("MVM_GATEWAY_BIN").is_some_and(|v| !v.is_empty()) {
+                NetworkingPreference::Native
+            } else {
+                let fallback = default_networking_mode();
+                tracing::warn!(
+                    fallback = ?fallback,
+                    "MVM_NETWORKING=native requires MVM_GATEWAY_BIN to point at the \
+                     gateway binary; falling back to per-OS default"
+                );
+                fallback
+            }
+        }
         None | Some("") => default_networking_mode(),
         Some(other) => {
             let fallback = default_networking_mode();
@@ -234,7 +266,7 @@ pub fn resolve_networking_mode() -> NetworkingPreference {
                 tracing::warn!(
                     value = other,
                     fallback = ?fallback,
-                    "MVM_NETWORKING unrecognised; falling back to per-OS default (accepted: passt, gvproxy)"
+                    "MVM_NETWORKING unrecognised; falling back to per-OS default (accepted: passt, gvproxy, native)"
                 );
             }
             fallback
@@ -2220,6 +2252,23 @@ mod tests {
             // Unknown value falls back to the per-OS default without panic.
             std::env::set_var("MVM_NETWORKING", "vmnet-helper");
             assert_eq!(resolve_networking_mode(), default_networking_mode());
+
+            // `native` requires MVM_GATEWAY_BIN to name the gateway binary;
+            // without it, it falls back (fail-safe, no wrong-gateway spawn).
+            std::env::remove_var("MVM_GATEWAY_BIN");
+            std::env::set_var("MVM_NETWORKING", "native");
+            assert_eq!(
+                resolve_networking_mode(),
+                default_networking_mode(),
+                "native without MVM_GATEWAY_BIN must fall back to the per-OS default"
+            );
+            // With MVM_GATEWAY_BIN set, `native` resolves (case- and
+            // whitespace-insensitive like the other accepted values).
+            std::env::set_var("MVM_GATEWAY_BIN", "/path/to/gateway");
+            assert_eq!(resolve_networking_mode(), NetworkingPreference::Native);
+            std::env::set_var("MVM_NETWORKING", " NATIVE ");
+            assert_eq!(resolve_networking_mode(), NetworkingPreference::Native);
+            std::env::remove_var("MVM_GATEWAY_BIN");
 
             std::env::remove_var("MVM_NETWORKING");
         }

--- a/crates/mvm-build/src/libkrun_network_provider.rs
+++ b/crates/mvm-build/src/libkrun_network_provider.rs
@@ -52,6 +52,10 @@ impl LibkrunNetworkProvider {
         match pref {
             NetworkingPreference::Gvproxy => "gvproxy",
             NetworkingPreference::Passt => "passt",
+            // Native shares the gvproxy vfkit spawn path — it differs only in
+            // the binary (via MVM_GATEWAY_BIN) — so the supervisor config keys
+            // on the same "gvproxy" kind.
+            NetworkingPreference::Native => "gvproxy",
         }
     }
 }
@@ -120,6 +124,11 @@ mod tests {
         assert_eq!(
             LibkrunNetworkProvider::gateway_kind(NetworkingPreference::Passt),
             "passt"
+        );
+        // Native reuses the gvproxy vfkit kind; the binary swap is orthogonal.
+        assert_eq!(
+            LibkrunNetworkProvider::gateway_kind(NetworkingPreference::Native),
+            "gvproxy"
         );
     }
 


### PR DESCRIPTION
ADR-082 Phase 1 — wire the opt-in flag for the in-house native egress gateway. **Default unchanged; no behavior changes unless you opt in.**

## What

The native gateway speaks the **same `-listen-vfkit` unixgram protocol** as gvproxy, so this reuses the gvproxy vfkit backend wholesale — **zero forked protocol code**. The only difference is the binary, located via `MVM_GATEWAY_BIN` (the existing conformance-test seam, now honored on the production spawn path).

- `NetworkingPreference::Native` + `MVM_NETWORKING=native`. Falls back to the per-OS default (with a warning) when `MVM_GATEWAY_BIN` is unset — a misconfig never silently spawns the wrong gateway (same fail-safe shape as the passt-on-macOS fallback).
- `locate_gvproxy()` honors `MVM_GATEWAY_BIN` → the spawn-binary seam for any vfkit-compatible gateway, on **both** the libkrun and Vz `host_gvproxy` paths.
- `apply_networking_mode` / `mvm-backend` dispatch `Native → with_gvproxy`.
- `gateway_kind(Native) → "gvproxy"`: shares the vfkit spawn path the supervisor config keys on (the binary swap is orthogonal).

## Tests

- `resolve_networking_mode`: `native` resolves with `MVM_GATEWAY_BIN` set; falls back without it; case/whitespace-insensitive.
- `locate_gvproxy_honors_gateway_bin_override`: override wins; empty value ignored.
- `gateway_kind_maps_each_preference`: `Native → "gvproxy"`.

Local: fmt, `cargo check --all-targets`, clippy `-D warnings`, `-D warnings` rustc, and `check-no-spec-refs-in-comments` all clean; new unit tests pass.

## Scope / honesty

This is **scaffolding** — it can't be validated end-to-end until the gateway's live libkrun boot proof lands (Phase 2, connectivity parity). gvproxy/passt remain the defaults and the only paths exercised by default. The variant is named generically (`Native`) to keep the sibling slug out of source.