### PR TITLE
fix(plan-125): vz broker binds the wrong BROKER_PORT socket (round-trip broken on vz)

### DIFF
--- a/crates/mvm-backend/src/broker_services_spawn.rs
+++ b/crates/mvm-backend/src/broker_services_spawn.rs
@@ -221,9 +221,12 @@ pub struct BrokerSpawnParams<'a> {
     pub workload_id: &'a str,
     /// Tenant id.
     pub tenant_id: &'a str,
-    /// VM name; the broker binds the per-VM `BROKER_PORT` socket keyed on it
-    /// (the VMM forwards the guest's `connect_host_vsock(BROKER_PORT)` there).
-    pub vm_name: &'a str,
+    /// The per-VM `BROKER_PORT` socket the broker binds — the **backend-specific**
+    /// path the VMM forwards the guest's `connect_host_vsock(BROKER_PORT)` to:
+    /// `vm_vsock_port_socket` on libkrun (the VMM proxies straight to it),
+    /// `vm_vz_vsock_port_socket` on vz (the supervisor splices to it). Passed in
+    /// rather than derived because the two backends use different socket paths.
+    pub broker_uds_path: &'a Path,
     /// Per-VM state dir; holds the broker PID file.
     pub state_dir: &'a Path,
     /// The audit-signer UDS from [`spawn_audit_signer`] — the broker's
