### PR TITLE
feat(cli): audit verb_denied across exec/run-code/attach (Plan 218 follow-on)

### DIFF
--- a/crates/mvm-cli/src/commands/vm/mod.rs
+++ b/crates/mvm-cli/src/commands/vm/mod.rs
@@ -33,6 +33,7 @@ pub(super) mod session;
 pub(super) mod set_ttl;
 pub(super) mod tenant_resolution;
 pub(super) mod up;
+pub(in crate::commands) mod verb_audit;
 pub(super) mod volume;
 pub(in crate::commands) mod wait;
 

--- a/crates/mvm-cli/src/commands/vm/session.rs
+++ b/crates/mvm-cli/src/commands/vm/session.rs
@@ -565,7 +565,7 @@ fn dispatch_update_idle_timeout(vm_name: &str, secs: u64) -> Result<(u64, u64)> 
             // The agent refused a verb the admitted plan didn't grant. Record the
             // chain-signed `verb_denied` entry (claim-12 parity) before surfacing
             // the error, so the refusal is observable and tamper-evident.
-            emit_verb_denied_audit(vm_name, &verb);
+            super::verb_audit::emit_verb_denied(vm_name, &verb);
             anyhow::bail!("guest agent denied verb {verb:?}: not in the plan's agent_verbs grant")
         }
         UpdateIdleOutcome::Unexpected { detail } => {
@@ -606,40 +606,6 @@ fn classify_update_idle_response(resp: mvm_guest::vsock::GuestResponse) -> Updat
         other => UpdateIdleOutcome::Unexpected {
             detail: format!("{other:?}"),
         },
-    }
-}
-
-/// Best-effort chain-signed `verb_denied` audit (claim-12 parity): fired when the
-/// guest agent refuses a verb the admitted plan did not grant. Loads the VM's
-/// persisted plan + host signer; a missing plan/signer or a flaky audit fs warns
-/// and skips — it never fails the caller, because the refusal already surfaces as
-/// an error and the audit is an observability record, not load-bearing.
-fn emit_verb_denied_audit(vm_name: &str, verb: &str) {
-    let plan = match super::plan_persist::read_plan(vm_name) {
-        Ok(p) => p,
-        Err(e) => {
-            tracing::warn!(error = %e, vm = vm_name, verb = verb,
-                "no persisted plan; verb_denied not chain-bound");
-            return;
-        }
-    };
-    let signer = match super::host_signer::load_or_init() {
-        Ok(s) => s,
-        Err(e) => {
-            tracing::warn!(error = %e, "host signer unavailable; verb_denied entry skipped");
-            return;
-        }
-    };
-    let emitter = match super::audit_chain::AuditEmitter::new(signer.signing) {
-        Ok(e) => e,
-        Err(e) => {
-            tracing::warn!(error = %e, "audit emitter unavailable; verb_denied entry skipped");
-            return;
-        }
-    };
-    if let Err(e) = emitter.emit_verb_denied(&plan, verb) {
-        tracing::warn!(error = %e, vm = vm_name, verb = verb,
-            "audit emit_verb_denied failed (non-fatal)");
     }
 }
 
@@ -729,7 +695,10 @@ fn cmd_attach(args: AttachArgs) -> Result<()> {
         args.timeout.unwrap_or(30),
         Some(&id),
     )
-    .with_context(|| format!("dispatching into session {id}"))?;
+    .with_context(|| format!("dispatching into session {id}"))
+    .inspect_err(|e| {
+        super::verb_audit::audit_verb_refusal(&record.vm_name, e);
+    })?;
 
     // Bump the session's invoke counter / last-used timestamp so
     // observers (`mvmctl session info`) see the activity.
@@ -788,7 +757,9 @@ fn cmd_exec(args: ExecArgs) -> Result<()> {
         .map(|a| shell_quote(a))
         .collect::<Vec<_>>()
         .join(" ");
-    run_in_session(&id, &record, cmd_line, args.timeout)
+    run_in_session(&id, &record, cmd_line, args.timeout).inspect_err(|e| {
+        super::verb_audit::audit_verb_refusal(&record.vm_name, e);
+    })
 }
 
 fn cmd_run_code(args: RunCodeArgs) -> Result<()> {
@@ -811,7 +782,9 @@ fn cmd_run_code(args: RunCodeArgs) -> Result<()> {
     // `from foo import bar` in call 1 isn't visible in call 2. v2
     // routes through the warm-process pool's wrapper for stateful
     // eval; the wire shape stays identical.
-    dispatch_run_code(&id, &record, args.code, args.timeout)
+    dispatch_run_code(&id, &record, args.code, args.timeout).inspect_err(|e| {
+        super::verb_audit::audit_verb_refusal(&record.vm_name, e);
+    })
 }
 
 /// Send a `RunCode` request to the session's guest agent and stream
@@ -1136,13 +1109,6 @@ mod tests {
             }
             _ => panic!("expected Unexpected"),
         }
