### PR TITLE
docs(plan-197): Phase 2 design spike — split into 2a (mvm vsock channel) + 2b (rvproxy terminator)

### DIFF
--- a/specs/REFACTOR-STATUS.md
+++ b/specs/REFACTOR-STATUS.md
@@ -1,6 +1,6 @@
 # Refactor status — rollup checklist
 
-**Last updated: 2026-06-13** (Plan 185 test-isolation sweep advanced; ADR-080 program batch landed: Plans 188/186/187; Plan 189 WS-3 `dev status/down/up --json`; Plan 190 kernel egress close-out; Plan 191 declarative file materialization — ADR-080 P2-full; Plan 159: instant memory fork vm_full productized — admitted child, gvproxy-only invariant; Plan 118: Vz saved-standby warm pool claim live-validated + pool self-replenishes via detached re-warm (#840) + claim reuses admission image sha (#846); Plan 193 rvproxy network substrate proposed + gvproxy teardown/build-perf findings; Plan 195 builder-VM fingerprint narrowing planned; Plan 161 OCI-unpacker openat2 TOCTTOU fix landed (Plan 143 R2/R3 done) — writes resolve through `openat2(RESOLVE_IN_ROOT | RESOLVE_NO_SYMLINKS)`, follow-up routes whiteout removal through openat2 too; Plan 126 D1 forbidden-dep gate landed — closure ban on sigstore/opendal/pgp; Plan 124 D1.2a protocol type stubs — `protocol-v0.json` wired into `gen-stubs`/`check-stubs`, Python/TS protocol types generated + drift-checked; Plan 128 C3 Step 2 — `check-stubs` drift gate wired into ci.yml + ci-full.yml Lint, Linux codegen determinism verified; Sprint 55 (Plan 97) CLOSED — vz at parity with the macOS libkrun baseline, all criteria met-or-amended (Phase B ≥30%-win retired post-convergence, Phase C hash-match → functional parity, claim 5 Swift-equiv retired); Plan 152 WS-C fork primitive closed + WS-D nested-KVM out-of-scope; Plan 123 C3 met; egress secret substitution is Linux-only (FC/QEMU) — vz lacks it exactly as libkrun does; macOS port now tracked as Plan 197 (WorkloadBackend type-bar) which reclassifies it from optional fast-follow to a required build — Plan 197 Phase 1 (type-bar + qemu type-barred; mock kept as the ADR-045 hermetic test double + ADR-083) IMPLEMENTED on feat/plan-197-workload-backend, pending merge; Phase 2 substitution build is design-spike-gated)
+**Last updated: 2026-06-13** (Plan 185 test-isolation sweep advanced; ADR-080 program batch landed: Plans 188/186/187; Plan 189 WS-3 `dev status/down/up --json`; Plan 190 kernel egress close-out; Plan 191 declarative file materialization — ADR-080 P2-full; Plan 159: instant memory fork vm_full productized — admitted child, gvproxy-only invariant; Plan 118: Vz saved-standby warm pool claim live-validated + pool self-replenishes via detached re-warm (#840) + claim reuses admission image sha (#846); Plan 193 rvproxy network substrate proposed + gvproxy teardown/build-perf findings; Plan 195 builder-VM fingerprint narrowing planned; Plan 161 OCI-unpacker openat2 TOCTTOU fix landed (Plan 143 R2/R3 done) — writes resolve through `openat2(RESOLVE_IN_ROOT | RESOLVE_NO_SYMLINKS)`, follow-up routes whiteout removal through openat2 too; Plan 126 D1 forbidden-dep gate landed — closure ban on sigstore/opendal/pgp; Plan 124 D1.2a protocol type stubs — `protocol-v0.json` wired into `gen-stubs`/`check-stubs`, Python/TS protocol types generated + drift-checked; Plan 128 C3 Step 2 — `check-stubs` drift gate wired into ci.yml + ci-full.yml Lint, Linux codegen determinism verified; Sprint 55 (Plan 97) CLOSED — vz at parity with the macOS libkrun baseline, all criteria met-or-amended (Phase B ≥30%-win retired post-convergence, Phase C hash-match → functional parity, claim 5 Swift-equiv retired); Plan 152 WS-C fork primitive closed + WS-D nested-KVM out-of-scope; Plan 123 C3 met; egress secret substitution is Linux-only (FC/QEMU) — vz lacks it exactly as libkrun does; macOS port now tracked as Plan 197 (WorkloadBackend type-bar) which reclassifies it from optional fast-follow to a required build — Plan 197 Phase 1 (type-bar + qemu type-barred; mock kept as the ADR-045 hermetic test double + ADR-083) MERGED (#860/#861); Phase 2 spike DONE → 2a vsock substitution channel mvm-ready, 2b transparent :80/:443 terminator rvproxy-gated (Plan 193/ADR-082))
 
 > MAINTENANCE: keep this file current. Whenever you land, merge, or descope a
 > workstream in any plan below, tick/strike the matching box here in the SAME
@@ -45,7 +45,7 @@ details** below for the workstream-level state.
 - [x] **PLAN 191** — Declarative file materialization (ADR-080 P2-full) · 🟢 P2-full LANDED (FilesWrite lowers to the declarative `App.files` IR field, baked into the rootfs at build time via `mkFunctionService` `extraFiles`; the `before_start` shell hook is removed — file content/paths never reach a guest shell)
 - [ ] **PLAN 193** — rvproxy network substrate (replace gvproxy/passt) · 🔴 proposed, cross-repo — gated on rvproxy confirming libkrun-unixgram transport; biggest win = native flow API replaces the in-line claim-10 datapath wrapper (Plan 141)
 - [ ] **PLAN 195** — Builder-VM fingerprint narrowing · 🟡 planned — drop the redundant whole-workspace `Cargo.lock` from `builder_vm_source_fingerprint` (flake forbids buildRustPackage → L3 byte-hash already authoritative) to kill the ~9s Stage 0 re-materialize churn; Commit 2 tightens build.rs rerun triggers. Build-perf only, no claim impact. (194 reserved for ADR-081 A3)
-- [ ] **PLAN 197** — `WorkloadBackend` type-bar (core security features non-skippable) · 🟡 Phase 1 IMPLEMENTED (feat/plan-197-workload-backend, pending merge), Phase 2 spike-gated — marker trait gates the admitted launch path so qemu (a real dev/test VMM) is type-barred and a new backend can't reach the funnel without the shared enforcement (mock is permitted as the ADR-045 hermetic test double — carries no real workload); Phase 2 funnel-izes egress substitution + builds it on macOS (reclassifies the vz/libkrun substitution gap from optional to a required build). Arose from the Sprint 55 vz closeout finding.
+- [ ] **PLAN 197** — `WorkloadBackend` type-bar (core security features non-skippable) · 🟡 Phase 1 MERGED (#860); Phase 2 spike DONE → 2a (vsock substitution channel) mvm-ready, 2b (transparent :80/:443 terminator) rvproxy-gated — marker trait gates the admitted launch path so qemu (a real dev/test VMM) is type-barred and a new backend can't reach the funnel without the shared enforcement (mock is permitted as the ADR-045 hermetic test double — carries no real workload). Arose from the Sprint 55 vz closeout finding.
 
 ## Plan details
 
@@ -564,9 +564,14 @@ PLAN 193 — rvproxy network substrate (replace gvproxy/passt)  🔴 proposed, c
   at specs/plans/014-mvm-adoption-requirements.md. Gated on WS-1: rvproxy confirming the
   libkrun-unixgram transport (mvm's default macOS backend). Not-a-fix findings recorded in the
   plan (gvproxy has no log-level flag; nix-seed already cached for normal use; build slowness is
-  the base-VM fingerprint churn, a separate change). Plan: specs/plans/193-rvproxy-network-substrate.md
+  the base-VM fingerprint churn, a separate change).
+  NEW REQUIREMENT (Plan 197 Phase 2b): rvproxy must add transparent :80/:443 interception → a host
+  terminator port (the macOS analogue of FC's nft PREROUTING REDIRECT) so egress secret substitution's
+  transparent half works on libkrun/vz — macOS has no nft and the in-process bridge sees only
+  post-gateway frames, so this can only live in the gateway. Add to rvproxy's mvm-adoption requirements.
+  Plan: specs/plans/193-rvproxy-network-substrate.md
 
-PLAN 197 — WorkloadBackend type-bar (core security features non-skippable)  🟡 Phase 1 IMPLEMENTED
+PLAN 197 — WorkloadBackend type-bar (core security features non-skippable)  🟡 Phase 1 MERGED; Phase 2 spike DONE
   Arose from the Sprint 55 vz closeout: egress secret substitution (Plan 129) silently never
   reached libkrun/vz because it was a free function called ad-hoc in per-backend start paths.
   Fix is structural, not a capability matrix (rejected — documents holes, doesn't prevent them).
@@ -578,14 +583,16 @@ PLAN 197 — WorkloadBackend type-bar (core security features non-skippable)  �
       untrusted-workload path (ADR-002 Tier-2 carve-out is now a type constraint — ADR-083 + ADR-002
       cross-ref). BackendSecurityProfile kept advisory. Spec+quality reviewed; CI Test lane caught that
       barring mock broke the ADR-045 hermetic lifecycle tests → mock permitted; workspace build/clippy/
-      nightly-fmt green. Branch feat/plan-197-workload-backend,
-      pending merge. (Landed against up.rs without a Plan 189 collision — that PR had not touched up.rs.)
-  [ ] Phase 2 — funnel-ize substitution + build it on macOS (design-spike-gated): lift
-      spawn_substitution_endpoint into the shared funnel; add no-default `egress_substitution_transport()`
-      seam; implement for FC (nft) + libkrun/vz (macOS transport). Spike must first resolve the macOS
-      :80/:443 terminator, which ENTANGLES with rvproxy (Plan 193 / ADR-082 — likely lives in rvproxy,
-      not gvproxy). Reclassifies the vz/libkrun substitution gap from optional fast-follow to required build.
-  Design + bite-sized plan: specs/plans/197-workload-backend-core-trait.md
+      nightly-fmt green. MERGED #860 (code+ADR) / #861 (docs closeout+plan). (Landed against up.rs
+      without a Plan 189 collision — that PR had not touched up.rs.)
+  [x] Phase 2 design spike DONE: terminator → rvproxy (not gvproxy/standalone). Phase 2 SPLIT into:
+  [ ] 2a (mvm-side, ready): register SUBSTITUTION_PORT 5253 on libkrun+vz supervisors; add no-default
+      `egress_substitution_transport()` seam (FC=nft/TCP terminator, macOS=Uds vsock-5253 channel); lift
+      spawn_substitution_endpoint into the funnel. Delivers explicit-HTTP_PROXY substitution on macOS.
+  [ ] 2b (rvproxy-gated, cross-repo): transparent :80/:443 terminator must live in rvproxy (no nft on
+      macOS; the in-process bridge sees only post-gateway frames). Add to rvproxy's mvm-adoption
+      requirements (Plan 193 / ADR-082); gated on the rvproxy migration.
+  Design + spike output + bite-sized plan: specs/plans/197-workload-backend-core-trait.md
 ```
 
 ## Security claims

--- a/specs/plans/197-workload-backend-core-trait.md
+++ b/specs/plans/197-workload-backend-core-trait.md
@@ -219,14 +219,15 @@ clippy / nightly-fmt green. Pending merge.
       posture); enforcement is the type-bar. Recorded in its doc comment.
 - [x] ADR amendment: ADR-083 added; ADR-002 tier matrix cross-refs it.
 
-**Phase 2 — funnel-ize substitution + macOS build (design spike first):**
-- [ ] Design spike: resolve the macOS terminator (rvproxy vs. standalone)
-      and the `SUBSTITUTION_PORT` vsock-bridge hop; output the task list.
-- [ ] Lift `spawn_substitution_endpoint`/`reap_substitution_endpoint` out of
-      `qemu.rs`/`microvm.rs` `start()` into the shared funnel.
-- [ ] Add the no-default `egress_substitution_transport()` seam; implement
-      for Firecracker (existing nft terminator) and libkrun/vz (new macOS
-      transport) in the same change.
+**Phase 2 — funnel-ize substitution + macOS build (spike ✅ done — see Task 7):**
+- [x] Design spike: resolved. Terminator → rvproxy (not gvproxy/standalone);
+      Phase 2 splits into **2a** (vsock substitution channel, mvm-side, ready)
+      and **2b** (transparent :80/:443 terminator, rvproxy-gated, cross-repo).
+- [ ] **Phase 2a (Task 8):** register `SUBSTITUTION_PORT` 5253 on libkrun + vz
+      supervisors; add `egress_substitution_transport()` seam (FC = nft/TCP,
+      macOS = `Uds` vsock-5253 channel); lift substitution into the funnel.
+- [ ] **Phase 2b (Task 9):** rvproxy gains transparent :80/:443 interception
+      (cross-repo requirement); then wire the macOS terminator transport.
 
 ## Testing
 
@@ -453,27 +454,61 @@ let _workload = mvm_backend::workload_backend::require_workload_backend(&backend
 
 ## Phase 2 — funnel-ize substitution + macOS build
 
-> Phase 2 is **gated on a design spike** — the macOS :80/:443 terminator is
-> not yet designed and entangles with the rvproxy migration (ADR-082).
-> Executable code steps for the terminator are produced BY the spike; writing
-> them before the spike would be fabrication. The spike is the first task.
+### Task 7: design spike — ✅ DONE
 
-### Task 7: design spike (no production code)
+The spike resolved both questions and **splits Phase 2 into a mvm-buildable
+half (2a) and an rvproxy-gated half (2b).** Findings:
 
-- [ ] Resolve and write up (append to this plan): (a) terminator placement —
-      in the rvproxy gateway vs. a standalone macOS terminator — and how guest
-      `:80`/`:443` is steered to it without nft; (b) the `SUBSTITUTION_PORT`
-      (5253) vsock→Uds bridge hop in `vz_objc.rs` / the libkrun supervisor,
-      reusing `EndpointTransport::Uds`. Output: the concrete Task 8+ list.
-- [ ] Gate check: do not start Task 8 until the spike output is reviewed.
+**The substitution mechanism has two halves; only one is mvm-side.**
+- **Explicit channel (the vsock substitution channel).** The guest receives
+  `HTTP_PROXY` + placeholders and dials `SUBSTITUTION_PORT` (5253) over
+  AF_VSOCK; the host endpoint injects the real credential. This is fully
+  buildable in mvm on macOS:
+  - The endpoint already supports `EndpointTransport::Uds { path }`
+    (`substitution_endpoint.rs`); on Linux/QEMU it uses `Vsock`, FC uses the
+    per-port vsock→Uds proxy.
+  - macOS supervisors already bridge each guest vsock port to a host unix
+    socket at the `<vm_state_dir>/vsock-<port>.sock` convention
+    (`mvm_core::config`), e.g. the agent on 5252.
+  - **The only gap:** neither the libkrun nor vz supervisor registers port
+    **5253**, and the backend never spawns the endpoint with the `Uds`
+    transport pointing at `vsock-5253.sock`. That is the whole Phase 2a wiring.
+- **Transparent :80/:443 terminator.** On Linux this is an nft PREROUTING
+  REDIRECT (`egress_redirect.rs`, per-VM table, `iifname`-scoped) → a host
+  TCP terminator on `0.0.0.0:<18080+slot>`. **macOS has no nftables, and the
+  in-process bridge only sees post-gateway L2 frames — so the terminator
+  cannot live mvm-side.** It must live in the userspace gateway's TCP/IP
+  stack. gvproxy is vendored Go being retired, so the terminator belongs in
+  **rvproxy** (the in-house Rust gateway — ADR-082 / Plan 193), where it also
+  composes with rvproxy's native flow API. This is Phase 2b and is gated on
+  rvproxy + a cross-repo requirement.
 
-### Task 8+ (expanded by the spike)
+**Decision:** terminator → rvproxy (not gvproxy, not a standalone macOS
+process). The explicit vsock channel ships first, independently.
 
-- [ ] Lift `spawn_substitution_endpoint` / `reap_substitution_endpoint` from
-      `qemu.rs` + `microvm.rs` `start()` into the shared admitted-launch funnel.
+### Task 8 (Phase 2a — vsock substitution channel; mvm-side, ready)
+
+- [ ] Register `SUBSTITUTION_PORT` (5253) on the libkrun supervisor
+      (`.add_vsock_port`) and the vz supervisor (`vz_objc.rs` bridge hop) so
+      the guest→host channel lands at `<vm_state_dir>/vsock-5253.sock`.
 - [ ] Add the no-default `egress_substitution_transport()` seam to
-      `WorkloadBackend`; implement for Firecracker (existing nft terminator)
-      and libkrun/vz (the macOS transport from the spike) in one change so the
-      no-default method never exists without an implementation.
+      `WorkloadBackend`; Firecracker returns its existing nft/TCP terminator
+      transport, libkrun/vz return the `Uds { path: vsock-5253.sock }` channel
+      transport (terminator absent until Phase 2b).
+- [ ] Lift `spawn_substitution_endpoint` / `reap_substitution_endpoint` from
+      `qemu.rs` + `microvm.rs` `start()` into the shared admitted-launch funnel;
+      the funnel reads `egress_substitution_transport()` per backend.
 - [ ] Live-validate on macOS-26: a `SecretRef` workload on `--hypervisor vz`
-      sees only the placeholder; the host endpoint injects the real credential.
+      with an explicit `HTTP_PROXY` sees only the placeholder; the host
+      endpoint injects the real credential over the vsock channel.
+
+### Task 9 (Phase 2b — transparent :80/:443 terminator; rvproxy-gated, cross-repo)
+
+- [ ] **rvproxy requirement (separate repo):** rvproxy must support a
+      transparent :80/:443 interception → host terminator port (the macOS
+      analogue of the nft REDIRECT). Add this to rvproxy's mvm-adoption
+      requirements; it is gated on the rvproxy migration (Plan 193 / ADR-082).
+- [ ] Once rvproxy lands it: extend the macOS `egress_substitution_transport()`
+      to carry the terminator endpoint, and wire the gateway to steer guest
+      :80/:443 to it. Live-validate transparent (non-proxy-aware) egress
+      substitution on vz/libkrun.


### PR DESCRIPTION
## What

Records the Plan 197 **Phase 2 design spike** output. Docs-only.

The macOS egress-substitution work splits into two halves with different homes:

- **2a — vsock substitution channel (explicit `HTTP_PROXY`): buildable in mvm now.** The endpoint already supports `EndpointTransport::Uds`; macOS supervisors already bridge guest vsock ports to `<vm_state_dir>/vsock-<port>.sock`. The only gap is registering `SUBSTITUTION_PORT` (5253) on the libkrun/vz supervisors + spawning the endpoint with the Uds transport.
- **2b — transparent :80/:443 terminator: belongs in rvproxy.** macOS has no nftables and the in-process bridge only sees post-gateway frames, so the terminator must live in the userspace gateway. gvproxy is vendored Go being retired → the terminator goes in **rvproxy** (ADR-082 / Plan 193), a cross-repo requirement.

## Decision

Terminator → rvproxy (not gvproxy, not standalone). The explicit vsock channel (2a) ships first, independently.

## Files

`specs/plans/197-workload-backend-core-trait.md` (spike output + split task lists), `specs/REFACTOR-STATUS.md` (Plan 197 + Plan 193 rvproxy requirement). No code.