### PR TITLE
fix(#1255): short Vz persistent session id keeps vsock sockets under AF_UNIX sun_path

### DIFF
--- a/crates/mvm-build/src/host_gvproxy.rs
+++ b/crates/mvm-build/src/host_gvproxy.rs
@@ -47,9 +47,25 @@ pub const SOCKET_FILE_NAME: &str = "gvproxy.sock";
 /// `EINVAL`; gvproxy surfaces it as `vfkit listen error: ... bind: invalid
 /// argument` and exits before its listener socket appears.
 #[cfg(target_os = "macos")]
-const SUN_PATH_MAX: usize = 104;
+pub(crate) const SUN_PATH_MAX: usize = 104;
 #[cfg(not(target_os = "macos"))]
-const SUN_PATH_MAX: usize = 108;
+pub(crate) const SUN_PATH_MAX: usize = 108;
+
+/// Short, deterministic, filesystem-safe hex token derived from `input`
+/// (first `bytes` bytes of its SHA-256). Used to keep `AF_UNIX` socket paths
+/// short: as a relocated-socket filename here, and as the Vz persistent
+/// builder's session id (so its `<state_dir>/vsock/*` paths stay under
+/// [`SUN_PATH_MAX`]). Collision-resistant across a host's per-VM dirs.
+pub(crate) fn short_token(input: &str, bytes: usize) -> String {
+    let mut hasher = Sha256::new();
+    hasher.update(input.as_bytes());
+    let digest = hasher.finalize();
+    digest
+        .iter()
+        .take(bytes)
+        .map(|b| format!("{b:02x}"))
+        .collect()
+}
 
 /// Resolve the host-gvproxy listener socket path for a VM rooted at
 /// `scratch_dir`.
@@ -76,12 +92,9 @@ fn gvproxy_socket_path_in(scratch_dir: &Path, cache_root: &Path) -> PathBuf {
     if natural.as_os_str().len() < SUN_PATH_MAX {
         return natural;
     }
-    let mut hasher = Sha256::new();
-    hasher.update(scratch_dir.to_string_lossy().as_bytes());
-    let digest = hasher.finalize();
     // 12 hex chars (48 bits) keyed on the full scratch dir — collision-resistant
     // across a host's per-VM dirs, and short enough to stay well under the limit.
-    let token: String = digest.iter().take(6).map(|b| format!("{b:02x}")).collect();
+    let token = short_token(&scratch_dir.to_string_lossy(), 6);
     cache_root.join("gv").join(format!("{token}.sock"))
 }
 
@@ -440,6 +453,16 @@ mod tests {
             gvproxy_socket_path_in(&a, cache),
             gvproxy_socket_path_in(&b, cache)
         );
+    }
+
+    #[test]
+    fn short_token_is_deterministic_fixed_length_and_distinct() {
+        let a = short_token("scratch-a", 4);
+        assert_eq!(a.len(), 8, "4 bytes → 8 hex chars");
+        assert!(a.chars().all(|c| c.is_ascii_hexdigit()));
+        assert_eq!(a, short_token("scratch-a", 4)); // deterministic
+        assert_ne!(a, short_token("scratch-b", 4)); // distinct inputs differ
+        assert_eq!(short_token("x", 6).len(), 12); // 6 bytes → 12 hex
     }
 
     #[test]

--- a/crates/mvm-build/src/vz_builder.rs
+++ b/crates/mvm-build/src/vz_builder.rs
@@ -1081,6 +1081,34 @@ fn vz_shell_vm_name(job_id: &str) -> String {
     format!("vzsh-{job_id}")
 }
 
+/// Short, unique, filesystem-safe session id for a minted Vz persistent builder.
+/// Hashing `unique_job_id()` (unique per call) to 8 hex chars keeps the derived
+/// `mvm-persistent-builder-vz-<id>/vsock/vsock-<port>.sock` under the AF_UNIX
+/// sun_path limit on normal cache paths — the old `unique_job_id` (~19 chars)
+/// overran it. The always-short `dev` session is why `mvmctl dev up` never hit this.
+fn short_vz_persistent_session_id() -> String {
+    host_gvproxy::short_token(&unique_job_id(), 4)
+}
+
+/// Fail closed if a Vz persistent builder's builderd control socket
+/// (`<state_dir>/vsock/vsock-<port>.sock`) would exceed the AF_UNIX sun_path
+/// limit. The Vz supervisor only *warns* and skips an over-long bind, leaving
+/// the daemon unreachable and the typed `mvm-builderd` route silently falling
+/// back to legacy — so catch it here with an actionable error instead.
+fn ensure_vz_control_socket_fits(vm_state_dir: &Path) -> Result<(), BuilderVmError> {
+    let ctrl = crate::builderd::builderd_vz_control_socket_path(vm_state_dir);
+    if ctrl.as_os_str().len() >= host_gvproxy::SUN_PATH_MAX {
+        return Err(BuilderVmError::ExtractionFailed(format!(
+            "Vz builder control socket path {} is {} bytes, at/over the {}-byte AF_UNIX \
+             sun_path limit; use a shorter MVM_CACHE_DIR",
+            ctrl.display(),
+            ctrl.as_os_str().len(),
+            host_gvproxy::SUN_PATH_MAX,
+        )));
+    }
+    Ok(())
+}
+
 /// Resolve the absolute path to the `mvm-vz-supervisor` binary.
 ///
 /// Mirrors `mvm_backend::vz::resolve_supervisor_path` (which is
@@ -1334,7 +1362,18 @@ impl VzPersistentBuilderVm {
             u64::from(self.nix_store_mib),
         )?;
 
