### PR TITLE
docs(plan): Plan 228 — release 0.17.0 (HVF default, working & documented)

### DIFF
--- a/specs/plans/228-release-0-17-0.md
+++ b/specs/plans/228-release-0-17-0.md
@@ -1,0 +1,174 @@
+# Plan 228 — Release 0.17.0: "HVF default, working & documented"
+
+**Status: PROPOSED**
+**Created: 2026-07-06**
+**Scope decision:** narrow (owner, 2026-07-06) — make the already-shipped HVF arc
+coherent, working, and documented. Snapshot/instant-resume (Plan 227) is the
+*next* release (0.18.0), not a gate on this one.
+
+## Why this release
+
+The macOS-26 HVF-in-house arc already shipped under the hood (tags v0.15.2,
+v0.16.0, v0.16.1) but is **undocumented and functionally incomplete on its
+default platform**:
+
+- **Release pipeline is fully automated** on tag push (binaries + builder /
+  runtime-overlay / default-microVM images + GitHub Release with SBOM+cosign +
+  PyPI + npm + Homebrew; crates.io is a manual `workflow_dispatch`). Cutting a
+  release is `just release-auto`.
+- **The CHANGELOG silently broke three releases ago.** `git-cliff --prepend`
+  failed on v0.15.2 / v0.16.0 / v0.16.1; CHANGELOG.md still ends at 0.15.1 with
+  ~1,215 undocumented commits behind it. A release whose changelog can't answer
+  "what's in 0.16.1?" violates the project's "stated explicitly" promise.
+- **The macOS-26 default backend can't finish a `machine run`.** #1482 fixed HVF
+  routing + host→guest transport reachability, but the in-house guest agent does
+  not reply to the `ProtocolHello`, so non-interactive `machine run -- <cmd>`
+  hangs then times out. This is the one true functional release blocker.
+- **The 15 open issues contain no hard blockers** — several are already fixed or
+  Vz-obsoleted (immediate closes); the rest are DX/live-validation, deferrable.
+
+Goal of 0.17.0: on macOS 26 (the default tier) `mvmctl machine run --image
+alpine -- <cmd>` works end-to-end, and the release is honestly documented.
+
+## Definition of done (release gate)
+
+- [ ] macOS 26 default (`hvf`): `machine run --image alpine -- sh -c 'echo ok'`
+      returns `ok`; `-it` shell works; a Nix-flake workload boots and runs.
+- [ ] CHANGELOG.md documents 0.15.2 → 0.17.0; the `just release-auto` flow can
+      no longer silently drop entries.
+- [ ] Stale issues closed with evidence; live-gated issues labelled.
+- [ ] No doc-vs-code drift in the security claims (ADR-002 ↔ claim-3 scoping).
+- [ ] All CI green: ci.yml (6 jobs) + security.yml (14 jobs).
+- [ ] `just release-auto` → tag → automated pipeline → `verify-release` gate green.
+
+## Explicitly OUT of scope (→ 0.18.0 / Plan 227)
+
+- Snapshot / pause / fork on HVF (227 WS-E), facade lifecycle ops (227 WS-F),
+  vsock-only builder/libkrun cutover (227 WS-B), PII masking (227 WS-G).
+- Plan 214 VmmDriver seam unification — a refactor, **not** a release gate: HVF
+  already works via the current backend path. Landing it does not change what
+  0.17.0 ships.
+- Vz deletion (Plan 222) — Vz stays as the opt-in `--hypervisor vz` fallback; it
+  is not on the default path and does not block the release.
+
+## Workstreams
+
+### WS-1 — HVF guest agent reply (P0, the functional gate)
+
+The in-house guest agent receives the host's `ProtocolHello` (host delivery of
+the 133-byte `OP_RW` into the guest RX queue is instrumented and proven) but
+sends no reply, so `wait_for_agent` → `negotiate_protocol` blocks. FC works with
+the same agent, isolating the defect to the in-house virtio-vsock device ↔ guest
+driver interaction.
+
+- [ ] **WS-1.1** Root-cause: live device+guest trace comparing `OP_REQUEST`
+      (works) vs the post-handshake `OP_RW` (delivered but no reply). Candidate
+      causes to probe live: guest rx-buffer size vs the 44+133-byte frame;
+      feature/event-queue negotiation; the guest driver dropping `OP_RW` when the
+      accepted connection isn't yet in its accept queue. Requires a working boot
+      (recover the builder first: `rm -rf ~/.cache/mvm/builder-vm` if the store is
+      degraded).
+- [ ] **WS-1.2** Fix at the device (or guest-driver) level with a regression test
+      (a loopback guest-driver harness in `crates/mvm-backend/src/vmm/`).
+- [ ] **WS-1.3** Send `OP_RST` to the guest when the host side of an agent stream
+      closes — `agent_bridge::close()` today leaks a guest half-open connection
+      per dropped `for_vm` probe.
+- [ ] **Acceptance:** the three default-tier checks in Definition of Done pass on
+      macOS 26 with no `--hypervisor` flag.
+
+*Note: this is a systematic-debugging task requiring live boots on the Mac, not a
+spec-complete mechanical task — execute it under superpowers:systematic-debugging,
+not as a blind implementer dispatch.*
+
+### WS-2 — CHANGELOG reconstruction + release-flow repair (P1)
+
+- [ ] **WS-2.1** Reconstruct CHANGELOG entries for 0.15.2, 0.16.0, 0.16.1 from
+      `git log v0.15.1..<tag>` grouped by the shipped arcs (HVF in-house default,
+      virtiofs-root, storage providers, snapshot crypto, network observability,
+      signed-plan enforcement, README rewrite, MachineSpec builder).
+- [ ] **WS-2.2** Fix `just release-auto` so a failed/empty git-cliff prepend
+      **fails the recipe** instead of silently continuing (assert the changelog
+      grew and contains the new version before commit/tag).
+- [ ] **Acceptance:** CHANGELOG covers every shipped tag; a dry-run of the release
+      recipe on a scratch version demonstrates it aborts when the changelog
+      doesn't update.
+
+### WS-3 — Issue-tracker cleanup (P1)
+
+- [ ] **WS-3.1** Close with evidence: **#1403** (in-house builder CLI-selectable,
+      e47cf5ae), **#1270** (Vz-only lock, obsoleted by HVF default), **#1405**
+      (operator cache action, flake-slot kernel fixed #1435), **#1458**
+      (ADR-109 future seam), **#1156** (dev-shell agent cache 85222658 — verify
+      present on main first).
+- [ ] **WS-3.2** Label as live-validation-gated (keep open): **#1462**, **#1478**
+      (fs_quick de-Vz done, vm_full pending), **#1227**, **#1404**.
+- [ ] **WS-3.3** Confirm-then-defer to 0.18.0: **#1280**, **#1283**, **#1366**,
+      **#1229**, **#1264** (kernel-pin watcher already advisory).
+- [ ] **Acceptance:** open-issue count reflects reality; every remaining issue has
+      a current status label.
+
+### WS-4 — Security-doc drift fix (P1)
+
+- [ ] **WS-4.1** Cross-link ADR-002's claim table to the claim-3 backend scoping
+      (virtiofs-root / Plan 221 Option A has a weaker integrity contract than
+      block+ext4; catalog.md already scopes it, ADR-002's table does not say so).
+- [ ] **WS-4.2** Confirm `xtask check-claim-catalog` + `check-no-overclaim` pass
+      and that the README's 15-claim summary matches the catalog.
+- [ ] **Acceptance:** a reader of ADR-002 alone cannot mistake claim 3 as
+      universal; claim gates green.
+
+### WS-5 — Land in-flight follow-ups (P1)
+
+- [ ] **WS-5.1** Merge **#1485** (MachineSpec builder + example refresh + Rust SDK
+      docs) — already open, auto-merge armed.
+- [ ] **Acceptance:** builder + refreshed examples/docs on main.
+
+### WS-6 — Cut the release (P0, last)
+
+- [ ] **WS-6.1** Verify CI green on the release commit (6 ci.yml + 14 security.yml
+      jobs); confirm the 10 ignored RUSTSEC advisories haven't grown.
+- [ ] **WS-6.2** `just release-auto` (git-cliff bumps 0.16.1 → 0.17.0 from the
+      conventional commits, prepends the changelog, tags, pushes).
+- [ ] **WS-6.3** Watch the automated pipeline; confirm the `verify-release` job
+      (checksums + cosign + SBOM + version match) passes.
+- [ ] **WS-6.4** Manually dispatch `publish-crates.yml` (the one non-auto step),
+      dry-run first.
+- [ ] **Acceptance:** `install.sh` fetches 0.17.0; `mvmctl --version` → 0.17.0;
+      PyPI/npm/Homebrew updated.
+
+## Sequencing
+
+```
+WS-5 (#1485, in flight)   ─┐
+WS-2 CHANGELOG + flow ─────┤
+WS-3 issue cleanup ────────┼─► (P1 done, parallel, low-risk)
+WS-4 doc drift ────────────┘
+WS-1 HVF agent reply ──────────► (P0 functional gate — the long pole)
+                                        │
+                                        ▼
+                              WS-6 cut 0.17.0
+```
+
+WS-2/3/4/5 are independent and can land in any order (mechanical/doc). WS-1 is
+the long pole and gates WS-6. Do not tag until WS-1 acceptance passes on a real
+macOS-26 boot.
+
+## Risks
+
+- **WS-1 depth.** The guest-no-reply is a subtle virtio-vsock interaction; the
+  investigation this session cleared the host device path by static review, so
+  the fix likely lives in the guest driver/agent or a rx-buffer/credit edge —
+  requires live iteration and possibly a guest-image rebuild. If it slips, the
+  fallback is the "doc/hygiene 0.16.2" path (WS-2/3/4 only) so the shipped line
+  is at least documented while WS-1 continues.
+- **CHANGELOG force-push.** Reconstructing entries for already-pushed tags means
+  either amending history (avoid) or documenting them forward in the 0.17.0
+  entry with a "previously shipped in 0.16.x" note. Prefer forward-documenting.
+- **crates.io manual step.** Easy to forget post-tag; WS-6.4 makes it explicit.
+
+## Execution note
+
+P1 workstreams (WS-2/3/4/5) are clean enough for subagent-driven execution or
+direct completion. WS-1 is a live debugging task — run it under
+superpowers:systematic-debugging with real boots, not a spec-blind implementer.
+WS-6 is an owner-gated action (tagging a public release).


