### PR TITLE
feat(mvm-client-local): resolve registry refs + unpacked dirs in LocalBackend.run

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2657,10 +2657,13 @@ name = "mvm-client-local"
 version = "0.16.1"
 dependencies = [
  "async-trait",
+ "flate2",
  "mvm-backend",
+ "mvm-build",
  "mvm-client",
  "mvm-core",
  "mvm-hostd",
+ "mvm-oci",
  "tempfile",
  "tokio",
 ]

--- a/crates/mvm-build/src/lib.rs
+++ b/crates/mvm-build/src/lib.rs
@@ -56,6 +56,9 @@ pub mod rootfs;
 /// Self-hosting builder-rootfs bootstrap: inject freshly built mvm host binaries
 /// into a rootfs via an initramfs patcher on the in-house VMM (no legacy builder).
 pub mod rootfs_inject;
+/// Shared run-path rootfs orchestration (inject runtime + materialize ext4),
+/// used by the CLI's `run --image` and the `mvm-client` local backend.
+pub mod run_image;
 pub mod stage0;
 pub mod template_reuse;
 /// Type-safe interface to the `mvm-vz-supervisor` binary —

--- a/crates/mvm-build/src/run_image.rs
+++ b/crates/mvm-build/src/run_image.rs
@@ -1,0 +1,118 @@
+//! Run-path rootfs materialization: turn an unpacked OCI tree into the bootable
+//! `rootfs.ext4`, in-process by default (the pure-Rust `mvm-ext4` writer — no
+//! builder VM, no `mkfs`, no subprocess).
+//!
+//! Shared by the CLI's `run --image` path and the `mvm-client` local backend so
+//! both drive one orchestration: resolve the guest-agent binaries, inject the
+//! mvm runtime into the unpacked tree, materialize the ext4 image, and write the
+//! overlay-aware guest sidecar beside it.
+
+use std::path::Path;
+
+use anyhow::{Context, Result};
+
+use crate::rootfs::MaterializeExt4Input;
+
+/// Inject the mvm runtime into `unpacked_root`, materialize it into `output` (a
+/// `rootfs.ext4` path), and write the overlay-aware guest sidecar beside it.
+/// `cache_root` holds the guest-agent binary cache; `label` names the image in
+/// the sidecar.
+///
+/// The guest binaries are resolved via `guest_agent_build`, which cross-compiles
+/// them from a source checkout — the same path the CLI uses (an end-user
+/// binary that ships the runtime overlay is a separate, not-yet-wired path).
+pub fn inject_and_materialize(
+    cache_root: &Path,
+    unpacked_root: &Path,
+    output: &Path,
+    label: &str,
+) -> Result<()> {
+    let arch = mvm_core::arch::GuestArch::host();
+    // `CARGO_MANIFEST_DIR` is bound at this crate's compile time, so it always
+    // points at `crates/mvm-build`; its grandparent is the workspace root.
+    let workspace_root = Path::new(env!("CARGO_MANIFEST_DIR"))
+        .parent()
+        .and_then(|p| p.parent())
+        .ok_or_else(|| anyhow::anyhow!("cannot locate workspace root for guest-agent build"))?;
+    let bins = crate::guest_agent_build::resolve_or_build_guest_binaries(
+        cache_root,
+        env!("CARGO_PKG_VERSION"),
+        arch,
+        workspace_root,
+    )
+    .context("obtain guest agent binaries for OCI run")?;
+    crate::oci_runtime_inject::inject_mvm_runtime(unpacked_root, &bins)
+        .context("inject mvm runtime into OCI rootfs")?;
+
+    // Measure AFTER injection so the ext4 sizing covers the baked agent/netinit.
+    let tree_size = unpacked_tree_size(unpacked_root)
+        .with_context(|| format!("measure unpacked root {}", unpacked_root.display()))?;
+    materialize_run_rootfs(&MaterializeExt4Input::new(
+        unpacked_root.to_path_buf(),
+        output.to_path_buf(),
+        tree_size,
+    ))?;
+
+    // The sidecar lives next to rootfs.ext4 so the backend's admit_overlay_aware
+    // gate reads it at start.
+    let rootfs_dir = output
+        .parent()
+        .ok_or_else(|| anyhow::anyhow!("rootfs path has no parent dir: {}", output.display()))?;
+    crate::builder_vm::GuestSidecar::for_oci_run(label)
+        .write_to_dir(rootfs_dir)
+        .with_context(|| format!("write OCI sidecar in {}", rootfs_dir.display()))?;
+    Ok(())
+}
+
+/// Materialize a run-path rootfs from an already-complete unpacked tree.
+///
+/// Default: the pure in-process `mvm-ext4` writer. `MVM_MATERIALIZE_BUILDER_VM`
+/// (any value) routes back through the builder-VM `mkfs` path for parity /
+/// debugging. Verity is left off (no `rootfs.verity` / `rootfs.roothash`
+/// sidecars), so the run path's `verity_path`/`roothash = None` boot config is
+/// unchanged — this is a materialization *mechanism* choice, not a boot-semantics
+/// change.
+pub fn materialize_run_rootfs(input: &MaterializeExt4Input) -> Result<()> {
+    #[cfg(feature = "pure-mkfs")]
+    if std::env::var_os("MVM_MATERIALIZE_BUILDER_VM").is_none() {
+        return crate::rootfs::materialize_ext4_pure(input)
+            .map(|_| ())
+            .with_context(|| format!("materialize {} in-process", input.output.display()));
+    }
+    materialize_run_rootfs_builder_vm(input)
+}
+
+#[cfg(feature = "builder-vm")]
+fn materialize_run_rootfs_builder_vm(input: &MaterializeExt4Input) -> Result<()> {
+    crate::rootfs::materialize_ext4(input, &crate::rootfs::MaterializeExt4Options::default())
+        .map(|_| ())
+        .with_context(|| format!("materialize {} via builder VM", input.output.display()))
+}
+
+#[cfg(not(feature = "builder-vm"))]
+fn materialize_run_rootfs_builder_vm(_input: &MaterializeExt4Input) -> Result<()> {
+    anyhow::bail!(
+        "no rootfs materializer compiled in: enable the `pure-mkfs` or `builder-vm` feature"
+    )
+}
+
+/// Sum of regular-file sizes under `root` (symlink-aware, never follows) — the
+/// ext4 sizing input.
+pub fn unpacked_tree_size(root: &Path) -> Result<u64> {
+    let mut total = 0u64;
+    let mut stack = vec![root.to_path_buf()];
+    while let Some(path) = stack.pop() {
+        let metadata = std::fs::symlink_metadata(&path)
+            .with_context(|| format!("stat unpacked path {}", path.display()))?;
+        if metadata.is_dir() {
+            for entry in
+                std::fs::read_dir(&path).with_context(|| format!("read {}", path.display()))?
+            {
+                stack.push(entry?.path());
+            }
+        } else if metadata.is_file() {
+            total = total.saturating_add(metadata.len());
+        }
+    }
+    Ok(total)
+}

