### PR TITLE
feat(core): add snapshot_at to the signed ExecutionPlan (Plan 214 Phase 5/11)

### DIFF
--- a/crates/mvm-cli/src/commands/vm/plan_builder.rs
+++ b/crates/mvm-cli/src/commands/vm/plan_builder.rs
@@ -236,6 +236,7 @@ pub fn synthesize_plan(input: &SynthesisInput<'_>) -> Result<ExecutionPlan> {
     };
 
     Ok(ExecutionPlan {
+        snapshot_at: Default::default(),
         network_mode: Default::default(),
         schema_version: SCHEMA_VERSION,
         plan_id,

--- a/crates/mvm-cli/src/commands/vm/policy_resolver.rs
+++ b/crates/mvm-cli/src/commands/vm/policy_resolver.rs
@@ -604,6 +604,7 @@ mod tests {
     fn fixture_plan() -> ExecutionPlan {
         let now = chrono::Utc::now();
         ExecutionPlan {
+            snapshot_at: Default::default(),
             network_mode: Default::default(),
             schema_version: SCHEMA_VERSION,
             plan_id: PlanId("plan-test".to_string()),

--- a/crates/mvm-core/src/lifecycle.rs
+++ b/crates/mvm-core/src/lifecycle.rs
@@ -77,7 +77,8 @@ impl LifecycleMarker {
 }
 
 /// When to capture a warm snapshot of a guest.
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default, serde::Serialize, serde::Deserialize)]
+#[serde(rename_all = "snake_case")]
 pub enum SnapshotAt {
     /// Before the workload entrypoint runs — fastest to capture, coldest cache.
     PreExec,

--- a/crates/mvm-core/src/plan/execution_plan.rs
+++ b/crates/mvm-core/src/plan/execution_plan.rs
@@ -81,7 +81,7 @@ pub struct ExecutionPlan {
     /// warm-snapshotted; `Some(at)` = the host may capture a warm snapshot when
     /// the guest reaches `at`'s trigger marker (`mvm-init` lifecycle). Part of
     /// the signed contract so the snapshot point is admitted, not host-chosen.
-    /// `#[serde(default)]` so a pre-v8 plan deserializes as `None`.
+    /// `#[serde(default)]` so a plan without the field deserializes as `None`.
     #[serde(default)]
     pub snapshot_at: Option<SnapshotAt>,
 

--- a/crates/mvm-core/src/plan/execution_plan.rs
+++ b/crates/mvm-core/src/plan/execution_plan.rs
@@ -10,6 +10,7 @@
 use chrono::{DateTime, Utc};
 use serde::{Deserialize, Serialize};
 
+use crate::lifecycle::SnapshotAt;
 use crate::plan::bundle::PlanArtifact;
 use crate::plan::types::{
     AdmissionProfile, ArtifactPolicy, AttestationRequirement, AuditLabels, AuthPolicy,
@@ -75,6 +76,14 @@ pub struct ExecutionPlan {
     /// closed default.
     #[serde(default)]
     pub network_mode: NetworkMode,
+
+    /// Opt-in warm-snapshot timing. `None` (default) = this workload is not
+    /// warm-snapshotted; `Some(at)` = the host may capture a warm snapshot when
+    /// the guest reaches `at`'s trigger marker (`mvm-init` lifecycle). Part of
+    /// the signed contract so the snapshot point is admitted, not host-chosen.
+    /// `#[serde(default)]` so a pre-v8 plan deserializes as `None`.
+    #[serde(default)]
+    pub snapshot_at: Option<SnapshotAt>,
 
     /// Filesystem policy reference.
     pub fs_policy: FsPolicyRef,

--- a/crates/mvm-core/src/plan/signing.rs
+++ b/crates/mvm-core/src/plan/signing.rs
@@ -464,8 +464,8 @@ mod tests {
 
     #[test]
     fn plan_without_snapshot_at_field_defaults_to_none() {
-        // A plan serialized before `snapshot_at` existed must still deserialize,
-        // defaulting to `None` (not warm-snapshotted) — `serde(default)`.
+        // A plan whose JSON lacks `snapshot_at` must still deserialize,
+        // defaulting to `None` via `serde(default)`.
         let plan = sample_plan();
         let mut value = serde_json::to_value(&plan).unwrap();
         value.as_object_mut().unwrap().remove("snapshot_at");

--- a/crates/mvm-core/src/plan/signing.rs
+++ b/crates/mvm-core/src/plan/signing.rs
@@ -200,6 +200,7 @@ pub mod test_support {
     /// Callers override `valid_from`/`valid_until`/`nonce` for their scenario.
     pub fn sample_plan() -> ExecutionPlan {
         ExecutionPlan {
+            snapshot_at: Default::default(),
             network_mode: Default::default(),
             schema_version: SCHEMA_VERSION,
             plan_id: PlanId("01HXTESTPLAN000000000000".to_string()),
@@ -459,6 +460,32 @@ mod tests {
         let json = serde_json::to_string(&plan).unwrap();
         let parsed: ExecutionPlan = serde_json::from_str(&json).unwrap();
         assert_eq!(parsed.network_mode, NetworkMode::HostVsockProxy);
+    }
+
+    #[test]
+    fn plan_without_snapshot_at_field_defaults_to_none() {
+        // A plan serialized before `snapshot_at` existed must still deserialize,
+        // defaulting to `None` (not warm-snapshotted) — `serde(default)`.
+        let plan = sample_plan();
+        let mut value = serde_json::to_value(&plan).unwrap();
+        value.as_object_mut().unwrap().remove("snapshot_at");
+        assert!(value.get("snapshot_at").is_none());
+        let parsed: ExecutionPlan = serde_json::from_value(value).unwrap();
+        assert_eq!(parsed.snapshot_at, None);
+    }
+
+    #[test]
+    fn snapshot_at_round_trips_in_the_plan() {
+        use crate::lifecycle::SnapshotAt;
+        let mut plan = sample_plan();
+        plan.snapshot_at = Some(SnapshotAt::AfterWarmup);
+        let json = serde_json::to_string(&plan).unwrap();
+        assert!(
+            json.contains("after_warmup"),
+            "snake_case wire token: {json}"
+        );
+        let parsed: ExecutionPlan = serde_json::from_str(&json).unwrap();
+        assert_eq!(parsed.snapshot_at, Some(SnapshotAt::AfterWarmup));
     }
 
     #[test]

--- a/crates/mvm-core/src/plan/test_support.rs
+++ b/crates/mvm-core/src/plan/test_support.rs
@@ -93,6 +93,7 @@ impl PlanFixture {
     pub fn build(self) -> ExecutionPlan {
         let now = Utc::now();
         ExecutionPlan {
+            snapshot_at: Default::default(),
             network_mode: Default::default(),
             schema_version: SCHEMA_VERSION,
             plan_id: PlanId(self.plan_id),

--- a/crates/mvm-core/tests/replay_protection.rs
+++ b/crates/mvm-core/tests/replay_protection.rs
@@ -16,6 +16,7 @@ use mvm_core::plan::{ExecutionPlan, SCHEMA_VERSION};
 
 fn fixture_plan(nonce: [u8; 16]) -> ExecutionPlan {
     ExecutionPlan {
+        snapshot_at: Default::default(),
         network_mode: Default::default(),
         schema_version: SCHEMA_VERSION,
         plan_id: PlanId("test-plan-001".to_string()),

--- a/crates/mvm-hostd/src/supervisor/aggregate.rs
+++ b/crates/mvm-hostd/src/supervisor/aggregate.rs
@@ -1149,6 +1149,7 @@ mod tests {
 
     fn sample_plan() -> ExecutionPlan {
         ExecutionPlan {
+            snapshot_at: Default::default(),
             network_mode: Default::default(),
             schema_version: SCHEMA_VERSION,
             plan_id: PlanId("01HXTEST0000000000000000".to_string()),

--- a/crates/mvm-hostd/src/supervisor/audit.rs
+++ b/crates/mvm-hostd/src/supervisor/audit.rs
@@ -308,6 +308,7 @@ mod tests {
 
     fn sample_plan() -> ExecutionPlan {
         ExecutionPlan {
+            snapshot_at: Default::default(),
             network_mode: Default::default(),
             schema_version: SCHEMA_VERSION,
             plan_id: PlanId("plan-x".to_string()),

--- a/crates/mvm-hostd/src/supervisor/backend.rs
+++ b/crates/mvm-hostd/src/supervisor/backend.rs
@@ -224,6 +224,7 @@ mod tests {
         let expected_slot = config.slot.clone();
         let launcher = FirecrackerRunConfigLauncher::new(config).expect("valid config");
         let plan = ExecutionPlan {
+            snapshot_at: Default::default(),
             network_mode: Default::default(),
             schema_version: mvm_core::plan::SCHEMA_VERSION,
             plan_id: PlanId("01HXTEST0000000000000000".to_string()),

--- a/crates/mvm-hostd/src/supervisor/gateway_bridge.rs
+++ b/crates/mvm-hostd/src/supervisor/gateway_bridge.rs
@@ -4478,6 +4478,7 @@ mod tests {
             TenantId, TimeoutSpec, WorkloadId,
         };
         ExecutionPlan {
+            snapshot_at: Default::default(),
             network_mode: Default::default(),
             schema_version: SCHEMA_VERSION,
             plan_id: PlanId("test-plan".into()),

--- a/crates/mvm-hostd/src/supervisor/network/mod.rs
+++ b/crates/mvm-hostd/src/supervisor/network/mod.rs
@@ -921,6 +921,7 @@ mod tests {
             TenantId, TimeoutSpec, WorkloadId,
         };
         ExecutionPlan {
+            snapshot_at: Default::default(),
             network_mode: Default::default(),
             schema_version: SCHEMA_VERSION,
             plan_id: PlanId("test-plan".into()),


### PR DESCRIPTION
## What

**Plan 214 Phase 5/11: put opt-in warm-snapshot timing into the signed `ExecutionPlan`** (schema v8). Continues the contract-integration pattern from #1358.

- Reuse `lifecycle::SnapshotAt` (`PreExec`/`Ready`/`AfterWarmup`) — added `serde(rename_all = "snake_case")` derives so it serializes in the plan.
- New `ExecutionPlan.snapshot_at: Option<SnapshotAt>`, `#[serde(default)]`: `None` = not warm-snapshotted; `Some(at)` = the host may capture a warm snapshot when the guest reaches `at`'s trigger marker (`mvm-init` lifecycle). The snapshot point is now **admitted, not host-chosen**.
- `SCHEMA_VERSION` **7 → 8** (older verifier fails closed on v8). All 10 constructor sites updated.

`snapshot_at` is **inert** until the warm-pool path reads it (later phase) — additive, no behavior change.

## TDD / tests

- `SnapshotAt` default/trigger-marker (lifecycle).
- **Backward-compat**: pre-v8 plan without `snapshot_at` → `None` (`serde(default)`).
- `Some(AfterWarmup)` roundtrips with the `after_warmup` snake_case wire token.

## Verification

- `cargo check --workspace --all-targets` → Finished.
- `cargo clippy -p mvm-core --all-targets -- -D warnings` clean.
- `cargo nextest` (mvm-core/hostd/cli) → **1173 passed**; the single failure (`embedded_binaries` elf-magic) is the `MVM_SKIP_EMBED_BINARIES` stub-build artifact, not this change.

## Context

Stacked on **#1358** (network_mode plan integration, schema v7) and merges the **#1344** lifecycle-markers branch for `SnapshotAt`. Part of Plan 214 (Phase 5/11). **Spike — not for merge.**
