### PR TITLE
feat(plan-200): admit MCP code-runs so deny-all egress is enforced (WS-B follow-up)

### DIFF
--- a/crates/mvm-cli/src/commands/ops/mcp.rs
+++ b/crates/mvm-cli/src/commands/ops/mcp.rs
@@ -408,9 +408,21 @@ impl ExecDispatcher {
             // MCP runs untrusted code: deny egress by default.
             network_policy: mvm_core::network_policy::NetworkPolicy::deny_all(),
         };
-        // MCP code-run stays on the un-admitted path for now (no bridge); its
-        // egress hardening is a tracked follow-up.
-        crate::exec::run_captured(req, None)
+        // Admit the run like any untrusted transient workload: the signed plan's
+        // tenant_id makes the libkrun/Vz supervisor spawn the enforcing gateway
+        // bridge, so the deny-all above is actually applied (without admission no
+        // bridge spawns and the deny-all is inert on those backends; Firecracker
+        // enforces the same field via nftables). Each cold call is its own
+        // admission against the host signer.
+        let backend = mvm_backend::backend::AnyBackend::auto_select()
+            .name()
+            .to_string();
+        let admit = crate::commands::vm::untrusted_transient_admit(
+            backend,
+            DEFAULT_VM_CPUS,
+            u64::from(DEFAULT_VM_MEM_MIB),
+        );
+        crate::exec::run_captured(req, Some(&admit))
     }
 
     /// Warm-VM path (A.2 v2): boot the session's VM on first call,

--- a/crates/mvm-cli/src/commands/vm/mod.rs
+++ b/crates/mvm-cli/src/commands/vm/mod.rs
@@ -35,3 +35,7 @@ pub(super) mod volume;
 pub(super) mod wait;
 
 pub(super) use super::{Cli, shared};
+
+// Shared untrusted-transient admission hook — `up` is `pub(super)` (vm-only),
+// so re-export the one helper the MCP code-runner (`commands::ops`) needs.
+pub(in crate::commands) use up::untrusted_transient_admit;

--- a/crates/mvm-cli/src/commands/vm/up.rs
+++ b/crates/mvm-cli/src/commands/vm/up.rs
@@ -473,6 +473,78 @@ pub(super) fn admit_plan_for_boot(
     }))
 }
 
