### PR TITLE
docs(plan-181): record preview-ingress DX benchmark, validate L4-first

### DIFF
--- a/specs/SPRINT.md
+++ b/specs/SPRINT.md
@@ -2731,6 +2731,10 @@ URL on one box.
 - [ ] Local single-machine dev ingress: tiny first-party reverse proxy mapping
   `http://s-<id>-<port>.preview.localhost` → published host port + wake hook;
   `up`/`run` prints the URL(s). No auth/TLS/wildcard-DNS (mvmd owns those).
+- Note: a DX benchmark vs a peer self-hosted sandbox backend confirmed preview URL is
+  the *only* local-DX gap to close here (idle-sleep/wake + HTTP control plane are mvmd's;
+  warm pool 118 + sub-second up/down 198 obviate its lazy-wake) and validated the L4 +
+  local-proxy-first shape over an ambient per-route HTTP proxy — see Plan 181 WS-A.
 
 ### W4 (Plan 181 WS-C) — Streamable task + files protocol  🟡 proposed
 - [ ] Async task protocol over agent-RPC (Plan 169) reusing `ExecEvent` streaming

--- a/specs/plans/181-app-builder-product-surface.md
+++ b/specs/plans/181-app-builder-product-surface.md
@@ -122,6 +122,29 @@ local proxy) and leave HTTP-aware routing to mvmd, vs. ship a fuller local HTTP
 router now. Recommendation: L4 + local proxy first (cheap, owns nothing we don't
 already own); richer routing rides mvmd.
 
+**External-benchmark datapoint (supports L4-first).** A DX comparison against a
+peer self-hosted sandbox backend — whose pitch is the same create→agent→live
+preview URL loop — found the preview URL is the *only* local-DX gap worth
+closing here; the rest of its surface is either already matched (one-command
+bring-up, live output streaming) or correctly mvmd's:
+
+- Its idle-sleep + wake-on-request density and its HTTP control plane sit on the
+  mvmd side of ADR-070, not in mvm. The wake-on-access *seam* above is the mvm
+  primitive; the detector/router stays in mvmd (fleet) or the local proxy (dev).
+- Its lazy-wake exists to hide slow cold starts. Our warm pool (Plan 118) +
+  sub-second up/down (Plan 198) already cover that, so the local proxy can dial
+  the wake hook synchronously without a "waking…" UX of its own.
+- That peer buys the DX with Docker-socket isolation, host-path mounts, and
+  auth/caps off — the posture §Non-goals already rejects. The takeaway is the
+  *shape* of the URL, not the trust model.
+
+This validates shipping L4 + local proxy first and resisting an ambient,
+per-route HTTP proxy with its own port registry (the cheap-but-weaker shape the
+peer uses): keep ports signed into the `ExecutionPlan` and route at the gateway
+seam. Note publication is **not** claim-15-gated — a sealed prod workload
+*serving its published port* is the intended behavior, distinct from interactive
+console access; only ambient (unpublished) ports stay default-deny.
+
 ## WS-B — Lifecycle verb taxonomy (instance vs. workspace)
 
 Adopt the sibling's clean split between *instance* lifecycle and *workspace-data*


### PR DESCRIPTION
## What

Folds an external DX-benchmark finding into **Plan 181 WS-A — Preview ingress** (and a one-line pointer in the Sprint 61 W3 section). Docs-only; no code, no new plan.

## Why

We compared mvm's local-dev DX against a peer self-hosted sandbox backend (same create→agent→live-preview-URL pitch). The benchmark found that the **live preview URL is the only local-DX gap worth closing in mvm** — and that gap is **already tracked, and better specified, in Plan 181 WS-A**. Everything else is either already matched or correctly out of scope:

- One-command bring-up (`dev up`) and live output streaming (`invoke`/`exec`) — already matched.
- Idle-sleep + wake-on-request density and the HTTP control plane — correctly **mvmd's** (ADR-070), not mvm.
- The peer's lazy-wake exists to hide slow cold starts; our warm pool (Plan 118) + sub-second up/down (Plan 198) already cover that.

An initial standalone plan draft was discarded once WS-A was found to already own this — and to own it *more correctly* (published ports signed into the `ExecutionPlan` + L4 gateway-seam routing, vs. an ambient per-route HTTP proxy). This PR records the benchmark as a decision-supporting datapoint instead of duplicating the design.

## Changes

- `specs/plans/181-app-builder-product-surface.md` — WS-A: an "external-benchmark datapoint" note supporting the open *L4-first* owner-decision, plus a clarification that port publication is **not** claim-15-gated (a sealed prod workload serving its published port is intended; only unpublished ports stay default-deny).
- `specs/SPRINT.md` — Sprint 61 W3: one-line pointer to the above.

No claim impact; default-deny egress unchanged.