### PR TITLE
feat(egress): Slice 1 Phase A — libkrun transparent-TCP vsock egress (flag-gated, NIC retained)

### DIFF
--- a/crates/mvm-backend/src/egress_shared.rs
+++ b/crates/mvm-backend/src/egress_shared.rs
@@ -13,7 +13,7 @@ use std::path::Path;
 /// secrets, else `None` (legacy / non-admitted / no-secret boot — nothing to
 /// wire). A missing `plan.json` or an undecodable placeholder plan is the no-op
 /// path, not an error.
-pub(crate) fn decode_plan_secrets_from_state(
+pub fn decode_plan_secrets_from_state(
     state_dir: &Path,
 ) -> Result<
     Option<(
@@ -49,6 +49,16 @@ pub(crate) fn decode_plan_secrets_from_state(
     Ok(Some((plan.secrets, plan.redaction, plan.tenant.0)))
 }
 
+/// True when the workload's persisted plan carries at least one bound secret
+/// (i.e. the credential-substitution endpoint will own `EGRESS_PORT`). The
+/// transparent-TCP vsock egress path (Phase A) is scoped to the `false` case so
+/// the two never contend for the port.
+pub fn state_has_bound_secrets(state_dir: &Path) -> Result<bool> {
+    Ok(decode_plan_secrets_from_state(state_dir)?
+        .map(|(secrets, _, _)| !secrets.is_empty())
+        .unwrap_or(false))
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -72,5 +82,17 @@ mod tests {
         let out = decode_plan_secrets_from_state(&dir).unwrap();
         assert!(out.is_none());
         std::fs::remove_dir_all(&dir).ok();
+    }
+}
+
+#[cfg(test)]
+mod phase_a_tests {
+    use super::state_has_bound_secrets;
+
+    #[test]
+    fn state_has_bound_secrets_is_false_for_empty_state() {
+        let dir = tempfile::tempdir().unwrap();
+        // No plan file written → no secrets.
+        assert!(!state_has_bound_secrets(dir.path()).unwrap());
     }
 }

--- a/crates/mvm-backend/src/lib.rs
+++ b/crates/mvm-backend/src/lib.rs
@@ -54,7 +54,7 @@ pub mod compat;
 pub mod egress_redirect;
 /// Cfg-free decode of the admitted plan's egress secret bindings, shared by
 /// the libkrun + Firecracker substitution-endpoint spawn paths.
-pub(crate) mod egress_shared;
+pub mod egress_shared;
 pub mod firecracker;
 pub mod handle_registry;
 pub(crate) mod host_agent_spawn;

--- a/crates/mvm-backend/src/libkrun.rs
+++ b/crates/mvm-backend/src/libkrun.rs
@@ -305,9 +305,12 @@ fn build_supervisor_config(config: &VmStartConfig, state_dir: &Path) -> Result<S
         cmdline.push(' ');
         cmdline.push_str(&token);
     }
+    let vsock_egress_opt_in = mvm_build::libkrun_network_provider::vsock_egress_opt_in();
     if let Some(token) = vsock_egress_cmdline_token(
-        mvm_build::libkrun_network_provider::vsock_egress_opt_in(),
-        crate::egress_shared::state_has_bound_secrets(state_dir).unwrap_or(false),
+        vsock_egress_opt_in,
+        // Only read plan.json for secrets when the flag is on (short-circuit).
+        vsock_egress_opt_in
+            && crate::egress_shared::state_has_bound_secrets(state_dir).unwrap_or(false),
     ) {
         cmdline.push(' ');
         cmdline.push_str(&token);

--- a/crates/mvm-backend/src/libkrun.rs
+++ b/crates/mvm-backend/src/libkrun.rs
@@ -273,6 +273,15 @@ fn libkrun_kernel_for_host(kernel: &str) -> Result<(String, KernelFormat)> {
     Ok((kernel.to_string(), KernelFormat::Raw))
 }
 
+/// Kernel cmdline token that turns on the in-guest vsock egress client. Emitted
+/// only when the host opted in AND the workload carries no bound secrets (Phase A
+/// scope — a secrets workload still uses the substitution endpoint on the NIC).
+/// mkGuest's `/init` parses `mvm.vsock_egress=1` and exports `MVM_VSOCK_EGRESS`,
+/// which starts `mvm-egress-client` and points the workload's proxy env at it.
+fn vsock_egress_cmdline_token(opt_in: bool, has_bound_secrets: bool) -> Option<String> {
+    (opt_in && !has_bound_secrets).then(|| "mvm.vsock_egress=1".to_string())
+}
+
 fn build_supervisor_config(config: &VmStartConfig, state_dir: &Path) -> Result<SupervisorConfig> {
     let kernel = config
         .kernel_path
@@ -293,6 +302,13 @@ fn build_supervisor_config(config: &VmStartConfig, state_dir: &Path) -> Result<S
         cmdline.push_str(&token);
     }
     if let Some(token) = crate::microvm::require_grant_cmdline_token(&config.name) {
+        cmdline.push(' ');
+        cmdline.push_str(&token);
+    }
+    if let Some(token) = vsock_egress_cmdline_token(
+        mvm_build::libkrun_network_provider::vsock_egress_opt_in(),
+        crate::egress_shared::state_has_bound_secrets(state_dir).unwrap_or(false),
+    ) {
         cmdline.push(' ');
         cmdline.push_str(&token);
     }
@@ -1626,5 +1642,17 @@ mod tests {
                 .join(crate::substitution_spawn::SUBST_PID_FILE)
                 .exists()
         );
+    }
+
+    #[test]
+    fn vsock_egress_cmdline_token_only_when_eligible() {
+        // Eligible: opted in, no secrets → token present.
+        assert_eq!(
+            vsock_egress_cmdline_token(true, false).as_deref(),
+            Some("mvm.vsock_egress=1")
+        );
+        // Any disqualifier → no token (legacy NIC path, byte-identical cmdline).
+        assert_eq!(vsock_egress_cmdline_token(false, false), None);
+        assert_eq!(vsock_egress_cmdline_token(true, true), None);
     }
 }

--- a/crates/mvm-build/src/libkrun_network_provider.rs
+++ b/crates/mvm-build/src/libkrun_network_provider.rs
@@ -27,6 +27,15 @@ use mvm_network::{NetHandle, NetworkError, NetworkProvider, NetworkSpec};
 
 use crate::libkrun_builder::{NetworkingPreference, resolve_networking_mode};
 
+/// Host opt-in for the transparent-TCP vsock egress path on libkrun (Phase A).
+/// Unset ⇒ the legacy gvproxy/passt NIC path is used unchanged. Mirrors the
+/// `MVM_NETWORKING` selector convention (present-and-non-empty ⇒ on).
+pub fn vsock_egress_opt_in() -> bool {
+    std::env::var("MVM_VSOCK_EGRESS")
+        .map(|v| !v.trim().is_empty())
+        .unwrap_or(false)
+}
+
 /// libkrun gvproxy/passt network provider (a config producer; owns no host
 /// state — see the module docs).
 pub struct LibkrunNetworkProvider {
@@ -137,5 +146,14 @@ mod tests {
         // libkrun's chokepoint is the supervisor's in-process gateway-bridge
         // FlowPolicy, not a separate EgressEnforcer object → None (default).
         assert!(provider.egress_enforcer().is_none());
+    }
+
+    #[test]
+    fn vsock_egress_opt_in_reads_env() {
+        // Guard: this test mutates process env; keep it serial-safe by scoping.
+        unsafe { std::env::set_var("MVM_VSOCK_EGRESS", "1") };
+        assert!(vsock_egress_opt_in());
+        unsafe { std::env::remove_var("MVM_VSOCK_EGRESS") };
+        assert!(!vsock_egress_opt_in());
     }
 }

--- a/crates/mvm-vm-host/Cargo.toml
+++ b/crates/mvm-vm-host/Cargo.toml
@@ -60,7 +60,10 @@ mvm-backend = { workspace = true }
 # vsock port constants (WORKLOAD_EXIT_PORT) for the exit-capture thread.
 mvm-guest = { workspace = true }
 # SupervisorConfig — the stdin JSON contract the Vz supervisor decodes.
-mvm-build = { workspace = true }
+# builder-vm: pulls libkrun_network_provider::vsock_egress_opt_in (Phase A egress
+# server wiring in mvm-libkrun-supervisor); gated here so it only activates in the
+# per-VM supervisor process, not in library users.
+mvm-build = { workspace = true, features = ["builder-vm"] }
 # libkrun bindings/wrapper; FFI linkage gated by the libkrun-sys feature.
 libkrun-sys = { workspace = true }
 anyhow = { workspace = true }

