### PR TITLE
docs(adr-082): align flag literal with shipped `native`

### DIFF
--- a/specs/adrs/082-rust-native-egress-gateway.md
+++ b/specs/adrs/082-rust-native-egress-gateway.md
@@ -55,8 +55,9 @@ replacing the vendored Go gateway. Do it as a flag-gated, parity-tested
 migration — the playbook used for the Swift→Rust supervisor cutover (Plan 152),
 not a blind swap of the security seam.
 
-- Add an `Rvproxy` variant to `NetworkingPreference` (`MVM_NETWORKING=rvproxy`).
-  gvproxy/passt remain selectable until the parity gate passes.
+- Add a `Native` variant to `NetworkingPreference` (`MVM_NETWORKING=native`).
+  gvproxy/passt remain selectable until the parity gate passes. The variant
+  and flag are named generically — the source carries no project slug.
 - The native gateway must terminate the **same** `-listen-vfkit` unixgram
   protocol libkrun (`krun_add_net_unixgram`) and Vz (vfkit) already speak, so
   the backend dispatch (`apply_networking`, `host_gvproxy`) changes only which
@@ -72,8 +73,8 @@ not a blind swap of the security seam.
 
 ## Migration plan (parity-gated)
 
-1. **Wire the flag.** `Rvproxy` variant + `apply_networking` dispatch + spawn
-   path; daemon behind `MVM_NETWORKING=rvproxy`, default unchanged.
+1. **Wire the flag.** `Native` variant + `apply_networking` dispatch + spawn
+   path; daemon behind `MVM_NETWORKING=native`, default unchanged.
 2. **Connectivity parity.** Builder + Stage 0 cold build over the Rust gateway
    reaches cache.nixos.org and completes byte-identical artifacts on libkrun and
    Vz. (Linux/passt parity tracked separately.)


### PR DESCRIPTION
Pure doc fix. ADR-082's prose calls the gateway "the native gateway" everywhere, but two leftover literals named the `NetworkingPreference` variant `Rvproxy` and the env flag `MVM_NETWORKING=rvproxy`.

PR #848 (ADR-082 Phase 1 scaffolding) shipped the variant/flag as the generic `Native` / `MVM_NETWORKING=native` — deliberately, to keep the gateway's project slug out of source. This aligns the ADR to the shipped code.

Without this, a reader following ADR-082 verbatim types `MVM_NETWORKING=rvproxy`, hits the unrecognized-value arm in `resolve_networking_mode`, and silently gets the per-OS default.

- No code change; no behavior change.
- Adds a one-line note that the variant/flag are named generically so the source carries no project slug — which is consistent with the ADR's already-slug-free prose.

Pairs with #848 (the code that adds the `native` flag).