### PR TITLE
refactor(egress): name the two EgressProxy traits by layer (Plan 185 Phase 3 Task 4 Step 3)

### DIFF
--- a/crates/mvm-cli/src/commands/vm/plan_admission.rs
+++ b/crates/mvm-cli/src/commands/vm/plan_admission.rs
@@ -31,7 +31,7 @@
 //!   the `AdmittedPlan`'s `plan_id`; this module is silent on audit.
 //!
 //! - **Resolve component slots.** A later step maps `PolicyRef →
-//!   concrete EgressProxy/ToolGate/...`. This module returns the
+//!   concrete SupervisorEgressProxy/ToolGate/...`. This module returns the
 //!   plan with refs unresolved.
 //!
 //! ## Test seam

--- a/crates/mvm-cli/src/commands/vm/policy_resolver.rs
+++ b/crates/mvm-cli/src/commands/vm/policy_resolver.rs
@@ -12,7 +12,7 @@
 //! single-tenant local dev posture, or `"<tenant>:<workload>"` for a
 //! mvmd-managed policy bundle on disk at
 //! `~/.mvm/policies/<tenant>/<workload>.toml`. The supervisor needs
-//! four trait objects (`EgressProxy`, `ToolGate`, `KeystoreReleaser`,
+//! four trait objects (`SupervisorEgressProxy`, `ToolGate`, `KeystoreReleaser`,
 //! `ArtifactCollector`) to make admission decisions; this resolver
 //! is the function that turns a plan's refs into those objects.
 //!
@@ -72,11 +72,11 @@ use mvm_core::plan::{ExecutionPlan, FsPolicyRef, PolicyRef};
 use mvm_core::policy::canonicalize_l4;
 use mvm_hostd::supervisor::{
     ArtifactCollector, AuditPolicyValidationError, CanonicalL4Gate, EgressPolicyValidationError,
-    EgressProxy, KeystoreReleaser, L4Gate, L7EgressProxy, LiveArtifactCollector,
-    LiveKeystoreReleaser, NoopArtifactCollector, NoopEgressAuditSink, NoopEgressProxy,
-    NoopKeystoreReleaser, NoopL4Gate, NoopToolGate, PiiPolicyError, PolicyToolGate,
-    TokioDnsResolver, ToolGate, build_inspector_chain_with_pii,
-    validate_audit_policy_stream_destinations, validate_egress_policy_inspector_names,
+    KeystoreReleaser, L4Gate, L7EgressProxy, LiveArtifactCollector, LiveKeystoreReleaser,
+    NoopArtifactCollector, NoopEgressAuditSink, NoopEgressProxy, NoopKeystoreReleaser, NoopL4Gate,
+    NoopToolGate, PiiPolicyError, PolicyToolGate, SupervisorEgressProxy, TokioDnsResolver,
+    ToolGate, build_inspector_chain_with_pii, validate_audit_policy_stream_destinations,
+    validate_egress_policy_inspector_names,
 };
 
 /// The fixed identifier for the local-dev policy bundle. Any
