### PR TITLE
test(sdk): conformance-pin the create --image shape across all surfaces

### DIFF
--- a/crates/mvm-sdk/src/facade.rs
+++ b/crates/mvm-sdk/src/facade.rs
@@ -409,18 +409,29 @@ mod tests {
 
     #[test]
     fn create_start_rm_args_build_the_machine_verbs() {
+        // Matches the shared `create-image.argv` conformance fixture, so the
+        // client's create argv is drift-locked against the CLI + every SDK.
         let spec = MachineSpec {
-            name: "db".into(),
+            name: "web".into(),
             image: "alpine:3.20".into(),
-            cpus: 1,
-            memory_mib: 256,
+            cpus: 2,
+            memory_mib: 512,
             env: vec![],
         };
-        // create persists the spec (no boot).
-        let create = create_args(&spec).unwrap();
-        assert_eq!(create[0], "create");
-        assert!(create.iter().any(|a| a == "alpine:3.20"));
-        assert!(create.iter().any(|a| a == "256M"));
+        assert_eq!(
+            create_args(&spec).unwrap(),
+            vec![
+                "create",
+                "--name",
+                "web",
+                "--image",
+                "alpine:3.20",
+                "--cpus",
+                "2",
+                "--memory",
+                "512M",
+            ]
+        );
 
         let id = MachineId("db".into());
         assert_eq!(start_args(&id).unwrap(), vec!["start", "db"]);

--- a/crates/mvm-sdk/tests/machine_verb_conformance.rs
+++ b/crates/mvm-sdk/tests/machine_verb_conformance.rs
@@ -93,6 +93,20 @@ fn create_manifest_matches_shared_fixture() {
 }
 
 #[test]
+fn create_image_matches_shared_fixture() {
+    // The `--image` + resources shape the `MvmClient` facade's `create_machine`
+    // emits (SubprocessBackend::create_args). Pins that exact argv so a CLI, an
+    // SDK, and the client all produce the identical create.
+    let argv = MachineCreate::builder("web")
+        .image("alpine:3.20")
+        .cpus(2)
+        .memory("512M")
+        .machine_args()
+        .expect("create-image argv");
+    assert_eq!(argv, fixture("create-image"));
+}
+
+#[test]
 fn check_artifact_matches_shared_fixture() {
     let argv = MachineCheckArtifact::builder("/tmp/app.mvm")
         .key("/tmp/app.pub")
@@ -221,6 +235,7 @@ fn fixture_coverage_is_accounted_for() {
     // Rust conformance complete.
     let asserted = [
         "check-artifact",
+        "create-image",
         "create-manifest",
         "exec",
         "inspect",

--- a/sdks/machine-fixtures/create-image.argv
+++ b/sdks/machine-fixtures/create-image.argv
@@ -1,0 +1,9 @@
+create
+--name
+web
+--image
+alpine:3.20
+--cpus
+2
+--memory
+512M

--- a/sdks/python/tests/test_machine.py
+++ b/sdks/python/tests/test_machine.py
@@ -99,6 +99,16 @@ def test_machine_create_manifest_argv_matches_cli_unknown_key_fixture() -> None:
     ) == _fixture("create-manifest")
 
 
+def test_machine_create_image_argv_matches_shared_fixture() -> None:
+    # The --image + resources shape the MvmClient facade's create_machine emits.
+    assert _machine_create_argv(
+        name="web",
+        image="alpine:3.20",
+        cpus=2,
+        memory="512M",
+    ) == _fixture("create-image")
+
+
 def test_machine_check_artifact_argv_matches_cli_fixture() -> None:
     assert _machine_check_artifact_argv(
         path="/tmp/app.mvm",

--- a/sdks/typescript/tests/machine.test.ts
+++ b/sdks/typescript/tests/machine.test.ts
@@ -176,6 +176,16 @@ describe("Machine persistent lifecycle", () => {
     })).toEqual(readArgvFixture("create-manifest"));
   });
 
+  it("emits the shared image create argv fixture", () => {
+    // The --image + resources shape the MvmClient facade's create_machine emits.
+    expect(machineCreateArgv({
+      name: "web",
+      image: "alpine:3.20",
+      cpus: 2,
+      memory: "512M",
+    })).toEqual(readArgvFixture("create-image"));
+  });
+
   it("shells create/start/exec/shell/stop through mvmctl machine", () => {
     const script = writeFixtureMvmctl();
     process.env.MVM_CLI_BIN = script;

--- a/specs/notes/machine-verb-conformance-audit.md
+++ b/specs/notes/machine-verb-conformance-audit.md
@@ -35,16 +35,16 @@ Legend: ● driver+pure-argv-builder · ◐ driver only · ○ absent · 🔒 fi
 | CLI verb | Python | TypeScript | Rust `machine.rs` | Rust facade (`MvmClient`) | Shared fixture |
 |---|---|---|---|---|---|
 | run           | ● | ● | ● | ◐ (gated on admitted-boot) | 🔒 ×3 |
-| create        | ● | ● | ● | ○ | 🔒 |
+| create        | ● | ● | ● | ● | 🔒 ×2 |
 | check-artifact| ● | ● | ● | ○ | 🔒 |
-| start         | ● | ● | ● | ○ | 🔒 |
+| start         | ● | ● | ● | ● | 🔒 |
 | exec          | ● | ● | ● | ● | 🔒 |
 | shell         | ● | ● | ● | ○ (excluded: interactive PTY) | 🔒 |
 | stop          | ● | ● | ● | ● | 🔒 |
 | ls / list     | ● | ● | ● | ● | 🔒 |
 | logs          | ● | ● | ● | ● | 🔒 |
-| inspect       | ● | ● | ● | ○ | 🔒 |
-| rm            | ● | ● | ● | ○ | 🔒 ×2 |
+| inspect       | ● | ● | ● | ● | 🔒 |
+| rm            | ● | ● | ● | ● | 🔒 ×2 |
 | build         | ○ | ○ | ○ | ○ | — (image pipeline, no SDK surface by design) |
 | console       | ○ | ○ | ○ | ○ | — (dev-only interactive PTY, out of scope) |
 
@@ -88,6 +88,16 @@ Only `build` and `console` remain CLI-only, both by design.
    lives in `mvm-cli` and exposing it to `mvm-client`/`mvm-sdk` is a large lift
    tracked in Plan 214; until then both `run` paths fail closed to preserve
    claim 8.
+
+7. **The `MvmClient` trait now covers the full machine lifecycle.** The typed
+   facade grew `inspect`/`create`/`start`/`remove` alongside `list`/`run`/`stop`/
+   `logs`/`exec`, so a Rust consumer (mvmd) gets the same lifecycle a language
+   SDK does — no more `○` gaps in the facade column. Where an impl genuinely
+   can't support an op (the cloud `GatewayBackend` boots on create; the
+   in-process `LocalBackend` lacks the CLI-side machine registry / a destroy
+   seam) it returns an honest error, not a fake. The `create-image` shared
+   fixture pins the `--image` + resources shape the facade's `create_machine`
+   emits, so a CLI, an SDK, and the client all produce the identical create argv.
 
 ## The harness (approach 1, across all languages)
 


### PR DESCRIPTION
## What

`create` already had cross-language conformance — but only for the create-from-**manifest** shape (`create --name --manifest --profile --force --json`). #1464's `MvmClient` facade `create_machine` emits the create-from-**image** shape (`create --name --image --cpus --memory`), which **no shared fixture covered** — so the client's create argv wasn't drift-locked against the SDKs.

Adds the `create-image.argv` shared fixture and asserts it across **all four surfaces**:
- Rust `MachineCreate::builder().image().cpus().memory()` (+ tripwire registration),
- the facade `create_args` (the **#1464 client path** — ties the trait method to the shared fixture),
- Python `_machine_create_argv(image=…, cpus=…, memory=…)`,
- TypeScript `machineCreateArgv({image, cpus, memory})`.

All three languages already emit this shape in the same flag order, so the fixture **pins it and guards future drift** — a CLI, an SDK, and the client now produce byte-identical create argv. This is the vision made concrete: one contract, every frontend conforms.

## Also

Refreshes `specs/notes/machine-verb-conformance-audit.md`: #1464 filled the facade's `inspect`/`create`/`start`/`remove` `○` gaps (now `●`), and `create` gains 🔒 ×2.

## Tests

Rust conformance (16) + facade (1) pass; Python (2 create tests) pass; TypeScript (117) pass; clippy + fmt clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)