### PR TITLE
fix(sdk): restore hidden no-vm transport

### DIFF
--- a/crates/mvm-cli/src/commands/cmd_audit.rs
+++ b/crates/mvm-cli/src/commands/cmd_audit.rs
@@ -148,6 +148,7 @@ impl Commands {
             },
             Commands::Ls(a) => a.json,
             Commands::Run(a) => a.json,
+            Commands::SdkNoVm(_) => true,
             Commands::Machine(a) => match &a.action {
                 // Folded advanced ops delegate to their own check.
                 machine::MachineAction::Vm(cmd) => cmd.emits_machine_readable_stdout(),
@@ -201,6 +202,7 @@ impl Commands {
             Commands::Dev(_) => "dev",
             Commands::Ls(_) => "ls",
             Commands::Run(_) => "run",
+            Commands::SdkNoVm(_) => "__sdk-no-vm",
             Commands::Doctor(_) => "doctor",
             Commands::Manifest(_) => "manifest",
             Commands::Image(_) => "image",

--- a/crates/mvm-cli/src/commands/mod.rs
+++ b/crates/mvm-cli/src/commands/mod.rs
@@ -94,6 +94,9 @@ pub(in crate::commands) enum Commands {
     /// rather than break that transport.
     #[command(hide = true)]
     Run(vm::exec::RunArgs),
+    /// Internal SDK host-dispatch transport for `MVM_NO_VM=1`.
+    #[command(name = "__sdk-no-vm", hide = true)]
+    SdkNoVm(vm::sdk_no_vm::Args),
     /// Prepare the environment + pre-fetch the builder VM image
     ///
     /// Runs host-tooling setup and pre-acquires the builder VM image so the
@@ -310,6 +313,7 @@ pub fn run() -> Result<()> {
         Commands::Dev(a) => env::dev::run(&cli, a, &cfg),
         Commands::Ls(a) => vm::ps::run(&cli, a, &cfg),
         Commands::Run(a) => vm::exec::run_secure(&cli, a, &cfg),
+        Commands::SdkNoVm(a) => vm::sdk_no_vm::run(&a),
         Commands::Doctor(a) => env::doctor::run(&cli, a, &cfg),
         Commands::Build(a) => build::group::run(&cli, a, &cfg),
         Commands::Manifest(a) => manifest::run(&cli, a, &cfg),

--- a/crates/mvm-cli/src/commands/tests.rs
+++ b/crates/mvm-cli/src/commands/tests.rs
@@ -530,6 +530,40 @@ fn run_kept_hidden_as_sdk_transport() {
 }
 
 #[test]
+fn sdk_no_vm_kept_hidden_as_sdk_transport() {
+    let cli = Cli::try_parse_from([
+        "mvmctl",
+        "__sdk-no-vm",
+        "--language",
+        "python",
+        "--module",
+        "adder_mod",
+        "--function",
+        "add",
+        "--format",
+        "json",
+        "--source-path",
+        "/tmp/src",
+        "--stdin",
+        "-",
+    ])
+    .unwrap();
+    assert!(matches!(cli.command, Commands::SdkNoVm(_)));
+
+    let help = {
+        use clap::CommandFactory;
+        let mut cmd = Cli::command();
+        let mut buf = Vec::new();
+        cmd.write_long_help(&mut buf).unwrap();
+        String::from_utf8(buf).unwrap()
+    };
+    assert!(
+        !help.contains("__sdk-no-vm"),
+        "`__sdk-no-vm` must be hidden from top-level help"
+    );
+}
+
+#[test]
 fn invoke_removed() {
     let result = Cli::try_parse_from(["mvmctl", "invoke", "tmpl"]);
     assert!(

--- a/crates/mvm-cli/src/commands/vm/mod.rs
+++ b/crates/mvm-cli/src/commands/vm/mod.rs
@@ -28,6 +28,7 @@ pub(super) mod redaction_flags;
 pub(super) mod rekernel;
 pub(super) mod run_plan;
 pub(super) mod sandbox;
+pub(super) mod sdk_no_vm;
 pub(super) mod session;
 pub(super) mod set_ttl;
 pub(super) mod tenant_resolution;

--- a/crates/mvm-cli/src/commands/vm/sdk_no_vm.rs
+++ b/crates/mvm-cli/src/commands/vm/sdk_no_vm.rs
@@ -1,0 +1,230 @@
+//! Host-side SDK wrapper dispatch.
+//!
+//! Runs the workload wrapper directly on the host: no VM boot, no vsock, no
+//! Nix. This keeps the SDK's fast local-dispatch regression path available
+//! without restoring the retired public `invoke` command.
+
+use anyhow::{Context, Result, bail};
+use clap::Args as ClapArgs;
+use std::io::Write;
+use std::process::{Command, Stdio};
+
+const ONESHOT_PY: &str = include_str!("../../../../../nix/wrappers/python/oneshot.py");
+const ONESHOT_MJS: &str = include_str!("../../../../../nix/wrappers/node/oneshot.mjs");
+
+#[derive(ClapArgs, Debug, Clone)]
+pub(in crate::commands) struct Args {
+    /// Wrapper language.
+    #[arg(long, value_name = "LANGUAGE")]
+    pub language: Option<String>,
+    /// Importable user module.
+    #[arg(long, value_name = "MODULE")]
+    pub module: Option<String>,
+    /// Function name inside the module.
+    #[arg(long, value_name = "FUNCTION")]
+    pub function: Option<String>,
+    /// Payload serialization format.
+    #[arg(long, value_name = "FORMAT", default_value = "json")]
+    pub format: String,
+    /// Directory that should be importable as the user source root.
+    #[arg(long = "source-path", value_name = "PATH")]
+    pub source_path: Option<String>,
+    /// Stdin payload: a file path, or `-` for mvmctl's own stdin.
+    #[arg(long, value_name = "PATH")]
+    pub stdin: Option<String>,
+}
+
+#[derive(Debug)]
+struct NoVmConfig<'a> {
+    language: &'a str,
+    module: &'a str,
+    function: &'a str,
+    format: &'a str,
+    source_path: &'a str,
+}
+
+impl<'a> NoVmConfig<'a> {
+    fn from_args(args: &'a Args) -> Result<Self> {
+        let missing = |name: &str| -> anyhow::Error {
+            anyhow::anyhow!(
+                "__sdk-no-vm requires --{name}. The SDK passes \
+                 --language/--module/--function/--format/--source-path \
+                 when MVM_NO_VM=1."
+            )
+        };
+        Ok(Self {
+            language: args
+                .language
+                .as_deref()
+                .ok_or_else(|| missing("language"))?,
+            module: args.module.as_deref().ok_or_else(|| missing("module"))?,
+            function: args
+                .function
+                .as_deref()
+                .ok_or_else(|| missing("function"))?,
+            format: args.format.as_str(),
+            source_path: args
+                .source_path
+                .as_deref()
+                .ok_or_else(|| missing("source-path"))?,
+        })
+    }
+}
+
+pub(in crate::commands) fn run(args: &Args) -> Result<()> {
+    let stdin_bytes = super::invoke::read_stdin_payload(args.stdin.as_deref())?;
+    let exit_code = run_wrapper(args, stdin_bytes)?;
+    if exit_code != 0 {
+        std::process::exit(exit_code);
+    }
+    Ok(())
+}
+
+fn run_wrapper(args: &Args, stdin_bytes: Vec<u8>) -> Result<i32> {
+    let cfg = NoVmConfig::from_args(args)?;
+    if cfg.format != "json" && cfg.format != "msgpack" {
+        bail!(
+            "__sdk-no-vm: unsupported --format {:?} (must be \"json\" or \"msgpack\")",
+            cfg.format
+        );
+    }
+
+    let tmp = tempfile::tempdir().context("creating tempdir for __sdk-no-vm")?;
+
+    let wrapper_json_path = tmp.path().join("wrapper.json");
+    let wrapper_json = serde_json::to_vec(&serde_json::json!({
+        "module": cfg.module,
+        "function": cfg.function,
+        "format": cfg.format,
+        "working_dir": cfg.source_path,
+        "mode": "dev",
+    }))
+    .context("serializing wrapper.json")?;
+    std::fs::write(&wrapper_json_path, &wrapper_json)
+        .with_context(|| format!("writing {}", wrapper_json_path.display()))?;
+
+    let (wrapper_path, interpreter) = match cfg.language {
+        "python" => {
+            let path = tmp.path().join("wrapper.py");
+            std::fs::write(&path, ONESHOT_PY)
+                .with_context(|| format!("writing {}", path.display()))?;
+            (path, "python3")
+        }
+        "node" => {
+            let path = tmp.path().join("wrapper.mjs");
+            std::fs::write(&path, ONESHOT_MJS)
+                .with_context(|| format!("writing {}", path.display()))?;
+            (path, "node")
+        }
+        other => bail!(
+            "__sdk-no-vm: unsupported --language {other:?}. Built-in wrappers \
+             ship for `python` and `node`; wasm requires the VM path."
+        ),
+    };
+
+    let mut cmd = Command::new(interpreter);
+    cmd.arg(&wrapper_path);
+    cmd.env("MVM_WRAPPER_CONFIG_PATH", &wrapper_json_path);
+    match cfg.language {
+        "python" => {
+            cmd.env("PYTHONPATH", cfg.source_path);
+        }
+        "node" => {
+            cmd.env("NODE_PATH", cfg.source_path);
+        }
+        _ => unreachable!("language was validated above"),
+    }
+    cmd.stdin(Stdio::piped());
+    cmd.stdout(Stdio::inherit());
+    cmd.stderr(Stdio::inherit());
+
+    let mut child = cmd
+        .spawn()
+        .with_context(|| format!("spawning {interpreter}; is it on PATH?"))?;
+
+    if let Some(mut child_stdin) = child.stdin.take()
+        && !stdin_bytes.is_empty()
+    {
+        let _ = child_stdin.write_all(&stdin_bytes);
+    }
+
+    let status = child.wait().context("waiting on wrapper subprocess")?;
+    Ok(status.code().unwrap_or(1))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn empty_args() -> Args {
+        Args {
+            language: None,
+            module: None,
+            function: None,
+            format: "json".to_string(),
+            source_path: None,
+            stdin: None,
+        }
+    }
+
+    #[test]
+    fn from_args_requires_language() {
+        let args = empty_args();
+        let err = NoVmConfig::from_args(&args).unwrap_err();
+        assert!(err.to_string().contains("--language"), "{err}");
+    }
+
+    #[test]
+    fn from_args_requires_module() {
+        let mut args = empty_args();
+        args.language = Some("python".to_string());
+        let err = NoVmConfig::from_args(&args).unwrap_err();
+        assert!(err.to_string().contains("--module"), "{err}");
+    }
+
+    #[test]
+    fn from_args_requires_function() {
+        let mut args = empty_args();
+        args.language = Some("python".to_string());
+        args.module = Some("m".to_string());
+        let err = NoVmConfig::from_args(&args).unwrap_err();
+        assert!(err.to_string().contains("--function"), "{err}");
+    }
+
+    #[test]
+    fn from_args_requires_source_path() {
+        let mut args = empty_args();
+        args.language = Some("python".to_string());
+        args.module = Some("m".to_string());
+        args.function = Some("f".to_string());
+        let err = NoVmConfig::from_args(&args).unwrap_err();
+        assert!(err.to_string().contains("--source-path"), "{err}");
+    }
+
+    #[test]
+    fn from_args_succeeds_when_all_present() {
+        let mut args = empty_args();
+        args.language = Some("python".to_string());
+        args.module = Some("m".to_string());
+        args.function = Some("f".to_string());
+        args.source_path = Some("/tmp/src".to_string());
+        let cfg = NoVmConfig::from_args(&args).unwrap();
+        assert_eq!(cfg.language, "python");
+        assert_eq!(cfg.module, "m");
+        assert_eq!(cfg.function, "f");
+        assert_eq!(cfg.format, "json");
+        assert_eq!(cfg.source_path, "/tmp/src");
+    }
+
+    #[test]
+    fn embedded_wrappers_contain_envelope_marker() {
+        assert!(ONESHOT_PY.contains("MVM_ENVELOPE: "));
+        assert!(ONESHOT_MJS.contains("MVM_ENVELOPE: "));
+    }
+
+    #[test]
+    fn embedded_wrappers_honor_env_override() {
+        assert!(ONESHOT_PY.contains("MVM_WRAPPER_CONFIG_PATH"));
+        assert!(ONESHOT_MJS.contains("MVM_WRAPPER_CONFIG_PATH"));
+    }
+}

--- a/crates/mvm-cli/tests/core_demo_e2e.rs
+++ b/crates/mvm-cli/tests/core_demo_e2e.rs
@@ -1,6 +1,7 @@
 //! The core demo, end to end: `dev up` (builder VM) → `compile` the
-//! hello-app → `up` (build in-VM, boot, wait for the guest agent over
-//! vsock) → teardown. This is the regression guard for the whole spine.
+//! hello-app → `machine run --flake` (build in-VM, boot, wait for the
+//! guest agent over vsock) → teardown. This is the regression guard for
+//! the whole spine.
 //!
 //! Gated on `MVM_E2E_SMOKE=1` because it needs libkrun + the builder VM
 //! and runs for minutes; the default (ungated) run skips and passes.
@@ -11,9 +12,9 @@
 //! preferring libkrun over Vz on macOS 26+ (which is a deliberate Vz
 //! priority for general use; the demo wants the vsock path).
 //!
-//! `up` waits for the guest agent (`wait_for_guest_agent` → vsock Ping)
-//! and only prints `Guest agent not reachable.` on failure — so `up`
-//! exiting 0 *without* that line is the boot→ping proof.
+//! `machine run --flake` waits for the guest agent (`wait_for_guest_agent`
+//! → vsock Ping) and only prints `Guest agent not reachable.` on failure —
+//! so the command exiting 0 *without* that line is the boot→ping proof.
 //!
 //! NO-FREEZE design (this test cost multiple whole sessions, frozen).
 //! Two independent guards make a hang impossible:
@@ -38,6 +39,7 @@ const DEV_UP_BUDGET: Duration = Duration::from_secs(900);
 const COMPILE_BUDGET: Duration = Duration::from_secs(180);
 const UP_BUDGET: Duration = Duration::from_secs(900);
 const DOWN_BUDGET: Duration = Duration::from_secs(120);
+const WORKLOAD_NAME: &str = "core-demo-e2e";
 
 /// Outcome of one bounded `mvmctl` invocation.
 struct Step {
@@ -285,17 +287,22 @@ fn core_demo_dev_compile_up_ping() {
     );
     assert!(c.success, "compile failed: {}", c.output);
 
-    // 3) build + boot the workload microVM; `up` waits for the agent
-    //    over vsock (`wait_for_guest_agent` → protocol Ping). The proof
-    //    is twofold and scans BOTH streams (`up.output`): the wait
-    //    actually ran ("Waiting for guest agent...") AND it succeeded
+    // 3) build + boot the workload microVM; `machine run --flake` waits
+    //    for the agent over vsock (`wait_for_guest_agent` → protocol Ping).
+    //    The proof is twofold and scans BOTH streams (`up.output`): the
+    //    wait actually ran ("Waiting for guest agent...") AND it succeeded
     //    (no "Guest agent not reachable."). Checking only one of these
-    //    is how this test previously false-greened — `up` used to skip
-    //    the wait entirely on libkrun, and the warn line lands on
+    //    is how this test previously false-greened — the old boot path used
+    //    to skip the wait entirely on libkrun, and the warn line lands on
     //    stdout, not stderr.
     let up = mvmctl(
         &[
-            "up",
+            "machine",
+            "run",
+            "-d",
+            "--name",
+            WORKLOAD_NAME,
+            "--force",
             "--hypervisor",
             workload_hypervisor(),
             "--flake",
@@ -322,6 +329,12 @@ fn core_demo_dev_compile_up_ping() {
         up.output
     );
 
-    // 4) tear down the builder (best-effort, still bounded).
+    // 4) tear down the workload and builder (best-effort, still bounded).
+    let _ = mvmctl(
+        &["machine", "stop", WORKLOAD_NAME],
+        &scratch,
+        "machine-stop",
+        DOWN_BUDGET,
+    );
     let _ = mvmctl(&["dev", "down"], &scratch, "dev-down", DOWN_BUDGET);
 }

--- a/sdks/python/mvm/_remote.py
+++ b/sdks/python/mvm/_remote.py
@@ -128,12 +128,12 @@ DEFAULT_KILL_GRACE_SEC = 5.0
 # built.
 EMITTING_ENV_VAR = "MVM_EMITTING"
 
-# Slice E1b: setting MVM_NO_VM=1 routes dispatch through
-# `mvmctl invoke --no-vm`, which runs the wrapper directly on the
-# host (no VM boot, no vsock). Per-call module/function/source-path
-# are derived from the wrapped Python function via `inspect`. Only
-# valid for :class:`RemoteFunction` (cross-workload
-# :class:`WorkloadRef` calls have no local fn to introspect).
+# Setting MVM_NO_VM=1 routes dispatch through mvmctl's hidden SDK
+# host-wrapper transport, which runs the wrapper directly on the host
+# (no VM boot, no vsock). Per-call module/function/source-path are
+# derived from the wrapped Python function via `inspect`. Only valid
+# for :class:`RemoteFunction` (cross-workload :class:`WorkloadRef`
+# calls have no local fn to introspect).
 NO_VM_ENV_VAR = "MVM_NO_VM"
 
 
@@ -215,7 +215,7 @@ class NoVmIntrospectionError(MvmTransportError):
 
 
 def _no_vm_flags_for(fn: Callable[..., Any], format: str) -> list[str]:
-    """Derive the per-call `--no-vm` argv flags from the wrapped fn.
+    """Derive the per-call host-wrapper argv flags from the wrapped fn.
 
     The Rust side wants `--language` / `--module` / `--function` /
     `--format` / `--source-path` and uses these to write a temp
@@ -248,7 +248,6 @@ def _no_vm_flags_for(fn: Callable[..., Any], format: str) -> list[str]:
         ) from exc
     source_path = os.path.dirname(os.path.abspath(source_file))
     return [
-        "--no-vm",
         "--language", "python",
         "--module", module,
         "--function", function_name,
@@ -411,11 +410,11 @@ def _prepare_invoke(
     fn_selector: str | None = None,
     use_active_session: bool = True,
     fn: Callable[..., Any] | None = None,
-) -> tuple[list[str], bytes, float, int]:
+) -> tuple[list[str], bytes, float, int, str]:
     """Run pre-spawn checks shared by sync and async dispatch paths.
 
-    Returns ``(argv, payload, timeout_sec, output_cap_bytes)``. Raises
-    before any subprocess spawn, leaving no orphan process behind.
+    Returns ``(argv, payload, timeout_sec, output_cap_bytes, command_label)``.
+    Raises before any subprocess spawn, leaving no orphan process behind.
 
     ``fn_selector``: when set, append ``--fn <name>`` to the argv. The
     ``WorkloadRef`` proxy passes the attribute the user wrote so the
@@ -431,8 +430,8 @@ def _prepare_invoke(
 
     ``fn``: the wrapped Python function. Required when ``MVM_NO_VM=1``
     so the SDK can derive module / function / source-path from the
-    local definition and feed them to ``mvmctl invoke --no-vm``.
-    ``None`` is fine outside `--no-vm` mode.
+    local definition and feed them to mvmctl's hidden SDK no-VM transport.
+    ``None`` is fine outside no-VM mode.
     """
     _check_emitting_context(call_site)
     _check_id("workload_id", workload_id)
@@ -450,21 +449,24 @@ def _prepare_invoke(
     # after it as positional, so an id starting with `-` (already rejected
     # at IR + SDK level, but defense in depth) cannot be misparsed as a
     # flag. All optional flags must come *before* the separator.
-    argv: list[str] = [bin_path, "invoke"]
     no_vm = os.environ.get(NO_VM_ENV_VAR) == "1"
     if no_vm:
         if fn is None:
             raise NoVmIntrospectionError(
                 f"MVM_NO_VM=1 set but no local function available to "
-                f"introspect for {call_site}. --no-vm is only valid "
+                f"introspect for {call_site}. no-VM mode is only valid "
                 "for RemoteFunction calls; cross-workload WorkloadRef "
                 "dispatch requires a real VM."
             )
+        argv: list[str] = [bin_path, "__sdk-no-vm"]
+        command_label = "mvmctl __sdk-no-vm"
         argv += _no_vm_flags_for(fn, format)
-        # Sessions and --fn don't apply on the local-dispatch path:
-        # the wrapper picks `fn` from the inspected definition, and
+        # Sessions, --fn, and workload_id don't apply on the local-dispatch
+        # path: the wrapper picks `fn` from the inspected definition, and
         # there's no warm VM to attach to.
     else:
+        argv = [bin_path, "invoke"]
+        command_label = "mvmctl invoke"
         if use_active_session:
             session_id = current_session_id()
             if session_id is not None:
@@ -476,20 +478,28 @@ def _prepare_invoke(
     # mvmctl over our own stdin pipe; `--stdin -` tells mvmctl to
     # consume it rather than discarding stdin (default is empty).
     argv += ["--stdin", "-"]
-    argv += ["--", workload_id]
+    if not no_vm:
+        argv += ["--", workload_id]
     timeout = env_float("MVM_INVOKE_TIMEOUT_SEC", DEFAULT_INVOKE_TIMEOUT_SEC)
     cap = env_int("MVM_MAX_OUTPUT_BYTES", DEFAULT_MAX_OUTPUT_BYTES)
-    return argv, payload, timeout, cap
+    return argv, payload, timeout, cap, command_label
 
 
-def _decode_or_raise(workload_id: str, format: str, returncode: int, stdout: bytes, stderr: bytes) -> Any:
+def _decode_or_raise(
+    workload_id: str,
+    format: str,
+    returncode: int,
+    stdout: bytes,
+    stderr: bytes,
+    command_label: str,
+) -> Any:
     if returncode != 0:
         envelope = _parse_error_envelope(stderr)
         if envelope is not None:
             raise envelope
         msg = stderr.decode("utf-8", errors="replace").strip()
         raise MvmTransportError(
-            f"mvmctl invoke {workload_id} exited {returncode}: {msg or '(no stderr)'}"
+            f"{command_label} {workload_id} exited {returncode}: {msg or '(no stderr)'}"
         )
     return _decode(format, stdout)
 
@@ -505,7 +515,7 @@ def _invoke_sync(
     use_active_session: bool = True,
     fn: Callable[..., Any] | None = None,
 ) -> Any:
-    argv, payload, timeout, cap = _prepare_invoke(
+    argv, payload, timeout, cap, command_label = _prepare_invoke(
         call_site,
         workload_id,
         format,
@@ -524,15 +534,22 @@ def _invoke_sync(
         )
     except TransportTimeout as exc:
         raise MvmTransportError(
-            f"mvmctl invoke {workload_id} timed out after {timeout}s"
+            f"{command_label} {workload_id} timed out after {timeout}s"
         ) from exc
     except TransportOutputOverflow as exc:
         raise MvmTransportError(
-            f"mvmctl invoke {workload_id} exceeded {cap}-byte output cap"
+            f"{command_label} {workload_id} exceeded {cap}-byte output cap"
         ) from exc
     except FileNotFoundError as exc:
         raise MvmTransportError(f"failed to spawn mvmctl: {exc}") from exc
-    return _decode_or_raise(workload_id, format, proc.returncode, proc.stdout, proc.stderr)
+    return _decode_or_raise(
+        workload_id,
+        format,
+        proc.returncode,
+        proc.stdout,
+        proc.stderr,
+        command_label,
+    )
 
 
 async def _invoke_async(
@@ -546,7 +563,7 @@ async def _invoke_async(
     use_active_session: bool = True,
     fn: Callable[..., Any] | None = None,
 ) -> Any:
-    argv, payload, timeout, cap = _prepare_invoke(
+    argv, payload, timeout, cap, command_label = _prepare_invoke(
         call_site,
         workload_id,
         format,
@@ -608,7 +625,7 @@ async def _invoke_async(
         except asyncio.TimeoutError as exc:
             await _terminate_process_group()
             raise MvmTransportError(
-                f"mvmctl invoke {workload_id} timed out after {timeout}s"
+                f"{command_label} {workload_id} timed out after {timeout}s"
             ) from exc
     except asyncio.CancelledError:
         await _terminate_process_group()
@@ -616,10 +633,17 @@ async def _invoke_async(
 
     if len(stdout) > cap or len(stderr) > cap:
         raise MvmTransportError(
-            f"mvmctl invoke {workload_id} exceeded {cap}-byte output cap"
+            f"{command_label} {workload_id} exceeded {cap}-byte output cap"
         )
 
-    return _decode_or_raise(workload_id, format, proc.returncode or 0, stdout, stderr)
+    return _decode_or_raise(
+        workload_id,
+        format,
+        proc.returncode or 0,
+        stdout,
+        stderr,
+        command_label,
+    )
 
 
 class RemoteFunction:

--- a/sdks/python/tests/test_remote_no_vm_e2e.py
+++ b/sdks/python/tests/test_remote_no_vm_e2e.py
@@ -1,8 +1,8 @@
-"""End-to-end test for `mvmctl invoke --no-vm` against the real binary.
+"""End-to-end test for SDK no-VM dispatch against the real binary.
 
-Plan 60 Phase 5 Slice E1b. Validates the full SDK wire contract:
+Validates the full SDK wire contract:
 
-    Python SDK  --(encode args)-->  mvmctl invoke --no-vm
+    Python SDK  --(encode args)-->  mvmctl __sdk-no-vm
                                           |
                                           v
                                     embedded oneshot.py wrapper
@@ -99,7 +99,7 @@ def adder_module(tmp_path: Path) -> Iterator[object]:
 def _decorate(adder_module: object) -> mvm.RemoteFunction:
     """Wrap the imported `adder_mod.add` directly so its `__module__`
     points at `adder_mod` (not at this test file) — the SDK's
-    `--no-vm` argv-builder reads `fn.__module__` to tell mvmctl where
+    no-VM argv-builder reads `fn.__module__` to tell mvmctl where
     to import the function from.
     """
     return mvm.func(name="adder")(adder_module.add)
@@ -110,7 +110,7 @@ def test_no_vm_sync_roundtrip_returns_real_value(
     adder_module: object,
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    """``f.sync(2, 3) == 5`` against the real mvmctl --no-vm path."""
+    """``f.sync(2, 3) == 5`` against the real mvmctl no-VM path."""
     monkeypatch.setenv("MVM_NO_VM", "1")
     monkeypatch.setenv("MVM_MVM_BIN", str(real_mvmctl))
 
@@ -123,7 +123,7 @@ def test_no_vm_async_roundtrip_returns_real_value(
     adder_module: object,
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    """``await f(2, 3) == 5`` against the real mvmctl --no-vm path.
+    """``await f(2, 3) == 5`` against the real mvmctl no-VM path.
 
     Confirms the async dispatch path (the canonical SDK call form)
     works end-to-end, not just the sync escape hatch.

--- a/tests/audit_total_coverage.rs
+++ b/tests/audit_total_coverage.rs
@@ -391,6 +391,7 @@ const AUDIT_POSTURE: &[(&str, AuditPosture)] = &[
     // Sandbox transport (`run --mode live/plan`); its posture is unchanged.
     ("ls", AuditPosture::ReadOnly),
     ("run", AuditPosture::InteractiveOrControl),
+    ("__sdk-no-vm", AuditPosture::InteractiveOrControl),
     // Build / artifact / registry. Plan 178 (D1) — image/compile/validate/
     // kernel grouped under `build <sub>`.
     ("build", AuditPosture::DelegatesToSub(BUILD_SUB)),


### PR DESCRIPTION
## Summary

- restore SDK no-VM dispatch through hidden `mvmctl __sdk-no-vm`
- keep public `mvmctl invoke` retired and parser-covered
- migrate Python `MVM_NO_VM=1` to the hidden transport
- migrate gated `core_demo_e2e` from `up --flake` to `machine run -d --flake`

Closes #1293.

## Verification

- `cargo test -p mvm-cli sdk_no_vm --lib`
- `cargo test -p mvm-cli invoke_removed --lib`
- `cargo build -p mvmctl --bin mvmctl`
- `MVM_E2E_MVM_BIN=.mvm-test/target/debug/mvmctl uv run pytest tests/test_remote_no_vm_e2e.py`
- `cargo test -p mvmctl --test audit_total_coverage`
- `cargo test -p mvm-cli --test core_demo_e2e` (default gated skip/pass)
- `cargo clippy -p mvm-cli --all-targets -- -D warnings`

## Notes

- Attempted `cargo test --workspace`; it reached unrelated backend tests, then stalled in a nested `cargo build -p mvm-vm-host --bin mvm-vz-supervisor --bin mvm-bridge` spawned by `mvm-backend` and surfaced crates.io timeout warnings. The stuck parent/child test processes were reaped.
- Live `MVM_E2E_SMOKE=1` core demo boot was not run in this session.
