### PR TITLE
feat(machine): make `machine exec <name>` argv optional (drop into a shell)

### DIFF
--- a/crates/mvm-cli/src/commands/machine/mod.rs
+++ b/crates/mvm-cli/src/commands/machine/mod.rs
@@ -883,8 +883,9 @@ pub(in crate::commands) struct MachineExecArgs {
     /// Accepted as an alias for `-t` so `-it` parses.
     #[arg(short = 'i', long = "interactive")]
     pub interactive: bool,
-    /// Argv to run inside the guest (use `--` to separate).
-    #[arg(trailing_var_arg = true, allow_hyphen_values = true, required = true)]
+    /// Argv to run inside the guest (use `--` to separate). Omit to drop into
+    /// an interactive shell, like `machine shell`.
+    #[arg(trailing_var_arg = true, allow_hyphen_values = true)]
     pub argv: Vec<String>,
 }
 
@@ -2210,21 +2211,28 @@ fn stop_failed_machine_start(name: &str) {
 
 fn exec_machine(cli: &Cli, args: MachineExecArgs, cfg: &MvmConfig) -> Result<()> {
     let spec = ensure_machine_spec_exists(&args.name)?;
+    // No argv: `machine exec <name>` drops into an interactive shell, matching
+    // `machine shell <name>` (command: None launches the guest's default shell).
+    let command = if args.argv.is_empty() {
+        None
+    } else {
+        Some(machine_exec_command(&args.argv))
+    };
     if args.tty || args.interactive {
         use std::io::IsTerminal as _;
         require_tty(std::io::stdin().is_terminal())?;
         super::vm::console::enforce_accessible_gate(&args.name, args.force)?;
-        return console::console_pty_command(
-            &args.name,
-            machine_exec_command(&args.argv),
-            machine_console_env(spec.ssh_agent),
-        );
+        let env = machine_console_env(spec.ssh_agent);
+        return match command {
+            Some(cmd) => console::console_pty_command(&args.name, cmd, env),
+            None => console::console_interactive_with_env_and_argv(&args.name, env, Vec::new()),
+        };
     }
     console::run(
         cli,
         console::Args {
             name: args.name,
-            command: Some(machine_exec_command(&args.argv)),
+            command,
             force: args.force,
             env: machine_console_env(spec.ssh_agent),
             pty_argv: Vec::new(),
@@ -3910,9 +3918,16 @@ mod tests {
     }
 
     #[test]
-    fn exec_requires_argv() {
-        let err = parse(&["exec", "web"]).expect_err("argv is required");
-        assert_eq!(err.kind(), clap::error::ErrorKind::MissingRequiredArgument);
+    fn exec_argv_is_optional_for_interactive_shell() {
+        // `machine exec <name>` with no argv parses and yields an empty argv,
+        // which the handler turns into an interactive shell (like `machine shell`).
+        match parse(&["exec", "web"]).expect("parse") {
+            MachineAction::Exec(args) => {
+                assert_eq!(args.name, "web");
+                assert!(args.argv.is_empty());
+            }
+            other => panic!("expected exec action, got {other:?}"),
+        }
     }
 
     #[test]

--- a/public/src/content/docs/reference/cli-commands.md
+++ b/public/src/content/docs/reference/cli-commands.md
@@ -419,6 +419,7 @@ or mounts private keys, `~/.ssh`, known-hosts material, or SSH config.
 | `mvmctl machine rm <name>... --yes --json` | Print a JSON array deletion summary |
 | `mvmctl machine exec <name> -- <cmd>...` | Run a command in an already-started named machine |
 | `mvmctl machine exec <name> -it -- <cmd>...` | Run a command in an already-started named machine attached to a PTY |
+| `mvmctl machine exec <name>` | Omit the command to drop into an interactive shell (same as `machine shell`) |
 | `mvmctl machine shell <name>` | Attach an interactive shell/console to an already-started named machine |
 | `mvmctl machine stop <name>...` | Stop one or more already-started named machines (prompts for confirmation; pass `--yes` to skip) |
 | `mvmctl machine check-artifact <artifact.mvm>` | Verify a portable artifact and preview its admission posture without extracting or booting |
@@ -466,8 +467,8 @@ mvmctl machine stop  blue-fox-3f2a --yes      # tear it down when done
 **Interactive is dev-only.** `-t`/`--tty` attaches the foreground command to a
 PTY and is refused for a sealed/production image (claim 15 — no interactive
 access to a sealed microVM) and when stdin is not a terminal. `machine run -it`
-requires an argv after `--`; use `machine shell <name>` for the default
-shell on an already-running machine.
+requires an argv after `--`; use `machine shell <name>` (or `machine exec
+<name>` with no argv) for the default shell on an already-running machine.
 
 `machine create` accepts either `--image <ref>` or an image-backed manifest, not
 both. When `--image` is omitted, it searches the current directory for


### PR DESCRIPTION
## What

`machine exec <name>` with no argv now drops into an interactive shell — the same behavior as `machine shell <name>` — instead of failing with a missing-required-argument error.

## Why

`machine exec` and `machine shell` already share the same PTY-over-vsock transport and env layering; the only difference was that `exec` demanded an argv. Making argv optional lets `machine exec <name>` serve as the natural "run a command, or just give me a shell" verb.

## How

- Dropped `required = true` from the `argv` clap arg on `MachineExecArgs`.
- `exec_machine` maps empty argv to `command: None` (the guest's default shell). The `-it` path routes through `console_interactive_with_env_and_argv` instead of building an empty `exec ` command string.
- Non-empty argv is unchanged.

## Tests

- Replaced `exec_requires_argv` with `exec_argv_is_optional_for_interactive_shell`, asserting `machine exec <name>` parses to an empty argv.
- All 95 machine-module tests pass; `cargo fmt --all --check` and `cargo clippy -p mvm-cli` clean.

## Docs

- `reference/cli-commands.md`: added the no-argv row to the machine command table and noted the shortcut alongside `machine shell`.

## Not verified

The empty-argv → shell behavior is verified at the parse/routing level; the live interactive-shell boot needs a running microVM and was not exercised end-to-end.

🤖 Generated with [Claude Code](https://claude.com/claude-code)