### PR TITLE
plan-199 WS-B: directory-wide host-package release-binary guard

### DIFF
--- a/specs/plans/199-host-runtime-packaging-and-crate-boundaries.md
+++ b/specs/plans/199-host-runtime-packaging-and-crate-boundaries.md
@@ -56,14 +56,40 @@ The target shape is:
 ### B. Native VMM package recipes
 
 - [ ] Add reviewed, source-built Nix recipes for libkrun firmware and the
-      libkrun shared library.
+      libkrun shared library. → **builder-VM-gated** (see note). The recipe
+      *shape* is settled (a `fetchurl`-from-upstream `stdenv.mkDerivation` for
+      `libkrunfw` + `libkrun`, source-built, no prebuilt binary); the blocker is
+      computing the real upstream source hashes + the per-arch build under the
+      approved builder-VM Nix path. Writing them with placeholder hashes is
+      disallowed, so the derivations land once the builder VM can verify them.
 - [ ] Expose the native VMM recipes only after their source pins, kernel source,
       cargo vendor hashes, and platform matrix have been verified in the builder
-      VM.
-- [ ] Wire `mvmctl.override { withNativeLibkrun = true; libkrun = ...; }` as the
-      opt-in native package path once the recipes are verified.
-- [ ] Add a structural test that no mvm host package uses project release
-      tarballs or `binaryNativeCode` provenance.
+      VM. → **builder-VM-gated** (the verification step itself).
+- [~] Wire `mvmctl.override { withNativeLibkrun = true; libkrun = ...; }` as the
+      opt-in native package path once the recipes are verified. → **the override
+      seam already exists** (WS-A: `mvmctl.nix` takes `libkrun ? null` +
+      `withNativeLibkrun ? false`, asserts `withNativeLibkrun -> libkrun != null`,
+      and wires `buildInputs`/`MVM_LIBKRUN_HEADER`/the `*/libkrun-sys` features;
+      guarded by `host_mvmctl_package_keeps_native_vmm_linkage_explicit`). It is
+      consumable the moment the box-1 recipe exists — no further wiring needed,
+      only the verified `libkrun` package to pass in.
+- [x] Add a structural test that no mvm host package uses project release
+      tarballs or `binaryNativeCode` provenance. →
+      `no_host_package_uses_release_binary_provenance` in
+      `tests/nix_flake_structure.rs` scans **every** `nix/packages/*.nix` (not
+      just `mvmctl.nix`) for project-release / `binaryNativeCode` provenance.
+      Deliberately project-release-specific (not a blanket `fetchurl` ban) so the
+      future source-built `libkrun`/`libkrunfw` recipes — which legitimately
+      fetch upstream *source* — stay valid; the strict no-fetch rule remains
+      scoped to `mvmctl.nix`.
+
+> **Builder-VM gate (boxes 1–2).** The libkrun/libkrunfw source recipes need
+> real upstream source hashes + a per-arch source build, both of which must be
+> produced and verified through the approved builder-VM Nix path (host Nix is
+> never used by mvmctl). They are intentionally *not* committed with placeholder
+> hashes. Tracked here as the remaining native-VMM-recipe work; the consuming
+> override seam (box 3) and the directory-wide guard (box 4) are already in
+> place, so the recipes drop in without further host-package changes.
 
 ### B2. Release installation policy
 

--- a/tests/nix_flake_structure.rs
+++ b/tests/nix_flake_structure.rs
@@ -603,3 +603,55 @@ fn flake_lock_pins_microvm_input_by_hash() {
         "flake.lock must pin inputs by `rev` (commit hash)"
     );
 }
