### PR TITLE
docs(plan-183): close resolved DHCP follow-up + re-confirm the two deferred items

### DIFF
--- a/specs/REFACTOR-STATUS.md
+++ b/specs/REFACTOR-STATUS.md
@@ -308,7 +308,12 @@ PLAN 118 — Supervisor standby pool              🟡 libkrun + Vz done; FC fol
       follow-up; not blocking current libkrun/Vz use
 
 PLAN 183 — Builder-VM egress posture + net boot ✅ DONE (follow-ups tracked in plan)
-  Last updated: 2026-06-12
+  Last updated: 2026-06-15 (deferred-section precision pass: DHCP belt-and-suspenders
+  item closed — resolved by WS-E2, static fallback a deliberate keep; the two remaining
+  deferred items re-confirmed correctly deferred — persistent-builder gvproxy is dead
+  scaffold (`builder_backend_select` picks the one-shot, not the persistent driver),
+  and the doctor egress-posture line is enforced in-guest + the lease/static/none
+  outcome isn't host-recorded, so both need builder-boot work, not a quick slice)
   [x] follow-ups: fs_quick-on-Vz (pause-aware gate) + vm_full restore (gvproxy re-spawn, idempotent cleanup)
   Diagnosis proven 2026-06-11: boot-time install_egress_lockdown (OUTPUT DROP,
   proxy-uid-only) applied to the whole builder VM and dropped every nix fetch.

--- a/specs/plans/183-builder-vm-egress-posture-and-dns.md
+++ b/specs/plans/183-builder-vm-egress-posture-and-dns.md
@@ -282,9 +282,10 @@ Two independent defects blocked `mvmctl up --flake <workload> --hypervisor vz`:
 
 ### deferred follow-ups
 
-- [ ] Vz DHCP datagram-path root cause was resolved by WS-E2 (unbound dgram socket);
-  the static-IP fallback from WS-B2 remains as belt-and-suspenders for any residual
-  race during udhcpc startup.
+- [x] Vz DHCP datagram-path root cause was resolved by WS-E2 (unbound dgram socket).
+  No pending action: the static-IP fallback from WS-B2 is a deliberate keep
+  (belt-and-suspenders for any residual race during udhcpc startup), not a TODO to
+  remove. Closed 2026-06-15.
 - [ ] Persistent Vz builder (`VzPersistentBuilderVm`) still runs `network: None`;
   wire gvproxy when that path leaves scaffold status.
   Close-out triage (2026-06-13): DEFERRED by design — the one-shot Vz builder
@@ -292,6 +293,14 @@ Two independent defects blocked `mvmctl up --flake <workload> --hypervisor vz`:
   proven cold `dev up`/`build` path uses; the persistent path is still scaffold,
   so wiring gvproxy there (~50-70 LOC copy of the one-shot pattern) can't be
   live-validated until that path is exercised. Not a vz close-out blocker.
+  Re-confirmed 2026-06-15: the persistent driver is **not selected** —
+  `builder_backend_select` picks the one-shot `run_build` path, and
+  `build_persistent_supervisor_config` (vz_builder.rs `network: None`) documents
+  in-code that it "stays offline until it is [selected] — at which point it gets
+  the same trusted-builder gvproxy as the one-shot path." So wiring it now is
+  speculative + dead-on-arrival; do it as part of making the persistent driver
+  the selected path, not before. (The caller, `commands/env/dev_vz.rs`, is also in
+  the Plan 189 boundary — coordinate there.)
 - [ ] `mvmctl doctor` line surfacing the in-builder egress posture + last builder
   network bootstrap outcome (lease vs static vs none), so this class of failure is
   diagnosable without console archaeology.
@@ -301,6 +310,13 @@ Two independent defects blocked `mvmctl up --flake <workload> --hypervisor vz`:
   surface it). The static per-arm egress posture alone (boot=open, install=locked)
   is already documented; the diagnostic value is in the *outcome*, which is the
   part that needs the substrate. Not a vz close-out blocker.
+  Re-confirmed 2026-06-15: the per-arm posture is enforced **in-guest**
+  (`mvm-host-vm-init/network.rs::install_egress_lockdown`, applied inside the
+  builder VM on Linux), so the host-side `doctor` can't read the live state — a
+  doctor line would either restate a fixed design constant (low value) or need
+  the builder boot to record its lease/static/none outcome to a host-readable
+  sidecar first (the plumbing). Either way it edits Linux-gated builder-boot code,
+  not a host-only doctor tweak.
 - [x] fs_quick on Vz: teach the quiesce gate to recognize the Vz paused state
   (pid stays alive under pause), and/or stop deleting the per-instance CoW
   rootfs on `down` so a stopped VM remains checkpointable.


### PR DESCRIPTION
Investigated whether any remaining Plan 183 deferred follow-up is a clean small slice. **None is** — both actionable items need builder-boot / Linux work, not a quick host-side change. This is the accurate-doc pass that records that finding.

- **DHCP datagram-path item → closed.** Root cause was resolved by WS-E2 (unbound dgram socket); the WS-B2 static-IP fallback is a deliberate keep (belt-and-suspenders for a residual udhcpc-startup race), not a pending TODO. It was sitting unticked as if it were open work.
- **Persistent-builder gvproxy → re-confirmed deferred.** The `VzPersistentBuilderVm` driver is **not selected** — `builder_backend_select` picks the one-shot `run_build` path (which already spawns gvproxy), and `build_persistent_supervisor_config`'s own in-code comment says it "stays offline until it is [selected]." Wiring it now would be dead-on-arrival + unvalidatable; its caller (`commands/env/dev_vz.rs`) is also inside the Plan 189 boundary.
- **doctor egress-posture line → re-confirmed deferred.** The per-arm posture is enforced **in-guest** (`mvm-host-vm-init/network.rs::install_egress_lockdown`), so the host-side `doctor` can't read live state; surfacing the lease/static/none outcome needs the builder boot to record it host-readable first.

Doc-only. Bumps the Plan 183 rollup block date.