### PR TITLE
fix(fc): sub-second down + kernel-less flake boot for Firecracker

### DIFF
--- a/crates/mvm-backend/src/microvm.rs
+++ b/crates/mvm-backend/src/microvm.rs
@@ -3732,7 +3732,11 @@ mod tests {
         .expect("probe never errors");
         assert!(!exited, "guest ignored ACPI → caller must hard-kill");
         assert_eq!(probes.get(), 2, "polled only within the graceful window");
-        assert_eq!(slept.get(), 2, "slept once per poll, never past the deadline");
+        assert_eq!(
+            slept.get(),
+            2,
+            "slept once per poll, never past the deadline"
+        );
     }
 
     #[test]
@@ -3745,6 +3749,9 @@ mod tests {
             Instant::now,
             |_| {},
         );
-        assert!(result.is_err(), "a failing liveness probe must surface, not be swallowed");
+        assert!(
+            result.is_err(),
+            "a failing liveness probe must surface, not be swallowed"
+        );
     }
 }

--- a/crates/mvm-backend/src/microvm.rs
+++ b/crates/mvm-backend/src/microvm.rs
@@ -1203,6 +1203,31 @@ pub fn balloon_state(name: &str) -> Result<u32> {
     Ok(amount as u32)
 }
 
+/// Wait for a Firecracker guest to power down on its own after an ACPI
+/// shutdown request, polling `is_running` every `poll_interval` until it
+/// reports the VM gone or `max_wait` elapses. Returns `true` when the
+/// guest exited within the window (no hard kill needed), `false` on
+/// timeout. The liveness probe, clock, and sleep are injected so the
+/// escalation decision — "did the guest honor the ACPI request before we
+/// fall back to SIGKILL?" — is unit-testable without a live guest or
+/// real-time waits.
+fn await_graceful_exit(
+    max_wait: std::time::Duration,
+    poll_interval: std::time::Duration,
+    mut is_running: impl FnMut() -> Result<bool>,
+    mut now: impl FnMut() -> std::time::Instant,
+    mut sleep: impl FnMut(std::time::Duration),
+) -> Result<bool> {
+    let deadline = now() + max_wait;
+    while now() < deadline {
+        if !is_running()? {
+            return Ok(true);
+        }
+        sleep(poll_interval);
+    }
+    Ok(false)
+}
+
 pub fn stop_vm(name: &str) -> Result<()> {
     require_linux_env()?;
 
@@ -1249,15 +1274,13 @@ pub fn stop_vm(name: &str) -> Result<()> {
         warn!("failed to send graceful shutdown to VM: {e}");
     }
 
-    let deadline = std::time::Instant::now() + std::time::Duration::from_millis(250);
-    let mut exited_gracefully = false;
-    while std::time::Instant::now() < deadline {
-        if !firecracker::is_vm_running(&pid_file)? {
-            exited_gracefully = true;
-            break;
-        }
-        std::thread::sleep(std::time::Duration::from_millis(25));
-    }
+    let exited_gracefully = await_graceful_exit(
+        std::time::Duration::from_millis(250),
+        std::time::Duration::from_millis(25),
+        || firecracker::is_vm_running(&pid_file),
+        std::time::Instant::now,
+        std::thread::sleep,
+    )?;
 
     // Clean up the API socket either way; only fall back to a hard kill when
     // the guest ignored the ACPI request within the graceful window.
@@ -3640,5 +3663,88 @@ mod tests {
                 None => std::env::remove_var("MVM_PASST_PATH"),
             }
         }
