### PR TITLE
Plan 214 (F): libkrun as a selectable Linux runtime + /dev/kvm doctor guidance

### DIFF
--- a/crates/mvm-cli/src/commands/machine/mod.rs
+++ b/crates/mvm-cli/src/commands/machine/mod.rs
@@ -224,8 +224,13 @@ pub(in crate::commands) struct MachineRunArgs {
     /// mismatch is an error.
     #[arg(long)]
     pub force: bool,
-    /// Override the backend hypervisor (hidden; for testing only).
-    #[arg(long, value_name = "HYPERVISOR", hide = true)]
+    /// Workload VMM backend. Defaults to the host's best supported backend
+    /// (Linux+KVM → firecracker; macOS 26+ → vz; macOS 13-25 → libkrun). On a
+    /// Linux+KVM host, `--hypervisor libkrun` opts into the libkrun runtime instead
+    /// of the firecracker default — both require `/dev/kvm` and enforce claim-10
+    /// egress (qemu is a no-`/dev/kvm` dev/test fallback only). `MVM_HYPERVISOR` is
+    /// the env equivalent.
+    #[arg(long, value_name = "HYPERVISOR")]
     pub hypervisor: Option<String>,
     /// Skip plan-admission signing (hidden; for testing only).
     #[arg(long, hide = true)]
@@ -740,8 +745,13 @@ pub(in crate::commands) struct MachineStartArgs {
     /// when an interactive shell attach follows. Not a CLI flag.
     #[arg(skip)]
     pub quiet: bool,
-    /// Override the backend hypervisor (hidden; for testing only).
-    #[arg(long, value_name = "HYPERVISOR", hide = true)]
+    /// Workload VMM backend. Defaults to the host's best supported backend
+    /// (Linux+KVM → firecracker; macOS 26+ → vz; macOS 13-25 → libkrun). On a
+    /// Linux+KVM host, `--hypervisor libkrun` opts into the libkrun runtime instead
+    /// of the firecracker default — both require `/dev/kvm` and enforce claim-10
+    /// egress (qemu is a no-`/dev/kvm` dev/test fallback only). `MVM_HYPERVISOR` is
+    /// the env equivalent.
+    #[arg(long, value_name = "HYPERVISOR")]
     pub hypervisor: Option<String>,
     /// Skip plan-admission signing (hidden; for testing only).
     #[arg(long, hide = true)]

--- a/crates/mvm-cli/src/commands/shared/resolve.rs
+++ b/crates/mvm-cli/src/commands/shared/resolve.rs
@@ -239,11 +239,25 @@ fn parse_allow_host(entry: &str) -> Result<mvm_core::network_policy::HostPort> {
 /// Resolve the requested hypervisor to the effective one for this host. `firecracker`
 /// (the default `--hypervisor`) auto-detects: KVM → firecracker, macOS 26+ Apple Silicon
 /// → vz, macOS 13-25 + libkrun → libkrun, else firecracker (surfaces a clear
-/// "not available" error). Any explicit value is returned as-is. Single source of truth,
-/// shared by `mvmctl up` and `mvmctl pool` so they agree on the backend.
+/// "not available" error). Any explicit value is returned as-is. The `MVM_HYPERVISOR`
+/// env var (alias `MVM_BACKEND`) overrides auto-detect — the workload-VMM override
+/// mirroring `MVM_BUILDER_BACKEND` for the builder, so a Linux/KVM host can opt into
+/// `libkrun` instead of the Firecracker default. Single source of truth, shared by
+/// the run/pool paths so they agree on the backend.
 pub fn resolve_effective_hypervisor(requested: &str) -> String {
     if requested != "firecracker" {
         return requested.to_string();
+    }
+    // Env override (auto-detect mode only — an explicit `--hypervisor` flag already
+    // won above): `MVM_HYPERVISOR=<firecracker|libkrun|vz|hvf|qemu>`, with the older
+    // `MVM_BACKEND` kept as a back-compat alias. Does not change the platform default.
+    for var in ["MVM_HYPERVISOR", "MVM_BACKEND"] {
+        if let Some(name) = std::env::var_os(var) {
+            let name = name.to_string_lossy().trim().to_ascii_lowercase();
+            if !name.is_empty() {
+                return name;
+            }
+        }
     }
     let plat = mvm_core::platform::current();
     if plat.has_kvm() {
@@ -358,5 +372,50 @@ mod tests {
             "libkrun:l4-host-port"
         );
         assert_eq!(egress_enforcement_label("vz", &p), "vz:l4-host-port");
+    }
+
+    /// An explicit `--hypervisor <x>` (anything but the `firecracker`
+    /// auto-detect sentinel) is returned verbatim — so a Linux/KVM host can
+    /// select `libkrun` (or any other backend) without env.
+    #[test]
+    fn explicit_hypervisor_is_returned_verbatim() {
+        assert_eq!(resolve_effective_hypervisor("libkrun"), "libkrun");
+        assert_eq!(resolve_effective_hypervisor("vz"), "vz");
+        assert_eq!(resolve_effective_hypervisor("hvf"), "hvf");
+        assert_eq!(resolve_effective_hypervisor("qemu"), "qemu");
+    }
+
+    /// `MVM_HYPERVISOR` overrides auto-detect (and `MVM_BACKEND` is the
+    /// back-compat alias); an explicit flag still wins over both. Process-isolated
+    /// under nextest; restored here so a threaded runner doesn't leak it.
+    #[test]
+    fn env_overrides_auto_detect_with_alias() {
+        let saved_hv = std::env::var_os("MVM_HYPERVISOR");
+        let saved_be = std::env::var_os("MVM_BACKEND");
+        // SAFETY: test-local env mutation, restored before returning.
+        unsafe {
+            std::env::remove_var("MVM_BACKEND");
+            std::env::set_var("MVM_HYPERVISOR", "libkrun");
+        }
+        assert_eq!(resolve_effective_hypervisor("firecracker"), "libkrun");
+        // An explicit flag wins over the env override.
+        assert_eq!(resolve_effective_hypervisor("vz"), "vz");
+        // The older alias is still honored.
+        unsafe {
+            std::env::remove_var("MVM_HYPERVISOR");
+            std::env::set_var("MVM_BACKEND", "hvf");
+        }
+        assert_eq!(resolve_effective_hypervisor("firecracker"), "hvf");
+        // SAFETY: restore prior values.
+        unsafe {
+            match saved_hv {
+                Some(v) => std::env::set_var("MVM_HYPERVISOR", v),
+                None => std::env::remove_var("MVM_HYPERVISOR"),
+            }
+            match saved_be {
+                Some(v) => std::env::set_var("MVM_BACKEND", v),
+                None => std::env::remove_var("MVM_BACKEND"),
+            }
+        }
     }
 }

--- a/crates/mvm-cli/src/doctor.rs
+++ b/crates/mvm-cli/src/doctor.rs
@@ -207,6 +207,38 @@ struct WarmStartSubstrate {
 /// detail) so "why did Stage 0 fire / when did it last run?" is
 /// answerable without grep-ing the audit log. Informational: a stale or
 /// never-run Stage 0 is not a host-side defect, so `ok` is always true.
+/// Informational: which **workload** runtime backend(s) this host can run, driven
+/// by a `/dev/kvm` probe. On Linux+KVM both `firecracker` (default) and `libkrun`
+/// are workload backends (selectable via `--hypervisor` / `MVM_HYPERVISOR`); with
+/// no `/dev/kvm` only `qemu` runs, and it is dev/test-only — claim-10 egress is
+/// deliberately NOT enforced there, so the tier downgrade stays explicit.
+fn runtime_backend_check(plat: platform::Platform) -> Check {
+    use platform::Platform;
+    let info = match plat {
+        Platform::LinuxNative => "/dev/kvm present — `firecracker` (default) or \
+             `--hypervisor libkrun` (MVM_HYPERVISOR=libkrun); both need /dev/kvm and \
+             enforce claim-10 egress"
+            .to_string(),
+        Platform::LinuxNoKvm => "no /dev/kvm — only the `qemu` dev/test backend runs \
+             here, which is NOT a workload backend: claim-10 egress is deliberately \
+             NOT enforced (dev/test only)"
+            .to_string(),
+        Platform::Wsl2 => "WSL2 — a workload runtime needs nested /dev/kvm; without it \
+             only `qemu` (dev/test only, no claim-10) runs"
+            .to_string(),
+        Platform::MacOS => "macOS — `vz` (macOS 26+) or `libkrun` (macOS 13-25) \
+             workload backends, selectable via `--hypervisor`"
+            .to_string(),
+        Platform::Windows => "Windows — no local microVM workload path yet".to_string(),
+    };
+    Check {
+        name: "workload runtime backend",
+        category: "platform",
+        ok: true,
+        info,
+    }
+}
+
 fn stage0_status_check() -> Check {
     use mvm_core::policy::audit::LocalAuditKind;
     let info = match mvm_core::policy::audit::read_last_stage0_event() {
@@ -537,6 +569,7 @@ pub fn run(json: bool, workflow: Option<DoctorWorkflow>) -> Result<()> {
     checks.push(vz_check(plat));
     checks.push(libkrun_check(plat));
     checks.push(builder_backend_check(plat));
+    checks.push(runtime_backend_check(plat));
     checks.push(residency_check());
     checks.push(builder_residency_check());
     checks.push(network_backend_check(plat));


### PR DESCRIPTION
Decomposed from the Plan 214 spike branch (part of the monster PR #1362), scoped to the two independent CLI deliverables — no dependency on the in-house VMM, builds clean on current main.

## What
- **`--hypervisor libkrun` is now a real selector on Linux/KVM** (`resolve.rs`, `machine/mod.rs`): the flag is un-hidden and user-facing; `resolve_effective_hypervisor` honors an explicit `--hypervisor` and the `MVM_HYPERVISOR`/`MVM_BACKEND` env override in auto-detect mode. Firecracker stays the Linux default; `--hypervisor libkrun` opts into the libkrun runtime instead. Both require `/dev/kvm` and enforce claim-10 egress; qemu remains a no-`/dev/kvm` dev/test fallback only.
- **doctor `/dev/kvm`-driven runtime-backend guidance** (`doctor.rs`): a `runtime_backend_check` line that reports, per platform — Linux+KVM → firecracker (default) or `--hypervisor libkrun`; Linux without KVM → qemu dev/test only, **claim-10 NOT enforced**; macOS → vz/libkrun via `--hypervisor`.

## Tests
`cargo nextest run -p mvm-cli resolve` → 95/95 pass (incl. the selector tests: explicit-hypervisor-returned-verbatim, env-overrides-auto-detect). `fmt --all --check` + `clippy -p mvm-cli -D warnings` clean on current main. Verified live on a Linux/KVM host earlier this session (doctor renders the runtime-backend line correctly; `--hypervisor libkrun` selects).

Part of decomposing #1362 into reviewable pieces; #1362 (the whole-spike blob) to be closed once the stack lands.