### PR TITLE
refactor(backend): typed BackendKind selectors over name() strings (Plan 185 Phase 3 Task 5)

### DIFF
--- a/crates/mvm-backend/src/catalog.rs
+++ b/crates/mvm-backend/src/catalog.rs
@@ -100,7 +100,9 @@ macro_rules! backend_catalog {
         }
 
         impl AnyBackend {
-            pub(crate) fn kind(&self) -> BackendKind {
+            /// The typed discriminant for this backend. Lets callers branch on
+            /// `BackendKind::Vz` etc. instead of string-matching `name()`.
+            pub fn kind(&self) -> BackendKind {
                 match self {
                     $(Self::$kind(_) => BackendKind::$kind),*
                 }

--- a/crates/mvm-cli/src/commands/pool.rs
+++ b/crates/mvm-cli/src/commands/pool.rs
@@ -15,6 +15,7 @@ use std::path::Path;
 use anyhow::{Context, Result};
 use clap::{Args as ClapArgs, Subcommand};
 use mvm_backend::backend::AnyBackend;
+use mvm_backend::catalog::BackendKind;
 use mvm_backend::standby_pool::SupervisorStandbyPool;
 use mvm_core::user_config::MvmConfig;
 use mvm_core::vm_backend::{
@@ -370,7 +371,7 @@ pub fn replenish_after_launch(backend: &AnyBackend, cfg: &VmStartConfig) -> Resu
     // against an already-full pool is a cheap no-op, not an over-warm. Two
     // races against the same image can still transiently overshoot target by
     // one per concurrent launch; the surplus ages out via the standby TTL.
-    if backend.as_vm_backend().name() == "vz" {
+    if backend.kind() == BackendKind::Vz {
         spawn_detached_rewarm(&cfg.rootfs_path, cfg.warm_pool_size)?;
         return Ok(0);
     }
@@ -1032,7 +1033,7 @@ fn resolve_warm_shape(cfg: &MvmConfig, rootfs_override: Option<&str>) -> Result<
             .context("resolve default-microvm kernel for the warm pool")?;
     let vcpus = u8::try_from(cfg.default_cpus.clamp(1, u32::from(u8::MAX))).unwrap_or(u8::MAX);
     // Vz needs an image; libkrun does not. Resolve: explicit --rootfs > env var > default.
-    let image = if backend_name == "vz" || backend_name == "virtualization" {
+    let image = if backend.kind() == BackendKind::Vz {
         let path = rootfs_override
             .map(str::to_string)
             .or_else(|| std::env::var("MVM_POOL_ROOTFS").ok())

--- a/specs/plans/185-idiomatic-rust-hygiene.md
+++ b/specs/plans/185-idiomatic-rust-hygiene.md
@@ -186,14 +186,36 @@ Priority order:
 `crates/mvm-network/src/registry.rs`,
 `crates/mvm-storage/src/mount_provider.rs`.
 
-- [ ] **Step 1 - keep strings at CLI/config edges.** Parsing raw user input stays
-      close to Clap/config decoding.
-- [ ] **Step 2 - use typed selectors internally.** Prefer `BackendKind` and
-      descriptor APIs inside backend code; prefer provider-specific enums where
-      network/storage mode is already structured.
-- [ ] **Step 3 - avoid duplicate registries.** If a descriptor/registry already
-      owns a selector table, reuse it instead of creating another string list.
-- [ ] **Step 4 - green.** Run targeted tests and clippy for touched crates.
+- [x] **Step 1 - keep strings at CLI/config edges.** Confirmed: backend selection
+      already funnels raw `--hypervisor`/config strings through the single edge
+      parser `AnyBackend::from_hypervisor(&str)` → `catalog::descriptor_for_selector`.
+      Network/storage providers register by a `kind()` string *on purpose* — it's
+      the documented open-registry extension point (external S3/NFS/custom providers
+      join without a core-enum edit), so those strings are left as-is.
+- [~] **Step 2 - use typed selectors internally.** The typed foundation already
+      exists from the backend descriptor registry: `BackendKind` enum +
+      `AnyBackend::kind()`. Exposed `kind()` as `pub` (was needlessly `pub(crate)`
+      while `BackendKind` was already `pub`) and migrated the `&AnyBackend`-in-hand
+      call sites in `mvm-cli/pool.rs` from `name() == "vz"` to
+      `kind() == BackendKind::Vz`. Deferred: the `kernel_identity`/`image_identity`/
+      `compat_for_launch` sites still take `&dyn VmBackend` (the mvm-core trait,
+      which cannot expose `BackendKind` without a layer inversion) — typing those
+      needs a `&dyn VmBackend → &AnyBackend` signature ripple through pool.rs,
+      scoped as a follow-up to avoid churning that hot file here.
+- [x] **Step 3 - avoid duplicate registries.** Removed the duplicated alias literal
+      `backend_name == "vz" || backend_name == "virtualization"` in pool.rs in favor
+      of `backend.kind() == BackendKind::Vz` — the descriptor registry already owns
+      the vz alias table, so the call site no longer re-lists it.
+- [x] **Step 4 - green.** `mvm-backend`/`mvm-cli` clippy clean; 14 pool tests pass.
+
+#### Task 5 deferred follow-ups
+
+- [ ] Convert `kernel_identity`/`image_identity`/`compat_for_launch` (and the
+      `StandbyCompatParams.backend` field at the call-chain root) from
+      `&dyn VmBackend` to `&AnyBackend`, then replace their `name() == "..."`
+      comparisons with `kind()` checks. Held back from the Task 5 slice because
+      pool.rs is a hot file (warm-pool work) and the signature ripple is best
+      landed when that area is quiet.
 
 ---
 


### PR DESCRIPTION
## What

The Plan 184 descriptor registry already provides a typed `BackendKind` enum and the `AnyBackend::kind()` discriminant — but `kind()` was `pub(crate)` (while `BackendKind` itself was already `pub`), so call sites outside mvm-backend fell back to string-matching `name()`. This exposes `kind()` and migrates the `&AnyBackend`-in-hand sites in `pool.rs`:

- warm-replenish gate: `name() == "vz"` → `kind() == BackendKind::Vz`
- default-image resolve: dropped the duplicated alias literal `backend_name == "vz" || backend_name == "virtualization"` for `backend.kind() == BackendKind::Vz`. The registry already owns vz's alias table (`from_hypervisor` resolved `virtualization`→Vz one line above), so the call site no longer re-lists it (Step 3 — no duplicate selector tables).

Strings stay where they belong (Step 1): the single `from_hypervisor(&str)` edge parser, and the network/storage provider `kind()` registries (a deliberate open-extension point for external providers).

## Deferred

The `kernel_identity`/`image_identity`/`compat_for_launch` sites take `&dyn VmBackend` (the mvm-core trait — it can't expose the mvm-backend `BackendKind` without a layer inversion). Typing them needs a `&dyn VmBackend → &AnyBackend` signature ripple through pool.rs; recorded as a Task 5 follow-up in the plan to avoid churning that hot warm-pool file now.

## Verification

`mvm-backend` + `mvm-cli` clippy clean (lib + tests); 14 pool tests pass.