### PR TITLE
feat(virtiofs-root): chain-audit the resolved boot posture (Plan 223 A3)

### DIFF
--- a/crates/mvm-cli/src/commands/vm/exec.rs
+++ b/crates/mvm-cli/src/commands/vm/exec.rs
@@ -422,10 +422,12 @@ pub(in crate::commands) fn run_secure(cli: &Cli, args: RunArgs, cfg: &MvmConfig)
             prod,
             network_policy,
         )?;
-        let output = match crate::exec::run_captured(req, Some(&admit)) {
+        let posture = crate::exec::PostureSink::new(mvm_build::run_image::RootStrategy::BlockExt4);
+        let output = match crate::exec::run_captured_with_posture(req, Some(&admit), &posture) {
             Ok(o) => {
                 let ctx = admit_ctx.borrow_mut().take();
                 super::up::emit_launched_if(&ctx, &receipt_backend);
+                super::up::emit_boot_posture_if(&ctx, posture.get());
                 o
             }
             Err(e) => {
@@ -574,11 +576,15 @@ fn run_run_args(
     audit: RunAudit<'_>,
 ) -> Result<()> {
     let req = build_exec_request(args, "`mvmctl run`", image, prod, network_policy)?;
-    let exit_code = match crate::exec::run(req, audit.admit) {
+    let posture = crate::exec::PostureSink::new(mvm_build::run_image::RootStrategy::BlockExt4);
+    let exit_code = match crate::exec::run_with_posture(req, audit.admit, &posture) {
         Ok(code) => {
             // The VM booted and the command ran (whatever its exit code), so the
-            // admission launched — emit `plan.launched`.
-            super::up::emit_launched_if(&audit.ctx.borrow_mut().take(), audit.backend);
+            // admission launched — emit `plan.launched` plus the resolved boot
+            // posture (virtiofs-root vs block-ext4) against the same plan.
+            let ctx = audit.ctx.borrow_mut().take();
+            super::up::emit_launched_if(&ctx, audit.backend);
+            super::up::emit_boot_posture_if(&ctx, posture.get());
             code
         }
         Err(e) => {

--- a/crates/mvm-cli/src/commands/vm/up.rs
+++ b/crates/mvm-cli/src/commands/vm/up.rs
@@ -830,6 +830,26 @@ pub(super) fn emit_launched_if(ctx: &Option<AdmissionContext>, backend: &str) {
     }
 }
 
+/// Record the resolved boot posture (which rootfs strategy the run-path tier
+/// gate actually selected) on the chain-signed admission log. Fires alongside
+/// `plan.launched`, reflecting the decision `run_inner` made — never a
+/// re-derivation — so a virtiofs-root dev boot and an Option-B block boot are
+/// distinguishable in the tamper-evident chain. No-op when admission was
+/// skipped (no plan to bind to).
+pub(super) fn emit_boot_posture_if(
+    ctx: &Option<AdmissionContext>,
+    strategy: mvm_build::run_image::RootStrategy,
+) {
+    let Some(ctx) = ctx else { return };
+    let label = match strategy {
+        mvm_build::run_image::RootStrategy::VirtiofsRoot => "virtiofs-root",
+        mvm_build::run_image::RootStrategy::BlockExt4 => "block-ext4",
+    };
+    if let Err(e) = ctx.emitter.emit_boot_posture(&ctx.admitted.plan, label) {
+        tracing::warn!(error = %e, "audit emit_boot_posture failed (non-fatal)");
+    }
+}
+
 /// Tier A.1 admission enforcement: refuse to boot if any volume about to
 /// be attached isn't named in the verified `ExecutionPlan.shares`. No-op
 /// when admission was skipped (no plan to enforce against). Called right

--- a/crates/mvm-cli/src/exec.rs
+++ b/crates/mvm-cli/src/exec.rs
@@ -510,7 +510,18 @@ pub struct ExecOutput {
 /// CLI's interactive `mvmctl exec` keeps using [`run`] (streaming) so
 /// human ergonomics don't regress.
 pub fn run_captured(req: ExecRequest, admit: Option<&SessionAdmit<'_>>) -> Result<ExecOutput> {
-    run_inner(req, /* capture = */ true, admit)
+    run_inner(req, /* capture = */ true, admit, None)
+        .map(|either| either.right().expect("capture mode returns ExecOutput"))
+}
+
+/// Like [`run_captured`], but also reports the resolved boot posture into
+/// `posture` so the command layer can chain-audit it (`plan.boot_posture`).
+pub fn run_captured_with_posture(
+    req: ExecRequest,
+    admit: Option<&SessionAdmit<'_>>,
+    posture: &PostureSink,
+) -> Result<ExecOutput> {
+    run_inner(req, /* capture = */ true, admit, Some(posture))
         .map(|either| either.right().expect("capture mode returns ExecOutput"))
 }
 
@@ -520,7 +531,18 @@ pub fn run_captured(req: ExecRequest, admit: Option<&SessionAdmit<'_>>) -> Resul
 /// agent unreachable, vsock error), returns an error; the VM is torn down
 /// best-effort before returning.
 pub fn run(req: ExecRequest, admit: Option<&SessionAdmit<'_>>) -> Result<i32> {
-    run_inner(req, /* capture = */ false, admit)
+    run_inner(req, /* capture = */ false, admit, None)
+        .map(|either| either.left().expect("streaming mode returns exit code"))
+}
+
+/// Like [`run`], but also reports the resolved boot posture into `posture` so
+/// the command layer can chain-audit it (`plan.boot_posture`).
+pub fn run_with_posture(
+    req: ExecRequest,
+    admit: Option<&SessionAdmit<'_>>,
+    posture: &PostureSink,
+) -> Result<i32> {
+    run_inner(req, /* capture = */ false, admit, Some(posture))
         .map(|either| either.left().expect("streaming mode returns exit code"))
 }
 
@@ -545,10 +567,18 @@ impl<L, R> Either<L, R> {
     }
 }
 
+/// Side channel by which [`run_inner`] reports the resolved boot posture (which
+/// rootfs strategy the run-path tier gate selected) back to the command layer,
+/// which records it on the chain-signed admission log (`plan.boot_posture`).
+/// The command layer reads it after the run returns. `None` means the caller
+/// does not audit posture (MCP / session boots, which never reach virtiofs).
+pub type PostureSink = std::cell::Cell<mvm_build::run_image::RootStrategy>;
+
 fn run_inner(
     req: ExecRequest,
     capture: bool,
     admit: Option<&SessionAdmit<'_>>,
+    posture: Option<&PostureSink>,
 ) -> Result<Either<i32, ExecOutput>> {
     let backend = AnyBackend::auto_select();
 
@@ -652,6 +682,18 @@ fn run_inner(
         backend.capabilities().virtiofs_root,
         verity_path.is_some(),
     );
+
+    // Report the resolved strategy to the command layer for chain-audit. This is
+    // the single source of truth — the same value that drives the boot below —
+    // so the `plan.boot_posture` entry can never diverge from what actually
+    // booted.
+    if let Some(sink) = posture {
+        sink.set(if virtiofs_root.is_some() {
+            mvm_build::run_image::RootStrategy::VirtiofsRoot
+        } else {
+            mvm_build::run_image::RootStrategy::BlockExt4
+        });
+    }
 
     let t_drives_ready = timing.then(std::time::Instant::now);
 

--- a/crates/mvm-hostd/src/audit/emitter.rs
+++ b/crates/mvm-hostd/src/audit/emitter.rs
@@ -155,6 +155,23 @@ impl AuditEmitter {
         )
     }
 
+    /// Emit `plan.boot_posture` — records which rootfs strategy the run-path
+    /// tier gate actually selected for this boot, so an audit reader can tell a
+    /// dev virtiofs-root boot (the weaker dev-tier virtiofs contract — no
+    /// dm-verity, does not witness claim 3) from a block+ext4 boot (the path the
+    /// numbered claim-3 witness rides on). `root_strategy` is
+    /// `"virtiofs-root"` or `"block-ext4"`. Informational — the hard admission
+    /// decision is still `plan.admitted`; this event lets an operator answer
+    /// "did this run boot off a virtiofs root or a materialized block image?"
+    /// via the tamper-evident chain rather than an unsigned side channel.
+    pub fn emit_boot_posture(&self, plan: &ExecutionPlan, root_strategy: &str) -> Result<()> {
+        self.emit(
+            plan,
+            "plan.boot_posture",
+            [("root_strategy".to_string(), root_strategy.to_string())],
+        )
+    }
+
     /// Emit `plan.policy_resolved` — fires after the resolver
     /// successfully constructs `ResolvedSlots` from the plan's policy
     /// refs. `slots_mode` is `"noop"` when all four refs are
@@ -449,6 +466,36 @@ mod tests {
         assert!(content.contains("oci_resolved_digest"));
         assert!(content.contains("oci_layer_digests"));
         assert_eq!(verify_audit_chain(&path, &vk).unwrap(), 1);
+    }
+
+    #[test]
+    fn boot_posture_event_is_chain_signed_and_distinguishes_root_strategy() {
+        // The dev virtiofs-root boot and the block boot must be distinguishable
+        // in the tamper-evident chain (dev-tier virtiofs vs the claim-3 block
+        // witness). Emit one of each and assert both verify + carry the right
+        // root_strategy label.
+        let dir = tempfile::tempdir().unwrap();
+        let key = SigningKey::generate(&mut OsRng);
+        let vk = key.verifying_key();
+        let emitter = AuditEmitter::with_dir(key, dir.path()).unwrap();
+
+        let vfs = fixture_plan("local", "plan-vfs");
+        let blk = fixture_plan("local", "plan-blk");
+        emitter.emit_boot_posture(&vfs, "virtiofs-root").unwrap();
+        emitter.emit_boot_posture(&blk, "block-ext4").unwrap();
+
+        let path = dir.path().join("local.jsonl");
+        let content = std::fs::read_to_string(&path).expect("audit file exists");
+        let lines: Vec<&str> = content.lines().collect();
+        assert_eq!(lines.len(), 2);
+        assert!(lines[0].contains("plan.boot_posture"));
+        assert!(lines[0].contains("virtiofs-root"));
+        assert!(lines[0].contains("\"plan-vfs\""));
+        assert!(lines[1].contains("block-ext4"));
+        assert!(lines[1].contains("\"plan-blk\""));
+        // A block boot never mislabels as virtiofs and vice-versa.
+        assert!(!lines[1].contains("virtiofs-root"));
+        assert_eq!(verify_audit_chain(&path, &vk).unwrap(), 2);
     }
 
     #[test]

--- a/specs/plans/223-virtiofs-root.md
+++ b/specs/plans/223-virtiofs-root.md
@@ -78,15 +78,24 @@ backed by the unpacked-tree host directory, read-only.
 
 ### A3 — Integrity enforcement per ADR-107 (dev tier)
 
-- [ ] unpack-time verification is **load-bearing and un-bypassable** on the
-  virtiofs path: per-layer sha256 (mvm-oci) + cosign when policy demands, run
-  **before** the tree is exposed to the guest, failing closed.
-- [ ] the served directory is mounted **read-only** in the guest and is not
-  mutated by the host after unpack (no writable overlay on the root; writable
-  state goes to a separate tmpfs/volume, as today).
-- [ ] audit: the admission log records that the boot used the virtiofs-root
-  dev-tier posture (so a reader can tell a dev virtiofs boot from an Option-B
-  claim-3 boot).
+- [x] unpack-time verification is **load-bearing and un-bypassable** on the
+  virtiofs path: per-layer sha256 (mvm-oci `OciLayerFetcher::fetch_layer` streams
+  the hash and fails closed) runs **before** the tree is unpacked/served; the
+  virtiofs candidate (`unpacked_dir_if_present`) only ever names a tree whose
+  layers all passed digest verification. Cosign gates the resolved digest on
+  `--prod` (which stays Option B). Witnessed by the `oci-digest-mismatch-reject`
+  lane.
+- [x] the served directory is mounted **read-only** in the guest and is not
+  mutated by the host after unpack: the FUSE server refuses every mutating
+  opcode (`EROFS`) and the tree is written once at pull, never after
+  (`vmm::virtio_fs`, symlink-confinement fix + regression test already merged).
+- [x] audit: the admission log records the boot posture — `run_inner` (the sole
+  tier-gate authority) reports its resolved `RootStrategy` out to the command
+  layer, which emits a chain-signed `plan.boot_posture` entry
+  (`AuditEmitter::emit_boot_posture`, `root_strategy=virtiofs-root|block-ext4`)
+  alongside `plan.launched`. A reader distinguishes a dev virtiofs boot from an
+  Option-B claim-3 boot in the tamper-evident chain
+  (`boot_posture_event_is_chain_signed_and_distinguishes_root_strategy`).
 
 ### A4 — Run-path tier gate + wiring
 


### PR DESCRIPTION
## What

Records the resolved **boot posture** on the chain-signed admission log: a new `plan.boot_posture` entry (`root_strategy=virtiofs-root|block-ext4`) fired alongside `plan.launched`. Completes the audit bullet of the Plan 223 A3 integrity workstream.

## Why

The run-path tier gate picks between a dev **virtiofs-root** boot and an Option-B **block+ext4** boot. The admission log recorded OCI provenance and launch, but not which rootfs strategy actually booted — so a reader couldn't distinguish a dev virtiofs boot (the weaker dev-tier virtiofs contract; no dm-verity; does **not** witness claim 3) from a block boot (the path the numbered claim-3 witness rides on).

## Design — single authority, no drift

`run_inner` stays the **sole** tier-gate authority (preserving A4's boot-boundary guarantee that prod/sealed can never reach virtiofs). It now reports its resolved `RootStrategy` out to the command layer via a `PostureSink` cell — *the same value that drives the boot* — and the command layer emits the chain event. The audit therefore can never diverge from what actually booted; there is no second re-derivation of the gate.

- `AuditEmitter::emit_boot_posture(plan, root_strategy)` — sibling to `emit_launched` / `emit_oci_provenance`.
- `exec::run_with_posture` / `run_captured_with_posture` — variants that surface the decision; the plain `run`/`run_captured` are unchanged (MCP/session boots pass none, they never reach virtiofs).
- `up::emit_boot_posture_if` — maps `RootStrategy` → label and emits against the admitted plan.

## A3's other two bullets — already witnessed

- **Fail-closed unpack**: `mvm_oci::OciLayerFetcher::fetch_layer` streams the layer sha256 and fails closed *before* unpack; the virtiofs candidate (`unpacked_dir_if_present`) only ever names a tree whose layers all verified. Backed by the `oci-digest-mismatch-reject` lane.
- **Read-only served dir**: the FUSE server refuses every mutating opcode (`EROFS`) and the tree is written once at pull, never after (merged symlink-confinement fix + regression test).

Both are ticked in the plan doc with their existing witnesses.

## Test

`boot_posture_event_is_chain_signed_and_distinguishes_root_strategy` emits one virtiofs-root and one block-ext4 posture, asserts both verify clean via `verify_audit_chain`, and that neither mislabels.

🤖 Generated with [Claude Code](https://claude.com/claude-code)