### PR TITLE
plan-199 WS-B2: release artifact matrix + fail-closed verification gate

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -466,3 +466,38 @@ jobs:
             --ref "${TAG_NAME}" \
             -f tag="${TAG_NAME}" \
             -f dry_run=false
+
+  # Plan 199 B2: post-publish gate. Download the just-created release and assert
+  # every binary target has a tarball + matching SHA256 + cosign signature bundle
+  # + an entry in the combined checksums manifest, and that the SBOM is signed.
+  # Fail-closed — a release missing a checksum/signature or whose bytes don't
+  # match their recorded hash fails here, surfacing it instead of shipping silently.
+  verify-release:
+    needs: [release]
+    if: ${{ needs.release.result == 'success' }}
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Install cosign
+        uses: sigstore/cosign-installer@v3
+
+      - name: Download published release assets
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          TAG_NAME: ${{ github.ref_name }}
+        run: |
+          mkdir -p release-assets
+          gh release download "${TAG_NAME}" --repo "${GITHUB_REPOSITORY}" --dir release-assets
+
+      - name: Verify release asset set (checksums + signatures + SBOM + version)
+        env:
+          # Keyless GitHub-OIDC signing identity for this workflow's blobs.
+          COSIGN_IDENTITY_REGEXP: "^https://github.com/${{ github.repository }}/.github/workflows/release.yml@refs/tags/.*$"
+          COSIGN_OIDC_ISSUER: "https://token.actions.githubusercontent.com"
+          TAG_NAME: ${{ github.ref_name }}
+        run: |
+          bash packaging/release/verify-release-assets.sh \
+            --assets-dir release-assets \
+            --cosign \
+            --expect-version "${TAG_NAME#v}"

