### PR TITLE
Local kernel metrics + --boot-check for 'build kernel build'

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5838,6 +5838,7 @@ dependencies = [
  "clap",
  "clap_mangen",
  "mvm-cli",
+ "mvm-core",
  "regex",
  "serde",
  "serde_json",

--- a/crates/mvm-build/src/bin/stage0-init.rs
+++ b/crates/mvm-build/src/bin/stage0-init.rs
@@ -595,7 +595,57 @@ mod linux {
         if store_path.is_empty() {
             return Err("nix build emitted no /nix/store path".into());
         }
-        copy_artifacts(Path::new(&store_path), &mode)
+        copy_artifacts(Path::new(&store_path), &mode)?;
+
+        // Best-effort: also emit the resolved `.config` so the host can report
+        // the `=y` symbol count without a CI round-trip. The configfile is a
+        // cached build dep of the kernel just built, so this realises instantly.
+        // A failure here never fails the kernel build — the kernel is the
+        // artifact that matters.
+        if mode == "kernel"
+            && let Some(config_attr) = conf.get("MVM_STAGE0_CONFIG_ATTR")
+        {
+            if let Err(e) = emit_resolved_config(&nix, &arch, config_attr) {
+                eprintln!("stage0-init: skipping kernel-config emit: {e}");
+            }
+        }
+        Ok(())
+    }
+
+    /// Realise the resolved-`.config` flake attr and copy it to
+    /// `/out/mvm-kernel.config`. Cheap — it's a cached dependency of the
+    /// kernel just built.
+    fn emit_resolved_config(nix: &Path, arch: &str, config_attr: &str) -> Result<(), String> {
+        let flake_ref =
+            format!("path:/work/nix/images/builder-vm#packages.{arch}-linux.{config_attr}");
+        let mut cmd = Command::new(nix);
+        cmd.args([
+            "build",
+            &flake_ref,
+            "--extra-experimental-features",
+            "nix-command flakes",
+            "--option",
+            "build-users-group",
+            "",
+            "--max-jobs",
+            "1",
+            "--no-link",
+            "--no-write-lock-file",
+            "--impure",
+            "--print-out-paths",
+        ]);
+        let out = cmd.output().map_err(|e| format!("nix build config: {e}"))?;
+        if !out.status.success() {
+            return Err(format!(
+                "nix build config exit {}",
+                out.status.code().unwrap_or(-1)
+            ));
+        }
+        let store_path = String::from_utf8_lossy(&out.stdout).trim().to_string();
+        if store_path.is_empty() {
+            return Err("config build emitted no /nix/store path".into());
+        }
+        copy_deref(Path::new(&store_path), Path::new("/out/mvm-kernel.config"))
     }
 
     /// Spawn `cmd`, streaming its stderr line-by-line to `live` (flushed per

--- a/crates/mvm-cli/src/commands/build/kernel.rs
+++ b/crates/mvm-cli/src/commands/build/kernel.rs
@@ -17,6 +17,8 @@
 //! ~20s; `--verbose` streams the builder VM's `console.log` (the inner
 //! `nix build` output) to stderr live.
 
+#[cfg(feature = "builder-vm")]
+use anyhow::Context;
 use anyhow::Result;
 use clap::{Args as ClapArgs, Subcommand, ValueEnum};
 
@@ -55,6 +57,13 @@ struct BuildArgs {
     /// can target a non-host arch (Stage 0 cannot cross-compile).
     #[arg(long, value_parser = ["aarch64", "x86_64"])]
     arch: Option<String>,
+
+    /// After building, boot a throwaway microVM on the new kernel and confirm
+    /// the in-guest agent answers over vsock — a build that links isn't proof
+    /// it boots. Workload kernel only; needs a source checkout (uses
+    /// `examples/sleeper`) + a working local backend.
+    #[arg(long)]
+    boot_check: bool,
 }
 
 #[derive(ValueEnum, Debug, Clone, Copy, PartialEq, Eq)]
@@ -111,13 +120,127 @@ fn run_build(args: BuildArgs, verbose: bool) -> Result<()> {
         }
     };
 
