### PR TITLE
feat(plan-193): WS-2.2b — emit the full rvproxy run --config TOML

### DIFF
--- a/crates/mvm-hostd/src/supervisor/network/mod.rs
+++ b/crates/mvm-hostd/src/supervisor/network/mod.rs
@@ -34,6 +34,8 @@ pub mod flow_byte_log;
 pub mod latency;
 pub mod packet;
 pub mod pipeline;
+/// Render the full `rvproxy run --config` TOML for a native gateway.
+pub mod rvproxy_config;
 /// Lowering of a resolved egress policy into rvproxy's native `[policy]` config
 /// (claim-10 enforcement onto the rvproxy substrate).
 pub mod rvproxy_policy;

--- a/crates/mvm-hostd/src/supervisor/network/rvproxy_config.rs
+++ b/crates/mvm-hostd/src/supervisor/network/rvproxy_config.rs
@@ -1,0 +1,251 @@
+//! Render the full `rvproxy run --config` TOML for a native gateway.
+//!
+//! Wraps the lowered `[policy]` table ([`super::rvproxy_policy`]) in the rest of
+//! the rvproxy config the dataplane needs — the same shape rvproxy's own
+//! gvproxy-compat mode builds (`BackendKind::Vfkit` + `TransportKind::Vfkit` over
+//! the unixgram socket libkrun connects to, gateway DNS on), plus the `[audit]`
+//! section pointing rvproxy's flow-event export at the JSONL file mvm tails (the
+//! source for [`super::rvproxy_flow_audit`]).
+//!
+//! mvm has no rvproxy crate dependency, so the TOML is emitted from mvm-side
+//! structs whose field names/spellings match rvproxy's serde exactly. Schema
+//! fidelity is validated end-to-end against the real `rvproxy` binary in the
+//! parity gate (the emitted config is parsed + `RvproxyConfig::validate()`d);
+//! these unit tests cover the structure mvm controls.
+
+use std::net::Ipv4Addr;
+use std::path::Path;
+
+use mvm_core::policy::projection::CanonicalEgress;
+use serde::Serialize;
+
+use super::rvproxy_policy::{RvproxyPolicy, lower_policy};
+
+/// The dev-network constants mvm's bridge uses (and rvproxy's `single_vm`
+/// defaults match): guest `192.168.127.2`, gateway `192.168.127.1`, /24, 1500.
+const DEV_CIDR: &str = "192.168.127.0/24";
+const DEV_GATEWAY_IP: Ipv4Addr = Ipv4Addr::new(192, 168, 127, 1);
+const DEV_GUEST_IP: Ipv4Addr = Ipv4Addr::new(192, 168, 127, 2);
+const DEV_MTU: u16 = 1500;
+
+/// Per-VM inputs for a native rvproxy gateway config.
+pub struct RvproxyConfigParams<'a> {
+    /// Stable id for the rvproxy instance (per-VM).
+    pub id: &'a str,
+    /// Unixgram socket libkrun connects to (the vfkit transport listen path).
+    pub transport_socket: &'a Path,
+    /// rvproxy's local control API socket.
+    pub api_socket: &'a Path,
+    /// JSONL file rvproxy exports flow events to; mvm tails it (2c).
+    pub flow_audit_path: &'a Path,
+    /// The resolved egress projection to enforce.
+    pub egress: &'a CanonicalEgress,
+    /// DNS hostname allow-list (dotted-suffix); empty = no hostname restriction.
+    pub dns_allow: &'a [String],
+    /// Upstream DNS resolvers the gateway forwards allowed lookups to.
+    pub upstream_resolvers: &'a [Ipv4Addr],
+}
+
+/// Render the complete rvproxy config TOML for `params`.
+pub fn render_rvproxy_config(params: &RvproxyConfigParams<'_>) -> Result<String, toml::ser::Error> {
+    let doc = RvproxyConfigDoc {
+        id: params.id.to_string(),
+        mode: "single-vm",
+        network: NetworkSection {
+            cidr: DEV_CIDR.to_string(),
+            gateway_ip: DEV_GATEWAY_IP.to_string(),
+            guest_ip: DEV_GUEST_IP.to_string(),
+            mtu: DEV_MTU,
+        },
+        backend: KindSection { kind: "vfkit" },
+        transport: TransportSection {
+            kind: "vfkit",
+            path: params.transport_socket.display().to_string(),
+        },
+        api: ApiSection {
+            listen: format!("unix:{}", params.api_socket.display()),
+        },
+        dns: DnsSection {
+            enabled: true,
+            upstream_resolvers: params
+                .upstream_resolvers
+                .iter()
+                .map(|ip| ip.to_string())
+                .collect(),
+        },
+        audit: AuditSection {
+            dataplane_audit_jsonl_path: params.flow_audit_path.display().to_string(),
+        },
+        // `policy` is the last field so its `[[policy.l4_allowlist]]`
+        // array-of-tables is the final thing in the document (TOML requires an
+        // array-of-tables to follow every scalar/inline value at its level).
+        policy: lower_policy(params.egress, params.dns_allow).policy,
+    };
+    toml::to_string(&doc)
+}
+
+#[derive(Serialize)]
+struct RvproxyConfigDoc {
+    id: String,
+    mode: &'static str,
+    network: NetworkSection,
+    backend: KindSection,
+    transport: TransportSection,
+    api: ApiSection,
+    dns: DnsSection,
+    audit: AuditSection,
+    policy: RvproxyPolicy,
+}
+
+#[derive(Serialize)]
+struct NetworkSection {
+    cidr: String,
+    gateway_ip: String,
+    guest_ip: String,
+    mtu: u16,
+}
+
+#[derive(Serialize)]
+struct KindSection {
+    kind: &'static str,
+}
+
+#[derive(Serialize)]
+struct TransportSection {
+    kind: &'static str,
+    path: String,
+}
+
+#[derive(Serialize)]
+struct ApiSection {
+    listen: String,
+}
+
+#[derive(Serialize)]
+struct DnsSection {
+    enabled: bool,
+    // rvproxy's `DnsConfig` renames this field to `upstream` in TOML; emitting
+    // `upstream_resolvers` would be silently ignored (no deny_unknown_fields) and
+    // fail validation with "no upstream resolver".
+    #[serde(rename = "upstream")]
+    upstream_resolvers: Vec<String>,
+}
+
+#[derive(Serialize)]
+struct AuditSection {
+    dataplane_audit_jsonl_path: String,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use mvm_core::policy::projection::{CanonicalRule, Proto};
+    use std::path::PathBuf;
+
+    fn params<'a>(
+        egress: &'a CanonicalEgress,
+        dns_allow: &'a [String],
+        resolvers: &'a [Ipv4Addr],
+        sockets: &'a (PathBuf, PathBuf, PathBuf),
+    ) -> RvproxyConfigParams<'a> {
+        RvproxyConfigParams {
+            id: "vm-demo",
+            transport_socket: &sockets.0,
+            api_socket: &sockets.1,
+            flow_audit_path: &sockets.2,
+            egress,
+            dns_allow,
+            upstream_resolvers: resolvers,
+        }
+    }
+
+    fn sockets() -> (PathBuf, PathBuf, PathBuf) {
+        (
+            PathBuf::from("/run/mvm/vm-demo/gateway.sock"),
+            PathBuf::from("/run/mvm/vm-demo/rvproxy.sock"),
+            PathBuf::from("/run/mvm/vm-demo/flow-audit.jsonl"),
+        )
+    }
+
+    #[test]
+    fn renders_the_required_sections_for_a_deny_by_default_policy() {
+        let egress = CanonicalEgress::Rules(vec![CanonicalRule {
+            proto: Proto::Tcp,
+            net: "93.184.216.0/24".parse().unwrap(),
+            port_lo: 443,
+            port_hi: 443,
+        }]);
+        let resolvers = [Ipv4Addr::new(1, 1, 1, 1), Ipv4Addr::new(8, 8, 8, 8)];
+        let sk = sockets();
+        let toml = render_rvproxy_config(&params(
+            &egress,
+            &["example.com".to_string()],
+            &resolvers,
+            &sk,
+        ))
+        .unwrap();
+
+        // Identity + transport (the proven vfkit/unixgram path).
+        assert!(toml.contains("id = \"vm-demo\""));
+        assert!(toml.contains("mode = \"single-vm\""));
+        assert!(toml.contains("[network]"));
+        assert!(toml.contains("cidr = \"192.168.127.0/24\""));
+        assert!(toml.contains("[backend]\nkind = \"vfkit\""));
+        assert!(toml.contains("[transport]"));
+        assert!(toml.contains("kind = \"vfkit\""));
+        assert!(toml.contains("path = \"/run/mvm/vm-demo/gateway.sock\""));
+        assert!(toml.contains("listen = \"unix:/run/mvm/vm-demo/rvproxy.sock\""));
+        // DNS forwarding + flow-event export (2c reads this file).
+        assert!(toml.contains("[dns]"));
+        assert!(toml.contains("upstream = [\"1.1.1.1\", \"8.8.8.8\"]"));
+        assert!(
+            toml.contains("dataplane_audit_jsonl_path = \"/run/mvm/vm-demo/flow-audit.jsonl\"")
+        );
+        // Policy: transport switches on, deny-by-default, L4 + DNS rules.
+        assert!(toml.contains("allow_transport_ingress = true"));
+        assert!(toml.contains("allow_transport_egress = true"));
+        assert!(toml.contains("default_egress_deny = true"));
+        assert!(toml.contains("dns_hostname_allowlist = [\"example.com\"]"));
+        assert!(toml.contains("[[policy.l4_allowlist]]"));
+        assert!(toml.contains("protocol = \"tcp\""));
+        assert!(toml.contains("port_lo = 443"));
+    }
+
+    #[test]
+    fn unrestricted_policy_is_allow_unless_denied() {
+        let egress = CanonicalEgress::Unrestricted;
+        let resolvers = [Ipv4Addr::new(1, 1, 1, 1)];
+        let sk = sockets();
+        let toml = render_rvproxy_config(&params(&egress, &[], &resolvers, &sk)).unwrap();
+        assert!(toml.contains("default_egress_deny = false"));
+        // Mandatory-deny denylist is always present.
+        assert!(toml.contains("169.254.169.254/32"));
+        // No L4 allow-list for the open posture.
+        assert!(!toml.contains("[[policy.l4_allowlist]]"));
+    }
+
+    /// Print a sample config so it can be fed to the real `rvproxy` binary for
+    /// schema-fidelity validation (`cargo test -- --nocapture --ignored`).
+    #[test]
+    #[ignore]
+    fn print_sample_config_for_rvproxy_validation() {
+        let egress = CanonicalEgress::Rules(vec![CanonicalRule {
+            proto: Proto::Tcp,
+            net: "93.184.216.0/24".parse().unwrap(),
+            port_lo: 443,
+            port_hi: 443,
+        }]);
+        let resolvers = [Ipv4Addr::new(1, 1, 1, 1), Ipv4Addr::new(8, 8, 8, 8)];
+        let sk = sockets();
+        print!(
+            "{}",
+            render_rvproxy_config(&params(
+                &egress,
+                &["example.com".to_string()],
+                &resolvers,
+                &sk
+            ))
+            .unwrap()
+        );
+    }
+}