--- a/packaging/release/verify-release-assets.sh
+++ b/packaging/release/verify-release-assets.sh
@@ -1,0 +1,124 @@
+#!/usr/bin/env bash
+# Verify a published mvm release's asset set is complete and self-consistent:
+# every binary target tarball has a SHA256 file that matches, a cosign
+# signature bundle, and an entry in the combined checksums manifest; the
+# signed SBOM is present. Fail-closed — any missing or mismatched asset is a
+# nonzero exit. Run post-publish (release.yml `verify-release` job) against a
+# directory of downloaded release assets, or locally against a staging dir.
+#
+# Usage:
+#   verify-release-assets.sh --assets-dir DIR [--targets "t1 t2 ..."] [--cosign]
+#
+# --targets defaults to the release.yml build matrix. --cosign additionally
+# runs `cosign verify-blob` against each bundle (needs cosign on PATH and the
+# expected OIDC identity in COSIGN_IDENTITY / COSIGN_OIDC_ISSUER).
+set -euo pipefail
+
+ASSETS_DIR=""
+# Keep in lockstep with the release.yml `build` matrix. x86_64-apple-darwin is
+# deferred there (no Intel runner), so it is deliberately absent here too.
+TARGETS="aarch64-apple-darwin x86_64-unknown-linux-gnu aarch64-unknown-linux-gnu"
+DO_COSIGN=0
+EXPECT_VERSION=""
+
+while [ $# -gt 0 ]; do
+  case "$1" in
+    --assets-dir)     ASSETS_DIR="$2"; shift 2 ;;
+    --targets)        TARGETS="$2"; shift 2 ;;
+    --cosign)         DO_COSIGN=1; shift ;;
+    # Assert the packaged binary reports this version. Only the target that
+    # matches the host can be executed; cross-arch targets are skipped (their
+    # `--version` is covered by the build-job smoke test before packaging).
+    --expect-version) EXPECT_VERSION="$2"; shift 2 ;;
+    *) echo "unknown arg: $1" >&2; exit 2 ;;
+  esac
+done
+
+# Which release target, if any, can run on this host?
+host_target() {
+  case "$(uname -s)/$(uname -m)" in
+    Linux/x86_64)          echo "x86_64-unknown-linux-gnu" ;;
+    Linux/aarch64)         echo "aarch64-unknown-linux-gnu" ;;
+    Darwin/arm64)          echo "aarch64-apple-darwin" ;;
+    *)                     echo "" ;;
+  esac
+}
+HOST_TARGET="$(host_target)"
+
+[ -n "$ASSETS_DIR" ] || { echo "error: --assets-dir is required" >&2; exit 2; }
+[ -d "$ASSETS_DIR" ] || { echo "error: assets dir not found: $ASSETS_DIR" >&2; exit 2; }
+
+fail() { echo "::error::$*" >&2; FAILED=1; }
+FAILED=0
+
+# Prefer sha256sum (Linux), fall back to shasum -a 256 (macOS).
+sha256_of() {
+  if command -v sha256sum >/dev/null 2>&1; then sha256sum "$1" | awk '{print $1}';
+  else shasum -a 256 "$1" | awk '{print $1}'; fi
+}
+
+COMBINED="$ASSETS_DIR/checksums-sha256.txt"
+[ -f "$COMBINED" ] || fail "combined checksums manifest missing: checksums-sha256.txt"
+
+for target in $TARGETS; do
+  tarball="$ASSETS_DIR/mvmctl-${target}.tar.gz"
+  sha="$tarball.sha256"
+  bundle="$tarball.bundle"
+
+  [ -f "$tarball" ] || { fail "[$target] tarball missing: $(basename "$tarball")"; continue; }
+  [ -f "$sha" ]     || fail "[$target] checksum file missing: $(basename "$sha")"
+  [ -f "$bundle" ]  || fail "[$target] cosign signature bundle missing: $(basename "$bundle")"
+
+  # The .sha256 file records the SHA over the tarball — recompute and compare.
+  if [ -f "$sha" ]; then
+    want=$(awk '{print $1}' "$sha")
+    got=$(sha256_of "$tarball")
+    [ "$want" = "$got" ] || fail "[$target] sha256 mismatch: recorded=$want actual=$got"
+  fi
+
+  # The combined manifest must cover this tarball (download-path integrity).
+  if [ -f "$COMBINED" ]; then
+    grep -q "mvmctl-${target}.tar.gz" "$COMBINED" \
+      || fail "[$target] not listed in checksums-sha256.txt"
+  fi
+
+  if [ "$DO_COSIGN" = 1 ] && [ -f "$bundle" ]; then
+    command -v cosign >/dev/null 2>&1 || { fail "--cosign given but cosign not on PATH"; continue; }
+    cosign verify-blob --bundle "$bundle" \
+      ${COSIGN_IDENTITY_REGEXP:+--certificate-identity-regexp "$COSIGN_IDENTITY_REGEXP"} \
+      ${COSIGN_IDENTITY:+--certificate-identity "$COSIGN_IDENTITY"} \
+      ${COSIGN_OIDC_ISSUER:+--certificate-oidc-issuer "$COSIGN_OIDC_ISSUER"} \
+      "$tarball" >/dev/null 2>&1 \
+      || fail "[$target] cosign verify-blob failed"
+  fi
+
+  if [ -n "$EXPECT_VERSION" ] && [ "$target" = "$HOST_TARGET" ] && [ -f "$tarball" ]; then
+    tmp=$(mktemp -d)
+    if tar xzf "$tarball" -C "$tmp" 2>/dev/null; then
+      bin="$tmp/mvmctl-${target}/mvmctl"
+      if [ -x "$bin" ]; then
+        ver=$("$bin" --version 2>/dev/null || true)
+        case "$ver" in
+          *"$EXPECT_VERSION"*) : ;;
+          *) fail "[$target] --version mismatch: expected to contain '$EXPECT_VERSION', got '$ver'" ;;
+        esac
+      else
+        fail "[$target] packaged mvmctl binary missing or not executable"
+      fi
+    else
+      fail "[$target] tarball failed to extract"
+    fi
+    rm -rf "$tmp"
+  fi
+done
+
+# The SBOM ships signed alongside the binaries on every release.
+[ -f "$ASSETS_DIR/sbom.cdx.json" ]        || fail "SBOM missing: sbom.cdx.json"
+[ -f "$ASSETS_DIR/sbom.cdx.json.bundle" ] || fail "SBOM signature bundle missing: sbom.cdx.json.bundle"
+
+if [ "$FAILED" = 0 ]; then
+  echo "ok: all $(echo "$TARGETS" | wc -w | tr -d ' ') target(s) have tarball + matching sha256 + signature bundle + manifest entry; SBOM signed."
+else
+  echo "release asset verification FAILED" >&2
+  exit 1
+fi

