### PR TITLE
feat(vz): give the persistent dev builder VM gvproxy egress (Plan 183 follow-up)

### DIFF
--- a/crates/mvm-build/src/vz_builder.rs
+++ b/crates/mvm-build/src/vz_builder.rs
@@ -64,6 +64,16 @@ struct BuilderGvproxyGuard {
     state_dir: PathBuf,
 }
 
+impl BuilderGvproxyGuard {
+    /// Disarm the guard so it does NOT reap gvproxy on drop. Used by
+    /// the persistent VM's `start` once the supervisor is spawned: the
+    /// detached gvproxy must outlive the CLI and is reaped later,
+    /// cross-process, by `stop_persistent_vz_by_pid_file`.
+    fn defuse(self) {
+        std::mem::forget(self);
+    }
+}
+
 impl Drop for BuilderGvproxyGuard {
     fn drop(&mut self) {
         if let Err(e) = host_gvproxy::stop_by_pid_file(&self.state_dir) {
@@ -1135,6 +1145,21 @@ impl VzPersistentBuilderVm {
             ))
         })?;
 
+        // Spawn host-side gvproxy so the long-lived dev VM has egress
+        // (a cold `nix build` from `dev shell` fetches nixpkgs). The
+        // guard reaps it if any fallible step below (config build,
+        // supervisor spawn) returns early; on success we `defuse()` so
+        // the detached gvproxy outlives the CLI — it's reaped later,
+        // cross-process, by `stop_persistent_vz_by_pid_file`.
+        let gvproxy = host_gvproxy::spawn_detached(&vm_state_dir).map_err(|e| {
+            BuilderVmError::ExtractionFailed(format!(
+                "spawn gvproxy for Vz persistent builder VM: {e}"
+            ))
+        })?;
+        let gvproxy_guard = BuilderGvproxyGuard {
+            state_dir: vm_state_dir.clone(),
+        };
+
         let cfg = build_vz_persistent_supervisor_config(VzPersistentConfigParams {
             vm_name: &vm_name,
             vm_state_dir: &vm_state_dir,
@@ -1145,9 +1170,13 @@ impl VzPersistentBuilderVm {
             vcpus: self.vcpus,
             memory_mib: self.memory_mib,
             expose_guest_agent: self.expose_guest_agent,
+            gvproxy: Some(&gvproxy),
         })?;
 
         let child = spawn_vz_supervisor_in_background(&supervisor_path, &cfg)?;
+
+        // Supervisor is up; hand gvproxy's lifetime to the detached VM.
+        gvproxy_guard.defuse();
 
         Ok(VzPersistentVmHandle {
             vm_state_dir,
@@ -1196,6 +1225,9 @@ struct VzPersistentConfigParams<'a> {
     memory_mib: u32,
     /// Open the guest-agent port (5252) alongside the dispatch port.
     expose_guest_agent: bool,
+    /// Host-side gvproxy giving the VM egress. `None` keeps the VM
+    /// offline (the cached-derivation path). A shared ref — `Copy`-safe.
+    gvproxy: Option<&'a host_gvproxy::HostGvproxyInfo>,
 }
 
 /// Build a [`crate::vz::SupervisorConfig`] for the persistent VM.
@@ -1218,6 +1250,7 @@ fn build_vz_persistent_supervisor_config(
         vcpus,
         memory_mib,
         expose_guest_agent,
+        gvproxy,
     } = params;
     let BuilderVmImage::Rootfs {
         kernel_path,
@@ -1321,13 +1354,18 @@ fn build_vz_persistent_supervisor_config(
             host_listen_ports: vec![],
         },
         console_output_path: Some(console_log),
-        // No virtio-net on the persistent driver yet. gvproxy is wired
-        // into the one-shot `run_build` path (the one
-        // `builder_backend_select` actually picks); this persistent
-        // driver isn't selected, so it stays offline until it is — at
-        // which point it gets the same trusted-builder gvproxy
-        // (no flow-audit drainer) as the one-shot path.
-        network: None,
+        // Host-side gvproxy gives the long-lived dev VM egress (a cold
+        // `nix build` from `dev shell` fetches nixpkgs). `None` keeps
+        // the offline / cached-derivation path (the caller passes
+        // `None` to opt out). The builder VM is a TRUSTED dev-tier build
+        // VM, not a workload subject to the claim-10 gateway flow-audit,
+        // so it gets plain gvproxy with no flow-audit drainer
+        // (events_ingest_socket_path stays None).
+        network: gvproxy.map(|g| crate::vz::NetworkConfig::Gvproxy {
+            socket_path: g.socket_path.to_string_lossy().into_owned(),
+            mac: host_gvproxy::derive_mac(vm_name),
+            events_ingest_socket_path: None,
+        }),
         balloon: None,
         control_socket_path: None,
         startup_mode: crate::vz::StartupMode::Boot,
@@ -1504,6 +1542,12 @@ pub fn persistent_vz_vsock_dir(session_id: &str) -> PathBuf {
 /// `VzBackend::stop` reap ladder without depending on its private
 /// helpers across the crate boundary.
 pub fn stop_persistent_vz_by_pid_file(state_dir: &Path) -> bool {
+    // Best-effort reap of the VM's host-side gvproxy. The supervisor
+    // detaches it, so `dev down` owns its teardown. Idempotent (a
+    // missing PID sidecar is a clean no-op), so it's safe even on the
+    // early-return paths below.
+    let _ = host_gvproxy::stop_by_pid_file(state_dir);
+
     let pid_path = state_dir.join(PERSISTENT_VZ_PID_FILE);
     let Some(pid) = read_pid_file(&pid_path) else {
         return false;
@@ -2085,6 +2129,7 @@ mod tests {
             vcpus: VZ_BUILDER_DEFAULT_VCPUS,
             memory_mib: VZ_BUILDER_DEFAULT_MEMORY_MIB,
             expose_guest_agent: false,
+            gvproxy: None,
         })
         .expect_err("non-Rootfs image must reject");
         assert!(format!("{err}").contains("non-Rootfs image"), "got: {err}");
@@ -2108,6 +2153,7 @@ mod tests {
             vcpus: 4,
             memory_mib: 8192,
             expose_guest_agent: false,
+            gvproxy: None,
         })
         .expect("config builds");
 
@@ -2138,13 +2184,53 @@ mod tests {
         );
         assert!(cfg.vsock.socket_dir.ends_with("vsock"));
 
-        // Persistent driver is still offline (not yet selected by
-        // builder_backend_select); gvproxy is wired into the one-shot
-        // run_build path instead. See build_vz_persistent_supervisor_config.
+        // No gvproxy passed → VM stays offline (cached-derivation path).
         assert!(cfg.network.is_none());
         // Boot startup; persistent Vz doesn't yet restore from a saved
         // snapshot.
         assert!(matches!(cfg.startup_mode, crate::vz::StartupMode::Boot));
+    }
+
+    #[test]
+    fn build_vz_persistent_supervisor_config_wires_gvproxy_when_present() {
+        let scratch = tempfile::tempdir().unwrap();
+        let vm_name = "mvm-persistent-builder-vz-net";
+        let vm_state_dir = scratch.path().join("vms").join(vm_name);
+        let gvproxy = host_gvproxy::HostGvproxyInfo {
+            socket_path: scratch.path().join("gvproxy.sock"),
+            pid: 4242,
+        };
+        let cfg = build_vz_persistent_supervisor_config(VzPersistentConfigParams {
+            vm_name,
+            vm_state_dir: &vm_state_dir,
+            image: &rootfs_image(),
+            workspace_root: &scratch.path().join("work"),
+            job_dir: &scratch.path().join("job"),
+            nix_store_img: &scratch.path().join("nix-store.img"),
+            vcpus: 2,
+            memory_mib: 1024,
+            expose_guest_agent: false,
+            gvproxy: Some(&gvproxy),
+        })
+        .expect("config builds");
+
+        // gvproxy present → trusted-builder plain Gvproxy (no flow-audit
+        // drainer), MAC derived from the VM name, socket pointed at the
+        // spawned listener.
+        match cfg.network.expect("network wired when gvproxy is present") {
+            crate::vz::NetworkConfig::Gvproxy {
+                socket_path,
+                mac,
+                events_ingest_socket_path,
+            } => {
+                assert_eq!(socket_path, gvproxy.socket_path.to_string_lossy());
+                assert_eq!(mac, host_gvproxy::derive_mac(vm_name));
+                assert!(
+                    events_ingest_socket_path.is_none(),
+                    "trusted dev-tier builder has no claim-10 flow-audit drainer"
+                );
+            }
+        }
     }
 
     #[test]
@@ -2166,6 +2252,7 @@ mod tests {
             vcpus: 2,
             memory_mib: 1024,
             expose_guest_agent: false,
+            gvproxy: None,
         })
         .expect("config builds");
         assert_eq!(cfg.kernel.cmdline, DEFAULT_VZ_BUILDER_CMDLINE);
@@ -2188,6 +2275,7 @@ mod tests {
             vcpus: 2,
             memory_mib: 1024,
             expose_guest_agent: false,
+            gvproxy: None,
         })
         .expect("config builds");
         let console = cfg.console_output_path.expect("console path set");
@@ -2224,6 +2312,7 @@ mod tests {
             vcpus: 2,
             memory_mib: 1024,
             expose_guest_agent: false,
+            gvproxy: None,
         })
         .expect("config builds");
         let socket_dir = std::path::Path::new(&cfg.vsock.socket_dir);
