### PR TITLE
docs(adr-084): host services as a per-tenant daemon, not per-VM spawn (+ Plan 201)

### DIFF
--- a/specs/adrs/084-host-services-daemon-not-per-vm-spawn.md
+++ b/specs/adrs/084-host-services-daemon-not-per-vm-spawn.md
@@ -1,0 +1,108 @@
+# ADR-084: Host services as a per-tenant daemon, not per-VM spawn
+
+- Status: Proposed
+- Date: 2026-06-16
+- Owner: MVM Project
+- Related: ADR-059 (host services broker over vsock — this revises its process model), ADR-049 (TLS substitution mechanism), ADR-002 (microVM security posture — claims 12/13), ADR-041 (signed audited execution plans — claim 8), mvmd Plan 52 (host-services consumer, open)
+- Sequenced by: [Plan 202 — Host services daemon](../plans/202-host-services-daemon.md)
+
+## Context
+
+ADR-059 specified the host-services broker as an **in-process** listener inside the per-VM supervisor, with `host.secrets.v1` split into a dedicated subprocess. The implementation that actually shipped (the E5.3b-2 spawn stack) diverged: both the broker **and** the audit-signer became **per-VM detached subprocesses**, forked from `mvmctl up` via `mvm_backend::broker_services_spawn::spawn_broker_services_if_admitted` — one `mvm-broker` and one `mvm-audit-signer` `setsid` child per admitted VM, each binding a UDS, readiness-polled, then reaped on stop.
+
+That model has two problems we hit grounding the first live in-guest `host.audit.v1` round-trip:
+
+1. **It is fork-per-request at the wrong granularity.** `N` VMs cost `2N` host processes plus a fork/exec/bind/poll cycle on *every* boot. mvm tolerates that for one dev VM; `mvmd`, whose entire point is density (dozens–hundreds of microVMs per host), cannot. This is the CGI-fork antipattern where a resident daemon belongs.
+
+2. **Availability got coupled to egress.** The broker only spawns when `up` threads `tenant_id` into the launch, and `up` only does that under `MVM_GATEWAY_BRIDGE=1` (`should_thread_signed_plan`). So on a normal admitted `mvmctl up`, `host.audit.v1` is silently absent — a workload's `emit` fails with a transport error for a reason that has nothing to do with audit. The gating signal is the egress bridge, which is the wrong axis entirely.
+
+The moat that the two-process split exists to provide is real and must survive: the broker parses **untrusted guest frames** (the fuzzed surface, claim 5) and must never share an address space with the **host signing key** (claim 13 — no raw secret crosses the broker channel). But that is an *address-space* boundary between *two roles*; it does not require a process *per VM*. Two processes total satisfy it.
+
+`mvmd` is the production consumer of this surface (its host-services work is open), and we want the same capability locally in `mvm`. Whatever process model we pick is the one `mvmd` inherits at fleet scale — so the decision has to be made for density now, not retrofitted later.
+
+## Decision
+
+Host services run as **two long-lived daemons, scoped per tenant**, that VMs **register with** at boot and **deregister from** at teardown. There is no per-VM fork.
+
+- **`mvm-broker` daemon (per tenant)** — guest-facing dispatch. Holds no keys. Owns a control socket; binds each registered VM's `BROKER_PORT` socket dynamically and demultiplexes accepted connections to a `vm_id` by *which socket accepted them*. Enforces the admitted plan's `services` bindings (claim 12) and the per-workload rate limit, both keyed by `vm_id`.
+- **`mvm-audit-signer` daemon (per tenant)** — holds the tenant signing key and is the single writer to every per-VM workload chain (`<tenant>.<vm>.workload.jsonl`), one in-memory chain head per `vm_id`. The broker forwards each accepted entry tagged with a **server-derived** `vm_id` (never guest-supplied) for the signer to route and stamp `category: workload_audit`.
+
+Per tenant, that is **two** processes regardless of VM count. Per host it is `O(active tenants)`, never `O(VMs)`.
+
+VM lifecycle becomes registration:
+
+- **start** → `ensure_daemons(tenant)` (lazy, idempotent; warm after the first VM) → `Register { vm_id, broker_listen_socket, services_bindings, workload_chain_path }`. The supervisor splices the guest's `connect_host_vsock(BROKER_PORT)` to `broker_listen_socket` exactly as today — the backend-specific path is unchanged.
+- **stop** → `Deregister { vm_id }` → the broker unbinds and drops that VM's socket; the signer flushes and closes that VM's chain head.
+
+Registration is driven by the **admitted plan**, not by `MVM_GATEWAY_BRIDGE`. A plan that binds no host services registers nothing and spawns nothing — same zero-process outcome as today, but for the right reason. `host.audit.v1` is implicitly available to any admitted workload (emitting to your own chain is a low-risk, broadly useful capability); the catalog services (`time`, `cost`, secrets, future addons) require an explicit `ExecutionPlan.services` binding and are dispatch-gated on it.
+
+### Scope: per tenant
+
+The broker holds no secrets, so a single host-wide broker handling every tenant would be functionally sufficient. We reject it for **defense in depth**: a parsing bug in a daemon that eats untrusted guest input must not be a cross-tenant confidentiality boundary, and the audit-signer holds a tenant-scoped signing key that must not be reachable from another tenant's traffic. One daemon pair per tenant makes the process boundary the tenant boundary. For local `mvm` that is one tenant (`local`) and therefore one pair; for `mvmd` it is one pair per *active* tenant on the host — bounded by tenancy, not by fan-out.
+
+## Architecture
+
+### Identity is server-derived
+
+`vm_id` for every dispatched call and every signed entry comes from the socket that accepted the connection, established at `Register` time — never from a field in the guest frame. This is the same discipline the broker already applies to `correlation_id` (the supervisor reassigns a server-authoritative id at ingress). A compromised guest therefore cannot address another VM's bindings or write another VM's chain, even within one shared broker process.
+
+### Registration control plane
+
+The daemons listen on a per-tenant control socket under the run dir (e.g. `<run>/broker-control-<tenant>.sock`, mode 0700, host-owned). `Register`/`Deregister` are signed by the host (the same host identity that signs plans), so a guest — which has no access to the control socket — cannot register or unbind sockets. The wire `ServiceCall`/`ServiceResponse` shape on `BROKER_PORT` is unchanged from ADR-059; only the *owner* of the per-VM socket moves from a per-VM fork to the resident daemon.
+
+### Crash and restart
+
+A resident per-tenant daemon has a larger blast radius than a per-VM child: its crash drops host services for every VM of that tenant. Mitigations:
+
+- The daemon is **supervised** — by `mvm` locally and by `mvmd`'s host agent in the fleet — and restarted.
+- Chain integrity survives restart: each per-VM head already persists out of band (the secondary head file), so the signer rebuilds heads from disk + the live registration set rather than forking the chain. A restart re-binds sockets for the still-registered VMs from the journal.
+- This is the ordinary resident-daemon bargain (nix-daemon, containerd) and is the correct trade for `O(tenants)` instead of `O(VMs)` processes.
+
+### Why not fold the broker into the supervisor
+
+Considered: drop the broker process entirely, handle `BROKER_PORT` inline in the per-VM supervisor (which already parses guest vsock I/O), keep only the shared signer. Rejected: the supervisor is the VMM — already the largest, most-exposed TCB — and widening it with host-service dispatch is the wrong direction. Dispatch stays in a separate, keyless, *shared* daemon.
+
+## Security model
+
+The claim-12 (binding-gated dispatch) and claim-13 (no raw secret over the broker channel) properties are **preserved unchanged** — this ADR moves *where the two roles live*, not *what they may do*:
+
+- Two address spaces still separate the untrusted-input parser (broker, keyless) from the key holder (signer). `2` per tenant instead of `2N`.
+- `vm_id` and `correlation_id` remain server-authoritative — a guest cannot forge cross-VM identity, and the per-tenant process boundary blocks cross-tenant reach.
+- The rate limit and the 4 KiB record cap stay host-side, now keyed by `vm_id` in the daemon's per-VM state.
+- The signing key path stays pinned under the host key dir (the claim-8 trust boundary); the daemon model does not relax it.
+
+### Surfaces that do not expand
+
+The guest-facing wire (`ServiceCall` over `AuthenticatedFrame` on `BROKER_PORT`) is byte-identical to ADR-059. The new surface is the **host-side control socket** (Register/Deregister), reachable only by the host (mode 0700, host-signed messages), never by a guest. No new guest-reachable verb, port, or frame type.
+
+## Alternatives considered
+
+- **Per-VM subprocess (status quo).** Correct moat, wrong granularity: `2N` processes + per-boot spawn latency. Fails mvmd density. This ADR replaces it.
+- **In-process broker in the supervisor (original ADR-059).** Avoids a separate broker process but puts guest-service dispatch in the VMM's address space and is still per-VM. Rejected for TCB and granularity reasons.
+- **Single host-wide broker for all tenants.** Fewest processes, but a parsing bug becomes a cross-tenant boundary and one signer would hold every tenant's key. Rejected for tenant isolation; per-tenant is the chosen middle.
+- **Lazy spawn on first guest dial.** Defers the cost but reintroduces per-VM processes and adds first-call latency inside the request path. The register-at-boot daemon gets the same "only when needed" property without per-VM processes.
+
+## Consequences
+
+### Positive
+
+- Host-process count drops from `O(VMs)` to `O(active tenants)`; per-VM boot no longer pays a fork/exec/bind/poll cycle.
+- `host.audit.v1` becomes available on a normal admitted `up`, decoupled from the egress bridge.
+- One daemon + protocol is shared by `mvm` (local) and `mvmd` (fleet) — local is a single-tenant slice of production, not a different code path.
+- The moat and all claim-12/13 properties are preserved.
+
+### Negative
+
+- Larger crash blast radius per tenant (mitigated by supervision + persisted heads + a registration journal).
+- A registration control plane is new surface to implement, supervise, and reason about (host-only, host-signed).
+- Revises a process model that just shipped; the per-VM spawn stack must be migrated, not extended.
+
+## Migration
+
+Phased in [Plan 202](../plans/202-host-services-daemon.md). The wire protocol on `BROKER_PORT` does not change, so guests, the SDK veneer, and the in-guest probe are untouched. The change is host-side: `spawn_broker_services_if_admitted` (fork) becomes `ensure_daemons` + `register_vm`, the daemons gain a control plane, and `mvmd`'s host agent adopts the same daemon per tenant.
+
+## Out of scope
+
+- The guest-facing wire format, the service catalog, and the capability-gating rules — all unchanged from ADR-059.
+- Cross-VM / cross-tenant data delegation, which remains mvmd's tenant-scoped-authz responsibility (ADR-059 §Cross-VM delegation).
+- The egress gateway bridge and its L4 policy enforcement — a separate axis that this ADR deliberately stops conflating with host-service availability.

