### PR TITLE
feat(mvm-client): add inspect/create/start/remove to the MvmClient trait

### DIFF
--- a/crates/mvm-client-local/src/lib.rs
+++ b/crates/mvm-client-local/src/lib.rs
@@ -237,6 +237,26 @@ impl MvmClient for LocalBackend {
             .collect())
     }
 
+    async fn inspect_machine(&self, id: &MachineId) -> Result<MachineState> {
+        self.backend
+            .list()
+            .map_err(backend_err)?
+            .into_iter()
+            .map(to_state)
+            .find(|m| m.id == *id)
+            .ok_or_else(|| MvmError::NotFound { id: id.0.clone() })
+    }
+
+    async fn create_machine(&self, _spec: MachineSpec) -> Result<MachineState> {
+        // Create-without-boot needs the machine registry (spec persistence),
+        // which is a CLI-side path not wired into the in-process backend.
+        Err(MvmError::Backend {
+            reason: "local create (persist without boot) is not wired in the in-process backend; \
+                     use run_machine, or the CLI's `machine create`"
+                .into(),
+        })
+    }
+
     async fn run_machine(&self, spec: MachineSpec) -> Result<MachineState> {
         let rootfs = resolve_local_rootfs(&spec.image, &spec.name).await?;
         let (verity_path, roothash) = host_verity_sidecars(&rootfs);
@@ -278,8 +298,28 @@ impl MvmClient for LocalBackend {
         })
     }
 
