### PR TITLE
feat(client): mvm-client crate — MvmClient facade trait + DTO contract + mock (Plan 216 S0)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,6 +28,7 @@ members = [
     # JSON-in/JSON-out cdylib every language SDK loads through a thin FFI
     # shim, so adding a language carries no new Rust binding code.
     "crates/mvm-host-services-ffi",
+    "crates/mvm-client",
     "crates/mvm-mcp",
     # plan 74 W1 — OCI image distribution client (registry resolution,
     # manifest fetch, digest verification; layer fetch + ext4 unpack +

--- a/crates/mvm-client/Cargo.toml
+++ b/crates/mvm-client/Cargo.toml
@@ -1,0 +1,14 @@
+[package]
+name = "mvm-client"
+version.workspace = true
+edition.workspace = true
+license.workspace = true
+
+[dependencies]
+async-trait.workspace = true
+serde = { workspace = true, features = ["derive"] }
+thiserror = "1"
+
+[dev-dependencies]
+serde_json = { workspace = true }
+tokio = { workspace = true, features = ["macros", "rt"] }

--- a/crates/mvm-client/src/client.rs
+++ b/crates/mvm-client/src/client.rs
@@ -1,0 +1,1 @@
+//! Placeholder — filled by the next task.

--- a/crates/mvm-client/src/client.rs
+++ b/crates/mvm-client/src/client.rs
@@ -1,1 +1,35 @@
-//! Placeholder — filled by the next task.
+//! The facade trait. `async_trait` boxes the futures so `dyn MvmClient` stays
+//! object-safe — callers hold one backend behind a trait object and never see
+//! which transport is underneath.
+
+use async_trait::async_trait;
+
+use crate::dto::{LogOpts, MachineFilter, MachineId, MachineSpec, MachineState};
+use crate::error::Result;
+
+#[async_trait]
+pub trait MvmClient: Send + Sync {
+    /// List machines matching `filter`.
+    async fn list_machines(&self, filter: MachineFilter) -> Result<Vec<MachineState>>;
+
+    /// Launch a machine from `spec`; returns its initial state.
+    async fn run_machine(&self, spec: MachineSpec) -> Result<MachineState>;
+
+    /// Stop a machine by id. Idempotent: stopping a stopped machine is `Ok`.
+    async fn stop_machine(&self, id: &MachineId) -> Result<()>;
+
+    /// Fetch a machine's captured console/log bytes.
+    async fn machine_logs(&self, id: &MachineId, opts: LogOpts) -> Result<Vec<u8>>;
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    // Compile-time proof the trait is object-safe: a `dyn MvmClient` must be
+    // constructable, since callers (CLI, studio) hold one behind a box.
+    #[test]
+    fn trait_is_object_safe() {
+        fn _accepts(_c: &dyn MvmClient) {}
+    }
+}

--- a/crates/mvm-client/src/dto.rs
+++ b/crates/mvm-client/src/dto.rs
@@ -1,0 +1,1 @@
+//! Placeholder — filled by the next task.

--- a/crates/mvm-client/src/dto.rs
+++ b/crates/mvm-client/src/dto.rs
@@ -1,1 +1,101 @@
-//! Placeholder — filled by the next task.
+//! The wire contract. These types are the seam between a caller and any
+//! backend; the same structs will be deserialized by mvmd-gateway from the
+//! network, so they fail closed on unknown fields and carry intent only —
+//! never local host artifacts (keys, paths).
+
+use serde::{Deserialize, Serialize};
+
+#[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
+pub struct MachineId(pub String);
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum MachineStatus {
+    Starting,
+    Running,
+    Stopped,
+    Failed,
+}
+
+/// What to run — intent only. No host paths, no signing material.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct MachineSpec {
+    pub name: String,
+    pub image: String,
+    pub cpus: u32,
+    pub memory_mib: u32,
+    pub env: Vec<(String, String)>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct MachineState {
+    pub id: MachineId,
+    pub name: String,
+    pub status: MachineStatus,
+}
+
+#[derive(Debug, Clone, Default, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct MachineFilter {
+    pub name: Option<String>,
+    pub status: Option<MachineStatus>,
+}
+
+impl MachineFilter {
+    /// The unconstrained filter — matches every machine.
+    pub fn all() -> Self {
+        Self::default()
+    }
+}
+
+#[derive(Debug, Clone, Default, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct LogOpts {
+    pub follow: bool,
+    pub tail_lines: Option<u32>,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn machine_spec_serde_round_trips() {
+        let spec = MachineSpec {
+            name: "web".into(),
+            image: "docker.io/lib/nginx:1".into(),
+            cpus: 2,
+            memory_mib: 512,
+            env: vec![("PORT".into(), "8080".into())],
+        };
+        let json = serde_json::to_string(&spec).unwrap();
+        let back: MachineSpec = serde_json::from_str(&json).unwrap();
+        assert_eq!(spec, back);
+    }
+
+    #[test]
+    fn unknown_field_is_rejected_fail_closed() {
+        // A gateway deserializes these from the network; unexpected fields must
+        // fail closed, not be silently ignored.
+        let err = serde_json::from_str::<MachineSpec>(
+            r#"{"name":"w","image":"i","cpus":1,"memory_mib":64,"env":[],"rogue":true}"#,
+        );
+        assert!(err.is_err(), "unknown field must be rejected");
+    }
+
+    #[test]
+    fn machine_status_wire_is_snake_case() {
+        assert_eq!(
+            serde_json::to_string(&MachineStatus::Running).unwrap(),
+            "\"running\""
+        );
+    }
+
+    #[test]
+    fn filter_all_matches_nothing_set() {
+        let f = MachineFilter::all();
+        assert!(f.name.is_none() && f.status.is_none());
+    }
+}

