### PR TITLE
refactor(hostd): move plan admission into mvm-hostd (#1388 slice 2)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2746,6 +2746,7 @@ dependencies = [
  "serde_json",
  "sha2",
  "sysinfo",
+ "tar",
  "tempfile",
  "thiserror 1.0.69",
  "tokio",

--- a/crates/mvm-cli/src/commands/ops/bench.rs
+++ b/crates/mvm-cli/src/commands/ops/bench.rs
@@ -945,7 +945,7 @@ fn boot_vz_hold_once(vm_name: &str) -> Result<HeldVzVm> {
     use mvm_core::vm_backend::VmStartConfig;
     use std::time::Instant;
 
-    use crate::commands::vm::plan_admission::populate_audit_substrate;
+    use mvm_hostd::plan_admission::populate_audit_substrate;
 
     let img = super::bench_probe::resolve_probe_image()?;
     let admitted = super::bench_probe::admit_probe_plan(
@@ -1138,7 +1138,7 @@ fn boot_firecracker_hold_once(vm_name: &str, warm_pool_size: u32) -> Result<Held
     use mvm_core::vm_backend::VmStartConfig;
     use std::time::Instant;
 
-    use crate::commands::vm::plan_admission::populate_audit_substrate;
+    use mvm_hostd::plan_admission::populate_audit_substrate;
 
     let img = super::bench_probe::resolve_probe_image()?;
     let admitted = super::bench_probe::admit_probe_plan(

--- a/crates/mvm-cli/src/commands/ops/bench_probe.rs
+++ b/crates/mvm-cli/src/commands/ops/bench_probe.rs
@@ -7,10 +7,8 @@ use anyhow::{Context, Result};
 use mvm_core::plan::{PlanSeccompTier, SecretReleasePolicy};
 
 use crate::commands::env::dev_vz::ensure_default_microvm_image;
-use crate::commands::vm::plan_admission::{
-    AdmittedPlan, InMemoryNonceLedger, SystemClock, admit_for_run,
-};
 use mvm_core::plan::SynthesisInput;
+use mvm_hostd::plan_admission::{AdmittedPlan, InMemoryNonceLedger, SystemClock, admit_for_run};
 
 /// Keep the live probe above the current default-image kernel load floor. Smaller
 /// values can fail before readiness on Linux/libkrun, which makes the benchmark
@@ -164,7 +162,7 @@ pub fn boot_hold_once(vm_name: &str) -> Result<HeldProbeVm> {
     use mvm_core::vm_backend::{VmBackend, VmStartConfig};
     use std::time::Instant;
 
-    use crate::commands::vm::plan_admission::populate_audit_substrate;
+    use mvm_hostd::plan_admission::populate_audit_substrate;
 
     let img = resolve_probe_image()?;
     // `None` keys_dir → the real ~/.mvm/keys host signer, so the

--- a/crates/mvm-cli/src/commands/pool.rs
+++ b/crates/mvm-cli/src/commands/pool.rs
@@ -27,7 +27,7 @@ use sha2::{Digest, Sha256};
 use super::Cli;
 use super::env::dev_vz::ensure_default_microvm_image;
 use super::vm::host_signer;
-use super::vm::plan_admission::stash_plan_for_bridge;
+use mvm_hostd::plan_admission::stash_plan_for_bridge;
 
 /// Lowercase-hex sha256 of a kernel image — part of the base-compat key.
 pub fn kernel_sha256_hex(kernel: &Path) -> Result<String> {

--- a/crates/mvm-cli/src/commands/vm/checkpoint.rs
+++ b/crates/mvm-cli/src/commands/vm/checkpoint.rs
@@ -866,7 +866,7 @@ fn fork_vm_full_arm_inner(p: ForkVmFullArmParams<'_>) -> Result<()> {
         .find(|b| b.name == "rootfs.ext4")
         .map(|b| b.sha256.clone());
     let tenant = super::tenant_resolution::resolve_tenant(None);
-    let ledger = super::plan_admission::InMemoryNonceLedger::new();
+    let ledger = mvm_hostd::plan_admission::InMemoryNonceLedger::new();
     let admission = super::up::admit_plan_for_boot(super::up::AdmitPlanForBootParams {
         tenant: &tenant,
         vm_name: &child_vm_name,
@@ -1014,7 +1014,7 @@ fn boot_forked_child(p: BootForkedChildParams<'_>) -> Result<()> {
         &effective_hypervisor,
     )?;
 
-    let ledger = super::plan_admission::InMemoryNonceLedger::new();
+    let ledger = mvm_hostd::plan_admission::InMemoryNonceLedger::new();
     let admission = super::up::admit_plan_for_boot(super::up::AdmitPlanForBootParams {
         tenant: &tenant,
         vm_name: p.child_vm_name,
@@ -1053,7 +1053,7 @@ fn boot_forked_child(p: BootForkedChildParams<'_>) -> Result<()> {
     };
 
     if let Some(ctx) = admission.as_ref() {
-        super::plan_admission::populate_audit_substrate(
+        mvm_hostd::plan_admission::populate_audit_substrate(
             &mut start_config,
             &ctx.admitted,
             ctx.policy_bundle.as_ref(),

--- a/crates/mvm-cli/src/commands/vm/exec.rs
+++ b/crates/mvm-cli/src/commands/vm/exec.rs
@@ -20,9 +20,9 @@ use super::super::env::dev_vz::{ensure_default_microvm_image, ensure_workload_ke
 use super::Cli;
 use super::audit_chain::AuditEmitter;
 use super::host_signer::{PUBLIC_FILENAME, host_signer_id, load_or_init};
-use super::plan_admission::{InMemoryNonceLedger, SystemClock, admit_for_run};
 use crate::ui;
 use mvm_core::plan::SynthesisInput;
+use mvm_hostd::plan_admission::{InMemoryNonceLedger, SystemClock, admit_for_run};
 
 #[derive(ClapArgs, Debug, Clone)]
 pub(in crate::commands) struct Args {
@@ -337,7 +337,7 @@ pub(in crate::commands) fn run_secure(cli: &Cli, args: RunArgs, cfg: &MvmConfig)
     let admit = move |rootfs: &std::path::Path,
                       vm_name: &str|
           -> Result<Option<crate::exec::SessionAuditSubstrate>> {
-        let ledger = super::plan_admission::InMemoryNonceLedger::default();
+        let ledger = mvm_hostd::plan_admission::InMemoryNonceLedger::default();
         let ctx = super::up::admit_plan_for_boot(super::up::AdmitPlanForBootParams {
             tenant: "local",
             vm_name,

--- a/crates/mvm-cli/src/commands/vm/invoke.rs
+++ b/crates/mvm-cli/src/commands/vm/invoke.rs
@@ -156,7 +156,7 @@ pub(in crate::commands) fn run_entrypoint(call: EntrypointCall) -> Result<()> {
                     move |rootfs: &std::path::Path,
                           vm_name: &str|
                           -> Result<Option<crate::exec::SessionAuditSubstrate>> {
-                        let ledger = super::plan_admission::InMemoryNonceLedger::default();
+                        let ledger = mvm_hostd::plan_admission::InMemoryNonceLedger::default();
                         let ctx = super::up::admit_plan_for_boot(super::up::AdmitPlanForBootParams {
                             tenant: "local",
                             vm_name,

--- a/crates/mvm-cli/src/commands/vm/mod.rs
+++ b/crates/mvm-cli/src/commands/vm/mod.rs
@@ -18,7 +18,6 @@ pub(super) mod logs;
 pub(super) mod managed_secrets;
 pub(super) mod pause;
 pub(crate) mod phase_timing;
-pub(super) mod plan_admission;
 pub(super) mod plan_persist;
 pub(super) mod policy_resolver;
 pub(super) mod proc;

--- a/crates/mvm-cli/src/commands/vm/run_plan.rs
+++ b/crates/mvm-cli/src/commands/vm/run_plan.rs
@@ -63,11 +63,11 @@ use crate::commands::build::trace_secret_scan::SecretFinding;
 use mvm_sdk::ir::{App, Workload};
 
 use super::managed_secrets::lower_app_secrets;
-use super::plan_admission::{InMemoryNonceLedger, SystemClock, admit_for_run};
 use crate::commands::build::sandbox_record::{
     LoadedRecording, auto_exec_record_script, script_language_from_path,
 };
 use mvm_core::plan::SynthesisInput;
+use mvm_hostd::plan_admission::{InMemoryNonceLedger, SystemClock, admit_for_run};
 
 use super::exec::{RunArgs, RunMode};
 

--- a/crates/mvm-cli/src/commands/vm/up.rs
+++ b/crates/mvm-cli/src/commands/vm/up.rs
@@ -15,10 +15,6 @@ use mvm_core::naming::validate_vm_name;
 use super::super::env::dev_vz::ensure_default_microvm_image;
 use super::audit_chain::{AuditEmitter, default_audit_dir};
 use super::host_signer::load_or_init_at;
-use super::plan_admission::{
-    AdmittedPlan, BundleAdmissionContext, InMemoryNonceLedger, SystemClock, admit_for_run,
-    populate_audit_substrate, stash_plan_for_bridge, thread_tenant_id,
-};
 use super::policy_resolver::{
     LOCAL_DEFAULT, ResolveError, resolve_policy_bundle, resolve_policy_bundle_with_dir,
     resolve_supervisor_components, resolve_supervisor_components_with_dir,
@@ -28,6 +24,10 @@ use super::shared::{
 };
 use mvm_core::plan::SynthesisInput;
 use mvm_core::policy::PolicyBundle;
+use mvm_hostd::plan_admission::{
+    AdmittedPlan, BundleAdmissionContext, InMemoryNonceLedger, SystemClock, admit_for_run,
+    populate_audit_substrate, stash_plan_for_bridge, thread_tenant_id,
+};
 
 /// Inputs for [`admit_plan_for_boot`]. Grouped so the helper avoids
 /// the workspace `clippy::too_many_arguments = "deny"` ceiling and so
@@ -830,7 +830,7 @@ fn enforce_shares_if(
     volumes: &[mvm_core::vm_backend::VmVolume],
 ) -> Result<()> {
     if let Some(ctx) = ctx {
-        super::plan_admission::enforce_admitted_shares(volumes, &ctx.admitted.plan)
+        mvm_hostd::plan_admission::enforce_admitted_shares(volumes, &ctx.admitted.plan)
             .context("admission share check")?;
     }
     Ok(())

--- a/crates/mvm-hostd/Cargo.toml
+++ b/crates/mvm-hostd/Cargo.toml
@@ -107,6 +107,10 @@ landlock = { workspace = true }
 
 [dev-dependencies]
 tempfile.workspace = true
+# plan_admission bundle re-verify tests build/read `.mvmpkg` archives; verb-grant
+# test decodes the signer pubkey hex.
+tar.workspace = true
+hex.workspace = true
 # `TestEnv` env-var guard for env-mutating tests (reaper / substitution_endpoint).
 mvm-core = { workspace = true, features = ["test-support"] }
 tokio = { workspace = true, features = ["macros", "rt", "rt-multi-thread", "net", "io-util", "time", "sync", "test-util"] }

--- a/crates/mvm-hostd/src/lib.rs
+++ b/crates/mvm-hostd/src/lib.rs
@@ -36,4 +36,5 @@ pub mod keyholder;
 /// instant its supervisor dies, closing the macOS / abnormal-death gap the
 /// spawn-side `PR_SET_PDEATHSIG` attach leaves open.
 pub mod parent_death;
+pub mod plan_admission;
 pub mod supervisor;

--- a/crates/mvm-hostd/src/plan_admission.rs
+++ b/crates/mvm-hostd/src/plan_admission.rs
@@ -2,7 +2,7 @@
 //!
 //! Lives in `mvm-hostd` beside the host signing key it uses, so every driver
 //! reaches one admission contract: `mvmctl up`/`run` today, and the
-//! `mvm-client` local backend once the boot seam wires `run` (issue #1388).
+//! `mvm-client` local backend once the boot seam wires local `run`.
 //!
 //! Threads `synthesize_plan` + the host keypair into the
 //! supervisor-equivalent admission flow:

--- a/crates/mvm-hostd/src/plan_admission.rs
+++ b/crates/mvm-hostd/src/plan_admission.rs
@@ -1,6 +1,10 @@
-//! Plan-admission pipeline used by `mvmctl up`.
+//! Host-side plan-admission pipeline (claim 8).
 //!
-//! Threads `synthesize_plan` + `host_signer` into the
+//! Lives in `mvm-hostd` beside the host signing key it uses, so every driver
+//! reaches one admission contract: `mvmctl up`/`run` today, and the
+//! `mvm-client` local backend once the boot seam wires `run` (issue #1388).
+//!
+//! Threads `synthesize_plan` + the host keypair into the
 //! supervisor-equivalent admission flow:
 //!
 //! ```text
@@ -50,7 +54,7 @@ use mvm_core::plan::{
 use mvm_core::policy::PolicyBundle;
 use std::sync::Mutex;
 
-use super::host_signer::host_signer_id;
+use crate::audit::host_keypair::host_signer_id;
 use mvm_core::plan::{SynthesisInput, synthesize_plan};
 
 pub use mvm_core::time::{Clock, SystemClock};
@@ -79,22 +83,15 @@ impl Default for InMemoryNonceLedger {
 
 /// Result of a successful admission. Carries everything the caller
 /// needs to hand to the backend (the plan + its id), to the audit
-/// chain (the plan again, for `AuditEntry::for_plan`), and — for
-/// downstream consumers that want the canonical envelope — the
-/// `SignedExecutionPlan` itself.
-///
-/// `signed` carries a `#[allow(dead_code)]` because the only current
-/// consumer is in-module tests proving the envelope round-trips
-/// through `verify_plan`. Cross-process consumers (a future
-/// `mvm-hostd` lift, or `mvmctl plan show` once it lands) will read
-/// the envelope verbatim. Keeping the field on the struct stabilises
-/// the surface for those callers.
+/// chain (the plan again, for `AuditEntry::for_plan`), and — for the
+/// bridge audit substrate and any cross-process consumer — the canonical
+/// `SignedExecutionPlan` envelope, which [`populate_audit_substrate`]
+/// serializes verbatim onto `VmStartConfig.plan_json`.
 #[derive(Debug)]
 pub struct AdmittedPlan {
     pub plan: ExecutionPlan,
     pub plan_id: PlanId,
     pub signer_id: String,
-    #[allow(dead_code)]
     pub signed: SignedExecutionPlan,
 }
 
@@ -143,8 +140,8 @@ pub fn admit_for_run(
     // Load or generate the host signer. load_or_init refuses
     // loose perms; that error propagates verbatim.
     let signer = match host_signer_keys_dir {
-        Some(dir) => super::host_signer::load_or_init_at(dir)?,
-        None => super::host_signer::load_or_init()?,
+        Some(dir) => crate::audit::host_keypair::load_or_init_at(dir)?,
+        None => crate::audit::host_keypair::load_or_init()?,
     };
     let signer_id = host_signer_id();
 
@@ -345,7 +342,7 @@ pub(crate) fn write_secret_file(path: &std::path::Path, body: &[u8]) -> Result<(
 /// because the producer is the only place that has the signed envelope
 /// in scope; `microvm` reads it back from disk inside the
 /// `target_os = "linux"` bridge-spawn block.
-pub(crate) fn stash_plan_for_bridge(cfg: &mvm_core::vm_backend::VmStartConfig) -> Result<()> {
+pub fn stash_plan_for_bridge(cfg: &mvm_core::vm_backend::VmStartConfig) -> Result<()> {
     let Some(plan_json) = cfg.plan_json.as_deref() else {
         return Ok(());
     };
@@ -393,12 +390,12 @@ fn mint_verb_grant_sidecar(
     };
 
     let keys_dir = mvm_core::config::mvm_keys_dir();
-    let signer = super::host_signer::load_or_init_at(&keys_dir)
+    let signer = crate::audit::host_keypair::load_or_init_at(&keys_dir)
         .context("load host signer for verb-grant mint")?;
-    let keystore = mvm_hostd::host_signer::keystore::Keystore::load_from_file(&signer.secret_path)
+    let keystore = crate::host_signer::keystore::Keystore::load_from_file(&signer.secret_path)
         .context("load Keystore from host-signer key file")?;
 
-    let grant = mvm_hostd::host_signer::mint_verb_grant(
+    let grant = crate::host_signer::mint_verb_grant(
         &keystore,
         vm_name,
         &plan.nonce,
@@ -435,7 +432,7 @@ fn mint_verb_grant_sidecar(
 /// It's the trust-boundary hook: no host-fs grant reaches a guest unless
 /// the signed plan admitted it (claim 1 / claim 8). The supervisor +
 /// mvmd enforcement mirror this check against the same `plan.shares`.
-pub(crate) fn enforce_admitted_shares(
+pub fn enforce_admitted_shares(
     volumes: &[mvm_core::vm_backend::VmVolume],
     plan: &ExecutionPlan,
 ) -> Result<()> {
@@ -577,7 +574,7 @@ mod tests {
         assert!(admitted.signer_id.starts_with("host:"));
         // The signed envelope must be re-verifiable with the public
         // half of the host signer.
-        let signer = super::super::host_signer::load_or_init_at(dir.path()).unwrap();
+        let signer = crate::audit::host_keypair::load_or_init_at(dir.path()).unwrap();
         let trusted: [(&str, &ed25519_dalek::VerifyingKey); 1] =
             [(&admitted.signer_id, &signer.verifying)];
         let recovered = mvm_core::plan::verify_plan(&admitted.signed, &trusted).unwrap();
@@ -592,7 +589,7 @@ mod tests {
         // then ask the ledger to admit twice. The second call must
         // refuse with nonce-replay.
         let plan = synthesize_plan(&fixture_input("vm1")).unwrap();
-        let signer = super::super::host_signer::load_or_init_at(dir.path()).unwrap();
+        let signer = crate::audit::host_keypair::load_or_init_at(dir.path()).unwrap();
         let signer_id = host_signer_id();
         let signed = sign_plan(&plan, &signer.signing, &signer_id);
         let verified =
@@ -624,7 +621,7 @@ mod tests {
         let mut plan = synthesize_plan(&fixture_input("vm1")).unwrap();
         plan.valid_from = Utc.with_ymd_and_hms(2000, 1, 1, 0, 0, 0).unwrap();
         plan.valid_until = Utc.with_ymd_and_hms(2000, 1, 1, 0, 10, 0).unwrap();
-        let signer = super::super::host_signer::load_or_init_at(dir.path()).unwrap();
+        let signer = crate::audit::host_keypair::load_or_init_at(dir.path()).unwrap();
         let signed = sign_plan(&plan, &signer.signing, &host_signer_id());
         let verified = verify_plan(&signed, &[(&host_signer_id(), &signer.verifying)]).unwrap();
         let _clock = FixedClock(now_plus_30);
@@ -646,7 +643,7 @@ mod tests {
         .unwrap();
         // The signed field is what the audit signer will hash;
         // proving it round-trips here closes the contract.
-        let signer = super::super::host_signer::load_or_init_at(dir.path()).unwrap();
+        let signer = crate::audit::host_keypair::load_or_init_at(dir.path()).unwrap();
         let trusted: [(&str, &ed25519_dalek::VerifyingKey); 1] =
             [(&admitted.signer_id, &signer.verifying)];
         assert!(verify_plan(&admitted.signed, &trusted).is_ok());
@@ -962,7 +959,7 @@ mod tests {
             serde_json::from_str(&plan_json).expect("roundtrip");
         // Re-verify the envelope to get the inner ExecutionPlan and
         // confirm the plan_id matches what the producer admitted.
-        let signer = super::super::host_signer::load_or_init_at(dir.path()).unwrap();
+        let signer = crate::audit::host_keypair::load_or_init_at(dir.path()).unwrap();
         let trusted: [(&str, &ed25519_dalek::VerifyingKey); 1] =
             [(&admitted.signer_id, &signer.verifying)];
         let recovered =


### PR DESCRIPTION
## What

Moves the whole `plan_admission` module — `admit_for_run`, `AdmittedPlan`, `InMemoryNonceLedger`, `BundleAdmissionContext`, and the audit-substrate / bridge-stash producer fns — from `mvm-cli` into **`mvm-hostd`**, beside the host signing key it already uses (`audit::host_keypair`) and the supervisor admit path. Pure relocation, no behavior change.

## Why (slice 2 of #1388)

The signed-plan admission pipeline lived at the **top** of the dep graph (mvm-cli), so `mvm-client`/`mvm-sdk` couldn't reach it and their local `run` fails closed. Admission now lives low enough for every driver to share one contract:
- `mvmctl up`/`run` today — re-pointed to `mvm_hostd::plan_admission`.
- the `mvm-client` local backend once the boot seam wires `run` (slice 4).

**Claim 8 is enforced exactly as before** — this only changes *where the code lives*, not what it does.

Follows slice 1 (#1398, plan synthesis → `mvm-core`). Remaining: slice 3 (split the CLI-only producer bits from the reusable admit path if needed) → slice 4 (expose `boot_admitted` + wire both `run` sites).

## Changes

- Whole-file `git mv` (history preserved); internal refs re-homed (`host_signer` → `crate::audit::host_keypair`, `mvm_hostd::host_signer` → `crate::host_signer`).
- `stash_plan_for_bridge` / `enforce_admitted_shares` made `pub` for the mvm-cli producer sites; `AdmittedPlan.signed` drops its `#[allow(dead_code)]` (now consumed in-crate by `populate_audit_substrate`).
- `tar` + `hex` added to mvm-hostd dev-deps (the moved bundle-reverify / verb-grant tests).
- mvm-cli re-pointed across 8 files; module declaration dropped.

## Verification

- **All 22 admission tests pass in mvm-hostd** (admit core, bundle re-verify ladder, verb-grant mint, stash, `enforce_admitted_shares`).
- mvm-hostd + mvm-cli build clean against the re-pointed paths.
- fmt (rustup) + clippy + `check-no-display-on-secret-types` + `check-core-runtime-free` all clean.
- The full mvm-cli suite (consumer tests: up/exec/checkpoint — import-path-only changes) runs in CI here.