### PR TITLE
feat(sdk): status-aware machine ls (close the facade's always-Stopped gap)

### DIFF
--- a/crates/mvm-cli/src/commands/machine/mod.rs
+++ b/crates/mvm-cli/src/commands/machine/mod.rs
@@ -1597,20 +1597,52 @@ fn create_machine(args: MachineCreateArgs) -> Result<()> {
     Ok(())
 }
 
+/// `machine ls` row: the persisted spec plus its live run status. `status` is
+/// `running` when the backend reports the VM up, else `stopped`. SDK facades
+/// read this field so `MvmClient::list_machines` reports real status instead of
+/// assuming every persisted machine is stopped.
+#[derive(serde::Serialize)]
+struct MachineListEntry<'a> {
+    #[serde(flatten)]
+    spec: &'a MachineSpec,
+    status: &'static str,
+}
+
+/// Live status label for a persisted machine, resolved through the backend.
+fn machine_status_label(name: &str) -> &'static str {
+    if machine_is_running(name) {
+        "running"
+    } else {
+        "stopped"
+    }
+}
+
 fn list_machines(args: MachineListArgs) -> Result<()> {
     let specs = list_machine_specs()?;
     if args.json {
-        println!("{}", serde_json::to_string_pretty(&specs)?);
+        let entries: Vec<MachineListEntry<'_>> = specs
+            .iter()
+            .map(|spec| MachineListEntry {
+                spec,
+                status: machine_status_label(&spec.name),
+            })
+            .collect();
+        println!("{}", serde_json::to_string_pretty(&entries)?);
     } else if specs.is_empty() {
         println!("no machines");
     } else {
-        for spec in specs {
+        for spec in &specs {
             let source = spec
                 .image
                 .as_deref()
                 .or(spec.manifest.as_deref())
                 .unwrap_or("<no source>");
-            println!("{}\t{}", spec.name, source);
+            println!(
+                "{}\t{}\t{}",
+                spec.name,
+                machine_status_label(&spec.name),
+                source
+            );
         }
     }
     Ok(())
@@ -4250,6 +4282,21 @@ ssh_agent = true
             .map(|spec| spec.name)
             .collect::<Vec<_>>();
         assert_eq!(names, vec!["alpha", "zeta"]);
+    }
+
+    #[test]
+    fn machine_list_entry_flattens_spec_and_adds_status() {
+        let spec = spec_fixture("web");
+        let entry = MachineListEntry {
+            spec: &spec,
+            status: "running",
+        };
+        let v: serde_json::Value = serde_json::to_value(&entry).expect("serialize");
+        // Spec fields are flattened to the top level (not nested under `spec`),
+        // and the live `status` label rides alongside — the shape SDK facades read.
+        assert_eq!(v["name"], "web");
+        assert_eq!(v["status"], "running");
+        assert!(v.get("spec").is_none());
     }
 
     #[test]

--- a/crates/mvm-sdk/src/facade.rs
+++ b/crates/mvm-sdk/src/facade.rs
@@ -75,11 +75,26 @@ fn exit_to_error(code: i32, stderr: &str) -> MvmError {
     }
 }
 