--- a/crates/mvm-client/src/error.rs
+++ b/crates/mvm-client/src/error.rs
@@ -1,0 +1,1 @@
+//! Placeholder — filled by the next task.

--- a/crates/mvm-client/src/error.rs
+++ b/crates/mvm-client/src/error.rs
@@ -1,1 +1,30 @@
-//! Placeholder — filled by the next task.
+//! The facade's error type. Deliberately transport-agnostic: a `LocalBackend`
+//! and a `GatewayBackend` surface the same variants so callers branch on the
+//! failure, not on which backend produced it.
+
+use thiserror::Error;
+
+pub type Result<T> = std::result::Result<T, MvmError>;
+
+#[derive(Debug, Error)]
+pub enum MvmError {
+    #[error("machine not found: {id}")]
+    NotFound { id: String },
+    #[error("invalid machine spec: {reason}")]
+    InvalidSpec { reason: String },
+    #[error("backend error: {reason}")]
+    Backend { reason: String },
+    #[error("unauthorized: {reason}")]
+    Unauthorized { reason: String },
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn not_found_displays_the_id() {
+        let e = MvmError::NotFound { id: "m1".into() };
+        assert_eq!(e.to_string(), "machine not found: m1");
+    }
+}

--- a/crates/mvm-client/src/lib.rs
+++ b/crates/mvm-client/src/lib.rs
@@ -1,0 +1,13 @@
+//! The `MvmClient` facade: one trait fronting local microVM operations
+//! (in-process) and a remote `mvmd` fleet (REST), so a caller drives either
+//! target through the same calls. The remote implementation is a courier with
+//! no enforcement authority — every security decision is made by the authority
+//! that owns the path (the local host, or mvmd), never by this client.
+
+pub mod client;
+pub mod dto;
+pub mod error;
+pub mod mock;
+
+// Crate-root re-exports are added by the tasks that define each item
+// (`error`, then `client`) so the crate builds at every step.

--- a/crates/mvm-client/src/lib.rs
+++ b/crates/mvm-client/src/lib.rs
@@ -9,5 +9,5 @@ pub mod dto;
 pub mod error;
 pub mod mock;
 
-// Crate-root re-exports are added by the tasks that define each item
-// (`error`, then `client`) so the crate builds at every step.
+pub use client::MvmClient;
+pub use error::{MvmError, Result};

--- a/crates/mvm-client/src/mock.rs
+++ b/crates/mvm-client/src/mock.rs
@@ -1,0 +1,1 @@
+//! Placeholder — filled by the next task.

