### PR TITLE
docs: rename removed top-level verbs (`down`/`logs`/`console`/`vm`/`fs`) to the `machine` surface

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,9 +91,8 @@ mvmctl up --dev --flake .
 mvmctl ls
 
 # Stop one VM, or all
-mvmctl down app1
-mvmctl down
-
+mvmctl machine stop app1
+mvmctl machine stop --all
 # Force a specific backend
 mvmctl up --flake . --hypervisor cloud-hypervisor
 
@@ -102,7 +101,7 @@ mvmctl invoke <vm> --stdin '{"name": "world"}'
 ```
 
 `mvmctl up <flake>` produces a **sealed** image by default —
-`mvmctl console <vm>` will refuse on it unless you pass `--force`.
+`mvmctl machine console <vm>` will refuse on it unless you pass `--force`.
 Pass `--dev` to `up` for the accessible posture. This is the
 runtime enforcement of security claim 4 (CLAUDE.md "Security model").
 
@@ -210,12 +209,12 @@ See `nix/lib/default.nix` for the full `mkGuest` API and
 | `mvmctl up -d` | Detached background mode |
 | `mvmctl up -p HOST:GUEST` | Port mapping (repeatable) |
 | `mvmctl up --hypervisor <backend>` | Force backend selection |
-| `mvmctl down [name]` | Stop a VM by name, or all if omitted |
+| `mvmctl machine stop [name]` | Stop a VM by name, or all if omitted |
 | `mvmctl ls` / `mvmctl ls -a` | List running / all VMs |
-| `mvmctl logs <name>` | Console logs (`-f` to follow) |
+| `mvmctl machine logs <name>` | Console logs (`-f` to follow) |
 | `mvmctl invoke <vm>` | Function-entrypoint call (production-safe) |
 | `mvmctl exec <vm>` | One-shot exec (dev-only — sealed images refuse) |
-| `mvmctl console <vm>` | Attach console (refuses on sealed VMs; `--force` overrides) |
+| `mvmctl machine console <vm>` | Attach console (refuses on sealed VMs; `--force` overrides) |
 | `mvmctl forward <name> -p PORT` | Forward a guest port to localhost |
 
 ### Building

--- a/public/src/components/landing/CodeExample.tsx
+++ b/public/src/components/landing/CodeExample.tsx
@@ -10,8 +10,8 @@ mvmctl build --flake .
 # Boot a headless Firecracker VM
 mvmctl up --flake . --cpus 2 --memory 1024
 
-# Check health via vsock
-mvmctl vm ping`;
+# Confirm it's running
+mvmctl ls`;
 
 const nixFlake = `{
   inputs = {

--- a/public/src/content/docs/architecture/control-surfaces.mdx
+++ b/public/src/content/docs/architecture/control-surfaces.mdx
@@ -36,8 +36,8 @@ Use `mvmctl` for the full local lifecycle:
 mvmctl build ./agent
 mvmctl up ./agent --name agent-dev
 mvmctl exec agent-dev -- python /work/task.py
-mvmctl logs agent-dev
-mvmctl down agent-dev
+mvmctl machine logs agent-dev
+mvmctl machine stop agent-dev
 ```
 
 Prefer JSON where available:
@@ -151,8 +151,8 @@ policy profiles.
 Use console access for human debugging:
 
 ```sh
-mvmctl console agent-dev
-mvmctl console agent-dev --command "uname -a"
+mvmctl machine console agent-dev
+mvmctl machine console agent-dev --command "uname -a"
 ```
 
 Console access is broad authority inside the guest. Development images can

--- a/public/src/content/docs/console/attach.md
+++ b/public/src/content/docs/console/attach.md
@@ -7,7 +7,7 @@ Start a development microVM, then attach:
 
 ```sh
 mvmctl up ./my-app --name devbox
-mvmctl console devbox
+mvmctl machine console devbox
 ```
 
 The console uses the project's guest-control path rather than requiring SSH
@@ -17,7 +17,7 @@ second always-on remote access service.
 ## One-shot command
 
 ```sh
-mvmctl console devbox --command "id && uname -a"
+mvmctl machine console devbox --command "id && uname -a"
 ```
 
 Use this for terminal-shaped checks. For normal automation, prefer:
@@ -36,7 +36,7 @@ Console behavior depends on the active backend and image mode:
 - Terminal resize, signal forwarding, and scrollback are backend-specific.
 - Console sessions end when the VM stops.
 
-When a backend cannot provide a console, use `mvmctl logs`, `mvmctl exec`, and
+When a backend cannot provide a console, use `mvmctl machine logs`, `mvmctl exec`, and
 guest readiness probes to debug the workload.
 
 ## Security checklist

--- a/public/src/content/docs/console/index.md
+++ b/public/src/content/docs/console/index.md
@@ -25,8 +25,8 @@ for production workloads.
 
 ```sh
 mvmctl up ./my-app --name devbox
-mvmctl console devbox
-mvmctl console devbox --command "uname -a"
+mvmctl machine console devbox
+mvmctl machine console devbox --command "uname -a"
 ```
 
 Use `--command` for a one-shot shell command when you want console transport
@@ -36,11 +36,11 @@ but not an interactive session. Use `mvmctl exec` for normal automation.
 
 | Need | Prefer |
 | --- | --- |
-| Human debugging | `mvmctl console <name>` |
+| Human debugging | `mvmctl machine console <name>` |
 | Scripted command execution | `mvmctl exec <name> -- <cmd>` |
 | Process lifecycle control | `mvmctl proc start/list/wait/kill` |
-| File transfer | `mvmctl fs` or `mvmctl cp` |
-| Service logs | `mvmctl logs <name>` |
+| File transfer | `mvmctl machine fs` or `mvmctl cp` |
+| Service logs | `mvmctl machine logs <name>` |
 
 ## Related pages
 

--- a/public/src/content/docs/console/transparent-rebuild.md
+++ b/public/src/content/docs/console/transparent-rebuild.md
@@ -17,9 +17,9 @@ workspace state remains available.
 ```sh
 $EDITOR flake.nix
 mvmctl build ./my-app
-mvmctl down devbox
+mvmctl machine stop devbox
 mvmctl up ./my-app --name devbox
-mvmctl console devbox
+mvmctl machine console devbox
 ```
 
 This keeps rebuild semantics obvious. The rootfs comes from the Nix flake; the

--- a/public/src/content/docs/contributing/development.md
+++ b/public/src/content/docs/contributing/development.md
@@ -266,7 +266,7 @@ just run -- doctor                  # dependency checks
 
 ### Console Access
 
-microVMs have no SSH. Interactive access is via `mvmctl console` which uses PTY-over-vsock:
+microVMs have no SSH. Interactive access is via `mvmctl machine console` which uses PTY-over-vsock:
 - Authenticated via the existing Ed25519 vsock protocol
 - Dev-mode only (`access.console` must be `true` in the guest security policy)
 - Single session per VM, 15-minute idle timeout

--- a/public/src/content/docs/examples/ci-cd-ephemeral-builder.md
+++ b/public/src/content/docs/examples/ci-cd-ephemeral-builder.md
@@ -36,7 +36,7 @@ Avoid caching:
 ## Cleanup
 
 ```sh
-mvmctl down
+mvmctl machine stop --all
 mvmctl manifest prune --orphans --dry-run
 mvmctl cache prune --orphan-builds
 ```

--- a/public/src/content/docs/examples/dev-vm-from-flake.md
+++ b/public/src/content/docs/examples/dev-vm-from-flake.md
@@ -23,10 +23,10 @@ runtime sizing.
 ```sh
 mvmctl build ./my-dev-vm
 mvmctl up ./my-dev-vm --name my-dev-vm
-mvmctl console my-dev-vm
+mvmctl machine console my-dev-vm
 ```
 
-Use `mvmctl exec` for scripted commands and `mvmctl console` for interactive
+Use `mvmctl exec` for scripted commands and `mvmctl machine console` for interactive
 debugging.
 
 ## Iterate
@@ -35,7 +35,7 @@ debugging.
 $EDITOR flake.nix
 nix flake update
 mvmctl build ./my-dev-vm
-mvmctl down my-dev-vm
+mvmctl machine stop my-dev-vm
 mvmctl up ./my-dev-vm --name my-dev-vm
 ```
 

--- a/public/src/content/docs/getting-started/first-microvm.md
+++ b/public/src/content/docs/getting-started/first-microvm.md
@@ -107,7 +107,7 @@ mvmctl up --flake . --cpus 2 --memory 1024
 mvmctl ls
 
 # View guest console logs
-mvmctl logs hello
+mvmctl machine logs hello
 ```
 
 ## Run with Config and Secrets
@@ -129,7 +129,7 @@ Inside the guest, config files appear at `/mnt/config/` and secrets at `/mnt/sec
 ## Stop
 
 ```bash
-mvmctl down hello
+mvmctl machine stop hello
 ```
 
 ## Next Steps

--- a/public/src/content/docs/getting-started/happy-paths.md
+++ b/public/src/content/docs/getting-started/happy-paths.md
@@ -62,7 +62,7 @@ booted from it.
 ```bash
 mvmctl doctor --workflow cli-run                # preflight
 mvmctl up --flake . --cpus 2 --memory 1024      # build + boot
-mvmctl down                                     # tear down
+mvmctl machine stop --all                                     # tear down
 ```
 
 The first run downloads the builder VM image (or builds it from a
@@ -134,7 +134,7 @@ to launch.
 ```bash
 mvmctl doctor --workflow bundle-run             # preflight (no host rust needed)
 mvmctl up --bundle ./my-app.mvmpkg              # boot
-mvmctl down                                     # tear down
+mvmctl machine stop --all                                     # tear down
 ```
 
 `bundle-run` doctor scope explicitly drops `prerequisites` and

--- a/public/src/content/docs/getting-started/nix-for-mvm.mdx
+++ b/public/src/content/docs/getting-started/nix-for-mvm.mdx
@@ -274,13 +274,13 @@ Your microVM is serving traffic from inside a Firecracker VM (or whichever backe
 mvmctl ls
 
 # View logs (including health check output)
-mvmctl logs hello -f
+mvmctl machine logs hello -f
 
 # Forward additional ports from a running VM
 mvmctl forward hello -p 9090:9090
 
 # Stop it
-mvmctl down hello
+mvmctl machine stop hello
 ```
 
 The first build downloads dependencies and takes a few minutes. Subsequent builds with the same `flake.lock` can be much faster because Nix reuses cached inputs and build outputs.

--- a/public/src/content/docs/getting-started/quickstart.md
+++ b/public/src/content/docs/getting-started/quickstart.md
@@ -79,9 +79,9 @@ Release binaries download the builder image (~200MB) and dev microVM image on fi
 ```bash
 mvmctl ls         # List running VMs (aliases: ps, status)
 mvmctl dev shell  # Open a shell in the dev microVM
-mvmctl down       # Stop all running VMs
+mvmctl machine stop --all       # Stop all running VMs
 mvmctl doctor     # Check system dependencies and configuration
-mvmctl console vm # Interactive shell into a running VM (PTY-over-vsock)
+mvmctl machine console vm # Interactive shell into a running VM (PTY-over-vsock)
 ```
 
 ## 4. Build and Run
@@ -149,8 +149,8 @@ mvmctl up my-app                          # Boot the VM
 Access a running VM without SSH -- uses PTY-over-vsock:
 
 ```bash
-mvmctl console myvm                    # Interactive shell
-mvmctl console myvm --command "ls -la" # One-shot command
+mvmctl machine console myvm                    # Interactive shell
+mvmctl machine console myvm --command "ls -la" # One-shot command
 ```
 
 ## 8. Sandboxed One-Shot Commands
@@ -186,7 +186,7 @@ mvmctl network list
 
 ```bash
 mvmctl doctor           # Deps, available backends, and security posture (one report)
-mvmctl logs vm1         # View guest console logs
+mvmctl machine logs vm1         # View guest console logs
 mvmctl cache info       # Cache directory disk usage
 ```
 

--- a/public/src/content/docs/guides/agent-tool-contract.mdx
+++ b/public/src/content/docs/guides/agent-tool-contract.mdx
@@ -66,10 +66,10 @@ the CLI while preserving the same contract the SDK target should expose.
 ```sh
 mvmctl build ./agent-tool
 mvmctl up ./agent-tool --name agent-tool-call
-mvmctl fs write agent-tool-call /work/main.py < /tmp/request-main.py
+mvmctl machine fs write agent-tool-call /work/main.py < /tmp/request-main.py
 mvmctl exec agent-tool-call --timeout 20 -- python /work/main.py
-mvmctl logs agent-tool-call
-mvmctl down agent-tool-call
+mvmctl machine logs agent-tool-call
+mvmctl machine stop agent-tool-call
 ```
 
 For one-off command execution, prefer a single bounded run when the workflow

--- a/public/src/content/docs/guides/building-microvm-images.md
+++ b/public/src/content/docs/guides/building-microvm-images.md
@@ -115,7 +115,7 @@ Independent of the sealed/accessible distinction, mvm exposes two **runtime life
 | Mode | What it means | When to use |
 |---|---|---|
 | `attached` | VM lifecycle bound to the calling process — Ctrl-C / process exit sends SIGTERM to the VM. | `mvmctl run` interactive, `mvmctl dev` shell sessions, test harnesses that want deterministic teardown. |
-| `detached` | VM survives caller exit — only `mvmctl down` (or `VmBackend::stop`) terminates it. | `mvmctl up` (background), production agents, CI fixtures that boot once and run multiple phases. |
+| `detached` | VM survives caller exit — only `mvmctl machine stop` (or `VmBackend::stop`) terminates it. | `mvmctl up` (background), production agents, CI fixtures that boot once and run multiple phases. |
 
 The default is `detached`. Override:
 
@@ -133,13 +133,13 @@ The lifecycle mode is **orthogonal** to the sealed/accessible distinction:
 | accessible + attached | Dev-mode debug session: `entrypoint.shell`, Ctrl-C ends the session. |
 | accessible + detached | Long-running dev container: shell available, survives reconnect. |
 | sealed + attached | Test harness running an entrypoint to completion, exit captured. |
-| sealed + detached | Production: `entrypoint.command`, runs forever until `mvmctl down`. |
+| sealed + detached | Production: `entrypoint.command`, runs forever until `mvmctl machine stop`. |
 
 The trait surface lives at `mvm_core::vm_backend::{StartMode, VmBackend::start_with_mode, VmBackend::wait, VmBackend::detach}`. The libkrun backend records `StartMode` intent at `~/.mvm/vms/<name>/mode.json`; `mvmctl status` surfaces it.
 
 ## Sealed vs accessible — the same flake works for both
 
-The mvm builder transparently determines whether the resulting image is **sealed** (production — no console attach) or **accessible** (dev — `mvmctl console <vm>` opens an interactive PTY over vsock). The decision is encoded in `passthru.mvm.{accessible, sealed, entrypointKind}` on the resulting derivation, and `mvmctl` reads that metadata to gate the `console` subcommand.
+The mvm builder transparently determines whether the resulting image is **sealed** (production — no console attach) or **accessible** (dev — `mvmctl machine console <vm>` opens an interactive PTY over vsock). The decision is encoded in `passthru.mvm.{accessible, sealed, entrypointKind}` on the resulting derivation, and `mvmctl` reads that metadata to gate the `console` subcommand.
 
 The default inference:
 

--- a/public/src/content/docs/guides/config-secrets.md
+++ b/public/src/content/docs/guides/config-secrets.md
@@ -193,6 +193,6 @@ different configs and secrets at runtime.
 ### Monitoring the VM
 
 ```bash
-mvmctl logs my-vm        # view console output
-mvmctl logs my-vm -f     # follow in real time
+mvmctl machine logs my-vm        # view console output
+mvmctl machine logs my-vm -f     # follow in real time
 ```

--- a/public/src/content/docs/guides/dev-image.md
+++ b/public/src/content/docs/guides/dev-image.md
@@ -41,7 +41,7 @@ A dev image is just an mkGuest call with `entrypoint.shell` set. Your project's 
           name = "my-app-dev";
 
           # entrypoint.shell auto-infers `dev = true` (accessible).
-          # `mvmctl console <vm>` attaches via vsock.
+          # `mvmctl machine console <vm>` attaches via vsock.
           entrypoint.shell = "/bin/bash";
 
           # Anything in nixpkgs.
@@ -75,7 +75,7 @@ Then:
 ```sh
 mvmctl dev up         # builds the .dev output, boots it, drops you into the shell
 mvmctl dev down       # stop the dev VM
-mvmctl console        # reattach to the running shell
+mvmctl machine console        # reattach to the running shell
 ```
 
 You **never edit anything inside the mvm repository** to customize your dev image. Your project owns its dev image; mvm is the library.
@@ -105,7 +105,7 @@ Each service runs as its own supervised process. The shell stays your foreground
 
 ### Forcing the dev path on a sealed entrypoint
 
-If you want a dev image whose primary entrypoint is a *program* (not a shell) but still want `mvmctl console` to attach for debugging:
+If you want a dev image whose primary entrypoint is a *program* (not a shell) but still want `mvmctl machine console` to attach for debugging:
 
 ```nix
 dev = mvm.lib.${system}.mkGuest {

--- a/public/src/content/docs/guides/exec.md
+++ b/public/src/content/docs/guides/exec.md
@@ -31,7 +31,7 @@ mvmctl exec --launch-plan ./launch.json
   up a long-running VM.
 - **Reach for `mvmctl up`** when you want a long-running VM you can
   re-enter, share state with, or expose ports from.
-- **Reach for `mvmctl console <vm> --command "..."`** when you already
+- **Reach for `mvmctl machine console <vm> --command "..."`** when you already
   have a VM running and want to run something inside it without a fresh
   boot.
 
@@ -235,7 +235,7 @@ highest):
 - **Ctrl-C**: a SIGINT handler triggers teardown so the Firecracker
   process and any tap interface don't get orphaned.
 - **Hard kill** (`kill -9` on `mvmctl exec` itself): teardown is
-  best-effort; you may need `mvmctl ls` and `mvmctl down <name>` to
+  best-effort; you may need `mvmctl ls` and `mvmctl machine stop <name>` to
   clean up. Each transient VM is named `exec-<pid>-<rand>` so they're
   easy to spot.
 

--- a/public/src/content/docs/guides/macos-sandbox-debugging.md
+++ b/public/src/content/docs/guides/macos-sandbox-debugging.md
@@ -17,7 +17,7 @@ macOS is a supported local development target. Linux-specific build and runtime 
 ```sh
 mvmctl dev status
 mvmctl doctor
-mvmctl logs <name>
+mvmctl machine logs <name>
 mvmctl boot-report <name>
 ```
 

--- a/public/src/content/docs/guides/manifests.md
+++ b/public/src/content/docs/guides/manifests.md
@@ -175,7 +175,7 @@ Snapshots (`--snapshot`) are Firecracker-only. On Apple Virtualization or Docker
 
 ## Listing / inspecting / removing
 
-Manifest registry operations live under `mvmctl manifest`. (The unprefixed `mvmctl ls` / `mvmctl info` / `mvmctl down` continue to operate on **running VMs** — those are unchanged.)
+Manifest registry operations live under `mvmctl manifest`. (The unprefixed `mvmctl ls` / `mvmctl info` / `mvmctl machine stop` continue to operate on **running VMs** — those are unchanged.)
 
 ```bash
 mvmctl manifest ls                            # list built slots (manifest path, name, last built)
@@ -192,7 +192,7 @@ mvmctl manifest rm /path/to/project --force   # idempotent
 mvmctl manifest rm --manifest-file            # also delete mvm.toml on disk (off by default)
 ```
 
-For running VMs (separate concern), continue to use `mvmctl ls` / `mvmctl down <vm>` / `mvmctl logs <vm>` etc.
+For running VMs (separate concern), continue to use `mvmctl ls` / `mvmctl machine stop <vm>` / `mvmctl machine logs <vm>` etc.
 
 ## Booting
 

--- a/public/src/content/docs/guides/networking.md
+++ b/public/src/content/docs/guides/networking.md
@@ -61,7 +61,7 @@ MicroVMs have **no SSH access** by design. Communication is exclusively via vsoc
 - SSH daemon attack surface
 - Network-based authentication bypasses
 
-For debugging dev builds, use `mvmctl logs <name>` to view guest console output, or `mvmctl logs <name> -f` to follow in real time.
+For debugging dev builds, use `mvmctl machine logs <name>` to view guest console output, or `mvmctl machine logs <name> -f` to follow in real time.
 
 ## Network Policies
 

--- a/public/src/content/docs/guides/nix-flakes.md
+++ b/public/src/content/docs/guides/nix-flakes.md
@@ -146,8 +146,8 @@ healthChecks.my-app = {
 Query health status from the host:
 
 ```bash
-mvmctl logs <name>       # view guest console (includes health check results)
-mvmctl logs <name> -f    # follow in real time
+mvmctl machine logs <name>       # view guest console (includes health check results)
+mvmctl machine logs <name> -f    # follow in real time
 ```
 
 ## Users

--- a/public/src/content/docs/guides/observability-and-results.mdx
+++ b/public/src/content/docs/guides/observability-and-results.mdx
@@ -58,7 +58,7 @@ For a long-running sandbox:
 mvmctl up ./service --name service-dev --metrics-port 9100
 mvmctl wait service-dev --for all
 mvmctl boot-report service-dev --json
-mvmctl logs service-dev -n 200
+mvmctl machine logs service-dev -n 200
 mvmctl metrics --json
 ```
 

--- a/public/src/content/docs/guides/persistent-workspaces.md
+++ b/public/src/content/docs/guides/persistent-workspaces.md
@@ -12,7 +12,7 @@ explicit before the sandbox starts.
 
 | Need | Use | Security posture |
 | --- | --- | --- |
-| One input file or result file | `mvmctl cp` or `mvmctl fs` | Narrowest boundary; preferred for generated-code tasks. |
+| One input file or result file | `mvmctl cp` or `mvmctl machine fs` | Narrowest boundary; preferred for generated-code tasks. |
 | Read-only fixtures | `mvmctl run --add-dir ...:ro` | Host data is exposed but not writable by the guest. |
 | Local dev edits | `mvmctl run --profile dev --add-dir ...:rw` | Writable host share; use only for trusted dev workflows. |
 | Stateful app data | managed encrypted volume | Encrypted at rest when locked; plaintext exists while unlocked. |
@@ -144,7 +144,7 @@ mvmctl cp ./task.json coding-agent:/work/task.json
 mvmctl exec coding-agent --timeout 120 -- python /work/run_task.py
 mvmctl cp --max-bytes 16777216 coding-agent:/work/result.json ./result.json
 mvmctl volume unmount coding-agent /workspace
-mvmctl down coding-agent
+mvmctl machine stop coding-agent
 mvmctl volume lock coding-agent-work
 ```
 
@@ -152,7 +152,7 @@ mvmctl volume lock coding-agent-work
 
 Before marking a stateful sandbox done:
 
-- stop compute with `mvmctl down` when it no longer needs to run;
+- stop compute with `mvmctl machine stop` when it no longer needs to run;
 - lock every managed volume;
 - remove mounts that are no longer needed;
 - delete snapshots that no longer have a recovery purpose;

--- a/public/src/content/docs/guides/troubleshooting.md
+++ b/public/src/content/docs/guides/troubleshooting.md
@@ -87,8 +87,8 @@ in-guest seed-store fallback that aggravates first-boot geometry on a cold cache
 The Firecracker process may have crashed. Check the logs:
 
 ```bash
-mvmctl logs <name>
-mvmctl logs <name> --hypervisor   # Firecracker logs
+mvmctl machine logs <name>
+mvmctl machine logs <name> --hypervisor   # Firecracker logs
 ```
 
 ### "Failed to create TAP device"
@@ -196,7 +196,7 @@ error: timed out waiting for ...
 
 **Cause**: Network connectivity issue or a service failed to start within the expected time.
 
-**Fix**: Check that the dev VM has internet access and that your service binds to the correct port. Use `mvmctl logs <name>` to inspect guest output.
+**Fix**: Check that the dev VM has internet access and that your service binds to the correct port. Use `mvmctl machine logs <name>` to inspect guest output.
 
 ## Machine Run Issues
 

--- a/public/src/content/docs/install/macos.md
+++ b/public/src/content/docs/install/macos.md
@@ -90,7 +90,7 @@ mvmctl run
 
 **`nix build` fails with "a 'x86_64-linux' with features … is required"** — that is a direct host-side Nix command failing because macOS cannot build Linux derivations by itself. Use `mvmctl build --flake .` so the Linux build runs inside the builder VM. If you intentionally want direct `nix build` on macOS, configure [`nix-darwin`'s `linux-builder`](https://nix.dev/manual/nix/stable/installation/installing-binary).
 
-**`mvmctl run` boots but `mvmctl console` fails to attach** — the `console` subcommand is only enabled for *accessible* images. If your `entrypoint.command = [ ... ]`, the build is *sealed* and console attach is rejected. Switch to `entrypoint.shell = "/bin/sh"` or pass `dev = true` in your `mkGuest` call. See [Building MicroVM Images](/guides/building-microvm-images).
+**`mvmctl run` boots but `mvmctl machine console` fails to attach** — the `console` subcommand is only enabled for *accessible* images. If your `entrypoint.command = [ ... ]`, the build is *sealed* and console attach is rejected. Switch to `entrypoint.shell = "/bin/sh"` or pass `dev = true` in your `mkGuest` call. See [Building MicroVM Images](/guides/building-microvm-images).
 
 **"libkrun shared library not found"** — install libkrun, then rerun the command. On Apple Silicon with Homebrew:
 

--- a/public/src/content/docs/reference/cli-commands.md
+++ b/public/src/content/docs/reference/cli-commands.md
@@ -63,19 +63,19 @@ templates, the guest-RPC surface, fleet-shaped workflows).
 | `mvmctl up --network-allow host:port` | Allow egress to specific host:port (repeatable, mutually exclusive with preset) |
 | `mvmctl up --seccomp <tier>` | Seccomp profile: `essential`, `minimal`, `standard` (default), `network`, `unrestricted`. The selected tier is enforced through the guest `seccomp.json` manifest and recorded in the signed admission profile for audit. |
 | `mvmctl up --network <name>` | Named dev network to attach VM to (default: "default") |
-| `mvmctl down [name]` | Stop VMs by name, or all if omitted |
+| `mvmctl machine stop [name]` | Stop VMs by name, or all if omitted |
 | `mvmctl ls` | List running VMs (aliases: `ps`, `status`) |
 | `mvmctl ls -a` | Show all VMs including stopped |
 | `mvmctl ls --json` | Output as JSON |
-| `mvmctl vm forward <name> -p PORT` | Forward a port from a running VM to localhost |
-| `mvmctl logs <name>` | View guest console logs (`-f` to follow, `-n` for line count) |
-| `mvmctl logs <name> --hypervisor` | View Firecracker hypervisor logs |
-| `mvmctl vm diff <name>` | Show filesystem changes in a running VM (created/modified/deleted since boot) |
-| `mvmctl vm diff <name> --json` | Output filesystem diff as JSON |
-| `mvmctl vm wait <name> --for <component>` | Block until a guest readiness component is `Ready`, `Disabled`, or `Failed`. Targets: `control-plane`, `entrypoint`, `warm-pool`, `integrations`, `probes`, `all` (default). Exit codes: `0` ready, `65` (`EX_DATAERR`) failed, `75` (`EX_TEMPFAIL`) timeout. Plan 76 Phase 2. |
-| `mvmctl vm wait <name> --timeout <secs> --interval-ms <ms>` | Tune the deadline and poll cadence. Defaults: 60s / 250ms. |
-| `mvmctl vm boot-report <name>` | Print a single readiness snapshot + per-phase boot timings. Plan 76 Phase 4. |
-| `mvmctl vm boot-report <name> --json` | Same payload as JSON. |
+| `mvmctl machine forward <name> -p PORT` | Forward a port from a running VM to localhost |
+| `mvmctl machine logs <name>` | View guest console logs (`-f` to follow, `-n` for line count) |
+| `mvmctl machine logs <name> --hypervisor` | View Firecracker hypervisor logs |
+| `mvmctl machine diff <name>` | Show filesystem changes in a running VM (created/modified/deleted since boot) |
+| `mvmctl machine diff <name> --json` | Output filesystem diff as JSON |
+| `mvmctl machine wait <name> --for <component>` | Block until a guest readiness component is `Ready`, `Disabled`, or `Failed`. Targets: `control-plane`, `entrypoint`, `warm-pool`, `integrations`, `probes`, `all` (default). Exit codes: `0` ready, `65` (`EX_DATAERR`) failed, `75` (`EX_TEMPFAIL`) timeout. Plan 76 Phase 2. |
+| `mvmctl machine wait <name> --timeout <secs> --interval-ms <ms>` | Tune the deadline and poll cadence. Defaults: 60s / 250ms. |
+| `mvmctl machine boot-report <name>` | Print a single readiness snapshot + per-phase boot timings. Plan 76 Phase 4. |
+| `mvmctl machine boot-report <name> --json` | Same payload as JSON. |
 
 ## Environment Management
 
@@ -300,8 +300,8 @@ never the token value.
 
 | Command | Description |
 |---------|-------------|
-| `mvmctl console <name>` | Interactive PTY shell into a running VM (vsock, no SSH) |
-| `mvmctl console <name> --command <cmd>` | Run a one-shot command in the VM |
+| `mvmctl machine console <name>` | Interactive PTY shell into a running VM (vsock, no SSH) |
+| `mvmctl machine console <name> --command <cmd>` | Run a one-shot command in the VM |
 
 ## One-shot Run (transient runner)
 
@@ -508,10 +508,10 @@ exposes named networks and policy bundles.
 
 | Command | Description |
 |---------|-------------|
-| `mvmctl vm sandbox gc` | Dry-run cleanup of stale sandbox name-registry entries for stopped or expired VMs |
-| `mvmctl vm sandbox gc --dry-run` | Explicit dry-run; reports candidates and does not mutate state |
-| `mvmctl vm sandbox gc --apply` | Remove stale stopped/expired registry entries and emit a `SandboxGc` audit entry |
-| `mvmctl vm sandbox gc --json` | Print a machine-readable GC summary with candidates, reasons, and removed count |
+| `mvmctl machine sandbox gc` | Dry-run cleanup of stale sandbox name-registry entries for stopped or expired VMs |
+| `mvmctl machine sandbox gc --dry-run` | Explicit dry-run; reports candidates and does not mutate state |
+| `mvmctl machine sandbox gc --apply` | Remove stale stopped/expired registry entries and emit a `SandboxGc` audit entry |
+| `mvmctl machine sandbox gc --json` | Print a machine-readable GC summary with candidates, reasons, and removed count |
 
 `sandbox gc` never tears down a live VM. Entries that still appear as starting,
 running, or paused in a backend listing are skipped; cleanup only removes stale
@@ -521,20 +521,20 @@ host registry records.
 
 ## Checkpoint
 
-`mvmctl vm save` / `mvmctl vm restore` are the first-class Vz machine-state verbs. They are thin aliases over the `vm-full` checkpoint path: save captures memory + disk through Vz `saveMachineStateToURL`, restore verifies the sealed checkpoint content and resumes the same VM identity. `mvmctl vm checkpoint` remains the advanced checkpoint store surface for list/remove/fork/diff and explicit class selection. `mvmctl vm snapshot ls` / `mvmctl vm snapshot rm` remain for Firecracker sealed snapshots.
+`mvmctl machine save` / `mvmctl machine restore` are the first-class Vz machine-state verbs. They are thin aliases over the `vm-full` checkpoint path: save captures memory + disk through Vz `saveMachineStateToURL`, restore verifies the sealed checkpoint content and resumes the same VM identity. `mvmctl machine checkpoint` remains the advanced checkpoint store surface for list/remove/fork/diff and explicit class selection. `mvmctl machine snapshot ls` / `mvmctl machine snapshot rm` remain for Firecracker sealed snapshots.
 
 | Command | Description |
 |---------|-------------|
-| `mvmctl vm save <name> [--tag <tag>] [--json]` | Save a running Vz VM as a `vm_full` checkpoint. Refuses when the active host/backend does not report the `save-restore` snapshot tier. |
-| `mvmctl vm restore <checkpoint> [--json]` | Restore a previously saved `vm_full` checkpoint into the original VM identity after content verification. Refuses when the active host/backend does not report the `save-restore` snapshot tier. |
-| `mvmctl vm checkpoint create <name> [--class fs-quick\|vm-full] [--tag <tag>] [--json]` | Capture a checkpoint. `--class vm-full` saves full machine state (memory + disk) via Vz's `saveMachineStateToURL`. Records content hash in the audit chain. |
-| `mvmctl vm checkpoint restore <checkpoint> [--json]` | Restore a previously created `vm_full` checkpoint into the original VM identity. Re-hashes content against the recorded metadata before loading. |
-| `mvmctl vm checkpoint fork <checkpoint> [--new-id <name>] [--boot] [--json]` | Restore a checkpoint into a new VM identity (new name, separate audit lineage). `vm_full` forks auto-boot; `fs_quick` forks boot only with `--boot`. |
-| `mvmctl vm checkpoint ls [--json]` | List checkpoints. |
-| `mvmctl vm checkpoint diff <a> <b> [--json]` | Compare two checkpoint metadata/content manifests. |
-| `mvmctl vm checkpoint rm <checkpoint> [--json]` | Delete a checkpoint and its blobs. |
-| `mvmctl vm snapshot ls [--json]` | List sealed Firecracker instance snapshots. |
-| `mvmctl vm snapshot rm <name> [--json]` | Delete a sealed Firecracker instance snapshot. |
+| `mvmctl machine save <name> [--tag <tag>] [--json]` | Save a running Vz VM as a `vm_full` checkpoint. Refuses when the active host/backend does not report the `save-restore` snapshot tier. |
+| `mvmctl machine restore <checkpoint> [--json]` | Restore a previously saved `vm_full` checkpoint into the original VM identity after content verification. Refuses when the active host/backend does not report the `save-restore` snapshot tier. |
+| `mvmctl machine checkpoint create <name> [--class fs-quick\|vm-full] [--tag <tag>] [--json]` | Capture a checkpoint. `--class vm-full` saves full machine state (memory + disk) via Vz's `saveMachineStateToURL`. Records content hash in the audit chain. |
+| `mvmctl machine checkpoint restore <checkpoint> [--json]` | Restore a previously created `vm_full` checkpoint into the original VM identity. Re-hashes content against the recorded metadata before loading. |
+| `mvmctl machine checkpoint fork <checkpoint> [--new-id <name>] [--boot] [--json]` | Restore a checkpoint into a new VM identity (new name, separate audit lineage). `vm_full` forks auto-boot; `fs_quick` forks boot only with `--boot`. |
+| `mvmctl machine checkpoint ls [--json]` | List checkpoints. |
+| `mvmctl machine checkpoint diff <a> <b> [--json]` | Compare two checkpoint metadata/content manifests. |
+| `mvmctl machine checkpoint rm <checkpoint> [--json]` | Delete a checkpoint and its blobs. |
+| `mvmctl machine snapshot ls [--json]` | List sealed Firecracker instance snapshots. |
+| `mvmctl machine snapshot rm <name> [--json]` | Delete a sealed Firecracker instance snapshot. |
 
 Checkpoint blobs are stored under the configured checkpoint store (`MVM_DATA_DIR` / `~/.mvm` via the core path helpers). The audit chain records `checkpoint.created`, `checkpoint.restored`, and `checkpoint.forked` entries with content hashes; restore and fork refuse tampered checkpoint content before booting.
 
@@ -542,12 +542,12 @@ Checkpoint blobs are stored under the configured checkpoint store (`MVM_DATA_DIR
 
 | Command | Description |
 |---------|-------------|
-| `mvmctl vm cp <host-path> <vm>:/absolute/path` | Copy one regular file from the host into a running VM |
-| `mvmctl vm cp <vm>:/absolute/path <host-path>` | Copy one regular file from a running VM to the host |
-| `mvmctl vm cp --force <src> <dst>` | Overwrite an existing destination |
-| `mvmctl vm cp --create-parents <src> <dst>` | Create destination parent directories |
-| `mvmctl vm cp --max-bytes <n> <src> <dst>` | Refuse copies larger than the byte cap. Default: 16 MiB |
-| `mvmctl vm cp --json <src> <dst>` | Print a machine-readable copy summary without host paths or file contents |
+| `mvmctl machine cp <host-path> <vm>:/absolute/path` | Copy one regular file from the host into a running VM |
+| `mvmctl machine cp <vm>:/absolute/path <host-path>` | Copy one regular file from a running VM to the host |
+| `mvmctl machine cp --force <src> <dst>` | Overwrite an existing destination |
+| `mvmctl machine cp --create-parents <src> <dst>` | Create destination parent directories |
+| `mvmctl machine cp --max-bytes <n> <src> <dst>` | Refuse copies larger than the byte cap. Default: 16 MiB |
+| `mvmctl machine cp --json <src> <dst>` | Print a machine-readable copy summary without host paths or file contents |
 
 Exactly one endpoint must use `VM:/absolute/path` form. Guest paths are
 validated by the guest agent's filesystem policy before any read or write. Host
@@ -637,19 +637,19 @@ to cold boot with a warning rather than aborting the exec. See the
 
 | Command | Description |
 |---------|-------------|
-| `mvmctl vm volume create <name>` | Create a locked mvm-managed encrypted local volume archive |
-| `mvmctl vm volume create <name> --root <absolute-dir>` | Create the mvm-managed encrypted volume under a specific root |
-| `mvmctl vm volume create <name> --host-backed` | Create the previous host-backed managed directory, requiring encrypted backing storage |
-| `mvmctl vm volume unlock <name>` | Decrypt a managed volume into its plaintext mount directory |
-| `mvmctl vm volume lock <name>` | Seal a managed volume back into its encrypted archive and remove plaintext |
-| `mvmctl vm volume catalog` | List managed local volumes |
-| `mvmctl vm volume catalog --json` | List managed local volumes as JSON |
-| `mvmctl vm volume mount <vm> --volume <name> --guest <absolute-path>` | Register an unlocked managed local virtio-fs volume mount for a VM. Read-only by default |
-| `mvmctl vm volume mount <vm> --volume <name> --host <absolute-dir> --guest <absolute-path>` | Register an ad-hoc encrypted host directory as a virtio-fs volume mount |
-| `mvmctl vm volume mount <vm> --volume <name> --host <absolute-dir> --guest <absolute-path> --rw` | Register the volume read-write |
-| `mvmctl vm volume ls <vm>` | List registered volume mounts |
-| `mvmctl vm volume ls <vm> --json` | List registered volume mounts as JSON |
-| `mvmctl vm volume unmount <vm> <guest-path>` | Remove a registered volume mount |
+| `mvmctl machine volume create <name>` | Create a locked mvm-managed encrypted local volume archive |
+| `mvmctl machine volume create <name> --root <absolute-dir>` | Create the mvm-managed encrypted volume under a specific root |
+| `mvmctl machine volume create <name> --host-backed` | Create the previous host-backed managed directory, requiring encrypted backing storage |
+| `mvmctl machine volume unlock <name>` | Decrypt a managed volume into its plaintext mount directory |
+| `mvmctl machine volume lock <name>` | Seal a managed volume back into its encrypted archive and remove plaintext |
+| `mvmctl machine volume catalog` | List managed local volumes |
+| `mvmctl machine volume catalog --json` | List managed local volumes as JSON |
+| `mvmctl machine volume mount <vm> --volume <name> --guest <absolute-path>` | Register an unlocked managed local virtio-fs volume mount for a VM. Read-only by default |
+| `mvmctl machine volume mount <vm> --volume <name> --host <absolute-dir> --guest <absolute-path>` | Register an ad-hoc encrypted host directory as a virtio-fs volume mount |
+| `mvmctl machine volume mount <vm> --volume <name> --host <absolute-dir> --guest <absolute-path> --rw` | Register the volume read-write |
+| `mvmctl machine volume ls <vm>` | List registered volume mounts |
+| `mvmctl machine volume ls <vm> --json` | List registered volume mounts as JSON |
+| `mvmctl machine volume unmount <vm> <guest-path>` | Remove a registered volume mount |
 
 Managed local volumes are encrypted by mvm at rest. `volume create` writes a
 locked AES-256-GCM encrypted archive plus wrapped per-volume data key metadata

--- a/public/src/content/docs/reference/guest-agent.md
+++ b/public/src/content/docs/reference/guest-agent.md
@@ -282,10 +282,10 @@ After the grace period expires, normal health reporting resumes.
 
 ```bash
 # Check guest console output
-mvmctl logs my-vm
+mvmctl machine logs my-vm
 
 # Follow logs in real time
-mvmctl logs my-vm -f
+mvmctl machine logs my-vm -f
 
 # List VMs and their status
 mvmctl ls

--- a/public/src/content/docs/reference/limits.md
+++ b/public/src/content/docs/reference/limits.md
@@ -40,7 +40,7 @@ mvmctl doctor
 
 ## Files and volumes
 
-Keep host mounts narrow. Use `mvmctl fs`, `mvmctl cp`, and declared volumes
+Keep host mounts narrow. Use `mvmctl machine fs`, `mvmctl cp`, and declared volumes
 instead of broad writable host shares when running untrusted code.
 
 Snapshots and cold-mode artifacts may contain guest memory, generated files,

--- a/public/src/content/docs/sdk/errors-metrics.md
+++ b/public/src/content/docs/sdk/errors-metrics.md
@@ -74,7 +74,7 @@ Use these while SDK error and metric helpers mature:
 ```sh
 mvmctl run --receipt /tmp/receipt.json -- python task.py
 mvmctl boot-report devbox --json
-mvmctl logs devbox
+mvmctl machine logs devbox
 mvmctl audit tail -n 20
 mvmctl audit verify --tenant local
 mvmctl doctor --json

--- a/public/src/content/docs/sdk/lifecycle-matrix.md
+++ b/public/src/content/docs/sdk/lifecycle-matrix.md
@@ -28,7 +28,7 @@ keep a workflow documented as planned.
 | One-shot run | Shipped | Target | Target | `mvmctl run -- <cmd>` is current; SDK convenience helpers should preserve receipts and policy. |
 | Start command | Shipped | Partial | Partial | SDK exposes `commands.start(...)`; result capture is still a target. |
 | Command result capture | Shipped | Target | Target | CLI one-shot JSON/receipt paths exist; SDK `commands.run(...)` result shape is a target. |
-| File write | Shipped | Shipped | Shipped | SDK supports `files.write(...)`; live mode shells to `mvmctl fs write`. |
+| File write | Shipped | Shipped | Shipped | SDK supports `files.write(...)`; live mode shells to `mvmctl machine fs write`. |
 | File read/list/remove | Shipped | Target | Target | CLI filesystem verbs exist; SDK wrappers need shared tests. |
 | Logs | Shipped | Target | Target | SDK log helpers should keep payload redaction rules explicit. |
 | Port forwarding | Shipped | Target | Target | SDK helpers should require explicit host and guest port binding. |
@@ -47,7 +47,7 @@ keep a workflow documented as planned.
 | Local SDK smoke script | Python or TypeScript `Sandbox.create(...)` in record mode | Produces Workload IR without booting a VM. |
 | Live SDK experiment | `mvmctl run --mode live ./script.py` or `.ts` | Exercises current live transport and cleanup helpers. |
 | Deployable workload declaration | Static declaration workflow | Avoids importing user modules during compile. |
-| Persistent service | `mvmctl build`, `mvmctl up`, `mvmctl logs`, `mvmctl down` | CLI has the broadest lifecycle coverage today. |
+| Persistent service | `mvmctl build`, `mvmctl up`, `mvmctl machine logs`, `mvmctl machine stop` | CLI has the broadest lifecycle coverage today. |
 | Cold recovery test | `mvmctl pause/resume` or `mvmctl checkpoint create/restore` | Backend-specific state handling is visible. |
 
 ## SDK parity rules

--- a/public/src/content/docs/sdk/operations-cookbook.mdx
+++ b/public/src/content/docs/sdk/operations-cookbook.mdx
@@ -23,13 +23,13 @@ language SDK tests prove them.
 | Create live sandbox | `mvmctl run --mode live ./script.py` | `mvmctl run --mode live ./script.ts` | `mvmctl up` |
 | Start command | `sandbox.commands.start([...])` | `sandbox.commands.start([...])` | `mvmctl proc start` or `mvmctl exec` |
 | Capture command result | Target `commands.run(...)` | Target `commands.run(...)` | CLI command result and receipt paths |
-| Write file | `sandbox.files.write(path, data)` | `sandbox.files.write(path, data)` | `mvmctl fs write` |
-| Read/list/remove file | Target helpers | Target helpers | `mvmctl fs read`, `mvmctl fs ls`, `mvmctl fs rm` |
-| Logs | Target helper | Target helper | `mvmctl logs` |
+| Write file | `sandbox.files.write(path, data)` | `sandbox.files.write(path, data)` | `mvmctl machine fs write` |
+| Read/list/remove file | Target helpers | Target helpers | `mvmctl machine fs read`, `mvmctl machine fs ls`, `mvmctl machine fs rm` |
+| Logs | Target helper | Target helper | `mvmctl machine logs` |
 | Ports | Target helper | Target helper | port-forwarding CLI commands |
 | Pause/resume | Target helper | Target helper | `mvmctl pause`, `mvmctl resume` |
 | Checkpoint create/restore | Target helper | Target helper | `mvmctl checkpoint create --class vm-full`, `mvmctl checkpoint restore` |
-| Stop cleanup | context manager or `kill()` | `using`/`Symbol.dispose` or `kill()` | `mvmctl down` |
+| Stop cleanup | context manager or `kill()` | `using`/`Symbol.dispose` or `kill()` | `mvmctl machine stop` |
 
 ## Current paths
 
@@ -242,7 +242,7 @@ mvmctl pause agent-sandbox
 mvmctl resume agent-sandbox
 mvmctl checkpoint create agent-sandbox --class vm-full
 mvmctl checkpoint restore agent-sandbox --name after-index
-mvmctl down agent-sandbox
+mvmctl machine stop agent-sandbox
 ```
 
 Snapshots and cold state can contain memory, files, process state, and

--- a/public/src/content/docs/sdk/runtime-modes.md
+++ b/public/src/content/docs/sdk/runtime-modes.md
@@ -85,9 +85,9 @@ The CLI sets `MVM_SDK_MODE=live` and `MVM_CLI_BIN` for the child process. The SD
 then uses the local CLI for operations such as:
 
 - `mvmctl up --up-json --detach --name <generated-id> --manifest <template>`
-- `mvmctl fs write <vm> <path>`
+- `mvmctl machine fs write <vm> <path>`
 - `mvmctl proc start <vm> -- <argv>`
-- `mvmctl down <vm>`
+- `mvmctl machine stop <vm>`
 
 Live mode creates a real microVM. It should be used only when the caller is ready
 for runtime side effects: boot, file writes, command execution, logs, audit
@@ -103,7 +103,7 @@ Live mode is intentionally narrower than the target SDK contract:
 | TTL | Defaults to 30 minutes unless the caller sets `ttl`. |
 | Commands | `commands.start(...)` starts a command; result capture is still a parity target. |
 | Files | `files.write(...)` stages bytes into the running VM. |
-| Cleanup | Python `with`, TypeScript `using`, or explicit `kill()` calls `mvmctl down`. |
+| Cleanup | Python `with`, TypeScript `using`, or explicit `kill()` calls `mvmctl machine stop`. |
 | Secrets | Live command env forwarding accepts literal values only. Secret refs must use host-managed injection paths. |
 
 `commands.start(...)` is a developer-oriented command surface. Production-style

--- a/public/src/content/docs/sdk/sandbox-types.md
+++ b/public/src/content/docs/sdk/sandbox-types.md
@@ -11,7 +11,7 @@ can layer specialized helpers over that substrate.
 
 | Type | Best for | Current path | SDK status |
 | --- | --- | --- | --- |
-| General sandbox | Commands, files, services, long-running work. | `mvmctl build`, `mvmctl up`, `mvmctl exec`, `mvmctl fs`, `mvmctl logs`. | Partial Python/TypeScript runtime surface. |
+| General sandbox | Commands, files, services, long-running work. | `mvmctl build`, `mvmctl up`, `mvmctl exec`, `mvmctl machine fs`, `mvmctl machine logs`. | Partial Python/TypeScript runtime surface. |
 | Code sandbox | Short code execution and interpreter-style tools. | `mvmctl run -- <cmd>` or a named Python manifest. | Planned convenience helper. |
 | Browser sandbox | Browser automation with Playwright/Puppeteer-like tooling. | Build a browser-capable Nix image, run automation inside the guest, forward explicit ports if needed. | Planned high-level helper. |
 | Desktop sandbox | GUI or computer-use workflows. | Backend- and image-specific today; use explicit images and port/console access. | Planned high-level helper. |

--- a/public/src/content/docs/templates/build.md
+++ b/public/src/content/docs/templates/build.md
@@ -43,7 +43,7 @@ mvmctl manifest info ./my-worker --json
 mvmctl manifest verify
 ```
 
-Use `mvmctl ls`, `mvmctl info`, `mvmctl logs`, and `mvmctl down` for running
+Use `mvmctl ls`, `mvmctl info`, `mvmctl machine logs`, and `mvmctl machine stop` for running
 VMs. Use `mvmctl manifest *` for build slots and registry state.
 
 ## Boot after build

--- a/public/src/content/docs/tutorials/coding-agent.md
+++ b/public/src/content/docs/tutorials/coding-agent.md
@@ -46,7 +46,7 @@ mvmctl pause coding-agent
 mvmctl resume coding-agent
 ```
 
-Use `mvmctl down` and cleanup commands when the task is complete.
+Use `mvmctl machine stop` and cleanup commands when the task is complete.
 
 ## Security checklist
 

--- a/public/src/content/docs/tutorials/interactive-terminal.md
+++ b/public/src/content/docs/tutorials/interactive-terminal.md
@@ -15,8 +15,8 @@ Use the existing console and guest RPC surfaces:
 
 ```sh
 mvmctl up ./mvm.toml --name debug-vm
-mvmctl console debug-vm
-mvmctl logs debug-vm -f
+mvmctl machine console debug-vm
+mvmctl machine logs debug-vm -f
 ```
 
 ## Security notes

--- a/public/src/content/docs/tutorials/long-running-services.md
+++ b/public/src/content/docs/tutorials/long-running-services.md
@@ -11,12 +11,12 @@ Services need more lifecycle structure than one-shot commands.
 - Declare the service command as the entrypoint.
 - Declare ports explicitly.
 - Add readiness checks where supported.
-- Use `mvmctl logs`, `mvmctl wait`, and `mvmctl boot-report` for diagnostics.
+- Use `mvmctl machine logs`, `mvmctl wait`, and `mvmctl boot-report` for diagnostics.
 
 ```sh
 mvmctl up ./mvm.toml --name api-dev -p 8080:8080
 mvmctl wait api-dev --for all
-mvmctl logs api-dev -f
+mvmctl machine logs api-dev -f
 ```
 
 ## Security notes

--- a/public/src/content/docs/working/commands.md
+++ b/public/src/content/docs/working/commands.md
@@ -31,7 +31,7 @@ mvmctl run --dry-run --json -- python task.py
 ```sh
 mvmctl up ./my-app --name agent-sandbox
 mvmctl exec agent-sandbox -- python /work/task.py
-mvmctl logs agent-sandbox -f
+mvmctl machine logs agent-sandbox -f
 ```
 
 Use this path when the VM has state, files, services, or snapshots that should survive across commands.

--- a/public/src/content/docs/working/index.md
+++ b/public/src/content/docs/working/index.md
@@ -11,8 +11,8 @@ description: Local sandbox management with mvmctl.
 mvmctl build ./my-app
 mvmctl up ./my-app --name agent-sandbox
 mvmctl exec agent-sandbox -- python /work/task.py
-mvmctl logs agent-sandbox -f
-mvmctl down agent-sandbox
+mvmctl machine logs agent-sandbox -f
+mvmctl machine stop agent-sandbox
 ```
 
 ## Management tasks

--- a/public/src/content/docs/working/lifecycle-states.md
+++ b/public/src/content/docs/working/lifecycle-states.md
@@ -15,7 +15,7 @@ cleanup is still required.
 | No image | No build artifact exists for the workload yet. | `mvmctl build` | Build inputs still need policy and secret review before launch. |
 | Built | A launchable artifact exists, but no sandbox is running. | `mvmctl up` or `mvmctl run` | Artifact metadata can reveal package, path, and configuration choices. |
 | Starting | The backend is creating the VM, attaching drives, and waiting for readiness. | `mvmctl wait` or `mvmctl boot-report` | Admission failures should be reported without leaking secrets. |
-| Running | Guest compute is active and can execute commands, expose ports, write files, and emit logs. | `mvmctl exec`, `mvmctl logs`, `mvmctl fs`, `mvmctl down`, or snapshot commands | Treat command output, files, logs, ports, and receipts as boundary-crossing data. |
+| Running | Guest compute is active and can execute commands, expose ports, write files, and emit logs. | `mvmctl exec`, `mvmctl machine logs`, `mvmctl machine fs`, `mvmctl machine stop`, or snapshot commands | Treat command output, files, logs, ports, and receipts as boundary-crossing data. |
 | Paused | Guest execution is suspended and can be resumed by the backend path that created the pause. | `mvmctl resume` | Paused memory can contain tokens, browser sessions, plaintext files, and process state. |
 | Cold | Compute is released while recoverable state is retained through a backend snapshot or checkpoint. | `mvmctl resume` or `mvmctl checkpoint restore` | Cold state is persistence, not a security boundary. Protect it like sensitive data. |
 | Restoring | The backend is loading saved state and re-establishing runtime control. | Wait for readiness, then verify workload health | Restore can fail because of backend, host, image, or policy drift. |
@@ -29,10 +29,10 @@ cleanup is still required.
 | Source to image | `mvmctl build` |
 | Image to running sandbox | `mvmctl up` or `mvmctl run` |
 | Wait for readiness | `mvmctl wait`, `mvmctl boot-report` |
-| Run work | `mvmctl exec`, `mvmctl fs`, `mvmctl logs`, port-forwarding commands |
+| Run work | `mvmctl exec`, `mvmctl machine fs`, `mvmctl machine logs`, port-forwarding commands |
 | Running to paused or cold | `mvmctl pause`, `mvmctl checkpoint create` |
 | Paused or cold to running | `mvmctl resume`, `mvmctl checkpoint restore` |
-| Running to stopped | `mvmctl down` |
+| Running to stopped | `mvmctl machine stop` |
 | Remove retained local state | `mvmctl sandbox gc`, `mvmctl cleanup`, snapshot and volume cleanup commands |
 
 ## Backend behavior

--- a/public/src/content/docs/working/network.md
+++ b/public/src/content/docs/working/network.md
@@ -40,7 +40,7 @@ Use readiness and logs while developing services:
 ```sh
 mvmctl wait api-dev --for all
 mvmctl boot-report api-dev
-mvmctl logs api-dev -f
+mvmctl machine logs api-dev -f
 ```
 
 ## Host control channel
@@ -48,8 +48,8 @@ mvmctl logs api-dev -f
 Host control does not require SSH. Guest communication uses the mvm control plane and guest protocol where supported. For debugging, prefer:
 
 ```sh
-mvmctl console api-dev
-mvmctl logs api-dev
+mvmctl machine console api-dev
+mvmctl machine logs api-dev
 mvmctl exec api-dev -- sh -lc 'id && pwd'
 ```
 

--- a/public/src/content/docs/working/persistence.md
+++ b/public/src/content/docs/working/persistence.md
@@ -31,7 +31,7 @@ Cold mode is the product posture where a sandbox is snapshotted, compute is rele
 ## Cleanup
 
 ```sh
-mvmctl down agent-sandbox
+mvmctl machine stop agent-sandbox
 mvmctl sandbox gc
 mvmctl cleanup
 ```

--- a/public/src/content/docs/working/sandbox-management.md
+++ b/public/src/content/docs/working/sandbox-management.md
@@ -20,7 +20,7 @@ mvmctl up ./agent-sandbox --name agent-sandbox
 ```sh
 mvmctl ls
 mvmctl boot-report agent-sandbox
-mvmctl logs agent-sandbox
+mvmctl machine logs agent-sandbox
 ```
 
 Use JSON output where commands support it when integrating with tooling.
@@ -29,7 +29,7 @@ Use JSON output where commands support it when integrating with tooling.
 
 ```sh
 mvmctl exec agent-sandbox -- python /work/task.py
-mvmctl fs ls agent-sandbox /work
+mvmctl machine fs ls agent-sandbox /work
 mvmctl forward agent-sandbox -p 8080:8080
 ```
 
@@ -54,7 +54,7 @@ Snapshots can contain memory, files, and runtime credentials. Apply retention an
 ## Stop and clean up
 
 ```sh
-mvmctl down agent-sandbox
+mvmctl machine stop agent-sandbox
 mvmctl cleanup
 ```
 


### PR DESCRIPTION
## Why
#1249 (Plan 208 Tasks 1–7) folded `down`/`logs`/`console`/`vm <x>`/`fs` under `machine` — so **~50 references across 44 docs/example files are broken on `main` right now** (`mvmctl down`/`logs`/`console`/`vm …` no longer parse).

## What
Migrates only the **already-removed** verbs (mappings are final — they won't change again):
- `logs`/`console`/`fs`/`vm <x>` → `machine <x>`
- `down <name>` → `machine stop <name>`
- bare `down` (stop all): `machine stop --all` in runnable code blocks; `machine stop` (the verb, generically) in prose/tables where `--all` would be wrong (e.g. `kill()` stops one sandbox, not all)
- fixes a stale `mvmctl vm ping` landing example → `mvmctl ls`

**`up`/`run`/`invoke` are deliberately left as-is** — they're still valid on `main` until the Plan 208 `machine run` work (#1258) removes them; their doc sweep is a separate, later wave.

44 files, pure renames (no broken `down`/`logs`/`console`/`vm`/`fs` references remain). No code touched.