### PR TITLE
test(cli): session + up env tests onto TestEnv (Plan 185)

### DIFF
--- a/crates/mvm-cli/src/commands/vm/session.rs
+++ b/crates/mvm-cli/src/commands/vm/session.rs
@@ -1016,40 +1016,30 @@ fn cmd_console(args: ConsoleArgs) -> Result<()> {
 mod tests {
     use super::*;
 
-    /// Same env-var serialization as the on-disk store tests in mvm-core.
-    /// Two tests in this module mutate `MVM_RUNTIME_DIR`; the lock keeps
-    /// them from racing each other.
-    static ENV_LOCK: std::sync::Mutex<()> = std::sync::Mutex::new(());
+    use mvm_core::util::test_env::TestEnv;
 
     struct RuntimeDirGuard {
         _temp: tempfile::TempDir,
-        _lock: std::sync::MutexGuard<'static, ()>,
-        prev: Option<String>,
+        env: TestEnv,
     }
 
-    impl Drop for RuntimeDirGuard {
-        fn drop(&mut self) {
-            unsafe {
-                match self.prev.take() {
-                    Some(prev) => std::env::set_var("MVM_RUNTIME_DIR", prev),
-                    None => std::env::remove_var("MVM_RUNTIME_DIR"),
-                }
-            }
+    impl RuntimeDirGuard {
+        /// Set an additional env var on this guard's `TestEnv`. Tests that
+        /// already hold the guard must mutate through it rather than create a
+        /// second `TestEnv`, which would deadlock on the shared env lock.
+        fn set(&mut self, key: &str, value: &str) {
+            self.env.set(key, value);
         }
     }
 
     fn isolated_runtime_dir() -> RuntimeDirGuard {
-        let lock = ENV_LOCK.lock().unwrap_or_else(|p| p.into_inner());
         let temp = tempfile::tempdir().expect("tempdir");
-        let prev = std::env::var("MVM_RUNTIME_DIR").ok();
-        unsafe {
-            std::env::set_var("MVM_RUNTIME_DIR", temp.path());
-        }
-        RuntimeDirGuard {
-            _temp: temp,
-            _lock: lock,
-            prev,
-        }
+        // `TestEnv` serializes env-mutating tests behind a process-wide lock
+        // and restores `MVM_RUNTIME_DIR` (and anything else set via the guard)
+        // on drop.
+        let mut env = TestEnv::new();
+        env.set("MVM_RUNTIME_DIR", temp.path());
+        RuntimeDirGuard { _temp: temp, env }
     }
 
     #[test]
@@ -1161,22 +1151,13 @@ mod tests {
         // Records written before the field existed have
         // creator_pid=0; the gate is implicitly disabled for them
         // even when the env var is set, so old records keep working.
-        let _guard = isolated_runtime_dir();
+        let mut guard = isolated_runtime_dir();
         let mut rec = session::SessionRecord::new_running("vm-1", "wl", session::SessionMode::Prod);
         rec.creator_pid = 0;
         let id = rec.id.clone();
 
-        let prev = std::env::var(session::STRICT_CREATOR_PID_ENV).ok();
-        unsafe {
-            std::env::set_var(session::STRICT_CREATOR_PID_ENV, "1");
-        }
+        guard.set(session::STRICT_CREATOR_PID_ENV, "1");
         let result = enforce_creator_pid_gate(&id, &rec);
-        unsafe {
-            match prev {
-                Some(v) => std::env::set_var(session::STRICT_CREATOR_PID_ENV, v),
-                None => std::env::remove_var(session::STRICT_CREATOR_PID_ENV),
-            }
-        }
         result.expect("creator_pid=0 records bypass the gate");
     }
 
@@ -1184,22 +1165,13 @@ mod tests {
     fn creator_pid_gate_rejects_different_pid_when_enabled() {
         // With the env var on AND a non-zero creator_pid that
         // differs from the caller's, the gate must refuse.
-        let _guard = isolated_runtime_dir();
+        let mut guard = isolated_runtime_dir();
         let mut rec = session::SessionRecord::new_running("vm-1", "wl", session::SessionMode::Prod);
         rec.creator_pid = std::process::id().wrapping_add(1); // definitely not us
         let id = rec.id.clone();
 
-        let prev = std::env::var(session::STRICT_CREATOR_PID_ENV).ok();
-        unsafe {
-            std::env::set_var(session::STRICT_CREATOR_PID_ENV, "1");
-        }
+        guard.set(session::STRICT_CREATOR_PID_ENV, "1");
         let result = enforce_creator_pid_gate(&id, &rec);
-        unsafe {
-            match prev {
-                Some(v) => std::env::set_var(session::STRICT_CREATOR_PID_ENV, v),
-                None => std::env::remove_var(session::STRICT_CREATOR_PID_ENV),
-            }
-        }
         let err = result.expect_err("different PID should be refused");
         assert!(
             err.to_string().contains("created by pid"),
@@ -1210,23 +1182,14 @@ mod tests {
     #[test]
     fn creator_pid_gate_accepts_same_pid_when_enabled() {
         // The common case: caller IS the creator. Gate accepts.
-        let _guard = isolated_runtime_dir();
+        let mut guard = isolated_runtime_dir();
         let rec = session::SessionRecord::new_running("vm-1", "wl", session::SessionMode::Prod);
         // `new_running` captures std::process::id() into creator_pid,
         // so the caller (this test) is by construction the creator.
         let id = rec.id.clone();
 
-        let prev = std::env::var(session::STRICT_CREATOR_PID_ENV).ok();
-        unsafe {
-            std::env::set_var(session::STRICT_CREATOR_PID_ENV, "1");
-        }
+        guard.set(session::STRICT_CREATOR_PID_ENV, "1");
         let result = enforce_creator_pid_gate(&id, &rec);
-        unsafe {
-            match prev {
-                Some(v) => std::env::set_var(session::STRICT_CREATOR_PID_ENV, v),
-                None => std::env::remove_var(session::STRICT_CREATOR_PID_ENV),
-            }
-        }
         result.expect("same-pid call should pass the gate");
     }
 

--- a/crates/mvm-cli/src/commands/vm/up.rs
+++ b/crates/mvm-cli/src/commands/vm/up.rs
@@ -2630,8 +2630,7 @@ mod runtime_overlay_attach_tests {
 #[cfg(test)]
 mod resolve_vz_workload_kernel_tests {
     use super::*;
-
-    static LOCK: std::sync::Mutex<()> = std::sync::Mutex::new(());
+    use mvm_core::util::test_env::TestEnv;
 
     #[test]
     fn existing_path_passes_through_unchanged() {
@@ -2644,17 +2643,16 @@ mod resolve_vz_workload_kernel_tests {
 
     #[test]
     fn non_vz_hypervisor_passes_through_even_when_missing() {
-        let _g = LOCK.lock().unwrap_or_else(|e| e.into_inner());
+        let mut env = TestEnv::new();
         let tmp = tempfile::tempdir().unwrap();
-        unsafe { std::env::set_var("MVM_CACHE_DIR", tmp.path()) };
+        env.set("MVM_CACHE_DIR", tmp.path());
         let result = resolve_vz_workload_kernel("/nonexistent/vmlinux", "libkrun").unwrap();
         assert_eq!(result, "/nonexistent/vmlinux");
-        unsafe { std::env::remove_var("MVM_CACHE_DIR") };
     }
 
     #[test]
     fn vz_missing_kernel_falls_back_to_builder_vm_cache() {
-        let _g = LOCK.lock().unwrap_or_else(|e| e.into_inner());
+        let mut env = TestEnv::new();
         let tmp = tempfile::tempdir().unwrap();
         let arch = if cfg!(target_arch = "aarch64") {
             "aarch64"
@@ -2665,22 +2663,20 @@ mod resolve_vz_workload_kernel_tests {
         std::fs::create_dir_all(&fallback_dir).unwrap();
         let fallback = fallback_dir.join("vmlinux");
         std::fs::write(&fallback, b"builder-kernel").unwrap();
-        unsafe { std::env::set_var("MVM_CACHE_DIR", tmp.path()) };
+        env.set("MVM_CACHE_DIR", tmp.path());
         let result = resolve_vz_workload_kernel("/nonexistent/vmlinux", "vz").unwrap();
         assert_eq!(result, fallback.to_str().unwrap());
-        unsafe { std::env::remove_var("MVM_CACHE_DIR") };
     }
 
     #[test]
     fn vz_both_missing_returns_error_mentioning_dev_up() {
-        let _g = LOCK.lock().unwrap_or_else(|e| e.into_inner());
+        let mut env = TestEnv::new();
         let tmp = tempfile::tempdir().unwrap();
-        unsafe { std::env::set_var("MVM_CACHE_DIR", tmp.path()) };
+        env.set("MVM_CACHE_DIR", tmp.path());
         let err = resolve_vz_workload_kernel("/nonexistent/vmlinux", "vz").unwrap_err();
         let msg = err.to_string();
         assert!(msg.contains("dev up"), "expected 'dev up' in: {msg}");
         assert!(msg.contains("vz"), "expected hypervisor name in: {msg}");
-        unsafe { std::env::remove_var("MVM_CACHE_DIR") };
     }
 }
 

--- a/specs/REFACTOR-STATUS.md
+++ b/specs/REFACTOR-STATUS.md
@@ -379,13 +379,14 @@ PLAN 185 — Idiomatic Rust hygiene audit         🟢 started
       `libkrun-sys` `gvproxy`/`passt` (PATH + MVM_GATEWAY_BIN tests; deleted the
       crate-wide `TEST_ENV_LOCK`, added the mvm-core `test-support` dev-dep;
       lock-only reap tests keep a bare `TestEnv` guard)
-  [~] `mvm-cli` batch (in progress): `env/artifact_verify` (ENV_LOCK) +
-      `build/sandbox_record` (TsxGuard/ENV_LOCK) migrated. Remaining mvm-cli:
-      `vm/session` (RuntimeDirGuard — note: tests holding the guard + mutating a
-      2nd var need a guard-set helper, not a nested `TestEnv::new()` which would
-      deadlock on the shared lock), `vm/up`, `doctor`, `template_cmd`,
-      `vm/tenant_resolution`, `ops/mcp` (unique-name tests), `commands/mod`,
-      `build/build`
+  [~] `mvm-cli` batch (in progress): `env/artifact_verify` (ENV_LOCK),
+      `build/sandbox_record` (TsxGuard/ENV_LOCK), `vm/session`
+      (RuntimeDirGuard/ENV_LOCK — added a `RuntimeDirGuard::set` helper so the
+      guard-holding creator-pid tests mutate a 2nd var without a deadlocking
+      nested `TestEnv::new()`), and `vm/up` (LOCK; `resolve_vz_workload_kernel`
+      MVM_CACHE_DIR tests) migrated. Remaining mvm-cli: `doctor`, `template_cmd`
+      (each a holdout lock), `vm/tenant_resolution`, `ops/mcp` (unique-name
+      tests — consistency-only), `commands/mod`, `build/build`
   [ ] `mvm-backend` env tests (host-gated: its test bin SIGKILLs under macOS
       amfid — migrate where CI/Linux runs them)
   [ ] Standardize poisoned-lock handling by distinguishing test/global


### PR DESCRIPTION
## What

Second `mvm-cli` Plan 185 slice — migrate two more files onto the shared `TestEnv`, deleting two more local locks.

- **`commands/vm/session.rs`** — `RuntimeDirGuard` now wraps a `TestEnv` (drops the local `ENV_LOCK` + the manual `prev`/`Drop` restore). The three `creator_pid_gate_*` tests that hold the guard **and** also set `MVMCTL_STRICT_CREATOR_PID` mutate through a new `RuntimeDirGuard::set` helper — a nested `TestEnv::new()` would **deadlock** on the shared (non-reentrant) env lock.
- **`commands/vm/up.rs`** — the `resolve_vz_workload_kernel` tests (`MVM_CACHE_DIR`) move onto `TestEnv`; drops the module-local `LOCK`. The production `MVM_REEXEC_NAME` `set_var` (re-exec path) is deliberately untouched — it's runtime behaviour, not a test.

Pure test-only.

## Verification
- `cargo nextest run -p mvm-cli` (9 touched tests incl. the 3 deadlock-prone STRICT tests) — pass
- `cargo clippy -p mvm-cli --all-targets -- -D warnings` — clean
- `cargo fmt --all -- --check`, `check-no-spec-refs-in-comments` — clean

## Remaining mvm-cli
`doctor`, `template_cmd` (each a holdout lock), `vm/tenant_resolution`, `ops/mcp` (unique-name — consistency-only), `commands/mod`, `build/build`; then `mvm-backend` (host-gated) + Phases 2–7.