### PR TITLE
docs: plan attested fast first boot packs

### DIFF
--- a/specs/adrs/097-attested-downloadable-runtime-and-builder-packs.md
+++ b/specs/adrs/097-attested-downloadable-runtime-and-builder-packs.md
@@ -1,0 +1,231 @@
+# ADR-097 — Attested downloadable runtime and builder packs for fast first launch
+
+**Status:** Proposed
+**Date:** 2026-06-24
+**Relates to:** [ADR-041](041-signed-audited-execution-plans.md),
+[ADR-046](046-builder-vm-via-libkrun.md),
+[ADR-071](071-stage0-bootstrap-trust-model.md),
+[ADR-073](073-warm-snapshot-prior-art-adoption-boundary.md),
+[ADR-086](086-relocatable-dependency-free-host-bundle.md),
+[ADR-089](089-builder-vm-resident-control-plane.md),
+[ADR-095](095-slim-microvm-kernel.md)
+
+## Context
+
+mvm's product promise has two requirements that can pull against each other:
+
+1. **Attestable deterministic microVMs.** Workloads built from OCI images and
+   Nix flakes must be traceable back to pinned inputs, deterministic build
+   machinery, signed plans, and auditable launch decisions.
+2. **Fast first-use developer experience.** A user should not wait for a fresh
+   builder VM, Stage 0 bootstrap, Nix store population, kernel/image build, rootfs
+   materialization, and guest boot before seeing a shell or command result.
+
+The current architecture lets the builder VM sit on the critical path for fresh
+OCI and Nix work. That is correct for determinism, but poor for first-use
+latency. The mistake would be to remove Nix or the builder VM from the product;
+the better split is to remove them from the hot launch path when their outputs
+are already known and attestable.
+
+The key product question is not only "is this artifact signed?" It is:
+
+> Can a user prove exactly what launched, where it came from, what policy
+> admitted it, and whether local state changed it?
+
+That requires an attestation chain from source inputs through artifact
+publication, local verification, snapshot/warm derivation, launch admission, and
+command execution.
+
+## Decision
+
+### 1. Nix remains the build authority
+
+Nix remains the canonical mechanism for producing deterministic mvm runtime and
+builder artifacts. OCI tags are resolved to digests before build or admission.
+Flake inputs are locked before build. The builder VM remains the Linux execution
+boundary for local Nix evals/builds, OCI materialization, and private or
+unpublished project artifacts.
+
+The launch path changes: when a requested runtime, builder, image, or project
+artifact is already published and policy-compatible, the host verifies and
+consumes it instead of booting the builder VM to recreate it.
+
+### 2. Publish attested downloadable packs
+
+mvm publishes content-addressed, signed packs produced by CI or another
+controlled builder:
+
+- **Runtime pack** — slim kernel, initramfs or agent rootfs, guest agent,
+  launcher compatibility metadata, and capability declarations.
+- **Builder pack** — deterministic builder VM base disk, builder kernel/init
+  artifacts, seeded Nix closure for common mvm build paths, builder agent, and
+  builder capability declarations.
+- **Image/project pack** — optional prepared OCI or flake output artifacts,
+  rootfs/layer metadata, setup-cache layers, and admission sidecars.
+
+Every pack carries a manifest with:
+
+- Pack kind, schema version, target architecture, backend compatibility, and
+  required host capabilities.
+- Input identities: flake lock hashes, derivation paths, NAR hashes, OCI image
+  digests, setup command hashes, policy hashes, source revisions, and toolchain
+  versions.
+- Output identities: content hashes for every file, aggregate pack hash,
+  closure hash, rootfs hash, kernel hash, initramfs or agent-rootfs hash, and
+  builder-image hash where applicable.
+- Provenance: builder identity, build environment identity, build timestamp,
+  reproducibility status, SBOM reference, and signature bundle.
+- Trust metadata: signing key id, expiry, revocation channel, transparency-log
+  reference when available, and artifact-channel identity.
+
+The pack hash, not a mutable channel name, is the runtime identity. Channels may
+point to packs, but launches record the resolved pack hash.
+
+### 3. Local launch verifies first, builds only on cache miss or policy demand
+
+The host runtime has three launch states:
+
+| State | Behavior |
+|---|---|
+| Prepared and verified locally | Create CoW sandbox, claim warm VM or restore local snapshot, launch |
+| Downloadable and policy-compatible | Download, verify, populate cache, derive local snapshot or warm standby, launch |
+| Unavailable, private, mutable, or policy-rebuild-required | Use the builder VM prepare path, then launch from the produced artifact |
+
+This removes builder-VM time from first launch only when a suitable attested
+artifact is already local or downloadable. It does not weaken the guarantee for
+novel local flakes, private OCI sources, mutable tags that cannot resolve to a
+digest, or enterprise policies that require local rebuild verification.
+
+### 4. Builder VM becomes a fast prepared capability
+
+The builder VM remains core to the product, but it is itself delivered as an
+attested pack and prepared for fast use:
+
+- The base builder disk is read-only and verified by content hash.
+- Local builder use creates a writable CoW overlay.
+- The builder boots to a minimal builder-agent-ready state.
+- The host creates a local builder-ready snapshot after verifying the builder
+  pack and before injecting project secrets.
+- A warm builder standby may be kept resident for developer sessions.
+
+The published artifact is the deterministic builder disk/kernel/init identity.
+Memory snapshots are local derived artifacts because they depend on host,
+backend, and version details.
+
+### 5. Snapshots and warm standbys are local derived artifacts
+
+mvm does not treat published memory snapshots as globally reproducible artifacts.
+Instead:
+
+1. Verify a signed runtime or builder pack.
+2. Boot it locally to an agent-ready state.
+3. Record a local snapshot derivation event containing parent pack hash, host
+   architecture, backend id, backend version, memory/CPU shape, policy hash, and
+   agent readiness proof.
+4. Use that local snapshot or warm standby for fast launches.
+
+Snapshots must be created before per-run secrets, registry credentials, SSH
+agents, project-private material, or user data are injected. Per-run secrets are
+mounted or sent only after restore/claim and are never captured into base
+snapshots.
+
+### 6. Launch attestation is first-class
+
+Every launched microVM produces a launch attestation record. The record links:
+
+```
+source inputs
+-> build derivation or OCI digest
+-> builder identity
+-> artifact pack
+-> local verification
+-> local snapshot or warm standby derivation
+-> admission policy decision
+-> command execution record
+```
+
+Each arrow is represented by a hash, signature, policy decision, or audit event.
+The launch record includes the exact command, plan hash, network policy hash,
+artifact hashes, snapshot/warm identity, backend identity, launcher version,
+time, and result.
+
+This record is stored in a tamper-evident local audit log. Future remote
+transparency logging may mirror selected records, but the local record is the
+minimum viable audit surface.
+
+### 7. The CLI explains fast-path eligibility and trust
+
+mvm exposes user-facing explanations instead of silent fallback:
+
+- `mvm prepare <image-or-flake>` fetches/builds/verifies artifacts and warms the
+  runtime where policy allows.
+- `mvm cache status` shows local packs, sizes, expiry, revocation status, and
+  whether instant launch is ready.
+- `mvm explain <run-id>` explains what launched, what admitted it, which
+  artifact and snapshot were used, and why the builder VM was or was not needed.
+- `machine run` reports preparation reasons when instant launch is unavailable:
+  missing pack, expired signature, revoked signer, unsupported backend, local
+  rebuild required, mutable input, private input, or incompatible policy.
+
+### 8. Cache and update behavior is fail-closed
+
+The artifact cache is content-addressed and permission-hardened. Downloads and
+extractions happen in quarantine paths, are fully verified, and are promoted
+atomically only after all hashes and signatures match. Every use revalidates the
+pack manifest and policy compatibility before launch.
+
+Artifacts have expiry and revocation metadata. mvm supports key rotation,
+artifact-channel pinning, enterprise mirrors, offline mode, and local rebuild
+verification. A stale but validly signed artifact is not trusted forever unless
+policy explicitly permits that channel and expiry state.
+
+## Consequences
+
+**Positive**
+
+- First launch can avoid builder-VM boot and Nix materialization when the needed
+  artifact is already local or downloadable.
+- Nix remains the deterministic source of truth for runtime, builder, OCI, and
+  flake-derived artifacts.
+- The builder VM remains a core feature, but becomes a prepared/warm capability
+  rather than a mandatory first-command dependency.
+- Launches become more auditable: users can prove the exact artifact, policy,
+  snapshot, backend, and command involved in a run.
+- Enterprise users get a clean model for mirrors, channel pins, local rebuild
+  requirements, and offline operation.
+
+**Negative / costs**
+
+- The release pipeline becomes security-critical: pack manifests, signatures,
+  SBOMs, revocation, expiry, and transparency references must be correct.
+- Local cache management becomes a user-visible product surface with disk,
+  network, and cleanup expectations.
+- Snapshot identity and invalidation become part of the trust model.
+- Some first launches remain slow by design: private flakes, unpublished OCI
+  digests, mutable inputs, and policies that require local rebuilds still need
+  the builder VM prepare path.
+- The CLI must clearly distinguish "instant because prepared and attested" from
+  "preparing deterministically before launch."
+
+## Alternatives considered
+
+- **Remove Nix from the development launch layer entirely.** Rejected. It would
+  weaken the product's deterministic and attestable build promise. The correct
+  move is to consume Nix-produced artifacts on the hot path, not to replace Nix.
+- **Always build locally in the builder VM.** Rejected as the default. It is the
+  strongest local-rebuild story but makes fast first-use UX impossible on fresh
+  machines and wastes work for public, already-built artifacts.
+- **Ship only runtime packs, not builder packs.** Rejected. The builder VM is a
+  user-visible capability and must also have a fast prepared path.
+- **Publish memory snapshots as release artifacts.** Rejected. Memory snapshots
+  are backend/version/host-shape sensitive and may capture state that should
+  remain local. Publish deterministic disk/kernel/init artifacts and derive
+  snapshots locally.
+- **Trust signed packs without launch records.** Rejected. Artifact attestation
+  alone does not prove what was launched or whether local state modified it.
+
+## Required follow-up
+
+Plan 213 implements this decision: pack schema, release publishing, cache
+verification, runtime fast path, builder fast path, audit/explain surfaces, and
+latency/security gates.

