### PR TITLE
fix(host-vm-init): TestEnv-guard the TMPDIR test so it can't break parallel tests (Plan 185 Phase 1)

### DIFF
--- a/crates/mvm-build/src/bin/mvm-host-vm-init.rs
+++ b/crates/mvm-build/src/bin/mvm-host-vm-init.rs
@@ -3162,31 +3162,23 @@ mod linux {
             let cmd_path = dir.path().join("cmd.sh");
             std::fs::write(&cmd_path, "echo \"tmpdir=${TMPDIR-UNSET}\" >&2\nexit 0\n")
                 .expect("write cmd.sh");
-            // SAFETY: this test runs single-threaded in cargo
-            // test's default scheduler for this binary; we set the
-            // env var briefly to a known value and then assert the
-            // subprocess saw exactly that (not some `/scratch/...`
-            // override). Restoring afterward.
+            // The assertion: with `tmpdir = None`, `run_job_streaming` doesn't
+            // call `.env("TMPDIR", _)` — it leaves the parent's env alone, so
+            // the subprocess sees whatever TMPDIR the parent has.
             //
-            // The point of the assertion: with `tmpdir = None`,
-            // `run_job_streaming` doesn't call `.env("TMPDIR", _)`
-            // — it leaves the parent's env alone.
-            let prior = std::env::var("TMPDIR").ok();
-            unsafe {
-                std::env::set_var("TMPDIR", "/inherited-from-parent");
-            }
+            // `TestEnv` sets it under the shared process-env lock and restores
+            // on drop (even on panic). cargo runs this binary's tests
+            // multi-threaded, so a sibling test's `tempfile::tempdir()` may
+            // observe this TMPDIR during the window — point it at a *valid*
+            // directory (the test's own tempdir) so that stays harmless instead
+            // of handing siblings a non-existent path.
+            let sentinel = dir.path().to_str().expect("utf-8 tempdir").to_string();
+            let mut env = mvm_core::util::test_env::TestEnv::new();
+            env.set("TMPDIR", &sentinel);
             let (code, tail) =
                 run_job_streaming(cmd_path.to_str().unwrap(), None, Isolation::Inherit, |_| {});
-            // Restore TMPDIR before the assert so a panic still
-            // leaves the parent env clean for other tests.
-            unsafe {
-                match prior {
-                    Some(v) => std::env::set_var("TMPDIR", v),
-                    None => std::env::remove_var("TMPDIR"),
-                }
-            }
             assert_eq!(code, 0);
-            assert_eq!(tail, "tmpdir=/inherited-from-parent");
+            assert_eq!(tail, format!("tmpdir={sentinel}"));
         }
 
         /// `Isolation::Unshared` mode wraps


### PR DESCRIPTION
A **Phase 7 Linux workspace test run** (Plan 185 closeout) surfaced **15 failures** in the `mvm-build` `mvm-host-vm-init` bin tests — all `tempfile::tempdir()` calls failing with `/inherited-from-parent ... No such file or directory`.

**Root cause:** `run_job_streaming_does_not_override_tmpdir_when_none` set `TMPDIR=/inherited-from-parent` (a non-existent path) directly via `std::env::set_var`, with a SAFETY note *wrongly* asserting the binary's tests run single-threaded. cargo runs them multi-threaded, so the bogus `TMPDIR` leaked to every sibling test that creates a tempdir during the window. **Invisible on macOS** — the bin is `cfg(target_os = "linux")`, so the macOS CI host never runs these tests; only a Linux run exposes it.

This is exactly the process-global env-mutation hazard **Plan 185 Phase 1's `TestEnv`** exists to prevent; the test was missed by the Phase 1 sweep because it never ran on the CI host.

**Fix:** set `TMPDIR` through `TestEnv` (shared process-env lock + restore on drop, even on panic) and point the sentinel at a **valid** directory (the test's own tempdir), so even a racing sibling that observes it during the window gets a usable path instead of a non-existent one. The asserted behavior is unchanged: with `tmpdir = None`, the subprocess inherits the parent's `TMPDIR` verbatim.

**Verified on the x86_64 Linux box** (the only place these `cfg(linux)` tests run): the 15 failures are gone and `cargo test --workspace --no-fail-fast` is being confirmed green.
