### PR TITLE
fix(machine): hash flake slot identities without canonicalizing

### DIFF
--- a/crates/mvm-cli/src/commands/build/build.rs
+++ b/crates/mvm-cli/src/commands/build/build.rs
@@ -9,8 +9,8 @@ use crate::ui;
 use mvm::vm::template::lifecycle as tmpl;
 use mvm_backend::image;
 use mvm_core::manifest::{
-    self, MANIFEST_SCHEMA_VERSION, Manifest, PersistedManifest, Provenance, canonical_key_for_path,
-    resolve_manifest_config_path,
+    self, MANIFEST_SCHEMA_VERSION, Manifest, PersistedManifest, Provenance,
+    key_for_manifest_identity, resolve_manifest_config_path,
 };
 use mvm_core::naming::validate_flake_ref;
 use mvm_core::user_config::MvmConfig;
@@ -666,25 +666,7 @@ pub(in crate::commands) fn build_flake_to_slot(
     // flake ref — it is never read from disk (the PersistedManifest records
     // the resolved flake_ref directly) and exists solely to give the slot
     // a stable sha256 key.
-    let synthetic_path_str = format!("<flake-slot>/{}", resolved);
-    let synthetic_path = std::path::Path::new(&synthetic_path_str);
-
-    let persisted = PersistedManifest {
-        schema_version: MANIFEST_SCHEMA_VERSION,
-        manifest_path: synthetic_path_str.clone(),
-        manifest_hash: canonical_key_for_path(synthetic_path)?,
-        flake_ref: resolved.clone(),
-        profile: profile.unwrap_or("default").to_string(),
-        vcpus: 2,
-        mem_mib: 512,
-        mem_initial_mib: None,
-        data_disk_mib: 0,
-        name: None,
-        backend,
-        provenance: Provenance::current(),
-        created_at: mvm_core::time::utc_now(),
-        updated_at: mvm_core::time::utc_now(),
-    };
+    let persisted = flake_slot_manifest(&resolved, profile, &backend);
 
     let slot_hash = persisted.manifest_hash.clone();
     let revision = tmpl::template_build_from_manifest(&persisted, false, false, mode)
@@ -693,6 +675,30 @@ pub(in crate::commands) fn build_flake_to_slot(
     audit_build_ok("flake-slot", &resolved, &slot_hash, &revision.revision_hash);
 
     Ok(slot_hash)
+}
+
+fn flake_slot_manifest(
+    resolved_flake_ref: &str,
+    profile: Option<&str>,
+    backend: &str,
+) -> PersistedManifest {
+    let synthetic_path = format!("<flake-slot>/{resolved_flake_ref}");
+    PersistedManifest {
+        schema_version: MANIFEST_SCHEMA_VERSION,
+        manifest_path: synthetic_path.clone(),
+        manifest_hash: key_for_manifest_identity(&synthetic_path),
+        flake_ref: resolved_flake_ref.to_string(),
+        profile: profile.unwrap_or("default").to_string(),
+        vcpus: 2,
+        mem_mib: 512,
+        mem_initial_mib: None,
+        data_disk_mib: 0,
+        name: None,
+        backend: backend.to_string(),
+        provenance: Provenance::current(),
+        created_at: mvm_core::time::utc_now(),
+        updated_at: mvm_core::time::utc_now(),
+    }
 }
 
 /// Read the volume's `meta.json.annotations.lockfile_sha256`. Returns
@@ -706,4 +712,23 @@ fn volume_lockfile_sha256(volume_dir: &std::path::Path) -> Option<String> {
         .get("lockfile_sha256")?
         .as_str()
         .map(str::to_string)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn flake_slot_manifest_hashes_synthetic_identity_without_canonicalizing() {
+        let resolved = "/tmp/flake-that-does-not-exist";
+        let persisted = flake_slot_manifest(resolved, Some("minimal"), "mock");
+
+        assert_eq!(persisted.manifest_path, format!("<flake-slot>/{resolved}"));
+        assert_eq!(
+            persisted.manifest_hash,
+            key_for_manifest_identity(&persisted.manifest_path)
+        );
+        assert_eq!(persisted.flake_ref, resolved);
+        assert_eq!(persisted.profile, "minimal");
+    }
 }

--- a/crates/mvm-core/src/domain/manifest.rs
+++ b/crates/mvm-core/src/domain/manifest.rs
@@ -492,6 +492,14 @@ pub fn resolve_manifest_config_path(path: &Path) -> Result<PathBuf> {
     Err(anyhow!("manifest path does not exist: {}", path.display()))
 }
 
+/// Registry key for an already-canonical manifest identity:
+/// `sha256(identity)` as 64-char hex.
+pub fn key_for_manifest_identity(identity: &str) -> String {
+    let mut hasher = sha2::Sha256::new();
+    hasher.update(identity.as_bytes());
+    format!("{:x}", hasher.finalize())
+}
+
 /// Canonical registry key for a manifest at `path`:
 /// `sha256(canonical_absolute_path)` as 64-char hex. Resolves
 /// symlinks so two access paths to the same file hash to the same
@@ -499,14 +507,11 @@ pub fn resolve_manifest_config_path(path: &Path) -> Result<PathBuf> {
 pub fn canonical_key_for_path(path: &Path) -> Result<String> {
     let canonical = std::fs::canonicalize(path)
         .with_context(|| format!("Failed to canonicalize {}", path.display()))?;
-    let bytes = canonical
+    let identity = canonical
         .as_os_str()
         .to_str()
-        .ok_or_else(|| anyhow!("canonical path contains non-UTF-8: {:?}", canonical))?
-        .as_bytes();
-    let mut hasher = sha2::Sha256::new();
-    hasher.update(bytes);
-    Ok(format!("{:x}", hasher.finalize()))
+        .ok_or_else(|| anyhow!("canonical path contains non-UTF-8: {:?}", canonical))?;
+    Ok(key_for_manifest_identity(identity))
 }
 
 /// Slot directory for a given canonical-path-hash:
@@ -1254,6 +1259,19 @@ mod tests {
         let via_dot = canonical_key_for_path(&tmp.path().join("./mvm.toml")).unwrap();
         assert_eq!(direct, via_dot);
         assert_eq!(direct.len(), 64);
+    }
+
+    #[test]
+    fn manifest_identity_key_hashes_non_filesystem_identities() {
+        let key = key_for_manifest_identity("abc");
+        assert_eq!(
+            key,
+            "ba7816bf8f01cfea414140de5dae2223b00361a396177a9cb410ff61f20015ad"
+        );
+
+        let synthetic = key_for_manifest_identity("<flake-slot>/github:tinylabscom/mvm#default");
+        assert_eq!(synthetic.len(), 64);
+        assert!(synthetic.chars().all(|c| c.is_ascii_hexdigit()));
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- add a manifest identity hash helper for non-filesystem slot identities
- use that helper for synthetic flake slots instead of canonicalizing `<flake-slot>/...`
- add focused regression coverage in mvm-core and mvm-cli

## Root cause
`machine run --flake` builds a flake into a synthetic manifest slot keyed by `<flake-slot>/<resolved-flake-ref>`. That identity is not a real filesystem path, but the slot code called `canonical_key_for_path`, so path canonicalization failed before boot validation could reach the runtime path.

## Validation
- `cargo test -p mvm-core manifest_identity_key_hashes_non_filesystem_identities`
- `cargo test -p mvm-cli flake_slot_manifest_hashes_synthetic_identity_without_canonicalizing`
- `cargo check --workspace`
- `cargo test --workspace`
- `cargo clippy --workspace --all-targets -- -D warnings`