### PR TITLE
Isolate microVM vsock runtime paths

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3094,6 +3094,7 @@ dependencies = [
  "chrono",
  "colored",
  "ed25519-dalek",
+ "fs2",
  "indicatif",
  "inquire",
  "libc",

--- a/crates/mvm-backend/src/backend.rs
+++ b/crates/mvm-backend/src/backend.rs
@@ -171,7 +171,9 @@ impl VmBackend for FirecrackerBackend {
         let rootfs_dir = rootfs.parent().unwrap_or_else(|| std::path::Path::new("."));
         mvm_build::builder_vm::admit_overlay_aware(rootfs_dir)?;
         crate::base::runtime_meta::record_from_rootfs(&config.name, StartMode::Detached, rootfs)?;
+        let mut slot_reservation = microvm::SlotReservationGuard::new(&fc_config.run_config.slot);
         microvm::run_from_build(&fc_config.run_config)?;
+        slot_reservation.defuse();
         Ok(VmId(fc_config.run_config.name.clone()))
     }
 

--- a/crates/mvm-backend/src/microvm.rs
+++ b/crates/mvm-backend/src/microvm.rs
@@ -94,6 +94,37 @@ impl Drop for TapGuard {
     }
 }
 
+/// Removes a slot reservation if launch fails before real run-info is written.
+pub struct SlotReservationGuard {
+    slot: Option<VmSlot>,
+}
+
+impl SlotReservationGuard {
+    pub fn new(slot: &VmSlot) -> Self {
+        Self {
+            slot: Some(slot.clone()),
+        }
+    }
+
+    pub fn defuse(&mut self) {
+        self.slot = None;
+    }
+}
+
+impl Drop for SlotReservationGuard {
+    fn drop(&mut self) {
+        if let Some(ref slot) = self.slot
+            && let Err(e) = release_slot_reservation(slot)
+        {
+            warn!(
+                vm = %slot.name,
+                slot = slot.index,
+                "SlotReservationGuard: cleanup failed: {e}"
+            );
+        }
+    }
+}
+
 /// RAII reaper for the per-VM substitution endpoint when it is spawned
 /// **before** boot (the placeholders it mints must ride the boot
 /// cmdline). If a later boot step fails and returns before the endpoint
@@ -156,16 +187,22 @@ pub fn resolve_running_vm_dir(name: &str) -> Result<String> {
     Ok(format!("{}/{}", abs_vms, name))
 }
 
