### PR TITLE
chore(deps): patch rand + time security advisories

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3678,9 +3678,9 @@ dependencies = [
 
 [[package]]
 name = "num-conv"
-version = "0.1.0"
+version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "51d515d32fb182ee37cda2ccdcb92950d6a3c2893aa280e540671c2cd0f3b1d9"
+checksum = "521739c6d2bac4aa25192232afe6841231376b2b26d4d9fae5ecf8ca5772e441"
 
 [[package]]
 name = "num-integer"
@@ -4562,7 +4562,7 @@ dependencies = [
  "bytes",
  "getrandom 0.3.4",
  "lru-slab",
- "rand 0.9.2",
+ "rand 0.9.4",
  "ring",
  "rustc-hash",
  "rustls",
@@ -4616,9 +4616,9 @@ dependencies = [
 
 [[package]]
 name = "rand"
-version = "0.9.2"
+version = "0.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6db2770f06117d490610c7488547d543617b21bfa07796d7a12f6f1bd53850d1"
+checksum = "44c5af06bb1b7d3216d91932aed5265164bf384dc89cd6ba05cf59a35f5f76ea"
 dependencies = [
  "rand_chacha 0.9.0",
  "rand_core 0.9.5",
@@ -5894,9 +5894,9 @@ dependencies = [
 
 [[package]]
 name = "time"
-version = "0.3.45"
+version = "0.3.47"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f9e442fc33d7fdb45aa9bfeb312c095964abdf596f7567261062b2a7107aaabd"
+checksum = "743bd48c283afc0388f9b8827b976905fb217ad9e647fae3a379a9283c4def2c"
 dependencies = [
  "deranged",
  "itoa",
@@ -5909,15 +5909,15 @@ dependencies = [
 
 [[package]]
 name = "time-core"
-version = "0.1.7"
+version = "0.1.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8b36ee98fd31ec7426d599183e8fe26932a8dc1fb76ddb6214d05493377d34ca"
+checksum = "7694e1cfe791f8d31026952abf09c69ca6f6fa4e1a1229e18988f06a04a12dca"
 
 [[package]]
 name = "time-macros"
-version = "0.2.25"
+version = "0.2.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "71e552d1249bf61ac2a52db88179fd0673def1e1ad8243a00d9ec9ed71fee3dd"
+checksum = "2e70e4c5a0e0a8a4823ad65dfe1a6930e4f4d756dcd9dd7939022b5e8c501215"
 dependencies = [
  "num-conv",
  "time-core",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -143,7 +143,7 @@ resolver = "3"
 # promise.
 version = "0.16.1"
 edition = "2024"
-rust-version = "1.85"
+rust-version = "1.88"
 license = "Apache-2.0"
 repository = "https://github.com/tinylabscom/mvm"
 homepage = "https://github.com/tinylabscom/mvm"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -143,7 +143,7 @@ resolver = "3"
 # promise.
 version = "0.16.1"
 edition = "2024"
-rust-version = "1.88"
+rust-version = "1.85"
 license = "Apache-2.0"
 repository = "https://github.com/tinylabscom/mvm"
 homepage = "https://github.com/tinylabscom/mvm"

--- a/deny.toml
+++ b/deny.toml
@@ -62,16 +62,6 @@ ignore = [
     # the shipped binary. Will resolve when sigstore (or its
     # json-syntax dep) bumps to proc-macro-error2.
     { id = "RUSTSEC-2024-0370", reason = "proc-macro-error v1 unmaintained; build-time-only via sigstore→json-syntax; no runtime surface; audited 2026-05-01" },
-    # `time v0.3.x` stack-exhaustion DoS via crafted parsed input.
-    # Path: sigstore → openidconnect → serde_with → time. mvmctl uses
-    # the time crate transitively only inside the cosign verification
-    # path, where the input is the manifest signature material from
-    # the project's release pipeline — not attacker-influenced bytes
-    # capable of triggering the stack exhaustion. The advisory's DoS
-    # only matters when parsing externally-supplied time strings;
-    # we don't expose that surface. Re-evaluate when time v0.4
-    # ships with the bound.
-    { id = "RUSTSEC-2026-0009", reason = "time stack-exhaustion DoS; transitive via sigstore→openidconnect→serde_with; no untrusted-time-string parsing surface in mvmctl; audited 2026-05-01" },
     # `async-std` discontinued. DEV-DEPENDENCY ONLY: pulled via httpmock
     # (test HTTP mock) → async-object-pool → async-std. Absent from every
     # shipped artifact (mvmctl, guest agents, supervisors); no production

--- a/deny.toml
+++ b/deny.toml
@@ -42,19 +42,29 @@ ignore = [
     # `number_prefix` is a pure-functional formatter used by indicatif.
     # Unmaintained but functionally complete; no security surface.
     { id = "RUSTSEC-2025-0119", reason = "transitive via indicatif; pure formatter, no IO, audited 2026-04-30" },
-    # `rsa v0.9.x` Marvin Attack timing side-channel. Pulled in via
-    # `sigstore → openidconnect → rsa` (plan 36 PR-A.2 introduces
-    # `sigstore` for cosign-keyless verification of the dev image
-    # manifest). The advisory has no safe upgrade today; the
-    # RustCrypto team is working on a constant-time fix. Mvmctl's
-    # use of `rsa` is purely verification-side: we only consume
-    # signatures from the project's release pipeline against
-    # operator-controlled local input (downloaded artifact bytes).
-    # The Marvin Attack requires an attacker to observe timing of
-    # decryption operations against attacker-influenced ciphertexts,
-    # which is not the threat shape mvmctl exposes. Re-evaluate when
-    # `rsa v0.10` ships with the constant-time fix.
-    { id = "RUSTSEC-2023-0071", reason = "rsa Marvin Attack; transitive via sigstore→openidconnect; mvmctl is verification-only side, no decryption operations exposed; audited 2026-05-01" },
+    # `rsa v0.9.x` Marvin Attack timing side-channel. Reaches the
+    # shipped `mvmctl` (release builds enable `manifest-verify`) via
+    # `openidconnect → sigstore`, where sigstore backs cosign-keyless
+    # verification of the dev image manifest.
+    #
+    # Why this is not exploitable here: the Marvin Attack is a timing
+    # side-channel on RSA *private-key* operations (PKCS#1 v1.5
+    # decryption / signing) by which an attacker recovers the private
+    # key. mvm holds no RSA private key and performs no RSA decryption
+    # — its only sigstore use is bundle signature *verification* with
+    # public keys (`mvm-core/src/crypto/image_verify.rs`), and cosign
+    # bundles are ECDSA P-256, so the rsa path is not exercised at
+    # runtime. The advisory's threat shape does not exist in mvm.
+    #
+    # Why we cannot drop it: in sigstore 0.13 `rsa` is a non-optional
+    # dependency, so no feature trim removes it. Bumping to sigstore
+    # 0.14 drops sigstore's *direct* rsa edge but leaves it reachable
+    # via `openidconnect` (the `verify → fulcio → oauth` feature chain
+    # hard-pulls the OIDC client, which still depends on rsa 0.9). The
+    # only real fix is upstream: a constant-time `rsa` (0.10, still
+    # pre-release) adopted by openidconnect. Tracking follow-up in
+    # specs/plans/36. Re-evaluate when openidconnect ships on rsa 0.10.
+    { id = "RUSTSEC-2023-0071", reason = "rsa Marvin Attack; reaches release mvmctl via openidconnect→sigstore (manifest-verify); verification-only, no RSA private-key/decrypt ops, cosign bundles are ECDSA P-256; non-optional in sigstore 0.13 and 0.14 only relocates the edge to openidconnect; fix is upstream rsa 0.10; audited 2026-06-21" },
     # `proc-macro-error v1` is unmaintained — replaced upstream by
     # `proc-macro-error2`. Transitive via
     # `sigstore → json-syntax → locspan-derive`. This is a

--- a/specs/plans/36-sealed-signed-builder-image.md
+++ b/specs/plans/36-sealed-signed-builder-image.md
@@ -454,3 +454,18 @@ deliberate design decision, not a code rollback.
 - **Lockfile inventory**: confirm `nix/dev/flake.lock` exists alongside
   `nix/flake.nix::flake.lock` and `nix/images/builder/flake.lock`. Add
   any others surfaced by `find nix -name flake.lock`.
+
+## Deferred follow-ups
+
+- [ ] **Drop the `rsa` Marvin-Attack advisory (RUSTSEC-2023-0071).**
+  `manifest-verify` pulls `sigstore`, which transitively pulls
+  `rsa 0.9` and trips RUSTSEC-2023-0071 (accepted in `deny.toml` —
+  verification-only, no RSA private-key ops, cosign bundles are ECDSA
+  P-256). `rsa` is non-optional in sigstore 0.13; sigstore 0.14 drops
+  its direct edge but `rsa` still arrives via
+  `verify → fulcio → oauth → openidconnect → rsa`. The real fix is a
+  constant-time `rsa` 0.10 (still pre-release) adopted by
+  `openidconnect`. Re-evaluate — and remove the ignore — once
+  `openidconnect` ships on `rsa` 0.10. A sigstore 0.14 bump is a
+  separate modernization (clears RUSTSEC-2024-0370, pulls a new crypto
+  stack needing ADR-002 re-vetting); it does not by itself remove `rsa`.


### PR DESCRIPTION
## What

`cargo audit` flagged two actionable advisories. Both are in-major patch bumps.

| Crate | Advisory | Change |
|---|---|---|
| `rand` | RUSTSEC-2026-0097 (unsound — aliased mutable ref in `ThreadRng` reseed; via `quinn-proto`/`reqwest`) | 0.9.2 → 0.9.4 |
| `time` | RUSTSEC-2026-0009 (DoS — parser stack exhaustion; via `sigstore`/`rcgen`) | 0.3.45 → 0.3.47 |

`rand` was a **new, unaccepted** finding — it was not in `deny.toml`. `time` was previously accepted there; 0.3.47 actually fixes it, so the stale ignore entry is removed.

## MSRV stays at 1.85

`time 0.3.47` declares Rust 1.88, but only needs it to *build* — the CI/dev toolchain is 1.95 and there is no MSRV gate, so `--locked` builds are unaffected. An initial bump to `rust-version = 1.88` was reverted: at MSRV 1.88 clippy begins enforcing let-chain `collapsible_if` workspace-wide (let-chains stabilized in 1.88), which fails the Lint job on pre-existing code. Promoting the floor to 1.88 + the let-chain modernization is a deliberate separate change, not security-patch scope.

## `rsa` (RUSTSEC-2023-0071) — accepted, no clean fix

Traced in full and documented in `deny.toml`:
- Reaches the **release** binary (`manifest-verify`) via `openidconnect → sigstore`.
- **Not exploitable here:** Marvin targets RSA *private-key* ops (decrypt/sign); mvm only *verifies* cosign bundles with public keys (`image_verify.rs`), and bundles are ECDSA P-256 — the rsa path isn't exercised.
- **Cannot be trimmed:** `rsa` is non-optional in sigstore 0.13. A sigstore 0.14 experiment confirmed 0.14 drops the *direct* edge but `rsa` still arrives via `verify → fulcio → oauth → openidconnect`. Real fix is upstream `rsa` 0.10 (pre-release) adopted by `openidconnect`. Tracked in `specs/plans/36`.

## Verification

- `cargo clippy --workspace --all-targets -- -D warnings` → clean
- `cargo deny check advisories` → advisories ok
- `cargo fmt --all -- --check` → clean
- Remaining `cargo audit` warnings are unmaintained-crate notices already documented in `deny.toml`.