### PR TITLE
fix(run): make the default in-process rootfs materialize fail-safe (fallback + xattr)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -317,10 +317,14 @@ the source gap analysis is at
     + F wire the user-facing OCI image runner to the same audit chain
     that backs claim 8 — see `specs/claims/claim-10-oci-image-provenance.md`.
     `mvmctl image pull` materializes the layer set in `mvm-oci`'s
-    allow-listed unpacker (`mvm_oci::unpack::unpack_layer`), formats an
-    ext4 rootfs in the builder VM (`mvm_build::oci_to_rootfs::
-    materialize_to_ext4`, never on the macOS host — ADR-050), and
-    persists provenance metadata (registry host, repo, supplied
+    allow-listed unpacker (`mvm_oci::unpack::unpack_layer`),
+    materializes an ext4 rootfs — by default in-process on the host
+    via the memory-safe pure-Rust writer (`mvm_build::rootfs::
+    materialize_ext4_pure`; ADR-106 supersedes ADR-050's builder-VM
+    `mkfs` mechanism while preserving its roothash guarantee, and
+    auto-falls-back to the builder VM for trees the writer can't
+    faithfully emit, e.g. ones carrying `security.capability`
+    xattrs) — and persists provenance metadata (registry host, repo, supplied
     reference, resolved manifest digest, layer digest list, trust
     policy, cosign verdict). `mvmctl run --image` admits an
     `ExecutionPlan` (claim 8 path) and then emits a

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2589,6 +2589,7 @@ dependencies = [
  "tracing",
  "uuid",
  "which 6.0.3",
+ "xattr",
 ]
 
 [[package]]

--- a/crates/mvm-build/Cargo.toml
+++ b/crates/mvm-build/Cargo.toml
@@ -66,6 +66,10 @@ lzma-rs = "0.3"
 
 mvm-core.workspace = true
 mvm-ext4 = { workspace = true, optional = true }
+# Read xattrs during the pure walk so a tree carrying attrs the writer can't
+# represent (e.g. `security.capability`) routes to the builder-VM fallback
+# instead of silently dropping them. Already in the mvmctl closure via mvm-oci.
+xattr = { workspace = true, optional = true }
 mvm-guest.workspace = true
 # `LibkrunNetworkProvider` impls the `NetworkProvider`
 # seam. mvm-network deps only mvm-core + mvm-sdk, so this edge is acyclic.
@@ -144,7 +148,7 @@ default = []
 # In-process, pure-Rust ext4 materialization (no builder VM / mkfs). Off by
 # default so the mvmctl default closure does not gain `mvm-ext4` until the pure
 # path is the run-path default; enabled where `materialize_ext4_pure` is used.
-pure-mkfs = ["dep:mvm-ext4"]
+pure-mkfs = ["dep:mvm-ext4", "dep:xattr"]
 # Folded in with the mvm-egress-proxy bin. Off by default;
 # tests/dev enable it so the `mvm-egress-proxy` bin honors a
 # `MVM_EGRESS_ALLOWLIST=host1,host2` override. Production binaries (no

--- a/crates/mvm-build/src/rootfs.rs
+++ b/crates/mvm-build/src/rootfs.rs
@@ -125,7 +125,7 @@ pub enum RootfsError {
 
     #[cfg(feature = "pure-mkfs")]
     #[error("building ext4 image in-process: {0}")]
-    PureBuild(String),
+    PureBuild(#[from] mvm_ext4::Ext4Error),
 
     #[cfg(feature = "pure-mkfs")]
     #[error("writing rootfs image {path}: {source}")]
@@ -134,6 +134,30 @@ pub enum RootfsError {
         #[source]
         source: std::io::Error,
     },
+
+    #[cfg(feature = "pure-mkfs")]
+    #[error("{path} carries an extended attribute ({name}) the in-process writer cannot represent")]
+    PureUnsupportedXattr { path: PathBuf, name: String },
+}
+
+#[cfg(feature = "pure-mkfs")]
+impl RootfsError {
+    /// Whether a pure-path failure is a *capacity limit* of the in-process ext4
+    /// writer (the image is too big / too fragmented for the current design),
+    /// meaning the run path can retry via the builder VM. A malformed-tree or
+    /// I/O failure returns `false` and surfaces unchanged.
+    pub fn is_pure_capacity_limit(&self) -> bool {
+        matches!(self, RootfsError::PureBuild(e) if e.is_capacity_limit())
+    }
+
+    /// Whether the run path should retry this pure-path failure via the builder
+    /// VM. True when the in-process writer structurally can't emit a faithful
+    /// image — a capacity limit, or a tree carrying an extended attribute the
+    /// writer can't represent (the builder VM's `cp -a` preserves it). A
+    /// malformed tree or I/O error is genuine and surfaces unchanged.
+    pub fn pure_should_fall_back(&self) -> bool {
+        self.is_pure_capacity_limit() || matches!(self, RootfsError::PureUnsupportedXattr { .. })
+    }
 }
 
 /// Estimate the sparse image size for an OCI rootfs.
@@ -358,7 +382,7 @@ pub fn materialize_ext4_pure(
         ));
     }
     let nodes = collect_nodes(&input.unpacked_root)?;
