### PR TITLE
test(hostd): allow slower broker restart recovery

### DIFF
--- a/crates/mvm-hostd/tests/host_agent_restart.rs
+++ b/crates/mvm-hostd/tests/host_agent_restart.rs
@@ -16,6 +16,7 @@ use tokio::net::UnixStream;
 
 const HOST_AGENT_BIN: &str = env!("CARGO_BIN_EXE_mvm-host-agent");
 const SIGNER_HELPER_BIN: &str = env!("CARGO_BIN_EXE_mvm-signer-helper");
+const BROKER_RECOVERY_TIMEOUT: Duration = Duration::from_secs(30);
 
 struct HostAgentFixture {
     _env: TestEnv,
@@ -105,7 +106,7 @@ impl HostAgentFixture {
     }
 
     async fn wait_for_emit(&self, event: &str) -> ServiceResponse {
-        let deadline = Instant::now() + Duration::from_secs(10);
+        let deadline = Instant::now() + BROKER_RECOVERY_TIMEOUT;
         let mut last_error = None;
         while Instant::now() < deadline {
             match self.try_emit(event).await {


### PR DESCRIPTION
## Summary
- give the host-agent restart recovery poll a named 30s timeout so overloaded CI has enough headroom for broker rebinding
- keep the existing assertion that recovery succeeds and the workload audit chain remains valid

## Validation
- cargo test -p mvm-hostd --test host_agent_restart daemon_crash_mid_flight_loses_at_most_one_call_and_preserves_chain
- cargo test -p mvm-hostd --test host_agent_restart
- cargo clippy -p mvm-hostd --tests -- -D warnings