### PR TITLE
verb-grant follow-ups: ADR-108 Option-A sync + require_grant token allowlist gate

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -113,6 +113,9 @@ jobs:
       - name: vsock-only egress (no guest NIC on the vmm/HVF path, ADR-100)
         run: cargo run -p xtask -- check-vsock-only-egress
 
+      - name: require-grant token confined to allowlist (guards mvmd no-brick invariant)
+        run: cargo run -p xtask -- check-require-grant-token-allowlist
+
       - name: host-binaries manifest parity
         run: cargo run -p xtask -- check-mvm-host-binaries-sync
 

--- a/specs/adrs/108-verb-grant-measured-trust-policy.md
+++ b/specs/adrs/108-verb-grant-measured-trust-policy.md
@@ -113,10 +113,14 @@ on it with a single code path:
 - **Policy present, valid grant pinned** ⇒ serve.
 - **Policy present, grant absent / malformed / verification-failed** ⇒ emit an
   **audited observability signal** ("verb-trust policy present but no valid grant
-  pinned") *regardless* of `require_grant`, then:
-  - `require_grant: true` ⇒ **fail closed** — refuse to serve control RPCs.
-  - `require_grant: false` ⇒ serve (observe mode; the audited signal is the only
-    effect).
+  pinned"), then fail closed **iff** enforcement is required. As shipped (see
+  Rollout / Stage A), the enforcement trigger is `trust_decision(policy,
+  grant_present, launch_requires_grant)`: fail closed when the launch asserts
+  `mvm.require_grant=1` **OR** the baked `require_grant: true` **OR**
+  `grant_key_source: attested`; otherwise serve (observe mode). Because Stage B/A
+  bake `require_grant: false`, the enforcement in practice comes from the
+  launch-asserted `mvm.require_grant=1` token (emitted only when the host
+  delivered a grant), leaving mvmd / direct-launch instances in observe mode.
 
 The fail-closed behavior is thus fully implemented in the guest from day one;
 whether it *bites* is driven entirely by the measured `require_grant` bit. This
@@ -144,12 +148,38 @@ therefore rolled out in two stages, each a distinct PR:
   `false`), the audited observe signal, restore reconciliation, and the
   `grant_key_source` seam. Live-prove that every *mvmctl* sealed launch + restore
   flavor delivers a valid grant.
-- **Stage A (fast-follow) — enforce.** Flip the baked bit to `require_grant:
-  true` for sealed prod images. Gate the flip on a concrete criterion: every
-  sealed-image launch + restore path in **both** mvmctl (verified in Stage B) and
-  mvmd is confirmed to deliver a grant. This is a one-line policy-value change,
-  not a mechanism change, tracked as an explicit follow-up so observe mode does
-  not become permanent.
+- **Stage A (shipped) — enforce, launcher-gated (Option A).** Investigating the
+  Stage-A precondition established that **mvmd cannot be relied on to deliver a
+  grant**: it boots instances through a *direct* Firecracker launch
+  (`mvmd-runtime` `instance_start_inner`) that synthesizes no `ExecutionPlan`,
+  mints no `VerbGrant`, and **bypasses mvm-backend's cmdline assembly entirely**.
+  So flipping the *baked* bit to `require_grant: true` would fail-close every
+  mvmd instance. Stage A therefore does **not** flip the baked bit (it stays
+  `false`); instead enforcement is **launcher-gated**:
+  - The host emits a `mvm.require_grant=1` kernel-cmdline token **only when it
+    delivered a grant** (`require_grant_cmdline_token`, keyed on the
+    `verb-grant.json` sidecar *existing* — so a corrupt sidecar still asserts
+    enforcement and the guest fails closed rather than running grant-less),
+    appended at the four mvm-backend cmdline builders
+    (`microvm`/`qemu`/`libkrun`/`vz`) — all of which mvmd bypasses.
+  - The guest reads it (`launch_requires_grant()` over `/proc/cmdline`) and
+    `trust_decision(policy, grant_present, launch_requires_grant)` fails closed
+    when enforcement is **launch-asserted OR baked-policy-required OR
+    `grant_key_source: attested`**, and no grant is pinned.
+
+  Net: mvmctl grant-delivering launches enforce; mvmd (and any direct-launch
+  path) asserts nothing → always serves → **no brick, no mvmd change**. The
+  measured `require_grant` field is retained for the observe signal and the
+  `attested` seam; the enforcement *trigger* moved to the launch token. Trade-off
+  vs. the original "flip the baked bit" plan: `require_grant` enforcement is now
+  launcher-asserted rather than rootfs-measured — a slight weakening of the
+  measured-policy property, accepted because a delivered grant is still
+  pinned+enforced and the launcher emits the flag in the same routine that
+  delivers the grant. A stale-sidecar guard unlinks a pre-existing
+  `verb-grant.json` on re-stash so a reused persistent name cannot inherit a
+  spurious enforcement assertion; an `xtask` gate machine-checks that
+  `mvm.require_grant=1` appears only in the four allowlisted builders (guards the
+  no-brick invariant).
 
 ### 3. Restore reconciliation (grant survives every restore flavor)
 
