### PR TITLE
feat(backend): WorkloadBackend type-bar — core security features non-skippable (Plan 197 Phase 1)

### DIFF
--- a/crates/mvm-backend/src/backend.rs
+++ b/crates/mvm-backend/src/backend.rs
@@ -484,6 +484,19 @@ impl AnyBackend {
         self.inner()
     }
 
+    /// Borrow as `&dyn WorkloadBackend` — `Some` only for backends permitted
+    /// to carry an untrusted workload. The exhaustive match means a new
+    /// `AnyBackend` variant forces an explicit workload/non-workload decision
+    /// here (compile error otherwise).
+    pub fn as_workload_backend(&self) -> Option<&dyn crate::workload_backend::WorkloadBackend> {
+        match self {
+            AnyBackend::Firecracker(b) => Some(b),
+            AnyBackend::Libkrun(b) => Some(b),
+            AnyBackend::Vz(b) => Some(b),
+            AnyBackend::Qemu(_) | AnyBackend::Mock(_) => None,
+        }
+    }
+
     /// Does this backend support a prelaunched-supervisor standby
     /// pool? See [`VmBackend::supports_standby_pool`]. Only libkrun does today.
     pub fn supports_standby_pool(&self) -> bool {
@@ -1062,6 +1075,28 @@ mod tests {
                  update one to match the other.",
                 enum_tier,
                 profile_tier
+            );
+        }
+    }
+
+    #[test]
+    fn as_workload_backend_some_for_workload_variants() {
+        for name in ["firecracker", "libkrun", "vz"] {
+            let backend = AnyBackend::from_hypervisor(name);
+            assert!(
+                backend.as_workload_backend().is_some(),
+                "{name}: must be a workload backend"
+            );
+        }
+    }
+
+    #[test]
+    fn as_workload_backend_none_for_non_workload_variants() {
+        for name in ["qemu", "mock"] {
+            let backend = AnyBackend::from_hypervisor(name);
+            assert!(
+                backend.as_workload_backend().is_none(),
+                "{name}: Tier-2/test backend must not be a workload backend"
             );
         }
     }

