### PR TITLE
feat(machine): Machine -> launchable VmStartConfig (Plan 214 slice 5)

### DIFF
--- a/crates/mvm/src/lib.rs
+++ b/crates/mvm/src/lib.rs
@@ -23,7 +23,7 @@ pub use vm::lease::{AcquireSpec, WarmLease};
 // The Machine product abstraction — the construction + capability-gate seam
 // the CLI, mvmd, and the SDKs share.
 pub use machine::{
-    CapabilityError, Machine, MachineBuilder, MachineError, MachineSpec, NetworkMode,
+    CapabilityError, LaunchInputs, Machine, MachineBuilder, MachineError, MachineSpec, NetworkMode,
 };
 
 // Substrate re-exports — see crate doc comment.

--- a/crates/mvm/src/machine/mod.rs
+++ b/crates/mvm/src/machine/mod.rs
@@ -11,7 +11,8 @@
 
 use mvm_backend::AnyBackend;
 use mvm_backend::selection::SelectionError;
-use mvm_core::vm_backend::{RequiredCapabilities, VmCapabilities};
+use mvm_core::network_policy::NetworkPolicy;
+use mvm_core::vm_backend::{RequiredCapabilities, VmCapabilities, VmStartConfig};
 
 /// How a machine reaches the network. Closed by default: a machine gets no
 /// guest NIC, and reaches nothing until networking is explicitly requested.
@@ -122,6 +123,17 @@ pub struct MachineSpec {
     pub pty: bool,
 }
 
+/// Resolved launch inputs for a machine: the per-run name plus the artifact
+/// paths the deterministic build/artifact pipeline produced for the image.
+/// Kept separate from [`MachineSpec`] because artifact resolution is the
+/// pipeline's job, not the builder's.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct LaunchInputs {
+    pub name: String,
+    pub rootfs_path: String,
+    pub kernel_path: Option<String>,
+}
+
 /// A workload machine. Construct via [`Machine::builder`]. Boot / exec / shell
 /// are layered on this handle in later work.
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -176,6 +188,26 @@ impl Machine {
     /// This is selection only — it does not boot anything.
     pub fn select_backend(&self) -> Result<AnyBackend, SelectionError> {
         AnyBackend::select_capable(&self.required_capabilities())
+    }
+
+    /// Translate this machine plus resolved artifacts into a backend-agnostic
+    /// [`VmStartConfig`] a backend can launch. Transient by default
+    /// (`warm_pool_size = 0`).
+    pub fn to_start_config(&self, inputs: LaunchInputs) -> VmStartConfig {
+        // Closed by default. `NetworkMode::HostVsockProxy` will resolve to a
+        // broker-backed policy once the brokers land; until then it cannot be
+        // selected (see `select_backend`), so deny-all is the honest mapping.
+        let network_policy = NetworkPolicy::deny_all();
+        VmStartConfig {
+            name: inputs.name,
+            rootfs_path: inputs.rootfs_path,
+            kernel_path: inputs.kernel_path,
+            cpus: self.spec.cpus,
+            memory_mib: u32::try_from(self.spec.memory_mib).unwrap_or(u32::MAX),
+            network_policy,
+            warm_pool_size: 0,
+            ..Default::default()
+        }
     }
 }
 
@@ -285,5 +317,58 @@ mod tests {
                     .all(|(_, m)| m.contains(&"host_vsock_proxy"))
             ),
         }
+    }
+
+    #[test]
+    fn to_start_config_carries_resources_and_artifacts() {
+        let machine = Machine::builder()
+            .image("alpine")
+            .cpus(2)
+            .memory_mib(1024)
+            .build()
+            .unwrap();
+        let cfg = machine.to_start_config(LaunchInputs {
+            name: "m1".into(),
+            rootfs_path: "/store/rootfs.ext4".into(),
+            kernel_path: Some("/store/vmlinux".into()),
+        });
+        assert_eq!(cfg.name, "m1");
+        assert_eq!(cfg.rootfs_path, "/store/rootfs.ext4");
+        assert_eq!(cfg.kernel_path.as_deref(), Some("/store/vmlinux"));
+        assert_eq!(cfg.cpus, 2);
+        assert_eq!(cfg.memory_mib, 1024);
+        assert_eq!(cfg.warm_pool_size, 0, "transient by default");
+    }
+
+    #[test]
+    fn to_start_config_no_network_is_deny_all() {
+        let machine = Machine::builder().image("alpine").build().unwrap();
+        let cfg = machine.to_start_config(LaunchInputs {
+            name: "m1".into(),
+            rootfs_path: "/store/rootfs.ext4".into(),
+            kernel_path: None,
+        });
+        assert_eq!(
+            cfg.network_policy,
+            mvm_core::network_policy::NetworkPolicy::deny_all()
+        );
+    }
+
+    #[test]
+    fn produced_config_is_launchable_by_a_backend() {
+        // Prove the translation yields a config a backend accepts: the mock
+        // (the VmBackend test double) starts it and records a running VM.
+        use mvm_backend::mock::MockBackend;
+        use mvm_core::vm_backend::VmBackend;
+
+        let machine = Machine::builder().image("alpine").build().unwrap();
+        let cfg = machine.to_start_config(LaunchInputs {
+            name: "m1".into(),
+            rootfs_path: "/store/rootfs.ext4".into(),
+            kernel_path: None,
+        });
+        let backend = MockBackend::new();
+        let id = backend.start(&cfg).unwrap();
+        backend.stop(&id).unwrap();
     }
 }


### PR DESCRIPTION
## What

**Plan 214 slice 5: translate a `Machine` into a launchable `VmStartConfig`** — the boot-wiring bridge between the library and the backend launch path.

- `Machine::to_start_config(LaunchInputs)` maps the validated machine + resolved artifact paths into a backend-agnostic `VmStartConfig`: resources carried, **transient by default** (`warm_pool_size = 0`), **network closed by default** (`NetworkPolicy::deny_all`).
- `LaunchInputs { name, rootfs_path, kernel_path }` — artifact resolution is the pipeline's job, kept separate from the builder.
- A test drives the produced config through `MockBackend` (the `VmBackend` test double) to prove it is **launchable at the backend-trait boundary**.

## Scope boundary (read this)

This is the spec → launchable-config bridge, verified against the mock. It is **not** a full end-to-end boot. Still required, and deliberately out of this slice because they need the artifact pipeline and a live VM to verify honestly:

- artifact resolution (`--image alpine` → real rootfs/kernel paths)
- live `backend.start` of a real guest
- exec-over-vsock (reusing `ExecBuilder`) + teardown

So `mvm machine run --image alpine -- /bin/sh` does **not** run end-to-end from this PR — this lays the typed, tested bridge it will use.

## TDD

`to_start_config_carries_resources_and_artifacts` watched fail (`cannot find LaunchInputs` / `no method to_start_config`) before implementation; plus closed-by-default network mapping and the mock-launchable proof.

## Verification

- `cargo fmt --all -- --check` clean
- `cargo clippy -p mvm --all-targets -- -D warnings` clean
- `cargo nextest run -p mvm` → 236 passed, 0 failed

## Context

Top of the Plan 214 stack: #1339 → #1338 → #1337 → #1336 → #1335. Base branch `feat/plan-214-machine-select`.
