### PR TITLE
feat(cache): reap orphaned dead-microVM helpers by default in cache prune

### DIFF
--- a/crates/mvm-cli/src/commands/ops/cache.rs
+++ b/crates/mvm-cli/src/commands/ops/cache.rs
@@ -30,14 +30,17 @@ pub(in crate::commands) enum CacheAction {
         /// these are slot directories under `~/.mvm/templates/`.)
         #[arg(long)]
         orphan_builds: bool,
-        /// Also reap orphaned per-VM helpers — `mvm-libkrun-supervisor`,
-        /// `gvproxy`, and console-tail processes that were reparented
-        /// to launchd when the parent `mvmctl` was killed mid-run, plus
-        /// their `~/.cache/mvm/builder-vm/vms/<id>/` cache directories.
-        /// Skips dirs whose PIDs are still children of a live `mvmctl`
-        /// (those are in-flight `dev up` runs, not orphans).
+        /// Skip reaping orphaned per-VM helpers. By default `prune` reaps
+        /// `mvm-libkrun-supervisor` / `gvproxy` / console-tail processes that
+        /// were reparented to launchd when their parent `mvmctl` was killed
+        /// mid-run, plus their `~/.cache/mvm/builder-vm/vms/<id>/` cache
+        /// directories — so dead microVMs don't accumulate. The sweep is
+        /// liveness-aware: a running VM (a detached `up -d`, the persistent dev
+        /// builder, any in-flight `dev up`) is spared; only already-dead
+        /// helpers are reaped. Pass this to prune disk only, touching no
+        /// processes.
         #[arg(long)]
-        reap_orphans: bool,
+        no_reap_orphans: bool,
     },
     /// Show cache directory path and disk usage
     Info {
@@ -159,13 +162,13 @@ pub(in crate::commands) fn run(_cli: &Cli, args: Args, _cfg: &MvmConfig) -> Resu
         CacheAction::Prune {
             dry_run,
             orphan_builds,
-            reap_orphans,
+            no_reap_orphans,
         } => {
-            // Reap orphaned per-VM helpers. Done first so subsequent
-            // steps see a clean process list and so the
-            // sweeper can drop the per-VM cache dirs along with the
-            // helpers that were holding their sockets/PIDs.
-            if reap_orphans {
+            // Reap orphaned per-VM helpers by default (liveness-aware: live VMs
+            // are spared). Done first so subsequent steps see a clean process
+            // list and so the sweeper can drop the per-VM cache dirs along with
+            // the helpers that were holding their sockets/PIDs.
+            if !no_reap_orphans {
                 match super::super::env::dev_vz::reap_orphaned_vm_helpers(dry_run) {
                     Ok(o) => {
                         if o.killed == 0 && o.removed_dirs == 0 {

--- a/crates/mvm-cli/src/commands/tests.rs
+++ b/crates/mvm-cli/src/commands/tests.rs
@@ -2853,12 +2853,13 @@ fn test_cache_prune_dry_run() {
                 CacheAction::Prune {
                     dry_run,
                     orphan_builds,
-                    reap_orphans,
+                    no_reap_orphans,
                 },
         }) => {
             assert!(dry_run);
             assert!(!orphan_builds);
-            assert!(!reap_orphans);
+            // Reaping is on by default; `--no-reap-orphans` was not passed.
+            assert!(!no_reap_orphans);
         }
         _ => panic!("Expected Cache Prune command"),
     }
@@ -2873,36 +2874,52 @@ fn test_cache_prune_orphan_builds_flag() {
                 CacheAction::Prune {
                     dry_run,
                     orphan_builds,
-                    reap_orphans,
+                    no_reap_orphans,
                 },
         }) => {
             assert!(!dry_run);
             assert!(orphan_builds);
-            assert!(!reap_orphans);
+            // Reaping is on by default; `--no-reap-orphans` was not passed.
+            assert!(!no_reap_orphans);
         }
         _ => panic!("Expected Cache Prune command"),
     }
 }
 
 #[test]
-fn test_cache_prune_reap_orphans_flag() {
-    // `--reap-orphans` sweeps orphaned mvm-libkrun-supervisor /
-    // gvproxy / console-tail processes left behind by killed
-    // `mvmctl dev up` runs, plus their per-VM cache dirs.
-    let cli = Cli::try_parse_from(["mvmctl", "cache", "prune", "--reap-orphans"]).unwrap();
+fn test_cache_prune_no_reap_orphans_flag() {
+    // `prune` reaps orphaned mvm-libkrun-supervisor / gvproxy / console-tail
+    // processes (and their per-VM cache dirs) by default; `--no-reap-orphans`
+    // opts out so a disk-only prune touches no processes.
+    let cli = Cli::try_parse_from(["mvmctl", "cache", "prune", "--no-reap-orphans"]).unwrap();
     match cli.command {
         Commands::Cache(cache::Args {
             action:
                 CacheAction::Prune {
                     dry_run,
                     orphan_builds,
-                    reap_orphans,
+                    no_reap_orphans,
                 },
         }) => {
             assert!(!dry_run);
             assert!(!orphan_builds);
-            assert!(reap_orphans);
+            assert!(no_reap_orphans);
         }
+        _ => panic!("Expected Cache Prune command"),
+    }
+}
+
+#[test]
+fn test_cache_prune_reaps_orphans_by_default() {
+    // Regression: a bare `cache prune` must reap orphans (dead microVMs don't
+    // accumulate); the opt-out flag is off.
+    let cli = Cli::try_parse_from(["mvmctl", "cache", "prune"]).unwrap();
+    match cli.command {
+        Commands::Cache(cache::Args {
+            action: CacheAction::Prune {
+                no_reap_orphans, ..
+            },
+        }) => assert!(!no_reap_orphans),
         _ => panic!("Expected Cache Prune command"),
     }
 }
@@ -2917,7 +2934,7 @@ fn test_cache_prune_combined_flags() {
         "prune",
         "--dry-run",
         "--orphan-builds",
-        "--reap-orphans",
+        "--no-reap-orphans",
     ])
     .unwrap();
     match cli.command {
@@ -2926,12 +2943,12 @@ fn test_cache_prune_combined_flags() {
                 CacheAction::Prune {
                     dry_run,
                     orphan_builds,
-                    reap_orphans,
+                    no_reap_orphans,
                 },
         }) => {
             assert!(dry_run);
             assert!(orphan_builds);
-            assert!(reap_orphans);
+            assert!(no_reap_orphans);
         }
         _ => panic!("Expected Cache Prune command"),
     }

--- a/crates/mvm/src/vm/reconcile.rs
+++ b/crates/mvm/src/vm/reconcile.rs
@@ -17,7 +17,7 @@
 //! **Cheapness is a hard constraint.** Liveness is a `kill(pid, 0)`
 //! stat against the recorded supervisor pid files only — never `pgrep` / `ps`
 //! (which spawn subprocesses), never a VM boot, never Nix. The heavier
-//! helper-PID argv sweep stays in `mvmctl cache prune --reap-orphans`. This
+//! helper-PID argv sweep stays in `mvmctl cache prune` (on by default). This
 //! reuses the live-vs-orphan discrimination from `mvm-cli`'s
 //! `env::dev_vz` reaper rather than reinventing the policy; the bare
 //! syscall is restated here only because the lower `mvm` crate can't depend on


### PR DESCRIPTION
## What

Make `mvmctl cache prune` reap orphaned dead-microVM helpers **by default** (add `--no-reap-orphans` to opt out). Companion to #1035.

## Why

Reaping orphaned per-VM helpers (`mvm-libkrun-supervisor` / `gvproxy` / console-tail processes reparented to launchd when their parent `mvmctl` was killed mid-run) was gated behind `--reap-orphans` — so it was never run and dead microVMs accumulated (a dev box collected ~20). The whole point of the sweep is to keep dead VMs from piling up; that shouldn't require remembering a flag.

## Safe to default

The sweep (`reap_orphaned_vm_helpers`) is already **liveness-aware** and only ever touches an *already-dead* VM's leftovers:
- A running VM is **spared** — a detached `up -d` workload (under `~/.mvm/vms/`), the persistent dev builder, and any in-flight `dev up` all run launchd-parented supervisors *by design*; the two-phase classify treats `parent == launchd` as their steady state, not an orphan signal, and only reaps a helper once its supervisor is confirmed gone.
- Managed dirs are never auto-removed.

So a long-running VM the user deliberately started is never killed.

## How

Invert `reap_orphans` → `no_reap_orphans`; reap when `!no_reap_orphans`. Updated the parse tests (bare `prune` now reaps; `--no-reap-orphans` opts out; added a default-reaps regression test) and the `reconcile` doc reference.

## Tests

6 `cache prune` parse tests pass; clippy `-D warnings --all-targets`, fmt, spec gates green.
