### PR TITLE
feat(plan-193): WS-2 full-fidelity policy lowering (L4 proto/port + DNS sinkhole)

### DIFF
--- a/crates/mvm-hostd/src/supervisor/network/rvproxy_policy.rs
+++ b/crates/mvm-hostd/src/supervisor/network/rvproxy_policy.rs
@@ -5,29 +5,27 @@
 //! subprocess (`rvproxy run --config`), so the binding is *config*, not an
 //! in-process trait — mvm emits the `[policy]` table rvproxy enforces.
 //!
-//! ## What lowers, and what stays in the splice
+//! ## Fidelity
 //!
-//! rvproxy's `[policy]` table is an **IP-level** allow/deny: `default_egress_deny`
-//! + `cidr_allowlist` + `cidr_denylist`. It expresses exactly:
-//!   - deny-by-default (claim-10's coarse gate),
-//!   - the always-on mandatory-deny set (link-local + cloud metadata) as a
-//!     denylist,
-//!   - per-tenant L4 grants *coarsened to their destination CIDRs*.
+//! rvproxy's `[policy]` table expresses the full coarse + L4 + DNS shape of
+//! claim-10's egress gate:
+//!   - `default_egress_deny` — the deny-by-default coarse gate,
+//!   - `cidr_denylist` — the always-on mandatory-deny set (link-local + cloud
+//!     metadata),
+//!   - `l4_allowlist` — per-tenant L4 grants at full proto + CIDR + port-range
+//!     precision (rvproxy `policy_flow_reason`),
+//!   - `dns_allowlist` — the upstream DNS hostname sinkhole (dotted-suffix).
 //!
-//! It cannot express port/proto scoping, DNS hostname allow-lists, or the byte
-//! scans (placeholder-leak, undeclared redaction). So this lowering is a **sound
-//! coarse pre-filter**: rvproxy denies everything outside the allowed CIDRs and
-//! the mandatory-deny set, and the splice's `L4PolicyScan` / `DnsSinkholeScan` /
-//! byte scans refine *within* what rvproxy admits. The composition never
-//! over-permits (rvproxy's allow is a superset of the precise policy; the splice
-//! still drops wrong-port/proto/host) and never under-blocks (every destination
-//! some rule could permit is admitted at the IP layer).
-//!
-//! [`RvproxyPolicyGaps`] enumerates what did NOT lower so the caller keeps the
-//! splice for it — the coarsening is explicit, never silent.
+//! So the lowering is an exact projection of the resolved `CanonicalEgress`
+//! (proven by the parity tests: `permits_flow` agrees with
+//! `CanonicalEgress::permits` for every probed proto/ip/port) plus the DNS
+//! hostname gate (mirroring `DnsSinkholeScan`). The only claim-10 dimension that
+//! does NOT lower to `[policy]` is the byte scans (placeholder-leak + undeclared
+//! redaction), which ride the transform/redaction path; [`RvproxyPolicyGaps`]
+//! records that residual so the splice keeps it.
 
 use mvm_core::network_policy::MANDATORY_DENY_RANGES;
-use mvm_core::policy::projection::CanonicalEgress;
+use mvm_core::policy::projection::{CanonicalEgress, Proto};
 use serde::Serialize;
 use std::net::IpAddr;
 
