### PR TITLE
chore(just): add `check-linux` — zig Linux cross-compile-check on macOS

### DIFF
--- a/Justfile
+++ b/Justfile
@@ -28,6 +28,17 @@ build:
 check:
     cargo check --workspace --all-targets
 
+# Cross-compile every crate's lib for Linux (glibc) via zig — no Docker — so
+# cfg(target_os="linux") code a macOS host never compiles is caught locally.
+# --all-features reaches feature-gated modules (e.g. libkrun_builder). Lib-only:
+# linking the libkrun-sys bins needs target libkrun, which CI provides. Needs
+# `cargo install cargo-zigbuild`, a `zig` on PATH, and
+# `rustup target add x86_64-unknown-linux-gnu`. musl is intentionally not the
+# default — libc's ioctl request arg is c_int there vs c_ulong on glibc, so the
+# COW FICLONE path (mvm-backend) only type-checks against glibc.
+check-linux TARGET="x86_64-unknown-linux-gnu":
+    cargo zigbuild --target {{TARGET}} --workspace --lib --all-features
+
 # Run mvmctl with arguments
 run *ARGS:
     cargo run -- {{ARGS}}


### PR DESCRIPTION
Adds a one-liner so macOS contributors can catch `cfg(target_os="linux")` compile errors (and feature-gated modules like `libkrun_builder`) locally, without Docker.

```
just check-linux            # x86_64-unknown-linux-gnu
just check-linux <triple>   # any target
```

Wraps `cargo zigbuild --target x86_64-unknown-linux-gnu --workspace --lib --all-features`. Plain `cargo check --target` fails on this box for lack of a cross C toolchain (ring/tree-sitter); `zig cc` supplies it — the project already depends on zig + cargo-zigbuild for the embedded musl host-vm bins.

**Why glibc, not musl:** libc's `ioctl` request arg is `c_int` on musl vs `c_ulong` on glibc, so mvm-backend's COW `FICLONE` path only type-checks against glibc — which is also the Linux runtime + CI target. Lib-only because linking the libkrun-sys bins needs target libkrun (CI provides it).

Motivated while verifying #1265's host-page-size fix on a Mac.