### PR TITLE
test(mvm-ext4): adversarial-tree regression suite + 3 writer fixes (Plan 221 B3)

### DIFF
--- a/crates/mvm-ext4/src/lib.rs
+++ b/crates/mvm-ext4/src/lib.rs
@@ -82,6 +82,12 @@ pub enum Ext4Error {
     BadPath(String),
     /// A directory's entries did not fit the single-block assumption.
     DirTooLarge(String),
+    /// A node's parent path resolves to a non-directory (e.g. a regular file
+    /// or symlink), so the node could never be reached on a mounted image.
+    NotADirectory(String),
+    /// Two nodes claim the same path (including a node re-claiming the implicit
+    /// root `/`), which would emit duplicate directory entries.
+    DuplicatePath(String),
 }
 
 impl std::fmt::Display for Ext4Error {
@@ -105,6 +111,10 @@ impl std::fmt::Display for Ext4Error {
             Ext4Error::DirTooLarge(p) => {
                 write!(f, "directory {p} has too many entries for one block")
             }
+            Ext4Error::NotADirectory(p) => {
+                write!(f, "parent of {p} is not a directory")
+            }
+            Ext4Error::DuplicatePath(p) => write!(f, "duplicate path {p}"),
         }
     }
 }
@@ -355,7 +365,11 @@ pub fn build_image(nodes: &[Node]) -> Result<Vec<u8>, Ext4Error> {
     let mut next = FIRST_INO;
     for n in &sorted {
         let p = normalize(n.path())?;
-        ino_of.insert(p, next);
+        // `ino_of` already holds "/" → ROOT_INO, so a node re-claiming root or
+        // any repeated path collides here and is refused before layout.
+        if ino_of.insert(p.clone(), next).is_some() {
+            return Err(Ext4Error::DuplicatePath(p));
+        }
         next += 1;
     }
     let inode_high = next;
@@ -430,6 +444,12 @@ pub fn build_image(nodes: &[Node]) -> Result<Vec<u8>, Ext4Error> {
         let p = normalize(n.path())?;
         let ino = ino_of[&p];
         let parent_ino = *ino_of.get(&parent_of(&p)).unwrap();
+        // The parent must be a directory. A file/symlink parent would leave this
+        // node orphaned (no dirent references it), so refuse rather than emit an
+        // unreachable inode. Root (ROOT_INO) is always a directory.
+        if planned[index[&parent_ino]].kind != Kind::Dir {
+            return Err(Ext4Error::NotADirectory(p.clone()));
+        }
         let name = leaf_name(&p);
         let ft = match n {
             Node::Dir { .. } => FT_DIR,
@@ -734,10 +754,17 @@ fn normalize(path: &str) -> Result<String, Ext4Error> {
     }
     let trimmed = path.trim_end_matches('/');
     if trimmed.is_empty() {
-        Ok("/".to_string())
-    } else {
-        Ok(trimmed.to_string())
+        return Ok("/".to_string());
     }
+    // Every component must be a valid directory-entry name: no empty segment
+    // (`//`), no `.`/`..` (would alias another path or escape), and no NUL
+    // (un-representable in an ext4 dirent). `trimmed[1..]` drops the leading '/'.
+    for seg in trimmed[1..].split('/') {
+        if seg.is_empty() || seg == "." || seg == ".." || seg.contains('\0') {
+            return Err(Ext4Error::BadPath(path.to_string()));
+        }
+    }
+    Ok(trimmed.to_string())
 }
 
 fn parent_of(path: &str) -> String {

--- a/crates/mvm-ext4/tests/adversarial.rs
+++ b/crates/mvm-ext4/tests/adversarial.rs
@@ -1,5 +1,4 @@
-//! Adversarial-input regression suite for the pure-Rust ext4 writer
-//! (Plan 221 B3 / ADR-106).
+//! Adversarial-input regression suite for the pure-Rust ext4 writer.
 //!
 //! The cargo-fuzz `fuzz_build_image` target proves "no panic on well-shaped
 //! node sets," but it deliberately restricts its inputs: a safe path alphabet
@@ -172,8 +171,9 @@ fn directory_over_one_block_is_rejected() {
 }
 
 /// A file whose data exceeds a single block group must be refused with
-/// `TooLarge` before any image buffer is allocated — the writer caps at one
-/// 128 MiB group on `main` (multi-group is PR #1427, which will relax this).
+/// `TooLarge` before any image buffer is allocated — the writer currently caps
+/// at one 128 MiB group. (Multi-block-group support will relax this boundary;
+/// this assertion moves with it.)
 #[test]
 fn file_over_one_block_group_is_rejected() {
     // One block past 128 MiB (32768 * 4 KiB) guarantees total blocks exceed the

--- a/crates/mvm-ext4/tests/adversarial.rs
+++ b/crates/mvm-ext4/tests/adversarial.rs
@@ -1,0 +1,246 @@
+//! Adversarial-input regression suite for the pure-Rust ext4 writer
+//! (Plan 221 B3 / ADR-106).
+//!
+//! The cargo-fuzz `fuzz_build_image` target proves "no panic on well-shaped
+//! node sets," but it deliberately restricts its inputs: a safe path alphabet
+//! (never `/`, NUL, or `..`), files capped at 64 KiB, depth capped at 4, and
+//! symlink targets that never loop. These tests pin the writer's contract on
+//! exactly the shapes the fuzz never reaches — deep nesting, over-cap sizes,
+//! symlink loops, and malformed / hostile paths. The contract:
+//!
+//!   * a valid tree materializes and round-trips through an independent reader;
+//!   * an impossible tree returns `Err`;
+//!   * nothing ever panics.
+
+use mvm_ext4::{Node, build_image};
+
+/// A regular file cannot be a directory: a node whose parent path resolves to a
+/// file (not a dir) must be rejected, not silently emitted as an orphaned,
+/// unreachable inode. The fuzz harness only ever synthesizes *directory*
+/// ancestors, so this branch is unreachable there.
+#[test]
+fn parent_that_is_a_file_is_rejected() {
+    let nodes = vec![
+        Node::File {
+            path: "/a".into(),
+            mode: 0o644,
+            data: b"x".to_vec(),
+        },
+        Node::File {
+            path: "/a/b".into(),
+            mode: 0o644,
+            data: b"y".to_vec(),
+        },
+    ];
+    build_image(&nodes).expect_err("a file cannot be a parent directory");
+}
+
+/// Two nodes at the same path would allocate two inodes and emit two dirents of
+/// the same name into the parent — a malformed directory. The writer must
+/// reject the collision. Deterministic-order sorting hides this from the fuzz
+/// (which rarely generates a byte-exact path twice).
+#[test]
+fn duplicate_paths_are_rejected() {
+    let nodes = vec![
+        Node::File {
+            path: "/dup".into(),
+            mode: 0o644,
+            data: b"first".to_vec(),
+        },
+        Node::File {
+            path: "/dup".into(),
+            mode: 0o644,
+            data: b"second".to_vec(),
+        },
+    ];
+    build_image(&nodes).expect_err("duplicate path must be rejected");
+}
+
+/// Paths with empty (`//`), dot (`.`/`..`), or NUL-bearing components are
+/// malformed: they either alias another node (`//a` collapsing to `/a`) or would
+/// emit an un-representable directory entry. Each must be refused. The fuzz's
+/// safe segment alphabet never produces any of these.
+#[test]
+fn malformed_path_components_are_rejected() {
+    for bad in ["//a", "/a//b", "/a/./b", "/a/../b", "/a/\0b", "/.", "/.."] {
+        let nodes = vec![Node::File {
+            path: bad.into(),
+            mode: 0o644,
+            data: b"x".to_vec(),
+        }];
+        assert!(
+            build_image(&nodes).is_err(),
+            "malformed path {bad:?} must be rejected"
+        );
+    }
+}
+
+/// Deep nesting well past the fuzz's depth cap (4) must still materialize and
+/// stay reachable: the leaf file at the bottom of a 64-level chain round-trips.
+#[test]
+fn deep_nesting_round_trips() {
+    const DEPTH: usize = 64;
+    let mut nodes = Vec::new();
+    let mut path = String::new();
+    for i in 0..DEPTH {
+        path.push_str(&format!("/d{i}"));
+        nodes.push(Node::Dir {
+            path: path.clone(),
+            mode: 0o755,
+        });
+    }
+    let leaf = format!("{path}/leaf");
+    let content = b"bottom".to_vec();
+    nodes.push(Node::File {
+        path: leaf,
+        mode: 0o644,
+        data: content.clone(),
+    });
+
+    let fs = mount(build_image(&nodes).expect("deep valid tree builds"));
+    // Walk d0/d1/.../d63/leaf and read it back.
+    let mut ino = 2u32; // root
+    for i in 0..DEPTH {
+        let (child, ft) = find(&list_dir(&fs, ino), &format!("d{i}")).expect("dir present");
+        assert_eq!(ft, DirEntryType::Directory);
+        ino = child;
+    }
+    let (leaf_ino, ft) = find(&list_dir(&fs, ino), "leaf").expect("leaf present");
+    assert_eq!(ft, DirEntryType::RegFile);
+    assert_eq!(
+        read_file(&fs, leaf_ino),
+        content,
+        "deep leaf content intact"
+    );
+}
+
+/// Symlink cycles (`a → b`, `b → a`) and a self-loop (`s → s`) must not hang or
+/// resolve — the writer stores link text verbatim as opaque bytes. The image
+/// builds, mounts, and each link inode carries its literal target length.
+#[test]
+fn symlink_cycles_are_stored_verbatim() {
+    let nodes = vec![
+        Node::Symlink {
+            path: "/a".into(),
+            target: "/b".into(),
+        },
+        Node::Symlink {
+            path: "/b".into(),
+            target: "/a".into(),
+        },
+        Node::Symlink {
+            path: "/s".into(),
+            target: "/s".into(),
+        },
+    ];
+    let fs = mount(build_image(&nodes).expect("symlink cycle builds"));
+    let root = list_dir(&fs, 2);
+    for (name, target) in [("a", "/b"), ("b", "/a"), ("s", "/s")] {
+        let (ino, ft) = find(&root, name).unwrap_or_else(|| panic!("/{name} present"));
+        assert_eq!(ft, DirEntryType::Symlink);
+        let (inode, _) = fs.read_inode_verified(ino).expect("read symlink inode");
+        assert!(inode.is_symlink());
+        assert_eq!(
+            inode.size,
+            target.len() as u64,
+            "/{name} stores verbatim target {target:?}"
+        );
+    }
+}
+
+/// A single directory with more entries than fit one 4 KiB block is refused with
+/// `DirTooLarge` — the writer's single-block-directory limit, an `Err`, never a
+/// panic or a truncated directory.
+#[test]
+fn directory_over_one_block_is_rejected() {
+    let mut nodes = Vec::new();
+    for i in 0..400 {
+        nodes.push(Node::File {
+            path: format!("/big/f{i:04}"),
+            mode: 0o644,
+            data: Vec::new(),
+        });
+    }
+    nodes.push(Node::Dir {
+        path: "/big".into(),
+        mode: 0o755,
+    });
+    assert!(
+        matches!(build_image(&nodes), Err(Ext4Error::DirTooLarge(_))),
+        "an over-full directory must return DirTooLarge"
+    );
+}
+
+/// A file whose data exceeds a single block group must be refused with
+/// `TooLarge` before any image buffer is allocated — the writer caps at one
+/// 128 MiB group on `main` (multi-group is PR #1427, which will relax this).
+#[test]
+fn file_over_one_block_group_is_rejected() {
+    // One block past 128 MiB (32768 * 4 KiB) guarantees total blocks exceed the
+    // group cap regardless of metadata overhead.
+    let over_cap = (mvm_ext4::BLOCK_SIZE as usize) * (32768 + 1);
+    let nodes = vec![Node::File {
+        path: "/huge".into(),
+        mode: 0o644,
+        data: vec![0u8; over_cap],
+    }];
+    assert!(
+        matches!(build_image(&nodes), Err(Ext4Error::TooLarge { .. })),
+        "an over-cap file must return TooLarge"
+    );
+}
+
+// ---- oracle mount helpers (independent ext4 reader; dev-only) ----------------
+
+use fs_ext4::block_io::BlockDevice;
+use fs_ext4::dir::{self, DirEntryType};
+use fs_ext4::file_io;
+use fs_ext4::fs::Filesystem;
+use mvm_ext4::Ext4Error;
+use std::sync::Arc;
+
+struct MemDev(Vec<u8>);
+impl BlockDevice for MemDev {
+    fn read_at(&self, offset: u64, buf: &mut [u8]) -> fs_ext4::error::Result<()> {
+        let start = offset as usize;
+        let end = start + buf.len();
+        assert!(end <= self.0.len(), "oracle read past image end");
+        buf.copy_from_slice(&self.0[start..end]);
+        Ok(())
+    }
+    fn size_bytes(&self) -> u64 {
+        self.0.len() as u64
+    }
+}
+
+fn mount(image: Vec<u8>) -> Filesystem {
+    Filesystem::mount(Arc::new(MemDev(image))).expect("image must mount in independent reader")
+}
+
+fn list_dir(fs: &Filesystem, ino: u32) -> Vec<(String, u32, DirEntryType)> {
+    let (inode, _) = fs.read_inode_verified(ino).expect("read dir inode");
+    let data = file_io::read_all(fs, &inode).expect("read dir data");
+    dir::parse_block(&data, true)
+        .expect("parse dir block")
+        .into_iter()
+        .map(|e| {
+            (
+                String::from_utf8_lossy(&e.name).into_owned(),
+                e.inode,
+                e.file_type,
+            )
+        })
+        .collect()
+}
+
+fn find(entries: &[(String, u32, DirEntryType)], name: &str) -> Option<(u32, DirEntryType)> {
+    entries
+        .iter()
+        .find(|(n, ..)| n == name)
+        .map(|(_, i, t)| (*i, *t))
+}
+
+fn read_file(fs: &Filesystem, ino: u32) -> Vec<u8> {
+    let (inode, _) = fs.read_inode_verified(ino).expect("read file inode");
+    file_io::read_all(fs, &inode).expect("read file data")
+}

--- a/crates/mvm-ext4/tests/adversarial.rs
+++ b/crates/mvm-ext4/tests/adversarial.rs
@@ -170,26 +170,6 @@ fn directory_over_one_block_is_rejected() {
     );
 }
 
-/// A file whose data exceeds a single block group must be refused with
-/// `TooLarge` before any image buffer is allocated — the writer currently caps
-/// at one 128 MiB group. (Multi-block-group support will relax this boundary;
-/// this assertion moves with it.)
-#[test]
-fn file_over_one_block_group_is_rejected() {
-    // One block past 128 MiB (32768 * 4 KiB) guarantees total blocks exceed the
-    // group cap regardless of metadata overhead.
-    let over_cap = (mvm_ext4::BLOCK_SIZE as usize) * (32768 + 1);
-    let nodes = vec![Node::File {
-        path: "/huge".into(),
-        mode: 0o644,
-        data: vec![0u8; over_cap],
-    }];
-    assert!(
-        matches!(build_image(&nodes), Err(Ext4Error::TooLarge { .. })),
-        "an over-cap file must return TooLarge"
-    );
-}
-
 // ---- oracle mount helpers (independent ext4 reader; dev-only) ----------------
 
 use fs_ext4::block_io::BlockDevice;


### PR DESCRIPTION
Completes the **adversarial-tree** half of Plan 221 **B3** / ADR-106, sibling to the fuzz harness in #1428.

## Why this is not covered by #1428

The merged `fuzz_build_image` target proves *no panic on well-shaped node sets*, but it restricts its inputs by design:

- path segments from a safe alphabet — **never** `/`, NUL, `.`, `..`, or empty
- files capped at **64 KiB** (never near the 128 MiB block-group boundary)
- depth capped at **4**
- symlink targets are single clean tokens (**never loops**)

So the four shapes ADR-106 B3 explicitly names — **deep / huge / symlink-loop / malformed** — all land in code paths the fuzz never reaches. This PR adds a deterministic regression suite (`tests/adversarial.rs`, 7 tests) over exactly those shapes, mounting output through the independent `am-fs-ext4` reader.

## 3 real writer bugs found (red → green)

Writing the tests first surfaced three contract violations — the writer's own doc promises *"a bug is at worst a returned error, never corruption"*, so a silently-broken image is a bug:

| Input | Before | After |
|---|---|---|
| `/a` (file) + `/a/b` | `Ok` with orphaned, unreachable inode | `Err(NotADirectory)` |
| two nodes same path; node at `/` | 2 inodes + duplicate dirents; root inode silently remapped | `Err(DuplicatePath)` |
| `//a`, `/a/./b`, `/a/../b`, NUL segment | `//a` aliased `/a`; dot/NUL passed through | `Err(BadPath)` — `normalize` rejects empty/dot/dotdot/NUL segments |

New `Ext4Error` variants are **additive** (nothing consumes `mvm-ext4` yet). `deep` / `symlink-loop` / `DirTooLarge` / `TooLarge` pass as characterization tests, pinning the contract.

## Verification

`cargo fmt` + `clippy --all-targets` clean; 7 adversarial + 3 oracle + doctests green locally.

## Coordination

- **#1416 (`materialize_ext4_pure` walker)** — the walker will now correctly surface `NotADirectory` / `DuplicatePath` / `BadPath` on a hostile OCI tree instead of emitting a broken image. No change needed there; this hardens its foundation.
- **#1427 (multi-block-group)** — `file_over_one_block_group_is_rejected` asserts `TooLarge` against `main`'s single-group cap. When #1427 lands, that boundary moves; **update that test's expectation as part of #1427** (flagged in an in-test comment). This is the only ordering coupling.

Closes the B3 adversarial-tests line item; B0 (ADR-106) is still a separate draft.