### PR TITLE
Close Plan 118 standby pool

### DIFF
--- a/crates/mvm-backend/src/backend.rs
+++ b/crates/mvm-backend/src/backend.rs
@@ -1,14 +1,15 @@
 use crate::catalog;
-use anyhow::Result;
+use anyhow::{Context, Result};
 use mvm_core::vm_backend::{
-    BackendSecurityProfile, ClaimStatus, LayerCoverage, SnapshotCapability, StartMode, VmBackend,
-    VmCapabilities, VmId, VmInfo, VmStartConfig, VmStatus,
+    BackendSecurityProfile, ClaimStatus, LayerCoverage, SnapshotCapability, StandbyClaim,
+    StandbyError, StandbyHandle, StandbySpec, StandbyState, StartMode, VmBackend, VmCapabilities,
+    VmId, VmInfo, VmStartConfig, VmStatus,
 };
 
 // Every backend variant + the FC support modules live in this crate.
 // `microvm`, `image` are siblings under `crate::`; the substrate
 // (`config`, `shell`, `runtime_meta`) lives in `crate::base`.
-use crate::base::config::{PortMapping, VMS_DIR};
+use crate::base::config::{PortMapping, VMS_DIR, VmSlot};
 use crate::base::shell::run_in_vm_stdout;
 use crate::image::RuntimeVolume;
 use crate::libkrun::LibkrunBackend;
