### PR TITLE
fix(builder): pin materialize toolchain as a GC root so cap-GC can't strand mkfs.ext4

### DIFF
--- a/crates/mvm-build/src/builder_vm_runtime.rs
+++ b/crates/mvm-build/src/builder_vm_runtime.rs
@@ -494,6 +494,22 @@ else
     rm -f /out/mvm-meta.json
 fi
 
+# Pin the builder VM's own materialize toolchain under fixed GC roots so the
+# cap GC below can't reap it. The OCI rootfs materialize job runs
+# /sbin/mkfs.ext4 (and `mount`) inside this VM but registers no root of its
+# own, and a workload build's $NIX_OUT closure never carries e2fsprogs — so
+# without these roots a cap GC after a workload build leaves /sbin/mkfs.ext4
+# a dangling symlink and every later image run dies with "mkfs.ext4: not
+# found". Best-effort; skips a tool already missing (recovery rebuilds it).
+for tool in /sbin/mkfs.ext4 mount; do
+  tool_path=$(command -v "$tool" 2>/dev/null) || continue
+  tool_store=$(readlink -f "$tool_path" 2>/dev/null) || continue
+  [ -n "$tool_store" ] || continue
+  tool_root="/nix/var/nix/gcroots/mvm-builder-tools-$(basename "$tool")"
+  nix-store --add-root "$tool_root" --indirect -r "$tool_store" >/dev/null 2>&1 \
+    || ln -sfn "$tool_store" "$tool_root" 2>/dev/null || true
+done
+
 # Bound the persistent /nix store: GC stale closures once it grows
 # past the cap. `--delete-older-than 14d` keeps the just-built closure
 # (recent) so rebuilds stay warm; only old-revision garbage is freed.
@@ -2021,6 +2037,37 @@ mod tests {
         assert!(
             warm_idx < gc_idx,
             "warm gcroot must be registered before the GC tail"
+        );
+    }
+
+    #[test]
+    fn render_flake_cmd_sh_pins_builder_toolchain_before_gc() {
+        let body = render_flake_cmd_sh(".", "default", false);
+        // The OCI rootfs materialize job runs /sbin/mkfs.ext4 inside the
+        // builder VM but registers no GC root, and a workload build's
+        // $NIX_OUT closure never carries e2fsprogs. Without a dedicated root
+        // the cap GC reaps the builder's own toolchain, leaving
+        // /sbin/mkfs.ext4 a dangling symlink and breaking every later image
+        // run. Pin the materialize toolchain under fixed roots, before the GC.
+        let pin_idx = body
+            .find("/nix/var/nix/gcroots/mvm-builder-tools-")
+            .expect("builder-toolchain gcroot present");
+        assert!(
+            body.contains("tool_root=\"/nix/var/nix/gcroots/mvm-builder-tools-"),
+            "toolchain pin must build the gcroot path in:\n{body}"
+        );
+        assert!(
+            body.contains("nix-store --add-root \"$tool_root\" --indirect -r \"$tool_store\""),
+            "toolchain pin must register an indirect --add-root in:\n{body}"
+        );
+        assert!(
+            body.contains("/sbin/mkfs.ext4"),
+            "toolchain pin must cover mkfs.ext4 in:\n{body}"
+        );
+        let gc_idx = body.find("nix-collect-garbage").expect("gc present");
+        assert!(
+            pin_idx < gc_idx,
+            "builder-toolchain gcroot must be registered before the GC tail"
         );
     }
 


### PR DESCRIPTION
Fixes #1289. Related: #1281 (same warm-gcroot mechanism, different victim).

## Problem

After the builder VM's cap-triggered GC runs, every `mvmctl machine run --image <oci>` fails hard:

```
builder VM ext4 materialization failed: /job/cmd.sh: line 8: /sbin/mkfs.ext4: not found
```

The OCI rootfs materialize job (`crates/mvm-build/src/rootfs.rs`) runs `/sbin/mkfs.ext4` inside the builder VM — a symlink into the Nix store provided by `e2fsprogs` (`builderPackages`). The only warm GC root, `mvm-warm-latest`, pins the just-built **user** image closure, which never carries `e2fsprogs`. The cap-triggered `nix-collect-garbage --delete-older-than 14d` then "deletes every unrooted path regardless of age" (its own comment), reaping `e2fsprogs` and dangling the `/sbin/mkfs.ext4` symlink. Every later image run dies until the builder VM is rebuilt. Confirmed live: materialize worked at 04:23, a cap-GC at 05:36 deleted 2259 paths, and materialize failed from 06:05 on.

## Fix

Before the GC tail in the builder build script (`builder_vm_runtime.rs`), register fixed `mvm-builder-tools-*` indirect GC roots for the materialize toolchain (`mkfs.ext4`, `mount`), resolved via `command -v` + `readlink -f`. Every build now re-pins the toolchain before any GC could run, so the cap GC can never strand it. Best-effort and skips a tool that's already missing (an already-degraded store is repaired by a builder rebuild; the next build then pins it).

Unit test `render_flake_cmd_sh_pins_builder_toolchain_before_gc` asserts the toolchain root is registered before the `nix-collect-garbage` tail — sibling to the existing `mvm-warm-latest` ordering assertion.

## Scope

`builder_vm_runtime.rs` only. The deeper keyed-warm-roots redesign in #1281 is complementary; this is the targeted, cadence-independent fix for the materialize toolchain specifically. Does not retroactively repair an already-GC'd store — a builder rebuild does that, after which this keeps it pinned.
