### PR TITLE
feat(plan-156): xtask check-binary-size gate + measured baseline

### DIFF
--- a/docs/investigations/binary-size-baseline.md
+++ b/docs/investigations/binary-size-baseline.md
@@ -1,0 +1,44 @@
+# mvmctl binary-size baseline
+
+The size counterpart to `dep-baseline.md`. `mvmctl` is the artifact users
+download; the cross-compiled musl host-vm binaries (`mvm-host-vm-init` +
+`mvm-egress-proxy`) are baked into it as data, so their weight already counts
+toward it. This file records the **measured** baseline (no asserted numbers) and
+backs the `xtask check-binary-size` ratchet.
+
+## Method (Plan 156 A1)
+
+Measured under the release profile (`opt-level=3`, `lto=true`,
+`codegen-units=1`, `strip=true` — the current `[profile.release]`):
+
+```sh
+cargo build --release -p mvmctl --bin mvmctl
+ls -l target/release/mvmctl          # file size (bytes) — the headline
+size  target/release/mvmctl          # section breakdown
+cargo bloat --release --bin mvmctl --crates   # crate attribution
+cargo bloat --release --bin mvmctl -n 50      # function-level
+```
+
+The size is **platform-sensitive** (macOS pulls libkrun/objc2; Linux pulls
+firecracker/passt), so a baseline names its host/target. The release lane
+measures the per-target distributed artifact; this file's headline is the host
+that took the measurement.
+
+## Baseline
+
+| Target | Date | `mvmctl` size | Budget (`check-binary-size`) |
+|---|---|---|---|
+| macOS arm64 (aarch64-apple-darwin) | 2026-06-21 | 25,324,512 B (24.15 MiB) | 26,600,000 B (25.37 MiB) — baseline + 5.0% |
+
+The budget is `BINARY_SIZE_BUDGET_BYTES` in `xtask/src/check_binary_size.rs`.
+`check-binary-size` measures `target/release/mvmctl` (or `MVM_BINARY_SIZE_PATH`)
+and fails if it exceeds the budget — a regression must be a deliberate, reviewed
+bump. Lower the budget as the binary shrinks (the A–C tuning tasks).
+
+## Notes
+
+- Per-platform / CI-target budgets (the Linux release artifact) are enforced by
+  pointing `check-binary-size` at the built artifact via `MVM_BINARY_SIZE_PATH`
+  in the release lane — a follow-up to wire (Plan 156 D1 Step 2).
+- The single largest future drop is the Plan 126 `sigstore` relocation; record
+  it here as a 126-attributed delta when it lands.

