### PR TITLE
feat(nix): drop the Rust toolchain (~1.9 GB) from the dev builder rootfs

### DIFF
--- a/nix/images/builder-vm/flake.nix
+++ b/nix/images/builder-vm/flake.nix
@@ -257,9 +257,15 @@
       # Added on top of `builderPackages` when `interactive = true`.
       # Provides a useful shell environment for contributors debugging
       # inside the builder VM via `mvmctl dev shell`.
+      #
+      # The Rust toolchain (`cargo` + `rustc`) is deliberately NOT baked in:
+      # it is ~1 GB of closure and `mvm` itself builds on the host, while Rust
+      # guest workloads build through nix (`buildRustPackage`) — so interactive
+      # `cargo`/`rustc` here only served ad-hoc poking. The builder VM has `nix`
+      # and (in the dev shell) open egress, so a contributor who wants it runs
+      # `nix shell nixpkgs#rustc nixpkgs#cargo` on demand; it then persists in
+      # the `/nix-store` image. Halving the dev rootfs is worth the one-time pull.
       devPackages = pkgs: with pkgs; [
-        cargo
-        rustc
         nano
       ];
 


### PR DESCRIPTION
## Why

The dev `rootfs.ext4` is ~2.8 GB. The single biggest chunk is the **Rust toolchain** (`cargo` + `rustc`, ~1 GB of closure), which the interactive builder VM baked in purely for ad-hoc poking in `mvmctl dev shell`:

```nix
devPackages = pkgs: with pkgs; [ cargo rustc nano ];
```

But `mvm` itself builds on the **host**, and Rust guest workloads build through **nix** (`buildRustPackage`) — so interactive `cargo`/`rustc` inside the builder VM is low value for its size.

## What

Drop `cargo` + `rustc` from `devPackages` (keep `nano`). Rust isn't gone — the builder VM has `nix` and, in the dev shell, **open egress** (the Flake-arm posture; the egress lockdown only applies to the app-deps *install* arm, confirmed in `mvm-host-vm-init::apply_job_posture`). So a contributor who wants it runs:

```sh
nix shell nixpkgs#rustc nixpkgs#cargo
```

on demand, and it persists in the `/nix-store` image after first pull.

Net: roughly **halves the dev rootfs**, speeding every cold `mvmctl dev up` (less to build, ext4-format, and attach) and cutting disk use, for a one-time on-demand pull on the rare interactive Rust use.

## Verification

- Egress premise confirmed in code: `apply_job_posture` → `open_egress` for Flake jobs (lockdown only for Install jobs), so on-demand `nix shell` reaches substituters in the dev shell.
- The headless builder variant already lacks Rust and builds fine, so dropping it from the dev variant can't break builds.
- **Live cold build of the slimmed image in progress** (isolated cache) — will post the measured before/after rootfs size.