### PR TITLE
fix(firecracker): make the gateway-bridge sidecar actually run (plan.json decode + seccomp gaps)

### DIFF
--- a/crates/mvm-hostd/src/jailer/seccomp.rs
+++ b/crates/mvm-hostd/src/jailer/seccomp.rs
@@ -124,6 +124,19 @@ pub(crate) const BRIDGE_SYSCALLS: &[(&str, libc::c_long)] = &[
     // tokio's runtime queries CPU affinity when it spawns workers after
     // confinement (worker count / NUMA placement).
     ("sched_getaffinity", libc::SYS_sched_getaffinity),
+    // Completed via live FC strace: the Rust/tokio runtime (thread TLS, stack
+    // limits, allocator realloc) + the transcript-capture sink + the
+    // gateway-audit socket make these after confinement; without them the
+    // bridge takes SIGSYS and the watchdog tears down the VM.
+    ("access", libc::SYS_access),
+    ("arch_prctl", libc::SYS_arch_prctl),
+    ("chmod", libc::SYS_chmod),
+    ("ioctl", libc::SYS_ioctl),
+    ("listen", libc::SYS_listen),
+    ("mremap", libc::SYS_mremap),
+    ("newfstatat", libc::SYS_newfstatat),
+    ("prlimit64", libc::SYS_prlimit64),
+    ("unlink", libc::SYS_unlink),
 ];
 
 #[cfg(target_arch = "aarch64")]
@@ -212,6 +225,16 @@ pub(crate) const BRIDGE_SYSCALLS: &[(&str, libc::c_long)] = &[
     // tokio's runtime queries CPU affinity when it spawns workers after
     // confinement (worker count / NUMA placement).
     ("sched_getaffinity", libc::SYS_sched_getaffinity),
+    // Completed via live FC strace (x86_64). aarch64 has no arch_prctl, and
+    // access/chmod/unlink fold into the *at variants glibc actually issues.
+    ("faccessat", libc::SYS_faccessat),
+    ("fchmodat", libc::SYS_fchmodat),
+    ("ioctl", libc::SYS_ioctl),
+    ("listen", libc::SYS_listen),
+    ("mremap", libc::SYS_mremap),
+    ("newfstatat", libc::SYS_newfstatat),
+    ("prlimit64", libc::SYS_prlimit64),
+    ("unlinkat", libc::SYS_unlinkat),
 ];
 
 /// Resolve a syscall by name to its `libc::SYS_*` number on the current

