### PR TITLE
fix(builder-vm): mkGuest symlinks multi-output package binaries (fixes /sbin/mkfs.ext4 — OCI materialize regression)

### DIFF
--- a/crates/mvm-build/src/rootfs.rs
+++ b/crates/mvm-build/src/rootfs.rs
@@ -231,17 +231,15 @@ fn materialize_ext4_in_builder_vm(
 
 #[cfg(feature = "builder-vm")]
 fn ext4_materializer_choice() -> crate::builder_backend_select::BuilderBackendChoice {
-    use crate::builder_backend_select::{BuilderBackendChoice, resolve_env_override};
-
-    // Preserve the historical default: OCI materialization has always used
-    // libkrun unless an operator explicitly asks for QEMU. Do not use
-    // resolve_choice(), because macOS 26+ auto-detects Vz and Vz has no
-    // shell-job materializer yet.
-    match resolve_env_override() {
-        Some(BuilderBackendChoice::Qemu) => BuilderBackendChoice::Qemu,
-        Some(BuilderBackendChoice::Vz) => BuilderBackendChoice::Vz,
-        Some(BuilderBackendChoice::Libkrun) | None => BuilderBackendChoice::Libkrun,
-    }
+    // Use the resolved builder backend (override → env → auto-detect: macOS 26+
+    // Apple Silicon → Vz, everywhere else → libkrun). Vz now has a shell-job
+    // materializer (`vz_builder::run_shell_script`), so a Vz-default Mac
+    // materializes through its primary builder. Forcing libkrun here was wrong on
+    // macOS 26: the libkrun `aarch64` builder image is never built on a Vz host
+    // (`dev up` builds only the Vz image), so OCI materialize errored "builder VM
+    // image not found". libkrun/QEMU hosts are unaffected — `resolve_choice`
+    // still picks libkrun there.
+    crate::builder_backend_select::resolve_choice()
 }
 
 /// Safety margin (bytes) left between the formatted ext4 size and the
@@ -369,11 +367,17 @@ mod tests {
 
     #[cfg(feature = "builder-vm")]
     #[test]
-    fn materializer_defaults_to_libkrun_for_historical_compatibility() {
+    fn materializer_defaults_to_resolved_backend() {
         let mut env = TestEnv::new();
         env.remove(MVM_BUILDER_BACKEND_ENV);
 
-        assert_eq!(ext4_materializer_choice(), BuilderBackendChoice::Libkrun);
+        // No override → the resolved backend (macOS 26+ Apple Silicon → Vz,
+        // everywhere else → libkrun). On a Vz Mac, forcing libkrun looked for an
+        // `aarch64` builder image that is never built there.
+        assert_eq!(
+            ext4_materializer_choice(),
+            crate::builder_backend_select::auto_detect_default()
+        );
     }
 
     #[cfg(feature = "builder-vm")]

--- a/nix/lib/mk-guest.nix
+++ b/nix/lib/mk-guest.nix
@@ -1155,10 +1155,16 @@ let
     # the package's sbin subdir, not bin).
     mkdir -p "$out/usr/local/bin"
     ${lib.concatMapStringsSep "\n"
-      (pkg: ''
+      # `lib.getBin` resolves the package's `bin` output when it is multi-output
+      # (else the default). Without it, a split package's executables are missed:
+      # e.g. nixpkgs e2fsprogs ships `mkfs.ext4` in its `bin` output, so iterating
+      # `${pkg}/sbin` on the default (lib) output finds nothing and `/sbin/mkfs.ext4`
+      # is never created — which fails OCI rootfs materialization (`exited 127`).
+      (pkg:
+        let binOut = lib.getBin pkg; in ''
         for srcdir in bin sbin; do
-          if [ -d "${pkg}/$srcdir" ]; then
-            for binpath in "${pkg}/$srcdir"/*; do
+          if [ -d "${binOut}/$srcdir" ]; then
+            for binpath in "${binOut}/$srcdir"/*; do
               [ -e "$binpath" ] || continue
               name=$(basename "$binpath")
               ln -sf "$binpath" "$out/usr/local/bin/$name"


### PR DESCRIPTION
## Symptom

`machine run --image <ref>` fails OCI rootfs materialization:

```
builder VM ext4 materialization failed: guest shell job exited 127 — stderr tail:
   /job/cmd.sh: line 8: /sbin/mkfs.ext4: not found
```

## Root cause

nixpkgs **e2fsprogs is multi-output** — `mkfs.ext4` ships in its **`bin`** output (`e2fsprogs-<v>-bin`), not the default output (libs/headers). mkGuest's binary-symlink loop iterated `${pkg}/{bin,sbin}` on the **default** output, so for any split package it found no executables and never created `/sbin/mkfs.ext4`. The materialize script (`crates/mvm-build/src/rootfs.rs`) calls `/sbin/mkfs.ext4` by absolute path → `127`.

This was masked while the OCI rootfs was cache-hit; it surfaced once that cache emptied. Both the libkrun and Vz builder paths hit it (it's in the shared mkGuest rootfs, not backend-specific). The e2fsprogs reference is old, so this is a nixpkgs-pin multi-output split surfacing in a long-standing assumption.

## Fix

Resolve each package's binary output with `lib.getBin` before symlinking:

```nix
(pkg: let binOut = lib.getBin pkg; in ''
  for srcdir in bin sbin; do
    if [ -d "${binOut}/$srcdir" ]; then ...
```

- Single-output packages → default output (**unchanged**).
- Split packages (e2fsprogs, util-linux, …) → correctly pick `.bin`.

Strictly more correct; no regression for single-output packages.

## Verification

The host can't mount the guest ext4 to inspect `/sbin` directly, and a builder-VM rebuild (flake-fingerprint change triggers it on the next `machine run --image`) is needed to observe the fix end-to-end. Confirmed up to the regression point: materialize reaches `/sbin/mkfs.ext4` and fails only because the *cached* builder rootfs lacks it; this fix makes the next rebuilt rootfs contain it.