### PR TITLE
fix(cli): mint default agent-verb grant only for sealed images (#1381 item 2)

### DIFF
--- a/crates/mvm-cli/src/commands/vm/agent_verbs.rs
+++ b/crates/mvm-cli/src/commands/vm/agent_verbs.rs
@@ -2,6 +2,24 @@ use anyhow::{Context, Result, bail};
 use mvm_core::plan::VerbId;
 use mvm_guest::vsock::GuestRequest;
 
+/// Whether the image at `rootfs_path` is a sealed prod image, read from the
+/// `mvm-meta.json` sidecar the build/materialize pipeline writes next to the
+/// rootfs. Absent or unreadable sidecar => `false` (treat as not sealed => no
+/// default grant), matching the `accessible: true` fallback convention for
+/// pre-sidecar artifacts.
+#[allow(dead_code)] // wired up by the verb-grant call-site in the machine-run path
+pub(crate) fn image_is_sealed(rootfs_path: &std::path::Path) -> bool {
+    rootfs_path
+        .parent()
+        .and_then(|dir| {
+            mvm_build::builder_vm::GuestSidecar::read_from_dir(dir)
+                .ok()
+                .flatten()
+        })
+        .map(|s| s.sealed)
+        .unwrap_or(false)
+}
+
 /// Whether a run should receive an attenuated agent-verb grant. Only a
 /// baked-entrypoint run on a non-dev profile qualifies: those issue only
 /// ProdSafe verbs. An interactive PTY (ConsoleOpen) or an ad-hoc command
@@ -123,6 +141,38 @@ mod tests {
             grant_eligible(false, false, false),
             "persistent baked-entrypoint on non-dev profile must be eligible"
         );
+    }
+
+    #[test]
+    fn image_is_sealed_reads_sidecar_sealed_field() {
+        use mvm_build::builder_vm::GuestSidecar;
+        let dir = tempfile::tempdir().unwrap();
+        let rootfs = dir.path().join("rootfs.ext4");
+        std::fs::write(&rootfs, b"x").unwrap();
+
+        // A sealed prod sidecar => sealed.
+        let mut sc = GuestSidecar::for_oci_run("t"); // accessible:true, sealed:false baseline
+        sc.accessible = false;
+        sc.sealed = true;
+        sc.write_to_dir(dir.path()).unwrap();
+        assert!(image_is_sealed(&rootfs));
+    }
+
+    #[test]
+    fn image_is_sealed_false_for_accessible_and_oci_and_absent() {
+        use mvm_build::builder_vm::GuestSidecar;
+        let dir = tempfile::tempdir().unwrap();
+        let rootfs = dir.path().join("rootfs.ext4");
+        std::fs::write(&rootfs, b"x").unwrap();
+
+        // Absent sidecar => not sealed.
+        assert!(!image_is_sealed(&rootfs));
+
+        // OCI sidecar (accessible:true, sealed:false) => not sealed.
+        GuestSidecar::for_oci_run("t")
+            .write_to_dir(dir.path())
+            .unwrap();
+        assert!(!image_is_sealed(&rootfs));
     }
 
     #[test]

--- a/crates/mvm-cli/src/commands/vm/agent_verbs.rs
+++ b/crates/mvm-cli/src/commands/vm/agent_verbs.rs
@@ -7,7 +7,6 @@ use mvm_guest::vsock::GuestRequest;
 /// rootfs. Absent or unreadable sidecar => `false` (treat as not sealed => no
 /// default grant), matching the `accessible: true` fallback convention for
 /// pre-sidecar artifacts.