+/// Build the boot-time admission hook for an **untrusted transient run** —
+/// deny-all egress, no secrets, tenant `local`. The locally-signed
+/// `ExecutionPlan` sets `tenant_id`, which makes the libkrun/Vz supervisor
+/// spawn the enforcing gateway bridge (so the resolved egress policy is
+/// actually applied) instead of the legacy unfiltered path; Firecracker reads
+/// the same field through nftables. Shared by `mvmctl run` and the MCP
+/// code-runner so both admit identically — neither leaves a deny-all inert on
+/// the bridge backends.
+///
+/// The returned closure owns a fresh nonce ledger per boot and yields the
+/// `SessionAuditSubstrate` (tenant + signed plan) the exec layer hands to the
+/// backend, persisting the bare plan first on the backends that read it from
+/// disk before `start()`.
+pub(in crate::commands) fn untrusted_transient_admit(
+    backend_name: String,
+    cpus: u32,
+    mem_mib: u64,
+) -> impl Fn(&std::path::Path, &str) -> Result<Option<crate::exec::SessionAuditSubstrate>> {
+    untrusted_transient_admit_in(backend_name, cpus, mem_mib, None, None)
+}
+
+/// [`untrusted_transient_admit`] with explicit signer / audit directories so
+/// tests can admit against isolated `TempDir`s; production passes `None` (the
+/// default `~/.mvm` locations).
+fn untrusted_transient_admit_in(
+    backend_name: String,
+    cpus: u32,
+    mem_mib: u64,
+    keys_dir: Option<std::path::PathBuf>,
+    audit_dir: Option<std::path::PathBuf>,
+) -> impl Fn(&std::path::Path, &str) -> Result<Option<crate::exec::SessionAuditSubstrate>> {
+    move |rootfs: &std::path::Path, vm_name: &str| {
+        let ledger = InMemoryNonceLedger::new();
+        let ctx = admit_plan_for_boot(AdmitPlanForBootParams {
+            tenant: "local",
+            vm_name,
+            backend_name: &backend_name,
+            rootfs_path: rootfs,
+            precomputed_image_sha256: None,
+            cpus,
+            mem_mib,
+            seccomp_tier: mvm_core::plan::PlanSeccompTier::Standard,
+            // No secrets on the untrusted transient path; deny secret release.
+            secret_release: mvm_core::plan::SecretReleasePolicy::default(),
+            secrets: Vec::new(),
+            no_supervisor: false,
+            ledger: &ledger,
+            keys_dir: keys_dir.as_deref(),
+            audit_dir: audit_dir.as_deref(),
+            policy_dir: None,
+            bundle_pin: None,
+            deps_volume: None,
+            shares: Vec::new(),
+            redaction: mvm_core::policy::RedactionPolicy::default(),
+        })?;
+        let Some(c) = ctx else { return Ok(None) };
+        // Persist the bare plan so the pre-start moat / endpoint can read it on
+        // the backends that consume it from disk.
+        if persists_plan_before_start(&backend_name) {
+            super::plan_persist::write_plan(vm_name, &c.admitted.plan)
+                .context("persisting admitted plan for the untrusted transient run")?;
+        }
+        let plan_json = serde_json::to_string(&c.admitted.signed)
+            .context("serializing admitted plan for the untrusted transient run")?;
+        Ok(Some(crate::exec::SessionAuditSubstrate {
+            tenant_id: c.admitted.plan.tenant.0.clone(),
+            plan_json,
+            bundle_json: None,
+        }))
+    }
+}
+
 #[derive(Debug)]
 struct PolicyAdmissionResolution {
     slots_mode: &'static str,
@@ -3066,6 +3138,46 @@ mod admit_plan_tests {
         let content = std::fs::read_to_string(&audit_path).expect("audit file exists");
         assert!(content.contains("plan.admitted"));
         assert!(content.contains(&ctx.admitted.plan_id.0));
+    }
+
+    // The shared untrusted-transient admit closure (used by both `mvmctl run`
+    // and the MCP code-runner) must produce a real audit substrate — a
+    // non-empty `tenant_id` + signed `plan_json`. That substrate is precisely
+    // what makes the libkrun/Vz supervisor spawn the enforcing gateway bridge,
+    // so a `Some` here is the proof that a deny-all is no longer inert on the
+    // bridge backends (the bug: the MCP path passed `admit = None`).
+    #[test]
+    fn untrusted_transient_admit_yields_bridge_substrate() {
+        let keys_dir = tempfile::tempdir().unwrap();
+        let audit_dir = tempfile::tempdir().unwrap();
+        let rootfs_dir = tempfile::tempdir().unwrap();
+        let rootfs = write_rootfs(rootfs_dir.path(), b"untrusted code rootfs");
+
+        let admit = untrusted_transient_admit_in(
+            "firecracker".to_string(),
+            2,
+            1024,
+            Some(keys_dir.path().to_path_buf()),
+            Some(audit_dir.path().to_path_buf()),
+        );
+        let substrate = admit(&rootfs, "mcp-cold-vm")
+            .expect("admission runs")
+            .expect("untrusted transient run is admitted (Some), not bypassed");
+
+        assert_eq!(substrate.tenant_id, "local");
+        assert!(
+            !substrate.plan_json.is_empty(),
+            "the signed plan must travel to the backend so the bridge spawns"
+        );
+        assert!(
+            substrate.bundle_json.is_none(),
+            "the bare untrusted path pins no bundle"
+        );
+        // The admission emitted its `plan.admitted` chain entry to the isolated
+        // audit dir, confirming the closure went through real admission.
+        let chain = std::fs::read_to_string(audit_dir.path().join("local.jsonl"))
+            .expect("audit chain file exists");
+        assert!(chain.contains("plan.admitted"));
     }
 
     #[test]


### PR DESCRIPTION
## What

Route the MCP code-runner's cold-boot path through plan admission so its `deny_all()` egress policy is actually enforced.

## Why

`run_cold` set `network_policy: deny_all()` but passed `admit = None` to `run_captured`. On the gateway-bridge backends (libkrun/Vz) no admitted plan means **no enforcing bridge spawns**, so the deny-all was *inert*. MCP runs untrusted AI code — exactly claim 10's target. (Firecracker enforces the same field via nftables and was unaffected.)

## How

- Extracted the transient-run admit closure into one shared helper `untrusted_transient_admit` (tenant `local`, no secrets, deny-all) in `commands::vm::up`, re-exported `pub(in crate::commands)` so the MCP runner can reuse it instead of forking a second copy.
- `run_cold` now admits each call and passes `Some(&admit)` — the signed plan's `tenant_id` makes the bridge spawn and the deny-all apply.
- Test seam `untrusted_transient_admit_in(keys_dir, audit_dir)` admits against isolated `TempDir`s, so the new test verifies hermetically that the helper yields `Some(substrate)` with `tenant_id = "local"` + a signed `plan_json` and emits `plan.admitted` — the proof the deny-all is no longer inert.

## Scope / follow-up

Cold path only. The **warm path** (`get_or_boot_warm_vm` → `boot_session_vm`) also passes `admit = None`; `boot_session_vm` already accepts an admit closure, but admitting there forces a **cold boot** (a substrate disables snapshot restore — `secret_workload ⇒ !use_snapshot`), a real perf tradeoff for warm sessions. Tracked as a follow-up rather than silently regressing warm-session latency under a "security closeout".

## Tests

Full `mvm-cli` lib suite (1008 pass), `clippy -D warnings --all-targets`, `fmt --all`, `check-no-spec-refs-in-comments`, `check-spec-numbers` — all green. End-to-end deny-all drop on a live bridge is box-gated; the bridge's fail-closed-to-deny-all behaviour is already covered by the WS-B `gateway_bridge` live tests.

## Note on bookkeeping

REFACTOR-STATUS / SPRINT / plan-doc updates for this slice (and for the already-landed #1008/#1010/#1013/#1015) are intentionally batched into one consolidated rollup once #1006 (the in-flight "WS-B MERGED" REFACTOR-STATUS rewrite) lands, to avoid a 3-way reconcile of its narrative block.
