### PR TITLE
feat(ext4): pure-Rust dm-verity root hash, validated == veritysetup (Plan 221 B)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -287,7 +287,7 @@ jobs:
       - name: Install Rust toolchain
         uses: dtolnay/rust-toolchain@stable
       - name: Write a sample image with the pure-Rust ext4 writer
-        run: cargo run -p mvm-ext4 --example write_sample -- /tmp/sample.ext4
+        run: cargo run -p mvm-ext4 --example write_sample -- /tmp/sample.ext4 | tee /tmp/sample.out
       - name: Loop-mount read-only and verify the tree on the real kernel
         run: |
           set -euo pipefail
@@ -305,3 +305,19 @@ jobs:
           [ "$(stat -c '%a' "$mnt/hello")" = "755" ]
           [ "$(stat -c '%a' "$mnt/etc/hosts")" = "644" ]
           echo "pure-Rust ext4 mounted + verified on the real Linux kernel"
+      - name: dm-verity root hash matches real veritysetup
+        run: |
+          set -euo pipefail
+          sudo apt-get update && sudo apt-get install -y cryptsetup-bin
+          # Our writer printed `ROOTHASH <hex>`; extract it.
+          ours=$(grep '^ROOTHASH ' /tmp/sample.out | awk '{print $2}')
+          # Real veritysetup on the same image, same params (v1, sha256, 4 KiB
+          # data+hash blocks, 32-byte zero salt).
+          theirs=$(veritysetup format \
+              --data-block-size=4096 --hash-block-size=4096 \
+              --salt=0000000000000000000000000000000000000000000000000000000000000000 \
+              /tmp/sample.ext4 /tmp/sample.verity \
+            | awk '/^Root hash:/ {print $3}')
+          echo "ours=$ours theirs=$theirs"
+          [ -n "$ours" ] && [ "$ours" = "$theirs" ]
+          echo "pure-Rust dm-verity root hash == veritysetup"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2707,6 +2707,7 @@ name = "mvm-ext4"
 version = "0.16.1"
 dependencies = [
  "am-fs-ext4",
+ "sha2",
  "tempfile",
 ]
 

--- a/crates/mvm-ext4/Cargo.toml
+++ b/crates/mvm-ext4/Cargo.toml
@@ -8,6 +8,9 @@ publish = false
 description = "Minimal, memory-safe (#![forbid(unsafe_code)]), deterministic ext4 image writer for read-only microVM rootfs materialization. No journal, no metadata_csum, extents-only. Zero mvm-* deps; builds an image from a node list in pure userspace — no mkfs, no builder VM, no subprocess."
 
 [dependencies]
+# dm-verity Merkle roothash (SHA-256 tree). sha2's own internal `unsafe` lives
+# in that crate, not ours — our `#![forbid(unsafe_code)]` still holds.
+sha2 = { workspace = true }
 
 [dev-dependencies]
 # Read-only ext4 oracle: our writer's output must read back identically through

--- a/crates/mvm-ext4/examples/write_sample.rs
+++ b/crates/mvm-ext4/examples/write_sample.rs
@@ -40,4 +40,11 @@ fn main() {
     let image = build_image(&nodes).expect("build ext4 image");
     std::fs::write(&out, &image).expect("write image file");
     eprintln!("wrote {} bytes to {out}", image.len());
+
+    // Print our dm-verity root hash (v1, sha256, 4 KiB data+hash blocks, zero
+    // salt) so the CI lane can diff it against real `veritysetup` on the same
+    // image. Single stdout line: `ROOTHASH <64-hex>`.
+    let salt = [0u8; 32];
+    let root = mvm_ext4::verity::root_hash(&image, &salt, 4096, 4096);
+    println!("ROOTHASH {}", mvm_ext4::verity::to_hex(&root));
 }

--- a/crates/mvm-ext4/src/lib.rs
+++ b/crates/mvm-ext4/src/lib.rs
@@ -27,6 +27,8 @@
 
 #![forbid(unsafe_code)]
 
+pub mod verity;
+
 use std::collections::BTreeMap;
 
 pub const BLOCK_SIZE: u32 = 4096;

