### PR TITLE
refactor(egress): dedup FC plan-secret decode + drop QEMU's dead substitution arm (Plan 197 cleanups)

### DIFF
--- a/crates/mvm-backend/src/egress_shared.rs
+++ b/crates/mvm-backend/src/egress_shared.rs
@@ -1,10 +1,8 @@
-//! Cfg-free egress-substitution plan decode for the macOS workload backends.
+//! Cfg-free egress-substitution plan decode shared by every workload backend.
 //!
-//! libkrun (and vz, next commit) decode the admitted plan's secret bindings
-//! with no OS gate. The Firecracker path still has its own Linux-gated copy in
-//! `microvm.rs`; collapsing that into this function is a tracked cleanup (it
-//! edits Linux-only code and wants a Linux-target check) — until then this is
-//! the macOS-side copy, not yet the single shared one.
+//! libkrun, vz, and the Linux-gated Firecracker path (`microvm.rs`) all decode
+//! the admitted plan's secret bindings through this one function — no OS gate,
+//! no per-backend copy.
 
 use anyhow::Result;
 use std::path::Path;

--- a/crates/mvm-backend/src/microvm.rs
+++ b/crates/mvm-backend/src/microvm.rs
@@ -2470,64 +2470,6 @@ fn resolve_fc_bridge_path() -> Result<std::path::PathBuf> {
     )
 }
 
-/// Stand up this VM's transparent egress substitution moat (endpoint +
-/// terminator + nft TAP REDIRECT) when the admitted plan carries
-/// secret bindings. Called after the FC guest is healthy.
-///
-/// The plan lives at `vm_state_dir(name)/plan.json` (the same file
-/// `spawn_fc_bridge` parses — `mvm_data_dir()/vms/<name>`, NOT the `abs_dir`
-/// VMS_DIR tree). The substitution pid + env sidecars also land under
-/// `vm_state_dir` so the invoke path's `vm_substitution_env_path` lookup
-/// resolves identically to the QEMU backend.
-///
-/// Fail-closed: any error propagates so the caller rolls back the VM. A
-/// missing/unsigned `plan.json` (legacy / non-admitted boot) or a plan with no
-/// secrets is a clean no-op — there's nothing to substitute.
-///
-/// The installed [`EgressRedirect`] is `persist`ed (not dropped): the VM keeps
-/// running after this returns, and `stop_vm` removes the nft table by name.
-///
-/// Shared plan decode: `Some((secrets, tenant))` when the admitted
-/// plan carries egress secrets, else `None` (legacy / non-admitted / no-secret
-/// boot — nothing to wire). A missing `plan.json` or an undecodable placeholder
-/// plan is the no-op path, not an error.
-#[cfg(target_os = "linux")]
-fn decode_plan_secrets(
-    state_dir: &std::path::Path,
-) -> Result<
-    Option<(
-        Vec<mvm_core::plan::SecretBinding>,
-        mvm_core::policy::RedactionPolicy,
-        String,
-    )>,
-> {
-    let plan_path = state_dir.join("plan.json");
-    let plan_json = match std::fs::read_to_string(&plan_path) {
-        Ok(s) => s,
-        Err(e) if e.kind() == std::io::ErrorKind::NotFound => return Ok(None),
-        Err(e) => {
-            return Err(anyhow::anyhow!(
-                "read plan.json at {} for egress substitution: {e}",
-                plan_path.display()
-            ));
-        }
-    };
-    // Both producers land here: the pre-start persist writes the bare
-    // `ExecutionPlan` (the shape the firecracker bridge parses too) and the
-    // gateway-bridge stash writes the signed envelope. Accept either.
-    let plan = match mvm_core::plan::plan_from_admitted_json(&plan_json) {
-        Ok(p) => p,
-        Err(e) => {
-            tracing::warn!(error = %e, "plan.json not a decodable admitted plan; skipping egress substitution");
-            return Ok(None);
-        }
-    };
-    if plan.secrets.is_empty() {
-        return Ok(None);
-    }
-    Ok(Some((plan.secrets, plan.redaction, plan.tenant.0)))
-}
-
 /// Spawn the per-VM substitution endpoint **before** the guest boots,
 /// so the `(var → placeholder)` pairs it mints (and
 /// writes to `vm_substitution_env_path`) are available when `boot_args` is built
