### PR TITLE
fix(core): ingress redaction — mask longest secrets first to stop tail leak

### DIFF
--- a/crates/mvm-core/src/ingress_redaction.rs
+++ b/crates/mvm-core/src/ingress_redaction.rs
@@ -22,10 +22,27 @@ pub struct RedactionResult {
 /// Mask every occurrence of any known secret value in `buffer` before it is
 /// delivered to the guest. Binary-safe (operates on raw bytes). Empty secret
 /// values are ignored — they would otherwise match everywhere.
+///
+/// `buffer` must be a **complete** inbound message, not one chunk of a stream:
+/// matching is per-buffer, so a secret split across two buffers would slip
+/// through the seam. A streaming caller must reassemble (or carry the trailing
+/// `max_secret_len - 1` bytes across chunk boundaries) before calling this.
+///
+/// Matching is exact-byte on the secret's raw value. A secret the upstream
+/// echoes back **transformed** (base64/percent-encoded, case-folded) will not
+/// match — value-based masking sees only the literal bytes.
 pub fn redact_for_guest(buffer: &[u8], secret_values: &[&str]) -> RedactionResult {
+    // Mask longest secrets first. `replace_all` is non-overlapping, so if a
+    // shorter secret is a substring/prefix of a longer one and were masked
+    // first, the longer secret's tail would survive (e.g. masking "AAA" inside
+    // "AAAA" leaves a trailing "A"). Longest-first masks the full secret before
+    // any of its substrings are considered.
+    let mut ordered: Vec<&str> = secret_values.to_vec();
+    ordered.sort_by_key(|s| std::cmp::Reverse(s.len()));
+
     let mut redacted = buffer.to_vec();
     let mut hits = 0;
-    for secret in secret_values {
+    for secret in ordered {
         let needle = secret.as_bytes();
         if needle.is_empty() {
             continue;
@@ -114,5 +131,42 @@ mod tests {
         assert_eq!(result.hits, 1);
         assert!(!result.redacted.windows(5).any(|w| w == b"TOKEN"));
         assert_eq!(result.redacted.first(), Some(&0xff));
+    }
+
+    #[test]
+    fn longer_secret_tail_does_not_leak_when_prefix_listed_first() {
+        // A shorter secret that prefixes a longer one, listed first, must not
+        // leave the longer secret's tail in the buffer.
+        let body = b"key=sk-live-12345 end";
+        let result = redact_for_guest(body, &["sk-live", "sk-live-12345"]);
+        assert!(
+            !result
+                .redacted
+                .windows("sk-live-12345".len())
+                .any(|w| w == b"sk-live-12345"),
+            "full secret must not survive"
+        );
+        assert!(
+            !result
+                .redacted
+                .windows("-12345".len())
+                .any(|w| w == b"-12345"),
+            "the longer secret's tail must not leak"
+        );
+    }
+
+    #[test]
+    fn overlapping_substring_secrets_fully_masked_regardless_of_order() {
+        for order in [["AAA", "AAAA"], ["AAAA", "AAA"]] {
+            let result = redact_for_guest(b"xAAAAx", &order);
+            assert!(
+                !result.redacted.windows(4).any(|w| w == b"AAAA"),
+                "full secret must not survive (order {order:?})"
+            );
+            assert!(
+                !result.redacted.windows(3).any(|w| w == b"AAA"),
+                "no secret substring may leak (order {order:?})"
+            );
+        }
     }
 }


### PR DESCRIPTION
Addresses the background security review of `crates/mvm-core/src/ingress_redaction.rs` (landed in #1357).

## Finding 2 — substring/ordering tail leak (**fixed**)
`replace_all` is non-overlapping and secrets were masked in list order, so a shorter secret that prefixes a longer one — masked first — left the longer secret's **tail** in the buffer delivered to the guest:

```
secrets = ["sk-live", "sk-live-12345"]  ->  "[mvm-redacted]-12345"   ← tail leaks
```

Fix: **sort secret values longest-first** so the full secret is masked before any of its substrings are considered. Regression tests cover the prefix case and both list orderings.

## Finding 1 — streaming boundary (**documented; not exploitable today**)
`redact_for_guest` has **no caller yet** (it's a primitive awaiting ingress wiring), so a per-chunk split isn't reachable. Documented the **whole-buffer contract**: a streaming caller must reassemble, or carry the trailing `max_secret_len - 1` bytes across chunk boundaries, before calling. (A stateful streaming redactor can follow when the ingress path is wired.)

## Finding 3 — exact-byte matching (**documented limitation**)
Value-based masking sees only literal bytes; a secret the upstream echoes back **encoded** (base64/percent-encoded/case-folded) won't match. Noted in the doc comment.

## Verification
7 tests pass (5 existing + 2 new), `clippy -D warnings` + fmt clean. No behavior change beyond ordering; the function stays binary-safe and non-overlapping.