### PR TITLE
test(hostd,build): migrate env tests onto TestEnv (Plan 185 tail)

### DIFF
--- a/crates/mvm-build/src/runtime_overlay.rs
+++ b/crates/mvm-build/src/runtime_overlay.rs
@@ -1003,6 +1003,7 @@ fn validate_roothash_shape(s: &str) -> Result<(), RuntimeOverlayError> {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use mvm_core::util::test_env::TestEnv;
     use tempfile::TempDir;
 
     const FAKE_ROOTHASH: &str = "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef";
@@ -1771,29 +1772,19 @@ mod tests {
     /// mutex so concurrent tests don't fight over the env var.
     #[test]
     fn release_base_url_honors_env_override() {
-        // SAFETY: tests in this module that touch env vars must run
-        // serially. The harness runs each #[test] in its own thread;
-        // setting an env in one test and unsetting in another can
-        // race. Use a process-local mutex to serialize.
-        let _g = env_test_mutex().lock().unwrap();
-        // SAFETY: env mutation is serialized by the mutex above;
-        // no other thread can observe the inconsistent state.
-        unsafe {
-            std::env::set_var("MVM_OVERLAY_BASE_URL", "https://mirror.example.com/mvm");
-        }
+        // `TestEnv` serializes env-mutating tests in this process behind a
+        // shared lock and restores the prior value on drop.
+        let mut env = TestEnv::new();
+        env.set("MVM_OVERLAY_BASE_URL", "https://mirror.example.com/mvm");
         let url = release_base_url("9.9.9");
         assert_eq!(url, "https://mirror.example.com/mvm/v9.9.9");
-        unsafe {
-            std::env::remove_var("MVM_OVERLAY_BASE_URL");
-        }
+        env.remove("MVM_OVERLAY_BASE_URL");
     }
 
     #[test]
     fn release_base_url_falls_back_to_default_without_env() {
-        let _g = env_test_mutex().lock().unwrap();
-        unsafe {
-            std::env::remove_var("MVM_OVERLAY_BASE_URL");
-        }
+        let mut env = TestEnv::new();
+        env.remove("MVM_OVERLAY_BASE_URL");
         let url = release_base_url("0.14.0");
         assert_eq!(
             url,
@@ -1803,20 +1794,11 @@ mod tests {
 
     #[test]
     fn release_base_url_strips_trailing_slash_on_override() {
-        let _g = env_test_mutex().lock().unwrap();
-        unsafe {
-            std::env::set_var("MVM_OVERLAY_BASE_URL", "https://mirror.example.com/mvm/");
-        }
+        let mut env = TestEnv::new();
+        env.set("MVM_OVERLAY_BASE_URL", "https://mirror.example.com/mvm/");
         let url = release_base_url("9.9.9");
         assert_eq!(url, "https://mirror.example.com/mvm/v9.9.9");
-        unsafe {
-            std::env::remove_var("MVM_OVERLAY_BASE_URL");
-        }
-    }
-
-    fn env_test_mutex() -> &'static std::sync::Mutex<()> {
-        static M: std::sync::OnceLock<std::sync::Mutex<()>> = std::sync::OnceLock::new();
-        M.get_or_init(|| std::sync::Mutex::new(()))
+        env.remove("MVM_OVERLAY_BASE_URL");
     }
 
     #[test]
@@ -1918,7 +1900,7 @@ short  bar.ext4
     fn download_runtime_overlay_end_to_end_against_file_url_fixture() {
         // SAFETY: must serialize against other env-touching tests
         // in this module.
-        let _g = env_test_mutex().lock().unwrap();
+        let mut env = TestEnv::new();
 
         let upstream = TempDir::new().unwrap();
         let release_dir = upstream.path().join("v9.9.9");
@@ -1960,16 +1942,12 @@ short  bar.ext4
         );
 
         let base_url = format!("file://{}", upstream.path().display());
-        unsafe {
-            std::env::set_var("MVM_OVERLAY_BASE_URL", &base_url);
-        }
+        env.set("MVM_OVERLAY_BASE_URL", &base_url);
 
         let cache = TempDir::new().unwrap();
         let result = download_runtime_overlay("9.9.9", GuestArch::Aarch64, cache.path());
 
-        unsafe {
-            std::env::remove_var("MVM_OVERLAY_BASE_URL");
-        }
+        env.remove("MVM_OVERLAY_BASE_URL");
 
         let installed = result.expect("download + install must succeed against fixture");
         assert_eq!(installed.arch, GuestArch::Aarch64);
@@ -1998,7 +1976,7 @@ short  bar.ext4
     /// unchanged. This is the fail-closed integrity contract.
     #[test]
     fn download_runtime_overlay_rejects_checksum_mismatch() {
-        let _g = env_test_mutex().lock().unwrap();
+        let mut env = TestEnv::new();
 
         let upstream = TempDir::new().unwrap();
         let release_dir = upstream.path().join("v9.9.9");
@@ -2033,14 +2011,10 @@ short  bar.ext4
         );
 
         let base_url = format!("file://{}", upstream.path().display());
-        unsafe {
-            std::env::set_var("MVM_OVERLAY_BASE_URL", &base_url);
-        }
+        env.set("MVM_OVERLAY_BASE_URL", &base_url);
         let cache = TempDir::new().unwrap();
         let result = download_runtime_overlay("9.9.9", GuestArch::Aarch64, cache.path());
-        unsafe {
-            std::env::remove_var("MVM_OVERLAY_BASE_URL");
-        }
+        env.remove("MVM_OVERLAY_BASE_URL");
 
         let err = result.expect_err("tampered ext4 must reject");
         match err {
@@ -2057,7 +2031,7 @@ short  bar.ext4
     /// aborts before any artifact is fetched.
     #[test]
     fn download_runtime_overlay_rejects_missing_checksum_entry() {
-        let _g = env_test_mutex().lock().unwrap();
+        let mut env = TestEnv::new();
 
         let upstream = TempDir::new().unwrap();
         let release_dir = upstream.path().join("v9.9.9");
@@ -2075,14 +2049,10 @@ short  bar.ext4
         );
 
         let base_url = format!("file://{}", upstream.path().display());
-        unsafe {
-            std::env::set_var("MVM_OVERLAY_BASE_URL", &base_url);
-        }
+        env.set("MVM_OVERLAY_BASE_URL", &base_url);
         let cache = TempDir::new().unwrap();
         let result = download_runtime_overlay("9.9.9", GuestArch::Aarch64, cache.path());
-        unsafe {
-            std::env::remove_var("MVM_OVERLAY_BASE_URL");
-        }
+        env.remove("MVM_OVERLAY_BASE_URL");
 
         let err = result.expect_err("missing VERSION entry must reject");
         match err {

--- a/crates/mvm-hostd/Cargo.toml
+++ b/crates/mvm-hostd/Cargo.toml
@@ -100,6 +100,8 @@ landlock = { workspace = true }
 
 [dev-dependencies]
 tempfile.workspace = true
+# `TestEnv` env-var guard for env-mutating tests (reaper / substitution_endpoint).
+mvm-core = { workspace = true, features = ["test-support"] }
 tokio = { workspace = true, features = ["macros", "rt", "rt-multi-thread", "net", "io-util", "time", "sync", "test-util"] }
 # audit-chain drift tripwire (supervisor tests).
 mvm-verify = { path = "../mvm-verify" }

--- a/crates/mvm-hostd/src/supervisor/reaper.rs
+++ b/crates/mvm-hostd/src/supervisor/reaper.rs
@@ -291,6 +291,7 @@ pub fn deregister_only_teardown() -> TeardownFn {
 mod tests {
     use super::*;
     use mvm::vm::name_registry::RegisterParams;
+    use mvm_core::util::test_env::TestEnv;
     use rand::SeedableRng;
     use rand::rngs::StdRng;
     use std::sync::Arc;
@@ -694,17 +695,17 @@ mod tests {
 
     #[test]
     fn global_idle_timeout_from_env_parses_and_treats_zero_as_off() {
-        // SAFETY: process-isolated under nextest; set + clear within the test.
-        unsafe { std::env::set_var(IDLE_TIMEOUT_ENV, "45") };
+        let mut env = TestEnv::new();
+        env.set(IDLE_TIMEOUT_ENV, "45");
         assert_eq!(
             global_idle_timeout_from_env(),
             Some(Duration::from_secs(45))
         );
-        unsafe { std::env::set_var(IDLE_TIMEOUT_ENV, "0") };
+        env.set(IDLE_TIMEOUT_ENV, "0");
         assert_eq!(global_idle_timeout_from_env(), None);
-        unsafe { std::env::set_var(IDLE_TIMEOUT_ENV, "garbage") };
+        env.set(IDLE_TIMEOUT_ENV, "garbage");
         assert_eq!(global_idle_timeout_from_env(), None);
-        unsafe { std::env::remove_var(IDLE_TIMEOUT_ENV) };
+        env.remove(IDLE_TIMEOUT_ENV);
         assert_eq!(global_idle_timeout_from_env(), None);
     }
 }

--- a/crates/mvm-hostd/src/supervisor/substitution_endpoint.rs
+++ b/crates/mvm-hostd/src/supervisor/substitution_endpoint.rs
@@ -207,6 +207,7 @@ mod tests {
     use super::*;
     use crate::keyholder::{BindingStore, SecretBindingMeta};
     use mvm_core::plan::SecretSource;
+    use mvm_core::util::test_env::TestEnv;
     use mvm_sdk::ir::AuthType;
     use secrecy::SecretBox;
     use tempfile::tempdir;
@@ -215,9 +216,8 @@ mod tests {
     fn build_audit_recorder_attaches_when_signer_key_present() {
         // No host signer key under a fresh data dir → no recorder (best-effort).
         let dir = tempdir().unwrap();
-        // SAFETY: single-threaded test; restored at scope end is unnecessary —
-        // each test process is isolated and this only steers the config helper.
-        unsafe { std::env::set_var("MVM_DATA_DIR", dir.path()) };
+        let mut env = TestEnv::new();
+        env.set("MVM_DATA_DIR", dir.path());
         assert!(
             build_audit_recorder("local").is_none(),
             "no signer key ⇒ no recorder"
@@ -230,7 +230,6 @@ mod tests {
             build_audit_recorder("local").is_some(),
             "signer key present ⇒ recorder attaches"
         );
-        unsafe { std::env::remove_var("MVM_DATA_DIR") };
     }
 
     fn vsock_cfg(secrets: Vec<SecretBinding>, dir: &std::path::Path) -> EndpointConfig {

--- a/specs/REFACTOR-STATUS.md
+++ b/specs/REFACTOR-STATUS.md
@@ -33,7 +33,7 @@ details** below for the workstream-level state.
 - [x] **PLAN 177** — Backend consolidation (8→4) · ✅ both phases merged (#806/#789/#812/#814/#817); DX-parity → Plan 189; lone caveat = host-gated hardware smoke
 - [x] **PLAN 182** — Trait hygiene + backend catalog · ✅ DONE — Clock/KeyProvider unified, `backend_catalog!` single-source, doctor sourced from it, arch docs current (all via #802). The lone open box (literal `cargo test --workspace`) is closed as documented-environmental: package-by-package + `-E 'not package(mvm-backend)'` are green; the aggregate only SIGKILLs the `mvm-backend` unit-test bin via macOS amfid codesign on this host (CI runs it green)
 - [x] **PLAN 184** — Backend descriptor registry · ✅ DONE — catalog promoted to a `BackendDescriptor` registry (descriptor-named helpers); dual `instantiate`/`instantiate_dyn` constructors with dyn↔enum parity test; doctor migrated to `instantiate_dyn`; `AnyBackend` narrowed to enum-specific ops (no duplication remained); boundary + ordering-freeze tests; arch/supervisor docs describe the behavior/discovery/dispatch split
-- [ ] **PLAN 185** — Idiomatic Rust hygiene audit · 🟢 shared TestEnv expanded into mvm-cli/mvm-build/mvm-core; guest hook tests de-shelled; mvm-core env tests (config/user_config/secret_binding) migrated onto TestEnv + config.rs's duplicate `ENV_TEST_LOCK` deleted; remaining: mvm-backend/mvm-build/mvm-hostd env-test tail, poison-lock policy, naming/typed-selector/unsafe-boundary phases
+- [ ] **PLAN 185** — Idiomatic Rust hygiene audit · 🟢 TestEnv migration advancing: mvm-core (config/user_config/secret_binding, `ENV_TEST_LOCK` deleted) + mvm-hostd (reaper/substitution_endpoint) + mvm-build `runtime_overlay` (`env_test_mutex` deleted) now on TestEnv; remaining: mvm-backend (host-gated SIGKILL), mvm-build libkrun_builder/builder_vm_runtime, mvm-cli, libkrun-sys; then poison-lock policy + naming/typed-selector/unsafe-boundary phases
 - [ ] **PLAN 189** — VZ DX parity (post-convergence) · 🟡 in progress — WS-3 `dev status --json` landed; remaining: save/restore verbs, cached fast-boot default, more --json coverage, base pinning (spun out of 177; sibling of 159)
 - [ ] **PLAN 175** — Firecracker live-memory warm-start · 🔴 not started (live-KVM-gated)
 - [x] **PLAN 183** — Builder-VM egress posture + network bootstrap · ✅ (E2E-proven 2026-06-12; Vz checkpoint-integration follow-ups tracked in the plan)
@@ -363,9 +363,15 @@ PLAN 185 — Idiomatic Rust hygiene audit         🟢 started
       (incl. deleting its duplicate per-module `ENV_TEST_LOCK`/`env_lock` helper),
       `user_config.rs`, `policy/secret_binding.rs`; manual save/restore boilerplate
       removed; 1248 mvm-core tests + clippy green
-  [ ] Roll `TestEnv` through remaining high-risk env-mutating tests in `mvm-backend`,
-      `mvm-cli`, `mvm-build`, `mvm-hostd`, `libkrun-sys` (incl. `mvm-core`
-      `domain/session` + `domain/template_tags`, which use a different `env::` form)
+  [x] Migrate `mvm-hostd` (reaper idle-timeout env + substitution_endpoint
+      MVM_DATA_DIR; added the `test-support` feature to its mvm-core dev-dep) and
+      `mvm-build` `runtime_overlay` (MVM_OVERLAY_BASE_URL; deleted its local
+      duplicate `env_test_mutex` OnceLock)
+  [ ] Roll `TestEnv` through the remaining env-mutating tests: `mvm-backend`
+      (host-gated: its test bin SIGKILLs under macOS amfid — migrate where CI/Linux
+      runs them), `mvm-build` `libkrun_builder`/`builder_vm_runtime` (each with a
+      local lock to fold), `mvm-cli`, `libkrun-sys`, + `mvm-core`
+      `domain/session` + `domain/template_tags` (different `env::` form)
   [ ] Standardize poisoned-lock handling by distinguishing test/global
       serialization locks from real runtime state locks
   [ ] Rename overly generic internal traits/types where the blast radius is


### PR DESCRIPTION
## What

Next Plan 185 (Phase 1, Task 2) slice — roll the shared `mvm_core::util::test_env::TestEnv` guard through `mvm-hostd` and one more `mvm-build` file.

- **mvm-hostd** — `reaper.rs` (idle-timeout env var) and `substitution_endpoint.rs` (`MVM_DATA_DIR`) tests move onto `TestEnv`. Adds the `test-support` feature to mvm-hostd's `mvm-core` **dev-dependency** (as mvm-cli/mvm-build already do) so the guard — gated behind `#[cfg(any(test, feature = "test-support"))]` — is in scope.
- **mvm-build** — `runtime_overlay.rs` (`MVM_OVERLAY_BASE_URL` tests) moves onto `TestEnv`, **deleting the file's local duplicate `env_test_mutex()` `OnceLock` lock** (the same dedup `config.rs` got) and the multi-line `unsafe` save/restore blocks.

Pure test-only; no production code touched.

## Scope note
The remaining tail is in the rollup: `mvm-backend` (host-gated — its test binary SIGKILLs under macOS amfid here, so better migrated where CI/Linux runs them), `mvm-build` `libkrun_builder`/`builder_vm_runtime` (each with a local lock to fold), `mvm-cli`, `libkrun-sys`, and `mvm-core` `domain/session`+`domain/template_tags`.

## Verification
- `cargo nextest run -p mvm-build -p mvm-hostd` — 1560 pass
- `cargo clippy -p mvm-hostd -p mvm-build --all-targets -- -D warnings` — clean
- `cargo fmt --all -- --check`, `check-no-spec-refs-in-comments`, `check-spec-numbers` — clean