-    for (variant, label) in variants {
-        let path = acquire_kernel(args.source, variant, label, &arch, verbose)?;
-        let mib = std::fs::metadata(&path).map(|m| m.len()).unwrap_or(0) as f64 / (1024.0 * 1024.0);
-        ui::success(&format!(
-            "{label} kernel ({arch}): {} ({mib:.1} MiB)",
-            path.display()
-        ));
+    for (variant, label) in &variants {
+        let path = acquire_kernel(args.source, *variant, label, &arch, verbose)?;
+        let bytes = std::fs::metadata(&path).map(|m| m.len()).unwrap_or(0);
+        let mib = bytes as f64 / (1024.0 * 1024.0);
+
+        // Local metrics: if Stage 0 emitted the resolved `.config` next to the
+        // kernel, count built-in (`=y`) symbols and persist a metrics sidecar —
+        // so a config edit's effect is visible here, not only from CI.
+        match emit_local_metrics(&path, label, &arch, bytes) {
+            Some(y) => ui::success(&format!(
+                "{label} kernel ({arch}): {} — {mib:.1} MiB, {y} built-in (=y) symbols",
+                path.display()
+            )),
+            None => ui::success(&format!(
+                "{label} kernel ({arch}): {} ({mib:.1} MiB)",
+                path.display()
+            )),
+        }
+    }
+
+    if args.boot_check {
+        run_boot_check(&variants)?;
+    }
+    Ok(())
+}
+
+/// JSON metrics emitted next to the cached kernel — the same shape the
+/// `kernel-build` CI lane uploads (sans gz, which needs a compressor), so a
+/// contributor sees `=y` count + size locally without a CI round-trip.
+#[cfg(feature = "builder-vm")]
+#[derive(serde::Serialize)]
+struct KernelMetrics<'a> {
+    arch: &'a str,
+    variant: &'a str,
+    y_symbol_count: usize,
+    vmlinux_bytes: u64,
+}
+
+/// Count built-in (`=y`) symbols in a resolved kernel `.config` — the metric
+/// the `check-kernel-config-budget` gate ratchets on. Matches CI's
+/// `grep -c '=y$'`.
+fn count_builtin_symbols(config: &str) -> usize {
+    config
+        .lines()
+        .filter(|l| l.trim_end().ends_with("=y"))
+        .count()
+}
+
+/// Read the `config` sidecar Stage 0 dropped next to `vmlinux`, count `=y`,
+/// write `kernel-metrics-<arch>.json` beside it, and return the count. Returns
+/// `None` when no config was emitted (e.g. `--source download`) — purely
+/// additive, never an error.
+#[cfg(feature = "builder-vm")]
+fn emit_local_metrics(
+    vmlinux: &std::path::Path,
+    label: &str,
+    arch: &str,
+    bytes: u64,
+) -> Option<usize> {
+    let config = vmlinux.with_file_name("config");
+    let content = std::fs::read_to_string(&config).ok()?;
+    let y_symbol_count = count_builtin_symbols(&content);
+    let metrics = KernelMetrics {
+        arch,
+        variant: label,
+        y_symbol_count,
+        vmlinux_bytes: bytes,
+    };
+    if let Ok(json) = serde_json::to_string(&metrics) {
+        let dest = vmlinux.with_file_name(format!("kernel-metrics-{arch}.json"));
+        let _ = std::fs::write(dest, json + "\n");
+    }
+    Some(y_symbol_count)
+}
+
+/// Boot a throwaway microVM on the freshly-built workload kernel and confirm
+/// the agent answers. Re-execs `mvmctl` (the real `up` / `machine` paths)
+/// rather than reconstructing their argument plumbing here.
+#[cfg(feature = "builder-vm")]
+fn run_boot_check(variants: &[(crate::commands::env::dev_vz::KernelVariant, &str)]) -> Result<()> {
+    use crate::commands::env::dev_vz::KernelVariant;
+    use crate::ui;
+
+    if !variants.iter().any(|(v, _)| *v == KernelVariant::Workload) {
+        ui::warn(
+            "--boot-check applies to the workload kernel; nothing to boot for --which builder",
+        );
+        return Ok(());
+    }
+    if !std::path::Path::new("examples/sleeper").is_dir() {
+        anyhow::bail!(
+            "--boot-check needs a source checkout (examples/sleeper not found in the cwd)"
+        );
+    }
+    let exe = std::env::current_exe().context("locating mvmctl for --boot-check")?;
+    let name = "kernel-bootcheck";
+    let _ = run_self(&exe, &["machine", "stop", name]); // clear any stale VM
+
+    ui::info("boot-check: booting a throwaway VM on the new workload kernel…");
+    run_self(
+        &exe,
+        &["up", "--flake", "examples/sleeper", "--name", name, "-d"],
+    )
+    .context("boot-check: `up` failed to launch the VM")?;
+
+    let booted = run_self(&exe, &["machine", "wait", name]);
+    let _ = run_self(&exe, &["machine", "stop", name]);
+    booted.context("boot-check: the guest agent never became ready")?;
+    ui::success("boot-check: the new kernel boots and the agent answered over vsock");
+    Ok(())
+}
+
+/// Run `mvmctl <args>` inheriting stdio; error on non-zero exit.
+#[cfg(feature = "builder-vm")]
+fn run_self(exe: &std::path::Path, args: &[&str]) -> Result<()> {
+    let status = std::process::Command::new(exe)
+        .args(args)
+        .status()
+        .with_context(|| format!("spawning mvmctl {}", args.join(" ")))?;
+    if !status.success() {
+        anyhow::bail!("mvmctl {} exited {}", args.join(" "), status);
     }
     Ok(())
 }