-        let session_id = self.session_id.clone().unwrap_or_else(unique_job_id);
+        // A minted session id must be SHORT: it lands in the
+        // `mvm-persistent-builder-vz-{session}` state-dir name, and the Vz
+        // supervisor's sockets nest one level deeper under `<state_dir>/vsock/`.
+        // The old `unique_job_id` (~19 chars) pushed `vsock/vsock-<port>.sock`
+        // past the AF_UNIX sun_path limit (the supervisor warns + skips the
+        // bind, so builderd is unreachable and the typed route silently falls
+        // back to legacy). A short hashed id keeps those paths short, matching
+        // the always-short `dev` session that has always worked.
+        let session_id = self
+            .session_id
+            .clone()
+            .unwrap_or_else(short_vz_persistent_session_id);
         let job_dir = builder_vm_cache_dir().join("jobs").join(&session_id);
         stage_persistent_vz_job_dir(&job_dir)?;
 
@@ -1350,6 +1389,11 @@ impl VzPersistentBuilderVm {
                 vm_state_dir.display()
             ))
         })?;
+        // Defense in depth: even a short id can't save a pathologically long
+        // MVM_CACHE_DIR/$HOME. If the builderd control socket still wouldn't fit
+        // sun_path, fail loud here rather than booting a builder whose control
+        // socket can't bind (which surfaces only as a silent typed→legacy fallback).
+        ensure_vz_control_socket_fits(&vm_state_dir)?;
 
         // Spawn host-side gvproxy so the long-lived dev VM has egress
         // (a cold `nix build` from `dev shell` fetches nixpkgs). The
@@ -2202,6 +2246,27 @@ mod tests {
     use super::*;
     #[cfg(unix)]
     use std::os::unix::net::UnixListener;
+
+    #[test]
+    fn short_vz_persistent_session_id_is_short_hex() {
+        let id = short_vz_persistent_session_id();
+        assert_eq!(id.len(), 8, "8 hex chars keeps the state-dir name short");
+        assert!(id.chars().all(|c| c.is_ascii_hexdigit()), "{id}");
+    }
+
+    #[test]
+    fn vz_control_socket_guard_accepts_short_rejects_overlong() {
+        // Normal cache + short (hashed) session id → control socket fits.
+        let ok = Path::new("/Users/u/.cache/mvm/builder-vm/vms/mvm-persistent-builder-vz-deadbeef");
+        assert!(ensure_vz_control_socket_fits(ok).is_ok());
+        // Pathologically long cache/$HOME → control socket over sun_path → loud error.
+        let long = PathBuf::from(format!(
+            "/Users/{}/.cache/mvm/builder-vm/vms/mvm-persistent-builder-vz-deadbeef",
+            "x".repeat(60)
+        ));
+        let err = ensure_vz_control_socket_fits(&long).unwrap_err();
+        assert!(format!("{err}").contains("sun_path"), "{err}");
+    }
 
     fn rootfs_image() -> BuilderVmImage {
         BuilderVmImage::Rootfs {


### PR DESCRIPTION
## Root cause

Sibling of #1247/#1248. `#1248` relocated the **gvproxy** socket under the `AF_UNIX` `sun_path` limit, but the **Vz supervisor's own** sockets under `<state_dir>/vsock/` weren't covered. A minted persistent-builder session used `unique_job_id` (~19 chars), so:

```
110  <cache>/builder-vm/vms/mvm-persistent-builder-vz-<ts-pid>/vsock/vsock-21473.sock   ← builderd control
(usable sun_path = 103 on macOS)
```

The Vz supervisor logs `unix socket path too long (… limit 103)` and **skips the bind**, so the builderd control socket never appears → `resolve_running_builder_socket` finds no ready daemon → the typed `mvm-builderd` route returns `Fellback` → **silent** legacy/single-shot. The `dev` session (`DEV_VM_SESSION_ID="dev"`, 3 chars) stayed short, which is why `mvmctl dev up` always worked.

Live-confirmed (macOS-26): with #1245 + #1248, `persistent-builder start --builder vz` brings the Vz builder *up* (`PB_START_EXIT=0`) and the typed route is *reached* (`persistent-route=1`), but it falls back because the control socket can't bind. Fixes #1255.

## Fix

- Mint a **short hashed session id** (8 hex of `unique_job_id`) for the Vz persistent builder, so `<state_dir>/vsock/*` stays under `sun_path` — making minted sessions behave like the always-short, always-working `dev` session. No change to where the supervisor binds (just a shorter state-dir name), so it can't introduce a supervisor-side surprise.
- Add `ensure_vz_control_socket_fits` — a host-side guard that **fails closed with an actionable error** if a pathologically long `MVM_CACHE_DIR`/`$HOME` would still overrun the limit, instead of booting a builder whose control socket silently can't bind.
- Factor the `sun_path` constant + a shared `short_token` helper out of `host_gvproxy` (DRY with #1248).

## Tests

- `short_vz_persistent_session_id_is_short_hex`
- `vz_control_socket_guard_accepts_short_rejects_overlong`
- `short_token_is_deterministic_fixed_length_and_distinct`

fmt + clippy `-D warnings` + the mvm-build `--features builder-vm` suite green.

## Verification

The mechanism is proven: short id → short path == the `dev` session shape that already works, and #1248 already proved a short `unixgram` path binds. A full live `persistent-builder start --builder vz` → typed-vs-legacy equality proof is running on a macOS-26 box; I'll post the result. This is the third and (per the analysis) final `sun_path` socket in the Vz persistent path, so it should close the Plan 204 WS-D Vz proof (PR #1250).

Related: #1247/#1248 (gvproxy sun_path), #1241/#1245 (`--builder vz`), #1250 (WS-D, held).
