### PR TITLE
feat(stage0): stream the in-guest nix build log to the host console live

### DIFF
--- a/crates/mvm-build/src/bin/stage0-init.rs
+++ b/crates/mvm-build/src/bin/stage0-init.rs
@@ -42,7 +42,7 @@ fn main() -> ExitCode {
 mod linux {
     use sha2::{Digest, Sha256};
     use std::path::{Path, PathBuf};
-    use std::process::{Command, ExitCode};
+    use std::process::{Command, ExitCode, Stdio};
 
     /// Where nix runs from (its store paths are absolute `/nix/store/...`).
     const NIX_TARGET: &str = "/nix";
@@ -553,50 +553,87 @@ mod linux {
         let flake_ref = format!("path:/work/nix/images/builder-vm#packages.{arch}-linux.{attr}");
 
         eprintln!("stage0-init: building {flake_ref} (output_mode={mode})");
-        let out = Command::new(&nix)
-            .args([
-                "build",
-                &flake_ref,
-                "--extra-experimental-features",
-                "nix-command flakes",
-                // Single-user root bootstrap: the seed has no `nixbld` build
-                // users + no daemon, so build directly as root (empty
-                // build-users-group). Keep the DEFAULT sandbox — it gives
-                // each build a clean env (its own /bin/sh + toolchain),
-                // independent of the minimal seed rootfs; disabling it makes
-                // builds fail on the seed's missing `/bin`, `gcc`, etc.
-                "--option",
-                "build-users-group",
-                "",
-                "--option",
-                "connect-timeout",
-                "30",
-                "--max-jobs",
-                "1",
-                "--no-link",
-                "--no-write-lock-file",
-                "--impure",
-                "--print-out-paths",
-                "--print-build-logs",
-            ])
-            .output()
-            .map_err(|e| format!("spawn nix build: {e}"))?;
-        // nix's --print-build-logs go to stderr; surface them to the console.
-        std::io::Write::write_all(&mut std::io::stderr(), &out.stderr).ok();
+        let mut cmd = Command::new(&nix);
+        cmd.args([
+            "build",
+            &flake_ref,
+            "--extra-experimental-features",
+            "nix-command flakes",
+            // Single-user root bootstrap: the seed has no `nixbld` build
+            // users + no daemon, so build directly as root (empty
+            // build-users-group). Keep the DEFAULT sandbox — it gives
+            // each build a clean env (its own /bin/sh + toolchain),
+            // independent of the minimal seed rootfs; disabling it makes
+            // builds fail on the seed's missing `/bin`, `gcc`, etc.
+            "--option",
+            "build-users-group",
+            "",
+            "--option",
+            "connect-timeout",
+            "30",
+            "--max-jobs",
+            "1",
+            "--no-link",
+            "--no-write-lock-file",
+            "--impure",
+            "--print-out-paths",
+            "--print-build-logs",
+        ]);
+        // Echo nix's `--print-build-logs` to the guest's own stderr, which the
+        // host captures to `console.log` live — that's what makes the otherwise-
+        // silent multi-minute build tailable from the host.
+        let (status, stderr_log, stdout) =
+            run_streaming(cmd, &mut std::io::stderr()).map_err(|e| format!("nix build: {e}"))?;
+
         // Persist the full log to /out (a virtio-fs share) for host-side
         // post-mortem at ~/.cache/mvm/builder-vm/.../nix-stderr.log.
-        let _ = std::fs::write("/out/nix-stderr.log", &out.stderr);
-        if !out.status.success() {
-            return Err(format!(
-                "nix build exit {}",
-                out.status.code().unwrap_or(-1)
-            ));
+        let _ = std::fs::write("/out/nix-stderr.log", &stderr_log);
+        if !status.success() {
+            return Err(format!("nix build exit {}", status.code().unwrap_or(-1)));
         }
-        let store_path = String::from_utf8_lossy(&out.stdout).trim().to_string();
+        let store_path = stdout.trim().to_string();
         if store_path.is_empty() {
             return Err("nix build emitted no /nix/store path".into());
         }
         copy_artifacts(Path::new(&store_path), &mode)
+    }
+
+    /// Spawn `cmd`, streaming its stderr line-by-line to `live` (flushed per
+    /// line so a host tailing the console sees progress as it arrives) while
+    /// accumulating the full stderr for a post-mortem log, and capturing stdout
+    /// (nix's single trailing out-path). Returns `(status, stderr_log, stdout)`.
+    ///
+    /// Draining stderr to EOF before reading stdout can't deadlock here: nix
+    /// writes only the short out-path to stdout (well under the pipe buffer), so
+    /// it never blocks waiting for us to read it.
+    fn run_streaming(
+        mut cmd: Command,
+        live: &mut dyn std::io::Write,
+    ) -> Result<(std::process::ExitStatus, Vec<u8>, String), String> {
+        use std::io::{BufRead, Read};
+        let mut child = cmd
+            .stdout(Stdio::piped())
+            .stderr(Stdio::piped())
+            .spawn()
+            .map_err(|e| format!("spawn: {e}"))?;
+
+        let mut stderr_log: Vec<u8> = Vec::new();
+        if let Some(child_stderr) = child.stderr.take() {
+            let reader = std::io::BufReader::new(child_stderr);
+            for chunk in reader.split(b'\n') {
+                let Ok(mut chunk) = chunk else { break };
+                chunk.push(b'\n');
+                let _ = live.write_all(&chunk);
+                let _ = live.flush();
+                stderr_log.extend_from_slice(&chunk);
+            }
+        }
+        let mut stdout = String::new();
+        if let Some(mut child_stdout) = child.stdout.take() {
+            let _ = child_stdout.read_to_string(&mut stdout);
+        }
+        let status = child.wait().map_err(|e| format!("wait: {e}"))?;
+        Ok((status, stderr_log, stdout))
     }
 
     /// Output by mode: image = kernel + rootfs.ext4 + cmdline; kernel =
@@ -776,6 +813,41 @@ mod linux {
                 eprintln!("stage0-init: reboot syscall failed: {e}");
                 ExitCode::FAILURE
             }
+        }
+    }
+
+    #[cfg(test)]
+    mod tests {
+        use super::run_streaming;
+        use std::process::Command;
+
+        #[test]
+        fn streams_stderr_live_keeps_full_log_and_captures_stdout() {
+            // Mimic nix: build logs to stderr, the out-path to stdout.
+            let mut cmd = Command::new("sh");
+            cmd.args([
+                "-c",
+                "printf 'log1\\nlog2\\n' >&2; printf '/nix/store/abc\\n'",
+            ]);
+            let mut live: Vec<u8> = Vec::new();
+            let (status, stderr_log, stdout) = run_streaming(cmd, &mut live).unwrap();
+            assert!(status.success());
+            // Echoed live to the console sink…
+            assert_eq!(live, b"log1\nlog2\n");
+            // …and accumulated for the post-mortem log.
+            assert_eq!(stderr_log, b"log1\nlog2\n");
+            // out-path captured from stdout.
+            assert_eq!(stdout.trim(), "/nix/store/abc");
+        }
+
+        #[test]
+        fn propagates_nonzero_exit_with_log() {
+            let mut cmd = Command::new("sh");
+            cmd.args(["-c", "echo boom >&2; exit 7"]);
+            let mut live: Vec<u8> = Vec::new();
+            let (status, stderr_log, _stdout) = run_streaming(cmd, &mut live).unwrap();
+            assert_eq!(status.code(), Some(7));
+            assert_eq!(stderr_log, b"boom\n");
         }
     }
 }

