### PR TITLE
feat(plan-202): make the host-agent daemon the default (Phase 3a)

### DIFF
--- a/crates/mvm-backend/src/host_agent_spawn.rs
+++ b/crates/mvm-backend/src/host_agent_spawn.rs
@@ -259,13 +259,20 @@ impl Drop for HostAgentServicesGuard {
     }
 }
 
-/// Whether the host-agent daemon path is selected (opt-in during rollout —
-/// the default stays the proven per-VM fork until the daemon path is live-
-/// validated and made default).
+/// Whether the host-agent daemon path is selected. **Default: enabled** — the
+/// per-tenant daemon is the default for an admitted libkrun/vz workload, so
+/// `host.audit.v1` is available on a plain `up` (no `MVM_GATEWAY_BRIDGE`).
+/// `MVM_HOST_AGENT_DAEMON=0` is the opt-out escape hatch back to the per-VM
+/// broker fork during the transition; the fork is removed once the daemon path
+/// has soaked. Any value other than `0` leaves the daemon on.
 pub fn host_agent_daemon_enabled() -> bool {
-    std::env::var("MVM_HOST_AGENT_DAEMON")
-        .map(|v| v == "1")
-        .unwrap_or(false)
+    daemon_enabled_from(std::env::var("MVM_HOST_AGENT_DAEMON").ok().as_deref())
+}
+
+/// Pure decision for [`host_agent_daemon_enabled`] — unset ⇒ on; explicit `0`
+/// ⇒ off (fork); anything else ⇒ on.
+fn daemon_enabled_from(env: Option<&str>) -> bool {
+    env != Some("0")
 }
 
 /// Unifies the two start-path service guards (fork vs daemon) so a backend's
@@ -447,6 +454,15 @@ mod tests {
         // No host-agent.tenant marker ⇒ fork path ⇒ this must do nothing and
         // must not panic (so it's safe to call unconditionally in stop()).
         reap_host_agent_services_from_state(dir.path(), "vm-1");
+    }
+
+    #[test]
+    fn daemon_is_the_default_with_a_zero_opt_out() {
+        // Default (unset) is on; only an explicit "0" opts back to the fork.
+        assert!(daemon_enabled_from(None), "default is the daemon");
+        assert!(!daemon_enabled_from(Some("0")), "0 opts out to the fork");
+        assert!(daemon_enabled_from(Some("1")));
+        assert!(daemon_enabled_from(Some("")), "non-0 stays on the daemon");
     }
 
     #[test]

