### PR TITLE
feat(run): embed guest-agent binaries so end-user run --image works offline

### DIFF
--- a/crates/mvm-build/src/guest_agent_build.rs
+++ b/crates/mvm-build/src/guest_agent_build.rs
@@ -11,10 +11,12 @@
 //!
 //! `cargo-zigbuild` is the single portable cross path: the agent pulls
 //! `ring` (C), so a static musl build needs a musl C cross-compiler, and
-//! zig supplies it without a system `<arch>-linux-musl-gcc`. The build is
-//! only reachable from a source checkout (it needs the workspace + zig);
-//! an end-user mvmctl gets the binaries from the published runtime
-//! overlay instead (a separate path).
+//! zig supplies it without a system `<arch>-linux-musl-gcc`. The
+//! source-checkout build ([`resolve_or_build_guest_binaries`]) is only
+//! reachable with the workspace + zig; a **shipped mvmctl** embeds these two
+//! binaries at build time (`crates/mvm-cli/build.rs`) and installs the embedded
+//! bytes via [`install_prebuilt_guest_binaries`]. The resolution order —
+//! cache → source checkout → embedded — lives in `run_image::inject_and_materialize`.
 
 use mvm_core::arch::GuestArch;
 use std::path::{Path, PathBuf};
@@ -180,6 +182,40 @@ pub fn install_into_cache(
     Ok(layout.binaries())
 }
 
