### PR TITLE
feat(doctor): surface the builder VM's last net-bootstrap outcome (Plan 183 final item)

### DIFF
--- a/crates/mvm-build/src/guest_net.rs
+++ b/crates/mvm-build/src/guest_net.rs
@@ -172,6 +172,76 @@ fn set_sockaddr_in(dst: *mut libc::sockaddr, addr: [u8; 4]) {
     }
 }
 
+/// The persistent builder VM's last network-bootstrap outcome, as
+/// recovered from its host-readable `console.log`.
+///
+/// The builder guest's init brings `eth0` up, runs busybox `udhcpc`, and
+/// on a failed lease falls back to the fixed gvproxy static address. Each
+/// path emits a distinct console line; this enum is the classification of
+/// the *last* such line (a VM can reboot, so later lines win).
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum BuilderNetBootstrap {
+    /// busybox udhcpc obtained a DHCP lease for `ip`.
+    Lease { ip: String },
+    /// udhcpc failed and init applied the fixed gvproxy static address.
+    /// Degraded but reachable.
+    StaticFallback { ip: String },
+    /// udhcpc failed and no static fallback was applied — the builder VM
+    /// has no IP and inner builds can't fetch.
+    Failed,
+    /// No recognizable outcome in the log yet.
+    Unknown,
+}
+
+/// The fixed gvproxy static address init falls back to when DHCP fails.
+/// gvproxy's virtual subnet is `192.168.127.0/24` (gateway+DNS at `.1`,
+/// first DHCP client at `.3`); each builder VM gets its own gvproxy
+/// instance, so this address can't collide across VMs.
+const GVPROXY_STATIC_FALLBACK_IP: &str = "192.168.127.3";
+
+/// Classify a persistent builder VM's network-bootstrap outcome from its
+/// `console.log` contents.
+///
+/// Scans every line and returns the *last* recognizable outcome, so a VM
+/// that rebooted reports its most recent boot rather than a stale one.
+/// Robust to interleaved log noise: only the three known markers are
+/// matched, anything else is ignored.
+///
+/// Markers (in `setup_network`'s emission order on a single boot):
+/// - DHCP lease: busybox prints `udhcpc: lease of <ip> obtained from ...`.
+/// - Static fallback: init prints `... falling back to static gvproxy
+///   addressing` after a non-zero udhcpc exit.
+/// - Failure: init prints `setup_network warning (non-fatal): ...` carrying
+///   `udhcpc exit <N>` with neither a lease nor a fallback line after it.
+pub fn classify_builder_net_bootstrap(console_log: &str) -> BuilderNetBootstrap {
+    let mut outcome = BuilderNetBootstrap::Unknown;
+    for line in console_log.lines() {
+        if let Some(ip) = parse_udhcpc_lease_ip(line) {
+            outcome = BuilderNetBootstrap::Lease { ip };
+        } else if line.contains("falling back to static gvproxy addressing") {
+            outcome = BuilderNetBootstrap::StaticFallback {
+                ip: GVPROXY_STATIC_FALLBACK_IP.to_string(),
+            };
+        } else if line.contains("setup_network warning (non-fatal)") && line.contains("udhcpc exit")
+        {
+            outcome = BuilderNetBootstrap::Failed;
+        }
+    }
+    outcome
+}
+
+/// Extract the leased IP from a busybox udhcpc lease line, if this is one.
+///
+/// Matches `udhcpc: lease of <ip> obtained from ...` and returns `<ip>`.
+/// Returns `None` for any other line. The address itself is validated
+/// through [`parse_ipv4`] so a malformed token isn't reported as a lease.
+fn parse_udhcpc_lease_ip(line: &str) -> Option<String> {
+    let after = line.split("lease of ").nth(1)?;
+    let ip = after.split_whitespace().next()?;
+    parse_ipv4(ip)?;
+    Some(ip.to_string())
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -220,5 +290,113 @@ mod tests {
         let over = "a".repeat(libc::IFNAMSIZ);
         let err = encode_iface_name(&over).expect_err("IFNAMSIZ-byte name rejected");
         assert!(err.contains("IFNAMSIZ"), "err mentions limit: {err}");
+    }
+
+    #[test]
+    fn classify_lease_from_real_busybox_line() {
+        let log = "udhcpc: lease of 192.168.127.3 obtained from 192.168.127.1, lease time 3600";
+        assert_eq!(
+            classify_builder_net_bootstrap(log),
+            BuilderNetBootstrap::Lease {
+                ip: "192.168.127.3".to_string()
+            }
+        );
+    }
+
+    #[test]
+    fn classify_lease_amid_noise() {
+        let log = "\
+booting...
+mvm-host-vm-init: bring_iface_up eth0
+udhcpc: sending discover
+udhcpc: lease of 10.0.2.15 obtained from 10.0.2.2, lease time 86400
+some-service: ready";
+        assert_eq!(
+            classify_builder_net_bootstrap(log),
+            BuilderNetBootstrap::Lease {
+                ip: "10.0.2.15".to_string()
+            }
+        );
+    }
+
+    #[test]
+    fn classify_static_fallback() {
+        let log = "\
+udhcpc: no lease, failing
+mvm-host-vm-init: udhcpc exit 1 — falling back to static gvproxy addressing";
+        assert_eq!(
+            classify_builder_net_bootstrap(log),
+            BuilderNetBootstrap::StaticFallback {
+                ip: "192.168.127.3".to_string()
+            }
+        );
+    }
+
+    #[test]
+    fn classify_failed_when_warning_without_lease_or_fallback() {
+        let log = "\
+udhcpc: sending discover
+mvm-host-vm-init: setup_network warning (non-fatal): spawn /bin/udhcpc: udhcpc exit 1";
+        assert_eq!(
+            classify_builder_net_bootstrap(log),
+            BuilderNetBootstrap::Failed
+        );
+    }
+
+    #[test]
+    fn classify_unknown_on_empty() {
+        assert_eq!(
+            classify_builder_net_bootstrap(""),
+            BuilderNetBootstrap::Unknown
+        );
+    }
+
+    #[test]
+    fn classify_unknown_on_unrelated_noise() {
+        let log = "boot ok\nservice up\nready";
+        assert_eq!(
+            classify_builder_net_bootstrap(log),
+            BuilderNetBootstrap::Unknown
+        );
+    }
+
+    #[test]
+    fn classify_takes_last_outcome_across_reboot() {
+        // A reboot: first boot leased, second boot fell back to static.
+        // The later outcome wins.
+        let log = "\
+udhcpc: lease of 192.168.127.3 obtained from 192.168.127.1, lease time 3600
+--- reboot ---
+mvm-host-vm-init: udhcpc exit 1 — falling back to static gvproxy addressing";
+        assert_eq!(
+            classify_builder_net_bootstrap(log),
+            BuilderNetBootstrap::StaticFallback {
+                ip: "192.168.127.3".to_string()
+            }
+        );
+    }
+
+    #[test]
+    fn classify_fallback_supersedes_earlier_failure_warning() {
+        // On one boot the warning and the fallback both appear; the
+        // fallback is the real outcome (reachable), so it must win.
+        let log = "\
+mvm-host-vm-init: setup_network warning (non-fatal): udhcpc exit 1
+mvm-host-vm-init: udhcpc exit 1 — falling back to static gvproxy addressing";
+        assert_eq!(
+            classify_builder_net_bootstrap(log),
+            BuilderNetBootstrap::StaticFallback {
+                ip: "192.168.127.3".to_string()
+            }
+        );
+    }
+
+    #[test]
+    fn classify_rejects_malformed_lease_ip() {
+        let log = "udhcpc: lease of not.an.ip.addr obtained from 192.168.127.1";
+        assert_eq!(
+            classify_builder_net_bootstrap(log),
+            BuilderNetBootstrap::Unknown
+        );
     }
 }

