### PR TITLE
feat: macOS egress secret substitution — vsock-5253 channel on libkrun + vz (Plan 197 Phase 2a)

### DIFF
--- a/crates/mvm-backend/src/checkpoint/mod.rs
+++ b/crates/mvm-backend/src/checkpoint/mod.rs
@@ -1208,6 +1208,7 @@ mod tests {
             vsock: mvm_build::vz::VsockConfig {
                 ports: vec![],
                 socket_dir: dir.join("vsock").to_string_lossy().into_owned(),
+                host_listen_ports: vec![],
             },
             console_output_path: None,
             network: Some(mvm_build::vz::NetworkConfig::Gvproxy {
@@ -1577,6 +1578,7 @@ mod tests {
             vsock: mvm_build::vz::VsockConfig {
                 ports: vec![],
                 socket_dir: dir.join("vsock").to_string_lossy().into_owned(),
+                host_listen_ports: vec![],
             },
             console_output_path: None,
             network: None,

--- a/crates/mvm-backend/src/egress_shared.rs
+++ b/crates/mvm-backend/src/egress_shared.rs
@@ -1,0 +1,78 @@
+//! Cfg-free egress-substitution plan decode for the macOS workload backends.
+//!
+//! libkrun (and vz, next commit) decode the admitted plan's secret bindings
+//! with no OS gate. The Firecracker path still has its own Linux-gated copy in
+//! `microvm.rs`; collapsing that into this function is a tracked cleanup (it
+//! edits Linux-only code and wants a Linux-target check) — until then this is
+//! the macOS-side copy, not yet the single shared one.
+
+use anyhow::Result;
+use std::path::Path;
+
+/// Decode the admitted plan's egress secret bindings from `<state_dir>/plan.json`.
+///
+/// `Some((secrets, redaction, tenant))` when the admitted plan carries egress
+/// secrets, else `None` (legacy / non-admitted / no-secret boot — nothing to
+/// wire). A missing `plan.json` or an undecodable placeholder plan is the no-op
+/// path, not an error.
+pub(crate) fn decode_plan_secrets_from_state(
+    state_dir: &Path,
+) -> Result<
+    Option<(
+        Vec<mvm_core::plan::SecretBinding>,
+        mvm_core::policy::RedactionPolicy,
+        String,
+    )>,
+> {
+    let plan_path = state_dir.join("plan.json");
+    let plan_json = match std::fs::read_to_string(&plan_path) {
+        Ok(s) => s,
+        Err(e) if e.kind() == std::io::ErrorKind::NotFound => return Ok(None),
+        Err(e) => {
+            return Err(anyhow::anyhow!(
+                "read plan.json at {} for egress substitution: {e}",
+                plan_path.display()
+            ));
+        }
+    };
+    // Both producers land here: the pre-start persist writes the bare
+    // `ExecutionPlan` (the shape the firecracker bridge parses too) and the
+    // gateway-bridge stash writes the signed envelope. Accept either.
+    let plan = match mvm_core::plan::plan_from_admitted_json(&plan_json) {
+        Ok(p) => p,
+        Err(e) => {
+            tracing::warn!(error = %e, "plan.json not a decodable admitted plan; skipping egress substitution");
+            return Ok(None);
+        }
+    };
+    if plan.secrets.is_empty() {
+        return Ok(None);
+    }
+    Ok(Some((plan.secrets, plan.redaction, plan.tenant.0)))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn returns_none_when_no_plan_json() {
+        let dir = std::env::temp_dir().join(format!("mvm-egress-shared-{}", std::process::id()));
+        std::fs::create_dir_all(&dir).unwrap();
+        // No plan.json in the fresh dir → no-op path, not an error.
+        let out = decode_plan_secrets_from_state(&dir).unwrap();
+        assert!(out.is_none());
+        std::fs::remove_dir_all(&dir).ok();
+    }
+
+    #[test]
+    fn returns_none_when_plan_json_undecodable() {
+        let dir =
+            std::env::temp_dir().join(format!("mvm-egress-shared-bad-{}", std::process::id()));
+        std::fs::create_dir_all(&dir).unwrap();
+        std::fs::write(dir.join("plan.json"), b"not a plan").unwrap();
+        let out = decode_plan_secrets_from_state(&dir).unwrap();
+        assert!(out.is_none());
+        std::fs::remove_dir_all(&dir).ok();
+    }
+}

--- a/crates/mvm-backend/src/lib.rs
+++ b/crates/mvm-backend/src/lib.rs
@@ -84,7 +84,7 @@ pub use libkrun::LibkrunBackend;
 pub use mock::MockBackend;
 pub use qemu::QemuBackend;
 pub use vz::VzBackend;
-pub use workload_backend::WorkloadBackend;
+pub use workload_backend::{EgressSubstitutionTransport, WorkloadBackend};
 
 /// The per-VM egress-TLS cert/key split helper. `mvmctl up`
 /// (mvm-cli) calls this while assembling the guest secrets drive: the cert is

--- a/crates/mvm-backend/src/lib.rs
+++ b/crates/mvm-backend/src/lib.rs
@@ -48,6 +48,9 @@ pub mod compat;
 /// to the guest TAP) steering guest :80 to the host-side substitution
 /// terminator. Linux-only mechanism; consumed by the FC path.
 pub mod egress_redirect;
+/// Cfg-free decode of the admitted plan's egress secret bindings, shared by
+/// the libkrun + Firecracker substitution-endpoint spawn paths.
+pub(crate) mod egress_shared;
 pub mod firecracker;
 pub mod handle_registry;
 pub mod image;
@@ -91,7 +94,7 @@ pub use workload_backend::{EgressSubstitutionTransport, WorkloadBackend};
 /// pushed onto the drive, the key is persisted host-side for the terminator
 /// endpoint. See [`substitution_spawn::build_egress_tls_delivery`].
 pub use substitution_spawn::{
-    EGRESS_CERT_DRIVE_NAME, EgressTlsDelivery, build_egress_tls_delivery,
+    EGRESS_CERT_DRIVE_NAME, EgressTlsDelivery, EndpointTransport, build_egress_tls_delivery,
 };
 
 /// Crate-wide test serialization for tests that mutate `HOME` or

--- a/crates/mvm-backend/src/libkrun.rs
+++ b/crates/mvm-backend/src/libkrun.rs
@@ -46,41 +46,7 @@ use std::time::{Duration, Instant, SystemTime};
 /// libkrun backend (Linux KVM / macOS Hypervisor.framework).
 pub struct LibkrunBackend;
 
-/// RAII reaper for the per-VM substitution endpoint, armed during `start`
-/// while the VM is being wired and dropped on any early-return so the
-/// decrypted-secret process can't outlive a failed launch. Defused once the
-/// VM is fully up (the normal `stop` path then owns teardown). Mirrors the FC
-/// `EndpointGuard` in `microvm.rs`.
-struct EndpointGuard {
-    vm_name: Option<String>,
-}
-
-impl EndpointGuard {
-    fn new(vm_name: &str) -> Self {
-        Self {
-            vm_name: Some(vm_name.to_string()),
-        }
-    }
-    /// A guard for a VM that spawned no endpoint (no secrets) — Drop is a no-op.
-    fn defused() -> Self {
-        Self { vm_name: None }
-    }
-    fn defuse(&mut self) {
-        self.vm_name = None;
-    }
-}
-
-impl Drop for EndpointGuard {
-    fn drop(&mut self) {
-        if let Some(ref name) = self.vm_name {
-            tracing::warn!(vm = %name, "EndpointGuard: reaping orphaned substitution endpoint");
-            crate::substitution_spawn::reap_substitution_endpoint(
-                &mvm_core::config::vm_state_dir(name),
-                name,
-            );
-        }
-    }
-}
+use crate::substitution_spawn::EndpointGuard;
 
 /// Spawn the per-VM substitution endpoint when the admitted plan carries egress
 /// secrets, returning an armed [`EndpointGuard`]; a secret-free plan (or no

--- a/crates/mvm-backend/src/libkrun.rs
+++ b/crates/mvm-backend/src/libkrun.rs
@@ -46,6 +46,79 @@ use std::time::{Duration, Instant, SystemTime};
 /// libkrun backend (Linux KVM / macOS Hypervisor.framework).
 pub struct LibkrunBackend;
 
+/// RAII reaper for the per-VM substitution endpoint, armed during `start`
+/// while the VM is being wired and dropped on any early-return so the
+/// decrypted-secret process can't outlive a failed launch. Defused once the
+/// VM is fully up (the normal `stop` path then owns teardown). Mirrors the FC
+/// `EndpointGuard` in `microvm.rs`.
+struct EndpointGuard {
+    vm_name: Option<String>,
+}
+
+impl EndpointGuard {
+    fn new(vm_name: &str) -> Self {
+        Self {
+            vm_name: Some(vm_name.to_string()),
+        }
+    }
+    /// A guard for a VM that spawned no endpoint (no secrets) — Drop is a no-op.
+    fn defused() -> Self {
+        Self { vm_name: None }
+    }
+    fn defuse(&mut self) {
+        self.vm_name = None;
+    }
+}
+
+impl Drop for EndpointGuard {
+    fn drop(&mut self) {
+        if let Some(ref name) = self.vm_name {
+            tracing::warn!(vm = %name, "EndpointGuard: reaping orphaned substitution endpoint");
+            crate::substitution_spawn::reap_substitution_endpoint(
+                &mvm_core::config::vm_state_dir(name),
+                name,
+            );
+        }
+    }
+}
+
+/// Spawn the per-VM substitution endpoint when the admitted plan carries egress
+/// secrets, returning an armed [`EndpointGuard`]; a secret-free plan (or no
+/// `plan.json`) yields a defused no-op guard. The libkrun guest reaches the
+/// endpoint by dialing `connect_host_vsock(SUBSTITUTION_PORT)`; libkrun proxies
+/// that to the per-VM UDS the endpoint binds, so the transport is `Uds`. No
+/// transparent terminator on this path (`terminator_listen: None`), hence no
+/// per-VM TLS intermediate.
+fn spawn_libkrun_egress_endpoint_if_needed(
+    vm_name: &str,
+    state_dir: &Path,
+) -> Result<EndpointGuard> {
+    use crate::substitution_spawn::{
+        EndpointTransport, SubstitutionSpawnParams, spawn_substitution_endpoint,
+    };
+    let Some((secrets, redaction, tenant)) =
+        crate::egress_shared::decode_plan_secrets_from_state(state_dir)?
+    else {
+        return Ok(EndpointGuard::defused());
+    };
+    spawn_substitution_endpoint(SubstitutionSpawnParams {
+        vm_name,
+        state_dir,
+        tenant: &tenant,
+        secrets: &secrets,
+        redaction: &redaction,
+        transport: EndpointTransport::Uds {
+            path: mvm_core::config::vm_vsock_port_socket(
+                vm_name,
+                mvm_guest::vsock::SUBSTITUTION_PORT,
+            ),
+        },
+        terminator_listen: None,
+        tls_intermediate: None,
+    })?;
+    Ok(EndpointGuard::new(vm_name))
+}
+
 /// How long [`LibkrunBackend::start`] waits for the supervisor to
 /// write its PID file before giving up and killing the child.
 const PID_FILE_TIMEOUT: Duration = Duration::from_secs(5);
@@ -125,7 +198,11 @@ fn krun_context_base(
         .with_vsock_socket_dir(state_dir.to_string_lossy().into_owned())
         .add_vsock_port(mvm_guest::vsock::GUEST_AGENT_PORT)
         // Workload exit-code capture (listen=false → host binds).
-        .add_host_listen_port(mvm_guest::vsock::WORKLOAD_EXIT_PORT);
+        .add_host_listen_port(mvm_guest::vsock::WORKLOAD_EXIT_PORT)
+        // Egress substitution channel (listen=false → host binds). Registered
+        // unconditionally; fail-closed: when the plan carries no secrets nothing
+        // binds the UDS, so a stray guest dial gets ECONNREFUSED.
+        .add_host_listen_port(mvm_guest::vsock::SUBSTITUTION_PORT);
     krun.rootfs_path = None;
     // Select the gateway through the same
     // `resolve_networking_mode` the builder VM + cold path use (TSI is rejected by the
@@ -476,15 +553,30 @@ impl VmBackend for LibkrunBackend {
             std::thread::sleep(Duration::from_millis(50));
         }
 
+        // The supervisor is up and its vsock listeners are bound. Spawn the
+        // egress substitution endpoint if the admitted plan carries secrets so
+        // the guest's egress can resolve placeholders host-side (the guest never
+        // holds the real secret). Armed via the guard until the VM is fully up;
+        // a spawn failure rolls the launch back (fail closed). When the plan has
+        // no secrets this is a defused no-op.
+        let mut endpoint_guard = spawn_libkrun_egress_endpoint_if_needed(&config.name, &state_dir)?;
+
         ui::success(&format!(
             "libkrun VM '{}' started (pid file: {}).",
             config.name,
             pid_file.display()
         ));
+        endpoint_guard.defuse();
         Ok(VmId(config.name.clone()))
     }
 
     fn stop(&self, id: &VmId) -> Result<()> {
+        // Reap the per-VM substitution endpoint first (no-op when none was
+        // spawned) so a crashed VM's decrypted-secret process can't outlive the
+        // guest. Mirrors the FC `stop_vm` ordering — safe because reap is a
+        // no-op when nothing exists, even before the not-running early return.
+        crate::substitution_spawn::reap_substitution_endpoint(&vm_state_dir(&id.0), &id.0);
+
         let pid_path = vm_libkrun_pid(&id.0);
         let pid = match read_pid(&pid_path) {
             Some(p) => p,
@@ -1300,6 +1392,57 @@ mod tests {
                 .vsock_ports
                 .contains(&mvm_guest::vsock::WORKLOAD_EXIT_PORT),
             "WORKLOAD_EXIT_PORT must not appear in vsock_ports"
+        );
+    }
+
+    #[test]
+    fn build_supervisor_config_registers_substitution_port() {
+        // The egress substitution port is a host-listen port (the endpoint
+        // binds the UDS, the guest dials it) — registered unconditionally so
+        // libkrun proxies the guest's connect. Fail-closed: nothing binds the
+        // UDS unless the plan carries secrets.
+        let config = VmStartConfig {
+            name: "subst-port-test".into(),
+            rootfs_path: "/tmp/rootfs.ext4".into(),
+            kernel_path: Some("/tmp/vmlinux".into()),
+            cpus: 1,
+            memory_mib: 256,
+            ..Default::default()
+        };
+        let tmp = tempfile::tempdir().unwrap();
+        let cfg = build_supervisor_config(&config, tmp.path()).expect("build");
+        assert!(
+            cfg.krun
+                .host_listen_ports
+                .contains(&mvm_guest::vsock::SUBSTITUTION_PORT),
+            "SUBSTITUTION_PORT must be in host_listen_ports"
+        );
+        assert!(
+            !cfg.krun
+                .vsock_ports
+                .contains(&mvm_guest::vsock::SUBSTITUTION_PORT),
+            "SUBSTITUTION_PORT must not appear in vsock_ports"
+        );
+    }
+
+    /// No `plan.json` (or a secret-free plan) ⇒ no endpoint is spawned and the
+    /// returned guard is defused (its Drop is a no-op, so an early return can't
+    /// reap a process that was never started).
+    #[test]
+    fn libkrun_substitution_not_spawned_when_no_secrets() {
+        let tmp = tempfile::tempdir().unwrap();
+        // Empty state dir: no plan.json at all.
+        let guard = spawn_libkrun_egress_endpoint_if_needed("no-secrets-vm", tmp.path())
+            .expect("no-secrets path must succeed");
+        assert!(
+            guard.vm_name.is_none(),
+            "a secret-free plan must yield a defused (no-op) guard"
+        );
+        // No pidfile was written (nothing spawned).
+        assert!(
+            !tmp.path()
+                .join(crate::substitution_spawn::SUBST_PID_FILE)
+                .exists()
         );
     }
 }

--- a/crates/mvm-backend/src/microvm.rs
+++ b/crates/mvm-backend/src/microvm.rs
@@ -2557,15 +2557,18 @@ fn spawn_egress_endpoint(config: &FlakeRunConfig) -> Result<EndpointGuard> {
     // the sidecar. Hand the KEY to the endpoint so the `https` terminator can
     // mint per-SNI leaves; it never reaches the guest. Absent ⇒ `http`-only.
     let tls_intermediate = read_egress_intermediate(&state_dir)?;
-    spawn_substitution_endpoint(
-        name,
-        &state_dir,
-        &tenant,
-        &secrets,
-        &redaction,
-        Some(listen),
+    spawn_substitution_endpoint(crate::substitution_spawn::SubstitutionSpawnParams {
+        vm_name: name,
+        state_dir: &state_dir,
+        tenant: &tenant,
+        secrets: &secrets,
+        redaction: &redaction,
+        transport: crate::substitution_spawn::EndpointTransport::Vsock {
+            port: mvm_guest::vsock::SUBSTITUTION_PORT,
+        },
+        terminator_listen: Some(listen),
         tls_intermediate,
-    )?;
+    })?;
     Ok(EndpointGuard::new(name))
 }
 

--- a/crates/mvm-backend/src/qemu.rs
+++ b/crates/mvm-backend/src/qemu.rs
@@ -254,15 +254,20 @@ impl VmBackend for QemuBackend {
                     // to install, so `terminator_listen: None`. The vsock
                     // substitution channel alone is unchanged.
                     if let Err(e) = spawn_substitution_endpoint(
-                        &config.name,
-                        &state_dir,
-                        tenant,
-                        &secrets,
-                        &redaction,
-                        None,
-                        // No transparent terminator on slirp ⇒ no TLS leg, so no
-                        // per-VM intermediate (https termination is FC-scoped).
-                        None,
+                        crate::substitution_spawn::SubstitutionSpawnParams {
+                            vm_name: &config.name,
+                            state_dir: &state_dir,
+                            tenant,
+                            secrets: &secrets,
+                            redaction: &redaction,
+                            transport: crate::substitution_spawn::EndpointTransport::Vsock {
+                                port: mvm_guest::vsock::SUBSTITUTION_PORT,
+                            },
+                            terminator_listen: None,
+                            // No transparent terminator on slirp ⇒ no TLS leg, so
+                            // no per-VM intermediate (https is FC-scoped).
+                            tls_intermediate: None,
+                        },
                     ) {
                         rollback_qemu(&state_dir, &pid_file);
                         return Err(e);

--- a/crates/mvm-backend/src/substitution_spawn.rs
+++ b/crates/mvm-backend/src/substitution_spawn.rs
@@ -293,6 +293,41 @@ fn read_handshake_line(
     }
 }
 
+/// RAII reaper for the per-VM substitution endpoint, armed while a backend's
+/// `start` is wiring the VM and dropped on any early-return so the
+/// decrypted-secret process can't outlive a failed launch. Defused once the VM
+/// is fully up (the normal `stop` path then owns teardown). Shared by the
+/// libkrun and vz backends — one definition so the spawn/reap moat can't drift.
+pub(crate) struct EndpointGuard {
+    /// `Some(name)` while armed; `None` once defused. Read by backend tests to
+    /// assert the no-secrets path yields a no-op guard.
+    pub(crate) vm_name: Option<String>,
+}
+
+impl EndpointGuard {
+    pub(crate) fn new(vm_name: &str) -> Self {
+        Self {
+            vm_name: Some(vm_name.to_string()),
+        }
+    }
+    /// A guard for a VM that spawned no endpoint (no secrets) — Drop is a no-op.
+    pub(crate) fn defused() -> Self {
+        Self { vm_name: None }
+    }
+    pub(crate) fn defuse(&mut self) {
+        self.vm_name = None;
+    }
+}
+
+impl Drop for EndpointGuard {
+    fn drop(&mut self) {
+        if let Some(ref name) = self.vm_name {
+            tracing::warn!(vm = %name, "EndpointGuard: reaping orphaned substitution endpoint");
+            reap_substitution_endpoint(&mvm_core::config::vm_state_dir(name), name);
+        }
+    }
+}
+
 /// Reap the per-VM substitution endpoint (if this VM spawned one) so its
 /// decrypted secrets don't outlive the guest, and drop the pid + env sidecars.
 /// Best-effort + idempotent: a VM with no endpoint (no secrets) is a no-op. The

--- a/crates/mvm-backend/src/substitution_spawn.rs
+++ b/crates/mvm-backend/src/substitution_spawn.rs
@@ -13,10 +13,28 @@ use crate::microvm::DriveFile;
 use anyhow::{Result, anyhow, bail};
 use mvm_core::crypto::egress_ca::EgressCa;
 use mvm_core::plan::SecretBinding;
+use serde::{Deserialize, Serialize};
 use std::net::SocketAddr;
 use std::path::{Path, PathBuf};
 use std::process::Command;
 use std::time::Duration;
+
+/// How the guest reaches the substitution endpoint. Backend-shaped: QEMU's
+/// `vhost-vsock` gives a real guest→host AF_VSOCK path, so the host binds an
+/// AF_VSOCK listener; Firecracker/libkrun route guest→host through a per-port
+/// UDS the in-process VMM proxies, so the host binds that UDS.
+///
+/// This is the wire contract the `mvm-substitution-endpoint` bin parses on
+/// stdin; mvm-hostd re-exports it so the bin and its tests keep one definition.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(tag = "kind", rename_all = "snake_case")]
+pub enum EndpointTransport {
+    /// Host AF_VSOCK listener on this port (QEMU). The guest dials
+    /// `connect_host_vsock(SUBSTITUTION_PORT)`.
+    Vsock { port: u32 },
+    /// Host UDS the per-port vsock proxy forwards to (Firecracker/libkrun).
+    Uds { path: PathBuf },
+}
 
 /// The per-VM egress intermediate cert lands in the guest's `mvm-secrets`
 /// drive under this filename; the mkGuest boot step appends it to the guest
@@ -121,27 +139,54 @@ fn resolve_substitution_endpoint_path() -> Result<PathBuf> {
     bail!("could not locate the {BIN} binary (set MVM_SUBSTITUTION_ENDPOINT_PATH)")
 }
 
+/// Inputs to [`spawn_substitution_endpoint`]. Grouped into a struct (rather
+/// than threading bare positional args) so the backend-shaped fields —
+/// `transport` (vsock vs UDS), `terminator_listen`, `tls_intermediate` — read
+/// at the callsite and stay under the argument-count lint.
+pub struct SubstitutionSpawnParams<'a> {
+    /// VM name; keys the per-VM substitution env path.
+    pub vm_name: &'a str,
+    /// Per-VM state dir; holds the endpoint PID file.
+    pub state_dir: &'a Path,
+    /// Tenant id stamped into the endpoint config.
+    pub tenant: &'a str,
+    /// The admitted plan's secret bindings handed to the endpoint on stdin.
+    pub secrets: &'a [SecretBinding],
+    /// Per-destination redaction policy from the signed plan.
+    pub redaction: &'a mvm_core::policy::RedactionPolicy,
+    /// Backend-shaped guest→host channel: `Vsock` (FC/QEMU) or `Uds`
+    /// (libkrun/vz, the per-VM socket the VMM proxies).
+    pub transport: EndpointTransport,
+    /// `Some(addr)` ⇒ also run the transparent HTTP terminator on that host TCP
+    /// addr (FC nft REDIRECT feeds it). `None` on slirp / in-process VMMs.
+    pub terminator_listen: Option<SocketAddr>,
+    /// `(cert_pem, key_pem)` of the per-VM intermediate for the `https`
+    /// terminator; the key never reaches the guest. `None` ⇒ `http`-only.
+    pub tls_intermediate: Option<(String, String)>,
+}
+
 /// Spawn the per-VM `mvm-substitution-endpoint` moat. Hands it the
 /// plan's secret bindings on stdin, reads back the minted `(guest var,
 /// placeholder)` handshake line, and persists it to the per-VM substitution env
 /// file for the invoke path to inject (`HTTP_PROXY` + placeholder vars). The
-/// endpoint binds a host AF_VSOCK listener on `SUBSTITUTION_PORT` (the guest→
-/// host substitution channel); when `terminator_listen` is `Some`, it *also*
-/// runs the transparent HTTP terminator on that host TCP addr — the FC
-/// nft TAP REDIRECT steers guest :80 there. Detached via `setsid` so it
-/// outlives `mvmctl up`; the stop path reaps it via [`SUBST_PID_FILE`]. The real
-/// secret values never leave the endpoint's address space — only the opaque
-/// placeholders are persisted/handed out.
-pub fn spawn_substitution_endpoint(
-    vm_name: &str,
-    state_dir: &Path,
-    tenant: &str,
-    secrets: &[SecretBinding],
-    redaction: &mvm_core::policy::RedactionPolicy,
-    terminator_listen: Option<SocketAddr>,
-    tls_intermediate: Option<(String, String)>,
-) -> Result<()> {
+/// endpoint serves the guest→host substitution channel over `transport`; when
+/// `terminator_listen` is `Some`, it *also* runs the transparent HTTP
+/// terminator on that host TCP addr — the FC nft TAP REDIRECT steers guest :80
+/// there. Detached via `setsid` so it outlives `mvmctl up`; the stop path reaps
+/// it via [`SUBST_PID_FILE`]. The real secret values never leave the endpoint's
+/// address space — only the opaque placeholders are persisted/handed out.
+pub fn spawn_substitution_endpoint(params: SubstitutionSpawnParams<'_>) -> Result<()> {
     use std::io::Write;
+    let SubstitutionSpawnParams {
+        vm_name,
+        state_dir,
+        tenant,
+        secrets,
+        redaction,
+        transport,
+        terminator_listen,
+        tls_intermediate,
+    } = params;
 
     let bin = resolve_substitution_endpoint_path()?;
     let mut cfg = serde_json::json!({
@@ -151,7 +196,10 @@ pub fn spawn_substitution_endpoint(
         // applies it to the cleartext it forwards. Default (all-off) is harmless.
         "redaction": serde_json::to_value(redaction)
             .expect("RedactionPolicy serializes to JSON"),
-        "transport": { "kind": "vsock", "port": mvm_guest::vsock::SUBSTITUTION_PORT },
+        // Backend-shaped guest→host channel: FC/QEMU dial the per-port vsock
+        // (Vsock); libkrun/vz route through the per-VM UDS the VMM proxies (Uds).
+        "transport": serde_json::to_value(&transport)
+            .expect("EndpointTransport serializes to JSON"),
     });
     if let Some(addr) = terminator_listen {
         // `EndpointConfig.terminator_listen: Option<SocketAddr>`:
@@ -289,6 +337,84 @@ mod tests {
         reap_substitution_endpoint(&dir, "nonexistent-vm");
         // Idempotent: a second call on the same empty dir is still clean.
         reap_substitution_endpoint(&dir, "nonexistent-vm");
+        std::fs::remove_dir_all(&dir).ok();
+    }
+
+    // The libkrun/vz transport: `spawn_substitution_endpoint` must serialize the
+    // `Uds` variant into the config JSON the endpoint bin parses
+    // (`{"kind":"uds","path":...}`). Drive it with a stub bin (via
+    // `MVM_SUBSTITUTION_ENDPOINT_PATH`) that copies its stdin config to a file
+    // for inspection and prints a one-line ready handshake.
+    #[test]
+    fn spawn_substitution_endpoint_emits_uds_transport() {
+        let _g = crate::base::runtime_meta::HOME_TEST_LOCK
+            .lock()
+            .unwrap_or_else(|p| p.into_inner());
+        let dir = std::env::temp_dir().join(format!("mvm-subst-uds-{}", std::process::id()));
+        std::fs::create_dir_all(&dir).unwrap();
+        let saved_home = std::env::var_os("HOME");
+        // Route vm_substitution_env_path under our temp HOME so the write lands
+        // somewhere disposable.
+        // SAFETY: serialised by HOME_TEST_LOCK.
+        unsafe { std::env::set_var("HOME", &dir) };
+
+        // Stub endpoint: dump stdin (the config JSON) to a file, then emit one
+        // handshake line so the spawn helper's read_handshake_line succeeds.
+        let cfg_out = dir.join("captured-config.json");
+        let stub = dir.join("stub-endpoint.sh");
+        std::fs::write(
+            &stub,
+            format!(
+                "#!/bin/sh\ncat > {}\necho 'ready handshake'\n",
+                cfg_out.display()
+            ),
+        )
+        .unwrap();
+        {
+            use std::os::unix::fs::PermissionsExt;
+            std::fs::set_permissions(&stub, std::fs::Permissions::from_mode(0o755)).unwrap();
+        }
+        let saved_bin = std::env::var_os("MVM_SUBSTITUTION_ENDPOINT_PATH");
+        // SAFETY: serialised by HOME_TEST_LOCK.
+        unsafe { std::env::set_var("MVM_SUBSTITUTION_ENDPOINT_PATH", &stub) };
+
+        // The spawn helper writes the minted (var→placeholder) handshake to
+        // `vm_substitution_env_path` — ensure its parent dir exists under HOME.
+        if let Some(parent) = mvm_core::config::vm_substitution_env_path("uds-xport-vm").parent() {
+            std::fs::create_dir_all(parent).unwrap();
+        }
+
+        let sock = dir.join("vsock-5253.sock");
+        let redaction = mvm_core::policy::RedactionPolicy::default();
+        let res = spawn_substitution_endpoint(SubstitutionSpawnParams {
+            vm_name: "uds-xport-vm",
+            state_dir: &dir,
+            tenant: "tenant-x",
+            secrets: &[],
+            redaction: &redaction,
+            transport: EndpointTransport::Uds { path: sock.clone() },
+            terminator_listen: None,
+            tls_intermediate: None,
+        });
+
+        // Restore env before asserting so a failure can't leak it.
+        unsafe {
+            match saved_bin {
+                Some(v) => std::env::set_var("MVM_SUBSTITUTION_ENDPOINT_PATH", v),
+                None => std::env::remove_var("MVM_SUBSTITUTION_ENDPOINT_PATH"),
+            }
+            match saved_home {
+                Some(v) => std::env::set_var("HOME", v),
+                None => std::env::remove_var("HOME"),
+            }
+        }
+        res.expect("spawn with stub endpoint should succeed");
+
+        let captured = std::fs::read_to_string(&cfg_out).expect("stub wrote config");
+        let v: serde_json::Value = serde_json::from_str(&captured).expect("config is JSON");
+        assert_eq!(v["transport"]["kind"], "uds");
+        assert_eq!(v["transport"]["path"], sock.to_string_lossy().as_ref());
+
         std::fs::remove_dir_all(&dir).ok();
     }
 

--- a/crates/mvm-backend/src/vz.rs
+++ b/crates/mvm-backend/src/vz.rs
@@ -379,16 +379,32 @@ impl VmBackend for VzBackend {
             );
         }
 
+        // The supervisor is up (PID file written) and its host-listen proxy is
+        // bound. Spawn the egress substitution endpoint if the admitted plan
+        // carries secrets so the guest's egress can resolve placeholders
+        // host-side (the guest never holds the real secret). The guard reaps the
+        // endpoint on any early return below; defused once the VM is confirmed up
+        // (the `stop` path then owns teardown). A secret-free plan is a defused
+        // no-op.
+        let mut endpoint_guard = spawn_vz_egress_endpoint_if_needed(&config.name, &state_dir)?;
+
         ui::success(&format!(
             "Vz VM '{}' started (pid file: {}, console log: {}).",
             config.name,
             pid_file.display(),
             console_log.display()
         ));
+        endpoint_guard.defuse();
         Ok(VmId(config.name.clone()))
     }
 
     fn stop(&self, id: &VmId) -> Result<()> {
+        // Reap the per-VM substitution endpoint first (no-op when none was
+        // spawned) so a crashed VM's decrypted-secret process can't outlive the
+        // guest. Mirrors the libkrun / FC stop ordering — safe because reap is a
+        // no-op when nothing exists, even before the not-running early return.
+        crate::substitution_spawn::reap_substitution_endpoint(&vm_state_dir(&id.0), &id.0);
+
         let pid_path = vm_state_dir(&id.0).join(PID_FILE_NAME);
         let pid = match read_pid(&pid_path) {
             Some(p) => p,
@@ -1720,6 +1736,45 @@ fn remove_instance_rootfs(vm_name: &str) {
     }
 }
 
+/// Spawn the per-VM substitution endpoint when the admitted plan carries egress
+/// secrets, returning an armed [`EndpointGuard`]; a secret-free plan (or no
+/// `plan.json`) yields a defused no-op guard. The Vz guest reaches the endpoint
+/// by dialing `connect_host_vsock(SUBSTITUTION_PORT)`; the supervisor's
+/// host-listen proxy splices that to the per-VM `vsock/` UDS the endpoint binds,
+/// so the transport is `Uds`. No transparent terminator on this path
+/// (`terminator_listen: None`), hence no per-VM TLS intermediate.
+fn spawn_vz_egress_endpoint_if_needed(
+    vm_name: &str,
+    state_dir: &Path,
+) -> Result<crate::substitution_spawn::EndpointGuard> {
+    use crate::substitution_spawn::{
+        EndpointGuard, EndpointTransport, SubstitutionSpawnParams, spawn_substitution_endpoint,
+    };
+    let Some((secrets, redaction, tenant)) =
+        crate::egress_shared::decode_plan_secrets_from_state(state_dir)?
+    else {
+        return Ok(EndpointGuard::defused());
+    };
+    spawn_substitution_endpoint(SubstitutionSpawnParams {
+        vm_name,
+        state_dir,
+        tenant: &tenant,
+        secrets: &secrets,
+        redaction: &redaction,
+        // Vz routes guest→host through the per-VM UDS the supervisor's
+        // host-listen proxy forwards into; the endpoint binds it under `vsock/`.
+        transport: EndpointTransport::Uds {
+            path: mvm_core::config::vm_vz_vsock_port_socket(
+                vm_name,
+                mvm_guest::vsock::SUBSTITUTION_PORT,
+            ),
+        },
+        terminator_listen: None,
+        tls_intermediate: None,
+    })?;
+    Ok(EndpointGuard::new(vm_name))
+}
+
 fn build_supervisor_config(
     config: &VmStartConfig,
     kernel: &str,
@@ -1807,6 +1862,12 @@ fn build_supervisor_config(
         vsock: vz::VsockConfig {
             ports: vec![mvm_guest::vsock::GUEST_AGENT_PORT],
             socket_dir: vsock_dir,
+            // Host-listens / guest-connects channel for egress substitution: the
+            // guest dials SUBSTITUTION_PORT, the supervisor accepts and splices to
+            // the per-VM UDS the substitution endpoint binds. Unconditional —
+            // fail-closed: nothing binds that UDS unless the plan has secrets, so a
+            // stray guest dial gets refused.
+            host_listen_ports: vec![mvm_guest::vsock::SUBSTITUTION_PORT],
         },
         console_output_path: Some(console_log),
         // gvproxy backend with claim-10 audit bridge ingest hookup.
@@ -2406,6 +2467,23 @@ mod tests {
         assert!(built.disks[0].read_only);
         assert!(built.virtio_fs.is_empty());
         assert_eq!(built.vsock.ports, vec![mvm_guest::vsock::GUEST_AGENT_PORT]);
+        // The egress-substitution channel is host-listens / guest-connects: the
+        // supervisor must listen on SUBSTITUTION_PORT so the guest can dial it.
+        assert!(
+            built
+                .vsock
+                .host_listen_ports
+                .contains(&mvm_guest::vsock::SUBSTITUTION_PORT),
+            "SUBSTITUTION_PORT must be in vsock.host_listen_ports"
+        );
+        // ...and it must NOT appear in the host-dials-guest proxy port set.
+        assert!(
+            !built
+                .vsock
+                .ports
+                .contains(&mvm_guest::vsock::SUBSTITUTION_PORT),
+            "SUBSTITUTION_PORT must not appear in vsock.ports"
+        );
         assert_eq!(built.pid_file_name.as_deref(), Some(PID_FILE_NAME));
         // Console capture goes to a file under state_dir; never `None`
         // — capture-only is the workload contract.
@@ -2436,6 +2514,28 @@ mod tests {
             }
             None => panic!("network should be Some(Gvproxy {{ .. }}) after W6.A.5"),
         }
+    }
+
+    /// No `plan.json` (or a secret-free plan) ⇒ no Vz egress endpoint is spawned
+    /// and the returned guard is defused (its Drop is a no-op, so an early return
+    /// can't reap a process that was never started). Mirrors the libkrun no-op
+    /// test.
+    #[test]
+    fn vz_substitution_not_spawned_when_no_secrets() {
+        let tmp = tempfile::tempdir().unwrap();
+        // Empty state dir: no plan.json at all.
+        let guard = spawn_vz_egress_endpoint_if_needed("vz-no-secrets-vm", tmp.path())
+            .expect("no-secrets path must succeed");
+        assert!(
+            guard.vm_name.is_none(),
+            "a secret-free plan must yield a defused (no-op) guard"
+        );
+        // No pidfile was written (nothing spawned).
+        assert!(
+            !tmp.path()
+                .join(crate::substitution_spawn::SUBST_PID_FILE)
+                .exists()
+        );
     }
 
     #[test]
@@ -2782,6 +2882,7 @@ mod tests {
             vsock: mvm_build::vz::VsockConfig {
                 ports: vec![],
                 socket_dir: state_dir.to_string_lossy().into_owned(),
+                host_listen_ports: vec![],
             },
             console_output_path: None,
             network: None,
@@ -2856,6 +2957,7 @@ mod tests {
             vsock: vz::VsockConfig {
                 ports: vec![],
                 socket_dir: "/parent/state/parentvm/vsock".into(),
+                host_listen_ports: vec![],
             },
             console_output_path: Some("/parent/state/parentvm/console.log".into()),
             network: Some(vz::NetworkConfig::Gvproxy {
@@ -3058,6 +3160,7 @@ mod tests {
             vsock: vz::VsockConfig {
                 ports: vec![],
                 socket_dir: state_dir.to_string_lossy().into_owned(),
+                host_listen_ports: vec![],
             },
             console_output_path: None,
             network: None,

--- a/crates/mvm-backend/src/workload_backend.rs
+++ b/crates/mvm-backend/src/workload_backend.rs
@@ -9,17 +9,55 @@ use crate::vz::VzBackend;
 use anyhow::{Result, anyhow};
 use mvm_core::vm_backend::VmBackend;
 
-/// Type-level permission to carry an untrusted workload.
-pub trait WorkloadBackend: VmBackend {}
+/// Declares how a workload backend carries the egress secret-substitution
+/// channel. The shared launch funnel interprets this to spawn the per-VM
+/// substitution endpoint; the backend only declares the mode.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum EgressSubstitutionTransport {
+    /// Linux Firecracker: the guest's :80/:443 is steered to a host TCP
+    /// terminator via an nft PREROUTING REDIRECT; the funnel computes the
+    /// per-slot terminator address and installs the redirect post-boot.
+    NftTerminator,
+    /// macOS (libkrun / vz): the guest dials the substitution port over
+    /// vsock, bridged to a host unix socket; the endpoint listens on that
+    /// `Uds`. No transparent :80/:443 terminator yet (that is gated on the
+    /// rvproxy gateway — a separate follow-up).
+    VsockUdsChannel,
+    /// This backend does not run egress substitution (the mock test double).
+    None,
+}
 
-impl WorkloadBackend for FirecrackerBackend {}
-impl WorkloadBackend for LibkrunBackend {}
-impl WorkloadBackend for VzBackend {}
+/// Type-level permission to carry an untrusted workload.
+pub trait WorkloadBackend: VmBackend {
+    /// How this backend carries the egress substitution channel. No default:
+    /// a new workload backend must declare it (cannot silently omit it).
+    fn egress_substitution_transport(&self) -> EgressSubstitutionTransport;
+}
+
+impl WorkloadBackend for FirecrackerBackend {
+    fn egress_substitution_transport(&self) -> EgressSubstitutionTransport {
+        EgressSubstitutionTransport::NftTerminator
+    }
+}
+impl WorkloadBackend for LibkrunBackend {
+    fn egress_substitution_transport(&self) -> EgressSubstitutionTransport {
+        EgressSubstitutionTransport::VsockUdsChannel
+    }
+}
+impl WorkloadBackend for VzBackend {
+    fn egress_substitution_transport(&self) -> EgressSubstitutionTransport {
+        EgressSubstitutionTransport::VsockUdsChannel
+    }
+}
 // `MockBackend` is the hermetic lifecycle test double — it carries no real
 // workload, so it stands in for a workload backend on the admitted path in
 // tests. `QemuBackend` (a real dev/test VMM) is deliberately NOT a
 // `WorkloadBackend`: it is the meaningful Tier-2 carve-out.
-impl WorkloadBackend for MockBackend {}
+impl WorkloadBackend for MockBackend {
+    fn egress_substitution_transport(&self) -> EgressSubstitutionTransport {
+        EgressSubstitutionTransport::None
+    }
+}
 
 /// The single boundary the admitted launch path goes through. Returns the
 /// backend as `&dyn WorkloadBackend`, or a typed refusal for backends not
@@ -49,6 +87,38 @@ mod tests {
         assert_is_workload_backend::<LibkrunBackend>();
         assert_is_workload_backend::<VzBackend>();
         assert_is_workload_backend::<MockBackend>();
+    }
+
+    #[test]
+    fn firecracker_declares_nft_terminator() {
+        assert_eq!(
+            FirecrackerBackend.egress_substitution_transport(),
+            EgressSubstitutionTransport::NftTerminator
+        );
+    }
+
+    #[test]
+    fn libkrun_declares_vsock_uds_channel() {
+        assert_eq!(
+            LibkrunBackend.egress_substitution_transport(),
+            EgressSubstitutionTransport::VsockUdsChannel
+        );
+    }
+
+    #[test]
+    fn vz_declares_vsock_uds_channel() {
+        assert_eq!(
+            VzBackend.egress_substitution_transport(),
+            EgressSubstitutionTransport::VsockUdsChannel
+        );
+    }
+
+    #[test]
+    fn mock_declares_none() {
+        assert_eq!(
+            MockBackend::new().egress_substitution_transport(),
+            EgressSubstitutionTransport::None
+        );
     }
 
     #[test]

--- a/crates/mvm-build/src/vz.rs
+++ b/crates/mvm-build/src/vz.rs
@@ -263,6 +263,14 @@ pub struct VsockConfig {
     /// Per-VM directory the supervisor creates mode 0700 and binds
     /// the per-port unix sockets inside.
     pub socket_dir: String,
+    /// Guest ports the supervisor must *listen* on for guest-initiated
+    /// connections (host-listens / guest-connects). Each installs a
+    /// `VZVirtioSocketListener` on the VM's socket device; an accepted guest
+    /// connection is spliced to `<socket_dir>/vsock-<port>.sock`, which a
+    /// separate host process (the egress substitution endpoint) binds. Opposite
+    /// direction from `ports` (those the supervisor dials into the guest).
+    #[serde(default)]
+    pub host_listen_ports: Vec<u32>,
 }
 
 #[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
@@ -433,6 +441,7 @@ mod tests {
             vsock: VsockConfig {
                 ports: vec![5252],
                 socket_dir: "/tmp/vz-smoke/vsock".into(),
+                host_listen_ports: vec![],
             },
             console_output_path: None,
             network: None,
@@ -456,6 +465,31 @@ mod tests {
         assert_eq!(back.name, cfg.name);
         assert_eq!(back.disks.len(), 1);
         assert_eq!(back.vsock.ports, vec![5252]);
+    }
+
+    #[test]
+    fn vsock_host_listen_ports_roundtrips() {
+        let mut cfg = minimal_config();
+        cfg.vsock.host_listen_ports = vec![5253];
+        let json = cfg.to_json().expect("serialize");
+        let back: SupervisorConfig = serde_json::from_str(&json).expect("roundtrip parses");
+        assert_eq!(back.vsock.host_listen_ports, vec![5253]);
+    }
+
+    #[test]
+    fn vsock_host_listen_ports_defaults_empty_when_absent() {
+        // Backward-compat: a config JSON produced before host_listen_ports
+        // existed (the field is `#[serde(default)]`) still decodes, with the
+        // new field defaulting to an empty Vec.
+        let mut value = serde_json::to_value(minimal_config()).unwrap();
+        value
+            .get_mut("vsock")
+            .and_then(|v| v.as_object_mut())
+            .unwrap()
+            .remove("host_listen_ports");
+        let json = serde_json::to_string(&value).unwrap();
+        let back: SupervisorConfig = serde_json::from_str(&json).expect("decode without field");
+        assert!(back.vsock.host_listen_ports.is_empty());
     }
 
     #[test]

--- a/crates/mvm-build/src/vz_builder.rs
+++ b/crates/mvm-build/src/vz_builder.rs
@@ -315,6 +315,9 @@ fn build_vz_supervisor_config(
         vsock: crate::vz::VsockConfig {
             ports: config.vsock_ports.clone(),
             socket_dir: vsock_dir,
+            // The builder VM has no egress-substitution endpoint; no host-listen
+            // ports.
+            host_listen_ports: vec![],
         },
         console_output_path: Some(console_log),
         // gvproxy gives a cold `nix build` egress to fetch nixpkgs.
@@ -1313,6 +1316,9 @@ fn build_vz_persistent_supervisor_config(
                 ports
             },
             socket_dir: vsock_dir,
+            // The builder VM has no egress-substitution endpoint; no host-listen
+            // ports.
+            host_listen_ports: vec![],
         },
         console_output_path: Some(console_log),
         // No virtio-net on the persistent driver yet. gvproxy is wired

--- a/crates/mvm-build/tests/vz_supervisor_parity.rs
+++ b/crates/mvm-build/tests/vz_supervisor_parity.rs
@@ -100,6 +100,7 @@ fn build_boot_config(name: &str, kernel: &str, rootfs: &str, state_dir: &Path) -
         vsock: VsockConfig {
             ports: vec![5252],
             socket_dir: state_dir.join("vsock").to_string_lossy().into_owned(),
+            host_listen_ports: vec![],
         },
         console_output_path: Some(state_dir.join("console.log").to_string_lossy().into_owned()),
         network: None,

--- a/crates/mvm-cli/src/commands/vm/checkpoint.rs
+++ b/crates/mvm-cli/src/commands/vm/checkpoint.rs
@@ -1103,6 +1103,7 @@ mod tests {
             vsock: mvm_build::vz::VsockConfig {
                 ports: vec![],
                 socket_dir: state_dir.to_string_lossy().into_owned(),
+                host_listen_ports: vec![],
             },
             console_output_path: None,
             network: None,

--- a/crates/mvm-hostd/src/supervisor/substitution_endpoint.rs
+++ b/crates/mvm-hostd/src/supervisor/substitution_endpoint.rs
@@ -32,19 +32,11 @@ fn default_forward_timeout_secs() -> u64 {
     30
 }
 
-/// How the guest reaches this endpoint. Backend-shaped: QEMU's `vhost-vsock`
-/// gives a real guest→host AF_VSOCK path, so the host binds an AF_VSOCK
-/// listener; Firecracker/libkrun route guest→host through a per-port UDS the
-/// in-process VMM proxies, so the host binds that UDS.
-#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
-#[serde(tag = "kind", rename_all = "snake_case")]
-pub enum EndpointTransport {
-    /// Host AF_VSOCK listener on this port (QEMU). The guest dials
-    /// `connect_host_vsock(SUBSTITUTION_PORT)`.
-    Vsock { port: u32 },
-    /// Host UDS the per-port vsock proxy forwards to (Firecracker/libkrun).
-    Uds { path: PathBuf },
-}
+/// How the guest reaches this endpoint. Defined in `mvm-backend` (next to the
+/// `spawn_substitution_endpoint` writer) and re-exported here so the bin, its
+/// tests, and `EndpointConfig` share one wire definition without a dependency
+/// cycle (mvm-hostd → mvm-backend, never the reverse).
+pub use mvm_backend::EndpointTransport;
 
 /// The per-VM name-constrained intermediate the terminator
 /// terminates bound-host TLS under. The guest trusts the matching cert (delivered

--- a/crates/mvm-vm-host/src/vz_objc.rs
+++ b/crates/mvm-vm-host/src/vz_objc.rs
@@ -53,7 +53,7 @@ use objc2_virtualization::{
 };
 use tokio::io::unix::AsyncFd;
 use tokio::io::{AsyncRead, AsyncReadExt, AsyncWrite, AsyncWriteExt, ReadBuf};
-use tokio::net::UnixListener;
+use tokio::net::{UnixListener, UnixStream};
 use tokio::sync::{mpsc, oneshot, watch};
 use tokio::task::JoinHandle;
 
@@ -766,6 +766,12 @@ pub struct VzSupervisor {
     exit_task: Option<JoinHandle<()>>,
     /// Retains the exit-port `VZVirtioSocketListener` for the VM's lifetime.
     _exit_listener: Option<ExitListenerHandle>,
+    /// Host-listen (guest→host) proxy accept loops for the egress-substitution
+    /// channel; aborted on [`shutdown`](Self::shutdown).
+    host_listen_tasks: Vec<JoinHandle<()>>,
+    /// Retains each host-listen port's `VZVirtioSocketListener` for the VM's
+    /// lifetime (the framework drops accepts once the listener is released).
+    _host_listen_listeners: Vec<ExitListenerHandle>,
     /// In-process flow-audited gvproxy bridge thread.
     /// Held for its lifetime; process exit reaps it. `None` when no audit
     /// substrate (direct gvproxy attach) or no network.
@@ -797,6 +803,10 @@ impl VzSupervisor {
             .filter(|&p| p != WORKLOAD_EXIT_PORT)
             .collect();
         let capture_exit = config.vsock.ports.contains(&WORKLOAD_EXIT_PORT);
+        // Guest→host host-listen ports (egress substitution): the supervisor
+        // installs a VZVirtioSocketListener per port and splices each accepted
+        // guest connection to the per-VM UDS the endpoint binds.
+        let host_listen_ports = config.vsock.host_listen_ports.clone();
         let vm_state_dir = config.vm_state_dir.clone();
         let control_path = config.control_socket_path.clone();
         let mem_total_bytes = mib_to_bytes(config.resources.memory_mib);
@@ -849,6 +859,8 @@ impl VzSupervisor {
             captured_exit: Arc::new(Mutex::new(None)),
             exit_task: None,
             _exit_listener: None,
+            host_listen_tasks: Vec::new(),
+            _host_listen_listeners: Vec::new(),
             _bridge: None,
         };
         // Bind the host-side vsock proxy + control socket + workload-exit
@@ -862,6 +874,13 @@ impl VzSupervisor {
         }
         if capture_exit {
             this.start_exit_listener(&vm_state_dir).await?;
+        }
+        // Host-listen (guest→host) proxy for the egress-substitution channel.
+        // The listener must be installed before the guest can dial it, so this
+        // runs before start()/restore_and_resume().
+        if !host_listen_ports.is_empty() {
+            this.start_host_listen_proxy(&vsock_dir, &host_listen_ports)
+                .await?;
         }
         // Flow-audited networking: spawn the in-process gvproxy bridge before
         // start so it is splicing before the guest brings its NIC up. Fail-closed
@@ -1004,6 +1023,62 @@ impl VzSupervisor {
         Ok(())
     }
 
+    /// Install a guest→host `VZVirtioSocketListener` per host-listen port and
+    /// spawn an accept loop that splices each accepted guest connection to the
+    /// per-VM `<socket_dir>/vsock-<port>.sock` a separate host process binds (the
+    /// egress substitution endpoint). Opposite direction from
+    /// [`start_vsock_proxy`](Self::start_vsock_proxy) (host dials guest); here the
+    /// guest dials the port and the host forwards into the endpoint's UDS. The
+    /// listener must be installed before boot so the guest's first dial is
+    /// accepted. We do NOT bind the UDS — the endpoint owns it; if it hasn't bound
+    /// yet (no secrets in the plan) the connect fails and the guest dial is
+    /// refused, fail-closed.
+    async fn start_host_listen_proxy(&mut self, socket_dir: &str, ports: &[u32]) -> Result<()> {
+        if ports.is_empty() {
+            return Ok(());
+        }
+        let dir = PathBuf::from(socket_dir);
+        for &port in ports {
+            let (tx, rx) = mpsc::unbounded_channel::<SendableConnection>();
+            let handle = Arc::clone(&self.handle);
+            let listener_handle = self
+                .queue
+                .dispatch(move || -> Result<ExitListenerHandle> {
+                    // SAFETY: socketDevices() is a queue-bound accessor.
+                    let devices = unsafe { handle.vm.socketDevices() };
+                    let device = devices
+                        .to_vec()
+                        .into_iter()
+                        .next()
+                        .and_then(|d| Retained::downcast::<VZVirtioSocketDevice>(d).ok())
+                        .ok_or_else(|| {
+                            anyhow!("VM has no virtio-socket device for host-listen proxy")
+                        })?;
+                    let delegate = VsockListenerDelegate::new(tx);
+                    // SAFETY: new() returns a default socket listener.
+                    let listener = unsafe { VZVirtioSocketListener::new() };
+                    // SAFETY: setDelegate installs our accept delegate.
+                    unsafe { listener.setDelegate(Some(delegate.as_protocol())) };
+                    // SAFETY: setSocketListener_forPort must run on the VM's queue.
+                    unsafe { device.setSocketListener_forPort(&listener, port) };
+                    Ok(ExitListenerHandle {
+                        _listener: listener,
+                        _delegate: delegate,
+                    })
+                })
+                .await??;
+            let endpoint_sock = dir.join(format!("vsock-{port}.sock"));
+            self.host_listen_tasks
+                .push(tokio::spawn(run_host_listen_port_proxy(
+                    rx,
+                    endpoint_sock,
+                    port,
+                )));
+            self._host_listen_listeners.push(listener_handle);
+        }
+        Ok(())
+    }
+
     /// Abort the vsock proxy + control + exit accept loops and unlink their
     /// sockets. Best-effort; process exit would reap them anyway, but this keeps
     /// the state dir clean.
@@ -1011,9 +1086,15 @@ impl VzSupervisor {
         for task in &self.vsock_tasks {
             task.abort();
         }
+        for task in &self.host_listen_tasks {
+            task.abort();
+        }
         for task in self.control_task.iter().chain(self.exit_task.iter()) {
             task.abort();
         }
+        // NB: the host-listen `vsock-<port>.sock` paths are deliberately NOT
+        // unlinked here — the egress substitution endpoint process binds and owns
+        // them, so removing them would yank a live listener out from under it.
         for path in self.vsock_paths.iter().chain(self.control_path.iter()) {
             let _ = std::fs::remove_file(path);
         }
@@ -1127,6 +1208,49 @@ async fn run_port_proxy(conn: VmConn, listener: UnixListener, port: u32) {
                     }
                 }
                 Err(e) => tracing::warn!(port, error = %e, "vsock connect to guest failed"),
+            }
+        });
+    }
+}
+
+/// Accept loop for one host-listen (guest→host) port: each guest connection
+/// the listener accepted (forwarded over `rx`) is built into a `VsockStream`,
+/// then spliced to the per-VM `endpoint_sock` UDS the egress substitution
+/// endpoint binds. Per-connection failures are logged and dropped; the loop ends
+/// when the listener delegate's sender is dropped (VM teardown). When no endpoint
+/// is bound (a secret-free plan), `UnixStream::connect` fails and the guest's
+/// dial is refused — fail-closed.
+async fn run_host_listen_port_proxy(
+    mut rx: mpsc::UnboundedReceiver<SendableConnection>,
+    endpoint_sock: PathBuf,
+    port: u32,
+) {
+    while let Some(conn) = rx.recv().await {
+        let guest = match VsockStream::from_connection(conn.0) {
+            Ok(s) => s,
+            Err(e) => {
+                tracing::warn!(port, error = %e, "host-listen: build guest stream failed");
+                continue;
+            }
+        };
+        let endpoint_sock = endpoint_sock.clone();
+        tokio::spawn(async move {
+            let host = match UnixStream::connect(&endpoint_sock).await {
+                Ok(s) => s,
+                Err(e) => {
+                    tracing::warn!(
+                        port,
+                        socket = %endpoint_sock.display(),
+                        error = %e,
+                        "host-listen: connect to substitution endpoint socket failed"
+                    );
+                    return;
+                }
+            };
+            let mut guest = guest;
+            let mut host = host;
+            if let Err(e) = tokio::io::copy_bidirectional(&mut host, &mut guest).await {
+                tracing::debug!(port, error = %e, "host-listen bridge closed with error");
             }
         });
     }

--- a/specs/notes/plan-197-phase2a-blueprint.md
+++ b/specs/notes/plan-197-phase2a-blueprint.md
@@ -53,6 +53,11 @@ param + update FC/QEMU callers (no behavior change); shared
 **live vz boot** — a `SecretRef` workload on `--hypervisor vz` with explicit
 `HTTP_PROXY` sees only the placeholder, host endpoint injects the real credential.
 
+**Commit-2 cleanup (reuse-first):** collapse FC's Linux-gated
+`microvm.rs::decode_plan_secrets` into `egress_shared::decode_plan_secrets_from_state`
+(repoint FC's two callsites, delete the dup). It edits Linux-only code, so verify
+with a Linux-target `cargo clippy --target` cross-check, not just the macOS build.
+
 ## Risks (from the spike + architect review)
 
 - libkrun: endpoint (not supervisor) binds `vsock-5253.sock`; supervisor must not

--- a/specs/notes/plan-197-phase2a-blueprint.md
+++ b/specs/notes/plan-197-phase2a-blueprint.md
@@ -1,0 +1,64 @@
+# Plan 197 Phase 2a — macOS egress substitution: implementation blueprint
+
+**Date:** 2026-06-13
+**Status:** design accepted; implementing in 2 commits
+**Scope:** wire the egress-substitution **vsock channel** (explicit `HTTP_PROXY`)
+onto libkrun + vz. The transparent :80/:443 terminator is Phase 2b (rvproxy).
+
+## Key decision — port 5253 direction
+
+`SUBSTITUTION_PORT` (5253) is **host-listens / guest-connects** (the guest dials
+`connect_host_vsock(5253)`), the same direction as `WORKLOAD_EXIT_PORT` (5251) —
+**not** `GUEST_AGENT_PORT` (5252, guest-listens). The host substitution endpoint
+process binds the per-VM UDS; the guest's AF_VSOCK connect is routed to it.
+
+- **libkrun:** register 5253 via `.add_host_listen_port(5253)` in
+  `krun_context_base` (unconditional — fail-closed: nothing binds the UDS when
+  the plan has no secrets, so a stray dial gets ECONNREFUSED). The **endpoint
+  process** binds `vm_vsock_port_socket(name, 5253)`; libkrun proxies guest
+  connects to it. No supervisor change. (Verify `configure()` does NOT pre-unlink
+  `listen=false` sockets — it must not clobber the endpoint's bind.)
+- **vz:** the existing `start_vsock_proxy` is the wrong direction
+  (host-connects-to-guest). Add a new `host_listen_ports: Vec<u32>` to
+  `mvm_build::vz::VsockConfig` (`#[serde(default)]`) and a
+  `start_host_listen_proxy` in `vz_objc.rs` that installs a
+  `VZVirtioSocketListener` on 5253 and splices each guest connection to
+  `vm_vz_vsock_port_socket(name, 5253)` (the endpoint's UDS). Must run before
+  `start()`. `shutdown()` must NOT unlink that UDS (the endpoint owns it).
+
+## Shared
+
+- `substitution_spawn::spawn_substitution_endpoint` currently hardcodes
+  `transport: vsock{5253}`. Add a `transport: EndpointTransport` param and
+  serialize it. FC passes `Vsock{5253}` (no behavior change); macOS passes
+  `Uds{ path: <per-VM 5253 socket> }`; `terminator_listen: None` on macOS.
+- Un-Linux-gate `decode_plan_secrets` into a shared
+  `decode_plan_secrets_from_state(state_dir)` (used by libkrun + vz; FC keeps
+  its path or shares it).
+- Each macOS backend spawns the endpoint after the supervisor PID file appears,
+  before returning `Ok(VmId)`, gated on the plan carrying secrets; an
+  `EndpointGuard` reaps on early return; `stop()` reaps (mirrors FC `stop_vm`).
+
+## Build sequence
+
+**Commit 1 (libkrun half — CI-verifiable):** `substitution_spawn` transport
+param + update FC/QEMU callers (no behavior change); shared
+`decode_plan_secrets_from_state`; `add_host_listen_port(5253)` in
+`krun_context_base`; libkrun `start`/`stop` spawn+reap+guard; unit tests
+(no-secrets no-op; spawn writes `kind:"uds"` config with a stub endpoint bin).
+
+**Commit 2 (vz half + cleanup — needs live boot):** `VsockConfig.host_listen_ports`;
+`vz_objc.rs` `start_host_listen_proxy` + `run_host_listen_port_proxy`; vz
+`start`/`stop` spawn+reap; remove QEMU's dead substitution call; vz serde test;
+**live vz boot** — a `SecretRef` workload on `--hypervisor vz` with explicit
+`HTTP_PROXY` sees only the placeholder, host endpoint injects the real credential.
+
+## Risks (from the spike + architect review)
+
+- libkrun: endpoint (not supervisor) binds `vsock-5253.sock`; supervisor must not
+  pre-unlink it. Fail-closed when no secrets.
+- vz: the `VZVirtioSocketListener` must be installed before boot; `shutdown` must
+  not unlink the endpoint-owned UDS; spawn-timing must put the listener up before
+  the guest can dial.
+- Commit 2's vz proxy + live boot is the high-risk part — validate on the macOS-26
+  Vz box, isolated env.


### PR DESCRIPTION
## What

Wires egress secret substitution (Plan 129) onto the **macOS** workload backends (libkrun + vz) via the vsock substitution channel — closing the gap surfaced by the Sprint 55 vz closeout (substitution shipped on Linux FC/QEMU but silently never reached libkrun/vz).

- **Seam:** `WorkloadBackend::egress_substitution_transport()` (FC→`NftTerminator`, libkrun/vz→`VsockUdsChannel`, mock→`None`).
- **`SUBSTITUTION_PORT` (5253)** is host-listens/guest-connects (like the exit port). libkrun registers it via `add_host_listen_port`; vz adds a new `VZVirtioSocketListener → host-UDS` proxy (`start_host_listen_proxy` in `vz_objc.rs`, modeled on `start_exit_listener`). Both spawn the substitution endpoint over `EndpointTransport::Uds{ vsock-5253.sock }`, gated on the admitted plan carrying secrets, reaped on stop (shared `EndpointGuard`).
- `EndpointTransport` moved to `mvm-backend` (re-exported from `mvm-hostd`) to break a dependency cycle; `spawn_substitution_endpoint` now takes a `transport`. FC/QEMU callers unchanged in behavior.

## ⚠️ Not yet live-booted

This is **code-complete and statically verified** (the objc2 vz supervisor compiles; clippy/tests/nightly-fmt/spec-ref all clean) but has **not been booted on hardware**. The key unvalidated assumption is that a single `VZVirtioSocketListener` keeps accepting *repeated* guest dials on 5253. Live validation on the macOS-26 Vz box (a `SecretRef` workload sees only the placeholder; host injects the real credential) is the immediate next step, tracked separately. Merging now per maintainer decision; live-validation follows.

## Remaining (tracked, not in this PR)
- QEMU's now-dead substitution call removal; collapse FC's `decode_plan_secrets` dup (Linux-target check).
- **Phase 2b:** the transparent :80/:443 terminator in rvproxy (ADR-082 / Plan 193) — gives transparent (non-proxy-aware) substitution. This PR delivers the explicit-`HTTP_PROXY` channel only.

Design + blueprint: `specs/plans/197-...` + `specs/notes/plan-197-phase2a-blueprint.md`.