### PR TITLE
ci(release): fix macOS brew untrusted-tap + stale metrics smoke test (dry-run-verified)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -77,9 +77,18 @@ jobs:
       # kernel-extraction path needs libkrunfw. Both ship via the slp/krun
       # Homebrew tap. Without them the build panics in libkrun-sys/build.rs
       # ("libkrun.h was not found"). Linux uses Firecracker — no libkrun.
+      #
+      # `brew trust` is required since Homebrew began refusing to auto-load
+      # formulae from third-party ("untrusted") taps: installing
+      # `slp/krun/libkrun` pulls a transitive formula (`virglrenderer`) from the
+      # same tap, and without trust the install fails with "Refusing to load
+      # formula ... from untrusted tap slp/krun". Tap + trust before installing.
       - name: Install libkrun (macOS backend FFI)
         if: runner.os == 'macOS'
-        run: brew install slp/krun/libkrun slp/krun/libkrunfw
+        run: |
+          brew tap slp/krun
+          brew trust slp/krun
+          brew install slp/krun/libkrun slp/krun/libkrunfw
 
       - name: Install cross-compilation tools (Linux aarch64)
         if: matrix.target == 'aarch64-unknown-linux-gnu'
@@ -143,7 +152,7 @@ jobs:
           BIN="target/${TARGET}/release/mvmctl"
           "$BIN" --version
           "$BIN" --help > /dev/null
-          "$BIN" metrics --json | python3 -c "
+          "$BIN" ops metrics --json | python3 -c "
           import sys, json
           d = json.load(sys.stdin)
           # metrics JSON is sectioned: counters live under 'global'.


### PR DESCRIPTION
Fixes the two pre-existing release-build breakages the no-publish dry-run (#1309) surfaced — both unrelated to the per-VM host-bin packaging (#1307), which the dry-run confirmed works.

## Fixes
- **macOS `Install libkrun`**: Homebrew now refuses to auto-load formulae from third-party ("untrusted") taps; `brew install slp/krun/libkrun` pulls a transitive `virglrenderer` from the same tap and fails *"Refusing to load formula … from untrusted tap slp/krun"*. Added `brew tap` + `brew trust slp/krun` before the install (the remedy the error names; verified locally → "Trusted tap: slp/krun").
- **x86_64-linux `Smoke test`**: ran `mvmctl metrics --json`, but `metrics` moved under `ops` → now `mvmctl ops metrics`. Updated the smoke test (verified locally that `ops metrics --json` still carries `global.requests_total`).

## Validation (dry-run dispatched from this branch — [run 28479922494](https://github.com/tinylabscom/mvm/actions/runs/28479922494))
All three `build` targets now **succeed**; publish/Nix jobs skipped (dry-run). The **macOS tarball** bundles `mvm-bridge` + `mvm-vz-supervisor` + `mvm-libkrun-supervisor` + `mvmctl`; the Linux tarballs bundle `mvm-bridge` + `mvmctl`. This completes the end-to-end validation of #1307's packaging on every target, including the Linux cross-build.

🤖 Generated with [Claude Code](https://claude.com/claude-code)