### PR TITLE
feat(ext4): full dm-verity hash tree, byte-diffed vs veritysetup (Plan 221 B)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -304,20 +304,30 @@ jobs:
           # Permissions preserved.
           [ "$(stat -c '%a' "$mnt/hello")" = "755" ]
           [ "$(stat -c '%a' "$mnt/etc/hosts")" = "644" ]
+          [ "$(stat -c '%s' "$mnt/big")" = "716800" ]
           echo "pure-Rust ext4 mounted + verified on the real Linux kernel"
-      - name: dm-verity root hash matches real veritysetup
+      - name: dm-verity root hash + hash tree match real veritysetup
         run: |
           set -euo pipefail
           sudo apt-get update && sudo apt-get install -y cryptsetup-bin
-          # Our writer printed `ROOTHASH <hex>`; extract it.
+          # Our writer printed `ROOTHASH <hex>` and wrote the no-superblock hash
+          # tree to `<image>.verity`.
           ours=$(grep '^ROOTHASH ' /tmp/sample.out | awk '{print $2}')
-          # Real veritysetup on the same image, same params (v1, sha256, 4 KiB
-          # data+hash blocks, 32-byte zero salt).
-          theirs=$(veritysetup format \
+          # Real veritysetup, same params (v1, sha256, 4 KiB data+hash blocks,
+          # 32-byte zero salt). --no-superblock keeps the tree deterministic (no
+          # random UUID) and matches our `format()` layout.
+          theirs=$(veritysetup format --no-superblock \
               --data-block-size=4096 --hash-block-size=4096 \
               --salt=0000000000000000000000000000000000000000000000000000000000000000 \
-              /tmp/sample.ext4 /tmp/sample.verity \
+              /tmp/sample.ext4 /tmp/vs.verity \
             | awk '/^Root hash:/ {print $3}')
           echo "ours=$ours theirs=$theirs"
           [ -n "$ours" ] && [ "$ours" = "$theirs" ]
-          echo "pure-Rust dm-verity root hash == veritysetup"
+          # Hash-tree bytes must match byte-for-byte.
+          if ! cmp -s /tmp/sample.ext4.verity /tmp/vs.verity; then
+            echo "::error::hash tree differs from veritysetup"
+            ls -l /tmp/sample.ext4.verity /tmp/vs.verity
+            cmp -l /tmp/sample.ext4.verity /tmp/vs.verity | head -20 || true
+            exit 1
+          fi
+          echo "pure-Rust dm-verity root hash + hash tree == veritysetup"

--- a/crates/mvm-ext4/examples/write_sample.rs
+++ b/crates/mvm-ext4/examples/write_sample.rs
@@ -36,15 +36,25 @@ fn main() {
             path: "/bin".into(),
             mode: 0o755,
         },
+        // A big file so the image exceeds 128 data blocks (512 KiB) — this
+        // forces a MULTI-level verity hash tree, so the byte-for-byte cmp
+        // against veritysetup actually exercises the level layout/ordering.
+        Node::File {
+            path: "/big".into(),
+            mode: 0o644,
+            data: (0..700 * 1024u32).map(|i| (i % 251) as u8).collect(),
+        },
     ];
     let image = build_image(&nodes).expect("build ext4 image");
     std::fs::write(&out, &image).expect("write image file");
     eprintln!("wrote {} bytes to {out}", image.len());
 
-    // Print our dm-verity root hash (v1, sha256, 4 KiB data+hash blocks, zero
-    // salt) so the CI lane can diff it against real `veritysetup` on the same
-    // image. Single stdout line: `ROOTHASH <64-hex>`.
+    // dm-verity (v1, sha256, 4 KiB data+hash blocks, zero salt): write the
+    // no-superblock hash tree beside the image and print the root hash, so the
+    // CI lane can diff both against real `veritysetup` on the same image.
+    // `ROOTHASH <64-hex>` on stdout; `<out>.verity` holds the tree.
     let salt = [0u8; 32];
-    let root = mvm_ext4::verity::root_hash(&image, &salt, 4096, 4096);
-    println!("ROOTHASH {}", mvm_ext4::verity::to_hex(&root));
+    let vout = mvm_ext4::verity::format(&image, &salt, 4096, 4096);
+    std::fs::write(format!("{out}.verity"), &vout.hash_tree).expect("write hash tree");
+    println!("ROOTHASH {}", mvm_ext4::verity::to_hex(&vout.root_hash));
 }

--- a/crates/mvm-ext4/src/verity.rs
+++ b/crates/mvm-ext4/src/verity.rs
@@ -57,6 +57,79 @@ pub fn root_hash(
     }
 }
 