--- a/crates/mvm-ext4/src/verity.rs
+++ b/crates/mvm-ext4/src/verity.rs
@@ -1,0 +1,125 @@
+//! Pure-Rust dm-verity (version 1, SHA-256) Merkle **root hash**.
+//!
+//! Replaces the `veritysetup format` shell-out: given the rootfs image bytes,
+//! the salt, and the block sizes, compute the same 32-byte root hash
+//! `veritysetup` prints as `Root hash:`. That hash is dm-verity's integrity
+//! anchor (claim 3) and mvm's content-addressed image identifier — so it is
+//! deterministic by construction (a pure function of data + salt + block sizes).
+//!
+//! The CI `ext4-real-mount` lane cross-checks this against real `veritysetup` on
+//! the same image, byte-for-byte on the hex.
+//!
+//! Version 1 hashing: each block digest is `SHA-256(salt ‖ block)` (salt
+//! prepended). Leaves are the data-block digests; each level's digests are
+//! packed 32 bytes each into hash blocks (zero-padded), and each hash block is
+//! hashed to form the level above, until one block remains — the root hash is
+//! that final block's digest.
+
+use sha2::{Digest, Sha256};
+
+const DIGEST_SIZE: usize = 32;
+
+/// Compute the dm-verity v1 SHA-256 root hash of `data`.
+///
+/// `data.len()` should be a multiple of `data_block_size` (a rootfs image is);
+/// a short final block is zero-padded, matching `veritysetup`.
+pub fn root_hash(
+    data: &[u8],
+    salt: &[u8],
+    data_block_size: usize,
+    hash_block_size: usize,
+) -> [u8; DIGEST_SIZE] {
+    // Level 0 (leaves): digest of each data block.
+    let n_data_blocks = data.len().div_ceil(data_block_size).max(1);
+    let mut level: Vec<[u8; DIGEST_SIZE]> = (0..n_data_blocks)
+        .map(|i| {
+            let start = i * data_block_size;
+            let end = (start + data_block_size).min(data.len());
+            let mut block = vec![0u8; data_block_size];
+            if start < data.len() {
+                block[..end - start].copy_from_slice(&data[start..end]);
+            }
+            hash_block(salt, &block)
+        })
+        .collect();
+
+    let hashes_per_block = hash_block_size / DIGEST_SIZE;
+    loop {
+        let n_blocks = level.len().div_ceil(hashes_per_block).max(1);
+        if n_blocks == 1 {
+            // This level fits one hash block — its digest is the root hash.
+            return hash_block(salt, &pack(&level, 0, hash_block_size));
+        }
+        // Otherwise, hash each packed block to form the level above.
+        level = (0..n_blocks)
+            .map(|b| hash_block(salt, &pack(&level, b * hashes_per_block, hash_block_size)))
+            .collect();
+    }
+}
+
+/// Pack up to `hash_block_size / 32` digests starting at `from` into a single
+/// zero-padded hash block.
+fn pack(digests: &[[u8; DIGEST_SIZE]], from: usize, hash_block_size: usize) -> Vec<u8> {
+    let hashes_per_block = hash_block_size / DIGEST_SIZE;
+    let mut block = vec![0u8; hash_block_size];
+    for j in 0..hashes_per_block {
+        match digests.get(from + j) {
+            Some(d) => block[j * DIGEST_SIZE..(j + 1) * DIGEST_SIZE].copy_from_slice(d),
+            None => break,
+        }
+    }
+    block
+}
+
+fn hash_block(salt: &[u8], block: &[u8]) -> [u8; DIGEST_SIZE] {
+    let mut h = Sha256::new();
+    h.update(salt);
+    h.update(block);
+    h.finalize().into()
+}
+
+/// Lowercase-hex of a digest (the form `veritysetup` prints and mvm's
+/// `rootfs.roothash` stores).
+pub fn to_hex(digest: &[u8; DIGEST_SIZE]) -> String {
+    let mut s = String::with_capacity(DIGEST_SIZE * 2);
+    for b in digest {
+        s.push_str(&format!("{b:02x}"));
+    }
+    s
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn root_hash_is_deterministic() {
+        let data = vec![0xABu8; 4096 * 5];
+        let salt = [0u8; 32];
+        let a = root_hash(&data, &salt, 4096, 4096);
+        let b = root_hash(&data, &salt, 4096, 4096);
+        assert_eq!(a, b);
+        assert_eq!(to_hex(&a).len(), 64);
+    }
+
+    #[test]
+    fn single_data_block_matches_hand_computation() {
+        // One 4096-byte data block of zeros, zero salt. The tree is a single
+        // leaf that fits one hash block, so root = H(salt ‖ pack([H(salt ‖ block)])).
+        let data = vec![0u8; 4096];
+        let salt = [0u8; 32];
+        let leaf = hash_block(&salt, &vec![0u8; 4096]);
+        let mut hash_block_bytes = vec![0u8; 4096];
+        hash_block_bytes[..32].copy_from_slice(&leaf);
+        let expected = hash_block(&salt, &hash_block_bytes);
+        assert_eq!(root_hash(&data, &salt, 4096, 4096), expected);
+    }
+
+    #[test]
+    fn distinct_data_changes_the_root() {
+        let salt = [0u8; 32];
+        let a = root_hash(&vec![0u8; 4096 * 3], &salt, 4096, 4096);
+        let b = root_hash(&vec![1u8; 4096 * 3], &salt, 4096, 4096);
+        assert_ne!(a, b);
+    }
+}


### PR DESCRIPTION
Adds `mvm_ext4::verity::root_hash` — the dm-verity v1 SHA-256 Merkle root hash in **pure safe Rust**, replacing the `veritysetup format` shell-out for the local run path.

## Validated against the authoritative oracle

The CI `ext4-real-mount` lane now installs `cryptsetup-bin` and asserts **our root hash equals real `veritysetup format`** on the same image (v1, sha256, 4 KiB data+hash blocks, zero salt). This already ran green on the source commit:

```
dm-verity root hash matches real veritysetup … success
```

Plus unit tests: determinism, a hand-computed single-block vector, and data-sensitivity.

## Why it's safe/right

- Deterministic by construction (pure function of data + salt + block sizes) — required for the content-addressed roothash (claim 3).
- `#![forbid(unsafe_code)]` holds (sha2's internal `unsafe` is in that crate, not ours).

## Note on provenance

This is the verity half of the #1418 branch: #1418 auto-merged the mount lane at an earlier commit before this push registered, so this cherry-picks the verity delta cleanly onto main.

## Plan 221 B

| step | what | status |
|---|---|---|
| B2 | `mvm-ext4` writer (mounts on real kernel) | ✅ #1414 + #1418 |
| B4a | `materialize_ext4_pure` | ✅ #1416 |
| verity | **root hash == veritysetup** | **this PR** |
| next | full hash-tree sidecar bytes (also veritysetup-diffed) → wire verity into `materialize_ext4_pure` → `LocalBackend.run` |