--- a/crates/mvm-cli/src/commands/image/mod.rs
+++ b/crates/mvm-cli/src/commands/image/mod.rs
@@ -9,8 +9,6 @@ use anyhow::{Context, Result, bail};
 use clap::{Args as ClapArgs, Subcommand};
 use flate2::read::GzDecoder;
 use mvm_build::rootfs::MaterializeExt4Input;
-#[cfg(feature = "builder-vm")]
-use mvm_build::rootfs::{MaterializeExt4Options, materialize_ext4};
 use mvm_oci::{
     ImageReference, LayerDescriptor, LayerFetchOptions, LinuxPlatform, OciLayerFetcher,
     OciManifestFetcher, RegistryAuthConfig, UnpackOptions, read_oci_archive, unpack_layer,
@@ -537,27 +535,7 @@ pub(in crate::commands) fn resolve_or_pull_run_image(
 /// path's `verity_path`/`roothash = None` boot config is unchanged — this flips
 /// the materialization *mechanism*, not the boot semantics.
 fn materialize_run_rootfs(input: &MaterializeExt4Input) -> Result<()> {
-    #[cfg(feature = "pure-mkfs")]
-    if std::env::var_os("MVM_MATERIALIZE_BUILDER_VM").is_none() {
-        return mvm_build::rootfs::materialize_ext4_pure(input)
-            .map(|_| ())
-            .with_context(|| format!("materialize {} in-process", input.output.display()));
-    }
-    materialize_run_rootfs_builder_vm(input)
-}
-
-#[cfg(feature = "builder-vm")]
-fn materialize_run_rootfs_builder_vm(input: &MaterializeExt4Input) -> Result<()> {
-    materialize_ext4(input, &MaterializeExt4Options::default())
-        .map(|_| ())
-        .with_context(|| format!("materialize {} via builder VM", input.output.display()))
-}
-
-#[cfg(not(feature = "builder-vm"))]
-fn materialize_run_rootfs_builder_vm(_input: &MaterializeExt4Input) -> Result<()> {
-    anyhow::bail!(
-        "no rootfs materializer compiled in: enable the `pure-mkfs` or `builder-vm` feature"
-    )
+    mvm_build::run_image::materialize_run_rootfs(input)
 }
 
 fn inject_runtime_and_materialize(
@@ -566,41 +544,7 @@ fn inject_runtime_and_materialize(
     rootfs_abs: &Path,
     image_label: &str,
 ) -> Result<()> {
-    let arch = mvm_core::arch::GuestArch::host();
-    let workspace_root = Path::new(env!("CARGO_MANIFEST_DIR"))
-        .parent()
-        .and_then(|p| p.parent())
-        .ok_or_else(|| anyhow::anyhow!("cannot locate workspace root for guest-agent build"))?;
-    let bins = mvm_build::guest_agent_build::resolve_or_build_guest_binaries(
-        cache_root,
-        env!("CARGO_PKG_VERSION"),
-        arch,
-        workspace_root,
-    )
-    .context("obtain guest agent binaries for OCI run")?;
-    mvm_build::oci_runtime_inject::inject_mvm_runtime(unpacked_root, &bins)
-        .context("inject mvm runtime into OCI rootfs")?;
-
-    // Measure AFTER injection so the ext4 sizing covers the baked
-    // agent/netinit (~1.6 MiB).
-    let tree_size = unpacked_tree_size(unpacked_root)
-        .with_context(|| format!("measure unpacked root {}", unpacked_root.display()))?;
-    materialize_run_rootfs(&MaterializeExt4Input::new(
-        unpacked_root.to_path_buf(),
-        rootfs_abs.to_path_buf(),
-        tree_size,
-    ))
-    .context("materialize OCI rootfs.ext4")?;
-
-    // The sidecar lives next to rootfs.ext4 so the backend's
-    // admit_overlay_aware gate reads it at start.
-    let rootfs_dir = rootfs_abs.parent().ok_or_else(|| {
-        anyhow::anyhow!("rootfs path has no parent dir: {}", rootfs_abs.display())
-    })?;
-    mvm_build::builder_vm::GuestSidecar::for_oci_run(image_label)
-        .write_to_dir(rootfs_dir)
-        .with_context(|| format!("write OCI sidecar in {}", rootfs_dir.display()))?;
-    Ok(())
+    mvm_build::run_image::inject_and_materialize(cache_root, unpacked_root, rootfs_abs, image_label)
 }
 
 /// Ingest a local OCI image-layout archive (`oci-archive:<path>`) into a
@@ -758,7 +702,7 @@ fn ingest_rootfs_dir(
 
     let key = canonical_key_for_path(rootfs_dir)
         .with_context(|| format!("canonicalize rootfs dir {}", rootfs_dir.display()))?;
-    let tree_size = unpacked_tree_size(rootfs_dir)
+    let tree_size = mvm_build::run_image::unpacked_tree_size(rootfs_dir)
         .with_context(|| format!("measure rootfs dir {}", rootfs_dir.display()))?;
     let rootfs_rel = format!("rootfs/{key}/rootfs.ext4");
     let rootfs_abs = cache_root.join(&rootfs_rel);
@@ -1361,23 +1305,6 @@ fn sha256_hex(digest: &str) -> Result<String> {
         bail!("malformed sha256 digest: {digest:?}");
     }
     Ok(hex.to_string())
-}
-
-fn unpacked_tree_size(root: &Path) -> Result<u64> {
-    let mut total = 0u64;
-    let mut stack = vec![root.to_path_buf()];
-    while let Some(path) = stack.pop() {
-        let metadata = fs::symlink_metadata(&path)
-            .with_context(|| format!("stat unpacked path {}", path.display()))?;
-        if metadata.is_dir() {
-            for entry in fs::read_dir(&path).with_context(|| format!("read {}", path.display()))? {
-                stack.push(entry?.path());
-            }
-        } else if metadata.is_file() {
-            total = total.saturating_add(metadata.len());
-        }
-    }
-    Ok(total)
 }
 
 fn upsert_image(index: &mut OciCacheIndex, image: CachedOciImage) {

--- a/crates/mvm-client-local/Cargo.toml
+++ b/crates/mvm-client-local/Cargo.toml
@@ -19,8 +19,20 @@ mvm-core = { workspace = true }
 # to the default build; it does not form a cycle because mvm-sdk — which
 # mvm-hostd pulls in — carries no dependency back on this crate.
 mvm-hostd = { workspace = true }
+# Shared run-path orchestration (`run_image::inject_and_materialize`) — the same
+# pure-Rust materialize the CLI's `run --image` uses. `pure-mkfs` pulls mvm-ext4,
+# already in the mvmctl closure via the CLI, so this adds no default crates.
+mvm-build = { workspace = true, default-features = false, features = ["pure-mkfs"] }
+# OCI pull + hardened unpack for registry-ref resolution. Already in the mvmctl
+# closure (the CLI links it); mvm-oci carries no back-edge to this crate.
+mvm-oci = { workspace = true }
+# gzip layer decode at this crate's boundary (mvm-oci stays decompressor-free by
+# design; the CLI decodes at its boundary the same way).
+flate2 = { workspace = true }
+# `Vec<u8>` implements tokio's `AsyncWrite`, the sink for `fetch_layer`.
+tokio = { workspace = true, features = ["rt"] }
+tempfile = { workspace = true }
 async-trait = { workspace = true }
 
 [dev-dependencies]
 tokio = { workspace = true, features = ["macros", "rt"] }
-tempfile = { workspace = true }

--- a/crates/mvm-client-local/src/lib.rs
+++ b/crates/mvm-client-local/src/lib.rs
@@ -5,20 +5,27 @@
 //!
 //! `list`/`stop`/`logs` go straight to the backend dispatch (they act on VMs
 //! that already exist, so they carry no admission concern). `run` boots through
-//! the signed-plan admission gate in-process — no subprocess, no CLI — by
-//! resolving the spec's image to a host-materialized rootfs and handing it to
-//! `mvm_hostd::run::admit_and_boot_local`. Image refs that still need a registry
-//! pull or an unpacked-dir materialize step fail honestly (that resolution is
-//! not wired into this backend yet); a workload never boots on a path that
-//! skipped admission.
+//! the signed-plan admission gate in-process — no subprocess, no CLI. It
+//! resolves the spec's image to a host-materialized rootfs — a ready
+//! `rootfs.ext4`, an unpacked OCI directory (inject runtime + pure-materialize),
+//! or a registry ref (pull + unpack + inject + materialize) — reusing the exact
+//! `mvm_build::run_image` orchestration the CLI's `run --image` uses, then hands
+//! it to `mvm_hostd::run::admit_and_boot_local`. A workload never boots on a
+//! path that skipped admission.
 
-use std::path::Path;
+use std::io::Cursor;
+use std::path::{Path, PathBuf};
 
 use async_trait::async_trait;
+use flate2::read::GzDecoder;
 use mvm_backend::AnyBackend;
 use mvm_core::protocol::vm_backend::{VmId, VmInfo, VmStatus};
 use mvm_hostd::plan_admission::{InMemoryNonceLedger, SystemClock};
 use mvm_hostd::run::{LocalRunContext, LocalRunRequest, admit_and_boot_local};
+use mvm_oci::{
+    ImageReference, LayerDescriptor, LayerFetchOptions, LinuxPlatform, OciLayerFetcher,
+    OciManifestFetcher, UnpackOptions, unpack_layer,
+};
 
 use mvm_client::dto::{
     ExecResult, LogOpts, MachineFilter, MachineId, MachineSpec, MachineState, MachineStatus,
@@ -76,27 +83,119 @@ fn backend_err(e: impl std::fmt::Display) -> MvmError {
     }
 }
 
-/// Resolve `image` to a host path pointing at an already-materialized ext4
-/// rootfs. Only a direct path to a materialized image boots in-process today;
-/// an unpacked-dir materialize step and registry pulls are deferred to a later
-/// slice and fail with a clear message rather than a partial boot.
-fn resolve_local_rootfs(image: &str) -> Result<std::path::PathBuf> {
+/// How a `spec.image` string is interpreted.
+#[derive(Debug, PartialEq, Eq)]
+enum ImageSource {
+    /// A path to an already-materialized `rootfs.ext4` — boot it directly.
+    Materialized(PathBuf),
+    /// A path to an unpacked OCI rootfs directory — inject runtime + materialize.
+    UnpackedDir(PathBuf),
+    /// Anything else is treated as an OCI registry reference — pull + unpack +
+    /// inject + materialize.
+    Registry(String),
+}
+
+/// Classify a `spec.image`: an existing file is a materialized rootfs, an
+/// existing directory is an unpacked tree, everything else is a registry ref.
+fn classify_image(image: &str) -> ImageSource {
     let path = Path::new(image);
     if path.is_file() {
-        return Ok(path.to_path_buf());
+        ImageSource::Materialized(path.to_path_buf())
+    } else if path.is_dir() {
+        ImageSource::UnpackedDir(path.to_path_buf())
+    } else {
+        ImageSource::Registry(image.to_string())
     }
-    if path.is_dir() {
+}
+
+/// Resolve `spec.image` to a host `rootfs.ext4` path, materializing in-process
+/// as needed (no subprocess, no CLI). Registry pulls are async; the dir +
+/// pre-materialized cases are synchronous.
+async fn resolve_local_rootfs(image: &str, name: &str) -> Result<PathBuf> {
+    match classify_image(image) {
+        ImageSource::Materialized(path) => Ok(path),
+        ImageSource::UnpackedDir(dir) => materialize_from_dir(&dir, name),
+        ImageSource::Registry(reference) => {
+            let staging = tempfile::tempdir().map_err(backend_err)?;
+            pull_image_to_dir(&reference, staging.path()).await?;
+            materialize_from_dir(staging.path(), name)
+        }
+    }
+}
+
+/// Cache location for a locally-materialized run rootfs, keyed by machine name.
+fn run_rootfs_output(name: &str) -> PathBuf {
+    let key: String = name
+        .chars()
+        .map(|c| if c.is_ascii_alphanumeric() { c } else { '_' })
+        .collect();
+    PathBuf::from(mvm_core::config::mvm_cache_dir())
+        .join("local-run")
+        .join(key)
+        .join("rootfs.ext4")
+}
+
+/// Inject the mvm runtime into an unpacked tree and materialize it into the
+/// run-rootfs cache, reusing the CLI's shared `run_image` orchestration.
+fn materialize_from_dir(dir: &Path, name: &str) -> Result<PathBuf> {
+    let output = run_rootfs_output(name);
+    let cache_root = PathBuf::from(mvm_core::config::mvm_cache_dir());
+    mvm_build::run_image::inject_and_materialize(&cache_root, dir, &output, name)
+        .map_err(backend_err)?;
+    Ok(output)
+}
+
+/// Pull a public OCI registry reference and unpack every layer into `dest`,
+/// reusing mvm-oci's fetch + hardened unpacker (gzip is decoded here, at the
+/// crate boundary, keeping mvm-oci decompressor-free by design).
+async fn pull_image_to_dir(reference: &str, dest: &Path) -> Result<()> {
+    let image_ref: ImageReference = reference
+        .parse()
+        .map_err(|e| backend_err(format!("parse image reference {reference:?}: {e}")))?;
+    let manifest_fetcher = OciManifestFetcher::new();
+    let manifest = manifest_fetcher
+        .fetch_linux_platform_manifest(&image_ref, &LinuxPlatform::for_current_arch())
+        .await
+        .map_err(|e| backend_err(format!("fetch manifest for {reference}: {e}")))?;
+    let layers = manifest
+        .layers()
+        .map_err(|e| backend_err(format!("parse layers for {reference}: {e}")))?;
+    if layers.is_empty() {
+        return Err(backend_err(format!("OCI image {reference} has no layers")));
+    }
+    let layer_fetcher =
+        OciLayerFetcher::from_manifest_fetcher(&manifest_fetcher, LayerFetchOptions::default());
+    for layer in &layers {
+        let mut bytes = Vec::new();
+        layer_fetcher
+            .fetch_layer(&image_ref, layer, &mut bytes)
+            .await
+            .map_err(|e| backend_err(format!("fetch layer {}: {e}", layer.digest)))?;
+        unpack_one_layer(layer, &bytes, dest)?;
+    }
+    Ok(())
+}
+
+/// Unpack one layer's bytes into `dest`, decompressing gzip layers first.
+fn unpack_one_layer(layer: &LayerDescriptor, bytes: &[u8], dest: &Path) -> Result<()> {
+    let mt = &layer.media_type;
+    let report = if mt.ends_with("+gzip") || mt.ends_with(".gzip") || mt.contains("tar.gzip") {
+        unpack_layer(
+            GzDecoder::new(Cursor::new(bytes)),
+            dest,
+            &UnpackOptions::default(),
+        )
+    } else {
+        unpack_layer(Cursor::new(bytes), dest, &UnpackOptions::default())
+    }
+    .map_err(|e| backend_err(format!("unpack layer {}: {e}", layer.digest)))?;
+    if !report.refused.is_empty() {
         return Err(backend_err(format!(
-            "'{image}' is an unpacked rootfs directory; in-process materialization \
-             is not wired into the local backend yet — pre-materialize a rootfs.ext4 \
-             or use `mvmctl machine run`"
+            "layer {} unpack refused entries: {:?}",
+            layer.digest, report.refused
         )));
     }
-    Err(backend_err(format!(
-        "in-process local run expects a path to a materialized rootfs.ext4; '{image}' \
-         is neither a file nor a directory (registry pulls are not wired into the local \
-         backend — use `mvmctl machine run`)"
-    )))
+    Ok(())
 }
 
 /// Probe the dm-verity sidecars the pure materializer writes beside the image
@@ -137,7 +236,7 @@ impl MvmClient for LocalBackend {
     }
 
     async fn run_machine(&self, spec: MachineSpec) -> Result<MachineState> {
-        let rootfs = resolve_local_rootfs(&spec.image)?;
+        let rootfs = resolve_local_rootfs(&spec.image, &spec.name).await?;
         let (verity_path, roothash) = host_verity_sidecars(&rootfs);
 
         let req = LocalRunRequest {
@@ -146,7 +245,7 @@ impl MvmClient for LocalBackend {
             // libkrun/Vz/mock carry their own kernel; a Firecracker local run
             // that needs an explicit kernel path is a later slice.
             kernel_path: None,
-            verity_path: verity_path.map(std::path::PathBuf::from),
+            verity_path: verity_path.map(PathBuf::from),
             roothash,
             cpus: spec.cpus,
             mem_mib: spec.memory_mib,
@@ -231,20 +330,37 @@ mod tests {
         assert!(none.len() <= machines.len());
     }
 
-    #[tokio::test]
-    async fn run_refuses_unresolvable_image_ref() {
-        // A registry ref (neither a file nor a dir on this host) fails honestly
-        // — the local backend doesn't pull, and never boots without admission.
-        let be = LocalBackend::with_hypervisor("mock");
-        let spec = MachineSpec {
-            name: "w".into(),
-            image: "registry.example.com/app:latest".into(),
-            cpus: 1,
-            memory_mib: 64,
-            env: vec![],
-        };
-        let err = be.run_machine(spec).await.unwrap_err();
-        assert!(matches!(err, MvmError::Backend { .. }));
+    #[test]
+    fn classify_image_routes_file_dir_and_registry() {
+        let dir = tempfile::tempdir().unwrap();
+        let file = dir.path().join("rootfs.ext4");
+        std::fs::write(&file, b"x").unwrap();
+
+        // An existing file → a materialized rootfs.
+        assert_eq!(
+            classify_image(&file.to_string_lossy()),
+            ImageSource::Materialized(file.clone())
+        );
+        // An existing directory → an unpacked tree.
+        assert_eq!(
+            classify_image(&dir.path().to_string_lossy()),
+            ImageSource::UnpackedDir(dir.path().to_path_buf())
+        );
+        // Anything else → a registry reference (no network touched here).
+        assert_eq!(
+            classify_image("docker.io/library/alpine:3.20"),
+            ImageSource::Registry("docker.io/library/alpine:3.20".into())
+        );
+    }
+
+    #[test]
+    fn run_rootfs_output_is_name_sanitized_and_under_cache() {
+        let out = run_rootfs_output("my/app:1.2");
+        assert!(out.ends_with("rootfs.ext4"));
+        let s = out.to_string_lossy();
+        assert!(s.contains("local-run"));
+        // Path-hostile characters in the name are replaced.
+        assert!(s.contains("my_app_1_2"));
     }
 
     #[tokio::test]


### PR DESCRIPTION
## What

`LocalBackend::run_machine` now resolves **any** `spec.image`, not just a pre-materialized rootfs path:

- a `rootfs.ext4` **file** → boot directly (as before);
- an unpacked OCI rootfs **directory** → inject runtime + pure-materialize → boot;
- an OCI **registry ref** → pull + hardened-unpack every layer (mvm-oci) → the dir path.

All **in-process** — no subprocess, no CLI — through the same `admit_and_boot_local` seam, so a workload never boots on a path that skipped admission.

## Reuse, not duplication

The inject + materialize orchestration is **lifted out of mvm-cli into `mvm_build::run_image`** (`inject_and_materialize` / `materialize_run_rootfs` / `unpacked_tree_size`). `mvm-cli`'s `run --image` now **delegates** to it — the two former cli helpers + the builder-VM routing collapse to thin wrappers — and `mvm-client-local` calls the same code. One materialize path for both. The registry pull composes mvm-oci's fetch + unpacker directly (gzip decoded at this crate's boundary, keeping mvm-oci decompressor-free by design).

## Deps / budget / cycle

Deps added to `mvm-client-local` (`mvm-build[pure-mkfs]`, `mvm-oci`, `flate2`, `tokio`, `tempfile`) are **all already in the mvmctl closure** via the CLI — **budget stays 337**, no cycle (mvm-sdk / mvm-oci carry no back-edge here).

## Tests

- `classify_image` routes file / dir / registry; `run_rootfs_output` sanitizes the name under the cache; the pre-materialized boot test still passes over the mock backend.
- CLI's own image tests (45) still pass after the dedup; closure budget + dup-majors + fmt clean.
- The dir + registry **materialize** paths reuse the CLI-tested `run_image` code and the live `run --image` path already validated end-to-end on a real Vz microVM.

## Known limitation (inherited)

Guest-binary resolution still requires a source checkout — the **same** limitation the CLI's `run --image` has today; the shipped-runtime-overlay path is a separate, not-yet-wired concern (called out in the module doc).

🤖 Generated with [Claude Code](https://claude.com/claude-code)