### PR TITLE
Plan 209 follow-up: ratchet kernel symbol budget to 1327 + enforce it

### DIFF
--- a/.github/workflows/kernel-build.yml
+++ b/.github/workflows/kernel-build.yml
@@ -85,6 +85,19 @@ jobs:
           # the shrink audit + the check-kernel-config-budget gate.
           cp "$CFG" "staging/workload-config-${ARCH}"
           Y_COUNT=$(grep -c '=y$' "$CFG")
+          # Symbol-budget ratchet: fail if the workload kernel grew a new
+          # built-in past the committed ceiling. The budget lives in the xtask
+          # (single source of truth) — read it out rather than duplicate it, so
+          # this can't drift from `cargo run -p xtask -- check-kernel-config-budget`.
+          BUDGET=$(grep -oP 'KERNEL_Y_BUDGET: usize = \K[0-9]+' \
+            xtask/src/check_kernel_config_budget.rs)
+          echo "workload kernel ${ARCH}: ${Y_COUNT} =y symbols (budget ${BUDGET})"
+          if [ "$Y_COUNT" -gt "$BUDGET" ]; then
+            echo "::error::workload kernel ${ARCH} has ${Y_COUNT} built-in (=y) symbols, \
+              over the ${BUDGET} budget — a new subsystem was compiled in. Drop it, or bump \
+              KERNEL_Y_BUDGET in xtask/src/check_kernel_config_budget.rs with justification."
+            exit 1
+          fi
           RAW_BYTES=$(stat -c%s "staging/vmlinux-${ARCH}-workload")
           GZ_BYTES=$(gzip -c "staging/vmlinux-${ARCH}-workload" | wc -c)
           printf '{"arch":"%s","y_symbol_count":%d,"vmlinux_bytes":%d,"vmlinux_gz_bytes":%d}\n' \