+    }
+
+    // ---- await_graceful_exit (Firecracker `stop_vm` shutdown escalation) ----
+    //
+    // The probe, clock, and sleep are injected, so these exercise the real
+    // escalation decision with no VM and no wall-clock waits (sleep is a
+    // no-op; the clock is a deterministic tick where it matters).
+    use std::cell::Cell;
+    use std::time::{Duration, Instant};
+
+    #[test]
+    fn await_graceful_exit_true_when_guest_exits_in_window() {
+        // Guest is still up on the first probe, gone on the second.
+        let probes = Cell::new(0u32);
+        let is_running = || {
+            let n = probes.get();
+            probes.set(n + 1);
+            Ok(n < 1)
+        };
+        // Generous window with a slow-ticking clock so the deadline is never
+        // the reason the loop ends — the guest exiting is.
+        let base = Instant::now();
+        let tick = Cell::new(0u64);
+        let now = || {
+            let n = tick.get();
+            tick.set(n + 1);
+            base + Duration::from_millis(n)
+        };
+        let exited = await_graceful_exit(
+            Duration::from_secs(10),
+            Duration::from_millis(25),
+            is_running,
+            now,
+            |_| {},
+        )
+        .expect("probe never errors");
+        assert!(exited, "guest exited within the window → no hard kill");
+        assert_eq!(probes.get(), 2, "polled until the guest reported gone");
+    }
+
+    #[test]
+    fn await_graceful_exit_false_on_timeout_with_bounded_polls() {
+        // Guest never powers down.
+        let probes = Cell::new(0u32);
+        let is_running = || {
+            probes.set(probes.get() + 1);
+            Ok(true)
+        };
+        // Clock jumps 100ms per call; with a 250ms window the loop runs twice
+        // before `now()` passes the deadline (calls at 0/100/200/300ms).
+        let base = Instant::now();
+        let tick = Cell::new(0u64);
+        let now = || {
+            let n = tick.get();
+            tick.set(n + 1);
+            base + Duration::from_millis(n * 100)
+        };
+        let slept = Cell::new(0u32);
+        let sleep = |_| slept.set(slept.get() + 1);
+        let exited = await_graceful_exit(
+            Duration::from_millis(250),
+            Duration::from_millis(25),
+            is_running,
+            now,
+            sleep,
+        )
+        .expect("probe never errors");
+        assert!(!exited, "guest ignored ACPI → caller must hard-kill");
+        assert_eq!(probes.get(), 2, "polled only within the graceful window");
+        assert_eq!(slept.get(), 2, "slept once per poll, never past the deadline");
+    }
+
+    #[test]
+    fn await_graceful_exit_propagates_probe_error() {
+        let is_running = || Err(anyhow::anyhow!("liveness probe failed"));
+        let result = await_graceful_exit(
+            Duration::from_secs(1),
+            Duration::from_millis(25),
+            is_running,
+            Instant::now,
+            |_| {},
+        );
+        assert!(result.is_err(), "a failing liveness probe must surface, not be swallowed");
     }
 }

