### PR TITLE
feat(run): materialize the run-path rootfs in-process by default

### DIFF
--- a/crates/mvm-build/src/rootfs.rs
+++ b/crates/mvm-build/src/rootfs.rs
@@ -28,6 +28,13 @@ pub struct MaterializeExt4Input {
     pub output: PathBuf,
     /// Sum of OCI layer uncompressed sizes for this image.
     pub uncompressed_size_bytes: u64,
+    /// When true, the pure path also computes dm-verity and writes the
+    /// `rootfs.verity` + `rootfs.roothash` sidecars beside the image. Off by
+    /// default so materializing a rootfs is a pure mechanism swap: the run path
+    /// today boots these images without rootfs verity (the boot config sets
+    /// `verity_path`/`roothash` to `None`), and emitting sidecars a probe would
+    /// pick up would silently change that. The builder-VM path ignores this.
+    pub emit_verity: bool,
 }
 
 impl MaterializeExt4Input {
@@ -36,7 +43,14 @@ impl MaterializeExt4Input {
             unpacked_root,
             output,
             uncompressed_size_bytes,
+            emit_verity: false,
         }
+    }
+
+    /// Opt into dm-verity sidecar emission on the pure path.
+    pub fn with_verity(mut self) -> Self {
+        self.emit_verity = true;
+        self
     }
 }
 
@@ -351,6 +365,14 @@ pub fn materialize_ext4_pure(
         source,
     })?;
 
+    if !input.emit_verity {
+        return Ok(MaterializedExt4 {
+            path: input.output.clone(),
+            size_bytes,
+            verity_root_hash: None,
+        });
+    }
+
     // dm-verity, computed in-process (no `veritysetup`). v1, sha256, 4 KiB
     // data+hash blocks, zero salt — the params the boot path expects. Write the
     // hash tree + 64-hex root hash beside the image under the fixed names
