### PR TITLE
fix(machine): populate flake slot kernel fallback

### DIFF
--- a/crates/mvm-cli/src/commands/machine/mod.rs
+++ b/crates/mvm-cli/src/commands/machine/mod.rs
@@ -2431,6 +2431,7 @@ fn run_dispatch(cli: &Cli, mut args: MachineRunArgs, cfg: &MvmConfig) -> Result<
     // below treat it as a manifest-backed source.
     let resolved_flake_slot = if let Some(flake_ref) = args.flake.take() {
         let slot_hash = build::build_flake_to_slot(&flake_ref, args.flake_profile.as_deref())?;
+        args.manifest = Some(slot_hash.clone());
         Some(slot_hash)
     } else {
         None
@@ -2972,6 +2973,18 @@ mod tests {
             let mode = args.resolve_mode().expect("resolve");
             assert_eq!(mode, *expected, "argv {argv:?}");
         }
+    }
+
+    #[test]
+    fn resolve_mode_accepts_materialized_flake_slot_after_build() {
+        let mut args = parse_run(&["run", "--flake", ".", "--", "cmd"]).expect("parse");
+        let flake = args.flake.take().expect("flake source present");
+        assert_eq!(flake, ".");
+        args.manifest = Some("materialized-slot".to_string());
+
+        let mode = args.resolve_mode().expect("materialized flake is a source");
+
+        assert_eq!(mode, MachineRunMode::Transient);
     }
 
     #[test]

--- a/crates/mvm/src/vm/template/lifecycle.rs
+++ b/crates/mvm/src/vm/template/lifecycle.rs
@@ -1,6 +1,7 @@
 use std::time::{Duration, Instant};
 
 use anyhow::{Context, Result, anyhow};
+use mvm_core::arch::GuestArch;
 use mvm_core::naming::validate_template_name;
 use mvm_core::template::{
     SnapshotInfo, TemplateSpec, template_dir, template_revision_dir, template_snapshot_dir,
@@ -29,6 +30,28 @@ fn build_mode_label(mode: mvm_build::pipeline::BuildMode) -> &'static str {
         mvm_build::pipeline::BuildMode::Dev => "dev",
         mvm_build::pipeline::BuildMode::Prod => "prod",
     }
+}
+
+fn slot_kernel_source(
+    built_vmlinux: &std::path::Path,
+    cache_root: &std::path::Path,
+    arch: GuestArch,
+) -> Result<std::path::PathBuf> {
+    if built_vmlinux.is_file() {
+        return Ok(built_vmlinux.to_path_buf());
+    }
+    let fallback = cache_root
+        .join("builder-vm")
+        .join(arch.to_string())
+        .join("vmlinux");
+    if fallback.is_file() {
+        return Ok(fallback);
+    }
+    anyhow::bail!(
+        "flake build produced no vmlinux at {} and the cached builder kernel fallback is absent at {}",
+        built_vmlinux.display(),
+        fallback.display()
+    )
 }
 
 use super::registry::TemplateRegistry;
@@ -734,7 +757,12 @@ pub fn template_build_from_manifest(
     let rev_dst = slot_revision_dir(slot_hash, rev);
     ui::info("Storing artifacts in slot revision directory...");
     shell::run_in_vm(&format!("mkdir -p {rev_dst}"))?;
-    shell::run_in_vm(&format!("cp -a {} {rev_dst}/vmlinux", result.vmlinux_path))?;
+    let kernel_src = slot_kernel_source(
+        std::path::Path::new(&result.vmlinux_path),
+        std::path::Path::new(&mvm_core::config::mvm_cache_dir()),
+        GuestArch::host(),
+    )?;
+    shell::run_in_vm(&format!("cp -a {} {rev_dst}/vmlinux", kernel_src.display()))?;
     if let Some(initrd) = &result.initrd_path {
         shell::run_in_vm(&format!("cp -a {} {rev_dst}/initrd", initrd))?;
     }
@@ -1723,6 +1751,50 @@ mod tests {
         let parsed: Checksums = serde_json::from_str(&json).unwrap();
         let parsed_keys: Vec<&str> = parsed.files.keys().map(|s| s.as_str()).collect();
         assert_eq!(parsed_keys, vec!["a-file", "m-file", "z-file"]);
+    }
+
+    #[test]
+    fn slot_kernel_source_prefers_built_kernel() {
+        let tmp = tempfile::tempdir().unwrap();
+        let built = tmp.path().join("build").join("vmlinux");
+        std::fs::create_dir_all(built.parent().unwrap()).unwrap();
+        std::fs::write(&built, b"built-kernel").unwrap();
+        let cache = tmp.path().join("cache");
+
+        let selected = slot_kernel_source(&built, &cache, GuestArch::X86_64).unwrap();
+
+        assert_eq!(selected, built);
+    }
+
+    #[test]
+    fn slot_kernel_source_uses_builder_kernel_fallback() {
+        let tmp = tempfile::tempdir().unwrap();
+        let built = tmp.path().join("build").join("vmlinux");
+        let fallback = tmp
+            .path()
+            .join("cache")
+            .join("builder-vm")
+            .join("x86_64")
+            .join("vmlinux");
+        std::fs::create_dir_all(fallback.parent().unwrap()).unwrap();
+        std::fs::write(&fallback, b"fallback-kernel").unwrap();
+
+        let selected =
+            slot_kernel_source(&built, &tmp.path().join("cache"), GuestArch::X86_64).unwrap();
+
+        assert_eq!(selected, fallback);
+    }
+
+    #[test]
+    fn slot_kernel_source_errors_without_built_or_fallback_kernel() {
+        let tmp = tempfile::tempdir().unwrap();
+        let built = tmp.path().join("build").join("vmlinux");
+        let err = slot_kernel_source(&built, &tmp.path().join("cache"), GuestArch::X86_64)
+            .unwrap_err()
+            .to_string();
+
+        assert!(err.contains("flake build produced no vmlinux"));
+        assert!(err.contains("builder-vm/x86_64/vmlinux"));
     }
 
     // -----------------------------------------------------------------

--- a/crates/mvm/src/vm/template/lifecycle.rs
+++ b/crates/mvm/src/vm/template/lifecycle.rs
@@ -54,6 +54,17 @@ fn slot_kernel_source(
     )
 }
 
