### PR TITLE
feat(cli): stream the Stage 0 builder build log under -v/RUST_LOG

### DIFF
--- a/crates/mvm-build/src/libkrun_builder.rs
+++ b/crates/mvm-build/src/libkrun_builder.rs
@@ -481,13 +481,18 @@ impl LibkrunBuilderVm {
         })?;
         let console_log = vm_state_dir.join("console.log");
         // The in-guest nix build streams its `--print-build-logs` to this
-        // console as it runs (stage0-init echoes each line live), so point the
-        // operator at it — the build is otherwise silent for minutes. `[mvm]`
-        // eprintln matches the existing Stage 0 hint channel (stage0.rs).
-        eprintln!(
-            "[mvm] Stage 0 build log streams to {} — `tail -f` it to watch progress",
-            console_log.display()
-        );
+        // console as it runs (stage0-init echoes each line live). In verbose
+        // mode the host forwards that console to stderr, so the build log is
+        // already on screen — pointing at the file would be redundant. In quiet
+        // mode the build is silent for minutes, so point the operator at the
+        // file. `[mvm]` eprintln matches the existing Stage 0 hint channel.
+        if !self.verbose {
+            eprintln!(
+                "[mvm] Stage 0 build log streams to {} — `tail -f` it to watch progress \
+                 (or re-run with `-v` to stream it here)",
+                console_log.display()
+            );
+        }
 
         let mut krun = krun_context_for_image(&vm_name, &image)?
             .with_resources(self.vcpus, self.memory_mib)

--- a/crates/mvm-cli/src/commands/env/dev_vz.rs
+++ b/crates/mvm-cli/src/commands/env/dev_vz.rs
@@ -2344,15 +2344,20 @@ pub(in crate::commands) fn bootstrap_builder_vm_image() -> Result<()> {
             // removed; `nix/images/builder/flake.nix` is deleted.
             #[cfg(feature = "builder-vm")]
             {
-                // The Stage 0 build runs `nix` inside the guest with no
-                // host-visible output for minutes; a liveness heartbeat keeps it
-                // from reading as a hang. Dropped (thread stopped) when the build
-                // returns.
-                let _heartbeat = BuildHeartbeat::start("Builder VM image build");
+                // `-v`/`RUST_LOG` streams the in-guest nix `--print-build-logs`
+                // output live to the terminal. In that mode the streamed lines
+                // are the progress signal, so the spinner/heartbeat stays off (it
+                // would fight the scrolling output). Quiet mode keeps the spinner:
+                // the Stage 0 build is otherwise silent for minutes and would read
+                // as a hang.
+                let verbose = mvm::ui::is_verbose();
+                let _heartbeat =
+                    (!verbose).then(|| BuildHeartbeat::start("Builder VM image build"));
                 bootstrap_builder_vm_image_via_root_dir_stage0(
                     &flake_dir,
                     &out_dir,
                     &source_fingerprint,
+                    verbose,
                 )
                 .context("building the source-checkout builder VM image via root-dir Stage 0")
             }
@@ -2567,6 +2572,7 @@ fn bootstrap_builder_vm_image_via_root_dir_stage0(
     builder_flake_dir: &str,
     out_dir: &str,
     source_fingerprint: &str,
+    verbose: bool,
 ) -> Result<()> {
     let _stage0_guard = acquire_stage0_lock(out_dir)?;
 
@@ -2681,6 +2687,7 @@ fn bootstrap_builder_vm_image_via_root_dir_stage0(
             &host_bin_dir,
             kernel,
             source_fingerprint,
+            verbose,
         )
     } else {
         run_stage0_root_dir(
@@ -2690,6 +2697,7 @@ fn bootstrap_builder_vm_image_via_root_dir_stage0(
             "/init",
             &host_bin_dir,
             source_fingerprint,
+            verbose,
         )
     };
     let duration_ms = started.elapsed().as_millis() as u64;
@@ -2807,6 +2815,7 @@ fn run_stage0_rootfs_with_external_kernel(
     host_bin_dir: &std::path::Path,
     external_kernel: &std::path::Path,
     source_fingerprint: &str,
+    verbose: bool,
 ) -> std::result::Result<(), (Stage0FailureStage, anyhow::Error)> {
     use mvm_build::builder_backend_select::resolve_stage0_backend;
 
@@ -2822,7 +2831,7 @@ fn run_stage0_rootfs_with_external_kernel(
         )
     })?;
 
-    let backend = resolve_stage0_backend(false);
+    let backend = resolve_stage0_backend(verbose);
     backend
         .run_stage0(
             guest_root_dir,
@@ -3047,6 +3056,7 @@ fn run_stage0_root_dir(
     entry_path: &str,
     host_bin_dir: &std::path::Path,
     source_fingerprint: &str,
+    verbose: bool,
 ) -> std::result::Result<(), (Stage0FailureStage, anyhow::Error)> {
     use mvm_build::builder_backend_select::resolve_stage0_backend;
 
@@ -3056,7 +3066,9 @@ fn run_stage0_root_dir(
     // Vz auto-detect default on macOS-26+, since Vz Stage 0 is still a gap.
     // That preserves the "Stage 0 is libkrun even on Vz-default hosts"
     // invariant while adding QEMU as the second implemented backend.
-    let backend = resolve_stage0_backend(false);
+    // `verbose` makes the backend forward the in-guest nix `--print-build-logs`
+    // output (already streamed to the guest console) live to the host stderr.
+    let backend = resolve_stage0_backend(verbose);
     backend
         .run_stage0(
             guest_root_dir,


### PR DESCRIPTION
Stacked on #1218 (the spinner). Base will retarget to `main` once #1218 merges.

## Why

`mvmctl up --dev` builds the builder-VM image by running `nix` inside a guest, and the host only wrote a `console.log` while telling you to `tail -f` it. You asked for the logs to stream through `RUST_LOG` instead.

## What

The forwarding plumbing already existed and was the surprising part of the investigation:
- `stage0-init` already runs `nix … --print-build-logs` and streams each line to the guest console live.
- The host's `echo_console_chunk` / `panic_watcher` already tails `console.log` and forwards it to stderr **under a `verbose` flag**.

The only missing wire: the `dev up` Stage 0 entry hardcoded `verbose=false`. This threads the resolved verbosity (`-v` or any `RUST_LOG`, via `mvm::ui::is_verbose()`) through `bootstrap_builder_vm_image` → `run_stage0_root_dir` / `run_stage0_rootfs_with_external_kernel` → `resolve_stage0_backend(verbose)`.

- In **verbose** mode the streamed build log is the progress signal, so the spinner (#1218) stays off (it would fight the scrolling output) and the "tail -f it yourself" hint is suppressed.
- In **quiet** mode the spinner stays, and the hint now also points at `-v` to stream.

So: `mvmctl -v up --dev` (or `RUST_LOG=… mvmctl up --dev`) now streams the nix build log to the terminal; plain `mvmctl up --dev` shows the spinner.

## Verification

`cargo fmt --all --check`, `cargo clippy -p mvm-cli -p mvm-build --features builder-vm -D warnings`: clean. 24 unit tests pass (heartbeat lifecycle + formatters). Live cold `up --dev -v` streaming validation in progress — will note the result.