### PR TITLE
fix(run): boot --image OCI runs on a prebuilt workload kernel (avoid Nix + 220 MB on the OCI path)

### DIFF
--- a/crates/mvm-cli/src/commands/env/dev_vz.rs
+++ b/crates/mvm-cli/src/commands/env/dev_vz.rs
@@ -4445,11 +4445,35 @@ pub(crate) fn ensure_workload_kernel() -> Result<String> {
     if let Some(built) = try_build_workload_kernel_locally()? {
         return Ok(built);
     }
-    if let Some(parent) = std::path::Path::new(&dest).parent() {
+    download_workload_kernel(arch, &dest)?;
+    Ok(dest)
+}
+
+/// End-user download of the published, hash-verified `vmlinux-<arch>-workload`
+/// (~10 MB, no Nix) for this mvmctl's release tag. Mirrors
+/// `download_default_microvm_image`'s verify-then-cache flow via the same
+/// non-gated artifact helpers, so the OCI `--image` path resolves a kernel even
+/// when mvmctl is built without the `builder-vm` feature.
+fn download_workload_kernel(arch: &str, dest: &str) -> Result<()> {
+    if let Some(parent) = std::path::Path::new(dest).parent() {
         std::fs::create_dir_all(parent)?;
     }
-    crate::update::download_kernel(arch, "workload", std::path::Path::new(&dest))?;
-    Ok(dest)
+    let version = env!("CARGO_PKG_VERSION");
+    let base_url = format!("https://github.com/tinylabscom/mvm/releases/download/v{version}");
+    let asset = format!("vmlinux-{arch}-workload");
+    let checksums_url = format!("{base_url}/kernel-{arch}-checksums-sha256.txt");
+
+    ui::info(&format!(
+        "Downloading workload kernel {asset} (v{version})..."
+    ));
+    let expected = fetch_expected_hashes(&checksums_url, &[asset.as_str()])?;
+    let asset_url = format!("{base_url}/{asset}");
+    download_file(&asset_url, dest).with_context(|| format!("Failed to download {asset_url}"))?;
+    verify_artifact_hash(dest, &asset, expected.get(&asset))?;
+    ui::success(&format!(
+        "Workload kernel {asset} downloaded, hash-verified, and cached."
+    ));
+    Ok(())
 }
 
 /// First existing workload-kernel `vmlinux` on disk among the dedicated kernel

--- a/crates/mvm-cli/src/commands/env/dev_vz.rs
+++ b/crates/mvm-cli/src/commands/env/dev_vz.rs
@@ -4428,6 +4428,61 @@ pub(crate) fn ensure_default_microvm_image(
     }
 }
 
