### PR TITLE
docs(release): record why Linux intentionally omits mvm-libkrun-supervisor

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -123,10 +123,20 @@ jobs:
       #   - mvm-bridge: cross-platform external-VMM gateway/audit sidecar
       #     (Firecracker passt + vz VzIngest). Builds everywhere, no extra deps.
       #   - mvm-vz-supervisor (macOS only): the vz VMM supervisor.
-      #   - mvm-libkrun-supervisor (macOS only here): needs the libkrun-sys FFI,
-      #     which links libkrun — installed on the macOS runner above but not on
-      #     Linux ("Linux uses Firecracker"). Linux libkrun-supervisor packaging
-      #     needs a Linux libkrun build step — tracked as a follow-up.
+      #   - mvm-libkrun-supervisor (macOS only, and INTENTIONALLY so — not a
+      #     follow-up): it has `required-features = ["libkrun-sys"]`, and the
+      #     released Linux mvmctl deliberately does NOT link libkrun — the
+      #     `libkrun-sys` feature is a macOS-only target dep (see the rationale
+      #     at the top-level Cargo.toml, `[target.'cfg(target_os="macos")']`:
+      #     "Linux CI/runtimes use Firecracker … no libkrun-dev package exists").
+      #     So on Linux the supervisor can't be built here (no libkrun to link)
+      #     and isn't needed at runtime: workloads use Firecracker (-> mvm-bridge)
+      #     and the builder VM uses libkrun-if-genuinely-available-else-QEMU
+      #     (ADR-093), with libkrun's FFI stubbed out in a no-feature build so it
+      #     never spawns this supervisor. Shipping mvm-bridge alone on Linux is
+      #     correct + complete. Supporting the libkrun backend for *downloaded*
+      #     Linux binaries would be a product decision (vendor/build libkrun +
+      #     flip the feature), not a packaging fix.
       - name: Build per-VM host binaries
         env:
           TARGET: ${{ matrix.target }}


### PR DESCRIPTION
Corrects the `Build per-VM host binaries` comment in release.yml: the macOS-only libkrun supervisor is **intentional**, not a follow-up.

A downloaded Linux mvmctl deliberately doesn't link libkrun (`libkrun-sys` is a macOS-only target dep — no `libkrun-dev` package), `mvm-libkrun-supervisor` has `required-features = ["libkrun-sys"]` (can't build on the Linux runner), and it isn't needed at runtime (Firecracker workloads → `mvm-bridge`; builder = libkrun-if-available-else-QEMU with the FFI stubbed in a no-feature build). Shipping `mvm-bridge` alone on Linux is correct + complete.

Comment-only change so the (non-)gap doesn't get re-flagged. Supporting libkrun for downloaded Linux binaries would be a product decision, not a packaging fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)