--- a/crates/mvm-backend/src/microvm.rs
+++ b/crates/mvm-backend/src/microvm.rs
@@ -1235,7 +1235,11 @@ pub fn stop_vm(name: &str) -> Result<()> {
 
     ui::info(&format!("Stopping VM '{}'...", name));
 
-    // Try graceful shutdown
+    // Ask the guest to power down via ACPI (SendCtrlAltDel), then poll for a
+    // clean exit on a tight cadence. A headless workload guest has no
+    // power-button handler, so the former unconditional 2s sleep-then-kill made
+    // every `down` cost two seconds for nothing — escalate to a hard kill the
+    // moment the short graceful window lapses instead of always waiting it out.
     if let Err(e) = run_in_vm(&format!(
         r#"sudo curl -s -X PUT --unix-socket {socket} \
             --data '{{"action_type": "SendCtrlAltDel"}}' \
@@ -1245,19 +1249,32 @@ pub fn stop_vm(name: &str) -> Result<()> {
         warn!("failed to send graceful shutdown to VM: {e}");
     }
 
-    std::thread::sleep(std::time::Duration::from_secs(2));
+    let deadline = std::time::Instant::now() + std::time::Duration::from_millis(250);
+    let mut exited_gracefully = false;
+    while std::time::Instant::now() < deadline {
+        if !firecracker::is_vm_running(&pid_file)? {
+            exited_gracefully = true;
+            break;
+        }
+        std::thread::sleep(std::time::Duration::from_millis(25));
+    }
 
-    // Force kill and clean up
-    run_in_vm(&format!(
-        r#"
-        if [ -f {pid} ]; then
-            sudo kill $(cat {pid}) 2>/dev/null || true
-        fi
-        sudo rm -f {socket}
-        "#,
-        pid = pid_file,
-        socket = socket,
-    ))?;
+    // Clean up the API socket either way; only fall back to a hard kill when
+    // the guest ignored the ACPI request within the graceful window.
+    if exited_gracefully {
+        run_in_vm(&format!("sudo rm -f {socket}", socket = socket))?;
+    } else {
+        run_in_vm(&format!(
+            r#"
+            if [ -f {pid} ]; then
+                sudo kill $(cat {pid}) 2>/dev/null || true
+            fi
+            sudo rm -f {socket}
+            "#,
+            pid = pid_file,
+            socket = socket,
+        ))?;
+    }
 
     // Read run info to find the TAP device to destroy
     if let Some(info) = read_vm_run_info_from(&abs_dir)

--- a/crates/mvm-cli/src/commands/vm/checkpoint.rs
+++ b/crates/mvm-cli/src/commands/vm/checkpoint.rs
@@ -849,7 +849,7 @@ fn boot_forked_child(p: BootForkedChildParams<'_>) -> Result<()> {
         .parent()
         .unwrap_or_else(|| std::path::Path::new("."))
         .join("vmlinux");
-    let vmlinux_path = super::up::resolve_vz_workload_kernel(
+    let vmlinux_path = super::up::resolve_workload_kernel(
         vmlinux_placeholder.to_str().unwrap_or(""),
         &effective_hypervisor,
     )?;

--- a/crates/mvm-cli/src/commands/vm/up.rs
+++ b/crates/mvm-cli/src/commands/vm/up.rs
@@ -2156,7 +2156,7 @@ pub(super) fn cmd_run(params: RunParams<'_>) -> Result<()> {
     // Vz-family backends need a real kernel file; mkGuest workload images ship
     // none (libkrun self-materializes its bundled kernel). Resolve the fallback
     // before either the snapshot-restore or cold-boot arm consumes vmlinux_path.
-    let vmlinux_path = resolve_vz_workload_kernel(&vmlinux_path, effective_hypervisor)?;
+    let vmlinux_path = resolve_workload_kernel(&vmlinux_path, effective_hypervisor)?;
 
     // If a template snapshot exists AND the backend supports snapshots,
     // restore from it instead of cold-booting.
@@ -2659,10 +2659,14 @@ fn attach_runtime_overlay(
 
 /// Kernel-less images (mkGuest ships no kernel) boot fine on libkrun,
 /// which materializes its own bundled kernel and ignores this path. The
-/// VZ-family backends need a real kernel file; fall back to the cached
-/// builder-VM kernel (an ARM64 boot Image, the same kernel the Vz builder
-/// and dev VMs boot) rather than handing VZ a missing path.
-pub(super) fn resolve_vz_workload_kernel(
+/// out-of-process backends (vz and firecracker) need a real kernel file;
+/// fall back to the cached builder-VM kernel — the same kernel the builder
+/// and dev VMs boot — rather than handing them a missing path.
+///
+/// Firecracker's direct/manifest boot path already performs this same
+/// fallback; without it here the flake path would refuse a kernel-less
+/// mkGuest workload that the manifest path boots fine.
+pub(super) fn resolve_workload_kernel(
     vmlinux_path: &str,
     hypervisor: &str,
 ) -> anyhow::Result<String> {
@@ -2671,8 +2675,9 @@ pub(super) fn resolve_vz_workload_kernel(
     }
     // `virtualization` is the long-form alias the backend dispatcher
     // accepts for vz; missing it here would skip the fallback and hand
-    // VZ a nonexistent kernel path.
-    if !matches!(hypervisor, "vz" | "virtualization") {
+    // the backend a nonexistent kernel path. libkrun supplies its own
+    // bundled kernel, so it never needs the fallback.
+    if !matches!(hypervisor, "vz" | "virtualization" | "firecracker") {
         return Ok(vmlinux_path.to_string());
     }
     let arch = if cfg!(target_arch = "aarch64") {
@@ -2778,7 +2783,7 @@ mod runtime_overlay_attach_tests {
 }
 
 #[cfg(test)]
-mod resolve_vz_workload_kernel_tests {
+mod resolve_workload_kernel_tests {
     use super::*;
     use mvm_core::util::test_env::TestEnv;
 
@@ -2787,7 +2792,7 @@ mod resolve_vz_workload_kernel_tests {
         let tmp = tempfile::tempdir().unwrap();
         let vmlinux = tmp.path().join("vmlinux");
         std::fs::write(&vmlinux, b"kernel").unwrap();
-        let result = resolve_vz_workload_kernel(vmlinux.to_str().unwrap(), "vz").unwrap();
+        let result = resolve_workload_kernel(vmlinux.to_str().unwrap(), "vz").unwrap();
         assert_eq!(result, vmlinux.to_str().unwrap());
     }
 
@@ -2796,7 +2801,7 @@ mod resolve_vz_workload_kernel_tests {
         let mut env = TestEnv::new();
         let tmp = tempfile::tempdir().unwrap();
         env.set("MVM_CACHE_DIR", tmp.path());
-        let result = resolve_vz_workload_kernel("/nonexistent/vmlinux", "libkrun").unwrap();
+        let result = resolve_workload_kernel("/nonexistent/vmlinux", "libkrun").unwrap();
         assert_eq!(result, "/nonexistent/vmlinux");
     }
 
@@ -2814,7 +2819,29 @@ mod resolve_vz_workload_kernel_tests {
         let fallback = fallback_dir.join("vmlinux");
         std::fs::write(&fallback, b"builder-kernel").unwrap();
         env.set("MVM_CACHE_DIR", tmp.path());
-        let result = resolve_vz_workload_kernel("/nonexistent/vmlinux", "vz").unwrap();
+        let result = resolve_workload_kernel("/nonexistent/vmlinux", "vz").unwrap();
+        assert_eq!(result, fallback.to_str().unwrap());
+    }
+
+    #[test]
+    fn firecracker_missing_kernel_falls_back_to_builder_vm_cache() {
+        // The firecracker flake path must reuse the cached builder-VM
+        // kernel for a kernel-less mkGuest workload, exactly as the
+        // firecracker manifest path does — otherwise a `sleeper`-style
+        // image (no emitted vmlinux) can't boot under firecracker.
+        let mut env = TestEnv::new();
+        let tmp = tempfile::tempdir().unwrap();
+        let arch = if cfg!(target_arch = "aarch64") {
+            "aarch64"
+        } else {
+            "x86_64"
+        };
+        let fallback_dir = tmp.path().join("builder-vm").join(arch);
+        std::fs::create_dir_all(&fallback_dir).unwrap();
+        let fallback = fallback_dir.join("vmlinux");
+        std::fs::write(&fallback, b"builder-kernel").unwrap();
+        env.set("MVM_CACHE_DIR", tmp.path());
+        let result = resolve_workload_kernel("/nonexistent/vmlinux", "firecracker").unwrap();
         assert_eq!(result, fallback.to_str().unwrap());
     }
 
@@ -2823,7 +2850,7 @@ mod resolve_vz_workload_kernel_tests {
         let mut env = TestEnv::new();
         let tmp = tempfile::tempdir().unwrap();
         env.set("MVM_CACHE_DIR", tmp.path());
-        let err = resolve_vz_workload_kernel("/nonexistent/vmlinux", "vz").unwrap_err();
+        let err = resolve_workload_kernel("/nonexistent/vmlinux", "vz").unwrap_err();
         let msg = err.to_string();
         assert!(msg.contains("dev up"), "expected 'dev up' in: {msg}");
         assert!(msg.contains("vz"), "expected hypervisor name in: {msg}");


### PR DESCRIPTION
Unlanded Firecracker follow-ups to the merged #868 (vz/fc sub-second up/down), rebased onto current `main`.

## 1. Sub-second `down`
`stop_vm` did an unconditional `sleep(2s)` after the ACPI `SendCtrlAltDel`, then SIGKILL — a headless workload guest has no power-button handler, so every `down` paid 2 s for nothing. Replaced with a 250 ms graceful window polled at 25 ms (`firecracker::is_vm_running` until exit), escalating to the hard kill only when the guest ignores the request. The escalation decision is a pure `await_graceful_exit(max_wait, poll_interval, is_running, now, sleep)` helper — probe/clock/sleep injected — so it's unit-tested without a live guest or wall-clock waits (3 tests).

**Box-validated** (x86_64 KVM, Firecracker v1.14.1): warm `down` 0.78 / 0.84 / 0.86 s vs the old 2 s floor.

## 2. Kernel-less mkGuest flake boot
The firecracker *direct/manifest* path already falls back to the cached builder-VM kernel when a mkGuest workload emits no kernel (libkrun bundles its own; firecracker boots them on the cached kernel). The *flake* path routed through `resolve_vz_workload_kernel`, whose fallback was gated to vz only, so a kernel-less flake (e.g. `examples/sleeper`) refused under `--hypervisor firecracker` with `read kernel <build>/vmlinux: No such file`. Broadened the fallback to firecracker and renamed the resolver `resolve_vz_workload_kernel → resolve_workload_kernel` (it now covers both out-of-process backends). +1 unit test beside the existing vz ones.

`cargo clippy` + nightly `fmt` clean; `cargo test -p mvm-cli --lib resolve_workload_kernel` (5) green.