### PR TITLE
Plan 214 (C1): HVF vsock egress gateway — claim-10 default-deny, live

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -110,6 +110,9 @@ jobs:
       - name: Trust-gradient ledger
         run: cargo run -p xtask -- check-trust-gradient
 
+      - name: vsock-only egress (no guest NIC on the vmm/HVF path, ADR-100)
+        run: cargo run -p xtask -- check-vsock-only-egress
+
       - name: host-binaries manifest parity
         run: cargo run -p xtask -- check-mvm-host-binaries-sync
 

--- a/crates/mvm-backend/examples/hvf-backend-egress.rs
+++ b/crates/mvm-backend/examples/hvf-backend-egress.rs
@@ -1,0 +1,90 @@
+//! Prove the end-to-end policy-driven vsock egress through the HVF backend +
+//! supervisor (ADR-100): a VM started with an allow-list `NetworkPolicy` reaches
+//! the admitted destination over vsock; the supervisor resolves the host pin,
+//! projects the gate, and proxies. macOS / Apple-silicon.
+//!
+//! Uses this host's LAN IP (RFC1918 — not mandatory-deny) with a local echo
+//! server, so the test is deterministic and offline.
+//!
+//! ```sh
+//! MVM_HVF_SUPERVISOR_PATH=target/debug/mvm-hvf-supervisor \
+//!   MVM_HVF_KERNEL=/tmp/mvm-hvf-kernel/Image-builder \
+//!   MVM_HVF_INITRD=/tmp/hvf-init-echo/initramfs.cpio \
+//!   MVM_HVF_EGRESS_HOST=192.168.4.23 MVM_HVF_EGRESS_PORT=19099 \
+//!   ./target/debug/examples/hvf-backend-egress
+//! ```
+
+fn main() {
+    #[cfg(all(target_os = "macos", target_arch = "aarch64"))]
+    {
+        use mvm_backend::hvf_backend::HvfBackend;
+        use mvm_core::policy::network_policy::{HostPort, NetworkPolicy};
+        use mvm_core::vm_backend::{VmBackend, VmStartConfig, VmStatus};
+        use std::io::{Read, Write};
+        use std::net::TcpListener;
+        use std::time::Duration;
+
+        // Bound the run so the demo always terminates (this echo guest doesn't
+        // report a workload-exit), then observe via status/logs.
+        // SAFETY: single-threaded test setup.
+        unsafe { std::env::set_var("MVM_HVF_TIMEOUT", "8") };
+
+        let host = std::env::var("MVM_HVF_EGRESS_HOST").unwrap_or_else(|_| "192.168.4.23".into());
+        let port: u16 = std::env::var("MVM_HVF_EGRESS_PORT")
+            .ok()
+            .and_then(|s| s.parse().ok())
+            .unwrap_or(19099);
+
+        // One-shot local echo server at the admitted destination.
+        let listener = TcpListener::bind((host.as_str(), port)).expect("bind echo server");
+        let echo = std::thread::spawn(move || {
+            if let Ok((mut c, _)) = listener.accept() {
+                let mut buf = [0u8; 64];
+                if let Ok(n) = c.read(&mut buf) {
+                    let _ = c.write_all(&buf[..n]);
+                }
+            }
+        });
+
+        let backend = HvfBackend;
+        let cfg = VmStartConfig {
+            name: "hvf-egress-policy-demo".to_string(),
+            kernel_path: Some(
+                std::env::var("MVM_HVF_KERNEL")
+                    .unwrap_or_else(|_| "/tmp/mvm-hvf-kernel/Image".into()),
+            ),
+            initrd_path: std::env::var("MVM_HVF_INITRD").ok(),
+            // Policy-driven: admit exactly the echo destination over vsock.
+            network_policy: NetworkPolicy::allow_list(vec![HostPort {
+                host: host.clone(),
+                port,
+            }]),
+            ..Default::default()
+        };
+
+        let id = backend.start(&cfg).expect("start");
+        // Poll until the (bounded) supervisor stops, then read the captured console.
+        for _ in 0..150 {
+            if backend.status(&id).unwrap() == VmStatus::Stopped {
+                break;
+            }
+            std::thread::sleep(Duration::from_millis(100));
+        }
+        let _ = echo.join();
+        let logs = backend.logs(&id, 0, false).unwrap_or_default();
+        let ok = logs.contains("egress reply over vsock: ping");
+        println!("policy: allow-list [{host}:{port}] | egress reply received: {ok}");
+        if ok {
+            println!(
+                "PROOF: a VM started with an allow-list NetworkPolicy reached {host}:{port} over \
+                 vsock — the supervisor resolved the pin, projected the claim-10 gate, and proxied \
+                 the bytes (no guest NIC)."
+            );
+        } else {
+            eprintln!("no proxied reply; console:\n{logs}");
+            std::process::exit(1);
+        }
+    }
+    #[cfg(not(all(target_os = "macos", target_arch = "aarch64")))]
+    println!("hvf-backend-egress: only on macOS / Apple silicon");
+}

--- a/crates/mvm-backend/examples/hvf-kernel-boot.rs
+++ b/crates/mvm-backend/examples/hvf-kernel-boot.rs
@@ -71,6 +71,15 @@ fn main() {
                     "diag: psci_fns={:#x?} other_ecs={:#x?}",
                     r.psci_fns, r.other_ecs
                 );