+    async fn start_machine(&self, _id: &MachineId) -> Result<MachineState> {
+        // Starting a created/stopped machine needs the machine registry (spec
+        // persistence) to know what to boot — a CLI-side path not wired here.
+        Err(MvmError::Backend {
+            reason: "local start of a created machine is not wired in the in-process backend; \
+                     use run_machine, or the CLI's `machine start`"
+                .into(),
+        })
+    }
+
     async fn stop_machine(&self, id: &MachineId) -> Result<()> {
         self.backend.stop(&VmId(id.0.clone())).map_err(backend_err)
+    }
+
+    async fn remove_machine(&self, _id: &MachineId) -> Result<()> {
+        // The backend dispatch (`AnyBackend`) exposes stop/list/status but no
+        // destroy seam, so a full remove (delete the machine record) isn't
+        // wired; that lifecycle lives on the CLI's `machine rm`.
+        Err(MvmError::Backend {
+            reason: "local remove requires a backend destroy seam (not wired); use `machine rm`"
+                .into(),
+        })
     }
 
     async fn machine_logs(&self, id: &MachineId, opts: LogOpts) -> Result<Vec<u8>> {

--- a/crates/mvm-client/src/client.rs
+++ b/crates/mvm-client/src/client.rs
@@ -12,11 +12,25 @@ pub trait MvmClient: Send + Sync {
     /// List machines matching `filter`.
     async fn list_machines(&self, filter: MachineFilter) -> Result<Vec<MachineState>>;
 
-    /// Launch a machine from `spec`; returns its initial state.
+    /// Inspect one machine by id; returns its current state.
+    async fn inspect_machine(&self, id: &MachineId) -> Result<MachineState>;
+
+    /// Create a machine from `spec` **without** starting it; returns its initial
+    /// (stopped) state. `run_machine` is the create-and-start shorthand.
+    async fn create_machine(&self, spec: MachineSpec) -> Result<MachineState>;
+
+    /// Launch a machine from `spec` (create + start); returns its initial state.
     async fn run_machine(&self, spec: MachineSpec) -> Result<MachineState>;
+
+    /// Start an already-created (or stopped) machine by id; returns its state.
+    async fn start_machine(&self, id: &MachineId) -> Result<MachineState>;
 
     /// Stop a machine by id. Idempotent: stopping a stopped machine is `Ok`.
     async fn stop_machine(&self, id: &MachineId) -> Result<()>;
+
+    /// Remove a machine by id (stopping it first if needed). Idempotent:
+    /// removing an absent machine is `Ok`.
+    async fn remove_machine(&self, id: &MachineId) -> Result<()>;
 
     /// Fetch a machine's captured console/log bytes.
     async fn machine_logs(&self, id: &MachineId, opts: LogOpts) -> Result<Vec<u8>>;

--- a/crates/mvm-client/src/gateway.rs
+++ b/crates/mvm-client/src/gateway.rs
@@ -194,6 +194,32 @@ impl MvmClient for GatewayBackend {
         Ok(filter_machines(machines, &filter))
     }
 
+    async fn inspect_machine(&self, id: &MachineId) -> Result<MachineState> {
+        let url = self.endpoint(&format!("/api/v1/sandboxes/{}", id.0))?;
+        let resp = self
+            .authed(self.http.get(url))
+            .send()
+            .await
+            .map_err(|e| MvmError::Backend {
+                reason: format!("inspect request failed: {e}"),
+            })?;
+        if let Some(e) = status_error(resp.status(), &id.0) {
+            return Err(e);
+        }
+        let env: SandboxEnvelope = resp.json().await.map_err(|e| MvmError::Backend {
+            reason: format!("parsing inspect response: {e}"),
+        })?;
+        Ok(env.data.into())
+    }
+
+    async fn create_machine(&self, _spec: MachineSpec) -> Result<MachineState> {
+        // The cloud sandbox model boots on create; there is no
+        // create-without-start endpoint. Refuse rather than fake a stopped state.
+        Err(MvmError::Backend {
+            reason: "gateway sandboxes boot on create; create-without-start is not supported (use run_machine)".into(),
+        })
+    }
+
     async fn run_machine(&self, spec: MachineSpec) -> Result<MachineState> {
         // The create-sandbox endpoint has no env field; refuse rather than
         // silently drop env the workload would expect.
@@ -226,6 +252,16 @@ impl MvmClient for GatewayBackend {
         Ok(env.data.into())
     }
 
+    async fn start_machine(&self, _id: &MachineId) -> Result<MachineState> {
+        // Sandboxes boot on create; there is no idle "created" state to start
+        // from. Refuse rather than fake a running state.
+        Err(MvmError::Backend {
+            reason:
+                "gateway sandboxes have no separate start; they boot on create (use run_machine)"
+                    .into(),
+        })
+    }
+
     async fn stop_machine(&self, id: &MachineId) -> Result<()> {
         let url = self.endpoint(&format!("/api/v1/sandboxes/{}/stop", id.0))?;
         let resp =
@@ -235,6 +271,25 @@ impl MvmClient for GatewayBackend {
                 .map_err(|e| MvmError::Backend {
                     reason: format!("stop request failed: {e}"),
                 })?;
+        match status_error(resp.status(), &id.0) {
+            Some(e) => Err(e),
+            None => Ok(()),
+        }
+    }
+
+    async fn remove_machine(&self, id: &MachineId) -> Result<()> {
+        let url = self.endpoint(&format!("/api/v1/sandboxes/{}", id.0))?;
+        let resp = self
+            .authed(self.http.delete(url))
+            .send()
+            .await
+            .map_err(|e| MvmError::Backend {
+                reason: format!("remove request failed: {e}"),
+            })?;
+        // A 404 means already gone — remove is idempotent.
+        if resp.status() == StatusCode::NOT_FOUND {
+            return Ok(());
+        }
         match status_error(resp.status(), &id.0) {
             Some(e) => Err(e),
             None => Ok(()),

--- a/crates/mvm-client/src/mock.rs
+++ b/crates/mvm-client/src/mock.rs
@@ -15,6 +15,27 @@ pub struct MockBackend {
     next: Mutex<u64>,
 }
 
+impl MockBackend {
+    /// Insert a new machine with the given initial status (create → Stopped,
+    /// run → Running).
+    fn insert(&self, spec: MachineSpec, status: MachineStatus) -> Result<MachineState> {
+        if spec.name.is_empty() {
+            return Err(MvmError::InvalidSpec {
+                reason: "name must not be empty".into(),
+            });
+        }
+        let mut n = self.next.lock().unwrap();
+        *n += 1;
+        let state = MachineState {
+            id: MachineId(format!("m{n}")),
+            name: spec.name,
+            status,
+        };
+        self.machines.lock().unwrap().push(state.clone());
+        Ok(state)
+    }
+}
+
 #[async_trait]
 impl MvmClient for MockBackend {
     async fn list_machines(&self, filter: MachineFilter) -> Result<Vec<MachineState>> {
@@ -27,21 +48,32 @@ impl MvmClient for MockBackend {
             .collect())
     }
 
+    async fn inspect_machine(&self, id: &MachineId) -> Result<MachineState> {
+        self.machines
+            .lock()
+            .unwrap()
+            .iter()
+            .find(|m| m.id == *id)
+            .cloned()
+            .ok_or_else(|| MvmError::NotFound { id: id.0.clone() })
+    }
+
+    async fn create_machine(&self, spec: MachineSpec) -> Result<MachineState> {
+        self.insert(spec, MachineStatus::Stopped)
+    }
+
     async fn run_machine(&self, spec: MachineSpec) -> Result<MachineState> {
-        if spec.name.is_empty() {
-            return Err(MvmError::InvalidSpec {
-                reason: "name must not be empty".into(),
-            });
-        }
-        let mut n = self.next.lock().unwrap();
-        *n += 1;
-        let state = MachineState {
-            id: MachineId(format!("m{n}")),
-            name: spec.name,
-            status: MachineStatus::Running,
-        };
-        self.machines.lock().unwrap().push(state.clone());
-        Ok(state)
+        self.insert(spec, MachineStatus::Running)
+    }
+
+    async fn start_machine(&self, id: &MachineId) -> Result<MachineState> {
+        let mut all = self.machines.lock().unwrap();
+        let m = all
+            .iter_mut()
+            .find(|m| m.id == *id)
+            .ok_or_else(|| MvmError::NotFound { id: id.0.clone() })?;
+        m.status = MachineStatus::Running;
+        Ok(m.clone())
     }
 
     async fn stop_machine(&self, id: &MachineId) -> Result<()> {
@@ -51,6 +83,12 @@ impl MvmClient for MockBackend {
             .find(|m| m.id == *id)
             .ok_or_else(|| MvmError::NotFound { id: id.0.clone() })?;
         m.status = MachineStatus::Stopped;
+        Ok(())
+    }
+
+    async fn remove_machine(&self, id: &MachineId) -> Result<()> {
+        // Idempotent: removing an absent machine is Ok (per the trait contract).
+        self.machines.lock().unwrap().retain(|m| m.id != *id);
         Ok(())
     }
 
@@ -107,6 +145,57 @@ mod tests {
         mock.stop_machine(&started.id).await.unwrap();
         let after = mock.list_machines(MachineFilter::all()).await.unwrap();
         assert_eq!(after[0].status, MachineStatus::Stopped);
+    }
+
+    #[tokio::test]
+    async fn create_inspect_start_remove_lifecycle() {
+        let mock = MockBackend::default();
+        let spec = MachineSpec {
+            name: "db".into(),
+            image: "img".into(),
+            cpus: 1,
+            memory_mib: 128,
+            env: vec![],
+        };
+
+        // create → stopped (not started).
+        let created = mock.create_machine(spec).await.unwrap();
+        assert_eq!(created.status, MachineStatus::Stopped);
+
+        // inspect returns it.
+        let got = mock.inspect_machine(&created.id).await.unwrap();
+        assert_eq!(got.name, "db");
+        assert_eq!(got.status, MachineStatus::Stopped);
+
+        // start → running.
+        let started = mock.start_machine(&created.id).await.unwrap();
+        assert_eq!(started.status, MachineStatus::Running);
+        assert_eq!(
+            mock.inspect_machine(&created.id).await.unwrap().status,
+            MachineStatus::Running
+        );
+
+        // remove → gone; inspect now NotFound; remove is idempotent.
+        mock.remove_machine(&created.id).await.unwrap();
+        assert!(matches!(
+            mock.inspect_machine(&created.id).await,
+            Err(MvmError::NotFound { .. })
+        ));
+        mock.remove_machine(&created.id).await.unwrap(); // idempotent
+    }
+
+    #[tokio::test]
+    async fn inspect_and_start_unknown_are_not_found() {
+        let mock = MockBackend::default();
+        let missing = MachineId("nope".into());
+        assert!(matches!(
+            mock.inspect_machine(&missing).await,
+            Err(MvmError::NotFound { .. })
+        ));
+        assert!(matches!(
+            mock.start_machine(&missing).await,
+            Err(MvmError::NotFound { .. })
+        ));
     }
 
     #[tokio::test]

--- a/crates/mvm-sdk/src/facade.rs
+++ b/crates/mvm-sdk/src/facade.rs
@@ -18,7 +18,7 @@ use mvm_client::dto::{
 };
 use mvm_client::{MvmClient, MvmError, Result};
 
-use crate::machine::{Machine, MachineError, MachineLs};
+use crate::machine::{Machine, MachineCreate, MachineError, MachineLs};
 
 /// Env var overriding the `mvmctl` binary path (shared with `machine.rs`).
 const MVM_CLI_BIN_ENV: &str = "MVM_CLI_BIN";
@@ -100,6 +100,45 @@ fn run_args(spec: &MachineSpec) -> Result<Vec<String>> {
     }
     args.push("--up-json".to_string());
     Ok(args)
+}
+
+/// Build the argv for `machine create --name … --image …` — persists the spec
+/// without booting. Uses the shared builder so it can't drift from the CLI.
+fn create_args(spec: &MachineSpec) -> Result<Vec<String>> {
+    if spec.name.is_empty() {
+        return Err(MvmError::InvalidSpec {
+            reason: "name must not be empty".into(),
+        });
+    }
+    if spec.image.is_empty() {
+        return Err(MvmError::InvalidSpec {
+            reason: "image must not be empty".into(),
+        });
+    }
+    MachineCreate::builder(&spec.name)
+        .image(&spec.image)
+        .cpus(spec.cpus as u16)
+        .memory(format!("{}M", spec.memory_mib))
+        .machine_args()
+        .map_err(machine_err)
+}
+
+fn start_args(id: &MachineId) -> Result<Vec<String>> {
+    Machine::named(&id.0)
+        .map_err(machine_err)?
+        .start()
+        .machine_args()
+        .map_err(machine_err)
+}
+
+fn rm_args(id: &MachineId) -> Result<Vec<String>> {
+    Machine::named(&id.0)
+        .map_err(machine_err)?
+        .rm()
+        // Non-interactive: the facade never prompts.
+        .yes(true)
+        .machine_args()
+        .map_err(machine_err)
 }
 
 /// The `machine run --up-json` boot envelope. The CLI prints it as the sole
@@ -233,6 +272,27 @@ impl MvmClient for SubprocessBackend {
         Ok(machines.into_iter().filter(|m| filter.matches(m)).collect())
     }
 
+    async fn inspect_machine(&self, id: &MachineId) -> Result<MachineState> {
+        // The facade's MachineState is the live runtime state, which
+        // `machine ls` reports; `machine inspect` dumps the persisted spec.
+        let stdout = self.run_cli(&list_args()?)?;
+        parse_machine_list(&stdout)?
+            .into_iter()
+            .find(|m| m.id == *id)
+            .ok_or_else(|| MvmError::NotFound { id: id.0.clone() })
+    }
+
+    async fn create_machine(&self, spec: MachineSpec) -> Result<MachineState> {
+        // `machine create` persists the spec without booting → stopped.
+        let name = spec.name.clone();
+        self.run_cli(&create_args(&spec)?)?;
+        Ok(MachineState {
+            id: MachineId(name.clone()),
+            name,
+            status: MachineStatus::Stopped,
+        })
+    }
+
     async fn run_machine(&self, spec: MachineSpec) -> Result<MachineState> {
         // `machine run` does the full OCI pull + rootfs materialize + signed-plan
         // admission (claim 8) + boot; `--up-json` boots it detached and prints the
@@ -246,8 +306,21 @@ impl MvmClient for SubprocessBackend {
         })
     }
 
+    async fn start_machine(&self, id: &MachineId) -> Result<MachineState> {
+        self.run_cli(&start_args(id)?)?;
+        Ok(MachineState {
+            id: id.clone(),
+            name: id.0.clone(),
+            status: MachineStatus::Running,
+        })
+    }
+
     async fn stop_machine(&self, id: &MachineId) -> Result<()> {
         self.run_cli(&stop_args(id)?).map(|_| ())
+    }
+
+    async fn remove_machine(&self, id: &MachineId) -> Result<()> {
+        self.run_cli(&rm_args(id)?).map(|_| ())
     }
 
     async fn machine_logs(&self, id: &MachineId, opts: LogOpts) -> Result<Vec<u8>> {
@@ -332,6 +405,42 @@ mod tests {
                 "--up-json",
             ]
         );
+    }
+
+    #[test]
+    fn create_start_rm_args_build_the_machine_verbs() {
+        let spec = MachineSpec {
+            name: "db".into(),
+            image: "alpine:3.20".into(),
+            cpus: 1,
+            memory_mib: 256,
+            env: vec![],
+        };
+        // create persists the spec (no boot).
+        let create = create_args(&spec).unwrap();
+        assert_eq!(create[0], "create");
+        assert!(create.iter().any(|a| a == "alpine:3.20"));
+        assert!(create.iter().any(|a| a == "256M"));
+
+        let id = MachineId("db".into());
+        assert_eq!(start_args(&id).unwrap(), vec!["start", "db"]);
+        // rm is non-interactive (--yes) so the facade never blocks on a prompt.
+        let rm = rm_args(&id).unwrap();
+        assert_eq!(rm[0], "rm");
+        assert!(rm.iter().any(|a| a == "db"));
+        assert!(rm.iter().any(|a| a == "--yes"));
+    }
+
+    #[test]
+    fn create_args_reject_empty_name_and_image() {
+        let bad = MachineSpec {
+            name: String::new(),
+            image: "img".into(),
+            cpus: 1,
+            memory_mib: 64,
+            env: vec![],
+        };
+        assert!(create_args(&bad).is_err());
     }
 
     #[test]


### PR DESCRIPTION
## Why

The typed `MvmClient` facade had only 5 methods (`list`/`run`/`stop`/`logs`/`exec`) — **narrower than both the CLI machine verbs and the language SDK surface**, which already expose `inspect`/`rm`/`start`. A Rust consumer (mvmd) got fewer typed lifecycle operations than a Python SDK user. This makes the trait the **complete canonical machine-lifecycle surface** everything conforms to (your "SDK drives this client's methods" model).

## What

Four methods across all four impls:
- `inspect_machine(id) -> MachineState` — the live runtime state
- `create_machine(spec) -> MachineState` — persist **without** booting (→ Stopped)
- `start_machine(id) -> MachineState` — start a created/stopped machine
- `remove_machine(id) -> ()` — idempotent

Per-impl, **honest where an impl can't cleanly support an op** (not faked):

| impl | inspect | create | start | remove |
|---|---|---|---|---|
| **SubprocessBackend** (reference) | ✅ | ✅ | ✅ | ✅ (`--yes`) |
| **MockBackend** | ✅ | ✅ | ✅ | ✅ |
| **GatewayBackend** (cloud) | ✅ GET | honest err¹ | honest err¹ | ✅ DELETE (404-idempotent) |
| **LocalBackend** (in-process) | ✅ | honest err² | honest err² | honest err² |

¹ the cloud sandbox model boots on create — no create-without-start.
² needs the CLI-side machine registry / a backend destroy seam not wired into the in-process path (same discipline as the original `run` stub).

SubprocessBackend drives the **shared machine argv builders** (`create`/`start`/`rm`), so it can't drift from the CLI.

## Scope (deliberately bounded)

The client stays the **remotable machine-lifecycle** surface. Local-only host verbs (`build`/`dev`/`doctor`/`network`/…) don't belong here — mvmd already reaches those via the library re-exports (`mvmctl::runtime`/`build`/`backend`). This isn't "cover all 28 CLI groups"; it's "complete the lifecycle a machine client should have."

## Tests

Mock `create → inspect → start → remove` lifecycle + not-found paths; facade argv builders for create/start/rm. clippy/fmt clean; SDK stubs no drift.

## Follow-up (not in this PR)

Adding `create` to the **language** SDKs + their conformance fixtures (they already have start/inspect/rm) is a separate conformance slice, since it touches the per-language argv fixtures.

🤖 Generated with [Claude Code](https://claude.com/claude-code)