### PR TITLE
feat(plan-193): WS-2.2c — re-feed rvproxy flow events into the chain-signed audit

### DIFF
--- a/crates/mvm-hostd/src/supervisor/network/mod.rs
+++ b/crates/mvm-hostd/src/supervisor/network/mod.rs
@@ -36,6 +36,8 @@ pub mod packet;
 pub mod pipeline;
 /// Render the full `rvproxy run --config` TOML for a native gateway.
 pub mod rvproxy_config;
+/// Re-feed rvproxy's exported flow events into mvm's chain-signed audit.
+pub mod rvproxy_flow_audit;
 /// Resolve an admitted bundle into a written native rvproxy gateway config.
 pub mod rvproxy_launch;
 /// Lowering of a resolved egress policy into rvproxy's native `[policy]` config

--- a/crates/mvm-hostd/src/supervisor/network/rvproxy_flow_audit.rs
+++ b/crates/mvm-hostd/src/supervisor/network/rvproxy_flow_audit.rs
@@ -1,0 +1,232 @@
+//! Re-feed rvproxy's exported flow events into mvm's chain-signed audit.
+//!
+//! When the gateway runs as a native `rvproxy run --config` subprocess, rvproxy
+//! emits flow lifecycle events to its dataplane-audit export stream (JSONL file
+//! or UDS). Each line is a `DataplaneAuditEvent` tagged by kind; the `flow`
+//! records carry rvproxy's `FlowEvent`. This module parses those records and maps
+//! them into mvm's [`FlowEvent`], which the per-VM `signer_task` chain-signs — so
+//! the claim-10 audit stays mvm's source of truth even though rvproxy is the
+//! event *source*.
+//!
+//! Only `flow` records are consumed; rvproxy's other dataplane-audit records
+//! (`forward-flow` / `guest-egress` / `packet`) are ignored here. In mvm's
+//! deployment the byte scans (placeholder-leak + undeclared redaction) stay in
+//! the splice, so rvproxy only ever emits `opened`, policy-`denied`, and normal
+//! `closed` flow events — which is why the verdict→reason mapping below is total.
+//!
+//! Unlike the splice's coarse per-VM-direction `flow_id` (`<vm>-egress`), the
+//! native path is per-connection: each rvproxy flow carries its 5-tuple, so the
+//! re-emitted `flow_id` is `<vm>-egress-<proto>-<src>-<dst>` (strictly more
+//! granular audit).
+
+use std::io::BufRead;
+use std::net::Ipv4Addr;
+
+use serde::Deserialize;
+
+use crate::supervisor::audit::{FlowCloseReason, FlowDirection};
+use crate::supervisor::gateway_bridge::{FlowEvent, FlowEventKind};
+
+/// rvproxy's exported `FlowEvent` (mirror of
+/// `rvproxy-transport::FlowEvent` / `FlowEndpoints`). mvm consumes rvproxy as a
+/// subprocess and does not depend on its crates, so the wire shape is mirrored
+/// here; the field names and enum spellings match rvproxy's serde exactly.
+#[derive(Debug, Deserialize)]
+struct RvproxyFlowEvent {
+    kind: RvproxyFlowKind,
+    protocol: String,
+    endpoints: RvproxyFlowEndpoints,
+    verdict: RvproxyFlowVerdict,
+    #[serde(default)]
+    #[allow(dead_code)]
+    reason: Option<String>,
+    #[serde(default)]
+    #[allow(dead_code)]
+    bytes_to_remote: u64,
+    #[serde(default)]
+    #[allow(dead_code)]
+    bytes_to_guest: u64,
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "snake_case")]
+enum RvproxyFlowKind {
+    Opened,
+    Closed,
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "snake_case")]
+enum RvproxyFlowVerdict {
+    Allowed,
+    Denied,
+}
+
+#[derive(Debug, Deserialize)]
+struct RvproxyFlowEndpoints {
+    source_ip: Ipv4Addr,
+    source_port: u16,
+    destination_ip: Ipv4Addr,
+    destination_port: u16,
+}
+
+/// Extract the rvproxy `FlowEvent` from one exported dataplane-audit line, or
+/// `None` if the line is not a `flow` record (or is unparseable). The outer
+/// envelope is `{"kind":"<type>","event":{...}}`; only `kind == "flow"` carries
+/// a `FlowEvent`, so other record kinds are skipped without erroring.
+fn parse_flow_record(line: &str) -> Option<RvproxyFlowEvent> {
+    let value: serde_json::Value = serde_json::from_str(line).ok()?;
+    if value.get("kind")?.as_str()? != "flow" {
+        return None;
+    }
+    serde_json::from_value(value.get("event")?.clone()).ok()
+}
+
+/// Map an rvproxy flow event onto mvm's audit [`FlowEvent`]. rvproxy flow events
+/// are guest-egress flows, so the direction is always `Egress`. A `denied`
+/// verdict is a policy drop (claim-10); a normal `closed` flow maps to `Eof`.
+fn to_mvm_flow_event(vm_name: &str, event: &RvproxyFlowEvent) -> FlowEvent {
+    let ep = &event.endpoints;
+    let flow_id = format!(
+        "{vm_name}-egress-{}-{}:{}-{}:{}",
+        event.protocol, ep.source_ip, ep.source_port, ep.destination_ip, ep.destination_port
+    );
+    let kind = match (&event.kind, &event.verdict) {
+        (RvproxyFlowKind::Opened, _) => FlowEventKind::Opened,
+        (RvproxyFlowKind::Closed, RvproxyFlowVerdict::Denied) => FlowEventKind::Closed {
+            reason: FlowCloseReason::PolicyDropped,
+        },
+        (RvproxyFlowKind::Closed, RvproxyFlowVerdict::Allowed) => FlowEventKind::Closed {
+            reason: FlowCloseReason::Eof,
+        },
+    };
+    FlowEvent {
+        flow_id,
+        direction: FlowDirection::Egress,
+        kind,
+    }
+}
+
+/// Read rvproxy's exported dataplane-audit stream line by line, mapping each
+/// `flow` record into an mvm [`FlowEvent`] handed to `sink`. The real caller
+/// passes a sink that forwards into `signer_task`'s mpsc channel (so the events
+/// are chain-signed); `reader` is the JSONL file or UDS connection. Non-flow and
+/// blank/garbage lines are skipped. Returns when the stream ends or on read
+/// error.
+pub fn pump_flow_audit<R: BufRead>(
+    reader: R,
+    vm_name: &str,
+    mut sink: impl FnMut(FlowEvent),
+) -> std::io::Result<()> {
+    for line in reader.lines() {
+        let line = line?;
+        if let Some(event) = parse_flow_record(line.trim()) {
+            sink(to_mvm_flow_event(vm_name, &event));
+        }
+    }
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::sync::{Arc, Mutex};
+
+    fn flow_line(kind: &str, verdict: &str, reason: &str, dst: &str, dport: u16) -> String {
+        format!(
+            r#"{{"kind":"flow","event":{{"kind":"{kind}","protocol":"tcp","endpoints":{{"source_ip":"192.168.127.2","source_port":41000,"destination_ip":"{dst}","destination_port":{dport}}},"verdict":"{verdict}","reason":{reason},"bytes_to_remote":12,"bytes_to_guest":34}}}}"#
+        )
+    }
+
+    #[test]
+    fn parses_opened_flow_record() {
+        let line = flow_line("opened", "allowed", "null", "93.184.216.34", 443);
+        let ev = parse_flow_record(&line).expect("flow record parses");
+        let mapped = to_mvm_flow_event("vm-demo", &ev);
+        assert!(matches!(mapped.kind, FlowEventKind::Opened));
+        assert!(matches!(mapped.direction, FlowDirection::Egress));
+        assert_eq!(
+            mapped.flow_id,
+            "vm-demo-egress-tcp-192.168.127.2:41000-93.184.216.34:443"
+        );
+    }
+
+    #[test]
+    fn denied_close_maps_to_policy_dropped() {
+        let line = flow_line("closed", "denied", "\"deny-by-default\"", "8.8.8.8", 443);
+        let ev = parse_flow_record(&line).unwrap();
+        let mapped = to_mvm_flow_event("vm-demo", &ev);
+        assert!(matches!(
+            mapped.kind,
+            FlowEventKind::Closed {
+                reason: FlowCloseReason::PolicyDropped
+            }
+        ));
+    }
+
+    #[test]
+    fn allowed_close_maps_to_eof() {
+        let line = flow_line("closed", "allowed", "\"guest_fin\"", "93.184.216.34", 443);
+        let ev = parse_flow_record(&line).unwrap();
+        let mapped = to_mvm_flow_event("vm-demo", &ev);
+        assert!(matches!(
+            mapped.kind,
+            FlowEventKind::Closed {
+                reason: FlowCloseReason::Eof
+            }
+        ));
+    }
+
+    #[test]
+    fn non_flow_and_garbage_records_are_skipped() {
+        // Other dataplane-audit record kinds carry a different `event` shape.
+        let guest_egress = r#"{"kind":"guest-egress","event":{"event_type":"allowed","protocol":"tcp","source_ip":"192.168.127.2","source_port":41000,"destination_ip":"8.8.8.8","destination_port":443,"message":null}}"#;
+        let packet = r#"{"kind":"packet","event":{"event_type":"invalid-frame","message":"x"}}"#;
+        assert!(parse_flow_record(guest_egress).is_none());
+        assert!(parse_flow_record(packet).is_none());
+        assert!(parse_flow_record("not json").is_none());
+        assert!(parse_flow_record("").is_none());
+    }
+
+    #[test]
+    fn pump_maps_only_flow_records_in_order() {
+        let stream = [
+            flow_line("opened", "allowed", "null", "93.184.216.34", 443),
+            r#"{"kind":"packet","event":{"event_type":"invalid-frame","message":"x"}}"#.to_string(),
+            String::new(), // blank line
+            flow_line("closed", "denied", "\"l4_allowlist_miss\"", "8.8.8.8", 80),
+            "garbage".to_string(),
+            flow_line(
+                "closed",
+                "allowed",
+                "\"idle_timeout\"",
+                "93.184.216.34",
+                443,
+            ),
+        ]
+        .join("\n");
+
+        let collected = Arc::new(Mutex::new(Vec::new()));
+        let sink_collected = collected.clone();
+        pump_flow_audit(stream.as_bytes(), "vm-demo", move |ev| {
+            sink_collected.lock().unwrap().push(ev);
+        })
+        .unwrap();
+
+        let events = collected.lock().unwrap();
+        assert_eq!(events.len(), 3, "only the 3 flow records map");
+        assert!(matches!(events[0].kind, FlowEventKind::Opened));
+        assert!(matches!(
+            events[1].kind,
+            FlowEventKind::Closed {
+                reason: FlowCloseReason::PolicyDropped
+            }
+        ));
+        assert!(matches!(
+            events[2].kind,
+            FlowEventKind::Closed {
+                reason: FlowCloseReason::Eof
+            }
+        ));
+    }
+}

