### PR TITLE
feat(cli): animated spinner for the builder-VM build wait

### DIFF
--- a/crates/mvm-cli/src/commands/env/dev_vz.rs
+++ b/crates/mvm-cli/src/commands/env/dev_vz.rs
@@ -2394,19 +2394,58 @@ const BUILD_HEARTBEAT_INTERVAL: std::time::Duration = std::time::Duration::from_
 struct BuildHeartbeat {
     stop: std::sync::Arc<std::sync::atomic::AtomicBool>,
     handle: Option<std::thread::JoinHandle<()>>,
+    // `Some` on a TTY: an animated spinner whose message is refreshed with the
+    // elapsed time. `None` when piped/redirected — there the text path emits a
+    // periodic line instead (a spinner draws nothing off a terminal).
+    spinner: Option<indicatif::ProgressBar>,
 }
 
 #[cfg(feature = "builder-vm")]
 impl BuildHeartbeat {
     fn start(activity: &'static str) -> Self {
-        // `notice`, not `info`: the heartbeat is always-on liveness — the only
-        // feedback during a multi-minute silent build — so it must survive the
-        // default quiet mode where `info` chatter is suppressed.
-        Self::start_with(activity, BUILD_HEARTBEAT_INTERVAL, ui::notice)
+        // On a TTY the animated spinner is the liveness signal and reads far
+        // better than a wall of repeating text lines. Off a TTY (pipe, CI, log
+        // capture) a spinner renders nothing, so fall back to the periodic text
+        // line — routed through `notice`, not `info`, so it survives the default
+        // quiet mode where `info` chatter is suppressed.
+        if std::io::IsTerminal::is_terminal(&std::io::stderr()) {
+            Self::start_spinner(activity)
+        } else {
+            Self::start_with(activity, BUILD_HEARTBEAT_INTERVAL, ui::notice)
+        }
     }
 
-    /// Injectable core: `interval` and `emit` are parameters so a test can drive
-    /// a tight cadence into a counter instead of stdout.
+    /// TTY path: an `indicatif` spinner refreshed with elapsed time. The spinner
+    /// self-animates via its steady tick; this thread only updates the message.
+    fn start_spinner(activity: &'static str) -> Self {
+        use std::sync::atomic::Ordering;
+        let pb = ui::spinner(&ui::format_build_progress(
+            activity,
+            std::time::Duration::ZERO,
+        ));
+        let stop = std::sync::Arc::new(std::sync::atomic::AtomicBool::new(false));
+        let thread_stop = std::sync::Arc::clone(&stop);
+        let pb_thread = pb.clone();
+        let handle = std::thread::spawn(move || {
+            let start = std::time::Instant::now();
+            while !thread_stop.load(Ordering::Relaxed) {
+                std::thread::sleep(std::time::Duration::from_millis(250));
+                if thread_stop.load(Ordering::Relaxed) {
+                    break;
+                }
+                pb_thread.set_message(ui::format_build_progress(activity, start.elapsed()));
+            }
+        });
+        Self {
+            stop,
+            handle: Some(handle),
+            spinner: Some(pb),
+        }
+    }
+
+    /// Injectable text core: `interval` and `emit` are parameters so a test can
+    /// drive a tight cadence into a counter instead of stdout. Also the non-TTY
+    /// runtime path.
     fn start_with(
         activity: &'static str,
         interval: std::time::Duration,
@@ -2434,6 +2473,7 @@ impl BuildHeartbeat {
         Self {
             stop,
             handle: Some(handle),
+            spinner: None,
         }
     }
 }
@@ -2444,6 +2484,10 @@ impl Drop for BuildHeartbeat {
         self.stop.store(true, std::sync::atomic::Ordering::Relaxed);
         if let Some(h) = self.handle.take() {
             let _ = h.join();
+        }
+        // Clear the spinner line so the build's own next output starts clean.
+        if let Some(pb) = self.spinner.take() {
+            pb.finish_and_clear();
         }
     }
 }

--- a/crates/mvm-cli/src/ui.rs
+++ b/crates/mvm-cli/src/ui.rs
@@ -77,6 +77,14 @@ pub fn format_heartbeat(activity: &str, elapsed: std::time::Duration) -> String 
     )
 }
 
+/// Spinner message for a long, silent blocking step: `<activity> — <secs>s
+/// elapsed`. Used on a TTY where the animated spinner already conveys liveness,
+/// so the message stays terse (no need for the [`format_heartbeat`] "not a
+/// hang" reassurance the non-TTY text line carries). Pure (testable).
+pub fn format_build_progress(activity: &str, elapsed: std::time::Duration) -> String {
+    format!("{activity} — {}s elapsed", elapsed.as_secs())
+}
+
 // ---------------------------------------------------------------------------
 // Banner / status / prompts / spinners (always printed; delegate)
 // ---------------------------------------------------------------------------
@@ -135,5 +143,18 @@ mod tests {
         assert!(line.contains("not a hang"));
         // Whole seconds, no fractional noise.
         assert!(!line.contains("40.0"));
+    }
+
+    #[test]
+    fn format_build_progress_is_terse_with_whole_seconds() {
+        assert_eq!(
+            format_build_progress("Builder VM image build", std::time::Duration::from_secs(23)),
+            "Builder VM image build — 23s elapsed"
+        );
+        // The spinner conveys liveness, so the verbose "not a hang" reassurance
+        // is intentionally absent here.
+        let line = format_build_progress("x", std::time::Duration::from_millis(7_900));
+        assert_eq!(line, "x — 7s elapsed");
+        assert!(!line.contains("hang"));
     }
 }


### PR DESCRIPTION
## Why

`mvmctl up` / `up --dev` blocks for minutes during the Stage 0 builder-VM image build while `nix` runs silently inside the guest. The only feedback was a text heartbeat repeated every ~20s (`"… still running — Ns elapsed"`), which on a terminal reads as a wall of repeating noise.

## What

`BuildHeartbeat` now renders an animated `indicatif` spinner (already a workspace dep, via `ui::spinner`) whose message carries the live elapsed time **when stderr is a TTY**, and falls back to the existing periodic text line **off a TTY** (pipe, CI, log capture) where a spinner draws nothing. The spinner is cleared on drop so the build's own next output starts clean.

- New pure formatter `ui::format_build_progress` (terse `"<activity> — Ns elapsed"`) with a unit test.
- Non-TTY text path and its lifecycle test (`build_heartbeat_emits_while_alive_and_stops_on_drop`) unchanged.

## Verification

`cargo fmt --all --check`, `cargo clippy -p mvm-cli --features builder-vm -D warnings`: clean. Tests: `format_build_progress`, `format_heartbeat`, `build_heartbeat_*` all pass.

## Scope / follow-up

This is the **spinner** half of the build-progress DX. Live **log streaming** (the bigger ask) is intentionally a separate PR: the in-guest `nix build` is invoked without `-L` and its output isn't routed to the guest console today (that's *why* the build is silent), so real streaming needs `nix build -L --print-build-logs`, console routing, a host-side tail-and-forward gated by `-v`/`RUST_LOG`, and a builder-VM boot to validate.