### PR TITLE
feat(core): egress-broker handler — decision + trace + audit (Plan 214 vertical)

### DIFF
--- a/crates/mvm-core/src/egress_handler.rs
+++ b/crates/mvm-core/src/egress_handler.rs
@@ -1,0 +1,96 @@
+//! Egress-broker handler: compose decision + trace into an audit record.
+//!
+//! The per-request logic the host `mvm-egress-broker` runs: decide the request
+//! against the workload's network policy ([`crate::egress_broker`]), and emit an
+//! audit record carrying the verdict plus the [`crate::trace_context`]
+//! correlation so the flow is fully traceable in the chain-signed log. This is
+//! the pure composition; the broker process forwards/blocks per the verdict and
+//! writes the record to the audit sink.
+
+use crate::egress_broker::{EgressRequest, EgressVerdict, decide_egress};
+use crate::policy::network_policy::NetworkPolicy;
+use crate::trace_context::TraceContext;
+
+/// The audit record for one brokered egress flow: the requested endpoint, the
+/// verdict (allowed + matched rule, or denied + reason), and the trace
+/// correlation so the flow is linkable across hops in the chain-signed log.
+/// Secret-free by construction — it names the endpoint and decision, never
+/// payload or credential bytes.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct EgressFlowAudit {
+    pub trace_id: String,
+    pub span_id: String,
+    pub host: String,
+    pub port: u16,
+    pub allowed: bool,
+    /// The allowlist rule that permitted the flow (`host:port`), if any.
+    pub matched_rule: Option<String>,
+    /// The deny reason token, if denied.
+    pub deny_reason: Option<&'static str>,
+}
+
+/// Decide a brokered egress request against `policy` and produce its audit
+/// record under `trace`. Returns the verdict (so the broker forwards or blocks)
+/// and the record (so the broker emits it to the chain-signed audit sink).
+pub fn handle_egress(
+    policy: &NetworkPolicy,
+    trace: &TraceContext,
+    req: &EgressRequest,
+) -> (EgressVerdict, EgressFlowAudit) {
+    let verdict = decide_egress(policy, req);
+    let (allowed, matched_rule, deny_reason) = match &verdict {
+        EgressVerdict::Allowed { matched } => (
+            true,
+            matched.as_ref().map(|m| format!("{}:{}", m.host, m.port)),
+            None,
+        ),
+        EgressVerdict::Denied { reason } => (false, None, Some(reason.label())),
+    };
+    let audit = EgressFlowAudit {
+        trace_id: trace.trace_id.to_hex(),
+        span_id: trace.span_id.to_hex(),
+        host: req.host.clone(),
+        port: req.port,
+        allowed,
+        matched_rule,
+        deny_reason,
+    };
+    (verdict, audit)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::policy::network_policy::HostPort;
+    use crate::trace_context::{SpanId, TraceId};
+
+    #[test]
+    fn handle_egress_allows_and_records_trace_and_rule() {
+        let policy = NetworkPolicy::allow_list(vec![HostPort::new("api.example.com", 443)]);
+        let trace = TraceContext::new(TraceId([0x4b; 16]), SpanId([0x1a; 8]));
+        let (verdict, audit) =
+            handle_egress(&policy, &trace, &EgressRequest::new("api.example.com", 443));
+        assert!(verdict.is_allowed());
+        assert!(audit.allowed);
+        assert_eq!(audit.trace_id, trace.trace_id.to_hex());
+        assert_eq!(audit.span_id, trace.span_id.to_hex());
+        assert_eq!(audit.matched_rule.as_deref(), Some("api.example.com:443"));
+        assert_eq!(audit.deny_reason, None);
+    }
+
+    #[test]
+    fn handle_egress_denies_and_records_reason() {
+        let trace = TraceContext::new(TraceId([0x4b; 16]), SpanId([0x1a; 8]));
+        let (verdict, audit) = handle_egress(
+            &NetworkPolicy::deny_all(),
+            &trace,
+            &EgressRequest::new("evil.example.com", 443),
+        );
+        assert!(!verdict.is_allowed());
+        assert!(!audit.allowed);
+        assert_eq!(audit.deny_reason, Some("deny_all"));
+        assert_eq!(audit.matched_rule, None);
+        assert_eq!(audit.host, "evil.example.com");
+        assert_eq!(audit.port, 443);
+    }
+}

--- a/crates/mvm-core/src/lib.rs
+++ b/crates/mvm-core/src/lib.rs
@@ -9,6 +9,8 @@ pub mod config;
 pub mod dev_network;
 /// Host egress-broker decision logic (closed-by-default allow/deny per request).
 pub mod egress_broker;
+/// Egress-broker handler: compose decision + trace into an audit record.
+pub mod egress_handler;
 pub mod entrypoint_policy;
 pub mod exit_capture;
 /// Guest `mvm-netd` helpers (proxy env-var injection for cooperative apps).


### PR DESCRIPTION
## What

**Plan 214 vertical composition (Phase 6 × Phase 3): the egress-broker handler.** Proves the primitives fit together — `mvm_core::egress_handler::handle_egress`:

1. decides the request against the workload's network policy (`egress_broker::decide_egress`),
2. builds an `EgressFlowAudit` carrying the verdict (allowed + matched `host:port` rule, or denied + reason token) **plus the `TraceContext` correlation** (`trace_id`/`span_id`) so the flow is linkable across hops in the chain-signed log,
3. returns `(verdict, audit)` so the broker forwards/blocks per the verdict and emits the record.

Secret-free by construction — it names the endpoint and decision, never payload/credential bytes.

## TDD

`handle_egress_allows_and_records_trace_and_rule` watched fail before implementation; then the deny path records the reason token and no matched rule, and both carry the trace correlation.

## Verification

- `cargo fmt --all -- --check` clean
- `cargo clippy -p mvm-core --all-targets -- -D warnings` clean
- `cargo nextest run -p mvm-core` → 1399 passed, 0 failed

## Context

Composes **#1348** (egress decision) + **#1349** (trace context) — based on the egress branch with the trace branch merged in, so the diff includes both modules. The broker *process* wires this to the vsock transport + chain-signed audit sink. **Spike — not for merge.**