-    let image = mvm_ext4::build_image(&nodes).map_err(|e| RootfsError::PureBuild(e.to_string()))?;
+    let image = mvm_ext4::build_image(&nodes).map_err(RootfsError::PureBuild)?;
     let size_bytes = image.len() as u64;
     // The run path's cache dir (`.../rootfs/<key>/`) may not exist yet — the
     // builder-VM path created it via `allocate_sparse_image`, so the pure path
@@ -439,6 +463,18 @@ fn collect_nodes(root: &std::path::Path) -> Result<Vec<mvm_ext4::Node>, RootfsEr
                 path: path.clone(),
                 source,
             })?;
+            // The pure writer represents no xattrs. If a real (non-symlink)
+            // entry carries one that matters to the guest — a file capability,
+            // POSIX ACL, or image-authored user/trusted attr — refuse so the run
+            // path falls back to the builder VM (whose `cp -a` preserves it)
+            // rather than silently dropping it. Host-managed labels the guest
+            // re-derives (SELinux/IMA/EVM, macOS `com.apple.*`) are ignored so
+            // they never force a spurious fallback.
+            if !ft.is_symlink()
+                && let Some(name) = blocking_xattr(&path)
+            {
+                return Err(RootfsError::PureUnsupportedXattr { path, name });
+            }
             if ft.is_symlink() {
                 let target = std::fs::read_link(&path).map_err(|source| RootfsError::PureWalk {
                     path: path.clone(),
@@ -468,6 +504,32 @@ fn collect_nodes(root: &std::path::Path) -> Result<Vec<mvm_ext4::Node>, RootfsEr
         }
     }
     Ok(out)
+}
+
+/// The name of the first extended attribute on `path` that the pure writer can't
+/// represent and the guest actually needs, or `None`. Ignores host-managed
+/// labels (SELinux/IMA/EVM, macOS `com.apple.*`) so they never force a fallback.
+#[cfg(feature = "pure-mkfs")]
+fn blocking_xattr(path: &std::path::Path) -> Option<String> {
+    // A read failure means the FS doesn't support xattrs (or we lack access):
+    // nothing to preserve, so don't force a fallback.
+    let names = xattr::list(path).ok()?;
+    names
+        .map(|n| n.to_string_lossy().into_owned())
+        .find(|n| xattr_matters_for_guest(n))
+}
+
+/// Whether an xattr name carries guest-relevant image semantics the pure writer
+/// would silently drop. File capabilities and POSIX ACLs are preserved; other
+/// `security.*` attrs are host-managed labels the guest kernel re-derives (or
+/// that don't port between hosts) and are deliberately ignored.
+#[cfg(feature = "pure-mkfs")]
+fn xattr_matters_for_guest(name: &str) -> bool {
+    match name {
+        "security.capability" | "system.posix_acl_access" | "system.posix_acl_default" => true,
+        _ if name.starts_with("security.") => false,
+        _ => name.starts_with("user.") || name.starts_with("trusted."),
+    }
 }
 
 #[cfg(feature = "pure-mkfs")]