--- a/specs/notes/plan-199-release-artifact-matrix.md
+++ b/specs/notes/plan-199-release-artifact-matrix.md
@@ -1,0 +1,70 @@
+# Plan 199 Workstream B2 — release artifact matrix + verification
+
+**Date:** 2026-06-16 · **Owner:** mvm · Companion to
+[`plans/199-host-runtime-packaging-and-crate-boundaries.md`](../plans/199-host-runtime-packaging-and-crate-boundaries.md)
+
+The contract for what every `v*` tag publishes (`.github/workflows/release.yml`),
+and the post-publish gate that enforces it
+(`packaging/release/verify-release-assets.sh`, run by the `verify-release` job).
+
+## The matrix
+
+### Binary `mvmctl` (the default user download path — install.sh / `mvmctl update` / Homebrew)
+
+| Target | Arch | OS | Status |
+|---|---|---|---|
+| `aarch64-apple-darwin` | arm64 | macOS | published (product baseline, macOS 26+) |
+| `x86_64-unknown-linux-gnu` | x86_64 | Linux | published |
+| `aarch64-unknown-linux-gnu` | arm64 | Linux | published |
+| `x86_64-apple-darwin` | x86_64 | macOS | **deferred** — needs a native Intel runner (libkrun link); install.sh/Homebrew `on_intel` point at the absent asset |
+
+Per published target: `mvmctl-<target>.tar.gz` + `.tar.gz.sha256` (per-file SHA256)
++ `.tar.gz.bundle` (cosign keyless OIDC signature: signature + Fulcio cert + Rekor
+proof). Plus one combined `checksums-sha256.txt` across all targets, and a signed
+SBOM `sbom.cdx.json` (+ `.bundle`).
+
+### Image artifacts (best-effort — an image-build failure must not block the binary release)
+
+Per arch (`aarch64`, `x86_64`), each with a `*-checksums-sha256.txt`:
+
+- **builder-vm** — `builder-vm-vmlinux-<arch>`, `builder-vm-rootfs-<arch>.ext4`, optional `.cmdline.txt` / `.manifest.json`
+- **runtime-overlay** — `runtime-overlay-<arch>.{ext4,verity,roothash,VERSION}`
+- **default-microvm** (prod variant) — `default-microvm-vmlinux-<arch>`, `default-microvm-rootfs-<arch>.{ext4,verity,roothash}`, `default-microvm-meta-<arch>.json`
+
+Image `*.manifest.json` files are cosign-signed (`.bundle`) per ADR-005 so
+`mvm-security::image_verify` can consume them.
+
+## Provenance
+
+- **Signatures:** cosign keyless via GitHub OIDC (`id-token: write`). Identity =
+  the `release.yml` workflow ref; issuer = `https://token.actions.githubusercontent.com`.
+  No long-lived signing key.
+- **SBOM:** CycloneDX (`cargo cyclonedx`) over the whole workspace, signed.
+- **Reproducibility:** `security.yml` double-builds `mvmctl` and asserts a matching
+  SHA256 across two clean builds (claim 7 / W5.3) — independent of this gate.
+
+## The verification gate (B2 deliverable)
+
+`packaging/release/verify-release-assets.sh --assets-dir DIR` is **fail-closed**:
+for every published target it asserts the tarball, its `.sha256` (and that the
+recorded hash matches the actual bytes), its `.bundle` signature, and an entry in
+the combined `checksums-sha256.txt`; then that the signed SBOM is present. `--cosign`
+additionally runs `cosign verify-blob` against each bundle (identity via
+`COSIGN_IDENTITY_REGEXP`/`COSIGN_IDENTITY` + `COSIGN_OIDC_ISSUER`).
+
+The `verify-release` job in `release.yml` (needs `release`) downloads the just-published
+assets and runs it with `--cosign`, so a release that is missing a checksum, a
+signature, or whose bytes don't match their recorded hash **fails the workflow**.
+
+Self-tested (no tag needed) across happy-path + five tamper cases (bad checksum,
+missing signature, missing tarball, not-in-manifest, missing SBOM signature) — all
+behave as expected.
+
+## Scope notes
+
+- This gate proves the binary download path is **complete, checksummed, and signed**.
+  It deliberately does not re-derive image provenance — image manifests carry their
+  own cosign bundles consumed by `image_verify`.
+- The deferred `x86_64-apple-darwin` target is intentionally absent from the verified
+  set; restore the row here and in the script's default `--targets` when an Intel
+  runner is available.

--- a/specs/plans/199-host-runtime-packaging-and-crate-boundaries.md
+++ b/specs/plans/199-host-runtime-packaging-and-crate-boundaries.md
@@ -69,14 +69,28 @@ The target shape is:
 
 - [x] Document release-binary installation as the primary user path, separate
       from source-checkout Nix builds.
-- [ ] Define the release artifact matrix for Linux and macOS, including
-      architecture, checksums, signatures, and provenance metadata.
-- [ ] Decide whether a Nix expression that installs release binaries is useful
+- [x] Define the release artifact matrix for Linux and macOS, including
+      architecture, checksums, signatures, and provenance metadata. → documented
+      in [`../notes/plan-199-release-artifact-matrix.md`](../notes/plan-199-release-artifact-matrix.md)
+      (3 published binary targets + the deferred Intel-mac row; per-target
+      sha256 + cosign bundle; combined manifest; signed SBOM; per-arch image set).
+- [x] Decide whether a Nix expression that installs release binaries is useful
       for Nix users; if added, keep it separate from the source-built package
