### PR TITLE
test(core,libkrun-sys): migrate env tests onto TestEnv + drop 3 more local locks (Plan 185)

### DIFF
--- a/crates/deps/libkrun-sys/Cargo.toml
+++ b/crates/deps/libkrun-sys/Cargo.toml
@@ -92,6 +92,8 @@ libkrun-sys = []
 [dev-dependencies]
 # passt supervisor tests stage scratch dirs.
 tempfile.workspace = true
+# `TestEnv` env-var guard for the passt/gvproxy PATH + MVM_GATEWAY_BIN tests.
+mvm-core = { workspace = true, features = ["test-support"] }
 # The smoke example shares `GUEST_AGENT_PORT` with the production vsock
 # plumbing.
 mvm-guest.workspace = true

--- a/crates/deps/libkrun-sys/src/gvproxy.rs
+++ b/crates/deps/libkrun-sys/src/gvproxy.rs
@@ -455,7 +455,7 @@ fn pid_alive(pid: i32) -> bool {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::TEST_ENV_LOCK as ENV_LOCK;
+    use mvm_core::util::test_env::TestEnv;
 
     #[test]
     fn install_hint_is_platform_specific() {
@@ -476,20 +476,17 @@ mod tests {
     /// empty value is ignored so it falls back to the `$PATH` probe.
     #[test]
     fn locate_gvproxy_honors_gateway_bin_override() {
-        let _guard = ENV_LOCK.lock().unwrap();
-        // SAFETY: env mutation serialized by the crate-wide TEST_ENV_LOCK.
-        unsafe {
-            std::env::set_var("MVM_GATEWAY_BIN", "/opt/mvm/native-gateway");
-            assert_eq!(
-                locate_gvproxy(),
-                Some(PathBuf::from("/opt/mvm/native-gateway")),
-                "MVM_GATEWAY_BIN must override the default gvproxy lookup"
-            );
-            std::env::set_var("MVM_GATEWAY_BIN", "");
-            // Empty → ignored; must not return an empty path.
-            assert_ne!(locate_gvproxy(), Some(PathBuf::new()));
-            std::env::remove_var("MVM_GATEWAY_BIN");
-        }
+        let mut env = TestEnv::new();
+        env.set("MVM_GATEWAY_BIN", "/opt/mvm/native-gateway");
+        assert_eq!(
+            locate_gvproxy(),
+            Some(PathBuf::from("/opt/mvm/native-gateway")),
+            "MVM_GATEWAY_BIN must override the default gvproxy lookup"
+        );
+        env.set("MVM_GATEWAY_BIN", "");
+        // Empty → ignored; must not return an empty path.
+        assert_ne!(locate_gvproxy(), Some(PathBuf::new()));
+        env.remove("MVM_GATEWAY_BIN");
     }
 
     /// A reserved port is in gvproxy's accepted `-ssh-port` range
@@ -508,20 +505,10 @@ mod tests {
 
     #[test]
     fn spawn_without_gvproxy_returns_not_installed() {
-        let _guard = ENV_LOCK.lock().unwrap();
+        let mut env = TestEnv::new();
         let tmp = tempfile::tempdir().unwrap();
-        let original_path = std::env::var_os("PATH");
-        // SAFETY: tests are single-threaded; serialize env mutation.
-        unsafe {
-            std::env::set_var("PATH", tmp.path());
-        }
+        env.set("PATH", tmp.path());
         let result = spawn(tmp.path());
-        unsafe {
-            match original_path {
-                Some(v) => std::env::set_var("PATH", v),
-                None => std::env::remove_var("PATH"),
-            }
-        }
         match result {
             Err(GvproxyError::NotInstalled { install_hint }) => {
                 assert!(!install_hint.is_empty());
@@ -567,13 +554,13 @@ mod tests {
 
     /// `reap_by_pid_file` SIGTERMs the pid named in the sidecar and
     /// removes the sidecar + socket. Uses a real `sleep` child as the
-    /// stand-in daemon — no gvproxy needed. Holds `ENV_LOCK` so the
-    /// PATH-mutating `spawn_without_gvproxy_*` test can't make our
+    /// stand-in daemon — no gvproxy needed. Holds the shared `TestEnv` guard
+    /// so the PATH-mutating `spawn_without_gvproxy_*` test can't make our
     /// `sleep` lookup miss.
     #[test]
     fn reap_by_pid_file_kills_live_pid_and_cleans_files() {
         use std::os::unix::process::ExitStatusExt;
-        let _guard = ENV_LOCK.lock().unwrap();
+        let _env = TestEnv::new();
         let tmp = tempfile::tempdir().unwrap();
         let mut child = Command::new("sleep")
             .arg("30")
@@ -610,7 +597,9 @@ mod tests {
     /// (no panic, stale files swept).
     #[test]
     fn reap_by_pid_file_missing_or_stale_is_noop() {
-        let _guard = ENV_LOCK.lock().unwrap();
+        // No env mutation here, but hold the shared guard so a PATH-mutating
+        // test can't hide `sleep` from this test's `Command::new` mid-run.
+        let _env = TestEnv::new();
         let tmp = tempfile::tempdir().unwrap();
         // Missing sidecar — must not panic.
         reap_by_pid_file(tmp.path());

--- a/crates/deps/libkrun-sys/src/lib.rs
+++ b/crates/deps/libkrun-sys/src/lib.rs
@@ -57,15 +57,6 @@ pub mod gvproxy;
 // a dependency cycle (`mvm-backend` can't depend on `mvm-hostd`).
 pub mod framing;
 
-/// Cross-module env mutation serializer. Both `passt::tests` and
-/// `gvproxy::tests` mutate `$PATH` to verify their `NotInstalled`
-/// error paths; `cargo test`'s default parallelism would race them
-/// otherwise and leak the "set PATH to a tmp dir" state across the
-/// two tests, making one's spawn call see the other's modified env.
-#[cfg(test)]
-pub(crate) static TEST_ENV_LOCK: std::sync::LazyLock<std::sync::Mutex<()>> =
-    std::sync::LazyLock::new(|| std::sync::Mutex::new(()));
-
 /// Errors returned by this crate.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum Error {

--- a/crates/deps/libkrun-sys/src/passt.rs
+++ b/crates/deps/libkrun-sys/src/passt.rs
@@ -328,7 +328,7 @@ fn clear_cloexec(fd: RawFd) -> io::Result<()> {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::TEST_ENV_LOCK as ENV_LOCK;
+    use mvm_core::util::test_env::TestEnv;
     use std::path::Path;
 
     #[test]
@@ -349,25 +349,11 @@ mod tests {
 
     #[test]
     fn spawn_without_passt_returns_not_installed() {
-        let _guard = ENV_LOCK
-            .lock()
-            .unwrap_or_else(|poisoned| poisoned.into_inner());
-        // Hide passt from PATH for this test by setting PATH to
-        // an empty dir.
+        let mut env = TestEnv::new();
+        // Hide passt from PATH for this test by setting PATH to an empty dir.
         let tmp = tempfile::tempdir().unwrap();
-        let original_path = std::env::var_os("PATH");
-        // SAFETY: tests are single-threaded by default in Rust;
-        // set_var is fine here as long as we restore.
-        unsafe {
-            std::env::set_var("PATH", tmp.path());
-        }
+        env.set("PATH", tmp.path());
         let result = spawn(tmp.path());
-        unsafe {
-            match original_path {
-                Some(v) => std::env::set_var("PATH", v),
-                None => std::env::remove_var("PATH"),
-            }
-        }
         match result {
             Err(PasstError::NotInstalled { install_hint }) => {
                 assert!(!install_hint.is_empty());

--- a/crates/mvm-core/src/domain/session.rs
+++ b/crates/mvm-core/src/domain/session.rs
@@ -599,44 +599,18 @@ mod tests {
     /// lock for the duration so parallel tests don't race the env var.
     struct RuntimeDirGuard {
         _temp: tempfile::TempDir,
-        _lock: std::sync::MutexGuard<'static, ()>,
-        prev: Option<String>,
+        _env: crate::util::test_env::TestEnv,
     }
-
-    impl Drop for RuntimeDirGuard {
-        fn drop(&mut self) {
-            // SAFETY: the static mutex guarantees only one test at a time
-            // mutates the env vars these helpers consult.
-            unsafe {
-                match self.prev.take() {
-                    Some(prev) => std::env::set_var("MVM_RUNTIME_DIR", prev),
-                    None => std::env::remove_var("MVM_RUNTIME_DIR"),
-                }
-            }
-        }
-    }
-
-    /// Serializes env-mutating tests within this module. `cargo test` runs
-    /// tests across threads by default, but `std::env::set_var` is
-    /// process-global — without this lock, two tests setting different
-    /// runtime dirs race each other.
-    static ENV_LOCK: std::sync::Mutex<()> = std::sync::Mutex::new(());
 
     fn isolated_runtime_dir() -> RuntimeDirGuard {
-        let lock = ENV_LOCK
-            .lock()
-            .unwrap_or_else(|poisoned| poisoned.into_inner());
         let temp = tempfile::tempdir().expect("tempdir");
-        let prev = std::env::var("MVM_RUNTIME_DIR").ok();
-        // SAFETY: the lock above ensures no other test in this module is
-        // touching `MVM_RUNTIME_DIR` concurrently.
-        unsafe {
-            std::env::set_var("MVM_RUNTIME_DIR", temp.path());
-        }
+        // `TestEnv` serializes env-mutating tests behind a process-wide lock
+        // and restores `MVM_RUNTIME_DIR` to its prior value on drop.
+        let mut env = crate::util::test_env::TestEnv::new();
+        env.set("MVM_RUNTIME_DIR", temp.path());
         RuntimeDirGuard {
             _temp: temp,
-            _lock: lock,
-            prev,
+            _env: env,
         }
     }
 

--- a/crates/mvm-core/src/domain/template_tags.rs
+++ b/crates/mvm-core/src/domain/template_tags.rs
@@ -215,41 +215,24 @@ fn validate_revision_hash(s: &str) -> Result<()> {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use std::sync::Mutex;
 
     /// Test guard that overrides `MVM_DATA_DIR` to a tempdir so
     /// concurrent tests don't share `~/.mvm/templates/...` state.
     struct DataDirGuard {
-        _guard: std::sync::MutexGuard<'static, ()>,
-        prev: Option<String>,
+        _env: crate::util::test_env::TestEnv,
         _tmp: tempfile::TempDir,
     }
 
-    static DATA_DIR_LOCK: Mutex<()> = Mutex::new(());
-
     impl DataDirGuard {
         fn new() -> Self {
-            let g = DATA_DIR_LOCK.lock().unwrap_or_else(|e| e.into_inner());
             let tmp = tempfile::tempdir().expect("tempdir");
-            let prev = std::env::var("MVM_DATA_DIR").ok();
-            unsafe {
-                std::env::set_var("MVM_DATA_DIR", tmp.path());
-            }
+            // `TestEnv` serializes env-mutating tests behind a process-wide
+            // lock and restores `MVM_DATA_DIR` on drop.
+            let mut env = crate::util::test_env::TestEnv::new();
+            env.set("MVM_DATA_DIR", tmp.path());
             DataDirGuard {
-                _guard: g,
-                prev,
+                _env: env,
                 _tmp: tmp,
-            }
-        }
-    }
-
-    impl Drop for DataDirGuard {
-        fn drop(&mut self) {
-            unsafe {
-                match &self.prev {
-                    Some(v) => std::env::set_var("MVM_DATA_DIR", v),
-                    None => std::env::remove_var("MVM_DATA_DIR"),
-                }
             }
         }
     }

--- a/specs/REFACTOR-STATUS.md
+++ b/specs/REFACTOR-STATUS.md
@@ -34,7 +34,7 @@ details** below for the workstream-level state.
 - [x] **PLAN 177** — Backend consolidation (8→4) · ✅ both phases merged (#806/#789/#812/#814/#817); DX-parity → Plan 189; lone caveat = host-gated hardware smoke
 - [x] **PLAN 182** — Trait hygiene + backend catalog · ✅ DONE — Clock/KeyProvider unified, `backend_catalog!` single-source, doctor sourced from it, arch docs current (all via #802). The lone open box (literal `cargo test --workspace`) is closed as documented-environmental: package-by-package + `-E 'not package(mvm-backend)'` are green; the aggregate only SIGKILLs the `mvm-backend` unit-test bin via macOS amfid codesign on this host (CI runs it green)
 - [x] **PLAN 184** — Backend descriptor registry · ✅ DONE — catalog promoted to a `BackendDescriptor` registry (descriptor-named helpers); dual `instantiate`/`instantiate_dyn` constructors with dyn↔enum parity test; doctor migrated to `instantiate_dyn`; `AnyBackend` narrowed to enum-specific ops (no duplication remained); boundary + ordering-freeze tests; arch/supervisor docs describe the behavior/discovery/dispatch split
-- [ ] **PLAN 185** — Idiomatic Rust hygiene audit · 🟢 TestEnv migration advancing: mvm-core (config/user_config/secret_binding) + mvm-hostd (reaper/substitution_endpoint) + mvm-build (runtime_overlay, libkrun_builder, builder_vm_runtime) now on TestEnv — **6 duplicate local test locks deleted** (`ENV_TEST_LOCK`, `env_test_mutex`, `ENV_LOCK`, `TIMEOUT_ENV_LOCK`, `GC_ENV_LOCK`, …); remaining: mvm-backend (host-gated SIGKILL), mvm-cli, libkrun-sys, mvm-core domain/session+template_tags; then poison-lock policy + naming/typed-selector/unsafe-boundary phases
+- [ ] **PLAN 185** — Idiomatic Rust hygiene audit · 🟢 TestEnv migration advancing: mvm-core (config/user_config/secret_binding + domain/session+template_tags) + mvm-hostd (reaper/substitution_endpoint) + mvm-build (runtime_overlay, libkrun_builder, builder_vm_runtime) + libkrun-sys (gvproxy/passt) now on TestEnv — **9 duplicate local test locks deleted** (`ENV_TEST_LOCK`, `env_test_mutex`, `ENV_LOCK`×2, `TIMEOUT_ENV_LOCK`, `GC_ENV_LOCK`, `DATA_DIR_LOCK`, `TEST_ENV_LOCK`, …); remaining: **mvm-cli** (last big batch) + mvm-backend (host-gated amfid SIGKILL — best on CI/Linux); then poison-lock policy + naming/typed-selector/unsafe-boundary phases
 - [ ] **PLAN 189** — VZ DX parity (post-convergence) · 🟡 in progress — WS-3 `dev status --json` landed; remaining: save/restore verbs, cached fast-boot default, more --json coverage, base pinning (spun out of 177; sibling of 159)
 - [ ] **PLAN 175** — Firecracker live-memory warm-start · 🔴 not started (live-KVM-gated)
 - [x] **PLAN 183** — Builder-VM egress posture + network bootstrap · ✅ (E2E-proven 2026-06-12; Vz checkpoint-integration follow-ups tracked in the plan)
@@ -374,10 +374,15 @@ PLAN 185 — Idiomatic Rust hygiene audit         🟢 started
       MVM_GATEWAY_BIN/XDG_CACHE_HOME tests — green under `--features builder-vm`)
       and `builder_vm_runtime` (`TIMEOUT_ENV_LOCK` + `GC_ENV_LOCK`; timeout +
       /nix-store GC-cap tests, dropping the let-old/match-old restore boilerplate)
-  [ ] Roll `TestEnv` through the remaining env-mutating tests: `mvm-backend`
-      (host-gated: its test bin SIGKILLs under macOS amfid — migrate where CI/Linux
-      runs them), `mvm-cli`, `libkrun-sys`, + `mvm-core`
-      `domain/session` + `domain/template_tags` (different `env::` form)
+  [x] Migrate `mvm-core` `domain/session` (`RuntimeDirGuard`→TestEnv, `ENV_LOCK`)
+      + `domain/template_tags` (`DataDirGuard`→TestEnv, `DATA_DIR_LOCK`) and
+      `libkrun-sys` `gvproxy`/`passt` (PATH + MVM_GATEWAY_BIN tests; deleted the
+      crate-wide `TEST_ENV_LOCK`, added the mvm-core `test-support` dev-dep;
+      lock-only reap tests keep a bare `TestEnv` guard)
+  [ ] Roll `TestEnv` through the remaining env-mutating tests: `mvm-cli` (the last
+      big batch — doctor/up/session/tenant_resolution/template_cmd/ops·mcp/build·*)
+      and `mvm-backend` (host-gated: its test bin SIGKILLs under macOS amfid —
+      migrate where CI/Linux runs them)
   [ ] Standardize poisoned-lock handling by distinguishing test/global
       serialization locks from real runtime state locks
   [ ] Rename overly generic internal traits/types where the blast radius is


### PR DESCRIPTION
## What

Next Plan 185 slice — migrate the `mvm-core` `domain` + `libkrun-sys` env-mutating tests onto the shared `mvm_core::util::test_env::TestEnv` guard, deleting **three more duplicate local locks**.

- **mvm-core `domain/session.rs`** — `RuntimeDirGuard` now wraps a `TestEnv` instead of a hand-rolled `MutexGuard` + `prev: Option<String>` + `Drop` restore. Deletes the local `ENV_LOCK`.
- **mvm-core `domain/template_tags.rs`** — same for `DataDirGuard`. Deletes the local `DATA_DIR_LOCK`.
- **libkrun-sys `gvproxy.rs` + `passt.rs`** — the PATH / `MVM_GATEWAY_BIN` tests move onto `TestEnv`. Deletes the **crate-wide `TEST_ENV_LOCK`** in `lib.rs` and adds the `test-support` feature to the `mvm-core` dev-dependency. The lock-only `reap_by_pid_file_*` tests (no env mutation, but must serialize against the PATH-mutating tests so their `Command::new("sleep")` isn't starved) hold a bare `TestEnv` guard.

Pure test-only; no production code touched.

## Verification
- `cargo nextest run -p mvm-core -p libkrun-sys` — 1317 pass
- `cargo clippy -p mvm-core -p libkrun-sys --all-targets -- -D warnings` — clean
- `cargo fmt --all -- --check`, `check-no-spec-refs-in-comments`, `check-spec-numbers` — clean

## Remaining 185 tail
`mvm-cli` (the last big batch — doctor/up/session/tenant_resolution/template_cmd/ops·mcp/build·*) and `mvm-backend` (host-gated amfid SIGKILL — best on CI/Linux); then Phases 2–7.