--- a/crates/mvm-hostd/src/supervisor/network/rvproxy_policy.rs
+++ b/crates/mvm-hostd/src/supervisor/network/rvproxy_policy.rs
@@ -35,10 +35,20 @@ use std::net::IpAddr;
 /// config rvproxy reads.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize)]
 pub struct RvproxyPolicy {
+    /// Allow the guest's L2 frames into the gateway. rvproxy defaults this to
+    /// `false`, so the emitted `[policy]` must set it true or the dataplane drops
+    /// every ingress frame.
+    pub allow_transport_ingress: bool,
+    /// Allow the gateway's frames back out to the guest. Same false default.
+    pub allow_transport_egress: bool,
     /// Master egress switch. Always true here; the deny decision is expressed
     /// through `default_egress_deny` + the allow/deny lists so a single oracle
     /// ([`Self::permits_flow`]) governs the verdict.
     pub allow_guest_egress: bool,
+    /// Answer guest lookups at the gateway DNS (gateway name + static zones).
+    pub allow_dns_local: bool,
+    /// Forward non-local lookups upstream — refined by `dns_hostname_allowlist`.
+    pub allow_dns_upstream: bool,
     /// Deny a destination matching no allow rule (claim-10 deny-by-default).
     pub default_egress_deny: bool,
     /// IP-only destination allow-list. Unused by the precise lowering (L4 grants
@@ -167,7 +177,11 @@ pub fn lower_policy(egress: &CanonicalEgress, dns_allow: &[String]) -> RvproxyLo
 
     RvproxyLowering {
         policy: RvproxyPolicy {
+            allow_transport_ingress: true,
+            allow_transport_egress: true,
             allow_guest_egress: true,
+            allow_dns_local: true,
+            allow_dns_upstream: true,
             default_egress_deny,
             cidr_allowlist: Vec::new(),
             cidr_denylist,

--- a/specs/plans/193-rvproxy-network-substrate.md
+++ b/specs/plans/193-rvproxy-network-substrate.md
@@ -143,6 +143,21 @@ own internal default).
         launch `rvproxy run --config` behind a flag, keeping the splice. Real
         config-parse validation lands here via the parity gate (the emitted TOML
         is fed to the actual rvproxy binary). (Overlaps WS-3.)
+    - [x] **config emission.** `render_rvproxy_config` emits the complete
+          single-vm config (id/mode/network/backend/transport/api/dns/audit +
+          the lowered `[policy]`) over mvm-side `Serialize` structs — no rvproxy
+          crate dep. Transport is the proven `BackendKind::Vfkit` +
+          `TransportKind::Vfkit` unixgram pair (same shape rvproxy's gvproxy-compat
+          mode builds), so `run --config` reaches WS-1's validated boot path. The
+          emitted TOML is parsed + `RvproxyConfig::validate()`d against the real
+          rvproxy binary (off-tree); that caught a silent schema-fidelity hole —
+          `DnsConfig` renames its resolvers field to `upstream`, so emitting
+          `upstream_resolvers` was dropped to empty and failed validation. Also
+          set the four `[policy]` toggles rvproxy defaults to `false`
+          (`allow_transport_{ingress,egress}`, `allow_dns_{local,upstream}`) or
+          the dataplane drops every frame.
+    - [ ] **native launch.** Rewire the gvproxy spawn to `rvproxy run --config`
+          behind a flag (keeping the splice) + a live `dev up`-through-rvproxy boot.
   - [ ] **2c — flow-event sink → audit re-emission.** Subscribe to rvproxy's
         `FlowEvent` export (needs the rvproxy JSONL/UDS export followup) and
         re-feed `signer_task`'s chain so the claim-10 audit stays mvm's source of


### PR DESCRIPTION
## What

WS-2.2b config-emission half: `render_rvproxy_config` produces the complete `rvproxy run --config` TOML for a per-VM native gateway — `id`/`mode`/`network`/`backend`/`transport`/`api`/`dns`/`audit` wrapped around the lowered `[policy]` table from WS-2.2a (`lower_policy`).

mvm keeps **zero rvproxy crate deps** — the TOML is emitted from mvm-side `Serialize` structs whose field names match rvproxy's serde exactly.

## Why this shape

- **Transport** is the `BackendKind::Vfkit` + `TransportKind::Vfkit` unixgram pair — the same shape rvproxy's gvproxy-compat mode builds — so `run --config` reaches the boot path WS-1 already proved.
- **`[audit]`** points rvproxy's `FlowEvent` JSONL export at the file mvm tails in WS-2.2c (#985).
- **`[policy]`** now also sets the four toggles rvproxy defaults to `false` (`allow_transport_{ingress,egress}`, `allow_dns_{local,upstream}`) — without them the dataplane drops every frame.

## Validation

The emitted TOML is parsed + `RvproxyConfig::validate()`d against the **real rvproxy binary** (off-tree throwaway test). That caught a silent schema-fidelity hole unit tests alone could not: `DnsConfig` renames its resolvers field to `upstream`, so emitting `upstream_resolvers` was dropped to empty and failed validation with "no upstream resolver". Fixed via `#[serde(rename = "upstream")]`.

## Scope

Config emission only. The native-launch half (rewire the gvproxy spawn to `rvproxy run --config` behind a flag + a live `dev up`-through-rvproxy boot) is the remaining WS-2.2b item and lands separately once it's boot-validated.

## Tests

`cargo test -p mvm-hostd --lib supervisor::network::rvproxy` — 9 green. fmt + clippy + `check-no-spec-refs-in-comments` clean.