### PR TITLE
docs(adr-084): single host-agent daemon + signer helper; tenant boundaries

### DIFF
--- a/specs/adrs/084-host-services-daemon-not-per-vm-spawn.md
+++ b/specs/adrs/084-host-services-daemon-not-per-vm-spawn.md
@@ -22,23 +22,27 @@ The moat that the two-process split exists to provide is real and must survive: 
 
 ## Decision
 
-Host services run as **two long-lived daemons, scoped per tenant**, that VMs **register with** at boot and **deregister from** at teardown. There is no per-VM fork.
+Host services run as a **single host-agent daemon plus a supervised signer helper, scoped per tenant**. VMs **register with** the daemon at boot and **deregister** at teardown. There is no per-VM fork.
 
-- **`mvm-broker` daemon (per tenant)** — guest-facing dispatch. Holds no keys. Owns a control socket; binds each registered VM's `BROKER_PORT` socket dynamically and demultiplexes accepted connections to a `vm_id` by *which socket accepted them*. Enforces the admitted plan's `services` bindings (claim 12) and the per-workload rate limit, both keyed by `vm_id`.
-- **`mvm-audit-signer` daemon (per tenant)** — holds the tenant signing key and is the single writer to every per-VM workload chain (`<tenant>.<vm>.workload.jsonl`), one in-memory chain head per `vm_id`. The broker forwards each accepted entry tagged with a **server-derived** `vm_id` (never guest-supplied) for the signer to route and stamp `category: workload_audit`.
+- **Host-agent daemon (per tenant)** — the one process a user runs (`mvmctl` is a thin client to it). **Keyless.** Owns VM lifecycle, admission orchestration, and **broker dispatch**: a control socket for register/deregister, dynamic binding of each registered VM's `BROKER_PORT` socket, demultiplexing accepted connections to a `vm_id` by *which socket accepted them*, and enforcement of the admitted plan's `services` bindings (claim 12) + the per-workload rate limit, both keyed by `vm_id`. It parses untrusted guest frames but holds no signing key.
+- **Signer helper (per tenant)** — the **one separate address space**. Holds *all* of the tenant's signing keys (admission plan-signing **and** audit-chain signing) and is the single writer to every per-VM workload chain (`<tenant>.<vm>.workload.jsonl`), one in-memory chain head per `vm_id`. The host agent forwards each sign request — a plan to admit, or an accepted audit entry tagged with a **server-derived** `vm_id` (never guest-supplied) — for the helper to sign/route and stamp `category: workload_audit`. The host agent never holds a key, which is why one helper suffices.
 
-Per tenant, that is **two** processes regardless of VM count. Per host it is `O(active tenants)`, never `O(VMs)`.
+Per tenant, that is **two processes regardless of VM count** — a user's many microVMs are *registrations* in the one daemon, not processes. Per host it is `O(active tenants)`, never `O(VMs)`. The helper is a privilege-separated child supervised by the host agent (the sshd model): the user runs and manages **one daemon**; the helper is invisible to them.
 
 VM lifecycle becomes registration:
 
-- **start** → `ensure_daemons(tenant)` (lazy, idempotent; warm after the first VM) → `Register { vm_id, broker_listen_socket, services_bindings, workload_chain_path }`. The supervisor splices the guest's `connect_host_vsock(BROKER_PORT)` to `broker_listen_socket` exactly as today — the backend-specific path is unchanged.
-- **stop** → `Deregister { vm_id }` → the broker unbinds and drops that VM's socket; the signer flushes and closes that VM's chain head.
+- **start** → `ensure_daemon(tenant)` (lazy, idempotent; warm after the first VM) → `Register { vm_id, broker_listen_socket, services_bindings, workload_chain_path }`. The per-VM supervisor splices the guest's `connect_host_vsock(BROKER_PORT)` to `broker_listen_socket` exactly as today — the backend-specific path is unchanged.
+- **stop** → `Deregister { vm_id }` → the daemon unbinds and drops that VM's socket; the helper flushes and closes that VM's chain head.
 
