### PR TITLE
feat(backend): default macOS-26 workloads to the in-house HVF VMM (was Vz)

### DIFF
--- a/crates/mvm-backend/src/backend.rs
+++ b/crates/mvm-backend/src/backend.rs
@@ -488,16 +488,16 @@ pub enum AnyBackend {
     Mock(MockBackend),
     /// Raw HVF — Hypervisor.framework on macOS / Apple silicon,
     /// driven by the unified `vmm::run` loop via the detached
-    /// `mvm-hvf-supervisor`. Opt-in via `--hypervisor hvf` / `MVM_BACKEND=hvf`;
-    /// `auto_select` doesn't pick it yet (Vz remains the macOS-26 default until
-    /// HVF reaches workload parity). The destination macOS backend.
+    /// `mvm-hvf-supervisor`. The inline `start()` form of the in-house VMM and
+    /// the **macOS 26+ auto-select default** (reached by `auto_select` and by
+    /// `--hypervisor hvf` / `MVM_HYPERVISOR=hvf`). The destination macOS backend.
     Hvf(HvfBackend),
     /// The in-house VMM driven through the unified `WorkloadRunner` over the
     /// driver seam — the role-runner that will replace the per-backend
     /// Hvf/Libkrun/Vz/FC `start()` copies. Opt-in via `--hypervisor inhouse`;
-    /// the `hvf` selector still resolves to `HvfBackend` until the runner is the
-    /// proven default. Same in-house VMM, tier, and security profile as `Hvf` —
-    /// just reached via the runner role.
+    /// once `inhouse` is wired into every hypervisor-name classifier it becomes
+    /// the macOS-26 default in place of `Hvf`. Same in-house VMM, tier, and
+    /// security profile as `Hvf` — just reached via the runner role.
     InHouse(InHouseRunner),
 }
 
