### PR TITLE
fix(audit): resolve supervisor signing-key dir through mvm_keys_dir()

### DIFF
--- a/crates/deps/libkrun-sys/src/lib.rs
+++ b/crates/deps/libkrun-sys/src/lib.rs
@@ -1426,11 +1426,18 @@ impl SupervisorConfig {
             .ok_or(AuditSubstrateError::MissingField("signing_key_path"))?;
         // Path-traversal defense: the signing key is host-trust-
         // boundary state. Reject callers that point us anywhere
-        // outside the well-known location. We accept both the
-        // canonical form and the un-canonicalized form pointing
-        // under `~/.mvm/keys/` (canonicalize would fail if the
-        // file doesn't exist yet, which is legal at admission).
-        let keys_dir = home_mvm_keys_dir();
+        // outside the operator's keys dir. Resolved through the same
+        // `mvm_keys_dir()` every other site uses (admission's
+        // `default_keys_dir`, the audit-substrate builder), so the
+        // prefix check holds across the supervisor process boundary —
+        // the supervisor inherits the launcher's data-dir env. This
+        // honors the data-dir override (worktree isolation) rather than
+        // hard-pinning `$HOME`: relocating the key via the environment
+        // requires host access, and a malicious host is out of the
+        // threat model. The prefix check accepts the un-canonicalized
+        // form (canonicalize would fail if the file doesn't exist yet,
+        // which is legal at admission).
+        let keys_dir = mvm_core::config::mvm_keys_dir();
         if !signing_key.starts_with(&keys_dir) {
             return Err(AuditSubstrateError::SigningKeyOutsideKeysDir {
                 path: signing_key.display().to_string(),
@@ -1648,16 +1655,6 @@ mod base_attach_tests {
         });
         assert!(serde_json::from_value::<SupervisorBaseConfig>(whole).is_err());
     }
-}
-
-/// `~/.mvm/keys/` resolver. Centralised so the signing-key
-/// validation in [`SupervisorConfig::validate_audit_substrate`]
-/// can be tested without env mutation across multiple sites.
-fn home_mvm_keys_dir() -> std::path::PathBuf {
-    let home = std::env::var_os("HOME")
-        .map(std::path::PathBuf::from)
-        .unwrap_or_else(|| std::path::PathBuf::from("/"));
-    home.join(".mvm").join("keys")
 }
 
 /// Errors returned by [`SupervisorConfig::validate_audit_substrate`]
@@ -2070,7 +2067,7 @@ mod tests {
     // -----------------------------------------------------------------
 
     fn well_formed_supervisor_config() -> SupervisorConfig {
-        let keys = home_mvm_keys_dir();
+        let keys = mvm_core::config::mvm_keys_dir();
         SupervisorConfig {
             krun: KrunContext::new("vm-a", "/k", "/r"),
             vm_state_dir: "/tmp/mvm/vms/vm-a".to_string(),
@@ -2172,8 +2169,8 @@ mod tests {
     #[test]
     fn validate_audit_substrate_refuses_signing_key_path_traversal() {
         let mut cfg = well_formed_supervisor_config();
-        let keys = home_mvm_keys_dir();
-        // Traversal attempt: ~/.mvm/keys/../../../etc/shadow.
+        let keys = mvm_core::config::mvm_keys_dir();
+        // Traversal attempt: <keys-dir>/../../../etc/shadow.
         cfg.signing_key_path = Some(
             keys.join("..")
                 .join("..")


### PR DESCRIPTION
## The bug

`SupervisorConfig::validate_audit_substrate` (the claim-10 no-bypass admission check) pinned the host signing key under a **private HOME-fixed resolver** (`home_mvm_keys_dir()` → `$HOME/.mvm/keys`), while every other site resolves it **data-dir-aware**:

| Site | Resolver |
|------|----------|
| Admission (`load_or_init` → `default_keys_dir`) | `mvm_data_dir_strict()/keys` |
| `compute_audit_substrate` | `mvm_data_dir()/keys` |
| `validate_audit_substrate` | `home_mvm_keys_dir()` = `$HOME/.mvm/keys` ← outlier |

They coincide in normal use and **diverge only under an `MVM_DATA_DIR` override**: the builder writes the key path under the data dir, the validator demands `$HOME`, and the supervisor refuses every bridge admission with *"signing_key must canonicalize under `~/.mvm/keys`"*. So the gateway-audit **bridge path is unusable under data-dir isolation** (worktree / parallel sessions) — surfaced while bringing up the Plan-193 native rvproxy gateway end-to-end.

## The fix

Point the validator at the same `mvm_core::config::mvm_keys_dir()` the rest of the codebase already uses, and drop the orphaned `home_mvm_keys_dir()` helper.

## Why this is the correct alignment, not a weakening

- **ADR-041** specifies the key at `~/.mvm/keys/` — the conventional shorthand for `mvm_data_dir()/keys`, which is exactly what `mvm_keys_dir()` returns (and respects `MVM_DATA_DIR`). The validator was simply the lone site using a divergent helper.
- **Path-traversal defense intact**: the key must still live under the operator's keys dir (same `starts_with` prefix check); a tampered `SupervisorConfig` still can't point elsewhere.
- **Resolves across the process moat**: the supervisor is spawned with no `env_clear`, so it inherits the launcher's `MVM_DATA_DIR` and the prefix resolves identically on both sides.
- **Threat model**: a malicious host is explicitly out of scope (ADR-002), so the only thing the HOME-pin added — defense against environment relocation — guards a threat that requires host access we already trust. Honoring the override instead matches the worktree-isolation invariant (`CLAUDE.md`: never inline `$HOME/.mvm`).

## Tests

`cargo test -p libkrun-sys --features libkrun-sys -- validate_audit_substrate` — 9 green (incl. the path-traversal rejection). fmt + clippy + `check-claim-catalog` (16 claims / 39 witnesses) clean.

Unblocks the WS-2.2b native-rvproxy guest-boot final mile (#992) under isolated caches.