### PR TITLE
fix(run): default macOS 26 workloads to in-house hvf VMM + reach its agent over vsock

### DIFF
--- a/crates/mvm-backend/src/backend.rs
+++ b/crates/mvm-backend/src/backend.rs
@@ -488,16 +488,17 @@ pub enum AnyBackend {
     Mock(MockBackend),
     /// Raw HVF — Hypervisor.framework on macOS / Apple silicon,
     /// driven by the unified `vmm::run` loop via the detached
-    /// `mvm-hvf-supervisor`. Opt-in via `--hypervisor hvf` / `MVM_BACKEND=hvf`;
-    /// `auto_select` doesn't pick it yet (Vz remains the macOS-26 default until
-    /// HVF reaches workload parity). The destination macOS backend.
+    /// `mvm-hvf-supervisor`. Selectable via `--hypervisor hvf` / `MVM_BACKEND=hvf`,
+    /// and the macOS-26 auto-detect default (Vz is sunset, opt-in only). Its
+    /// `start()` spawns the per-VM gating endpoint that is the sole claim-10 egress
+    /// gate over vsock — no gvproxy sidecar. The destination macOS backend.
     Hvf(HvfBackend),
     /// The in-house VMM driven through the unified `WorkloadRunner` over the
     /// driver seam — the role-runner that will replace the per-backend
-    /// Hvf/Libkrun/Vz/FC `start()` copies. Opt-in via `--hypervisor inhouse`;
-    /// the `hvf` selector still resolves to `HvfBackend` until the runner is the
-    /// proven default. Same in-house VMM, tier, and security profile as `Hvf` —
-    /// just reached via the runner role.
+    /// Hvf/Libkrun/Vz/FC `start()` copies. Opt-in via `--hypervisor inhouse`.
+    /// Same in-house VMM, tier, and security profile as `Hvf` — just reached via
+    /// the runner role. `auto_select` picks the raw [`Self::Hvf`] variant on the
+    /// macOS-26 tier today, not this one.
     InHouse(InHouseRunner),
 }
 
