### PR TITLE
ci(release): add a no-publish dry-run mode (workflow_dispatch + dry_run)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -4,6 +4,18 @@ on:
   push:
     tags:
       - "v*"
+  # Manual dry-run: validate the release build + packaging (binaries, host-bin
+  # bundling, Linux cross-build) on the real CI runners WITHOUT publishing.
+  # `dry_run=true` (the default) runs only the `build` job and skips the Nix
+  # image jobs, the publishing `release` job, and `verify-release`. A real
+  # release still happens via a `v*` tag push; an explicit `dry_run=false`
+  # dispatch publishes too (escape hatch).
+  workflow_dispatch:
+    inputs:
+      dry_run:
+        description: "Build + package only; do NOT publish (no GitHub release, no crates.io)"
+        type: boolean
+        default: true
 
 permissions:
   contents: write
@@ -211,6 +223,9 @@ jobs:
   # — into this one; the sealed runtime builder for mvmd's pool-build
   # pipeline, if still needed, is sourced from mvmd, not built here.)
   builder-vm-image:
+    # Skipped on a dry-run dispatch — Nix image builds are slow and unchanged by
+    # the binary-packaging path a dry-run validates. Runs on tag push / dry_run=false.
+    if: ${{ github.event_name == 'push' || github.event.inputs.dry_run == 'false' }}
     strategy:
       matrix:
         include:
@@ -279,6 +294,8 @@ jobs:
   # the arch suffix so the combined release-asset pool doesn't
   # collide between aarch64 and x86_64.
   runtime-overlay-image:
+    # Skipped on a dry-run dispatch (see builder-vm-image).
+    if: ${{ github.event_name == 'push' || github.event.inputs.dry_run == 'false' }}
     strategy:
       matrix:
         include:
@@ -333,6 +350,8 @@ jobs:
   # mode, never published. `download_default_microvm_image` fetches these five
   # assets + the checksums.
   default-microvm:
+    # Skipped on a dry-run dispatch (see builder-vm-image).
+    if: ${{ github.event_name == 'push' || github.event.inputs.dry_run == 'false' }}
     strategy:
       matrix:
         include:
@@ -389,7 +408,10 @@ jobs:
     # (mvmctl tarballs + checksums) that install.sh / `mvmctl update` /
     # the Homebrew tap consume. `!cancelled()` lets this run after image
     # jobs fail; the result check keeps the binary build a hard requirement.
-    if: ${{ !cancelled() && needs.build.result == 'success' }}
+    # Dry-run guard: a `workflow_dispatch` with dry_run=true builds + packages
+    # (the `build` job) but never reaches this publish job — only a tag push or
+    # an explicit dry_run=false dispatch publishes.
+    if: ${{ !cancelled() && needs.build.result == 'success' && (github.event_name == 'push' || github.event.inputs.dry_run == 'false') }}
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6


### PR DESCRIPTION
Adds a **no-publish dry-run** to the release workflow so the build + packaging can be validated on the real CI runners without cutting an irreversible release.

## Why
A `v*` tag is the only way to run `release.yml` today, and it does a **real, irreversible** release (public GitHub release + crates.io publish). So the new per-VM host-binary bundling (#1307) and the Linux cross-build can't be validated short of shipping.

## What
- New `workflow_dispatch` trigger with a `dry_run` boolean input (**default true**).
- `dry_run=true` → only the **`build`** job runs (mvmctl + the per-VM host bins on all three targets, packaged into the tarballs + uploaded as run artifacts). The Nix image jobs (slow, unchanged), the publishing **`release`** job, and **`verify-release`** are skipped. **Nothing is published.**
- Real releases still go via a `v*` tag push (unchanged).
- `dry_run=false` on a dispatch is an escape hatch to publish from a manual run.

Mechanism: publish/expensive jobs gain `if: github.event_name == 'push' || github.event.inputs.dry_run == 'false'`; `verify-release` already gates on `needs.release.result == 'success'`, so it auto-skips when `release` skips.

## Use
```
gh workflow run release.yml -f dry_run=true
```
(or the Actions UI), then download the `build` artifacts to confirm each tarball carries `mvm-bridge` (+ `mvm-vz-supervisor` / `mvm-libkrun-supervisor` on macOS).

## Validation
- YAML parses (ruby `YAML.load_file`); all four job guards + the input reviewed.
- `workflow_dispatch` must live on the default branch to be dispatchable, so the dry-run becomes runnable once this merges to `main`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)