--- a/specs/plans/202-host-services-daemon.md
+++ b/specs/plans/202-host-services-daemon.md
@@ -1,0 +1,80 @@
+# Plan 202 — Host services daemon (per-tenant, not per-VM spawn)
+
+- Status: **Proposed**
+- ADR: [ADR-084](../adrs/084-host-services-daemon-not-per-vm-spawn.md)
+- Revises: the E5.3b-2 per-VM spawn stack (`mvm_backend::broker_services_spawn`) landed under [Plan 125](125-cli-sdk-dx-surface.md) E5.3b
+- Consumer: mvmd Plan 52 (host services) adopts the daemon per tenant
+
+## Goal
+
+Replace per-VM `mvm-broker` + `mvm-audit-signer` forks with **two long-lived per-tenant daemons** that VMs register with at boot and deregister from at teardown. Host-process count drops from `O(VMs)` to `O(active tenants)`; `host.audit.v1` becomes available on a normal admitted `up`, decoupled from `MVM_GATEWAY_BRIDGE`. The guest-facing wire (`ServiceCall` on `BROKER_PORT`) does not change.
+
+## Invariants to hold throughout
+
+- The moat survives: broker (keyless, untrusted-input parser) and signer (key holder) stay in separate address spaces.
+- `vm_id` and `correlation_id` are server-derived, never guest-supplied.
+- The control plane (Register/Deregister) is host-only (mode 0700) and host-signed — never guest-reachable.
+- Claim 12 (binding-gated dispatch), claim 13 (no raw secret over the channel), the 20/s rate limit, and the 4 KiB cap are preserved, keyed by `vm_id`.
+- No guest-facing protocol, port, or frame change — the SDK veneer and the in-guest `audit-probe` are untouched.
+
+## Phase 0 — ADR + plan
+
+- [x] ADR-084 written (per-tenant daemon model, supersedes the in-process/per-VM split).
+- [x] Plan 202 written (this doc).
+- [ ] ADR-084 reviewed + accepted.
+
+## Phase 1 — broker daemon + control plane
+
+- [ ] **1a — control protocol.** Define `RegisterVm { vm_id, tenant, broker_listen_socket, services_bindings, workload_chain_path }` / `DeregisterVm { vm_id }`, host-signed, framed on a per-tenant control UDS (`<run>/broker-control-<tenant>.sock`, 0700). Serde roundtrip + tampered-signature rejection tests.
+- [ ] **1b — daemon skeleton.** `mvm-broker` runs as a resident per-tenant process: accept on the control socket, hold a `vm_id → {socket, bindings, rate-bucket}` map, bind/unbind per-VM `BROKER_PORT` sockets on register/deregister, demux accepted connections to `vm_id` by accepting socket. Reuse the existing `ServiceCall` dispatch + claim-12 gate unchanged.
+- [ ] **1c — `ensure_daemon` + `register_vm`.** New `mvm_backend` seam replacing `spawn_broker` in the start path: lazily start the per-tenant broker (idempotent; pid/lock under the run dir so concurrent `up`s converge on one) and send `RegisterVm`. `stop()` sends `DeregisterVm` (no daemon teardown — it stays warm).
+- [ ] **1d — identity is server-derived.** Assert in tests that the dispatched `vm_id` comes from the accepting socket, not the frame; a frame claiming another `vm_id` cannot reach that VM's bindings.
+
+**Verify:** `cargo test -p mvm-hostd -p mvm-backend`; unit test for register→bind→dispatch→deregister→unbind; concurrent-`up` converges-on-one-daemon test.
+
+## Phase 2 — audit-signer daemon
+
+- [ ] **2a — daemon + per-VM heads.** `mvm-audit-signer` resident per tenant, holding the tenant key, with a `vm_id → in-memory chain head` map; `RegisterVm` opens/owns that VM's `<tenant>.<vm>.workload.jsonl`, `DeregisterVm` flushes + closes it. Single-writer per file preserved by one owning process.
+- [ ] **2b — broker→signer forwarding tagged by server `vm_id`.** The broker forwards each accepted entry with the server-derived `vm_id`; the signer routes to the right head and stamps `category: workload_audit`. Cross-VM forgery test (guest A cannot land in B's chain).
+- [ ] **2c — restart rebuilds heads.** On daemon restart, rebuild each head from the persisted secondary head + re-bind from the live registration set; chain stays append-only (no fork). Kill-and-restart test asserts the chain still `verify_workload_chain`s clean across the restart.
+
+**Verify:** `verify_workload_chain` clean before and after a signer restart; per-VM chains isolated; `cargo test -p mvm-hostd`.
+
+## Phase 3 — decouple availability from the egress bridge
+
+- [ ] **3a — registration driven by the admitted plan.** In `up`, drive `register_vm` from the admitted `ExecutionPlan` (any admitted workload registers; `host.audit.v1` implicitly available; catalog services require an explicit `services` binding and stay dispatch-gated). Remove the `MVM_GATEWAY_BRIDGE` coupling from host-service availability — that flag goes back to gating *only* the egress bridge / L4 policy.
+- [ ] **3b — zero-cost when unused.** A plan binding no services registers nothing and starts no daemon (assert no broker/signer process appears).
+- [ ] **3c — `mvmctl doctor`** reports the per-tenant daemon state (running / warm / absent) so the move from per-VM is observable.
+
+**Verify:** a plain `mvmctl up --tenant local` (no `MVM_GATEWAY_BRIDGE`) makes `host.audit.v1` reachable; a no-services plan spawns nothing; live libkrun round-trip green (the [Plan 125 E5.3b-4](125-cli-sdk-dx-surface.md) probe, now without the bridge env).
+
+## Phase 4 — supervision + crash semantics
+
+- [ ] **4a — registration journal.** Persist the live registration set so a restarted daemon re-binds sockets + reopens heads for still-running VMs.
+- [ ] **4b — supervised restart.** `mvm` restarts a crashed local daemon; document the blast-radius trade. Crash-mid-flight test: a kill during dispatch loses at most the in-flight call, never corrupts a chain.
+
+**Verify:** kill-and-restart leaves every running VM's `host.audit.v1` working and chains clean.
+
+## Phase 5 — mvmd adoption (cross-repo)
+
+- [ ] **5a — host agent owns the daemon per tenant.** mvmd's host agent starts/supervises one daemon pair per active tenant at host init (not per VM), registering VMs as it launches them. Tracked in mvmd Plan 52; this repo exposes the daemon + control protocol as the shared surface.
+- [ ] **5b — density check.** Confirm `O(tenants)` process count under a fleet-shaped load (many VMs, few tenants).
+
+## Phase 6 — closeout
+
+- [ ] Remove `broker_services_spawn::spawn_broker_services_if_admitted` (per-VM fork) and its call sites once the daemon path is the default on libkrun + vz.
+- [ ] Update ADR-059 status to note its process model is superseded by ADR-084.
+- [ ] `specs/REFACTOR-STATUS.md` + this plan ticked; CLAUDE.md "process moat" description updated (per-tenant daemon, not per-VM subprocess).
+
+## Success criteria
+
+- `host.audit.v1` works on a plain admitted `mvmctl up` (libkrun + vz) with no `MVM_GATEWAY_BRIDGE`.
+- One broker + one audit-signer **per tenant**, warm across VM churn; a no-services plan starts neither.
+- Live round-trip + `verify_workload_chain` green, including across a daemon restart.
+- Claim 12/13, rate limit, cap, and server-derived identity all preserved (existing tests stay green; cross-VM/cross-tenant forgery tests added).
+- mvmd consumes the same daemon per tenant.
+
+## Deferred / follow-ups
+
+- [ ] Per-tenant **secrets dispatcher** (`host.secrets.v1`, ADR-059) folded into the same register/deregister model (it is the next catalog service after audit/time/cost).
+- [ ] Whether the broker control socket should carry a nonce/replay guard beyond host-signing (host-only access makes it low-risk, but worth a look when secrets ride the same plane).

--- a/specs/plans/host-services-daemon-phase-1-kickoff.md
+++ b/specs/plans/host-services-daemon-phase-1-kickoff.md
@@ -1,0 +1,66 @@
+# Kickoff prompt — Plan 202 Phase 1 (host-services broker daemon + control plane)
+
+> Paste this into a fresh session to implement Phase 1. It is self-contained; do not assume prior context.
+> Filename is deliberately non-numeric so it does not trip `xtask check-spec-numbers` (which fails on duplicate `NNN-` plan prefixes).
+
+## Mission
+
+Implement **Phase 1 of [Plan 202](202-host-services-daemon.md)** under **[ADR-084](../adrs/084-host-services-daemon-not-per-vm-spawn.md)**: replace the per-VM *fork* of `mvm-broker` with a **long-lived, per-tenant broker daemon** that VMs **register/deregister** with. Phase 1 is the broker only — the audit-signer daemon is Phase 2, do not touch it yet beyond what register/forward requires.
+
+## Read these first (in order)
+
+1. `specs/adrs/084-host-services-daemon-not-per-vm-spawn.md` — the decision, the moat, why per-tenant, the control-plane shape, crash semantics.
+2. `specs/plans/202-host-services-daemon.md` — Phase 1 tasks 1a–1d + the invariants list. **Your work is bounded by Phase 1; do not start Phases 2–6.**
+3. `crates/mvm-backend/src/broker_services_spawn.rs` — the current per-VM fork you are replacing (`spawn_broker_services_if_admitted`, `spawn_broker`, the reaper, the `BrokerServicesGuard`). Note the call sites in `libkrun.rs` and `vz.rs` `start()`.
+4. `crates/mvm-hostd/src/broker/` — the broker server, dispatch, registry, `host_audit_v1` handler, `ServiceCall`/`ServiceResponse` wire. `src/bin/mvm-broker.rs` is the current per-VM binary entry.
+5. `crates/mvm-hostd/src/broker/handlers/host_audit_v1.rs` — claim-12 binding gate, the 20/s token bucket, the 4 KiB cap, the `workload_audit` stamp. These behaviors must survive unchanged, now keyed by `vm_id`.
+
+## Phase 1 scope (tasks 1a–1d from the plan)
+
+- **1a — control protocol.** `RegisterVm { vm_id, tenant, broker_listen_socket, services_bindings, workload_chain_path }` / `DeregisterVm { vm_id }`, **host-signed**, framed on a per-tenant control UDS `<run>/broker-control-<tenant>.sock` (mode 0700, host-owned). Use the host signer identity that already signs plans. Tests: serde roundtrip, tampered-signature rejection.
+- **1b — daemon skeleton.** `mvm-broker` becomes a resident per-tenant process: accept on the control socket, hold a `vm_id → { listen_socket, bindings, rate-bucket }` map, **bind/unbind each VM's `BROKER_PORT` socket dynamically** on register/deregister, demux accepted guest connections to a `vm_id` **by which socket accepted them**. Reuse the existing `ServiceCall` dispatch + claim-12 gate verbatim.
+- **1c — `ensure_daemon` + `register_vm`.** New `mvm_backend` seam replacing the `spawn_broker` call in `start()`: lazily start the per-tenant broker (idempotent — pid/lock under the run dir so concurrent `mvmctl up`s converge on one daemon, never racing two) and send `RegisterVm`. `stop()` sends `DeregisterVm`; it does **not** tear the daemon down (stays warm).
+- **1d — server-derived identity.** Assert in tests that the dispatched `vm_id` comes from the accepting socket, never from the guest frame — a frame claiming another `vm_id` cannot reach that VM's bindings. (Same discipline as the server-authoritative `correlation_id` the broker already mints.)
+
+## Invariants you must hold (from the ADR/plan)
+
+- **The moat stays:** the broker holds **no keys**. It only forwards "sign this" to the (still per-VM, for now) audit-signer. Do not move the signing key into the broker.
+- **`vm_id` and `correlation_id` are server-derived**, never guest-supplied.
+- **Control plane is host-only** (mode 0700, host-signed) — never guest-reachable. No new guest-facing port, verb, or frame.
+- **Guest-facing wire is byte-identical** — the SDK veneer and the in-guest `audit-probe` must keep working unchanged. The supervisor still splices `connect_host_vsock(BROKER_PORT)` to the backend-specific `broker_listen_socket` (libkrun `vm_vsock_port_socket`, vz `vm_vz_vsock_port_socket` — see `mvm_core::config`).
+- Claim 12 (binding-gated dispatch), the 20/s rate limit, the 4 KiB cap — preserved, keyed by `vm_id`.
+
+## Explicitly NOT in this phase
+
+- The audit-signer daemon (Phase 2) — leave the per-VM signer as-is; the broker still forwards to it. Only thread the server-derived `vm_id` through the forward so Phase 2 can route.
+- Decoupling availability from `MVM_GATEWAY_BRIDGE` (Phase 3).
+- Crash/restart journal + supervision (Phase 4).
+- mvmd adoption (Phase 5).
+- Removing `spawn_broker_services_if_admitted` (Phase 6) — keep the audit-signer half of it; only the broker half moves to the daemon.
+
+## Repo conventions (do not skip — these are CI-gated)
+
+- **Work in a git worktree off `origin/main`**, not the main checkout. `git fetch origin` first.
+- **Check `gh pr list` + recent `git log origin/main` before starting** — a parallel session may already own `broker_services_spawn.rs` / the broker. Coordinate; do not duplicate (this exact dup happened on the vz-socket fix, #970 vs #971).
+- Gates before every push: `rustup run nightly cargo fmt --all -- --check`; `cargo clippy --workspace --all-targets -- -D warnings`; `cargo check --workspace --all-targets`; full `cargo test -p <crate>` for crates you touch (`mvm-hostd`, `mvm-backend`); `cargo run -p xtask -- check-no-spec-refs-in-comments`; `cargo run -p xtask -- check-core-runtime-free`.
+- **Homebrew `rustc` shadows rustup** on this Mac — pin to the rustup toolchain (`PATH="$(dirname "$(rustup which rustc)"):$PATH"`) or gates see the wrong compiler and target dirs cross-contaminate (E0514).
+- **No spec/PR/ADR citations in code comments** — keep the reasoning, drop the citation (the `check-no-spec-refs-in-comments` lint enforces this). ADRs/plans cite each other freely; code does not.
+- **No `Co-Authored-By: Claude` trailer**; attribute to the user.
+- Keep `specs/plans/202-host-services-daemon.md` checkboxes + `specs/REFACTOR-STATUS.md` current in the same change as the code.
+- Prefer small testable functions, builder/struct params over long arg lists (`#[allow(clippy::too_many_arguments)]` is banned), and a trait over scattered backend `match`es.
+
+## How to verify (live)
+
+Phase 1 is host-side, so unit/integration tests cover most of it (register → bind → dispatch → deregister → unbind; concurrent-`up`-converges-on-one-daemon; server-derived `vm_id`). For the end-to-end smoke, reuse the E5.3b-4 libkrun round-trip:
+
+- Build: `cargo build --bin mvmctl`; `cargo build -p mvm-hostd --bin mvm-broker --bin mvm-audit-signer`; `cargo build -p mvm-vm-host --bin mvm-libkrun-supervisor --features libkrun-sys`.
+- Boot the `examples/audit-probe` fixture (baked by the `withAuditProbe` mkGuest flag) on **libkrun**, real `~/.mvm` (the bridge supervisor pins the host-signer key under `~/.mvm/keys`), warm shared `~/.cache/mvm`, `MVM_BUILDER_BACKEND=libkrun`. Until Phase 3, `host.audit.v1` availability still needs `MVM_GATEWAY_BRIDGE=1`.
+- The probe emits in-guest; entries land in `~/.mvm/audit/local.<vm>.workload.jsonl`. Verify the **workload chain** clean in isolation: copy it + the real `~/.mvm/keys/host-signer.ed25519` into a temp `MVM_DATA_DIR/{audit,keys}` (no `local.jsonl`) and run `mvmctl trust audit verify --tenant local` — it must report the workload chain clean. (Verifying against real `~/.mvm` directly trips on a pre-existing corrupt shared `local.jsonl`; that's not your bug.)
+- Run live tests **backgrounded + `gtimeout`**, log to files; never unbounded. Clean up `~/.mvm/vms/<vm>` + the workload chain after.
+
+## Definition of done for Phase 1
+
+- `mvm-broker` runs as a resident per-tenant daemon; `start()` registers, `stop()` deregisters, the daemon stays warm across VM churn; concurrent `up`s converge on one daemon.
+- Guest-facing wire unchanged; the live libkrun round-trip + isolated `verify_workload_chain` still green (with `MVM_GATEWAY_BRIDGE=1`, since Phase 3 hasn't landed).
+- Server-derived `vm_id` proven by test; claim-12 / rate-limit / cap tests still green.
+- All gates clean; Plan 202 Phase 1 checkboxes ticked; PR scoped to Phase 1 only.


### PR DESCRIPTION
## What

ADR-084 + Plan 201 — re-architect the host-services broker/audit-signer from **per-VM subprocess spawn** to **two long-lived per-tenant daemons** that VMs register with at boot and deregister from at teardown.

## Why

Grounding the first live in-guest `host.audit.v1` round-trip (E5.3b-4) surfaced two problems with the shipped E5.3b-2 model:

1. **Fork-per-request at the wrong granularity** — one `mvm-broker` + one `mvm-audit-signer` per admitted VM = `2N` host processes + a fork/bind/readiness-poll cycle on every boot. mvm tolerates it for one dev VM; `mvmd` (whose point is density) cannot. Classic CGI-fork-where-a-daemon-belongs.
2. **Availability coupled to egress** — the broker only spawns when `up` threads `tenant_id`, which only happens under `MVM_GATEWAY_BRIDGE=1`. So on a normal admitted `up`, `host.audit.v1` is silently absent for a reason unrelated to audit.

## Decision

- **Two daemons, scoped per tenant**: keyless guest-facing `mvm-broker` + key-holding `mvm-audit-signer`, separate address spaces (the moat — claims 12/13 — preserved), but **`O(active tenants)` processes, not `O(VMs)`**.
- VM lifecycle becomes **Register/Deregister** over a host-only, host-signed control socket; the daemon binds/unbinds each VM's `BROKER_PORT` socket dynamically. The guest-facing wire (`ServiceCall` on `BROKER_PORT`) is **byte-identical** — SDK veneer and the in-guest probe are untouched.
- `vm_id` is **server-derived** (from the accepting socket), so no cross-VM forgery even within a shared broker; **per-tenant** scope makes the process boundary the tenant boundary.
- Registration is driven by the **admitted plan**, fully decoupling host-service availability from the egress bridge. `host.audit.v1` implicit; catalog services binding-gated. A no-services plan starts nothing.
- **mvmd** consumes the same daemon per tenant (its host-services work, open) — local `mvm` becomes a single-tenant slice of production, one code path.

Revises ADR-059's process model (which specified in-process; the impl drifted to per-VM subprocess — ADR-084 reconciles both).

## Scope

Docs only (ADR + phased plan). No code. Plan 201 phases: control plane → broker daemon → signer daemon → decouple from `MVM_GATEWAY_BRIDGE` → supervision/restart → mvmd adoption → retire the per-VM fork.

## Gates

`xtask check-spec-numbers` (unique), `check-adr-coverage` (0 broken refs), `check-no-overclaim`, `check-doc-claims`, `check-claim-catalog` — all clean. Cross-doc links resolve.