### PR TITLE
feat(backend): HvfBackend opt-in relay egress path (Plan 214 P2.3)

### DIFF
--- a/crates/mvm-backend/examples/hvf-backend-relay-egress.rs
+++ b/crates/mvm-backend/examples/hvf-backend-relay-egress.rs
@@ -1,0 +1,204 @@
+//! Live proof that claim-10 egress is enforced through the *production*
+//! `HvfBackend` when it is routed onto the relay path (`MVM_HVF_EGRESS_RELAY=1`):
+//! the backend spawns the per-VM `mvm-substitution-endpoint` itself, threads its
+//! UDS into the guest's `EGRESS_PORT`, and boots via `InHouseDriver`. The run
+//! loop is a pure relay; the endpoint gates.
+//!
+//! Sibling to `hvf-relay-egress`, but entered through `HvfBackend::start` (not
+//! the driver directly) so it exercises the real backend routing + the
+//! `RealEndpointSpawner`, not a hand-wired harness. Runs twice against a
+//! discovered LAN echo server: once with a policy that admits it (reply expected)
+//! and once with a policy that admits only a different port (reply refused). Both
+//! verdicts must hold.
+//!
+//! macOS / Apple silicon. Build the per-VM aux bins and echo guest first:
+//! ```sh
+//! cargo build -p mvm-vm-host --bin mvm-hvf-supervisor
+//! cargo build -p mvm-hostd --bin mvm-substitution-endpoint
+//! OUT=/tmp/hvf-egress-guest bash crates/mvm-backend/examples/hvf-egress-guest/build.sh
+//! MVM_HVF_SUPERVISOR_PATH=target/debug/mvm-hvf-supervisor \
+//!   MVM_SUBSTITUTION_ENDPOINT_PATH=target/debug/mvm-substitution-endpoint \
+//!   MVM_HVF_KERNEL=/tmp/mvm-hvf-kernel/Image-builder \
+//!   MVM_HVF_INITRD=/tmp/hvf-egress-guest/initramfs.cpio \
+//!   cargo run -p mvm-backend --example hvf-backend-relay-egress
+//! ```
+
+#[cfg(all(target_os = "macos", target_arch = "aarch64"))]
+fn discover_lan_ipv4() -> Option<std::net::Ipv4Addr> {
+    use std::net::Ipv4Addr;
+    // SAFETY: standard getifaddrs walk; every pointer is null-checked and the list
+    // is freed before return.
+    unsafe {
+        let mut ifap: *mut libc::ifaddrs = std::ptr::null_mut();
+        if libc::getifaddrs(&mut ifap) != 0 {
+            return None;
+        }
+        let mut found = None;
+        let mut cur = ifap;
+        while !cur.is_null() {
+            let ifa = &*cur;
+            if !ifa.ifa_addr.is_null() && (*ifa.ifa_addr).sa_family as i32 == libc::AF_INET {
+                let sin = ifa.ifa_addr as *const libc::sockaddr_in;
+                let o = (*sin).sin_addr.s_addr.to_ne_bytes();
+                let ip = Ipv4Addr::new(o[0], o[1], o[2], o[3]);
+                if ip.is_private() && !ip.is_loopback() && !ip.is_link_local() {
+                    found = Some(ip);
+                    break;
+                }
+            }
+            cur = ifa.ifa_next;
+        }
+        libc::freeifaddrs(ifap);
+        found
+    }
+}
+
+#[cfg(all(target_os = "macos", target_arch = "aarch64"))]
+fn main() {
+    use std::net::TcpListener;
+    use std::time::{Duration, Instant};
+
+    use mvm_backend::hvf_backend::HvfBackend;
+    use mvm_core::config::vm_state_dir;
+    use mvm_core::policy::network_policy::{HostPort, NetworkPolicy};
+    use mvm_core::vm_backend::{VmBackend, VmStartConfig, VmStatus};
+
+    // Route the production backend onto the relay egress path for the whole run.
+    // SAFETY: single-threaded example setup.
+    unsafe { std::env::set_var("MVM_HVF_EGRESS_RELAY", "1") };
+
+    // One run: bind a LAN echo server, gate it with `policy`, start the guest
+    // through HvfBackend with its egress relayed to the endpoint, and report
+    // whether the guest received the proxied echo. `name` must be unique per run.
+    fn run_once(
+        name: &str,
+        kernel: &str,
+        initramfs: &str,
+        lan: std::net::Ipv4Addr,
+        policy_for: impl Fn(u16) -> NetworkPolicy,
+    ) -> (bool, String) {
+        use std::io::{Read as _, Write as _};
+
+        let listener = TcpListener::bind((lan, 0)).expect("bind echo server");
+        listener
+            .set_nonblocking(true)
+            .expect("nonblocking echo listener");
+        let addr = listener.local_addr().expect("echo local_addr");
+        // Self-terminating: a refused run never connects, so accept must not block
+        // forever — poll with a deadline, echo once if a connection lands.
+        let echo = std::thread::spawn(move || {
+            let deadline = Instant::now() + Duration::from_secs(12);
+            while Instant::now() < deadline {
+                match listener.accept() {
+                    Ok((mut c, _)) => {
+                        c.set_nonblocking(false).ok();
+                        let mut buf = [0u8; 64];
+                        if let Ok(n) = c.read(&mut buf) {
+                            let _ = c.write_all(&buf[..n]);
+                        }
+                        return;
+                    }
+                    Err(e) if e.kind() == std::io::ErrorKind::WouldBlock => {
+                        std::thread::sleep(Duration::from_millis(50))
+                    }
+                    Err(_) => return,
+                }
+            }
+        });
+
+        let state_dir = vm_state_dir(name);
+        let _ = std::fs::create_dir_all(&state_dir);
+        // No admitted plan on disk → the relay path takes the raw egress branch and
+        // gates on the config's network_policy. Drop any stale plan from a prior run.
+        let _ = std::fs::remove_file(state_dir.join("plan.json"));
+
+        // The guest reads its target from the cmdline; bound the run and end it via
+        // the workload-exit report (or the timeout backstop for the refused case).
+        // SAFETY: single-threaded example setup.
+        unsafe {
+            std::env::set_var("MVM_HVF_KERNEL", kernel);
+            std::env::set_var("MVM_HVF_INITRD", initramfs);
+            std::env::set_var(
+                "MVM_HVF_BOOTARGS_EXTRA",
+                format!("mvm.egress_target={}:{}", addr.ip(), addr.port()),
+            );
+            std::env::set_var("MVM_HVF_TIMEOUT", "8");
+        }
+
+        // Initramfs-only echo guest: no rootfs (rootfs_path empty). The backend
+        // spawns the gating endpoint itself and relays EGRESS_PORT to it.
+        let config = VmStartConfig {
+            name: name.to_string(),
+            rootfs_path: String::new(),
+            kernel_path: Some(kernel.to_string()),
+            initrd_path: Some(initramfs.to_string()),
+            cpus: 1,
+            memory_mib: 512,
+            network_policy: policy_for(addr.port()),
+            ..Default::default()
+        };
+
+        let backend = HvfBackend;
+        let id = backend
+            .start(&config)
+            .expect("HvfBackend::start (relay) boots");
+        for _ in 0..150 {
+            if backend.status(&id).unwrap() == VmStatus::Stopped {
+                break;
+            }
+            std::thread::sleep(Duration::from_millis(100));
+        }
+        let _ = echo.join();
+        // Reap the supervisor + the endpoint (stop owns endpoint teardown).
+        let _ = backend.stop(&id);
+
+        let console = std::fs::read_to_string(state_dir.join("console.log")).unwrap_or_default();
+        let reachable = console.contains("egress reply over vsock: ping");
+        (reachable, console)
+    }
+
+    let lan = discover_lan_ipv4().expect(
+        "no private non-loopback IPv4 interface — this proof needs a routable LAN address \
+         (loopback is mandatory-deny by design)",
+    );
+    let kernel = std::env::var("MVM_HVF_KERNEL")
+        .unwrap_or_else(|_| "/tmp/mvm-hvf-kernel/Image-builder".into());
+    let initramfs = std::env::var("MVM_HVF_INITRD")
+        .unwrap_or_else(|_| "/tmp/hvf-egress-guest/initramfs.cpio".into());
+
+    // Admit run: the policy admits exactly the echo destination → reachable.
+    let (admit_ok, admit_console) = run_once(
+        "hvf-backend-relay-admit",
+        &kernel,
+        &initramfs,
+        lan,
+        |port| NetworkPolicy::allow_list(vec![HostPort::new(lan.to_string(), port)]),
+    );
+    // Deny run: the policy admits only a DIFFERENT port, so the real target is not
+    // admitted → refused. Proves the endpoint gate discriminates by policy.
+    let (deny_reachable, deny_console) =
+        run_once("hvf-backend-relay-deny", &kernel, &initramfs, lan, |port| {
+            NetworkPolicy::allow_list(vec![HostPort::new(lan.to_string(), port.wrapping_add(1))])
+        });
+
+    println!("admitted destination reachable: {admit_ok}");
+    println!("non-admitted destination reachable: {deny_reachable}");
+
+    if admit_ok && !deny_reachable {
+        println!(
+            "PROOF: routed through the production HvfBackend relay path, the in-house VMM guest \
+             reached the admitted LAN destination over vsock and was refused the non-admitted \
+             one — the host endpoint enforces claim-10, no guest NIC, no in-loop gate."
+        );
+    } else {
+        eprintln!("FAILED: admit_ok={admit_ok} deny_reachable={deny_reachable}");
+        eprintln!("--- admit console ---\n{admit_console}");
+        eprintln!("--- deny console ---\n{deny_console}");
+        std::process::exit(1);
+    }
+}
+
+#[cfg(not(all(target_os = "macos", target_arch = "aarch64")))]
+fn main() {
+    println!("hvf-backend-relay-egress: only on macOS / Apple silicon");
+}

