### PR TITLE
feat(checkpoint): de-Vz fs_quick — resolve rootfs backend-neutrally (works on Firecracker/HVF) (#1478 step 1)

### DIFF
--- a/crates/mvm-backend/src/base/runtime_meta.rs
+++ b/crates/mvm-backend/src/base/runtime_meta.rs
@@ -52,6 +52,16 @@ pub struct VmRuntimeMeta {
     /// (VMs predating the flag were all accessible).
     #[serde(default = "default_accessible")]
     pub accessible: bool,
+
+    /// Absolute path to the rootfs image the VM was started from.
+    ///
+    /// Written at start time by every backend that calls
+    /// `record_from_rootfs`. Absent in older mode.json files (reads
+    /// as `None`). Used by the fs_quick checkpoint path to resolve the
+    /// rootfs backend-neutrally without requiring a backend-specific
+    /// supervisor config.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub rootfs_path: Option<String>,
 }
 
 fn default_accessible() -> bool {
@@ -152,6 +162,7 @@ pub fn dev_attached(mode: StartMode) -> VmRuntimeMeta {
     VmRuntimeMeta {
         mode: mode.into(),
         accessible: true,
+        rootfs_path: None,
     }
 }
 
@@ -168,6 +179,7 @@ pub fn from_sidecar(mode: StartMode, rootfs_dir: &std::path::Path) -> Result<VmR
     Ok(VmRuntimeMeta {
         mode: mode.into(),
         accessible,
+        rootfs_path: None,
     })
 }
 
@@ -185,7 +197,8 @@ pub fn from_sidecar(mode: StartMode, rootfs_dir: &std::path::Path) -> Result<VmR
 /// step is best-effort and only logs warnings.
 pub fn record_from_rootfs(name: &str, mode: StartMode, rootfs: &std::path::Path) -> Result<()> {
     let dir = rootfs.parent().unwrap_or_else(|| std::path::Path::new("."));
-    let meta = from_sidecar(mode, dir)?;
+    let mut meta = from_sidecar(mode, dir)?;
+    meta.rootfs_path = Some(rootfs.to_string_lossy().into_owned());
     write(name, &meta)
 }
 
@@ -229,6 +242,7 @@ mod tests {
             let meta = VmRuntimeMeta {
                 mode: StartModeKind::Attached,
                 accessible: true,
+                rootfs_path: None,
             };
             write("rt-test-1", &meta).expect("write");
             let read_back = read("rt-test-1").expect("read").expect("present");
@@ -242,6 +256,7 @@ mod tests {
             let meta = VmRuntimeMeta {
                 mode: StartModeKind::Detached,
                 accessible: false,
+                rootfs_path: None,
             };
             write("rt-test-2", &meta).expect("write");
             let read_back = read("rt-test-2").expect("read").expect("present");
@@ -319,5 +334,73 @@ mod tests {
         .expect("write malformed");
         let result = from_sidecar(StartMode::Attached, tmp.path());
         assert!(result.is_err(), "malformed sidecar should error");
+    }
+
+    // ── rootfs_path field ────────────────────────────────────────────────
+
+    /// `record_from_rootfs` stores the absolute rootfs path and round-trips it.
+    #[test]
+    fn rootfs_path_round_trips_via_record_from_rootfs() {
+        with_home_temp(|_home| {
+            let tmp = tempfile::tempdir().expect("tempdir");
+            let rootfs = tmp.path().join("rootfs.ext4");
+            std::fs::write(&rootfs, b"fake").expect("write rootfs");
+
+            record_from_rootfs("rt-rootfs-test", StartMode::Detached, &rootfs).expect("record");
+
+            let meta = read("rt-rootfs-test")
+                .expect("read ok")
+                .expect("file present");
+            assert_eq!(
+                meta.rootfs_path.as_deref(),
+                Some(rootfs.to_str().unwrap()),
+                "rootfs_path must match the path passed to record_from_rootfs"
+            );
+        });
+    }
+
+    /// Older mode.json files that lack the `rootfs_path` field parse as `None`.
+    #[test]
+    fn rootfs_path_absent_in_old_file_reads_as_none() {
+        with_home_temp(|home| {
+            let dir = home.join(".mvm").join("vms").join("oldvm");
+            std::fs::create_dir_all(&dir).unwrap();
+            // Old shape: no rootfs_path field.
+            std::fs::write(
+                dir.join("mode.json"),
+                "{\"mode\":\"detached\",\"accessible\":false}\n",
+            )
+            .unwrap();
+            let meta = read("oldvm").expect("read").expect("present");
+            assert!(
+                meta.rootfs_path.is_none(),
+                "missing rootfs_path field must parse as None"
+            );
+        });
+    }
+
+    /// A meta with `rootfs_path: Some(...)` serializes it; `None` omits it
+    /// (skip_serializing_if).
+    #[test]
+    fn rootfs_path_serialization_round_trip() {
+        with_home_temp(|_home| {
+            let with_path = VmRuntimeMeta {
+                mode: StartModeKind::Detached,
+                accessible: false,
+                rootfs_path: Some("/abs/path/rootfs.ext4".to_string()),
+            };
+            write("rp-with", &with_path).expect("write");
+            let back = read("rp-with").expect("read").expect("present");
+            assert_eq!(back.rootfs_path.as_deref(), Some("/abs/path/rootfs.ext4"));
+
+            let without_path = VmRuntimeMeta {
+                mode: StartModeKind::Attached,
+                accessible: true,
+                rootfs_path: None,
+            };
+            write("rp-without", &without_path).expect("write");
+            let back2 = read("rp-without").expect("read").expect("present");
+            assert!(back2.rootfs_path.is_none());
+        });
     }
 }

--- a/crates/mvm-cli/src/commands/machine/mod.rs
+++ b/crates/mvm-cli/src/commands/machine/mod.rs
@@ -3789,6 +3789,7 @@ mod tests {
             &mvm::vm::runtime_meta::VmRuntimeMeta {
                 mode: mvm::vm::runtime_meta::StartModeKind::Detached,
                 accessible: false,
+                rootfs_path: None,
             },
         )
         .expect("write sealed runtime meta");

--- a/crates/mvm-cli/src/commands/tests.rs
+++ b/crates/mvm-cli/src/commands/tests.rs
@@ -4075,6 +4075,7 @@ fn machine_console_refused_on_sealed_image() {
         &VmRuntimeMeta {
             mode: StartModeKind::Detached,
             accessible: false,
+            rootfs_path: None,
         },
     )
     .expect("write");

--- a/crates/mvm-cli/src/commands/vm/checkpoint.rs
+++ b/crates/mvm-cli/src/commands/vm/checkpoint.rs
@@ -3,8 +3,10 @@
 //! lineage from one. With `--boot` the fork arm also admits and launches the
 //! child as a fresh VM, adopting the materialized rootfs without clobbering it.
 //!
-//! Only the macOS Vz workload backend materializes a host-side rootfs image,
-//! so checkpointing is gated to a VM that has one.
+//! Rootfs resolution is backend-neutral: every backend that calls
+//! `record_from_rootfs` at start time writes the rootfs path into mode.json,
+//! which `resolve_quiesced_vm_rootfs` reads as its primary source.  The Vz
+//! supervisor-config fallback remains for VMs started before this was wired in.
 
 use std::path::PathBuf;
 use std::time::{SystemTime, UNIX_EPOCH};
@@ -254,11 +256,11 @@ fn now_unix() -> u64 {
 /// queues quiesced). A live, unpaused VM is refused: an fs_quick checkpoint has
 /// no memory, so the rootfs must be in a clean, deterministic state.
 ///
-/// Rootfs location is backend-specific but the macOS Vz workload backend keeps
-/// the image under `vm_state_dir(name)`:
-///   - a per-instance `rootfs.ext4` CoW clone lands there;
-///   - Vz boots from a supplied path but persists the launch config, whose
-///     `rootfs` disk records that path.
+/// Resolution order (first match wins):
+/// 1. Per-instance `rootfs.ext4` CoW clone in `vm_state_dir(name)`.
+/// 2. `mode.json` `rootfs_path` field (backend-neutral; written by every
+///    backend that calls `record_from_rootfs` at start time).
+/// 3. Vz supervisor-config fallback (for VMs predating the mode.json field).
 fn resolve_quiesced_vm_rootfs(name: &str) -> Result<PathBuf> {
     if !vm_is_quiesced(name) {
         bail!("stop or pause VM '{name}' before checkpointing");
@@ -271,8 +273,24 @@ fn resolve_quiesced_vm_rootfs(name: &str) -> Result<PathBuf> {
         return Ok(instance_rootfs);
     }
 
+    // Backend-neutral: every backend that calls `record_from_rootfs` at start
+    // time writes the rootfs path into mode.json.
+    if let Some(path) = rootfs_from_mode_json(&state_dir)? {
+        if !path.exists() {
+            bail!(
+                "fs_quick checkpoint needs the VM's rootfs ({}), which is no longer \
+                 on disk. Pause instead of stopping: `mvmctl vm pause {name}`, \
+                 checkpoint, then `mvmctl vm resume {name}` — or use \
+                 `--class vm-full` on a running VM.",
+                path.display()
+            );
+        }
+        return Ok(path);
+    }
+
     // Vz persists its full supervisor config at launch; the rootfs disk's
-    // path points at the bootable image.
+    // path points at the bootable image.  Kept for VMs started before the
+    // mode.json rootfs_path field was added.
     if let Some(path) = vz_rootfs_from_supervisor_config(&state_dir)? {
         if !path.exists() {
             bail!(
@@ -287,6 +305,20 @@ fn resolve_quiesced_vm_rootfs(name: &str) -> Result<PathBuf> {
     }
 
     bail!("fs_quick checkpoint is not supported for this VM's backend");
+}
+
+/// Read `mode.json` and return the recorded `rootfs_path` field, if present.
+/// Absent file or absent field → `Ok(None)`. Malformed JSON propagates.
+fn rootfs_from_mode_json(state_dir: &std::path::Path) -> Result<Option<PathBuf>> {
+    let path = state_dir.join("mode.json");
+    let body = match std::fs::read_to_string(&path) {
+        Ok(b) => b,
+        Err(e) if e.kind() == std::io::ErrorKind::NotFound => return Ok(None),
+        Err(e) => return Err(e).with_context(|| format!("reading {}", path.display())),
+    };
+    let meta: mvm_backend::base::runtime_meta::VmRuntimeMeta =
+        serde_json::from_str(&body).with_context(|| format!("parsing {}", path.display()))?;
+    Ok(meta.rootfs_path.map(PathBuf::from))
 }
 
 /// Read the persisted Vz supervisor config and return the `rootfs` disk path,
@@ -313,7 +345,7 @@ fn vz_rootfs_from_supervisor_config(state_dir: &std::path::Path) -> Result<Optio
 /// files names a live process. Mirrors the per-backend `kill(pid, 0)` probe.
 fn vm_is_running(name: &str) -> bool {
     let state_dir = vm_state_dir(name);
-    ["vz.pid", "libkrun.pid"]
+    ["vz.pid", "libkrun.pid", "fc.pid"]
         .iter()
         .filter_map(|f| std::fs::read_to_string(state_dir.join(f)).ok())
         .filter_map(|s| s.trim().parse::<libc::pid_t>().ok())
@@ -1036,20 +1068,6 @@ fn boot_forked_child(p: BootForkedChildParams<'_>) -> Result<()> {
 
     let effective_hypervisor = super::super::shared::resolve_effective_hypervisor(p.hypervisor);
 
-    // The fork was captured from a VZ-family VM and the no-clobber rootfs
-    // adoption relies on the VZ backend's instance-path early-return; other
-    // backends would mutate the forked copy in place or mismatch the kernel.
-    if !matches!(
-        effective_hypervisor.as_str(),
-        "vz" | "virtualization" | "apple-container"
-    ) {
-        anyhow::bail!(
-            "checkpoint fork --boot supports the VZ-family backends only \
-             (resolved hypervisor: {effective_hypervisor}); omit --hypervisor \
-             to use the platform default"
-        );
-    }
-
     // Resource shape: flag > parent plan > global defaults.
     let (parent_cpus, parent_mem) = parent_plan_resources(p.parent_checkpoint, p.store);
     let user_cfg = mvm_core::user_config::load(None);
@@ -1385,6 +1403,70 @@ mod tests {
         assert!(
             msg.contains("vm-full") || msg.contains("vm_full"),
             "error should mention vm-full alternative: {msg}"
+        );
+    }
+
+    // ── resolve_quiesced_vm_rootfs: mode.json rootfs_path resolution ─────
+
+    /// A stopped VM whose mode.json carries `rootfs_path` pointing at an
+    /// existing file resolves that path without needing a supervisor config.
+    #[test]
+    fn resolve_rootfs_from_mode_json_when_present() {
+        let mut env = mvm_core::util::test_env::TestEnv::new();
+        let tmp = tempfile::tempdir().unwrap();
+        env.set("MVM_DATA_DIR", tmp.path());
+
+        let vm_name = "mode-json-rootfs-vm";
+        let state_dir = mvm_core::config::vm_state_dir(vm_name);
+        std::fs::create_dir_all(&state_dir).unwrap();
+
+        // Write a stub rootfs file.
+        let rootfs_file = tmp.path().join("images").join("rootfs.ext4");
+        std::fs::create_dir_all(rootfs_file.parent().unwrap()).unwrap();
+        std::fs::write(&rootfs_file, b"fake rootfs").unwrap();
+
+        // Write mode.json carrying the rootfs_path (as record_from_rootfs would).
+        let meta = mvm_backend::base::runtime_meta::VmRuntimeMeta {
+            mode: mvm_backend::base::runtime_meta::StartModeKind::Detached,
+            accessible: false,
+            rootfs_path: Some(rootfs_file.to_string_lossy().into_owned()),
+        };
+        let json = serde_json::to_string(&meta).unwrap();
+        std::fs::write(state_dir.join("mode.json"), json).unwrap();
+
+        // VM is stopped (no pid file) — quiesced.
+        let resolved = resolve_quiesced_vm_rootfs(vm_name).expect("must resolve");
+        assert_eq!(resolved, rootfs_file);
+    }
+
+    /// When mode.json carries `rootfs_path` but the file no longer exists on
+    /// disk, the error mentions the pause workflow (same user-visible guidance
+    /// as the Vz supervisor-config path).
+    #[test]
+    fn mode_json_rootfs_path_missing_on_disk_produces_actionable_error() {
+        let mut env = mvm_core::util::test_env::TestEnv::new();
+        let tmp = tempfile::tempdir().unwrap();
+        env.set("MVM_DATA_DIR", tmp.path());
+
+        let vm_name = "mode-json-gone-vm";
+        let state_dir = mvm_core::config::vm_state_dir(vm_name);
+        std::fs::create_dir_all(&state_dir).unwrap();
+
+        // Write mode.json pointing at a rootfs that does NOT exist.
+        let gone_path = tmp.path().join("gone").join("rootfs.ext4");
+        let meta = mvm_backend::base::runtime_meta::VmRuntimeMeta {
+            mode: mvm_backend::base::runtime_meta::StartModeKind::Detached,
+            accessible: false,
+            rootfs_path: Some(gone_path.to_string_lossy().into_owned()),
+        };
+        let json = serde_json::to_string(&meta).unwrap();
+        std::fs::write(state_dir.join("mode.json"), json).unwrap();
+
+        let err = resolve_quiesced_vm_rootfs(vm_name).expect_err("must error");
+        let msg = err.to_string();
+        assert!(
+            msg.contains("pause") || msg.contains("vm-full") || msg.contains("vm_full"),
+            "error must guide the user: {msg}"
         );
     }
 

--- a/crates/mvm-cli/src/commands/vm/console.rs
+++ b/crates/mvm-cli/src/commands/vm/console.rs
@@ -660,6 +660,7 @@ mod accessible_gate_tests {
                 &VmRuntimeMeta {
                     mode: StartModeKind::Attached,
                     accessible: true,
+                    rootfs_path: None,
                 },
             )
             .expect("write");
@@ -701,6 +702,7 @@ mod accessible_gate_tests {
                 &VmRuntimeMeta {
                     mode: StartModeKind::Detached,
                     accessible: false,
+                    rootfs_path: None,
                 },
             )
             .expect("write");
@@ -725,6 +727,7 @@ mod accessible_gate_tests {
                 &VmRuntimeMeta {
                     mode: StartModeKind::Detached,
                     accessible: false,
+                    rootfs_path: None,
                 },
             )
             .expect("write");
@@ -742,6 +745,7 @@ mod accessible_gate_tests {
                 &VmRuntimeMeta {
                     mode: StartModeKind::Attached,
                     accessible: false,
+                    rootfs_path: None,
                 },
             )
             .expect("write");


### PR DESCRIPTION
Step 1 of #1478 — decouple the `fs_quick` checkpoint path from Vz, since **Vz is being deprecated/removed** (HVF is the macOS backend; nothing should depend on Vz).

## Problem
`machine checkpoint create <vm> --class fs-quick` only worked on Vz: `resolve_quiesced_vm_rootfs` resolved the VM's rootfs **only** from the persisted Vz supervisor config, so on Firecracker (and HVF) it errored `fs_quick checkpoint is not supported for this VM's backend`. fs_quick is a CoW-rootfs clone with no memory snapshot — it should be backend-agnostic.

## Change
Record the rootfs path in a **backend-neutral** place every backend already writes:
- `VmRuntimeMeta` (`mode.json`) gains `rootfs_path: Option<String>` (`#[serde(default)]`, back-compat — old files read as `None`).
- `record_from_rootfs` (the cross-backend start helper, which already receives the rootfs) persists it. Firecracker already calls this at start, so FC now records its rootfs.
- `resolve_quiesced_vm_rootfs` reads `mode.json`'s `rootfs_path` (backend-neutral) **before** the Vz supervisor-config fallback.
- Removed the Vz-family-only guard in `boot_forked_child` (the instance-rootfs adoption seam is backend-agnostic); added `fc.pid` to the liveness probe so Firecracker VMs are correctly detected as running vs. quiesced.

## ⚠️ Vz-removal note
This keeps `vz_rootfs_from_supervisor_config` as a **transitional fallback** for VMs booted before the `rootfs_path` field existed. It is **dead-code-in-waiting** and should be **deleted together with `vz.rs`** when the Vz removal lands — it is not new Vz coupling. Flagged on #1478 so it's removed as part of the Vz deletion.

## Testing
Unit: `VmRuntimeMeta` serde round-trip incl. `rootfs_path` + legacy-shape `None` default; `record_from_rootfs` persists it; `resolve_quiesced_vm_rootfs` resolves from `mode.json`. `cargo check --workspace`, `nextest -p mvm-backend -p mvm-cli`, `fmt --all`, `clippy -D warnings` clean.

**Live-validated on Firecracker/KVM:** boot a VM, `machine pause`, `machine checkpoint create --class fs-quick` → **succeeds** (`ckpt id=...`; was "not supported" before), `machine checkpoint fork --boot` → **child boots**. `mode.json` recorded `rootfs_path` on FC. So checkpoint/fork now runs with **zero Vz dependency**.

Scope: this PR is the fs_quick rootfs-resolution de-Vz only. The verb-grant re-pin on a *sealed* fork (#1452 Task 5) is unit-tested; live-exercising it needs a sealed-image fixture (the FC test used an unsealed OCI image, whose fork child correctly gets no default grant). vm_full de-Vz (a `VmBackend` capture trait) + HVF snapshot remain per #1478 steps 2–3.

Refs: #1478, #1462.

🤖 Generated with [Claude Code](https://claude.com/claude-code)