### PR TITLE
feat(mvm-client-local): real local remove_machine (stop-based teardown)

### DIFF
--- a/crates/mvm-client-local/src/lib.rs
+++ b/crates/mvm-client-local/src/lib.rs
@@ -312,14 +312,28 @@ impl MvmClient for LocalBackend {
         self.backend.stop(&VmId(id.0.clone())).map_err(backend_err)
     }
 
-    async fn remove_machine(&self, _id: &MachineId) -> Result<()> {
-        // The backend dispatch (`AnyBackend`) exposes stop/list/status but no
-        // destroy seam, so a full remove (delete the machine record) isn't
-        // wired; that lifecycle lives on the CLI's `machine rm`.
-        Err(MvmError::Backend {
-            reason: "local remove requires a backend destroy seam (not wired); use `machine rm`"
-                .into(),
-        })
+    async fn remove_machine(&self, id: &MachineId) -> Result<()> {
+        let vid = VmId(id.0.clone());
+        // Idempotent: removing an absent machine is `Ok` (trait contract).
+        // `list` is the source of truth for what this backend can see, so an
+        // id it doesn't know is already "removed".
+        let present = self
+            .backend
+            .list()
+            .map_err(backend_err)?
+            .iter()
+            .any(|v| v.id == vid);
+        if !present {
+            return Ok(());
+        }
+        // This backend is registry-less — it drives live VMs the VMM tracks,
+        // with no persisted spec to delete (which is why `create`/`start`
+        // fail closed above). For that model `stop` *is* the removal: it tears
+        // the VM down and clears the run-state marker the VMM lists on, so the
+        // machine drops out of `list`. Idempotent on an already-stopped VM.
+        // (The CLI's `machine rm` additionally deletes a persisted machine
+        // record — a spec store this in-process backend doesn't own.)
+        self.backend.stop(&vid).map_err(backend_err)
     }
 
     async fn machine_logs(&self, id: &MachineId, opts: LogOpts) -> Result<Vec<u8>> {
@@ -437,6 +451,55 @@ mod tests {
                 .iter()
                 .any(|m| m.name == "local-boot-from-image-path")
         );
+    }
+
+    #[tokio::test]
+    async fn remove_drops_the_machine_from_list_and_is_idempotent() {
+        // Isolate the host signer + mock VM dirs under a tempdir (nextest runs
+        // each test in its own process, so the env var can't race a sibling).
+        let data = tempfile::tempdir().unwrap();
+        // SAFETY: single-threaded test; no other thread reads these vars.
+        unsafe {
+            std::env::set_var("MVM_DATA_DIR", data.path());
+        }
+        let rootfs = data.path().join("rootfs.ext4");
+        std::fs::write(&rootfs, b"hashable-rootfs-bytes\n").unwrap();
+
+        let be = LocalBackend::with_hypervisor("mock");
+        let spec = MachineSpec {
+            name: "local-remove-target".into(),
+            image: rootfs.to_string_lossy().into_owned(),
+            cpus: 1,
+            memory_mib: 128,
+            env: vec![],
+        };
+        let state = be.run_machine(spec).await.expect("boot");
+        assert!(
+            be.list_machines(MachineFilter::all())
+                .await
+                .unwrap()
+                .iter()
+                .any(|m| m.id == state.id),
+            "the booted machine should list before removal"
+        );
+
+        // Remove drops it from the backend's view.
+        be.remove_machine(&state.id).await.expect("remove");
+        assert!(
+            !be.list_machines(MachineFilter::all())
+                .await
+                .unwrap()
+                .iter()
+                .any(|m| m.id == state.id),
+            "removed machine must not list"
+        );
+
+        // Idempotent: removing the now-absent machine, and a never-existed id,
+        // both succeed rather than erroring.
+        be.remove_machine(&state.id).await.expect("re-remove is Ok");
+        be.remove_machine(&MachineId("never-existed-xyz".into()))
+            .await
+            .expect("removing an absent machine is Ok");
     }
 
     #[test]


### PR DESCRIPTION
`LocalBackend::remove_machine` was an honest error — *"local remove requires a backend destroy seam (not wired)"*. It turns out it has one.

## The seam
This backend is **registry-less**: it drives live VMs the VMM tracks, with no persisted spec (which is exactly why `create`/`start` fail closed). For that model **`stop` *is* the removal** — stopping tears the VM down and clears the run-state marker the VMM lists on:
- the **mock** backend drops it from its in-memory registry;
- **libkrun** deletes the pid file, so the VM falls out of `list`'s `~/.mvm/vms/*/libkrun.pid` scan.

Either way the machine disappears from `list`, which is what a caller sees.

## Change
`remove_machine` = idempotent absent-check against `list` (removing a machine this backend can't see is `Ok`, per the trait contract) + `backend.stop`. `create`/`start` stay fail-closed — those genuinely need a spec store this in-process backend doesn't own. The CLI's `machine rm` additionally deletes that persisted record; this is the live-VM half.

## Why now
This completes the `MvmClient` surface a **visual frontend (mvm-studio)** needs to drive local microVMs — its Delete button maps to `remove_machine`. It's the prerequisite for Studio's local-backend mode (tinylabscom/mvm-studio#2 wired the remote path).

## Test
New `remove_drops_the_machine_from_list_and_is_idempotent`: boots a VM over the mock backend, removes it, asserts it drops from `list`, and asserts a second remove + an absent-id remove are both `Ok`.

`cargo nextest -p mvm-client-local` (7/7) + clippy + fmt clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)