+/// Resolve **only** the workload microVM kernel, returning its path. The OCI
+/// `--image` run path needs just a kernel — the materialized OCI rootfs (with
+/// its injected agent) is the workload — so this avoids building/downloading a
+/// whole default image. It's the same `workload-kernel` the default microVM
+/// boots on. An end-user mvmctl downloads the published, hash-verified
+/// `vmlinux-<arch>-workload` (~10 MB, no Nix); a source checkout builds just the
+/// `workload-kernel` flake target locally (no rootfs/verity). Cache-hit-fast.
+pub(crate) fn ensure_workload_kernel() -> Result<String> {
+    let arch = builder_vm_host_arch();
+    let cache = mvm_core::config::mvm_cache_dir();
+    if let Some(cached) = find_cached_workload_kernel(&cache, arch) {
+        return Ok(cached);
+    }
+    let dest = format!("{cache}/builder-vm/{arch}/kernels/workload/vmlinux");
+    if let Some(built) = try_build_workload_kernel_locally()? {
+        return Ok(built);
+    }
+    if let Some(parent) = std::path::Path::new(&dest).parent() {
+        std::fs::create_dir_all(parent)?;
+    }
+    crate::update::download_kernel(arch, "workload", std::path::Path::new(&dest))?;
+    Ok(dest)
+}
+
+/// First existing workload-kernel `vmlinux` on disk among the dedicated kernel
+/// cache and the default-microvm images — all the identical `mkWorkloadKernel`
+/// derivation, so any one is a valid workload kernel. `None` ⇒ build/download.
+/// Path-injectable (no global state) so it's hermetically testable.
+fn find_cached_workload_kernel(cache_dir: &str, arch: &str) -> Option<String> {
+    [
+        format!("{cache_dir}/builder-vm/{arch}/kernels/workload/vmlinux"),
+        format!("{cache_dir}/default-microvm/prod/vmlinux"),
+        format!("{cache_dir}/default-microvm/dev/vmlinux"),
+    ]
+    .into_iter()
+    .find(|p| std::path::Path::new(p).is_file())
+}
+
+/// Source-checkout local build of just the workload kernel. `Some` when the
+/// in-repo `builder-vm` flake resolves; `None` (→ caller downloads) otherwise.
+#[cfg(feature = "builder-vm")]
+fn try_build_workload_kernel_locally() -> Result<Option<String>> {
+    if find_builder_vm_flake().is_err() {
+        return Ok(None);
+    }
+    ui::info("Building the workload microVM kernel locally (source checkout)...");
+    let path = build_kernel_via_stage0(KernelVariant::Workload, false)?;
+    Ok(Some(path.display().to_string()))
+}
+
+#[cfg(not(feature = "builder-vm"))]
+fn try_build_workload_kernel_locally() -> Result<Option<String>> {
+    Ok(None)
+}
+
 /// Prod-mode default image. On a source checkout (the in-repo `builder-vm` flake
 /// resolves and this mvmctl carries the `builder-vm` feature) it builds the
 /// verity-sealed `default` variant locally via the builder VM, honoring the
@@ -5714,6 +5769,40 @@ mod builder_vm_bootstrap_tests {
     //! `find_builder_vm_flake` + `bootstrap_builder_vm_image`.
     use super::*;
     use std::io::Write;
+
+    #[test]
+    fn find_cached_workload_kernel_prefers_dedicated_then_default_images() {
+        let tmp = tempfile::tempdir().unwrap();
+        let cache = tmp.path().to_str().unwrap();
+        let arch = "x86_64";
+        // Nothing on disk → None (caller will build/download).
+        assert_eq!(find_cached_workload_kernel(cache, arch), None);
+
+        let mk = |rel: &str| {
+            let p = tmp.path().join(rel);
+            std::fs::create_dir_all(p.parent().unwrap()).unwrap();
+            std::fs::write(&p, b"vmlinux").unwrap();
+            p.to_str().unwrap().to_string()
+        };
+        // The dev default image's kernel is a valid reuse source.
+        let dev = mk("default-microvm/dev/vmlinux");
+        assert_eq!(
+            find_cached_workload_kernel(cache, arch).as_deref(),
+            Some(dev.as_str())
+        );
+        // Prod wins over dev (checked first).
+        let prod = mk("default-microvm/prod/vmlinux");
+        assert_eq!(
+            find_cached_workload_kernel(cache, arch).as_deref(),
+            Some(prod.as_str())
+        );
+        // The dedicated kernel cache wins over everything.
+        let dedicated = mk(&format!("builder-vm/{arch}/kernels/workload/vmlinux"));
+        assert_eq!(
+            find_cached_workload_kernel(cache, arch).as_deref(),
+            Some(dedicated.as_str())
+        );
+    }
 
     #[test]
     #[cfg(feature = "builder-vm")]

--- a/crates/mvm-cli/src/commands/vm/exec.rs
+++ b/crates/mvm-cli/src/commands/vm/exec.rs
@@ -16,7 +16,7 @@ use serde::{Deserialize, Serialize};
 use sha2::{Digest, Sha256};
 use std::path::{Path, PathBuf};
 
-use super::super::env::dev_vz::ensure_default_microvm_image;
+use super::super::env::dev_vz::{ensure_default_microvm_image, ensure_workload_kernel};
 use super::Cli;
 use super::audit_chain::AuditEmitter;
 use super::host_signer::{PUBLIC_FILENAME, host_signer_id, load_or_init};
@@ -617,10 +617,14 @@ fn build_exec_request(
                     auth_source
                 );
             }