--- a/crates/mvm-build/src/vz_builder.rs
+++ b/crates/mvm-build/src/vz_builder.rs
@@ -1534,6 +1534,21 @@ pub fn persistent_vz_vsock_dir(session_id: &str) -> PathBuf {
     persistent_vz_state_dir(session_id).join("vsock")
 }
 
+/// Host path of the persistent dev builder VM's `console.log`.
+///
+/// The `"dev"` session id mirrors the CLI's `DEV_VM_SESSION_ID` — the id
+/// `mvmctl dev up` boots the long-lived Vz builder VM under. It is
+/// duplicated here as a string literal rather than imported because the
+/// CLI's dev session module is off-limits to this crate's dependency
+/// direction; if the CLI's id ever changes, this must move with it.
+///
+/// The guest writes its network-bootstrap outcome (DHCP lease / static
+/// fallback / failure) to this log, so it is the host-readable source for
+/// the `mvmctl doctor` builder-egress diagnostic.
+pub fn dev_builder_vz_console_log() -> PathBuf {
+    persistent_vz_state_dir("dev").join("console.log")
+}
+
 /// Read the supervisor PID file under `state_dir` and SIGTERM the
 /// process, escalating to SIGKILL after `PERSISTENT_VZ_STOP_TIMEOUT`.
 /// Idempotent: a missing PID file or an already-dead process is a
