### PR TITLE
feat(core): record build provenance in the signed ExecutionPlan (Plan 214 Phase 4)

### DIFF
--- a/crates/mvm-cli/src/commands/vm/plan_builder.rs
+++ b/crates/mvm-cli/src/commands/vm/plan_builder.rs
@@ -236,6 +236,7 @@ pub fn synthesize_plan(input: &SynthesisInput<'_>) -> Result<ExecutionPlan> {
     };
 
     Ok(ExecutionPlan {
+        build_provenance: Default::default(),
         snapshot_at: Default::default(),
         network_mode: Default::default(),
         schema_version: SCHEMA_VERSION,

--- a/crates/mvm-cli/src/commands/vm/policy_resolver.rs
+++ b/crates/mvm-cli/src/commands/vm/policy_resolver.rs
@@ -604,6 +604,7 @@ mod tests {
     fn fixture_plan() -> ExecutionPlan {
         let now = chrono::Utc::now();
         ExecutionPlan {
+            build_provenance: Default::default(),
             snapshot_at: Default::default(),
             network_mode: Default::default(),
             schema_version: SCHEMA_VERSION,

--- a/crates/mvm-core/src/plan/execution_plan.rs
+++ b/crates/mvm-core/src/plan/execution_plan.rs
@@ -14,9 +14,9 @@ use crate::lifecycle::SnapshotAt;
 use crate::plan::bundle::PlanArtifact;
 use crate::plan::types::{
     AdmissionProfile, ArtifactPolicy, AttestationRequirement, AuditLabels, AuthPolicy,
-    DepsVolumeBinding, FsPolicyRef, HostShareGrant, KeyRotationSpec, NetworkMode, Nonce, PlanId,
-    PolicyRef, PostRunLifecycle, ReleasePin, Resources, RuntimeProfileRef, SecretBinding,
-    SignedImageRef, TenantId, WorkloadId,
+    BuildProvenance, DepsVolumeBinding, FsPolicyRef, HostShareGrant, KeyRotationSpec, NetworkMode,
+    Nonce, PlanId, PolicyRef, PostRunLifecycle, ReleasePin, Resources, RuntimeProfileRef,
+    SecretBinding, SignedImageRef, TenantId, WorkloadId,
 };
 use crate::plan::verb::VerbId;
 
@@ -84,6 +84,14 @@ pub struct ExecutionPlan {
     /// `#[serde(default)]` so a plan without the field deserializes as `None`.
     #[serde(default)]
     pub snapshot_at: Option<SnapshotAt>,
+
+    /// Build provenance: the input kind/ref, input pin, builder identity, and
+    /// per-artifact digests behind this launch — so a run is traceable to exact
+    /// deterministic inputs and outputs. `None` (default) = not recorded for this
+    /// workload. The deterministic build pipeline populates it.
+    /// `#[serde(default)]` so a plan without the field deserializes as `None`.
+    #[serde(default)]
+    pub build_provenance: Option<BuildProvenance>,
 
     /// Filesystem policy reference.
     pub fs_policy: FsPolicyRef,

--- a/crates/mvm-core/src/plan/signing.rs
+++ b/crates/mvm-core/src/plan/signing.rs
@@ -200,6 +200,7 @@ pub mod test_support {
     /// Callers override `valid_from`/`valid_until`/`nonce` for their scenario.
     pub fn sample_plan() -> ExecutionPlan {
         ExecutionPlan {
+            build_provenance: Default::default(),
             snapshot_at: Default::default(),
             network_mode: Default::default(),
             schema_version: SCHEMA_VERSION,
@@ -486,6 +487,37 @@ mod tests {
         );
         let parsed: ExecutionPlan = serde_json::from_str(&json).unwrap();
         assert_eq!(parsed.snapshot_at, Some(SnapshotAt::AfterWarmup));
+    }
+
+    #[test]
+    fn plan_without_build_provenance_defaults_to_none() {
+        let plan = sample_plan();
+        let mut value = serde_json::to_value(&plan).unwrap();
+        value.as_object_mut().unwrap().remove("build_provenance");
+        assert!(value.get("build_provenance").is_none());
+        let parsed: ExecutionPlan = serde_json::from_value(value).unwrap();
+        assert_eq!(parsed.build_provenance, None);
+    }
+
+    #[test]
+    fn build_provenance_round_trips_in_the_plan() {
+        use crate::plan::types::{ArtifactDigests, BuildProvenance, InputKind};
+        let mut plan = sample_plan();
+        plan.build_provenance = Some(BuildProvenance {
+            input_kind: InputKind::NixFlake,
+            input_ref: ".#app".to_string(),
+            lock_digest: Some("sha256:lock".to_string()),
+            builder_id: Some("builder-01".to_string()),
+            artifacts: ArtifactDigests {
+                kernel: Some("k".repeat(64)),
+                rootfs: Some("r".repeat(64)),
+                ..Default::default()
+            },
+        });
+        let json = serde_json::to_string(&plan).unwrap();
+        assert!(json.contains("nix_flake"), "snake_case input kind: {json}");
+        let parsed: ExecutionPlan = serde_json::from_str(&json).unwrap();
+        assert_eq!(parsed.build_provenance, plan.build_provenance);
     }
 
     #[test]

--- a/crates/mvm-core/src/plan/test_support.rs
+++ b/crates/mvm-core/src/plan/test_support.rs
@@ -93,6 +93,7 @@ impl PlanFixture {
     pub fn build(self) -> ExecutionPlan {
         let now = Utc::now();
         ExecutionPlan {
+            build_provenance: Default::default(),
             snapshot_at: Default::default(),
             network_mode: Default::default(),
             schema_version: SCHEMA_VERSION,

--- a/crates/mvm-core/src/plan/types.rs
+++ b/crates/mvm-core/src/plan/types.rs
@@ -26,6 +26,65 @@ pub enum NetworkMode {
     HostVsockProxy,
 }
 
+/// How the workload image was specified — the source the deterministic build
+/// pipeline consumed.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum InputKind {
+    /// An OCI image reference.
+    Oci,
+    /// A bundled Nix template.
+    NixTemplate,
+    /// A Nix flake output (`.#app`).
+    NixFlake,
+    /// A local repo/project with detected Nix metadata.
+    LocalProject,
+}
+
+/// Content-addressed digests (hex sha256) of the artifacts a build produced,
+/// recorded so a launch is traceable to exact bytes. `None` = not applicable to
+/// this workload (e.g. no initramfs).
+#[derive(Debug, Clone, Default, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct ArtifactDigests {
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub kernel: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub rootfs: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub initramfs: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub mvm_init: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub mvm_netd: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub snapshot_base: Option<String>,
+}
+
+/// Provenance of a workload build: what input was consumed, pinned how, by which
+/// builder, producing which artifacts. Recorded in the signed plan so a launch
+/// is traceable end-to-end to deterministic inputs and outputs. The build
+/// pipeline populates it; absence (`None` on the plan) means provenance was not
+/// recorded for this workload.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct BuildProvenance {
+    /// Which kind of source produced this image.
+    pub input_kind: InputKind,
+    /// The supplied reference: OCI ref, flake ref, template name, or local
+    /// project path.
+    pub input_ref: String,
+    /// Pin of the input: image manifest digest, `flake.lock` hash, etc.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub lock_digest: Option<String>,
+    /// Identity/fingerprint of the builder VM that produced the artifacts.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub builder_id: Option<String>,
+    /// Content-addressed digests of the produced artifacts.
+    #[serde(default)]
+    pub artifacts: ArtifactDigests,
+}
+
 /// Stable identifier for an `ExecutionPlan` instance. Currently a
 /// ULID; we keep the type opaque so the constructor can switch
 /// generators (UUIDv7, snowflake, etc.) without touching the wire
@@ -753,6 +812,56 @@ mod network_mode_tests {
         assert_eq!(
             serde_json::from_str::<NetworkMode>("\"none\"").unwrap(),
             NetworkMode::None
+        );
+    }
+}
+
+#[cfg(test)]
+mod build_provenance_tests {
+    use super::*;
+
+    #[test]
+    fn input_kind_uses_snake_case_tokens() {
+        assert_eq!(
+            serde_json::to_string(&InputKind::NixFlake).unwrap(),
+            "\"nix_flake\""
+        );
+        assert_eq!(
+            serde_json::from_str::<InputKind>("\"local_project\"").unwrap(),
+            InputKind::LocalProject
+        );
+    }
+
+    #[test]
+    fn provenance_round_trips_with_digests() {
+        let prov = BuildProvenance {
+            input_kind: InputKind::Oci,
+            input_ref: "docker.io/library/alpine@sha256:abc".to_string(),
+            lock_digest: Some("sha256:manifest".to_string()),
+            builder_id: Some("builder-vz-01".to_string()),
+            artifacts: ArtifactDigests {
+                kernel: Some("k".repeat(64)),
+                rootfs: Some("r".repeat(64)),
+                mvm_init: Some("i".repeat(64)),
+                ..Default::default()
+            },
+        };
+        let json = serde_json::to_string(&prov).unwrap();
+        let back: BuildProvenance = serde_json::from_str(&json).unwrap();
+        assert_eq!(back, prov);
+    }
+
+    #[test]
+    fn absent_artifact_digests_are_omitted_not_null() {
+        let digests = ArtifactDigests {
+            kernel: Some("k".repeat(64)),
+            ..Default::default()
+        };
+        let json = serde_json::to_string(&digests).unwrap();
+        assert!(json.contains("kernel"));
+        assert!(
+            !json.contains("initramfs"),
+            "absent digests omitted: {json}"
         );
     }
 }

--- a/crates/mvm-core/tests/replay_protection.rs
+++ b/crates/mvm-core/tests/replay_protection.rs
@@ -16,6 +16,7 @@ use mvm_core::plan::{ExecutionPlan, SCHEMA_VERSION};
 
 fn fixture_plan(nonce: [u8; 16]) -> ExecutionPlan {
     ExecutionPlan {
+        build_provenance: Default::default(),
         snapshot_at: Default::default(),
         network_mode: Default::default(),
         schema_version: SCHEMA_VERSION,

--- a/crates/mvm-hostd/src/supervisor/aggregate.rs
+++ b/crates/mvm-hostd/src/supervisor/aggregate.rs
@@ -1149,6 +1149,7 @@ mod tests {
 
     fn sample_plan() -> ExecutionPlan {
         ExecutionPlan {
+            build_provenance: Default::default(),
             snapshot_at: Default::default(),
             network_mode: Default::default(),
             schema_version: SCHEMA_VERSION,

--- a/crates/mvm-hostd/src/supervisor/audit.rs
+++ b/crates/mvm-hostd/src/supervisor/audit.rs
@@ -308,6 +308,7 @@ mod tests {
 
     fn sample_plan() -> ExecutionPlan {
         ExecutionPlan {
+            build_provenance: Default::default(),
             snapshot_at: Default::default(),
             network_mode: Default::default(),
             schema_version: SCHEMA_VERSION,

--- a/crates/mvm-hostd/src/supervisor/backend.rs
+++ b/crates/mvm-hostd/src/supervisor/backend.rs
@@ -224,6 +224,7 @@ mod tests {
         let expected_slot = config.slot.clone();
         let launcher = FirecrackerRunConfigLauncher::new(config).expect("valid config");
         let plan = ExecutionPlan {
+            build_provenance: Default::default(),
             snapshot_at: Default::default(),
             network_mode: Default::default(),
             schema_version: mvm_core::plan::SCHEMA_VERSION,

--- a/crates/mvm-hostd/src/supervisor/gateway_bridge.rs
+++ b/crates/mvm-hostd/src/supervisor/gateway_bridge.rs
@@ -4478,6 +4478,7 @@ mod tests {
             TenantId, TimeoutSpec, WorkloadId,
         };
         ExecutionPlan {
+            build_provenance: Default::default(),
             snapshot_at: Default::default(),
             network_mode: Default::default(),
             schema_version: SCHEMA_VERSION,

--- a/crates/mvm-hostd/src/supervisor/network/mod.rs
+++ b/crates/mvm-hostd/src/supervisor/network/mod.rs
@@ -921,6 +921,7 @@ mod tests {
             TenantId, TimeoutSpec, WorkloadId,
         };
         ExecutionPlan {
+            build_provenance: Default::default(),
             snapshot_at: Default::default(),
             network_mode: Default::default(),
             schema_version: SCHEMA_VERSION,


### PR DESCRIPTION
## What

**Plan 214 Phase 4 (plan-side): record build provenance in the signed `ExecutionPlan`** (schema v9) — so "what launched" is traceable to deterministic inputs and outputs in the admitted contract.

- `InputKind` — `oci` / `nix_template` / `nix_flake` / `local_project` (snake_case).
- `ArtifactDigests` — `kernel`/`rootfs`/`initramfs`/`mvm_init`/`mvm_netd`/`snapshot_base`, each optional hex sha256 (absent ones omitted, not `null`).
- `BuildProvenance` — `input_kind` + `input_ref` + `lock_digest` + `builder_id` + `artifacts`.
- New `ExecutionPlan.build_provenance: Option<BuildProvenance>`, `#[serde(default)]` (`None` = not recorded). `SCHEMA_VERSION` **8 → 9** (older verifier fails closed). All 10 constructor sites updated.

## Scope

This is the **typed contract** (in-sandbox-verifiable). Populating it — the deterministic Nix build wiring that builds `mvm-init`/`mvm-netd` and records their digests — needs a builder VM and is the hardware-gated remainder of Phase 4.

## TDD / tests

`InputKind` snake_case serde; provenance + digests roundtrip; absent-digests-omitted; plan **pre-v9 backward-compat** (`None`); populated-provenance plan roundtrip.

## Verification

- `cargo check --workspace --all-targets` → Finished.
- `cargo clippy -p mvm-core --all-targets -- -D warnings` clean.
- `cargo nextest` (mvm-core/hostd/cli) → **1173 passed**; the single failure (`embedded_binaries` elf-magic) is the `MVM_SKIP_EMBED_BINARIES` stub artifact, not this change.

## Context

Stacked on **#1359** (snapshot_at, v8) → **#1358** (network_mode, v7). Part of Plan 214 (Phase 4). **Spike — not for merge.**