@@ -545,7 +546,7 @@ impl AnyBackend {
     ///
     /// Priority:
     /// 1. **Firecracker** (if native Linux `/dev/kvm` is available — production Tier 1)
-    /// 2. Vz — Apple Virtualization.framework (macOS 13+)
+    /// 2. In-house HVF VMM (macOS 26+ Apple Silicon — vsock-only egress, no Vz/gvproxy)
     /// 3. raw libkrun
     ///
     /// If none of the above match, the function returns Firecracker as
@@ -562,9 +563,11 @@ impl AnyBackend {
             return Self::Firecracker(FirecrackerBackend);
         }
 
-        // 2. macOS 26+ → Apple Virtualization.framework via the vz supervisor.
+        // 2. macOS 26+ Apple Silicon → the in-house HVF VMM (`hvf`). Vz is sunset
+        //    (opt-in only via `--hypervisor vz`); the hvf path enforces claim-10
+        //    egress via its per-VM gating endpoint over vsock — no gvproxy sidecar.
         if plat.is_vz_default_tier() {
-            return Self::Vz(VzBackend);
+            return Self::Hvf(HvfBackend);
         }
 
         // 3. libkrun installed → use the raw libkrun shim.
@@ -981,10 +984,9 @@ mod tests {
     #[test]
     fn test_any_backend_from_hypervisor_vz() {
         // `--backend vz` and the longer `--backend virtualization`
-        // both route to the new Vz backend.
-        // `auto_select()` itself stays unchanged on macOS (libkrun
-        // remains the default per the user's "don't replace libkrun"
-        // instruction).
+        // both still route to the Vz backend — Vz stays selectable as an
+        // opt-in. `auto_select()` no longer picks it on macOS 26+; the
+        // in-house VMM is the workload default there.
         for alias in ["vz", "virtualization"] {
             let backend = AnyBackend::from_hypervisor(alias);
             assert!(matches!(backend, AnyBackend::Vz(_)), "alias {alias}");
@@ -1165,7 +1167,10 @@ mod tests {
         let name = backend.name();
         assert!(
             // The full set of legitimate auto_select returns is:
-            matches!(name, "firecracker" | "vz" | "libkrun"),
+            //   firecracker (KVM), hvf (macOS 26+ in-house VMM, via the InHouse
+            //   runner whose name() delegates to the in-house driver), libkrun
+            //   (macOS 13-25 / Linux non-KVM fallback).
+            matches!(name, "firecracker" | "hvf" | "libkrun"),
             "auto_select returned unexpected backend: {name}"
         );
     }

--- a/crates/mvm-backend/src/hvf_backend.rs
+++ b/crates/mvm-backend/src/hvf_backend.rs
@@ -216,7 +216,7 @@ impl VmBackend for HvfBackend {
         // config; the `MVM_HVF_AGENT_SOCKET` dev hook still wins for live drivers.
         let agent_socket = std::env::var_os("MVM_HVF_AGENT_SOCKET")
             .map(PathBuf::from)
-            .unwrap_or_else(|| state_dir.join("hvf-agent.sock"));
+            .unwrap_or_else(|| mvm_core::config::vm_hvf_agent_socket(&config.name));
 
         // virtiofs-root dev boot (Plan-223 tier gate): serve the unpacked+injected
         // tree read-only over virtio-fs; no block rootfs is attached.

--- a/crates/mvm-cli/src/commands/shared/resolve.rs
+++ b/crates/mvm-cli/src/commands/shared/resolve.rs
@@ -238,7 +238,8 @@ fn parse_allow_host(entry: &str) -> Result<mvm_core::network_policy::HostPort> {
 
 /// Resolve the requested hypervisor to the effective one for this host. `firecracker`
 /// (the default `--hypervisor`) auto-detects: KVM → firecracker, macOS 26+ Apple Silicon
-/// → vz, macOS 13-25 + libkrun → libkrun, else firecracker (surfaces a clear
+/// → hvf (the in-house HVF VMM with vsock-only egress — no Vz supervisor, no
+/// gvproxy), macOS 13-25 + libkrun → libkrun, else firecracker (surfaces a clear
 /// "not available" error). Any explicit value is returned as-is. The `MVM_HYPERVISOR`
 /// env var (alias `MVM_BACKEND`) overrides auto-detect — the workload-VMM override
 /// mirroring `MVM_BUILDER_BACKEND` for the builder, so a Linux/KVM host can opt into
@@ -263,7 +264,11 @@ pub fn resolve_effective_hypervisor(requested: &str) -> String {
     if plat.has_kvm() {
         "firecracker"
     } else if plat.is_vz_default_tier() {
-        "vz"
+        // macOS 26+ Apple Silicon: the in-house HVF VMM (`hvf`) is the workload
+        // default. Vz is sunset (opt-in only via `--hypervisor vz`); the hvf path
+        // carries claim-10 egress over vsock via its per-VM gating endpoint — no
+        // gvproxy sidecar.
+        "hvf"
     } else if plat.has_libkrun() {
         "libkrun"
     } else {
@@ -404,6 +409,37 @@ mod tests {
         unsafe {
             std::env::remove_var("MVM_HYPERVISOR");
             std::env::set_var("MVM_BACKEND", "hvf");
+        }
+        assert_eq!(resolve_effective_hypervisor("firecracker"), "hvf");
+        // SAFETY: restore prior values.
+        unsafe {
+            match saved_hv {
+                Some(v) => std::env::set_var("MVM_HYPERVISOR", v),
+                None => std::env::remove_var("MVM_HYPERVISOR"),
+            }
+            match saved_be {
+                Some(v) => std::env::set_var("MVM_BACKEND", v),
+                None => std::env::remove_var("MVM_BACKEND"),
+            }
+        }
+    }
+
+    /// On the macOS-26 Apple Silicon tier the auto-detect default is the
+    /// in-house HVF VMM (`hvf`) — never `vz`. Vz is sunset and reachable
+    /// only via an explicit `--hypervisor vz`. Host-conditioned: the assertion
+    /// only fires on a host that actually reports the tier.
+    #[cfg(target_os = "macos")]
+    #[test]
+    fn macos_26_default_is_hvf_not_vz() {
+        if !mvm_core::platform::current().is_vz_default_tier() {
+            return; // Not on the macOS-26 tier (e.g. macOS 13-25 CI runner).
+        }
+        let saved_hv = std::env::var_os("MVM_HYPERVISOR");
+        let saved_be = std::env::var_os("MVM_BACKEND");
+        // SAFETY: test-local env mutation, restored before returning.
+        unsafe {
+            std::env::remove_var("MVM_HYPERVISOR");
+            std::env::remove_var("MVM_BACKEND");
         }
         assert_eq!(resolve_effective_hypervisor("firecracker"), "hvf");
         // SAFETY: restore prior values.

--- a/crates/mvm-cli/src/commands/vm/console.rs
+++ b/crates/mvm-cli/src/commands/vm/console.rs
@@ -775,7 +775,7 @@ mod picker_inhouse_tests {
         env.set("MVM_ENV", "dev");
         let state = mvm_core::config::vm_state_dir(name);
         std::fs::create_dir_all(&state).unwrap();
-        let agent = state.join("agent.sock");
+        let agent = mvm_core::config::vm_hvf_agent_socket(name);
         let listener = UnixListener::bind(&agent).unwrap();
         (tmp, env, listener)
     }
@@ -807,7 +807,7 @@ mod picker_inhouse_tests {
         let name = "inhouse-prod-workload";
         let state = mvm_core::config::vm_state_dir(name);
         std::fs::create_dir_all(&state).unwrap();
-        let agent = state.join("agent.sock");
+        let agent = mvm_core::config::vm_hvf_agent_socket(name);
         let _listener = UnixListener::bind(&agent).unwrap();
 
         // Non-dev: inhouse arm must not fire. The picker falls through; the Vz
@@ -858,7 +858,7 @@ mod picker_inhouse_tests {
         let name = "inhouse-with-dev-present";
         let state = mvm_core::config::vm_state_dir(name);
         std::fs::create_dir_all(&state).unwrap();
-        let workload_agent = state.join("agent.sock");
+        let workload_agent = mvm_core::config::vm_hvf_agent_socket(name);
         let _workload_listener = UnixListener::bind(&workload_agent).unwrap();
 
         // The picker must select the workload's own inhouse socket, not the

--- a/crates/mvm-cli/src/exec.rs
+++ b/crates/mvm-cli/src/exec.rs
@@ -1282,11 +1282,23 @@ pub fn wait_for_agent(vm_name: &str, timeout_secs: u64) -> bool {
         // that is *not* "reachable" from the caller's perspective.
         if let Ok(transport) = vsock_transport::for_vm(vm_name)
             && let Ok(mut stream) = transport.connect(mvm_guest::vsock::GUEST_AGENT_PORT)
-            && mvm_guest::vsock::negotiate_protocol(
-                &mut stream,
-                vec![mvm_guest::vsock::GuestCapability::Ping],
-            )
-            .is_ok()
+            && {
+                // Bound each probe: a transport whose socket is bound but whose
+                // guest agent hasn't replied yet (e.g. still booting, or an
+                // in-house VMM whose relay isn't answering) must not block the
+                // whole hello read forever — otherwise this loop never gets back
+                // to the deadline check and hangs instead of timing out. A short
+                // per-attempt read timeout lets `negotiate_protocol` fail fast so
+                // the outer loop retries and ultimately honours `timeout_secs`.
+                // The stream is a throwaway probe (dropped below), so the timeout
+                // never touches a real agent-RPC data stream.
+                let _ = stream.set_read_timeout(Some(std::time::Duration::from_secs(3)));
+                mvm_guest::vsock::negotiate_protocol(
+                    &mut stream,
+                    vec![mvm_guest::vsock::GuestCapability::Ping],
+                )
+                .is_ok()
+            }
         {
             return true;
         }

--- a/crates/mvm-core/src/config.rs
+++ b/crates/mvm-core/src/config.rs
@@ -495,6 +495,16 @@ pub fn vm_substitution_endpoint_socket(name: &str) -> std::path::PathBuf {
     vm_state_dir(name).join("substitution-endpoint.sock")
 }
 
+/// The in-house (HVF / `WorkloadRunner`) VMM's host→guest agent-RPC socket:
+/// `<vm_state_dir>/hvf-agent.sock`. The device's `AgentBridge` binds it and
+/// bridges every host connection to the guest agent on `GUEST_AGENT_PORT`.
+/// Single source of truth so the backend (which binds it) and the host-side
+/// agent-RPC transport (which connects to it) cannot drift — the drift that
+/// silently broke non-interactive `machine run` on the in-house VMM.
+pub fn vm_hvf_agent_socket(name: &str) -> std::path::PathBuf {
+    vm_state_dir(name).join("hvf-agent.sock")
+}
+
 // ============================================================================
 // Sensitive ~/.mvm subdirectories
 // ============================================================================

--- a/crates/mvm/src/vsock_transport.rs
+++ b/crates/mvm/src/vsock_transport.rs
@@ -147,15 +147,19 @@ impl VsockTransport for VzTransport {
 ///
 /// The in-house runner binds two distinct socket layouts under the per-VM
 /// state dir:
-/// - Agent RPC (`GUEST_AGENT_PORT`): `<state_dir>/agent.sock` — the
-///   standing bridge the supervisor opens at boot.
+/// - Agent RPC (`GUEST_AGENT_PORT`): `<state_dir>/hvf-agent.sock` — the
+///   standing agent bridge the device binds at boot (see
+///   [`mvm_core::config::vm_hvf_agent_socket`]).
 /// - Console data (ports in `dev_console_data_ports()`): `<state_dir>/vsock/vsock-<port>.sock`
 ///   — same `vsock/` subdir convention the Vz supervisor uses, populated
 ///   only when `VmStartConfig.dev_console` is true.
 ///
-/// This transport is DEV-ONLY: `pick_console_transport` selects it only
-/// when `is_dev_mode()` is set, so a sealed production runner cannot
-/// receive an interactive attach over this path.
+/// The **agent-RPC** use (via [`for_vm`]) is not dev-gated — every
+/// `machine run -- <cmd>` / `machine exec` / `invoke` reaches the agent this
+/// way, on prod runners too. The **console-data** use is dev-only:
+/// `pick_console_transport` selects it for console ports only when
+/// `is_dev_mode()` is set, so a sealed production runner cannot receive an
+/// interactive attach over this path.
 pub struct DevConsoleTransport {
     state_dir: PathBuf,
     vsock_dir: PathBuf,
@@ -182,12 +186,14 @@ impl DevConsoleTransport {
 
     /// Resolve the host UDS for a port.
     ///
-    /// - `GUEST_AGENT_PORT` → `<state_dir>/agent.sock` (the standing bridge).
+    /// - `GUEST_AGENT_PORT` → `<state_dir>/hvf-agent.sock` (the standing agent
+    ///   bridge the in-house device binds — see
+    ///   [`mvm_core::config::vm_hvf_agent_socket`]).
     /// - Any other port → `<state_dir>/vsock/vsock-<port>.sock` (the
     ///   pre-opened console data socket, same convention as Vz).
     pub(crate) fn socket_path(&self, port: u32) -> PathBuf {
         if port == mvm_guest::vsock::GUEST_AGENT_PORT {
-            self.state_dir.join("agent.sock")
+            self.state_dir.join("hvf-agent.sock")
         } else {
             self.vsock_dir
                 .join(mvm_core::config::vsock_socket_filename(port))
@@ -268,6 +274,16 @@ impl VsockTransport for NestingHopTransport {
 /// `connect()`. This matches the legacy ladder it replaces, which
 /// already did one throwaway probe before the real call.
 pub fn for_vm(vm_name: &str) -> Result<Box<dyn VsockTransport>> {
+    // In-house (HVF / WorkloadRunner) VMs bind the agent bridge at
+    // `<state_dir>/hvf-agent.sock`. Probe it first — it's the macOS-26 default
+    // backend, and the socket name is distinct from the libkrun/vz layouts so a
+    // hit here is unambiguous. Without this branch the agent-RPC path (every
+    // non-interactive `machine run -- <cmd>`, `machine exec`, `invoke`) could
+    // never reach an in-house guest and timed out after 30s.
+    let inhouse = DevConsoleTransport::for_vm(vm_name);
+    if inhouse.connect(mvm_guest::vsock::GUEST_AGENT_PORT).is_ok() {
+        return Ok(Box::new(inhouse));
+    }
     let libkrun = LibkrunTransport::for_vm(vm_name);
     if libkrun.connect(mvm_guest::vsock::GUEST_AGENT_PORT).is_ok() {
         return Ok(Box::new(libkrun));
@@ -369,6 +385,32 @@ mod tests {
     }
 
     #[test]
+    fn for_vm_selects_inhouse_when_hvf_agent_socket_present() {
+        use std::os::unix::net::UnixListener;
+        // The in-house (HVF / WorkloadRunner) agent bridge binds
+        // `<state_dir>/hvf-agent.sock`. With only that socket present the picker
+        // must select the in-house transport — the regression for the
+        // non-interactive `machine run` reachability gap (the picker previously
+        // knew only libkrun/vz/firecracker, so it fell through to the
+        // firecracker error and the agent-RPC path timed out after 30s).
+        let _lock = crate::vm::DATA_DIR_TEST_LOCK
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner());
+        let dir = tempfile::tempdir().unwrap();
+        unsafe { std::env::set_var("MVM_DATA_DIR", dir.path()) };
+        let name = "inhouse-picker-probe";
+        let sock = mvm_core::config::vm_hvf_agent_socket(name);
+        std::fs::create_dir_all(sock.parent().unwrap()).unwrap();
+        let _listener = UnixListener::bind(&sock).unwrap();
+
+        let t = for_vm(name).expect("picker should find the in-house transport");
+        t.connect(mvm_guest::vsock::GUEST_AGENT_PORT)
+            .expect("selected transport should connect to the hvf-agent socket");
+
+        unsafe { std::env::remove_var("MVM_DATA_DIR") };
+    }
+
+    #[test]
     fn nesting_hop_for_host_vm_derives_forward_socket_path() {
         let t = NestingHopTransport::for_host_vm("/tmp/vm-state", "wl-1");
         assert_eq!(
@@ -427,14 +469,17 @@ mod tests {
     // --- DevConsoleTransport ---
 
     #[test]
-    fn dev_console_transport_agent_port_resolves_to_agent_sock() {
-        // GUEST_AGENT_PORT → `<state_dir>/agent.sock`, not the vsock/ subdir.
+    fn dev_console_transport_agent_port_resolves_to_hvf_agent_sock() {
+        // GUEST_AGENT_PORT → `<state_dir>/hvf-agent.sock` (what the in-house
+        // device's AgentBridge actually binds), not the vsock/ subdir. The old
+        // `agent.sock` name never matched the backend, so the host agent-RPC
+        // path could not reach an in-house guest.
         let t = DevConsoleTransport::new("/tmp/no-such-inhouse-vm");
         let path = t.socket_path(mvm_guest::vsock::GUEST_AGENT_PORT);
         assert_eq!(
             path,
-            PathBuf::from("/tmp/no-such-inhouse-vm/agent.sock"),
-            "agent port must resolve to agent.sock at state-dir root"
+            PathBuf::from("/tmp/no-such-inhouse-vm/hvf-agent.sock"),
+            "agent port must resolve to hvf-agent.sock at state-dir root"
         );
     }
 
@@ -469,14 +514,14 @@ mod tests {
     }
 
     #[test]
-    fn dev_console_transport_connects_via_agent_sock() {
+    fn dev_console_transport_connects_via_hvf_agent_sock() {
         use std::os::unix::net::UnixListener;
         let dir = tempfile::tempdir().unwrap();
-        let agent = dir.path().join("agent.sock");
+        let agent = dir.path().join("hvf-agent.sock");
         let _listener = UnixListener::bind(&agent).unwrap();
         let t = DevConsoleTransport::new(dir.path());
         t.connect(mvm_guest::vsock::GUEST_AGENT_PORT)
-            .expect("should connect to agent.sock");
+            .expect("should connect to hvf-agent.sock");
     }
 
     #[test]


### PR DESCRIPTION
## What broke

`cargo run -- machine run --image alpine -it -- /bin/sh` on macOS 26 failed with:

```
Error: starting transient microVM
Caused by: supervisor did not write .../vz.pid within 5s; killed.
```

The macOS-26 auto-detect default resolved to the **sunset Vz backend**, which spins up a `vz-supervisor` **and a gvproxy sidecar** — neither of which should exist post-migration to the in-house HVF VMM + vsock-only egress.

## The fix

**1. Flip the macOS-26 workload default `vz` → `hvf`** in both selection sites:
- `resolve_effective_hypervisor` (the CLI run/up/pool path)
- `AnyBackend::auto_select` (the backend-internal path)

Vz stays opt-in via `--hypervisor vz`. `HvfBackend::start` spawns its own per-VM gating endpoint — the sole claim-10 egress gate — so there's **no gvproxy and no claim-10 regression**.

**2. Reach the in-house agent over vsock.** Flipping the default surfaced that the host could never reach an in-house guest's agent for non-interactive `machine run -- <cmd>` / `machine exec` / `invoke`. Two host-side bugs:
- `vsock_transport::for_vm` (the agent-RPC transport picker) had **no in-house branch** — only libkrun/vz/firecracker — so it errored and `wait_for_agent` timed out at 30s.
- The in-house transport pointed at `<state_dir>/agent.sock`, but `HvfBackend` binds `<state_dir>/hvf-agent.sock` — a **path drift**.

Fixed by adding `mvm_core::config::vm_hvf_agent_socket` as the single source of truth (used by both the backend that binds it and the transport that connects to it), pointing the in-house transport at it, and probing the in-house transport first in `for_vm`. A 3s per-probe read timeout in `wait_for_agent` makes a bound-but-unanswered socket degrade to the bounded 30s error instead of an infinite `ProtocolHello` read. (`-it` console is unaffected — it uses console data ports via `console_interactive`, never the agent port.)

## Verified live on macOS 26

- Default now boots via `mvm-hvf-supervisor` (**no Vz supervisor, no gvproxy**).
- Host reaches the agent bridge; guest **accepts** the connection (OP_RESPONSE) and receives the request — `flush_rx` tracing confirms the `ProtocolHello` is delivered into the guest RX queue. None of this happened before.

## Tests
`macos_26_default_is_hvf_not_vz`, `test_auto_select_returns_valid_backend` (hvf allow-set), `for_vm_selects_inhouse_when_hvf_agent_socket_present`, `dev_console_transport_agent_port_resolves_to_hvf_agent_sock`. fmt + clippy clean.

## Known follow-up (guest-side, out of scope)
With the transport fixed, tracing proves the host **delivers** the request into the guest RX queue but the in-house **guest agent does not reply** (`negotiate_protocol` then blocks — the 30s timeout above bounds it). That's a rootfs-image-level defect in the guest agent, tracked separately as the remaining core of the in-house non-interactive relay work. Also latent: `agent_bridge::close()` doesn't send OP_RST to the guest on a host-side close (host-dropped probe leaks a guest half-open connection).

🤖 Generated with [Claude Code](https://claude.com/claude-code)