--- a/crates/mvm-backend/src/hvf_backend.rs
+++ b/crates/mvm-backend/src/hvf_backend.rs
@@ -22,11 +22,28 @@ use std::time::{Duration, Instant};
 use anyhow::{Context, Result, anyhow, bail};
 use mvm_build::hvf_supervisor::HvfSupervisorConfig;
 use mvm_core::config::{mvm_data_dir, vm_state_dir};
+use mvm_core::plan::SecretBinding;
+use mvm_core::policy::RedactionPolicy;
+use mvm_core::policy::network_policy::NetworkPolicy;
 use mvm_core::vm_backend::{
     VmBackend, VmCapabilities, VmExitStatus, VmId, VmInfo, VmStartConfig, VmStatus,
 };
 
 use crate::base::ui;
+use crate::driver::InHouseDriver;
+use crate::workload_runner::{RealEndpointSpawner, WorkloadLaunchInputs, WorkloadRunner};
+
+/// Env flag opting `HvfBackend::start` onto the relay egress path — routing the
+/// workload through `WorkloadRunner<InHouseDriver>` and the host-side gating
+/// endpoint instead of the legacy in-loop supervisor gate. Off by default: the
+/// relay's WireRequest path is not yet live-proven, so legacy stays the default
+/// until that proof lands and the default flips.
+const RELAY_EGRESS_ENV: &str = "MVM_HVF_EGRESS_RELAY";
+
+/// Default tenant stamped on a relay endpoint for a secret-free plan that carries
+/// no tenant of its own. The relay path always spawns a gating endpoint (the sole
+/// egress gate), so it always needs a tenant even when the plan has no secrets.
+const RELAY_DEFAULT_TENANT: &str = "local";
 
 /// PID file the supervisor writes inside `vm_state_dir`. Distinct from the other
 /// backends' markers so HVF VMs coexist under the same `~/.mvm/vms/` root.