--- a/specs/plans/193-rvproxy-network-substrate.md
+++ b/specs/plans/193-rvproxy-network-substrate.md
@@ -204,10 +204,20 @@ own internal default).
           needs an egress-attempting fixture (curl an allowed host + a denied
           host, assert the verdicts + flow-audit entries). The last check before
           2d deletes the splice.
-  - [ ] **2c — flow-event sink → audit re-emission.** Subscribe to rvproxy's
-        `FlowEvent` export (needs the rvproxy JSONL/UDS export followup) and
-        re-feed `signer_task`'s chain so the claim-10 audit stays mvm's source of
-        truth.
+  - [x] **2c — flow-event sink → audit re-emission (parser + mapper + pump).**
+        `supervisor::network::rvproxy_flow_audit` parses rvproxy's exported
+        dataplane-audit JSONL/UDS stream, keeps only the `flow` records, and maps
+        each rvproxy `FlowEvent` onto mvm's audit `FlowEvent` (`opened`→`Opened`;
+        `denied` close→`Closed{PolicyDropped}` for claim-10; normal
+        `closed`→`Closed{Eof}`), with a per-connection `flow_id` from the 5-tuple
+        (more granular than the splice's coarse `<vm>-egress`). `pump_flow_audit`
+        runs over any `BufRead` (real source = the JSONL file / `UnixStream`) and
+        hands mapped events to a sink; the production sink forwards into
+        `signer_task`'s mpsc channel so they're chain-signed. Byte-scan kills stay
+        splice-side, so rvproxy only emits opened/denied/normal-closed — the
+        mapping is total. Pure + golden-tested; spawning the reader thread + the
+        sink→channel wiring lands with 2b (the export only flows once rvproxy runs
+        with the emitted config).
   - [ ] **2d — parity-gate extension + splice deletion.** Make the WS-1.5
         witnesses run against the **native** path (binary-discriminating) and
         delete the splice + Plan-141 `on_packet` hooks only once green.


### PR DESCRIPTION
## Plan 193 WS-2.2c — flow-event → audit re-emission

The mvm-side consumer of rvproxy's `FlowEvent` export (rvproxy #113). When the gateway runs as a native `rvproxy run --config` subprocess, rvproxy emits flow lifecycle events to its dataplane-audit JSONL/UDS stream; this re-feeds them into mvm's chain-signed audit so the **claim-10 audit stays mvm's source of truth** while rvproxy is the event *source*.

### What's here
`supervisor::network::rvproxy_flow_audit`:
- Mirrors rvproxy's exported `FlowEvent` wire shape (mvm has no rvproxy crate dep) and extracts only the `flow` records from the `{"kind":…,"event":…}` envelope — other dataplane-audit kinds (`forward-flow`/`guest-egress`/`packet`) are skipped, not errored.
- Maps each onto mvm's audit `FlowEvent`: `opened`→`Opened`; `closed`+`denied`→`Closed{PolicyDropped}` (the claim-10 case); `closed`+`allowed`→`Closed{Eof}`.
- `flow_id` is **per-connection** from the 5-tuple (`<vm>-egress-<proto>-<src>-<dst>`) — strictly more granular than the splice's coarse `<vm>-egress`.
- `pump_flow_audit` runs over any `BufRead` (real source = the JSONL file / `UnixStream`) and hands mapped events to a sink; the production sink forwards into `signer_task`'s mpsc channel.

Byte-scan kills (placeholder-leak + undeclared redaction) stay splice-side in mvm's deployment, so rvproxy only emits opened/denied/normal-closed — the verdict→reason mapping is total.

### Tests
parse opened/denied/allowed; **denied→PolicyDropped (RED-verified)**; allowed→Eof; non-flow + garbage + blank skipped; pump maps only flow records in order. 5 green; nightly fmt + clippy + `check-no-spec-refs` clean. Pure — deletes nothing.

### Scope
Spawning the reader thread + wiring the sink into `signer_task`'s channel lands with **2b** (the export only flows once rvproxy runs with the emitted config). Independent of #980 (the dns-field fix).