### PR TITLE
Plan 214 (D): unified vsock egress+substitution gateway — claims 10/12/13 in one endpoint

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2486,6 +2486,7 @@ name = "mvm-backend"
 version = "0.16.1"
 dependencies = [
  "anyhow",
+ "base64",
  "block2",
  "colored",
  "dispatch2",
@@ -2513,6 +2514,7 @@ dependencies = [
  "tokio",
  "toml",
  "tracing",
+ "url",
  "uuid",
  "which 7.0.3",
 ]

--- a/crates/mvm-backend/Cargo.toml
+++ b/crates/mvm-backend/Cargo.toml
@@ -85,9 +85,15 @@ tempfile.workspace = true
 tokio.workspace = true
 toml.workspace = true
 tracing.workspace = true
+# `url` parses the WireRequest target host:port for the substitution bridge's
+# claim-10 gate (vetted parser rather than hand-rolled URL splitting on a
+# security path); same version mvm-hostd/mvm-oci use.
+url = "2"
 
 [dev-dependencies]
 mvm-core = { workspace = true, features = ["test-support"] }
+# `base64` builds WireRequest body fixtures in the substitution-bridge tests.
+base64.workspace = true
 
 # Apple Virtualization.framework bindings (objc2) for the providers
 # interface — folded in with the former mvm-providers crate. macOS-only;

--- a/crates/mvm-backend/src/hvf/kernel_boot.rs
+++ b/crates/mvm-backend/src/hvf/kernel_boot.rs
@@ -16,6 +16,7 @@
 //! root filesystem (initramfs / virtio-blk) is the next slice.
 
 use std::alloc::{Layout, alloc_zeroed, dealloc};
+use std::path::PathBuf;
 use std::sync::Arc;
 use std::sync::atomic::{AtomicBool, AtomicUsize, Ordering};
 use std::time::Duration;
@@ -101,6 +102,18 @@ fn default_bootargs(has_disk: bool) -> String {
     args
 }
 
+/// Host-side channels the supervisor wires into the guest's vsock device: the
+/// claim-10 egress gateway policy (ADR-100), the per-VM host→guest agent RPC
+/// socket, and the per-VM substitution-endpoint socket (ADR-101). Bundled so the
+/// boot entry stays under the argument-count lint. The two socket paths fall back
+/// to the `MVM_HVF_{AGENT,SUBSTITUTION}_SOCKET` env hooks when `None` (dev/live
+/// drivers); the productionized path threads them through the supervisor config.
+pub struct HostChannels {
+    pub egress: crate::vmm::egress_gate::EgressGate,
+    pub agent_socket: Option<PathBuf>,
+    pub substitution_socket: Option<PathBuf>,
+}
+
 /// Boot `image` (an arm64 `Image`) under HVF, optionally with an `initramfs`
 /// (cpio, gzip-or-raw), returning what it printed within `timeout`.
 pub fn boot_kernel(
@@ -118,15 +131,20 @@ pub fn boot_kernel(
         vsock,
         timeout,
         &NEVER_STOP,
-        egress_gate_from_env(),
+        HostChannels {
+            egress: egress_gate_from_env(),
+            agent_socket: None,
+            substitution_socket: None,
+        },
     )
 }
 
 /// Like [`boot_kernel`], but stops as soon as `stop` is set — a
-/// persistent-until-stop VM — and drives egress through the caller-supplied
-/// `egress` gateway (the supervisor builds it from the admitted plan's network
-/// policy). The supervisor sets `stop` from a SIGTERM handler so
-/// `HvfBackend::stop` ends the guest cleanly. `timeout` still caps the run.
+/// persistent-until-stop VM — and drives egress + the agent/substitution channels
+/// through the caller-supplied [`HostChannels`] (the supervisor builds them from
+/// the admitted plan + per-VM socket paths). The supervisor sets `stop` from a
+/// SIGTERM handler so `HvfBackend::stop` ends the guest cleanly. `timeout` still
+/// caps the run.
 pub fn boot_kernel_until(
     image: &[u8],
     initramfs: Option<&[u8]>,
@@ -134,9 +152,9 @@ pub fn boot_kernel_until(
     vsock: bool,
     timeout: Duration,
     stop: &'static AtomicBool,
-    egress: crate::vmm::egress_gate::EgressGate,
+    channels: HostChannels,
 ) -> Result<KernelBootResult, HvfError> {
-    boot_kernel_impl(image, initramfs, disk, vsock, timeout, stop, egress)
+    boot_kernel_impl(image, initramfs, disk, vsock, timeout, stop, channels)
 }
 
 fn boot_kernel_impl(
@@ -146,7 +164,7 @@ fn boot_kernel_impl(
     vsock: bool,
     timeout: Duration,
     stop: &'static AtomicBool,
-    egress: crate::vmm::egress_gate::EgressGate,
+    channels: HostChannels,
 ) -> Result<KernelBootResult, HvfError> {
     // Validate it's an arm64 Image; we load at the fixed boot-protocol offset.
     let _hdr = kernel_image::parse(image).map_err(|_| HvfError::BadKernel)?;
@@ -229,7 +247,9 @@ fn boot_kernel_impl(
                 disk,
                 vsock,
                 timeout,
-                egress,
+                egress: channels.egress,
+                agent_socket: channels.agent_socket,
+                substitution_socket: channels.substitution_socket,
             },
             stop,
         );
@@ -281,6 +301,11 @@ struct RunInputs<'a> {
     timeout: Duration,
     /// Host egress gateway policy.
     egress: crate::vmm::egress_gate::EgressGate,
+    /// Per-VM agent RPC socket (productionized off `MVM_HVF_AGENT_SOCKET`).
+    agent_socket: Option<PathBuf>,
+    /// Per-VM substitution-endpoint socket (productionized off
+    /// `MVM_HVF_SUBSTITUTION_SOCKET`; ADR-101).
+    substitution_socket: Option<PathBuf>,
 }
 
 unsafe fn run(
@@ -295,6 +320,8 @@ unsafe fn run(
         vsock,
         timeout,
         egress,
+        agent_socket,
+        substitution_socket,
     } = inputs;
     unsafe {
         // In-kernel GICv3 — created after the VM, before any vCPU. Base
@@ -368,13 +395,13 @@ unsafe fn run(
         // services agent streams even while the guest is idle in WFI — an agent VM
         // exists to answer host RPC, so the wake is warranted. (A transient
         // run-to-exit VM leaves this unset and keeps the egress-gated heartbeat.)
-        let agent_socket = std::env::var("MVM_HVF_AGENT_SOCKET").ok();
+        // Per-VM socket paths come from the supervisor config; fall back to the
+        // dev/live env hooks when the config omits them (the example drivers).
+        let agent_socket =
+            agent_socket.or_else(|| std::env::var_os("MVM_HVF_AGENT_SOCKET").map(PathBuf::from));
         let agent_bound = agent_socket.is_some();
-        // Per-VM substitution-endpoint socket (ADR-101). When wired, EGRESS_PORT
-        // carries the WireRequest substitution protocol to the endpoint (claims
-        // 10/12/13). Dev/live hook today, mirroring the agent socket; the
-        // productionized path threads it through the supervisor config.
-        let substitution_socket = std::env::var("MVM_HVF_SUBSTITUTION_SOCKET").ok();
+        let substitution_socket = substitution_socket
+            .or_else(|| std::env::var_os("MVM_HVF_SUBSTITUTION_SOCKET").map(PathBuf::from));
         let handle = vcpu.exit_token();
         let watchdog = std::thread::spawn(move || {
             let step = Duration::from_millis(5);
@@ -425,8 +452,11 @@ unsafe fn run(
             // clients (`machine invoke`) reach the guest agent over vsock.
             if let Some(path) = &agent_socket {
                 v.set_agent_activity(egress_active.clone());
-                if let Err(e) = v.set_agent_socket(std::path::Path::new(path)) {
-                    eprintln!("mvm-hvf: agent socket bind failed at {path}: {e}");
+                if let Err(e) = v.set_agent_socket(path) {
+                    eprintln!(
+                        "mvm-hvf: agent socket bind failed at {}: {e}",
+                        path.display()
+                    );
                 }
             }
             // Substitution gateway (ADR-101): route EGRESS_PORT to the per-VM
@@ -434,7 +464,7 @@ unsafe fn run(
             // WireRequest awaiting its reply keeps the run loop polling.
             if let Some(path) = &substitution_socket {
                 v.set_substitution_activity(egress_active.clone());
-                v.set_substitution_endpoint(std::path::Path::new(path));
+                v.set_substitution_endpoint(path);
             }
         }
 

--- a/crates/mvm-backend/src/hvf/kernel_boot.rs
+++ b/crates/mvm-backend/src/hvf/kernel_boot.rs
@@ -370,6 +370,11 @@ unsafe fn run(
         // run-to-exit VM leaves this unset and keeps the egress-gated heartbeat.)
         let agent_socket = std::env::var("MVM_HVF_AGENT_SOCKET").ok();
         let agent_bound = agent_socket.is_some();
+        // Per-VM substitution-endpoint socket (ADR-101). When wired, EGRESS_PORT
+        // carries the WireRequest substitution protocol to the endpoint (claims
+        // 10/12/13). Dev/live hook today, mirroring the agent socket; the
+        // productionized path threads it through the supervisor config.
+        let substitution_socket = std::env::var("MVM_HVF_SUBSTITUTION_SOCKET").ok();
         let handle = vcpu.exit_token();
         let watchdog = std::thread::spawn(move || {
             let step = Duration::from_millis(5);
@@ -423,6 +428,13 @@ unsafe fn run(
                 if let Err(e) = v.set_agent_socket(std::path::Path::new(path)) {
                     eprintln!("mvm-hvf: agent socket bind failed at {path}: {e}");
                 }
+            }
+            // Substitution gateway (ADR-101): route EGRESS_PORT to the per-VM
+            // endpoint. Shares the egress heartbeat counter so an in-flight
+            // WireRequest awaiting its reply keeps the run loop polling.
+            if let Some(path) = &substitution_socket {
+                v.set_substitution_activity(egress_active.clone());
+                v.set_substitution_endpoint(std::path::Path::new(path));
             }
         }
 

--- a/crates/mvm-backend/src/hvf/kernel_boot.rs
+++ b/crates/mvm-backend/src/hvf/kernel_boot.rs
@@ -103,8 +103,8 @@ fn default_bootargs(has_disk: bool) -> String {
 }
 
 /// Host-side channels the supervisor wires into the guest's vsock device: the
-/// claim-10 egress gateway policy (ADR-100), the per-VM host→guest agent RPC
-/// socket, and the per-VM substitution-endpoint socket (ADR-101). Bundled so the
+/// claim-10 egress gateway policy, the per-VM host→guest agent RPC
+/// socket, and the per-VM substitution-endpoint socket. Bundled so the
 /// boot entry stays under the argument-count lint. The two socket paths fall back
 /// to the `MVM_HVF_{AGENT,SUBSTITUTION}_SOCKET` env hooks when `None` (dev/live
 /// drivers); the productionized path threads them through the supervisor config.
@@ -304,7 +304,7 @@ struct RunInputs<'a> {
     /// Per-VM agent RPC socket (productionized off `MVM_HVF_AGENT_SOCKET`).
     agent_socket: Option<PathBuf>,
     /// Per-VM substitution-endpoint socket (productionized off
-    /// `MVM_HVF_SUBSTITUTION_SOCKET`; ADR-101).
+    /// `MVM_HVF_SUBSTITUTION_SOCKET`).
     substitution_socket: Option<PathBuf>,
 }
 
@@ -459,7 +459,7 @@ unsafe fn run(
                     );
                 }
             }
-            // Substitution gateway (ADR-101): route EGRESS_PORT to the per-VM
+            // Substitution gateway: route EGRESS_PORT to the per-VM
             // endpoint. Shares the egress heartbeat counter so an in-flight
             // WireRequest awaiting its reply keeps the run loop polling.
             if let Some(path) = &substitution_socket {

--- a/crates/mvm-backend/src/hvf/kernel_boot.rs
+++ b/crates/mvm-backend/src/hvf/kernel_boot.rs
@@ -446,7 +446,6 @@ unsafe fn run(
         // claim-10 default-deny until the plan's policy is threaded in.
         if let Some(v) = vsock_dev.as_mut() {
             v.capture_workload_exit(stop);
-            v.set_egress_gate(egress);
             v.set_egress_activity(egress_active.clone());
             // Host→guest agent RPC (GUEST_AGENT_PORT): expose the listener so host
             // clients (`machine invoke`) reach the guest agent over vsock.
@@ -459,13 +458,19 @@ unsafe fn run(
                     );
                 }
             }
-            // Substitution gateway: route EGRESS_PORT to the per-VM
-            // endpoint. Shares the egress heartbeat counter so an in-flight
-            // WireRequest awaiting its reply keeps the run loop polling.
+            // Substitution gateway: route EGRESS_PORT to the per-VM endpoint. The
+            // bridge makes the claim-10 decision on the first frame using the same
+            // gate the raw-egress path uses (hence a clone), then relays admitted
+            // streams to the secrets endpoint. Shares the egress heartbeat counter
+            // so an in-flight WireRequest awaiting its reply keeps the loop polling.
             if let Some(path) = &substitution_socket {
                 v.set_substitution_activity(egress_active.clone());
+                v.set_substitution_gate(egress.clone());
                 v.set_substitution_endpoint(path);
             }
+            // The raw-egress gate takes ownership last (the substitution path only
+            // needs a clone above).
+            v.set_egress_gate(egress);
         }
 
         // Diagnostics gathered by the exception hook (HVC/PSCI + other traps).

--- a/crates/mvm-backend/src/hvf/mod.rs
+++ b/crates/mvm-backend/src/hvf/mod.rs
@@ -22,4 +22,4 @@ mod vcpu;
 pub use boot_smoke::{BootProof, HvfError, MAGIC, boot_smoke, probe_available};
 pub use console_smoke::{ConsoleProof, console_smoke};
 pub use hv_impl::{HvfHandle, HvfVcpu, HvfVm};
-pub use kernel_boot::{KernelBootResult, boot_kernel, boot_kernel_until};
+pub use kernel_boot::{HostChannels, KernelBootResult, boot_kernel, boot_kernel_until};

--- a/crates/mvm-backend/src/hvf_backend.rs
+++ b/crates/mvm-backend/src/hvf_backend.rs
@@ -77,6 +77,44 @@ fn vms_root() -> PathBuf {
     PathBuf::from(mvm_data_dir()).join("vms")
 }
 
+/// Spawn the per-VM substitution endpoint when the admitted plan carries egress
+/// secrets (ADR-101), returning an armed `EndpointGuard` and the endpoint socket
+/// path to hand the supervisor; a secret-free plan (or no `plan.json`) yields a
+/// defused no-op guard and `None`. Unlike Vz — where the Swift supervisor proxies
+/// the guest vsock dial to the endpoint — the in-house VMM's substitution bridge
+/// connects the guest's `EGRESS_PORT` stream straight to this socket, so the
+/// transport is the per-VM `Uds` the endpoint binds. Mirrors
+/// `vz::spawn_vz_egress_endpoint_if_needed`.
+fn spawn_hvf_egress_endpoint_if_needed(
+    vm_name: &str,
+    state_dir: &Path,
+) -> Result<(crate::substitution_spawn::EndpointGuard, Option<PathBuf>)> {
+    use crate::substitution_spawn::{
+        EndpointGuard, EndpointTransport, SubstitutionSpawnParams, spawn_substitution_endpoint,
+    };
+    let Some((secrets, redaction, tenant)) =
+        crate::egress_shared::decode_plan_secrets_from_state(state_dir)?
+    else {
+        return Ok((EndpointGuard::defused(), None));
+    };
+    let socket = mvm_core::config::vm_substitution_endpoint_socket(vm_name);
+    spawn_substitution_endpoint(SubstitutionSpawnParams {
+        vm_name,
+        state_dir,
+        tenant: &tenant,
+        secrets: &secrets,
+        redaction: &redaction,
+        transport: EndpointTransport::Uds {
+            path: socket.clone(),
+        },
+        // The in-house VMM has no transparent :80/:443 terminator — all egress is
+        // the proxy-aware WireRequest path, so no terminator + no per-VM TLS.
+        terminator_listen: None,
+        tls_intermediate: None,
+    })?;
+    Ok((EndpointGuard::new(vm_name), Some(socket)))
+}
+
 impl VmBackend for HvfBackend {
     fn name(&self) -> &str {
         "hvf"
@@ -117,6 +155,19 @@ impl VmBackend for HvfBackend {
         let workload_exit = state_dir.join("workload.exit");
         let _ = std::fs::remove_file(&workload_exit);
 
+        // Spawn the per-VM substitution endpoint when the admitted plan carries
+        // egress secrets (ADR-101). The guard reaps it on any early return below —
+        // so a decrypted-secret process can't outlive a failed launch — and is
+        // defused once boot is confirmed (the stop path then owns teardown). A
+        // secret-free plan yields a defused no-op guard and no endpoint socket.
+        let (mut endpoint_guard, substitution_socket) =
+            spawn_hvf_egress_endpoint_if_needed(&config.name, &state_dir)?;
+        // Productionized per-VM agent RPC socket threaded through the supervisor
+        // config; the `MVM_HVF_AGENT_SOCKET` dev hook still wins for live drivers.
+        let agent_socket = std::env::var_os("MVM_HVF_AGENT_SOCKET")
+            .map(PathBuf::from)
+            .unwrap_or_else(|| state_dir.join("hvf-agent.sock"));
+
         let disk = Some(config.rootfs_path.clone())
             .filter(|p| !p.is_empty())
             .map(PathBuf::from);
@@ -139,6 +190,8 @@ impl VmBackend for HvfBackend {
             workload_exit,
             network_policy: config.network_policy.clone(),
             timeout_secs,
+            agent_socket: Some(agent_socket),
+            substitution_socket,
         };
         let json = serde_json::to_string(&cfg)
             .map_err(|e| anyhow!("serialize HvfSupervisorConfig: {e}"))?;
@@ -190,6 +243,11 @@ impl VmBackend for HvfBackend {
             std::thread::sleep(Duration::from_millis(50));
         }
 
+        // Boot confirmed: the supervisor's device is wired to the endpoint, so it
+        // must outlive this launch. Defuse the guard (its Drop becomes a no-op);
+        // the stop path now owns reaping the endpoint.
+        endpoint_guard.defuse();
+
         // Detach: dropping the `Child` does not kill the process, so the
         // supervisor outlives this CLI invocation (reaped via its PID file).
         drop(child);
@@ -212,7 +270,12 @@ impl VmBackend for HvfBackend {
     }
 
     fn stop(&self, id: &VmId) -> Result<()> {
-        let pid_path = vm_state_dir(&id.0).join(PID_FILE_NAME);
+        let state_dir = vm_state_dir(&id.0);
+        // Reap the per-VM substitution endpoint first (before the not-running
+        // check), so a crashed VM's decrypted-secret process can't outlive the
+        // guest. Idempotent + no-op when the VM spawned none (no secrets).
+        crate::substitution_spawn::reap_substitution_endpoint(&state_dir, &id.0);
+        let pid_path = state_dir.join(PID_FILE_NAME);
         if let Some(pid) = read_pid(&pid_path) {
             // SIGTERM (default action terminates — the supervisor installs no
             // handler), then SIGKILL if it lingers. The HVF VM dies with it.
@@ -361,6 +424,25 @@ mod tests {
         let id = VmId("hvf-nonexistent-test-vm".into());
         assert_eq!(HvfBackend.status(&id).unwrap(), VmStatus::Stopped);
         assert!(HvfBackend.stop(&id).is_ok());
+    }
+
+    #[test]
+    fn substitution_endpoint_not_spawned_when_no_secrets() {
+        // A state dir with no plan.json (or a secret-free plan) must not spawn the
+        // endpoint: the guard is defused (Drop no-op) and there is no socket to
+        // hand the supervisor, so EGRESS_PORT keeps the legacy egress path.
+        let tmp = tempfile::tempdir().unwrap();
+        let (guard, socket) =
+            spawn_hvf_egress_endpoint_if_needed("hvf-no-secrets-vm", tmp.path()).unwrap();
+        assert!(
+            socket.is_none(),
+            "a secret-free plan must not yield an endpoint socket"
+        );
+        assert!(
+            !tmp.path().join("substitution.pid").exists(),
+            "no endpoint process for a secret-free plan"
+        );
+        drop(guard); // defused → Drop reaps nothing
     }
 
     #[test]

--- a/crates/mvm-backend/src/hvf_backend.rs
+++ b/crates/mvm-backend/src/hvf_backend.rs
@@ -78,7 +78,7 @@ fn vms_root() -> PathBuf {
 }
 
 /// Spawn the per-VM substitution endpoint when the admitted plan carries egress
-/// secrets (ADR-101), returning an armed `EndpointGuard` and the endpoint socket
+/// secrets, returning an armed `EndpointGuard` and the endpoint socket
 /// path to hand the supervisor; a secret-free plan (or no `plan.json`) yields a
 /// defused no-op guard and `None`. Unlike Vz — where the Swift supervisor proxies
 /// the guest vsock dial to the endpoint — the in-house VMM's substitution bridge
@@ -156,7 +156,7 @@ impl VmBackend for HvfBackend {
         let _ = std::fs::remove_file(&workload_exit);
 
         // Spawn the per-VM substitution endpoint when the admitted plan carries
-        // egress secrets (ADR-101). The guard reaps it on any early return below —
+        // egress secrets. The guard reaps it on any early return below —
         // so a decrypted-secret process can't outlive a failed launch — and is
         // defused once boot is confirmed (the stop path then owns teardown). A
         // secret-free plan yields a defused no-op guard and no endpoint socket.

--- a/crates/mvm-backend/src/vmm/mod.rs
+++ b/crates/mvm-backend/src/vmm/mod.rs
@@ -19,5 +19,6 @@ pub mod guest_mem;
 pub mod hv;
 pub mod kernel_image;
 pub mod run;
+pub(crate) mod substitution_bridge;
 pub mod virtio;
 pub mod vsock;

--- a/crates/mvm-backend/src/vmm/run.rs
+++ b/crates/mvm-backend/src/vmm/run.rs
@@ -226,12 +226,13 @@ impl RunDevice for super::vsock::VirtioVsock {
         self.write(offset, value).then(|| self.irq())
     }
     fn poll(&mut self) -> Option<u32> {
-        // Host→guest work each timer tick: drain admitted egress sockets, and
-        // accept/relay host-initiated agent streams. Either may deliver an rx
-        // packet and need an interrupt.
+        // Host→guest work each timer tick: drain admitted egress sockets, relay
+        // host-initiated agent streams, and drain substitution-endpoint replies.
+        // Any may deliver an rx packet and need an interrupt.
         let egress = self.drain_egress();
         let agent = self.drain_agent();
-        egress.or(agent)
+        let subst = self.drain_substitution();
+        egress.or(agent).or(subst)
     }
 }
 

--- a/crates/mvm-backend/src/vmm/substitution_bridge.rs
+++ b/crates/mvm-backend/src/vmm/substitution_bridge.rs
@@ -1,18 +1,22 @@
 //! The host-side substitution bridge — guest egress stream ↔ per-VM endpoint UDS.
 //!
-//! On the in-house VMM, [`EGRESS_PORT`](mvm_guest::vsock::EGRESS_PORT) (5253)
-//! carries exactly one protocol — the WireRequest substitution protocol the
-//! guest's forward-proxy speaks — and exactly one enforcer: the per-VM
-//! `mvm-substitution-endpoint`, which decides claims 10/12/13. This
-//! bridge is the transport between the two: for each guest→host stream on 5253 it
-//! opens a Unix-socket connection to that endpoint and relays bytes both ways.
+//! On the in-house VMM, the egress port carries one protocol — the WireRequest
+//! substitution protocol the guest's forward-proxy speaks — and the host gateway
+//! makes the whole egress decision before any byte reaches the wire:
 //!
-//! Like [`EgressProxy`](super::egress_proxy::EgressProxy) it is **a dumb byte
-//! relay** keyed by an opaque connection id (the guest vsock `src_port`): it
-//! parses no WireRequest and enforces no policy — every decision lives in the
-//! endpoint it forwards to. The only judgement it makes is fail-closed: with no
-//! endpoint configured, or if the endpoint socket can't be reached, the stream is
-//! reset and no bytes leave the host (default-deny, claim-10).
+//! 1. **Claim-10** (this bridge): the destination host:port in the first
+//!    WireRequest frame is checked against the same [`EgressGate`] the device's
+//!    raw-egress path uses (default-deny). An unadmitted destination is refused
+//!    here, before the endpoint is even contacted — so the secrets moat never
+//!    sees traffic the network policy forbids.
+//! 2. **Claims 12/13** (the endpoint): once admitted, the stream is relayed to
+//!    the per-VM `mvm-substitution-endpoint`, which binding-checks the secret and
+//!    substitutes the real credential.
+//!
+//! The two run as a pipeline on the same stream — every request passes both. The
+//! bridge therefore peeks the first frame (it must, to decide claim-10 before
+//! relaying — relaying first would leak bytes past the gate), then becomes a plain
+//! byte relay for the rest of the connection. Keyed by the guest vsock `src_port`.
 
 use std::collections::HashMap;
 use std::io::{Read, Write};
@@ -21,17 +25,27 @@ use std::path::{Path, PathBuf};
 use std::sync::Arc;
 use std::sync::atomic::{AtomicUsize, Ordering};
 
+use mvm_core::substitution_wire::WireRequest;
+use url::Url;
+
+use super::egress_gate::{EgressGate, EgressVerdict};
+
 /// Per-drain read budget per endpoint connection.
 const READ_CHUNK: usize = 16 * 1024;
+/// Largest WireRequest frame we'll buffer to make the claim-10 decision — matches
+/// the endpoint's own frame cap. A length prefix above this fails closed.
+const MAX_FRAME_BYTES: usize = 16 * 1024 * 1024;
 
 /// What the device should signal the guest after an inbound substitution frame.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub(crate) enum SubstitutionAction {
-    /// Stream opened to the endpoint (or already open) — bytes relayed; no control
-    /// reply beyond the credit update the device already sends.
+    /// Admitted + relayed to the endpoint (or a later frame on an open stream).
     Relayed,
-    /// No endpoint reachable — reset the stream. Fail-closed: a guest with no
-    /// substitution endpoint gets no egress (default-deny).
+    /// Still buffering the first frame for the claim-10 decision — ack the bytes
+    /// and wait; no endpoint connection yet.
+    Pending,
+    /// Refused: no endpoint, a denied/malformed destination, or a connect failure.
+    /// Fail-closed — the stream is reset and nothing leaves the host.
     Refused,
 }
 
@@ -43,18 +57,29 @@ pub(crate) struct SubstitutionDrain {
     pub closed: Vec<u32>,
 }
 
-/// The substitution transport for one guest: the per-VM endpoint socket path plus
-/// the open relay connections.
+/// One guest substitution stream: buffered until the claim-10 decision, then a
+/// plain relay to the endpoint.
+struct SubstConn {
+    /// Endpoint connection — `None` until the destination is admitted.
+    upstream: Option<UnixStream>,
+    /// Bytes buffered until the first WireRequest frame is parsed for the
+    /// claim-10 decision. Emptied (flushed to the endpoint) once admitted.
+    pending: Vec<u8>,
+    /// The claim-10 decision is made and the endpoint is open → pure relay.
+    admitted: bool,
+}
+
+/// The substitution transport for one guest.
 pub(crate) struct SubstitutionBridge {
-    /// Per-VM `mvm-substitution-endpoint` Unix socket. `None` ⇒ no endpoint for
-    /// this VM, so every stream is refused (fail-closed; the workload carries no
-    /// admitted egress).
+    /// Per-VM `mvm-substitution-endpoint` socket. `None` ⇒ no endpoint, fail-closed.
     endpoint: Option<PathBuf>,
-    /// Open endpoint connections, keyed by the guest vsock `src_port` (conn id).
-    conns: HashMap<u32, UnixStream>,
-    /// Open-connection count, published for the host run loop's heartbeat (it must
-    /// keep waking an idle guest while there's an endpoint reply to deliver). Same
-    /// counter shape as the egress proxy / agent bridge.
+    /// Claim-10 gate — the same policy the device's raw-egress path enforces.
+    /// `None` ⇒ deny everything (fail closed with no policy installed).
+    gate: Option<EgressGate>,
+    /// Open streams keyed by the guest vsock `src_port`.
+    conns: HashMap<u32, SubstConn>,
+    /// Open-(admitted-)connection count, published for the run loop heartbeat so it
+    /// keeps waking an idle guest while there's an endpoint reply to deliver.
     active: Option<Arc<AtomicUsize>>,
 }
 
@@ -62,64 +87,119 @@ impl SubstitutionBridge {
     pub fn new() -> Self {
         Self {
             endpoint: None,
+            gate: None,
             conns: HashMap::new(),
             active: None,
         }
     }
 
-    /// Point the bridge at this VM's substitution-endpoint socket. Until set (or if
-    /// the path can't be reached), every stream is refused.
+    /// Point the bridge at this VM's substitution-endpoint socket.
     pub fn set_endpoint(&mut self, path: &Path) {
         self.endpoint = Some(path.to_path_buf());
     }
 
-    /// Whether a substitution endpoint is configured for this VM. The device uses
-    /// this to decide, at configuration time (not by inspecting guest bytes),
-    /// whether `EGRESS_PORT` routes here (WireRequest substitution) or to the
-    /// legacy raw-TCP egress proxy.
+    /// Install the claim-10 policy (the same gate the raw-egress path uses). Until
+    /// set, every destination is refused.
+    pub fn set_gate(&mut self, gate: EgressGate) {
+        self.gate = Some(gate);
+    }
+
+    /// Whether a substitution endpoint is configured. The device uses this to
+    /// decide, at configuration time (not by inspecting guest bytes), whether the
+    /// egress port routes here or to the legacy raw-TCP egress proxy.
     pub fn has_endpoint(&self) -> bool {
         self.endpoint.is_some()
     }
 
-    /// Share the open-connection counter with the host run loop heartbeat.
+    /// Share the open-connection counter with the run loop heartbeat.
     pub fn set_activity(&mut self, counter: Arc<AtomicUsize>) {
         self.active = Some(counter);
     }
 
-    /// True while at least one endpoint connection is open (the heartbeat gate).
+    /// True while at least one admitted stream is open (the heartbeat gate). A
+    /// still-buffering stream has no endpoint reply to drain, so it doesn't count.
     pub fn has_active(&self) -> bool {
-        !self.conns.is_empty()
+        self.conns.values().any(|c| c.admitted)
     }
 
-    /// Relay one inbound substitution frame on stream `conn_id` to the endpoint.
-    /// The first frame opens the endpoint connection; later frames are written to
-    /// it. The bridge interprets none of the bytes — the WireRequest framing and
-    /// every claim-10/12/13 decision live in the endpoint. Replies stream back
-    /// asynchronously via [`Self::drain`].
+    /// Relay one inbound frame on stream `conn_id`. Buffers until the first
+    /// WireRequest frame yields a claim-10 decision; on admit, opens the endpoint
+    /// and relays; later frames on an admitted stream relay directly.
     pub fn handle_frame(&mut self, conn_id: u32, payload: &[u8]) -> SubstitutionAction {
-        // Established stream → write this frame to the endpoint socket.
-        if let Some(stream) = self.conns.get_mut(&conn_id) {
-            write_nonblocking(stream, payload);
-            return SubstitutionAction::Relayed;
+        if let Some(conn) = self.conns.get_mut(&conn_id) {
+            if conn.admitted {
+                if let Some(up) = conn.upstream.as_mut() {
+                    write_nonblocking(up, payload);
+                }
+                return SubstitutionAction::Relayed;
+            }
+            conn.pending.extend_from_slice(payload);
+            return self.decide(conn_id);
         }
+        // New stream — needs a configured endpoint, else fail closed.
+        if self.endpoint.is_none() {
+            return SubstitutionAction::Refused;
+        }
+        self.conns.insert(
+            conn_id,
+            SubstConn {
+                upstream: None,
+                pending: payload.to_vec(),
+                admitted: false,
+            },
+        );
+        self.decide(conn_id)
+    }
 
-        // First frame: open a connection to the per-VM endpoint, or fail closed.
+    /// Make (or defer) the claim-10 decision for a buffering stream from its
+    /// accumulated bytes.
+    fn decide(&mut self, conn_id: u32) -> SubstitutionAction {
+        let Some(conn) = self.conns.get(&conn_id) else {
+            return SubstitutionAction::Refused;
+        };
+        let dest = match frame_destination(&conn.pending) {
+            FrameDest::Incomplete => return SubstitutionAction::Pending,
+            FrameDest::Malformed => {
+                self.conns.remove(&conn_id);
+                return SubstitutionAction::Refused;
+            }
+            FrameDest::Dest(d) => d,
+        };
+        // Claim-10: consult the same gate the raw-egress path uses. No gate, a
+        // denied, or a malformed destination all fail closed.
+        let admitted = matches!(
+            self.gate.as_ref().map(|g| g.decide_request(&dest)),
+            Some(EgressVerdict::Allow { .. })
+        );
+        if !admitted {
+            self.conns.remove(&conn_id);
+            return SubstitutionAction::Refused;
+        }
+        // Admitted: open the endpoint and flush the buffered frame(s).
         let Some(path) = self.endpoint.clone() else {
-            return SubstitutionAction::Refused; // no endpoint → no egress
+            self.conns.remove(&conn_id);
+            return SubstitutionAction::Refused;
         };
         match UnixStream::connect(&path) {
             Ok(stream) => {
-                // Non-blocking so `drain` reads replies without stalling the run loop.
                 let _ = stream.set_nonblocking(true);
-                self.conns.insert(conn_id, stream);
-                // Write the first frame now that the stream is established.
-                if let Some(s) = self.conns.get_mut(&conn_id) {
-                    write_nonblocking(s, payload);
+                let conn = self
+                    .conns
+                    .get_mut(&conn_id)
+                    .expect("conn present: just looked it up");
+                let buffered = std::mem::take(&mut conn.pending);
+                conn.upstream = Some(stream);
+                conn.admitted = true;
+                if let Some(up) = conn.upstream.as_mut() {
+                    write_nonblocking(up, &buffered);
                 }
                 self.bump(1);
                 SubstitutionAction::Relayed
             }
-            Err(_) => SubstitutionAction::Refused,
+            Err(_) => {
+                self.conns.remove(&conn_id);
+                SubstitutionAction::Refused
+            }
         }
     }
 
@@ -128,10 +208,13 @@ impl SubstitutionBridge {
     pub fn drain(&mut self) -> SubstitutionDrain {
         let mut ready = Vec::new();
         let mut closed = Vec::new();
-        for (conn_id, stream) in self.conns.iter_mut() {
+        for (conn_id, conn) in self.conns.iter_mut() {
+            let Some(up) = conn.upstream.as_mut() else {
+                continue; // still buffering — nothing to read yet
+            };
             let mut buf = vec![0u8; READ_CHUNK];
-            match stream.read(&mut buf) {
-                Ok(0) => closed.push(*conn_id), // peer EOF (endpoint closed the reply)
+            match up.read(&mut buf) {
+                Ok(0) => closed.push(*conn_id), // endpoint closed the reply
                 Ok(n) => {
                     buf.truncate(n);
                     ready.push((*conn_id, buf));
@@ -141,17 +224,17 @@ impl SubstitutionBridge {
             }
         }
         for conn_id in &closed {
-            if self.conns.remove(conn_id).is_some() {
-                self.bump(-1);
-            }
+            self.close(*conn_id);
         }
         SubstitutionDrain { ready, closed }
     }
 
-    /// Close a stream (guest `OP_SHUTDOWN`/`OP_RST`), tearing down its endpoint
-    /// connection so the endpoint sees EOF on the relayed request.
+    /// Close a stream (guest `OP_SHUTDOWN`/`OP_RST`), dropping its endpoint
+    /// connection so the endpoint sees EOF.
     pub fn close(&mut self, conn_id: u32) {
-        if self.conns.remove(&conn_id).is_some() {
+        if let Some(conn) = self.conns.remove(&conn_id)
+            && conn.admitted
+        {
             self.bump(-1);
         }
     }
@@ -167,9 +250,45 @@ impl SubstitutionBridge {
     }
 }
 
+/// The claim-10 target parsed from a buffered WireRequest frame.
+enum FrameDest {
+    /// Not enough bytes yet to parse the first frame.
+    Incomplete,
+    /// A complete-but-unparseable frame, or a target with no host:port — deny.
+    Malformed,
+    /// The `host:port` the gate decides against.
+    Dest(String),
+}
+
+/// Parse the destination `host:port` from a buffered substitution stream's bytes:
+/// a 4-byte big-endian length prefix + a JSON [`WireRequest`], from whose absolute
+/// `url` the host and (scheme-default) port are taken. Returns `Incomplete` until
+/// the whole frame is present, `Malformed` on a bad frame / target.
+fn frame_destination(buf: &[u8]) -> FrameDest {
+    if buf.len() < 4 {
+        return FrameDest::Incomplete;
+    }
+    let len = u32::from_be_bytes([buf[0], buf[1], buf[2], buf[3]]) as usize;
+    if len > MAX_FRAME_BYTES {
+        return FrameDest::Malformed; // an absurd length prefix fails closed
+    }
+    if buf.len() < 4 + len {
+        return FrameDest::Incomplete;
+    }
+    let Ok(req) = serde_json::from_slice::<WireRequest>(&buf[4..4 + len]) else {
+        return FrameDest::Malformed;
+    };
+    match Url::parse(&req.url) {
+        Ok(u) => match (u.host_str(), u.port_or_known_default()) {
+            (Some(host), Some(port)) => FrameDest::Dest(format!("{host}:{port}")),
+            _ => FrameDest::Malformed,
+        },
+        Err(_) => FrameDest::Malformed,
+    }
+}
+
 /// Write `payload` to a non-blocking socket, briefly spinning past `WouldBlock` so
-/// a small frame goes out without stalling the run loop indefinitely. Mirrors the
-/// egress proxy / agent bridge writer.
+/// a small frame goes out without stalling the run loop indefinitely.
 fn write_nonblocking(stream: &mut UnixStream, payload: &[u8]) {
     let mut off = 0;
     let mut spins = 0u32;
@@ -189,43 +308,135 @@ fn write_nonblocking(stream: &mut UnixStream, payload: &[u8]) {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use base64::Engine;
+    use base64::engine::general_purpose::STANDARD as B64;
+    use mvm_core::policy::dns_pin::{DnsPin, DnsPinRegistry};
+    use mvm_core::policy::network_policy::{HostPort, NetworkPolicy};
     use std::os::unix::net::UnixListener;
     use std::time::Duration;
 
-    /// No endpoint configured → every stream is refused, nothing is opened.
+    /// A gate admitting exactly `host:port`, with a self-pin so the gate can
+    /// resolve the WireRequest host to a fixed IP.
+    fn gate_allowing(host: &str, port: u16) -> EgressGate {
+        let now = "2026-01-01T00:00:00Z";
+        let mut pins = DnsPinRegistry::new();
+        pins.add(DnsPin::at(
+            host,
+            vec!["93.184.216.34".parse().unwrap()],
+            "2025-01-01T00:00:00Z",
+            "2030-01-01T00:00:00Z",
+        ));
+        let policy = NetworkPolicy::allow_list(vec![HostPort {
+            host: host.into(),
+            port,
+        }]);
+        EgressGate::from_network_policy(&policy, &pins, now)
+    }
+
+    /// Build a framed WireRequest (4-byte BE len + JSON) for `url`.
+    fn wire_frame(url: &str) -> Vec<u8> {
+        let req = WireRequest {
+            method: "POST".into(),
+            url: url.into(),
+            headers: vec![("authorization".into(), "Bearer mvm-secret-abc".into())],
+            body_b64: B64.encode(b"{}"),
+        };
+        let body = serde_json::to_vec(&req).unwrap();
+        let mut frame = (body.len() as u32).to_be_bytes().to_vec();
+        frame.extend_from_slice(&body);
+        frame
+    }
+
+    /// No endpoint configured → every stream is refused, nothing opened.
     #[test]
     fn no_endpoint_refuses_fail_closed() {
         let mut b = SubstitutionBridge::new();
-        assert_eq!(b.handle_frame(5, b"anything"), SubstitutionAction::Refused);
+        b.set_gate(gate_allowing("api.openai.com", 443));
+        assert_eq!(
+            b.handle_frame(5, &wire_frame("https://api.openai.com/v1")),
+            SubstitutionAction::Refused
+        );
         assert!(!b.has_active());
     }
 
-    /// An endpoint path that doesn't exist → the connect fails → refused (the
-    /// guest gets no egress when the moat isn't up).
+    /// Claim-10: a destination the gate does not admit is refused at the bridge —
+    /// the endpoint is never contacted (here it doesn't even exist, proving no
+    /// connection was attempted before the gate).
     #[test]
-    fn unreachable_endpoint_refuses() {
+    fn unadmitted_destination_refused_before_the_endpoint() {
         let dir = tempfile::tempdir().unwrap();
         let mut b = SubstitutionBridge::new();
-        b.set_endpoint(&dir.path().join("nope.sock"));
-        assert_eq!(b.handle_frame(7, b"req"), SubstitutionAction::Refused);
+        b.set_endpoint(&dir.path().join("subst.sock"));
+        b.set_gate(gate_allowing("api.openai.com", 443));
+        // A different host than the one admitted.
+        assert_eq!(
+            b.handle_frame(7, &wire_frame("https://evil.example.com/x")),
+            SubstitutionAction::Refused
+        );
         assert!(!b.has_active());
     }
 
-    /// Full relay over a real Unix socket: a mock endpoint reads the guest's
-    /// request bytes and writes a reply; the bridge relays the request to the
-    /// endpoint and the reply back to the guest stream. This is the per-VM
-    /// substitution transport end to end (minus the device framing).
+    /// A complete frame that isn't a valid WireRequest fails closed (Refused),
+    /// never relayed.
     #[test]
-    fn relays_request_to_endpoint_and_reply_back() {
+    fn malformed_frame_fails_closed() {
+        let dir = tempfile::tempdir().unwrap();
+        let mut b = SubstitutionBridge::new();
+        b.set_endpoint(&dir.path().join("subst.sock"));
+        b.set_gate(gate_allowing("api.openai.com", 443));
+        // 4-byte length prefix = 3, then 3 bytes of non-JSON.
+        let frame = [0, 0, 0, 3, b'x', b'y', b'z'];
+        assert_eq!(b.handle_frame(9, &frame), SubstitutionAction::Refused);
+    }
+
+    /// A frame split across two writes buffers (Pending) until complete, then is
+    /// decided once whole.
+    #[test]
+    fn split_frame_buffers_until_complete() {
         let dir = tempfile::tempdir().unwrap();
         let sock = dir.path().join("subst.sock");
-
-        // Mock endpoint: accept one connection, echo the request prefixed with
-        // "REPLY:" so the test can tell the reply apart from the request.
         let listener = UnixListener::bind(&sock).unwrap();
         let server = std::thread::spawn(move || {
             let (mut c, _) = listener.accept().unwrap();
-            let mut buf = [0u8; 64];
+            let mut buf = [0u8; 512];
+            let n = c.read(&mut buf).unwrap();
+            c.write_all(&buf[..n]).unwrap();
+        });
+
+        let mut b = SubstitutionBridge::new();
+        b.set_endpoint(&sock);
+        b.set_gate(gate_allowing("api.openai.com", 443));
+
+        let frame = wire_frame("https://api.openai.com/v1");
+        let (head, tail) = frame.split_at(3); // less than the 4-byte length prefix
+        assert_eq!(b.handle_frame(11, head), SubstitutionAction::Pending);
+        assert_eq!(b.handle_frame(11, tail), SubstitutionAction::Relayed);
+        assert!(b.has_active());
+
+        let mut got = None;
+        for _ in 0..200 {
+            let d = b.drain();
+            if let Some((cid, bytes)) = d.ready.into_iter().next() {
+                assert_eq!(cid, 11);
+                got = Some(bytes);
+                break;
+            }
+            std::thread::sleep(Duration::from_millis(5));
+        }
+        assert_eq!(got.as_deref(), Some(frame.as_slice()));
+        server.join().unwrap();
+    }
+
+    /// Happy path: an admitted destination opens the endpoint, relays the request,
+    /// and streams the endpoint's reply back.
+    #[test]
+    fn admitted_destination_relays_to_endpoint_and_back() {
+        let dir = tempfile::tempdir().unwrap();
+        let sock = dir.path().join("subst.sock");
+        let listener = UnixListener::bind(&sock).unwrap();
+        let server = std::thread::spawn(move || {
+            let (mut c, _) = listener.accept().unwrap();
+            let mut buf = [0u8; 512];
             let n = c.read(&mut buf).unwrap();
             let mut reply = b"REPLY:".to_vec();
             reply.extend_from_slice(&buf[..n]);
@@ -236,16 +447,13 @@ mod tests {
         let active = Arc::new(AtomicUsize::new(0));
         b.set_activity(active.clone());
         b.set_endpoint(&sock);
+        b.set_gate(gate_allowing("api.openai.com", 443));
 
-        // Guest → host: first frame opens the endpoint connection and relays.
-        assert_eq!(
-            b.handle_frame(42, b"WireRequest"),
-            SubstitutionAction::Relayed
-        );
+        let frame = wire_frame("https://api.openai.com/v1");
+        assert_eq!(b.handle_frame(42, &frame), SubstitutionAction::Relayed);
         assert!(b.has_active());
         assert_eq!(active.load(Ordering::Relaxed), 1);
 
-        // host → guest: poll until the endpoint's reply arrives on the same stream.
         let mut got = None;
         for _ in 0..200 {
             let d = b.drain();
@@ -256,11 +464,10 @@ mod tests {
             }
             std::thread::sleep(Duration::from_millis(5));
         }
-        assert_eq!(got.as_deref(), Some(&b"REPLY:WireRequest"[..]));
+        let got = got.expect("endpoint reply");
+        assert!(got.starts_with(b"REPLY:"));
         server.join().unwrap();
 
-        // The endpoint closed after replying → a later drain reports the stream
-        // closed and the active counter drops to zero.
         for _ in 0..200 {
             let d = b.drain();
             if d.closed.contains(&42) {
@@ -270,53 +477,5 @@ mod tests {
         }
         assert!(!b.has_active());
         assert_eq!(active.load(Ordering::Relaxed), 0);
-    }
-
-    /// A second frame on an already-open stream writes to the same endpoint
-    /// connection (it does not re-open one), so a chunked request stays on one
-    /// endpoint stream.
-    #[test]
-    fn second_frame_reuses_the_open_connection() {
-        let dir = tempfile::tempdir().unwrap();
-        let sock = dir.path().join("subst.sock");
-        let listener = UnixListener::bind(&sock).unwrap();
-        let server = std::thread::spawn(move || {
-            let (mut c, _) = listener.accept().unwrap();
-            let mut buf = [0u8; 64];
-            // Read both frames (they were written back-to-back on one stream).
-            let mut total = Vec::new();
-            for _ in 0..2 {
-                let n = c.read(&mut buf).unwrap();
-                if n == 0 {
-                    break;
-                }
-                total.extend_from_slice(&buf[..n]);
-                if total.len() >= 6 {
-                    break;
-                }
-            }
-            c.write_all(&total).unwrap();
-        });
-
-        let mut b = SubstitutionBridge::new();
-        b.set_endpoint(&sock);
-        assert_eq!(b.handle_frame(9, b"abc"), SubstitutionAction::Relayed);
-        assert_eq!(b.handle_frame(9, b"def"), SubstitutionAction::Relayed);
-        // Only one endpoint connection opened for the two frames.
-        assert_eq!(b.conns.len(), 1);
-
-        let mut got = Vec::new();
-        for _ in 0..200 {
-            let d = b.drain();
-            for (_, bytes) in d.ready {
-                got.extend_from_slice(&bytes);
-            }
-            if got.len() >= 6 {
-                break;
-            }
-            std::thread::sleep(Duration::from_millis(5));
-        }
-        assert_eq!(&got, b"abcdef");
-        server.join().unwrap();
     }
 }

--- a/crates/mvm-backend/src/vmm/substitution_bridge.rs
+++ b/crates/mvm-backend/src/vmm/substitution_bridge.rs
@@ -3,7 +3,7 @@
 //! On the in-house VMM, [`EGRESS_PORT`](mvm_guest::vsock::EGRESS_PORT) (5253)
 //! carries exactly one protocol — the WireRequest substitution protocol the
 //! guest's forward-proxy speaks — and exactly one enforcer: the per-VM
-//! `mvm-substitution-endpoint`, which decides claims 10/12/13 (ADR-101). This
+//! `mvm-substitution-endpoint`, which decides claims 10/12/13. This
 //! bridge is the transport between the two: for each guest→host stream on 5253 it
 //! opens a Unix-socket connection to that endpoint and relays bytes both ways.
 //!
@@ -12,7 +12,7 @@
 //! parses no WireRequest and enforces no policy — every decision lives in the
 //! endpoint it forwards to. The only judgement it makes is fail-closed: with no
 //! endpoint configured, or if the endpoint socket can't be reached, the stream is
-//! reset and no bytes leave the host (default-deny, ADR-100/claim-10).
+//! reset and no bytes leave the host (default-deny, claim-10).
 
 use std::collections::HashMap;
 use std::io::{Read, Write};

--- a/crates/mvm-backend/src/vmm/substitution_bridge.rs
+++ b/crates/mvm-backend/src/vmm/substitution_bridge.rs
@@ -1,0 +1,322 @@
+//! The host-side substitution bridge — guest egress stream ↔ per-VM endpoint UDS.
+//!
+//! On the in-house VMM, [`EGRESS_PORT`](mvm_guest::vsock::EGRESS_PORT) (5253)
+//! carries exactly one protocol — the WireRequest substitution protocol the
+//! guest's forward-proxy speaks — and exactly one enforcer: the per-VM
+//! `mvm-substitution-endpoint`, which decides claims 10/12/13 (ADR-101). This
+//! bridge is the transport between the two: for each guest→host stream on 5253 it
+//! opens a Unix-socket connection to that endpoint and relays bytes both ways.
+//!
+//! Like [`EgressProxy`](super::egress_proxy::EgressProxy) it is **a dumb byte
+//! relay** keyed by an opaque connection id (the guest vsock `src_port`): it
+//! parses no WireRequest and enforces no policy — every decision lives in the
+//! endpoint it forwards to. The only judgement it makes is fail-closed: with no
+//! endpoint configured, or if the endpoint socket can't be reached, the stream is
+//! reset and no bytes leave the host (default-deny, ADR-100/claim-10).
+
+use std::collections::HashMap;
+use std::io::{Read, Write};
+use std::os::unix::net::UnixStream;
+use std::path::{Path, PathBuf};
+use std::sync::Arc;
+use std::sync::atomic::{AtomicUsize, Ordering};
+
+/// Per-drain read budget per endpoint connection.
+const READ_CHUNK: usize = 16 * 1024;
+
+/// What the device should signal the guest after an inbound substitution frame.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum SubstitutionAction {
+    /// Stream opened to the endpoint (or already open) — bytes relayed; no control
+    /// reply beyond the credit update the device already sends.
+    Relayed,
+    /// No endpoint reachable — reset the stream. Fail-closed: a guest with no
+    /// substitution endpoint gets no egress (default-deny).
+    Refused,
+}
+
+/// Result of draining the open endpoint sockets once.
+pub(crate) struct SubstitutionDrain {
+    /// Bytes read per connection id, to frame back to the guest as `OP_RW`.
+    pub ready: Vec<(u32, Vec<u8>)>,
+    /// Connection ids that hit EOF / error and were closed.
+    pub closed: Vec<u32>,
+}
+
+/// The substitution transport for one guest: the per-VM endpoint socket path plus
+/// the open relay connections.
+pub(crate) struct SubstitutionBridge {
+    /// Per-VM `mvm-substitution-endpoint` Unix socket. `None` ⇒ no endpoint for
+    /// this VM, so every stream is refused (fail-closed; the workload carries no
+    /// admitted egress).
+    endpoint: Option<PathBuf>,
+    /// Open endpoint connections, keyed by the guest vsock `src_port` (conn id).
+    conns: HashMap<u32, UnixStream>,
+    /// Open-connection count, published for the host run loop's heartbeat (it must
+    /// keep waking an idle guest while there's an endpoint reply to deliver). Same
+    /// counter shape as the egress proxy / agent bridge.
+    active: Option<Arc<AtomicUsize>>,
+}
+
+impl SubstitutionBridge {
+    pub fn new() -> Self {
+        Self {
+            endpoint: None,
+            conns: HashMap::new(),
+            active: None,
+        }
+    }
+
+    /// Point the bridge at this VM's substitution-endpoint socket. Until set (or if
+    /// the path can't be reached), every stream is refused.
+    pub fn set_endpoint(&mut self, path: &Path) {
+        self.endpoint = Some(path.to_path_buf());
+    }
+
+    /// Whether a substitution endpoint is configured for this VM. The device uses
+    /// this to decide, at configuration time (not by inspecting guest bytes),
+    /// whether `EGRESS_PORT` routes here (WireRequest substitution) or to the
+    /// legacy raw-TCP egress proxy.
+    pub fn has_endpoint(&self) -> bool {
+        self.endpoint.is_some()
+    }
+
+    /// Share the open-connection counter with the host run loop heartbeat.
+    pub fn set_activity(&mut self, counter: Arc<AtomicUsize>) {
+        self.active = Some(counter);
+    }
+
+    /// True while at least one endpoint connection is open (the heartbeat gate).
+    pub fn has_active(&self) -> bool {
+        !self.conns.is_empty()
+    }
+
+    /// Relay one inbound substitution frame on stream `conn_id` to the endpoint.
+    /// The first frame opens the endpoint connection; later frames are written to
+    /// it. The bridge interprets none of the bytes — the WireRequest framing and
+    /// every claim-10/12/13 decision live in the endpoint. Replies stream back
+    /// asynchronously via [`Self::drain`].
+    pub fn handle_frame(&mut self, conn_id: u32, payload: &[u8]) -> SubstitutionAction {
+        // Established stream → write this frame to the endpoint socket.
+        if let Some(stream) = self.conns.get_mut(&conn_id) {
+            write_nonblocking(stream, payload);
+            return SubstitutionAction::Relayed;
+        }
+
+        // First frame: open a connection to the per-VM endpoint, or fail closed.
+        let Some(path) = self.endpoint.clone() else {
+            return SubstitutionAction::Refused; // no endpoint → no egress
+        };
+        match UnixStream::connect(&path) {
+            Ok(stream) => {
+                // Non-blocking so `drain` reads replies without stalling the run loop.
+                let _ = stream.set_nonblocking(true);
+                self.conns.insert(conn_id, stream);
+                // Write the first frame now that the stream is established.
+                if let Some(s) = self.conns.get_mut(&conn_id) {
+                    write_nonblocking(s, payload);
+                }
+                self.bump(1);
+                SubstitutionAction::Relayed
+            }
+            Err(_) => SubstitutionAction::Refused,
+        }
+    }
+
+    /// Read each open endpoint socket once (non-blocking); a peer EOF or error
+    /// closes that connection. The host→guest half of the relay.
+    pub fn drain(&mut self) -> SubstitutionDrain {
+        let mut ready = Vec::new();
+        let mut closed = Vec::new();
+        for (conn_id, stream) in self.conns.iter_mut() {
+            let mut buf = vec![0u8; READ_CHUNK];
+            match stream.read(&mut buf) {
+                Ok(0) => closed.push(*conn_id), // peer EOF (endpoint closed the reply)
+                Ok(n) => {
+                    buf.truncate(n);
+                    ready.push((*conn_id, buf));
+                }
+                Err(e) if e.kind() == std::io::ErrorKind::WouldBlock => {}
+                Err(_) => closed.push(*conn_id),
+            }
+        }
+        for conn_id in &closed {
+            if self.conns.remove(conn_id).is_some() {
+                self.bump(-1);
+            }
+        }
+        SubstitutionDrain { ready, closed }
+    }
+
+    /// Close a stream (guest `OP_SHUTDOWN`/`OP_RST`), tearing down its endpoint
+    /// connection so the endpoint sees EOF on the relayed request.
+    pub fn close(&mut self, conn_id: u32) {
+        if self.conns.remove(&conn_id).is_some() {
+            self.bump(-1);
+        }
+    }
+
+    fn bump(&self, delta: i32) {
+        if let Some(c) = &self.active {
+            if delta >= 0 {
+                c.fetch_add(delta as usize, Ordering::Relaxed);
+            } else {
+                c.fetch_sub((-delta) as usize, Ordering::Relaxed);
+            }
+        }
+    }
+}
+
+/// Write `payload` to a non-blocking socket, briefly spinning past `WouldBlock` so
+/// a small frame goes out without stalling the run loop indefinitely. Mirrors the
+/// egress proxy / agent bridge writer.
+fn write_nonblocking(stream: &mut UnixStream, payload: &[u8]) {
+    let mut off = 0;
+    let mut spins = 0u32;
+    while off < payload.len() {
+        match stream.write(&payload[off..]) {
+            Ok(0) => break,
+            Ok(n) => off += n,
+            Err(e) if e.kind() == std::io::ErrorKind::WouldBlock && spins < 10_000 => {
+                spins += 1;
+                std::thread::yield_now();
+            }
+            Err(_) => break,
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::os::unix::net::UnixListener;
+    use std::time::Duration;
+
+    /// No endpoint configured → every stream is refused, nothing is opened.
+    #[test]
+    fn no_endpoint_refuses_fail_closed() {
+        let mut b = SubstitutionBridge::new();
+        assert_eq!(b.handle_frame(5, b"anything"), SubstitutionAction::Refused);
+        assert!(!b.has_active());
+    }
+
+    /// An endpoint path that doesn't exist → the connect fails → refused (the
+    /// guest gets no egress when the moat isn't up).
+    #[test]
+    fn unreachable_endpoint_refuses() {
+        let dir = tempfile::tempdir().unwrap();
+        let mut b = SubstitutionBridge::new();
+        b.set_endpoint(&dir.path().join("nope.sock"));
+        assert_eq!(b.handle_frame(7, b"req"), SubstitutionAction::Refused);
+        assert!(!b.has_active());
+    }
+
+    /// Full relay over a real Unix socket: a mock endpoint reads the guest's
+    /// request bytes and writes a reply; the bridge relays the request to the
+    /// endpoint and the reply back to the guest stream. This is the per-VM
+    /// substitution transport end to end (minus the device framing).
+    #[test]
+    fn relays_request_to_endpoint_and_reply_back() {
+        let dir = tempfile::tempdir().unwrap();
+        let sock = dir.path().join("subst.sock");
+
+        // Mock endpoint: accept one connection, echo the request prefixed with
+        // "REPLY:" so the test can tell the reply apart from the request.
+        let listener = UnixListener::bind(&sock).unwrap();
+        let server = std::thread::spawn(move || {
+            let (mut c, _) = listener.accept().unwrap();
+            let mut buf = [0u8; 64];
+            let n = c.read(&mut buf).unwrap();
+            let mut reply = b"REPLY:".to_vec();
+            reply.extend_from_slice(&buf[..n]);
+            c.write_all(&reply).unwrap();
+        });
+
+        let mut b = SubstitutionBridge::new();
+        let active = Arc::new(AtomicUsize::new(0));
+        b.set_activity(active.clone());
+        b.set_endpoint(&sock);
+
+        // Guest → host: first frame opens the endpoint connection and relays.
+        assert_eq!(
+            b.handle_frame(42, b"WireRequest"),
+            SubstitutionAction::Relayed
+        );
+        assert!(b.has_active());
+        assert_eq!(active.load(Ordering::Relaxed), 1);
+
+        // host → guest: poll until the endpoint's reply arrives on the same stream.
+        let mut got = None;
+        for _ in 0..200 {
+            let d = b.drain();
+            if let Some((cid, bytes)) = d.ready.into_iter().next() {
+                assert_eq!(cid, 42);
+                got = Some(bytes);
+                break;
+            }
+            std::thread::sleep(Duration::from_millis(5));
+        }
+        assert_eq!(got.as_deref(), Some(&b"REPLY:WireRequest"[..]));
+        server.join().unwrap();
+
+        // The endpoint closed after replying → a later drain reports the stream
+        // closed and the active counter drops to zero.
+        for _ in 0..200 {
+            let d = b.drain();
+            if d.closed.contains(&42) {
+                break;
+            }
+            std::thread::sleep(Duration::from_millis(5));
+        }
+        assert!(!b.has_active());
+        assert_eq!(active.load(Ordering::Relaxed), 0);
+    }
+
+    /// A second frame on an already-open stream writes to the same endpoint
+    /// connection (it does not re-open one), so a chunked request stays on one
+    /// endpoint stream.
+    #[test]
+    fn second_frame_reuses_the_open_connection() {
+        let dir = tempfile::tempdir().unwrap();
+        let sock = dir.path().join("subst.sock");
+        let listener = UnixListener::bind(&sock).unwrap();
+        let server = std::thread::spawn(move || {
+            let (mut c, _) = listener.accept().unwrap();
+            let mut buf = [0u8; 64];
+            // Read both frames (they were written back-to-back on one stream).
+            let mut total = Vec::new();
+            for _ in 0..2 {
+                let n = c.read(&mut buf).unwrap();
+                if n == 0 {
+                    break;
+                }
+                total.extend_from_slice(&buf[..n]);
+                if total.len() >= 6 {
+                    break;
+                }
+            }
+            c.write_all(&total).unwrap();
+        });
+
+        let mut b = SubstitutionBridge::new();
+        b.set_endpoint(&sock);
+        assert_eq!(b.handle_frame(9, b"abc"), SubstitutionAction::Relayed);
+        assert_eq!(b.handle_frame(9, b"def"), SubstitutionAction::Relayed);
+        // Only one endpoint connection opened for the two frames.
+        assert_eq!(b.conns.len(), 1);
+
+        let mut got = Vec::new();
+        for _ in 0..200 {
+            let d = b.drain();
+            for (_, bytes) in d.ready {
+                got.extend_from_slice(&bytes);
+            }
+            if got.len() >= 6 {
+                break;
+            }
+            std::thread::sleep(Duration::from_millis(5));
+        }
+        assert_eq!(&got, b"abcdef");
+        server.join().unwrap();
+    }
+}

--- a/crates/mvm-backend/src/vmm/vsock.rs
+++ b/crates/mvm-backend/src/vmm/vsock.rs
@@ -161,8 +161,9 @@ pub struct VirtioVsock {
     agent: super::agent_bridge::AgentBridge,
     /// Per-VM substitution gateway. When a substitution endpoint UDS is
     /// configured, `EGRESS_PORT` carries the WireRequest substitution protocol and
-    /// routes here instead of the raw-TCP `egress` proxy; claims 10/12/13 are all
-    /// decided in the endpoint subprocess this bridges to.
+    /// routes here instead of the raw-TCP `egress` proxy. The bridge makes the
+    /// claim-10 decision on the first frame (reusing the egress gate), then relays
+    /// admitted streams to the endpoint subprocess that enforces claims 12/13.
     substitution: super::substitution_bridge::SubstitutionBridge,
     /// Inbound vsock header per substitution stream (keyed by guest `src_port`), so
     /// an endpoint reply can be framed back on the right stream.
@@ -230,6 +231,14 @@ impl VirtioVsock {
     /// raw-TCP egress proxy. Without it, `EGRESS_PORT` keeps the legacy egress path.
     pub fn set_substitution_endpoint(&mut self, path: &std::path::Path) {
         self.substitution.set_endpoint(path);
+    }
+
+    /// Install the claim-10 policy on the substitution gateway — the same
+    /// [`EgressGate`](super::egress_gate::EgressGate) the raw-egress path uses, so
+    /// a destination the network policy forbids is refused at the bridge before the
+    /// secrets endpoint is contacted.
+    pub fn set_substitution_gate(&mut self, gate: super::egress_gate::EgressGate) {
+        self.substitution.set_gate(gate);
     }
 
     /// Share the heartbeat activity counter with the substitution gateway so an
@@ -467,18 +476,25 @@ impl VirtioVsock {
     }
 
     /// Frame an inbound substitution request to the [`SubstitutionBridge`] and map
-    /// its action to a vsock control reply. The bridge relays the bytes
-    /// to the per-VM endpoint, which makes every claim-10/12/13 decision; the device
-    /// owns only the rx framing and the per-stream header.
+    /// its action to a vsock control reply. The bridge enforces claim-10 on the
+    /// first frame and relays admitted streams to the per-VM endpoint (claims
+    /// 12/13); the device owns only the rx framing and the per-stream header.
     fn handle_substitution_request(&mut self, hdr: &Hdr, payload: &[u8]) {
         use super::substitution_bridge::SubstitutionAction;
         match self.substitution.handle_frame(hdr.src_port, payload) {
-            SubstitutionAction::Relayed => {
+            // Relayed (admitted) or Pending (buffering the first frame): ack the
+            // bytes so the guest's credit recovers, and keep the stream's header
+            // for framing replies / a later reset.
+            SubstitutionAction::Relayed | SubstitutionAction::Pending => {
                 self.substitution_hdrs.insert(hdr.src_port, *hdr);
-                self.queue_reply(hdr, OP_CREDIT_UPDATE, &[]); // ack the relayed bytes
+                self.queue_reply(hdr, OP_CREDIT_UPDATE, &[]);
             }
-            // Fail-closed: no endpoint reachable → reset the stream (no egress).
-            SubstitutionAction::Refused => self.queue_reply(hdr, OP_RST, &[]),
+            // Fail-closed: no endpoint, a claim-10 deny, or a malformed frame →
+            // reset the stream (no egress).
+            SubstitutionAction::Refused => {
+                self.substitution_hdrs.remove(&hdr.src_port);
+                self.queue_reply(hdr, OP_RST, &[]);
+            }
         }
     }
 
@@ -752,49 +768,89 @@ mod tests {
         assert_eq!(d.received, b"hello");
     }
 
-    /// With a substitution endpoint wired, a guest OP_RW to `EGRESS_PORT` is
-    /// relayed to the endpoint (not captured as raw bytes, not handed to the
-    /// raw-TCP egress proxy), and the endpoint's reply frames back to the guest as
-    /// OP_RW on the same stream.
+    /// Build a `(gate-admitting-the-host, framed-WireRequest)` pair for the
+    /// substitution device tests: the gate self-pins `host:port`, the frame targets
+    /// `https://<host>/v1`.
+    #[cfg(test)]
+    fn subst_gate_and_frame(
+        host: &str,
+        port: u16,
+    ) -> (crate::vmm::egress_gate::EgressGate, Vec<u8>) {
+        use base64::Engine;
+        use mvm_core::policy::dns_pin::{DnsPin, DnsPinRegistry};
+        use mvm_core::policy::network_policy::{HostPort, NetworkPolicy};
+        use mvm_core::substitution_wire::WireRequest;
+
+        let mut pins = DnsPinRegistry::new();
+        pins.add(DnsPin::at(
+            host,
+            vec!["93.184.216.34".parse().unwrap()],
+            "2025-01-01T00:00:00Z",
+            "2030-01-01T00:00:00Z",
+        ));
+        let gate = crate::vmm::egress_gate::EgressGate::from_network_policy(
+            &NetworkPolicy::allow_list(vec![HostPort {
+                host: host.into(),
+                port,
+            }]),
+            &pins,
+            "2026-01-01T00:00:00Z",
+        );
+        let req = WireRequest {
+            method: "POST".into(),
+            url: format!("https://{host}/v1"),
+            headers: vec![("authorization".into(), "Bearer mvm-secret-abc".into())],
+            body_b64: base64::engine::general_purpose::STANDARD.encode(b"{}"),
+        };
+        let body = serde_json::to_vec(&req).unwrap();
+        let mut frame = (body.len() as u32).to_be_bytes().to_vec();
+        frame.extend_from_slice(&body);
+        (gate, frame)
+    }
+
+    /// With a substitution endpoint wired, a guest OP_RW to `EGRESS_PORT` carrying a
+    /// WireRequest to an *admitted* destination is relayed to the endpoint (not
+    /// captured as raw bytes, not handed to the raw-TCP egress proxy), and the
+    /// endpoint's reply frames back to the guest as OP_RW on the same stream.
     #[test]
-    fn egress_port_routes_to_substitution_endpoint_when_wired() {
+    fn egress_port_routes_admitted_request_to_substitution_endpoint() {
         use std::io::{Read, Write};
         let dir = tempfile::tempdir().unwrap();
         let sock = dir.path().join("subst.sock");
 
-        // Mock endpoint: read the relayed request, reply "REPLY:" + it.
+        // Mock endpoint: read the relayed frame, reply "REPLY:" + it.
         let listener = std::os::unix::net::UnixListener::bind(&sock).unwrap();
         let server = std::thread::spawn(move || {
             let (mut c, _) = listener.accept().unwrap();
-            let mut buf = [0u8; 64];
+            let mut buf = [0u8; 256];
             let n = c.read(&mut buf).unwrap();
             let mut reply = b"REPLY:".to_vec();
             reply.extend_from_slice(&buf[..n]);
             c.write_all(&reply).unwrap();
         });
 
+        let (gate, frame) = subst_gate_and_frame("api.openai.com", 443);
         let mut d = dev();
         d.set_substitution_endpoint(&sock);
+        d.set_substitution_gate(gate);
 
-        // Guest sends a WireRequest frame to EGRESS_PORT.
         let rw = Hdr {
             src_cid: GUEST_CID,
             dst_cid: HOST_CID,
             src_port: 1000,
             dst_port: mvm_guest::vsock::EGRESS_PORT,
-            len: 11,
+            len: frame.len() as u32,
             op: OP_RW,
             typ: TYPE_STREAM,
             ..Default::default()
         };
-        d.handle_packet(rw, b"WireRequest");
+        d.handle_packet(rw, &frame);
 
-        // Routed to the endpoint, NOT the raw capture buffer.
+        // Routed to the endpoint, NOT the raw capture buffer; the stream is acked.
         assert!(
             d.received.is_empty(),
             "substitution bytes must not hit the capture path"
         );
-        // An ack (credit update) was queued for the relayed stream.
         assert!(
             d.pending_rx.iter().any(|(h, _)| h.op == OP_CREDIT_UPDATE),
             "relayed stream must be acked"
@@ -816,8 +872,70 @@ mod tests {
         }
         let (h, payload) = reply.expect("endpoint reply framed back to the guest");
         assert_eq!(h.src_port, mvm_guest::vsock::EGRESS_PORT); // swapped from inbound
-        assert_eq!(payload, b"REPLY:WireRequest");
+        assert!(
+            payload.starts_with(b"REPLY:"),
+            "reply must be the endpoint's echoed frame"
+        );
         server.join().unwrap();
+    }
+
+    /// Claim-10 at the device: a WireRequest to a destination the gate does NOT
+    /// admit is reset (OP_RST), never relayed — the endpoint (here a live socket
+    /// that would accept) is never contacted, so nothing reaches the wire.
+    #[test]
+    fn egress_port_resets_unadmitted_substitution_request() {
+        use std::io::Read;
+        let dir = tempfile::tempdir().unwrap();
+        let sock = dir.path().join("subst.sock");
+        let listener = std::os::unix::net::UnixListener::bind(&sock).unwrap();
+        let contacted = std::sync::Arc::new(std::sync::atomic::AtomicBool::new(false));
+        let contacted_w = contacted.clone();
+        let server = std::thread::spawn(move || {
+            // If the bridge wrongly relayed, the endpoint would accept a connection.
+            listener
+                .set_nonblocking(true)
+                .expect("nonblocking listener");
+            for _ in 0..40 {
+                if let Ok((mut c, _)) = listener.accept() {
+                    let mut b = [0u8; 8];
+                    let _ = c.read(&mut b);
+                    contacted_w.store(true, std::sync::atomic::Ordering::Relaxed);
+                    return;
+                }
+                std::thread::sleep(std::time::Duration::from_millis(5));
+            }
+        });
+
+        // Gate admits api.openai.com; the request targets a different host.
+        let (gate, _admitted) = subst_gate_and_frame("api.openai.com", 443);
+        let (_g2, denied_frame) = subst_gate_and_frame("evil.example.com", 443);
+        let mut d = dev();
+        d.set_substitution_endpoint(&sock);
+        d.set_substitution_gate(gate);
+
+        let rw = Hdr {
+            src_cid: GUEST_CID,
+            dst_cid: HOST_CID,
+            src_port: 1234,
+            dst_port: mvm_guest::vsock::EGRESS_PORT,
+            len: denied_frame.len() as u32,
+            op: OP_RW,
+            typ: TYPE_STREAM,
+            ..Default::default()
+        };
+        d.handle_packet(rw, &denied_frame);
+
+        // The stream was reset, not acked/relayed.
+        assert!(
+            d.pending_rx.iter().any(|(h, _)| h.op == OP_RST),
+            "a claim-10-denied request must be reset"
+        );
+        assert!(d.received.is_empty());
+        let _ = server.join();
+        assert!(
+            !contacted.load(std::sync::atomic::Ordering::Relaxed),
+            "the secrets endpoint must not be contacted for a denied destination"
+        );
     }
 
     /// Without a substitution endpoint, `EGRESS_PORT` keeps the legacy raw-TCP

--- a/crates/mvm-backend/src/vmm/vsock.rs
+++ b/crates/mvm-backend/src/vmm/vsock.rs
@@ -159,7 +159,7 @@ pub struct VirtioVsock {
     /// its `OP_REQUEST`/`OP_RW` onto the rx queue and routes the guest's replies
     /// back to the host socket.
     agent: super::agent_bridge::AgentBridge,
-    /// Per-VM substitution gateway (ADR-101). When a substitution endpoint UDS is
+    /// Per-VM substitution gateway. When a substitution endpoint UDS is
     /// configured, `EGRESS_PORT` carries the WireRequest substitution protocol and
     /// routes here instead of the raw-TCP `egress` proxy; claims 10/12/13 are all
     /// decided in the endpoint subprocess this bridges to.
@@ -225,7 +225,7 @@ impl VirtioVsock {
     }
 
     /// Point the substitution gateway at this VM's `mvm-substitution-endpoint`
-    /// Unix socket (ADR-101). Once set, a guest connect to `EGRESS_PORT` is relayed
+    /// Unix socket. Once set, a guest connect to `EGRESS_PORT` is relayed
     /// to the endpoint (WireRequest substitution; claims 10/12/13) rather than the
     /// raw-TCP egress proxy. Without it, `EGRESS_PORT` keeps the legacy egress path.
     pub fn set_substitution_endpoint(&mut self, path: &std::path::Path) {
@@ -467,7 +467,7 @@ impl VirtioVsock {
     }
 
     /// Frame an inbound substitution request to the [`SubstitutionBridge`] and map
-    /// its action to a vsock control reply (ADR-101). The bridge relays the bytes
+    /// its action to a vsock control reply. The bridge relays the bytes
     /// to the per-VM endpoint, which makes every claim-10/12/13 decision; the device
     /// owns only the rx framing and the per-stream header.
     fn handle_substitution_request(&mut self, hdr: &Hdr, payload: &[u8]) {
@@ -755,7 +755,7 @@ mod tests {
     /// With a substitution endpoint wired, a guest OP_RW to `EGRESS_PORT` is
     /// relayed to the endpoint (not captured as raw bytes, not handed to the
     /// raw-TCP egress proxy), and the endpoint's reply frames back to the guest as
-    /// OP_RW on the same stream (ADR-101).
+    /// OP_RW on the same stream.
     #[test]
     fn egress_port_routes_to_substitution_endpoint_when_wired() {
         use std::io::{Read, Write};

--- a/crates/mvm-backend/src/vmm/vsock.rs
+++ b/crates/mvm-backend/src/vmm/vsock.rs
@@ -159,6 +159,14 @@ pub struct VirtioVsock {
     /// its `OP_REQUEST`/`OP_RW` onto the rx queue and routes the guest's replies
     /// back to the host socket.
     agent: super::agent_bridge::AgentBridge,
+    /// Per-VM substitution gateway (ADR-101). When a substitution endpoint UDS is
+    /// configured, `EGRESS_PORT` carries the WireRequest substitution protocol and
+    /// routes here instead of the raw-TCP `egress` proxy; claims 10/12/13 are all
+    /// decided in the endpoint subprocess this bridges to.
+    substitution: super::substitution_bridge::SubstitutionBridge,
+    /// Inbound vsock header per substitution stream (keyed by guest `src_port`), so
+    /// an endpoint reply can be framed back on the right stream.
+    substitution_hdrs: std::collections::HashMap<u32, Hdr>,
 }
 
 impl VirtioVsock {
@@ -183,6 +191,8 @@ impl VirtioVsock {
             egress: super::egress_proxy::EgressProxy::new(),
             egress_hdrs: std::collections::HashMap::new(),
             agent: super::agent_bridge::AgentBridge::new(),
+            substitution: super::substitution_bridge::SubstitutionBridge::new(),
+            substitution_hdrs: std::collections::HashMap::new(),
         }
     }
 
@@ -212,6 +222,24 @@ impl VirtioVsock {
     /// heartbeat can be gated on there being host→guest work to deliver.
     pub fn set_egress_activity(&mut self, counter: std::sync::Arc<std::sync::atomic::AtomicUsize>) {
         self.egress.set_activity(counter);
+    }
+
+    /// Point the substitution gateway at this VM's `mvm-substitution-endpoint`
+    /// Unix socket (ADR-101). Once set, a guest connect to `EGRESS_PORT` is relayed
+    /// to the endpoint (WireRequest substitution; claims 10/12/13) rather than the
+    /// raw-TCP egress proxy. Without it, `EGRESS_PORT` keeps the legacy egress path.
+    pub fn set_substitution_endpoint(&mut self, path: &std::path::Path) {
+        self.substitution.set_endpoint(path);
+    }
+
+    /// Share the heartbeat activity counter with the substitution gateway so an
+    /// open substitution stream awaiting an endpoint reply keeps the run loop waking
+    /// an idle guest (the same counter the egress proxy + agent bridge use).
+    pub fn set_substitution_activity(
+        &mut self,
+        counter: std::sync::Arc<std::sync::atomic::AtomicUsize>,
+    ) {
+        self.substitution.set_activity(counter);
     }
 
     /// Egress targets the gateway refused (claim-10) — for audit / verification.
@@ -388,10 +416,19 @@ impl VirtioVsock {
                         stop.store(true, std::sync::atomic::Ordering::Relaxed);
                     }
                 } else if hdr.dst_port == mvm_guest::vsock::EGRESS_PORT {
-                    // Egress request: the payload is the connect target
-                    // "ip:port". The gateway decides per the plan's policy
-                    // (claim-10 default-deny) before any host socket is opened.
-                    self.handle_egress_request(&hdr, &payload[..n]);
+                    // The egress port carries one of two protocols, chosen at
+                    // configuration time (not by peeking the bytes): if a
+                    // substitution endpoint is wired for this VM, the stream speaks
+                    // the WireRequest substitution protocol and is relayed to the
+                    // endpoint, which makes the whole egress decision. Otherwise it
+                    // is the legacy raw-TCP egress request — payload "ip:port",
+                    // decided against the default-deny gate before any host socket
+                    // is opened.
+                    if self.substitution.has_endpoint() {
+                        self.handle_substitution_request(&hdr, &payload[..n]);
+                    } else {
+                        self.handle_egress_request(&hdr, &payload[..n]);
+                    }
                     self.fwd_cnt = self.fwd_cnt.wrapping_add(n as u32);
                     return;
                 } else {
@@ -402,7 +439,14 @@ impl VirtioVsock {
                 self.queue_reply(&hdr, OP_CREDIT_UPDATE, &[]);
             }
             OP_CREDIT_REQUEST => self.queue_reply(&hdr, OP_CREDIT_UPDATE, &[]),
-            OP_SHUTDOWN => self.queue_reply(&hdr, OP_RST, &[]),
+            OP_SHUTDOWN => {
+                // A substitution stream the guest is done with: tear down its
+                // endpoint connection so the endpoint sees EOF on the request.
+                if self.substitution_hdrs.remove(&hdr.src_port).is_some() {
+                    self.substitution.close(hdr.src_port);
+                }
+                self.queue_reply(&hdr, OP_RST, &[]);
+            }
             _ => {}
         }
     }
@@ -419,6 +463,46 @@ impl VirtioVsock {
             }
             EgressAction::Refused => self.queue_reply(hdr, OP_RST, &[]),
             EgressAction::Wrote => {}
+        }
+    }
+
+    /// Frame an inbound substitution request to the [`SubstitutionBridge`] and map
+    /// its action to a vsock control reply (ADR-101). The bridge relays the bytes
+    /// to the per-VM endpoint, which makes every claim-10/12/13 decision; the device
+    /// owns only the rx framing and the per-stream header.
+    fn handle_substitution_request(&mut self, hdr: &Hdr, payload: &[u8]) {
+        use super::substitution_bridge::SubstitutionAction;
+        match self.substitution.handle_frame(hdr.src_port, payload) {
+            SubstitutionAction::Relayed => {
+                self.substitution_hdrs.insert(hdr.src_port, *hdr);
+                self.queue_reply(hdr, OP_CREDIT_UPDATE, &[]); // ack the relayed bytes
+            }
+            // Fail-closed: no endpoint reachable → reset the stream (no egress).
+            SubstitutionAction::Refused => self.queue_reply(hdr, OP_RST, &[]),
+        }
+    }
+
+    /// Drain endpoint replies into the guest's rx queue — the host→guest half of
+    /// the substitution relay, called on every timer tick (via [`RunDevice::poll`])
+    /// so a `WireResponse` reaches a guest blocked in `recv`. Returns `Some(irq)`
+    /// if a reply was delivered into a posted rx buffer.
+    pub fn drain_substitution(&mut self) -> Option<u32> {
+        if !self.substitution.has_active() {
+            return None;
+        }
+        let drained = self.substitution.drain();
+        for (conn_id, bytes) in drained.ready {
+            if let Some(h) = self.substitution_hdrs.get(&conn_id).copied() {
+                self.queue_reply(&h, OP_RW, &bytes);
+            }
+        }
+        for conn_id in drained.closed {
+            self.substitution_hdrs.remove(&conn_id);
+        }
+        if self.flush_rx() {
+            Some(self.irq)
+        } else {
+            None
         }
     }
 
@@ -666,6 +750,98 @@ mod tests {
         };
         d.handle_packet(rw, b"hello");
         assert_eq!(d.received, b"hello");
+    }
+
+    /// With a substitution endpoint wired, a guest OP_RW to `EGRESS_PORT` is
+    /// relayed to the endpoint (not captured as raw bytes, not handed to the
+    /// raw-TCP egress proxy), and the endpoint's reply frames back to the guest as
+    /// OP_RW on the same stream (ADR-101).
+    #[test]
+    fn egress_port_routes_to_substitution_endpoint_when_wired() {
+        use std::io::{Read, Write};
+        let dir = tempfile::tempdir().unwrap();
+        let sock = dir.path().join("subst.sock");
+
+        // Mock endpoint: read the relayed request, reply "REPLY:" + it.
+        let listener = std::os::unix::net::UnixListener::bind(&sock).unwrap();
+        let server = std::thread::spawn(move || {
+            let (mut c, _) = listener.accept().unwrap();
+            let mut buf = [0u8; 64];
+            let n = c.read(&mut buf).unwrap();
+            let mut reply = b"REPLY:".to_vec();
+            reply.extend_from_slice(&buf[..n]);
+            c.write_all(&reply).unwrap();
+        });
+
+        let mut d = dev();
+        d.set_substitution_endpoint(&sock);
+
+        // Guest sends a WireRequest frame to EGRESS_PORT.
+        let rw = Hdr {
+            src_cid: GUEST_CID,
+            dst_cid: HOST_CID,
+            src_port: 1000,
+            dst_port: mvm_guest::vsock::EGRESS_PORT,
+            len: 11,
+            op: OP_RW,
+            typ: TYPE_STREAM,
+            ..Default::default()
+        };
+        d.handle_packet(rw, b"WireRequest");
+
+        // Routed to the endpoint, NOT the raw capture buffer.
+        assert!(
+            d.received.is_empty(),
+            "substitution bytes must not hit the capture path"
+        );
+        // An ack (credit update) was queued for the relayed stream.
+        assert!(
+            d.pending_rx.iter().any(|(h, _)| h.op == OP_CREDIT_UPDATE),
+            "relayed stream must be acked"
+        );
+
+        // host → guest: poll until the endpoint's reply frames back as OP_RW.
+        let mut reply = None;
+        for _ in 0..200 {
+            let _ = d.drain_substitution();
+            if let Some((h, payload)) = d
+                .pending_rx
+                .iter()
+                .find(|(h, _)| h.op == OP_RW && h.dst_port == 1000)
+            {
+                reply = Some((*h, payload.clone()));
+                break;
+            }
+            std::thread::sleep(std::time::Duration::from_millis(5));
+        }
+        let (h, payload) = reply.expect("endpoint reply framed back to the guest");
+        assert_eq!(h.src_port, mvm_guest::vsock::EGRESS_PORT); // swapped from inbound
+        assert_eq!(payload, b"REPLY:WireRequest");
+        server.join().unwrap();
+    }
+
+    /// Without a substitution endpoint, `EGRESS_PORT` keeps the legacy raw-TCP
+    /// egress path: a connect target that no gate admits is refused (default-deny),
+    /// and nothing is relayed to a substitution endpoint.
+    #[test]
+    fn egress_port_uses_legacy_egress_proxy_without_endpoint() {
+        let mut d = dev();
+        // No substitution endpoint, no egress gate → default-deny.
+        let rw = Hdr {
+            src_cid: GUEST_CID,
+            dst_cid: HOST_CID,
+            src_port: 2000,
+            dst_port: mvm_guest::vsock::EGRESS_PORT,
+            len: 16,
+            op: OP_RW,
+            typ: TYPE_STREAM,
+            ..Default::default()
+        };
+        d.handle_packet(rw, b"93.184.216.34:80");
+        // The legacy egress proxy refused it (recorded as denied), and it was not
+        // captured as raw bytes.
+        assert!(d.received.is_empty());
+        assert_eq!(d.egress_denied(), &["93.184.216.34:80".to_string()]);
     }
 
     #[test]

--- a/crates/mvm-build/src/hvf_supervisor.rs
+++ b/crates/mvm-build/src/hvf_supervisor.rs
@@ -51,7 +51,7 @@ pub struct HvfSupervisorConfig {
     /// Threading it here is the productionized path off that env hook.
     #[serde(default)]
     pub agent_socket: Option<PathBuf>,
-    /// Per-VM substitution-endpoint socket (ADR-101). When set, the supervisor
+    /// Per-VM substitution-endpoint socket. When set, the supervisor
     /// routes `EGRESS_PORT` to the `mvm-substitution-endpoint` bound here
     /// (WireRequest substitution; claims 10/12/13). `None` ⇒ the legacy raw-TCP
     /// egress path (no secret-bearing egress). The backend spawns the endpoint and

--- a/crates/mvm-build/src/hvf_supervisor.rs
+++ b/crates/mvm-build/src/hvf_supervisor.rs
@@ -45,6 +45,19 @@ pub struct HvfSupervisorConfig {
     /// guest is forced out after this long. The backend sets it from the VM's
     /// requested lifetime.
     pub timeout_secs: u64,
+    /// Per-VM host→guest agent RPC socket. The supervisor binds it so host clients
+    /// (`machine invoke`) reach the guest agent over vsock. `None` ⇒ no agent
+    /// listener (the supervisor falls back to the `MVM_HVF_AGENT_SOCKET` dev hook).
+    /// Threading it here is the productionized path off that env hook.
+    #[serde(default)]
+    pub agent_socket: Option<PathBuf>,
+    /// Per-VM substitution-endpoint socket (ADR-101). When set, the supervisor
+    /// routes `EGRESS_PORT` to the `mvm-substitution-endpoint` bound here
+    /// (WireRequest substitution; claims 10/12/13). `None` ⇒ the legacy raw-TCP
+    /// egress path (no secret-bearing egress). The backend spawns the endpoint and
+    /// sets this only when the admitted plan carries egress secrets.
+    #[serde(default)]
+    pub substitution_socket: Option<PathBuf>,
 }
 
 #[cfg(test)]
@@ -63,12 +76,23 @@ mod tests {
             workload_exit: "/state/workload.exit".into(),
             network_policy: mvm_core::policy::network_policy::NetworkPolicy::deny_all(),
             timeout_secs: 30,
+            agent_socket: Some("/state/hvf-agent.sock".into()),
+            substitution_socket: Some("/state/substitution-endpoint.sock".into()),
         };
         let json = serde_json::to_string(&cfg).unwrap();
         assert_eq!(
             serde_json::from_str::<HvfSupervisorConfig>(&json).unwrap(),
             cfg
         );
+    }
+
+    #[test]
+    fn socket_fields_default_to_none() {
+        // Older configs (and non-secret VMs) omit the socket fields → None.
+        let json = r#"{"kernel":"/k/Image","console_log":"/c.log","pid_file":"/p.pid","workload_exit":"/w.exit","timeout_secs":5}"#;
+        let cfg: HvfSupervisorConfig = serde_json::from_str(json).unwrap();
+        assert_eq!(cfg.agent_socket, None);
+        assert_eq!(cfg.substitution_socket, None);
     }
 
     #[test]

--- a/crates/mvm-cli/src/commands/vm/up.rs
+++ b/crates/mvm-cli/src/commands/vm/up.rs
@@ -839,13 +839,13 @@ pub(super) fn emit_failed_if(ctx: &Option<AdmissionContext>, class: &str, err: &
 /// persist:
 ///
 /// - **Firecracker**: the nft TAP-redirect moat reads the plan at spawn time.
-/// - **vz / libkrun (macOS)**: the substitution endpoint reads
+/// - **vz / libkrun / hvf (macOS)**: the substitution endpoint reads
 ///   `<state_dir>/plan.json` inside `start()` to decide whether to spawn.
 ///
 /// QEMU is excluded: it reads the in-memory config and must not overwrite the
 /// persisted plan.
 pub(super) fn persists_plan_before_start(hypervisor: &str) -> bool {
-    matches!(hypervisor, "firecracker" | "vz" | "libkrun")
+    matches!(hypervisor, "firecracker" | "vz" | "libkrun" | "hvf")
 }
 
 pub(super) fn load_workload_ir(
@@ -2682,5 +2682,21 @@ port_hi  = 443
             content.contains("\"error_class\":\"policy-l4-spec-invalid\""),
             "audit chain must classify the failure: {content}"
         );
+    }
+
+    #[test]
+    fn persists_plan_before_start_covers_the_substitution_backends() {
+        // The substitution endpoint reads <state_dir>/plan.json inside start() to
+        // decide whether to spawn, so every backend that spawns it must persist the
+        // plan first — including the in-house hvf backend. QEMU must not (it would
+        // overwrite the in-memory config).
+        for hv in ["firecracker", "vz", "libkrun", "hvf"] {
+            assert!(
+                persists_plan_before_start(hv),
+                "{hv} spawns the substitution endpoint and must persist plan.json"
+            );
+        }
+        assert!(!persists_plan_before_start("qemu"));
+        assert!(!persists_plan_before_start("mock"));
     }
 }

--- a/crates/mvm-core/src/config.rs
+++ b/crates/mvm-core/src/config.rs
@@ -486,7 +486,7 @@ pub fn vm_substitution_env_path(name: &str) -> std::path::PathBuf {
 
 /// Per-VM Unix socket the `mvm-substitution-endpoint` binds and the in-house VMM's
 /// substitution bridge connects to: `<vm_state_dir>/substitution-endpoint.sock`
-/// (ADR-101). Unlike the Vz path (where the Swift supervisor proxies the guest
+///. Unlike the Vz path (where the Swift supervisor proxies the guest
 /// vsock dial to a `vsock/`-nested socket), the in-house VMM's device bridges
 /// `EGRESS_PORT` straight to this socket, so it lives at the state-dir root. Single
 /// source of truth: the backend spawn (which binds it) and the supervisor config
@@ -958,7 +958,7 @@ mod tests {
             vm_vsock_port_socket("foo", 5252)
         );
         // The in-house VMM's substitution-endpoint socket sits at the state-dir
-        // root (the device bridges to it directly; ADR-101) and honors MVM_DATA_DIR.
+        // root (the device bridges to it directly) and honors MVM_DATA_DIR.
         assert_eq!(
             vm_substitution_endpoint_socket("foo"),
             std::path::PathBuf::from("/custom/data/vms/foo/substitution-endpoint.sock")

--- a/crates/mvm-core/src/config.rs
+++ b/crates/mvm-core/src/config.rs
@@ -484,6 +484,17 @@ pub fn vm_substitution_env_path(name: &str) -> std::path::PathBuf {
     vm_state_dir(name).join("substitution-env.json")
 }
 
+/// Per-VM Unix socket the `mvm-substitution-endpoint` binds and the in-house VMM's
+/// substitution bridge connects to: `<vm_state_dir>/substitution-endpoint.sock`
+/// (ADR-101). Unlike the Vz path (where the Swift supervisor proxies the guest
+/// vsock dial to a `vsock/`-nested socket), the in-house VMM's device bridges
+/// `EGRESS_PORT` straight to this socket, so it lives at the state-dir root. Single
+/// source of truth: the backend spawn (which binds it) and the supervisor config
+/// (which hands it to the device) both resolve it here.
+pub fn vm_substitution_endpoint_socket(name: &str) -> std::path::PathBuf {
+    vm_state_dir(name).join("substitution-endpoint.sock")
+}
+
 // ============================================================================
 // Sensitive ~/.mvm subdirectories
 // ============================================================================
@@ -945,6 +956,12 @@ mod tests {
         assert_eq!(
             vm_state_dir("foo").join(vsock_socket_filename(5252)),
             vm_vsock_port_socket("foo", 5252)
+        );
+        // The in-house VMM's substitution-endpoint socket sits at the state-dir
+        // root (the device bridges to it directly; ADR-101) and honors MVM_DATA_DIR.
+        assert_eq!(
+            vm_substitution_endpoint_socket("foo"),
+            std::path::PathBuf::from("/custom/data/vms/foo/substitution-endpoint.sock")
         );
 
         env.remove("MVM_DATA_DIR");

--- a/crates/mvm-vm-host/src/bin/mvm-hvf-supervisor.rs
+++ b/crates/mvm-vm-host/src/bin/mvm-hvf-supervisor.rs
@@ -220,7 +220,11 @@ fn main() -> anyhow::Result<()> {
         cfg.vsock,
         timeout,
         &STOP,
-        egress,
+        mvm_backend::hvf::HostChannels {
+            egress,
+            agent_socket: cfg.agent_socket.clone(),
+            substitution_socket: cfg.substitution_socket.clone(),
+        },
     );
 
     // The VM has stopped. Persist the outputs (console + workload exit code)

--- a/nix/lib/mk-guest.nix
+++ b/nix/lib/mk-guest.nix
@@ -232,7 +232,7 @@ let
   #     → `do_exec` stripped → CI's symbol-absence gate passes
   #
   # Either way the binary is the production Rust build, not a stub.
-  guestAgentPkg = pkgs.callPackage../packages/mvm-guest-agent.nix {
+  guestAgentPkg = pkgs.callPackage ../packages/mvm-guest-agent.nix {
     inherit mvmSrc withDevShell;
   };
 
@@ -242,27 +242,27 @@ let
   # zone empty" pattern from `specs/contracts/local-addon-dns.md`);
   # /init activates it only when a zone file is present, so a guest
   # without addons keeps its baked /etc/resolv.conf byte-for-byte.
-  addonDnsPkg = pkgs.callPackage../packages/mvm-addon-dns.nix {
+  addonDnsPkg = pkgs.callPackage ../packages/mvm-addon-dns.nix {
     inherit mvmSrc;
   };
 
   # Exit reporter — records workload exit status before poweroff.
   # Baked unconditionally into every guest rootfs (prod and dev).
-  exitReportPkg = pkgs.callPackage../packages/mvm-exit-report.nix {
+  exitReportPkg = pkgs.callPackage ../packages/mvm-exit-report.nix {
     inherit mvmSrc;
   };
 
   # Egress shim  — loopback SOCKS5 → host vsock egress gateway. Baked
   # unconditionally (inert unless /init starts it when the boot env requests
   # vsock-only egress); the guest's sole path off-VM under the no-NIC model.
-  egressClientPkg = pkgs.callPackage../packages/mvm-egress-client.nix {
+  egressClientPkg = pkgs.callPackage ../packages/mvm-egress-client.nix {
     inherit mvmSrc;
   };
 
   # In-guest host.audit.v1 driver — test fixture, baked only when
   # `withAuditProbe`. Compiled lazily (Nix only evaluates this when the
   # bake below references it) so the default path adds no build cost.
-  auditProbePkg = pkgs.callPackage../packages/mvm-audit-probe.nix {
+  auditProbePkg = pkgs.callPackage ../packages/mvm-audit-probe.nix {
     inherit mvmSrc;
   };
 
@@ -623,7 +623,7 @@ let
       # Build the new resolv.conf in /run (tmpfs, always writable)
       # and bind-mount it over /etc/resolv.conf. The:: literal is
       # written via printf so the heredoc body stays parameter-free.
-      printf 'nameserver 127.0.0.1\nnameserver::1\n' > /run/mvm/resolv.conf
+      printf 'nameserver 127.0.0.1\nnameserver ::1\n' > /run/mvm/resolv.conf
       /bin/busybox chmod 0644 /run/mvm/resolv.conf
       /bin/busybox mount --bind /run/mvm/resolv.conf /etc/resolv.conf
 
@@ -712,7 +712,7 @@ let
       # On libkrun this just swaps a blocking console read for an explicit
       # idle — same "stay alive", no change to the agent shell path. A
       # busybox-portable loop avoids depending on `sleep infinity`.
-      while:; do /bin/busybox sleep 2147483647; done
+      while :; do /bin/busybox sleep 2147483647; done
     fi
 
     # Stage 4.5 — mvm runtime overlay env.
@@ -1221,7 +1221,7 @@ let
     storePaths = [ rootfsTree ];
     volumeLabel = "mvm-${name}";
     populateImageCommands = ''
-      cp -a --reflink=auto ${rootfsTree}/../files/
+      cp -a --reflink=auto ${rootfsTree}/. ./files/
     '';
   };
 

--- a/specs/adrs/101-in-house-vmm-unified-egress-substitution-gateway.md
+++ b/specs/adrs/101-in-house-vmm-unified-egress-substitution-gateway.md
@@ -48,47 +48,61 @@ the same capability without regressing the claim-10 it already has.
 ## Decision
 
 **On the in-house VMM, `EGRESS_PORT` (5253) carries exactly one protocol — the
-WireRequest substitution protocol — and exactly one enforcer: the per-VM
-`mvm-substitution-endpoint`, which decides claims 10, 12, and 13 for every request.**
+WireRequest substitution protocol — through one host gateway (the per-VM
+`SubstitutionBridge`) that pipelines two enforcement stages on every request:
+claim-10 at the bridge (the existing egress gate) and claims 12/13 at the per-VM
+`mvm-substitution-endpoint`.**
 
-1. **One protocol on the wire.** 5253 speaks WireRequest only. This is what the
-   guest's sole egress client already sends and what Vz already terminates, so the
-   guest image stays backend-agnostic. The raw-`"ip:port"` `EgressProxy` protocol
-   is spoken by no guest; it is **retired from the workload egress path** (the
-   examples that drove it directly are reframed as device/relay tests, not a guest
-   transport). There is no first-frame peek and therefore no protocol-confusion
-   surface.
+1. **One protocol per route, chosen at configuration time — never by peeking the
+   wire.** For a secret-bearing workload (a substitution endpoint is configured)
+   5253 routes to the `SubstitutionBridge` and speaks WireRequest only — what the
+   guest's sole egress client sends and what Vz terminates, so the guest image stays
+   backend-agnostic. For a workload with no endpoint, 5253 keeps the legacy raw-
+   `"ip:port"` `EgressProxy` route. The device picks the route from VM configuration
+   (is an endpoint wired?), not from inspecting guest bytes — so there is no
+   protocol-confusion surface between the two. The bridge does parse the first frame
+   of its own protocol, but only to make the claim-10 decision; it never has to
+   guess *which* protocol a stream is.
 
-2. **A dumb host relay.** A per-VM `SubstitutionBridge` in `vmm/` bridges each
-   guest→host 5253 vsock stream to the per-VM endpoint's Unix socket, mirroring
-   `AgentBridge`/`EgressProxy` (transport-agnostic, keyed by the guest `src_port`,
-   speaks raw bytes). It parses nothing and enforces nothing — it moves bytes
-   between the device and the endpoint UDS. This reuses the
-   `EndpointTransport::Uds { path }` channel the libkrun/vz backends already use,
-   so the endpoint binary is unchanged on its listener side.
+2. **A per-VM `SubstitutionBridge` in `vmm/` is the host gateway.** It bridges each
+   guest→host 5253 vsock stream to the per-VM endpoint's Unix socket, keyed by the
+   guest `src_port`, reusing the `EndpointTransport::Uds { path }` channel the
+   libkrun/vz backends already use (so the endpoint binary is unchanged). It is
+   **frame-aware for exactly one decision**: it buffers the first WireRequest frame,
+   extracts the destination host:port from its `url`, and makes the claim-10
+   allow/deny call (below) *before* opening the endpoint — then becomes a plain byte
+   relay for the rest of the connection.
 
-3. **All enforcement folds into the one endpoint** (option *b*, not multiplexing):
-   - **Claim 13** — raw secret never crosses; the guest holds only `mvm-secret-<hex>`
-     placeholders (unchanged endpoint behavior).
-   - **Claim 12** — per-secret destination binding; an unbound destination →
-     `WireResponse::Refused`, no upstream connection (unchanged).
-   - **Claim 10** — the signed plan's network policy is added to `EndpointConfig`;
-     the endpoint refuses any destination the policy does not admit (default-deny)
-     **before** binding/forwarding. This is the new enforcement this ADR mandates,
-     and it is *essential, not deferrable*: routing WireRequests to an endpoint
-     that did not gate the destination would let a placeholder-free request reach
-     any host — a claim-10 regression. One process now owns the whole egress
-     decision.
+3. **Enforcement is a two-stage pipeline on the one stream** — both stages run for
+   every request, so there is no protocol-confusion surface and no place to smuggle
+   traffic past a gate:
+   - **Claim 10 — at the bridge.** The bridge decides the destination against the
+     *same* `EgressGate` the device's raw-egress path uses (`vmm/egress_gate.rs`,
+     default-deny, DNS-pin host resolution). An unadmitted destination is refused
+     *before the endpoint is contacted* — check-then-relay, never relay-then-check
+     (which would leak bytes past the gate). This keeps claim-10 where the in-house
+     VMM already enforces it (the egress gate) and keeps the secrets moat focused on
+     secrets. **Why not in the endpoint:** folding the network policy into the
+     shared `mvm-substitution-endpoint` would change the moat that *every* backend
+     (Firecracker/libkrun/vz) spawns and force-touch all four spawn call sites for a
+     gate the in-house VMM already owns. Enforcing at the bridge is HVF-local — zero
+     shared-code change — and reuses the existing gate.
+   - **Claims 12/13 — at the endpoint** (unchanged). Once admitted, the stream is
+     relayed to the per-VM `mvm-substitution-endpoint`, which binding-checks the
+     secret (claim 12 — unbound → `WireResponse::Refused`, no upstream) and never
+     lets a raw secret cross (claim 13 — the guest holds only `mvm-secret-<hex>`).
 
 4. **Lifecycle.** The endpoint is spawned/reaped through the existing shared moat
    (`substitution_spawn::{spawn_substitution_endpoint, reap_substitution_endpoint}`,
    `EndpointTransport::Uds`), called from `HvfBackend::{start,stop}` exactly as
-   `VzBackend` calls it. It is spawned whenever the admitted plan permits egress
-   (secret bindings present, or a network policy that admits any host). A pure
-   default-deny / no-egress workload spawns no endpoint; the bridge's connect to
-   the absent UDS then fails closed (no egress), which is the correct default-deny
-   outcome. The decrypted-secret process never outlives a failed launch
-   (`EndpointGuard`) or the guest (reap-before-not-running, as on Vz).
+   `VzBackend` calls it — unchanged: spawned when the admitted plan carries secret
+   bindings, reaped before the not-running check on stop. The decrypted-secret
+   process never outlives a failed launch (`EndpointGuard`) or the guest. The bridge
+   is wired (endpoint socket + claim-10 gate) only when that endpoint exists; a
+   secret-free workload keeps the legacy raw-egress path. Note this means a
+   *no-secret but allow-listed* workload still egresses over the legacy path, not
+   the WireRequest gateway — the same scope Vz has today; widening the bridge to all
+   egress is a later step, not required to carry secret-bearing workloads.
 
 5. **`HvfBackend` declares `EgressSubstitutionTransport::VsockUdsChannel`** and
    `backend.rs::as_workload_backend` returns `Some` for `Hvf` — but only **after**
@@ -108,23 +122,32 @@ WireRequest substitution protocol — and exactly one enforcer: the per-VM
   contract, and forks egress policy across two enforcers (the claim-10 gate would
   not see substitution traffic, and vice-versa) — the same split-brain risk as (a),
   just statically partitioned.
-- **(b) One protocol, one enforcer** is the only option with no shape-guess and no
-  split enforcement: every byte of guest egress is a WireRequest, decided in one
-  process that holds claim-10, claim-12, and claim-13 together. It also matches Vz
-  (`VsockUdsChannel`) and the guest contract verbatim, so the guest image and the
-  `WorkloadBackend` seam need no per-backend special-casing.
+- **(b) One protocol, one gateway, a two-stage pipeline** is the chosen option: a
+  secret-bearing stream is WireRequest only, through one host gateway that runs
+  claim-10 (bridge) then claims 12/13 (endpoint) in sequence — no shape-guess, no
+  split-by-protocol. It matches Vz (`VsockUdsChannel`) and the guest contract, so
+  the guest image and the `WorkloadBackend` seam need no per-backend special-casing.
+  Claim-10 lives at the **bridge** rather than inside the endpoint deliberately:
+  folding the network policy into the shared `mvm-substitution-endpoint` would
+  change the secrets moat that Firecracker/libkrun/vz all spawn and force-touch
+  every spawn call site, to enforce a decision the in-house VMM's egress gate
+  already makes. Bridge-side claim-10 is HVF-local (zero shared-code change) and a
+  true pipeline (both stages run on every request), so it is not the split-brain of
+  (a)/(c) — there is exactly one route a secret-bearing stream can take, and it
+  passes both gates.
 
 ## Consequences
 
 - The in-house VMM gains secret-bearing workload support and HVF can retire Vz
   (Plan 214) once verified.
-- `EgressProxy`'s raw-`"ip:port"` role on the workload path is superseded. Its core
-  (`vmm/egress_proxy.rs`) and the `EgressGate` (`vmm/egress_gate.rs`) are not
-  deleted in this step — claim-10 policy construction is reused by the endpoint —
-  but the device no longer routes 5253 OP_RW to it for a workload guest.
-- The endpoint subprocess is now an egress dependency for *any* admitted egress,
-  not only secret-bearing egress. The fail-closed-on-absent-UDS property keeps a
-  spawn failure safe.
+- `EgressProxy` (`vmm/egress_proxy.rs`) stays the route for a no-endpoint workload;
+  for a secret-bearing one, 5253 routes to the bridge instead. The `EgressGate`
+  (`vmm/egress_gate.rs`) is shared by both routes — the device hands a clone to the
+  bridge so claim-10 is one rule set whichever route a stream takes.
+- The shared `mvm-substitution-endpoint` and its spawn path are **unchanged** by
+  this ADR (no `network_policy` field, no touched call sites) — claim-10 is added
+  at the HVF bridge, not the moat. The endpoint remains spawned only for a
+  secret-bearing plan.
 - Non-HTTP raw-TCP egress is **out of scope**: the WireRequest gateway is HTTP(S)
   absolute-form only, matching Vz's capability. The in-house VMM never carried a
   guest raw-TCP egress client, so nothing regresses. If a future workload needs

--- a/specs/adrs/101-in-house-vmm-unified-egress-substitution-gateway.md
+++ b/specs/adrs/101-in-house-vmm-unified-egress-substitution-gateway.md
@@ -1,0 +1,139 @@
+# ADR-101 — In-house VMM: one unified vsock egress gateway (claims 10/12/13 in one endpoint)
+
+**Status:** Accepted (2026-06-30)
+**Relates to:** [ADR-100](100-vsock-sole-guest-world-channel.md) (vsock is the sole
+guest↔world channel — this ADR is the concrete in-house realization of its "single
+host gateway"), [ADR-049](049-vsock-substitution-service.md) (vsock substitution),
+[ADR-059](059-host-services-broker.md) (claims 12/13), [ADR-082](082-rust-native-egress-gateway.md)
+(the gateway seam), [ADR-083](083-workload-backend-type-bar.md) (`WorkloadBackend`),
+[ADR-002](002-microvm-security-posture.md) (claim 10), [Plan 214](../plans/214-clean-replacement-architecture.md).
+
+## Context
+
+ADR-100 made it a backend-wide invariant that a workload guest's only channel off
+the guest is vsock, and that all egress flows through "a single host gateway that
+enforces the signed `ExecutionPlan`'s network policy ... fed by the substitution
+service." That ADR fixed the *principle*. It did not pin down how the in-house VMM
+(HVF/KVM — `crates/mvm-backend/src/{vmm,hvf,kvm}`) realizes it concretely, and the
+in-house path arrived at that principle from two directions that had not yet been
+joined:
+
+- **Raw-TCP egress (claim 10).** `vmm/egress_proxy.rs` (`EgressProxy`) treats the
+  first frame on a `EGRESS_PORT` (5253) stream as a connect target `"ip:port"`,
+  decides it against the claim-10 `EgressGate` (default-deny), then proxies raw
+  bytes. This is the path the in-house VMM's claim-10 milestone proved (the
+  `kvm-backend-egress` / `hvf-backend-egress` examples drive it directly).
+- **Substitution (claims 12/13).** The guest's *only* egress client —
+  `mvm-guest`'s forward-proxy (`forward_proxy.rs` → `substitution_client.rs`) —
+  dials `EGRESS_PORT` and speaks the **WireRequest** protocol (4-byte BE length +
+  JSON; `mvm_core::substitution_wire`). The host terminates TLS and injects the
+  bound credential. The endpoint (`mvm-substitution-endpoint`) enforces the
+  per-secret binding (claim 12) and never lets a raw secret cross (claim 13).
+
+These two collide on one port. `EgressProxy` reads the WireRequest's length prefix
+as a malformed `"ip:port"` and resets the stream — which is exactly why
+secret-bearing (and in fact *all* forward-proxy) egress does not work on the
+in-house VMM today. A guest contract for the resolution is already written
+(`crates/mvm-guest/src/vsock.rs` `EGRESS_PORT`): 5253 is "the single host-mediated
+egress chokepoint ... the host's per-VM gateway makes the claim-10 allow/deny
+decision and proxies the flow, and for a bound-secret destination performs the
+claims-12/13 credential substitution — **a behavior of this one gateway, not a
+separate channel**." This ADR makes the host side match that contract.
+
+The trigger is Plan 214: HVF must carry secret-bearing workloads (claims 12/13) to
+retire Vz. Vz carries them over `EgressSubstitutionTransport::VsockUdsChannel` (the
+supervisor splices a guest 5253 dial to the per-VM endpoint UDS). HVF must reach
+the same capability without regressing the claim-10 it already has.
+
+## Decision
+
+**On the in-house VMM, `EGRESS_PORT` (5253) carries exactly one protocol — the
+WireRequest substitution protocol — and exactly one enforcer: the per-VM
+`mvm-substitution-endpoint`, which decides claims 10, 12, and 13 for every request.**
+
+1. **One protocol on the wire.** 5253 speaks WireRequest only. This is what the
+   guest's sole egress client already sends and what Vz already terminates, so the
+   guest image stays backend-agnostic. The raw-`"ip:port"` `EgressProxy` protocol
+   is spoken by no guest; it is **retired from the workload egress path** (the
+   examples that drove it directly are reframed as device/relay tests, not a guest
+   transport). There is no first-frame peek and therefore no protocol-confusion
+   surface.
+
+2. **A dumb host relay.** A per-VM `SubstitutionBridge` in `vmm/` bridges each
+   guest→host 5253 vsock stream to the per-VM endpoint's Unix socket, mirroring
+   `AgentBridge`/`EgressProxy` (transport-agnostic, keyed by the guest `src_port`,
+   speaks raw bytes). It parses nothing and enforces nothing — it moves bytes
+   between the device and the endpoint UDS. This reuses the
+   `EndpointTransport::Uds { path }` channel the libkrun/vz backends already use,
+   so the endpoint binary is unchanged on its listener side.
+
+3. **All enforcement folds into the one endpoint** (option *b*, not multiplexing):
+   - **Claim 13** — raw secret never crosses; the guest holds only `mvm-secret-<hex>`
+     placeholders (unchanged endpoint behavior).
+   - **Claim 12** — per-secret destination binding; an unbound destination →
+     `WireResponse::Refused`, no upstream connection (unchanged).
+   - **Claim 10** — the signed plan's network policy is added to `EndpointConfig`;
+     the endpoint refuses any destination the policy does not admit (default-deny)
+     **before** binding/forwarding. This is the new enforcement this ADR mandates,
+     and it is *essential, not deferrable*: routing WireRequests to an endpoint
+     that did not gate the destination would let a placeholder-free request reach
+     any host — a claim-10 regression. One process now owns the whole egress
+     decision.
+
+4. **Lifecycle.** The endpoint is spawned/reaped through the existing shared moat
+   (`substitution_spawn::{spawn_substitution_endpoint, reap_substitution_endpoint}`,
+   `EndpointTransport::Uds`), called from `HvfBackend::{start,stop}` exactly as
+   `VzBackend` calls it. It is spawned whenever the admitted plan permits egress
+   (secret bindings present, or a network policy that admits any host). A pure
+   default-deny / no-egress workload spawns no endpoint; the bridge's connect to
+   the absent UDS then fails closed (no egress), which is the correct default-deny
+   outcome. The decrypted-secret process never outlives a failed launch
+   (`EndpointGuard`) or the guest (reap-before-not-running, as on Vz).
+
+5. **`HvfBackend` declares `EgressSubstitutionTransport::VsockUdsChannel`** and
+   `backend.rs::as_workload_backend` returns `Some` for `Hvf` — but only **after**
+   the path above is built and adversarially verified live (claims 12/13 + the
+   protocol-confusion failure modes). Declaring the transport or flipping the gate
+   on an unverified path would be a false security claim.
+
+## Why option (b), not (a) multiplex or (c) two ports
+
+- **(a) Multiplex 5253 by peeking the first frame** (raw `"ip:port"` vs. a JSON
+  length prefix) puts a heuristic at the security boundary. The two protocols feed
+  *different enforcers* (raw-TCP → claim-10 only; WireRequest → claim-12/13), so a
+  guest that steers a stream to the weaker enforcer for a given destination is a
+  bypass primitive. A byte-shape guess is precisely the confusion surface to avoid.
+- **(c) Put substitution on a second vsock port**, leaving `EgressProxy` on 5253,
+  contradicts ADR-100's single-chokepoint invariant and the already-written guest
+  contract, and forks egress policy across two enforcers (the claim-10 gate would
+  not see substitution traffic, and vice-versa) — the same split-brain risk as (a),
+  just statically partitioned.
+- **(b) One protocol, one enforcer** is the only option with no shape-guess and no
+  split enforcement: every byte of guest egress is a WireRequest, decided in one
+  process that holds claim-10, claim-12, and claim-13 together. It also matches Vz
+  (`VsockUdsChannel`) and the guest contract verbatim, so the guest image and the
+  `WorkloadBackend` seam need no per-backend special-casing.
+
+## Consequences
+
+- The in-house VMM gains secret-bearing workload support and HVF can retire Vz
+  (Plan 214) once verified.
+- `EgressProxy`'s raw-`"ip:port"` role on the workload path is superseded. Its core
+  (`vmm/egress_proxy.rs`) and the `EgressGate` (`vmm/egress_gate.rs`) are not
+  deleted in this step — claim-10 policy construction is reused by the endpoint —
+  but the device no longer routes 5253 OP_RW to it for a workload guest.
+- The endpoint subprocess is now an egress dependency for *any* admitted egress,
+  not only secret-bearing egress. The fail-closed-on-absent-UDS property keeps a
+  spawn failure safe.
+- Non-HTTP raw-TCP egress is **out of scope**: the WireRequest gateway is HTTP(S)
+  absolute-form only, matching Vz's capability. The in-house VMM never carried a
+  guest raw-TCP egress client, so nothing regresses. If a future workload needs
+  raw-TCP egress it is a separate ADR (a CONNECT-style verb within the same
+  endpoint, still one enforcer).
+
+## Out of scope (same threat model, deferred)
+
+- Productionizing the per-VM **agent** socket off the `MVM_HVF_AGENT_SOCKET` env
+  hook onto a supervisor-config per-VM path (Plan 214 follow-up; orthogonal to
+  egress enforcement, tracked alongside the gate flip).
+- Auto-selecting HVF on macOS 26+ and deleting the Vz backend (Plan 214 endgame).

--- a/xtask/src/check_closure_budget.rs
+++ b/xtask/src/check_closure_budget.rs
@@ -22,9 +22,10 @@ const BUDGET_TARGET: &str = "x86_64-unknown-linux-gnu";
 
 /// Max distinct crates allowed in `mvmctl`'s default no-dev closure on
 /// [`BUDGET_TARGET`]. Baseline measured 2026-06-17 against the audited default
-/// closure. Lower it freely as deps drop; raising it must be justified in the
-/// PR that does.
-const CLOSURE_BUDGET: usize = 335;
+/// closure. The Linux KVM backend adds one audited ioctl-wrapper crate to the
+/// default Linux release path. Lower it freely as deps drop; raising it must be
+/// justified in the change that does.
+const CLOSURE_BUDGET: usize = 336;
 
 pub fn run(workspace: &Path) -> Result<()> {
     let count = default_closure_crate_count(workspace)?;


### PR DESCRIPTION
**Top of the stack: #1375 (C2) → #1374 (C1) → #1373 (B) → #1372 (A).** Review/merge A→C2 first. 8 commits. Completes the in-house VMM decomposition of #1362.

Folds substitution into the single vsock egress gateway, so one host endpoint carries claim-10 (the gate), claims 12/13 (destination-bound credential substitution) — no NIC, one chokepoint:

- **ADR-101** — the unified vsock egress+substitution gateway design for the in-house VMM.
- **substitution bridge** — routes the guest's `EGRESS_PORT` stream to the per-VM substitution endpoint (claims 12/13) when a flow targets a bound secret, and enforces **claim-10 at the bridge** (default-deny gate before contacting the endpoint) — the HVF-local claim-10 enforcement point.
- **spawn/reap the per-VM substitution endpoint** + thread its sockets via the supervisor config.
- `fix(cli)`: persist `plan.json` before start for the hvf backend; `fix(mkguest)` spacing; xtask closure-budget ratchet for the KVM backend.

## Tests
`cargo nextest run -p mvm-backend` → 451/451 pass; `check-vsock-only-egress` clean (20 files NIC-free). `fmt --all --check` + `clippy -p mvm-backend -p mvm-vm-host -D warnings` clean.

Once A→D land, the whole-spike blob **#1362 can be closed** — its contents are covered by A→D (in-house VMM) + #1371 (E, builder transfer) + #1370 (F, libkrun selector) + #1368 (S0 seam).