### PR TITLE
docs(mvm-build): fix unconditional broken intra-doc links (Plan 185 Task 13)

### DIFF
--- a/crates/mvm-build/src/bin/mvm-egress-proxy.rs
+++ b/crates/mvm-build/src/bin/mvm-egress-proxy.rs
@@ -3,10 +3,10 @@
 //!
 //! The binary:
 //!
-//! 1. Builds an [`Allowlist`] (production hostnames by default;
+//! 1. Builds an `Allowlist` (production hostnames by default;
 //!    `MVM_EGRESS_ALLOWLIST` env-var override gated behind the
 //!    `dev-shell` Cargo feature for tests).
-//! 2. Binds the proxy at [`crate::proxy::DEFAULT_BIND`] (or
+//! 2. Binds the proxy at `DEFAULT_BIND` (or
 //!    `MVM_EGRESS_BIND` if set — gated the same way for tests).
 //! 3. Prints `mvm-egress-proxy: listening on <addr>` to stdout so
 //!    the parent (mvm-host-vm-init) can scrape the addr if it

--- a/crates/mvm-build/src/builder_vm.rs
+++ b/crates/mvm-build/src/builder_vm.rs
@@ -522,7 +522,7 @@ fn dir_size_bytes(dir: &std::path::Path) -> u64 {
 /// Stub implementation. Every method returns
 /// [`BuilderVmError::NotYetImplemented`]. Kept around for tests that
 /// want a `BuilderVm` impl with deterministic error behavior;
-/// production code uses [`LibkrunBuilderVm`].
+/// production code uses [`crate::libkrun_builder::LibkrunBuilderVm`].
 #[derive(Debug, Default, Clone, Copy)]
 pub struct StubBuilderVm;
 

--- a/crates/mvm-build/src/host_gvproxy.rs
+++ b/crates/mvm-build/src/host_gvproxy.rs
@@ -192,7 +192,7 @@ pub fn spawn_detached(scratch_dir: &Path) -> Result<HostGvproxyInfo> {
 }
 
 /// Read the PID file under `scratch_dir`, SIGTERM the gvproxy
-/// process, wait up to [`STOP_TIMEOUT`] for it to exit, and fall
+/// process, wait up to `STOP_TIMEOUT` for it to exit, and fall
 /// back to SIGKILL. Removes the PID file + socket file on success
 /// or on a clean already-gone state. Idempotent — no-op when the
 /// PID file is missing or the named process is already gone.

--- a/crates/mvm-build/src/vz.rs
+++ b/crates/mvm-build/src/vz.rs
@@ -111,11 +111,11 @@ pub struct SupervisorConfig {
 
 /// How the supervisor brings the VM up.
 ///
-/// The supervisor branches on this tagged enum: [`Boot`] is the original
-/// kernel-and-cmdline path; [`Restore`] loads the VM state from a
-/// previously saved snapshot blob (macOS 14+).
+/// The supervisor branches on this tagged enum: [`StartupMode::Boot`] is the
+/// original kernel-and-cmdline path; [`StartupMode::Restore`] loads the VM
+/// state from a previously saved snapshot blob (macOS 14+).
 ///
-/// Default is [`Boot`] so old JSON corpora without this field keep
+/// Default is [`StartupMode::Boot`] so old JSON corpora without this field keep
 /// the original behaviour, which keeps the fuzz corpus valid and lets
 /// every caller that doesn't care about restore (almost everyone) skip
 /// the field.
@@ -129,7 +129,7 @@ pub enum StartupMode {
     /// Restore from a previously saved Vz machine-state file. The
     /// supervisor:
     ///
-    /// 1. Constructs a [`VZVirtualMachineConfiguration`] from the
+    /// 1. Constructs a `VZVirtualMachineConfiguration` from the
     ///    same disks / cpu / memory / vsock / network / balloon
     ///    fields a `Boot` mode would, **omitting** the boot loader.
     /// 2. If `machine_id_path` is set and the sidecar exists, parses

--- a/crates/mvm-build/src/vz_builder.rs
+++ b/crates/mvm-build/src/vz_builder.rs
@@ -1,5 +1,5 @@
 //! Apple Virtualization.framework (Vz) backend for the builder VM,
-//! parallel to [`libkrun_builder::LibkrunBuilderBackend`].
+//! parallel to [`crate::libkrun_builder::LibkrunBuilderBackend`].
 //!
 //! Second `VmBackendForBuilder` impl. Owns the
 //! Vz-specific spawn (`mvm-vz-supervisor` binary with
@@ -76,7 +76,7 @@ impl Drop for BuilderGvproxyGuard {
     }
 }
 
-/// Vz parallel of [`libkrun_builder::LibkrunBuilderBackend`]. Holds
+/// Vz parallel of [`crate::libkrun_builder::LibkrunBuilderBackend`]. Holds
 /// the resolved supervisor binary path + cached builder VM image so
 /// a missing prerequisite surfaces at `new()`-time, not mid-build.
 ///
@@ -435,24 +435,24 @@ fn path_to_string(p: &Path, field: &str) -> Result<String, BuilderVmError> {
 // ─────────────────────────────────────────────────────────────────
 
 /// Default vCPU count for Vz builder VM runs. Same value as
-/// [`libkrun_builder::DEFAULT_VCPUS`] — nix builds parallelise at
+/// [`crate::libkrun_builder::DEFAULT_VCPUS`] — nix builds parallelise at
 /// the derivation level, so 4 cores keeps a build saturated without
 /// pinning the host.
 pub const VZ_BUILDER_DEFAULT_VCPUS: u8 = crate::libkrun_builder::DEFAULT_VCPUS;
 
 /// Default guest RAM (MiB) for Vz builder VM runs. Same value as
-/// [`libkrun_builder::DEFAULT_MEMORY_MIB`] for parity with the
+/// [`crate::libkrun_builder::DEFAULT_MEMORY_MIB`] for parity with the
 /// libkrun path; the Stage 0 tmpfs cap inside the builder VM rootfs
 /// is what actually limits build memory, not the VM-level cap.
 pub const VZ_BUILDER_DEFAULT_MEMORY_MIB: u32 = crate::libkrun_builder::DEFAULT_MEMORY_MIB;
 
 /// Default persistent `/nix-store` sparse-image cap (MiB) for Vz
 /// builder VM runs. Same value as
-/// [`libkrun_builder::DEFAULT_NIX_STORE_MIB`] so swapping backends
+/// [`crate::libkrun_builder::DEFAULT_NIX_STORE_MIB`] so swapping backends
 /// doesn't change the on-disk cache footprint.
 pub const VZ_BUILDER_DEFAULT_NIX_STORE_MIB: u32 = crate::libkrun_builder::DEFAULT_NIX_STORE_MIB;
 
-/// Vz parallel of [`libkrun_builder::LibkrunBuilderVm`]. Implements
+/// Vz parallel of [`crate::libkrun_builder::LibkrunBuilderVm`]. Implements
 /// [`BuilderVm::run_build`] against the [`VzBuilderBackend`] seam,
 /// sharing every bit of substrate orchestration with the libkrun
 /// driver via the shared `builder_vm_runtime` helpers.
@@ -475,7 +475,7 @@ pub struct VzBuilderVm {
     /// [`Self::run_build`] boots from this kernel/rootfs/cmdline
     /// instead of resolving the builder VM image from
     /// `~/.cache/mvm/builder-vm/<arch>/`. Same shape as the libkrun
-    /// driver's [`libkrun_builder::LibkrunBuilderVm::image_override`].
+    /// driver's [`crate::libkrun_builder::LibkrunBuilderVm::image_override`].
     pub image_override: Option<BuilderVmImage>,
     /// Optional supervisor binary path override. When `None`,
     /// [`resolve_vz_supervisor_path`] is consulted. Useful for tests
@@ -526,7 +526,7 @@ impl VzBuilderVm {
         self
     }
 
-    /// Mirror of [`libkrun_builder::LibkrunBuilderVm::validate_mounts`].
+    /// Mirror of [`crate::libkrun_builder::LibkrunBuilderVm::validate_mounts`].
     /// Same shape — the validation is hypervisor-agnostic so we
     /// reuse the wording but keep the function private so each
     /// backend can evolve its own surface (e.g. Vz refusing a
@@ -566,7 +566,7 @@ impl VzBuilderVm {
     }
 
     /// Same shape as
-    /// [`libkrun_builder::LibkrunBuilderVm::validate_job`].
+    /// [`crate::libkrun_builder::LibkrunBuilderVm::validate_job`].
     fn validate_job(&self, job: &BuilderJob) -> Result<(), BuilderVmError> {
         match job {
             BuilderJob::Flake {
@@ -951,7 +951,7 @@ fn workspace_root_from_crate_manifest_dir(manifest_dir: &Path) -> Option<PathBuf
 // VzPersistentBuilderVm
 // ──────────────────────────────────────────────────────────────────
 //
-// Parallel of [`libkrun_builder::LibkrunPersistentHostVm`]. Same
+// Parallel of [`crate::libkrun_builder::LibkrunPersistentHostVm`]. Same
 // dispatch-loop semantics (vsock-framed `HostVmRequest::Run` from the
 // host-side [`crate::persistent_builder::PersistentBuilderSupervisor`]
 // → in-guest `mvm-host-vm-init` runs cmd.sh / install_spec.json →


### PR DESCRIPTION
Continues the Task 13 doc-hygiene pass into **mvm-build** (sibling to the mvm-core pass in #939). Fixes the intra-doc links that are broken **regardless of platform/features** — bare or wrong module paths that resolve once qualified.

- `vz_builder.rs`: 10× `[`libkrun_builder::X`]` → `[`crate::libkrun_builder::X`]` (the *code* already uses `crate::libkrun_builder::…`; only the doc links dropped the prefix).
- `vz.rs`: `[`Boot`]`/`[`Restore`]` → `[`StartupMode::Boot`]`/`[`StartupMode::Restore`]`; the external objc2 `VZVirtualMachineConfiguration` backticked.
- `builder_vm.rs`: `[`LibkrunBuilderVm`]` → `[`crate::libkrun_builder::LibkrunBuilderVm`]`.
- `host_gvproxy.rs`: private const `STOP_TIMEOUT` backticked.
- `mvm-egress-proxy` bin: `Allowlist`/`DEFAULT_BIND` backticked (bin-crate prose).

**Verified:** `cargo doc -p mvm-build --all-features --no-deps` with `-W rustdoc::broken_intra_doc_links` drops the count **45 → 32**. Doc-comment-only; `clippy -p mvm-build --all-features --all-targets -- -D warnings`, nightly fmt, and the spec gates pass.

**Important finding (refines Task 13):** the remaining 32 are *not* plain bugs. Most are module-doc `//!` bare names needing crate-qualification, and a cluster points at `#[cfg(target_os = "linux")]` builder-VM bins (`mvm-host-vm-init`, egress-proxy internals) that aren't in the doc graph on a **macOS host** — they resolve on a **Linux** doc build. So a genuinely clean workspace doc needs **Linux + `--all-features`, per-crate**; backticking valid-on-Linux links to satisfy the macOS host would be wrong. This reframes the Phase 7 `cargo doc` gate.

Plan/SPRINT/rollup tracking for this finding is deliberately **not** edited here to avoid a merge-queue conflict with #939 (which rewrites the same Task 13 block); it'll be folded in once #939 lands.