### PR DESCRIPTION
Release plan for the next cut, synthesized from a four-axis audit of `main` (in-flight plan status via REFACTOR-STATUS, triage of all 15 open issues, the snapshot capability matrix, and release mechanics + CHANGELOG + ADR/claim drift). **Docs only.**

## Scope (narrow, owner-decided)

Make the already-shipped macOS-26 **HVF in-house** arc *work end-to-end and be honestly documented*. Snapshot / instant-resume (Plan 227) and the Plan 214 seam unification are explicitly **not** gates on this release — they're 0.18.0.

## Key findings baked in

- **Release pipeline is fully automated on tag push** (binaries + images + GitHub Release w/ SBOM+cosign + PyPI + npm + Homebrew; crates.io the one manual step). Cutting a release is `just release-auto`.
- **The CHANGELOG silently broke three releases ago** — tags v0.15.2 / v0.16.0 / v0.16.1 all shipped but `git-cliff --prepend` failed each time; CHANGELOG ends at 0.15.1 with ~1,215 undocumented commits.
- **The one true functional blocker:** the macOS-26 default (`hvf`) can't finish a non-interactive `machine run` — #1482 fixed routing+transport, but the in-house guest agent doesn't reply to the `ProtocolHello` (host delivery proven; FC works with the same agent, isolating it to the in-house vsock device↔guest-driver path).
- **No hard blockers in the 15 open issues** — several already fixed or Vz-obsoleted (immediate closes); the rest DX/live-validation, deferrable.

## Workstreams

WS-1 HVF guest-agent reply (P0, the gate — a systematic-debugging task, live boots) · WS-2 CHANGELOG reconstruction + release-flow repair · WS-3 issue cleanup · WS-4 ADR-002↔claim-3 doc-drift fix · WS-5 land in-flight #1485 · WS-6 cut 0.17.0.

`check-spec-numbers` + `check-no-spec-refs-in-comments` clean.

Fallback if WS-1 slips: a doc/hygiene **0.16.2** (WS-2/3/4 only) so the shipped line is documented while the HVF fix continues.