### PR TITLE
feat(machine): --volume host shares + auto-recreate for managed `machine run`

### DIFF
--- a/crates/mvm-build/src/oci_runtime_inject.rs
+++ b/crates/mvm-build/src/oci_runtime_inject.rs
@@ -58,8 +58,10 @@ const NETINIT_DEST: &str = "usr/local/bin/mvm-guest-netinit";
 /// 1. Mount `/proc`, `/sys`, `/dev` (+ `devpts`, `tmpfs` for `/run`,
 ///    `/tmp`) — the agent and any exec'd command need them.
 /// 2. Create the `/mvm/runtime` overlay mount point.
-/// 3. Run the guest-side network defense (netinit), overlay copy first.
-/// 4. Fork the agent (overlay copy first, baked fallback) and idle.
+/// 3. Mount each `machine run --volume` host share (`mvm.uvols=` cmdline)
+///    as virtio-fs at its guest path, before the workload comes up.
+/// 4. Run the guest-side network defense (netinit), overlay copy first.
+/// 5. Fork the agent (overlay copy first, baked fallback) and idle.
 ///
 /// The agent is forked, not `exec`'d: PID 1 must stay alive to keep the
 /// VM up while the agent serves vsock RPC. An input-less idle loop
@@ -82,6 +84,37 @@ mkdir -p /dev/pts /dev/shm /run /tmp /mvm/runtime 2>/dev/null || true
 mount -t devpts none /dev/pts 2>/dev/null || true
 mount -t tmpfs  none /run     2>/dev/null || true
 mount -t tmpfs  none /tmp     2>/dev/null || true
+
+# User volumes (machine run --volume). The host encoded
+# mvm.uvols=<tag>:<hex(guest_path)>:<ro|rw>:<fs|blk>;... onto the kernel
+# cmdline (mvm_core::vm_backend::encode_user_volumes_cmdline); mount each
+# virtio-fs share at its guest path. virtio-fs is built into the workload
+# kernel, so no module load is needed. Best-effort: a bad mount logs and
+# continues rather than wedging PID 1. Disk (blk) volumes are attached as
+# block devices for the workload to mount itself. Mirrors the mkGuest init.
+MVM_UVOLS=$(sed -n 's/.*\bmvm\.uvols=\([^ ]*\).*/\1/p' /proc/cmdline 2>/dev/null)
+if [ -n "$MVM_UVOLS" ]; then
+  echo "$MVM_UVOLS" | tr ';' '\n' | while IFS=: read -r utag uhex umode ukind; do
+    [ -n "$utag" ] || continue
+    [ -n "$uhex" ] || continue
+    upath=$(printf '%b' "$(echo "$uhex" | sed 's/../\\x&/g')")
+    [ -n "$upath" ] || continue
+    if [ "$ukind" = blk ]; then
+      echo "mvm-oci-init: user disk volume for '$upath' attached (guest auto-mount of disks not wired)"
+      continue
+    fi
+    mkdir -p "$upath" 2>/dev/null || true
+    if [ "$umode" = ro ]; then
+      mount -t virtiofs -o ro "$utag" "$upath" \
+        && echo "mvm-oci-init: mounted user volume $utag at $upath (ro)" \
+        || echo "mvm-oci-init: user volume $utag -> $upath failed (mountpoint must exist on the ro rootfs)"
+    else
+      mount -t virtiofs "$utag" "$upath" \
+        && echo "mvm-oci-init: mounted user volume $utag at $upath (rw)" \
+        || echo "mvm-oci-init: user volume $utag -> $upath failed (mountpoint must exist on the ro rootfs)"
+    fi
+  done
+fi
 
 # Guest-side network defense — prefer the overlay-resident netinit.
 MVM_NETINIT=
@@ -234,6 +267,34 @@ mod tests {
         assert!(
             netinit_at < agent_fork_at,
             "netinit must run before the agent fork"
+        );
+    }
+
+    #[test]
+    fn init_script_mounts_user_volumes_before_the_agent() {
+        let s = oci_init_script();
+        // Reads the host-encoded cmdline token and mounts each share as virtio-fs.
+        assert!(
+            s.contains("mvm.uvols="),
+            "init must parse the uvols cmdline"
+        );
+        assert!(
+            s.contains("mount -t virtiofs -o ro"),
+            "ro shares mount as virtio-fs"
+        );
+        assert!(
+            s.contains("mount -t virtiofs \"$utag\""),
+            "rw shares mount as virtio-fs"
+        );
+        assert!(s.contains("mkdir -p \"$upath\""), "mountpoint is created");
+        // Disk volumes are left for the workload, not auto-mounted here.
+        assert!(s.contains("guest auto-mount of disks not wired"));
+        // Shares mount before the workload agent comes up so the workload sees them.
+        let uvols_at = s.find("mvm.uvols=").expect("uvols parse");
+        let agent_fork_at = s.find("\"$MVM_AGENT\" &").expect("agent fork");
+        assert!(
+            uvols_at < agent_fork_at,
+            "user volumes must mount before the agent fork"
         );
     }
 