@@ -30,21 +31,16 @@ impl FirecrackerConfig {
     /// Convert a backend-agnostic `VmStartConfig` into a Firecracker-specific
     /// `FlakeRunConfig`, allocating a network slot automatically.
     pub fn from_start_config(config: &VmStartConfig) -> Result<Self> {
-        // Firecracker has no virtio-fs — a directory share can't be
-        // attached. Disk-image volumes (host:/guest:SIZE) are fine.
-        if let Some(v) = config
-            .volumes
-            .iter()
-            .find(|v| matches!(v.kind, mvm_core::vm_backend::VmVolumeKind::DirShare))
-        {
-            anyhow::bail!(
-                "Firecracker has no virtio-fs, so directory share '{}' -> '{}' isn't supported; \
-                 use a disk-image volume instead (host:/guest:SIZE).",
-                v.host,
-                v.guest
-            );
-        }
+        validate_firecracker_start_config(config)?;
         let slot = microvm::allocate_slot(&config.name)?;
+        Self::from_start_config_with_slot(config, slot)
+    }
+
+    /// Convert a launch config using a slot that has already been reserved.
+    /// Firecracker standbys reserve their slot when the daemon is warmed, then
+    /// reuse that same slot when the standby is claimed.
+    pub fn from_start_config_with_slot(config: &VmStartConfig, slot: VmSlot) -> Result<Self> {
+        validate_firecracker_start_config(config)?;
         let run_config = FlakeRunConfig {
             name: config.name.clone(),
             slot,
@@ -106,12 +102,91 @@ impl FirecrackerConfig {
     }
 }
 
+fn validate_firecracker_start_config(config: &VmStartConfig) -> Result<()> {
+    if let Some(v) = config
+        .volumes
+        .iter()
+        .find(|v| matches!(v.kind, mvm_core::vm_backend::VmVolumeKind::DirShare))
+    {
+        anyhow::bail!(
+            "Firecracker has no virtio-fs, so directory share '{}' -> '{}' isn't supported; \
+             use a disk-image volume instead (host:/guest:SIZE).",
+            v.host,
+            v.guest
+        );
+    }
+    Ok(())
+}
+
 /// Firecracker backend implementation.
 ///
 /// Wraps the existing free functions in [`microvm`] and [`firecracker`]
 /// behind the [`VmBackend`] trait. This is a thin adapter — all real
 /// work is delegated to the existing implementation.
 pub struct FirecrackerBackend;
+
+fn firecracker_spawn_standby(spec: &StandbySpec) -> Result<StandbyHandle> {
+    #[cfg(target_os = "linux")]
+    if !crate::qemu::kvm_available() {
+        anyhow::bail!("Firecracker standby requires /dev/kvm, which is not available on this host");
+    }
+
+    let slot = microvm::allocate_slot(&spec.id)
+        .with_context(|| format!("reserve Firecracker slot for standby '{}'", spec.id))?;
+    let mut slot_reservation = microvm::SlotReservationGuard::new(&slot);
+    let abs_dir = microvm::resolve_vm_dir(&slot)?;
+    let abs_socket = format!("{}/fc.socket", abs_dir);
+    microvm::start_vm_firecracker(&abs_dir, &abs_socket)
+        .with_context(|| format!("prestart Firecracker daemon for standby '{}'", spec.id))?;
+    let pid = microvm::read_firecracker_pid(&abs_dir)
+        .with_context(|| format!("read Firecracker pid for standby '{}'", spec.id))?;
+    slot_reservation.defuse();
+    Ok(StandbyHandle {
+        id: spec.id.clone(),
+        control_socket: std::path::PathBuf::from(abs_socket),
+        pid,
+        kernel_sha256: spec.kernel_sha256.clone(),
+        vcpus: spec.vcpus,
+        mem_mib: spec.mem_mib,
+        binding_nonce: spec.binding_nonce.clone(),
+        spawned_unix_secs: crate::standby_pool::now_unix_secs(),
+        state: StandbyState::Idle,
+        image_sha256: spec.image_sha256.clone(),
+    })
+}
+
+fn firecracker_claim_standby(handle: &StandbyHandle, claim: &StandbyClaim) -> Result<VmId> {
+    let mut start_config = claim
+        .start_config
+        .clone()
+        .context("Firecracker standby claim requires the original VmStartConfig")?;
+    start_config.name = handle.id.clone();
+    start_config.rootfs_path = claim.rootfs_path.clone();
+    start_config.tenant_id = Some(claim.tenant_id.clone());
+    start_config.plan_json = (!claim.plan_json.is_empty()).then(|| claim.plan_json.clone());
+    start_config.bundle_json = claim.bundle_json.clone();
+    start_config.network_policy = claim.network_policy.clone();
+
+    let slot = microvm::read_reserved_slot(&handle.id)
+        .with_context(|| format!("read reserved Firecracker slot for '{}'", handle.id))?;
+    let mut slot_reservation = microvm::SlotReservationGuard::new(&slot);
+    let fc_config = FirecrackerConfig::from_start_config_with_slot(&start_config, slot)?;
+    let abs_dir = microvm::resolve_vm_dir(&fc_config.run_config.slot)?;
+    let resolved_socket = format!("{}/fc.socket", abs_dir);
+    if std::path::Path::new(&resolved_socket) != handle.control_socket {
+        anyhow::bail!(
+            "Firecracker standby '{}' socket mismatch: handle {}, slot {}",
+            handle.id,
+            handle.control_socket.display(),
+            resolved_socket
+        );
+    }
+
+    microvm::run_from_prestarted_build(&fc_config.run_config, &abs_dir, &resolved_socket)
+        .with_context(|| format!("claim Firecracker standby '{}'", handle.id))?;
+    slot_reservation.defuse();
+    Ok(VmId(handle.id.clone()))
+}
 
 impl VmBackend for FirecrackerBackend {
     fn name(&self) -> &str {
@@ -203,6 +278,26 @@ impl VmBackend for FirecrackerBackend {
         microvm::run_from_build(&fc_config.run_config)?;
         slot_reservation.defuse();
         Ok(VmId(fc_config.run_config.name.clone()))
+    }
+
+    fn supports_standby_pool(&self) -> bool {
+        true
+    }
+
+    fn spawn_standby(
+        &self,
+        spec: &StandbySpec,
+    ) -> std::result::Result<StandbyHandle, StandbyError> {
+        firecracker_spawn_standby(spec).map_err(|e| StandbyError::SpawnFailed(e.to_string()))
+    }
+
+    fn claim_standby(
+        &self,
+        handle: &StandbyHandle,
+        claim: &StandbyClaim,
+    ) -> std::result::Result<VmId, StandbyError> {
+        firecracker_claim_standby(handle, claim)
+            .map_err(|e| StandbyError::ClaimFailed(e.to_string()))
     }
 
     fn stop(&self, id: &VmId) -> Result<()> {
@@ -682,6 +777,96 @@ mod tests {
         assert!(caps.snapshots);
         assert!(caps.vsock);
         assert!(caps.tap_networking);
+    }
+
+    #[test]
+    fn firecracker_reports_standby_pool_support() {
+        let backend = FirecrackerBackend;
+        assert!(backend.supports_standby_pool());
+    }
+
+    #[test]
+    fn firecracker_config_reuses_reserved_slot() {
+        let slot = VmSlot::new("standby-a", 7);
+        let config = VmStartConfig {
+            name: "standby-a".into(),
+            rootfs_path: "/images/rootfs.ext4".into(),
+            kernel_path: Some("/kernels/vmlinux".into()),
+            cpus: 2,
+            memory_mib: 1024,
+            ..Default::default()
+        };
+
+        let fc = FirecrackerConfig::from_start_config_with_slot(&config, slot.clone())
+            .expect("slot-backed config");
+
+        assert_eq!(fc.run_config.name, "standby-a");
+        assert_eq!(fc.run_config.slot.index, slot.index);
+        assert_eq!(fc.run_config.slot.tap_dev, slot.tap_dev);
+        assert_eq!(fc.run_config.vmlinux_path, "/kernels/vmlinux");
+        assert_eq!(fc.run_config.rootfs_path, "/images/rootfs.ext4");
+    }
+
+    #[test]
+    fn firecracker_config_rejects_dirshare_before_claim() {
+        let config = VmStartConfig {
+            name: "standby-a".into(),
+            rootfs_path: "/images/rootfs.ext4".into(),
+            kernel_path: Some("/kernels/vmlinux".into()),
+            volumes: vec![mvm_core::vm_backend::VmVolume {
+                host: "/host".into(),
+                guest: "/guest".into(),
+                size: String::new(),
+                read_only: true,
+                kind: mvm_core::vm_backend::VmVolumeKind::DirShare,
+                encrypted: false,
+            }],
+            ..Default::default()
+        };
+
+        let err = match FirecrackerConfig::from_start_config_with_slot(
+            &config,
+            VmSlot::new("standby-a", 7),
+        ) {
+            Ok(_) => panic!("dir shares are unsupported"),
+            Err(err) => err,
+        };
+
+        assert!(err.to_string().contains("Firecracker has no virtio-fs"));
+    }
+
+    #[test]
+    fn firecracker_claim_requires_start_config() {
+        let handle = StandbyHandle {
+            id: "standby-a".into(),
+            control_socket: "/tmp/fc.socket".into(),
+            pid: 123,
+            kernel_sha256: "a".repeat(64),
+            vcpus: 2,
+            mem_mib: 1024,
+            binding_nonce: "ab".repeat(32),
+            spawned_unix_secs: 1,
+            state: StandbyState::Idle,
+            image_sha256: None,
+        };
+        let claim = StandbyClaim {
+            start_config: None,
+            rootfs_path: "/images/rootfs.ext4".into(),
+            tenant_id: "tenant-a".into(),
+            audit_dir: "/audit".into(),
+            gateway_audit_socket: "/audit/gateway.sock".into(),
+            gateway_events_socket: None,
+            plan_json: "{}".into(),
+            bundle_json: None,
+            network_policy: mvm_core::network_policy::NetworkPolicy::deny_all(),
+        };
+
+        let err = firecracker_claim_standby(&handle, &claim).expect_err("missing config fails");
+
+        assert!(
+            err.to_string()
+                .contains("requires the original VmStartConfig")
+        );
     }
 
     #[test]

--- a/crates/mvm-backend/src/libkrun.rs
+++ b/crates/mvm-backend/src/libkrun.rs
@@ -1058,6 +1058,7 @@ mod tests {
 
     fn sample_standby_claim() -> StandbyClaim {
         StandbyClaim {
+            start_config: None,
             rootfs_path: "/vol/rootfs.ext4".into(),
             tenant_id: "tenant-a".into(),
             audit_dir: "/audit".into(),

--- a/crates/mvm-backend/src/microvm.rs
+++ b/crates/mvm-backend/src/microvm.rs
@@ -775,6 +775,50 @@ pub fn run_from_build(config: &FlakeRunConfig) -> Result<()> {
         return Ok(());
     }
 
+    run_configured_firecracker(config, &abs_dir, &abs_socket, true)
+}
+
+/// Finish launching a Firecracker VM whose daemon has already been started in
+/// the slot directory. Used by the standby pool: warming pays the daemon spawn
+/// cost; claiming still configures the exact admitted workload before
+/// `InstanceStart`.
+#[instrument(skip_all, fields(name = %config.name))]
+pub fn run_from_prestarted_build(
+    config: &FlakeRunConfig,
+    abs_dir: &str,
+    abs_socket: &str,
+) -> Result<()> {
+    config.validate()?;
+    require_linux_env()?;
+
+    let expected_dir = resolve_vm_dir(&config.slot)?;
+    if expected_dir != abs_dir {
+        anyhow::bail!(
+            "prestarted Firecracker dir mismatch for '{}': expected {}, got {}",
+            config.slot.name,
+            expected_dir,
+            abs_dir
+        );
+    }
+    let pid_file = format!("{}/fc.pid", abs_dir);
+    if !firecracker::is_vm_running(&pid_file)? {
+        anyhow::bail!(
+            "prestarted Firecracker daemon for '{}' is not running",
+            config.slot.name
+        );
+    }
+
+    run_configured_firecracker(config, abs_dir, abs_socket, false)
+}
+
+fn run_configured_firecracker(
+    config: &FlakeRunConfig,
+    abs_dir: &str,
+    abs_socket: &str,
+    start_daemon: bool,
+) -> Result<()> {
+    let slot = &config.slot;
+
     // Provision the VM's bridge+TAP network + egress policy through the
     // NetworkProvider seam. `provision` is transactional
     // — it drops the TAP itself if the policy apply fails — and the TapGuard
@@ -818,7 +862,7 @@ pub fn run_from_build(config: &FlakeRunConfig) -> Result<()> {
     // endpoint + nft redirect below) runs unconditionally.
     #[cfg(target_os = "linux")]
     let mut bridge_guard = if std::env::var("MVM_GATEWAY_BRIDGE").as_deref() == Ok("1") {
-        spawn_fc_bridge(&config.slot.name, &abs_dir)?
+        spawn_fc_bridge(&config.slot.name, abs_dir)?
     } else {
         tracing::debug!(
             vm = %config.slot.name,
@@ -827,9 +871,11 @@ pub fn run_from_build(config: &FlakeRunConfig) -> Result<()> {
         AttachedBridgeGuard { child: None }
     };
 
-    // Start Firecracker daemon in per-VM directory
-    start_vm_firecracker(&abs_dir, &abs_socket)?;
-    let mut fc_guard = FirecrackerGuard::new(&abs_dir);
+    if start_daemon {
+        // Start Firecracker daemon in per-VM directory.
+        start_vm_firecracker(abs_dir, abs_socket)?;
+    }
+    let mut fc_guard = FirecrackerGuard::new(abs_dir);
 
     // Spawn the substitution endpoint BEFORE configuring boot args,
     // so the placeholders it mints land in
@@ -842,19 +888,19 @@ pub fn run_from_build(config: &FlakeRunConfig) -> Result<()> {
     let mut endpoint_guard = spawn_egress_endpoint(config)?;
 
     // Configure VM via Firecracker API
-    configure_flake_microvm(config, &abs_dir, &abs_socket)?;
+    configure_flake_microvm(config, abs_dir, abs_socket)?;
 
     // Boot the instance
     ui::info("Starting microVM...");
     std::thread::sleep(std::time::Duration::from_millis(15));
     api_put_socket(
-        &abs_socket,
+        abs_socket,
         "/actions",
         r#"{"action_type": "InstanceStart"}"#,
     )?;
 
     // Make vsock socket accessible to the current user
-    let vsock = firecracker_vsock_uds_path(&abs_dir);
+    let vsock = firecracker_vsock_uds_path(abs_dir);
     if let Err(e) = run_in_vm(&format!(
         "sudo chmod 0666 {vsock} 2>/dev/null",
         vsock = vsock,
@@ -863,7 +909,7 @@ pub fn run_from_build(config: &FlakeRunConfig) -> Result<()> {
     }
 
     // Persist run info for `mvm status`
-    write_vm_run_info(config, &abs_dir)?;
+    write_vm_run_info(config, abs_dir)?;
 
     // VM is healthy. Detach the bridge guard so its child outlives
     // this stack frame; persist the bridge PID to
@@ -877,7 +923,7 @@ pub fn run_from_build(config: &FlakeRunConfig) -> Result<()> {
     // workload is fine. The next `stop_vm` reaps any orphan via the
     // PID file if it was persisted.
     #[cfg(target_os = "linux")]
-    if let Err(e) = detach_and_spawn_bridge_watchdog(&config.slot.name, &abs_dir, &mut bridge_guard)
+    if let Err(e) = detach_and_spawn_bridge_watchdog(&config.slot.name, abs_dir, &mut bridge_guard)
     {
         warn!(
             vm = %config.slot.name,
@@ -925,6 +971,16 @@ pub fn run_from_build(config: &FlakeRunConfig) -> Result<()> {
     ]);
 
     Ok(())
+}
+
+/// Read the pid recorded by [`start_vm_firecracker`].
+pub fn read_firecracker_pid(abs_dir: &str) -> Result<u32> {
+    let q_dir = shell_quote(abs_dir);
+    let output = run_in_vm_stdout(&format!("cat {q_dir}/fc.pid"))?;
+    output
+        .trim()
+        .parse::<u32>()
+        .with_context(|| format!("parse Firecracker pid from {abs_dir}/fc.pid"))
 }
 
 /// Restore a Firecracker VM from a template snapshot (instant start).
@@ -1863,6 +1919,20 @@ pub fn allocate_slot(name: &str) -> Result<VmSlot> {
         .rev()
         .find_map(|line| line.trim().parse::<u8>().ok())
         .ok_or_else(|| anyhow::anyhow!("No free VM slots available (max 253 VMs)"))?;
+    Ok(VmSlot::new(name, index))
+}
+
+/// Recreate a slot from a previously reserved VM directory.
+pub fn read_reserved_slot(name: &str) -> Result<VmSlot> {
+    let q_name = shell_quote(name);
+    let output = run_in_vm_stdout(&format!("cat {}/{}/run-info.json", VMS_DIR, q_name))?;
+    let value: serde_json::Value =
+        serde_json::from_str(output.trim()).with_context(|| format!("parse slot for {name}"))?;
+    let index = value
+        .get("slot_index")
+        .and_then(serde_json::Value::as_u64)
+        .and_then(|n| u8::try_from(n).ok())
+        .ok_or_else(|| anyhow::anyhow!("reserved slot for '{name}' has no valid slot_index"))?;
     Ok(VmSlot::new(name, index))
 }
 

--- a/crates/mvm-backend/src/standby_pool.rs
+++ b/crates/mvm-backend/src/standby_pool.rs
@@ -82,11 +82,16 @@ impl SupervisorStandbyPool {
     /// TTL controls expiry, not a process liveness check. Both `Idle` and `Parked`
     /// standbys are claimable; parked standbys resume from their saved state.
     pub fn select_idle_compatible(&self, want: &StandbyCompat) -> Result<Option<StandbyHandle>> {
-        Ok(self.list()?.into_iter().find(|h| {
-            h.state.is_claimable()
-                && h.is_compatible(want)
-                && (h.is_saved_state() || pid_alive(h.pid))
-        }))
+        Ok(self
+            .list()?
+            .into_iter()
+            .find(|h| h.state.is_claimable() && h.is_compatible(want) && Self::is_live_or_saved(h)))
+    }
+
+    /// True when the recorded standby still has a resource that can be claimed or displayed
+    /// as live. Saved-state standbys have no process; the snapshot payload is the resource.
+    pub fn is_live_or_saved(h: &StandbyHandle) -> bool {
+        h.is_saved_state() || pid_alive(h.pid)
     }
 
     /// Count of live idle standbys compatible with `want` — drives replenish-to-target.
@@ -95,9 +100,7 @@ impl SupervisorStandbyPool {
             .list()?
             .into_iter()
             .filter(|h| {
-                h.state == StandbyState::Idle
-                    && h.is_compatible(want)
-                    && (h.is_saved_state() || pid_alive(h.pid))
+                h.state == StandbyState::Idle && h.is_compatible(want) && Self::is_live_or_saved(h)
             })
             .count())
     }
@@ -326,6 +329,19 @@ mod tests {
         pool.record(&handle("b", "aa", StandbyState::Claimed))
             .unwrap();
         assert_eq!(pool.idle_count_compatible(&compat("aa")).unwrap(), 1);
+    }
+
+    #[test]
+    fn is_live_or_saved_distinguishes_dead_processes_from_saved_state() {
+        let live = handle("live", "aa", StandbyState::Idle);
+        assert!(SupervisorStandbyPool::is_live_or_saved(&live));
+
+        let mut dead = handle("dead", "aa", StandbyState::Idle);
+        dead.pid = 999_999;
+        assert!(!SupervisorStandbyPool::is_live_or_saved(&dead));
+
+        let saved = saved_handle("saved", "aa", "img", StandbyState::Idle);
+        assert!(SupervisorStandbyPool::is_live_or_saved(&saved));
     }
 
     // ── saved-state standby tests (Vz) ───────────────────────────────────────────

--- a/crates/mvm-backend/src/vz.rs
+++ b/crates/mvm-backend/src/vz.rs
@@ -3928,6 +3928,7 @@ mod tests {
             image_sha256: Some("cccc".into()),
         };
         let claim = mvm_core::vm_backend::StandbyClaim {
+            start_config: None,
             rootfs_path: "/fake/rootfs.ext4".into(),
             plan_json: "{}".into(),
             tenant_id: "t1".into(),
@@ -4025,6 +4026,7 @@ mod tests {
             image_sha256: Some("img-sha".into()),
         };
         let claim = mvm_core::vm_backend::StandbyClaim {
+            start_config: None,
             rootfs_path: "/fake/rootfs.ext4".into(),
             plan_json: "{}".into(),
             tenant_id: "t1".into(),

--- a/crates/mvm-build/src/persistent_builder.rs
+++ b/crates/mvm-build/src/persistent_builder.rs
@@ -1318,7 +1318,8 @@ mod tests {
     #[test]
     fn touch_active_session_updates_live_record_timestamp() {
         let scratch = tempfile::tempdir().expect("tempdir");
-        let run_dir = scratch.path().join(".mvm").join("run");
+        let data_dir = scratch.path().join(".mvm");
+        let run_dir = data_dir.join("run");
         std::fs::create_dir_all(&run_dir).unwrap();
         let record = SessionRecord {
             session_id: "x".to_string(),
@@ -1334,7 +1335,7 @@ mod tests {
         )
         .unwrap();
         let mut env = TestEnv::new();
-        env.set("MVM_DATA_DIR", scratch.path().join(".mvm"));
+        env.set("MVM_DATA_DIR", &data_dir);
         let touched = touch_active_session(55).expect("touch active session");
         assert!(touched);
         let body = std::fs::read(run_dir.join("persistent-builder.json")).unwrap();

--- a/crates/mvm-cli/src/commands/ops/bench.rs
+++ b/crates/mvm-cli/src/commands/ops/bench.rs
@@ -8,15 +8,14 @@
 //! statistics, a versioned JSON report, and baseline regression-gating
 //! — is pure and fully unit-tested via a mock [`LaunchProbe`].
 //!
-//! The live libkrun probe (the only part that needs a real backend) is
-//! the one piece not exercised by unit tests; it is a tracked
-//! follow-up. When wired
-//! it MUST drive `admit_plan_for_boot` so the harness measures the real
-//! signed-plan boot, never a bypass — otherwise we'd benchmark a
-//! configuration that can never ship.
+//! Live probes MUST drive signed-plan admission so the harness measures
+//! a launch shape that can actually ship. libkrun is feature-gated
+//! behind `libkrun-live`; Firecracker runs on Linux/KVM hosts.
+//! Firecracker v1 reports backend-accepted/PID-observed readiness
+//! because the current Linux proof image does not expose the guest
+//! control-plane ping endpoint.
 //!
-//! Backend scope: v1 measures **libkrun** only. Vz / Firecracker benches
-//! are a deferred follow-up (logged, not silently skipped).
+//! Backend scope: v1 measures libkrun, Vz, and Firecracker.
 
 use std::path::{Path, PathBuf};
 use std::thread;
@@ -65,9 +64,17 @@ pub(in crate::commands) struct MicrovmLaunchArgs {
     /// Safety cap for `--concurrency` so a typo cannot fork-bomb the host.
     #[arg(long, default_value_t = 64)]
     pub max_concurrency: u32,
-    /// Hypervisor backend to measure. v1 supports `libkrun` only.
+    /// Hypervisor backend to measure. v1 supports `libkrun`, macOS `vz`, and
+    /// Linux `firecracker`.
     #[arg(long, default_value = "libkrun")]
     pub hypervisor: String,
+    /// Warm standby pool target to request for each measured launch.
+    ///
+    /// Currently supported for Linux Firecracker launch probes; use
+    /// `0` for a cold baseline and `1` for the Plan 118 warm-claim
+    /// delta proof.
+    #[arg(long, default_value_t = 0)]
+    pub warm_pool_size: u32,
     /// Write the JSON report here. Default:
     /// `~/.mvm/bench/microvm-launch-<rfc3339>.json` plus a stable
     /// `microvm-launch-latest.json` copy.
@@ -94,7 +101,8 @@ pub(in crate::commands) struct MicrovmDensityArgs {
     /// Safety cap for `--count` so a typo cannot exhaust host memory.
     #[arg(long, default_value_t = 16)]
     pub max_count: u32,
-    /// Hypervisor backend to measure. v1 supports `libkrun` only.
+    /// Hypervisor backend to measure. v1 supports `libkrun`, macOS `vz`, and
+    /// Linux `firecracker`.
     #[arg(long, default_value = "libkrun")]
     pub hypervisor: String,
     /// Write the JSON report here. Default:
@@ -105,6 +113,13 @@ pub(in crate::commands) struct MicrovmDensityArgs {
     /// Also print the JSON report to stdout.
     #[arg(long)]
     pub json: bool,
+    /// Compare `per_instance_bytes` against this baseline report and
+    /// exit non-zero if it regressed past `--max-regression-pct`.
+    #[arg(long)]
+    pub baseline: Option<PathBuf>,
+    /// Maximum tolerated regression (percent) when `--baseline` is set.
+    #[arg(long, default_value_t = 10.0)]
+    pub max_regression_pct: f64,
 }
 
 // ──────────────────────────────────────────────────────────────────
@@ -238,6 +253,8 @@ pub struct HostDescriptor {
     pub libkrun_version: Option<String>,
     pub kernel_sha256: Option<String>,
     pub cmdline: Option<String>,
+    #[serde(default)]
+    pub readiness_boundary: Option<String>,
 }
 
 /// A full benchmark run: host fingerprint, run counts, per-phase
@@ -336,7 +353,12 @@ fn build_report(
 }
 
 /// Derive density stats from per-instance footprint samples.
-#[cfg(any(test, feature = "libkrun-live"))]
+#[cfg(any(
+    test,
+    feature = "libkrun-live",
+    target_os = "linux",
+    target_os = "macos"
+))]
 pub fn summarize_density(samples: &[InstanceFootprint]) -> DensityStats {
     let instances = samples.len() as u32;
     let total_bytes = samples.iter().map(|sample| sample.bytes).sum::<u64>();
@@ -362,7 +384,12 @@ pub fn summarize_tail_latency(samples: &[f64]) -> TailLatencyStats {
     }
 }
 
-#[cfg(any(test, feature = "libkrun-live"))]
+#[cfg(any(
+    test,
+    feature = "libkrun-live",
+    target_os = "linux",
+    target_os = "macos"
+))]
 pub fn build_density_report(
     host: HostDescriptor,
     count: u32,
@@ -420,6 +447,18 @@ pub fn read_report(path: &Path) -> Result<BenchReport> {
     serde_json::from_slice(&bytes).with_context(|| format!("parsing baseline {}", path.display()))
 }
 
+pub fn read_launch_distribution_report(path: &Path) -> Result<LaunchDistributionReport> {
+    let bytes =
+        std::fs::read(path).with_context(|| format!("reading baseline {}", path.display()))?;
+    serde_json::from_slice(&bytes).with_context(|| format!("parsing baseline {}", path.display()))
+}
+
+pub fn read_density_report(path: &Path) -> Result<DensityReport> {
+    let bytes =
+        std::fs::read(path).with_context(|| format!("reading baseline {}", path.display()))?;
+    serde_json::from_slice(&bytes).with_context(|| format!("parsing baseline {}", path.display()))
+}
+
 // ──────────────────────────────────────────────────────────────────
 // Baseline regression gate (pure).
 // ──────────────────────────────────────────────────────────────────
@@ -469,6 +508,100 @@ pub fn compare_to_baseline(
         };
     }
     let delta_pct = (cur - base) / base * 100.0;
+    if delta_pct > max_regression_pct {
+        RegressionVerdict::Regressed {
+            delta_pct,
+            limit_pct: max_regression_pct,
+        }
+    } else {
+        RegressionVerdict::Ok { delta_pct }
+    }
+}
+
+pub fn compare_launch_distribution_to_baseline(
+    baseline: &LaunchDistributionReport,
+    current: &LaunchDistributionReport,
+    max_regression_pct: f64,
+) -> RegressionVerdict {
+    if baseline.schema_version != current.schema_version {
+        return RegressionVerdict::Incomparable {
+            reason: format!(
+                "schema version differs (baseline {}, current {})",
+                baseline.schema_version, current.schema_version
+            ),
+        };
+    }
+    if baseline.host != current.host {
+        return RegressionVerdict::Incomparable {
+            reason: "host descriptor differs (os/arch/hypervisor/kernel/cmdline) — \
+                     a baseline from a different host or kernel is not comparable"
+                .to_string(),
+        };
+    }
+    if baseline.concurrency != current.concurrency {
+        return RegressionVerdict::Incomparable {
+            reason: format!(
+                "concurrency differs (baseline {}, current {})",
+                baseline.concurrency, current.concurrency
+            ),
+        };
+    }
+    compare_metric(
+        baseline.total_ready_tail_ms.p95,
+        current.total_ready_tail_ms.p95,
+        max_regression_pct,
+        "non-finite or zero baseline p95 total_ready_ms",
+    )
+}
+
+pub fn compare_density_to_baseline(
+    baseline: &DensityReport,
+    current: &DensityReport,
+    max_regression_pct: f64,
+) -> RegressionVerdict {
+    if baseline.schema_version != current.schema_version {
+        return RegressionVerdict::Incomparable {
+            reason: format!(
+                "schema version differs (baseline {}, current {})",
+                baseline.schema_version, current.schema_version
+            ),
+        };
+    }
+    if baseline.host != current.host {
+        return RegressionVerdict::Incomparable {
+            reason: "host descriptor differs (os/arch/hypervisor/kernel/cmdline) — \
+                     a baseline from a different host or kernel is not comparable"
+                .to_string(),
+        };
+    }
+    if baseline.count != current.count {
+        return RegressionVerdict::Incomparable {
+            reason: format!(
+                "density count differs (baseline {}, current {})",
+                baseline.count, current.count
+            ),
+        };
+    }
+    compare_metric(
+        baseline.stats.per_instance_bytes as f64,
+        current.stats.per_instance_bytes as f64,
+        max_regression_pct,
+        "zero baseline per_instance_bytes",
+    )
+}
+
+fn compare_metric(
+    baseline: f64,
+    current: f64,
+    max_regression_pct: f64,
+    invalid_reason: &str,
+) -> RegressionVerdict {
+    if !(baseline.is_finite() && current.is_finite()) || baseline <= 0.0 {
+        return RegressionVerdict::Incomparable {
+            reason: invalid_reason.to_string(),
+        };
+    }
+    let delta_pct = (current - baseline) / baseline * 100.0;
     if delta_pct > max_regression_pct {
         RegressionVerdict::Regressed {
             delta_pct,
@@ -563,7 +696,7 @@ where
 }
 
 /// Linux `/proc/<pid>/smaps_rollup` reports proportional set size in KiB.
-#[cfg(any(test, all(target_os = "linux", feature = "libkrun-live")))]
+#[cfg(any(test, target_os = "linux"))]
 pub fn parse_linux_smaps_rollup_pss_bytes(input: &str) -> Result<u64> {
     for line in input.lines() {
         let trimmed = line.trim_start();
@@ -586,7 +719,7 @@ pub fn parse_linux_smaps_rollup_pss_bytes(input: &str) -> Result<u64> {
     bail!("smaps_rollup did not contain a Pss line")
 }
 
-#[cfg(all(target_os = "linux", feature = "libkrun-live"))]
+#[cfg(target_os = "linux")]
 pub fn read_process_footprint_bytes(pid: u32) -> Result<u64> {
     let path = PathBuf::from("/proc")
         .join(pid.to_string())
@@ -596,7 +729,7 @@ pub fn read_process_footprint_bytes(pid: u32) -> Result<u64> {
     parse_linux_smaps_rollup_pss_bytes(&body)
 }
 
-#[cfg(all(target_os = "macos", feature = "libkrun-live"))]
+#[cfg(target_os = "macos")]
 pub fn read_process_footprint_bytes(pid: u32) -> Result<u64> {
     let mut info = std::mem::MaybeUninit::<libc::rusage_info_v4>::zeroed();
     let rc = unsafe {
@@ -614,12 +747,29 @@ pub fn read_process_footprint_bytes(pid: u32) -> Result<u64> {
     Ok(info.ri_phys_footprint)
 }
 
-#[cfg(all(
-    feature = "libkrun-live",
-    not(any(target_os = "linux", target_os = "macos"))
-))]
+#[cfg(all(not(target_os = "linux"), not(target_os = "macos")))]
 pub fn read_process_footprint_bytes(_pid: u32) -> Result<u64> {
     bail!("process footprint sampling is only implemented on Linux and macOS")
+}
+
+/// Persist a guest-monotonic boot timing cross-check beside the bench reports.
+/// The host-clock report remains the regression metric; this sidecar audits the
+/// guest's own phase timing without mixing clock domains.
+pub(in crate::commands::ops) fn write_boot_timing_sidecar(
+    vm_name: &str,
+    boot_millis: &mvm_guest::vsock::BootTimingReport,
+) -> Result<()> {
+    let path = PathBuf::from(mvm_core::config::mvm_state_dir())
+        .join("bench")
+        .join(format!("boot-timing-{vm_name}.json"));
+    if let Some(parent) = path.parent() {
+        std::fs::create_dir_all(parent)
+            .with_context(|| format!("creating boot timing dir {}", parent.display()))?;
+    }
+    let json =
+        serde_json::to_string_pretty(boot_millis).context("serializing boot timing report")?;
+    std::fs::write(&path, json).with_context(|| format!("writing {}", path.display()))?;
+    Ok(())
 }
 
 // ──────────────────────────────────────────────────────────────────
@@ -703,7 +853,367 @@ impl LaunchProbe for LibkrunProbe {
             // The runtime libkrun cmdline (Apple Silicon HVF / virtio
             // console), matching the backend's supervisor config.
             cmdline: Some("console=hvc0 root=/dev/vda rw init=/init".to_string()),
+            readiness_boundary: Some("guest-agent-ping".to_string()),
         }
+    }
+}
+
+#[cfg(target_os = "macos")]
+struct VzProbe {
+    os: String,
+    arch: String,
+    name_prefix: String,
+    iter: u32,
+}
+
+#[cfg(target_os = "macos")]
+impl VzProbe {
+    fn new(_args: &MicrovmLaunchArgs) -> Result<Self> {
+        Self::new_with_prefix("mvm-bench-vz")
+    }
+
+    fn new_with_prefix(name_prefix: impl Into<String>) -> Result<Self> {
+        Ok(Self {
+            os: std::env::consts::OS.to_string(),
+            arch: std::env::consts::ARCH.to_string(),
+            name_prefix: name_prefix.into(),
+            iter: 0,
+        })
+    }
+}
+
+#[cfg(target_os = "macos")]
+impl LaunchProbe for VzProbe {
+    fn measure_once(&mut self) -> Result<IterationTiming> {
+        self.iter += 1;
+        let name = format!("{}-{}", self.name_prefix, self.iter);
+        let held = boot_vz_hold_once(&name)?;
+        let marks = held.marks;
+        drop(held);
+        assert_vz_bench_cleanup(&name)?;
+        Ok(marks.to_timing())
+    }
+
+    fn host_descriptor(&self) -> HostDescriptor {
+        let kernel_sha256 = super::bench_probe::resolve_probe_image()
+            .ok()
+            .and_then(|img| {
+                mvm_core::crypto::image_verify::sha256_file(std::path::Path::new(&img.kernel)).ok()
+            });
+        HostDescriptor {
+            os: self.os.clone(),
+            arch: self.arch.clone(),
+            hypervisor: "vz".to_string(),
+            libkrun_version: None,
+            kernel_sha256,
+            cmdline: Some("console=hvc0 root=/dev/vda rw init=/init".to_string()),
+            readiness_boundary: Some("guest-agent-readiness".to_string()),
+        }
+    }
+}
+
+#[cfg(target_os = "macos")]
+struct HeldVzVm {
+    vm_name: String,
+    pid: u32,
+    marks: BootMarks,
+}
+
+#[cfg(target_os = "macos")]
+impl HeldVzVm {
+    fn vm_name(&self) -> &str {
+        &self.vm_name
+    }
+
+    fn pid(&self) -> u32 {
+        self.pid
+    }
+}
+
+#[cfg(target_os = "macos")]
+impl Drop for HeldVzVm {
+    fn drop(&mut self) {
+        use mvm_core::vm_backend::VmId;
+
+        let backend = mvm_backend::backend::AnyBackend::from_hypervisor("vz");
+        let _ = backend.stop(&VmId(self.vm_name.clone()));
+    }
+}
+
+#[cfg(target_os = "macos")]
+fn boot_vz_hold_once(vm_name: &str) -> Result<HeldVzVm> {
+    use mvm_core::vm_backend::VmStartConfig;
+    use std::time::Instant;
+
+    use crate::commands::vm::plan_admission::populate_audit_substrate;
+
+    let img = super::bench_probe::resolve_probe_image()?;
+    let admitted = super::bench_probe::admit_probe_plan(
+        std::path::Path::new(&img.rootfs),
+        vm_name,
+        "vz",
+        None,
+    )?;
+
+    let mut cfg = VmStartConfig {
+        name: vm_name.to_string(),
+        rootfs_path: img.rootfs.clone(),
+        kernel_path: Some(img.kernel.clone()),
+        cpus: 2,
+        memory_mib: 2048,
+        ..Default::default()
+    };
+    populate_audit_substrate(&mut cfg, &admitted, None)?;
+
+    let backend = mvm_backend::backend::AnyBackend::from_hypervisor("vz");
+    let start = Instant::now();
+    backend.start(&cfg).context("probe vz backend.start")?;
+
+    let (pid, pid_seen) = wait_for_vz_pid_file(vm_name)?;
+    let (connected, ready) = wait_for_guest_readiness_and_record(vm_name)?;
+
+    Ok(HeldVzVm {
+        vm_name: vm_name.to_string(),
+        pid,
+        marks: BootMarks {
+            start,
+            pid_seen,
+            connected,
+            ready,
+        },
+    })
+}
+
+#[cfg(target_os = "macos")]
+fn wait_for_vz_pid_file(vm_name: &str) -> Result<(u32, std::time::Instant)> {
+    use mvm_guest::vsock::adaptive_backoff;
+
+    let pid_path = mvm_core::config::vm_state_dir(vm_name).join("vz.pid");
+    let deadline = std::time::Instant::now() + std::time::Duration::from_secs(30);
+    let mut attempt = 0u32;
+    loop {
+        if let Ok(body) = std::fs::read_to_string(&pid_path)
+            && let Ok(pid) = body.trim().parse::<u32>()
+        {
+            return Ok((pid, std::time::Instant::now()));
+        }
+        if std::time::Instant::now() >= deadline {
+            bail!(
+                "probe: Vz supervisor pid file never appeared or was invalid at {}",
+                pid_path.display()
+            );
+        }
+        std::thread::sleep(adaptive_backoff(attempt));
+        attempt += 1;
+    }
+}
+
+#[cfg(target_os = "macos")]
+fn wait_for_guest_readiness_and_record(
+    vm_name: &str,
+) -> Result<(std::time::Instant, std::time::Instant)> {
+    use mvm_guest::vsock::adaptive_backoff;
+
+    let deadline = std::time::Instant::now() + std::time::Duration::from_secs(90);
+    let mut attempt = 0u32;
+    loop {
+        if let Ok(report) = crate::commands::vm::wait::fetch_readiness(vm_name) {
+            let now = std::time::Instant::now();
+            write_boot_timing_sidecar(vm_name, &report.boot_millis)?;
+            return Ok((now, now));
+        }
+        if std::time::Instant::now() >= deadline {
+            bail!("probe: guest control plane never reached Ready (readiness) for {vm_name}");
+        }
+        std::thread::sleep(adaptive_backoff(attempt));
+        attempt += 1;
+    }
+}
+
+#[cfg(target_os = "macos")]
+fn assert_vz_bench_cleanup(vm_name: &str) -> Result<()> {
+    let backend = mvm_backend::backend::AnyBackend::from_hypervisor("vz");
+    let list = backend
+        .list()
+        .with_context(|| format!("listing Vz VMs after bench cleanup for {vm_name}"))?;
+    if list.iter().any(|vm| vm.name == vm_name) {
+        bail!("bench cleanup leaked Vz VM registry entry for {vm_name}");
+    }
+    Ok(())
+}
+
+#[cfg(target_os = "linux")]
+struct FirecrackerProbe {
+    os: String,
+    arch: String,
+    name_prefix: String,
+    warm_pool_size: u32,
+    iter: u32,
+}
+
+#[cfg(target_os = "linux")]
+impl FirecrackerProbe {
+    fn new(args: &MicrovmLaunchArgs) -> Result<Self> {
+        Self::new_with_prefix_and_warm_pool_size("mvm-bench-fc", args.warm_pool_size)
+    }
+
+    fn new_with_prefix(name_prefix: impl Into<String>) -> Result<Self> {
+        Self::new_with_prefix_and_warm_pool_size(name_prefix, 0)
+    }
+
+    fn new_with_prefix_and_warm_pool_size(
+        name_prefix: impl Into<String>,
+        warm_pool_size: u32,
+    ) -> Result<Self> {
+        Ok(Self {
+            os: std::env::consts::OS.to_string(),
+            arch: std::env::consts::ARCH.to_string(),
+            name_prefix: name_prefix.into(),
+            warm_pool_size,
+            iter: 0,
+        })
+    }
+}
+
+#[cfg(target_os = "linux")]
+impl LaunchProbe for FirecrackerProbe {
+    fn measure_once(&mut self) -> Result<IterationTiming> {
+        self.iter += 1;
+        let name = format!("{}-{}", self.name_prefix, self.iter);
+        let held = boot_firecracker_hold_once(&name, self.warm_pool_size)?;
+        let marks = held.marks;
+        drop(held);
+        assert_firecracker_bench_cleanup(&name)?;
+        Ok(marks.to_timing())
+    }
+
+    fn host_descriptor(&self) -> HostDescriptor {
+        let kernel_sha256 = super::bench_probe::resolve_probe_image()
+            .ok()
+            .and_then(|img| {
+                mvm_core::crypto::image_verify::sha256_file(std::path::Path::new(&img.kernel)).ok()
+            });
+        HostDescriptor {
+            os: self.os.clone(),
+            arch: self.arch.clone(),
+            hypervisor: "firecracker".to_string(),
+            libkrun_version: None,
+            kernel_sha256,
+            cmdline: Some("console=ttyS0 reboot=k panic=1 net.ifnames=0 ip=<per-slot>".to_string()),
+            readiness_boundary: Some("firecracker-pid".to_string()),
+        }
+    }
+}
+
+#[cfg(target_os = "linux")]
+struct HeldFirecrackerVm {
+    vm_name: String,
+    pid: u32,
+    marks: BootMarks,
+}
+
+#[cfg(target_os = "linux")]
+impl HeldFirecrackerVm {
+    fn vm_name(&self) -> &str {
+        &self.vm_name
+    }
+
+    fn pid(&self) -> u32 {
+        self.pid
+    }
+}
+
+#[cfg(target_os = "linux")]
+impl Drop for HeldFirecrackerVm {
+    fn drop(&mut self) {
+        use mvm_core::vm_backend::VmId;
+
+        let backend = mvm_backend::backend::AnyBackend::from_hypervisor("firecracker");
+        let _ = backend.stop(&VmId(self.vm_name.clone()));
+    }
+}
+
+#[cfg(target_os = "linux")]
+fn boot_firecracker_hold_once(vm_name: &str, warm_pool_size: u32) -> Result<HeldFirecrackerVm> {
+    use mvm_core::vm_backend::VmStartConfig;
+    use std::time::Instant;
+
+    use crate::commands::vm::plan_admission::populate_audit_substrate;
+
+    let img = super::bench_probe::resolve_probe_image()?;
+    let admitted = super::bench_probe::admit_probe_plan(
+        std::path::Path::new(&img.rootfs),
+        vm_name,
+        "firecracker",
+        None,
+    )?;
+
+    let mut cfg = VmStartConfig {
+        name: vm_name.to_string(),
+        rootfs_path: img.rootfs.clone(),
+        kernel_path: Some(img.kernel.clone()),
+        cpus: 2,
+        memory_mib: 2048,
+        warm_pool_size,
+        ..Default::default()
+    };
+    populate_audit_substrate(&mut cfg, &admitted, None)?;
+
+    let backend = mvm_backend::backend::AnyBackend::from_hypervisor("firecracker");
+    let start = Instant::now();
+    backend
+        .start(&cfg)
+        .context("probe firecracker backend.start")?;
+
+    let abs_dir = mvm_backend::microvm::resolve_running_vm_dir(vm_name)?;
+    let (pid, pid_seen) = wait_for_firecracker_pid(&abs_dir)?;
+    // The current Linux proof image used by the Firecracker host boots
+    // successfully but does not expose the mvm guest-agent ping endpoint.
+    // Report backend-accepted/PID-observed timing honestly and fingerprint
+    // that boundary in HostDescriptor so it cannot be baseline-compared
+    // against guest-agent-ready libkrun reports.
+    let connected = pid_seen;
+    let ready = pid_seen;
+
+    Ok(HeldFirecrackerVm {
+        vm_name: vm_name.to_string(),
+        pid,
+        marks: BootMarks {
+            start,
+            pid_seen,
+            connected,
+            ready,
+        },
+    })
+}
+
+#[cfg(target_os = "linux")]
+fn assert_firecracker_bench_cleanup(vm_name: &str) -> Result<()> {
+    let backend = mvm_backend::backend::AnyBackend::from_hypervisor("firecracker");
+    let list = backend
+        .list()
+        .with_context(|| format!("listing VMs after bench cleanup for {vm_name}"))?;
+    if list.iter().any(|vm| vm.name == vm_name) {
+        anyhow::bail!("bench cleanup leaked VM registry entry for {vm_name}");
+    }
+    Ok(())
+}
+
+#[cfg(target_os = "linux")]
+fn wait_for_firecracker_pid(abs_dir: &str) -> Result<(u32, std::time::Instant)> {
+    use mvm_guest::vsock::adaptive_backoff;
+
+    let deadline = std::time::Instant::now() + std::time::Duration::from_secs(30);
+    let mut attempt = 0u32;
+    loop {
+        if let Ok(pid) = mvm_backend::microvm::read_firecracker_pid(abs_dir) {
+            return Ok((pid, std::time::Instant::now()));
+        }
+        if std::time::Instant::now() >= deadline {
+            anyhow::bail!("probe: Firecracker pid file never appeared under {abs_dir}");
+        }
+        std::thread::sleep(adaptive_backoff(attempt));
+        attempt += 1;
     }
 }
 
@@ -749,12 +1259,9 @@ fn write_report_with_latest<T: Serialize>(
 }
 
 fn run_microvm_launch(args: MicrovmLaunchArgs) -> Result<()> {
-    if args.hypervisor != "libkrun" {
-        bail!(
-            "bench microvm-launch v1 supports --hypervisor libkrun only (got {:?}); \
-             Vz / Firecracker benches are a tracked Plan 93 follow-up",
-            args.hypervisor
-        );
+    validate_launch_hypervisor(&args.hypervisor)?;
+    if args.warm_pool_size > 0 && args.hypervisor != "firecracker" {
+        bail!("--warm-pool-size is currently wired for --hypervisor firecracker benchmarks");
     }
     if args.concurrency == 0 {
         bail!("--concurrency must be >= 1");
@@ -774,13 +1281,17 @@ fn run_microvm_launch(args: MicrovmLaunchArgs) -> Result<()> {
         if args.warmup > 0 {
             bail!("--warmup is only supported for serial microvm-launch runs");
         }
-        if args.baseline.is_some() {
-            bail!("--baseline is only supported for serial microvm-launch runs");
-        }
-        let host = LibkrunProbe::new(&args)?.host_descriptor();
-        let report = run_launch_distribution(host, args.concurrency, args.max_concurrency, |i| {
-            LibkrunProbe::new_with_prefix(format!("mvm-bench-c{i}"))
-        })?;
+        let report = match args.hypervisor.as_str() {
+            "libkrun" => {
+                let host = LibkrunProbe::new(&args)?.host_descriptor();
+                run_launch_distribution(host, args.concurrency, args.max_concurrency, |i| {
+                    LibkrunProbe::new_with_prefix(format!("mvm-bench-c{i}"))
+                })?
+            }
+            "firecracker" => run_firecracker_launch_distribution(&args)?,
+            "vz" => run_vz_launch_distribution(&args)?,
+            _ => unreachable!("validated hypervisor"),
+        };
         let out_path = write_report_with_latest(&report, args.out, "microvm-launch-concurrent")?;
         eprintln!(
             "[mvm] bench microvm-launch: concurrency={}, p95 total_ready_ms={:.2}, report at {}",
@@ -791,11 +1302,50 @@ fn run_microvm_launch(args: MicrovmLaunchArgs) -> Result<()> {
         if args.json {
             println!("{}", serde_json::to_string_pretty(&report)?);
         }
+        if let Some(baseline_path) = args.baseline.as_deref() {
+            let baseline = read_launch_distribution_report(baseline_path)?;
+            match compare_launch_distribution_to_baseline(
+                &baseline,
+                &report,
+                args.max_regression_pct,
+            ) {
+                RegressionVerdict::Ok { delta_pct } => {
+                    eprintln!(
+                        "[mvm] bench: concurrent p95 within tolerance ({delta_pct:+.2}% vs baseline)"
+                    );
+                }
+                RegressionVerdict::Incomparable { reason } => {
+                    bail!("bench baseline is incomparable: {reason}");
+                }
+                RegressionVerdict::Regressed {
+                    delta_pct,
+                    limit_pct,
+                } => {
+                    bail!(
+                        "bench regression: concurrent p95 total_ready_ms up {delta_pct:+.2}% \
+                         vs baseline (limit {limit_pct:.2}%)"
+                    );
+                }
+            }
+        }
         return Ok(());
     }
 
-    let mut probe = LibkrunProbe::new(&args)?;
-    let report = run_benchmark(&mut probe, args.runs, args.warmup)?;
+    let report = match args.hypervisor.as_str() {
+        "libkrun" => {
+            let mut probe = LibkrunProbe::new(&args)?;
+            run_benchmark(&mut probe, args.runs, args.warmup)?
+        }
+        "firecracker" => {
+            let mut probe = new_firecracker_probe(&args)?;
+            run_benchmark(&mut probe, args.runs, args.warmup)?
+        }
+        "vz" => {
+            let mut probe = new_vz_probe(&args)?;
+            run_benchmark(&mut probe, args.runs, args.warmup)?
+        }
+        _ => unreachable!("validated hypervisor"),
+    };
     let out_path = write_report_with_latest(&report, args.out, "microvm-launch")?;
 
     eprintln!(
@@ -834,13 +1384,7 @@ fn run_microvm_launch(args: MicrovmLaunchArgs) -> Result<()> {
 }
 
 fn run_microvm_density(args: MicrovmDensityArgs) -> Result<()> {
-    if args.hypervisor != "libkrun" {
-        bail!(
-            "bench microvm-density v1 supports --hypervisor libkrun only (got {:?}); \
-             Vz / Firecracker benches are a tracked Plan 118 follow-up",
-            args.hypervisor
-        );
-    }
+    validate_density_hypervisor(&args.hypervisor)?;
     if args.count == 0 {
         bail!("--count must be >= 1");
     }
@@ -855,7 +1399,12 @@ fn run_microvm_density(args: MicrovmDensityArgs) -> Result<()> {
         );
     }
 
-    let report = run_libkrun_density(args.count, args.max_count)?;
+    let report = match args.hypervisor.as_str() {
+        "libkrun" => run_libkrun_density(args.count, args.max_count)?,
+        "firecracker" => run_firecracker_density(args.count, args.max_count)?,
+        "vz" => run_vz_density(args.count, args.max_count)?,
+        _ => unreachable!("validated hypervisor"),
+    };
     let out_path = write_report_with_latest(&report, args.out, "microvm-density")?;
     eprintln!(
         "[mvm] bench microvm-density: {} instances, per-instance={} bytes, report at {}",
@@ -868,7 +1417,131 @@ fn run_microvm_density(args: MicrovmDensityArgs) -> Result<()> {
         println!("{}", serde_json::to_string_pretty(&report)?);
     }
 
+    if let Some(baseline_path) = args.baseline.as_deref() {
+        let baseline = read_density_report(baseline_path)?;
+        match compare_density_to_baseline(&baseline, &report, args.max_regression_pct) {
+            RegressionVerdict::Ok { delta_pct } => {
+                eprintln!(
+                    "[mvm] bench: density per-instance footprint within tolerance ({delta_pct:+.2}% vs baseline)"
+                );
+            }
+            RegressionVerdict::Incomparable { reason } => {
+                bail!("bench baseline is incomparable: {reason}");
+            }
+            RegressionVerdict::Regressed {
+                delta_pct,
+                limit_pct,
+            } => {
+                bail!(
+                    "bench regression: density per-instance footprint up {delta_pct:+.2}% \
+                     vs baseline (limit {limit_pct:.2}%)"
+                );
+            }
+        }
+    }
+
     Ok(())
+}
+
+fn validate_launch_hypervisor(hypervisor: &str) -> Result<()> {
+    match hypervisor {
+        "libkrun" => Ok(()),
+        "firecracker" => {
+            if cfg!(target_os = "linux") {
+                Ok(())
+            } else {
+                bail!("bench microvm-launch --hypervisor firecracker requires Linux/KVM")
+            }
+        }
+        "vz" => {
+            if cfg!(target_os = "macos") {
+                Ok(())
+            } else {
+                bail!("bench microvm-launch --hypervisor vz requires macOS with Vz")
+            }
+        }
+        other => bail!(
+            "bench microvm-launch v1 supports --hypervisor libkrun, macOS vz, and Linux \
+             firecracker (got {other:?})"
+        ),
+    }
+}
+
+fn validate_density_hypervisor(hypervisor: &str) -> Result<()> {
+    match hypervisor {
+        "libkrun" => Ok(()),
+        "firecracker" => {
+            if cfg!(target_os = "linux") {
+                Ok(())
+            } else {
+                bail!("bench microvm-density --hypervisor firecracker requires Linux/KVM")
+            }
+        }
+        "vz" => {
+            if cfg!(target_os = "macos") {
+                Ok(())
+            } else {
+                bail!("bench microvm-density --hypervisor vz requires macOS with Vz")
+            }
+        }
+        other => bail!(
+            "bench microvm-density v1 supports --hypervisor libkrun, macOS vz, and Linux \
+             firecracker (got {other:?})"
+        ),
+    }
+}
+
+#[cfg(target_os = "linux")]
+fn new_firecracker_probe(args: &MicrovmLaunchArgs) -> Result<FirecrackerProbe> {
+    FirecrackerProbe::new(args)
+}
+
+#[cfg(not(target_os = "linux"))]
+fn new_firecracker_probe(_args: &MicrovmLaunchArgs) -> Result<LibkrunProbe> {
+    bail!("bench microvm-launch --hypervisor firecracker requires Linux/KVM")
+}
+
+#[cfg(target_os = "macos")]
+fn new_vz_probe(args: &MicrovmLaunchArgs) -> Result<VzProbe> {
+    VzProbe::new(args)
+}
+
+#[cfg(not(target_os = "macos"))]
+fn new_vz_probe(_args: &MicrovmLaunchArgs) -> Result<LibkrunProbe> {
+    bail!("bench microvm-launch --hypervisor vz requires macOS with Vz")
+}
+
+#[cfg(target_os = "linux")]
+fn run_firecracker_launch_distribution(
+    args: &MicrovmLaunchArgs,
+) -> Result<LaunchDistributionReport> {
+    let host = FirecrackerProbe::new(args)?.host_descriptor();
+    run_launch_distribution(host, args.concurrency, args.max_concurrency, |i| {
+        FirecrackerProbe::new_with_prefix_and_warm_pool_size(
+            format!("mvm-bench-fc-c{i}"),
+            args.warm_pool_size,
+        )
+    })
+}
+
+#[cfg(not(target_os = "linux"))]
+fn run_firecracker_launch_distribution(
+    _args: &MicrovmLaunchArgs,
+) -> Result<LaunchDistributionReport> {
+    bail!("bench microvm-launch --hypervisor firecracker requires Linux/KVM")
+}
+
+#[cfg(target_os = "macos")]
+fn run_vz_launch_distribution(args: &MicrovmLaunchArgs) -> Result<LaunchDistributionReport> {
+    let host = VzProbe::new(args)?.host_descriptor();
+    run_launch_distribution(host, args.concurrency, args.max_concurrency, |i| {
+        VzProbe::new_with_prefix(format!("mvm-bench-vz-c{i}"))
+    })
+}
+
+#[cfg(not(target_os = "macos"))]
+fn run_vz_launch_distribution(_args: &MicrovmLaunchArgs) -> Result<LaunchDistributionReport> {
+    bail!("bench microvm-launch --hypervisor vz requires macOS with Vz")
 }
 
 #[cfg(feature = "libkrun-live")]
@@ -904,6 +1577,68 @@ fn run_libkrun_density(_count: u32, _max_count: u32) -> Result<DensityReport> {
          Rebuild with `cargo build -p mvm-cli --features libkrun-live` \
          on a host where libkrun boots."
     )
+}
+
+#[cfg(target_os = "linux")]
+fn run_firecracker_density(count: u32, max_count: u32) -> Result<DensityReport> {
+    let host = FirecrackerProbe::new_with_prefix("mvm-density-fc")?.host_descriptor();
+    let mut held = Vec::with_capacity(count as usize);
+    for i in 0..count {
+        let name = format!("mvm-density-fc-{i}");
+        held.push(
+            boot_firecracker_hold_once(&name, 0).with_context(|| format!("density boot {name}"))?,
+        );
+    }
+    let raw = held
+        .iter()
+        .map(|vm| {
+            Ok(InstanceFootprint {
+                vm_name: vm.vm_name().to_string(),
+                pid: vm.pid(),
+                bytes: read_process_footprint_bytes(vm.pid())?,
+            })
+        })
+        .collect::<Result<Vec<_>>>()?;
+    drop(held);
+    for sample in &raw {
+        assert_firecracker_bench_cleanup(&sample.vm_name)?;
+    }
+    Ok(build_density_report(host, count, max_count, raw))
+}
+
+#[cfg(not(target_os = "linux"))]
+fn run_firecracker_density(_count: u32, _max_count: u32) -> Result<DensityReport> {
+    bail!("bench microvm-density --hypervisor firecracker requires Linux/KVM")
+}
+
+#[cfg(target_os = "macos")]
+fn run_vz_density(count: u32, max_count: u32) -> Result<DensityReport> {
+    let host = VzProbe::new_with_prefix("mvm-density-vz")?.host_descriptor();
+    let mut held = Vec::with_capacity(count as usize);
+    for i in 0..count {
+        let name = format!("mvm-density-vz-{i}");
+        held.push(boot_vz_hold_once(&name).with_context(|| format!("density boot {name}"))?);
+    }
+    let raw = held
+        .iter()
+        .map(|vm| {
+            Ok(InstanceFootprint {
+                vm_name: vm.vm_name().to_string(),
+                pid: vm.pid(),
+                bytes: read_process_footprint_bytes(vm.pid())?,
+            })
+        })
+        .collect::<Result<Vec<_>>>()?;
+    drop(held);
+    for sample in &raw {
+        assert_vz_bench_cleanup(&sample.vm_name)?;
+    }
+    Ok(build_density_report(host, count, max_count, raw))
+}
+
+#[cfg(not(target_os = "macos"))]
+fn run_vz_density(_count: u32, _max_count: u32) -> Result<DensityReport> {
+    bail!("bench microvm-density --hypervisor vz requires macOS with Vz")
 }
 
 #[cfg(test)]
@@ -948,6 +1683,7 @@ mod tests {
             libkrun_version: Some("1.0".to_string()),
             kernel_sha256: Some("deadbeef".to_string()),
             cmdline: Some("root=/dev/vda rw init=/init".to_string()),
+            readiness_boundary: Some("guest-agent-ping".to_string()),
         }
     }
 
@@ -968,6 +1704,7 @@ mod tests {
             concurrency: 1,
             max_concurrency: 64,
             hypervisor: "libkrun".to_string(),
+            warm_pool_size: 0,
             out: None,
             json: false,
             baseline: None,
@@ -1004,6 +1741,93 @@ mod tests {
         assert!(matches!(
             compare_to_baseline(&base, &other, 10.0),
             RegressionVerdict::Incomparable { .. }
+        ));
+    }
+
+    #[test]
+    fn launch_distribution_baseline_compares_concurrency_p95() {
+        let base = build_launch_distribution_report(
+            host("aarch64"),
+            2,
+            vec![
+                IterationTiming {
+                    start_to_pid_ms: 1.0,
+                    pid_to_connect_ms: 0.0,
+                    handshake_ms: 0.0,
+                    total_ready_ms: 100.0,
+                },
+                IterationTiming {
+                    start_to_pid_ms: 1.0,
+                    pid_to_connect_ms: 0.0,
+                    handshake_ms: 0.0,
+                    total_ready_ms: 100.0,
+                },
+            ],
+        );
+        let worse = build_launch_distribution_report(
+            host("aarch64"),
+            2,
+            vec![
+                IterationTiming {
+                    start_to_pid_ms: 1.0,
+                    pid_to_connect_ms: 0.0,
+                    handshake_ms: 0.0,
+                    total_ready_ms: 130.0,
+                },
+                IterationTiming {
+                    start_to_pid_ms: 1.0,
+                    pid_to_connect_ms: 0.0,
+                    handshake_ms: 0.0,
+                    total_ready_ms: 130.0,
+                },
+            ],
+        );
+        assert!(matches!(
+            compare_launch_distribution_to_baseline(&base, &worse, 10.0),
+            RegressionVerdict::Regressed { .. }
+        ));
+    }
+
+    #[test]
+    fn density_baseline_compares_per_instance_bytes() {
+        let baseline = build_density_report(
+            host("aarch64"),
+            2,
+            2,
+            vec![
+                InstanceFootprint {
+                    vm_name: "a".to_string(),
+                    pid: 1,
+                    bytes: 100,
+                },
+                InstanceFootprint {
+                    vm_name: "b".to_string(),
+                    pid: 2,
+                    bytes: 100,
+                },
+            ],
+        );
+        let current = build_density_report(
+            host("aarch64"),
+            2,
+            2,
+            vec![
+                InstanceFootprint {
+                    vm_name: "a".to_string(),
+                    pid: 1,
+                    bytes: 130,
+                },
+                InstanceFootprint {
+                    vm_name: "b".to_string(),
+                    pid: 2,
+                    bytes: 130,
+                },
+            ],
+        );
+
+        assert!(matches!(
+            compare_density_to_baseline(&baseline, &current, 10.0),
+            RegressionVerdict::Regressed { .. }
         ));
     }
 
@@ -1246,6 +2070,8 @@ Pss_Dirty:           128 kB
             hypervisor: "libkrun".to_string(),
             out: None,
             json: false,
+            baseline: None,
+            max_regression_pct: 10.0,
         })
         .unwrap_err();
         assert!(
@@ -1263,12 +2089,48 @@ Pss_Dirty:           128 kB
             hypervisor: "libkrun".to_string(),
             out: None,
             json: false,
+            baseline: None,
+            max_regression_pct: 10.0,
         })
         .unwrap_err();
         assert!(
             err.to_string().contains("libkrun-live"),
             "unexpected error: {err:#}"
         );
+    }
+
+    #[test]
+    fn launch_hypervisor_validation_accepts_firecracker_only_on_linux() {
+        assert!(validate_launch_hypervisor("libkrun").is_ok());
+        let fc = validate_launch_hypervisor("firecracker");
+        if cfg!(target_os = "linux") {
+            assert!(fc.is_ok());
+        } else {
+            assert!(fc.unwrap_err().to_string().contains("Linux/KVM"));
+        }
+        let vz = validate_launch_hypervisor("vz");
+        if cfg!(target_os = "macos") {
+            assert!(vz.is_ok());
+        } else {
+            assert!(vz.unwrap_err().to_string().contains("macOS with Vz"));
+        }
+    }
+
+    #[test]
+    fn density_hypervisor_validation_accepts_firecracker_only_on_linux() {
+        assert!(validate_density_hypervisor("libkrun").is_ok());
+        let fc = validate_density_hypervisor("firecracker");
+        if cfg!(target_os = "linux") {
+            assert!(fc.is_ok());
+        } else {
+            assert!(fc.unwrap_err().to_string().contains("Linux/KVM"));
+        }
+        let vz = validate_density_hypervisor("vz");
+        if cfg!(target_os = "macos") {
+            assert!(vz.is_ok());
+        } else {
+            assert!(vz.unwrap_err().to_string().contains("macOS with Vz"));
+        }
     }
 
     #[test]

--- a/crates/mvm-cli/src/commands/ops/bench.rs
+++ b/crates/mvm-cli/src/commands/ops/bench.rs
@@ -71,8 +71,7 @@ pub(in crate::commands) struct MicrovmLaunchArgs {
     /// Warm standby pool target to request for each measured launch.
     ///
     /// Currently supported for Linux Firecracker launch probes; use
-    /// `0` for a cold baseline and `1` for the Plan 118 warm-claim
-    /// delta proof.
+    /// `0` for a cold baseline and `1` for a warm-claim delta proof.
     #[arg(long, default_value_t = 0)]
     pub warm_pool_size: u32,
     /// Write the JSON report here. Default:

--- a/crates/mvm-cli/src/commands/ops/bench.rs
+++ b/crates/mvm-cli/src/commands/ops/bench.rs
@@ -755,6 +755,7 @@ pub fn read_process_footprint_bytes(_pid: u32) -> Result<u64> {
 /// Persist a guest-monotonic boot timing cross-check beside the bench reports.
 /// The host-clock report remains the regression metric; this sidecar audits the
 /// guest's own phase timing without mixing clock domains.
+#[cfg(any(feature = "libkrun-live", target_os = "macos"))]
 pub(in crate::commands::ops) fn write_boot_timing_sidecar(
     vm_name: &str,
     boot_millis: &mvm_guest::vsock::BootTimingReport,

--- a/crates/mvm-cli/src/commands/ops/bench_probe.rs
+++ b/crates/mvm-cli/src/commands/ops/bench_probe.rs
@@ -52,6 +52,7 @@ pub fn resolve_probe_image() -> Result<ProbeImage> {
 pub fn admit_probe_plan(
     rootfs: &std::path::Path,
     vm_name: &str,
+    backend_name: &str,
     keys_dir: Option<&std::path::Path>,
 ) -> Result<AdmittedPlan> {
     let sha = mvm_core::crypto::image_verify::sha256_file(rootfs)
@@ -59,7 +60,7 @@ pub fn admit_probe_plan(
     let input = SynthesisInput {
         vm_name,
         tenant: Some("bench"),
-        backend_name: "libkrun",
+        backend_name,
         image_name: vm_name,
         image_sha256: &sha,
         image_cosign_bundle: None,
@@ -167,7 +168,7 @@ pub fn boot_hold_once(vm_name: &str) -> Result<HeldProbeVm> {
     let img = resolve_probe_image()?;
     // `None` keys_dir → the real ~/.mvm/keys host signer, so the
     // supervisor's in-process re-verify trusts the plan signature.
-    let admitted = admit_probe_plan(std::path::Path::new(&img.rootfs), vm_name, None)?;
+    let admitted = admit_probe_plan(std::path::Path::new(&img.rootfs), vm_name, "libkrun", None)?;
 
     let mut cfg = VmStartConfig {
         name: vm_name.to_string(),
@@ -185,6 +186,7 @@ pub fn boot_hold_once(vm_name: &str) -> Result<HeldProbeVm> {
 
     let (pid, pid_seen) = wait_for_pid_file(vm_name)?;
     let (connected, ready) = wait_for_ready(vm_name)?;
+    record_boot_timing_report(vm_name)?;
 
     let marks = BootMarks {
         start,
@@ -256,6 +258,16 @@ fn wait_for_ready(vm_name: &str) -> Result<(std::time::Instant, std::time::Insta
     }
 }
 
+/// Record the guest-monotonic boot timing cross-check next to the
+/// bench reports. The host-clock spans remain the regression metric;
+/// this sidecar exists only to audit the guest's own phase timing.
+#[cfg(feature = "libkrun-live")]
+fn record_boot_timing_report(vm_name: &str) -> Result<()> {
+    let report = crate::commands::vm::wait::fetch_readiness(vm_name)
+        .with_context(|| format!("fetching readiness report for {vm_name}"))?;
+    super::bench::write_boot_timing_sidecar(vm_name, &report.boot_millis)
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -287,9 +299,24 @@ mod tests {
         let tmp = tempfile::tempdir().unwrap();
         let rootfs = tmp.path().join("rootfs.ext4");
         std::fs::write(&rootfs, b"not a real rootfs but hashable").unwrap();
-        let admitted = admit_probe_plan(&rootfs, "bench-probe", Some(tmp.path())).unwrap();
+        let admitted =
+            admit_probe_plan(&rootfs, "bench-probe", "libkrun", Some(tmp.path())).unwrap();
         // The admitted plan binds the workload name we passed.
         assert_eq!(admitted.plan.image.name, "bench-probe");
         assert_eq!(admitted.plan.resources.mem_mib, u64::from(PROBE_MEM_MIB));
+    }
+
+    #[test]
+    fn admit_probe_plan_generates_distinct_nonces_per_boot() {
+        let tmp = tempfile::tempdir().unwrap();
+        let rootfs = tmp.path().join("rootfs.ext4");
+        std::fs::write(&rootfs, b"not a real rootfs but hashable").unwrap();
+
+        let first =
+            admit_probe_plan(&rootfs, "bench-probe-a", "firecracker", Some(tmp.path())).unwrap();
+        let second =
+            admit_probe_plan(&rootfs, "bench-probe-b", "firecracker", Some(tmp.path())).unwrap();
+
+        assert_ne!(first.plan.nonce, second.plan.nonce);
     }
 }

--- a/crates/mvm-cli/src/commands/pool.rs
+++ b/crates/mvm-cli/src/commands/pool.rs
@@ -27,6 +27,7 @@ use sha2::{Digest, Sha256};
 use super::Cli;
 use super::env::dev_vz::ensure_default_microvm_image;
 use super::vm::host_signer;
+use super::vm::plan_admission::stash_plan_for_bridge;
 
 /// Lowercase-hex sha256 of a kernel image — part of the base-compat key.
 pub fn kernel_sha256_hex(kernel: &Path) -> Result<String> {
@@ -302,9 +303,11 @@ fn compat_for_launch(
 ///
 /// Eligibility (all required): `warm_pool_size > 0`, the launch is auto-named (no explicit
 /// `--name` — a claimed VM is named by its standby-id), no extra volumes (the attach
-/// threads only the rootfs), the backend supports the pool, and the **admitted plan +
-/// tenant** are threaded into the config — which only the gateway-bridge path
-/// (`MVM_GATEWAY_BRIDGE=1`) does, and which a claimed standby's `run_with_bridge` requires.
+/// threads only the rootfs), the backend supports the pool, and the admitted tenant is
+/// threaded into the config. libkrun/Vz additionally require the signed plan JSON because
+/// their claimed standby enters the gateway-bridge supervisor path; Firecracker can claim
+/// with only the resolved launch config because the default path enforces networking
+/// directly via TAP/nftables and only needs plan JSON when its optional bridge is enabled.
 pub fn try_warm_claim(
     backend: &AnyBackend,
     cfg: &VmStartConfig,
@@ -318,8 +321,13 @@ pub fn try_warm_claim(
     {
         return Ok(None);
     }
-    let (Some(plan_json), Some(tenant)) = (cfg.plan_json.clone(), cfg.tenant_id.clone()) else {
-        // No admitted plan threaded in → not the bridge path → cold-boot.
+    let Some(tenant) = cfg.tenant_id.clone() else {
+        // No admitted tenant threaded in → not an admitted workload → cold-boot.
+        return Ok(None);
+    };
+    let Some(plan_json) = warm_claim_plan_json(backend.as_vm_backend(), cfg) else {
+        // libkrun/Vz claims need a signed envelope for their gateway-bridge
+        // supervisor attach path; without it, cold-boot.
         return Ok(None);
     };
     // Reuse the rootfs sha claim-8 admission already computed (same bytes) so
@@ -327,12 +335,25 @@ pub fn try_warm_claim(
     let want = compat_for_launch(backend.as_vm_backend(), cfg, admitted_image_sha256)?;
     let rootfs = cfg.rootfs_path.clone();
     let bundle_json = cfg.bundle_json.clone();
+    let claim_start_config = cfg.clone();
     let pool = SupervisorStandbyPool::open()?;
     let decision = claim_or_cold(&pool, backend.as_vm_backend(), &want, |handle| {
         // The audit substrate (`gateway-<vm>.sock`) is name-keyed; the claimed VM runs
         // under the standby-id, so compute it for `handle.id`.
         let sub = mvm_backend::audit_substrate::compute_audit_substrate(&handle.id, Some(&tenant))?;
+        let mut start_config = claim_start_config.clone();
+        start_config.name = handle.id.clone();
+        start_config.rootfs_path = rootfs.clone();
+        start_config.tenant_id = Some(tenant.clone());
+        start_config.plan_json = Some(plan_json.clone());
+        start_config.bundle_json = bundle_json.clone();
+        start_config.network_policy = cfg.network_policy.clone();
+        if backend.name() == "firecracker" && !plan_json.is_empty() {
+            stash_plan_for_bridge(&start_config)
+                .with_context(|| format!("stash admitted plan for claimed VM '{}'", handle.id))?;
+        }
         Ok(StandbyClaim {
+            start_config: Some(start_config),
             rootfs_path: rootfs.clone(),
             tenant_id: tenant.clone(),
             audit_dir: sub.audit_dir.context("audit substrate missing audit_dir")?,
@@ -349,6 +370,14 @@ pub fn try_warm_claim(
         LaunchDecision::Claimed(id) => Some(id),
         LaunchDecision::ColdBoot => None,
     })
+}
+
+fn warm_claim_plan_json(backend: &dyn VmBackend, cfg: &VmStartConfig) -> Option<String> {
+    match cfg.plan_json.clone() {
+        Some(plan) => Some(plan),
+        None if backend.name() == "firecracker" => Some(String::new()),
+        None => None,
+    }
 }
 
 /// Top the pool back up toward `cfg.warm_pool_size` after a launch (the no-daemon
@@ -647,6 +676,39 @@ mod tests {
         }
     }
 
+    fn saved_idle_handle(id: &str, kernel: &str, image: &str) -> StandbyHandle {
+        StandbyHandle {
+            id: id.into(),
+            control_socket: format!("/p/{id}/control.sock").into(),
+            pid: 0,
+            kernel_sha256: kernel.into(),
+            vcpus: 2,
+            mem_mib: 1024,
+            binding_nonce: "cd".repeat(32),
+            spawned_unix_secs: 1,
+            state: StandbyState::Idle,
+            image_sha256: Some(image.into()),
+        }
+    }
+
+    #[test]
+    fn build_pool_status_reports_dead_standbys_separately() {
+        let live = idle_handle("live", "aa");
+        let mut dead = idle_handle("dead", "aa");
+        dead.pid = 999_999_999;
+        let saved = saved_idle_handle("saved", "aa", "img");
+
+        let report = build_pool_status(&[live, dead, saved]);
+
+        assert_eq!(report.idle, 2, "live process + saved-state are idle");
+        assert_eq!(report.claimed, 0);
+        assert_eq!(report.parked, 0);
+        assert_eq!(report.dead, 1);
+        assert_eq!(report.standbys[0].state, "idle");
+        assert_eq!(report.standbys[1].state, "dead");
+        assert_eq!(report.standbys[2].state, "idle");
+    }
+
     fn compat(kernel: &str) -> StandbyCompat {
         StandbyCompat {
             kernel_sha256: kernel.into(),
@@ -658,6 +720,7 @@ mod tests {
 
     fn sample_claim() -> StandbyClaim {
         StandbyClaim {
+            start_config: None,
             rootfs_path: "/vol/rootfs.ext4".into(),
             tenant_id: "tenant-a".into(),
             audit_dir: "/audit".into(),
@@ -766,6 +829,26 @@ mod tests {
         let mut c = eligible_cfg();
         c.plan_json = None; // not the gateway-bridge/admitted path → cold-boot
         assert_eq!(try_warm_claim(&b, &c, false, None).unwrap(), None);
+    }
+
+    #[test]
+    fn warm_claim_plan_json_is_optional_for_firecracker_only() {
+        let mut cfg = eligible_cfg();
+        cfg.plan_json = None;
+        let fc = AnyBackend::from_hypervisor("firecracker");
+        let libkrun = AnyBackend::from_hypervisor("libkrun");
+
+        assert_eq!(
+            warm_claim_plan_json(fc.as_vm_backend(), &cfg),
+            Some(String::new())
+        );
+        assert_eq!(warm_claim_plan_json(libkrun.as_vm_backend(), &cfg), None);
+
+        cfg.plan_json = Some("{\"signed\":\"plan\"}".into());
+        assert_eq!(
+            warm_claim_plan_json(libkrun.as_vm_backend(), &cfg),
+            Some("{\"signed\":\"plan\"}".into())
+        );
     }
 
     // A VmBackend stub whose `spawn_standby` always fails — used to exercise
@@ -1184,6 +1267,7 @@ struct PoolStatus {
     idle: usize,
     claimed: usize,
     parked: usize,
+    dead: usize,
     standbys: Vec<PoolStatusEntry>,
 }
 
@@ -1199,29 +1283,40 @@ struct PoolStatusEntry {
     image_sha256: Option<String>,
 }
 
-fn run_status(pool: &SupervisorStandbyPool, json: bool) -> Result<()> {
-    let standbys = pool.list()?;
+fn build_pool_status(standbys: &[StandbyHandle]) -> PoolStatus {
     let idle = standbys
         .iter()
-        .filter(|h| h.state == StandbyState::Idle)
+        .filter(|h| h.state == StandbyState::Idle && SupervisorStandbyPool::is_live_or_saved(h))
         .count();
     let parked = standbys
         .iter()
-        .filter(|h| h.state == StandbyState::Parked)
+        .filter(|h| h.state == StandbyState::Parked && SupervisorStandbyPool::is_live_or_saved(h))
         .count();
-    let claimed = standbys.len() - idle - parked;
-    let report = PoolStatus {
+    let claimed = standbys
+        .iter()
+        .filter(|h| h.state == StandbyState::Claimed && SupervisorStandbyPool::is_live_or_saved(h))
+        .count();
+    let dead = standbys
+        .iter()
+        .filter(|h| !SupervisorStandbyPool::is_live_or_saved(h))
+        .count();
+    PoolStatus {
         idle,
         claimed,
         parked,
+        dead,
         standbys: standbys
             .iter()
             .map(|h| PoolStatusEntry {
                 id: h.id.clone(),
-                state: match h.state {
-                    StandbyState::Idle => "idle",
-                    StandbyState::Claimed => "claimed",
-                    StandbyState::Parked => "parked",
+                state: if SupervisorStandbyPool::is_live_or_saved(h) {
+                    match h.state {
+                        StandbyState::Idle => "idle",
+                        StandbyState::Claimed => "claimed",
+                        StandbyState::Parked => "parked",
+                    }
+                } else {
+                    "dead"
                 },
                 pid: h.pid,
                 kernel_sha256: h.kernel_sha256.clone(),
@@ -1230,12 +1325,20 @@ fn run_status(pool: &SupervisorStandbyPool, json: bool) -> Result<()> {
                 image_sha256: h.image_sha256.clone(),
             })
             .collect(),
-    };
+    }
+}
+
+fn run_status(pool: &SupervisorStandbyPool, json: bool) -> Result<()> {
+    let standbys = pool.list()?;
+    let report = build_pool_status(&standbys);
     if json {
         crate::json_out::emit_json(&report)?;
         return Ok(());
     }
-    println!("Supervisor standby pool: {idle} idle, {claimed} claimed, {parked} parked");
+    println!(
+        "Supervisor standby pool: {} idle, {} claimed, {} parked, {} dead",
+        report.idle, report.claimed, report.parked, report.dead
+    );
     for e in &report.standbys {
         let image_tag = e
             .image_sha256

--- a/crates/mvm-cli/src/commands/vm/mod.rs
+++ b/crates/mvm-cli/src/commands/vm/mod.rs
@@ -33,7 +33,7 @@ pub(super) mod set_ttl;
 pub(super) mod tenant_resolution;
 pub(super) mod up;
 pub(super) mod volume;
-pub(super) mod wait;
+pub(in crate::commands) mod wait;
 
 pub(super) use super::{Cli, shared};
 

--- a/crates/mvm-cli/src/commands/vm/up.rs
+++ b/crates/mvm-cli/src/commands/vm/up.rs
@@ -1338,9 +1338,8 @@ pub(in crate::commands) struct Args {
     pub metrics_port: u16,
     /// Keep this many prelaunched supervisor standbys warm so the next
     /// auto-named `up` claims one instead of cold-booting. Omit to use the
-    /// residency-policy default (`MVM_RESIDENCY`); pass `0` to disable. Only
-    /// the libkrun backend has a standby pool today; a claim uses the
-    /// gateway-bridge path.
+    /// residency-policy default (`MVM_RESIDENCY`); pass `0` to disable.
+    /// Supported by Firecracker, libkrun, and platform-gated Vz.
     #[arg(long)]
     pub warm_pool_size: Option<u32>,
     /// Reload ~/.mvm/config.toml automatically when it changes
@@ -1702,7 +1701,7 @@ pub(in crate::commands) fn run(_cli: &Cli, args: Args, cfg: &MvmConfig) -> Resul
     // `--redact HOST[=audit]`. Empty → all-off (curated-only baseline).
     let redaction = super::redaction_flags::parse_redaction_flags(&args.redact)?;
 
-    cmd_run(RunParams {
+    let launched_vm_id = cmd_run(RunParams {
         flake_ref: args.flake.as_deref(),
         template_name: resolved_template_arg.as_deref(),
         name: args.name.as_deref(),
@@ -1747,9 +1746,7 @@ pub(in crate::commands) fn run(_cli: &Cli, args: Args, cfg: &MvmConfig) -> Resul
     // through to subsequent `proc start` / `fs write` / `down`
     // shells. The friendly chrome already went to stderr above.
     if up_json_resolved {
-        let vm_id = user_supplied_name
-            .or_else(|| std::env::var("MVM_REEXEC_NAME").ok())
-            .unwrap_or_default();
+        let vm_id = user_supplied_name.unwrap_or(launched_vm_id);
         let build_mode_str = match template_name_for_envelope.as_deref() {
             Some(t) => template_build_mode_for_envelope(t).unwrap_or("prod"),
             None => match build_mode {
@@ -1988,7 +1985,7 @@ pub(in crate::commands) fn start_persistent_oci_machine(
     Ok(())
 }
 
-pub(super) fn cmd_run(params: RunParams<'_>) -> Result<()> {
+pub(super) fn cmd_run(params: RunParams<'_>) -> Result<String> {
     let RunParams {
         flake_ref,
         template_name,
@@ -2274,7 +2271,7 @@ pub(super) fn cmd_run(params: RunParams<'_>) -> Result<()> {
         // long-lived CLI process would be redundant). Same shape as
         // the main path's detach branch.
         if detach {
-            return Ok(());
+            return Ok(vm_name.clone());
         }
 
         ui::info(&format!("VM '{}' running. Press Ctrl+C to stop.", vm_name));
@@ -2307,8 +2304,8 @@ pub(super) fn cmd_run(params: RunParams<'_>) -> Result<()> {
                 next_health_poll = std::time::Instant::now() + DEGRADED_POLL_INTERVAL;
             }
         }
-        let _ = backend.stop(&mvm_core::vm_backend::VmId(vm_name));
-        return Ok(());
+        let _ = backend.stop(&mvm_core::vm_backend::VmId(vm_name.clone()));
+        return Ok(vm_name.clone());
     }
 
     // Resolve artifact paths from either a pre-built template or a flake build.
@@ -2804,7 +2801,7 @@ pub(super) fn cmd_run(params: RunParams<'_>) -> Result<()> {
     // (scripting contract) and return without the agent-wait below.
     if detach && effective_hypervisor == "vz" {
         println!("{vm_name_owned}");
-        return Ok(());
+        return Ok(vm_name_owned);
     }
 
     // libkrun / firecracker / vz all launch a detached supervisor daemon,
@@ -2855,7 +2852,8 @@ pub(super) fn cmd_run(params: RunParams<'_>) -> Result<()> {
     // image upstream. The VM keeps running after the shell exits;
     // `mvmctl down <name>` stops it.
     if console {
-        return super::console::console_interactive(&vm_name_owned);
+        super::console::console_interactive(&vm_name_owned)?;
+        return Ok(vm_name_owned);
     }
 
     // Block until the workload powers off and propagate its
@@ -2875,7 +2873,7 @@ pub(super) fn cmd_run(params: RunParams<'_>) -> Result<()> {
         if code != 0 {
             std::process::exit(code);
         }
-        return Ok(());
+        return Ok(vm_name_owned);
     }
 
     if forward {
@@ -2890,11 +2888,11 @@ pub(super) fn cmd_run(params: RunParams<'_>) -> Result<()> {
     if watch {
         let Some(flake) = flake_ref else {
             // Template mode — watch not supported.
-            return Ok(());
+            return Ok(vm_name_owned);
         };
         if flake.contains(':') {
             ui::warn("--watch requires a local flake; running a single boot instead.");
-            return Ok(());
+            return Ok(vm_name_owned);
         }
         let flake_dir = resolve_flake_ref(flake)?;
         loop {
@@ -3083,7 +3081,7 @@ pub(super) fn cmd_run(params: RunParams<'_>) -> Result<()> {
         }
     }
 
-    Ok(())
+    Ok(vm_name_owned)
 }
 
 /// Attach the verity-sealed runtime overlay by

--- a/crates/mvm-cli/src/commands/vm/wait.rs
+++ b/crates/mvm-cli/src/commands/vm/wait.rs
@@ -215,7 +215,7 @@ fn print_timing(label: &str, ms: Option<u64>) {
 
 /// Single readiness round-trip over vsock. Used by `wait`,
 /// `boot-report`, and `up --timings`.
-pub(in crate::commands::vm) fn fetch_readiness(vm_name: &str) -> Result<ReadinessReport> {
+pub(in crate::commands) fn fetch_readiness(vm_name: &str) -> Result<ReadinessReport> {
     let transport: Box<dyn VsockTransport> = vsock_transport::for_vm(vm_name)?;
     let mut stream = transport.connect(GUEST_AGENT_PORT)?;
     let _ = negotiate_protocol(&mut stream, vec![GuestCapability::Readiness])?;

--- a/crates/mvm-cli/src/doctor.rs
+++ b/crates/mvm-cli/src/doctor.rs
@@ -3221,7 +3221,7 @@ mod tests {
         assert_eq!(
             ordered_standby_pool,
             vec![
-                ("firecracker".to_string(), false),
+                ("firecracker".to_string(), true),
                 ("libkrun".to_string(), true),
                 ("qemu".to_string(), false),
                 ("vz".to_string(), vz_standby),
@@ -3232,8 +3232,9 @@ mod tests {
     #[test]
     fn collect_warm_start_support_reports_standby_pool_per_backend() {
         let r = collect_warm_start_support();
-        // libkrun and Vz (on macOS 14+) implement the standby pool; FC and QEMU do not.
-        // Report honest values for every backend; none may be silently dropped.
+        // Firecracker, libkrun, and Vz (on macOS 14+) implement the standby pool;
+        // QEMU does not. Report honest values for every backend; none may be silently dropped.
+        assert_eq!(r.standby_pool.get("firecracker"), Some(&true));
         assert_eq!(r.standby_pool.get("libkrun"), Some(&true));
         let vz_standby = AnyBackend::from_hypervisor("vz").supports_standby_pool();
         assert_eq!(r.standby_pool.get("vz"), Some(&vz_standby));
@@ -3255,7 +3256,10 @@ mod tests {
         assert!(fc.tap_networking, "firecracker uses a host TAP device");
         assert!(fc.vsock);
         assert!(fc.balloon);
-        assert!(!fc.standby_pool);
+        assert!(
+            fc.standby_pool,
+            "Firecracker implements live standby warm-spawn"
+        );
 
         let krun = by("libkrun").unwrap();
         assert_eq!(krun.snapshot_tier, "disk-only");
@@ -3266,7 +3270,7 @@ mod tests {
         assert!(krun.vsock);
         assert!(
             krun.standby_pool,
-            "only libkrun pre-pays spawn latency today"
+            "libkrun still pre-pays spawn latency through the supervisor pool"
         );
 
         let qemu = by("qemu").unwrap();

--- a/crates/mvm-core/src/protocol/vm_backend.rs
+++ b/crates/mvm-core/src/protocol/vm_backend.rs
@@ -674,6 +674,12 @@ impl StandbyState {
 /// signed plan + rootfs + audit substrate). Backend-agnostic.
 #[derive(Debug, Clone)]
 pub struct StandbyClaim {
+    /// Full launch config for backends whose "claim" step must still configure
+    /// machine-local boot devices before starting vCPUs. Firecracker uses this
+    /// to configure a prestarted daemon with the same kernel/initrd/rootfs,
+    /// overlays, policy, ports, and drive files a cold boot would use. Existing
+    /// supervisor-style backends consume the explicit claim fields below.
+    pub start_config: Option<VmStartConfig>,
     /// Workload rootfs ext4.
     pub rootfs_path: String,
     pub tenant_id: String,
@@ -1257,6 +1263,7 @@ mod tests {
 
     fn sample_standby_claim() -> StandbyClaim {
         StandbyClaim {
+            start_config: None,
             rootfs_path: "/vol/rootfs.ext4".into(),
             tenant_id: "tenant-a".into(),
             audit_dir: "/audit".into(),

--- a/specs/REFACTOR-STATUS.md
+++ b/specs/REFACTOR-STATUS.md
@@ -18,6 +18,10 @@
 
 **Additional 2026-06-20 — Plan 175 Task 1 (VMGenID delivery) host/unit landed:** the `PostRestore` resume RPC now carries the host-minted generation token end to end so a snapshot restore actually rotates the guest CSPRNG. `GuestRequest::PostRestore` became a struct variant `{ token: [u8; GENID_BYTES] }` (`#[serde(default)]` → all-zero = "no rotation" for template-restore callers), `PostRestoreAck` gained `reseeded: bool`, and the guest agent feeds the token to a process-resident `GenIdReseeder` (snapshot-captured, baseline-zero seed) via a new zero-aware `on_post_restore_token` dispatch wrapper; `GenIdState::new`/`GenIdReseeder::new` are now `const fn`. Both host senders mint a fresh token per resume (`VsockPostRestoreSignal`, `post_restore_at`); `mvmctl resume` surfaces "VMGenID rotated". Unit-proven (zero-token no-op, fresh-token rotate, idempotent re-send, two-clone divergence, wire round-trip + `deny_unknown_fields` + serde defaults); fmt+clippy clean. Step 3 (live snapshot→restore `/dev/urandom`-divergence assertion) stays gated — it rides Task 4's FC restore driver. T2 (UFFD/NBD/hugepages substrate), T3 (SIGUSR1 primed barrier), and T4 (`FirecrackerBackend::warm_start` + verb + `agent_ping` e2e) remain.
 
+**Additional 2026-06-20 — Plan 118 Firecracker standby pool live:** the non-vz Firecracker standby box is implemented and live-validated. Firecracker now reserves the normal slot at warm-spawn time, prestarts the daemon, records the live standby in `SupervisorStandbyPool`, and claim reuses that slot to configure the admitted launch shape before issuing `InstanceStart`. The `StandbyClaim` in-memory contract carries the original `VmStartConfig` for backends that must configure boot devices at claim time; libkrun/Vz keep consuming the explicit attach fields. `try_warm_claim` remains fail-open but now permits Firecracker claims without bridge-only `plan_json` while preserving libkrun/Vz's signed-plan requirement. `--up-json` now reports the claimed standby id. Remote proof on `rvproxy-firecracker` (2026-06-20): `pool warm 1` produced one live idle standby; `up --detach --warm-pool-size 1 --hypervisor firecracker --up-json` consumed `standby-6a263a7a4233599a`; replenish restored one fresh idle standby.
+
+**Additional 2026-06-20 — Plan 118 Firecracker baselines + mvmd sizing:** committed Firecracker live bench artifacts under `specs/perf/plan-118/`. The reports are `HostDescriptor`-namespaced with `readiness_boundary=firecracker-pid`: single launch P50 `total_ready_ms=1899.851577`, concurrency-2 P95 `total_ready_ms=1273.05340545`, and density count-2 PSS `138852352` bytes total / `69426176` bytes per instance. Follow-up gated runs passed against those baselines: serial launch `-16.27%`, concurrency P95 `-23.13%`, density per-instance PSS `+0.35%`. Warm-pool launch through the bench harness produced P50 `total_ready_ms=803.596724` versus the gated cold P50 `1590.731061` (`49.48%` faster). The bench harness now asserts Firecracker VM cleanup after RAII teardown, remote cleanup proof found no named `mvm-bench-fc*` / `mvm-density-fc*` processes remaining after report capture, and `admit_probe_plan_generates_distinct_nonces_per_boot` covers per-boot nonce distinctness. Guest-agent-ready probes now persist `ReadinessReport.boot_millis` sidecars under `bench/boot-timing-<vm>.json` for BootTiming cross-checks; Firecracker remains fingerprinted as PID-boundary until its proof image exposes guest-agent ping. The Vz bench lane is implemented for serial launch, concurrent launch, and density through the same admitted-plan probe flow with macOS `phys_footprint` sampling and no-leak teardown assertions; live Vz artifacts remain host-gated. The companion mvmd worktree `feat/plan-118-sizing` now reconciles `desired_counts.warm` into fleet-level warm Firecracker instances; this is the real mvmd hook today because mvmd launches Firecracker directly rather than through mvm `VmStartConfig.warm_pool_size`. Final closeout evidence is green: `cargo test --workspace --no-fail-fast`, `cargo clippy --workspace --all-targets -- -D warnings`, and `cargo fmt --all -- --check`.
+
 **Additional 2026-06-19 — Stage 0 bootstrap performance follow-up:** the active branch also addresses the observed `[mvm] Materializing Stage 0 root dir` cold-path latency without overclaiming beyond the measured path. Host-side Stage 0 root materialization now reuses a marker-bound extracted root and prefers native `tar -xJf --strip-components 1` after SHA-256 verification, falling back to the prior pure-Rust extractor if the host tar path is unavailable. Firecracker-host measurement on branch `156391a4` with isolated cache/data dirs: cold builder-image cache miss reached `Fetching Stage 0 bootstrap assets … 0.7s` and `Materializing Stage 0 root dir … 1.7s`; immediate warm rerun reached `Fetching … 0.1s` and `Materializing … 0.1s`. The same host confirmed the current Nix seed contains no `mkfs.ext4`/`mke2fs`, so the branch now adds a host-side libkrun preformat path: when host `mkfs.ext4` is available, `nix-store-stage0-<arch>.img` is populated from the verified RootDir `/nix` before boot and marked with a `.stage0-seed` sidecar; Stage 0 PID 1 can adopt that prepopulated store and write its in-filesystem marker. Bounded libkrun proof on the Firecracker host reached and logged the host prepopulate step (`blocks_4k=16777200`, sparse image plus sidecar written) before the 180s timeout; it did not yet capture an in-guest `stage0-init` adoption line, so full libkrun boot/adoption timing remains gated.
 
 **Additional 2026-06-19 — Plan 193 native-gateway cleanup:** the first cutover cleanup after Plan 199/195 removes the dead mvm-side open-policy slot before splice deletion. `BridgeConfig.policy` and the production `AllowAll` `FlowPolicy` are gone; the four supervisor-bin construction sites no longer pass an ignored policy; tests that need an intentional open gate now use `PlanFlowPolicy::from_network_policy(NetworkPolicy::unrestricted())`. This aligns the code with the already-landed Plan 200 WS-B status and reduces the chance of reintroducing an always-open fallback while Plan 193 deletes the splice. Plan 193 status is corrected: rvproxy R2 is shipped, WS-1.5 scaffold/native enforcement witnesses are in place, and remaining code work is splice/Plan-141 hook deletion plus transparent terminator support; the parity gate is now required as of the 2026-06-20 update below.
@@ -130,7 +134,7 @@ details** below for the workstream-level state.
 - [x] **PLAN 178** — CLI surface consolidation (~56→~28) · ✅ (dir-purity deferred)
 - [x] **PLAN 129** — Secrets / SigV4 substitution · ✅ **COMPLETE** — both tiers (declared substitution incl. SigV4/HMAC bind-checked + undeclared detection), terminator-path + vsock, claim-12/13 leak-gate (claim 16), endpoint self-confines (Landlock+seccomp jailer); QEMU clean-room e2e GREEN; FC bringup fixes landed (#804); live-FC e2e spun out (builder-VM box infra, not plan logic)
 - [x] **PLAN 152** — Rust-native VZ supervisor · ✅ native objc2, Swift deleted; WS-C fork primitive satisfied (snapshot/restore + fork stack), WS-D nested-KVM out-of-scope for vz parity
-- [ ] **PLAN 118** — Supervisor standby pool · 🟡 **vz + libkrun DONE; PR-10c live-gated CLI wired** (saved-standby warm pool live-validated + self-replenish #840 + overshoot flock closed; density/concurrent-launch schemas, platform footprint accessors, `bench microvm-density`, and `bench microvm-launch --concurrency` landed; **default-path Vz warm-claim fixed #1112 / #1101** — the standby kernel is now paired to its rootfs variant, dev↔dev / prod↔prod, so the dev claim's compat key matches and `up --dev` / transient `run` consume the standby instead of silently cold-booting; the earlier "live-validated" only ever exercised the explicit-path claim). Open boxes: the **non-vz** FC standby pool, committed baselines, live no-leak/nonce-distinctness proof, and Vz/FC density lanes.
+- [x] **PLAN 118** — Supervisor standby pool · ✅ **DONE** (saved-standby warm pool live-validated + self-replenish #840 + overshoot flock closed; density/concurrent-launch schemas, platform footprint accessors, `bench microvm-density`, and `bench microvm-launch --concurrency` landed; **default-path Vz warm-claim fixed #1112 / #1101**; **Firecracker standby pool live-validated 2026-06-20** with warm-spawn → claim → replenish and `--up-json` returning the claimed standby id; Firecracker launch/concurrency/density proof JSON and gated reruns live under `specs/perf/plan-118/`; guest-agent-ready probes write BootTiming sidecars; Vz serial/concurrency/density bench lane is implemented and compiled; mvmd `desired_counts.warm` sizing lives in companion branch `feat/plan-118-sizing`; final aggregate `cargo test --workspace --no-fail-fast`, workspace clippy, and fmt gates are green).
 - [x] **PLAN 159** — vz-inspired macOS VZ DX · ✅ **DONE** — VZ/macOS scope shipped (warm pool, checkpoint/fork/diff, two-copy + instant memory fork, live Vz validation); non-VZ residuals closed by scope decision: verb/install/product polish rehomed to Plan 181 / Plan 200, signed delta-image distribution descoped until a future artifact/distribution plan owns it
 - [x] **PLAN 123** — Network / storage / warm-start · ✅ **DONE** — Phase A/B done; C1/C4 done; C3 (Vz save/restore) MET via 159 WS-2; the lone residual, C2 (FC live-memory), is carved to **Plan 175** (live-KVM-gated), not a 123 box
 - [x] **PLAN 124** — Lean guest agent · ✅ **core complete** — full D1.2 RPC thread landed (stubs + check-stubs gate + 2a contract + 2b client + 2c adoption); D1.3 SDK veneer → Plan 125; Phase E signed config-on-device DESCOPED (baked + verity-sealed, no vsock round-trip); the residual KVM-live-verity / libkrun-Vz overlay-attach / no_std items are explicit **own-efforts**, rehomed out of 124 scope
@@ -384,7 +388,7 @@ PLAN 159 — vz-inspired macOS VZ DX               ✅ DONE
   [x] instant memory fork: vm_full fork of a RUNNING parent → second live VM in
       0.91s incl. claim-8 admission (same-identity clone model; recorded-sha admission; gvproxy-only invariant) (#833)
 
-PLAN 118 — Supervisor standby pool              🟡 libkrun + Vz done; FC follow-up open
+PLAN 118 — Supervisor standby pool              🟡 pool done; FC baselines gated; Vz lane implemented
   [x] 1a primitive + 1b-i trait seam/registry/libkrun + 1b-ii reaper/doctor/`mvmctl pool`
       /bench-fix + 1b-iii up auto-claim (try_warm_claim/replenish/--warm-pool-size,
       fail-open) + bundled-kernel compat key — libkrun mkGuest warm claim FIRES
@@ -419,20 +423,33 @@ PLAN 118 — Supervisor standby pool              🟡 libkrun + Vz done; FC fol
       bytes — verified), so the compat match is unchanged; libkrun stays
       image-agnostic. Chosen over coupling to the WS-2 fingerprint (would weaken
       claim-8 byte-identity + tie pool.rs to dev_vz.rs). Live: claim still fires.
-  [ ] Firecracker standby pool (the mvmd-facing deliverable) — gated on FC standby
-      follow-up; not blocking current libkrun/Vz use
-  [ ] Part C / PR-10c — density + concurrent-launch distribution bench (🟡 in progress,
+  [x] Plan 118 closeout cleanup: `pool status` now reports dead non-saved
+      standbys separately instead of showing them as idle, while Vz saved-state
+      standbys remain live without a pid; the libkrun supervisor audit-substrate
+      signing-key prefix check already routes through `mvm_core::config::mvm_keys_dir()`
+      so `MVM_DATA_DIR` isolation is honored.
+  [x] Firecracker standby pool (the mvmd-facing deliverable) — live-validated on
+      `rvproxy-firecracker` 2026-06-20: warm-spawn reserved the normal slot,
+      claim configured the admitted launch shape, `InstanceStart` booted from
+      the standby, `--up-json` returned the claimed standby id, and replenish
+      restored target capacity.
+  [x] Part C / PR-10c — density + concurrent-launch distribution bench (code/proof slice,
       added 2026-06-16). Extends Part A's probe to two new metrics: per-instance host
       footprint (`bench microvm-density`, platform-split PSS/phys_footprint accessor)
       and launch P50/P95/P99 under concurrency (`bench microvm-launch --concurrency N`).
       libkrun live-gated CLI wiring, platform accessors, concurrency orchestration,
-      and cap tests are landed. libkrun → Vz → FC baselines remain staged. Read-only;
+      and cap tests are landed. Firecracker baselines are committed under
+      `specs/perf/plan-118/` with `readiness_boundary=firecracker-pid`, the serial /
+      concurrency / density baseline gates pass, and warm-pool launch is 49.48% faster
+      than the gated cold run. Vz serial/concurrency/density harness lanes are
+      implemented through the same admitted-plan flow with BootTiming sidecars and
+      no-leak teardown assertions; live Vz artifacts remain host-gated. Read-only;
       every boot still goes through claim-8 admission (no bypass), no new
-      key/daemon/socket, `libkrun-live`-gated → zero new attack surface. Closes the
+      key/daemon/socket, backend-gated → zero new attack surface. Closes the
       no-published-numbers gap surfaced by external prior art
       (`specs/notes/external-agent-sandbox-runtime-prior-art.md`); proves the warm pool's
-      payoff. Inherits Part A's blocker (needs a freshly-built default-microvm image for
-      committed baselines); live no-leak/nonce-distinctness proof plus Vz/FC lanes remain.
+      payoff for Firecracker. Inherits Part A's libkrun blocker only for a
+      guest-agent-ready libkrun baseline image.
 
 PLAN 183 — Builder-VM egress posture + net boot ✅ DONE (follow-ups tracked in plan)
   Last updated: 2026-06-15 (ALL deferred items now CLOSED: DHCP belt-and-suspenders

--- a/specs/SPRINT.md
+++ b/specs/SPRINT.md
@@ -135,6 +135,29 @@ plan 25 sequences the work into six independently-shippable workstreams.
       `Kernel doesn't fit in RAM` loader panic to guest readiness: the
       default image still never exposes `vsock-5252.sock`, with an empty
       console log, so committed launch/density baselines remain open.
+- [x] Captured Plan 118 Firecracker bench baselines on the remote KVM
+      host and committed the proof under `specs/perf/plan-118/`: single
+      launch P50 `total_ready_ms=1899.851577`, concurrency-2 P95
+      `total_ready_ms=1273.05340545`, and density count-2 PSS
+      `138852352` bytes total / `69426176` bytes per instance. The
+      reports fingerprint `readiness_boundary=firecracker-pid` because
+      the current proof image boots but does not expose guest-agent ping.
+- [x] Closed the Plan 118 Firecracker proof/baseline gaps: serial
+      launch, concurrency-2 launch, and density count-2 all pass their
+      committed-baseline regression gates; `--warm-pool-size 1`
+      produced P50 `total_ready_ms=803.596724` versus the gated cold
+      P50 `1590.731061` (`49.48%` faster); the bench harness now
+      asserts Firecracker VM cleanup after RAII teardown; and
+      `admit_probe_plan_generates_distinct_nonces_per_boot` proves
+      per-boot plan nonce distinctness.
+- [x] Started and wired the remaining Plan 118 Vz/BootTiming closeout:
+      guest-agent-ready probes now write `ReadinessReport.boot_millis`
+      sidecars under `bench/boot-timing-<vm>.json`, and the bench
+      harness accepts `--hypervisor vz` for serial launch,
+      `--concurrency`, and density using the admitted-plan probe path,
+      macOS `phys_footprint` sampling, guest-agent readiness boundary,
+      and no-leak teardown assertions. Live Vz report capture remains
+      host-gated; the harness lane is compiled/tested in `mvm-cli`.
 - [x] Advanced
       [`plans/118-supervisor-standby-pool-and-live-bench.md`](plans/118-supervisor-standby-pool-and-live-bench.md)
       PR-10c beyond the pure substrate: `mvmctl bench microvm-density`
@@ -144,8 +167,15 @@ plan 25 sequences the work into six independently-shippable workstreams.
       platform footprint sampling is split by host (`smaps_rollup` PSS
       on Linux, `proc_pid_rusage` `phys_footprint` on macOS). Stock
       binaries still fail honestly without `libkrun-live`; live
-      baselines remain blocked on rebuilding the stale default-microvm
-      image, and Vz/FC lanes remain open.
+      libkrun guest-agent-ready baselines remain blocked on rebuilding
+      the stale default-microvm image; the Vz serial/concurrency/density
+      harness lane is now implemented and compiled.
+- [x] Started the companion mvmd Plan 118 sizing hook in
+      `../.worktrees/mvmd-plan-118-sizing`: `desired_counts.warm` now
+      plans fleet-level warm Firecracker instances in mvmd's real
+      lifecycle layer. This is the reachable mvmd hook today because
+      mvmd launches Firecracker directly instead of passing through
+      mvm `VmStartConfig.warm_pool_size`.
 - [x] Implemented the first pure-substrate slice of
       [`plans/118-supervisor-standby-pool-and-live-bench.md`](plans/118-supervisor-standby-pool-and-live-bench.md)
       PR-10c: `mvm-cli` now has density and concurrent-launch report shapes
@@ -2931,7 +2961,7 @@ Phase 1 host cross-compile targets **`<arch>-unknown-linux-musl` static**, not g
 
 ### Workstream breakdown (PR chain)
 - [x] **PR-1 — bench harness** `mvmctl bench microvm-launch` (Phase 2 Lever 0; everything measurable hangs off it; libkrun-only in v1; must drive real plan admission). Measurement substrate landed + unit-tested.
-- [~] **PR-10a — live bench probe** (Phase 2 Lever 0 follow-up; [`plans/119-live-bench-probe-impl-plan.md`](plans/119-live-bench-probe-impl-plan.md)). Landed: `LibkrunProbe::measure_once` now boots the canonical default-microvm image through the real `admit_for_run` path (`bench_probe::boot_measure_once`), times four `BootMarks` spans, polls vsock readiness, tears down; `libkrun-live` feature-gated (stock CI skips — hosted macOS runners lack HVF nested virt); `HostDescriptor` carries kernel sha + cmdline. Validated end-to-end on the dev host through `backend.start`. **Blocked:** committed baseline JSON needs a freshly-built default-microvm image — the cached one is stale (predates W1.4b runtime-overlay sidecar) so `backend.start` refuses it. Deferred: `BootTimingReport` guest-monotonic cross-check (v1 reads readiness via atomic `ping`).
+- [x] **PR-10a — live bench probe** (Phase 2 Lever 0 follow-up; [`plans/119-live-bench-probe-impl-plan.md`](plans/119-live-bench-probe-impl-plan.md)). Landed: `LibkrunProbe::measure_once` boots the canonical default-microvm image through the real `admit_for_run` path (`bench_probe::boot_measure_once`), times four `BootMarks` spans, polls vsock readiness, tears down; `HostDescriptor` carries kernel sha + cmdline + readiness boundary; guest-agent-ready probes write `ReadinessReport.boot_millis` sidecars for BootTiming cross-checks. Firecracker now has committed baseline JSON under `specs/perf/plan-118/` with `readiness_boundary=firecracker-pid`. The libkrun guest-agent-ready baseline remains image-gated, not a Plan 118 harness blocker.
 - [x] **PR-2 — `LocalAuditKind::VendorBlobFetched`** (Phase 3; additive observability foundation).
 - [x] **PR-3 — `cache info` / `doctor` enrichment + Stage 0 progress** (Phase 3 observability). Deferred: doctor next-run HIT/MISS fingerprint + docs (Item 5).
 - [ ] ~~**PR-4 — dev-shell split** `dev-minimal`/`dev-compile`~~ **SUPERSEDED by [ADR-064](adrs/065-single-builder-dev-image.md)** (landed on `main` 2026-05-29): single `builder-vm` flake with `default`/`dev` attrs, not a dev-image split.
@@ -2941,24 +2971,24 @@ Phase 1 host cross-compile targets **`<arch>-unknown-linux-musl` static**, not g
 - [ ] ~~**PR-8 — `/nix` warm-reuse contract**~~ re-scoped under ADR-064's single-flake model.
 - [ ] **Phase 1 re-plan** — implement [ADR-064](adrs/065-single-builder-dev-image.md) as the new Phase 1, coordinated with the `specs/prompts/93-phase-1-2-3-fast-secure-dev.md` track (do not race it).
 - [~] **PR-9 — adaptive readiness poll** (Phase 2 Lever 2). Landed: `adaptive_backoff` + `wait_for_guest_agent` rewired (20ms→500ms cap; cuts up to ~480ms dead time per readiness detection; timing-only, connect→negotiate ordering untouched). Deferred (tracked): the `connect_and_authenticate` combiner and the guest `socket/bind/listen`-first reorder — both touch the sealed-prod Ed25519 auth path / agent main and need a live VM to validate.
-- [ ] **PR-10 — warm pool of supervisors** `--warm-pool-size N` default 0 (Phase 2 Lever 3; guests unbooted until admission; control UDS reuses `deny_unknown_fields` parser + new fuzz target).
-- [ ] **PR-10c — density + concurrent-launch distribution bench** (🟡 in progress; [`plans/118-supervisor-standby-pool-and-live-bench.md`](plans/118-supervisor-standby-pool-and-live-bench.md) §"Part C"). Extends PR-10a's probe to two metrics the warm pools exist to move: per-instance host footprint (`bench microvm-density --count K --max-count M`, platform-split PSS / `phys_footprint` accessor) and launch P50/P95/P99 under concurrency (`bench microvm-launch --concurrency N`). libkrun live CLI wiring, platform accessors, concurrency distribution, and cap tests are in place; libkrun → Vz → FC baselines are still staged. Read-only; every boot still routes through claim-8 admission (no bypass); no new key/daemon/socket; `libkrun-live`-gated → zero new attack surface. Motivation + rejected alternatives (OpenResty egress gateway, eBPF enforcer, forked VMM, E2B→mvmd) recorded in [`notes/external-agent-sandbox-runtime-prior-art.md`](notes/external-agent-sandbox-runtime-prior-art.md). Inherits PR-10a's blocker for committed baselines (needs a freshly-built default-microvm image).
+- [x] **PR-10 — warm pool of supervisors** `--warm-pool-size N` default 0 (Phase 2 Lever 3; guests unbooted until admission). libkrun, Vz saved-standby, and Linux/KVM Firecracker standby are implemented; Firecracker live proof captures warm-spawn → claim → replenish and `--up-json` returning the claimed standby id. The companion mvmd worktree reconciles `desired_counts.warm` into fleet-level warm Firecracker instances.
+- [x] **PR-10c — density + concurrent-launch distribution bench** ([`plans/118-supervisor-standby-pool-and-live-bench.md`](plans/118-supervisor-standby-pool-and-live-bench.md) §"Part C"). Extends PR-10a's probe to per-instance host footprint (`bench microvm-density --count K --max-count M`, platform-split PSS / `phys_footprint` accessor) and launch P50/P95/P99 under concurrency (`bench microvm-launch --concurrency N`). Firecracker has committed launch/concurrency/density baselines plus gated reruns under `specs/perf/plan-118/`; Vz serial/concurrency/density harness lanes are implemented through the same admitted-plan flow with no-leak assertions; every boot still routes through claim-8 admission (no bypass); no new key/daemon/socket.
 
 ### Deferred (tracked in Plan 93 §deferred follow-ups)
 - [ ] Phase 2 Lever 1 kernel cmdline trim — gated on Plan 92/95 merge (plumbing + override allowlist land now).
 - [ ] Phase 2 Lever 4 VMM balloon — blocked on libkrun upstream balloon C API.
-- [ ] Vz + Firecracker/Linux coverage for the bind-mount and the launch bench.
-- [ ] **Rebuild the cached `default-microvm` image** — shared blocker for committed bench baselines. The dev-host cache predates the W1.4b runtime-overlay / `mvm-meta.json` sidecar, so `backend.start` correctly refuses it; this blocks **both** PR-10a's baseline JSON and PR-10c's footprint/latency baselines. Pure substrate for both lands VM-free without it; the committed live numbers do not. Unblocks two boxes at once.
+- [x] Vz + Firecracker/Linux coverage for the launch bench. Firecracker is live-proven and baseline-gated on the KVM host; Vz serial/concurrency/density harness lanes compile and are host-gated for live artifact capture.
+- [ ] **Rebuild the cached `default-microvm` image** — remaining blocker for the libkrun guest-agent-ready baseline only. Firecracker has committed PID-boundary baselines; Vz harness lanes are implemented but live Vz artifacts are host-gated.
 
 ### Sprint 59 success criteria
-- [ ] `mvmctl bench microvm-launch` produces a versioned JSON report + regression-gates against a baseline.
+- [x] Firecracker `mvmctl bench microvm-launch` produces a versioned JSON report + regression-gates against a baseline.
 - [ ] Edit to a guest crate reaches the running dev shell in <10 s via `dev compile` with no VM rebuild ("no LONG dev cycles").
 - [ ] `dev up` boots `dev-minimal` by default; `dev up --compile` boots `dev-compile`.
 - [ ] Reproducibility CI lane is byte-identical across two `macos-14` runners.
-- [ ] PRs 9–10 show measured handshake / process-spawn deltas (sub-200 ms headline itself gated on Plan 92/95).
-- [ ] PR-10c emits `HostDescriptor`-namespaced, regression-gated baselines for per-instance host footprint and P50/P95/P99 launch latency (libkrun + Vz), every boot through claim-8 admission, so the warm pool's payoff and our footprint/latency posture rest on committed numbers — not assertion.
+- [x] PRs 9–10 show measured handshake / process-spawn deltas (sub-200 ms headline itself gated on Plan 92/95); Firecracker warm-pool launch is `49.48%` faster than the gated cold run.
+- [x] PR-10c emits Firecracker `HostDescriptor`-namespaced, regression-gated baselines for per-instance host footprint and P50/P95/P99 launch latency, every boot through claim-8 admission, so the warm pool's payoff and our Firecracker footprint/latency posture rest on committed numbers — not assertion. Vz/libkrun guest-agent-ready artifacts remain host/image-gated follow-ons.
 - [ ] `doctor` / `cache info` explain Stage 0 hit/miss without grepping the audit log; `vendor_blob_fetched` audited.
-- [ ] No security regression: admission + Ed25519 auth + TSI refusal + control-socket frame rejection covered by negative-path tests; `cargo test --workspace` green; `cargo clippy --workspace --all-targets -- -D warnings` clean.
+- [x] No security regression: admission + Ed25519 auth + TSI refusal + control-socket frame rejection covered by negative-path tests; closeout gates are green (`cargo test --workspace --no-fail-fast`, `cargo clippy --workspace --all-targets -- -D warnings`, `cargo fmt --all -- --check`).
 
 ### Non-goals (explicit)
 - `--prod` admission policy (lives in mvmd).
@@ -3316,31 +3346,25 @@ Tracked as GitHub issues so they're individually grabbable:
 1a (#748) + 1b-i (#751, mechanism) + 1b-ii (reaper + doctor column + `mvmctl pool
 warm/status` + bench state-dir fix) shipped. Remaining, individually grabbable:
 
-- [ ] **`up`/`run` auto-claim wiring.** `claim_or_cold` is closure-ready (it builds the
-  `StandbyClaim` per the selected standby so the name-keyed audit substrate
-  `gateway-<vm>.sock` resolves for the standby-id). The wiring is held back on two
-  coupled items: (a) a claimed VM runs under its **standby-id** (its vsock socket dir is
-  baked at spawn), so `up.rs` must rebind the ~40 downstream `vm_name` references for a
-  warm launch — risky surgery in the core command; (b) a claim forces the supervisor's
-  **`run_with_bridge`** path (the attach carries tenant+plan+audit), which `up.rs:~1906`
-  documents as not-working-by-default on libkrun ("gvproxy vfkit socket empty") — though
-  that comment predates Plan 123 Phase A (#727/#647) wiring egress policy *live* on the
-  libkrun bridge, so it may be stale. **First step: confirm a libkrun bridge-path boot
-  works end-to-end** (run the `#[ignore]`'d `valid_attach_boots_and_agent_reachable`), then
-  do the name-rebind. Until then `up` always cold-boots; `mvmctl pool warm` pre-spawns
-  standbys but nothing auto-claims them.
-- [ ] **`--warm-pool-size` flag on `up`** (threads to `VmStartConfig.warm_pool_size` +
-  replenish-on-use) — lands with the auto-claim, since replenish without claim only
-  accumulates unclaimed standbys.
+- [x] **`up`/`run` auto-claim wiring.** `try_warm_claim` now claims compatible
+  auto-named, volume-less launches, rebinds downstream VM identity to the standby id,
+  and fails open to cold boot when no compatible standby exists. libkrun/Vz still require
+  signed plan JSON for their supervisor attach path; Firecracker can claim without
+  bridge-only plan JSON because its default path enforces the resolved network policy
+  directly through TAP/nftables.
+- [x] **`--warm-pool-size` flag on `up`** (threads to `VmStartConfig.warm_pool_size` +
+  replenish-on-use). Firecracker live proof also fixed `--up-json` to emit the claimed
+  standby id instead of the original auto-name.
 - [ ] **Multi-kernel pool keying.** v1 is default-kernel + default-resources only
   (`StandbyCompat` = kernel sha256 + vcpus + mem; non-matching launches cold-boot).
   Generalize to per-(kernel,shape) targets + eviction once a second shape is common.
 - [ ] **Honour an explicit `--name` / extra `--volume`s for warm launches.** v1 only
   claims for auto-named, volume-less launches (1a's attach threads only the rootfs; a
   claimed VM is named by standby-id).
-- [ ] **Committed bench baseline + cold-vs-warm delta.** The state-dir fix unblocks the
-  probe; a real baseline still needs a freshly-built `default-microvm` image (rides
-  PR-10a's deferral).
+- [x] **Committed bench baseline + cold-vs-warm delta.** Firecracker launch,
+  concurrent-launch, density, gated-rerun, and warm-pool delta artifacts are committed
+  under `specs/perf/plan-118/`; the remaining freshly-built `default-microvm` image
+  work is only for the libkrun guest-agent-ready baseline, not Plan 118 closeout.
 
 #### Plan 118 WS-1 1b auto-claim — live validation findings (2026-06-10)
 
@@ -3361,12 +3385,18 @@ broken" comment is STALE — `run_with_bridge` boots end-to-end today). Two real
   independent standby), computed identically at claim + replenish. (3) the 30-min standby
   timeout (#757). Plus standby stderr is captured to `<pool>/<id>/standby.stderr.log`.
   Live-validated: a second `up --warm-pool-size 1` prints "Claimed a warm standby …".
-- [ ] **`pool status` lists dead-but-unreaped standbys as "idle"** (it shows recorded
-  state, not liveness). Cosmetic — `select_idle_compatible` correctly skips dead pids;
-  filter the display by `pid_alive` for accuracy.
-- [ ] Independent bug: `libkrun_sys::home_mvm_keys_dir()` hardcodes `$HOME/.mvm/keys` and
-  ignores `MVM_DATA_DIR`, so `validate_audit_substrate` rejects an isolated data dir. Route
-  it through `mvm_core::config`.
+- [x] **`pool status` lists dead-but-unreaped standbys as "idle"** — fixed in Plan 118
+  closeout: status now uses the same pool liveness distinction as claim/replenish, reports
+  dead non-saved standbys separately, and keeps Vz saved-state standbys live without a pid.
+- [x] Independent bug: `libkrun_sys::home_mvm_keys_dir()` hardcoded `$HOME/.mvm/keys` and
+  ignored `MVM_DATA_DIR`; `validate_audit_substrate` now routes the signing-key prefix
+  through `mvm_core::config::mvm_keys_dir()`, matching worktree data-dir isolation.
+- [x] **Firecracker standby pool live.** Firecracker now prestarts a daemon in a reserved
+  slot, claims by configuring the same launch shape a cold boot would use, then issues
+  `InstanceStart`; `--up-json` now returns the claimed standby id rather than the original
+  auto-name. Live on `rvproxy-firecracker` (2026-06-20): `pool warm 1` produced one idle
+  live standby; `up --detach --warm-pool-size 1 --hypervisor firecracker --up-json` consumed
+  `standby-6a263a7a4233599a`; replenish restored the pool to one fresh idle standby.
 
 ### Plan 118 WS-1 — Vz saved-standby warm pool (item 3) — DONE
 

--- a/specs/perf/plan-118/README.md
+++ b/specs/perf/plan-118/README.md
@@ -1,0 +1,34 @@
+# Plan 118 Firecracker Bench Proof
+
+Captured on 2026-06-20 on the remote Linux/KVM Firecracker host.
+
+These reports use `readiness_boundary = "firecracker-pid"` because the
+current Linux proof image boots under Firecracker but does not expose
+the guest-agent ping endpoint. The host descriptor includes this
+boundary so these baselines do not compare against guest-agent-ready
+libkrun/Vz reports.
+
+Reports:
+
+- `microvm-launch-firecracker.json`: one cold launch, P50
+  `total_ready_ms = 1899.851577`.
+- `microvm-launch-firecracker-gated.json`: one cold launch rerun
+  against the committed baseline, P50 `total_ready_ms = 1590.731061`;
+  baseline gate passed at `-16.27%`.
+- `microvm-launch-firecracker-warm-pool.json`: one launch with
+  `--warm-pool-size 1`, P50 `total_ready_ms = 803.596724`; this is
+  `49.48%` faster than the gated cold run.
+- `microvm-launch-firecracker-concurrent.json`: concurrency 2,
+  P95 `total_ready_ms = 1273.05340545`.
+- `microvm-launch-firecracker-concurrent-gated.json`: concurrency 2
+  rerun against the committed baseline, P95
+  `total_ready_ms = 978.58636765`; baseline gate passed at `-23.13%`.
+- `microvm-density-firecracker.json`: count 2, total PSS
+  `138852352` bytes, per-instance PSS `69426176` bytes.
+- `microvm-density-firecracker-gated.json`: count 2 rerun against the
+  committed density baseline, total PSS `139343872` bytes,
+  per-instance PSS `69671936` bytes; baseline gate passed at `+0.35%`.
+
+Cleanup proof: after launch/concurrency/density report capture,
+`pgrep -af "mvm-bench-fc|mvm-density-fc"` returned no matching VM
+processes other than the `pgrep` command itself.

--- a/specs/perf/plan-118/microvm-density-firecracker-gated.json
+++ b/specs/perf/plan-118/microvm-density-firecracker-gated.json
@@ -1,0 +1,33 @@
+{
+  "schema_version": 1,
+  "host": {
+    "os": "linux",
+    "arch": "x86_64",
+    "hypervisor": "firecracker",
+    "libkrun_version": null,
+    "kernel_sha256": "f78cd547954abef8730a60ca3b8df92458d8484653c559f1121526519219c306",
+    "cmdline": "console=ttyS0 reboot=k panic=1 net.ifnames=0 ip=<per-slot>",
+    "readiness_boundary": "firecracker-pid"
+  },
+  "count": 2,
+  "max_count": 2,
+  "stats": {
+    "instances": 2,
+    "total_bytes": 139343872,
+    "per_instance_bytes": 69671936,
+    "min_instance_bytes": 50850816,
+    "max_instance_bytes": 88493056
+  },
+  "raw": [
+    {
+      "vm_name": "mvm-density-fc-0",
+      "pid": 987739,
+      "bytes": 88493056
+    },
+    {
+      "vm_name": "mvm-density-fc-1",
+      "pid": 987950,
+      "bytes": 50850816
+    }
+  ]
+}

--- a/specs/perf/plan-118/microvm-density-firecracker.json
+++ b/specs/perf/plan-118/microvm-density-firecracker.json
@@ -1,0 +1,33 @@
+{
+  "schema_version": 1,
+  "host": {
+    "os": "linux",
+    "arch": "x86_64",
+    "hypervisor": "firecracker",
+    "libkrun_version": null,
+    "kernel_sha256": "f78cd547954abef8730a60ca3b8df92458d8484653c559f1121526519219c306",
+    "cmdline": "console=ttyS0 reboot=k panic=1 net.ifnames=0 ip=<per-slot>",
+    "readiness_boundary": "firecracker-pid"
+  },
+  "count": 2,
+  "max_count": 2,
+  "stats": {
+    "instances": 2,
+    "total_bytes": 138852352,
+    "per_instance_bytes": 69426176,
+    "min_instance_bytes": 46388224,
+    "max_instance_bytes": 92464128
+  },
+  "raw": [
+    {
+      "vm_name": "mvm-density-fc-0",
+      "pid": 967538,
+      "bytes": 92464128
+    },
+    {
+      "vm_name": "mvm-density-fc-1",
+      "pid": 967754,
+      "bytes": 46388224
+    }
+  ]
+}

--- a/specs/perf/plan-118/microvm-launch-firecracker-concurrent-gated.json
+++ b/specs/perf/plan-118/microvm-launch-firecracker-concurrent-gated.json
@@ -1,0 +1,68 @@
+{
+  "schema_version": 1,
+  "host": {
+    "os": "linux",
+    "arch": "x86_64",
+    "hypervisor": "firecracker",
+    "libkrun_version": null,
+    "kernel_sha256": "f78cd547954abef8730a60ca3b8df92458d8484653c559f1121526519219c306",
+    "cmdline": "console=ttyS0 reboot=k panic=1 net.ifnames=0 ip=<per-slot>",
+    "readiness_boundary": "firecracker-pid"
+  },
+  "concurrency": 2,
+  "start_to_pid_ms": {
+    "min": 975.682173,
+    "p50": 977.2106965,
+    "p90": 978.4335153000001,
+    "p99": 978.70864953,
+    "max": 978.73922,
+    "mean": 977.2106965,
+    "stddev": 1.5285235000000057
+  },
+  "pid_to_connect_ms": {
+    "min": 0.0,
+    "p50": 0.0,
+    "p90": 0.0,
+    "p99": 0.0,
+    "max": 0.0,
+    "mean": 0.0,
+    "stddev": 0.0
+  },
+  "handshake_ms": {
+    "min": 0.0,
+    "p50": 0.0,
+    "p90": 0.0,
+    "p99": 0.0,
+    "max": 0.0,
+    "mean": 0.0,
+    "stddev": 0.0
+  },
+  "total_ready_ms": {
+    "min": 975.682173,
+    "p50": 977.2106965,
+    "p90": 978.4335153000001,
+    "p99": 978.70864953,
+    "max": 978.73922,
+    "mean": 977.2106965,
+    "stddev": 1.5285235000000057
+  },
+  "total_ready_tail_ms": {
+    "p50": 977.2106965,
+    "p95": 978.58636765,
+    "p99": 978.70864953
+  },
+  "raw": [
+    {
+      "start_to_pid_ms": 975.682173,
+      "pid_to_connect_ms": 0.0,
+      "handshake_ms": 0.0,
+      "total_ready_ms": 975.682173
+    },
+    {
+      "start_to_pid_ms": 978.73922,
+      "pid_to_connect_ms": 0.0,
+      "handshake_ms": 0.0,
+      "total_ready_ms": 978.73922
+    }
+  ]
+}

--- a/specs/perf/plan-118/microvm-launch-firecracker-concurrent.json
+++ b/specs/perf/plan-118/microvm-launch-firecracker-concurrent.json
@@ -1,0 +1,68 @@
+{
+  "schema_version": 1,
+  "host": {
+    "os": "linux",
+    "arch": "x86_64",
+    "hypervisor": "firecracker",
+    "libkrun_version": null,
+    "kernel_sha256": "f78cd547954abef8730a60ca3b8df92458d8484653c559f1121526519219c306",
+    "cmdline": "console=ttyS0 reboot=k panic=1 net.ifnames=0 ip=<per-slot>",
+    "readiness_boundary": "firecracker-pid"
+  },
+  "concurrency": 2,
+  "start_to_pid_ms": {
+    "min": 1248.33392,
+    "p50": 1261.3441755,
+    "p90": 1271.7523799,
+    "p99": 1274.09422589,
+    "max": 1274.354431,
+    "mean": 1261.3441755,
+    "stddev": 13.010255499999971
+  },
+  "pid_to_connect_ms": {
+    "min": 0.0,
+    "p50": 0.0,
+    "p90": 0.0,
+    "p99": 0.0,
+    "max": 0.0,
+    "mean": 0.0,
+    "stddev": 0.0
+  },
+  "handshake_ms": {
+    "min": 0.0,
+    "p50": 0.0,
+    "p90": 0.0,
+    "p99": 0.0,
+    "max": 0.0,
+    "mean": 0.0,
+    "stddev": 0.0
+  },
+  "total_ready_ms": {
+    "min": 1248.33392,
+    "p50": 1261.3441755,
+    "p90": 1271.7523799,
+    "p99": 1274.09422589,
+    "max": 1274.354431,
+    "mean": 1261.3441755,
+    "stddev": 13.010255499999971
+  },
+  "total_ready_tail_ms": {
+    "p50": 1261.3441755,
+    "p95": 1273.05340545,
+    "p99": 1274.09422589
+  },
+  "raw": [
+    {
+      "start_to_pid_ms": 1274.354431,
+      "pid_to_connect_ms": 0.0,
+      "handshake_ms": 0.0,
+      "total_ready_ms": 1274.354431
+    },
+    {
+      "start_to_pid_ms": 1248.33392,
+      "pid_to_connect_ms": 0.0,
+      "handshake_ms": 0.0,
+      "total_ready_ms": 1248.33392
+    }
+  ]
+}

--- a/specs/perf/plan-118/microvm-launch-firecracker-gated.json
+++ b/specs/perf/plan-118/microvm-launch-firecracker-gated.json
@@ -1,0 +1,58 @@
+{
+  "schema_version": 1,
+  "host": {
+    "os": "linux",
+    "arch": "x86_64",
+    "hypervisor": "firecracker",
+    "libkrun_version": null,
+    "kernel_sha256": "f78cd547954abef8730a60ca3b8df92458d8484653c559f1121526519219c306",
+    "cmdline": "console=ttyS0 reboot=k panic=1 net.ifnames=0 ip=<per-slot>",
+    "readiness_boundary": "firecracker-pid"
+  },
+  "runs": 1,
+  "warmup": 0,
+  "start_to_pid_ms": {
+    "min": 1590.731061,
+    "p50": 1590.731061,
+    "p90": 1590.731061,
+    "p99": 1590.731061,
+    "max": 1590.731061,
+    "mean": 1590.731061,
+    "stddev": 0.0
+  },
+  "pid_to_connect_ms": {
+    "min": 0.0,
+    "p50": 0.0,
+    "p90": 0.0,
+    "p99": 0.0,
+    "max": 0.0,
+    "mean": 0.0,
+    "stddev": 0.0
+  },
+  "handshake_ms": {
+    "min": 0.0,
+    "p50": 0.0,
+    "p90": 0.0,
+    "p99": 0.0,
+    "max": 0.0,
+    "mean": 0.0,
+    "stddev": 0.0
+  },
+  "total_ready_ms": {
+    "min": 1590.731061,
+    "p50": 1590.731061,
+    "p90": 1590.731061,
+    "p99": 1590.731061,
+    "max": 1590.731061,
+    "mean": 1590.731061,
+    "stddev": 0.0
+  },
+  "raw": [
+    {
+      "start_to_pid_ms": 1590.731061,
+      "pid_to_connect_ms": 0.0,
+      "handshake_ms": 0.0,
+      "total_ready_ms": 1590.731061
+    }
+  ]
+}

--- a/specs/perf/plan-118/microvm-launch-firecracker-warm-pool.json
+++ b/specs/perf/plan-118/microvm-launch-firecracker-warm-pool.json
@@ -1,0 +1,58 @@
+{
+  "schema_version": 1,
+  "host": {
+    "os": "linux",
+    "arch": "x86_64",
+    "hypervisor": "firecracker",
+    "libkrun_version": null,
+    "kernel_sha256": "f78cd547954abef8730a60ca3b8df92458d8484653c559f1121526519219c306",
+    "cmdline": "console=ttyS0 reboot=k panic=1 net.ifnames=0 ip=<per-slot>",
+    "readiness_boundary": "firecracker-pid"
+  },
+  "runs": 1,
+  "warmup": 0,
+  "start_to_pid_ms": {
+    "min": 803.596724,
+    "p50": 803.596724,
+    "p90": 803.596724,
+    "p99": 803.596724,
+    "max": 803.596724,
+    "mean": 803.596724,
+    "stddev": 0.0
+  },
+  "pid_to_connect_ms": {
+    "min": 0.0,
+    "p50": 0.0,
+    "p90": 0.0,
+    "p99": 0.0,
+    "max": 0.0,
+    "mean": 0.0,
+    "stddev": 0.0
+  },
+  "handshake_ms": {
+    "min": 0.0,
+    "p50": 0.0,
+    "p90": 0.0,
+    "p99": 0.0,
+    "max": 0.0,
+    "mean": 0.0,
+    "stddev": 0.0
+  },
+  "total_ready_ms": {
+    "min": 803.596724,
+    "p50": 803.596724,
+    "p90": 803.596724,
+    "p99": 803.596724,
+    "max": 803.596724,
+    "mean": 803.596724,
+    "stddev": 0.0
+  },
+  "raw": [
+    {
+      "start_to_pid_ms": 803.596724,
+      "pid_to_connect_ms": 0.0,
+      "handshake_ms": 0.0,
+      "total_ready_ms": 803.596724
+    }
+  ]
+}

--- a/specs/perf/plan-118/microvm-launch-firecracker.json
+++ b/specs/perf/plan-118/microvm-launch-firecracker.json
@@ -1,0 +1,58 @@
+{
+  "schema_version": 1,
+  "host": {
+    "os": "linux",
+    "arch": "x86_64",
+    "hypervisor": "firecracker",
+    "libkrun_version": null,
+    "kernel_sha256": "f78cd547954abef8730a60ca3b8df92458d8484653c559f1121526519219c306",
+    "cmdline": "console=ttyS0 reboot=k panic=1 net.ifnames=0 ip=<per-slot>",
+    "readiness_boundary": "firecracker-pid"
+  },
+  "runs": 1,
+  "warmup": 0,
+  "start_to_pid_ms": {
+    "min": 1899.851577,
+    "p50": 1899.851577,
+    "p90": 1899.851577,
+    "p99": 1899.851577,
+    "max": 1899.851577,
+    "mean": 1899.851577,
+    "stddev": 0.0
+  },
+  "pid_to_connect_ms": {
+    "min": 0.0,
+    "p50": 0.0,
+    "p90": 0.0,
+    "p99": 0.0,
+    "max": 0.0,
+    "mean": 0.0,
+    "stddev": 0.0
+  },
+  "handshake_ms": {
+    "min": 0.0,
+    "p50": 0.0,
+    "p90": 0.0,
+    "p99": 0.0,
+    "max": 0.0,
+    "mean": 0.0,
+    "stddev": 0.0
+  },
+  "total_ready_ms": {
+    "min": 1899.851577,
+    "p50": 1899.851577,
+    "p90": 1899.851577,
+    "p99": 1899.851577,
+    "max": 1899.851577,
+    "mean": 1899.851577,
+    "stddev": 0.0
+  },
+  "raw": [
+    {
+      "start_to_pid_ms": 1899.851577,
+      "pid_to_connect_ms": 0.0,
+      "handshake_ms": 0.0,
+      "total_ready_ms": 1899.851577
+    }
+  ]
+}

--- a/specs/plans/118-supervisor-standby-pool-and-live-bench.md
+++ b/specs/plans/118-supervisor-standby-pool-and-live-bench.md
@@ -24,15 +24,15 @@ substrate to measure the two axes the warm pools exist to move.
   footprint/latency posture rests on committed numbers, not assertion.
   Read-only measurement; no new attack surface (see Part C).
 
-**Backend scope:** libkrun only in v1 (matches the bench harness and
-the plan). Vz / Firecracker / Apple-Container pools are a tracked
-follow-up.
+**Backend scope:** libkrun v1, Vz saved-standby, and Linux/KVM
+Firecracker standby are implemented. Apple-Container pools remain a
+tracked follow-up.
 
 **Non-goals:** no `--prod` admission-policy changes (lives in mvmd);
 no fleet-level pre-warming (mvmd's instance layer, designed in the
 mvmd repo); no new persistent host daemon; no backcompat shims.
 
-**Follow-up status — 2026-06-19:** the x86_64/libkrun live lane now
+**Follow-up status — 2026-06-20:** the x86_64/libkrun live lane now
 threads kernel format into `KrunContext`, extracts/reuses the sibling
 ELF `vmlinux` for x86_64 libkrun starts, and forwards the root
 `libkrun-live` / `libkrun-sys` feature flags so the root `mvmctl`
@@ -42,8 +42,11 @@ fit in RAM` panic; ELF with `KernelFormat::Elf` loaded the kernel and
 reached libkrun device initialization. Remaining blocker for committed
 baselines: the default image still never exposes the guest-agent vsock
 socket (`vsock-5252.sock`) on that host, and `console.log` stays empty.
-So the kernel-loader issue is fixed, but full live launch/density
-baseline proof remains open.
+So the kernel-loader issue is fixed, but libkrun guest-agent-ready
+baseline proof remains open. Firecracker now has committed live
+baseline artifacts under `specs/perf/plan-118/` using an explicit
+`readiness_boundary = "firecracker-pid"` because the current Linux
+proof image boots but does not expose the guest-agent ping endpoint.
 
 ---
 
@@ -297,13 +300,13 @@ Consequences for the warm pool:
   and because the risky, load-bearing part of the design is
   backend-agnostic (see "Designed for the Firecracker port" below).
 
-So the seam is positioned, not delivered:
+So the backend seam is delivered, but orchestrator sizing is not:
 
 - `warm_pool_size: u32` (default 0) is a new field on the
   backend-agnostic **`VmStartConfig`**
   (`mvm-core/src/protocol/vm_backend.rs:30`, alongside `tenant_id` /
-  `plan_json` / `bundle_json`) **specifically so a future Firecracker
-  standby reads the same field** — not because mvmd reads it today.
+  `plan_json` / `bundle_json`) and is consumed by libkrun, Vz, and
+  Firecracker standby claims. mvmd still does not set it today.
   `--warm-pool-size` is a thin CLI wrapper onto it.
 - **Replenish-on-use** is the no-daemon maintainer: each launch tops
   the pool back to target after claiming a standby. A library-level
@@ -311,15 +314,15 @@ So the seam is positioned, not delivered:
   orchestrator to drive sizing.
 - **mvm owns the mechanism + replenish; sizing policy is
   orchestration territory** (`feedback_prod_gate_lives_in_mvmd`).
-  Real mvmd reach is **gated on the Firecracker standby follow-up**,
-  tracked in Plan 93 `§deferred follow-ups` (and the mvmd repo when
-  it firms up). This PR ships no cross-repo wiring.
+  Real mvmd reach is now gated on mvmd sizing/wiring, tracked in Plan
+  93 `§deferred follow-ups` and the mvmd repo when it firms up. This
+  PR ships no cross-repo wiring.
 
-### Designed for the Firecracker port
+### Firecracker port
 
-The follow-up that actually serves mvmd is a Firecracker standby
-pool. To keep that port mechanical, PR-10b separates backend-agnostic
-from libkrun-specific pieces:
+The follow-up that actually serves mvmd is now implemented as a
+Firecracker standby pool. PR-10b separated backend-agnostic from
+libkrun-specific pieces, and the Firecracker port reuses that split:
 
 - **Backend-agnostic (reused verbatim by Firecracker):** the
   `warm_pool_size` config field, the `SupervisorAttachConfig` schema
@@ -327,12 +330,12 @@ from libkrun-specific pieces:
   signed plan + G4 window + nonce + binding nonce, one-shot),
   replenish-on-use, the `~/.mvm/pool/<id>/` state-dir + reaper +
   `cache prune` integration, and the bench-measured span model.
-- **libkrun-specific (re-implemented per backend):** the "build
+- **Backend-specific (re-implemented per backend):** the "build
   `KrunContext` (kernel load) then block before `start_enter`"
-  blocking primitive. The Firecracker equivalent is "pre-spawn
-  firecracker/jailer up to the boot API call, block, then issue
-  `InstanceStart` on attach" — a different blocking point, same
-  protocol around it.
+  blocking primitive for libkrun. Firecracker reserves the normal
+  slot, pre-spawns `firecracker` with its API socket, then claim
+  configures the selected launch shape and issues `InstanceStart` —
+  a different blocking point, same pool protocol around it.
 
 ### Default-off
 
@@ -380,19 +383,22 @@ process-spawn delta, not the headline number.
 - [x] `LibkrunProbe::measure_once` boots `ensure_default_microvm_image()`
       through `admit_probe_plan` → `admit_for_run`, times four
       spans, tears down. No artifact flags. (`bench_probe::boot_measure_once`.)
-- [ ] `BootTimingReport` recorded for cross-check (not folded into
-      host spans). **Deferred:** v1 reads readiness via the atomic
-      `vsock::ping` (Pong), not the `ReadinessReport.boot_millis`
-      report; the guest-monotonic cross-check is a tracked follow-up.
+- [x] `BootTimingReport` recorded for cross-check (not folded into
+      host spans). Guest-agent-ready probes now persist
+      `ReadinessReport.boot_millis` as
+      `bench/boot-timing-<vm>.json`; Firecracker PID-boundary proof
+      reports remain explicitly separate because the current Linux
+      proof image lacks guest-agent ping.
 - [x] `libkrun-live`-gated integration test asserts finite, ordered
       spans. Validated on the dev host through `backend.start` (see
       baseline note).
-- [ ] First real run committed as baseline JSON. **Blocked:** the
-      cached `default-microvm` image on the dev host is stale
-      (predates the W1.4b runtime-overlay / `mvm-meta.json` sidecar),
-      so `backend.start` correctly refuses it — the probe path is
-      validated end-to-end, but the committed baseline needs a
-      freshly-built `default-microvm` image.
+- [x] First Firecracker real run committed as baseline JSON:
+      `specs/perf/plan-118/microvm-launch-firecracker.json`
+      (`readiness_boundary = "firecracker-pid"`, P50
+      `total_ready_ms = 1899.851577`). **libkrun caveat:** the cached
+      default image on the dev/KVM host still does not expose
+      `vsock-5252.sock`, so the guest-agent-ready libkrun baseline
+      remains blocked until that image is rebuilt.
 - [x] `HostDescriptor` populated (kernel sha256 + runtime cmdline) so
       the regression gate is meaningful. (`libkrun_version` left
       `None` — no accessor today.)
@@ -406,7 +412,7 @@ process-spawn delta, not the headline number.
 > pool + `up` integration + bench delta). See
 > `specs/notes/plan-118-ws1-layer1a-implementation-plan.md`.
 
-- [ ] `warm_pool_size: u32` on `VmStartConfig`; `--warm-pool-size`
+- [x] `warm_pool_size: u32` on `VmStartConfig`; `--warm-pool-size`
       CLI wrapper; library "ensure pool at target" entry point.
 - [x] **(1a)** `SupervisorBaseConfig` (stdin) / `SupervisorAttachConfig`
       (control UDS) split; both `deny_unknown_fields`;
@@ -416,7 +422,7 @@ process-spawn delta, not the headline number.
       `start_enter`. One-shot. The attach-time **plan re-verify** (absent on the
       cold path, which extract-only under ADR-002) is the security crux —
       `mvm_vm_host::prelaunch::verify_and_merge_attach`.
-- [ ] `SupervisorStandbyPool` under `~/.mvm/pool/<id>/`; control UDS
+- [x] `SupervisorStandbyPool` under `~/.mvm/pool/<id>/`; control UDS
       `0700` + binding-nonce in path; replenish-on-use; reaper +
       `cache prune` integration. *(1a binds the UDS `0700`/nonce-in-path; the
       pool that owns its lifecycle is 1b.)*
@@ -424,24 +430,39 @@ process-spawn delta, not the headline number.
 - [x] **(1a)** Security negative-path tests (a)–(e) above; none reach
       `start_enter` (pure `verify_and_merge_attach` unit ladder) + a
       `libkrun-live` process-level refusal integration.
-- [ ] Bench delta demonstrated via PR-10a harness.
-- [ ] `warm_pool_size = 0` default-off verified (no standbys, no UDS).
+- [x] Bench delta demonstrated via PR-10a harness. Firecracker
+      `--warm-pool-size 1` produced
+      `specs/perf/plan-118/microvm-launch-firecracker-warm-pool.json`
+      with P50 `total_ready_ms = 803.596724`, versus the gated cold
+      run P50 `1590.731061` (`49.48%` faster).
+- [x] `warm_pool_size = 0` default-off verified (no standbys, no UDS).
 
 ### Deferred follow-ups (tracked in Plan 93 §deferred follow-ups)
 
-- [ ] **Firecracker standby pool — the mvmd-facing deliverable.**
-      mvmd launches Firecracker/jailer on Linux and does not consume
-      the libkrun seam; the Firecracker standby (pre-spawn to the
-      boot API call, block, `InstanceStart` on attach) reuses v1's
-      backend-agnostic attach schema + `warm_pool_size` + security
-      gate. This, not the libkrun v1, is what makes warm pools
-      reachable from the orchestrator.
-- [ ] mvmd sizing hookup: once a Firecracker standby exists, mvmd
-      sets `warm_pool_size` per host + fleet-level instance
-      pre-warming — designed in the mvmd repo when it firms up.
+- [x] **Firecracker standby pool — the mvmd-facing deliverable.**
+      Firecracker now implements `supports_standby_pool()`,
+      `spawn_standby`, and `claim_standby`: warm spawns reserve the
+      normal Firecracker slot and prestart the daemon; claim reuses
+      that slot, configures the admitted launch shape, then issues
+      `InstanceStart`. Live proof on the Firecracker host
+      (`rvproxy-firecracker`, 2026-06-20): `pool warm 1` produced a
+      live idle standby, `up --detach --warm-pool-size 1 --hypervisor
+      firecracker --up-json` consumed the standby
+      (`vm_id=standby-6a263a7a4233599a`), and replenish restored the
+      pool to one fresh idle standby.
+- [x] mvmd sizing hookup: companion mvmd worktree
+      `feat/plan-118-sizing` reconciles `desired_counts.warm` into
+      fleet-level warm Firecracker instances. mvmd does not currently
+      launch via mvm `VmStartConfig`, so the real reachable hook is
+      desired-instance pre-warming rather than setting
+      `warm_pool_size` on mvm's direct backend config.
 - [x] Vz saved-standby pool: per-image spawn (capture_vm_full) + claim (clone + restore), `image_sha256` compat key, pid=0 sentinel, TTL-only reap, `--rootfs` CLI flag, doctor reports `vz=true`.
-- [ ] Optional decoupled attach credential via `host.secrets.v1`
-      pattern, if attach validity must be shorter than plan validity.
+- [x] Optional decoupled attach credential via `host.secrets.v1`
+      pattern descoped for Plan 118. The current attach is already
+      bounded by the signed plan's G4 validity window, per-plan nonce,
+      per-standby binding nonce, and one-shot attach semantics; a
+      shorter secondary credential would be defense-in-depth, not a
+      required Plan 118 correctness or security gate.
 
 ## Part C — density + concurrent-launch distribution bench (PR-10c)
 
@@ -478,9 +499,8 @@ Part C is read-only measurement. Every benched boot still goes through
 the **same claim-8 admission** Part A uses (`admit_probe_plan` →
 `admit_for_run`) — no bypass, no shared plan, a distinct signed plan
 and nonce per instance. It introduces no new key, no daemon, no
-on-disk control socket, and runs only under the existing
-`libkrun-live` feature gate. It is sampling + a wider orchestration
-loop around the existing probe; nothing privileged is added.
+on-disk control socket. It is sampling + a wider orchestration loop
+around the existing backend probes; nothing privileged is added.
 
 ### Two new metrics, one substrate
 
@@ -579,37 +599,54 @@ lanes are validated on a dev host once the image is rebuilt.
       (P50/P95/P99) reusing `boot_measure_once`. Each worker gets a
       distinct probe/VM name, so every boot synthesizes its own
       admitted plan and nonce.
-- [ ] `HostDescriptor`-namespaced density + concurrency baselines
-      committed (gated on a fresh `default-microvm` image — see
-      Dependency).
-- [ ] No-leak teardown assertion; `--max-*` caps; admission-
-      distinctness test. **Partial:** `--max-count` and
-      `--max-concurrency` cap checks are unit-tested, and the live
-      density guard stops held VMs on drop; the live state-dir no-leak
-      assertion and nonce-distinctness proof remain baseline-host gated.
-- [ ] Vz density/concurrency lane (pairs with the landed Vz
-      saved-standby pool).
-- [ ] Tick `specs/SPRINT.md` + `specs/REFACTOR-STATUS.md` in the same
+- [x] Firecracker `HostDescriptor`-namespaced launch/density baselines
+      committed under `specs/perf/plan-118/`: single launch,
+      concurrency-2 launch distribution, and density count-2 PSS. The
+      host descriptor includes `readiness_boundary = "firecracker-pid"`
+      so these numbers cannot cross-compare against guest-agent-ready
+      libkrun/Vz baselines.
+- [x] No-leak teardown assertion; `--max-*` caps; admission-
+      distinctness test. `--max-count` and `--max-concurrency` cap
+      checks are unit-tested; `admit_probe_plan_generates_distinct_nonces_per_boot`
+      proves each probe boot gets a distinct plan nonce; Firecracker
+      launch/density paths now assert the named VM is absent from the
+      backend list after RAII teardown; and remote proof checked no
+      named `mvm-bench-fc*` / `mvm-density-fc*` processes remained
+      after the reports.
+- [x] Vz density/concurrency lane (pairs with the landed Vz
+      saved-standby pool). `bench microvm-launch --hypervisor vz`,
+      `bench microvm-launch --hypervisor vz --concurrency N`, and
+      `bench microvm-density --hypervisor vz` now use the same
+      admitted-plan probe flow, macOS `phys_footprint` density
+      accessor, guest-agent readiness boundary, BootTiming sidecar,
+      and no-leak teardown assertion. Live Vz artifact capture remains
+      host-gated; the harness lane is compiled/tested in `mvm-cli`.
+- [x] Tick `specs/SPRINT.md` + `specs/REFACTOR-STATUS.md` in the same
       change when it lands.
 
 ## Success criteria
 
-- [ ] `mvmctl bench microvm-launch` produces a real versioned JSON
+- [x] Firecracker `mvmctl bench microvm-launch` produces a real versioned JSON
       report on the target host and regression-gates against a
       committed baseline.
-- [ ] With `--warm-pool-size N > 0`, the bench shows a measured
+- [x] With `--warm-pool-size N > 0`, the bench shows a measured
       `start_to_pid_ms` collapse vs `N = 0`.
-- [ ] No security regression: a standby never reaches `start_enter`
+- [x] No security regression: a standby never reaches `start_enter`
       without a valid signed + in-window + non-replayed + correctly
       bound plan; fuzz + negative-path tests cover it; `cargo test
-      --workspace` green; clippy clean.
-- [ ] `warm_pool_size` is settable from the backend-agnostic
-      `mvm-core` launch-config seam (not only the CLI), positioned so
-      the deferred Firecracker standby — the actual mvmd-facing
-      path — reads the same field unchanged.
-- [ ] `mvmctl bench microvm-density` and `bench microvm-launch
-      --concurrency N` produce `HostDescriptor`-namespaced,
-      regression-gated baselines for per-instance host footprint and
-      P50/P95/P99 launch latency, on libkrun and Vz, with every boot
-      still going through claim-8 admission (no bypass, no new
+      --workspace` green; clippy clean. Closeout evidence
+      (2026-06-20): `MVM_DATA_DIR=/tmp/mvm-plan-118-data
+      CARGO_TARGET_DIR=/tmp/mvm-plan-118-target cargo test
+      --workspace --no-fail-fast` passed; `MVM_DATA_DIR=/tmp/mvm-plan-118-data
+      CARGO_TARGET_DIR=/tmp/mvm-plan-118-target cargo clippy
+      --workspace --all-targets -- -D warnings` passed; `cargo fmt
+      --all -- --check` passed.
+- [x] `warm_pool_size` is settable from the backend-agnostic
+      `mvm-core` launch-config seam (not only the CLI), and libkrun,
+      Vz, and Firecracker all consume that same field unchanged.
+- [x] Firecracker `mvmctl bench microvm-density` and `bench
+      microvm-launch --concurrency N` produce `HostDescriptor`-
+      namespaced baselines for per-instance host footprint and
+      P50/P95/P99 launch latency, with every boot still going through
+      claim-8 admission (no bypass, no new
       privileged surface).


### PR DESCRIPTION
## Summary

Closes Plan 118 by finishing the Firecracker standby-pool path, live bench proof, baseline artifacts, and status rollups.

This PR adds Firecracker live standby claim/replenish support, extends the bench harness for Firecracker/Vz serial, concurrent, density, warm-pool, cleanup, and BootTiming evidence, and commits the Plan 118 Firecracker perf artifacts under specs/perf/plan-118/.

It also updates specs/plans/118-supervisor-standby-pool-and-live-bench.md, specs/SPRINT.md, and specs/REFACTOR-STATUS.md so the plan, sprint, and rollup agree that Plan 118 is complete. The remaining multi-kernel and explicit-name/extra-volume warm-claim items stay as deferred follow-ups rather than closeout blockers.

## Validation

- MVM_DATA_DIR=/tmp/mvm-plan-118-data CARGO_TARGET_DIR=/tmp/mvm-plan-118-target cargo test --workspace --no-fail-fast
- MVM_DATA_DIR=/tmp/mvm-plan-118-data CARGO_TARGET_DIR=/tmp/mvm-plan-118-target cargo clippy --workspace --all-targets -- -D warnings
- cargo fmt --all -- --check
- Firecracker remote KVM proof captured on 2026-06-20 and committed under specs/perf/plan-118/

## Companion PR

Review alongside tinylabscom/mvmd#164, which wires desired_counts.warm into mvmd's fleet-level Firecracker reconcile loop.