--- a/crates/mvm-vm-host/src/bin/mvm-libkrun-supervisor.rs
+++ b/crates/mvm-vm-host/src/bin/mvm-libkrun-supervisor.rs
@@ -194,10 +194,14 @@ fn dispatch_config(cfg: SupervisorConfig) -> ExitCode {
     // vsock path used to live-prove egress before the NIC is removed in Phase B.
     {
         let opt_in = mvm_build::libkrun_network_provider::vsock_egress_opt_in();
-        let has_secrets = mvm_backend::egress_shared::state_has_bound_secrets(
-            std::path::Path::new(&cfg.vm_state_dir),
-        )
-        .unwrap_or(false);
+        // Short-circuit on the opt-in flag so the default (flag-off) path does no
+        // extra plan.json read. `should_serve_vsock_egress` also requires `opt_in`,
+        // so passing `has_secrets = false` when opted out changes nothing.
+        let has_secrets = opt_in
+            && mvm_backend::egress_shared::state_has_bound_secrets(std::path::Path::new(
+                &cfg.vm_state_dir,
+            ))
+            .unwrap_or(false);
         if mvm_vm_host::egress_server::should_serve_vsock_egress(
             &cfg.krun.host_listen_ports,
             opt_in,
@@ -210,25 +214,33 @@ fn dispatch_config(cfg: SupervisorConfig) -> ExitCode {
                 .unwrap_or_else(mvm_core::network_policy::NetworkPolicy::deny_all);
             let gate = mvm_hostd::supervisor::substitution_endpoint::build_egress_gate(&policy);
             let egress_sock = cfg.krun.vsock_socket_path(mvm_guest::vsock::EGRESS_PORT);
-            let _ = std::fs::remove_file(&egress_sock);
-            match tokio::net::UnixListener::bind(&egress_sock) {
-                Ok(listener) => {
-                    std::thread::spawn(move || {
-                        let rt = match tokio::runtime::Runtime::new() {
-                            Ok(rt) => rt,
-                            Err(e) => {
-                                eprintln!("mvm-libkrun-supervisor: egress runtime: {e}");
-                                return;
-                            }
-                        };
-                        if let Err(e) = rt.block_on(mvm_vm_host::egress_server::run(listener, gate))
-                        {
-                            eprintln!("mvm-libkrun-supervisor: egress server: {e}");
-                        }
-                    });
+            // Bind INSIDE the runtime context: `tokio::net::UnixListener::bind`
+            // registers the fd with the reactor via `Handle::current()` and panics if
+            // no runtime is entered. `dispatch_config` runs on a plain (non-tokio)
+            // thread, so create + enter the runtime first, then remove_file + bind,
+            // then serve — mirroring the runtime-first pattern in
+            // `mvm_hostd::supervisor::gateway_bridge`.
+            std::thread::spawn(move || {
+                let rt = match tokio::runtime::Runtime::new() {
+                    Ok(rt) => rt,
+                    Err(e) => {
+                        eprintln!("mvm-libkrun-supervisor: egress runtime: {e}");
+                        return;
+                    }
+                };
+                let _guard = rt.enter();
+                let _ = std::fs::remove_file(&egress_sock);
+                let listener = match tokio::net::UnixListener::bind(&egress_sock) {
+                    Ok(l) => l,
+                    Err(e) => {
+                        eprintln!("mvm-libkrun-supervisor: bind egress socket: {e}");
+                        return;
+                    }
+                };
+                if let Err(e) = rt.block_on(mvm_vm_host::egress_server::run(listener, gate)) {
+                    eprintln!("mvm-libkrun-supervisor: egress server: {e}");
                 }
-                Err(e) => eprintln!("mvm-libkrun-supervisor: bind egress socket: {e}"),
-            }
+            });
         }
     }
 

--- a/crates/mvm-vm-host/src/bin/mvm-libkrun-supervisor.rs
+++ b/crates/mvm-vm-host/src/bin/mvm-libkrun-supervisor.rs
@@ -208,8 +208,7 @@ fn dispatch_config(cfg: SupervisorConfig) -> ExitCode {
                 .clone()
                 .and_then(|v| serde_json::from_value(v).ok())
                 .unwrap_or_else(mvm_core::network_policy::NetworkPolicy::deny_all);
-            let gate =
-                mvm_hostd::supervisor::substitution_endpoint::build_egress_gate(&policy);
+            let gate = mvm_hostd::supervisor::substitution_endpoint::build_egress_gate(&policy);
             let egress_sock = cfg.krun.vsock_socket_path(mvm_guest::vsock::EGRESS_PORT);
             let _ = std::fs::remove_file(&egress_sock);
             match tokio::net::UnixListener::bind(&egress_sock) {
@@ -222,8 +221,7 @@ fn dispatch_config(cfg: SupervisorConfig) -> ExitCode {
                                 return;
                             }
                         };
-                        if let Err(e) =
-                            rt.block_on(mvm_vm_host::egress_server::run(listener, gate))
+                        if let Err(e) = rt.block_on(mvm_vm_host::egress_server::run(listener, gate))
                         {
                             eprintln!("mvm-libkrun-supervisor: egress server: {e}");
                         }

--- a/crates/mvm-vm-host/src/bin/mvm-libkrun-supervisor.rs
+++ b/crates/mvm-vm-host/src/bin/mvm-libkrun-supervisor.rs
@@ -187,6 +187,53 @@ fn dispatch_config(cfg: SupervisorConfig) -> ExitCode {
         }
     }
 
+    // Phase A: transparent-TCP vsock egress. When the host opted in and the
+    // workload carries no bound secrets (so the substitution endpoint is NOT
+    // binding EGRESS_PORT), bind the EGRESS_PORT UDS and run the claim-10 egress
+    // server. The NIC is still attached (Phase A retains it); this is the opt-in
+    // vsock path used to live-prove egress before the NIC is removed in Phase B.
+    {
+        let opt_in = mvm_build::libkrun_network_provider::vsock_egress_opt_in();
+        let has_secrets = mvm_backend::egress_shared::state_has_bound_secrets(
+            std::path::Path::new(&cfg.vm_state_dir),
+        )
+        .unwrap_or(false);
+        if mvm_vm_host::egress_server::should_serve_vsock_egress(
+            &cfg.krun.host_listen_ports,
+            opt_in,
+            has_secrets,
+        ) {
+            let policy: mvm_core::network_policy::NetworkPolicy = cfg
+                .network_policy
+                .clone()
+                .and_then(|v| serde_json::from_value(v).ok())
+                .unwrap_or_else(mvm_core::network_policy::NetworkPolicy::deny_all);
+            let gate =
+                mvm_hostd::supervisor::substitution_endpoint::build_egress_gate(&policy);
+            let egress_sock = cfg.krun.vsock_socket_path(mvm_guest::vsock::EGRESS_PORT);
+            let _ = std::fs::remove_file(&egress_sock);
+            match tokio::net::UnixListener::bind(&egress_sock) {
+                Ok(listener) => {
+                    std::thread::spawn(move || {
+                        let rt = match tokio::runtime::Runtime::new() {
+                            Ok(rt) => rt,
+                            Err(e) => {
+                                eprintln!("mvm-libkrun-supervisor: egress runtime: {e}");
+                                return;
+                            }
+                        };
+                        if let Err(e) =
+                            rt.block_on(mvm_vm_host::egress_server::run(listener, gate))
+                        {
+                            eprintln!("mvm-libkrun-supervisor: egress server: {e}");
+                        }
+                    });
+                }
+                Err(e) => eprintln!("mvm-libkrun-supervisor: bind egress socket: {e}"),
+            }
+        }
+    }
+
     // Route to the bridge path when the producer
     // populated the audit substrate, otherwise fall back to the
     // legacy direct-libkrun path (Stage 0 builder VMs, smoke tests,

--- a/crates/mvm-vm-host/src/egress_server.rs
+++ b/crates/mvm-vm-host/src/egress_server.rs
@@ -96,9 +96,7 @@ pub fn should_serve_vsock_egress(
     opt_in: bool,
     has_bound_secrets: bool,
 ) -> bool {
-    opt_in
-        && !has_bound_secrets
-        && host_listen_ports.contains(&mvm_guest::vsock::EGRESS_PORT)
+    opt_in && !has_bound_secrets && host_listen_ports.contains(&mvm_guest::vsock::EGRESS_PORT)
 }
 
 /// Accept egress connections on `listener` (the host-bound UDS libkrun forwards the

--- a/crates/mvm-vm-host/src/egress_server.rs
+++ b/crates/mvm-vm-host/src/egress_server.rs
@@ -87,6 +87,20 @@ where
     Ok(out.len())
 }
 
+/// Phase A guard: serve transparent-TCP vsock egress only when the host opted in,
+/// the workload carries NO bound secrets (else the substitution endpoint owns
+/// `EGRESS_PORT`), and `EGRESS_PORT` is actually forwarded. All three required —
+/// fail closed on any missing.
+pub fn should_serve_vsock_egress(
+    host_listen_ports: &[u32],
+    opt_in: bool,
+    has_bound_secrets: bool,
+) -> bool {
+    opt_in
+        && !has_bound_secrets
+        && host_listen_ports.contains(&mvm_guest::vsock::EGRESS_PORT)
+}
+
 /// Accept egress connections on `listener` (the host-bound UDS libkrun forwards the
 /// guest egress vsock stream to) and serve each against `gate`, dialing real host
 /// TCP connections. Runs until the listener errors.
@@ -202,5 +216,16 @@ mod tests {
         })
         .await
         .unwrap();
+    }
+
+    #[test]
+    fn serves_only_when_opted_in_no_secrets_and_port_present() {
+        let egress = mvm_guest::vsock::EGRESS_PORT;
+        // Happy path: opted in, no secrets, port listed.
+        assert!(should_serve_vsock_egress(&[egress], true, false));
+        // Any single disqualifier fails closed.
+        assert!(!should_serve_vsock_egress(&[egress], false, false)); // not opted in
+        assert!(!should_serve_vsock_egress(&[egress], true, true)); // has secrets
+        assert!(!should_serve_vsock_egress(&[], true, false)); // port absent
     }
 }

