### PR TITLE
feat(mvm-client-local): boot local runs in-process via the admission seam

### DIFF
--- a/crates/mvm-client-local/Cargo.toml
+++ b/crates/mvm-client-local/Cargo.toml
@@ -14,7 +14,13 @@ license.workspace = true
 mvm-client = { workspace = true }
 mvm-backend = { workspace = true, default-features = false }
 mvm-core = { workspace = true }
+# The in-process admitted-boot seam (`run::admit_and_boot_local`). mvm-hostd is
+# already in the mvmctl closure (the CLI links it), so this edge adds no crates
+# to the default build; it does not form a cycle because mvm-sdk — which
+# mvm-hostd pulls in — carries no dependency back on this crate.
+mvm-hostd = { workspace = true }
 async-trait = { workspace = true }
 
 [dev-dependencies]
 tokio = { workspace = true, features = ["macros", "rt"] }
+tempfile = { workspace = true }

--- a/crates/mvm-client-local/src/lib.rs
+++ b/crates/mvm-client-local/src/lib.rs
@@ -4,15 +4,21 @@
 //! dependency (see this crate's `Cargo.toml` for the cycle it avoids).
 //!
 //! `list`/`stop`/`logs` go straight to the backend dispatch (they act on VMs
-//! that already exist, so they carry no admission concern). `run` deliberately
-//! does not boot here yet: the local start path admits a signed plan (the
-//! workload-admission guarantee), and that flow is not yet exposed as a library
-//! entrypoint. Until it is, `run` fails honestly rather than booting a workload
-//! that skipped admission.
+//! that already exist, so they carry no admission concern). `run` boots through
+//! the signed-plan admission gate in-process — no subprocess, no CLI — by
+//! resolving the spec's image to a host-materialized rootfs and handing it to
+//! `mvm_hostd::run::admit_and_boot_local`. Image refs that still need a registry
+//! pull or an unpacked-dir materialize step fail honestly (that resolution is
+//! not wired into this backend yet); a workload never boots on a path that
+//! skipped admission.
+
+use std::path::Path;
 
 use async_trait::async_trait;
 use mvm_backend::AnyBackend;
 use mvm_core::protocol::vm_backend::{VmId, VmInfo, VmStatus};
+use mvm_hostd::plan_admission::{InMemoryNonceLedger, SystemClock};
+use mvm_hostd::run::{LocalRunContext, LocalRunRequest, admit_and_boot_local};
 
 use mvm_client::dto::{
     ExecResult, LogOpts, MachineFilter, MachineId, MachineSpec, MachineState, MachineStatus,
@@ -70,6 +76,55 @@ fn backend_err(e: impl std::fmt::Display) -> MvmError {
     }
 }
 
