### PR TITLE
feat(ext4): real-kernel mount + pure dm-verity roothash, veritysetup-diffed (Plan 221 B)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -275,3 +275,33 @@ jobs:
             echo "=== $d ==="
             nix flake check --no-build "./$d"
           done
+
+  # The pure-Rust `mvm-ext4` writer (Plan 221) must produce an image the real
+  # Linux kernel mounts — the strongest correctness oracle, beyond the in-process
+  # `am-fs-ext4` read oracle. Write a fixed sample image and loop-mount it.
+  ext4-real-mount:
+    name: mvm-ext4 output mounts on the real kernel
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+      - name: Install Rust toolchain
+        uses: dtolnay/rust-toolchain@stable
+      - name: Write a sample image with the pure-Rust ext4 writer
+        run: cargo run -p mvm-ext4 --example write_sample -- /tmp/sample.ext4
+      - name: Loop-mount read-only and verify the tree on the real kernel
+        run: |
+          set -euo pipefail
+          mnt=$(mktemp -d)
+          sudo mount -o ro,loop /tmp/sample.ext4 "$mnt"
+          trap 'sudo umount "$mnt" || true; rmdir "$mnt" || true' EXIT
+          # File contents ($() strips the trailing newline).
+          [ "$(cat "$mnt/etc/hosts")" = "127.0.0.1 localhost" ]
+          diff <(printf 'hi from pure-rust ext4\n') "$mnt/hello"
+          # Symlink resolves to its target.
+          [ "$(readlink "$mnt/etc/localhost")" = "hosts" ]
+          # Directories present.
+          [ -d "$mnt/bin" ] && [ -d "$mnt/etc" ]
+          # Permissions preserved.
+          [ "$(stat -c '%a' "$mnt/hello")" = "755" ]
+          [ "$(stat -c '%a' "$mnt/etc/hosts")" = "644" ]
+          echo "pure-Rust ext4 mounted + verified on the real Linux kernel"

--- a/crates/mvm-ext4/examples/write_sample.rs
+++ b/crates/mvm-ext4/examples/write_sample.rs
@@ -1,0 +1,43 @@
+//! Write a fixed sample ext4 image with the pure-Rust writer, for the CI lane
+//! that loop-mounts it on the real Linux kernel (the strongest correctness
+//! oracle — beyond the in-process `am-fs-ext4` read oracle).
+//!
+//! Usage: `cargo run -p mvm-ext4 --example write_sample -- <out.ext4>`
+//!
+//! The tree here MUST match what `.github/workflows/ci.yml::ext4-real-mount`
+//! asserts after mounting.
+
+use mvm_ext4::{Node, build_image};
+
+fn main() {
+    let out = std::env::args()
+        .nth(1)
+        .expect("usage: write_sample <out.ext4>");
+    let nodes = vec![
+        Node::Dir {
+            path: "/etc".into(),
+            mode: 0o755,
+        },
+        Node::File {
+            path: "/etc/hosts".into(),
+            mode: 0o644,
+            data: b"127.0.0.1 localhost\n".to_vec(),
+        },
+        Node::File {
+            path: "/hello".into(),
+            mode: 0o755,
+            data: b"hi from pure-rust ext4\n".to_vec(),
+        },
+        Node::Symlink {
+            path: "/etc/localhost".into(),
+            target: "hosts".into(),
+        },
+        Node::Dir {
+            path: "/bin".into(),
+            mode: 0o755,
+        },
+    ];
+    let image = build_image(&nodes).expect("build ext4 image");
+    std::fs::write(&out, &image).expect("write image file");
+    eprintln!("wrote {} bytes to {out}", image.len());
+}


### PR DESCRIPTION
Validates the pure-Rust `mvm-ext4` writer against the **real Linux kernel**, not just the in-process `am-fs-ext4` read oracle.

## What

- `crates/mvm-ext4/examples/write_sample.rs` — writes a fixed sample tree (`/etc/hosts`, `/hello`, `/etc/localhost` symlink, `/bin`, perms) to an image path.
- `.github/workflows/ci.yml::ext4-real-mount` — builds it and `sudo mount -o ro,loop`s it on `ubuntu-latest`, then asserts file contents, the symlink target, directory presence, and preserved permissions (755/644).

## Why now

This is the oracle the rest of Plan 221 needs. Multi-block-group and dm-verity both touch subtle on-disk format details that a real-kernel mount validates far more strictly than an independent Rust reader — so this lane goes in **before** those, letting them iterate against the real kernel.

Static-literal job (no untrusted event input). I can't loop-mount on macOS, so this lane is the CI validation of the writer we already merged (#1414).

## Plan 221 progress

| step | what | status |
|---|---|---|
| B2 | `mvm-ext4` writer | ✅ #1414 |
| B4a | `materialize_ext4_pure` | ✅ #1416 |
| B3 | real-kernel mount CI lane | **this PR** |
| next | dm-verity roothash (pure) · multi-block-group · wire `LocalBackend.run` | — |