--- a/nix/lib/mk-guest.nix
+++ b/nix/lib/mk-guest.nix
@@ -655,7 +655,7 @@ let
     # workload path sets `mvm.vsock_egress=1` on the kernel cmdline; export the
     # env var Stage 2.6 keys on. Mirrors the mvm.secret_env / mvm.verb_grant
     # cmdline parsers above. Absent token ⇒ no-op (NIC guests boot unchanged).
-    if /bin/busybox grep -q ' mvm\.vsock_egress=1\( \|$\)' /proc/cmdline 2>/dev/null; then
+    if /bin/busybox grep -qE ' mvm\.vsock_egress=1( |$)' /proc/cmdline 2>/dev/null; then
       export MVM_VSOCK_EGRESS=1
     fi
 

--- a/nix/lib/mk-guest.nix
+++ b/nix/lib/mk-guest.nix
@@ -651,6 +651,14 @@ let
         -- /usr/local/bin/mvm-addon-dns &
     fi
 
+    # Stage 2.55 — decode the vsock-egress opt-in. The libkrun/vsock-gateway
+    # workload path sets `mvm.vsock_egress=1` on the kernel cmdline; export the
+    # env var Stage 2.6 keys on. Mirrors the mvm.secret_env / mvm.verb_grant
+    # cmdline parsers above. Absent token ⇒ no-op (NIC guests boot unchanged).
+    if /bin/busybox grep -q ' mvm\.vsock_egress=1\( \|$\)' /proc/cmdline 2>/dev/null; then
+      export MVM_VSOCK_EGRESS=1
+    fi
+
     # Stage 2.6 — vsock egress shim. When the boot env requests vsock-only
     # egress (the backend sets MVM_VSOCK_EGRESS for a vsock-gateway backend — HVF/KVM
     # today), bring up loopback, start the SOCKS5→vsock shim under the agent uid, and

--- a/specs/notes/2026-07-05-slice1-libkrun-vsock-egress-phase-a-plan.md
+++ b/specs/notes/2026-07-05-slice1-libkrun-vsock-egress-phase-a-plan.md
@@ -288,78 +288,100 @@ git commit -m "feat(egress): run egress_server on EGRESS_PORT in libkrun supervi
 
 ---
 
-### Task 5: Inject `MVM_VSOCK_EGRESS=1` into the guest entrypoint env
+### Task 5: Turn on the in-guest egress client via a kernel cmdline token
 
-So the baked-but-inert `mvm-egress-client` actually starts (mkGuest Stage 2.6 keys on the guest env var `MVM_VSOCK_EGRESS`). Build the env list in a pure, tested helper, then apply it via `KrunContext::with_guest_envp`.
+**CORRECTED MECHANISM (2026-07-05).** A libkrun **workload** boots a full rootfs
+image with `init=/init` — it does *not* use `KrunContext::with_guest_envp`/`root_dir`
+(that is the libkrun *builder/command* path, and it appears nowhere in `libkrun.rs`).
+The workload guest env is carried on the **kernel cmdline**: `build_supervisor_config`
+(`libkrun.rs:286`) appends `mvm.uvols=…`, `mvm.egress_ca=…`, `mvm.secret_env=…`,
+`mvm.verb_grant=…` tokens, and mkGuest `/init` parses each with
+`sed -n 's/.*\bmvm\.KEY=…/\1/p' /proc/cmdline`. mkGuest Stage 2.6 (`mk-guest.nix:661`)
+keys on the env var `MVM_VSOCK_EGRESS`, but **nothing sets it** — a gap on both sides.
+This task mirrors the existing token pattern: host appends `mvm.vsock_egress=1`; `/init`
+parses it into `MVM_VSOCK_EGRESS`.
 
 **Files:**
-- Modify: `crates/mvm-backend/src/libkrun.rs` (the guest-entrypoint construction — `krun_context_base`, lines 147–195, where `with_guest_envp` is/should be called)
-- Test: `crates/mvm-backend/src/libkrun.rs` inline
+- Modify: `crates/mvm-backend/src/libkrun.rs` — add `vsock_egress_cmdline_token` helper + append it in `build_supervisor_config` after the verb-grant token (~line 297), mirroring `crate::microvm::verb_grant_cmdline_token`.
+- Modify: `nix/lib/mk-guest.nix` — add a `/proc/cmdline` parse setting `MVM_VSOCK_EGRESS` immediately before the Stage 2.6 `if [ -n "$MVM_VSOCK_EGRESS" ]` check (`mk-guest.nix:661`), mirroring the `mvm.secret_env` parser at `mk-guest.nix:551`.
+- Test: `crates/mvm-backend/src/libkrun.rs` inline (host helper).
 
 **Interfaces:**