@@ -187,9 +217,12 @@ policy value and the guest's key-source branch. This ADR deliberately leaves the
 ## Consequences
 
 **Positive**
-- A sealed image's grant requirement is dm-verity-measured: no silent downgrade
-  to class-gate-only from a buggy/omitting/tampering launch path.
-- `require_grant` holds across all restore flavors; the "forked children run
+- A grant-delivering launch enforces the grant end-to-end: a launch that mints a
+  grant asserts `mvm.require_grant=1`, so a bug/corruption that drops or mangles
+  the delivered grant fails closed rather than silently downgrading to
+  class-gate-only. (The *policy* is dm-verity-measured; the enforcement *trigger*
+  is the launch token — see Rollout / Stage A for why.)
+- Enforcement holds across all restore flavors; the "forked children run
   class-gate-only" gap is closed with a correct per-child grant.
 - The honest limitation is documented in one place, and the future
   attestation upgrade has a defined, churn-free seam (`grant_key_source`).
@@ -200,11 +233,12 @@ policy value and the guest's key-source branch. This ADR deliberately leaves the
   numbered claim ledger.
 - New surface: one optional `PostRestore` field, a guest re-pin path, and
   mint-at-fork. All reuse existing frames/mechanisms.
-- Once enforced (Stage A), `require_grant: true` makes a sealed image un-bootable
-  if the launch path genuinely cannot deliver a grant — the intended fail-closed,
-  but it raises the bar on the launch path's correctness for sealed images. The
-  staged rollout (measure-now / enforce-fast-follow) bounds this to paths already
-  confirmed to deliver a grant across both mvmctl and mvmd.
+- Under Stage A, a grant-delivering launch that asserts `mvm.require_grant=1` but
+  then cannot pin a valid grant fails closed — the intended catch, but it raises
+  the bar on the correctness of the launch paths that deliver grants. The
+  launcher-gated design (Option A) bounds this to exactly the mvmctl paths that
+  emit the token; mvmd and other direct-launch paths never assert it, so they are
+  never fail-closed.
 
 **Neutral**
 - Dev / OCI images are unaffected (policy file absent ⇒ permissive default),
@@ -226,6 +260,12 @@ policy value and the guest's key-source branch. This ADR deliberately leaves the
 - **Pull hardware attestation into scope.** The only construction that yields
   real key separation, but a deliberate ADR-002 scope expansion beyond this
   work; recorded as the future seam instead.
+- **Stage A as a baked `require_grant: true` flip** (the original Rollout plan).
+  Superseded before implementation: mvmd boots sealed images through a direct
+  Firecracker path that delivers no grant, so a baked flip would brick every
+  mvmd instance. Replaced by the launcher-gated `mvm.require_grant=1` token
+  (Option A, see Rollout / Stage A), which enforces only where a grant was
+  delivered and leaves mvmd untouched with no mvmd-side change.
 
 ## Out of scope
 