--- a/crates/mvm-build/src/libkrun_builder.rs
+++ b/crates/mvm-build/src/libkrun_builder.rs
@@ -480,6 +480,14 @@ impl LibkrunBuilderVm {
             ))
         })?;
         let console_log = vm_state_dir.join("console.log");
+        // The in-guest nix build streams its `--print-build-logs` to this
+        // console as it runs (stage0-init echoes each line live), so point the
+        // operator at it — the build is otherwise silent for minutes. `[mvm]`
+        // eprintln matches the existing Stage 0 hint channel (stage0.rs).
+        eprintln!(
+            "[mvm] Stage 0 build log streams to {} — `tail -f` it to watch progress",
+            console_log.display()
+        );
 
         let mut krun = krun_context_for_image(&vm_name, &image)?
             .with_resources(self.vcpus, self.memory_mib)


### PR DESCRIPTION
Completes the **streaming half of #1122** (the heartbeat half is #1130). Together they make the silent Stage 0 build fully observable: #1130 says "still alive, Ns elapsed"; this shows *what* it's building.

## Problem

`stage0-init` ran the builder-image `nix build` via `Command::output()`, which **buffers** all of `--print-build-logs` until the process exits and only then writes it to stderr + `/out/nix-stderr.log`. The guest's stderr is captured to the host `console.log` *live* — so the buffering is precisely why `tail -f console.log` showed `building path:…builder-vm` and then nothing for minutes.

## Fix

Stream instead of buffer:
- Spawn nix with piped stdout/stderr; read stderr line-by-line, echoing each line to the guest's own stderr (→ host `console.log`) **as it arrives**, flushed per line.
- Still accumulate the full stderr for the `/out/nix-stderr.log` post-mortem (unchanged contract — nothing reads it programmatically, verified) and capture stdout (nix's trailing out-path).
- Factored into a `run_streaming(cmd, live) -> (status, stderr_log, stdout)` helper.
- The host (`run_stage0_impl`) prints the console.log path up front via the existing `[mvm]` eprintln hint channel so the operator knows where to look:
  ```
  [mvm] Stage 0 build log streams to …/mvm-stage0-…/console.log — `tail -f` it to watch progress
  ```

Draining stderr to EOF before reading stdout can't deadlock: nix writes only the short out-path to stdout (well under the pipe buffer).

## Verification

- `cargo clippy -p mvm-build` (macOS host) clean; `cargo fmt --all --check` clean.
- `stage0-init` is a Linux-only bin, so cross-compiled for `aarch64-unknown-linux-musl` (the embed target) — **bin + test harness compile clean** (`cargo zigbuild --tests`, RUSTC pinned to rustup). The musl test binary can't run on macOS; the two `run_streaming` unit tests (live-stream + nonzero-exit) run on Linux CI.
- **Live:** a real cold Stage 0 build surfaced **1212 nix build-log lines** in `console.log` while still mid-build (killed at 90s, build ~6–8min) — e.g. `building '/nix/store/…linux-6.12.87.drv'…`, `copying path … from cache.nixos.org`, `linux> unpacking source archive …`. Under the old code: nothing until completion.

## Scope note
This streams to the existing `console.log` (the guest console is already a live host stream), so no new virtio-fs share and no guest-init transport changes beyond the nix invocation itself.