@@ -99,6 +116,56 @@ fn vms_root() -> PathBuf {
     PathBuf::from(mvm_data_dir()).join("vms")
 }
 
+/// The egress inputs the relay path resolves from an admitted `VmStartConfig`
+/// and its persisted plan: the claim-10 policy the endpoint gates against plus
+/// the tenant/secrets/redaction the substitution endpoint needs. Owned so the
+/// borrow the `WorkloadRunner` takes is straightforward.
+struct RelayEgressInputs {
+    tenant: String,
+    secrets: Vec<SecretBinding>,
+    redaction: RedactionPolicy,
+    network_policy: NetworkPolicy,
+}
+
+/// Resolve the relay egress inputs. A plan carrying egress secrets (`decoded`
+/// `Some`) contributes its secret bindings, redaction, and tenant (the tenant the
+/// plan was admitted under). A secret-free plan (`None`) is the raw path — no
+/// secrets, default redaction, tenant from the config (else [`RELAY_DEFAULT_TENANT`]).
+/// Either way the endpoint gates against the admitted config's `network_policy`.
+fn resolve_relay_egress_inputs(
+    config: &VmStartConfig,
+    decoded: Option<(Vec<SecretBinding>, RedactionPolicy, String)>,
+) -> RelayEgressInputs {
+    let network_policy = config.network_policy.clone();
+    match decoded {
+        Some((secrets, redaction, tenant)) => RelayEgressInputs {
+            tenant,
+            secrets,
+            redaction,
+            network_policy,
+        },
+        None => RelayEgressInputs {
+            tenant: config
+                .tenant_id
+                .clone()
+                .unwrap_or_else(|| RELAY_DEFAULT_TENANT.to_string()),
+            secrets: Vec::new(),
+            redaction: RedactionPolicy::default(),
+            network_policy,
+        },
+    }
+}
+
+/// Whether the relay egress path is opt-in-enabled. Pure over the raw env value
+/// so it is testable without touching the process environment: truthy is `1` or
+/// `true` (case-insensitive); anything else — including unset — is off.
+fn relay_egress_enabled_from(v: Option<&str>) -> bool {
+    matches!(
+        v.map(|s| s.trim().to_ascii_lowercase()).as_deref(),
+        Some("1" | "true")
+    )
+}
+
 /// Spawn the per-VM substitution endpoint when the admitted plan carries egress
 /// secrets, returning an armed `EndpointGuard` and the endpoint socket
 /// path to hand the supervisor; a secret-free plan (or no `plan.json`) yields a