--- a/xtask/src/check_require_grant_token_allowlist.rs
+++ b/xtask/src/check_require_grant_token_allowlist.rs
@@ -1,0 +1,123 @@
+//! `xtask check-require-grant-token-allowlist`
+//!
+//! Guards the invariant that `mvm.require_grant=1` is emitted only by the
+//! mvm-backend cmdline builders and matched by the guest vsock reader. A stray
+//! emit site in any other crate could brick mvmd sealed workloads — the fleet
+//! orchestrator bypasses `VmBackend::start` cmdline assembly and would silently
+//! miss or double-emit the token.
+
+use anyhow::{Result, bail};
+use std::path::{Path, PathBuf};
+
+/// The literal that only the allowlisted files may contain.
+const TOKEN: &str = "mvm.require_grant=1";
+
+/// Files (workspace-relative) that are permitted to contain the token.
+const ALLOWLIST: &[&str] = &[
+    "crates/mvm-backend/src/microvm.rs",
+    "crates/mvm-backend/src/qemu.rs",
+    "crates/mvm-backend/src/libkrun.rs",
+    "crates/mvm-backend/src/vz.rs",
+    "crates/mvm-guest/src/vsock.rs",
+];
+
+pub fn run(workspace: &Path) -> Result<()> {
+    let mut rs_files = Vec::new();
+    collect_rs_files(&workspace.join("crates"), &mut rs_files)?;
+
+    let mut hits = Vec::new();
+    for file in &rs_files {
+        let rel = file
+            .strip_prefix(workspace)
+            .unwrap_or(file)
+            .to_string_lossy()
+            .replace('\\', "/");
+
+        // Skip files that are explicitly allowlisted.
+        if ALLOWLIST.iter().any(|a| rel == *a) {
+            continue;
+        }
+
+        let text = std::fs::read_to_string(file).unwrap_or_default();
+        for (n, line) in text.lines().enumerate() {
+            if line.contains(TOKEN) {
+                hits.push(format!("{}:{}: {}", rel, n + 1, line.trim()));
+            }
+        }
+    }
+
+    if !hits.is_empty() {
+        bail!(
+            "check-require-grant-token-allowlist: `{TOKEN}` found outside the allowlist \
+             (only mvm-backend cmdline builders and mvm-guest/vsock.rs may emit/match it):\n{}",
+            hits.join("\n")
+        );
+    }
+    eprintln!(
+        "check-require-grant-token-allowlist: clean ({} files scanned; token confined to allowlist)",
+        rs_files.len()
+    );
+    Ok(())
+}
+
+fn collect_rs_files(dir: &Path, out: &mut Vec<PathBuf>) -> Result<()> {
+    if !dir.is_dir() {
+        return Ok(());
+    }
+    for entry in std::fs::read_dir(dir)?.flatten() {
+        let path = entry.path();
+        if path.is_dir() {
+            collect_rs_files(&path, out)?;
+        } else if path.extension().is_some_and(|e| e == "rs") {
+            out.push(path);
+        }
+    }
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::fs;
+
+    fn make_tree(files: &[(&str, &str)]) -> tempfile::TempDir {
+        let dir = tempfile::tempdir().expect("tempdir");
+        for (rel_path, content) in files {
+            let full = dir.path().join(rel_path);
+            fs::create_dir_all(full.parent().unwrap()).unwrap();
+            fs::write(&full, content).unwrap();
+        }
+        dir
+    }
+
+    #[test]
+    fn allowlisted_file_passes() {
+        let tree = make_tree(&[(
+            "crates/mvm-backend/src/microvm.rs",
+            r#"fn foo() { let _ = "mvm.require_grant=1"; }"#,
+        )]);
+        run(tree.path()).expect("allowlisted path must pass");
+    }
+
+    #[test]
+    fn non_allowlisted_file_fails() {
+        let tree = make_tree(&[(
+            "crates/mvm-core/src/lib.rs",
+            r#"fn bad() { let _ = "mvm.require_grant=1"; }"#,
+        )]);
+        let err = run(tree.path()).expect_err("non-allowlisted path must fail");
+        assert!(
+            err.to_string().contains("mvm-core/src/lib.rs"),
+            "error must name the violating file: {err}"
+        );
+    }
+
+    #[test]
+    fn file_without_token_passes() {
+        let tree = make_tree(&[(
+            "crates/mvm-core/src/config.rs",
+            r#"fn foo() { let _ = "mvm.other_flag=1"; }"#,
+        )]);
+        run(tree.path()).expect("file without token must pass");
+    }
+}

--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -29,6 +29,7 @@ mod check_no_display_on_secret_types;
 mod check_no_host_nix;
 mod check_no_overclaim;
 mod check_no_spec_refs_in_comments;
+mod check_require_grant_token_allowlist;
 mod check_runtime_overlay_version;
 mod check_spec_numbers;
 mod check_trust_gradient;
@@ -136,6 +137,10 @@ fn main() -> Result<()> {
             let workspace = workspace_root();
             check_vsock_only_egress::run(&workspace)
         }
