### PR TITLE
feat(machine): positional name for `machine start` + confirm prompt on `machine stop`

### DIFF
--- a/crates/mvm-cli/src/commands/build/kernel.rs
+++ b/crates/mvm-cli/src/commands/build/kernel.rs
@@ -233,7 +233,7 @@ fn run_boot_check(
     }
     let exe = std::env::current_exe().context("locating mvmctl for --boot-check")?;
     let name = "kernel-bootcheck";
-    let _ = run_self(&exe, &["machine", "stop", name]); // clear any stale VM
+    let _ = run_self(&exe, &["machine", "stop", name, "--yes"]); // clear any stale VM
 
     // Force libkrun: it's available wherever `--source compile` ran (it drives
     // Stage 0), so the check is deterministic and doesn't depend on the host's
@@ -256,7 +256,7 @@ fn run_boot_check(
     .context("boot-check: `up` failed to launch the VM")?;
 
     let booted = run_self(&exe, &["machine", "wait", name]);
-    let _ = run_self(&exe, &["machine", "stop", name]);
+    let _ = run_self(&exe, &["machine", "stop", name, "--yes"]);
     booted.context("boot-check: the guest agent never became ready")?;
     ui::success("boot-check: the new kernel boots and the agent answered over vsock");
     Ok(())

--- a/crates/mvm-cli/src/commands/machine/mod.rs
+++ b/crates/mvm-cli/src/commands/machine/mod.rs
@@ -750,7 +750,7 @@ pub(in crate::commands) struct MachineRemoveArgs {
 #[derive(ClapArgs, Debug, Clone)]
 pub(in crate::commands) struct MachineStartArgs {
     /// Persistent machine name.
-    #[arg(long)]
+    #[arg(value_name = "NAME")]
     pub name: String,
     /// Write a signed machine-start receipt to this path.
     #[arg(long, value_name = "PATH")]
@@ -828,6 +828,9 @@ pub(in crate::commands) struct MachineStopArgs {
     /// Stop all running VMs.
     #[arg(long, conflicts_with = "name")]
     pub all: bool,
+    /// Skip the interactive confirmation prompt.
+    #[arg(long)]
+    pub yes: bool,
 }
 
 #[derive(Debug, Serialize)]
@@ -2110,6 +2113,16 @@ fn shell_machine(cli: &Cli, args: MachineShellArgs, cfg: &MvmConfig) -> Result<(
 }
 
 fn stop_machine(cli: &Cli, args: MachineStopArgs, cfg: &MvmConfig) -> Result<()> {
+    if !args.yes {
+        let prompt = match args.name.as_deref() {
+            Some(name) => format!("Stop machine {name:?}?"),
+            None => "Stop all running machines?".to_string(),
+        };
+        if !crate::ui::confirm(&prompt) {
+            println!("aborted");
+            return Ok(());
+        }
+    }
     if let Some(ref name) = args.name {
         reap_proxy(name);
     }
@@ -3567,7 +3580,6 @@ mod tests {
         }
         match parse(&[
             "start",
-            "--name",
             "web",
             "--receipt",
             "/tmp/web.receipt.json",
@@ -3639,12 +3651,12 @@ mod tests {
     fn start_quiet_is_internal_only_and_defaults_off() {
         // `quiet` is not a user-facing flag — the standalone `machine start`
         // and the detached path must keep printing the boot banner.
-        match parse(&["start", "--name", "web"]).expect("parse") {
+        match parse(&["start", "web"]).expect("parse") {
             MachineAction::Start(args) => assert!(!args.quiet),
             other => panic!("expected start action, got {other:?}"),
         }
         assert!(
-            parse(&["start", "--name", "web", "--quiet"]).is_err(),
+            parse(&["start", "web", "--quiet"]).is_err(),
             "--quiet must not be exposed as a CLI flag"
         );
     }
@@ -4524,7 +4536,6 @@ ssh_agent = true
             "mvmctl",
             "machine",
             "start",
-            "--name",
             "web",
             "--receipt",
             "/tmp/web.receipt.json",
@@ -4573,6 +4584,7 @@ ssh_agent = true
             MachineAction::Stop(args) => {
                 assert_eq!(args.name.as_deref(), Some("web"));
                 assert!(!args.all);
+                assert!(!args.yes, "confirmation is required by default");
             }
             other => panic!("expected stop action, got {other:?}"),
         }
@@ -4580,6 +4592,25 @@ ssh_agent = true
             MachineAction::Stop(args) => {
                 assert!(args.name.is_none());
                 assert!(args.all);
+                assert!(!args.yes);
+            }
+            other => panic!("expected stop action, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn machine_stop_yes_skips_confirmation() {
+        match parse(&["stop", "web", "--yes"]).expect("parse named --yes") {
+            MachineAction::Stop(args) => {
+                assert_eq!(args.name.as_deref(), Some("web"));
+                assert!(args.yes);
+            }
+            other => panic!("expected stop action, got {other:?}"),
+        }
+        match parse(&["stop", "--all", "--yes"]).expect("parse --all --yes") {
+            MachineAction::Stop(args) => {
+                assert!(args.all);
+                assert!(args.yes);
             }
             other => panic!("expected stop action, got {other:?}"),
         }

--- a/crates/mvm-cli/tests/core_demo_e2e.rs
+++ b/crates/mvm-cli/tests/core_demo_e2e.rs
@@ -331,7 +331,7 @@ fn core_demo_dev_compile_up_ping() {
 
     // 4) tear down the workload and builder (best-effort, still bounded).
     let _ = mvmctl(
-        &["machine", "stop", WORKLOAD_NAME],
+        &["machine", "stop", WORKLOAD_NAME, "--yes"],
         &scratch,
         "machine-stop",
         DOWN_BUDGET,

--- a/crates/mvm-sdk/src/machine.rs
+++ b/crates/mvm-sdk/src/machine.rs
@@ -643,7 +643,8 @@ impl MachineStartBuilder {
     /// Return the `machine` subcommand argv, excluding the `mvmctl` program.
     pub fn machine_args(&self) -> Result<Vec<String>, MachineError> {
         let name = require_non_empty(self.name.clone(), "name")?;
-        let mut args = vec!["start".to_string(), "--name".to_string(), name];
+        // `machine start` takes a positional name, not `--name`.
+        let mut args = vec!["start".to_string(), name];
         append_optional(&mut args, "--receipt", self.receipt.as_deref())?;
         if self.json {
             args.push("--json".to_string());
@@ -766,8 +767,10 @@ impl MachineStopBuilder {
     pub fn machine_args(&self) -> Result<Vec<String>, MachineError> {
         let name = require_non_empty(self.name.clone(), "name")?;
         // `machine stop` takes a positional name, not `--name` (the CLI parser
-        // rejects the flag form). See the shared `stop.argv` fixture.
-        Ok(vec!["stop".to_string(), name])
+        // rejects the flag form). See the shared `stop.argv` fixture. Pass
+        // `--yes` because the SDK runs the CLI non-interactively — without it
+        // `machine stop` prompts for y/n confirmation and aborts on no TTY.
+        Ok(vec!["stop".to_string(), name, "--yes".to_string()])
     }
 
     /// Execute this builder with the default [`MachineClient`].

--- a/crates/mvm-sdk/tests/machine.rs
+++ b/crates/mvm-sdk/tests/machine.rs
@@ -211,7 +211,6 @@ fn persistent_machine_lifecycle_builders_reuse_machine_cli() {
         [
             "machine",
             "start",
-            "--name",
             "devbox",
             "--receipt",
             "/tmp/start.json",
@@ -243,8 +242,9 @@ fn persistent_machine_lifecycle_builders_reuse_machine_cli() {
     );
 
     machine.stop().run_with(&client).expect("stop");
-    // `machine stop` takes a positional name, not `--name`.
-    assert_eq!(fake.argv(), ["machine", "stop", "devbox"]);
+    // `machine stop` takes a positional name, not `--name`, plus `--yes` to
+    // skip the interactive confirmation prompt when the SDK shells out.
+    assert_eq!(fake.argv(), ["machine", "stop", "devbox", "--yes"]);
 }
 
 #[test]

--- a/public/src/content/docs/getting-started/quickstart.md
+++ b/public/src/content/docs/getting-started/quickstart.md
@@ -36,9 +36,9 @@ For a named machine that survives across starts:
 
 ```bash
 mvmctl machine create --name alpine-dev --image alpine
-mvmctl machine start --name alpine-dev
+mvmctl machine start alpine-dev
 mvmctl machine exec --name alpine-dev -- uname -a
-mvmctl machine stop --name alpine-dev
+mvmctl machine stop alpine-dev
 ```
 
 ## 2. Launch the Dev Environment

--- a/public/src/content/docs/guides/machine-use-cases.md
+++ b/public/src/content/docs/guides/machine-use-cases.md
@@ -56,10 +56,10 @@ Use named machines when you want state across starts:
 
 ```bash
 mvmctl machine create --name alpine-dev --image alpine:3.20 --net
-mvmctl machine start --name alpine-dev
+mvmctl machine start alpine-dev
 mvmctl machine exec --name alpine-dev -- apk add jq
 mvmctl machine shell --name alpine-dev
-mvmctl machine stop --name alpine-dev
+mvmctl machine stop alpine-dev
 ```
 
 The durable spec is stored under the mvm data directory, not in your source tree.
@@ -84,7 +84,7 @@ ssh_agent = true
 
 ```bash
 mvmctl machine create --name js-dev --manifest ./mvm.toml
-mvmctl machine start --name js-dev
+mvmctl machine start js-dev
 ```
 
 Unknown manifest keys are rejected. That is intentional: typos should not

--- a/public/src/content/docs/guides/manifests.md
+++ b/public/src/content/docs/guides/manifests.md
@@ -104,7 +104,7 @@ volumes = ["./workspace:/work:ro"]
 
 ```bash
 mvmctl machine create --name alpine-dev --manifest ./mvm.toml
-mvmctl machine start --name alpine-dev
+mvmctl machine start alpine-dev
 ```
 
 `machine create` stores a strict JSON spec under `MVM_DATA_DIR`, and

--- a/public/src/content/docs/guides/troubleshooting.md
+++ b/public/src/content/docs/guides/troubleshooting.md
@@ -246,7 +246,7 @@ with no other config flags — a matching config reuses the running machine.
 mvmctl machine ls                 # list persisted machines
 mvmctl machine shell --name <N>   # interactive shell (dev)
 mvmctl machine exec  --name <N> -- <cmd>   # one-shot command
-mvmctl machine stop  --name <N>   # tear it down
+mvmctl machine stop  <N>          # tear it down (prompts; add --yes to skip)
 ```
 
 ## Network Issues

--- a/public/src/content/docs/reference/cli-commands.md
+++ b/public/src/content/docs/reference/cli-commands.md
@@ -405,11 +405,11 @@ or mounts private keys, `~/.ssh`, known-hosts material, or SSH config.
 | `mvmctl machine create --name <name> --image <ref> --net --allow-host <host[:port]>` | Persist a named spec with opt-in egress settings for future lifecycle starts |
 | `mvmctl machine create --name <name> --manifest <path>` | Persist an image-backed `mvm.toml` / `Mvmfile.toml` as a named machine spec |
 | `mvmctl machine create --name <name> --image <ref> --force` | Overwrite an existing named machine spec |
-| `mvmctl machine start --name <name>` | Boot a persisted named machine through the admitted OCI-backed start path |
-| `mvmctl machine start --name <name> --dry-run` | Validate and explain the effective machine-start policy without booting a VM |
-| `mvmctl machine start --name <name> --dry-run --json` | Print the machine-start preflight summary as redacted JSON |
-| `mvmctl machine start --name <name> --json` | Print a redacted JSON start summary instead of plain text |
-| `mvmctl machine start --name <name> --receipt <path>` | Write a signed machine-start receipt with effective policy plus the resolved digest and start timestamp |
+| `mvmctl machine start <name>` | Boot a persisted named machine through the admitted OCI-backed start path |
+| `mvmctl machine start <name> --dry-run` | Validate and explain the effective machine-start policy without booting a VM |
+| `mvmctl machine start <name> --dry-run --json` | Print the machine-start preflight summary as redacted JSON |
+| `mvmctl machine start <name> --json` | Print a redacted JSON start summary instead of plain text |
+| `mvmctl machine start <name> --receipt <path>` | Write a signed machine-start receipt with effective policy plus the resolved digest and start timestamp |
 | `mvmctl machine ls` | List persisted named machine specs |
 | `mvmctl machine ls --json` | Print persisted named machine specs as JSON |
 | `mvmctl machine inspect <name>` | Show one persisted named machine spec |
@@ -420,7 +420,7 @@ or mounts private keys, `~/.ssh`, known-hosts material, or SSH config.
 | `mvmctl machine exec --name <name> -- <cmd>...` | Run a command in an already-started named machine |
 | `mvmctl machine exec --name <name> -it -- <cmd>...` | Run a command in an already-started named machine attached to a PTY |
 | `mvmctl machine shell --name <name>` | Attach an interactive shell/console to an already-started named machine |
-| `mvmctl machine stop --name <name>` | Stop an already-started named machine |
+| `mvmctl machine stop <name>` | Stop an already-started named machine (prompts for confirmation; pass `--yes` to skip) |
 | `mvmctl machine check-artifact <artifact.mvm>` | Verify a portable artifact and preview its admission posture without extracting or booting |
 | `mvmctl machine check-artifact <artifact.mvm> --key <pubkey>` | Verify with an explicit raw Ed25519 public key |
 | `mvmctl machine check-artifact <artifact.mvm> --json` | Print the verified artifact/admission preview as JSON |
@@ -458,7 +458,7 @@ mvmctl machine run -d --image alpine          # boots, prints e.g. "blue-fox-3f2
 mvmctl machine shell --name blue-fox-3f2a     # reconnect (dev PTY)
 mvmctl machine exec  --name blue-fox-3f2a -- ps   # one-shot command in the running machine
 mvmctl machine exec  --name blue-fox-3f2a -it -- /bin/sh   # PTY command in the running machine
-mvmctl machine stop  --name blue-fox-3f2a     # tear it down when done
+mvmctl machine stop  blue-fox-3f2a --yes      # tear it down when done
 ```
 
 `-d --name <N>` does the same with a name you choose.

--- a/sdks/machine-fixtures/start.argv
+++ b/sdks/machine-fixtures/start.argv
@@ -1,5 +1,4 @@
 start
---name
 web
 --receipt
 /tmp/mvm-sdk-machine.receipt.json

--- a/sdks/machine-fixtures/stop.argv
+++ b/sdks/machine-fixtures/stop.argv
@@ -1,2 +1,3 @@
 stop
 web
+--yes

--- a/sdks/python/mvm/_machine.py
+++ b/sdks/python/mvm/_machine.py
@@ -217,7 +217,8 @@ def _machine_start_argv(
     json: bool = False,
     dry_run: bool = False,
 ) -> list[str]:
-    argv = ["start", "--name", _require_non_empty_str(name, "name")]
+    # `machine start` takes a positional name, not `--name`.
+    argv = ["start", _require_non_empty_str(name, "name")]
     if receipt is not None:
         argv.extend(["--receipt", _require_non_empty_str(receipt, "receipt")])
     if json:
@@ -252,8 +253,10 @@ def _machine_shell_argv(*, name: str, force: bool = False) -> list[str]:
 
 def _machine_stop_argv(*, name: str) -> list[str]:
     # `machine stop` takes a positional name, not `--name` (the CLI rejects the
-    # flag form). See the shared `stop.argv` fixture.
-    return ["stop", _require_non_empty_str(name, "name")]
+    # flag form). See the shared `stop.argv` fixture. Pass `--yes` because the
+    # SDK runs the CLI non-interactively — without it `machine stop` prompts for
+    # y/n confirmation and aborts on no TTY.
+    return ["stop", _require_non_empty_str(name, "name"), "--yes"]
 
 
 def _machine_ls_argv(*, json: bool = False) -> list[str]:

--- a/sdks/python/mvm/_sandbox.py
+++ b/sdks/python/mvm/_sandbox.py
@@ -840,7 +840,9 @@ class _LiveTransport:
             if proc.poll() is None:
                 proc.terminate()
         self._forwards.clear()
-        shell = [self.mvm_cli_bin, "machine", "stop", self.vm_id]
+        # `--yes` skips the interactive confirmation prompt; the sandbox tears
+        # down non-interactively.
+        shell = [self.mvm_cli_bin, "machine", "stop", self.vm_id, "--yes"]
         try:
             result = subprocess.run(
                 shell,

--- a/sdks/python/tests/test_machine.py
+++ b/sdks/python/tests/test_machine.py
@@ -221,7 +221,7 @@ def test_machine_persistent_lifecycle_shells_to_cli(tmp_path: Path) -> None:
     assert "verb=create" in text
     assert "--name devbox --manifest mvm.toml --profile dev --force" in text
     assert "verb=start" in text
-    assert "--name devbox --dry-run" in text
+    assert "devbox --dry-run" in text
     assert "verb=exec" in text
     assert "--name devbox --force -- echo hi" in text
     assert "verb=shell" in text

--- a/sdks/python/tests/test_sandbox_live.py
+++ b/sdks/python/tests/test_sandbox_live.py
@@ -323,7 +323,7 @@ def test_kill_shells_to_mvmctl_down(tmp_path: Path) -> None:
     sb.kill()
 
     calls = _read_fixture_log(tmp_path)
-    assert any(c == "machine stop sb-kill-vm" for c in calls)
+    assert any(c == "machine stop sb-kill-vm --yes" for c in calls)
 
 
 def test_context_manager_kills_on_exit(tmp_path: Path) -> None:

--- a/sdks/typescript/src/_machine.ts
+++ b/sdks/typescript/src/_machine.ts
@@ -208,7 +208,8 @@ export function machineCheckArtifactArgv(options: MachineCheckArtifactOptions): 
 }
 
 export function machineStartArgv(name: string, options: MachineStartOptions = {}): string[] {
-  const argv = ["start", "--name", requireString(name, "name")];
+  // `machine start` takes a positional name, not `--name`.
+  const argv = ["start", requireString(name, "name")];
   if (options.receipt !== undefined) argv.push("--receipt", requireString(options.receipt, "receipt"));
   if (options.json) argv.push("--json");
   if (options.dryRun) argv.push("--dry-run");
@@ -236,8 +237,10 @@ export function machineShellArgv(name: string, options: MachineShellOptions = {}
 
 export function machineStopArgv(name: string): string[] {
   // `machine stop` takes a positional name, not `--name` (the CLI rejects the
-  // flag form). See the shared `stop.argv` fixture.
-  return ["stop", requireString(name, "name")];
+  // flag form). See the shared `stop.argv` fixture. Pass `--yes` because the
+  // SDK runs the CLI non-interactively — without it `machine stop` prompts for
+  // y/n confirmation and aborts on no TTY.
+  return ["stop", requireString(name, "name"), "--yes"];
 }
 
 export function machineLsArgv(options: MachineLsOptions = {}): string[] {

--- a/sdks/typescript/src/_sandbox.ts
+++ b/sdks/typescript/src/_sandbox.ts
@@ -697,7 +697,9 @@ export class LiveTransport {
       }
     }
     this.forwards = [];
-    const shell = [this.mvmCliBin, "machine", "stop", this.vmId];
+    // `--yes` skips the interactive confirmation prompt; the sandbox tears down
+    // non-interactively.
+    const shell = [this.mvmCliBin, "machine", "stop", this.vmId, "--yes"];
     // eslint-disable-next-line @typescript-eslint/no-require-imports
     const child = require("node:child_process") as typeof import("node:child_process");
     try {

--- a/sdks/typescript/tests/machine.test.ts
+++ b/sdks/typescript/tests/machine.test.ts
@@ -193,10 +193,10 @@ describe("Machine persistent lifecycle", () => {
 
     const text = readFixtureLog().join("\n");
     expect(text).toContain("machine:create --name devbox --manifest mvm.toml --profile dev --force");
-    expect(text).toContain("machine:start --name devbox --dry-run");
+    expect(text).toContain("machine:start devbox --dry-run");
     expect(text).toContain("machine:exec --name devbox --force -- echo hi");
     expect(text).toContain("machine:shell --name devbox --force");
-    expect(text).toContain("machine:stop devbox");
+    expect(text).toContain("machine:stop devbox --yes");
   });
 
   it("emits the shared start/exec/shell/stop argv fixtures", () => {

--- a/sdks/typescript/tests/sandbox_live.test.ts
+++ b/sdks/typescript/tests/sandbox_live.test.ts
@@ -311,7 +311,7 @@ describe("Sandbox.kill (live mode)", () => {
     sb.kill();
 
     const calls = readFixtureLog();
-    expect(calls).toContain("machine stop sb-kill-vm");
+    expect(calls).toContain("machine stop sb-kill-vm --yes");
   });
 
   it("[Symbol.dispose] kills once", () => {

--- a/tests/audit_emissions_live.rs
+++ b/tests/audit_emissions_live.rs
@@ -1179,7 +1179,7 @@ fn machine_stop_all_emits_vm_stop_audit_entry() {
     let sandbox = AuditSandbox::new();
     let output = sandbox
         .mvmctl()
-        .args(["machine", "stop", "--all"])
+        .args(["machine", "stop", "--all", "--yes"])
         .output()
         .expect("spawn mvmctl");
     assert!(
@@ -1208,7 +1208,7 @@ fn machine_stop_with_name_emits_vm_stop_for_that_name() {
     let sandbox = AuditSandbox::new();
     let output = sandbox
         .mvmctl()
-        .args(["machine", "stop", "ghost-vm"])
+        .args(["machine", "stop", "ghost-vm", "--yes"])
         .output()
         .expect("spawn mvmctl");
     assert!(


### PR DESCRIPTION
## What

Two small beginner-facing DX changes to the `machine` lifecycle verbs, from a DX exploration session:

1. **`machine start <name>`** — the machine name is now a positional argument instead of `--name <name>`. This matches `inspect <name>`, `rm <name>...`, `logs <name>`, and `stop <name>`, plus the docker/podman convention (`docker start <name>`).

2. **`machine stop <name>` / `machine stop --all`** — now prompts for a y/n confirmation unless `--yes` is passed. Confirmation defaults to *no*; a non-interactive stdin declines and prints `aborted`, so scripts fail safe rather than tearing down a VM by surprise.

## Why

Beginner ergonomics: the positional name reads more naturally and is consistent with the sibling verbs, and a destructive `stop` shouldn't fire without a confirm (or an explicit `--yes`).

## Cross-language contract

The `machine` argv is a shared contract across the Rust/Python/TS SDK builders, the golden fixtures in `sdks/machine-fixtures/`, and a CLI round-trip test. All of it moves together:

- `sdks/machine-fixtures/start.argv` drops `--name`; `stop.argv` gains `--yes`.
- SDK `start` builders emit a positional name; SDK `stop` builders + the Python/TS sandbox teardown paths append `--yes` (they shell the CLI non-interactively, where the new prompt would otherwise abort them).
- Docs updated; several pre-existing `machine stop --name` examples the CLI never actually accepted were corrected to positional.

## Verification

- `cargo fmt --all --check` ✓ · clippy `-D warnings` (mvm-cli, mvm-sdk) ✓
- Rust: 1558 tests + doctests ✓
- Python SDK: 58 ✓ · TypeScript SDK: 52 ✓
- Runtime: help output correct; `stop` prompts/aborts on piped stdin, `--yes` skips; `start <name>` accepted, `start --name` rejected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)