### PR TITLE
fix(kernel): re-enable PCI/VIRTIO_PCI for vz — fixes #1297 (vz builder hang) + #1298 root cause

### DIFF
--- a/nix/images/kernel/base.nix
+++ b/nix/images/kernel/base.nix
@@ -47,12 +47,18 @@ let
   # `make olddefconfig` fills in transitive dependencies, so this names
   # only what we directly require.
   baseEnables = [
-    # virtio bus + transport (sans virtio-fs — that's builder-only;
-    # a sealed workload mounts no host shares). Shrink batch 3: PCI dropped —
-    # libkrun/Firecracker present virtio over the MMIO transport, so the whole
-    # PCI subsystem + its host-controller drivers are dead weight. virtio-pci
-    # goes with it; virtio-mmio carries every device.
-    "VIRTIO" "VIRTIO_MENU" "VIRTIO_MMIO"
+    # virtio bus + BOTH transports (sans virtio-fs — that's builder-only; a
+    # sealed workload mounts no host shares). Both transports are required
+    # because the backends differ: libkrun/Firecracker present virtio over
+    # MMIO, but **vz (Apple Virtualization.framework) presents virtio over
+    # PCI**. A kernel without PCI/VIRTIO_PCI boots blind under vz — no
+    # virtio-console (zero bytes on hvc0), no virtio-net, no virtio-block — so
+    # the vz builder + workload VMs hang at boot. PCI + PCI_MSI + VIRTIO_PCI
+    # therefore stay enabled; do not drop them as "MMIO-only dead weight" (that
+    # regression broke every vz boot on macOS). The generic ECAM PCI host
+    # controller AVF's bus needs comes from `make defconfig` once PCI is on.
+    "VIRTIO" "VIRTIO_MENU" "VIRTIO_MMIO" "VIRTIO_PCI"
+    "PCI" "PCI_MSI"
     "VIRTIO_BLK" "VIRTIO_NET" "VIRTIO_CONSOLE"
     "VSOCKETS" "VIRTIO_VSOCKETS" "VIRTIO_BALLOON"
     "HW_RANDOM" "HW_RANDOM_VIRTIO"
@@ -172,15 +178,16 @@ let
     "PINCTRL"              # SoC pin-mux
     "MFD_CORE"             # multi-function (PMIC) device core
 
-    # Shrink batch 3 — the whole PCI subsystem + host-controller drivers.
-    # Force-dropped (defconfig defaults it on) since virtio rides MMIO here.
-    "PCI"
+    # NOTE: PCI is intentionally NOT disabled — vz (Apple
+    # Virtualization.framework) presents virtio over PCI, so PCI + VIRTIO_PCI
+    # are in the enable list above. libkrun/Firecracker (MMIO) simply don't
+    # probe it. Dropping PCI here is what broke every vz boot on macOS.
 
     # Shrink batch 4 — more whole subsystems a sealed virtio microVM never
     # uses. Each cascades its family (drivers + helpers) via olddefconfig.
     "NFS_FS"               # no network filesystems mounted
     "PHYLIB" "MDIO_DEVICE" # ethernet PHY mgmt — virtio-net has no PHY
-    "VFIO"                 # device passthrough (and PCI is gone)
+    "VFIO"                 # device passthrough — unused (no PCI passthrough)
     "IPMI_HANDLER"         # no BMC / out-of-band mgmt
     "CPU_FREQ" "CPU_IDLE"  # no DVFS/idle-governor in a guest
     "SPI"                  # no SPI buses behind virtio (drops SPI flash/RTC/…)

--- a/xtask/src/check_kernel_config_budget.rs
+++ b/xtask/src/check_kernel_config_budget.rs
@@ -20,12 +20,21 @@ use std::path::Path;
 
 /// Per-arch max built-in (`=y`) symbol counts. Tighten on every shrink; raising
 /// one must be justified in the PR that does. Tracks the audit-subtraction pass
-/// that took the baseline 1716 → these figures (PCI / EFI / MFD / I2C / GPIO /
-/// NFS / VFIO / IPMI / cpufreq / SPI / CORESIGHT / KVM / IOMMU / squashfs /
-/// suspend / SoC-errata and other off-the-boot-path subsystems), each cut
-/// boot-validated under libkrun.
-const BUDGET_AARCH64: usize = 1327;
-const BUDGET_X86_64: usize = 1130;
+/// that took the baseline 1716 → these figures (EFI / MFD / I2C / GPIO / NFS /
+/// VFIO / IPMI / cpufreq / SPI / CORESIGHT / KVM / IOMMU / squashfs / suspend /
+/// SoC-errata and other off-the-boot-path subsystems), each cut boot-validated
+/// under libkrun.
+///
+/// PCI was re-added after the initial shrink dropped it: vz (Apple
+/// Virtualization.framework) presents virtio over PCI, not MMIO, so a PCI-less
+/// kernel boots blind under vz (no console/net/block). Re-enabling PCI +
+/// PCI_MSI + VIRTIO_PCI raised x86_64 by 73 (1130 → 1203, measured). aarch64 is
+/// set to a comparable delta (core PCI is arch-shared; the SoC PCIe host
+/// controllers stay off since their deps are disabled) and is confirmed by CI's
+/// native aarch64 config build — ratchet it to the count CI reports if it
+/// differs.
+const BUDGET_AARCH64: usize = 1420;
+const BUDGET_X86_64: usize = 1203;
 
 /// Resolve the budget for a config path by the arch in its name. Unknown →
 /// the larger budget (fail-open on the ceiling, never a false pass on a real


### PR DESCRIPTION
Closes #1297
Closes #1298

Fixes **#1297** (vz builder cold-build hang) and **#1298** (workload guest-agent timeout) — one root cause.

## Root cause
The slim-kernel shrink (`ca85ca03`) dropped **PCI + VIRTIO_PCI** from the shared `nix/images/kernel/base.nix` (rationale: "libkrun/Firecracker use MMIO"). But **vz (Apple Virtualization.framework) presents virtio over PCI**. With PCI gone, every vz guest sees zero virtio devices — no virtio-console (0-byte `hvc0`), no virtio-net, no virtio-block — so vz VMs boot blind and hang. Same `base.nix` underlies the builder VM and the workload, breaking both (#1297 builder, #1298 workload). libkrun/Firecracker (MMIO) were unaffected.

## Fix
Re-enable `PCI` + `PCI_MSI` + `VIRTIO_PCI` in `base.nix`; remove `PCI` from the disable list (with a comment so it isn't re-dropped). One kernel boots on all backends (vz=PCI, libkrun/FC=MMIO).

## Symbol-budget gate
x86_64 measured at **1203** (1130 → 1203, +73). aarch64 → 1420 (comparable delta; SoC PCIe controllers stay off via disabled deps) — CI's native aarch64 build confirms the exact figure; ratchet if it differs.

## Verification (macOS 26, live, end-to-end)
With PCI re-enabled, `machine run --image alpine -- echo "Hello anna"` **works end-to-end on the vz default path, both cold and warm**:
- vz **builder** boots (`EXT4-fs (vdb): mounted`, `mvm-guest-agent: control plane ready`, `mvm-builderd` listening) — was a 0-byte console + 30-min hang.
- cold OCI materialize (pull alpine → vz builder → ext4) succeeds.
- vz **workload** boots via `mvm-bridge` (`endpoint="vz_ingest"`), agent reachable → prints "Hello anna", VM stops cleanly. Exit 0.

(The `storage device attachment is invalid (VZErrorDomain:2)` seen mid-debugging was **transient state corruption** from killed/churned runs, not a real bug — it does not reproduce from clean state.)

## Minor non-blocking follow-ups observed (not in this PR)
- vz supervisor can leak an orphan on teardown (supervisor-reap).
- `host.audit.v1 unavailable` WARN when `mvm-host-agent` isn't on PATH (service-only; workload runs fine).

🤖 Generated with [Claude Code](https://claude.com/claude-code)