### PR TITLE
fix(builder): page-align the libkrun builder kernel (Linux KVM rc -22)

### DIFF
--- a/crates/mvm-build/src/libkrun_builder.rs
+++ b/crates/mvm-build/src/libkrun_builder.rs
@@ -1264,10 +1264,23 @@ impl BuilderVmImage {
 /// pre-populated with the variant's kernel cmdline (where applicable).
 /// `RootDir` images carry no cmdline — libkrun handles `set_root`
 /// mode without one.
-/// Page size KVM's `KVM_SET_USER_MEMORY_REGION` aligns to (4 KiB on x86_64 /
-/// aarch64 Linux, where the bug below manifests; larger guest pages are still
-/// multiples of it).
-const KVM_REGION_ALIGN: u64 = 4096;
+/// The alignment KVM's `KVM_SET_USER_MEMORY_REGION` enforces: the **host** page
+/// size. 4 KiB on x86_64 and 4K-page aarch64, but 16 KiB / 64 KiB aarch64 hosts
+/// exist (RHEL/CentOS 64K-page kernels), where a kernel aligned only to 4 KiB
+/// still trips `EINVAL`. Query `sysconf(_SC_PAGESIZE)` so the padding is correct
+/// on every host instead of assuming 4 KiB; fall back to 4 KiB only if the query
+/// is unavailable.
+fn host_page_size() -> u64 {
+    #[cfg(unix)]
+    {
+        // SAFETY: `sysconf` is a side-effect-free query with no preconditions.
+        let v = unsafe { libc::sysconf(libc::_SC_PAGESIZE) };
+        if v > 0 {
+            return v as u64;
+        }
+    }
+    4096
+}
 
 /// Round `n` up to the next multiple of `align`.
 fn align_up(n: u64, align: u64) -> u64 {
@@ -1286,6 +1299,10 @@ fn align_up(n: u64, align: u64) -> u64 {
 /// `vmlinux.page-aligned`) created next to it and reused across builds. Trailing
 /// zeros are safe — libkrun loads the kernel from its own headers; the padded
 /// tail is unused guest RAM.
+///
+/// Scope: only the external-`vmlinux` (`Rootfs`) path runs this. `RootDir` /
+/// Stage 0 boots use libkrun's bundled libkrunfw kernel via `set_kernel`, which
+/// libkrun maps itself — they never reach here and need no padding.
 fn page_aligned_kernel(kernel_path: &Path) -> Result<PathBuf, BuilderVmError> {
     if !cfg!(target_os = "linux") {
         return Ok(kernel_path.to_path_buf());
@@ -1298,10 +1315,11 @@ fn page_aligned_kernel(kernel_path: &Path) -> Result<PathBuf, BuilderVmError> {
             ))
         })?
         .len();
-    if size.is_multiple_of(KVM_REGION_ALIGN) {
+    let align = host_page_size();
+    if size.is_multiple_of(align) {
         return Ok(kernel_path.to_path_buf());
     }
-    let aligned_size = align_up(size, KVM_REGION_ALIGN);
+    let aligned_size = align_up(size, align);
     let aligned_path = kernel_path.with_extension("page-aligned");
     if !aligned_copy_is_current(&aligned_path, aligned_size, kernel_path) {
         write_zero_padded_copy(kernel_path, &aligned_path, aligned_size)?;
@@ -1323,15 +1341,18 @@ fn aligned_copy_is_current(aligned_path: &Path, aligned_size: u64, source: &Path
 }
 
 /// Copy `source` to `dest` and zero-extend it to `padded_size` (`set_len`
-/// zero-fills the tail). Written to a temp sibling then renamed so a concurrent
-/// reader never sees a half-written kernel.
+/// zero-fills the tail). Written to a process-unique temp sibling then renamed
+/// onto `dest`, so a concurrent reader never sees a half-written kernel and two
+/// builders sharing a cache dir don't interleave each other's copy/extend on a
+/// shared `.tmp` path — each writes its own `.tmp.<pid>` and the final rename is
+/// atomic (last-writer-wins; both produce byte-identical padded copies).
 fn write_zero_padded_copy(
     source: &Path,
     dest: &Path,
     padded_size: u64,
 ) -> Result<(), BuilderVmError> {
     let mut tmp = dest.as_os_str().to_owned();
-    tmp.push(".tmp");
+    tmp.push(format!(".tmp.{}", std::process::id()));
     let tmp = PathBuf::from(tmp);
     std::fs::copy(source, &tmp).map_err(|e| {
         BuilderVmError::ExtractionFailed(format!(
@@ -2562,8 +2583,23 @@ mod tests {
         assert_eq!(padded.len(), 8192, "padded to the page boundary");
         assert_eq!(&padded[..5000], &body[..], "original bytes preserved");
         assert!(padded[5000..].iter().all(|&b| b == 0), "tail zero-filled");
-        // The temp sibling is renamed away, not left behind.
-        assert!(!dir.path().join("vmlinux.page-aligned.tmp").exists());
+        // The process-unique temp sibling is renamed away, not left behind.
+        let leftover_tmp = std::fs::read_dir(dir.path())
+            .unwrap()
+            .filter_map(Result::ok)
+            .any(|e| {
+                e.file_name()
+                    .to_string_lossy()
+                    .contains(".page-aligned.tmp")
+            });
+        assert!(!leftover_tmp, "no .tmp.<pid> sibling left behind");
+    }
+
+    #[test]
+    fn host_page_size_is_a_sane_page() {
+        let p = host_page_size();
+        assert!(p >= 4096, "page size {p} unexpectedly small");
+        assert!(p.is_power_of_two(), "page size {p} not a power of two");
     }
 
     #[cfg(unix)]
@@ -2602,7 +2638,9 @@ mod tests {
     fn page_aligned_kernel_passes_through_when_already_aligned() {
         let dir = TempDir::new().unwrap();
         let k = dir.path().join("vmlinux");
-        std::fs::write(&k, vec![0u8; 8192]).unwrap(); // multiple of 4096
+        // A whole number of host pages is aligned by construction on any host.
+        let aligned_len = (host_page_size() * 2) as usize;
+        std::fs::write(&k, vec![0u8; aligned_len]).unwrap();
         // Already aligned → original path, no sibling created.
         assert_eq!(page_aligned_kernel(&k).unwrap(), k);
         assert!(!dir.path().join("vmlinux.page-aligned").exists());
@@ -2615,10 +2653,13 @@ mod tests {
     fn page_aligned_kernel_pads_unaligned_on_linux() {
         let dir = TempDir::new().unwrap();
         let k = dir.path().join("vmlinux");
-        std::fs::write(&k, vec![7u8; 5000]).unwrap(); // not a multiple of 4096
+        // 5000 is not a whole number of pages on any real page size (4K/16K/64K).
+        let raw = 5000u64;
+        std::fs::write(&k, vec![7u8; raw as usize]).unwrap();
         let aligned = page_aligned_kernel(&k).unwrap();
         assert_eq!(aligned, dir.path().join("vmlinux.page-aligned"));
-        assert_eq!(std::fs::metadata(&aligned).unwrap().len(), 8192);
+        let expected = align_up(raw, host_page_size());
+        assert_eq!(std::fs::metadata(&aligned).unwrap().len(), expected);
     }
 
     fn ok_mounts(scratch: &TempDir) -> BuilderMounts {

--- a/crates/mvm-build/src/libkrun_builder.rs
+++ b/crates/mvm-build/src/libkrun_builder.rs
@@ -1278,7 +1278,7 @@ fn align_up(n: u64, align: u64) -> u64 {
 /// exact size. Linux KVM rejects a `KVM_SET_USER_MEMORY_REGION` whose size is
 /// not a multiple of the host page size, so an unaligned `vmlinux` makes VM
 /// creation fail with `EINVAL` (`rc -22`) — distinct from a `nix build` error,
-/// and previously masked by the ADR-093 libkrun→QEMU fallback. macOS HVF has no
+/// and previously masked by the libkrun→QEMU builder fallback. macOS HVF has no
 /// such requirement, so this is a no-op off Linux.
 ///
 /// Return a kernel path whose file size is page-aligned: the original when it

--- a/crates/mvm-build/src/libkrun_builder.rs
+++ b/crates/mvm-build/src/libkrun_builder.rs
@@ -1264,6 +1264,108 @@ impl BuilderVmImage {
 /// pre-populated with the variant's kernel cmdline (where applicable).
 /// `RootDir` images carry no cmdline — libkrun handles `set_root`
 /// mode without one.
+/// Page size KVM's `KVM_SET_USER_MEMORY_REGION` aligns to (4 KiB on x86_64 /
+/// aarch64 Linux, where the bug below manifests; larger guest pages are still
+/// multiples of it).
+const KVM_REGION_ALIGN: u64 = 4096;
+
+/// Round `n` up to the next multiple of `align`.
+fn align_up(n: u64, align: u64) -> u64 {
+    n.div_ceil(align) * align
+}
+
+/// libkrun maps the external kernel into guest memory with the kernel file's
+/// exact size. Linux KVM rejects a `KVM_SET_USER_MEMORY_REGION` whose size is
+/// not a multiple of the host page size, so an unaligned `vmlinux` makes VM
+/// creation fail with `EINVAL` (`rc -22`) — distinct from a `nix build` error,
+/// and previously masked by the ADR-093 libkrun→QEMU fallback. macOS HVF has no
+/// such requirement, so this is a no-op off Linux.
+///
+/// Return a kernel path whose file size is page-aligned: the original when it
+/// already is, otherwise a zero-padded sibling (`vmlinux` →
+/// `vmlinux.page-aligned`) created next to it and reused across builds. Trailing
+/// zeros are safe — libkrun loads the kernel from its own headers; the padded
+/// tail is unused guest RAM.
+fn page_aligned_kernel(kernel_path: &Path) -> Result<PathBuf, BuilderVmError> {
+    if !cfg!(target_os = "linux") {
+        return Ok(kernel_path.to_path_buf());
+    }
+    let size = std::fs::metadata(kernel_path)
+        .map_err(|e| {
+            BuilderVmError::ExtractionFailed(format!(
+                "stat builder kernel {}: {e}",
+                kernel_path.display()
+            ))
+        })?
+        .len();
+    if size.is_multiple_of(KVM_REGION_ALIGN) {
+        return Ok(kernel_path.to_path_buf());
+    }
+    let aligned_size = align_up(size, KVM_REGION_ALIGN);
+    let aligned_path = kernel_path.with_extension("page-aligned");
+    if !aligned_copy_is_current(&aligned_path, aligned_size, kernel_path) {
+        write_zero_padded_copy(kernel_path, &aligned_path, aligned_size)?;
+    }
+    Ok(aligned_path)
+}
+
+/// True when `aligned_path` is a reusable cached copy: it exists, has the
+/// expected padded size, and is no older than the source (a rebuilt `vmlinux`
+/// regenerates it).
+fn aligned_copy_is_current(aligned_path: &Path, aligned_size: u64, source: &Path) -> bool {
+    let (Ok(a), Ok(s)) = (std::fs::metadata(aligned_path), std::fs::metadata(source)) else {
+        return false;
+    };
+    if a.len() != aligned_size {
+        return false;
+    }
+    matches!((a.modified(), s.modified()), (Ok(am), Ok(sm)) if am >= sm)
+}
+
+/// Copy `source` to `dest` and zero-extend it to `padded_size` (`set_len`
+/// zero-fills the tail). Written to a temp sibling then renamed so a concurrent
+/// reader never sees a half-written kernel.
+fn write_zero_padded_copy(
+    source: &Path,
+    dest: &Path,
+    padded_size: u64,
+) -> Result<(), BuilderVmError> {
+    let mut tmp = dest.as_os_str().to_owned();
+    tmp.push(".tmp");
+    let tmp = PathBuf::from(tmp);
+    std::fs::copy(source, &tmp).map_err(|e| {
+        BuilderVmError::ExtractionFailed(format!(
+            "copy kernel {} -> {}: {e}",
+            source.display(),
+            tmp.display()
+        ))
+    })?;
+    // `fs::copy` preserves the source's mode; the cached `vmlinux` comes from a
+    // read-only Nix store path, so make the working copy writable before we
+    // extend it (else `set_len` fails EACCES for a non-root builder).
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::PermissionsExt;
+        std::fs::set_permissions(&tmp, std::fs::Permissions::from_mode(0o644)).map_err(|e| {
+            BuilderVmError::ExtractionFailed(format!("chmod {}: {e}", tmp.display()))
+        })?;
+    }
+    let f = std::fs::OpenOptions::new()
+        .write(true)
+        .open(&tmp)
+        .map_err(|e| BuilderVmError::ExtractionFailed(format!("open {}: {e}", tmp.display())))?;
+    f.set_len(padded_size)
+        .map_err(|e| BuilderVmError::ExtractionFailed(format!("pad {}: {e}", tmp.display())))?;
+    drop(f);
+    std::fs::rename(&tmp, dest).map_err(|e| {
+        BuilderVmError::ExtractionFailed(format!(
+            "rename {} -> {}: {e}",
+            tmp.display(),
+            dest.display()
+        ))
+    })
+}
+
 fn krun_context_for_image(
     vm_name: &str,
     image: &BuilderVmImage,
@@ -1273,12 +1375,15 @@ fn krun_context_for_image(
             kernel_path,
             rootfs_path,
             cmdline,
-        } => Ok(KrunContext::new(
-            vm_name,
-            path_to_str(kernel_path, "kernel_path")?,
-            path_to_str(rootfs_path, "rootfs_path")?,
-        )
-        .with_cmdline(cmdline.as_str())),
+        } => {
+            let kernel = page_aligned_kernel(kernel_path)?;
+            Ok(KrunContext::new(
+                vm_name,
+                path_to_str(&kernel, "kernel_path")?,
+                path_to_str(rootfs_path, "rootfs_path")?,
+            )
+            .with_cmdline(cmdline.as_str()))
+        }
         BuilderVmImage::RootDir {
             root_dir,
             entry_path,
@@ -2433,6 +2538,88 @@ mod tests {
     use crate::builder_vm_runtime::{INSTALL_SPEC_FILENAME, shell_single_quote_escape};
     use mvm_core::util::test_env::TestEnv;
     use tempfile::TempDir;
+
+    #[test]
+    fn align_up_rounds_to_next_multiple() {
+        assert_eq!(align_up(0, 4096), 0);
+        assert_eq!(align_up(1, 4096), 4096);
+        assert_eq!(align_up(4096, 4096), 4096);
+        assert_eq!(align_up(4097, 4096), 8192);
+        // The real builder-kernel case: 8_963_072 (mod 4096 == 1024) → 8_966_144.
+        assert_eq!(align_up(8_963_072, 4096), 8_966_144);
+    }
+
+    #[test]
+    fn write_zero_padded_copy_pads_and_preserves_prefix() {
+        let dir = TempDir::new().unwrap();
+        let src = dir.path().join("vmlinux");
+        let body = vec![0xABu8; 5000]; // not a multiple of 4096
+        std::fs::write(&src, &body).unwrap();
+        let dest = dir.path().join("vmlinux.page-aligned");
+        write_zero_padded_copy(&src, &dest, 8192).unwrap();
+
+        let padded = std::fs::read(&dest).unwrap();
+        assert_eq!(padded.len(), 8192, "padded to the page boundary");
+        assert_eq!(&padded[..5000], &body[..], "original bytes preserved");
+        assert!(padded[5000..].iter().all(|&b| b == 0), "tail zero-filled");
+        // The temp sibling is renamed away, not left behind.
+        assert!(!dir.path().join("vmlinux.page-aligned.tmp").exists());
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn write_zero_padded_copy_handles_read_only_source() {
+        use std::os::unix::fs::PermissionsExt;
+        let dir = TempDir::new().unwrap();
+        let src = dir.path().join("vmlinux");
+        std::fs::write(&src, vec![0x5Au8; 5000]).unwrap();
+        // Mirror the cached kernel: a read-only Nix-store-style source.
+        std::fs::set_permissions(&src, std::fs::Permissions::from_mode(0o444)).unwrap();
+        let dest = dir.path().join("vmlinux.page-aligned");
+        // Must not fail EACCES extending the copied (read-only) file.
+        write_zero_padded_copy(&src, &dest, 8192).unwrap();
+        assert_eq!(std::fs::metadata(&dest).unwrap().len(), 8192);
+    }
+
+    #[test]
+    fn aligned_copy_is_current_only_when_sized_and_fresh() {
+        let dir = TempDir::new().unwrap();
+        let src = dir.path().join("vmlinux");
+        std::fs::write(&src, vec![1u8; 5000]).unwrap();
+        let aligned = dir.path().join("vmlinux.page-aligned");
+
+        // Absent → not current.
+        assert!(!aligned_copy_is_current(&aligned, 8192, &src));
+        // Wrong size → not current.
+        std::fs::write(&aligned, vec![0u8; 4096]).unwrap();
+        assert!(!aligned_copy_is_current(&aligned, 8192, &src));
+        // Correct size and at least as new as the source → current.
+        std::fs::write(&aligned, vec![0u8; 8192]).unwrap();
+        assert!(aligned_copy_is_current(&aligned, 8192, &src));
+    }
+
+    #[test]
+    fn page_aligned_kernel_passes_through_when_already_aligned() {
+        let dir = TempDir::new().unwrap();
+        let k = dir.path().join("vmlinux");
+        std::fs::write(&k, vec![0u8; 8192]).unwrap(); // multiple of 4096
+        // Already aligned → original path, no sibling created.
+        assert_eq!(page_aligned_kernel(&k).unwrap(), k);
+        assert!(!dir.path().join("vmlinux.page-aligned").exists());
+    }
+
+    // The padding path is Linux-only (KVM's alignment requirement; macOS HVF
+    // tolerates an unaligned kernel and `page_aligned_kernel` short-circuits).
+    #[cfg(target_os = "linux")]
+    #[test]
+    fn page_aligned_kernel_pads_unaligned_on_linux() {
+        let dir = TempDir::new().unwrap();
+        let k = dir.path().join("vmlinux");
+        std::fs::write(&k, vec![7u8; 5000]).unwrap(); // not a multiple of 4096
+        let aligned = page_aligned_kernel(&k).unwrap();
+        assert_eq!(aligned, dir.path().join("vmlinux.page-aligned"));
+        assert_eq!(std::fs::metadata(&aligned).unwrap().len(), 8192);
+    }
 
     fn ok_mounts(scratch: &TempDir) -> BuilderMounts {
         let flake = scratch.path().join("flake");

--- a/specs/adrs/093-linux-builder-libkrun-fallback.md
+++ b/specs/adrs/093-linux-builder-libkrun-fallback.md
@@ -128,11 +128,20 @@ ioctl(KVM_SET_USER_MEMORY_REGION, {slot=1, guest_phys_addr=0x80000000,
 `8963072 % 4096 = 1024` — **not page-aligned**. Linux KVM requires
 `KVM_SET_USER_MEMORY_REGION` sizes to be a multiple of the host page size; mvm
 passed the kernel to libkrun (`krun_set_kernel`), which maps it verbatim, so an
-unaligned `vmlinux` fails VM creation regardless of guest RAM (the earlier
-"2 GiB boots past it" reading was a coincidence of layout). macOS HVF imposes no
-such requirement — which is why the identical (also-unaligned) aarch64 builder
+unaligned `vmlinux` fails VM creation regardless of guest RAM. macOS HVF imposes
+no such requirement — which is why the identical (also-unaligned) aarch64 builder
 kernel boots under libkrun on macOS. So this **is** an mvm-addressable bug, not
 purely a libkrun/kernel defect.
+
+On the **"2 GiB boots past it" anomaly**: the rejected region is slot 1, the
+*kernel*, whose size is the `vmlinux` file size — independent of how much guest
+RAM is configured. So a smaller-RAM run must hit `EINVAL` at this *same* ioctl;
+guest-RAM size cannot explain the difference. The earlier "2 GiB boots" reading
+was never reproduced under `strace` and is **not** explained by this root cause —
+most plausibly that run used a different, already-aligned kernel build (or never
+reached slot 1 for an unrelated reason). We record it as an unexplained prior
+observation rather than attribute a mechanism we can't substantiate; the
+strace-confirmed alignment defect above is the real, reproduced cause.
 
 **Fix:** `mvm_build::libkrun_builder::page_aligned_kernel` zero-pads the builder
 kernel up to a page boundary (a cached `vmlinux.page-aligned` sibling) before

--- a/specs/adrs/093-linux-builder-libkrun-fallback.md
+++ b/specs/adrs/093-linux-builder-libkrun-fallback.md
@@ -111,3 +111,37 @@ fallback).
   doc aligned with the libkrun + qemu-fallback reality.
 - Optional: persist a per-host "libkrun-builder-unavailable" marker so affected
   hosts skip the failing libkrun attempt on subsequent builds.
+
+## Update (2026-06-22): root cause corrected — unaligned kernel, fixed in mvm
+
+The "`KVM_SET_USER_MEMORY_REGION` EINVAL for any region above ~4 GiB" diagnosis
+above was **incomplete**. `strace -f` of the failing supervisor on the same box
+showed the rejected ioctl is the **kernel** region, not a RAM region above the
+PCI hole:
+
+```
+ioctl(KVM_SET_USER_MEMORY_REGION, {slot=1, guest_phys_addr=0x80000000,
+      memory_size=8963072, ...}) = -1 EINVAL
+```
+
+`memory_size=8963072` is exactly the builder `vmlinux` file size, and
+`8963072 % 4096 = 1024` — **not page-aligned**. Linux KVM requires
+`KVM_SET_USER_MEMORY_REGION` sizes to be a multiple of the host page size; mvm
+passed the kernel to libkrun (`krun_set_kernel`), which maps it verbatim, so an
+unaligned `vmlinux` fails VM creation regardless of guest RAM (the earlier
+"2 GiB boots past it" reading was a coincidence of layout). macOS HVF imposes no
+such requirement — which is why the identical (also-unaligned) aarch64 builder
+kernel boots under libkrun on macOS. So this **is** an mvm-addressable bug, not
+purely a libkrun/kernel defect.
+
+**Fix:** `mvm_build::libkrun_builder::page_aligned_kernel` zero-pads the builder
+kernel up to a page boundary (a cached `vmlinux.page-aligned` sibling) before
+`krun_set_kernel`. Confirmed on the box: with the unaligned kernel on disk, the
+code auto-creates the aligned sibling, every `KVM_SET_USER_MEMORY_REGION`
+succeeds, and `KVM_RUN` runs the vCPUs (the EINVAL is gone).
+
+This does **not** retire the qemu fallback: it still covers other VM-creation
+failures, and at least one affected host shows a *separate* later issue (the
+guest userspace does not reach `cmd.sh` under libkrun — empty console, no nix
+output), tracked separately. The fallback stays; this fix removes the
+unaligned-kernel EINVAL as one of its triggers.


### PR DESCRIPTION
## What

libkrun maps the external builder kernel into guest memory with the `vmlinux` file's **exact size**. Linux KVM rejects a `KVM_SET_USER_MEMORY_REGION` whose size isn't a multiple of the host page size, so an unaligned `vmlinux` fails VM creation with `EINVAL` (`rc -22`).

`page_aligned_kernel` (in `mvm_build::libkrun_builder`) zero-pads the kernel up to a page boundary in a cached `vmlinux.page-aligned` sibling before `krun_set_kernel`. No-op when already aligned or off Linux. The padded copy is made writable before `set_len` so a non-root builder doesn't hit `EACCES` on the read-only Nix-store kernel.

## Root cause (corrects ADR-093)

`strace -f` of the failing supervisor on a bare-metal Linux KVM box:

```
ioctl(KVM_SET_USER_MEMORY_REGION, {slot=1, guest_phys_addr=0x80000000,
      memory_size=8963072, ...}) = -1 EINVAL
```

`8963072` is exactly the builder `vmlinux` file size, and `8963072 % 4096 = 1024` — not page-aligned. The failing region is the **kernel**, independent of guest RAM. ADR-093 framed this as a libkrun ">4 GiB" defect; it's an mvm-addressable alignment bug. macOS HVF has no such requirement, which is why the same unaligned kernel boots libkrun on macOS. ADR-093 carries a dated correction.

## Verification

- Unit tests: `align_up`, `write_zero_padded_copy` (pads + preserves prefix + zero tail), read-only-source regression (the `EACCES` case), `aligned_copy_is_current`, `page_aligned_kernel` pass-through + Linux-gated padding. All green; `cargo fmt`/`clippy -D warnings` clean for `mvm-build`.
- **Live on the box:** with the unaligned kernel on disk, the code auto-creates `vmlinux.page-aligned`, every `KVM_SET_USER_MEMORY_REGION` succeeds, and `KVM_RUN` runs the vCPUs — `rc -22` is gone.

## Scope

This removes the unaligned-kernel EINVAL as a trigger of the ADR-093 libkrun→qemu fallback; the fallback stays for other VM-creation failures. A *separate* later issue on at least one host (guest userspace not reaching `cmd.sh` under libkrun — empty console, no nix output) is tracked independently and is not addressed here.
