### PR TITLE
feat(kernel): strip unreachable block drivers from the workload kernel (Plan 209 Batch 6)

### DIFF
--- a/crates/mvm-cli/src/commands/env/dev_vz.rs
+++ b/crates/mvm-cli/src/commands/env/dev_vz.rs
@@ -34,6 +34,13 @@ const DEV_VM_SESSION_ID: &str = mvm_build::vz_builder::DEV_SESSION_ID;
 #[cfg(feature = "builder-vm")]
 const DEV_VZ_ACTIVITY_FILE: &str = "last-activity-unix-secs";
 const BUILDER_VM_SOURCE_FINGERPRINT_FILE: &str = ".mvm-source.sha256";
+/// Sidecar written next to a cached workload `vmlinux` recording the SHA-256 of
+/// its kernel-config nix source (`nix/images/kernel/`). A source-checkout boot
+/// treats a cached kernel as stale when this fingerprint no longer matches the
+/// on-disk config, so an edit to `base.nix`/`workload.nix` rebuilds on the very
+/// next `machine run` instead of silently reusing the old vmlinux (the cache is
+/// otherwise keyed by path-existence, which cannot see a config change).
+const KERNEL_SOURCE_FINGERPRINT_FILE: &str = ".mvm-kernel-source.sha256";
 const BUILDER_VM_ARTIFACT_DIGEST_FILE: &str = ".mvm-artifacts.sha256";
 const BUILDER_VM_PROVENANCE_FILE: &str = ".mvm-provenance.json";
 #[cfg(feature = "builder-vm")]
