### PR TITLE
fix(plan-193): match rvproxy's dns_hostname_allowlist field name (+ WS-2 status reconcile)

### DIFF
--- a/crates/mvm-hostd/src/supervisor/network/rvproxy_policy.rs
+++ b/crates/mvm-hostd/src/supervisor/network/rvproxy_policy.rs
@@ -14,7 +14,7 @@
 //!     metadata),
 //!   - `l4_allowlist` — per-tenant L4 grants at full proto + CIDR + port-range
 //!     precision (rvproxy `policy_flow_reason`),
-//!   - `dns_allowlist` — the upstream DNS hostname sinkhole (dotted-suffix).
+//!   - `dns_hostname_allowlist` — the upstream DNS hostname sinkhole (dotted-suffix).
 //!
 //! So the lowering is an exact projection of the resolved `CanonicalEgress`
 //! (proven by the parity tests: `permits_flow` agrees with
@@ -49,7 +49,7 @@ pub struct RvproxyPolicy {
     pub cidr_denylist: Vec<String>,
     /// Upstream DNS hostname allow-list (dotted-suffix sinkhole).
     #[serde(skip_serializing_if = "Vec::is_empty")]
-    pub dns_allowlist: Vec<String>,
+    pub dns_hostname_allowlist: Vec<String>,
     /// Per-tenant L4 grants: proto + CIDR + inclusive port range. Kept last
     /// because the `toml` crate renders a `Vec<struct>` as an array-of-tables
     /// (`[[l4_allowlist]]`), which must follow every scalar/inline-array field.
@@ -110,15 +110,15 @@ impl RvproxyPolicy {
 
     /// Whether `name` may be resolved upstream under the DNS hostname allow-list.
     /// Empty list = no restriction. Dotted-suffix, case/dot-normalized — mirrors
-    /// rvproxy's `dns_allowlist_permits` and mvm's `DnsSinkholeScan`: `name` is
+    /// rvproxy's `hostname_matches_allowlist` and mvm's `DnsSinkholeScan`: `name` is
     /// admitted iff it equals a listed suffix or is a dotted subdomain of one
     /// (so `example.com` admits `api.example.com`, never `notexample.com`).
     pub fn dns_permits(&self, name: &str) -> bool {
-        if self.dns_allowlist.is_empty() {
+        if self.dns_hostname_allowlist.is_empty() {
             return true;
         }
         let query = name.trim_matches('.').to_ascii_lowercase();
-        self.dns_allowlist.iter().any(|suffix| {
+        self.dns_hostname_allowlist.iter().any(|suffix| {
             let suffix = suffix.trim_matches('.').to_ascii_lowercase();
             !suffix.is_empty() && (query == suffix || query.ends_with(&format!(".{suffix}")))
         })
@@ -172,7 +172,7 @@ pub fn lower_policy(egress: &CanonicalEgress, dns_allow: &[String]) -> RvproxyLo
             cidr_allowlist: Vec::new(),
             cidr_denylist,
             l4_allowlist,
-            dns_allowlist: dns_allow.to_vec(),
+            dns_hostname_allowlist: dns_allow.to_vec(),
         },
         gaps: RvproxyPolicyGaps {
             byte_scans_in_splice: true,
@@ -330,7 +330,7 @@ mod tests {
             &CanonicalEgress::Rules(vec![]),
             &["example.com".to_string(), "Foo.NET".to_string()],
         );
-        assert_eq!(lowered.policy.dns_allowlist.len(), 2);
+        assert_eq!(lowered.policy.dns_hostname_allowlist.len(), 2);
         assert!(lowered.policy.dns_permits("example.com"));
         assert!(lowered.policy.dns_permits("api.example.com"));
         assert!(lowered.policy.dns_permits("API.EXAMPLE.COM."));
@@ -368,7 +368,7 @@ mod tests {
         assert!(toml.contains("allow_guest_egress = true"));
         assert!(toml.contains("default_egress_deny = true"));
         assert!(toml.contains("169.254.169.254/32"));
-        assert!(toml.contains("dns_allowlist = [\"example.com\"]"));
+        assert!(toml.contains("dns_hostname_allowlist = [\"example.com\"]"));
         // L4 rules serialize as a TOML array-of-tables rvproxy parses.
         assert!(toml.contains("[[l4_allowlist]]"));
         assert!(toml.contains("protocol = \"tcp\""));

--- a/specs/plans/193-rvproxy-network-substrate.md
+++ b/specs/plans/193-rvproxy-network-substrate.md
@@ -126,7 +126,7 @@ own internal default).
         `CanonicalEgress` (+ DNS allow-list) into rvproxy's `[policy]` table at
         **full claim-10 fidelity** now that rvproxy ships the L4 + DNS config
         (rvproxy `014` follow-ups): `default_egress_deny` + mandatory-deny
-        `cidr_denylist` + `l4_allowlist` (proto/CIDR/port) + `dns_allowlist`
+        `cidr_denylist` + `l4_allowlist` (proto/CIDR/port) + `dns_hostname_allowlist`
         (dotted-suffix sinkhole). The unit parity oracle `permits_flow` mirrors
         rvproxy's `policy_flow_reason` and is proven verdict-identical to
         `CanonicalEgress::permits` for every probed proto/ip/port (no longer just
@@ -134,7 +134,9 @@ own internal default).
         residual left (`RvproxyPolicyGaps`) is the byte scans (placeholder-leak +
         undeclared redaction), which ride the transform path, not `[policy]`.
         Pure, no live boot; deletes nothing. (Started as an IP-coarse pre-filter;
-        completed to full L4+DNS once rvproxy #115/#120 landed.)
+        completed to full L4+DNS once rvproxy #115/#119 landed; the
+        `dns_hostname_allowlist` field name matches rvproxy main, which merged the
+        DNS sinkhole as #119.)
   - [ ] **2b — config emission + native launch path.** Wrap the lowered
         `[policy]` in the full rvproxy config (network/api/forward/audit — the
         audit section points the `FlowEvent` JSONL/UDS export at mvm for 2c) and


### PR DESCRIPTION
## Defect fix — DNS sinkhole field-name mismatch

The rvproxy DNS hostname sinkhole shipped via a maintainer PR (rvproxy #119) that named the `[policy]` field **`dns_hostname_allowlist`**. mvm's policy lowering (#964) serialized it as **`dns_allowlist`**.

rvproxy parses its config with `#[serde(default)]`, so the mismatched field would be **silently ignored** once mvm emits a config in 2b — leaving the DNS sinkhole **disabled on the native path**, a latent claim-10 hole with no error. This renames mvm's `RvproxyPolicy` field (and its TOML output) to `dns_hostname_allowlist` to match rvproxy's actual schema.

Caught in review **before 2b wires config emission**, so the field was never actually emitted yet — pure rename, no behavior change.

Also reconciles the Plan 193 WS-2 notes: the DNS sinkhole landed as rvproxy **#119** (the original #120 was closed), and the field name is now correct.

### Tests
`rvproxy_policy` parity + serialization tests updated for the field name; 7 green; nightly fmt + clippy + `check-no-spec-refs` clean.