### PR TITLE
feat(hostd): admit_and_start — shared admitted-boot entrypoint (#1388 slice 4a)

### DIFF
--- a/crates/mvm-hostd/src/plan_admission.rs
+++ b/crates/mvm-hostd/src/plan_admission.rs
@@ -55,7 +55,9 @@ use mvm_core::policy::PolicyBundle;
 use std::sync::Mutex;
 
 use crate::audit::host_keypair::host_signer_id;
+use mvm_backend::AnyBackend;
 use mvm_core::plan::{SynthesisInput, synthesize_plan};
+use mvm_core::vm_backend::{VmId, VmStartConfig};
 
 pub use mvm_core::time::{Clock, SystemClock};
 
@@ -460,6 +462,63 @@ pub fn enforce_admitted_shares(
         }
     }
     Ok(())
+}
+
+/// Inputs for [`admit_and_start`]. The `synthesis` describes the plan to admit
+/// (the signed authority) and `config` is the launch shape to boot; they come
+/// from one source in a well-formed caller, and [`enforce_admitted_shares`]
+/// fails closed if they ever disagree on volumes.
+pub struct AdmitAndStartParams<'a> {
+    pub synthesis: &'a SynthesisInput<'a>,
+    pub config: VmStartConfig,
+    pub clock: &'a dyn Clock,
+    pub ledger: &'a InMemoryNonceLedger,
+    pub host_signer_keys_dir: Option<&'a std::path::Path>,
+    pub bundle_ctx: Option<&'a BundleAdmissionContext<'a>>,
+    pub policy_bundle: Option<&'a PolicyBundle>,
+}
+
+/// Outcome of a successful admitted boot: the backend's VM id plus the
+/// `AdmittedPlan` (for the caller's audit chain / typed result).
+#[derive(Debug)]
+pub struct StartedMachine {
+    pub vm_id: VmId,
+    pub admitted: AdmittedPlan,
+}
+
+/// The single admitted-boot entrypoint every driver shares — the CLI's
+/// `mvmctl up`/`run` and the `mvm-client` local backend both reach it, so a
+/// workload can never boot on a path that skipped admission.
+///
+/// Order matters and is fail-closed: synthesize + sign + verify + validity +
+/// replay (+ bundle re-verify) run first; only then is the signed plan threaded
+/// onto the launch config and every volume checked against the admitted shares
+/// (claim 1); only then does the backend start the VM. Any earlier failure
+/// returns with **no VM created** — admission is a gate, not a formality.
+///
+/// The caller resolves the image to a `config.rootfs_path` beforehand; this
+/// function is backend-agnostic (it drives whatever `AnyBackend` it is handed,
+/// including the in-memory mock in tests).
+pub fn admit_and_start(
+    backend: &AnyBackend,
+    params: AdmitAndStartParams<'_>,
+) -> Result<StartedMachine> {
+    let admitted = admit_for_run(
+        params.synthesis,
+        params.clock,
+        params.ledger,
+        params.host_signer_keys_dir,
+        params.bundle_ctx,
+    )?;
+
+    let mut config = params.config;
+    populate_audit_substrate(&mut config, &admitted, params.policy_bundle)?;
+    enforce_admitted_shares(&config.volumes, &admitted.plan)?;
+
+    let vm_id = backend
+        .start(&config)
+        .context("backend start after signed-plan admission")?;
+    Ok(StartedMachine { vm_id, admitted })
 }
 
 #[cfg(test)]
@@ -1245,5 +1304,89 @@ mod tests {
             !dir.path().join("vms/vm-no-verbs/verb-grant.json").exists(),
             "verb-grant.json must NOT be written when agent_verbs is None"
         );