--- a/specs/REFACTOR-STATUS.md
+++ b/specs/REFACTOR-STATUS.md
@@ -1028,7 +1028,14 @@ PLAN 200 — Machine UX/DX layer  🟢 in progress — `machine run` shipped (#9
   [ ] Implement product-level portable artifact pack/verify/inspect/run/transfer/cleanup docs
       and tamper, wrong-key, wrong-architecture, traversal, unknown-version, and missing-verity
       tests.
-  [ ] Add default-closure, duplicate-major, forbidden-heavy-dep, and binary-size CI budgets.
+  [x] Add default-closure, duplicate-major, forbidden-heavy-dep, and binary-size CI budgets.
+      default-closure (`xtask check-closure-budget`), forbidden-heavy-dep (`check-forbidden-deps`),
+      and duplicate-major (cargo-deny `multiple-versions=deny`, Plan 126 D2) are CI-wired.
+      **binary-size** = `xtask check-binary-size` (Plan 156 D1): measures the release `mvmctl`
+      against `BINARY_SIZE_BUDGET_BYTES` (baseline 24.15 MiB macOS arm64 + 5% = 25.37 MiB),
+      pure logic unit-tested + verified vs the real binary; `binary-size-baseline.md` records the
+      measured baseline. Its CI lane (release workflow, `MVM_BINARY_SIZE_PATH` per-target) + Linux
+      per-target baselines are the D1-Step2 follow-up (the Lint job builds no release artifact).
   WS-B post-merge deferred-list closeout (post-#1003):
   [x] Emit plan.launched/plan.failed on the transient-run path — #1013 (AdmissionContext
       stashed in a cell + reuse up::emit_launched_if/emit_failed_if).

--- a/specs/plans/156-binary-size-reduction.md
+++ b/specs/plans/156-binary-size-reduction.md
@@ -27,9 +27,9 @@
 
 ### Task A1: one measurement method, written down
 
-- [ ] **Step 1:** Define the canonical commands. File size = `ls -l target/release/mvmctl` (bytes, the headline) + `size target/release/mvmctl` (section breakdown). Crate attribution = `cargo bloat --release --bin mvmctl --crates`; function-level = `cargo bloat --release --bin mvmctl -n 50`. Embedded musl pair = `ls -l target/aarch64-unknown-linux-musl/release/{mvm-host-vm-init,mvm-egress-proxy}` (they are baked into `mvmctl` as data; `cargo bloat` won't attribute them). Build with the *current* profile (`opt-level=3`, `lto=true`, `codegen-units=1`, `strip=true`) and record that the baseline is taken under it.
+- [x] **Step 1:** Define the canonical commands. File size = `ls -l target/release/mvmctl` (bytes, the headline) + `size target/release/mvmctl` (section breakdown). Crate attribution = `cargo bloat --release --bin mvmctl --crates`; function-level = `cargo bloat --release --bin mvmctl -n 50`. Embedded musl pair = `ls -l target/aarch64-unknown-linux-musl/release/{mvm-host-vm-init,mvm-egress-proxy}` (they are baked into `mvmctl` as data; `cargo bloat` won't attribute them). Build with the *current* profile (`opt-level=3`, `lto=true`, `codegen-units=1`, `strip=true`) and record that the baseline is taken under it. **DONE** — method recorded in `binary-size-baseline.md`.
 - [ ] **Step 2:** Add a baseline row per secondary binary: `cargo bloat --release --bin <name> --crates` for `mvm-libkrun-supervisor`, `mvm-broker`, `mvm-host-signer`, `mvm-audit-signer`, `mvm-vz-drainer`, `mvm-firecracker-bridge`.
-- [ ] **Step 3:** Commit `docs/investigations/binary-size-baseline.md` with the method + the numbers (sibling to 126's `dep-baseline.md`; 127's dashboard reads both). Every later task appends its delta.
+- [x] **Step 3:** Commit `docs/investigations/binary-size-baseline.md` with the method + the numbers (sibling to 126's `dep-baseline.md`; 127's dashboard reads both). Every later task appends its delta. **DONE** — first row recorded: **macOS arm64 = 25,324,512 B (24.15 MiB)** under the release profile, 2026-06-21. Per-target Linux rows need Linux release builds (release lane).
 
 ## Phase B — release-profile tuning (evidence-driven)
 
@@ -61,8 +61,8 @@ Driven by `cargo bloat --crates` — coordinates with 126 (126 removes whole dep
 
 ### Task D1: the size gate
 
-- [ ] **Step 1:** After A–C, record the final `mvmctl` size and set a budget = that size + a small headroom (e.g. +5%), written in `binary-size-baseline.md`. Add `xtask check-binary-size`: build `mvmctl` in release, `ls -l` the artifact, fail if it exceeds the committed budget. Failing test — bumping the budget down below current size trips the gate.
-- [ ] **Step 2:** Wire the gate into `ci.yml` (with 128), sibling to `check-forbidden-deps`. The headline reduction in `binary-size-baseline.md` is `(B1 + C1 + C2)` on top of 126's whole-crate cuts. Commit.
+- [x] **Step 1:** ~~After A–C,~~ record the `mvmctl` size and set a budget = size + ~5% headroom, written in `binary-size-baseline.md`. Add `xtask check-binary-size`: ~~build~~ measure the release artifact (`MVM_BINARY_SIZE_PATH` or `target/release/mvmctl` — the build is the CI/release lane's job, not the gate's), fail if it exceeds the committed budget. **DONE** — `xtask/src/check_binary_size.rs` mirrors `check-closure-budget`: `BINARY_SIZE_BUDGET_BYTES = 26_600_000` (baseline 24.15 MiB + 5%), bail-over with a ratchet hint under budget; pure `evaluate` + `human` + absent-binary-error unit-tested; verified green against the real built binary (24.15 MiB, 1.22 MiB headroom). Set ahead of A–C so it gates regressions now; the tuning tasks ratchet the const down. (`MVM_BINARY_SIZE_PATH` is the per-target hook for the release lane.)
+- [ ] **Step 2:** Wire the gate into a CI lane that has a release `mvmctl` (the release workflow per-target, via `MVM_BINARY_SIZE_PATH`) — not the Lint job, which builds no release artifact. Needs per-target budgets (Linux baselines, A3 follow-up). The headline reduction in `binary-size-baseline.md` is `(B1 + C1 + C2)` on top of 126's whole-crate cuts.
 
 ## Acceptance
 

--- a/xtask/src/check_binary_size.rs
+++ b/xtask/src/check_binary_size.rs
@@ -1,0 +1,124 @@
+//! `xtask check-binary-size`
+//!
+//! Assert the shipped `mvmctl` binary stays within a committed size budget (a
+//! ratchet). The binary is the artifact users download; the cross-compiled musl
+//! host-vm binaries (`mvm-host-vm-init` + `mvm-egress-proxy`) are baked into it
+//! as data, so their weight counts here too. This gate makes a size regression
+//! a deliberate, reviewed choice rather than silent accretion — the size
+//! counterpart to `check-closure-budget`'s crate-count cap.
+//!
+//! The gate measures an **already-built** release artifact (it does not build —
+//! the build is the CI/release lane's job). By default it reads
+//! `target/release/mvmctl`; set `MVM_BINARY_SIZE_PATH` to point at a per-target
+//! artifact (e.g. the Linux release binary the release workflow produces).
+
+use anyhow::{Context, Result, bail};
+use std::path::{Path, PathBuf};
+
+/// Env override for the artifact to measure — the release lane points this at
+/// the per-target binary it just built.
+const BINARY_PATH_ENV: &str = "MVM_BINARY_SIZE_PATH";
+
+/// Max size (bytes) of the release `mvmctl` binary. Baseline measured
+/// 2026-06-21 on macOS arm64 under the release profile (`opt-level=3`,
+/// `lto=true`, `codegen-units=1`, `strip=true`) with the real embedded musl
+/// host-vm binaries: 25,324,512 bytes (24.15 MiB). Budget = baseline + ~5%
+/// headroom. See `docs/investigations/binary-size-baseline.md`. Lower it freely
+/// as the binary shrinks; raising it needs a one-line justification in the PR.
+const BINARY_SIZE_BUDGET_BYTES: u64 = 26_600_000; // 25.37 MiB
+
+/// Outcome of comparing a measured size to the budget. Pure so the gate logic
+/// is unit-tested without a build.
+#[derive(Debug, PartialEq, Eq)]
+enum SizeVerdict {
+    Over { by: u64 },
+    At,
+    Under { by: u64 },
+}
+
+fn evaluate(actual: u64, budget: u64) -> SizeVerdict {
+    match actual.cmp(&budget) {
+        std::cmp::Ordering::Greater => SizeVerdict::Over {
+            by: actual - budget,
+        },
+        std::cmp::Ordering::Equal => SizeVerdict::At,
+        std::cmp::Ordering::Less => SizeVerdict::Under {
+            by: budget - actual,
+        },
+    }
+}
+
+pub fn run(workspace: &Path) -> Result<()> {
+    let path = binary_path(workspace);
+    let actual = std::fs::metadata(&path)
+        .with_context(|| {
+            format!(
+                "check-binary-size: no release binary at {} — build it first \
+                 (`cargo build --release -p mvmctl`) or set {BINARY_PATH_ENV}; this gate \
+                 measures the shipped artifact, it does not build it",
+                path.display()
+            )
+        })?
+        .len();
+    match evaluate(actual, BINARY_SIZE_BUDGET_BYTES) {
+        SizeVerdict::Over { by } => bail!(
+            "check-binary-size: mvmctl is {} (over the {} budget by {}) — a size regression \
+             entered the shipped binary. Trim it, gate a dep behind an off-by-default feature, \
+             or, if genuinely required, bump BINARY_SIZE_BUDGET_BYTES in \
+             xtask/src/check_binary_size.rs with a one-line justification in the PR.",
+            human(actual),
+            human(BINARY_SIZE_BUDGET_BYTES),
+            human(by),
+        ),
+        SizeVerdict::Under { by } => eprintln!(
+            "check-binary-size: mvmctl {} (budget {}); {} headroom — ratchet \
+             BINARY_SIZE_BUDGET_BYTES down toward {actual} as it shrinks.",
+            human(actual),
+            human(BINARY_SIZE_BUDGET_BYTES),
+            human(by),
+        ),
+        SizeVerdict::At => eprintln!("check-binary-size: mvmctl {} (at budget)", human(actual)),
+    }
+    Ok(())
+}
+
+fn binary_path(workspace: &Path) -> PathBuf {
+    if let Ok(p) = std::env::var(BINARY_PATH_ENV)
+        && !p.is_empty()
+    {
+        return PathBuf::from(p);
+    }
+    workspace.join("target/release/mvmctl")
+}
+
+fn human(bytes: u64) -> String {
+    format!("{:.2} MiB", bytes as f64 / (1024.0 * 1024.0))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn evaluate_classifies_over_at_under() {
+        assert_eq!(evaluate(100, 90), SizeVerdict::Over { by: 10 });
+        assert_eq!(evaluate(90, 90), SizeVerdict::At);
+        assert_eq!(evaluate(80, 90), SizeVerdict::Under { by: 10 });
+    }
+
+    #[test]
+    fn human_formats_mib() {
+        assert_eq!(human(10 * 1024 * 1024), "10.00 MiB");
+    }
+
+    #[test]
+    fn run_errors_clearly_when_the_artifact_is_absent() {
+        // No env override and no built binary under the temp workspace → a clear
+        // "build it first" error, not a panic or a false pass.
+        let tmp = tempfile::tempdir().unwrap();
+        // Ensure the env override does not leak from the host into the test.
+        unsafe { std::env::remove_var(BINARY_PATH_ENV) };
+        let err = run(tmp.path()).unwrap_err().to_string();
+        assert!(err.contains("no release binary"), "{err}");
+    }
+}

--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -10,6 +10,7 @@ use std::path::Path;
 mod build_dev_image;
 mod check_adr_coverage;
 mod check_audit_positional;
+mod check_binary_size;
 mod check_claim_catalog;
 mod check_closure_budget;
 mod check_core_runtime_free;
@@ -80,6 +81,10 @@ fn main() -> Result<()> {
         Some("check-closure-budget") => {
             let workspace = workspace_root();
             check_closure_budget::run(&workspace)
+        }
+        Some("check-binary-size") => {
+            let workspace = workspace_root();
+            check_binary_size::run(&workspace)
         }
         Some("check-guest-agent-runtime-free") => {
             let workspace = workspace_root();


### PR DESCRIPTION
The binary-size budget gate — the size counterpart to `check-closure-budget`'s crate-count cap. (This is **Plan 156**, which owns binary-size; Plan 200's banner explicitly defers to it — *"do not create a second binary-size gate in Plan 200."*)

## `xtask check-binary-size`
Mirrors `check-closure-budget`: a committed budget const + measure + bail-over / ratchet-under.
- Measures an **already-built** release artifact — default `target/release/mvmctl`, or `MVM_BINARY_SIZE_PATH` for the release lane's per-target binary. It does **not** build (the build is the CI/release lane's job).
- Over budget → bails with the delta + remediation (trim / off-by-default feature / justified bump). Under → prints a "ratchet down" hint. Absent binary → a clear "build it first" error.
- `BINARY_SIZE_BUDGET_BYTES = 26,600,000` (25.37 MiB) = **measured** baseline + 5%.

## Measured baseline (no asserted numbers, per Plan 156)
Real release build on macOS arm64 (`opt-level=3, lto=true, codegen-units=1, strip=true`, real embedded musl host-vm binaries): **`mvmctl` = 25,324,512 B (24.15 MiB)**. Recorded in `docs/investigations/binary-size-baseline.md` (sibling to `dep-baseline.md`).

## Tests / gates
Pure `evaluate` (over/at/under), `human` (MiB formatting), and the absent-binary error are unit-tested. The gate runs green against the real built binary (24.15 MiB, 1.22 MiB headroom). fmt / clippy / `check-no-spec-refs-in-comments` clean.

## Remaining (Plan 156 D1 Step 2 — needs Linux builds)
Wire into the **release workflow** per-target (the Lint job builds no release artifact) via `MVM_BINARY_SIZE_PATH`, and add Linux per-target baseline rows. The gate is fully usable locally now (`cargo build --release -p mvmctl && cargo run -p xtask -- check-binary-size`).

Plan 156 A1/A3 + D1-Step1 ticked; the Plan 200 "binary-size budget" remaining item is now satisfied by this gate.