@@ -139,6 +206,55 @@ fn spawn_hvf_egress_endpoint_if_needed(
     Ok((EndpointGuard::new(vm_name), Some(socket)))
 }
 
+impl HvfBackend {
+    /// The relay egress path (opt-in via [`RELAY_EGRESS_ENV`]): route the workload
+    /// through `WorkloadRunner<InHouseDriver>` so the host-side gating endpoint is
+    /// the sole path off the box — claim 10 enforced at the endpoint, the run loop
+    /// a pure relay — replacing the legacy in-loop supervisor gate. The
+    /// `InHouseDriver` writes the same `hvf.pid` / `console.log` / `workload.exit`
+    /// under the VM state dir that `stop`/`status`/`wait`/`list` read, so the rest
+    /// of the lifecycle is unchanged. Fail-closed: if the runner errors after
+    /// spawning the endpoint, reap it so a decrypted-secret process can't outlive
+    /// a failed launch.
+    fn start_via_relay(&self, config: &VmStartConfig) -> Result<VmId> {
+        let state_dir = vm_state_dir(&config.name);
+        std::fs::create_dir_all(&state_dir)
+            .with_context(|| format!("create state dir {}", state_dir.display()))?;
+
+        let decoded = crate::egress_shared::decode_plan_secrets_from_state(&state_dir)?;
+        let egress = resolve_relay_egress_inputs(config, decoded);
+
+        let runner = WorkloadRunner::new(InHouseDriver::new(), RealEndpointSpawner);
+        // The in-house driver assembles the kernel cmdline inside the supervisor,
+        // so the spec cmdline is unused on this path — pass empty.
+        let inputs = WorkloadLaunchInputs {
+            config,
+            tenant: &egress.tenant,
+            secrets: &egress.secrets,
+            redaction: &egress.redaction,
+            network_policy: &egress.network_policy,
+            cmdline: String::new(),
+        };
+
+        ui::info(&format!(
+            "Starting HVF VM '{}' via the relay egress path...",
+            config.name
+        ));
+        match runner.start_workload(&inputs) {
+            Ok(_vm) => {
+                // Detached: the supervisor lives on via its PID file; dropping the
+                // handle does not kill it (InHouseRunningVm has no Drop).
+                ui::success(&format!("HVF VM '{}' started (relay egress).", config.name));
+                Ok(VmId(config.name.clone()))
+            }
+            Err(e) => {
+                crate::substitution_spawn::reap_substitution_endpoint(&state_dir, &config.name);
+                Err(e)
+            }
+        }
+    }
+}
+
 impl VmBackend for HvfBackend {
     fn name(&self) -> &str {
         "hvf"
@@ -158,6 +274,12 @@ impl VmBackend for HvfBackend {
     }
 
     fn start(&self, config: &VmStartConfig) -> Result<VmId> {
+        // Opt-in relay egress path routes through WorkloadRunner + the gating
+        // endpoint; the default stays the legacy in-loop gate until the relay's
+        // WireRequest path is live-proven and the default flips.
+        if relay_egress_enabled_from(std::env::var(RELAY_EGRESS_ENV).ok().as_deref()) {
+            return self.start_via_relay(config);
+        }
         // No parent-entitlement gate here: the detached supervisor self-signs the
         // hypervisor entitlement and does the HVF work. The parent (CLI) only
         // spawns it, so it needn't be entitled. (`is_available` still probes for
@@ -453,6 +575,76 @@ mod tests {
             "no endpoint process for a secret-free plan"
         );
         drop(guard); // defused → Drop reaps nothing
+    }
+
+    #[test]
+    fn relay_egress_inputs_carry_decoded_plan_secrets_over_the_config_policy() {
+        use mvm_core::plan::SecretSource;
+        use mvm_core::policy::network_policy::HostPort;
+
+        let config = VmStartConfig {
+            name: "w".into(),
+            tenant_id: Some("config-tenant".into()),
+            network_policy: NetworkPolicy::allow_list(vec![HostPort::new("api.openai.com", 443)]),
+            ..Default::default()
+        };
+        let secret = SecretBinding {
+            name: "OPENAI_API_KEY".into(),
+            source: SecretSource::Static { value: "sk".into() },
+        };
+        let decoded = Some((
+            vec![secret],
+            RedactionPolicy::default(),
+            "plan-tenant".into(),
+        ));
+
+        let out = resolve_relay_egress_inputs(&config, decoded);
+        // The plan's own tenant wins when it carries secrets; the endpoint gates
+        // against the config's admitted policy either way.
+        assert_eq!(out.tenant, "plan-tenant");
+        assert_eq!(out.secrets.len(), 1);
+        assert_eq!(out.secrets[0].name, "OPENAI_API_KEY");
+        assert_eq!(out.network_policy, config.network_policy);
+    }
+
+    #[test]
+    fn relay_egress_inputs_for_a_secret_free_plan_are_raw_with_the_config_tenant() {
+        let config = VmStartConfig {
+            name: "w".into(),
+            tenant_id: Some("config-tenant".into()),
+            network_policy: NetworkPolicy::deny_all(),
+            ..Default::default()
+        };
+        let out = resolve_relay_egress_inputs(&config, None);
+        assert!(out.secrets.is_empty(), "no plan secrets ⇒ raw egress");
+        assert_eq!(out.tenant, "config-tenant");
+        assert_eq!(
+            serde_json::to_value(&out.redaction).unwrap(),
+            serde_json::to_value(RedactionPolicy::default()).unwrap()
+        );
+        assert_eq!(out.network_policy, NetworkPolicy::deny_all());
+    }
+
+    #[test]
+    fn relay_egress_inputs_default_the_tenant_when_config_has_none() {
+        let config = VmStartConfig {
+            name: "w".into(),
+            tenant_id: None,
+            ..Default::default()
+        };
+        let out = resolve_relay_egress_inputs(&config, None);
+        assert_eq!(out.tenant, RELAY_DEFAULT_TENANT);
+    }
+
+    #[test]
+    fn relay_egress_flag_is_off_unless_truthy() {
+        assert!(!relay_egress_enabled_from(None), "unset ⇒ legacy default");
+        assert!(!relay_egress_enabled_from(Some("0")));
+        assert!(!relay_egress_enabled_from(Some("")));
+        assert!(!relay_egress_enabled_from(Some("no")));
+        assert!(relay_egress_enabled_from(Some("1")));
+        assert!(relay_egress_enabled_from(Some("true")));
+        assert!(relay_egress_enabled_from(Some("TRUE")), "case-insensitive");
     }
 
     #[test]

--- a/crates/mvm-backend/src/workload_runner/spec_map.rs
+++ b/crates/mvm-backend/src/workload_runner/spec_map.rs
@@ -26,7 +26,12 @@ pub fn workload_blocks(config: &VmStartConfig) -> Vec<BlockDev> {
         slot,
     };
 
-    let mut blocks = vec![ro(&config.rootfs_path, 0)];
+    // An empty rootfs_path means an initramfs-only guest (no sealed rootfs) —
+    // skip the slot-0 disk rather than attach a bogus empty-source virtio-blk.
+    let mut blocks = Vec::new();
+    if !config.rootfs_path.is_empty() {
+        blocks.push(ro(&config.rootfs_path, 0));
+    }
 
     if let Some(verity) = &config.verity_path {
         blocks.push(ro(verity, 1));
@@ -138,6 +143,23 @@ mod tests {
 
     fn nodes(blocks: &[BlockDev]) -> Vec<String> {
         blocks.iter().map(BlockDev::device_node).collect()
+    }
+
+    #[test]
+    fn empty_rootfs_path_yields_no_blocks() {
+        // An initramfs-only guest (e.g. the egress live-proof echo guest) carries no
+        // sealed rootfs. An empty `rootfs_path` must not synthesize a bogus
+        // empty-source virtio-blk — the legacy backend filtered this before the
+        // WorkloadRunner path existed.
+        let cfg = VmStartConfig {
+            name: "w".into(),
+            rootfs_path: String::new(),
+            ..Default::default()
+        };
+        assert!(
+            workload_blocks(&cfg).is_empty(),
+            "empty rootfs_path must yield no disks"
+        );
     }
 
     #[test]

--- a/crates/mvm-hostd/src/supervisor/raw_egress.rs
+++ b/crates/mvm-hostd/src/supervisor/raw_egress.rs
@@ -179,10 +179,10 @@ fn handle_raw_conn_blocking(
     gate: &EgressGate,
     timeout: Duration,
 ) -> std::io::Result<()> {
-    use std::io::{Read, Write};
     use std::os::fd::{FromRawFd, OwnedFd};
 
-    // Adopt the fd; a File over a socket fd gives blocking Read+Write.
+    // Adopt the fd; a File over a socket fd gives blocking Read+Write, pumped
+    // below via `std::io::copy` (no trait import needed at this scope).
     let owned = unsafe { OwnedFd::from_raw_fd(conn_fd) };
     let mut guest = std::fs::File::from(owned);
 


### PR DESCRIPTION
Routes `HvfBackend::start` onto the relay egress path so the host-side gating endpoint becomes the sole path off the box — claim-10 enforced at the endpoint, the run loop a pure relay — replacing the legacy in-loop supervisor gate. Stacks on P2.1 (`WorkloadRunner<D,S>`); base branch `plan-214-p21-base` is a throwaway ref at that commit so this PR shows only its own delta (retarget to `feat/plan-214-hvf-spike` once that's on origin).

## What changed

- **`HvfBackend::start` opt-in relay routing** (`MVM_HVF_EGRESS_RELAY`, default off): routes through `WorkloadRunner<InHouseDriver, RealEndpointSpawner>`. Off by default — the relay's WireRequest (secret-bearing) path is not yet live-proven, so legacy stays the default until that lands and the default flips (P2.4). Mirrors the P1 additive-migration discipline and the note's invariant: *legacy stays until both raw and wire relay paths are live-green*.
- **`resolve_relay_egress_inputs`**: pure mapping of an admitted `VmStartConfig` + its persisted plan → `{tenant, secrets, redaction, network_policy}`. Secret-free plans take the raw egress branch; secret-bearing plans the wire substitution branch; the endpoint gates against the config's `network_policy` either way.
- **Fail-closed reap** at the call site: if the runner errors after spawning the endpoint, reap it so a decrypted-secret process can't outlive a failed launch (covers the current `RealEndpointSpawner`-returns-`PathBuf`-no-guard shape).
- **`workload_blocks` fix**: an empty `rootfs_path` no longer synthesizes a bogus empty-source virtio-blk (the legacy backend filtered this; the spec path didn't). Enables initramfs-only guests through the WorkloadRunner path.
- **New `hvf-backend-relay-egress` example**: live-proof regression through the production backend.

Lifecycle is unchanged: the in-house driver writes the same `hvf.pid` / `console.log` / `workload.exit` that `stop`/`status`/`wait`/`list` read.

## Verification

TDD'd (RED→GREEN watched) for the pure helpers + the `workload_blocks` fix.

Local gates (all green): `cargo fmt --all --check`, `cargo clippy -p mvm-backend --all-targets -D warnings`, `cargo test -p mvm-backend --lib` → **482 passed, 0 failed**, no spec-refs in comments, `--all-targets` build clean.

**Live-proven on HVF (macOS / Apple silicon)** through the production `HvfBackend::start` relay path:

```
admitted destination reachable: true
non-admitted destination reachable: false
```

Admit VM console logged `>>> egress reply over vsock: ping`; deny VM had no reply line — the endpoint gate discriminates by policy from its new home, no guest NIC, no in-loop gate.

## Not in scope

- **Default stays legacy** — the Wire relay path live proof is P2.2; P2.4 flips the default and deletes the in-loop gate afterward.
- Does not touch the shared plan/note (concurrent session owns it); status recorded in commit messages.