### PR TITLE
feat(plan-200): admit the MCP warm-session VM too (claim-10 closeout)

### DIFF
--- a/crates/mvm-cli/src/commands/ops/mcp.rs
+++ b/crates/mvm-cli/src/commands/ops/mcp.rs
@@ -385,6 +385,24 @@ fn build_tool_registry() -> ToolRegistry {
     registry
 }
 
+/// The admission hook every MCP code-run boots under — cold and warm alike.
+/// MCP runs untrusted AI code, so each VM is admitted as a deny-all transient
+/// workload: the signed plan's `tenant_id` makes the libkrun/Vz supervisor
+/// spawn the enforcing gateway bridge (Firecracker enforces the same policy
+/// field via nftables). Without admission no bridge spawns and the deny-all is
+/// inert on the bridge backends.
+fn mcp_untrusted_admit()
+-> impl Fn(&std::path::Path, &str) -> Result<Option<crate::exec::SessionAuditSubstrate>> {
+    let backend = mvm_backend::backend::AnyBackend::auto_select()
+        .name()
+        .to_string();
+    crate::commands::vm::untrusted_transient_admit(
+        backend,
+        DEFAULT_VM_CPUS,
+        u64::from(DEFAULT_VM_MEM_MIB),
+    )
+}
+
 impl ExecDispatcher {
     /// Cold-boot path: every call boots its own transient VM via
     /// [`crate::exec::run_captured`]. Used when the client did not
@@ -408,20 +426,9 @@ impl ExecDispatcher {
             // MCP runs untrusted code: deny egress by default.
             network_policy: mvm_core::network_policy::NetworkPolicy::deny_all(),
         };
-        // Admit the run like any untrusted transient workload: the signed plan's
-        // tenant_id makes the libkrun/Vz supervisor spawn the enforcing gateway
-        // bridge, so the deny-all above is actually applied (without admission no
-        // bridge spawns and the deny-all is inert on those backends; Firecracker
-        // enforces the same field via nftables). Each cold call is its own
-        // admission against the host signer.
-        let backend = mvm_backend::backend::AnyBackend::auto_select()
-            .name()
-            .to_string();
-        let admit = crate::commands::vm::untrusted_transient_admit(
-            backend,
-            DEFAULT_VM_CPUS,
-            u64::from(DEFAULT_VM_MEM_MIB),
-        );
+        // Admit the run (see `mcp_untrusted_admit`): without it no bridge spawns
+        // and the deny-all above is inert on the libkrun/Vz backends.
+        let admit = mcp_untrusted_admit();
         crate::exec::run_captured(req, Some(&admit))
     }
 
@@ -467,9 +474,21 @@ impl ExecDispatcher {
         // tears down its own boot. That's correct (no leak) at the
         // cost of an extra VM start in pathological cases.
         let prefix = format!("mcp-session-{}", short_id(session_id));
-        let booted =
-            crate::exec::boot_session_vm(env, &prefix, DEFAULT_VM_CPUS, DEFAULT_VM_MEM_MIB, None)
-                .with_context(|| format!("booting warm VM for session '{session_id}'"))?;
+        // Admit the session VM like the cold path so the gateway bridge spawns and
+        // the deny-all is enforced (see `mcp_untrusted_admit`). A substrate forces
+        // a cold boot — snapshot restore goes through `FlakeRunConfig`, which
+        // carries `network_policy` but not the `tenant_id`/`plan_json` that trigger
+        // the bridge — so the first call of a session pays a cold boot; every later
+        // call reuses this running VM.
+        let admit = mcp_untrusted_admit();
+        let booted = crate::exec::boot_session_vm(
+            env,
+            &prefix,
+            DEFAULT_VM_CPUS,
+            DEFAULT_VM_MEM_MIB,
+            Some(&admit),
+        )
+        .with_context(|| format!("booting warm VM for session '{session_id}'"))?;
         let booted_name = booted.vm_name.clone();
         let handle = Arc::new(Mutex::new(booted));
 


### PR DESCRIPTION
## What

Admit the MCP **warm-session** VM, completing the claim-10 closeout #1017 started for the cold path.

## Why

#1017 routed the MCP cold path through admission, but `get_or_boot_warm_vm` → `boot_session_vm` still passed `admit = None`. So the first boot of an MCP session was un-admitted, and its `deny_all()` egress was **inert on the libkrun/Vz gateway-bridge backends** (no admitted plan → no bridge spawns; Firecracker still enforces the field via nftables). MCP runs untrusted AI code on both the cold and warm paths — same gap.

## How

- Build the same untrusted-transient admit hook for the session VM and pass `Some(&admit)` to `boot_session_vm`.
- A substrate forces a **cold boot**: snapshot restore goes through `FlakeRunConfig`, which carries `network_policy` but **not** the `tenant_id`/`plan_json` that trigger the bridge. So the first call of a session pays a cold boot; every later call reuses the running VM — warm reuse, the path's real benefit, is unaffected. Extending the snapshot path to carry the admitted plan is a larger, separate effort; security wins here.
- Dedup the admit construction shared by `run_cold` and `get_or_boot_warm_vm` into one `mcp_untrusted_admit()` free fn.

## Tests

Full `mvm-cli` lib suite (1008 pass), `clippy -D warnings --all-targets`, `fmt --all`, `check-no-spec-refs-in-comments`, `check-spec-numbers` — green. The admit helper (`untrusted_transient_admit`) is unit-tested in `commands::vm::up`; bridge-spawn-on-boot is box-gated, like the cold path.

With this, **both** MCP execution paths are admitted and the deny-all is enforced on the bridge backends.
