### PR TITLE
docs: mvm-client facade design + mvmd cloud-readiness assessment (research)

### DIFF
--- a/specs/adrs/104-cloud-control-plane-trust-boundary.md
+++ b/specs/adrs/104-cloud-control-plane-trust-boundary.md
@@ -1,0 +1,177 @@
+# ADR-104: Cloud control-plane trust boundary (multi-tenant superset of ADR-002)
+
+- Status: Proposed
+- Date: 2026-07-01
+- Owner: MVM Project
+- Related: ADR-002 (microVM security posture — the 15 claims, single-host scope), ADR-041 (signed audited execution plans — claim 8), ADR-059 (host services broker — claim 12 binding-gated dispatch), ADR-049 (destination/time-bound secret substitution — claim 13). Design input: `specs/notes/mvm-client-facade-design.md`, `specs/research/mvmd-cloud-readiness-assessment.md`.
+- Sequenced by: cloud claim catalog + `two_org_isolation` witness (Task A, in `mvmd`); `mvm-client` facade Phase 2 (remote) is gated on this ADR being Accepted.
+
+## Context
+
+`mvm` (this repo) is the open-source, run-microVMs-locally product. `mvmd` (sibling
+repo) is the paid, multi-tenant cloud where users *deploy* microVMs onto hosts we
+operate. `mvm-studio` and — per the facade design — `mvmctl` reach **both**: a local
+in-process path and a remote REST path to an `mvmd-gateway`, through one `MvmClient`
+trait.
+
+ADR-002 is the source of truth for the local security posture. Its threat model is
+scoped, explicitly, to:
+
+- a **single trusted local host** (the user owns the machine),
+- **one guest = one workload** (no multi-tenant guests),
+- **malicious host out of scope**.
+
+The 15 CI-enforced claims all defend *that* boundary: a workload escaping onto the
+*user's own* machine.
+
+The cloud product **inverts every one of those assumptions**. We own the host; the
+user is untrusted; **many** untrusted tenants share our hosts. The threat becomes
+tenant→host and tenant→tenant escape — precisely the two items ADR-002 declares out of
+scope (multi-tenant guests; an untrusted-host relationship from the tenant's view).
+
+Introducing `mvmctl --remote <url>` also adds a **new actor** ADR-002 never modeled: a
+remote control plane reachable over a network, with a network in between. A trait that
+makes the local and remote calls look identical can hide that their security
+*guarantees* are enforced by different authorities. That is a mental-model hazard, not
+just a code one.
+
+This ADR establishes the cloud tier's trust boundary as an explicit **superset** of
+ADR-002, so "the cloud keeps every local guarantee, and adds the multi-tenant ones" is
+a *checkable* statement rather than an aspiration.
+
+## Decision
+
+### 1. The cloud tier is ADR-002 plus a named set of multi-tenant claims
+
+The 15 local claims remain necessary and continue to hold on the workload backends.
+The cloud tier adds, at minimum:
+
+- **CT-1 Cross-tenant isolation.** A principal scoped to tenant/org A cannot read or
+  mutate any resource of tenant/org B — enforced on the request hot path *and* backed
+  by a database-level fail-closed backstop (row-level security), so a forgotten
+  handler check is not a breach.
+- **CT-2 Admission under fleet authority.** Every deploy / lifecycle mutation is
+  authorized by the control plane's policy engine before state change and recorded in
+  the chain-signed audit log. (Mirrors claim 8, enforced by mvmd's authority.)
+- **CT-3 Control-plane replay resistance.** Signed control-plane requests carry
+  freshness (validity window + per-signer nonce) and are rejected on replay. (The
+  `mvm-core` primitive for this is Task B; the reconcile-path wiring is mvmd's.)
+- **CT-4 Per-tenant resource bounds.** A tenant's workloads cannot starve another's on
+  a shared host — resource caps and/or placement isolation, per the co-location
+  decision below.
+
+The catalog is seeded here and owned as a living `specs/claims/catalog.md` in `mvmd`
+(Task A). It is expected to grow (secret confidentiality across the boundary, egress
+attribution, etc.); this ADR fixes the *discipline*, not the final list.
+
+### 2. The trait unifies the call, never the trust
+
+There are two authorities, and they are never silently merged:
+
+- **Local path** — the authority is the local host, exactly as ADR-002 describes
+  (host-signed `ExecutionPlan`, broker, local audit chain). `LocalBackend` runs the
+  same `mvmctl` library over the same on-disk state.
+- **Remote path** — the authority is `mvmd`. `GatewayBackend` is a **dumb courier with
+  zero enforcement authority**: it presents credentials and ships intent; every
+  security decision (RBAC, quota, admission, audit, rate-limit) is made server-side and
+  the server treats the client as untrusted input regardless.
+
+Security is therefore never a property of the transport the caller picked; it is
+enforced at whichever authority owns that path. The facade must make the acting
+authority observable, never present remote guarantees as if they were the local ones.
+
+### 3. Key-domain separation
+
+Local signing keys (`~/.mvm/keys/host-signer`) are the *local host's* authority and
+must never be trusted by the fleet. The facade must not ship a locally-signed plan and
+have `mvmd` honor that local signature — that is key-trust confusion. Remote DTOs carry
+**intent**; `mvmd` re-admits and re-signs under its own fleet key. The shared wire
+contract must not leak local signing material or host paths across the boundary. This
+is a constraint on the DTO shapes, not only a runtime check.
+
+### 4. Client-side rules are fail-closed
+
+- **Prefer mTLS; require TLS.** HTTPS + cert validation by default; support the
+  gateway's `require_client_cert` mode; **refuse plaintext to any non-loopback host**
+  (the loopback sidecar is the only cleartext exception).
+- **Ride the server's auth model exactly** — scoped bearer keys, honor expiry warnings,
+  hard-fail on API-version skew. No bespoke client auth.
+- **Credentials** — OS keychain (studio) or env var / mode-0600 file (CLI); never a
+  token flag (leaks to `ps`/history); never logged; `zeroize` on drop; **endpoint-bound**
+  so a token is never sent to a different `--remote` URL.
+- **Untrusted-input hardening** — the shared DTOs are deserialized by the server from
+  anyone with network reach: `#[serde(deny_unknown_fields)]`, size/depth limits,
+  validation. Typed DTOs fail closed; today's `Result<Value>` surface does not.
+
+### 5. Built is not wired: enforcement must fail CI when absent
+
+A control that exists but is not on the request hot path with a passing witness is
+treated as **absent**. Each cloud claim maps to a named test/CI gate (the mvm
+claim→witness→gate discipline, ported to `mvmd`). This is a direct response to the
+present state, where a production-grade IAM + RLS subsystem shipped ~100% built and ~0%
+wired without turning CI red.
+
+### 6. Sequencing
+
+The `mvm-client` remote phase (`--remote` / mTLS / `GatewayBackend`) ships only once
+this ADR is Accepted **and** cross-tenant enforcement (CT-1) is wired with a green
+witness. Shipping a polished remote client over an unenforced authorization boundary
+would make the insecure path easier to reach — the worst outcome.
+
+## Threat model — new actors (relative to ADR-002)
+
+In scope for the cloud tier, additional to ADR-002:
+
+- **The network between client and `mvmd`.** Mitigated by TLS/mTLS, endpoint-bound
+  credentials, replay resistance (CT-3), fail-closed client rules.
+- **Other tenants on a shared host / control plane.** Mitigated by CT-1 (isolation +
+  RLS backstop), CT-4 (resource bounds), and the co-location decision.
+- **A tenant's untrusted workload versus the fleet host.** The ADR-002 guest-boundary
+  claims (1–15) carry over unchanged and are the first line; multi-tenancy raises the
+  blast-radius stakes but not the per-guest mechanism.
+
+Still out of scope (named, deliberately):
+
+- **A malicious `mvmd` operator / the host we operate.** We trust our own control-plane
+  operators with the hypervisor and fleet keys, mirroring ADR-002's malicious-host
+  exclusion. (Reducing this trust — confidential computing, hardware attestation — is a
+  separate future ADR.)
+- **Hardware-backed key attestation.** As ADR-002.
+
+## Consequences
+
+- "Same guarantees or stricter, in the cloud" becomes provable: the superset is
+  enumerated and each element has a CI witness.
+- The facade design gains a hard gate (§6): remote is not shippable until CT-1 is
+  enforced, not merely designed.
+- Honest current status at authorship: CT-1 is built (mvmd IAM + Postgres RLS) but not
+  wired; CT-3's `mvm-core` primitive has landed (Task B) with the mvmd reconcile-path
+  wiring outstanding; CT-2 is partial (prod-gated signature verify, no end-to-end
+  gateway→agent signing); CT-4 is open (unrestricted co-location). This ADR does not
+  claim these are done — it makes their absence a tracked, CI-visible gap.
+
+## Alternatives considered
+
+- **Keep ADR-002 as-is; handle cloud security ad hoc.** Rejected: there is then no
+  checkable superset, and the built-≠-wired failure mode has nothing to make it red.
+- **A separate cloud threat-model doc only, no ADR.** Partially adopted: a companion
+  `specs/threat-models/` doc in `mvmd` may hold the long-form analysis, but the *trust
+  boundary decision* belongs in the ADR ledger next to ADR-002 so the two are read
+  together.
+- **Make the trait fully uniform over local/remote, hiding the transport.** Rejected:
+  uniformity of *interface* is good DX; uniformity of *apparent trust* is a hazard. The
+  acting authority must stay observable (§2).
+
+## Co-location decision (to resolve; drives CT-4 and unit economics)
+
+Two honest options, called out so it is decided before more scheduler logic is built on
+the current co-locate-freely default:
+
+- **Dedicated node pools per tenant** — simplest, strongest isolation, lower density
+  and thinner margins.
+- **Hardened co-location** — denser and better economics, but defends the
+  Firecracker/VMM boundary, network segmentation, and noisy-neighbor between untrusted
+  tenants on shared silicon.
+
+This is a product+security decision, not purely security; this ADR records it as the
+open question gating CT-4 rather than pre-deciding it.

--- a/specs/notes/mvm-client-facade-design.md
+++ b/specs/notes/mvm-client-facade-design.md
@@ -1,0 +1,204 @@
+# mvm-client — unified local/remote client facade
+
+**Status:** Design (pre-ADR, pre-plan)
+**Date:** 2026-07-01
+**Spawns:** ADR-104 (control-plane trust boundary) · Plan 216 (implementation)
+
+## Problem
+
+`mvmctl` and `mvm-studio` both need to drive microVM operations that may run
+in two places:
+
+- **Local** — single-machine microVMs on this host.
+- **Fleet** — a multi-tenant fleet managed by `mvmd` over its REST API.
+
+Today the two surfaces are reached in incompatible ways. Studio spawns an
+`mvmd-gateway` sidecar and speaks HTTP to it (even locally); `mvmctl` drives the
+local path through clap command handlers that are not cleanly callable as a
+library. There is no single interface a caller programs against to say "run this
+machine" without first deciding *where* and *how*.
+
+We want one facade — a trait — with a local (in-process) impl and a remote
+(REST) impl, so the CLI and studio can target local microVMs **or** the mvmd
+fleet through the same calls. Deploy-from-CLI and deploy-from-studio become the
+same code path with a different backend selected.
+
+## Non-goals
+
+- **No REST *server* in `mvmctl`.** `mvmd-gateway` remains the sole HTTP server.
+  This adds a *client-side* facade only.
+- No change to guest/workload isolation. Claims 1–15 are enforced by the
+  supervisor/hostd at launch and are unaffected by which client initiated.
+- No new orchestration in `mvmctl`. Tenant/pool/deploy authority stays in mvmd.
+
+## Decision
+
+Introduce a client facade trait with **two implementations** (option "C" from
+the brainstorm):
+
+- `LocalBackend` — calls mvmctl's Rust libraries in-process. Same code and same
+  `~/.mvm` on-disk state that the CLI drives today; identical trust.
+- `GatewayBackend` — a REST client speaking HTTP(S) to an `mvmd-gateway`. Serves
+  both the local sidecar (loopback) and a remote fleet — the only difference is
+  the URL and the transport hardening.
+
+Because `mvmd-gateway` already links mvmctl as a library, the in-process path and
+the sidecar path run the **same mvmctl code over the same state**. "C" therefore
+does not create two divergent local behaviors — it is one behavior reachable by
+two transports.
+
+### Where it lives (dependency direction)
+
+`mvmd` depends on `mvm`, never the reverse. A REST client is defined by the
+**wire protocol**, not by a Rust dependency — a client doing `GET /sandboxes`
+needs the HTTP contract, not mvmd's crate. So the entire facade lives in the
+**mvm** repo without importing anything from mvmd:
+
+```
+crates/mvm-client/                (new; tokio allowed — NOT mvm-core)
+  trait MvmClient                 the async facade
+  LocalBackend                    in-process mvmctl library calls
+  GatewayBackend                  reqwest -> mvmd-gateway, zero mvmd imports
+  dto::*                          shared, typed wire contract
+```
+
+- **`mvm-client` is a new crate, not `mvm-core`.** The trait is async and pulls
+  `reqwest`/`tokio`; `mvm-core` must stay runtime-free (the
+  `check-core-runtime-free` gate). Only the serde DTO *structs* may live in
+  `mvm-core` if reused there — they carry no runtime deps.
+- **`mvmctl`** depends on `mvm-client` → gets local + remote for free.
+- **`mvm-studio`** depends on `mvm-client` → same dual mode; retires its bespoke
+  `mvmd-client` usage.
+- **`mvmd-gateway`** depends on the same `dto::*` for its handlers, replacing
+  today's stringly `Result<Value>` with one typed contract shared by client and
+  server. The existing `mvmd-client` crate is superseded (or becomes a thin
+  re-export of `GatewayBackend`).
+
+### Selection
+
+```
+mvmctl machine list                 -> LocalBackend
+mvmctl --remote <url> machine list  -> GatewayBackend(url)
+studio (local view)                 -> GatewayBackend(loopback sidecar)
+studio (fleet view)                 -> GatewayBackend(remote)
+```
+
+## Trait shape (sketch)
+
+Async trait; domain-typed in/out (not `Value`). Scoped to machine lifecycle for
+v1; grows by operation, not by transport.
+
+```rust
+#[async_trait]
+pub trait MvmClient {
+    async fn list_machines(&self, f: MachineFilter) -> Result<Vec<MachineState>>;
+    async fn run_machine(&self, spec: MachineSpec) -> Result<MachineHandle>;
+    async fn stop_machine(&self, id: &MachineId) -> Result<()>;
+    async fn machine_logs(&self, id: &MachineId, opts: LogOpts) -> Result<LogStream>;
+    // ... intent-shaped operations only
+}
+```
+
+`MachineSpec`/`MachineState`/`MachineId` reuse `mvm-core` domain types where they
+exist. The DTOs are **intent-shaped**: they carry *what to do*, never local host
+artifacts (signing keys, host paths) — see key-domain separation below.
+
+## Security & Trust Boundary
+
+This is a first-class part of the design, not an afterthought. The remote
+endpoint (`mvmd-gateway`) is already a hardened control plane — scoped bearer
+keys (`Authorization: Bearer mvmd_<org>_<hex>`, HMAC-hashed, expiry-warned),
+mTLS (`require_client_cert`), RBAC, per-key rate limiting, quota enforcement,
+audit, and `X-API-Version` skew detection. The facade's job is to **consume that
+enforcement correctly**, adding no trust of its own.
+
+### Governing principle: the remote client is a dumb courier with zero authority
+
+Every security decision lives on the enforcing side. On the local path the
+authority is the local host (signed `ExecutionPlan`, broker, audit chain — as
+today). On the remote path the authority is `mvmd-gateway` (RBAC, quota, audit,
+its own admission + signing). `GatewayBackend` holds **no enforcement logic** —
+it presents credentials and ships intent; the server treats it as untrusted
+input regardless. Security is never a property of the transport the caller
+picked; it is enforced identically at whichever authority owns that path. **The
+trait unifies the call, never the trust.**
+
+### Key-domain separation (the subtle trap)
+
+Local signing keys (`~/.mvm/keys/host-signer`) are the *local host's* authority
+and must never be trusted by the fleet. The facade must never ship a
+locally-signed plan and have the gateway honor that local signature —
+that is key-trust confusion. Remote DTOs carry **intent**; the gateway
+re-admits and re-signs under its own fleet key. The wire contract must not leak
+local signing material or host paths across the boundary. This is a design
+constraint on the DTOs, not merely a runtime check.
+
+### Client-side rules (fail-closed)
+
+1. **Ride the gateway auth model exactly** — `Bearer mvmd_<org>_<hex>`, honor
+   `X-Key-Expires-Soon`, hard-fail on `X-API-Version` mismatch. No bespoke auth.
+2. **Prefer mTLS; require TLS.** HTTPS + cert validation by default; support the
+   gateway's `require_client_cert` mode; **refuse plaintext to any non-loopback
+   host** (loopback sidecar is the only cleartext exception).
+3. **Credential storage** — OS keychain (studio), env var or mode-0600 file
+   (CLI). Never a `--token` flag (leaks to `ps`/shell history), never logged,
+   `zeroize` on drop, routed through the `check-no-display-on-secret-types`
+   discipline.
+4. **Endpoint-bound tokens** — a token is bound to its configured endpoint and
+   never sent to a different `--remote` URL. Kills token exfil via URL confusion.
+5. **Fail closed** — TLS failure, version skew, expired/revoked key → hard error,
+   never a silent degrade to a weaker mode.
+
+### Untrusted-input hardening on the shared DTOs
+
+The gateway deserializes client DTOs from anyone with network reach.
+`#[serde(deny_unknown_fields)]` on every wire type, plus size/depth limits and
+the gateway's existing `validation.rs`. Typed DTOs are a security win over
+today's `Value` soup — they fail closed. The `LocalBackend` path carries no new
+surface: it is the same in-process code and state as running `mvmctl` today.
+
+### Trust-model expansion → ADR-104
+
+`mvmd`-over-network is a **new actor** relative to ADR-002, which scopes the
+threat model to a single trusted local host. This is the only place the threat
+model actually expands, and it must be written down. **ADR-104 is a prerequisite
+deliverable** for the remote path: it defines the control-plane trust boundary,
+the dumb-courier principle, key-domain separation, and the client-side fail-closed
+rules as posture, and states plainly that local and remote guarantees are
+enforced by *different authorities* (never silently uniform).
+
+## Scope / sequencing
+
+- **v1 (Plan 216, Phase 1):** `mvm-client` crate + `MvmClient` trait +
+  `LocalBackend` + the full typed `dto::*` contract + `mvmctl` wired to
+  `LocalBackend`. Authors **ADR-104**. No remote wire yet — this de-risks the
+  interface and the DTO shapes against the local path first.
+- **v1.1 (Plan 216, Phase 2), gated on ADR-104 accepted:** `GatewayBackend` +
+  `mvmctl --remote` + TLS/mTLS enforcement + gateway adopts `dto::*` + studio
+  migrates off bespoke `mvmd-client`. This is the security-critical phase and
+  ships only behind the accepted ADR.
+
+Rationale: the remote goal is firmly in the plan (CLI *and* studio deploy to the
+fleet), but the transport that expands the threat model lands behind its ADR
+rather than racing ahead of it.
+
+## Testing
+
+- Trait: `LocalBackend` against a temp `MVM_DATA_DIR`; roundtrip machine
+  lifecycle.
+- DTOs: serde roundtrip, `deny_unknown_fields` rejection, defaults.
+- `GatewayBackend` (Phase 2): mock HTTP server; assert `Bearer` header, TLS-refuse
+  on non-loopback plaintext, version-skew hard-fail, endpoint-bound token,
+  no-secret-in-logs.
+- Contract: a shared-DTO conformance test both `mvm-client` and `mvmd-gateway`
+  compile against, so the wire contract can't drift silently.
+
+## Open questions
+
+- DTO home: `mvm-core` (reused by mvmd already) vs `mvm-client` only. Leaning
+  `mvm-core` for the pure structs so the gateway shares them without depending on
+  `mvm-client`'s runtime.
+- Log/exec streaming shape over REST (SSE — the gateway already has
+  `sse_helpers.rs`) vs the local in-process stream; the trait must express both
+  without leaking transport.
+- Whether `mvmd-client` is deleted or kept as a thin re-export during migration.

--- a/specs/research/mvmd-cloud-readiness-assessment.md
+++ b/specs/research/mvmd-cloud-readiness-assessment.md
@@ -3,7 +3,7 @@
 **Status:** Research (handoff)
 **Date:** 2026-07-01
 **Audience:** engineering partner picking up the cloud-tier security work
-**Related:** `specs/notes/mvm-client-facade-design.md` (the client facade this sprint started from), ADR-002 (local security posture), ADR-104 (to be written — cloud trust boundary)
+**Related:** `specs/notes/mvm-client-facade-design.md` (the client facade this sprint started from), ADR-002 (local security posture), `specs/adrs/104-cloud-control-plane-trust-boundary.md` (cloud trust boundary — the superset threat model this assessment motivates)
 
 ## TL;DR
 

--- a/specs/research/mvmd-cloud-readiness-assessment.md
+++ b/specs/research/mvmd-cloud-readiness-assessment.md
@@ -1,0 +1,242 @@
+# mvmd cloud-readiness — security assessment & path to monetizable production
+
+**Status:** Research (handoff)
+**Date:** 2026-07-01
+**Audience:** engineering partner picking up the cloud-tier security work
+**Related:** `specs/notes/mvm-client-facade-design.md` (the client facade this sprint started from), ADR-002 (local security posture), ADR-104 (to be written — cloud trust boundary)
+
+## TL;DR
+
+The bones are strong. `mvmd` is a real distributed control plane (~390K LOC, 14 crates,
+1,700+ tests, coordinator + per-node QUIC agents, per-tenant L4 proxy/TLS/rate-limiting,
+scheduler, metering→Stripe). It is **not** a scaffold.
+
+The problem is not missing components — it is the recurring gap between **built** and
+**wired**. The multi-tenant *enforcement gates* are designed and, in the latest sprint,
+fully implemented — but not connected to the request path. The most recent example (IAM,
+PR #161) is a production-grade authorization + row-level-security system that is ~100%
+built and ~0% integrated.
+
+The single missing discipline that would fix this class of problem: mvm's
+**claim → named witness → CI gate** ledger, ported to the cloud tier. Today nothing fails
+CI when a security control ships un-enforced.
+
+## Business context and why the threat model inverts
+
+- **OSS-local (`mvm`)** — the user owns and trusts the host. Threat: a workload escaping onto
+  *their own* machine. ADR-002 encodes this: *single trusted local host, one guest = one
+  workload, malicious host out of scope.* The 15 CI-enforced claims all defend this boundary.
+- **Paid-cloud (`mvmd`)** — *we* own the host; the user is untrusted; **many** untrusted
+  tenants share *our* hosts. Threat: tenant→host and tenant→tenant escape.
+
+The cloud product must therefore solve exactly the two things ADR-002 declares **out of
+scope**: multi-tenant guests, and an untrusted-host relationship from the tenant's view.
+"Keep every guarantee, even stricter" is the right goal, and concretely it means the cloud
+tier needs a **superset** of the local posture: the 15 claims **plus** cross-tenant
+isolation **plus** untrusted-tenant admission. The 15 claims are necessary, not sufficient.
+
+## The client facade (where this sprint began)
+
+`specs/notes/mvm-client-facade-design.md` proposes a `MvmClient` trait with two impls —
+`LocalBackend` (in-process mvmctl) and `GatewayBackend` (REST → mvmd-gateway, local sidecar
+or remote fleet). It is a good architecture move and worth building. But it is the thin
+enabling layer, not the security story: it adds no trust of its own and depends entirely on
+the server enforcing. See "Implication for the facade" below — its remote phase must be
+gated on the enforcement work landing.
+
+## Current state of mvmd
+
+### Genuinely solid (implemented and enforced)
+
+- HMAC-SHA256 API-key auth with per-key caching, expiry warnings (`auth/middleware.rs`).
+- Per-tenant L4 proxy isolation — tenant identity derived from the **listen socket**, not
+  client headers (`mvmd-proxy`, SECURITY_MODEL.md).
+- Per-tenant TLS termination with hot cert reload + ACME (Sprint 139).
+- Per-tenant rate limiting + wake-amplification circuit breaker.
+- VM-level hardening: Firecracker + jailer + seccomp + cgroups (`mvmd-runtime`).
+- Working scheduler with capacity/constraint/cost scoring and node-failover.
+- Metering pipeline → Stripe usage records (functioning meter, not yet a billing system).
+
+### The IAM sprint (PR #161 / Sprint 137) — built ~100%, wired ~0%
+
+New crates `mvmd-iam` + `mvmd-iam-storage` landed a production-grade authz foundation:
+
+- **Policy engine** (`mvmd-iam/src/policy/`): RBAC + ACL evaluation, Deny-wins precedence,
+  effective-role computation from memberships (`rbac.rs`, `acl.rs`, `effective.rs`).
+- **Domain model**: organizations, teams, workspaces, principals, API keys, ACL grants,
+  audit_log; Postgres + libSQL backends; dbmate migrations.
+- **Real Postgres row-level security** — the strongest artifact in either repo:
+  `migrations/postgres/0002_iam_rls.sql` defines `USING`/`WITH CHECK` policies scoped by a
+  transaction-local GUC `app.current_org`; `0003_iam_functions.sql` sets it via a
+  `SECURITY DEFINER set_request_scope()`; **fail-closed** — an unscoped connection sees
+  nothing.
+
+**The wiring did not land:**
+
+- `mvmd-gateway` does **not** depend on `mvmd-iam` (no Cargo.toml entry).
+- The gateway never calls the policy engine (`evaluate_with_acls()`), never calls
+  `enter_org_scope()`, never activates RLS. It still runs on the legacy `StateStore`
+  (in-memory/etcd), not Postgres.
+- The hot path authorizes with the **old coarse model**: `ApiKeyRecord.can_access_tenant()`
+  against a static per-key `tenant_scopes` list; the `route_auth` permission guard checks
+  **role only**, not org/tenant (`auth/permissions.rs`).
+
+**Precise verdict** (correcting an earlier overstatement): it is *not* "any key touches any
+tenant" — the legacy per-key `tenant_scopes` allowlist does gate access. But the new
+fine-grained model — org/workspace/team membership, ACLs, and the DB-level RLS backstop —
+gives **zero runtime protection today**, because nothing on the request path invokes it. If
+a handler forgets its manual `can_access_tenant()` check, there is no DB-level net beneath
+it. M1 has moved from "designed, not built" to **"built, not wired."**
+
+### Remaining gaps — current status
+
+| # | Gap | Status | Evidence |
+|---|-----|--------|----------|
+| 1 | Replay protection on signed requests | **Mostly open** | `mvm-core/src/protocol/signing.rs` `SignedPayload` is still `{payload, signature, signer_id}` — no timestamp/nonce. A `ReplayWindow` exists only for delegated host-services (`mvmd-agent/src/transport.rs`); the main `ReconcileSigned` path (`agent.rs`) has none. **This blocker lives in the `mvm` repo — see Task B.** |
+| 2 | Per-instance / tenant secret encryption | **Narrower than feared** | Secrets travel **by name** (`SecretScope{integration, keys: Vec<String>}` in `mvm-core/src/domain/pool.rs`), not as values in `DesiredState`. Raw values don't transit the reconcile payload (aligns with mvm claim 13). No payload-level envelope encryption, but exposure is limited. |
+| 3 | Signature-verification gating | **Prod-enforced, dev-skipped** | `is_production_mode()` rejects unsigned `Reconcile` in prod (`mvmd-agent/src/agent.rs`); dev/test accept unsigned. Works, but the dev/prod split is a footgun. |
+| 4 | Per-tenant node quotas / co-location isolation | **Open** | Unrestricted co-location; no per-node per-tenant CPU/mem/net caps. `SpreadAcrossNodes` is advisory scoring, not a hard rule (`mvmd-coordinator/src/scheduler/placement.rs`). |
+| 5 | End-to-end signing gateway→coordinator→agent | **Open** | Coordinator gossips unsigned `DesiredState` (`mvmd-coordinator/src/gossip/mod.rs`); agent verifies only pre-signed `ReconcileSigned` variants. |
+
+## The meta-pattern, and the actual fix
+
+The important finding is not any single gap. It is the recurring gap between **built** and
+**wired**, and *why* it persists: **there is no gate that fails when a control ships
+un-enforced.** IAM is the exemplar — a production-grade RLS + policy engine merged, CI
+stayed green, and the request path gained no protection.
+
+This is precisely what mvm's **claim → witness → CI-gate** discipline prevents. A cloud claim
+*"a principal scoped to org A receives 403/empty on org B's resources,"* witnessed by a
+two-org integration test wired into CI, would have shown PR #161 as a **red claim** rather
+than a green "we shipped IAM." Porting that ledger to the cloud tier is the highest-leverage
+move and is **Task A**.
+
+## Reprioritized path forward
+
+1. **Integration over new foundations.** The next unit of work is wiring, not building:
+   gateway depends on `mvmd-iam` + `mvmd-iam-storage`; auth middleware resolves
+   principal→org/workspace/role from the IAM store; **call `enter_org_scope()` (activating
+   RLS) before every data access**; route handlers call the policy engine. Activating RLS is
+   the single highest security-ROI action — a backstop that holds even when a handler is
+   wrong.
+2. **Stand up the cloud claim catalog now** (Task A), cross-tenant isolation as claim #1 with
+   a two-org test as its witness, gated in CI. This stops the built-but-not-wired pattern
+   from recurring.
+3. **Close `SignedPayload{timestamp, nonce}` in mvm** (Task B). Still open, in *our* repo,
+   still blocking real replay protection on the main reconcile path. Small, high-leverage.
+4. **Make the co-location decision** — dedicated node pools per tenant (simpler, stronger
+   isolation, lower density/margin) vs hardened co-location (denser, harder security). This
+   drives both the threat model and unit economics; decide it before building more scheduler
+   logic on the current co-locate-freely default.
+
+## Implication for the facade
+
+The `GatewayBackend` "dumb courier / zero authority" principle is *more* correct given these
+findings — but it is only safe if the server actually enforces, which today the fine-grained
+model does not. So the facade's **Phase 2 (remote `--remote` / mTLS)** must be gated not only
+on ADR-104 but on **IAM integration being live and its cross-tenant claim green**. Shipping a
+polished remote client over an unenforced authorization boundary is the worst outcome — it
+makes the insecure path easier to reach. (Update `mvm-client-facade-design.md` §Scope to add
+this dependency when Task A lands.)
+
+---
+
+# Appendix — Task A: cloud claim catalog + first cross-tenant witness
+
+**Repo:** `mvmd` (with an `xtask`-style gate mirroring mvm's `check-claim-catalog`)
+**Why:** convert "we built IAM" into "cross-tenant isolation is enforced and *stays* enforced."
+The absence of this gate is the root cause of the built-but-not-wired pattern.
+
+**Deliverables**
+
+1. `specs/claims/catalog.md` in `mvmd` — a claim→witness ledger modeled on
+   `mvm`'s `specs/claims/catalog.md`. Seed it with:
+   - **Claim C1 — cross-tenant isolation.** *A principal scoped to org A cannot read or
+     mutate any resource belonging to org B.* Witness: `two_org_isolation` integration test
+     (below). CI lane: gateway test job.
+   - **Claim C2 — RLS fail-closed backstop.** *A DB connection with no `app.current_org`
+     scope set returns zero rows from any IAM-scoped table.* Witness: a storage-layer test
+     that queries without calling `enter_org_scope()` and asserts empty.
+   - **Claim C3 — admission under fleet authority.** *Every deploy/instance mutation is
+     authorized by the policy engine before state change and recorded in the audit log.*
+     Witness: handler test asserting `evaluate_with_acls()` is on the path and an audit
+     entry is emitted. (Depends on the integration work; may start as `Pending`.)
+2. `two_org_isolation` integration test (`mvmd-gateway/tests/`):
+   - Bootstrap org A and org B, each with a scoped API key and one sandbox/instance.
+   - Assert A's key on B's resource → **403** (or 404 by policy), for read, mutate, delete.
+   - Assert A's key listing returns only A's resources (no B leakage).
+   - Run against the **wired** path (gateway → mvmd-iam → RLS-scoped store), not the legacy
+     `can_access_tenant()` shortcut. Until integration lands, mark C1 `Pending` with the test
+     `#[ignore]`d and a one-line note — never silently green.
+3. `xtask check-claim-catalog` (or CI step) that fails if a named witness stops existing —
+   same contract as mvm's gate.
+
+**Acceptance criteria**
+
+- `catalog.md` exists with C1–C3, each naming a real witness file/test.
+- `two_org_isolation` passes against the integrated path (or is explicitly `Pending`+`#[ignore]`
+  with a tracked reason, not omitted).
+- The catalog gate runs in CI and fails on a missing witness.
+- A follow-up issue links C3 to the IAM-integration work so it flips green when wiring lands.
+
+**Non-goals:** porting all 15 mvm claims at once; billing/compliance claims. Start with the
+three that gate multi-tenant safety.
+
+---
+
+# Appendix — Task B: `SignedPayload{timestamp, nonce}` + validity/replay verification
+
+**Repo:** `mvm` (`mvm-core`), unblocking `mvmd`'s replay protection on the reconcile path.
+**Why:** the main `ReconcileSigned` path has no replay protection because the signed type
+carries no freshness. A captured signed desired-state replays indefinitely.
+
+**Current state**
+
+`mvm-core/src/protocol/signing.rs`:
+```rust
+pub struct SignedPayload { payload: ..., signature: ..., signer_id: ... }
+```
+No `timestamp`, no `nonce`. mvmd's `ReplayWindow` (`mvmd-agent/src/transport.rs`) only guards
+delegated host-services calls (caller-supplied `request_id`), not `ReconcileSigned`.
+
+**Design**
+
+- Add `issued_at: <unix-millis>` and `nonce: [u8; 16]` to `SignedPayload`. The signed bytes
+  **must include both** (they are inside the signed envelope, not siblings of the signature),
+  so tampering with freshness breaks verification.
+- New fields deserialize with `#[serde(default)]` for wire tolerance, but verification
+  **requires** them present and non-default (nothing is in production; no schema-version
+  bump — see the project's no-ceremony convention).
+- Verification API: a validity window (`issued_at` within ±skew) + a nonce replay store,
+  mirroring the G4 validity-window + nonce replay-store already used for `ExecutionPlan`
+  admission (claim 8). Reuse that machinery rather than inventing a second replay store.
+- Consumer wiring is out of scope for this task except to expose the verify entrypoint the
+  agent will call; the mvmd side (guarding `ReconcileSigned` with the store) is a follow-up
+  issue in mvmd that depends on this.
+
+**Files**
+
+- `mvm-core/src/protocol/signing.rs` — struct fields, sign path includes them in the signed
+  bytes, verify path checks window + nonce.
+- Wherever the ExecutionPlan nonce store lives (`mvm-core/src/plan/…`) — reuse or generalize
+  the replay store; do not fork a second copy.
+
+**Test plan (mvm's positive/negative/edge discipline)**
+
+- Roundtrip: sign→verify with fresh `issued_at`/`nonce` passes.
+- Replay: same payload verified twice → second is rejected by the nonce store.
+- Stale: `issued_at` outside the window → rejected.
+- Tamper: flip a `nonce`/`issued_at` byte after signing → signature verification fails.
+- Serde: `#[serde(default)]` deserialization of a payload missing the fields → verify
+  rejects (absent freshness is not valid), proving fail-closed.
+
+**Acceptance criteria**
+
+- `SignedPayload` carries `issued_at` + `nonce` inside the signed envelope.
+- Verify enforces validity window + nonce replay via the shared store (no second store).
+- All five tests above pass; `cargo fmt --all`, `nextest`, `--doc`, `clippy -D warnings`
+  clean.
+- A tracked mvmd follow-up issue references this to guard `ReconcileSigned` end-to-end.
+
+**Non-goals:** wiring mvmd's agent to the store (separate mvmd issue); end-to-end
+gateway→coordinator→agent signing (gap #5, separate).


### PR DESCRIPTION
Research handoff for the local/remote client-facade idea and the security path to a monetizable multi-tenant cloud tier.

## Contents
- **`specs/notes/mvm-client-facade-design.md`** — `MvmClient` trait fronting `LocalBackend` (in-process mvmctl) and `GatewayBackend` (REST → mvmd-gateway, local sidecar or remote fleet). Lives in a new `mvm-client` crate; respects `mvm ← mvmd` dependency direction because a REST client is defined by the wire protocol, not a Rust dep. Security is first-class (dumb-courier principle, key-domain separation, fail-closed client rules).
- **`specs/research/mvmd-cloud-readiness-assessment.md`** — honest state of mvmd for the paid cloud tier. Strong bones, but the recurring **built ≠ wired** gap: IAM/RLS (PR #161) is ~100% built, ~0% integrated on the request path. Core fix = port mvm's claim→witness→CI-gate discipline to the cloud tier. Includes two ready-to-file task drafts.

## Task drafts (appendices)
- **Task A** — cloud claim catalog + two-org cross-tenant witness (in mvmd).
- **Task B** — `SignedPayload{timestamp, nonce}` + replay verification (in mvm-core); implementation in progress on its own branch.

Docs only — no code changes. For partner review.