### PR TITLE
docs(claims): scope claim 3 to block+ext4; note virtiofs-root posture (ADR-107)

### DIFF
--- a/specs/adrs/002-microvm-security-posture.md
+++ b/specs/adrs/002-microvm-security-posture.md
@@ -202,6 +202,19 @@ runtime-overlay build (the standalone bundled prod image it formerly
 built was retired by Plan 115); the live-KVM tamper test exercises the
 boot-time panic on a flipped data block.
 
+Claim 3's witness (dm-verity) is **block-device-specific**: it applies to
+the **block+ext4** backends — Firecracker and the in-process Option B
+materialize path (ADR-106). A **virtiofs root** (Plan 221 Option A) serves
+a host *directory*, not a block device, so it cannot dm-verity a filesystem
+whose blocks it does not own. Per **ADR-107**, virtiofs-root is a
+**dev/local-tier** boot mechanism carrying an explicitly weaker contract —
+unpack-time per-layer sha256 verification (plus cosign on policy-gated
+pulls) then read-only serving from the trusted host, with no guest-enforced,
+plan-bound re-verification of served files. It **does not witness claim 3**,
+and prod / sealed / `--prod` workloads (and Firecracker on every tier) stay
+on Option B, where claim 3 holds unchanged. See ADR-107 for the full
+virtiofs-root integrity posture and the deferred promotion path.
+
 ### Backend symmetry (Plan 98)
 
 Claims 1, 5, 7, 8, and 11 have **backend-symmetric evidence**: the

--- a/specs/claims/catalog.md
+++ b/specs/claims/catalog.md
@@ -29,7 +29,7 @@ tracked separately as a follow-up audit (see "deferred follow-ups").
 |----|-------|-----------|-----------|--------|
 | 1  | No host-fs access from a guest beyond explicit shares | fn:seccomp_allows_listed_denies_unlisted, ci:seccomp-functional, fn:validated_conversion_enforces_mount_allow_list, fn:dir_share_two_part_defaults_ro, fn:vz_rootfs_disk_is_read_only, fn:libkrun_refuses_read_only_virtiofs_share, fn:enforce_admitted_shares_refuses_unadmitted_or_mismatched | seccomp + setpriv (ADR-002 §W2) + user-volume allow-list / ro-default / admission-enforced shares (mvm-cli + mvm-backend) | Shipped |
 | 2  | No guest binary can elevate to uid 0 | fn:set_no_new_privs, fn:virtiofs_mount_flags_keep_workspace_read_only | setpriv --no-new-privs + RO config binds (ADR-002 §W2.2) | Shipped |
-| 3  | A tampered rootfs ext4 fails to boot | ci:verified-boot-artifacts | dm-verity + roothash (ADR-002 §W3) | Shipped |
+| 3  | A tampered rootfs ext4 fails to boot | ci:verified-boot-artifacts | dm-verity + roothash on **block+ext4** backends — Firecracker + Option B (ADR-002 §W3, ADR-106); virtiofs-root is a dev-tier path with a weaker contract that does **not** witness this claim (ADR-107) | Shipped |
 | 4  | The guest agent has no do_exec in production builds | ci:prod-agent-runentry-contract | ELF symbol contract (ADR-002 §W4.3) | Shipped |
 | 5  | Vsock framing + supervisor-config JSON are fuzzed | ci:fuzz | cargo-fuzz (ADR-002 §W4.1/W4.2) | Shipped |
 | 6  | The pre-built dev image is hash-verified | ci:hash-verify-tests, fn:download_runtime_overlay_rejects_checksum_mismatch | SHA-256 manifest (ADR-002 §W5.1) | Shipped |
@@ -51,6 +51,18 @@ numbered claim in ADR-002's source-of-truth table is a separate maintainer
 decision. It does not restate or replace the broker rows 12/13 — those are the
 shipped broker delivery; row 16 backs the same two invariants on the egress
 substitution path.
+
+**Claim 3 backend scoping (ADR-107).** Claim 3's witness, dm-verity, is
+block-device-specific: it ratifies the claim on the **block+ext4** backends
+— Firecracker and the in-process Option B materialize path (ADR-106). A
+**virtiofs root** (Plan 221 Option A) serves a host directory, not a block
+device, so it cannot be dm-verity-sealed. Per ADR-107, virtiofs-root is a
+dev/local-tier boot mechanism carrying an explicitly weaker contract
+(unpack-time per-layer sha256 + read-only serving from the trusted host, no
+guest-enforced plan-bound re-verification); it does **not** witness claim 3.
+Prod / sealed / `--prod` workloads — and Firecracker on every tier — stay on
+Option B, where claim 3 holds unchanged. No numbered claim is weakened; this
+note only scopes which backends the existing witness covers.
 
 ## Maintaining this catalog
 

--- a/specs/plans/223-virtiofs-root.md
+++ b/specs/plans/223-virtiofs-root.md
@@ -40,7 +40,11 @@ weakened. This plan implements Option A under that decision.
 
 `specs/adrs/107-virtiofs-root-integrity.md` (**Accepted**). Decision: tiered
 posture, prod stays on Option B, claim 3 scoped to block+ext4. Everything below
-assumes that decision.
+assumes that decision. The ADR-107 doc consequence — scoping claim 3 to the
+block+ext4 backends in `specs/claims/catalog.md` and ADR-002's verity-surface
+prose, with a pointer to ADR-107 for the virtiofs-root dev-tier posture — is
+**landed** (the "Claims catalog" validation bullet below); the A1–A5 code work
+remains parked.
 
 **Parked.** A1–A5 are not scheduled: Option B already meets the "no subprocess
 on the run path" goal, so Option A is a dev-loop optimization, and A1 depends on


### PR DESCRIPTION
Lands the pending documentation consequence of **ADR-107** (Accepted via #1439, which added only the ADR + Plan 223). ADR-107 §Consequences requires the claims catalog and ADR-002 to scope claim 3 to the block+ext4 backends and point to ADR-107 for the virtiofs-root dev-tier posture — "documentation debt is explicit, not hidden." That scoping wasn't in the tree yet (neither `catalog.md` nor ADR-002 referenced ADR-107).

## Why now
Plan 221 **Option A** (virtiofs root) implementation (Plan 223 A1–A5) is explicitly **parked** — it's a dev-loop optimization gated on the in-house HVF virtiofs-root device. But the *decision's* doc consequence is actionable now and prevents a real overclaiming hazard: someone reading the catalog could mistake a future dev-tier virtiofs boot for a claim-3 boot.

## What
- **`catalog.md`** — claim 3's Authority cell scoped to block+ext4 (Firecracker + Option B), plus a "Claim 3 backend scoping (ADR-107)" note after the table.
- **ADR-002** — the verity-surface (claim 3) prose now states dm-verity is block-device-specific, applies to block+ext4, and points to ADR-107 for the virtiofs-root dev-tier contract (unpack-time sha256 + read-only trusted-host serving, no guest-enforced re-verification).
- **Plan 223 A0** — records this doc consequence as landed; A1–A5 stay parked.

## Not weakening anything
No numbered claim changes — this only scopes which backends the existing witness (dm-verity) covers. Prod / sealed / `--prod` and Firecracker stay on Option B where claim 3 holds unchanged.

`check-claim-catalog` (16 claims, 39 witnesses) / `check-no-overclaim` / `check-doc-claims` / `check-spec-numbers` all clean. Docs-only, no code.