@@ -2544,7 +2486,9 @@ fn spawn_egress_endpoint(config: &FlakeRunConfig) -> Result<EndpointGuard> {
 
     let name = &config.slot.name;
     let state_dir = mvm_core::config::vm_state_dir(name);
-    let Some((secrets, redaction, tenant)) = decode_plan_secrets(&state_dir)? else {
+    let Some((secrets, redaction, tenant)) =
+        crate::egress_shared::decode_plan_secrets_from_state(&state_dir)?
+    else {
         return Ok(EndpointGuard { vm_name: None });
     };
 
@@ -2582,7 +2526,7 @@ fn install_egress_redirect(config: &FlakeRunConfig) -> Result<()> {
 
     let name = &config.slot.name;
     let state_dir = mvm_core::config::vm_state_dir(name);
-    if decode_plan_secrets(&state_dir)?.is_none() {
+    if crate::egress_shared::decode_plan_secrets_from_state(&state_dir)?.is_none() {
         return Ok(());
     }
     let term_port = terminator_port_for(config.slot.index);

--- a/crates/mvm-backend/src/qemu.rs
+++ b/crates/mvm-backend/src/qemu.rs
@@ -45,7 +45,6 @@ use std::time::{Duration, Instant};
 
 use crate::base::ui;
 use crate::libkrun::open_console_capture;
-use crate::substitution_spawn::{reap_substitution_endpoint, spawn_substitution_endpoint};
 
 /// QEMU workload backend (Linux dev/test; KVM where present, TCG fallback).
 pub struct QemuBackend;
@@ -235,52 +234,9 @@ impl VmBackend for QemuBackend {
             return Err(e);
         }
 
-        // When the admitted plan carries secret bindings, spawn the per-VM
-        // substitution endpoint moat so the guest's egress can resolve
-        // placeholders host-side (the guest never holds the real secret). Fail
-        // closed: a secret-bearing workload whose endpoint can't come up is
-        // rolled back rather than run with its secrets unavailable.
-        if let (Some(tenant), Some(plan_json)) =
-            (config.tenant_id.as_deref(), config.plan_json.as_deref())
-        {
-            match mvm_core::plan::secrets_from_signed_json(plan_json) {
-                Ok(secrets) if !secrets.is_empty() => {
-                    // Per-destination redaction rides the same signed plan; a
-                    // parse hiccup defaults to all-off rather than failing the
-                    // boot (secrets already gate that).
-                    let redaction =
-                        mvm_core::plan::redaction_from_signed_json(plan_json).unwrap_or_default();
-                    // QEMU is slirp (no host TAP) — no transparent terminator
-                    // to install, so `terminator_listen: None`. The vsock
-                    // substitution channel alone is unchanged.
-                    if let Err(e) = spawn_substitution_endpoint(
-                        crate::substitution_spawn::SubstitutionSpawnParams {
-                            vm_name: &config.name,
-                            state_dir: &state_dir,
-                            tenant,
-                            secrets: &secrets,
-                            redaction: &redaction,
-                            transport: crate::substitution_spawn::EndpointTransport::Vsock {
-                                port: mvm_guest::vsock::SUBSTITUTION_PORT,
-                            },
-                            terminator_listen: None,
-                            // No transparent terminator on slirp ⇒ no TLS leg, so
-                            // no per-VM intermediate (https is FC-scoped).
-                            tls_intermediate: None,
-                        },
-                    ) {
-                        rollback_qemu(&state_dir, &pid_file);
-                        return Err(e);
-                    }
-                }
-                Ok(_) => {} // plan has no egress secrets — no endpoint needed.
-                Err(e) => {
-                    // Not a decodable signed plan (legacy / test callers that
-                    // pass a placeholder plan_json). No secrets ⇒ no endpoint.
-                    tracing::warn!(error = %e, "plan_json not a decodable signed plan; skipping substitution endpoint");
-                }
-            }
-        }
+        // No egress substitution moat here: QEMU is type-barred from carrying
+        // an untrusted (secret-bearing) workload, so a signed plan with secrets
+        // never reaches this backend.
 
         ui::success(&format!(
             "QEMU workload '{}' started (pid: {}).",
@@ -301,10 +257,6 @@ impl VmBackend for QemuBackend {
             send_signal(bpid, libc::SIGTERM);
         }
         let _ = std::fs::remove_file(state_dir.join(BRIDGE_PID_FILE));
-
-        // Reap the substitution endpoint moat (if this VM had one) so its
-        // decrypted secrets don't outlive the guest.
-        reap_substitution_endpoint(&state_dir, &id.0);
 
         let pid_path = state_dir.join(QEMU_PID_FILE);
         let Some(pid) = read_pid(&pid_path) else {
@@ -677,21 +629,6 @@ fn spawn_vsock_bridge(name: &str, cid: u32, state_dir: &Path) -> Result<()> {
         std::thread::sleep(Duration::from_millis(50));
     }
     Ok(())
-}
-
-/// Kill the just-started qemu + bridge and drop their sidecars — used when a
-/// later step of `start` fails so a failed `start` (not followed by `stop`)
-/// doesn't orphan a daemonized qemu.
-fn rollback_qemu(state_dir: &Path, pid_file: &Path) {
-    if let Some(bpid) = read_pid(&state_dir.join(BRIDGE_PID_FILE)) {
-        send_signal(bpid, libc::SIGTERM);
-    }
-    if let Some(pid) = read_pid(pid_file) {
-        send_signal(pid, libc::SIGTERM);
-    }
-    let _ = std::fs::remove_file(pid_file);
-    let _ = std::fs::remove_file(state_dir.join(QEMU_CID_FILE));
-    let _ = std::fs::remove_file(state_dir.join(BRIDGE_PID_FILE));
 }
 
 /// Body of the `mvmctl __qemu-vsock-bridge` subcommand. Listens on the


### PR DESCRIPTION
The two Plan 197 follow-ups #921 listed as "remaining, non-blocking." Reuse-first, **no behavior change**.

## 1. FC `decode_plan_secrets` dedup
`microvm.rs` carried a Linux-gated `decode_plan_secrets` **byte-identical** to `egress_shared::decode_plan_secrets_from_state` (the cfg-free decoder vz/libkrun already share — its module doc flagged the collapse as a tracked cleanup). Confirmed identical (same return type, same `plan.json` read, same `NotFound→None` / undecodable→`warn`+`None` / empty-secrets→`None` semantics). Repointed FC's two call sites (`spawn_egress_endpoint`, `install_egress_redirect`) at the shared fn, deleted the dup, and updated the module doc to "one decoder for every backend."

## 2. QEMU dead-substitution removal
QEMU is type-barred from carrying a secret-bearing workload — only FC/libkrun/vz/mock impl `WorkloadBackend`, `require_workload_backend` refuses qemu, and `AnyBackend::auto_select()` never returns qemu. Verified **every** `QemuBackend::start` caller is gated:
- `up.rs` (all 3 `backend.start` sites) — `require_workload_backend` immediately precedes each.
- `exec.rs::boot_session_vm` (the invoke/secret path that sets `plan_json`) — uses `auto_select()`, never qemu; ignores `--hypervisor`.
- `exec.rs` transient runner — `plan_json` stays `None`.
- `checkpoint.rs::boot_forked_child` — `bail!`s for any non-VZ-family hypervisor and admits no secrets.

So `QemuBackend::start`'s `spawn_substitution_endpoint` arm was dead. Removed it, the `stop()` reap, the now-orphaned `rollback_qemu` (its only caller), and the unused `substitution_spawn` import; left a one-line comment noting the type-bar.

## Verification
Both edits touch **Linux-gated** code (skipped by a plain macOS build), so verified on **`aarch64-unknown-linux-gnu`** via `cargo-zigbuild clippy -p mvm-backend --all-targets -D warnings` (clean) — plus macOS `clippy -p mvm-backend -D warnings`, `check-no-spec-refs-in-comments`, and the `egress_shared` / `qemu` / `workload_backend` (incl. `require_workload_backend_refuses_qemu`) lib tests. Net +11 / −132.