@@ -4857,11 +4864,18 @@ pub(crate) fn ensure_default_microvm_image(
 pub(crate) fn ensure_workload_kernel() -> Result<String> {
     let arch = builder_vm_host_arch();
     let cache = mvm_core::config::mvm_cache_dir();
-    if let Some(cached) = find_cached_workload_kernel(&cache, arch) {
+    // Source-checkout: fingerprint `nix/images/kernel/` so a stale cached vmlinux
+    // from since-edited config is rejected and rebuilt (path-existence alone
+    // can't see a config change). End-user prebuilt → None → prior behavior.
+    let source_fingerprint = workload_kernel_source_fingerprint_opt();
+    if let Some(cached) = find_cached_workload_kernel(&cache, arch, source_fingerprint.as_deref()) {
         return Ok(cached);
     }
     let dest = format!("{cache}/builder-vm/{arch}/kernels/workload/vmlinux");
     if let Some(built) = try_build_workload_kernel_locally()? {
+        if let Some(fp) = &source_fingerprint {
+            write_kernel_source_fingerprint(std::path::Path::new(&built), fp);
+        }
         return Ok(built);
     }
     download_workload_kernel(arch, &dest)?;
@@ -4895,18 +4909,90 @@ fn download_workload_kernel(arch: &str, dest: &str) -> Result<()> {
     Ok(())
 }
 
-/// First existing workload-kernel `vmlinux` on disk among the dedicated kernel
-/// cache and the default-microvm images — all the identical `mkWorkloadKernel`
-/// derivation, so any one is a valid workload kernel. `None` ⇒ build/download.
-/// Path-injectable (no global state) so it's hermetically testable.
-fn find_cached_workload_kernel(cache_dir: &str, arch: &str) -> Option<String> {
+/// SHA-256 fingerprint of the workload kernel's nix-config source
+/// (`nix/images/kernel/` — base.nix, workload.nix, builder.nix, flake.nix,
+/// flake.lock). `None` when not in a source checkout (no in-repo flake to
+/// locate the workspace): an end-user mvmctl boots the published, hash-verified
+/// `vmlinux-<arch>-workload` prebuilt, which carries no local source to compare,
+/// so the cache stays keyed by path-existence as before. On a source checkout
+/// this fingerprint gates the cache so a `base.nix`/`workload.nix` edit rebuilds
+/// on the next boot — the same "your change appears in the very next run"
+/// contract the builder-VM image already honors via its own source fingerprint.
+fn workload_kernel_source_fingerprint_opt() -> Option<String> {
+    let flake = find_builder_vm_flake().ok()?;
+    let workspace_root = workspace_root_for_builder_flake(std::path::Path::new(&flake)).ok()?;
+    workload_kernel_source_fingerprint(&workspace_root).ok()
+}
+
+/// Hash `nix/images/kernel/` recursively (the complete workload-kernel config
+/// source). Separated from the flake lookup so it is hermetically testable
+/// against a fixture workspace.
+fn workload_kernel_source_fingerprint(workspace_root: &std::path::Path) -> Result<String> {
+    let kernel_dir = workspace_root.join("nix").join("images").join("kernel");
+    if !kernel_dir.is_dir() {
+        anyhow::bail!(
+            "workload kernel source dir missing at {}",
+            kernel_dir.display()
+        );
+    }
+    let mut hasher = Sha256::new();
+    hash_dir_recursive(&mut hasher, "nix/images/kernel", &kernel_dir)?;
+    Ok(format!("{:x}", hasher.finalize()))
+}
+
+/// Does the `KERNEL_SOURCE_FINGERPRINT_FILE` sidecar in `dir` match `expected`?
+/// A missing/unreadable sidecar is a miss (treated as stale → rebuild), so a
+/// kernel cached before this gate existed is refreshed once.
+fn kernel_source_fingerprint_matches(dir: &std::path::Path, expected: &str) -> bool {
+    std::fs::read_to_string(dir.join(KERNEL_SOURCE_FINGERPRINT_FILE))
+        .map(|actual| actual.trim() == expected)
+        .unwrap_or(false)
+}
+
+/// Record the kernel-config source fingerprint next to a freshly-built
+/// `vmlinux` so subsequent boots recognise it as current. Best-effort — a write
+/// failure only costs a redundant rebuild next time, never a stale boot.
+fn write_kernel_source_fingerprint(vmlinux_path: &std::path::Path, fingerprint: &str) {
+    if let Some(dir) = vmlinux_path.parent() {
+        let _ = std::fs::write(
+            dir.join(KERNEL_SOURCE_FINGERPRINT_FILE),
+            format!("{fingerprint}\n"),
+        );
+    }
+}
+
+/// First workload-kernel `vmlinux` on disk among the dedicated kernel cache and
+/// the default-microvm images — all the identical `mkWorkloadKernel` derivation,
+/// so any one is a valid workload kernel. `None` ⇒ build/download.
+///
+/// `expected_fingerprint` gates a source-checkout boot: a candidate is accepted
+/// only when its `KERNEL_SOURCE_FINGERPRINT_FILE` sidecar matches, so a stale
+/// vmlinux from a since-edited `nix/images/kernel/` is rejected and rebuilt.
+/// `None` (end-user prebuilt, no local source) keeps the prior path-existence
+/// behavior. Path-injectable (no global state) so it's hermetically testable.
+fn find_cached_workload_kernel(
+    cache_dir: &str,
+    arch: &str,
+    expected_fingerprint: Option<&str>,
+) -> Option<String> {
     [
         format!("{cache_dir}/builder-vm/{arch}/kernels/workload/vmlinux"),
         format!("{cache_dir}/default-microvm/prod/vmlinux"),
         format!("{cache_dir}/default-microvm/dev/vmlinux"),
     ]
     .into_iter()
-    .find(|p| std::path::Path::new(p).is_file())
+    .find(|p| {
+        let path = std::path::Path::new(p);
+        if !path.is_file() {
+            return false;
+        }
+        match expected_fingerprint {
+            None => true,
+            Some(fp) => path
+                .parent()
+                .is_some_and(|dir| kernel_source_fingerprint_matches(dir, fp)),
+        }
+    })
 }
 
 /// Source-checkout local build of just the workload kernel. `Some` when the
@@ -5127,6 +5213,13 @@ fn build_default_microvm_via_libkrun(
     }
     let kernel = format!("{out_dir}/vmlinux");
     let rootfs = format!("{out_dir}/rootfs.ext4");
+    // Stamp the kernel-config fingerprint next to this image's bundled vmlinux so
+    // the OCI `ensure_workload_kernel` path recognises it as a current workload
+    // kernel (same mkWorkloadKernel derivation) rather than building a separate
+    // copy, and so a later config edit invalidates it here too.
+    if let Some(fp) = workload_kernel_source_fingerprint_opt() {
+        write_kernel_source_fingerprint(std::path::Path::new(&kernel), &fp);
+    }
     Ok((kernel, rootfs))
 }
 
@@ -6304,7 +6397,7 @@ mod builder_vm_bootstrap_tests {
         let cache = tmp.path().to_str().unwrap();
         let arch = "x86_64";
         // Nothing on disk → None (caller will build/download).
-        assert_eq!(find_cached_workload_kernel(cache, arch), None);
+        assert_eq!(find_cached_workload_kernel(cache, arch, None), None);
 
         let mk = |rel: &str| {
             let p = tmp.path().join(rel);
@@ -6315,21 +6408,73 @@ mod builder_vm_bootstrap_tests {
         // The dev default image's kernel is a valid reuse source.
         let dev = mk("default-microvm/dev/vmlinux");
         assert_eq!(
-            find_cached_workload_kernel(cache, arch).as_deref(),
+            find_cached_workload_kernel(cache, arch, None).as_deref(),
             Some(dev.as_str())
         );
         // Prod wins over dev (checked first).
         let prod = mk("default-microvm/prod/vmlinux");
         assert_eq!(
-            find_cached_workload_kernel(cache, arch).as_deref(),
+            find_cached_workload_kernel(cache, arch, None).as_deref(),
             Some(prod.as_str())
         );
         // The dedicated kernel cache wins over everything.
         let dedicated = mk(&format!("builder-vm/{arch}/kernels/workload/vmlinux"));
         assert_eq!(
-            find_cached_workload_kernel(cache, arch).as_deref(),
+            find_cached_workload_kernel(cache, arch, None).as_deref(),
             Some(dedicated.as_str())
         );
+    }
+
+    #[test]
+    fn find_cached_workload_kernel_rejects_stale_fingerprint() {
+        let tmp = tempfile::tempdir().unwrap();
+        let cache = tmp.path().to_str().unwrap();
+        let arch = "x86_64";
+        let dir = tmp
+            .path()
+            .join(format!("builder-vm/{arch}/kernels/workload"));
+        std::fs::create_dir_all(&dir).unwrap();
+        let vmlinux = dir.join("vmlinux");
+        std::fs::write(&vmlinux, b"vmlinux").unwrap();
+
+        // No sidecar yet: with a fingerprint expectation the candidate is a miss
+        // (treated as stale → rebuild), but None (end-user prebuilt) accepts it.
+        assert_eq!(find_cached_workload_kernel(cache, arch, Some("abc")), None);
+        assert_eq!(
+            find_cached_workload_kernel(cache, arch, None).as_deref(),
+            Some(vmlinux.to_str().unwrap())
+        );
+
+        // Stamp fingerprint "abc": matching expectation hits, a changed config
+        // ("xyz") misses.
+        write_kernel_source_fingerprint(&vmlinux, "abc");
+        assert_eq!(
+            find_cached_workload_kernel(cache, arch, Some("abc")).as_deref(),
+            Some(vmlinux.to_str().unwrap())
+        );
+        assert_eq!(find_cached_workload_kernel(cache, arch, Some("xyz")), None);
+    }
+
+    #[test]
+    fn workload_kernel_source_fingerprint_changes_with_config() {
+        let tmp = tempfile::tempdir().unwrap();
+        let kernel_dir = tmp.path().join("nix/images/kernel");
+        std::fs::create_dir_all(&kernel_dir).unwrap();
+        std::fs::write(kernel_dir.join("base.nix"), b"baseEnables = [ ];\n").unwrap();
+        std::fs::write(kernel_dir.join("workload.nix"), b"extraDisables = [ ];\n").unwrap();
+
+        let before = workload_kernel_source_fingerprint(tmp.path()).unwrap();
+        // Editing the config (a new disable) changes the fingerprint.
+        std::fs::write(
+            kernel_dir.join("workload.nix"),
+            b"extraDisables = [ \"BLK_DEV_NBD\" ];\n",
+        )
+        .unwrap();
+        let after = workload_kernel_source_fingerprint(tmp.path()).unwrap();
+        assert_ne!(before, after, "a config edit must change the fingerprint");
+
+        // Missing source dir → Err (caller maps to None → path-existence mode).
+        assert!(workload_kernel_source_fingerprint(&tmp.path().join("nope")).is_err());
     }
 
     #[test]

--- a/crates/mvm-cli/src/commands/vm/up.rs
+++ b/crates/mvm-cli/src/commands/vm/up.rs
@@ -12,7 +12,7 @@ use mvm_backend::image;
 use mvm_core::domain::instance::InstanceReadiness;
 use mvm_core::naming::validate_vm_name;
 
-use super::super::env::dev_vz::ensure_default_microvm_image;
+use super::super::env::dev_vz::ensure_workload_kernel;
 use super::audit_chain::{AuditEmitter, default_audit_dir};
 use super::host_signer::load_or_init_at;
 use super::policy_resolver::{
@@ -1095,7 +1095,7 @@ pub(in crate::commands) struct PersistentImageStartParams<'a> {
     pub hypervisor_override: Option<&'a str>,
     /// Skip plan-admission signing (test escape).
     pub no_supervisor: bool,
-    /// Pre-built kernel path: skips `ensure_default_microvm_image` when set.
+    /// Pre-built kernel path: skips `ensure_workload_kernel` when set.
     pub kernel_path: Option<String>,
     /// Raw `--agent-verb` strings from the CLI. Empty ⇒ use the computed
     /// sealed-prod default.
@@ -1154,8 +1154,13 @@ pub(in crate::commands) fn start_persistent_oci_machine(
     let kernel_path = if let Some(k) = kernel_path {
         k
     } else {
-        let (k, _) = ensure_default_microvm_image(mvm_build::pipeline::BuildMode::Dev)?;
-        k
+        // The rootfs is supplied (OCI image / manifest); we need only a kernel.
+        // Resolve just the workload kernel — same as the transient OCI path
+        // (`exec.rs`) — rather than building/downloading a whole default-microvm
+        // image whose 220 MB rootfs we'd discard. This also routes through the
+        // kernel's source-fingerprint cache, so a `nix/images/kernel/` edit
+        // rebuilds on the next boot instead of reusing a stale default image.
+        ensure_workload_kernel()?
     };
     register_vm_name(name, "default");
 

--- a/nix/images/kernel/base.nix
+++ b/nix/images/kernel/base.nix
@@ -204,6 +204,24 @@ let
     "IOMMU_SUPPORT"        # virtio-mmio uses direct DMA; no SMMU present
     "SERIAL_XILINX_PS_UART" "SERIAL_FSL_LPUART" "SERIAL_FSL_LINFLEXUART"
     "SERIAL_MCTRL_GPIO" "SERIAL_DEV_BUS"  # SoC/serdev UARTs — console is PL011
+
+    # Shrink batch 6 — block-device *clients* defconfig builds in that no mvm
+    # backend can ever drive. Every guest boots one virtio-blk disk (`vda`,
+    # kept via VIRTIO_BLK above); libkrun / vz / Firecracker present no NBD
+    # server and no NVMe controller, so these drivers register phantom devices
+    # (nbd0–15) and idle rescuer workqueue threads (16× kworker/R-nbd*, 3×
+    # kworker/R-nvme) with nothing behind them. A workload *cannot* reach them —
+    # there is no host-side device — so dropping them is pure attack-surface +
+    # thread-count reduction with zero functional loss on any boot path.
+    # Only NBD/NVMe live here (shared base): they are universally dead — no
+    # host-side device exists on any backend, so neither the builder nor a
+    # workload can reach them. The sibling block-driver drops BLK_DEV_LOOP and
+    # BLK_DEV_MD are scoped to workload.nix instead: the builder kernel may
+    # loop-mount while assembling images, and BLK_DEV_MD only materialises where
+    # the CONFIG_MD umbrella is enabled (workload's dm-verity delta). See
+    # workload.nix.
+    "BLK_DEV_NBD"          # network block device — no NBD server on any backend
+    "BLK_DEV_NVME" "NVME_CORE"  # NVMe — no NVMe controller behind virtio
   ] ++ pkgs.lib.optionals (kernelArch == "arm64") [
     # arm64 boots from the FDT libkrun / Firecracker hand us; ACPI is
     # never consulted, so drop the ACPICA interpreter and the whole

--- a/nix/images/kernel/workload.nix
+++ b/nix/images/kernel/workload.nix
@@ -27,9 +27,29 @@
 
 base.mkKernel {
   extraEnables = [ "MD" "BLK_DEV_DM" "DM_VERITY" "VIRTIO_FS" "FUSE_FS" ];
-  # Workload-only: the guest enforces egress host-side (egress proxy) + via
-  # blackhole routes (mvm-guest-netinit, rtnetlink), never in-guest iptables —
-  # so it needs no netfilter tables. The builder kernel keeps netfilter for its
-  # OUTPUT-chain egress lockdown, so this drop lives here, not in shared base.
-  extraDisables = [ "NETFILTER" ];
+  # Workload-only disables. Each drop lives here (not in shared base.nix)
+  # because it depends on a workload-specific enable or would be unsafe for
+  # the builder kernel:
+  #
+  #   NETFILTER   — the guest enforces egress host-side (egress proxy) + via
+  #                 blackhole routes (mvm-guest-netinit, rtnetlink), never
+  #                 in-guest iptables. The builder kernel KEEPS netfilter for
+  #                 its OUTPUT-chain egress lockdown, so this cannot go in base.
+  #   BLK_DEV_MD  — the software-RAID personality (md_mod + kworker/R-md*). We
+  #                 enable the CONFIG_MD *umbrella* above only so device-mapper
+  #                 (BLK_DEV_DM) and dm-verity (Claim 3 verified boot) build; the
+  #                 RAID arrays themselves are never assembled in a single-disk
+  #                 (vda) guest. Dropping BLK_DEV_MD keeps MD + BLK_DEV_DM +
+  #                 DM_VERITY (asserted by base.nix's olddefconfig guard) while
+  #                 deleting the unused RAID core. Workload-only because base
+  #                 never enables the MD menu, so it has no effect there.
+  #   BLK_DEV_LOOP — loopback block devices (loop0–7). No mvm path loop-mounts
+  #                 in-guest (the OCI rootfs is virtio-blk `vda`, volumes are
+  #                 virtio-fs, dm-verity is dm). Kept OUT of base so the builder
+  #                 kernel — which may loop-mount while assembling images — is
+  #                 unaffected. TRADEOFF: a user workload that loop-mounts a
+  #                 squashfs / disk image in-guest would need this re-enabled;
+  #                 unlike NBD/NVMe (no host-side device exists) loop is
+  #                 guest-internal, so this is a policy choice, not a free cut.
+  extraDisables = [ "NETFILTER" "BLK_DEV_MD" "BLK_DEV_LOOP" ];
 }

--- a/specs/plans/209-slim-microvm-kernel.md
+++ b/specs/plans/209-slim-microvm-kernel.md
@@ -636,6 +636,38 @@ builder kernel (which needs iptables for its egress lockdown). The enable-stick 
 it in CI; fixed by moving the drop to `workload.nix` (workload-only). This is exactly the
 "requested enables must stick" guard requested during the machine-run-volume coordination.
 
+### Batch 6 (2026-07-05) — block-device clients
+
+After Batches 1-5, PCI + PCI_MSI + VIRTIO_PCI were re-added for vz (Apple
+Virtualization.framework presents virtio over PCI, not MMIO), moving the aarch64 ceiling to
+**1420** (see `check_kernel_config_budget.rs`). Batch 6 subtracts the block-device *clients*
+that `defconfig` compiles in but no mvm backend can ever drive — each registered phantom
+devices and idle rescuer workqueue kthreads with nothing behind them:
+
+- **base.nix** (universally dead — no host-side device exists on any backend, so a workload
+  *cannot* reach them): `BLK_DEV_NBD` (nbd0-15 + 16× `kworker/R-nbd*`), `BLK_DEV_NVME` +
+  `NVME_CORE` (3× `kworker/R-nvme`).
+- **workload.nix** (workload-only, to leave the builder kernel untouched): `BLK_DEV_LOOP`
+  (loop0-7 — the builder may loop-mount while assembling images, so this stays a
+  workload-only drop) and `BLK_DEV_MD` (software-RAID core `md_mod` + `kworker/R-md*`; the
+  `CONFIG_MD` umbrella + `BLK_DEV_DM` + `DM_VERITY` are kept, so Claim 3 verified boot is
+  unaffected — asserted by the base.nix olddefconfig enable-stick guard and confirmed live:
+  `dm_verity` built-in, device-mapper control device registered, `md_mod` gone).
+
+| | workload `=y` (aarch64) | vmlinux |
+|---|---|---|
+| Post-PCI-re-add ceiling | 1420 | — |
+| Batch 6 | **1374** | 17.13 MB (-140 KB) |
+
+**Live-validated** on macOS 26 (in-house→libkrun builder fallback): the default-microvm dev
+image was rebuilt from the stripped config and `machine run --image alpine` booted it with
+`BLOCK_DEVS=vda` only (all of nbd/nvme/loop gone), rescuer kworkers 40 → 19, and the full
+`create/start/exec/shell/stop/rm` lifecycle passing. `BUDGET_AARCH64` ratcheted 1420 → 1374
+(measured from the built kernel's embedded ikconfig). x86_64 drops by a comparable
+arch-independent delta but was not re-measured (macOS cannot cross-compile the kernel); its
+ceiling stays 1203 pending CI's x86_64 config-build count. The authoritative dm-verity tamper
+regression remains the live-KVM lane in `security.yml`.
+
 ### Deferred follow-ups (shrink)
 
 - [ ] **Push toward the ~1005 reference floor.** The remaining ~320 `=y` gap is *entangled*,

--- a/xtask/src/check_kernel_config_budget.rs
+++ b/xtask/src/check_kernel_config_budget.rs
@@ -33,7 +33,17 @@ use std::path::Path;
 /// controllers stay off since their deps are disabled) and is confirmed by CI's
 /// native aarch64 config build — ratchet it to the count CI reports if it
 /// differs.
-const BUDGET_AARCH64: usize = 1420;
+///
+/// Batch 6 (block-device clients): dropped BLK_DEV_NBD + BLK_DEV_NVME/NVME_CORE
+/// (base.nix) and BLK_DEV_LOOP + BLK_DEV_MD (workload.nix) — no mvm backend
+/// presents an NBD server / NVMe controller, no mvm path loop-mounts in-guest,
+/// and the guest assembles no RAID array (dm-verity keeps only CONFIG_MD +
+/// BLK_DEV_DM + DM_VERITY). aarch64 measured 1374 from the built workload
+/// kernel's embedded ikconfig; ratcheted below. x86_64 drops by a comparable
+/// (arch-independent block-driver) delta but was NOT re-measured here — macOS
+/// cannot cross-compile the kernel — so BUDGET_X86_64 stays a valid (slightly
+/// slack) ceiling; ratchet it to the count CI's x86_64 config build reports.
+const BUDGET_AARCH64: usize = 1374;
 const BUDGET_X86_64: usize = 1203;
 
 /// Resolve the budget for a config path by the arch in its name. Unknown →


### PR DESCRIPTION
Two related changes to the slim workload kernel, both starting from a user noticing ~20 spurious `kworker/R-*` threads in a live `machine run --image alpine`.

## 1. Strip unreachable block drivers (Plan 209 Batch 6)

`defconfig` compiles in block-device *clients* that no mvm backend can ever drive — each registers phantom devices and idle rescuer workqueue kthreads with nothing behind them.

| | before | after |
|---|---|---|
| `/sys/class/block` | `loop0–7 nbd0–15 vda` | **`vda`** |
| storage modules | `nbd nvme nvme_core loop md_mod dm_*` | `dm_*` only |
| rescuer kworkers | **40** | **19** (−21: 16 nbd + 3 nvme + 2 md) |
| aarch64 `=y` symbols | ≤1420 | **1374** |
| vmlinux | 17.27 MB | 17.13 MB |

- **base.nix** (shared — universally dead, no host-side device exists on any backend): `BLK_DEV_NBD`, `BLK_DEV_NVME` + `NVME_CORE`.
- **workload.nix** (workload-only, builder kernel untouched): `BLK_DEV_LOOP` (the builder may loop-mount while assembling images) and `BLK_DEV_MD` (software-RAID core; `CONFIG_MD` + `BLK_DEV_DM` + `DM_VERITY` are kept, so Claim 3 verified boot is unaffected).

Only virtio-blk (`vda`) remains reachable. `BUDGET_AARCH64` ratcheted 1420 → 1374 (measured); x86_64 unchanged (macOS can't cross-compile to re-measure — ratchet to CI's count).

**Tradeoff:** NBD/NVMe are free cuts (no host-side device exists). `BLK_DEV_LOOP` is guest-internal, so a workload that loop-mounts a squashfs/disk image would need it re-enabled — a policy choice, one-line revert.

## 2. Make kernel-config edits actually reach the boot

Two caching gaps let a `nix/images/kernel/` edit go unnoticed on the next boot:

- The source-checkout workload-kernel cache was keyed by path-existence, so editing `base.nix`/`workload.nix` reused the stale vmlinux until an explicit `build kernel build`. Now `ensure_workload_kernel` fingerprints `nix/images/kernel/` (SHA-256, `.mvm-kernel-source.sha256` sidecar next to each cached vmlinux) and rebuilds on mismatch — the same "your change appears in the next run" contract the builder-VM image already honors. End-user prebuilt boots (no local source) keep the prior path-existence behavior.
- The persistent OCI path (`start_persistent_oci_machine`) resolved its kernel via `ensure_default_microvm_image` — building a whole default-microvm image and discarding its 220 MB rootfs — while the transient path already used `ensure_workload_kernel`. Switched the persistent path to `ensure_workload_kernel` too: cheaper, and it routes through the fingerprint cache so a config edit reaches the default `machine run --image` path.

## Verification

- **Live (macOS 26):** rebuilt the default-microvm dev image from the stripped config and booted the default `machine run --image alpine` path — `BLOCK_DEVS=vda` only, rescuer kworkers 40 → 19, dm-verity intact (`dm_verity` built-in, device-mapper control registered, `md_mod` gone), full create/start/exec/shell/stop/rm lifecycle passing. Config extracted from the built kernel's ikconfig confirms the four symbols `not set` and `DM_VERITY`/`BLK_DEV_DM`/`CONFIG_MD` kept.
- **Unit tests:** 11 total — fingerprint changes with config; `find_cached_workload_kernel` stale-reject / match-accept / None-passthrough; existing `resolve_workload_kernel_tests` green.
- CI Test + Lint + both from-source kernel builds green. The authoritative dm-verity tamper regression remains the live-KVM lane in `security.yml`. A boot-rebuild e2e for the fingerprint fix was blocked by concurrent builder contention on the dev host; re-run on a quiet host to confirm end to end.
