### PR TITLE
fix(run): actually enable the pure in-process rootfs materialize in mvmctl

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -472,7 +472,7 @@ which.workspace = true
 # libkrun isn't installed on the host, so a default-features binary works
 # everywhere. Library consumers (mvmd) that want a lean closure build with
 # `default-features = false`.
-default = ["builder-vm"]
+default = ["builder-vm", "pure-mkfs"]
 contributor-bootstrap = [
     "mvm/contributor-bootstrap",
     "mvm-backend/contributor-bootstrap",
@@ -486,6 +486,12 @@ builder-vm = [
     "mvm-build/builder-vm",
     "mvm-cli/builder-vm",
 ]
+# In-process, pure-Rust rootfs materialization for `run --image` (no builder
+# VM / mkfs). Must be forwarded here: the root `mvmctl` binary builds mvm-cli
+# with `default-features = false`, so mvm-cli's own `pure-mkfs` default never
+# reaches the shipped binary without this. Default-on so the run path
+# materializes in-process; `MVM_MATERIALIZE_BUILDER_VM` is the runtime opt-out.
+pure-mkfs = ["mvm-cli/pure-mkfs"]
 custom-dns = ["mvm-cli/custom-dns"]
 dev-watch = ["mvm-cli/dev-watch"]
 libkrun-live = ["mvm-cli/libkrun-live"]

--- a/crates/mvm-build/src/rootfs.rs
+++ b/crates/mvm-build/src/rootfs.rs
@@ -590,7 +590,11 @@ mod tests {
         let src = tempfile::tempdir().unwrap();
         std::fs::write(src.path().join("f"), b"x").unwrap();
         let out = tempfile::tempdir().unwrap();
-        let nested = out.path().join("rootfs").join("deadbeef").join("rootfs.ext4");
+        let nested = out
+            .path()
+            .join("rootfs")
+            .join("deadbeef")
+            .join("rootfs.ext4");
         assert!(!nested.parent().unwrap().exists());
 
         let input = MaterializeExt4Input::new(src.path().to_path_buf(), nested.clone(), 0);

--- a/crates/mvm-build/src/rootfs.rs
+++ b/crates/mvm-build/src/rootfs.rs
@@ -360,6 +360,15 @@ pub fn materialize_ext4_pure(
     let nodes = collect_nodes(&input.unpacked_root)?;
     let image = mvm_ext4::build_image(&nodes).map_err(|e| RootfsError::PureBuild(e.to_string()))?;
     let size_bytes = image.len() as u64;
+    // The run path's cache dir (`.../rootfs/<key>/`) may not exist yet — the
+    // builder-VM path created it via `allocate_sparse_image`, so the pure path
+    // must create it too before writing the image + its sidecars.
+    if let Some(parent) = input.output.parent() {
+        std::fs::create_dir_all(parent).map_err(|source| RootfsError::WriteOutput {
+            path: parent.to_path_buf(),
+            source,
+        })?;
+    }
     std::fs::write(&input.output, &image).map_err(|source| RootfsError::WriteOutput {
         path: input.output.clone(),
         source,
@@ -571,6 +580,22 @@ mod tests {
             materialize_ext4_pure(&input),
             Err(RootfsError::UnpackedRootNotDirectory(_))
         ));
+    }
+
+    #[cfg(feature = "pure-mkfs")]
+    #[test]
+    fn pure_materialize_creates_missing_output_parent() {
+        // The run path's cache dir may not exist yet; the pure writer must
+        // create it rather than fail with ENOENT.
+        let src = tempfile::tempdir().unwrap();
+        std::fs::write(src.path().join("f"), b"x").unwrap();
+        let out = tempfile::tempdir().unwrap();
+        let nested = out.path().join("rootfs").join("deadbeef").join("rootfs.ext4");
+        assert!(!nested.parent().unwrap().exists());
+
+        let input = MaterializeExt4Input::new(src.path().to_path_buf(), nested.clone(), 0);
+        materialize_ext4_pure(&input).expect("pure materialize into a missing parent dir");
+        assert!(nested.is_file());
     }
 
     #[test]

--- a/xtask/src/check_closure_budget.rs
+++ b/xtask/src/check_closure_budget.rs
@@ -25,7 +25,12 @@ const BUDGET_TARGET: &str = "x86_64-unknown-linux-gnu";
 /// closure. The Linux KVM backend adds one audited ioctl-wrapper crate to the
 /// default Linux release path. Lower it freely as deps drop; raising it must be
 /// justified in the change that does.
-const CLOSURE_BUDGET: usize = 336;
+///
+/// 337 (was 336): the default `run --image` path now materializes the rootfs
+/// in-process via `mvm-ext4` (`pure-mkfs`), one small `forbid(unsafe)` crate,
+/// instead of booting a builder VM to shell `mkfs.ext4` — a net removal of a
+/// whole VM launch from the run path for one audited crate.
+const CLOSURE_BUDGET: usize = 337;
 
 pub fn run(workspace: &Path) -> Result<()> {
     let count = default_closure_crate_count(workspace)?;


### PR DESCRIPTION
The flip (#1431) was **inert in the shipped binary** — live-boot validation caught it. Two bugs:

## 1. `pure-mkfs` never reached the `mvmctl` binary

The root `mvmctl` package builds `mvm-cli` with `default-features = false` (and a macOS target override that pins an explicit feature list), so mvm-cli's *new* `pure-mkfs` default never propagated. Every `run --image` still went **"via builder VM"**. Fix: forward `pure-mkfs` through the root package and add it to the root `default`, exactly as `builder-vm` is forwarded.

## 2. Pure path didn't create the output parent dir

`materialize_ext4_pure` wrote the image straight to `.../rootfs/<key>/rootfs.ext4`, but that cache dir doesn't exist yet on the run path — the builder-VM path created it via `allocate_sparse_image`. The pure write failed with `ENOENT`. Fix: `create_dir_all(parent)` first (+ a regression test).

## Live validation (real Vz microVM, macOS 26)

`mvmctl run --image docker.io/library/alpine:3.18 -- /bin/echo <marker>`:
- **materializes in-process** — fresh rootfs is **10 MiB sized-to-fit**, not the builder-VM's 64 MiB sparse image (the two older cached images are exactly `67108864`);
- **no `via builder VM`** in the path;
- **no verity sidecars** (boot semantics unchanged);
- **boots**, and the guest **echoes the marker back** over the agent vsock (EXIT=0).

## Closure budget 336 → 337

mvm-ext4 now *genuinely* enters the default closure (the earlier "holds at 336" measured a closure where pure-mkfs wasn't actually reachable). One small `forbid(unsafe)` crate, in exchange for removing a whole builder-VM launch from the run path — bumped with justification in `xtask`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)