--- a/crates/mvm-backend/src/backend.rs
+++ b/crates/mvm-backend/src/backend.rs
@@ -487,13 +487,17 @@ impl AnyBackend {
     /// Borrow as `&dyn WorkloadBackend` — `Some` only for backends permitted
     /// to carry an untrusted workload. The exhaustive match means a new
     /// `AnyBackend` variant forces an explicit workload/non-workload decision
-    /// here (compile error otherwise).
+    /// here (compile error otherwise). `Qemu` is barred (a real VMM scoped to
+    /// dev/test); `Mock` is permitted as the hermetic lifecycle test double —
+    /// it carries no real workload, so it is the stand-in tests drive through
+    /// the admitted path.
     pub fn as_workload_backend(&self) -> Option<&dyn crate::workload_backend::WorkloadBackend> {
         match self {
             AnyBackend::Firecracker(b) => Some(b),
             AnyBackend::Libkrun(b) => Some(b),
             AnyBackend::Vz(b) => Some(b),
-            AnyBackend::Qemu(_) | AnyBackend::Mock(_) => None,
+            AnyBackend::Mock(b) => Some(b),
+            AnyBackend::Qemu(_) => None,
         }
     }
 
@@ -1081,7 +1085,9 @@ mod tests {
 
     #[test]
     fn as_workload_backend_some_for_workload_variants() {
-        for name in ["firecracker", "libkrun", "vz"] {
+        // mock is included: it is the hermetic lifecycle test double that
+        // stands in for a workload backend on the admitted path (ADR-045).
+        for name in ["firecracker", "libkrun", "vz", "mock"] {
             let backend = AnyBackend::from_hypervisor(name);
             assert!(
                 backend.as_workload_backend().is_some(),
@@ -1091,14 +1097,14 @@ mod tests {
     }
 
     #[test]
-    fn as_workload_backend_none_for_non_workload_variants() {
-        for name in ["qemu", "mock"] {
-            let backend = AnyBackend::from_hypervisor(name);
-            assert!(
-                backend.as_workload_backend().is_none(),
-                "{name}: Tier-2/test backend must not be a workload backend"
-            );
-        }
+    fn as_workload_backend_none_for_qemu() {
+        // qemu is the meaningful carve-out: a real dev/test VMM that must not
+        // carry an untrusted workload.
+        let backend = AnyBackend::from_hypervisor("qemu");
+        assert!(
+            backend.as_workload_backend().is_none(),
+            "qemu: dev/test VMM must not be a workload backend"
+        );
     }
 
     #[test]

--- a/crates/mvm-backend/src/backend.rs
+++ b/crates/mvm-backend/src/backend.rs
@@ -1086,7 +1086,7 @@ mod tests {
     #[test]
     fn as_workload_backend_some_for_workload_variants() {
         // mock is included: it is the hermetic lifecycle test double that
-        // stands in for a workload backend on the admitted path (ADR-045).
+        // stands in for a workload backend on the admitted path.
         for name in ["firecracker", "libkrun", "vz", "mock"] {
             let backend = AnyBackend::from_hypervisor(name);
             assert!(

--- a/crates/mvm-backend/src/lib.rs
+++ b/crates/mvm-backend/src/lib.rs
@@ -74,12 +74,17 @@ pub mod vz;
 // Rust client for the Vz supervisor's control socket
 // (PAUSE / RESUME / BALLOON / SAVE). Used by VzBackend.
 pub mod vz_control;
+/// `WorkloadBackend` marker trait — the type-level permission to carry an
+/// untrusted workload. The admitted launch path accepts `&dyn WorkloadBackend`
+/// only, so a non-workload backend (QEMU dev/test, mock) cannot reach it.
+pub mod workload_backend;
 
 pub use backend::{AnyBackend, FirecrackerBackend, FirecrackerConfig};
 pub use libkrun::LibkrunBackend;
 pub use mock::MockBackend;
 pub use qemu::QemuBackend;
 pub use vz::VzBackend;
+pub use workload_backend::WorkloadBackend;
 
 /// The per-VM egress-TLS cert/key split helper. `mvmctl up`
 /// (mvm-cli) calls this while assembling the guest secrets drive: the cert is

--- a/crates/mvm-backend/src/workload_backend.rs
+++ b/crates/mvm-backend/src/workload_backend.rs
@@ -1,0 +1,69 @@
+//! `WorkloadBackend`: the type-level permission to carry an untrusted
+//! workload. Only backends that go through the full enforcement funnel
+//! implement it; the admitted launch path accepts `&dyn WorkloadBackend`
+//! only, so a non-workload backend cannot reach it.
+use crate::backend::{AnyBackend, FirecrackerBackend};
+use crate::libkrun::LibkrunBackend;
+use crate::vz::VzBackend;
+use anyhow::{Result, anyhow};
+use mvm_core::vm_backend::VmBackend;
+
+/// Type-level permission to carry an untrusted workload.
+pub trait WorkloadBackend: VmBackend {}
+
+impl WorkloadBackend for FirecrackerBackend {}
+impl WorkloadBackend for LibkrunBackend {}
+impl WorkloadBackend for VzBackend {}
+
+/// The single boundary the admitted launch path goes through. Returns the
+/// backend as `&dyn WorkloadBackend`, or a typed refusal for backends not
+/// permitted to carry an untrusted workload (the dev/test backends). The
+/// bar is permission, not tier — libkrun and vz are Tier-2 yet workload-capable.
+pub fn require_workload_backend(backend: &AnyBackend) -> Result<&dyn WorkloadBackend> {
+    backend.as_workload_backend().ok_or_else(|| {
+        anyhow!(
+            "backend `{}` is not a workload backend — it cannot carry an \
+             untrusted workload",
+            backend.name()
+        )
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    // Compile-time proof the three workload backends implement the marker.
+    fn assert_is_workload_backend<T: WorkloadBackend>() {}
+
+    #[test]
+    fn workload_backends_implement_marker() {
+        assert_is_workload_backend::<FirecrackerBackend>();
+        assert_is_workload_backend::<LibkrunBackend>();
+        assert_is_workload_backend::<VzBackend>();
+    }
+
+    #[test]
+    fn require_workload_backend_accepts_firecracker() {
+        let backend = AnyBackend::from_hypervisor("firecracker");
+        let workload = match require_workload_backend(&backend) {
+            Ok(w) => w,
+            Err(e) => panic!("firecracker is a workload backend: {e}"),
+        };
+        assert_eq!(workload.name(), "firecracker");
+    }
+
+    #[test]
+    fn require_workload_backend_refuses_qemu() {
+        let backend = AnyBackend::from_hypervisor("qemu");
+        // `&dyn WorkloadBackend` isn't `Debug`, so match rather than `expect_err`.
+        let err = match require_workload_backend(&backend) {
+            Ok(_) => panic!("qemu is a Tier-2 dev/test backend, not a workload backend"),
+            Err(e) => e,
+        };
+        assert!(
+            err.to_string().contains("not a workload backend"),
+            "refusal must explain the bar, got: {err}"
+        );
+    }
+}

--- a/crates/mvm-backend/src/workload_backend.rs
+++ b/crates/mvm-backend/src/workload_backend.rs
@@ -4,6 +4,7 @@
 //! only, so a non-workload backend cannot reach it.
 use crate::backend::{AnyBackend, FirecrackerBackend};
 use crate::libkrun::LibkrunBackend;
+use crate::mock::MockBackend;
 use crate::vz::VzBackend;
 use anyhow::{Result, anyhow};
 use mvm_core::vm_backend::VmBackend;
@@ -14,6 +15,11 @@ pub trait WorkloadBackend: VmBackend {}
 impl WorkloadBackend for FirecrackerBackend {}
 impl WorkloadBackend for LibkrunBackend {}
 impl WorkloadBackend for VzBackend {}
+// `MockBackend` is the hermetic lifecycle test double — it carries no real
+// workload, so it stands in for a workload backend on the admitted path in
+// tests. `QemuBackend` (a real dev/test VMM) is deliberately NOT a
+// `WorkloadBackend`: it is the meaningful Tier-2 carve-out.
+impl WorkloadBackend for MockBackend {}
 
 /// The single boundary the admitted launch path goes through. Returns the
 /// backend as `&dyn WorkloadBackend`, or a typed refusal for backends not
@@ -33,7 +39,8 @@ pub fn require_workload_backend(backend: &AnyBackend) -> Result<&dyn WorkloadBac
 mod tests {
     use super::*;
 
-    // Compile-time proof the three workload backends implement the marker.
+    // Compile-time proof the workload backends implement the marker (incl. the
+    // mock test double; qemu is intentionally absent).
     fn assert_is_workload_backend<T: WorkloadBackend>() {}
 
     #[test]
@@ -41,6 +48,7 @@ mod tests {
         assert_is_workload_backend::<FirecrackerBackend>();
         assert_is_workload_backend::<LibkrunBackend>();
         assert_is_workload_backend::<VzBackend>();
+        assert_is_workload_backend::<MockBackend>();
     }
 
     #[test]

--- a/crates/mvm-cli/src/commands/vm/up.rs
+++ b/crates/mvm-cli/src/commands/vm/up.rs
@@ -1586,6 +1586,10 @@ pub(super) fn cmd_run(params: RunParams<'_>) -> Result<()> {
 
         enforce_shares_if(&admission, &start_config.volumes)?;
         let backend = AnyBackend::from_hypervisor(effective_hypervisor);
+        if let Err(e) = mvm_backend::workload_backend::require_workload_backend(&backend) {
+            emit_failed_if(&admission, "backend-start", &e);
+            return Err(e);
+        }
         if let Err(e) = backend.start(&start_config) {
             emit_failed_if(&admission, "backend-start", &e);
             return Err(e);
@@ -2151,6 +2155,10 @@ pub(super) fn cmd_run(params: RunParams<'_>) -> Result<()> {
         match claimed {
             Some(name) => vm_name_owned = name,
             None => {
+                if let Err(e) = mvm_backend::workload_backend::require_workload_backend(&backend) {
+                    emit_failed_if(&admission_main, "backend-start", &e);
+                    return Err(e);
+                }
                 if let Err(e) = backend.start(&start_config) {
                     emit_failed_if(&admission_main, "backend-start", &e);
                     return Err(e);
@@ -2417,6 +2425,11 @@ pub(super) fn cmd_run(params: RunParams<'_>) -> Result<()> {
             }
             enforce_shares_if(&watch_admission, &w_start_config.volumes)?;
             let w_backend = AnyBackend::from_hypervisor(effective_hypervisor);
+            if let Err(e) = mvm_backend::workload_backend::require_workload_backend(&w_backend) {
+                emit_failed_if(&watch_admission, "backend-start", &e);
+                ui::warn(&format!("Could not start VM: {e}; waiting for next change..."));
+                continue;
+            }
             if let Err(e) = w_backend.start(&w_start_config) {
                 emit_failed_if(&watch_admission, "backend-start", &e);
                 ui::warn(&format!(

--- a/crates/mvm-cli/src/commands/vm/up.rs
+++ b/crates/mvm-cli/src/commands/vm/up.rs
@@ -2427,7 +2427,9 @@ pub(super) fn cmd_run(params: RunParams<'_>) -> Result<()> {
             let w_backend = AnyBackend::from_hypervisor(effective_hypervisor);
             if let Err(e) = mvm_backend::workload_backend::require_workload_backend(&w_backend) {
                 emit_failed_if(&watch_admission, "backend-start", &e);
-                ui::warn(&format!("Could not start VM: {e}; waiting for next change..."));
+                ui::warn(&format!(
+                    "Could not start VM: {e}; waiting for next change..."
+                ));
                 continue;
             }
             if let Err(e) = w_backend.start(&w_start_config) {

--- a/crates/mvm-core/src/protocol/vm_backend.rs
+++ b/crates/mvm-core/src/protocol/vm_backend.rs
@@ -775,6 +775,11 @@ impl LayerCoverage {
 /// `notes` provides per-backend rationale shown in doctor output and is
 /// where backends explain partial claims (e.g. "claim 3 partial — verified
 /// boot for VZ-backed rootfs not yet wired up").
+///
+/// This profile is **advisory** — it describes posture for `doctor` output.
+/// The load-bearing guarantee that a non-workload backend cannot carry an
+/// untrusted workload is enforced by the `WorkloadBackend` type-bar on the
+/// admitted launch path, not by this array.
 #[derive(Debug, Clone)]
 pub struct BackendSecurityProfile {
     /// Status of claims 1..=7 (indexed 0..7).

--- a/specs/adrs/002-microvm-security-posture.md
+++ b/specs/adrs/002-microvm-security-posture.md
@@ -403,10 +403,11 @@ through its start path first (`VmStartConfig` carries no egress-policy field
 today); that is a deliberate future decision, not a Phase A gap. This refines
 the "Network policy enforcement at hypervisor level" non-goal below, which
 predates Plan 123's host-side enforcement. As of [ADR-083](083-workload-backend-type-bar.md)
-this exclusion is **type-enforced**: QEMU and the mock backend do not
-implement the `WorkloadBackend` marker, so they cannot reach the admitted
-workload-launch path at all — the carve-out is a compile-time constraint,
-not only prose.
+this exclusion is **type-enforced**: QEMU does not implement the
+`WorkloadBackend` marker, so it cannot reach the admitted workload-launch
+path at all — the carve-out is a compile-time constraint, not only prose.
+(The mock backend implements the marker as the hermetic lifecycle test
+double per ADR-045; it never carries a real workload.)
 
 **Tier-0 preview substrate (a naming bridge).** The `wasm-sandbox` backend
 above asserts none of the numbered claims by design, so it sits *outside* the

--- a/specs/adrs/002-microvm-security-posture.md
+++ b/specs/adrs/002-microvm-security-posture.md
@@ -402,7 +402,11 @@ ever promoted to a workload-bearing tier, claim-10 would have to be plumbed
 through its start path first (`VmStartConfig` carries no egress-policy field
 today); that is a deliberate future decision, not a Phase A gap. This refines
 the "Network policy enforcement at hypervisor level" non-goal below, which
-predates Plan 123's host-side enforcement.
+predates Plan 123's host-side enforcement. As of [ADR-083](083-workload-backend-type-bar.md)
+this exclusion is **type-enforced**: QEMU and the mock backend do not
+implement the `WorkloadBackend` marker, so they cannot reach the admitted
+workload-launch path at all — the carve-out is a compile-time constraint,
+not only prose.
 
 **Tier-0 preview substrate (a naming bridge).** The `wasm-sandbox` backend
 above asserts none of the numbered claims by design, so it sits *outside* the

--- a/specs/adrs/083-workload-backend-type-bar.md
+++ b/specs/adrs/083-workload-backend-type-bar.md
@@ -41,8 +41,11 @@ Introduce a marker trait and type-bar the admitted workload-launch path.
 pub trait WorkloadBackend: VmBackend {}
 ```
 
-- `FirecrackerBackend`, `LibkrunBackend`, `VzBackend` implement it. `qemu`
-  (Tier-2 dev/test) and `mock` (test double) do **not**.
+- `FirecrackerBackend`, `LibkrunBackend`, `VzBackend` implement it. `mock`
+  also implements it — it is the hermetic lifecycle test double (ADR-045)
+  that stands in for a workload backend on the admitted path in tests and
+  carries no real workload, so permitting it has no security cost. `qemu`
+  (a real Tier-2 dev/test VMM) does **not** — it is the meaningful carve-out.
 - `AnyBackend::as_workload_backend(&self) -> Option<&dyn WorkloadBackend>`
   converts via an **exhaustive match** — a new `AnyBackend` variant cannot
   compile without an explicit workload / non-workload decision.
@@ -68,7 +71,8 @@ in a follow-on phase, so it cannot be omitted either.
 - **ADR-002's Tier-2 carve-out is now a type constraint.** QEMU's exclusion
   from claim-10 egress enforcement was previously prose ("dev/test only, not
   wired"); it is now enforced by types — `qemu` is not a `WorkloadBackend`,
-  so it cannot be passed to the admitted launch path. `mock` likewise.
+  so it cannot be passed to the admitted launch path. (`mock` is permitted —
+  the hermetic test double — but it never carries a real workload.)
 - **Egress secret substitution on macOS becomes a required build.** When the
   substitution transport becomes a no-default `WorkloadBackend` method,
   libkrun and vz will not compile without implementing it. This reclassifies

--- a/specs/adrs/083-workload-backend-type-bar.md
+++ b/specs/adrs/083-workload-backend-type-bar.md
@@ -1,0 +1,102 @@
+# ADR-083 — Core security enforcement is a compile-time obligation on workload backends
+
+**Status:** Accepted
+**Amends:** [ADR-002](002-microvm-security-posture.md) (per-backend tier matrix — the workload / non-workload split becomes type-enforced rather than prose)
+**Preserves:** all numbered claims; [ADR-082](082-rust-native-egress-gateway.md) and Plan 129 egress secret substitution (now a tracked compile-time obligation on macOS, not an optional follow-up)
+
+## Context
+
+`mvm` runs untrusted workloads across several backends behind the
+`AnyBackend` enum. The cross-cutting security enforcement that backs the
+claims — signed-plan admission, default-deny egress + flow audit, app-deps
+seal, console lockdown, egress secret substitution — was applied in two
+different ways:
+
+- Some concerns run in a **shared funnel**: admission in the `up` launch
+  path, the egress bridge in the per-backend supervisor, app-deps seal in
+  the supervisor admission verifier. These apply to every workload backend
+  uniformly.
+- One concern, **egress secret substitution** (Plan 129), was hand-rolled
+  as a free function (`spawn_substitution_endpoint`) called *inside*
+  individual backends' `start()` methods — Firecracker and QEMU only.
+
+Because nothing forced a backend to acknowledge that free function, libkrun
+and vz silently never got it. The gap was invisible: a backend could be
+fully wired for boot, admission, and egress *filtering* while missing an
+entire security mechanism, and the type system was content. `BackendSecurityProfile`
+(its `claims: [ClaimStatus; 7]` array) did not help — it is advisory, and
+frozen at seven claims, so the substitution concern had no cell to be
+missing from.
+
+The lesson: a core security feature must not be expressible as *absent*
+without a deliberate, visible decision. A declaration matrix that lets a
+backend mark a core feature "unsupported" only *documents* the hole; it
+does not prevent it.
+
+## Decision
+
+Introduce a marker trait and type-bar the admitted workload-launch path.
+
+```rust
+pub trait WorkloadBackend: VmBackend {}
+```
+
+- `FirecrackerBackend`, `LibkrunBackend`, `VzBackend` implement it. `qemu`
+  (Tier-2 dev/test) and `mock` (test double) do **not**.
+- `AnyBackend::as_workload_backend(&self) -> Option<&dyn WorkloadBackend>`
+  converts via an **exhaustive match** — a new `AnyBackend` variant cannot
+  compile without an explicit workload / non-workload decision.
+- `require_workload_backend(&AnyBackend) -> Result<&dyn WorkloadBackend>`
+  is the single boundary the admitted launch path runs; it refuses a
+  non-workload backend before any VM starts.
+
+The admitted launch arms in the `up` / `invoke` path call this guard before
+dispatching, so a non-workload backend is refused, not launched.
+
+This is the structural fix, not a capability matrix: a backend reaches the
+untrusted-workload path only by being a `WorkloadBackend`, and the shared
+funnel — not the backend — applies the cross-cutting enforcement. The lone
+genuinely per-backend concern (the egress substitution *transport*, which
+differs by backend mechanism) becomes a no-default `WorkloadBackend` method
+in a follow-on phase, so it cannot be omitted either.
+
+## Consequences
+
+- **A new backend cannot reach the workload path silently.** It must either
+  implement `WorkloadBackend` (and therefore the shared funnel applies) or
+  be deliberately excluded — a visible, reviewable decision.
+- **ADR-002's Tier-2 carve-out is now a type constraint.** QEMU's exclusion
+  from claim-10 egress enforcement was previously prose ("dev/test only, not
+  wired"); it is now enforced by types — `qemu` is not a `WorkloadBackend`,
+  so it cannot be passed to the admitted launch path. `mock` likewise.
+- **Egress secret substitution on macOS becomes a required build.** When the
+  substitution transport becomes a no-default `WorkloadBackend` method,
+  libkrun and vz will not compile without implementing it. This reclassifies
+  the macOS substitution port from an optional fast-follow to a compliance
+  requirement. (The transparent :80/:443 terminator half entangles with the
+  rvproxy migration — ADR-082 / Plan 193 — and is resolved by a design
+  spike before implementation.)
+- **`BackendSecurityProfile` stays advisory.** It continues to drive
+  `doctor` posture output; it is no longer mistaken for the enforcement
+  mechanism.
+
+## Alternatives considered
+
+- **Capability matrix + witness gate** (a `BackendCapabilityMatrix` with a
+  `Supported`/`DeliberatelyUnsupported` cell per concern, plus an xtask gate
+  asserting each `Supported` cell has a witness). Rejected: for a *core*
+  feature, a `DeliberatelyUnsupported` cell documents a hole rather than
+  preventing it, which is the opposite of the goal. The compiler forbids the
+  actual failure (a missing implementation) for free.
+- **Every backend enforces (close the Tier-2 carve-out).** Put the core
+  obligation on `VmBackend` so even `qemu` must enforce egress. Deferred: it
+  reopens ADR-002's settled Tier-2 decision and forces enforcement onto a
+  dev/test backend that carries no untrusted workload. Recorded as a future
+  option.
+- **Shared launch funnel with a per-backend transport seam only
+  (no-op-proofing).** Lift all enforcement into one pipeline so a backend
+  cannot even supply an inert implementation. Deferred: a larger launch-path
+  refactor; adopt only if inert seams prove to be a real problem (a witness
+  gate is the cheaper escalation).
+
+Implementation is sequenced in Plan 197.


### PR DESCRIPTION
## What

Makes it structurally impossible for a workload-bearing backend to skip the shared security funnel. Introduces a `WorkloadBackend: VmBackend` marker trait and type-bars the admitted launch path on `&dyn WorkloadBackend`.

The egress-substitution gap (Plan 129 silently never reached libkrun/vz) was possible because cross-cutting enforcement was a free function called ad-hoc in per-backend `start()` paths. This is the structural fix — not a capability matrix (which only documents holes).

## Changes

- `WorkloadBackend: VmBackend` marker; impl for Firecracker/libkrun/vz only (not qemu/mock).
- `AnyBackend::as_workload_backend()` — exhaustive match; a new backend variant can't compile without a workload/non-workload decision.
- `require_workload_backend()` guard wired into all three admitted `up.rs` launch arms → qemu/mock are refused before `.start()`.
- ADR-083 (type-enforced tier split) + ADR-002 tier-matrix cross-ref; `BackendSecurityProfile` clarified as advisory.

## Result

qemu/mock are type-barred from the untrusted-workload path — ADR-002's Tier-2 carve-out is now a compile-time constraint, not prose. A new backend cannot reach the workload path without going through the shared funnel.

## Scope

Phase 1 (the type-bar). Phase 2 (funnel-ize substitution + build it on macOS) is design-spike-gated and tracked in Plan 197; the macOS terminator entangles with the rvproxy migration (ADR-082 / Plan 193).

## Verification

Workspace build clean; clippy `-D warnings` clean; nightly rustfmt clean; backend + cli tests green. Full workspace nextest gated by CI (mvm-backend test bin SIGKILLs under local macOS codesign).