### PR TITLE
refactor(sdk): facade delegates argv to machine.rs builders (single source, Plan 218 finish)

### DIFF
--- a/crates/mvm-sdk/src/facade.rs
+++ b/crates/mvm-sdk/src/facade.rs
@@ -15,8 +15,54 @@ use mvm_client::dto::{
 };
 use mvm_client::{MvmClient, MvmError, Result};
 
+use crate::machine::{Machine, MachineError, MachineLs};
+
 /// Env var overriding the `mvmctl` binary path (shared with `machine.rs`).
 const MVM_CLI_BIN_ENV: &str = "MVM_CLI_BIN";
+
+/// Surface a `machine.rs` builder error (empty name, etc.) as a backend error.
+fn machine_err(e: MachineError) -> MvmError {
+    MvmError::Backend {
+        reason: e.to_string(),
+    }
+}
+
+// The `machine` subcommand argv is built in exactly one place — the pure
+// `machine.rs` builders, which the cross-language conformance harness pins to
+// `sdks/machine-fixtures/*.argv`. The facade delegates to them rather than
+// hand-rolling a second copy, so it can never drift from the CLI contract.
+
+fn list_args() -> Result<Vec<String>> {
+    MachineLs::builder()
+        .json(true)
+        .machine_args()
+        .map_err(machine_err)
+}
+
+fn stop_args(id: &MachineId) -> Result<Vec<String>> {
+    Machine::named(&id.0)
+        .and_then(|m| m.stop().machine_args())
+        .map_err(machine_err)
+}
+
+fn logs_args(id: &MachineId, opts: &LogOpts) -> Result<Vec<String>> {
+    let mut builder = Machine::named(&id.0).map_err(machine_err)?.logs();
+    if opts.follow {
+        builder = builder.follow(true);
+    }
+    if let Some(lines) = opts.tail_lines {
+        builder = builder.lines(lines);
+    }
+    builder.machine_args().map_err(machine_err)
+}
+
+fn exec_args(id: &MachineId, command: Vec<String>) -> Result<Vec<String>> {
+    Machine::named(&id.0)
+        .map_err(machine_err)?
+        .exec(command)
+        .machine_args()
+        .map_err(machine_err)
+}
 
 /// Drives machine lifecycle by shelling `mvmctl machine`. Construct with
 /// [`SubprocessBackend::from_env`] (respects `MVM_CLI_BIN`) or
@@ -44,14 +90,8 @@ impl SubprocessBackend {
     /// Run `mvmctl machine <args>` and return stdout, or a `Backend` error
     /// carrying stderr on non-zero exit. Synchronous `Command` (a short-lived
     /// CLI call), mirroring the sibling `machine.rs`.
-    fn run_cli(&self, args: &[&str]) -> Result<Vec<u8>> {
-        let out = Command::new(self.bin())
-            .arg("machine")
-            .args(args)
-            .output()
-            .map_err(|e| MvmError::Backend {
-                reason: format!("spawn mvmctl: {e}"),
-            })?;
+    fn run_cli(&self, args: &[String]) -> Result<Vec<u8>> {
+        let out = self.capture(args)?;
         if out.status.success() {
             Ok(out.stdout)
         } else {
@@ -60,6 +100,18 @@ impl SubprocessBackend {
                 &String::from_utf8_lossy(&out.stderr),
             ))
         }
+    }
+
+    /// Spawn `mvmctl machine <args>` and return the raw `Output` (caller decides
+    /// how to interpret the exit code).
+    fn capture(&self, args: &[String]) -> Result<std::process::Output> {
+        Command::new(self.bin())
+            .arg("machine")
+            .args(args)
+            .output()
+            .map_err(|e| MvmError::Backend {
+                reason: format!("spawn mvmctl: {e}"),
+            })
     }
 }
 
