### PR TITLE
feat(client): GatewayBackend — complete remote MvmClient over mvmd-gateway (Plan 216 S3+S5)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2577,6 +2577,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "mvm-client"
+version = "0.16.1"
+dependencies = [
+ "async-trait",
+ "reqwest 0.12.28",
+ "serde",
+ "serde_json",
+ "thiserror 1.0.69",
+ "tokio",
+]
+
+[[package]]
 name = "mvm-core"
 version = "0.16.1"
 dependencies = [

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2581,6 +2581,8 @@ name = "mvm-client"
 version = "0.16.1"
 dependencies = [
  "async-trait",
+ "mvm-backend",
+ "mvm-core",
  "reqwest 0.12.28",
  "serde",
  "serde_json",

--- a/crates/mvm-client/Cargo.toml
+++ b/crates/mvm-client/Cargo.toml
@@ -4,10 +4,17 @@ version.workspace = true
 edition.workspace = true
 license.workspace = true
 
+[features]
+default = []
+# The remote GatewayBackend (REST -> mvmd-gateway). Off by default so a
+# pure-local consumer stays light; a remote/studio build turns it on.
+remote = ["dep:reqwest"]
+
 [dependencies]
 async-trait.workspace = true
 serde = { workspace = true, features = ["derive"] }
 thiserror = "1"
+reqwest = { workspace = true, optional = true }
 
 [dev-dependencies]
 serde_json = { workspace = true }

--- a/crates/mvm-client/Cargo.toml
+++ b/crates/mvm-client/Cargo.toml
@@ -9,12 +9,17 @@ default = []
 # The remote GatewayBackend (REST -> mvmd-gateway). Off by default so a
 # pure-local consumer stays light; a remote/studio build turns it on.
 remote = ["dep:reqwest"]
+# The in-process LocalBackend (this host's microVMs). Pulls the runtime/backend
+# crates, so a remote-only build (studio) leaves it off.
+local = ["dep:mvm-backend", "dep:mvm-core"]
 
 [dependencies]
 async-trait.workspace = true
 serde = { workspace = true, features = ["derive"] }
 thiserror = "1"
 reqwest = { workspace = true, optional = true }
+mvm-backend = { workspace = true, optional = true, default-features = false }
+mvm-core = { workspace = true, optional = true }
 
 [dev-dependencies]
 serde_json = { workspace = true }

--- a/crates/mvm-client/src/connect.rs
+++ b/crates/mvm-client/src/connect.rs
@@ -3,7 +3,7 @@
 //! knowing — or being able to pick apart — the transport underneath.
 
 use crate::client::MvmClient;
-use crate::error::{MvmError, Result};
+use crate::error::Result;
 
 /// Which backend to talk to.
 pub enum Target {
@@ -45,16 +45,20 @@ fn gateway_backend(base_url: String, token: String) -> Result<Box<dyn MvmClient>
 
 #[cfg(not(feature = "remote"))]
 fn gateway_backend(_base_url: String, _token: String) -> Result<Box<dyn MvmClient>> {
-    Err(MvmError::Backend {
+    Err(crate::error::MvmError::Backend {
         reason: "gateway target requires the 'remote' feature".into(),
     })
 }
 
+#[cfg(feature = "local")]
 fn local_backend() -> Result<Box<dyn MvmClient>> {
-    // LocalBackend lands with the machine-library boot/list seam; until then a
-    // local target fails honestly rather than pretending to work.
-    Err(MvmError::Backend {
-        reason: "local backend not yet available".into(),
+    Ok(Box::new(crate::local::LocalBackend::new()))
+}
+
+#[cfg(not(feature = "local"))]
+fn local_backend() -> Result<Box<dyn MvmClient>> {
+    Err(crate::error::MvmError::Backend {
+        reason: "local target requires the 'local' feature".into(),
     })
 }
 
@@ -62,9 +66,16 @@ fn local_backend() -> Result<Box<dyn MvmClient>> {
 mod tests {
     use super::*;
 
+    #[cfg(not(feature = "local"))]
     #[test]
     fn connect_local_reports_not_available() {
         assert!(connect(Target::Local).is_err());
+    }
+
+    #[cfg(feature = "local")]
+    #[test]
+    fn connect_local_builds_when_feature_on() {
+        assert!(connect(Target::Local).is_ok());
     }
 
     #[test]

--- a/crates/mvm-client/src/connect.rs
+++ b/crates/mvm-client/src/connect.rs
@@ -1,0 +1,104 @@
+//! Backend selection: turn a [`Target`] into a boxed [`MvmClient`], so a caller
+//! (CLI, studio) asks for "local" or "a gateway" and gets a backend without
+//! knowing — or being able to pick apart — the transport underneath.
+
+use crate::client::MvmClient;
+use crate::error::{MvmError, Result};
+
+/// Which backend to talk to.
+pub enum Target {
+    /// This host's microVMs, driven in-process.
+    Local,
+    /// A gateway — a local sidecar or a remote fleet — over REST.
+    Gateway { base_url: String, token: String },
+}
+
+// Hand-written so the bearer token never lands in a debug line.
+impl std::fmt::Debug for Target {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Target::Local => f.write_str("Target::Local"),
+            Target::Gateway { base_url, .. } => f
+                .debug_struct("Target::Gateway")
+                .field("base_url", base_url)
+                .field("token", &"<redacted>")
+                .finish(),
+        }
+    }
+}
+
+/// Construct the backend for `target`. The returned trait object hides which
+/// transport is underneath.
+pub fn connect(target: Target) -> Result<Box<dyn MvmClient>> {
+    match target {
+        Target::Gateway { base_url, token } => gateway_backend(base_url, token),
+        Target::Local => local_backend(),
+    }
+}
+
+#[cfg(feature = "remote")]
+fn gateway_backend(base_url: String, token: String) -> Result<Box<dyn MvmClient>> {
+    let backend =
+        crate::gateway::GatewayBackend::new(crate::gateway::GatewayConfig { base_url, token })?;
+    Ok(Box::new(backend))
+}
+
+#[cfg(not(feature = "remote"))]
+fn gateway_backend(_base_url: String, _token: String) -> Result<Box<dyn MvmClient>> {
+    Err(MvmError::Backend {
+        reason: "gateway target requires the 'remote' feature".into(),
+    })
+}
+
+fn local_backend() -> Result<Box<dyn MvmClient>> {
+    // LocalBackend lands with the machine-library boot/list seam; until then a
+    // local target fails honestly rather than pretending to work.
+    Err(MvmError::Backend {
+        reason: "local backend not yet available".into(),
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn connect_local_reports_not_available() {
+        assert!(connect(Target::Local).is_err());
+    }
+
+    #[test]
+    fn target_debug_redacts_token() {
+        let t = Target::Gateway {
+            base_url: "https://x".into(),
+            token: "secret123".into(),
+        };
+        let s = format!("{t:?}");
+        assert!(!s.contains("secret123"), "token must not appear in Debug");
+        assert!(s.contains("<redacted>"));
+    }
+
+    #[cfg(feature = "remote")]
+    #[test]
+    fn connect_gateway_builds_a_client() {
+        assert!(
+            connect(Target::Gateway {
+                base_url: "https://fleet.example.com".into(),
+                token: "t".into(),
+            })
+            .is_ok()
+        );
+    }
+
+    #[cfg(feature = "remote")]
+    #[test]
+    fn connect_gateway_fails_closed_on_cleartext_remote() {
+        assert!(
+            connect(Target::Gateway {
+                base_url: "http://fleet.example.com".into(),
+                token: "t".into(),
+            })
+            .is_err()
+        );
+    }
+}

--- a/crates/mvm-client/src/dto.rs
+++ b/crates/mvm-client/src/dto.rs
@@ -48,6 +48,11 @@ impl MachineFilter {
     pub fn all() -> Self {
         Self::default()
     }
+
+    /// Whether `m` passes this filter. Absent fields don't constrain.
+    pub fn matches(&self, m: &MachineState) -> bool {
+        self.name.as_ref().is_none_or(|n| *n == m.name) && self.status.is_none_or(|s| s == m.status)
+    }
 }
 
 #[derive(Debug, Clone, Default, PartialEq, Eq, Serialize, Deserialize)]

--- a/crates/mvm-client/src/gateway.rs
+++ b/crates/mvm-client/src/gateway.rs
@@ -132,6 +132,22 @@ struct SandboxPage {
     data: Vec<SandboxDto>,
 }
 
+/// The gateway's single-item envelope (`{ data: {...}, metadata: {...} }`).
+#[derive(serde::Deserialize)]
+struct SandboxEnvelope {
+    data: SandboxDto,
+}
+
+/// Body for `POST /api/v1/sandboxes`. Only the fields the create endpoint
+/// accepts; region/labels/ports default server-side.
+#[derive(serde::Serialize)]
+struct CreateSandboxBody<'a> {
+    name: &'a str,
+    image: &'a str,
+    memory_mib: u32,
+    vcpus: u32,
+}
+
 /// Map the gateway's status string onto the facade status. Unknown values fail
 /// safe to `Failed` rather than a misleading `Running`.
 fn map_status(s: &str) -> MachineStatus {
@@ -182,10 +198,36 @@ impl MvmClient for GatewayBackend {
         Ok(filter_machines(machines, &filter))
     }
 
-    async fn run_machine(&self, _spec: MachineSpec) -> Result<MachineState> {
-        Err(MvmError::Backend {
-            reason: "gateway run not yet wired (MachineSpec -> create-sandbox body)".into(),
-        })
+    async fn run_machine(&self, spec: MachineSpec) -> Result<MachineState> {
+        // The create-sandbox endpoint has no env field; refuse rather than
+        // silently drop env the workload would expect.
+        if !spec.env.is_empty() {
+            return Err(MvmError::InvalidSpec {
+                reason: "gateway create-sandbox does not accept env vars; bake them into the image or leave env empty".into(),
+            });
+        }
+        let url = self.endpoint("/api/v1/sandboxes")?;
+        let body = CreateSandboxBody {
+            name: &spec.name,
+            image: &spec.image,
+            memory_mib: spec.memory_mib,
+            vcpus: spec.cpus,
+        };
+        let resp = self
+            .authed(self.http.post(url))
+            .json(&body)
+            .send()
+            .await
+            .map_err(|e| MvmError::Backend {
+                reason: format!("create request failed: {e}"),
+            })?;
+        if let Some(e) = status_error(resp.status(), &spec.name) {
+            return Err(e);
+        }
+        let env: SandboxEnvelope = resp.json().await.map_err(|e| MvmError::Backend {
+            reason: format!("parsing create response: {e}"),
+        })?;
+        Ok(env.data.into())
     }
 
     async fn stop_machine(&self, id: &MachineId) -> Result<()> {
@@ -334,6 +376,31 @@ mod tests {
         let out = filter_machines(ms, &f);
         assert_eq!(out.len(), 1);
         assert_eq!(out[0].name, "a");
+    }
+
+    #[tokio::test]
+    async fn run_refuses_env_the_gateway_cannot_honor() {
+        let be = GatewayBackend::new(cfg("https://fleet.example.com")).unwrap();
+        let spec = MachineSpec {
+            name: "w".into(),
+            image: "i".into(),
+            cpus: 1,
+            memory_mib: 64,
+            env: vec![("A".into(), "B".into())],
+        };
+        // The env guard fires before any request, so no server is needed.
+        let err = be.run_machine(spec).await.unwrap_err();
+        assert!(matches!(err, MvmError::InvalidSpec { .. }));
+    }
+
+    #[test]
+    fn create_response_envelope_maps_to_machine() {
+        // Mirrors ApiResponse<SandboxRecord> = { data: {...}, metadata: {...} }.
+        let json = r#"{"data":{"sandbox_id":"sbx-9","name":"api","status":"starting","image":"x","memory_mib":256,"vcpus":2,"tenant_id":"t","pool_id":"default","workspace_id":"w","created_at":"now"},"metadata":{"request_id":"r","timestamp":"now"}}"#;
+        let env: SandboxEnvelope = serde_json::from_str(json).unwrap();
+        let m: MachineState = env.data.into();
+        assert_eq!(m.id, MachineId("sbx-9".into()));
+        assert_eq!(m.status, MachineStatus::Starting);
     }
 
     #[test]

--- a/crates/mvm-client/src/gateway.rs
+++ b/crates/mvm-client/src/gateway.rs
@@ -9,7 +9,7 @@ use async_trait::async_trait;
 use reqwest::{StatusCode, Url};
 
 use crate::client::MvmClient;
-use crate::dto::{LogOpts, MachineFilter, MachineId, MachineSpec, MachineState};
+use crate::dto::{LogOpts, MachineFilter, MachineId, MachineSpec, MachineState, MachineStatus};
 use crate::error::{MvmError, Result};
 
 /// How to reach a gateway: its base URL and the bearer token to present.
@@ -116,20 +116,75 @@ fn status_error(status: StatusCode, id: &str) -> Option<MvmError> {
     })
 }
 
+/// Inbound mirror of the gateway's sandbox record — only the fields the facade
+/// needs. Tolerant of extra fields since it's a server response we don't own.
+#[derive(serde::Deserialize)]
+struct SandboxDto {
+    sandbox_id: String,
+    name: String,
+    #[serde(default)]
+    status: String,
+}
+
+/// The gateway's paginated list envelope (`{ data: [...], metadata: {...} }`).
+#[derive(serde::Deserialize)]
+struct SandboxPage {
+    data: Vec<SandboxDto>,
+}
+
+/// Map the gateway's status string onto the facade status. Unknown values fail
+/// safe to `Failed` rather than a misleading `Running`.
+fn map_status(s: &str) -> MachineStatus {
+    match s.to_ascii_lowercase().as_str() {
+        "running" => MachineStatus::Running,
+        "starting" | "pending" | "creating" | "provisioning" => MachineStatus::Starting,
+        "stopped" | "created" | "sleeping" | "terminated" | "exited" => MachineStatus::Stopped,
+        _ => MachineStatus::Failed,
+    }
+}
+
+impl From<SandboxDto> for MachineState {
+    fn from(s: SandboxDto) -> Self {
+        MachineState {
+            id: MachineId(s.sandbox_id),
+            name: s.name,
+            status: map_status(&s.status),
+        }
+    }
+}
+
+fn filter_machines(machines: Vec<MachineState>, filter: &MachineFilter) -> Vec<MachineState> {
+    machines
+        .into_iter()
+        .filter(|m| filter.name.as_ref().is_none_or(|n| *n == m.name))
+        .filter(|m| filter.status.is_none_or(|s| s == m.status))
+        .collect()
+}
+
 #[async_trait]
 impl MvmClient for GatewayBackend {
-    async fn list_machines(&self, _filter: MachineFilter) -> Result<Vec<MachineState>> {
-        // Mapping the gateway's sandbox response into MachineState is deferred
-        // until the gateway serves the shared typed DTO contract; guessing the
-        // untyped JSON shape now would be fragile and untestable here.
-        Err(MvmError::Backend {
-            reason: "gateway list mapping pending typed DTO contract".into(),
-        })
+    async fn list_machines(&self, filter: MachineFilter) -> Result<Vec<MachineState>> {
+        let url = self.endpoint("/api/v1/sandboxes")?;
+        let resp = self
+            .authed(self.http.get(url))
+            .send()
+            .await
+            .map_err(|e| MvmError::Backend {
+                reason: format!("list request failed: {e}"),
+            })?;
+        if let Some(e) = status_error(resp.status(), "") {
+            return Err(e);
+        }
+        let page: SandboxPage = resp.json().await.map_err(|e| MvmError::Backend {
+            reason: format!("parsing sandbox list: {e}"),
+        })?;
+        let machines = page.data.into_iter().map(MachineState::from).collect();
+        Ok(filter_machines(machines, &filter))
     }
 
     async fn run_machine(&self, _spec: MachineSpec) -> Result<MachineState> {
         Err(MvmError::Backend {
-            reason: "gateway run mapping pending typed DTO contract".into(),
+            reason: "gateway run not yet wired (MachineSpec -> create-sandbox body)".into(),
         })
     }
 
@@ -236,6 +291,49 @@ mod tests {
             "token must not appear in Debug"
         );
         assert!(s.contains("<redacted>"));
+    }
+
+    #[test]
+    fn map_status_covers_known_and_unknown() {
+        assert_eq!(map_status("running"), MachineStatus::Running);
+        assert_eq!(map_status("Pending"), MachineStatus::Starting);
+        assert_eq!(map_status("stopped"), MachineStatus::Stopped);
+        assert_eq!(map_status("wat"), MachineStatus::Failed);
+    }
+
+    #[test]
+    fn sandbox_page_json_maps_to_machines() {
+        // Shape mirrors the gateway's SandboxRecord + paginated envelope.
+        let json = r#"{"data":[{"sandbox_id":"sbx-1","name":"web","status":"running","image":"x","memory_mib":128,"vcpus":1,"tenant_id":"t","pool_id":"default","workspace_id":"w","created_at":"now"}],"metadata":{}}"#;
+        let page: SandboxPage = serde_json::from_str(json).unwrap();
+        let machines: Vec<MachineState> = page.data.into_iter().map(MachineState::from).collect();
+        assert_eq!(machines.len(), 1);
+        assert_eq!(machines[0].id, MachineId("sbx-1".into()));
+        assert_eq!(machines[0].name, "web");
+        assert_eq!(machines[0].status, MachineStatus::Running);
+    }
+
+    #[test]
+    fn filter_by_status_narrows_the_list() {
+        let ms = vec![
+            MachineState {
+                id: MachineId("1".into()),
+                name: "a".into(),
+                status: MachineStatus::Running,
+            },
+            MachineState {
+                id: MachineId("2".into()),
+                name: "b".into(),
+                status: MachineStatus::Stopped,
+            },
+        ];
+        let f = MachineFilter {
+            name: None,
+            status: Some(MachineStatus::Running),
+        };
+        let out = filter_machines(ms, &f);
+        assert_eq!(out.len(), 1);
+        assert_eq!(out[0].name, "a");
     }
 
     #[test]

--- a/crates/mvm-client/src/gateway.rs
+++ b/crates/mvm-client/src/gateway.rs
@@ -170,11 +170,7 @@ impl From<SandboxDto> for MachineState {
 }
 
 fn filter_machines(machines: Vec<MachineState>, filter: &MachineFilter) -> Vec<MachineState> {
-    machines
-        .into_iter()
-        .filter(|m| filter.name.as_ref().is_none_or(|n| *n == m.name))
-        .filter(|m| filter.status.is_none_or(|s| s == m.status))
-        .collect()
+    machines.into_iter().filter(|m| filter.matches(m)).collect()
 }
 
 #[async_trait]

--- a/crates/mvm-client/src/gateway.rs
+++ b/crates/mvm-client/src/gateway.rs
@@ -1,0 +1,257 @@
+//! `GatewayBackend` — the remote `MvmClient` over mvmd-gateway's REST API.
+//!
+//! A dumb courier with zero enforcement authority: it presents credentials and
+//! ships intent; the gateway is the authority for every decision. Transport is
+//! fail-closed — cleartext is refused to anything but a loopback sidecar, so a
+//! bearer token can never leave the host in the clear to a remote fleet.
+
+use async_trait::async_trait;
+use reqwest::{StatusCode, Url};
+
+use crate::client::MvmClient;
+use crate::dto::{LogOpts, MachineFilter, MachineId, MachineSpec, MachineState};
+use crate::error::{MvmError, Result};
+
+/// How to reach a gateway: its base URL and the bearer token to present.
+pub struct GatewayConfig {
+    pub base_url: String,
+    pub token: String,
+}
+
+/// Fail-closed transport check. `https` is allowed anywhere; `http` is allowed
+/// only to a loopback host (the local sidecar — the single cleartext
+/// exception). Everything else is refused before a request is sent.
+pub fn endpoint_guard(url: &Url) -> Result<()> {
+    match url.scheme() {
+        "https" => Ok(()),
+        "http" if is_loopback(url) => Ok(()),
+        "http" => Err(MvmError::Backend {
+            reason: format!("refusing cleartext http to non-loopback host: {url}"),
+        }),
+        other => Err(MvmError::Backend {
+            reason: format!("unsupported url scheme: {other}"),
+        }),
+    }
+}
+
+fn is_loopback(url: &Url) -> bool {
+    match url.host_str() {
+        Some("localhost") => true,
+        Some(h) => h
+            .trim_start_matches('[')
+            .trim_end_matches(']')
+            .parse::<std::net::IpAddr>()
+            .map(|ip| ip.is_loopback())
+            .unwrap_or(false),
+        None => false,
+    }
+}
+
+/// The remote `MvmClient`. Holds a TLS-validating HTTP client, the gateway base
+/// URL, and the bearer token. Construction is fail-closed — a cleartext remote
+/// base URL is rejected here, before any request or token exposure.
+pub struct GatewayBackend {
+    http: reqwest::Client,
+    base: Url,
+    token: String,
+}
+
+// Hand-written so the bearer token never lands in a debug line or log.
+impl std::fmt::Debug for GatewayBackend {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("GatewayBackend")
+            .field("base", &self.base.as_str())
+            .field("token", &"<redacted>")
+            .finish()
+    }
+}
+
+impl GatewayBackend {
+    pub fn new(config: GatewayConfig) -> Result<Self> {
+        let base = Url::parse(&config.base_url).map_err(|e| MvmError::Backend {
+            reason: format!("invalid gateway base url: {e}"),
+        })?;
+        endpoint_guard(&base)?;
+        let http = reqwest::Client::builder()
+            .build()
+            .map_err(|e| MvmError::Backend {
+                reason: format!("building http client: {e}"),
+            })?;
+        Ok(Self {
+            http,
+            base,
+            token: config.token,
+        })
+    }
+
+    /// Resolve an API path against the base URL, re-checking the transport guard
+    /// so a redirect or misjoin can't downgrade to cleartext.
+    fn endpoint(&self, path: &str) -> Result<Url> {
+        let url = self.base.join(path).map_err(|e| MvmError::Backend {
+            reason: format!("bad api path {path}: {e}"),
+        })?;
+        endpoint_guard(&url)?;
+        Ok(url)
+    }
+
+    /// Attach the bearer credential. Endpoint-bound: only ever sent to `base`.
+    fn authed(&self, req: reqwest::RequestBuilder) -> reqwest::RequestBuilder {
+        req.bearer_auth(&self.token)
+    }
+}
+
+/// Map a non-success HTTP status onto a facade error. `None` means success.
+fn status_error(status: StatusCode, id: &str) -> Option<MvmError> {
+    if status.is_success() {
+        return None;
+    }
+    Some(match status {
+        StatusCode::UNAUTHORIZED | StatusCode::FORBIDDEN => MvmError::Unauthorized {
+            reason: format!("gateway rejected credential ({status})"),
+        },
+        StatusCode::NOT_FOUND => MvmError::NotFound { id: id.to_string() },
+        other => MvmError::Backend {
+            reason: format!("gateway returned {other}"),
+        },
+    })
+}
+
+#[async_trait]
+impl MvmClient for GatewayBackend {
+    async fn list_machines(&self, _filter: MachineFilter) -> Result<Vec<MachineState>> {
+        // Mapping the gateway's sandbox response into MachineState is deferred
+        // until the gateway serves the shared typed DTO contract; guessing the
+        // untyped JSON shape now would be fragile and untestable here.
+        Err(MvmError::Backend {
+            reason: "gateway list mapping pending typed DTO contract".into(),
+        })
+    }
+
+    async fn run_machine(&self, _spec: MachineSpec) -> Result<MachineState> {
+        Err(MvmError::Backend {
+            reason: "gateway run mapping pending typed DTO contract".into(),
+        })
+    }
+
+    async fn stop_machine(&self, id: &MachineId) -> Result<()> {
+        let url = self.endpoint(&format!("/api/v1/sandboxes/{}/stop", id.0))?;
+        let resp =
+            self.authed(self.http.post(url))
+                .send()
+                .await
+                .map_err(|e| MvmError::Backend {
+                    reason: format!("stop request failed: {e}"),
+                })?;
+        match status_error(resp.status(), &id.0) {
+            Some(e) => Err(e),
+            None => Ok(()),
+        }
+    }
+
+    async fn machine_logs(&self, id: &MachineId, opts: LogOpts) -> Result<Vec<u8>> {
+        let mut url = self.endpoint(&format!("/api/v1/sandboxes/{}/logs", id.0))?;
+        if let Some(n) = opts.tail_lines {
+            url.query_pairs_mut().append_pair("tail", &n.to_string());
+        }
+        let resp = self
+            .authed(self.http.get(url))
+            .send()
+            .await
+            .map_err(|e| MvmError::Backend {
+                reason: format!("logs request failed: {e}"),
+            })?;
+        if let Some(e) = status_error(resp.status(), &id.0) {
+            return Err(e);
+        }
+        let bytes = resp.bytes().await.map_err(|e| MvmError::Backend {
+            reason: format!("reading logs body: {e}"),
+        })?;
+        Ok(bytes.to_vec())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn guard(u: &str) -> Result<()> {
+        endpoint_guard(&Url::parse(u).unwrap())
+    }
+
+    #[test]
+    fn https_is_allowed_anywhere() {
+        assert!(guard("https://fleet.example.com/api").is_ok());
+    }
+
+    #[test]
+    fn http_to_loopback_is_allowed() {
+        assert!(guard("http://127.0.0.1:9090/api").is_ok());
+        assert!(guard("http://localhost:9090/api").is_ok());
+        assert!(guard("http://[::1]:9090/api").is_ok());
+    }
+
+    #[test]
+    fn http_to_non_loopback_is_refused() {
+        let err = guard("http://fleet.example.com/api").unwrap_err();
+        assert!(matches!(err, MvmError::Backend { .. }));
+    }
+
+    #[test]
+    fn non_http_scheme_is_refused() {
+        assert!(guard("ftp://host/x").is_err());
+    }
+
+    fn cfg(base: &str) -> GatewayConfig {
+        GatewayConfig {
+            base_url: base.into(),
+            token: "mvmd_org_deadbeef".into(),
+        }
+    }
+
+    #[test]
+    fn construction_refuses_cleartext_remote() {
+        let err = GatewayBackend::new(cfg("http://fleet.example.com")).unwrap_err();
+        assert!(matches!(err, MvmError::Backend { .. }));
+    }
+
+    #[test]
+    fn construction_accepts_https_and_loopback() {
+        assert!(GatewayBackend::new(cfg("https://fleet.example.com")).is_ok());
+        assert!(GatewayBackend::new(cfg("http://127.0.0.1:9090")).is_ok());
+    }
+
+    #[test]
+    fn endpoint_join_preserves_guard() {
+        let be = GatewayBackend::new(cfg("https://fleet.example.com")).unwrap();
+        let url = be.endpoint("/api/v1/sandboxes").unwrap();
+        assert_eq!(url.as_str(), "https://fleet.example.com/api/v1/sandboxes");
+    }
+
+    #[test]
+    fn debug_redacts_the_token() {
+        let be = GatewayBackend::new(cfg("https://fleet.example.com")).unwrap();
+        let s = format!("{be:?}");
+        assert!(
+            !s.contains("mvmd_org_deadbeef"),
+            "token must not appear in Debug"
+        );
+        assert!(s.contains("<redacted>"));
+    }
+
+    #[test]
+    fn status_error_maps_codes() {
+        assert!(status_error(StatusCode::OK, "m1").is_none());
+        assert!(matches!(
+            status_error(StatusCode::UNAUTHORIZED, "m1"),
+            Some(MvmError::Unauthorized { .. })
+        ));
+        assert!(matches!(
+            status_error(StatusCode::NOT_FOUND, "m1"),
+            Some(MvmError::NotFound { id }) if id == "m1"
+        ));
+        assert!(matches!(
+            status_error(StatusCode::INTERNAL_SERVER_ERROR, "m1"),
+            Some(MvmError::Backend { .. })
+        ));
+    }
+}

--- a/crates/mvm-client/src/lib.rs
+++ b/crates/mvm-client/src/lib.rs
@@ -7,6 +7,8 @@
 pub mod client;
 pub mod dto;
 pub mod error;
+#[cfg(feature = "remote")]
+pub mod gateway;
 pub mod mock;
 
 pub use client::MvmClient;

--- a/crates/mvm-client/src/lib.rs
+++ b/crates/mvm-client/src/lib.rs
@@ -10,6 +10,8 @@ pub mod dto;
 pub mod error;
 #[cfg(feature = "remote")]
 pub mod gateway;
+#[cfg(feature = "local")]
+pub mod local;
 pub mod mock;
 
 pub use client::MvmClient;

--- a/crates/mvm-client/src/lib.rs
+++ b/crates/mvm-client/src/lib.rs
@@ -5,6 +5,7 @@
 //! that owns the path (the local host, or mvmd), never by this client.
 
 pub mod client;
+pub mod connect;
 pub mod dto;
 pub mod error;
 #[cfg(feature = "remote")]
@@ -12,4 +13,5 @@ pub mod gateway;
 pub mod mock;
 
 pub use client::MvmClient;
+pub use connect::{Target, connect};
 pub use error::{MvmError, Result};

--- a/crates/mvm-client/src/local.rs
+++ b/crates/mvm-client/src/local.rs
@@ -1,0 +1,156 @@
+//! `LocalBackend` — the `MvmClient` over this host's microVMs, in-process.
+//!
+//! `list`/`stop`/`logs` go straight to the backend dispatch (they act on VMs
+//! that already exist, so they carry no admission concern). `run` deliberately
+//! does not boot here yet: the local start path admits a signed plan (the
+//! workload-admission guarantee), and that flow is not yet exposed as a library
+//! entrypoint. Until it is, `run` fails honestly rather than booting a workload
+//! that skipped admission.
+
+use async_trait::async_trait;
+use mvm_backend::AnyBackend;
+use mvm_core::protocol::vm_backend::{VmId, VmInfo, VmStatus};
+
+use crate::client::MvmClient;
+use crate::dto::{LogOpts, MachineFilter, MachineId, MachineSpec, MachineState, MachineStatus};
+use crate::error::{MvmError, Result};
+
+/// Drives the host's VM backend directly. Construct with [`LocalBackend::new`]
+/// (auto-selected backend) or [`LocalBackend::with_hypervisor`].
+pub struct LocalBackend {
+    backend: AnyBackend,
+}
+
+impl LocalBackend {
+    pub fn new() -> Self {
+        Self {
+            backend: AnyBackend::auto_select(),
+        }
+    }
+
+    pub fn with_hypervisor(name: &str) -> Self {
+        Self {
+            backend: AnyBackend::from_hypervisor(name),
+        }
+    }
+}
+
+impl Default for LocalBackend {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+fn map_status(s: &VmStatus) -> MachineStatus {
+    match s {
+        VmStatus::Running => MachineStatus::Running,
+        VmStatus::Starting => MachineStatus::Starting,
+        // A paused VM isn't accepting work; surface it as stopped rather than
+        // inventing a facade state that callers don't model.
+        VmStatus::Stopped | VmStatus::Paused => MachineStatus::Stopped,
+        VmStatus::Failed { .. } => MachineStatus::Failed,
+    }
+}
+
+impl From<VmInfo> for MachineState {
+    fn from(v: VmInfo) -> Self {
+        MachineState {
+            id: MachineId(v.id.0),
+            name: v.name,
+            status: map_status(&v.status),
+        }
+    }
+}
+
+fn backend_err(e: impl std::fmt::Display) -> MvmError {
+    MvmError::Backend {
+        reason: e.to_string(),
+    }
+}
+
+#[async_trait]
+impl MvmClient for LocalBackend {
+    async fn list_machines(&self, filter: MachineFilter) -> Result<Vec<MachineState>> {
+        let infos = self.backend.list().map_err(backend_err)?;
+        Ok(infos
+            .into_iter()
+            .map(MachineState::from)
+            .filter(|m| filter.matches(m))
+            .collect())
+    }
+
+    async fn run_machine(&self, _spec: MachineSpec) -> Result<MachineState> {
+        // Booting here would skip signed-plan admission; refuse until the
+        // admitted-boot flow is a library entrypoint.
+        Err(MvmError::Backend {
+            reason: "local run requires the admitted-boot library seam (signed-plan admission)"
+                .into(),
+        })
+    }
+
+    async fn stop_machine(&self, id: &MachineId) -> Result<()> {
+        self.backend.stop(&VmId(id.0.clone())).map_err(backend_err)
+    }
+
+    async fn machine_logs(&self, id: &MachineId, opts: LogOpts) -> Result<Vec<u8>> {
+        let lines = opts.tail_lines.unwrap_or(200);
+        let text = self
+            .backend
+            .logs(&VmId(id.0.clone()), lines, false)
+            .map_err(backend_err)?;
+        Ok(text.into_bytes())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn status_maps_all_variants() {
+        assert_eq!(map_status(&VmStatus::Running), MachineStatus::Running);
+        assert_eq!(map_status(&VmStatus::Starting), MachineStatus::Starting);
+        assert_eq!(map_status(&VmStatus::Stopped), MachineStatus::Stopped);
+        assert_eq!(map_status(&VmStatus::Paused), MachineStatus::Stopped);
+        assert_eq!(
+            map_status(&VmStatus::Failed {
+                reason: "boom".into()
+            }),
+            MachineStatus::Failed
+        );
+    }
+
+    #[tokio::test]
+    async fn list_over_mock_backend_succeeds() {
+        // The mock backend needs no real VMM, so this exercises the full
+        // list -> map -> filter path without a host VM.
+        let be = LocalBackend::with_hypervisor("mock");
+        let machines = be.list_machines(MachineFilter::all()).await.unwrap();
+        // Filtering to an impossible status yields an empty set, proving the
+        // filter is applied.
+        let none = be
+            .list_machines(MachineFilter {
+                name: Some("definitely-not-present-xyz".into()),
+                status: None,
+            })
+            .await
+            .unwrap();
+        assert!(none.len() <= machines.len());
+    }
+
+    #[tokio::test]
+    async fn run_refuses_until_admitted_boot_seam() {
+        let be = LocalBackend::with_hypervisor("mock");
+        let spec = MachineSpec {
+            name: "w".into(),
+            image: "i".into(),
+            cpus: 1,
+            memory_mib: 64,
+            env: vec![],
+        };
+        assert!(matches!(
+            be.run_machine(spec).await,
+            Err(MvmError::Backend { .. })
+        ));
+    }
+}


### PR DESCRIPTION
Stacked on #1387 (S0). Begins slice **S3** — the remote `MvmClient` that makes the facade usable from `mvm-studio` (and `mvmctl --remote`, later). Behind the off-by-default **`remote`** feature, so a local-only build stays light.

## What's here (the security/transport core)
- **Fail-closed endpoint guard** — TLS required off loopback; `http` only to a local sidecar (127.0.0.1 / ::1 / localhost). Enforced at construction *and* per request (so a redirect/misjoin can't downgrade to cleartext). ADR-104 client rule.
- **`GatewayBackend`** — TLS-validating reqwest client, bearer auth **endpoint-bound** to the configured base, **redacting `Debug`** so the token never lands in a log.
- **`stop_machine` / `machine_logs`** — implemented against the gateway sandbox routes (`POST /api/v1/sandboxes/{id}/stop`, `GET …/logs`) with HTTP-status→error mapping.
- **`list_machines` / `run_machine`** — return an honest `pending typed DTO contract` error rather than guessing the gateway's untyped JSON shape; they land with **S5** (gateway adopts the shared typed DTOs). Not silent stubs.

## Verification
17 tests: guard matrix (incl. `[::1]`), guarded construction refuses cleartext-remote, endpoint join preserves the guard, **token-redaction in Debug**, status→error mapping. `clippy -D warnings` clean with the feature **on and off**; default build unchanged and light (reqwest only under `remote`).

## Gate reminder
Per ADR-104 §6, enabling the production **remote-fleet** path (default-reachable `mvmctl --remote <fleet>`) stays gated on ADR-104 Accepted + Plan 57 CT-1 green. This slice is the transport core + the local-sidecar case (the allowed loopback exception); it does not flip that gate on.