@@ -2249,6 +2338,7 @@ mod tests {
             vcpus: 2,
             memory_mib: 1024,
             expose_guest_agent: false,
+            gvproxy: None,
         };
         let dispatch_only = build_vz_persistent_supervisor_config(VzPersistentConfigParams {
             expose_guest_agent: false,

--- a/specs/REFACTOR-STATUS.md
+++ b/specs/REFACTOR-STATUS.md
@@ -312,12 +312,14 @@ PLAN 118 — Supervisor standby pool              🟡 libkrun + Vz done; FC fol
       follow-up; not blocking current libkrun/Vz use
 
 PLAN 183 — Builder-VM egress posture + net boot ✅ DONE (follow-ups tracked in plan)
-  Last updated: 2026-06-15 (deferred-section precision pass: DHCP belt-and-suspenders
-  item closed — resolved by WS-E2, static fallback a deliberate keep; the two remaining
-  deferred items re-confirmed correctly deferred — persistent-builder gvproxy is dead
-  scaffold (`builder_backend_select` picks the one-shot, not the persistent driver),
-  and the doctor egress-posture line is enforced in-guest + the lease/static/none
-  outcome isn't host-recorded, so both need builder-boot work, not a quick slice)
+  Last updated: 2026-06-15 (deferred-section close-out: DHCP belt-and-suspenders item
+  closed; persistent Vz builder VM now gets gvproxy egress — `dev up` spawns gvproxy +
+  the dev VM takes a DHCP lease 192.168.127.3 from the gvproxy gateway, `dev down`
+  reaps it, all contained to vz_builder.rs, live-validated on macOS-26; only the
+  doctor egress-posture line remains deferred — it's in-guest-enforced + the
+  lease/static/none outcome isn't host-recorded, so it needs builder-boot work)
+  [x] persistent Vz builder VM gvproxy egress — vz_builder.rs spawn+config+reap;
+      live-validated (dev up lease 192.168.127.3 from gvproxy gw; dev down no leak)
   [x] follow-ups: fs_quick-on-Vz (pause-aware gate) + vm_full restore (gvproxy re-spawn, idempotent cleanup)
   Diagnosis proven 2026-06-11: boot-time install_egress_lockdown (OUTPUT DROP,
   proxy-uid-only) applied to the whole builder VM and dropped every nix fetch.

--- a/specs/plans/183-builder-vm-egress-posture-and-dns.md
+++ b/specs/plans/183-builder-vm-egress-posture-and-dns.md
@@ -286,21 +286,17 @@ Two independent defects blocked `mvmctl up --flake <workload> --hypervisor vz`:
   No pending action: the static-IP fallback from WS-B2 is a deliberate keep
   (belt-and-suspenders for any residual race during udhcpc startup), not a TODO to
   remove. Closed 2026-06-15.
-- [ ] Persistent Vz builder (`VzPersistentBuilderVm`) still runs `network: None`;
-  wire gvproxy when that path leaves scaffold status.
-  Close-out triage (2026-06-13): DEFERRED by design — the one-shot Vz builder
-  already spawns gvproxy (`host_gvproxy::spawn_detached`), which is what the
-  proven cold `dev up`/`build` path uses; the persistent path is still scaffold,
-  so wiring gvproxy there (~50-70 LOC copy of the one-shot pattern) can't be
-  live-validated until that path is exercised. Not a vz close-out blocker.
-  Re-confirmed 2026-06-15: the persistent driver is **not selected** —
-  `builder_backend_select` picks the one-shot `run_build` path, and
-  `build_persistent_supervisor_config` (vz_builder.rs `network: None`) documents
-  in-code that it "stays offline until it is [selected] — at which point it gets
-  the same trusted-builder gvproxy as the one-shot path." So wiring it now is
-  speculative + dead-on-arrival; do it as part of making the persistent driver
-  the selected path, not before. (The caller, `commands/env/dev_vz.rs`, is also in
-  the Plan 189 boundary — coordinate there.)
+- [x] Persistent Vz builder (`VzPersistentBuilderVm`) gets gvproxy egress.
+  DONE 2026-06-15: `start` spawns `host_gvproxy::spawn_detached` (a
+  `BuilderGvproxyGuard` reaps it on any start-error path, defused on success so the
+  detached gvproxy outlives the CLI), `build_vz_persistent_supervisor_config` now
+  wires `NetworkConfig::Gvproxy` (was `network: None`; no flow-audit drainer —
+  trusted dev-tier), and `stop_persistent_vz_by_pid_file` reaps it so `dev down`
+  doesn't leak it — all contained to `vz_builder.rs` (the dev_vz.rs down path
+  already delegates the reap here). Live-validated on macOS-26: `dev up` spawned
+  gvproxy and the dev VM took a DHCP lease 192.168.127.3 from the gvproxy gateway
+  192.168.127.1 (vs no virtio-net at all under `network: None`); `dev down` reaped
+  the gvproxy with no leak.
 - [ ] `mvmctl doctor` line surfacing the in-builder egress posture + last builder
   network bootstrap outcome (lease vs static vs none), so this class of failure is
   diagnosable without console archaeology.


### PR DESCRIPTION
The long-lived persistent Vz builder VM that `mvmctl dev up` boots ran `network: None`, so `dev shell` had no egress (an in-shell `nix build` / `curl` couldn't reach the network). This wires it the same trusted-builder gvproxy the one-shot `run_build` path already uses — the last open *code* item in Plan 183.

## Change (contained to `crates/mvm-build/src/vz_builder.rs`)
- `VzPersistentBuilderVm::start` spawns `host_gvproxy::spawn_detached` and threads it into the supervisor config. A `BuilderGvproxyGuard` reaps it if a later start step fails; it's `defuse()`'d on success so the detached gvproxy outlives the CLI.
- `build_vz_persistent_supervisor_config` now sets `NetworkConfig::Gvproxy` (was `None`); `events_ingest_socket_path: None` keeps the trusted dev-tier builder off the flow-audit drainer, matching the one-shot path.
- `stop_persistent_vz_by_pid_file` reaps the gvproxy too, so `dev down` doesn't leak it. No `dev_vz.rs` change — that down path already delegates the reap here (avoids the Plan 189 boundary).

## Live validation (macOS-26 Apple Silicon)
`dev up` (isolated env) → `dev down`:
- ✅ **gvproxy spawned** for the persistent dev VM (`host-gvproxy.pid` + `gvproxy.sock`) — `network: None` produced neither.
- ✅ **dev VM got network**: console shows `udhcpc: lease of 192.168.127.3 obtained from 192.168.127.1` (the gvproxy subnet) — no virtio-net device existed before.
- ✅ **`dev down` reaped gvproxy** (pid gone, no leak).

## Tests / gates
Unit tests assert the config wires gvproxy when present and stays offline when absent (`--features builder-vm`, 662 green). `cargo fmt`, `clippy -p mvm-build --features builder-vm -D warnings`, `check-no-spec-refs-in-comments` — all clean.

Also folds the Plan 183 deferred-section close-out: DHCP belt-and-suspenders item closed (resolved by WS-E2, fallback a deliberate keep); the `doctor` egress-posture line stays deferred (in-guest-enforced + outcome not host-recorded — needs builder-boot work). **Supersedes #935** (which re-confirmed this item as deferred before it was implemented).