### PR TITLE
test(secret-exposure): negative Debug-redaction tests for host secret types (Plan 185 Task 12)

### DIFF
--- a/crates/mvm-core/src/crypto/egress_ca.rs
+++ b/crates/mvm-core/src/crypto/egress_ca.rs
@@ -281,6 +281,22 @@ mod tests {
         assert!(cert.tbs_certificate.is_ca());
     }
 
+    #[test]
+    fn debug_redacts_ca_key_and_cert() {
+        let dir = tempdir().unwrap();
+        let ca = EgressCa::load_or_init_at(dir.path()).unwrap();
+        let dbg = format!("{ca:?}");
+        // The private key PEM must never reach a `{:?}` site.
+        assert!(
+            !dbg.contains("PRIVATE KEY") && !dbg.contains(&ca.key.serialize_pem()),
+            "EgressCa Debug leaked private key material: {dbg}"
+        );
+        // The cert PEM is redacted too (it's not secret, but Debug should stay
+        // terse rather than dump a multi-line PEM).
+        assert!(!dbg.contains("BEGIN CERTIFICATE"));
+        assert!(dbg.contains("<redacted>"), "expected key redaction: {dbg}");
+    }
+
     #[cfg(unix)]
     #[test]
     fn ca_key_is_mode_0400() {

--- a/crates/mvm-core/src/policy/secret_binding.rs
+++ b/crates/mvm-core/src/policy/secret_binding.rs
@@ -422,4 +422,49 @@ mod tests {
         // Manifest should NOT contain the actual secret value
         assert!(parsed[0].get("value").is_none());
     }
+
+    #[test]
+    fn debug_redacts_resolved_binding_value() {
+        let secret = "super-secret-token-value";
+        let binding = ResolvedBinding {
+            env_var: "API_KEY".to_string(),
+            target_host: "api.example.com".to_string(),
+            header: "authorization".to_string(),
+            value: secret.to_string(),
+        };
+        let dbg = format!("{binding:?}");
+        // The plaintext value must never reach a `{:?}` site.
+        assert!(
+            !dbg.contains(secret),
+            "ResolvedBinding Debug leaked the secret value: {dbg}"
+        );
+        // Addressing metadata is not secret and must stay visible.
+        assert!(dbg.contains("API_KEY"));
+        assert!(dbg.contains("api.example.com"));
+        // The value is redacted to its byte length.
+        assert!(
+            dbg.contains(&format!("<{} bytes>", secret.len())),
+            "expected byte-length redaction, got: {dbg}"
+        );
+    }
+
+    #[test]
+    fn debug_redacts_resolved_secrets_values() {
+        let secret = "another-secret-0xDEADBEEF";
+        let resolved = ResolvedSecrets {
+            bindings: vec![ResolvedBinding {
+                env_var: "TOKEN".to_string(),
+                target_host: "host.com".to_string(),
+                header: "x-token".to_string(),
+                value: secret.to_string(),
+            }],
+        };
+        // `ResolvedSecrets` Debug delegates to each binding's redacting Debug.
+        let dbg = format!("{resolved:?}");
+        assert!(
+            !dbg.contains(secret),
+            "ResolvedSecrets Debug leaked a secret value: {dbg}"
+        );
+        assert!(dbg.contains(&format!("<{} bytes>", secret.len())));
+    }
 }

--- a/crates/mvm-hostd/src/audit/host_keypair.rs
+++ b/crates/mvm-hostd/src/audit/host_keypair.rs
@@ -287,6 +287,31 @@ mod tests {
     }
 
     #[test]
+    fn debug_redacts_signing_key() {
+        let dir = fresh_keys_dir();
+        let signer = load_or_init_at(dir.path()).expect("init");
+        let dbg = format!("{signer:?}");
+        // The Ed25519 secret bytes must never reach a `{:?}` site, in any
+        // encoding the derived Debug might have produced.
+        let secret_hex: String = signer
+            .signing
+            .to_bytes()
+            .iter()
+            .map(|b| format!("{b:02x}"))
+            .collect();
+        assert!(
+            !dbg.contains(&secret_hex),
+            "HostSigner Debug leaked the signing key: {dbg}"
+        );
+        assert!(
+            dbg.contains("<redacted>"),
+            "signing key must be redacted: {dbg}"
+        );
+        // The public-key prefix is non-secret and stays visible for diagnostics.
+        assert!(dbg.contains("verifying_pubkey_prefix"));
+    }
+
+    #[test]
     fn refuses_loose_perms_above_0600() {
         let dir = fresh_keys_dir();
         load_or_init_at(dir.path()).expect("init");


### PR DESCRIPTION
Plan 185 **Task 12** (secret / debug exposure audit).

**Audit conclusion — the codebase already enforces secret hygiene well:**
- The name-based `check-no-display-on-secret-types` xtask gate is clean.
- Raw credential values live in zeroizing `secrecy::SecretBox` (e.g. the keyholder resolver returns `SecretBox<Vec<u8>>`).
- Secret-bearing types carry hand-written redacting `Debug` impls with `// allow(secret-debug)` notes.
- A field-name sweep for raw secret fields (`secret`/`password`/`api_key`/`private_key`/`token` of `String`/`Vec<u8>`) on non-`SecretBox` types found **no unprotected types** — the only hits are an opaque `pid_token` CLI arg and the already-hand-redacted `vmgenid::GenerationToken`.

**The gap (Step 3):** several types had a redacting `Debug` but **no negative test** pinning that behavior. A future edit that drops the custom impl (or re-adds the field to a derived `Debug`) would silently start leaking, and the name-based gate can't catch that (it only checks an impl *exists*, not that it *redacts*). This PR adds those tests:

- **mvm-hostd `HostSigner`** — `Debug` omits the Ed25519 signing-key bytes (asserted in hex) and shows `<redacted>` + the public-key prefix.
- **mvm-core `ResolvedBinding` / `ResolvedSecrets`** — `Debug` omits the plaintext `value`, keeps the addressing metadata, and redacts to a `<N bytes>` marker.
- **mvm-core `EgressCa`** — `Debug` omits the private-key PEM and shows `<redacted>`.

(`identity::SecretBytes`, the TLS intermediate, and the web-search provider already had equivalent redaction tests.)

**Tests-only — no production change.** Verified: the 3 new tests + the existing redaction tests pass; `cargo clippy -p mvm-core --features egress-ca -p mvm-hostd --all-targets -- -D warnings`, nightly fmt, and the `check-no-display-on-secret-types` / spec gates are clean.

Plan/SPRINT/rollup tracking for Task 12 (and the mvm-build Task 13 finding from #941) is intentionally **not** edited here — it would conflict with #939 in the merge queue (which rewrites the shared Task 13 block + SPRINT/rollup). It will be synced in one consolidated PR once #939/#941 land.
