### PR TITLE
Fix machine run interactive argv semantics

### DIFF
--- a/crates/mvm-cli/src/commands/machine/mod.rs
+++ b/crates/mvm-cli/src/commands/machine/mod.rs
@@ -190,8 +190,8 @@ pub(in crate::commands) struct MachineRunArgs {
     /// Validate and explain the effective run plan without booting a VM.
     #[arg(long)]
     pub dry_run: bool,
-    /// Persist the machine under this name: it survives the command and is
-    /// reconnectable via `machine shell/exec/stop`. Implies persistence.
+    /// Run under this machine identity. Foreground runs still tear down when
+    /// the command exits; use `machine create`/`start` for long-lived machines.
     #[arg(long, value_name = "NAME")]
     pub name: Option<String>,
     /// Boot a persistent machine and return immediately. Auto-names the machine
@@ -209,13 +209,15 @@ pub(in crate::commands) struct MachineRunArgs {
     /// or a bare number of seconds. The reaper tears down expired machines.
     #[arg(long, value_name = "DURATION")]
     pub ttl: Option<String>,
-    /// Attach an interactive PTY shell (dev-only; refused for `--prod`/sealed
-    /// images). Does not affect persistence: `-t` alone is a transient
-    /// interactive machine, gone when the shell exits.
-    #[arg(short = 't', long)]
+    /// Attach the foreground command to an interactive PTY.
+    #[arg(short = 't', long, conflicts_with_all = ["detach", "up_json", "ttl"])]
     pub tty: bool,
     /// Accepted as an alias for `-t` so the conventional `-it` bundle parses.
-    #[arg(short = 'i', long = "interactive")]
+    #[arg(
+        short = 'i',
+        long = "interactive",
+        conflicts_with_all = ["detach", "up_json", "ttl"]
+    )]
     pub interactive: bool,
     /// Force-recreate a persistent machine whose on-disk spec exists with a
     /// different config (stop + overwrite + restart). Without it, a config
