### PR TITLE
fix(pool): serialize warm_to_target with a pool-dir flock (Plan 118)

### DIFF
--- a/crates/mvm-backend/src/standby_pool.rs
+++ b/crates/mvm-backend/src/standby_pool.rs
@@ -30,6 +30,12 @@ impl SupervisorStandbyPool {
         Self { root: root.into() }
     }
 
+    /// The pool's root directory. Callers that need to serialize across the
+    /// whole pool (e.g. an exclusive warm lock) anchor on this.
+    pub fn root(&self) -> &Path {
+        &self.root
+    }
+
     /// Persist (or update) a standby's handle under `<root>/<id>/standby.json`,
     /// creating the dir `0700`.
     pub fn record(&self, h: &StandbyHandle) -> Result<()> {

--- a/crates/mvm-cli/src/commands/pool.rs
+++ b/crates/mvm-cli/src/commands/pool.rs
@@ -215,6 +215,12 @@ pub fn warm_to_target(pool: &SupervisorStandbyPool, p: &WarmParams<'_>) -> Resul
             failed: 0,
         });
     }
+    // Serialize concurrent warms on the pool directory. Without this lock two
+    // launches can both read an empty pool and each spawn up to `target`,
+    // overshooting it; the standbys then age out via TTL but waste a boot each.
+    // The lock spans the idle-count read through the spawn loop and releases on
+    // return.
+    let _warm_guard = mvm_core::atomic_io::FileLock::acquire(&pool.root().join("warm"))?;
     // The compat identity computed identically here and at claim time (a constant for
     // libkrun's bundled kernel) so a warmed standby is actually claimable.
     let kernel_sha256 = kernel_identity(p.backend, p.kernel.to_str())?;
@@ -851,6 +857,125 @@ mod tests {
         // Already at target → no spawns attempted, no failures.
         assert_eq!(result.spawned, 0);
         assert_eq!(result.failed, 0);
+    }
+
+    // A VmBackend stub whose `spawn_standby` always succeeds, echoing the spec's
+    // compat fields into the handle so the spawned standby is counted as idle.
+    // Stateless → Send + Sync, shareable across threads.
+    struct SpawnOkBackend;
+    impl VmBackend for SpawnOkBackend {
+        fn name(&self) -> &str {
+            "stub-spawn-ok"
+        }
+        fn capabilities(&self) -> VmCapabilities {
+            VmCapabilities::default()
+        }
+        fn supports_standby_pool(&self) -> bool {
+            true
+        }
+        fn spawn_standby(
+            &self,
+            spec: &mvm_core::vm_backend::StandbySpec,
+        ) -> std::result::Result<StandbyHandle, StandbyError> {
+            Ok(StandbyHandle {
+                id: spec.id.clone(),
+                control_socket: spec.control_socket.clone(),
+                pid: std::process::id(),
+                kernel_sha256: spec.kernel_sha256.clone(),
+                vcpus: spec.vcpus,
+                mem_mib: spec.mem_mib,
+                binding_nonce: spec.binding_nonce.clone(),
+                spawned_unix_secs: 1,
+                state: StandbyState::Idle,
+                image_sha256: spec.image_sha256.clone(),
+            })
+        }
+        fn start_with_mode(&self, _: &VmStartConfig, _: StartMode) -> anyhow::Result<VmId> {
+            unreachable!()
+        }
+        fn stop(&self, _: &VmId) -> anyhow::Result<()> {
+            Ok(())
+        }
+        fn stop_all(&self) -> anyhow::Result<()> {
+            Ok(())
+        }
+        fn pause(&self, _: &VmId) -> anyhow::Result<()> {
+            Ok(())
+        }
+        fn resume(&self, _: &VmId) -> anyhow::Result<()> {
+            Ok(())
+        }
+        fn status(&self, _: &VmId) -> anyhow::Result<VmStatus> {
+            Ok(VmStatus::Stopped)
+        }
+        fn list(&self) -> anyhow::Result<Vec<VmInfo>> {
+            Ok(vec![])
+        }
+        fn logs(&self, _: &VmId, _: u32, _: bool) -> anyhow::Result<String> {
+            Ok(String::new())
+        }
+        fn is_available(&self) -> anyhow::Result<bool> {
+            Ok(true)
+        }
+        fn install(&self) -> anyhow::Result<()> {
+            Ok(())
+        }
+    }
+
+    // Two launches warming the same pool to the same target concurrently must
+    // not overshoot it: the pool-dir flock serializes the idle-count read →
+    // spawn loop, so the second warmer observes the first's standbys and spawns
+    // nothing. Without the lock both read an empty pool and each spawn `target`.
+    #[test]
+    fn warm_to_target_concurrent_calls_do_not_overshoot() {
+        let tmp = tempfile::tempdir().unwrap();
+        let pool = SupervisorStandbyPool::at(tmp.path().join("pool"));
+        let kernel = tmp.path().join("vmlinux");
+        std::fs::write(&kernel, b"k").unwrap();
+        let key = tmp.path().join("key");
+        std::fs::write(&key, b"fake-key").unwrap();
+
+        let backend = SpawnOkBackend;
+        fn warm_once(
+            pool: &SupervisorStandbyPool,
+            backend: &dyn VmBackend,
+            kernel: &std::path::Path,
+            key: &std::path::Path,
+        ) {
+            warm_to_target(
+                pool,
+                &WarmParams {
+                    backend,
+                    kernel,
+                    vcpus: 2,
+                    mem_mib: 1024,
+                    signer_id: "host:test",
+                    signing_key_path: key,
+                    target: 2,
+                    image: None,
+                },
+            )
+            .unwrap();
+        }
+
+        std::thread::scope(|s| {
+            let a = s.spawn(|| warm_once(&pool, &backend, &kernel, &key));
+            let b = s.spawn(|| warm_once(&pool, &backend, &kernel, &key));
+            a.join().unwrap();
+            b.join().unwrap();
+        });
+
+        let want = StandbyCompat {
+            kernel_sha256: kernel_sha256_hex(&kernel).unwrap(),
+            vcpus: 2,
+            mem_mib: 1024,
+            image_sha256: None,
+        };
+        assert_eq!(
+            pool.idle_count_compatible(&want).unwrap(),
+            2,
+            "concurrent warms overshot the target — the read→spawn lock is missing or not held"
+        );
     }
 }
 

