### PR TITLE
docs(plan-200): mark net-policy note superseded by #1003 (WS-B)

### DIFF
--- a/specs/plans/200-machine-ux-dx-layer.md
+++ b/specs/plans/200-machine-ux-dx-layer.md
@@ -519,8 +519,13 @@ Implementation shape:
   as non-sensitive metadata.
 - Add parser tests, dry-run tests, deny-by-default tests, and allow-list tests.
 
-> **Implementation plan (investigated 2026-06-16; not yet built).** Exact
-> touch points + one security decision, so the next pass is mechanical:
+> **Implementation plan — SUPERSEDED: `--net`/`--allow-host` shipped and
+> live-validated via WS-B (#1003).** `VmStartConfig.network_policy` now exists
+> and is applied per-backend; the deny-all default holds. The investigation
+> notes below are kept as history — note the `VmStartConfig` field that #1003
+> added did *not* exist when this was written (a separate attempt confirmed the
+> gap; #1003 closed it). See the "Deferred follow-ups (from WS-B live
+> validation)" section lower in this doc for the remaining items.
 >
 > - **Reuse, don't reinvent:** `resolve_network_policy(preset, allow)`
 >   (`commands/shared/resolve.rs`) already maps preset/allow-list → a


### PR DESCRIPTION
Housekeeping to reconcile the plan record after discovering that **#1003 (WS-B) already shipped + live-validated the full `--net`/`--allow-host` enforcement slice** — `VmStartConfig.network_policy` added, per-backend application, deny-all default.

- Marks the stale "Implementation plan (investigated; **not yet built**)" note (from #1004) as **SUPERSEDED by #1003**, since the feature is now built. Keeps the investigation text as labeled history.
- Companion to closing the obsolete correction PR #1005 (its "VmStartConfig has no `network_policy` field" note was true when written but #1003 made it false).

Docs-only. No code change.