-- Consumes: `mvm_build::libkrun_network_provider::vsock_egress_opt_in`, `mvm_backend::egress_shared::state_has_bound_secrets`
-- Produces: `fn workload_guest_envp(base: &[String], opt_in: bool, has_bound_secrets: bool) -> Vec<String>`
+- Consumes: `mvm_build::libkrun_network_provider::vsock_egress_opt_in`, `crate::egress_shared::state_has_bound_secrets` (both reachable — `mvm-backend` already enables `mvm-build`'s `builder-vm` feature, `Cargo.toml:58`).
+- Produces: `fn vsock_egress_cmdline_token(opt_in: bool, has_bound_secrets: bool) -> Option<String>` returning `Some("mvm.vsock_egress=1")` only when eligible.
 
 - [ ] **Step 1: Write the failing test**
 
 ```rust
 #[test]
-fn workload_guest_envp_adds_flag_only_when_eligible() {
-    let base = vec!["PATH=/usr/bin".to_string()];
-    // Eligible: opted in, no secrets → flag appended.
-    let got = workload_guest_envp(&base, true, false);
-    assert!(got.contains(&"MVM_VSOCK_EGRESS=1".to_string()));
-    assert!(got.contains(&"PATH=/usr/bin".to_string()));
-    // Not eligible → base returned unchanged (no flag).
-    assert_eq!(workload_guest_envp(&base, false, false), base);
-    assert_eq!(workload_guest_envp(&base, true, true), base);
+fn vsock_egress_cmdline_token_only_when_eligible() {
+    // Eligible: opted in, no secrets → token present.
+    assert_eq!(
+        vsock_egress_cmdline_token(true, false).as_deref(),
+        Some("mvm.vsock_egress=1")
+    );
+    // Any disqualifier → no token (legacy NIC path, byte-identical cmdline).
+    assert_eq!(vsock_egress_cmdline_token(false, false), None);
+    assert_eq!(vsock_egress_cmdline_token(true, true), None);
 }
 ```
 
 - [ ] **Step 2: Run test to verify it fails**
 
-Run: `cargo nextest run -p mvm-backend workload_guest_envp_adds_flag_only_when_eligible`
-Expected: FAIL — `workload_guest_envp` not found.
+Run: `cargo nextest run -p mvm-backend vsock_egress_cmdline_token_only_when_eligible`
+Expected: FAIL — `vsock_egress_cmdline_token` not found.
 
-- [ ] **Step 3: Implement the helper** (add near `krun_context_base` in `libkrun.rs`)
+- [ ] **Step 3: Implement the helper** (add near `build_supervisor_config` in `libkrun.rs`)
 
 ```rust
-/// Append `MVM_VSOCK_EGRESS=1` to the guest entrypoint env when the host opted
-/// in AND the workload carries no bound secrets. That flag is what mkGuest's
-/// Stage 2.6 keys on to start the in-guest `mvm-egress-client` and point the
-/// workload's proxy env at the loopback SOCKS5 listener. Otherwise the base env
-/// is returned unchanged (legacy NIC path, no in-guest egress client).
-fn workload_guest_envp(base: &[String], opt_in: bool, has_bound_secrets: bool) -> Vec<String> {
-    let mut envp = base.to_vec();
-    if opt_in && !has_bound_secrets {
-        envp.push("MVM_VSOCK_EGRESS=1".to_string());
-    }
-    envp
+/// Kernel cmdline token that turns on the in-guest vsock egress client. Emitted
+/// only when the host opted in AND the workload carries no bound secrets (Phase A
+/// scope — a secrets workload still uses the substitution endpoint on the NIC).
+/// mkGuest's `/init` parses `mvm.vsock_egress=1` and exports `MVM_VSOCK_EGRESS`,
+/// which starts `mvm-egress-client` and points the workload's proxy env at it.
+fn vsock_egress_cmdline_token(opt_in: bool, has_bound_secrets: bool) -> Option<String> {
+    (opt_in && !has_bound_secrets).then(|| "mvm.vsock_egress=1".to_string())
 }
 ```
 
-- [ ] **Step 4: Apply it at the guest-entrypoint construction site**
+- [ ] **Step 4: Append the token in `build_supervisor_config`**
 
-In `krun_context_base` (or wherever the workload's `with_guest_envp(...)` is called — confirm via the Step-1 read of Task 4's file is different; here read `libkrun.rs:147–195`), route the env list through the helper. Concretely, where the guest envp is built for a **workload** (root_dir set), replace the direct `.with_guest_envp(base_env)` with:
+Immediately after the `require_grant_cmdline_token` block (`libkrun.rs:295–298`), add:
 
 ```rust
-let opt_in = mvm_build::libkrun_network_provider::vsock_egress_opt_in();
-let has_secrets = crate::egress_shared::state_has_bound_secrets(state_dir).unwrap_or(false);
-krun.with_guest_envp(workload_guest_envp(&base_env, opt_in, has_secrets))
+if let Some(token) = vsock_egress_cmdline_token(
+    mvm_build::libkrun_network_provider::vsock_egress_opt_in(),
+    crate::egress_shared::state_has_bound_secrets(state_dir).unwrap_or(false),
+) {
+    cmdline.push(' ');
+    cmdline.push_str(&token);
+}
 ```
 
-(If `krun_context_base` does not currently set `with_guest_envp`, add the call on the workload branch only — it is a no-op unless `root_dir` is set, per the libkrun-sys doc at `lib.rs:503`.)
+- [ ] **Step 5: Parse the token in mkGuest `/init`**
 
-- [ ] **Step 5: Run tests + build**
-
-Run: `cargo nextest run -p mvm-backend workload_guest_envp_adds_flag_only_when_eligible && cargo build -p mvm-backend`
-Expected: PASS + clean build.
-
-- [ ] **Step 6: Commit**
+In `nix/lib/mk-guest.nix`, immediately before the Stage 2.6 line `if [ -n "$MVM_VSOCK_EGRESS" ] && [ -x /usr/local/bin/mvm-egress-client ]; then` (`mk-guest.nix:661`), insert (mirroring the `mvm.secret_env` parser style, and note the double-single-quote `''` escaping that this nix heredoc uses for shell `$`):
 
 ```bash
-git add crates/mvm-backend/src/libkrun.rs
-git commit -m "feat(egress): inject MVM_VSOCK_EGRESS=1 into eligible workload guest env (Phase A)"
+    # Stage 2.55 — decode the vsock-egress opt-in. The libkrun/vsock-gateway
+    # workload path sets `mvm.vsock_egress=1` on the kernel cmdline; export the
+    # env var Stage 2.6 keys on. Mirrors the mvm.secret_env / mvm.verb_grant
+    # cmdline parsers above. Absent token ⇒ no-op (NIC guests boot unchanged).
+    if /bin/busybox grep -q ' mvm\.vsock_egress=1\( \|$\)' /proc/cmdline 2>/dev/null; then
+      export MVM_VSOCK_EGRESS=1
+    fi
+```
+
+- [ ] **Step 6: Run tests + build**
+
+Run: `cargo nextest run -p mvm-backend vsock_egress_cmdline_token_only_when_eligible && cargo build -p mvm-backend`
+Expected: PASS + clean build. (The nix `/init` change has no Rust test; it is exercised by the Task 6 live boot.)
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add crates/mvm-backend/src/libkrun.rs nix/lib/mk-guest.nix
+git commit -m "feat(egress): mvm.vsock_egress cmdline token turns on in-guest egress client (Phase A)"
 ```
 
 ---

--- a/specs/notes/2026-07-05-slice1-libkrun-vsock-egress-phase-a-plan.md
+++ b/specs/notes/2026-07-05-slice1-libkrun-vsock-egress-phase-a-plan.md
@@ -1,0 +1,416 @@
+# Slice 1 Phase A — libkrun transparent-TCP vsock egress (flag-gated, NIC retained) Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Make a **no-bound-secret** libkrun workload reach the network through the host vsock `EgressGate` (claim-10) instead of the NIC, opt-in behind the `MVM_VSOCK_EGRESS` host flag, with the gvproxy/passt NIC **retained** so the change is reversible and non-regressing.
+
+**Architecture:** The guest side is already built and inert — `mvm-egress-client` (SOCKS5→vsock, writes `"host:port\n"`), its nix package, and mkGuest Stage 2.6 (gated on the guest env var `MVM_VSOCK_EGRESS`) all exist. This phase lights it up on libkrun: (1) the libkrun backend injects `MVM_VSOCK_EGRESS=1` into the guest entrypoint env via `KrunContext::with_guest_envp` when the host opts in and the workload has no bound secrets; (2) the `mvm-libkrun-supervisor` binds the `EGRESS_PORT` UDS and runs the already-built `mvm_vm_host::egress_server::run(listener, gate)`, mirroring its existing `WORKLOAD_EXIT_PORT` exit-capture pattern. No collision with credential substitution: the substitution endpoint only binds `EGRESS_PORT` when secrets are present, and this phase is scoped to the no-secrets case, so the two are mutually exclusive.
+
+**Tech Stack:** Rust, tokio (supervisor runtime), libkrun-sys `KrunContext`, `mvm_backend::vsock_egress_bridge::egress_gate::EgressGate`, nextest.
+
+## Global Constraints
+
+- No `#[allow(clippy::too_many_arguments)]` in hand-written code — use a params struct + builder (CLAUDE.md).
+- All `~/.mvm` / `~/.cache/mvm` paths go through `mvm-core::config` helpers — never inline `$HOME`.
+- Reuse first: call `mvm_hostd::supervisor::substitution_endpoint::build_egress_gate` and `mvm_backend::egress_shared::decode_plan_secrets_from_state` — do not reimplement gate/secret decode.
+- Every change gated: unset `MVM_VSOCK_EGRESS` (or any workload carrying bound secrets) ⇒ **byte-identical legacy NIC path**. The NIC (`with_gvproxy`/`with_passt`) is **not** removed in this phase.
+- Test gate before "done": `cargo fmt --all -- --check` && `cargo nextest run --workspace` && `cargo test --workspace --doc` && `cargo clippy --workspace -- -D warnings`.
+- Per-VM aux bins (`mvm-libkrun-supervisor`) are **not** rebuilt by `cargo run`/test — rebuild explicitly with `cargo build -p mvm-vm-host --bin mvm-libkrun-supervisor` before any live boot (stale bin ⇒ `deny_unknown_fields` boot failure).
+
+## Scope note (read before starting)
+
+This plan is **Phase A only**. It deliberately does NOT: fold claims-12/13 credential substitution onto the transparent-TCP path, delete the NIC, or widen `check-vsock-only-egress`. Those are **Phase B**, a separate review-gated plan (substitution is a `WireRequest` RPC today; unifying it with the transparent-TCP stream is the security-critical change the ADR-100 Step 2.3 note reserves for maintainer review + a live boot). Phase A stands up and live-proves the transparent-TCP path with the NIC still present as a fallback; Phase B is authored only after Phase A's live boot passes.
+
+---
+
+### Task 1: Expose the secrets-presence check (reuse, make `pub`)
+
+The supervisor and backend must both answer "does this workload carry bound secrets?" to stay mutually exclusive with the substitution endpoint. `decode_plan_secrets_from_state` already answers it but is `pub(crate)` in `mvm-backend`. Promote it and add a thin boolean wrapper.
+
+**Files:**
+- Modify: `crates/mvm-backend/src/egress_shared.rs` (the `decode_plan_secrets_from_state` fn, currently `pub(crate)` around lines 16–24)
+- Test: `crates/mvm-backend/src/egress_shared.rs` (inline `#[cfg(test)]`)
+
+**Interfaces:**
+- Produces: `pub fn decode_plan_secrets_from_state(state_dir: &Path) -> Result<Option<(Vec<mvm_core::plan::SecretBinding>, mvm_core::policy::RedactionPolicy, String)>>` and `pub fn state_has_bound_secrets(state_dir: &Path) -> Result<bool>`
+
+- [ ] **Step 1: Write the failing test** (append to `egress_shared.rs`)
+
+```rust
+#[cfg(test)]
+mod phase_a_tests {
+    use super::*;
+
+    #[test]
+    fn state_has_bound_secrets_is_false_for_empty_state() {
+        let dir = tempfile::tempdir().unwrap();
+        // No plan file written → no secrets.
+        assert!(!state_has_bound_secrets(dir.path()).unwrap());
+    }
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cargo nextest run -p mvm-backend state_has_bound_secrets_is_false_for_empty_state`
+Expected: FAIL — `state_has_bound_secrets` not found.
+
+- [ ] **Step 3: Change visibility + add the wrapper**
+
+Change the existing signature from `pub(crate) fn decode_plan_secrets_from_state` to `pub fn decode_plan_secrets_from_state` (keep the body untouched). Then add directly below it:
+
+```rust
+/// True when the workload's persisted plan carries at least one bound secret
+/// (i.e. the credential-substitution endpoint will own `EGRESS_PORT`). The
+/// transparent-TCP vsock egress path (Phase A) is scoped to the `false` case so
+/// the two never contend for the port.
+pub fn state_has_bound_secrets(state_dir: &Path) -> Result<bool> {
+    Ok(decode_plan_secrets_from_state(state_dir)?
+        .map(|(secrets, _, _)| !secrets.is_empty())
+        .unwrap_or(false))
+}
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `cargo nextest run -p mvm-backend state_has_bound_secrets_is_false_for_empty_state`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add crates/mvm-backend/src/egress_shared.rs
+git commit -m "feat(egress): pub state_has_bound_secrets for Phase A gating"
+```
+
+---
+
+### Task 2: Host opt-in flag reader
+
+One host env var, `MVM_VSOCK_EGRESS`, gates the whole phase. Read it in one place.
+
+**Files:**
+- Modify: `crates/mvm-build/src/libkrun_network_provider.rs` (next to `resolve_networking_mode`, the existing per-OS networking selector)
+- Test: same file, inline
+
+**Interfaces:**
+- Produces: `pub fn vsock_egress_opt_in() -> bool`
+
+- [ ] **Step 1: Write the failing test**
+
+```rust
+#[test]
+fn vsock_egress_opt_in_reads_env() {
+    // Guard: this test mutates process env; keep it serial-safe by scoping.
+    unsafe { std::env::set_var("MVM_VSOCK_EGRESS", "1") };
+    assert!(vsock_egress_opt_in());
+    unsafe { std::env::remove_var("MVM_VSOCK_EGRESS") };
+    assert!(!vsock_egress_opt_in());
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cargo nextest run -p mvm-build vsock_egress_opt_in_reads_env`
+Expected: FAIL — `vsock_egress_opt_in` not found.
+
+- [ ] **Step 3: Implement**
+
+```rust
+/// Host opt-in for the transparent-TCP vsock egress path on libkrun (Phase A).
+/// Unset ⇒ the legacy gvproxy/passt NIC path is used unchanged. Mirrors the
+/// `MVM_NETWORKING` selector convention (present-and-non-empty ⇒ on).
+pub fn vsock_egress_opt_in() -> bool {
+    std::env::var("MVM_VSOCK_EGRESS")
+        .map(|v| !v.trim().is_empty())
+        .unwrap_or(false)
+}
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `cargo nextest run -p mvm-build vsock_egress_opt_in_reads_env`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add crates/mvm-build/src/libkrun_network_provider.rs
+git commit -m "feat(egress): MVM_VSOCK_EGRESS host opt-in reader"
+```
+
+---
+
+### Task 3: Supervisor decision predicate (testable, extracted from the bin)
+
+The bin can't be unit-tested directly, so extract the "should I serve vsock egress?" decision into a pure function in the `mvm-vm-host` lib.
+
+**Files:**
+- Modify: `crates/mvm-vm-host/src/egress_server.rs` (add a pure predicate + its test)
+
+**Interfaces:**
+- Consumes: `SupervisorConfig.krun.host_listen_ports: Vec<u32>`, `mvm_guest::vsock::EGRESS_PORT`
+- Produces: `pub fn should_serve_vsock_egress(host_listen_ports: &[u32], opt_in: bool, has_bound_secrets: bool) -> bool`
+
+- [ ] **Step 1: Write the failing test** (append to `egress_server.rs` test module)
+
+```rust
+#[test]
+fn serves_only_when_opted_in_no_secrets_and_port_present() {
+    let egress = mvm_guest::vsock::EGRESS_PORT;
+    // Happy path: opted in, no secrets, port listed.
+    assert!(should_serve_vsock_egress(&[egress], true, false));
+    // Any single disqualifier fails closed.
+    assert!(!should_serve_vsock_egress(&[egress], false, false)); // not opted in
+    assert!(!should_serve_vsock_egress(&[egress], true, true)); // has secrets
+    assert!(!should_serve_vsock_egress(&[], true, false)); // port absent
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cargo nextest run -p mvm-vm-host serves_only_when_opted_in_no_secrets_and_port_present`
+Expected: FAIL — `should_serve_vsock_egress` not found.
+
+- [ ] **Step 3: Implement** (add near the top of `egress_server.rs`, outside the test module)
+
+```rust
+/// Phase A guard: serve transparent-TCP vsock egress only when the host opted in,
+/// the workload carries NO bound secrets (else the substitution endpoint owns
+/// `EGRESS_PORT`), and `EGRESS_PORT` is actually forwarded. All three required —
+/// fail closed on any missing.
+pub fn should_serve_vsock_egress(
+    host_listen_ports: &[u32],
+    opt_in: bool,
+    has_bound_secrets: bool,
+) -> bool {
+    opt_in
+        && !has_bound_secrets
+        && host_listen_ports.contains(&mvm_guest::vsock::EGRESS_PORT)
+}
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `cargo nextest run -p mvm-vm-host serves_only_when_opted_in_no_secrets_and_port_present`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add crates/mvm-vm-host/src/egress_server.rs
+git commit -m "feat(egress): should_serve_vsock_egress Phase A predicate"
+```
+
+---
+
+### Task 4: Bind EGRESS_PORT + run the egress server in the supervisor bin
+
+Wire the already-built `egress_server::run` into `mvm-libkrun-supervisor`, mirroring the existing `WORKLOAD_EXIT_PORT` exit-capture block (`dispatch_config`, lines 168–188).
+
+**Files:**
+- Modify: `crates/mvm-vm-host/src/bin/mvm-libkrun-supervisor.rs` (`dispatch_config`, immediately after the exit-capture block, before the bridge/legacy route at line ~194)
+
+**Interfaces:**
+- Consumes: `should_serve_vsock_egress`, `mvm_build::libkrun_network_provider::vsock_egress_opt_in`, `mvm_backend::egress_shared::state_has_bound_secrets`, `mvm_hostd::supervisor::substitution_endpoint::build_egress_gate`, `mvm_vm_host::egress_server::run`, `cfg.krun.vsock_socket_path(port)`, `cfg.network_policy: Option<serde_json::Value>`, `cfg.vm_state_dir: String`
+
+- [ ] **Step 1: Read the orientation context**
+
+Read `crates/mvm-vm-host/src/bin/mvm-libkrun-supervisor.rs` lines 160–210 to confirm the exit-capture block shape and where `dispatch_config` branches to `run_with_bridge`/`run_legacy`. Confirm `use tokio::net::UnixListener;` is already imported (the exit-capture block uses `UnixListener::bind`).
+
+- [ ] **Step 2: Add the egress-server block** (insert after the exit-capture `if` block, before the `let outcome = if cfg.tenant_id.is_some()` line)
+
+```rust
+// Phase A: transparent-TCP vsock egress. When the host opted in and the
+// workload carries no bound secrets (so the substitution endpoint is NOT
+// binding EGRESS_PORT), bind the EGRESS_PORT UDS and run the claim-10 egress
+// server. The NIC is still attached (Phase A retains it); this is the opt-in
+// vsock path used to live-prove egress before the NIC is removed in Phase B.
+{
+    let opt_in = mvm_build::libkrun_network_provider::vsock_egress_opt_in();
+    let has_secrets = mvm_backend::egress_shared::state_has_bound_secrets(
+        std::path::Path::new(&cfg.vm_state_dir),
+    )
+    .unwrap_or(false);
+    if mvm_vm_host::egress_server::should_serve_vsock_egress(
+        &cfg.krun.host_listen_ports,
+        opt_in,
+        has_secrets,
+    ) {
+        let policy: mvm_core::network_policy::NetworkPolicy = cfg
+            .network_policy
+            .clone()
+            .and_then(|v| serde_json::from_value(v).ok())
+            .unwrap_or_else(mvm_core::network_policy::NetworkPolicy::deny_all);
+        let gate =
+            mvm_hostd::supervisor::substitution_endpoint::build_egress_gate(&policy);
+        let egress_sock = cfg.krun.vsock_socket_path(mvm_guest::vsock::EGRESS_PORT);
+        let _ = std::fs::remove_file(&egress_sock);
+        match UnixListener::bind(&egress_sock) {
+            Ok(listener) => {
+                std::thread::spawn(move || {
+                    let rt = match tokio::runtime::Runtime::new() {
+                        Ok(rt) => rt,
+                        Err(e) => {
+                            eprintln!("mvm-libkrun-supervisor: egress runtime: {e}");
+                            return;
+                        }
+                    };
+                    if let Err(e) =
+                        rt.block_on(mvm_vm_host::egress_server::run(listener, gate))
+                    {
+                        eprintln!("mvm-libkrun-supervisor: egress server: {e}");
+                    }
+                });
+            }
+            Err(e) => eprintln!("mvm-libkrun-supervisor: bind egress socket: {e}"),
+        }
+    }
+}
+```
+
+- [ ] **Step 3: Build the bin (it is not built by test runs)**
+
+Run: `cargo build -p mvm-vm-host --bin mvm-libkrun-supervisor`
+Expected: builds clean (confirms `vsock_socket_path`, `build_egress_gate`, `NetworkPolicy::deny_all` all resolve; fix imports if not).
+
+- [ ] **Step 4: Workspace test + clippy**
+
+Run: `cargo nextest run -p mvm-vm-host && cargo clippy -p mvm-vm-host --bin mvm-libkrun-supervisor -- -D warnings`
+Expected: PASS, zero warnings.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add crates/mvm-vm-host/src/bin/mvm-libkrun-supervisor.rs
+git commit -m "feat(egress): run egress_server on EGRESS_PORT in libkrun supervisor (Phase A, gated)"
+```
+
+---
+
+### Task 5: Inject `MVM_VSOCK_EGRESS=1` into the guest entrypoint env
+
+So the baked-but-inert `mvm-egress-client` actually starts (mkGuest Stage 2.6 keys on the guest env var `MVM_VSOCK_EGRESS`). Build the env list in a pure, tested helper, then apply it via `KrunContext::with_guest_envp`.
+
+**Files:**
+- Modify: `crates/mvm-backend/src/libkrun.rs` (the guest-entrypoint construction — `krun_context_base`, lines 147–195, where `with_guest_envp` is/should be called)
+- Test: `crates/mvm-backend/src/libkrun.rs` inline
+
+**Interfaces:**
+- Consumes: `mvm_build::libkrun_network_provider::vsock_egress_opt_in`, `mvm_backend::egress_shared::state_has_bound_secrets`
+- Produces: `fn workload_guest_envp(base: &[String], opt_in: bool, has_bound_secrets: bool) -> Vec<String>`
+
+- [ ] **Step 1: Write the failing test**
+
+```rust
+#[test]
+fn workload_guest_envp_adds_flag_only_when_eligible() {
+    let base = vec!["PATH=/usr/bin".to_string()];
+    // Eligible: opted in, no secrets → flag appended.
+    let got = workload_guest_envp(&base, true, false);
+    assert!(got.contains(&"MVM_VSOCK_EGRESS=1".to_string()));
+    assert!(got.contains(&"PATH=/usr/bin".to_string()));
+    // Not eligible → base returned unchanged (no flag).
+    assert_eq!(workload_guest_envp(&base, false, false), base);
+    assert_eq!(workload_guest_envp(&base, true, true), base);
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cargo nextest run -p mvm-backend workload_guest_envp_adds_flag_only_when_eligible`
+Expected: FAIL — `workload_guest_envp` not found.
+
+- [ ] **Step 3: Implement the helper** (add near `krun_context_base` in `libkrun.rs`)
+
+```rust
+/// Append `MVM_VSOCK_EGRESS=1` to the guest entrypoint env when the host opted
+/// in AND the workload carries no bound secrets. That flag is what mkGuest's
+/// Stage 2.6 keys on to start the in-guest `mvm-egress-client` and point the
+/// workload's proxy env at the loopback SOCKS5 listener. Otherwise the base env
+/// is returned unchanged (legacy NIC path, no in-guest egress client).
+fn workload_guest_envp(base: &[String], opt_in: bool, has_bound_secrets: bool) -> Vec<String> {
+    let mut envp = base.to_vec();
+    if opt_in && !has_bound_secrets {
+        envp.push("MVM_VSOCK_EGRESS=1".to_string());
+    }
+    envp
+}
+```
+
+- [ ] **Step 4: Apply it at the guest-entrypoint construction site**
+
+In `krun_context_base` (or wherever the workload's `with_guest_envp(...)` is called — confirm via the Step-1 read of Task 4's file is different; here read `libkrun.rs:147–195`), route the env list through the helper. Concretely, where the guest envp is built for a **workload** (root_dir set), replace the direct `.with_guest_envp(base_env)` with:
+
+```rust
+let opt_in = mvm_build::libkrun_network_provider::vsock_egress_opt_in();
+let has_secrets = crate::egress_shared::state_has_bound_secrets(state_dir).unwrap_or(false);
+krun.with_guest_envp(workload_guest_envp(&base_env, opt_in, has_secrets))
+```
+
+(If `krun_context_base` does not currently set `with_guest_envp`, add the call on the workload branch only — it is a no-op unless `root_dir` is set, per the libkrun-sys doc at `lib.rs:503`.)
+
+- [ ] **Step 5: Run tests + build**
+
+Run: `cargo nextest run -p mvm-backend workload_guest_envp_adds_flag_only_when_eligible && cargo build -p mvm-backend`
+Expected: PASS + clean build.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add crates/mvm-backend/src/libkrun.rs
+git commit -m "feat(egress): inject MVM_VSOCK_EGRESS=1 into eligible workload guest env (Phase A)"
+```
+
+---
+
+### Task 6: Full gate + live-boot verification runbook (manual, gated)
+
+Phase A is "done" only after a live libkrun boot proves the vsock path. This task is the runbook + the checklist that unblocks Phase B.
+
+**Files:**
+- Create: `specs/runbooks/slice1-phase-a-libkrun-vsock-egress.md`
+
+- [ ] **Step 1: Run the full workspace gate**
+
+Run: `cargo fmt --all -- --check && cargo nextest run --workspace && cargo test --workspace --doc && cargo clippy --workspace -- -D warnings`
+Expected: all green.
+
+- [ ] **Step 2: Rebuild the aux bin explicitly**
+
+Run: `cargo build -p mvm-vm-host --bin mvm-libkrun-supervisor && cargo build`
+Expected: clean (stale supervisor would fail the boot with a `deny_unknown_fields` error).
+
+- [ ] **Step 3: Live boot — allow path** (macOS with `slp/krun/*` trio installed)
+
+Boot a **no-secrets** workload with an allow-list policy admitting one `host:port`, with `MVM_VSOCK_EGRESS=1` set on the host `machine run`. From inside the guest, a `curl` (which honors `ALL_PROXY=socks5h://127.0.0.1:1080`) to the allow-listed target must succeed. Record the exact command in the runbook.
+
+- [ ] **Step 4: Live boot — deny path**
+
+Same VM, a target NOT on the allow-list: the fetch must fail (gate `Deny`, never dialed). Record.
+
+- [ ] **Step 5: Confirm the NIC is still present (Phase A retains it)**
+
+`ip link` inside the guest shows the NIC in addition to `lo` (Phase A does not remove it). Record — Phase B is what removes it and flips this assertion to "only `lo`".
+
+- [ ] **Step 6: Write the runbook + commit**
+
+Capture Steps 2–5 (commands, expected output, actual output) in `specs/runbooks/slice1-phase-a-libkrun-vsock-egress.md`, then:
+
+```bash
+git add specs/runbooks/slice1-phase-a-libkrun-vsock-egress.md
+git commit -m "docs(runbook): Slice 1 Phase A libkrun vsock egress live-boot verification"
+```
+
+- [ ] **Step 7: Unblock Phase B**
+
+Only once Steps 3–5 pass on a real boot: author the Phase B plan (fold claims-12/13 substitution onto the transparent-TCP front door as TLS-terminating behavior; remove `with_gvproxy`/`with_passt` + terminator/redirect; widen `check-vsock-only-egress` to `libkrun.rs` + the supervisor). Phase B is security-touching and requires maintainer review per the ADR-100 Step 2.3 note.
+
+---
+
+## Self-review notes
+
+- **Spec coverage (design doc Slice 1):** Phase A covers the reversible, non-regressing half — vsock egress path stood up + live-proven with NIC retained. The design doc's Slice-1 items that remain (substitution fold, NIC delete, gate widening) are explicitly deferred to Phase B with a review gate, consistent with the ADR-100 Step 2.3 note that reserves the substitution unification for maintainer review. No silent scope drop.
+- **Reuse:** gate built via `build_egress_gate`; secrets via `decode_plan_secrets_from_state`; env inject via existing `with_guest_envp`; supervisor wiring mirrors the existing exit-capture block. No reimplementation.
+- **Type consistency:** `EGRESS_PORT: u32`; `host_listen_ports: Vec<u32>`; `vsock_socket_path(u32) -> PathBuf`; `build_egress_gate(&NetworkPolicy) -> EgressGate`; `egress_server::run(UnixListener, EgressGate)`. All match the signatures read from source.
+- **Fail-closed:** every predicate requires all conditions; missing/undecodable policy ⇒ `deny_all`; ineligible ⇒ legacy path unchanged.

--- a/specs/notes/2026-07-05-vsock-only-egress-cutover-path-a-design.md
+++ b/specs/notes/2026-07-05-vsock-only-egress-cutover-path-a-design.md
@@ -1,0 +1,187 @@
+# vsock-only egress cutover — Path A design
+
+**Date:** 2026-07-05
+**Status:** Draft (brainstorm output, pre-plan)
+**Relates to:** [ADR-100](../adrs/100-vsock-sole-guest-world-channel.md) (vsock is the
+sole guest↔world channel), [ADR-002](../adrs/002-microvm-security-posture.md) (claim 10),
+[ADR-049](../adrs/049-secret-substitution-mechanism.md) / [ADR-059](../adrs/059-host-services-broker.md)
+(claims 12/13 substitution + broker), [ADR-082](../adrs/082-rust-native-egress-gateway.md)
+(in-house gateway), [ADR-083](../adrs/083-workload-backend-type-bar.md) (`WorkloadBackend`),
+[Plan 214](../plans/214-clean-replacement-architecture.md),
+[Step 2.3 libkrun cutover note](2026-06-29-adr100-step2.3-libkrun-cutover-plan.md).
+
+## Goal
+
+Make **vsock the sole egress transport for every workload guest** across all
+backends, and **retire the virtio-net / userspace-gateway machinery** on the
+workload path: gvproxy, passt, the in-house rvproxy, the redirect/TLS terminator,
+and the FC nftables install. Egress becomes one host seam — `EgressGate` — fed by
+guest→vsock streams, enforcing claim-10 default-deny and folding the claims-12/13
+credential substitution onto the same path.
+
+Separately, **close the builder VM's claim-10 gap** so its egress is policed and
+recorded, without forcing `nix build` through a vsock proxy.
+
+## Non-goals (explicit)
+
+- **Builder VM egress does NOT move to vsock.** The builder keeps a real NIC +
+  gvproxy/passt because `nix build` fans out to hundreds of parallel HTTPS/DNS/git
+  fetches against binary caches; an L4 vsock proxy sustaining that is novel, risky
+  ("builds break") work with a poor cost/benefit ratio for a trusted first-party
+  box. The builder's *security* requirement — be tracked and monitored — is met by
+  policing + auditing its existing NIC, not by changing its transport. Revisiting
+  builder-over-vsock is deferred and out of scope here.
+- No new inbound/listener model, no UDP/QUIC/raw-IP guest support beyond what the
+  gateway already scopes. ADR-100's "inbound is a host port-forward terminated at
+  the gateway" stands.
+- No change to the control plane — console/exec/file-ops/secrets/broker are already
+  vsock-only on every backend.
+
+## Decision of record: "one policy, two enforcement points"
+
+There are two distinct egress consumers with different trust and traffic profiles;
+we enforce **one policy + audit model** at **two enforcement points**:
+
+| Consumer | Trust | Traffic | Enforcement point |
+|----------|-------|---------|-------------------|
+| Workload guest | untrusted | low-volume TCP/DNS/TLS | **vsock → `EgressGate`** (no NIC) |
+| Builder VM | trusted box running untrusted build inputs | high-volume nix fetcher fan-out | **NIC behind the packet-observer pipeline** (policed + audited) |
+
+This is deliberately *not* "one transport everywhere." Forcing vsock onto the
+builder optimizes architectural purity at the cost of the flakiest, highest-effort
+work in the plan for a marginal gain (uniformity + guest-kernel surface) that does
+not apply to a trusted build box. The security property the user wants — visibility
+and policy on builder egress — is fully delivered by enforcement point #2.
+
+### Consequence for "delete gvproxy/passt entirely"
+
+Under this design gvproxy/passt do **not** reach zero survivors: they shrink to
+**builder-only, and now audited**. rvproxy and the terminator **do** die (they are
+workload gateways). If literal zero-survivors is later deemed a hard requirement,
+that is the deferred builder-over-vsock project, taken on with eyes open.
+
+## Current-state map (where the machinery lives)
+
+- **HVF / in-house `vmm`** — already vsock-only, NIC-free; guarded by
+  `xtask check-vsock-only-egress` (`crates/mvm-backend/src/{vmm,hvf,vsock_egress_bridge}`).
+  This is the reference implementation; the shared core is `EgressGate`
+  (`decide_request("ip:port") -> Allow/Deny/Malformed`, wraps `CanonicalEgress`).
+- **libkrun** (`crates/mvm-backend/src/libkrun.rs`) — attaches a NIC via
+  `with_gvproxy`/`with_passt`; already opens a vsock `SUBSTITUTION_PORT` host-listen
+  channel for claims-12/13; threads `network_policy` to the gateway-bridge. Step 2.3
+  note is the file-level plan; `EgressGate` + `mvm_vm_host::egress_server` +
+  in-guest `mvm-egress-client` are already built and unit-tested.
+- **Firecracker** — NIC + host **nftables default-deny** via
+  `crates/mvm-hostd/src/supervisor/firewall/` (`linux_nft.rs`, `seam.rs`, `mod.rs`);
+  netdev wiring via the FC bridge (`crates/mvm-vm-host/src/firecracker_bridge/`).
+- **vz** (`crates/mvm-backend/src/vz.rs`) — NIC via `mvm_build::host_gvproxy` +
+  `mvm-bridge` sidecar; backend is already being sunset.
+- **Gateway machinery to retire (workload path):**
+  - `crates/mvm-hostd/src/supervisor/gateway_bridge.rs` (4,540 lines)
+  - `crates/mvm-hostd/src/supervisor/network/` (rvproxy_config/launch/policy/flow_audit,
+    pipeline, packet, stages, latency, flow_count, flow_byte_log — 11 files)
+  - `crates/mvm-hostd/src/supervisor/terminator/` (8 files)
+  - `crates/deps/libkrun-sys/src/{gvproxy.rs,passt.rs}` — **retained** (builder needs them)
+- **Packet-observer seam (Plan 141):** `network/pipeline.rs` + `network/mod.rs`
+  (`Verdict`, `on_packet`), consumed by `gateway_bridge.rs`. Currently wraps the
+  **workload** gateway. The **builder** spawns its own gvproxy via
+  `mvm_build::host_gvproxy` and does **not** flow through this pipeline yet — so the
+  builder-monitoring slice is "bring `host_gvproxy` egress under the observer +
+  audit," not a one-line wiring.
+
+## Decomposition (5 slices)
+
+Each slice is independently shippable and independently testable. Sequence is
+workload-first (lowest risk, already teed up), deletion after all workload
+consumers are gone, builder-monitoring in parallel.
+
+### Slice 1 — libkrun workload → vsock
+Execute the Step 2.3 note. Delete the NIC attach (`with_gvproxy`/`with_passt`) on
+the workload path; stand up the host egress server (`mvm_vm_host::egress_server`)
+on a dedicated `EGRESS_PORT` UDS reusing `EgressGate`; fold claims-12/13
+substitution onto the vsock path (security-touching — needs review + a live libkrun
+boot). Host-side DNS via the pin registry.
+**Done when:** a libkrun workload boots with no virtio-net device, egress flows
+guest→vsock→`EgressGate`, claim-10 default-deny holds, claims-12/13 substitution
+still works, live boot verified, and `check-vsock-only-egress` is extended to guard
+`libkrun.rs`.
+
+### Slice 2 — Firecracker workload → vsock
+Delete the FC virtio-net netdev + the nftables `install_default_deny` from the
+workload start path; route FC guest egress through the same vsock `EgressGate`
+server. (Linux-only; validate on KVM.)
+**Done when:** an FC workload boots NIC-free, egress is vsock-mediated through the
+identical gate, the firewall/nft install is gone from the workload path, and the
+gate is extended to guard the FC path.
+
+### Slice 3 — vz workload → vsock (or delete vz)
+vz is already sunset. Prefer **deleting the vz workload backend** outright if no
+consumer remains; otherwise converge it like libkrun. Decide at slice start based
+on vz's live status.
+**Done when:** no vz workload path attaches a NIC — either removed or vsock-mediated.
+
+### Slice 4 — delete the dead workload gateway code
+Once slices 1–3 land and no workload consumer references them, delete
+`gateway_bridge.rs`, `supervisor/network/rvproxy_*` + pipeline/packet/stages, and
+`supervisor/terminator/`. Remove rvproxy config rendering + launch. Keep
+`libkrun-sys/src/{gvproxy,passt}.rs` (builder). Prune dead deps + the `mvm-network`
+provider surfaces no longer used.
+**Done when:** `rg rvproxy crates/` returns only builder/spec hits; the workload
+supervisor no longer compiles the gateway-bridge; CI green.
+
+### Slice 5 — builder VM egress: policed + audited (NIC retained)
+Bring the builder's `mvm_build::host_gvproxy` egress under the Plan 141
+packet-observer pipeline (or an equivalent host seam), wire it to a builder egress
+policy (default-deny-with-nix-cache-allowlist, tunable) and to the chain-signed
+audit log so every builder flow is recorded. NIC stays.
+**Done when:** builder egress flows are visible in the audit chain, a policy can
+deny an off-allowlist destination, and `nix build` throughput is unregressed.
+
+### Dependency graph
+```
+Slice 1 (libkrun) ─┐
+Slice 2 (FC)       ─┼──→ Slice 4 (delete dead gateway code)
+Slice 3 (vz)       ─┘
+Slice 5 (builder monitoring) — independent, parallelizable, blocks nothing
+```
+
+## Security considerations
+
+- **Claims 12/13 move transport.** Substitution shifts off the NIC onto the vsock
+  path (slice 1). This is security-touching: every slice touching substitution
+  needs the rejection-ladder tests re-run (denied destination, zeroize, no raw
+  secret bytes on channel) plus a live boot. Execute with review, not blind.
+- **Claim 10 becomes one seam.** After slices 1–4, the only workload egress
+  enforcement is `EgressGate` on the vsock path — no nftables, no gateway-bridge.
+  Fewer mechanisms to audit; a vsock stream cannot bypass it.
+- **Builder claim-10 gap closes (slice 5).** The builder moves from "open NAT, no
+  per-flow record" to "policed + audited NIC," closing the documented exception
+  where claim-10 default-deny is enforced only on the two workload backends.
+- **`check-vsock-only-egress` expands** its `GUARDED_DIRS` to cover each workload
+  path as it converges (libkrun.rs, the FC start path), so regressions that
+  re-attach a NIC fail closed.
+
+## Testing & gates
+
+- Per-slice: live boot (libkrun on macOS; FC on KVM), claim-10 default-deny
+  positive/negative, claims-12/13 rejection ladder where touched.
+- Expand `xtask check-vsock-only-egress` GUARDED_DIRS incrementally (slices 1–3).
+- `cargo nextest run --workspace` + `cargo test --workspace --doc` + `cargo clippy
+  --workspace -- -D warnings` + `cargo fmt --all -- --check` per slice.
+- Slice 5: an audit-chain assertion that builder flows are recorded; a deny test;
+  a `nix build` throughput sanity check.
+
+## Risks / open questions
+
+1. **Slice 1 substitution fold** is the sharpest edge — moving claims-12/13 onto
+   vsock changes a security-critical path. Mitigation: it is already partly built
+   and the Step 2.3 note has the file-level plan; gate on a live boot.
+2. **vz fate (slice 3)** — confirm at slice start whether vz has any live workload
+   consumer or can simply be deleted.
+3. **Builder observer coverage (slice 5)** — `host_gvproxy` is not currently on the
+   Plan 141 pipeline; scoping must confirm the cleanest way to route builder egress
+   through the observer without regressing `nix build` fan-out. If that proves
+   heavier than expected, fall back to a lighter-weight flow-logging shim on
+   `host_gvproxy` that still feeds the audit chain.
+4. **DNS host-side** — the vsock path resolves DNS via the pin registry; confirm
+   coverage for the destinations real workloads use.

--- a/specs/runbooks/slice1-phase-a-libkrun-vsock-egress.md
+++ b/specs/runbooks/slice1-phase-a-libkrun-vsock-egress.md
@@ -1,0 +1,100 @@
+# Runbook — Slice 1 Phase A: libkrun transparent-TCP vsock egress live verification
+
+**What this proves:** a no-bound-secret libkrun **workload** reaches the network
+through the host vsock `EgressGate` (claim-10) instead of the NIC, when opted in via
+`MVM_VSOCK_EGRESS`, with the gvproxy/passt NIC still attached (Phase A retains it).
+Passing this unblocks **Phase B** (fold claims-12/13 substitution onto the vsock
+front door, delete the NIC, widen `check-vsock-only-egress`).
+
+**Where this must run:** macOS with the `slp/krun/*` Homebrew trio
+(`brew install slp/krun/libkrun slp/krun/libkrunfw slp/krun/gvproxy`). It cannot run
+in CI — the automated gate (below) is green, but the vsock path is only *proven* by a
+live boot.
+
+## Automated gate (already green on this branch)
+
+- `cargo fmt --all -- --check` ✅
+- `cargo clippy --workspace -- -D warnings` ✅
+- `cargo clippy -p mvm-vm-host --features libkrun-sys -- -D warnings` ✅ (lints the cfg-gated egress block)
+- `cargo nextest run --workspace` — see branch status
+- New unit tests: `state_has_bound_secrets_is_false_for_empty_state`, `vsock_egress_opt_in_reads_env`, `serves_only_when_opted_in_no_secrets_and_port_present`, `vsock_egress_cmdline_token_only_when_eligible`.
+
+## Pre-flight
+
+```sh
+# From the worktree. The supervisor bin is NOT rebuilt by test runs — rebuild it,
+# or a stale bin fails the boot with a deny_unknown_fields error.
+cargo build -p mvm-vm-host --bin mvm-libkrun-supervisor --features libkrun-sys
+cargo build
+```
+
+## Step 1 — allow path (the core proof)
+
+Boot a **no-secrets** workload with a network policy that allow-lists exactly one
+`host:port`, with the host opt-in set:
+
+```sh
+MVM_VSOCK_EGRESS=1 <your machine-run invocation> \
+  --network-allow <HOST:PORT>            # a policy admitting one destination
+```
+
+Inside the guest, a proxy-aware client must reach the allow-listed target (mkGuest
+Stage 2.6 exports `ALL_PROXY=socks5h://127.0.0.1:1080`):
+
+```sh
+curl -sS http://<HOST>:<PORT>/...        # honors ALL_PROXY → vsock → EgressGate → allow
+```
+
+Expected: the request succeeds; the host `mvm-libkrun-supervisor` egress server logs
+an accepted flow; the guest never opened a NIC socket to reach it.
+
+## Step 2 — verify the flag actually reached the guest (guards Minor M2)
+
+The in-guest client only starts if `/init` set `MVM_VSOCK_EGRESS`. Confirm the token
+threaded end-to-end:
+
+```sh
+# In the guest console/log:
+cat /proc/cmdline | tr ' ' '\n' | grep mvm.vsock_egress   # expect: mvm.vsock_egress=1
+pgrep -af mvm-egress-client                                # expect: the SOCKS5 client running
+```
+
+**If `mvm.vsock_egress=1` is present on the cmdline but the client did NOT start**,
+the `/init` parse (busybox `grep` BRE `\|`) didn't match — apply the portable fix in
+`nix/lib/mk-guest.nix` Stage 2.55: replace
+`grep -q ' mvm\.vsock_egress=1\( \|$\)'` with `grep -qE ' mvm\.vsock_egress=1( |$)'`
+(ERE), rebuild the image, re-boot.
+
+## Step 3 — deny path
+
+Same VM, a target NOT on the allow-list:
+
+```sh
+curl -sS http://<OTHER_HOST>:<PORT>/...   # expect: failure — EgressGate Deny, never dialed
+```
+
+Expected: connection refused/closed by the host egress server; the target host sees no
+connection.
+
+## Step 4 — confirm the NIC is still attached (Phase A retains it)
+
+```sh
+# In the guest:
+ip link                                    # expect: lo AND the workload NIC present
+```
+
+Phase A does **not** remove the NIC. Phase B is what flips this assertion to "only
+`lo`" once substitution is folded onto the vsock path.
+
+## Step 5 — record results and unblock Phase B
+
+Fill in the actual commands + output below, then author the Phase B plan
+(substitution fold + NIC delete + widen `check-vsock-only-egress`). Phase B is
+security-touching and requires maintainer review per the ADR-100 Step 2.3 note.
+
+| Check | Command | Expected | Actual |
+|-------|---------|----------|--------|
+| allow-path fetch | (Step 1) | 200/success | _TBD on hardware_ |
+| flag reached guest | (Step 2) | token + client running | _TBD_ |
+| deny-path fetch | (Step 3) | refused | _TBD_ |
+| NIC retained | (Step 4) | NIC + lo | _TBD_ |


### PR DESCRIPTION
## What & why

First slice of the vsock-only egress cutover (ADR-100, Accepted). Lights up a **transparent-TCP vsock egress path** on the libkrun backend: a **no-bound-secret** workload reaches the network through the host vsock `EgressGate` (claim-10) instead of the gvproxy/passt NIC, **opt-in behind `MVM_VSOCK_EGRESS`**, with the **NIC retained** so the change is reversible and non-regressing.

The in-guest egress client (`mvm-egress-client`), its nix package, and mkGuest Stage 2.6 already existed but were **inert** — nothing set `MVM_VSOCK_EGRESS`. This branch wires the host + guest ends so the path actually activates.

Design + decomposition: `specs/notes/2026-07-05-vsock-only-egress-cutover-path-a-design.md`
Plan: `specs/notes/2026-07-05-slice1-libkrun-vsock-egress-phase-a-plan.md`

## What's in it

- `state_has_bound_secrets` (pub) + `pub mod egress_shared` — secrets-presence gate.
- `vsock_egress_opt_in()` — host `MVM_VSOCK_EGRESS` reader.
- `should_serve_vsock_egress` — pure predicate: serve iff `opt_in && !has_bound_secrets && EGRESS_PORT present`.
- Supervisor wiring: `mvm-libkrun-supervisor` binds `EGRESS_PORT` and runs `egress_server::run` (gated), inside a tokio runtime.
- Guest activation: host emits `mvm.vsock_egress=1` on the kernel cmdline; mkGuest `/init` parses it into `MVM_VSOCK_EGRESS` (mirrors the existing `mvm.secret_env` / `mvm.verb_grant` cmdline tokens — **not** `with_guest_envp`, which is the builder/command path and doesn't apply to a rootfs-boot workload).

## Gating / safety

- Flag off **or** a workload carrying bound secrets ⇒ **byte-identical legacy NIC path** (no cmdline mutation, no UDS bind). NIC is **not** removed here.
- No `EGRESS_PORT` collision: the substitution endpoint owns that UDS when secrets are present; the transparent egress server binds it only when `should_serve_vsock_egress` is true (which requires no secrets).
- Fail-closed: absent/undecodable network policy ⇒ `NetworkPolicy::deny_all`.

## Reviews

Two whole-branch reviews. The background reviewer caught a **Critical**: `tokio::net::UnixListener::bind` was called on a non-tokio thread outside any runtime → would **panic** the supervisor on the first `MVM_VSOCK_EGRESS=1` boot (invisible to CI — no test drives the bin's dispatch path). **Fixed** (`6b1ad4ff`): bind moved inside the runtime via `rt.enter()`, mirroring the `gateway_bridge` runtime-first pattern. Also fixed M2 (portable ERE grep in `/init`) and added an opt-in short-circuit so the flag-off path does zero extra I/O.

**Non-blocking fast-follow** (both reviewers agreed): thread `has_bound_secrets` through `SupervisorConfig` once instead of re-deriving it in two processes — matters more at Phase B; harmless at Phase A given opt-in + NIC retained.

## Verification

`cargo fmt --all --check` ✅ · `cargo clippy --workspace -D warnings` ✅ · `cargo clippy -p mvm-vm-host --features libkrun-sys -D warnings` ✅ (lints the cfg-gated egress block) · `cargo nextest run --workspace` ✅ **6919/6919** · `cargo test --workspace --doc` ✅.

⚠️ **Live libkrun boot NOT yet run** — needs macOS + the `slp/krun` trio. Runbook: `specs/runbooks/slice1-phase-a-libkrun-vsock-egress.md` (allow/deny fetch through `ALL_PROXY`, confirm the flag threads to the guest, NIC still present). Phase A is gate-green but not *proven* end-to-end until that passes.

## Next

**Phase B** (separate, review-gated): fold claims-12/13 credential substitution onto the vsock front door, **delete the NIC (gvproxy/passt/rvproxy/terminator)**, widen `check-vsock-only-egress`. Authored only after this boots clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)