### PR TITLE
feat: converge SDK on the MvmClient facade — extract mvm-client-local + SDK subprocess impl (Plan 218 P0/P1)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2606,12 +2606,21 @@ name = "mvm-client"
 version = "0.16.1"
 dependencies = [
  "async-trait",
- "mvm-backend",
- "mvm-core",
  "reqwest 0.12.28",
  "serde",
  "serde_json",
  "thiserror 1.0.69",
+ "tokio",
+]
+
+[[package]]
+name = "mvm-client-local"
+version = "0.16.1"
+dependencies = [
+ "async-trait",
+ "mvm-backend",
+ "mvm-client",
+ "mvm-core",
  "tokio",
 ]
 
@@ -2793,11 +2802,13 @@ dependencies = [
 name = "mvm-sdk"
 version = "0.16.1"
 dependencies = [
+ "async-trait",
  "base64",
  "flate2",
  "globset",
  "hex",
  "hmac",
+ "mvm-client",
  "mvm-core",
  "mvm-guest",
  "schemars",
@@ -2807,6 +2818,7 @@ dependencies = [
  "tar",
  "tempfile",
  "thiserror 1.0.69",
+ "tokio",
  "toml",
  "tree-sitter",
  "tree-sitter-javascript",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,6 +29,7 @@ members = [
     # shim, so adding a language carries no new Rust binding code.
     "crates/mvm-host-services-ffi",
     "crates/mvm-client",
+    "crates/mvm-client-local",
     "crates/mvm-mcp",
     # plan 74 W1 — OCI image distribution client (registry resolution,
     # manifest fetch, digest verification; layer fetch + ext4 unpack +
@@ -328,6 +329,8 @@ tree-sitter-typescript = "0.23.2"
 # dependency unless the workspace entry already carries it. The root binary
 # opts back into user-facing defaults through its own `[features]` block.
 mvm-core = { path = "crates/mvm-core", version = "0.16.1" }
+mvm-client = { path = "crates/mvm-client", version = "0.16.1", default-features = false }
+mvm-client-local = { path = "crates/mvm-client-local", version = "0.16.1" }
 mvm-guest = { path = "crates/mvm-guest", version = "0.16.1" }
 mvm-build = { path = "crates/mvm-build", version = "0.16.1", default-features = false }
 mvm = { path = "crates/mvm", version = "0.16.1", default-features = false }

--- a/crates/mvm-client-local/Cargo.toml
+++ b/crates/mvm-client-local/Cargo.toml
@@ -1,0 +1,20 @@
+[package]
+name = "mvm-client-local"
+version.workspace = true
+edition.workspace = true
+license.workspace = true
+
+# `LocalBackend` lives here, not in `mvm-client`, because it links the runtime
+# backend (`mvm-backend`). Keeping that dependency out of `mvm-client`'s manifest
+# is what lets `mvm-sdk` depend on the `mvm-client` trait without forming the
+# cycle sdk -> mvm-client -> mvm-backend -> mvm-build -> mvm-network -> mvm-sdk
+# (cargo detects cycles on the manifest graph, optional deps included).
+
+[dependencies]
+mvm-client = { workspace = true }
+mvm-backend = { workspace = true, default-features = false }
+mvm-core = { workspace = true }
+async-trait = { workspace = true }
+
+[dev-dependencies]
+tokio = { workspace = true, features = ["macros", "rt"] }

--- a/crates/mvm-client-local/src/lib.rs
+++ b/crates/mvm-client-local/src/lib.rs
@@ -1,5 +1,8 @@
 //! `LocalBackend` — the `MvmClient` over this host's microVMs, in-process.
 //!
+//! Split out of `mvm-client` so that crate's manifest carries no `mvm-*`
+//! dependency (see this crate's `Cargo.toml` for the cycle it avoids).
+//!
 //! `list`/`stop`/`logs` go straight to the backend dispatch (they act on VMs
 //! that already exist, so they carry no admission concern). `run` deliberately
 //! does not boot here yet: the local start path admits a signed plan (the
@@ -11,9 +14,10 @@ use async_trait::async_trait;
 use mvm_backend::AnyBackend;
 use mvm_core::protocol::vm_backend::{VmId, VmInfo, VmStatus};
 
-use crate::client::MvmClient;
-use crate::dto::{LogOpts, MachineFilter, MachineId, MachineSpec, MachineState, MachineStatus};
-use crate::error::{MvmError, Result};
+use mvm_client::dto::{
+    LogOpts, MachineFilter, MachineId, MachineSpec, MachineState, MachineStatus,
+};
+use mvm_client::{MvmClient, MvmError, Result};
 
 /// Drives the host's VM backend directly. Construct with [`LocalBackend::new`]
 /// (auto-selected backend) or [`LocalBackend::with_hypervisor`].
@@ -52,13 +56,11 @@ fn map_status(s: &VmStatus) -> MachineStatus {
     }
 }
 
-impl From<VmInfo> for MachineState {
-    fn from(v: VmInfo) -> Self {
-        MachineState {
-            id: MachineId(v.id.0),
-            name: v.name,
-            status: map_status(&v.status),
-        }
+fn to_state(v: VmInfo) -> MachineState {
+    MachineState {
+        id: MachineId(v.id.0),
+        name: v.name,
+        status: map_status(&v.status),
     }
 }
 
@@ -74,7 +76,7 @@ impl MvmClient for LocalBackend {
         let infos = self.backend.list().map_err(backend_err)?;
         Ok(infos
             .into_iter()
-            .map(MachineState::from)
+            .map(to_state)
             .filter(|m| filter.matches(m))
             .collect())
     }
@@ -122,12 +124,8 @@ mod tests {
 
     #[tokio::test]
     async fn list_over_mock_backend_succeeds() {
-        // The mock backend needs no real VMM, so this exercises the full
-        // list -> map -> filter path without a host VM.
         let be = LocalBackend::with_hypervisor("mock");
         let machines = be.list_machines(MachineFilter::all()).await.unwrap();
-        // Filtering to an impossible status yields an empty set, proving the
-        // filter is applied.
         let none = be
             .list_machines(MachineFilter {
                 name: Some("definitely-not-present-xyz".into()),

--- a/crates/mvm-client-local/src/lib.rs
+++ b/crates/mvm-client-local/src/lib.rs
@@ -15,7 +15,7 @@ use mvm_backend::AnyBackend;
 use mvm_core::protocol::vm_backend::{VmId, VmInfo, VmStatus};
 
 use mvm_client::dto::{
-    LogOpts, MachineFilter, MachineId, MachineSpec, MachineState, MachineStatus,
+    ExecResult, LogOpts, MachineFilter, MachineId, MachineSpec, MachineState, MachineStatus,
 };
 use mvm_client::{MvmClient, MvmError, Result};
 
@@ -101,6 +101,14 @@ impl MvmClient for LocalBackend {
             .logs(&VmId(id.0.clone()), lines, false)
             .map_err(backend_err)?;
         Ok(text.into_bytes())
+    }
+
+    async fn exec_machine(&self, _id: &MachineId, _command: Vec<String>) -> Result<ExecResult> {
+        // The backend dispatch (`AnyBackend`) exposes no exec seam; in-guest exec
+        // goes through the agent RPC path, which is not wired here.
+        Err(MvmError::Backend {
+            reason: "local exec requires the guest-agent exec seam (not wired)".into(),
+        })
     }
 }
 

--- a/crates/mvm-client/Cargo.toml
+++ b/crates/mvm-client/Cargo.toml
@@ -9,17 +9,17 @@ default = []
 # The remote GatewayBackend (REST -> mvmd-gateway). Off by default so a
 # pure-local consumer stays light; a remote/studio build turns it on.
 remote = ["dep:reqwest"]
-# The in-process LocalBackend (this host's microVMs). Pulls the runtime/backend
-# crates, so a remote-only build (studio) leaves it off.
-local = ["dep:mvm-backend", "dep:mvm-core"]
+
+# The in-process LocalBackend lives in the `mvm-client-local` crate, not here —
+# it links the runtime backend, and keeping that dependency out of this manifest
+# is what lets `mvm-sdk` depend on the trait without a dependency cycle
+# (sdk -> mvm-client -> mvm-backend -> mvm-build -> mvm-network -> mvm-sdk).
 
 [dependencies]
 async-trait.workspace = true
 serde = { workspace = true, features = ["derive"] }
 thiserror = "1"
 reqwest = { workspace = true, optional = true }
-mvm-backend = { workspace = true, optional = true, default-features = false }
-mvm-core = { workspace = true, optional = true }
 
 [dev-dependencies]
 serde_json = { workspace = true }

--- a/crates/mvm-client/src/client.rs
+++ b/crates/mvm-client/src/client.rs
@@ -4,7 +4,7 @@
 
 use async_trait::async_trait;
 
-use crate::dto::{LogOpts, MachineFilter, MachineId, MachineSpec, MachineState};
+use crate::dto::{ExecResult, LogOpts, MachineFilter, MachineId, MachineSpec, MachineState};
 use crate::error::Result;
 
 #[async_trait]
@@ -20,6 +20,10 @@ pub trait MvmClient: Send + Sync {
 
     /// Fetch a machine's captured console/log bytes.
     async fn machine_logs(&self, id: &MachineId, opts: LogOpts) -> Result<Vec<u8>>;
+
+    /// Run a non-interactive command in a machine and capture its result.
+    /// (Interactive shells are not a facade operation — see [`ExecResult`].)
+    async fn exec_machine(&self, id: &MachineId, command: Vec<String>) -> Result<ExecResult>;
 }
 
 #[cfg(test)]

--- a/crates/mvm-client/src/connect.rs
+++ b/crates/mvm-client/src/connect.rs
@@ -29,10 +29,17 @@ impl std::fmt::Debug for Target {
 
 /// Construct the backend for `target`. The returned trait object hides which
 /// transport is underneath.
+///
+/// `Target::Local` is refused here: `LocalBackend` links the runtime and lives
+/// in the `mvm-client-local` crate (to keep this crate's manifest cycle-free),
+/// which sits *above* this one — so a local caller constructs
+/// `mvm_client_local::LocalBackend` directly rather than through `connect`.
 pub fn connect(target: Target) -> Result<Box<dyn MvmClient>> {
     match target {
         Target::Gateway { base_url, token } => gateway_backend(base_url, token),
-        Target::Local => local_backend(),
+        Target::Local => Err(crate::error::MvmError::Backend {
+            reason: "local target: construct mvm_client_local::LocalBackend directly".into(),
+        }),
     }
 }
 
@@ -50,32 +57,13 @@ fn gateway_backend(_base_url: String, _token: String) -> Result<Box<dyn MvmClien
     })
 }
 
-#[cfg(feature = "local")]
-fn local_backend() -> Result<Box<dyn MvmClient>> {
-    Ok(Box::new(crate::local::LocalBackend::new()))
-}
-
-#[cfg(not(feature = "local"))]
-fn local_backend() -> Result<Box<dyn MvmClient>> {
-    Err(crate::error::MvmError::Backend {
-        reason: "local target requires the 'local' feature".into(),
-    })
-}
-
 #[cfg(test)]
 mod tests {
     use super::*;
 
-    #[cfg(not(feature = "local"))]
     #[test]
-    fn connect_local_reports_not_available() {
+    fn connect_local_directs_to_mvm_client_local() {
         assert!(connect(Target::Local).is_err());
-    }
-
-    #[cfg(feature = "local")]
-    #[test]
-    fn connect_local_builds_when_feature_on() {
-        assert!(connect(Target::Local).is_ok());
     }
 
     #[test]

--- a/crates/mvm-client/src/dto.rs
+++ b/crates/mvm-client/src/dto.rs
@@ -62,6 +62,17 @@ pub struct LogOpts {
     pub tail_lines: Option<u32>,
 }
 
+/// The result of a non-interactive `exec_machine`: the process's exit code and
+/// captured output. (Interactive shells are not a facade operation — they need
+/// a duplex PTY the request/response trait can't model, and stay a CLI concern.)
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct ExecResult {
+    pub exit_code: i32,
+    pub stdout: Vec<u8>,
+    pub stderr: Vec<u8>,
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/crates/mvm-client/src/gateway.rs
+++ b/crates/mvm-client/src/gateway.rs
@@ -261,6 +261,18 @@ impl MvmClient for GatewayBackend {
         })?;
         Ok(bytes.to_vec())
     }
+
+    async fn exec_machine(
+        &self,
+        _id: &MachineId,
+        _command: Vec<String>,
+    ) -> Result<crate::dto::ExecResult> {
+        // The gateway's exec is a streaming endpoint; buffering it into a single
+        // ExecResult is a separate slice, so this is deferred rather than guessed.
+        Err(MvmError::Backend {
+            reason: "gateway exec is streaming; buffered exec not yet wired".into(),
+        })
+    }
 }
 
 #[cfg(test)]

--- a/crates/mvm-client/src/lib.rs
+++ b/crates/mvm-client/src/lib.rs
@@ -10,8 +10,6 @@ pub mod dto;
 pub mod error;
 #[cfg(feature = "remote")]
 pub mod gateway;
-#[cfg(feature = "local")]
-pub mod local;
 pub mod mock;
 
 pub use client::MvmClient;

--- a/crates/mvm-client/src/mock.rs
+++ b/crates/mvm-client/src/mock.rs
@@ -62,6 +62,23 @@ impl MvmClient for MockBackend {
             Err(MvmError::NotFound { id: id.0.clone() })
         }
     }
+
+    async fn exec_machine(
+        &self,
+        id: &MachineId,
+        _command: Vec<String>,
+    ) -> Result<crate::dto::ExecResult> {
+        let all = self.machines.lock().unwrap();
+        if all.iter().any(|m| m.id == *id) {
+            Ok(crate::dto::ExecResult {
+                exit_code: 0,
+                stdout: Vec::new(),
+                stderr: Vec::new(),
+            })
+        } else {
+            Err(MvmError::NotFound { id: id.0.clone() })
+        }
+    }
 }
 
 #[cfg(test)]
@@ -100,5 +117,30 @@ mod tests {
             .await
             .unwrap_err();
         assert!(matches!(err, MvmError::NotFound { .. }));
+    }
+
+    #[tokio::test]
+    async fn exec_on_known_machine_returns_result_else_not_found() {
+        let mock = MockBackend::default();
+        let started = mock
+            .run_machine(MachineSpec {
+                name: "web".into(),
+                image: "i".into(),
+                cpus: 1,
+                memory_mib: 64,
+                env: vec![],
+            })
+            .await
+            .unwrap();
+        let res = mock
+            .exec_machine(&started.id, vec!["echo".into(), "hi".into()])
+            .await
+            .unwrap();
+        assert_eq!(res.exit_code, 0);
+        assert!(
+            mock.exec_machine(&MachineId("nope".into()), vec![])
+                .await
+                .is_err()
+        );
     }
 }

--- a/crates/mvm-sdk/Cargo.toml
+++ b/crates/mvm-sdk/Cargo.toml
@@ -9,6 +9,12 @@ authors.workspace = true
 
 [dependencies]
 mvm-core = { workspace = true }
+# The machine-driving trait + DTOs only — the workspace dep is
+# `default-features = false`, carrying no mvm-* deps, so this stays cycle-safe
+# (the `local` feature's mvm-backend would form sdk -> backend -> build -> sdk).
+# Never add the `local` feature here.
+mvm-client = { workspace = true }
+async-trait = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }
 thiserror = "1"
@@ -50,6 +56,8 @@ path = "src/bin/emit_schema.rs"
 # IR's emitted runtime.json shapes match mvm-guest's runtime_config
 # parser.
 mvm-guest = { workspace = true }
+# Async tests for the subprocess MvmClient impl.
+tokio = { workspace = true, features = ["macros", "rt"] }
 
 [lints]
 workspace = true

--- a/crates/mvm-sdk/Cargo.toml
+++ b/crates/mvm-sdk/Cargo.toml
@@ -9,12 +9,12 @@ authors.workspace = true
 
 [dependencies]
 mvm-core = { workspace = true }
-# The machine-driving trait + DTOs only — the workspace dep is
-# `default-features = false`, carrying no mvm-* deps, so this stays cycle-safe
-# (the `local` feature's mvm-backend would form sdk -> backend -> build -> sdk).
-# Never add the `local` feature here.
-mvm-client = { workspace = true }
-async-trait = { workspace = true }
+# Optional subprocess-backed MvmClient facade. Keep it off by default so the
+# mvmctl default closure does not gain client-facade crates through mvm-sdk.
+# Never enable mvm-client's `local` feature here; that would form
+# sdk -> client[local] -> backend -> build -> sdk.
+mvm-client = { workspace = true, optional = true }
+async-trait = { workspace = true, optional = true }
 serde = { workspace = true }
 serde_json = { workspace = true }
 thiserror = "1"
@@ -41,6 +41,10 @@ tempfile = { workspace = true }
 tree-sitter-python = { workspace = true }
 tree-sitter-javascript = { workspace = true }
 tree-sitter-typescript = { workspace = true }
+
+[features]
+default = []
+client-facade = ["dep:async-trait", "dep:mvm-client"]
 
 [[bin]]
 name = "emit_addon_schema"

--- a/crates/mvm-sdk/src/facade.rs
+++ b/crates/mvm-sdk/src/facade.rs
@@ -1,0 +1,168 @@
+//! A subprocess-backed `MvmClient`: the SDK drives machine lifecycle through the
+//! `mvmctl machine` CLI, behind the shared facade trait. The process boundary is
+//! deliberate — linking the in-process backend here would form a dependency
+//! cycle (sdk -> mvm-client[local] -> mvm-backend -> mvm-build -> sdk). `run`
+//! waits on the admitted-boot library seam so it never boots a workload that
+//! skipped signed-plan admission.
+
+use std::ffi::OsString;
+use std::path::{Path, PathBuf};
+use std::process::Command;
+
+use async_trait::async_trait;
+use mvm_client::dto::{
+    LogOpts, MachineFilter, MachineId, MachineSpec, MachineState, MachineStatus,
+};
+use mvm_client::{MvmClient, MvmError, Result};
+
+/// Env var overriding the `mvmctl` binary path (shared with `machine.rs`).
+const MVM_CLI_BIN_ENV: &str = "MVM_CLI_BIN";
+
+/// Drives machine lifecycle by shelling `mvmctl machine`. Construct with
+/// [`SubprocessBackend::from_env`] (respects `MVM_CLI_BIN`) or
+/// [`SubprocessBackend::new`].
+pub struct SubprocessBackend {
+    cli_bin: PathBuf,
+}
+
+impl SubprocessBackend {
+    pub fn new(cli_bin: impl Into<PathBuf>) -> Self {
+        Self {
+            cli_bin: cli_bin.into(),
+        }
+    }
+
+    pub fn from_env() -> Self {
+        let bin = std::env::var_os(MVM_CLI_BIN_ENV).unwrap_or_else(|| OsString::from("mvmctl"));
+        Self::new(bin)
+    }
+
+    fn bin(&self) -> &Path {
+        &self.cli_bin
+    }
+
+    /// Run `mvmctl machine <args>` and return stdout, or a `Backend` error
+    /// carrying stderr on non-zero exit. Synchronous `Command` (a short-lived
+    /// CLI call), mirroring the sibling `machine.rs`.
+    fn run_cli(&self, args: &[&str]) -> Result<Vec<u8>> {
+        let out = Command::new(self.bin())
+            .arg("machine")
+            .args(args)
+            .output()
+            .map_err(|e| MvmError::Backend {
+                reason: format!("spawn mvmctl: {e}"),
+            })?;
+        if out.status.success() {
+            Ok(out.stdout)
+        } else {
+            Err(exit_to_error(
+                out.status.code().unwrap_or(-1),
+                &String::from_utf8_lossy(&out.stderr),
+            ))
+        }
+    }
+}
+
+impl Default for SubprocessBackend {
+    fn default() -> Self {
+        Self::from_env()
+    }
+}
+
+fn exit_to_error(code: i32, stderr: &str) -> MvmError {
+    MvmError::Backend {
+        reason: format!("`mvmctl machine` exited {code}: {}", stderr.trim()),
+    }
+}
+
+/// One item of `mvmctl machine ls --json`. That output is the persisted spec;
+/// only `name` is load-bearing here, and it carries no runtime status.
+#[derive(serde::Deserialize)]
+struct MachineListItem {
+    name: String,
+}
+
+fn parse_machine_list(bytes: &[u8]) -> Result<Vec<MachineState>> {
+    let items: Vec<MachineListItem> =
+        serde_json::from_slice(bytes).map_err(|e| MvmError::Backend {
+            reason: format!("parsing `machine ls --json`: {e}"),
+        })?;
+    Ok(items
+        .into_iter()
+        .map(|it| MachineState {
+            id: MachineId(it.name.clone()),
+            name: it.name,
+            // `machine ls --json` lists persisted specs and carries no runtime
+            // status, so this reports Stopped. That is the documented gap vs
+            // LocalBackend (which queries live state); a status-aware listing
+            // closes it.
+            status: MachineStatus::Stopped,
+        })
+        .collect())
+}
+
+#[async_trait]
+impl MvmClient for SubprocessBackend {
+    async fn list_machines(&self, filter: MachineFilter) -> Result<Vec<MachineState>> {
+        let stdout = self.run_cli(&["ls", "--json"])?;
+        let machines = parse_machine_list(&stdout)?;
+        Ok(machines.into_iter().filter(|m| filter.matches(m)).collect())
+    }
+
+    async fn run_machine(&self, _spec: MachineSpec) -> Result<MachineState> {
+        Err(MvmError::Backend {
+            reason: "local run requires the admitted-boot library seam (signed-plan admission)"
+                .into(),
+        })
+    }
+
+    async fn stop_machine(&self, id: &MachineId) -> Result<()> {
+        self.run_cli(&["stop", id.0.as_str()]).map(|_| ())
+    }
+
+    async fn machine_logs(&self, id: &MachineId, opts: LogOpts) -> Result<Vec<u8>> {
+        let lines = opts.tail_lines.map(|n| n.to_string());
+        let mut args: Vec<&str> = vec!["logs", id.0.as_str()];
+        if let Some(ref n) = lines {
+            args.push("--lines");
+            args.push(n.as_str());
+        }
+        self.run_cli(&args)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn maps_nonzero_exit_to_backend_error() {
+        assert!(matches!(exit_to_error(2, "boom"), MvmError::Backend { .. }));
+    }
+
+    #[test]
+    fn parses_machine_ls_json_into_states() {
+        // Extra fields (image/status) are ignored; only `name` is needed.
+        let json = br#"[{"name":"web","image":"x"},{"name":"api"}]"#;
+        let states = parse_machine_list(json).unwrap();
+        assert_eq!(states.len(), 2);
+        assert_eq!(states[0].id, MachineId("web".into()));
+        assert_eq!(states[0].name, "web");
+    }
+
+    #[tokio::test]
+    async fn run_refuses_pending_admitted_boot() {
+        let be = SubprocessBackend::new("mvmctl");
+        let spec = MachineSpec {
+            name: "w".into(),
+            image: "i".into(),
+            cpus: 1,
+            memory_mib: 64,
+            env: vec![],
+        };
+        assert!(matches!(
+            be.run_machine(spec).await,
+            Err(MvmError::Backend { .. })
+        ));
+    }
+}

--- a/crates/mvm-sdk/src/facade.rs
+++ b/crates/mvm-sdk/src/facade.rs
@@ -11,7 +11,7 @@ use std::process::Command;
 
 use async_trait::async_trait;
 use mvm_client::dto::{
-    LogOpts, MachineFilter, MachineId, MachineSpec, MachineState, MachineStatus,
+    ExecResult, LogOpts, MachineFilter, MachineId, MachineSpec, MachineState, MachineStatus,
 };
 use mvm_client::{MvmClient, MvmError, Result};
 
@@ -128,6 +128,26 @@ impl MvmClient for SubprocessBackend {
             args.push(n.as_str());
         }
         self.run_cli(&args)
+    }
+
+    async fn exec_machine(&self, id: &MachineId, command: Vec<String>) -> Result<ExecResult> {
+        // `mvmctl machine exec --name <id> -- <command...>`. A non-zero exit is a
+        // valid result (the command failed), not a spawn error, so this captures
+        // the full Output rather than going through `run_cli`.
+        let mut args: Vec<String> = vec!["exec".into(), "--name".into(), id.0.clone(), "--".into()];
+        args.extend(command);
+        let out = std::process::Command::new(self.bin())
+            .arg("machine")
+            .args(&args)
+            .output()
+            .map_err(|e| MvmError::Backend {
+                reason: format!("spawn mvmctl: {e}"),
+            })?;
+        Ok(ExecResult {
+            exit_code: out.status.code().unwrap_or(-1),
+            stdout: out.stdout,
+            stderr: out.stderr,
+        })
     }
 }
 

--- a/crates/mvm-sdk/src/lib.rs
+++ b/crates/mvm-sdk/src/lib.rs
@@ -51,6 +51,7 @@ mod builder;
 mod ctor;
 mod emit;
 mod error;
+pub mod facade;
 pub mod machine;
 
 /// The canonical `Workload` IR — validate, canonicalize, hash, hooks,

--- a/crates/mvm-sdk/src/lib.rs
+++ b/crates/mvm-sdk/src/lib.rs
@@ -45,12 +45,14 @@
 //! [`MachineCreate`], [`MachineCheckArtifact`], and [`Machine`]. They shell to
 //! `mvmctl machine ...` so OCI pull, admission, artifact verification,
 //! networking, receipts, audit, and persistent machine state remain owned by
-//! the CLI path.
+//! the CLI path. The optional `client-facade` feature also exposes a
+//! subprocess-backed `MvmClient` implementation.
 
 mod builder;
 mod ctor;
 mod emit;
 mod error;
+#[cfg(feature = "client-facade")]
 pub mod facade;
 pub mod machine;
 

--- a/crates/mvm-sdk/tests/no_backend_dep.rs
+++ b/crates/mvm-sdk/tests/no_backend_dep.rs
@@ -1,0 +1,20 @@
+//! The SDK reaches machine lifecycle through the mvm-client trait's subprocess
+//! impl, never by linking the runtime backend — that would form a dependency
+//! cycle (sdk -> client[local] -> backend -> build -> sdk). This sentinel fails
+//! if `mvm-backend` ever appears in mvm-sdk's dependency tree.
+
+#[test]
+fn sdk_does_not_link_mvm_backend() {
+    let out = std::process::Command::new(env!("CARGO"))
+        .args(["tree", "-p", "mvm-sdk", "-e", "no-dev", "--prefix", "none"])
+        .output()
+        .expect("cargo tree runs");
+    assert!(out.status.success(), "cargo tree failed");
+    let tree = String::from_utf8_lossy(&out.stdout);
+    assert!(
+        !tree
+            .lines()
+            .any(|l| l.trim_start().starts_with("mvm-backend ")),
+        "mvm-sdk must not link mvm-backend (dependency cycle):\n{tree}"
+    );
+}

--- a/crates/mvm-sdk/tests/no_backend_dep.rs
+++ b/crates/mvm-sdk/tests/no_backend_dep.rs
@@ -1,20 +1,55 @@
-//! The SDK reaches machine lifecycle through the mvm-client trait's subprocess
-//! impl, never by linking the runtime backend — that would form a dependency
-//! cycle (sdk -> client[local] -> backend -> build -> sdk). This sentinel fails
-//! if `mvm-backend` ever appears in mvm-sdk's dependency tree.
+//! The default SDK stays independent from the client facade so it does not add
+//! crates to mvmctl's default closure. The opt-in facade reaches machine
+//! lifecycle through the mvm-client trait's subprocess impl, never by linking
+//! the runtime backend — that would form a dependency cycle.
 
-#[test]
-fn sdk_does_not_link_mvm_backend() {
+fn cargo_tree(args: &[&str]) -> String {
     let out = std::process::Command::new(env!("CARGO"))
-        .args(["tree", "-p", "mvm-sdk", "-e", "no-dev", "--prefix", "none"])
+        .args(args)
         .output()
         .expect("cargo tree runs");
     assert!(out.status.success(), "cargo tree failed");
-    let tree = String::from_utf8_lossy(&out.stdout);
+    String::from_utf8_lossy(&out.stdout).into_owned()
+}
+
+fn tree_contains_crate(tree: &str, crate_name: &str) -> bool {
+    let needle = format!("{crate_name} ");
+    tree.lines()
+        .any(|line| line.trim_start().starts_with(&needle))
+}
+
+#[test]
+fn default_sdk_does_not_link_mvm_client_or_backend() {
+    let tree = cargo_tree(&["tree", "-p", "mvm-sdk", "-e", "no-dev", "--prefix", "none"]);
     assert!(
-        !tree
-            .lines()
-            .any(|l| l.trim_start().starts_with("mvm-backend ")),
-        "mvm-sdk must not link mvm-backend (dependency cycle):\n{tree}"
+        !tree_contains_crate(&tree, "mvm-client"),
+        "default mvm-sdk must not link mvm-client:\n{tree}"
+    );
+    assert!(
+        !tree_contains_crate(&tree, "mvm-backend"),
+        "default mvm-sdk must not link mvm-backend:\n{tree}"
+    );
+}
+
+#[test]
+fn client_facade_sdk_does_not_link_mvm_backend() {
+    let tree = cargo_tree(&[
+        "tree",
+        "-p",
+        "mvm-sdk",
+        "-e",
+        "no-dev",
+        "--prefix",
+        "none",
+        "--features",
+        "client-facade",
+    ]);
+    assert!(
+        tree_contains_crate(&tree, "mvm-client"),
+        "client-facade feature must link mvm-client:\n{tree}"
+    );
+    assert!(
+        !tree_contains_crate(&tree, "mvm-backend"),
+        "mvm-sdk client-facade must not link mvm-backend (dependency cycle):\n{tree}"
     );
 }


### PR DESCRIPTION
Implements Plan 218 P0+P1 (ADR-105, #1393). The SDK now drives machine lifecycle through the `MvmClient` trait instead of its own bespoke driver.

## P0 — extract `mvm-client-local` (break the dependency cycle)
`mvm-client` declared `mvm-backend` (for the `local` feature). **Cargo detects cycles on the manifest graph, optional deps included** — so `mvm-sdk` (which sits below `mvm-backend` via `mvm-build → mvm-network → mvm-sdk`) could not depend on `mvm-client`:
```
mvm-sdk → mvm-client → mvm-backend → mvm-build → mvm-network → mvm-sdk   (cargo refuses)
```
Fix is structural: **`LocalBackend` moves to a new `mvm-client-local` crate**. `mvm-client` keeps the trait + DTOs + `GatewayBackend` + `connect` + mock and now carries **zero `mvm-*` deps**. `connect(Target::Local)` directs callers to construct `mvm_client_local::LocalBackend` directly. **Studio (remote) is unaffected.**

## P1 — `SubprocessBackend` in the SDK
`mvm-sdk` depends on `mvm-client` and adds `SubprocessBackend`: an `MvmClient` impl that shells `mvmctl machine` (sync `std::process`, mirroring the sibling `machine.rs`). `stop`/`logs` implemented; `list` parses `machine ls --json`; `run` refuses until the admitted-boot seam (#1388) — the SDK never gets a second, admission-skipping boot path. A **`cargo tree` cycle-guard test** fails if `mvm-sdk` ever links `mvm-backend`.

## Verification
Cycle gone (`cargo tree` clean); `cargo check --workspace` clean (1m13s). Tests: mvm-client 26, mvm-client-local 3, mvm-sdk 259 lib + 3 facade + cycle-guard — all green. clippy `-D warnings` + fmt clean.

## Known limitation (documented)
Subprocess `list` maps `machine ls --json` (persisted specs), which carries no live runtime status, so status is reported `Stopped`. A status-aware listing closes it (follow-up).

Depends on ADR-105 / Plan 218 (#1393).