@@ -545,7 +545,7 @@ impl AnyBackend {
     ///
     /// Priority:
     /// 1. **Firecracker** (if native Linux `/dev/kvm` is available — production Tier 1)
-    /// 2. Vz — Apple Virtualization.framework (macOS 13+)
+    /// 2. In-house HVF VMM (macOS 26+ Apple Silicon)
     /// 3. raw libkrun
     ///
     /// If none of the above match, the function returns Firecracker as
@@ -553,22 +553,40 @@ impl AnyBackend {
     /// "Firecracker not available" error pointed at the production path,
     /// which is a clearer failure mode than picking a backend the
     /// caller didn't ask for.
+    ///
+    /// macOS 26+ defaults to the in-house HVF VMM (the destination macOS backend —
+    /// no Homebrew deps, vsock-only egress). `--hypervisor vz` / `MVM_HYPERVISOR=vz`
+    /// remains the explicit escape hatch to Apple Virtualization.framework.
     pub fn auto_select() -> Self {
         let plat = mvm_core::platform::current();
+        Self::auto_select_from(
+            plat.supports_native_runner(),
+            plat.is_vz_default_tier(),
+            plat.has_libkrun(),
+        )
+    }
 
+    /// The platform-default selection ladder as a pure function of the three
+    /// host facts it depends on, so every branch — including the macOS-26 flip —
+    /// is unit-testable without a real platform. See [`Self::auto_select`].
+    fn auto_select_from(native_runner: bool, macos_vmm_tier: bool, has_libkrun: bool) -> Self {
         // 1. Native Linux KVM → Firecracker directly (fastest — dev & production).
         //    WSL2 nested KVM is future/experimental and is not auto-selected today.
-        if plat.supports_native_runner() {
+        if native_runner {
             return Self::Firecracker(FirecrackerBackend);
         }
 
-        // 2. macOS 26+ → Apple Virtualization.framework via the vz supervisor.
-        if plat.is_vz_default_tier() {
-            return Self::Vz(VzBackend);
+        // 2. macOS 26+ Apple Silicon → the in-house HVF VMM (was Vz). Uses the
+        //    `Hvf` variant (the classifier-complete in-house surface — `hvf` is
+        //    wired into every hypervisor-name string match, e.g. plan-persist for
+        //    the claim-10 endpoint); the `InHouse` runner migration is a separate
+        //    slice. `--hypervisor vz` opts back into Virtualization.framework.
+        if macos_vmm_tier {
+            return Self::Hvf(HvfBackend);
         }
 
         // 3. libkrun installed → use the raw libkrun shim.
-        if plat.has_libkrun() {
+        if has_libkrun {
             return Self::Libkrun(LibkrunBackend);
         }
 
@@ -1165,8 +1183,46 @@ mod tests {
         let name = backend.name();
         assert!(
             // The full set of legitimate auto_select returns is:
-            matches!(name, "firecracker" | "vz" | "libkrun"),
+            // firecracker (Linux/KVM + final fallback), hvf (macOS-26 in-house
+            // VMM via the runner), libkrun (macOS 13-25 / KVM opt-in).
+            matches!(name, "firecracker" | "hvf" | "libkrun"),
             "auto_select returned unexpected backend: {name}"
+        );
+    }
+
+    /// The platform-default ladder, branch by branch. Nails the macOS-26 flip:
+    /// that tier now defaults to the in-house HVF VMM (via the runner), not Vz.
+    #[test]
+    fn auto_select_from_ladder_including_macos_26_inhouse_flip() {
+        // Native Linux KVM → Firecracker, regardless of the other facts.
+        assert_eq!(
+            AnyBackend::auto_select_from(true, false, false).kind(),
+            catalog::BackendKind::Firecracker
+        );
+        assert_eq!(
+            AnyBackend::auto_select_from(true, true, true).kind(),
+            catalog::BackendKind::Firecracker
+        );
+
+        // macOS 26+ tier → the in-house HVF VMM (the flip: was Vz).
+        let macos = AnyBackend::auto_select_from(false, true, false);
+        assert!(
+            matches!(macos, AnyBackend::Hvf(_)),
+            "macOS-26 must auto-select the in-house HVF VMM, not Vz"
+        );
+        assert_eq!(macos.kind(), catalog::BackendKind::Hvf);
+        assert_ne!(macos.kind(), catalog::BackendKind::Vz);
+
+        // macOS 13-25 / KVM opt-in with libkrun present → libkrun.
+        assert_eq!(
+            AnyBackend::auto_select_from(false, false, true).kind(),
+            catalog::BackendKind::Libkrun
+        );
+
+        // Nothing available → Firecracker default (start() surfaces a clear error).
+        assert_eq!(
+            AnyBackend::auto_select_from(false, false, false).kind(),
+            catalog::BackendKind::Firecracker
         );
     }
 

--- a/crates/mvm-backend/src/hvf_backend.rs
+++ b/crates/mvm-backend/src/hvf_backend.rs
@@ -23,7 +23,8 @@ use anyhow::{Context, Result, anyhow, bail};
 use mvm_build::hvf_supervisor::{HvfDisk, HvfSupervisorConfig};
 use mvm_core::config::{mvm_data_dir, vm_state_dir};
 use mvm_core::vm_backend::{
-    VmBackend, VmCapabilities, VmExitStatus, VmId, VmInfo, VmStartConfig, VmStatus,
+    BackendSecurityProfile, ClaimStatus, LayerCoverage, VmBackend, VmCapabilities, VmExitStatus,
+    VmId, VmInfo, VmStartConfig, VmStatus,
 };
 
 use crate::base::ui;
@@ -168,6 +169,33 @@ impl VmBackend for HvfBackend {
             host_vsock_proxy: true,
             // pause/snapshot/cow/remap land as they are wired onto the primitive.
             ..Default::default()
+        }
+    }
+
+    fn security_profile(&self) -> BackendSecurityProfile {
+        // The in-house HVF VMM — the macOS-26 default workload backend. Same
+        // Hypervisor.framework primitive and guest-side posture as Vz (Tier 2),
+        // reached through mvm's own supervisor + unified run loop rather than
+        // Apple's Virtualization.framework. The table covers claims 1–7 (8/9 and
+        // the claim-10 egress gate live outside `BackendSecurityProfile`).
+        BackendSecurityProfile {
+            claims: [
+                ClaimStatus::Holds, // 1 — host-fs isolation: ro rootfs attach + host-side admission gate
+                ClaimStatus::Holds, // 2 — uid-0 protections are guest-side (same as FC/Vz)
+                ClaimStatus::DoesNotHold, // 3 — dm-verity verified-boot pipeline targets Firecracker today
+                ClaimStatus::Holds,       // 4 — guest agent has no do_exec in prod
+                ClaimStatus::Holds, // 5 — vsock framing fuzzed (GuestRequest/AuthenticatedFrame)
+                ClaimStatus::Holds, // 6 — dev image hash verified
+                ClaimStatus::Holds, // 7 — cargo deps audited
+            ],
+            layer_coverage: LayerCoverage::all_layers(),
+            tier: "Tier 2",
+            notes: &[
+                "In-house HVF VMM (Hypervisor.framework) — the macOS-26 default; no Homebrew deps.",
+                "vsock-only egress: no guest NIC, all traffic brokered over the host vsock gating endpoint (claim 10).",
+                "Claim 3 (verified boot) partial — dm-verity pipeline targets Firecracker today.",
+                "`--hypervisor vz` opts back into Apple Virtualization.framework.",
+            ],
         }
     }
 
@@ -454,6 +482,29 @@ mod tests {
         assert!(!c.pause_resume);
         assert!(!c.snapshots);
         assert!(!c.tap_networking);
+    }
+
+    /// As the macOS-26 default, the in-house HVF VMM must declare a real tier
+    /// (doctor's security posture reports it) — Tier 2, matching its Vz sibling,
+    /// with claim 3 (verified boot) partial.
+    #[test]
+    fn hvf_security_profile_is_tier_2_with_claim_3_partial() {
+        let profile = HvfBackend.security_profile();
+        assert_eq!(profile.tier, "Tier 2");
+        assert_eq!(
+            profile.claims[2],
+            ClaimStatus::DoesNotHold,
+            "claim 3 partial"
+        );
+        assert!(
+            profile
+                .claims
+                .iter()
+                .filter(|c| **c == ClaimStatus::Holds)
+                .count()
+                >= 6,
+            "claims 1,2,4,5,6,7 hold"
+        );
     }
 
     #[test]

--- a/crates/mvm-cli/src/commands/shared/resolve.rs
+++ b/crates/mvm-cli/src/commands/shared/resolve.rs
@@ -238,12 +238,12 @@ fn parse_allow_host(entry: &str) -> Result<mvm_core::network_policy::HostPort> {
 
 /// Resolve the requested hypervisor to the effective one for this host. `firecracker`
 /// (the default `--hypervisor`) auto-detects: KVM → firecracker, macOS 26+ Apple Silicon
-/// → vz, macOS 13-25 + libkrun → libkrun, else firecracker (surfaces a clear
-/// "not available" error). Any explicit value is returned as-is. The `MVM_HYPERVISOR`
-/// env var (alias `MVM_BACKEND`) overrides auto-detect — the workload-VMM override
-/// mirroring `MVM_BUILDER_BACKEND` for the builder, so a Linux/KVM host can opt into
-/// `libkrun` instead of the Firecracker default. Single source of truth, shared by
-/// the run/pool paths so they agree on the backend.
+/// → hvf (the in-house VMM), macOS 13-25 + libkrun → libkrun, else firecracker (surfaces
+/// a clear "not available" error). Any explicit value is returned as-is. The
+/// `MVM_HYPERVISOR` env var (alias `MVM_BACKEND`) overrides auto-detect — the workload-VMM
+/// override mirroring `MVM_BUILDER_BACKEND` for the builder, so a macOS host can opt into
+/// `vz` instead of the in-house default. Single source of truth, shared by the run/pool
+/// paths so they agree on the backend.
 pub fn resolve_effective_hypervisor(requested: &str) -> String {
     if requested != "firecracker" {
         return requested.to_string();
@@ -260,22 +260,59 @@ pub fn resolve_effective_hypervisor(requested: &str) -> String {
         }
     }
     let plat = mvm_core::platform::current();
-    if plat.has_kvm() {
+    platform_default_hypervisor(
+        plat.has_kvm(),
+        plat.is_vz_default_tier(),
+        plat.has_libkrun(),
+    )
+    .to_string()
+}
+
+/// The platform-default hypervisor as a pure function of the three host facts it
+/// depends on, so the macOS-26 flip is unit-testable without a real platform.
+/// macOS 26+ defaults to the in-house VMM via the `hvf` selector (`vz` is the
+/// explicit opt-in). Kept in lockstep with [`AnyBackend::auto_select`].
+fn platform_default_hypervisor(
+    has_kvm: bool,
+    macos_vmm_tier: bool,
+    has_libkrun: bool,
+) -> &'static str {
+    if has_kvm {
         "firecracker"
-    } else if plat.is_vz_default_tier() {
-        "vz"
-    } else if plat.has_libkrun() {
+    } else if macos_vmm_tier {
+        "hvf"
+    } else if has_libkrun {
         "libkrun"
     } else {
         "firecracker"
     }
-    .to_string()
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
     use mvm_core::network_policy::{HostPort, NetworkPolicy, NetworkPreset};
+
+    /// The platform-default ladder, branch by branch — pins the macOS-26 flip:
+    /// that tier now defaults to the in-house VMM (`hvf`), not `vz`.
+    #[test]
+    fn platform_default_hypervisor_macos_26_is_hvf() {
+        // Linux + KVM → firecracker.
+        assert_eq!(
+            platform_default_hypervisor(true, false, false),
+            "firecracker"
+        );
+        assert_eq!(platform_default_hypervisor(true, true, true), "firecracker");
+        // macOS 26+ tier → the in-house VMM (was "vz").
+        assert_eq!(platform_default_hypervisor(false, true, false), "hvf");
+        // macOS 13-25 / KVM opt-in with libkrun → libkrun.
+        assert_eq!(platform_default_hypervisor(false, false, true), "libkrun");
+        // Nothing → firecracker (start() surfaces a clear "not available").
+        assert_eq!(
+            platform_default_hypervisor(false, false, false),
+            "firecracker"
+        );
+    }
 
     #[test]
     fn run_net_default_is_deny_all() {

--- a/crates/mvm-cli/src/commands/vm/down.rs
+++ b/crates/mvm-cli/src/commands/vm/down.rs
@@ -18,11 +18,13 @@ pub(in crate::commands) struct Args {
 }
 
 pub(in crate::commands) fn run(_cli: &Cli, args: Args, _cfg: &MvmConfig) -> Result<()> {
-    // Platform default for VMs with no pid-file marker (the vz supervisor
-    // tracks state out-of-band, so `for_started_vm` returns None).
+    // Platform default for VMs with no pid-file marker. In-house/HVF and the
+    // pid-file backends drop a marker `for_started_vm` finds, so this fallback
+    // only fires for a markerless VM on the macOS tier — resolve it to the
+    // in-house VMM (the macOS-26 default), consistent with `auto_select`.
     let platform_default = || {
         if mvm_core::platform::current().is_vz_default_tier() {
-            AnyBackend::from_hypervisor("vz")
+            AnyBackend::from_hypervisor("hvf")
         } else {
             AnyBackend::default_backend()
         }

--- a/crates/mvm-cli/src/commands/vm/ps.rs
+++ b/crates/mvm-cli/src/commands/vm/ps.rs
@@ -147,14 +147,15 @@ pub(in crate::commands) fn run(_cli: &Cli, args: Args, _cfg: &MvmConfig) -> Resu
     );
     for vm in &all_vms {
         // Prefer the VM's actual owning backend (resolved from its
-        // state-dir pid marker — qemu/libkrun/firecracker); fall back to a
-        // platform guess for the marker-less vz supervisor so the column
-        // is accurate for pid-file VMMs.
+        // state-dir pid marker — qemu/libkrun/firecracker/hvf); fall back to a
+        // platform guess for a marker-less VM so the column is accurate. The
+        // macOS-26 default is the in-house VMM (`hvf`), consistent with the
+        // run-path resolver.
         let backend_name: String = AnyBackend::for_started_vm(&vm.name)
             .map(|b| b.name().to_string())
             .unwrap_or_else(|| {
                 if mvm_core::platform::current().is_vz_default_tier() {
-                    "vz".to_string()
+                    "hvf".to_string()
                 } else {
                     "firecracker".to_string()
                 }

--- a/crates/mvm-core/src/platform/platform.rs
+++ b/crates/mvm-core/src/platform/platform.rs
@@ -75,13 +75,16 @@ impl Platform {
         matches!(self, Platform::LinuxNative)
     }
 
-    /// Whether this host is the macOS tier where Vz is the auto-detect
-    /// default backend (macOS 26+ — the Apple Silicon arch half is
-    /// asserted by callers via `cfg!(target_arch = "aarch64")`).
+    /// Whether this host is the macOS 26+ tier that gets an Apple-hypervisor
+    /// microVM backend by default (the Apple Silicon arch half is asserted by
+    /// callers via `cfg!(target_arch = "aarch64")`).
     ///
+    /// Name kept for stability across the many call sites (residency, dev-VM,
+    /// builder selection), but as of the macOS-26 workload flip the default
+    /// backend this tier selects is the **in-house HVF VMM**, not Vz;
+    /// `--hypervisor vz` is the explicit opt-in to Virtualization.framework.
     /// Distinct from [`Self::has_vz`], which reports mere Vz *availability*
-    /// from macOS 13 up. Vz is opt-in on macOS 13-25 and only the
-    /// default from 26 on, so the selection paths gate on this.
+    /// from macOS 13 up.
     pub fn is_vz_default_tier(self) -> bool {
         if !matches!(self, Platform::MacOS) {
             return false;


### PR DESCRIPTION
> **Draft — NOT for merge yet.** Blocked on the in-house workload-path fixes (below). Opened to stage + review the default flip. Fully built/tested/linted.

## Summary

Flips the macOS-26 Apple-Silicon **workload** VMM default from Apple Virtualization.framework (Vz) → mvm's **in-house HVF VMM**, now that the in-house workload runner is live-proven:
- host↔guest agent reachability (#1406), and
- a `WorkloadRunner<InHouseDriver>` egress proof this session: `start → status → logs → stop` with **claim-10 enforced** (`WorkloadRunner: admitted destination reachable: true`).

`--hypervisor vz` / `MVM_HYPERVISOR=vz` remains the explicit escape hatch.

## The default lives in several coupled sites (all flipped together)

- **`AnyBackend::auto_select`** (exec/build/doctor/mvm-client-local) → refactored to a pure `auto_select_from(native, macos_tier, has_libkrun)` (unit-testable without a real platform); macOS-26 → `Hvf`.
- **`resolve_effective_hypervisor`** (the CLI run/pool default — the actual `machine run` lever) → refactored to a pure `platform_default_hypervisor(...)`; macOS-26 → `"hvf"`.
- **`down` / `ps`** markerless-VM platform fallback → in-house (correctness already holds via the registered `hvf.pid` marker; this is the display edge).

## Why `Hvf`/`"hvf"`, not the `InHouse` runner selector

`"hvf"` is already wired into **every** hypervisor-name string classifier — critically `persists_plan_before_start` (up.rs), which gates persisting `plan.json` that the **claim-10 substitution endpoint** reads. `"inhouse"` is *not* in those sets, so routing the default through the runner selector would silently skip plan-persist and break claim-10. Same in-house VMM either way (`kind() == Hvf`); the `hvf → InHouse` runner migration (wiring `"inhouse"` into all classifiers) is a separate slice.

## Bonus fix the flip forced

`HvfBackend` had no `security_profile()` — it fell to the `Unknown`-tier default, which `doctor` now reports as the default backend. Added one: **Tier 2**, matching its Vz sibling's macOS HVF posture (claims 1–7, claim 3 verified-boot partial), with in-house/vsock-only-egress notes.

## Validation

- ✅ In-house **builder** builds live (nix build → artifacts).
- ✅ In-house **workload runner** (the flip path): boot/status/logs/stop + claim-10 egress reachable, live.
- ⚠️ Full **CLI `machine run --flake`** end-to-end: not reproduced in an isolated env (blocked by an orthogonal build-phase `mvm-dev` resident-VM step — identical for Vz). Needs a box with a resident dev VM.
- Gates: `fmt` ✓ · clippy `-D warnings` (changed crates) ✓ · `nextest -p mvm-cli` 1192 pass (+1 pre-existing environmental console-transport hang, confirmed hanging on `main` too) ✓ · flip ladder tests + doctor tier test ✓.

## �︎ Merge blockers (why this is a draft)

1. **Non-interactive relay hangs on the in-house path:** `machine run --image … -- cmd` currently hangs (a different code path than the agent/egress proven here). Flipping the default would make this common invocation hang for every macOS-26 user. Being fixed on `feat/plan-222-delete-vz`.
2. **Interactive `-it`** host-close/OP_SHUTDOWN hang — fixed on `feat/plan-222-delete-vz`.
3. A full-CLI `machine run` e2e on the in-house default (with a resident dev VM).

Merge only after 1–3 land/verify. `--hypervisor vz` is the fallback throughout.

🤖 Generated with [Claude Code](https://claude.com/claude-code)