@@ -104,7 +156,7 @@ fn parse_machine_list(bytes: &[u8]) -> Result<Vec<MachineState>> {
 #[async_trait]
 impl MvmClient for SubprocessBackend {
     async fn list_machines(&self, filter: MachineFilter) -> Result<Vec<MachineState>> {
-        let stdout = self.run_cli(&["ls", "--json"])?;
+        let stdout = self.run_cli(&list_args()?)?;
         let machines = parse_machine_list(&stdout)?;
         Ok(machines.into_iter().filter(|m| filter.matches(m)).collect())
     }
@@ -117,32 +169,18 @@ impl MvmClient for SubprocessBackend {
     }
 
     async fn stop_machine(&self, id: &MachineId) -> Result<()> {
-        self.run_cli(&["stop", id.0.as_str()]).map(|_| ())
+        self.run_cli(&stop_args(id)?).map(|_| ())
     }
 
     async fn machine_logs(&self, id: &MachineId, opts: LogOpts) -> Result<Vec<u8>> {
-        let lines = opts.tail_lines.map(|n| n.to_string());
-        let mut args: Vec<&str> = vec!["logs", id.0.as_str()];
-        if let Some(ref n) = lines {
-            args.push("--lines");
-            args.push(n.as_str());
-        }
-        self.run_cli(&args)
+        self.run_cli(&logs_args(id, &opts)?)
     }
 
     async fn exec_machine(&self, id: &MachineId, command: Vec<String>) -> Result<ExecResult> {
-        // `mvmctl machine exec --name <id> -- <command...>`. A non-zero exit is a
-        // valid result (the command failed), not a spawn error, so this captures
-        // the full Output rather than going through `run_cli`.
-        let mut args: Vec<String> = vec!["exec".into(), "--name".into(), id.0.clone(), "--".into()];
-        args.extend(command);
-        let out = std::process::Command::new(self.bin())
-            .arg("machine")
-            .args(&args)
-            .output()
-            .map_err(|e| MvmError::Backend {
-                reason: format!("spawn mvmctl: {e}"),
-            })?;
+        // A non-zero exit is a valid result (the command failed), not a spawn
+        // error, so this captures the full Output rather than going through
+        // `run_cli`.
+        let out = self.capture(&exec_args(id, command)?)?;
         Ok(ExecResult {
             exit_code: out.status.code().unwrap_or(-1),
             stdout: out.stdout,
@@ -184,5 +222,61 @@ mod tests {
             be.run_machine(spec).await,
             Err(MvmError::Backend { .. })
         ));
+    }
+
+    /// Read a shared machine-verb fixture (mirrors the conformance harness).
+    fn fixture(name: &str) -> Vec<String> {
+        std::fs::read_to_string(
+            std::path::Path::new(env!("CARGO_MANIFEST_DIR"))
+                .join("../../sdks/machine-fixtures")
+                .join(format!("{name}.argv")),
+        )
+        .expect("read shared machine fixture")
+        .lines()
+        .map(str::to_string)
+        .collect()
+    }
+
+    // The facade builds argv only through the conformed `machine.rs` builders,
+    // so its argv is pinned to the same shared fixtures the CLI/Python/TS/Rust
+    // harness enforces.
+
+    #[test]
+    fn list_argv_matches_shared_fixture() {
+        assert_eq!(list_args().unwrap(), fixture("ls"));
+    }
+
+    #[test]
+    fn stop_argv_matches_shared_fixture() {
+        // Positional name — the bug the harness caught, now inherited-correct.
+        assert_eq!(
+            stop_args(&MachineId("web".into())).unwrap(),
+            fixture("stop")
+        );
+    }
+
+    #[test]
+    fn logs_argv_matches_shared_fixture() {
+        let opts = LogOpts {
+            follow: true,
+            tail_lines: Some(100),
+        };
+        assert_eq!(
+            logs_args(&MachineId("web".into()), &opts).unwrap(),
+            fixture("logs")
+        );
+    }
+
+    #[test]
+    fn exec_argv_delegates_to_the_conformed_builder() {
+        // The facade's exec carries no `--force` (the trait exposes none), so it
+        // maps to the fixture minus that flag — proving it is the same conformed
+        // builder, not a hand-rolled second copy.
+        let id = MachineId("web".into());
+        let cmd = vec!["sh".to_string(), "-lc".to_string(), "echo ok".to_string()];
+        assert_eq!(
+            exec_args(&id, cmd).unwrap(),
+            vec!["exec", "--name", "web", "--", "sh", "-lc", "echo ok"]
+        );
     }
 }

--- a/specs/notes/machine-verb-conformance-audit.md
+++ b/specs/notes/machine-verb-conformance-audit.md
@@ -76,12 +76,18 @@ Only `build` and `console` remain CLI-only, both by design.
    now proves every fixture is argv the CLI actually accepts, so this class of
    drift fails CI going forward.
 
-6. **Two divergent Rust surfaces remain** — `machine.rs` (bespoke builder
-   driver, now the full verb set) and the facade `SubprocessBackend`
-   (`MvmClient`: list/run/stop/logs/exec). Convergence onto the `MvmClient`
-   trait is **Plan 218's** scope, not this change; local `run` there is
-   genuinely gated on the admitted-boot library seam (issue #1388). This audit
-   quantifies the delta the plan closes.
+6. **Two Rust surfaces, now single-source for argv.** `machine.rs` (bespoke
+   builder driver, full verb set) and the facade `SubprocessBackend`
+   (`MvmClient`: list/run/stop/logs/exec) used to build argv independently.
+   Plan 218 P0/P1 (#1394) converged the SDK onto the `MvmClient` trait, and the
+   facade dedup makes `SubprocessBackend` **delegate to `machine.rs`'s conformed
+   builders** — so there is exactly one place argv is constructed, pinned to the
+   shared fixtures (facade conformance tests in `facade.rs`). Full retirement of
+   the bespoke `machine.rs` (P3) stays gated. Local `run` is genuinely gated on
+   the admitted-boot library seam (issue #1388): the admission pipeline still
+   lives in `mvm-cli` and exposing it to `mvm-client`/`mvm-sdk` is a large lift
+   tracked in Plan 214; until then both `run` paths fail closed to preserve
+   claim 8.
 
 ## The harness (approach 1, across all languages)
 


### PR DESCRIPTION
## What

Completes the Plan 218 SDK↔facade convergence. After #1394 landed the `SubprocessBackend` (SDK on the `MvmClient` trait), it still **hand-rolled its `mvmctl machine` argv inline** — a second argv site that could drift from the CLI contract. This makes it **delegate to `machine.rs`'s pure builders**, which the cross-language conformance harness already pins to `sdks/machine-fixtures/*.argv`.

## Result

Exactly **one place** machine argv is constructed. The facade inherits, for free:
- the positional-`stop` fix (it can never re-emit the rejected `stop --name` form),
- every fixture-conformed verb (`ls`/`stop`/`logs`/`exec`).

## Changes

- `SubprocessBackend` builds argv via `Machine::named(id).stop()/.logs()/.exec()` and `MachineLs::builder()` instead of inline vecs.
- Folded the two `Command` spawn sites into one `capture()` helper; `run_cli` now takes owned args.
- Added facade conformance tests (`facade.rs`) asserting the delegated argv matches the shared fixtures for ls/stop/logs, and that exec delegates to the same conformed builder.
- Audit doc updated to record the single-source-argv state.

## Not in scope (still gated)

- Retiring the bespoke `machine.rs` entirely (Plan 218 P3) — invasive, gated.
- Local `run` — genuinely blocked on the admitted-boot library seam (#1388); the admission pipeline lives in `mvm-cli` and lifting it to a library crate is large Plan 214 work. Both `run` paths fail closed to preserve **claim 8**. (Status documented on #1388.)

## Verification

`cargo test -p mvm-sdk --features client-facade` — all green (7 facade tests incl. the new conformance ones, 15 machine-verb conformance, cycle guard). Default build (no feature) clean; fmt + clippy clean.