@@ -182,4 +305,34 @@ fn run_build(_args: BuildArgs, _verbose: bool) -> Result<()> {
         "`mvmctl kernel build` requires the `builder-vm` feature; \
          rebuild mvmctl with it enabled."
     )
+}
+
+#[cfg(test)]
+mod tests {
+    use super::count_builtin_symbols;
+
+    #[test]
+    fn counts_only_lines_ending_in_y() {
+        let cfg = "\
+CONFIG_A=y
+CONFIG_B=m
+# CONFIG_C is not set
+CONFIG_D=y
+CONFIG_E=\"some=y string\"
+CONFIG_F=42
+CONFIG_G=y
+";
+        // A, D, G — not the =m, the comment, the quoted-value, or the number.
+        assert_eq!(count_builtin_symbols(cfg), 3);
+    }
+
+    #[test]
+    fn empty_config_is_zero() {
+        assert_eq!(count_builtin_symbols(""), 0);
+    }
+
+    #[test]
+    fn tolerates_trailing_whitespace() {
+        assert_eq!(count_builtin_symbols("CONFIG_A=y \nCONFIG_B=y\t\n"), 2);
+    }
 }

--- a/crates/mvm-cli/src/commands/build/kernel.rs
+++ b/crates/mvm-cli/src/commands/build/kernel.rs
@@ -161,6 +161,7 @@ struct KernelMetrics<'a> {
 /// Count built-in (`=y`) symbols in a resolved kernel `.config` — the metric
 /// the `check-kernel-config-budget` gate ratchets on. Matches CI's
 /// `grep -c '=y$'`.
+#[cfg(feature = "builder-vm")]
 fn count_builtin_symbols(config: &str) -> usize {
     config
         .lines()
@@ -307,7 +308,7 @@ fn run_build(_args: BuildArgs, _verbose: bool) -> Result<()> {
     )
 }
 
-#[cfg(test)]
+#[cfg(all(test, feature = "builder-vm"))]
 mod tests {
     use super::count_builtin_symbols;
 

--- a/crates/mvm-cli/src/commands/env/dev_vz.rs
+++ b/crates/mvm-cli/src/commands/env/dev_vz.rs
@@ -2756,6 +2756,18 @@ impl KernelVariant {
         }
     }
 