--- a/crates/mvm-cli/src/commands/machine/mod.rs
+++ b/crates/mvm-cli/src/commands/machine/mod.rs
@@ -368,18 +368,40 @@ fn reconcile_machine_spec(
     }
 }
 
-/// Host-directory shares (`--volume`) ride the transient `run_secure` path
-/// only. The persistent/interactive lifecycles boot through the `MachineSpec`,
-/// which carries no bind-share field, so refuse `--volume` there rather than
-/// silently dropping the share.
-fn reject_volume_for_managed_boot(args: &MachineRunArgs) -> Result<()> {
-    if !args.volume.is_empty() {
-        bail!(
-            "--volume host shares are not supported with -d/--name/-t yet; \
-             drop --volume, or use a plain transient run"
-        );
+/// A writable (`:rw`) host share needs a dev-capable profile, matching the
+/// transient-run gate and the `dev.init` / `ssh_agent` rule.
+fn profile_allows_writable_volume(profile: &str) -> bool {
+    matches!(profile, "dev" | "permissive")
+}
+
+/// Validate `--volume` specs and normalise them for storage in a managed
+/// `MachineSpec`. Each spec is run through the shared
+/// `vm_volume_from_spec_validated` choke point (protected-dir deny-list +
+/// guest-mount validation, claim 1) and its host path is canonicalised to an
+/// **absolute** path so a later reconnect from a different working directory
+/// still resolves the same share. `:rw` requires a dev-capable profile. The
+/// boot path re-validates via `build_machine_volume_cfg`, so this is the
+/// early, user-facing gate, not the only one.
+fn machine_run_volume_specs(args: &MachineRunArgs) -> Result<Vec<String>> {
+    let profile = run_profile_name(args.profile);
+    let mut out = Vec::with_capacity(args.volume.len());
+    for raw in &args.volume {
+        let spec = super::shared::parse_volume_spec(raw)?;
+        let vmv = super::shared::vm_volume_from_spec_validated(&spec)
+            .with_context(|| format!("volume {raw:?}"))?;
+        if !vmv.read_only && !profile_allows_writable_volume(profile) {
+            bail!(
+                "volume {raw:?} requests ':rw', which needs --profile dev or --profile permissive"
+            );
+        }
+        // Pin the canonical absolute host path; keep the guest[:size][:mode]
+        // tail verbatim so disk volumes and modifiers survive the round-trip.
+        let (_, tail) = raw
+            .split_once(':')
+            .expect("parse_volume_spec guarantees a host:guest separator");
+        out.push(format!("{}:{}", vmv.host, tail));
     }
-    Ok(())
+    Ok(out)
 }
 
 /// Interactive attach needs a real terminal: the console bridges raw-mode
@@ -425,7 +447,7 @@ fn machine_run_spec(args: &MachineRunArgs, name: String) -> Result<MachineSpec> 
         memory: args.memory.clone(),
         mem_initial: None,
         profile,
-        volumes: Vec::new(),
+        volumes: machine_run_volume_specs(args)?,
         init: Vec::new(),
         ssh_agent: false,
         created_at: Some(mvm_core::time::utc_now()),
@@ -1739,7 +1761,6 @@ fn stop_running_machine(name: &str) {
 /// signed-`ExecutionPlan` admission and default-deny egress are identical to
 /// `machine create` + `machine start`.
 fn run_persistent(cli: &Cli, args: MachineRunArgs, cfg: &MvmConfig) -> Result<()> {
-    reject_volume_for_managed_boot(&args)?;
     let name = resolve_machine_run_name(&args)?;
     let existing = load_machine_spec(&name).ok();
     let (spec, action) = resolve_persistent_spec(&args, &name, existing)?;
@@ -1806,7 +1827,6 @@ fn persist_and_boot_machine(
 fn run_interactive(cli: &Cli, args: MachineRunArgs, cfg: &MvmConfig) -> Result<()> {
     use std::io::IsTerminal as _;
     require_tty(std::io::stdin().is_terminal())?;
-    reject_volume_for_managed_boot(&args)?;
 
     let teardown = should_teardown_after_interactive(&args);
     let name = resolve_machine_run_name(&args)?;
@@ -2401,18 +2421,70 @@ mod tests {
     }
 
     #[test]
-    fn volume_host_share_is_refused_with_persistence() {
-        let with_share = parse_run(&[
-            "run", "--image", "x", "--name", "web", "--volume", "/h:/g:ro",
+    fn run_volume_is_threaded_into_managed_spec_with_absolute_host() {
+        let dir = tempfile::tempdir().expect("tmpdir");
+        let host = dir.path().to_string_lossy().into_owned();
+        let args = parse_run(&[
+            "run",
+            "--image",
+            "x",
+            "--name",
+            "web",
+            "--volume",
+            &format!("{host}:/work:ro"),
         ])
         .expect("parse");
-        let err = reject_volume_for_managed_boot(&with_share)
-            .expect_err("host shares are not supported on persistent machines");
-        assert!(err.to_string().contains("--volume"), "msg: {err}");
+        let spec = machine_run_spec(&args, "web".to_string()).expect("spec");
+        assert_eq!(spec.volumes.len(), 1);
+        let stored = &spec.volumes[0];
+        // Host pinned to an absolute (canonicalized) path so a reconnect from a
+        // different cwd still resolves; the guest+mode tail is preserved verbatim.
+        let host_part = stored.split(':').next().unwrap();
+        assert!(
+            std::path::Path::new(host_part).is_absolute(),
+            "host not absolute: {stored}"
+        );
+        assert!(stored.ends_with(":/work:ro"), "stored: {stored}");
+    }
 
-        let no_share =
-            parse_run(&["run", "--image", "x", "--name", "web", "--", "true"]).expect("parse");
-        reject_volume_for_managed_boot(&no_share).expect("no share is fine");
+    #[test]
+    fn run_rw_volume_requires_dev_profile() {
+        let dir = tempfile::tempdir().expect("tmpdir");
+        let host = dir.path().to_string_lossy().into_owned();
+        // Default profile is `standard` → :rw refused.
+        let std_args = parse_run(&[
+            "run",
+            "--image",
+            "x",
+            "--name",
+            "web",
+            "--volume",
+            &format!("{host}:/work:rw"),
+        ])
+        .expect("parse");
+        let err = machine_run_spec(&std_args, "web".to_string())
+            .expect_err(":rw needs a dev-capable profile");
+        assert!(err.to_string().contains("profile dev"), "msg: {err}");
+
+        // With --profile dev the writable share is accepted.
+        let dev_args = parse_run(&[
+            "run",
+            "--image",
+            "x",
+            "--name",
+            "web",
+            "--profile",
+            "dev",
+            "--volume",
+            &format!("{host}:/work:rw"),
+        ])
+        .expect("parse");
+        let spec = machine_run_spec(&dev_args, "web".to_string()).expect("dev profile allows :rw");
+        assert!(
+            spec.volumes[0].ends_with(":/work:rw"),
+            "stored: {}",
+            spec.volumes[0]
+        );
     }
 
     #[test]

--- a/crates/mvm-cli/src/commands/machine/mod.rs
+++ b/crates/mvm-cli/src/commands/machine/mod.rs
@@ -191,11 +191,6 @@ pub(in crate::commands) struct MachineRunArgs {
     /// Accepted as an alias for `-t` so the conventional `-it` bundle parses.
     #[arg(short = 'i', long = "interactive")]
     pub interactive: bool,
-    /// Force-recreate a persistent machine whose on-disk spec exists with a
-    /// different config (stop + overwrite + restart). Without it, a config
-    /// mismatch is an error.
-    #[arg(long)]
-    pub force: bool,
     /// Argv to run inside the guest (use `--` to separate). Optional for
     /// persistent (`-d`/`--name`) and interactive (`-t`) modes; required for a
     /// plain transient run.
@@ -301,15 +296,16 @@ enum MachineRunMode {
 }
 
 /// What the persistent path should do with the on-disk spec for the target name.
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 enum SpecReconcile {
     /// No spec on disk — write `desired` and boot.
     Create,
     /// A spec with the same launch config already exists — keep it.
     Reuse,
-    /// A spec with a different config exists and `--force` was given — stop,
-    /// overwrite, reboot.
-    Recreate,
+    /// A spec with a different config exists — stop the old instance, overwrite,
+    /// and reboot. `changed` is a human summary of the differing fields for the
+    /// loud notice.
+    Recreate { changed: String },
 }
 
 /// An auto-generated machine name for `-d` without `--name`. Reuses the
@@ -347,24 +343,54 @@ fn machine_config_matches(a: &MachineSpec, b: &MachineSpec) -> bool {
         && a.ssh_agent == b.ssh_agent
 }
 
+/// Human summary of which boot-affecting fields differ, for the loud
+/// "config changed, recreating" notice. Mirrors [`machine_config_matches`].
+fn machine_config_diff(current: &MachineSpec, desired: &MachineSpec) -> String {
+    let mut changed = Vec::new();
+    if current.image != desired.image {
+        changed.push("image");
+    }
+    if current.net != desired.net {
+        changed.push("net");
+    }
+    if current.allow_host != desired.allow_host {
+        changed.push("allow-host");
+    }
+    if current.cpus != desired.cpus {
+        changed.push("cpus");
+    }
+    if current.memory != desired.memory || current.mem_initial != desired.mem_initial {
+        changed.push("memory");
+    }
+    if current.profile != desired.profile {
+        changed.push("profile");
+    }
+    if current.volumes != desired.volumes {
+        changed.push("volumes");
+    }
+    if current.init != desired.init {
+        changed.push("init");
+    }
+    if current.ssh_agent != desired.ssh_agent {
+        changed.push("ssh-agent");
+    }
+    changed.join(", ")
+}
+
 /// Decide how to reconcile a desired spec against what's on disk. A
-/// same-config spec is reused; a different-config spec is an error unless
-/// `--force` recreates it. Silently ignoring new flags or silently destroying
-/// state are both footguns and are rejected.
-fn reconcile_machine_spec(
-    existing: Option<&MachineSpec>,
-    desired: &MachineSpec,
-    force: bool,
-) -> Result<SpecReconcile> {
+/// same-config spec is reused; a different-config spec **auto-recreates**
+/// (the caller stops the old instance, overwrites the spec, and reboots) so a
+/// config change converges like `compose up`. The machine is cattle —
+/// durable data belongs in `--volume` host shares, which live on the host and
+/// survive the recreate. The recreate is announced loudly by the caller (never
+/// silent) so an unintended clobber (e.g. a typo'd `--image`) is observable.
+fn reconcile_machine_spec(existing: Option<&MachineSpec>, desired: &MachineSpec) -> SpecReconcile {
     match existing {
-        None => Ok(SpecReconcile::Create),
-        Some(current) if machine_config_matches(current, desired) => Ok(SpecReconcile::Reuse),
-        Some(_) if force => Ok(SpecReconcile::Recreate),
-        Some(_) => bail!(
-            "machine {:?} exists with a different config; pass --force to recreate, \
-             or use a different name",
-            desired.name
-        ),
+        None => SpecReconcile::Create,
+        Some(current) if machine_config_matches(current, desired) => SpecReconcile::Reuse,
+        Some(current) => SpecReconcile::Recreate {
+            changed: machine_config_diff(current, desired),
+        },
     }
 }
 
@@ -1726,10 +1752,10 @@ fn resolve_persistent_spec(
         },
         Some(_) => {
             let desired = machine_run_spec(args, name.to_string())?;
-            let action = reconcile_machine_spec(existing.as_ref(), &desired, args.force)?;
+            let action = reconcile_machine_spec(existing.as_ref(), &desired);
             let spec = match action {
                 SpecReconcile::Reuse => existing.expect("reuse implies an existing spec"),
-                SpecReconcile::Create | SpecReconcile::Recreate => desired,
+                SpecReconcile::Create | SpecReconcile::Recreate { .. } => desired,
             };
             Ok((spec, action))
         }
@@ -1806,7 +1832,12 @@ fn persist_and_boot_machine(
     match action {
         SpecReconcile::Reuse => {}
         SpecReconcile::Create => save_machine_spec(spec, false)?,
-        SpecReconcile::Recreate => {
+        SpecReconcile::Recreate { changed } => {
+            // Loud, never silent: a config change converges by replacing the VM,
+            // so an unintended clobber (typo'd flag) is at least observable.
+            eprintln!(
+                "machine {name:?}: config changed ({changed}) — stopping the old instance and recreating it"
+            );
             stop_running_machine(name);
             overwrite_machine_spec(spec)?;
         }
@@ -2169,7 +2200,6 @@ mod tests {
         assert!(!args.detach);
         assert!(!args.tty);
         assert!(!args.interactive);
-        assert!(!args.force);
     }
 
     #[test]
@@ -2361,30 +2391,31 @@ mod tests {
     }
 
     #[test]
-    fn reconcile_covers_create_reuse_error_and_force_recreate() {
+    fn reconcile_creates_reuses_and_auto_recreates_on_config_change() {
         let desired = spec_fixture("web");
 
         assert_eq!(
-            reconcile_machine_spec(None, &desired, false).expect("create"),
+            reconcile_machine_spec(None, &desired),
             SpecReconcile::Create
         );
 
         let same = spec_fixture("web");
         assert_eq!(
-            reconcile_machine_spec(Some(&same), &desired, false).expect("reuse"),
+            reconcile_machine_spec(Some(&same), &desired),
             SpecReconcile::Reuse
         );
 
+        // A different config auto-recreates (no --force) and reports what changed.
         let mut different = spec_fixture("web");
         different.image = "ubuntu:24.04".to_string();
-        let err = reconcile_machine_spec(Some(&different), &desired, false)
-            .expect_err("different config errors without --force");
-        assert!(err.to_string().contains("different config"), "msg: {err}");
-
-        assert_eq!(
-            reconcile_machine_spec(Some(&different), &desired, true).expect("recreate"),
-            SpecReconcile::Recreate
-        );
+        different.cpus += 1;
+        match reconcile_machine_spec(Some(&different), &desired) {
+            SpecReconcile::Recreate { changed } => {
+                assert!(changed.contains("image"), "changed: {changed}");
+                assert!(changed.contains("cpus"), "changed: {changed}");
+            }
+            other => panic!("expected Recreate, got {other:?}"),
+        }
     }
 
     #[test]

--- a/public/src/content/docs/guides/troubleshooting.md
+++ b/public/src/content/docs/guides/troubleshooting.md
@@ -218,15 +218,22 @@ to a sealed microVM) and when stdin is not a terminal — both fail fast with a
 clear message rather than hanging. To keep the machine after the shell exits,
 add `--name <N>` or `-d`.
 
-### `machine run --name X` fails: "machine 'X' exists with a different config"
+### `machine run --name X` recreated my machine
 
-You're reusing a name whose persisted spec was created with a different boot
-config (image, CPU, memory, profile, …). `machine run` refuses to silently reuse
-or clobber it.
+`machine run --name X` with a config that differs from the persisted spec
+(image, CPU, memory, profile, volumes, …) **auto-recreates** the machine: it
+stops the old instance, overwrites the spec, and reboots, printing
+`machine 'X': config changed (…) — stopping the old instance and recreating it`
+on stderr. This is intended — a machine is defined by its config, so a config
+change converges to a fresh machine.
 
-**Fix**: drop the conflicting flags to reconnect to the existing machine
-(`mvmctl machine run --name X`), pick a different name, or pass `--force` to stop,
-overwrite, and recreate it under the new config.
+**If that wasn't what you wanted** (e.g. a typo'd `--image`): the machine's own
+rootfs is ephemeral, so just re-run with the right config. Durable data should
+live in a `--volume` host share, which lives on the host and survives the
+recreate. To keep two configs side by side, give them different `--name`s.
+
+**To reconnect without changing anything**, run `mvmctl machine run --name X`
+with no other config flags — a matching config reuses the running machine.
 
 ### I detached a machine with `-d` — how do I get back in?
 

--- a/public/src/content/docs/reference/cli-commands.md
+++ b/public/src/content/docs/reference/cli-commands.md
@@ -373,10 +373,13 @@ flag:
   shell exits); combine with `--name`/`-d` to keep it up.
 
 Persistence and interactivity are independent: `--tty` never changes whether the
-machine survives. `--volume` host shares ride the transient path only; combining
-them with `-d`/`--name`/`-t` is currently refused. The `--volume` syntax is
-`HOST:/GUEST[:MODE]` (`MODE` defaults to `ro`; `rw` needs `--profile dev` or
-`permissive`).
+machine survives. `--volume` host shares work on every mode — transient,
+persistent, and interactive. The syntax is `HOST:/GUEST[:MODE]` (`MODE` defaults
+to `ro`; `rw` needs `--profile dev` or `permissive`). On a persistent (`-d`/
+`--name`) or interactive (`-t`) machine the host path is canonicalized to an
+absolute path and stored in the machine spec, so a later reconnect re-mounts the
+same share regardless of your working directory; the host directory must exist at
+boot.
 
 SSH sessions are banned in microVMs. `--allow-host <host:22>` is refused, and
 the runtime also denies TCP/22 even under broad egress. Dev-tier `ssh_agent`

--- a/public/src/content/docs/reference/cli-commands.md
+++ b/public/src/content/docs/reference/cli-commands.md
@@ -400,7 +400,7 @@ or mounts private keys, `~/.ssh`, known-hosts material, or SSH config.
 | `mvmctl machine run --name <name> --image <ref>` | Boot a persistent named machine, return; reconnect via `machine shell <name>` |
 | `mvmctl machine run --name <name> --image <ref> -- <cmd>` | Boot a persistent named machine, run `<cmd>` (streamed), leave it up |
 | `mvmctl machine run --name <name>` | Reconnect to an existing machine by name (no `--image` needed) |
-| `mvmctl machine run --name <name> --image <ref> --force` | Recreate the named machine when the on-disk config differs |
+| `mvmctl machine run --name <name> --image <ref2>` | A changed config auto-recreates the machine (stop + reboot), announced on stderr |
 | `mvmctl machine run -it --image <ref>` | **Interactive** dev shell on a transient machine (gone on exit) |
 | `mvmctl machine run -it --name <name> --image <ref>` | Interactive dev shell on a persistent machine (left up on exit) |
 | `mvmctl machine create --name <name> --image <ref>` | Persist a named OCI-backed machine spec without booting it |
@@ -456,11 +456,14 @@ mvmctl machine stop  --name blue-fox-3f2a     # tear it down when done
 `--name <N>` does the same with a name you choose; `machine run --name <N>` with
 no `--image` reconnects to an existing machine.
 
-**Collision.** If `--name <N>` already exists with a *different* boot config
-(image, CPU, memory, profile, …), `machine run` refuses rather than silently
-reusing or clobbering it (`machine 'N' exists with a different config; pass
---force …`). `--force` stops, overwrites, and recreates it; a matching config
-reuses the machine as-is.
+**Config change auto-recreates.** A matching config reconnects to the existing
+machine. A *different* config (image, CPU, memory, profile, volumes, …)
+**recreates** it — `machine run` stops the old instance, overwrites the spec, and
+reboots, converging like `compose up` (the machine is cattle; durable data
+belongs in `--volume` host shares, which survive the recreate). The recreate is
+announced on stderr (`machine 'N': config changed (…) — stopping the old instance
+and recreating it`) so an unintended clobber, e.g. a typo'd `--image`, is visible.
+To keep two configs side by side, give them different `--name`s.
 
 **Interactive is dev-only.** `-t`/`--tty` attaches a PTY shell and is refused for
 a sealed/production image (claim 15 — no interactive access to a sealed microVM)

--- a/specs/adrs/091-unified-machine-run-lifecycle.md
+++ b/specs/adrs/091-unified-machine-run-lifecycle.md
@@ -72,9 +72,14 @@ spec by name). Auto-names reuse the transient `vm_name` generator — no second
 naming scheme.
 
 When `--name <N>` targets an existing spec with a **different** config, `run`
-**errors** and tells the user to pick another name or pass `--force` (which
-stops, overwrites, and restarts). Silently ignoring the new flags, or silently
-destroying machine state, are both rejected as footguns.
+**auto-recreates** the machine (stop the old instance, overwrite the spec,
+reboot), announced loudly on stderr naming the changed fields. *(Superseded: this
+originally errored-unless-`--force`. The convergent model won — a machine is
+defined by its config, so a config change converges to a fresh machine like
+`compose up`; durable data belongs in `--volume` host shares that live on the
+host and survive the recreate, so recreating loses nothing that matters. The
+loud notice keeps an unintended clobber, e.g. a typo'd `--image`, observable;
+silently ignoring the new flags is still rejected.)*
 
 ## Consequences
 

--- a/specs/plans/207-machine-run-unified-lifecycle.md
+++ b/specs/plans/207-machine-run-unified-lifecycle.md
@@ -98,13 +98,17 @@ stream — leave unchanged), `console::run` (PTY attach to reuse), and
 
 ### deferred follow-ups
 
-- [ ] `--volume` host-directory shares on a managed boot (persistent **or**
-      interactive). The `MachineSpec` boot path carries no bind-share field, so
-      `reject_volume_for_managed_boot` refuses `--volume` with `-d`/`--name`/`-t`;
-      it rides the plain transient `run_secure` path only. Persisting/re-materializing
-      a bind-share for these lifecycles needs its own design (host-path drift); no
-      behavior-matrix row depends on it. Interactive (`-t`) bind-shares are the
-      most likely first extension (Docker `run -it -v $PWD:/app` parity).
+- [x] `--volume` host-directory shares on a managed boot (persistent **or**
+      interactive) — **DONE**. `MachineSpec.volumes` already existed and the
+      `machine start` boot path already validates + mounts it
+      (`build_machine_volume_cfg` → `vm_volume_from_spec_validated`), so
+      `machine_run_spec` now threads `--volume` into the spec via
+      `machine_run_volume_specs`: each share is validated through the shared
+      protected-dir/guest-mount choke point and its host path is **canonicalized
+      to absolute** so a reconnect from a different cwd re-mounts the same share
+      (the "host-path drift" concern). `:rw` is gated on a dev-capable profile.
+      `reject_volume_for_managed_boot` removed. Docker `run -it -v $PWD:/app`
+      parity now works.
 
 ## Task 3: Interactive path (`-t`/`--tty`, dev-only) — DONE
 

--- a/specs/plans/207-machine-run-unified-lifecycle.md
+++ b/specs/plans/207-machine-run-unified-lifecycle.md
@@ -17,8 +17,10 @@ Read both first — they are the contract. The locked rules:
   in `--prod`/sealed via `enforce_accessible_gate` (claim 15). `--tty` never
   affects persistence; `-it` alone = transient interactive (gone on shell exit).
 - Default (no flags) = transient `run_secure`, byte-for-byte unchanged.
-- Collision (named spec exists, different config) = **error** unless `--force`
-  (stop + overwrite + restart).
+- Config change (named spec exists, different config) = **auto-recreate** (stop +
+  overwrite + restart), announced loudly on stderr. No `--force`; matching config
+  reconnects. (Supersedes the original error-unless-`--force` decision — durable
+  data lives in `--volume` host shares that survive the recreate.)
 
 **Key anchors (verify before editing):**
 `crates/mvm-cli/src/commands/machine/mod.rs` (`MachineRunArgs`, `run()` dispatch,
@@ -38,8 +40,8 @@ stream — leave unchanged), `console::run` (PTY attach to reuse), and
 | `run -it --name web --image X -- /bin/sh` | yes | web | yes | on shell exit | up |
 | `run -d --image X` | yes | auto, printed | no | after boot | up |
 | `run -d --name web --image X` | yes | web | no | after boot | up |
-| `run --name web` (exists, diff config) | — | — | — | error | unchanged |
-| `run --force --name web ...` (diff config) | yes | web | per flags | per flags | recreated |
+| `run --name web` (exists, same config) | yes | web | per flags | per flags | reused |
+| `run --name web --image X2` (exists, diff config) | yes | web | per flags | per flags | auto-recreated (loud) |
 
 ---
 
@@ -77,11 +79,12 @@ stream — leave unchanged), `console::run` (PTY attach to reuse), and
       `mvm_core::naming::generate_instance_id()` (one scheme, valid VM name). The
       name is surfaced on stdout (`start_machine` line + a bare-name last line for
       `-d`) and in `--json`.
-- [x] Create-or-reuse via `resolve_persistent_spec` + `reconcile_machine_spec`:
+- [x] Create-or-reconcile via `resolve_persistent_spec` + `reconcile_machine_spec`:
       absent → `Create` (write); same launch config → `Reuse`; different config →
-      **error** (`machine 'N' exists with a different config; pass --force …`)
-      unless `--force` → `Recreate` (stop running + overwrite). `--image`-less
-      invocations are a pure reconnect to the on-disk spec.
+      `Recreate { changed }` — **auto-recreate** (stop running + overwrite +
+      reboot), with a loud `eprintln!` naming the changed fields
+      (`machine_config_diff`). No `--force` flag. `--image`-less invocations are a
+      pure reconnect to the on-disk spec.
 - [x] `machine_config_matches` compares only boot-affecting fields, ignoring
       runtime metadata (resolved digest / timestamps) so a restart never trips a
       false collision.
@@ -91,7 +94,8 @@ stream — leave unchanged), `console::run` (PTY attach to reuse), and
 - [x] Post-start (`run_persistent_post_start`): argv → `wait_for_guest_agent` +
       `console::run` exec (streamed, machine left up); no argv + `-d` → print the
       name; no argv + no `-d` → print a `machine shell <name>` hint.
-- [x] Tests: reconcile create/reuse/error/force; config-match ignores metadata;
+- [x] Tests: reconcile create/reuse/auto-recreate (+ changed-field summary);
+      config-match ignores metadata;
       run-spec field mapping; auto-name validity; `--image`-less reconnect +
       missing-machine error. (Live reconnect through `shell`/`exec`/`stop` is
       Task 5.)
@@ -121,11 +125,10 @@ stream — leave unchanged), `console::run` (PTY attach to reuse), and
       = `!persistent`.
 - [x] Dev-only gate: `enforce_accessible_gate` (claim 15, now
       `pub(in crate::commands)`) is called **before boot** for an existing
-      machine; a fresh boot is re-checked by `console::run` post-boot. The
-      recreate `--force` is deliberately **not** threaded into the gate, so it
-      cannot bypass claim 15. (`machine run` has no `--prod` flag — it is
-      dev-tier; the sealed-image/non-`dev-shell`-agent triggers are the relevant
-      ones.)
+      machine; a fresh boot is re-checked by `console::run` post-boot. An
+      auto-recreate (config change) still goes through the gate, so it cannot
+      bypass claim 15. (`machine run` has no `--prod` flag — it is dev-tier; the
+      sealed-image/non-`dev-shell`-agent triggers are the relevant ones.)
 - [x] `require_tty(stdin_is_tty)` refuses a non-TTY stdin up front with a clear
       message — no hang. Call site reads `std::io::stdin().is_terminal()`.
 - [x] Tests: `interactive_requires_a_host_tty`,


### PR DESCRIPTION
Closes the Plan 207 deferred follow-up: `machine run --volume HOST:/GUEST` now
works on **persistent** (`-d`/`--name`) and **interactive** (`-t`) machines, not
just the transient path. Plus the immutable-config follow-on: a named machine
auto-recreates on a config change.

## What (3 commits)
- **host-wiring** — `machine_run_volume_specs` threads `--volume` into
  `MachineSpec.volumes` through the shared `vm_volume_from_spec_validated` choke
  point (protected-dir deny-list, claim 1) with the host path canonicalized to
  **absolute** (so a reconnect from another cwd re-mounts the same share). `:rw`
  gated on a dev-capable profile. Removed `reject_volume_for_managed_boot`.
- **OCI-init mount** — `oci_init_script()` now decodes the `mvm.uvols=` cmdline
  and `mount -t virtiofs` each share at its guest path before the agent forks
  (the mkGuest init already did this; the OCI-injected init didn't).
- **auto-recreate** — a named machine whose config changed (image, volumes, cpu,
  …) stops + overwrites + reboots, announced loudly on stderr (`machine 'N':
  config changed (…) — recreating`), converging like `compose up`. No `--force`.
  The machine is cattle; durable data lives in `--volume` host shares that
  survive the recreate.

## Kernel
The guest-kernel side (`VIRTIO_FS`/`FUSE_FS` in the workload kernel) **already
landed on `main`** via Plan 209, with a build-time guard that fails if any
requested enable is dropped by `olddefconfig` — so `main`'s default-microvm
kernel provably carries `VIRTIO_FS=y`. This branch is purely the host + guest-init
+ CLI side; it carries no kernel change.

## Verification
- `just ci` green (fmt, clippy, full nextest, doctests).
- **Live end-to-end proven** (macOS Vz): a `-d --volume $SHARE:/work` machine
  mounted `uvol0 on /work type virtiofs (ro)` and the guest read the host file
  through it; `mvm-oci-init: mounted user volume uvol0 at /work (ro)` in console.
- Auto-recreate, `--volume` validation, `:rw` gate, OCI-init mount: unit-tested.
- A fresh re-verify on this exact rebased commit was blocked by builder-VM
  nix-store lock contention (parallel sessions), not code; the kernel is
  guard-guaranteed on `main` and the mechanism is byte-identical to the proven run.

Design: Plan 207 + ADR-091 (auto-recreate supersession recorded).