### PR TITLE
Per-arch kernel symbol budgets (aarch64 1327 / x86_64 1130)

### DIFF
--- a/.github/workflows/kernel-build.yml
+++ b/.github/workflows/kernel-build.yml
@@ -85,17 +85,18 @@ jobs:
           # the shrink audit + the check-kernel-config-budget gate.
           cp "$CFG" "staging/workload-config-${ARCH}"
           Y_COUNT=$(grep -c '=y$' "$CFG")
-          # Symbol-budget ratchet: fail if the workload kernel grew a new
-          # built-in past the committed ceiling. The budget lives in the xtask
-          # (single source of truth) — read it out rather than duplicate it, so
-          # this can't drift from `cargo run -p xtask -- check-kernel-config-budget`.
-          BUDGET=$(grep -oP 'KERNEL_Y_BUDGET: usize = \K[0-9]+' \
+          # Per-arch symbol-budget ratchet: fail if this arch's workload kernel
+          # grew a new built-in past its committed ceiling. The budgets live in
+          # the xtask (single source of truth) — read the arch-specific one out
+          # rather than duplicate it, so this can't drift from
+          # `cargo run -p xtask -- check-kernel-config-budget`.
+          BUDGET=$(grep -oP "BUDGET_${ARCH^^}: usize = \K[0-9]+" \
             xtask/src/check_kernel_config_budget.rs)
           echo "workload kernel ${ARCH}: ${Y_COUNT} =y symbols (budget ${BUDGET})"
           if [ "$Y_COUNT" -gt "$BUDGET" ]; then
             echo "::error::workload kernel ${ARCH} has ${Y_COUNT} built-in (=y) symbols, \
               over the ${BUDGET} budget — a new subsystem was compiled in. Drop it, or bump \
-              KERNEL_Y_BUDGET in xtask/src/check_kernel_config_budget.rs with justification."
+              BUDGET_${ARCH^^} in xtask/src/check_kernel_config_budget.rs with justification."
             exit 1
           fi
           RAW_BYTES=$(stat -c%s "staging/vmlinux-${ARCH}-workload")

--- a/xtask/src/check_kernel_config_budget.rs
+++ b/xtask/src/check_kernel_config_budget.rs
@@ -7,41 +7,58 @@
 //! reviewed choice rather than silent accretion, and keeps the "tiny kernel"
 //! property true over time instead of only at landing.
 //!
-//! Takes the path to a resolved kernel `.config` (the `workload-configfile`
-//! flake output). CI builds that output on a Linux runner and hands the path
-//! here, so the gate itself does no Nix evaluation and runs anywhere.
+//! Takes the path to a resolved kernel `.config` (the `workload-config-<arch>`
+//! flake output). The budget is **per-arch** — aarch64 carries more
+//! arch/platform built-ins than x86_64, so a single ceiling at the aarch64
+//! figure is slack for x86_64 and would miss an x86_64-only regression. The
+//! arch is inferred from the config path (`…-aarch64` / `…-x86_64`). CI builds
+//! the config on a Linux runner and hands the path here, so the gate does no
+//! Nix evaluation and runs anywhere.
 
 use anyhow::{Result, bail};
 use std::path::Path;
 
-/// Max built-in (`=y`) symbols allowed in the workload kernel config.
-///
-/// Set to the aarch64 measurement — the higher of the two arches (x86_64 is
-/// ~1130; aarch64 carries more arch/platform built-ins). Tighten on every
-/// shrink; raising it must be justified in the PR that does. Tracks the
-/// audit-subtraction pass that took the baseline 1716 → 1327 (PCI / EFI / MFD /
-/// I2C / GPIO / NFS / VFIO / IPMI / cpufreq / SPI / CORESIGHT / KVM / IOMMU and
-/// other off-the-boot-path subsystems), each cut boot-validated under libkrun.
-const KERNEL_Y_BUDGET: usize = 1327;
+/// Per-arch max built-in (`=y`) symbol counts. Tighten on every shrink; raising
+/// one must be justified in the PR that does. Tracks the audit-subtraction pass
+/// that took the baseline 1716 → these figures (PCI / EFI / MFD / I2C / GPIO /
+/// NFS / VFIO / IPMI / cpufreq / SPI / CORESIGHT / KVM / IOMMU / squashfs /
+/// suspend / SoC-errata and other off-the-boot-path subsystems), each cut
+/// boot-validated under libkrun.
+const BUDGET_AARCH64: usize = 1327;
+const BUDGET_X86_64: usize = 1130;
+
+/// Resolve the budget for a config path by the arch in its name. Unknown →
+/// the larger budget (fail-open on the ceiling, never a false pass on a real
+/// regression: an unrecognised arch still can't exceed the most generous bound).
+fn budget_for_path(path: &str) -> usize {
+    if path.contains("x86_64") {
+        BUDGET_X86_64
+    } else if path.contains("aarch64") {
+        BUDGET_AARCH64
+    } else {
+        BUDGET_AARCH64.max(BUDGET_X86_64)
+    }
+}
 
 pub fn run(args: &[String]) -> Result<()> {
     let Some(path) = args.first() else {
         bail!(
             "check-kernel-config-budget: needs a path to a resolved kernel .config \
-             (build the `workload-configfile` flake output and pass its path)"
+             (build the `workload-config-<arch>` flake output and pass its path)"
         );
     };
     let content = std::fs::read_to_string(Path::new(path))
         .map_err(|e| anyhow::anyhow!("reading kernel config {path}: {e}"))?;
+    let budget = budget_for_path(path);
     let count = count_builtins(&content);
-    evaluate_budget(&content, KERNEL_Y_BUDGET)?;
-    if count < KERNEL_Y_BUDGET {
+    evaluate_budget(&content, budget)?;
+    if count < budget {
         eprintln!(
             "check-kernel-config-budget: {count} built-in (=y) symbols \
-             (budget {KERNEL_Y_BUDGET}); ratchet KERNEL_Y_BUDGET down to {count}."
+             (budget {budget}); ratchet the matching BUDGET_* down to {count}."
         );
     } else {
-        eprintln!("check-kernel-config-budget: {count} built-in symbols (at budget)");
+        eprintln!("check-kernel-config-budget: {count} built-in symbols (at budget {budget})");
     }
     Ok(())
 }
@@ -62,7 +79,7 @@ pub fn evaluate_budget(config: &str, budget: usize) -> Result<()> {
         bail!(
             "check-kernel-config-budget: {count} built-in (=y) kernel symbols exceeds the \
              budget of {budget} — a new subsystem was compiled in. Drop it (each `=y` is \
-             attack surface), or, if genuinely required, bump KERNEL_Y_BUDGET in \
+             attack surface), or, if genuinely required, bump the matching BUDGET_<arch> in \
              xtask/src/check_kernel_config_budget.rs with a one-line justification in the PR."
         );
     }
@@ -95,5 +112,22 @@ mod tests {
     fn at_budget_passes() {
         let cfg = "CONFIG_A=y\nCONFIG_B=y\n";
         assert!(evaluate_budget(cfg, 2).is_ok());
+    }
+
+    #[test]
+    fn budget_resolves_per_arch_from_path() {
+        assert_eq!(
+            budget_for_path("staging/workload-config-aarch64"),
+            BUDGET_AARCH64
+        );
+        assert_eq!(
+            budget_for_path("staging/workload-config-x86_64"),
+            BUDGET_X86_64
+        );
+        // Unknown arch → the larger ceiling (never a false pass).
+        assert_eq!(
+            budget_for_path("/tmp/some.config"),
+            BUDGET_AARCH64.max(BUDGET_X86_64)
+        );
     }
 }


### PR DESCRIPTION
Closes one of the two deferred items from `specs/plans/209`.

A single `KERNEL_Y_BUDGET` ceiling (set to the aarch64 figure, the higher arch) is slack for x86_64 (~1130 vs 1327) — an x86_64-only regression of up to ~200 built-ins could slip through. This splits it per-arch:

- `BUDGET_AARCH64` / `BUDGET_X86_64` constants (single source of truth).
- The arch is inferred from the config path (`workload-config-<arch>`); unknown → the larger ceiling (never a false pass).
- The `kernel-build` CI lane reads the arch-specific constant (`BUDGET_${ARCH^^}`), so the per-arch gate runs on both runners.
- Unit-tested (arch inference + the existing budget logic), 5/5.

No runtime change — a tightened CI gate + constants.

---
**The other deferred item (push toward ~1005) is *not* in this PR.** I cut a safe Batch 6 (Cavium/Qualcomm CPU errata for silicon we never run on, squashfs we don't mount, suspend/hibernation a microVM never does — all dropped by the proven-minimal reference too) and the kernel built + measured **1291 aarch64 (−36)**, all cuts sticking. But I could not boot-validate it: current main has **three machine-CLI regressions** that block flake boot-validation — `up` retired (breaks the merged `--boot-check`), `machine wait` removed, and `machine run --flake` hits a `<flake-slot>` canonicalize bug. None relate to the kernel cuts. Per the project's boot-validate-every-cut discipline, Batch 6 stays deferred until those land a fix; the cut list + the `up`→`machine run --up-json` boot-check fix are ready to apply once flake-boot works again.