+    /// Flake attr for the *resolved `.config`* of this kernel. The names are
+    /// historically irregular (the builder's predates the workload split), so
+    /// they're spelled out rather than derived from `attr()`. Stage 0 realises
+    /// this (a cached build dep of the kernel) and copies it out so the host
+    /// can report the `=y` symbol count without a CI round-trip.
+    fn config_attr(self) -> &'static str {
+        match self {
+            Self::Builder => "kernel-configfile",
+            Self::Workload => "workload-kernel-configfile",
+        }
+    }
+
     fn label(self) -> &'static str {
         match self {
             Self::Builder => "builder",
@@ -2970,9 +2982,12 @@ pub(crate) fn build_kernel_via_stage0(
 
     // Point stage0-init at the kernel attr + kernel-only output. Absent this
     // file (the `dev up` path), stage0-init builds the full image.
+    // `MVM_STAGE0_CONFIG_ATTR` asks Stage 0 to also emit the resolved `.config`
+    // (a cached build dep — near-free) so the host can report the `=y` count.
     let conf = format!(
-        "MVM_STAGE0_BUILD_ATTR={}\nMVM_STAGE0_OUTPUT_MODE=kernel\n",
-        variant.attr()
+        "MVM_STAGE0_BUILD_ATTR={}\nMVM_STAGE0_OUTPUT_MODE=kernel\nMVM_STAGE0_CONFIG_ATTR={}\n",
+        variant.attr(),
+        variant.config_attr(),
     );
     std::fs::write(staging_dir.join("stage0-build.conf"), conf)
         .with_context(|| format!("writing stage0-build.conf in {}", staging_dir.display()))?;
@@ -3055,6 +3070,17 @@ pub(crate) fn build_kernel_via_stage0(
     let dest = out_dir_path.join("vmlinux");
     std::fs::copy(&built, &dest)
         .with_context(|| format!("copying kernel to {}", dest.display()))?;
+
+    // Promote the resolved `.config` Stage 0 emitted (best-effort — the kernel
+    // is the artifact that matters; a missing config just means no local
+    // metrics). Lands next to the kernel so `mvmctl` can count `=y` symbols.
+    let staged_config = staging_dir.join("mvm-kernel.config");
+    if staged_config.is_file() {
+        let config_dest = out_dir_path.join("config");
+        if let Err(e) = std::fs::copy(&staged_config, &config_dest) {
+            ui::warn(&format!("could not cache the resolved kernel config: {e}"));
+        }
+    }
     let _ = std::fs::remove_dir_all(&staging_dir);
 
     Ok(dest)


### PR DESCRIPTION
Two ergonomics wins for working on the kernel config — born out of the Plan 209 shrink, where measuring a cut meant pushing and waiting on CI every time.

## Problem
`mvmctl build kernel build` hands the host only `vmlinux` (a size). The resolved `.config` — and thus the `=y` symbol count the budget gate ratchets on — was only obtainable from the `kernel-build` CI lane. So iterating on `base.nix`/`workload.nix` meant: edit → push → wait ~13 min for CI → read the number. And a kernel that *compiles* still has to *boot*, which was a separate manual 3-command dance.

## Changes
- **Local `=y` metrics.** Stage 0 now also emits the resolved `.config` (a cached build-dep of the kernel — near-free to realise) next to `vmlinux`. `build kernel build` counts built-in symbols, prints `<label> kernel (<arch>): … — 16.0 MiB, 1343 built-in (=y) symbols`, and writes `kernel-metrics-<arch>.json` (same shape CI uploads). Best-effort — a missing config never fails the build (e.g. `--source download`).
- **`--boot-check`.** `build kernel build --which workload --boot-check` boots a throwaway microVM on the new kernel and confirms the in-guest agent answers over vsock, then tears it down. Re-execs the real `up`/`machine wait`/`machine stop` paths.

## Implementation
- `KernelVariant::config_attr()` — the irregular configfile flake-attr names (builder `kernel-configfile`, workload `workload-kernel-configfile`) in one place.
- `build_kernel_via_stage0` threads `MVM_STAGE0_CONFIG_ATTR` to Stage 0 and copies the emitted config into the cache.
- `stage0-init::emit_resolved_config` realises + copies it (resilient).
- `count_builtin_symbols` is unit-tested (=m / comments / quoted-values / trailing-whitespace).

## Result
Edit config → `just run -- build kernel build --which workload --boot-check` → `boots ✓ · 16.0 MiB · 1343 =y`, all local. No CI round-trip to measure.

Tooling only — independent of the shrink config-cut PR (#1271).