### PR TITLE
feat(plan-200): image source classifier + run --image seam

### DIFF
--- a/crates/mvm-cli/src/commands/image/mod.rs
+++ b/crates/mvm-cli/src/commands/image/mod.rs
@@ -25,6 +25,7 @@ mod inspect;
 mod ls;
 mod pull;
 mod rm;
+mod source;
 
 const INDEX_FILE: &str = "index.json";
 
@@ -411,6 +412,16 @@ pub(in crate::commands) fn resolve_or_pull_run_image(
     reference: &str,
     prod: bool,
 ) -> Result<ResolvedOciRunImage> {
+    // Registry refs flow through the existing pull path; local sources
+    // (oci-archive / rootfs-dir / stdin) are refused here until their ingest
+    // lands, rather than being misparsed as a registry reference.
+    let classified = source::ImageSource::classify(reference)?;
+    if !classified.is_registry() {
+        bail!(
+            "`run --image` does not support local image sources yet ({classified:?}); \
+             use a registry reference for now"
+        );
+    }
     let image_ref: ImageReference = reference.parse()?;
     if prod && !image_ref.is_digest_pinned() {
         bail!("mvmctl run --image --prod requires a digest-pinned reference");

--- a/crates/mvm-cli/src/commands/image/source.rs
+++ b/crates/mvm-cli/src/commands/image/source.rs
@@ -1,0 +1,175 @@
+//! Image source classification — the entry seam that decides whether an
+//! `--image` / `mvm.toml image =` value is a registry reference or a local
+//! source (OCI-layout archive file, stdin stream, or unpacked rootfs
+//! directory).
+//!
+//! Registry refs flow to the existing `mvm_oci::ImageReference` + pull path
+//! (the only source that touches the network); local sources route to the
+//! same hardened unpack / provenance / ext4 materialization without a fetch.
+//!
+//! Classification is purely **prefix-driven** (skopeo-style transports) so it
+//! is deterministic and never probes the filesystem — `alpine:3.20` stays a
+//! registry ref despite the colon. Existence, architecture, and traversal
+//! checks are the ingest step's job, not classification's.
+
+use std::path::PathBuf;
+
+use anyhow::{Result, bail};
+
+/// Reserved transport prefix for a local OCI-layout archive file.
+const OCI_ARCHIVE: &str = "oci-archive:";
+/// Reserved transport prefix for an already-unpacked rootfs directory.
+const ROOTFS_DIR: &str = "rootfs-dir:";
+
+/// Where an `--image` value's bytes come from. Every variant routes to the
+/// same downstream unpack / provenance / ext4 path; only acquisition differs.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(in crate::commands) enum ImageSource {
+    /// A registry reference (`alpine:3.20`, `ghcr.io/x/y@sha256:…`). Parsed
+    /// downstream by `mvm_oci::ImageReference`; the only network-fetching
+    /// source.
+    Registry(String),
+    /// A local OCI-layout archive file (`oci-archive:PATH`).
+    OciArchive(PathBuf),
+    /// An OCI-layout archive streamed on stdin (`-` or `oci-archive:-`).
+    Stdin,
+    /// An already-unpacked rootfs directory (`rootfs-dir:PATH`).
+    RootfsDir(PathBuf),
+}
+
+impl ImageSource {
+    /// Classify a `--image` / `image =` value. Prefix-driven and
+    /// filesystem-free: `oci-archive:` / `rootfs-dir:` are reserved
+    /// transports, `-` is a stdin archive, and everything else is a registry
+    /// reference (so `alpine:3.20` and `ghcr.io/x:y` stay registry refs
+    /// despite the colon). Empty input — or a transport with no locator — is
+    /// an error.
+    pub(in crate::commands) fn classify(input: &str) -> Result<Self> {
+        let input = input.trim();
+        if input.is_empty() {
+            bail!("image source must not be empty");
+        }
+        if input == "-" {
+            return Ok(Self::Stdin);
+        }
+        if let Some(rest) = input.strip_prefix(OCI_ARCHIVE) {
+            if rest == "-" {
+                return Ok(Self::Stdin);
+            }
+            if rest.is_empty() {
+                bail!("`{OCI_ARCHIVE}` requires a path");
+            }
+            return Ok(Self::OciArchive(PathBuf::from(rest)));
+        }
+        if let Some(rest) = input.strip_prefix(ROOTFS_DIR) {
+            if rest.is_empty() {
+                bail!("`{ROOTFS_DIR}` requires a path");
+            }
+            return Ok(Self::RootfsDir(PathBuf::from(rest)));
+        }
+        Ok(Self::Registry(input.to_string()))
+    }
+
+    /// True when acquiring this source requires a network registry fetch.
+    pub(in crate::commands) fn is_registry(&self) -> bool {
+        matches!(self, Self::Registry(_))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn bare_name_is_a_registry_reference() {
+        assert_eq!(
+            ImageSource::classify("alpine").unwrap(),
+            ImageSource::Registry("alpine".to_string())
+        );
+    }
+
+    #[test]
+    fn tagged_and_digested_refs_stay_registry_despite_the_colon() {
+        // The colon in a tag/digest must not be mistaken for a transport.
+        assert_eq!(
+            ImageSource::classify("alpine:3.20").unwrap(),
+            ImageSource::Registry("alpine:3.20".to_string())
+        );
+        assert_eq!(
+            ImageSource::classify("ghcr.io/foo/bar@sha256:abc").unwrap(),
+            ImageSource::Registry("ghcr.io/foo/bar@sha256:abc".to_string())
+        );
+        assert!(
+            ImageSource::classify("registry.local:5000/x:v1")
+                .unwrap()
+                .is_registry()
+        );
+    }
+
+    #[test]
+    fn oci_archive_prefix_yields_a_local_archive_path() {
+        assert_eq!(
+            ImageSource::classify("oci-archive:/tmp/img.tar").unwrap(),
+            ImageSource::OciArchive(PathBuf::from("/tmp/img.tar"))
+        );
+    }
+
+    #[test]
+    fn rootfs_dir_prefix_yields_a_directory_path() {
+        assert_eq!(
+            ImageSource::classify("rootfs-dir:/var/lib/rootfs").unwrap(),
+            ImageSource::RootfsDir(PathBuf::from("/var/lib/rootfs"))
+        );
+    }
+
+    #[test]
+    fn dash_is_a_stdin_archive() {
+        assert_eq!(ImageSource::classify("-").unwrap(), ImageSource::Stdin);
+        assert_eq!(
+            ImageSource::classify("oci-archive:-").unwrap(),
+            ImageSource::Stdin
+        );
+    }
+
+    #[test]
+    fn input_is_trimmed() {
+        assert_eq!(
+            ImageSource::classify("  alpine  ").unwrap(),
+            ImageSource::Registry("alpine".to_string())
+        );
+    }
+
+    #[test]
+    fn empty_input_is_rejected() {
+        assert!(ImageSource::classify("").is_err());
+        assert!(ImageSource::classify("   ").is_err());
+    }
+
+    #[test]
+    fn transport_without_a_locator_is_rejected() {
+        let oci = ImageSource::classify("oci-archive:")
+            .unwrap_err()
+            .to_string();
+        assert!(oci.contains("oci-archive:"), "got {oci}");
+        let dir = ImageSource::classify("rootfs-dir:")
+            .unwrap_err()
+            .to_string();
+        assert!(dir.contains("rootfs-dir:"), "got {dir}");
+    }
+
+    #[test]
+    fn is_registry_only_for_registry_variant() {
+        assert!(ImageSource::classify("alpine").unwrap().is_registry());
+        assert!(
+            !ImageSource::classify("oci-archive:/x.tar")
+                .unwrap()
+                .is_registry()
+        );
+        assert!(
+            !ImageSource::classify("rootfs-dir:/x")
+                .unwrap()
+                .is_registry()
+        );
+        assert!(!ImageSource::classify("-").unwrap().is_registry());
+    }
+}

--- a/specs/plans/200-machine-ux-dx-layer.md
+++ b/specs/plans/200-machine-ux-dx-layer.md
@@ -503,6 +503,13 @@ Implementation shape:
 - Add a typed `MachineImageSource` enum for registry refs, archive files, stdin
   archives, and unpacked rootfs directories. Avoid stringly typed source
   dispatch at call sites.
+  - **Landed (classifier + seam):** `ImageSource` (`commands/image/source.rs`) —
+    prefix-driven, filesystem-free taxonomy (`oci-archive:` / `rootfs-dir:` /
+    `-` stdin / bare → registry), wired into `resolve_or_pull_run_image`. The
+    registry path is byte-unchanged; local sources fail closed with a clear
+    message until their ingest lands. Per-variant ingest (archive / rootfs-dir /
+    stdin) + the traversal / malformed / wrong-arch / missing-provenance negative
+    tests are the following slices.
 - Route every `MachineImageSource` through the existing OCI/rootfs hardening,
   provenance, policy admission, and receipt/audit code paths. Do not add a
   daemon-bypass or extraction shortcut for DX.


### PR DESCRIPTION
## What

Plan 200 slice 1, **first bullet**: the typed image-source taxonomy that local image-source handling routes through. The single seam is `resolve_or_pull_run_image()` (`image/mod.rs`), where the input was previously parsed directly as a registry reference.

- **`ImageSource`** (`commands/image/source.rs`): prefix-driven, **filesystem-free** classifier — `oci-archive:PATH`, `rootfs-dir:PATH`, `-` (stdin archive), bare → registry. Deterministic: `alpine:3.20` / `ghcr.io/x:y` stay registry refs despite the colon; existence / architecture / traversal checks are the ingest step's job, not classification's.
- Wired into `resolve_or_pull_run_image`: the **registry path is byte-unchanged**; local sources fail closed with a clear message until their ingest lands (rather than being misparsed as a registry reference).
- 9 unit tests: every variant + empty / locator-less transport / trimming edges.

## Why a classifier first

It establishes the taxonomy + the single dispatch boundary end-to-end before any ingest, so the following PRs each add one source's ingest on a stable seam. (Named `ImageSource`, not the plan's tentative `MachineImageSource`, since it serves `run --image` generally, not just the machine surface.)

## Following slices (each its own PR)

2. `OciArchive` ingest — local OCI-layout tar → existing hardened unpack → ext4; local-source provenance; missing-provenance reject.
3. `RootfsDir` ingest — unpacked dir → ext4, re-validated; traversal / wrong-arch reject.
4. `Stdin` ingest — archive stream.
5. Extend `oci_unpack_attacks.rs` with the per-source negative cases.

## Verification

`cargo test -p mvm-cli --lib commands::image::source` → **9 passed**. `fmt --all --check`, `clippy -p mvm-cli -- -D warnings`, and `check-no-spec-refs-in-comments` all clean (full local gate set).