### PR TITLE
feat(machine): Machine::select_backend, fail-closed (Plan 214 slice 4)

### DIFF
--- a/crates/mvm/src/machine/mod.rs
+++ b/crates/mvm/src/machine/mod.rs
@@ -9,6 +9,8 @@
 //! Boot / exec / shell wiring lands on top of this seam in later work; this
 //! module is the construction + capability-gate backbone.
 
+use mvm_backend::AnyBackend;
+use mvm_backend::selection::SelectionError;
 use mvm_core::vm_backend::{RequiredCapabilities, VmCapabilities};
 
 /// How a machine reaches the network. Closed by default: a machine gets no
@@ -168,6 +170,13 @@ impl Machine {
             Err(CapabilityError { missing })
         }
     }
+
+    /// Choose the most-preferred backend whose capabilities can serve this
+    /// machine, failing closed with the per-candidate shortfall if none can.
+    /// This is selection only — it does not boot anything.
+    pub fn select_backend(&self) -> Result<AnyBackend, SelectionError> {
+        AnyBackend::select_capable(&self.required_capabilities())
+    }
 }
 
 #[cfg(test)]
@@ -250,5 +259,31 @@ mod tests {
             ..VmCapabilities::default()
         };
         assert!(machine.check_backend(&caps).is_ok());
+    }
+
+    #[test]
+    fn select_backend_picks_a_capable_backend_for_a_basic_machine() {
+        let machine = Machine::builder().image("alpine").build().unwrap();
+        let backend = machine.select_backend().unwrap();
+        assert!(backend.capabilities().vsock);
+    }
+
+    #[test]
+    fn select_backend_fails_closed_for_host_vsock_proxy_until_brokers_exist() {
+        // No backend advertises the broker capabilities yet, so a brokered-net
+        // machine is rejected rather than degraded onto a guest-NIC path.
+        let machine = Machine::builder()
+            .image("alpine")
+            .network(NetworkMode::HostVsockProxy)
+            .build()
+            .unwrap();
+        match machine.select_backend() {
+            Ok(_) => panic!("host-vsock-proxy has no capable backend yet; must fail closed"),
+            Err(err) => assert!(
+                err.shortfalls
+                    .iter()
+                    .all(|(_, m)| m.contains(&"host_vsock_proxy"))
+            ),
+        }
     }
 }


### PR DESCRIPTION
## What

**Plan 214 slice 4: link `Machine` to fail-closed selection.** The additive connective step — `Machine` can now choose its backend by capability. Still no live boot.

- `Machine::select_backend() -> Result<AnyBackend, SelectionError>` delegates to `AnyBackend::select_capable(self.required_capabilities())`.
- Selection only — it does not boot anything.
- A `HostVsockProxy` machine has no capable backend yet (brokers land in Phase 6/7), so it is **rejected** rather than degraded onto a guest-NIC path — proven by test.

## TDD

`select_backend_picks_a_capable_backend_for_a_basic_machine` watched fail (`no method select_backend`) before implementation; plus the fail-closed host-vsock-proxy case.

## Verification

- `cargo fmt --all -- --check` clean
- `cargo clippy -p mvm --all-targets -- -D warnings` clean
- `cargo nextest run -p mvm` → 233 passed, 0 failed

## Context

Top of the Plan 214 foundation stack: #1338 (selection) → #1337 (Machine) → #1336 (capabilities) → #1335 (docs). Base branch `feat/plan-214-capability-selection`.
