### PR TITLE
feat(audit): chain-signed plan.grant_required entry (M1, #1457)

### DIFF
--- a/crates/mvm-cli/src/commands/vm/up.rs
+++ b/crates/mvm-cli/src/commands/vm/up.rs
@@ -565,6 +565,11 @@ pub(super) fn admit_plan_for_boot(
     if let Err(e) = emitter.emit_admitted(&admitted.plan, &admitted.signer_id) {
         tracing::warn!(error = %e, "audit emit_admitted failed (non-fatal)");
     }
+    if let Some(verbs) = admitted.plan.agent_verbs.as_ref()
+        && let Err(e) = emitter.emit_grant_required(&admitted.plan, verbs)
+    {
+        tracing::warn!(error = %e, "audit emit_grant_required failed (non-fatal)");
+    }
     // Claim 1 / claim 8 — record the admitted host-fs grants in the
     // chain-signed log (no-op when there are none).
     if let Err(e) = emitter.emit_shares_admitted(&admitted.plan) {

--- a/crates/mvm-hostd/src/audit/emitter.rs
+++ b/crates/mvm-hostd/src/audit/emitter.rs
@@ -299,6 +299,24 @@ impl AuditEmitter {
         )
     }
 
+    /// Emit `plan.grant_required` — records that this admission asserted verb-grant
+    /// enforcement (the admitted plan carries `agent_verbs`, so the launcher emits
+    /// `mvm.require_grant=1` and the guest fails closed without a valid grant).
+    /// Binds the granted verb set to the same plan id as the launch decision, so
+    /// `trust audit verify` can attest the enforcement posture. Host-side: the guest
+    /// cannot sign this chain.
+    pub fn emit_grant_required(
+        &self,
+        plan: &ExecutionPlan,
+        verbs: &[mvm_core::plan::VerbId],
+    ) -> Result<()> {
+        let mut labels = vec![("verb_count".to_string(), verbs.len().to_string())];
+        for (i, v) in verbs.iter().enumerate() {
+            labels.push((format!("verb_{i}"), v.as_str().to_string()));
+        }
+        self.emit(plan, "plan.grant_required", labels)
+    }
+
     /// Emit `plan.failed` — fires on any error path between admission
     /// and successful boot. `class` is a short tag (`backend-start`,
     /// `snapshot-restore`, etc.) the operator can grep for; `message`
@@ -431,6 +449,39 @@ mod tests {
         assert!(content.contains("oci_resolved_digest"));
         assert!(content.contains("oci_layer_digests"));
         assert_eq!(verify_audit_chain(&path, &vk).unwrap(), 1);
+    }
+
+    #[test]
+    fn grant_required_event_is_chain_signed_with_required_labels() {
+        let dir = tempfile::tempdir().unwrap();
+        let key = SigningKey::generate(&mut OsRng);
+        let vk = key.verifying_key();
+        let emitter = AuditEmitter::with_dir(key, dir.path()).unwrap();
+        let plan = fixture_plan("local", "plan-GR");
+
+        let verbs = vec![
+            mvm_core::plan::VerbId::new("ping").unwrap(),
+            mvm_core::plan::VerbId::new("run-entrypoint").unwrap(),
+        ];
+        emitter.emit_grant_required(&plan, &verbs).unwrap();
+
+        let path = dir.path().join("local.jsonl");
+        let content = std::fs::read_to_string(&path).expect("audit file exists");
+        assert!(
+            content.contains("plan.grant_required"),
+            "event kind must appear in log"
+        );
+        assert!(content.contains("\"2\""), "verb_count must be 2");
+        assert!(content.contains("ping"), "verb_0 label must contain 'ping'");
+        assert!(
+            content.contains("run-entrypoint"),
+            "verb_1 label must contain 'run-entrypoint'"
+        );
+        assert_eq!(
+            verify_audit_chain(&path, &vk).unwrap(),
+            1,
+            "single-entry chain must verify clean"
+        );
     }
 
     #[test]

--- a/crates/mvm-hostd/src/audit/emitter.rs
+++ b/crates/mvm-hostd/src/audit/emitter.rs
@@ -301,7 +301,7 @@ impl AuditEmitter {
 
     /// Emit `plan.grant_required` — records that this admission asserted verb-grant
     /// enforcement (the admitted plan carries `agent_verbs`, so the launcher emits
-    /// `mvm.require_grant=1` and the guest fails closed without a valid grant).
+    /// the grant-required boot marker and the guest fails closed without a valid grant).
     /// Binds the granted verb set to the same plan id as the launch decision, so
     /// `trust audit verify` can attest the enforcement posture. Host-side: the guest
     /// cannot sign this chain.


### PR DESCRIPTION
Closes #1457 (M1 follow-up from ADR-108 / #1381 item 3).

## What
Emits a **chain-signed** `plan.grant_required` audit entry at admission whenever the host asserts verb-grant enforcement (the admitted plan carries `agent_verbs`, so the launcher emits `mvm.require_grant=1` and the guest fails closed without a valid grant). This makes the enforcement posture **attestable via `mvmctl trust audit verify`**, rather than only observable as a guest console line.

The guest can't sign the host's claim-8 chain (it only holds a verifying key), so — as the M1 issue noted — this is emitted **host-side**, alongside `plan.admitted`/`plan.launched`.

## How
- `AuditEmitter::emit_grant_required(plan, verbs)` in `crates/mvm-hostd/src/audit/emitter.rs`, modeled exactly on `emit_oci_provenance` — reuses the internal `emit()` signer, event kind `plan.grant_required`, labels = `verb_count` + one `verb_N` per granted verb. Event kinds are free-form strings (the chain verifier is kind-agnostic), so no verify-path/enum change is needed.
- Emitted from the **shared** `admit_plan_for_boot` (up.rs), right after `emit_admitted`, guarded on `agent_verbs.is_some()`. Because `up.rs`, the transient `exec.rs` path, and `invoke.rs` all admit through that one function, every grant-bearing admission is covered by a single DRY site. The separate OCI-provenance admission (`exec.rs`, `agent_verbs: None`) is correctly not touched. Non-fatal (warns, never fails the run), matching the neighboring `emit_admitted`/`emit_launched` calls.

## Testing
`grant_required_event_is_chain_signed_with_required_labels` (mvm-hostd) — emits, reads the chain file, asserts the `plan.grant_required` entry with the verb labels and that the chain still verifies (signature intact), modeled on the existing `oci_provenance` test. `cargo check --workspace`, `nextest -p mvm-hostd`, `fmt --all`, `clippy -p mvm-hostd -p mvm-cli -D warnings` clean.

Pairs with collecting ObserveGap telemetry during the measure-now window.

🤖 Generated with [Claude Code](https://claude.com/claude-code)