+/// The cached guest binaries if a complete set is already present, else `None`.
+/// Lets a caller check the cache without triggering a source-checkout build.
+pub fn cached_guest_binaries(
+    cache_root: &Path,
+    version: &str,
+    arch: GuestArch,
+) -> Option<MvmRuntimeBinaries> {
+    let layout = GuestAgentLayout::under(cache_root, version, arch);
+    layout.is_complete().then(|| layout.binaries())
+}
+
+/// Install guest binaries from in-memory bytes (embedded in the host binary at
+/// build time) into the cache. The end-user path: a shipped mvmctl has no
+/// source checkout to cross-compile from, so it writes the embedded bytes here.
+pub fn install_prebuilt_guest_binaries(
+    agent_bytes: &[u8],
+    netinit_bytes: &[u8],
+    cache_root: &Path,
+    version: &str,
+    arch: GuestArch,
+) -> Result<MvmRuntimeBinaries, GuestAgentBuildError> {
+    let layout = GuestAgentLayout::under(cache_root, version, arch);
+    std::fs::create_dir_all(&layout.dir)?;
+    write_exec(&layout.agent, agent_bytes)?;
+    write_exec(&layout.netinit, netinit_bytes)?;
+    Ok(layout.binaries())
+}
+
+fn write_exec(dst: &Path, bytes: &[u8]) -> Result<(), GuestAgentBuildError> {
+    let _ = std::fs::remove_file(dst);
+    std::fs::write(dst, bytes)?;
+    set_exec(dst)
+}
+
 fn install_one(src: &Path, dst: &Path) -> Result<(), GuestAgentBuildError> {
     if !src.is_file() {
         return Err(GuestAgentBuildError::OutputMissing(src.to_path_buf()));
@@ -260,6 +296,41 @@ fn set_exec(_path: &Path) -> Result<(), GuestAgentBuildError> {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn install_prebuilt_then_cached_round_trips() {
+        let cache = tempfile::tempdir().unwrap();
+        let arch = GuestArch::Aarch64;
+
+        // Nothing cached yet.
+        assert!(cached_guest_binaries(cache.path(), "9.9.9", arch).is_none());
+
+        // Install embedded-style bytes, then the cache lookup finds them.
+        let bins = install_prebuilt_guest_binaries(
+            b"fake-agent-elf",
+            b"fake-netinit-elf",
+            cache.path(),
+            "9.9.9",
+            arch,
+        )
+        .expect("install prebuilt");
+        assert!(bins.agent.is_file());
+        assert!(bins.netinit.is_file());
+        assert_eq!(std::fs::read(&bins.agent).unwrap(), b"fake-agent-elf");
+
+        let cached = cached_guest_binaries(cache.path(), "9.9.9", arch).expect("now cached");
+        assert_eq!(cached.agent, bins.agent);
+        // Executable bit is set on the installed binary.
+        #[cfg(unix)]
+        {
+            use std::os::unix::fs::PermissionsExt;
+            let mode = std::fs::metadata(&cached.agent)
+                .unwrap()
+                .permissions()
+                .mode();
+            assert_eq!(mode & 0o111, 0o111, "installed agent must be executable");
+        }
+    }
 
     #[test]
     fn musl_triple_per_arch() {

--- a/crates/mvm-build/src/run_image.rs
+++ b/crates/mvm-build/src/run_image.rs
@@ -11,36 +11,34 @@ use std::path::Path;
 
 use anyhow::{Context, Result};
 
+use crate::oci_runtime_inject::MvmRuntimeBinaries;
 use crate::rootfs::MaterializeExt4Input;
+
+/// Guest-agent binaries (`mvm-guest-agent` + `mvm-guest-netinit`) embedded in
+/// the host binary at build time — the end-user fallback for a shipped mvmctl
+/// with no source checkout to cross-compile from.
+pub struct PrebuiltGuestBinaries<'a> {
+    pub agent: &'a [u8],
+    pub netinit: &'a [u8],
+}
 
 /// Inject the mvm runtime into `unpacked_root`, materialize it into `output` (a
 /// `rootfs.ext4` path), and write the overlay-aware guest sidecar beside it.
 /// `cache_root` holds the guest-agent binary cache; `label` names the image in
 /// the sidecar.
 ///
-/// The guest binaries are resolved via `guest_agent_build`, which cross-compiles
-/// them from a source checkout — the same path the CLI uses (an end-user
-/// binary that ships the runtime overlay is a separate, not-yet-wired path).
+/// Guest binaries resolve in order: a cache hit, then a source-checkout
+/// cross-compile (contributors get their local edits), then the `prebuilt`
+/// bytes embedded in the host binary (the shipped-mvmctl end-user path). A
+/// caller with no embedded binaries passes `None`.
 pub fn inject_and_materialize(
     cache_root: &Path,
     unpacked_root: &Path,
     output: &Path,
     label: &str,
+    prebuilt: Option<PrebuiltGuestBinaries<'_>>,
 ) -> Result<()> {
-    let arch = mvm_core::arch::GuestArch::host();
-    // `CARGO_MANIFEST_DIR` is bound at this crate's compile time, so it always
-    // points at `crates/mvm-build`; its grandparent is the workspace root.
-    let workspace_root = Path::new(env!("CARGO_MANIFEST_DIR"))
-        .parent()
-        .and_then(|p| p.parent())
-        .ok_or_else(|| anyhow::anyhow!("cannot locate workspace root for guest-agent build"))?;
-    let bins = crate::guest_agent_build::resolve_or_build_guest_binaries(
-        cache_root,
-        env!("CARGO_PKG_VERSION"),
-        arch,
-        workspace_root,
-    )
-    .context("obtain guest agent binaries for OCI run")?;
+    let bins = resolve_guest_binaries(cache_root, prebuilt)?;
     crate::oci_runtime_inject::inject_mvm_runtime(unpacked_root, &bins)
         .context("inject mvm runtime into OCI rootfs")?;
 
@@ -62,6 +60,50 @@ pub fn inject_and_materialize(
         .write_to_dir(rootfs_dir)
         .with_context(|| format!("write OCI sidecar in {}", rootfs_dir.display()))?;
     Ok(())
+}
+
+/// Resolve the guest-agent binaries: cache hit → source-checkout cross-compile
+/// → embedded prebuilt bytes.
+fn resolve_guest_binaries(
+    cache_root: &Path,
+    prebuilt: Option<PrebuiltGuestBinaries<'_>>,
+) -> Result<MvmRuntimeBinaries> {
+    let arch = mvm_core::arch::GuestArch::host();
+    let version = env!("CARGO_PKG_VERSION");
+
+    if let Some(cached) = crate::guest_agent_build::cached_guest_binaries(cache_root, version, arch)
+    {
+        return Ok(cached);
+    }
+
+    // A source checkout cross-compiles fresh, so contributors editing `mvm-guest`
+    // get their local changes. `CARGO_MANIFEST_DIR` is baked at this crate's
+    // compile time and points at `crates/mvm-build`; on a shipped binary that
+    // path doesn't exist on the end-user's host — which is exactly how we detect
+    // "not a source checkout" and fall through to the embedded bytes.
+    let workspace_root = Path::new(env!("CARGO_MANIFEST_DIR"))
+        .parent()
+        .and_then(|p| p.parent());
+    if let Some(ws) = workspace_root
+        && ws.join("crates/mvm-guest").is_dir()
+    {
+        return crate::guest_agent_build::resolve_or_build_guest_binaries(
+            cache_root, version, arch, ws,
+        )
+        .context("build guest agent binaries from the source checkout");
+    }
+
+    if let Some(p) = prebuilt {
+        return crate::guest_agent_build::install_prebuilt_guest_binaries(
+            p.agent, p.netinit, cache_root, version, arch,
+        )
+        .context("install the embedded guest agent binaries");
+    }
+
+    anyhow::bail!(
+        "no guest agent binaries available: this build embeds none and there is no source \
+         checkout to cross-compile from"
+    )
 }
 
 /// Materialize a run-path rootfs from an already-complete unpacked tree.

--- a/crates/mvm-cli/build.rs
+++ b/crates/mvm-cli/build.rs
@@ -96,6 +96,29 @@ fn main() {
         );
     }
 
+    // Guest-agent binaries (`mvm-guest-agent` + `mvm-guest-netinit`, dev-shell,
+    // guest arch = host arch). Embedded alongside the host bins so an end-user
+    // mvmctl with no source checkout can inject them into an OCI `run --image`
+    // rootfs. Built in one cargo invocation; they ride the same `EMBEDDED` array
+    // and are looked up by name. Honors MVM_SKIP_EMBED_BINARIES (zero-byte
+    // stubs) — a stub build can't materialize an OCI run, same as the host bins.
+    if !skip_embed {
+        run_guest_zigbuild(&workspace_root, &host_target_dir, &pin.target, &bins_out);
+    }
+    for name in ["mvm-guest-agent", "mvm-guest-netinit"] {
+        let out_file = bins_out.join(name);
+        if skip_embed {
+            std::fs::write(&out_file, b"")
+                .unwrap_or_else(|e| panic!("write stub {}: {e}", out_file.display()));
+        }
+        let sha = sha256_hex(&out_file);
+        entries.push((name.to_string(), out_file, sha));
+    }
+    println!(
+        "cargo:rerun-if-changed={}",
+        workspace_root.join("crates/mvm-guest/src").display()
+    );
+
     let embedded_rs = render_embedded_rs(&entries);
     std::fs::write(out_dir.join("embedded.rs"), embedded_rs).unwrap();
     println!(
@@ -260,6 +283,52 @@ fn run_cargo_zigbuild(root: &Path, target_dir: &Path, pkg: &str, target: &str, o
         .join(pkg);
     std::fs::copy(&built, out)
         .unwrap_or_else(|e| panic!("copy {} → {}: {e}", built.display(), out.display()));
+}
+
+/// Cross-compile the guest agent + netinit (one invocation, dev-shell feature)
+/// to the static musl `target`, copying both into `out_dir`. Same zig/rustup
+/// handling as `run_cargo_zigbuild`; the guest binaries are a single `mvm-guest`
+/// package build with two `--bin`s, not one bin per call.
+fn run_guest_zigbuild(root: &Path, target_dir: &Path, target: &str, out_dir: &Path) {
+    eprintln!(
+        "[build.rs] cargo zigbuild --release --target {target} -p mvm-guest \
+         --bin mvm-guest-agent --bin mvm-guest-netinit --features mvm-guest/dev-shell"
+    );
+    let (cargo, rustc) = rustup_cargo_and_rustc(strip_glibc(target));
+    let status = Command::new(&cargo)
+        .args([
+            "zigbuild",
+            "--release",
+            "--target",
+            target,
+            "-p",
+            "mvm-guest",
+            "--bin",
+            "mvm-guest-agent",
+            "--bin",
+            "mvm-guest-netinit",
+            "--features",
+            "mvm-guest/dev-shell",
+        ])
+        .env("RUSTC", &rustc)
+        .env("CARGO_TARGET_DIR", target_dir)
+        .env_remove("RUSTUP_TOOLCHAIN")
+        .env_remove("RUSTC_WRAPPER")
+        .env_remove("RUSTC_WORKSPACE_WRAPPER")
+        .current_dir(root)
+        .status()
+        .expect("spawn `cargo zigbuild` for the guest agent");
+    assert!(
+        status.success(),
+        "cargo zigbuild failed for the guest agent"
+    );
+    let rel = target_dir.join(strip_glibc(target)).join("release");
+    for name in ["mvm-guest-agent", "mvm-guest-netinit"] {
+        let built = rel.join(name);
+        let dest = out_dir.join(name);
+        std::fs::copy(&built, &dest)
+            .unwrap_or_else(|e| panic!("copy {} → {}: {e}", built.display(), dest.display()));
+    }
 }
 
 /// Find a `(cargo, rustc)` pair that has `target` installed in its sysroot.

--- a/crates/mvm-cli/src/commands/image/mod.rs
+++ b/crates/mvm-cli/src/commands/image/mod.rs
@@ -544,7 +544,30 @@ fn inject_runtime_and_materialize(
     rootfs_abs: &Path,
     image_label: &str,
 ) -> Result<()> {
-    mvm_build::run_image::inject_and_materialize(cache_root, unpacked_root, rootfs_abs, image_label)
+    mvm_build::run_image::inject_and_materialize(
+        cache_root,
+        unpacked_root,
+        rootfs_abs,
+        image_label,
+        embedded_guest_binaries(),
+    )
+}
+
+/// The guest-agent binaries embedded in this mvmctl at build time (build.rs).
+/// `None` when this build baked zero-byte stubs (`MVM_SKIP_EMBED_BINARIES`), in
+/// which case the run path falls back to a source-checkout cross-compile.
+fn embedded_guest_binaries() -> Option<mvm_build::run_image::PrebuiltGuestBinaries<'static>> {
+    let find = |name: &str| {
+        crate::host_binaries::embedded::EMBEDDED
+            .iter()
+            .find(|b| b.name == name)
+            .map(|b| b.bytes)
+            .filter(|b| !b.is_empty())
+    };
+    Some(mvm_build::run_image::PrebuiltGuestBinaries {
+        agent: find("mvm-guest-agent")?,
+        netinit: find("mvm-guest-netinit")?,
+    })
 }
 
 /// Ingest a local OCI image-layout archive (`oci-archive:<path>`) into a

--- a/crates/mvm-client-local/src/lib.rs
+++ b/crates/mvm-client-local/src/lib.rs
@@ -140,7 +140,9 @@ fn run_rootfs_output(name: &str) -> PathBuf {
 fn materialize_from_dir(dir: &Path, name: &str) -> Result<PathBuf> {
     let output = run_rootfs_output(name);
     let cache_root = PathBuf::from(mvm_core::config::mvm_cache_dir());
-    mvm_build::run_image::inject_and_materialize(&cache_root, dir, &output, name)
+    // `None`: this library carries no embedded guest binaries (only the mvmctl
+    // binary does), so it resolves them from the cache or a source checkout.
+    mvm_build::run_image::inject_and_materialize(&cache_root, dir, &output, name, None)
         .map_err(backend_err)?;
     Ok(output)
 }


### PR DESCRIPTION
## What

`mvmctl run --image` injects the guest agent + netinit into the OCI rootfs before materializing it. Those binaries came **only** from a source-checkout cross-compile (`cargo-zigbuild`), so a **shipped end-user mvmctl couldn't materialize an OCI run** — the limitation flagged in #1438.

Fix: `build.rs` now cross-compiles `mvm-guest-agent` + `mvm-guest-netinit` (dev-shell, guest arch) and **embeds** them alongside the host-vm binaries in the same `EMBEDDED` array — the same pattern the small static host binaries (`mvm-host-vm-init`, `mvm-egress-proxy`) already use.

Resolution order in `mvm_build::run_image` is now:
1. **cache hit**,
2. **source-checkout cross-compile** (contributors get their local `mvm-guest` edits),
3. **embedded prebuilt bytes** (shipped mvmctl, offline).

A source checkout is detected by the baked `CARGO_MANIFEST_DIR` workspace path existing at runtime; on an end-user host it doesn't, so the embedded bytes install into the guest-agent cache.

## Why embed (not download)

The guest-agent binaries are small static helpers in the same class as `mvm-host-vm-init` / `mvm-egress-proxy`, which are **already embedded** — so this fits an existing precedent, needs **no release-pipeline change**, and works offline. (A downloadable release artifact was the alternative; embedding is the lower-machinery, fully-locally-validatable choice.)

## Shape

- **mvm-build**: `cached_guest_binaries` + `install_prebuilt_guest_binaries`; `inject_and_materialize` takes `Option<PrebuiltGuestBinaries>` and does the 3-way resolve.
- **mvm-cli**: `build.rs` `run_guest_zigbuild` cross-compiles + embeds; passes the embedded bytes (skip-embed stubs → `None`). **mvm-client-local** passes `None` (library, no embed).
- Honors `MVM_SKIP_EMBED_BINARIES` (zero-byte stubs, fast dev builds).

## Gates

- Budget stays **337** (embed is bytes, not crates); `host-binaries-sync` unaffected (guest bins ride `EMBEDDED`, not the host manifest); clippy + fmt clean; CLI's 45 image tests pass.

## Validation

- A **real build embeds a 1.4 MiB agent + 394 KiB netinit** (musl, confirmed).
- Unit test round-trips `install_prebuilt` → `cached_guest_binaries` (with the exec bit set).
- The **source-checkout** resolve path is already **live-proven** by the `run --image` boot on a real Vz microVM. The embedded end-user path (no checkout) is validated structurally (bytes embedded + install unit test); forcing "no checkout" from within the worktree isn't feasible, so a clean-machine smoke is the one thing left for a release build.

🤖 Generated with [Claude Code](https://claude.com/claude-code)