--- a/specs/plans/213-attested-fast-first-boot-packs.md
+++ b/specs/plans/213-attested-fast-first-boot-packs.md
@@ -1,0 +1,296 @@
+# Plan 213 — Attested fast-first-boot packs
+
+**Status: Proposed**
+**Owner:** mvm
+**Date:** 2026-06-24
+**Depends on:** [ADR-097](../adrs/097-attested-downloadable-runtime-and-builder-packs.md),
+[ADR-041](../adrs/041-signed-audited-execution-plans.md),
+[ADR-046](../adrs/046-builder-vm-via-libkrun.md),
+[ADR-071](../adrs/071-stage0-bootstrap-trust-model.md),
+[ADR-073](../adrs/073-warm-snapshot-prior-art-adoption-boundary.md),
+[ADR-095](../adrs/095-slim-microvm-kernel.md),
+[Plan 199](199-host-runtime-packaging-and-crate-boundaries.md),
+[Plan 212](212-subsecond-machine-run.md)
+
+## Goal
+
+Make first-use developer launches fast without weakening mvm's deterministic,
+attestable microVM promise.
+
+The target user-visible shape is:
+
+- Public/common runtime, builder, OCI, and flake-derived artifacts can be
+  downloaded, verified, prepared, and warmed before the first explicit
+  `machine run`.
+- The builder VM remains the deterministic local build boundary for private,
+  unpublished, mutable, or policy-rebuild-required inputs.
+- A prepared run does not boot the builder VM. It verifies local artifacts,
+  creates a CoW sandbox, claims a warm VM or restores a local snapshot, records
+  launch attestation, and dispatches over vsock.
+- Every run can be explained after the fact: exact inputs, artifact hashes,
+  signatures, policy decision, snapshot/warm source, backend identity, command,
+  and result.
+
+## Non-goals
+
+- Do not remove Nix from OCI or flake build authority.
+- Do not move Nix evals/builds out of the builder VM for local source builds.
+- Do not publish release memory snapshots as globally trusted artifacts.
+- Do not inject secrets before snapshot capture.
+- Do not make a mutable OCI tag or unlocked flake eligible for instant launch.
+- Do not silently fall back from attested launch to an unattested path.
+- Do not require host Nix for the normal installed-user path.
+
+## Definitions
+
+- **Pack:** A signed, content-addressed artifact bundle with a manifest,
+  provenance, hashes, capability metadata, and trust metadata.
+- **Runtime pack:** Kernel, initramfs or agent rootfs, guest agent, and backend
+  compatibility metadata.
+- **Builder pack:** Builder VM base disk, builder kernel/init artifacts, seeded
+  Nix closure, builder agent, and builder capability metadata.
+- **Image/project pack:** Prepared OCI or flake output artifacts, setup-cache
+  layers, rootfs metadata, and admission sidecars.
+- **Local derived snapshot:** A host-created snapshot derived from a verified
+  pack and recorded in the local audit log. It is not a published trust root.
+- **Launch attestation:** The per-run record linking source inputs, artifact
+  verification, local snapshot/warm identity, policy admission, command, and
+  result.
+
+## Product states
+
+| State | CLI behavior | Builder VM involvement |
+|---|---|---|
+| Prepared and verified locally | Launch immediately from warm VM or snapshot | None |
+| Downloadable and policy-compatible | Download, verify, cache, prepare, launch | None |
+| Missing/private/mutable/rebuild-required | Explain preparation, build in builder VM, cache result, launch | Required |
+| Verification or policy failure | Refuse and explain | None unless user explicitly rebuilds |
+
+## Workstreams
+
+### A. Pack identity, schema, and verification core
+
+- [ ] Add pack manifest types for runtime, builder, and image/project packs.
+- [ ] Represent pack kind, schema version, architecture, backend compatibility,
+      required host capabilities, and policy compatibility as typed fields.
+- [ ] Represent input identities: flake lock hashes, derivation paths, NAR
+      hashes, OCI digests, setup-command hashes, source revisions, and
+      toolchain versions.
+- [ ] Represent output identities: pack hash, file hashes, closure hash, rootfs
+      hash, kernel hash, initramfs or agent-rootfs hash, and builder-image hash.
+- [ ] Represent provenance: builder identity, build environment identity, build
+      timestamp, reproducibility status, SBOM reference, and signature bundle.
+- [ ] Represent trust metadata: signing key id, expiry, revocation channel,
+      channel identity, mirror identity, and optional transparency-log reference.
+- [ ] Add serde roundtrip tests for every manifest type.
+- [ ] Add negative parser tests for missing hashes, unsupported schema versions,
+      mutable OCI references, expired trust metadata, and incompatible
+      architecture/backend declarations.
+- [ ] Add a verifier API that validates manifest schema, file hashes, aggregate
+      pack hash, signature bundle, expiry, revocation status, and local policy.
+- [ ] Add tamper tests proving changed file contents, changed manifests,
+      mismatched pack hashes, and revoked/expired signatures are rejected.
+
+### B. Release production and artifact publishing
+
+- [ ] Extend the release pipeline to produce runtime packs for each supported
+      host architecture/backend pair.
+- [ ] Extend the release pipeline to produce builder packs for each supported
+      builder architecture.
+- [ ] Include seeded Nix closures for common mvm build and materialization paths
+      in builder packs.
+- [ ] Emit SBOMs, checksums, signatures, provenance, and pack manifests for every
+      release pack.
+- [ ] Add release verification checks that fail closed when any pack lacks a
+      manifest, signature bundle, checksum, SBOM, or expected version metadata.
+- [ ] Add a reproducibility verification job that rebuilds at least one published
+      runtime pack and one published builder pack from source pins and compares
+      output hashes.
+- [ ] Document the release artifact matrix and channel semantics in the release
+      notes or packaging reference.
+
+### C. Hardened local artifact cache
+
+- [ ] Add a content-addressed pack cache under the existing mvm cache helpers,
+      respecting `MVM_CACHE_DIR` and XDG isolation.
+- [ ] Download and extract packs into quarantine paths before atomic promotion.
+- [ ] Enforce restrictive permissions on cache directories and promoted pack
+      contents.
+- [ ] Reverify manifest, hashes, signatures, expiry, revocation, and policy
+      compatibility before every use.
+- [ ] Add cache indexes for pack hash, kind, architecture, backend, channel,
+      expiry, size, and last-used time.
+- [ ] Implement `mvm cache status` showing local packs, readiness, size, expiry,
+      revocation state, and instant-launch eligibility.
+- [ ] Implement `mvm cache prune` with policy-aware deletion that refuses to
+      remove packs needed by active snapshots or warm standbys.
+- [ ] Add tests for interrupted downloads, partial extraction, atomic promotion,
+      permission hardening, cache poisoning attempts, and policy-aware pruning.
+
+### D. Install and prepare UX
+
+- [ ] Add install-time or first `mvm dev up` preparation for the default runtime
+      pack and builder pack when network and policy allow.
+- [ ] Add `mvm prepare <image-or-flake>` to resolve inputs, download or build
+      packs, verify them, and optionally derive local snapshots/warm standbys.
+- [ ] Add `mvm prepare --dry-run <image-or-flake>` showing download size, cache
+      impact, builder-VM need, trust state, and expected fast-path eligibility.
+- [ ] Make `machine run` report precise preparation reasons when instant launch
+      is unavailable: missing pack, mutable input, private input, expired
+      signature, revoked signer, unsupported backend, incompatible host, or local
+      rebuild required.
+- [ ] Add CLI integration tests for prepared fast-path messages, cache-miss
+      messages, policy-refusal messages, and explicit builder-VM prepare
+      messages.
+- [ ] Update CLI reference and getting-started docs for prepare/cache behavior.
+
+### E. Runtime pack launch path
+
+- [ ] Add a launch path that consumes a verified runtime pack without booting the
+      builder VM.
+- [ ] Create per-run CoW sandboxes from prepared image/project artifacts.
+- [ ] Derive an agent-ready local runtime snapshot after verifying the runtime
+      pack and before injecting secrets.
+- [ ] Record snapshot derivation events with parent pack hash, backend id,
+      backend version, memory/CPU shape, policy hash, and agent readiness proof.
+- [ ] Prefer warm-standby claim for prepared runs; fall back to local snapshot
+      restore; fall back to prepared cold direct boot; fall back to builder
+      prepare only when required.
+- [ ] Dispatch commands over the guest agent transport rather than SSH or
+      network readiness.
+- [ ] Add tests proving prepared launches do not invoke the builder VM path.
+- [ ] Add tests proving per-run secrets are injected only after claim/restore and
+      are not present in base snapshots.
+- [ ] Add live evidence capture for prepared runtime launch latency across warm
+      claim, snapshot restore, and prepared cold direct boot.
+
+### F. Fast builder VM path
+
+- [ ] Add builder-pack verification and local cache resolution.
+- [ ] Boot the verified builder base disk with a writable CoW overlay.
+- [ ] Seed the builder VM with the published Nix closure from the builder pack.
+- [ ] Derive a local builder-ready snapshot after the builder agent and Nix
+      readiness checks pass.
+- [ ] Add an optional warm builder standby during `mvm dev up`.
+- [ ] Ensure project secrets, registry credentials, SSH agents, and local source
+      material are injected after builder snapshot restore, never before
+      snapshot capture.
+- [ ] Route private flakes, unpublished OCI digests, mutable inputs, and
+      policy-rebuild-required inputs through the fast builder path.
+- [ ] Add tests proving builder snapshot invalidation when builder pack hash,
+      backend version, memory/CPU shape, Nix closure hash, or policy hash
+      changes.
+- [ ] Add live evidence capture for builder cold boot, builder snapshot restore,
+      and warm builder claim latency.
+
+### G. OCI and flake artifact preparation
+
+- [ ] Resolve OCI tags to digests before pack eligibility or admission.
+- [ ] Reject instant launch for mutable OCI inputs that cannot be resolved to a
+      digest under current policy.
+- [ ] Resolve flake inputs to committed locks before pack eligibility or
+      admission.
+- [ ] Build unpublished or private OCI/flake artifacts inside the builder VM and
+      publish them only to the local content-addressed cache unless the user
+      explicitly exports them.
+- [ ] Key setup-cache layers by image digest, flake lock hash, setup command
+      hash, environment-relevant inputs, mount shape, runtime pack hash, and
+      policy hash.
+- [ ] Add positive and negative tests for OCI digest resolution, flake lock
+      resolution, setup-cache hits, and setup-cache invalidation.
+
+### H. Launch attestation and explainability
+
+- [ ] Define the launch attestation record linking source input, builder
+      identity, pack identity, local verification, snapshot/warm derivation,
+      policy admission, command, and result.
+- [ ] Store launch records in a tamper-evident local audit log.
+- [ ] Include command, plan hash, network policy hash, artifact hashes,
+      snapshot/warm identity, backend identity, launcher version, timestamps,
+      exit status, and output digest metadata.
+- [ ] Implement `mvm explain <run-id>` for successful launches, builder-prepare
+      launches, cache misses, and refusals.
+- [ ] Add tests proving audit records are emitted on success, refusal, builder
+      fallback, verification failure, and interrupted launch.
+- [ ] Add tamper tests proving modified audit records are detected.
+
+### I. Revocation, mirrors, and enterprise policy
+
+- [ ] Add artifact-channel configuration with pinned channel identity and signing
+      key set.
+- [ ] Add revocation metadata fetching and offline-cache behavior.
+- [ ] Add key rotation support that accepts overlapping keys only within an
+      explicit policy window.
+- [ ] Add enterprise mirror configuration for pack downloads and revocation
+      metadata.
+- [ ] Add policy modes for online default, offline pinned, mirror-only, and
+      local-rebuild-required operation.
+- [ ] Add tests for revoked artifacts, expired artifacts, stale revocation
+      metadata, mirror mismatch, offline pinned launch, and local-rebuild
+      enforcement.
+- [ ] Document channel pinning, mirror setup, offline operation, and revocation
+      behavior.
+
+### J. Metrics, proof gates, and regression tests
+
+- [ ] Instrument launch phases: artifact resolution, verification, CoW sandbox
+      creation, warm claim, snapshot restore, guest-agent readiness, command
+      dispatch, and teardown.
+- [ ] Instrument builder phases: pack resolution, verification, CoW overlay
+      creation, builder cold boot, builder snapshot restore, builder warm claim,
+      Nix readiness, and materialization.
+- [ ] Add an evidence harness that records p50/p95 for prepared warm claim,
+      prepared snapshot restore, prepared cold direct boot, downloadable pack
+      first use, builder warm claim, and builder snapshot restore.
+- [ ] Add a regression gate for the prepared warm path once the live baseline is
+      measured on the supported macOS backend.
+- [ ] Add a regression gate ensuring prepared runtime launch does not call the
+      builder path.
+- [ ] Add a regression gate ensuring builder pack verification happens before
+      any builder snapshot or warm claim is used.
+- [ ] Publish evidence artifacts outside the repository tree and summarize them
+      in the plan before marking implementation complete.
+
+### K. Documentation and migration
+
+- [ ] Update `public/src/content/docs/reference/cli-commands.md` for
+      `mvm prepare`, `mvm cache status`, `mvm cache prune`, and `mvm explain`.
+- [ ] Update installation docs to describe install-time pack preparation,
+      download sizes, cache locations, opt-out, and offline/mirror behavior.
+- [ ] Update architecture docs to show build plane vs run plane and the artifact
+      attestation chain.
+- [ ] Update troubleshooting docs for cache verification failures, revocation
+      failures, local rebuild requirements, and builder-pack incompatibility.
+- [ ] Update `specs/SPRINT.md` and `specs/REFACTOR-STATUS.md` as workstreams
+      land.
+
+## Security invariants
+
+- Every launch must either verify an attested artifact chain or explicitly build
+  through the builder VM before launch.
+- Mutable inputs are not instant-launch eligible.
+- A signature alone is insufficient; pack hash, file hashes, expiry,
+  revocation, policy compatibility, and backend compatibility all have to pass.
+- Local snapshots derive from verified packs and are invalidated by parent pack,
+  backend, shape, policy, or readiness-proof changes.
+- Secrets are injected only after restore/claim and are never captured into base
+  runtime or builder snapshots.
+- Cache population is quarantine-first and atomic-promote only after full
+  verification.
+- Audit records are emitted for success, refusal, fallback, and failure.
+
+## Completion criteria
+
+- A fresh installed environment can run a prepared public image without booting
+  the builder VM on the launch path.
+- A fresh installed environment can use a verified builder pack without a full
+  Stage 0 rebuild on the first builder use.
+- A private or unpublished flake still builds through the builder VM and records
+  that fact in launch attestation.
+- `mvm explain <run-id>` can reconstruct the artifact, policy, snapshot/warm,
+  backend, and command chain for representative success and refusal cases.
+- Security tests cover tampered packs, revoked signatures, expired metadata,
+  poisoned cache entries, mutable inputs, and secret-before-snapshot prevention.
+- Live evidence records prepared warm-claim, prepared snapshot-restore,
+  prepared cold-direct-boot, builder warm-claim, and builder snapshot-restore
+  timings.


### PR DESCRIPTION
## Summary
- Adds ADR-097 for attested downloadable runtime, builder, and image/project packs
- Adds Plan 213 with implementation workstreams for pack schema, cache verification, fast runtime launch, fast builder launch, attestation, revocation, and evidence gates
- Preserves Nix and the builder VM as deterministic build authority while moving verified prepared artifacts off the launch hot path

## Verification
- git diff --check