-/// One item of `mvmctl machine ls --json`. That output is the persisted spec;
-/// only `name` is load-bearing here, and it carries no runtime status.
+/// One item of `mvmctl machine ls --json`: the persisted spec, of which `name`
+/// and the live `status` label are load-bearing here (other fields ignored).
+/// `status` is `#[serde(default)]` so an older CLI without the field degrades
+/// to `Stopped` rather than failing the parse.
 #[derive(serde::Deserialize)]
 struct MachineListItem {
     name: String,
+    #[serde(default)]
+    status: Option<String>,
+}
+
+/// Map the CLI's `ls --json` status label to a facade [`MachineStatus`].
+fn status_from_label(label: Option<&str>) -> MachineStatus {
+    match label {
+        Some("running") => MachineStatus::Running,
+        Some("starting") => MachineStatus::Starting,
+        Some("failed") => MachineStatus::Failed,
+        // `stopped`, absent (older CLI), or anything unrecognized → stopped.
+        _ => MachineStatus::Stopped,
+    }
 }
 
 fn parse_machine_list(bytes: &[u8]) -> Result<Vec<MachineState>> {
@@ -91,12 +106,8 @@ fn parse_machine_list(bytes: &[u8]) -> Result<Vec<MachineState>> {
         .into_iter()
         .map(|it| MachineState {
             id: MachineId(it.name.clone()),
+            status: status_from_label(it.status.as_deref()),
             name: it.name,
-            // `machine ls --json` lists persisted specs and carries no runtime
-            // status, so this reports Stopped. That is the documented gap vs
-            // LocalBackend (which queries live state); a status-aware listing
-            // closes it.
-            status: MachineStatus::Stopped,
         })
         .collect())
 }
@@ -161,13 +172,33 @@ mod tests {
     }
 
     #[test]
-    fn parses_machine_ls_json_into_states() {
-        // Extra fields (image/status) are ignored; only `name` is needed.
-        let json = br#"[{"name":"web","image":"x"},{"name":"api"}]"#;
+    fn parses_machine_ls_json_with_live_status() {
+        // Unknown fields (image) ignored; `status` maps to the facade status.
+        let json =
+            br#"[{"name":"web","image":"x","status":"running"},{"name":"api","status":"stopped"}]"#;
         let states = parse_machine_list(json).unwrap();
         assert_eq!(states.len(), 2);
         assert_eq!(states[0].id, MachineId("web".into()));
-        assert_eq!(states[0].name, "web");
+        assert_eq!(states[0].status, MachineStatus::Running);
+        assert_eq!(states[1].status, MachineStatus::Stopped);
+    }
+
+    #[test]
+    fn missing_status_degrades_to_stopped() {
+        // An older CLI without the `status` field must not fail the parse.
+        let json = br#"[{"name":"web"}]"#;
+        let states = parse_machine_list(json).unwrap();
+        assert_eq!(states[0].status, MachineStatus::Stopped);
+    }
+
+    #[test]
+    fn status_label_mapping_is_total() {
+        assert_eq!(status_from_label(Some("running")), MachineStatus::Running);
+        assert_eq!(status_from_label(Some("starting")), MachineStatus::Starting);
+        assert_eq!(status_from_label(Some("failed")), MachineStatus::Failed);
+        assert_eq!(status_from_label(Some("stopped")), MachineStatus::Stopped);
+        assert_eq!(status_from_label(Some("weird")), MachineStatus::Stopped);
+        assert_eq!(status_from_label(None), MachineStatus::Stopped);
     }
 
     #[tokio::test]


### PR DESCRIPTION
## What

`SubprocessBackend::list_machines` reported **every** persisted machine as `Stopped`, because `mvmctl machine ls --json` emitted only the persisted spec with no runtime status — the documented gap vs `LocalBackend`, which queries live state.

## Fix (at the source)

- **CLI**: `machine ls --json` now emits a `status` field (`running`/`stopped`, via the existing `machine_is_running` backend check) flattened alongside each spec; the human `ls` gains a status column.
- **Facade**: parses `status` into `MachineStatus`. The field is `#[serde(default)]`, so an older CLI without it degrades to `Stopped` rather than failing the parse (forward/backward compatible).

## Tests

- CLI `machine_list_entry_flattens_spec_and_adds_status` — spec fields stay top-level (flatten), `status` rides alongside, no nested `spec` key.
- Facade: `running`/`stopped` roundtrip, missing-field → `Stopped` fallback, and a total status-label mapping test.
- mvm-cli machine suite **99 green**, facade suite green, fmt + clippy clean.

Independent of the facade-dedup PR (#1397) — that changes `list_machines`'s argv construction; this changes `parse_machine_list`, a different function. Merges cleanly either order.