### PR TITLE
test(cli): unify doctor ts-runner tests onto TestEnv, drop local ENV_LOCK (Plan 185)

### DIFF
--- a/crates/mvm-cli/src/doctor.rs
+++ b/crates/mvm-cli/src/doctor.rs
@@ -2896,11 +2896,13 @@ mod tests {
 
     // ── Dev-VM gating + data-dir-mode routing tests ─────────────────
     //
-    // These tests mutate `MVM_DATA_DIR` / `MVM_SHARE_DIR` to redirect
-    // doctor's filesystem probes at a tempdir. Env-var mutation is
-    // process-wide, so the shared test env guard serializes and restores it.
+    // These tests mutate `MVM_DATA_DIR` / `MVM_SHARE_DIR` (and the ts-runner
+    // tests below, PATH / MVM_TSX) to redirect doctor's probes at a tempdir.
+    // Env-var mutation is process-wide, so they all go through the shared
+    // `TestEnv` guard, which serializes them behind one lock and restores the
+    // prior values on drop.
 
-    static ENV_LOCK: std::sync::Mutex<()> = std::sync::Mutex::new(());
+    use mvm_core::util::test_env::TestEnv;
 
     struct EnvGuard {
         _env: mvm_core::util::test_env::TestEnv,
@@ -2997,32 +2999,19 @@ mod tests {
         // flaky. The probe must still return `ok: true` (WARN, not
         // FAIL) so `mvmctl doctor` exits 0 on a host without a TS
         // runner.
-        let g = ENV_LOCK.lock().unwrap_or_else(|e| e.into_inner());
-        let prev_path = std::env::var("PATH").ok();
-        let prev_tsx = std::env::var("MVM_TSX").ok();
+        let mut env = TestEnv::new();
         let prev_cwd = std::env::current_dir().expect("cwd");
         let tmp = tempfile::tempdir().unwrap();
-        unsafe {
-            std::env::set_var("PATH", "");
-            std::env::remove_var("MVM_TSX");
-        }
+        env.set("PATH", "");
+        env.remove("MVM_TSX");
         std::env::set_current_dir(tmp.path()).expect("chdir");
 
         let c = ts_runner_check();
 
-        // Restore before any assert can fail the test.
+        // Restore cwd before any assert can fail (TestEnv restores PATH /
+        // MVM_TSX on drop; cwd is restored manually).
         let _ = std::env::set_current_dir(&prev_cwd);
-        unsafe {
-            match prev_path {
-                Some(v) => std::env::set_var("PATH", v),
-                None => std::env::remove_var("PATH"),
-            }
-            match prev_tsx {
-                Some(v) => std::env::set_var("MVM_TSX", v),
-                None => std::env::remove_var("MVM_TSX"),
-            }
-        }
-        drop(g);
+        drop(env);
 
         assert_eq!(c.name, "TypeScript runner");
         assert_eq!(c.category, "tools");
@@ -3047,30 +3036,21 @@ mod tests {
     #[test]
     fn ts_runner_check_reports_pass_when_project_local_present() {
         use std::os::unix::fs::PermissionsExt;
-        let g = ENV_LOCK.lock().unwrap_or_else(|e| e.into_inner());
+        let mut env = TestEnv::new();
         let prev_cwd = std::env::current_dir().expect("cwd");
-        let prev_tsx = std::env::var("MVM_TSX").ok();
         let tmp = tempfile::tempdir().unwrap();
         let bin = tmp.path().join("node_modules").join(".bin");
         std::fs::create_dir_all(&bin).unwrap();
         let tsx = bin.join("tsx");
         std::fs::write(&tsx, "#!/bin/sh\nexit 0\n").unwrap();
         std::fs::set_permissions(&tsx, std::fs::Permissions::from_mode(0o755)).unwrap();
-        unsafe {
-            std::env::remove_var("MVM_TSX");
-        }
+        env.remove("MVM_TSX");
         std::env::set_current_dir(tmp.path()).expect("chdir");
 
         let c = ts_runner_check();
 
         let _ = std::env::set_current_dir(&prev_cwd);
-        unsafe {
-            match prev_tsx {
-                Some(v) => std::env::set_var("MVM_TSX", v),
-                None => std::env::remove_var("MVM_TSX"),
-            }
-        }
-        drop(g);
+        drop(env);
 
         assert!(c.ok);
         assert!(

--- a/specs/REFACTOR-STATUS.md
+++ b/specs/REFACTOR-STATUS.md
@@ -385,11 +385,13 @@ PLAN 185 — Idiomatic Rust hygiene audit         🟢 started
       guard-holding creator-pid tests mutate a 2nd var without a deadlocking
       nested `TestEnv::new()`), and `vm/up` (LOCK; `resolve_vz_workload_kernel`
       MVM_CACHE_DIR tests), and `template_cmd` (probe_test_lock + `clear_llm_env`
-      now thread a `&mut TestEnv`) migrated. Remaining mvm-cli: `doctor` (the one
-      messy/partially-migrated file — a TestEnv guard + a holdout `ENV_LOCK` +
-      lock-less save/restore tests, best done as a dedicated pass),
-      `vm/tenant_resolution`, `ops/mcp` (unique-name tests — consistency-only),
-      `commands/mod`, `build/build`
+      now thread a `&mut TestEnv`), and `doctor` ts-runner tests (folded the
+      holdout `ENV_LOCK` onto the shared TestEnv the EnvGuard already used —
+      fixing a latent two-lock race) migrated. **All mvm-cli local test locks
+      are now folded.** Remaining = consistency-only / gated leftovers:
+      `vm/tenant_resolution`, `ops/mcp` (unique-name tests), `commands/mod`,
+      `build/build`, and doctor's `builder_backend`/`nested-kvm` tests (Linux +
+      `builder-vm`-gated — not compilable on macOS, go with the mvm-backend batch)
   [ ] `mvm-backend` env tests (host-gated: its test bin SIGKILLs under macOS
       amfid — migrate where CI/Linux runs them)
   [ ] Standardize poisoned-lock handling by distinguishing test/global


### PR DESCRIPTION
## What

`doctor.rs`'s `EnvGuard` already used the shared `mvm_core` `TestEnv`, but the two `ts_runner_check` tests held a **separate module-local `ENV_LOCK`** — so a `TestEnv`-guarded test and a ts-runner test could run concurrently and **race** process-global env (a latent bug).

- Move the ts-runner tests (`PATH` / `MVM_TSX`) onto `TestEnv` too, so every env-mutating doctor test serializes behind one lock.
- Delete the local `ENV_LOCK`. (cwd is restored manually — `TestEnv` only manages env vars.)

This folds the **last mvm-cli local test lock**.

## Scope note
doctor's `builder_backend_check` / `nested-kvm` tests are `#[cfg(all(target_os = "linux", feature = "builder-vm"))]` — not compilable on this macOS host and they don't use `ENV_LOCK`. They keep raw save/restore for now and go with the `mvm-backend` CI/Linux batch.

## Verification
- `cargo nextest run -p mvm-cli` (both ts_runner tests) — pass
- `cargo clippy -p mvm-cli --all-targets -- -D warnings` — clean
- `cargo fmt --all -- --check`, `check-no-spec-refs-in-comments` — clean

## Remaining 185
Consistency-only mvm-cli no-lock files (`tenant_resolution`, `ops/mcp`, `commands/mod`, `build/build`), `mvm-backend` + doctor's Linux-gated tests (CI/Linux), then Phases 2–7.