### PR TITLE
feat(mvm-ext4): multi-block-group images (rootfs past 128 MiB)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -336,3 +336,22 @@ jobs:
             exit 1
           fi
           echo "pure-Rust dm-verity root hash + hash tree == veritysetup"
+      - name: Write + loop-mount a MULTI-block-group image (> 128 MiB)
+        run: |
+          set -euo pipefail
+          cargo run -p mvm-ext4 --example write_multigroup -- /tmp/multigroup.ext4
+          # Sanity: bigger than one group's 128 MiB.
+          [ "$(stat -c '%s' /tmp/multigroup.ext4)" -gt 134217728 ]
+          mnt=$(mktemp -d)
+          sudo mount -o ro,loop /tmp/multigroup.ext4 "$mnt"
+          trap 'sudo umount "$mnt" || true; rmdir "$mnt" || true' EXIT
+          [ "$(cat "$mnt/etc/marker")" = "multi-group marker" ]
+          # The big file spans two block groups as two extents — size + a byte
+          # past the group boundary must read back correctly.
+          [ "$(stat -c '%s' "$mnt/big")" = "136314880" ]
+          # Byte at offset 130 MiB-ish (well past the first group) follows the
+          # i%251 pattern the example wrote.
+          off=134000000
+          got=$(dd if="$mnt/big" bs=1 skip=$off count=1 2>/dev/null | od -An -tu1 | tr -d ' ')
+          [ "$got" = "$((off % 251))" ]
+          echo "multi-group pure-Rust ext4 mounted + verified on the real Linux kernel"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2660,6 +2660,8 @@ dependencies = [
  "mvm-backend",
  "mvm-client",
  "mvm-core",
+ "mvm-hostd",
+ "tempfile",
  "tokio",
 ]
 

--- a/crates/mvm-ext4/examples/write_multigroup.rs
+++ b/crates/mvm-ext4/examples/write_multigroup.rs
@@ -1,0 +1,53 @@
+//! Write a **multi-block-group** ext4 image (> 128 MiB, so it needs a second
+//! block group) for the CI lane that loop-mounts it on the real Linux kernel —
+//! the strongest oracle for the multi-group layout the single-group sample
+//! can't reach.
+//!
+//! Usage: `cargo run -p mvm-ext4 --example write_multigroup -- <out.ext4>`
+//!
+//! The tree here MUST match what `.github/workflows/ci.yml::ext4-real-mount`
+//! asserts after mounting.
+
+use mvm_ext4::{Node, build_image};
+
+fn main() {
+    let out = std::env::args()
+        .nth(1)
+        .expect("usage: write_multigroup <out.ext4>");
+
+    // 130 MiB deterministic payload: past one group's 128 MiB, so the file
+    // spans two groups' data regions as two extents.
+    let big: Vec<u8> = (0..130 * 1024 * 1024usize)
+        .map(|i| (i % 251) as u8)
+        .collect();
+    let nodes = vec![
+        Node::Dir {
+            path: "/etc".into(),
+            mode: 0o755,
+        },
+        Node::File {
+            path: "/etc/marker".into(),
+            mode: 0o644,
+            data: b"multi-group marker\n".to_vec(),
+        },
+        Node::File {
+            path: "/big".into(),
+            mode: 0o644,
+            data: big,
+        },
+    ];
+
+    let image = build_image(&nodes).expect("build multi-group ext4 image");
+    let one_group = 32768usize * mvm_ext4::BLOCK_SIZE as usize;
+    assert!(
+        image.len() > one_group,
+        "expected a multi-group image, got {} bytes",
+        image.len()
+    );
+    std::fs::write(&out, &image).expect("write image file");
+    eprintln!(
+        "wrote {} bytes ({} groups worth) to {out}",
+        image.len(),
+        image.len().div_ceil(one_group)
+    );
+}

--- a/crates/mvm-ext4/src/lib.rs
+++ b/crates/mvm-ext4/src/lib.rs
@@ -18,12 +18,20 @@
 //! real readers (and the Linux kernel) mount; integrity comes from verity, not
 //! from in-filesystem checksums. The unused ~80% of a full ext4 (journaling,
 //! casefold, ACL, fsck) is intentionally absent — it would only be attack
-//! surface. Single block group for now (≤128 MiB at 4 KiB blocks); multi-group
-//! is a mechanical follow-up.
+//! surface.
+//!
+//! Images span **multiple block groups**, so total size is not capped at one
+//! group's 128 MiB (at 4 KiB blocks): the layout is uniform per group (a
+//! superblock + group-descriptor-table backup, then bitmaps and the inode
+//! table, then data), and file data is allocated as extents across each group's
+//! data region. A single file that would fragment into more than the four
+//! inline extents an inode holds is rejected (an extent-tree interior node is a
+//! future addition); the common rootfs — many modest files — needs one or a few
+//! extents each.
 //!
 //! Correctness is validated by reading the output back through an independent
