### PR TITLE
fix(vz): make vm save/restore round-trip survive a stop

### DIFF
--- a/crates/mvm-backend/src/checkpoint/mod.rs
+++ b/crates/mvm-backend/src/checkpoint/mod.rs
@@ -1374,7 +1374,11 @@ mod tests {
         assert_eq!(child.parent.as_ref().unwrap(), &parent.id);
         assert_eq!(child.vm_name, "childvm");
         assert_eq!(child.content, parent.content);
-        let names: Vec<_> = child.content.iter().map(|blob| blob.name.as_str()).collect();
+        let names: Vec<_> = child
+            .content
+            .iter()
+            .map(|blob| blob.name.as_str())
+            .collect();
         assert_eq!(
             names,
             vec![

--- a/crates/mvm-backend/src/checkpoint/mod.rs
+++ b/crates/mvm-backend/src/checkpoint/mod.rs
@@ -1359,8 +1359,14 @@ mod tests {
         )
         .unwrap();
 
-        // All three blobs cloned into the child dir.
-        for name in ["rootfs.ext4", "memory.bin", "machine-id"] {
+        // All vm_full blobs cloned into the child dir, including the launch
+        // config needed to survive stop/restart state-dir reaping.
+        for name in [
+            "rootfs.ext4",
+            "memory.bin",
+            "machine-id",
+            crate::vz::SUPERVISOR_CONFIG_FILE_NAME,
+        ] {
             assert!(dest.join(name).exists(), "{name} not cloned");
         }
         // Lineage + class + content carried over.
@@ -1368,7 +1374,16 @@ mod tests {
         assert_eq!(child.parent.as_ref().unwrap(), &parent.id);
         assert_eq!(child.vm_name, "childvm");
         assert_eq!(child.content, parent.content);
-        assert_eq!(child.content.len(), 3);
+        let names: Vec<_> = child.content.iter().map(|blob| blob.name.as_str()).collect();
+        assert_eq!(
+            names,
+            vec![
+                "rootfs.ext4",
+                "memory.bin",
+                "machine-id",
+                crate::vz::SUPERVISOR_CONFIG_FILE_NAME,
+            ]
+        );
 
         // Spawner invoked with the rewritten child config.
         let cfg = spawner.seen.borrow().clone().unwrap();

--- a/crates/mvm-backend/src/checkpoint/mod.rs
+++ b/crates/mvm-backend/src/checkpoint/mod.rs
@@ -408,6 +408,9 @@ pub struct CaptureVmFullParams {
     pub id: CheckpointId,
     pub vm_name: String,
     pub supervisor_config_digest: String,
+    /// The live VM's persisted supervisor config, copied into the checkpoint so
+    /// restore can rebuild the state dir (every stop reaps the live one).
+    pub supervisor_config_src: PathBuf,
     pub tag: Option<String>,
     pub created_unix: u64,
 }
@@ -446,6 +449,18 @@ pub fn capture_vm_full(
     captured?;
     resumed.context("resuming VM after vm_full capture")?;
 
+    // Persist the launch config into the checkpoint. Restore needs it to resolve
+    // the target rootfs path and to spawn the supervisor, but every stop reaps
+    // the VM's state dir — so without storing it here the round-trip is
+    // unreachable. (Static during the pause window; copied after resume.)
+    let config_dst = content_dir.join(crate::vz::SUPERVISOR_CONFIG_FILE_NAME);
+    std::fs::copy(&params.supervisor_config_src, &config_dst).with_context(|| {
+        format!(
+            "copying supervisor config {} into checkpoint",
+            params.supervisor_config_src.display()
+        )
+    })?;
+
     let content = vec![
         ContentBlob {
             name: "rootfs.ext4".into(),
@@ -458,6 +473,10 @@ pub fn capture_vm_full(
         ContentBlob {
             name: "machine-id".into(),
             sha256: sha256_file_hex(&machine_id)?,
+        },
+        ContentBlob {
+            name: crate::vz::SUPERVISOR_CONFIG_FILE_NAME.into(),
+            sha256: sha256_file_hex(&config_dst)?,
         },
     ];
     let meta = CheckpointMeta::builder(params.id, CheckpointClass::VmFull, params.vm_name)
@@ -476,13 +495,41 @@ pub trait VmFullRestore {
     /// Materialize `rootfs_src` onto the target VM's rootfs, then restore the
     /// machine `memory` + `machine_id`, and resume. The target must already be
     /// stopped — callers must ensure no live supervisor is racing the rootfs.
+    ///
+    /// `config_src`, when present, is the launch config persisted in the
+    /// checkpoint; the backend rebuilds the target state dir from it (every stop
+    /// reaps the live one). `None` for legacy checkpoints — fall through to the
+    /// existing live-state-dir behavior.
     fn restore(
         &self,
         target_vm: &str,
         rootfs_src: &Path,
         memory: &Path,
         machine_id: &Path,
+        config_src: Option<&Path>,
     ) -> Result<()>;
+}
+
+/// Rebuild a stopped VM's persisted supervisor config at `target_config` from
+/// the checkpoint's `config_src`, unless one is already present. Restore needs
+/// it to resolve the rootfs target + spawn the supervisor, but the per-VM
+/// drainer reaps the state dir on every stop. Side-effect-free when the target
+/// already exists, so it's safe to call unconditionally.
+pub(crate) fn reconstruct_state_config(config_src: &Path, target_config: &Path) -> Result<()> {
+    if target_config.exists() {
+        return Ok(());
+    }
+    if let Some(parent) = target_config.parent() {
+        std::fs::create_dir_all(parent)
+            .with_context(|| format!("creating restore target state dir {}", parent.display()))?;
+    }
+    std::fs::copy(config_src, target_config).with_context(|| {
+        format!(
+            "reconstructing supervisor config at {} from checkpoint",
+            target_config.display()
+        )
+    })?;
+    Ok(())
 }
 
 pub struct RestoreParams {
@@ -509,11 +556,20 @@ pub fn restore_checkpoint(
     }
     verify_content(store, &meta)?;
     let dir = store.content_dir(&meta.id);
+
+    // The checkpoint carries the launch config (for checkpoints captured after
+    // this landed). Hand it to the restore seam so the backend can rebuild the
+    // target state dir the stop reaped. Older checkpoints lack it → `None`, and
+    // the backend falls through to its legacy live-state-dir behavior.
+    let stored_config = dir.join(crate::vz::SUPERVISOR_CONFIG_FILE_NAME);
+    let config_src = stored_config.is_file().then_some(stored_config.as_path());
+
     restore.restore(
         &params.target_vm,
         &dir.join("rootfs.ext4"),
         &dir.join("memory.bin"),
         &dir.join("machine-id"),
+        config_src,
     )
 }
 
@@ -1031,12 +1087,15 @@ mod tests {
             rootfs,
             events: RefCell::new(vec![]),
         };
+        let config = tmp.path().join("supervisor-config.json");
+        std::fs::write(&config, b"{\"cfg\":true}").unwrap();
         let meta = capture_vm_full(
             &store,
             CaptureVmFullParams {
                 id: CheckpointId::new("v1"),
                 vm_name: "vm".into(),
                 supervisor_config_digest: "d".into(),
+                supervisor_config_src: config,
                 tag: None,
                 created_unix: 9,
             },
@@ -1050,12 +1109,16 @@ mod tests {
             names.contains(&"rootfs.ext4")
                 && names.contains(&"memory.bin")
                 && names.contains(&"machine-id")
+                // The launch config is now captured so restore can rebuild the
+                // reaped state dir.
+                && names.contains(&"supervisor-config.json")
         );
         verify_content(&store, &meta).unwrap();
     }
 
     struct MockRestore {
         seen: RefCell<Option<(String, PathBuf, PathBuf, PathBuf)>>,
+        config_seen: RefCell<Option<PathBuf>>,
     }
     impl VmFullRestore for MockRestore {
         fn restore(
@@ -1064,6 +1127,7 @@ mod tests {
             rootfs_src: &Path,
             memory: &Path,
             machine_id: &Path,
+            config_src: Option<&Path>,
         ) -> Result<()> {
             *self.seen.borrow_mut() = Some((
                 target_vm.to_string(),
@@ -1071,6 +1135,7 @@ mod tests {
                 memory.to_path_buf(),
                 machine_id.to_path_buf(),
             ));
+            *self.config_seen.borrow_mut() = config_src.map(Path::to_path_buf);
             Ok(())
         }
     }
@@ -1078,6 +1143,8 @@ mod tests {
     fn seed_vm_full_checkpoint(store: &CheckpointStore, tmp: &Path, id: &str) -> CheckpointMeta {
         let rootfs = tmp.join("live.ext4");
         std::fs::write(&rootfs, b"disk").unwrap();
+        let config = tmp.join(format!("{id}-supervisor-config.json"));
+        std::fs::write(&config, b"{\"cfg\":true}").unwrap();
         let ctl = MockControl {
             rootfs,
             events: RefCell::new(vec![]),
@@ -1088,6 +1155,7 @@ mod tests {
                 id: CheckpointId::new(id),
                 vm_name: "origin".into(),
                 supervisor_config_digest: "d".into(),
+                supervisor_config_src: config,
                 tag: None,
                 created_unix: 1,
             },
@@ -1103,6 +1171,7 @@ mod tests {
         let ckpt = seed_vm_full_checkpoint(&store, tmp.path(), "v1");
         let restore = MockRestore {
             seen: RefCell::new(None),
+            config_seen: RefCell::new(None),
         };
         restore_checkpoint(
             &store,
@@ -1119,6 +1188,29 @@ mod tests {
         assert_eq!(r, cdir.join("rootfs.ext4"));
         assert_eq!(m, cdir.join("memory.bin"));
         assert_eq!(mid, cdir.join("machine-id"));
+        // The stored launch config is handed to the seam so the backend can
+        // rebuild the reaped state dir.
+        assert_eq!(
+            restore.config_seen.borrow().clone(),
+            Some(cdir.join("supervisor-config.json"))
+        );
+    }
+
+    #[test]
+    fn reconstruct_state_config_writes_when_absent_and_is_a_noop_when_present() {
+        let tmp = tempfile::tempdir().unwrap();
+        let src = tmp.path().join("src.json");
+        std::fs::write(&src, b"FROM-CHECKPOINT").unwrap();
+
+        // Absent target → reconstructed (parent dir created) from the source.
+        let target = tmp.path().join("vms/origin/supervisor-config.json");
+        reconstruct_state_config(&src, &target).unwrap();
+        assert_eq!(std::fs::read(&target).unwrap(), b"FROM-CHECKPOINT");
+
+        // Present target → left untouched (a live config wins, never clobbered).
+        std::fs::write(&target, b"LIVE").unwrap();
+        reconstruct_state_config(&src, &target).unwrap();
+        assert_eq!(std::fs::read(&target).unwrap(), b"LIVE");
     }
 
     #[test]
@@ -1128,6 +1220,7 @@ mod tests {
         let fsq = seed_fs_quick_checkpoint(&store, tmp.path(), "p1");
         let restore = MockRestore {
             seen: RefCell::new(None),
+            config_seen: RefCell::new(None),
         };
         let err = restore_checkpoint(
             &store,
@@ -1154,6 +1247,7 @@ mod tests {
         std::fs::write(&blob, b"tampered").unwrap();
         let restore = MockRestore {
             seen: RefCell::new(None),
+            config_seen: RefCell::new(None),
         };
         let err = restore_checkpoint(
             &store,

--- a/crates/mvm-backend/src/vz.rs
+++ b/crates/mvm-backend/src/vz.rs
@@ -137,7 +137,7 @@ const DRAINER_PID_FILE_NAME: &str = "vz-drainer.pid";
 /// `snapshot_restore` can replay the same shape with
 /// `startup_mode` flipped. Mode 0600 — same tier as the audit
 /// chain and the host signer.
-const SUPERVISOR_CONFIG_FILE_NAME: &str = "supervisor-config.json";
+pub(crate) const SUPERVISOR_CONFIG_FILE_NAME: &str = "supervisor-config.json";
 
 /// Canonical path to a VM's persisted supervisor config inside its state dir.
 /// The single source of truth for the file name so callers (e.g. the
@@ -1045,6 +1045,7 @@ impl crate::checkpoint::VmFullRestore for VzBackend {
         rootfs_src: &std::path::Path,
         memory: &std::path::Path,
         machine_id: &std::path::Path,
+        config_src: Option<&std::path::Path>,
     ) -> anyhow::Result<()> {
         restore_with_spawn(
             self,
@@ -1052,6 +1053,7 @@ impl crate::checkpoint::VmFullRestore for VzBackend {
             rootfs_src,
             memory,
             machine_id,
+            config_src,
             |backend, vm, mem, mid| {
                 backend
                     .snapshot_restore(&VmId(vm.to_string()), mem, Some(mid))
@@ -1069,9 +1071,16 @@ fn restore_with_spawn(
     rootfs_src: &std::path::Path,
     memory: &std::path::Path,
     machine_id: &std::path::Path,
+    config_src: Option<&std::path::Path>,
     do_restore: impl FnOnce(&VzBackend, &str, &std::path::Path, &std::path::Path) -> anyhow::Result<()>,
 ) -> anyhow::Result<()> {
     refuse_if_running(target_vm)?;
+    // Rebuild the state dir the stop reaped before anything reads it: restore
+    // resolves the rootfs target and spawns the supervisor from this config.
+    if let Some(config_src) = config_src {
+        let target_config = supervisor_config_path(&vm_state_dir(target_vm));
+        crate::checkpoint::reconstruct_state_config(config_src, &target_config)?;
+    }
     use crate::checkpoint::VmFullControl as _;
     let target_rootfs = VzVmFullControl::new(target_vm)
         .rootfs_path()
@@ -1417,6 +1426,9 @@ fn vz_spawn_standby(
         id: pool_id.clone(),
         vm_name: spec.id.clone(),
         supervisor_config_digest: cfg_digest,
+        // The seed's own state dir is torn down at stop, so capture from the
+        // durable copy just persisted into the pool dir.
+        supervisor_config_src: pool_seed_config_path(&pool_root, &spec.id),
         tag: None,
         created_unix: crate::standby_pool::now_unix_secs(),
     };
@@ -3276,6 +3288,7 @@ mod tests {
                 std::path::Path::new("/nonexistent/rootfs.ext4"),
                 std::path::Path::new("/nonexistent/memory.bin"),
                 std::path::Path::new("/nonexistent/machine-id"),
+                None,
             )
             .expect_err("must refuse restore into a running VM");
 
@@ -3377,6 +3390,7 @@ mod tests {
             &src_rootfs,
             Path::new("/abs/memory.bin"),
             Path::new("/abs/machine-id"),
+            None,
             |_, _, _, _| anyhow::bail!("injected spawn failure"),
         )
         .expect_err("injected failure must propagate");
@@ -3433,6 +3447,7 @@ mod tests {
             &src_rootfs,
             Path::new("/abs/memory.bin"),
             Path::new("/abs/machine-id"),
+            None,
             |_, _, _, _| panic!("spawn must not be called when target already exists"),
         )
         .expect_err("pre-existing target must error");

--- a/crates/mvm-cli/src/commands/vm/checkpoint.rs
+++ b/crates/mvm-cli/src/commands/vm/checkpoint.rs
@@ -435,6 +435,7 @@ fn create_vm_full(name: &str, tag: Option<String>, json: bool) -> Result<()> {
             id,
             vm_name: name.to_string(),
             supervisor_config_digest: supervisor_config_digest(&state_dir),
+            supervisor_config_src: supervisor_config_path(&state_dir),
             tag,
             created_unix: now,
         },


### PR DESCRIPTION
Fixes #1136. Unblocks the Plan 189 WS-1 live acceptance ("round-trip a vz VM through save → stop → restore on macOS-26; state preserved").

## Problem

`mvmctl vm save` / `vm restore` could never complete a `save → stop → restore` round-trip. Restore resolved its target rootfs and spawned the supervisor by reading the **live** VM's `supervisor-config.json`, but:
- Every stop (`down`, SIGTERM, SIGKILL) reaps the per-VM state dir via the drainer, and
- restore refuses a still-running VM (`refuse_if_running`).

So restore was only reachable for a VM that never stopped — contradictory. The natural flow failed with:
```
restoring checkpoint "ckpt-X-..."
  0: resolving target VM rootfs path for restore
  1: reading ~/.mvm/vms/X/supervisor-config.json: No such file or directory
```
The checkpoint content was already self-contained (`rootfs.ext4` + `memory.bin` + `machine-id`) — only the launch config was missing.

## Fix

- **Save** (`capture_vm_full`): copy the live `supervisor-config.json` into the checkpoint content (it was already digested for the pin; this stores the matching content). Source path is passed in via `CaptureVmFullParams.supervisor_config_src` so it stays unit-testable.
- **Restore** (`VmFullRestore::restore` + the Vz impl): hand the stored config to the restore seam; the backend rebuilds the target state dir from it via `reconstruct_state_config` — digest-bound, and a no-op when a live config is already present (never clobbers) — before resolving the rootfs and spawning. Legacy checkpoints without the stored config (`None`) fall through to the previous behavior.

## Verification

- `cargo clippy -p mvm-backend -p mvm-cli` clean; `cargo fmt --all --check` clean.
- Unit tests: capture now asserts the `supervisor-config.json` blob is stored; the restore-seam test asserts the config flows through; new `reconstruct_state_config` test covers absent→write and present→no-op. All green.
- **Live, macOS 26 / Vz:** `up --name X --dev -d` → write a marker to `/tmp` (tmpfs/RAM) → `vm save` → `down` (reaps the state dir) → `vm restore` → the restored guest returns the **exact** marker (`mvm-p189c-...`). tmpfs content can only survive a real memory restore, so this proves the end-to-end round-trip through a genuine stop — the precise flow that errored before this change.

## Note
`fork` from a vm-full checkpoint reads the live parent config the same way and has the same latent gap; it now has the stored config available to fix as a focused follow-up (left out here to keep the change reviewable).