+/// A verity root hash plus the hash-tree bytes (no-superblock layout) that
+/// dm-verity / `veritysetup open` consumes as the hash device.
+pub struct VerityOutput {
+    pub root_hash: [u8; DIGEST_SIZE],
+    /// The hash tree, levels concatenated **top-first** (level L-1 down to
+    /// level 0) — the layout `veritysetup format --no-superblock` writes and the
+    /// kernel dm-verity target reads.
+    pub hash_tree: Vec<u8>,
+}
+
+/// Compute the dm-verity v1 SHA-256 root hash **and** emit the full hash tree
+/// (no-superblock). Byte-for-byte equal to `veritysetup format --no-superblock`
+/// for the same `(data, salt, block sizes)`, which the CI lane asserts.
+pub fn format(
+    data: &[u8],
+    salt: &[u8],
+    data_block_size: usize,
+    hash_block_size: usize,
+) -> VerityOutput {
+    let hashes_per_block = hash_block_size / DIGEST_SIZE;
+
+    // Level 0 (leaves): one digest per data block.
+    let n_data_blocks = data.len().div_ceil(data_block_size).max(1);
+    let mut cur: Vec<[u8; DIGEST_SIZE]> = (0..n_data_blocks)
+        .map(|i| {
+            let start = i * data_block_size;
+            let end = (start + data_block_size).min(data.len());
+            let mut block = vec![0u8; data_block_size];
+            if start < data.len() {
+                block[..end - start].copy_from_slice(&data[start..end]);
+            }
+            hash_block(salt, &block)
+        })
+        .collect();
+
+    // Build each level's *block bytes* bottom-up: level 0 first in `levels`.
+    let mut levels: Vec<Vec<u8>> = Vec::new();
+    loop {
+        let n_blocks = cur.len().div_ceil(hashes_per_block).max(1);
+        let mut level_bytes = vec![0u8; n_blocks * hash_block_size];
+        for (j, digest) in cur.iter().enumerate() {
+            let blk = j / hashes_per_block;
+            let idx = j % hashes_per_block;
+            let off = blk * hash_block_size + idx * DIGEST_SIZE;
+            level_bytes[off..off + DIGEST_SIZE].copy_from_slice(digest);
+        }
+        levels.push(level_bytes);
+        if n_blocks == 1 {
+            break;
+        }
+        // Next level up: hash each block of this level.
+        let this = levels.last().expect("just pushed");
+        cur = (0..n_blocks)
+            .map(|b| hash_block(salt, &this[b * hash_block_size..(b + 1) * hash_block_size]))
+            .collect();
+    }
+
+    // Root hash = digest of the single top-level block.
+    let top = levels.last().expect("at least one level");
+    let root_hash = hash_block(salt, top);
+
+    // Tree file: top level first, leaves last.
+    let mut hash_tree = Vec::with_capacity(levels.iter().map(Vec::len).sum());
+    for level in levels.iter().rev() {
+        hash_tree.extend_from_slice(level);
+    }
+
+    VerityOutput {
+        root_hash,
+        hash_tree,
+    }
+}
+
 /// Pack up to `hash_block_size / 32` digests starting at `from` into a single
 /// zero-padded hash block.
 fn pack(digests: &[[u8; DIGEST_SIZE]], from: usize, hash_block_size: usize) -> Vec<u8> {
@@ -113,6 +186,17 @@ mod tests {
         hash_block_bytes[..32].copy_from_slice(&leaf);
         let expected = hash_block(&salt, &hash_block_bytes);
         assert_eq!(root_hash(&data, &salt, 4096, 4096), expected);
+    }
+
+    #[test]
+    fn format_agrees_with_root_hash_and_emits_whole_blocks() {
+        // 200 data blocks → 2 leaf hash blocks → a 2-level tree.
+        let data = vec![0x5Au8; 4096 * 200];
+        let salt = [0u8; 32];
+        let out = format(&data, &salt, 4096, 4096);
+        assert_eq!(out.root_hash, root_hash(&data, &salt, 4096, 4096));
+        assert!(!out.hash_tree.is_empty());
+        assert_eq!(out.hash_tree.len() % 4096, 0, "tree is whole hash blocks");
     }
 
     #[test]


### PR DESCRIPTION
Completes the pure-Rust verity primitive: `mvm_ext4::verity::format` returns the **root hash + the full no-superblock hash tree** — no `veritysetup` shell-out — and the CI lane cross-checks **both** byte-for-byte against real `veritysetup`.

## What

- `format(data, salt, dbs, hbs) -> VerityOutput { root_hash, hash_tree }` — levels concatenated top-first (the layout the kernel dm-verity target reads). `root_hash` stays as the lean, already-validated path; a unit test asserts they agree.
- The `ext4-real-mount` lane now `cmp`s our tree vs `veritysetup format --no-superblock` (deterministic — no random UUID), and dumps first-differing offsets on mismatch.
- The sample gains a 700 KiB file so the image exceeds 128 data blocks → a **multi-level** tree, so the diff actually exercises level layout/ordering (a single leaf block wouldn't).

## Validation

Local: 7 mvm-ext4 tests green (incl. `format` ↔ `root_hash` agreement). CI: the loop-mount + roothash + **tree byte-diff** all run on the real kernel + real veritysetup.

## Plan 221 B

| step | what | status |
|---|---|---|
| B2 / B4a | writer + `materialize_ext4_pure` | ✅ (#1414/#1418/#1416) |
| verity roothash | == veritysetup | ✅ #1420 |
| verity tree | == veritysetup (byte-for-byte) | **this PR** |
| next | wire verity into `materialize_ext4_pure` → `LocalBackend.run` |