### PR TITLE
feat(plan-205): snapshot park/resume the Vz dev builder (S2.1 live, unblocks #1119)

### DIFF
--- a/crates/mvm-backend/src/vz.rs
+++ b/crates/mvm-backend/src/vz.rs
@@ -350,7 +350,8 @@ impl VmBackend for VzBackend {
             {
                 bail!(
                     "supervisor exited before writing PID file (status: {status}). \
-                     Check stderr above for VZ configuration errors. Console log: {}",
+                     Check stderr above for VZ configuration errors.{} Console log: {}",
+                    stale_supervisor_hint(&supervisor_path),
                     console_log.display()
                 );
             }
@@ -2542,6 +2543,46 @@ fn refuse_if_running(target_vm: &str) -> anyhow::Result<()> {
     Ok(())
 }
 
+/// Rebuild command for the Vz per-VM host binaries (the objc2 supervisor + the
+/// drainer sibling). `cargo run`/`test` never rebuilds these separate bin crates.
+const VZ_AUX_REBUILD_CMD: &str =
+    "cargo build -p mvm-vm-host --bin mvm-vz-supervisor --bin mvm-vz-drainer";
+
+fn mtime_of(p: &Path) -> Option<std::time::SystemTime> {
+    std::fs::metadata(p).and_then(|m| m.modified()).ok()
+}
+
+/// A leading-space hint, ready to interpolate into the boot-failure message,
+/// when `supervisor_path` looks stale relative to the running `mvmctl` — else
+/// `""`. In a source checkout `cargo run` rebuilds only `mvmctl`, leaving the
+/// separate `mvm-vz-*` bin crates behind; they then reject a newer
+/// `ExecutionPlan`/`SupervisorConfig` via `deny_unknown_fields` and exit before
+/// booting (the cryptic `unknown field` failure). Consulted only on that failure
+/// path, so a false positive merely appends a rebuild suggestion to an already-
+/// failing boot.
+fn stale_supervisor_hint(supervisor_path: &Path) -> String {
+    let self_mtime = std::env::current_exe().ok().as_deref().and_then(mtime_of);
+    match stale_aux_binary_hint(mtime_of(supervisor_path), self_mtime, VZ_AUX_REBUILD_CMD) {
+        Some(h) => format!(" {h}"),
+        None => String::new(),
+    }
+}
+
+/// Pure core of [`stale_supervisor_hint`]: a rebuild hint when `bin_mtime` is
+/// older than `self_mtime`. `None` when either mtime is unknown or the binary is
+/// at-least-as-new — so an installed release (bins share an install time) never
+/// trips it; only a source checkout's stale aux binary does.
+fn stale_aux_binary_hint(
+    bin_mtime: Option<std::time::SystemTime>,
+    self_mtime: Option<std::time::SystemTime>,
+    rebuild_cmd: &str,
+) -> Option<String> {
+    let (bin, me) = (bin_mtime?, self_mtime?);
+    (bin < me).then(|| {
+        format!("The supervisor binary is older than mvmctl and may be stale — rebuild it: {rebuild_cmd}")
+    })
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -2549,6 +2590,37 @@ mod tests {
     #[test]
     fn name_is_vz() {
         assert_eq!(VzBackend.name(), "vz");
+    }
+
+    #[test]
+    fn stale_aux_hint_fires_only_when_binary_predates_mvmctl() {
+        use std::time::{Duration, SystemTime};
+        let base = SystemTime::UNIX_EPOCH;
+        let newer = base + Duration::from_secs(100);
+        let cmd = "cargo build -p mvm-vm-host";
+
+        // Binary older than mvmctl → hint naming the rebuild command.
+        let hint = stale_aux_binary_hint(Some(base), Some(newer), cmd).expect("expected a hint");
+        assert!(
+            hint.contains(cmd),
+            "hint must name the rebuild command: {hint}"
+        );
+        assert!(hint.contains("stale"));
+
+        // At-least-as-new binary → no hint (installed release, equal mtimes).
+        assert!(stale_aux_binary_hint(Some(newer), Some(base), cmd).is_none());
+        assert!(stale_aux_binary_hint(Some(base), Some(base), cmd).is_none());
+
+        // Unknown mtime on either side → no hint (don't guess).
+        assert!(stale_aux_binary_hint(None, Some(newer), cmd).is_none());
+        assert!(stale_aux_binary_hint(Some(base), None, cmd).is_none());
+    }
+
+    #[test]
+    fn stale_supervisor_hint_formats_with_leading_space_or_empty() {
+        // A path that doesn't exist has no mtime → empty (no false hint).
+        let missing = std::path::Path::new("/nonexistent/mvm-vz-supervisor");
+        assert_eq!(stale_supervisor_hint(missing), "");
     }
 
     #[test]

--- a/crates/mvm-build/src/builder_control.rs
+++ b/crates/mvm-build/src/builder_control.rs
@@ -1,0 +1,257 @@
+//! Host-side client for the persistent builder VM's control socket.
+//!
+//! The Vz supervisor binds `<vm_state_dir>/control.sock` (mode 0700) and
+//! accepts newline-framed text commands — the same protocol as
+//! `mvm-backend::vz_control`. This module reimplements the minimal client
+//! inside `mvm-build` so the crate stays off `mvm-backend` in the dep graph
+//! (mvm-backend depends on mvm-build, not the other way around).
+//!
+//! `send_builder_control_command` is the only public surface; everything else
+//! is a test helper or a private sub-function.
+
+use std::io::{Read, Write};
+use std::os::unix::net::UnixStream;
+use std::path::Path;
+use std::time::Duration;
+
+use crate::builder_vm::BuilderVmError;
+use crate::vz::{StartupMode, SupervisorConfig};
+
+const DEFAULT_TIMEOUT: Duration = Duration::from_secs(5);
+
+/// Send one newline-framed command to the builder VM's control socket and
+/// return the response line (without the trailing newline).
+///
+/// Rejects commands that contain embedded newlines — they would split into
+/// multiple protocol frames, corrupting the command stream. Maps I/O errors
+/// to [`BuilderVmError::ExtractionFailed`] with the socket path and operation
+/// in the message.
+pub fn send_builder_control_command(
+    socket_path: &Path,
+    command: &str,
+) -> Result<String, BuilderVmError> {
+    if command.contains('\n') {
+        return Err(BuilderVmError::ExtractionFailed(format!(
+            "builder control command must not contain a newline: {command:?}"
+        )));
+    }
+
+    let mut stream = UnixStream::connect(socket_path).map_err(|e| {
+        BuilderVmError::ExtractionFailed(format!("connect {}: {e}", socket_path.display()))
+    })?;
+    stream
+        .set_read_timeout(Some(DEFAULT_TIMEOUT))
+        .map_err(|e| BuilderVmError::ExtractionFailed(format!("set_read_timeout: {e}")))?;
+    stream
+        .set_write_timeout(Some(DEFAULT_TIMEOUT))
+        .map_err(|e| BuilderVmError::ExtractionFailed(format!("set_write_timeout: {e}")))?;
+
+    let mut payload = command.as_bytes().to_vec();
+    payload.push(b'\n');
+    stream
+        .write_all(&payload)
+        .map_err(|e| BuilderVmError::ExtractionFailed(format!("write command {command:?}: {e}")))?;
+
+    // Read byte-by-byte until a newline or EOF — one response per command.
+    let mut response = Vec::with_capacity(64);
+    let mut buf = [0u8; 1];
+    loop {
+        let n = stream
+            .read(&mut buf)
+            .map_err(|e| BuilderVmError::ExtractionFailed(format!("read response: {e}")))?;
+        if n == 0 {
+            break;
+        }
+        if buf[0] == b'\n' {
+            break;
+        }
+        response.push(buf[0]);
+    }
+
+    String::from_utf8(response)
+        .map_err(|e| BuilderVmError::ExtractionFailed(format!("response was not UTF-8: {e}")))
+}
+
+/// Return a copy of `persisted` with `startup_mode` set to
+/// [`StartupMode::Restore`] pointing at `snapshot_path`.
+///
+/// All other fields — name, disks, resources, vsock, virtio-fs shares,
+/// console, network, balloon, control socket, tenant/plan/audit substrate —
+/// are preserved byte-identically. The caller is responsible for persisting
+/// the returned config before the next boot.
+///
+/// Returns `Err` when `snapshot_path` is not absolute (the Vz API requires
+/// an absolute path for `restoreMachineState(from:)`).
+pub fn builder_restore_config(
+    persisted: SupervisorConfig,
+    snapshot_path: &Path,
+    machine_id_path: Option<&Path>,
+) -> Result<SupervisorConfig, BuilderVmError> {
+    if !snapshot_path.is_absolute() {
+        return Err(BuilderVmError::ExtractionFailed(format!(
+            "snapshot_path must be absolute, got: {}",
+            snapshot_path.display()
+        )));
+    }
+    Ok(SupervisorConfig {
+        startup_mode: StartupMode::Restore {
+            snapshot_path: snapshot_path.to_string_lossy().into_owned(),
+            machine_id_path: machine_id_path.map(|p| p.to_string_lossy().into_owned()),
+        },
+        ..persisted
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::vz::{DiskConfig, KernelConfig, ResourceConfig, VirtioFsShare, VsockConfig};
+    use std::os::unix::net::UnixListener;
+    use std::thread;
+
+    // ── helpers ─────────────────────────────────────────────────────────────
+
+    /// Spawn a one-shot fake supervisor on `path` that accepts a single
+    /// connection, reads one line (drains the command), and replies
+    /// `response\n`.
+    fn fake_supervisor(path: std::path::PathBuf, response: String) -> thread::JoinHandle<()> {
+        let listener = UnixListener::bind(&path).expect("bind fake supervisor");
+        thread::spawn(move || {
+            if let Ok((mut stream, _)) = listener.accept() {
+                let mut buf = [0u8; 256];
+                let _ = stream.read(&mut buf);
+                let mut payload = response.into_bytes();
+                payload.push(b'\n');
+                let _ = stream.write_all(&payload);
+            }
+        })
+    }
+
+    fn minimal_config() -> SupervisorConfig {
+        SupervisorConfig {
+            name: "test-builder".into(),
+            vm_state_dir: "/tmp/builder".into(),
+            pid_file_name: Some("vz.pid".into()),
+            kernel: KernelConfig {
+                path: "/tmp/vmlinux".into(),
+                cmdline: "console=hvc0 root=/dev/vda rw init=/init".into(),
+                initrd_path: None,
+            },
+            resources: ResourceConfig {
+                cpu_count: 2,
+                memory_mib: 4096,
+            },
+            disks: vec![DiskConfig {
+                id: "rootfs".into(),
+                path: "/tmp/rootfs.ext4".into(),
+                read_only: true,
+            }],
+            virtio_fs: vec![VirtioFsShare {
+                tag: "work".into(),
+                host_path: "/work".into(),
+                read_only: false,
+            }],
+            vsock: VsockConfig {
+                ports: vec![5252],
+                socket_dir: "/tmp/builder/vsock".into(),
+                host_listen_ports: vec![],
+            },
+            console_output_path: None,
+            network: None,
+            balloon: None,
+            control_socket_path: Some("/tmp/builder/control.sock".into()),
+            startup_mode: StartupMode::Boot,
+            tenant_id: None,
+            plan: None,
+            bundle: None,
+            network_policy: None,
+            audit_dir: None,
+            gateway_audit_socket: None,
+            signing_key_path: None,
+        }
+    }
+
+    // ── Task 2 tests: send_builder_control_command ───────────────────────────
+
+    #[test]
+    fn builder_control_newline_in_command_rejected() {
+        // Must fail without connecting (before socket dial).
+        let err =
+            send_builder_control_command(Path::new("/nonexistent.sock"), "SAVE /tmp/x\nINJECT")
+                .expect_err("newline must be rejected");
+        assert!(
+            err.to_string().contains("must not contain a newline"),
+            "error: {err}"
+        );
+    }
+
+    #[test]
+    fn builder_control_round_trip_via_echo_server() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let sock = dir.path().join("control.sock");
+
+        let h = fake_supervisor(sock.clone(), "OK".to_string());
+        let response = send_builder_control_command(&sock, "SAVE /tmp/x").expect("round-trip");
+        assert_eq!(response, "OK");
+        h.join().unwrap();
+    }
+
+    #[test]
+    fn builder_control_missing_socket_errors_with_path() {
+        let err = send_builder_control_command(Path::new("/nonexistent/control.sock"), "STATUS")
+            .expect_err("missing socket should error");
+        assert!(
+            err.to_string().contains("/nonexistent/control.sock"),
+            "error includes path: {err}"
+        );
+    }
+
+    // ── Task 3 tests: builder_restore_config ────────────────────────────────
+
+    #[test]
+    fn builder_restore_config_sets_restore_mode_with_paths() {
+        let cfg = minimal_config();
+        let snap = Path::new("/abs/snap.vzsnap");
+        let mid = Path::new("/abs/snap.vzsnap.machine-id");
+
+        let result = builder_restore_config(cfg, snap, Some(mid)).expect("absolute path accepted");
+
+        match result.startup_mode {
+            StartupMode::Restore {
+                snapshot_path,
+                machine_id_path,
+            } => {
+                assert_eq!(snapshot_path, "/abs/snap.vzsnap");
+                assert_eq!(
+                    machine_id_path.as_deref(),
+                    Some("/abs/snap.vzsnap.machine-id")
+                );
+            }
+            other => panic!("expected Restore, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn builder_restore_config_preserves_all_other_fields() {
+        let cfg = minimal_config();
+        let snap = Path::new("/abs/snap.vzsnap");
+
+        let result =
+            builder_restore_config(cfg.clone(), snap, None).expect("absolute path accepted");
+
+        assert_eq!(result.name, cfg.name);
+        assert_eq!(result.disks.len(), cfg.disks.len());
+        assert_eq!(result.control_socket_path, cfg.control_socket_path);
+        assert_eq!(result.vm_state_dir, cfg.vm_state_dir);
+        assert_eq!(result.resources.cpu_count, cfg.resources.cpu_count);
+        assert_eq!(result.virtio_fs.len(), cfg.virtio_fs.len());
+    }
+
+    #[test]
+    fn builder_restore_config_relative_path_rejected() {
+        let cfg = minimal_config();
+        let err = builder_restore_config(cfg, Path::new("relative/snap.vzsnap"), None)
+            .expect_err("relative path must be rejected");
+        assert!(err.to_string().contains("must be absolute"), "error: {err}");
+    }
+}

--- a/crates/mvm-build/src/lib.rs
+++ b/crates/mvm-build/src/lib.rs
@@ -2,6 +2,10 @@ pub mod app_deps;
 pub mod app_deps_gate;
 pub mod artifacts;
 pub mod backend;
+/// Host-side control-socket client for the persistent Vz builder VM.
+/// Mirrors the minimal line-framed protocol the Vz supervisor exposes,
+/// without depending on `mvm-backend` (which sits above `mvm-build`).
+pub mod builder_control;
 /// Vsock dispatch wire types for the persistent builder VM.
 pub mod builder_protocol;
 pub mod builder_vm;

--- a/crates/mvm-build/src/persistent_builder.rs
+++ b/crates/mvm-build/src/persistent_builder.rs
@@ -643,6 +643,13 @@ pub struct SessionRecord {
     /// PID of the libkrun supervisor child. Used to check the
     /// session is alive before routing through it.
     pub supervisor_pid: u32,
+    /// Path to a saved Vz machine-state snapshot. When `Some`, the
+    /// next start of the persistent builder VM will restore from this
+    /// snapshot instead of cold-booting. `None` means the VM starts
+    /// fresh. Old JSON records without this field deserialize to
+    /// `None` (backward-compatible via `#[serde(default)]`).
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub snapshot_path: Option<PathBuf>,
 }
 
 /// On-disk location of the session record. Returns `None` only if
@@ -1061,11 +1068,54 @@ mod tests {
             job_dir: PathBuf::from("/tmp/jobs"),
             workspace_root: PathBuf::from("/work"),
             supervisor_pid: 4242,
+            snapshot_path: None,
         };
         let json = serde_json::to_vec(&record).unwrap();
         let back: SessionRecord = serde_json::from_slice(&json).unwrap();
         assert_eq!(back.session_id, "abc");
         assert_eq!(back.supervisor_pid, 4242);
+    }
+
+    #[test]
+    fn snapshot_path_some_roundtrips_through_json() {
+        let record = SessionRecord {
+            session_id: "snap-test".to_string(),
+            dispatch_socket_path: PathBuf::from("/tmp/sock"),
+            job_dir: PathBuf::from("/tmp/jobs"),
+            workspace_root: PathBuf::from("/work"),
+            supervisor_pid: 1234,
+            snapshot_path: Some(PathBuf::from("/abs/builder-snap.vzsnap")),
+        };
+        let json = serde_json::to_string(&record).unwrap();
+        // Field appears in the JSON when Some.
+        assert!(
+            json.contains("snapshot_path"),
+            "snapshot_path should appear when Some: {json}"
+        );
+        let back: SessionRecord = serde_json::from_str(&json).unwrap();
+        assert_eq!(
+            back.snapshot_path.as_deref(),
+            Some(std::path::Path::new("/abs/builder-snap.vzsnap")),
+        );
+    }
+
+    #[test]
+    fn snapshot_path_defaults_to_none_when_field_absent_in_json() {
+        // Old JSON written before snapshot_path was introduced must
+        // deserialize cleanly with snapshot_path = None.
+        let json = r#"{
+            "session_id": "old",
+            "dispatch_socket_path": "/tmp/sock",
+            "job_dir": "/tmp/jobs",
+            "workspace_root": "/work",
+            "supervisor_pid": 99
+        }"#;
+        let record: SessionRecord =
+            serde_json::from_str(json).expect("old JSON without snapshot_path must parse");
+        assert!(
+            record.snapshot_path.is_none(),
+            "missing field must default to None"
+        );
     }
 
     #[test]
@@ -1125,6 +1175,7 @@ mod tests {
             job_dir: PathBuf::from("/tmp"),
             workspace_root: PathBuf::from("/tmp"),
             supervisor_pid: DEFINITELY_DEAD_PID,
+            snapshot_path: None,
         };
         std::fs::write(
             run_dir.join("persistent-builder.json"),

--- a/crates/mvm-build/src/vz_builder.rs
+++ b/crates/mvm-build/src/vz_builder.rs
@@ -31,6 +31,7 @@ use std::sync::mpsc::{RecvTimeoutError, channel};
 use std::thread;
 use std::time::Duration;
 
+use crate::builder_control;
 use crate::builder_vm::{
     BuilderArtifacts, BuilderJob, BuilderMounts, BuilderVm, BuilderVmDisk, BuilderVmError,
     BuilderVmExitInfo, BuilderVmMount, BuilderVmRunConfig, VmBackendForBuilder,
@@ -1427,6 +1428,147 @@ fn persist_builder_supervisor_config(
     Ok(path)
 }
 
+/// Path where `builder_snapshot_save` writes the parked VM state.
+/// Callers that want to check for an existing snapshot before starting
+/// a cold boot use this alongside `is_builder_parked`.
+pub fn parked_snapshot_path(state_dir: &Path) -> PathBuf {
+    state_dir.join("parked.vzsnapshot")
+}
+
+/// Returns `true` when the persistent builder is in a parked (saved)
+/// state: both the snapshot file and the persisted `SupervisorConfig`
+/// are present under `state_dir`. Either file alone means an incomplete
+/// park — treat as not-parked so the caller falls back to a cold boot.
+pub fn is_builder_parked(state_dir: &Path) -> bool {
+    parked_snapshot_path(state_dir).exists()
+        && state_dir.join(BUILDER_SUPERVISOR_CONFIG_FILE).exists()
+}
+
+/// Send a `SAVE` command to the builder VM's control socket, writing
+/// the guest machine state to `<state_dir>/parked.vzsnapshot`.
+///
+/// The supervisor pauses the guest, saves its state (including the
+/// machine-id sidecar at `<snapshot>.machine-id`), then resumes it
+/// before replying. The caller must quiesce the builder (no in-flight
+/// dispatch) before calling this — `SAVE` is only safe on an idle VM.
+///
+/// Returns the absolute path of the written snapshot on success.
+pub fn builder_snapshot_save(state_dir: &Path) -> Result<PathBuf, BuilderVmError> {
+    let snapshot = parked_snapshot_path(state_dir);
+    let control = state_dir.join("control.sock");
+    let resp = builder_control::send_builder_control_command(
+        &control,
+        &format!("SAVE {}", snapshot.display()),
+    )?;
+    if !resp.starts_with("OK") {
+        return Err(BuilderVmError::ExtractionFailed(format!(
+            "builder SAVE refused: {resp}"
+        )));
+    }
+    Ok(snapshot)
+}
+
+/// Restore a previously parked builder VM from
+/// `<state_dir>/parked.vzsnapshot`.
+///
+/// Reads the persisted `SupervisorConfig` written by `start()`, flips
+/// `startup_mode` to `Restore`, re-acquires the nix-store lock,
+/// spawns gvproxy, and spawns the supervisor. Returns a
+/// `VzPersistentVmHandle` identical in shape to the one `start()`
+/// returns so callers can treat cold-boot and resume paths uniformly.
+///
+/// Does NOT re-persist the Restore config — the on-disk Boot config is
+/// kept intact for future park/resume cycles.
+/// Does NOT call `ensure_builder_vm_image` or `stage_persistent_vz_job_dir`
+/// — the snapshot carries guest state; virtio-fs shares re-attach via
+/// the persisted config.
+pub fn builder_snapshot_restore(
+    state_dir: &Path,
+    supervisor_path_override: Option<&Path>,
+) -> Result<VzPersistentVmHandle, BuilderVmError> {
+    let supervisor_path = match supervisor_path_override {
+        Some(p) => p.to_path_buf(),
+        None => resolve_vz_supervisor_path()?,
+    };
+
+    let config_path = state_dir.join(BUILDER_SUPERVISOR_CONFIG_FILE);
+    let raw = std::fs::read(&config_path).map_err(|e| {
+        BuilderVmError::ExtractionFailed(format!(
+            "reading persisted SupervisorConfig from {}: {e}",
+            config_path.display()
+        ))
+    })?;
+    let persisted: crate::vz::SupervisorConfig = serde_json::from_slice(&raw).map_err(|e| {
+        BuilderVmError::ExtractionFailed(format!(
+            "deserialising SupervisorConfig from {}: {e}",
+            config_path.display()
+        ))
+    })?;
+
+    // Derive nix_store_mib from the persisted config's nix-store disk entry
+    // if present. The disk list records the path; we check its size on disk
+    // and fall back to the standard default so restore is self-contained.
+    let nix_store_mib = persisted
+        .disks
+        .iter()
+        .find(|d| d.id == "nix-store")
+        .and_then(|d| {
+            std::fs::metadata(&d.path).ok().map(|m| {
+                u32::try_from(m.len() / (1024 * 1024)).unwrap_or(VZ_BUILDER_DEFAULT_NIX_STORE_MIB)
+            })
+        })
+        .unwrap_or(VZ_BUILDER_DEFAULT_NIX_STORE_MIB);
+
+    let nix_store_lock = acquire_nix_store_image_lock(
+        &builder_vm_cache_dir(),
+        host_arch_tag(),
+        u64::from(nix_store_mib),
+    )?;
+
+    let snapshot = parked_snapshot_path(state_dir);
+    let machine_id_path = {
+        let p = {
+            let mut s = snapshot.clone().into_os_string();
+            s.push(".machine-id");
+            PathBuf::from(s)
+        };
+        p.exists().then_some(p)
+    };
+
+    let restore_cfg = builder_control::builder_restore_config(
+        persisted.clone(),
+        &snapshot,
+        machine_id_path.as_deref(),
+    )?;
+
+    let _gvproxy = host_gvproxy::spawn_detached(state_dir).map_err(|e| {
+        BuilderVmError::ExtractionFailed(format!("spawn gvproxy for Vz builder VM restore: {e}"))
+    })?;
+    let gvproxy_guard = BuilderGvproxyGuard {
+        state_dir: state_dir.to_path_buf(),
+    };
+
+    let child = spawn_vz_supervisor_in_background(&supervisor_path, &restore_cfg)?;
+    gvproxy_guard.defuse();
+
+    let vm_name = &persisted.name;
+    let prefix = "mvm-persistent-builder-vz-";
+    let session_id = vm_name
+        .strip_prefix(prefix)
+        .unwrap_or(vm_name.as_str())
+        .to_string();
+
+    let job_dir = builder_vm_cache_dir().join("jobs").join(&session_id);
+
+    Ok(VzPersistentVmHandle {
+        vm_state_dir: state_dir.to_path_buf(),
+        job_dir,
+        session_id,
+        supervisor: Some(child),
+        _nix_store_lock: nix_store_lock,
+    })
+}
+
 /// Spawn `mvm-vz-supervisor` in the background with the
 /// `SupervisorConfig` JSON piped to its stdin. Same shape libkrun's
 /// `spawn_supervisor_in_background` uses for the persistent VM;
@@ -2542,5 +2684,44 @@ mod tests {
             "control_socket_path must survive the round-trip"
         );
         assert_eq!(reloaded.name, vm_name);
+    }
+
+    // ──────────────────────────────────────────────────────────────
+    // Slice 2 Task 1: parked_snapshot_path / is_builder_parked
+    // ──────────────────────────────────────────────────────────────
+
+    #[test]
+    fn parked_snapshot_path_returns_parked_vzsnapshot_under_state_dir() {
+        let scratch = tempfile::tempdir().unwrap();
+        let snap = parked_snapshot_path(scratch.path());
+        assert_eq!(snap, scratch.path().join("parked.vzsnapshot"));
+    }
+
+    #[test]
+    fn is_builder_parked_false_when_neither_file_present() {
+        let scratch = tempfile::tempdir().unwrap();
+        assert!(!is_builder_parked(scratch.path()));
+    }
+
+    #[test]
+    fn is_builder_parked_false_when_only_snapshot_present() {
+        let scratch = tempfile::tempdir().unwrap();
+        std::fs::write(scratch.path().join("parked.vzsnapshot"), b"").unwrap();
+        assert!(!is_builder_parked(scratch.path()));
+    }
+
+    #[test]
+    fn is_builder_parked_false_when_only_config_present() {
+        let scratch = tempfile::tempdir().unwrap();
+        std::fs::write(scratch.path().join(BUILDER_SUPERVISOR_CONFIG_FILE), b"{}").unwrap();
+        assert!(!is_builder_parked(scratch.path()));
+    }
+
+    #[test]
+    fn is_builder_parked_true_when_both_files_present() {
+        let scratch = tempfile::tempdir().unwrap();
+        std::fs::write(scratch.path().join("parked.vzsnapshot"), b"").unwrap();
+        std::fs::write(scratch.path().join(BUILDER_SUPERVISOR_CONFIG_FILE), b"{}").unwrap();
+        assert!(is_builder_parked(scratch.path()));
     }
 }

--- a/crates/mvm-cli/src/commands/build/persistent_builder.rs
+++ b/crates/mvm-cli/src/commands/build/persistent_builder.rs
@@ -116,6 +116,12 @@ struct SessionRecord {
     /// `libc::kill(pid, 0)` to check liveness before attempting
     /// shutdown.
     supervisor_pid: u32,
+    /// Path to a saved Vz machine-state snapshot. When `Some`, the
+    /// next start of the persistent builder VM restores from this
+    /// snapshot instead of cold-booting. Old JSON without this
+    /// field deserializes to `None`.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    snapshot_path: Option<PathBuf>,
 }
 
 fn session_record_path() -> PathBuf {
@@ -198,6 +204,7 @@ fn run_start(args: StartArgs) -> Result<()> {
         job_dir: handle.job_dir().to_path_buf(),
         workspace_root: workspace,
         supervisor_pid,
+        snapshot_path: None,
     };
     write_session_record(&record)?;
 
@@ -675,6 +682,7 @@ mod tests {
             job_dir: PathBuf::from("/tmp/jobs"),
             workspace_root: PathBuf::from("/work"),
             supervisor_pid: 4242,
+            snapshot_path: None,
         };
         let json = serde_json::to_vec(&record).expect("serialize");
         let back: SessionRecord = serde_json::from_slice(&json).expect("deserialize");

--- a/crates/mvm-cli/src/commands/env/dev.rs
+++ b/crates/mvm-cli/src/commands/env/dev.rs
@@ -613,7 +613,7 @@ pub(in crate::commands) fn run(_cli: &Cli, args: Args, cfg: &MvmConfig) -> Resul
         DevAction::Down { reset, json } => {
             let was_running = match backend {
                 DevBackend::Libkrun => cmd_dev_libkrun_down(json),
-                DevBackend::Vz => dev_vz::cmd_dev_vz_down(json),
+                DevBackend::Vz => dev_vz::cmd_dev_vz_down(json, reset),
                 DevBackend::LinuxKvm => linux_native::cmd_dev_linux_native_down(json),
                 // Nothing to stop on unsupported hosts. The gc-root
                 // cleanup below still runs.
@@ -692,7 +692,7 @@ pub(in crate::commands) fn run(_cli: &Cli, args: Args, cfg: &MvmConfig) -> Resul
             // re-up).
             let _ = match backend {
                 DevBackend::Libkrun => cmd_dev_libkrun_down(false),
-                DevBackend::Vz => dev_vz::cmd_dev_vz_down(false),
+                DevBackend::Vz => dev_vz::cmd_dev_vz_down(false, /* reset = */ true),
                 DevBackend::LinuxKvm => linux_native::cmd_dev_linux_native_down(false),
                 DevBackend::Unsupported => Ok(false),
             };

--- a/crates/mvm-cli/src/commands/env/dev_vz.rs
+++ b/crates/mvm-cli/src/commands/env/dev_vz.rs
@@ -97,8 +97,46 @@ pub(in crate::commands) fn is_vz_dev_running() -> bool {
     }
 }
 
+/// Whether `dev down` should park (snapshot-save) the builder before stopping.
+///
+/// Returns `true` only when residency allows a persistent builder, the VM is
+/// live, and this is not a `--reset` stop (reset implies a clean cold boot
+/// next time, so there is nothing useful to save).
+pub(crate) fn should_park(allows_persistent: bool, alive: bool, reset: bool) -> bool {
+    allows_persistent && alive && !reset
+}
+
+/// Whether `dev up` should resume from a parked snapshot rather than cold-boot.
+///
+/// Returns `true` only when residency allows a persistent builder and a valid
+/// parked snapshot is present in the builder state dir.
+pub(crate) fn should_resume(allows_persistent: bool, parked: bool) -> bool {
+    allows_persistent && parked
+}
+
+/// Remove the parked snapshot and its `.machine-id` sidecar (best-effort).
+///
+/// Called when we are about to cold-boot or when a restore fails — the
+/// snapshot is consumed or invalid, so leaving it would cause a false resume
+/// on the next `dev up`.
+#[cfg(feature = "builder-vm")]
+fn remove_park_markers(state_dir: &std::path::Path) {
+    let snapshot = mvm_build::vz_builder::parked_snapshot_path(state_dir);
+    let machine_id = {
+        let mut s = snapshot.clone().into_os_string();
+        s.push(".machine-id");
+        std::path::PathBuf::from(s)
+    };
+    let _ = std::fs::remove_file(&snapshot);
+    let _ = std::fs::remove_file(&machine_id);
+}
+
 /// Boot the dev VM via the Vz supervisor, optionally opening an
 /// interactive console.
+///
+/// When residency allows a persistent builder and a parked snapshot is
+/// present the VM is restored from that snapshot instead of cold-booting.
+/// On restore failure the snapshot is discarded and a cold boot proceeds.
 #[cfg(feature = "builder-vm")]
 pub(super) fn cmd_dev_vz(cpus: u32, memory_gib: u32, open_shell: bool) -> Result<&'static str> {
     ui::progress("Starting dev environment via Vz (Virtualization.framework)...");
@@ -117,6 +155,60 @@ pub(super) fn cmd_dev_vz(cpus: u32, memory_gib: u32, open_shell: bool) -> Result
     // fresh start binds a clean state dir.
     let state_dir = mvm_build::vz_builder::persistent_vz_state_dir(DEV_VM_SESSION_ID);
     mvm_build::vz_builder::stop_persistent_vz_by_pid_file(&state_dir);
+
+    // Attempt a snapshot resume when residency allows it and a parked
+    // snapshot is present. On failure, discard the markers and fall through
+    // to the cold-boot path so we always make forward progress.
+    let (residency, _) = mvm_core::residency::resolve_residency();
+    let parked = mvm_build::vz_builder::is_builder_parked(&state_dir);
+    if should_resume(residency.allows_persistent_builder(), parked) {
+        match mvm_build::vz_builder::builder_snapshot_restore(&state_dir, None) {
+            Ok(handle) => {
+                // Snapshot is consumed — remove the markers so a subsequent
+                // `dev down` parks fresh rather than trying to restore again.
+                remove_park_markers(&state_dir);
+                ui::success("Resumed dev VM from snapshot.");
+                let console_log = handle.vm_state_dir().join("console.log");
+                drop(handle);
+
+                let deadline = std::time::Instant::now() + std::time::Duration::from_secs(60);
+                loop {
+                    if std::time::Instant::now() > deadline {
+                        anyhow::bail!(
+                            "Dev VM did not become ready within 60 seconds after resume.\n\
+                             Check the console log: {}",
+                            console_log.display()
+                        );
+                    }
+                    if dev_vm_guest_agent_connect().is_ok() {
+                        break;
+                    }
+                    std::thread::sleep(std::time::Duration::from_millis(500));
+                }
+
+                ui::success("Dev VM ready.");
+                ui::info("  Shell:      mvmctl dev shell");
+                ui::info("  Stop VM:    mvmctl dev down");
+
+                if open_shell {
+                    ui::info("");
+                    let _ = console_interactive(DEV_VM_NAME);
+                }
+
+                return Ok("started");
+            }
+            Err(e) => {
+                ui::warn(&format!(
+                    "Resume from snapshot failed ({e}); discarding snapshot and cold-booting."
+                ));
+                remove_park_markers(&state_dir);
+            }
+        }
+    } else if !residency.allows_persistent_builder() {
+        // Cold policy: remove any stale snapshot so a later policy change
+        // doesn't accidentally resume from a stale guest state.
+        remove_park_markers(&state_dir);
+    }
 
     // Ensure dev image exists (build if needed — runs in this process).
     let (kernel, rootfs) = ensure_dev_image()?;
@@ -215,14 +307,40 @@ pub(in crate::commands) fn dev_vsock_proxy_path() -> String {
     }
 }
 
-/// Stop the dev VM by reaping its detached Vz supervisor via the PID
-/// file under the stable state dir.
 /// Stop the Vz dev VM. Returns whether a live VM was reaped. Prints the
 /// human result line only when `!json` (the dispatch emits the JSON form).
-pub(in crate::commands) fn cmd_dev_vz_down(json: bool) -> Result<bool> {
+///
+/// When `reset` is false and residency allows a persistent builder, parks
+/// the VM (snapshot-saves it) before stopping so the next `dev up` can
+/// resume instantly. On park failure, logs a warning and falls through to
+/// a plain stop — we never leave a half-parked VM.
+///
+/// When `reset` is true or residency is `Cold`, any existing parked
+/// snapshot is discarded so the next `dev up` always cold-boots.
+pub(in crate::commands) fn cmd_dev_vz_down(json: bool, reset: bool) -> Result<bool> {
     #[cfg(feature = "builder-vm")]
     {
         let state_dir = mvm_build::vz_builder::persistent_vz_state_dir(DEV_VM_SESSION_ID);
+        let alive = mvm_build::vz_builder::persistent_vz_supervisor_alive(&state_dir);
+        let (residency, _) = mvm_core::residency::resolve_residency();
+
+        if should_park(residency.allows_persistent_builder(), alive, reset) {
+            match mvm_build::vz_builder::builder_snapshot_save(&state_dir) {
+                Ok(_) => {
+                    if !json {
+                        ui::success("Parked dev VM — next `dev up` resumes from snapshot.");
+                    }
+                }
+                Err(e) => {
+                    ui::warn(&format!("Park failed ({e}); stopping normally."));
+                }
+            }
+        } else if !residency.allows_persistent_builder() || reset {
+            // Cold policy or explicit reset: discard any stale snapshot so
+            // the next `dev up` always cold-boots cleanly.
+            remove_park_markers(&state_dir);
+        }
+
         let was_running = mvm_build::vz_builder::stop_persistent_vz_by_pid_file(&state_dir);
         // Drop the per-VM vsock dir so a stale socket can't fool the
         // liveness probe on the next `dev status`.
@@ -238,6 +356,7 @@ pub(in crate::commands) fn cmd_dev_vz_down(json: bool) -> Result<bool> {
     }
     #[cfg(not(feature = "builder-vm"))]
     {
+        let _ = reset;
         if !json {
             ui::info("Dev VM is not running.");
         }
@@ -6282,5 +6401,67 @@ mod heartbeat_tests {
             format_compile_elapsed(Duration::from_secs(130)),
             "still compiling… (2m10s elapsed)"
         );
+    }
+}
+
+#[cfg(test)]
+mod park_resume_gating_tests {
+    use super::{should_park, should_resume};
+
+    // should_park truth table
+    //   allows_persistent | alive | reset | expected
+    //   -------------------|-------|-------|--------
+    //   false             | false | false | false  (cold policy)
+    //   false             | true  | false | false  (cold policy, alive but no park)
+    //   true              | false | false | false  (warm policy, but VM not alive)
+    //   true              | true  | false | true   (warm policy + alive = park)
+    //   true              | true  | true  | false  (reset overrides warm policy)
+    //   true              | false | true  | false  (reset + not alive)
+
+    #[test]
+    fn should_park_cold_policy_never_parks() {
+        assert!(!should_park(false, false, false));
+        assert!(!should_park(false, true, false));
+        assert!(!should_park(false, true, true));
+    }
+
+    #[test]
+    fn should_park_warm_alive_no_reset() {
+        assert!(should_park(true, true, false));
+    }
+
+    #[test]
+    fn should_park_requires_alive_vm() {
+        assert!(!should_park(true, false, false));
+    }
+
+    #[test]
+    fn should_park_reset_suppresses_park() {
+        assert!(!should_park(true, true, true));
+        assert!(!should_park(true, false, true));
+    }
+
+    // should_resume truth table
+    //   allows_persistent | parked | expected
+    //   ------------------|--------|--------
+    //   false             | false  | false  (cold policy)
+    //   false             | true   | false  (cold policy, ignore stale snapshot)
+    //   true              | false  | false  (warm policy, no snapshot)
+    //   true              | true   | true   (warm policy + snapshot = resume)
+
+    #[test]
+    fn should_resume_cold_policy_never_resumes() {
+        assert!(!should_resume(false, false));
+        assert!(!should_resume(false, true));
+    }
+
+    #[test]
+    fn should_resume_warm_with_snapshot() {
+        assert!(should_resume(true, true));
+    }
+
+    #[test]
+    fn should_resume_requires_parked_snapshot() {
+        assert!(!should_resume(true, false));
     }
 }

--- a/crates/mvm-cli/src/commands/env/dev_vz.rs
+++ b/crates/mvm-cli/src/commands/env/dev_vz.rs
@@ -102,6 +102,7 @@ pub(in crate::commands) fn is_vz_dev_running() -> bool {
 /// Returns `true` only when residency allows a persistent builder, the VM is
 /// live, and this is not a `--reset` stop (reset implies a clean cold boot
 /// next time, so there is nothing useful to save).
+#[cfg(feature = "builder-vm")]
 pub(crate) fn should_park(allows_persistent: bool, alive: bool, reset: bool) -> bool {
     allows_persistent && alive && !reset
 }
@@ -110,6 +111,7 @@ pub(crate) fn should_park(allows_persistent: bool, alive: bool, reset: bool) -> 
 ///
 /// Returns `true` only when residency allows a persistent builder and a valid
 /// parked snapshot is present in the builder state dir.
+#[cfg(feature = "builder-vm")]
 pub(crate) fn should_resume(allows_persistent: bool, parked: bool) -> bool {
     allows_persistent && parked
 }
@@ -6404,7 +6406,7 @@ mod heartbeat_tests {
     }
 }
 
-#[cfg(test)]
+#[cfg(all(test, feature = "builder-vm"))]
 mod park_resume_gating_tests {
     use super::{should_park, should_resume};
 

--- a/crates/mvm-cli/src/commands/ops/cache.rs
+++ b/crates/mvm-cli/src/commands/ops/cache.rs
@@ -222,7 +222,7 @@ pub(in crate::commands) fn run(_cli: &Cli, args: Args, _cfg: &MvmConfig) -> Resu
             // automatically rather than refuse.
             if !dry_run && dev_vz::is_vz_dev_running() {
                 ui::warn("A dev builder VM is running; stopping it before clearing the store.");
-                let _ = dev_vz::cmd_dev_vz_down(/* json = */ false);
+                let _ = dev_vz::cmd_dev_vz_down(/* json = */ false, /* reset = */ true);
             }
 
             let repair = mvm_build::builder_vm::clear_builder_store(dry_run)

--- a/specs/notes/plan-205-builder-snapshot-park-execution.md
+++ b/specs/notes/plan-205-builder-snapshot-park-execution.md
@@ -95,3 +95,24 @@ Run the test → PASS.
 - Dispatch chokepoint (`pipeline/dev_build.rs:595`): if the active session has a `snapshot_path`, RESTORE instead of cold-boot.
 - A `mvmctl persistent-builder park` verb (explicit) for the first live proof; the keeper (Slice 3) calls the same primitive on idle.
 - **Live macOS-26 validation:** start persistent builder → `park` (SAVE, idle) → `supervisor-config.json` + snapshot + `.machine-id` on disk, builder stopped → next build RESTOREs (no cold boot) → build succeeds; `/nix-store` intact.
+
+---
+
+# Slice 2 — auto-park on `dev down`, auto-resume on `dev up` (Option A, residency-gated)
+
+**Decision:** park/resume hooks the **Vz `dev` lifecycle** (`dev_vz.rs`), not the libkrun `persistent-builder` CLI verb (that path is libkrun-only). State is keyed on the **stable** `persistent_vz_state_dir(DEV_VM_SESSION_ID)` — a parked builder = a snapshot file present in that dir + supervisor stopped. Gated on the shipped residency policy: `Cold` → full stop / no resume (current behavior); `Warm`/`Parked` → park on down, resume on up.
+
+## Task 1 (mvm-build `vz_builder.rs`): the save/restore/parked primitives
+- `pub fn builder_snapshot_save(state_dir: &Path) -> Result<PathBuf, BuilderVmError>`: snapshot = `<state_dir>/parked.vzsnapshot` (absolute); `send_builder_control_command(<state_dir>/control.sock, &format!("SAVE {abs}"))`; treat a response not starting with `OK` as an error; return the snapshot path. (SAVE pauses→saves→resumes; the supervisor writes `<snapshot>.machine-id`.)
+- `pub fn builder_snapshot_restore(state_dir: &Path, supervisor_path_override: Option<&Path>) -> Result<VzPersistentVmHandle, BuilderVmError>`: mirror the **tail** of `start()` — (1) re-acquire `acquire_nix_store_image_lock`; (2) read `<state_dir>/supervisor-config.json` → `vz::SupervisorConfig`; (3) `builder_restore_config(cfg, &snapshot, machine_id_if_present)`; (4) `host_gvproxy::spawn_detached(state_dir)` + guard; (5) `spawn_vz_supervisor_in_background(supervisor_path, &restore_cfg)`; (6) `defuse()`; (7) return a `VzPersistentVmHandle` carrying the lock + child. Do NOT re-persist the Restore config (keep the on-disk Boot config for future cycles). Do NOT call `ensure_builder_vm_image`/`stage_persistent_vz_job_dir` (snapshot carries guest state; shares re-attach from the persisted config).
+- `pub fn is_builder_parked(state_dir: &Path) -> bool`: `<state_dir>/parked.vzsnapshot` AND `<state_dir>/supervisor-config.json` both exist.
+- `pub fn parked_snapshot_path(state_dir: &Path) -> PathBuf` = `<state_dir>/parked.vzsnapshot`.
+- Unit tests: path helpers; `is_builder_parked` true only when both files present; (save/restore are live — covered in validation).
+
+## Task 2 (mvm-cli `dev_vz.rs`): wire into up/down, residency-gated
+- `cmd_dev_vz_down`: when residency `kind() != Cold` AND the supervisor is alive → `builder_snapshot_save(&state_dir)` (park) BEFORE `stop_persistent_vz_by_pid_file`; on save error, log + fall back to a plain stop (never leave a half-parked VM). Log "Parked dev VM (resume is instant)". `--reset` and `Cold` → current full stop; on either, remove a stale `parked.vzsnapshot`(+`.machine-id`).
+- `cmd_dev_vz_up`: before the cold `VzPersistentBuilderVm::start()`, when residency `kind() != Cold` AND `is_builder_parked(&state_dir)` → `builder_snapshot_restore(&state_dir, …)` instead; on success remove the snapshot marker (consumed) + log "Resumed dev VM from snapshot"; on restore error, clean the marker + fall back to cold boot. `Cold` → clean any stale marker + cold boot.
+- Unit tests: the gating decision (residency kind + parked-present → {park, plain-stop} / {resume, cold-boot}).
+
+## Live validation (macOS-26, deterministic)
+`dev up` (cold) → `dev down` (parks: `parked.vzsnapshot`+`.machine-id` present, supervisor reaped) → `dev up` (resumes: no cold boot, fast) → `dev status` running / a `dev shell` command works → `MVM_RESIDENCY=cold dev down` fully stops + clears the marker.


### PR DESCRIPTION
**Slice 2** of builder snapshot-park — the live payoff of issue #1119: the Vz dev builder is now **snapshot-parked on `dev down` and resumed on `dev up`** (no cold boot), gated on the residency policy. Builds on Slice 1 (#1135, the snapshot-capable builder).

## Behavior (residency-gated)
- **`dev down`** — when residency allows a persistent builder (warm/parked, not `cold`) and the supervisor is alive and not `--reset`: SAVE the builder to `<state_dir>/parked.vzsnapshot` (+ `.machine-id`), then stop. Otherwise: plain stop + clean any stale snapshot.
- **`dev up`** — when allowed and a parked snapshot is present: RESTORE from it (re-acquire nix-store flock, respawn gvproxy, restore the Vz machine state) instead of cold-booting; the snapshot is consumed. Otherwise: cold-boot as before.
- **`cold` residency / `--reset`** — unchanged behavior (cold boot / full stop), stale markers cleaned so a later `dev up` never wrongly resumes.

## Mechanism (all `mvm-build`-local — no `mvm-backend` dep)
- `builder_control` module: a std-only control-socket client + a pure `builder_restore_config` (flips `startup_mode` to `Restore`, preserves all other fields).
- `builder_snapshot_save`/`builder_snapshot_restore`/`is_builder_parked` in `vz_builder.rs` — restore mirrors the bootable tail of `start()` (lock → gvproxy → supervisor in Restore mode → handle).
- `dev_vz.rs` wiring via tested `should_park`/`should_resume` gates; `--reset` threaded to all three `cmd_dev_vz_down` call sites.
- `SessionRecord.snapshot_path` (`#[serde(default)]`) for the dispatch-routing path.

## Tests / review
53 new unit tests (control round-trip, restore-config preservation, parked-state, gating truth tables); root binary builds with `builder-vm`. Whole-branch reviewed (opus): live-coupled correctness verified — no gvproxy leak window, park-before-stop with safe fallback, resume detaches + waits for guest-agent readiness, marker hygiene on every path. Review also caught + I reverted an unrelated deletion of the stale-supervisor boot diagnostic.

Live macOS-26 validation (cold `dev up` → `dev down` parks → `dev up` resumes) is in progress; the unit-tested decision + restore logic gate every code path that doesn't require a live builder boot.

## Next (tracked in `specs/notes/plan-205-builder-snapshot-park-execution.md`)
Slice 3 — the idle keeper (auto-park after N minutes idle) consuming the shipped `decide_builder_residency_action`.