### PR TITLE
fix(machine): `machine start` on an already-running machine is a no-op notice

### DIFF
--- a/crates/mvm-cli/src/commands/machine/mod.rs
+++ b/crates/mvm-cli/src/commands/machine/mod.rs
@@ -1881,6 +1881,17 @@ fn mark_machine_started(spec: &mut MachineSpec, resolved_digest: String) {
     spec.last_started_at = Some(mvm_core::time::utc_now());
 }
 
+/// Human/JSON notice printed when `machine start` targets a machine that is
+/// already running. Pure so the wording is unit-testable; the liveness probe
+/// itself lives in [`machine_is_running`].
+fn already_running_notice(name: &str, json: bool) -> String {
+    if json {
+        serde_json::json!({ "machine": name, "already_running": true }).to_string()
+    } else {
+        format!("machine {name} is already running")
+    }
+}
+
 fn start_machine(args: MachineStartArgs) -> Result<()> {
     let mut spec = ensure_machine_spec_exists(&args.name)?;
     if args.dry_run {
@@ -1890,6 +1901,12 @@ fn start_machine(args: MachineStartArgs) -> Result<()> {
         } else {
             print_machine_start_preflight_human(&summary);
         }
+        return Ok(());
+    }
+    // Starting an already-running machine is a no-op, not a second boot: say so
+    // and return, matching the persistent (`run -d`) path's behaviour.
+    if machine_is_running(&args.name) {
+        println!("{}", already_running_notice(&args.name, args.json));
         return Ok(());
     }
     enforce_dev_init_profile(&spec.profile, &spec.init)?;
@@ -3850,6 +3867,18 @@ mod tests {
     fn start_requires_at_least_one_name() {
         let err = parse(&["start"]).expect_err("a machine name is required");
         assert_eq!(err.kind(), clap::error::ErrorKind::MissingRequiredArgument);
+    }
+
+    #[test]
+    fn already_running_notice_wording() {
+        assert_eq!(
+            already_running_notice("web", false),
+            "machine web is already running"
+        );
+        let json: serde_json::Value =
+            serde_json::from_str(&already_running_notice("web", true)).expect("valid json");
+        assert_eq!(json["machine"], "web");
+        assert_eq!(json["already_running"], true);
     }
 
     #[test]


### PR DESCRIPTION
## What

`mvmctl machine start <name>` run twice reported success both times and booted the VM again, instead of noticing the machine was already up.

It now probes liveness first — the same `machine_is_running` check the persistent `run -d` path (`persist_and_boot_machine`) already uses — and if the machine is running, prints a clear notice and returns without a second boot:

```
$ mvmctl machine start ihpersist
started machine ihpersist
$ mvmctl machine start ihpersist
machine ihpersist is already running
```

Under `--json` it emits `{"machine":"ihpersist","already_running":true}`. `--dry-run` is unaffected (it still explains the plan regardless of run state). Idempotent + exit 0, matching docker's `start` semantics and the existing `run -d` "already running" behaviour.

## Independent of the machine-DX stack

Branched off `main` and touches only `start_machine`'s body, so it merges independently of the in-flight `machine` DX PRs (which add `run_start`/positional args elsewhere and don't touch this path).

## Verification

- `cargo fmt --check` ✓ · clippy `-D warnings` ✓ · full `mvm-cli` machine module (103) ✓, incl. a new `already_running_notice_wording` test.

🤖 Generated with [Claude Code](https://claude.com/claude-code)