### PR TITLE
docs(adrs): record bundle and GPU posture decisions

### DIFF
--- a/specs/adrs/085-bundled-egress-gateway.md
+++ b/specs/adrs/085-bundled-egress-gateway.md
@@ -1,0 +1,98 @@
+# ADR-085 — The egress gateway ships inside the mvmctl artifact
+
+**Status:** Proposed
+**Extends:** [ADR-082](082-rust-native-egress-gateway.md) — from "adopt the Rust-native gateway" to "ship it in the box"
+**Depends on:** [Plan 193](../plans/193-rvproxy-network-substrate.md) (substrate cutover), [Plan 199](../plans/199-host-runtime-packaging-and-crate-boundaries.md) (host packaging)
+**Preserves:** [ADR-058](058-claim-10-bytes-leaving-trust-boundary.md) no-bypass invariant; claim 10 (default-deny egress); [Plan 129](../plans/129-secrets-subsystem.md) substitution; [Plan 141](../plans/141-vz-payload-tap-and-rust-owned-shuffle.md) flow observation
+
+## Context
+
+ADR-082 settled *which daemon runs at the egress chokepoint*: the Rust-native
+gateway (`rvproxy`) replaces the vendored Go gateway (gvproxy) and passt, behind
+a parity gate. It did not settle *how that daemon reaches the user's machine*.
+
+Today the gateway is an install-time prerequisite. On macOS the user runs `brew
+install slp/krun/gvproxy`; on Linux they install passt from the distro. That is
+the same first-run friction as the rest of the Homebrew trio — except it sits at
+the security chokepoint, so it cannot be made optional.
+
+The no-bypass invariant (ADR-058) is the structural reason this matters. Tools
+that lean on a VMM's built-in networking can drop the external gateway entirely;
+we cannot, because every guest packet must traverse virtio-net and pass an
+auditing/enforcing/substituting gateway before egress. We *must* ship a gateway.
+The only open question is whether the user installs it separately or it arrives
+in the box.
+
+The gateway is now uniquely suited to bundling:
+
+- It is a **single self-contained Rust binary we build** — no Go toolchain, no
+  foreign runtime, no per-distro build like passt.
+- libkrun `krun_add_net_unixgram` interop is **already proven** (ADR-082
+  §Validation: `run_libkrun_gvproxy_bridge` DHCP round-trip passes with the
+  gateway as `MVM_GATEWAY_BIN`, 2026-06-05).
+- Its native policy / audit / substitution seams are the ones claim 10,
+  Plan 129, and Plan 141 want anyway (Plan 193), so bundling it and adopting it
+  are the same motion.
+
+Bundling gvproxy (a Go binary) or passt (a Linux-only C binary) would be a
+vendoring chore at the trust boundary. Bundling our own gateway is not.
+
+## Decision
+
+The egress gateway is distributed **inside** the `mvmctl` release artifact, not
+as a separate dependency.
+
+- The CLI resolves its gateway from the bundle by default. `MVM_GATEWAY_BIN`
+  remains a development override; the flag/env surface stays generic (no project
+  slug in code), per ADR-082.
+- **End-state: the bundled gateway is the *sole* gateway.** gvproxy leaves the
+  macOS install contract once ADR-082's macOS parity gate is green. passt remains
+  the Linux fallback only until the Linux parity gate (a Plan 193 follow-on,
+  explicitly out of ADR-082 Phase 1) closes.
+- The bundled gateway carries claim 10 / Plan 129 / Plan 141 through its native
+  policy + audit seams, not the spliced `mvm-hostd` `gateway_bridge`. The splice
+  + `etherparse` scaffolding is deleted when the fallback window closes.
+- `mvmctl doctor` reports the resolved gateway *source* (`bundled` / `override`
+  / `legacy-tap`) on the gateway line, mirroring the `builder backend` line, so
+  the in-box path is observable.
+
+Bundling is decoupled from defaulting: the binary can be present-and-selectable
+before it becomes the default. The parity gate still gates the default flip — a
+regression here is a claim-10 regression.
+
+## Sequencing
+
+1. **Bundle present.** The gateway ships in the artifact; resolved from the
+   bundle but selectable via override. Default unchanged (gvproxy/passt).
+2. **macOS parity gate green** (ADR-082 Phase 1, libkrun + Vz) → flip the macOS
+   default to the bundled gateway → drop gvproxy from the macOS install contract.
+3. **Linux parity gate green** (Plan 193 follow-on) → drop passt → remove the
+   splice/`gateway_bridge` scaffolding.
+
+## Consequences
+
+- One Homebrew package (gvproxy) leaves the macOS first-run path; passt leaves
+  the Linux path at step 3. This is the first concrete cut into the trio.
+- The gateway is version-pinned to the CLI by construction (same artifact) —
+  no skew between a bundled-but-stale gateway and the CLI that drives it.
+- Bundle size grows by one static binary; tracked under [Plan 156](../plans/156-binary-size-reduction.md).
+- The security-load-bearing networking code (claim 10 / 129 / 141) collapses
+  from a spliced reconstruction into a contract with an in-box daemon we own.
+
+## Out of scope
+
+- Vendoring libkrun/libkrunfw and the full relocatable dependency-free bundle —
+  [ADR-086](086-relocatable-dependency-free-host-bundle.md).
+- Inbound TLS (mvmd's edge, per ADR-058).
+- Linux/passt-replacement parity timing (Plan 193 follow-on).
+- Bring-up performance — the gateway does not own it (ADR-082 §"not a
+  performance decision").
+
+## References
+
+- [ADR-082](082-rust-native-egress-gateway.md) — adopt the Rust-native gateway
+- [ADR-058](058-claim-10-bytes-leaving-trust-boundary.md) — no-bypass invariant, claim 10
+- [ADR-055](055-passt-virtio-net.md) — gvproxy / passt gateway choice
+- [Plan 193](../plans/193-rvproxy-network-substrate.md) — substrate cutover
+- [Plan 199](../plans/199-host-runtime-packaging-and-crate-boundaries.md) — host packaging
+- [Plan 129](../plans/129-secrets-subsystem.md), [Plan 141](../plans/141-vz-payload-tap-and-rust-owned-shuffle.md), [Plan 156](../plans/156-binary-size-reduction.md)

--- a/specs/adrs/086-relocatable-dependency-free-host-bundle.md
+++ b/specs/adrs/086-relocatable-dependency-free-host-bundle.md
@@ -1,0 +1,146 @@
+# ADR-086 — The mvmctl distribution is a relocatable, dependency-free, signed bundle
+
+**Status:** Accepted — Option A (vendor + sign the VMM ourselves), staged. One pre-merge checklist item remains (see §"Why Option A, and how it's staged")
+**Date:** 2026-06-17
+**Owner:** MVM Project
+**Builds on:** [Plan 199](../plans/199-host-runtime-packaging-and-crate-boundaries.md) (host runtime packaging); [ADR-085](085-bundled-egress-gateway.md) (bundled gateway)
+**Touches the trust model:** [ADR-002](002-microvm-security-posture.md) — who builds and signs the in-box VMM
+**Preserves:** [ADR-046](046-builder-vm-via-libkrun.md) two-artifact-layers rule; claim 6 (hash-verified download)
+
+## Context
+
+Plan 199 (WS-A done) made the default install a signed release binary / one-line
+installer, added an optional Nix host package for `mvmctl`, kept native VMM
+linkage explicit and opt-in, and forbade source-checkout builds from downloading
+published artifacts. It deliberately stopped short of one thing: vendoring the
+VMM so the published artifact is dependency-free.
+
+That is the remaining first-run cliff. On macOS a user must `brew install
+slp/krun/{libkrun,libkrunfw,gvproxy}` before `mvmctl` works. The trio is where
+we lose the comparison against tools that install with one command and run. The
+security substrate behind `mvmctl` is irrelevant to a developer who never gets
+past step one — DX is the gate, the substrate is the moat behind it.
+
+The mechanics of a relocatable bundle are well understood and already partly in
+our toolbox:
+
+- Ship the CLI, the VMM dylibs, the gateway (ADR-085), the guest kernel, and the
+  agent rootfs in one directory.
+- Make dynamic linkage load-relative: `$ORIGIN`-relative rpath on Linux
+  (patchelf), `@loader_path` install names on macOS. Nothing resolves to a
+  system prefix.
+- Bake the guest kernel at build time rather than extracting it from the dylib's
+  `.rodata` at runtime (today's `extract_bundled_kernel()` path). Runtime
+  extraction keeps working; baking is the cleaner bundle shape, not a hard
+  requirement.
+- Produce the whole thing from one root flake that is *both* the dev shell and
+  the release packager, sharing derivations. The end-user Nix consumer derivation
+  merely **relocates** the prebuilt signed tarball.
+
+`mvm-cli/build.rs` already cross-compiles and embeds the host-VM binaries; this
+ADR extends the same "ship what the runtime needs in the artifact" instinct from
+those binaries to the VMM, kernel, and gateway.
+
+This does **not** weaken the source-checkout invariant. Source checkouts still
+build every image locally from the in-repo flakes (ADR-046). Only the *published*
+artifact is prebuilt — the same posture the GitHub-release prebuilts already
+hold. The consumer-relocates-prebuilt path is an end-user path, never a
+source-checkout prerequisite.
+
+## Decision
+
+We adopt **Option A** — vendor, pin, build, and sign the VMM ourselves — staged
+so the VMM-vendoring is the last, separable step (see §"Why Option A, and how
+it's staged").
+
+The published `mvmctl` distribution is a single **relocatable, signed,
+dependency-free bundle**. On a supported host the one-line installer drops a
+self-contained directory and `mvmctl machine run ...` works with **no
+package-manager prerequisites**.
+
+- The bundle vendors: the CLI, the egress gateway (ADR-085), libkrun, libkrunfw,
+  the guest kernel (baked at build time), and the agent rootfs.
+- Dynamic linkage is load-relative (`$ORIGIN` / `@loader_path`); a wrapper points
+  the CLI at the bundled rootfs.
+- One root flake builds all components and emits the bundle; its dev shell and
+  release packager share derivations. The Nix consumer path relocates the signed
+  prebuilt; source checkouts continue to build locally from in-repo flakes.
+- The bundle is signed and the installer verifies before install — an extension
+  of the existing dev-image hash-verify posture (claim 6), not a new mechanism.
+
+## Why Option A, and how it's staged
+
+The choice was whether to vendor and sign the C VMM (libkrun/libkrunfw)
+ourselves, or keep it from the third-party slp/krun Homebrew tap. We vendor it,
+for three reasons:
+
+- **The alternative does not solve the problem.** Keeping the VMM on the tap
+  leaves `brew install slp/krun/{libkrun,libkrunfw}` in the first-run path — the
+  trio becomes a duo, the user still hits a package-manager wall, and the
+  zero-to-running metric does not move. A half-open gate is a closed gate.
+- **It is a supply-chain upgrade, not a downgrade.** Today we depend on whatever
+  version the tap ships: unpinned, mutable, signed by someone else, and a
+  `brew upgrade` can silently break our FFI (`extract_bundled_kernel` from the
+  dylib `.rodata`, `krun_add_net_unixgram`, the `libkrun-sys` bindings). ADR-002
+  already trusts the host with the hypervisor binary; vendoring does not widen
+  that boundary, it changes the *origin* to a pinned-rev, reproducible,
+  release-key-signed build. Pinned + signed + reproducible beats mutable +
+  foreign on every axis the threat model cares about.
+- **The VMM-vendoring is the last, separable step**, so committing now is
+  low-risk: the expensive machinery (gateway bundle, kernel, rootfs, rpath
+  rewriting, signed installer) lands first regardless and proves itself before
+  any VMM source is pinned.
+
+**Staging.** Each step ships and is useful on its own. macOS first — the trio
+pain is worst there and gateway interop is proven (ADR-085 / ADR-082
+§Validation):
+
+1. **Bundle machinery.** Gateway (ADR-085) + kernel + agent rootfs in one
+   relocatable, load-relative, signed artifact with a verifying installer. These
+   are components we already build; this proves the plumbing.
+2. **Vendor the VMM.** Add libkrun + libkrunfw as pinned submodules built by the
+   root flake into the same artifact. This is the only A-specific increment and
+   it lands last, after step 1 is trusted. After this, macOS first-run is
+   genuinely zero-dependency.
+3. **Linux.** Follows ADR-085 / Plan 193 gateway timing (passt replacement).
+
+**Pre-merge checklist** (gates the step-2 vendoring, not this decision):
+
+- [ ] Confirm libkrunfw kernel redistribution terms. libkrun is Apache-2.0;
+  libkrunfw embeds a GPL Linux kernel. Redistributing that binary in the bundle
+  is expected to be fine under GPL (source is public / offered), but confirm and
+  record the obligation (offer-of-source / license notices shipped in the
+  artifact) before step 2 lands.
+
+## Consequences
+
+- macOS first-run becomes genuinely zero-dependency once step 2 lands: one signed
+  artifact, reproducible and pinned VMM, no Homebrew prerequisite.
+- We take on building libkrun/libkrunfw in the release pipeline — a reproducible
+  kernel compile across platform targets. A one-time pipeline investment; tracked
+  with bundle-size growth under [Plan 156](../plans/156-binary-size-reduction.md).
+- One more C codebase falls under our review + signing umbrella. This does not
+  widen the runtime trust boundary (the VMM is already load-bearing in-process);
+  it moves supply-chain origin in-house and pins it.
+- The bundle is the **end-user** path only; source-checkout builds are unchanged
+  (Plan 199 non-goal preserved).
+- `mvmctl doctor` reports bundle provenance (signed, pinned-VMM rev) so the
+  install path is observable.
+
+## Out of scope
+
+- GPU passthrough — a separate strategic decision, not a packaging one.
+- Inbound TLS (mvmd's edge, per ADR-058).
+- The `machine` / pack UX surface ([Plan 200](../plans/200-machine-ux-dx-layer.md), [Plan 155](../plans/155-portable-runnable-artifacts.md)) — this ADR ships the substrate that surface runs on, not the surface.
+- Bring-up performance (kernel prebuilt / store persistence own it — ADR-082
+  §"not a performance decision").
+
+## References
+
+- [Plan 199](../plans/199-host-runtime-packaging-and-crate-boundaries.md) — host runtime packaging (this ADR is its missing "dependency-free bundle" decision)
+- [ADR-085](085-bundled-egress-gateway.md) — bundled egress gateway
+- [ADR-082](082-rust-native-egress-gateway.md) — Rust-native gateway
+- [ADR-002](002-microvm-security-posture.md) — security posture / who builds the VMM
+- [ADR-046](046-builder-vm-via-libkrun.md) — two artifact layers, two acquisition paths
+- [ADR-013](013-libkrun-microvm-nix-pivot.md) — libkrun pivot (runtime kernel extraction)
+- [Plan 155](../plans/155-portable-runnable-artifacts.md), [Plan 156](../plans/156-binary-size-reduction.md), [Plan 200](../plans/200-machine-ux-dx-layer.md)

--- a/specs/adrs/087-gpu-posture.md
+++ b/specs/adrs/087-gpu-posture.md
@@ -1,0 +1,85 @@
+# ADR-087 — GPU posture: paravirtual display GPU is a deferred fast-follow; compute passthrough is out of scope
+
+**Status:** Accepted
+**Relates to:** [ADR-002](002-microvm-security-posture.md) (tier matrix, out-of-scope discipline); [Plan 60](../plans/60-mvm-libkrun-migration.md) Phase 7b (`gpu-virgl` scaffold); [Plan 111](../plans/111-cardoso-gap-coordination.md) Workstream D (GPU deferral); [Plan 37](../plans/37-whitepaper-alignment.md) (`GpuRequirement` enum stub)
+**Does not gate:** [ADR-085](085-bundled-egress-gateway.md) / [ADR-086](086-relocatable-dependency-free-host-bundle.md) — the host bundle ships without GPU
+
+## Context
+
+A competing sandbox tool leads its marketing with "Vulkan access to the host
+GPU." That raised the question of whether mvm must ship GPU support to be
+competitive, and whether our security model makes it prohibitively expensive.
+
+The question conflated two unrelated features with different cost structures:
+
+- **(A) Paravirtual display/3D GPU** — virtio-gpu + venus/virgl, giving the guest
+  Vulkan/GL against the host GPU. No VFIO, no dedicated device, no Cloud
+  Hypervisor requirement. libkrun supports it; Plan 60 Phase 7b already scaffolds
+  it behind an off-by-default `gpu-virgl` flag. This is what the competitor
+  actually ships (render / GUI / computer-use demos).
+- **(B) Compute passthrough** — real CUDA/ROCm via VFIO. This is the one
+  Firecracker refuses by design, that needs the Cloud Hypervisor path, that
+  breaks one-VM-per-workload density and opens a hardware attack surface. The
+  competitor does **not** ship this.
+
+mvm is a sandboxing product. The fastest-growing relevant use-case —
+computer-use / browser / GUI agents — needs (A), a framebuffer with GL/Vulkan,
+not (B). The "we'll lose without GPU" framing applied to (B); it does not survive
+the disambiguation.
+
+The cost of (A) is not the hypervisor — it is **one new untrusted-input parser
+surface** (the venus/virgl command stream the guest writes), which must be kept
+away from the sealed-prod claim set.
+
+## Decision
+
+1. **(A) is a deferred fast-follow, not a launch requirement.** The host bundle
+   (ADR-085/086) and the `machine`/pack UX ship first; the security substrate is
+   the moat and the GPU demo is a fast-follow. GPU does not gate launch.
+
+2. **When (A) lands, it is a dev / computer-use tier feature**, modelled exactly
+   like `console` and `do_exec`:
+   - off by default;
+   - **never linked into the sealed-prod untrusted path** (a sealed prod agent
+     has no GPU device, the same way it has no console — claims 1–15 unaffected);
+   - **libkrun-path only.** Firecracker has no virtio-gpu (so GPU is not a
+     Firecracker prod-tier feature); the Vz Linux-guest Vulkan path is unverified
+     and not assumed. "GPU ⇒ libkrun" is the routing rule.
+
+3. **(A) stays out of the default zero-dependency bundle.** venus needs a host
+   Vulkan userspace present, which fights ADR-086's zero-dep promise. GPU is an
+   opt-in add-on component with its own `mvmctl doctor` probe; it must not
+   reintroduce a brew-trio-style first-run dependency into the core install.
+
+4. **(B) compute passthrough is out of scope**, deferred with an explicit
+   trigger rather than left as a silent gap: revisit only on **named customer
+   demand for in-VM compute *and* a matured Cloud Hypervisor backend**. Until
+   both hold, mvm does not do VFIO GPU passthrough.
+
+## Consequences
+
+- Launch is not blocked on GPU; engineering spend goes to the bundle + UX moat
+  first.
+- (A) is cheap when scheduled — flip an already-scaffolded flag on the libkrun
+  path — but carries one obligation: the venus/virgl parser is a new fuzz target
+  if GPU is ever proposed for anything beyond the dev/computer-use tier. Any such
+  promotion is a separate ADR-002 amendment (new claim + parser fuzzing), and is
+  expected to be resisted.
+- The `GpuRequirement` enum (Plan 37) and Plan 60 Phase 7b scaffold remain valid;
+  this ADR sets their posture and tier, it does not schedule the work.
+- (B) being a written, trigger-gated "no" keeps it from resurfacing as an
+  unscoped panic; the trigger is the place to reopen it.
+
+## Out of scope
+
+- Scheduling (A) — that is a plan/sprint decision once the bundle and UX ship.
+- VFIO / compute passthrough mechanics — gated behind the (B) trigger above.
+- Inbound TLS, networking, and packaging — covered by their own ADRs.
+
+## References
+
+- [ADR-002](002-microvm-security-posture.md) — security posture, tier matrix, out-of-scope discipline
+- [ADR-085](085-bundled-egress-gateway.md), [ADR-086](086-relocatable-dependency-free-host-bundle.md) — the bundle GPU does not gate
+- [Plan 60](../plans/60-mvm-libkrun-migration.md) — Phase 7b `gpu-virgl` scaffold
+- [Plan 111](../plans/111-cardoso-gap-coordination.md) — Workstream D GPU deferral
+- [Plan 37](../plans/37-whitepaper-alignment.md) — `GpuRequirement` enum


### PR DESCRIPTION
## Summary
- add ADR-085 for bundling the egress gateway inside the mvmctl artifact
- add ADR-086 for a relocatable, dependency-free, signed mvmctl distribution
- add ADR-087 for GPU posture: paravirtual display GPU fast-follow, compute passthrough out of scope

## Validation
- placeholder scan: `rg -n "TBD|TODO|PLACEHOLDER|Engineer adapts|Concrete diff depends|<PLACEHOLDER>" specs/adrs/085-bundled-egress-gateway.md specs/adrs/086-relocatable-dependency-free-host-bundle.md specs/adrs/087-gpu-posture.md`
- checked referenced core ADR/plan docs exist