-#[allow(dead_code)] // wired up by the verb-grant call-site in the machine-run path
 pub(crate) fn image_is_sealed(rootfs_path: &std::path::Path) -> bool {
     rootfs_path
         .parent()
@@ -20,13 +19,19 @@ pub(crate) fn image_is_sealed(rootfs_path: &std::path::Path) -> bool {
         .unwrap_or(false)
 }
 
-/// Whether a run should receive an attenuated agent-verb grant. Only a
-/// baked-entrypoint run on a non-dev profile qualifies: those issue only
-/// ProdSafe verbs. An interactive PTY (ConsoleOpen) or an ad-hoc command
-/// (Exec) needs DevOnly verbs and must NOT be grant-restricted; dev profile
-/// stays permissive by contract.
-pub(crate) fn grant_eligible(pty: bool, has_ad_hoc_argv: bool, is_dev_profile: bool) -> bool {
-    !pty && !has_ad_hoc_argv && !is_dev_profile
+/// Whether a run should receive an attenuated default agent-verb grant. Only a
+/// baked-entrypoint run, on a non-dev profile, of a **sealed** image qualifies:
+/// those issue only ProdSafe verbs and the image's agent has no console/exec
+/// baked in. An interactive PTY (ConsoleOpen) or ad-hoc command (Exec) needs
+/// DevOnly verbs; a dev profile stays permissive by contract; and a dev-shell /
+/// OCI image (not sealed) must stay reachable via `machine exec` / `console`.
+pub(crate) fn grant_eligible(
+    pty: bool,
+    has_ad_hoc_argv: bool,
+    is_dev_profile: bool,
+    image_sealed: bool,
+) -> bool {
+    !pty && !has_ad_hoc_argv && !is_dev_profile && image_sealed
 }
 
 /// Compute the default agent-verb set for a workload.
@@ -114,33 +119,28 @@ mod tests {
     }
 
     #[test]
-    fn grant_eligible_only_for_nonpty_noargv_nondev() {
-        // Baked-entrypoint run on a prod profile → eligible.
-        assert!(grant_eligible(false, false, false));
-        // Interactive (pty) → NOT eligible (needs ConsoleOpen, DevOnly).
-        assert!(!grant_eligible(true, false, false));
-        // Ad-hoc command (argv present) → NOT eligible (needs Exec, DevOnly).
-        assert!(!grant_eligible(false, true, false));
-        // Dev profile → NOT eligible (dev stays permissive).
-        assert!(!grant_eligible(false, false, true));
-        // Any combination with a disqualifier → NOT eligible.
-        assert!(!grant_eligible(true, true, true));
+    fn grant_eligible_only_for_nonpty_noargv_nondev_sealed() {
+        // Baked-entrypoint, prod profile, SEALED image → eligible.
+        assert!(grant_eligible(false, false, false, true));
+        // Same run but the image is NOT sealed (dev-shell / OCI) → NOT eligible.
+        assert!(!grant_eligible(false, false, false, false));
+        // Interactive (pty) → NOT eligible even when sealed.
+        assert!(!grant_eligible(true, false, false, true));
+        // Ad-hoc command (argv) → NOT eligible even when sealed.
+        assert!(!grant_eligible(false, true, false, true));
+        // Dev profile → NOT eligible even when sealed.
+        assert!(!grant_eligible(false, false, true, true));
+        // Every disqualifier at once → NOT eligible.
+        assert!(!grant_eligible(true, true, true, false));
     }
 
     #[test]
     fn persistent_with_trailing_argv_is_not_eligible() {
-        // `machine run -d --image X -- cmd` boots the machine AND then runs an
-        // ad-hoc command via GuestRequest::Exec (a DevOnly verb). The admitted
-        // plan must NOT carry an attenuated ProdSafe grant.
-        assert!(
-            !grant_eligible(false, true, false),
-            "persistent + ad-hoc argv must not receive a ProdSafe-only grant"
-        );
-        // Without trailing argv, a non-dev persistent boot IS eligible.
-        assert!(
-            grant_eligible(false, false, false),
-            "persistent baked-entrypoint on non-dev profile must be eligible"
-        );
+        // `machine run -d --image X -- cmd` runs an ad-hoc Exec (DevOnly): no grant,
+        // regardless of sealed state.
+        assert!(!grant_eligible(false, true, false, true));
+        // Sealed baked-entrypoint on non-dev profile IS eligible.
+        assert!(grant_eligible(false, false, false, true));
     }
 
     #[test]

--- a/crates/mvm-cli/src/commands/vm/exec.rs
+++ b/crates/mvm-cli/src/commands/vm/exec.rs
@@ -380,6 +380,7 @@ pub(in crate::commands) fn run_secure(cli: &Cli, args: RunArgs, cfg: &MvmConfig)
                 admit_pty,
                 admit_has_argv,
                 admit_is_dev,
+                crate::commands::vm::agent_verbs::image_is_sealed(rootfs),
             ),
         })?;
         let Some(c) = ctx else { return Ok(None) };