+/// Resolve `image` to a host path pointing at an already-materialized ext4
+/// rootfs. Only a direct path to a materialized image boots in-process today;
+/// an unpacked-dir materialize step and registry pulls are deferred to a later
+/// slice and fail with a clear message rather than a partial boot.
+fn resolve_local_rootfs(image: &str) -> Result<std::path::PathBuf> {
+    let path = Path::new(image);
+    if path.is_file() {
+        return Ok(path.to_path_buf());
+    }
+    if path.is_dir() {
+        return Err(backend_err(format!(
+            "'{image}' is an unpacked rootfs directory; in-process materialization \
+             is not wired into the local backend yet — pre-materialize a rootfs.ext4 \
+             or use `mvmctl machine run`"
+        )));
+    }
+    Err(backend_err(format!(
+        "in-process local run expects a path to a materialized rootfs.ext4; '{image}' \
+         is neither a file nor a directory (registry pulls are not wired into the local \
+         backend — use `mvmctl machine run`)"
+    )))
+}
+
+/// Probe the dm-verity sidecars the pure materializer writes beside the image
+/// (`rootfs.verity` + `rootfs.roothash`), reading them from the host filesystem
+/// directly. Returns `(verity_path, roothash)` when both are present and the
+/// hash is well-formed (64-hex); `(None, None)` for an unverified image.
+///
+/// Distinct from `mvm_backend::probe_verity_sidecar`, which reads the sidecars
+/// from inside a builder VM — wrong for a host-materialized rootfs.
+fn host_verity_sidecars(rootfs: &Path) -> (Option<String>, Option<String>) {
+    let Some(parent) = rootfs.parent() else {
+        return (None, None);
+    };
+    let verity = parent.join("rootfs.verity");
+    let roothash_file = parent.join("rootfs.roothash");
+    if !verity.is_file() {
+        return (None, None);
+    }
+    let Ok(raw) = std::fs::read_to_string(&roothash_file) else {
+        return (None, None);
+    };
+    let hash = raw.trim().to_string();
+    if hash.len() != 64 || !hash.chars().all(|c| c.is_ascii_hexdigit()) {
+        return (None, None);
+    }
+    (Some(verity.to_string_lossy().into_owned()), Some(hash))
+}
+
 #[async_trait]
 impl MvmClient for LocalBackend {
     async fn list_machines(&self, filter: MachineFilter) -> Result<Vec<MachineState>> {
@@ -81,12 +136,44 @@ impl MvmClient for LocalBackend {
             .collect())
     }
 
-    async fn run_machine(&self, _spec: MachineSpec) -> Result<MachineState> {
-        // Booting here would skip signed-plan admission; refuse until the
-        // admitted-boot flow is a library entrypoint.
-        Err(MvmError::Backend {
-            reason: "local run requires the admitted-boot library seam (signed-plan admission)"
-                .into(),
+    async fn run_machine(&self, spec: MachineSpec) -> Result<MachineState> {
+        let rootfs = resolve_local_rootfs(&spec.image)?;
+        let (verity_path, roothash) = host_verity_sidecars(&rootfs);
+
+        let req = LocalRunRequest {
+            name: spec.name.clone(),
+            rootfs_path: rootfs,
+            // libkrun/Vz/mock carry their own kernel; a Firecracker local run
+            // that needs an explicit kernel path is a later slice.
+            kernel_path: None,
+            verity_path: verity_path.map(std::path::PathBuf::from),
+            roothash,
+            cpus: spec.cpus,
+            mem_mib: spec.memory_mib,
+            backend_name: self.backend.name().to_string(),
+        };
+
+        // A fresh per-run ledger: local runs are one-shot from this process, so
+        // replay protection spans this admission (the CLI uses the same
+        // per-invocation shape). Keys dir `None` → the host signer at
+        // `~/.mvm/keys/`.
+        let ledger = InMemoryNonceLedger::new();
+        let clock = SystemClock;
+        let started = admit_and_boot_local(
+            &self.backend,
+            &req,
+            LocalRunContext {
+                clock: &clock,
+                ledger: &ledger,
+                host_signer_keys_dir: None,
+            },
+        )
+        .map_err(backend_err)?;
+
+        Ok(MachineState {
+            id: MachineId(started.vm_id.0),
+            name: spec.name,
+            status: MachineStatus::Running,
         })
     }
 
@@ -145,18 +232,72 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn run_refuses_until_admitted_boot_seam() {
+    async fn run_refuses_unresolvable_image_ref() {
+        // A registry ref (neither a file nor a dir on this host) fails honestly
+        // — the local backend doesn't pull, and never boots without admission.
         let be = LocalBackend::with_hypervisor("mock");
         let spec = MachineSpec {
             name: "w".into(),
-            image: "i".into(),
+            image: "registry.example.com/app:latest".into(),
             cpus: 1,
             memory_mib: 64,
             env: vec![],
         };
-        assert!(matches!(
-            be.run_machine(spec).await,
-            Err(MvmError::Backend { .. })
-        ));
+        let err = be.run_machine(spec).await.unwrap_err();
+        assert!(matches!(err, MvmError::Backend { .. }));
+    }
+
+    #[tokio::test]
+    async fn run_boots_admitted_plan_from_materialized_rootfs() {
+        // Isolate the host signer + mock VM dirs under a tempdir.
+        let data = tempfile::tempdir().unwrap();
+        // SAFETY: single-threaded test; no other thread reads these vars.
+        unsafe {
+            std::env::set_var("MVM_DATA_DIR", data.path());
+        }
+        let rootfs = data.path().join("rootfs.ext4");
+        std::fs::write(&rootfs, b"hashable-rootfs-bytes\n").unwrap();
+
+        let be = LocalBackend::with_hypervisor("mock");
+        let spec = MachineSpec {
+            name: "local-boot-from-image-path".into(),
+            image: rootfs.to_string_lossy().into_owned(),
+            cpus: 1,
+            memory_mib: 128,
+            env: vec![],
+        };
+        let state = be
+            .run_machine(spec)
+            .await
+            .expect("in-process admitted boot");
+        assert_eq!(state.name, "local-boot-from-image-path");
+        assert_eq!(state.status, MachineStatus::Running);
+        // The boot really landed a VM: it shows up in the backend listing.
+        let listed = be.list_machines(MachineFilter::all()).await.unwrap();
+        assert!(
+            listed
+                .iter()
+                .any(|m| m.name == "local-boot-from-image-path")
+        );
+    }
+
+    #[test]
+    fn host_verity_sidecars_reads_well_formed_pair() {
+        let dir = tempfile::tempdir().unwrap();
+        let rootfs = dir.path().join("rootfs.ext4");
+        std::fs::write(&rootfs, b"x").unwrap();
+        // No sidecars yet → unverified.
+        assert_eq!(host_verity_sidecars(&rootfs), (None, None));
+
+        std::fs::write(dir.path().join("rootfs.verity"), b"tree").unwrap();
+        let hex = "a".repeat(64);
+        std::fs::write(dir.path().join("rootfs.roothash"), format!("{hex}\n")).unwrap();
+        let (v, h) = host_verity_sidecars(&rootfs);
+        assert!(v.unwrap().ends_with("rootfs.verity"));
+        assert_eq!(h.unwrap(), hex);
+
+        // A malformed (non-hex / wrong-length) roothash is rejected.
+        std::fs::write(dir.path().join("rootfs.roothash"), "nothex\n").unwrap();
+        assert_eq!(host_verity_sidecars(&rootfs), (None, None));
     }
 }

--- a/crates/mvm-hostd/src/lib.rs
+++ b/crates/mvm-hostd/src/lib.rs
@@ -37,4 +37,5 @@ pub mod keyholder;
 /// spawn-side `PR_SET_PDEATHSIG` attach leaves open.
 pub mod parent_death;
 pub mod plan_admission;
+pub mod run;
 pub mod supervisor;

--- a/crates/mvm-hostd/src/run.rs
+++ b/crates/mvm-hostd/src/run.rs
@@ -1,0 +1,228 @@
+//! In-process local-run seam: boot a host-materialized rootfs through the
+//! signed-plan admission gate without shelling out to the CLI.
+//!
+//! [`admit_and_boot_local`] is the thin, safe-by-default entrypoint the
+//! `mvm-client` local backend calls. It hashes the already-materialized
+//! `rootfs.ext4`, synthesizes an `ExecutionPlan` with the conservative facade
+//! defaults (deny-all egress, standard seccomp, no secrets, no bundle, no
+//! host-fs shares), and hands the whole thing to [`admit_and_start`]. The
+//! backend never boots until the plan is signed, verified, inside its validity
+//! window, and non-replayed — the same gate `mvmctl up`/`run` go through.
+//!
+//! The richer knobs the CLI threads (secrets, bundle pins, deps volumes,
+//! per-destination redaction, custom egress policy) are deliberately absent:
+//! the facade `MachineSpec` does not carry them, so exposing them here would
+//! invent a surface no caller can fill. When a driver needs them it uses the
+//! CLI admission path directly.
+
+use std::path::{Path, PathBuf};
+
+use anyhow::{Context, Result};
+use mvm_backend::AnyBackend;
+use mvm_core::plan::{AuthPolicy, PlanSeccompTier, SecretReleasePolicy, SynthesisInput};
+use mvm_core::vm_backend::VmStartConfig;
+
+use crate::plan_admission::{
+    AdmitAndStartParams, Clock, InMemoryNonceLedger, StartedMachine, admit_and_start,
+};
+
+/// The tenant every locally-run machine is admitted under. Local runs are
+/// single-tenant by construction (one host, one operator), so the audit chain
+/// and gateway substrate key off this fixed label rather than a fleet tenant.
+const LOCAL_TENANT: &str = "local";
+
+/// A minimal, safe-by-default request to admit and boot a locally-materialized
+/// rootfs. The caller resolves the image to `rootfs_path` (and its optional
+/// dm-verity sidecars) before constructing this; everything security-relevant
+/// that the facade doesn't expose defaults to the most restrictive value.
+pub struct LocalRunRequest {
+    /// Machine name — also the synthesized plan's `image_name` and the mock
+    /// backend's per-VM directory key.
+    pub name: String,
+    /// Absolute path to the already-materialized ext4 rootfs. Hashed for the
+    /// plan's `image_sha256`, so it must exist and be readable.
+    pub rootfs_path: PathBuf,
+    /// Kernel image path. `None` for backends that carry their own kernel
+    /// (libkrun's bundled kernel, the mock backend); `Some` for Firecracker.
+    pub kernel_path: Option<PathBuf>,
+    /// dm-verity Merkle-tree sidecar, paired with `roothash`. Both `Some` for a
+    /// verified-boot rootfs; both `None` otherwise.
+    pub verity_path: Option<PathBuf>,
+    /// 64-char lowercase-hex dm-verity root hash, paired with `verity_path`.
+    pub roothash: Option<String>,
+    pub cpus: u32,
+    pub mem_mib: u32,
+    /// Backend name recorded in the signed plan (`firecracker`, `libkrun`,
+    /// `mock`, …) — must match the backend the caller starts.
+    pub backend_name: String,
+}
+
+/// Admission substrate for a local run: the clock and replay ledger that drive
+/// the validity-window + nonce checks, plus an optional host-signer keys dir
+/// override (production passes `None` → `~/.mvm/keys/`; tests inject a tempdir).
+pub struct LocalRunContext<'a> {
+    pub clock: &'a dyn Clock,
+    pub ledger: &'a InMemoryNonceLedger,
+    pub host_signer_keys_dir: Option<&'a Path>,
+}
+
+/// Admit `req` through the signed-plan gate and boot it on `backend`.
+///
+/// On success the plan was signed under the host key, verified, inside its
+/// validity window, and non-replayed before the backend saw a single byte of
+/// launch config. Any failure returns with no VM created.
+pub fn admit_and_boot_local(
+    backend: &AnyBackend,
+    req: &LocalRunRequest,
+    ctx: LocalRunContext<'_>,
+) -> Result<StartedMachine> {
+    let sha = mvm_core::crypto::image_verify::sha256_file_cached(&req.rootfs_path)
+        .with_context(|| format!("hashing rootfs at {}", req.rootfs_path.display()))?;
+
+    let synthesis = SynthesisInput {
+        vm_name: &req.name,
+        tenant: Some(LOCAL_TENANT),
+        backend_name: &req.backend_name,
+        image_name: &req.name,
+        image_sha256: &sha,
+        image_cosign_bundle: None,
+        intent: None,
+        seccomp_tier: PlanSeccompTier::Standard,
+        network_policy_ref: None,
+        fs_policy_ref: None,
+        egress_policy_ref: None,
+        tool_policy_ref: None,
+        secret_release: SecretReleasePolicy::None,
+        secrets: Vec::new(),
+        auth: AuthPolicy::none(),
+        audit_event_prefix: None,
+        cpus: req.cpus,
+        mem_mib: u64::from(req.mem_mib),
+        disk_mib: 0,
+        boot_timeout_secs: 60,
+        exec_timeout_secs: 0,
+        // A persistent local machine outlives the admitting call, so it must
+        // not be torn down when this function returns.
+        destroy_on_exit: false,
+        bundle_pin: None,
+        deps_volume: None,
+        shares: Vec::new(),
+        redaction: Default::default(),
+        audit_labels: Default::default(),
+        agent_verbs: None,
+    };
+
+    let path_string = |p: &Path| p.to_string_lossy().into_owned();
+    let config = VmStartConfig {
+        name: req.name.clone(),
+        rootfs_path: path_string(&req.rootfs_path),
+        kernel_path: req.kernel_path.as_deref().map(path_string),
+        verity_path: req.verity_path.as_deref().map(path_string),
+        roothash: req.roothash.clone(),
+        cpus: req.cpus,
+        memory_mib: req.mem_mib,
+        tenant_id: Some(LOCAL_TENANT.to_string()),
+        // network_policy defaults to deny-all via VmStartConfig's Default.
+        ..Default::default()
+    };
+
+    admit_and_start(
+        backend,
+        AdmitAndStartParams {
+            synthesis: &synthesis,
+            config,
+            clock: ctx.clock,
+            ledger: ctx.ledger,
+            host_signer_keys_dir: ctx.host_signer_keys_dir,
+            bundle_ctx: None,
+            policy_bundle: None,
+        },
+    )
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::plan_admission::SystemClock;
+
+    /// A local run over the mock backend admits a signed plan and boots — no
+    /// subprocess, no CLI. Proves the seam the local backend calls is real.
+    #[test]
+    fn admit_and_boot_local_over_mock_boots_admitted_plan() {
+        let data = tempfile::tempdir().unwrap();
+        // Isolate the mock backend's per-VM dirs + keystore under a tempdir so
+        // the test never touches the real ~/.mvm.
+        // SAFETY: single-threaded test; no other thread reads these vars.
+        unsafe {
+            std::env::set_var("MVM_DATA_DIR", data.path());
+        }
+        let keys = tempfile::tempdir().unwrap();
+
+        let rootfs = data.path().join("rootfs.ext4");
+        std::fs::write(&rootfs, b"not-a-real-ext4-but-hashable\n").unwrap();
+
+        let backend = AnyBackend::from_hypervisor("mock");
+        let ledger = InMemoryNonceLedger::new();
+        let clock = SystemClock;
+        let req = LocalRunRequest {
+            name: "local-run-seam-test".into(),
+            rootfs_path: rootfs,
+            kernel_path: None,
+            verity_path: None,
+            roothash: None,
+            cpus: 1,
+            mem_mib: 128,
+            backend_name: "mock".into(),
+        };
+
+        let started = admit_and_boot_local(
+            &backend,
+            &req,
+            LocalRunContext {
+                clock: &clock,
+                ledger: &ledger,
+                host_signer_keys_dir: Some(keys.path()),
+            },
+        )
+        .expect("admit + boot over mock");
+
+        assert_eq!(started.vm_id.0, "local-run-seam-test");
+        assert_eq!(started.admitted.plan.tenant.0, LOCAL_TENANT);
+        // The plan was actually signed under the host key (proves admission,
+        // not a stub): a signer id is present and the plan bound the exact
+        // rootfs bytes we handed it (64-hex sha256) on our backend.
+        assert!(!started.admitted.signer_id.is_empty());
+        assert_eq!(started.admitted.plan.image.sha256.len(), 64);
+        assert_eq!(started.admitted.plan.runtime_profile.0, "mock");
+    }
+
+    /// A missing rootfs fails at the hash step, before any admission or boot.
+    #[test]
+    fn admit_and_boot_local_missing_rootfs_fails_before_boot() {
+        let keys = tempfile::tempdir().unwrap();
+        let backend = AnyBackend::from_hypervisor("mock");
+        let ledger = InMemoryNonceLedger::new();
+        let clock = SystemClock;
+        let req = LocalRunRequest {
+            name: "missing-rootfs".into(),
+            rootfs_path: PathBuf::from("/nonexistent/rootfs.ext4"),
+            kernel_path: None,
+            verity_path: None,
+            roothash: None,
+            cpus: 1,
+            mem_mib: 128,
+            backend_name: "mock".into(),
+        };
+        let err = admit_and_boot_local(
+            &backend,
+            &req,
+            LocalRunContext {
+                clock: &clock,
+                ledger: &ledger,
+                host_signer_keys_dir: Some(keys.path()),
+            },
+        )
+        .unwrap_err();
+        assert!(err.to_string().contains("hashing rootfs"));
+    }
+}


### PR DESCRIPTION
Stacked on #1425 (the `admit_and_boot_local` seam). Base retargets to `main` once #1425 merges.

## What

`LocalBackend::run_machine` no longer refuses. It now:
1. Resolves `spec.image` to a host-materialized `rootfs.ext4`,
2. Probes the dm-verity sidecars the pure materializer writes beside it (`rootfs.verity` / `rootfs.roothash`), reading them from the **host** filesystem (not the VM-side `probe_verity_sidecar`),
3. Boots via `mvm_hostd::run::admit_and_boot_local` — **signed-plan admitted, in-process, no subprocess, no CLI**.

## Scope (honest boundaries)

- A **direct path to a materialized `rootfs.ext4`** boots today.
- An **unpacked-dir materialize** step and **registry pulls** fail with a clear message rather than a partial boot — that resolution is a later slice (it needs the pure materializer wired in without pulling `mvm-ext4` into the mvmctl default closure).

## Deps / cycle

Adds the `mvm-hostd` edge only. It's already in the mvmctl closure (the CLI links it), so no new crates; no cycle because `mvm-sdk` — which `mvm-hostd` pulls — carries no dependency back on `mvm-client-local`.

## Test

Over the mock backend: a real admitted boot from a materialized rootfs path (the VM then appears in the backend listing), an honest refusal on an unresolvable registry ref, and the host-side verity-sidecar probe (well-formed pair accepted; malformed roothash rejected). `cargo test -p mvm-client-local` green; clippy clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)