-      and mark `binaryNativeCode` provenance explicitly.
-- [ ] Add release verification tests or CI checks proving every published
+      and mark `binaryNativeCode` provenance explicitly. → **Decided: not now.**
+      install.sh + Homebrew + `cargo install` cover binary install; the
+      source-built `packages.<system>.mvmctl` is the Nix path. Revisit only on
+      Nix-user demand; if added it must be a separate `binaryNativeCode`-marked
+      package (WS-B's structural test already guards the source package against
+      release tarballs).
+- [x] Add release verification tests or CI checks proving every published
       archive has a checksum, signature, and matching `mvmctl --version`
-      metadata.
+      metadata. → `packaging/release/verify-release-assets.sh` (fail-closed:
+      per-target tarball + matching sha256 + cosign signature bundle + manifest
+      entry + signed SBOM, with `--cosign` validity check and a host-native
+      `--expect-version` assertion) wired as the `verify-release` job in
+      `release.yml` (needs `release`). Self-tested across happy-path + 6 tamper
+      cases (bad checksum, missing signature, missing tarball, not-in-manifest,
+      missing SBOM sig, version mismatch).
 - [x] Keep install docs clear that package-manager and one-line installs do not
       require host Nix.
 
@@ -102,8 +116,9 @@ The target shape is:
 - [x] `cargo clippy --workspace --all-targets -- -D warnings`
 - [ ] Builder-VM follow-up: `nix flake check --no-build` for `nix/`
 - [ ] Builder-VM follow-up: build `.#mvmctl` on at least one Linux system
-- [ ] Release artifact follow-up: verify signature/checksum metadata for the
-      published binary install path
+- [x] Release artifact follow-up: verify signature/checksum metadata for the
+      published binary install path → `verify-release` job in `release.yml`
+      (implemented + self-tested; executes on the next `v*` tag).
 
 ## Security notes
 


### PR DESCRIPTION
## What

Plan 199 **Workstream B2** (release installation policy). The release pipeline already emits per-target `sha256` + cosign keyless signatures; the missing piece was a **post-publish gate** that proves the published asset set is complete and self-consistent.

- **`packaging/release/verify-release-assets.sh`** — fail-closed verifier. For each published binary target asserts: tarball present, `.sha256` present **and matching the actual bytes**, cosign signature `.bundle` present, and an entry in the combined `checksums-sha256.txt`; then the signed SBOM. `--cosign` runs `cosign verify-blob` (GH-OIDC identity); `--expect-version <v>` extracts the host-native target's binary and asserts `mvmctl --version` matches.
- **`release.yml`** — new `verify-release` job (`needs: release`) downloads the just-published assets and runs the verifier with `--cosign --expect-version <tag>`.
- **`specs/notes/plan-199-release-artifact-matrix.md`** — the matrix contract (3 published targets + deferred Intel-mac row; checksums; cosign provenance; signed SBOM; per-arch image set).

## Verification

The release workflow only runs on `v*` tags, so the verifier is **self-tested** (no tag needed):

| Case | Result |
|---|---|
| happy path | exit 0 ✓ |
| tampered tarball (sha mismatch) | exit 1 ✓ |
| missing signature bundle | exit 1 ✓ |
| missing tarball | exit 1 ✓ |
| not listed in manifest | exit 1 ✓ |
| missing SBOM signature | exit 1 ✓ |
| `--version` mismatch | exit 1 ✓ |

`shellcheck` clean; `release.yml` parses (6 jobs incl. `verify-release`). The `--cosign` verify-blob path uses the GH-OIDC keyless identity and runs for real on the next tag.

## Boxes ticked

B2: matrix defined · Nix release-installer **decided: not now** (install.sh/Homebrew/`cargo` cover it; revisit on demand, must be a separate `binaryNativeCode` package) · verification CI added. Plus the D release-artifact follow-up.

## Notes

- Independent of #984 (WS-C); both branch off `main`. `REFACTOR-STATUS.md` untouched (avoids the in-flight wave-1 #981 conflict); the 199 rollup tick folds in when those land.
- WS-B (native-VMM Nix recipes + the no-release-tarball structural test) is the remaining 199 workstream — separate PR, with the builder-VM "expose after verification" step flagged as gated.