### PR TITLE
Plan 214 (E): vsock file-transfer + build-session protocol for the in-house-VMM builder

### DIFF
--- a/crates/mvm-guest/src/builder_build.rs
+++ b/crates/mvm-guest/src/builder_build.rs
@@ -1,0 +1,219 @@
+//! The in-house-VMM builder's guest-side nix build.
+//!
+//! Runs `nix build` against the vsock-staged `/work` tree (with `/mvm-bins`
+//! exposed as `MVM_HOST_BIN_DIR`) and stages the kernel + rootfs into a local dir
+//! the [build session](crate::builder_session) streams back to the host. It is
+//! the transport-free build core the builder server's `serve_build` closure runs.
+//! Mirrors the legacy builder agent's nix invocation, but stages to a plain
+//! directory instead of a `/dev/vdb` disk mount — the in-house VMM has no writable
+//! host-shared disk, so artifacts go back over vsock.
+
+use std::io::{Read, Write};
+use std::path::Path;
+use std::process::Command;
+
+use crate::builder_agent::{validate_build_attr, validate_flake_ref};
+use crate::builder_session::{BuildOutcome, BuildProduct, BuildRequest, serve_build};
+
+/// Default build timeout when the request leaves it unset (30 min).
+const DEFAULT_TIMEOUT_SECS: u64 = 1800;
+
+/// The shell command that builds `flake_ref#attr` and prints the store path.
+/// `flake_ref`/`attr` are validated by [`run_nix_build`] before this is built, so
+/// they carry no shell metacharacters.
+pub fn nix_build_command(flake_ref: &str, attr: &str, timeout_secs: u64) -> String {
+    format!("timeout {timeout_secs} nix build {flake_ref}#{attr} --no-link --print-out-paths")
+}
+
+/// The built output path — the last `/nix/store/...` line of nix's stdout.
+pub fn extract_store_path(stdout: &str) -> Option<String> {
+    stdout
+        .lines()
+        .map(str::trim)
+        .rev()
+        .find(|l| l.starts_with("/nix/store/"))
+        .map(str::to_string)
+}
+
+/// The shell command that copies the kernel + rootfs out of `store_path` into
+/// `out_dir`, accepting either output naming (`kernel`/`vmlinux`,
+/// `rootfs`/`rootfs.ext4`).
+pub fn stage_command(store_path: &str, out_dir: &str) -> String {
+    format!(
+        "set -eu; \
+         cp {s}/kernel {o}/vmlinux 2>/dev/null || cp {s}/vmlinux {o}/vmlinux; \
+         cp {s}/rootfs {o}/rootfs.ext4 2>/dev/null || cp {s}/rootfs.ext4 {o}/rootfs.ext4",
+        s = store_path,
+        o = out_dir
+    )
+}
+
+/// Run a build for one session: validate the inputs, `nix build` in `work` with
+/// `MVM_HOST_BIN_DIR=mvm_bins`, stage the kernel + rootfs into `out_dir`, and
+/// return a [`BuildProduct`]. Every failure (bad input, nix error, missing store
+/// path, staging error) returns [`BuildOutcome::Failure`] with the captured logs
+/// — never a panic, so the session always completes cleanly.
+pub fn run_nix_build(
+    work: &Path,
+    mvm_bins: &Path,
+    out_dir: &Path,
+    req: &BuildRequest,
+) -> BuildProduct {
+    let mut logs = Vec::new();
+    let fail = |logs: Vec<String>, message: String| BuildProduct {
+        outcome: BuildOutcome::Failure { message },
+        out_dir: std::path::PathBuf::new(),
+        logs,
+    };
+
+    // Reuse the legacy agent's input validation (no shell metacharacters / no
+    // path traversal) before the inputs reach a shell.
+    if let Err(e) = validate_flake_ref(&req.flake_ref) {
+        return fail(logs, format!("invalid flake_ref: {e}"));
+    }
+    if let Err(e) = validate_build_attr(&req.attr) {
+        return fail(logs, format!("invalid attr: {e}"));
+    }
+    if let Err(e) = std::fs::create_dir_all(out_dir) {
+        return fail(logs, format!("create out dir: {e}"));
+    }
+
+    let timeout = req.timeout_secs.unwrap_or(DEFAULT_TIMEOUT_SECS);
+    let build = nix_build_command(&req.flake_ref, &req.attr, timeout);
+    let output = match Command::new("sh")
+        .arg("-c")
+        .arg(&build)
+        .current_dir(work)
+        .env("MVM_HOST_BIN_DIR", mvm_bins)
+        .output()
+    {
+        Ok(o) => o,
+        Err(e) => return fail(logs, format!("spawn nix build: {e}")),
+    };
+    capture_lines(&mut logs, &output.stdout);
+    capture_lines(&mut logs, &output.stderr);
+
+    if !output.status.success() {
+        return fail(logs, format!("nix build failed (exit {})", output.status));
+    }
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    let Some(store_path) = extract_store_path(&stdout) else {
+        return fail(logs, "nix build produced no store path".into());
+    };
+
+    let stage = stage_command(&store_path, &out_dir.to_string_lossy());
+    match Command::new("sh").arg("-c").arg(&stage).output() {
+        Ok(o) if o.status.success() => {}
+        Ok(o) => {
+            capture_lines(&mut logs, &o.stderr);
+            return fail(logs, format!("stage artifacts failed (exit {})", o.status));
+        }
+        Err(e) => return fail(logs, format!("spawn artifact staging: {e}")),
+    }
+
+    BuildProduct {
+        outcome: BuildOutcome::Success,
+        out_dir: out_dir.to_path_buf(),
+        logs,
+    }
+}
+
+fn capture_lines(logs: &mut Vec<String>, bytes: &[u8]) {
+    for line in String::from_utf8_lossy(bytes).lines() {
+        logs.push(line.to_string());
+    }
+}
+
+/// Serve one builder session on `stream`: receive `/work` + `/mvm-bins` into the
+/// given destinations, run the nix build into `out_dir`, and stream logs +
+/// outcome (+ artifacts on success) back. The transport glue between
+/// [`serve_build`] and [`run_nix_build`] the builder server's accept loop calls
+/// per connection.
+pub fn serve_builder_session<S: Read + Write>(
+    stream: &mut S,
+    work_dest: &Path,
+    mvm_bins_dest: &Path,
+    out_dir: &Path,
+) -> anyhow::Result<()> {
+    serve_build(stream, work_dest, mvm_bins_dest, |w, b, req| {
+        run_nix_build(w, b, out_dir, req)
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn nix_build_command_is_well_formed() {
+        let cmd = nix_build_command(".", "packages.aarch64-linux.default", 600);
+        assert_eq!(
+            cmd,
+            "timeout 600 nix build .#packages.aarch64-linux.default --no-link --print-out-paths"
+        );
+    }
+
+    #[test]
+    fn extract_store_path_takes_the_last_store_line() {
+        let stdout = "evaluating...\n\
+                      /nix/store/aaa-first\n\
+                      warning: x\n\
+                      /nix/store/bbb-final\n";
+        assert_eq!(
+            extract_store_path(stdout),
+            Some("/nix/store/bbb-final".to_string())
+        );
+    }
+
+    #[test]
+    fn extract_store_path_none_when_absent() {
+        assert_eq!(extract_store_path("error: eval failed\n"), None);
+    }
+
+    #[test]
+    fn stage_command_handles_both_artifact_namings() {
+        let cmd = stage_command("/nix/store/xyz-out", "/tmp/o");
+        // kernel→vmlinux with a vmlinux fallback.
+        assert!(cmd.contains("cp /nix/store/xyz-out/kernel /tmp/o/vmlinux"));
+        assert!(cmd.contains("cp /nix/store/xyz-out/vmlinux /tmp/o/vmlinux"));
+        // rootfs→rootfs.ext4 with a rootfs.ext4 fallback.
+        assert!(cmd.contains("cp /nix/store/xyz-out/rootfs /tmp/o/rootfs.ext4"));
+        assert!(cmd.contains("cp /nix/store/xyz-out/rootfs.ext4 /tmp/o/rootfs.ext4"));
+    }
+
+    #[test]
+    fn run_nix_build_refuses_a_malicious_flake_ref_before_any_exec() {
+        let work = tempfile::tempdir().unwrap();
+        let bins = tempfile::tempdir().unwrap();
+        let out = tempfile::tempdir().unwrap();
+        let req = BuildRequest {
+            flake_ref: ".#x; rm -rf /".into(),
+            attr: "packages.default".into(),
+            timeout_secs: Some(60),
+        };
+        let product = run_nix_build(work.path(), bins.path(), out.path(), &req);
+        assert!(
+            matches!(product.outcome, BuildOutcome::Failure { ref message } if message.contains("invalid flake_ref")),
+            "a shell-metachar flake_ref must fail validation: {:?}",
+            product.outcome
+        );
+    }
+
+    #[test]
+    fn run_nix_build_refuses_a_malicious_attr() {
+        let work = tempfile::tempdir().unwrap();
+        let bins = tempfile::tempdir().unwrap();
+        let out = tempfile::tempdir().unwrap();
+        let req = BuildRequest {
+            flake_ref: ".".into(),
+            attr: "packages.default && curl evil".into(),
+            timeout_secs: Some(60),
+        };
+        let product = run_nix_build(work.path(), bins.path(), out.path(), &req);
+        assert!(
+            matches!(product.outcome, BuildOutcome::Failure { ref message } if message.contains("invalid attr")),
+            "a shell-metachar attr must fail validation: {:?}",
+            product.outcome
+        );
+    }
+}

--- a/crates/mvm-guest/src/builder_session.rs
+++ b/crates/mvm-guest/src/builder_session.rs
@@ -1,0 +1,256 @@
+//! The in-house-VMM builder's host↔guest build session, over one vsock stream.
+//!
+//! A builder VM booted by the in-house VMM (HVF/KVM) has no host-mounted share, so
+//! a whole build is driven over a single vsock connection using the
+//! [`builder_transfer`](crate::builder_transfer) file primitive plus a few control
+//! messages. The sequence on one stream, in order (no interleaving, so each side
+//! always knows what to read next):
+//!
+//! 1. host → guest: the source tree (`/work`) as a transfer.
+//! 2. host → guest: the host-binary tree (`/mvm-bins`) as a transfer.
+//! 3. host → guest: a [`BuildRequest`].
+//! 4. guest → host: zero or more [`SessionEvent::Log`] lines.
+//! 5. guest → host: [`SessionEvent::Done`] carrying the [`BuildOutcome`].
+//! 6. guest → host (only on success): the artifact tree (`/out`) as a transfer.
+//!
+//! The guest is untrusted on the return leg, so step 6's receive is the
+//! path-sanitized [`builder_transfer::receive_into`] — a hostile guest cannot
+//! write outside the host's artifact dir.
+
+use std::io::{Read, Write};
+use std::path::{Path, PathBuf};
+
+use anyhow::Result;
+use serde::{Deserialize, Serialize};
+
+use crate::builder_transfer::{read_msg, receive_into, send_dir, write_msg};
+
+/// What the host asks the builder guest to build. `flake_ref`/`attr` are the
+/// same validated inputs the existing builder agent takes; the guest resolves
+/// them against the staged `/work` tree.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct BuildRequest {
+    pub flake_ref: String,
+    pub attr: String,
+    pub timeout_secs: Option<u64>,
+}
+
+/// Terminal result of a build.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(tag = "status", rename_all = "snake_case")]
+pub enum BuildOutcome {
+    /// The build succeeded; the artifact tree follows on the stream.
+    Success,
+    /// The build failed; no artifact tree follows.
+    Failure { message: String },
+}
+
+/// A guest→host event during/after the build.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(tag = "kind", rename_all = "snake_case")]
+pub enum SessionEvent {
+    /// A streamed build log line.
+    Log { line: String },
+    /// The build finished with this outcome (last control message).
+    Done { outcome: BuildOutcome },
+}
+
+/// What the guest's build closure returns: the outcome, the directory to stream
+/// back as `/out` on success, and any log lines to surface to the host.
+pub struct BuildProduct {
+    pub outcome: BuildOutcome,
+    /// Directory whose tree is streamed to the host on success. Ignored on failure.
+    pub out_dir: PathBuf,
+    pub logs: Vec<String>,
+}
+
+/// Host side: drive a full build over `stream`. Sends `/work` + `/mvm-bins`,
+/// sends the request, surfaces each log line via `on_log`, and on success
+/// receives the artifact tree into `out_dir` (path-sanitized). Returns the
+/// outcome.
+pub fn drive_build<S: Read + Write>(
+    stream: &mut S,
+    work_dir: &Path,
+    mvm_bins_dir: &Path,
+    request: &BuildRequest,
+    out_dir: &Path,
+    mut on_log: impl FnMut(&str),
+) -> Result<BuildOutcome> {
+    send_dir(stream, work_dir)?;
+    send_dir(stream, mvm_bins_dir)?;
+    write_msg(stream, request)?;
+    loop {
+        match read_msg::<_, SessionEvent>(stream)? {
+            SessionEvent::Log { line } => on_log(&line),
+            SessionEvent::Done { outcome } => {
+                if matches!(outcome, BuildOutcome::Success) {
+                    receive_into(stream, out_dir)?;
+                }
+                return Ok(outcome);
+            }
+        }
+    }
+}
+
+/// Guest side: serve one build session on `stream`. Receives `/work` +
+/// `/mvm-bins` into the given destinations, reads the request, runs `build`, then
+/// streams the logs + outcome (+ the artifact tree on success) back.
+pub fn serve_build<S, F>(
+    stream: &mut S,
+    work_dest: &Path,
+    mvm_bins_dest: &Path,
+    build: F,
+) -> Result<()>
+where
+    S: Read + Write,
+    F: FnOnce(&Path, &Path, &BuildRequest) -> BuildProduct,
+{
+    receive_into(stream, work_dest)?;
+    receive_into(stream, mvm_bins_dest)?;
+    let request: BuildRequest = read_msg(stream)?;
+    let product = build(work_dest, mvm_bins_dest, &request);
+    for line in &product.logs {
+        write_msg(stream, &SessionEvent::Log { line: line.clone() })?;
+    }
+    write_msg(
+        stream,
+        &SessionEvent::Done {
+            outcome: product.outcome.clone(),
+        },
+    )?;
+    if matches!(product.outcome, BuildOutcome::Success) {
+        send_dir(stream, &product.out_dir)?;
+    }
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::os::unix::net::UnixStream;
+    use std::thread;
+
+    fn request() -> BuildRequest {
+        BuildRequest {
+            flake_ref: ".".into(),
+            attr: "packages.aarch64-linux.default".into(),
+            timeout_secs: Some(600),
+        }
+    }
+
+    /// Full happy path over a real socket pair: the host sends `/work` +
+    /// `/mvm-bins` and a request; the guest "builds" (here: copies `/work` into an
+    /// `/out` dir) and streams logs + the artifact tree back; the host receives the
+    /// artifacts.
+    #[test]
+    fn drives_a_build_and_receives_artifacts() {
+        let (mut host, mut guest) = UnixStream::pair().unwrap();
+
+        let work = tempfile::tempdir().unwrap();
+        std::fs::write(work.path().join("flake.nix"), b"{ outputs = ...; }").unwrap();
+        std::fs::create_dir_all(work.path().join("src")).unwrap();
+        std::fs::write(work.path().join("src/app.py"), b"print('hi')").unwrap();
+        let bins = tempfile::tempdir().unwrap();
+        std::fs::write(bins.path().join("mvm-host-vm-init"), b"ELF...").unwrap();
+
+        // Guest server thread: build = copy /work into a fresh /out, emit a log.
+        let guest_handle = thread::spawn(move || {
+            let work_dest = tempfile::tempdir().unwrap();
+            let bins_dest = tempfile::tempdir().unwrap();
+            serve_build(
+                &mut guest,
+                work_dest.path(),
+                bins_dest.path(),
+                |work_in, bins_in, req| {
+                    // The guest saw the staged trees + the request.
+                    assert!(work_in.join("flake.nix").exists());
+                    assert!(bins_in.join("mvm-host-vm-init").exists());
+                    assert_eq!(req.attr, "packages.aarch64-linux.default");
+                    // "Build": produce an artifact dir.
+                    let out = tempfile::tempdir().unwrap();
+                    std::fs::write(out.path().join("vmlinux"), b"KERNEL").unwrap();
+                    std::fs::write(out.path().join("rootfs.ext4"), vec![9u8; 2048]).unwrap();
+                    let out_dir = out.keep();
+                    BuildProduct {
+                        outcome: BuildOutcome::Success,
+                        out_dir,
+                        logs: vec!["building default".into(), "done".into()],
+                    }
+                },
+            )
+            .unwrap();
+        });
+
+        let out = tempfile::tempdir().unwrap();
+        let mut logs = Vec::new();
+        let outcome = drive_build(
+            &mut host,
+            work.path(),
+            bins.path(),
+            &request(),
+            out.path(),
+            |l| logs.push(l.to_string()),
+        )
+        .unwrap();
+        guest_handle.join().unwrap();
+
+        assert_eq!(outcome, BuildOutcome::Success);
+        assert_eq!(logs, vec!["building default", "done"]);
+        // The artifacts streamed back.
+        assert_eq!(
+            std::fs::read(out.path().join("vmlinux")).unwrap(),
+            b"KERNEL"
+        );
+        assert_eq!(
+            std::fs::read(out.path().join("rootfs.ext4")).unwrap(),
+            vec![9u8; 2048]
+        );
+    }
+
+    /// A failing build streams the failure outcome and **no** artifact tree; the
+    /// host's `out_dir` stays empty.
+    #[test]
+    fn a_failed_build_streams_no_artifacts() {
+        let (mut host, mut guest) = UnixStream::pair().unwrap();
+        let work = tempfile::tempdir().unwrap();
+        std::fs::write(work.path().join("flake.nix"), b"broken").unwrap();
+        let bins = tempfile::tempdir().unwrap();
+        std::fs::write(bins.path().join("x"), b"x").unwrap();
+
+        let guest_handle = thread::spawn(move || {
+            let wd = tempfile::tempdir().unwrap();
+            let bd = tempfile::tempdir().unwrap();
+            serve_build(&mut guest, wd.path(), bd.path(), |_w, _b, _r| {
+                BuildProduct {
+                    outcome: BuildOutcome::Failure {
+                        message: "nix build exit 1".into(),
+                    },
+                    out_dir: PathBuf::new(),
+                    logs: vec!["error: eval failed".into()],
+                }
+            })
+            .unwrap();
+        });
+
+        let out = tempfile::tempdir().unwrap();
+        let outcome = drive_build(
+            &mut host,
+            work.path(),
+            bins.path(),
+            &request(),
+            out.path(),
+            |_| {},
+        )
+        .unwrap();
+        guest_handle.join().unwrap();
+
+        assert_eq!(
+            outcome,
+            BuildOutcome::Failure {
+                message: "nix build exit 1".into()
+            }
+        );
+        // Nothing was written to the host artifact dir.
+        assert_eq!(std::fs::read_dir(out.path()).unwrap().count(), 0);
+    }
+}

--- a/crates/mvm-guest/src/builder_transfer.rs
+++ b/crates/mvm-guest/src/builder_transfer.rs
@@ -25,6 +25,7 @@ use std::io::{Read, Write};
 use std::path::{Component, Path, PathBuf};
 
 use anyhow::{Context, Result, bail};
+use serde::de::DeserializeOwned;
 use serde::{Deserialize, Serialize};
 
 /// Cap on a single frame's JSON header (paths are short; this is generous).
@@ -158,33 +159,40 @@ fn safe_join(root: &Path, rel: &str) -> Result<PathBuf> {
     Ok(out)
 }
 
-/// Write a length-prefixed JSON frame (4-byte big-endian length + body).
 fn write_frame<W: Write>(out: &mut W, frame: &Frame) -> Result<()> {
-    let body = serde_json::to_vec(frame).context("encode transfer frame")?;
-    let len: u32 = body
-        .len()
-        .try_into()
-        .context("transfer frame header too large")?;
+    write_msg(out, frame)
+}
+
+fn read_frame<R: Read>(input: &mut R) -> Result<Frame> {
+    read_msg(input)
+}
+
+/// Write a length-prefixed JSON message (4-byte big-endian length + JSON body) —
+/// the shared framing for the transfer file headers and the build-session control
+/// messages built on top of them.
+pub fn write_msg<W: Write, T: Serialize>(out: &mut W, msg: &T) -> Result<()> {
+    let body = serde_json::to_vec(msg).context("encode framed message")?;
+    let len: u32 = body.len().try_into().context("framed message too large")?;
     out.write_all(&len.to_be_bytes())?;
     out.write_all(&body)?;
     Ok(())
 }
 
-/// Read one length-prefixed JSON frame. The cap bounds a hostile header.
-fn read_frame<R: Read>(input: &mut R) -> Result<Frame> {
+/// Read one length-prefixed JSON message. The cap bounds a hostile header.
+pub fn read_msg<R: Read, T: DeserializeOwned>(input: &mut R) -> Result<T> {
     let mut len_buf = [0u8; 4];
     input
         .read_exact(&mut len_buf)
-        .context("read transfer frame length")?;
+        .context("read framed message length")?;
     let len = u32::from_be_bytes(len_buf) as usize;
     if len > MAX_HEADER_BYTES {
-        bail!("transfer frame header {len} exceeds the {MAX_HEADER_BYTES}-byte cap");
+        bail!("framed message header {len} exceeds the {MAX_HEADER_BYTES}-byte cap");
     }
     let mut body = vec![0u8; len];
     input
         .read_exact(&mut body)
-        .context("read transfer frame body")?;
-    serde_json::from_slice(&body).context("decode transfer frame")
+        .context("read framed message body")?;
+    serde_json::from_slice(&body).context("decode framed message")
 }
 
 #[cfg(unix)]

--- a/crates/mvm-guest/src/builder_transfer.rs
+++ b/crates/mvm-guest/src/builder_transfer.rs
@@ -1,0 +1,350 @@
+//! Builder-VM file transfer over the guest↔host vsock channel.
+//!
+//! The in-house VMM (HVF on macOS, KVM on Linux) has no virtio-fs and no
+//! writable host-shared disk — only virtio-blk + vsock. So the builder VM moves
+//! files the way everything moves under the vsock-only guest channel: over vsock.
+//! The host streams the source tree (and host binaries) *into* the builder guest,
+//! and the guest streams
+//! the built artifacts *back*. No host directory is ever live-mounted into the
+//! guest, and the host never parses a guest-authored filesystem image.
+//!
+//! Wire format: a framed stream. Each regular file is a length-prefixed JSON
+//! header ([`Frame::File`] — relative path, unix mode, byte length) immediately
+//! followed by exactly `len` content bytes; a [`Frame::End`] marker closes the
+//! tree. Framing reuses the 4-byte big-endian length prefix the rest of the vsock
+//! protocol uses.
+//!
+//! **Security.** The receiver is the trust boundary: when the host receives the
+//! guest's `/out`, the guest is *untrusted*. [`receive_into`] therefore admits
+//! only `Component::Normal` path segments — no `..`, absolute paths, prefixes, or
+//! root-dir — so a hostile sender cannot escape the destination root, mirroring
+//! the OCI unpacker's no-path-escape discipline (a defense-in-depth `starts_with`
+//! check backs it up). Per-file and per-header size caps bound memory.
+
+use std::io::{Read, Write};
+use std::path::{Component, Path, PathBuf};
+
+use anyhow::{Context, Result, bail};
+use serde::{Deserialize, Serialize};
+
+/// Cap on a single frame's JSON header (paths are short; this is generous).
+const MAX_HEADER_BYTES: usize = 64 * 1024;
+/// Cap on a single transferred file (a built kernel/rootfs is the large case).
+const MAX_FILE_BYTES: u64 = 8 * 1024 * 1024 * 1024;
+
+/// One framed message on the transfer stream.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(tag = "kind", rename_all = "snake_case")]
+enum Frame {
+    /// A regular file: `len` content bytes follow this header on the stream.
+    File {
+        /// Path relative to the tree root. Sanitized on receive.
+        rel_path: String,
+        /// Unix permission bits (low 12) to set on the written file.
+        mode: u32,
+        /// Content length in bytes that immediately follow this header.
+        len: u64,
+    },
+    /// End of the tree — no more files.
+    End,
+}
+
+/// Stream every regular file under `src` to `out` as framed messages, then an
+/// [`Frame::End`]. Directories are implicit (recreated from the file paths);
+/// symlinks and other non-regular entries are skipped (the builder tree is
+/// plain files). Paths are stored relative to `src`.
+pub fn send_dir<W: Write>(out: &mut W, src: &Path) -> Result<()> {
+    send_dir_inner(out, src, src)?;
+    write_frame(out, &Frame::End)
+}
+
+fn send_dir_inner<W: Write>(out: &mut W, root: &Path, dir: &Path) -> Result<()> {
+    let mut entries: Vec<_> = std::fs::read_dir(dir)
+        .with_context(|| format!("read_dir {}", dir.display()))?
+        .filter_map(|e| e.ok())
+        .collect();
+    // Deterministic order so a transfer is reproducible.
+    entries.sort_by_key(|e| e.file_name());
+    for entry in entries {
+        let path = entry.path();
+        let ft = entry.file_type()?;
+        if ft.is_dir() {
+            send_dir_inner(out, root, &path)?;
+        } else if ft.is_file() {
+            let rel = path
+                .strip_prefix(root)
+                .with_context(|| format!("{} not under {}", path.display(), root.display()))?
+                .to_string_lossy()
+                .into_owned();
+            let meta = entry.metadata()?;
+            write_frame(
+                out,
+                &Frame::File {
+                    rel_path: rel,
+                    mode: unix_mode(&meta),
+                    len: meta.len(),
+                },
+            )?;
+            let mut f =
+                std::fs::File::open(&path).with_context(|| format!("open {}", path.display()))?;
+            std::io::copy(&mut f, out).with_context(|| format!("stream {}", path.display()))?;
+        }
+        // non-regular (symlink, fifo, …): skipped — not part of the build tree.
+    }
+    Ok(())
+}
+
+/// Receive a framed tree into `dest_root`, sanitizing every path. Returns the
+/// number of files written. Fails closed on an unsafe path, an oversize file, or
+/// a short content read — the partial tree is left for the caller to discard.
+pub fn receive_into<R: Read>(input: &mut R, dest_root: &Path) -> Result<u64> {
+    std::fs::create_dir_all(dest_root)
+        .with_context(|| format!("create dest root {}", dest_root.display()))?;
+    let mut written = 0u64;
+    loop {
+        match read_frame(input)? {
+            Frame::End => break,
+            Frame::File {
+                rel_path,
+                mode,
+                len,
+            } => {
+                if len > MAX_FILE_BYTES {
+                    bail!("transferred file {rel_path:?} exceeds the {MAX_FILE_BYTES}-byte cap");
+                }
+                let dest = safe_join(dest_root, &rel_path)?;
+                if let Some(parent) = dest.parent() {
+                    std::fs::create_dir_all(parent)
+                        .with_context(|| format!("create {}", parent.display()))?;
+                }
+                let mut f = std::fs::File::create(&dest)
+                    .with_context(|| format!("create {}", dest.display()))?;
+                let mut limited = input.take(len);
+                let copied = std::io::copy(&mut limited, &mut f)
+                    .with_context(|| format!("write {}", dest.display()))?;
+                if copied != len {
+                    bail!("short content for {rel_path:?}: got {copied} of {len} bytes");
+                }
+                set_unix_mode(&dest, mode)?;
+                written += 1;
+            }
+        }
+    }
+    Ok(written)
+}
+
+/// Join `rel` under `root`, admitting only `Component::Normal` segments. Any
+/// `..`, absolute path, prefix, or root-dir component is refused — a hostile
+/// sender cannot escape `root`. The trailing `starts_with` is belt-and-braces.
+fn safe_join(root: &Path, rel: &str) -> Result<PathBuf> {
+    let mut out = root.to_path_buf();
+    let mut had_segment = false;
+    for comp in Path::new(rel).components() {
+        match comp {
+            Component::Normal(seg) => {
+                out.push(seg);
+                had_segment = true;
+            }
+            Component::CurDir => {} // `.` is harmless; ignore
+            other => bail!("unsafe path component {other:?} in transferred path {rel:?}"),
+        }
+    }
+    if !had_segment {
+        bail!("empty transferred path");
+    }
+    if !out.starts_with(root) {
+        bail!("transferred path {rel:?} escapes the destination root");
+    }
+    Ok(out)
+}
+
+/// Write a length-prefixed JSON frame (4-byte big-endian length + body).
+fn write_frame<W: Write>(out: &mut W, frame: &Frame) -> Result<()> {
+    let body = serde_json::to_vec(frame).context("encode transfer frame")?;
+    let len: u32 = body
+        .len()
+        .try_into()
+        .context("transfer frame header too large")?;
+    out.write_all(&len.to_be_bytes())?;
+    out.write_all(&body)?;
+    Ok(())
+}
+
+/// Read one length-prefixed JSON frame. The cap bounds a hostile header.
+fn read_frame<R: Read>(input: &mut R) -> Result<Frame> {
+    let mut len_buf = [0u8; 4];
+    input
+        .read_exact(&mut len_buf)
+        .context("read transfer frame length")?;
+    let len = u32::from_be_bytes(len_buf) as usize;
+    if len > MAX_HEADER_BYTES {
+        bail!("transfer frame header {len} exceeds the {MAX_HEADER_BYTES}-byte cap");
+    }
+    let mut body = vec![0u8; len];
+    input
+        .read_exact(&mut body)
+        .context("read transfer frame body")?;
+    serde_json::from_slice(&body).context("decode transfer frame")
+}
+
+#[cfg(unix)]
+fn unix_mode(meta: &std::fs::Metadata) -> u32 {
+    use std::os::unix::fs::MetadataExt;
+    meta.mode() & 0o7777
+}
+
+#[cfg(not(unix))]
+fn unix_mode(_meta: &std::fs::Metadata) -> u32 {
+    0o644
+}
+
+#[cfg(unix)]
+fn set_unix_mode(path: &Path, mode: u32) -> Result<()> {
+    use std::os::unix::fs::PermissionsExt;
+    std::fs::set_permissions(path, std::fs::Permissions::from_mode(mode & 0o7777))
+        .with_context(|| format!("chmod {}", path.display()))
+}
+
+#[cfg(not(unix))]
+fn set_unix_mode(_path: &Path, _mode: u32) -> Result<()> {
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::io::Cursor;
+
+    /// A directory tree (nested) round-trips byte-for-byte, preserving content
+    /// and unix mode, through a single stream.
+    #[test]
+    fn round_trips_a_nested_tree() {
+        let src = tempfile::tempdir().unwrap();
+        std::fs::create_dir_all(src.path().join("a/b")).unwrap();
+        std::fs::write(src.path().join("top.txt"), b"hello").unwrap();
+        std::fs::write(src.path().join("a/mid.bin"), vec![7u8; 4096]).unwrap();
+        std::fs::write(src.path().join("a/b/deep"), b"deep!").unwrap();
+        #[cfg(unix)]
+        {
+            use std::os::unix::fs::PermissionsExt;
+            std::fs::set_permissions(
+                src.path().join("a/b/deep"),
+                std::fs::Permissions::from_mode(0o755),
+            )
+            .unwrap();
+        }
+
+        let mut buf = Vec::new();
+        send_dir(&mut buf, src.path()).unwrap();
+
+        let dst = tempfile::tempdir().unwrap();
+        let n = receive_into(&mut Cursor::new(buf), dst.path()).unwrap();
+        assert_eq!(n, 3, "three regular files");
+
+        assert_eq!(std::fs::read(dst.path().join("top.txt")).unwrap(), b"hello");
+        assert_eq!(
+            std::fs::read(dst.path().join("a/mid.bin")).unwrap(),
+            vec![7u8; 4096]
+        );
+        assert_eq!(
+            std::fs::read(dst.path().join("a/b/deep")).unwrap(),
+            b"deep!"
+        );
+        #[cfg(unix)]
+        {
+            use std::os::unix::fs::PermissionsExt;
+            let m = std::fs::metadata(dst.path().join("a/b/deep"))
+                .unwrap()
+                .permissions()
+                .mode();
+            assert_eq!(m & 0o777, 0o755, "mode preserved");
+        }
+    }
+
+    /// An empty file transfers (zero content bytes, no desync).
+    #[test]
+    fn empty_file_round_trips() {
+        let src = tempfile::tempdir().unwrap();
+        std::fs::write(src.path().join("empty"), b"").unwrap();
+        std::fs::write(src.path().join("after"), b"x").unwrap();
+        let mut buf = Vec::new();
+        send_dir(&mut buf, src.path()).unwrap();
+        let dst = tempfile::tempdir().unwrap();
+        receive_into(&mut Cursor::new(buf), dst.path()).unwrap();
+        assert_eq!(std::fs::read(dst.path().join("empty")).unwrap(), b"");
+        assert_eq!(std::fs::read(dst.path().join("after")).unwrap(), b"x");
+    }
+
+    /// Adversarial: a `..` traversal in a received path is refused — the file is
+    /// NOT written outside the destination root.
+    #[test]
+    fn parent_dir_traversal_is_refused() {
+        let frame = Frame::File {
+            rel_path: "../escape.txt".into(),
+            mode: 0o644,
+            len: 5,
+        };
+        let mut stream = Vec::new();
+        write_frame(&mut stream, &frame).unwrap();
+        stream.extend_from_slice(b"PWNED");
+        // no End needed — it fails before that
+
+        let dst = tempfile::tempdir().unwrap();
+        let err = receive_into(&mut Cursor::new(stream), dst.path()).unwrap_err();
+        assert!(
+            err.to_string().contains("unsafe path component"),
+            "got: {err}"
+        );
+        // The escape target must not exist.
+        assert!(!dst.path().parent().unwrap().join("escape.txt").exists());
+    }
+
+    /// Adversarial: an absolute path is refused (it would escape via the root).
+    #[test]
+    fn absolute_path_is_refused() {
+        let frame = Frame::File {
+            rel_path: "/etc/passwd".into(),
+            mode: 0o644,
+            len: 1,
+        };
+        let mut stream = Vec::new();
+        write_frame(&mut stream, &frame).unwrap();
+        stream.extend_from_slice(b"x");
+        let dst = tempfile::tempdir().unwrap();
+        let err = receive_into(&mut Cursor::new(stream), dst.path()).unwrap_err();
+        assert!(
+            err.to_string().contains("unsafe path component"),
+            "got: {err}"
+        );
+    }
+
+    /// Adversarial: a `..` buried mid-path (after a normal segment) is refused.
+    #[test]
+    fn embedded_parent_dir_is_refused() {
+        let frame = Frame::File {
+            rel_path: "a/../../b".into(),
+            mode: 0o644,
+            len: 0,
+        };
+        let mut stream = Vec::new();
+        write_frame(&mut stream, &frame).unwrap();
+        let dst = tempfile::tempdir().unwrap();
+        let err = receive_into(&mut Cursor::new(stream), dst.path()).unwrap_err();
+        assert!(err.to_string().contains("unsafe path component"));
+    }
+
+    /// An over-cap file length in the header is refused before any content read.
+    #[test]
+    fn oversize_file_is_refused() {
+        let frame = Frame::File {
+            rel_path: "huge".into(),
+            mode: 0o644,
+            len: MAX_FILE_BYTES + 1,
+        };
+        let mut stream = Vec::new();
+        write_frame(&mut stream, &frame).unwrap();
+        let dst = tempfile::tempdir().unwrap();
+        let err = receive_into(&mut Cursor::new(stream), dst.path()).unwrap_err();
+        assert!(err.to_string().contains("exceeds"), "got: {err}");
+    }
+}

--- a/crates/mvm-guest/src/lib.rs
+++ b/crates/mvm-guest/src/lib.rs
@@ -6,6 +6,8 @@
 /// `ServiceResponse`. The workload→host call half of the broker path.
 pub mod broker_client;
 pub mod builder_agent;
+/// Builder-VM file transfer over vsock (the in-house VMM has no virtio-fs).
+pub mod builder_transfer;
 /// PTY-over-vsock interactive console — the single dev-only interactive path
 /// into a guest. Gated behind `dev-shell` so the relay symbols are absent from
 /// a sealed production agent (claim 15: no interactive access to a sealed prod

--- a/crates/mvm-guest/src/lib.rs
+++ b/crates/mvm-guest/src/lib.rs
@@ -6,6 +6,8 @@
 /// `ServiceResponse`. The workload→host call half of the broker path.
 pub mod broker_client;
 pub mod builder_agent;
+/// The in-house-VMM builder's host↔guest build session over one vsock stream.
+pub mod builder_session;
 /// Builder-VM file transfer over vsock (the in-house VMM has no virtio-fs).
 pub mod builder_transfer;
 /// PTY-over-vsock interactive console — the single dev-only interactive path

--- a/crates/mvm-guest/src/lib.rs
+++ b/crates/mvm-guest/src/lib.rs
@@ -6,6 +6,9 @@
 /// `ServiceResponse`. The workload→host call half of the broker path.
 pub mod broker_client;
 pub mod builder_agent;
+/// The in-house-VMM builder's guest-side nix build (stages artifacts for the
+/// session to stream back).
+pub mod builder_build;
 /// The in-house-VMM builder's host↔guest build session over one vsock stream.
 pub mod builder_session;
 /// Builder-VM file transfer over vsock (the in-house VMM has no virtio-fs).


### PR DESCRIPTION
Decomposed from the Plan 214 spike (part of #1362). Purely additive `mvm-guest` modules — no dependency on the in-house VMM backend, builds clean on current main. This is the transport the future in-house *builder* (S6) uses instead of virtio-fs host shares: the in-house VMM has only vsock + one virtio-blk, so builder artifacts move over vsock, honoring the vsock-only invariant.

## What (additive modules)
- **`builder_transfer.rs`** — framed vsock file-tree streaming. The receiver admits only `Component::Normal` path segments (no `..`, no absolute, no escape) with a `starts_with` backstop + size caps — the untrusted-guest `/out` boundary, reusing the OCI-unpacker no-escape discipline. Adversarial tests: absolute/parent-traversal/embedded-`..`/oversize all refused.
- **`builder_session.rs`** — `drive_build` (host) / `serve_build` (guest) over one vsock stream: send `/work` + `/mvm-bins` → `BuildRequest` → log stream → `BuildOutcome` → artifacts on success. Generalizes the transfer framing to `write_msg`/`read_msg`.
- **`builder_build.rs`** — the guest-side nix-build core (validated flake ref/attr, staged artifacts) the session's `serve_build` closure runs.

## Tests
`cargo nextest run -p mvm-guest builder_` → 25/25 pass (incl. the 6 adversarial transfer tests). `fmt --all --check` + `clippy -p mvm-guest -D warnings` clean on current main.

Part of decomposing #1362 into reviewable pieces.