@@ -1693,11 +1694,13 @@ mod tests {
     #[test]
     fn transient_grant_eligibility_matches_run_mode() {
         use crate::commands::vm::agent_verbs::grant_eligible;
-        // Interactive transient (pty) → not eligible.
-        assert!(!grant_eligible(true, false, false));
-        // Ad-hoc transient (argv) → not eligible.
-        assert!(!grant_eligible(false, true, false));
-        // Transient baked-entrypoint (no pty, no argv, prod) → eligible.
-        assert!(grant_eligible(false, false, false));
+        // Interactive transient (pty) → not eligible even when sealed.
+        assert!(!grant_eligible(true, false, false, true));
+        // Ad-hoc transient (argv) → not eligible even when sealed.
+        assert!(!grant_eligible(false, true, false, true));
+        // Transient baked-entrypoint (no pty, no argv, prod, sealed) → eligible.
+        assert!(grant_eligible(false, false, false, true));
+        // Same run but image not sealed (dev-shell / OCI) → NOT eligible.
+        assert!(!grant_eligible(false, false, false, false));
     }
 }

--- a/crates/mvm-cli/src/commands/vm/invoke.rs
+++ b/crates/mvm-cli/src/commands/vm/invoke.rs
@@ -191,8 +191,11 @@ pub(in crate::commands) fn run_entrypoint(call: EntrypointCall) -> Result<()> {
                             agent_verb_override: vec![],
                             // --keep-alive-dev marks the session for subsequent session exec /
                             // run-code (DevOnly verbs); those must not be blocked by an
-                            // attenuated ProdSafe grant.
-                            restrict_agent_verbs: !call.keep_alive_dev,
+                            // attenuated ProdSafe grant. Additionally, the default grant is
+                            // only minted for a sealed image (mvm-meta.json `sealed: true`);
+                            // unsealed dev-shell or OCI images are not restricted.
+                            restrict_agent_verbs: !call.keep_alive_dev
+                                && super::agent_verbs::image_is_sealed(rootfs),
                         })?;
                         let Some(c) = ctx else { return Ok(None) };
                         // Persist the bare admitted plan to the per-VM state dir

