### PR TITLE
fix(machine): run interactive argv in PTY

### DIFF
--- a/crates/mvm-cli/src/commands/machine/mod.rs
+++ b/crates/mvm-cli/src/commands/machine/mod.rs
@@ -1899,6 +1899,17 @@ fn machine_exec_command(argv: &[String]) -> String {
     format!("exec {}", quoted.join(" "))
 }
 
+fn machine_interactive_pty_argv(argv: &[String]) -> Vec<String> {
+    if argv.is_empty() {
+        return Vec::new();
+    }
+    vec![
+        "/bin/sh".to_string(),
+        "-lc".to_string(),
+        machine_exec_command(argv),
+    ]
+}
+
 fn build_machine_volume_cfg(
     volume_specs: &[String],
 ) -> Result<Vec<mvm_backend::image::RuntimeVolume>> {
@@ -1958,6 +1969,7 @@ fn exec_machine(cli: &Cli, args: MachineExecArgs, cfg: &MvmConfig) -> Result<()>
             command: Some(machine_exec_command(&args.argv)),
             force: args.force,
             env: machine_console_env(spec.ssh_agent),
+            pty_argv: Vec::new(),
         },
         cfg,
     )
@@ -1972,6 +1984,7 @@ fn shell_machine(cli: &Cli, args: MachineShellArgs, cfg: &MvmConfig) -> Result<(
             command: None,
             force: args.force,
             env: machine_console_env(spec.ssh_agent),
+            pty_argv: Vec::new(),
         },
         cfg,
     )
@@ -2198,6 +2211,7 @@ fn run_interactive(
             command: None,
             force: false,
             env: machine_console_env(spec.ssh_agent),
+            pty_argv: machine_interactive_pty_argv(&args.argv),
         },
         cfg,
     );
@@ -2233,6 +2247,7 @@ fn run_persistent_post_start(
                 command: Some(machine_exec_command(&args.argv)),
                 force: false,
                 env: machine_console_env(spec.ssh_agent),
+                pty_argv: Vec::new(),
             },
             cfg,
         );
@@ -3111,6 +3126,25 @@ mod tests {
         assert!(
             msg.contains("tty") || msg.contains("terminal") || msg.contains("interactive"),
             "msg: {msg}"
+        );
+    }
+
+    #[test]
+    fn interactive_pty_argv_uses_same_command_quoting_as_exec() {
+        assert!(machine_interactive_pty_argv(&[]).is_empty());
+
+        let argv = vec![
+            "sh".to_string(),
+            "-lc".to_string(),
+            "echo hello world".to_string(),
+        ];
+        assert_eq!(
+            machine_interactive_pty_argv(&argv),
+            vec![
+                "/bin/sh".to_string(),
+                "-lc".to_string(),
+                machine_exec_command(&argv),
+            ]
         );
     }
 

--- a/crates/mvm-cli/src/commands/tests.rs
+++ b/crates/mvm-cli/src/commands/tests.rs
@@ -2285,11 +2285,13 @@ fn test_console_with_command() {
             command,
             force,
             env,
+            pty_argv,
         }) => {
             assert_eq!(name, "myvm");
             assert_eq!(command.as_deref(), Some("ls"));
             assert!(!force, "default --force is off");
             assert!(env.is_empty());
+            assert!(pty_argv.is_empty());
         }
         _ => panic!("Expected machine console action"),
     }

--- a/crates/mvm-cli/src/commands/vm/console.rs
+++ b/crates/mvm-cli/src/commands/vm/console.rs
@@ -70,14 +70,16 @@ pub(in crate::commands) struct Args {
     /// Run a single command instead of an interactive shell
     #[arg(long)]
     pub command: Option<String>,
-    /// Bypass the sealed-image check (use with care: the image was
-    /// built without dev surface, so the in-VM agent may refuse
-    /// `Exec`/`ConsoleOpen` regardless).
+    /// Attempt the attach even when legacy metadata is incomplete. This never
+    /// bypasses a sealed-image refusal.
     #[arg(long)]
     pub force: bool,
     /// Extra KEY=VALUE environment entries for the guest dev shell/session.
     #[arg(skip)]
     pub env: Vec<(String, String)>,
+    /// Explicit PTY argv. Empty uses the guest agent default shell.
+    #[arg(skip)]
+    pub pty_argv: Vec<String>,
 }
 
 /// Refuse to attach if the VM's image was built sealed (dev = false /