-Registration is driven by the **admitted plan**, not by `MVM_GATEWAY_BRIDGE`. A plan that binds no host services registers nothing and spawns nothing — same zero-process outcome as today, but for the right reason. `host.audit.v1` is implicitly available to any admitted workload (emitting to your own chain is a low-risk, broadly useful capability); the catalog services (`time`, `cost`, secrets, future addons) require an explicit `ExecutionPlan.services` binding and are dispatch-gated on it.
+Registration is driven by the **admitted plan**, not by `MVM_GATEWAY_BRIDGE`. A plan that binds no host services registers nothing — same zero-process outcome as today, but for the right reason. `host.audit.v1` is implicitly available to any admitted workload (emitting to your own chain is a low-risk, broadly useful capability); the catalog services (`time`, `cost`, secrets, future addons) require an explicit `ExecutionPlan.services` binding and are dispatch-gated on it.
+
+### mvm and mvmd are one design
+
+`mvm` without `mvmd` is a **single tenant** running many microVMs: one host-agent daemon + one signer helper, fixed, for the whole install — its VMs are registrations, not processes. `mvmd` is the **coordinator** that replicates that unit — one (host-agent + helper) per active tenant — and adds fleet orchestration, density, and cross-VM/cross-tenant arbitration. `mvmd` does not reimplement the daemon; it conducts per-tenant instances. Local `mvm` is therefore the literal single-tenant degenerate case of the fleet design: **mvm-daemon ⊂ mvmd**. Tenant separation under `mvmd` is detailed in [Tenant boundaries](#tenant-boundaries).
 
 ### Scope: per tenant
 
-The broker holds no secrets, so a single host-wide broker handling every tenant would be functionally sufficient. We reject it for **defense in depth**: a parsing bug in a daemon that eats untrusted guest input must not be a cross-tenant confidentiality boundary, and the audit-signer holds a tenant-scoped signing key that must not be reachable from another tenant's traffic. One daemon pair per tenant makes the process boundary the tenant boundary. For local `mvm` that is one tenant (`local`) and therefore one pair; for `mvmd` it is one pair per *active* tenant on the host — bounded by tenancy, not by fan-out.
+The host agent holds no secrets, so a single host-wide agent serving every tenant would be functionally sufficient. We reject it for **defense in depth** (detailed under [Tenant boundaries](#tenant-boundaries)): a parsing bug in a daemon that eats untrusted guest input must not be a cross-tenant boundary, and each tenant's signer helper holds that tenant's keys, which must not be reachable from another tenant's traffic. One (host-agent + helper) per tenant makes the process boundary the tenant boundary — one tenant for local `mvm`, one per *active* tenant for `mvmd`, bounded by tenancy not by fan-out.
 
 ## Architecture
 
@@ -58,15 +62,28 @@ A resident per-tenant daemon has a larger blast radius than a per-VM child: its 
 - Chain integrity survives restart: each per-VM head already persists out of band (the secondary head file), so the signer rebuilds heads from disk + the live registration set rather than forking the chain. A restart re-binds sockets for the still-registered VMs from the journal.
 - This is the ordinary resident-daemon bargain (nix-daemon, containerd) and is the correct trade for `O(tenants)` instead of `O(VMs)` processes.
 
-### Why not fold the broker into the supervisor
+### Where broker dispatch lives — the host agent, not the VMM
 
-Considered: drop the broker process entirely, handle `BROKER_PORT` inline in the per-VM supervisor (which already parses guest vsock I/O), keep only the shared signer. Rejected: the supervisor is the VMM — already the largest, most-exposed TCB — and widening it with host-service dispatch is the wrong direction. Dispatch stays in a separate, keyless, *shared* daemon.
+Broker dispatch folds into the **host-agent daemon** (a host-side control process), not into the per-VM supervisor. Folding it into the supervisor was rejected: the supervisor is the VMM — already the largest, most-exposed TCB — and widening it with host-service dispatch is the wrong direction. The host agent is a separate host-side daemon, so it carries dispatch without touching the VMM's TCB; it stays keyless, with the signer helper as the only key-holding address space.
+
+## Tenant boundaries
+
+`mvmd` separates tenants in layers, strongest first. The host-services daemon model is defense in depth on top of the VM boundary, not the primary isolation.
+
+1. **Hypervisor + jailer, per microVM — primary.** Each workload is its own guest (Firecracker + jailer on the fleet path) with its own kernel, seccomp, cgroups, and namespaces. ADR-002 holds: one guest = one tenant's workload; multi-tenant *inside* a guest is out of scope. Two tenants' VMs are isolated because they are separate jailed VMs — full stop.
+2. **Host services — separation by replication.** `mvmd` runs one (host-agent daemon + signer helper) per tenant, so there is no shared mutable host-services state across tenants: separate **process** (a parser bug or crash in one tenant's daemon can't reach another's), separate **key** (each helper holds only its tenant's signing keys — it cannot sign as another tenant, and compromising it yields nothing of another's), separate **audit** (a tenant's chains are written only by its helper, signed by its key, verified against its pubkey). Within a tenant, cross-VM is blocked by the server-derived `vm_id`; a VM reaches only its own tenant's daemon because that daemon is the only one that binds its socket.
+3. **`mvmd` is the cross-tenant arbiter — and in the TCB.** It assigns VMs to tenants, scopes each tenant's network/egress policy, and arbitrates cross-VM/cross-tenant requests under tenant-scoped authz. The orchestration-layer tenant boundary is exactly as strong as `mvmd`'s authz — `mvmd`'s to harden.
+
+Two constraints make this real:
+
+- **Per-tenant keys are required, not optional.** The key/audit boundaries mean nothing if tenants share one host key; each tenant's helper holds that tenant's signing key(s). Local single-tenant `mvm` is the degenerate case (one key, one helper).
+- **The trust root is the host.** All tenants share one host and one hypervisor; a VM escape or host compromise defeats tenant isolation (ADR-002 trusts the hypervisor and puts a malicious host out of scope). Daemon-set replication contains *host-services-layer* faults to a tenant — it does not change the trust root.
 
 ## Security model
 
 The claim-12 (binding-gated dispatch) and claim-13 (no raw secret over the broker channel) properties are **preserved unchanged** — this ADR moves *where the two roles live*, not *what they may do*:
 
-- Two address spaces still separate the untrusted-input parser (broker, keyless) from the key holder (signer). `2` per tenant instead of `2N`.
+- Two address spaces still separate the untrusted-input parser (the keyless host-agent daemon, which does broker dispatch) from the key holder (the signer helper). `2` per tenant instead of `2N`.
 - `vm_id` and `correlation_id` remain server-authoritative — a guest cannot forge cross-VM identity, and the per-tenant process boundary blocks cross-tenant reach.
 - The rate limit and the 4 KiB record cap stay host-side, now keyed by `vm_id` in the daemon's per-VM state.
 - The signing key path stays pinned under the host key dir (the claim-8 trust boundary); the daemon model does not relax it.
@@ -99,7 +116,7 @@ The guest-facing wire (`ServiceCall` over `AuthenticatedFrame` on `BROKER_PORT`)
 
 ## Migration
 
-Phased in [Plan 202](../plans/202-host-services-daemon.md). The wire protocol on `BROKER_PORT` does not change, so guests, the SDK veneer, and the in-guest probe are untouched. The change is host-side: `spawn_broker_services_if_admitted` (fork) becomes `ensure_daemons` + `register_vm`, the daemons gain a control plane, and `mvmd`'s host agent adopts the same daemon per tenant.
+Phased in [Plan 202](../plans/202-host-services-daemon.md). The wire protocol on `BROKER_PORT` does not change, so guests, the SDK veneer, and the in-guest probe are untouched. The change is host-side: `spawn_broker_services_if_admitted` (fork) becomes `ensure_daemon` + `register_vm`, the host-agent daemon gains a control plane with the signer as a supervised helper, and `mvmd` adopts the same per-tenant daemon by replication.
 
 ## Out of scope
 

--- a/specs/plans/202-host-services-daemon.md
+++ b/specs/plans/202-host-services-daemon.md
@@ -7,15 +7,16 @@
 
 ## Goal
 
-Replace per-VM `mvm-broker` + `mvm-audit-signer` forks with **two long-lived per-tenant daemons** that VMs register with at boot and deregister from at teardown. Host-process count drops from `O(VMs)` to `O(active tenants)`; `host.audit.v1` becomes available on a normal admitted `up`, decoupled from `MVM_GATEWAY_BRIDGE`. The guest-facing wire (`ServiceCall` on `BROKER_PORT`) does not change.
+Replace per-VM `mvm-broker` + `mvm-audit-signer` forks with **one host-agent daemon + a supervised signer helper, per tenant** — the user runs one daemon, its many microVMs are *registrations* not processes, and the helper is an invisible privilege-separated child. Host-process count drops from `O(VMs)` to `O(active tenants)`; `host.audit.v1` becomes available on a normal admitted `up`, decoupled from `MVM_GATEWAY_BRIDGE`. `mvm` (one tenant) is the single-tenant degenerate case of `mvmd` (one such unit per tenant). The guest-facing wire (`ServiceCall` on `BROKER_PORT`) does not change.
 
 ## Invariants to hold throughout
 
-- The moat survives: broker (keyless, untrusted-input parser) and signer (key holder) stay in separate address spaces.
+- The moat survives: the host-agent daemon (keyless, does broker dispatch + parses untrusted guest input) and the signer helper (holds all signing keys) stay in separate address spaces.
 - `vm_id` and `correlation_id` are server-derived, never guest-supplied.
 - The control plane (Register/Deregister) is host-only (mode 0700) and host-signed — never guest-reachable.
 - Claim 12 (binding-gated dispatch), claim 13 (no raw secret over the channel), the 20/s rate limit, and the 4 KiB cap are preserved, keyed by `vm_id`.
 - No guest-facing protocol, port, or frame change — the SDK veneer and the in-guest `audit-probe` are untouched.
+- **Tenant boundary by replication:** one (host-agent + helper) per tenant; each helper holds only *that tenant's* keys; the VM/jailer is the primary boundary and `mvmd` is the cross-tenant arbiter (ADR-084 §Tenant boundaries). Per-tenant keys are required, not optional.
 
 ## Phase 0 — ADR + plan
 
@@ -23,20 +24,25 @@ Replace per-VM `mvm-broker` + `mvm-audit-signer` forks with **two long-lived per
 - [x] Plan 202 written (this doc).
 - [ ] ADR-084 reviewed + accepted.
 
-## Phase 1 — broker daemon + control plane
+## Phase 1 — host-agent daemon (broker dispatch) + control plane
 
-- [ ] **1a — control protocol.** Define `RegisterVm { vm_id, tenant, broker_listen_socket, services_bindings, workload_chain_path }` / `DeregisterVm { vm_id }`, host-signed, framed on a per-tenant control UDS (`<run>/broker-control-<tenant>.sock`, 0700). Serde roundtrip + tampered-signature rejection tests.
-- [ ] **1b — daemon skeleton.** `mvm-broker` runs as a resident per-tenant process: accept on the control socket, hold a `vm_id → {socket, bindings, rate-bucket}` map, bind/unbind per-VM `BROKER_PORT` sockets on register/deregister, demux accepted connections to `vm_id` by accepting socket. Reuse the existing `ServiceCall` dispatch + claim-12 gate unchanged.
-- [ ] **1c — `ensure_daemon` + `register_vm`.** New `mvm_backend` seam replacing `spawn_broker` in the start path: lazily start the per-tenant broker (idempotent; pid/lock under the run dir so concurrent `up`s converge on one) and send `RegisterVm`. `stop()` sends `DeregisterVm` (no daemon teardown — it stays warm).
+The host-agent daemon does broker dispatch and stays **keyless**; the signer it talks to is still the per-VM signer for now and becomes the supervised helper in Phase 2.
+
+- [ ] **1a — control protocol.** Define `RegisterVm { vm_id, tenant, broker_listen_socket, services_bindings, workload_chain_path }` / `DeregisterVm { vm_id }`, host-signed, framed on a per-tenant control UDS (`<run>/host-agent-<tenant>.sock`, 0700). Serde roundtrip + tampered-signature rejection tests.
+- [ ] **1b — daemon skeleton.** The host-agent daemon runs as a resident per-tenant process: accept on the control socket, hold a `vm_id → {socket, bindings, rate-bucket}` map, bind/unbind per-VM `BROKER_PORT` sockets on register/deregister, demux accepted connections to `vm_id` by accepting socket. Reuse the existing `ServiceCall` dispatch + claim-12 gate unchanged. (Repurpose the `mvm-broker` bin as the host-agent's dispatch core.)
+- [ ] **1c — `ensure_daemon` + `register_vm`.** New `mvm_backend` seam replacing `spawn_broker` in the start path: lazily start the per-tenant host-agent daemon (idempotent; pid/lock under the run dir so concurrent `up`s converge on one) and send `RegisterVm`. `stop()` sends `DeregisterVm` (no daemon teardown — it stays warm).
 - [ ] **1d — identity is server-derived.** Assert in tests that the dispatched `vm_id` comes from the accepting socket, not the frame; a frame claiming another `vm_id` cannot reach that VM's bindings.
 
 **Verify:** `cargo test -p mvm-hostd -p mvm-backend`; unit test for register→bind→dispatch→deregister→unbind; concurrent-`up` converges-on-one-daemon test.
 
-## Phase 2 — audit-signer daemon
+## Phase 2 — signer helper (the one key-holding address space)
 
-- [ ] **2a — daemon + per-VM heads.** `mvm-audit-signer` resident per tenant, holding the tenant key, with a `vm_id → in-memory chain head` map; `RegisterVm` opens/owns that VM's `<tenant>.<vm>.workload.jsonl`, `DeregisterVm` flushes + closes it. Single-writer per file preserved by one owning process.
-- [ ] **2b — broker→signer forwarding tagged by server `vm_id`.** The broker forwards each accepted entry with the server-derived `vm_id`; the signer routes to the right head and stamps `category: workload_audit`. Cross-VM forgery test (guest A cannot land in B's chain).
-- [ ] **2c — restart rebuilds heads.** On daemon restart, rebuild each head from the persisted secondary head + re-bind from the live registration set; chain stays append-only (no fork). Kill-and-restart test asserts the chain still `verify_workload_chain`s clean across the restart.
+The signer becomes a **supervised helper** of the host-agent daemon, holding **all** of the tenant's signing keys, so the host agent is keyless including admission.
+
+- [ ] **2a — helper + per-VM heads.** The signer helper is resident per tenant (a child the host agent supervises), holding the tenant's key(s), with a `vm_id → in-memory chain head` map; `RegisterVm` opens/owns that VM's `<tenant>.<vm>.workload.jsonl`, `DeregisterVm` flushes + closes it. Single-writer per file preserved by one owning process.
+- [ ] **2b — host-agent→helper forwarding tagged by server `vm_id`.** The host agent forwards each accepted audit entry with the server-derived `vm_id`; the helper routes to the right head and stamps `category: workload_audit`. Cross-VM forgery test (guest A cannot land in B's chain).
+- [ ] **2c — admission signing moves to the helper.** Plan admission (`host_signer`) signs via the helper too, so the keyless-host-agent invariant covers admission as well as audit — one helper holds every key. Existing claim-8 admission tests stay green through the indirection.
+- [ ] **2d — restart rebuilds heads.** On helper restart, rebuild each head from the persisted secondary head + re-bind from the live registration set; chain stays append-only (no fork). Kill-and-restart test asserts the chain still `verify_workload_chain`s clean across the restart.
 
 **Verify:** `verify_workload_chain` clean before and after a signer restart; per-VM chains isolated; `cargo test -p mvm-hostd`.
 
@@ -55,10 +61,14 @@ Replace per-VM `mvm-broker` + `mvm-audit-signer` forks with **two long-lived per
 
 **Verify:** kill-and-restart leaves every running VM's `host.audit.v1` working and chains clean.
 
-## Phase 5 — mvmd adoption (cross-repo)
+## Phase 5 — mvmd adoption + tenant boundaries (cross-repo)
 
-- [ ] **5a — host agent owns the daemon per tenant.** mvmd's host agent starts/supervises one daemon pair per active tenant at host init (not per VM), registering VMs as it launches them. Tracked in mvmd Plan 52; this repo exposes the daemon + control protocol as the shared surface.
-- [ ] **5b — density check.** Confirm `O(tenants)` process count under a fleet-shaped load (many VMs, few tenants).
+mvmd replicates the local unit — **one (host-agent + helper) per active tenant** — and is the cross-tenant arbiter. It does not reimplement the daemon.
+
+- [ ] **5a — coordinator replicates per tenant.** mvmd starts/supervises one (host-agent + helper) per active tenant at host init (not per VM), registering VMs as it launches them under the right tenant. Tracked in mvmd Plan 52; this repo exposes the daemon + control protocol as the shared surface.
+- [ ] **5b — per-tenant keys.** Each tenant's helper holds only that tenant's signing key(s); mvmd mints/scopes them. A cross-tenant sign/forge attempt is refused (test).
+- [ ] **5c — boundary tests.** A VM of tenant A cannot reach tenant B's host agent or write tenant B's chain (the VM's socket is bound only by A's daemon); tenant-scoped authz on cross-VM requests is mvmd's (ADR-084 §Tenant boundaries).
+- [ ] **5d — density check.** Confirm `O(active tenants)` process count under a fleet-shaped load (many VMs, few tenants).
 
 ## Phase 6 — closeout
 
@@ -69,10 +79,10 @@ Replace per-VM `mvm-broker` + `mvm-audit-signer` forks with **two long-lived per
 ## Success criteria
 
 - `host.audit.v1` works on a plain admitted `mvmctl up` (libkrun + vz) with no `MVM_GATEWAY_BRIDGE`.
-- One broker + one audit-signer **per tenant**, warm across VM churn; a no-services plan starts neither.
+- One host-agent daemon + one signer helper **per tenant**, warm across VM churn; a user's many VMs add zero processes; a no-services plan starts neither.
 - Live round-trip + `verify_workload_chain` green, including across a daemon restart.
 - Claim 12/13, rate limit, cap, and server-derived identity all preserved (existing tests stay green; cross-VM/cross-tenant forgery tests added).
-- mvmd consumes the same daemon per tenant.
+- mvmd replicates the unit per tenant with per-tenant keys; cross-tenant reach/forge refused (ADR-084 §Tenant boundaries).
 
 ## Deferred / follow-ups
 


### PR DESCRIPTION
Design-review refinement of ADR-084 + Plan 202 (both merged in #977). Two markdown files, docs-only.

## What changed

- **One host-agent daemon + one signer helper, per tenant** (was "two co-equal daemons"). The host-agent daemon is keyless and does lifecycle + admission + broker dispatch; the signer helper is the *one* separate address space and holds *all* signing keys (admission **and** audit). The user runs **one daemon**; a tenant's many microVMs are *registrations*, not processes; the helper is an invisible privilege-separated child (the sshd model).
- **`mvm` ⊂ `mvmd`.** `mvm` without `mvmd` is a single tenant running many VMs (one host-agent + one helper, fixed). `mvmd` is the coordinator that replicates that unit per tenant. Local mvm is the literal single-tenant degenerate case — one design, not two.
- **New "Tenant boundaries" section** (ADR): layered, strongest first — (1) hypervisor + jailer per microVM is the primary boundary (one guest = one tenant's workload); (2) host services separate by replication (process/key/audit per tenant, no shared mutable state); (3) `mvmd` is the cross-tenant arbiter and in the TCB. Plus the two constraints that make it real: **per-tenant keys are required**, and **the host is the shared trust root** (VM escape / host compromise defeats it — universal).
- **Plan 202 phases retuned:** Phase 1 = keyless host-agent daemon + control plane; Phase 2 = signer helper holding all keys incl. admission signing; Phase 5 = mvmd replicates per tenant + cross-tenant boundary tests + per-tenant keys.

## Gates
`check-spec-numbers`, `check-adr-coverage` (0 broken refs), `check-no-overclaim` clean; the `#tenant-boundaries` anchor resolves to the new section.