### PR TITLE
chore(just): add watch-prs recipe for tailing open PR merge state

### DIFF
--- a/Justfile
+++ b/Justfile
@@ -366,6 +366,9 @@ fuzz-authenticated-frame SECONDS="300":
 outdated:
     cargo outdated -R
 
+# Watch open PRs for a GitHub repo
+watch-prs repo="tinylabscom/mvm" interval="10":
+    watch -n {{interval}} "gh pr list --repo {{repo}} --state open --json number,title,mergeStateStatus,reviewDecision,isDraft --jq '.[] | \"#\(.number)  \(.mergeStateStatus // \"UNKNOWN\")  review=\(.reviewDecision // \"NONE\")  draft=\(.isDraft)  \(.title)\"'"
 
 # List all available recipes
 @_default:


### PR DESCRIPTION
Adds a `just watch-prs` recipe that tails open-PR merge state for a repo, refreshing on an interval.

```
just watch-prs                          # tinylabscom/mvm, every 10s
just watch-prs tinylabscom/mvm 5        # custom repo + interval
```

Shows `#<num>  <mergeStateStatus>  review=<decision>  draft=<bool>  <title>` per open PR via `gh pr list --json ... --jq`.

Mechanical addition — no code paths touched.