-//! ext4 reader (`am-fs-ext4`, a dev-only test oracle) and, in CI, by mounting it
-//! on Linux.
+//! ext4 reader (`am-fs-ext4`, a dev-only test oracle) and, in CI, by mounting
+//! it on Linux (both a single-group and a multi-group image).
 
 #![forbid(unsafe_code)]
 
@@ -39,7 +47,15 @@ const FIRST_INO: u32 = 11;
 const EXTENT_MAGIC: u16 = 0xF30A;
 const EXTENTS_FL: u32 = 0x0008_0000;
 const INCOMPAT_FILETYPE_EXTENTS: u32 = 0x2 | 0x40;
-const MAX_BLOCKS_PER_GROUP: u32 = BLOCK_SIZE * 8; // 32768 at 4 KiB
+const BLOCKS_PER_GROUP: u32 = BLOCK_SIZE * 8; // 32768 at 4 KiB (block-bitmap bound)
+// Inodes are floored at 16 per group so the inode table is a whole block and
+// the reserved inodes (1..=10) + root live in group 0.
+const MIN_INODES_PER_GROUP: u32 = 16;
+// Sanity ceiling on group count: 4096 groups × 128 MiB ≈ 512 GiB, far past any
+// rootfs. Hitting it means a pathologically large input, not a real image.
+const MAX_GROUPS: u32 = 4096;
+// An inode holds four extent entries inline (no extent-tree interior node yet).
+const MAX_INLINE_EXTENTS: usize = 4;
 
 // File-type byte in a directory entry (ext4 filetype feature).
 const FT_FILE: u8 = 1;
