### PR TITLE
feat(build): materialize_ext4_pure — in-process rootfs materialize (Plan 221 B)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -169,6 +169,11 @@ jobs:
           cargo test -p mvm-build --features builder-vm --lib \
             builder_backend_select::tests::auto_detect_default_for_everything_else_picks_libkrun
 
+      - name: In-process pure-mkfs materialize tests
+        # `pure-mkfs` is off by default (keeps mvm-ext4 out of the mvmctl default
+        # closure), so the default workspace run skips these. Cover them here.
+        run: cargo test -p mvm-build --features pure-mkfs --lib rootfs::tests::pure
+
   test:
     name: Test
     runs-on: ubuntu-latest

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2571,6 +2571,7 @@ dependencies = [
  "libkrun-sys",
  "lzma-rs",
  "mvm-core",
+ "mvm-ext4",
  "mvm-guest",
  "mvm-network",
  "mvm-sdk",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -339,6 +339,7 @@ mvm-guest = { path = "crates/mvm-guest", version = "0.16.1" }
 mvm-build = { path = "crates/mvm-build", version = "0.16.1", default-features = false }
 mvm = { path = "crates/mvm", version = "0.16.1", default-features = false }
 mvm-oci = { path = "crates/mvm-oci", version = "0.16.1" }
+mvm-ext4 = { path = "crates/mvm-ext4", version = "0.16.1" }
 mvm-storage = { path = "crates/mvm-storage", version = "0.16.1" }
 mvm-network = { path = "crates/mvm-network", version = "0.16.1" }
 mvm-cli = { path = "crates/mvm-cli", version = "0.16.1", default-features = false }

--- a/crates/mvm-build/Cargo.toml
+++ b/crates/mvm-build/Cargo.toml
@@ -65,6 +65,7 @@ tar.workspace = true
 lzma-rs = "0.3"
 
 mvm-core.workspace = true
+mvm-ext4.workspace = true
 mvm-guest.workspace = true
 # `LibkrunNetworkProvider` impls the `NetworkProvider`
 # seam. mvm-network deps only mvm-core + mvm-sdk, so this edge is acyclic.

--- a/crates/mvm-build/Cargo.toml
+++ b/crates/mvm-build/Cargo.toml
@@ -65,7 +65,7 @@ tar.workspace = true
 lzma-rs = "0.3"
 
 mvm-core.workspace = true
-mvm-ext4.workspace = true
+mvm-ext4 = { workspace = true, optional = true }
 mvm-guest.workspace = true
 # `LibkrunNetworkProvider` impls the `NetworkProvider`
 # seam. mvm-network deps only mvm-core + mvm-sdk, so this edge is acyclic.
@@ -141,6 +141,10 @@ tempfile.workspace = true
 
 [features]
 default = []
+# In-process, pure-Rust ext4 materialization (no builder VM / mkfs). Off by
+# default so the mvmctl default closure does not gain `mvm-ext4` until the pure
+# path is the run-path default; enabled where `materialize_ext4_pure` is used.
+pure-mkfs = ["dep:mvm-ext4"]
 # Folded in with the mvm-egress-proxy bin. Off by default;
 # tests/dev enable it so the `mvm-egress-proxy` bin honors a
 # `MVM_EGRESS_ALLOWLIST=host1,host2` override. Production binaries (no

--- a/crates/mvm-build/src/rootfs.rs
+++ b/crates/mvm-build/src/rootfs.rs
@@ -95,6 +95,23 @@ pub enum RootfsError {
     #[cfg(feature = "builder-vm")]
     #[error("builder VM ext4 materialization failed: {0}")]
     BuilderVm(#[from] crate::builder_vm::BuilderVmError),
+
+    #[error("walking unpacked tree at {path}: {source}")]
+    PureWalk {
+        path: PathBuf,
+        #[source]
+        source: std::io::Error,
+    },
+
+    #[error("building ext4 image in-process: {0}")]
+    PureBuild(String),
+
+    #[error("writing rootfs image {path}: {source}")]
+    WriteOutput {
+        path: PathBuf,
+        #[source]
+        source: std::io::Error,
+    },
 }
 
 /// Estimate the sparse image size for an OCI rootfs.
@@ -298,6 +315,117 @@ trap - EXIT
     )
 }
 
