### PR TITLE
feat(mvm-ext4): native in-inode xattr support (preserve file capabilities)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -310,6 +310,14 @@ jobs:
           [ "$(stat -c '%a' "$mnt/hello")" = "755" ]
           [ "$(stat -c '%a' "$mnt/etc/hosts")" = "644" ]
           [ "$(stat -c '%s' "$mnt/big")" = "716800" ]
+          # Inline xattr: the real kernel reads back the security.capability the
+          # writer emitted, byte-for-byte (getfattr reads raw bytes — no cap
+          # validation — so an arbitrary fixed blob round-trips deterministically).
+          sudo apt-get update && sudo apt-get install -y attr
+          cap=$(sudo getfattr --absolute-names -n security.capability -e hex "$mnt/bin/ping" \
+            | grep '^security.capability=' | cut -d= -f2)
+          echo "security.capability=$cap"
+          [ "$cap" = "0x0000000200300000000000000000000000000000" ]
           echo "pure-Rust ext4 mounted + verified on the real Linux kernel"
       - name: dm-verity root hash + hash tree match real veritysetup
         run: |

--- a/crates/mvm-build/src/rootfs.rs
+++ b/crates/mvm-build/src/rootfs.rs
@@ -134,29 +134,23 @@ pub enum RootfsError {
         #[source]
         source: std::io::Error,
     },
-
-    #[cfg(feature = "pure-mkfs")]
-    #[error("{path} carries an extended attribute ({name}) the in-process writer cannot represent")]
-    PureUnsupportedXattr { path: PathBuf, name: String },
 }
 
 #[cfg(feature = "pure-mkfs")]
 impl RootfsError {
     /// Whether a pure-path failure is a *capacity limit* of the in-process ext4
-    /// writer (the image is too big / too fragmented for the current design),
-    /// meaning the run path can retry via the builder VM. A malformed-tree or
-    /// I/O failure returns `false` and surfaces unchanged.
+    /// writer (the image is too big / too fragmented, or an inode's xattrs
+    /// overflow the in-inode area), meaning the run path can retry via the
+    /// builder VM. A malformed-tree or I/O failure returns `false`.
     pub fn is_pure_capacity_limit(&self) -> bool {
         matches!(self, RootfsError::PureBuild(e) if e.is_capacity_limit())
     }
 
     /// Whether the run path should retry this pure-path failure via the builder
-    /// VM. True when the in-process writer structurally can't emit a faithful
-    /// image — a capacity limit, or a tree carrying an extended attribute the
-    /// writer can't represent (the builder VM's `cp -a` preserves it). A
+    /// VM (which has no such limits and whose `cp -a` preserves xattrs). A
     /// malformed tree or I/O error is genuine and surfaces unchanged.
     pub fn pure_should_fall_back(&self) -> bool {
-        self.is_pure_capacity_limit() || matches!(self, RootfsError::PureUnsupportedXattr { .. })
+        self.is_pure_capacity_limit()
     }
 }
 
@@ -463,18 +457,11 @@ fn collect_nodes(root: &std::path::Path) -> Result<Vec<mvm_ext4::Node>, RootfsEr
                 path: path.clone(),
                 source,
             })?;
-            // The pure writer represents no xattrs. If a real (non-symlink)
-            // entry carries one that matters to the guest — a file capability,
-            // POSIX ACL, or image-authored user/trusted attr — refuse so the run
-            // path falls back to the builder VM (whose `cp -a` preserves it)
-            // rather than silently dropping it. Host-managed labels the guest
-            // re-derives (SELinux/IMA/EVM, macOS `com.apple.*`) are ignored so
-            // they never force a spurious fallback.
-            if !ft.is_symlink()
-                && let Some(name) = blocking_xattr(&path)
-            {
-                return Err(RootfsError::PureUnsupportedXattr { path, name });
-            }
+            // Capture image-semantic xattrs (file capabilities, POSIX ACLs,
+            // user/trusted attrs) so the writer preserves them inline. Attrs too
+            // large for the in-inode area surface later as XattrTooLarge (a
+            // capacity limit → builder-VM fallback). Host-managed labels the
+            // guest re-derives (SELinux/IMA/EVM, macOS `com.apple.*`) are skipped.
             if ft.is_symlink() {
                 let target = std::fs::read_link(&path).map_err(|source| RootfsError::PureWalk {
                     path: path.clone(),
@@ -485,9 +472,11 @@ fn collect_nodes(root: &std::path::Path) -> Result<Vec<mvm_ext4::Node>, RootfsEr
                     target: target.to_string_lossy().into_owned(),
                 });
             } else if ft.is_dir() {
+                let xattrs = collect_guest_xattrs(&path);
                 out.push(mvm_ext4::Node::Dir {
                     path: guest_path,
                     mode: mode_of(&path, 0o755),
+                    xattrs,
                 });
                 stack.push(path);
             } else if ft.is_file() {
@@ -495,10 +484,12 @@ fn collect_nodes(root: &std::path::Path) -> Result<Vec<mvm_ext4::Node>, RootfsEr
                     path: path.clone(),
                     source,
                 })?;
