### PR TITLE
fix(release): ship per-VM host binaries (mvm-bridge etc.) for downloaded installs

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -92,6 +92,36 @@ jobs:
           OPENSSL_VENDORED: 1
         run: cargo build --release --target "${TARGET}" --features "${MVMCTL_RELEASE_FEATURES}"
 
+      # The per-VM host processes mvmctl spawns at runtime (one process per
+      # guest). They are SEPARATE bin targets in `mvm-vm-host` — the root
+      # `cargo build` above only produces `mvmctl`, so without this step a
+      # downloaded (non-source) install has no `mvm-bridge` and the backend's
+      # adjacent-to-exe resolver (which also checks `MVM_BRIDGE_PATH` and the
+      # source-tree `target/`) finds nothing. They ship next to `mvmctl` in the
+      # tarball below so the resolver locates them.
+      #   - mvm-bridge: cross-platform external-VMM gateway/audit sidecar
+      #     (Firecracker passt + vz VzIngest). Builds everywhere, no extra deps.
+      #   - mvm-vz-supervisor (macOS only): the vz VMM supervisor.
+      #   - mvm-libkrun-supervisor (macOS only here): needs the libkrun-sys FFI,
+      #     which links libkrun — installed on the macOS runner above but not on
+      #     Linux ("Linux uses Firecracker"). Linux libkrun-supervisor packaging
+      #     needs a Linux libkrun build step — tracked as a follow-up.
+      - name: Build per-VM host binaries
+        env:
+          TARGET: ${{ matrix.target }}
+          OPENSSL_STATIC: 1
+          OPENSSL_VENDORED: 1
+        shell: bash
+        run: |
+          if [[ "${TARGET}" == *apple-darwin ]]; then
+            cargo build --release --target "${TARGET}" -p mvm-vm-host \
+              --bin mvm-bridge --bin mvm-vz-supervisor \
+              --bin mvm-libkrun-supervisor --features libkrun-sys
+          else
+            cargo build --release --target "${TARGET}" -p mvm-vm-host \
+              --bin mvm-bridge
+          fi
+
       - name: Smoke test binary (native targets only)
         if: matrix.target == 'x86_64-unknown-linux-gnu' || matrix.target == 'aarch64-apple-darwin'
         env:
@@ -139,6 +169,14 @@ jobs:
 
           mkdir -p "staging/${ARCHIVE_NAME}"
           cp "target/${TARGET}/release/${BIN_NAME}" "staging/${ARCHIVE_NAME}/"
+          # Per-VM host processes (built in the prior step), shipped next to
+          # mvmctl so the backend's adjacent-to-exe resolver finds them on a
+          # downloaded install. copy-if-exists: the set differs by OS (macOS
+          # gets all three; Linux gets mvm-bridge only).
+          for hostbin in mvm-bridge mvm-vz-supervisor mvm-libkrun-supervisor; do
+            src="target/${TARGET}/release/${hostbin}"
+            [ -f "$src" ] && cp "$src" "staging/${ARCHIVE_NAME}/" && echo "bundled ${hostbin}"
+          done
           cp -r resources "staging/${ARCHIVE_NAME}/" 2>/dev/null || true
           cp README.md "staging/${ARCHIVE_NAME}/" 2>/dev/null || true
           # Include generated man pages

--- a/install.sh
+++ b/install.sh
@@ -131,6 +131,21 @@ else
 fi
 
 $SUDO install -m 0755 "$SRC/mvmctl" "$INSTALL_DIR/mvmctl"
+
+# Per-VM host processes mvmctl spawns at runtime (one process per guest VM).
+# They must sit NEXT TO mvmctl so the backend's adjacent-to-exe resolver finds
+# them — installing only mvmctl strands them. copy-if-exists: the bundled set
+# differs by platform (macOS ships all three; Linux ships mvm-bridge only).
+# No codesigning here: the vz/libkrun supervisors self-sign with the
+# VZ/Hypervisor entitlements on first spawn (ensure_signed); mvm-bridge does
+# networking only and needs no entitlement.
+for hostbin in mvm-bridge mvm-vz-supervisor mvm-libkrun-supervisor; do
+  if [ -f "$SRC/$hostbin" ]; then
+    $SUDO install -m 0755 "$SRC/$hostbin" "$INSTALL_DIR/$hostbin"
+    say "Installed: $INSTALL_DIR/$hostbin"
+  fi
+done
+
 if [ -d "$SRC/resources" ]; then
   $SUDO rm -rf "$INSTALL_DIR/resources"
   $SUDO cp -R "$SRC/resources" "$INSTALL_DIR/resources"


### PR DESCRIPTION
Implements the **packaging/embed** follow-up flagged in #1303 — the DX-critical piece behind "a single command that works for users who download mvmctl, no source checkout."

## The gap
The release build (`cargo build --release` of the root package) produces only `mvmctl`. The per-VM host processes it spawns at runtime are **separate bin targets** in `mvm-vm-host`:
- `mvm-bridge` — shared external-VMM gateway/audit sidecar (Firecracker passt + vz VzIngest)
- `mvm-vz-supervisor` — vz VMM supervisor
- `mvm-libkrun-supervisor` — libkrun VMM supervisor

None were built or bundled, so a downloaded install had **no `mvm-bridge` on disk**. The backend resolver checks `MVM_BRIDGE_PATH` → adjacent-to-exe → source `target/`; on a non-source install all three miss. vz/FC could only run from a source checkout.

## Fix
**`release.yml`** — new "Build per-VM host binaries" step:
- **macOS** targets build all three (`--features libkrun-sys`; libkrun is already installed on the macOS runner).
- **Linux** targets build `mvm-bridge` only (the Linux runner has no libkrun — "Linux uses Firecracker"; `mvm-vz-supervisor` is macOS-only).
- The package step copies the built bins (copy-if-exists) next to `mvmctl` in the tarball.

**`install.sh`** — install the bundled host bins alongside `mvmctl` (copy-if-exists). Installing only `mvmctl` would strand them. No codesigning here: the vz/libkrun supervisors **self-sign** with the VZ/Hypervisor entitlements on first spawn (`ensure_signed`); `mvm-bridge` is networking-only and needs none.

## Verification
- **Locally (macOS aarch64):** all three bins build via the combined `-p mvm-vm-host --bin … --features libkrun-sys` command (~11 MB total).
- **Simulated the full package→install→resolve flow** into a temp dir: `mvmctl env sign` run from the install dir resolves and signs the **adjacent** `mvm-vz-supervisor` / `mvm-libkrun-supervisor` (proving the resolver finds the bundled bins, not the source tree).
- `install.sh` passes `sh -n`; release.yml step indentation verified.
- Full release-tag build + clean-machine install is CI-on-tag (can't run locally).

## Follow-ups (out of scope, noted in commit)
- **Linux `mvm-libkrun-supervisor`** packaging needs a Linux libkrun build step in CI (Linux libkrun users currently still need a source build).
- `ops/bootstrap/install.sh` is a stale separate installer (expects `mvm-<target>/mvm`, not the current `mvmctl-<target>/mvmctl`) — pre-existing, untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)