### PR TITLE
feat(run): virtiofs-root selection wired into run --image on HVF (Plan 223 A4→run path)

### DIFF
--- a/crates/mvm-backend/src/hvf_backend.rs
+++ b/crates/mvm-backend/src/hvf_backend.rs
@@ -218,18 +218,26 @@ impl VmBackend for HvfBackend {
             .map(PathBuf::from)
             .unwrap_or_else(|| state_dir.join("hvf-agent.sock"));
 
+        // virtiofs-root dev boot (Plan-223 tier gate): serve the unpacked+injected
+        // tree read-only over virtio-fs; no block rootfs is attached.
+        let virtiofs_root = config.virtiofs_root.clone().map(PathBuf::from);
         // Single workload rootfs → one ephemeral (RAM-backed) writable disk: the
         // guest mounts it `rw` but its writes must not persist to the base image.
-        let disks = Some(config.rootfs_path.clone())
-            .filter(|p| !p.is_empty())
-            .map(|p| {
-                vec![HvfDisk {
-                    path: PathBuf::from(p),
-                    read_only: false,
-                    ephemeral: true,
-                }]
-            })
-            .unwrap_or_default();
+        // Skipped entirely on the virtiofs-root path.
+        let disks = if virtiofs_root.is_some() {
+            Vec::new()
+        } else {
+            Some(config.rootfs_path.clone())
+                .filter(|p| !p.is_empty())
+                .map(|p| {
+                    vec![HvfDisk {
+                        path: PathBuf::from(p),
+                        read_only: false,
+                        ephemeral: true,
+                    }]
+                })
+                .unwrap_or_default()
+        };
         // A transient workload ends the VM by reporting its exit code over the
         // vsock exit port (the default — VM life = workload life); a persistent
         // (`-d`) VM ends on `stop`. MVM_HVF_TIMEOUT is only a backstop cap
@@ -247,9 +255,7 @@ impl VmBackend for HvfBackend {
             memory_mib: config.memory_mib,
             initramfs: config.initrd_path.clone().map(PathBuf::from),
             disks,
-            // Block-rootfs path today; the virtiofs-root strategy sets this
-            // instead (via the run-path tier gate) on a dev-tier boot.
-            virtiofs_root: None,
+            virtiofs_root,
             vsock: true,
             console_log: console_log.clone(),
             pid_file: pid_file.clone(),

--- a/crates/mvm-backend/src/mock.rs
+++ b/crates/mvm-backend/src/mock.rs
@@ -383,6 +383,7 @@ mod tests {
             kernel_path: None,
             initrd_path: None,
             rootfs_path: "/tmp/stub.ext4".to_string(),
+            virtiofs_root: None,
             verity_path: None,
             roothash: None,
             runtime_overlay_path: None,

--- a/crates/mvm-cli/src/commands/image/mod.rs
+++ b/crates/mvm-cli/src/commands/image/mod.rs
@@ -127,6 +127,10 @@ pub(in crate::commands) struct ResolvedOciRunImage {
     pub reference: String,
     pub resolved_digest: String,
     pub rootfs_path: PathBuf,
+    /// The unpacked+injected OCI tree (`<cache>/unpacked/<hash>`), when it is
+    /// present on disk — the source a virtiofs-root dev boot serves directly.
+    /// `None` when only the cached ext4 is available (booted as block rootfs).
+    pub unpacked_root: Option<PathBuf>,
     pub pulled: bool,
     pub provenance: OciProvenance,
     pub auth_source: Option<String>,
@@ -507,11 +511,13 @@ pub(in crate::commands) fn resolve_or_pull_run_image(
         Some(trust) => trust,
         None => trust_decision_for_cached_image(&image_ref, &image, prod, &CosignCommandVerifier)?,
     };
+    let unpacked_root = unpacked_dir_if_present(cache_root, &image.resolved_digest);
     Ok(ResolvedOciRunImage {
         provenance: image.provenance("run_image", reference, &trust),
         reference: image.reference,
         resolved_digest: image.resolved_digest,
         rootfs_path,
+        unpacked_root,
         pulled,
         auth_source: auth_source_from_pull,
     })
@@ -682,6 +688,7 @@ fn ingest_archive_from_reader<R: Read>(
         reference: image.manifest_digest.clone(),
         resolved_digest: image.manifest_digest,
         rootfs_path: rootfs_abs,
+        unpacked_root: Some(unpacked_root.clone()),
         pulled: true,
         provenance,
         auth_source: None,
@@ -753,6 +760,8 @@ fn ingest_rootfs_dir(
         reference: supplied_reference.to_string(),
         resolved_digest: String::new(),
         rootfs_path: rootfs_abs,
+        // rootfs-dir is a niche dev path (no digest); boot it as block ext4.
+        unpacked_root: None,
         pulled: true,
         provenance,
         auth_source: None,
@@ -1314,6 +1323,18 @@ fn write_cache_file(cache_root: &Path, relative: &str, bytes: &[u8]) -> Result<(
 
 fn layer_blob_path(digest: &str) -> Result<String> {
     Ok(format!("blobs/sha256/{}", sha256_hex(digest)?))
+}
+
+/// The unpacked+injected OCI tree for `resolved_digest`, iff present on disk.
+/// Its location is deterministic (`<cache>/unpacked/<sha256_hex(digest)>`); a
+/// virtiofs-root dev boot serves it directly, so gate on existence.
+fn unpacked_dir_if_present(cache_root: &Path, resolved_digest: &str) -> Option<PathBuf> {
+    if resolved_digest.is_empty() {
+        return None;
+    }
+    let hex = sha256_hex(resolved_digest).ok()?;
+    let dir = cache_root.join("unpacked").join(hex);
+    dir.is_dir().then_some(dir)
 }
 
 fn sha256_hex(digest: &str) -> Result<String> {

--- a/crates/mvm-cli/src/commands/vm/exec.rs
+++ b/crates/mvm-cli/src/commands/vm/exec.rs
@@ -681,6 +681,14 @@ fn build_exec_request(
                 rootfs_path: cached.rootfs_path.display().to_string(),
                 initrd_path: None,
                 label: format!("oci:{}", cached.resolved_digest),
+                // Offer the unpacked+injected tree as a virtiofs-root candidate;
+                // the run-path tier gate (backend cap × prod × sealed) decides.
+                virtiofs_oci_root: cached.unpacked_root.as_ref().map(|tree| {
+                    crate::exec::VirtiofsOciRoot {
+                        tree_dir: tree.display().to_string(),
+                        prod,
+                    }
+                }),
             }
         }
         (None, None) => {
@@ -692,6 +700,7 @@ fn build_exec_request(
                 rootfs_path,
                 initrd_path: None,
                 label: "default-microvm".to_string(),
+                virtiofs_oci_root: None,
             }
         }
     };

--- a/crates/mvm-cli/src/exec.rs
+++ b/crates/mvm-cli/src/exec.rs
@@ -150,7 +150,51 @@ pub enum ImageSource {
         initrd_path: Option<String>,
         /// Display label used in messages and `flake_ref` (no functional effect).
         label: String,
+        /// When set, a candidate to boot from a read-only **virtiofs root**
+        /// serving the unpacked+injected OCI tree instead of `rootfs_path`. Only
+        /// the OCI `run --image` path sets it; the run-path tier gate
+        /// ([`mvm_build::run_image::select_root_strategy`]) makes the final call
+        /// from this candidate + the backend capability + sealed state.
+        virtiofs_oci_root: Option<VirtiofsOciRoot>,
     },
+}
+
+/// A candidate unpacked OCI tree to boot as a virtiofs root, carried from OCI
+/// resolution to the run-path tier gate.
+#[derive(Debug, Clone)]
+pub struct VirtiofsOciRoot {
+    /// Host path of the unpacked+injected OCI tree to serve read-only.
+    pub tree_dir: String,
+    /// Whether this is a `--prod` run — a hard disqualifier for the dev-tier
+    /// virtiofs path (the gate keeps prod on Option B / block+ext4).
+    pub prod: bool,
+}
+
+/// The run-path tier gate: return the tree to boot as a virtiofs root, or `None`
+/// to use the block rootfs. `select_root_strategy` is the single authority — it
+/// can never yield virtiofs for a prod or sealed workload, nor on a
+/// non-virtiofs-capable backend. Only an OCI `Prebuilt` carrying a candidate can
+/// reach virtiofs at all; every other image source is `None`.
+fn resolve_virtiofs_root(
+    image: &ImageSource,
+    backend_virtiofs_root: bool,
+    sealed: bool,
+) -> Option<String> {
+    let ImageSource::Prebuilt {
+        virtiofs_oci_root: Some(candidate),
+        ..
+    } = image
+    else {
+        return None;
+    };
+    match mvm_build::run_image::select_root_strategy(mvm_build::run_image::RootStrategySelection {
+        backend_virtiofs_root,
+        prod: candidate.prod,
+        sealed,
+    }) {
+        mvm_build::run_image::RootStrategy::VirtiofsRoot => Some(candidate.tree_dir.clone()),
+        mvm_build::run_image::RootStrategy::BlockExt4 => None,
+    }
 }
 
 /// All inputs to the orchestrator.
@@ -542,6 +586,7 @@ fn run_inner(
                 rootfs_path,
                 initrd_path,
                 label,
+                ..
             } => (
                 kernel_path.clone(),
                 initrd_path.clone(),
@@ -598,6 +643,16 @@ fn run_inner(
     // inside the VM, so we can't `Path::exists()` them from the host —
     // shell out into the VM instead.
     let (verity_path, roothash) = mvm_backend::microvm::probe_verity_sidecar(&rootfs);
+
+    // Run-path tier gate: a virtiofs-capable backend + a non-prod, non-sealed OCI
+    // dev run boots from the unpacked tree over virtio-fs (no ext4 materialize);
+    // prod, sealed, and block backends stay on the materialized rootfs (claim 3).
+    let virtiofs_root = resolve_virtiofs_root(
+        &req.image,
+        backend.capabilities().virtiofs_root,
+        verity_path.is_some(),
+    );
+
     let t_drives_ready = timing.then(std::time::Instant::now);
 
     // Pre-open console data sockets for interactive PTY runs against
@@ -614,6 +669,7 @@ fn run_inner(
     let mut start_config = VmStartConfig {
         name: vm_name.clone(),
         rootfs_path: rootfs.clone(),
+        virtiofs_root,
         kernel_path: Some(vmlinux.clone()),
         initrd_path: initrd.clone(),
         verity_path,
@@ -1762,7 +1818,46 @@ mod tests {
             rootfs_path: "/r".into(),
             initrd_path: None,
             label: "lbl".into(),
+            virtiofs_oci_root: None,
         }
+    }
+
+    #[test]
+    fn virtiofs_gate_only_dev_capable_nonsealed_reaches_virtiofs() {
+        let with = |prod| ImageSource::Prebuilt {
+            kernel_path: "/k".into(),
+            rootfs_path: "/r".into(),
+            initrd_path: None,
+            label: "l".into(),
+            virtiofs_oci_root: Some(VirtiofsOciRoot {
+                tree_dir: "/tree".into(),
+                prod,
+            }),
+        };
+        // The one cell that reaches virtiofs: OCI candidate, capable backend,
+        // non-prod, non-sealed.
+        assert_eq!(
+            resolve_virtiofs_root(&with(false), true, false).as_deref(),
+            Some("/tree")
+        );
+        // Every disqualifier keeps it on the block rootfs (claim 3):
+        assert_eq!(
+            resolve_virtiofs_root(&with(true), true, false),
+            None,
+            "prod"
+        );
+        assert_eq!(
+            resolve_virtiofs_root(&with(false), true, true),
+            None,
+            "sealed"
+        );
+        assert_eq!(
+            resolve_virtiofs_root(&with(false), false, false),
+            None,
+            "non-virtiofs backend (e.g. Firecracker)"
+        );
+        // A non-OCI image (flake/template/default) never reaches virtiofs.
+        assert_eq!(resolve_virtiofs_root(&prebuilt(), true, false), None);
     }
 
     fn add_dir() -> AddDir {

--- a/crates/mvm-core/src/protocol/vm_backend.rs
+++ b/crates/mvm-core/src/protocol/vm_backend.rs
@@ -32,6 +32,12 @@ pub struct VmStartConfig {
     pub name: String,
     /// Absolute path to the root filesystem (ext4 image).
     pub rootfs_path: String,
+    /// When set, boot from a read-only **virtiofs root** serving this host
+    /// directory (the unpacked+injected OCI tree) instead of a block `rootfs_path`
+    /// — the Plan-223 dev-tier boot on a virtiofs-capable backend. The run-path
+    /// tier gate sets this only for non-prod, non-sealed dev workloads; other
+    /// backends/tiers leave it `None` and use `rootfs_path`.
+    pub virtiofs_root: Option<String>,
     /// Absolute path to the kernel image (Firecracker needs this; others may ignore).
     pub kernel_path: Option<String>,
     /// Absolute path to the initial ramdisk (NixOS stage-1), if present.


### PR DESCRIPTION
Stacked on #1472. Threads the virtiofs-root selection from the run path to the in-house backend.

- `VmStartConfig.virtiofs_root: Option<String>` (defaults `None`; every site spreads `Default`, zero behavior change).
- `HvfBackend::start`: when set, attach **no block rootfs** and pass the directory to the supervisor's `virtiofs_root` (served read-only over virtio-fs).

Backend-side plumbing only — any `VmStartConfig` producer can now request a virtiofs-root boot; the mechanism is the one already **live-validated on HVF** (#1472). The run-path tier gate that *sets* the field (`select_root_strategy` → inject-only tree → `VmStartConfig`) is the next slice.

clippy `--all-targets -D` / fmt / spec-refs / core-runtime-free clean.