@@ -87,14 +89,12 @@ pub(in crate::commands) struct Args {
 /// Reused by `machine run -t` (claim 15: no interactive access to a sealed
 /// production microVM).
 pub(in crate::commands) fn enforce_accessible_gate(name: &str, force: bool) -> Result<()> {
-    if force {
-        return Ok(());
-    }
+    let _ = force;
     match mvm::vm::runtime_meta::read(name) {
         Ok(Some(meta)) if !meta.accessible => anyhow::bail!(
             "console refused: VM {name:?} was built from a sealed image (passthru.mvm.accessible = false). \
              Sealed images don't ship the dev agent surface. \
-             Rebuild with `dev = true` or pass `--force` to attempt the attach anyway."
+             Rebuild with `dev = true` for interactive development."
         ),
         _ => Ok(()),
     }
@@ -156,7 +156,7 @@ pub(in crate::commands) fn run(_cli: &Cli, args: Args, _cfg: &MvmConfig) -> Resu
         }
     } else {
         // Interactive PTY session
-        console_interactive_with_env(name, args.env)
+        console_interactive_with_env_and_argv(name, args.env, args.pty_argv)
     }
 }
 
@@ -199,6 +199,14 @@ pub(in crate::commands) fn console_interactive_with_env(
     name: &str,
     env: Vec<(String, String)>,
 ) -> Result<()> {
+    console_interactive_with_env_and_argv(name, env, Vec::new())
+}
+
+pub(in crate::commands) fn console_interactive_with_env_and_argv(
+    name: &str,
+    env: Vec<(String, String)>,
+    argv: Vec<String>,
+) -> Result<()> {
     let (cols, rows) = get_terminal_size();
 
     ui::info(&format!(
@@ -213,7 +221,12 @@ pub(in crate::commands) fn console_interactive_with_env(
         &mut stream,
         &[mvm_guest::vsock::GuestCapability::Console],
     )?;
-    let req = mvm_guest::vsock::GuestRequest::ConsoleOpen { cols, rows, env };
+    let req = mvm_guest::vsock::GuestRequest::ConsoleOpen {
+        cols,
+        rows,
+        env,
+        argv,
+    };
     // Inbound vsock RPC audit.
     super::shared::emit_vsock_rpc_audit(name, &req);
     let (session_id, data_port) = match mvm_guest::vsock::call_unary(&mut stream, &req)? {
@@ -618,7 +631,10 @@ mod accessible_gate_tests {
             let err = enforce_accessible_gate(name, false).expect_err("must refuse");
             let msg = err.to_string();
             assert!(msg.contains("sealed image"), "msg: {msg}");
-            assert!(msg.contains("--force"), "msg should hint at --force: {msg}");
+            assert!(
+                !msg.contains("--force"),
+                "msg must not suggest bypass: {msg}"
+            );
         });
     }
 
@@ -642,7 +658,7 @@ mod accessible_gate_tests {
     }
 
     #[test]
-    fn gate_force_bypasses_sealed_refusal() {
+    fn gate_force_does_not_bypass_sealed_refusal() {
         with_home(|_| {
             let name = "sealed-but-forced";
             write_meta(
@@ -653,7 +669,9 @@ mod accessible_gate_tests {
                 },
             )
             .expect("write");
-            assert!(enforce_accessible_gate(name, true).is_ok());
+            let err =
+                enforce_accessible_gate(name, true).expect_err("force must not bypass sealed");
+            assert!(err.to_string().contains("sealed image"), "msg: {err}");
         });
     }
 }

--- a/crates/mvm-guest/src/bin/mvm-guest-agent.rs
+++ b/crates/mvm-guest/src/bin/mvm-guest-agent.rs
@@ -2345,7 +2345,12 @@ fn handle_client(
         // above already rejects these verbs in sealed-prod, but the compile-time
         // gate is the load-bearing guarantee — no console code is even linked.
         #[cfg(feature = "dev-shell")]
-        GuestRequest::ConsoleOpen { cols, rows, env } => {
+        GuestRequest::ConsoleOpen {
+            cols,
+            rows,
+            env,
+            argv,
+        } => {
             // Check security policy — console requires access.console = true.
             // When no policy file is provisioned (dev mode), use permissive defaults.
             let policy = mvm_guest::builder_agent::load_security_policy()
@@ -2362,7 +2367,7 @@ fn handle_client(
                     },
                 );
             }
-            match mvm_guest::console::open_session(cols, rows, &env) {
+            match mvm_guest::console::open_session(cols, rows, &env, &argv) {
                 Ok(session) => {
                     let session_id = session.session_id;
                     let data_port = session.data_port;

--- a/crates/mvm-guest/src/console.rs
+++ b/crates/mvm-guest/src/console.rs
@@ -32,6 +32,7 @@ pub struct ConsoleSession {
 #[derive(Debug)]
 pub enum ConsoleError {
     AlreadyActive,
+    InvalidCommand(String),
     OpenPtyFailed,
     ForkFailed,
     BindFailed(u32),
@@ -41,6 +42,7 @@ impl std::fmt::Display for ConsoleError {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
             Self::AlreadyActive => write!(f, "a console session is already active"),
+            Self::InvalidCommand(message) => write!(f, "invalid console command: {message}"),
             Self::OpenPtyFailed => write!(f, "openpty() failed"),
             Self::ForkFailed => write!(f, "fork() failed"),
             Self::BindFailed(port) => write!(f, "failed to bind vsock port {port}"),
@@ -120,7 +122,16 @@ pub fn open_session(
     cols: u16,
     rows: u16,
     extra_env: &[(String, String)],
+    argv: &[String],
 ) -> Result<ConsoleSession, ConsoleError> {
+    let command_argv = build_console_argv(argv)?;
+    let command_path = command_argv[0].as_ptr().cast::<u8>();
+    let mut command_argv_ptrs: Vec<*const u8> = command_argv
+        .iter()
+        .map(|c| c.as_ptr().cast::<u8>())
+        .collect();
+    command_argv_ptrs.push(std::ptr::null());
+
     // Only one session at a time
     if CONSOLE_ACTIVE.swap(true, Ordering::SeqCst) {
         return Err(ConsoleError::AlreadyActive);
@@ -207,13 +218,9 @@ pub fn open_session(
             // Start in $HOME.
             let _ = chdir(c"/root".as_ptr().cast());
 
-            // Exec /bin/sh with the prepared environment. The path is
-            // absolute, so there is no PATH search (and thus no execvp
-            // allocation) to perform.
-            let shell = b"/bin/sh\0";
-            let dash_i = b"-i\0";
-            let argv: [*const u8; 3] = [shell.as_ptr(), dash_i.as_ptr(), std::ptr::null()];
-            execve(shell.as_ptr(), argv.as_ptr(), envp.as_ptr());
+            // Exec the prepared absolute command path. There is no PATH search
+            // here because the post-fork child must avoid allocation.
+            execve(command_path, command_argv_ptrs.as_ptr(), envp.as_ptr());
 
             std::process::exit(127);
         }
@@ -511,21 +518,39 @@ unsafe extern "C" {
 
 const SHUT_RDWR: i32 = 2;
 
-/// Build the shell's environment block as owned NUL-terminated C strings,
-/// inheriting the agent's current environment but overriding `HOME` and
-/// `TERM`. Constructed in the parent before `fork()` so the post-fork child
-/// can `execve` a fixed array without any allocation (see the async-signal
-/// safety note in `open_session`).
-fn build_shell_env() -> Vec<std::ffi::CString> {
-    build_shell_env_with(&[])
-}
-
 fn build_shell_env_with(extra_env: &[(String, String)]) -> Vec<std::ffi::CString> {
     build_shell_env_from(std::env::vars_os(), extra_env)
 }
 
-/// Pure core of [`build_shell_env`], parameterized over the source vars so it
-/// is testable without mutating process-global state.
+fn build_console_argv(argv: &[String]) -> Result<Vec<std::ffi::CString>, ConsoleError> {
+    let effective = if argv.is_empty() {
+        vec!["/bin/sh".to_string(), "-i".to_string()]
+    } else {
+        argv.to_vec()
+    };
+    if effective[0].is_empty() {
+        return Err(ConsoleError::InvalidCommand(
+            "argv[0] must not be empty".to_string(),
+        ));
+    }
+    if !effective[0].starts_with('/') {
+        return Err(ConsoleError::InvalidCommand(format!(
+            "argv[0] must be an absolute path, got {:?}",
+            effective[0]
+        )));
+    }
+    effective
+        .into_iter()
+        .map(|arg| {
+            std::ffi::CString::new(arg).map_err(|_| {
+                ConsoleError::InvalidCommand("argv must not contain NUL bytes".to_string())
+            })
+        })
+        .collect()
+}
+
+/// Pure core of the shell environment builder, parameterized over the source
+/// vars so it is testable without mutating process-global state.
 fn build_shell_env_from<I>(vars: I, extra_env: &[(String, String)]) -> Vec<std::ffi::CString>
 where
     I: IntoIterator<Item = (std::ffi::OsString, std::ffi::OsString)>,
@@ -633,6 +658,46 @@ mod tests {
         );
         let strs: Vec<&str> = out.iter().filter_map(|c| c.to_str().ok()).collect();
         assert!(strs.contains(&"SSH_AUTH_SOCK=/run/mvm/ssh-agent.sock"));
+    }
+
+    #[test]
+    fn build_console_argv_defaults_to_interactive_shell() {
+        let argv = build_console_argv(&[]).expect("default shell argv");
+        let got: Vec<&str> = argv.iter().filter_map(|c| c.to_str().ok()).collect();
+        assert_eq!(got, ["/bin/sh", "-i"]);
+    }
+
+    #[test]
+    fn build_console_argv_accepts_absolute_explicit_command() {
+        let argv = build_console_argv(&["/bin/sh".to_string()]).expect("explicit shell argv");
+        let got: Vec<&str> = argv.iter().filter_map(|c| c.to_str().ok()).collect();
+        assert_eq!(got, ["/bin/sh"]);
+    }
+
+    #[test]
+    fn build_console_argv_rejects_relative_command() {
+        let err = build_console_argv(&["sh".to_string()]).expect_err("relative command is unsafe");
+        assert!(
+            err.to_string().contains("absolute path"),
+            "unexpected error: {err}"
+        );
+    }
+
+    #[test]
+    fn open_session_rejects_invalid_argv_before_marking_active() {
+        CONSOLE_ACTIVE.store(false, Ordering::SeqCst);
+        let err = match open_session(80, 24, &[], &["sh".to_string()]) {
+            Ok(_) => panic!("relative command should be rejected before PTY allocation"),
+            Err(err) => err,
+        };
+        assert!(
+            err.to_string().contains("absolute path"),
+            "unexpected error: {err}"
+        );
+        assert!(
+            !is_active(),
+            "invalid argv must not leave the console marked active"
+        );
     }
 
     #[test]

--- a/crates/mvm-guest/src/vsock.rs
+++ b/crates/mvm-guest/src/vsock.rs
@@ -277,6 +277,8 @@ pub enum GuestRequest {
         rows: u16,
         #[serde(default)]
         env: Vec<(String, String)>,
+        #[serde(default, skip_serializing_if = "Vec::is_empty")]
+        argv: Vec<String>,
     },
     /// Close an active console session.
     ConsoleClose { session_id: u32 },
@@ -3257,6 +3259,7 @@ mod tests {
                 cols: 120,
                 rows: 40,
                 env: Vec::new(),
+                argv: Vec::new(),
             },
             GuestRequest::ConsoleClose { session_id: 1 },
             GuestRequest::ConsoleResize {
@@ -5481,6 +5484,7 @@ mod tests {
                 cols: 1,
                 rows: 1,
                 env: Vec::new(),
+                argv: Vec::new(),
             },
             GuestRequest::ConsoleClose { session_id: 1 },
             GuestRequest::ConsoleResize {
@@ -5609,6 +5613,7 @@ mod tests {
                 cols: 80,
                 rows: 24,
                 env: Vec::new(),
+                argv: Vec::new(),
             },
             GuestRequest::ProcStart {
                 argv: vec!["/x".into()],
@@ -5979,6 +5984,7 @@ mod tests {
                     cols: 0,
                     rows: 0,
                     env: Vec::new(),
+                    argv: Vec::new(),
                 },
                 "console-open",
             ),
@@ -6149,6 +6155,39 @@ mod tests {
             )
             .is_err()
         );
+    }
+
+    #[test]
+    fn console_open_missing_argv_defaults_empty() {
+        let req: GuestRequest =
+            serde_json::from_str(r#"{"ConsoleOpen":{"cols":80,"rows":24,"env":[]}}"#)
+                .expect("legacy console-open request should deserialize");
+        match req {
+            GuestRequest::ConsoleOpen { argv, .. } => assert!(argv.is_empty()),
+            other => panic!("expected ConsoleOpen, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn console_open_preserves_explicit_argv() {
+        let req = GuestRequest::ConsoleOpen {
+            cols: 80,
+            rows: 24,
+            env: Vec::new(),
+            argv: vec!["/bin/sh".to_string()],
+        };
+        let json = serde_json::to_string(&req).expect("serialize console-open");
+        assert!(
+            json.contains(r#""argv":["/bin/sh"]"#),
+            "serialized request should carry argv: {json}"
+        );
+        let parsed: GuestRequest = serde_json::from_str(&json).expect("deserialize console-open");
+        match parsed {
+            GuestRequest::ConsoleOpen { argv, .. } => {
+                assert_eq!(argv, vec!["/bin/sh".to_string()]);
+            }
+            other => panic!("expected ConsoleOpen, got {other:?}"),
+        }
     }
 
     // send_exec_streaming host reader

--- a/public/src/content/docs/guides/troubleshooting.md
+++ b/public/src/content/docs/guides/troubleshooting.md
@@ -213,10 +213,12 @@ To get an interactive shell, add `-it` (dev-only):
 mvmctl machine run -it --image <dev-image> -- /bin/sh   # drops into a shell
 ```
 
-`-it` is refused for a sealed/production image (claim 15: no interactive access
-to a sealed microVM) and when stdin is not a terminal — both fail fast with a
-clear message rather than hanging. To keep the machine after the shell exits,
-add `--name <N>` or `-d`.
+The command after `--` is the same command argv as a non-interactive run; `-it`
+only adds a PTY and forwards stdin. Omit the command to use the guest default
+shell. `-it` is refused for a sealed/production image (claim 15: no interactive
+access to a sealed microVM), with no `--force` override. It is also refused when
+stdin is not a terminal — both fail fast with a clear message rather than
+hanging. To keep the machine after the shell exits, add `--name <N>` or `-d`.
 
 ### `machine run --name X` recreated my machine
 

--- a/public/src/content/docs/reference/cli-commands.md
+++ b/public/src/content/docs/reference/cli-commands.md
@@ -300,8 +300,8 @@ never the token value.
 
 | Command | Description |
 |---------|-------------|
-| `mvmctl machine console <name>` | Interactive PTY shell into a running VM (vsock, no SSH) |
-| `mvmctl machine console <name> --command <cmd>` | Run a one-shot command in the VM |
+| `mvmctl machine console <name>` | Dev-only interactive PTY shell into a running VM (vsock, no SSH; refused for sealed/production VMs) |
+| `mvmctl machine console <name> --command <cmd>` | Dev-only one-shot command in the VM (refused for sealed/production VMs) |
 
 ## One-shot Run (transient runner)
 
@@ -370,7 +370,9 @@ flag:
 - **Interactive** (`-t`/`--tty`, with `-i` accepted so `-it` parses): attach a
   PTY shell. **Dev-only** — refused for a sealed image (claim 15) and when stdin
   is not a terminal. `-t` alone is a transient interactive machine (gone when the
-  shell exits); combine with `--name`/`-d` to keep it up.
+  shell exits); combine with `--name`/`-d` to keep it up. With a trailing
+  `-- <argv>`, the same argv is run with a PTY attached; without argv, the guest
+  default shell is used.
 
 Persistence and interactivity are independent: `--tty` never changes whether the
 machine survives. `--volume` host shares work on every mode — transient,
@@ -402,6 +404,7 @@ or mounts private keys, `~/.ssh`, known-hosts material, or SSH config.
 | `mvmctl machine run --name <name>` | Reconnect to an existing machine by name (no `--image` needed) |
 | `mvmctl machine run --name <name> --image <ref2>` | A changed config auto-recreates the machine (stop + reboot), announced on stderr |
 | `mvmctl machine run -it --image <ref>` | **Interactive** dev shell on a transient machine (gone on exit) |
+| `mvmctl machine run -it --image <ref> -- /bin/sh` | Interactive `/bin/sh` PTY on a transient machine |
 | `mvmctl machine run -it --name <name> --image <ref>` | Interactive dev shell on a persistent machine (left up on exit) |
 | `mvmctl machine create --name <name> --image <ref>` | Persist a named OCI-backed machine spec without booting it |
 | `mvmctl machine create --name <name> --manifest <path>` | Persist a named machine spec from an image-backed `mvm.toml` / `Mvmfile.toml` |
@@ -465,11 +468,13 @@ announced on stderr (`machine 'N': config changed (…) — stopping the old ins
 and recreating it`) so an unintended clobber, e.g. a typo'd `--image`, is visible.
 To keep two configs side by side, give them different `--name`s.
 
-**Interactive is dev-only.** `-t`/`--tty` attaches a PTY shell and is refused for
-a sealed/production image (claim 15 — no interactive access to a sealed microVM)
-and when stdin is not a terminal, both failing fast rather than hanging. It never
-affects persistence: `-it` alone is transient, `-it` with `--name`/`-d` keeps the
-machine. The design rationale and full behavior matrix are recorded in ADR-091
+**Interactive is dev-only.** `-t`/`--tty`, `machine shell`, `machine console`,
+and `machine exec` are refused for sealed/production images (claim 15 — no
+interactive or arbitrary shell access to a sealed microVM). There is no `--force`
+override for that refusal. `-it` also requires stdin to be a terminal, failing
+fast rather than hanging when it is not. It never affects persistence: `-it`
+alone is transient, `-it` with `--name`/`-d` keeps the machine. The design
+rationale and full behavior matrix are recorded in ADR-091
 (`specs/adrs/091-unified-machine-run-lifecycle.md`).
 
 `machine create` accepts either `--image <ref>` or an image-backed manifest, not

--- a/schema/protocol-v0.json
+++ b/schema/protocol-v0.json
@@ -1285,6 +1285,12 @@
                 "rows"
               ],
               "properties": {
+                "argv": {
+                  "type": "array",
+                  "items": {
+                    "type": "string"
+                  }
+                },
                 "cols": {
                   "type": "integer",
                   "format": "uint16",

--- a/sdks/python/mvm/_protocol/protocol.py
+++ b/sdks/python/mvm/_protocol/protocol.py
@@ -448,6 +448,7 @@ class GuestRequest16:
 class ConsoleOpen:
     cols: int
     rows: int
+    argv: Optional[List[str]] = None
     env: Optional[List[List[str]]] = field(default_factory=lambda: [])
 
 

--- a/sdks/typescript/src/protocol/protocol.ts
+++ b/sdks/typescript/src/protocol/protocol.ts
@@ -106,6 +106,7 @@ export type GuestRequest =
     }
   | {
       ConsoleOpen: {
+        argv?: string[];
         cols: number;
         env?: [string, string][];
         rows: number;

--- a/specs/plans/207-machine-run-unified-lifecycle.md
+++ b/specs/plans/207-machine-run-unified-lifecycle.md
@@ -128,7 +128,9 @@ stream — leave unchanged), `console::run` (PTY attach to reuse), and
       machine; a fresh boot is re-checked by `console::run` post-boot. An
       auto-recreate (config change) still goes through the gate, so it cannot
       bypass claim 15. (`machine run` has no `--prod` flag — it is dev-tier; the
-      sealed-image/non-`dev-shell`-agent triggers are the relevant ones.)
+      sealed-image/non-`dev-shell`-agent triggers are the relevant ones.) A
+      later regression pass made this refusal non-bypassable: `--force` no
+      longer overrides `accessible=false`.
 - [x] `require_tty(stdin_is_tty)` refuses a non-TTY stdin up front with a clear
       message — no hang. Call site reads `std::io::stdin().is_terminal()`.
 - [x] Tests: `interactive_requires_a_host_tty`,
@@ -212,6 +214,30 @@ existing fast `backend.stop_transient` (the same path `mvmctl run` uses —
 SIGKILL up front, no grace) via a new `stop_transient_machine` helper, plus a
 one-line "Stopping transient machine …" notice for immediate feedback.
 Measured on macOS Vz: teardown after Ctrl+D dropped 6.44s → 0.06s.
+
+## Post-regression: `-it -- /bin/sh` parsed but did not open the requested shell
+
+`machine run --image alpine -it -- /bin/sh` parsed the trailing argv but the
+interactive path discarded it: `run_interactive` always called `console::run`
+with `command: None`, so the guest opened its default shell regardless of the
+user's argv. A first fix exposed the guest PTY implementation detail too
+directly by treating trailing argv as a raw `execve` command, which required an
+absolute `argv[0]` and diverged from non-interactive `machine run`.
+
+Fixed: `machine run` now has one user-facing argv model. Non-interactive runs
+still use the existing `Exec` stream path and return the command exit code;
+interactive runs adapt the same shell-quoted `exec <argv>` command into a PTY
+process (`/bin/sh -lc ...`) so `-it` changes terminal/stdin behavior, not argv
+semantics. Empty interactive argv still opens the guest default shell. The guest
+console protocol now carries optional explicit PTY argv for this adapter, but
+production isolation remains unchanged: `ConsoleOpen` and `Exec` are `DevOnly`
+verbs in the guest profile classifier, sealed-prod agents reject them, and the
+host metadata gate refuses `accessible=false` with no `--force` override.
+
+Coverage: `interactive_pty_argv_uses_same_command_quoting_as_exec`,
+`gate_force_does_not_bypass_sealed_refusal`, `machine_console_refused_on_sealed_image`,
+guest `test_sealed_prod_rejects_dev_only_verbs`, and the full workspace
+`cargo test --workspace`/clippy gates.
 
 ## Out of scope
 


### PR DESCRIPTION
## Summary
- Thread `machine run -it -- <argv>` through the console open protocol so interactive runs execute the requested command instead of always opening the default shell.
- Preserve one Docker-like argv model: `-it` changes PTY/stdin behavior, not command parsing; empty argv still opens the dev shell.
- Harden sealed/production refusal by removing the `--force` bypass from the host-side console gate while keeping the guest `SealedProd` DevOnly rejection as defense in depth.
- Update CLI docs, troubleshooting, and Plan 207 with the regression and policy details.

## Validation
- `cargo fmt --all`
- `cargo test -p mvm-cli machine`
- `cargo test -p mvm-cli gate_force_does_not_bypass_sealed_refusal`
- `cargo test -p mvm-cli machine_console_refused_on_sealed_image`
- `cargo test -p mvm-guest test_sealed_prod_rejects_dev_only_verbs`
- `cargo test -p mvm-guest --features dev-shell console::tests`
- `cargo check --workspace`
- `cargo clippy --workspace --all-targets -- -D warnings`
- `cargo clippy -p mvm-guest --features dev-shell --all-targets -- -D warnings`
- `cargo test --workspace`

## Notes
- Security: this remains dev-only. `ConsoleOpen`, `Exec`, process RPC, filesystem RPC, and forwarding are DevOnly in the guest profile classifier, and host runtime metadata with `accessible=false` now refuses even when `--force` is passed.
- DX follow-up to consider: PTY sessions still behave like console attach for process status; unlike non-interactive exec, the current host console protocol does not propagate the child exit code back to `mvmctl` for cases like `machine run -it -- false`.
