### PR TITLE
fix(cli): persist plan.json pre-start so vz/libkrun egress substitution actually spawns (Plan 197 Phase 2a)

### DIFF
--- a/crates/mvm-cli/src/commands/vm/invoke.rs
+++ b/crates/mvm-cli/src/commands/vm/invoke.rs
@@ -293,6 +293,17 @@ pub(in crate::commands) fn run(_cli: &Cli, args: Args, _cfg: &MvmConfig) -> Resu
                             redaction: mvm_core::policy::RedactionPolicy::default(),
                         })?;
                         let Some(c) = ctx else { return Ok(None) };
+                        // Persist the bare admitted plan to the per-VM state dir
+                        // before boot. The macOS substitution endpoint decodes
+                        // its secret bindings from `<state_dir>/plan.json` inside
+                        // `backend.start()`; `boot_session_vm` only threads the
+                        // plan in-memory, so without this on-disk copy the
+                        // endpoint silently no-ops on vz/libkrun (the in-memory
+                        // thread alone never reaches the disk-reading decode).
+                        if super::up::persists_plan_before_start(&backend_name) {
+                            super::plan_persist::write_plan(vm_name, &c.admitted.plan)
+                                .context("persisting admitted plan for the pre-start egress moat")?;
+                        }
                         let plan_json = serde_json::to_string(&c.admitted.signed)
                             .context("serializing admitted plan for the session VM")?;
                         Ok(Some(crate::exec::SessionAuditSubstrate {

--- a/crates/mvm-cli/src/commands/vm/up.rs
+++ b/crates/mvm-cli/src/commands/vm/up.rs
@@ -679,7 +679,7 @@ fn should_thread_signed_plan(gateway_bridge_enabled: bool, hypervisor: &str) -> 
 ///
 /// QEMU is excluded: it reads the in-memory config and must not overwrite the
 /// persisted plan.
-fn persists_plan_before_start(hypervisor: &str) -> bool {
+pub(super) fn persists_plan_before_start(hypervisor: &str) -> bool {
     matches!(hypervisor, "firecracker" | "vz" | "libkrun")
 }
 

--- a/crates/mvm-cli/src/commands/vm/up.rs
+++ b/crates/mvm-cli/src/commands/vm/up.rs
@@ -668,6 +668,21 @@ fn should_thread_signed_plan(gateway_bridge_enabled: bool, hypervisor: &str) -> 
     gateway_bridge_enabled || hypervisor == "qemu"
 }
 
+/// Whether the admitted plan must be persisted to `<state_dir>/plan.json`
+/// *before* `backend.start()`. Every backend whose `start()` reads that file
+/// off disk to decide whether to stand up its egress moat needs the pre-start
+/// persist:
+///
+/// - **Firecracker**: the nft TAP-redirect moat reads the plan at spawn time.
+/// - **vz / libkrun (macOS)**: the substitution endpoint reads
+///   `<state_dir>/plan.json` inside `start()` to decide whether to spawn.
+///
+/// QEMU is excluded: it reads the in-memory config and must not overwrite the
+/// persisted plan.
+fn persists_plan_before_start(hypervisor: &str) -> bool {
+    matches!(hypervisor, "firecracker" | "vz" | "libkrun")
+}
+
 fn should_wait_for_direct_boot_agent(detach: bool, ports_env: Option<&str>) -> bool {
     !detach || ports_env.is_some_and(|ports| !ports.is_empty())
 }
@@ -2182,19 +2197,20 @@ pub(super) fn cmd_run(params: RunParams<'_>) -> Result<()> {
         // (the persistent-agent wait further down is skipped for `detach`).
 
         enforce_shares_if(&admission_main, &start_config.volumes)?;
-        // The Firecracker egress moat (substitution endpoint + nft TAP
-        // redirect) reads the admitted plan from the per-VM state dir
-        // *before* boot, so a secret-bearing plan must be persisted
-        // pre-start — the post-launch persist in `emit_launched_if` is
-        // too late for it. Other backends read the in-memory config.
-        // Fail closed: a secret-declaring workload must not boot without
-        // its substitution path.
-        if effective_hypervisor == "firecracker"
+        // The disk-reading egress moats read the admitted plan from the per-VM
+        // state dir *before* boot: Firecracker's nft TAP-redirect moat, and the
+        // vz/libkrun macOS substitution endpoints (which read
+        // `<state_dir>/plan.json` inside `start()`). So a secret-bearing plan
+        // must be persisted pre-start — the post-launch persist in
+        // `emit_launched_if` is too late for them. Only QEMU reads the
+        // in-memory config and is excluded. Fail closed: a secret-declaring
+        // workload must not boot without its substitution path.
+        if persists_plan_before_start(effective_hypervisor)
             && let Some(ctx) = admission_main.as_ref()
             && !ctx.admitted.plan.secrets.is_empty()
         {
             super::plan_persist::write_plan(&ctx.admitted.plan.workload.0, &ctx.admitted.plan)
-                .context("persisting admitted plan for the Firecracker egress moat")?;
+                .context("persisting admitted plan for the pre-start egress moat")?;
         }
         // Try a warm-pool claim first (auto-named + bridge-admitted
         // launches only; fail-open to cold boot). A claimed VM runs under its standby-id,
@@ -3815,6 +3831,19 @@ mod resolve_deps_volume_tests {
         assert!(!should_thread_signed_plan(false, "libkrun"));
         assert!(!should_thread_signed_plan(false, "vz"));
         assert!(should_thread_signed_plan(true, "libkrun"));
+    }
+
+    #[test]
+    fn pre_start_persist_covers_every_disk_reading_egress_moat() {
+        // Firecracker's nft TAP-redirect moat and the vz/libkrun substitution
+        // endpoints all read `<state_dir>/plan.json` inside `start()`, so the
+        // plan must be persisted before boot for each of them.
+        assert!(persists_plan_before_start("firecracker"));
+        assert!(persists_plan_before_start("vz"));
+        assert!(persists_plan_before_start("libkrun"));
+        // QEMU reads the in-memory config and must not overwrite the persisted
+        // plan, so it stays out of the pre-start persist.
+        assert!(!persists_plan_before_start("qemu"));
     }
 
     #[test]


### PR DESCRIPTION
## The bug (two call sites)

Plan 197 Phase 2a wired the macOS workload backends to spawn the egress secret-substitution endpoint: `VzBackend::start` / `LibkrunBackend::start` call `decode_plan_secrets_from_state(state_dir)`, which reads `<state_dir>/plan.json` **off disk** to decide whether to stand up the per-VM endpoint (and the supervisor's `host_listen_ports:[5253]` proxy).

Two launch paths thread the admitted plan but never land it on disk pre-start, so the decode hits `NotFound`, returns `None`, and the endpoint **silently never spawns** (no error; the command exits 0). A secret-declaring workload then runs on vz/libkrun with **no substitution path** — the exact silent-egress gap the `WorkloadBackend` type-bar (Plan 197) exists to prevent, hiding one layer up.

**Commit 1 — `up` path (`up.rs`):** the pre-start `write_plan` was gated `effective_hypervisor == "firecracker"`; for vz/libkrun the plan landed only post-launch (`emit_launched_if`), too late. Extracted `persists_plan_before_start(hyp)` = `firecracker | vz | libkrun` (QEMU excluded — in-memory config) and broadened the gate. Regression test.

**Commit 2 — `invoke`/`run` path (`invoke.rs` + `exec::boot_session_vm`):** the transient/session boot threads the plan **in-memory** (`start_config.plan_json`) and even comments "so `backend.start` spawns the substitution endpoint" — but `boot_session_vm` never writes `<state_dir>/plan.json` (zero `write_plan` in `exec.rs`). Persist the bare admitted plan in the invoke admit-closure (it already holds the plan + vm_name; `exec.rs` deliberately carries no admission dep), gated by the same predicate.

## Live validation (macOS-26 Apple Silicon, `--hypervisor vz`)

Before: `up --flake <secret-egress> --hypervisor vz` admitted the plan (with secrets) and booted, but **no `vsock-5253.sock`, no `substitution.pid`, no endpoint** — silent no-op.

After commit 1, same command:
- Plan admitted with secrets (`backend=vz`, claim 8).
- **Endpoint spawns**: `vsock/vsock-5253.sock` bound, `substitution.pid` alive, supervisor installs `host_listen_ports:[5253]` (`VZVirtioSocketListener`).
- **Guest receives only the placeholder**: `substitution-env.json` maps `API_KEY → mvm-secret-…`; the real credential never enters the guest (claim 13, control plane).

Independently corroborated by a second session on `origin/main` (incl. a proxy-off A/B confirming the fix is required on main).

## Scope note

This PR closes the **endpoint-spawn** gap on both macOS launch paths. The full **data-plane** roundtrip (guest dials 5253 → endpoint swaps the real credential → real upstream request) + the repeated-`VZVirtioSocketListener`-dials stress are a follow-up: driving it needs the function entrypoint to actually run (`invoke`/`run` with the workload registered as a manifest/template + `--from-workload-ir`), not `up --flake` (which boots + confirms the agent but never sends `RunEntrypoint`). The earlier-suspected vsock-5252 "race" was ruled out — `up`'s 30s agent-wait succeeds; the early resets are transient.

## Gates
`cargo fmt` · `clippy -p mvm-cli -D warnings` · regression test green · `check-no-spec-refs-in-comments` clean.