### PR TITLE
refactor(build): fold last env-test locks into TestEnv + poison-lock policy (Plan 185 Phase 2)

### DIFF
--- a/crates/mvm-build/src/builder_backend_select.rs
+++ b/crates/mvm-build/src/builder_backend_select.rs
@@ -271,31 +271,17 @@ pub fn linux_builder_vm_readiness() -> Result<(), BuilderVmError> {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use std::sync::{LazyLock, Mutex};
-
-    /// Process-wide lock for env mutation. Same pattern the
-    /// `builder_vm_timeout` tests use; serialises tests so concurrent
-    /// threads don't observe each other's writes.
-    static ENV_LOCK: LazyLock<Mutex<()>> = LazyLock::new(|| Mutex::new(()));
+    use mvm_core::util::test_env::TestEnv;
 
     fn with_env<F: FnOnce() -> R, R>(value: Option<&str>, f: F) -> R {
-        let _guard = ENV_LOCK.lock().unwrap();
-        let prev = std::env::var_os(MVM_BUILDER_BACKEND_ENV);
-        // SAFETY: tests serialise env mutation via ENV_LOCK.
-        unsafe {
-            match value {
-                Some(v) => std::env::set_var(MVM_BUILDER_BACKEND_ENV, v),
-                None => std::env::remove_var(MVM_BUILDER_BACKEND_ENV),
-            }
+        // `TestEnv` serializes env-mutating tests behind a shared lock and
+        // restores MVM_BUILDER_BACKEND_ENV on drop (after `f` returns).
+        let mut env = TestEnv::new();
+        match value {
+            Some(v) => env.set(MVM_BUILDER_BACKEND_ENV, v),
+            None => env.remove(MVM_BUILDER_BACKEND_ENV),
         }
-        let result = f();
-        unsafe {
-            match prev {
-                Some(v) => std::env::set_var(MVM_BUILDER_BACKEND_ENV, v),
-                None => std::env::remove_var(MVM_BUILDER_BACKEND_ENV),
-            }
-        }
-        result
+        f()
     }
 
     // ── Auto-detect (pure, hermetic — no env / OS / arch sensitivity) ──
@@ -316,7 +302,7 @@ mod tests {
         );
     }
 
-    // ── Env-var parsing (hermetic via ENV_LOCK + explicit values) ──
+    // ── Env-var parsing (hermetic via the shared TestEnv guard + explicit values) ──
 
     #[test]
     fn resolve_env_override_returns_none_when_unset() {

--- a/crates/mvm-build/src/vz_builder.rs
+++ b/crates/mvm-build/src/vz_builder.rs
@@ -1943,33 +1943,15 @@ mod tests {
         );
     }
 
-    /// Process-wide lock for `MVM_VZ_SUPERVISOR_PATH` mutation. Same
-    /// pattern as the env-mutating tests in
-    /// `builder_backend_select` + `builder_vm_runtime`; without it
-    /// the two resolver tests race on the env var and one observes
-    /// the other's value.
-    static SUPERVISOR_ENV_LOCK: std::sync::LazyLock<std::sync::Mutex<()>> =
-        std::sync::LazyLock::new(|| std::sync::Mutex::new(()));
-
     fn with_supervisor_env<F: FnOnce() -> R, R>(value: Option<&Path>, f: F) -> R {
-        let _guard = SUPERVISOR_ENV_LOCK.lock().unwrap();
-        let prev = std::env::var_os("MVM_VZ_SUPERVISOR_PATH");
-        // SAFETY: SUPERVISOR_ENV_LOCK serialises every test that
-        // mutates MVM_VZ_SUPERVISOR_PATH.
-        unsafe {
-            match value {
-                Some(v) => std::env::set_var("MVM_VZ_SUPERVISOR_PATH", v),
-                None => std::env::remove_var("MVM_VZ_SUPERVISOR_PATH"),
-            }
+        // `TestEnv` serializes env-mutating tests behind a shared lock and
+        // restores MVM_VZ_SUPERVISOR_PATH on drop (after `f` returns).
+        let mut env = mvm_core::util::test_env::TestEnv::new();
+        match value {
+            Some(v) => env.set("MVM_VZ_SUPERVISOR_PATH", v),
+            None => env.remove("MVM_VZ_SUPERVISOR_PATH"),
         }
-        let result = f();
-        unsafe {
-            match prev {
-                Some(v) => std::env::set_var("MVM_VZ_SUPERVISOR_PATH", v),
-                None => std::env::remove_var("MVM_VZ_SUPERVISOR_PATH"),
-            }
-        }
-        result
+        f()
     }
 
     #[test]

--- a/specs/REFACTOR-STATUS.md
+++ b/specs/REFACTOR-STATUS.md
@@ -396,8 +396,14 @@ PLAN 185 — Idiomatic Rust hygiene audit         🟢 started
       with the mvm-backend batch)
   [ ] `mvm-backend` env tests (host-gated: its test bin SIGKILLs under macOS
       amfid — migrate where CI/Linux runs them)
-  [ ] Standardize poisoned-lock handling by distinguishing test/global
-      serialization locks from real runtime state locks
+  [~] Phase 2 (poison-lock policy): policy decided + written into the plan —
+      test/global *serialization* locks recover via `into_inner()` (fold env ones
+      into TestEnv; cwd/signal ones use `unwrap_or_else(into_inner)`), runtime
+      *state* locks stay fail-closed. Applied: folded the last two mvm-build env
+      serializers (`builder_backend_select` `with_env`, `vz_builder`
+      `with_supervisor_env`) into TestEnv; audited runtime `.lock().unwrap()` sites
+      as intentionally fail-closed. Remaining: `mvm-cli::dev_vz` (hot) + mvm-backend
+      test locks (host-gated)
   [ ] Rename overly generic internal traits/types where the blast radius is
       small, including storage/backend and layer-local egress proxy names
   [ ] Push stringly backend/provider selectors toward typed values at module

--- a/specs/plans/185-idiomatic-rust-hygiene.md
+++ b/specs/plans/185-idiomatic-rust-hygiene.md
@@ -116,19 +116,44 @@ Priority order:
 **Files:** start from
 `rg -n 'expect\\(\".*poison|mutex poisoned|lock poisoned|unwrap_or_else\\(.*into_inner' crates tests`.
 
-- [ ] **Step 1 - write the policy into this plan.** Runtime state locks return an
+- [x] **Step 1 - write the policy into this plan.** Runtime state locks return an
       error or fail closed when poisoning means state may be corrupt. Test/global
       serialization locks recover with `into_inner()` so one failed test does not
       poison the rest of the test binary.
-- [ ] **Step 2 - add a tiny helper if it pays for itself.** If repeated recovery
-      code remains noisy, add a focused helper for test locks rather than a broad
-      mutex wrapper.
-- [ ] **Step 3 - migrate known test/global locks.** Start with the env/test locks
-      and helper-style mutexes discovered during Plan 182 and this plan.
-- [ ] **Step 4 - keep runtime fail-closed paths explicit.** Do not blanket-recover
-      locks that protect real runtime state such as worker pools, backend launch
-      maps, or audit cursors unless the local invariant proves recovery is safe.
-- [ ] **Step 5 - green.** Run targeted tests and clippy for each touched crate.
+
+      **POLICY (decided):**
+      - **Test/global serialization locks** (locks whose only job is to serialize
+        env/cwd/fixture mutation across the test binary's threads — they guard *no*
+        real state, just ordering) **recover from poison via `into_inner()`**: a
+        panic in one test must not cascade-poison the lock and fail every sibling
+        test. The shared `mvm_core::util::test_env::TestEnv` guard already encodes
+        this (`ENV_LOCK.lock().unwrap_or_else(|p| p.into_inner())`), so the
+        preferred form is to *fold env-serialization locks into `TestEnv`* and let
+        non-env serializers (cwd, signal) use the same `unwrap_or_else(into_inner)`.
+      - **Runtime state locks** (worker/standby pools, backend launch/handle maps,
+        audit cursors, the broker registry, anything guarding data a later reader
+        trusts) **fail closed**: poison means a writer panicked mid-mutation and the
+        guarded state may be torn, so propagate the error / bail rather than hand a
+        caller a half-written value. Do **not** blanket-`into_inner()` these.
+- [x] **Step 2 - add a tiny helper if it pays for itself.** N/A — `TestEnv` *is*
+      the focused test-lock helper (it owns the recovery + restore). Non-env test
+      serializers use the one-line `unwrap_or_else(|p| p.into_inner())` directly;
+      a second wrapper would not pay for itself.
+- [~] **Step 3 - migrate known test/global locks.** Done for the env serializers:
+      every env-mutating test lock is folded into `TestEnv` (mvm-core/mvm-hostd/
+      mvm-build incl. `builder_backend_select` + `vz_builder`/libkrun-sys/mvm-cli).
+      Non-env test serializers already recover (`ts_runner::CWD_LOCK`,
+      `runtime_meta::HOME_TEST_LOCK`). Remaining: `mvm-cli::dev_vz` env lock (hot
+      file — other sessions) + the `mvm-backend` test env locks (host-gated build),
+      to land where CI/Linux runs them.
+- [x] **Step 4 - keep runtime fail-closed paths explicit.** Audited the
+      `.lock().unwrap()` sites: the runtime ones (e.g. the guest-agent
+      `RUN_ENTRYPOINT_LOCK`, supervisor pool/registry mutexes) are intentionally
+      left fail-closed (a panic-poisoned runtime lock means torn state). Only
+      serialization-only test locks were touched.
+- [x] **Step 5 - green.** `cargo nextest run -p mvm-build [--features builder-vm]`
+      + `cargo clippy -p mvm-build --features builder-vm --all-targets -- -D warnings`
+      green for the folded locks.
 
 ---
 


### PR DESCRIPTION
## What

Plan 185 **Phase 2 / Task 3 — poison-lock policy.**

**Policy (now written into the plan):**
- **Test/global serialization locks** (guard only env/cwd/fixture *ordering*, no real state) → **recover from poison via `into_inner()`** so a panicking test doesn't cascade-poison the lock and fail every sibling. Preferred form: fold env serializers into the shared `TestEnv` guard (which already does this); non-env serializers use `unwrap_or_else(|p| p.into_inner())`.
- **Runtime state locks** (worker/standby pools, backend launch/handle maps, audit cursors, broker registry) → **fail closed**, because poison means a writer panicked mid-mutation and the state may be torn. No blanket `into_inner()`.

**Applied:**
- The two env serializers the `TestEnv` sweep missed — `builder_backend_select::with_env` and `vz_builder::with_supervisor_env` — now wrap a `TestEnv` instead of a hand-rolled `LazyLock<Mutex>` + save/restore. **Both local locks deleted.**
- Audited the runtime `.lock().unwrap()` sites (guest-agent `RUN_ENTRYPOINT_LOCK`, supervisor pool/registry mutexes) — intentionally left fail-closed. Non-env test serializers (`ts_runner::CWD_LOCK`, `runtime_meta::HOME_TEST_LOCK`) already recover.

Pure test-only.

## Verification
- `cargo nextest run -p mvm-build --features builder-vm` (builder_backend_select + vz_builder env tests) — pass
- `cargo clippy -p mvm-build --features builder-vm --all-targets -- -D warnings` — clean
- `cargo fmt --all -- --check`, `check-no-spec-refs-in-comments`, `check-spec-numbers` — clean

## Remaining (Phase 2)
`mvm-cli::dev_vz` env lock (hot file — other sessions) + `mvm-backend` test env locks (host-gated build) — to land where CI/Linux runs them. Then Phases 3–7.