+fn slot_sidecar_source(build_dir: &std::path::Path) -> Result<std::path::PathBuf> {
+    let sidecar = build_dir.join(mvm_build::builder_vm::SIDECAR_FILENAME);
+    if sidecar.is_file() {
+        return Ok(sidecar);
+    }
+    anyhow::bail!(
+        "flake build produced no runtime sidecar at {}",
+        sidecar.display()
+    )
+}
+
 use super::registry::TemplateRegistry;
 
 fn validate_legacy_template_name(id: &str) -> Result<()> {
@@ -769,6 +780,12 @@ pub fn template_build_from_manifest(
     shell::run_in_vm(&format!(
         "cp -a {} {rev_dst}/rootfs.ext4 && chmod u+w {rev_dst}/rootfs.ext4",
         result.rootfs_path
+    ))?;
+    let sidecar_src = slot_sidecar_source(std::path::Path::new(&result.build_dir))?;
+    shell::run_in_vm(&format!(
+        "cp -a {} {rev_dst}/{}",
+        sidecar_src.display(),
+        mvm_build::builder_vm::SIDECAR_FILENAME
     ))?;
 
     // Copy the OCI image tarball (if the flake's `mkGuest` emits one
@@ -1795,6 +1812,26 @@ mod tests {
 
         assert!(err.contains("flake build produced no vmlinux"));
         assert!(err.contains("builder-vm/x86_64/vmlinux"));
+    }
+
+    #[test]
+    fn slot_sidecar_source_selects_builder_sidecar() {
+        let tmp = tempfile::tempdir().unwrap();
+        let sidecar = tmp.path().join(mvm_build::builder_vm::SIDECAR_FILENAME);
+        std::fs::write(&sidecar, b"{\"overlay_aware\":true}").unwrap();
+
+        let selected = slot_sidecar_source(tmp.path()).unwrap();
+
+        assert_eq!(selected, sidecar);
+    }
+
+    #[test]
+    fn slot_sidecar_source_errors_without_builder_sidecar() {
+        let tmp = tempfile::tempdir().unwrap();
+        let err = slot_sidecar_source(tmp.path()).unwrap_err().to_string();
+
+        assert!(err.contains("flake build produced no runtime sidecar"));
+        assert!(err.contains(mvm_build::builder_vm::SIDECAR_FILENAME));
     }
 
     // -----------------------------------------------------------------


### PR DESCRIPTION
## Summary
- Select the built flake kernel when present and otherwise fall back to the cached builder kernel when populating the flake slot revision.
- Fail with an explicit error when neither kernel source exists instead of creating a slot whose fc-base.json points at a missing vmlinux.
- Copy the required `mvm-meta.json` runtime sidecar from the build output into the slot revision beside `rootfs.ext4`.
- Preserve the materialized flake slot as the manifest source before `machine run` lifecycle validation, so `--flake ... -- <cmd>` does not lose its source after build.
- Add focused unit coverage for built-kernel, fallback-kernel, missing-kernel, runtime-sidecar, and materialized-flake dispatch paths.

## KVM evidence
- Reproduced on root@88.99.197.234 with isolated MVM_DATA_DIR/MVM_CACHE_DIR on current main during #1405 triage.
- The first reproduction showed `mvm-meta.json` and `rootfs.ext4` present in the dev build output, but the slot revision lacked `vmlinux` while fc-base.json contained `"kernel_image_path": "vmlinux"`, so the Firecracker boot artifact set was incomplete.
- The same run then exposed that `run_dispatch` consumed `--flake` before `resolve_mode()`, producing the fresh-boot source error even though `--flake` had been supplied.
- A follow-up live run on this PR confirmed the nonzero `vmlinux` was copied into the slot, then exposed the remaining missing-slot-sidecar refusal: the slot revision had `rootfs.ext4` but lacked `mvm-meta.json`.
- After adding the sidecar copy, a fresh live run produced both `rootfs.ext4` and `mvm-meta.json` in the builder staging output. That run did not reach slot finalization because the builder VM job stayed active after producing output; that is tracked as the remaining live-validation blocker on #1405, not as a missing-artifact copy bug.

## Tests
- cargo test -p mvm slot_
- cargo test -p mvm-cli resolve_mode_accepts_materialized_flake_slot_after_build
- cargo clippy -p mvm -p mvm-cli -- -D warnings

Part of #1405.
