### PR TITLE
feat(plan-175): primed ready-barrier protocol (Task 3, Step 1)

### DIFF
--- a/crates/mvm/src/vm/instance_snapshot.rs
+++ b/crates/mvm/src/vm/instance_snapshot.rs
@@ -213,6 +213,51 @@ pub fn verify_and_resume<IO: SnapshotIO + ?Sized>(
 // Post-restore signal — the host-side sender
 // ============================================================================
 
+// ============================================================================
+// "Primed" ready-barrier — gate a warm snapshot on the workload finishing warmup
+// ============================================================================
+
+/// Outcome of waiting for a workload's "primed" ready signal.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum PrimedOutcome {
+    /// The workload signalled it has finished warming (caches, JITs, model load).
+    Primed,
+    /// The wait window elapsed with no signal.
+    TimedOut,
+}
+
+/// Source of a workload's "primed" ready signal. The production impl waits for
+/// the guest to notify the host (over vsock — no new guest privilege, unlike a
+/// host-delivered SIGUSR1); tests inject a deterministic source. Kept a trait
+/// so the barrier *policy* is unit-testable without a live guest (mirrors
+/// [`PostRestoreSignal`]).
+pub trait PrimedSignalSource {
+    /// Block up to `timeout` for the workload to signal it has finished
+    /// warming. Returns whether the signal arrived.
+    fn wait_for_primed(&self, timeout: std::time::Duration) -> PrimedOutcome;
+}
+
+/// Wait for the workload's "primed" ready barrier before sealing a warm
+/// snapshot, so the snapshot captures a *deterministic, fully-warmed* base and
+/// every resume starts past cold-start.
+///
+/// Fails closed: a workload that never signals primed must NOT produce a
+/// half-warmed snapshot — that would defeat the barrier's purpose — so a
+/// timeout is an error, never a "snapshot anyway". The caller runs this before
+/// [`pause_and_seal`].
+pub fn await_primed_barrier<S: PrimedSignalSource + ?Sized>(
+    source: &S,
+    timeout: std::time::Duration,
+) -> Result<()> {
+    match source.wait_for_primed(timeout) {
+        PrimedOutcome::Primed => Ok(()),
+        PrimedOutcome::TimedOut => bail!(
+            "workload did not signal 'primed' within {timeout:?} — refusing to seal a \
+             half-warmed snapshot; give the workload longer to warm or check its readiness hook"
+        ),
+    }
+}
+
 /// Outcome of signaling `PostRestore` to a resumed guest.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct PostRestoreOutcome {
@@ -1068,5 +1113,38 @@ mod tests {
             "context: {chained}"
         );
         assert!(chained.contains("connection refused"), "cause: {chained}");
+    }
+
+    /// Canned [`PrimedSignalSource`] so the barrier policy is testable without
+    /// a live guest (mirrors `MockSignal`).
+    struct MockPrimed(PrimedOutcome);
+    impl PrimedSignalSource for MockPrimed {
+        fn wait_for_primed(&self, _timeout: std::time::Duration) -> PrimedOutcome {
+            self.0.clone()
+        }
+    }
+
+    #[test]
+    fn primed_barrier_passes_when_workload_signals() {
+        await_primed_barrier(
+            &MockPrimed(PrimedOutcome::Primed),
+            std::time::Duration::from_secs(5),
+        )
+        .expect("a primed workload clears the barrier");
+    }
+
+    #[test]
+    fn primed_barrier_fails_closed_on_timeout() {
+        // The whole point of the barrier is a deterministic warm base, so a
+        // workload that never signals must NOT yield a half-warmed snapshot.
+        let err = await_primed_barrier(
+            &MockPrimed(PrimedOutcome::TimedOut),
+            std::time::Duration::from_millis(10),
+        )
+        .expect_err("a timed-out barrier must fail closed");
+        assert!(
+            err.to_string().contains("half-warmed"),
+            "fail-closed message names the hazard: {err}"
+        );
     }
 }


### PR DESCRIPTION
## Plan 175 — Task 3 (Step 1): "primed" ready-barrier

Stacked on #1155. The barrier policy that gates a warm snapshot on the workload finishing warmup, so the sealed base is deterministic and every resume starts past cold-start.

- `await_primed_barrier(source, timeout)` — **fails closed**: a workload that never signals `primed` must NOT yield a half-warmed snapshot, so a timeout is an error, not "snapshot anyway".
- `PrimedSignalSource` trait — production waits for the guest's vsock notification (no new guest privilege, unlike a host-delivered SIGUSR1); tests inject a deterministic source. Mirrors `PostRestoreSignal` so the policy is unit-tested without a live guest.
- Tests green: primed → clears; timeout → fail-closed with a hazard-naming message.

**Step 2 remains**: the production `PrimedSignalSource` (guest→host primed signal over vsock) + integration into the `vm pause` path + live verification. Tracked as the remaining T3 work.