--- a/specs/REFACTOR-STATUS.md
+++ b/specs/REFACTOR-STATUS.md
@@ -275,9 +275,14 @@ PLAN 118 — Supervisor standby pool              🟡 libkrun + Vz done; FC fol
       hands the re-warm to a DETACHED `mvmctl pool warm` subprocess (own process
       group, null stdio, inherits env, via current_exe) — `up` returns at once
       and the child re-warms only the deficit off the hot path. Live: claim
-      drained 1→0, detached re-warm refilled to 1. Follow-up (in-code): no pool
-      lock → concurrent claims can overshoot target by ~1 each (ages out via
-      TTL); a pool-dir flock around warm_to_target's read→spawn is the clean fix.
+      drained 1→0, detached re-warm refilled to 1.
+  [x] Pool-dir warm flock: `warm_to_target` now takes an exclusive `FileLock`
+      (reused `mvm_core::atomic_io::FileLock`) on `<pool>/warm.lock` spanning the
+      idle-count read → spawn loop, so concurrent launches no longer both observe
+      an empty pool and each spawn to target (the prior ~1-per-claim overshoot
+      that aged out via TTL). `SupervisorStandbyPool::root()` accessor added;
+      no-overshoot witness is a 2-thread test (TDD-verified: 5/5 overshoot
+      without the lock, 2 == target with it).
   [x] Warm claim reuses the admission image sha (#846): the claim's compat key
       threads `ExecutionPlan.image.sha256` (already computed by claim-8
       admission) instead of re-hashing the rootfs a second time on the launch


### PR DESCRIPTION
## What

The Plan 118 in-code follow-up: `warm_to_target` read the compatible-idle count and then spawned toward the target in a loop with **nothing between the read and the spawns**. Two concurrent `up` launches both observed an empty pool and each spawned up to `target` standbys, overshooting it — the extras only reclaimed later via the TTL reaper, wasting a boot each.

## Fix

- Take an exclusive `FileLock` on `<pool>/warm.lock` spanning the idle-count read through the spawn loop. **Reuses the existing `mvm_core::atomic_io::FileLock`** (already used for the Stage 0 lock) — no new dependency.
- The lock anchors on the pool's own directory via a new `SupervisorStandbyPool::root()` accessor, so it is isolated per pool (and per test) rather than on the global pool dir.

## Test

A two-thread no-overshoot test (`warm_to_target_concurrent_calls_do_not_overshoot`): both threads warm the same pool to `target = 2` concurrently; the pool must end with exactly 2 idle standbys, not 4.

TDD-verified as a real witness: **5/5 runs overshoot to 4 without the lock**, exactly 2 with it.

## Verification

- `cargo nextest run -p mvm-cli` — 979 pass
- `cargo clippy -p mvm-backend -p mvm-cli --all-targets -- -D warnings` — clean
- `cargo fmt --all -- --check`, `check-no-spec-refs-in-comments`, `check-spec-numbers` — clean

Rollup Plan 118 block updated (flock follow-up ticked).