-    }
-
-    #[test]
-    fn emit_verb_denied_audit_is_best_effort_when_no_plan() {
-        // A VM with no persisted plan ⇒ the helper warns and returns without
-        // panicking (mirrors the best-effort posture of the dispatch path).
-        emit_verb_denied_audit("nonexistent-vm-for-verb-denied-test", "update-idle-timeout");
     }
 
     struct RuntimeDirGuard {

--- a/crates/mvm-cli/src/commands/vm/verb_audit.rs
+++ b/crates/mvm-cli/src/commands/vm/verb_audit.rs
@@ -1,0 +1,103 @@
+//! Best-effort chain-signed `verb_denied` audit for agent-RPC refusals.
+//!
+//! When the guest agent refuses a verb the admitted plan's `agent_verbs` grant
+//! does not permit, it answers `VerbNotAuthorized`, which the host dispatch
+//! surfaces as a typed [`RpcError::VerbNotAuthorized`]. The host records that
+//! refusal as a chain-signed `verb_denied` entry (claim-12 parity) so denials are
+//! observable and tamper-evident. Emission is best-effort — the refusal already
+//! surfaces to the caller as an error; the audit is an observability record, not
+//! load-bearing.
+
+use mvm_guest::vsock::RpcError;
+
+/// Extract the denied verb from an error chain that carries an
+/// [`RpcError::VerbNotAuthorized`]. Pure (no I/O) so it is unit-tested; returns
+/// `None` for any other error, letting callers hand every dispatch failure to
+/// [`audit_verb_refusal`] without discriminating.
+fn denied_verb(err: &anyhow::Error) -> Option<&str> {
+    err.chain()
+        .find_map(|e| match e.downcast_ref::<RpcError>() {
+            Some(RpcError::VerbNotAuthorized { verb }) => Some(verb.as_str()),
+            _ => None,
+        })
+}
+
+/// Record a chain-signed `verb_denied` entry for `verb` on `vm_name`. Best-effort:
+/// loads the VM's persisted plan + host signer; a missing plan/signer or a flaky
+/// audit fs warns and skips — it never fails the caller.
+pub(in crate::commands) fn emit_verb_denied(vm_name: &str, verb: &str) {
+    let plan = match super::plan_persist::read_plan(vm_name) {
+        Ok(p) => p,
+        Err(e) => {
+            tracing::warn!(error = %e, vm = vm_name, verb = verb,
+                "no persisted plan; verb_denied not chain-bound");
+            return;
+        }
+    };
+    let signer = match super::host_signer::load_or_init() {
+        Ok(s) => s,
+        Err(e) => {
+            tracing::warn!(error = %e, "host signer unavailable; verb_denied entry skipped");
+            return;
+        }
+    };
+    let emitter = match super::audit_chain::AuditEmitter::new(signer.signing) {
+        Ok(e) => e,
+        Err(e) => {
+            tracing::warn!(error = %e, "audit emitter unavailable; verb_denied entry skipped");
+            return;
+        }
+    };
+    if let Err(e) = emitter.emit_verb_denied(&plan, verb) {
+        tracing::warn!(error = %e, vm = vm_name, verb = verb,
+            "audit emit_verb_denied failed (non-fatal)");
+    }
+}
+
+/// If `err`'s chain carries an [`RpcError::VerbNotAuthorized`], record the
+/// refusal; a no-op for any other error. Callers pass every dispatch failure here
+/// on the error path so grant refusals are audited uniformly across the verb
+/// surface (exec / run-code / attach / set-timeout).
+pub(in crate::commands) fn audit_verb_refusal(vm_name: &str, err: &anyhow::Error) {
+    if let Some(verb) = denied_verb(err) {
+        emit_verb_denied(vm_name, verb);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn denied_verb_extracts_from_a_context_wrapped_rpc_error() {
+        // Mirrors the real dispatch chain: RpcError::VerbNotAuthorized wrapped by
+        // `.context(...)` on the way up to the CLI command handler.
+        let err = anyhow::Error::from(RpcError::VerbNotAuthorized {
+            verb: "exec".into(),
+        })
+        .context("dispatching into session s-1");
+        assert_eq!(denied_verb(&err), Some("exec"));
+    }
+
+    #[test]
+    fn denied_verb_is_none_for_a_different_rpc_error() {
+        let err = anyhow::Error::from(RpcError::Agent("boom".into())).context("x");
+        assert_eq!(denied_verb(&err), None);
+    }
+
+    #[test]
+    fn denied_verb_is_none_for_a_plain_error() {
+        let err = anyhow::anyhow!("connection reset by peer");
+        assert_eq!(denied_verb(&err), None);
+    }
+
+    #[test]
+    fn audit_verb_refusal_is_best_effort_when_no_plan() {
+        // Carries a VerbNotAuthorized but the VM has no persisted plan ⇒ the helper
+        // warns and returns without panicking.
+        let err = anyhow::Error::from(RpcError::VerbNotAuthorized {
+            verb: "exec".into(),
+        });
+        audit_verb_refusal("nonexistent-vm-for-verb-audit-test", &err);
+    }
+}

--- a/crates/mvm-guest/src/vsock.rs
+++ b/crates/mvm-guest/src/vsock.rs
@@ -2950,6 +2950,11 @@ where
         let event = match resp {
             GuestResponse::ExecEvent(e) => e,
             GuestResponse::Error { message } => bail!("guest exec error: {message}"),
+            // Surface a grant refusal as the typed RpcError (not a stringified
+            // "unexpected variant") so the host can audit it as `verb_denied`.
+            GuestResponse::VerbNotAuthorized { verb } => {
+                return Err(RpcError::VerbNotAuthorized { verb }.into());
+            }
             other => bail!("expected ExecEvent during exec stream, got {other:?}"),
         };
         if event.is_terminal() {
@@ -6541,6 +6546,30 @@ mod tests {
         assert_eq!(got.len(), 1);
         assert!(matches!(got[0], ExecEvent::Stderr { ref chunk } if chunk == b"e"));
         assert!(matches!(term, ExecEvent::Exit { code: 2 }));
+    }
+
+    #[test]
+    fn read_exec_stream_surfaces_verb_denied_as_typed_rpc_error() {
+        // A grant refusal arriving on the exec stream must surface as the typed
+        // RpcError::VerbNotAuthorized (downcastable) so the host can audit it as
+        // `verb_denied` — not a stringified "unexpected variant".
+        let (mut host, mut guest) = UnixStream::pair().unwrap();
+        host.set_read_timeout(Some(Duration::from_secs(5))).unwrap();
+        let guest_handle = std::thread::spawn(move || {
+            write_frame(
+                &mut guest,
+                &GuestResponse::VerbNotAuthorized {
+                    verb: "run-code".to_string(),
+                },
+            )
+            .unwrap();
+        });
+        let err = read_exec_stream(&mut host, |_| {}).unwrap_err();
+        guest_handle.join().unwrap();
+        match err.downcast_ref::<RpcError>() {
+            Some(RpcError::VerbNotAuthorized { verb }) => assert_eq!(verb, "run-code"),
+            other => panic!("expected typed RpcError::VerbNotAuthorized, got {other:?}"),
+        }
     }
 }
 

--- a/crates/mvm/src/vm/exec_builder.rs
+++ b/crates/mvm/src/vm/exec_builder.rs
@@ -196,6 +196,11 @@ fn run_batch(
                 peak_rss_kib: o.peak_rss_kib,
             })
             .collect()),
