### PR TITLE
fix(stage0): bump seed Nix 2.31.1 → 2.34.7 (lock-matching narHash; fixes ADR-096 regression)

### DIFF
--- a/crates/mvm-build/src/stage0.rs
+++ b/crates/mvm-build/src/stage0.rs
@@ -65,9 +65,9 @@ pub struct BootstrapAsset {
 /// Nix release we seed from. Bump in lockstep with the SHA-256 pins below.
 ///
 /// 2.31.1 was the outlier that computed a divergent flake-input narHash vs the
-/// committed flake.locks (ADR-096), breaking every fresh builder-VM build since
-/// the Plan 160 nix-seed cutover. 2.34.7 computes the lock-matching narHash
-/// (verified against the same nixpkgs rev the locks pin).
+/// committed flake.locks, breaking every fresh builder-VM build since the
+/// nix-seed Stage 0 cutover. 2.34.7 computes the lock-matching narHash (verified
+/// against the same nixpkgs rev the locks pin).
 pub const NIX_SEED_VERSION: &str = "2.34.7";
 
 /// Official Nix release tarball for aarch64-linux guests (~23 MiB). When

--- a/crates/mvm-build/src/stage0.rs
+++ b/crates/mvm-build/src/stage0.rs
@@ -63,23 +63,28 @@ pub struct BootstrapAsset {
 // ============================================================================
 
 /// Nix release we seed from. Bump in lockstep with the SHA-256 pins below.
-pub const NIX_SEED_VERSION: &str = "2.31.1";
+///
+/// 2.31.1 was the outlier that computed a divergent flake-input narHash vs the
+/// committed flake.locks (ADR-096), breaking every fresh builder-VM build since
+/// the Plan 160 nix-seed cutover. 2.34.7 computes the lock-matching narHash
+/// (verified against the same nixpkgs rev the locks pin).
+pub const NIX_SEED_VERSION: &str = "2.34.7";
 
 /// Official Nix release tarball for aarch64-linux guests (~23 MiB). When
 /// extracted, its `store/` IS a populated `/nix/store` carrying the `nix`
 /// binary + its runtime closure. `signature_url: None` — SHA-256 only.
 pub const NIX_SEED_AARCH64: BootstrapAsset = BootstrapAsset {
     cache_filename: "nix-seed-aarch64.tar.xz",
-    url: "https://releases.nixos.org/nix/nix-2.31.1/nix-2.31.1-aarch64-linux.tar.xz",
-    sha256_hex: "4ae8cb26dada33765f3068d185b36dcfe23efba2ba678048b70d36d8b1553850",
+    url: "https://releases.nixos.org/nix/nix-2.34.7/nix-2.34.7-aarch64-linux.tar.xz",
+    sha256_hex: "f1cee64ae7a02330c6421924c28f597c41813f2214ff108622087d8056378b08",
     mode: 0o644,
 };
 
 /// Official Nix release tarball for x86_64-linux guests (Linux KVM path).
 pub const NIX_SEED_X86_64: BootstrapAsset = BootstrapAsset {
     cache_filename: "nix-seed-x86_64.tar.xz",
-    url: "https://releases.nixos.org/nix/nix-2.31.1/nix-2.31.1-x86_64-linux.tar.xz",
-    sha256_hex: "75f18f5d567bb8c7b5d62155f8c852e62ffac0c81acda02f52b998281e3603ce",
+    url: "https://releases.nixos.org/nix/nix-2.34.7/nix-2.34.7-x86_64-linux.tar.xz",
+    sha256_hex: "eafe5042404e818505e28c5ca3d0885f3ec45c31f955489a25bb38258f87560e",
     mode: 0o644,
 };
 


### PR DESCRIPTION
Implements the fix for **ADR-096** (merged): the Stage 0 seed Nix 2.31.1 computed a divergent nixpkgs flake-input narHash vs the committed flake.locks, breaking every fresh builder-VM build since the nix-seed Stage 0 cutover. Bumps the seed to **2.34.7**, which computes the lock-matching narHash.

## Change
- `crates/mvm-build/src/stage0.rs`: `NIX_SEED_VERSION` 2.31.1 → **2.34.7**, both per-arch URLs, and SHA-256 pins:
  - aarch64: `f1cee64ae7a02330c6421924c28f597c41813f2214ff108622087d8056378b08`
  - x86_64: `eafe5042404e818505e28c5ca3d0885f3ec45c31f955489a25bb38258f87560e`
  - (tarballs fetched from `releases.nixos.org/nix/nix-2.34.7/` and hashed.)

## Why 2.34.7
Same nixpkgs rev (`8fd9daa3`), the locks pin `sha256-Ti+ZBvW6…`. Nix 2.31.1 computes `sha256-hOlf/RVFs9…` (the bug); Nix 2.34.7 computes `sha256-Ti+ZBvW6…` (matches the lock). Same rev ⇒ identical built artifacts, so dm-verity roothashes (claim 3) and image-hash manifests (claim 6) are unaffected.

## Verification (end-to-end, on the failing path)
On the original failing machine (macOS 26 Apple Silicon, **no host Nix** → the Stage 0 seed path), with the builder-VM + OCI caches cleared:
- `mvmctl dev up --no-shell` downloaded the **nix-2.34.7** seed and ran a cold Stage 0 build.
- The builder-VM image built from scratch (~5–6 min) → produced `builder-vm/aarch64/{rootfs.ext4, vmlinux, cmdline.txt}`.
- **Zero `narHash` errors** anywhere in the Stage 0 / in-guest nix logs.

This also resolves ADR-096 open-Q3: the in-builder runtime Nix did **not** diverge — bumping the seed alone is sufficient.

Gates green locally: `check-no-spec-refs-in-comments`, `check-spec-numbers`, `cargo fmt`, `cargo test -p mvm-build --lib stage0` (incl. the version-consistency test now asserting 2.34.7).

## Follow-up (ADR-096 open-Q4, not in this PR)
Add a CI gate asserting the seed Nix and committed flake.locks agree on narHash, so a future seed bump can't silently re-break fresh installs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)