### PR TITLE
feat(machine): positional name for `machine exec` / `machine shell`

### DIFF
--- a/crates/mvm-cli/src/commands/machine/mod.rs
+++ b/crates/mvm-cli/src/commands/machine/mod.rs
@@ -339,7 +339,7 @@ impl MachineRunArgs {
     fn resolve_mode(&self) -> Result<MachineRunMode> {
         let mode = match (self.interactive(), self.persistent()) {
             (true, true) => bail!(
-                "`machine run -it` is foreground-only; use `machine exec --name <name> -it -- <cmd>` for an interactive command in a long-lived machine"
+                "`machine run -it` is foreground-only; use `machine exec <name> -it -- <cmd>` for an interactive command in a long-lived machine"
             ),
             (false, true) => MachineRunMode::Persistent,
             // Fresh-boot modes always materialize a new VM and need an image.
@@ -790,7 +790,7 @@ pub(in crate::commands) struct MachineStartArgs {
 #[derive(ClapArgs, Debug, Clone)]
 pub(in crate::commands) struct MachineExecArgs {
     /// Persistent machine name.
-    #[arg(long)]
+    #[arg(value_name = "NAME")]
     pub name: String,
     /// Bypass the sealed-image accessibility check.
     #[arg(long)]
@@ -809,7 +809,7 @@ pub(in crate::commands) struct MachineExecArgs {
 #[derive(ClapArgs, Debug, Clone)]
 pub(in crate::commands) struct MachineShellArgs {
     /// Persistent machine name.
-    #[arg(long)]
+    #[arg(value_name = "NAME")]
     pub name: String,
     /// Bypass the sealed-image accessibility check.
     #[arg(long)]
@@ -3676,7 +3676,7 @@ mod tests {
 
     #[test]
     fn exec_shell_and_stop_parse() {
-        match parse(&["exec", "--name", "web", "--", "echo", "hello world"]).expect("parse") {
+        match parse(&["exec", "web", "--", "echo", "hello world"]).expect("parse") {
             MachineAction::Exec(args) => {
                 assert_eq!(args.name, "web");
                 assert_eq!(args.argv, vec!["echo", "hello world"]);
@@ -3686,7 +3686,7 @@ mod tests {
             }
             other => panic!("expected exec action, got {other:?}"),
         }
-        match parse(&["shell", "--name", "web", "--force"]).expect("parse") {
+        match parse(&["shell", "web", "--force"]).expect("parse") {
             MachineAction::Shell(args) => {
                 assert_eq!(args.name, "web");
                 assert!(args.force);
@@ -3704,13 +3704,13 @@ mod tests {
 
     #[test]
     fn exec_requires_argv() {
-        let err = parse(&["exec", "--name", "web"]).expect_err("argv is required");
+        let err = parse(&["exec", "web"]).expect_err("argv is required");
         assert_eq!(err.kind(), clap::error::ErrorKind::MissingRequiredArgument);
     }
 
     #[test]
     fn exec_accepts_it_for_pty_command() {
-        match parse(&["exec", "--name", "web", "-it", "--", "/bin/sh"]).expect("parse") {
+        match parse(&["exec", "web", "-it", "--", "/bin/sh"]).expect("parse") {
             MachineAction::Exec(args) => {
                 assert_eq!(args.name, "web");
                 assert!(args.tty);
@@ -4575,10 +4575,8 @@ ssh_agent = true
 
     #[test]
     fn top_level_cli_routes_machine_exec() {
-        let cli = Cli::try_parse_from([
-            "mvmctl", "machine", "exec", "--name", "web", "--", "echo", "hi",
-        ])
-        .expect("top-level parse");
+        let cli = Cli::try_parse_from(["mvmctl", "machine", "exec", "web", "--", "echo", "hi"])
+            .expect("top-level parse");
         match cli.command {
             Commands::Machine(args) => match args.action {
                 MachineAction::Exec(exec) => {

--- a/crates/mvm-sdk/src/facade.rs
+++ b/crates/mvm-sdk/src/facade.rs
@@ -459,7 +459,7 @@ mod tests {
         let cmd = vec!["sh".to_string(), "-lc".to_string(), "echo ok".to_string()];
         assert_eq!(
             exec_args(&id, cmd).unwrap(),
-            vec!["exec", "--name", "web", "--", "sh", "-lc", "echo ok"]
+            vec!["exec", "web", "--", "sh", "-lc", "echo ok"]
         );
     }
 }

--- a/crates/mvm-sdk/src/machine.rs
+++ b/crates/mvm-sdk/src/machine.rs
@@ -149,7 +149,7 @@ impl Machine {
         MachineStartBuilder::new(self.name.clone())
     }
 
-    /// Build a `mvmctl machine exec --name <name> -- <command...>` invocation.
+    /// Build a `mvmctl machine exec <name> -- <command...>` invocation.
     pub fn exec<I, S>(&self, command: I) -> MachineExecBuilder
     where
         I: IntoIterator<Item = S>,
@@ -158,7 +158,7 @@ impl Machine {
         MachineExecBuilder::new(self.name.clone(), collect_strings(command))
     }
 
-    /// Build a `mvmctl machine shell --name <name>` invocation.
+    /// Build a `mvmctl machine shell <name>` invocation.
     pub fn shell(&self) -> MachineShellBuilder {
         MachineShellBuilder::new(self.name.clone())
     }
@@ -693,7 +693,8 @@ impl MachineExecBuilder {
     pub fn machine_args(&self) -> Result<Vec<String>, MachineError> {
         let name = require_non_empty(self.name.clone(), "name")?;
         require_non_empty_slice(&self.command, "command")?;
-        let mut args = vec!["exec".to_string(), "--name".to_string(), name];
+        // `machine exec` takes a positional name, not `--name`.
+        let mut args = vec!["exec".to_string(), name];
         if self.force {
             args.push("--force".to_string());
         }
@@ -734,7 +735,8 @@ impl MachineShellBuilder {
     /// Return the `machine` subcommand argv, excluding the `mvmctl` program.
     pub fn machine_args(&self) -> Result<Vec<String>, MachineError> {
         let name = require_non_empty(self.name.clone(), "name")?;
-        let mut args = vec!["shell".to_string(), "--name".to_string(), name];
+        // `machine shell` takes a positional name, not `--name`.
+        let mut args = vec!["shell".to_string(), name];
         if self.force {
             args.push("--force".to_string());
         }

--- a/crates/mvm-sdk/tests/machine.rs
+++ b/crates/mvm-sdk/tests/machine.rs
@@ -226,9 +226,7 @@ fn persistent_machine_lifecycle_builders_reuse_machine_cli() {
         .expect("exec");
     assert_eq!(
         fake.argv(),
-        [
-            "machine", "exec", "--name", "devbox", "--force", "--", "echo", "hi",
-        ]
+        ["machine", "exec", "devbox", "--force", "--", "echo", "hi",]
     );
 
     machine
@@ -236,10 +234,7 @@ fn persistent_machine_lifecycle_builders_reuse_machine_cli() {
         .force(true)
         .run_with(&client)
         .expect("shell");
-    assert_eq!(
-        fake.argv(),
-        ["machine", "shell", "--name", "devbox", "--force"]
-    );
+    assert_eq!(fake.argv(), ["machine", "shell", "devbox", "--force"]);
 
     machine.stop().run_with(&client).expect("stop");
     // `machine stop` takes a positional name, not `--name`, plus `--yes` to

--- a/public/src/content/docs/getting-started/quickstart.md
+++ b/public/src/content/docs/getting-started/quickstart.md
@@ -37,7 +37,7 @@ For a named machine that survives across starts:
 ```bash
 mvmctl machine create --name alpine-dev --image alpine
 mvmctl machine start alpine-dev
-mvmctl machine exec --name alpine-dev -- uname -a
+mvmctl machine exec alpine-dev -- uname -a
 mvmctl machine stop alpine-dev
 ```
 

--- a/public/src/content/docs/guides/machine-use-cases.md
+++ b/public/src/content/docs/guides/machine-use-cases.md
@@ -57,8 +57,8 @@ Use named machines when you want state across starts:
 ```bash
 mvmctl machine create --name alpine-dev --image alpine:3.20 --net
 mvmctl machine start alpine-dev
-mvmctl machine exec --name alpine-dev -- apk add jq
-mvmctl machine shell --name alpine-dev
+mvmctl machine exec alpine-dev -- apk add jq
+mvmctl machine shell alpine-dev
 mvmctl machine stop alpine-dev
 ```
 
@@ -100,7 +100,7 @@ Use it only when the host has `SSH_AUTH_SOCK` pointing to a Unix socket:
 
 ```bash
 mvmctl machine create --name dev --image alpine:3.20 --ssh-agent
-mvmctl machine exec --name dev -- env | grep SSH_AUTH_SOCK
+mvmctl machine exec dev -- env | grep SSH_AUTH_SOCK
 ```
 
 The guest sees `/run/mvm/ssh-agent.sock`; the private keys remain controlled by

--- a/public/src/content/docs/guides/troubleshooting.md
+++ b/public/src/content/docs/guides/troubleshooting.md
@@ -244,8 +244,8 @@ with no other config flags — a matching config reuses the running machine.
 
 ```bash
 mvmctl machine ls                 # list persisted machines
-mvmctl machine shell --name <N>   # interactive shell (dev)
-mvmctl machine exec  --name <N> -- <cmd>   # one-shot command
+mvmctl machine shell <N>          # interactive shell (dev)
+mvmctl machine exec  <N> -- <cmd>   # one-shot command
 mvmctl machine stop  <N>          # tear it down (prompts; add --yes to skip)
 ```
 

--- a/public/src/content/docs/reference/cli-commands.md
+++ b/public/src/content/docs/reference/cli-commands.md
@@ -396,7 +396,7 @@ or mounts private keys, `~/.ssh`, known-hosts material, or SSH config.
 | `mvmctl machine run --image <ref> --json -- <cmd>` | Print a redacted JSON execution summary |
 | `mvmctl machine run --image <ref> --receipt <path> -- <cmd>` | Write a signed execution receipt |
 | `mvmctl machine run -d --image <ref>` | Boot a **persistent** machine, auto-name it (printed), return |
-| `mvmctl machine run -d --name <name> --image <ref>` | Boot a **persistent** named machine, return; reconnect via `machine shell --name <name>` |
+| `mvmctl machine run -d --name <name> --image <ref>` | Boot a **persistent** named machine, return; reconnect via `machine shell <name>` |
 | `mvmctl machine run --name <name> --image <ref> -- <cmd>` | Boot a named foreground transient machine, run `<cmd>`, tear down |
 | `mvmctl machine run -it --image <ref> -- <cmd>` | Run `<cmd>` attached to a PTY, return its exit code, tear down |
 | `mvmctl machine run -it --name <name> --image <ref> -- <cmd>` | Same, with a stable transient VM name while it runs |
@@ -417,9 +417,9 @@ or mounts private keys, `~/.ssh`, known-hosts material, or SSH config.
 | `mvmctl machine rm <name>... --yes` | Remove one or more persisted named machine specs |
 | `mvmctl machine rm --all --yes` | Remove every persisted named machine spec |
 | `mvmctl machine rm <name>... --yes --json` | Print a JSON array deletion summary |
-| `mvmctl machine exec --name <name> -- <cmd>...` | Run a command in an already-started named machine |
-| `mvmctl machine exec --name <name> -it -- <cmd>...` | Run a command in an already-started named machine attached to a PTY |
-| `mvmctl machine shell --name <name>` | Attach an interactive shell/console to an already-started named machine |
+| `mvmctl machine exec <name> -- <cmd>...` | Run a command in an already-started named machine |
+| `mvmctl machine exec <name> -it -- <cmd>...` | Run a command in an already-started named machine attached to a PTY |
+| `mvmctl machine shell <name>` | Attach an interactive shell/console to an already-started named machine |
 | `mvmctl machine stop <name>` | Stop an already-started named machine (prompts for confirmation; pass `--yes` to skip) |
 | `mvmctl machine check-artifact <artifact.mvm>` | Verify a portable artifact and preview its admission posture without extracting or booting |
 | `mvmctl machine check-artifact <artifact.mvm> --key <pubkey>` | Verify with an explicit raw Ed25519 public key |
@@ -455,9 +455,9 @@ Use the explicit persistent lifecycle when you want the VM to survive:
 
 ```bash
 mvmctl machine run -d --image alpine          # boots, prints e.g. "blue-fox-3f2a", returns
-mvmctl machine shell --name blue-fox-3f2a     # reconnect (dev PTY)
-mvmctl machine exec  --name blue-fox-3f2a -- ps   # one-shot command in the running machine
-mvmctl machine exec  --name blue-fox-3f2a -it -- /bin/sh   # PTY command in the running machine
+mvmctl machine shell blue-fox-3f2a            # reconnect (dev PTY)
+mvmctl machine exec  blue-fox-3f2a -- ps          # one-shot command in the running machine
+mvmctl machine exec  blue-fox-3f2a -it -- /bin/sh   # PTY command in the running machine
 mvmctl machine stop  blue-fox-3f2a --yes      # tear it down when done
 ```
 
@@ -466,7 +466,7 @@ mvmctl machine stop  blue-fox-3f2a --yes      # tear it down when done
 **Interactive is dev-only.** `-t`/`--tty` attaches the foreground command to a
 PTY and is refused for a sealed/production image (claim 15 — no interactive
 access to a sealed microVM) and when stdin is not a terminal. `machine run -it`
-requires an argv after `--`; use `machine shell --name <name>` for the default
+requires an argv after `--`; use `machine shell <name>` for the default
 shell on an already-running machine.
 
 `machine create` accepts either `--image <ref>` or an image-backed manifest, not

--- a/sdks/machine-fixtures/exec.argv
+++ b/sdks/machine-fixtures/exec.argv
@@ -1,5 +1,4 @@
 exec
---name
 web
 --force
 --

--- a/sdks/machine-fixtures/shell.argv
+++ b/sdks/machine-fixtures/shell.argv
@@ -1,4 +1,3 @@
 shell
---name
 web
 --force

--- a/sdks/python/mvm/_machine.py
+++ b/sdks/python/mvm/_machine.py
@@ -237,7 +237,8 @@ def _machine_exec_argv(
     command = _string_list(command, "command")
     if not command:
         raise ValueError("command must be non-empty")
-    argv = ["exec", "--name", _require_non_empty_str(name, "name")]
+    # `machine exec` takes a positional name, not `--name`.
+    argv = ["exec", _require_non_empty_str(name, "name")]
     if force:
         argv.append("--force")
     argv.extend(["--", *command])
@@ -245,7 +246,8 @@ def _machine_exec_argv(
 
 
 def _machine_shell_argv(*, name: str, force: bool = False) -> list[str]:
-    argv = ["shell", "--name", _require_non_empty_str(name, "name")]
+    # `machine shell` takes a positional name, not `--name`.
+    argv = ["shell", _require_non_empty_str(name, "name")]
     if force:
         argv.append("--force")
     return argv

--- a/sdks/python/tests/test_machine.py
+++ b/sdks/python/tests/test_machine.py
@@ -223,7 +223,7 @@ def test_machine_persistent_lifecycle_shells_to_cli(tmp_path: Path) -> None:
     assert "verb=start" in text
     assert "devbox --dry-run" in text
     assert "verb=exec" in text
-    assert "--name devbox --force -- echo hi" in text
+    assert "devbox --force -- echo hi" in text
     assert "verb=shell" in text
     assert "verb=stop" in text
 

--- a/sdks/typescript/src/_machine.ts
+++ b/sdks/typescript/src/_machine.ts
@@ -223,14 +223,16 @@ export function machineExecArgv(
 ): string[] {
   command = requireStringArray(command, "command");
   if (command.length === 0) throw new RangeError("command must be non-empty");
-  const argv = ["exec", "--name", requireString(name, "name")];
+  // `machine exec` takes a positional name, not `--name`.
+  const argv = ["exec", requireString(name, "name")];
   if (options.force) argv.push("--force");
   argv.push("--", ...command);
   return argv;
 }
 
 export function machineShellArgv(name: string, options: MachineShellOptions = {}): string[] {
-  const argv = ["shell", "--name", requireString(name, "name")];
+  // `machine shell` takes a positional name, not `--name`.
+  const argv = ["shell", requireString(name, "name")];
   if (options.force) argv.push("--force");
   return argv;
 }

--- a/sdks/typescript/tests/machine.test.ts
+++ b/sdks/typescript/tests/machine.test.ts
@@ -194,8 +194,8 @@ describe("Machine persistent lifecycle", () => {
     const text = readFixtureLog().join("\n");
     expect(text).toContain("machine:create --name devbox --manifest mvm.toml --profile dev --force");
     expect(text).toContain("machine:start devbox --dry-run");
-    expect(text).toContain("machine:exec --name devbox --force -- echo hi");
-    expect(text).toContain("machine:shell --name devbox --force");
+    expect(text).toContain("machine:exec devbox --force -- echo hi");
+    expect(text).toContain("machine:shell devbox --force");
     expect(text).toContain("machine:stop devbox --yes");
   });
 


### PR DESCRIPTION
## What

Finishes the machine-name consistency pass started in #1440. `machine exec <name> -- <cmd>` and `machine shell <name>` now take the machine name as a **positional argument** instead of `--name <name>`.

After this, every machine verb that operates on a named machine takes the name positionally — `start`, `stop`, `inspect`, `rm`, `logs`, and now `exec`/`shell` — matching the docker/podman convention (`docker exec <container> <cmd>`). (`run` and `create` keep `--name` as an *optional identity* flag, since that's where the name is being *defined*, not referenced.)

## Cross-language contract

Same shared argv contract as #1440 (Rust/Python/TS SDK builders + `sdks/machine-fixtures/*.argv` + the CLI round-trip test). All of it moves together:

- `sdks/machine-fixtures/exec.argv` and `shell.argv` drop `--name`.
- The Rust/Python/TS SDK `exec`/`shell` builders emit a positional name.
- The user-facing `machine run -it` hint and all docs (`cli-commands.md`, `quickstart.md`, `machine-use-cases.md`, `troubleshooting.md`) show the positional form.

## Verification

- `cargo fmt --all --check` ✓ · clippy `-D warnings` (mvm-cli, mvm-sdk) ✓
- Rust: 1558 tests + doctests ✓
- Python SDK: 58 ✓ · TypeScript SDK: 52 ✓
- Runtime: `machine exec [OPTIONS] <NAME> <ARGV>...` and `machine shell [OPTIONS] <NAME>`; positional accepted, `--name` form rejected.

## Stacked on #1440

Based on `worktree-machine-start-stop-dx` (#1440). Review/merge that first, or this PR's base auto-retargets to `main` when #1440 merges.

🤖 Generated with [Claude Code](https://claude.com/claude-code)