### PR TITLE
fix(fc): skip the vestigial secrets drive when it has no content

### DIFF
--- a/crates/mvm-backend/src/microvm.rs
+++ b/crates/mvm-backend/src/microvm.rs
@@ -2107,17 +2107,26 @@ pub fn configure_flake_microvm_with_drives_dir(
         ),
     )?;
 
-    // Create and attach mvm-secrets drive (stub secrets.json + extra secret files)
-    ui::info("Creating secrets drive...");
-    let secrets_drive = create_dev_secrets_drive(drives_dir, &config.secret_files)?;
-    api_put_socket(
-        socket,
-        "/drives/secrets",
-        &format!(
-            r#"{{"drive_id": "secrets", "path_on_host": "{path}", "is_root_device": false, "is_read_only": true}}"#,
-            path = secrets_drive,
-        ),
-    )?;
+    // Attach the mvm-secrets drive ONLY when there is something to put on it.
+    // The workload guest never mounts this drive — `/init` reads the egress CA
+    // cert and the secret PLACEHOLDERS from the kernel cmdline (`mvm.egress_ca=`
+    // / `mvm.secret_env=`), and raw secrets never enter the guest (they are
+    // substituted at egress, claim 13). So for the common no-secret-binding
+    // workload the drive carries only a stub `{}` and is dead weight; skip the
+    // `mkfs` + attach entirely. It is still built when `secret_files` is
+    // non-empty (an explicit `--volume <host>:/mnt/secrets` share).
+    if !config.secret_files.is_empty() {
+        ui::info("Creating secrets drive...");
+        let secrets_drive = create_dev_secrets_drive(drives_dir, &config.secret_files)?;
+        api_put_socket(
+            socket,
+            "/drives/secrets",
+            &format!(
+                r#"{{"drive_id": "secrets", "path_on_host": "{path}", "is_root_device": false, "is_read_only": true}}"#,
+                path = secrets_drive,
+            ),
+        )?;
+    }
 
     for (idx, vol) in config.volumes.iter().enumerate() {
         let drive_id = format!("vol{}", idx);


### PR DESCRIPTION
## What

The Firecracker workload boot path created and attached an `mvm-secrets` ext4 drive on every `up`, even for workloads with no secrets — where it carried only a stub `{}`. This skips the `mkfs` + FC API attach when there's nothing to put on it.

```rust
if !config.secret_files.is_empty() {
    // create + attach mvm-secrets drive
}
```

## Why it's safe (the drive is vestigial)

The workload guest **never mounts** this drive. `mkGuest`'s `/init` mounts only pseudo-filesystems + user volumes (via the `mvm.uvols=` cmdline tag); it has no block-device mount for config or secrets. Everything the workload needs arrives on the **kernel cmdline**:

- the per-VM egress CA **certificate** → `mvm.egress_ca=` (cert only; the private key stays host-side in the terminator)
- secret **placeholders** → `mvm.secret_env=` (never values — raw secrets are substituted at egress, claim 13)

The mkGuest comments are explicit: *"a fresh FC boot attaches no secrets drive"* and *"no-secret guests boot byte-identically."* So for the common no-secret-binding workload the drive is pure dead weight.

`secret_files` is non-empty only for an explicit `--volume <host>:/mnt/secrets` share, in which case the drive is still built (behavior unchanged).

## Validation

Live on the x86_64 KVM box (Firecracker v1.14.1, `examples/sleeper`):
- `up` exits 0, VM is `Running`
- `Creating secrets drive` log line: **absent**
- `secrets.ext4` on disk: **never created** (VM dir holds only `mode.json` + `plan.json`)
- workload runs normally

`cargo build -p mvm-backend` + `cargo clippy -p mvm-backend` + nightly `fmt` clean.

## Follow-up (not in this PR)

The drive looks vestigial even when *non-empty* (the cert copy is redundant with the cmdline, and `/mnt/secrets` user-shares also target a drive the guest never mounts) — a candidate for full removal alongside the config drive, pending verification of the `/mnt/secrets`, snapshot-restore, and non-FC paths.