### PR TITLE
fix(net): tie gvproxy/passt to supervisor lifetime (no orphaned helpers on supervisor death)

### DIFF
--- a/crates/deps/libkrun-sys/src/child_lifecycle.rs
+++ b/crates/deps/libkrun-sys/src/child_lifecycle.rs
@@ -1,0 +1,67 @@
+//! Tie a spawned networking helper (gvproxy / passt) to the lifetime of the
+//! supervisor that spawns it, so a dead supervisor never orphans the helper.
+//!
+//! The supervisor's `SIGTERM` handler already reaps gvproxy on a graceful
+//! `mvmctl stop` / `kill`, but a `SIGKILL` or a panic it can't catch leaves the
+//! helper re-parented to init — accumulating as a leaked daemon (commonly stuck
+//! at gvproxy's "waiting for clients" when the VM never connected).
+//!
+//! On Linux, `PR_SET_PDEATHSIG` closes that gap at the source: the kernel
+//! delivers `SIGTERM` to the child the instant its parent dies, for *any*
+//! reason. macOS has no equivalent primitive for an unmodifiable child, so the
+//! orphan-reaper (`mvmctl cache prune` / reconcile-on-entry) is the backstop
+//! there — this call is a no-op on non-Linux hosts.
+
+use std::process::Command;
+
+/// Arrange for `cmd`'s child to receive `SIGTERM` if this process (its parent)
+/// dies. Call it on the `Command` immediately before `spawn()`.
+pub(crate) fn tie_to_parent_death(cmd: &mut Command) {
+    #[cfg(target_os = "linux")]
+    {
+        use std::os::unix::process::CommandExt;
+        // SAFETY: the closure runs in the forked child after `fork(2)` and
+        // before `execve(2)`, where only async-signal-safe functions are
+        // permitted — `prctl`, `getppid`, and `_exit` all qualify
+        // (signal-safety(7)). `PR_SET_PDEATHSIG` is preserved across the
+        // following `execve` for a non-set-id binary (gvproxy / passt are
+        // not set-id). The `getppid() == 1` check closes the race where the
+        // parent exits between `fork` and `prctl`: if we were already
+        // re-parented to init, honour the death signal we just missed.
+        unsafe {
+            cmd.pre_exec(|| {
+                if libc::prctl(libc::PR_SET_PDEATHSIG, libc::SIGTERM as libc::c_ulong) != 0 {
+                    return Err(std::io::Error::last_os_error());
+                }
+                if libc::getppid() == 1 {
+                    libc::_exit(0);
+                }
+                Ok(())
+            });
+        }
+    }
+    #[cfg(not(target_os = "linux"))]
+    {
+        // No parent-death primitive for an unmodifiable child on macOS; the
+        // orphan-reaper is the backstop. Touch `cmd` so the arg isn't unused.
+        let _ = cmd;
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::tie_to_parent_death;
+    use std::process::Command;
+
+    #[test]
+    fn tied_command_still_spawns_and_exits_clean() {
+        // On Linux this exercises the real `pre_exec` `prctl` + `getppid` path
+        // in an actual fork/exec — the parent (this test) is alive, so the
+        // child proceeds to exec `true`. On macOS it is the documented no-op.
+        // Either way the command must still run to completion.
+        let mut cmd = Command::new("true");
+        tie_to_parent_death(&mut cmd);
+        let status = cmd.status().expect("spawn `true`");
+        assert!(status.success());
+    }
+}

--- a/crates/deps/libkrun-sys/src/gvproxy.rs
+++ b/crates/deps/libkrun-sys/src/gvproxy.rs
@@ -333,6 +333,9 @@ pub fn spawn(
     cmd.stdout(std::process::Stdio::from(stdio_log))
         .stderr(std::process::Stdio::from(stdio_log_err));
 
+    // Tie gvproxy to the supervisor's lifetime: a SIGKILL'd / panicked
+    // supervisor (which the SIGTERM handler can't catch) must not orphan it.
+    crate::child_lifecycle::tie_to_parent_death(&mut cmd);
     let mut child = cmd.spawn().map_err(GvproxyError::Spawn)?;
 
     // Record the pid before the poll loop: the SIGTERM handler reaps

--- a/crates/deps/libkrun-sys/src/lib.rs
+++ b/crates/deps/libkrun-sys/src/lib.rs
@@ -51,6 +51,11 @@ pub mod passt;
 #[cfg(target_family = "unix")]
 pub mod gvproxy;
 
+// Tie a spawned networking helper to its supervisor's lifetime so a dead
+// supervisor never orphans it (Linux `PR_SET_PDEATHSIG`; no-op elsewhere).
+#[cfg(target_family = "unix")]
+mod child_lifecycle;
+
 // Sync length-prefixed JSON framing for the supervisor control
 // channels. Colocated with the `Supervisor*Config` wire types it frames so both the
 // `mvm-backend` writer (`claim_standby`) and the supervisor-bin reader reach it without

--- a/crates/deps/libkrun-sys/src/passt.rs
+++ b/crates/deps/libkrun-sys/src/passt.rs
@@ -219,6 +219,9 @@ pub fn spawn(scratch_dir: &std::path::Path) -> Result<PasstHandle, PasstError> {
         source: e,
     })?;
 
+    // Tie passt to the supervisor's lifetime so a SIGKILL'd / panicked
+    // supervisor never orphans it (Linux `PR_SET_PDEATHSIG`).
+    crate::child_lifecycle::tie_to_parent_death(&mut cmd);
     let child = cmd.spawn().map_err(PasstError::Spawn)?;
 
     // Close the child end on the parent side — the child inherits


### PR DESCRIPTION
## What

Tie the gvproxy / passt networking helpers to their supervisor's lifetime so a dead supervisor never orphans them. (Follow-up to finding ~20 leaked helpers on a dev box.)

## Why

The supervisor's `SIGTERM` handler reaps gvproxy on a graceful `mvmctl stop` / `kill`, but a **SIGKILL or panic it can't catch** leaves the helper re-parented to init — accumulating as a leaked daemon, commonly stuck at gvproxy's "waiting for clients" (the VM never connected, so there's no peer-close to make it exit).

## How

`child_lifecycle::tie_to_parent_death(&mut cmd)` is called immediately before spawning gvproxy and passt:
- **Linux:** a `pre_exec` hook installs `PR_SET_PDEATHSIG(SIGTERM)` — the kernel signals the helper the instant its parent dies, for *any* reason (including the SIGKILL/panic the supervisor's own handler can't). A `getppid() == 1` check in the same hook closes the fork→prctl race.
- **macOS:** no equivalent primitive exists for an unmodifiable child, so it's a documented no-op; the orphan-reaper (`mvmctl cache prune` / reconcile-on-entry) stays the backstop there. (Making `cache prune` reap orphans by default is the companion change.)

This only ever affects a helper whose supervisor is **already dead** — a live VM's supervisor is alive, so its gvproxy is untouched.

## Tests

`tied_command_still_spawns_and_exits_clean` exercises the real `pre_exec` `prctl`+`getppid` path on Linux (parent alive ⇒ child execs `true`) and the no-op on macOS. macOS `cargo check`/clippy/fmt green; the **Linux target was cross-compiled with `cargo-zigbuild`** since macOS clippy skips the `cfg(linux)` `prctl` branch + passt.
