### PR TITLE
fix(builder): per-kind warm gcroot so alternating builds don't evict each other (#1281)

### DIFF
--- a/crates/mvm-build/src/builder_vm_runtime.rs
+++ b/crates/mvm-build/src/builder_vm_runtime.rs
@@ -440,13 +440,25 @@ printf '%s\n' "$NIX_OUT" > /job/store-path
 # below spares the kernel + runtime base it carries. That GC deletes every
 # unrooted path regardless of age, and a fresh build's kernel/base are
 # reachable only through the transient build root — so without this the next
-# build recompiles the kernel and re-pulls the base closure. A FIXED root
-# name (overwritten each build) keeps only
-# the latest closure warm, so an unchanged kernel derivation is a store hit
-# next build while the store stays bounded. Best-effort; never fails the build.
+# build recompiles the kernel and re-pulls the base closure.
+#
+# Key the root by build kind so alternating builder-vm-image (dev up / stage0)
+# and workload (machine run) builds don't evict each other's closure. Two
+# bounded fixed names keep the store bounded — the cap GC still frees a
+# superseded closure within a kind, and an unchanged derivation is a store hit
+# next build. The builder-vm image derivation name (mvm-builder-vm-image-* /
+# mvm-builder-vm-dev-*) is set in nix/images/builder-vm/flake.nix; everything
+# else (workload rootfs/images) is the workload kind. Best-effort; never fails
+# the build.
+case "$(basename "$NIX_OUT")" in
+  *-mvm-builder-vm-*) warm=builder ;;
+  *)                  warm=workload ;;
+esac
 mkdir -p /nix/var/nix/gcroots 2>/dev/null || true
-nix-store --add-root /nix/var/nix/gcroots/mvm-warm-latest --indirect -r "$NIX_OUT" >/dev/null 2>&1 \
-  || ln -sfn "$NIX_OUT" /nix/var/nix/gcroots/mvm-warm-latest 2>/dev/null || true
+nix-store --add-root "/nix/var/nix/gcroots/mvm-warm-$warm" --indirect -r "$NIX_OUT" >/dev/null 2>&1 \
+  || ln -sfn "$NIX_OUT" "/nix/var/nix/gcroots/mvm-warm-$warm" 2>/dev/null || true
+# Retire the pre-fix single root so it stops protecting a stale closure.
+rm -f /nix/var/nix/gcroots/mvm-warm-latest 2>/dev/null || true
 
 # Copy the artifacts the host expects into /out. A plain mkGuest
 # workload image is a *bare ext4 file* ($NIX_OUT is the rootfs
