### PR TITLE
docs(adr): ADR-107 virtiofs-root integrity decision + Plan 223 impl plan

### DIFF
--- a/specs/adrs/107-virtiofs-root-integrity.md
+++ b/specs/adrs/107-virtiofs-root-integrity.md
@@ -1,6 +1,6 @@
 # ADR-107: Integrity model for a virtiofs root filesystem
 
-- Status: Proposed
+- Status: Accepted
 - Date: 2026-07-04
 - Owner: MVM Project
 - Related: ADR-002 (microVM security posture — **claim 3**, threat model, tier

--- a/specs/adrs/107-virtiofs-root-integrity.md
+++ b/specs/adrs/107-virtiofs-root-integrity.md
@@ -1,0 +1,175 @@
+# ADR-107: Integrity model for a virtiofs root filesystem
+
+- Status: Proposed
+- Date: 2026-07-04
+- Owner: MVM Project
+- Related: ADR-002 (microVM security posture — **claim 3**, threat model, tier
+  matrix), ADR-106 (in-process rootfs materialization — Option B, block+verity),
+  ADR-050 (materialize + verity; ADR-106 supersedes its mechanism, preserves its
+  guarantee), ADR-051 (runtime overlay sealed like the rootfs), Plan 214
+  (in-house HVF VMM), Plan 221 (this is its Option A / A0 deliverable),
+  Plan 223 (virtiofs-root implementation, gated on this ADR).
+
+## Context
+
+Plan 221 Option A proposes booting a guest with the **unpacked OCI directory as
+a virtiofs root** — no ext4, no `mkfs`, no image at all. The host serves files
+to the guest on demand over virtiofs. This is the supermachine model and the
+Plan-214 in-house-HVF end state, and it deletes the last piece of
+image-materialization on the virtiofs-capable run path (Option B's in-process
+ext4 + dm-verity, ADR-106).
+
+It runs straight into **claim 3** ("a tampered rootfs ext4 fails to boot"):
+
+> dm-verity over the read-only ext4 lower layer; root hash on the (signed)
+> kernel cmdline; `mvm-verity-init` mounts it; the guest kernel panics before
+> userspace on a flipped data block.
+
+dm-verity is **block-device-specific**. A virtiofs root is a host *directory*,
+not a block device — there is no fixed block layout to build a Merkle tree over,
+and the guest kernel cannot dm-verity a filesystem it does not own the blocks
+of. So Option A cannot satisfy claim 3 by its current mechanism, and claim 3 is
+a **numbered security claim**. This ADR decides what integrity a virtiofs root
+provides, and therefore whether Option A can carry prod workloads.
+
+### What does claim 3 actually buy, given the threat model?
+
+ADR-002 puts a **trusted host** at the center: "mvmctl trusts the host with the
+hypervisor and private build keys… a malicious host is out of scope." So claim 3
+is **not** defending against a host that tampers with the rootfs at serve time.
+What it *does* buy, on top of the trusted host:
+
+1. **End-to-end binding of rootfs content to the signed plan.** The roothash
+   lives on the signed `ExecutionPlan` cmdline. The guest kernel enforces every
+   block against it. So the *bytes the guest actually executes* are
+   cryptographically tied to what was admitted — not to whatever happens to be
+   on disk at boot.
+2. **Detection of at-rest tampering / corruption between admit and boot.** A
+   flipped bit in `rootfs.ext4` — cache corruption, a stray writer, a swapped
+   file across reboots, a tampered published `.mvm` artifact or registry layer —
+   is caught at read time, not trusted blindly.
+3. **A guest-side enforcement point** independent of the host userspace that
+   assembled the image.
+
+For a virtiofs root, the content's authenticity is instead established **at pull
+/ unpack time**: `mvm-oci` verifies every layer's sha256 against the manifest,
+and `--prod` additionally cosign-verifies the resolved manifest digest before
+the layers are unpacked (ADR-002 claim 14). After that, the *trusted host*
+serves those exact files read-only. The gap versus claim 3 is precisely
+properties (1)–(3): there is **no guest-enforced, plan-bound, continuous
+re-verification** of the served files. A corruption or substitution of the
+unpacked tree *after* unpack and *before/while* the guest reads it is not caught
+by the guest — it rests entirely on the trusted-host axiom.
+
+### The candidate mechanisms
+
+- **(i) Per-file fs-verity.** Enable fs-verity on each file in the host tree and
+  have the guest verify each file's Merkle root against a signed manifest.
+  Problems: fs-verity is a **host-kernel** feature that virtiofs does not
+  transparently propagate to the guest; the guest would need its own enforcement
+  layer; it requires the host filesystem to support fs-verity (ext4/f2fs/btrfs
+  with the feature enabled); and it re-introduces a per-file Merkle build that is
+  most of the cost Option A set out to remove.
+- **(ii) Signed content manifest + guest-side verification.** Ship a manifest
+  (path → sha256 for every file), signed and bound to the plan; the guest
+  verifies files against it — either a full scan at mount (expensive: rehash the
+  whole tree in-guest on every boot) or lazily per-read via a FUSE/overlay shim
+  (complex: a new in-guest verification component on the read path). This is
+  essentially re-implementing dm-verity at the file layer inside the guest.
+- **(iii) Tiered posture.** Treat virtiofs-root as a **dev/local-tier** boot
+  mechanism whose integrity contract is *unpack-time verification + read-only
+  virtiofs + trusted host* — explicitly weaker than claim 3 — and keep **prod on
+  Option B** (block + ext4 + dm-verity), where claim 3 holds unchanged. This
+  mirrors the existing per-tier matrix, where dev/test tiers already carry
+  relaxed guarantees (e.g. the QEMU/microvm_nix builder deliberately omits
+  claim-10 egress enforcement as a Tier-2 dev/test backend).
+
+## Decision
+
+**Adopt (iii): virtiofs-root is a dev/local-tier mechanism; prod stays on
+Option B.** Concretely:
+
+1. **virtiofs-root does not witness claim 3.** Its integrity contract is a
+   distinct, explicitly weaker property:
+
+   > **Virtiofs-root integrity (dev tier).** The rootfs content is verified at
+   > unpack time (per-layer sha256 against the manifest; cosign on the manifest
+   > digest when a registry policy demands it), then served **read-only** from a
+   > trusted host over virtiofs. There is no guest-enforced, plan-bound
+   > re-verification of served files; integrity after unpack rests on the
+   > trusted-host axiom (ADR-002 threat model).
+
+   This is recorded as a documented posture, **not** promoted into ADR-002's
+   numbered claim-3 prose. The claims catalog gains a note that claim 3's
+   witness (dm-verity) applies to the **block+ext4** backends
+   (Firecracker + Option B), and that the virtiofs-root dev path carries the
+   weaker contract above.
+
+2. **Prod refuses virtiofs-root.** A sealed / `--prod` workload continues to
+   require Option B: in-process (or builder-VM) ext4 + dm-verity + roothash on
+   the signed cmdline. The run path selects virtiofs-root **only** for the
+   dev/local tier on virtiofs-capable backends (in-house HVF, libkrun, Vz);
+   `--prod` and any sealed-image admission path fall back to Option B, on every
+   backend. **Firecracker always uses Option B** (it has no virtiofs root
+   device; ADR-106).
+
+3. **A stronger path is left open but deferred.** If prod-on-virtiofs is ever
+   required, candidate (ii) — a plan-bound **signed content manifest** with
+   guest-side verification — is the promotion path to a claim-3-equivalent
+   guarantee, and would get its own ADR. Candidate (i) (fs-verity) is recorded
+   as considered-and-not-chosen for the reasons above. Nothing here forecloses
+   them; this ADR only declines to block Option A's dev-tier value on solving
+   prod-grade virtiofs integrity first.
+
+### Why this is the right call
+
+- **It respects the threat model rather than overclaiming.** The trusted host
+  already serves the guest's memory, devices, and vsock; a trusted host serving
+  a read-only, unpack-verified directory adds no new *host* trust. What it drops
+  versus claim 3 is defense-in-depth against **at-rest tampering between admit
+  and boot** — a real property, but one whose value is concentrated in the
+  **prod** distribution story (published artifacts, registry layers, long-lived
+  caches), exactly where we keep Option B.
+- **It keeps Option A's whole point.** Option A exists to delete
+  materialization on the fast dev/local loop. Gating it behind a full guest-side
+  file-verification subsystem would erase that win. The tiered decision ships the
+  dev-loop speedup now without weakening any *numbered* prod guarantee.
+- **It matches the existing architecture.** ADR-002 already grades guarantees by
+  tier; this is one more per-tier distinction, made explicit and CI-notable
+  rather than implicit.
+
+## Consequences
+
+- **Claim 3 is unchanged for prod and for Firecracker.** No numbered claim is
+  weakened. The claims catalog gains a scoping note (block+ext4 backends witness
+  claim 3; virtiofs-root dev path carries the weaker contract).
+- **The run path grows a tier gate.** Selecting virtiofs-root requires: a
+  virtiofs-capable backend, the dev/local tier, and a non-sealed / non-`--prod`
+  workload. Everything else routes to Option B. This gate is testable and is a
+  named deliverable of Plan 223.
+- **Unpack-time verification becomes load-bearing for the virtiofs path.** The
+  per-layer sha256 check in `mvm-oci` (and cosign for policy-gated pulls) is the
+  *only* content-authenticity step for a virtiofs boot, so it must run before the
+  tree is exposed to the guest and must fail closed. (It already does for the
+  materialize path; the virtiofs path must not bypass it.)
+- **Documentation debt is explicit, not hidden.** A reader of ADR-002 will find
+  claim 3 scoped to block+ext4 and a pointer to this ADR for the virtiofs-root
+  posture, so no one mistakes a dev-tier virtiofs boot for a claim-3 boot.
+
+## Alternatives considered
+
+- **Make virtiofs-root witness claim 3 via a signed manifest now (ii).** Correct
+  end state for prod-on-virtiofs, but it re-adds a full guest-side verification
+  component (mount-time rescan or per-read FUSE shim) that negates Option A's
+  performance rationale and is a large surface to get right. Deferred, not
+  rejected.
+- **fs-verity (i).** Host-fs-dependent, does not cross the virtiofs boundary to
+  the guest transparently, and re-introduces per-file Merkle builds. Rejected as
+  the primary mechanism.
+- **Ship virtiofs-root for all tiers and quietly relax claim 3.** Rejected:
+  claim 3 is CI-enforced and load-bearing for the prod distribution story;
+  silently weakening it to cover a dev optimization is exactly the overclaiming
+  ADR-002's discipline exists to prevent.
+- **Never ship virtiofs-root; keep Option B everywhere.** Rejected as the
+  default: it forfeits the dev-loop speedup and the Plan-214 end state for a
+  prod property the dev tier does not need. Option B remains the prod path.

--- a/specs/plans/221-in-process-rootfs-materialize.md
+++ b/specs/plans/221-in-process-rootfs-materialize.md
@@ -142,12 +142,15 @@ Boot the guest with the unpacked OCI dir as a **virtiofs root**. No ext4, no
 `mkfs`, no verity-of-a-block-device. This is supermachine's model and the
 Plan-214 in-house-HVF end state.
 
-> **Scoped out into its own docs.** The integrity decision is drafted as
-> **ADR-107** (`specs/adrs/107-virtiofs-root-integrity.md`, Proposed — tiered:
+> **Scoped out into its own docs.** The integrity decision is **ADR-107**
+> (`specs/adrs/107-virtiofs-root-integrity.md`, **Accepted** — tiered:
 > virtiofs-root is dev/local-tier, **prod stays on Option B**, claim 3 scoped to
 > block+ext4), and the phased implementation is **Plan 223**
-> (`specs/plans/223-virtiofs-root.md`), which is the live tracker and is gated on
-> ADR-107 being accepted. The A0–A5 sketch below is retained for context.
+> (`specs/plans/223-virtiofs-root.md`), the live tracker. Option A is
+> **deliberately parked** behind Plan 214's in-house-HVF virtiofs-root device:
+> Option B already meets the "no subprocess on the run path" goal, so Option A is
+> a later dev-loop optimization, not a gap. The A0–A5 sketch below is retained
+> for context.
 
 - **A0 — ADR-107 (the hard part).** Integrity model for a virtiofs root:
   dm-verity is block-device-specific and does **not** apply to a virtiofs dir, so

--- a/specs/plans/221-in-process-rootfs-materialize.md
+++ b/specs/plans/221-in-process-rootfs-materialize.md
@@ -142,6 +142,13 @@ Boot the guest with the unpacked OCI dir as a **virtiofs root**. No ext4, no
 `mkfs`, no verity-of-a-block-device. This is supermachine's model and the
 Plan-214 in-house-HVF end state.
 
+> **Scoped out into its own docs.** The integrity decision is drafted as
+> **ADR-107** (`specs/adrs/107-virtiofs-root-integrity.md`, Proposed — tiered:
+> virtiofs-root is dev/local-tier, **prod stays on Option B**, claim 3 scoped to
+> block+ext4), and the phased implementation is **Plan 223**
+> (`specs/plans/223-virtiofs-root.md`), which is the live tracker and is gated on
+> ADR-107 being accepted. The A0–A5 sketch below is retained for context.
+
 - **A0 — ADR-107 (the hard part).** Integrity model for a virtiofs root:
   dm-verity is block-device-specific and does **not** apply to a virtiofs dir, so
   **claim 3 needs a new mechanism**. Candidates: (i) trusted immutable host dir +

--- a/specs/plans/223-virtiofs-root.md
+++ b/specs/plans/223-virtiofs-root.md
@@ -1,0 +1,126 @@
+# Plan 223 — Virtiofs root filesystem (Plan 221 Option A)
+
+**Status:** proposed
+**Owner:** _tbd_
+**Related:** ADR-107 (virtiofs-root integrity — the gating decision), ADR-106
+(in-process materialize — Option B, block+verity, stays for prod + Firecracker),
+ADR-002 (security posture — claim 3, tier matrix), Plan 214 (in-house HVF VMM),
+Plan 221 (Option A lives here; B4 fallback stays), #1388 seam
+(`admit_and_start`).
+
+## Why
+
+Plan 221 Option B made the run-path materialize **in-process** (pure-Rust ext4 +
+dm-verity, no builder VM, no subprocess). Option A goes one step further for
+**virtiofs-capable backends**: boot the guest with the **unpacked OCI directory
+as a virtiofs root** — no ext4, no `mkfs`, no image at all. That is the
+supermachine model and the Plan-214 in-house-HVF end state; it deletes rootfs
+materialization entirely on the dev/local loop.
+
+The hard part was never the plumbing — it was the **integrity model**, because
+dm-verity (claim 3) is block-device-specific and a virtiofs root is a host
+directory. **ADR-107 settles that**: virtiofs-root is a **dev/local-tier**
+mechanism (unpack-time verification + read-only virtiofs + trusted host), and
+**prod stays on Option B** (block + ext4 + dm-verity), so no numbered claim is
+weakened. This plan implements Option A under that decision.
+
+## Non-goals
+
+- **Prod-on-virtiofs.** Sealed / `--prod` workloads keep Option B on every
+  backend (ADR-107 §Decision). A future signed-content-manifest path (ADR-107
+  candidate (ii)) is the only way that changes, and it is out of scope here.
+- **Firecracker.** Firecracker has no virtiofs root device; it always uses
+  Option B. This plan touches only the virtiofs-capable backends.
+- **Deleting Option B.** Option B remains the prod path, the Firecracker path,
+  and the Plan 221 B4 fallback.
+
+## Phases
+
+### A0 — Integrity decision (ADR-107) — **done**
+
+`specs/adrs/107-virtiofs-root-integrity.md` (Proposed). Decision: tiered posture,
+prod stays on Option B, claim 3 scoped to block+ext4. Everything below assumes
+that decision; if it is rejected in review, A1–A5 do not ship.
+
+### A1 — Virtiofs **root** device on virtiofs-capable backends
+
+libkrun and Vz already expose virtiofs *shares* (`krun_add_*` / `vz_objc.rs`
+`VZVirtioFileSystemDeviceConfiguration`); the in-house HVF backend (Plan 214)
+needs the same primitive. Extend all three to attach a **root** virtiofs device
+(tag `root`, or the conventional `virtiofs`/`myfs` tag the guest init expects)
+backed by the unpacked-tree host directory, read-only.
+
+- [ ] in-house HVF backend: attach a read-only virtiofs device for the root tree.
+- [ ] libkrun / Vz: confirm a share can serve as the root (tag + read-only).
+- [ ] host-side: the served directory is the unpack-verified tree; never a
+  writable or post-unpack-mutable path.
+
+### A2 — Guest boot model
+
+- [ ] kernel cmdline carries `rootfstype=virtiofs root=<tag>` (or the
+  equivalent the chosen VMM/kernel expects); the guest kernel has `VIRTIO_FS`
+  built in (already true for the Plan-209 managed-volume path).
+- [ ] `/init` mounts the virtiofs root read-only and pivots to it; the
+  `mvm-guest` agent + entrypoint run on a virtiofs root exactly as on ext4.
+- [ ] the mvm runtime injection (agent, netinit, `/mvm/runtime`,
+  `/etc/mvm/entrypoint`) is applied to the **unpacked tree on the host** before
+  it is served (reuse `mvm_build::oci_runtime_inject::inject_mvm_runtime`), so no
+  materialize step is needed — injection writes into the dir, virtiofs serves it.
+
+### A3 — Integrity enforcement per ADR-107 (dev tier)
+
+- [ ] unpack-time verification is **load-bearing and un-bypassable** on the
+  virtiofs path: per-layer sha256 (mvm-oci) + cosign when policy demands, run
+  **before** the tree is exposed to the guest, failing closed.
+- [ ] the served directory is mounted **read-only** in the guest and is not
+  mutated by the host after unpack (no writable overlay on the root; writable
+  state goes to a separate tmpfs/volume, as today).
+- [ ] audit: the admission log records that the boot used the virtiofs-root
+  dev-tier posture (so a reader can tell a dev virtiofs boot from an Option-B
+  claim-3 boot).
+
+### A4 — Run-path tier gate + wiring
+
+- [ ] a single selection gate: virtiofs-root is chosen **iff** the backend is
+  virtiofs-capable **and** the tier is dev/local **and** the workload is not
+  sealed / not `--prod`. Otherwise Option B (materialize + verity). Firecracker
+  and every prod/sealed path always take Option B.
+- [ ] wire the gate into the shared run orchestration
+  (`mvm_build::run_image` — the module Plan 221 Option B introduced and that the
+  CLI + `mvm-client` local backend already share), so both drivers get the same
+  virtiofs-vs-materialize decision.
+- [ ] the gate is unit-testable in isolation (backend capability × tier ×
+  sealed-flag → virtiofs | block).
+
+### A5 — Retire materialize for virtiofs-capable dev boots
+
+- [ ] on a virtiofs-capable dev boot, **no ext4 is produced** — the boot goes
+  straight from unpacked+injected dir → virtiofs root. Materialize
+  (`materialize_run_rootfs`) is not on that path.
+- [ ] Option B stays wired for: Firecracker (all tiers), prod/sealed (all
+  backends), and the Plan 221 B4 builder-VM fallback.
+
+## Validation
+
+- **Live boot.** `mvmctl run --image <ref>` on the in-house HVF backend (and Vz)
+  boots off a virtiofs root and round-trips the guest agent (the same marker
+  round-trip Option B was validated with on a live Vz microVM) — with **no**
+  `rootfs.ext4` produced on that path.
+- **Tier gate.** Automated: dev + virtiofs-capable → virtiofs; `--prod` → Option
+  B; Firecracker → Option B; sealed image → Option B.
+- **Integrity fail-closed.** A layer whose sha256 mismatches the manifest is
+  refused before the tree is ever served (regression test on the unpack gate).
+- **Claims catalog.** Add the ADR-107 scoping note: claim 3's witness
+  (dm-verity) is the block+ext4 backends; the virtiofs-root dev path carries the
+  weaker ADR-107 contract. `xtask check-claim-catalog` stays green.
+- **No numbered-claim regression.** Prod + Firecracker still witness claim 3
+  unchanged; the `verified-boot-artifacts` lane is untouched.
+
+## Sequencing / risk
+
+A1–A2 are backend + guest plumbing (Plan-214-adjacent; the in-house HVF backend
+is where the value concentrates). A3–A4 are the security-relevant gate and are
+where review attention should focus — the one-line risk is a path that reaches
+virtiofs-root for a prod/sealed workload, which A4's gate + A3's fail-closed
+unpack must make unrepresentable. A5 is cleanup once A1–A4 are proven. The whole
+plan is **gated on ADR-107 being accepted**; until then this is design only.

--- a/specs/plans/223-virtiofs-root.md
+++ b/specs/plans/223-virtiofs-root.md
@@ -36,11 +36,16 @@ weakened. This plan implements Option A under that decision.
 
 ## Phases
 
-### A0 — Integrity decision (ADR-107) — **done**
+### A0 — Integrity decision (ADR-107) — **done (Accepted)**
 
-`specs/adrs/107-virtiofs-root-integrity.md` (Proposed). Decision: tiered posture,
-prod stays on Option B, claim 3 scoped to block+ext4. Everything below assumes
-that decision; if it is rejected in review, A1–A5 do not ship.
+`specs/adrs/107-virtiofs-root-integrity.md` (**Accepted**). Decision: tiered
+posture, prod stays on Option B, claim 3 scoped to block+ext4. Everything below
+assumes that decision.
+
+**Parked.** A1–A5 are not scheduled: Option B already meets the "no subprocess
+on the run path" goal, so Option A is a dev-loop optimization, and A1 depends on
+Plan 214's in-house-HVF backend exposing a virtiofs **root** device. Pick this up
+when that lands; until then this plan is the accepted design, not active work.
 
 ### A1 — Virtiofs **root** device on virtiofs-capable backends
 
@@ -122,5 +127,6 @@ A1–A2 are backend + guest plumbing (Plan-214-adjacent; the in-house HVF backen
 is where the value concentrates). A3–A4 are the security-relevant gate and are
 where review attention should focus — the one-line risk is a path that reaches
 virtiofs-root for a prod/sealed workload, which A4's gate + A3's fail-closed
-unpack must make unrepresentable. A5 is cleanup once A1–A4 are proven. The whole
-plan is **gated on ADR-107 being accepted**; until then this is design only.
+unpack must make unrepresentable. A5 is cleanup once A1–A4 are proven. ADR-107 is
+accepted, so the design is settled; scheduling waits on Plan 214's in-house-HVF
+virtiofs-root device (see A0 — parked).


### PR DESCRIPTION
Drafts the gating decision + phased plan for **Plan 221 Option A** (boot a virtiofs root off the unpacked OCI dir, deleting rootfs materialization on the virtiofs-capable path).

## The problem

Option A collides with **claim 3**: dm-verity is block-device-specific, and a virtiofs root is a host *directory* — the numbered rootfs-integrity claim has no mechanism there.

## ADR-107 — the decision (Proposed)

**Tiered posture.** virtiofs-root is a **dev/local-tier** mechanism whose integrity contract is *unpack-time verification (mvm-oci per-layer sha256 + cosign when policy demands) + read-only virtiofs + trusted host* — explicitly weaker than claim 3 and **not** a claim-3 witness. **Prod / sealed workloads and Firecracker stay on Option B** (block + ext4 + dm-verity), so **no numbered claim is weakened**.

The reasoning is grounded in the ADR-002 threat model (trusted host): what claim 3 buys *on top of* a trusted host is end-to-end plan-bound binding + detection of at-rest tampering between admit and boot — value concentrated in the **prod distribution story**, exactly where Option B stays. A signed-content-manifest path (candidate ii) is left open as the future promotion to prod-on-virtiofs; fs-verity (i) is considered-and-declined with reasons.

## Plan 223 — the implementation

Sequences A1–A5 under that decision: virtiofs root device on the virtiofs-capable backends → guest boot model → fail-closed unpack-time integrity → the **run-path tier gate** (the security-critical piece: virtiofs-root is unrepresentable for prod/sealed) → retire materialize for virtiofs-capable dev boots. All gated on ADR-107 being accepted.

Plan 221's Option A section now points at both.

## Gates

Doc gates green: `check-spec-numbers` (107/223 unique), `check-no-overclaim`, `check-doc-claims`, `check-adr-coverage` (ADR-107 resolves prior forward-refs, 0 broken).

**Decision doc — needs a maintainer accept** before Plan 223 implementation starts.

🤖 Generated with [Claude Code](https://claude.com/claude-code)