### PR TITLE
chore: gitignore the .superpowers/ scratch dir

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@
 # Swift Package Manager build output (mvm-providers/swift, mvm-vz-supervisor).
 **/.build/
 .playwright-mcp/
+.superpowers/
 .claude/*
 !.claude/settings.json
 **/node_modules


### PR DESCRIPTION
Adds `.superpowers/` to `.gitignore`.

It's a local-only tooling scratch directory, same category as the already-ignored `.claude/*` and `.playwright-mcp/`. Nothing in it should ever be committed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)