### PR TITLE
feat(plan-204): route persistent guest-image builds through mvm-builderd (WS-D)

### DIFF
--- a/crates/mvm-build/src/persistent_builder.rs
+++ b/crates/mvm-build/src/persistent_builder.rs
@@ -932,12 +932,13 @@ fn shell_single_quote(s: &str) -> String {
 }
 
 /// Extract the leading hash from a Nix store path. Mirror of the
-/// single-shot helper in `libkrun_builder.rs` (kept local rather
-/// than re-exported to keep this module self-contained). Only used
-/// by `PersistentBuilderVm`, so gated on the `builder-vm` feature
-/// to keep no-feature builds free of dead-code warnings.
+/// single-shot helper in `libkrun_builder.rs`. Shared with the typed
+/// builder-dispatch path in `pipeline::dev_build`, which derives a
+/// build's revision hash from the daemon-reported store out-path.
+/// Gated on the `builder-vm` feature to keep no-feature builds free of
+/// dead-code warnings.
 #[cfg(any(test, feature = "builder-vm"))]
-fn extract_nix_store_hash(store_path: &str) -> Option<&str> {
+pub(crate) fn extract_nix_store_hash(store_path: &str) -> Option<&str> {
     let name = store_path.strip_prefix("/nix/store/")?;
     let (hash, _rest) = name.split_once('-')?;
     if hash.is_empty() { None } else { Some(hash) }

--- a/crates/mvm-build/src/pipeline/dev_build.rs
+++ b/crates/mvm-build/src/pipeline/dev_build.rs
@@ -610,6 +610,22 @@ fn dev_build_via_builder_vm_uncached(
             socket = %record.dispatch_socket_path.display(),
             "routing build through persistent supervisor"
         );
+        // Opt-in typed route (`MVM_BUILDERD_TYPED` + a reachable mvm-builderd):
+        // build `/work#<attr>` through the resident daemon and read the
+        // daemon-exported artifacts off the `/job` share. Not opted in / no
+        // daemon → `None` → legacy shell-job dispatch below; a daemon build
+        // failure or transport error → warn → legacy fallback (the opt-in path
+        // never turns a build the legacy path would pass into a failure).
+        match try_typed_persistent_build(env, &record, profile) {
+            Some(Ok(result)) => return Ok(result),
+            Some(Err(e)) => {
+                tracing::warn!(
+                    error = %e,
+                    "typed builder dispatch failed; falling back to legacy shell-job dispatch"
+                );
+            }
+            None => {}
+        }
         let persistent = crate::persistent_builder::PersistentBuilderVm::new(record.clone());
         match dev_build_with_builder_vm(env, flake_ref, profile, mode, &persistent) {
             Ok(result) => return Ok(result),
@@ -774,6 +790,120 @@ fn dev_build_with_builder_vm<B: crate::builder_vm::BuilderVm + ?Sized>(
 
     env.log_success(&format!(
         "Builder VM build complete; artifacts at {build_dir}"
+    ));
+
+    Ok(DevBuildResult {
+        build_dir,
+        vmlinux_path,
+        initrd_path,
+        rootfs_path,
+        revision_hash,
+        cached: false,
+        runner_dir,
+        artifact_sizes,
+    })
+}
+
+/// Attempt a guest-image build through the resident `mvm-builderd` typed
+/// control plane instead of the legacy shell-job dispatch.
+///
+/// Returns `None` when the typed route is not taken (caller not opted in via
+/// `MVM_BUILDERD_TYPED`, or no reachable daemon) so the caller falls back to the
+/// legacy persistent dispatch; `Some(Ok(_))` once the daemon built the image and
+/// exported its artifacts to the `/job` share, which we read into the dev build
+/// dir; `Some(Err(_))` on a daemon-reported build failure or a transport/IO
+/// error (the caller logs and falls back).
+///
+/// Builds `/work#<attr>` — the same target, and the same no-`--override-input`,
+/// that the legacy persistent dispatch uses (`run_flake_dispatch` ignores the
+/// source-checkout staging too) — so the two paths are behaviourally equivalent.
+#[cfg(feature = "builder-vm")]
+fn try_typed_persistent_build(
+    env: &dyn ShellEnvironment,
+    record: &crate::persistent_builder::SessionRecord,
+    profile: Option<&str>,
+) -> Option<Result<DevBuildResult>> {
+    use crate::builder_route::{BuildDispatch, BuildVerdict, try_typed_build};
+    use crate::builder_vm::host_system_linux;
+    use crate::libkrun_builder::GUEST_WORK_DIR;
+
+    let system = host_system_linux();
+    let attr_path = match profile {
+        Some(p) if p != "default" => format!("packages.{system}.tenant-{p}"),
+        _ => format!("packages.{system}.default"),
+    };
+
+    // A fresh per-build subdir under the session's `/job` share for the daemon
+    // to export into: host `<job_dir>/<id>/out` is guest `/job/<id>/out`.
+    let job_id = uuid::Uuid::new_v4().to_string();
+    let host_out = crate::persistent_builder::artifact_dir_for(&record.job_dir, &job_id);
+    if let Err(e) = std::fs::create_dir_all(&host_out) {
+        return Some(Err(anyhow::anyhow!(
+            "creating typed build output dir {}: {e}",
+            host_out.display()
+        )));
+    }
+    let guest_out = format!(
+        "/job/{job_id}/{out}",
+        out = crate::persistent_builder::ARTIFACT_SUBDIR
+    );
+
+    let vms_root = crate::builder_vm::builder_vm_cache_dir().join("vms");
+    match try_typed_build(&vms_root, GUEST_WORK_DIR, &attr_path, Some(&guest_out)) {
+        BuildDispatch::Fellback => None,
+        BuildDispatch::Took(Ok(BuildVerdict::Built { store_path, .. })) => {
+            Some(finalize_typed_persistent_build(env, &host_out, &store_path))
+        }
+        BuildDispatch::Took(Ok(BuildVerdict::Failed { message })) => Some(Err(anyhow::anyhow!(
+            "typed builder build failed: {message}"
+        ))),
+        BuildDispatch::Took(Err(e)) => {
+            Some(Err(anyhow::anyhow!("typed builder dispatch error: {e}")))
+        }
+    }
+}
+
+/// Read a typed build's exported artifacts off the `/job` share into the dev
+/// build cache dir and assemble the [`DevBuildResult`]. `store_path` is the
+/// daemon-reported `/nix/store/...` out-path, from which the cache revision hash
+/// is derived (matching the legacy persistent path's sidecar-derived hash).
+#[cfg(feature = "builder-vm")]
+fn finalize_typed_persistent_build(
+    env: &dyn ShellEnvironment,
+    host_out: &std::path::Path,
+    store_path: &str,
+) -> Result<DevBuildResult> {
+    let revision_hash = crate::persistent_builder::extract_nix_store_hash(store_path.trim())
+        .ok_or_else(|| anyhow::anyhow!("malformed store path from typed build: {store_path:?}"))?
+        .to_string();
+
+    let final_dir = dev_build_dir(&revision_hash);
+    if std::path::Path::new(&final_dir).exists() {
+        env.log_info(&format!(
+            "Cache hit on rev {revision_hash}; discarding typed build export."
+        ));
+    } else {
+        std::fs::create_dir_all(&final_dir)
+            .with_context(|| format!("creating final build dir {final_dir}"))?;
+        let host_out_str = host_out
+            .to_str()
+            .ok_or_else(|| anyhow::anyhow!("non-utf8 output dir {}", host_out.display()))?;
+        copy_staged_artifacts(host_out_str, &final_dir)?;
+    }
+    // Best-effort: drop the per-build export subdir under the `/job` share.
+    if let Some(job_sub) = host_out.parent() {
+        let _ = std::fs::remove_dir_all(job_sub);
+    }
+
+    let build_dir = final_dir;
+    let vmlinux_path = format!("{build_dir}/vmlinux");
+    let rootfs_path = format!("{build_dir}/rootfs.ext4");
+    let initrd_path = detect_initrd(env, &build_dir);
+    let runner_dir = detect_runner(env, &build_dir);
+    let artifact_sizes = measure_artifact_sizes(env, &build_dir, initrd_path.is_some());
+
+    env.log_success(&format!(
+        "Builder VM build complete (typed); artifacts at {build_dir}"
     ));
 
     Ok(DevBuildResult {
@@ -1340,6 +1470,47 @@ mod tests {
         fn log_success(&self, msg: &str) {
             self.logs.lock().unwrap().push(format!("SUCCESS: {}", msg));
         }
+    }
+
+    #[cfg(feature = "builder-vm")]
+    #[test]
+    fn finalize_typed_build_derives_hash_and_copies_exported_artifacts() {
+        let temp = tempfile::tempdir().expect("create temp MVM_DATA_DIR");
+        let mut process_env = mvm_core::util::test_env::TestEnv::new();
+        process_env.set("MVM_DATA_DIR", temp.path().join(".mvm"));
+
+        // Stand in for the daemon's export onto the `/job` share:
+        // `<job_dir>/<id>/out/{vmlinux,rootfs.ext4}`.
+        let host_out = temp.path().join("job").join("build-1").join("out");
+        std::fs::create_dir_all(&host_out).unwrap();
+        std::fs::write(host_out.join("vmlinux"), b"kernel").unwrap();
+        std::fs::write(host_out.join("rootfs.ext4"), b"rootfs").unwrap();
+
+        let env = TestEnv::new();
+        let store_path = "/nix/store/abc123hash-mvm-guest-image";
+        let result = finalize_typed_persistent_build(&env, &host_out, store_path).unwrap();
+
+        // Revision hash is the store-path leading hash; artifacts land in the
+        // dev build cache dir keyed by it.
+        assert_eq!(result.revision_hash, "abc123hash");
+        assert_eq!(result.build_dir, dev_build_dir("abc123hash"));
+        assert_eq!(std::fs::read(&result.vmlinux_path).unwrap(), b"kernel");
+        assert_eq!(std::fs::read(&result.rootfs_path).unwrap(), b"rootfs");
+        assert!(!result.cached);
+        // The per-build `/job` export subdir is cleaned up.
+        assert!(!host_out.exists());
+    }
+
+    #[cfg(feature = "builder-vm")]
+    #[test]
+    fn finalize_typed_build_rejects_a_malformed_store_path() {
+        let temp = tempfile::tempdir().expect("create temp MVM_DATA_DIR");
+        let mut process_env = mvm_core::util::test_env::TestEnv::new();
+        process_env.set("MVM_DATA_DIR", temp.path().join(".mvm"));
+        let host_out = temp.path().join("job").join("build-2").join("out");
+        std::fs::create_dir_all(&host_out).unwrap();
+        let env = TestEnv::new();
+        assert!(finalize_typed_persistent_build(&env, &host_out, "not-a-store-path").is_err());
     }
 
     #[cfg(feature = "builder-vm")]

--- a/specs/plans/204-builder-vm-resident-control-plane.md
+++ b/specs/plans/204-builder-vm-resident-control-plane.md
@@ -313,13 +313,22 @@ arm lands with the daemon's image baking (boot-gated).
       `artifact_path` = that host-readable dir while `store_path` stays the
       out-path. `run_build`/`try_typed_build` thread `output_dir` and return the
       `artifact_dir`. Unit-tested: dir/file out-path export, missing-rootfs
-      error, and the full `dispatch_nix_build` export path (479 mvm-build tests).
-      **Remaining to make builds the default:** wire `dev_build` to set up
-      `<session.job_dir>/<op>/out`, call `try_typed_build` with the `/job/<op>/out`
-      guest path, read the exported artifacts into the dev build dir, fall back to
-      legacy on `Fellback`; then a builder-image rebake to deploy the daemon
-      change and a live typed guest-image build proof; then flip `resolve_route`'s
-      default for builds.
+      error, and the full `dispatch_nix_build` export path.
+      **dev_build wiring landed (opt-in):** `dev_build_via_builder_vm_uncached`
+      now tries `try_typed_persistent_build` before the legacy persistent
+      dispatch — it mints a `/job/<id>/out` export dir, calls `try_typed_build`
+      for `/work#<attr>` (the same target and same no-`--override-input` the
+      legacy `run_flake_dispatch` uses, so the paths are behaviourally
+      equivalent), then `finalize_typed_persistent_build` derives the revision
+      hash from the daemon-reported store path and reads the exported artifacts
+      into the dev build cache dir. `Fellback` (not opted in / no daemon) and any
+      daemon/transport error fall through to the legacy dispatch, so the opt-in
+      path never turns a passing build into a failure. Unit-tested:
+      `finalize_typed_build_*` (hash derivation + artifact copy + cleanup;
+      malformed-store-path rejection).
+      **Remaining to make builds the default:** a builder-image rebake to deploy
+      the daemon export change, a live typed guest-image build proof on KVM, then
+      flip `resolve_route`'s default for builds.
 - [ ] Gate raw shell execution behind an explicit debug/development flag.
       Blocked on the line above — raw shell stays the default until a typed op replaces it; the gate flips once the typed path is the default.
 - [x] Add a lint or structural test that prevents new normal-path shell jobs.


### PR DESCRIPTION
## Summary

**Stacked on #1213** (daemon export). Wires `dev_build`'s persistent path to the typed daemon export. **Opt-in (`MVM_BUILDERD_TYPED`), default-off** — zero behaviour change until opted in.

`dev_build_via_builder_vm_uncached` now tries `try_typed_persistent_build` before the legacy persistent dispatch:
- mints a fresh `/job/<id>/out` export dir under the session `job_dir` (host `<job_dir>/<id>/out` == guest `/job/<id>/out`, reusing `artifact_dir_for`),
- calls `builder_route::try_typed_build` for `/work#<attr>` — the **same target** and the **same no-`--override-input`** the legacy `run_flake_dispatch` uses, so the two paths are behaviourally equivalent,
- `finalize_typed_persistent_build` derives the revision hash from the daemon-reported store path (shared `persistent_builder::extract_nix_store_hash`, now `pub(crate)`) and reads the exported `vmlinux`/`rootfs.ext4` into the dev build cache dir, then cleans up the per-build `/job` subdir.

`Fellback` (not opted in / no reachable daemon) and any daemon build failure or transport error **fall through to the legacy dispatch** — the opt-in path never turns a build the legacy path would pass into a failure.

## Verification

- `finalize_typed_build_derives_hash_and_copies_exported_artifacts` + `finalize_typed_build_rejects_a_malformed_store_path`; `dev_build`/`persistent_builder`/`builder_route`/`builderd` targeted suites green; `cargo clippy -p mvm-build --features builder-vm` + `cargo fmt --all -- --check` clean.

## Remaining (#4, next)

Builder-image rebake to deploy the daemon export change, a **live typed guest-image build proof on KVM**, then flip `resolve_route`'s default for builds. (The currently-running builder has the old daemon, which rejects the new `output_dir` field under `deny_unknown_fields` and falls back to legacy — so the live proof requires the rebake first.)