@@ -2369,6 +2384,13 @@ mod tests {
         let state = persistent_vz_state_dir("dev");
         assert!(state.ends_with("mvm-persistent-builder-vz-dev"));
         assert_eq!(persistent_vz_vsock_dir("dev"), state.join("vsock"));
+    }
+
+    #[test]
+    fn dev_builder_console_log_is_under_dev_state_dir() {
+        let log = dev_builder_vz_console_log();
+        assert!(log.ends_with("console.log"));
+        assert_eq!(log, persistent_vz_state_dir("dev").join("console.log"));
     }
 
     #[test]

--- a/crates/mvm-cli/src/doctor.rs
+++ b/crates/mvm-cli/src/doctor.rs
@@ -258,6 +258,90 @@ fn builder_store_check() -> Check {
     }
 }
 
+/// The builder VM's fixed egress posture, appended to every
+/// builder-egress line as an affirmation. The builder VM locks egress on
+/// the deps-install arm (proxy-uid-only, fail-closed) and opens it for
+/// flake-build fetches — a fixed design, not a runtime decision.
+const BUILDER_EGRESS_POSTURE: &str = "egress is locked on the deps-install arm (proxy-uid-only, fail-closed) \
+     and open for flake-build fetches";
+
+/// Map a parsed network-bootstrap outcome to its `Check` body.
+/// Pure so the classification → report mapping is unit-testable without
+/// touching the filesystem.
+#[cfg(feature = "builder-vm")]
+fn builder_egress_check_from_outcome(outcome: mvm_build::guest_net::BuilderNetBootstrap) -> Check {
+    use mvm_build::guest_net::BuilderNetBootstrap;
+    // The check name is already "builder egress", and the renderer prints
+    // it as `builder egress: <status> (<info>)` — so the info body omits
+    // the redundant prefix and leads with the outcome.
+    let (ok, info) = match outcome {
+        BuilderNetBootstrap::Lease { ip } => (
+            true,
+            format!("DHCP lease {ip} via the gvproxy gateway; {BUILDER_EGRESS_POSTURE}"),
+        ),
+        BuilderNetBootstrap::StaticFallback { ip } => (
+            true,
+            format!(
+                "static fallback {ip} (no DHCP lease — degraded but \
+                 reachable); {BUILDER_EGRESS_POSTURE}"
+            ),
+        ),
+        BuilderNetBootstrap::Failed => (
+            false,
+            format!(
+                "net bootstrap FAILED (no DHCP lease, no static fallback \
+                 — builds can't fetch); {BUILDER_EGRESS_POSTURE}"
+            ),
+        ),
+        BuilderNetBootstrap::Unknown => (
+            true,
+            format!("outcome not yet recorded in console.log; {BUILDER_EGRESS_POSTURE}"),
+        ),
+    };
+    Check {
+        name: "builder egress",
+        category: "platform",
+        ok,
+        info,
+    }
+}
+
+/// Surface the persistent builder VM's last network-bootstrap outcome
+/// (DHCP lease / static fallback / failure) so the failure class is
+/// diagnosable without reading the guest console by hand.
+///
+/// Reads the persistent dev builder VM's host-side `console.log`. Only the
+/// Vz dev VM (the macOS-26 default) has a stable, predictable console-log
+/// path under a fixed session id; the libkrun persistent path keys off an
+/// opaque per-run job id, so there is no analogous fixed helper to probe.
+#[cfg(feature = "builder-vm")]
+fn builder_egress_check() -> Check {
+    let log_path = mvm_build::vz_builder::dev_builder_vz_console_log();
+    let Ok(contents) = std::fs::read_to_string(&log_path) else {
+        return Check {
+            name: "builder egress",
+            category: "platform",
+            ok: true,
+            info: "no builder VM yet (run `mvmctl dev up`)".to_string(),
+        };
+    };
+    let outcome = mvm_build::guest_net::classify_builder_net_bootstrap(&contents);
+    builder_egress_check_from_outcome(outcome)
+}
+
+/// Stub when the `builder-vm` feature is off — the Vz console-log helper
+/// is feature-gated, and a CLI built without builder support never boots
+/// a builder VM.
+#[cfg(not(feature = "builder-vm"))]
+fn builder_egress_check() -> Check {
+    Check {
+        name: "builder egress",
+        category: "platform",
+        ok: true,
+        info: "n/a (mvm-cli built without `builder-vm` feature)".to_string(),
+    }
+}
+
 /// One-line summary of a dry-run convergence report for `doctor`.
 /// Pure so it's testable without touching the registry.
 fn registry_drift_summary(report: &mvm::vm::reconcile::ConvergeReport) -> String {
@@ -341,6 +425,7 @@ pub fn run(json: bool, workflow: Option<DoctorWorkflow>) -> Result<()> {
     checks.push(ts_runner_check());
     checks.push(stage0_status_check());
     checks.push(builder_store_check());
+    checks.push(builder_egress_check());
     checks.push(registry_drift_check());
 
     checks.push(disk_space_check(false));
@@ -2444,6 +2529,88 @@ mod tests {
             info: "not found".to_string(),
         };
         assert!(!c.ok);
+    }
+
+    #[cfg(feature = "builder-vm")]
+    #[test]
+    fn builder_egress_lease_is_ok_and_names_ip() {
+        use mvm_build::guest_net::BuilderNetBootstrap;
+        let c = builder_egress_check_from_outcome(BuilderNetBootstrap::Lease {
+            ip: "192.168.127.3".to_string(),
+        });
+        assert_eq!(c.name, "builder egress");
+        assert_eq!(c.category, "platform");
+        assert!(c.ok);
+        assert!(c.info.contains("DHCP lease 192.168.127.3"));
+        assert!(c.info.contains("gvproxy gateway"));
+        assert!(c.info.contains("fail-closed"), "posture appended");
+    }
+
+    #[cfg(feature = "builder-vm")]
+    #[test]
+    fn builder_egress_static_fallback_is_ok_but_degraded() {
+        use mvm_build::guest_net::BuilderNetBootstrap;
+        let c = builder_egress_check_from_outcome(BuilderNetBootstrap::StaticFallback {
+            ip: "192.168.127.3".to_string(),
+        });
+        assert!(c.ok);
+        assert!(c.info.contains("static fallback 192.168.127.3"));
+        assert!(c.info.contains("degraded but reachable"));
+    }
+
+    #[cfg(feature = "builder-vm")]
+    #[test]
+    fn builder_egress_failed_is_not_ok() {
+        use mvm_build::guest_net::BuilderNetBootstrap;
+        let c = builder_egress_check_from_outcome(BuilderNetBootstrap::Failed);
+        assert!(!c.ok);
+        assert!(c.info.contains("FAILED"));
+        assert!(c.info.contains("can't fetch"));
+    }
+
+    #[cfg(feature = "builder-vm")]
+    #[test]
+    fn builder_egress_unknown_is_ok() {
+        use mvm_build::guest_net::BuilderNetBootstrap;
+        let c = builder_egress_check_from_outcome(BuilderNetBootstrap::Unknown);
+        assert!(c.ok);
+        assert!(c.info.contains("not yet recorded"));
+    }
+
+    #[cfg(feature = "builder-vm")]
+    #[test]
+    fn builder_egress_check_reports_no_vm_when_console_log_absent() {
+        use mvm_core::util::test_env::TestEnv;
+        // With MVM_CACHE_DIR pointed at an empty dir there is no
+        // persistent builder console.log, so the check reports the
+        // no-VM-yet info and exits ok.
+        let scratch = tempfile::tempdir().unwrap();
+        let mut env = TestEnv::new();
+        env.set("MVM_CACHE_DIR", scratch.path());
+        let c = builder_egress_check();
+        assert!(c.ok);
+        assert!(c.info.contains("no builder VM yet"));
+    }
+
+    #[cfg(feature = "builder-vm")]
+    #[test]
+    fn builder_egress_check_classifies_a_fixture_console_log() {
+        use mvm_core::util::test_env::TestEnv;
+        let scratch = tempfile::tempdir().unwrap();
+        let mut env = TestEnv::new();
+        env.set("MVM_CACHE_DIR", scratch.path());
+        // Materialize a fixture console.log at the exact path the helper
+        // resolves, then assert the lease is read end-to-end.
+        let log = mvm_build::vz_builder::dev_builder_vz_console_log();
+        std::fs::create_dir_all(log.parent().unwrap()).unwrap();
+        std::fs::write(
+            &log,
+            "udhcpc: lease of 192.168.127.3 obtained from 192.168.127.1, lease time 3600\n",
+        )
+        .unwrap();
+        let c = builder_egress_check();
+        assert!(c.ok);
+        assert!(c.info.contains("DHCP lease 192.168.127.3"));
     }
 
     #[test]

--- a/crates/mvm-cli/src/doctor.rs
+++ b/crates/mvm-cli/src/doctor.rs
@@ -262,6 +262,7 @@ fn builder_store_check() -> Check {
 /// builder-egress line as an affirmation. The builder VM locks egress on
 /// the deps-install arm (proxy-uid-only, fail-closed) and opens it for
 /// flake-build fetches — a fixed design, not a runtime decision.
+#[cfg(feature = "builder-vm")]
 const BUILDER_EGRESS_POSTURE: &str = "egress is locked on the deps-install arm (proxy-uid-only, fail-closed) \
      and open for flake-build fetches";
 

--- a/specs/REFACTOR-STATUS.md
+++ b/specs/REFACTOR-STATUS.md
@@ -312,14 +312,17 @@ PLAN 118 — Supervisor standby pool              🟡 libkrun + Vz done; FC fol
       follow-up; not blocking current libkrun/Vz use
 
 PLAN 183 — Builder-VM egress posture + net boot ✅ DONE (follow-ups tracked in plan)
-  Last updated: 2026-06-15 (deferred-section close-out: DHCP belt-and-suspenders item
-  closed; persistent Vz builder VM now gets gvproxy egress — `dev up` spawns gvproxy +
-  the dev VM takes a DHCP lease 192.168.127.3 from the gvproxy gateway, `dev down`
-  reaps it, all contained to vz_builder.rs, live-validated on macOS-26; only the
-  doctor egress-posture line remains deferred — it's in-guest-enforced + the
-  lease/static/none outcome isn't host-recorded, so it needs builder-boot work)
-  [x] persistent Vz builder VM gvproxy egress — vz_builder.rs spawn+config+reap;
+  Last updated: 2026-06-15 (ALL deferred items now CLOSED: DHCP belt-and-suspenders
+  resolved by WS-E2; persistent Vz builder VM gets gvproxy egress (live-validated
+  DHCP lease 192.168.127.3, dev down reaps — #940); and the `doctor` builder-egress
+  line lands — it parses the persistent builder VM's console.log for the last
+  net-bootstrap outcome (lease/static-fallback/failed) + surfaces the per-arm posture,
+  the earlier "needs host-side plumbing" premise was wrong since the outcome is already
+  host-readable in console.log)
+  [x] persistent Vz builder VM gvproxy egress (#940) — vz_builder.rs spawn+config+reap;
       live-validated (dev up lease 192.168.127.3 from gvproxy gw; dev down no leak)
+  [x] doctor builder-egress line — guest_net::classify_builder_net_bootstrap +
+      doctor builder_egress_check; live-validated (reports the DHCP lease)
   [x] follow-ups: fs_quick-on-Vz (pause-aware gate) + vm_full restore (gvproxy re-spawn, idempotent cleanup)
   Diagnosis proven 2026-06-11: boot-time install_egress_lockdown (OUTPUT DROP,
   proxy-uid-only) applied to the whole builder VM and dropped every nix fetch.

--- a/specs/plans/183-builder-vm-egress-posture-and-dns.md
+++ b/specs/plans/183-builder-vm-egress-posture-and-dns.md
@@ -297,22 +297,23 @@ Two independent defects blocked `mvmctl up --flake <workload> --hypervisor vz`:
   gvproxy and the dev VM took a DHCP lease 192.168.127.3 from the gvproxy gateway
   192.168.127.1 (vs no virtio-net at all under `network: None`); `dev down` reaped
   the gvproxy with no leak.
-- [ ] `mvmctl doctor` line surfacing the in-builder egress posture + last builder
-  network bootstrap outcome (lease vs static vs none), so this class of failure is
-  diagnosable without console archaeology.
-  Close-out triage (2026-06-13): DEFERRED — the "last net-bootstrap outcome
-  (lease|static|none)" is not recorded in any audit/state substrate today, so the
-  line needs new plumbing first (record the bootstrap result at builder boot, then
-  surface it). The static per-arm egress posture alone (boot=open, install=locked)
-  is already documented; the diagnostic value is in the *outcome*, which is the
-  part that needs the substrate. Not a vz close-out blocker.
-  Re-confirmed 2026-06-15: the per-arm posture is enforced **in-guest**
-  (`mvm-host-vm-init/network.rs::install_egress_lockdown`, applied inside the
-  builder VM on Linux), so the host-side `doctor` can't read the live state — a
-  doctor line would either restate a fixed design constant (low value) or need
-  the builder boot to record its lease/static/none outcome to a host-readable
-  sidecar first (the plumbing). Either way it edits Linux-gated builder-boot code,
-  not a host-only doctor tweak.
+- [x] `mvmctl doctor` line surfacing the builder VM's egress posture + last
+  network-bootstrap outcome (lease / static-fallback / failed), so this failure
+  class is diagnosable without console archaeology.
+  DONE 2026-06-15. The earlier "needs new host-side recording plumbing" premise
+  was wrong: the outcome is **already host-readable** in the persistent builder
+  VM's `console.log` (busybox's `udhcpc: lease of <ip> …`, our `falling back to
+  static gvproxy addressing`, and the `setup_network warning … udhcpc exit N`
+  failure line). So no in-guest plumbing was needed — `doctor` just parses it.
+  `guest_net::classify_builder_net_bootstrap` (pure, cfg-free) maps the console.log
+  to `Lease{ip}` / `StaticFallback{ip}` / `Failed` / `Unknown`;
+  `vz_builder::dev_builder_vz_console_log` resolves the persistent dev VM's
+  console.log; `doctor`'s `builder_egress_check` reports the outcome plus the
+  static per-arm posture (install-arm locked fail-closed, flake-build arm open),
+  with a `Failed` bootstrap surfaced as not-OK. vz-only (the libkrun persistent
+  dev VM has no fixed session path to probe; vz is the macOS-26 default).
+  Live-validated: `doctor` reports "DHCP lease 192.168.127.3 via the gvproxy
+  gateway" against a real dev-up console.log.
 - [x] fs_quick on Vz: teach the quiesce gate to recognize the Vz paused state
   (pid stays alive under pause), and/or stop deleting the per-instance CoW
   rootfs on `down` so a stopped VM remains checkpointable.


### PR DESCRIPTION
The last open Plan 183 item: a `mvmctl doctor` line so a builder-VM network-bootstrap failure is diagnosable without reading `console.log` by hand.

**The earlier "needs new host-side plumbing" premise was wrong** — the outcome is *already* host-readable in the persistent builder VM's `console.log`. So `doctor` just parses it; no in-guest recording change needed.

## Change
- `guest_net::classify_builder_net_bootstrap(&str)` (pure, cfg-free) → `Lease{ip}` / `StaticFallback{ip}` / `Failed` / `Unknown`, by scanning the console for busybox's `udhcpc: lease of <ip> …`, our `falling back to static gvproxy addressing`, and the `setup_network warning … udhcpc exit N` failure line (last recognizable outcome wins; lease IP validated via the existing `parse_ipv4`).
- `vz_builder::dev_builder_vz_console_log()` resolves the persistent dev VM's console.log (session id mirrors the CLI's `DEV_VM_SESSION_ID`).
- `doctor::builder_egress_check` reports the outcome + the static per-arm posture (deps-install arm locked proxy-uid-only fail-closed; flake-build arm open). A `Failed` bootstrap is `ok=false`; no builder VM yet → a clean informational line. `builder-vm`-feature-gated with a stub, mirroring `builder_backend_check`.

vz-only: the libkrun persistent dev VM has no fixed session path to probe; vz is the macOS-26 default (documented).

## Validation
- 17 new unit tests (classify variants incl. the real busybox line + malformed-IP rejection + reboot/last-outcome-wins; the pure outcome→Check mapping; an end-to-end fixture via `TestEnv`+`MVM_CACHE_DIR`).
- `cargo fmt`, `clippy -p mvm-build -p mvm-cli -D warnings`, `check-no-spec-refs-in-comments` — clean.
- **Live**: ran `mvmctl doctor` against a real prior-`dev up` console.log →
  `builder egress: OK (DHCP lease 192.168.127.3 via the gvproxy gateway; egress is locked on the deps-install arm (proxy-uid-only, fail-closed) and open for flake-build fetches)`

With this + #940 (persistent-builder gvproxy), **all Plan 183 deferred items are closed.** Docs updated; the REFACTOR-STATUS block composes with #940 regardless of merge order.