### PR TITLE
feat(core): reusable freshness primitive for signed-payload replay protection (Task B)

### DIFF
--- a/crates/mvm-core/src/plan/mod.rs
+++ b/crates/mvm-core/src/plan/mod.rs
@@ -52,4 +52,6 @@ pub use types::{
     RuntimeProfileRef, SecretBinding, SecretReleasePolicy, SecretSource, ShareKind, SignedImageRef,
     TenantId, TimeoutSpec, Variant, WorkloadId, WorkloadIntent,
 };
-pub use validity::{NonceStore, PlanValidityError, check_window};
+pub use validity::{
+    CheckedFreshness, Freshness, FreshnessClaims, NonceStore, PlanValidityError, check_window,
+};

--- a/crates/mvm-core/src/plan/validity.rs
+++ b/crates/mvm-core/src/plan/validity.rs
@@ -38,28 +38,109 @@ pub enum PlanValidityError {
     },
     #[error("plan nonce already seen for signer '{signer}'")]
     NonceReplay { signer: String },
+    #[error("freshness block missing required field(s)")]
+    MissingFreshness,
 }
 
-/// Stateless check: does the plan's window cover `now`, and is it
+/// The freshness inputs the window + nonce checks need, decoupled
+/// from `ExecutionPlan` so any signed payload — a plan, a signed
+/// reconcile request — reuses one replay ledger instead of forking
+/// its own.
+pub trait Freshness {
+    fn nonce(&self) -> &Nonce;
+    fn valid_from(&self) -> DateTime<Utc>;
+    fn valid_until(&self) -> DateTime<Utc>;
+}
+
+impl Freshness for ExecutionPlan {
+    fn nonce(&self) -> &Nonce {
+        &self.nonce
+    }
+    fn valid_from(&self) -> DateTime<Utc> {
+        self.valid_from
+    }
+    fn valid_until(&self) -> DateTime<Utc> {
+        self.valid_until
+    }
+}
+
+/// Freshness block embedded inside a signed payload (e.g. a signed
+/// reconcile request). It lives inside the signed bytes, so tampering
+/// with the window or nonce breaks signature verification upstream.
+///
+/// Fields are optional on the wire so a payload that predates the
+/// block still deserializes; [`checked`](FreshnessClaims::checked)
+/// then fails closed when any is absent.
+#[derive(Debug, Clone, Default, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
+pub struct FreshnessClaims {
+    #[serde(default)]
+    pub valid_from: Option<DateTime<Utc>>,
+    #[serde(default)]
+    pub valid_until: Option<DateTime<Utc>>,
+    #[serde(default)]
+    pub nonce: Option<Nonce>,
+}
+
+impl FreshnessClaims {
+    pub fn new(valid_from: DateTime<Utc>, valid_until: DateTime<Utc>, nonce: Nonce) -> Self {
+        Self {
+            valid_from: Some(valid_from),
+            valid_until: Some(valid_until),
+            nonce: Some(nonce),
+        }
+    }
+
+    /// Fail-closed conversion to a verifiable value: absent freshness
+    /// is never valid.
+    pub fn checked(&self) -> Result<CheckedFreshness, PlanValidityError> {
+        match (self.valid_from, self.valid_until, self.nonce.clone()) {
+            (Some(valid_from), Some(valid_until), Some(nonce)) => Ok(CheckedFreshness {
+                valid_from,
+                valid_until,
+                nonce,
+            }),
+            _ => Err(PlanValidityError::MissingFreshness),
+        }
+    }
+}
+
+/// A [`FreshnessClaims`] with every field present, ready for
+/// [`check_window`] and [`NonceStore::check_and_insert`].
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct CheckedFreshness {
+    pub valid_from: DateTime<Utc>,
+    pub valid_until: DateTime<Utc>,
+    pub nonce: Nonce,
+}
+
+impl Freshness for CheckedFreshness {
+    fn nonce(&self) -> &Nonce {
+        &self.nonce
+    }
+    fn valid_from(&self) -> DateTime<Utc> {
+        self.valid_from
+    }
+    fn valid_until(&self) -> DateTime<Utc> {
+        self.valid_until
+    }
+}
+
+/// Stateless check: does the item's window cover `now`, and is it
 /// well-formed? Inverted windows fail closed.