@@ -287,6 +289,8 @@ impl MachineRunArgs {
             // Default off; `run_dispatch` sets it for the warm-claim-eligible
             // transient mode.
             warm_pool_size: 0,
+            pty: false,
+            vm_name: self.name,
             image: self.image,
             net: self.net,
             allow_host: self.allow_host,
@@ -316,26 +320,27 @@ impl MachineRunArgs {
         self.tty || self.interactive
     }
 
-    /// `--name` or `-d`/`--detach`/`--up-json` makes the machine survive the command.
+    /// `-d`/`--detach`, `--up-json`, or `--ttl` makes the machine survive the command.
     /// `--tty` is deliberately NOT consulted here — persistence and
     /// interactivity are independent axes.
     fn persistent(&self) -> bool {
-        self.name.is_some() || self.detach || self.up_json
+        self.detach || self.up_json || self.ttl.is_some()
     }
 
-    /// Resolve the lifecycle mode purely from the flags. The only validation is
-    /// that a plain transient run carries a command; persistent and interactive
-    /// modes default to "just boot" / "default shell" respectively.
+    /// Resolve the lifecycle mode purely from the flags. Fresh foreground runs
+    /// need an image source and an argv; persistent runs just boot and return.
     fn resolve_mode(&self) -> Result<MachineRunMode> {
         let mode = match (self.interactive(), self.persistent()) {
-            // Persistent modes may reconnect to an existing machine by name, so
-            // `--image` is optional here (validated against spec existence in the
-            // persistent path).
-            (true, true) => MachineRunMode::InteractivePersistent,
+            (true, true) => bail!(
+                "`machine run -it` is foreground-only; use `machine exec --name <name> -it -- <cmd>` for an interactive command in a long-lived machine"
+            ),
             (false, true) => MachineRunMode::Persistent,
             // Fresh-boot modes always materialize a new VM and need an image.
             (true, false) => {
                 self.require_image_for_fresh_boot()?;
+                if self.argv.is_empty() {
+                    bail!("machine run -it needs a command after `--`, for example `-- /bin/sh`");
+                }
                 MachineRunMode::InteractiveTransient
             }
             (false, false) => {
@@ -343,8 +348,8 @@ impl MachineRunArgs {
                 if self.argv.is_empty() {
                     bail!(
                         "machine run needs a command: pass `-- <cmd>`, \
-                         or `-d`/`--name <N>` to boot a persistent machine, \
-                         or `-t` for an interactive shell"
+                         or `-d`/`--detach` to boot a persistent machine, \
+                         or `-it -- /bin/sh` for an interactive shell"
                     );
                 }
                 MachineRunMode::Transient
@@ -367,35 +372,32 @@ impl MachineRunArgs {
 }
 
 /// The lifecycle `machine run` resolves to, computed purely from the parsed
-/// flags. Persistence (`--name`/`-d`) and interactivity (`-t`/`-i`) are
-/// independent axes, so the interactive variants record whether the machine
-/// also persists.
+/// flags. Persistence (`-d`/`--up-json`/`--ttl`) and interactivity
+/// (`-t`/`-i`) are independent axes; `--name` is only an identity unless one of
+/// the persistence flags is present.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 enum MachineRunMode {
     /// Default one-shot: boot, run argv, tear down. Unchanged `run_secure`.
     Transient,
-    /// Persistent (named or detached), non-interactive.
+    /// Persistent (detached or lifecycle-managed), non-interactive.
     Persistent,
-    /// Interactive PTY shell on a throwaway machine (gone on shell exit).
+    /// Foreground command attached to a PTY on a transient machine.
     InteractiveTransient,
-    /// Interactive PTY shell on a persistent machine (left up on exit).
-    InteractivePersistent,
 }
 
 impl MachineRunMode {
-    /// Warm-pool size for this run mode. Transient and
-    /// interactive-transient runs are throwaway, auto-named cattle — eligible to
-    /// claim a pre-booted standby and to replenish the pool, so they take the
-    /// residency-policy size (`effective_warm_pool_size`). A user-named or `-d`
-    /// persistent machine is long-lived, not pool cattle, so it never claims
-    /// (size 0). `explicit` is a caller override (e.g. a future `--warm` flag),
-    /// applied only to the claim-eligible modes.
-    fn warm_pool_size(self, explicit: Option<u32>) -> u32 {
-        match self {
-            MachineRunMode::Transient | MachineRunMode::InteractiveTransient => {
+    /// Warm-pool size for this run mode. Only unnamed foreground transient
+    /// runs are throwaway cattle — eligible to claim a pre-booted standby and
+    /// to replenish the pool. A named foreground run has an observable VM
+    /// identity, and persistent machines are long-lived, so both cold-boot
+    /// under the requested identity.
+    fn warm_pool_size(self, explicit: Option<u32>, has_name: bool) -> u32 {
+        match (self, has_name) {
+            (MachineRunMode::Transient | MachineRunMode::InteractiveTransient, false) => {
                 mvm_core::residency::effective_warm_pool_size(explicit)
             }
-            MachineRunMode::Persistent | MachineRunMode::InteractivePersistent => 0,
+            (MachineRunMode::Transient | MachineRunMode::InteractiveTransient, true) => 0,
+            (MachineRunMode::Persistent, _) => 0,
         }
     }
 }
@@ -414,10 +416,10 @@ enum SpecReconcile {
 }
 
 /// An auto-generated machine name for `-d` without `--name`. Reuses the
-/// `mvm-core` instance-ID helper so there is one naming scheme, not two; the
-/// `i-<hex>` shape satisfies `validate_vm_name`.
+/// `mvm-core` helper so foreground and persistent generated names share one
+/// human-friendly naming scheme.
 fn auto_machine_name() -> String {
-    naming::generate_instance_id()
+    naming::generate_machine_name()
 }
 
 /// Resolve the persistent machine's name: the explicit `--name`, or an
@@ -559,12 +561,6 @@ fn require_tty(stdin_is_tty: bool) -> Result<()> {
         );
     }
     Ok(())
-}
-
-/// An interactive machine is torn down on shell exit only when it is transient
-/// (no `--name`/`-d`); a persistent one is left up.
-fn should_teardown_after_interactive(args: &MachineRunArgs) -> bool {
-    !args.persistent()
 }
 
 /// Build a persistent `MachineSpec` from the `run` flags. Mirrors the
@@ -765,6 +761,12 @@ pub(in crate::commands) struct MachineExecArgs {
     /// Bypass the sealed-image accessibility check.
     #[arg(long)]
     pub force: bool,
+    /// Attach the command to an interactive PTY.
+    #[arg(short = 't', long)]
+    pub tty: bool,
+    /// Accepted as an alias for `-t` so `-it` parses.
+    #[arg(short = 'i', long = "interactive")]
+    pub interactive: bool,
     /// Argv to run inside the guest (use `--` to separate).
     #[arg(trailing_var_arg = true, allow_hyphen_values = true, required = true)]
     pub argv: Vec<String>,
@@ -1899,17 +1901,6 @@ fn machine_exec_command(argv: &[String]) -> String {
     format!("exec {}", quoted.join(" "))
 }
 
-fn machine_interactive_pty_argv(argv: &[String]) -> Vec<String> {
-    if argv.is_empty() {
-        return Vec::new();
-    }
-    vec![
-        "/bin/sh".to_string(),
-        "-lc".to_string(),
-        machine_exec_command(argv),
-    ]
-}
-
 fn build_machine_volume_cfg(
     volume_specs: &[String],
 ) -> Result<Vec<mvm_backend::image::RuntimeVolume>> {
@@ -1962,6 +1953,16 @@ fn stop_failed_machine_start(name: &str) {
 
 fn exec_machine(cli: &Cli, args: MachineExecArgs, cfg: &MvmConfig) -> Result<()> {
     let spec = ensure_machine_spec_exists(&args.name)?;
+    if args.tty || args.interactive {
+        use std::io::IsTerminal as _;
+        require_tty(std::io::stdin().is_terminal())?;
+        super::vm::console::enforce_accessible_gate(&args.name, args.force)?;
+        return console::console_pty_command(
+            &args.name,
+            machine_exec_command(&args.argv),
+            machine_console_env(spec.ssh_agent),
+        );
+    }
     console::run(
         cli,
         console::Args {
@@ -2053,21 +2054,6 @@ fn stop_running_machine(name: &str) {
     }
 }
 
-/// Fast teardown for a throwaway interactive-transient machine. The guest shell
-/// has already exited, so there is nothing to flush: SIGKILL the
-/// supervisor/drainer/gvproxy up front (`stop_transient`) instead of burning the
-/// graceful ACPI grace `stop()` waits out — on Vz that grace runs ~6s across the
-/// supervisor, gvproxy, and drainer, which reads as a hang after Ctrl+D. Mirrors
-/// the `mvmctl run` transient teardown.
-fn stop_transient_machine(name: &str) {
-    reap_proxy(name);
-    let backend =
-        AnyBackend::from_hypervisor(&super::shared::resolve_effective_hypervisor("firecracker"));
-    if let Err(err) = backend.stop_transient(&VmId(name.to_string())) {
-        tracing::warn!(error = %err, machine = name, "fast-stopping transient machine failed");
-    }
-}
-
 /// The persistent lifecycle: `machine run --name <N>` / `-d`. Composes the
 /// existing create + start (+ exec) verbs — no new lifecycle code — so the
 /// signed-`ExecutionPlan` admission and default-deny egress are identical to
@@ -2148,83 +2134,6 @@ fn persist_and_boot_machine(
         start_machine(start)?;
         Ok(true)
     }
-}
-
-/// The interactive lifecycle: `machine run -t`/`--tty`. Boots (or reconnects to)
-/// the machine via the same managed path as the persistent lifecycle, attaches
-/// a PTY shell through `console::run`, and tears the machine down on exit only
-/// when it is transient. Dev-only: claim 15's `enforce_accessible_gate` refuses
-/// a sealed machine before attach, and a non-TTY stdin is refused up front.
-fn run_interactive(
-    cli: &Cli,
-    args: MachineRunArgs,
-    cfg: &MvmConfig,
-    resolved_flake_slot: Option<&str>,
-) -> Result<()> {
-    use std::io::IsTerminal as _;
-    require_tty(std::io::stdin().is_terminal())?;
-
-    let teardown = should_teardown_after_interactive(&args);
-    let name = resolve_machine_run_name(&args)?;
-    let existing = load_machine_spec(&name).ok();
-
-    // Claim 15, before boot: a previously-started machine carries runtime meta,
-    // so a sealed one is refused here; a fresh boot is re-checked by
-    // `console::run` post-boot. The recreate `--force` must not bypass this
-    // security gate, so it is not threaded in.
-    super::vm::console::enforce_accessible_gate(&name, false)?;
-
-    let (spec, action) = resolve_persistent_spec(&args, &name, existing, resolved_flake_slot)?;
-
-    if args.dry_run {
-        let summary = machine_start_preflight_summary(&spec, args.receipt.as_deref())?;
-        if args.json {
-            println!("{}", serde_json::to_string_pretty(&summary)?);
-        } else {
-            print_machine_start_preflight_human(&summary);
-        }
-        return Ok(());
-    }
-
-    persist_and_boot_machine(
-        &name,
-        &spec,
-        action,
-        MachineStartArgs {
-            name: name.clone(),
-            receipt: None,
-            json: false,
-            dry_run: false,
-            quiet: true,
-            hypervisor: args.hypervisor.clone(),
-            no_supervisor: args.no_supervisor,
-            kernel_pin: args.kernel_pin.clone(),
-        },
-    )?;
-
-    // Attach the interactive PTY (command: None ⇒ a shell). `force: false`
-    // keeps claim 15 strict on the post-boot re-check.
-    let attached = console::run(
-        cli,
-        console::Args {
-            name: name.clone(),
-            command: None,
-            force: false,
-            env: machine_console_env(spec.ssh_agent),
-            pty_argv: machine_interactive_pty_argv(&args.argv),
-        },
-        cfg,
-    );
-
-    if teardown {
-        // Fast SIGKILL teardown — the shell already exited, so skip the graceful
-        // ACPI grace that otherwise sits silent for seconds after Ctrl+D.
-        println!("Stopping transient machine {name}.");
-        stop_transient_machine(&name);
-        // Best-effort: drop the throwaway spec we created for this session.
-        let _ = remove_machine_spec(&name, true);
-    }
-    attached
 }
 
 /// After the machine is up: run the command (streamed, machine left up), or —
@@ -2408,32 +2317,36 @@ fn run_dispatch(cli: &Cli, mut args: MachineRunArgs, cfg: &MvmConfig) -> Result<
     }
 
     let mode = args.resolve_mode()?;
+    let warm_pool_size = mode.warm_pool_size(None, args.name.is_some());
     // Resolve warm-pool eligibility per mode. Threaded into the
     // claim path next; logged here so the dark-landed decision is observable
-    // (transient/interactive-transient take the residency size, persistent → 0).
-    tracing::debug!(
-        ?mode,
-        warm_pool_size = mode.warm_pool_size(None),
-        "machine run warm-pool eligibility"
-    );
+    // (unnamed transient/interactive-transient take the residency size, named
+    // foreground and persistent → 0).
+    tracing::debug!(?mode, warm_pool_size, "machine run warm-pool eligibility");
     match mode {
         MachineRunMode::Transient => {
             // For flake runs, pass the slot hash as the manifest.
             if let Some(slot) = resolved_flake_slot {
                 args.manifest = Some(slot);
             }
-            // A throwaway transient run is warm-claim
-            // eligible — carry the residency-policy size so `run_inner` can claim
-            // a pre-booted standby and replenish the pool.
+            // Only unnamed throwaway transient runs are warm-claim eligible.
             let mut run_args = args.into_run_args();
-            run_args.warm_pool_size = mode.warm_pool_size(None);
+            run_args.warm_pool_size = warm_pool_size;
             run_secure(cli, run_args, cfg)
         }
         MachineRunMode::Persistent => {
             run_persistent(cli, args, cfg, resolved_flake_slot.as_deref())
         }
-        MachineRunMode::InteractiveTransient | MachineRunMode::InteractivePersistent => {
-            run_interactive(cli, args, cfg, resolved_flake_slot.as_deref())
+        MachineRunMode::InteractiveTransient => {
+            use std::io::IsTerminal as _;
+            require_tty(std::io::stdin().is_terminal())?;
+            if let Some(slot) = resolved_flake_slot {
+                args.manifest = Some(slot);
+            }
+            let mut run_args = args.into_run_args();
+            run_args.pty = true;
+            run_args.warm_pool_size = warm_pool_size;
+            run_secure(cli, run_args, cfg)
         }
     }
 }
@@ -2804,11 +2717,11 @@ mod tests {
     }
 
     #[test]
-    fn name_implies_persistence_without_detach() {
+    fn name_is_identity_not_persistence() {
         let args =
             parse_run(&["run", "--image", "alpine", "--name", "web", "--", "true"]).expect("parse");
         assert_eq!(args.name.as_deref(), Some("web"));
-        assert!(args.persistent());
+        assert!(!args.persistent());
         assert!(!args.detach);
         assert!(!args.interactive());
     }
@@ -2841,31 +2754,23 @@ mod tests {
             ),
             (
                 &["run", "--name", "web", "--image", "X", "--", "cmd"],
-                MachineRunMode::Persistent,
-            ),
-            (
-                &[
-                    "run", "-it", "--name", "web", "--image", "X", "--", "/bin/sh",
-                ],
-                MachineRunMode::InteractivePersistent,
+                MachineRunMode::Transient,
             ),
             (&["run", "-d", "--image", "X"], MachineRunMode::Persistent),
             (
                 &["run", "-d", "--name", "web", "--image", "X"],
                 MachineRunMode::Persistent,
             ),
-            (
-                &["run", "-t", "--image", "X"],
-                MachineRunMode::InteractiveTransient,
-            ),
-            (
-                &["run", "--name", "web", "--image", "X"],
-                MachineRunMode::Persistent,
-            ),
             // `--up-json` implies Persistent (SDK boot-and-return path).
             (
                 &["run", "--up-json", "--manifest", "tmpl"],
                 MachineRunMode::Persistent,
+            ),
+            (
+                &[
+                    "run", "-it", "--name", "web", "--image", "X", "--", "/bin/sh",
+                ],
+                MachineRunMode::InteractiveTransient,
             ),
         ];
         for (argv, expected) in cases {
@@ -2876,28 +2781,34 @@ mod tests {
     }
 
     #[test]
+    fn interactive_run_requires_foreground_argv() {
+        let args = parse_run(&["run", "-t", "--image", "X"]).expect("parse");
+        let err = args.resolve_mode().expect_err("interactive run needs argv");
+        assert!(err.to_string().contains("command after `--`"));
+    }
+
+    #[test]
     fn warm_pool_size_is_claim_eligible_only_for_throwaway_runs() {
-        // Transient + interactive-transient are auto-named cattle → eligible:
+        // Unnamed transient + interactive-transient are cattle → eligible:
         // an explicit override is honoured verbatim (the residency-policy default
         // for `None` is env-dependent, so the override path is the deterministic
         // assertion).
-        assert_eq!(MachineRunMode::Transient.warm_pool_size(Some(3)), 3);
+        assert_eq!(MachineRunMode::Transient.warm_pool_size(Some(3), false), 3);
         assert_eq!(
-            MachineRunMode::InteractiveTransient.warm_pool_size(Some(2)),
+            MachineRunMode::InteractiveTransient.warm_pool_size(Some(2), false),
             2
         );
-        // A user-named / `-d` persistent machine is long-lived, never pooled —
-        // size 0 regardless of any override.
-        assert_eq!(MachineRunMode::Persistent.warm_pool_size(Some(5)), 0);
-        assert_eq!(MachineRunMode::Persistent.warm_pool_size(None), 0);
+        // A user-named foreground run has an observable identity, so it never
+        // reuses pool cattle.
+        assert_eq!(MachineRunMode::Transient.warm_pool_size(Some(3), true), 0);
         assert_eq!(
-            MachineRunMode::InteractivePersistent.warm_pool_size(Some(5)),
+            MachineRunMode::InteractiveTransient.warm_pool_size(Some(2), true),
             0
         );
-        assert_eq!(
-            MachineRunMode::InteractivePersistent.warm_pool_size(None),
-            0
-        );
+        // A persistent machine is long-lived, never pooled — size 0 regardless
+        // of any override.
+        assert_eq!(MachineRunMode::Persistent.warm_pool_size(Some(5), false), 0);
+        assert_eq!(MachineRunMode::Persistent.warm_pool_size(None, true), 0);
     }
 
     #[test]
@@ -3127,37 +3038,6 @@ mod tests {
             msg.contains("tty") || msg.contains("terminal") || msg.contains("interactive"),
             "msg: {msg}"
         );
-    }
-
-    #[test]
-    fn interactive_pty_argv_uses_same_command_quoting_as_exec() {
-        assert!(machine_interactive_pty_argv(&[]).is_empty());
-
-        let argv = vec![
-            "sh".to_string(),
-            "-lc".to_string(),
-            "echo hello world".to_string(),
-        ];
-        assert_eq!(
-            machine_interactive_pty_argv(&argv),
-            vec![
-                "/bin/sh".to_string(),
-                "-lc".to_string(),
-                machine_exec_command(&argv),
-            ]
-        );
-    }
-
-    #[test]
-    fn interactive_tears_down_only_the_transient_machine() {
-        let transient = parse_run(&["run", "-t", "--image", "x"]).expect("parse");
-        assert!(should_teardown_after_interactive(&transient));
-
-        let named = parse_run(&["run", "-it", "--name", "web", "--image", "x"]).expect("parse");
-        assert!(!should_teardown_after_interactive(&named));
-
-        let detached = parse_run(&["run", "-it", "-d", "--image", "x"]).expect("parse");
-        assert!(!should_teardown_after_interactive(&detached));
     }
 
     #[test]
@@ -3473,6 +3353,8 @@ mod tests {
                 assert_eq!(args.name, "web");
                 assert_eq!(args.argv, vec!["echo", "hello world"]);
                 assert!(!args.force);
+                assert!(!args.tty);
+                assert!(!args.interactive);
             }
             other => panic!("expected exec action, got {other:?}"),
         }
@@ -3496,6 +3378,19 @@ mod tests {
     fn exec_requires_argv() {
         let err = parse(&["exec", "--name", "web"]).expect_err("argv is required");
         assert_eq!(err.kind(), clap::error::ErrorKind::MissingRequiredArgument);
+    }
+
+    #[test]
+    fn exec_accepts_it_for_pty_command() {
+        match parse(&["exec", "--name", "web", "-it", "--", "/bin/sh"]).expect("parse") {
+            MachineAction::Exec(args) => {
+                assert_eq!(args.name, "web");
+                assert!(args.tty);
+                assert!(args.interactive);
+                assert_eq!(args.argv, vec!["/bin/sh"]);
+            }
+            other => panic!("expected exec action, got {other:?}"),
+        }
     }
 
     #[test]

--- a/crates/mvm-cli/src/commands/ops/mcp.rs
+++ b/crates/mvm-cli/src/commands/ops/mcp.rs
@@ -415,6 +415,7 @@ impl ExecDispatcher {
     ) -> Result<crate::exec::ExecOutput, anyhow::Error> {
         let argv = bash_dash_c(&shell_escape(code));
         let req = crate::exec::ExecRequest {
+            name: None,
             image: crate::exec::ImageSource::Template(env.to_string()),
             // MCP sessions don't use the warm pool.
             warm_pool_size: 0,
@@ -425,6 +426,7 @@ impl ExecDispatcher {
             env: Vec::new(),
             target: crate::exec::ExecTarget::Inline { argv },
             timeout_secs: Some(timeout),
+            pty: false,
             // MCP runs untrusted code: deny egress by default.
             network_policy: mvm_core::network_policy::NetworkPolicy::deny_all(),
         };

--- a/crates/mvm-cli/src/commands/vm/console.rs
+++ b/crates/mvm-cli/src/commands/vm/console.rs
@@ -192,14 +192,26 @@ fn touch_activity(name: &str) {
 /// sockets), Apple Container (via direct vsock), and vsock proxy (via
 /// daemon Unix socket for cross-process access).
 pub(in crate::commands) fn console_interactive(name: &str) -> Result<()> {
-    console_interactive_with_env(name, Vec::new())
+    console_interactive_with_env(name, Vec::new()).map(|_| ())
 }
 
 pub(in crate::commands) fn console_interactive_with_env(
     name: &str,
     env: Vec<(String, String)>,
+) -> Result<i32> {
+    console_pty_with_argv(name, env, Vec::new())
+}
+
+pub(crate) fn console_pty_command(
+    name: &str,
+    command: String,
+    env: Vec<(String, String)>,
 ) -> Result<()> {
-    console_interactive_with_env_and_argv(name, env, Vec::new())
+    let exit_code = run_pty_command_for_exit(name, command, env)?;
+    if exit_code != 0 {
+        std::process::exit(exit_code);
+    }
+    Ok(())
 }
 
 pub(in crate::commands) fn console_interactive_with_env_and_argv(
@@ -207,6 +219,26 @@ pub(in crate::commands) fn console_interactive_with_env_and_argv(
     env: Vec<(String, String)>,
     argv: Vec<String>,
 ) -> Result<()> {
+    let exit_code = console_pty_with_argv(name, env, argv)?;
+    if exit_code != 0 {
+        std::process::exit(exit_code);
+    }
+    Ok(())
+}
+
+pub(crate) fn run_pty_command_for_exit(
+    name: &str,
+    command: String,
+    env: Vec<(String, String)>,
+) -> Result<i32> {
+    console_pty_with_argv(name, env, shell_command_argv(command))
+}
+
+fn shell_command_argv(command: String) -> Vec<String> {
+    vec!["/bin/sh".to_string(), "-lc".to_string(), command]
+}
+
+fn console_pty_with_argv(name: &str, env: Vec<(String, String)>, argv: Vec<String>) -> Result<i32> {
     let (cols, rows) = get_terminal_size();
 
     ui::info(&format!(
@@ -270,8 +302,23 @@ pub(in crate::commands) fn console_interactive_with_env_and_argv(
 
     mvm_core::audit_emit!(ConsoleSessionEnd, vm: name, "session_id={session_id}");
 
+    let exit_code = console_exit_code(&transport, session_id)?;
     println!("\nConsole session ended.");
-    result.map(|_| ())
+    result.map(|_| exit_code)
+}
+
+fn console_exit_code(transport: &Arc<dyn VsockTransport>, session_id: u32) -> Result<i32> {
+    let mut stream = transport.connect(mvm_guest::vsock::GUEST_AGENT_PORT)?;
+    mvm_guest::vsock::require_capabilities(
+        &mut stream,
+        &[mvm_guest::vsock::GuestCapability::Console],
+    )?;
+    let req = mvm_guest::vsock::GuestRequest::ConsoleClose { session_id };
+    match mvm_guest::vsock::call_unary(&mut stream, &req)? {
+        mvm_guest::vsock::GuestResponse::ConsoleExited { exit_code, .. } => Ok(exit_code),
+        mvm_guest::vsock::GuestResponse::Error { message } => anyhow::bail!("{message}"),
+        other => anyhow::bail!("Unexpected response: {other:?}"),
+    }
 }
 
 /// Flag set by the SIGWINCH signal handler.

--- a/crates/mvm-cli/src/commands/vm/exec.rs
+++ b/crates/mvm-cli/src/commands/vm/exec.rs
@@ -37,6 +37,12 @@ pub(in crate::commands) struct Args {
     /// from `machine run` dispatch. `> 0` ⇒ eligible to claim a warm standby.
     #[arg(skip)]
     pub warm_pool_size: u32,
+    /// Internal (not a CLI flag): attach the command to a PTY.
+    #[arg(skip)]
+    pub pty: bool,
+    /// Internal (not a CLI flag): optional foreground transient VM identity.
+    #[arg(skip)]
+    pub vm_name: Option<String>,
     /// vCPU cores (default: 2)
     #[arg(long, default_value = "2")]
     pub cpus: u32,
@@ -101,6 +107,12 @@ pub(in crate::commands) struct RunArgs {
     /// claim a pre-booted standby + replenish the pool.
     #[arg(skip)]
     pub warm_pool_size: u32,
+    /// Internal (not a CLI flag): attach the command to a PTY.
+    #[arg(skip)]
+    pub pty: bool,
+    /// Internal (not a CLI flag): optional foreground transient VM identity.
+    #[arg(skip)]
+    pub vm_name: Option<String>,
     /// Enable dev-tier outbound networking (broad egress + DNS). Off by
     /// default (deny-all). Narrow it with `--allow-host`.
     #[arg(long)]
@@ -234,6 +246,8 @@ impl RunArgs {
         Args {
             manifest: self.manifest,
             warm_pool_size: self.warm_pool_size,
+            pty: self.pty,
+            vm_name: self.vm_name,
             cpus: self.cpus,
             memory: self.memory,
             add_dir: self.add_dir,
@@ -655,6 +669,7 @@ fn build_exec_request(
         }
     };
     Ok(crate::exec::ExecRequest {
+        name: args.vm_name,
         image,
         cpus: args.cpus,
         memory_mib,
@@ -666,6 +681,7 @@ fn build_exec_request(
         env: env_pairs,
         target,
         timeout_secs: args.timeout,
+        pty: args.pty,
         network_policy,
         warm_pool_size: args.warm_pool_size,
     })
@@ -1335,6 +1351,8 @@ mod tests {
     fn run_args(profile: RunProfile) -> RunArgs {
         RunArgs {
             warm_pool_size: 0,
+            pty: false,
+            vm_name: None,
             manifest: None,
             image: None,
             net: false,

--- a/crates/mvm-cli/src/commands/vm/mod.rs
+++ b/crates/mvm-cli/src/commands/vm/mod.rs
@@ -3,7 +3,7 @@
 pub(super) mod artifact;
 pub(super) mod audit_chain;
 pub(super) mod checkpoint;
-pub(super) mod console;
+pub(crate) mod console;
 pub(super) mod cp;
 pub(super) mod diff;
 pub(super) mod down;

--- a/crates/mvm-cli/src/commands/vm/run_plan.rs
+++ b/crates/mvm-cli/src/commands/vm/run_plan.rs
@@ -529,6 +529,8 @@ mod tests {
         RunArgs {
             manifest: None,
             warm_pool_size: 0,
+            pty: false,
+            vm_name: None,
             image: None,
             net: false,
             allow_host: Vec::new(),

--- a/crates/mvm-cli/src/exec.rs
+++ b/crates/mvm-cli/src/exec.rs
@@ -156,6 +156,9 @@ pub enum ImageSource {
 /// All inputs to the orchestrator.
 #[derive(Debug, Clone)]
 pub struct ExecRequest {
+    /// Optional VM identity for a foreground transient run. Absent generates a
+    /// throwaway name.
+    pub name: Option<String>,
     pub image: ImageSource,
     pub cpus: u32,
     pub memory_mib: u32,
@@ -173,6 +176,8 @@ pub struct ExecRequest {
     /// Timeout for the in-guest command in seconds. `None` ⇒ no per-command
     /// kill (the default for interactive/ad-hoc exec).
     pub timeout_secs: Option<u64>,
+    /// Run the command attached to a PTY instead of pipe-streamed stdio.
+    pub pty: bool,
     /// Effective egress policy for the transient VM. Defaults to
     /// `deny_all`; `--net` / `--allow-host` widen it. Threaded onto
     /// `VmStartConfig.network_policy` so every backend enforces the same
@@ -401,13 +406,7 @@ pub fn build_guest_wrapper(req: &ExecRequest, add_dir_labels: &[String]) -> Stri
 
 /// Generate a transient VM name for an exec invocation.
 pub fn transient_vm_name() -> String {
-    use std::time::{SystemTime, UNIX_EPOCH};
-    let nanos = SystemTime::now()
-        .duration_since(UNIX_EPOCH)
-        .map(|d| d.subsec_nanos())
-        .unwrap_or_default();
-    let pid = std::process::id();
-    format!("exec-{pid:x}-{nanos:08x}")
+    mvm_core::naming::generate_machine_name()
 }
 
 /// Decide whether snapshot restore is safe for this request.
@@ -545,7 +544,7 @@ fn run_inner(
 
     // Build read-only ext4 images for each --add-dir, staged in a transient
     // VMS subdirectory so cleanup is straightforward.
-    let mut vm_name = transient_vm_name();
+    let mut vm_name = req.name.clone().unwrap_or_else(transient_vm_name);
     let staging_dir = format!("{}/{}/extras", mvm::config::VMS_DIR, vm_name);
     let mut volumes: Vec<mvm_backend::image::RuntimeVolume> = Vec::new();
     let mut add_dir_labels: Vec<String> = Vec::new();
@@ -881,6 +880,12 @@ fn run_in_guest(
     let vsock_ready = timing.then(std::time::Instant::now);
     let wrapper = build_guest_wrapper(req, labels);
 
+    if req.pty {
+        let exit_code =
+            crate::commands::vm::console::run_pty_command_for_exit(vm_name, wrapper, Vec::new())?;
+        return Ok((Either::Left(exit_code), vsock_ready));
+    }
+
     let transport = vsock_transport::for_vm(vm_name)?;
     let mut stream = transport.connect(mvm_guest::vsock::GUEST_AGENT_PORT)?;
     // Inbound vsock RPC audit. exec.rs is a top-level module that can't
@@ -1112,6 +1117,7 @@ pub fn dispatch_in_session(
     // with no add_dirs (sessions don't take --add-dir). The wrapper
     // emits `set -e\n<env exports>\n<argv>\n`.
     let req = ExecRequest {
+        name: None,
         warm_pool_size: 0,
         image: ImageSource::Template(String::new()),
         cpus: 0,
@@ -1123,6 +1129,7 @@ pub fn dispatch_in_session(
             argv: vec!["bash".to_string(), "-c".to_string(), code],
         },
         timeout_secs,
+        pty: false,
         // Wrapper-string construction only — the session VM is already
         // running, so this never reaches a backend boot.
         network_policy: mvm_core::network_policy::NetworkPolicy::deny_all(),
@@ -1309,6 +1316,7 @@ mod tests {
     #[test]
     fn target_command_inline_quotes_each_arg() {
         let req = ExecRequest {
+            name: None,
             warm_pool_size: 0,
             image: ImageSource::Template("t".into()),
             cpus: 1,
@@ -1320,6 +1328,7 @@ mod tests {
                 argv: vec!["uname".into(), "-a".into()],
             },
             timeout_secs: Some(30),
+            pty: false,
             network_policy: mvm_core::network_policy::NetworkPolicy::deny_all(),
         };
         assert_eq!(req.target_command(), "exec 'uname' '-a'");
@@ -1328,6 +1337,7 @@ mod tests {
     #[test]
     fn build_guest_wrapper_no_extras() {
         let req = ExecRequest {
+            name: None,
             warm_pool_size: 0,
             image: ImageSource::Template("t".into()),
             cpus: 1,
@@ -1339,6 +1349,7 @@ mod tests {
                 argv: vec!["true".into()],
             },
             timeout_secs: Some(30),
+            pty: false,
             network_policy: mvm_core::network_policy::NetworkPolicy::deny_all(),
         };
         let script = build_guest_wrapper(&req, &[]);
@@ -1351,6 +1362,7 @@ mod tests {
     #[test]
     fn build_guest_wrapper_mounts_and_env() {
         let req = ExecRequest {
+            name: None,
             warm_pool_size: 0,
             image: ImageSource::Template("t".into()),
             cpus: 1,
@@ -1366,6 +1378,7 @@ mod tests {
                 argv: vec!["echo".into(), "$FOO".into()],
             },
             timeout_secs: Some(30),
+            pty: false,
             network_policy: mvm_core::network_policy::NetworkPolicy::deny_all(),
         };
         let script = build_guest_wrapper(&req, &["mvm-extra-0".to_string()]);
@@ -1378,6 +1391,7 @@ mod tests {
     #[test]
     fn build_guest_wrapper_writable_mount_drops_ro_flag() {
         let req = ExecRequest {
+            name: None,
             warm_pool_size: 0,
             image: ImageSource::Template("t".into()),
             cpus: 1,
@@ -1393,6 +1407,7 @@ mod tests {
                 argv: vec!["true".into()],
             },
             timeout_secs: Some(30),
+            pty: false,
             network_policy: mvm_core::network_policy::NetworkPolicy::deny_all(),
         };
         let script = build_guest_wrapper(&req, &["mvm-extra-0".to_string()]);
@@ -1407,8 +1422,9 @@ mod tests {
     #[test]
     fn transient_vm_name_format() {
         let n = transient_vm_name();
-        assert!(n.starts_with("exec-"));
-        assert!(n.len() > "exec-".len());
+        mvm_core::naming::validate_vm_name(&n)
+            .unwrap_or_else(|e| panic!("transient name {n:?} invalid: {e}"));
+        assert_eq!(n.split('-').count(), 3);
         assert!(!n.contains(' '));
         assert!(!n.contains('/'));
     }
@@ -1609,6 +1625,7 @@ mod tests {
     #[test]
     fn target_command_launch_plan_quotes_argv() {
         let req = ExecRequest {
+            name: None,
             warm_pool_size: 0,
             image: ImageSource::Template("t".into()),
             cpus: 1,
@@ -1624,6 +1641,7 @@ mod tests {
                 },
             },
             timeout_secs: Some(30),
+            pty: false,
             network_policy: mvm_core::network_policy::NetworkPolicy::deny_all(),
         };
         assert_eq!(req.target_command(), "exec 'python' '-m' 'x'");
@@ -1635,6 +1653,7 @@ mod tests {
         env.insert("PORT".to_string(), "8080".to_string());
         env.insert("LOG".to_string(), "info".to_string());
         let req = ExecRequest {
+            name: None,
             warm_pool_size: 0,
             image: ImageSource::Template("t".into()),
             cpus: 1,
@@ -1650,6 +1669,7 @@ mod tests {
                 },
             },
             timeout_secs: Some(30),
+            pty: false,
             network_policy: mvm_core::network_policy::NetworkPolicy::deny_all(),
         };
         let script = build_guest_wrapper(&req, &[]);
@@ -1676,6 +1696,7 @@ mod tests {
     fn build_guest_wrapper_inline_target_unchanged() {
         // Sanity: inline target wrapper still does not emit cd or extra env blocks.
         let req = ExecRequest {
+            name: None,
             warm_pool_size: 0,
             image: ImageSource::Template("t".into()),
             cpus: 1,
@@ -1687,6 +1708,7 @@ mod tests {
                 argv: vec!["true".into()],
             },
             timeout_secs: Some(30),
+            pty: false,
             network_policy: mvm_core::network_policy::NetworkPolicy::deny_all(),
         };
         let script = build_guest_wrapper(&req, &[]);

--- a/crates/mvm-core/src/naming.rs
+++ b/crates/mvm-core/src/naming.rs
@@ -83,6 +83,27 @@ pub fn generate_instance_id() -> String {
     )
 }
 
+/// Generate a human-friendly VM name, e.g. "brisk-otter-a1b2".
+///
+/// The suffix keeps the name collision-resistant while preserving a stable,
+/// easy-to-say shape for CLI output and logs.
+pub fn generate_machine_name() -> String {
+    const ADJECTIVES: &[&str] = &[
+        "brisk", "calm", "clever", "cozy", "dapper", "fuzzy", "gentle", "glossy", "happy",
+        "lively", "merry", "nimble", "plucky", "quiet", "snug", "sunny",
+    ];
+    const ANIMALS: &[&str] = &[
+        "badger", "beaver", "finch", "gecko", "heron", "koala", "lemur", "lynx", "marten", "otter",
+        "panda", "pika", "puffin", "quokka", "stoat", "wombat",
+    ];
+
+    let bytes = rand_bytes();
+    let adjective = ADJECTIVES[usize::from(bytes[0]) % ADJECTIVES.len()];
+    let animal = ANIMALS[usize::from(bytes[1]) % ANIMALS.len()];
+    let suffix = u16::from_be_bytes([bytes[2], bytes[3]]);
+    format!("{adjective}-{animal}-{suffix:04x}")
+}
+
 /// Generate a TAP device name: tn<net_id>i<ip_offset>.
 /// Max 12 chars, fits within Linux 15-char IFNAMSIZ limit.
 pub fn tap_name(tenant_net_id: u16, ip_offset: u8) -> String {
@@ -170,6 +191,16 @@ mod tests {
         let id = generate_instance_id();
         assert!(id.starts_with("i-"));
         assert_eq!(id.len(), 10); // "i-" + 8 hex chars
+    }
+
+    #[test]
+    fn test_generate_machine_name_is_valid_vm_name() {
+        let name = generate_machine_name();
+        validate_vm_name(&name).unwrap_or_else(|e| panic!("generated name {name:?}: {e}"));
+        assert!(
+            name.split('-').count() == 3,
+            "expected adjective-animal-hex, got {name:?}"
+        );
     }
 
     #[test]

--- a/crates/mvm-guest/src/bin/mvm-guest-agent.rs
+++ b/crates/mvm-guest/src/bin/mvm-guest-agent.rs
@@ -2397,7 +2397,7 @@ fn handle_client(
         },
 
         #[cfg(feature = "dev-shell")]
-        GuestRequest::ConsoleClose { session_id: _ } => {
+        GuestRequest::ConsoleClose { session_id } => {
             // Console sessions end when the shell exits or the host disconnects.
             // Explicit close is a no-op if already closed.
             if mvm_guest::console::is_active() {
@@ -2405,9 +2405,14 @@ fn handle_client(
                     message: "explicit close not yet supported — disconnect to end session"
                         .to_string(),
                 }
+            } else if let Some(exit_code) = mvm_guest::console::completed_exit_code(session_id) {
+                GuestResponse::ConsoleExited {
+                    session_id,
+                    exit_code,
+                }
             } else {
                 GuestResponse::ConsoleExited {
-                    session_id: 0,
+                    session_id,
                     exit_code: 0,
                 }
             }

--- a/crates/mvm-guest/src/console.rs
+++ b/crates/mvm-guest/src/console.rs
@@ -17,6 +17,8 @@ use crate::vsock::CONSOLE_PORT_BASE;
 /// Tracks the active console session. Only one session at a time.
 static CONSOLE_ACTIVE: AtomicBool = AtomicBool::new(false);
 static CONSOLE_SESSION_ID: AtomicU32 = AtomicU32::new(0);
+static COMPLETED_SESSION_ID: AtomicU32 = AtomicU32::new(0);
+static COMPLETED_EXIT_CODE: std::sync::atomic::AtomicI32 = std::sync::atomic::AtomicI32::new(0);
 /// Active PTY master fd for resize support. -1 when no session is active.
 static CONSOLE_MASTER_FD: std::sync::atomic::AtomicI32 = std::sync::atomic::AtomicI32::new(-1);
 
@@ -139,6 +141,8 @@ pub fn open_session(
 
     let session_id = CONSOLE_SESSION_ID.fetch_add(1, Ordering::SeqCst) + 1;
     let data_port = CONSOLE_PORT_BASE + session_id;
+    COMPLETED_SESSION_ID.store(0, Ordering::SeqCst);
+    COMPLETED_EXIT_CODE.store(0, Ordering::SeqCst);
 
     let ws = Winsize {
         ws_row: rows,
@@ -177,7 +181,6 @@ pub fn open_session(
     let shell_env = build_shell_env_with(extra_env);
     let mut envp: Vec<*const u8> = shell_env.iter().map(|c| c.as_ptr().cast::<u8>()).collect();
     envp.push(std::ptr::null());
-
     // SAFETY: fork() takes no arguments and has no preconditions; it returns
     // twice (0 in the child, the child pid in the parent).
     let pid = unsafe { fork() };
@@ -199,10 +202,10 @@ pub fn open_session(
         //
         // SAFETY: `slave_fd`/`master_fd` are valid fds from openpty; dup2's
         // target fds 0/1/2 are always valid; `argv` and `envp` are
-        // NUL-/NULL-terminated arrays whose backing storage (`shell_env`,
-        // the byte literals) was allocated in the parent before the fork and
-        // is unmodified in the child's copy-on-write image. `execve` replaces
-        // the process image and only returns on error.
+        // NUL-/NULL-terminated arrays whose backing storage was allocated in
+        // the parent before the fork and is unmodified in the child's
+        // copy-on-write image. `execve` replaces the process image and only
+        // returns on error.
         unsafe {
             close(master_fd);
             setsid();
@@ -313,11 +316,13 @@ pub fn close_session(session: &ConsoleSession) -> i32 {
     CONSOLE_ACTIVE.store(false, Ordering::SeqCst);
 
     // Extract exit code
-    if status & 0x7f == 0 {
+    let exit_code = if status & 0x7f == 0 {
         (status >> 8) & 0xff // normal exit
     } else {
         128 + (status & 0x7f) // signal
-    }
+    };
+    record_completed_session(session.session_id, exit_code);
+    exit_code
 }
 
 /// Start the vsock data relay for a console session.
@@ -498,16 +503,31 @@ pub fn run_console_relay(session: &ConsoleSession) -> i32 {
 
     // Don't call close_session — we already waited and the fds are owned
     // by the File/UnixStream objects which will drop.
-    if status & 0x7f == 0 {
+    let exit_code = if status & 0x7f == 0 {
         (status >> 8) & 0xff
     } else {
         128 + (status & 0x7f)
-    }
+    };
+    record_completed_session(session.session_id, exit_code);
+    exit_code
 }
 
 /// Check if a console session is currently active.
 pub fn is_active() -> bool {
     CONSOLE_ACTIVE.load(Ordering::SeqCst)
+}
+
+fn record_completed_session(session_id: u32, exit_code: i32) {
+    COMPLETED_EXIT_CODE.store(exit_code, Ordering::SeqCst);
+    COMPLETED_SESSION_ID.store(session_id, Ordering::SeqCst);
+}
+
+pub fn completed_exit_code(session_id: u32) -> Option<i32> {
+    if COMPLETED_SESSION_ID.load(Ordering::SeqCst) == session_id {
+        Some(COMPLETED_EXIT_CODE.load(Ordering::SeqCst))
+    } else {
+        None
+    }
 }
 
 // FFI for chdir / shutdown
@@ -601,6 +621,10 @@ mod tests {
         );
         assert_eq!(ConsoleError::OpenPtyFailed.to_string(), "openpty() failed");
         assert_eq!(ConsoleError::ForkFailed.to_string(), "fork() failed");
+        assert_eq!(
+            ConsoleError::InvalidCommand.to_string(),
+            "console command contains an interior NUL"
+        );
         assert_eq!(
             ConsoleError::BindFailed(20001).to_string(),
             "failed to bind vsock port 20001"

--- a/public/src/content/docs/guides/exec.md
+++ b/public/src/content/docs/guides/exec.md
@@ -236,8 +236,8 @@ highest):
   process and any tap interface don't get orphaned.
 - **Hard kill** (`kill -9` on `mvmctl exec` itself): teardown is
   best-effort; you may need `mvmctl ls` and `mvmctl machine stop <name>` to
-  clean up. Each transient VM is named `exec-<pid>-<rand>` so they're
-  easy to spot.
+  clean up. Each unnamed transient VM gets a generated name like
+  `brisk-otter-a1b2`, so it is easy to spot.
 
 ## Limits
 

--- a/public/src/content/docs/reference/cli-commands.md
+++ b/public/src/content/docs/reference/cli-commands.md
@@ -362,26 +362,23 @@ flag:
   `mvmctl run --image`, inheriting **deny-all networking by default**, opt-in
   egress via `--net` / `--allow-host`, and the same `--profile`, `--volume`,
   `--receipt`, `--json`, and `--dry-run` semantics.
-- **Persistent** (`--name <N>` or `-d`/`--detach`): boot a machine that survives
-  the command and is reconnectable by name through `machine shell`/`exec`/`stop`.
-  `--name` gives it a name; bare `-d` auto-generates one and prints it. With a
-  command, the command is run (streamed) and the machine is left up; without one,
-  the machine just boots.
-- **Interactive** (`-t`/`--tty`, with `-i` accepted so `-it` parses): attach a
-  PTY shell. **Dev-only** — refused for a sealed image (claim 15) and when stdin
-  is not a terminal. `-t` alone is a transient interactive machine (gone when the
-  shell exits); combine with `--name`/`-d` to keep it up. With a trailing
-  `-- <argv>`, the same argv is run with a PTY attached; without argv, the guest
-  default shell is used.
+- **Foreground interactive** (`-t`/`--tty`, with `-i` accepted so `-it`
+  parses): boot a fresh transient VM, run the requested argv attached to a PTY,
+  return that command's exit code, then tear the VM down. **Dev-only** —
+  refused for a sealed image (claim 15) and when stdin is not a terminal.
+- **Persistent** (`machine create` + `machine start`, or `machine run -d`):
+  boot a machine that survives after the command returns and is reconnectable by
+  name through `machine shell`/`exec`/`stop`. Bare `-d` auto-generates a name and
+  prints it; `-d --name <N>` uses your chosen name.
 
-Persistence and interactivity are independent: `--tty` never changes whether the
-machine survives. `--volume` host shares work on every mode — transient,
-persistent, and interactive. The syntax is `HOST:/GUEST[:MODE]` (`MODE` defaults
-to `ro`; `rw` needs `--profile dev` or `permissive`). On a persistent (`-d`/
-`--name`) or interactive (`-t`) machine the host path is canonicalized to an
-absolute path and stored in the machine spec, so a later reconnect re-mounts the
-same share regardless of your working directory; the host directory must exist at
-boot.
+Identity and lifetime are separate: `--name <N>` names a foreground transient
+run but does not make it persistent. `-d`/`--detach`, `--up-json`, or the
+explicit `machine create`/`start` lifecycle make a long-lived machine.
+`--volume` host shares work on every run mode. The syntax is
+`HOST:/GUEST[:MODE]` (`MODE` defaults to `ro`; `rw` needs `--profile dev` or
+`permissive`). Persistent machine specs canonicalize host paths to absolute
+paths so later reconnects re-mount the same share regardless of your working
+directory; the host directory must exist at boot.
 
 SSH sessions are banned in microVMs. `--allow-host <host:22>` is refused, and
 the runtime also denies TCP/22 even under broad egress. Dev-tier `ssh_agent`
@@ -399,13 +396,10 @@ or mounts private keys, `~/.ssh`, known-hosts material, or SSH config.
 | `mvmctl machine run --image <ref> --json -- <cmd>` | Print a redacted JSON execution summary |
 | `mvmctl machine run --image <ref> --receipt <path> -- <cmd>` | Write a signed execution receipt |
 | `mvmctl machine run -d --image <ref>` | Boot a **persistent** machine, auto-name it (printed), return |
-| `mvmctl machine run --name <name> --image <ref>` | Boot a persistent named machine, return; reconnect via `machine shell <name>` |
-| `mvmctl machine run --name <name> --image <ref> -- <cmd>` | Boot a persistent named machine, run `<cmd>` (streamed), leave it up |
-| `mvmctl machine run --name <name>` | Reconnect to an existing machine by name (no `--image` needed) |
-| `mvmctl machine run --name <name> --image <ref2>` | A changed config auto-recreates the machine (stop + reboot), announced on stderr |
-| `mvmctl machine run -it --image <ref>` | **Interactive** dev shell on a transient machine (gone on exit) |
-| `mvmctl machine run -it --image <ref> -- /bin/sh` | Interactive `/bin/sh` PTY on a transient machine |
-| `mvmctl machine run -it --name <name> --image <ref>` | Interactive dev shell on a persistent machine (left up on exit) |
+| `mvmctl machine run -d --name <name> --image <ref>` | Boot a **persistent** named machine, return; reconnect via `machine shell --name <name>` |
+| `mvmctl machine run --name <name> --image <ref> -- <cmd>` | Boot a named foreground transient machine, run `<cmd>`, tear down |
+| `mvmctl machine run -it --image <ref> -- <cmd>` | Run `<cmd>` attached to a PTY, return its exit code, tear down |
+| `mvmctl machine run -it --name <name> --image <ref> -- <cmd>` | Same, with a stable transient VM name while it runs |
 | `mvmctl machine create --name <name> --image <ref>` | Persist a named OCI-backed machine spec without booting it |
 | `mvmctl machine create --name <name> --manifest <path>` | Persist a named machine spec from an image-backed `mvm.toml` / `Mvmfile.toml` |
 | `mvmctl machine create --name <name> --image <ref> --net --allow-host <host[:port]>` | Persist a named spec with opt-in egress settings for future lifecycle starts |
@@ -423,6 +417,7 @@ or mounts private keys, `~/.ssh`, known-hosts material, or SSH config.
 | `mvmctl machine rm <name> --yes` | Remove one persisted named machine spec |
 | `mvmctl machine rm <name> --yes --json` | Print a JSON deletion summary |
 | `mvmctl machine exec --name <name> -- <cmd>...` | Run a command in an already-started named machine |
+| `mvmctl machine exec --name <name> -it -- <cmd>...` | Run a command in an already-started named machine attached to a PTY |
 | `mvmctl machine shell --name <name>` | Attach an interactive shell/console to an already-started named machine |
 | `mvmctl machine stop --name <name>` | Stop an already-started named machine |
 | `mvmctl machine check-artifact <artifact.mvm>` | Verify a portable artifact and preview its admission posture without extracting or booting |
@@ -439,43 +434,39 @@ mvmctl machine run --image alpine -- echo hi      # prints "hi", VM gone
 ```
 
 A bare `machine run --image alpine -- /bin/sh` is **non-interactive**: it streams
-the command's output but forwards no stdin, so an interactive shell sees EOF and
-exits at once. For a live shell, add `-it` (dev-only — see below):
+the command's output but forwards no terminal. For a live shell or any command
+that needs a TTY, add `-it` and pass the foreground argv explicitly:
 
 ```bash
-mvmctl machine run -it --image <dev-image> -- /bin/sh   # live shell, VM gone on exit
+mvmctl machine run -it --image <dev-image> -- /bin/sh   # exits with /bin/sh, VM gone
+mvmctl machine run -it --image <dev-image> -- htop      # exits with htop, VM gone
 ```
 
-Naming or detaching is the *only* thing that keeps a machine alive past the
-command — that is the whole difference between a transient and a persistent run:
+Naming a foreground run does not make it persistent; it only gives the transient
+VM a stable identity while it is running:
+
+```bash
+mvmctl machine run --name debug --image alpine -- echo hi
+mvmctl machine run -it --name debug --image <dev-image> -- /bin/sh
+```
+
+Use the explicit persistent lifecycle when you want the VM to survive:
 
 ```bash
 mvmctl machine run -d --image alpine          # boots, prints e.g. "blue-fox-3f2a", returns
 mvmctl machine shell --name blue-fox-3f2a     # reconnect (dev PTY)
 mvmctl machine exec  --name blue-fox-3f2a -- ps   # one-shot command in the running machine
+mvmctl machine exec  --name blue-fox-3f2a -it -- /bin/sh   # PTY command in the running machine
 mvmctl machine stop  --name blue-fox-3f2a     # tear it down when done
 ```
 
-`--name <N>` does the same with a name you choose; `machine run --name <N>` with
-no `--image` reconnects to an existing machine.
+`-d --name <N>` does the same with a name you choose.
 
-**Config change auto-recreates.** A matching config reconnects to the existing
-machine. A *different* config (image, CPU, memory, profile, volumes, …)
-**recreates** it — `machine run` stops the old instance, overwrites the spec, and
-reboots, converging like `compose up` (the machine is cattle; durable data
-belongs in `--volume` host shares, which survive the recreate). The recreate is
-announced on stderr (`machine 'N': config changed (…) — stopping the old instance
-and recreating it`) so an unintended clobber, e.g. a typo'd `--image`, is visible.
-To keep two configs side by side, give them different `--name`s.
-
-**Interactive is dev-only.** `-t`/`--tty`, `machine shell`, `machine console`,
-and `machine exec` are refused for sealed/production images (claim 15 — no
-interactive or arbitrary shell access to a sealed microVM). There is no `--force`
-override for that refusal. `-it` also requires stdin to be a terminal, failing
-fast rather than hanging when it is not. It never affects persistence: `-it`
-alone is transient, `-it` with `--name`/`-d` keeps the machine. The design
-rationale and full behavior matrix are recorded in ADR-091
-(`specs/adrs/091-unified-machine-run-lifecycle.md`).
+**Interactive is dev-only.** `-t`/`--tty` attaches the foreground command to a
+PTY and is refused for a sealed/production image (claim 15 — no interactive
+access to a sealed microVM) and when stdin is not a terminal. `machine run -it`
+requires an argv after `--`; use `machine shell --name <name>` for the default
+shell on an already-running machine.
 
 `machine create` accepts either `--image <ref>` or an image-backed manifest, not
 both. When `--image` is omitted, it searches the current directory for


### PR DESCRIPTION
## Summary
- Make foreground machine runs transient even when --name is provided; --name is identity only unless -d/--up-json/--ttl is used.
- Route machine run -it through the explicit argv command path attached to a PTY, returning the guest command exit code and tearing down afterward.
- Add machine exec --name <name> -it -- <cmd> for PTY commands in already-running machines, and keep shell as the persistent default-console path.
- Generate human-friendly names for unnamed transient/persistent runs, e.g. brisk-otter-a1b2.
- Update CLI docs for transient vs persistent lifecycle semantics.

## Verification
- cargo test --workspace
- cargo clippy --workspace --all-targets -- -D warnings
- cargo test -p mvm-core naming::tests::
- cargo test -p mvm-cli --lib transient_vm_name_format
- cargo test -p mvm-cli --lib commands::machine::tests::
- cargo test -p mvm-guest --lib
- cargo check -p mvm-core -p mvm-cli -p mvm-guest
- git diff --check

## Live smoke status
- Blocked: builder/dev VM startup did not reach running state in this session.
- Vz attempt: cargo run -- dev up --no-shell --json spawned target/debug/mvm-vz-supervisor but remained silent; dev status still reported state=stopped. The stuck process was terminated.
- libkrun attempt: cargo run -- --builder libkrun dev up --no-shell --json spawned mvm-libkrun-supervisor/gvproxy and remained at gvproxy waiting for clients; dev status still reported state=stopped. The stuck process was terminated.
