### PR TITLE
feat(machine): auto-generate a name for `machine create` when omitted

### DIFF
--- a/crates/mvm-cli/src/commands/machine/mod.rs
+++ b/crates/mvm-cli/src/commands/machine/mod.rs
@@ -78,8 +78,8 @@ pub(in crate::commands) enum MachineAction {
     /// Remove one or more persistent named machine specs (or --all)
     #[command(name = "rm", display_order = 6)]
     Rm(MachineRemoveArgs),
-    /// List persistent named machine specs
-    #[command(name = "ls", display_order = 7)]
+    /// List persistent named machine specs (alias: `ps`)
+    #[command(name = "ls", visible_alias = "ps", display_order = 7)]
     Ls(MachineListArgs),
     /// Show one persistent named machine spec
     #[command(display_order = 8)]
@@ -3618,6 +3618,11 @@ mod tests {
         match parse(&["ls", "--json"]).expect("parse") {
             MachineAction::Ls(args) => assert!(args.json),
             other => panic!("expected ls action, got {other:?}"),
+        }
+        // `ps` is a docker-style visible alias for `ls`.
+        match parse(&["ps", "--json"]).expect("parse ps alias") {
+            MachineAction::Ls(args) => assert!(args.json),
+            other => panic!("expected ls action from `ps`, got {other:?}"),
         }
         match parse(&[
             "start",

--- a/crates/mvm-cli/src/commands/machine/mod.rs
+++ b/crates/mvm-cli/src/commands/machine/mod.rs
@@ -1533,7 +1533,19 @@ fn overwrite_machine_spec(spec: &MachineSpec) -> Result<()> {
 
 fn load_machine_spec(name: &str) -> Result<MachineSpec> {
     validate_machine_name(name)?;
-    load_machine_spec_from_path(&config::machine_spec_path(name))
+    let path = config::machine_spec_path(name);
+    if !path.exists() {
+        // A missing spec is the common beginner error (typo'd name, or the
+        // machine was never created). Give an actionable message with the two
+        // recovery verbs instead of leaking the internal `machine.json` path
+        // through a raw `No such file or directory`.
+        bail!(
+            "machine {name:?} does not exist. \
+             Run `mvmctl machine ls` to list machines, \
+             or `mvmctl machine create --name {name} --image <ref>` to create one."
+        );
+    }
+    load_machine_spec_from_path(&path)
 }
 
 fn load_machine_spec_from_path(path: &Path) -> Result<MachineSpec> {
@@ -1735,7 +1747,7 @@ fn remove_machine(args: MachineRemoveArgs) -> Result<()> {
     for name in &targets {
         validate_machine_name(name)?;
         if !config::machine_state_dir(name).exists() {
-            bail!("machine {:?} does not exist", name);
+            bail!("machine {name:?} does not exist. Run `mvmctl machine ls` to list machines.");
         }
     }
     let mut summaries = Vec::with_capacity(targets.len());
@@ -1754,7 +1766,9 @@ fn remove_machine(args: MachineRemoveArgs) -> Result<()> {
 }
 
 fn ensure_machine_spec_exists(name: &str) -> Result<MachineSpec> {
-    load_machine_spec(name).with_context(|| format!("loading machine spec for {name:?}"))
+    // `load_machine_spec` already emits an actionable "does not exist" message
+    // for a missing spec, so no extra context wrapper is needed here.
+    load_machine_spec(name)
 }
 
 fn mark_machine_started(spec: &mut MachineSpec, resolved_digest: String) {
@@ -4504,7 +4518,10 @@ ssh_agent = true
         let _state = IsolatedMachineState::new();
         let err = ensure_machine_spec_exists("web").expect_err("missing spec rejected");
         let msg = format!("{err:#}");
-        assert!(msg.contains("loading machine spec for \"web\""));
+        // Actionable not-found: names the machine and points at the recovery verbs.
+        assert!(msg.contains("machine \"web\" does not exist"), "msg: {msg}");
+        assert!(msg.contains("machine ls"), "msg: {msg}");
+        assert!(msg.contains("machine create"), "msg: {msg}");
     }
 
     #[test]

--- a/crates/mvm-cli/src/commands/machine/mod.rs
+++ b/crates/mvm-cli/src/commands/machine/mod.rs
@@ -673,9 +673,10 @@ struct MachineSpec {
 
 #[derive(ClapArgs, Debug, Clone)]
 pub(in crate::commands) struct MachineCreateArgs {
-    /// Persistent machine name. Lowercase alphanumeric plus hyphens.
+    /// Persistent machine name (auto-generated and printed if omitted).
+    /// Lowercase alphanumeric plus hyphens.
     #[arg(long)]
-    pub name: String,
+    pub name: Option<String>,
     /// Image-backed machine manifest (`mvm.toml`, its directory, or
     /// `Mvmfile.toml`) to source defaults from. If omitted and `--image` is not
     /// set, the current directory is searched.
@@ -967,7 +968,15 @@ struct MachineStartReceiptSignature {
 
 impl MachineCreateArgs {
     fn into_spec(self) -> Result<MachineSpec> {
-        validate_machine_name(&self.name)?;
+        // Auto-generate a name when `--name` is omitted, mirroring `machine run
+        // -d` (`create_machine` prints the chosen name).
+        let name = match self.name {
+            Some(name) => {
+                validate_machine_name(&name)?;
+                name
+            }
+            None => auto_machine_name(),
+        };
         let manifest_source = match (self.image.is_none(), self.manifest.as_deref()) {
             (_, Some(arg)) => Some(load_machine_manifest_source(Path::new(arg))?),
             (true, None) => Some(load_machine_manifest_source(Path::new(".")).with_context(
@@ -1031,7 +1040,7 @@ impl MachineCreateArgs {
         };
         Ok(MachineSpec {
             schema_version: MACHINE_SPEC_SCHEMA_VERSION,
-            name: self.name,
+            name,
             image: Some(image),
             manifest: None,
             resolved_digest: None,
@@ -3599,7 +3608,7 @@ mod tests {
         .expect("parse");
         match action {
             MachineAction::Create(args) => {
-                assert_eq!(args.name, "web");
+                assert_eq!(args.name.as_deref(), Some("web"));
                 assert_eq!(args.image.as_deref(), Some("ghcr.io/acme/web:latest"));
                 assert!(args.net);
                 assert_eq!(args.allow_host, vec!["api.example.com:443"]);
@@ -3804,7 +3813,7 @@ mod tests {
     fn create_persists_machine_spec_under_data_dir() {
         let _state = IsolatedMachineState::new();
         let args = MachineCreateArgs {
-            name: "web".to_string(),
+            name: Some("web".to_string()),
             manifest: None,
             image: Some("alpine:latest".to_string()),
             net: true,
@@ -3826,6 +3835,30 @@ mod tests {
         assert_eq!(loaded.schema_version, MACHINE_SPEC_SCHEMA_VERSION);
         assert!(loaded.created_at.is_some());
         assert!(loaded.last_started_at.is_none());
+    }
+
+    #[test]
+    fn create_auto_generates_a_name_when_omitted() {
+        let _state = IsolatedMachineState::new();
+        let spec = MachineCreateArgs {
+            name: None,
+            manifest: None,
+            image: Some("alpine:latest".to_string()),
+            net: false,
+            allow_host: Vec::new(),
+            cpus: None,
+            memory: None,
+            mem_initial: None,
+            profile: None,
+            force: false,
+            json: false,
+        }
+        .into_spec()
+        .expect("auto-named spec");
+        // A generated name is present and passes the same validation as an
+        // explicit one, so a subsequent `start`/`ls`/`rm` can reference it.
+        assert!(!spec.name.is_empty());
+        validate_machine_name(&spec.name).expect("generated name is valid");
     }
 
     #[test]
@@ -3855,7 +3888,7 @@ ssh_agent = true
         .expect("manifest");
 
         let spec = MachineCreateArgs {
-            name: "web".to_string(),
+            name: Some("web".to_string()),
             manifest: Some(dir.path().join("mvm.toml").display().to_string()),
             image: None,
             net: false,
@@ -3890,7 +3923,7 @@ ssh_agent = true
         let dir = tempfile::tempdir().expect("tempdir");
         std::fs::write(dir.path().join("mvm.toml"), "flake = \".\"\n").expect("manifest");
         let err = MachineCreateArgs {
-            name: "web".to_string(),
+            name: Some("web".to_string()),
             manifest: Some(dir.path().join("mvm.toml").display().to_string()),
             image: None,
             net: false,
@@ -3919,7 +3952,7 @@ ssh_agent = true
         )
         .expect("manifest");
         let err = MachineCreateArgs {
-            name: "web".to_string(),
+            name: Some("web".to_string()),
             manifest: Some(dir.path().join("mvm.toml").display().to_string()),
             image: None,
             net: false,
@@ -3948,7 +3981,7 @@ ssh_agent = true
         )
         .expect("manifest");
         let err = MachineCreateArgs {
-            name: "web".to_string(),
+            name: Some("web".to_string()),
             manifest: Some(dir.path().join("mvm.toml").display().to_string()),
             image: None,
             net: false,
@@ -4280,7 +4313,7 @@ ssh_agent = true
     #[test]
     fn create_rejects_unsafe_machine_name() {
         let args = MachineCreateArgs {
-            name: "../web".to_string(),
+            name: Some("../web".to_string()),
             manifest: None,
             image: Some("alpine:latest".to_string()),
             net: false,
@@ -4569,7 +4602,7 @@ ssh_agent = true
         match cli.command {
             Commands::Machine(args) => match args.action {
                 MachineAction::Create(create) => {
-                    assert_eq!(create.name, "web");
+                    assert_eq!(create.name.as_deref(), Some("web"));
                     assert_eq!(create.image.as_deref(), Some("alpine"));
                 }
                 other => panic!("expected create action, got {other:?}"),

--- a/crates/mvm-cli/src/commands/machine/mod.rs
+++ b/crates/mvm-cli/src/commands/machine/mod.rs
@@ -339,7 +339,7 @@ impl MachineRunArgs {
     fn resolve_mode(&self) -> Result<MachineRunMode> {
         let mode = match (self.interactive(), self.persistent()) {
             (true, true) => bail!(
-                "`machine run -it` is foreground-only; use `machine exec --name <name> -it -- <cmd>` for an interactive command in a long-lived machine"
+                "`machine run -it` is foreground-only; use `machine exec <name> -it -- <cmd>` for an interactive command in a long-lived machine"
             ),
             (false, true) => MachineRunMode::Persistent,
             // Fresh-boot modes always materialize a new VM and need an image.
@@ -790,7 +790,7 @@ pub(in crate::commands) struct MachineStartArgs {
 #[derive(ClapArgs, Debug, Clone)]
 pub(in crate::commands) struct MachineExecArgs {
     /// Persistent machine name.
-    #[arg(long)]
+    #[arg(value_name = "NAME")]
     pub name: String,
     /// Bypass the sealed-image accessibility check.
     #[arg(long)]
@@ -809,7 +809,7 @@ pub(in crate::commands) struct MachineExecArgs {
 #[derive(ClapArgs, Debug, Clone)]
 pub(in crate::commands) struct MachineShellArgs {
     /// Persistent machine name.
-    #[arg(long)]
+    #[arg(value_name = "NAME")]
     pub name: String,
     /// Bypass the sealed-image accessibility check.
     #[arg(long)]
@@ -3676,7 +3676,7 @@ mod tests {
 
     #[test]
     fn exec_shell_and_stop_parse() {
-        match parse(&["exec", "--name", "web", "--", "echo", "hello world"]).expect("parse") {
+        match parse(&["exec", "web", "--", "echo", "hello world"]).expect("parse") {
             MachineAction::Exec(args) => {
                 assert_eq!(args.name, "web");
                 assert_eq!(args.argv, vec!["echo", "hello world"]);
@@ -3686,7 +3686,7 @@ mod tests {
             }
             other => panic!("expected exec action, got {other:?}"),
         }
-        match parse(&["shell", "--name", "web", "--force"]).expect("parse") {
+        match parse(&["shell", "web", "--force"]).expect("parse") {
             MachineAction::Shell(args) => {
                 assert_eq!(args.name, "web");
                 assert!(args.force);
@@ -3704,13 +3704,13 @@ mod tests {
 
     #[test]
     fn exec_requires_argv() {
-        let err = parse(&["exec", "--name", "web"]).expect_err("argv is required");
+        let err = parse(&["exec", "web"]).expect_err("argv is required");
         assert_eq!(err.kind(), clap::error::ErrorKind::MissingRequiredArgument);
     }
 
     #[test]
     fn exec_accepts_it_for_pty_command() {
-        match parse(&["exec", "--name", "web", "-it", "--", "/bin/sh"]).expect("parse") {
+        match parse(&["exec", "web", "-it", "--", "/bin/sh"]).expect("parse") {
             MachineAction::Exec(args) => {
                 assert_eq!(args.name, "web");
                 assert!(args.tty);
@@ -4575,10 +4575,8 @@ ssh_agent = true
 
     #[test]
     fn top_level_cli_routes_machine_exec() {
-        let cli = Cli::try_parse_from([
-            "mvmctl", "machine", "exec", "--name", "web", "--", "echo", "hi",
-        ])
-        .expect("top-level parse");
+        let cli = Cli::try_parse_from(["mvmctl", "machine", "exec", "web", "--", "echo", "hi"])
+            .expect("top-level parse");
         match cli.command {
             Commands::Machine(args) => match args.action {
                 MachineAction::Exec(exec) => {

--- a/crates/mvm-cli/src/commands/machine/mod.rs
+++ b/crates/mvm-cli/src/commands/machine/mod.rs
@@ -739,7 +739,7 @@ pub(in crate::commands) struct MachineRemoveArgs {
     /// Remove all persistent machine specs.
     #[arg(long, conflicts_with = "names")]
     pub all: bool,
-    /// Confirm deletion.
+    /// Skip the interactive confirmation prompt.
     #[arg(long)]
     pub yes: bool,
     /// Print a JSON deletion summary.
@@ -1737,10 +1737,24 @@ fn remove_machine(args: MachineRemoveArgs) -> Result<()> {
         return Ok(());
     }
     if !args.yes {
-        bail!(
-            "refusing to remove {} machine(s) without --yes",
-            targets.len()
-        );
+        use std::io::IsTerminal as _;
+        // Prompt for confirmation like `machine stop`. Only prompt on an
+        // interactive terminal; a non-interactive caller that didn't pass
+        // `--yes` declines (never block a script waiting on `/dev/tty`).
+        let prompt = if targets.len() == 1 {
+            format!("Remove machine {:?}?", targets[0])
+        } else {
+            format!(
+                "Remove {} machines ({})?",
+                targets.len(),
+                targets.join(", ")
+            )
+        };
+        let confirmed = std::io::stdin().is_terminal() && crate::ui::confirm(&prompt);
+        if !confirmed {
+            println!("aborted");
+            return Ok(());
+        }
     }
     // Validate the whole set before deleting anything so a single typo doesn't
     // leave a partially-removed batch behind (all-or-nothing on missing specs).
@@ -4473,15 +4487,14 @@ ssh_agent = true
     }
 
     #[test]
-    fn remove_machine_batch_requires_confirmation_and_keeps_all_specs() {
+    fn remove_machine_batch_declines_without_confirmation_and_keeps_all_specs() {
         let _state = IsolatedMachineState::new();
         for name in ["web", "db"] {
             seed_machine_spec(name);
         }
-        let err = remove_machine(rm_args(&["web", "db"], false, false))
-            .expect_err("confirmation required");
-        assert!(err.to_string().contains("without --yes"));
-        // Nothing removed when confirmation is missing.
+        // No `--yes` on a non-interactive stdin: the prompt is declined, nothing
+        // is removed, and it is not an error (mirrors `machine stop`).
+        remove_machine(rm_args(&["web", "db"], false, false)).expect("declined without error");
         assert!(config::machine_state_dir("web").exists());
         assert!(config::machine_state_dir("db").exists());
     }

--- a/crates/mvm-sdk/src/facade.rs
+++ b/crates/mvm-sdk/src/facade.rs
@@ -459,7 +459,7 @@ mod tests {
         let cmd = vec!["sh".to_string(), "-lc".to_string(), "echo ok".to_string()];
         assert_eq!(
             exec_args(&id, cmd).unwrap(),
-            vec!["exec", "--name", "web", "--", "sh", "-lc", "echo ok"]
+            vec!["exec", "web", "--", "sh", "-lc", "echo ok"]
         );
     }
 }

--- a/crates/mvm-sdk/src/machine.rs
+++ b/crates/mvm-sdk/src/machine.rs
@@ -149,7 +149,7 @@ impl Machine {
         MachineStartBuilder::new(self.name.clone())
     }
 
-    /// Build a `mvmctl machine exec --name <name> -- <command...>` invocation.
+    /// Build a `mvmctl machine exec <name> -- <command...>` invocation.
     pub fn exec<I, S>(&self, command: I) -> MachineExecBuilder
     where
         I: IntoIterator<Item = S>,
@@ -158,7 +158,7 @@ impl Machine {
         MachineExecBuilder::new(self.name.clone(), collect_strings(command))
     }
 
-    /// Build a `mvmctl machine shell --name <name>` invocation.
+    /// Build a `mvmctl machine shell <name>` invocation.
     pub fn shell(&self) -> MachineShellBuilder {
         MachineShellBuilder::new(self.name.clone())
     }
@@ -693,7 +693,8 @@ impl MachineExecBuilder {
     pub fn machine_args(&self) -> Result<Vec<String>, MachineError> {
         let name = require_non_empty(self.name.clone(), "name")?;
         require_non_empty_slice(&self.command, "command")?;
-        let mut args = vec!["exec".to_string(), "--name".to_string(), name];
+        // `machine exec` takes a positional name, not `--name`.
+        let mut args = vec!["exec".to_string(), name];
         if self.force {
             args.push("--force".to_string());
         }
@@ -734,7 +735,8 @@ impl MachineShellBuilder {
     /// Return the `machine` subcommand argv, excluding the `mvmctl` program.
     pub fn machine_args(&self) -> Result<Vec<String>, MachineError> {
         let name = require_non_empty(self.name.clone(), "name")?;
-        let mut args = vec!["shell".to_string(), "--name".to_string(), name];
+        // `machine shell` takes a positional name, not `--name`.
+        let mut args = vec!["shell".to_string(), name];
         if self.force {
             args.push("--force".to_string());
         }

--- a/crates/mvm-sdk/tests/machine.rs
+++ b/crates/mvm-sdk/tests/machine.rs
@@ -226,9 +226,7 @@ fn persistent_machine_lifecycle_builders_reuse_machine_cli() {
         .expect("exec");
     assert_eq!(
         fake.argv(),
-        [
-            "machine", "exec", "--name", "devbox", "--force", "--", "echo", "hi",
-        ]
+        ["machine", "exec", "devbox", "--force", "--", "echo", "hi",]
     );
 
     machine
@@ -236,10 +234,7 @@ fn persistent_machine_lifecycle_builders_reuse_machine_cli() {
         .force(true)
         .run_with(&client)
         .expect("shell");
-    assert_eq!(
-        fake.argv(),
-        ["machine", "shell", "--name", "devbox", "--force"]
-    );
+    assert_eq!(fake.argv(), ["machine", "shell", "devbox", "--force"]);
 
     machine.stop().run_with(&client).expect("stop");
     // `machine stop` takes a positional name, not `--name`, plus `--yes` to

--- a/public/src/content/docs/getting-started/quickstart.md
+++ b/public/src/content/docs/getting-started/quickstart.md
@@ -37,7 +37,7 @@ For a named machine that survives across starts:
 ```bash
 mvmctl machine create --name alpine-dev --image alpine
 mvmctl machine start alpine-dev
-mvmctl machine exec --name alpine-dev -- uname -a
+mvmctl machine exec alpine-dev -- uname -a
 mvmctl machine stop alpine-dev
 ```
 

--- a/public/src/content/docs/guides/machine-use-cases.md
+++ b/public/src/content/docs/guides/machine-use-cases.md
@@ -57,8 +57,8 @@ Use named machines when you want state across starts:
 ```bash
 mvmctl machine create --name alpine-dev --image alpine:3.20 --net
 mvmctl machine start alpine-dev
-mvmctl machine exec --name alpine-dev -- apk add jq
-mvmctl machine shell --name alpine-dev
+mvmctl machine exec alpine-dev -- apk add jq
+mvmctl machine shell alpine-dev
 mvmctl machine stop alpine-dev
 ```
 
@@ -100,7 +100,7 @@ Use it only when the host has `SSH_AUTH_SOCK` pointing to a Unix socket:
 
 ```bash
 mvmctl machine create --name dev --image alpine:3.20 --ssh-agent
-mvmctl machine exec --name dev -- env | grep SSH_AUTH_SOCK
+mvmctl machine exec dev -- env | grep SSH_AUTH_SOCK
 ```
 
 The guest sees `/run/mvm/ssh-agent.sock`; the private keys remain controlled by

--- a/public/src/content/docs/guides/troubleshooting.md
+++ b/public/src/content/docs/guides/troubleshooting.md
@@ -244,8 +244,8 @@ with no other config flags — a matching config reuses the running machine.
 
 ```bash
 mvmctl machine ls                 # list persisted machines
-mvmctl machine shell --name <N>   # interactive shell (dev)
-mvmctl machine exec  --name <N> -- <cmd>   # one-shot command
+mvmctl machine shell <N>          # interactive shell (dev)
+mvmctl machine exec  <N> -- <cmd>   # one-shot command
 mvmctl machine stop  <N>          # tear it down (prompts; add --yes to skip)
 ```
 

--- a/public/src/content/docs/reference/cli-commands.md
+++ b/public/src/content/docs/reference/cli-commands.md
@@ -475,7 +475,9 @@ both. When `--image` is omitted, it searches the current directory for
 persisted spec carries the manifest's image, CPU/memory sizing, `mem_initial`,
 network defaults, allow-hosts, and volumes. Relative manifest volume host paths
 are resolved relative to the manifest file; volume validation keeps the shared
-default of read-only mounts unless `:rw` is explicit.
+default of read-only mounts unless `:rw` is explicit. `--name` is optional: when
+omitted, `machine create` auto-generates a name and prints it (mirroring
+`machine run -d`).
 
 `machine start`, `machine exec`, `machine shell`, and `machine stop` require the
 named `MachineSpec` to exist first. `machine start` resolves the stored OCI

--- a/public/src/content/docs/reference/cli-commands.md
+++ b/public/src/content/docs/reference/cli-commands.md
@@ -396,7 +396,7 @@ or mounts private keys, `~/.ssh`, known-hosts material, or SSH config.
 | `mvmctl machine run --image <ref> --json -- <cmd>` | Print a redacted JSON execution summary |
 | `mvmctl machine run --image <ref> --receipt <path> -- <cmd>` | Write a signed execution receipt |
 | `mvmctl machine run -d --image <ref>` | Boot a **persistent** machine, auto-name it (printed), return |
-| `mvmctl machine run -d --name <name> --image <ref>` | Boot a **persistent** named machine, return; reconnect via `machine shell --name <name>` |
+| `mvmctl machine run -d --name <name> --image <ref>` | Boot a **persistent** named machine, return; reconnect via `machine shell <name>` |
 | `mvmctl machine run --name <name> --image <ref> -- <cmd>` | Boot a named foreground transient machine, run `<cmd>`, tear down |
 | `mvmctl machine run -it --image <ref> -- <cmd>` | Run `<cmd>` attached to a PTY, return its exit code, tear down |
 | `mvmctl machine run -it --name <name> --image <ref> -- <cmd>` | Same, with a stable transient VM name while it runs |
@@ -417,9 +417,9 @@ or mounts private keys, `~/.ssh`, known-hosts material, or SSH config.
 | `mvmctl machine rm <name>... --yes` | Remove one or more persisted named machine specs |
 | `mvmctl machine rm --all --yes` | Remove every persisted named machine spec |
 | `mvmctl machine rm <name>... --yes --json` | Print a JSON array deletion summary |
-| `mvmctl machine exec --name <name> -- <cmd>...` | Run a command in an already-started named machine |
-| `mvmctl machine exec --name <name> -it -- <cmd>...` | Run a command in an already-started named machine attached to a PTY |
-| `mvmctl machine shell --name <name>` | Attach an interactive shell/console to an already-started named machine |
+| `mvmctl machine exec <name> -- <cmd>...` | Run a command in an already-started named machine |
+| `mvmctl machine exec <name> -it -- <cmd>...` | Run a command in an already-started named machine attached to a PTY |
+| `mvmctl machine shell <name>` | Attach an interactive shell/console to an already-started named machine |
 | `mvmctl machine stop <name>` | Stop an already-started named machine (prompts for confirmation; pass `--yes` to skip) |
 | `mvmctl machine check-artifact <artifact.mvm>` | Verify a portable artifact and preview its admission posture without extracting or booting |
 | `mvmctl machine check-artifact <artifact.mvm> --key <pubkey>` | Verify with an explicit raw Ed25519 public key |
@@ -455,9 +455,9 @@ Use the explicit persistent lifecycle when you want the VM to survive:
 
 ```bash
 mvmctl machine run -d --image alpine          # boots, prints e.g. "blue-fox-3f2a", returns
-mvmctl machine shell --name blue-fox-3f2a     # reconnect (dev PTY)
-mvmctl machine exec  --name blue-fox-3f2a -- ps   # one-shot command in the running machine
-mvmctl machine exec  --name blue-fox-3f2a -it -- /bin/sh   # PTY command in the running machine
+mvmctl machine shell blue-fox-3f2a            # reconnect (dev PTY)
+mvmctl machine exec  blue-fox-3f2a -- ps          # one-shot command in the running machine
+mvmctl machine exec  blue-fox-3f2a -it -- /bin/sh   # PTY command in the running machine
 mvmctl machine stop  blue-fox-3f2a --yes      # tear it down when done
 ```
 
@@ -466,7 +466,7 @@ mvmctl machine stop  blue-fox-3f2a --yes      # tear it down when done
 **Interactive is dev-only.** `-t`/`--tty` attaches the foreground command to a
 PTY and is refused for a sealed/production image (claim 15 — no interactive
 access to a sealed microVM) and when stdin is not a terminal. `machine run -it`
-requires an argv after `--`; use `machine shell --name <name>` for the default
+requires an argv after `--`; use `machine shell <name>` for the default
 shell on an already-running machine.
 
 `machine create` accepts either `--image <ref>` or an image-backed manifest, not

--- a/public/src/content/docs/reference/cli-commands.md
+++ b/public/src/content/docs/reference/cli-commands.md
@@ -410,7 +410,7 @@ or mounts private keys, `~/.ssh`, known-hosts material, or SSH config.
 | `mvmctl machine start <name> --dry-run --json` | Print the machine-start preflight summary as redacted JSON |
 | `mvmctl machine start <name> --json` | Print a redacted JSON start summary instead of plain text |
 | `mvmctl machine start <name> --receipt <path>` | Write a signed machine-start receipt with effective policy plus the resolved digest and start timestamp |
-| `mvmctl machine ls` | List persisted named machine specs |
+| `mvmctl machine ls` (alias `ps`) | List persisted named machine specs |
 | `mvmctl machine ls --json` | Print persisted named machine specs as JSON |
 | `mvmctl machine inspect <name>` | Show one persisted named machine spec |
 | `mvmctl machine inspect <name> --json` | Print one persisted named machine spec as JSON |

--- a/sdks/machine-fixtures/exec.argv
+++ b/sdks/machine-fixtures/exec.argv
@@ -1,5 +1,4 @@
 exec
---name
 web
 --force
 --

--- a/sdks/machine-fixtures/shell.argv
+++ b/sdks/machine-fixtures/shell.argv
@@ -1,4 +1,3 @@
 shell
---name
 web
 --force

--- a/sdks/python/mvm/_machine.py
+++ b/sdks/python/mvm/_machine.py
@@ -237,7 +237,8 @@ def _machine_exec_argv(
     command = _string_list(command, "command")
     if not command:
         raise ValueError("command must be non-empty")
-    argv = ["exec", "--name", _require_non_empty_str(name, "name")]
+    # `machine exec` takes a positional name, not `--name`.
+    argv = ["exec", _require_non_empty_str(name, "name")]
     if force:
         argv.append("--force")
     argv.extend(["--", *command])
@@ -245,7 +246,8 @@ def _machine_exec_argv(
 
 
 def _machine_shell_argv(*, name: str, force: bool = False) -> list[str]:
-    argv = ["shell", "--name", _require_non_empty_str(name, "name")]
+    # `machine shell` takes a positional name, not `--name`.
+    argv = ["shell", _require_non_empty_str(name, "name")]
     if force:
         argv.append("--force")
     return argv

--- a/sdks/python/tests/test_machine.py
+++ b/sdks/python/tests/test_machine.py
@@ -223,7 +223,7 @@ def test_machine_persistent_lifecycle_shells_to_cli(tmp_path: Path) -> None:
     assert "verb=start" in text
     assert "devbox --dry-run" in text
     assert "verb=exec" in text
-    assert "--name devbox --force -- echo hi" in text
+    assert "devbox --force -- echo hi" in text
     assert "verb=shell" in text
     assert "verb=stop" in text
 

--- a/sdks/typescript/src/_machine.ts
+++ b/sdks/typescript/src/_machine.ts
@@ -223,14 +223,16 @@ export function machineExecArgv(
 ): string[] {
   command = requireStringArray(command, "command");
   if (command.length === 0) throw new RangeError("command must be non-empty");
-  const argv = ["exec", "--name", requireString(name, "name")];
+  // `machine exec` takes a positional name, not `--name`.
+  const argv = ["exec", requireString(name, "name")];
   if (options.force) argv.push("--force");
   argv.push("--", ...command);
   return argv;
 }
 
 export function machineShellArgv(name: string, options: MachineShellOptions = {}): string[] {
-  const argv = ["shell", "--name", requireString(name, "name")];
+  // `machine shell` takes a positional name, not `--name`.
+  const argv = ["shell", requireString(name, "name")];
   if (options.force) argv.push("--force");
   return argv;
 }

--- a/sdks/typescript/tests/machine.test.ts
+++ b/sdks/typescript/tests/machine.test.ts
@@ -194,8 +194,8 @@ describe("Machine persistent lifecycle", () => {
     const text = readFixtureLog().join("\n");
     expect(text).toContain("machine:create --name devbox --manifest mvm.toml --profile dev --force");
     expect(text).toContain("machine:start devbox --dry-run");
-    expect(text).toContain("machine:exec --name devbox --force -- echo hi");
-    expect(text).toContain("machine:shell --name devbox --force");
+    expect(text).toContain("machine:exec devbox --force -- echo hi");
+    expect(text).toContain("machine:shell devbox --force");
     expect(text).toContain("machine:stop devbox --yes");
   });
 


### PR DESCRIPTION
## What

`machine create` required `--name`. It now **auto-generates a name when `--name` is omitted** (and prints it via the existing `created machine <name>` line), mirroring `machine run -d`. This removes the last inconsistency the DX review flagged between `create` (was name-required) and `run -d` (auto-names).

The generated name passes the same `validate_machine_name` check as an explicit one, so a later `start`/`ls`/`rm` can reference it.

## No contract change

Passing `--name` is unchanged and still valid, so the Rust/Python/TS SDK `create` builders and the shared `create-manifest.argv` fixture are untouched.

## Verification

- Full `mvm-cli` suite (1205) ✓, incl. a new `create_auto_generates_a_name_when_omitted` test.
- Runtime: `machine create --image alpine` → `created machine snug-panda-62a2`, then listed by `machine ls`.

## Stacked on #1445 → #1444 → #1443 → #1441 → #1440.

🤖 Generated with [Claude Code](https://claude.com/claude-code)