--- a/specs/plans/209-slim-microvm-kernel.md
+++ b/specs/plans/209-slim-microvm-kernel.md
@@ -613,3 +613,40 @@ boots + agent ready; `vm rekernel rk --flake examples/sleeper --kernel-pin 6.12.
 (`resolve_pinned_kernel` → cached workload `vmlinux`); `REKERNEL_EXIT=0`, VM restarts under
 libkrun, guest agent answers over vsock (`vm wait` → 0, control-plane ready, first accept
 914 ms). `up --kernel-pin`'s `None` path is byte-unchanged, so existing boots are unaffected.
+
+## Shrink campaign (2026-06-22) — drive to the floor
+
+Inventory-driven audit-subtraction, **every batch boot-validated live under libkrun**
+(`machine boot-report` -> control plane ready = agent answers over vsock) on both the
+workload *and* builder kernels, and cross-checked against a proven-minimal libkrun guest
+config as an upper bound.
+
+| | workload `=y` | vmlinux | gz |
+|---|---|---|---|
+| Baseline | 1716 | 21.2 MB | 9.4 MB |
+| Final (Batches 1-5) | **1327** (-389, -22.7%) | **16.0 MiB** (-20%) | 7.1 MB |
+
+Batches (each a separate boot-validated commit): **1** firmware/firewire/input/serio/hwmon/
+watchdog; **2** EFI/MFD/I2C/GPIO/pinctrl/ChromeOS-EC; **3** the whole PCI subsystem (virtio
+rides MMIO); **4** NFS/PHY-MDIO/VFIO/IPMI/cpufreq-cpuidle/SPI/NVMEM/PWM; **5** CORESIGHT/
+KVM/remoteproc-RPMSG/IOMMU/vendor-UARTs. Budget ratcheted 4096 -> **1327** and enforced in the
+`kernel-build` lane (reads the xtask constant). x86_64 lands at ~1130.
+
+**Guard earned its keep:** a netfilter cut placed in the shared `base.nix` cascaded into the
+builder kernel (which needs iptables for its egress lockdown). The enable-stick guard caught
+it in CI; fixed by moving the drop to `workload.nix` (workload-only). This is exactly the
+"requested enables must stick" guard requested during the machine-run-volume coordination.
+
+### Deferred follow-ups (shrink)
+
+- [ ] **Push toward the ~1005 reference floor.** The remaining ~320 `=y` gap is *entangled*,
+  not cruft: ARM/ARCH platform built-ins (largely arch-essential), NET woven through
+  virtio-net/IP core, the CRYPTO set the minimal reference itself keeps, and GPIO/MOUSE/MDIO
+  residuals *select-pulled* by the VT console (a disable is a no-op without cutting the
+  console). Each costs real boot-risk for marginal size — do it surgically, one
+  boot-validated batch at a time, only if the size genuinely matters.
+- [ ] **Per-arch budgets.** A single 1327 ceiling (the aarch64 max) is loose for x86_64
+  (~1130). Split if x86_64 regressions need tight guarding.
+- [x] **Local metrics tooling** — `build kernel build` now emits the resolved `.config` +
+  `kernel-metrics-<arch>.json` and `--boot-check` self-validates the boot (PR #1275), so the
+  build->measure loop no longer needs a CI round-trip.

--- a/specs/plans/209-slim-microvm-kernel.md
+++ b/specs/plans/209-slim-microvm-kernel.md
@@ -578,7 +578,6 @@ git commit -am "docs(plan-209): unified slim-kernel docs + status rollup"
 - [ ] **Detection watcher** — sibling plan: flag when `linux_6_12.y` trails the latest LTS point release or is hit by a published Linux CVE (sibling to ADR-002 claim 7's `cargo audit`). Not in this plan.
 - [ ] **mvmd fleet rollout** — drain-and-roll across running microVMs lives in the mvmd repo. mvm exposes the single-VM primitive (Task 11); mvmd consumes it. Not in this repo.
 - [ ] **Option 2 fallback wiring** — only if Gate 0 (Task 3) says DOES-NOT-BOOT: slim `nix/packages/libkrunfw.nix`'s bundled config for macOS. Tracked here, built only on that branch.
-</content>
 
 ## Gate 0 findings (2026-06-21)
 

--- a/xtask/src/check_kernel_config_budget.rs
+++ b/xtask/src/check_kernel_config_budget.rs
@@ -16,11 +16,13 @@ use std::path::Path;
 
 /// Max built-in (`=y`) symbols allowed in the workload kernel config.
 ///
-/// Provisional ceiling: the workload `.config` cannot be realised on a
-/// non-Linux host, so this starts loose and PRINTS the measured count. Ratchet
-/// it down to the value the first kernel-build CI run reports, then tighten on
-/// every shrink. Raising it must be justified in the PR that does.
-const KERNEL_Y_BUDGET: usize = 4096;
+/// Set to the aarch64 measurement — the higher of the two arches (x86_64 is
+/// ~1130; aarch64 carries more arch/platform built-ins). Tighten on every
+/// shrink; raising it must be justified in the PR that does. Tracks the
+/// audit-subtraction pass that took the baseline 1716 → 1327 (PCI / EFI / MFD /
+/// I2C / GPIO / NFS / VFIO / IPMI / cpufreq / SPI / CORESIGHT / KVM / IOMMU and
+/// other off-the-boot-path subsystems), each cut boot-validated under libkrun.
+const KERNEL_Y_BUDGET: usize = 1327;
 
 pub fn run(args: &[String]) -> Result<()> {
     let Some(path) = args.first() else {


### PR DESCRIPTION
**Follow-up to #1271 (merged).** The shrink batches landed, but three commits — the budget ratchet, its CI enforcement, and the plan-doc campaign record — were pushed seconds after #1271 auto-merged (squash), so they missed the cutoff. Main still carries the provisional `KERNEL_Y_BUDGET = 4096`, i.e. the 1716→1327 shrink is **unguarded**. This re-lands exactly those orphaned commits on current main.

## Changes
- **Ratchet `KERNEL_Y_BUDGET` 4096 → 1327** — the aarch64 measurement of the shrunk workload kernel that's now on main (x86_64 is ~1130; aarch64 is the higher/binding arch).
- **Enforce it in the `kernel-build` lane** — fails the build if the workload config grows a new built-in past the budget, reading the ceiling straight from the xtask constant (single source of truth, no Rust compile in that job).
- **Record the shrink campaign** in `specs/plans/209` (1716→1327, per-batch, the entangled remainder deferred) + drop a stray `</content>` artifact.

## Verification
- `check-kernel-config-budget` reports `1327 built-in symbols (at budget)` (exit 0) against the real merged config; `1328`-style growth fails.
- xtask budget unit tests green.

No code/runtime change — a CI gate + a constant + docs.