### PR TITLE
fix(hvf): make the in-house VMM guest agent host-reachable over vsock

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -97,7 +97,7 @@ version = "1.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "40c48f72fd53cd289104fc64099abca73db4166ad86ea0b4341abe65af83dadc"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -108,7 +108,7 @@ checksum = "291e6a250ff86cd4a820112fb8898808a366d8f9f58ce16d1f538353ad55747d"
 dependencies = [
  "anstyle",
  "once_cell_polyfill",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -559,7 +559,7 @@ version = "3.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "faf9468729b8cbcea668e36183cb69d317348c2e08e994829fb56ebfdfbaac34"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -1144,7 +1144,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -2497,6 +2497,7 @@ dependencies = [
  "kvm-ioctls",
  "libc",
  "libkrun-sys",
+ "mio",
  "mvm-build",
  "mvm-core",
  "mvm-guest",
@@ -3030,7 +3031,7 @@ version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -3850,7 +3851,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys 0.12.1",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -3908,7 +3909,7 @@ dependencies = [
  "security-framework",
  "security-framework-sys",
  "webpki-root-certs",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -4623,7 +4624,7 @@ dependencies = [
  "getrandom 0.4.1",
  "once_cell",
  "rustix 1.1.4",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -5427,7 +5428,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -235,6 +235,9 @@ names = { version = "0.14", default-features = false }
 # Signal handling
 ctrlc = "3.4"
 libc = "0.2"
+# Readiness-driven event loop for the in-house VMM's host↔guest vsock I/O thread
+# (os-poll = kqueue/epoll + Waker; os-ext = SourceFd to register std sockets).
+mio = { version = "1", features = ["os-poll", "os-ext"] }
 
 # Seccomp BPF compilation (W2.4 — per-service syscall filtering inside
 # guests, applied via the `mvm-seccomp-apply` shim before execve into

--- a/crates/mvm-backend/Cargo.toml
+++ b/crates/mvm-backend/Cargo.toml
@@ -57,6 +57,7 @@ mvm-guest.workspace = true
 # which this crate already depends on non-optionally — so no new dep.
 mvm-build = { workspace = true, features = ["builder-vm"] }
 libkrun-sys.workspace = true
+mio.workspace = true
 # Vz backend foundation crate (SupervisorConfig types, supervisor-binary
 # path resolution). Pure data + helpers; no Swift dep.
 # Folded in with the former mvm-base crate: the base substrate's ui

--- a/crates/mvm-backend/src/hvf/kernel_boot.rs
+++ b/crates/mvm-backend/src/hvf/kernel_boot.rs
@@ -86,6 +86,22 @@ const PSCI_SYSTEM_OFF: u64 = 0x8400_0008;
 const PSCI_SYSTEM_RESET: u64 = 0x8400_0009;
 const PSCI_NOT_SUPPORTED: u64 = (-1i64) as u64;
 
+/// Raises a device SPI on the process-global in-kernel GIC — the [`IrqLine`] the
+/// vsock host-I/O thread uses to interrupt the guest off the vCPU exit path
+/// (mirrors the vCPU-path `set_irq` closure below). Zero-sized: the GIC is a
+/// process-global HVF resource, so no per-VM handle is needed.
+struct GicSpi;
+
+impl crate::vmm::vsock::IrqLine for GicSpi {
+    fn signal(&self, spi: u32) {
+        // SAFETY: FFI to the process-global in-kernel GIC created for this VM; it
+        // is thread-safe, so the host-I/O thread may assert an SPI directly.
+        unsafe {
+            hv_gic_set_spi(spi, true);
+        }
+    }
+}
+
 /// Outcome of a kernel boot attempt (with boot diagnostics).
 #[derive(Debug, Clone, Default)]
 pub struct KernelBootResult {
@@ -476,10 +492,19 @@ unsafe fn run(
             .collect();
         let mut vsock_dev =
             vsock.then(|| VirtioVsock::new(VSOCK_MMIO_BASE, VSOCK_IRQ, ram, RAM_BASE, ram_size));
-        // Transient run-to-exit: a guest write of the exit code to the workload
-        // exit port stops the run (and is captured below).
         if let Some(v) = vsock_dev.as_mut() {
-            v.capture_workload_exit(stop);
+            // Transient run-to-exit: a guest write of the exit code to the workload
+            // exit port stops the run (VM life = workload life) — but ONLY when this
+            // is not an agent-serving VM. An agent VM binds the agent socket; its
+            // baked `/init` reports a workload-exit the instant it finds no
+            // per-call entrypoint, yet the agent keeps serving. Tearing the VM down
+            // on that early signal would kill the agent before a host RPC (e.g.
+            // `machine invoke`) can reach it. Persistent agent VMs are ended by the
+            // supervisor's SIGTERM/timeout instead. The exit code is still recorded
+            // for reporting either way.
+            if !agent_bound {
+                v.capture_workload_exit(stop);
+            }
             // Host→guest agent RPC (GUEST_AGENT_PORT): expose the listener so host
             // clients (`machine invoke`) reach the guest agent over vsock.
             if let Some(path) = &agent_socket {
@@ -502,6 +527,12 @@ unsafe fn run(
                 v.set_substitution_activity(egress_active.clone());
                 v.set_substitution_endpoint(relay);
             }
+            // Start the dedicated host-I/O thread now that the agent/egress sockets
+            // are wired: it services host→guest delivery on wall-clock time and
+            // raises the guest IRQ itself, so reachability no longer depends on the
+            // starved vCPU `poll()` path. Joined in `shutdown()` below before RAM
+            // is freed.
+            v.start_io(Arc::new(GicSpi));
         }
 
         // Diagnostics gathered by the exception hook (HVC/PSCI + other traps).
@@ -568,6 +599,11 @@ unsafe fn run(
 
         done.store(true, Ordering::Relaxed);
         let _ = watchdog.join();
+        // Join the vsock host-I/O thread before touching device state or freeing
+        // the guest RAM it points into — the join is the memory-safety barrier.
+        if let Some(v) = vsock_dev.as_mut() {
+            v.shutdown();
+        }
         let final_pc = vcpu.get_core(CoreReg::Pc).unwrap_or(0);
         hv_vcpu_destroy(vcpu_id);
 
@@ -586,8 +622,8 @@ unsafe fn run(
             ..Default::default()
         };
         if let Some(vs) = &vsock_dev {
-            r.vsock_received = vs.received.clone();
-            r.workload_exit_code = vs.workload_exit_code;
+            r.vsock_received = vs.received();
+            r.workload_exit_code = vs.workload_exit_code();
         }
         Ok(r)
     }

--- a/crates/mvm-backend/src/kvm/vm.rs
+++ b/crates/mvm-backend/src/kvm/vm.rs
@@ -248,7 +248,7 @@ impl KvmVm {
 
         Ok(KvmEgressResult {
             console: serial.output,
-            workload_exit_code: vsock.workload_exit_code,
+            workload_exit_code: vsock.workload_exit_code(),
         })
     }
 }

--- a/crates/mvm-backend/src/vmm/agent_bridge.rs
+++ b/crates/mvm-backend/src/vmm/agent_bridge.rs
@@ -75,6 +75,13 @@ impl AgentBridge {
         self.active = Some(counter);
     }
 
+    /// Raw fd of the bound listener, for the host-I/O thread to register with its
+    /// `mio::Poll` (readiness-driven accept). `None` until [`Self::bind`].
+    pub fn listener_fd(&self) -> Option<std::os::fd::RawFd> {
+        use std::os::fd::AsRawFd as _;
+        self.listener.as_ref().map(|l| l.as_raw_fd())
+    }
+
     /// Is `conn_id` a host-initiated agent stream (so guest packets addressed to it
     /// route here, not to the workload-exit / egress / capture paths)?
     pub fn is_agent_stream(&self, conn_id: u32) -> bool {

--- a/crates/mvm-backend/src/vmm/guest_mem.rs
+++ b/crates/mvm-backend/src/vmm/guest_mem.rs
@@ -9,6 +9,14 @@ pub(super) struct GuestMem {
     size: usize,
 }
 
+// SAFETY: `GuestMem` is a raw view onto the single mapped guest-RAM region, which
+// outlives every thread that touches it. The vsock device shares it between the
+// vCPU thread and the dedicated host-I/O thread, but all access is serialized
+// under the device's `Mutex<VsockShared>`, and the I/O thread is joined before the
+// RAM is unmapped/freed (`VirtioVsock::shutdown` runs before `dealloc`). So the
+// pointer is only ever dereferenced by one thread at a time and never dangles.
+unsafe impl Send for GuestMem {}
+
 impl GuestMem {
     /// # Safety
     /// `ram` must point to `size` bytes mapped as guest RAM at `base`, valid for

--- a/crates/mvm-backend/src/vmm/mod.rs
+++ b/crates/mvm-backend/src/vmm/mod.rs
@@ -24,3 +24,4 @@ pub mod run;
 
 pub mod virtio;
 pub mod vsock;
+mod vsock_io;

--- a/crates/mvm-backend/src/vmm/run.rs
+++ b/crates/mvm-backend/src/vmm/run.rs
@@ -223,15 +223,15 @@ impl RunDevice for super::vsock::VirtioVsock {
         (*self).read(offset)
     }
     fn write(&mut self, offset: u64, value: u64, _size: u8) -> Option<u32> {
-        self.write(offset, value).then(|| self.irq())
+        super::vsock::VirtioVsock::write(self, offset, value).then(|| self.irq())
     }
     fn poll(&mut self) -> Option<u32> {
-        // Host→guest work each timer tick: relay host-initiated agent streams and
-        // drain egress-endpoint replies. Either may deliver an rx packet and need
-        // an interrupt.
-        let agent = self.drain_agent();
-        let subst = self.drain_substitution();
-        agent.or(subst)
+        // Host→guest work: relay host-initiated agent streams and drain
+        // egress-endpoint replies. On HVF the dedicated host-I/O thread
+        // ([`super::vsock_io`]) drives this reliably off the vCPU exit path; this
+        // run-loop path remains a fallback (e.g. KVM) and is a harmless no-op when
+        // the I/O thread already serviced everything (both run under the lock).
+        super::vsock::VirtioVsock::poll(self)
     }
 }
 
@@ -568,5 +568,77 @@ mod tests {
         let mut devs: Vec<&mut dyn RunDevice> = vec![];
         let out = run(&vcpu, |_, _| Ok(()), &mut devs, no_exceptions, || true).unwrap();
         assert_eq!(out, RunOutcome::Halt);
+    }
+
+    /// Regression for the host→guest poll-starvation bug: the dedicated vsock I/O
+    /// thread must service a host connection even when the guest produces ONLY
+    /// `Mmio` exits (no `VTimer`/`Canceled`, so the run loop's `poll()` fallback is
+    /// never invoked). Before the fix, host servicing rode on `poll()` and was
+    /// starved under MMIO load, so the agent connection was never accepted.
+    #[test]
+    fn vsock_io_thread_services_host_under_sustained_mmio() {
+        use super::super::vsock::{IrqLine, VirtioVsock};
+        use std::sync::Arc;
+        use std::sync::atomic::{AtomicU32, Ordering};
+
+        struct CountIrq(AtomicU32);
+        impl IrqLine for CountIrq {
+            fn signal(&self, _spi: u32) {
+                self.0.fetch_add(1, Ordering::Relaxed);
+            }
+        }
+
+        // Guest RAM for the device (freed only after the device — and its joined I/O
+        // thread — drop at end of the test).
+        let mut ram = vec![0u8; 0x10000];
+        let base = 0x0a00_0200u64;
+        // SAFETY: `ram` outlives `dev`; the device joins its I/O thread on drop
+        // before `ram` is freed.
+        let mut dev =
+            unsafe { VirtioVsock::new(base, 49, ram.as_mut_ptr(), 0x4000_0000, ram.len()) };
+
+        let dir = tempfile::tempdir().unwrap();
+        let sock = dir.path().join("agent.sock");
+        dev.set_agent_socket(&sock).unwrap();
+        dev.start_io(Arc::new(CountIrq(AtomicU32::new(0))));
+
+        // A host RPC client connects. No rx buffers are posted, so the framed
+        // OP_REQUEST stays queued — observable via `queued_host_packets`.
+        let _client = std::os::unix::net::UnixStream::connect(&sock).unwrap();
+
+        // Drive the run loop with ONLY `Mmio` exits (reads of the vsock magic
+        // register) then `Halt`. The `poll()` fallback fires only on
+        // `VTimer`/`Canceled`, neither of which appears here.
+        let mut script = Vec::new();
+        for _ in 0..50 {
+            script.push(VcpuExit::Mmio {
+                phys_addr: base,
+                write: false,
+                len: 4,
+                data: 0,
+            });
+        }
+        script.push(VcpuExit::Halt);
+        let vcpu = ScriptVcpu::new(script);
+        {
+            let mut devs: Vec<&mut dyn RunDevice> = vec![&mut dev];
+            let out = run(&vcpu, |_, _| Ok(()), &mut devs, no_exceptions, || true).unwrap();
+            assert_eq!(out, RunOutcome::Halt);
+        }
+
+        // The I/O thread (readiness + 5 ms backstop) accepts the connection and
+        // frames its OP_REQUEST entirely off the vCPU exit path.
+        let mut serviced = false;
+        for _ in 0..400 {
+            if dev.queued_host_packets() > 0 {
+                serviced = true;
+                break;
+            }
+            std::thread::sleep(std::time::Duration::from_millis(5));
+        }
+        assert!(
+            serviced,
+            "the I/O thread must accept the host connection under pure-MMIO activity"
+        );
     }
 }

--- a/crates/mvm-backend/src/vmm/vsock.rs
+++ b/crates/mvm-backend/src/vmm/vsock.rs
@@ -8,7 +8,21 @@
 //! in the guest's `QueueNotify` MMIO exit and completed by the backend raising
 //! the device's SPI line.
 
+use std::os::fd::RawFd;
+use std::sync::{Arc, Mutex, MutexGuard};
+
 use super::guest_mem::GuestMem;
+
+/// A guest interrupt line the host-I/O thread can assert on its own — the seam
+/// that lets host→guest vsock delivery raise the device's IRQ **off** the vCPU
+/// exit path (the fix for the poll-starvation reachability bug). The backend
+/// injects an impl wrapping its interrupt primitive (HVF's process-global GIC SPI
+/// today). `Send + Sync` because the I/O thread holds it.
+pub trait IrqLine: Send + Sync {
+    /// Assert the device's SPI to the guest (level-high; the guest acks via
+    /// `INTERRUPT_ACK`). Called after the I/O thread delivers an rx packet.
+    fn signal(&self, spi: u32);
+}
 
 const VIRTIO_MAGIC: u32 = 0x7472_6976;
 const VIRTIO_VERSION: u32 = 2;
@@ -122,10 +136,12 @@ impl Hdr {
     }
 }
 
-/// virtio-vsock device: host-side listener that accepts any connection and
-/// records the stream bytes the guest sends.
-pub struct VirtioVsock {
-    base: u64,
+/// The lockable inner state of the virtio-vsock device: host-side listener that
+/// accepts any connection and records the stream bytes the guest sends. Shared
+/// (behind `Mutex`) between the vCPU thread (MMIO dispatch) and the host-I/O
+/// thread ([`super::vsock_io`]); every field is touched only while the lock is
+/// held, so guest RAM and the virtqueues are never accessed concurrently.
+pub(super) struct VsockShared {
     irq: u32,
     mem: GuestMem,
     device_features_sel: u32,
@@ -135,7 +151,12 @@ pub struct VirtioVsock {
     interrupt_status: u32,
     /// Bytes received from the guest over an accepted stream (for the host).
     pub received: Vec<u8>,
-    fwd_cnt: u32,
+    /// Per-connection receive credit: bytes the host has consumed from the guest,
+    /// keyed by `(host_port, guest_port)`. Advertised back to the guest as a
+    /// packet's `fwd_cnt` so its tx-credit accounting stays valid. Must be
+    /// per-connection — a global counter mixes one stream's bytes into another's
+    /// credit and breaks the handshake (the guest resets or can't reply).
+    recv_cnt: std::collections::HashMap<(u32, u32), u32>,
     /// Pending packets to deliver to the guest on its rx queue.
     pending_rx: Vec<(Hdr, Vec<u8>)>,
     /// Workload exit code captured from a guest write to
@@ -161,12 +182,11 @@ pub struct VirtioVsock {
     substitution_hdrs: std::collections::HashMap<u32, Hdr>,
 }
 
-impl VirtioVsock {
+impl VsockShared {
     /// # Safety
     /// `ram` must point to `ram_size` bytes mapped as guest RAM at `ram_base`.
-    pub unsafe fn new(base: u64, irq: u32, ram: *mut u8, ram_base: u64, ram_size: usize) -> Self {
+    unsafe fn new(irq: u32, ram: *mut u8, ram_base: u64, ram_size: usize) -> Self {
         Self {
-            base,
             irq,
             // SAFETY: forwarded from this fn's contract.
             mem: unsafe { GuestMem::new(ram, ram_base, ram_size) },
@@ -176,7 +196,7 @@ impl VirtioVsock {
             queues: [Queue::default(); NUM_QUEUES],
             interrupt_status: 0,
             received: Vec::new(),
-            fwd_cnt: 0,
+            recv_cnt: std::collections::HashMap::new(),
             pending_rx: Vec::new(),
             workload_exit_code: None,
             exit_stop: None,
@@ -223,13 +243,6 @@ impl VirtioVsock {
     /// code and sets `stop` so the run loop ends (VM life = workload life).
     pub fn capture_workload_exit(&mut self, stop: &'static std::sync::atomic::AtomicBool) {
         self.exit_stop = Some(stop);
-    }
-
-    pub fn base(&self) -> u64 {
-        self.base
-    }
-    pub fn contains(&self, addr: u64) -> bool {
-        addr >= self.base && addr < self.base + MMIO_LEN
     }
 
     pub fn read(&self, offset: u64) -> u64 {
@@ -351,11 +364,12 @@ impl VirtioVsock {
                 OP_RW => {
                     let n = (hdr.len as usize).min(payload.len());
                     self.agent.write_to_host(hdr.dst_port, &payload[..n]);
-                    self.fwd_cnt = self.fwd_cnt.wrapping_add(n as u32);
+                    self.add_recv(&hdr, n as u32);
                     self.queue_reply(&hdr, OP_CREDIT_UPDATE, &[]);
                 }
                 OP_SHUTDOWN | OP_RST => {
                     self.agent.close(hdr.dst_port);
+                    self.recv_cnt.remove(&(hdr.dst_port, hdr.src_port));
                     self.queue_reply(&hdr, OP_RST, &[]);
                 }
                 _ => {}
@@ -388,12 +402,12 @@ impl VirtioVsock {
                     // it only relays the stream both ways. With no endpoint wired
                     // the bridge fails closed (resets the stream).
                     self.handle_substitution_request(&hdr, &payload[..n]);
-                    self.fwd_cnt = self.fwd_cnt.wrapping_add(n as u32);
+                    self.add_recv(&hdr, n as u32);
                     return;
                 } else {
                     self.received.extend_from_slice(&payload[..n]);
                 }
-                self.fwd_cnt = self.fwd_cnt.wrapping_add(n as u32);
+                self.add_recv(&hdr, n as u32);
                 // Acknowledge consumed bytes so the guest's credit recovers.
                 self.queue_reply(&hdr, OP_CREDIT_UPDATE, &[]);
             }
@@ -404,6 +418,7 @@ impl VirtioVsock {
                 if self.substitution_hdrs.remove(&hdr.src_port).is_some() {
                     self.substitution.close(hdr.src_port);
                 }
+                self.recv_cnt.remove(&(hdr.dst_port, hdr.src_port));
                 self.queue_reply(&hdr, OP_RST, &[]);
             }
             _ => {}
@@ -487,6 +502,27 @@ impl VirtioVsock {
         }
     }
 
+    /// Count `n` bytes consumed from the guest on the connection an inbound
+    /// (guest→host) packet belongs to. The connection is keyed `(host_port,
+    /// guest_port)` = `(inbound.dst_port, inbound.src_port)`.
+    fn add_recv(&mut self, inbound: &Hdr, n: u32) {
+        let e = self
+            .recv_cnt
+            .entry((inbound.dst_port, inbound.src_port))
+            .or_default();
+        *e = e.wrapping_add(n);
+    }
+
+    /// The `fwd_cnt` to advertise on a host→guest packet for the stream
+    /// `(host_port, guest_port)` — bytes the host has consumed from the guest on
+    /// that stream (0 for a stream with no guest data yet).
+    fn fwd_cnt_for(&self, host_port: u32, guest_port: u32) -> u32 {
+        self.recv_cnt
+            .get(&(host_port, guest_port))
+            .copied()
+            .unwrap_or(0)
+    }
+
     /// Frame a host-*initiated* host→guest packet for an agent stream. Unlike
     /// [`queue_reply`](Self::queue_reply) (which swaps an inbound header), this
     /// builds a fresh header for a stream the host opened: `src_port` is the
@@ -502,7 +538,12 @@ impl VirtioVsock {
             op,
             flags: 0,
             buf_alloc: HOST_BUF_ALLOC,
-            fwd_cnt: self.fwd_cnt,
+            // Per-connection credit: bytes the host has consumed from the guest on
+            // THIS stream (host is `src_port`, guest is `dst_port`). A global
+            // counter here would advertise `peer_fwd_cnt > tx_cnt` to the guest,
+            // underflowing its tx-credit accounting so it can't reply (or resets
+            // the stream).
+            fwd_cnt: self.fwd_cnt_for(src_port, dst_port),
         };
         self.pending_rx.push((hdr, payload.to_vec()));
     }
@@ -519,7 +560,10 @@ impl VirtioVsock {
             op,
             flags: 0,
             buf_alloc: HOST_BUF_ALLOC,
-            fwd_cnt: self.fwd_cnt,
+            // Inbound is guest→host, so the host side of this stream is
+            // `inbound.dst_port` and the guest side is `inbound.src_port` — the same
+            // key the receive path counts under.
+            fwd_cnt: self.fwd_cnt_for(inbound.dst_port, inbound.src_port),
         };
         self.pending_rx.push((reply, payload.to_vec()));
     }
@@ -573,9 +617,174 @@ impl VirtioVsock {
         self.interrupt_status |= 1;
     }
 
-    /// The device's SPI INTID — raised by the platform run loop on completion.
+    /// Do one non-blocking pass of host→guest servicing: accept new agent
+    /// connections + frame their `OP_REQUEST`/`OP_RW`, and drain egress-endpoint
+    /// replies. Returns `true` if anything was delivered into the guest's rx queue
+    /// (so the caller raises the device IRQ). This is the body both the run loop's
+    /// [`RunDevice::poll`](super::run::RunDevice::poll) and the dedicated host-I/O
+    /// thread ([`super::vsock_io`]) run — the I/O thread is what makes it happen
+    /// reliably, independent of vCPU exits.
+    pub(super) fn service_host_io(&mut self) -> bool {
+        let agent = self.drain_agent();
+        let subst = self.drain_substitution();
+        agent.is_some() || subst.is_some()
+    }
+
+    /// Raw fd of the bound host agent listener, for the I/O thread to register
+    /// with its `mio::Poll` (readiness-driven accept). `None` until an agent
+    /// socket is bound. The listener lives inside the lock for the whole run, so
+    /// the fd stays valid while registered (the I/O thread is joined before the
+    /// device drops).
+    pub(super) fn agent_listener_fd(&self) -> Option<RawFd> {
+        self.agent.listener_fd()
+    }
+}
+
+/// The virtio-vsock device the run loop drives (a [`RunDevice`](super::run::RunDevice)).
+///
+/// A thin handle over the lockable [`VsockShared`] plus the dedicated host-I/O
+/// thread. The vCPU thread reaches guest→host work through the MMIO delegators
+/// ([`Self::read`]/[`Self::write`]); the host→guest direction (accepting the agent
+/// socket, draining sockets, framing rx packets, raising the IRQ) runs on the I/O
+/// thread so it is never starved by the vCPU's MMIO cadence. `base`/`irq` are
+/// immutable and kept out of the lock so address matching needs no lock.
+pub struct VirtioVsock {
+    base: u64,
+    irq: u32,
+    shared: Arc<Mutex<VsockShared>>,
+    io: Option<super::vsock_io::IoHandle>,
+}
+
+impl VirtioVsock {
+    /// # Safety
+    /// `ram` must point to `ram_size` bytes mapped as guest RAM at `ram_base`,
+    /// valid until the device (and its joined I/O thread) are dropped.
+    pub unsafe fn new(base: u64, irq: u32, ram: *mut u8, ram_base: u64, ram_size: usize) -> Self {
+        // SAFETY: forwarded from this fn's contract.
+        let shared = unsafe { VsockShared::new(irq, ram, ram_base, ram_size) };
+        Self {
+            base,
+            irq,
+            shared: Arc::new(Mutex::new(shared)),
+            io: None,
+        }
+    }
+
+    /// Lock the shared state, recovering the guard if a peer thread panicked while
+    /// holding it (a poisoned lock is not itself a reason to abort teardown).
+    fn lock(&self) -> MutexGuard<'_, VsockShared> {
+        self.shared.lock().unwrap_or_else(|e| e.into_inner())
+    }
+
+    /// Expose the host-side agent listener at `path` (host→guest). Host RPC
+    /// clients connect here; the bridge opens a vsock stream to the guest agent on
+    /// [`GUEST_AGENT_PORT`](mvm_guest::vsock::GUEST_AGENT_PORT).
+    pub fn set_agent_socket(&mut self, path: &std::path::Path) -> std::io::Result<()> {
+        self.lock().set_agent_socket(path)
+    }
+
+    /// Share the heartbeat activity counter with the agent bridge.
+    pub fn set_agent_activity(&mut self, counter: Arc<std::sync::atomic::AtomicUsize>) {
+        self.lock().set_agent_activity(counter);
+    }
+
+    /// Point the egress relay at this VM's `mvm-substitution-endpoint` Unix socket.
+    pub fn set_substitution_endpoint(&mut self, path: &std::path::Path) {
+        self.lock().set_substitution_endpoint(path);
+    }
+
+    /// Share the heartbeat activity counter with the egress relay.
+    pub fn set_substitution_activity(&mut self, counter: Arc<std::sync::atomic::AtomicUsize>) {
+        self.lock().set_substitution_activity(counter);
+    }
+
+    /// Capture the transient workload-exit code (guest write to the exit port).
+    pub fn capture_workload_exit(&mut self, stop: &'static std::sync::atomic::AtomicBool) {
+        self.lock().capture_workload_exit(stop);
+    }
+
+    /// Spawn the dedicated host-I/O thread: it owns a `mio::Poll` over the agent
+    /// listener (readiness-driven accept) with a short backstop tick, runs
+    /// [`VsockShared::service_host_io`] on each wake, and raises `irq_line` when it
+    /// delivers — so host→guest reachability no longer depends on vCPU exits.
+    /// Idempotent-ish: a second call replaces the handle (the old thread is
+    /// joined). Call after the agent/egress sockets are wired.
+    pub fn start_io(&mut self, irq_line: Arc<dyn IrqLine>) {
+        self.shutdown();
+        self.io = Some(super::vsock_io::spawn(
+            Arc::clone(&self.shared),
+            irq_line,
+            self.irq,
+        ));
+    }
+
+    /// Stop and join the host-I/O thread (if running). Must run before the guest
+    /// RAM the device points into is unmapped/freed — the join guarantees the I/O
+    /// thread has stopped touching guest memory.
+    pub fn shutdown(&mut self) {
+        if let Some(io) = self.io.take() {
+            io.stop();
+        }
+    }
+
+    /// Bytes the guest sent to the host over the capture path. Read after the run
+    /// ends (post-[`Self::shutdown`]).
+    pub fn received(&self) -> Vec<u8> {
+        self.lock().received.clone()
+    }
+
+    /// Workload exit code, if the guest reported one over the workload-exit port.
+    pub fn workload_exit_code(&self) -> Option<i32> {
+        self.lock().workload_exit_code
+    }
+
+    /// Count of host→guest packets queued but not yet delivered into the guest rx
+    /// queue — used by tests to observe that the I/O thread serviced a host
+    /// connection (framed an `OP_REQUEST`) without any rx buffers posted.
+    #[cfg(test)]
+    pub(crate) fn queued_host_packets(&self) -> usize {
+        self.lock().pending_rx.len()
+    }
+
+    pub fn base(&self) -> u64 {
+        self.base
+    }
+    pub fn contains(&self, addr: u64) -> bool {
+        addr >= self.base && addr < self.base + MMIO_LEN
+    }
     pub fn irq(&self) -> u32 {
         self.irq
+    }
+
+    /// Service a guest MMIO load (vCPU thread).
+    pub fn read(&self, offset: u64) -> u64 {
+        self.lock().read(offset)
+    }
+
+    /// Service a guest MMIO store (vCPU thread); `true` ⇒ the guest needs an IRQ.
+    pub fn write(&self, offset: u64, value: u64) -> bool {
+        self.lock().write(offset, value)
+    }
+
+    /// Run loop fallback host→guest servicing (used by backends without the I/O
+    /// thread, e.g. KVM). Returns `Some(irq)` if a packet was delivered. On HVF the
+    /// I/O thread does this reliably; this path is harmless there (both run under
+    /// the lock).
+    pub fn poll(&self) -> Option<u32> {
+        if self.lock().service_host_io() {
+            Some(self.irq)
+        } else {
+            None
+        }
+    }
+}
+
+impl Drop for VirtioVsock {
+    fn drop(&mut self) {
+        // Safety net: guarantee the I/O thread is joined before the shared state
+        // (and the guest-RAM pointer it holds) is torn down. `kernel_boot` also
+        // calls `shutdown()` explicitly before freeing RAM.
+        self.shutdown();
     }
 }
 
@@ -605,10 +814,10 @@ fn set_hi(v: &mut u64, hi: u32) {
 mod tests {
     use super::*;
 
-    fn dev() -> VirtioVsock {
+    fn dev() -> VsockShared {
         let mut ram = vec![0u8; 0x1000];
         // SAFETY: leaked for the test.
-        unsafe { VirtioVsock::new(0x0a00_0200, 49, ram.as_mut_ptr(), 0x4000_0000, ram.len()) }
+        unsafe { VsockShared::new(49, ram.as_mut_ptr(), 0x4000_0000, ram.len()) }
     }
 
     #[test]
@@ -757,6 +966,152 @@ mod tests {
         assert!(
             d.pending_rx.iter().any(|(h, _)| h.op == OP_RST),
             "egress with no endpoint must fail closed (reset)"
+        );
+    }
+
+    /// A host-initiated agent `OP_REQUEST` to port 5252 must carry valid credit —
+    /// a non-zero `buf_alloc` and, crucially, `fwd_cnt == 0` for a fresh stream.
+    /// Advertising another stream's cumulative `fwd_cnt` (the global-counter bug)
+    /// makes the guest's tx-credit accounting underflow, so it resets the stream or
+    /// never replies. This is the device side of the reachability handshake.
+    #[test]
+    fn host_agent_request_advertises_zero_credit_so_guest_does_not_reset() {
+        let mut d = dev();
+        // Pollute a *different* stream's receive credit first: a guest→host capture
+        // stream that sends 5 bytes bumps that connection's consumed count.
+        let cap = Hdr {
+            src_cid: GUEST_CID,
+            dst_cid: HOST_CID,
+            src_port: 7000,
+            dst_port: 9000,
+            len: 5,
+            op: OP_RW,
+            typ: TYPE_STREAM,
+            ..Default::default()
+        };
+        d.handle_packet(cap, b"hello");
+        let credit = d
+            .pending_rx
+            .iter()
+            .find(|(h, _)| h.op == OP_CREDIT_UPDATE && h.dst_port == 7000)
+            .expect("capture stream acked");
+        assert_eq!(credit.0.fwd_cnt, 5, "the capture stream's own credit is 5");
+        d.pending_rx.clear();
+
+        // A host-initiated agent stream (host src_port, guest listener 5252) must
+        // advertise fwd_cnt=0 — NOT the 5 bytes from the unrelated capture stream.
+        d.queue_host_packet(1 << 20, mvm_guest::vsock::GUEST_AGENT_PORT, OP_REQUEST, &[]);
+        let req = &d.pending_rx[0].0;
+        assert_eq!(req.op, OP_REQUEST);
+        assert_eq!(req.dst_port, mvm_guest::vsock::GUEST_AGENT_PORT);
+        assert_eq!(
+            req.fwd_cnt, 0,
+            "a fresh stream must advertise fwd_cnt=0, not another stream's credit"
+        );
+        assert_eq!(
+            req.buf_alloc, HOST_BUF_ALLOC,
+            "non-zero rx credit advertised"
+        );
+    }
+
+    /// Per-connection credit tracks each stream independently: two streams that
+    /// send different amounts each get their own `fwd_cnt` in their credit updates —
+    /// one stream's bytes never leak into another's accounting.
+    #[test]
+    fn receive_credit_is_tracked_per_connection() {
+        let mut d = dev();
+        // Stream A: guest sends 3 bytes.
+        let a = Hdr {
+            src_cid: GUEST_CID,
+            dst_cid: HOST_CID,
+            src_port: 7000,
+            dst_port: 9000,
+            len: 3,
+            op: OP_RW,
+            typ: TYPE_STREAM,
+            ..Default::default()
+        };
+        d.handle_packet(a, b"abc");
+        // Stream B: guest sends 10 bytes on a different ephemeral port.
+        let b = Hdr {
+            src_cid: GUEST_CID,
+            dst_cid: HOST_CID,
+            src_port: 8000,
+            dst_port: 9000,
+            len: 10,
+            op: OP_RW,
+            typ: TYPE_STREAM,
+            ..Default::default()
+        };
+        d.handle_packet(b, b"0123456789");
+        // Each stream's CREDIT_UPDATE reflects only its own consumed bytes.
+        let ca = d
+            .pending_rx
+            .iter()
+            .find(|(h, _)| h.op == OP_CREDIT_UPDATE && h.dst_port == 7000)
+            .expect("stream A credit");
+        let cb = d
+            .pending_rx
+            .iter()
+            .find(|(h, _)| h.op == OP_CREDIT_UPDATE && h.dst_port == 8000)
+            .expect("stream B credit");
+        assert_eq!(ca.0.fwd_cnt, 3, "stream A consumed 3 bytes");
+        assert_eq!(
+            cb.0.fwd_cnt, 10,
+            "stream B consumed 10 bytes, independent of A"
+        );
+    }
+
+    /// The egress/substitution host→guest reply path is driven by the same
+    /// `service_host_io` the I/O thread runs — so a `WireResponse` from the endpoint
+    /// reaches the guest via that path, not only the vCPU `poll()`.
+    #[test]
+    fn service_host_io_drains_egress_replies() {
+        use std::io::{Read, Write};
+        let dir = tempfile::tempdir().unwrap();
+        let sock = dir.path().join("subst.sock");
+        let listener = std::os::unix::net::UnixListener::bind(&sock).unwrap();
+        let server = std::thread::spawn(move || {
+            let (mut c, _) = listener.accept().unwrap();
+            let mut buf = [0u8; 64];
+            let n = c.read(&mut buf).unwrap();
+            c.write_all(b"OK").unwrap();
+            buf[..n].to_vec()
+        });
+
+        let mut d = dev();
+        d.set_substitution_endpoint(&sock);
+        let rw = Hdr {
+            src_cid: GUEST_CID,
+            dst_cid: HOST_CID,
+            src_port: 1500,
+            dst_port: mvm_guest::vsock::EGRESS_PORT,
+            len: 5,
+            op: OP_RW,
+            typ: TYPE_STREAM,
+            ..Default::default()
+        };
+        d.handle_packet(rw, b"1.2.3");
+        server.join().unwrap();
+        d.pending_rx.clear();
+
+        // `service_host_io` (the I/O-thread body) must drain the endpoint reply and
+        // frame it back to the guest as OP_RW on the same stream.
+        let mut framed = false;
+        for _ in 0..200 {
+            let _ = d.service_host_io();
+            if d.pending_rx
+                .iter()
+                .any(|(h, _)| h.op == OP_RW && h.dst_port == 1500)
+            {
+                framed = true;
+                break;
+            }
+            std::thread::sleep(std::time::Duration::from_millis(5));
+        }
+        assert!(
+            framed,
+            "service_host_io must relay the endpoint reply to the guest"
         );
     }
 

--- a/crates/mvm-backend/src/vmm/vsock_io.rs
+++ b/crates/mvm-backend/src/vmm/vsock_io.rs
@@ -1,0 +1,141 @@
+//! The dedicated host-I/O thread for the in-house VMM's virtio-vsock device.
+//!
+//! Host→guest vsock delivery used to run only from the vCPU run loop's
+//! `poll()` — serviced on `VTimer`/`Canceled` exits. On HVF a busy guest produces
+//! a torrent of `Mmio` exits and almost no timer/cancel exits, so `poll()` (and
+//! thus accepting the host agent connection + delivering rx packets) was starved
+//! to a handful of calls over tens of seconds — the host could never reach the
+//! guest agent.
+//!
+//! This module moves that servicing onto its own OS thread driven by a
+//! `mio::Poll` (kqueue/epoll) event loop, so it runs on wall-clock time regardless
+//! of what the guest's vCPU is doing. The thread:
+//!
+//! - registers the agent Unix listener for readiness (so a host connection is
+//!   accepted promptly) plus a `Waker` (for a prompt stop),
+//! - wakes on that readiness, on the waker, or on a short backstop timeout, and on
+//!   each wake takes the device lock and runs [`VsockShared::service_host_io`]
+//!   (accept + drain the agent/egress sockets, frame rx packets into the guest's
+//!   rx queue),
+//! - raises the device IRQ via the injected [`IrqLine`] when it delivered — which
+//!   also wakes a guest blocked in WFI to consume the packet — **independent of
+//!   any vCPU exit**.
+//!
+//! Guest RAM and the virtqueues are only ever touched under the device lock, and
+//! the thread is joined (via [`IoHandle::stop`]) before the guest RAM is freed, so
+//! it never races the vCPU thread or dereferences unmapped memory.
+
+use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::{Arc, Mutex};
+use std::thread::JoinHandle;
+use std::time::Duration;
+
+use mio::unix::SourceFd;
+use mio::{Events, Interest, Poll, Token, Waker};
+
+use super::vsock::{IrqLine, VsockShared};
+
+/// The agent listener readiness source.
+const LISTENER: Token = Token(0);
+/// The waker used to break the poll for a prompt stop.
+const WAKER: Token = Token(1);
+/// Backstop poll timeout. The listener wakes us on a new connection; this bounds
+/// the latency of draining already-open agent/egress sockets (whose per-fd
+/// readiness we deliberately don't register — see the module note on fd lifetime)
+/// so a guest→host reply or egress response is delivered within a few ms even
+/// with no new connection event.
+const BACKSTOP: Duration = Duration::from_millis(5);
+
+/// Handle to a running host-I/O thread. Dropping it (or calling [`Self::stop`])
+/// stops and joins the thread.
+pub(super) struct IoHandle {
+    stop: Arc<AtomicBool>,
+    waker: Arc<Waker>,
+    join: Option<JoinHandle<()>>,
+}
+
+impl IoHandle {
+    /// Signal the thread to stop and join it. Blocks until the thread has exited,
+    /// guaranteeing it no longer touches the shared state / guest RAM.
+    pub(super) fn stop(mut self) {
+        self.stop.store(true, Ordering::Relaxed);
+        let _ = self.waker.wake();
+        if let Some(j) = self.join.take() {
+            let _ = j.join();
+        }
+    }
+}
+
+impl Drop for IoHandle {
+    fn drop(&mut self) {
+        // If stopped via `stop()` the join already happened; otherwise ensure the
+        // thread is torn down here too.
+        self.stop.store(true, Ordering::Relaxed);
+        let _ = self.waker.wake();
+        if let Some(j) = self.join.take() {
+            let _ = j.join();
+        }
+    }
+}
+
+/// Spawn the host-I/O thread for `shared`, raising `spi` via `irq` on delivery.
+pub(super) fn spawn(shared: Arc<Mutex<VsockShared>>, irq: Arc<dyn IrqLine>, spi: u32) -> IoHandle {
+    let poll = Poll::new().expect("mvm-vsock-io: mio::Poll");
+    let waker = Arc::new(Waker::new(poll.registry(), WAKER).expect("mvm-vsock-io: mio::Waker"));
+    // Register the agent listener for readiness so a host connection is accepted
+    // promptly. The fd lives inside the lock for the whole run, so it stays valid
+    // while registered (the thread is joined before the device drops). Egress has
+    // no listener; without an agent socket bound we run purely on the backstop.
+    if let Some(fd) = shared
+        .lock()
+        .unwrap_or_else(|e| e.into_inner())
+        .agent_listener_fd()
+    {
+        let mut src = SourceFd(&fd);
+        let _ = poll
+            .registry()
+            .register(&mut src, LISTENER, Interest::READABLE);
+    }
+    let stop = Arc::new(AtomicBool::new(false));
+    let stop_t = Arc::clone(&stop);
+    let join = std::thread::Builder::new()
+        .name("mvm-vsock-io".into())
+        .spawn(move || io_loop(poll, shared, irq, spi, stop_t))
+        .expect("mvm-vsock-io: spawn");
+    IoHandle {
+        stop,
+        waker,
+        join: Some(join),
+    }
+}
+
+/// The event loop: wake on listener readiness / waker / backstop, service host
+/// I/O under the lock, and raise the IRQ on delivery.
+fn io_loop(
+    mut poll: Poll,
+    shared: Arc<Mutex<VsockShared>>,
+    irq: Arc<dyn IrqLine>,
+    spi: u32,
+    stop: Arc<AtomicBool>,
+) {
+    let mut events = Events::with_capacity(16);
+    while !stop.load(Ordering::Relaxed) {
+        // A backstop timeout bounds latency for already-open sockets; a new host
+        // connection or the stop-waker breaks the wait sooner. `EINTR` surfaces as
+        // `Err` — just loop and re-check `stop`.
+        let _ = poll.poll(&mut events, Some(BACKSTOP));
+        if stop.load(Ordering::Relaxed) {
+            break;
+        }
+        // On any wake (listener readable, waker, or backstop) do one servicing
+        // pass. `accept_new` drains the listener to `WouldBlock`, so its readiness
+        // clears and we don't spin.
+        let delivered = shared
+            .lock()
+            .unwrap_or_else(|e| e.into_inner())
+            .service_host_io();
+        if delivered {
+            irq.signal(spi);
+        }
+    }
+}


### PR DESCRIPTION
## Summary

The in-house HVF backend boots a real mkGuest workload and the guest agent listens on vsock `GUEST_AGENT_PORT` (5252), but the host→guest ProtocolHello handshake never completed — `hvf-agent-ping` reported `reachable: false`. This is the Step-0 blocker for making `--hypervisor inhouse` the macOS-26 default and deprecating Vz (Plan 214).

Live-debugged on macOS 26.5.1 arm64 against `/tmp/hvf-real/{Image,rootfs.ext4}`. The repro now handshakes in **~500 ms, reliably** (`reachable: true` across 5+ runs).

## Root causes (3 stacked)

The earlier diagnosis ("poll starvation + guest RST") was directionally right, but **#2's mechanism was different** — there is no RST bug.

1. **Poll starvation.** Host→guest servicing rode on the run loop's device `poll()`, invoked only on `VTimer`/`Canceled` vCPU exits — starved under a busy guest's MMIO torrent (`vtimer=0, canceled≈10` over 30k exits), so the host agent connection was *never* accepted.

2. **Per-connection credit (the real "#2").** With prompt servicing the guest **accepts** (`op=2` OP_RESPONSE), never RST. But the agent never replied because every packet carried a single **global `fwd_cnt`**; the guest's lifecycle/workload-exit write inflated it, so the agent stream advertised `peer_fwd_cnt > tx_cnt(=0)` → the guest's tx-credit accounting underflowed → its HelloAck write blocked (and, under other timing, would reset the stream — exactly the hinted "`fwd_cnt` credit so the guest doesn't reset"). Proven by forcing `fwd_cnt=0` → instant `op=5` reply + `reachable: true`.

3. **Agent-VM lifecycle.** The dev image's `/init` reports a workload-exit (code 7) the instant it finds no entrypoint, while the agent keeps serving ~3 s. `capture_workload_exit` tore the VM down at ~150 ms, before the host connects (~588 ms).

## Fix

- **`vmm/vsock_io.rs` (new)** — a dedicated `mio::Poll` I/O thread owns the agent listener (readiness) + a `Waker` + a 5 ms backstop, runs host servicing under the device `Mutex`, and raises the guest IRQ itself via an injected `IrqLine` (HVF `GicSpi` = `hv_gic_set_spi`) — fully off the vCPU exit path. Joined before guest RAM is freed.
- **`vmm/vsock.rs`** — split into a `VirtioVsock` wrapper (RunDevice + `start_io`/`shutdown`) over `Arc<Mutex<VsockShared>>`; replaced the global `fwd_cnt` with a per-`(host_port, guest_port)` `recv_cnt` map.
- **`hvf/kernel_boot.rs`** — `GicSpi` `IrqLine`, `start_io`/`shutdown` wiring, and gate `capture_workload_exit` on `!agent_bound` (transient runs unchanged; agent VMs persist).
- **`vmm/guest_mem.rs`** — `unsafe impl Send`. KVM path preserved (still uses `poll()`, and now also benefits from the per-connection credit fix). Adds `mio` (passes `cargo deny`).

## Tests

- `run.rs::vsock_io_thread_services_host_under_sustained_mmio` — the I/O thread accepts a host connection while the guest produces only `Mmio` exits.
- `vsock.rs::host_agent_request_advertises_zero_credit_so_guest_does_not_reset`
- `vsock.rs::receive_credit_is_tracked_per_connection`
- `vsock.rs::service_host_io_drains_egress_replies` — the claim-10 egress reply path rides the same servicing.

## Verification

- `hvf-agent-ping` → `reachable: true`, ~500 ms, 5+ consecutive clean runs.
- `cargo fmt --all --check` ✓ · `cargo clippy --workspace --all-targets -D warnings` ✓ · `cargo nextest run -p mvm-backend` (499 pass) ✓ · doctests ✓

## Coordination

Touches `vmm/{run.rs,vsock.rs}`, which the active Plan 214 session develops. Verified the vmm vsock code was byte-identical on `origin/main` and `origin/feat/plan-214-hvf-spike` and no open PR touched it; branched off `origin/main`.

## Follow-ups (not blockers)

- Egress data-plane latency: already-open sockets are drained on the 5 ms backstop (accept is readiness-driven). Per-conn fd registration would trim the ≤5 ms/hop tail; deferred to avoid fd-lifetime hazards.

🤖 Generated with [Claude Code](https://claude.com/claude-code)