+    }
+
+    // ───────────────────────────────────────────────────────────────
+    // admit_and_start: the shared admitted-boot entrypoint
+    // ───────────────────────────────────────────────────────────────
+
+    #[test]
+    fn admit_and_start_admits_then_boots_on_mock() {
+        let dir = tempfile::tempdir().unwrap();
+        let backend = mvm_backend::AnyBackend::from_hypervisor("mock");
+        let ledger = InMemoryNonceLedger::new();
+        let config = mvm_core::vm_backend::VmStartConfig {
+            name: "vm-boot".into(),
+            rootfs_path: "/store/rootfs.ext4".into(),
+            ..Default::default()
+        };
+        let started = admit_and_start(
+            &backend,
+            AdmitAndStartParams {
+                synthesis: &fixture_input("vm-boot"),
+                config,
+                clock: &SystemClock,
+                ledger: &ledger,
+                host_signer_keys_dir: Some(dir.path()),
+                bundle_ctx: None,
+                policy_bundle: None,
+            },
+        )
+        .expect("admit + boot");
+
+        // Admission ran (claim 8): a signed plan id under the host signer.
+        assert!(!started.admitted.plan_id.0.is_empty());
+        assert!(started.admitted.signer_id.starts_with("host:"));
+        // The backend actually started the VM and reports it running.
+        assert_eq!(started.vm_id.0, "vm-boot");
+        assert!(matches!(
+            backend.status(&started.vm_id).unwrap(),
+            mvm_core::vm_backend::VmStatus::Running
+        ));
+    }
+
+    #[test]
+    fn admit_and_start_refuses_unadmitted_volume_before_boot() {
+        use mvm_core::vm_backend::{VmVolume, VmVolumeKind};
+        let dir = tempfile::tempdir().unwrap();
+        let backend = mvm_backend::AnyBackend::from_hypervisor("mock");
+        let ledger = InMemoryNonceLedger::new();
+        // The synthesized plan admits no shares, but the launch config carries a
+        // volume — claim 1 must refuse before the backend ever starts.
+        let config = mvm_core::vm_backend::VmStartConfig {
+            name: "vm-badvol".into(),
+            rootfs_path: "/store/rootfs.ext4".into(),
+            volumes: vec![VmVolume {
+                host: "/etc".into(),
+                guest: "/data".into(),
+                read_only: true,
+                kind: VmVolumeKind::DirShare,
+                ..Default::default()
+            }],
+            ..Default::default()
+        };
+        let err = admit_and_start(
+            &backend,
+            AdmitAndStartParams {
+                synthesis: &fixture_input("vm-badvol"),
+                config,
+                clock: &SystemClock,
+                ledger: &ledger,
+                host_signer_keys_dir: Some(dir.path()),
+                bundle_ctx: None,
+                policy_bundle: None,
+            },
+        )
+        .expect_err("unadmitted volume must refuse");
+        assert!(
+            err.chain()
+                .any(|e| e.to_string().contains("not named in the signed")),
+            "expected admitted-shares refusal; got: {err:#}"
+        );
+        // Crucially: no VM was started (the gate fired before backend.start).
+        assert!(matches!(
+            backend.status(&VmId("vm-badvol".into())),
+            Ok(mvm_core::vm_backend::VmStatus::Stopped)
+        ));
     }
 }


### PR DESCRIPTION
## What

Adds `mvm_hostd::plan_admission::admit_and_start(backend, params)` — the single library function that **admits a signed plan and boots it**, so no driver can reach `backend.start` on a path that skipped admission. This is the "boot entrypoint" the seam (#1388) needed.

## Order is the guarantee (fail-closed)

1. `admit_for_run` — synthesize + sign + verify + validity + replay (+ bundle re-verify)
2. `populate_audit_substrate` — thread the signed plan onto the launch config
3. `enforce_admitted_shares` — every volume must be in the admitted plan (**claim 1**)
4. `backend.start`

Any earlier failure returns with **no VM created** — admission is a gate, not a formality.

## Design

- **Backend-agnostic**: drives any `AnyBackend` (firecracker/libkrun/vz/mock), so it's testable end-to-end with the in-memory mock — no real VM needed in CI.
- **Composes with image resolution**: the caller resolves the image to `config.rootfs_path` beforehand, so this works with the CLI's existing resolve path today and a future library materialize seam later.

## Consumers

- The CLI's `up`/`run` can collapse their inline admit→populate→enforce→start onto this (a later cleanup).
- The `mvm-client` local backend calls it once it can resolve a spec to a `rootfs_path` (the remaining image-materialize step — the honest last gap before local `run` works end-to-end).

## Tests

- `admit_and_start_admits_then_boots_on_mock` — asserts admission ran (signed plan id under the host signer) **and** the backend started the VM (mock reports Running).
- `admit_and_start_refuses_unadmitted_volume_before_boot` — a volume the plan didn't admit refuses via claim 1, and **no VM is started**.
- mvm-hostd: **24 plan_admission tests green**; fmt (rustup) + clippy + `check-no-spec-refs-in-comments` clean.

## Seam progress (#1388)

| slice | what | status |
|---|---|---|
| 1 | plan synthesis → `mvm-core` | ✅ #1398 |
| 2 | admission pipeline → `mvm-hostd` | ✅ #1407 |
| **4a** | **`admit_and_start` boot entrypoint** | **this PR** |
| 4b | `mvm-client` local backend calls it (needs image→rootfs materialize seam) | next |