--- a/crates/mvm-cli/src/commands/vm/up.rs
+++ b/crates/mvm-cli/src/commands/vm/up.rs
@@ -1191,6 +1191,7 @@ pub(in crate::commands) fn start_persistent_oci_machine(
             false,
             has_ad_hoc_argv,
             profile == "dev",
+            super::agent_verbs::image_is_sealed(rootfs_path),
         ),
     })?;
     let mut start_config = VmStartParams {

--- a/crates/mvm-cli/src/commands/vm/up.rs
+++ b/crates/mvm-cli/src/commands/vm/up.rs
@@ -153,7 +153,7 @@ pub(super) struct AdmitPlanForBootParams<'a> {
     /// `parse_agent_verb_override`; any unknown/DevOnly verb is an error.
     pub agent_verb_override: Vec<String>,
     /// True iff this run should receive an attenuated (ProdSafe-only) agent-verb
-    /// grant. Set this with `grant_eligible(pty, has_ad_hoc_argv, is_dev_profile)`.
+    /// grant. Set this with `grant_eligible(pty, has_ad_hoc_argv, is_dev_profile, image_sealed)`.
     /// Interactive / ad-hoc / dev runs must pass `false`: they issue DevOnly verbs
     /// (ConsoleOpen, Exec) that a ProdSafe grant would refuse.
     pub restrict_agent_verbs: bool,

--- a/specs/notes/2026-07-04-verb-grant-sealed-gating.md
+++ b/specs/notes/2026-07-04-verb-grant-sealed-gating.md
@@ -1,0 +1,135 @@
+# Verb-grant default eligibility gated on the image's sealed state
+
+**Status:** Design (approved). Follow-on to ADR-103 / Plan 215, issue #1381 item 2.
+**Date:** 2026-07-04
+**Scope:** `mvm-cli` grant-decision sites only. No protocol/schema change.
+
+## Problem
+
+Plan-bound agent-verb enforcement mints a *default* `VerbGrant` (all `ProdSafe`
+verbs, minus volume verbs when the workload declares no shares) for any
+baked-entrypoint, non-interactive, non-ad-hoc, **non-dev-*profile*** run. The
+`grant_eligible(pty, has_ad_hoc_argv, is_dev_profile)` predicate keys on the
+**run's `--profile`**, not the **image's baked capability**.
+
+But the host already records the image's real capability in the `mvm-meta.json`
+`GuestSidecar` written next to every rootfs:
+
+- `accessible: true` / `sealed: false` — dev-shell agent (console + `do_exec`
+  symbols present).
+- `accessible: false` / `sealed: true` — sealed prod agent (dm-verity, no
+  console/`do_exec` — claim 4/15).
+
+OCI-image workloads are **always** materialized with the dev-shell agent
+(`GuestSidecar::for_oci_run` → `accessible: true, sealed: false`). So a plain
+`machine run --image X -d` mints a `ProdSafe`-only default grant that then
+**refuses `machine exec` / `machine console`** — even though the guest agent
+can serve them. This was observed live on the KVM box (`ocica`: `machine exec`
+→ `verb exec not authorized by the session's verb grant`). It is surprising
+(docker-like `run -d` then `exec` is expected to work) and the grant bought no
+real security there — the image has the dev symbols regardless of the run
+profile.
+
+Because minting a grant is the **restrictive** direction, this residual can
+only *over*-restrict (break a legitimate later `exec`/`console` on a dev/OCI
+image); it can never *under*-restrict. So it is a correctness/DX defect, not a
+security hole.
+
+## Design
+
+Align the **default** grant with the image's actual sealed state, which the
+host can read at admit time. Keep run mode as an additional gate. Leave
+explicit `--agent-verb` overrides untouched (a user request is always honored).
+
+### Change 1 — extend the pure predicate
+
+`crates/mvm-cli/src/commands/vm/agent_verbs.rs`
+
+```rust
+pub(crate) fn grant_eligible(
+    pty: bool,
+    has_ad_hoc_argv: bool,
+    is_dev_profile: bool,
+    image_sealed: bool,
+) -> bool {
+    !pty && !has_ad_hoc_argv && !is_dev_profile && image_sealed
+}
+```
+
+Still pure and truth-table testable. A grant is now eligible only for a
+baked-entrypoint, non-dev-profile run **of a sealed image**.
+
+### Change 2 — impure sidecar reader
+
+`crates/mvm-cli/src/commands/vm/agent_verbs.rs`
+
+```rust
+/// Whether the image at `rootfs_path` is a sealed prod image, read from the
+/// `mvm-meta.json` GuestSidecar the build/materialize pipeline writes next to
+/// the rootfs. Absent/unreadable sidecar => `false` (treat as not sealed =>
+/// no default grant), matching the `accessible: true` fallback convention and
+/// pre-enforcement permissiveness. Backward-compatible for pre-sidecar artifacts.
+pub(crate) fn image_is_sealed(rootfs_path: &std::path::Path) -> bool {
+    rootfs_path
+        .parent()
+        .and_then(|dir| mvm_build::builder_vm::GuestSidecar::read_from_dir(dir).ok().flatten())
+        .map(|s| s.sealed)
+        .unwrap_or(false)
+}
+```
+
+### Change 3 — the two production call sites pass `image_sealed`
+
+- `crates/mvm-cli/src/commands/vm/up.rs` (persistent, ~:1190): the site already
+  has `rootfs_path` in scope (used at ~:1198). Compute
+  `image_is_sealed(&rootfs_path)` and pass it as the fourth arg.
+- `crates/mvm-cli/src/commands/vm/exec.rs` (transient, ~:379): `rootfs` is in
+  scope (used at ~:359). Same.
+
+Test fixtures in `up.rs` `admit_plan_tests` (`restrict_agent_verbs: true`,
+~:1716+) are unchanged — they set a scenario value deliberately.
+
+### Explicit override is preserved
+
+`synthesize_plan` computes `agent_verbs` as
+`parse_agent_verb_override(...).or_else(|| default_agent_verbs(restrict_agent_verbs, ...))`
+(up.rs:467-473). Only the `default_agent_verbs` branch is gated by
+`restrict_agent_verbs`; an explicit `--agent-verb` returns `Some(..)` and wins
+via `.or_else`, regardless of sealed state. No change needed there.
+
+## Behavior after
+
+| Run | Before | After |
+|-----|--------|-------|
+| Sealed prod flake entrypoint (`-d`, non-dev) | default grant | **default grant (unchanged)** |
+| Dev-shell flake image entrypoint (non-dev profile) | default grant | class-gate-only |
+| Any OCI image (`machine run --image X -d`) | default grant → `exec` denied | **class-gate-only → `exec` works** |
+| Explicit `--agent-verb ping` (any image) | grant `{ping}` | grant `{ping}` (unchanged) |
+| Interactive `-it` / ad-hoc `-- cmd` / dev profile | no grant | no grant (unchanged) |
+| Absent sidecar (pre-enforcement artifact) | default grant | class-gate-only |
+
+## Testing
+
+- `grant_eligible`: extend the truth table with the `image_sealed` dimension —
+  eligible **iff** `!pty && !argv && !dev && sealed`; every disqualifier
+  (including `!sealed`) returns `false`.
+- `image_is_sealed`: sealed sidecar → `true`; accessible sidecar → `false`;
+  `GuestSidecar::for_oci_run` sidecar → `false`; absent dir/sidecar → `false`.
+- Site behavior: a synthesized `SynthesisInput` with `restrict_agent_verbs`
+  from an accessible-image site yields `agent_verbs: None`; a sealed-image site
+  yields the default set; an explicit override yields the override on both.
+
+## Live validation (Firecracker/KVM box)
+
+- Re-run the exact `ocica` scenario (`machine run --image alpine -d` →
+  `machine exec --name N -- echo ok`): `exec` now **succeeds** (no default grant
+  minted; no `verb-grant.json` in the vm dir).
+- Craft a sealed sidecar (`sealed: true`) next to a rootfs and confirm the
+  default grant is still minted (`verb-grant.json` present) — proves the sealed
+  path is unchanged.
+
+## Non-goals
+
+- Real cryptographic key separation (issue #1381 item 3 — separate ADR).
+- Changing the sealed/accessible sidecar semantics or the `console`
+  accessible-gate (`enforce_accessible_gate`) — reused as-is.

--- a/specs/notes/2026-07-04-verb-grant-sealed-gating.md
+++ b/specs/notes/2026-07-04-verb-grant-sealed-gating.md
@@ -78,13 +78,17 @@ pub(crate) fn image_is_sealed(rootfs_path: &std::path::Path) -> bool {
 }
 ```
 
-### Change 3 — the two production call sites pass `image_sealed`
+### Change 3 — the three production grant-decision sites pass `image_sealed`
 
 - `crates/mvm-cli/src/commands/vm/up.rs` (persistent, ~:1190): the site already
   has `rootfs_path` in scope (used at ~:1198). Compute
   `image_is_sealed(&rootfs_path)` and pass it as the fourth arg.
 - `crates/mvm-cli/src/commands/vm/exec.rs` (transient, ~:379): `rootfs` is in
   scope (used at ~:359). Same.
+- `crates/mvm-cli/src/commands/vm/invoke.rs` (entrypoint invoke / `!keep_alive_dev`,
+  ~:195): `rootfs: &std::path::Path` (closure param declared ~:165). Combines
+  `!call.keep_alive_dev && image_is_sealed(rootfs)` — the dev-relay flag and the
+  sealed-image check are both required for the attenuated grant to apply.
 
 Test fixtures in `up.rs` `admit_plan_tests` (`restrict_agent_verbs: true`,
 ~:1716+) are unchanged — they set a scenario value deliberately.


### PR DESCRIPTION
## What

The plan-bound agent-verb enforcement (ADR-103 / Plan 215) mints a *default* attenuated `VerbGrant` (all `ProdSafe` verbs) for baked-entrypoint, non-interactive, non-ad-hoc, non-dev-**profile** runs. That decision keyed only on the run's `--profile`, never on the **image's** baked capability.

But the host already records the image's real capability in the `mvm-meta.json` `GuestSidecar` next to every rootfs (`sealed: true` = dm-verity sealed prod agent, no console/`do_exec`; `sealed: false` = dev-shell agent). OCI images are **always** materialized dev-shell-capable (`sealed: false`). So a plain `machine run --image X -d` minted a `ProdSafe`-only grant that then **denied `machine exec`/`console`** — which I hit live on the KVM box (`ocica`: `verb exec not authorized by the session's verb grant`). Surprising (docker-like `run -d` then `exec`), and the grant bought no real security there — the image has the dev symbols regardless of run profile.

Because minting a grant is the **restrictive** direction, this only ever *over*-restricted (broke a legit later `exec`/`console`), never *under*-restricted — a correctness/DX defect, not a security hole.

## Fix

Gate the **default** grant on the image's actual sealed state (readable at admit time), keeping run mode as an additional gate and leaving explicit `--agent-verb` overrides untouched (they win via `.or_else` in synthesis).

- `image_is_sealed(rootfs) -> bool` — reads the `sealed` flag from the `mvm-meta.json` sidecar next to the rootfs; **absent/unreadable ⇒ `false`** (no default grant; backward-compatible with pre-sidecar artifacts).
- `grant_eligible(pty, has_ad_hoc_argv, is_dev_profile, image_sealed)` — ANDs `image_sealed` in. A grant is eligible **iff** `!pty && !argv && !dev && sealed`.
- All **three** production grant-decision sites now pass the sealed value derived from the run's actual rootfs: `up.rs` (persistent), `exec.rs` (transient), and `invoke.rs` (entrypoint invoke — `!keep_alive_dev && image_is_sealed(rootfs)`).

**Every change is safe-direction** — adding `&& image_sealed` can only turn a prior grant off, never on. Sealed prod flake entrypoints keep their default grant unchanged.

## Behavior after

| Run | Before | After |
|-----|--------|-------|
| Sealed prod flake entrypoint (`-d`, non-dev) | default grant | default grant (unchanged) |
| Dev-shell flake image / any OCI image | default grant → `exec` denied | class-gate-only → `exec` works |
| Explicit `--agent-verb ping` (any image) | grant `{ping}` | grant `{ping}` (unchanged) |
| `-it` / ad-hoc `-- cmd` / dev profile | no grant | no grant (unchanged) |
| Absent sidecar (pre-enforcement artifact) | default grant | class-gate-only |

## Testing

Unit: extended the `grant_eligible` truth table with the sealed dimension; `image_is_sealed` covering sealed / accessible / `for_oci_run` / absent→false. `cargo check --workspace --all-targets`, `cargo nextest run -p mvm-cli` (all relevant tests pass with the real `mvmctl` bin), `cargo fmt --all`, `cargo clippy -p mvm-cli -D warnings` — clean.

Design: `specs/notes/2026-07-04-verb-grant-sealed-gating.md`. Live-boot re-validation of the `ocica` exec-now-succeeds scenario to follow on the KVM box.

Addresses #1381 item 2 (the `is_sealed_prod`/baked-profile residual). Item 3 (build-time key anchor) remains.

🤖 Generated with [Claude Code](https://claude.com/claude-code)