@@ -506,6 +568,76 @@ fn shell_single_quote_escape(s: &str) -> String {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[cfg(feature = "pure-mkfs")]
+    #[test]
+    fn pure_capacity_limit_is_retryable_but_malformed_is_not() {
+        let capacity = RootfsError::PureBuild(mvm_ext4::Ext4Error::FileTooFragmented {
+            ino: 12,
+            extents: 9,
+        });
+        assert!(
+            capacity.is_pure_capacity_limit(),
+            "a capacity limit must be retryable via the builder VM"
+        );
+        let malformed = RootfsError::PureBuild(mvm_ext4::Ext4Error::BadPath("//a".into()));
+        assert!(
+            !malformed.is_pure_capacity_limit(),
+            "a malformed-tree error must surface, not fall back"
+        );
+        let io = RootfsError::WriteOutput {
+            path: PathBuf::from("/x"),
+            source: std::io::Error::other("boom"),
+        };
+        assert!(!io.is_pure_capacity_limit());
+    }
+
+    #[cfg(feature = "pure-mkfs")]
+    #[test]
+    fn only_image_semantic_xattrs_force_a_fallback() {
+        // Preserved (image semantics the guest needs and won't re-derive).
+        assert!(xattr_matters_for_guest("security.capability"));
+        assert!(xattr_matters_for_guest("system.posix_acl_access"));
+        assert!(xattr_matters_for_guest("system.posix_acl_default"));
+        assert!(xattr_matters_for_guest("user.mvm.anything"));
+        assert!(xattr_matters_for_guest("trusted.foo"));
+        // Ignored: host-managed labels the guest re-derives. Treating SELinux as
+        // blocking would force a builder-VM fallback for *every* image on an
+        // SELinux-labelled host (Fedora/RHEL) — defeating the pure default.
+        assert!(!xattr_matters_for_guest("security.selinux"));
+        assert!(!xattr_matters_for_guest("security.ima"));
+        assert!(!xattr_matters_for_guest("security.evm"));
+        assert!(!xattr_matters_for_guest("com.apple.provenance"));
+    }
+
+    #[cfg(feature = "pure-mkfs")]
+    #[test]
+    fn xattr_bearing_tree_routes_to_builder_vm_fallback() {
+        let src = tempfile::tempdir().unwrap();
+        let bin = src.path().join("ping");
+        std::fs::write(&bin, b"\x7fELF fake binary").unwrap();
+        // Mirror the OCI unpacker's probe: skip where the host FS can't hold
+        // xattrs (some CI tmpfs). A `user.*` attr is settable on both Linux and
+        // macOS and trips the same "writer can't represent this" branch as a
+        // real `security.capability`.
+        if xattr::set(&bin, "user.mvm.test_cap", b"cap").is_err() {
+            return;
+        }
+        let out = tempfile::tempdir().unwrap();
+        let input =
+            MaterializeExt4Input::new(src.path().to_path_buf(), out.path().join("rootfs.ext4"), 0);
+
+        let err = materialize_ext4_pure(&input)
+            .expect_err("an xattr-bearing tree must not be silently materialized without it");
+        assert!(
+            matches!(err, RootfsError::PureUnsupportedXattr { .. }),
+            "got {err:?}"
+        );
+        assert!(
+            err.pure_should_fall_back(),
+            "an unsupported xattr must route to the builder-VM fallback"
+        );
+    }
 
     #[cfg(feature = "builder-vm")]
     use crate::builder_backend_select::{BuilderBackendChoice, MVM_BUILDER_BACKEND_ENV};

--- a/crates/mvm-build/src/run_image.rs
+++ b/crates/mvm-build/src/run_image.rs
@@ -75,9 +75,26 @@ pub fn inject_and_materialize(
 pub fn materialize_run_rootfs(input: &MaterializeExt4Input) -> Result<()> {
     #[cfg(feature = "pure-mkfs")]
     if std::env::var_os("MVM_MATERIALIZE_BUILDER_VM").is_none() {
-        return crate::rootfs::materialize_ext4_pure(input)
-            .map(|_| ())
-            .with_context(|| format!("materialize {} in-process", input.output.display()));
+        match crate::rootfs::materialize_ext4_pure(input) {
+            Ok(_) => return Ok(()),
+            // Auto-fallback: the in-process writer structurally can't emit a
+            // faithful image — too large / too fragmented / a directory over one
+            // block, or the tree carries an xattr the writer can't represent — so
+            // retry via the builder VM, which has no such limits and whose
+            // `cp -a` preserves xattrs. Logged, never silent.
+            Err(e) if e.pure_should_fall_back() => {
+                tracing::warn!(
+                    error = %e,
+                    "in-process rootfs materialize needs the builder VM; falling back"
+                );
+                // fall through to the builder-VM path below
+            }
+            // A malformed tree or I/O failure is genuine — surface it, no retry.
+            Err(e) => {
+                return Err(e)
+                    .with_context(|| format!("materialize {} in-process", input.output.display()));
+            }
+        }
     }
     materialize_run_rootfs_builder_vm(input)
 }

--- a/crates/mvm-ext4/src/lib.rs
+++ b/crates/mvm-ext4/src/lib.rs
@@ -128,6 +128,24 @@ impl std::fmt::Display for Ext4Error {
     }
 }
 
+impl Ext4Error {
+    /// Whether this failure is a *capacity limit* of the pure writer (the image
+    /// is structurally too big / too fragmented for the current single-writer
+    /// design) rather than a *malformed tree*. The run path retries a capacity
+    /// limit via the builder VM (which has no such limits); a malformed-tree
+    /// error is genuine and surfaces unchanged. A real OCI-unpacked FS tree can
+    /// only ever produce capacity limits — the malformed variants require a
+    /// synthetic node list.
+    pub fn is_capacity_limit(&self) -> bool {
+        matches!(
+            self,
+            Ext4Error::TooLarge { .. }
+                | Ext4Error::FileTooFragmented { .. }
+                | Ext4Error::DirTooLarge(_)
+        )
+    }
+}
+
 impl std::error::Error for Ext4Error {}
 
 /// A filesystem node to place in the image. Paths are absolute (`/`-rooted);

--- a/crates/mvm-ext4/tests/error_classify.rs
+++ b/crates/mvm-ext4/tests/error_classify.rs
@@ -1,0 +1,38 @@
+//! `Ext4Error::is_capacity_limit` classifies build failures for the run path's
+//! materialize dispatch: a *capacity limit* (the pure writer structurally can't
+//! emit this image) is retryable via the builder VM, whereas a *malformed tree*
+//! is a genuine error to surface. A real OCI-unpacked FS tree only ever produces
+//! capacity limits — the malformed variants require a synthetic node list.
+
+use mvm_ext4::Ext4Error;
+
+#[test]
+fn capacity_limits_are_classified_for_fallback() {
+    let capacity = [
+        Ext4Error::TooLarge { blocks: 1 << 40 },
+        Ext4Error::FileTooFragmented {
+            ino: 12,
+            extents: 9,
+        },
+        Ext4Error::DirTooLarge("/big".into()),
+    ];
+    for e in capacity {
+        assert!(e.is_capacity_limit(), "{e:?} should be a capacity limit");
+    }
+}
+
+#[test]
+fn malformed_tree_errors_are_not_capacity_limits() {
+    let malformed = [
+        Ext4Error::MissingParent("/a/b".into()),
+        Ext4Error::BadPath("//a".into()),
+        Ext4Error::NotADirectory("/a/b".into()),
+        Ext4Error::DuplicatePath("/dup".into()),
+    ];
+    for e in malformed {
+        assert!(
+            !e.is_capacity_limit(),
+            "{e:?} is a malformed-tree error, not a capacity limit"
+        );
+    }
+}

--- a/specs/plans/221-in-process-rootfs-materialize.md
+++ b/specs/plans/221-in-process-rootfs-materialize.md
@@ -1,8 +1,15 @@
 # Plan 221 — In-process rootfs materialization (no builder-VM, no subprocess)
 
-**Status:** proposed
+**Status:** Option B shipped (B0–B5 landed: pure-Rust `mvm-ext4` writer +
+in-process dm-verity + multi-block-group + fuzz + adversarial suite; ADR-106
+records the Phase-A/Phase-B boundary; the run path materializes in-process by
+default with an ADR-093-style auto-fallback to the builder VM on a pure-writer
+limit or an xattr-bearing tree). Option A (virtiofs root) remains, gated on
+ADR-107. Native inline-xattr support in the writer is a possible follow-up to
+keep capability-bearing images on the pure path (today they fall back).
 **Owner:** _tbd_
-**Related:** ADR-050 (OCI verity posture — superseded *mechanism*), ADR-046/013
+**Related:** ADR-106 (Phase-A/Phase-B boundary — the in-process materialize
+decision), ADR-050 (OCI verity posture — superseded *mechanism*), ADR-046/013
 (no host tools / no host Nix), ADR-093 (builder auto-fallback), Plan 214
 (in-house HVF VMM), #1388 seam (synthesis→admission→`admit_and_start`).
 


### PR DESCRIPTION
The default flip to pure in-process rootfs materialize shipped two gaps vs the builder-VM path — both live by default. This makes the pure path **fail-safe**: anything it can't faithfully write transparently retries via the builder VM (whose `cp -a` preserves xattrs and has no size limits), announced on stderr, never silent.

## Gaps closed

**1. No auto-fallback (hard-fail).** The dispatch returned the pure error directly; `MVM_MATERIALIZE_BUILDER_VM` was only a *manual* escape hatch. A real image tripping a writer capacity limit — a file spanning >4 block groups (`FileTooFragmented`) or a directory over one 4 KiB block (`DirTooLarge`) — would fail the run instead of falling back.

**2. Silent xattr drop.** The pure walk captured only mode + symlink target, so a tree carrying `security.capability` (file caps like `cap_net_bind_service`) was materialized **without them, silently**. The OCI unpacker preserves these into the tree where the host FS allows, so it's a real correctness loss.

## Approach

- **mvm-ext4** — `Ext4Error::is_capacity_limit()` splits retryable capacity limits from malformed-tree errors (`NotADirectory`/`DuplicatePath`/`BadPath`, which a real FS tree can't even produce).
- **mvm-build** — `RootfsError` now preserves the structured `Ext4Error` (was stringified); the walk detects an xattr the writer can't represent → `PureUnsupportedXattr`. `pure_should_fall_back()` = capacity limit OR unsupported xattr.
- **mvm-cli** — the run-path dispatch retries via the builder VM when `pure_should_fall_back()`, surfaces malformed/IO errors unchanged.

### The one subtle correctness call
Detection **ignores host-managed labels** — `security.selinux`/`ima`/`evm`, macOS `com.apple.*` — and blocks only image-semantic attrs (`security.capability`, POSIX ACLs, `user.*`/`trusted.*`). Treating `security.selinux` as blocking would divert **every** image to the builder VM on a labelled Fedora/RHEL host, defeating the pure default. A unit test pins this.

## Verification
- New tests: capacity-limit classifier, SELinux-safe xattr policy, and an xattr-bearing-tree → fallback test that **runs on macOS too** (proves the cross-platform `xattr` path).
- fmt / clippy `--all-targets` / `check-no-spec-refs` / `check-closure-budget` (337, unchanged — `xattr` was already in-closure via mvm-oci) all clean; mvm-ext4 + mvm-build (both features) + doctests green.

## Docs (Task C)
CLAUDE.md's claim-14 note no longer claims materialize is "in the builder VM, never on the macOS host" (false since the flip) and cites ADR-106; Plan 221 status reflects Option B shipped.

## Follow-up (not this PR)
**Native inline-xattr support in the `mvm-ext4` writer** would keep capability-bearing images on the pure path instead of falling back — a new on-disk ext4 format feeding dm-verity/boot, so it wants its own real-kernel-mount validation. Flagged in the plan.