--- a/crates/mvm-backend/src/libkrun.rs
+++ b/crates/mvm-backend/src/libkrun.rs
@@ -572,7 +572,7 @@ impl VmBackend for LibkrunBackend {
         // defused once the VM is up and the `stop` path owns teardown.
         // libkrun proxies the guest's BROKER_PORT dial straight to this per-VM
         // socket — bound by the per-VM broker fork, or by the per-tenant daemon
-        // when the daemon path is opted in.
+        // (the default; opt out with MVM_HOST_AGENT_DAEMON=0).
         let broker_listen_socket =
             mvm_core::config::vm_vsock_port_socket(&config.name, mvm_guest::vsock::BROKER_PORT);
         let mut broker_guard = if crate::host_agent_spawn::host_agent_daemon_enabled() {

--- a/specs/plans/202-host-services-daemon.md
+++ b/specs/plans/202-host-services-daemon.md
@@ -51,11 +51,11 @@ The signer becomes a **supervised helper** of the host-agent daemon, holding **a
 
 ## Phase 3 — decouple availability from the egress bridge
 
-- [ ] **3a — registration driven by the admitted plan.** In `up`, drive `register_vm` from the admitted `ExecutionPlan` (any admitted workload registers; `host.audit.v1` implicitly available; catalog services require an explicit `services` binding and stay dispatch-gated). Remove the `MVM_GATEWAY_BRIDGE` coupling from host-service availability — that flag goes back to gating *only* the egress bridge / L4 policy.
-- [ ] **3b — zero-cost when unused.** A plan binding no services registers nothing and starts no daemon (assert no broker/signer process appears).
+- [x] **3a — daemon is the default.** `host_agent_daemon_enabled()` inverted: **default on**, `MVM_HOST_AGENT_DAEMON=0` is the opt-out escape hatch back to the per-VM fork during the soak. An admitted `up` already threads `tenant_id` unconditionally (the broker-spawn decoupling), so a plain `up` registers with the daemon and `host.audit.v1` is reachable **without `MVM_GATEWAY_BRIDGE`** — that flag now gates *only* the egress bridge / L4 policy. Catalog services still require an explicit `services` binding (dispatch-gated).
+- [ ] **3b — cost is `O(active tenants)`, not zero-per-workload.** Per ADR-084 `host.audit.v1` is implicitly available to *every* admitted workload, so the daemon runs whenever a tenant has an admitted workload — but it is **per-tenant and warm**, so the host-services process cost is `O(active tenants)`, not `O(VMs)`. (The per-VM audit-signer is still forked until Phase 2.) "Zero cost when unused" holds at the install level — no admitted workloads ⇒ no daemon.
 - [ ] **3c — `mvmctl doctor`** reports the per-tenant daemon state (running / warm / absent) so the move from per-VM is observable.
 
-**Verify:** a plain `mvmctl up --tenant local` (no `MVM_GATEWAY_BRIDGE`) makes `host.audit.v1` reachable; a no-services plan spawns nothing; live libkrun round-trip green (the [Plan 125 E5.3b-4](125-cli-sdk-dx-surface.md) probe, now without the bridge env).
+**Verify:** a plain `mvmctl up --tenant local` (no `MVM_GATEWAY_BRIDGE`) makes `host.audit.v1` reachable — **PROVEN live on libkrun 2026-06-16**: the daemon spawned per-tenant (control socket mode 0700), bound the VM's `BROKER_PORT` socket on register, the in-guest probe's 22 emits verified clean via `verify_workload_chain`, and teardown deregistered while the daemon stayed warm. The `MVM_HOST_AGENT_DAEMON=1` boot proved the path; the default-on boot is the same code with the env-default flipped. vz live-verify + the `doctor` line (3c) remain.
 
 ## Phase 4 — supervision + crash semantics
 


### PR DESCRIPTION
**Flips the per-tenant host-agent daemon on by default** for admitted libkrun/vz workloads. The daemon path is [live-proven](https://github.com/tinylabscom/mvm/pull/1028) end-to-end; Phase 1 built it flag-gated, this makes it the default.

## What

- `host_agent_daemon_enabled()` inverted → **default on**; `MVM_HOST_AGENT_DAEMON=0` is the opt-out escape hatch back to the per-VM broker fork during the soak (the fork is deleted in Phase 6).
- Decision extracted to a pure `daemon_enabled_from` + unit-tested (unset/non-`0` → on; `0` → fork).

## Effect

A plain admitted `mvmctl up --tenant local` now:
- registers with the per-tenant daemon (one daemon, `O(active tenants)` not `O(VMs)`),
- makes `host.audit.v1` reachable **without `MVM_GATEWAY_BRIDGE`** — that flag now gates *only* the egress bridge / L4 policy.

## Why it's safe

- The daemon path itself is **live-proven** (libkrun, real `~/.mvm`, no `MVM_GATEWAY_BRIDGE`): per-tenant daemon spawned, `0700` control socket, register bound the `BROKER_PORT` socket, the in-guest probe's 22 emits verified clean via `verify_workload_chain`, teardown deregistered while the daemon stayed warm. This PR is the same code with the env-default flipped (the one-line logic is unit-tested).
- The fork is **one env var away** (`MVM_HOST_AGENT_DAEMON=0`) for the whole soak.
- Firecracker is unaffected (no broker leg).

## Remaining (tracked in Plan 202)

vz live-verify, the `doctor` daemon-state line (3c), Phase 2 (daemon-ize the audit-signer), Phase 6 (delete the fork).

## Gates

6 `host_agent_spawn` tests (incl. the new default test) · `clippy -p mvm-backend --all-targets -D warnings` · nightly `fmt --all --check` · `check-no-spec-refs-in-comments` — clean.