### PR TITLE
fix(plan-203): capture denied (dropped) egress in the forensic transcript (closes #1231)

### DIFF
--- a/crates/mvm-core/src/transcript.rs
+++ b/crates/mvm-core/src/transcript.rs
@@ -42,6 +42,12 @@ pub struct ChunkRecord {
     pub sha256_hex: String,
     pub size_bytes: u64,
     pub direction: Direction,
+    /// True when the frame was denied by egress policy (dropped, not forwarded)
+    /// rather than crossing the boundary — forensically the interesting case (an
+    /// attempt to reach a blocked endpoint). `#[serde(default)]` so manifests
+    /// written before this field parse as `false` (forwarded).
+    #[serde(default)]
+    pub dropped: bool,
 }
 
 /// Which admitted workload/session a transcript belongs to. Capture is never
@@ -253,6 +259,26 @@ impl TranscriptWriter {
     /// Encrypt and append one payload chunk, or fail closed on a bound. The
     /// budget is checked on the *plaintext* size before any ciphertext lands.
     pub fn push(&mut self, direction: Direction, plaintext: &[u8]) -> Result<(), TranscriptError> {
+        self.push_inner(direction, false, plaintext)
+    }
+
+    /// Append a frame that egress policy **denied** (dropped, not forwarded),
+    /// recorded with `dropped = true`. Same bounds + at-rest encryption as
+    /// [`push`]; lets the forensic transcript show attempted-but-blocked egress.
+    pub fn push_dropped(
+        &mut self,
+        direction: Direction,
+        plaintext: &[u8],
+    ) -> Result<(), TranscriptError> {
+        self.push_inner(direction, true, plaintext)
+    }
+
+    fn push_inner(
+        &mut self,
+        direction: Direction,
+        dropped: bool,
+        plaintext: &[u8],
+    ) -> Result<(), TranscriptError> {
         self.budget.try_add(plaintext.len() as u64)?;
         let seq = self.chunks.len() as u64;
         let file = format!("{seq}.chunk");
@@ -273,6 +299,7 @@ impl TranscriptWriter {
             sha256_hex,
             size_bytes: ciphertext.len() as u64,
             direction,
+            dropped,
         });
         Ok(())
     }
@@ -383,6 +410,7 @@ mod tests {
             sha256_hex: sha,
             size_bytes: body.len() as u64,
             direction: Direction::Egress,
+            dropped: false,
         }
     }
 
@@ -394,6 +422,7 @@ mod tests {
             sha256_hex: "ab".to_string(),
             size_bytes: 2,
             direction: Direction::Ingress,
+            dropped: false,
         }]);
         let json = serde_json::to_string(&m).unwrap();
         let back: TranscriptManifest = serde_json::from_str(&json).unwrap();