-/// Firecracker binds the vsock UDS at `<dir>/v.sock`, but the host-side
-/// transport resolves it via `vsock_uds_path` = `<dir>/runtime/v.sock`
-/// (the convention the template/slot launch and the mock agent share).
-/// Expose the socket under `runtime/` so `wait_for_guest_agent` finds it.
-/// Best-effort; a dangling symlink until InstanceStart binds the socket.
-fn expose_vsock_runtime_symlink(dir: &str) {
+fn firecracker_vsock_uds_path(dir: &str) -> String {
+    format!("{dir}/runtime/v.sock")
+}
+
+/// Prepare the per-VM runtime directory that will hold the live vsock UDS.
+///
+/// The host transport already resolves `<vm_dir>/runtime/v.sock`, so we bind
+/// the socket there directly instead of creating a root-level `v.sock` plus a
+/// symlink. That keeps the communication path instance-scoped and avoids stale
+/// alias files after stop/restart.
+fn prepare_vsock_runtime_dir(dir: &str) {
+    let vsock = firecracker_vsock_uds_path(dir);
     if let Err(e) = run_in_vm(&format!(
-        "mkdir -p {dir}/runtime && ln -sf ../v.sock {dir}/runtime/v.sock"
+        "mkdir -p {dir}/runtime && rm -f {vsock} {dir}/v.sock"
     )) {
-        warn!("failed to expose vsock UDS under runtime/: {e}");
+        warn!("failed to prepare runtime vsock dir: {e}");
     }
 }
 
@@ -188,11 +225,12 @@ pub fn vm_console_log_path(vm_name: &str) -> Result<std::path::PathBuf> {
 #[instrument(skip_all)]
 fn start_firecracker_daemon(abs_dir: &str) -> Result<()> {
     ui::info("Starting Firecracker...");
+    let vsock = firecracker_vsock_uds_path(abs_dir);
     run_in_vm_visible(&format!(
         r#"
         mkdir -p {dir}
         sudo rm -f {socket}
-        rm -f {dir}/v.sock
+        rm -f {vsock} {dir}/v.sock
         touch {dir}/console.log {dir}/firecracker.log
         sudo bash -c 'nohup setsid firecracker --api-sock {socket} --enable-pci \
             </dev/null >{dir}/console.log 2>{dir}/firecracker.log &
@@ -219,11 +257,12 @@ fn start_firecracker_daemon(abs_dir: &str) -> Result<()> {
 #[instrument(skip_all)]
 pub fn start_vm_firecracker(abs_dir: &str, abs_socket: &str) -> Result<()> {
     ui::info("Starting Firecracker...");
+    let vsock = firecracker_vsock_uds_path(abs_dir);
     run_in_vm_visible(&format!(
         r#"
         mkdir -p {dir}
         sudo rm -f {socket}
-        rm -f {dir}/v.sock
+        rm -f {vsock} {dir}/v.sock
         touch {dir}/console.log {dir}/firecracker.log
         sudo bash -c 'nohup setsid firecracker --api-sock {socket} --enable-pci \
             </dev/null >{dir}/console.log 2>{dir}/firecracker.log &
@@ -404,16 +443,16 @@ fn configure_microvm(state: &MvmState, abs_dir: &str) -> Result<()> {
     )?;
 
     ui::info("Setting vsock device...");
+    prepare_vsock_runtime_dir(abs_dir);
+    let vsock = firecracker_vsock_uds_path(abs_dir);
     api_put(
         "/vsock",
         &format!(
-            r#"{{"vsock_id": "vsock0", "guest_cid": {cid}, "uds_path": "{dir}/v.sock"}}"#,
+            r#"{{"vsock_id": "vsock0", "guest_cid": {cid}, "uds_path": "{vsock}"}}"#,
             cid = mvm_guest::vsock::GUEST_CID,
-            dir = abs_dir,
+            vsock = vsock,
         ),
     )?;
-
-    expose_vsock_runtime_symlink(abs_dir);
 
     Ok(())
 }
@@ -465,7 +504,11 @@ pub fn start() -> Result<()> {
         );
 
     // Make vsock socket accessible to the current user
-    if let Err(e) = run_in_vm(&format!("sudo chmod 0666 {}/v.sock 2>/dev/null", abs_dir)) {
+    let vsock = firecracker_vsock_uds_path(&abs_dir);
+    if let Err(e) = run_in_vm(&format!(
+        "sudo chmod 0666 {vsock} 2>/dev/null",
+        vsock = vsock,
+    )) {
         warn!("failed to chmod vsock socket: {e}");
     }
 
@@ -519,10 +562,11 @@ pub fn stop() -> Result<()> {
         sudo pkill -x firecracker 2>/dev/null || true
         sudo rm -f {socket}
         rm -f {dir}/.mvm-run-info
-        rm -f {dir}/v.sock
+        rm -f {vsock} {dir}/v.sock
         "#,
         dir = MICROVM_DIR,
         socket = API_SOCKET,
+        vsock = firecracker_vsock_uds_path(MICROVM_DIR),
     ))?;
 
     // Tear down networking
@@ -810,7 +854,11 @@ pub fn run_from_build(config: &FlakeRunConfig) -> Result<()> {
     )?;
 
     // Make vsock socket accessible to the current user
-    if let Err(e) = run_in_vm(&format!("sudo chmod 0666 {}/v.sock 2>/dev/null", abs_dir)) {
+    let vsock = firecracker_vsock_uds_path(&abs_dir);
+    if let Err(e) = run_in_vm(&format!(
+        "sudo chmod 0666 {vsock} 2>/dev/null",
+        vsock = vsock,
+    )) {
         warn!("failed to chmod vsock socket: {e}");
     }
 
@@ -965,6 +1013,7 @@ pub fn restore_from_template_snapshot(
     // Start Firecracker daemon in per-VM directory (before acquiring lock)
     start_vm_firecracker(&abs_dir, &abs_socket)?;
     let mut fc_guard = FirecrackerGuard::new(&abs_dir);
+    let vsock_path = firecracker_vsock_uds_path(&abs_dir);
 
     // Atomic operation: create symlinks + load snapshot (serialized by flock)
     ui::info("Loading snapshot...");
@@ -985,7 +1034,7 @@ pub fn restore_from_template_snapshot(
             # Create symlinks to this instance's drives and vsock socket location
             ln -s {config} {runtime_dir}/config.ext4
             ln -s {secrets} {runtime_dir}/secrets.ext4
-            ln -s {abs_dir}/v.sock {runtime_dir}/v.sock
+            ln -s {vsock} {runtime_dir}/v.sock
 
             # Load snapshot (Firecracker opens the drives via symlinks)
             response=$(sudo curl -s -w "\n%{{http_code}}" --unix-socket {socket} -X PUT \
@@ -1004,6 +1053,7 @@ pub fn restore_from_template_snapshot(
         lock_file = lock_file,
         config = config_drive,
         secrets = secrets_drive,
+        vsock = &vsock_path,
         socket = abs_socket,
         vmstate = vmstate_path,
         mem = mem_path,
@@ -1014,13 +1064,15 @@ pub fn restore_from_template_snapshot(
     api_patch_socket(&abs_socket, "/vm", r#"{"state": "Resumed"}"#)?;
 
     // Make vsock socket accessible
-    if let Err(e) = run_in_vm(&format!("sudo chmod 0666 {}/v.sock 2>/dev/null", abs_dir)) {
+    if let Err(e) = run_in_vm(&format!(
+        "sudo chmod 0666 {vsock_path} 2>/dev/null",
+        vsock_path = &vsock_path,
+    )) {
         warn!("failed to chmod vsock socket: {e}");
     }
 
     // Post-restore: remount drives and restart services with fresh config/secrets.
     if !config.config_files.is_empty() || !config.secret_files.is_empty() {
-        let vsock_path = format!("{}/v.sock", abs_dir);
         ui::info("Sending post-restore signal (remounting drives, restarting services)...");
         // Wait for guest agent to be reachable after resume (may take a moment).
         let mut agent_ready = false;
@@ -1525,9 +1577,10 @@ pub fn diagnose_vm(name: &str) -> Result<DiagnoseResult> {
     }
 
     // Layer 3: Vsock socket exists?
+    let vsock_path = firecracker_vsock_uds_path(&abs_dir);
     let sock_check = run_in_vm_stdout(&format!(
-        "[ -S '{dir}/v.sock' ] && echo yes || echo no",
-        dir = abs_dir,
+        "[ -S '{vsock}' ] && echo yes || echo no",
+        vsock = &vsock_path,
     ))?;
     result.vsock_exists = sock_check.trim() == "yes";
     if !result.vsock_exists && result.fc_alive {
@@ -1569,7 +1622,6 @@ pub fn diagnose_vm(name: &str) -> Result<DiagnoseResult> {
 
     // Layer 6: Guest agent reachable? (short timeout)
     if result.vsock_exists {
-        let vsock_path = format!("{}/v.sock", abs_dir);
         match mvm_guest::vsock::ping_at(&vsock_path) {
             Ok(true) => {
                 result.agent_reachable = true;
@@ -1597,7 +1649,6 @@ pub fn diagnose_vm(name: &str) -> Result<DiagnoseResult> {
 
     // Layer 7: If agent reachable, get detailed status
     if result.agent_reachable {
-        let vsock_path = format!("{}/v.sock", abs_dir);
         if let Ok(mvm_guest::vsock::GuestResponse::WorkerStatus {
             status,
             last_busy_at,
@@ -1668,32 +1719,59 @@ pub fn list_vms() -> Result<Vec<RunInfo>> {
 
 /// Allocate the next free slot index by scanning existing VMs.
 pub fn allocate_slot(name: &str) -> Result<VmSlot> {
+    let q_name = shell_quote(name);
+    let q_json_name = shell_quote(&serde_json::to_string(name)?);
     let output = run_in_vm_stdout(&format!(
-        r#"for f in {dir}/*/run-info.json; do [ -f "$f" ] && cat "$f"; done 2>/dev/null || true"#,
+        r#"
+        set -e
+        mkdir -p {dir}
+        (
+          flock -x 9
+          used="$(
+            for f in {dir}/*/run-info.json; do
+              [ -f "$f" ] || continue
+              sed -n 's/.*"slot_index":\([0-9][0-9]*\).*/\1/p' "$f"
+            done 2>/dev/null || true
+          )"
+          for i in $(seq 0 252); do
+            if ! printf '%s\n' "$used" | grep -qx "$i"; then
+              vm_dir={dir}/{name}
+              mkdir -p "$vm_dir"
+              printf '{{"schema_version":1,"mode":"starting","name":%s,"slot_index":%s,"slot_reserved":true}}\n' {json_name} "$i" > "$vm_dir/run-info.json"
+              echo "$i"
+              exit 0
+            fi
+          done
+          exit 2
+        ) 9>{dir}/.slot.lock
+        "#,
         dir = VMS_DIR,
+        name = q_name,
+        json_name = q_json_name,
     ))?;
 
-    let mut used_indices: Vec<u8> = Vec::new();
-    for line in output.lines() {
-        let line = line.trim();
-        if line.is_empty() {
-            continue;
-        }
-        if let Ok(info) = serde_json::from_str::<serde_json::Value>(line)
-            && let Some(idx) = info.get("slot_index").and_then(|v| v.as_u64())
-        {
-            used_indices.push(idx as u8);
-        }
-    }
+    let index = output
+        .lines()
+        .rev()
+        .find_map(|line| line.trim().parse::<u8>().ok())
+        .ok_or_else(|| anyhow::anyhow!("No free VM slots available (max 253 VMs)"))?;
+    Ok(VmSlot::new(name, index))
+}
 
-    // Find first free index (0..253, since IP = index + 2, max 255)
-    for i in 0..253u8 {
-        if !used_indices.contains(&i) {
-            return Ok(VmSlot::new(name, i));
-        }
-    }
-
-    anyhow::bail!("No free VM slots available (max 253 VMs)")
+fn release_slot_reservation(slot: &VmSlot) -> Result<()> {
+    let q_name = shell_quote(&slot.name);
+    run_in_vm(&format!(
+        r#"
+        run_info={dir}/{name}/run-info.json
+        if [ -f {run_info} ] && grep -q '"slot_reserved":true' {run_info}; then
+          rm -f {run_info}
+        fi
+        "#,
+        dir = VMS_DIR,
+        name = q_name,
+        run_info = "$run_info",
+    ))
+    .map(|_| ())
 }
 
 /// Generate shell commands to inject `DriveFile`s into a mounted drive.
@@ -2162,16 +2240,17 @@ pub fn configure_flake_microvm_with_drives_dir(
     )?;
 
     ui::info("Setting vsock device...");
+    prepare_vsock_runtime_dir(drives_dir);
+    let vsock = firecracker_vsock_uds_path(drives_dir);
     api_put_socket(
         socket,
         "/vsock",
         &format!(
-            r#"{{"vsock_id": "vsock0", "guest_cid": {cid}, "uds_path": "{dir}/v.sock"}}"#,
+            r#"{{"vsock_id": "vsock0", "guest_cid": {cid}, "uds_path": "{vsock}"}}"#,
             cid = mvm_guest::vsock::GUEST_CID,
-            dir = drives_dir,
+            vsock = vsock,
         ),
     )?;
-    expose_vsock_runtime_symlink(drives_dir);
 
     // Virtio-balloon. Only attached when the workload opted in via
     // `mem_initial`. The device boots pre-inflated to `memory -
@@ -2944,6 +3023,14 @@ mod tests {
         assert!(f.name.is_empty());
         assert!(f.content.is_empty());
         assert_eq!(f.mode, 0o444);
+    }
+
+    #[test]
+    fn firecracker_vsock_uds_lives_under_vm_runtime_dir() {
+        assert_eq!(
+            firecracker_vsock_uds_path("/builder/microvm/vms/vm-a"),
+            "/builder/microvm/vms/vm-a/runtime/v.sock"
+        );
     }
 
     fn baseline_run_config(mem_initial: Option<u32>) -> FlakeRunConfig {

--- a/crates/mvm-cli/src/commands/vm/up.rs
+++ b/crates/mvm-cli/src/commands/vm/up.rs
@@ -1194,6 +1194,60 @@ fn write_host_only_file(path: &std::path::Path, bytes: &[u8]) -> std::io::Result
     std::fs::rename(&tmp, path)
 }
 
+struct VmNameReservation<'a> {
+    name: &'a str,
+    network: &'a str,
+    tags: std::collections::BTreeMap<String, String>,
+    expires_at: Option<String>,
+    auto_resume: bool,
+}
+
+fn reserve_vm_name(
+    registry_path: &std::path::Path,
+    reservation: VmNameReservation<'_>,
+) -> Result<()> {
+    let _lock = mvm::vm::name_registry::acquire_registry_lock(registry_path)?;
+    let mut registry = mvm::vm::name_registry::VmNameRegistry::load(registry_path)?;
+    if registry.lookup(reservation.name).is_some() {
+        anyhow::bail!(
+            "VM name {:?} is already reserved; stop the existing VM with `mvmctl down {}` or choose a different name",
+            reservation.name,
+            reservation.name
+        );
+    }
+    registry.register_with_metadata(mvm::vm::name_registry::RegisterParams {
+        name: reservation.name,
+        vm_dir: "",
+        network: reservation.network,
+        guest_ip: None,
+        slot_index: 0,
+        tags: reservation.tags,
+        expires_at: reservation.expires_at,
+        auto_resume: reservation.auto_resume,
+    })?;
+    registry.save(registry_path)
+}
+
+fn reserve_launch_vm_name(
+    registry_path: &std::path::Path,
+    vm_name: &str,
+    network_name: &str,
+    sandbox_tags: &std::collections::BTreeMap<String, String>,
+    sandbox_ttl: Option<std::time::Duration>,
+    auto_resume: bool,
+) -> Result<()> {
+    reserve_vm_name(
+        registry_path,
+        VmNameReservation {
+            name: vm_name,
+            network: network_name,
+            tags: sandbox_tags.clone(),
+            expires_at: sandbox_ttl.map(mvm_core::util::time::utc_plus_duration),
+            auto_resume,
+        },
+    )
+}
+
 /// Resolve the `source_root` for an app's lockfile path. For
 /// `Source::LocalPath { path, .. }` the source root is the directory
 /// the path resolves against — relative paths root at the IR file's
@@ -1918,25 +1972,7 @@ pub(super) fn cmd_run(params: RunParams<'_>) -> Result<()> {
             generator.next().unwrap_or_else(|| "vm-0".to_string())
         }),
     };
-
-    // Register the VM name in the persistent registry (best-effort).
     let registry_path = mvm::vm::name_registry::registry_path();
-    if let Ok(mut registry) = mvm::vm::name_registry::VmNameRegistry::load(&registry_path) {
-        // Deregister stale entry with the same name if it exists
-        registry.deregister(&vm_name);
-        let expires_at = sandbox_ttl.map(mvm_core::util::time::utc_plus_duration);
-        let _ = registry.register_with_metadata(mvm::vm::name_registry::RegisterParams {
-            name: &vm_name,
-            vm_dir: "",
-            network: network_name,
-            guest_ip: None,
-            slot_index: 0,
-            tags: sandbox_tags.clone(),
-            expires_at,
-            auto_resume,
-        });
-        let _ = registry.save(&registry_path);
-    }
 
     // Admission ledger. One per `cmd_run`; the watch-mode loop
     // reuses it across rebuilds so synthesized plans share a single
@@ -2014,6 +2050,14 @@ pub(super) fn cmd_run(params: RunParams<'_>) -> Result<()> {
             emit_failed_if(&admission, "backend-start", &e);
             return Err(e);
         }
+        reserve_launch_vm_name(
+            &registry_path,
+            &vm_name,
+            network_name,
+            &sandbox_tags,
+            sandbox_ttl,
+            auto_resume,
+        )?;
         if let Err(e) = backend.start(&start_config) {
             emit_failed_if(&admission, "backend-start", &e);
             return Err(e);
@@ -2468,6 +2512,14 @@ pub(super) fn cmd_run(params: RunParams<'_>) -> Result<()> {
             2,
             &format!("Restoring VM '{}' from snapshot", vm_name_owned),
         );
+        reserve_launch_vm_name(
+            &registry_path,
+            &vm_name_owned,
+            network_name,
+            &sandbox_tags,
+            sandbox_ttl,
+            auto_resume,
+        )?;
         if let Err(e) =
             microvm::restore_from_template_snapshot(tmpl, &run_config, &snap_dir, snap_info)
         {
@@ -2589,6 +2641,14 @@ pub(super) fn cmd_run(params: RunParams<'_>) -> Result<()> {
                     emit_failed_if(&admission_main, "backend-start", &e);
                     return Err(e);
                 }
+                reserve_launch_vm_name(
+                    &registry_path,
+                    &vm_name_owned,
+                    network_name,
+                    &sandbox_tags,
+                    sandbox_ttl,
+                    auto_resume,
+                )?;
                 if let Err(e) = backend.start(&start_config) {
                     emit_failed_if(&admission_main, "backend-start", &e);
                     return Err(e);
@@ -3041,6 +3101,35 @@ mod runtime_overlay_attach_tests {
             sc.runtime_overlay_path.is_none(),
             "cold cache must not attach (legacy boot)"
         );
+    }
+}
+
+#[cfg(test)]
+mod vm_name_reservation_tests {
+    use super::*;
+
+    fn reservation<'a>(name: &'a str, network: &'a str) -> VmNameReservation<'a> {
+        VmNameReservation {
+            name,
+            network,
+            tags: std::collections::BTreeMap::new(),
+            expires_at: None,
+            auto_resume: true,
+        }
+    }
+
+    #[test]
+    fn duplicate_reservation_fails_without_replacing_original() {
+        let tmp = tempfile::tempdir().unwrap();
+        let path = tmp.path().join("vm-names.json");
+
+        reserve_vm_name(&path, reservation("vm-a", "default")).unwrap();
+        let err = reserve_vm_name(&path, reservation("vm-a", "isolated")).unwrap_err();
+
+        assert!(err.to_string().contains("already reserved"));
+        let registry = mvm::vm::name_registry::VmNameRegistry::load(&path).unwrap();
+        assert_eq!(registry.len(), 1);
+        assert_eq!(registry.lookup("vm-a").unwrap().network, "default");
     }
 }
 

--- a/crates/mvm/Cargo.toml
+++ b/crates/mvm/Cargo.toml
@@ -41,6 +41,7 @@ toml.workspace = true
 tracing.workspace = true
 tokio.workspace = true
 libc.workspace = true
+fs2.workspace = true
 
 [features]
 default = []

--- a/crates/mvm/src/vm/name_registry.rs
+++ b/crates/mvm/src/vm/name_registry.rs
@@ -1,4 +1,5 @@
 use anyhow::{Context, Result, bail};
+use fs2::FileExt;
 use mvm_core::domain::instance::InstanceReadiness;
 use serde::{Deserialize, Serialize};
 use std::collections::{BTreeMap, HashMap};
@@ -12,6 +13,14 @@ use std::path::{Path, PathBuf};
 pub struct VmNameRegistry {
     /// Map from VM name to registration info.
     pub vms: HashMap<String, VmRegistration>,
+}
+
+/// Exclusive advisory lock for the VM name registry.
+///
+/// Keep this guard alive across load/mutate/save sequences that must be
+/// serialized across multiple `mvmctl` processes.
+pub struct VmNameRegistryLock {
+    _file: std::fs::File,
 }
 
 /// Registration info for a running or recently-running VM.
@@ -298,6 +307,33 @@ impl<'a> RegisterParams<'a> {
 /// Default registry file path.
 pub fn registry_path() -> PathBuf {
     PathBuf::from(mvm_core::config::mvm_share_dir()).join("vm-names.json")
+}
+
+/// Lock path paired with a registry file.
+pub fn registry_lock_path(registry_path: &Path) -> PathBuf {
+    registry_path.with_extension("json.lock")
+}
+
+/// Acquire an exclusive registry lock.
+///
+/// The registry file itself is written with atomic rename, so the lock lives in
+/// a stable sibling file that survives those renames.
+pub fn acquire_registry_lock(registry_path: &Path) -> Result<VmNameRegistryLock> {
+    let lock_path = registry_lock_path(registry_path);
+    if let Some(parent) = lock_path.parent() {
+        std::fs::create_dir_all(parent)
+            .with_context(|| format!("creating VM name registry lock dir {}", parent.display()))?;
+    }
+    let file = std::fs::OpenOptions::new()
+        .read(true)
+        .write(true)
+        .create(true)
+        .truncate(false)
+        .open(&lock_path)
+        .with_context(|| format!("opening VM name registry lock {}", lock_path.display()))?;
+    file.lock_exclusive()
+        .with_context(|| format!("locking VM name registry {}", lock_path.display()))?;
+    Ok(VmNameRegistryLock { _file: file })
 }
 
 /// Generate a unique VM name with a random suffix.
@@ -738,5 +774,24 @@ mod tests {
             r.last_readiness_change_at.as_deref(),
             Some("2025-01-01T00:00:00Z")
         );
+    }
+
+    #[test]
+    fn registry_lock_path_is_stable_sibling_file() {
+        let path = PathBuf::from("/tmp/mvm/vm-names.json");
+        assert_eq!(
+            registry_lock_path(&path),
+            PathBuf::from("/tmp/mvm/vm-names.json.lock")
+        );
+    }
+
+    #[test]
+    fn acquire_registry_lock_creates_parent_and_lock_file() {
+        let tmp = tempfile::tempdir().unwrap();
+        let path = tmp.path().join("nested").join("vm-names.json");
+
+        let _lock = acquire_registry_lock(&path).unwrap();
+
+        assert!(registry_lock_path(&path).is_file());
     }
 }

--- a/public/src/content/docs/guides/networking.md
+++ b/public/src/content/docs/guides/networking.md
@@ -47,6 +47,12 @@ MicroVMs don't use networking for host communication -- they use **vsock**:
 
 The host connects by writing `CONNECT 5252\n` to the vsock socket and reading `OK 5252\n`. All requests are request/response pairs. vsock is supported on Firecracker, Apple Container, and microvm.nix backends. Docker uses a unix socket instead.
 
+For Firecracker, the host-side vsock UDS is scoped to the running VM directory:
+`<vm-dir>/runtime/v.sock`. It is not a global or master socket. `mvmctl up`
+reserves the VM name before launch and rejects duplicate active/reserved names,
+because that name is the identity used to resolve the per-VM communication
+channel.
+
 ## No SSH
 
 MicroVMs have **no SSH access** by design. Communication is exclusively via vsock. This eliminates:

--- a/public/src/content/docs/reference/filesystem.md
+++ b/public/src/content/docs/reference/filesystem.md
@@ -112,6 +112,8 @@ On the host (on Linux) or inside the builder VM (on macOS), mvm stores data at:
         ├── fc-base.json
         ├── vmlinux
         ├── rootfs.ext4
+        ├── runtime/
+        │   └── v.sock          # per-VM Firecracker vsock UDS
         └── volumes/
             ├── config.ext4
             ├── secrets.ext4

--- a/tests/runtime_boot_bench.rs
+++ b/tests/runtime_boot_bench.rs
@@ -343,6 +343,7 @@ fn guest_agent_socket_path(backend: &str, name: &str) -> Result<PathBuf> {
                 .join("microvm")
                 .join("vms")
                 .join(name)
+                .join("runtime")
                 .join("v.sock"))
         }
         "libkrun" | "krun" => Ok(Path::new(&mvm_core::config::mvm_data_dir())
@@ -357,6 +358,16 @@ fn guest_agent_socket_path(backend: &str, name: &str) -> Result<PathBuf> {
 
 fn ping_guest_agent(uds_path: &Path) -> Result<()> {
     let mut stream = mvm_guest::vsock::connect_to(&uds_path.to_string_lossy(), 1)?;
+    let negotiated = mvm_guest::vsock::negotiate_protocol(
+        &mut stream,
+        vec![mvm_guest::vsock::GuestCapability::Ping],
+    )?;
+    if !negotiated
+        .capabilities
+        .contains(&mvm_guest::vsock::GuestCapability::Ping)
+    {
+        bail!("guest agent did not advertise the Ping capability");
+    }
     let response = mvm_guest::vsock::send_request(&mut stream, &GuestRequest::Ping)?;
     match response {
         GuestResponse::Pong => Ok(()),


### PR DESCRIPTION
## Summary
- bind Firecracker vsock UDS under each VM's runtime directory instead of a shared/master path
- reserve VM names under the registry lock so duplicate active/reserved names are refused
- reserve Firecracker slots/TAP indexes under a lock before boot to support concurrent starts
- update runtime boot benchmark protocol negotiation and docs for per-VM vsock paths

## Validation
- cargo fmt --all --check
- cargo check --workspace
- cargo test -p mvm vm::name_registry::tests::registry_lock_path_is_stable_sibling_file -- --exact --nocapture
- cargo test -p mvm vm::name_registry::tests::acquire_registry_lock_creates_parent_and_lock_file -- --exact --nocapture
- cargo test -p mvm-cli commands::vm::up::vm_name_reservation_tests::duplicate_reservation_fails_without_replacing_original -- --exact --nocapture
- cargo test -p mvm-backend microvm::tests::firecracker_vsock_uds_lives_under_vm_runtime_dir -- --exact --nocapture
- cargo test --test runtime_boot_bench --no-run
- cargo clippy -p mvm -p mvm-cli -p mvm-backend --all-targets -- -D warnings
- live VZ smoke: MVM_RUNTIME_BOOT_CONCURRENT=2 with guest-agent readiness
- live Firecracker smoke on remote KVM host: serial plus MVM_RUNTIME_BOOT_CONCURRENT=2 with guest-agent readiness

Note: cargo test --workspace exposed existing parallel test interference in three mvm lifecycle tests; each failed test passed isolated, and cargo test -p mvm --lib -- --test-threads=1 passed 209 tests.