### PR TITLE
fix(cli): `machine run --up-json`/`--ttl` + migrate SDK boot off retired `up` (un-break live mode)

### DIFF
--- a/crates/mvm-cli/src/commands/cmd_audit.rs
+++ b/crates/mvm-cli/src/commands/cmd_audit.rs
@@ -152,8 +152,9 @@ impl Commands {
                 // Folded advanced ops delegate to their own check.
                 machine::MachineAction::Vm(cmd) => cmd.emits_machine_readable_stdout(),
                 // `machine run --json` streams a structured MachineRunSummary;
+                // `machine run --up-json` emits the SDK boot envelope;
                 // reserve stdout so reconcile chrome can't interleave.
-                machine::MachineAction::Run(r) => r.json,
+                machine::MachineAction::Run(r) => r.json || r.up_json,
                 _ => false,
             },
             _ => false,

--- a/crates/mvm-cli/src/commands/machine/mod.rs
+++ b/crates/mvm-cli/src/commands/machine/mod.rs
@@ -198,6 +198,17 @@ pub(in crate::commands) struct MachineRunArgs {
     /// when `--name` is absent (the chosen name is printed). Implies persistence.
     #[arg(short = 'd', long)]
     pub detach: bool,
+    /// Emit a one-line JSON envelope on stdout when the machine is up.
+    /// Routes all other output to stderr. Implies persistence + detach
+    /// semantics (boot and return). Envelope shape:
+    /// `{"schema_version":1,"vm_id":"<name>","build_mode":"dev"|"prod"}`.
+    /// Used by the SDK live-mode transport to learn the vm_id and build_mode.
+    #[arg(long = "up-json")]
+    pub up_json: bool,
+    /// Set a TTL on the persistent machine after boot: `30s`, `5m`, `2h`, `7d`
+    /// or a bare number of seconds. The reaper tears down expired machines.
+    #[arg(long, value_name = "DURATION")]
+    pub ttl: Option<String>,
     /// Attach an interactive PTY shell (dev-only; refused for `--prod`/sealed
     /// images). Does not affect persistence: `-t` alone is a transient
     /// interactive machine, gone when the shell exits.
@@ -302,11 +313,11 @@ impl MachineRunArgs {
         self.tty || self.interactive
     }
 
-    /// `--name` or `-d`/`--detach` makes the machine survive the command.
+    /// `--name` or `-d`/`--detach`/`--up-json` makes the machine survive the command.
     /// `--tty` is deliberately NOT consulted here — persistence and
     /// interactivity are independent axes.
     fn persistent(&self) -> bool {
-        self.name.is_some() || self.detach
+        self.name.is_some() || self.detach || self.up_json
     }
 
     /// Resolve the lifecycle mode purely from the flags. The only validation is
@@ -2055,8 +2066,13 @@ fn run_persistent(
             kernel_pin: args.kernel_pin.clone(),
         },
     )?;
-    if !booted && !args.json {
+    if !booted && !args.json && !args.up_json {
         println!("machine {name} already running");
+    }
+
+    // Apply TTL if requested (after a successful boot record exists).
+    if let Some(dur_str) = args.ttl.as_deref() {
+        apply_machine_ttl(&name, dur_str)?;
     }
 
     run_persistent_post_start(cli, cfg, &args, &name, &spec)
@@ -2191,6 +2207,17 @@ fn run_persistent_post_start(
             cfg,
         );
     }
