### PR TITLE
test(build): migrate libkrun_builder + builder_vm_runtime onto TestEnv (Plan 185)

### DIFF
--- a/crates/mvm-build/src/builder_vm_runtime.rs
+++ b/crates/mvm-build/src/builder_vm_runtime.rs
@@ -1092,6 +1092,7 @@ pub fn builder_vm_timeout() -> Result<Duration, BuilderVmError> {
 mod tests {
     use super::*;
     use crate::builder_vm::{BuilderVmDisk, BuilderVmExitInfo, BuilderVmMount, BuilderVmRunConfig};
+    use mvm_core::util::test_env::TestEnv;
     use std::path::{Path, PathBuf};
     use std::time::Duration;
 
@@ -1775,106 +1776,56 @@ mod tests {
     }
 
     // -----------------------------------------------------------------
-    // builder_vm_timeout — reads
-    // MVM_BUILDER_VM_TIMEOUT_SECS from the process env; mutation is
-    // serialised through TIMEOUT_ENV_LOCK so concurrent test threads
-    // don't observe each other's writes.
+    // builder_vm_timeout — reads MVM_BUILDER_VM_TIMEOUT_SECS from the process
+    // env; `TestEnv` serializes env mutation across tests and restores it.
     // -----------------------------------------------------------------
-
-    use std::sync::{LazyLock, Mutex};
-
-    static TIMEOUT_ENV_LOCK: LazyLock<Mutex<()>> = LazyLock::new(|| Mutex::new(()));
 
     #[test]
     fn builder_vm_timeout_defaults_when_unset() {
-        let _lock = TIMEOUT_ENV_LOCK.lock().unwrap();
-        let old = std::env::var_os(MVM_BUILDER_VM_TIMEOUT_SECS_ENV);
-        // SAFETY: tests serialise env mutation via TIMEOUT_ENV_LOCK.
-        unsafe {
-            std::env::remove_var(MVM_BUILDER_VM_TIMEOUT_SECS_ENV);
-        }
+        let mut env = TestEnv::new();
+        env.remove(MVM_BUILDER_VM_TIMEOUT_SECS_ENV);
         assert_eq!(builder_vm_timeout().unwrap(), DEFAULT_BUILDER_VM_TIMEOUT);
-        unsafe {
-            match old {
-                Some(v) => std::env::set_var(MVM_BUILDER_VM_TIMEOUT_SECS_ENV, v),
-                None => std::env::remove_var(MVM_BUILDER_VM_TIMEOUT_SECS_ENV),
-            }
-        }
     }
 
     #[test]
     fn builder_vm_timeout_parses_positive_seconds() {
-        let _lock = TIMEOUT_ENV_LOCK.lock().unwrap();
-        let old = std::env::var_os(MVM_BUILDER_VM_TIMEOUT_SECS_ENV);
-        unsafe {
-            std::env::set_var(MVM_BUILDER_VM_TIMEOUT_SECS_ENV, "120");
-        }
+        let mut env = TestEnv::new();
+        env.set(MVM_BUILDER_VM_TIMEOUT_SECS_ENV, "120");
         assert_eq!(
             builder_vm_timeout().unwrap(),
             std::time::Duration::from_secs(120)
         );
-        unsafe {
-            match old {
-                Some(v) => std::env::set_var(MVM_BUILDER_VM_TIMEOUT_SECS_ENV, v),
-                None => std::env::remove_var(MVM_BUILDER_VM_TIMEOUT_SECS_ENV),
-            }
-        }
     }
 
     #[test]
     fn builder_vm_timeout_rejects_zero() {
-        let _lock = TIMEOUT_ENV_LOCK.lock().unwrap();
-        let old = std::env::var_os(MVM_BUILDER_VM_TIMEOUT_SECS_ENV);
-        unsafe {
-            std::env::set_var(MVM_BUILDER_VM_TIMEOUT_SECS_ENV, "0");
-        }
+        let mut env = TestEnv::new();
+        env.set(MVM_BUILDER_VM_TIMEOUT_SECS_ENV, "0");
         let err = builder_vm_timeout().unwrap_err();
         assert!(format!("{err}").contains("greater than zero"), "got {err}");
-        unsafe {
-            match old {
-                Some(v) => std::env::set_var(MVM_BUILDER_VM_TIMEOUT_SECS_ENV, v),
-                None => std::env::remove_var(MVM_BUILDER_VM_TIMEOUT_SECS_ENV),
-            }
-        }
     }
 
     #[test]
     fn builder_vm_timeout_rejects_non_integer() {
-        let _lock = TIMEOUT_ENV_LOCK.lock().unwrap();
-        let old = std::env::var_os(MVM_BUILDER_VM_TIMEOUT_SECS_ENV);
-        unsafe {
-            std::env::set_var(MVM_BUILDER_VM_TIMEOUT_SECS_ENV, "not-an-integer");
-        }
+        let mut env = TestEnv::new();
+        env.set(MVM_BUILDER_VM_TIMEOUT_SECS_ENV, "not-an-integer");
         let err = builder_vm_timeout().unwrap_err();
         let msg = format!("{err}");
         assert!(msg.contains("must be an integer"), "got: {msg}");
         // The bad value surfaces in the message so the operator
         // doesn't have to re-check their env to find the typo.
         assert!(msg.contains("not-an-integer"), "got: {msg}");
-        unsafe {
-            match old {
-                Some(v) => std::env::set_var(MVM_BUILDER_VM_TIMEOUT_SECS_ENV, v),
-                None => std::env::remove_var(MVM_BUILDER_VM_TIMEOUT_SECS_ENV),
-            }
-        }
     }
 
     // -----------------------------------------------------------------
-    // Builder persistent /nix store auto-GC. The cap is resolved
-    // on the host and baked into the rendered cmd.sh; env mutation is
-    // serialised through GC_ENV_LOCK like the timeout tests above.
+    // Builder persistent /nix store auto-GC. The cap is resolved on the host
+    // and baked into the rendered cmd.sh; `TestEnv` serializes env mutation.
     // -----------------------------------------------------------------
-
-    static GC_ENV_LOCK: LazyLock<Mutex<()>> = LazyLock::new(|| Mutex::new(()));
 
     #[test]
     fn render_flake_cmd_sh_embeds_gc_tail_with_default_cap() {
-        let _lock = GC_ENV_LOCK.lock().unwrap();
-        let old = std::env::var_os(MVM_BUILDER_STORE_GC_GIB_ENV);
-        // SAFETY: tests serialise env mutation via GC_ENV_LOCK.
-        unsafe {
-            std::env::remove_var(MVM_BUILDER_STORE_GC_GIB_ENV);
-        }
+        let mut env = TestEnv::new();
+        env.remove(MVM_BUILDER_STORE_GC_GIB_ENV);
         let body = render_flake_cmd_sh(".", "default", false);
         // Age-based GC is required (keeps the just-built closure warm).
         assert!(
@@ -1909,24 +1860,14 @@ mod tests {
             warm_idx < gc_idx,
             "warm gcroot must be registered before the GC tail"
         );
-        unsafe {
-            match old {
-                Some(v) => std::env::set_var(MVM_BUILDER_STORE_GC_GIB_ENV, v),
-                None => std::env::remove_var(MVM_BUILDER_STORE_GC_GIB_ENV),
-            }
-        }
     }
 
     #[test]
     fn builder_store_gc_cap_kib_default_override_and_garbage() {
-        let _lock = GC_ENV_LOCK.lock().unwrap();
-        let old = std::env::var_os(MVM_BUILDER_STORE_GC_GIB_ENV);
+        let mut env = TestEnv::new();
 
         // Unset → default 24 GiB in KiB.
-        // SAFETY: tests serialise env mutation via GC_ENV_LOCK.
-        unsafe {
-            std::env::remove_var(MVM_BUILDER_STORE_GC_GIB_ENV);
-        }
+        env.remove(MVM_BUILDER_STORE_GC_GIB_ENV);
         assert_eq!(
             builder_store_gc_cap_kib(),
             u64::from(DEFAULT_BUILDER_STORE_GC_GIB) * 1024 * 1024
@@ -1934,28 +1875,15 @@ mod tests {
         assert_eq!(builder_store_gc_cap_kib(), 25_165_824);
 
         // Valid override → that many GiB in KiB.
-        unsafe {
-            std::env::set_var(MVM_BUILDER_STORE_GC_GIB_ENV, "8");
-        }
+        env.set(MVM_BUILDER_STORE_GC_GIB_ENV, "8");
         assert_eq!(builder_store_gc_cap_kib(), 8 * 1024 * 1024);
 
         // Garbage → fall back to default (best-effort cap, never disabled).
-        unsafe {
-            std::env::set_var(MVM_BUILDER_STORE_GC_GIB_ENV, "not-a-number");
-        }
+        env.set(MVM_BUILDER_STORE_GC_GIB_ENV, "not-a-number");
         assert_eq!(builder_store_gc_cap_kib(), 25_165_824);
 
         // Zero → also falls back (zero would GC the just-built closure).
-        unsafe {
-            std::env::set_var(MVM_BUILDER_STORE_GC_GIB_ENV, "0");
-        }
+        env.set(MVM_BUILDER_STORE_GC_GIB_ENV, "0");
         assert_eq!(builder_store_gc_cap_kib(), 25_165_824);
-
-        unsafe {
-            match old {
-                Some(v) => std::env::set_var(MVM_BUILDER_STORE_GC_GIB_ENV, v),
-                None => std::env::remove_var(MVM_BUILDER_STORE_GC_GIB_ENV),
-            }
-        }
     }
 }

--- a/crates/mvm-build/src/libkrun_builder.rs
+++ b/crates/mvm-build/src/libkrun_builder.rs
@@ -2180,10 +2180,8 @@ impl PersistentVmHandle {
 mod tests {
     use super::*;
     use crate::builder_vm_runtime::{INSTALL_SPEC_FILENAME, shell_single_quote_escape};
-    use std::sync::{LazyLock, Mutex};
+    use mvm_core::util::test_env::TestEnv;
     use tempfile::TempDir;
-
-    static ENV_LOCK: LazyLock<Mutex<()>> = LazyLock::new(|| Mutex::new(()));
 
     fn ok_mounts(scratch: &TempDir) -> BuilderMounts {
         let flake = scratch.path().join("flake");
@@ -2221,57 +2219,53 @@ mod tests {
 
     #[test]
     fn resolve_networking_mode_parses_env() {
-        let _guard = ENV_LOCK.lock().unwrap();
-        // SAFETY: tests guarded by ENV_LOCK; env mutation in test
-        // process is fine when serialized.
-        unsafe {
-            // Default is per-OS — macOS → Gvproxy, others → Passt.
-            std::env::remove_var("MVM_NETWORKING");
-            assert_eq!(resolve_networking_mode(), default_networking_mode());
+        let mut env = TestEnv::new();
+        // Default is per-OS — macOS → Gvproxy, others → Passt.
+        env.remove("MVM_NETWORKING");
+        assert_eq!(resolve_networking_mode(), default_networking_mode());
 
-            std::env::set_var("MVM_NETWORKING", " passt ");
-            // passt is Linux-only (the Homebrew formula refuses to build it on
-            // macOS), so an explicit passt pin is macOS-safe: resolve falls back
-            // to gvproxy with a warning rather than handing the supervisor a
-            // gateway it can't spawn.
-            if cfg!(target_os = "macos") {
-                assert_eq!(resolve_networking_mode(), NetworkingPreference::Gvproxy);
-            } else {
-                assert_eq!(resolve_networking_mode(), NetworkingPreference::Passt);
-            }
-
-            std::env::set_var("MVM_NETWORKING", "GVPROXY");
+        env.set("MVM_NETWORKING", " passt ");
+        // passt is Linux-only (the Homebrew formula refuses to build it on
+        // macOS), so an explicit passt pin is macOS-safe: resolve falls back
+        // to gvproxy with a warning rather than handing the supervisor a
+        // gateway it can't spawn.
+        if cfg!(target_os = "macos") {
             assert_eq!(resolve_networking_mode(), NetworkingPreference::Gvproxy);
-
-            std::env::set_var("MVM_NETWORKING", " gvproxy ");
-            assert_eq!(resolve_networking_mode(), NetworkingPreference::Gvproxy);
-
-            std::env::set_var("MVM_NETWORKING", "");
-            assert_eq!(resolve_networking_mode(), default_networking_mode());
-
-            // Unknown value falls back to the per-OS default without panic.
-            std::env::set_var("MVM_NETWORKING", "vmnet-helper");
-            assert_eq!(resolve_networking_mode(), default_networking_mode());
-
-            // `native` requires MVM_GATEWAY_BIN to name the gateway binary;
-            // without it, it falls back (fail-safe, no wrong-gateway spawn).
-            std::env::remove_var("MVM_GATEWAY_BIN");
-            std::env::set_var("MVM_NETWORKING", "native");
-            assert_eq!(
-                resolve_networking_mode(),
-                default_networking_mode(),
-                "native without MVM_GATEWAY_BIN must fall back to the per-OS default"
-            );
-            // With MVM_GATEWAY_BIN set, `native` resolves (case- and
-            // whitespace-insensitive like the other accepted values).
-            std::env::set_var("MVM_GATEWAY_BIN", "/path/to/gateway");
-            assert_eq!(resolve_networking_mode(), NetworkingPreference::Native);
-            std::env::set_var("MVM_NETWORKING", " NATIVE ");
-            assert_eq!(resolve_networking_mode(), NetworkingPreference::Native);
-            std::env::remove_var("MVM_GATEWAY_BIN");
-
-            std::env::remove_var("MVM_NETWORKING");
+        } else {
+            assert_eq!(resolve_networking_mode(), NetworkingPreference::Passt);
         }
+
+        env.set("MVM_NETWORKING", "GVPROXY");
+        assert_eq!(resolve_networking_mode(), NetworkingPreference::Gvproxy);
+
+        env.set("MVM_NETWORKING", " gvproxy ");
+        assert_eq!(resolve_networking_mode(), NetworkingPreference::Gvproxy);
+
+        env.set("MVM_NETWORKING", "");
+        assert_eq!(resolve_networking_mode(), default_networking_mode());
+
+        // Unknown value falls back to the per-OS default without panic.
+        env.set("MVM_NETWORKING", "vmnet-helper");
+        assert_eq!(resolve_networking_mode(), default_networking_mode());
+
+        // `native` requires MVM_GATEWAY_BIN to name the gateway binary;
+        // without it, it falls back (fail-safe, no wrong-gateway spawn).
+        env.remove("MVM_GATEWAY_BIN");
+        env.set("MVM_NETWORKING", "native");
+        assert_eq!(
+            resolve_networking_mode(),
+            default_networking_mode(),
+            "native without MVM_GATEWAY_BIN must fall back to the per-OS default"
+        );
+        // With MVM_GATEWAY_BIN set, `native` resolves (case- and
+        // whitespace-insensitive like the other accepted values).
+        env.set("MVM_GATEWAY_BIN", "/path/to/gateway");
+        assert_eq!(resolve_networking_mode(), NetworkingPreference::Native);
+        env.set("MVM_NETWORKING", " NATIVE ");
+        assert_eq!(resolve_networking_mode(), NetworkingPreference::Native);
+        env.remove("MVM_GATEWAY_BIN");
+
+        env.remove("MVM_NETWORKING");
     }
 
     #[test]
@@ -2280,20 +2274,17 @@ mod tests {
         // resolve to a TSI mode — it falls back to the
         // per-OS gateway default with a warning. This guards the
         // claim-10 no-bypass invariant at the env-var surface.
-        let _guard = ENV_LOCK.lock().unwrap();
-        // SAFETY: ENV_LOCK serializes env mutation across tests.
-        unsafe {
-            for variant in ["tsi", "TSI", "Tsi", " tsi ", "tSi"] {
-                std::env::set_var("MVM_NETWORKING", variant);
-                assert_eq!(
-                    resolve_networking_mode(),
-                    default_networking_mode(),
-                    "MVM_NETWORKING={variant} must fall back to per-OS default \
-                     (TSI was removed in Plan 102 W6.A)"
-                );
-            }
-            std::env::remove_var("MVM_NETWORKING");
+        let mut env = TestEnv::new();
+        for variant in ["tsi", "TSI", "Tsi", " tsi ", "tSi"] {
+            env.set("MVM_NETWORKING", variant);
+            assert_eq!(
+                resolve_networking_mode(),
+                default_networking_mode(),
+                "MVM_NETWORKING={variant} must fall back to per-OS default \
+                 (TSI was removed)"
+            );
         }
+        env.remove("MVM_NETWORKING");
     }
 
     #[test]
@@ -2715,12 +2706,9 @@ mod tests {
 
     #[test]
     fn ensure_builder_vm_image_requires_cmdline_txt() {
-        let _lock = ENV_LOCK.lock().unwrap();
+        let mut env = TestEnv::new();
         let scratch = TempDir::new().unwrap();
-        let old = std::env::var("XDG_CACHE_HOME").ok();
-        unsafe {
-            std::env::set_var("XDG_CACHE_HOME", scratch.path());
-        }
+        env.set("XDG_CACHE_HOME", scratch.path());
 
         let arch_dir = scratch
             .path()
@@ -2736,13 +2724,6 @@ mod tests {
             format!("{err}").contains("cmdline.txt missing or unreadable"),
             "got {err}"
         );
-
-        unsafe {
-            match old {
-                Some(v) => std::env::set_var("XDG_CACHE_HOME", v),
-                None => std::env::remove_var("XDG_CACHE_HOME"),
-            }
-        }
     }
 
     // `builder_vm_timeout_*` tests migrated to `builder_vm_runtime`

--- a/specs/REFACTOR-STATUS.md
+++ b/specs/REFACTOR-STATUS.md
@@ -33,7 +33,7 @@ details** below for the workstream-level state.
 - [x] **PLAN 177** — Backend consolidation (8→4) · ✅ both phases merged (#806/#789/#812/#814/#817); DX-parity → Plan 189; lone caveat = host-gated hardware smoke
 - [x] **PLAN 182** — Trait hygiene + backend catalog · ✅ DONE — Clock/KeyProvider unified, `backend_catalog!` single-source, doctor sourced from it, arch docs current (all via #802). The lone open box (literal `cargo test --workspace`) is closed as documented-environmental: package-by-package + `-E 'not package(mvm-backend)'` are green; the aggregate only SIGKILLs the `mvm-backend` unit-test bin via macOS amfid codesign on this host (CI runs it green)
 - [x] **PLAN 184** — Backend descriptor registry · ✅ DONE — catalog promoted to a `BackendDescriptor` registry (descriptor-named helpers); dual `instantiate`/`instantiate_dyn` constructors with dyn↔enum parity test; doctor migrated to `instantiate_dyn`; `AnyBackend` narrowed to enum-specific ops (no duplication remained); boundary + ordering-freeze tests; arch/supervisor docs describe the behavior/discovery/dispatch split
-- [ ] **PLAN 185** — Idiomatic Rust hygiene audit · 🟢 TestEnv migration advancing: mvm-core (config/user_config/secret_binding, `ENV_TEST_LOCK` deleted) + mvm-hostd (reaper/substitution_endpoint) + mvm-build `runtime_overlay` (`env_test_mutex` deleted) now on TestEnv; remaining: mvm-backend (host-gated SIGKILL), mvm-build libkrun_builder/builder_vm_runtime, mvm-cli, libkrun-sys; then poison-lock policy + naming/typed-selector/unsafe-boundary phases
+- [ ] **PLAN 185** — Idiomatic Rust hygiene audit · 🟢 TestEnv migration advancing: mvm-core (config/user_config/secret_binding) + mvm-hostd (reaper/substitution_endpoint) + mvm-build (runtime_overlay, libkrun_builder, builder_vm_runtime) now on TestEnv — **6 duplicate local test locks deleted** (`ENV_TEST_LOCK`, `env_test_mutex`, `ENV_LOCK`, `TIMEOUT_ENV_LOCK`, `GC_ENV_LOCK`, …); remaining: mvm-backend (host-gated SIGKILL), mvm-cli, libkrun-sys, mvm-core domain/session+template_tags; then poison-lock policy + naming/typed-selector/unsafe-boundary phases
 - [ ] **PLAN 189** — VZ DX parity (post-convergence) · 🟡 in progress — WS-3 `dev status --json` landed; remaining: save/restore verbs, cached fast-boot default, more --json coverage, base pinning (spun out of 177; sibling of 159)
 - [ ] **PLAN 175** — Firecracker live-memory warm-start · 🔴 not started (live-KVM-gated)
 - [x] **PLAN 183** — Builder-VM egress posture + network bootstrap · ✅ (E2E-proven 2026-06-12; Vz checkpoint-integration follow-ups tracked in the plan)
@@ -367,10 +367,13 @@ PLAN 185 — Idiomatic Rust hygiene audit         🟢 started
       MVM_DATA_DIR; added the `test-support` feature to its mvm-core dev-dep) and
       `mvm-build` `runtime_overlay` (MVM_OVERLAY_BASE_URL; deleted its local
       duplicate `env_test_mutex` OnceLock)
+  [x] Migrate `mvm-build` `libkrun_builder` (`ENV_LOCK`; MVM_NETWORKING/
+      MVM_GATEWAY_BIN/XDG_CACHE_HOME tests — green under `--features builder-vm`)
+      and `builder_vm_runtime` (`TIMEOUT_ENV_LOCK` + `GC_ENV_LOCK`; timeout +
+      /nix-store GC-cap tests, dropping the let-old/match-old restore boilerplate)
   [ ] Roll `TestEnv` through the remaining env-mutating tests: `mvm-backend`
       (host-gated: its test bin SIGKILLs under macOS amfid — migrate where CI/Linux
-      runs them), `mvm-build` `libkrun_builder`/`builder_vm_runtime` (each with a
-      local lock to fold), `mvm-cli`, `libkrun-sys`, + `mvm-core`
+      runs them), `mvm-cli`, `libkrun-sys`, + `mvm-core`
       `domain/session` + `domain/template_tags` (different `env::` form)
   [ ] Standardize poisoned-lock handling by distinguishing test/global
       serialization locks from real runtime state locks


### PR DESCRIPTION
## What

Next Plan 185 slice — finish the `mvm-build` env-mutating tests onto the shared `mvm_core::util::test_env::TestEnv` guard, deleting **three more duplicate local locks**:

- **`builder_vm_runtime.rs`** — `TIMEOUT_ENV_LOCK` + `GC_ENV_LOCK` (builder-VM timeout + persistent `/nix`-store GC-cap tests). Also drops the per-test `let old = var_os(...)` / trailing `match old { Some/None }` save+restore boilerplate (TestEnv restores on drop).
- **`libkrun_builder.rs`** — `ENV_LOCK` (the `MVM_NETWORKING`/`MVM_GATEWAY_BIN` resolve tests + the `XDG_CACHE_HOME` image test). The whole-body `unsafe {}` blocks collapse to `env.set`/`env.remove`.

Pure test-only; no production code touched (production reads env via `std::env::var`/`var_os`, unchanged).

## Verification
- `cargo nextest run -p mvm-build` — 537 pass (builder_vm_runtime tests run by default)
- `cargo nextest run -p mvm-build --features builder-vm` filtered — the 3 libkrun_builder tests pass (they're `builder-vm`-gated)
- `cargo clippy -p mvm-build --all-targets -- -D warnings` and `... --features builder-vm ...` — both clean
- `cargo fmt --all -- --check`, `check-no-spec-refs-in-comments`, `check-spec-numbers` — clean

## Remaining 185 tail (rollup)
`mvm-backend` (host-gated amfid SIGKILL — best on CI/Linux), `mvm-cli`, `libkrun-sys`, mvm-core `domain/session`+`domain/template_tags`; then Phases 2–7 (poison-lock policy, naming, typed selectors, unsafe-boundary audit).