@@ -457,6 +486,7 @@ mod tests {
             sha256_hex: "00".to_string(),
             size_bytes: 1,
             direction: Direction::Egress,
+            dropped: false,
         };
         assert!(matches!(
             verify_chunks(&manifest(vec![c]), dir.path()).unwrap_err(),
@@ -473,6 +503,7 @@ mod tests {
             sha256_hex: "00".to_string(),
             size_bytes: 1,
             direction: Direction::Egress,
+            dropped: false,
         };
         assert!(matches!(
             verify_chunks(&manifest(vec![c]), dir.path()).unwrap_err(),
@@ -524,6 +555,24 @@ mod tests {
         verify_chunks(&manifest, dir.path()).unwrap();
         let out = export(&manifest, dir.path(), &fixed_key(7)).unwrap();
         assert_eq!(out, b"GET / HTTP/1.1\r\nHTTP/1.1 200 OK\r\n");
+    }
+
+    #[test]
+    fn push_dropped_marks_the_chunk_and_still_exports() {
+        let dir = tempfile::tempdir().unwrap();
+        let mut w = TranscriptWriter::new(dir.path(), fixed_key(7), writer_config());
+        w.push(Direction::Egress, b"allowed").unwrap();
+        w.push_dropped(Direction::Egress, b"denied").unwrap();
+        let manifest = w.seal();
+        assert_eq!(manifest.chunks.len(), 2);
+        assert!(!manifest.chunks[0].dropped, "forwarded frame not flagged");
+        assert!(manifest.chunks[1].dropped, "denied frame flagged dropped");
+        // Both are encrypted + verifiable + decrypt back in order.
+        verify_chunks(&manifest, dir.path()).unwrap();
+        assert_eq!(
+            export(&manifest, dir.path(), &fixed_key(7)).unwrap(),
+            b"alloweddenied"
+        );
     }
 
     #[test]

--- a/crates/mvm-hostd/src/supervisor/gateway_bridge.rs
+++ b/crates/mvm-hostd/src/supervisor/gateway_bridge.rs
@@ -1106,6 +1106,14 @@ async fn bridge_copy_bidirectional(
                     reason,
                     flow_key,
                 } => {
+                    // Forensic capture records the denied frame (the original,
+                    // un-forwarded bytes) flagged dropped, so an armed transcript
+                    // shows attempted-but-blocked egress, not only allowed traffic.
+                    if let Some(cap) = &cap_e
+                        && let Some(sink) = cap.lock().await.as_mut()
+                    {
+                        let _ = sink.push_dropped(mvm_core::transcript::Direction::Egress, &frame);
+                    }
                     if let Some(k) = flow_key {
                         killed_flows.lock().await.insert(k);
                     }
@@ -1198,6 +1206,12 @@ async fn bridge_copy_bidirectional(
                     reason,
                     flow_key,
                 } => {
+                    // Capture the denied ingress frame (flagged dropped) too.
+                    if let Some(cap) = &cap_i
+                        && let Some(sink) = cap.lock().await.as_mut()
+                    {
+                        let _ = sink.push_dropped(mvm_core::transcript::Direction::Ingress, &frame);
+                    }
                     if let Some(k) = flow_key {
                         killed_flows.lock().await.insert(k);
                     }

--- a/crates/mvm-hostd/src/supervisor/transcript_sink.rs
+++ b/crates/mvm-hostd/src/supervisor/transcript_sink.rs
@@ -90,6 +90,17 @@ impl TranscriptCaptureSink {
         self.writer.push(direction, bytes)
     }
 
+    /// Record a frame egress policy **denied** (dropped, not forwarded). Flagged
+    /// `dropped` in the manifest so the transcript captures attempted-but-blocked
+    /// egress — the forensically interesting case.
+    pub fn push_dropped(
+        &mut self,
+        direction: Direction,
+        bytes: &[u8],
+    ) -> Result<(), TranscriptError> {
+        self.writer.push_dropped(direction, bytes)
+    }
+
     /// Finalize: re-seal `manifest.json` with the captured chunks so the
     /// operator CLI lists/exports them. Returns the sealed manifest so the
     /// caller can emit the `TranscriptSealed` audit entry with the counts.

--- a/specs/plans/203-forensic-network-transcript-capture.md
+++ b/specs/plans/203-forensic-network-transcript-capture.md
@@ -179,7 +179,12 @@ This is a forensic tool, not a monitoring feature.
    `TranscriptWriter`; `push`/`seal` fill + finalize it. The
    `gateway_bridge::bridge_copy_bidirectional` tap opens the sink once per VM
    (`None` = no capture armed = zero cost), pushes each forwarded egress/ingress
-   frame, and seals + emits `TranscriptSealed` on teardown. Tested through the
+   frame, and seals + emits `TranscriptSealed` on teardown. **Denied egress is
+   captured too**: the `PacketDecision::Kill` arms push the original frame via
+   `push_dropped` (recorded with `ChunkRecord.dropped = true`), so the transcript
+   shows attempted-but-blocked egress — not only policy-allowed traffic. Without
+   this a deny-all workload captured zero chunks and attempted exfil to a denied
+   host was invisible. Tested through the
    **real** bridge relay (4 tests, `UnixStream` pairs): a forwarded frame is
    captured, sealed, and `transcript::export` decrypts it back byte-for-byte; all
    43 gateway_bridge tests stay green. The transcript lifecycle audit kinds landed


### PR DESCRIPTION
Closes #1231.

The forensic transcript tap only captured frames on the `PacketDecision::Forward` path, so:
- a workload under the default **deny-all** egress policy produced **zero chunks**, and
- **attempted exfiltration to a *denied* host** — the forensically most interesting traffic — was invisible to the transcript.

## Fix — capture denied frames too, flagged
- **mvm-core** (`transcript.rs`): `ChunkRecord` gains `dropped: bool` (`#[serde(default)]` → manifests written before this parse as `false`/forwarded; format unchanged). `TranscriptWriter::push_dropped` records a frame with `dropped = true` (shared `push_inner`; identical bounds + at-rest AEAD as `push`).
- **mvm-hostd** (`transcript_sink.rs`): `TranscriptCaptureSink::push_dropped` delegates to it.
- **mvm-hostd** (`gateway_bridge::bridge_copy_bidirectional`): both `PacketDecision::Kill` arms (egress + ingress) push the **original, un-forwarded** frame via `push_dropped`. So the transcript now records what the guest *attempted*, tagged dropped, not only what policy allowed.

`dropped` is orthogonal to `direction`, so allowed vs denied and egress vs ingress are both recoverable from the manifest.

## Tests + gates
- New `mvm-core` unit test: `push_dropped` marks the chunk (`dropped=true`), and the chunk still encrypts / `verify_chunks` / `export`s in order.
- All existing transcript + `gateway_bridge` tests stay green.
- `fmt`, `clippy -D warnings`, `check-core-runtime-free`, `check-stubs` (no drift), `check-no-spec-refs-in-comments` — clean.

## Context
Found via the live FC e2e behind #1214 (merged): once the gateway-bridge actually ran on Firecracker, a deny-all `sleeper` captured 0 chunks even with egress driven — root-caused to the capture living only in the `Forward` arm. This is the "yes, record denied egress" answer to #1231's design question.