+    if args.up_json {
+        // Emit the SDK boot envelope as the sole stdout line.
+        let build_mode_str = resolve_build_mode_for_envelope(args, name);
+        let envelope = serde_json::json!({
+            "schema_version": 1,
+            "vm_id": name,
+            "build_mode": build_mode_str,
+        });
+        println!("{envelope}");
+        return Ok(());
+    }
     if !args.json {
         if args.detach {
             // `-d`: the name is the handle. `start_machine` already printed it;
@@ -2201,6 +2228,64 @@ fn run_persistent_post_start(
         }
     }
     Ok(())
+}
+
+/// Set a TTL on a persistent machine by writing `expires_at` to the name registry.
+/// Reuses the same registry helpers as `machine vm set-ttl`.
+fn apply_machine_ttl(name: &str, dur_str: &str) -> Result<()> {
+    let dur = mvm_core::crypto::policy::parse_ttl(dur_str)
+        .with_context(|| format!("Invalid --ttl value {dur_str:?}"))?;
+    let expires_at = mvm_core::util::time::utc_plus_duration(dur);
+    let registry_path = mvm::vm::name_registry::registry_path();
+    let mut registry =
+        mvm::vm::name_registry::VmNameRegistry::load(&registry_path).with_context(|| {
+            format!(
+                "Failed to load VM name registry at {}",
+                registry_path.display()
+            )
+        })?;
+    registry
+        .set_expires_at(name, Some(expires_at))
+        .with_context(|| format!("Failed to set TTL for machine {name:?}"))?;
+    registry.save(&registry_path).with_context(|| {
+        format!(
+            "Failed to save VM name registry at {}",
+            registry_path.display()
+        )
+    })
+}
+
+/// Resolve the `build_mode` string for the `--up-json` envelope.
+///
+/// For manifest-backed boots, reads the template revision's `build_mode`
+/// field so the SDK knows whether `do_exec` is available (claim 4 / claim 15).
+/// For image-backed boots the runtime meta's `accessible` flag carries the
+/// same signal post-boot. Falls back to `"prod"` when no signal is available
+/// (fail-closed: the SDK will refuse exec against a prod image, which is
+/// correct).
+fn resolve_build_mode_for_envelope(args: &MachineRunArgs, name: &str) -> &'static str {
+    // Manifest path: read the template revision's stored build_mode.
+    if let Some(manifest) = args.manifest.as_deref() {
+        let slot_name = manifest
+            .trim_end_matches('/')
+            .split('/')
+            .next_back()
+            .unwrap_or(manifest);
+        if let Ok(Some(revision)) =
+            mvm::vm::template::lifecycle::template_load_current_revision(slot_name)
+        {
+            return match revision.build_mode.as_deref() {
+                Some("dev") => "dev",
+                _ => "prod",
+            };
+        }
+    }
+    // Image / fallback path: consult the runtime meta written at boot time.
+    // Missing or unreadable meta defaults to "prod" (fail-closed).
+    match mvm::vm::runtime_meta::read(name) {
+        Ok(Some(meta)) if meta.accessible => "dev",
+        _ => "prod",
+    }
 }
 
 /// The entrypoint action: dispatch the image's baked `/etc/mvm/entrypoint` (the
@@ -2337,6 +2422,8 @@ pub(in crate::commands) fn boot_persistent_by_name(
             interactive: false,
             force: false,
             no_supervisor: false,
+            up_json: false,
+            ttl: None,
             entrypoint: false,
             stdin: None,
             fresh: false,
@@ -2714,6 +2801,11 @@ mod tests {
             ),
             (
                 &["run", "--name", "web", "--image", "X"],
+                MachineRunMode::Persistent,
+            ),
+            // `--up-json` implies Persistent (SDK boot-and-return path).
+            (
+                &["run", "--up-json", "--manifest", "tmpl"],
                 MachineRunMode::Persistent,
             ),
         ];

--- a/crates/mvm-cli/src/commands/tests.rs
+++ b/crates/mvm-cli/src/commands/tests.rs
@@ -4031,3 +4031,72 @@ fn machine_console_refused_on_sealed_image() {
         "claim-15 gate must fire through machine console path: {err}"
     );
 }
+
+#[test]
+fn machine_run_up_json_and_ttl_parse() {
+    // `machine run --up-json --manifest x --ttl 60s` must parse without error
+    // and set the expected fields.
+    let args = parse_machine_run(&["--up-json", "--manifest", "x", "--ttl", "60s"]).unwrap();
+    assert!(args.up_json);
+    assert_eq!(args.ttl.as_deref(), Some("60s"));
+    assert_eq!(args.manifest.as_deref(), Some("x"));
+}
+
+#[test]
+fn machine_run_up_json_implies_persistent_mode() {
+    // `--up-json` implies persistence: `--manifest x --up-json` (no argv, no -d)
+    // must parse and route to the persistent lifecycle. We verify this via the
+    // parsed fields: up_json is set, and the parse doesn't error (a transient
+    // run with no argv would fail at dispatch, but persistent doesn't need argv).
+    let args = parse_machine_run(&["--up-json", "--manifest", "x"]).unwrap();
+    assert!(args.up_json, "up_json field must be set");
+    // The manifest source must survive parsing.
+    assert_eq!(args.manifest.as_deref(), Some("x"));
+    // No detach flag needed — up_json alone implies persistence.
+    assert!(!args.detach, "detach is not required when up_json is set");
+}
+
+#[test]
+fn machine_run_up_json_guards_stdout() {
+    // `machine run --up-json` must reserve stdout (emits_machine_readable_stdout).
+    let cli =
+        Cli::try_parse_from(["mvmctl", "machine", "run", "--up-json", "--manifest", "x"]).unwrap();
+    assert!(
+        cli.command.emits_machine_readable_stdout(),
+        "--up-json must guard stdout via emits_machine_readable_stdout"
+    );
+}
+
+#[test]
+fn sdk_live_mode_shelled_commands_keep_parsing() {
+    // Every command the SDKs shell to must parse against the real Cli.
+    // A future rename that breaks any of these will fail CI here first.
+    let sdk_commands: &[&[&str]] = &[
+        &[
+            "machine", "proc", "start", "vm", "-e", "K=V", "--", "echo", "hi",
+        ],
+        &["machine", "proc", "wait", "vm", "tok", "--timeout", "30"],
+        &["machine", "fs", "write", "vm", "/app/x"],
+        &["machine", "cp", "host.txt", "vm:/guest.txt"],
+        &["machine", "forward", "vm", "--port", "8080:80"],
+        &["machine", "stop", "vm"],
+        &[
+            "machine",
+            "run",
+            "-d",
+            "--up-json",
+            "--name",
+            "vm",
+            "--manifest",
+            "tmpl",
+            "--ttl",
+            "1800s",
+        ],
+    ];
+    for argv in sdk_commands {
+        let mut full = vec!["mvmctl"];
+        full.extend_from_slice(argv);
+        Cli::try_parse_from(full.clone())
+            .unwrap_or_else(|e| panic!("SDK command {:?} failed to parse: {e}", argv));
+    }
+}