-            // `exec` is interactive (dev): a sealed prod image refuses
-            // console/exec, so the default image must be the dev variant.
-            let (kernel_path, _default_rootfs_path) =
-                ensure_default_microvm_image(mvm_build::pipeline::BuildMode::Dev)?;
+            // An `--image` run boots the materialized OCI rootfs (with its
+            // injected agent), so we need only a workload kernel. Resolve just
+            // the kernel — the published `vmlinux-<arch>-workload` download for
+            // an end-user mvmctl (no Nix), or a local `workload-kernel` build on
+            // a source checkout — rather than building/downloading a whole
+            // default image whose rootfs we'd discard. Per Plan 200, the OCI
+            // path avoids Nix (end users) and a ~220 MB unused-rootfs fetch.
+            let kernel_path = ensure_workload_kernel()?;
             crate::exec::ImageSource::Prebuilt {
                 kernel_path,
                 rootfs_path: cached.rootfs_path.display().to_string(),

--- a/crates/mvm-cli/src/commands/vm/exec.rs
+++ b/crates/mvm-cli/src/commands/vm/exec.rs
@@ -622,8 +622,8 @@ fn build_exec_request(
             // the kernel — the published `vmlinux-<arch>-workload` download for
             // an end-user mvmctl (no Nix), or a local `workload-kernel` build on
             // a source checkout — rather than building/downloading a whole
-            // default image whose rootfs we'd discard. Per Plan 200, the OCI
-            // path avoids Nix (end users) and a ~220 MB unused-rootfs fetch.
+            // default image whose rootfs we'd discard. This keeps the OCI path
+            // free of Nix (end users) and of a ~220 MB unused-rootfs fetch.
             let kernel_path = ensure_workload_kernel()?;
             crate::exec::ImageSource::Prebuilt {
                 kernel_path,


### PR DESCRIPTION
Fixes #1151.

## Problem

`mvmctl machine run --image <oci>` (and `run --image`) sourced its kernel from `ensure_default_microvm_image(BuildMode::Dev)`. The dev default image has **no published prebuilt**, so an OCI run built the `default-tenant` flake locally — **a Linux kernel compile** — even for end users on a release binary. That contradicts Plan 200's explicit rule that *"the image-backed `machine run --image …` path should avoid Nix entirely,"* and it was the smoke's dominant cost (>10 min).

## Fix

Resolve **only** the workload kernel — the materialized OCI rootfs (with its injected agent) is the workload, so the default image's rootfs was always discarded anyway. New `ensure_workload_kernel()`:
1. **Reuse** any workload kernel already on disk — the dedicated kernel cache *or* a `default-microvm/{prod,dev}/vmlinux` (all the identical `mkWorkloadKernel` derivation). Avoids a redundant Stage 0 recompile when a default image is already built.
2. **End user:** download the published, hash-verified `vmlinux-<arch>-workload` (~10 MB, no Nix) via the existing `download_kernel`.
3. **Source checkout:** build just the `workload-kernel` flake target (no rootfs/verity).

This avoids both the local Nix build *and* the ~220 MB unused-rootfs fetch that reusing the prod default image would have cost. (Same workload kernel the default microVM boots on, so no behavioral change to the boot.)

## Verification

- `cargo clippy -p mvm-cli` clean **with and without** the `builder-vm` feature (the end-user download path compiles); `cargo fmt --all --check` clean.
- Unit test `find_cached_workload_kernel_prefers_dedicated_then_default_images` covers the reuse precedence (dedicated cache > prod > dev > none).
- **Live (Linux/KVM, x86_64, QEMU builder):** `machine run --image alpine` resolved the kernel as a **cache hit in ~4 s** (no recompile, no 220 MB) and the **microVM booted on it** (Guest IP assigned), where before the run spent >10 min compiling a kernel.

## Follow-on
The same live run surfaced a separate, independent blocker — the injected guest agent for OCI runs is built without `dev-shell`, so `machine run --image -- <cmd>` boots but can't exec the command (#1156). That's tracked separately; this PR fixes the kernel-sourcing half (#1151).