-pub fn check_window(plan: &ExecutionPlan, now: DateTime<Utc>) -> Result<(), PlanValidityError> {
-    if plan.valid_from >= plan.valid_until {
+pub fn check_window<F: Freshness>(item: &F, now: DateTime<Utc>) -> Result<(), PlanValidityError> {
+    let valid_from = item.valid_from();
+    let valid_until = item.valid_until();
+    if valid_from >= valid_until {
         return Err(PlanValidityError::InvertedWindow {
-            valid_from: plan.valid_from,
-            valid_until: plan.valid_until,
+            valid_from,
+            valid_until,
         });
     }
-    if now < plan.valid_from {
-        return Err(PlanValidityError::NotYetValid {
-            valid_from: plan.valid_from,
-            now,
-        });
+    if now < valid_from {
+        return Err(PlanValidityError::NotYetValid { valid_from, now });
     }
-    if now >= plan.valid_until {
-        return Err(PlanValidityError::Expired {
-            valid_until: plan.valid_until,
-            now,
-        });
+    if now >= valid_until {
+        return Err(PlanValidityError::Expired { valid_until, now });
     }
     Ok(())
 }
@@ -86,18 +167,18 @@ impl NonceStore {
     /// Atomic check-and-insert. If the nonce was previously seen for
     /// this signer, returns `Err(NonceReplay)` and does not modify
     /// state.
-    pub fn check_and_insert(
+    pub fn check_and_insert<F: Freshness>(
         &mut self,
         signer: &str,
-        plan: &ExecutionPlan,
+        item: &F,
     ) -> Result<(), PlanValidityError> {
         let entry = self.seen.entry(signer.to_string()).or_default();
-        if entry.contains_key(&plan.nonce) {
+        if entry.contains_key(item.nonce()) {
             return Err(PlanValidityError::NonceReplay {
                 signer: signer.to_string(),
             });
         }
-        entry.insert(plan.nonce.clone(), plan.valid_until);
+        entry.insert(item.nonce().clone(), item.valid_until());
         Ok(())
     }
 
@@ -117,5 +198,120 @@ impl NonceStore {
 
     pub fn is_empty(&self) -> bool {
         self.len() == 0
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::plan::test_support::PlanFixture;
+    use chrono::Duration;
+
+    fn nonce(seed: u8) -> Nonce {
+        Nonce::from_bytes([seed; 16])
+    }
+
+    // The reusable freshness primitive rides the same window + nonce
+    // ledger the plan path uses — one store, not a fork.
+    #[test]
+    fn checked_freshness_passes_window_and_records_once() {
+        let now = Utc::now();
+        let claims = FreshnessClaims::new(
+            now - Duration::seconds(1),
+            now + Duration::minutes(5),
+            nonce(1),
+        );
+        let fresh = claims.checked().expect("full claims are valid");
+
+        check_window(&fresh, now).expect("now is inside the window");
+
+        let mut store = NonceStore::new();
+        store
+            .check_and_insert("signer-a", &fresh)
+            .expect("first use accepted");
+        assert_eq!(
+            store.check_and_insert("signer-a", &fresh),
+            Err(PlanValidityError::NonceReplay {
+                signer: "signer-a".into()
+            }),
+            "replay of the same nonce for the same signer is refused",
+        );
+    }
+
+    #[test]
+    fn absent_freshness_fields_fail_closed() {
+        // Wire tolerance: a payload missing the freshness block still
+        // deserializes (serde default), but verification rejects it.
+        let claims: FreshnessClaims =
+            serde_json::from_str("{}").expect("empty object deserializes");
+        assert_eq!(claims.checked(), Err(PlanValidityError::MissingFreshness));
+
+        // A partially-populated block is equally invalid.
+        let now = Utc::now();
+        let partial = FreshnessClaims {
+            valid_from: Some(now),
+            valid_until: Some(now + Duration::minutes(1)),
+            nonce: None,
+        };
+        assert_eq!(partial.checked(), Err(PlanValidityError::MissingFreshness));
+    }
+
+    #[test]
+    fn checked_freshness_rejects_stale_and_future_windows() {
+        let now = Utc::now();
+
+        let expired = FreshnessClaims::new(
+            now - Duration::minutes(10),
+            now - Duration::minutes(5),
+            nonce(2),
+        )
+        .checked()
+        .unwrap();
+        assert!(matches!(
+            check_window(&expired, now),
+            Err(PlanValidityError::Expired { .. })
+        ));
+
+        let not_yet = FreshnessClaims::new(
+            now + Duration::minutes(5),
+            now + Duration::minutes(10),
+            nonce(3),
+        )
+        .checked()
+        .unwrap();
+        assert!(matches!(
+            check_window(&not_yet, now),
+            Err(PlanValidityError::NotYetValid { .. })
+        ));
+    }
+
+    #[test]
+    fn freshness_claims_serde_roundtrips() {
+        let now = Utc::now();
+        let claims = FreshnessClaims::new(now, now + Duration::minutes(1), nonce(4));
+        let json = serde_json::to_string(&claims).unwrap();
+        let back: FreshnessClaims = serde_json::from_str(&json).unwrap();
+        assert_eq!(claims, back);
+    }
+
+    // ExecutionPlan must keep working through the generalized helpers —
+    // proves the plan admission path is not forked off a second copy.
+    #[test]
+    fn execution_plan_flows_through_generic_freshness() {
+        let now = Utc::now();
+        let plan = PlanFixture::new()
+            .nonce([9u8; 16])
+            .validity(now - Duration::seconds(1), now + Duration::minutes(5))
+            .build();
+
+        check_window(&plan, now).expect("plan window covers now");
+        let mut store = NonceStore::new();
+        store
+            .check_and_insert("host-signer", &plan)
+            .expect("first admission");
+        assert!(
+            store.check_and_insert("host-signer", &plan).is_err(),
+            "replayed plan refused"
+        );
     }
 }


### PR DESCRIPTION
Task B from the mvmd cloud-readiness assessment (`specs/research/mvmd-cloud-readiness-assessment.md`, PR #1383). Closes the mvm-side blocker for replay protection on mvmd's signed reconcile path.

## Problem
`ExecutionPlan` admission already enforces a validity window + per-signer nonce ledger (claim 8), but that machinery is hard-coupled to `ExecutionPlan`. The signed `ReconcileSigned` path in mvmd has **no** replay protection — a captured signed desired-state replays indefinitely — and couldn't reuse the plan's store without forking it.

## Change (mvm-core, reuse-not-fork)
- `Freshness` trait (`nonce` / `valid_from` / `valid_until`); `ExecutionPlan` implements it.
- `check_window` and `NonceStore::check_and_insert` are now generic over `Freshness`. The supervisor's plan-admission call sites compile and behave unchanged — **one replay store, not two**.
- `FreshnessClaims`: a `#[serde(default)]`-tolerant freshness block to embed inside a signed payload's signed bytes (so tampering breaks the upstream signature). `checked()` **fails closed** when any field is absent.
- `CheckedFreshness`: the all-present, verifiable value.

## Design note
`SignedPayload` is an opaque signed envelope, so freshness deliberately lives *inside* the typed payload (as `ExecutionPlan` already does), not as sibling fields of the envelope. This corrects the original task sketch.

## Tests
Window pass/record-once, replay refusal, stale/future rejection, serde roundtrip, absent-fields-fail-closed, and ExecutionPlan-through-the-generic-path (no-fork regression). **1413 mvm-core lib tests green**; doctests, clippy `-D warnings`, and fmt clean; `mvm-hostd` builds.

## Follow-up (mvmd)
Embed `FreshnessClaims` in the reconcile payload and guard `ReconcileSigned` with a shared `NonceStore`. Tracked as the mvmd side of Task B.