@@ -38,24 +36,54 @@ use std::net::IpAddr;
 #[derive(Debug, Clone, PartialEq, Eq, Serialize)]
 pub struct RvproxyPolicy {
     /// Master egress switch. Always true here; the deny decision is expressed
-    /// through `default_egress_deny` + the lists so a single oracle
-    /// ([`Self::permits_dest`]) governs the verdict.
+    /// through `default_egress_deny` + the allow/deny lists so a single oracle
+    /// ([`Self::permits_flow`]) governs the verdict.
     pub allow_guest_egress: bool,
     /// Deny a destination matching no allow rule (claim-10 deny-by-default).
     pub default_egress_deny: bool,
-    /// Destination CIDRs egress is permitted to (coarsened L4 grants).
+    /// IP-only destination allow-list. Unused by the precise lowering (L4 grants
+    /// go to `l4_allowlist`); kept for completeness / the `open` posture.
+    #[serde(skip_serializing_if = "Vec::is_empty")]
     pub cidr_allowlist: Vec<String>,
     /// Always-denied CIDRs (mandatory-deny: link-local + cloud metadata).
     pub cidr_denylist: Vec<String>,
+    /// Upstream DNS hostname allow-list (dotted-suffix sinkhole).
+    #[serde(skip_serializing_if = "Vec::is_empty")]
+    pub dns_allowlist: Vec<String>,
+    /// Per-tenant L4 grants: proto + CIDR + inclusive port range. Kept last
+    /// because the `toml` crate renders a `Vec<struct>` as an array-of-tables
+    /// (`[[l4_allowlist]]`), which must follow every scalar/inline-array field.
+    #[serde(skip_serializing_if = "Vec::is_empty")]
+    pub l4_allowlist: Vec<RvproxyL4Rule>,
+}
+
+/// One L4 egress allow rule, mirroring rvproxy's `[[policy.l4_allowlist]]`
+/// (`rvproxy-policy::L4RuleConfig`).
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+pub struct RvproxyL4Rule {
+    /// `"tcp"` or `"udp"`.
+    pub protocol: String,
+    pub cidr: String,
+    pub port_lo: u16,
+    pub port_hi: u16,
+}
+
+impl RvproxyL4Rule {
+    fn permits(&self, proto: Proto, ip: IpAddr, port: u16) -> bool {
+        self.protocol == proto_str(proto)
+            && cidr_contains(&self.cidr, ip)
+            && self.port_lo <= port
+            && port <= self.port_hi
+    }
 }
 
 impl RvproxyPolicy {
-    /// The egress verdict rvproxy will reach for `ip`, mirroring its
-    /// `policy_destination_reason` precedence exactly: denylist match denies;
-    /// a non-empty allowlist with no match denies; deny-by-default with an empty
-    /// allowlist denies; otherwise allow. This is the parity oracle the splice's
-    /// coarse gate must agree with.
-    pub fn permits_dest(&self, ip: IpAddr) -> bool {
+    /// The egress verdict rvproxy will reach for a flow, mirroring its
+    /// `policy_flow_reason` precedence exactly: a denylist match denies; an L4 or
+    /// IP allow-list match admits; a non-empty allow-list with no match denies;
+    /// deny-by-default with empty allow-lists denies; otherwise allow. This is the
+    /// parity oracle the splice's gate must agree with.
+    pub fn permits_flow(&self, proto: Proto, ip: IpAddr, port: u16) -> bool {
         if self
             .cidr_denylist
             .iter()
@@ -63,37 +91,48 @@ impl RvproxyPolicy {
         {
             return false;
         }
-        if !self.cidr_allowlist.is_empty()
-            && !self
-                .cidr_allowlist
-                .iter()
-                .any(|cidr| cidr_contains(cidr, ip))
-        {
+        let l4_match = self
+            .l4_allowlist
+            .iter()
+            .any(|rule| rule.permits(proto, ip, port));
+        let cidr_match = self
+            .cidr_allowlist
+            .iter()
+            .any(|cidr| cidr_contains(cidr, ip));
+        if l4_match || cidr_match {
+            return true;
+        }
+        if !self.l4_allowlist.is_empty() || !self.cidr_allowlist.is_empty() {
             return false;
         }
-        if self.default_egress_deny && self.cidr_allowlist.is_empty() {
-            return false;
+        !self.default_egress_deny
+    }
+
+    /// Whether `name` may be resolved upstream under the DNS hostname allow-list.
+    /// Empty list = no restriction. Dotted-suffix, case/dot-normalized — mirrors
+    /// rvproxy's `dns_allowlist_permits` and mvm's `DnsSinkholeScan`: `name` is
+    /// admitted iff it equals a listed suffix or is a dotted subdomain of one
+    /// (so `example.com` admits `api.example.com`, never `notexample.com`).
+    pub fn dns_permits(&self, name: &str) -> bool {
+        if self.dns_allowlist.is_empty() {
+            return true;
         }
-        true
+        let query = name.trim_matches('.').to_ascii_lowercase();
+        self.dns_allowlist.iter().any(|suffix| {
+            let suffix = suffix.trim_matches('.').to_ascii_lowercase();
+            !suffix.is_empty() && (query == suffix || query.ends_with(&format!(".{suffix}")))
+        })
     }
 }
 
-/// What a resolved policy carries that rvproxy's IP-level `[policy]` table cannot
-/// express, so the caller must keep the in-line splice stage for it. A non-zero /
-/// true field means "the splice still owns this dimension."
+/// What a resolved policy carries that rvproxy's `[policy]` table cannot express,
+/// so the splice must keep enforcing it. Now that L4 (proto/port) and DNS
+/// hostnames lower natively, the only residual is the byte scans.
 #[derive(Debug, Clone, Default, PartialEq, Eq)]
 pub struct RvproxyPolicyGaps {
-    /// L4 grants carry a proto and (often) a port range; rvproxy's allowlist is
-    /// IP-only, so it would admit every proto/port to an allowed CIDR. The
-    /// splice's `L4PolicyScan` must refine these. Counts the coarsened rules.
-    pub l4_scoped_rules: usize,
-    /// DNS hostname allow-list entries; rvproxy has no hostname sinkhole (only
-    /// `allow_dns_local`/`allow_dns_upstream` booleans), so the splice's
-    /// `DnsSinkholeScan` must run. Counts the hostnames.
-    pub dns_hostnames: usize,
     /// Placeholder-leak backstop + undeclared redaction are byte scans, not
-    /// `[policy]`; they stay in the splice (a later slice may move redaction to an
-    /// rvproxy `secret-redaction-filter` plugin). Always true.
+    /// `[policy]`; they ride the transform/redaction path (a later slice may move
+    /// redaction to an rvproxy `secret-redaction-filter` plugin). Always true.
     pub byte_scans_in_splice: bool,
 }
 
@@ -105,18 +144,24 @@ pub fn lower_policy(egress: &CanonicalEgress, dns_allow: &[String]) -> RvproxyLo
         .map(|s| s.to_string())
         .collect();
 
-    let (default_egress_deny, cidr_allowlist, l4_scoped_rules) = match egress {
+    let (default_egress_deny, l4_allowlist) = match egress {
         // The `egress.mode = "open"` kill-switch: allow-unless-denied. Mandatory
         // deny still bites via the denylist.
-        CanonicalEgress::Unrestricted => (false, Vec::new(), 0),
-        // Rules — deny-by-default, allow the rules' destination CIDRs. An empty
-        // rule set is deny-all (empty allowlist + deny-by-default). Every rule is
-        // proto-scoped (and usually port-scoped), so each is a splice residual.
+        CanonicalEgress::Unrestricted => (false, Vec::new()),
+        // Rules — deny-by-default, allow each grant at full proto/CIDR/port
+        // precision. An empty rule set is deny-all (no allow rules + deny-by-
+        // default).
         CanonicalEgress::Rules(rules) => {
-            let mut allowlist: Vec<String> = rules.iter().map(|r| r.net.to_string()).collect();
-            allowlist.sort();
-            allowlist.dedup();
-            (true, allowlist, rules.len())
+            let l4 = rules
+                .iter()
+                .map(|r| RvproxyL4Rule {
+                    protocol: proto_str(r.proto).to_string(),
+                    cidr: r.net.to_string(),
+                    port_lo: r.port_lo,
+                    port_hi: r.port_hi,
+                })
+                .collect();
+            (true, l4)
         }
     };
 
@@ -124,12 +169,12 @@ pub fn lower_policy(egress: &CanonicalEgress, dns_allow: &[String]) -> RvproxyLo
         policy: RvproxyPolicy {
             allow_guest_egress: true,
             default_egress_deny,
-            cidr_allowlist,
+            cidr_allowlist: Vec::new(),
             cidr_denylist,
+            l4_allowlist,
+            dns_allowlist: dns_allow.to_vec(),
         },
         gaps: RvproxyPolicyGaps {
-            l4_scoped_rules,
-            dns_hostnames: dns_allow.len(),
             byte_scans_in_splice: true,
         },
     }
@@ -143,6 +188,13 @@ pub struct RvproxyLowering {
     pub gaps: RvproxyPolicyGaps,
 }
 
+fn proto_str(proto: Proto) -> &'static str {
+    match proto {
+        Proto::Tcp => "tcp",
+        Proto::Udp => "udp",
+    }
+}
+
 fn cidr_contains(cidr: &str, ip: IpAddr) -> bool {
     cidr.parse::<ipnet::IpNet>()
         .map(|net| net.contains(&ip))
@@ -152,7 +204,7 @@ fn cidr_contains(cidr: &str, ip: IpAddr) -> bool {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use mvm_core::policy::projection::{CanonicalRule, Proto};
+    use mvm_core::policy::projection::CanonicalRule;
 
     fn ip(s: &str) -> IpAddr {
         s.parse().unwrap()
@@ -167,112 +219,127 @@ mod tests {
         }
     }
 
-    /// The coarse IP-level decision the rvproxy `[policy]` table is meant to
-    /// reproduce: deny mandatory-deny, otherwise allow iff open or some rule's
-    /// CIDR covers the destination. The splice refines proto/port/host within.
-    fn coarse_permits(egress: &CanonicalEgress, ip: IpAddr) -> bool {
-        if mvm_core::network_policy::is_mandatory_deny(ip) {
-            return false;
-        }
-        match egress {
-            CanonicalEgress::Unrestricted => true,
-            CanonicalEgress::Rules(rules) => rules.iter().any(|r| r.net.contains(&ip)),
-        }
-    }
-
     const PROBES: &[&str] = &[
         "93.184.216.34",   // in a typical allowed CIDR
         "8.8.8.8",         // a different public IP
         "169.254.169.254", // cloud metadata (mandatory-deny)
         "169.254.1.1",     // link-local (mandatory-deny)
         "127.0.0.1",       // loopback (mandatory-deny)
+        "1.1.1.1",         // another allowed CIDR in tests
         "10.0.0.5",        // private
     ];
+    const PORTS: &[u16] = &[0, 53, 80, 443, 8080, 65535];
 
-    fn assert_parity(egress: CanonicalEgress, dns_allow: &[String]) {
-        let lowered = lower_policy(&egress, dns_allow);
-        for probe in PROBES {
-            let addr = ip(probe);
-            assert_eq!(
-                lowered.policy.permits_dest(addr),
-                coarse_permits(&egress, addr),
-                "rvproxy verdict diverges from the coarse policy for {probe} under {egress:?}",
-            );
-        }
-    }
-
-    #[test]
-    fn unrestricted_lowers_to_allow_unless_mandatory_deny() {
-        assert_parity(CanonicalEgress::Unrestricted, &[]);
-        let lowered = lower_policy(&CanonicalEgress::Unrestricted, &[]);
-        assert!(!lowered.policy.default_egress_deny);
-        assert!(lowered.policy.cidr_allowlist.is_empty());
-        assert!(lowered.policy.permits_dest(ip("8.8.8.8")));
-        assert!(!lowered.policy.permits_dest(ip("169.254.169.254")));
-    }
-
-    #[test]
-    fn empty_rules_lower_to_deny_all() {
-        let egress = CanonicalEgress::Rules(vec![]);
-        assert_parity(egress.clone(), &[]);
-        let lowered = lower_policy(&egress, &[]);
-        assert!(lowered.policy.default_egress_deny);
-        assert!(lowered.policy.cidr_allowlist.is_empty());
-        for probe in PROBES {
-            assert!(!lowered.policy.permits_dest(ip(probe)));
-        }
-    }
-
-    #[test]
-    fn cidr_rules_lower_to_allowlist_and_flag_l4_residual() {
-        let egress = CanonicalEgress::Rules(vec![
-            rule("93.184.216.0/24", Proto::Tcp, 443, 443),
-            rule("93.184.216.0/24", Proto::Udp, 0, 65535),
-        ]);
-        assert_parity(egress.clone(), &[]);
-        let lowered = lower_policy(&egress, &[]);
-        assert!(lowered.policy.default_egress_deny);
-        // Both rules share a CIDR → one deduped allowlist entry.
-        assert_eq!(lowered.policy.cidr_allowlist, vec!["93.184.216.0/24"]);
-        assert!(lowered.policy.permits_dest(ip("93.184.216.34")));
-        assert!(!lowered.policy.permits_dest(ip("8.8.8.8")));
-        // Every rule is proto/port-scoped → the splice's L4PolicyScan must run.
-        assert_eq!(lowered.gaps.l4_scoped_rules, 2);
-    }
-
-    #[test]
-    fn coarse_filter_never_under_blocks_a_permitted_destination() {
-        // Soundness: every (proto, ip, port) the precise policy permits must be
-        // admitted by the coarse rvproxy filter (the splice then refines). If the
-        // coarse layer denied a permitted destination, egress would break.
-        let egress = CanonicalEgress::Rules(vec![
-            rule("93.184.216.0/24", Proto::Tcp, 443, 443),
-            rule("1.1.1.0/24", Proto::Udp, 53, 53),
-        ]);
+    /// The lowering must reproduce `CanonicalEgress::permits` exactly for every
+    /// probed (proto, ip, port) — full L4 parity, not just coarse IP. This is the
+    /// binary-discriminating oracle WS-1.5 promotes to the live native path.
+    fn assert_flow_parity(egress: CanonicalEgress) {
         let lowered = lower_policy(&egress, &[]);
         for probe in PROBES {
             let addr = ip(probe);
             for proto in [Proto::Tcp, Proto::Udp] {
-                for port in [53_u16, 443, 80, 8080] {
-                    if egress.permits(&proto, addr, port) {
-                        assert!(
-                            lowered.policy.permits_dest(addr),
-                            "coarse filter under-blocked {addr} which policy permits on {proto:?}:{port}",
-                        );
-                    }
+                for &port in PORTS {
+                    assert_eq!(
+                        lowered.policy.permits_flow(proto, addr, port),
+                        egress.permits(&proto, addr, port),
+                        "verdict diverges for {proto:?} {addr}:{port} under {egress:?}",
+                    );
                 }
             }
         }
     }
 
     #[test]
-    fn dns_hostnames_are_flagged_as_splice_residual() {
+    fn unrestricted_lowers_to_allow_unless_mandatory_deny() {
+        assert_flow_parity(CanonicalEgress::Unrestricted);
+        let lowered = lower_policy(&CanonicalEgress::Unrestricted, &[]);
+        assert!(!lowered.policy.default_egress_deny);
+        assert!(lowered.policy.l4_allowlist.is_empty());
+        assert!(lowered.policy.permits_flow(Proto::Tcp, ip("8.8.8.8"), 443));
+        assert!(
+            !lowered
+                .policy
+                .permits_flow(Proto::Tcp, ip("169.254.169.254"), 443)
+        );
+    }
+
+    #[test]
+    fn empty_rules_lower_to_deny_all() {
+        let egress = CanonicalEgress::Rules(vec![]);
+        assert_flow_parity(egress.clone());
+        let lowered = lower_policy(&egress, &[]);
+        assert!(lowered.policy.default_egress_deny);
+        assert!(lowered.policy.l4_allowlist.is_empty());
+        for probe in PROBES {
+            assert!(!lowered.policy.permits_flow(Proto::Tcp, ip(probe), 443));
+        }
+    }
+
+    #[test]
+    fn l4_rules_lower_with_full_proto_and_port_parity() {
+        let egress = CanonicalEgress::Rules(vec![
+            rule("93.184.216.0/24", Proto::Tcp, 443, 443),
+            rule("1.1.1.0/24", Proto::Udp, 53, 53),
+        ]);
+        assert_flow_parity(egress.clone());
+        let lowered = lower_policy(&egress, &[]);
+        assert!(lowered.policy.default_egress_deny);
+        assert_eq!(lowered.policy.l4_allowlist.len(), 2);
+        // Exact proto+port+CIDR admitted; wrong port/proto denied.
+        assert!(
+            lowered
+                .policy
+                .permits_flow(Proto::Tcp, ip("93.184.216.34"), 443)
+        );
+        assert!(
+            !lowered
+                .policy
+                .permits_flow(Proto::Tcp, ip("93.184.216.34"), 8080)
+        );
+        assert!(
+            !lowered
+                .policy
+                .permits_flow(Proto::Udp, ip("93.184.216.34"), 443)
+        );
+        assert!(lowered.policy.permits_flow(Proto::Udp, ip("1.1.1.1"), 53));
+        // The L4 grants lowered natively → no L4 residual left for the splice.
+        assert_eq!(
+            lowered.gaps,
+            RvproxyPolicyGaps {
+                byte_scans_in_splice: true
+            }
+        );
+    }
+
+    #[test]
+    fn mandatory_deny_overrides_an_l4_grant() {
+        // A rule that would admit a mandatory-deny IP must still be denied.
+        let egress = CanonicalEgress::Rules(vec![rule("169.254.0.0/16", Proto::Tcp, 0, 65535)]);
+        assert_flow_parity(egress.clone());
+        let lowered = lower_policy(&egress, &[]);
+        assert!(
+            !lowered
+                .policy
+                .permits_flow(Proto::Tcp, ip("169.254.169.254"), 80)
+        );
+    }
+
+    #[test]
+    fn dns_allowlist_lowers_and_matches_dotted_suffix() {
         let lowered = lower_policy(
             &CanonicalEgress::Rules(vec![]),
-            &["api.example.com".to_string(), "cdn.example.com".to_string()],
+            &["example.com".to_string(), "Foo.NET".to_string()],
         );
-        assert_eq!(lowered.gaps.dns_hostnames, 2);
-        assert!(lowered.gaps.byte_scans_in_splice);
+        assert_eq!(lowered.policy.dns_allowlist.len(), 2);
+        assert!(lowered.policy.dns_permits("example.com"));
+        assert!(lowered.policy.dns_permits("api.example.com"));
+        assert!(lowered.policy.dns_permits("API.EXAMPLE.COM."));
+        assert!(lowered.policy.dns_permits("x.foo.net"));
+        assert!(!lowered.policy.dns_permits("notexample.com"));
+        assert!(!lowered.policy.dns_permits("evil.com"));
+        // Empty list → no restriction.
+        let open = lower_policy(&CanonicalEgress::Unrestricted, &[]);
+        assert!(open.policy.dns_permits("anything.example"));
     }
 
     #[test]
@@ -292,15 +359,19 @@ mod tests {
     }
 
     #[test]
-    fn policy_serializes_to_rvproxy_toml_field_names() {
+    fn policy_serializes_to_rvproxy_toml_shape() {
         let lowered = lower_policy(
             &CanonicalEgress::Rules(vec![rule("93.184.216.0/24", Proto::Tcp, 443, 443)]),
-            &[],
+            &["example.com".to_string()],
         );
         let toml = toml::to_string(&lowered.policy).unwrap();
         assert!(toml.contains("allow_guest_egress = true"));
         assert!(toml.contains("default_egress_deny = true"));
-        assert!(toml.contains("cidr_allowlist = [\"93.184.216.0/24\"]"));
         assert!(toml.contains("169.254.169.254/32"));
+        assert!(toml.contains("dns_allowlist = [\"example.com\"]"));
+        // L4 rules serialize as a TOML array-of-tables rvproxy parses.
+        assert!(toml.contains("[[l4_allowlist]]"));
+        assert!(toml.contains("protocol = \"tcp\""));
+        assert!(toml.contains("port_lo = 443"));
     }
 }

--- a/specs/plans/193-rvproxy-network-substrate.md
+++ b/specs/plans/193-rvproxy-network-substrate.md
@@ -121,19 +121,26 @@ own internal default).
       followups mvm needs from rvproxy: a JSONL/UDS **`FlowEvent` export** (slice-2
       deferral) and **port/proto + DNS-hostname policy config** (slice-1 covers
       only `default_egress_deny` + CIDR allow/deny). Sub-slices:
-  - [x] **2a — policy lowering (config half, the IP-coarse pre-filter).**
+  - [x] **2a — policy lowering, full fidelity.**
         `supervisor::network::rvproxy_policy::lower_policy` projects a resolved
-        `CanonicalEgress` (+ DNS allow-list) into rvproxy's `[policy]` table
-        (`default_egress_deny` + `cidr_allowlist` + mandatory-deny `cidr_denylist`),
-        with a unit parity oracle (`permits_dest` mirrors rvproxy's
-        `policy_destination_reason`) proving verdict-agreement with
-        `CanonicalEgress::permits` at the IP layer, and an explicit
-        `RvproxyPolicyGaps` enumerating what stays in the splice (port/proto-scoped
-        L4 rules, DNS hostnames, byte scans) — coarsening is never silent. Pure,
-        no live boot; deletes nothing.
-  - [ ] **2b — config emission + native launch path.** Write the full rvproxy
-        config (network/api/forward/audit + the lowered `[policy]`) and launch
-        `rvproxy run --config` behind a flag, keeping the splice. (Overlaps WS-3.)
+        `CanonicalEgress` (+ DNS allow-list) into rvproxy's `[policy]` table at
+        **full claim-10 fidelity** now that rvproxy ships the L4 + DNS config
+        (rvproxy `014` follow-ups): `default_egress_deny` + mandatory-deny
+        `cidr_denylist` + `l4_allowlist` (proto/CIDR/port) + `dns_allowlist`
+        (dotted-suffix sinkhole). The unit parity oracle `permits_flow` mirrors
+        rvproxy's `policy_flow_reason` and is proven verdict-identical to
+        `CanonicalEgress::permits` for every probed proto/ip/port (no longer just
+        the IP layer); `dns_permits` mirrors `DnsSinkholeScan`. The only splice
+        residual left (`RvproxyPolicyGaps`) is the byte scans (placeholder-leak +
+        undeclared redaction), which ride the transform path, not `[policy]`.
+        Pure, no live boot; deletes nothing. (Started as an IP-coarse pre-filter;
+        completed to full L4+DNS once rvproxy #115/#120 landed.)
+  - [ ] **2b — config emission + native launch path.** Wrap the lowered
+        `[policy]` in the full rvproxy config (network/api/forward/audit — the
+        audit section points the `FlowEvent` JSONL/UDS export at mvm for 2c) and
+        launch `rvproxy run --config` behind a flag, keeping the splice. Real
+        config-parse validation lands here via the parity gate (the emitted TOML
+        is fed to the actual rvproxy binary). (Overlaps WS-3.)
   - [ ] **2c — flow-event sink → audit re-emission.** Subscribe to rvproxy's
         `FlowEvent` export (needs the rvproxy JSONL/UDS export followup) and
         re-feed `signer_task`'s chain so the claim-10 audit stays mvm's source of


### PR DESCRIPTION
## Plan 193 WS-2 — full-fidelity policy lowering

**Stacked on #957** (the coarse IP lowering). Review/merge after it; base is `feat/plan-193-ws2-policy-lowering`.

#957 lowered only the coarse IP layer because rvproxy's `[policy]` table was IP-only. rvproxy has since shipped **L4 port/proto rules** (rvproxy #115) and a **DNS hostname allow-list** (rvproxy #120), so this completes the lowering to **full claim-10 fidelity**:

- L4 grants → `l4_allowlist` (proto + CIDR + inclusive port range), replacing the coarse `cidr_allowlist` projection — the decision is now port/proto-precise.
- DNS hostnames → `dns_allowlist` (dotted-suffix sinkhole).
- mandatory-deny → `cidr_denylist` (unchanged).

`RvproxyPolicy::permits_flow(proto, ip, port)` mirrors rvproxy's `policy_flow_reason` and is **proven verdict-identical to `CanonicalEgress::permits` for every probed proto/ip/port** — full L4 parity, not just the IP layer. `dns_permits` mirrors `DnsSinkholeScan`'s dotted-suffix match (lookalikes rejected).

With L4 + DNS lowering natively, `RvproxyPolicyGaps` collapses to a single residual: the **byte scans** (placeholder-leak + undeclared redaction), which ride the transform path, not `[policy]`.

### Tests
Full proto/ip/port parity vs `CanonicalEgress::permits` (Unrestricted / Rules / deny-all / mandatory-deny-overrides-grant); DNS dotted-suffix incl. lookalike rejection; TOML shape (`[[l4_allowlist]]`, `dns_allowlist`). Port precision **RED-verified**. 7 tests green; nightly fmt + clippy + `check-no-spec-refs` clean. Pure — deletes nothing.

### Remaining WS-2
- **2b** — wrap the lowered `[policy]` in the full rvproxy config (network/api/forward/audit; the audit section points the `FlowEvent` JSONL/UDS export at mvm for 2c) + flagged `rvproxy run --config` launch. Real config-parse validation lands here via the parity gate.
- **2c** — subscribe to rvproxy's `FlowEvent` export → re-feed `signer_task`'s chain.
- **2d** — extend the WS-1.5 parity gate to the native path, then delete the splice.