### PR TITLE
fix(cli): fast teardown for interactive-transient `machine run -t` (Ctrl+D no longer reads as a hang)

### DIFF
--- a/crates/mvm-cli/src/commands/machine/mod.rs
+++ b/crates/mvm-cli/src/commands/machine/mod.rs
@@ -1782,6 +1782,21 @@ fn stop_running_machine(name: &str) {
     }
 }
 
+/// Fast teardown for a throwaway interactive-transient machine. The guest shell
+/// has already exited, so there is nothing to flush: SIGKILL the
+/// supervisor/drainer/gvproxy up front (`stop_transient`) instead of burning the
+/// graceful ACPI grace `stop()` waits out — on Vz that grace runs ~6s across the
+/// supervisor, gvproxy, and drainer, which reads as a hang after Ctrl+D. Mirrors
+/// the `mvmctl run` transient teardown.
+fn stop_transient_machine(name: &str) {
+    reap_proxy(name);
+    let backend =
+        AnyBackend::from_hypervisor(&super::shared::resolve_effective_hypervisor("firecracker"));
+    if let Err(err) = backend.stop_transient(&VmId(name.to_string())) {
+        tracing::warn!(error = %err, machine = name, "fast-stopping transient machine failed");
+    }
+}
+
 /// The persistent lifecycle: `machine run --name <N>` / `-d`. Composes the
 /// existing create + start (+ exec) verbs — no new lifecycle code — so the
 /// signed-`ExecutionPlan` admission and default-deny egress are identical to
@@ -1907,7 +1922,10 @@ fn run_interactive(cli: &Cli, args: MachineRunArgs, cfg: &MvmConfig) -> Result<(
     );
 
     if teardown {
-        stop_running_machine(&name);
+        // Fast SIGKILL teardown — the shell already exited, so skip the graceful
+        // ACPI grace that otherwise sits silent for seconds after Ctrl+D.
+        println!("Stopping transient machine {name}.");
+        stop_transient_machine(&name);
         // Best-effort: drop the throwaway spec we created for this session.
         let _ = remove_machine_spec(&name, true);
     }

--- a/specs/plans/207-machine-run-unified-lifecycle.md
+++ b/specs/plans/207-machine-run-unified-lifecycle.md
@@ -199,6 +199,20 @@ agent + `enforce_accessible_gate` still bar a sealed prod guest, leaving the
 listeners inert there. Live-proven on macOS Vz: a managed alpine boot binds
 `vsock-20001.sock`…`vsock-20128.sock` and the guest agent answers.
 
+## Post-regression: slow transient teardown after the interactive shell exits
+
+Second issue found in the same session: after Ctrl+D (or `exit`), `machine run
+-t` (transient) sat silent for ~6s before returning, so the shell *looked* hung
+and users reached for Ctrl+C. The console relay itself tears down in ~0.05s; the
+delay was `run_interactive` calling the **graceful** `stop_running_machine`
+(`backend.stop`), which on Vz burns ~6s of ACPI grace across the supervisor,
+gvproxy, and drainer. The throwaway guest's work is already done, so the grace
+buys nothing. Fixed by routing the transient-interactive teardown through the
+existing fast `backend.stop_transient` (the same path `mvmctl run` uses —
+SIGKILL up front, no grace) via a new `stop_transient_machine` helper, plus a
+one-line "Stopping transient machine …" notice for immediate feedback.
+Measured on macOS Vz: teardown after Ctrl+D dropped 6.44s → 0.06s.
+
 ## Out of scope
 
 - Idle auto-stop / TTL reaping of persistent machines (warm-pool/reaper work is


### PR DESCRIPTION
## Problem

After the interactive shell exits (Ctrl+D or `exit`), a **transient** `machine run -t` sat silent for ~6s before returning to the host prompt. The shell *looked* hung, so users reached for Ctrl+C — i.e. "I have to press Ctrl+D **and** Ctrl+C."

The console relay itself tears down in ~0.05s. The delay was `run_interactive` calling the **graceful** `stop_running_machine` (`backend.stop`), which on Vz waits out ~6s of ACPI grace across the supervisor, gvproxy, and drainer. For a throwaway transient guest whose work is already done, that grace buys nothing.

## Fix

Route the transient-interactive teardown through the existing fast `backend.stop_transient` (the same SIGKILL-up-front path `mvmctl run` already uses) via a new `stop_transient_machine` helper, and print a one-line `Stopping transient machine …` notice for immediate feedback.

Teardown only fires for transient machines (`should_teardown_after_interactive` = `!persistent`), so the fast path is always correct here. Persistent `-d`/`--name` machines are left up, unchanged.

## Verification

- Reproduced + measured under a PTY harness on macOS Vz: teardown after Ctrl+D **6.44s → 0.06s**. Clean `exit` and Ctrl+D (`\x04`) both return immediately.
- `machine console` (non-transient) teardown was already ~0.05s and is unchanged.
- mvm-cli interactive/teardown tests pass (incl. `interactive_tears_down_only_the_transient_machine`); fmt + clippy clean.

Follow-up to #1261 (interactive console data ports). Plan 207 doc updated with the regression note.