@@ -55,8 +71,11 @@ const S_IFLNK: u16 = 0o120000;
 /// caller-influenced input).
 #[derive(Debug)]
 pub enum Ext4Error {
-    /// The tree does not fit in a single block group (≤128 MiB at 4 KiB).
+    /// The image would need more block groups than the sanity ceiling allows.
     TooLarge { blocks: u64 },
+    /// A single file fragments into more extents than fit inline in an inode
+    /// (an extent-tree interior node is not yet implemented).
+    FileTooFragmented { ino: u32, extents: usize },
     /// A node's parent directory was not present in the input.
     MissingParent(String),
     /// A path was empty or not rooted at `/`.
@@ -71,9 +90,14 @@ impl std::fmt::Display for Ext4Error {
             Ext4Error::TooLarge { blocks } => {
                 write!(
                     f,
-                    "image needs {blocks} blocks; single block group holds at most {MAX_BLOCKS_PER_GROUP}"
+                    "image needs {blocks} blocks, exceeding the {MAX_GROUPS}-group ceiling"
                 )
             }
+            Ext4Error::FileTooFragmented { ino, extents } => write!(
+                f,
+                "inode {ino} needs {extents} extents; only {MAX_INLINE_EXTENTS} fit inline \
+                 (extent-tree interior nodes are not yet supported)"
+            ),
             Ext4Error::MissingParent(p) => {
                 write!(f, "node {p} has no parent directory in the input")
             }
@@ -114,6 +138,17 @@ impl Node {
     }
 }
 
+/// One contiguous run of physical blocks backing a logical range of a file
+/// (or the single block of a directory / long symlink). `len` is in blocks and
+/// never exceeds a group's data region, so it always fits ext4's 15-bit
+/// initialized-extent length.
+#[derive(Debug, Clone, Copy)]
+struct Extent {
+    logical: u32,
+    len: u32,
+    phys: u32,
+}
+
 /// A little-endian byte writer over a fixed image buffer. Bounds-checked by
 /// `Vec`/slice indexing (a bug returns/panics, never corrupts memory).
 struct Image {
@@ -146,8 +181,9 @@ struct Planned {
     kind: Kind,
     mode: u16,
     parent: u32,
-    // Data blocks (contiguous) assigned; empty for fast symlinks.
-    first_block: u32,
+    // Physical extents backing this inode's data; empty for fast symlinks and
+    // the (never-materialized) empty root. Directories carry exactly one.
+    extents: Vec<Extent>,
     block_count: u32,
     size: u64,
     // File contents / symlink target for the emit pass.
@@ -163,6 +199,146 @@ enum Kind {
     Dir,
     File,
     Symlink,
+}
+
+/// Resolved on-disk geometry: how many block groups, where each group's
+/// metadata and data live, and how inodes map to groups. Every field is a pure
+/// function of `(inode_high, data_blocks_total)`, so the layout — and thus the
+/// image bytes — are deterministic.
+struct Layout {
+    groups: u32,
+    inodes_per_group: u32,
+    gdt_blocks: u32,
+    /// Metadata blocks at the start of every group: 1 (superblock/backup) +
+    /// gdt_blocks + 1 (block bitmap) + 1 (inode bitmap) + inode-table blocks.
+    prefix: u32,
+    total_blocks: u32,
+    inode_slots: u32,
+    /// Highest inode number in use (inodes `1..=used_inodes` are all occupied:
+    /// the reserved 1..=10, root at 2, then our nodes contiguously).
+    used_inodes: u32,
+}
+
+impl Layout {
+    fn plan(inode_high: u32, data_blocks_total: u64) -> Result<Self, Ext4Error> {
+        let used_inodes = inode_high.saturating_sub(1);
+        for groups in 1..=MAX_GROUPS {
+            let gdt_blocks = ceil_div_u32(groups.saturating_mul(32), BLOCK_SIZE);
+            let per_group_need = ceil_div_u32(inode_high, groups).max(MIN_INODES_PER_GROUP);
+            let inodes_per_group = round_up_8(per_group_need);
+            let itb_per_group = ceil_div_u32(inodes_per_group * INODE_SIZE as u32, BLOCK_SIZE);
+            let prefix = 3 + gdt_blocks + itb_per_group;
+            // A group whose metadata leaves no room for data can't help; a
+            // larger group count shrinks inodes_per_group and thus the prefix.
+            if prefix >= BLOCKS_PER_GROUP {
+                continue;
+            }
+            let data_per_group = (BLOCKS_PER_GROUP - prefix) as u64;
+            let capacity = groups as u64 * data_per_group;
+            if capacity < data_blocks_total {
+                continue;
+            }
+            // Trim the final group to exactly the data it holds so the image is
+            // no larger than the tree needs (verity hashes every byte).
+            let full_groups = (groups - 1) as u64;
+            let last_data = data_blocks_total - full_groups * data_per_group; // >= 1
+            let total = full_groups * BLOCKS_PER_GROUP as u64 + prefix as u64 + last_data;
+            if total > u32::MAX as u64 {
+                break;
+            }
+            return Ok(Self {
+                groups,
+                inodes_per_group,
+                gdt_blocks,
+                prefix,
+                total_blocks: total as u32,
+                inode_slots: inodes_per_group * groups,
+                used_inodes,
+            });
+        }
+        Err(Ext4Error::TooLarge {
+            blocks: data_blocks_total,
+        })
+    }
+
+    fn group_start(&self, g: u32) -> u32 {
+        g * BLOCKS_PER_GROUP
+    }
+    fn block_bitmap(&self, g: u32) -> u32 {
+        self.group_start(g) + 1 + self.gdt_blocks
+    }
+    fn inode_bitmap(&self, g: u32) -> u32 {
+        self.group_start(g) + 2 + self.gdt_blocks
+    }
+    fn inode_table(&self, g: u32) -> u32 {
+        self.group_start(g) + 3 + self.gdt_blocks
+    }
+    fn data_start(&self, g: u32) -> u32 {
+        self.group_start(g) + self.prefix
+    }
+    fn group_end(&self, g: u32) -> u32 {
+        ((g + 1) * BLOCKS_PER_GROUP).min(self.total_blocks)
+    }
+    /// `(group, local index)` of an inode number (1-based).
+    fn locate_inode(&self, ino: u32) -> (u32, u32) {
+        (
+            (ino - 1) / self.inodes_per_group,
+            (ino - 1) % self.inodes_per_group,
+        )
+    }
+    /// Per-group data regions, in order, that the allocator hands out.
+    fn data_regions(&self) -> Vec<(u32, u32)> {
+        (0..self.groups)
+            .filter_map(|g| {
+                let start = self.data_start(g);
+                let end = self.group_end(g);
+                (end > start).then_some((start, end - start))
+            })
+            .collect()
+    }
+}
+
+/// Hands out physical blocks from each group's data region in order, splitting
+/// a request into one [`Extent`] per region it spans (so no extent ever crosses
+/// a group's metadata prefix).
+struct RegionAllocator {
+    regions: Vec<(u32, u32)>,
+    ridx: usize,
+    roff: u32,
+}
+
+impl RegionAllocator {
+    fn new(layout: &Layout) -> Self {
+        Self {
+            regions: layout.data_regions(),
+            ridx: 0,
+            roff: 0,
+        }
+    }
+
+    fn take(&mut self, blocks: u32) -> Vec<Extent> {
+        let mut out = Vec::new();
+        let mut logical = 0u32;
+        let mut remaining = blocks;
+        while remaining > 0 {
+            let (start, len) = self.regions[self.ridx];
+            let avail = len - self.roff;
+            let n = avail.min(remaining);
+            out.push(Extent {
+                logical,
+                len: n,
+                phys: start + self.roff,
+            });
+            self.roff += n;
+            logical += n;
+            remaining -= n;
+            if self.roff == len {
+                self.ridx += 1;
+                self.roff = 0;
+            }
+        }
+        out
+    }
 }
 
 /// Build a deterministic read-only ext4 image containing `nodes` (plus the
@@ -182,7 +358,7 @@ pub fn build_image(nodes: &[Node]) -> Result<Vec<u8>, Ext4Error> {
         ino_of.insert(p, next);
         next += 1;
     }
-    let inode_count = next; // inodes 0..next-1 exist conceptually; we size for `next`.
+    let inode_high = next;
 
     // 3. Build planned inodes (root first).
     let mut planned: Vec<Planned> = Vec::new();
@@ -191,7 +367,7 @@ pub fn build_image(nodes: &[Node]) -> Result<Vec<u8>, Ext4Error> {
         kind: Kind::Dir,
         mode: S_IFDIR | 0o755,
         parent: ROOT_INO,
-        first_block: 0,
+        extents: Vec::new(),
         block_count: 0,
         size: 0,
         data: Vec::new(),
@@ -230,7 +406,7 @@ pub fn build_image(nodes: &[Node]) -> Result<Vec<u8>, Ext4Error> {
             kind,
             mode,
             parent: parent_ino,
-            first_block: 0,
+            extents: Vec::new(),
             block_count: 0,
             size,
             data,
@@ -300,64 +476,41 @@ pub fn build_image(nodes: &[Node]) -> Result<Vec<u8>, Ext4Error> {
         data_blocks_total += nblocks as u64;
     }
 
-    // 6. Fixed metadata layout (single group, 4 KiB blocks):
-    //    block 0: superblock, 1: GDT, 2: block bitmap, 3: inode bitmap,
-    //    4..4+itb: inode table, then data blocks.
-    let inode_table_blocks =
-        (inode_count as u64 * INODE_SIZE as u64).div_ceil(BLOCK_SIZE as u64) as u32;
-    let first_data_block = 4 + inode_table_blocks;
-    let total_blocks_u64 = first_data_block as u64 + data_blocks_total;
-    if total_blocks_u64 > MAX_BLOCKS_PER_GROUP as u64 {
-        return Err(Ext4Error::TooLarge {
-            blocks: total_blocks_u64,
-        });
-    }
-    let total_blocks = total_blocks_u64 as u32;
+    // 6. Resolve geometry (possibly many groups) from the inode + data counts.
+    let layout = Layout::plan(inode_high, data_blocks_total)?;
 
-    // 7. Allocate data blocks sequentially in inode order.
-    let mut cursor = first_data_block;
+    // 7. Allocate data blocks from the per-group regions, in inode order, as
+    //    extents. Reject a file that fragments past the inline-extent limit.
+    let mut alloc = RegionAllocator::new(&layout);
     for p in planned.iter_mut() {
         if p.block_count > 0 {
-            p.first_block = cursor;
-            cursor += p.block_count;
+            let extents = alloc.take(p.block_count);
+            if extents.len() > MAX_INLINE_EXTENTS {
+                return Err(Ext4Error::FileTooFragmented {
+                    ino: p.ino,
+                    extents: extents.len(),
+                });
+            }
+            p.extents = extents;
         }
     }
 
     // 8. Emit.
-    let mut img = Image::new(total_blocks);
-    let block_bitmap_block = 2u32;
-    let inode_bitmap_block = 3u32;
-    let inode_table_block = 4u32;
-
-    write_superblock(
-        &mut img,
-        total_blocks,
-        inode_count,
-        first_data_block,
-        &planned,
-    );
-    write_group_desc(
-        &mut img,
-        block_bitmap_block,
-        inode_bitmap_block,
-        inode_table_block,
-        total_blocks,
-        first_data_block,
-        inode_count,
-        &planned,
-    );
-    write_block_bitmap(&mut img, block_bitmap_block, total_blocks);
-    write_inode_bitmap(&mut img, inode_bitmap_block, inode_count);
+    let mut img = Image::new(layout.total_blocks);
+    write_superblock(&mut img, &layout);
+    write_group_descs(&mut img, &layout, &planned);
+    write_bitmaps(&mut img, &layout);
+    write_backups(&mut img, &layout);
 
     for p in &planned {
-        write_inode(&mut img, inode_table_block, p);
+        write_inode(&mut img, &layout, p);
         match p.kind {
             Kind::Dir => write_dir_block(&mut img, p),
             Kind::File => write_file_blocks(&mut img, p),
             Kind::Symlink => {
-                if p.block_count > 0 {
+                if let Some(ext) = p.extents.first() {
                     // Long symlink: target in a data block.
-                    let off = img.block_off(p.first_block);
+                    let off = img.block_off(ext.phys);
                     let t = p.symlink_target.clone().unwrap_or_default();
                     img.put_bytes(off, t.as_bytes());
                 }
@@ -366,6 +519,14 @@ pub fn build_image(nodes: &[Node]) -> Result<Vec<u8>, Ext4Error> {
     }
 
     Ok(img.bytes)
+}
+
+fn ceil_div_u32(a: u32, b: u32) -> u32 {
+    a.div_ceil(b)
+}
+
+fn round_up_8(x: u32) -> u32 {
+    (x + 7) & !7
 }
 
 fn dir_bytes(children: &[(String, u32, u8)]) -> usize {
@@ -382,88 +543,98 @@ fn dirent_len(name_len: usize) -> usize {
     (8 + name_len + 3) & !3
 }
 
-fn write_superblock(
-    img: &mut Image,
-    total_blocks: u32,
-    inode_count: u32,
-    first_data_block: u32,
-    planned: &[Planned],
-) {
+fn write_superblock(img: &mut Image, layout: &Layout) {
     let sb = 1024usize;
-    let used_blocks = first_data_block + planned.iter().map(|p| p.block_count).sum::<u32>();
-    let free_blocks = total_blocks - used_blocks;
-    let free_inodes = inode_count.saturating_sub(reserved_plus_used(planned));
+    let free_inodes = layout.inode_slots - layout.used_inodes;
 
-    img.put_u32(sb, inode_count);
-    img.put_u32(sb + 0x04, total_blocks);
-    img.put_u32(sb + 0x0C, free_blocks);
-    img.put_u32(sb + 0x10, free_inodes);
-    img.put_u32(sb + 0x14, 0); // first_data_block (0 for 4 KiB)
-    img.put_u32(sb + 0x18, 2); // log_block_size: 1024<<2 = 4096
-    img.put_u32(sb + 0x1C, 2); // log_cluster_size
-    img.put_u32(sb + 0x20, MAX_BLOCKS_PER_GROUP); // blocks_per_group
-    img.put_u32(sb + 0x24, MAX_BLOCKS_PER_GROUP); // clusters_per_group
-    img.put_u32(sb + 0x28, inode_count); // inodes_per_group (single group)
+    img.put_u32(sb, layout.inode_slots); // s_inodes_count
+    img.put_u32(sb + 0x04, layout.total_blocks); // s_blocks_count_lo
+    img.put_u32(sb + 0x0C, 0); // s_free_blocks_count_lo (RO image: none free)
+    img.put_u32(sb + 0x10, free_inodes); // s_free_inodes_count
+    img.put_u32(sb + 0x14, 0); // s_first_data_block (0 for 4 KiB)
+    img.put_u32(sb + 0x18, 2); // s_log_block_size: 1024<<2 = 4096
+    img.put_u32(sb + 0x1C, 2); // s_log_cluster_size
+    img.put_u32(sb + 0x20, BLOCKS_PER_GROUP); // s_blocks_per_group
+    img.put_u32(sb + 0x24, BLOCKS_PER_GROUP); // s_clusters_per_group
+    img.put_u32(sb + 0x28, layout.inodes_per_group); // s_inodes_per_group
     img.put_u16(sb + 0x38, EXT4_MAGIC);
-    img.put_u16(sb + 0x3A, 1); // state: cleanly unmounted
-    img.put_u16(sb + 0x3C, 1); // errors: continue
-    img.put_u16(sb + 0x36, 0xFFFF); // max_mnt_count = -1
-    img.put_u32(sb + 0x4C, 1); // rev_level: dynamic
-    img.put_u32(sb + 0x54, FIRST_INO); // first_ino
-    img.put_u16(sb + 0x58, INODE_SIZE); // inode_size
-    img.put_u16(sb + 0x5A, 0); // block_group_nr
-    img.put_u32(sb + 0x60, INCOMPAT_FILETYPE_EXTENTS); // feature_incompat
-    // UUID + volume name left zero for determinism.
+    img.put_u16(sb + 0x3A, 1); // s_state: cleanly unmounted
+    img.put_u16(sb + 0x3C, 1); // s_errors: continue
+    img.put_u16(sb + 0x36, 0xFFFF); // s_max_mnt_count = -1
+    img.put_u32(sb + 0x4C, 1); // s_rev_level: dynamic
+    img.put_u32(sb + 0x54, FIRST_INO); // s_first_ino
+    img.put_u16(sb + 0x58, INODE_SIZE); // s_inode_size
+    img.put_u16(sb + 0x5A, 0); // s_block_group_nr (primary)
+    img.put_u32(sb + 0x60, INCOMPAT_FILETYPE_EXTENTS); // s_feature_incompat
+    // s_feature_ro_compat left 0 (no sparse_super: SB+GDT backups sit at the
+    // start of every group), UUID + volume name left zero for determinism.
 }
 
-fn reserved_plus_used(planned: &[Planned]) -> u32 {
-    // Inodes 1..=10 are reserved; our nodes occupy 2 and FIRST_INO.. .
-    // Free = inode_count - (reserved_used + node_count). Root (2) is within the
-    // reserved range, so count reserved as 10 and add non-root nodes.
-    let non_root = planned.iter().filter(|p| p.ino >= FIRST_INO).count() as u32;
-    10 + non_root
-}
-
-#[allow(clippy::too_many_arguments)]
-fn write_group_desc(
-    img: &mut Image,
-    block_bitmap: u32,
-    inode_bitmap: u32,
-    inode_table: u32,
-    total_blocks: u32,
-    first_data_block: u32,
-    inode_count: u32,
-    planned: &[Planned],
-) {
-    let gd = img.block_off(1); // GDT at block 1
-    img.put_u32(gd, block_bitmap);
-    img.put_u32(gd + 0x04, inode_bitmap);
-    img.put_u32(gd + 0x08, inode_table);
-    let used_blocks = first_data_block + planned.iter().map(|p| p.block_count).sum::<u32>();
-    let free_blocks = (total_blocks - used_blocks) as u16;
-    let free_inodes = inode_count.saturating_sub(reserved_plus_used(planned)) as u16;
-    let used_dirs = planned.iter().filter(|p| p.kind == Kind::Dir).count() as u16;
-    img.put_u16(gd + 0x0C, free_blocks);
-    img.put_u16(gd + 0x0E, free_inodes);
-    img.put_u16(gd + 0x10, used_dirs);
-}
-
-fn write_block_bitmap(img: &mut Image, bitmap_block: u32, _total_blocks: u32) {
-    let base = img.block_off(bitmap_block);
-    // A sized-to-fit read-only image has no free space: every block we laid out
-    // is in use, and the bitmap bits past the image end (up to blocks_per_group)
-    // are marked used as padding. So the whole bitmap is 1s.
-    for b in 0..MAX_BLOCKS_PER_GROUP {
-        set_bit(&mut img.bytes, base, b as usize);
+fn write_group_descs(img: &mut Image, layout: &Layout, planned: &[Planned]) {
+    for g in 0..layout.groups {
+        let gd = img.block_off(1) + g as usize * 32; // 32-byte descriptors in the GDT
+        img.put_u32(gd, layout.block_bitmap(g));
+        img.put_u32(gd + 0x04, layout.inode_bitmap(g));
+        img.put_u32(gd + 0x08, layout.inode_table(g));
+        // RO image: no free blocks anywhere.
+        img.put_u16(gd + 0x0C, 0); // bg_free_blocks_count_lo
+        img.put_u16(gd + 0x0E, group_free_inodes(layout, g) as u16);
+        img.put_u16(gd + 0x10, group_used_dirs(layout, planned, g) as u16);
     }
 }
 
-fn write_inode_bitmap(img: &mut Image, bitmap_block: u32, inode_count: u32) {
-    let base = img.block_off(bitmap_block);
-    // Inodes are 1-based; bit i = inode i+1. Mark 1..=inode_count used, and pad
-    // the rest of the group's inode range used.
-    for i in 0..inode_count {
-        set_bit(&mut img.bytes, base, i as usize);
+/// Count inode slots in group `g` that are past `used_inodes` (hence free).
+fn group_free_inodes(layout: &Layout, g: u32) -> u32 {
+    let base = g * layout.inodes_per_group; // ino = base + local + 1
+    (0..layout.inodes_per_group)
+        .filter(|local| base + local + 1 > layout.used_inodes)
+        .count() as u32
+}
+
+fn group_used_dirs(layout: &Layout, planned: &[Planned], g: u32) -> u32 {
+    planned
+        .iter()
+        .filter(|p| p.kind == Kind::Dir && layout.locate_inode(p.ino).0 == g)
+        .count() as u32
+}
+
+fn write_bitmaps(img: &mut Image, layout: &Layout) {
+    for g in 0..layout.groups {
+        // Block bitmap: every block in the group is in use (metadata + data,
+        // plus padding past the image end in the final partial group).
+        let bb = img.block_off(layout.block_bitmap(g));
+        for b in 0..BLOCKS_PER_GROUP {
+            set_bit(&mut img.bytes, bb, b as usize);
+        }
+        // Inode bitmap: mark occupied inode slots used, pad the rest of the
+        // bitmap block used (bits past inodes_per_group are not real inodes).
+        let ib = img.block_off(layout.inode_bitmap(g));
+        let base = g * layout.inodes_per_group;
+        for local in 0..layout.inodes_per_group {
+            if base + local < layout.used_inodes {
+                set_bit(&mut img.bytes, ib, local as usize);
+            }
+        }
+        for pad in layout.inodes_per_group..(BLOCK_SIZE * 8) {
+            set_bit(&mut img.bytes, ib, pad as usize);
+        }
+    }
+}
+
+/// Copy the primary superblock + group-descriptor table into the backup slot at
+/// the start of every group past 0 (no sparse_super feature is set, so a reader
+/// expects a backup in each group). Kernel read-only mounts trust the primary;
+/// the backups keep the image self-consistent for offline tools.
+fn write_backups(img: &mut Image, layout: &Layout) {
+    let sb_primary = img.bytes[1024..2048].to_vec();
+    let gdt_bytes = layout.gdt_blocks as usize * BLOCK_SIZE as usize;
+    let gdt_primary = img.bytes[img.block_off(1)..img.block_off(1) + gdt_bytes].to_vec();
+    for g in 1..layout.groups {
+        let sb_off = img.block_off(layout.group_start(g));
+        img.put_bytes(sb_off, &sb_primary);
+        img.put_u16(sb_off + 0x5A, g as u16); // s_block_group_nr in the backup
+        let gdt_off = img.block_off(layout.group_start(g) + 1);
+        img.put_bytes(gdt_off, &gdt_primary);
     }
 }
 
@@ -471,8 +642,9 @@ fn set_bit(bytes: &mut [u8], base: usize, bit: usize) {
     bytes[base + bit / 8] |= 1u8 << (bit % 8);
 }
 
-fn write_inode(img: &mut Image, inode_table_block: u32, p: &Planned) {
-    let off = img.block_off(inode_table_block) + (p.ino as usize - 1) * INODE_SIZE as usize;
+fn write_inode(img: &mut Image, layout: &Layout, p: &Planned) {
+    let (g, local) = layout.locate_inode(p.ino);
+    let off = img.block_off(layout.inode_table(g)) + local as usize * INODE_SIZE as usize;
     img.put_u16(off, p.mode);
     img.put_u16(off + 0x02, 0); // uid
     img.put_u32(off + 0x04, (p.size & 0xFFFF_FFFF) as u32); // size_lo
@@ -482,35 +654,35 @@ fn write_inode(img: &mut Image, inode_table_block: u32, p: &Planned) {
     img.put_u32(off + 0x1C, sectors); // i_blocks_lo
     img.put_u16(off + 0x80, 32); // i_extra_isize
 
-    match p.kind {
-        Kind::Symlink if p.block_count == 0 => {
-            // Fast symlink: raw target in i_block, no extents flag.
-            let target = p.symlink_target.clone().unwrap_or_default();
-            img.put_bytes(off + 0x28, target.as_bytes());
-        }
-        _ => {
-            // Extents: header + one contiguous extent (dirs = 1 block; files =
-            // block_count blocks starting at first_block).
-            img.put_u32(off + 0x20, EXTENTS_FL);
-            let eh = off + 0x28;
-            img.put_u16(eh, EXTENT_MAGIC);
-            img.put_u16(eh + 0x02, if p.block_count > 0 { 1 } else { 0 }); // entries
-            img.put_u16(eh + 0x04, 4); // max inline
-            img.put_u16(eh + 0x06, 0); // depth (leaf)
-            img.put_u32(eh + 0x08, 0); // generation
-            if p.block_count > 0 {
-                let ee = eh + 12;
-                img.put_u32(ee, 0); // logical block 0
-                img.put_u16(ee + 0x04, p.block_count as u16); // len
-                img.put_u16(ee + 0x06, 0); // start_hi
-                img.put_u32(ee + 0x08, p.first_block); // start_lo
-            }
-        }
+    if p.kind == Kind::Symlink && p.extents.is_empty() {
+        // Fast symlink: raw target in i_block, no extents flag.
+        let target = p.symlink_target.clone().unwrap_or_default();
+        img.put_bytes(off + 0x28, target.as_bytes());
+        return;
+    }
+
+    // Extents: header + up to four inline entries (the planner rejects more).
+    img.put_u32(off + 0x20, EXTENTS_FL);
+    let eh = off + 0x28;
+    img.put_u16(eh, EXTENT_MAGIC);
+    img.put_u16(eh + 0x02, p.extents.len() as u16); // eh_entries
+    img.put_u16(eh + 0x04, MAX_INLINE_EXTENTS as u16); // eh_max
+    img.put_u16(eh + 0x06, 0); // eh_depth (leaf)
+    img.put_u32(eh + 0x08, 0); // eh_generation
+    for (i, ext) in p.extents.iter().enumerate() {
+        let ee = eh + 12 + i * 12;
+        img.put_u32(ee, ext.logical); // ee_block
+        img.put_u16(ee + 0x04, ext.len as u16); // ee_len
+        img.put_u16(ee + 0x06, 0); // ee_start_hi
+        img.put_u32(ee + 0x08, ext.phys); // ee_start_lo
     }
 }
 
 fn write_dir_block(img: &mut Image, p: &Planned) {
-    let base = img.block_off(p.first_block);
+    let Some(ext) = p.extents.first() else {
+        return;
+    };
+    let base = img.block_off(ext.phys);
     let mut pos = 0usize;
     // "." -> self
     pos += put_dirent(img, base + pos, p.ino, ".", FT_DIR, false);
@@ -542,11 +714,16 @@ fn put_dirent(img: &mut Image, off: usize, ino: u32, name: &str, ft: u8, last: b
 }
 
 fn write_file_blocks(img: &mut Image, p: &Planned) {
-    if p.block_count == 0 {
-        return;
+    let mut written = 0usize;
+    for ext in &p.extents {
+        if written >= p.data.len() {
+            break;
+        }
+        let span = ext.len as usize * BLOCK_SIZE as usize;
+        let end = (written + span).min(p.data.len());
+        img.put_bytes(img.block_off(ext.phys), &p.data[written..end]);
+        written += span;
     }
-    let off = img.block_off(p.first_block);
-    img.put_bytes(off, &p.data);
 }
 
 // ── path helpers ────────────────────────────────────────────────────────────

--- a/crates/mvm-ext4/tests/oracle.rs
+++ b/crates/mvm-ext4/tests/oracle.rs
@@ -142,3 +142,60 @@ fn output_is_deterministic() {
     let two = build_image(&nodes).unwrap();
     assert_eq!(one, two, "same input must produce byte-identical images");
 }
+
+/// One group holds 128 MiB of blocks at 4 KiB. A file past that forces a second
+/// block group and a file that spans two groups' data regions as two extents —
+/// the multi-group path the single-group tests never exercise. The independent
+/// reader must still mount it and read every byte back.
+#[test]
+fn multi_group_image_round_trips_through_real_reader() {
+    const ONE_GROUP_BYTES: usize = 32768 * mvm_ext4::BLOCK_SIZE as usize; // 128 MiB
+
+    // 130 MiB deterministic payload → ~33 280 blocks > one group's data region.
+    let big: Vec<u8> = (0..130 * 1024 * 1024usize)
+        .map(|i| (i % 251) as u8)
+        .collect();
+    let small = b"i live in a multi-group image\n".to_vec();
+    let nodes = vec![
+        Node::Dir {
+            path: "/etc".into(),
+            mode: 0o755,
+        },
+        Node::File {
+            path: "/etc/marker".into(),
+            mode: 0o644,
+            data: small.clone(),
+        },
+        Node::File {
+            path: "/big".into(),
+            mode: 0o644,
+            data: big.clone(),
+        },
+    ];
+
+    let image = build_image(&nodes).unwrap();
+    assert!(
+        image.len() > ONE_GROUP_BYTES,
+        "image ({} bytes) should span more than one block group",
+        image.len()
+    );
+
+    let fs = mount(image);
+    let root = list_dir(&fs, 2);
+
+    // The small file (in group 0) reads back exactly.
+    let etc = find(&root, "etc").expect("etc").0;
+    let (marker_ino, marker_ft) = find(&list_dir(&fs, etc), "marker").expect("marker");
+    assert_eq!(marker_ft, DirEntryType::RegFile);
+    assert_eq!(read_file(&fs, marker_ino), small);
+
+    // The big file (spanning groups as multiple extents) reads back byte-exact.
+    let (big_ino, big_ft) = find(&root, "big").expect("big");
+    assert_eq!(big_ft, DirEntryType::RegFile);
+    let got = read_file(&fs, big_ino);
+    assert_eq!(got.len(), big.len(), "big file length round-trips");
+    assert_eq!(
+        got, big,
+        "big file bytes round-trip across the group boundary"
+    );
+}


### PR DESCRIPTION
## What

The pure-Rust ext4 writer no longer caps at a single block group's **128 MiB**. It now:

- **Resolves geometry** (`Layout::plan`) from the inode + data-block counts: how many groups, inodes-per-group, GDT/inode-table sizing, and the final (possibly partial) group.
- Lays out a **uniform per-group metadata prefix** — superblock/GDT backup, block bitmap, inode bitmap, inode table — then data.
- **Distributes inodes** across groups (`locate_inode`) with correct per-group inode bitmaps + free counts.
- Allocates file data as **extents** from each group's data region (`RegionAllocator`), so a file crossing a group boundary becomes multiple extents.
- Writes **SB+GDT backups** into every group (no `sparse_super`) for offline-tool consistency; kernel RO mounts trust the primary.

A single file that would fragment past the **four inline extents** an inode holds is rejected with a clear `FileTooFragmented` error (extent-tree interior nodes are a future addition). The common rootfs — many modest files — needs one or a few extents each, so this unlocks arbitrarily large *total* images.

## Validation

- **Oracle test** (`multi_group_image_round_trips_through_real_reader`): a > 128 MiB image with a 130 MiB file mounts in the independent `am-fs-ext4` reader and reads back **byte-exact across the group boundary**.
- **CI** (`ext4-real-mount`): a new `write_multigroup` example + a mount step loop-mounts a multi-group image on the **real Linux kernel** and checks the big file's size + a byte well past the first group.
- Single-group images are unchanged (the layout reduces to the prior fixed one at `groups=1`); all existing oracle + determinism tests stay green. `#![forbid(unsafe_code)]` intact; clippy clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)