### PR TITLE
feat(core): guest mvm-netd proxy env injection (Plan 214 Phase 7)

### DIFF
--- a/crates/mvm-core/src/guest_netd.rs
+++ b/crates/mvm-core/src/guest_netd.rs
@@ -1,0 +1,66 @@
+//! Guest `mvm-netd` helpers.
+//!
+//! `mvm-netd` listens on guest loopback and forwards over vsock to the host
+//! egress broker. Cooperative apps are pointed at it via the standard proxy
+//! environment variables; loopback is excluded via `NO_PROXY` so the app's
+//! traffic to the local daemon (and to localhost) is not itself proxied. This
+//! module builds that env set deterministically.
+
+/// Loopback hosts excluded from proxying, so an app's calls to the local
+/// daemon and to localhost are not themselves routed through the broker.
+pub const NO_PROXY_LOOPBACK: &str = "localhost,127.0.0.1,::1";
+
+/// Build the standard proxy environment for a cooperative app, pointing it at
+/// the in-guest `mvm-netd` proxy at `proxy_addr` (e.g. `127.0.0.1:3128`). Both
+/// upper- and lower-case variants are emitted because tooling is inconsistent
+/// about which it reads. `NO_PROXY` excludes loopback.
+pub fn proxy_env_vars(proxy_addr: &str) -> Vec<(String, String)> {
+    let url = format!("http://{proxy_addr}");
+    let mut env = Vec::with_capacity(8);
+    for key in ["HTTP_PROXY", "HTTPS_PROXY", "ALL_PROXY"] {
+        env.push((key.to_string(), url.clone()));
+        env.push((key.to_lowercase(), url.clone()));
+    }
+    env.push(("NO_PROXY".to_string(), NO_PROXY_LOOPBACK.to_string()));
+    env.push(("no_proxy".to_string(), NO_PROXY_LOOPBACK.to_string()));
+    env
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::collections::HashMap;
+
+    #[test]
+    fn proxy_env_points_http_and_https_at_the_local_proxy() {
+        let env: HashMap<_, _> = proxy_env_vars("127.0.0.1:3128").into_iter().collect();
+        assert_eq!(
+            env.get("HTTP_PROXY").map(String::as_str),
+            Some("http://127.0.0.1:3128")
+        );
+        assert_eq!(
+            env.get("HTTPS_PROXY").map(String::as_str),
+            Some("http://127.0.0.1:3128")
+        );
+        assert_eq!(
+            env.get("ALL_PROXY").map(String::as_str),
+            Some("http://127.0.0.1:3128")
+        );
+    }
+
+    #[test]
+    fn no_proxy_excludes_loopback() {
+        let env: HashMap<_, _> = proxy_env_vars("127.0.0.1:3128").into_iter().collect();
+        let no_proxy = env.get("NO_PROXY").map(String::as_str).unwrap_or_default();
+        assert!(no_proxy.contains("127.0.0.1"));
+        assert!(no_proxy.contains("localhost"));
+    }
+
+    #[test]
+    fn lower_and_upper_case_variants_both_present() {
+        let env: HashMap<_, _> = proxy_env_vars("127.0.0.1:3128").into_iter().collect();
+        for key in ["http_proxy", "https_proxy", "all_proxy", "no_proxy"] {
+            assert!(env.contains_key(key), "missing {key}");
+        }
+    }
+}

--- a/crates/mvm-core/src/lib.rs
+++ b/crates/mvm-core/src/lib.rs
@@ -11,6 +11,8 @@ pub mod dev_network;
 pub mod egress_broker;
 pub mod entrypoint_policy;
 pub mod exit_capture;
+/// Guest `mvm-netd` helpers (proxy env-var injection for cooperative apps).
+pub mod guest_netd;
 /// Host ingress-broker decision logic (host listener only by explicit policy).
 pub mod ingress_broker;
 /// `mvm-init` supervisor core logic: metadata → exec spec, marker progression.


### PR DESCRIPTION
## What

**Plan 214 Phase 7: guest `mvm-netd` proxy env injection** (`mvm_core::guest_netd::proxy_env_vars`) — the cooperative-app path to brokered egress.

- Builds `HTTP_PROXY`/`HTTPS_PROXY`/`ALL_PROXY` (upper- and lower-case) pointing at the in-guest `mvm-netd` loopback proxy.
- `NO_PROXY` excludes loopback (`localhost,127.0.0.1,::1`) so the app's traffic to the local daemon / localhost isn't itself proxied.

`mvm-init` injects these for the workload; `mvm-netd` forwards over vsock to the host egress broker (fail-closed when the broker is unavailable). Transparent TCP redirect is the follow-up.

## TDD

`proxy_env_points_http_and_https_at_the_local_proxy` watched fail before implementation; then `NO_PROXY` loopback exclusion and lower/upper-case variant coverage.

## Verification

- `cargo fmt --all -- --check` clean
- `cargo clippy -p mvm-core --all-targets -- -D warnings` clean
- `cargo nextest run -p mvm-core` → 1392 passed, 0 failed

## Context

Part of Plan 214 (MVM-214-09, Phase 7), independent. **Spike — not for merge.**
