### PR TITLE
Plan 210: kernel-pin security watcher (ADR-093 §6 follow-up, detection side)

### DIFF
--- a/specs/plans/210-kernel-cve-watch.md
+++ b/specs/plans/210-kernel-cve-watch.md
@@ -1,0 +1,175 @@
+# Kernel-Pin Security Watcher Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Detect when mvm's pinned Linux kernel trails the latest 6.12 LTS point release (and, optionally, is hit by a published Linux CVE), emit a structured `KernelAdvisory`, and expose a stable trigger surface that **mvmd** polls to roll the fleet (rebuild kernel → `vm rekernel` each VM).
+
+**Architecture:** A reusable, pure detection library computes a `KernelAdvisory` from (our pins, upstream release data). A daily CI cron job (sibling to `security.yml`'s `cargo-audit`) runs it and fails / publishes the advisory on staleness. An `xtask`/CLI surface emits the same advisory for humans and for mvmd. mvm *detects + provides the per-VM `vm rekernel` primitive*; **mvmd orchestrates the fleet remediation** — that rollout is mvmd's plan, not this one.
+
+**Tech Stack:** Rust (a small detection lib + `xtask` subcommand), GitHub Actions (scheduled cron), kernel.org `releases.json` (upstream point-release source), optionally the kernel.org **linux-cve** feed (Phase 2).
+
+**Relates to:** ADR-093 §6 (this is the named "kernel-CVE detection watcher" follow-up), ADR-002 §W5.2 (`cargo-deny`/`cargo audit` — the sibling supply-chain cadence this mirrors), Plan 209 (`KernelArtifactId`, `vm rekernel`, the kernel-metrics CI lane).
+
+## Why this is a separate project (not Plan 209)
+
+Plan 209 delivered the *mechanism*: a versioned, hash-verified kernel artifact and the single-VM `vm rekernel` remediation primitive. This plan delivers the *trigger*: knowing **when** to remediate. The two are deliberately decoupled — detection has a different cadence (daily monitoring), a different failure surface (CI/advisory, not a VM boot), and a different consumer (mvmd's fleet orchestrator). Keeping it separate keeps `mvmctl`'s hot path free of monitoring concerns.
+
+## Global Constraints
+
+- **No host Nix in `mvmctl`** — this watcher runs in CI / as `xtask`, never on the `mvmctl` VM hot path. The detection lib must be pure (no VM spawn, no kernel build).
+- **Reuse, don't reinvent:** the workload `.config` `=y` list (Phase 2) comes from Plan 209's `workload-configfile` flake output / the `check-kernel-config-budget` gate — do not rebuild that.
+- **Two pins to watch:** `pkgs.linux_6_12` (nixpkgs — the builder/workload kernel, `nix/images/kernel/base.nix`) **and** the libkrunfw tarball (`linux-6.12.91.tar.xz` in `nix/packages/libkrunfw.nix`). Both must be checked; they can drift independently.
+- **Offline-tolerant:** a network failure fetching upstream data must produce a clear "unknown" advisory, never a false "up to date."
+- **No spec refs in code comments; no `Co-Authored-By: Claude` trailer.**
+- **Test gates:** `cargo nextest run --workspace`, `cargo clippy --workspace -- -D warnings`, `cargo fmt --all -- --check`.
+
+## Key design decisions (review these first)
+
+1. **Phase-1 signal = point-release staleness, not full CVE matching.** The 6.12 LTS maintainer backports CVE fixes into point releases, so "our pin is behind the latest 6.12.y" is a high-signal, cheap, deterministic proxy for "missing security fixes" — no CVE database, no config mapping. This mirrors `cargo audit`'s "your dep is behind a fixed version" model. Full CVE matching is Phase 2 (optional, config-aware).
+2. **Where it runs:** a **reusable pure lib** consumed by (a) a **daily CI cron job** (the enforcement/visibility surface, sibling to `cargo-audit`) and (b) an **`xtask`/CLI** for humans + mvmd. Not in `mvmctl`'s VM path.
+3. **mvmd is the orchestrator.** mvm emits a stable `KernelAdvisory` (JSON). mvmd polls it and, when action is needed, drives `mvmctl build kernel build` → `mvmctl vm rekernel <vm>` across the fleet. The fleet drain-and-roll is **mvmd's plan**; this plan stops at the advisory + the (already-built) single-VM primitive.
+4. **Config-aware CVE filtering is the shrink payoff (Phase 2).** A CVE in a subsystem we compile out (`=n`) cannot apply to a booted guest — so Phase 2 filters CVEs against the workload `=y` set. This is where Plan 209's slimming directly reduces the remediation workload, and it's the strongest part of the story.
+
+---
+
+## File Structure
+
+**New:**
+- `crates/mvm-core/src/kernel_advisory.rs` — pure types + comparison: `KernelPin`, `UpstreamReleases`, `Staleness`, `KernelAdvisory`, `assess(pins, upstream) -> KernelAdvisory`. No I/O.
+- `xtask/src/check_kernel_pin_freshness.rs` — the I/O shell: read our pins, fetch upstream `releases.json`, call `assess`, emit advisory JSON, exit nonzero past a threshold.
+- `.github/workflows/kernel-cve-watch.yml` — daily cron running the xtask; uploads the advisory artifact; fails on staleness.
+
+**Modified:**
+- `xtask/src/main.rs` — register `check-kernel-pin-freshness`.
+
+---
+
+## Phase 1 — Point-release staleness (the core)
+
+### Task 1: `KernelAdvisory` types + pure `assess`
+
+**Files:** Create `crates/mvm-core/src/kernel_advisory.rs`; modify `crates/mvm-core/src/lib.rs` (`pub mod kernel_advisory;`).
+
+**Interfaces (later tasks rely on these names):**
+- `KernelPin { name: String, version: String }` (e.g. `{"nixpkgs-linux_6_12","6.12.87"}`, `{"libkrunfw","6.12.91"}`).
+- `UpstreamReleases { latest_by_series: BTreeMap<String,String> }` (e.g. `{"6.12":"6.12.95"}`).
+- `Staleness { UpToDate, Behind { current, latest, patch_gap: u32 }, Unknown { reason } }`.
+- `KernelAdvisory { pins: Vec<(KernelPin, Staleness)>, worst: Staleness, action_recommended: bool }`.
+- `pub fn assess(pins: &[KernelPin], upstream: &UpstreamReleases) -> KernelAdvisory`.
+
+- [ ] **Step 1: Write failing tests**
+
+```rust
+#[test]
+fn behind_when_pin_trails_point_release() {
+    let pins = vec![KernelPin{ name:"k".into(), version:"6.12.87".into() }];
+    let up = UpstreamReleases{ latest_by_series: BTreeMap::from([("6.12".into(),"6.12.95".into())]) };
+    let a = assess(&pins, &up);
+    assert!(matches!(a.worst, Staleness::Behind{ patch_gap: 8, .. }));
+    assert!(a.action_recommended);
+}
+#[test]
+fn up_to_date_when_pin_is_latest() {
+    let pins = vec![KernelPin{ name:"k".into(), version:"6.12.95".into() }];
+    let up = UpstreamReleases{ latest_by_series: BTreeMap::from([("6.12".into(),"6.12.95".into())]) };
+    assert!(matches!(assess(&pins,&up).worst, Staleness::UpToDate));
+}
+#[test]
+fn unknown_when_series_absent() {
+    let pins = vec![KernelPin{ name:"k".into(), version:"6.12.87".into() }];
+    let up = UpstreamReleases{ latest_by_series: BTreeMap::new() };
+    assert!(matches!(assess(&pins,&up).worst, Staleness::Unknown{..}));
+    assert!(!assess(&pins,&up).action_recommended); // unknown must NOT auto-trigger
+}
+```
+
+- [ ] **Step 2: Run → fail.** `cargo test -p mvm-core kernel_advisory` → FAIL (undefined).
+- [ ] **Step 3: Implement** the types + `assess`: parse `MAJOR.MINOR.PATCH`, series = `MAJOR.MINOR`, `patch_gap = latest.patch - current.patch`; `Behind` when gap > 0, `Unknown` when series missing or unparsable, `UpToDate` otherwise. `worst` = the most-stale pin; `action_recommended` = any `Behind` with `patch_gap >= THRESHOLD` (start `THRESHOLD = 1`). `Unknown` never sets `action_recommended`.
+- [ ] **Step 4: Run → pass** + `cargo clippy -p mvm-core -- -D warnings`.
+- [ ] **Step 5: Commit** `feat(core): KernelAdvisory + pure point-release staleness assessment`.
+
+### Task 2: Read mvm's current pins
+
+**Files:** add `read_local_pins(workspace: &Path) -> Vec<KernelPin>` to the xtask module (Task 4) or a small helper in `kernel_advisory.rs` gated behind `std::fs` (keep the *parse* pure + tested separately).
+
+- [ ] **Step 1: Failing test** for the parsers (pure string in → version out):
+
+```rust
+#[test]
+fn parses_libkrunfw_tarball_version() {
+    let s = r#"url = "mirror://kernel/linux/kernel/v6.x/linux-6.12.91.tar.xz";"#;
+    assert_eq!(parse_libkrunfw_pin(s), Some("6.12.91".to_string()));
+}
+```
+
+- [ ] **Step 2: Run → fail.**
+- [ ] **Step 3: Implement** `parse_libkrunfw_pin` (regex/`splitn` on `linux-<ver>.tar.xz`) and `parse_nixpkgs_linux_pin` (read `pkgs.linux_6_12.version` — resolve via `nix eval --raw nixpkgs#linux_6_12.version` in the xtask I/O layer, OR read the flake.lock-pinned nixpkgs; keep the *fetch* in the xtask, the *parse* unit-tested). Note in a comment why both pins exist.
+- [ ] **Step 4: Run → pass.**
+- [ ] **Step 5: Commit** `feat(xtask): parse mvm's two kernel pins (nixpkgs + libkrunfw)`.
+
+### Task 3: Fetch upstream point releases
+
+**Files:** xtask module — `fetch_upstream_releases() -> Result<UpstreamReleases>`.
+
+- [ ] **Step 1:** Implement a fetch of `https://www.kernel.org/releases.json`, extracting the latest stable per `MAJOR.MINOR` series (filter `moniker == "longterm"`/`"stable"`). Use the workspace HTTP client already in tree (reuse — do not add a new one). On any failure return an `UpstreamReleases` that yields `Staleness::Unknown` (offline-tolerant), never a false up-to-date.
+- [ ] **Step 2: Test** the JSON extraction with a checked-in `releases.json` fixture (parse → `latest_by_series["6.12"]` correct). No live network in the unit test.
+- [ ] **Step 3: Commit** `feat(xtask): fetch latest LTS point releases from kernel.org`.
+
+### Task 4: `xtask check-kernel-pin-freshness`
+
+**Files:** Create `xtask/src/check_kernel_pin_freshness.rs`; modify `xtask/src/main.rs` (register the subcommand + help string).
+
+**Interfaces:** Consumes `assess` (Task 1), `read_local_pins` (Task 2), `fetch_upstream_releases` (Task 3). Produces a `KernelAdvisory` to stdout as JSON and exit code: `0` up-to-date/unknown, `>0` when `action_recommended`.
+
+- [ ] **Step 1:** `run(args)`: read pins → fetch upstream → `assess` → print `serde_json::to_string_pretty(&advisory)` → `std::process::exit(if advisory.action_recommended { 1 } else { 0 })`. A `--json`-only mode is the default; a human summary line goes to stderr (mirrors `check-closure-budget`'s style).
+- [ ] **Step 2:** Register `Some("check-kernel-pin-freshness") => check_kernel_pin_freshness::run(&args[2..])` + add to the available-tasks help string (sibling to `check-kernel-config-budget`).
+- [ ] **Step 3:** Run `cargo run -p xtask -- check-kernel-pin-freshness` locally; confirm it prints a well-formed advisory.
+- [ ] **Step 4: Commit** `feat(xtask): check-kernel-pin-freshness — emit a KernelAdvisory + exit on staleness`.
+
+### Task 5: Daily CI cron workflow
+
+**Files:** Create `.github/workflows/kernel-cve-watch.yml`.
+
+- [ ] **Step 1:** Author the workflow mirroring `security.yml`'s cadence: `schedule: cron` (daily, offset from the existing `17 4 * * *`), `workflow_dispatch`, and `pull_request` on `nix/images/kernel/**` + `nix/packages/libkrunfw.nix` (so a pin bump re-checks immediately). Steps: checkout → install Nix (for the nixpkgs pin read) → `cargo run -p xtask -- check-kernel-pin-freshness > advisory.json` → `upload-artifact advisory.json`. The scheduled run uses `continue-on-error` + opens/updates a single tracking issue on staleness (so the cron surfaces, not silently fails); the `pull_request` run fails hard if a *bump* still lands behind.
+- [ ] **Step 2:** `actionlint` clean (env-var inputs, no untrusted interpolation in `run:`).
+- [ ] **Step 3: Commit** `ci: daily kernel-pin freshness watch (advisory + staleness gate)`.
+
+---
+
+## Phase 2 — Config-aware CVE enrichment (optional)
+
+### Task 6: Filter Linux CVEs against the compiled-in `=y` set
+
+**Files:** extend `kernel_advisory.rs` (`CveHit`, `enrich_with_cves`) + the xtask.
+
+- [ ] **Step 1:** Fetch the kernel.org **linux-cve** feed for the pinned `6.12.x` (the project publishes per-release CVE JSON). For each CVE, determine the affected subsystem/source path.
+- [ ] **Step 2:** Load the workload `=y` set (reuse Plan 209's `workload-configfile` flake output — the same artifact `check-kernel-config-budget` consumes). Mark a CVE **applicable** only if its subsystem maps to a compiled-in symbol; otherwise **not-applicable (compiled out)** — the slim-kernel payoff, surfaced explicitly in the advisory.
+- [ ] **Step 3:** Add `CveHit { id, severity, applicable: bool, reason }` to `KernelAdvisory`; `action_recommended` also trips on any applicable high/critical CVE.
+- [ ] **Step 4:** Tests with a fixture CVE feed + a fixture `=y` list (one applicable, one compiled-out). Commit.
+
+> Phase 2 is gated on the subsystem→symbol mapping being tractable; if the mapping proves noisy, ship Phase 1 alone (point-release staleness is already high-signal) and keep CVE enrichment advisory-only (never auto-trigger on a fuzzy match).
+
+---
+
+## Phase 3 — The mvmd trigger contract
+
+### Task 7: Freeze + document `KernelAdvisory` as the mvmd-facing contract
+
+**Files:** doc comment on `KernelAdvisory` + a short `specs/adrs/` note or a section in this plan.
+
+- [ ] **Step 1:** Treat the `KernelAdvisory` JSON as a stable wire contract (it's what mvmd polls). Add `#[serde(deny_unknown_fields)]` discipline + a serde round-trip + schema-stability test. Document the consumer flow: **mvmd** polls the advisory (from the CI artifact / an `xtask` invocation) → if `action_recommended`, runs `mvmctl build kernel build --which workload` then `mvmctl vm rekernel <vm>` per fleet member (the single-VM primitive Plan 209 shipped).
+- [ ] **Step 2:** Commit `docs: freeze KernelAdvisory as the mvmd remediation-trigger contract`.
+
+---
+
+## Deferred / cross-repo (NOT this plan)
+
+- [ ] **mvmd fleet drain-and-roll** — poll the advisory, rebuild the kernel, `vm rekernel` each VM with health-gated batching. **Lives in the `mvmd` repo** (its own plan); this plan only emits the advisory + provides the per-VM primitive.
+- [ ] **Promote "pinned kernel is security-monitored" to a numbered ADR-002 claim** — a maintainer decision once Phase 1 is enforcing (sibling to claim 7). Not required to ship the watcher.
+- [ ] **Auto-bump PR** — a follow-up could have the cron open a PR bumping the pins when behind, but that's an automation nicety beyond detection.
+
+## Success criteria
+- `cargo run -p xtask -- check-kernel-pin-freshness` emits a valid `KernelAdvisory` and exits nonzero when either pin trails the latest 6.12.y.
+- The daily CI job surfaces staleness without silently failing; a pin bump that's still behind fails the PR.
+- `KernelAdvisory` is a documented, stable JSON contract mvmd can poll to trigger a fleet rekernel.
+- (Phase 2) CVEs in compiled-out subsystems are reported as non-applicable — the slim-kernel payoff is visible.


### PR DESCRIPTION
Detection-side plan for the kernel-CVE watcher named in ADR-093 §6. Separate project from Plan 209 (which shipped the `vm rekernel` remediation primitive). 

**Scope (mvm side):** a pure staleness-assessment lib (`KernelAdvisory`), a daily CI cron mirroring `cargo-audit`, and an `xtask` emitting a stable advisory JSON. **mvmd** polls the advisory and orchestrates the fleet rekernel — that rollout stays mvmd's plan.

Phase 1 = point-release staleness (no CVE DB needed — the LTS maintainer backports fixes into point releases, so 'behind the latest 6.12.y' is high-signal). Phase 2 = config-aware CVE filtering (a CVE in a compiled-out subsystem can't apply — the slim-kernel payoff). Phase 3 = freeze the mvmd trigger contract.

Plan doc only — no implementation. Watches **both** kernel pins (nixpkgs `linux_6_12` + libkrunfw tarball).