### PR TITLE
fix(plan-200): thread the resolved network policy through the up boot path

### DIFF
--- a/crates/mvm-cli/src/commands/shared/start.rs
+++ b/crates/mvm-cli/src/commands/shared/start.rs
@@ -32,6 +32,11 @@ pub struct VmStartParams<'a> {
     pub port_mappings: &'a [config::PortMapping],
     /// Warm-pool target (`--warm-pool-size`); 0 = off.
     pub warm_pool_size: u32,
+    /// Resolved egress policy (deny-all default, or the `--network-preset` /
+    /// `--network-allow` selection). Threaded onto `VmStartConfig` so the
+    /// gateway-bridge backends enforce the chosen posture instead of
+    /// fail-closing to deny-all regardless of the request.
+    pub network_policy: mvm_core::network_policy::NetworkPolicy,
 }
 
 impl VmStartParams<'_> {
@@ -49,6 +54,7 @@ impl VmStartParams<'_> {
             cpus: self.cpus,
             memory_mib: self.memory_mib,
             mem_initial_mib: self.mem_initial_mib,
+            network_policy: self.network_policy,
             warm_pool_size: self.warm_pool_size,
             ports: self
                 .port_mappings
@@ -96,5 +102,53 @@ impl VmStartParams<'_> {
             // for every caller that goes through `VmStartParams`.
             ..Default::default()
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use mvm_core::network_policy::NetworkPolicy;
+
+    fn params(network_policy: NetworkPolicy) -> VmStartParams<'static> {
+        VmStartParams {
+            name: "vm".into(),
+            rootfs_path: "/rootfs.ext4".into(),
+            vmlinux_path: "/vmlinux".into(),
+            initrd_path: None,
+            verity_path: None,
+            roothash: None,
+            revision_hash: "rev".into(),
+            flake_ref: ".".into(),
+            profile: None,
+            cpus: 1,
+            memory_mib: 256,
+            mem_initial_mib: None,
+            volumes: &[],
+            config_files: &[],
+            secret_files: &[],
+            port_mappings: &[],
+            warm_pool_size: 0,
+            network_policy,
+        }
+    }
+
+    // Regression: `VmStartParams` previously carried no egress policy, so
+    // `into_start_config()` fell through to `VmStartConfig::default()` =
+    // deny-all for every `up` boot — silently ignoring `--network-preset` /
+    // `--network-allow`. The resolved policy must survive the conversion so the
+    // backend (Firecracker nftables; the libkrun/Vz gateway bridge) enforces
+    // the requested posture instead of always deny-all.
+    #[test]
+    fn into_start_config_preserves_the_resolved_network_policy() {
+        let unrestricted = NetworkPolicy::unrestricted();
+        let sc = params(unrestricted.clone()).into_start_config();
+        assert_eq!(sc.network_policy, unrestricted);
+        assert!(sc.network_policy.is_unrestricted());
+
+        let deny = NetworkPolicy::deny_all();
+        let sc = params(deny.clone()).into_start_config();
+        assert_eq!(sc.network_policy, deny);
+        assert!(!sc.network_policy.is_unrestricted());
     }
 }

--- a/crates/mvm-cli/src/commands/vm/up.rs
+++ b/crates/mvm-cli/src/commands/vm/up.rs
@@ -1809,6 +1809,7 @@ pub(super) fn cmd_run(params: RunParams<'_>) -> Result<()> {
             kernel_path: Some(kernel),
             cpus: direct_cpus,
             memory_mib: direct_mem,
+            network_policy: network_policy.clone(),
             ..Default::default()
         };
         // Attach the verity-sealed runtime overlay (Firecracker only, non-fatal).
@@ -2311,6 +2312,7 @@ pub(super) fn cmd_run(params: RunParams<'_>) -> Result<()> {
             secret_files: &secret_files,
             port_mappings: &port_mappings,
             warm_pool_size,
+            network_policy: network_policy.clone(),
         }
         .into_start_config();
         // Attach the verity-sealed runtime overlay (Firecracker only, non-fatal).
@@ -2666,6 +2668,7 @@ pub(super) fn cmd_run(params: RunParams<'_>) -> Result<()> {
                 port_mappings: &w_port_mappings,
                 // `--wait` is a one-shot workload; no warm-pool claim on this path.
                 warm_pool_size: 0,
+                network_policy: network_policy.clone(),
             }
             .into_start_config();
             // Attach the verity-sealed runtime overlay (Firecracker only, non-fatal).


### PR DESCRIPTION
## What

Thread the resolved egress `NetworkPolicy` through the `mvmctl up` boot path. Surfaced by live macOS validation.

## Why

`up` resolves a `NetworkPolicy` from `--network-preset` / `--network-allow` in `run()`, but `VmStartParams` (the builder that produces the backend's `VmStartConfig`) **had no `network_policy` field** — so `into_start_config()` fell through to `VmStartConfig::default()` = **deny-all** for every boot. The resolved policy was dropped before the backend saw it: `up --network-preset unrestricted` launched with deny-all egress regardless of the flag.

## How

- Add `network_policy` to `VmStartParams`; set it in `into_start_config()`.
- Populate it at the three `cmd_run` boot sites (main cold-boot, `--watch` re-boot, `MVM_DIRECT_BOOT` direct-boot).

The backend already consumes `VmStartConfig.network_policy`: Firecracker via nftables, libkrun/Vz via the gateway bridge's no-bundle arm (`bare_network_policy_egress`).

## Scope / honesty

This is the CLI-side plumbing the policy needs. On **Firecracker** it makes `up --network-preset` actually take effect. On **libkrun/Vz** the gateway-bridge path that would enforce it is **separately incomplete** — `up.rs:2253` documents that the libkrun gvproxy bridge "is not yet working end-to-end" (opt-in behind `MVM_GATEWAY_BRIDGE=1`); live testing on this branch confirmed that path drops **all** egress regardless of policy (deny-all / unrestricted / allow-list all blocked). So this fix is a **necessary prerequisite** for libkrun/Vz `up` egress to honor the chosen policy, not a complete end-to-end fix for those backends — that remains the gateway-bridge (uniform-L4) work.

## Tests

`into_start_config_preserves_the_resolved_network_policy` (regression for the dropped field); full `mvm-cli` lib suite (1009 pass), clippy `-D warnings --all-targets`, fmt, spec gates green.
