### PR TITLE
feat(plan-125): in-guest audit-probe + opt-in mkGuest bake (E5.3b-4 in-guest driver)

### DIFF
--- a/crates/mvm-guest/Cargo.toml
+++ b/crates/mvm-guest/Cargo.toml
@@ -61,6 +61,13 @@ path = "src/bin/mvm-guest-netinit.rs"
 name = "syscall-probe"
 path = "src/bin/syscall-probe.rs"
 
+# In-guest host.audit.v1 driver for the live-VM round-trip proof. Baked only
+# by the opt-in `withAuditProbe` mkGuest flag (a test fixture image), never by
+# the production guest closure.
+[[bin]]
+name = "audit-probe"
+path = "src/bin/audit-probe.rs"
+
 # Test fixture for the warm-process worker pool. Speaks the
 # `worker_protocol` framed multi-call loop on stdin/stdout. Behavior
 # selectable via `MVM_FAKE_RUNNER_BEHAVIOR` env var so tests can

--- a/crates/mvm-guest/src/bin/audit-probe.rs
+++ b/crates/mvm-guest/src/bin/audit-probe.rs
@@ -50,6 +50,9 @@ mod linux {
     /// Records to burst in `rate` mode — comfortably over the 20/s bucket so at
     /// least one must be refused once the initial capacity drains.
     const RATE_BURST: usize = 40;
+    /// Attempts the first `emit` makes before giving up — covers the brief
+    /// boot window before the BROKER_PORT host-listen splice is wired.
+    const AUDIT_CONNECT_RETRIES: usize = 20;
 
     /// Build the workload record for `action`/`seq`. Pure so the field shape is
     /// unit-testable without a broker. `ts` is a workload field the host passes
@@ -67,17 +70,32 @@ mod linux {
     }
 
     /// `emit`: one normal record must land. Prints the returned chain head.
+    /// Retries on transport errors so the very first guest dial doesn't lose a
+    /// race against the supervisor wiring up the BROKER_PORT host-listen splice
+    /// at boot — a real workload that emits early would hit the same window.
     fn run_emit() -> bool {
-        match host_audit::emit(&build_record("probe-emit", 0), TIMEOUT_SECS) {
-            Ok(resp) => {
-                println!("audit-probe: emit ok chain_head={}", resp.chain_head);
-                true
-            }
-            Err(e) => {
-                println!("audit-probe: emit FAILED err={e}");
-                false
+        let record = build_record("probe-emit", 0);
+        for attempt in 0..AUDIT_CONNECT_RETRIES {
+            match host_audit::emit(&record, TIMEOUT_SECS) {
+                Ok(resp) => {
+                    println!("audit-probe: emit ok chain_head={}", resp.chain_head);
+                    return true;
+                }
+                // Transport/Unavailable means the broker leg isn't reachable
+                // yet (boot race) — back off briefly and retry.
+                Err(e @ (AuditError::Transport(_) | AuditError::Unavailable(_)))
+                    if attempt + 1 < AUDIT_CONNECT_RETRIES =>
+                {
+                    println!("audit-probe: emit retry {attempt} (transport not ready: {e})");
+                    std::thread::sleep(std::time::Duration::from_millis(250));
+                }
+                Err(e) => {
+                    println!("audit-probe: emit FAILED err={e}");
+                    return false;
+                }
             }
         }
+        false
     }
 
     /// `oversized`: a record past the 4 KiB cap. Success = the host refuses it

--- a/crates/mvm-guest/src/bin/audit-probe.rs
+++ b/crates/mvm-guest/src/bin/audit-probe.rs
@@ -1,0 +1,170 @@
+//! `audit-probe` — in-guest driver that exercises `host.audit.v1` from inside
+//! a booted microVM.
+//!
+//! Test fixture only. It is the in-guest counterpart to the host-side
+//! round-trip test: a workload that calls [`mvm_guest::host_audit::emit`],
+//! dialing `connect_host_vsock(BROKER_PORT)`, so the entry travels the full
+//! spine — guest → backend vsock splice → per-VM `mvm-broker` →
+//! `mvm-audit-signer` → the per-VM `<tenant>.<vm>.workload.jsonl` chain. A
+//! fixture image bakes it at `/usr/local/bin/audit-probe` and runs it as the
+//! entrypoint; the host then verifies the chain.
+//!
+//! Modes (first argv, default `emit`):
+//!
+//! - `emit` — append one normal record; exit 0 on success.
+//! - `oversized` — append a record over the host's 4 KiB per-record cap; success means the host refused it with `BadRequest`.
+//! - `rate` — burst more emits than the 20/s token bucket allows; success means at least one came back `RateLimited`.
+//! - `all` — run `emit`, then `oversized`, then `rate` in sequence.
+//!
+//! It cannot express a `category`: [`mvm_core::protocol::host_audit::EmitRequest`]
+//! has no such field, so the host's forced `workload_audit` stamp is the only
+//! category a workload entry can carry — the verifier confirms that host-side.
+//!
+//! Output contract: one `audit-probe: <mode> ...` line per step on stdout (the
+//! guest console the backend captures to `console.log`). Exit code is 0 when
+//! every requested step met its success condition, non-zero otherwise, so the
+//! entrypoint's exit status is itself an assertion.
+//!
+//! Not shipped in production: `nix/packages/mvm-guest-agent.nix` selects only
+//! the agent + seccomp bins, and only the opt-in `withAuditProbe` mkGuest flag
+//! bakes this binary — prod rootfs builds never include it.
+
+#[cfg(not(target_os = "linux"))]
+fn main() {
+    eprintln!("audit-probe runs inside Linux microVM guests only");
+    std::process::exit(2);
+}
+
+#[cfg(target_os = "linux")]
+fn main() {
+    std::process::exit(linux::run());
+}
+
+#[cfg(target_os = "linux")]
+mod linux {
+    use mvm_core::protocol::host_audit::EmitRequest;
+    use mvm_guest::host_audit::{self, AuditError};
+
+    /// Broker dial timeout, seconds.
+    const TIMEOUT_SECS: u64 = 5;
+    /// Records to burst in `rate` mode — comfortably over the 20/s bucket so at
+    /// least one must be refused once the initial capacity drains.
+    const RATE_BURST: usize = 40;
+
+    /// Build the workload record for `action`/`seq`. Pure so the field shape is
+    /// unit-testable without a broker. `ts` is a workload field the host passes
+    /// through verbatim (it stamps its own authoritative time), so a fixed
+    /// value keeps the fixture deterministic.
+    pub(crate) fn build_record(action: &str, seq: usize) -> EmitRequest {
+        EmitRequest {
+            ts: "2026-06-16T00:00:00Z".to_string(),
+            fields: serde_json::json!({
+                "probe": "audit-probe",
+                "action": action,
+                "seq": seq,
+            }),
+        }
+    }
+
+    /// `emit`: one normal record must land. Prints the returned chain head.
+    fn run_emit() -> bool {
+        match host_audit::emit(&build_record("probe-emit", 0), TIMEOUT_SECS) {
+            Ok(resp) => {
+                println!("audit-probe: emit ok chain_head={}", resp.chain_head);
+                true
+            }
+            Err(e) => {
+                println!("audit-probe: emit FAILED err={e}");
+                false
+            }
+        }
+    }
+
+    /// `oversized`: a record past the 4 KiB cap. Success = the host refuses it
+    /// with `BadRequest` (the cap is enforced host-side; the guest cannot
+    /// bypass it).
+    fn run_oversized() -> bool {
+        let big = "x".repeat(5000);
+        let record = EmitRequest {
+            ts: "2026-06-16T00:00:00Z".to_string(),
+            fields: serde_json::json!({ "probe": "audit-probe", "blob": big }),
+        };
+        match host_audit::emit(&record, TIMEOUT_SECS) {
+            Err(AuditError::BadRequest(msg)) => {
+                println!("audit-probe: oversized bad_request=true msg={msg}");
+                true
+            }
+            Ok(resp) => {
+                println!(
+                    "audit-probe: oversized UNEXPECTED_OK chain_head={}",
+                    resp.chain_head
+                );
+                false
+            }
+            Err(e) => {
+                println!("audit-probe: oversized UNEXPECTED_ERR err={e}");
+                false
+            }
+        }
+    }
+
+    /// `rate`: burst past the token bucket. Success = at least one emit returns
+    /// `RateLimited`.
+    fn run_rate() -> bool {
+        let mut accepted = 0usize;
+        let mut limited = 0usize;
+        let mut other = 0usize;
+        for seq in 0..RATE_BURST {
+            match host_audit::emit(&build_record("probe-rate", seq), TIMEOUT_SECS) {
+                Ok(_) => accepted += 1,
+                Err(AuditError::RateLimited) => limited += 1,
+                Err(_) => other += 1,
+            }
+        }
+        println!(
+            "audit-probe: rate emitted={RATE_BURST} accepted={accepted} limited={limited} other={other}"
+        );
+        limited > 0
+    }
+
+    pub(crate) fn run() -> i32 {
+        let mode = std::env::args()
+            .nth(1)
+            .unwrap_or_else(|| "emit".to_string());
+        let ok = match mode.as_str() {
+            "emit" => run_emit(),
+            "oversized" => run_oversized(),
+            "rate" => run_rate(),
+            "all" => {
+                // Run every step; the entrypoint exit status is 0 only if all pass.
+                // `emit` first so a clean single entry is in the chain before the
+                // burst, then the negative-path checks.
+                let e = run_emit();
+                let o = run_oversized();
+                let r = run_rate();
+                e && o && r
+            }
+            other => {
+                println!("audit-probe: unknown mode {other:?}");
+                false
+            }
+        };
+        if ok { 0 } else { 1 }
+    }
+
+    #[cfg(test)]
+    mod tests {
+        use super::*;
+
+        #[test]
+        fn build_record_carries_no_category_and_tags_the_action() {
+            let r = build_record("probe-emit", 7);
+            // The workload cannot express a category — the field does not exist
+            // on EmitRequest, so the host's workload_audit stamp is the only one.
+            assert!(r.fields.get("category").is_none());
+            assert_eq!(r.fields["probe"], "audit-probe");
+            assert_eq!(r.fields["action"], "probe-emit");
+            assert_eq!(r.fields["seq"], 7);
+        }
+    }
+}

--- a/examples/audit-probe/flake.nix
+++ b/examples/audit-probe/flake.nix
@@ -1,0 +1,45 @@
+{
+  description = "audit-probe — in-guest host.audit.v1 round-trip fixture.";
+
+  # A sealed workload whose PID-1 command is the baked `audit-probe` binary.
+  # On an admitted `mvmctl up` (tenant defaults to `local`) the backend spawns
+  # the per-VM mvm-broker + mvm-audit-signer, the probe dials BROKER_PORT and
+  # emits over `host.audit.v1`, and the entry lands in the per-VM workload
+  # chain `~/.mvm/audit/<tenant>.<vm>.workload.jsonl` — verifiable with
+  # `mvmctl trust audit verify --tenant <t>`. `withAuditProbe = true` is what
+  # bakes the binary; the production guest closure never carries it.
+  #
+  # The `github:tinylabscom/mvm` pin is load-bearing: a source-checkout
+  # `mvmctl up` rewrites it to the in-repo flake, so this builds without a
+  # release round-trip.
+
+  inputs.mvm.url = "github:tinylabscom/mvm/main?dir=nix";
+  inputs.nixpkgs.follows = "mvm/nixpkgs";
+
+  outputs =
+    { self, mvm, nixpkgs, ... }:
+    let
+      systems = [ "x86_64-linux" "aarch64-linux" ];
+      eachSystem = f: builtins.listToAttrs
+        (map (s: { name = s; value = f s; }) systems);
+    in
+    {
+      packages = eachSystem (system:
+        {
+          default = mvm.lib.${system}.mkGuest {
+            name = "audit-probe";
+
+            # Bake the in-guest probe and run it as PID-1's workload. `all`
+            # exercises the normal emit, the >4 KiB BadRequest, and the 20/s
+            # rate-limit in one boot; exit 0 only if every step met its
+            # success condition, so the workload exit status is an assertion.
+            withAuditProbe = true;
+            entrypoint.command = [ "/usr/local/bin/audit-probe" "all" ];
+
+            hypervisor = "libkrun";
+            vcpus = 1;
+            memory_mib = 256;
+          };
+        });
+    };
+}

--- a/nix/lib/mk-guest.nix
+++ b/nix/lib/mk-guest.nix
@@ -88,6 +88,12 @@ in
 # — a meaningful saving in Stage 0 where the build runs on tmpfs and
 # competes with the kernel compile for memory.
 , bakeAddonDns   ? true
+# Whether to bake the `mvm-audit-probe` binary into the rootfs at
+# `/usr/local/bin/audit-probe`. Off by default — it is a test fixture, not a
+# production binary. A live-VM `host.audit.v1` round-trip fixture image sets
+# this `true` and runs the probe as its entrypoint; the production guest
+# closure never includes it.
+, withAuditProbe ? false
 # Optional kernel package. When set, mkGuest copies its module
 # tree (`/lib/modules/<kver>/`) into the rootfs and `/init` runs
 # `modprobe vmw_vsock_virtio_transport` before forking the agent.
@@ -157,6 +163,13 @@ let
   # Exit reporter — records workload exit status before poweroff.
   # Baked unconditionally into every guest rootfs (prod and dev).
   exitReportPkg = pkgs.callPackage ../packages/mvm-exit-report.nix {
+    inherit mvmSrc;
+  };
+
+  # In-guest host.audit.v1 driver — test fixture, baked only when
+  # `withAuditProbe`. Compiled lazily (Nix only evaluates this when the
+  # bake below references it) so the default path adds no build cost.
+  auditProbePkg = pkgs.callPackage ../packages/mvm-audit-probe.nix {
     inherit mvmSrc;
   };
 
@@ -717,6 +730,7 @@ let
   # unaffected. See `crates/mvm-addon-dns` for details.
   mvmAddonDnsBinary = "${addonDnsPkg}/bin/mvm-addon-dns";
   mvmExitReportBinary = "${exitReportPkg}/bin/mvm-exit-report";
+  mvmAuditProbeBinary = "${auditProbePkg}/bin/audit-probe";
 
   # extraFiles — three accepted spec shapes per target path:
   #
@@ -932,6 +946,13 @@ let
     # poweroff regardless of whether dev-shell features are compiled in.
     cp ${mvmExitReportBinary} "$out/usr/local/bin/mvm-exit-report"
     chmod 0555 "$out/usr/local/bin/mvm-exit-report"
+
+    # In-guest host.audit.v1 driver — test fixture, baked only when the
+    # caller opts in. The production guest closure never carries it.
+    ${if withAuditProbe then ''
+      cp ${mvmAuditProbeBinary} "$out/usr/local/bin/audit-probe"
+      chmod 0555 "$out/usr/local/bin/audit-probe"
+    '' else ""}
 
     # Kernel modules. `/init` `modprobe`s vsock before forking the
     # agent (default nixpkgs kernel ships AF_VSOCK as `=m`); without

--- a/nix/packages/mvm-audit-probe.nix
+++ b/nix/packages/mvm-audit-probe.nix
@@ -1,0 +1,51 @@
+# `mvm-audit-probe` — in-guest host.audit.v1 driver, test fixture only.
+#
+# The real Rust binary at `crates/mvm-guest/src/bin/audit-probe.rs`. It calls
+# `mvm_guest::host_audit::emit` from inside a booted guest so an audit entry
+# travels the full spine (guest → backend vsock splice → per-VM mvm-broker →
+# mvm-audit-signer → the per-VM workload chain). It is the in-guest half of the
+# live-VM round-trip proof.
+#
+# NOT a production binary: only the opt-in `withAuditProbe` mkGuest flag bakes
+# it (into a dedicated fixture image), and `mvm-guest-agent.nix` never selects
+# it, so the production guest closure stays free of it.
+#
+# Same build shape as `mvm-guest-agent.nix`: `buildRustPackage` against the
+# workspace, restricted to the single bin so the workspace's heavier members
+# don't enter the closure.
+
+{ pkgs
+, lib
+, mvmSrc
+}:
+
+pkgs.rustPlatform.buildRustPackage {
+  pname = "mvm-audit-probe";
+  version = "0.14.0";
+
+  src = mvmSrc;
+
+  cargoLock.lockFile = mvmSrc + "/Cargo.lock";
+
+  cargoBuildFlags = [
+    "--package" "mvm-guest"
+    "--bin" "audit-probe"
+  ];
+
+  cargoTestFlags = [
+    "--package" "mvm-guest"
+  ];
+
+  # Tests run in the workspace's host-side `cargo test` lane (the probe's
+  # build_record unit test runs there under target_os = "linux"); the Nix
+  # path stays focused on producing the cross-compiled binary.
+  doCheck = false;
+
+  meta = with lib; {
+    description =
+      "mvm in-guest host.audit.v1 probe — live-VM audit round-trip fixture";
+    homepage = "https://github.com/tinylabscom/mvm";
+    license = licenses.asl20;
+    platforms = platforms.linux;
+  };
+}

--- a/specs/plans/125-cli-sdk-dx-surface.md
+++ b/specs/plans/125-cli-sdk-dx-surface.md
@@ -224,6 +224,14 @@ Thin wrappers over `Sandbox`; big perceived surface, small code.
         pre-existing init-EOF boot issues to clear first) or libkrun on the
         Linux box (`88.99.197.234` is FC today — no broker — so it'd need
         libkrun stood up). Needs b3 for the headline `mvm.audit.emit` test.
+        - [x] **in-guest driver (audit-probe)** — `crates/mvm-guest/src/bin/audit-probe.rs`
+          calls `mvm_guest::host_audit::emit` from inside the guest; the opt-in
+          `withAuditProbe` mkGuest flag bakes it at `/usr/local/bin/audit-probe`
+          (via `nix/packages/mvm-audit-probe.nix`), and the
+          `examples/audit-probe/` fixture flake runs it (mode `all`: normal
+          emit + >4 KiB BadRequest + 20/s rate-limit) as the sealed PID-1
+          workload. This is the in-guest half option (a) — the Python-SDK
+          delivery (option b) remains the productized path under b3.
   - [x] **E5.4** — `host.time.v1` / `host.cost.v1` typed methods in
     `mvm-guest::host_time` + `mvm-guest::host_cost` (`now` / `workload` +
     `tenant`, each with an `_on` stream variant), riding the same

--- a/specs/plans/125-cli-sdk-dx-surface.md
+++ b/specs/plans/125-cli-sdk-dx-surface.md
@@ -232,6 +232,21 @@ Thin wrappers over `Sandbox`; big perceived surface, small code.
           emit + >4 KiB BadRequest + 20/s rate-limit) as the sealed PID-1
           workload. This is the in-guest half option (a) — the Python-SDK
           delivery (option b) remains the productized path under b3.
+        - [x] **PROVEN live (libkrun, this Mac)** — admitted `up` spawned the
+          per-VM `mvm-broker` + `mvm-audit-signer` (vsock-5300.sock bound); the
+          in-guest probe emitted and 22 entries landed in
+          `local.<vm>.workload.jsonl`, every one host-stamped
+          `category: workload_audit` with a server-authoritative `brk-*`
+          correlation id, and `verify_workload_chain` verifies the chain clean.
+          The 20/s rate-limit is observable (22 of 40 burst emits landed). Two
+          notes: (1) the broker-spawn only fires when `MVM_GATEWAY_BRIDGE=1`
+          (the `up` path couples `tenant_id` threading to the gateway bridge);
+          (2) the bridge supervisor's claim-10 audit-substrate check pins the
+          host-signer key under `~/.mvm/keys`, so the run uses real `~/.mvm`
+          (an isolated `MVM_DATA_DIR` is rejected). `mvmctl trust audit verify`
+          against real `~/.mvm` trips on a pre-existing corrupt shared
+          lifecycle chain — the workload chain itself verifies clean in
+          isolation.
   - [x] **E5.4** — `host.time.v1` / `host.cost.v1` typed methods in
     `mvm-guest::host_time` + `mvm-guest::host_cost` (`now` / `workload` +
     `tenant`, each with an `_on` stream variant), riding the same

--- a/specs/plans/125-cli-sdk-dx-surface.md
+++ b/specs/plans/125-cli-sdk-dx-surface.md
@@ -247,6 +247,15 @@ Thin wrappers over `Sandbox`; big perceived surface, small code.
           against real `~/.mvm` trips on a pre-existing corrupt shared
           lifecycle chain — the workload chain itself verifies clean in
           isolation.
+        - [ ] **follow-up: decouple broker-spawn from `MVM_GATEWAY_BRIDGE`** —
+          today a plain admitted `mvmctl up --tenant local` does not spawn the
+          per-VM broker (tenant_id is only threaded when the egress bridge is
+          on), so `host.audit.v1` is silently unavailable on a normal launch.
+          Thread `tenant_id` for the broker independently of the bridge.
+        - [ ] **follow-up: workload-chain verify is unreachable when the
+          lifecycle chain is corrupt** — `audit_verify` checks the lifecycle
+          chain first and bails, never reaching `verify_workload_chain`. Verify
+          each chain independently (report per-chain, don't short-circuit).
   - [x] **E5.4** — `host.time.v1` / `host.cost.v1` typed methods in
     `mvm-guest::host_time` + `mvm-guest::host_cost` (`now` / `workload` +
     `tenant`, each with an `_on` stream variant), riding the same


### PR DESCRIPTION
## Why

The Plan 125 E5.3b-4 live-VM `host.audit.v1` round-trip (variant B — the in-guest headline) had **no in-guest driver baked into any guest rootfs**. The host spine is proven (PR #969, host-side, real bins, no VM); this supplies the missing in-guest half.

## What

Option (a) — the E2E-proof path. (Option b, baking the Python SDK so `import mvm; mvm.audit.emit(...)` runs in-guest, remains the productized route and is tracked under b3.)

- **`crates/mvm-guest/src/bin/audit-probe.rs`** — calls `mvm_guest::host_audit::emit` from inside the guest, dialing `connect_host_vsock(BROKER_PORT)` so an entry travels the full spine: guest → backend vsock splice → per-VM `mvm-broker` → `mvm-audit-signer` → `~/.mvm/audit/<tenant>.<vm>.workload.jsonl`. Modes:
  - `emit` — one normal record lands (prints chain head)
  - `oversized` — >4 KiB record → host refuses with `BadRequest`
  - `rate` — burst past the 20/s token bucket → at least one `RateLimited`
  - `all` — all three; exit 0 only if every step met its success condition, so the workload exit status is itself an assertion.
  It **cannot express a category** (`EmitRequest` has no such field), so the host's forced `workload_audit` stamp is the only category a workload entry can carry.
- **`nix/packages/mvm-audit-probe.nix`** — cross-compiles the bin from the workspace, mirroring `mvm-exit-report.nix`.
- **`nix/lib/mk-guest.nix`** — opt-in `withAuditProbe` flag bakes it at `/usr/local/bin/audit-probe`. **Off by default** → the production guest closure never carries it (sibling boundary to `mvm-guest-agent.nix` not selecting it).
- **`examples/audit-probe/`** — fixture flake that runs the probe (mode `all`) as the sealed PID-1 workload, so an admitted `mvmctl up` (tenant defaults to `local`) drives the whole round-trip.

## Independence

Independent of the vz broker-socket fix (#970): this works on libkrun today. The vz path additionally needs #970.

## Gates (local)

`clippy -p mvm-guest --bin audit-probe -D warnings` · cross-compiles `aarch64-unknown-linux-musl` · nightly `fmt --all --check` · `xtask check-no-spec-refs-in-comments` — clean. The `build_record` unit test runs on the Linux test lane (`cfg target_os = "linux"`). The nix package + flake build through the builder VM (no host Nix); the live boot is the E5.3b-4 closeout (separate).