### PR TITLE
feat(cli): heartbeat during the silent Stage 0 builder-image build

### DIFF
--- a/crates/mvm-cli/src/commands/env/dev_vz.rs
+++ b/crates/mvm-cli/src/commands/env/dev_vz.rs
@@ -1717,6 +1717,11 @@ pub(in crate::commands) fn bootstrap_builder_vm_image() -> Result<()> {
             // removed; `nix/images/builder/flake.nix` is deleted.
             #[cfg(feature = "builder-vm")]
             {
+                // The Stage 0 build runs `nix` inside the guest with no
+                // host-visible output for minutes; a liveness heartbeat keeps it
+                // from reading as a hang. Dropped (thread stopped) when the build
+                // returns.
+                let _heartbeat = BuildHeartbeat::start("Builder VM image build");
                 bootstrap_builder_vm_image_via_root_dir_stage0(
                     &flake_dir,
                     &out_dir,
@@ -1745,6 +1750,67 @@ fn builder_vm_host_arch() -> &'static str {
         "aarch64"
     } else {
         "x86_64"
+    }
+}
+
+/// Cadence of [`BuildHeartbeat`] liveness lines. ~20s keeps a multi-minute
+/// Stage 0 build under ~20 lines while never leaving the user wondering for long.
+const BUILD_HEARTBEAT_INTERVAL: std::time::Duration = std::time::Duration::from_secs(20);
+
+/// RAII liveness ticker for a long, silent blocking step. While alive, a thread
+/// emits a periodic [`ui::format_heartbeat`] line so the operation can't be
+/// mistaken for a hang — the Stage 0 builder-image build runs `nix` inside the
+/// guest with no host-visible output until it completes. Stops + joins on drop,
+/// so the build's own return is the natural end of the heartbeat.
+struct BuildHeartbeat {
+    stop: std::sync::Arc<std::sync::atomic::AtomicBool>,
+    handle: Option<std::thread::JoinHandle<()>>,
+}
+
+impl BuildHeartbeat {
+    fn start(activity: &'static str) -> Self {
+        Self::start_with(activity, BUILD_HEARTBEAT_INTERVAL, ui::info)
+    }
+
+    /// Injectable core: `interval` and `emit` are parameters so a test can drive
+    /// a tight cadence into a counter instead of stdout.
+    fn start_with(
+        activity: &'static str,
+        interval: std::time::Duration,
+        emit: impl Fn(&str) + Send + 'static,
+    ) -> Self {
+        use std::sync::atomic::Ordering;
+        let stop = std::sync::Arc::new(std::sync::atomic::AtomicBool::new(false));
+        let thread_stop = std::sync::Arc::clone(&stop);
+        // Poll finely so `drop` is responsive; emit only once per `interval`.
+        let poll = interval.min(std::time::Duration::from_millis(250));
+        let handle = std::thread::spawn(move || {
+            let start = std::time::Instant::now();
+            let mut next = interval;
+            while !thread_stop.load(Ordering::Relaxed) {
+                std::thread::sleep(poll);
+                if thread_stop.load(Ordering::Relaxed) {
+                    break;
+                }
+                if start.elapsed() >= next {
+                    emit(&ui::format_heartbeat(activity, start.elapsed()));
+                    next += interval;
+                }
+            }
+        });
+        Self {
+            stop,
+            handle: Some(handle),
+        }
+    }
+}
+
+impl Drop for BuildHeartbeat {
+    fn drop(&mut self) {
+        self.stop.store(true, std::sync::atomic::Ordering::Relaxed);
+        if let Some(h) = self.handle.take() {
+            let _ = h.join();
+        }
     }
 }
 
@@ -5187,6 +5253,36 @@ mod builder_vm_bootstrap_tests {
     //! `find_builder_vm_flake` + `bootstrap_builder_vm_image`.
     use super::*;
     use std::io::Write;
+
+    #[test]
+    fn build_heartbeat_emits_while_alive_and_stops_on_drop() {
+        use std::sync::Arc;
+        use std::sync::atomic::{AtomicUsize, Ordering};
+
+        let count = Arc::new(AtomicUsize::new(0));
+        let sink = Arc::clone(&count);
+        // Tight 10ms cadence into a counter (not stdout) so the test is fast and
+        // deterministic-ish; a generous window then asserts it ticked.
+        let hb = BuildHeartbeat::start_with(
+            "Test build",
+            std::time::Duration::from_millis(10),
+            move |_line| {
+                sink.fetch_add(1, Ordering::Relaxed);
+            },
+        );
+        std::thread::sleep(std::time::Duration::from_millis(120));
+        let while_alive = count.load(Ordering::Relaxed);
+        assert!(while_alive >= 1, "heartbeat should tick while alive");
+
+        drop(hb); // joins the thread — no further emits after this returns
+        let after_drop = count.load(Ordering::Relaxed);
+        std::thread::sleep(std::time::Duration::from_millis(60));
+        assert_eq!(
+            count.load(Ordering::Relaxed),
+            after_drop,
+            "no heartbeat ticks after drop joins the thread"
+        );
+    }
 
     #[test]
     fn find_builder_vm_flake_resolves_to_in_repo_path() {

--- a/crates/mvm-cli/src/commands/env/dev_vz.rs
+++ b/crates/mvm-cli/src/commands/env/dev_vz.rs
@@ -1755,6 +1755,7 @@ fn builder_vm_host_arch() -> &'static str {
 
 /// Cadence of [`BuildHeartbeat`] liveness lines. ~20s keeps a multi-minute
 /// Stage 0 build under ~20 lines while never leaving the user wondering for long.
+#[cfg(feature = "builder-vm")]
 const BUILD_HEARTBEAT_INTERVAL: std::time::Duration = std::time::Duration::from_secs(20);
 
 /// RAII liveness ticker for a long, silent blocking step. While alive, a thread
@@ -1762,11 +1763,13 @@ const BUILD_HEARTBEAT_INTERVAL: std::time::Duration = std::time::Duration::from_
 /// mistaken for a hang — the Stage 0 builder-image build runs `nix` inside the
 /// guest with no host-visible output until it completes. Stops + joins on drop,
 /// so the build's own return is the natural end of the heartbeat.
+#[cfg(feature = "builder-vm")]
 struct BuildHeartbeat {
     stop: std::sync::Arc<std::sync::atomic::AtomicBool>,
     handle: Option<std::thread::JoinHandle<()>>,
 }
 
+#[cfg(feature = "builder-vm")]
 impl BuildHeartbeat {
     fn start(activity: &'static str) -> Self {
         Self::start_with(activity, BUILD_HEARTBEAT_INTERVAL, ui::info)
@@ -1805,6 +1808,7 @@ impl BuildHeartbeat {
     }
 }
 
+#[cfg(feature = "builder-vm")]
 impl Drop for BuildHeartbeat {
     fn drop(&mut self) {
         self.stop.store(true, std::sync::atomic::Ordering::Relaxed);
@@ -5255,6 +5259,7 @@ mod builder_vm_bootstrap_tests {
     use std::io::Write;
 
     #[test]
+    #[cfg(feature = "builder-vm")]
     fn build_heartbeat_emits_while_alive_and_stops_on_drop() {
         use std::sync::Arc;
         use std::sync::atomic::{AtomicUsize, Ordering};

--- a/crates/mvm-cli/src/ui.rs
+++ b/crates/mvm-cli/src/ui.rs
@@ -66,6 +66,18 @@ pub fn timed_step(label: &str, elapsed: std::time::Duration) {
     info(&format_timed(label, elapsed));
 }
 
+/// Format a liveness heartbeat for a long, silent blocking step: `<activity>
+/// still running — <secs>s elapsed …`. The Stage 0 builder-image build runs
+/// `nix` inside the guest with no host-visible output until it completes, so a
+/// periodic line is the only way to distinguish "working" from "hung". Pure
+/// (testable); the ticker routes it through [`info`] so it shows by default.
+pub fn format_heartbeat(activity: &str, elapsed: std::time::Duration) -> String {
+    format!(
+        "{activity} still running — {}s elapsed (the in-guest nix build is silent until it finishes; this is normal, not a hang)",
+        elapsed.as_secs()
+    )
+}
+
 /// Print a numbered step: [mvm] Step n/total: message
 pub fn step(n: u32, total: u32, msg: &str) {
     let formatted = format!(
@@ -179,5 +191,15 @@ mod tests {
             format_timed("nix build", std::time::Duration::from_millis(12_345)),
             "nix build … 12.3s"
         );
+    }
+
+    #[test]
+    fn format_heartbeat_names_activity_whole_seconds_and_reassures() {
+        let line = format_heartbeat("Builder VM image build", std::time::Duration::from_secs(40));
+        assert!(line.starts_with("Builder VM image build still running — 40s elapsed"));
+        // Reassurance text is the whole point — it must say silence is expected.
+        assert!(line.contains("not a hang"));
+        // Whole seconds, no fractional noise.
+        assert!(!line.contains("40.0"));
     }
 }


### PR DESCRIPTION
Closes #1122

## Problem

A cold `mvmctl dev up` / `build` / `init` builds the builder VM image by running `nix` inside the Stage 0 guest. That produces **no host-visible output for minutes**: `console.log` only logs at phase milestones (it prints `building path:…builder-vm` and then goes silent until the build finishes), and the in-guest nix stderr isn't streamed to the host. Users — and coding agents — read the silence as a hang. In this session it directly caused a "this is taking FOREVER / is it stuck?" moment; the only liveness signal was inspecting `mvm-libkrun-supervisor` CPU by PID.

## Fix

A RAII heartbeat thread (`BuildHeartbeat`) around the shared `bootstrap_builder_vm_image` build call. While the build runs it emits a default-visible line every ~20s and stops + joins the thread when the build returns:

```
[mvm] Builder VM image build still running — 20s elapsed (the in-guest nix build is silent until it finishes; this is normal, not a hang)
[mvm] Builder VM image build still running — 40s elapsed (...)
[mvm] Builder VM image build still running — 60s elapsed (...)
```

- Emitted via `ui::info` — the same default-visible channel as the existing `[mvm] Builder VM image not in cache; building locally…` line, so it shows in quiet mode (exactly when the silence happens).
- Wrapped around the **shared** `bootstrap_builder_vm_image` ensure path, so every cold-build entry point (`dev up`, `build image`, `run --flake`, `init`) is covered, not just `dev up`.
- ~20s cadence keeps a multi-minute build under ~20 lines.

This is the issue's "cheap floor" (option 2). Full per-line streaming of the in-guest Stage 0 nix stderr to a host log (option 1) would touch the guest `stage0-init` + add a share and rebuild the embedded binary; deliberately scoped out here to keep the guest init untouched — worth a follow-up if the build *content* (not just liveness) is wanted.

## Verification

- `cargo clippy --all-targets -p mvm-cli` clean; `cargo fmt --all --check` clean.
- Unit tests: `format_heartbeat` (names activity, whole seconds, carries the "not a hang" reassurance) and the ticker (`build_heartbeat_emits_while_alive_and_stops_on_drop` — emits on a tight injected cadence, no further emits after drop joins the thread).
- **Live:** a real cold Stage 0 build in an isolated cache emitted the heartbeat at 20/40/60s during the silent build window, then stopped cleanly on teardown (output above).