### PR TITLE
feat(machine): batch `machine start <name>...`

### DIFF
--- a/crates/mvm-cli/src/commands/machine/mod.rs
+++ b/crates/mvm-cli/src/commands/machine/mod.rs
@@ -69,9 +69,9 @@ pub(in crate::commands) enum MachineAction {
     /// Create or update a persistent named machine spec without booting it
     #[command(display_order = 3)]
     Create(MachineCreateArgs),
-    /// Boot a persistent named machine without running a one-shot command
+    /// Boot one or more persistent named machines without running a one-shot command
     #[command(display_order = 4)]
-    Start(MachineStartArgs),
+    Start(MachineStartCmd),
     /// Stop a running VM by name, or all running VMs with --all
     #[command(display_order = 5)]
     Stop(MachineStopArgs),
@@ -786,6 +786,87 @@ pub(in crate::commands) struct MachineStartArgs {
     /// is up. Not a CLI flag — set programmatically by `run_persistent`.
     #[arg(skip)]
     pub has_ad_hoc_argv: bool,
+}
+
+/// CLI surface for `machine start`: one or more machine names plus the shared
+/// start flags. Each name is booted through the single-machine
+/// [`MachineStartArgs`] path, so the internal persistent-run caller and
+/// `start_machine` are untouched. `--receipt`/`--json`/`--dry-run` are
+/// single-machine outputs and are refused when more than one name is given.
+#[derive(ClapArgs, Debug, Clone)]
+pub(in crate::commands) struct MachineStartCmd {
+    /// Persistent machine name(s) to boot.
+    #[arg(value_name = "NAME", required = true)]
+    pub names: Vec<String>,
+    /// Write a signed machine-start receipt to this path (single machine only).
+    #[arg(long, value_name = "PATH")]
+    pub receipt: Option<PathBuf>,
+    /// Print a machine-readable, redacted start summary as JSON (single machine only).
+    #[arg(long)]
+    pub json: bool,
+    /// Validate and explain the effective start without booting a VM (single machine only).
+    #[arg(long)]
+    pub dry_run: bool,
+    /// Workload VMM backend. Defaults to the host's best supported backend
+    /// (Linux+KVM → firecracker; macOS 26+ → vz; macOS 13-25 → libkrun). On a
+    /// Linux+KVM host, `--hypervisor libkrun` opts into the libkrun runtime instead
+    /// of the firecracker default — both require `/dev/kvm` and enforce claim-10
+    /// egress (qemu is a no-`/dev/kvm` dev/test fallback only). `MVM_HYPERVISOR` is
+    /// the env equivalent.
+    #[arg(long, value_name = "HYPERVISOR")]
+    pub hypervisor: Option<String>,
+    /// Skip plan-admission signing (hidden; for testing only).
+    #[arg(long, hide = true)]
+    pub no_supervisor: bool,
+    /// Boot the locally-built workload kernel from the mvm cache instead of the
+    /// image's own kernel. (Hidden — primarily threaded by `vm rekernel`.)
+    #[arg(long = "kernel-pin", value_name = "PIN", hide = true)]
+    pub kernel_pin: Option<String>,
+}
+
+impl MachineStartCmd {
+    /// Build the single-machine [`MachineStartArgs`] for one name, cloning the
+    /// shared flags. Interactive-only fields (`quiet`, `has_ad_hoc_argv`) stay
+    /// off — those are set by the internal persistent-run path, not the CLI.
+    fn start_args_for(&self, name: &str) -> MachineStartArgs {
+        MachineStartArgs {
+            name: name.to_string(),
+            receipt: self.receipt.clone(),
+            json: self.json,
+            dry_run: self.dry_run,
+            quiet: false,
+            hypervisor: self.hypervisor.clone(),
+            no_supervisor: self.no_supervisor,
+            kernel_pin: self.kernel_pin.clone(),
+            has_ad_hoc_argv: false,
+        }
+    }
+}
+
+/// `machine start <name>...`: boot each named machine. A single name returns
+/// its error directly; a batch continues past a failed start so one bad name
+/// doesn't strand the rest, then fails if any failed.
+fn run_start(cmd: MachineStartCmd) -> Result<()> {
+    if cmd.names.len() > 1 && (cmd.receipt.is_some() || cmd.json || cmd.dry_run) {
+        bail!(
+            "--receipt/--json/--dry-run report on a single machine; \
+             start machines individually to use them"
+        );
+    }
+    if cmd.names.len() == 1 {
+        return start_machine(cmd.start_args_for(&cmd.names[0]));
+    }
+    let mut had_err = false;
+    for name in &cmd.names {
+        if let Err(err) = start_machine(cmd.start_args_for(name)) {
+            eprintln!("failed to start {name}: {err:#}");
+            had_err = true;
+        }
+    }
+    if had_err {
+        bail!("one or more machines failed to start");
+    }
+    Ok(())
 }
 
 #[derive(ClapArgs, Debug, Clone)]
@@ -2631,7 +2712,7 @@ pub(in crate::commands) fn run(cli: &Cli, args: Args, cfg: &MvmConfig) -> Result
         MachineAction::Ls(list_args) => list_machines(list_args),
         MachineAction::Inspect(inspect_args) => inspect_machine(inspect_args),
         MachineAction::Rm(remove_args) => remove_machine(remove_args),
-        MachineAction::Start(start_args) => start_machine(start_args),
+        MachineAction::Start(start_cmd) => run_start(start_cmd),
         MachineAction::Exec(exec_args) => exec_machine(cli, exec_args, cfg),
         MachineAction::Shell(shell_args) => shell_machine(cli, shell_args, cfg),
         MachineAction::Stop(stop_args) => stop_machine(cli, stop_args, cfg),
@@ -3676,7 +3757,7 @@ mod tests {
         .expect("parse")
         {
             MachineAction::Start(args) => {
-                assert_eq!(args.name, "web");
+                assert_eq!(args.names, vec!["web"]);
                 assert_eq!(
                     args.receipt.as_deref(),
                     Some(Path::new("/tmp/web.receipt.json"))
@@ -3736,16 +3817,39 @@ mod tests {
 
     #[test]
     fn start_quiet_is_internal_only_and_defaults_off() {
-        // `quiet` is not a user-facing flag — the standalone `machine start`
-        // and the detached path must keep printing the boot banner.
+        // `quiet` is an internal `MachineStartArgs` field, never a CLI flag —
+        // the standalone `machine start` path keeps printing the boot banner.
         match parse(&["start", "web"]).expect("parse") {
-            MachineAction::Start(args) => assert!(!args.quiet),
+            MachineAction::Start(args) => assert_eq!(args.names, vec!["web"]),
             other => panic!("expected start action, got {other:?}"),
         }
         assert!(
             parse(&["start", "web", "--quiet"]).is_err(),
             "--quiet must not be exposed as a CLI flag"
         );
+    }
+
+    #[test]
+    fn start_parses_multiple_names_and_refuses_single_machine_flags_in_batch() {
+        match parse(&["start", "web", "db", "cache"]).expect("parse batch") {
+            MachineAction::Start(cmd) => assert_eq!(cmd.names, vec!["web", "db", "cache"]),
+            other => panic!("expected start action, got {other:?}"),
+        }
+        // `--receipt`/`--json`/`--dry-run` report on one machine; a batch is
+        // refused before any boot is attempted.
+        let MachineAction::Start(cmd) =
+            parse(&["start", "web", "db", "--receipt", "/tmp/r.json"]).expect("parse")
+        else {
+            panic!("expected start action");
+        };
+        let err = run_start(cmd).expect_err("receipt + batch is refused");
+        assert!(err.to_string().contains("single machine"), "msg: {err}");
+    }
+
+    #[test]
+    fn start_requires_at_least_one_name() {
+        let err = parse(&["start"]).expect_err("a machine name is required");
+        assert_eq!(err.kind(), clap::error::ErrorKind::MissingRequiredArgument);
     }
 
     #[test]
@@ -4659,7 +4763,7 @@ ssh_agent = true
         match cli.command {
             Commands::Machine(args) => match args.action {
                 MachineAction::Start(start) => {
-                    assert_eq!(start.name, "web");
+                    assert_eq!(start.names, vec!["web"]);
                     assert_eq!(
                         start.receipt.as_deref(),
                         Some(Path::new("/tmp/web.receipt.json"))

--- a/crates/mvm-cli/src/commands/machine/mod.rs
+++ b/crates/mvm-cli/src/commands/machine/mod.rs
@@ -821,13 +821,14 @@ pub(in crate::commands) struct MachineShellArgs {
 #[command(group(
     clap::ArgGroup::new("target")
         .required(true)
-        .args(["name", "all"])
+        .args(["names", "all"])
 ))]
 pub(in crate::commands) struct MachineStopArgs {
-    /// VM name to stop.
-    pub name: Option<String>,
+    /// VM name(s) to stop.
+    #[arg(value_name = "NAME")]
+    pub names: Vec<String>,
     /// Stop all running VMs.
-    #[arg(long, conflicts_with = "name")]
+    #[arg(long, conflicts_with = "names")]
     pub all: bool,
     /// Skip the interactive confirmation prompt.
     #[arg(long)]
@@ -2151,19 +2152,50 @@ fn shell_machine(cli: &Cli, args: MachineShellArgs, cfg: &MvmConfig) -> Result<(
 
 fn stop_machine(cli: &Cli, args: MachineStopArgs, cfg: &MvmConfig) -> Result<()> {
     if !args.yes {
-        let prompt = match args.name.as_deref() {
-            Some(name) => format!("Stop machine {name:?}?"),
-            None => "Stop all running machines?".to_string(),
+        use std::io::IsTerminal as _;
+        let prompt = if args.all {
+            "Stop all running machines?".to_string()
+        } else if args.names.len() == 1 {
+            format!("Stop machine {:?}?", args.names[0])
+        } else {
+            format!(
+                "Stop {} machines ({})?",
+                args.names.len(),
+                args.names.join(", ")
+            )
         };
-        if !crate::ui::confirm(&prompt) {
+        // Only prompt on an interactive terminal; a non-interactive caller that
+        // didn't pass `--yes` declines rather than blocking on `/dev/tty`.
+        let confirmed = std::io::stdin().is_terminal() && crate::ui::confirm(&prompt);
+        if !confirmed {
             println!("aborted");
             return Ok(());
         }
     }
-    if let Some(ref name) = args.name {
-        reap_proxy(name);
+    // `--all` stops every running VM in one backend call.
+    if args.all {
+        return down::run(cli, down::Args { name: None }, cfg);
     }
-    down::run(cli, down::Args { name: args.name }, cfg)
+    // Otherwise stop each named machine, continuing past a failure so one bad
+    // name doesn't strand the rest, then fail if any failed.
+    let mut had_err = false;
+    for name in &args.names {
+        reap_proxy(name);
+        if let Err(err) = down::run(
+            cli,
+            down::Args {
+                name: Some(name.clone()),
+            },
+            cfg,
+        ) {
+            eprintln!("failed to stop {name}: {err:#}");
+            had_err = true;
+        }
+    }
+    if had_err {
+        bail!("one or more machines failed to stop");
+    }
+    Ok(())
 }
 
 /// Resolve the spec a persistent run should boot, reconciling the desired
@@ -3737,7 +3769,7 @@ mod tests {
         }
         match parse(&["stop", "web"]).expect("parse") {
             MachineAction::Stop(args) => {
-                assert_eq!(args.name.as_deref(), Some("web"));
+                assert_eq!(args.names, vec!["web"]);
                 assert!(!args.all);
             }
             other => panic!("expected stop action, got {other:?}"),
@@ -4661,15 +4693,23 @@ ssh_agent = true
     fn machine_stop_named_and_all_parse() {
         match parse(&["stop", "web"]).expect("parse named") {
             MachineAction::Stop(args) => {
-                assert_eq!(args.name.as_deref(), Some("web"));
+                assert_eq!(args.names, vec!["web"]);
                 assert!(!args.all);
                 assert!(!args.yes, "confirmation is required by default");
             }
             other => panic!("expected stop action, got {other:?}"),
         }
+        // Multiple names stop as a batch.
+        match parse(&["stop", "web", "db", "cache"]).expect("parse batch") {
+            MachineAction::Stop(args) => {
+                assert_eq!(args.names, vec!["web", "db", "cache"]);
+                assert!(!args.all);
+            }
+            other => panic!("expected stop action, got {other:?}"),
+        }
         match parse(&["stop", "--all"]).expect("parse --all") {
             MachineAction::Stop(args) => {
-                assert!(args.name.is_none());
+                assert!(args.names.is_empty());
                 assert!(args.all);
                 assert!(!args.yes);
             }
@@ -4681,7 +4721,7 @@ ssh_agent = true
     fn machine_stop_yes_skips_confirmation() {
         match parse(&["stop", "web", "--yes"]).expect("parse named --yes") {
             MachineAction::Stop(args) => {
-                assert_eq!(args.name.as_deref(), Some("web"));
+                assert_eq!(args.names, vec!["web"]);
                 assert!(args.yes);
             }
             other => panic!("expected stop action, got {other:?}"),

--- a/crates/mvm-cli/src/commands/tests.rs
+++ b/crates/mvm-cli/src/commands/tests.rs
@@ -1066,7 +1066,7 @@ fn machine_stop_named_and_all_parse() {
     };
     match mg.action {
         machine::MachineAction::Stop(args) => {
-            assert_eq!(args.name.as_deref(), Some("web"));
+            assert_eq!(args.names, vec!["web"]);
             assert!(!args.all);
         }
         _ => panic!("expected stop action"),
@@ -1078,7 +1078,7 @@ fn machine_stop_named_and_all_parse() {
     };
     match mg.action {
         machine::MachineAction::Stop(args) => {
-            assert!(args.name.is_none());
+            assert!(args.names.is_empty());
             assert!(args.all);
         }
         _ => panic!("expected stop action"),

--- a/public/src/content/docs/reference/cli-commands.md
+++ b/public/src/content/docs/reference/cli-commands.md
@@ -63,7 +63,7 @@ templates, the guest-RPC surface, fleet-shaped workflows).
 | `mvmctl up --network-allow host:port` | Allow egress to specific host:port (repeatable, mutually exclusive with preset) |
 | `mvmctl up --seccomp <tier>` | Seccomp profile: `essential`, `minimal`, `standard` (default), `network`, `unrestricted`. The selected tier is enforced through the guest `seccomp.json` manifest and recorded in the signed admission profile for audit. |
 | `mvmctl up --network <name>` | Named dev network to attach VM to (default: "default") |
-| `mvmctl machine stop [name]` | Stop VMs by name, or all if omitted |
+| `mvmctl machine stop [name...]` | Stop one or more VMs by name, or `--all` |
 | `mvmctl ls` | List running VMs (aliases: `ps`, `status`) |
 | `mvmctl ls -a` | Show all VMs including stopped |
 | `mvmctl ls --json` | Output as JSON |
@@ -420,7 +420,7 @@ or mounts private keys, `~/.ssh`, known-hosts material, or SSH config.
 | `mvmctl machine exec <name> -- <cmd>...` | Run a command in an already-started named machine |
 | `mvmctl machine exec <name> -it -- <cmd>...` | Run a command in an already-started named machine attached to a PTY |
 | `mvmctl machine shell <name>` | Attach an interactive shell/console to an already-started named machine |
-| `mvmctl machine stop <name>` | Stop an already-started named machine (prompts for confirmation; pass `--yes` to skip) |
+| `mvmctl machine stop <name>...` | Stop one or more already-started named machines (prompts for confirmation; pass `--yes` to skip) |
 | `mvmctl machine check-artifact <artifact.mvm>` | Verify a portable artifact and preview its admission posture without extracting or booting |
 | `mvmctl machine check-artifact <artifact.mvm> --key <pubkey>` | Verify with an explicit raw Ed25519 public key |
 | `mvmctl machine check-artifact <artifact.mvm> --json` | Print the verified artifact/admission preview as JSON |

--- a/public/src/content/docs/reference/cli-commands.md
+++ b/public/src/content/docs/reference/cli-commands.md
@@ -405,7 +405,7 @@ or mounts private keys, `~/.ssh`, known-hosts material, or SSH config.
 | `mvmctl machine create --name <name> --image <ref> --net --allow-host <host[:port]>` | Persist a named spec with opt-in egress settings for future lifecycle starts |
 | `mvmctl machine create --name <name> --manifest <path>` | Persist an image-backed `mvm.toml` / `Mvmfile.toml` as a named machine spec |
 | `mvmctl machine create --name <name> --image <ref> --force` | Overwrite an existing named machine spec |
-| `mvmctl machine start <name>` | Boot a persisted named machine through the admitted OCI-backed start path |
+| `mvmctl machine start <name>...` | Boot one or more persisted named machines through the admitted OCI-backed start path (`--receipt`/`--json`/`--dry-run` are single-machine) |
 | `mvmctl machine start <name> --dry-run` | Validate and explain the effective machine-start policy without booting a VM |
 | `mvmctl machine start <name> --dry-run --json` | Print the machine-start preflight summary as redacted JSON |
 | `mvmctl machine start <name> --json` | Print a redacted JSON start summary instead of plain text |


### PR DESCRIPTION
## What

`machine start` now accepts **multiple positional names** and boots each, docker-style (`docker start c1 c2 c3`):

```
mvmctl machine start web db cache
```

A single name returns its error directly; a batch continues past a failed start so one bad name doesn't strand the rest, then exits non-zero if any failed (each failure reuses the actionable "does not exist" message from #1443).

## Design

Implemented via a CLI-only `MachineStartCmd` struct that fans out to the existing single-machine `MachineStartArgs` / `start_machine` path — the internal persistent-run caller (`run -d` / `run --name`) and the boot logic are **untouched**. `--receipt`/`--json`/`--dry-run` are single-machine reports and are refused (before any boot) when more than one name is given. A single name parses exactly as before, so the SDK start builder and shared fixtures are unaffected.

## Verification

- Full `mvm-cli` + root `mvmctl` suites (1317) ✓ · clippy `-D warnings` ✓
- Runtime: `start [OPTIONS] <NAME>...`; `start a b --dry-run` refused; `start a b` (missing) reports each and exits non-zero.

## Stacked on #1448 → #1447 → #1445 → #1444 → #1443 → #1441 → #1440.

🤖 Generated with [Claude Code](https://claude.com/claude-code)