@@ -99,7 +99,7 @@ pub const LOCAL_DEFAULT: &str = "local-default";
 /// supervisor lift in mvm-hostd.
 pub struct ResolvedSlots {
     pub network: Box<dyn L4Gate>,
-    pub egress: Box<dyn EgressProxy>,
+    pub egress: Box<dyn SupervisorEgressProxy>,
     pub tool_gate: Box<dyn ToolGate>,
     pub keystore: Box<dyn KeystoreReleaser>,
     pub artifacts: Box<dyn ArtifactCollector>,
@@ -799,12 +799,12 @@ mod tests {
     fn policy_resolver_signature_returns_box_dyn_trait_objects() {
         // Compile-time check: the slots inside ResolvedSlots can be
         // moved into builder functions that accept
-        // `Box<dyn EgressProxy>`, etc. This proves the eventual
-        // `Supervisor::with_egress(self, Box<dyn EgressProxy>)` lift
+        // `Box<dyn SupervisorEgressProxy>`, etc. This proves the eventual
+        // `Supervisor::with_egress(self, Box<dyn SupervisorEgressProxy>)` lift
         // is just a `.with_egress(slots.egress)` call away — no
         // adapter layer needed.
         fn take_network(_: Box<dyn L4Gate>) {}
-        fn take_egress(_: Box<dyn EgressProxy>) {}
+        fn take_egress(_: Box<dyn SupervisorEgressProxy>) {}
         fn take_tool_gate(_: Box<dyn ToolGate>) {}
         fn take_keystore(_: Box<dyn KeystoreReleaser>) {}
         fn take_artifacts(_: Box<dyn ArtifactCollector>) {}

--- a/crates/mvm-core/src/plan/execution_plan.rs
+++ b/crates/mvm-core/src/plan/execution_plan.rs
@@ -88,7 +88,7 @@ pub struct ExecutionPlan {
     pub admission_profile: AdmissionProfile,
 
     /// Network policy reference. Wired to `mvm-core::policy::EgressPolicy`
-    /// (L7 + PII rules) via the supervisor's `EgressProxy`.
+    /// (L7 + PII rules) via the supervisor's `SupervisorEgressProxy`.
     pub network_policy: PolicyRef,
 
     /// Filesystem policy reference.

--- a/crates/mvm-core/src/policy/toml_loader.rs
+++ b/crates/mvm-core/src/policy/toml_loader.rs
@@ -6,7 +6,7 @@
 //! `ExecutionPlan` onto a single bundle file: a workload's
 //! `(network_policy, fs_policy, egress_policy, tool_policy)` refs
 //! all point at one TOML, which carries the per-policy sections
-//! the supervisor's component slots (`EgressProxy`, `ToolGate`,
+//! the supervisor's component slots (`SupervisorEgressProxy`, `ToolGate`,
 //! `KeystoreReleaser`, `ArtifactCollector`) consume at admission.
 //!
 //! ## Schema
@@ -58,7 +58,7 @@
 //!   This loader reads bare TOML for the single-host posture —
 //!   suitable for `local` tenant; mvmd-signed bundles layer on
 //!   later via the same parse + then verify-against-trusted-keys.
-//! - **Construct concrete `EgressProxy` / `ToolGate` impls.** That
+//! - **Construct concrete `SupervisorEgressProxy` / `ToolGate` impls.** That
 //!   wiring is the consumer's job (the L4/L7 proxies are built
 //!   elsewhere; this loader returns the parsed bundle). Until
 //!   those proxies ship, the resolver returns Noops even for

--- a/crates/mvm-hostd/src/supervisor/aggregate.rs
+++ b/crates/mvm-hostd/src/supervisor/aggregate.rs
@@ -35,7 +35,7 @@ use crate::supervisor::audit::{AuditSigner, NoopAuditSigner};
 use crate::supervisor::backend::{BackendError, BackendLauncher, NoopBackendLauncher};
 use crate::supervisor::circuit_breaker::{CircuitBreaker, InspectorReporter};
 use crate::supervisor::destination::DestinationPolicy;
-use crate::supervisor::egress::{EgressProxy, NoopEgressProxy};
+use crate::supervisor::egress::{NoopEgressProxy, SupervisorEgressProxy};
 use crate::supervisor::firewall::seam::SupervisorEgressEnforcer;
 use crate::supervisor::firewall::{
     FirewallEnforcer, FirewallError, FirewallSpec, NoopFirewallEnforcer,
@@ -134,7 +134,7 @@ pub enum SupervisorError {
 }
 
 pub struct Supervisor {
-    pub egress: Arc<dyn EgressProxy>,
+    pub egress: Arc<dyn SupervisorEgressProxy>,
     pub tool_gate: Arc<dyn ToolGate>,
     pub keystore: Arc<dyn KeystoreReleaser>,
     pub audit: Arc<dyn AuditSigner>,
@@ -215,7 +215,7 @@ impl Supervisor {
     }
 
     /// Wire a prebuilt egress proxy slot.
-    pub fn with_egress_proxy(mut self, egress: Arc<dyn EgressProxy>) -> Self {
+    pub fn with_egress_proxy(mut self, egress: Arc<dyn SupervisorEgressProxy>) -> Self {
         self.egress = egress;
         self
     }
@@ -745,7 +745,7 @@ impl Supervisor {
     /// `with_l7_egress` (the egress builder reads `self.circuit_breakers`
     /// at chain-build time). Calling it after has no effect on an
     /// already-built chain — the inspectors live inside the
-    /// `Arc<dyn EgressProxy>` and aren't reachable for re-wrapping.
+    /// `Arc<dyn SupervisorEgressProxy>` and aren't reachable for re-wrapping.
     pub fn with_circuit_breakers(mut self, reporter: Arc<InspectorReporter>) -> Self {
         self.circuit_breakers = Some(reporter);
         self
@@ -2308,7 +2308,7 @@ mod tests {
             )
             .expect("wire ok");
 
-        // The legacy `EgressProxy::inspect(host, path)` runs the
+        // The legacy `SupervisorEgressProxy::inspect(host, path)` runs the
         // chain. Because destination_policy's breaker is open, the
         // verdict is the chain's downstream "Allow" rather than the
         // `Deny` destination_policy would have produced.

--- a/crates/mvm-hostd/src/supervisor/egress.rs
+++ b/crates/mvm-hostd/src/supervisor/egress.rs
@@ -37,7 +37,7 @@ pub enum EgressError {
 /// header-time, then have its body redacted by `PiiRedactor`
 /// mid-stream, all under one `inspect` call.
 #[async_trait]
-pub trait EgressProxy: Send + Sync {
+pub trait SupervisorEgressProxy: Send + Sync {
     /// Inspect an outbound HTTP request. The signature is intentionally
     /// loose at this stage — the concrete `EgressRequest` +
     /// `EgressResponse` shapes arrive once the inspector chain is wired.
@@ -54,7 +54,7 @@ pub trait EgressProxy: Send + Sync {
 pub struct NoopEgressProxy;
 
 #[async_trait]
-impl EgressProxy for NoopEgressProxy {
+impl SupervisorEgressProxy for NoopEgressProxy {
     async fn inspect(&self, _host: &str, _path: &str) -> Result<EgressDecision, EgressError> {
         Err(EgressError::NotWired)
     }
@@ -72,6 +72,6 @@ mod tests {
     // it runs.
     #[test]
     fn noop_egress_proxy_is_constructable() {
-        let _: Box<dyn EgressProxy> = Box::new(NoopEgressProxy);
+        let _: Box<dyn SupervisorEgressProxy> = Box::new(NoopEgressProxy);
     }
 }

--- a/crates/mvm-hostd/src/supervisor/inspector.rs
+++ b/crates/mvm-hostd/src/supervisor/inspector.rs
@@ -1,7 +1,7 @@
 //! Inspector trait + InspectorChain — the L7 egress security backbone.
 //!
 //! Every outbound HTTP request the workload makes is mediated by the
-//! supervisor's `EgressProxy`. The proxy threads the request through
+//! supervisor's `SupervisorEgressProxy`. The proxy threads the request through
 //! an ordered chain of `Inspector`s, each of which can:
 //!   - allow the request through (default verdict)
 //!   - deny it with a reason that's surfaced to the workload + audit

--- a/crates/mvm-hostd/src/supervisor/l7_proxy.rs
+++ b/crates/mvm-hostd/src/supervisor/l7_proxy.rs
@@ -1,4 +1,4 @@
-//! `L7EgressProxy` — the real `EgressProxy` impl that wires the
+//! `L7EgressProxy` — the real `SupervisorEgressProxy` impl that wires the
 //! inspector chain into outbound HTTP traffic.
 //!
 //! ## Phase 1 scope (this module)
@@ -35,7 +35,7 @@ use tokio::io::{AsyncReadExt, AsyncWriteExt};
 use tokio::net::{TcpListener, TcpStream};
 
 use crate::supervisor::audit::AuditError;
-use crate::supervisor::egress::{EgressDecision, EgressError, EgressProxy};
+use crate::supervisor::egress::{EgressDecision, EgressError, SupervisorEgressProxy};
 use crate::supervisor::inspector::{InspectorChain, InspectorVerdict, RequestCtx};
 
 /// Async DNS resolver, abstracted so tests can inject mock IPs and
@@ -606,9 +606,9 @@ async fn write_status(client: &mut TcpStream, status: u16, msg: &str) -> std::io
 }
 
 #[async_trait]
-impl EgressProxy for L7EgressProxy {
+impl SupervisorEgressProxy for L7EgressProxy {
     async fn inspect(&self, host: &str, path: &str) -> Result<EgressDecision, EgressError> {
-        // The original `EgressProxy` trait predates the (host, port,
+        // The original `SupervisorEgressProxy` trait predates the (host, port,
         // body) shape. Until the trait widening, this method
         // delegates to `evaluate` with port=443 (the HTTPS default
         // — the host-only signature is never going to be the
@@ -823,7 +823,7 @@ mod tests {
         // The legacy 2-arg `inspect(host, path)` should delegate
         // through `evaluate` cleanly. Used by older callers until
         // the trait is widened.
-        let r: &dyn EgressProxy = &proxy;
+        let r: &dyn SupervisorEgressProxy = &proxy;
         let dec = r
             .inspect("api.openai.com", "/v1/chat")
             .await

--- a/crates/mvm-hostd/src/supervisor/mod.rs
+++ b/crates/mvm-hostd/src/supervisor/mod.rs
@@ -20,7 +20,7 @@
 //! Structure:
 //! - `state` — `PlanState` + `PlanStateMachine` (transition rules
 //!   for the supervisor's plan lifecycle).
-//! - `egress` — `EgressProxy` trait + `NoopEgressProxy`.
+//! - `egress` — `SupervisorEgressProxy` trait + `NoopEgressProxy`.
 //! - `tool_gate` — `ToolGate` trait + `NoopToolGate`.
 //! - `keystore` — `KeystoreReleaser` trait + `NoopKeystoreReleaser`.
 //! - `audit` — `AuditSigner` trait + `NoopAuditSigner`.
@@ -130,7 +130,7 @@ pub use circuit_breaker::{
     InspectorReporter, SystemClock as CircuitBreakerSystemClock,
 };
 pub use destination::DestinationPolicy;
-pub use egress::{EgressDecision, EgressError, EgressProxy, NoopEgressProxy};
+pub use egress::{EgressDecision, EgressError, NoopEgressProxy, SupervisorEgressProxy};
 pub use event_bus::{DEFAULT_CAPACITY as EVENT_BUS_DEFAULT_CAPACITY, EventBus, LifecycleEvent};
 #[cfg(any(target_os = "linux", test))]
 pub use firewall::linux_nft::{CommandNftApplier, LinuxNftFirewall, NftApplier, NftError};

--- a/crates/mvm-hostd/src/supervisor/proxy/l4.rs
+++ b/crates/mvm-hostd/src/supervisor/proxy/l4.rs
@@ -53,7 +53,7 @@ pub enum L4Decision {
 // ──────────────────────────────────────────────────────────────────────
 // L4Gate — supervisor slot consumed by the policy resolver.
 //
-// Symmetric with `EgressProxy` (L7) / `ToolGate` / `KeystoreReleaser` /
+// Symmetric with `SupervisorEgressProxy` (L7) / `ToolGate` / `KeystoreReleaser` /
 // `ArtifactCollector`: a `Box<dyn L4Gate>` slot the supervisor consults
 // at admission. `CanonicalL4Gate` is wired from a parsed bundle's
 // `[[network.l4]]` rows; the smoltcp / TUN consumer that turns an

--- a/crates/mvm/src/vm/egress_proxy.rs
+++ b/crates/mvm/src/vm/egress_proxy.rs
@@ -9,16 +9,16 @@
 //! to L3.
 //!
 //! The trait surface here is the integration point: when the mitmdump
-//! supervisor lands, it implements `EgressProxy` and `tap_create` calls
+//! supervisor lands, it implements `VmEgressProxy` and `tap_create` calls
 //! `start_for_vm` after the L3 rules are installed. See
-//! `EgressProxy::start_for_vm` for the contract.
+//! `VmEgressProxy::start_for_vm` for the contract.
 
 use std::fmt;
 
 use mvm_core::network_policy::{EgressMode, NetworkPolicy};
 
-/// Per-VM proxy handle. Returned by [`EgressProxy::start_for_vm`]
-/// and consumed by [`EgressProxy::stop_for_vm`]. The real implementation
+/// Per-VM proxy handle. Returned by [`VmEgressProxy::start_for_vm`]
+/// and consumed by [`VmEgressProxy::stop_for_vm`]. The real implementation
 /// fills in the actual fields (PID, listening port, allowlist hash).
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct ProxyHandle {
@@ -71,7 +71,7 @@ impl From<anyhow::Error> for EgressProxyError {
 ///   HTTPS/HTTP from the VM to itself.
 /// - `stop_for_vm`: stop the proxy and remove its iptables rules.
 ///   Idempotent — safe to call for a vm_name that was never started.
-pub trait EgressProxy: Send + Sync {
+pub trait VmEgressProxy: Send + Sync {
     fn start_for_vm(
         &self,
         vm_name: &str,
@@ -85,7 +85,7 @@ pub trait EgressProxy: Send + Sync {
 /// with a `MitmdumpSupervisor` that wraps `mitmdump` from nixpkgs.
 pub struct StubEgressProxy;
 
-impl EgressProxy for StubEgressProxy {
+impl VmEgressProxy for StubEgressProxy {
     fn start_for_vm(
         &self,
         _vm_name: &str,

--- a/specs/plans/185-idiomatic-rust-hygiene.md
+++ b/specs/plans/185-idiomatic-rust-hygiene.md
@@ -174,13 +174,19 @@ Priority order:
       Renamed to `DeviceMapperBackend` (the module models dmsetup/device-mapper
       thin-pool ops; impls are `DmsetupBackend` + `MockBackend`). Blast radius
       was three files: `storage/backend.rs`, `storage/mod.rs`, `storage/pool.rs`.
-- [ ] **Step 3 - clarify the two `EgressProxy` traits without unifying them.**
-      Candidate names should reflect layer ownership, for example runtime VM
-      egress vs supervisor policy egress.
-- [~] **Step 4 - update docs/comments only where they reference Rust type names.**
-      Done for the `storage::Backend` rename; `EgressProxy` doc pass pending Step 3.
-- [~] **Step 5 - green.** `mvm` lib+tests clippy clean, 14 storage tests pass;
-      `EgressProxy` crates pending Step 3.
+- [x] **Step 3 - clarify the two `EgressProxy` traits without unifying them.**
+      Renamed by layer ownership: the runtime per-VM lifecycle stub in
+      `mvm/src/vm/egress_proxy.rs` → `VmEgressProxy` (zero external callers), and
+      the supervisor's L7 payload-inspecting decision trait in
+      `mvm-hostd/src/supervisor/egress.rs` → `SupervisorEgressProxy` (~25 refs
+      across mvm-hostd/mvm-cli/mvm-core). Concrete impls `StubEgressProxy`,
+      `NoopEgressProxy`, `L7EgressProxy` keep their names.
+- [x] **Step 4 - update docs/comments only where they reference Rust type names.**
+      Done for both the `storage::Backend` and `EgressProxy` renames; no user-doc
+      churn (internal-only names).
+- [x] **Step 5 - green.** storage: `mvm` lib+tests clippy clean + 14 storage tests;
+      egress: `mvm-core`/`mvm`/`mvm-hostd`/`mvm-cli` clippy clean + 773 supervisor
+      tests pass.
 
 ### Task 5 - Push stringly selectors toward typed values at module boundaries
 


### PR DESCRIPTION
## What

Two distinct traits shared the bare name `EgressProxy`, obscuring which layer each belongs to. Renamed by ownership (no unification, no behavior change):

| Was | Now | Layer |
|-----|-----|-------|
| `mvm::vm::egress_proxy::EgressProxy` | `VmEgressProxy` | runtime per-VM proxy-lifecycle stub (`start_for_vm`/`stop_for_vm`) — zero external callers |
| `mvm_hostd::supervisor::egress::EgressProxy` | `SupervisorEgressProxy` | supervisor's L7 payload-inspecting egress-decision trait (~25 refs across mvm-hostd/mvm-cli/mvm-core) |

Concrete impls keep their names: `StubEgressProxy`, `NoopEgressProxy`, `L7EgressProxy`.

## Verification

`mvm-core` / `mvm` / `mvm-hostd` / `mvm-cli` clippy clean (lib + tests); 773 `mvm-hostd` supervisor tests pass.

Plan 185 Phase 3, Task 4 Step 3. (The rollup's single 'naming' line is updated by the sibling storage-rename PR #892; the plan doc — source of truth — is updated here.)