+                let xattrs = collect_guest_xattrs(&path);
                 out.push(mvm_ext4::Node::File {
                     path: guest_path,
                     mode: mode_of(&path, 0o644),
                     data,
+                    xattrs,
                 });
             }
         }
@@ -508,15 +499,26 @@ fn collect_nodes(root: &std::path::Path) -> Result<Vec<mvm_ext4::Node>, RootfsEr
 
 /// The name of the first extended attribute on `path` that the pure writer can't
 /// represent and the guest actually needs, or `None`. Ignores host-managed
-/// labels (SELinux/IMA/EVM, macOS `com.apple.*`) so they never force a fallback.
+/// labels (SELinux/IMA/EVM, macOS `com.apple.*`) so the guest re-derives them.
 #[cfg(feature = "pure-mkfs")]
-fn blocking_xattr(path: &std::path::Path) -> Option<String> {
+fn collect_guest_xattrs(path: &std::path::Path) -> Vec<mvm_ext4::Xattr> {
     // A read failure means the FS doesn't support xattrs (or we lack access):
-    // nothing to preserve, so don't force a fallback.
-    let names = xattr::list(path).ok()?;
-    names
-        .map(|n| n.to_string_lossy().into_owned())
-        .find(|n| xattr_matters_for_guest(n))
+    // nothing to preserve.
+    let Ok(names) = xattr::list(path) else {
+        return Vec::new();
+    };
+    let mut out = Vec::new();
+    for name in names {
+        let name = name.to_string_lossy().into_owned();
+        if xattr_matters_for_guest(&name)
+            && let Ok(Some(value)) = xattr::get(path, &name)
+        {
+            out.push(mvm_ext4::Xattr { name, value });
+        }
+    }
+    // Deterministic order (the writer also sorts, but keep the node stable).
+    out.sort_by(|a, b| a.name.cmp(&b.name));
+    out
 }
 
 /// Whether an xattr name carries guest-relevant image semantics the pure writer
@@ -594,16 +596,16 @@ mod tests {
 
     #[cfg(feature = "pure-mkfs")]
     #[test]
-    fn only_image_semantic_xattrs_force_a_fallback() {
-        // Preserved (image semantics the guest needs and won't re-derive).
+    fn only_image_semantic_xattrs_are_captured() {
+        // Captured (image semantics the guest needs and won't re-derive).
         assert!(xattr_matters_for_guest("security.capability"));
         assert!(xattr_matters_for_guest("system.posix_acl_access"));
         assert!(xattr_matters_for_guest("system.posix_acl_default"));
         assert!(xattr_matters_for_guest("user.mvm.anything"));
         assert!(xattr_matters_for_guest("trusted.foo"));
-        // Ignored: host-managed labels the guest re-derives. Treating SELinux as
-        // blocking would force a builder-VM fallback for *every* image on an
-        // SELinux-labelled host (Fedora/RHEL) — defeating the pure default.
+        // Ignored: host-managed labels the guest re-derives. Capturing SELinux
+        // would attach a host label to *every* file on an SELinux-labelled host
+        // (Fedora/RHEL) and bloat every inode's xattr area for nothing.
         assert!(!xattr_matters_for_guest("security.selinux"));
         assert!(!xattr_matters_for_guest("security.ima"));
         assert!(!xattr_matters_for_guest("security.evm"));
@@ -612,30 +614,49 @@ mod tests {
 
     #[cfg(feature = "pure-mkfs")]
     #[test]
-    fn xattr_bearing_tree_routes_to_builder_vm_fallback() {
+    fn xattr_bearing_tree_materializes_in_process() {
         let src = tempfile::tempdir().unwrap();
         let bin = src.path().join("ping");
         std::fs::write(&bin, b"\x7fELF fake binary").unwrap();
-        // Mirror the OCI unpacker's probe: skip where the host FS can't hold
-        // xattrs (some CI tmpfs). A `user.*` attr is settable on both Linux and
-        // macOS and trips the same "writer can't represent this" branch as a
-        // real `security.capability`.
+        // Skip where the host FS can't hold xattrs (some CI tmpfs). A small
+        // `user.*` attr fits the in-inode area, so the pure writer represents it
+        // and materialize succeeds — no builder-VM fallback.
         if xattr::set(&bin, "user.mvm.test_cap", b"cap").is_err() {
+            return;
+        }
+        assert_eq!(
+            collect_guest_xattrs(&bin),
+            vec![mvm_ext4::Xattr {
+                name: "user.mvm.test_cap".into(),
+                value: b"cap".to_vec(),
+            }],
+            "the walk must capture the image-semantic xattr"
+        );
+        let out = tempfile::tempdir().unwrap();
+        let input =
+            MaterializeExt4Input::new(src.path().to_path_buf(), out.path().join("rootfs.ext4"), 0);
+        materialize_ext4_pure(&input).expect("a small xattr fits inline; materialize succeeds");
+    }
+
+    #[cfg(feature = "pure-mkfs")]
+    #[test]
+    fn oversized_xattr_falls_back_to_builder_vm() {
+        let src = tempfile::tempdir().unwrap();
+        let bin = src.path().join("big");
+        std::fs::write(&bin, b"x").unwrap();
+        // A value far larger than the ~90-byte in-inode area can't be written
+        // inline (no external xattr block yet), so the build errors — and that
+        // error must route to the builder-VM fallback, not surface.
+        if xattr::set(&bin, "user.big", &vec![0u8; 512]).is_err() {
             return;
         }
         let out = tempfile::tempdir().unwrap();
         let input =
             MaterializeExt4Input::new(src.path().to_path_buf(), out.path().join("rootfs.ext4"), 0);
-
-        let err = materialize_ext4_pure(&input)
-            .expect_err("an xattr-bearing tree must not be silently materialized without it");
-        assert!(
-            matches!(err, RootfsError::PureUnsupportedXattr { .. }),
-            "got {err:?}"
-        );
+        let err = materialize_ext4_pure(&input).expect_err("an oversized xattr can't be inline");
         assert!(
             err.pure_should_fall_back(),
-            "an unsupported xattr must route to the builder-VM fallback"
+            "an oversized xattr must route to the builder-VM fallback, got {err:?}"
         );
     }
 

--- a/crates/mvm-ext4/examples/write_extent_tree.rs
+++ b/crates/mvm-ext4/examples/write_extent_tree.rs
@@ -23,16 +23,19 @@ fn main() {
         Node::Dir {
             path: "/etc".into(),
             mode: 0o755,
+            xattrs: Vec::new(),
         },
         Node::File {
             path: "/etc/marker".into(),
             mode: 0o644,
             data: b"extent-tree marker\n".to_vec(),
+            xattrs: Vec::new(),
         },
         Node::File {
             path: "/huge".into(),
             mode: 0o644,
             data: big,
+            xattrs: Vec::new(),
         },
     ];
 

--- a/crates/mvm-ext4/examples/write_multigroup.rs
+++ b/crates/mvm-ext4/examples/write_multigroup.rs
@@ -24,16 +24,19 @@ fn main() {
         Node::Dir {
             path: "/etc".into(),
             mode: 0o755,
+            xattrs: Vec::new(),
         },
         Node::File {
             path: "/etc/marker".into(),
             mode: 0o644,
             data: b"multi-group marker\n".to_vec(),
+            xattrs: Vec::new(),
         },
         Node::File {
             path: "/big".into(),
             mode: 0o644,
             data: big,
+            xattrs: Vec::new(),
         },
     ];
 

--- a/crates/mvm-ext4/examples/write_sample.rs
+++ b/crates/mvm-ext4/examples/write_sample.rs
@@ -7,26 +7,39 @@
 //! The tree here MUST match what `.github/workflows/ci.yml::ext4-real-mount`
 //! asserts after mounting.
 
-use mvm_ext4::{Node, build_image};
+use mvm_ext4::{Node, Xattr, build_image};
 
 fn main() {
     let out = std::env::args()
         .nth(1)
         .expect("usage: write_sample <out.ext4>");
+    // A fixed VFS capability blob (revision 2, cap_net_admin|cap_net_raw
+    // permitted). The CI lane reads it back with `getfattr` to prove the real
+    // kernel sees the inline xattr the writer emitted, byte-for-byte.
+    let cap = vec![
+        0x00, 0x00, 0x00, 0x02, // magic_etc: VFS_CAP_REVISION_2 (LE)
+        0x00, 0x30, 0x00, 0x00, // permitted lo
+        0x00, 0x00, 0x00, 0x00, // inheritable lo
+        0x00, 0x00, 0x00, 0x00, // permitted hi
+        0x00, 0x00, 0x00, 0x00, // inheritable hi
+    ];
     let nodes = vec![
         Node::Dir {
             path: "/etc".into(),
             mode: 0o755,
+            xattrs: Vec::new(),
         },
         Node::File {
             path: "/etc/hosts".into(),
             mode: 0o644,
             data: b"127.0.0.1 localhost\n".to_vec(),
+            xattrs: Vec::new(),
         },
         Node::File {
             path: "/hello".into(),
             mode: 0o755,
             data: b"hi from pure-rust ext4\n".to_vec(),
+            xattrs: Vec::new(),
         },
         Node::Symlink {
             path: "/etc/localhost".into(),
@@ -35,6 +48,16 @@ fn main() {
         Node::Dir {
             path: "/bin".into(),
             mode: 0o755,
+            xattrs: Vec::new(),
+        },
+        Node::File {
+            path: "/bin/ping".into(),
+            mode: 0o755,
+            data: b"\x7fELF fake capability binary".to_vec(),
+            xattrs: vec![Xattr {
+                name: "security.capability".into(),
+                value: cap,
+            }],
         },
         // A big file so the image exceeds 128 data blocks (512 KiB) — this
         // forces a MULTI-level verity hash tree, so the byte-for-byte cmp
@@ -43,6 +66,7 @@ fn main() {
             path: "/big".into(),
             mode: 0o644,
             data: (0..700 * 1024u32).map(|i| (i % 251) as u8).collect(),
+            xattrs: Vec::new(),
         },
     ];
     let image = build_image(&nodes).expect("build ext4 image");

--- a/crates/mvm-ext4/fuzz/fuzz_targets/fuzz_build_image.rs
+++ b/crates/mvm-ext4/fuzz/fuzz_targets/fuzz_build_image.rs
@@ -51,6 +51,7 @@ fn gen_nodes(u: &mut Unstructured) -> arbitrary::Result<Vec<Node>> {
             0 => nodes.push(Node::Dir {
                 path,
                 mode: u16::arbitrary(u)?,
+                            xattrs: Vec::new(),
             }),
             1 => {
                 let want = u.int_in_range(0..=MAX_FILE_BYTES)?;
@@ -60,6 +61,7 @@ fn gen_nodes(u: &mut Unstructured) -> arbitrary::Result<Vec<Node>> {
                     path,
                     mode: u16::arbitrary(u)?,
                     data,
+                                    xattrs: Vec::new(),
                 });
             }
             _ => {
@@ -121,6 +123,7 @@ fn with_ancestor_dirs(nodes: Vec<Node>) -> Vec<Node> {
     }
     let mut out = nodes;
     for path in extra {
+        out.push(Node::Dir { path, mode: 0o755         out.push(Node::Dir { path, mode: 0o755     xattrs: Vec::new(),
         out.push(Node::Dir { path, mode: 0o755 });
     }
     out
@@ -128,6 +131,8 @@ fn with_ancestor_dirs(nodes: Vec<Node>) -> Vec<Node> {
 
 fn node_path(n: &Node) -> String {
     match n {
+        Node::Dir { path, ..         Node::Dir { path, ..     xattrs: Vec::new(),
+        Node::Dir { path, .. } | Node::File { path, ..         Node::Dir { path, .. } | Node::File { path, ..     xattrs: Vec::new(),
         Node::Dir { path, .. } | Node::File { path, .. } | Node::Symlink { path, .. } => {
             path.clone()
         }

--- a/crates/mvm-ext4/src/lib.rs
+++ b/crates/mvm-ext4/src/lib.rs
@@ -97,6 +97,10 @@ pub enum Ext4Error {
     /// Two nodes claim the same path (including a node re-claiming the implicit
     /// root `/`), which would emit duplicate directory entries.
     DuplicatePath(String),
+    /// An inode's extended attributes don't fit the in-inode xattr area (an
+    /// external xattr block is not implemented). Treated as a capacity limit so
+    /// the run path falls back to the builder VM, which preserves them.
+    XattrTooLarge { ino: u32 },
 }
 
 impl std::fmt::Display for Ext4Error {
@@ -124,6 +128,11 @@ impl std::fmt::Display for Ext4Error {
                 write!(f, "parent of {p} is not a directory")
             }
             Ext4Error::DuplicatePath(p) => write!(f, "duplicate path {p}"),
+            Ext4Error::XattrTooLarge { ino } => write!(
+                f,
+                "inode {ino}'s extended attributes exceed the in-inode xattr area \
+                 (an external xattr block is not implemented)"
+            ),
         }
     }
 }
@@ -142,6 +151,7 @@ impl Ext4Error {
             Ext4Error::TooLarge { .. }
                 | Ext4Error::FileTooFragmented { .. }
                 | Ext4Error::DirTooLarge(_)
+                | Ext4Error::XattrTooLarge { .. }
         )
     }
 }
@@ -155,11 +165,13 @@ pub enum Node {
     Dir {
         path: String,
         mode: u16,
+        xattrs: Vec<Xattr>,
     },
     File {
         path: String,
         mode: u16,
         data: Vec<u8>,
+        xattrs: Vec<Xattr>,
     },
     Symlink {
         path: String,
@@ -167,10 +179,27 @@ pub enum Node {
     },
 }
 
+/// An extended attribute (name + raw value) to store in an inode's inline xattr
+/// area. `name` is fully-qualified (e.g. `security.capability`, `user.foo`);
+/// `value` is preserved verbatim.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct Xattr {
+    pub name: String,
+    pub value: Vec<u8>,
+}
+
 impl Node {
     fn path(&self) -> &str {
         match self {
             Node::Dir { path, .. } | Node::File { path, .. } | Node::Symlink { path, .. } => path,
+        }
+    }
+
+    /// The node's extended attributes (empty for symlinks).
+    fn xattrs(&self) -> &[Xattr] {
+        match self {
+            Node::Dir { xattrs, .. } | Node::File { xattrs, .. } => xattrs,
+            Node::Symlink { .. } => &[],
         }
     }
 }
@@ -233,6 +262,9 @@ struct Planned {
     // Directory children: (name, child_ino, child_ft). Filled after planning.
     children: Vec<(String, u32, u8)>,
     links: u16,
+    // Pre-encoded in-inode xattr region (magic + entries + values), written
+    // verbatim at inode offset 160. Empty when the inode has no xattrs.
+    xattr_block: Vec<u8>,
 }
 
 #[derive(Clone, Copy, PartialEq)]
@@ -420,6 +452,7 @@ pub fn build_image(nodes: &[Node]) -> Result<Vec<u8>, Ext4Error> {
         symlink_target: None,
         children: Vec::new(),
         links: 2,
+        xattr_block: Vec::new(),
     });
     for n in &sorted {
         let p = normalize(n.path())?;
@@ -447,6 +480,10 @@ pub fn build_image(nodes: &[Node]) -> Result<Vec<u8>, Ext4Error> {
                 target.len() as u64,
             ),
         };
+        // Encode the inode's xattrs into its in-inode region now; an oversized
+        // set surfaces as XattrTooLarge (a capacity limit → builder-VM fallback).
+        let xattr_block =
+            encode_inline_xattrs(n.xattrs()).ok_or(Ext4Error::XattrTooLarge { ino })?;
         planned.push(Planned {
             ino,
             kind,
@@ -460,6 +497,7 @@ pub fn build_image(nodes: &[Node]) -> Result<Vec<u8>, Ext4Error> {
             symlink_target,
             children: Vec::new(),
             links: if kind == Kind::Dir { 2 } else { 1 },
+            xattr_block,
         });
     }
 
@@ -734,6 +772,82 @@ fn set_bit(bytes: &mut [u8], base: usize, bit: usize) {
     bytes[base + bit / 8] |= 1u8 << (bit % 8);
 }
 
+// In-inode xattr area: starts at 128 + i_extra_isize(32), runs to the end of
+// the 256-byte inode. First 4 bytes are the magic; the rest holds entries
+// (growing forward) + values (packed backward) + a 4-byte terminator.
+const XATTR_REGION_OFFSET: usize = 128 + 32;
+const XATTR_REGION_LEN: usize = INODE_SIZE as usize - XATTR_REGION_OFFSET; // 96
+const XATTR_MAGIC: u32 = 0xEA02_0000;
+
+/// Split a fully-qualified xattr name into its ext4 `e_name_index` + suffix.
+/// `None` for a namespace the on-disk format doesn't encode.
+fn split_xattr_name(name: &str) -> Option<(u8, &str)> {
+    // Exact ACL names (their suffix is empty; the index implies the full name).
+    match name {
+        "system.posix_acl_access" => return Some((2, "")),
+        "system.posix_acl_default" => return Some((3, "")),
+        _ => {}
+    }
+    for (idx, prefix) in [
+        (1u8, "user."),
+        (4, "trusted."),
+        (6, "security."),
+        (7, "system."),
+    ] {
+        if let Some(rest) = name.strip_prefix(prefix) {
+            return Some((idx, rest));
+        }
+    }
+    None
+}
+
+/// Encode `xattrs` into an inode's in-inode xattr region (the bytes written at
+/// [`XATTR_REGION_OFFSET`]: 4-byte magic + entries + values). Returns `None` if
+/// they don't fit or carry an unencodable namespace, so the caller falls back to
+/// the builder VM. Empty input yields an empty region (no xattr area emitted).
+/// Deterministic: entries are sorted by (name_index, suffix).
+fn encode_inline_xattrs(xattrs: &[Xattr]) -> Option<Vec<u8>> {
+    if xattrs.is_empty() {
+        return Some(Vec::new());
+    }
+    let mut items: Vec<(u8, &str, &[u8])> = Vec::with_capacity(xattrs.len());
+    for x in xattrs {
+        let (idx, suffix) = split_xattr_name(&x.name)?;
+        items.push((idx, suffix, x.value.as_slice()));
+    }
+    items.sort_by(|a, b| (a.0, a.1).cmp(&(b.0, b.1)));
+
+    // `e_value_offs` is relative to the entry area (region byte 4), matching the
+    // reader. Entries grow from offset 0 of the entry area; values pack backward
+    // from its end. `entry_end + 4-byte terminator` must not cross `value_cursor`.
+    let entry_area = XATTR_REGION_LEN - 4;
+    let mut region = vec![0u8; XATTR_REGION_LEN];
+    region[0..4].copy_from_slice(&XATTR_MAGIC.to_le_bytes());
+    let mut entry_cursor = 0usize;
+    let mut value_cursor = entry_area;
+    for (idx, suffix, value) in items {
+        let name = suffix.as_bytes();
+        let entry_padded = (16 + name.len() + 3) & !3;
+        let value_padded = (value.len() + 3) & !3;
+        value_cursor = value_cursor.checked_sub(value_padded)?;
+        if entry_cursor + entry_padded + 4 > value_cursor {
+            return None;
+        }
+        let e = 4 + entry_cursor;
+        region[e] = name.len() as u8; // e_name_len
+        region[e + 1] = idx; // e_name_index
+        region[e + 2..e + 4].copy_from_slice(&(value_cursor as u16).to_le_bytes()); // e_value_offs
+        // e_value_inum (e+4..e+8) and e_hash (e+12..e+16) stay zero.
+        region[e + 8..e + 12].copy_from_slice(&(value.len() as u32).to_le_bytes()); // e_value_size
+        region[e + 16..e + 16 + name.len()].copy_from_slice(name);
+        let v = 4 + value_cursor;
+        region[v..v + value.len()].copy_from_slice(value);
+        entry_cursor += entry_padded;
+    }
+    // 4-byte zero terminator after the last entry is already zeroed.
+    Some(region)
+}
+
 fn write_inode(img: &mut Image, layout: &Layout, p: &Planned) {
     let (g, local) = layout.locate_inode(p.ino);
     let off = img.block_off(layout.inode_table(g)) + local as usize * INODE_SIZE as usize;
@@ -746,6 +860,14 @@ fn write_inode(img: &mut Image, layout: &Layout, p: &Planned) {
     let sectors = (p.block_count + p.leaf_blocks.len() as u32) * (BLOCK_SIZE / 512);
     img.put_u32(off + 0x1C, sectors); // i_blocks_lo
     img.put_u16(off + 0x80, 32); // i_extra_isize
+
+    // In-inode extended attributes: pre-encoded region (magic + entries +
+    // values) written at offset 160 (128 + i_extra_isize). Empty for symlinks
+    // and inodes without xattrs. Sits above the i_block/extent region, so it
+    // never overlaps file/dir data layout.
+    if !p.xattr_block.is_empty() {
+        img.put_bytes(off + XATTR_REGION_OFFSET, &p.xattr_block);
+    }
 
     if p.kind == Kind::Symlink && p.extents.is_empty() {
         // Fast symlink: raw target in i_block, no extents flag.

--- a/crates/mvm-ext4/tests/adversarial.rs
+++ b/crates/mvm-ext4/tests/adversarial.rs
@@ -24,11 +24,13 @@ fn parent_that_is_a_file_is_rejected() {
             path: "/a".into(),
             mode: 0o644,
             data: b"x".to_vec(),
+            xattrs: Vec::new(),
         },
         Node::File {
             path: "/a/b".into(),
             mode: 0o644,
             data: b"y".to_vec(),
+            xattrs: Vec::new(),
         },
     ];
     build_image(&nodes).expect_err("a file cannot be a parent directory");
@@ -45,11 +47,13 @@ fn duplicate_paths_are_rejected() {
             path: "/dup".into(),
             mode: 0o644,
             data: b"first".to_vec(),
+            xattrs: Vec::new(),
         },
         Node::File {
             path: "/dup".into(),
             mode: 0o644,
             data: b"second".to_vec(),
+            xattrs: Vec::new(),
         },
     ];
     build_image(&nodes).expect_err("duplicate path must be rejected");
@@ -66,6 +70,7 @@ fn malformed_path_components_are_rejected() {
             path: bad.into(),
             mode: 0o644,
             data: b"x".to_vec(),
+            xattrs: Vec::new(),
         }];
         assert!(
             build_image(&nodes).is_err(),
@@ -86,6 +91,7 @@ fn deep_nesting_round_trips() {
         nodes.push(Node::Dir {
             path: path.clone(),
             mode: 0o755,
+            xattrs: Vec::new(),
         });
     }
     let leaf = format!("{path}/leaf");
@@ -94,6 +100,7 @@ fn deep_nesting_round_trips() {
         path: leaf,
         mode: 0o644,
         data: content.clone(),
+        xattrs: Vec::new(),
     });
 
     let fs = mount(build_image(&nodes).expect("deep valid tree builds"));
@@ -158,11 +165,13 @@ fn directory_over_one_block_is_rejected() {
             path: format!("/big/f{i:04}"),
             mode: 0o644,
             data: Vec::new(),
+            xattrs: Vec::new(),
         });
     }
     nodes.push(Node::Dir {
         path: "/big".into(),
         mode: 0o755,
+        xattrs: Vec::new(),
     });
     assert!(
         matches!(build_image(&nodes), Err(Ext4Error::DirTooLarge(_))),

--- a/crates/mvm-ext4/tests/oracle.rs
+++ b/crates/mvm-ext4/tests/oracle.rs
@@ -85,16 +85,19 @@ fn tree_round_trips_through_real_reader() {
         Node::Dir {
             path: "/etc".into(),
             mode: 0o755,
+            xattrs: Vec::new(),
         },
         Node::File {
             path: "/etc/hosts".into(),
             mode: 0o644,
             data: hosts.clone(),
+            xattrs: Vec::new(),
         },
         Node::File {
             path: "/hello".into(),
             mode: 0o755,
             data: hello.clone(),
+            xattrs: Vec::new(),
         },
         Node::Symlink {
             path: "/etc/localhost".into(),
@@ -131,11 +134,13 @@ fn output_is_deterministic() {
         Node::Dir {
             path: "/a".into(),
             mode: 0o755,
+            xattrs: Vec::new(),
         },
         Node::File {
             path: "/a/f".into(),
             mode: 0o644,
             data: b"xyz".to_vec(),
+            xattrs: Vec::new(),
         },
     ];
     let one = build_image(&nodes).unwrap();
@@ -160,16 +165,19 @@ fn multi_group_image_round_trips_through_real_reader() {
         Node::Dir {
             path: "/etc".into(),
             mode: 0o755,
+            xattrs: Vec::new(),
         },
         Node::File {
             path: "/etc/marker".into(),
             mode: 0o644,
             data: small.clone(),
+            xattrs: Vec::new(),
         },
         Node::File {
             path: "/big".into(),
             mode: 0o644,
             data: big.clone(),
+            xattrs: Vec::new(),
         },
     ];
 
@@ -215,6 +223,7 @@ fn depth1_extent_tree_file_round_trips_through_real_reader() {
         path: "/huge".into(),
         mode: 0o644,
         data: big,
+        xattrs: Vec::new(),
     }];
     let image = build_image(&nodes).unwrap();
 

--- a/crates/mvm-ext4/tests/xattr.rs
+++ b/crates/mvm-ext4/tests/xattr.rs
@@ -1,0 +1,100 @@
+//! Native inline extended-attribute support: a file's `security.capability`
+//! (and other image-semantic xattrs) is written into the inode's in-inode xattr
+//! area and reads back identically through the independent `am-fs-ext4` reader.
+
+use std::sync::Arc;
+
+use fs_ext4::block_io::BlockDevice;
+use fs_ext4::dir::{self, DirEntryType};
+use fs_ext4::file_io;
+use fs_ext4::fs::Filesystem;
+use mvm_ext4::{Node, Xattr, build_image};
+
+struct MemDev(Vec<u8>);
+impl BlockDevice for MemDev {
+    fn read_at(&self, offset: u64, buf: &mut [u8]) -> fs_ext4::error::Result<()> {
+        let s = offset as usize;
+        buf.copy_from_slice(&self.0[s..s + buf.len()]);
+        Ok(())
+    }
+    fn size_bytes(&self) -> u64 {
+        self.0.len() as u64
+    }
+}
+
+fn root_entry(fs: &Filesystem, name: &str) -> (u32, DirEntryType) {
+    let (inode, _) = fs.read_inode_verified(2).unwrap();
+    let data = file_io::read_all(fs, &inode).unwrap();
+    dir::parse_block(&data, true)
+        .unwrap()
+        .into_iter()
+        .find(|e| e.name == name.as_bytes())
+        .map(|e| (e.inode, e.file_type))
+        .unwrap_or_else(|| panic!("/{name} present"))
+}
+
+/// A VFS capability blob (vfs_cap_data v2: magic+flags then two u32 pairs) —
+/// 24 opaque bytes we must preserve verbatim.
+fn cap_value() -> Vec<u8> {
+    let mut v = vec![0u8; 24];
+    v[0..4].copy_from_slice(&0x0200_0002u32.to_le_bytes()); // VFS_CAP_REVISION_2
+    v[4..8].copy_from_slice(&0x0000_2000u32.to_le_bytes()); // permitted: cap_net_bind_service
+    v
+}
+
+fn read_xattrs(dev: Arc<MemDev>, fs: &Filesystem, ino: u32) -> Vec<fs_ext4::xattr::XattrEntry> {
+    let (inode, raw) = fs.read_inode_verified(ino).unwrap();
+    fs_ext4::xattr::read_all(dev.as_ref(), &inode, &raw, 256, 4096).unwrap()
+}
+
+#[test]
+fn file_capability_round_trips_through_the_reader() {
+    let cap = cap_value();
+    let nodes = vec![Node::File {
+        path: "/ping".into(),
+        mode: 0o755,
+        data: b"\x7fELF".to_vec(),
+        xattrs: vec![Xattr {
+            name: "security.capability".into(),
+            value: cap.clone(),
+        }],
+    }];
+    let dev = Arc::new(MemDev(build_image(&nodes).expect("build with xattr")));
+    let fs = Filesystem::mount(dev.clone()).expect("mount");
+
+    let (ino, ft) = root_entry(&fs, "ping");
+    assert_eq!(ft, DirEntryType::RegFile);
+    let xattrs = read_xattrs(dev, &fs, ino);
+    let got = xattrs
+        .iter()
+        .find(|x| x.name == "security.capability")
+        .expect("capability xattr present after round-trip");
+    assert_eq!(got.value, cap, "capability bytes must survive verbatim");
+}
+
+#[test]
+fn xattrs_are_deterministic_and_order_independent() {
+    let mk = |order: bool| {
+        let mut xattrs = vec![
+            Xattr {
+                name: "user.a".into(),
+                value: b"1".to_vec(),
+            },
+            Xattr {
+                name: "security.capability".into(),
+                value: cap_value(),
+            },
+        ];
+        if order {
+            xattrs.reverse();
+        }
+        build_image(&[Node::File {
+            path: "/f".into(),
+            mode: 0o644,
+            data: b"x".to_vec(),
+            xattrs,
+        }])
+        .unwrap()
+    };
+    assert_eq!(mk(false), mk(true), "xattr order must not affect the image");
+}


### PR DESCRIPTION
Follow-up to the fail-safe materialize change (#1442): instead of falling back to the builder VM for any capability-bearing image, the pure writer now **represents xattrs natively**, keeping those images on the in-process path.

## What

- **Writer** — `Node::File`/`Dir` carry `Vec<Xattr>`. The writer encodes them into the inode's in-inode xattr area (the ~92 free bytes after `i_extra_isize`) using the real ext4 on-disk format: `0xEA020000` magic, entries growing forward, values packed backward, `e_value_offs` relative to the entry area, deterministic sort by (name_index, suffix). An oversized set → `XattrTooLarge` (a **capacity limit**, so it still falls back to the builder VM — no external xattr block yet).
- **Walk** — `collect_nodes` now **captures** image-semantic xattrs (`security.capability`, POSIX ACLs, `user.*`/`trusted.*`) into the node set instead of bailing. Host-managed labels the guest re-derives (`security.selinux`/`ima`/`evm`, macOS `com.apple.*`) are skipped — capturing SELinux would bloat every inode on a labelled Fedora/RHEL host.

This supersedes #1442's detect-and-fall-back for representable xattrs: `PureUnsupportedXattr` is gone; oversized xattrs fall back via `XattrTooLarge`.

## Validation

- **Unit** — a `security.capability` round-trips **verbatim** through the independent `am-fs-ext4` reader; encoding is deterministic + order-independent; an oversized xattr routes to fallback; capture is SELinux-safe. (All run on macOS, proving the cross-platform `xattr` path.)
- **Real kernel** — the `ext4-real-mount` CI lane now writes `/bin/ping` with a fixed `security.capability` and reads it back with `getfattr`, asserting the exact hex — proving the Linux kernel sees the inline xattr the writer emitted, byte-for-byte.
- clippy `--all-targets` / fmt / `check-no-spec-refs` clean; closure-budget unchanged (337).

## Follow-ups (noted, not this PR)
- Fuzz `build_image` with generated xattrs (the harness currently passes empty sets; the encoder is unit-tested).
- External xattr block for values too large for the inline area (today they fall back).