--- a/sdks/python/mvm/_sandbox.py
+++ b/sdks/python/mvm/_sandbox.py
@@ -829,7 +829,7 @@ class _LiveTransport:
         self._forwards.append(proc)
 
     def kill(self) -> None:
-        """Shell ``mvmctl down <vm>``. Idempotent — repeated kills
+        """Shell ``mvmctl machine stop <vm>``. Idempotent — repeated kills
         from the context manager + an explicit `sb.kill()` are
         coalesced so we don't trip on a double-down."""
         if self._killed:
@@ -858,7 +858,7 @@ class _LiveTransport:
             # failure here usually means the VM was already torn
             # down by the orchestrator's TTL reaper.
             sys.stderr.write(
-                f"mvm-sdk live: `mvmctl down {self.vm_id}` exited "
+                f"mvm-sdk live: `mvmctl machine stop {self.vm_id}` exited "
                 f"with {result.returncode}: {result.stderr}\n"
             )
 
@@ -1208,7 +1208,7 @@ class Sandbox:
         drops these; the microVM TTL is the orchestrator's job, but
         the bookkeeping is preserved through the recording so
         tooling can introspect intent). In live mode, shells
-        ``mvmctl down <vm>``."""
+        ``mvmctl machine stop <vm>``."""
         if self._live is not None:
             self._live.kill()
             _clear_live()
@@ -1227,7 +1227,7 @@ class Sandbox:
 
     async def __aexit__(self, *_exc: Any) -> None:
         # Same teardown as `__exit__`, off the event loop so a slow
-        # `mvmctl down` doesn't block the caller's loop.
+        # `mvmctl machine stop` doesn't block the caller's loop.
         await asyncio.to_thread(self.kill)
 
 

--- a/sdks/python/mvm/_sandbox.py
+++ b/sdks/python/mvm/_sandbox.py
@@ -17,8 +17,8 @@ Two modes are live:
   host's ``mvmctl compile`` / ``mvmctl run --mode plan`` verbs
   lower the recording via ``compile_recording``.
 - ``MVM_SDK_MODE=live`` (Plan 73 Followup H-live): every
-  ``Sandbox`` call shells to ``$MVM_CLI_BIN`` (``mvmctl up``,
-  ``mvmctl machine proc start``, ``mvmctl fs write``, ``mvmctl down``)
+  ``Sandbox`` call shells to ``$MVM_CLI_BIN`` (``mvmctl machine run``,
+  ``mvmctl machine proc start``, ``mvmctl fs write``, ``mvmctl machine stop``)
   against a real microVM. The shell is dispatched by
   :class:`_LiveTransport` below.
 
@@ -528,7 +528,7 @@ class _LiveTransport:
     Created by :meth:`Sandbox.create` when ``MVM_SDK_MODE=live``.
     Holds the resolved ``mvmctl`` binary path, the generated
     ``vm_id``, and the template's ``build_mode`` ("dev" / "prod")
