### PR TITLE
fix(plan-125): bind the host-services broker to the backend-specific BROKER_PORT socket (vz)

### DIFF
--- a/crates/mvm-backend/src/broker_services_spawn.rs
+++ b/crates/mvm-backend/src/broker_services_spawn.rs
@@ -221,9 +221,13 @@ pub struct BrokerSpawnParams<'a> {
     pub workload_id: &'a str,
     /// Tenant id.
     pub tenant_id: &'a str,
-    /// VM name; the broker binds the per-VM `BROKER_PORT` socket keyed on it
-    /// (the VMM forwards the guest's `connect_host_vsock(BROKER_PORT)` there).
-    pub vm_name: &'a str,
+    /// The per-VM `BROKER_PORT` UDS the broker binds — the path the active
+    /// backend's VMM splices the guest's `connect_host_vsock(BROKER_PORT)` dial
+    /// to. libkrun binds `<state>/vsock-<port>.sock`
+    /// (`vm_vsock_port_socket`); vz nests it under `<state>/vsock/`
+    /// (`vm_vz_vsock_port_socket`). The caller computes it so the broker binds
+    /// where its own VMM actually listens, instead of assuming one layout.
+    pub broker_listen_socket: &'a Path,
     /// Per-VM state dir; holds the broker PID file.
     pub state_dir: &'a Path,
     /// The audit-signer UDS from [`spawn_audit_signer`] — the broker's
@@ -236,7 +240,8 @@ pub struct BrokerSpawnParams<'a> {
 /// guest's `connect_host_vsock(BROKER_PORT)` to.
 #[derive(Debug)]
 pub struct BrokerHandle {
-    /// The `vm_vsock_port_socket(vm_name, BROKER_PORT)` the broker bound.
+    /// The backend-specific `BROKER_PORT` UDS the broker bound (the
+    /// `broker_listen_socket` it was handed).
     pub uds_path: PathBuf,
 }
 
