### PR TITLE
fix(cache): make `cache prune`/`repair` report their result by default

### DIFF
--- a/crates/mvm-cli/src/commands/ops/cache.rs
+++ b/crates/mvm-cli/src/commands/ops/cache.rs
@@ -233,12 +233,12 @@ pub(in crate::commands) fn run(_cli: &Cli, args: Args, _cfg: &MvmConfig) -> Resu
                 return Ok(());
             }
             if !repair.existed {
-                ui::info(&format!(
+                ui::notice(&format!(
                     "Builder store {} is already absent — nothing to repair.",
                     repair.path
                 ));
             } else if dry_run {
-                ui::info(&format!(
+                ui::notice(&format!(
                     "Would clear builder store {} ({}). Re-run without --dry-run to repair.",
                     repair.path,
                     human_bytes(repair.bytes_freed)
@@ -250,7 +250,7 @@ pub(in crate::commands) fn run(_cli: &Cli, args: Args, _cfg: &MvmConfig) -> Resu
                     repair.bytes_freed,
                     repair.path
                 );
-                ui::success(&format!(
+                ui::notice(&format!(
                     "Cleared builder store {} ({} freed). The next `mvmctl dev up` rebuilds it.",
                     repair.path,
                     human_bytes(repair.bytes_freed)
@@ -278,14 +278,14 @@ pub(in crate::commands) fn run(_cli: &Cli, args: Args, _cfg: &MvmConfig) -> Resu
                         if o.killed == 0 && o.removed_dirs == 0 {
                             ui::info("No orphaned VM helpers.");
                         } else if dry_run {
-                            ui::info(&format!(
+                            ui::notice(&format!(
                                 "(dry-run) Would reap {} orphaned helper PID(s) and {} cache dir(s) ({}).",
                                 o.killed,
                                 o.removed_dirs,
                                 human_bytes(o.freed_bytes)
                             ));
                         } else {
-                            ui::success(&format!(
+                            ui::notice(&format!(
                                 "Reaped {} orphaned helper PID(s) and {} cache dir(s), freed {}.",
                                 o.killed,
                                 o.removed_dirs,
@@ -504,15 +504,15 @@ pub(in crate::commands) fn run(_cli: &Cli, args: Args, _cfg: &MvmConfig) -> Resu
             }
 
             if removed == 0 {
-                ui::info("Nothing to prune.");
+                ui::notice("Nothing to prune.");
             } else if dry_run {
-                ui::info(&format!(
+                ui::notice(&format!(
                     "Would remove {} items, freeing {}",
                     removed,
                     human_bytes(freed)
                 ));
             } else {
-                ui::success(&format!(
+                ui::notice(&format!(
                     "Pruned {} items, freed {}",
                     removed,
                     human_bytes(freed)


### PR DESCRIPTION
## Summary

While cleaning up ~40 accumulated dead builder-VM scratch dirs under `~/.cache/mvm/builder-vm/vms/`, I found that `mvmctl cache prune` **reaps them correctly**, but reports nothing about it by default:

```
$ mvmctl cache prune --dry-run        # BEFORE — only the store footprint
Builder persistent /nix store images:
  nix-store-aarch64.img: 32.9G on disk / 64.0G cap (sparse)
  ...
```

The reaper result, the final "Pruned N items" tally, and the `--dry-run` preview all go through `ui::info`/`ui::success` — opt-in **chatter** suppressed unless `--verbose`/`RUST_LOG` is set (`chatter_enabled() = is_verbose()`). The persistent-store footprint immediately below prints unconditionally via `println!`, so a plain `cache prune` shows only the footprint. Worst case: `cache prune --dry-run`, whose entire purpose is to preview, prints nothing actionable by default — it reads as "nothing would happen" even when dirs are reapable. (This is exactly what made me initially think the reaper was broken; it isn't.)

## Change

Route the **result/preview** lines through `ui::notice` (always-visible, keeps the `[mvm]` prefix, still respects the json-envelope stderr routing):
- the orphan-helper reaper's "Reaped N PID(s) and M cache dir(s), freed X" / "(dry-run) Would reap …",
- the final "Pruned N items, freed X" / "Would remove …" / "Nothing to prune",
- `cache repair`'s "Cleared builder store … freed" / "Would clear …" / "already absent".

```
$ mvmctl cache prune --dry-run        # AFTER
[mvm] (dry-run) Would reap 0 orphaned helper PID(s) and 1 cache dir(s) (11B).
[mvm] Nothing to prune.
Builder persistent /nix store images:
  ...
```

Per-section detail lines (orphan-builds / standby / orphan-dirs) stay chatter — they already fold into the now-visible final total, so default output stays a clean 1–2 lines, not a wall.

**No logic change** — reaping/removal behaviour is identical; only the output verbosity policy for the primary result changes. The reaper's reaped-dir count is reported on its own line because it accumulates separately from the final tally (it runs before those counters exist).

## Verification

- Live on macOS 26 / Vz: real `cache prune` now prints `[mvm] Reaped 0 orphaned helper PID(s) and 1 cache dir(s), freed 11B.` and removes the dir; `--dry-run` previews without mutating.
- 54 `mvm-cli` cache/reaper tests green; `cargo fmt --all --check`, `cargo clippy -p mvm-cli -D warnings`, `xtask check-no-spec-refs-in-comments` all clean.