### PR TITLE
refactor(builder): persistent build route typed-only (drop legacy shell dispatch)

### DIFF
--- a/crates/mvm-build/src/builder_route.rs
+++ b/crates/mvm-build/src/builder_route.rs
@@ -16,12 +16,10 @@
 //! remaining shell surface stays visible and shrinkable (the
 //! `xtask check-builder-shell-job-sites` allowlist is the static counterpart).
 //!
-//! The phasing is "opt-in, then default", per operation. The **build** route has
-//! flipped to default-on: a reachable daemon is used unless the raw-shell debug
-//! gate [`BUILDERD_RAW_SHELL_ENV`] forces the legacy in-VM shell build. The
-//! **flake-check** route is still opt-in via [`BUILDERD_TYPED_OPT_IN_ENV`] until
-//! it gets the same live proof. Each flip is a one-line change to the route's
-//! opt-in helper rather than a scatter of call-site edits.
+//! The **build** route is typed-only: a reachable daemon builds guest images
+//! and there is no legacy in-VM shell build to fall back to (the caller drops to
+//! the single-shot builder instead). The **flake-check** route is still opt-in
+//! via [`BUILDERD_TYPED_OPT_IN_ENV`] until it gets the same live proof.
 
 use std::path::{Path, PathBuf};
 use std::time::Duration;