--- a/crates/mvm-client/src/mock.rs
+++ b/crates/mvm-client/src/mock.rs
@@ -1,1 +1,104 @@
-//! Placeholder — filled by the next task.
+//! An in-memory `MvmClient` for tests and for callers to develop against before
+//! a real backend exists. Not a production path.
+
+use std::sync::Mutex;
+
+use async_trait::async_trait;
+
+use crate::client::MvmClient;
+use crate::dto::{LogOpts, MachineFilter, MachineId, MachineSpec, MachineState, MachineStatus};
+use crate::error::{MvmError, Result};
+
+#[derive(Default)]
+pub struct MockBackend {
+    machines: Mutex<Vec<MachineState>>,
+    next: Mutex<u64>,
+}
+
+#[async_trait]
+impl MvmClient for MockBackend {
+    async fn list_machines(&self, filter: MachineFilter) -> Result<Vec<MachineState>> {
+        let all = self.machines.lock().unwrap();
+        Ok(all
+            .iter()
+            .filter(|m| filter.name.as_ref().is_none_or(|n| *n == m.name))
+            .filter(|m| filter.status.is_none_or(|s| s == m.status))
+            .cloned()
+            .collect())
+    }
+
+    async fn run_machine(&self, spec: MachineSpec) -> Result<MachineState> {
+        if spec.name.is_empty() {
+            return Err(MvmError::InvalidSpec {
+                reason: "name must not be empty".into(),
+            });
+        }
+        let mut n = self.next.lock().unwrap();
+        *n += 1;
+        let state = MachineState {
+            id: MachineId(format!("m{n}")),
+            name: spec.name,
+            status: MachineStatus::Running,
+        };
+        self.machines.lock().unwrap().push(state.clone());
+        Ok(state)
+    }
+
+    async fn stop_machine(&self, id: &MachineId) -> Result<()> {
+        let mut all = self.machines.lock().unwrap();
+        let m = all
+            .iter_mut()
+            .find(|m| m.id == *id)
+            .ok_or_else(|| MvmError::NotFound { id: id.0.clone() })?;
+        m.status = MachineStatus::Stopped;
+        Ok(())
+    }
+
+    async fn machine_logs(&self, id: &MachineId, _opts: LogOpts) -> Result<Vec<u8>> {
+        let all = self.machines.lock().unwrap();
+        if all.iter().any(|m| m.id == *id) {
+            Ok(Vec::new())
+        } else {
+            Err(MvmError::NotFound { id: id.0.clone() })
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::dto::*;
+
+    #[tokio::test]
+    async fn run_then_list_then_stop_roundtrips() {
+        let mock = MockBackend::default();
+
+        let spec = MachineSpec {
+            name: "web".into(),
+            image: "img".into(),
+            cpus: 1,
+            memory_mib: 128,
+            env: vec![],
+        };
+        let started = mock.run_machine(spec).await.unwrap();
+        assert_eq!(started.status, MachineStatus::Running);
+
+        let listed = mock.list_machines(MachineFilter::all()).await.unwrap();
+        assert_eq!(listed.len(), 1);
+        assert_eq!(listed[0].name, "web");
+
+        mock.stop_machine(&started.id).await.unwrap();
+        let after = mock.list_machines(MachineFilter::all()).await.unwrap();
+        assert_eq!(after[0].status, MachineStatus::Stopped);
+    }
+
+    #[tokio::test]
+    async fn stop_unknown_is_not_found() {
+        let mock = MockBackend::default();
+        let err = mock
+            .stop_machine(&MachineId("nope".into()))
+            .await
+            .unwrap_err();
+        assert!(matches!(err, MvmError::NotFound { .. }));
+    }
+}


### PR DESCRIPTION
Slice **S0** of [Plan 216](specs/plans/216-mvm-client-facade.md) — the additive foundation of the `mvm-client` facade. Purely additive: a new crate, plus one line in the workspace member list. No existing behavior changes.

## What's here
- `crates/mvm-client/` — new crate.
- `MvmClient` async trait (object-safe): `list_machines` / `run_machine` / `stop_machine` / `machine_logs`.
- `dto` — typed, **fail-closed** (`#[serde(deny_unknown_fields)]`), **intent-shaped** wire contract (`MachineSpec`/`MachineState`/`MachineId`/`MachineStatus`/`MachineFilter`/`LogOpts`). No host artifacts (keys/paths) — key-domain separation per ADR-104.
- `MvmError` — transport-agnostic error type.
- `MockBackend` — in-memory reference impl; the fixture later slices and studio test against.

## Not here (roadmapped)
`LocalBackend` (S1), `mvmctl` wiring (S2), `GatewayBackend` (S3, gated on ADR-104 + Plan 57 CT-1), `--remote`/TLS (S4). The trait holds zero enforcement authority (dumb-courier); the remote path lands behind server-side enforcement.

## Verification (TDD)
8 unit tests green (serde round-trip, unknown-field rejection, snake_case wire, object-safety, run→list→stop roundtrip, stop-unknown→NotFound). `clippy --all-targets -D warnings` clean, `fmt --all` clean, `cargo check --workspace` clean. `mvm-core` stays runtime-free (async/tokio live only in `mvm-client`).

Built by executing Plan 216 S0 task-by-task.