### PR TITLE
test(cli): artifact_verify + sandbox_record env tests onto TestEnv (Plan 185)

### DIFF
--- a/crates/mvm-cli/src/commands/build/sandbox_record.rs
+++ b/crates/mvm-cli/src/commands/build/sandbox_record.rs
@@ -250,41 +250,23 @@ fn env_override(name: &str) -> Option<PathBuf> {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use std::sync::Mutex;
+    use mvm_core::util::test_env::TestEnv;
 
-    /// Serializes tests that mutate `MVM_TSX` (process-wide).
-    static ENV_LOCK: Mutex<()> = Mutex::new(());
-
-    /// Restore-on-drop guard for `MVM_TSX`. Used to exercise the
-    /// env-override short-circuit in `resolve_interpreter` without
-    /// leaking state into sibling tests.
+    /// Restore-on-drop guard for `MVM_TSX`, built on the shared `TestEnv`
+    /// (serializes env-mutating tests and restores the prior value on drop),
+    /// to exercise the env-override short-circuit in `resolve_interpreter`.
     struct TsxGuard {
-        _guard: std::sync::MutexGuard<'static, ()>,
-        prev: Option<String>,
+        _env: TestEnv,
     }
 
     impl TsxGuard {
         fn set(value: Option<&str>) -> Self {
-            let g = ENV_LOCK.lock().unwrap_or_else(|e| e.into_inner());
-            let prev = std::env::var("MVM_TSX").ok();
-            unsafe {
-                match value {
-                    Some(v) => std::env::set_var("MVM_TSX", v),
-                    None => std::env::remove_var("MVM_TSX"),
-                }
+            let mut env = TestEnv::new();
+            match value {
+                Some(v) => env.set("MVM_TSX", v),
+                None => env.remove("MVM_TSX"),
             }
-            TsxGuard { _guard: g, prev }
-        }
-    }
-
-    impl Drop for TsxGuard {
-        fn drop(&mut self) {
-            unsafe {
-                match &self.prev {
-                    Some(v) => std::env::set_var("MVM_TSX", v),
-                    None => std::env::remove_var("MVM_TSX"),
-                }
-            }
+            TsxGuard { _env: env }
         }
     }
 

--- a/crates/mvm-cli/src/commands/env/artifact_verify.rs
+++ b/crates/mvm-cli/src/commands/env/artifact_verify.rs
@@ -236,9 +236,9 @@ pub(super) fn download_file(url: &str, dest: &str) -> Result<()> {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use mvm_core::util::test_env::TestEnv;
     use sha2::{Digest, Sha256};
     use std::io::Write;
-    use std::sync::Mutex;
 
     #[test]
     fn curl_download_args_request_resume() {
@@ -255,13 +255,6 @@ mod tests {
         assert_eq!(args.last().unwrap(), "https://example/x");
     }
 
-    /// Cargo test runs tests in parallel within a single binary. Two
-    /// of these tests touch `MVM_SKIP_HASH_VERIFY` (the global env-var
-    /// escape hatch), so they have to be serialised
-    /// against each other and against any other test that hashes a
-    /// real artifact. Static mutex held for the test's lifetime.
-    static ENV_LOCK: Mutex<()> = Mutex::new(());
-
     /// Compute the canonical lowercase-hex SHA-256 of a byte slice. Tests
     /// use this to derive matching expected values without rebuilding
     /// the production hash path.
@@ -271,7 +264,7 @@ mod tests {
 
     #[test]
     fn verify_hash_accepts_matching_artifact() {
-        let _guard = ENV_LOCK.lock().unwrap();
+        let _env = TestEnv::new();
         let dir = tempfile::tempdir().unwrap();
         let path = dir.path().join("artifact");
         let bytes = b"hello world\n";
@@ -291,7 +284,7 @@ mod tests {
 
     #[test]
     fn verify_hash_rejects_mismatched_artifact_and_deletes() {
-        let _guard = ENV_LOCK.lock().unwrap();
+        let _env = TestEnv::new();
         let dir = tempfile::tempdir().unwrap();
         let path = dir.path().join("artifact");
         std::fs::write(&path, b"actual contents").unwrap();
@@ -311,24 +304,15 @@ mod tests {
 
     #[test]
     fn verify_hash_skip_env_var_bypasses_check() {
-        let _guard = ENV_LOCK.lock().unwrap();
+        let mut env = TestEnv::new();
         // Ensure the file exists even though we'll set a "wrong" hash.
         let dir = tempfile::tempdir().unwrap();
         let path = dir.path().join("artifact");
         std::fs::write(&path, b"contents").unwrap();
         let wrong = hex_sha256(b"definitely not the contents");
 
-        // SAFETY: ENV_LOCK serialises every test that touches this env
-        // var, so no concurrent reader observes a half-set value. The
-        // unsafe block is only required by edition-2024's set_var /
-        // remove_var signatures; behaviour is unchanged.
-        unsafe {
-            std::env::set_var("MVM_SKIP_HASH_VERIFY", "1");
-        }
+        env.set("MVM_SKIP_HASH_VERIFY", "1");
         let result = verify_artifact_hash(path.to_str().unwrap(), "artifact", Some(&wrong));
-        unsafe {
-            std::env::remove_var("MVM_SKIP_HASH_VERIFY");
-        }
         assert!(result.is_ok(), "skip-env should bypass check: {result:?}");
     }
 

--- a/specs/REFACTOR-STATUS.md
+++ b/specs/REFACTOR-STATUS.md
@@ -379,10 +379,15 @@ PLAN 185 — Idiomatic Rust hygiene audit         🟢 started
       `libkrun-sys` `gvproxy`/`passt` (PATH + MVM_GATEWAY_BIN tests; deleted the
       crate-wide `TEST_ENV_LOCK`, added the mvm-core `test-support` dev-dep;
       lock-only reap tests keep a bare `TestEnv` guard)
-  [ ] Roll `TestEnv` through the remaining env-mutating tests: `mvm-cli` (the last
-      big batch — doctor/up/session/tenant_resolution/template_cmd/ops·mcp/build·*)
-      and `mvm-backend` (host-gated: its test bin SIGKILLs under macOS amfid —
-      migrate where CI/Linux runs them)
+  [~] `mvm-cli` batch (in progress): `env/artifact_verify` (ENV_LOCK) +
+      `build/sandbox_record` (TsxGuard/ENV_LOCK) migrated. Remaining mvm-cli:
+      `vm/session` (RuntimeDirGuard — note: tests holding the guard + mutating a
+      2nd var need a guard-set helper, not a nested `TestEnv::new()` which would
+      deadlock on the shared lock), `vm/up`, `doctor`, `template_cmd`,
+      `vm/tenant_resolution`, `ops/mcp` (unique-name tests), `commands/mod`,
+      `build/build`
+  [ ] `mvm-backend` env tests (host-gated: its test bin SIGKILLs under macOS
+      amfid — migrate where CI/Linux runs them)
   [ ] Standardize poisoned-lock handling by distinguishing test/global
       serialization locks from real runtime state locks
   [ ] Rename overly generic internal traits/types where the blast radius is


### PR DESCRIPTION
## What

First slice of the `mvm-cli` Plan 185 env-test batch — migrate two single-lock files onto the shared `mvm_core::util::test_env::TestEnv` guard, deleting two more local locks.

- **`commands/env/artifact_verify.rs`** — the `MVM_SKIP_HASH_VERIFY` test moves onto `TestEnv`; the hash-roundtrip tests that only needed to *serialize* against it hold a bare `TestEnv` guard. Deletes the local `ENV_LOCK`.
- **`commands/build/sandbox_record.rs`** — `TsxGuard` (`MVM_TSX`) now wraps a `TestEnv` instead of a hand-rolled `MutexGuard` + `prev` + `Drop`. Deletes the local `ENV_LOCK`.

Pure test-only; no production code touched.

## Verification
- `cargo nextest run -p mvm-cli` (4 touched tests) — pass
- `cargo clippy -p mvm-cli --all-targets -- -D warnings` — clean
- `cargo fmt --all -- --check`, `check-no-spec-refs-in-comments` — clean

## Remaining mvm-cli (rollup)
`vm/session` (RuntimeDirGuard — needs a guard-set helper, since a test holding the guard can't call `TestEnv::new()` again without deadlocking the shared lock), `vm/up`, `doctor`, `template_cmd`, `vm/tenant_resolution`, `ops/mcp`, `commands/mod`, `build/build`; then `mvm-backend` (host-gated) and Phases 2–7.