@@ -35,17 +33,9 @@ use crate::builderd_client::{
 use crate::builderd_protocol::{BuilderRequest, OperationId};
 
 /// Opt-in env flag letting a host build path prefer the typed `mvm-builderd`
-/// route when the daemon is reachable. Still gates the *flake-check* route
-/// (`try_typed_flake_check`); the *build* route now defaults on (see
-/// [`BUILDERD_RAW_SHELL_ENV`]).
+/// route when the daemon is reachable. Gates the *flake-check* route
+/// (`try_typed_flake_check`); the *build* route is typed-only and needs no flag.
 pub const BUILDERD_TYPED_OPT_IN_ENV: &str = "MVM_BUILDERD_TYPED";
-
-/// Opt-out env flag forcing a guest-image build down the legacy controlled
-/// shell-job channel even when the daemon is reachable — the raw-shell debug
-/// gate. The build route is typed by default once a daemon is reachable; set
-/// this (truthy: `1`/`true`/`yes`) to fall back to the in-VM shell build for
-/// debugging or to bypass a misbehaving daemon. Does not affect flake check.
-pub const BUILDERD_RAW_SHELL_ENV: &str = "MVM_BUILDERD_RAW_SHELL";
 
 /// Readiness-probe timeout when deciding whether to route typed: the daemon
 /// answers a handshake immediately or it isn't there.
@@ -83,21 +73,6 @@ pub fn resolve_route(daemon_reachable: bool, typed_opt_in: bool) -> BuilderRoute
 pub fn typed_opt_in(getter: impl Fn(&str) -> Option<String>) -> bool {
     matches!(
         getter(BUILDERD_TYPED_OPT_IN_ENV)
-            .as_deref()
-            .map(|v| v.trim().to_ascii_lowercase())
-            .as_deref(),
-        Some("1") | Some("true") | Some("yes")
-    )
-}
-
-/// Whether a guest-image build should take the typed route when the daemon is
-/// reachable. Builds default on: a reachable daemon is used unless the raw-shell
-/// debug gate ([`BUILDERD_RAW_SHELL_ENV`]) is set truthy to force the legacy
-/// in-VM shell build. Injected getter for unit-testability. Distinct from
-/// [`typed_opt_in`], which keeps flake check opt-in.
-pub fn build_typed_opt_in(getter: impl Fn(&str) -> Option<String>) -> bool {
-    !matches!(
-        getter(BUILDERD_RAW_SHELL_ENV)
             .as_deref()
             .map(|v| v.trim().to_ascii_lowercase())
             .as_deref(),
@@ -278,18 +253,16 @@ pub fn run_build(
     }
 }
 
-/// Route a guest-image build: take the typed daemon path whenever a ready
-/// builder daemon is reachable under `vms_root`, unless the raw-shell debug gate
-/// (`MVM_BUILDERD_RAW_SHELL`) forces legacy; otherwise fall back (emitting the
-/// compat diagnostic) to the caller's legacy in-VM build path. The build route
-/// is default-on — unlike flake check, which stays opt-in via `MVM_BUILDERD_TYPED`.
+/// Route a guest-image build to the typed daemon whenever a ready builder
+/// daemon is reachable under `vms_root`; otherwise `Fellback` so the caller
+/// drops to its single-shot builder. There is no legacy in-VM shell build for
+/// guest images any more — typed is the only persistent build path.
 pub fn try_typed_build(
     vms_root: &Path,
     flake_ref: &str,
     attr_path: &str,
     output_dir: Option<&str>,
 ) -> BuildDispatch {
-    let opt_in = build_typed_opt_in(|k| std::env::var(k).ok());
     let socket = resolve_running_builder_socket(vms_root);
     let reachable = socket.as_deref().is_some_and(|s| {
         matches!(
@@ -297,25 +270,17 @@ pub fn try_typed_build(
             BuilderdReadiness::Ready { .. }
         )
     });
-    match resolve_route(reachable, opt_in) {
-        BuilderRoute::Typed => {
-            let socket = socket.expect("reachable implies a resolved socket");
-            BuildDispatch::Took(run_build(
-                &socket,
-                flake_ref,
-                attr_path,
-                output_dir,
-                BUILD_OP_TIMEOUT,
-            ))
-        }
-        BuilderRoute::LegacyShell => {
-            tracing::debug!(
-                target: "mvm::builder",
-                "{}",
-                legacy_shell_diagnostic("build-guest-image")
-            );
-            BuildDispatch::Fellback
-        }
+    if reachable {
+        let socket = socket.expect("reachable implies a resolved socket");
+        BuildDispatch::Took(run_build(
+            &socket,
+            flake_ref,
+            attr_path,
+            output_dir,
+            BUILD_OP_TIMEOUT,
+        ))
+    } else {
+        BuildDispatch::Fellback
     }
 }
 
@@ -347,36 +312,6 @@ mod tests {
         assert!(!on(""));
         // Absent var → not opted in.
         assert!(!typed_opt_in(|_| None));
-    }
-
-    #[test]
-    fn build_route_defaults_on_and_raw_shell_gate_forces_legacy() {
-        // Absent gate → build is typed-eligible (default on).
-        assert!(build_typed_opt_in(|_| None));
-        let gate = |v: &str| {
-            let v = v.to_string();
-            build_typed_opt_in(move |_| Some(v.clone()))
-        };
-        // Truthy gate → forced legacy (not typed-eligible).
-        assert!(!gate("1"));
-        assert!(!gate("true"));
-        assert!(!gate("YES"));
-        assert!(!gate("  true  "));
-        // Non-truthy gate values leave the build default-on.
-        assert!(gate("0"));
-        assert!(gate("false"));
-        assert!(gate(""));
-    }
-
-    #[test]
-    fn raw_shell_gate_is_independent_of_flake_check_opt_in() {
-        // The build gate reads MVM_BUILDERD_RAW_SHELL, not MVM_BUILDERD_TYPED, so
-        // flipping the flake-check opt-in never changes the build default.
-        let only_typed_set = |k: &str| (k == BUILDERD_TYPED_OPT_IN_ENV).then(|| "1".to_string());
-        assert!(build_typed_opt_in(only_typed_set)); // build still default-on
-        assert!(!typed_opt_in(
-            |k: &str| (k == BUILDERD_RAW_SHELL_ENV).then(|| "1".to_string())
-        ));
     }
 
     #[test]

--- a/crates/mvm-build/src/pipeline/dev_build.rs
+++ b/crates/mvm-build/src/pipeline/dev_build.rs
@@ -610,32 +610,21 @@ fn dev_build_via_builder_vm_uncached(
             socket = %record.dispatch_socket_path.display(),
             "routing build through persistent supervisor"
         );
-        // Default-on typed route (a reachable mvm-builderd, unless the
-        // `MVM_BUILDERD_RAW_SHELL` debug gate forces legacy): build `/work#<attr>`
-        // through the resident daemon and read the daemon-exported artifacts off
-        // the `/job` share. Gated off / no daemon → `None` → legacy shell-job
-        // dispatch below; a daemon build failure or transport error → warn →
-        // legacy fallback (the typed path never turns a build the legacy path
-        // would pass into a failure).
+        // Typed-only persistent route: a reachable mvm-builderd builds
+        // `/work#<attr>` and the host reads the daemon-exported artifacts off
+        // the `/job` share. No reachable daemon → `None`; a daemon build
+        // failure or transport error → warn. Either falls through to the
+        // single-shot builder below — the safety net. The legacy in-VM
+        // shell-job dispatch was removed; typed is the only persistent path.
         match try_typed_persistent_build(env, &record, profile) {
             Some(Ok(result)) => return Ok(result),
             Some(Err(e)) => {
                 tracing::warn!(
                     error = %e,
-                    "typed builder dispatch failed; falling back to legacy shell-job dispatch"
+                    "typed builder dispatch failed; falling back to single-shot builder VM"
                 );
             }
             None => {}
-        }
-        let persistent = crate::persistent_builder::PersistentBuilderVm::new(record.clone());
-        match dev_build_with_builder_vm(env, flake_ref, profile, mode, &persistent) {
-            Ok(result) => return Ok(result),
-            Err(e) => {
-                tracing::warn!(
-                    error = %e,
-                    "persistent dispatch failed; falling back to single-shot builder VM"
-                );
-            }
         }
     }
 
@@ -819,18 +808,15 @@ fn dev_build_with_builder_vm<B: crate::builder_vm::BuilderVm + ?Sized>(
 }
 
 /// Attempt a guest-image build through the resident `mvm-builderd` typed
-/// control plane instead of the legacy shell-job dispatch.
+/// control plane — the only persistent build route.
 ///
-/// Returns `None` when the typed route is not taken (the `MVM_BUILDERD_RAW_SHELL`
-/// debug gate forced legacy, or no reachable daemon) so the caller falls back to
-/// the legacy persistent dispatch; `Some(Ok(_))` once the daemon built the image and
+/// Returns `None` when there is no reachable daemon, so the caller falls back to
+/// the single-shot builder; `Some(Ok(_))` once the daemon built the image and
 /// exported its artifacts to the `/job` share, which we read into the dev build
 /// dir; `Some(Err(_))` on a daemon-reported build failure or a transport/IO
-/// error (the caller logs and falls back).
+/// error (the caller logs and falls back to the single-shot builder).
 ///
-/// Builds `/work#<attr>` — the same target, and the same no-`--override-input`,
-/// that the legacy persistent dispatch uses (`run_flake_dispatch` ignores the
-/// source-checkout staging too) — so the two paths are behaviourally equivalent.
+/// Builds `/work#<attr>`.
 #[cfg(feature = "builder-vm")]
 fn try_typed_persistent_build(
     env: &dyn ShellEnvironment,

--- a/specs/plans/204-builder-vm-resident-control-plane.md
+++ b/specs/plans/204-builder-vm-resident-control-plane.md
@@ -348,12 +348,20 @@ arm lands with the daemon's image baking (boot-gated).
       set truthy to force the legacy in-VM shell build. `try_typed_flake_check`
       is untouched — flake check stays opt-in via `MVM_BUILDERD_TYPED`, so the
       flip is build-only. Three new unit tests cover the default-on + gate
-      semantics and the build/flake-check independence. The
-      `check-builder-shell-job-sites` allowlist stays at 4 entries (no drop): the
-      legacy `HostVmRequest::Run` construction in `persistent_builder.rs` is
-      retained as the daemon-unreachable + raw-shell-debug fallback, so that file
-      still *constructs* a shell job and legitimately stays allowlisted — the
-      drop only applies if the fallback is later removed entirely.
+      semantics and the build/flake-check independence.
+      **Follow-up landed — legacy build route removed:** `dev_build`'s persistent
+      path is now typed-only. The `MVM_BUILDERD_RAW_SHELL` debug gate and the
+      `dev_build` → `PersistentBuilderVm` shell-job fallback are deleted; a
+      reachable `mvm-builderd` builds guest images and an unreachable daemon /
+      daemon error falls through to the single-shot builder, not the legacy
+      in-VM shell build (which can no longer run a flake build anyway — it
+      dispatches `cmd.sh` under `setpriv --reuid=<builder-uid>`, and nix aborts
+      "cannot determine user's home directory" with no `/etc/passwd` entry; the
+      typed daemon and single-shot path run nix as uid 0). The
+      `check-builder-shell-job-sites` allowlist stays at 4 for now: the
+      now-orphaned `PersistentBuilderVm` / `submit()` machinery in
+      `persistent_builder.rs` still *constructs* `HostVmRequest::Run` and is
+      removed in a dead-code-teardown follow-up that drops the entry to 3.
       **Routing behaviour live-confirmed on macOS-26 Vz:** with the gate unset
       the build attempted the typed route by default (`dev_build`: "typed builder
       dispatch failed; falling back…"), and with `MVM_BUILDERD_RAW_SHELL=1` it


### PR DESCRIPTION
## What

The persistent builder's guest-image build is now **typed-only**: it goes exclusively through the resident `mvm-builderd` control plane. A reachable daemon builds the image; an unreachable daemon or a daemon error falls through to the **single-shot builder** — no longer to the in-VM legacy shell-job dispatch.

Removed:
- the `MVM_BUILDERD_RAW_SHELL` debug gate (`build_typed_opt_in` / `BUILDERD_RAW_SHELL_ENV`) and its tests — there is no legacy in-VM shell build to force any more;
- the `dev_build` → `PersistentBuilderVm` shell-job fallback.

## Why the legacy path is safe to drop

The legacy persistent shell dispatch couldn't build a flake at all: the guest runs its `cmd.sh` under `setpriv --reuid=<builder-uid>` with no `/etc/passwd` entry, so nix aborts `cannot determine user's home directory` even with `HOME` set (observed live). The typed daemon and the single-shot path run nix as **uid 0**, which is why they work. So typed-only routing is both correct and the only viable persistent path.

## Verification

`mvm-build`: `cargo fmt`/`clippy -D warnings` clean; the 10 `builder_route` tests pass. `mvm-cli` (consumer) compiles. Full workspace suite runs in CI.

## Scope / follow-up

This removes the legacy build path from the **build flow**. The now-orphaned `PersistentBuilderVm` / `submit()` machinery in `persistent_builder.rs` and the dev-only `persistent-builder submit` verb are left for a **dead-code-teardown follow-up** — which also drops the `check-builder-shell-job-sites` allowlist 4→3. That deletion touches the build-audit sink and the persistent install pipeline (claim 11), so it warrants its own fully-suite-verified PR.