@@ -257,15 +260,16 @@ fn spawn_broker_with_timeout(
     let BrokerSpawnParams {
         workload_id,
         tenant_id,
-        vm_name,
+        broker_uds_path,
         state_dir,
         audit_signer_uds_path,
     } = params;
 
     let bin = resolve_subprocess_bin("mvm-broker", "MVM_BROKER_PATH")?;
-    // The broker binds the per-VM BROKER_PORT socket the VMM forwards the
-    // guest's `connect_host_vsock(BROKER_PORT)` dial to.
-    let uds_path = mvm_core::config::vm_vsock_port_socket(vm_name, mvm_guest::vsock::BROKER_PORT);
+    // The broker binds the backend-specific per-VM BROKER_PORT socket the VMM
+    // forwards the guest's `connect_host_vsock(BROKER_PORT)` dial to (the caller
+    // passes the right path — libkrun and vz differ).
+    let uds_path = broker_uds_path;
     if let Some(parent) = uds_path.parent() {
         std::fs::create_dir_all(parent)
             .map_err(|e| anyhow!("create broker socket dir {}: {e}", parent.display()))?;
@@ -283,11 +287,13 @@ fn spawn_broker_with_timeout(
 
     let child = spawn_detached_with_config(&bin, &cfg, "mvm-broker")?;
     // No stdout handshake — the broker just binds. Readiness = the UDS appears.
-    wait_for_uds("mvm-broker", &uds_path, child.id(), ready_timeout)?;
+    wait_for_uds("mvm-broker", uds_path, child.id(), ready_timeout)?;
     let pid_file = state_dir.join(BROKER_PID_FILE);
     std::fs::write(&pid_file, child.id().to_string())
         .map_err(|e| anyhow!("write {}: {e}", pid_file.display()))?;
-    Ok(BrokerHandle { uds_path })
+    Ok(BrokerHandle {
+        uds_path: uds_path.to_path_buf(),
+    })
 }
 
 /// Spawn `bin` detached (`setsid`), write `cfg` JSON to its stdin then close it
@@ -365,10 +371,14 @@ pub struct BrokerServicesSpawnParams<'a> {
     /// is a defused no-op (an unadmitted dev VM has no broker services, so a
     /// stray guest dial to `BROKER_PORT` gets `ECONNREFUSED`).
     pub tenant_id: Option<&'a str>,
-    /// VM name; keys the per-VM workload chain + the `BROKER_PORT` socket.
+    /// VM name; keys the per-VM workload chain (`<tenant>.<vm>.workload.jsonl`).
     pub vm_name: &'a str,
     /// Per-VM state dir.
     pub state_dir: &'a Path,
+    /// The `BROKER_PORT` socket the broker binds — backend-specific (the caller
+    /// passes `vm_vsock_port_socket` on libkrun, `vm_vz_vsock_port_socket` on
+    /// vz; the VMM forwards the guest's `connect_host_vsock(BROKER_PORT)` here).
+    pub broker_listen_socket: &'a Path,
 }
 
 /// Spawn the per-VM broker services (audit-signer **then** broker) when the VM
@@ -388,6 +398,7 @@ pub fn spawn_broker_services_if_admitted(
         tenant_id,
         vm_name,
         state_dir,
+        broker_listen_socket,
     } = params;
     let Some(tenant_id) = tenant_id else {
         return Ok(BrokerServicesGuard::defused());
@@ -405,7 +416,7 @@ pub fn spawn_broker_services_if_admitted(
     spawn_broker(BrokerSpawnParams {
         workload_id,
         tenant_id,
-        vm_name,
+        broker_uds_path: broker_listen_socket,
         state_dir,
         audit_signer_uds_path: &audit.uds_path,
     })?;
@@ -668,7 +679,7 @@ mod tests {
         let res = spawn_broker(BrokerSpawnParams {
             workload_id: "wl-001",
             tenant_id: "tenant-x",
-            vm_name: "vm-1",
+            broker_uds_path: &uds,
             state_dir: &state_dir,
             audit_signer_uds_path: &audit_uds,
         });
@@ -729,6 +740,8 @@ mod tests {
             tenant_id: None,
             vm_name: "vm",
             state_dir: &dir,
+            // Unused on the unadmitted path (the gate short-circuits first).
+            broker_listen_socket: &dir,
         })
         .expect("unadmitted VM yields a defused no-op guard");
         drop(guard); // a defused guard's Drop reaps nothing
@@ -790,6 +803,7 @@ mod tests {
             tenant_id: Some("tenant-x"),
             vm_name: "vm-1",
             state_dir: &state_dir,
+            broker_listen_socket: &broker_uds,
         });
 
         // SAFETY: serialised by HOME_TEST_LOCK.

--- a/crates/mvm-backend/src/libkrun.rs
+++ b/crates/mvm-backend/src/libkrun.rs
@@ -546,6 +546,12 @@ impl VmBackend for LibkrunBackend {
                 tenant_id: config.tenant_id.as_deref(),
                 vm_name: &config.name,
                 state_dir: &state_dir,
+                // libkrun proxies the guest's BROKER_PORT dial straight to this
+                // per-VM socket.
+                broker_listen_socket: &mvm_core::config::vm_vsock_port_socket(
+                    &config.name,
+                    mvm_guest::vsock::BROKER_PORT,
+                ),
             },
         ) {
             Ok(guard) => guard,

--- a/crates/mvm-backend/src/vz.rs
+++ b/crates/mvm-backend/src/vz.rs
@@ -403,6 +403,13 @@ impl VmBackend for VzBackend {
                 tenant_id: config.tenant_id.as_deref(),
                 vm_name: &config.name,
                 state_dir: &state_dir,
+                // vz splices the guest's BROKER_PORT dial to the per-VM socket
+                // under `vsock/` (same shape as the substitution endpoint) — a
+                // different path from libkrun's, so the broker must bind THIS.
+                broker_listen_socket: &mvm_core::config::vm_vz_vsock_port_socket(
+                    &config.name,
+                    mvm_guest::vsock::BROKER_PORT,
+                ),
             },
         ) {
             Ok(guard) => guard,


### PR DESCRIPTION
**Bug found while grounding the E5.3b-4 live E2E: the host-services broker round-trip is silently broken on vz.**

`broker_services_spawn::spawn_broker` bound `vm_vsock_port_socket(vm, BROKER_PORT)` (`<state>/vsock-5300.sock`) **unconditionally**. That's correct for libkrun (the VMM proxies the guest's `connect_host_vsock(BROKER_PORT)` straight to it) but **wrong for vz**, which splices `host_listen_ports` to `vm_vz_vsock_port_socket` (`<state>/vsock/vsock-5300.sock` — the `vsock/`-subdir path the substitution endpoint binds, `vz.rs:1797`). So on vz the broker was bound one directory up from where the supervisor forwards the dial → the **vz guest leg was unreachable**, despite "round-trip live on vz".

### Why it slipped through
The host-spine integration test (#969) and the variant-A host-side proof both connect to the broker's **bound** UDS directly, bypassing the VMM splice — so neither exercises the path the guest actually traverses. Only the guest leg (VMM-forwarded) hits the mismatch.

### Fix
The broker's listen path is now **backend-supplied**, not derived:
- `BrokerServicesSpawnParams.broker_listen_socket` → `BrokerSpawnParams.broker_uds_path`
- `LibkrunBackend::start` passes `vm_vsock_port_socket`; `VzBackend::start` passes `vm_vz_vsock_port_socket`
- `spawn_broker` binds the passed path (no internal derivation)

### Tests / gates
`cargo test -p mvm-backend` green (329; the `spawn_broker` test already asserts `handle.uds_path == the passed path`, so it now guards that the param is honored — updated the two `BrokerServicesSpawnParams` constructions for the new field). clippy `-D warnings`, nightly fmt `--all`, `check-no-spec-refs-in-comments`, `check-core-runtime-free`, `cargo check --workspace --all-targets` clean.

Off `main`. Independent of #969 (test-only) and #965/#967 (codegen/veneer). E5.3b-4 variant A (host-side round-trip) was proven live separately this session.