@@ -257,15 +262,17 @@ fn spawn_broker_with_timeout(
     let BrokerSpawnParams {
         workload_id,
         tenant_id,
-        vm_name,
+        broker_listen_socket,
         state_dir,
         audit_signer_uds_path,
     } = params;
 
     let bin = resolve_subprocess_bin("mvm-broker", "MVM_BROKER_PATH")?;
-    // The broker binds the per-VM BROKER_PORT socket the VMM forwards the
-    // guest's `connect_host_vsock(BROKER_PORT)` dial to.
-    let uds_path = mvm_core::config::vm_vsock_port_socket(vm_name, mvm_guest::vsock::BROKER_PORT);
+    // The broker binds the per-VM BROKER_PORT socket the active backend's VMM
+    // forwards the guest's `connect_host_vsock(BROKER_PORT)` dial to. The caller
+    // computes it (libkrun vs vz layout differ), so the broker binds exactly
+    // where its own VMM listens.
+    let uds_path = broker_listen_socket.to_path_buf();
     if let Some(parent) = uds_path.parent() {
         std::fs::create_dir_all(parent)
             .map_err(|e| anyhow!("create broker socket dir {}: {e}", parent.display()))?;
@@ -365,10 +372,15 @@ pub struct BrokerServicesSpawnParams<'a> {
     /// is a defused no-op (an unadmitted dev VM has no broker services, so a
     /// stray guest dial to `BROKER_PORT` gets `ECONNREFUSED`).
     pub tenant_id: Option<&'a str>,
-    /// VM name; keys the per-VM workload chain + the `BROKER_PORT` socket.
+    /// VM name; keys the per-VM workload audit chain.
     pub vm_name: &'a str,
     /// Per-VM state dir.
     pub state_dir: &'a Path,
+    /// The per-VM `BROKER_PORT` UDS the broker should bind — backend-specific
+    /// (libkrun `<state>/vsock-<port>.sock`, vz `<state>/vsock/vsock-<port>.sock`),
+    /// computed by the caller's `start()` so the broker binds where the active
+    /// VMM splices the guest dial.
+    pub broker_listen_socket: &'a Path,
 }
 
 /// Spawn the per-VM broker services (audit-signer **then** broker) when the VM
@@ -388,6 +400,7 @@ pub fn spawn_broker_services_if_admitted(
         tenant_id,
         vm_name,
         state_dir,
+        broker_listen_socket,
     } = params;
     let Some(tenant_id) = tenant_id else {
         return Ok(BrokerServicesGuard::defused());
@@ -405,7 +418,7 @@ pub fn spawn_broker_services_if_admitted(
     spawn_broker(BrokerSpawnParams {
         workload_id,
         tenant_id,
-        vm_name,
+        broker_listen_socket,
         state_dir,
         audit_signer_uds_path: &audit.uds_path,
     })?;
@@ -668,7 +681,7 @@ mod tests {
         let res = spawn_broker(BrokerSpawnParams {
             workload_id: "wl-001",
             tenant_id: "tenant-x",
-            vm_name: "vm-1",
+            broker_listen_socket: &uds,
             state_dir: &state_dir,
             audit_signer_uds_path: &audit_uds,
         });
@@ -729,6 +742,7 @@ mod tests {
             tenant_id: None,
             vm_name: "vm",
             state_dir: &dir,
+            broker_listen_socket: &dir.join("vsock-5300.sock"),
         })
         .expect("unadmitted VM yields a defused no-op guard");
         drop(guard); // a defused guard's Drop reaps nothing
@@ -751,8 +765,14 @@ mod tests {
         let state_dir = dir.join("state");
         std::fs::create_dir_all(&state_dir).unwrap();
         let audit_uds = state_dir.join(AUDIT_SIGNER_SOCK);
-        let broker_uds =
-            mvm_core::config::vm_vsock_port_socket("vm-1", mvm_guest::vsock::BROKER_PORT);
+        // The caller now supplies the broker listen socket explicitly; point it
+        // at a vz-style `vsock/` subdir to prove the broker binds where it's
+        // told, not at libkrun's flat `<state>/vsock-<port>.sock` layout.
+        let broker_uds = state_dir
+            .join("vsock")
+            .join(mvm_core::config::vsock_socket_filename(
+                mvm_guest::vsock::BROKER_PORT,
+            ));
         std::fs::create_dir_all(broker_uds.parent().unwrap()).unwrap();
 
         // Two stubs, each binds (touches) its own UDS so both readiness polls pass.
@@ -790,6 +810,7 @@ mod tests {
             tenant_id: Some("tenant-x"),
             vm_name: "vm-1",
             state_dir: &state_dir,
+            broker_listen_socket: &broker_uds,
         });
 
         // SAFETY: serialised by HOME_TEST_LOCK.
@@ -810,6 +831,14 @@ mod tests {
             "audit-signer pid"
         );
         assert!(state_dir.join(BROKER_PID_FILE).exists(), "broker pid");
+        // The broker bound the caller-supplied vz-style listen socket, not the
+        // libkrun default — readiness polled exactly this path, so its presence
+        // proves the path was threaded through (the vz bug regression guard).
+        assert!(
+            broker_uds.exists(),
+            "broker bound the supplied listen socket {}",
+            broker_uds.display()
+        );
 
         guard.defuse();
         reap_broker_services(&state_dir);

--- a/crates/mvm-backend/src/libkrun.rs
+++ b/crates/mvm-backend/src/libkrun.rs
@@ -546,6 +546,12 @@ impl VmBackend for LibkrunBackend {
                 tenant_id: config.tenant_id.as_deref(),
                 vm_name: &config.name,
                 state_dir: &state_dir,
+                // libkrun binds one UDS per forwarded port directly under the
+                // state dir; that's where its supervisor splices BROKER_PORT.
+                broker_listen_socket: &mvm_core::config::vm_vsock_port_socket(
+                    &config.name,
+                    mvm_guest::vsock::BROKER_PORT,
+                ),
             },
         ) {
             Ok(guard) => guard,

--- a/crates/mvm-backend/src/vz.rs
+++ b/crates/mvm-backend/src/vz.rs
@@ -403,6 +403,14 @@ impl VmBackend for VzBackend {
                 tenant_id: config.tenant_id.as_deref(),
                 vm_name: &config.name,
                 state_dir: &state_dir,
+                // Vz nests its per-port vsock listeners under `<state>/vsock/`;
+                // the supervisor splices BROKER_PORT there (same shape as the
+                // substitution endpoint), so the broker must bind that path,
+                // not libkrun's flat `<state>/vsock-<port>.sock`.
+                broker_listen_socket: &mvm_core::config::vm_vz_vsock_port_socket(
+                    &config.name,
+                    mvm_guest::vsock::BROKER_PORT,
+                ),
             },
         ) {
             Ok(guard) => guard,

--- a/specs/plans/125-cli-sdk-dx-surface.md
+++ b/specs/plans/125-cli-sdk-dx-surface.md
@@ -208,7 +208,14 @@ Thin wrappers over `Sandbox`; big perceived surface, small code.
             registered handler (`host.audit.v1`), so it rides when the
             time/cost handlers that *do* gate on profile land.
       - [ ] **E5.3b-3** — PyO3/napi veneer.
-      - [ ] **E5.3b-4** — live-VM E2E on the dev-kvm box.
+      - [ ] **E5.3b-4** — live-VM E2E. Venue is a local libkrun/vz boot (the
+        dev-kvm box is Firecracker, which carries no broker).
+        - [x] **vz broker listen-socket fix** — `spawn_broker` bound the
+          libkrun-shaped `vm_vsock_port_socket` unconditionally; vz splices
+          `BROKER_PORT` to the `vsock/`-subdir `vm_vz_vsock_port_socket` (like
+          the substitution endpoint), so the guest leg was unreachable on vz.
+          The listen socket is now threaded into `BrokerServicesSpawnParams`,
+          computed per-backend by each `start()`.
   - [x] **E5.4** — `host.time.v1` / `host.cost.v1` typed methods in
     `mvm-guest::host_time` + `mvm-guest::host_cost` (`now` / `workload` +
     `tenant`, each with an `_on` stream variant), riding the same


### PR DESCRIPTION
## What

`spawn_broker` bound the **libkrun-shaped** `vm_vsock_port_socket` (`<state>/vsock-<port>.sock`) unconditionally. vz nests its per-port vsock listeners under `<state>/vsock/` and splices `BROKER_PORT` to `vm_vz_vsock_port_socket` — the same layout the egress-substitution endpoint already uses (`vz.rs` substitution path). On vz the broker therefore bound a path the supervisor never forwards the guest's `connect_host_vsock(BROKER_PORT)` dial to, leaving the in-guest `host.audit.v1` leg **unreachable**.

## Fix

Thread the broker listen socket into `BrokerServicesSpawnParams` / `BrokerSpawnParams`, computed by each backend's `start()`:
- **libkrun** → `vm_vsock_port_socket(name, BROKER_PORT)`
- **vz** → `vm_vz_vsock_port_socket(name, BROKER_PORT)`

`spawn_broker` now binds exactly the path it's handed instead of assuming one layout. `vm_name` (only ever used to compute that path) drops out of `BrokerSpawnParams`; the audit-signer keeps it for the per-VM chain key.

## Why this matters

Prerequisite for the Plan 125 E5.3b-4 live-VM `host.audit.v1` round-trip on the vz backend (the in-guest variant-B proof). Without it the guest can boot and dial but never reach the broker on macOS 26 / vz.

## Tests

- The admit + direct `spawn_broker` unit tests now point the supplied socket at a **vz-style `vsock/` subdir** and assert the broker bound *there* — a regression guard proving the path is threaded through, not recomputed as the libkrun flat layout. Readiness polls the supplied path, so a recompute regression would time out the spawn.

## Gates (local)

`cargo test -p mvm-backend --lib broker_services_spawn` (6 green) · `clippy -p mvm-backend --all-targets -D warnings` · `cargo check -p mvm-backend --all-targets` · nightly `fmt --all --check` · `xtask check-no-spec-refs-in-comments` — all clean.