### PR TITLE
feat(build): per-host libkrun-builder health cache (skip the doomed attempt)

### DIFF
--- a/crates/mvm-build/src/builder_backend_select.rs
+++ b/crates/mvm-build/src/builder_backend_select.rs
@@ -28,6 +28,7 @@
 //! match the *runtime* default there. Older macOS and Linux contributors
 //! keep libkrun as the cross-platform path they were already using.
 
+use crate::builder_health;
 use crate::builder_vm::{BuilderVm, BuilderVmError};
 use crate::libkrun_builder::LibkrunBuilderVm;
 use crate::qemu_builder::QemuBuilderVm;
@@ -236,10 +237,17 @@ fn is_linux_native_host() -> bool {
 ///   behaviour: Vz probe passes but the backend trips a runtime issue).
 /// - Auto-detected **libkrun on Linux** falls back to **qemu** — libkrun-on-KVM
 ///   can fail at VM creation on hosts the qemu/microvm_nix builder handles fine.
+///   When `libkrun_unhealthy` (a fresh per-host marker from a prior failed
+///   attempt — see [`crate::builder_health`]) the doomed libkrun attempt is
+///   skipped entirely and qemu is tried first, so a reliably-broken host
+///   doesn't re-pay the failure on every build. The marker only reorders the
+///   Linux-libkrun auto path; explicit choices and the macOS Vz→libkrun path
+///   ignore it.
 pub fn builder_attempt_order(
     selected: BuilderBackendChoice,
     explicit: bool,
     is_linux_native: bool,
+    libkrun_unhealthy: bool,
 ) -> Vec<BuilderBackendChoice> {
     if explicit {
         return vec![selected];
@@ -247,7 +255,11 @@ pub fn builder_attempt_order(
     match selected {
         BuilderBackendChoice::Vz => vec![BuilderBackendChoice::Vz, BuilderBackendChoice::Libkrun],
         BuilderBackendChoice::Libkrun if is_linux_native => {
-            vec![BuilderBackendChoice::Libkrun, BuilderBackendChoice::Qemu]
+            if libkrun_unhealthy {
+                vec![BuilderBackendChoice::Qemu]
+            } else {
+                vec![BuilderBackendChoice::Libkrun, BuilderBackendChoice::Qemu]
+            }
         }
         _ => vec![selected],
     }
@@ -266,14 +278,23 @@ pub fn run_with_builder_fallback<T>(
     explicit: bool,
     mut attempt: impl FnMut(BuilderBackendChoice) -> Result<T, BuilderVmError>,
 ) -> Result<T, BuilderVmError> {
-    let order = builder_attempt_order(selected, explicit, is_linux_native_host());
+    let order = builder_attempt_order(
+        selected,
+        explicit,
+        is_linux_native_host(),
+        builder_health::libkrun_marked_unavailable(),
+    );
     let last_idx = order.len() - 1;
     let mut last_err: Option<BuilderVmError> = None;
     for (idx, choice) in order.iter().copied().enumerate() {
         match attempt(choice) {
-            Ok(value) => return Ok(value),
+            Ok(value) => {
+                builder_health::note_attempt_outcome(choice, true);
+                return Ok(value);
+            }
             // Not the last backend, and a VMM-level failure → try the next.
             Err(e) if idx < last_idx && is_builder_vm_level_failure(&e) => {
+                builder_health::note_attempt_outcome(choice, false);
                 tracing::warn!(
                     error = %e,
                     from = choice.name(),
@@ -288,7 +309,14 @@ pub fn run_with_builder_fallback<T>(
                 last_err = Some(e);
             }
             // Last backend, or a genuine build error → surface it unchanged.
-            Err(e) => return Err(e),
+            // Still record a VMM-level libkrun failure so a doomed sole-backend
+            // libkrun isn't re-attempted next time; a build error is left alone.
+            Err(e) => {
+                if is_builder_vm_level_failure(&e) {
+                    builder_health::note_attempt_outcome(choice, false);
+                }
+                return Err(e);
+            }
         }
     }
     Err(last_err.expect("builder_attempt_order is never empty"))
@@ -314,13 +342,22 @@ pub fn run_with_builder_fallback_anyhow<T>(
     explicit: bool,
     mut attempt: impl FnMut(BuilderBackendChoice) -> anyhow::Result<T>,
 ) -> anyhow::Result<T> {
-    let order = builder_attempt_order(selected, explicit, is_linux_native_host());
+    let order = builder_attempt_order(
+        selected,
+        explicit,
+        is_linux_native_host(),
+        builder_health::libkrun_marked_unavailable(),
+    );
     let last_idx = order.len() - 1;
     let mut last_err: Option<anyhow::Error> = None;
     for (idx, choice) in order.iter().copied().enumerate() {
         match attempt(choice) {
-            Ok(value) => return Ok(value),
+            Ok(value) => {
+                builder_health::note_attempt_outcome(choice, true);
+                return Ok(value);
+            }
             Err(e) if idx < last_idx && anyhow_has_builder_vm_level_failure(&e) => {
+                builder_health::note_attempt_outcome(choice, false);
                 tracing::warn!(
                     error = %e,
                     from = choice.name(),
@@ -334,7 +371,12 @@ pub fn run_with_builder_fallback_anyhow<T>(
                 );
                 last_err = Some(e);
             }
-            Err(e) => return Err(e),
+            Err(e) => {
+                if anyhow_has_builder_vm_level_failure(&e) {
+                    builder_health::note_attempt_outcome(choice, false);
+                }
+                return Err(e);
+            }
         }
     }
     Err(last_err.expect("builder_attempt_order is never empty"))
@@ -623,25 +665,62 @@ mod tests {
     #[test]
     fn attempt_order_linux_libkrun_falls_back_to_qemu_only_when_auto() {
         use BuilderBackendChoice::*;
-        // Auto-detected libkrun on Linux → libkrun, then qemu.
+        // Auto-detected libkrun on Linux (healthy) → libkrun, then qemu.
         assert_eq!(
-            builder_attempt_order(Libkrun, false, true),
+            builder_attempt_order(Libkrun, false, true, false),
             vec![Libkrun, Qemu]
         );
         // Explicit libkrun → no fallback (operator asked for libkrun).
-        assert_eq!(builder_attempt_order(Libkrun, true, true), vec![Libkrun]);
+        assert_eq!(
+            builder_attempt_order(Libkrun, true, true, false),
+            vec![Libkrun]
+        );
         // libkrun off-Linux (e.g. macOS 13-25) → no qemu fallback.
-        assert_eq!(builder_attempt_order(Libkrun, false, false), vec![Libkrun]);
+        assert_eq!(
+            builder_attempt_order(Libkrun, false, false, false),
+            vec![Libkrun]
+        );
+    }
+
+    #[test]
+    fn attempt_order_skips_libkrun_when_marked_unhealthy_on_linux_auto() {
+        use BuilderBackendChoice::*;
+        // A fresh per-host "libkrun can't build here" marker → skip straight to
+        // qemu on the Linux auto path (no doomed libkrun attempt).
+        assert_eq!(
+            builder_attempt_order(Libkrun, false, true, true),
+            vec![Qemu]
+        );
+        // Explicit libkrun ignores the marker — the operator forced it, so we
+        // re-attempt (and a success would clear the marker).
+        assert_eq!(
+            builder_attempt_order(Libkrun, true, true, true),
+            vec![Libkrun]
+        );
+        // Off-Linux libkrun ignores the marker (there is no qemu fallback there
+        // to redirect to).
+        assert_eq!(
+            builder_attempt_order(Libkrun, false, false, true),
+            vec![Libkrun]
+        );
     }
 
     #[test]
     fn attempt_order_preserves_vz_to_libkrun_and_explicit_qemu() {
         use BuilderBackendChoice::*;
-        // Existing macOS behaviour unchanged.
-        assert_eq!(builder_attempt_order(Vz, false, false), vec![Vz, Libkrun]);
-        assert_eq!(builder_attempt_order(Vz, true, false), vec![Vz]);
+        // Existing macOS behaviour unchanged (and the libkrun marker never
+        // reorders the Vz→libkrun auto path).
+        assert_eq!(
+            builder_attempt_order(Vz, false, false, false),
+            vec![Vz, Libkrun]
+        );
+        assert_eq!(
+            builder_attempt_order(Vz, false, false, true),
+            vec![Vz, Libkrun]
+        );
+        assert_eq!(builder_attempt_order(Vz, true, false, false), vec![Vz]);
         // Explicit qemu is a single attempt.
-        assert_eq!(builder_attempt_order(Qemu, false, true), vec![Qemu]);
+        assert_eq!(builder_attempt_order(Qemu, false, true, false), vec![Qemu]);
     }
 
     #[test]
@@ -656,6 +735,11 @@ mod tests {
         // when the live host yields a 2-element order. To stay host-agnostic,
         // assert the *single-attempt* contract instead: a VMM failure with no
         // fallback available surfaces unchanged.
+        // Isolate the per-host builder-health marker the fallback now reads and
+        // writes (a libkrun VMM failure records it) so it can't leak across tests.
+        let scratch = tempfile::TempDir::new().unwrap();
+        let mut env = TestEnv::new();
+        env.set("MVM_CACHE_DIR", scratch.path().join(".cache"));
         let on_linux = is_linux_native_host();
         let calls = RefCell::new(Vec::new());
         let qemu_ok = AtomicBool::new(false);
@@ -692,6 +776,9 @@ mod tests {
     #[test]
     fn run_with_fallback_surfaces_real_build_errors_without_retry() {
         use std::cell::RefCell;
+        let scratch = tempfile::TempDir::new().unwrap();
+        let mut env = TestEnv::new();
+        env.set("MVM_CACHE_DIR", scratch.path().join(".cache"));
         let calls = RefCell::new(0u32);
         // A genuine build error must NOT trigger a fallback, even on Linux.
         let result: Result<(), _> =
@@ -727,6 +814,10 @@ mod tests {
     #[test]
     fn run_with_fallback_anyhow_retries_qemu_on_wrapped_supervisor_exit() {
         use std::cell::RefCell;
+        // Isolate the per-host builder-health marker (see the typed sibling test).
+        let scratch = tempfile::TempDir::new().unwrap();
+        let mut env = TestEnv::new();
+        env.set("MVM_CACHE_DIR", scratch.path().join(".cache"));
         let on_linux = is_linux_native_host();
         let calls = RefCell::new(Vec::new());
         let result = run_with_builder_fallback_anyhow(BuilderBackendChoice::Libkrun, false, |c| {
@@ -755,6 +846,9 @@ mod tests {
     #[test]
     fn run_with_fallback_anyhow_surfaces_real_build_error_without_retry() {
         use std::cell::RefCell;
+        let scratch = tempfile::TempDir::new().unwrap();
+        let mut env = TestEnv::new();
+        env.set("MVM_CACHE_DIR", scratch.path().join(".cache"));
         let calls = RefCell::new(0u32);
         let result: anyhow::Result<()> =
             run_with_builder_fallback_anyhow(BuilderBackendChoice::Libkrun, false, |_c| {

--- a/crates/mvm-build/src/builder_health.rs
+++ b/crates/mvm-build/src/builder_health.rs
@@ -1,0 +1,144 @@
+//! Per-host builder-VM health cache.
+//!
+//! On a host where libkrun can't create its builder VM — e.g. the
+//! `KVM_SET_USER_MEMORY_REGION` EINVAL defect on some Linux kernels (ADR-093) —
+//! the auto-fallback would otherwise pay a doomed libkrun attempt on *every*
+//! build before switching to qemu. This records a short-lived marker so
+//! subsequent builds skip straight to the qemu builder. The marker self-heals
+//! after a TTL (a transient failure, or a libkrun upgrade, re-probes the next
+//! day), and an explicit `--builder libkrun` that succeeds clears it.
+
+use std::path::PathBuf;
+use std::time::{SystemTime, UNIX_EPOCH};
+
+use crate::builder_backend_select::BuilderBackendChoice;
+
+/// How long a "libkrun builder unavailable" marker is honoured before it is
+/// treated as stale and re-probed. Long enough to spare a reliably-broken host
+/// the repeated doomed attempt across a dev session; short enough that a
+/// transient failure self-heals by the next day.
+const MARKER_TTL_SECS: u64 = 24 * 60 * 60;
+
+fn marker_path() -> PathBuf {
+    PathBuf::from(mvm_core::config::mvm_cache_dir())
+        .join("builder-health")
+        .join("libkrun-unavailable")
+}
+
+fn now_secs() -> u64 {
+    SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .map(|d| d.as_secs())
+        .unwrap_or(0)
+}
+
+/// Pure freshness check, lifted out so the TTL boundary is unit-testable
+/// without touching the clock or the filesystem.
+fn marker_is_fresh(recorded_at_secs: u64, now: u64) -> bool {
+    now.saturating_sub(recorded_at_secs) < MARKER_TTL_SECS
+}
+
+/// Is there a fresh "libkrun can't build here" marker? A stale marker is
+/// removed and reported absent so the host re-probes libkrun.
+pub fn libkrun_marked_unavailable() -> bool {
+    let path = marker_path();
+    let Ok(contents) = std::fs::read_to_string(&path) else {
+        return false;
+    };
+    let recorded = contents.trim().parse::<u64>().unwrap_or(0);
+    if marker_is_fresh(recorded, now_secs()) {
+        true
+    } else {
+        let _ = std::fs::remove_file(&path);
+        false
+    }
+}
+
+/// Record that an auto-detected libkrun builder failed to create its VM here.
+/// Best-effort: a write failure just means the next build re-attempts libkrun.
+fn record_libkrun_unavailable() {
+    let path = marker_path();
+    if let Some(dir) = path.parent() {
+        let _ = std::fs::create_dir_all(dir);
+    }
+    let _ = std::fs::write(&path, now_secs().to_string());
+}
+
+/// Clear the marker — libkrun built successfully, so it has recovered here (or
+/// was never broken).
+fn clear_libkrun_marker() {
+    let _ = std::fs::remove_file(marker_path());
+}
+
+/// Fold one builder attempt's outcome into the host health cache. Only libkrun
+/// outcomes move the marker: a VMM-level libkrun failure sets it; a libkrun
+/// success clears it. Other backends never touch it.
+pub fn note_attempt_outcome(choice: BuilderBackendChoice, succeeded: bool) {
+    if choice != BuilderBackendChoice::Libkrun {
+        return;
+    }
+    if succeeded {
+        clear_libkrun_marker();
+    } else {
+        record_libkrun_unavailable();
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use mvm_core::util::test_env::TestEnv;
+
+    fn isolated_cache() -> (TestEnv, tempfile::TempDir) {
+        let scratch = tempfile::TempDir::new().unwrap();
+        let mut env = TestEnv::new();
+        env.set("MVM_CACHE_DIR", scratch.path().join(".cache"));
+        (env, scratch)
+    }
+
+    #[test]
+    fn fresh_within_ttl_stale_beyond() {
+        assert!(marker_is_fresh(1_000, 1_000));
+        assert!(marker_is_fresh(1_000, 1_000 + MARKER_TTL_SECS - 1));
+        assert!(!marker_is_fresh(1_000, 1_000 + MARKER_TTL_SECS));
+        assert!(!marker_is_fresh(1_000, 1_000 + MARKER_TTL_SECS + 10));
+        // A clock that went backwards must not read as ancient (saturating).
+        assert!(marker_is_fresh(1_000, 500));
+    }
+
+    #[test]
+    fn libkrun_failure_sets_marker_success_clears_it() {
+        let (_env, _scratch) = isolated_cache();
+        assert!(!libkrun_marked_unavailable(), "no marker initially");
+
+        note_attempt_outcome(BuilderBackendChoice::Libkrun, false);
+        assert!(libkrun_marked_unavailable(), "libkrun VMM failure marks it");
+
+        note_attempt_outcome(BuilderBackendChoice::Libkrun, true);
+        assert!(!libkrun_marked_unavailable(), "libkrun success clears it");
+    }
+
+    #[test]
+    fn non_libkrun_outcomes_never_touch_marker() {
+        let (_env, _scratch) = isolated_cache();
+        note_attempt_outcome(BuilderBackendChoice::Libkrun, false);
+        // A qemu success after a libkrun failure must leave the marker intact —
+        // the fallback worked, libkrun is still broken here.
+        note_attempt_outcome(BuilderBackendChoice::Qemu, true);
+        assert!(libkrun_marked_unavailable());
+        // A Vz failure (macOS) is unrelated and must not set the libkrun marker.
+        note_attempt_outcome(BuilderBackendChoice::Libkrun, true); // reset
+        note_attempt_outcome(BuilderBackendChoice::Vz, false);
+        assert!(!libkrun_marked_unavailable());
+    }
+
+    #[test]
+    fn stale_marker_is_removed_and_reported_absent() {
+        let (_env, _scratch) = isolated_cache();
+        let path = marker_path();
+        std::fs::create_dir_all(path.parent().unwrap()).unwrap();
+        std::fs::write(&path, "1").unwrap(); // unix ts 1 — ancient
+        assert!(!libkrun_marked_unavailable());
+        assert!(!path.exists(), "stale marker removed on read");
+    }
+}

--- a/crates/mvm-build/src/builder_health.rs
+++ b/crates/mvm-build/src/builder_health.rs
@@ -1,7 +1,7 @@
 //! Per-host builder-VM health cache.
 //!
 //! On a host where libkrun can't create its builder VM — e.g. the
-//! `KVM_SET_USER_MEMORY_REGION` EINVAL defect on some Linux kernels (ADR-093) —
+//! `KVM_SET_USER_MEMORY_REGION` EINVAL defect on some Linux kernels —
 //! the auto-fallback would otherwise pay a doomed libkrun attempt on *every*
 //! build before switching to qemu. This records a short-lived marker so
 //! subsequent builds skip straight to the qemu builder. The marker self-heals

--- a/crates/mvm-build/src/lib.rs
+++ b/crates/mvm-build/src/lib.rs
@@ -95,6 +95,7 @@ pub mod vz_builder;
 /// concrete driver the env-var resolved to.
 #[cfg(feature = "builder-vm")]
 pub mod builder_backend_select;
+pub mod builder_health;
 
 /// Host-side cross-compile + cache of the guest agent/netinit binaries
 /// baked into an OCI rootfs by [`oci_runtime_inject`].

--- a/crates/mvm-build/src/lib.rs
+++ b/crates/mvm-build/src/lib.rs
@@ -95,6 +95,10 @@ pub mod vz_builder;
 /// concrete driver the env-var resolved to.
 #[cfg(feature = "builder-vm")]
 pub mod builder_backend_select;
+/// Per-host builder-VM health cache (skip a libkrun backend that can't create
+/// its VM here). Gated with `builder_backend_select` — its only consumers are
+/// the builder-selection paths behind `builder-vm`.
+#[cfg(feature = "builder-vm")]
 pub mod builder_health;
 
 /// Host-side cross-compile + cache of the guest agent/netinit binaries

--- a/crates/mvm-cli/src/commands/env/dev_vz.rs
+++ b/crates/mvm-cli/src/commands/env/dev_vz.rs
@@ -4776,7 +4776,12 @@ mod builder_backend_attempt_order_tests {
         );
         assert_eq!(
             builder_backend_attempt_order(BuilderBackendChoice::Libkrun, false),
-            builder_attempt_order(BuilderBackendChoice::Libkrun, false, is_linux)
+            builder_attempt_order(
+                BuilderBackendChoice::Libkrun,
+                false,
+                is_linux,
+                mvm_build::builder_health::libkrun_marked_unavailable(),
+            )
         );
     }
 }

--- a/crates/mvm-cli/src/commands/env/dev_vz.rs
+++ b/crates/mvm-cli/src/commands/env/dev_vz.rs
@@ -4638,11 +4638,18 @@ fn build_image_via_libkrun(out_dir: &str) -> Result<(String, String)> {
         let backend = resolve_builder_backend_with_override(Some(choice));
         match backend.run_build(&job, &mounts) {
             Ok(_) => {
+                mvm_build::builder_health::note_attempt_outcome(choice, true);
                 used_backend = choice;
                 last_error = None;
                 break;
             }
             Err(err) => {
+                // Record only a VMM-level libkrun failure in the per-host health
+                // cache so the next dev-image build skips the doomed attempt; a
+                // genuine build error must not poison the cache.
+                if mvm_build::builder_backend_select::is_builder_vm_level_failure(&err) {
+                    mvm_build::builder_health::note_attempt_outcome(choice, false);
+                }
                 if idx + 1 < attempt_order.len() {
                     ui::warn(&format!(
                         "Auto-selected {} builder failed ({}); retrying with {}.",
@@ -4702,7 +4709,9 @@ fn build_image_via_libkrun(out_dir: &str) -> Result<(String, String)> {
 /// to the shared [`mvm_build::builder_backend_select::builder_attempt_order`]
 /// (one policy: auto Vz→libkrun, auto libkrun→qemu on Linux, explicit→single)
 /// so this CLI loop and the `mvm-build` build paths can't drift. The live
-/// platform supplies the `is_linux_native` input the shared (pure) policy takes.
+/// platform supplies `is_linux_native`, and the per-host builder-health cache
+/// supplies whether libkrun should be skipped (a prior failed attempt left a
+/// marker — see [`mvm_build::builder_health`]).
 #[cfg(feature = "builder-vm")]
 fn builder_backend_attempt_order(
     selected: mvm_build::builder_backend_select::BuilderBackendChoice,
@@ -4716,6 +4725,7 @@ fn builder_backend_attempt_order(
         selected,
         explicit_override,
         is_linux_native,
+        mvm_build::builder_health::libkrun_marked_unavailable(),
     )
 }
 
@@ -5042,10 +5052,16 @@ fn build_default_microvm_via_libkrun(
         let backend = resolve_builder_backend_with_override(Some(choice));
         match backend.run_build(&job, &mounts) {
             Ok(_) => {
+                mvm_build::builder_health::note_attempt_outcome(choice, true);
                 last_error = None;
                 break;
             }
             Err(err) => {
+                // VMM-level libkrun failures feed the per-host health cache;
+                // genuine build errors do not (see the dev-image loop above).
+                if mvm_build::builder_backend_select::is_builder_vm_level_failure(&err) {
+                    mvm_build::builder_health::note_attempt_outcome(choice, false);
+                }
                 if idx + 1 < attempt_order.len() {
                     ui::warn(&format!(
                         "Auto-selected {} builder failed ({}); retrying with {}.",


### PR DESCRIPTION
**ADR-093 follow-up #3.** Re-land of #1246 against `main` — that PR merged into its intermediate stacked base (`feat/devbuild-qemu-fallback`) instead of `main`, so the health-cache code never reached `main` even though #1239 (its base) did. Identical content, now correctly based on `main`.

## Problem
On a host where libkrun can't create its builder VM (the `KVM_SET_USER_MEMORY_REGION` EINVAL / `rc -22` defect), the ADR-093 auto-fallback works but re-pays a doomed libkrun attempt (~5s + a failed VM spawn) on **every** build before switching to qemu.

## Fix
A short-lived per-host marker (`mvm_build::builder_health`). The first time libkrun fails VMM-level, it records a marker under `mvm_cache_dir()/builder-health/`; subsequent builds skip straight to qemu.

- `builder_attempt_order` gains a pure `libkrun_unhealthy` input → reorders the **Linux-libkrun auto** path to `[qemu]` when marked. macOS Vz→libkrun and explicit `--builder` ignore it.
- Both fallback helpers + the dev_vz CLI loops read the marker for the order and fold each attempt's outcome back: a VMM-level libkrun failure **sets** it, a libkrun success **clears** it; a genuine build error never poisons it.
- **Self-healing:** 24h TTL; an explicit `--builder libkrun` that succeeds clears it immediately.
- Gated behind `builder-vm` (matches `builder_backend_select`) so the musl `mvm-host-vm-init` cross-compile still builds.

## Tests
TTL boundary (incl. backwards-clock saturation), set/clear round-trip, non-libkrun no-op, stale-marker eviction, reordered attempt-order cases. Fallback unit tests isolate `MVM_CACHE_DIR`.

## Live-proven
Two-pass `up --flake` (no `--builder`) on the broken-libkrun box: run 1 → `rc -22` + fallback + **marker written**; run 2 → **0 `rc -22`** (libkrun skipped), boots via qemu directly.