--- a/crates/mvm-hostd/src/jailer/seccomp.rs
+++ b/crates/mvm-hostd/src/jailer/seccomp.rs
@@ -63,6 +63,11 @@ pub(crate) const BRIDGE_SYSCALLS: &[(&str, libc::c_long)] = &[
     ("exit_group", libc::SYS_exit_group),
     ("rt_sigprocmask", libc::SYS_rt_sigprocmask),
     ("rt_sigaction", libc::SYS_rt_sigaction),
+    // The Rust runtime installs an alternate signal stack (stack-overflow
+    // guard) during thread setup; without this the bridge takes SIGSYS on its
+    // own `sigaltstack` as soon as the packet thread spins up. Found via live
+    // FC strace — the allowlist had never been exercised on the real sidecar.
+    ("sigaltstack", libc::SYS_sigaltstack),
     ("mmap", libc::SYS_mmap),
     ("munmap", libc::SYS_munmap),
     ("mprotect", libc::SYS_mprotect),
@@ -151,6 +156,11 @@ pub(crate) const BRIDGE_SYSCALLS: &[(&str, libc::c_long)] = &[
     ("exit_group", libc::SYS_exit_group),
     ("rt_sigprocmask", libc::SYS_rt_sigprocmask),
     ("rt_sigaction", libc::SYS_rt_sigaction),
+    // The Rust runtime installs an alternate signal stack (stack-overflow
+    // guard) during thread setup; without this the bridge takes SIGSYS on its
+    // own `sigaltstack` as soon as the packet thread spins up. Found via live
+    // FC strace — the allowlist had never been exercised on the real sidecar.
+    ("sigaltstack", libc::SYS_sigaltstack),
     ("mmap", libc::SYS_mmap),
     ("munmap", libc::SYS_munmap),
     ("mprotect", libc::SYS_mprotect),

--- a/crates/mvm-vm-host/src/bin/mvm-firecracker-bridge.rs
+++ b/crates/mvm-vm-host/src/bin/mvm-firecracker-bridge.rs
@@ -82,7 +82,9 @@ use mvm_hostd::supervisor::network::{
     ObserverAllowlist, Pipeline, ProviderCapabilities, resolve_observer_chain_from_policy_source,
 };
 #[cfg(target_os = "linux")]
-use mvm_vm_host::firecracker_bridge::parse::{BridgeConfigJson, verify_passt_hash};
+use mvm_vm_host::firecracker_bridge::parse::{
+    BridgeConfigJson, decode_plan_json, verify_passt_hash,
+};
 #[cfg(target_os = "linux")]
 use std::io::Read;
 #[cfg(target_os = "linux")]
@@ -158,12 +160,14 @@ fn run() -> Result<()> {
 
     // ── Step 4: parse trusted plan + bundle ─────────────────────────
     //
-    // Trust model (see module doc): the producer (`FirecrackerBackend`)
-    // has already verified the signed envelope
-    // via `mvm-cli::admit_for_run`; we parse the inner ExecutionPlan
-    // body directly.
-    let plan: ExecutionPlan = serde_json::from_str(&cfg.plan_json)
-        .context("decode BridgeConfigJson.plan_json into ExecutionPlan")?;
+    // Trust model (see module doc): the producer (`FirecrackerBackend`) has
+    // already verified the signed envelope via `mvm-cli::admit_for_run`.
+    // `plan_json` is the `SignedExecutionPlan` envelope (the
+    // `VmStartConfig.plan_json` shape), so `decode_plan_json` extracts the inner
+    // `ExecutionPlan` from its payload — mirroring `mvm-libkrun-supervisor` —
+    // without re-verifying (the bridge shares the host TCB).
+    let plan: ExecutionPlan =
+        decode_plan_json(&cfg.plan_json).context("decode BridgeConfigJson.plan_json")?;
     let bundle: Option<PolicyBundle> = match &cfg.bundle_json {
         Some(s) => Some(
             serde_json::from_str(s)

--- a/crates/mvm-vm-host/src/firecracker_bridge/parse.rs
+++ b/crates/mvm-vm-host/src/firecracker_bridge/parse.rs
@@ -18,6 +18,7 @@ use std::io::Read;
 use std::path::{Path, PathBuf};
 
 use anyhow::{Context, Result, anyhow};
+use mvm_core::plan::{ExecutionPlan, SignedExecutionPlan};
 use serde::Deserialize;
 use sha2::{Digest, Sha256};
 
@@ -88,6 +89,26 @@ pub struct BridgeConfigJson {
     /// to label flow-event audit entries with the bundle digest).
     #[serde(default)]
     pub bundle_json: Option<String>,
+}
+
+/// Decode the bridge's `plan_json` into the inner [`ExecutionPlan`].
+///
+/// `VmStartConfig.plan_json` (what `stash_plan_for_bridge` persists to
+/// `<state_dir>/plan.json`) is the `SignedExecutionPlan` envelope, so the inner
+/// plan lives in its payload — the same shape `mvm-libkrun-supervisor` consumes.
+/// The producer already verified the envelope at admit time and the bridge
+/// shares the host TCB, so it does not re-verify here. Falls back to a bare
+/// `ExecutionPlan` (the inner form the lifecycle `write_plan` path persists to
+/// the same file), so the bridge is robust to whichever writer last touched
+/// `plan.json`.
+pub fn decode_plan_json(plan_json: &str) -> Result<ExecutionPlan> {
+    if let Ok(signed) = serde_json::from_str::<SignedExecutionPlan>(plan_json) {
+        return serde_json::from_slice::<ExecutionPlan>(&signed.0.payload)
+            .context("decode SignedExecutionPlan payload into ExecutionPlan");
+    }
+    serde_json::from_str::<ExecutionPlan>(plan_json).context(
+        "decode plan_json: neither a SignedExecutionPlan envelope nor a bare ExecutionPlan",
+    )
 }
 
 /// On-disk format of `~/.mvm/passt-hashes.toml`. Operator-managed —
@@ -195,6 +216,44 @@ pub(crate) fn hex_encode(bytes: &[u8]) -> String {
 mod tests {
     use super::*;
     use std::io::Write;
+
+    // ── decode_plan_json ────────────────────────────────────────────
+    // The producer stashes the SignedExecutionPlan envelope as plan_json; the
+    // bridge must extract the inner ExecutionPlan (regression for the FC bridge
+    // crashing on `unknown field 'payload'`).
+
+    #[test]
+    fn decode_plan_json_extracts_inner_from_signed_envelope() {
+        use ed25519_dalek::SigningKey;
+        use mvm_core::plan::sign_plan;
+        use mvm_core::plan::signing::test_support::sample_plan;
+
+        let plan = sample_plan();
+        let sk = SigningKey::from_bytes(&[7u8; 32]);
+        let signed = sign_plan(&plan, &sk, "test-signer");
+        // This is exactly what stash_plan_for_bridge persists.
+        let envelope_json = serde_json::to_string(&signed).unwrap();
+        assert!(
+            envelope_json.contains("\"payload\""),
+            "fixture must be the envelope shape that used to crash the bridge"
+        );
+        let decoded = decode_plan_json(&envelope_json).unwrap();
+        assert_eq!(decoded.plan_id, plan.plan_id);
+    }
+
+    #[test]
+    fn decode_plan_json_falls_back_to_bare_inner_plan() {
+        use mvm_core::plan::signing::test_support::sample_plan;
+        let plan = sample_plan();
+        let inner_json = serde_json::to_string(&plan).unwrap();
+        let decoded = decode_plan_json(&inner_json).unwrap();
+        assert_eq!(decoded.plan_id, plan.plan_id);
+    }
+
+    #[test]
+    fn decode_plan_json_rejects_neither_shape() {
+        assert!(decode_plan_json(r#"{"not_a_plan":true}"#).is_err());
+    }
 
     /// Build a tiny passt-like binary fixture under a tempdir and a
     /// matching `passt-hashes.toml`. Returns both paths.


### PR DESCRIPTION
The Firecracker **gateway-bridge** path (`MVM_GATEWAY_BRIDGE=1`) was broken at three independent layers, so the per-VM `mvm-firecracker-bridge` sidecar crashed at startup and (hard-fail policy) SIGTERM'd the workload VM ~4s after boot. Because the forensic transcript capture (#1190) rides on that sidecar, **transcript capture was non-functional on Firecracker** — and the existing bridge tests use socket-pair relays, so none of this is exercised until a real FC VM boots through the sidecar.

Found + fixed via a live Firecracker e2e on a KVM box.

## Three fixes (one per commit)
1. **plan.json envelope decode** — the bridge parsed `BridgeConfigJson.plan_json` directly as a bare `ExecutionPlan`, but `stash_plan_for_bridge` persists `VmStartConfig.plan_json` = the **`SignedExecutionPlan` envelope** (`{"payload":…}`). Result: `decode … into ExecutionPlan: unknown field 'payload'` → crash. Added `firecracker_bridge::parse::decode_plan_json`, which extracts the inner plan from the envelope payload (mirroring `mvm-libkrun-supervisor`), with a bare-plan fallback for the lifecycle `write_plan` shape. 3 unit tests.
2. **seccomp `sigaltstack`** — the `mvm-jailer-lite` `BRIDGE_SYSCALLS` allowlist omitted `sigaltstack`; the Rust runtime's stack-overflow guard tripped `SIGSYS` the instant the packet thread spun up. (Confirmed via strace: `si_syscall=__NR_sigaltstack`.)
3. **complete the seccomp allowlist** — `sigaltstack` was just the first gap; the profile had **never run with seccomp on**. Enumerated the full post-confinement syscall set via strace (confinement bypassed in a throwaway box build) and added the rest: x86_64 `access, arch_prctl, chmod, ioctl, listen, mremap, newfstatat, prlimit64, unlink`; aarch64 mirror with the `*at` variants (`faccessat`/`fchmodat`/`unlinkat`, no `arch_prctl`).

## Validation
- `decode_plan_json` unit tests (envelope→inner, bare fallback, reject-neither) pass on macOS + the Linux target.
- `mvm-vm-host` + `mvm-hostd` build on the x86_64 Linux box; the bridge bin compiles with all fixes.
- Live FC e2e on the KVM box drove the diagnosis layer by layer (passt-hash → plan.json → `sigaltstack` → remaining seccomp gaps); each fix advanced the bridge to the next failure, confirming root causes.
- `fmt` / `clippy` / `check-no-spec-refs-in-comments` clean.

## Notes
- `arch_prctl` is x86_64-only (correctly excluded from the aarch64 block, which can't build it).
- A non-obvious operational fact this surfaced: on Firecracker the gateway-bridge (and thus transcript capture) requires `MVM_GATEWAY_BRIDGE=1`; the default dev `up --flake` path doesn't spawn the sidecar. Worth a docs/runbook line.