+        Some("check-require-grant-token-allowlist") => {
+            let workspace = workspace_root();
+            check_require_grant_token_allowlist::run(&workspace)
+        }
         Some("check-mvm-host-binaries-sync") => {
             let workspace = workspace_root();
             check_mvm_host_binaries_sync::run(&workspace)
@@ -164,7 +169,7 @@ fn main() -> Result<()> {
             gen_stubs::check(&workspace)
         }
         Some(other) => anyhow::bail!(
-            "Unknown xtask: {:?}. Available: gen-man, check-adr-coverage, check-no-display-on-secret-types, check-audit-positional, check-doc-claims, check-machine-doc-guards, check-forbidden-deps, check-core-runtime-free, check-closure-budget, check-duplicate-majors, check-binary-size, check-kernel-config-budget, check-kernel-pin-freshness, check-builder-shell-job-sites, check-guest-agent-runtime-free, check-guest-agent-in-all-images, check-guest-images-no-builder-tools, check-no-overclaim, check-spec-numbers, check-no-spec-refs-in-comments, check-claim-catalog, check-trust-gradient, check-vsock-only-egress, check-mvm-host-binaries-sync, check-runtime-overlay-version, perf, build-dev-image, gen-stubs, check-stubs",
+            "Unknown xtask: {:?}. Available: gen-man, check-adr-coverage, check-no-display-on-secret-types, check-audit-positional, check-doc-claims, check-machine-doc-guards, check-forbidden-deps, check-core-runtime-free, check-closure-budget, check-duplicate-majors, check-binary-size, check-kernel-config-budget, check-kernel-pin-freshness, check-builder-shell-job-sites, check-guest-agent-runtime-free, check-guest-agent-in-all-images, check-guest-images-no-builder-tools, check-no-overclaim, check-spec-numbers, check-no-spec-refs-in-comments, check-claim-catalog, check-trust-gradient, check-vsock-only-egress, check-require-grant-token-allowlist, check-mvm-host-binaries-sync, check-runtime-overlay-version, perf, build-dev-image, gen-stubs, check-stubs",
             other
         ),
         None => {
@@ -232,6 +237,9 @@ fn main() -> Result<()> {
             );
             eprintln!(
                 "  check-trust-gradient                   Verify trust-gradient ledger: monotonic tiers, workload forbidden authorities, witnesses"
+            );
+            eprintln!(
+                "  check-require-grant-token-allowlist     assert mvm.require_grant=1 appears only in the four backend builders + mvm-guest/vsock.rs"
             );
             eprintln!(
                 "  check-mvm-host-binaries-sync            Plan 115 / ADR-065: assert Rust manifest and Nix attrset agree"


### PR DESCRIPTION
Two post-merge follow-ups from the verb-grant enforcement work (#1381 item 3, ADR-108).

## 1. ADR-108 sync — Stage A shipped as Option A (launcher-gated), not a baked flip
The merged ADR-108 still described Stage A as *"flip the baked bit to `require_grant: true`"* — the approach that was **abandoned** once the mvmd investigation showed it would brick the fleet (mvmd boots via a direct Firecracker path that delivers no grant and bypasses mvm-backend's cmdline assembly). The doc now records what actually shipped in #1454:
- Enforcement is **launcher-gated**: the host emits `mvm.require_grant=1` only when it delivered a grant; the guest fail-closes on `trust_decision(policy, grant_present, launch_requires_grant)`. The baked `require_grant` stays `false` (observe + `attested` seam); the enforcement *trigger* is the launch token. mvmd/direct-launch instances assert nothing → serve → no brick, no mvmd change.
- Rollout, Decision §2, Consequences, and Alternatives all updated to match; the abandoned baked-flip is recorded as a rejected alternative with the reason.

## 2. `xtask check-require-grant-token-allowlist` — machine-check the no-brick invariant
The mvmd-safety property (the `mvm.require_grant=1` token is emitted **only** by the four mvm-backend cmdline builders that mvmd bypasses) was guarded only by convention. New gate asserts the literal appears solely in the allowlist (`microvm`/`qemu`/`libkrun`/`vz` + the guest reader `vsock.rs`); any stray emit site — or an mvmd path that started routing through `VmBackend::start` — fails the build. Wired into the CI Lint job (`ci.yml`), modelled on `check-vsock-only-egress`, with a planted-violation sanity check.

## Testing
Gate passes on the real tree (887 files; token confined to allowlist) and fails naming the offending file when a violation is planted. `cargo check -p xtask`, `fmt --all`, `clippy -p xtask -D warnings`, and the gate's unit tests clean.

Follow-ups still tracked on #1381 (own issues to be filed): live-validate fork/restore grant delivery; M1 (chain-signed audit of the trust decision — host-side design); measured-boot/vTPM attestation → real key separation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)