### PR TITLE
test(plan): shared PlanFixture builder; collapse 6 duplicated ExecutionPlan fixtures (Plan 185 Task 11)

### DIFF
--- a/crates/mvm-core/src/plan/mod.rs
+++ b/crates/mvm-core/src/plan/mod.rs
@@ -27,6 +27,8 @@
 pub mod bundle;
 pub mod execution_plan;
 pub mod signing;
+#[cfg(any(test, feature = "test-support"))]
+pub mod test_support;
 pub mod types;
 pub mod validity;
 

--- a/crates/mvm-core/src/plan/test_support.rs
+++ b/crates/mvm-core/src/plan/test_support.rs
@@ -1,0 +1,186 @@
+//! Shared test-only `ExecutionPlan` fixtures.
+//!
+//! The audit / admission tests across mvm-core and mvm-hostd each hand-rolled
+//! the same ~40-line minimal plan. [`PlanFixture`] is the single source: a
+//! valid local plan (one cpu, 128 MiB, `local-default` policies, a 10-minute
+//! validity window, all-zero nonce) with builder overrides for only the fields
+//! a given test actually pins. Gated behind
+//! `cfg(any(test, feature = "test-support"))` so it never reaches a production
+//! build.
+
+use std::collections::BTreeMap;
+
+use chrono::{DateTime, Duration, Utc};
+
+use crate::plan::execution_plan::{ExecutionPlan, SCHEMA_VERSION};
+use crate::plan::types::{
+    AdmissionProfile, ArtifactPolicy, AttestationMode, AttestationRequirement, FsPolicyRef,
+    KeyRotationSpec, Nonce, PlanId, PlanSeccompTier, PolicyRef, PostRunLifecycle, Resources,
+    RuntimeProfileRef, SecretBinding, SignedImageRef, TenantId, TimeoutSpec, WorkloadId,
+};
+
+/// Builder for a minimal, valid local [`ExecutionPlan`]. Defaults match the
+/// shape the audit/admission tests need; override only what a test pins.
+pub struct PlanFixture {
+    tenant: String,
+    plan_id: String,
+    workload: String,
+    runtime_profile: String,
+    nonce: [u8; 16],
+    secrets: Vec<SecretBinding>,
+    valid_from: Option<DateTime<Utc>>,
+    valid_until: Option<DateTime<Utc>>,
+}
+
+impl Default for PlanFixture {
+    fn default() -> Self {
+        Self {
+            tenant: "local".to_string(),
+            plan_id: "fixture-plan".to_string(),
+            workload: "vm-test".to_string(),
+            runtime_profile: "firecracker".to_string(),
+            nonce: [0u8; 16],
+            secrets: Vec::new(),
+            valid_from: None,
+            valid_until: None,
+        }
+    }
+}
+
+impl PlanFixture {
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    pub fn tenant(mut self, tenant: impl Into<String>) -> Self {
+        self.tenant = tenant.into();
+        self
+    }
+
+    pub fn plan_id(mut self, plan_id: impl Into<String>) -> Self {
+        self.plan_id = plan_id.into();
+        self
+    }
+
+    pub fn workload(mut self, workload: impl Into<String>) -> Self {
+        self.workload = workload.into();
+        self
+    }
+
+    pub fn runtime_profile(mut self, runtime_profile: impl Into<String>) -> Self {
+        self.runtime_profile = runtime_profile.into();
+        self
+    }
+
+    pub fn nonce(mut self, nonce: [u8; 16]) -> Self {
+        self.nonce = nonce;
+        self
+    }
+
+    pub fn secrets(mut self, secrets: Vec<SecretBinding>) -> Self {
+        self.secrets = secrets;
+        self
+    }
+
+    /// Pin an explicit validity window. Without this the plan is valid from
+    /// `now` to `now + 10min`.
+    pub fn validity(mut self, from: DateTime<Utc>, until: DateTime<Utc>) -> Self {
+        self.valid_from = Some(from);
+        self.valid_until = Some(until);
+        self
+    }
+
+    pub fn build(self) -> ExecutionPlan {
+        let now = Utc::now();
+        ExecutionPlan {
+            schema_version: SCHEMA_VERSION,
+            plan_id: PlanId(self.plan_id),
+            plan_version: 1,
+            tenant: TenantId(self.tenant),
+            workload: WorkloadId(self.workload),
+            runtime_profile: RuntimeProfileRef(self.runtime_profile),
+            image: SignedImageRef {
+                name: "vm-test".to_string(),
+                sha256: "a".repeat(64),
+                cosign_bundle: None,
+                entrypoint_present: true,
+            },
+            resources: Resources {
+                cpus: 1,
+                mem_mib: 128,
+                disk_mib: 0,
+                timeouts: TimeoutSpec {
+                    boot_secs: 30,
+                    exec_secs: 0,
+                },
+            },
+            admission_profile: AdmissionProfile::local_default("vm:boot", PlanSeccompTier::Standard),
+            network_policy: PolicyRef("local-default".to_string()),
+            fs_policy: FsPolicyRef("local-default".to_string()),
+            secrets: self.secrets,
+            egress_policy: PolicyRef("local-default".to_string()),
+            redaction: Default::default(),
+            tool_policy: PolicyRef("local-default".to_string()),
+            artifact_policy: ArtifactPolicy {
+                capture_paths: Vec::new(),
+                retention_days: 0,
+            },
+            audit_labels: BTreeMap::new(),
+            key_rotation: KeyRotationSpec { interval_days: 0 },
+            attestation: AttestationRequirement {
+                mode: AttestationMode::Noop,
+            },
+            release_pin: None,
+            post_run: PostRunLifecycle {
+                destroy_on_exit: true,
+                snapshot_on_idle: false,
+                idle_secs: 0,
+            },
+            valid_from: self.valid_from.unwrap_or(now),
+            valid_until: self.valid_until.unwrap_or(now + Duration::minutes(10)),
+            nonce: Nonce::from_bytes(self.nonce),
+            bundle: None,
+            deps_volume: None,
+            shares: Vec::new(),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn default_builds_a_valid_minimal_plan() {
+        let plan = PlanFixture::new().build();
+        assert_eq!(plan.tenant.0, "local");
+        assert_eq!(plan.plan_id.0, "fixture-plan");
+        assert_eq!(plan.runtime_profile.0, "firecracker");
+        assert_eq!(plan.resources.cpus, 1);
+        assert_eq!(plan.resources.mem_mib, 128);
+        assert!(plan.secrets.is_empty());
+        // Validity window defaults to a live 10-minute window.
+        assert!(plan.valid_until > plan.valid_from);
+    }
+
+    #[test]
+    fn overrides_are_applied() {
+        let from = Utc::now();
+        let until = from + Duration::minutes(5);
+        let plan = PlanFixture::new()
+            .tenant("acme")
+            .plan_id("p-1")
+            .workload("w-1")
+            .runtime_profile("vz")
+            .nonce([7u8; 16])
+            .validity(from, until)
+            .build();
+        assert_eq!(plan.tenant.0, "acme");
+        assert_eq!(plan.plan_id.0, "p-1");
+        assert_eq!(plan.workload.0, "w-1");
+        assert_eq!(plan.runtime_profile.0, "vz");
+        assert_eq!(plan.nonce, Nonce::from_bytes([7u8; 16]));
+        assert_eq!(plan.valid_from, from);
+        assert_eq!(plan.valid_until, until);
+    }
+}

--- a/crates/mvm-core/src/plan/test_support.rs
+++ b/crates/mvm-core/src/plan/test_support.rs
@@ -114,7 +114,10 @@ impl PlanFixture {
                     exec_secs: 0,
                 },
             },
-            admission_profile: AdmissionProfile::local_default("vm:boot", PlanSeccompTier::Standard),
+            admission_profile: AdmissionProfile::local_default(
+                "vm:boot",
+                PlanSeccompTier::Standard,
+            ),
             network_policy: PolicyRef("local-default".to_string()),
             fs_policy: FsPolicyRef("local-default".to_string()),
             secrets: self.secrets,

--- a/crates/mvm-hostd/src/audit/bind.rs
+++ b/crates/mvm-hostd/src/audit/bind.rs
@@ -63,70 +63,13 @@ mod tests {
     use crate::supervisor::verify_audit_chain;
     use ed25519_dalek::SigningKey;
     use mvm_core::checkpoint::{CheckpointClass, CheckpointId, CheckpointMeta, ContentBlob};
-    use mvm_core::plan::{
-        AdmissionProfile, ArtifactPolicy, AttestationMode, AttestationRequirement, FsPolicyRef,
-        KeyRotationSpec, Nonce, PlanId, PlanSeccompTier, PolicyRef, PostRunLifecycle, Resources,
-        RuntimeProfileRef, SCHEMA_VERSION, SignedImageRef, TenantId, TimeoutSpec, WorkloadId,
-    };
     use rand::rngs::OsRng;
-    use std::collections::BTreeMap;
 
     fn fixture_plan(tenant: &str, plan_id: &str) -> mvm_core::plan::ExecutionPlan {
-        let now = chrono::Utc::now();
-        mvm_core::plan::ExecutionPlan {
-            schema_version: SCHEMA_VERSION,
-            plan_id: PlanId(plan_id.to_string()),
-            plan_version: 1,
-            tenant: TenantId(tenant.to_string()),
-            workload: WorkloadId("vm-test".to_string()),
-            runtime_profile: RuntimeProfileRef("firecracker".to_string()),
-            image: SignedImageRef {
-                name: "vm-test".to_string(),
-                sha256: "a".repeat(64),
-                cosign_bundle: None,
-                entrypoint_present: true,
-            },
-            resources: Resources {
-                cpus: 1,
-                mem_mib: 128,
-                disk_mib: 0,
-                timeouts: TimeoutSpec {
-                    boot_secs: 30,
-                    exec_secs: 0,
-                },
-            },
-            admission_profile: AdmissionProfile::local_default(
-                "vm:boot",
-                PlanSeccompTier::Standard,
-            ),
-            network_policy: PolicyRef("local-default".to_string()),
-            fs_policy: FsPolicyRef("local-default".to_string()),
-            secrets: Vec::new(),
-            egress_policy: PolicyRef("local-default".to_string()),
-            redaction: Default::default(),
-            tool_policy: PolicyRef("local-default".to_string()),
-            artifact_policy: ArtifactPolicy {
-                capture_paths: Vec::new(),
-                retention_days: 0,
-            },
-            audit_labels: BTreeMap::new(),
-            key_rotation: KeyRotationSpec { interval_days: 0 },
-            attestation: AttestationRequirement {
-                mode: AttestationMode::Noop,
-            },
-            release_pin: None,
-            post_run: PostRunLifecycle {
-                destroy_on_exit: true,
-                snapshot_on_idle: false,
-                idle_secs: 0,
-            },
-            valid_from: now,
-            valid_until: now + chrono::Duration::minutes(10),
-            nonce: Nonce::from_bytes([0u8; 16]),
-            bundle: None,
-            deps_volume: None,
-            shares: Vec::new(),
-        }
+        mvm_core::plan::test_support::PlanFixture::new()
+            .tenant(tenant)
+            .plan_id(plan_id)
+            .build()
     }
 
     fn vm_full_meta(id: &str, vm: &str) -> CheckpointMeta {

--- a/crates/mvm-hostd/src/audit/emitter.rs
+++ b/crates/mvm-hostd/src/audit/emitter.rs
@@ -322,70 +322,13 @@ impl AuditEmitter {
 mod tests {
     use super::*;
     use crate::supervisor::verify_audit_chain;
-    use mvm_core::plan::{
-        AdmissionProfile, ArtifactPolicy, AttestationMode, AttestationRequirement, FsPolicyRef,
-        KeyRotationSpec, Nonce, PlanId, PlanSeccompTier, PolicyRef, PostRunLifecycle, Resources,
-        RuntimeProfileRef, SCHEMA_VERSION, SignedImageRef, TenantId, TimeoutSpec, WorkloadId,
-    };
     use rand::rngs::OsRng;
-    use std::collections::BTreeMap;
 
     fn fixture_plan(tenant: &str, plan_id: &str) -> ExecutionPlan {
-        let now = chrono::Utc::now();
-        ExecutionPlan {
-            schema_version: SCHEMA_VERSION,
-            plan_id: PlanId(plan_id.to_string()),
-            plan_version: 1,
-            tenant: TenantId(tenant.to_string()),
-            workload: WorkloadId("vm-test".to_string()),
-            runtime_profile: RuntimeProfileRef("firecracker".to_string()),
-            image: SignedImageRef {
-                name: "vm-test".to_string(),
-                sha256: "a".repeat(64),
-                cosign_bundle: None,
-                entrypoint_present: true,
-            },
-            resources: Resources {
-                cpus: 1,
-                mem_mib: 128,
-                disk_mib: 0,
-                timeouts: TimeoutSpec {
-                    boot_secs: 30,
-                    exec_secs: 0,
-                },
-            },
-            admission_profile: AdmissionProfile::local_default(
-                "vm:boot",
-                PlanSeccompTier::Standard,
-            ),
-            network_policy: PolicyRef("local-default".to_string()),
-            fs_policy: FsPolicyRef("local-default".to_string()),
-            secrets: Vec::new(),
-            egress_policy: PolicyRef("local-default".to_string()),
-            redaction: Default::default(),
-            tool_policy: PolicyRef("local-default".to_string()),
-            artifact_policy: ArtifactPolicy {
-                capture_paths: Vec::new(),
-                retention_days: 0,
-            },
-            audit_labels: BTreeMap::new(),
-            key_rotation: KeyRotationSpec { interval_days: 0 },
-            attestation: AttestationRequirement {
-                mode: AttestationMode::Noop,
-            },
-            release_pin: None,
-            post_run: PostRunLifecycle {
-                destroy_on_exit: true,
-                snapshot_on_idle: false,
-                idle_secs: 0,
-            },
-            valid_from: now,
-            valid_until: now + chrono::Duration::minutes(10),
-            nonce: Nonce::from_bytes([0u8; 16]),
-            bundle: None,
-            deps_volume: None,
-            shares: Vec::new(),
-        }
+        mvm_core::plan::test_support::PlanFixture::new()
+            .tenant(tenant)
+            .plan_id(plan_id)
+            .build()
     }
 
     #[test]

--- a/crates/mvm-hostd/src/audit/host_keypair.rs
+++ b/crates/mvm-hostd/src/audit/host_keypair.rs
@@ -364,69 +364,10 @@ mod tests {
     }
 
     fn fixture_plan() -> mvm_core::plan::ExecutionPlan {
-        use mvm_core::plan::{
-            AdmissionProfile, ArtifactPolicy, AttestationMode, AttestationRequirement, FsPolicyRef,
-            KeyRotationSpec, Nonce, PlanId, PlanSeccompTier, PolicyRef, PostRunLifecycle,
-            Resources, RuntimeProfileRef, SCHEMA_VERSION, SignedImageRef, TenantId, TimeoutSpec,
-            WorkloadId,
-        };
-        use std::collections::BTreeMap;
-
-        let now = chrono::Utc::now();
-        mvm_core::plan::ExecutionPlan {
-            schema_version: SCHEMA_VERSION,
-            plan_id: PlanId("host-keypair-test".to_string()),
-            plan_version: 1,
-            tenant: TenantId("local".to_string()),
-            workload: WorkloadId("test-vm".to_string()),
-            runtime_profile: RuntimeProfileRef("firecracker".to_string()),
-            image: SignedImageRef {
-                name: "img".to_string(),
-                sha256: "a".repeat(64),
-                cosign_bundle: None,
-                entrypoint_present: true,
-            },
-            resources: Resources {
-                cpus: 1,
-                mem_mib: 256,
-                disk_mib: 0,
-                timeouts: TimeoutSpec {
-                    boot_secs: 30,
-                    exec_secs: 0,
-                },
-            },
-            admission_profile: AdmissionProfile::local_default(
-                "vm:boot",
-                PlanSeccompTier::Standard,
-            ),
-            network_policy: PolicyRef("local-default".to_string()),
-            fs_policy: FsPolicyRef("local-default".to_string()),
-            secrets: Vec::new(),
-            egress_policy: PolicyRef("local-default".to_string()),
-            redaction: Default::default(),
-            tool_policy: PolicyRef("local-default".to_string()),
-            artifact_policy: ArtifactPolicy {
-                capture_paths: Vec::new(),
-                retention_days: 0,
-            },
-            audit_labels: BTreeMap::new(),
-            key_rotation: KeyRotationSpec { interval_days: 0 },
-            attestation: AttestationRequirement {
-                mode: AttestationMode::Noop,
-            },
-            release_pin: None,
-            post_run: PostRunLifecycle {
-                destroy_on_exit: true,
-                snapshot_on_idle: false,
-                idle_secs: 0,
-            },
-            valid_from: now,
-            valid_until: now + chrono::Duration::minutes(10),
-            nonce: Nonce::from_bytes([0u8; 16]),
-            bundle: None,
-            deps_volume: None,
-            shares: Vec::new(),
-        }
+        mvm_core::plan::test_support::PlanFixture::new()
+            .plan_id("host-keypair-test")
+            .workload("test-vm")
+            .build()
     }
 
     #[test]

--- a/crates/mvm-hostd/src/audit/plan_persist.rs
+++ b/crates/mvm-hostd/src/audit/plan_persist.rs
@@ -114,69 +114,12 @@ pub fn read_plan_at(path: &Path) -> Result<ExecutionPlan> {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use mvm_core::plan::{
-        AdmissionProfile, ArtifactPolicy, AttestationMode, AttestationRequirement, FsPolicyRef,
-        KeyRotationSpec, Nonce, PlanId, PlanSeccompTier, PolicyRef, PostRunLifecycle, Resources,
-        RuntimeProfileRef, SCHEMA_VERSION, SignedImageRef, TenantId, TimeoutSpec, WorkloadId,
-    };
-    use std::collections::BTreeMap;
 
     fn fixture_plan() -> ExecutionPlan {
-        let now = chrono::Utc::now();
-        ExecutionPlan {
-            schema_version: SCHEMA_VERSION,
-            plan_id: PlanId("plan-persist-test".to_string()),
-            plan_version: 1,
-            tenant: TenantId("local".to_string()),
-            workload: WorkloadId("vm-test".to_string()),
-            runtime_profile: RuntimeProfileRef("vz".to_string()),
-            image: SignedImageRef {
-                name: "vm-test".to_string(),
-                sha256: "a".repeat(64),
-                cosign_bundle: None,
-                entrypoint_present: true,
-            },
-            resources: Resources {
-                cpus: 1,
-                mem_mib: 128,
-                disk_mib: 0,
-                timeouts: TimeoutSpec {
-                    boot_secs: 30,
-                    exec_secs: 0,
-                },
-            },
-            admission_profile: AdmissionProfile::local_default(
-                "vm:boot",
-                PlanSeccompTier::Standard,
-            ),
-            network_policy: PolicyRef("local-default".to_string()),
-            fs_policy: FsPolicyRef("local-default".to_string()),
-            secrets: Vec::new(),
-            egress_policy: PolicyRef("local-default".to_string()),
-            redaction: Default::default(),
-            tool_policy: PolicyRef("local-default".to_string()),
-            artifact_policy: ArtifactPolicy {
-                capture_paths: Vec::new(),
-                retention_days: 0,
-            },
-            audit_labels: BTreeMap::new(),
-            key_rotation: KeyRotationSpec { interval_days: 0 },
-            attestation: AttestationRequirement {
-                mode: AttestationMode::Noop,
-            },
-            release_pin: None,
-            post_run: PostRunLifecycle {
-                destroy_on_exit: true,
-                snapshot_on_idle: false,
-                idle_secs: 0,
-            },
-            valid_from: now,
-            valid_until: now + chrono::Duration::minutes(10),
-            nonce: Nonce::from_bytes([0u8; 16]),
-            bundle: None,
-            deps_volume: None,
-            shares: Vec::new(),
-        }
+        mvm_core::plan::test_support::PlanFixture::new()
+            .plan_id("plan-persist-test")
+            .runtime_profile("vz")
+            .build()
     }
 
     #[test]

--- a/crates/mvm-hostd/src/supervisor/audit_recorder.rs
+++ b/crates/mvm-hostd/src/supervisor/audit_recorder.rs
@@ -336,68 +336,11 @@ fn merge_extras(
 mod tests {
     use super::*;
     use crate::supervisor::audit::CapturingAuditSigner;
-    use mvm_core::plan::{
-        AdmissionProfile, ArtifactPolicy, AttestationMode, AttestationRequirement, FsPolicyRef,
-        KeyRotationSpec, Nonce, PlanSeccompTier, PolicyRef, PostRunLifecycle, Resources,
-        RuntimeProfileRef, SCHEMA_VERSION, SignedImageRef, TimeoutSpec, WorkloadId,
-    };
 
     fn fixture_plan() -> ExecutionPlan {
-        let now = chrono::Utc::now();
-        ExecutionPlan {
-            schema_version: SCHEMA_VERSION,
-            plan_id: PlanId("plan-test".to_string()),
-            plan_version: 1,
-            tenant: TenantId("local".to_string()),
-            workload: WorkloadId("vm-test".to_string()),
-            runtime_profile: RuntimeProfileRef("firecracker".to_string()),
-            image: SignedImageRef {
-                name: "vm-test".to_string(),
-                sha256: "a".repeat(64),
-                cosign_bundle: None,
-                entrypoint_present: true,
-            },
-            resources: Resources {
-                cpus: 1,
-                mem_mib: 128,
-                disk_mib: 0,
-                timeouts: TimeoutSpec {
-                    boot_secs: 30,
-                    exec_secs: 0,
-                },
-            },
-            admission_profile: AdmissionProfile::local_default(
-                "vm:boot",
-                PlanSeccompTier::Standard,
-            ),
-            network_policy: PolicyRef("local-default".to_string()),
-            fs_policy: FsPolicyRef("local-default".to_string()),
-            secrets: Vec::new(),
-            egress_policy: PolicyRef("local-default".to_string()),
-            redaction: Default::default(),
-            tool_policy: PolicyRef("local-default".to_string()),
-            artifact_policy: ArtifactPolicy {
-                capture_paths: Vec::new(),
-                retention_days: 0,
-            },
-            audit_labels: BTreeMap::new(),
-            key_rotation: KeyRotationSpec { interval_days: 0 },
-            attestation: AttestationRequirement {
-                mode: AttestationMode::Noop,
-            },
-            release_pin: None,
-            post_run: PostRunLifecycle {
-                destroy_on_exit: true,
-                snapshot_on_idle: false,
-                idle_secs: 0,
-            },
-            valid_from: now,
-            valid_until: now + chrono::Duration::minutes(10),
-            nonce: Nonce::from_bytes([0u8; 16]),
-            bundle: None,
-            deps_volume: None,
-            shares: Vec::new(),
-        }
+        mvm_core::plan::test_support::PlanFixture::new()
+            .plan_id("plan-test")
+            .build()
     }
 
     fn fixture_recorder() -> (Recorder, Arc<CapturingAuditSigner>) {

--- a/crates/mvm-hostd/src/supervisor/lifecycle_hooks.rs
+++ b/crates/mvm-hostd/src/supervisor/lifecycle_hooks.rs
@@ -287,69 +287,12 @@ mod tests {
     use super::*;
     use crate::supervisor::audit::CapturingAuditSigner;
     use mvm_core::observability::metrics::Metrics;
-    use mvm_core::plan::{
-        AdmissionProfile, ArtifactPolicy, AttestationMode, AttestationRequirement, FsPolicyRef,
-        KeyRotationSpec, Nonce, PlanId, PlanSeccompTier, PolicyRef, PostRunLifecycle, Resources,
-        RuntimeProfileRef, SCHEMA_VERSION, SignedImageRef, TimeoutSpec, WorkloadId,
-    };
-    use std::collections::BTreeMap;
+    use mvm_core::plan::PlanId;
 
     fn fixture_plan() -> ExecutionPlan {
-        let now = chrono::Utc::now();
-        ExecutionPlan {
-            schema_version: SCHEMA_VERSION,
-            plan_id: PlanId("plan-test".to_string()),
-            plan_version: 1,
-            tenant: TenantId("local".to_string()),
-            workload: WorkloadId("vm-test".to_string()),
-            runtime_profile: RuntimeProfileRef("firecracker".to_string()),
-            image: SignedImageRef {
-                name: "vm-test".to_string(),
-                sha256: "a".repeat(64),
-                cosign_bundle: None,
-                entrypoint_present: true,
-            },
-            resources: Resources {
-                cpus: 1,
-                mem_mib: 128,
-                disk_mib: 0,
-                timeouts: TimeoutSpec {
-                    boot_secs: 30,
-                    exec_secs: 0,
-                },
-            },
-            admission_profile: AdmissionProfile::local_default(
-                "vm:boot",
-                PlanSeccompTier::Standard,
-            ),
-            network_policy: PolicyRef("local-default".to_string()),
-            fs_policy: FsPolicyRef("local-default".to_string()),
-            secrets: Vec::new(),
-            egress_policy: PolicyRef("local-default".to_string()),
-            redaction: Default::default(),
-            tool_policy: PolicyRef("local-default".to_string()),
-            artifact_policy: ArtifactPolicy {
-                capture_paths: Vec::new(),
-                retention_days: 0,
-            },
-            audit_labels: BTreeMap::new(),
-            key_rotation: KeyRotationSpec { interval_days: 0 },
-            attestation: AttestationRequirement {
-                mode: AttestationMode::Noop,
-            },
-            release_pin: None,
-            post_run: PostRunLifecycle {
-                destroy_on_exit: true,
-                snapshot_on_idle: false,
-                idle_secs: 0,
-            },
-            valid_from: now,
-            valid_until: now + chrono::Duration::minutes(10),
-            nonce: Nonce::from_bytes([0u8; 16]),
-            bundle: None,
-            deps_volume: None,
-            shares: Vec::new(),
-        }
+        mvm_core::plan::test_support::PlanFixture::new()
+            .plan_id("plan-test")
+            .build()
     }
 
     fn build_hooks() -> (LifecycleHooks, Arc<CapturingAuditSigner>, EventBus) {


### PR DESCRIPTION
Plan 185 **Task 11** (consolidate repeated fixtures).

Six near-identical ~40-line minimal `ExecutionPlan` fixtures — the mvm-hostd audit/admission cluster — each hand-rolled the same plan. Replaced with a single **`mvm_core::plan::test_support::PlanFixture`** builder: a valid local plan (1 cpu, 128 MiB, `local-default` policies, 10-minute validity window, zero nonce) with overrides for only the fields a test pins (`tenant`, `plan_id`, `workload`, `runtime_profile`, `nonce`, `secrets`, validity).

- Gated behind `cfg(any(test, feature = "test-support"))` so it never reaches a production build; both mvm-hostd and mvm-cli already enable `mvm-core/test-support` in dev-deps. Adds no deps (`chrono` already present) — `check-core-runtime-free` stays green.
- Migrated (each `fixture_plan` is now a thin wrapper, call sites unchanged, each test's pinned values preserved): `audit/{emitter,bind,host_keypair,plan_persist}`, `supervisor/{lifecycle_hooks,audit_recorder}`. Removed the now-unused per-file plan-type import blocks. **Net −156 lines.**
- The realistic-shape fixtures (`signing::sample_plan`, supervisor `aggregate`/`audit`, mvm-cli `policy_resolver`) are a materially different plan (cpus 2 / 1024 MiB / real policies) and intentionally left alone — folding them in would need a second preset for little gain.

**Verified:** 83 mvm-hostd audit/supervisor tests + 2 new `PlanFixture` unit tests pass; `cargo clippy -p mvm-core --features test-support -p mvm-hostd --all-targets -- -D warnings`; nightly fmt; spec / core-runtime-free gates.

Plan/SPRINT/rollup tracking is intentionally not edited here (would conflict with #949's rollup edit in the queue); it'll be synced once #949 lands.