+        // Surface a grant refusal as the typed RpcError so the host audits it as
+        // `verb_denied` rather than losing the verb in a stringified error.
+        GuestResponse::VerbNotAuthorized { verb } => {
+            Err(mvm_guest::vsock::RpcError::VerbNotAuthorized { verb }.into())
+        }
         other => bail!("unexpected response to ExecBatch: {:?}", other.variant()),
     }
 }


### PR DESCRIPTION
Broadens the chain-signed `verb_denied` audit (claim-12 parity) beyond the set-timeout path landed in #1396: now **every grant-gated agent RPC** (exec, run-code, attach) that the guest refuses is recorded.

## The gap this closes
`enforce_verb_grant` gates *any* `GuestRequest`, but only `update-idle-timeout` audited the refusal. The others surfaced `VerbNotAuthorized` as a **stringified** "unexpected variant" (the verb lost before reaching the `mvm-cli` layer where the `AuditEmitter` lives), so a refused `exec`/`run-code`/attach went un-audited.

## Changes
- **mvm-guest** — `read_exec_stream` maps a `VerbNotAuthorized` frame to the typed `RpcError::VerbNotAuthorized` (covers exec + run-code streaming).
- **mvm** — `exec_builder::run_batch` does the same for the `ExecBatch` (`call_unary`) path. The entrypoint `call_streaming` path already surfaced the typed error via `check_response`.
- **mvm-cli** — new `verb_audit` module: `denied_verb` (pure chain-walk over the anyhow error chain, unit-tested) + `emit_verb_denied` (chain-signed, best-effort) + `audit_verb_refusal`. Consolidates #1396's set-timeout emit onto it and wires it at the exec/run-code/attach dispatch error paths (`inspect_err`, so it's a no-op when the error isn't a refusal).

## Verification
TDD (RED→GREEN): typed-error stream test (mvm-guest) + `denied_verb` chain-walk / best-effort-no-plan (mvm-cli); `classify` tests carried over. `fmt` + `clippy --all-targets -D warnings` clean across the three crates. Full-suite regression sweep runs in CI.

## Follow-up
Live-boot end-to-end validation (grant-bearing guest refuses a denied verb → host writes the chain-signed `verb_denied`) is being run on real hardware (KVM + HVF), tracked toward the #1381 items.