### PR TITLE
fix(pool): reap stale standbys on the launch path (no-daemon TTL enforcement)

### DIFF
--- a/crates/mvm-backend/src/standby_pool.rs
+++ b/crates/mvm-backend/src/standby_pool.rs
@@ -18,6 +18,14 @@ const HANDLE_FILE: &str = "standby.json";
 /// TTL by this factor before the reaper finally removes it.
 const PARKED_TTL_MULTIPLIER: u64 = 6;
 
+/// Default TTL the lazy reapers ([`SupervisorStandbyPool::reap_stale`]) apply to
+/// idle standbys. There is no daemon, so expiry is enforced on-use: both the
+/// launch path and `cache prune` reap standbys older than this. Set a little
+/// above the always-warm idle window (residency `idle_timeout`, 20 min) so a
+/// freshly-warmed spare survives to its next claim, while a one-off run's
+/// leftover spare is cleaned by the next mvmctl invocation.
+pub const STANDBY_POOL_TTL: std::time::Duration = std::time::Duration::from_secs(30 * 60);
+
 /// A view over `~/.mvm/pool/` (or a test root). Cheap to construct; all state is on disk.
 pub struct SupervisorStandbyPool {
     root: PathBuf,
@@ -199,6 +207,21 @@ fn set_mode_0700(p: &Path) -> Result<()> {
 mod tests {
     use super::*;
     use mvm_core::vm_backend::{StandbyCompat, StandbyHandle, StandbyState};
+
+    #[test]
+    fn standby_pool_ttl_exceeds_always_warm_idle_window() {
+        // The on-use reaper (launch path + `cache prune`) must not evict a
+        // freshly-warmed spare before its next claim, so the reap TTL has to sit
+        // above the always-warm idle window. If the residency idle window grows
+        // past this, the launch reaper would churn the very spare it warms.
+        let warm_idle = mvm_core::residency::ResidencyPolicy::always_warm()
+            .idle_timeout()
+            .expect("always-warm has an idle timeout");
+        assert!(
+            STANDBY_POOL_TTL > warm_idle,
+            "STANDBY_POOL_TTL {STANDBY_POOL_TTL:?} must exceed always-warm idle {warm_idle:?}"
+        );
+    }
 
     fn handle(id: &str, kernel: &str, state: StandbyState) -> StandbyHandle {
         StandbyHandle {

--- a/crates/mvm-cli/src/commands/ops/cache.rs
+++ b/crates/mvm-cli/src/commands/ops/cache.rs
@@ -387,8 +387,9 @@ pub(in crate::commands) fn run(_cli: &Cli, args: Args, _cfg: &MvmConfig) -> Resu
             // Reap stale supervisor standbys under `~/.mvm/pool/`.
             // The TTL guards a fresh pool (only dead-pid or expired standbys go); a
             // live-expired standby's entitled supervisor is SIGTERM'd before its dir is
-            // dropped, so idle entitled processes never accumulate.
-            const STANDBY_POOL_TTL: std::time::Duration = std::time::Duration::from_secs(30 * 60);
+            // dropped, so idle entitled processes never accumulate. Shares
+            // `STANDBY_POOL_TTL` with the launch-path reaper so both agree on "stale".
+            use mvm_backend::standby_pool::STANDBY_POOL_TTL;
             if dry_run {
                 if let Ok(pool) = mvm_backend::standby_pool::SupervisorStandbyPool::open()
                     && let Ok(n) = pool.list().map(|v| v.len())

--- a/crates/mvm-cli/src/commands/pool.rs
+++ b/crates/mvm-cli/src/commands/pool.rs
@@ -16,7 +16,7 @@ use anyhow::{Context, Result};
 use clap::{Args as ClapArgs, Subcommand};
 use mvm_backend::backend::AnyBackend;
 use mvm_backend::catalog::BackendKind;
-use mvm_backend::standby_pool::SupervisorStandbyPool;
+use mvm_backend::standby_pool::{STANDBY_POOL_TTL, SupervisorStandbyPool, now_unix_secs};
 use mvm_core::user_config::MvmConfig;
 use mvm_core::vm_backend::{
     StandbyClaim, StandbyCompat, StandbyHandle, StandbySpec, StandbyState, VmBackend, VmId,
@@ -370,6 +370,27 @@ fn warm_claim_plan_json(backend: &dyn VmBackend, cfg: &VmStartConfig) -> Option<
         Some(plan) => Some(plan),
         None if backend.name() == "firecracker" => Some(String::new()),
         None => None,
+    }
+}
+
+/// Lazily reap dead/expired standbys on the launch path — the no-daemon
+/// reap-on-use counterpart to [`replenish_after_launch`]. Without a background
+/// daemon nothing enforces the standby TTL between invocations, so every launch
+/// expires stale spares itself; otherwise a one-off run, or runs against
+/// different images, leave standbys resident until a manual `cache prune`
+/// (`reap_stale` is only otherwise wired into `cache prune`). Best-effort: a
+/// reap failure must never block a launch, so it is logged at debug and
+/// swallowed. Uses the same [`STANDBY_POOL_TTL`] as `cache prune` so the two
+/// reapers agree on what "stale" means.
+pub fn reap_stale_standbys_best_effort() {
+    match SupervisorStandbyPool::open()
+        .and_then(|pool| pool.reap_stale(STANDBY_POOL_TTL, now_unix_secs()))
+    {
+        Ok(reaped) if !reaped.is_empty() => {
+            tracing::debug!(count = reaped.len(), "reaped stale standbys on launch");
+        }
+        Ok(_) => {}
+        Err(e) => tracing::debug!(error = %e, "standby reap on launch failed (best-effort)"),
     }
 }
 

--- a/crates/mvm-cli/src/exec.rs
+++ b/crates/mvm-cli/src/exec.rs
@@ -642,6 +642,12 @@ fn run_inner(
     }
     let t_admitted = timing.then(std::time::Instant::now);
 
+    // Reap dead/expired standbys before claiming/booting. There is no daemon, so
+    // this on-use reap is what enforces the standby TTL between invocations —
+    // without it a one-off run (or runs against different images) leaves warm
+    // spares resident until a manual `cache prune`. Best-effort; never blocks.
+    crate::commands::pool::reap_stale_standbys_best_effort();
+
     // Try a warm-pool claim before snapshot/cold-boot. A claimed
     // standby is pre-booted to agent-ready and runs under its own standby-id, so
     // rebind `vm_name` for the Ctrl-C handler, run_in_guest, and teardown below.


### PR DESCRIPTION
## What this fixes
`SupervisorStandbyPool::reap_stale` (the standby TTL + dead-pid reaper) had exactly **one** production caller: `mvmctl cache prune`. Nothing on the launch path ran it. In the no-daemon model that means the standby TTL was **never enforced between invocations**:
- a warm spare left by a **one-off** `machine run` sat resident until a manual `cache prune`;
- spares left by runs against **different images** accumulated (claim-on-use only consumes a *compatible* live standby; it never reaps the rest).

## Fix
Add the reap-on-use counterpart to the existing replenish-on-use: every launch now calls `reap_stale_standbys_best_effort()` before claim/boot, expiring dead + aged standbys with the same `STANDBY_POOL_TTL` `cache prune` uses. Best-effort — a reap failure is logged at debug and never blocks a launch.

- Promote `STANDBY_POOL_TTL` from a file-local const in `cache.rs` to a shared `mvm_backend::standby_pool` const (single source of truth for "stale").
- New invariant test: the reap TTL must exceed the always-warm idle window (20 min) so the launch reaper never churns the spare it just warmed.

## Investigation notes (honest scope)
The user-observed "orphan `mvm-vz-supervisor` after a run" turned out to be mostly **not** a persistent leak:
- `stop_transient` correctly reaps the workload's supervisor/gvproxy/bridge (verified by PID-file vs process comparison).
- The lingering vz supervisor is the **detached `pool warm` rewarm** capturing a saved-standby — transient; it cleans up on completion/failure. After it settles the host is clean (verified).
- On the vz default tier the residency policy is `always-warm` (1 spare, 20-min idle) **by design** — bounded, not accumulating.

So this PR fixes the genuine latent gap (the reaper was never wired to the launch path). A **separate** follow-up: on vz the post-run rewarm boots a capture VM per run that currently records no registry entry locally — a wasted boot, worth its own look.

## Test
`cargo test -p mvm-backend` → 373 pass (incl. new `standby_pool_ttl_exceeds_always_warm_idle_window`); clippy clean; live-verified `machine run --image alpine` still works with the reap wired in, host clean after settle.

> Stacked on #1300 (branched off it for live testing on macOS 26). Rebase onto main after #1300 merges.

🤖 Generated with [Claude Code](https://claude.com/claude-code)