### PR TITLE
refactor(core): move plan synthesis into mvm-core (slice 1 of the #1388 boot seam)

### DIFF
--- a/crates/mvm-cli/src/commands/ops/bench_probe.rs
+++ b/crates/mvm-cli/src/commands/ops/bench_probe.rs
@@ -10,7 +10,7 @@ use crate::commands::env::dev_vz::ensure_default_microvm_image;
 use crate::commands::vm::plan_admission::{
     AdmittedPlan, InMemoryNonceLedger, SystemClock, admit_for_run,
 };
-use crate::commands::vm::plan_builder::SynthesisInput;
+use mvm_core::plan::SynthesisInput;
 
 /// Keep the live probe above the current default-image kernel load floor. Smaller
 /// values can fail before readiness on Linux/libkrun, which makes the benchmark

--- a/crates/mvm-cli/src/commands/vm/exec.rs
+++ b/crates/mvm-cli/src/commands/vm/exec.rs
@@ -21,8 +21,8 @@ use super::Cli;
 use super::audit_chain::AuditEmitter;
 use super::host_signer::{PUBLIC_FILENAME, host_signer_id, load_or_init};
 use super::plan_admission::{InMemoryNonceLedger, SystemClock, admit_for_run};
-use mvm_core::plan::SynthesisInput;
 use crate::ui;
+use mvm_core::plan::SynthesisInput;
 
 #[derive(ClapArgs, Debug, Clone)]
 pub(in crate::commands) struct Args {

--- a/crates/mvm-cli/src/commands/vm/exec.rs
+++ b/crates/mvm-cli/src/commands/vm/exec.rs
@@ -21,7 +21,7 @@ use super::Cli;
 use super::audit_chain::AuditEmitter;
 use super::host_signer::{PUBLIC_FILENAME, host_signer_id, load_or_init};
 use super::plan_admission::{InMemoryNonceLedger, SystemClock, admit_for_run};
-use super::plan_builder::SynthesisInput;
+use mvm_core::plan::SynthesisInput;
 use crate::ui;
 
 #[derive(ClapArgs, Debug, Clone)]

--- a/crates/mvm-cli/src/commands/vm/mod.rs
+++ b/crates/mvm-cli/src/commands/vm/mod.rs
@@ -19,7 +19,6 @@ pub(super) mod managed_secrets;
 pub(super) mod pause;
 pub(crate) mod phase_timing;
 pub(super) mod plan_admission;
-pub(crate) mod plan_builder;
 pub(super) mod plan_persist;
 pub(super) mod policy_resolver;
 pub(super) mod proc;

--- a/crates/mvm-cli/src/commands/vm/plan_admission.rs
+++ b/crates/mvm-cli/src/commands/vm/plan_admission.rs
@@ -51,7 +51,7 @@ use mvm_core::policy::PolicyBundle;
 use std::sync::Mutex;
 
 use super::host_signer::host_signer_id;
-use super::plan_builder::{SynthesisInput, synthesize_plan};
+use mvm_core::plan::{SynthesisInput, synthesize_plan};
 
 pub use mvm_core::time::{Clock, SystemClock};
 

--- a/crates/mvm-cli/src/commands/vm/run_plan.rs
+++ b/crates/mvm-cli/src/commands/vm/run_plan.rs
@@ -64,7 +64,7 @@ use mvm_sdk::ir::{App, Workload};
 
 use super::managed_secrets::lower_app_secrets;
 use super::plan_admission::{InMemoryNonceLedger, SystemClock, admit_for_run};
-use super::plan_builder::SynthesisInput;
+use mvm_core::plan::SynthesisInput;
 use crate::commands::build::sandbox_record::{
     LoadedRecording, auto_exec_record_script, script_language_from_path,
 };

--- a/crates/mvm-cli/src/commands/vm/run_plan.rs
+++ b/crates/mvm-cli/src/commands/vm/run_plan.rs
@@ -64,10 +64,10 @@ use mvm_sdk::ir::{App, Workload};
 
 use super::managed_secrets::lower_app_secrets;
 use super::plan_admission::{InMemoryNonceLedger, SystemClock, admit_for_run};
-use mvm_core::plan::SynthesisInput;
 use crate::commands::build::sandbox_record::{
     LoadedRecording, auto_exec_record_script, script_language_from_path,
 };
+use mvm_core::plan::SynthesisInput;
 
 use super::exec::{RunArgs, RunMode};
 

--- a/crates/mvm-cli/src/commands/vm/up.rs
+++ b/crates/mvm-cli/src/commands/vm/up.rs
@@ -19,7 +19,7 @@ use super::plan_admission::{
     AdmittedPlan, BundleAdmissionContext, InMemoryNonceLedger, SystemClock, admit_for_run,
     populate_audit_substrate, stash_plan_for_bridge, thread_tenant_id,
 };
-use super::plan_builder::SynthesisInput;
+use mvm_core::plan::SynthesisInput;
 use super::policy_resolver::{
     LOCAL_DEFAULT, ResolveError, resolve_policy_bundle, resolve_policy_bundle_with_dir,
     resolve_supervisor_components, resolve_supervisor_components_with_dir,
@@ -2147,7 +2147,7 @@ mod admit_plan_tests {
     fn admission_emits_policy_resolved_live_when_bundle_parses() {
         // Manually stage a bundle whose tenant matches the synthesized
         // plan's tenant. We can't trivially make the synthesizer emit
-        // `<tenant>:<workload>` refs (the plan_builder hard-codes
+        // `<tenant>:<workload>` refs (synthesis hard-codes
         // `local-default`), so this test exercises the audit-mode
         // branch via `resolve_policy_for_admission` directly with an
         // ExecutionPlan we mutate post-synthesis.

--- a/crates/mvm-cli/src/commands/vm/up.rs
+++ b/crates/mvm-cli/src/commands/vm/up.rs
@@ -19,7 +19,6 @@ use super::plan_admission::{
     AdmittedPlan, BundleAdmissionContext, InMemoryNonceLedger, SystemClock, admit_for_run,
     populate_audit_substrate, stash_plan_for_bridge, thread_tenant_id,
 };
-use mvm_core::plan::SynthesisInput;
 use super::policy_resolver::{
     LOCAL_DEFAULT, ResolveError, resolve_policy_bundle, resolve_policy_bundle_with_dir,
     resolve_supervisor_components, resolve_supervisor_components_with_dir,
@@ -27,6 +26,7 @@ use super::policy_resolver::{
 use super::shared::{
     VmStartParams, clap_flake_ref, clap_port_spec, clap_vm_name, clap_volume_spec,
 };
+use mvm_core::plan::SynthesisInput;
 use mvm_core::policy::PolicyBundle;
 
 /// Inputs for [`admit_plan_for_boot`]. Grouped so the helper avoids

--- a/crates/mvm-cli/src/lib.rs
+++ b/crates/mvm-cli/src/lib.rs
@@ -24,8 +24,10 @@ pub use commands::run;
 /// Plan synthesis for library consumers — building an
 /// [`mvm_core::plan::ExecutionPlan`] from typed inputs.
 ///
-/// Synthesis produces an unsigned plan and confers no authority; signing and
-/// admission still gate execution.
+/// The synthesis core now lives in `mvm-core` (beside the plan types) so every
+/// driver can reach it; this re-export preserves the `mvm_cli::plan_builder`
+/// path. Synthesis produces an unsigned plan and confers no authority; signing
+/// and admission still gate execution.
 pub mod plan_builder {
-    pub use crate::commands::vm::plan_builder::{SynthesisInput, synthesize_plan};
+    pub use mvm_core::plan::{SynthesisInput, synthesize_plan};
 }

--- a/crates/mvm-core/src/plan/mod.rs
+++ b/crates/mvm-core/src/plan/mod.rs
@@ -48,8 +48,8 @@ pub use signing::{
     secrets_from_signed_json, sign_plan, tenant_from_signed_json, verify_plan,
 };
 pub use synthesis::{
-    DEFAULT_AUDIT_EVENT_PREFIX, DEFAULT_INTENT, DEFAULT_POLICY_REF, DEFAULT_TENANT,
-    SynthesisInput, VALIDITY_WINDOW_MINUTES, synthesize_plan,
+    DEFAULT_AUDIT_EVENT_PREFIX, DEFAULT_INTENT, DEFAULT_POLICY_REF, DEFAULT_TENANT, SynthesisInput,
+    VALIDITY_WINDOW_MINUTES, synthesize_plan,
 };
 pub use types::{
     AdmissionProfile, ArtifactPolicy, AttestationMode, AttestationRequirement, AuditLabels,

--- a/crates/mvm-core/src/plan/mod.rs
+++ b/crates/mvm-core/src/plan/mod.rs
@@ -27,6 +27,7 @@
 pub mod bundle;
 pub mod execution_plan;
 pub mod signing;
+pub mod synthesis;
 #[cfg(any(test, feature = "test-support"))]
 pub mod test_support;
 pub mod types;
@@ -45,6 +46,10 @@ pub use execution_plan::{ExecutionPlan, SCHEMA_VERSION};
 pub use signing::{
     PlanVerifyError, SignedExecutionPlan, plan_from_admitted_json, redaction_from_signed_json,
     secrets_from_signed_json, sign_plan, tenant_from_signed_json, verify_plan,
+};
+pub use synthesis::{
+    DEFAULT_AUDIT_EVENT_PREFIX, DEFAULT_INTENT, DEFAULT_POLICY_REF, DEFAULT_TENANT,
+    SynthesisInput, VALIDITY_WINDOW_MINUTES, synthesize_plan,
 };
 pub use types::{
     AdmissionProfile, ArtifactPolicy, AttestationMode, AttestationRequirement, AuditLabels,

--- a/crates/mvm-core/src/plan/synthesis.rs
+++ b/crates/mvm-core/src/plan/synthesis.rs
@@ -41,8 +41,6 @@
 //! | `nonce` | fresh 128 bits from `OsRng` per invocation |
 //! | everything else | conservative defaults (no attestation, destroy-on-exit, etc.) |
 
-use anyhow::Result;
-use chrono::{Duration, Utc};
 use crate::plan::{
     AdmissionProfile, ArtifactPolicy, AttestationMode, AttestationRequirement, AuditLabels,
     AuditTaxonomy, AuthPolicy, DepsVolumeBinding, ExecutionPlan, FsPolicyRef, KeyRotationSpec,
@@ -50,6 +48,8 @@ use crate::plan::{
     SCHEMA_VERSION, SecretBinding, SecretReleasePolicy, SignedImageRef, TenantId, TimeoutSpec,
     WorkloadId, WorkloadIntent,
 };
+use anyhow::Result;
+use chrono::{Duration, Utc};
 use rand::RngCore;
 use std::collections::BTreeMap;
 

--- a/crates/mvm-core/src/plan/synthesis.rs
+++ b/crates/mvm-core/src/plan/synthesis.rs
@@ -1,8 +1,14 @@
-//! `ExecutionPlan` synthesis from `mvmctl up` CLI args.
+//! `ExecutionPlan` synthesis from a resolved [`SynthesisInput`].
 //!
-//! Turns the surface-level CLI shape (flake ref, name, cpus, memory,
-//! volumes, ports, secrets, etc.) into a typed `mvm_core::plan::ExecutionPlan`
-//! the supervisor can verify, audit, and gate on.
+//! Turns an already-resolved launch shape (name, backend, image digest,
+//! cpus, memory, volumes, secrets, policy refs, etc.) into a typed
+//! [`crate::plan::ExecutionPlan`] the supervisor can verify, audit, and gate
+//! on. This is the pure, side-effect-free core of signed-plan admission
+//! (claim 8): the caller resolves CLI/API args into a `SynthesisInput`, this
+//! builds the unsigned plan, and the caller signs + admits it. Living in
+//! `mvm-core` (beside the plan types) lets every driver — the CLI, and the
+//! `mvm-client` local backend once the boot seam lands — synthesize through
+//! one contract.
 //!
 //! ## What lives here
 //!
@@ -37,7 +43,7 @@
 
 use anyhow::Result;
 use chrono::{Duration, Utc};
-use mvm_core::plan::{
+use crate::plan::{
     AdmissionProfile, ArtifactPolicy, AttestationMode, AttestationRequirement, AuditLabels,
     AuditTaxonomy, AuthPolicy, DepsVolumeBinding, ExecutionPlan, FsPolicyRef, KeyRotationSpec,
     Nonce, PlanId, PlanSeccompTier, PolicyRef, PostRunLifecycle, Resources, RuntimeProfileRef,
@@ -132,7 +138,7 @@ pub struct SynthesisInput<'a> {
     /// admit path re-verifies the archive against this triple before
     /// backend dispatch. Populating it from `mvmctl up` flags is the
     /// next step.
-    pub bundle_pin: Option<mvm_core::plan::bundle::PlanArtifact>,
+    pub bundle_pin: Option<crate::plan::bundle::PlanArtifact>,
     /// Optional pin to an application-dependencies volume sealed by
     /// `mvm_sdk::compile::deps_audit::seal_volume`. Populated by
     /// `mvmctl up`'s deps-install path when the workload declares
@@ -145,10 +151,10 @@ pub struct SynthesisInput<'a> {
     /// User-supplied host-fs grants (`--volume` / `MVM_VOLUMES`) to bake
     /// into the signed plan + audit log (claim 1 / claim 8). Empty for
     /// the common no-volume case.
-    pub shares: Vec<mvm_core::plan::HostShareGrant>,
+    pub shares: Vec<crate::plan::HostShareGrant>,
     /// Per-destination egress redaction authored by `--redact HOST[=audit]`.
     /// Default (all-off) preserves the curated-only baseline.
-    pub redaction: mvm_core::policy::RedactionPolicy,
+    pub redaction: crate::policy::RedactionPolicy,
     /// Caller-supplied audit labels merged into the synthesized plan's
     /// `audit_labels`. They serialize inside the signed payload and are
     /// inherited by every chain-signed audit entry. The profile-derived keys
@@ -159,7 +165,7 @@ pub struct SynthesisInput<'a> {
     pub audit_labels: AuditLabels,
     /// Per-workload agent verb allow-list threaded verbatim into the plan.
     /// `None` preserves the current class/profile-gate-only behavior.
-    pub agent_verbs: Option<Vec<mvm_core::plan::VerbId>>,
+    pub agent_verbs: Option<Vec<crate::plan::VerbId>>,
 }
 
 /// Build an unsigned `ExecutionPlan` from CLI-shaped input.
@@ -167,7 +173,7 @@ pub struct SynthesisInput<'a> {
 /// Generates a fresh `plan_id` (UUIDv4) and `nonce` (128 random bits)
 /// per invocation; the validity window starts at the call site's
 /// `now()` and lasts `VALIDITY_WINDOW_MINUTES`. The caller signs the
-/// returned plan via [`mvm_core::plan::sign_plan`] before passing it to the
+/// returned plan via [`crate::plan::sign_plan`] before passing it to the
 /// supervisor.
 pub fn synthesize_plan(input: &SynthesisInput<'_>) -> Result<ExecutionPlan> {
     let plan_id = PlanId(uuid::Uuid::new_v4().to_string());
@@ -284,7 +290,7 @@ pub fn synthesize_plan(input: &SynthesisInput<'_>) -> Result<ExecutionPlan> {
     })
 }
 
-/// Generate a fresh 128-bit nonce from `OsRng`. `mvm_core::plan::Nonce`
+/// Generate a fresh 128-bit nonce from `OsRng`. `crate::plan::Nonce`
 /// wraps a 32-character lowercase hex string (i.e., 16 bytes = 128
 /// bits) — match that here so the wire format roundtrips.
 fn fresh_nonce() -> Nonce {
@@ -383,7 +389,7 @@ mod tests {
             bundle_pin: None,
             deps_volume: None,
             shares: Vec::new(),
-            redaction: mvm_core::policy::RedactionPolicy::default(),
+            redaction: crate::policy::RedactionPolicy::default(),
             audit_labels: Default::default(),
             agent_verbs: None,
         }
@@ -586,7 +592,7 @@ mod tests {
         inp.secret_release = SecretReleasePolicy::PlanBound;
         inp.secrets = vec![SecretBinding {
             name: "API_KEY".into(),
-            source: mvm_core::plan::SecretSource::Keystore {
+            source: crate::plan::SecretSource::Keystore {
                 address: "api-key".into(),
             },
         }];
@@ -596,7 +602,7 @@ mod tests {
 
     #[test]
     fn synthesized_plan_carries_redaction_profiles() {
-        use mvm_core::policy::{
+        use crate::policy::{
             EntropyMode, NameMode, RedactionAction, RedactionPolicy, RedactionProfile,
         };
         let mut inp = input("myvm");
@@ -676,9 +682,9 @@ mod tests {
 
         // The label survives the sign -> verify round-trip inside the signed bytes.
         let key = ed25519_dalek::SigningKey::from_bytes(&[3u8; 32]);
-        let signed = mvm_core::plan::sign_plan(&plan, &key, "host:test");
+        let signed = crate::plan::sign_plan(&plan, &key, "host:test");
         let recovered =
-            mvm_core::plan::verify_plan(&signed, &[("host:test", &key.verifying_key())]).unwrap();
+            crate::plan::verify_plan(&signed, &[("host:test", &key.verifying_key())]).unwrap();
         assert_eq!(recovered.audit_labels["origin.descriptor"], "blake3:abc");
     }
 }


### PR DESCRIPTION
## What

Moves `synthesize_plan` + `SynthesisInput` (plus helpers, defaults, and ~26 tests) from CLI-private `mvm-cli/commands/vm/plan_builder.rs` into **`mvm-core::plan::synthesis`**, beside the plan types they build. Pure relocation — no behavior change.

## Why (slice 1 of #1388)

The admitted-boot library seam (#1388) is blocked because the signed-plan admission pipeline lives in `mvm-cli`, at the **top** of the dep graph — so `mvm-client`/`mvm-sdk` can't reach it, and their local `run` fails closed. `synthesize_plan` is the one piece that is **pure plan construction over `mvm_core::plan` types** (zero CLI deps, no side effects), so it moves down cleanly. This makes plan synthesis reachable by every driver and is the foundational, low-risk first step of the seam.

## Roadmap for the rest of the seam (not this PR)

Slice 1 (this PR): synthesis → `mvm-core`. ✅
Remaining, each larger/entangled (tracked on #1388):
2. Lift signing/verify (`host_signer`, `sign_plan`/`verify_plan` are already in `mvm-core`) into a reusable admit fn.
3. Split `admit_plan_for_boot`'s 10 concerns — separate the pure admit path from filesystem I/O / audit emission / policy resolution.
4. Expose a `boot_admitted(VmStartConfig, admitted)` orchestration fn in the runtime crate, then wire `LocalBackend::run` + the SDK subprocess `run` through it (Plan 218 P4). Until then both `run` paths stay honest errors — **claim 8 preserved throughout**.

## Verification

- `mvm-core` 1485 lib tests + 26 moved synthesis tests green; doctests green.
- claim-8 admission unchanged: `plan_admission` 22, `run_plan` 14.
- `xtask check-core-runtime-free` clean (synthesis pulls only rand/chrono/anyhow — no tokio).
- `mvm-cli` public `plan_builder` re-export repointed to `mvm_core::plan` (mvmd API path stable); fmt + clippy clean.