### PR TITLE
docs(plan-205): Workstream F — what-runs-where, residency config, threat-model delta

### DIFF
--- a/public/src/content/docs/reference/architecture.md
+++ b/public/src/content/docs/reference/architecture.md
@@ -44,6 +44,52 @@ tier, per-VM marker file, started-VM probe order, and the listing/support sets t
 doctor` and `mvmctl ls` read. Both enum (`AnyBackend`) and trait-object (`Arc<dyn VmBackend>`)
 consumers construct from the same descriptors via `instantiate` / `instantiate_dyn`.
 
+## What runs where: the trust gradient
+
+mvm runs long-lived processes in three layers, one per trust tier. Authority decreases as
+you move away from the host, and each layer is trusted accordingly (see ADR-002 and ADR-090).
+
+| Layer | Process | Owns | Authority | Trust |
+|-------|---------|------|-----------|-------|
+| Host | the `mvmctl` control plane (plus, under the fleet, per-tenant signer/audit daemons) | host signing keys, plan admission, the chain-signed audit log, VM + pool lifecycle | full | trusted (TCB) |
+| Builder VM | the Linux builder environment (Nix + the builder store) | building guest/workload images | build-only | trusted to build; dev-tier |
+| Workload microVM | the guest agent | answering vsock RPCs for its one workload | none | untrusted |
+
+The governing rule: **a process never holds authority above its trust tier, and authority
+only ever decreases host → builder → workload.** Host signing keys, plan admission, and the
+audit chain never cross the host→builder boundary. The workload guest agent is the deliberate
+runt — a sealed production build links no `do_exec` and no console (claims 4 and 15) and holds
+no signing key or admission code. `mvmctl`'s `check-trust-gradient` lint machine-checks this
+ledger (`specs/claims/trust-gradient.md`) on every PR.
+
+What is installed where:
+
+- The **host** has `mvmctl` (and, under the fleet, the per-tenant `mvm-host-agent` +
+  `mvm-signer-helper` daemons). Host Nix is optional.
+- The **builder VM** owns Nix and the build toolchain. Making the builder a *resident* typed
+  vsock service (`mvm-builderd`) is the direction recorded in ADR-089 / Plan 204; today builder
+  work is controlled job execution, not yet a resident daemon.
+- **Workload microVM images** contain neither `mvmctl` nor builder tooling — only the minimal
+  guest agent baked by `mkGuest`.
+
+### Residency: how warm the standby pool is kept
+
+The standby pool is governed by a single residency policy (ADR-090), surfaced on `mvmctl
+doctor`'s `residency` line as `<policy> — <source> — warm_target=N[, idle=Nm]`.
+
+- `MVM_RESIDENCY=warm|parked|cold` overrides the policy. Unset, it resolves to a per-host
+  default: **macOS 26+ Apple Silicon defaults to `warm`** (a compatible standby is kept ready,
+  so a command does not pay a builder/VM boot); **every other host, including CI, defaults to
+  `parked`** (nothing is held warm; resume on demand).
+- The trade-off is resource cost vs. first-command latency: `warm` keeps a standby ready,
+  `parked`/`cold` hold none.
+- On the snapshot-capable macOS backend a standby is a captured saved state; when one ages
+  past the warm TTL the pool **demotes it to `parked`** — kept as a claimable saved-state
+  snapshot rather than discarded — and resumes it on the next compatible claim (matched on
+  `kernel_sha256` + image digest). On the live-process backend (libkrun) a standby cannot be
+  snapshotted, so an idle one is reaped to cold. `mvmctl pool status` reports `idle`,
+  `claimed`, and `parked` counts.
+
 ## Workspace Structure
 
 The workspace is organized by responsibility rather than by platform:

--- a/public/src/content/docs/reference/architecture.md
+++ b/public/src/content/docs/reference/architecture.md
@@ -60,7 +60,8 @@ only ever decreases host → builder → workload.** Host signing keys, plan adm
 audit chain never cross the host→builder boundary. The workload guest agent is the deliberate
 runt — a sealed production build links no `do_exec` and no console (claims 4 and 15) and holds
 no signing key or admission code. `mvmctl`'s `check-trust-gradient` lint machine-checks this
-ledger (`specs/claims/trust-gradient.md`) on every PR.
+ledger (`specs/claims/trust-gradient.md`) on every PR; the ledger carries the host and workload
+rows today, and the builder row is added once the resident builder daemon (`mvm-builderd`) exists.
 
 What is installed where:
 

--- a/specs/adrs/090-resident-daemon-trust-gradient-and-residency.md
+++ b/specs/adrs/090-resident-daemon-trust-gradient-and-residency.md
@@ -180,3 +180,28 @@ residency policy over the standby pool; make `mvm-builderd` resident across `mvm
 invocations (consuming Plan 204's protocol, not reimplementing it); wire snapshot
 park/resume into the parked state; add the cold-acquisition snapshot-bake; document
 "what runs where." No user command rename is required.
+
+## Threat-model delta (residency landed)
+
+The residency policy (Plan 205 WS-B) and parked-standby demotion (WS-D) are in the tree. This
+section records why neither changes the trust boundary or weakens an ADR-002 claim:
+
+- **Keys, admission, and audit stay host-side at every residency setting.** Residency only
+  changes how warm the standby pool is kept and whether an idle standby is parked or reaped.
+  The host control plane — signing keys, plan admission, the chain-signed audit log — is
+  untouched. No claim 8 / 12 / 13 surface moves.
+- **A parked standby is still admitted from content-addressed inputs.** A standby is a
+  kernel + supervisor saved state carrying no workload; the workload is attached at claim time
+  from the admitted, signed `ExecutionPlan` (claim 8) only after a compatibility check on
+  `kernel_sha256` + image digest (`StandbyCompat`). A parked standby cannot be claimed for an
+  incompatible image, and how long it sat parked changes nothing the admission path verifies.
+- **Demotion is gated by the dev-tier saved-state shape (`is_saved_state()`, pid 0).** Parking
+  applies only to a backend whose standby is already a captured saved state (the macOS managed
+  backend); the live-process backend reaps to cold. No production workload's posture is
+  snapshotted or resumed — the workload rootfs is dm-verity sealed (claim 3) and re-verified
+  independent of the standby it was claimed from.
+- **No new guest-reachable surface.** Residency is host-side pool bookkeeping (the reaper and
+  the selection predicate). The guest wire is unchanged and the workload agent gains nothing.
+
+Net: residency changes the builder/standby *lifecycle*, not the trust gradient. Claims 1–15
+are unaffected, and `check-trust-gradient` continues to machine-check the gradient on every PR.

--- a/specs/plans/205-resident-builder-control-plane.md
+++ b/specs/plans/205-resident-builder-control-plane.md
@@ -135,11 +135,12 @@ typed allowlisted protocol, so residency shrinks rather than widens the attack s
 
 ### F. Docs and posture
 
-- [ ] Add a "what runs where" table (host control / builder daemon / workload agent)
-      for users and contributors.
-- [ ] Document the residency default, the override, and the RAM-vs-latency tradeoff.
-- [ ] Write the threat-model delta: residency changes the builder lifecycle, not the
-      trust boundary; enumerate why each claim is unaffected.
+- [x] Add a "what runs where" table (host control / builder daemon / workload agent)
+      for users and contributors. — `reference/architecture.md` §"What runs where".
+- [x] Document the residency default, the override, and the RAM-vs-latency tradeoff. —
+      `reference/architecture.md` §"Residency".
+- [x] Write the threat-model delta: residency changes the builder lifecycle, not the
+      trust boundary; enumerate why each claim is unaffected. — ADR-090 §"Threat-model delta".
 
 ## Acceptance
 


### PR DESCRIPTION
Implements **Plan 205 Workstream F** (docs) on top of WS-A (#1090) / WS-B (#1094) / WS-D (#1099). Documents the residency work for users and contributors — strictly grounded in what actually merged.

## Changes
- **`reference/architecture.md`** — a "What runs where: the trust gradient" section (the three-daemon table: host control plane / builder VM / workload agent, with trust tiers and what's installed where) plus a "Residency" section (`MVM_RESIDENCY` override, per-host defaults — macOS-26 AS → warm, else → parked — the `doctor` residency line, and the parked-vs-reaped behavior with `pool status` counts).
- **`ADR-090`** — a "Threat-model delta" section: why residency (WS-B/D) changes the builder/standby *lifecycle*, not the trust boundary (keys/admission/audit stay host-side; parked standbys are still admitted from content-addressed inputs; demotion is gated by the dev-tier saved-state shape; no new guest surface).
- Ticks the WS-F boxes in the plan.

## Honesty
- Does **not** claim the resident `mvm-builderd` ships — explicitly states it's the ADR-089/Plan 204 direction, "not yet a resident daemon", and notes the builder row is intentionally absent from the machine-checked ledger until it exists.
- No measured-latency / "instant" numbers (no benchmark shipped here).
- Ran through an adversarial document review (most-capable model) that fact-checked **every** claim against the merged code (residency.rs, doctor.rs, standby_pool.rs, pool.rs, vm_backend.rs, the trust-gradient ledger + lint) → **Ready to merge**, no overclaims; the one advisory it raised (3-row table vs 2-row ledger) is now tightened.

Docs-only — no code changed.