-    parsed from ``mvmctl up --up-json``'s stdout envelope. The
+    parsed from ``mvmctl machine run --up-json``'s stdout envelope. The
     ``build_mode`` is what the SDK uses to enforce the W4.3
     dev-only ``proc start`` rule client-side."""
 
@@ -557,7 +557,7 @@ class _LiveTransport:
         workload_id: str,
         ttl_seconds: int,
     ) -> "_LiveTransport":
-        """Run ``mvmctl up --up-json --detach --name <id> --manifest
+        """Run ``mvmctl machine run -d --up-json --name <id> --manifest
         <template>`` and parse the JSON envelope. Raises
         :class:`SandboxLiveError` on any failure."""
         mvm_cli_bin = os.environ.get(MVM_CLI_BIN_ENV) or ""
@@ -565,7 +565,7 @@ class _LiveTransport:
             raise SandboxModeError(
                 "MVM_SDK_MODE=live requires MVM_CLI_BIN to point at a `mvmctl` binary."
             )
-        # Generate a short, validatable VM id. `mvmctl up` rejects
+        # Generate a short, validatable VM id. `mvmctl machine run` rejects
         # names that don't match its validator; alphanumerics with
         # a hyphen are safe.
         suffix = secrets.token_hex(4)
@@ -574,7 +574,9 @@ class _LiveTransport:
 
         argv = [
             mvm_cli_bin,
-            "up",
+            "machine",
+            "run",
+            "-d",
             "--up-json",
             "--name",
             vm_id,
@@ -598,7 +600,7 @@ class _LiveTransport:
 
         if result.returncode != 0:
             raise SandboxLiveError(
-                f"`mvmctl up` failed with exit code {result.returncode}",
+                f"`mvmctl machine run` failed with exit code {result.returncode}",
                 argv=argv,
                 exit_code=result.returncode,
                 stderr=result.stderr,
@@ -645,7 +647,7 @@ class _LiveTransport:
                     raise SandboxLiveError(
                         f"`commands.start` env {key!r} carries a non-literal value; "
                         f"live mode only forwards literal env vars (secrets must be "
-                        f"injected via the host keystore + `--secret` on `mvmctl up`).",
+                        f"injected via the host keystore + `--secret` on `mvmctl machine run`).",
                         argv=shell,
                     )
         shell += ["--", *argv]
@@ -687,7 +689,7 @@ class _LiveTransport:
                     raise SandboxLiveError(
                         f"`exec` env {key!r} carries a non-literal value; live mode "
                         f"only forwards literal env vars (secrets must be injected via "
-                        f"the host keystore + `--secret` on `mvmctl up`).",
+                        f"the host keystore + `--secret` on `mvmctl machine run`).",
                         argv=start_shell,
                     )
         if cwd is not None:
@@ -891,32 +893,32 @@ class _LiveTransport:
 
 
 def _parse_up_envelope(stdout: str, *, argv: list[str]) -> dict[str, str]:
-    """Parse ``mvmctl up --up-json`` stdout. The envelope is a single
+    """Parse ``mvmctl machine run --up-json`` stdout. The envelope is a single
     JSON line; trailing newlines tolerated. Raises
     :class:`SandboxLiveError` if the envelope is malformed."""
     line = stdout.strip()
     if not line:
         raise SandboxLiveError(
-            "`mvmctl up --up-json` produced empty stdout — expected a JSON envelope.",
+            "`mvmctl machine run --up-json` produced empty stdout — expected a JSON envelope.",
             argv=argv,
         )
     try:
         parsed = json.loads(line)
     except json.JSONDecodeError as exc:
         raise SandboxLiveError(
-            f"`mvmctl up --up-json` stdout is not valid JSON: {exc.msg}",
+            f"`mvmctl machine run --up-json` stdout is not valid JSON: {exc.msg}",
             argv=argv,
             stderr=line,
         ) from exc
     if not isinstance(parsed, dict):
         raise SandboxLiveError(
-            f"`mvmctl up --up-json` envelope must be a JSON object; got {type(parsed).__name__}",
+            f"`mvmctl machine run --up-json` envelope must be a JSON object; got {type(parsed).__name__}",
             argv=argv,
         )
     schema = parsed.get("schema_version")
     if schema != _LiveTransport.SCHEMA_VERSION:
         raise SandboxLiveError(
-            f"`mvmctl up --up-json` envelope schema_version={schema!r}; "
+            f"`mvmctl machine run --up-json` envelope schema_version={schema!r}; "
             f"SDK supports {_LiveTransport.SCHEMA_VERSION}",
             argv=argv,
         )
@@ -924,12 +926,12 @@ def _parse_up_envelope(stdout: str, *, argv: list[str]) -> dict[str, str]:
     build_mode = parsed.get("build_mode")
     if not isinstance(vm_id, str) or not vm_id:
         raise SandboxLiveError(
-            "`mvmctl up --up-json` envelope is missing a non-empty `vm_id` field.",
+            "`mvmctl machine run --up-json` envelope is missing a non-empty `vm_id` field.",
             argv=argv,
         )
     if build_mode not in ("dev", "prod"):
         raise SandboxLiveError(
-            f"`mvmctl up --up-json` envelope build_mode={build_mode!r}; "
+            f"`mvmctl machine run --up-json` envelope build_mode={build_mode!r}; "
             f"expected 'dev' or 'prod'.",
             argv=argv,
         )
@@ -942,11 +944,11 @@ class Sandbox:
 
     Construct via :meth:`Sandbox.create`. Under ``MVM_SDK_MODE=record``
     the constructor sets up an in-process recording; under
-    ``MVM_SDK_MODE=live`` it shells ``mvmctl up`` to boot a real
+    ``MVM_SDK_MODE=live`` it shells ``mvmctl machine run`` to boot a real
     microVM and stashes the resulting handle on
     ``self._live``. Supports context-manager usage; ``__exit__``
     issues a ``kill`` (record-mode: appends a kill op; live-mode:
-    shells ``mvmctl down``)."""
+    shells ``mvmctl machine stop``)."""
 
     def __init__(
         self,
@@ -979,7 +981,7 @@ class Sandbox:
         ``runtime::resolve_base_image``); in record mode unknown
         templates fail at lower time, not here, because the wire
         shape preserves them verbatim. In live mode unknown
-        templates fail when ``mvmctl up --manifest <template>``
+        templates fail when ``mvmctl machine run --manifest <template>``
         rejects them — that failure surfaces as
         :class:`SandboxLiveError` here.
 

--- a/sdks/python/tests/test_sandbox_live.py
+++ b/sdks/python/tests/test_sandbox_live.py
@@ -81,8 +81,8 @@ if [ "$verb" = "machine" ]; then
   shift || true
 fi
 case "$verb" in
-  up)
-    # Record stdin for completeness (mvmctl up has none).
+  up | run)
+    # Record stdin for completeness (mvmctl machine run has none).
     if [ -t 0 ]; then :; else cat > {stdin_dir!s}/up-stdin.bin || true; fi
     if [ "{up_exit}" -eq 0 ]; then
       echo '{envelope_json}'
@@ -207,7 +207,7 @@ def test_sandbox_create_live_parses_envelope_and_records_vm(
 
     calls = _read_fixture_log(tmp_path)
     assert len(calls) == 1
-    assert calls[0].startswith("up --up-json --name ")
+    assert calls[0].startswith("machine run -d --up-json --name ")
     assert "--manifest python-3.12" in calls[0]
     assert "--ttl" in calls[0]
 

--- a/sdks/python/tests/test_sandbox_live.py
+++ b/sdks/python/tests/test_sandbox_live.py
@@ -2,7 +2,7 @@
 
 Each test stands up a fixture `mvmctl` shell script that records its
 argv to a sidecar file and emits whatever stdout the live transport
-needs (e.g. the `mvmctl up --up-json` envelope). The SDK shells to
+needs (e.g. the `mvmctl machine run --up-json` envelope). The SDK shells to
 the fixture via `MVM_CLI_BIN`; no real microVM boots.
 
 What we assert:
@@ -61,7 +61,7 @@ def _write_fixture_mvmctl(
     """Write a shell script that pretends to be `mvmctl`. It
     records each invocation's argv + stdin to sidecar files so
     tests can assert wire shape, and emits the requested
-    envelope on `mvmctl up --up-json`.
+    envelope on `mvmctl machine run --up-json`.
     """
     log = tmp_path / "fixture-calls.log"
     stdin_dir = tmp_path / "fixture-stdin"

--- a/sdks/typescript/src/_sandbox.ts
+++ b/sdks/typescript/src/_sandbox.ts
@@ -19,7 +19,7 @@
  *   the Rust lowering at `mvm_sdk::runtime::compile_recording`
  *   produces a Workload.
  * - `MVM_SDK_MODE=live` (Plan 73 Followup H-live): every
- *   `Sandbox` call shells to `$MVM_CLI_BIN` (`mvmctl up`,
+ *   `Sandbox` call shells to `$MVM_CLI_BIN` (`mvmctl machine run`,
  *   `mvmctl machine proc start`, `mvmctl machine fs write`, `mvmctl machine stop`)
  *   against a real microVM. The shell is dispatched by
  *   {@link LiveTransport} below.
@@ -376,7 +376,7 @@ function requireRecording(): RuntimeRecordingWire {
  *
  *  Created by `Sandbox.create(...)` when `MVM_SDK_MODE=live`. Holds
  *  the resolved `mvmctl` path, the generated `vmId`, and the
- *  template's `build_mode` parsed from the `mvmctl up --up-json`
+ *  template's `build_mode` parsed from the `mvmctl machine run --up-json`
  *  envelope. The `build_mode` is what the SDK uses to enforce the
  *  W4.3 dev-only `proc start` rule client-side. */
 export class LiveTransport {
@@ -408,7 +408,7 @@ export class LiveTransport {
         "MVM_SDK_MODE=live requires MVM_CLI_BIN to point at a `mvmctl` binary.",
       );
     }
-    // Generate a short, validatable VM id. `mvmctl up` rejects
+    // Generate a short, validatable VM id. `mvmctl machine run` rejects
     // names that don't match its validator; alphanumerics with a
     // hyphen are safe.
     const suffix = randomHex(4);
@@ -419,7 +419,9 @@ export class LiveTransport {
     const vmId = `sdk-${slug}-${suffix}`;
 
     const argv = [
-      "up",
+      "machine",
+      "run",
+      "-d",
       "--up-json",
       "--name",
       vmId,
@@ -449,7 +451,7 @@ export class LiveTransport {
     }
     if (result.status !== 0) {
       throw new SandboxLiveError(
-        `\`mvmctl up\` failed with exit code ${result.status}`,
+        `\`mvmctl machine run\` failed with exit code ${result.status}`,
         {
           argv: [mvmCliBin, ...argv],
           exitCode: result.status,
@@ -504,7 +506,7 @@ export class LiveTransport {
         throw new SandboxLiveError(
           `env ${JSON.stringify(key)} carries a non-literal value; live mode only ` +
             "forwards literal env vars (secrets must be injected via the host keystore " +
-            "+ `--secret` on `mvmctl up`).",
+            "+ `--secret` on `mvmctl machine run`).",
           { argv: shellForErr },
         );
       }
@@ -749,7 +751,7 @@ export class LiveTransport {
   }
 }
 
-/** Parse an `mvmctl up --up-json` stdout envelope. The envelope is
+/** Parse an `mvmctl machine run --up-json` stdout envelope. The envelope is
  *  a single JSON line; trailing newlines tolerated. Throws
  *  `SandboxLiveError` on any shape violation. Exported for tests. */
 export function parseUpEnvelope(
@@ -759,7 +761,7 @@ export function parseUpEnvelope(
   const line = stdout.trim();
   if (!line) {
     throw new SandboxLiveError(
-      "`mvmctl up --up-json` produced empty stdout — expected a JSON envelope.",
+      "`mvmctl machine run --up-json` produced empty stdout — expected a JSON envelope.",
       { argv },
     );
   }
@@ -774,7 +776,7 @@ export function parseUpEnvelope(
   }
   if (typeof parsed !== "object" || parsed === null) {
     throw new SandboxLiveError(
-      "`mvmctl up --up-json` envelope must be a JSON object.",
+      "`mvmctl machine run --up-json` envelope must be a JSON object.",
       { argv },
     );
   }
@@ -788,7 +790,7 @@ export function parseUpEnvelope(
   }
   if (typeof obj.vm_id !== "string" || obj.vm_id.length === 0) {
     throw new SandboxLiveError(
-      "`mvmctl up --up-json` envelope is missing a non-empty `vm_id` field.",
+      "`mvmctl machine run --up-json` envelope is missing a non-empty `vm_id` field.",
       { argv },
     );
   }
@@ -821,7 +823,7 @@ function isLiveActive(): boolean {
  *
  *  Construct via `Sandbox.create(...)`. Under `MVM_SDK_MODE=record`
  *  the constructor sets up an in-process recording; under
- *  `MVM_SDK_MODE=live` it shells `mvmctl up` to boot a real
+ *  `MVM_SDK_MODE=live` it shells `mvmctl machine run` to boot a real
  *  microVM and stashes the resulting handle on
  *  `this._live`. Use `[Symbol.dispose]` (TS 5.2+) for automatic
  *  cleanup, or call `sb.kill()` explicitly. */

--- a/sdks/typescript/src/_sandbox.ts
+++ b/sdks/typescript/src/_sandbox.ts
@@ -486,7 +486,7 @@ export class LiveTransport {
 
   /** Encode `env` into `-e KEY=VALUE` flags for `mvmctl machine proc start`,
    *  rejecting non-literal (secret) values — live mode forwards only
-   *  literals; secrets are injected host-side via `--secret` on `up`. */
+   *  literals; secrets are injected host-side via `--secret` on `machine run`. */
   private encodeEnvFlags(
     env: Record<string, EnvValue | string> | undefined,
     shellForErr: string[],
@@ -770,7 +770,7 @@ export function parseUpEnvelope(
     parsed = JSON.parse(line);
   } catch (err) {
     throw new SandboxLiveError(
-      `\`mvmctl up --up-json\` stdout is not valid JSON: ${String(err)}`,
+      `\`mvmctl machine run --up-json\` stdout is not valid JSON: ${String(err)}`,
       { argv, stderr: line },
     );
   }
@@ -783,7 +783,7 @@ export function parseUpEnvelope(
   const obj = parsed as Record<string, unknown>;
   if (obj.schema_version !== LiveTransport.SCHEMA_VERSION) {
     throw new SandboxLiveError(
-      `\`mvmctl up --up-json\` envelope schema_version=${JSON.stringify(obj.schema_version)}; ` +
+      `\`mvmctl machine run --up-json\` envelope schema_version=${JSON.stringify(obj.schema_version)}; ` +
         `SDK supports ${LiveTransport.SCHEMA_VERSION}`,
       { argv },
     );
@@ -796,7 +796,7 @@ export function parseUpEnvelope(
   }
   if (obj.build_mode !== "dev" && obj.build_mode !== "prod") {
     throw new SandboxLiveError(
-      `\`mvmctl up --up-json\` envelope build_mode=${JSON.stringify(obj.build_mode)}; ` +
+      `\`mvmctl machine run --up-json\` envelope build_mode=${JSON.stringify(obj.build_mode)}; ` +
         "expected 'dev' or 'prod'.",
       { argv },
     );

--- a/sdks/typescript/tests/sandbox_live.test.ts
+++ b/sdks/typescript/tests/sandbox_live.test.ts
@@ -55,7 +55,7 @@ if [ "$verb" = "machine" ]; then
   shift || true
 fi
 case "$verb" in
-  up)
+  up | run)
     if [ -t 0 ]; then :; else cat > ${JSON.stringify(path.join(stdinDir, "up-stdin.bin"))} || true; fi
     if [ "${upExit}" -eq 0 ]; then
       echo '${envelopeJson}'
@@ -189,7 +189,7 @@ describe("Sandbox.create (live mode)", () => {
 
     const calls = readFixtureLog();
     expect(calls.length).toBe(1);
-    expect(calls[0]).toMatch(/^up --up-json --name /);
+    expect(calls[0]).toMatch(/^machine run -d --up-json --name /);
     expect(calls[0]).toContain("--manifest python-3.12");
     expect(calls[0]).toContain("--ttl");
   });

--- a/tests/run_live_mode.rs
+++ b/tests/run_live_mode.rs
@@ -5,7 +5,7 @@
 //!
 //! - A fixture `mvmctl` shell script (the "fake mvmctl") that
 //!   records each invocation's argv and emits the
-//!   `mvmctl up --up-json` envelope the SDK expects.
+//!   `mvmctl machine run --up-json` envelope the SDK expects.
 //! - A real `mvmctl run --mode live <script>` invocation that
 //!   spawns the user script with `MVM_SDK_MODE=live` +
 //!   `MVM_CLI_BIN=<fixture>`.
@@ -17,9 +17,9 @@
 //! 1. `mvmctl run --mode live` spawns the user script with the
 //!    right env vars (the fixture verifies `MVM_CLI_BIN` was set
 //!    by writing the binary path into its own log).
-//! 2. The SDK shells `mvmctl up --up-json` and parses the envelope.
-//! 3. The SDK shells `mvmctl proc start` against the dev VM.
-//! 4. The SDK shells `mvmctl down` on `Sandbox.__exit__`.
+//! 2. The SDK shells `mvmctl machine run --up-json` and parses the envelope.
+//! 3. The SDK shells `mvmctl machine proc start` against the dev VM.
+//! 4. The SDK shells `mvmctl machine stop` on `Sandbox.__exit__`.
 //! 5. Against a prod-template envelope, the SDK raises
 //!    `SandboxDevOnly` *before* any `proc start` shell — security
 //!    claim 4 enforcement.
@@ -64,7 +64,7 @@ fn python_on_path() -> Option<PathBuf> {
 }
 
 /// Write a fixture `mvmctl` shell script that records its argv to a
-/// log file and emits the requested envelope on `up --up-json`.
+/// log file and emits the requested envelope on `machine run --up-json`.
 fn write_fixture_mvmctl(dir: &std::path::Path, build_mode: &str) -> PathBuf {
     let log = dir.join("fixture-calls.log");
     let stdin_dir = dir.join("fixture-stdin");
@@ -84,7 +84,7 @@ if [ "$verb" = "machine" ]; then
   shift || true
 fi
 case "$verb" in
-  up)
+  run)
     echo '{envelope}'
     exit 0
     ;;
@@ -142,7 +142,7 @@ fn read_fixture_log(dir: &std::path::Path) -> Vec<String> {
 /// before reaching the SDK.
 ///
 /// In practice the verb sets `MVM_CLI_BIN=<current_exe>`. To
-/// avoid a real `mvmctl up` going out and trying to boot a VM,
+/// avoid a real `mvmctl machine run` going out and trying to boot a VM,
 /// the test overrides `MVM_CLI_BIN` directly via `Command::env`
 /// after the verb sets it — that's not possible because the verb
 /// is the spawner. So instead the test inlines the env override
@@ -187,14 +187,14 @@ fn sdk_live_dev_template_shells_to_proc_start() {
     );
 
     let calls = read_fixture_log(tmp.path());
-    // 1: up --up-json, 2: proc start, 3: fs write, 4: down
+    // 1: machine run --up-json, 2: machine proc start, 3: machine fs write, 4: machine stop
     assert!(
         calls.len() >= 4,
-        "expected >= 4 mvmctl shells (up, machine proc start, machine fs write, machine stop); got {calls:?}"
+        "expected >= 4 mvmctl shells (machine run, machine proc start, machine fs write, machine stop); got {calls:?}"
     );
     assert!(
-        calls[0].starts_with("up --up-json"),
-        "first shell must be `up --up-json`, got {:?}",
+        calls[0].starts_with("machine run -d --up-json"),
+        "first shell must be `machine run -d --up-json`, got {:?}",
         calls[0]
     );
     assert!(
@@ -256,8 +256,10 @@ fn sdk_live_prod_template_raises_sandbox_dev_only_before_proc_start() {
         "SDK must NOT have shelled to `mvmctl proc start` against a prod template (security claim 4 client-side enforcement); but the fixture saw: {calls:?}"
     );
     assert!(
-        calls.iter().any(|c| c.starts_with("up --up-json")),
-        "the `up` shell must still have fired; got {calls:?}"
+        calls
+            .iter()
+            .any(|c| c.starts_with("machine run -d --up-json")),
+        "the `machine run` boot shell must still have fired; got {calls:?}"
     );
 }
 


### PR DESCRIPTION
## Regression
#1258 removed the `up` verb, but the live-mode SDKs still shell to `up --up-json` to boot — so **SDK live-mode boot is broken on `main`** (`mvmctl up` → unrecognized subcommand). This is the regression the #1278 contract warned about; CI missed it (the SDK tests use a *mock* mvmctl), but the new guard (below) catches it.

## Fix
- **CLI:** add `--up-json` + `--ttl` to `machine run`. `--up-json` boots persistent (boot-and-return), reserves stdout, and emits exactly one envelope — `{"schema_version":1,"vm_id":"<name>","build_mode":"dev"|"prod"}` (ports the logic #1258 deleted from `up`). `build_mode` resolves from the manifest revision's build mode, else the booted image's `accessible` flag (fail-closed to `prod`). `--ttl` sets the registry `expires_at` via the same helper as `machine set-ttl`.
- **SDK:** `_sandbox.py` + `_sandbox.ts` boot call → `machine run -d --up-json …`; fixtures + assertions + stale `up`/`down` strings updated.
- **Guard:** `sdk_live_mode_shelled_commands_keep_parsing` parses every SDK-shelled command against the real `Cli` — the next rename fails CI instead of shipping a broken SDK. **(Supersedes #1282** — folded in here with the corrected `machine run` boot entry.)

Green: `mvm-cli` 1174/1174, `sandbox_live` 37 (py) + 114 (ts), fmt + clippy clean.

## ⚠️ Separate breakage found, NOT in this PR
#1258 also dropped `invoke --no-vm`, but the SDK's **remote no-vm dispatch** (`mvm/_remote.py`) still shells to `mvmctl invoke --no-vm` → `tests/test_remote_no_vm_e2e.py` fails locally (CI-gated; needs a built binary). That's a *feature drop*, not a rename, so it needs its own decision (restore the host shortcut, or rework the SDK's remote path) — flagged for follow-up.