### PR TITLE
feat(plan-200): default binary-closure budget CI gate

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -107,6 +107,9 @@ jobs:
       - name: mvm-core default build is runtime-free
         run: cargo run -p xtask -- check-core-runtime-free
 
+      - name: mvmctl default closure within budget
+        run: cargo run -p xtask -- check-closure-budget
+
       - name: mvm-guest agent closure is runtime-free
         run: cargo run -p xtask -- check-guest-agent-runtime-free
 

--- a/xtask/src/check_closure_budget.rs
+++ b/xtask/src/check_closure_budget.rs
@@ -1,0 +1,127 @@
+//! `xtask check-closure-budget`
+//!
+//! Assert the **default** `mvmctl` binary closure stays within a committed
+//! crate budget (a ratchet). Dependency weight is a first-class DX/security
+//! goal: every crate in the default no-dev closure is code that ships in the
+//! binary and is a supply-chain + attack-surface unit. This gate makes a *new*
+//! default dependency a deliberate, reviewed choice rather than a silent
+//! accretion.
+//!
+//! The closure is platform-sensitive (macOS pulls libkrun/objc2; Linux pulls
+//! firecracker/passt), so the gate pins the primary release/CI target
+//! (`x86_64-unknown-linux-gnu`) for a deterministic count regardless of the
+//! host running it — `cargo tree --target` resolves without building.
+
+use anyhow::{Context, Result, bail};
+use std::path::Path;
+use std::process::Command;
+
+/// Deployment/CI target the budget is measured against (deterministic across
+/// hosts).
+const BUDGET_TARGET: &str = "x86_64-unknown-linux-gnu";
+
+/// Max distinct crates allowed in `mvmctl`'s default no-dev closure on
+/// [`BUDGET_TARGET`]. Baseline measured 2026-06-17 against the audited default
+/// closure. Lower it freely as deps drop; raising it must be justified in the
+/// PR that does.
+const CLOSURE_BUDGET: usize = 335;
+
+pub fn run(workspace: &Path) -> Result<()> {
+    let count = default_closure_crate_count(workspace)?;
+    if count > CLOSURE_BUDGET {
+        bail!(
+            "check-closure-budget: mvmctl's default {BUDGET_TARGET} closure is {count} crates, \
+             over the budget of {CLOSURE_BUDGET} — a new dependency entered the default binary. \
+             Drop it, gate it behind an off-by-default feature, or, if it is genuinely required, \
+             bump CLOSURE_BUDGET in xtask/src/check_closure_budget.rs with a one-line \
+             justification in the PR."
+        );
+    }
+    if count < CLOSURE_BUDGET {
+        eprintln!(
+            "check-closure-budget: {count} crates (budget {CLOSURE_BUDGET}); deps dropped — \
+             ratchet CLOSURE_BUDGET down to {count}."
+        );
+    } else {
+        eprintln!("check-closure-budget: {count} crates (at budget {CLOSURE_BUDGET})");
+    }
+    Ok(())
+}
+
+fn default_closure_crate_count(workspace: &Path) -> Result<usize> {
+    let cargo = std::env::var("CARGO").unwrap_or_else(|_| "cargo".to_string());
+    let output = Command::new(&cargo)
+        .current_dir(workspace)
+        .args([
+            "tree",
+            "-p",
+            "mvmctl",
+            "-e",
+            "no-dev",
+            "--prefix",
+            "none",
+            "--locked",
+            "--target",
+            BUDGET_TARGET,
+        ])
+        .output()
+        .context("running `cargo tree -p mvmctl -e no-dev --target ...`")?;
+    if !output.status.success() {
+        bail!(
+            "cargo tree failed: {}",
+            String::from_utf8_lossy(&output.stderr).trim()
+        );
+    }
+    Ok(unique_crate_count(&String::from_utf8_lossy(&output.stdout)))
+}
+
+/// Count distinct crates in `cargo tree --prefix none` output. Each non-empty
+/// line begins with `name vX.Y.Z`; a crate recurs across the tree (and a
+/// repeated subtree is marked `(*)`), so dedup by `(name, version)` to count
+/// each compiled crate once. Two majors of the same crate count as two — they
+/// are two compilations in the binary.
+fn unique_crate_count(tree: &str) -> usize {
+    let mut crates: Vec<(&str, &str)> = tree
+        .lines()
+        .filter_map(|line| {
+            let mut it = line.split_whitespace();
+            let name = it.next()?;
+            let version = it.next().unwrap_or("");
+            Some((name, version))
+        })
+        .collect();
+    crates.sort_unstable();
+    crates.dedup();
+    crates.len()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::unique_crate_count;
+
+    #[test]
+    fn counts_distinct_name_version_pairs() {
+        let tree = "mvmctl v0.16.1\nserde v1.0.0\nanyhow v1.0.99\nserde v1.0.0\n";
+        // serde appears twice but is one crate.
+        assert_eq!(unique_crate_count(tree), 3);
+    }
+
+    #[test]
+    fn two_majors_count_as_two() {
+        let tree = "mvmctl v0.16.1\nbitflags v1.3.2\nbitflags v2.6.0\n";
+        assert_eq!(unique_crate_count(tree), 3);
+    }
+
+    #[test]
+    fn repeated_subtree_marker_is_ignored() {
+        // `cargo tree` marks a repeated subtree with a trailing `(*)`.
+        let tree = "mvmctl v0.16.1\nserde v1.0.0\nserde v1.0.0 (*)\n";
+        assert_eq!(unique_crate_count(tree), 2);
+    }
+
+    #[test]
+    fn blank_lines_are_skipped() {
+        let tree = "mvmctl v0.16.1\n\nserde v1.0.0\n\n";
+        assert_eq!(unique_crate_count(tree), 2);
+    }
+}