+/// Materialize `input.unpacked_root` into `input.output` **in-process** — no
+/// builder VM, no `mkfs`, no subprocess. Walks the unpacked tree and builds a
+/// deterministic read-only ext4 image with the memory-safe `mvm-ext4` writer.
+///
+/// This is the no-shell path the local run uses (Plan 221 Option B). It reads
+/// the whole tree into memory (each file's bytes + the assembled image), which
+/// is fine for small/medium rootfs; large images want the streaming +
+/// multi-block-group follow-ups. The output is a valid ext4 real readers mount;
+/// integrity is provided by dm-verity, added on top (not by in-filesystem
+/// checksums).
+pub fn materialize_ext4_pure(
+    input: &MaterializeExt4Input,
+) -> Result<MaterializedExt4, RootfsError> {
+    if !input.unpacked_root.is_dir() {
+        return Err(RootfsError::UnpackedRootNotDirectory(
+            input.unpacked_root.clone(),
+        ));
+    }
+    let nodes = collect_nodes(&input.unpacked_root)?;
+    let image = mvm_ext4::build_image(&nodes).map_err(|e| RootfsError::PureBuild(e.to_string()))?;
+    let size_bytes = image.len() as u64;
+    std::fs::write(&input.output, &image).map_err(|source| RootfsError::WriteOutput {
+        path: input.output.clone(),
+        source,
+    })?;
+    Ok(MaterializedExt4 {
+        path: input.output.clone(),
+        size_bytes,
+    })
+}
+
+/// Walk `root` into a flat `Node` list (guest-absolute paths), symlink-aware
+/// (never follows). Directories and their descendants, regular files (contents
+/// read in), and symlinks are captured; other inode types (fifo/socket/device)
+/// are skipped — an OCI rootfs mounts devtmpfs for those.
+fn collect_nodes(root: &std::path::Path) -> Result<Vec<mvm_ext4::Node>, RootfsError> {
+    let mut out = Vec::new();
+    let mut stack = vec![root.to_path_buf()];
+    while let Some(dir) = stack.pop() {
+        let read = std::fs::read_dir(&dir).map_err(|source| RootfsError::PureWalk {
+            path: dir.clone(),
+            source,
+        })?;
+        for entry in read {
+            let entry = entry.map_err(|source| RootfsError::PureWalk {
+                path: dir.clone(),
+                source,
+            })?;
+            let path = entry.path();
+            let guest_path = guest_path_of(root, &path);
+            let ft = entry.file_type().map_err(|source| RootfsError::PureWalk {
+                path: path.clone(),
+                source,
+            })?;
+            if ft.is_symlink() {
+                let target = std::fs::read_link(&path).map_err(|source| RootfsError::PureWalk {
+                    path: path.clone(),
+                    source,
+                })?;
+                out.push(mvm_ext4::Node::Symlink {
+                    path: guest_path,
+                    target: target.to_string_lossy().into_owned(),
+                });
+            } else if ft.is_dir() {
+                out.push(mvm_ext4::Node::Dir {
+                    path: guest_path,
+                    mode: mode_of(&path, 0o755),
+                });
+                stack.push(path);
+            } else if ft.is_file() {
+                let data = std::fs::read(&path).map_err(|source| RootfsError::PureWalk {
+                    path: path.clone(),
+                    source,
+                })?;
+                out.push(mvm_ext4::Node::File {
+                    path: guest_path,
+                    mode: mode_of(&path, 0o644),
+                    data,
+                });
+            }
+        }
+    }
+    Ok(out)
+}
+
+/// Guest-absolute path for `path` under `root` (e.g. `root/etc/hosts` → `/etc/hosts`).
+fn guest_path_of(root: &std::path::Path, path: &std::path::Path) -> String {
+    match path.strip_prefix(root) {
+        Ok(rel) => format!("/{}", rel.to_string_lossy()),
+        Err(_) => format!("/{}", path.to_string_lossy()),
+    }
+}
+
+/// Unix permission bits of `path` (not following symlinks), or `default` on a
+/// non-unix host.
+fn mode_of(path: &std::path::Path, default: u16) -> u16 {
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::PermissionsExt;
+        match std::fs::symlink_metadata(path) {
+            Ok(m) => (m.permissions().mode() & 0o7777) as u16,
+            Err(_) => default,
+        }
+    }
+    #[cfg(not(unix))]
+    {
+        let _ = path;
+        default
+    }
+}
+
 #[cfg(any(test, feature = "builder-vm"))]
 fn shell_single_quote_escape(s: &str) -> String {
     s.replace('\'', "'\\''")
@@ -311,6 +439,45 @@ mod tests {
     use crate::builder_backend_select::{BuilderBackendChoice, MVM_BUILDER_BACKEND_ENV};
     #[cfg(feature = "builder-vm")]
     use mvm_core::util::test_env::TestEnv;
+
+    #[test]
+    fn pure_materialize_writes_a_valid_ext4_from_a_dir_tree() {
+        let src = tempfile::tempdir().unwrap();
+        std::fs::create_dir(src.path().join("etc")).unwrap();
+        std::fs::write(src.path().join("etc/hosts"), b"127.0.0.1 localhost\n").unwrap();
+        std::fs::write(src.path().join("hello"), b"hi\n").unwrap();
+        #[cfg(unix)]
+        std::os::unix::fs::symlink("hosts", src.path().join("etc/localhost")).unwrap();
+
+        let out = tempfile::tempdir().unwrap();
+        let out_path = out.path().join("rootfs.ext4");
+        let input = MaterializeExt4Input::new(src.path().to_path_buf(), out_path.clone(), 0);
+
+        let mat = materialize_ext4_pure(&input).expect("pure materialize");
+        assert_eq!(mat.path, out_path);
+        assert!(mat.size_bytes > 0);
+
+        let img = std::fs::read(&out_path).unwrap();
+        assert_eq!(img.len() as u64, mat.size_bytes);
+        // ext4 superblock magic 0xEF53 (LE) at byte 1024 + 0x38.
+        assert_eq!(&img[1024 + 0x38..1024 + 0x3A], &[0x53, 0xEF]);
+        // Deterministic: same tree materializes to byte-identical output.
+        let out2 = out.path().join("rootfs2.ext4");
+        let input2 = MaterializeExt4Input::new(src.path().to_path_buf(), out2.clone(), 0);
+        materialize_ext4_pure(&input2).unwrap();
+        assert_eq!(std::fs::read(&out2).unwrap(), img);
+    }
+
+    #[test]
+    fn pure_materialize_rejects_non_directory() {
+        let f = tempfile::NamedTempFile::new().unwrap();
+        let input =
+            MaterializeExt4Input::new(f.path().to_path_buf(), f.path().with_extension("ext4"), 0);
+        assert!(matches!(
+            materialize_ext4_pure(&input),
+            Err(RootfsError::UnpackedRootNotDirectory(_))
+        ));
+    }
 
     #[test]
     fn estimate_uses_sixty_four_mib_floor() {

--- a/crates/mvm-build/src/rootfs.rs
+++ b/crates/mvm-build/src/rootfs.rs
@@ -96,6 +96,7 @@ pub enum RootfsError {
     #[error("builder VM ext4 materialization failed: {0}")]
     BuilderVm(#[from] crate::builder_vm::BuilderVmError),
 
+    #[cfg(feature = "pure-mkfs")]
     #[error("walking unpacked tree at {path}: {source}")]
     PureWalk {
         path: PathBuf,
@@ -103,9 +104,11 @@ pub enum RootfsError {
         source: std::io::Error,
     },
 
+    #[cfg(feature = "pure-mkfs")]
     #[error("building ext4 image in-process: {0}")]
     PureBuild(String),
 
+    #[cfg(feature = "pure-mkfs")]
     #[error("writing rootfs image {path}: {source}")]
     WriteOutput {
         path: PathBuf,
@@ -315,6 +318,7 @@ trap - EXIT
     )
 }
 
+#[cfg(feature = "pure-mkfs")]
 /// Materialize `input.unpacked_root` into `input.output` **in-process** — no
 /// builder VM, no `mkfs`, no subprocess. Walks the unpacked tree and builds a
 /// deterministic read-only ext4 image with the memory-safe `mvm-ext4` writer.
@@ -346,6 +350,7 @@ pub fn materialize_ext4_pure(
     })
 }
 
+#[cfg(feature = "pure-mkfs")]
 /// Walk `root` into a flat `Node` list (guest-absolute paths), symlink-aware
 /// (never follows). Directories and their descendants, regular files (contents
 /// read in), and symlinks are captured; other inode types (fifo/socket/device)
@@ -400,6 +405,7 @@ fn collect_nodes(root: &std::path::Path) -> Result<Vec<mvm_ext4::Node>, RootfsEr
     Ok(out)
 }
 
+#[cfg(feature = "pure-mkfs")]
 /// Guest-absolute path for `path` under `root` (e.g. `root/etc/hosts` → `/etc/hosts`).
 fn guest_path_of(root: &std::path::Path, path: &std::path::Path) -> String {
     match path.strip_prefix(root) {
@@ -408,6 +414,7 @@ fn guest_path_of(root: &std::path::Path, path: &std::path::Path) -> String {
     }
 }
 
+#[cfg(feature = "pure-mkfs")]
 /// Unix permission bits of `path` (not following symlinks), or `default` on a
 /// non-unix host.
 fn mode_of(path: &std::path::Path, default: u16) -> u16 {
@@ -440,6 +447,7 @@ mod tests {
     #[cfg(feature = "builder-vm")]
     use mvm_core::util::test_env::TestEnv;
 
+    #[cfg(feature = "pure-mkfs")]
     #[test]
     fn pure_materialize_writes_a_valid_ext4_from_a_dir_tree() {
         let src = tempfile::tempdir().unwrap();
@@ -468,6 +476,7 @@ mod tests {
         assert_eq!(std::fs::read(&out2).unwrap(), img);
     }
 
+    #[cfg(feature = "pure-mkfs")]
     #[test]
     fn pure_materialize_rejects_non_directory() {
         let f = tempfile::NamedTempFile::new().unwrap();

--- a/crates/mvm-build/src/rootfs.rs
+++ b/crates/mvm-build/src/rootfs.rs
@@ -319,7 +319,7 @@ trap - EXIT
 /// builder VM, no `mkfs`, no subprocess. Walks the unpacked tree and builds a
 /// deterministic read-only ext4 image with the memory-safe `mvm-ext4` writer.
 ///
-/// This is the no-shell path the local run uses (Plan 221 Option B). It reads
+/// This is the no-shell path the local run uses. It reads
 /// the whole tree into memory (each file's bytes + the assembled image), which
 /// is fine for small/medium rootfs; large images want the streaming +
 /// multi-block-group follow-ups. The output is a valid ext4 real readers mount;


### PR DESCRIPTION
Connects the `mvm-ext4` writer (#1414) to the real pipeline: `mvm_build::rootfs::materialize_ext4_pure` walks an OCI-unpacked tree and builds the rootfs ext4 **in-process, no builder VM, no `mkfs`, no subprocess**.

## What

- Symlink-aware walk (never follows) → `mvm_ext4::Node` list with guest-absolute paths + unix permission bits. Files/dirs/symlinks captured; other inode types skipped (an OCI rootfs mounts devtmpfs).
- Delegates to `mvm_ext4::build_image` — deterministic + `#![forbid(unsafe_code)]`.
- New `RootfsError` variants for the walk/build/write steps.

## Scope / honesty

Reads the tree + assembles the image in memory — fine for small/medium rootfs; **large images want streaming + multi-block-group** (Plan 221 follow-ups; the writer currently caps at a single 128 MiB block group). The builder-VM `materialize_ext4` stays for Nix builds and as the >128 MiB fallback (ADR-093-style), so nothing regresses.

## Tests

- Materialize a temp tree (`/etc/hosts`, `/hello`, `/etc/localhost` symlink) → valid ext4 (superblock magic `0xEF53`), and **byte-identical across two runs** (determinism).
- Non-directory input is rejected.
- clippy + fmt clean.

## Plan 221 progress

| step | what | status |
|---|---|---|
| B2 | `mvm-ext4` memory-safe writer | ✅ #1414 |
| B4a | `materialize_ext4_pure` (dir → ext4) | **this PR** |
| next | pure-Rust dm-verity roothash; multi-block-group; wire `LocalBackend.run` | — |