### PR TITLE
fix(run): wire dev_console on the interactive transient -it path (fixes '-it' console attach)

### DIFF
--- a/crates/mvm-cli/src/exec.rs
+++ b/crates/mvm-cli/src/exec.rs
@@ -590,6 +590,12 @@ fn run_inner(
     let (verity_path, roothash) = mvm_backend::microvm::probe_verity_sidecar(&rootfs);
     let t_drives_ready = timing.then(std::time::Instant::now);
 
+    // Interactive `-it` transient run: pre-open the console data-port sockets so
+    // the backend's PTY console attach can reach the agent-allocated channel.
+    // Gated on `pty` and an unsealed image — a verity sidecar means a sealed
+    // production rootfs, which never serves an interactive console.
+    let dev_console = req.pty && verity_path.is_none();
+
     // Template-restore VMs run without plan admission. Leave tenant_id /
     // plan_json / bundle_json at their None defaults (via
     // `..Default::default()`) so the libkrun/Vz backends take the legacy
@@ -626,6 +632,7 @@ fn run_inner(
         runner_dir: None,
         network_policy: req.network_policy.clone(),
         warm_pool_size: req.warm_pool_size,
+        dev_console,
         ..Default::default()
     };
 


### PR DESCRIPTION
## What

`mvmctl machine run --image X -it -- <cmd>` (a **transient** interactive run) never set `VmStartConfig.dev_console`, so the backend supervisor didn't pre-open the interactive console data-port sockets (`vsock-20001.sock`…). The console attach then failed:

```
Error: Failed to connect to console data port
  Caused by:
    0: Failed to connect to Vz vsock at .../vsock/vsock-20001.sock
    1: No such file or directory (os error 2)
```

The agent socket (`vsock-5252.sock`) existed — the VM booted fine — but the console data port (`20001`) was never bound, because `dev_console` was only wired on the persistent `up` path (`up.rs`), not on the transient `run_inner` path.

## Fix

Set `dev_console = req.pty && verity_path.is_none()` in `run_inner` — interactive **and** unsealed (a verity sidecar means a sealed production rootfs, which never serves an interactive console; claim 15). This makes the Vz/libkrun (and forthcoming in-house) supervisors pre-open the console data ports, so the PTY console attaches.

## Proof (macOS 26, Vz)

```
$ machine run --image alpine -it -- /bin/sh
~ # echo VZ-IT-SHELL-WORKS; uname -srm; id
Linux 6.12.87 aarch64
uid=0(root) gid=0(root)
VZ-IT-SHELL-WORKS
Console session ended.
```

## Note

This is the same wiring as Plan 221 Task 6 (`transient_run_dev_console`), extracted as a standalone fix so the transient `-it` shell works on the current default (Vz) today, independent of the in-house-backend migration. Coordinate on merge order with the Plan 221 branch to avoid a duplicate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