@@ -2020,19 +2032,40 @@ mod tests {
         let gc_idx = body.find("nix-collect-garbage").expect("gc present");
         assert!(gc_idx > meta_idx, "GC tail must follow output emission");
 
-        // A fixed-name warm gcroot must pin the just-built closure so the
-        // cap-triggered GC spares the kernel + base it contains. It must root
-        // $NIX_OUT, use the bounded fixed name, and be registered BEFORE the GC.
+        // The warm gcroot must be keyed by build kind so alternating
+        // builder-vm-image (dev up / stage0) and workload (machine run) builds
+        // don't evict each other's closure. Two bounded roots
+        // (mvm-warm-builder / mvm-warm-workload), classified from $NIX_OUT's
+        // derivation name, registered BEFORE the GC; the pre-fix single
+        // mvm-warm-latest root is retired.
         let warm_idx = body
-            .find("/nix/var/nix/gcroots/mvm-warm-latest")
-            .expect("warm gcroot present");
+            .find("case \"$(basename \"$NIX_OUT\")\" in")
+            .expect("per-kind warm gcroot classifier present");
         assert!(
-            body.contains("--add-root /nix/var/nix/gcroots/mvm-warm-latest"),
-            "warm gcroot must use nix-store --add-root in:\n{body}"
+            body.contains("*-mvm-builder-vm-*) warm=builder"),
+            "builder-vm image name must classify as the builder warm root in:\n{body}"
         );
         assert!(
-            body.contains("ln -sfn \"$NIX_OUT\" /nix/var/nix/gcroots/mvm-warm-latest"),
+            body.contains("warm=workload"),
+            "non-builder builds must classify as the workload warm root in:\n{body}"
+        );
+        assert!(
+            body.contains("--add-root \"/nix/var/nix/gcroots/mvm-warm-$warm\""),
+            "warm gcroot must add-root the per-kind name in:\n{body}"
+        );
+        assert!(
+            body.contains("ln -sfn \"$NIX_OUT\" \"/nix/var/nix/gcroots/mvm-warm-$warm\""),
             "warm gcroot must fall back to an ln symlink of $NIX_OUT in:\n{body}"
+        );
+        assert!(
+            body.contains("rm -f /nix/var/nix/gcroots/mvm-warm-latest"),
+            "the pre-fix single mvm-warm-latest root must be retired in:\n{body}"
+        );
+        // The pin itself must no longer target the single overwritten root.
+        assert!(
+            !body.contains("--add-root /nix/var/nix/gcroots/mvm-warm-latest")
+                && !body.contains("--add-root \"/nix/var/nix/gcroots/mvm-warm-latest\""),
+            "must not pin the single fixed-name mvm-warm-latest root in:\n{body}"
         );
         assert!(
             warm_idx < gc_idx,

--- a/specs/notes/2026-07-03-1281-warm-gcroot-eviction-design.md
+++ b/specs/notes/2026-07-03-1281-warm-gcroot-eviction-design.md
@@ -1,0 +1,121 @@
+# Design: per-kind builder warm gcroot (fixes #1281)
+
+**Status:** Approved (brainstorm) — ready for implementation
+**Issue:** #1281 — single fixed-name warm gcroot (`mvm-warm-latest`) can evict the
+workload kernel between alternating builds → unexpected cold recompile
+**Scope:** one file (`crates/mvm-build/src/builder_vm_runtime.rs`) + one test
+
+## Problem
+
+The persistent builder VM's flake-build script pins each completed build's closure
+under a **single fixed-name** indirect gcroot,
+`/nix/var/nix/gcroots/mvm-warm-latest`, overwritten on every build
+(`builder_vm_runtime.rs`, in `render_flake_cmd_sh`, ~line 448). The purpose is to
+spare the just-built closure (kernel + runtime base) from the cap-triggered
+`nix-collect-garbage --delete-older-than 14d` (~line 518), which fires once the
+persistent `/nix` store grows past the cap (default 24 GiB) and deletes every
+*unrooted* path.
+
+Because the root name is fixed and shared, only the **latest** closure stays warm.
+Two build kinds flow through this one root and carry **different** closures:
+
+- **builder-VM image** — `dev up` / Stage 0 rebake (builder kernel).
+- **workload image** — `machine run --flake` / `--image` (its own kernel/base).
+
+Alternating them ping-pongs the single root, so the displaced kind goes unrooted and
+is eventually GC'd → the next run recompiles from source (minutes):
+
+```
+machine run …   → mvm-warm-latest = workload closure   (workload warm)
+dev up / stage0 → mvm-warm-latest = builder closure     (workload now UNROOTED)
+… store exceeds cap → GC → workload closure evicted
+next machine run → cold recompile
+```
+
+### Verified facts (against `main`)
+
+- The single fixed root is still present at `builder_vm_runtime.rs:448`.
+- Kernel builds (`mvmctl build kernel`) do **not** use this root — they go through
+  Stage 0, which has its own GC. So `mvm-warm-latest` only ever pins **image**
+  builds via `run_build`.
+- Output shape is **not** a reliable kind discriminator: a Linux/Firecracker
+  workload image also emits a directory with a `vmlinux`, same shape as a builder
+  image. So `[ -f "$NIX_OUT" ]` would mis-bucket it.
+- The builder-VM image derivation name is a stable in-repo convention
+  (`nix/images/builder-vm/flake.nix:351`): `mvm-builder-vm-image-<system>` /
+  `mvm-builder-vm-dev-<system>` — both share the `mvm-builder-vm-` prefix.
+
+## Change
+
+Replace the single overwritten root with a **two-root scheme keyed by build kind**,
+classified at runtime from `$NIX_OUT`'s derivation name (platform-independent):
+
+```sh
+# Per-kind warm root so alternating builder-vm-image (dev up / stage0) and
+# workload (machine run) builds don't evict each other. Bounded to 2 roots so the
+# cap GC still works. Builder image name set in nix/images/builder-vm/flake.nix.
+case "$(basename "$NIX_OUT")" in
+  *-mvm-builder-vm-*) warm=builder ;;
+  *)                  warm=workload ;;
+esac
+mkdir -p /nix/var/nix/gcroots 2>/dev/null || true
+nix-store --add-root "/nix/var/nix/gcroots/mvm-warm-$warm" --indirect -r "$NIX_OUT" >/dev/null 2>&1 \
+  || ln -sfn "$NIX_OUT" "/nix/var/nix/gcroots/mvm-warm-$warm" 2>/dev/null || true
+# Retire the pre-fix single root so it stops protecting a stale closure.
+rm -f /nix/var/nix/gcroots/mvm-warm-latest 2>/dev/null || true
+```
+
+~8 lines of shell replacing the current 3-line pin block.
+
+### Why this shape
+
+- **Bounded (2 roots)** → the cap-triggered GC still functions and the store stays
+  bounded (avoids the unbounded per-closure failure mode where nothing is ever
+  unrooted and GC frees nothing).
+- **`dev up` (builder) and `machine run` (workload) no longer evict each other** —
+  exactly the reported ping-pong. Within a kind, latest-wins is correct: an
+  unchanged derivation is a store hit next build; a changed one supersedes.
+- **Runtime derivation-name classification** is platform-independent and needs **no
+  wire-protocol or host-API changes** — `BuilderJob::Flake` (a multi-callsite
+  protocol type) is left untouched; the classification happens entirely inside the
+  generated script from a value it already computes.
+
+### Rejected alternatives
+
+- **Output-shape kind (`[ -f "$NIX_OUT" ]`)** — platform-dependent; mis-buckets
+  Linux/Firecracker workloads (directory output) as "builder".
+- **Per-identity roots keyed by `FLAKE_REF#ATTR_PATH`, LRU-capped** — robust but
+  needs new LRU eviction to stay bounded. Disproportionate: there are effectively
+  two closure-families to keep warm, so two roots is exactly right (YAGNI).
+- **Explicit `kind` field on `BuilderJob::Flake`** — cleaner typed signal, but that
+  type is a host↔guest wire protocol with ~10 callsites + a guest-side parser;
+  disproportionate blast radius for this fix.
+
+## Error handling & migration
+
+Unchanged: the pin is **best-effort** (`|| true`) and never fails a build — a
+warm-root failure only costs a future recompile, it is not a correctness gate. The
+`rm -f` of the retired `mvm-warm-latest` is best-effort cleanup; no migration step —
+new builds create `mvm-warm-builder` / `mvm-warm-workload`.
+
+## Testing
+
+`render_flake_cmd_sh` already has script-content unit tests
+(`builder_vm_runtime.rs:2004`, `:2044`). Follow that pattern:
+
+- Update/add one script-content test asserting the generated script pins **both**
+  `mvm-warm-builder` and `mvm-warm-workload` via the per-kind `case`, no longer
+  writes `mvm-warm-latest` except the `rm -f` cleanup, and matches on the
+  `*-mvm-builder-vm-*` derivation-name prefix.
+- Update any existing test that asserts the literal `mvm-warm-latest` pin name.
+
+A comment in the script ties the `mvm-builder-vm-` match to
+`nix/images/builder-vm/flake.nix` so a future rename is caught in review.
+
+## Gates
+
+`cargo fmt --all --check`, `cargo clippy --workspace --all-targets -D warnings`,
+`cargo nextest run -p mvm-build`, `cargo test -p mvm-build --doc`. No live builder-VM
+boot is required to land this (script-generation + content tests only). A live
+confirmation (alternating `dev up` / `machine run` without a cold recompile) is an
+environment-gated follow-up.


### PR DESCRIPTION
## What

The persistent builder VM pinned every completed build's closure under a **single fixed-name** gcroot `/nix/var/nix/gcroots/mvm-warm-latest`, overwritten on every build (`render_flake_cmd_sh` in `builder_vm_runtime.rs`). Two build kinds flow through it carrying **different** closures — the **builder-VM image** (`dev up` / Stage 0) and **workload images** (`machine run`). Alternating them ping-ponged the one root, so the displaced kind went unrooted and the cap-triggered `nix-collect-garbage --delete-older-than 14d` eventually reaped it → a surprise multi-minute **cold kernel recompile** on the next run (the ugly part: it looks like a hang/regression, not a cache miss).

Fixes #1281.

## How

Key the warm root by build kind, classified at runtime from `$NIX_OUT`'s derivation name:

```sh
case "$(basename "$NIX_OUT")" in
  *-mvm-builder-vm-*) warm=builder ;;
  *)                  warm=workload ;;
esac
nix-store --add-root "/nix/var/nix/gcroots/mvm-warm-$warm" --indirect -r "$NIX_OUT" ... 
rm -f /nix/var/nix/gcroots/mvm-warm-latest ...   # retire the pre-fix single root
```

- **Bounded to 2 roots** → the store cap GC still functions (no unbounded per-closure accumulation).
- `dev up` (builder) and `machine run` (workload) no longer evict each other's warm closure; within a kind, latest-wins (correct).
- **Runtime derivation-name classification** is platform-independent — a Linux/Firecracker workload image also emits a `vmlinux` directory, so output shape can't discriminate — and needs **no wire-protocol / host-API change** (`BuilderJob::Flake` untouched).

The builder-VM image derivation name (`mvm-builder-vm-image-*` / `-dev-*`) is a stable convention set in `nix/images/builder-vm/flake.nix`; a comment ties the match to it so a rename is caught in review + by the test.

Design note: `specs/notes/2026-07-03-1281-warm-gcroot-eviction-design.md`.

## Testing

- Updated the existing `render_flake_cmd_sh` script-content test to assert the two per-kind roots + the retired-root cleanup, and that the single `mvm-warm-latest` pin is gone. (TDD: red before the impl, green after.)
- Runtime classification sanity-checked against real derivation names (builder-vm-image/dev → `builder`; mkguest/workload → `workload`).
- `cargo nextest run -p mvm-build` → **699/699**. `cargo fmt --all --check`, `cargo clippy --workspace --all-targets -D warnings` → clean.
- Full-workspace nextest: 2863 passed; the only non-passes were a `MVM_SKIP_EMBED_BINARIES=1` stub artifact (`each_embedded_binary_starts_with_elf_magic`) and the known env hang `pick_console_transport_does_not_route_workload_to_dev_socket` (in `console.rs`, untouched by this branch; green in CI). Neither relates to this change.

Live confirmation (alternating `dev up` / `machine run` without a cold recompile on a real builder VM) is an environment-gated follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)