@@ -509,8 +531,27 @@ mod tests {
         materialize_ext4_pure(&input2).unwrap();
         assert_eq!(std::fs::read(&out2).unwrap(), img);
 
-        // Verity: the returned root hash is 64-hex and the two sidecars land
-        // beside the image under the fixed names the boot path probes for.
+        // Default (no `with_verity`): no root hash, no sidecars — the run path
+        // boots these images without rootfs verity, so a probe must find nothing.
+        assert!(mat.verity_root_hash.is_none());
+        assert!(!out.path().join("rootfs.verity").exists());
+        assert!(!out.path().join("rootfs.roothash").exists());
+    }
+
+    #[cfg(feature = "pure-mkfs")]
+    #[test]
+    fn pure_materialize_with_verity_writes_sidecars() {
+        let src = tempfile::tempdir().unwrap();
+        std::fs::write(src.path().join("hello"), b"hi\n").unwrap();
+        let out = tempfile::tempdir().unwrap();
+        let out_path = out.path().join("rootfs.ext4");
+        let input =
+            MaterializeExt4Input::new(src.path().to_path_buf(), out_path.clone(), 0).with_verity();
+
+        let mat = materialize_ext4_pure(&input).expect("pure materialize with verity");
+
+        // The returned root hash is 64-hex and both sidecars land beside the
+        // image under the fixed names the boot path probes for.
         let root_hex = mat.verity_root_hash.expect("verity root hash");
         assert_eq!(root_hex.len(), 64);
         assert!(root_hex.chars().all(|c| c.is_ascii_hexdigit()));

--- a/crates/mvm-cli/Cargo.toml
+++ b/crates/mvm-cli/Cargo.toml
@@ -78,13 +78,19 @@ libc.workspace = true
 # builder VM with a persistent /nix store. Runtime gating via
 # `libkrun_sys::is_available()` still falls back cleanly when libkrun
 # isn't installed on the host.
-default = ["builder-vm"]
+default = ["builder-vm", "pure-mkfs"]
 contributor-bootstrap = [
     "mvm/contributor-bootstrap",
     "mvm-build/contributor-bootstrap",
     "mvm-backend/contributor-bootstrap",
 ]
 builder-vm = ["mvm-build/builder-vm"]
+# In-process, pure-Rust rootfs materialization (no builder VM / mkfs) for the
+# `run --image` path. Default: the run path builds the ext4 image with the
+# memory-safe `mvm-ext4` writer instead of shelling out to a builder VM. The
+# `builder-vm` feature stays default for `dev up`, and `MVM_MATERIALIZE_BUILDER_VM`
+# routes the run path back through the builder VM when set.
+pure-mkfs = ["mvm-build/pure-mkfs"]
 # Extract libkrunfw's bundled
 # TSI-patched kernel at runtime so Stage 0 boots a kernel where
 # libkrun's AF_INET-over-vsock (TSI) path actually works. The feature

--- a/crates/mvm-cli/src/commands/image/mod.rs
+++ b/crates/mvm-cli/src/commands/image/mod.rs
@@ -8,7 +8,9 @@ use std::path::{Component, Path, PathBuf};
 use anyhow::{Context, Result, bail};
 use clap::{Args as ClapArgs, Subcommand};
 use flate2::read::GzDecoder;
-use mvm_build::rootfs::{MaterializeExt4Input, MaterializeExt4Options, materialize_ext4};
+use mvm_build::rootfs::MaterializeExt4Input;
+#[cfg(feature = "builder-vm")]
+use mvm_build::rootfs::{MaterializeExt4Options, materialize_ext4};
 use mvm_oci::{
     ImageReference, LayerDescriptor, LayerFetchOptions, LinuxPlatform, OciLayerFetcher,
     OciManifestFetcher, RegistryAuthConfig, UnpackOptions, read_oci_archive, unpack_layer,
@@ -526,6 +528,38 @@ pub(in crate::commands) fn resolve_or_pull_run_image(
 /// injected `/init` + baked agent + `/mvm/runtime` mount point make the
 /// rootfs genuinely overlay-aware, so the `for_oci_run` sidecar admits
 /// honestly through `admit_overlay_aware` without weakening the gate.
+/// Materialize the run-path rootfs image from an unpacked tree.
+///
+/// Default: the pure in-process `mvm-ext4` writer — no builder VM, no `mkfs`,
+/// no subprocess. `MVM_MATERIALIZE_BUILDER_VM` (any value) routes back through
+/// the builder-VM `mkfs` path for parity / debugging. Verity is deliberately
+/// left off (no `rootfs.verity` / `rootfs.roothash` sidecars), so the run
+/// path's `verity_path`/`roothash = None` boot config is unchanged — this flips
+/// the materialization *mechanism*, not the boot semantics.
+fn materialize_run_rootfs(input: &MaterializeExt4Input) -> Result<()> {
+    #[cfg(feature = "pure-mkfs")]
+    if std::env::var_os("MVM_MATERIALIZE_BUILDER_VM").is_none() {
+        return mvm_build::rootfs::materialize_ext4_pure(input)
+            .map(|_| ())
+            .with_context(|| format!("materialize {} in-process", input.output.display()));
+    }
+    materialize_run_rootfs_builder_vm(input)
+}
+
+#[cfg(feature = "builder-vm")]
+fn materialize_run_rootfs_builder_vm(input: &MaterializeExt4Input) -> Result<()> {
+    materialize_ext4(input, &MaterializeExt4Options::default())
+        .map(|_| ())
+        .with_context(|| format!("materialize {} via builder VM", input.output.display()))
+}
+
+#[cfg(not(feature = "builder-vm"))]
+fn materialize_run_rootfs_builder_vm(_input: &MaterializeExt4Input) -> Result<()> {
+    anyhow::bail!(
+        "no rootfs materializer compiled in: enable the `pure-mkfs` or `builder-vm` feature"
+    )
+}
+
 fn inject_runtime_and_materialize(
     cache_root: &Path,
     unpacked_root: &Path,
@@ -551,14 +585,11 @@ fn inject_runtime_and_materialize(
     // agent/netinit (~1.6 MiB).
     let tree_size = unpacked_tree_size(unpacked_root)
         .with_context(|| format!("measure unpacked root {}", unpacked_root.display()))?;
-    materialize_ext4(
-        &MaterializeExt4Input::new(
-            unpacked_root.to_path_buf(),
-            rootfs_abs.to_path_buf(),
-            tree_size,
-        ),
-        &MaterializeExt4Options::default(),
-    )
+    materialize_run_rootfs(&MaterializeExt4Input::new(
+        unpacked_root.to_path_buf(),
+        rootfs_abs.to_path_buf(),
+        tree_size,
+    ))
     .context("materialize OCI rootfs.ext4")?;
 
     // The sidecar lives next to rootfs.ext4 so the backend's
@@ -731,10 +762,11 @@ fn ingest_rootfs_dir(
         .with_context(|| format!("measure rootfs dir {}", rootfs_dir.display()))?;
     let rootfs_rel = format!("rootfs/{key}/rootfs.ext4");
     let rootfs_abs = cache_root.join(&rootfs_rel);
-    materialize_ext4(
-        &MaterializeExt4Input::new(rootfs_dir.to_path_buf(), rootfs_abs.clone(), tree_size),
-        &MaterializeExt4Options::default(),
-    )
+    materialize_run_rootfs(&MaterializeExt4Input::new(
+        rootfs_dir.to_path_buf(),
+        rootfs_abs.clone(),
+        tree_size,
+    ))
     .context("materialize rootfs.ext4 from directory")?;
 
     let provenance = OciProvenance {
@@ -1586,6 +1618,40 @@ mod tests {
     use sha2::{Digest, Sha256};
     use std::cell::RefCell;
     use tar::{Builder, EntryType, Header};
+
+    // The default run-path materialize is the pure in-process writer, and it
+    // must NOT emit dm-verity sidecars — the run path boots these images with
+    // `verity_path`/`roothash = None`, so emitting `rootfs.verity` /
+    // `rootfs.roothash` (which the transient path's probe would pick up) would
+    // silently switch OCI runs to verified boot. This guards the mechanism swap.
+    #[cfg(feature = "pure-mkfs")]
+    #[test]
+    fn materialize_run_rootfs_default_is_pure_and_verity_free() {
+        // The builder-VM escape hatch must be unset for the default (pure) path.
+        assert!(
+            std::env::var_os("MVM_MATERIALIZE_BUILDER_VM").is_none(),
+            "test env must not force the builder-VM materializer"
+        );
+        let src = tempfile::tempdir().unwrap();
+        std::fs::create_dir(src.path().join("etc")).unwrap();
+        std::fs::write(src.path().join("etc/hostname"), b"box\n").unwrap();
+        let out = tempfile::tempdir().unwrap();
+        let rootfs = out.path().join("rootfs.ext4");
+
+        materialize_run_rootfs(&MaterializeExt4Input::new(
+            src.path().to_path_buf(),
+            rootfs.clone(),
+            0,
+        ))
+        .expect("pure materialize");
+
+        // A real ext4 image was written in-process (superblock magic present)…
+        let img = std::fs::read(&rootfs).unwrap();
+        assert_eq!(&img[1024 + 0x38..1024 + 0x3A], &[0x53, 0xEF]);
+        // …and NO verity sidecars sit beside it (boot semantics unchanged).
+        assert!(!out.path().join("rootfs.verity").exists());
+        assert!(!out.path().join("rootfs.roothash").exists());
+    }
 
     struct MockCosignVerifier {
         results: RefCell<Vec<Result<(), CosignVerifyError>>>,


### PR DESCRIPTION
The capstone of Plan 221 Option B: `mvmctl run --image` no longer boots a builder VM to `mkfs.ext4 + cp` a rootfs — it builds the ext4 image in-process with the pure-Rust `mvm-ext4` writer. **The run path no longer subprocesses to materialize a rootfs.**

## Change

- **mvm-cli** enables `pure-mkfs` by default. `builder-vm` stays default (for `dev up`), and **`MVM_MATERIALIZE_BUILDER_VM`** routes the run path back through the builder-VM `mkfs` for parity / debugging.
- A `materialize_run_rootfs` dispatcher fronts both call sites (OCI-pull + bare-rootfs-dir); it compiles cleanly for pure-only, builder-vm-only, and both-on feature combos.
- `MaterializeExt4Input` gains `emit_verity` (default **off**) + a `with_verity()` builder; the pure materializer only writes `rootfs.verity` / `rootfs.roothash` + returns a root hash when opted in.

## Why verity is off here (semantics preserved)

The run path today boots these images with `verity_path`/`roothash = None`, and the **transient** path calls `probe_verity_sidecar`. If the pure path emitted verity sidecars, the transient run would silently flip to verified boot (and could break on a guest that isn't verity-ready). So this PR keeps verity **off** — it's a materialization *mechanism* swap, not a boot-semantics change. Enabling verity-for-OCI is a separate, deliberate follow-up.

## Gates

- Closure budget holds at **336** (mvm-ext4 fit without a bump).
- clippy clean (default + pure-only combos), fmt clean, no new duplicate-majors.
- Tests: pure path emits no sidecars by default / does with `with_verity()`; the CLI dispatcher's default route writes a valid ext4 (superblock magic) with **no** verity sidecars.

## Not exercised here

A live OCI boot of a pure-materialized rootfs (needs a real VMM host — Mac/KVM). The writer's output is already kernel-mount-validated in CI (single- **and** multi-group images) and the boot semantics are unchanged by construction. Recommend a smoke `mvmctl run --image` on a VMM host before relying on it in anger; `MVM_MATERIALIZE_BUILDER_VM=1` is the instant rollback.

🤖 Generated with [Claude Code](https://claude.com/claude-code)