+                if !r.egress_denied.is_empty() {
+                    println!(
+                        "egress DENIED (claim-10 default-deny over vsock): {:?}",
+                        r.egress_denied
+                    );
+                }
+                if let Some(code) = r.workload_exit_code {
+                    println!("workload exited: code={code}");
+                }
                 if !r.vsock_received.is_empty() {
                     println!(
                         "vsock host received: {:?}",

--- a/crates/mvm-backend/examples/hvf-kernel-boot.rs
+++ b/crates/mvm-backend/examples/hvf-kernel-boot.rs
@@ -77,6 +77,12 @@ fn main() {
                         r.egress_denied
                     );
                 }
+                if !r.egress_allowed.is_empty() {
+                    println!(
+                        "egress ALLOWED (policy-admitted over vsock): {:?}",
+                        r.egress_allowed
+                    );
+                }
                 if let Some(code) = r.workload_exit_code {
                     println!("workload exited: code={code}");
                 }

--- a/crates/mvm-backend/src/hvf/kernel_boot.rs
+++ b/crates/mvm-backend/src/hvf/kernel_boot.rs
@@ -334,26 +334,36 @@ unsafe fn run(
             return Err(e);
         }
 
-        // Watchdog: a booting kernel never exits on its own, so force the vCPU out
-        // after `timeout`, or as soon as `stop` is set (graceful stop), via the
-        // seam's cross-thread cancel.
+        // Watchdog + heartbeat: a booting kernel never exits on its own, so force
+        // the vCPU out after `timeout` or as soon as `stop` is set (graceful stop).
+        // Between those, a periodic force-exit acts as a heartbeat: it breaks the
+        // guest out of WFI so the run loop can poll host-side async work (drain an
+        // egress socket into a guest blocked in `recv` — ADR-100). The run loop
+        // treats a forced exit as a stop only when `stop` is set, so a heartbeat
+        // wake just polls and continues. On timeout we set `stop` first so the run
+        // loop ends.
         let done = Arc::new(AtomicBool::new(false));
         let done_w = done.clone();
         let handle = vcpu.exit_token();
         let watchdog = std::thread::spawn(move || {
-            let step = Duration::from_millis(50);
+            let step = Duration::from_millis(5);
             let mut waited = Duration::ZERO;
-            while waited < timeout {
+            loop {
+                std::thread::sleep(step);
                 if done_w.load(Ordering::Relaxed) {
-                    return;
+                    return; // run already ended; don't poke a finishing vCPU
                 }
                 if stop.load(Ordering::Relaxed) {
-                    break; // requested stop → force-exit below
+                    break; // requested stop / workload-exit → final force-exit below
                 }
-                std::thread::sleep(step);
                 waited += step;
+                if waited >= timeout {
+                    stop.store(true, Ordering::Relaxed); // timeout → end the run
+                    break;
+                }
+                HvfHandle::force_exit(&[handle]); // heartbeat: wake the run loop
             }
-            HvfHandle::force_exit(&[handle]);
+            HvfHandle::force_exit(&[handle]); // final wake → loop sees stop, returns
         });
 
         let mut uart = Pl011::new(UART_BASE);
@@ -402,32 +412,41 @@ unsafe fn run(
                     Err(HvfError::GicCreate(0))
                 }
             };
-            run::run(&vcpu, set_irq, &mut devices, |vc: &HvfVcpu, esr, _phys| {
-                if esr_ec(esr) == EC_HVC_AARCH64 {
-                    hvc_calls += 1;
-                    let fn_id = vc.get_core(CoreReg::X(0))?;
-                    if psci_fns.len() < 16 && !psci_fns.contains(&fn_id) {
-                        psci_fns.push(fn_id);
+            run::run(
+                &vcpu,
+                set_irq,
+                &mut devices,
+                |vc: &HvfVcpu, esr, _phys| {
+                    if esr_ec(esr) == EC_HVC_AARCH64 {
+                        hvc_calls += 1;
+                        let fn_id = vc.get_core(CoreReg::X(0))?;
+                        if psci_fns.len() < 16 && !psci_fns.contains(&fn_id) {
+                            psci_fns.push(fn_id);
+                        }
+                        match fn_id {
+                            PSCI_SYSTEM_OFF | PSCI_SYSTEM_RESET => return Ok(RunControl::Stop),
+                            PSCI_VERSION_FN => vc.set_core(CoreReg::X(0), 0x1_0000)?, // PSCI v1.0
+                            _ => vc.set_core(CoreReg::X(0), PSCI_NOT_SUPPORTED)?,
+                        }
+                        // HVC is completed: HVF already advanced PC. Do NOT advance.
+                        Ok(RunControl::Continue)
+                    } else {
+                        let ec = esr_ec(esr);
+                        other_exceptions += 1;
+                        if other_ecs.len() < 16 && !other_ecs.contains(&ec) {
+                            other_ecs.push(ec);
+                        }
+                        // Advance past the faulting instruction and keep going.
+                        let pc = vc.get_core(CoreReg::Pc)?;
+                        vc.set_core(CoreReg::Pc, pc + 4)?;
+                        Ok(RunControl::Continue)
                     }
-                    match fn_id {
-                        PSCI_SYSTEM_OFF | PSCI_SYSTEM_RESET => return Ok(RunControl::Stop),
-                        PSCI_VERSION_FN => vc.set_core(CoreReg::X(0), 0x1_0000)?, // PSCI v1.0
-                        _ => vc.set_core(CoreReg::X(0), PSCI_NOT_SUPPORTED)?,
-                    }
-                    // HVC is completed: HVF already advanced PC. Do NOT advance.
-                    Ok(RunControl::Continue)
-                } else {
-                    let ec = esr_ec(esr);
-                    other_exceptions += 1;
-                    if other_ecs.len() < 16 && !other_ecs.contains(&ec) {
-                        other_ecs.push(ec);
-                    }
-                    // Advance past the faulting instruction and keep going.
-                    let pc = vc.get_core(CoreReg::Pc)?;
-                    vc.set_core(CoreReg::Pc, pc + 4)?;
-                    Ok(RunControl::Continue)
-                }
-            })?
+                },
+                // A forced exit is a real stop only when `stop` is set (timeout or
+                // graceful); otherwise it's a heartbeat wake so the run loop can drain
+                // egress sockets into a guest blocked in WFI (ADR-100 async proxy).
+                move || stop.load(Ordering::Relaxed),
+            )?
         };
 
         done.store(true, Ordering::Relaxed);

--- a/crates/mvm-backend/src/hvf/kernel_boot.rs
+++ b/crates/mvm-backend/src/hvf/kernel_boot.rs
@@ -80,6 +80,8 @@ pub struct KernelBootResult {
     /// port (the transient run-to-exit signal). `None` for a run that ended by
     /// timeout/stop without a workload-exit report.
     pub workload_exit_code: Option<i32>,
+    /// Egress targets the vsock gateway refused (claim-10 default-deny, ADR-100).
+    pub egress_denied: Vec<String>,
 }
 
 /// Boot `image` (an arm64 `Image`) under HVF, optionally with an `initramfs`
@@ -301,9 +303,11 @@ unsafe fn run(
         let mut vsock_dev =
             vsock.then(|| VirtioVsock::new(VSOCK_MMIO_BASE, VSOCK_IRQ, ram, RAM_BASE, RAM_SIZE));
         // Transient run-to-exit: a guest write of the exit code to the workload
-        // exit port stops the run (and is captured below).
+        // exit port stops the run (and is captured below). Egress over vsock is
+        // claim-10 default-deny until the plan's policy is threaded in (ADR-100).
         if let Some(v) = vsock_dev.as_mut() {
             v.capture_workload_exit(stop);
+            v.set_egress_gate(crate::vmm::egress_gate::EgressGate::default_deny());
         }
 
         // Diagnostics gathered by the exception hook (HVC/PSCI + other traps).
@@ -381,6 +385,7 @@ unsafe fn run(
         if let Some(vs) = &vsock_dev {
             r.vsock_received = vs.received.clone();
             r.workload_exit_code = vs.workload_exit_code;
+            r.egress_denied = vs.egress_denied.clone();
         }
         Ok(r)
     }

--- a/crates/mvm-backend/src/hvf/kernel_boot.rs
+++ b/crates/mvm-backend/src/hvf/kernel_boot.rs
@@ -17,7 +17,7 @@
 
 use std::alloc::{Layout, alloc_zeroed, dealloc};
 use std::sync::Arc;
-use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::atomic::{AtomicBool, AtomicUsize, Ordering};
 use std::time::Duration;
 
 use super::HvfError;
@@ -344,6 +344,11 @@ unsafe fn run(
         // loop ends.
         let done = Arc::new(AtomicBool::new(false));
         let done_w = done.clone();
+        // Open-egress-connection count, shared with the vsock device. The heartbeat
+        // only fires while this is non-zero — a guest with no open egress socket has
+        // no host push to wait for, so the host can idle instead of waking 200×/s.
+        let egress_active = Arc::new(AtomicUsize::new(0));
+        let egress_active_w = egress_active.clone();
         let handle = vcpu.exit_token();
         let watchdog = std::thread::spawn(move || {
             let step = Duration::from_millis(5);
@@ -361,7 +366,10 @@ unsafe fn run(
                     stop.store(true, Ordering::Relaxed); // timeout → end the run
                     break;
                 }
-                HvfHandle::force_exit(&[handle]); // heartbeat: wake the run loop
+                // Heartbeat only when there's host→guest egress to deliver.
+                if egress_active_w.load(Ordering::Relaxed) > 0 {
+                    HvfHandle::force_exit(&[handle]); // wake the run loop to drain
+                }
             }
             HvfHandle::force_exit(&[handle]); // final wake → loop sees stop, returns
         });
@@ -385,6 +393,7 @@ unsafe fn run(
         if let Some(v) = vsock_dev.as_mut() {
             v.capture_workload_exit(stop);
             v.set_egress_gate(egress);
+            v.set_egress_activity(egress_active.clone());
         }
 
         // Diagnostics gathered by the exception hook (HVC/PSCI + other traps).

--- a/crates/mvm-backend/src/hvf/kernel_boot.rs
+++ b/crates/mvm-backend/src/hvf/kernel_boot.rs
@@ -82,6 +82,8 @@ pub struct KernelBootResult {
     pub workload_exit_code: Option<i32>,
     /// Egress targets the vsock gateway refused (claim-10 default-deny, ADR-100).
     pub egress_denied: Vec<String>,
+    /// Egress targets the vsock gateway admitted + connected (ADR-100).
+    pub egress_allowed: Vec<String>,
 }
 
 /// Boot `image` (an arm64 `Image`) under HVF, optionally with an `initramfs`
@@ -203,6 +205,36 @@ fn boot_kernel_impl(
     result
 }
 
+/// Build the egress gateway policy. Until the admitted plan's network policy is
+/// threaded through (the productionized path), a dev hook
+/// `MVM_HVF_EGRESS_ALLOW=<ip>:<port>` admits one TCP destination; otherwise the
+/// gate is claim-10 default-deny (ADR-100).
+fn egress_gate_from_env() -> crate::vmm::egress_gate::EgressGate {
+    use crate::vmm::egress_gate::EgressGate;
+    use mvm_core::policy::projection::{CanonicalEgress, CanonicalRule, Proto};
+
+    let Ok(spec) = std::env::var("MVM_HVF_EGRESS_ALLOW") else {
+        return EgressGate::default_deny();
+    };
+    match spec.parse::<std::net::SocketAddr>() {
+        Ok(addr) => {
+            let cidr = if addr.is_ipv4() {
+                format!("{}/32", addr.ip())
+            } else {
+                format!("{}/128", addr.ip())
+            };
+            let rule = CanonicalRule {
+                proto: Proto::Tcp,
+                net: cidr.parse().expect("host cidr"),
+                port_lo: addr.port(),
+                port_hi: addr.port(),
+            };
+            EgressGate::new(CanonicalEgress::Rules(vec![rule]))
+        }
+        Err(_) => EgressGate::default_deny(),
+    }
+}
+
 /// # Safety
 /// Between `hv_vm_create`/`hv_vm_destroy`; `ram` holds RAM_SIZE bytes with the
 /// kernel + DTB loaded.
@@ -307,7 +339,7 @@ unsafe fn run(
         // claim-10 default-deny until the plan's policy is threaded in (ADR-100).
         if let Some(v) = vsock_dev.as_mut() {
             v.capture_workload_exit(stop);
-            v.set_egress_gate(crate::vmm::egress_gate::EgressGate::default_deny());
+            v.set_egress_gate(egress_gate_from_env());
         }
 
         // Diagnostics gathered by the exception hook (HVC/PSCI + other traps).
@@ -386,6 +418,7 @@ unsafe fn run(
             r.vsock_received = vs.received.clone();
             r.workload_exit_code = vs.workload_exit_code;
             r.egress_denied = vs.egress_denied.clone();
+            r.egress_allowed = vs.egress_allowed.clone();
         }
         Ok(r)
     }

--- a/crates/mvm-backend/src/hvf/kernel_boot.rs
+++ b/crates/mvm-backend/src/hvf/kernel_boot.rs
@@ -96,13 +96,22 @@ pub fn boot_kernel(
     timeout: Duration,
 ) -> Result<KernelBootResult, HvfError> {
     static NEVER_STOP: AtomicBool = AtomicBool::new(false);
-    boot_kernel_impl(image, initramfs, disk, vsock, timeout, &NEVER_STOP)
+    boot_kernel_impl(
+        image,
+        initramfs,
+        disk,
+        vsock,
+        timeout,
+        &NEVER_STOP,
+        egress_gate_from_env(),
+    )
 }
 
-/// Like [`boot_kernel`], but also stops as soon as `stop` is set — a
-/// persistent-until-stop VM. The supervisor sets `stop` from a SIGTERM handler so
-/// `HvfBackend::stop` ends the guest cleanly (console flushed) instead of a
-/// timeout. `timeout` still caps the run as a backstop.
+/// Like [`boot_kernel`], but stops as soon as `stop` is set — a
+/// persistent-until-stop VM — and drives egress through the caller-supplied
+/// `egress` gateway (the supervisor builds it from the admitted plan's network
+/// policy; ADR-100). The supervisor sets `stop` from a SIGTERM handler so
+/// `HvfBackend::stop` ends the guest cleanly. `timeout` still caps the run.
 pub fn boot_kernel_until(
     image: &[u8],
     initramfs: Option<&[u8]>,
@@ -110,8 +119,9 @@ pub fn boot_kernel_until(
     vsock: bool,
     timeout: Duration,
     stop: &'static AtomicBool,
+    egress: crate::vmm::egress_gate::EgressGate,
 ) -> Result<KernelBootResult, HvfError> {
-    boot_kernel_impl(image, initramfs, disk, vsock, timeout, stop)
+    boot_kernel_impl(image, initramfs, disk, vsock, timeout, stop, egress)
 }
 
 fn boot_kernel_impl(
@@ -121,6 +131,7 @@ fn boot_kernel_impl(
     vsock: bool,
     timeout: Duration,
     stop: &'static AtomicBool,
+    egress: crate::vmm::egress_gate::EgressGate,
 ) -> Result<KernelBootResult, HvfError> {
     // Validate it's an arm64 Image; we load at the fixed boot-protocol offset.
     let _hdr = kernel_image::parse(image).map_err(|_| HvfError::BadKernel)?;
@@ -196,7 +207,18 @@ fn boot_kernel_impl(
             dealloc(ram, layout);
             return Err(HvfError::VmCreate(rc));
         }
-        let r = run(ram, entry, dtb_addr, disk, vsock, timeout, stop);
+        let r = run(
+            ram,
+            entry,
+            dtb_addr,
+            RunInputs {
+                disk,
+                vsock,
+                timeout,
+                egress,
+            },
+            stop,
+        );
         hv_vm_destroy();
         r
     };
@@ -238,15 +260,28 @@ fn egress_gate_from_env() -> crate::vmm::egress_gate::EgressGate {
 /// # Safety
 /// Between `hv_vm_create`/`hv_vm_destroy`; `ram` holds RAM_SIZE bytes with the
 /// kernel + DTB loaded.
+/// Device + run inputs for [`run`], bundled to keep its argument count sane.
+struct RunInputs<'a> {
+    disk: Option<&'a [u8]>,
+    vsock: bool,
+    timeout: Duration,
+    /// Host egress gateway policy (ADR-100).
+    egress: crate::vmm::egress_gate::EgressGate,
+}
+
 unsafe fn run(
     ram: *mut u8,
     entry: u64,
     dtb_addr: u64,
-    disk: Option<&[u8]>,
-    vsock: bool,
-    timeout: Duration,
+    inputs: RunInputs,
     stop: &'static AtomicBool,
 ) -> Result<KernelBootResult, HvfError> {
+    let RunInputs {
+        disk,
+        vsock,
+        timeout,
+        egress,
+    } = inputs;
     unsafe {
         // In-kernel GICv3 — created after the VM, before any vCPU. Base
         // addresses must match the DTB's intc node, or the kernel's IRQ/timer
@@ -339,7 +374,7 @@ unsafe fn run(
         // claim-10 default-deny until the plan's policy is threaded in (ADR-100).
         if let Some(v) = vsock_dev.as_mut() {
             v.capture_workload_exit(stop);
-            v.set_egress_gate(egress_gate_from_env());
+            v.set_egress_gate(egress);
         }
 
         // Diagnostics gathered by the exception hook (HVC/PSCI + other traps).

--- a/crates/mvm-backend/src/hvf_backend.rs
+++ b/crates/mvm-backend/src/hvf_backend.rs
@@ -137,6 +137,7 @@ impl VmBackend for HvfBackend {
             console_log: console_log.clone(),
             pid_file: pid_file.clone(),
             workload_exit,
+            network_policy: config.network_policy.clone(),
             timeout_secs,
         };
         let json = serde_json::to_string(&cfg)

--- a/crates/mvm-backend/src/kvm/vm.rs
+++ b/crates/mvm-backend/src/kvm/vm.rs
@@ -118,6 +118,8 @@ impl KvmVm {
                 &mut devices,
                 // x86 KVM decodes every exit; the exception hook is never reached.
                 |_: &KvmVcpu, _, _| Ok(RunControl::Stop),
+                // No async host I/O on this path yet → a forced exit always stops.
+                || true,
             )
         };
         done.store(true, Ordering::Relaxed);

--- a/crates/mvm-backend/src/vmm/egress_gate.rs
+++ b/crates/mvm-backend/src/vmm/egress_gate.rs
@@ -47,6 +47,24 @@ impl EgressGate {
         Self { egress }
     }
 
+    /// Build a gate from a VM's resolved [`NetworkPolicy`] via the shared claim-10
+    /// projection. **Fails closed:** any projection error (e.g. a host-allowlist
+    /// rule whose DNS pin hasn't been threaded in yet) yields default-deny rather
+    /// than a permissive gate. This is the supervisor's path to the admitted
+    /// plan's policy (ADR-100).
+    ///
+    /// [`NetworkPolicy`]: mvm_core::policy::network_policy::NetworkPolicy
+    pub fn from_network_policy(
+        policy: &mvm_core::policy::network_policy::NetworkPolicy,
+        pins: &mvm_core::policy::dns_pin::DnsPinRegistry,
+        now: &str,
+    ) -> Self {
+        match mvm_core::policy::projection::canonicalize_network_policy(policy, pins, now) {
+            Ok(canon) => Self::new(canon),
+            Err(_) => Self::default_deny(),
+        }
+    }
+
     /// Decide a TCP connect to an already-resolved address.
     pub fn decide_addr(&self, ip: IpAddr, port: u16) -> EgressVerdict {
         if self.egress.permits(&Proto::Tcp, ip, port) {
@@ -153,6 +171,41 @@ mod tests {
                 ip: "93.184.216.34".parse().unwrap(),
                 port: 80
             }
+        );
+    }
+
+    /// `from_network_policy` is the supervisor's path: deny-all ⇒ deny,
+    /// unrestricted ⇒ admit, and any projection error ⇒ fail-closed deny.
+    #[test]
+    fn from_network_policy_threads_the_real_policy_and_fails_closed() {
+        use mvm_core::policy::dns_pin::DnsPinRegistry;
+        use mvm_core::policy::network_policy::{HostPort, NetworkPolicy};
+
+        let pins = DnsPinRegistry::new();
+        let now = "2026-01-01T00:00:00Z";
+
+        let deny = EgressGate::from_network_policy(&NetworkPolicy::deny_all(), &pins, now);
+        assert_eq!(deny.decide_request("1.1.1.1:443"), EgressVerdict::Deny);
+
+        let open = EgressGate::from_network_policy(&NetworkPolicy::unrestricted(), &pins, now);
+        assert_eq!(
+            open.decide_request("93.184.216.34:80"),
+            EgressVerdict::Allow {
+                ip: "93.184.216.34".parse().unwrap(),
+                port: 80
+            }
+        );
+
+        // A host-allowlist rule with no DNS pin can't project → fail closed (deny),
+        // never a permissive gate.
+        let unpinned = NetworkPolicy::allow_list(vec![HostPort {
+            host: "example.com".into(),
+            port: 443,
+        }]);
+        let gate = EgressGate::from_network_policy(&unpinned, &pins, now);
+        assert_eq!(
+            gate.decide_request("93.184.216.34:443"),
+            EgressVerdict::Deny
         );
     }
 }

--- a/crates/mvm-backend/src/vmm/egress_gate.rs
+++ b/crates/mvm-backend/src/vmm/egress_gate.rs
@@ -208,4 +208,36 @@ mod tests {
             EgressVerdict::Deny
         );
     }
+
+    /// An IP-host allow-list with the matching pin admits exactly that
+    /// destination — the supervisor's resolved-pin path (a literal IP "resolves"
+    /// to itself).
+    #[test]
+    fn ip_allow_list_with_pin_admits_only_that_destination() {
+        use mvm_core::policy::dns_pin::{DnsPin, DnsPinRegistry};
+        use mvm_core::policy::network_policy::{HostPort, NetworkPolicy};
+
+        let now = "2026-01-01T00:00:00Z";
+        let mut pins = DnsPinRegistry::new();
+        pins.add(DnsPin::at(
+            "192.168.4.23",
+            vec!["192.168.4.23".parse().unwrap()],
+            "2025-01-01T00:00:00Z",
+            "2030-01-01T00:00:00Z",
+        ));
+        let policy = NetworkPolicy::allow_list(vec![HostPort {
+            host: "192.168.4.23".into(),
+            port: 19099,
+        }]);
+        let gate = EgressGate::from_network_policy(&policy, &pins, now);
+        assert_eq!(
+            gate.decide_request("192.168.4.23:19099"),
+            EgressVerdict::Allow {
+                ip: "192.168.4.23".parse().unwrap(),
+                port: 19099
+            }
+        );
+        assert_eq!(gate.decide_request("192.168.4.23:80"), EgressVerdict::Deny);
+        assert_eq!(gate.decide_request("8.8.8.8:19099"), EgressVerdict::Deny);
+    }
 }

--- a/crates/mvm-backend/src/vmm/egress_gate.rs
+++ b/crates/mvm-backend/src/vmm/egress_gate.rs
@@ -128,4 +128,31 @@ mod tests {
             }
         );
     }
+
+    /// The gate composes with the real `NetworkPolicy` projection — the path the
+    /// HVF supervisor will thread in (deny-all ⇒ deny, unrestricted ⇒ admit).
+    #[test]
+    fn gate_honors_a_real_network_policy_projection() {
+        use mvm_core::policy::dns_pin::DnsPinRegistry;
+        use mvm_core::policy::network_policy::NetworkPolicy;
+        use mvm_core::policy::projection::canonicalize_network_policy;
+
+        let pins = DnsPinRegistry::new();
+        let now = "2026-01-01T00:00:00Z";
+
+        let deny = canonicalize_network_policy(&NetworkPolicy::deny_all(), &pins, now).unwrap();
+        assert_eq!(
+            EgressGate::new(deny).decide_request("1.1.1.1:443"),
+            EgressVerdict::Deny
+        );
+
+        let open = canonicalize_network_policy(&NetworkPolicy::unrestricted(), &pins, now).unwrap();
+        assert_eq!(
+            EgressGate::new(open).decide_request("93.184.216.34:80"),
+            EgressVerdict::Allow {
+                ip: "93.184.216.34".parse().unwrap(),
+                port: 80
+            }
+        );
+    }
 }

--- a/crates/mvm-backend/src/vmm/egress_gate.rs
+++ b/crates/mvm-backend/src/vmm/egress_gate.rs
@@ -1,0 +1,131 @@
+//! The host vsock egress gateway's allow/deny decision (ADR-100).
+//!
+//! Under the vsock-only invariant a workload guest has no NIC: it asks the host
+//! to open an outbound connection over vsock, and this gate decides whether the
+//! signed plan's network policy permits it. The decision reuses
+//! [`CanonicalEgress`] — the *same* claim-10 function nftables / the
+//! gateway-bridge enforce — so every backend agrees on one rule set. **Default is
+//! deny:** an empty rule set permits nothing, and mandatory-deny / SSH flows are
+//! refused regardless.
+//!
+//! This module is the pure decision; the vsock device calls it before opening any
+//! host socket. The connect/proxy data path is the gateway's separate concern.
+
+use std::net::{IpAddr, SocketAddr};
+
+use mvm_core::policy::projection::{CanonicalEgress, Proto};
+
+/// Outcome of an egress request.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum EgressVerdict {
+    /// The plan permits a TCP connection to this destination.
+    Allow { ip: IpAddr, port: u16 },
+    /// Refused — policy did not admit it (claim-10 default-deny / mandatory-deny).
+    Deny,
+    /// The guest's connect request was malformed (not `ip:port`).
+    Malformed,
+}
+
+/// The host-side egress decision for one VM, wrapping its resolved
+/// [`CanonicalEgress`] grant.
+#[derive(Debug, Clone)]
+pub struct EgressGate {
+    egress: CanonicalEgress,
+}
+
+impl EgressGate {
+    /// A gate that denies everything — the posture for a VM with no admitted
+    /// network policy (claim-10 default-deny).
+    pub fn default_deny() -> Self {
+        Self {
+            egress: CanonicalEgress::Rules(Vec::new()),
+        }
+    }
+
+    /// A gate over an explicit resolved grant.
+    pub fn new(egress: CanonicalEgress) -> Self {
+        Self { egress }
+    }
+
+    /// Decide a TCP connect to an already-resolved address.
+    pub fn decide_addr(&self, ip: IpAddr, port: u16) -> EgressVerdict {
+        if self.egress.permits(&Proto::Tcp, ip, port) {
+            EgressVerdict::Allow { ip, port }
+        } else {
+            EgressVerdict::Deny
+        }
+    }
+
+    /// Decide a guest connect request of the form `"<ip>:<port>"` (a numeric
+    /// address — DNS resolution, when added, happens before this). A request that
+    /// does not parse is [`EgressVerdict::Malformed`] (fail-closed: no connection).
+    pub fn decide_request(&self, target: &str) -> EgressVerdict {
+        match target.trim().parse::<SocketAddr>() {
+            Ok(addr) => self.decide_addr(addr.ip(), addr.port()),
+            Err(_) => EgressVerdict::Malformed,
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use mvm_core::policy::projection::CanonicalRule;
+
+    fn allow_rule(cidr: &str, port: u16) -> CanonicalRule {
+        CanonicalRule {
+            proto: Proto::Tcp,
+            net: cidr.parse().unwrap(),
+            port_lo: port,
+            port_hi: port,
+        }
+    }
+
+    #[test]
+    fn default_deny_refuses_everything() {
+        let gate = EgressGate::default_deny();
+        assert_eq!(gate.decide_request("1.1.1.1:443"), EgressVerdict::Deny);
+        assert_eq!(gate.decide_request("93.184.216.34:80"), EgressVerdict::Deny);
+    }
+
+    #[test]
+    fn allow_list_permits_only_the_listed_destination() {
+        let gate = EgressGate::new(CanonicalEgress::Rules(vec![allow_rule("1.1.1.1/32", 443)]));
+        assert_eq!(
+            gate.decide_request("1.1.1.1:443"),
+            EgressVerdict::Allow {
+                ip: "1.1.1.1".parse().unwrap(),
+                port: 443
+            }
+        );
+        // Wrong port / wrong host → still denied.
+        assert_eq!(gate.decide_request("1.1.1.1:80"), EgressVerdict::Deny);
+        assert_eq!(gate.decide_request("8.8.8.8:443"), EgressVerdict::Deny);
+    }
+
+    #[test]
+    fn ssh_flow_is_refused_even_when_listed() {
+        // A grant that names port 22 must still be refused (claim-10 banned-SSH).
+        let gate = EgressGate::new(CanonicalEgress::Rules(vec![allow_rule("1.1.1.1/32", 22)]));
+        assert_eq!(gate.decide_request("1.1.1.1:22"), EgressVerdict::Deny);
+    }
+
+    #[test]
+    fn malformed_request_fails_closed() {
+        let gate = EgressGate::new(CanonicalEgress::Unrestricted);
+        assert_eq!(gate.decide_request("not-an-addr"), EgressVerdict::Malformed);
+        assert_eq!(gate.decide_request(""), EgressVerdict::Malformed);
+    }
+
+    #[test]
+    fn unrestricted_permits_a_normal_flow() {
+        let gate = EgressGate::new(CanonicalEgress::Unrestricted);
+        assert_eq!(
+            gate.decide_request("93.184.216.34:80"),
+            EgressVerdict::Allow {
+                ip: "93.184.216.34".parse().unwrap(),
+                port: 80
+            }
+        );
+    }
+}

--- a/crates/mvm-backend/src/vmm/mod.rs
+++ b/crates/mvm-backend/src/vmm/mod.rs
@@ -11,6 +11,7 @@
 //! This module compiles on every target; it is the "no VMM lock-in" seam.
 
 pub mod device;
+pub mod egress_gate;
 pub mod fdt;
 pub mod guest_mem;
 pub mod hv;

--- a/crates/mvm-backend/src/vmm/run.rs
+++ b/crates/mvm-backend/src/vmm/run.rs
@@ -26,6 +26,13 @@ pub trait RunDevice {
     fn read(&mut self, offset: u64, size: u8) -> u64;
     /// Service a guest store; return `Some(irq)` to raise that interrupt line.
     fn write(&mut self, offset: u64, value: u64, size: u8) -> Option<u32>;
+    /// Do pending host-side async work (e.g. drain a backing socket into the
+    /// guest's rx queue) and return `Some(irq)` if the guest needs an interrupt.
+    /// Called on every timer tick so host→guest delivery happens even when the
+    /// guest isn't doing MMIO. Default: nothing to do.
+    fn poll(&mut self) -> Option<u32> {
+        None
+    }
 }
 
 /// Whether the loop should keep running after a caller-handled exception.
@@ -89,21 +96,51 @@ where
 /// - `on_exception(vcpu, syndrome, phys_addr)` handles a non-MMIO exception
 ///   (arm64 PSCI/HVC); return [`RunControl::Stop`] to end the run. x86 KVM never
 ///   reaches it (every exit is decoded).
-pub fn run<C, S, X>(
+/// - `should_stop()` disambiguates a forced exit ([`VcpuExit::Canceled`]): a real
+///   stop (watchdog timeout / graceful stop) returns `true` and ends the run; a
+///   `false` means the cancel was a *heartbeat wake* to let host-side async work
+///   run (e.g. draining an egress socket into the guest's rx queue while the guest
+///   is idle in WFI), so the loop polls devices and keeps going. Backends with no
+///   async host I/O pass `|| true` (a cancel always stops).
+pub fn run<C, S, X, Q>(
     vcpu: &C,
     set_irq: S,
     devices: &mut [&mut dyn RunDevice],
     mut on_exception: X,
+    should_stop: Q,
 ) -> Result<RunOutcome, C::Error>
 where
     C: HypervisorVcpu,
     S: Fn(u32, bool) -> Result<(), C::Error>,
     X: FnMut(&C, u64, u64) -> Result<RunControl, C::Error>,
+    Q: Fn() -> bool,
 {
     loop {
         match vcpu.step()? {
-            VcpuExit::VTimer => {}
-            VcpuExit::Canceled => return Ok(RunOutcome::Canceled),
+            VcpuExit::VTimer => {
+                // Host→guest async work each timer tick (e.g. drain an egress
+                // socket into the guest's rx queue), so delivery happens even
+                // when the guest is idle in WFI rather than doing MMIO.
+                for d in devices.iter_mut() {
+                    if let Some(irq) = d.poll() {
+                        set_irq(irq, true)?;
+                    }
+                }
+            }
+            VcpuExit::Canceled => {
+                // A forced exit: either a real stop or a heartbeat wake. Poll
+                // host-side async work either way (this is how an egress reply
+                // reaches a guest blocked in WFI), then end only if a stop was
+                // actually requested.
+                for d in devices.iter_mut() {
+                    if let Some(irq) = d.poll() {
+                        set_irq(irq, true)?;
+                    }
+                }
+                if should_stop() {
+                    return Ok(RunOutcome::Canceled);
+                }
+            }
             VcpuExit::Halt => return Ok(RunOutcome::Halt),
             VcpuExit::Mmio {
                 phys_addr,
@@ -187,6 +224,11 @@ impl RunDevice for super::vsock::VirtioVsock {
     }
     fn write(&mut self, offset: u64, value: u64, _size: u8) -> Option<u32> {
         self.write(offset, value).then(|| self.irq())
+    }
+    fn poll(&mut self) -> Option<u32> {
+        // Host→guest half of the egress proxy: drain admitted sockets into the rx
+        // queue each timer tick.
+        self.drain_egress()
     }
 }
 
@@ -277,6 +319,94 @@ mod tests {
         Ok(RunControl::Stop)
     }
 
+    /// A device whose `poll()` reports an interrupt exactly once — models an
+    /// async host→guest delivery (e.g. an egress reply arriving) that the run loop
+    /// must drain on a timer tick / heartbeat wake.
+    struct PollDev {
+        irq: u32,
+        polls: u32,
+        delivered: bool,
+    }
+    impl RunDevice for PollDev {
+        fn contains(&self, _addr: u64) -> bool {
+            false
+        }
+        fn base(&self) -> u64 {
+            0
+        }
+        fn read(&mut self, _: u64, _: u8) -> u64 {
+            0
+        }
+        fn write(&mut self, _: u64, _: u64, _: u8) -> Option<u32> {
+            None
+        }
+        fn poll(&mut self) -> Option<u32> {
+            self.polls += 1;
+            if self.delivered {
+                None
+            } else {
+                self.delivered = true;
+                Some(self.irq)
+            }
+        }
+    }
+
+    /// A heartbeat wake (`Canceled` with `should_stop()==false`) polls devices,
+    /// raises any reported IRQ, and keeps running — it must NOT end the run.
+    #[test]
+    fn canceled_with_no_stop_polls_then_continues() {
+        // Two cancels (heartbeats) then the guest halts.
+        let vcpu = ScriptVcpu::new(vec![VcpuExit::Canceled, VcpuExit::Canceled, VcpuExit::Halt]);
+        let raised = RefCell::new(Vec::new());
+        let mut dev = PollDev {
+            irq: 7,
+            polls: 0,
+            delivered: false,
+        };
+        let mut devs: Vec<&mut dyn RunDevice> = vec![&mut dev];
+        let out = run(
+            &vcpu,
+            |intid, level| {
+                raised.borrow_mut().push((intid, level));
+                Ok(())
+            },
+            &mut devs,
+            no_exceptions,
+            || false, // never a real stop → cancels are heartbeat wakes
+        )
+        .unwrap();
+        assert_eq!(out, RunOutcome::Halt); // ran to the guest halt, not the cancel
+        assert_eq!(*raised.borrow(), vec![(7u32, true)]); // delivered exactly once
+        assert_eq!(dev.polls, 2); // polled on each heartbeat wake
+    }
+
+    /// A real stop (`Canceled` with `should_stop()==true`) still drains one final
+    /// poll, then ends the run as `Canceled`.
+    #[test]
+    fn canceled_with_stop_polls_then_returns() {
+        let vcpu = ScriptVcpu::new(vec![VcpuExit::Canceled]);
+        let raised = RefCell::new(Vec::new());
+        let mut dev = PollDev {
+            irq: 9,
+            polls: 0,
+            delivered: false,
+        };
+        let mut devs: Vec<&mut dyn RunDevice> = vec![&mut dev];
+        let out = run(
+            &vcpu,
+            |intid, level| {
+                raised.borrow_mut().push((intid, level));
+                Ok(())
+            },
+            &mut devs,
+            no_exceptions,
+            || true, // real stop
+        )
+        .unwrap();
+        assert_eq!(out, RunOutcome::Canceled);
+        assert_eq!(*raised.borrow(), vec![(9u32, true)]); // final drain still delivered
+    }
+
     #[test]
     fn read_is_completed_with_the_device_value() {
         let vcpu = ScriptVcpu::new(vec![
@@ -295,7 +425,7 @@ mod tests {
             writes: vec![],
         };
         let mut devs: Vec<&mut dyn RunDevice> = vec![&mut dev];
-        let out = run(&vcpu, |_, _| Ok(()), &mut devs, no_exceptions).unwrap();
+        let out = run(&vcpu, |_, _| Ok(()), &mut devs, no_exceptions, || true).unwrap();
         assert_eq!(out, RunOutcome::Halt);
         assert_eq!(*vcpu.reads.borrow(), vec![0xdead_beef]);
     }
@@ -318,7 +448,7 @@ mod tests {
             writes: vec![],
         };
         let mut devs: Vec<&mut dyn RunDevice> = vec![&mut dev];
-        run(&vcpu, |_, _| Ok(()), &mut devs, no_exceptions).unwrap();
+        run(&vcpu, |_, _| Ok(()), &mut devs, no_exceptions, || true).unwrap();
         assert_eq!(dev.writes, vec![(0x10, 0x55)]);
         assert!(
             vcpu.reads.borrow().is_empty(),
@@ -353,6 +483,7 @@ mod tests {
             },
             &mut devs,
             no_exceptions,
+            || true,
         )
         .unwrap();
         assert_eq!(*raised.borrow(), vec![(42u32, true)]);
@@ -382,7 +513,7 @@ mod tests {
             writes: vec![],
         };
         let mut devs: Vec<&mut dyn RunDevice> = vec![&mut dev];
-        run(&vcpu, |_, _| Ok(()), &mut devs, no_exceptions).unwrap();
+        run(&vcpu, |_, _| Ok(()), &mut devs, no_exceptions, || true).unwrap();
         assert_eq!(*vcpu.reads.borrow(), vec![0xab, 0]); // device value, then RAZ
     }
 
@@ -390,7 +521,7 @@ mod tests {
     fn canceled_exit_ends_the_run() {
         let vcpu = ScriptVcpu::new(vec![VcpuExit::Canceled]);
         let mut devs: Vec<&mut dyn RunDevice> = vec![];
-        let out = run(&vcpu, |_, _| Ok(()), &mut devs, no_exceptions).unwrap();
+        let out = run(&vcpu, |_, _| Ok(()), &mut devs, no_exceptions, || true).unwrap();
         assert_eq!(out, RunOutcome::Canceled);
     }
 
@@ -421,6 +552,7 @@ mod tests {
                     RunControl::Continue
                 })
             },
+            || true,
         )
         .unwrap();
         assert_eq!(out, RunOutcome::Stopped);
@@ -431,7 +563,7 @@ mod tests {
     fn vtimer_is_ignored_and_the_loop_continues() {
         let vcpu = ScriptVcpu::new(vec![VcpuExit::VTimer, VcpuExit::VTimer, VcpuExit::Halt]);
         let mut devs: Vec<&mut dyn RunDevice> = vec![];
-        let out = run(&vcpu, |_, _| Ok(()), &mut devs, no_exceptions).unwrap();
+        let out = run(&vcpu, |_, _| Ok(()), &mut devs, no_exceptions, || true).unwrap();
         assert_eq!(out, RunOutcome::Halt);
     }
 }

--- a/crates/mvm-backend/src/vmm/vsock.rs
+++ b/crates/mvm-backend/src/vmm/vsock.rs
@@ -145,6 +145,15 @@ pub struct VirtioVsock {
     /// Set when the workload-exit code arrives, so the run loop's watchdog ends a
     /// transient VM (the same flag the SIGTERM/stop path uses).
     exit_stop: Option<&'static std::sync::atomic::AtomicBool>,
+    /// Host egress gateway policy (ADR-100). When set, a guest connect request to
+    /// the egress port is decided here (claim-10 default-deny) before any host
+    /// socket is opened. `None` ⇒ egress requests are refused outright.
+    egress: Option<super::egress_gate::EgressGate>,
+    /// Egress targets the gateway refused (claim-10) — for audit/verification.
+    pub egress_denied: Vec<String>,
+    /// Egress targets the gateway admitted (the connect/proxy data path is the
+    /// next slice; today an admitted request is recorded then the stream is reset).
+    pub egress_allowed: Vec<String>,
 }
 
 impl VirtioVsock {
@@ -166,7 +175,17 @@ impl VirtioVsock {
             pending_rx: Vec::new(),
             workload_exit_code: None,
             exit_stop: None,
+            egress: None,
+            egress_denied: Vec::new(),
+            egress_allowed: Vec::new(),
         }
+    }
+
+    /// Install the host egress gateway policy (ADR-100). A guest connect request
+    /// to the egress port is then decided against `gate` (claim-10 default-deny)
+    /// before any host connection is opened.
+    pub fn set_egress_gate(&mut self, gate: super::egress_gate::EgressGate) {
+        self.egress = Some(gate);
     }
 
     /// Capture the transient workload-exit code: a guest write of a 4-byte LE i32
@@ -306,6 +325,13 @@ impl VirtioVsock {
                     if let Some(stop) = self.exit_stop {
                         stop.store(true, std::sync::atomic::Ordering::Relaxed);
                     }
+                } else if hdr.dst_port == mvm_guest::vsock::SUBSTITUTION_PORT {
+                    // Egress request (ADR-100): the payload is the connect target
+                    // "ip:port". The gateway decides per the plan's policy
+                    // (claim-10 default-deny) before any host socket is opened.
+                    self.handle_egress_request(&hdr, &payload[..n]);
+                    self.fwd_cnt = self.fwd_cnt.wrapping_add(n as u32);
+                    return;
                 } else {
                     self.received.extend_from_slice(&payload[..n]);
                 }
@@ -317,6 +343,25 @@ impl VirtioVsock {
             OP_SHUTDOWN => self.queue_reply(&hdr, OP_RST, &[]),
             _ => {}
         }
+    }
+
+    /// Decide a guest egress request (target `"ip:port"`) against the gateway
+    /// policy (claim-10 default-deny) — ADR-100. No gate ⇒ deny. The connect/proxy
+    /// data path is the next slice; for now an admitted target is recorded and the
+    /// stream is reset, and a refused one is reset (never reaching the network).
+    fn handle_egress_request(&mut self, hdr: &Hdr, payload: &[u8]) {
+        use super::egress_gate::EgressVerdict;
+        let target = String::from_utf8_lossy(payload).trim().to_string();
+        let verdict = match &self.egress {
+            Some(gate) => gate.decide_request(&target),
+            None => EgressVerdict::Deny, // fail closed when no gateway is installed
+        };
+        match verdict {
+            EgressVerdict::Allow { .. } => self.egress_allowed.push(target),
+            EgressVerdict::Deny | EgressVerdict::Malformed => self.egress_denied.push(target),
+        }
+        // Reset the stream either way until the connect/proxy data path lands.
+        self.queue_reply(hdr, OP_RST, &[]);
     }
 
     /// Queue a host→guest reply (src/dst swapped from the inbound header).

--- a/crates/mvm-backend/src/vmm/vsock.rs
+++ b/crates/mvm-backend/src/vmm/vsock.rs
@@ -151,9 +151,14 @@ pub struct VirtioVsock {
     egress: Option<super::egress_gate::EgressGate>,
     /// Egress targets the gateway refused (claim-10) — for audit/verification.
     pub egress_denied: Vec<String>,
-    /// Egress targets the gateway admitted (the connect/proxy data path is the
-    /// next slice; today an admitted request is recorded then the stream is reset).
+    /// Egress targets the gateway admitted (recorded when the host TCP connection
+    /// is established).
     pub egress_allowed: Vec<String>,
+    /// Open host TCP connections for admitted egress streams, keyed by the guest's
+    /// vsock src_port. The first frame on a stream is the connect target; later
+    /// frames are proxied to the socket (synchronous request/response — full async
+    /// streaming is the next slice).
+    egress_conns: std::collections::HashMap<u32, std::net::TcpStream>,
 }
 
 impl VirtioVsock {
@@ -178,6 +183,7 @@ impl VirtioVsock {
             egress: None,
             egress_denied: Vec::new(),
             egress_allowed: Vec::new(),
+            egress_conns: std::collections::HashMap::new(),
         }
     }
 
@@ -345,23 +351,69 @@ impl VirtioVsock {
         }
     }
 
-    /// Decide a guest egress request (target `"ip:port"`) against the gateway
-    /// policy (claim-10 default-deny) — ADR-100. No gate ⇒ deny. The connect/proxy
-    /// data path is the next slice; for now an admitted target is recorded and the
-    /// stream is reset, and a refused one is reset (never reaching the network).
+    /// Host egress gateway over vsock (ADR-100). The first frame on an egress
+    /// stream is the connect target `"ip:port"`: it is decided against the gateway
+    /// policy (claim-10 default-deny) and, if admitted, a host TCP connection is
+    /// opened. Subsequent frames are proxied to that socket and the reply is
+    /// delivered back to the guest (synchronous request/response; full async
+    /// streaming is the next slice). A refused target never reaches the network.
     fn handle_egress_request(&mut self, hdr: &Hdr, payload: &[u8]) {
+        use std::io::{Read, Write};
+
         use super::egress_gate::EgressVerdict;
+
+        // Established stream → proxy this frame to the host socket + return its reply.
+        if self.egress_conns.contains_key(&hdr.src_port) {
+            let reply = {
+                let stream = self.egress_conns.get_mut(&hdr.src_port).expect("checked");
+                let _ = stream.write_all(payload);
+                let mut buf = vec![0u8; 16 * 1024];
+                match stream.read(&mut buf) {
+                    Ok(n) if n > 0 => {
+                        buf.truncate(n);
+                        Some(buf)
+                    }
+                    _ => None,
+                }
+            };
+            if let Some(bytes) = reply {
+                self.queue_reply(hdr, OP_RW, &bytes);
+            }
+            return;
+        }
+
+        // First frame = the connect target.
         let target = String::from_utf8_lossy(payload).trim().to_string();
         let verdict = match &self.egress {
             Some(gate) => gate.decide_request(&target),
             None => EgressVerdict::Deny, // fail closed when no gateway is installed
         };
         match verdict {
-            EgressVerdict::Allow { .. } => self.egress_allowed.push(target),
-            EgressVerdict::Deny | EgressVerdict::Malformed => self.egress_denied.push(target),
+            EgressVerdict::Allow { ip, port } => {
+                match std::net::TcpStream::connect_timeout(
+                    &std::net::SocketAddr::new(ip, port),
+                    std::time::Duration::from_secs(2),
+                ) {
+                    Ok(stream) => {
+                        let _ =
+                            stream.set_read_timeout(Some(std::time::Duration::from_millis(800)));
+                        self.egress_conns.insert(hdr.src_port, stream);
+                        self.egress_allowed.push(target);
+                        // Acknowledge the established connection.
+                        self.queue_reply(hdr, OP_CREDIT_UPDATE, &[]);
+                    }
+                    Err(_) => {
+                        self.egress_denied
+                            .push(format!("{target} (connect failed)"));
+                        self.queue_reply(hdr, OP_RST, &[]);
+                    }
+                }
+            }
+            EgressVerdict::Deny | EgressVerdict::Malformed => {
+                self.egress_denied.push(target);
+                self.queue_reply(hdr, OP_RST, &[]);
+            }
         }
-        // Reset the stream either way until the connect/proxy data path lands.
-        self.queue_reply(hdr, OP_RST, &[]);
     }
 
     /// Queue a host→guest reply (src/dst swapped from the inbound header).

--- a/crates/mvm-backend/src/vmm/vsock.rs
+++ b/crates/mvm-backend/src/vmm/vsock.rs
@@ -160,6 +160,11 @@ pub struct VirtioVsock {
     /// The first frame on a stream is the connect target; later frames are written
     /// to the socket and its replies are delivered asynchronously via `drain_egress`.
     egress_conns: std::collections::HashMap<u32, (std::net::TcpStream, Hdr)>,
+    /// Count of open egress connections, published for the host run loop's
+    /// heartbeat: the loop only needs to wake an idle (WFI) guest to deliver host
+    /// pushes while at least one egress socket is open, so the heartbeat is gated
+    /// on this being non-zero (a guest with no egress lets the host idle).
+    egress_active: Option<std::sync::Arc<std::sync::atomic::AtomicUsize>>,
 }
 
 impl VirtioVsock {
@@ -185,6 +190,7 @@ impl VirtioVsock {
             egress_denied: Vec::new(),
             egress_allowed: Vec::new(),
             egress_conns: std::collections::HashMap::new(),
+            egress_active: None,
         }
     }
 
@@ -193,6 +199,12 @@ impl VirtioVsock {
     /// before any host connection is opened.
     pub fn set_egress_gate(&mut self, gate: super::egress_gate::EgressGate) {
         self.egress = Some(gate);
+    }
+
+    /// Share the open-egress-connection counter with the host run loop so its
+    /// heartbeat can be gated on there being host→guest work to deliver.
+    pub fn set_egress_activity(&mut self, counter: std::sync::Arc<std::sync::atomic::AtomicUsize>) {
+        self.egress_active = Some(counter);
     }
 
     /// Capture the transient workload-exit code: a guest write of a 4-byte LE i32
@@ -401,6 +413,9 @@ impl VirtioVsock {
                         let _ = stream.set_nonblocking(true);
                         self.egress_conns.insert(hdr.src_port, (stream, *hdr));
                         self.egress_allowed.push(target);
+                        if let Some(c) = &self.egress_active {
+                            c.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
+                        }
                         // Acknowledge the established connection.
                         self.queue_reply(hdr, OP_CREDIT_UPDATE, &[]);
                     }
@@ -443,7 +458,11 @@ impl VirtioVsock {
             }
         }
         for port in &closed {
-            self.egress_conns.remove(port);
+            if self.egress_conns.remove(port).is_some()
+                && let Some(c) = &self.egress_active
+            {
+                c.fetch_sub(1, std::sync::atomic::Ordering::Relaxed);
+            }
         }
         for (hdr, bytes) in replies {
             self.queue_reply(&hdr, OP_RW, &bytes);

--- a/crates/mvm-backend/src/vmm/vsock.rs
+++ b/crates/mvm-backend/src/vmm/vsock.rs
@@ -155,10 +155,11 @@ pub struct VirtioVsock {
     /// is established).
     pub egress_allowed: Vec<String>,
     /// Open host TCP connections for admitted egress streams, keyed by the guest's
-    /// vsock src_port. The first frame on a stream is the connect target; later
-    /// frames are proxied to the socket (synchronous request/response — full async
-    /// streaming is the next slice).
-    egress_conns: std::collections::HashMap<u32, std::net::TcpStream>,
+    /// vsock src_port. Value = the non-blocking socket + the guest packet header
+    /// (so [`Self::drain_egress`] can frame socket→guest bytes on the right stream).
+    /// The first frame on a stream is the connect target; later frames are written
+    /// to the socket and its replies are delivered asynchronously via `drain_egress`.
+    egress_conns: std::collections::HashMap<u32, (std::net::TcpStream, Hdr)>,
 }
 
 impl VirtioVsock {
@@ -354,31 +355,31 @@ impl VirtioVsock {
     /// Host egress gateway over vsock (ADR-100). The first frame on an egress
     /// stream is the connect target `"ip:port"`: it is decided against the gateway
     /// policy (claim-10 default-deny) and, if admitted, a host TCP connection is
-    /// opened. Subsequent frames are proxied to that socket and the reply is
-    /// delivered back to the guest (synchronous request/response; full async
-    /// streaming is the next slice). A refused target never reaches the network.
+    /// opened (non-blocking). Subsequent frames are written to that socket; its
+    /// replies / streamed bytes are delivered back to the guest asynchronously in
+    /// [`Self::drain_egress`]. A refused target never reaches the network.
     fn handle_egress_request(&mut self, hdr: &Hdr, payload: &[u8]) {
-        use std::io::{Read, Write};
+        use std::io::Write;
 
         use super::egress_gate::EgressVerdict;
 
-        // Established stream → proxy this frame to the host socket + return its reply.
-        if self.egress_conns.contains_key(&hdr.src_port) {
-            let reply = {
-                let stream = self.egress_conns.get_mut(&hdr.src_port).expect("checked");
-                let _ = stream.write_all(payload);
-                let mut buf = vec![0u8; 16 * 1024];
-                match stream.read(&mut buf) {
-                    Ok(n) if n > 0 => {
-                        buf.truncate(n);
-                        Some(buf)
+        // Established stream → write this frame to the host socket (replies arrive
+        // asynchronously via `drain_egress`, so streaming / server-push works).
+        if let Some((stream, _)) = self.egress_conns.get_mut(&hdr.src_port) {
+            let mut off = 0;
+            let mut spins = 0u32;
+            while off < payload.len() {
+                match stream.write(&payload[off..]) {
+                    Ok(0) => break,
+                    Ok(n) => off += n,
+                    Err(e) if e.kind() == std::io::ErrorKind::WouldBlock && spins < 10_000 => {
+                        spins += 1;
+                        std::thread::yield_now();
                     }
-                    _ => None,
+                    Err(_) => break,
                 }
-            };
-            if let Some(bytes) = reply {
-                self.queue_reply(hdr, OP_RW, &bytes);
             }
+            self.fwd_cnt = self.fwd_cnt.wrapping_add(payload.len() as u32);
             return;
         }
 
@@ -395,9 +396,10 @@ impl VirtioVsock {
                     std::time::Duration::from_secs(2),
                 ) {
                     Ok(stream) => {
-                        let _ =
-                            stream.set_read_timeout(Some(std::time::Duration::from_millis(800)));
-                        self.egress_conns.insert(hdr.src_port, stream);
+                        // Non-blocking so `drain_egress` can read replies without
+                        // stalling the run loop.
+                        let _ = stream.set_nonblocking(true);
+                        self.egress_conns.insert(hdr.src_port, (stream, *hdr));
                         self.egress_allowed.push(target);
                         // Acknowledge the established connection.
                         self.queue_reply(hdr, OP_CREDIT_UPDATE, &[]);
@@ -413,6 +415,46 @@ impl VirtioVsock {
                 self.egress_denied.push(target);
                 self.queue_reply(hdr, OP_RST, &[]);
             }
+        }
+    }
+
+    /// Drain admitted egress sockets into the guest's rx queue — the host→guest
+    /// half of the proxy, called on every timer tick (via [`RunDevice::poll`]) so
+    /// replies + streamed bytes reach the guest even when it is idle in WFI.
+    /// Returns `Some(irq)` if a reply was delivered into a posted rx buffer.
+    pub fn drain_egress(&mut self) -> Option<u32> {
+        use std::io::Read;
+
+        if self.egress_conns.is_empty() {
+            return None;
+        }
+        let mut replies: Vec<(Hdr, Vec<u8>)> = Vec::new();
+        let mut closed: Vec<u32> = Vec::new();
+        for (port, (stream, hdr)) in self.egress_conns.iter_mut() {
+            let mut buf = vec![0u8; 16 * 1024];
+            match stream.read(&mut buf) {
+                Ok(0) => closed.push(*port), // peer EOF
+                Ok(n) => {
+                    buf.truncate(n);
+                    replies.push((*hdr, buf));
+                }
+                Err(e) if e.kind() == std::io::ErrorKind::WouldBlock => {}
+                Err(_) => closed.push(*port),
+            }
+        }
+        for port in &closed {
+            self.egress_conns.remove(port);
+        }
+        for (hdr, bytes) in replies {
+            self.queue_reply(&hdr, OP_RW, &bytes);
+        }
+        // Always attempt to flush: a reply queued on an earlier tick (before the
+        // guest posted an rx buffer) must still deliver now. `flush_rx` is a cheap
+        // no-op when nothing is pending.
+        if self.flush_rx() {
+            Some(self.irq)
+        } else {
+            None
         }
     }
 

--- a/crates/mvm-build/src/hvf_supervisor.rs
+++ b/crates/mvm-build/src/hvf_supervisor.rs
@@ -37,6 +37,10 @@ pub struct HvfSupervisorConfig {
     /// when the guest reports it over the workload-exit vsock port — the transient
     /// run-to-exit result the backend's `wait` reads.
     pub workload_exit: PathBuf,
+    /// The VM's resolved network policy — the supervisor projects it into the
+    /// vsock egress gateway (claim-10, ADR-100). Omitted ⇒ deny-all (fail closed).
+    #[serde(default = "mvm_core::policy::network_policy::NetworkPolicy::deny_all")]
+    pub network_policy: mvm_core::policy::network_policy::NetworkPolicy,
     /// Run budget in seconds — a booting kernel never exits on its own, so the
     /// guest is forced out after this long. The backend sets it from the VM's
     /// requested lifetime.
@@ -57,6 +61,7 @@ mod tests {
             console_log: "/state/console.log".into(),
             pid_file: "/state/hvf.pid".into(),
             workload_exit: "/state/workload.exit".into(),
+            network_policy: mvm_core::policy::network_policy::NetworkPolicy::deny_all(),
             timeout_secs: 30,
         };
         let json = serde_json::to_string(&cfg).unwrap();

--- a/crates/mvm-vm-host/src/bin/mvm-hvf-supervisor.rs
+++ b/crates/mvm-vm-host/src/bin/mvm-hvf-supervisor.rs
@@ -171,6 +171,14 @@ fn main() -> anyhow::Result<()> {
         Duration::from_secs(cfg.timeout_secs)
     };
 
+    // Project the VM's network policy into the vsock egress gateway (claim-10,
+    // ADR-100). deny-all / unrestricted are exact; DNS-pinned host allowlists need
+    // the admitted plan's pins threaded in (follow-on) and fail closed until then.
+    let egress = mvm_backend::vmm::egress_gate::EgressGate::from_network_policy(
+        &cfg.network_policy,
+        &mvm_core::policy::dns_pin::DnsPinRegistry::new(),
+        "",
+    );
     let result = mvm_backend::hvf::boot_kernel_until(
         &image,
         initramfs.as_deref(),
@@ -178,6 +186,7 @@ fn main() -> anyhow::Result<()> {
         cfg.vsock,
         timeout,
         &STOP,
+        egress,
     );
 
     // The VM has stopped: drop the PID file and flush whatever console we

--- a/crates/mvm-vm-host/src/bin/mvm-hvf-supervisor.rs
+++ b/crates/mvm-vm-host/src/bin/mvm-hvf-supervisor.rs
@@ -117,6 +117,37 @@ extern "C" fn on_stop_signal(_: libc::c_int) {
     STOP.store(true, std::sync::atomic::Ordering::Relaxed);
 }
 
+/// Resolve a network policy's host-allowlist entries to IPs (the admission-time
+/// DNS pin) so `host:port` rules gate at L4 — mirrors mvm-hostd's gateway-bridge
+/// `resolve_bare_dns_pins`. Literal IPs need no lookup; an unresolvable host pins
+/// an empty IP set so the projection fails CLOSED (deny) rather than widening.
+#[cfg(all(target_os = "macos", target_arch = "aarch64"))]
+fn resolve_dns_pins(
+    np: &mvm_core::policy::network_policy::NetworkPolicy,
+) -> mvm_core::policy::dns_pin::DnsPinRegistry {
+    use std::net::{IpAddr, ToSocketAddrs};
+    let mut reg = mvm_core::policy::dns_pin::DnsPinRegistry::new();
+    let Some(rules) = np.resolve_rules() else {
+        return reg; // unrestricted: no L4 pin set
+    };
+    for hp in rules {
+        let ips: Vec<IpAddr> = if let Ok(ip) = hp.host.parse::<IpAddr>() {
+            vec![ip]
+        } else {
+            (hp.host.as_str(), 0u16)
+                .to_socket_addrs()
+                .map(|addrs| addrs.map(|sa| sa.ip()).collect())
+                .unwrap_or_default()
+        };
+        reg.add(mvm_core::policy::dns_pin::DnsPin::new(
+            hp.host,
+            ips,
+            chrono::Duration::hours(24),
+        ));
+    }
+    reg
+}
+
 #[cfg(all(target_os = "macos", target_arch = "aarch64"))]
 fn main() -> anyhow::Result<()> {
     use std::io::{Read, Write};
@@ -172,12 +203,15 @@ fn main() -> anyhow::Result<()> {
     };
 
     // Project the VM's network policy into the vsock egress gateway (claim-10,
-    // ADR-100). deny-all / unrestricted are exact; DNS-pinned host allowlists need
-    // the admitted plan's pins threaded in (follow-on) and fail closed until then.
+    // ADR-100): resolve any host-allowlist entries to IPs once (the admission-time
+    // DNS pin), then project. deny-all / unrestricted need no pins; a host that
+    // fails to resolve pins an empty set so the projection fails CLOSED.
+    let pins = resolve_dns_pins(&cfg.network_policy);
+    let now = chrono::Utc::now().to_rfc3339();
     let egress = mvm_backend::vmm::egress_gate::EgressGate::from_network_policy(
         &cfg.network_policy,
-        &mvm_core::policy::dns_pin::DnsPinRegistry::new(),
-        "",
+        &pins,
+        &now,
     );
     let result = mvm_backend::hvf::boot_kernel_until(
         &image,
@@ -189,19 +223,20 @@ fn main() -> anyhow::Result<()> {
         egress,
     );
 
-    // The VM has stopped: drop the PID file and flush whatever console we
-    // captured (capture-only console — written on exit, like the vz path).
-    let _ = std::fs::remove_file(&cfg.pid_file);
+    // The VM has stopped. Persist the outputs (console + workload exit code)
+    // BEFORE removing the PID file: the backend keys "stopped" on the PID file via
+    // status/wait, so dropping it first races a reader to an empty console.
     let r = result.map_err(|e| anyhow::anyhow!("hvf boot failed: {e:?}"))?;
     if let Ok(mut f) = std::fs::File::create(&cfg.console_log) {
         let _ = f.write_all(&r.console);
     }
-
-    // Transient run-to-exit: if the guest reported a workload exit code over the
-    // vsock exit port, persist it (the backend's `wait` reads this) and mirror it
-    // as our own process exit code.
+    // Transient run-to-exit: persist the workload exit code (the backend's `wait`
+    // reads this) so it is durable before "stopped" is observable.
     if let Some(code) = r.workload_exit_code {
         let _ = std::fs::write(&cfg.workload_exit, code.to_string());
+    }
+    let _ = std::fs::remove_file(&cfg.pid_file);
+    if let Some(code) = r.workload_exit_code {
         std::process::exit(code);
     }
     Ok(())

--- a/specs/adrs/100-vsock-sole-guest-world-channel.md
+++ b/specs/adrs/100-vsock-sole-guest-world-channel.md
@@ -111,6 +111,27 @@ The guest therefore has exactly one device class for talking to anything: vsock.
    so a regression that re-adds a guest NIC fails closed — the machine-checked
    form of this invariant.
 
+## Status (HVF reference, live-proven on Apple silicon)
+
+Step 1 is substantially realized on HVF:
+
+- ✅ No guest NIC; the guest's only off-guest channels are vsock (control, the
+  transient workload-exit signal, and egress).
+- ✅ Egress **deny by default** — a NIC-less guest's connect request over vsock is
+  refused unless policy admits it (`vmm::egress_gate` reuses the claim-10
+  `CanonicalEgress`).
+- ✅ Egress **allow + TCP proxy** when admitted — the host opens the socket and
+  proxies bytes; an echo round-trips guest → vsock → host TCP → guest.
+- ✅ The gate is built from the **admitted plan's `NetworkPolicy`**, with the
+  supervisor **resolving host-allowlist DNS pins** at startup; fails closed.
+- ⏳ The proxy is currently **synchronous request/response** (the common workload
+  shape). Full **async bidirectional streaming** (server-push / long-lived streams
+  delivered to an idle guest) needs the run-loop `poll`/IRQ rx-wake path debugged
+  — a first attempt surfaced a subtle virtio-mmio async-rx-wake issue and was
+  reverted rather than shipped half-working.
+
+Steps 2 (converge FC/libkrun/vz off their NICs) and 3 (the CI guard) remain.
+
 ## Alternatives considered
 
 - **Keep per-backend NICs with host-enforced default-deny (today's posture).**

--- a/specs/adrs/100-vsock-sole-guest-world-channel.md
+++ b/specs/adrs/100-vsock-sole-guest-world-channel.md
@@ -113,7 +113,7 @@ The guest therefore has exactly one device class for talking to anything: vsock.
 
 ## Status (HVF reference, live-proven on Apple silicon)
 
-Step 1 is substantially realized on HVF:
+Step 1 is realized on HVF:
 
 - ✅ No guest NIC; the guest's only off-guest channels are vsock (control, the
   transient workload-exit signal, and egress).
@@ -124,13 +124,18 @@ Step 1 is substantially realized on HVF:
   proxies bytes; an echo round-trips guest → vsock → host TCP → guest.
 - ✅ The gate is built from the **admitted plan's `NetworkPolicy`**, with the
   supervisor **resolving host-allowlist DNS pins** at startup; fails closed.
-- ⏳ The proxy is currently **synchronous request/response** (the common workload
-  shape). Full **async bidirectional streaming** (server-push / long-lived streams
-  delivered to an idle guest) needs the run-loop `poll`/IRQ rx-wake path debugged
-  — a first attempt surfaced a subtle virtio-mmio async-rx-wake issue and was
-  reverted rather than shipped half-working.
+- ✅ **Async bidirectional streaming** — replies / server-push reach a guest
+  blocked in `recv` (WFI), not just inline request/response. The run loop takes a
+  `should_stop` predicate so a forced exit (`Canceled`) polls host-side I/O before
+  ending; the HVF watchdog doubles as a ~5 ms heartbeat that `force_exit`s the
+  vCPU to break WFI, so `drain_egress` runs and the vsock rx IRQ wakes the guest.
+  (Root cause: `hv_vcpu_run` sleeps on WFI, so the loop otherwise never returns to
+  drain the socket — confirmed by tracing.)
+- ✅ **CI guard** (`xtask check-vsock-only-egress`) keeps the vmm/HVF path NIC-free.
 
-Steps 2 (converge FC/libkrun/vz off their NICs) and 3 (the CI guard) remain.
+Step 1 (HVF reference) is complete. Step 2 — converge Firecracker/libkrun/vz off
+their NICs onto this gateway, then widen the CI guard to them — remains; it is a
+larger, per-backend change to the production workload paths.
 
 ## Alternatives considered
 

--- a/xtask/src/check_vsock_only_egress.rs
+++ b/xtask/src/check_vsock_only_egress.rs
@@ -1,0 +1,90 @@
+//! `xtask check-vsock-only-egress`
+//!
+//! ADR-100: a workload guest's only off-guest channel is vsock — there is **no
+//! guest NIC**, and egress flows guest → vsock → the host gateway. This gate
+//! locks that in for the converged vsock-only path (the portable `vmm` device
+//! model + the raw-HVF backend): a regression that attaches a virtio-net device,
+//! a tap, or a userspace net gateway to that path re-introduces a guest NIC and
+//! fails closed here.
+//!
+//! Scope note: Firecracker / libkrun / vz still attach a virtio-net NIC today and
+//! are converging onto the vsock gateway separately (ADR-100 step 2) — they are
+//! deliberately **out of scope** for this gate until that lands, so it guards only
+//! the directories that are supposed to already be NIC-free.
+
+use anyhow::{Result, bail};
+use regex::Regex;
+use std::path::{Path, PathBuf};
+
+/// Directories that implement the vsock-only path and must stay NIC-free.
+const GUARDED_DIRS: &[&str] = &["crates/mvm-backend/src/vmm", "crates/mvm-backend/src/hvf"];
+
+/// Tokens that signal a guest NIC / userspace net gateway on the data path.
+/// `virtio_net`/`virtio-net`, a virtio net device id, tap attach, or the
+/// userspace gateways (passt/gvproxy) appearing here would mean a guest NIC.
+const FORBIDDEN: &[&str] = &[
+    "virtio_net",
+    "virtio-net",
+    "VIRTIO_ID_NET",
+    "add_net",
+    "tap0",
+    "passt",
+    "gvproxy",
+];
+
+pub fn run(workspace: &Path) -> Result<()> {
+    let re = Regex::new(&FORBIDDEN.join("|")).expect("static regex");
+    let mut rs_files = Vec::new();
+    for dir in GUARDED_DIRS {
+        collect_rs_files(&workspace.join(dir), &mut rs_files)?;
+    }
+
+    let mut hits = Vec::new();
+    for file in &rs_files {
+        let text = std::fs::read_to_string(file).unwrap_or_default();
+        for (n, line) in text.lines().enumerate() {
+            // Skip comments — the gate is about code, and prose may mention NICs
+            // (e.g. "no guest NIC") to explain the invariant.
+            let trimmed = line.trim_start();
+            if trimmed.starts_with("//") || trimmed.starts_with('*') {
+                continue;
+            }
+            if re.is_match(line) {
+                hits.push(format!(
+                    "{}:{}: {}",
+                    file.strip_prefix(workspace).unwrap_or(file).display(),
+                    n + 1,
+                    line.trim()
+                ));
+            }
+        }
+    }
+
+    if !hits.is_empty() {
+        bail!(
+            "check-vsock-only-egress: a guest NIC / net gateway token appears on the \
+             vsock-only path (ADR-100 — no guest NIC; egress is vsock-mediated):\n{}",
+            hits.join("\n")
+        );
+    }
+    eprintln!(
+        "check-vsock-only-egress: clean ({} files; the vmm + hvf path is NIC-free)",
+        rs_files.len()
+    );
+    Ok(())
+}
+
+fn collect_rs_files(dir: &Path, out: &mut Vec<PathBuf>) -> Result<()> {
+    if !dir.is_dir() {
+        return Ok(());
+    }
+    for entry in std::fs::read_dir(dir)?.flatten() {
+        let path = entry.path();
+        if path.is_dir() {
+            collect_rs_files(&path, out)?;
+        } else if path.extension().is_some_and(|e| e == "rs") {
+            out.push(path);
+        }
+    }
+    Ok(())
+}

--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -32,6 +32,7 @@ mod check_no_spec_refs_in_comments;
 mod check_runtime_overlay_version;
 mod check_spec_numbers;
 mod check_trust_gradient;
+mod check_vsock_only_egress;
 mod gen_stubs;
 mod perf;
 
@@ -131,6 +132,10 @@ fn main() -> Result<()> {
             let workspace = workspace_root();
             check_trust_gradient::run(&workspace)
         }
+        Some("check-vsock-only-egress") => {
+            let workspace = workspace_root();
+            check_vsock_only_egress::run(&workspace)
+        }
         Some("check-mvm-host-binaries-sync") => {
             let workspace = workspace_root();
             check_mvm_host_binaries_sync::run(&workspace)
@@ -159,7 +164,7 @@ fn main() -> Result<()> {
             gen_stubs::check(&workspace)
         }
         Some(other) => anyhow::bail!(
-            "Unknown xtask: {:?}. Available: gen-man, check-adr-coverage, check-no-display-on-secret-types, check-audit-positional, check-doc-claims, check-machine-doc-guards, check-forbidden-deps, check-core-runtime-free, check-closure-budget, check-duplicate-majors, check-binary-size, check-kernel-config-budget, check-kernel-pin-freshness, check-builder-shell-job-sites, check-guest-agent-runtime-free, check-guest-agent-in-all-images, check-guest-images-no-builder-tools, check-no-overclaim, check-spec-numbers, check-no-spec-refs-in-comments, check-claim-catalog, check-trust-gradient, check-mvm-host-binaries-sync, check-runtime-overlay-version, perf, build-dev-image, gen-stubs, check-stubs",
+            "Unknown xtask: {:?}. Available: gen-man, check-adr-coverage, check-no-display-on-secret-types, check-audit-positional, check-doc-claims, check-machine-doc-guards, check-forbidden-deps, check-core-runtime-free, check-closure-budget, check-duplicate-majors, check-binary-size, check-kernel-config-budget, check-kernel-pin-freshness, check-builder-shell-job-sites, check-guest-agent-runtime-free, check-guest-agent-in-all-images, check-guest-images-no-builder-tools, check-no-overclaim, check-spec-numbers, check-no-spec-refs-in-comments, check-claim-catalog, check-trust-gradient, check-vsock-only-egress, check-mvm-host-binaries-sync, check-runtime-overlay-version, perf, build-dev-image, gen-stubs, check-stubs",
             other
         ),
         None => {


### PR DESCRIPTION
**Stacked on PR #1373 (B) → #1372 (A).** Review/merge A, B first. 11 commits. (C is split C1/C2 to stay reviewable — this is C1: the HVF egress data path; C2 is the cross-backend convergence.)

Brings claim-10 egress up on the in-house VMM entirely over vsock — no NIC, no gateway process, no nftables:

- **`EgressGate`** (`vmm/egress_gate.rs`) — the claim-10 decision, default-deny, built from the admitted plan's `NetworkPolicy` (composes with the real policy projection; DNS pins resolved once at admission).
- **vsock egress gateway in the device** — the guest's `EGRESS_PORT` stream is the sole path off the box; the host makes the allow/deny decision and proxies the TCP flow. Default-deny enforced, live.
- **async vsock egress proxy** — delivers replies to a guest blocked in WFI; heartbeat gated on open connections so idle guests sleep.
- **`check-vsock-only-egress` CI guard** — asserts the vmm/HVF path stays NIC-free (no virtio-net/tap/passt/gvproxy token).

## Tests
`cargo nextest run -p mvm-backend` → 432/432 pass; `cargo run -p xtask -- check-vsock-only-egress` → clean (17 files NIC-free). `fmt --all --check` + `clippy -p mvm-backend -D warnings` clean. Egress allow/deny live-proven on HVF during development.

Next: **C2 (EgressProxy extraction + SOCKS5 guest client + KVM vsock-only + transparent all-TCP + DNS-over-vsock) → D (substitution)**.