### PR TITLE
fix(build): decode mvm.verb_grant in the OCI guest init (enforcement was a no-op for OCI images)

### DIFF
--- a/crates/mvm-build/src/oci_runtime_inject.rs
+++ b/crates/mvm-build/src/oci_runtime_inject.rs
@@ -116,6 +116,19 @@ if [ -n "$MVM_UVOLS" ]; then
   done
 fi
 
+# Verb grant (plan-bound agent verb capabilities). The host encoded
+# mvm.verb_grant=<hex(JSON envelope)> onto the kernel cmdline; decode it to
+# the tmpfs so the agent can pin + enforce it before serving RPC. Absent
+# token => no-op (byte-identical boot; the agent starts with no grant).
+# Mirrors the mkGuest init verb-grant stage in nix/lib/mk-guest.nix.
+MVM_VERB_GRANT_HEX=$(sed -n 's/.*\bmvm\.verb_grant=\([^ ]*\).*/\1/p' /proc/cmdline 2>/dev/null)
+if [ -n "$MVM_VERB_GRANT_HEX" ]; then
+  mkdir -p /run/mvm 2>/dev/null || true
+  printf '%b' "$(echo "$MVM_VERB_GRANT_HEX" | sed 's/../\\x&/g')" > /run/mvm/verb-grant.json
+  chmod 0644 /run/mvm/verb-grant.json 2>/dev/null || true
+  echo "mvm-oci-init: provisioned verb-grant"
+fi
+
 # Guest-side network defense — prefer the overlay-resident netinit.
 MVM_NETINIT=
 if [ -x /mvm/runtime/netinit ]; then
@@ -295,6 +308,30 @@ mod tests {
         assert!(
             uvols_at < agent_fork_at,
             "user volumes must mount before the agent fork"
+        );
+    }
+
+    #[test]
+    fn init_script_decodes_verb_grant_before_the_agent() {
+        let s = oci_init_script();
+        // Decodes the host-encoded cmdline token into the tmpfs the agent
+        // reads, so an OCI workload pins + enforces its verb grant (parity
+        // with the mkGuest init).
+        assert!(
+            s.contains("mvm.verb_grant="),
+            "init must parse the verb_grant cmdline token"
+        );
+        assert!(
+            s.contains("/run/mvm/verb-grant.json"),
+            "decoded grant is written where the agent loads it"
+        );
+        // Must be provisioned before the agent forks, or the agent boots
+        // with no grant pinned and enforcement is a no-op.
+        let grant_at = s.find("mvm.verb_grant=").expect("verb_grant parse");
+        let agent_fork_at = s.find("\"$MVM_AGENT\" &").expect("agent fork");
+        assert!(
+            grant_at < agent_fork_at,
+            "verb grant must be decoded before the agent fork"
         );
     }
 


### PR DESCRIPTION
## fix: decode `mvm.verb_grant` in the OCI guest init (enforcement was a no-op for OCI images)

**Bug (found by live-boot validation, #1381):** for `machine run --image <OCI-ref>` workloads, the host minted the verb grant and delivered it on the kernel cmdline (`mvm.verb_grant=<hex>` was confirmed on the guest `/proc/cmdline`), but the **OCI guest init never decoded it** — so `/run/mvm/verb-grant.json` was never written, the agent pinned nothing, and `enforce_verb_grant(None)` allowed everything. Plan-bound verb enforcement was effectively a **no-op for every OCI-image workload** (it only engaged for flake/mkGuest images, whose `nix/lib/mk-guest.nix` init has the decode stage).

**Fix:** add the `mvm.verb_grant=` cmdline→`/run/mvm/verb-grant.json` decode stage to `oci_init_script()` (`crates/mvm-build/src/oci_runtime_inject.rs`), mirroring the mkGuest stage, placed **before the agent fork** (so the grant is pinned before the agent serves RPC). The OCI init already used this exact hex+sed+printf pattern for `mvm.uvols=`; this reuses it. Absent token ⇒ no-op (byte-identical boot).

**Tests:** new unit test `init_script_decodes_verb_grant_before_the_agent` (asserts the decode is present, writes the right path, and runs before the agent fork); fmt/clippy/`check` clean.

**Live-boot validated on Firecracker/KVM** (`machine run -d --image alpine --profile dev --agent-verb ping`, re-materialized with this fix):
```
mvm-oci-init: provisioned verb-grant                          ← /init decoded the token
Error: verb exec not authorized by the session's verb grant   ← out-of-grant exec now REFUSED
```
Before this fix, that same `exec` *ran* (enforcement inert). This is the definitive before/after.

**Not in scope (tracked #1381):** the OCI init is *also* missing `mvm.egress_ca=` and `mvm.secret_env=` decode stages that mkGuest has (claim-10 / claim-13-adjacent) — flagged separately for its own verification rather than mirrored blind here.

Refs #1381.