+
+/// Plan 199 WS-B — the no-release-binary contract (ADR-046) must hold for
+/// *every* host package under `nix/packages/`, not just `mvmctl.nix`. A new
+/// sidecar package that pulled a project release tarball or carried
+/// `binaryNativeCode` provenance would silently bypass the source-build
+/// guarantee. This scans the whole directory (so adding such a package fails
+/// CI immediately) rather than naming files.
+///
+/// Note the forbidden set is deliberately *project-release-specific*: a host
+/// package may legitimately `fetchurl` its own **upstream source** (the future
+/// source-built `libkrun` / `libkrunfw` recipes do exactly this — Plan 199 WS-B
+/// native-VMM recipes). Source-building from a pinned upstream tarball is the
+/// contract; pulling an mvm-published release binary or shipping prebuilt
+/// native code is what's banned. The stricter "no fetch at all" rule stays
+/// scoped to `mvmctl.nix` (which builds purely from `mvmSrc`).
+#[test]
+fn no_host_package_uses_release_binary_provenance() {
+    let dir = nix_dir().join("packages");
+    // Project-release / prebuilt-binary provenance — never source.
+    let forbidden = [
+        "releases/download",
+        "github.com/tinylabscom/mvm/releases",
+        "tinylabscom/mvm/releases",
+        "binaryNativeCode",
+    ];
+    let mut scanned = 0usize;
+    for entry in
+        fs::read_dir(&dir).unwrap_or_else(|e| panic!("nix/packages/ must be present: {e}"))
+    {
+        let path = entry.expect("readable dir entry").path();
+        if path.extension().and_then(|s| s.to_str()) != Some("nix") {
+            continue;
+        }
+        let content = fs::read_to_string(&path)
+            .unwrap_or_else(|e| panic!("reading {}: {e}", path.display()));
+        let name = path.file_name().unwrap().to_string_lossy();
+        for needle in forbidden {
+            assert!(
+                !content.contains(needle),
+                "host package nix/packages/{name} must not use {needle:?} — host \
+                 packages are source-built, never mvm-published release binaries \
+                 (ADR-046 / Plan 199 WS-B)"
+            );
+        }
+        scanned += 1;
+    }
+    // Guard against the scan silently matching nothing (wrong dir / glob drift).
+    assert!(
+        scanned >= 5,
+        "expected to scan every nix/packages/*.nix host package; only saw {scanned}"
+    );
+}

--- a/tests/nix_flake_structure.rs
+++ b/tests/nix_flake_structure.rs
@@ -629,15 +629,14 @@ fn no_host_package_uses_release_binary_provenance() {
         "binaryNativeCode",
     ];
     let mut scanned = 0usize;
-    for entry in
-        fs::read_dir(&dir).unwrap_or_else(|e| panic!("nix/packages/ must be present: {e}"))
+    for entry in fs::read_dir(&dir).unwrap_or_else(|e| panic!("nix/packages/ must be present: {e}"))
     {
         let path = entry.expect("readable dir entry").path();
         if path.extension().and_then(|s| s.to_str()) != Some("nix") {
             continue;
         }
-        let content = fs::read_to_string(&path)
-            .unwrap_or_else(|e| panic!("reading {}: {e}", path.display()));
+        let content =
+            fs::read_to_string(&path).unwrap_or_else(|e| panic!("reading {}: {e}", path.display()));
         let name = path.file_name().unwrap().to_string_lossy();
         for needle in forbidden {
             assert!(


### PR DESCRIPTION
## What

Plan 199 **Workstream B** (native VMM package recipes), completable slice.

WS-A already shipped (and the rollup under-credited) two of WS-B's pieces: the `mvmctl.nix` **override seam** (`libkrun ? null` + `withNativeLibkrun ? false` + `assert withNativeLibkrun -> libkrun != null` + `buildInputs`/`MVM_LIBKRUN_HEADER`/`*/libkrun-sys` wiring) and a no-release-binary test — but that test only covered `mvmctl.nix`. WS-B's box is "**no mvm host package**".

- **`no_host_package_uses_release_binary_provenance`** (`tests/nix_flake_structure.rs`) scans **every** `nix/packages/*.nix` so a new sidecar that pulls a project release tarball or carries `binaryNativeCode` provenance fails CI immediately.

## The careful bit

The forbidden set is **project-release-specific** (`releases/download`, our release URL, `binaryNativeCode`) — deliberately **not** a blanket `fetchurl` ban. The future source-built `libkrun`/`libkrunfw` recipes will legitimately `fetchurl` their *upstream source* (source-building is the contract; pulling an mvm-published binary is what's banned). The strict no-fetch-at-all rule stays scoped to `mvmctl.nix` (which builds purely from `mvmSrc`).

## Boxes

| WS-B box | State |
|---|---|
| structural test (no host pkg uses release binaries) | ✅ done (this PR) |
| `mvmctl.override { withNativeLibkrun; libkrun }` seam | already present (WS-A); consumable once the recipe exists |
| source-built `libkrun`/`libkrunfw` recipes | 🔒 **builder-VM-gated** — recipe shape settled, but real upstream hashes + per-arch build must be verified through the builder VM, not committed with placeholder hashes |
| expose recipes after builder-VM verification | 🔒 builder-VM-gated (the verification itself) |

## Verification

`cargo test --test nix_flake_structure` → **16 passed / 0 failed**.

## Notes

- Independent of #984 (WS-C) / #988 (WS-B2); all off `main`. `REFACTOR-STATUS.md` untouched (avoids the in-flight wave-1 #981 conflict).
- This closes out 199's in-repo-completable surface; the remaining native-VMM recipes need a builder-VM run (flagged in the plan, not faked).