### PR TITLE
test(machine): pin interactive image shell parsing

### DIFF
--- a/crates/mvm-cli/src/commands/tests.rs
+++ b/crates/mvm-cli/src/commands/tests.rs
@@ -2509,6 +2509,17 @@ fn run_timeout_parses_to_some() {
 }
 
 #[test]
+fn machine_run_interactive_image_shell_dx_parses() {
+    let args = parse_machine_run(&["--net", "-it", "--image", "alpine", "--", "/bin/sh"])
+        .expect("parse Docker-style interactive shell run");
+    assert!(args.net);
+    assert!(args.tty);
+    assert!(args.interactive);
+    assert_eq!(args.image.as_deref(), Some("alpine"));
+    assert_eq!(args.argv, vec!["/bin/sh".to_string()]);
+}
+
+#[test]
 fn run_image_flag_parses() {
     let cli = Cli::try_parse_from([
         "mvmctl",


### PR DESCRIPTION
## Summary
- Add a CLI parser regression test for `machine run --net -it --image alpine -- /bin/sh`
- Pin that `-it` keeps both TTY and interactive flags while preserving the explicit shell argv on the dev interactive path

## Validation
- `cargo test -p mvm-cli commands::tests::machine_run_interactive_image_shell_dx_parses`
- `cargo fmt`
- `cargo clippy -p mvm-cli --all-targets -- -D warnings`