### PR TITLE
test(cli): tenant_resolution + ops/mcp onto TestEnv — completes mvm-cli (Plan 185)

### DIFF
--- a/crates/mvm-cli/src/commands/ops/mcp.rs
+++ b/crates/mvm-cli/src/commands/ops/mcp.rs
@@ -855,6 +855,7 @@ fn audit_call_error(
 #[cfg(test)]
 mod tests {
     use super::*;
+    use mvm_core::util::test_env::TestEnv;
 
     #[test]
     fn truncate_under_cap_passes_through() {
@@ -975,14 +976,10 @@ mod tests {
     fn resolve_credential_returns_direct_env_var_when_set() {
         let direct = "MVM_TEST_CRED_DIRECT_RETURNED";
         let secret = "MVM_TEST_CRED_DIRECT_RETURNED_FROM_SECRET";
-        unsafe {
-            std::env::set_var(direct, "direct-value");
-        }
+        let mut env = TestEnv::new();
+        env.set(direct, "direct-value");
         let (_dir, store) = tempdir_store();
         let resolved = resolve_provider_credential(direct, secret, &store);
-        unsafe {
-            std::env::remove_var(direct);
-        }
         assert_eq!(exposed(resolved).as_deref(), Some("direct-value"));
     }
 
@@ -990,9 +987,8 @@ mod tests {
     fn resolve_credential_returns_secret_store_value_when_direct_unset() {
         let direct = "MVM_TEST_CRED_FALLBACK_DIRECT";
         let secret_ref = "MVM_TEST_CRED_FALLBACK_FROM_SECRET";
-        unsafe {
-            std::env::set_var(secret_ref, "my-stored-key");
-        }
+        let mut env = TestEnv::new();
+        env.set(secret_ref, "my-stored-key");
         let (_dir, store) = tempdir_store();
         store
             .put(
@@ -1002,9 +998,6 @@ mod tests {
             )
             .unwrap();
         let resolved = resolve_provider_credential(direct, secret_ref, &store);
-        unsafe {
-            std::env::remove_var(secret_ref);
-        }
         assert_eq!(exposed(resolved).as_deref(), Some("from-store"));
     }
 
@@ -1014,10 +1007,9 @@ mod tests {
         // operator has both env vars set.
         let direct = "MVM_TEST_CRED_PRIORITY_DIRECT";
         let secret_ref = "MVM_TEST_CRED_PRIORITY_FROM_SECRET";
-        unsafe {
-            std::env::set_var(direct, "direct-wins");
-            std::env::set_var(secret_ref, "stored-name");
-        }
+        let mut env = TestEnv::new();
+        env.set(direct, "direct-wins");
+        env.set(secret_ref, "stored-name");
         let (_dir, store) = tempdir_store();
         store
             .put(
@@ -1027,10 +1019,6 @@ mod tests {
             )
             .unwrap();
         let resolved = resolve_provider_credential(direct, secret_ref, &store);
-        unsafe {
-            std::env::remove_var(direct);
-            std::env::remove_var(secret_ref);
-        }
         assert_eq!(exposed(resolved).as_deref(), Some("direct-wins"));
     }
 
@@ -1051,10 +1039,9 @@ mod tests {
         // the secret-store lookup.
         let direct = "MVM_TEST_CRED_EMPTY_DIRECT";
         let secret_ref = "MVM_TEST_CRED_EMPTY_FROM_SECRET";
-        unsafe {
-            std::env::set_var(direct, "");
-            std::env::set_var(secret_ref, "actual-name");
-        }
+        let mut env = TestEnv::new();
+        env.set(direct, "");
+        env.set(secret_ref, "actual-name");
         let (_dir, store) = tempdir_store();
         store
             .put(
@@ -1064,10 +1051,6 @@ mod tests {
             )
             .unwrap();
         let resolved = resolve_provider_credential(direct, secret_ref, &store);
-        unsafe {
-            std::env::remove_var(direct);
-            std::env::remove_var(secret_ref);
-        }
         assert_eq!(exposed(resolved).as_deref(), Some("from-store-fallback"));
     }
 
@@ -1079,15 +1062,11 @@ mod tests {
         // config-drift path fires; a tracing::warn surfaces the
         // miss to the operator at boot time.
         let secret_ref = "MVM_TEST_CRED_MISS_FROM_SECRET";
-        unsafe {
-            std::env::set_var(secret_ref, "no-such-name");
-        }
+        let mut env = TestEnv::new();
+        env.set(secret_ref, "no-such-name");
         let (_dir, store) = tempdir_store();
         let resolved =
             resolve_provider_credential("MVM_TEST_CRED_MISS_DIRECT_UNSET", secret_ref, &store);
-        unsafe {
-            std::env::remove_var(secret_ref);
-        }
         assert!(resolved.is_none());
     }
 }

--- a/crates/mvm-cli/src/commands/vm/tenant_resolution.rs
+++ b/crates/mvm-cli/src/commands/vm/tenant_resolution.rs
@@ -56,40 +56,40 @@ fn read_config_tenant() -> Option<String> {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use mvm_core::util::test_env::TestEnv;
 
-    // SAFETY notes: these tests mutate process env. Run with
-    // `--test-threads=1` if collisions show up; the resolver itself
-    // is read-only against env so concurrent reads are fine, but
-    // overlapping set/remove between tests is not.
+    // These tests mutate MVM_TENANT (process-global). `TestEnv` serializes
+    // them behind a shared lock and restores the prior value on drop, so
+    // they're safe under the default multi-threaded test runner.
 
     #[test]
     fn flag_beats_env() {
-        unsafe { std::env::set_var("MVM_TENANT", "from-env") };
+        let mut env = TestEnv::new();
+        env.set("MVM_TENANT", "from-env");
         assert_eq!(resolve_tenant(Some("from-flag")), "from-flag");
-        unsafe { std::env::remove_var("MVM_TENANT") };
     }
 
     #[test]
     fn env_beats_default_when_no_flag() {
-        unsafe { std::env::set_var("MVM_TENANT", "from-env") };
+        let mut env = TestEnv::new();
+        env.set("MVM_TENANT", "from-env");
         assert_eq!(resolve_tenant(None), "from-env");
-        unsafe { std::env::remove_var("MVM_TENANT") };
     }
 
     #[test]
     fn empty_flag_falls_through_to_env() {
-        unsafe { std::env::set_var("MVM_TENANT", "from-env") };
+        let mut env = TestEnv::new();
+        env.set("MVM_TENANT", "from-env");
         assert_eq!(resolve_tenant(Some("")), "from-env");
-        unsafe { std::env::remove_var("MVM_TENANT") };
     }
 
     #[test]
     fn empty_env_falls_through_to_default() {
-        unsafe { std::env::set_var("MVM_TENANT", "") };
+        let mut env = TestEnv::new();
+        env.set("MVM_TENANT", "");
         // Either default or whatever ~/.mvm/config.toml says; both
         // are non-empty. The empty MVM_TENANT must NOT come through.
         let resolved = resolve_tenant(None);
         assert!(!resolved.is_empty());
-        unsafe { std::env::remove_var("MVM_TENANT") };
     }
 }

--- a/specs/REFACTOR-STATUS.md
+++ b/specs/REFACTOR-STATUS.md
@@ -379,7 +379,7 @@ PLAN 185 — Idiomatic Rust hygiene audit         🟢 started
       `libkrun-sys` `gvproxy`/`passt` (PATH + MVM_GATEWAY_BIN tests; deleted the
       crate-wide `TEST_ENV_LOCK`, added the mvm-core `test-support` dev-dep;
       lock-only reap tests keep a bare `TestEnv` guard)
-  [~] `mvm-cli` batch (in progress): `env/artifact_verify` (ENV_LOCK),
+  [x] `mvm-cli` batch (COMPLETE): `env/artifact_verify` (ENV_LOCK),
       `build/sandbox_record` (TsxGuard/ENV_LOCK), `vm/session`
       (RuntimeDirGuard/ENV_LOCK — added a `RuntimeDirGuard::set` helper so the
       guard-holding creator-pid tests mutate a 2nd var without a deadlocking
@@ -387,11 +387,13 @@ PLAN 185 — Idiomatic Rust hygiene audit         🟢 started
       MVM_CACHE_DIR tests), and `template_cmd` (probe_test_lock + `clear_llm_env`
       now thread a `&mut TestEnv`), and `doctor` ts-runner tests (folded the
       holdout `ENV_LOCK` onto the shared TestEnv the EnvGuard already used —
-      fixing a latent two-lock race) migrated. **All mvm-cli local test locks
-      are now folded.** Remaining = consistency-only / gated leftovers:
-      `vm/tenant_resolution`, `ops/mcp` (unique-name tests), `commands/mod`,
-      `build/build`, and doctor's `builder_backend`/`nested-kvm` tests (Linux +
-      `builder-vm`-gated — not compilable on macOS, go with the mvm-backend batch)
+      fixing a latent two-lock race), and `vm/tenant_resolution` (4 MVM_TENANT
+      tests — also a no-lock latent race, now serialized) + `ops/mcp`
+      (unique-name credential tests) migrated. **mvm-cli test env migration
+      COMPLETE** — every remaining raw `std::env::set_var` in mvm-cli is
+      production CLI-flag plumbing (`commands/mod.rs`, `build/build.rs`) or
+      Linux+`builder-vm`-gated (doctor's `builder_backend`/`nested-kvm`, which go
+      with the mvm-backend batch)
   [ ] `mvm-backend` env tests (host-gated: its test bin SIGKILLs under macOS
       amfid — migrate where CI/Linux runs them)
   [ ] Standardize poisoned-lock handling by distinguishing test/global


### PR DESCRIPTION
## What

Final `mvm-cli` Plan 185 slice — migrate the last two test files onto the shared `TestEnv`.

- **`commands/vm/tenant_resolution.rs`** — the four `resolve_tenant` tests all mutated `MVM_TENANT` with **no lock** (the comment even said to pass `--test-threads=1` if they collided — a latent race). Now on the shared `TestEnv`: serialized + restored on drop, raw `unsafe` gone.
- **`commands/ops/mcp.rs`** — the `resolve_provider_credential` tests use unique env-var names (race-free) but still carried raw `unsafe` set/remove with explicit cleanup; moved onto `TestEnv` for uniform restore-on-drop and no `unsafe`.

Production CLI-flag env-sets (`commands/mod.rs`, `build/build.rs`) are runtime behaviour and **left untouched**.

This **completes mvm-cli's test env migration** — every remaining raw `set_var` in mvm-cli is production or Linux/`builder-vm`-gated.

## Verification
- `cargo nextest run -p mvm-cli` (10 touched tests) — pass
- `cargo clippy -p mvm-cli --all-targets -- -D warnings` — clean
- `cargo fmt --all -- --check`, `check-no-spec-refs-in-comments` — clean

## Remaining 185
Only `mvm-backend` + doctor's Linux-gated tests (host-gated — CI/Linux) and Phases 2–7 (poison-lock policy, naming, typed selectors, unsafe-boundary audit).