--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -11,6 +11,7 @@ mod build_dev_image;
 mod check_adr_coverage;
 mod check_audit_positional;
 mod check_claim_catalog;
+mod check_closure_budget;
 mod check_core_runtime_free;
 mod check_doc_claims;
 mod check_forbidden_deps;
@@ -69,6 +70,10 @@ fn main() -> Result<()> {
             let workspace = workspace_root();
             check_core_runtime_free::run(&workspace)
         }
+        Some("check-closure-budget") => {
+            let workspace = workspace_root();
+            check_closure_budget::run(&workspace)
+        }
         Some("check-guest-agent-runtime-free") => {
             let workspace = workspace_root();
             check_guest_agent_runtime_free::run(&workspace)
@@ -115,7 +120,7 @@ fn main() -> Result<()> {
             gen_stubs::check(&workspace)
         }
         Some(other) => anyhow::bail!(
-            "Unknown xtask: {:?}. Available: gen-man, check-adr-coverage, check-no-display-on-secret-types, check-audit-positional, check-doc-claims, check-forbidden-deps, check-core-runtime-free, check-guest-agent-runtime-free, check-guest-agent-in-all-images, check-no-overclaim, check-spec-numbers, check-no-spec-refs-in-comments, check-claim-catalog, check-mvm-host-binaries-sync, check-runtime-overlay-version, perf, build-dev-image, gen-stubs, check-stubs",
+            "Unknown xtask: {:?}. Available: gen-man, check-adr-coverage, check-no-display-on-secret-types, check-audit-positional, check-doc-claims, check-forbidden-deps, check-core-runtime-free, check-closure-budget, check-guest-agent-runtime-free, check-guest-agent-in-all-images, check-no-overclaim, check-spec-numbers, check-no-spec-refs-in-comments, check-claim-catalog, check-mvm-host-binaries-sync, check-runtime-overlay-version, perf, build-dev-image, gen-stubs, check-stubs",
             other
         ),
         None => {
@@ -141,6 +146,9 @@ fn main() -> Result<()> {
             );
             eprintln!(
                 "  check-core-runtime-free                 Plan 126 B5: assert mvm-core's default build pulls no tokio"
+            );
+            eprintln!(
+                "  check-closure-budget                    Plan 200: assert mvmctl's default linux closure stays within the crate budget"
             );
             eprintln!(
                 "  check-guest-agent-runtime-free          Plan 124 A: assert mvm-guest's Linux closure pulls no tokio/async-trait/rtnetlink"


### PR DESCRIPTION
## What

A **default binary-closure budget** CI gate — the "default-closure CI budget" item from Plan 200 (dependency weight as a first-class DX/security goal). Every crate in the default `mvmctl` no-dev closure is code shipped in the binary and a supply-chain + attack-surface unit; this makes a *new* default dependency a deliberate, reviewed choice rather than silent accretion.

- **`xtask check-closure-budget`**: counts distinct `(name, version)` crates in `cargo tree -p mvmctl -e no-dev --target x86_64-unknown-linux-gnu` and fails if over `CLOSURE_BUDGET` (**335**, the current audited baseline). A ratchet — lower it freely as deps drop; raising it must be justified in the PR.
- **Pins the linux target** so the count is deterministic regardless of the host (macOS pulls libkrun/objc2; `cargo tree --target` resolves without building, so it works everywhere).
- Wired into the **ci.yml Lint job**; registered in xtask `main` + help.
- 4 unit tests on the parse (distinct name+version, two-majors, `(*)` repeated-subtree marker, blank lines).

Builds directly on the Plan 199 crate-boundary audit (which measured the default closure). `duplicate-major` + `forbidden-heavy-dep` budgets already exist (cargo-deny `multiple-versions=deny` + `check-forbidden-deps`); a binary **byte-size** budget is a separate follow-up.

## Verification

`cargo run -p xtask -- check-closure-budget` → **335 crates (at budget 335)**. xtask unit tests pass. `cargo fmt --all --check`, `clippy -p xtask -- -D warnings`, `check-no-spec-refs-in-comments` all clean; `ci.yml` valid YAML.

## Notes

Code-only (no `REFACTOR-STATUS`/plan-doc edit) to avoid racing the in-flight Plan 200 rollup PR #1006.
