### PR TITLE
docs: refresh CLI command tree (compile→build compile, up→machine run)

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,7 +108,7 @@ mvmctl dev down
 ### Examples
 
 Working example workloads live in [`examples/`](examples/) — build any of them
-with `mvmctl machine run --flake examples/<name>` (Nix) or `mvmctl compile`
+with `mvmctl machine run --flake examples/<name>` (Nix) or `mvmctl build compile`
 (SDK):
 
 | Example | Kind | What it shows |
@@ -192,7 +192,7 @@ form keeps a console. See the
 ### 3. From a decorated function (SDK)
 
 Write an ordinary function; the decorator declares the image, resources, deps,
-and env around it. `mvmctl compile` reads the file **statically** (it is never
+and env around it. `mvmctl build compile` reads the file **statically** (it is never
 executed on the host) and emits the flake + launch plan:
 
 ```python
@@ -211,9 +211,12 @@ def greet(name: str) -> str:
 ```
 
 ```bash
-mvmctl compile app.py          # static parse (no execution) → flake.nix + launch plan
-mvmctl machine run --flake .   # build + boot
-mvmctl invoke greet --input name=ari    # dispatch greet(name="ari") over vsock → "hello ari"
+mvmctl build compile app.py --out ./out   # static parse (no execution) → ./out (flake.nix + launch plan)
+mvmctl machine build --flake ./out        # build the image inside the builder VM
+
+# Dispatch greet(name="ari"): the entrypoint payload is [args, kwargs] JSON on stdin
+# (empty stdin ⇒ the default no-arg payload `[[], {}]`).
+echo '[[], {"name": "ari"}]' | mvmctl machine run --entrypoint --flake ./out   # → "hello ari"
 ```
 
 At build time the `@mvm.app` decorator and the `mvm` import are **stripped** from
@@ -234,7 +237,7 @@ fixtures so no SDK can drift from `mvmctl`.
 Declare a workload where it lives. `@mvm.app(...)` (Python) / `mvm.app({...})`
 (TypeScript) is higher-order: it records the declaration and returns your
 function unchanged, so the same file still runs normally under `python` / `tsx`
-and is *also* read statically by `mvmctl compile`.
+and is *also* read statically by `mvmctl build compile`.
 
 <table>
 <tr><th>Python</th><th>TypeScript</th></tr>

--- a/public/src/content/docs/architecture/control-surfaces.mdx
+++ b/public/src/content/docs/architecture/control-surfaces.mdx
@@ -33,9 +33,9 @@ cover an operation.
 Use `mvmctl` for the full local lifecycle:
 
 ```sh
-mvmctl build ./agent
-mvmctl up ./agent --name agent-dev
-mvmctl exec agent-dev -- python /work/task.py
+mvmctl machine build --flake ./agent
+mvmctl machine run --flake ./agent --name agent-dev -d
+mvmctl machine exec agent-dev -- python /work/task.py
 mvmctl machine logs agent-dev
 mvmctl machine stop agent-dev
 ```

--- a/public/src/content/docs/console/attach.md
+++ b/public/src/content/docs/console/attach.md
@@ -6,7 +6,7 @@ description: Open an interactive shell to a running microVM.
 Start a development microVM, then attach:
 
 ```sh
-mvmctl up ./my-app --name devbox
+mvmctl machine run --flake ./my-app --name devbox -d
 mvmctl machine console devbox
 ```
 
@@ -23,7 +23,7 @@ mvmctl machine console devbox --command "id && uname -a"
 Use this for terminal-shaped checks. For normal automation, prefer:
 
 ```sh
-mvmctl exec devbox -- id
+mvmctl machine exec devbox -- id
 mvmctl proc start devbox -- python /work/task.py
 ```
 
@@ -36,7 +36,7 @@ Console behavior depends on the active backend and image mode:
 - Terminal resize, signal forwarding, and scrollback are backend-specific.
 - Console sessions end when the VM stops.
 
-When a backend cannot provide a console, use `mvmctl machine logs`, `mvmctl exec`, and
+When a backend cannot provide a console, use `mvmctl machine logs`, `mvmctl machine exec`, and
 guest readiness probes to debug the workload.
 
 ## Security checklist

--- a/public/src/content/docs/console/index.md
+++ b/public/src/content/docs/console/index.md
@@ -7,7 +7,7 @@ The console is the human debugging path into a running microVM. Use it when
 you need a terminal, a shell prompt, or a one-off command with terminal
 semantics.
 
-Programmatic automation should usually use `mvmctl exec`, `mvmctl proc`, or
+Programmatic automation should usually use `mvmctl machine exec`, `mvmctl proc`, or
 the SDK runtime surface instead. Those paths are easier to script, test, and
 audit.
 
@@ -24,20 +24,20 @@ for production workloads.
 ## Common commands
 
 ```sh
-mvmctl up ./my-app --name devbox
+mvmctl machine run --flake ./my-app --name devbox -d
 mvmctl machine console devbox
 mvmctl machine console devbox --command "uname -a"
 ```
 
 Use `--command` for a one-shot shell command when you want console transport
-but not an interactive session. Use `mvmctl exec` for normal automation.
+but not an interactive session. Use `mvmctl machine exec` for normal automation.
 
 ## When to use which surface
 
 | Need | Prefer |
 | --- | --- |
 | Human debugging | `mvmctl machine console <name>` |
-| Scripted command execution | `mvmctl exec <name> -- <cmd>` |
+| Scripted command execution | `mvmctl machine exec <name> -- <cmd>` |
 | Process lifecycle control | `mvmctl proc start/list/wait/kill` |
 | File transfer | `mvmctl machine fs` or `mvmctl cp` |
 | Service logs | `mvmctl machine logs <name>` |

--- a/public/src/content/docs/console/transparent-rebuild.md
+++ b/public/src/content/docs/console/transparent-rebuild.md
@@ -16,9 +16,9 @@ workspace state remains available.
 
 ```sh
 $EDITOR flake.nix
-mvmctl build ./my-app
+mvmctl machine build --flake ./my-app
 mvmctl machine stop devbox
-mvmctl up ./my-app --name devbox
+mvmctl machine run --flake ./my-app --name devbox -d
 mvmctl machine console devbox
 ```
 

--- a/public/src/content/docs/contributing/adr/001-multi-backend.md
+++ b/public/src/content/docs/contributing/adr/001-multi-backend.md
@@ -37,7 +37,7 @@ Use Firecracker as the primary production backend. Support multiple backends: Ap
 3. **Docker running** -- Docker as container-based fallback
 4. **Other** (macOS Intel, Linux without KVM, native Windows, WSL2) -- unsupported for local microVM isolation today; Docker remains a Tier 3 convenience fallback only
 
-Override with `--hypervisor firecracker`, `--hypervisor apple-container`, `--hypervisor qemu`, or `--hypervisor docker`.
+Override with `--hypervisor firecracker`, `--hypervisor vz`, `--hypervisor qemu`, or `--hypervisor docker`.
 
 ## Consequences
 

--- a/public/src/content/docs/contributing/development.md
+++ b/public/src/content/docs/contributing/development.md
@@ -251,7 +251,7 @@ just run -- image fetch minimal     # build from catalog entry
 # Named dev networks
 just run -- network create isolated # create a named network
 just run -- network list            # list all networks
-just run -- up --flake . --network isolated  # attach VM to a network
+just run -- up --flake .  # attach VM to a network
 
 # Interactive console (PTY-over-vsock, no SSH)
 just run -- console myvm            # interactive shell

--- a/public/src/content/docs/examples/ai-agent-sandbox.md
+++ b/public/src/content/docs/examples/ai-agent-sandbox.md
@@ -22,8 +22,8 @@ Keep the flake pinned. Add only the packages the tool needs.
 ## Run a tool call
 
 ```sh
-mvmctl up . --name agent-tool
-mvmctl exec agent-tool -- python /work/tool.py
+mvmctl machine run --flake . --name agent-tool -d
+mvmctl machine exec agent-tool -- python /work/tool.py
 ```
 
 For one-off calls:

--- a/public/src/content/docs/examples/code-interpreter.md
+++ b/public/src/content/docs/examples/code-interpreter.md
@@ -20,9 +20,9 @@ Use this shape for stateless calls where every invocation should start clean.
 
 ```sh
 mvmctl init ./interpreter --preset python
-mvmctl build ./interpreter
-mvmctl up ./interpreter --name interpreter
-mvmctl exec interpreter -- python /work/run_cell.py
+mvmctl machine build --flake ./interpreter
+mvmctl machine run --flake ./interpreter --name interpreter -d
+mvmctl machine exec interpreter -- python /work/run_cell.py
 ```
 
 Use a named VM when you intentionally want cached packages, files, or session

--- a/public/src/content/docs/examples/dev-vm-from-flake.md
+++ b/public/src/content/docs/examples/dev-vm-from-flake.md
@@ -21,12 +21,12 @@ runtime sizing.
 ## Build and boot
 
 ```sh
-mvmctl build ./my-dev-vm
-mvmctl up ./my-dev-vm --name my-dev-vm
+mvmctl machine build --flake ./my-dev-vm
+mvmctl machine run --flake ./my-dev-vm --name my-dev-vm -d
 mvmctl machine console my-dev-vm
 ```
 
-Use `mvmctl exec` for scripted commands and `mvmctl machine console` for interactive
+Use `mvmctl machine exec` for scripted commands and `mvmctl machine console` for interactive
 debugging.
 
 ## Iterate
@@ -34,9 +34,9 @@ debugging.
 ```sh
 $EDITOR flake.nix
 nix flake update
-mvmctl build ./my-dev-vm
+mvmctl machine build --flake ./my-dev-vm
 mvmctl machine stop my-dev-vm
-mvmctl up ./my-dev-vm --name my-dev-vm
+mvmctl machine run --flake ./my-dev-vm --name my-dev-vm -d
 ```
 
 Only update `flake.lock` when you intend to change inputs. Review that diff.

--- a/public/src/content/docs/getting-started/connect-an-llm.mdx
+++ b/public/src/content/docs/getting-started/connect-an-llm.mdx
@@ -81,9 +81,9 @@ For repeated calls, build and boot a named sandbox instead:
 
 ```sh
 mvmctl init ./llm-tool --preset python
-mvmctl build ./llm-tool
-mvmctl up ./llm-tool --name llm-tool
-mvmctl exec llm-tool -- python /work/tool.py
+mvmctl machine build --flake ./llm-tool
+mvmctl machine run --flake ./llm-tool --name llm-tool -d
+mvmctl machine exec llm-tool -- python /work/tool.py
 ```
 
 ## Security checklist

--- a/public/src/content/docs/getting-started/first-microvm.md
+++ b/public/src/content/docs/getting-started/first-microvm.md
@@ -10,9 +10,9 @@ This guide walks through writing a Nix flake that builds a microVM image, then b
 mvmctl auto-selects the best backend for your platform:
 
 ```
-Linux (KVM):       mvmctl up  -->  Firecracker microVM (direct)
-macOS 26+ (AS):    mvmctl up  -->  Vz microVM (Apple Virtualization.framework)
-macOS 13-25 (AS):  mvmctl up  -->  libkrun microVM
+Linux (KVM):       mvmctl machine run  -->  Firecracker microVM (direct)
+macOS 26+ (AS):    mvmctl machine run  -->  Vz microVM (Apple Virtualization.framework)
+macOS 13-25 (AS):  mvmctl machine run  -->  libkrun microVM
 ```
 
 | Layer | Access command | Has your project files? |
@@ -84,20 +84,21 @@ With a `mvm.toml` next to `flake.nix`:
 
 ```bash
 # Build (manifest discovered from cwd)
-mvmctl build
+mvmctl machine build
 
 # Boot (auto-selects best backend)
-mvmctl up
+mvmctl machine run --manifest .
 
-# Or run in background with port forwarding
-mvmctl up -d -p 8080:8080
+# Or run in the background, then forward a port
+mvmctl machine run --manifest . --name my-vm -d
+mvmctl machine forward my-vm -p 8080:8080
 ```
 
 Without a `mvm.toml` (just a flake), pass `--flake` explicitly — that legacy path still works:
 
 ```bash
 mvmctl build --flake .
-mvmctl up --flake . --cpus 2 --memory 1024
+mvmctl machine run --flake . --cpus 2 --memory 1024
 ```
 
 ## Check Status
@@ -119,7 +120,7 @@ mkdir -p /tmp/config /tmp/secrets
 echo '{"port": 8080}' > /tmp/config/app.json
 echo 'API_KEY=sk-...' > /tmp/secrets/app.env
 
-mvmctl up --flake . \
+mvmctl machine run --flake . \
     -v /tmp/config:/mnt/config \
     -v /tmp/secrets:/mnt/secrets
 ```

--- a/public/src/content/docs/getting-started/happy-paths.md
+++ b/public/src/content/docs/getting-started/happy-paths.md
@@ -61,7 +61,7 @@ booted from it.
 
 ```bash
 mvmctl doctor --workflow cli-run                # preflight
-mvmctl up --flake . --cpus 2 --memory 1024      # build + boot
+mvmctl machine run --flake . --cpus 2 --memory 1024      # build + boot
 mvmctl machine stop --all                                     # tear down
 ```
 
@@ -76,7 +76,7 @@ source checkout); subsequent runs reuse the warm builder. Skip the
   owns Nix; the host doesn't need it.
 - `dev VM not running — run mvmctl dev up to verify` → that's just
   doctor telling you tool checks were skipped because the builder
-  VM is asleep. It's not a failure; `mvmctl up` boots it on
+  VM is asleep. It's not a failure; `mvmctl machine run` boots it on
   demand.
 - `disk space < N GiB` → free space on `~/.mvm/` (default cache
   location); `mvmctl cache info` shows what's there.
@@ -136,7 +136,7 @@ to launch.
 
 ```bash
 mvmctl doctor --workflow bundle-run             # preflight (no host rust needed)
-mvmctl up --bundle ./my-app.mvmpkg              # boot
+mvmctl machine check-artifact ./my-app.mvm   # verify the signed artifact before launch
 mvmctl machine stop --all                                     # tear down
 ```
 

--- a/public/src/content/docs/getting-started/happy-paths.md
+++ b/public/src/content/docs/getting-started/happy-paths.md
@@ -89,13 +89,15 @@ callable function.
 
 ```bash
 mvmctl doctor --workflow python-sdk                              # preflight
-mvmctl compile my_app.py --out /tmp/my-app && mvmctl up my-app   # compile + boot
-mvmctl invoke my-app --input name='ari'                          # call
+mvmctl build compile my_app.py --out /tmp/my-app                 # compile (static parse)
+echo '[[], {"name":"ari"}]' | \
+  mvmctl machine run --entrypoint --flake /tmp/my-app            # build + boot + call → "hello ari"
 ```
 
-`mvmctl compile` parses the decorator statically; user code does not
-execute on the host (only inside the microVM). `mvmctl invoke` accepts
-function arguments via `--input key=value` (repeatable). See
+`mvmctl build compile` parses the decorator statically; user code does not
+execute on the host (only inside the microVM). `mvmctl machine run --entrypoint`
+invokes the baked function, taking its arguments as an `[args, kwargs]` JSON
+payload on stdin (empty ⇒ `[[], {}]`). See
 [SDK guide](/guides/sdk/) for the decorator surface.
 
 **Failure recovery:**
@@ -113,8 +115,9 @@ Same shape as the Python flow with a `.ts` (or `.js`) entry file.
 
 ```bash
 mvmctl doctor --workflow typescript-sdk                          # preflight
-mvmctl compile my-app.ts --out /tmp/my-app && mvmctl up my-app   # compile + boot
-mvmctl invoke my-app --input name='ari'                          # call
+mvmctl build compile my-app.ts --out /tmp/my-app                 # compile (static parse)
+echo '[[], {"name":"ari"}]' | \
+  mvmctl machine run --entrypoint --flake /tmp/my-app            # build + boot + call → "hello ari"
 ```
 
 The preflight specifically checks the local TypeScript runner

--- a/public/src/content/docs/getting-started/installation.md
+++ b/public/src/content/docs/getting-started/installation.md
@@ -138,10 +138,10 @@ Running `mvmctl dev` or `mvmctl bootstrap` also handles setup automatically -- t
 You can force a specific backend with `--hypervisor`:
 
 ```bash
-mvmctl up --flake . --hypervisor firecracker  # Linux KVM
-mvmctl up --flake . --hypervisor vz           # macOS 26+ Apple Silicon
-mvmctl up --flake . --hypervisor libkrun      # macOS 13–25 Apple Silicon
-mvmctl up --flake . --hypervisor qemu         # microvm.nix — dev/test only
+mvmctl machine run --flake . --hypervisor firecracker  # Linux KVM
+mvmctl machine run --flake . --hypervisor vz           # macOS 26+ Apple Silicon
+mvmctl machine run --flake . --hypervisor libkrun      # macOS 13–25 Apple Silicon
+mvmctl machine run --flake . --hypervisor qemu         # microvm.nix — dev/test only
 ```
 
 Use `mvmctl doctor` to check which backends are available on your system.

--- a/public/src/content/docs/getting-started/nix-for-mvm.mdx
+++ b/public/src/content/docs/getting-started/nix-for-mvm.mdx
@@ -7,7 +7,7 @@ You don't need to be a Nix expert to use mvm. This guide teaches you exactly wha
 
 ## What you're building
 
-By the end of this guide, you'll have a `flake.nix` file that tells mvm how to build a VM image containing your app. Running `mvmctl build --flake .` will produce a bootable microVM from that file.
+By the end of this guide, you'll have a `flake.nix` file that tells mvm how to build a VM image containing your app. Running `mvmctl machine build --flake .` will produce a bootable microVM from that file.
 
 Here's the end result — don't worry about understanding it yet:
 
@@ -169,7 +169,7 @@ packages.${system}.default = mvm.lib.${system}.mkGuest {
 
 `mkGuest` is the mvm function that builds a complete microVM image. It handles the kernel, init system, guest agent, networking, and drive mounting — you just describe what you want inside the VM.
 
-**`packages.${system}.default`** — this is the standard Nix way to declare a build output. `mvmctl build --flake .` looks for this by default.
+**`packages.${system}.default`** — this is the standard Nix way to declare a build output. `mvmctl machine build --flake .` looks for this by default.
 
 ## Step 5: Add packages
 
@@ -255,13 +255,14 @@ You now have a complete flake. Build and boot it with port forwarding so you can
 
 ```bash
 # Build the VM image
-mvmctl build --flake .
+mvmctl machine build --flake .
 
-# Boot with port forwarding — map host port 8080 to guest port 8080
-mvmctl up --flake . --cpus 2 --memory 1024 -p 8080:8080
+# Boot a named machine in the background, then forward host port 8080 → guest 8080
+mvmctl machine run --flake . --name hello --cpus 2 --memory 1024 -d
+mvmctl machine forward hello -p 8080:8080
 ```
 
-The `-p 8080:8080` flag forwards port 8080 on your host to port 8080 inside the microVM. Without it, the service runs but isn't accessible from outside the VM.
+`machine forward` maps port 8080 on your host to port 8080 inside the microVM. Without it, the service runs but isn't reachable from outside the VM.
 
 Once it's running, open your browser to [http://localhost:8080](http://localhost:8080). You should see:
 
@@ -277,7 +278,7 @@ mvmctl ls
 mvmctl machine logs hello -f
 
 # Forward additional ports from a running VM
-mvmctl forward hello -p 9090:9090
+mvmctl machine forward hello -p 9090:9090
 
 # Stop it
 mvmctl machine stop hello
@@ -286,9 +287,10 @@ mvmctl machine stop hello
 The first build downloads dependencies and takes a few minutes. Subsequent builds with the same `flake.lock` can be much faster because Nix reuses cached inputs and build outputs.
 
 :::tip[Run in the background]
-Add `-d` to run detached (like `docker run -d`):
+`-d` runs the machine detached (like `docker run -d`); forward ports separately:
 ```bash
-mvmctl up --flake . -d -p 8080:8080
+mvmctl machine run --flake . --name hello -d
+mvmctl machine forward hello -p 8080:8080
 ```
 :::
 
@@ -296,12 +298,13 @@ mvmctl up --flake . -d -p 8080:8080
 
 Volumes let you pass files from your host into the microVM at boot — config files, secrets, or persistent data:
 
-```bash "-v"
+```bash
 # Mount host directories into the VM
-mvmctl up --flake . -p 8080:8080 \
-    -v ./config:/mnt/config \
-    -v ./secrets:/mnt/secrets \
-    -v ./data:/mnt/data:1024
+mvmctl machine run --flake . --name hello -d \
+    --volume ./config:/mnt/config \
+    --volume ./secrets:/mnt/secrets \
+    --volume ./data:/mnt/data:1024
+mvmctl machine forward hello -p 8080:8080
 ```
 
 Inside the guest, the files appear at the mount paths:
@@ -316,9 +319,10 @@ Config and secrets are read-only by design — you don't want your app accidenta
 
 ```bash
 # Read-only config + read-write 1GB data volume
-mvmctl up --flake . -p 8080:8080 \
-    -v ./config:/mnt/config \
-    -v ./data:/mnt/data:1024
+mvmctl machine run --flake . --name hello -d \
+    --volume ./config:/mnt/config \
+    --volume ./data:/mnt/data:1024
+mvmctl machine forward hello -p 8080:8080
 ```
 
 Your service can read config and write data at runtime — no rebuild needed:
@@ -370,7 +374,7 @@ services.my-api = {
 The `env` block above is for values you're comfortable baking into the image. For secrets or per-environment config, mount a `.env` file at boot instead:
 
 ```bash
-mvmctl up --flake . -v ./secrets:/mnt/secrets
+mvmctl machine run --flake . -v ./secrets:/mnt/secrets
 ```
 
 Then source it in `preStart`:
@@ -446,7 +450,7 @@ mvm.lib.${system}.mkGuest {
 
 ## What happens when you build
 
-When `mvmctl build --flake .` runs:
+When `mvmctl machine build --flake .` runs:
 
 1. Nix reads your `flake.nix` and resolves all inputs
 2. It builds your packages and services into a root filesystem (ext4 image)

--- a/public/src/content/docs/getting-started/nodejs-quickstart.md
+++ b/public/src/content/docs/getting-started/nodejs-quickstart.md
@@ -44,8 +44,8 @@ export const hello = mvm.app({
 The static compiler reads the declaration from source. It rejects non-literal values in declaration position so build-time behavior stays inspectable.
 
 ```sh
-mvmctl compile ./app.ts --out /tmp/hello-node
-mvmctl build /tmp/hello-node
+mvmctl build compile ./app.ts --out /tmp/hello-node
+mvmctl machine build --flake /tmp/hello-node
 ```
 
 ## Security checklist

--- a/public/src/content/docs/getting-started/python-quickstart.md
+++ b/public/src/content/docs/getting-started/python-quickstart.md
@@ -73,8 +73,8 @@ def main() -> str:
 Compile and build:
 
 ```sh
-mvmctl compile ./app.py --out /tmp/hello-python
-mvmctl build /tmp/hello-python
+mvmctl build compile ./app.py --out /tmp/hello-python
+mvmctl machine build --flake /tmp/hello-python
 ```
 
 ## Security checklist

--- a/public/src/content/docs/getting-started/quickstart.md
+++ b/public/src/content/docs/getting-started/quickstart.md
@@ -89,20 +89,21 @@ mvmctl machine console vm # Interactive shell into a running VM (PTY-over-vsock)
 Build a microVM image and run it in one command:
 
 ```bash
-mvmctl up --flake . --cpus 2 --memory 1024
+mvmctl machine run --flake . --cpus 2 --memory 1024
 ```
 
 Run in background with port forwarding:
 
 ```bash
-mvmctl up --flake . -d -p 8080:8080
+mvmctl machine run --flake . --name my-vm -d
+mvmctl machine forward my-vm -p 8080:8080
 ```
 
 Or build separately:
 
 ```bash
 mvmctl build --flake . --profile minimal
-mvmctl up --flake .
+mvmctl machine run --flake .
 ```
 
 ## 5. Manifests
@@ -115,7 +116,7 @@ mvmctl init base-worker --preset worker
 cd base-worker
 $EDITOR mvm.toml
 mvmctl build
-mvmctl up
+mvmctl machine run --manifest .
 ```
 
 Use `mvmctl manifest ls` and `mvmctl manifest info` to inspect built
@@ -141,7 +142,7 @@ Browse the bundled catalog and scaffold from a curated entry:
 mvmctl catalog list                       # Browse available entries
 mvmctl init my-app --catalog minimal      # Scaffold from a catalog entry
 mvmctl build my-app                       # Build the manifest
-mvmctl up my-app                          # Boot the VM
+mvmctl machine run --manifest my-app                          # Boot the VM
 ```
 
 ## 7. Interactive Console
@@ -178,7 +179,7 @@ Create isolated networks for different projects:
 
 ```bash
 mvmctl network create myproject
-mvmctl up --flake . --network myproject
+mvmctl machine run --flake .
 mvmctl network list
 ```
 

--- a/public/src/content/docs/guides/agent-tool-contract.mdx
+++ b/public/src/content/docs/guides/agent-tool-contract.mdx
@@ -64,10 +64,10 @@ Today the broadest shipped lifecycle surface is the CLI. A tool runner can use
 the CLI while preserving the same contract the SDK target should expose.
 
 ```sh
-mvmctl build ./agent-tool
-mvmctl up ./agent-tool --name agent-tool-call
+mvmctl machine build --flake ./agent-tool
+mvmctl machine run --flake ./agent-tool --name agent-tool-call -d
 mvmctl machine fs write agent-tool-call /work/main.py < /tmp/request-main.py
-mvmctl exec agent-tool-call --timeout 20 -- python /work/main.py
+mvmctl machine exec agent-tool-call --timeout 20 -- python /work/main.py
 mvmctl machine logs agent-tool-call
 mvmctl machine stop agent-tool-call
 ```

--- a/public/src/content/docs/guides/builder-vm.md
+++ b/public/src/content/docs/guides/builder-vm.md
@@ -22,7 +22,7 @@ builder VM
   v
 host artifact cache
   |
-  | mvmctl up --hypervisor apple-container
+  | mvmctl machine run --hypervisor vz
   v
 runtime microVM
 ```
@@ -67,7 +67,7 @@ Examples of things that should not require a dev shell:
 
 - `mvmctl build --flake .`;
 - `mvmctl run`;
-- `mvmctl up --flake .`;
+- `mvmctl machine run --flake .`;
 - building a registered template;
 - booting a prebuilt runtime image.
 
@@ -80,10 +80,10 @@ For an explicit two-step flow:
 mvmctl build --flake .
 
 # 2. Boot the already-built image.
-mvmctl up --flake . --hypervisor apple-container
+mvmctl machine run --flake . --hypervisor vz
 ```
 
-On macOS, `--hypervisor apple-container` selects the Apple Virtualization runtime backend when available. The builder VM remains a build-time implementation detail. It is not the same VM as your workload VM.
+On macOS, `--hypervisor vz` selects the Apple Virtualization runtime backend when available. The builder VM remains a build-time implementation detail. It is not the same VM as your workload VM.
 
 For development convenience, `mvmctl run` combines the two phases:
 
@@ -100,7 +100,7 @@ The builder VM and runtime microVM have different jobs:
 | VM | Purpose | Lifetime | State |
 |---|---|---|---|
 | Builder VM | Runs Linux Nix builds and image assembly. | Reused or launched as needed by the build pipeline. | Has a warm Nix store/cache. |
-| Runtime microVM | Runs your workload from a finished image. | Created by `mvmctl up`, `run`, `exec`, or tests. | Uses the built rootfs/kernel artifacts. |
+| Runtime microVM | Runs your workload from a finished image. | Created by `mvmctl machine run`, `run`, `exec`, or tests. | Uses the built rootfs/kernel artifacts. |
 
 Do not benchmark the builder VM when you want runtime boot time. The builder VM exists so that the host can ask for Linux builds without becoming a Linux build machine itself.
 

--- a/public/src/content/docs/guides/building-microvm-images.md
+++ b/public/src/content/docs/guides/building-microvm-images.md
@@ -56,8 +56,8 @@ mvmctl run                # builds (if needed) + boots
 `mvmctl` selects the runtime backend automatically when you boot the finished image. Use `--hypervisor` on runtime commands when you want to force a specific runtime backend:
 
 ```sh
-mvmctl up --flake . --hypervisor apple-container
-mvmctl up --flake . --hypervisor firecracker
+mvmctl machine run --flake . --hypervisor vz
+mvmctl machine run --flake . --hypervisor firecracker
 ```
 
 If you want to drive `nix build` directly without `mvmctl` in the loop:
@@ -115,7 +115,7 @@ Independent of the sealed/accessible distinction, mvm exposes two **runtime life
 | Mode | What it means | When to use |
 |---|---|---|
 | `attached` | VM lifecycle bound to the calling process — Ctrl-C / process exit sends SIGTERM to the VM. | `mvmctl run` interactive, `mvmctl dev` shell sessions, test harnesses that want deterministic teardown. |
-| `detached` | VM survives caller exit — only `mvmctl machine stop` (or `VmBackend::stop`) terminates it. | `mvmctl up` (background), production agents, CI fixtures that boot once and run multiple phases. |
+| `detached` | VM survives caller exit — only `mvmctl machine stop` (or `VmBackend::stop`) terminates it. | `mvmctl machine run` (background), production agents, CI fixtures that boot once and run multiple phases. |
 
 The default is `detached`. Override:
 
@@ -202,7 +202,7 @@ nix flake check --no-build
 mvm runs Nix builds inside the project builder VM and copies the finished kernel/rootfs artifacts back to the host cache. You don't need host-side Nix, and you don't need to enter a dev shell before building.
 
 - **Linux**: the builder VM provides the Linux build boundary and cache policy. Firecracker is the default runtime backend when `/dev/kvm` is available.
-- **macOS**: the host `mvmctl build` command orchestrates a Linux builder VM. The resulting runtime image can then boot with Apple Virtualization (`--hypervisor apple-container`) or another available macOS runtime backend.
+- **macOS**: the host `mvmctl build` command orchestrates a Linux builder VM. The resulting runtime image can then boot with Apple Virtualization (`--hypervisor vz`) or another available macOS runtime backend.
 - **Windows**: Tauri-only (the `mvm-studio` desktop app packages a WSL2-backed builder + runtime). See [ADR-031](https://github.com/tinylabscom/mvm/blob/main/specs/adrs/031-cross-platform-strategy.md).
 
 ## Rootless workloads

--- a/public/src/content/docs/guides/config-secrets.md
+++ b/public/src/content/docs/guides/config-secrets.md
@@ -18,7 +18,7 @@ mkdir -p /tmp/my-config /tmp/my-secrets
 echo '{"gateway": {"port": 8080}}' > /tmp/my-config/app.json
 echo 'API_KEY_REF=openai-api-key' > /tmp/my-secrets/app.env
 
-mvmctl up --manifest my-app \
+mvmctl machine run --manifest my-app \
     --volume /tmp/my-config:/mnt/config \
     --volume /tmp/my-secrets:/mnt/secrets
 ```
@@ -56,7 +56,7 @@ let config = FlakeRunConfig {
 
 ## Managed Secrets
 
-`mvmctl up --secret` has been removed.
+`mvmctl machine run` has no `--secret` flag (removed).
 
 Use `mvmctl secret put` to store local secret refs, then bind those refs
 through `mvm.toml` or the SDKs. That is the supported path for managed
@@ -92,12 +92,11 @@ worked LLM-agent example showing the pattern end-to-end.
 ### Running with host-mounted config and secrets
 
 ```bash
-mvmctl build ./openclaw
-mvmctl up ./openclaw --name oc \
-    -v nix/examples/openclaw/config:/mnt/config \
-    -v nix/examples/openclaw/secrets:/mnt/secrets \
-    -p 3000:3000
-mvmctl forward my-vm 3000:3000
+mvmctl machine build --flake ./openclaw
+mvmctl machine run --flake ./openclaw --name oc -d \
+    --volume nix/examples/openclaw/config:/mnt/config \
+    --volume nix/examples/openclaw/secrets:/mnt/secrets
+mvmctl machine forward oc -p 3000:3000
 ```
 
 Each `-v` flag mounts a host directory as an ext4 drive read-only by
@@ -121,10 +120,10 @@ cat > /tmp/my-secrets/secret-refs.env << 'EOF'
 ANTHROPIC_API_KEY_REF=anthropic-api-key
 EOF
 
-mvmctl up ./openclaw --name oc \
-    -v /tmp/oc-config:/mnt/config \
-    -v /tmp/oc-secrets:/mnt/secrets \
-    -p 3000:3000
+mvmctl machine run --flake ./openclaw --name oc -d \
+    --volume /tmp/oc-config:/mnt/config \
+    --volume /tmp/oc-secrets:/mnt/secrets
+mvmctl machine forward oc -p 3000:3000
 ```
 
 A typical `mkGuest` service uses `preStart` to check for
@@ -140,11 +139,11 @@ cold-booting. Published latency numbers must name the backend, host, artifact,
 and readiness boundary.
 
 ```bash
-mvmctl build ./openclaw --snapshot
-mvmctl up ./openclaw --name oc \
-    -v nix/examples/openclaw/config:/mnt/config \
-    -v nix/examples/openclaw/secrets:/mnt/secrets \
-    -p 3000:3000
+mvmctl machine build --flake ./openclaw --snapshot
+mvmctl machine run --flake ./openclaw --name oc -d \
+    --volume nix/examples/openclaw/config:/mnt/config \
+    --volume nix/examples/openclaw/secrets:/mnt/secrets
+mvmctl machine forward oc -p 3000:3000
 ```
 
 When restoring from a snapshot with `-v` mounts, the guest agent
@@ -170,21 +169,21 @@ keys:
 
 ```bash
 # Production gateway with prod Anthropic key
-mvmctl up --manifest openclaw --name oc-prod \
-    -v ./prod/config:/mnt/config \
-    -v ./prod/secrets:/mnt/secrets \
-    -p 3000:3000
+mvmctl machine run --manifest openclaw --name oc-prod \
+    --volume ./prod/config:/mnt/config \
+    --volume ./prod/secrets:/mnt/secrets
+mvmctl machine forward oc-prod -p 3000:3000
 
 # Staging gateway with test key
-mvmctl up --manifest openclaw --name oc-staging \
-    -v ./staging/config:/mnt/config \
-    -v ./staging/secrets:/mnt/secrets \
-    -p 3001:3000
+mvmctl machine run --manifest openclaw --name oc-staging \
+    --volume ./staging/config:/mnt/config \
+    --volume ./staging/secrets:/mnt/secrets
+mvmctl machine forward oc-staging -p 3001:3000
 
 # Dev gateway with no key (localhost-only testing)
-mvmctl up --manifest openclaw --name oc-dev \
-    -v ./dev/config:/mnt/config \
-    -p 3002:3000
+mvmctl machine run --manifest openclaw --name oc-dev \
+    --volume ./dev/config:/mnt/config
+mvmctl machine forward oc-dev -p 3002:3000
 ```
 
 All three restore from the same snapshot (1-2 second boot) but get

--- a/public/src/content/docs/guides/dev-image.md
+++ b/public/src/content/docs/guides/dev-image.md
@@ -30,7 +30,7 @@ A dev image is just an mkGuest call with `entrypoint.shell` set. Your project's 
     in
     {
       packages.${system} = {
-        # Production image — what `mvmctl up` builds.
+        # Production image — what `mvmctl machine run` builds.
         default = mvm.lib.${system}.mkGuest {
           name = "my-app";
           entrypoint.command = [ "/usr/local/bin/serve" ];

--- a/public/src/content/docs/guides/exec.md
+++ b/public/src/content/docs/guides/exec.md
@@ -21,7 +21,7 @@ mvmctl exec --launch-plan ./launch.json
 > compiled in only when the `dev-shell` Cargo feature is enabled. Production
 > guest builds omit the feature, so the handler is not present in the binary
 > at all and `exec` is physically unavailable. It is not meant for production
-> workloads; use `mvmctl up` (or `mvmd`) for those.
+> workloads; use `mvmctl machine run` (or `mvmd`) for those.
 
 ## When to use it
 
@@ -29,7 +29,7 @@ mvmctl exec --launch-plan ./launch.json
   a build script, an LLM-generated command, or any one-shot task that
   benefits from a strong isolation boundary but doesn't justify standing
   up a long-running VM.
-- **Reach for `mvmctl up`** when you want a long-running VM you can
+- **Reach for `mvmctl machine run`** when you want a long-running VM you can
   re-enter, share state with, or expose ports from.
 - **Reach for `mvmctl machine console <vm> --command "..."`** when you already
   have a VM running and want to run something inside it without a fresh
@@ -211,7 +211,7 @@ Only the entrypoint is consumed in v1; image selection still comes from
 }
 ```
 
-For long-running workloads, prefer `mvmctl up --flake <artifact-dir>`:
+For long-running workloads, prefer `mvmctl machine run --flake <artifact-dir>`:
 the SDK bakes the entrypoint into the generated flake's
 `services.<id>.command`, and mvm's PID-1 init supervises it across
 reboots.
@@ -253,7 +253,7 @@ highest):
   improvement.
 - **Persistent state** doesn't survive teardown beyond what `:rw`
   `--add-dir` rsyncs back. For larger or longer-lived state, use
-  `mvmctl up` with a persistent volume.
+  `mvmctl machine run` with a persistent volume.
 
 ## See also
 

--- a/public/src/content/docs/guides/exec.md
+++ b/public/src/content/docs/guides/exec.md
@@ -168,10 +168,10 @@ Workload IR manifest (top-level `apps[]`) — and auto-detects which
 one it is given. Both shapes were historically produced by the
 `mvmforge` toolchain
 ([see the migration guide](/guides/mvmforge-migration/));
-the canonical producer today is `mvmctl compile` in the mvm SDK.
+the canonical producer today is `mvmctl build compile` in the mvm SDK.
 
 ```bash
-mvmctl compile manifest.json --out ./build
+mvmctl build compile manifest.json --out ./build
 mvmctl exec --launch-plan ./build/launch.json
 ```
 

--- a/public/src/content/docs/guides/ir-to-image.mdx
+++ b/public/src/content/docs/guides/ir-to-image.mdx
@@ -557,7 +557,7 @@ enum Entrypoint {
 Once the rootfs is booted and the agent is up, a function call is just a vsock RPC. The shape:
 
 ```
-host (mvmctl invoke <id> --input name=Alice)
+host (mvmctl machine run --entrypoint --flake <dir>, stdin=[[], {"name": "Alice"}])
      │
      ▼  vsock: RunEntrypoint { stdin = encoded([args, kwargs]) }
 agent (uid 990, dev_image: do_exec gated by `dev-shell` feature)

--- a/public/src/content/docs/guides/ir-to-image.mdx
+++ b/public/src/content/docs/guides/ir-to-image.mdx
@@ -607,7 +607,7 @@ The rootfs itself stays minimal — it carries only the interpreter and the lang
 
 The IR hash isn't decorative — it's load-bearing in the admission path.
 
-**`mvmctl up`** (`crates/mvm-cli/src/commands/vm/plan_admission.rs`):
+**`mvmctl machine run`** (`crates/mvm-cli/src/commands/vm/plan_admission.rs`):
 
 1. Resolves the workload → IR JSON → `ir_hash`.
 2. Calls `synthesize_plan(input)` (`plan_builder.rs`) to build a typed `ExecutionPlan` carrying the IR hash, image ref, resources, policy refs, an intent-bound admission profile, validity window, and a fresh nonce.

--- a/public/src/content/docs/guides/manifests.md
+++ b/public/src/content/docs/guides/manifests.md
@@ -85,7 +85,7 @@ Three commands. That's the user model.
 mvmctl init                # scaffold mvm.toml + flake.nix in cwd
 $EDITOR mvm.toml           # tweak sizing / profile to taste
 mvmctl build               # discover manifest, run nix build, persist artifacts
-mvmctl up                  # boot the built microVM
+mvmctl machine run --manifest .                  # boot the built microVM
 ```
 
 Repeated edits are just edits. The next `mvmctl build` re-reads `mvm.toml` and re-runs the build. Resource changes (`vcpus`, `mem`, `data_disk`) update silently; identity changes (`flake`, `profile`) trip a drift refusal that asks you to `--force` or rename — see [Drift detection](#drift-detection) below.
@@ -114,7 +114,7 @@ until their runtime transports are implemented.
 
 ### Manifest discovery
 
-`mvmctl build`, `mvmctl up`, `mvmctl run`, `mvmctl exec`, `mvmctl info`, `mvmctl rm` all accept an optional `[PATH]` argument:
+`mvmctl build`, `mvmctl machine run`, `mvmctl run`, `mvmctl exec`, `mvmctl info`, `mvmctl rm` all accept an optional `[PATH]` argument:
 
 ```bash
 mvmctl build                              # walks up from cwd looking for mvm.toml
@@ -197,8 +197,8 @@ For running VMs (separate concern), continue to use `mvmctl ls` / `mvmctl machin
 ## Booting
 
 ```bash
-mvmctl up                            # boot from slot keyed by manifest at cwd
-mvmctl up /path/to/project           # explicit
+mvmctl machine run --manifest .                            # boot from slot keyed by manifest at cwd
+mvmctl machine run --manifest /path/to/project           # explicit
 mvmctl exec /path/to/project -- uname -a   # ephemeral one-shot
 ```
 
@@ -206,7 +206,7 @@ If no current revision exists, you get an error with a hint to run `mvmctl build
 
 ### Backend mismatch
 
-If the slot was built on Firecracker but you boot on Apple Virtualization (or vice versa), `mvmctl up` warns and proceeds when artifacts are compatible (cold-boot from rootfs); hard-errors only when the artifact shape can't be loaded.
+If the slot was built on Firecracker but you boot on Apple Virtualization (or vice versa), `mvmctl machine run` warns and proceeds when artifacts are compatible (cold-boot from rootfs); hard-errors only when the artifact shape can't be loaded.
 
 ## Local registry inspection / cleanup
 
@@ -265,8 +265,8 @@ To keep the schema small and the boundaries crisp, the following are explicitly 
 - **Build-time deps on other flakes** → flake `inputs` + `flake.lock`.
 - **Runtime deps on other VMs (lifecycle ordering, health gates)** → `mvmd` (separate repo).
 - **Per-tenant network bridges, tap names, IP allocation** → `mvmd`.
-- **Per-tenant network policy bundles** → `mvmctl up` flags or `~/.mvm/config.toml` defaults; eventually `mvmd` tenant config. The manifest only carries simple machine defaults (`net`, `allow_hosts`).
-- **Secrets / env vars at boot** → `mvmctl up`-time injection or `mvmd` instance config.
+- **Per-tenant network policy bundles** → `mvmctl machine run` flags or `~/.mvm/config.toml` defaults; eventually `mvmd` tenant config. The manifest only carries simple machine defaults (`net`, `allow_hosts`).
+- **Secrets / env vars at boot** → `mvmctl machine run`-time injection or `mvmd` instance config.
 
 ## See also
 

--- a/public/src/content/docs/guides/mvmforge-migration.md
+++ b/public/src/content/docs/guides/mvmforge-migration.md
@@ -16,7 +16,7 @@ mvm release ships the substrate and the SDK in lockstep.
 | `mvmforge-ir` crate                | `crates/mvm-ir`                                             |
 | `mvmforge-sdk` crate (Rust builder)| `crates/mvm-sdk` (`builder` module)                         |
 | `mvmforge-addon` crate             | `crates/mvm-sdk/src/addon/`                                 |
-| `mvmforge` host CLI compile path   | `crates/mvm-sdk/src/compile/` + `mvmctl compile`            |
+| `mvmforge` host CLI compile path   | `crates/mvm-sdk/src/compile/` + `mvmctl build compile`            |
 | `mvmforge-runtime` (in-guest)      | `crates/mvm-runner` + `nix/lib/factories/mkFunctionService` |
 | Python SDK (`@mv.func`)            | `sdks/python/mvm/` (`@mvm.app`)                             |
 | TypeScript SDK                     | `sdks/typescript/`                                          |

--- a/public/src/content/docs/guides/network-egress-policy.mdx
+++ b/public/src/content/docs/guides/network-egress-policy.mdx
@@ -16,10 +16,10 @@ forwarding mechanics, see [Networking](/guides/networking/).
 
 | Level | Use when | Example |
 | --- | --- | --- |
-| No egress | Generated code, code interpreters, offline analysis. | `--network-preset none` |
-| Package registries | Build or install steps need language registries. | `--network-preset registries` |
-| Local development | A developer needs common dev services. | `--network-preset dev` |
-| Explicit allowlist | Production-like agent or service path. | `--network-allow api.example.com:443` |
+| No egress | Generated code, code interpreters, offline analysis. | (default — deny-all) |
+| Package registries | Build or install steps need language registries. | `--net` |
+| Local development | A developer needs common dev services. | `--net` |
+| Explicit allowlist | Production-like agent or service path. | `--allow-host api.example.com:443` |
 | Unrestricted | Local debugging only. | Avoid for untrusted workloads. |
 
 For security-sensitive examples, use no egress or explicit allowlists. Broad
@@ -30,30 +30,29 @@ presets are convenience tools, not production policy.
 Start closed:
 
 ```sh
-mvmctl up --flake . --name agent-sandbox --network-preset none
+mvmctl machine run --flake . --name agent-sandbox
 ```
 
 Allow only package registries for install-heavy workflows:
 
 ```sh
-mvmctl up --flake . --name build-sandbox --network-preset registries
+mvmctl machine run --flake . --name build-sandbox --net
 ```
 
 Allow named destinations:
 
 ```sh
-mvmctl up --flake . --name agent-sandbox \
-  --network-preset none \
-  --network-allow api.openai.com:443 \
-  --network-allow github.com:443
+mvmctl machine run --flake . --name agent-sandbox \
+  \
+  --allow-host api.openai.com:443 \
+  --allow-host github.com:443
 ```
 
 Keep inbound ports separate from outbound egress:
 
 ```sh
-mvmctl up --flake . --name api-dev \
-  --network-preset none \
-  -p 127.0.0.1:8080:8080
+mvmctl machine run --flake . --name api-dev -d
+mvmctl machine forward api-dev -p 8080:8080
 ```
 
 Opening a host port does not mean the guest should have outbound internet

--- a/public/src/content/docs/guides/networking.md
+++ b/public/src/content/docs/guides/networking.md
@@ -27,14 +27,13 @@ On Linux with `/dev/kvm`, Firecracker boots directly on the host — no VM hop. 
 
 ## Port Forwarding
 
-Forward guest ports to the host with `-p`:
+`machine run` does not publish ports directly. Boot a named machine, then map
+guest ports to the host with `machine forward`:
 
 ```bash
-mvmctl up --flake . -p 8080:8080
-mvmctl up --flake . -p 3000:3000 -p 8080:8080   # multiple ports
-
-# Or forward after boot
-mvmctl forward my-vm -p 3000:3000
+mvmctl machine run --flake . --name my-vm -d
+mvmctl machine forward my-vm -p 8080:8080
+mvmctl machine forward my-vm -p 3000:3000 -p 8080:8080   # multiple ports
 ```
 
 ## vsock Communication
@@ -48,7 +47,7 @@ MicroVMs don't use networking for host communication -- they use **vsock**:
 The host connects by writing `CONNECT 5252\n` to the vsock socket and reading `OK 5252\n`. All requests are request/response pairs. vsock is supported on Firecracker, Apple Container, and microvm.nix backends. Docker uses a unix socket instead.
 
 For Firecracker, the host-side vsock UDS is scoped to the running VM directory:
-`<vm-dir>/runtime/v.sock`. It is not a global or master socket. `mvmctl up`
+`<vm-dir>/runtime/v.sock`. It is not a global or master socket. `mvmctl machine run`
 reserves the VM name before launch and rejects duplicate active/reserved names,
 because that name is the identity used to resolve the per-VM communication
 channel.
@@ -65,53 +64,42 @@ For debugging dev builds, use `mvmctl machine logs <name>` to view guest console
 
 ## Network Policies
 
-By default, microVMs have unrestricted internet access via NAT. Use `--network-preset` or `--network-allow` to restrict outbound traffic:
-For a deny-first review workflow, see [Network egress policy](/guides/network-egress-policy/).
+By default, a workload gets **no outbound network** (deny-all egress). Opt in
+with `--net` (broad dev egress) or narrow to specific hosts with `--allow-host
+HOST[:PORT]` (repeatable; `--allow-host` wins over `--net`). For a deny-first
+review workflow, see [Network egress policy](/guides/network-egress-policy/).
 
 ```bash
-# Built-in presets
-mvmctl up --flake . --network-preset dev          # GitHub, npm, PyPI, crates.io, OpenAI, Anthropic
-mvmctl up --flake . --network-preset registries    # Package registries only
-mvmctl up --flake . --network-preset none          # No outbound (DNS only)
+# Broad dev egress (DNS + general outbound)
+mvmctl machine run --flake . --net
 
-# Explicit allowlist
-mvmctl up --flake . \
-    --network-allow github.com:443 \
-    --network-allow api.openai.com:443
+# Narrow allowlist — only these hosts (PORT defaults to 443)
+mvmctl machine run --flake . \
+    --allow-host github.com:443 \
+    --allow-host api.openai.com:443
 ```
 
-Network policies are enforced via iptables FORWARD rules on the bridge interface (Firecracker backend on Linux). DNS (port 53) is always allowed so domain resolution works. Rules are automatically cleaned up when the VM stops. On macOS backends, policies are enforced at the host-side TSI/vmnet layer rather than via iptables.
+Network policies are enforced via iptables FORWARD rules on the bridge interface (Firecracker backend on Linux). DNS (port 53) is always allowed so domain resolution works. Rules are automatically cleaned up when the VM stops. On macOS backends, policies are enforced at the host-side layer rather than via iptables.
 
-**Built-in presets:**
+## Security Profiles
 
-| Preset | Allowed Domains |
-|--------|----------------|
-| `unrestricted` | All traffic (default) |
-| `dev` | github.com, api.github.com, registry.npmjs.org, crates.io, static.crates.io, index.crates.io, pypi.org, files.pythonhosted.org, api.openai.com, api.anthropic.com |
-| `registries` | registry.npmjs.org, crates.io, static.crates.io, index.crates.io, pypi.org, files.pythonhosted.org |
-| `none` | No outbound traffic (DNS only) |
-
-## Seccomp Profiles
-
-Restrict the syscalls available inside the microVM with `--seccomp`:
+Pick the guest's security posture with `--profile`. It governs env injection and
+host-share permissions, and selects the seccomp posture applied inside the guest:
 
 ```bash
-mvmctl up --flake . --seccomp standard    # File ops + process control (no sockets)
-mvmctl up --flake . --seccomp network     # Standard + socket syscalls
-mvmctl up --flake . --seccomp minimal     # Signals, pipes, timers only
+mvmctl machine run --flake . --profile restrictive   # no env injection, no host shares
+mvmctl machine run --flake . --profile standard      # explicit env; read-only host shares (default)
+mvmctl machine run --flake . --profile dev           # dev ergonomics: explicit env + writable host shares
 ```
 
-The seccomp manifest is written to the config drive as `seccomp.json` for the guest init to apply via `prctl(PR_SET_SECCOMP)`. Tiers are cumulative — each includes all syscalls from lower tiers.
+The resolved profile is copied into the signed `ExecutionPlan` admission record — audit/provenance data binding the declared workload intent to the chosen posture, policy refs, secret-release posture, and audit labels — so `mvmctl trust audit verify` can prove which posture was admitted.
 
-The same tier is also copied into the signed `ExecutionPlan` admission profile. That profile is audit/provenance data: it binds the declared workload intent to the chosen seccomp tier, policy refs, secret-release posture, and audit labels. The actual syscall enforcement remains the guest seccomp manifest generated from `mvm-security`; the plan-side tier exists so `mvmctl audit verify` can prove which posture was admitted.
-
-| Tier | Syscalls | Use Case |
-|------|----------|----------|
-| `essential` | ~40 | Process bootstrap only (linker, glibc init) |
-| `minimal` | ~110 | + signals, pipes, timers, process control |
-| `standard` | ~140 | + file manipulation, fs operations |
-| `network` | ~160 | + sockets, connect, bind (for networked agents) |
-| `unrestricted` | all | No restrictions (default) |
+| Profile | Env injection | Host shares |
+|---------|---------------|-------------|
+| `restrictive` | none | none |
+| `standard` (default) | explicit `-e KEY=VALUE` | read-only |
+| `dev` | explicit `-e KEY=VALUE` | read-write allowed |
+| `permissive` | explicit | read-write (requires `MVM_ACK_PERMISSIVE_RUN=1`) |
 
 ## DNS
 

--- a/public/src/content/docs/guides/nix-flakes.md
+++ b/public/src/content/docs/guides/nix-flakes.md
@@ -74,7 +74,7 @@ mkGuest {
 }
 ```
 
-The host (`mvmctl up` or mvmd) reads these declarations via `passthru.volumeMounts`:
+The host (`mvmctl machine run` or mvmd) reads these declarations via `passthru.volumeMounts`:
 
 ```sh
 nix eval .#mvm-worker.passthru.volumeMounts --json
@@ -328,9 +328,9 @@ printf '%s\n' 'sk-ant-…' > ~/.config/mvm/secrets/anthropic
 chmod 0400 ~/.config/mvm/secrets/anthropic
 
 cd my-claude-code-vm
-mvmctl build
-mvmctl up \
-  --add-dir "$PWD:/workspace:rw" \
+mvmctl machine build
+mvmctl machine run --manifest . --profile dev \
+  --volume "$PWD:/workspace:rw" \
   --volume "$HOME/.config/mvm/secrets:/mnt/secrets"
 ```
 

--- a/public/src/content/docs/guides/observability-and-results.mdx
+++ b/public/src/content/docs/guides/observability-and-results.mdx
@@ -55,7 +55,7 @@ metadata or metric labels.
 For a long-running sandbox:
 
 ```sh
-mvmctl up ./service --name service-dev --metrics-port 9100
+mvmctl machine run --flake ./service --name service-dev -d
 mvmctl wait service-dev --for all
 mvmctl boot-report service-dev --json
 mvmctl machine logs service-dev -n 200

--- a/public/src/content/docs/guides/persistent-workspaces.md
+++ b/public/src/content/docs/guides/persistent-workspaces.md
@@ -138,7 +138,7 @@ Example:
 ```sh
 mvmctl volume create coding-agent-work
 mvmctl volume unlock coding-agent-work
-mvmctl up ./agent-image --name coding-agent
+mvmctl machine run --flake ./agent-image --name coding-agent -d
 mvmctl volume mount coding-agent --volume coding-agent-work --guest /workspace --rw
 mvmctl cp ./task.json coding-agent:/work/task.json
 mvmctl exec coding-agent --timeout 120 -- python /work/run_task.py

--- a/public/src/content/docs/guides/policy-profiles.md
+++ b/public/src/content/docs/guides/policy-profiles.md
@@ -103,7 +103,7 @@ caught before a workload starts.
 Named VM launches expose a separate seccomp tier:
 
 ```sh
-mvmctl up ./my-app --name agent-sandbox --seccomp standard
+mvmctl machine run --flake ./my-app --name agent-sandbox -d --profile standard
 ```
 
 Supported tiers are:
@@ -126,7 +126,7 @@ The selected tier is recorded in the signed admission profile for audit.
 | Code interpreter | `mvmctl run --profile restrictive` | A bounded work directory or receipt output. |
 | CI validation | `mvmctl run --profile standard` | Read-only source share and explicit non-secret env. |
 | Local development | `mvmctl run --profile dev` | Writable project share. |
-| Long-running local service | `mvmctl up --seccomp standard` | Explicit ports, volumes, and readiness checks. |
+| Long-running local service | `mvmctl machine run --profile standard` | Explicit ports, volumes, and readiness checks. |
 
 Security-first defaults should feel slightly strict. A denied `--env` or
 writable share is a useful signal that the run is crossing a boundary.

--- a/public/src/content/docs/guides/sdk.mdx
+++ b/public/src/content/docs/guides/sdk.mdx
@@ -1,6 +1,6 @@
 ---
 title: SDK — Python and TypeScript
-description: Declare microVM workloads with the mvm Python and TypeScript SDKs. Decorator-style author surface; mvmctl compile / deploy compiles the same source statically without executing it.
+description: Declare microVM workloads with the mvm Python and TypeScript SDKs. Decorator-style author surface; mvmctl build compile / deploy compiles the same source statically without executing it.
 ---
 
 import { Tabs, TabItem } from "@astrojs/starlight/components";
@@ -12,7 +12,7 @@ source file produce the same `Workload` IR:
 - **In-process**: `python app.py` or `node app.ts` imports `mvm`, the
   decorator records the declaration, and `mvm.emit_json()` /
   `mvm.emitJson()` writes the canonical IR to stdout.
-- **Static compile**: `mvmctl compile app.py` walks the AST without
+- **Static compile**: `mvmctl build compile app.py` walks the AST without
   importing the script. Same IR; the host never runs user code.
 
 ## Declaration
@@ -47,10 +47,8 @@ def greet(name: str) -> str:
 Build, run, invoke:
 
 ```sh
-mvmctl compile examples/python/hello-app/app.py --out /tmp/hello-app
-mvmctl build /tmp/hello-app
-mvmctl up hello-app
-mvmctl invoke hello-app --input name='ari'
+mvmctl build compile examples/python/hello-app/app.py --out /tmp/hello-app
+echo '[[], {"name":"ari"}]' | mvmctl machine run --entrypoint --flake /tmp/hello-app   # → "hello ari"
 ```
 
 </TabItem>
@@ -76,10 +74,8 @@ export const greet = mvm.app({
 Build, run, invoke:
 
 ```sh
-mvmctl compile examples/node/hello-app/app.ts --out /tmp/hello-app
-mvmctl build /tmp/hello-app
-mvmctl up hello-app
-mvmctl invoke hello-app --input name='ari'
+mvmctl build compile examples/node/hello-app/app.ts --out /tmp/hello-app
+echo '[[], {"name":"ari"}]' | mvmctl machine run --entrypoint --flake /tmp/hello-app   # → "hello ari"
 ```
 
 </TabItem>
@@ -110,7 +106,7 @@ Four phases. Each accepts a string (shell line), a list of strings
 | --------------- | ------------------------------------------------------------------------------- |
 | `before_build`  | Inside the builder VM, after deps install and before the rootfs snapshot.       |
 | `before_start`  | At every microVM boot, before the entrypoint dispatch.                          |
-| `after_start`   | Readiness probe — polled to exit-0 before the agent accepts `mvmctl invoke`.    |
+| `after_start`   | Readiness probe — polled to exit-0 before the agent accepts entrypoint calls.   |
 | `before_stop`   | At shutdown, best-effort.                                                       |
 
 Addons (when attached via `addons=[...]`) contribute their own hooks;
@@ -120,7 +116,7 @@ Nix factory to bake into `/etc/mvm/hooks/<phase>.sh`.
 
 ## Build artifacts
 
-Use `mvmctl compile` to produce local build artifacts that can be reviewed,
+Use `mvmctl build compile` to produce local build artifacts that can be reviewed,
 signed, built, and launched through the normal `mvm` workflow. Treat packaging
 and rollout as a separate admission step, not as part of declaration parsing.
 
@@ -139,7 +135,7 @@ value.
 
 ## TypeScript runner
 
-`mvmctl compile app.ts` walks the AST statically for `mvm.app({...})`
+`mvmctl build compile app.ts` walks the AST statically for `mvm.app({...})`
 calls and does not run user code. When a `.ts` script uses the
 record-mode `Sandbox` API instead (no `mvm.app` decorator), `mvmctl
 compile` falls back to **auto-run**: it spawns the script on the host
@@ -173,7 +169,7 @@ compile` picks it up automatically — see the resolution order below.
 
 ### Resolution order
 
-`mvmctl compile` resolves the runner in this order, picking the
+`mvmctl build compile` resolves the runner in this order, picking the
 first hit:
 
 1. `MVM_TSX=<path>` env override — explicit pin (any binary).

--- a/public/src/content/docs/guides/troubleshooting.md
+++ b/public/src/content/docs/guides/troubleshooting.md
@@ -108,7 +108,7 @@ Snapshot may be corrupted after a Firecracker version change.
 **Fix**: Delete the snapshot and cold boot:
 ```bash
 mvmctl build <project-dir> --force
-mvmctl up <project-dir> --name <name>
+mvmctl machine run --flake <project-dir> --name <name> -d
 ```
 
 ## Build Issues
@@ -172,7 +172,7 @@ error: hash mismatch in fixed-output derivation
 **Fix**: Update the hash to the value shown after `got:` in the error message, or use `--update-hash`:
 
 ```bash
-mvmctl build ./my-service --update-hash
+mvmctl machine build --flake ./my-service --update-hash
 ```
 
 ### Manifest not found
@@ -279,16 +279,16 @@ mvmctl dev up --cpus 8 --memory 16
 
 Force a specific backend:
 ```bash
-mvmctl up --flake . --hypervisor firecracker
-mvmctl up --flake . --hypervisor apple-container
-mvmctl up --flake . --hypervisor docker
-mvmctl up --flake . --hypervisor qemu    # microvm.nix
+mvmctl machine run --flake . --hypervisor firecracker
+mvmctl machine run --flake . --hypervisor vz
+mvmctl machine run --flake . --hypervisor docker
+mvmctl machine run --flake . --hypervisor qemu    # microvm.nix
 mvmctl doctor   # check available backends
 ```
 
 ### macOS: first-run codesigning for `apple-container` and `libkrun`
 
-Both `mvmctl up --hypervisor apple-container` and (once plan 57 W3 wires guest boot) `mvmctl up --hypervisor libkrun` need ad-hoc codesigning before the macOS kernel will let the binary touch the hypervisor APIs:
+Both `mvmctl machine run --hypervisor vz` and (once plan 57 W3 wires guest boot) `mvmctl machine run --hypervisor libkrun` need ad-hoc codesigning before the macOS kernel will let the binary touch the hypervisor APIs:
 
 - `com.apple.security.virtualization` — required by `Virtualization.framework` (the `apple-container` backend).
 - `com.apple.security.hypervisor` — required by direct `Hypervisor.framework` callers (the `libkrun` backend).
@@ -298,7 +298,7 @@ On the **first** run of either backend, `mvmctl` ad-hoc signs itself with both e
 What you'll see on the first run:
 
 ```
-$ mvmctl up --flake . --hypervisor apple-container
+$ mvmctl machine run --flake . --hypervisor vz
 INFO Signing binary with virtualization + hypervisor entitlements...
 …starts the VM…
 ```
@@ -329,7 +329,7 @@ Hitting `KVM not available` on a cloud instance? Three options, in order of reco
 **Option 2 — Use the Tier 3 Docker fallback.** Works in any environment with Docker Engine. **Reduced security tier** — see the [Matryoshka model](/security/matryoshka). The L1–L3 layers collapse to the host kernel, so claims 1, 2, and 3 do not hold. Use only for non-security-sensitive workloads (CI scratch, local experiments).
 
 ```bash
-mvmctl up --flake . --hypervisor docker
+mvmctl machine run --flake . --hypervisor docker
 # Suppress the per-run banner once you've acknowledged the tier:
 export MVM_ACK_DOCKER_TIER=1
 ```

--- a/public/src/content/docs/install/macos.md
+++ b/public/src/content/docs/install/macos.md
@@ -52,7 +52,7 @@ cargo install mvmctl
 
 macOS Nix can't build Linux derivations natively, and most Mac users don't have Nix installed at all. mvm handles both cases **without requiring host-side configuration**: on `mvmctl build`, the host CLI stages the selected flake as a builder job, the Linux builder VM runs `nix build`, and mvm copies the resulting kernel/rootfs artifacts back to the host cache. See [Builder VM](/guides/builder-vm/) for the full control-plane flow.
 
-The builder VM is separate from the runtime VM. After the build completes, `mvmctl up --hypervisor apple-container` boots the already-built runtime image with Apple Virtualization. The build phase and boot phase can be benchmarked separately.
+The builder VM is separate from the runtime VM. After the build completes, `mvmctl machine run --hypervisor vz` boots the already-built runtime image with Apple Virtualization. The build phase and boot phase can be benchmarked separately.
 
 ### Optional: host-side Nix for power users
 

--- a/public/src/content/docs/reference/cli-commands.md
+++ b/public/src/content/docs/reference/cli-commands.md
@@ -22,7 +22,7 @@ verification under `trust`. Domains that already own their own subcommands
 
 | Group / top-level | Commands |
 |--------|----------|
-| Daily drivers (top-level) | `up`, `run`, `invoke`, `ls`, `console`, `down`, `logs`, `dev`, `doctor`, `init` |
+| Daily drivers (top-level) | `machine` (`run`/`exec`/`console`/`logs`/`stop`/`forward`/…), `ls`, `dev`, `build`, `doctor`, `init`, `bootstrap` |
 | `vm <sub>` | `pause`, `resume`, `snapshot`, `save`, `restore`, `checkpoint`, `cp`, `fs`, `proc`, `diff`, `wait`, `boot-report`, `set-ttl`, `forward`, `sandbox`, `session`, `volume` |
 | `build <sub>` | `image` (the former `build`), `compile`, `validate`, `kernel` |
 | `ops <sub>` | `metrics`, `bench`, `config`, `mcp` |
@@ -36,33 +36,29 @@ the common "run something in a microVM" cases, and the path the
 [getting-started docs](/getting-started/machine-scenarios/) lead with. Every
 verb in the grouping above is an **advanced / underlying surface**: `machine`
 is a thin UX layer over the *same* signed, audited, OCI-provenance execution
-path these verbs use, so the lower-level commands (`up`, `run`, `invoke`,
-`vm *`, `build *`, `console`, …) stay fully supported for power users and
-scripts. They are **not deprecated and not going away** — reach for them when
-you need finer control than `machine` exposes (custom flakes, snapshots,
-templates, the guest-RPC surface, fleet-shaped workflows).
+path. The former top-level `up`/`invoke`/`console`/`down` verbs have folded into
+`machine` (`machine run`, `machine run --entrypoint`, `machine console`,
+`machine stop`); the `vm *` and `build *` noun-groups and the internal `run`
+SDK transport remain for power users and scripts — reach for them when you need
+finer control than `machine` exposes (custom flakes, snapshots, templates, the
+guest-RPC surface, fleet-shaped workflows).
 
 | Command | Description |
 |---------|-------------|
-| `mvmctl up --flake <ref>` | Build and run a VM from a Nix flake |
-| `mvmctl up --manifest <path>` | Boot a pre-built manifest (path to `mvm.toml`, its directory, or a legacy slot name; mutually exclusive with `--flake`). Short form: `-m <path>` |
-| `mvmctl up --name <name>` | Specify VM name (auto-generated if omitted) |
-| `mvmctl up --profile <variant>` | Flake package variant (e.g. worker, gateway) |
-| `mvmctl up --cpus N --memory SIZE` | Override vCPU count and memory (supports 512M, 4G, etc.) |
-| `mvmctl up -p HOST:GUEST` | Forward a port mapping into the VM (repeatable) |
-| `mvmctl up -e KEY=VALUE` | Inject an environment variable (repeatable) |
-| `mvmctl up -v host:guest:size` | Mount a volume into the VM (repeatable) |
-| `mvmctl up -d` | Run in background (detached mode, via launchd) |
-| `mvmctl up --forward` | Auto-forward declared ports after boot (blocks until Ctrl-C) |
-| `mvmctl up --hypervisor <backend>` | Backend: `firecracker` (default), `apple-container`, `docker`, or `qemu` |
-| `mvmctl up --config <path>` | Runtime config (TOML) for persistent resources/volumes |
-| `mvmctl up --metrics-port PORT` | Bind a Prometheus metrics endpoint (0 = disabled) |
-| `mvmctl up --watch-config` | Reload ~/.mvm/config.toml automatically when it changes |
-| `mvmctl up --watch` | Watch flake for changes and auto-rebuild + reboot |
-| `mvmctl up --network-preset <preset>` | Network egress policy: `unrestricted` (default), `none`, `registries`, `dev`, `agent` (LLM-inference + GitHub bundle — see [ADR-004](https://github.com/tinylabscom/mvm/blob/main/specs/adrs/004-hypervisor-egress-policy.md)) |
-| `mvmctl up --network-allow host:port` | Allow egress to specific host:port (repeatable, mutually exclusive with preset) |
-| `mvmctl up --seccomp <tier>` | Seccomp profile: `essential`, `minimal`, `standard` (default), `network`, `unrestricted`. The selected tier is enforced through the guest `seccomp.json` manifest and recorded in the signed admission profile for audit. |
-| `mvmctl up --network <name>` | Named dev network to attach VM to (default: "default") |
+| `mvmctl machine run --flake <ref>` | Build a Nix flake and boot a transient VM |
+| `mvmctl machine run --manifest <path>` | Boot a pre-built manifest (`mvm.toml`, its directory, or a slot name; short form `-m`). Mutually exclusive with `--flake`/`--image` |
+| `mvmctl machine run --image <ref>` | Boot an OCI image (pulled/cached). Mutually exclusive with `--flake`/`--manifest` |
+| `mvmctl machine run --name <name>` | Run under a machine identity (auto-generated if omitted) |
+| `mvmctl machine run -d` | Boot a **persistent** machine detached and return immediately |
+| `mvmctl machine run --cpus N --memory SIZE` | vCPU count and memory (supports 512M, 4G, etc.) |
+| `mvmctl machine run -e KEY=VALUE` | Inject an environment variable (repeatable; gated by `--profile`) |
+| `mvmctl machine run --volume host:/guest[:mode]` | Share a host directory (mode defaults to `ro`; `rw` needs `--profile dev`/`permissive`) |
+| `mvmctl machine run --profile <p>` | Security posture: `restrictive`, `standard` (default), `dev`, `permissive` |
+| `mvmctl machine run --net` | Enable broad dev-tier outbound egress (default is deny-all) |
+| `mvmctl machine run --allow-host HOST[:PORT]` | Allow egress only to these hosts (repeatable; PORT defaults to 443; wins over `--net`) |
+| `mvmctl machine run --hypervisor <backend>` | Backend: `firecracker` (Linux/KVM), `vz` (macOS 26+), `libkrun` (macOS 13–25), `qemu` (dev/test) |
+| `mvmctl machine run --flake <ref> --flake-profile <variant>` | Flake package variant (e.g. worker, gateway) |
+| `mvmctl machine build --flake <ref> --watch` | Watch the flake and rebuild on change |
 | `mvmctl machine stop [name...]` | Stop one or more VMs by name, or `--all` |
 | `mvmctl ls` | List running VMs (aliases: `ps`, `status`) |
 | `mvmctl ls -a` | Show all VMs including stopped |
@@ -152,7 +148,7 @@ templates, the guest-RPC surface, fleet-shaped workflows).
 
 ### Running (top-level — already manifest-aware)
 
-`mvmctl up [PATH]` and `mvmctl run [PATH] -- <cmd>` accept a manifest path or its directory and look up the manifest-keyed slot. If no current revision exists, they error with a hint to run `mvmctl build image`. See the [VM Lifecycle](#vm-lifecycle) and [One-shot Exec](#one-shot-run-transient-runner) sections for full flag lists. (Plan 40 dropped the `start` and `run` aliases on `up`.)
+`mvmctl machine run [PATH]` and `mvmctl run [PATH] -- <cmd>` accept a manifest path or its directory and look up the manifest-keyed slot. If no current revision exists, they error with a hint to run `mvmctl build image`. See the [VM Lifecycle](#vm-lifecycle) and [One-shot Exec](#one-shot-run-transient-runner) sections for full flag lists. (Plan 40 dropped the `start` and `run` aliases on `up`.)
 
 ### Inspection / registry (`mvmctl manifest *`)
 
@@ -229,7 +225,7 @@ metadata plus `secret_visibility: "write_only"` and
 
 ## Policy Contracts
 
-`mvmctl up` still synthesizes and admits signed execution plans with policy
+`mvmctl machine run` still synthesizes and admits signed execution plans with policy
 references. The default local ref is `local-default`; tenant-scoped policy
 authoring, diffing, rollout, and review are exposed by `mvmd`, not by a public
 `mvmctl policy` command.
@@ -511,7 +507,7 @@ signed artifacts and live `machine run <artifact.mvm>` are still follow-up work.
 `machine check-artifact` is the current read-only portable-artifact gate: it
 verifies the signed manifest, file hashes, format version, sealed-prod verity
 requirements, host architecture, and fail-closed admission posture before
-printing a preview. Use `mvmctl up` for the manifest/flake path that already
+printing a preview. Use `mvmctl machine run` for the manifest/flake path that already
 exposes named networks and policy bundles.
 
 ## Sandbox State
@@ -681,7 +677,7 @@ When an image-taking command is invoked without `--flake` or `--manifest`,
 This applies to:
 
 - `mvmctl run -- <cmd>` — boots a fresh transient microVM and runs `<cmd>`
-- `mvmctl up` — boots a long-running microVM with the same image
+- `mvmctl machine run` — boots a long-running microVM with the same image
 
 The image is the bundled default — a minimal `mkGuest` rootfs shipped
 with mvm. Built via Nix on first use, cached at

--- a/public/src/content/docs/reference/filesystem.md
+++ b/public/src/content/docs/reference/filesystem.md
@@ -66,7 +66,7 @@ The data drive (`/dev/vdd`, mounted at `/mnt/data/`) is a persistent ext4 volume
 Specify size with `--volume`:
 
 ```bash
-mvmctl up --flake . --volume ./data:/data:1024
+mvmctl machine run --flake . --volume ./data:/data:1024
 ```
 
 For managed encrypted local volumes and workspace cleanup policy, see

--- a/public/src/content/docs/reference/guest-agent.md
+++ b/public/src/content/docs/reference/guest-agent.md
@@ -104,7 +104,7 @@ payload bytes. The list is the authoritative one:
   unit tests pin this.
 - `BackpressureReason::ServiceHealthPending { pending }` — service
   names only.
-- Receipts written by `mvmctl run` / `mvmctl up` / `mvmctl build`
+- Receipts written by `mvmctl run` / `mvmctl machine run` / `mvmctl build`
   (plan 74 W6) store hashes and metadata. Raw stdout / stderr /
   stdin / env / argv values are never written.
 - `mvmctl ls --json` rows — the `readiness` and
@@ -230,7 +230,7 @@ once a background init thread actually ran.
 
 - `mvmctl boot-report <vm> [--json]` — Single round-trip; prints
   the same `ReadinessReport` `mvmctl wait` polls, including the
-  per-phase timing table. Useful right after `mvmctl up` to
+  per-phase timing table. Useful right after `mvmctl machine run` to
   inspect cold-path latency.
 
 Both verbs require `GuestCapability::Readiness` from the

--- a/public/src/content/docs/reference/limits.md
+++ b/public/src/content/docs/reference/limits.md
@@ -18,8 +18,8 @@ data_disk = "0"
 Use CLI overrides for local experimentation:
 
 ```sh
-mvmctl build ./my-app --vcpus 4 --mem 2G --data-disk 8G
-mvmctl up ./my-app --cpus 4 --memory 2G
+mvmctl machine build --flake ./my-app --vcpus 4 --mem 2G --data-disk 8G
+mvmctl machine run --flake ./my-app --cpus 4 --memory 2G
 ```
 
 Commit the manifest values once the sizing is intentional.
@@ -52,7 +52,7 @@ Network policy should start narrow and open only required destinations or
 ports. Port forwarding is explicit:
 
 ```sh
-mvmctl forward devbox -p 8080:8080
+mvmctl machine forward devbox -p 8080:8080
 ```
 
 Prefer loopback host binds for local development unless public exposure is an

--- a/public/src/content/docs/sdk/declaration-cookbook.mdx
+++ b/public/src/content/docs/sdk/declaration-cookbook.mdx
@@ -43,8 +43,8 @@ def run(prompt: str) -> str:
 Compile and build:
 
 ```sh
-mvmctl compile ./tool.py --out /tmp/hello-python
-mvmctl build /tmp/hello-python
+mvmctl build compile ./tool.py --out /tmp/hello-python
+mvmctl machine build --flake /tmp/hello-python
 ```
 
 Security posture:
@@ -80,8 +80,8 @@ export const run = mvm.app({
 Compile and build:
 
 ```sh
-mvmctl compile ./tool.ts --out /tmp/hello-node
-mvmctl build /tmp/hello-node
+mvmctl build compile ./tool.ts --out /tmp/hello-node
+mvmctl machine build --flake /tmp/hello-node
 ```
 
 </TabItem>

--- a/public/src/content/docs/sdk/declaration-workflow.mdx
+++ b/public/src/content/docs/sdk/declaration-workflow.mdx
@@ -6,7 +6,7 @@ description: Compile Python and TypeScript workload declarations into Workload I
 import { Tabs, TabItem } from "@astrojs/starlight/components";
 
 The declaration workflow is the security-first path for deployable workloads.
-You write a small code declaration, `mvmctl compile` extracts the supported
+You write a small code declaration, `mvmctl build compile` extracts the supported
 literal shape, and the result becomes Workload IR plus staged build artifacts.
 
 Use this path when you want code-first ergonomics without treating module import
@@ -15,9 +15,9 @@ side effects as part of the build.
 ## Workflow
 
 ```sh
-mvmctl compile ./tool.py --out /tmp/tool-build
-mvmctl build /tmp/tool-build
-mvmctl up /tmp/tool-build --name tool-dev
+mvmctl build compile ./tool.py --out /tmp/tool-build
+mvmctl machine build --flake /tmp/tool-build
+mvmctl machine run --flake /tmp/tool-build --name tool-dev
 ```
 
 The compile step accepts:
@@ -63,7 +63,7 @@ def run(prompt: str) -> str:
 Compile it:
 
 ```sh
-mvmctl compile ./tool.py --out /tmp/agent-tool
+mvmctl build compile ./tool.py --out /tmp/agent-tool
 ```
 
 The compiler handles the declaration. The function body is workload code; it is
@@ -92,7 +92,7 @@ export const run = mvm.app({
 Compile it:
 
 ```sh
-mvmctl compile ./tool.ts --out /tmp/agent-tool
+mvmctl build compile ./tool.ts --out /tmp/agent-tool
 ```
 
 For TypeScript, install a project-local runner when a script needs runtime
@@ -114,25 +114,25 @@ posture because the script executes on the host.
 Compile a Workload IR file directly:
 
 ```sh
-mvmctl compile --from-ir ./workload.json --out /tmp/agent-tool
+mvmctl build compile --from-ir ./workload.json --out /tmp/agent-tool
 ```
 
 Compile IR from stdin:
 
 ```sh
-cat ./workload.json | mvmctl compile - --out /tmp/agent-tool
+cat ./workload.json | mvmctl build compile - --out /tmp/agent-tool
 ```
 
 Compile a deterministic archive:
 
 ```sh
-mvmctl compile --from-ir ./workload.json --out /tmp/agent-tool.tgz
+mvmctl build compile --from-ir ./workload.json --out /tmp/agent-tool.tgz
 ```
 
 Compile from an explicit runtime recording:
 
 ```sh
-mvmctl compile --from-recording ./recording.json --out /tmp/agent-tool
+mvmctl build compile --from-recording ./recording.json --out /tmp/agent-tool
 ```
 
 Use IR inputs when another tool already produced the workload contract. Use

--- a/public/src/content/docs/sdk/decorator.mdx
+++ b/public/src/content/docs/sdk/decorator.mdx
@@ -5,7 +5,7 @@ description: Declare reproducible mvm workloads in Python or TypeScript and comp
 
 import { Tabs, TabItem } from "@astrojs/starlight/components";
 
-The decorator SDK is the build-time authoring surface. It lets a developer describe a workload next to the function or service it runs, then compile that declaration into the same Workload IR consumed by `mvmctl build` and `mvmctl up`.
+The decorator SDK is the build-time authoring surface. It lets a developer describe a workload next to the function or service it runs, then compile that declaration into the same Workload IR consumed by `mvmctl machine build` and `mvmctl machine run`.
 
 This is the declarative side of the product: code-first workload declaration, resource selection, image selection, and deploy metadata. The security difference is intentional: the static compiler reads source and extracts literal declarations without importing the module.
 
@@ -71,14 +71,14 @@ export const run = mvm.app({
 Compile and inspect:
 
 ```sh
-mvmctl compile tool.py --out /tmp/agent-tool
-mvmctl build /tmp/agent-tool
-mvmctl up agent-tool
+mvmctl build compile tool.py --out /tmp/agent-tool
+mvmctl machine build --flake /tmp/agent-tool
+mvmctl machine run --flake /tmp/agent-tool
 ```
 
 ## Why static compile matters
 
-The safe path is static analysis: `mvmctl compile` reads the declaration and emits IR without importing and executing the user's source file. That keeps untrusted or side-effecting module import code out of the host process.
+The safe path is static analysis: `mvmctl build compile` reads the declaration and emits IR without importing and executing the user's source file. That keeps untrusted or side-effecting module import code out of the host process.
 
 Record-mode and live-mode runtime scripts exist for the imperative `Sandbox.create(...)` workflow, but they have a different trust posture because the user's script runs on the host process invoking the SDK. Prefer the static declaration form for security-sensitive deployable workloads.
 

--- a/public/src/content/docs/sdk/lifecycle-matrix.md
+++ b/public/src/content/docs/sdk/lifecycle-matrix.md
@@ -24,7 +24,7 @@ keep a workflow documented as planned.
 
 | Operation | CLI | Python SDK | TypeScript SDK | Notes |
 | --- | --- | --- | --- | --- |
-| Create named sandbox | Shipped | Partial | Partial | SDK live mode calls `mvmctl up`; record mode records `Sandbox.create(...)`. |
+| Create named sandbox | Shipped | Partial | Partial | SDK live mode calls `mvmctl machine run`; record mode records `Sandbox.create(...)`. |
 | One-shot run | Shipped | Target | Target | `mvmctl run -- <cmd>` is current; SDK convenience helpers should preserve receipts and policy. |
 | Start command | Shipped | Partial | Partial | SDK exposes `commands.start(...)`; result capture is still a target. |
 | Command result capture | Shipped | Target | Target | CLI one-shot JSON/receipt paths exist; SDK `commands.run(...)` result shape is a target. |
@@ -47,7 +47,7 @@ keep a workflow documented as planned.
 | Local SDK smoke script | Python or TypeScript `Sandbox.create(...)` in record mode | Produces Workload IR without booting a VM. |
 | Live SDK experiment | `mvmctl run --mode live ./script.py` or `.ts` | Exercises current live transport and cleanup helpers. |
 | Deployable workload declaration | Static declaration workflow | Avoids importing user modules during compile. |
-| Persistent service | `mvmctl build`, `mvmctl up`, `mvmctl machine logs`, `mvmctl machine stop` | CLI has the broadest lifecycle coverage today. |
+| Persistent service | `mvmctl build`, `mvmctl machine run`, `mvmctl machine logs`, `mvmctl machine stop` | CLI has the broadest lifecycle coverage today. |
 | Cold recovery test | `mvmctl pause/resume` or `mvmctl checkpoint create/restore` | Backend-specific state handling is visible. |
 
 ## SDK parity rules

--- a/public/src/content/docs/sdk/operations-cookbook.mdx
+++ b/public/src/content/docs/sdk/operations-cookbook.mdx
@@ -20,7 +20,7 @@ language SDK tests prove them.
 | Operation | Python today | TypeScript today | Secure fallback today |
 | --- | --- | --- | --- |
 | Create sandbox recording | `mvm.Sandbox.create(...)` | `Sandbox.create(...)` | `mvmctl build compile` or `mvmctl run --mode plan` |
-| Create live sandbox | `mvmctl run --mode live ./script.py` | `mvmctl run --mode live ./script.ts` | `mvmctl up` |
+| Create live sandbox | `mvmctl run --mode live ./script.py` | `mvmctl run --mode live ./script.ts` | `mvmctl machine run` |
 | Start command | `sandbox.commands.start([...])` | `sandbox.commands.start([...])` | `mvmctl proc start` or `mvmctl exec` |
 | Capture command result | Target `commands.run(...)` | Target `commands.run(...)` | CLI command result and receipt paths |
 | Write file | `sandbox.files.write(path, data)` | `sandbox.files.write(path, data)` | `mvmctl machine fs write` |

--- a/public/src/content/docs/sdk/operations-cookbook.mdx
+++ b/public/src/content/docs/sdk/operations-cookbook.mdx
@@ -19,7 +19,7 @@ language SDK tests prove them.
 
 | Operation | Python today | TypeScript today | Secure fallback today |
 | --- | --- | --- | --- |
-| Create sandbox recording | `mvm.Sandbox.create(...)` | `Sandbox.create(...)` | `mvmctl compile` or `mvmctl run --mode plan` |
+| Create sandbox recording | `mvm.Sandbox.create(...)` | `Sandbox.create(...)` | `mvmctl build compile` or `mvmctl run --mode plan` |
 | Create live sandbox | `mvmctl run --mode live ./script.py` | `mvmctl run --mode live ./script.ts` | `mvmctl up` |
 | Start command | `sandbox.commands.start([...])` | `sandbox.commands.start([...])` | `mvmctl proc start` or `mvmctl exec` |
 | Capture command result | Target `commands.run(...)` | Target `commands.run(...)` | CLI command result and receipt paths |
@@ -64,7 +64,7 @@ Security notes:
 Run modes:
 
 ```sh
-mvmctl compile ./sandbox.py --out /tmp/sandbox-ir
+mvmctl build compile ./sandbox.py --out /tmp/sandbox-ir
 mvmctl run --mode plan ./sandbox.py
 mvmctl run --mode live ./sandbox.py
 ```
@@ -100,7 +100,7 @@ Security notes:
 Run modes:
 
 ```sh
-mvmctl compile ./sandbox.ts --out /tmp/sandbox-ir
+mvmctl build compile ./sandbox.ts --out /tmp/sandbox-ir
 mvmctl run --mode plan ./sandbox.ts
 mvmctl run --mode live ./sandbox.ts
 ```

--- a/public/src/content/docs/sdk/python.md
+++ b/public/src/content/docs/sdk/python.md
@@ -13,7 +13,7 @@ Current:
 - `sandbox.commands.start(argv, env=...)`
 - `sandbox.files.write(path, content)`
 - context-manager cleanup with `with`
-- record mode for `mvmctl compile` and `mvmctl run --mode plan`
+- record mode for `mvmctl build compile` and `mvmctl run --mode plan`
 - live mode for `mvmctl run --mode live`
 
 Planned:

--- a/public/src/content/docs/sdk/runtime-modes.md
+++ b/public/src/content/docs/sdk/runtime-modes.md
@@ -84,7 +84,7 @@ mvmctl run --mode live ./sandbox.py
 The CLI sets `MVM_SDK_MODE=live` and `MVM_CLI_BIN` for the child process. The SDK
 then uses the local CLI for operations such as:
 
-- `mvmctl up --up-json --detach --name <generated-id> --manifest <template>`
+- `mvmctl machine run --up-json --detach --name <generated-id> --manifest <template>`
 - `mvmctl machine fs write <vm> <path>`
 - `mvmctl proc start <vm> -- <argv>`
 - `mvmctl machine stop <vm>`

--- a/public/src/content/docs/sdk/runtime-modes.md
+++ b/public/src/content/docs/sdk/runtime-modes.md
@@ -14,10 +14,10 @@ The mode decides which job is happening.
 
 | Mode | Command | Executes SDK script on host | Boots a microVM | Output |
 | --- | --- | --- | --- | --- |
-| Record | `mvmctl compile ./sandbox.py` | Yes | No | Workload IR or build input. |
+| Record | `mvmctl build compile ./sandbox.py` | Yes | No | Workload IR or build input. |
 | Plan | `mvmctl run --mode plan ./sandbox.py` | Yes | No | Admission/preflight plan. |
 | Live | `mvmctl run --mode live ./sandbox.py` | Yes | Yes | Real VM lifecycle and operations. |
-| Static declaration | `mvmctl compile ./app.py` | No import of the user module | No | Workload IR from literal declarations. |
+| Static declaration | `mvmctl build compile ./app.py` | No import of the user module | No | Workload IR from literal declarations. |
 
 Runtime scripts are imperative. The host runs the script so `Sandbox.create(...)`,
 `sandbox.files.write(...)`, and `sandbox.commands.start(...)` can be recorded or
@@ -34,7 +34,7 @@ Record mode is the default SDK transport. The script creates one sandbox handle,
 then each supported operation appends to an in-process recording.
 
 ```sh
-mvmctl compile ./sandbox.py --out /tmp/workload-ir
+mvmctl build compile ./sandbox.py --out /tmp/workload-ir
 ```
 
 Equivalent explicit environment for direct debugging:

--- a/public/src/content/docs/sdk/runtime.mdx
+++ b/public/src/content/docs/sdk/runtime.mdx
@@ -46,7 +46,7 @@ sandbox.commands.start(["node", "/app/main.js"]);
 <TabItem label="CLI">
 
 ```sh
-mvmctl compile ./agent.py --out /tmp/agent-ir
+mvmctl build compile ./agent.py --out /tmp/agent-ir
 mvmctl run --mode plan ./agent.py
 mvmctl run --mode live ./agent.py
 ```

--- a/public/src/content/docs/sdk/sandbox-types.md
+++ b/public/src/content/docs/sdk/sandbox-types.md
@@ -11,7 +11,7 @@ can layer specialized helpers over that substrate.
 
 | Type | Best for | Current path | SDK status |
 | --- | --- | --- | --- |
-| General sandbox | Commands, files, services, long-running work. | `mvmctl build`, `mvmctl up`, `mvmctl exec`, `mvmctl machine fs`, `mvmctl machine logs`. | Partial Python/TypeScript runtime surface. |
+| General sandbox | Commands, files, services, long-running work. | `mvmctl build`, `mvmctl machine run`, `mvmctl exec`, `mvmctl machine fs`, `mvmctl machine logs`. | Partial Python/TypeScript runtime surface. |
 | Code sandbox | Short code execution and interpreter-style tools. | `mvmctl run -- <cmd>` or a named Python manifest. | Planned convenience helper. |
 | Browser sandbox | Browser automation with Playwright/Puppeteer-like tooling. | Build a browser-capable Nix image, run automation inside the guest, forward explicit ports if needed. | Planned high-level helper. |
 | Desktop sandbox | GUI or computer-use workflows. | Backend- and image-specific today; use explicit images and port/console access. | Planned high-level helper. |
@@ -23,8 +23,8 @@ Use this for the broad lifecycle:
 
 ```sh
 mvmctl init ./worker --preset python
-mvmctl build ./worker
-mvmctl up ./worker --name worker
+mvmctl machine build --flake ./worker
+mvmctl machine run --flake ./worker --name worker -d
 mvmctl exec worker -- python /work/task.py
 ```
 
@@ -46,7 +46,7 @@ mvmctl run --timeout 10 -- python -c 'print(2 + 2)'
 Use a named sandbox when state is intentional:
 
 ```sh
-mvmctl up ./python-tool --name pytool
+mvmctl machine run --flake ./python-tool --name pytool -d
 mvmctl exec pytool -- python /work/cell.py
 ```
 

--- a/public/src/content/docs/security/matryoshka.md
+++ b/public/src/content/docs/security/matryoshka.md
@@ -43,7 +43,7 @@ L1 (host + hypervisor) doesn't carry its own claim — the host is **trusted** b
 
 ## Intent-bound admission profiles
 
-Every workload also goes through a signed admission step before boot. `mvmctl up` synthesizes an `ExecutionPlan`, signs it with the host key, checks its validity window and replay nonce, then emits a chain-signed audit entry.
+Every workload also goes through a signed admission step before boot. `mvmctl machine run` synthesizes an `ExecutionPlan`, signs it with the host key, checks its validity window and replay nonce, then emits a chain-signed audit entry.
 
 The plan now carries an `admission_profile`: a compact record of the workload's declared intent and the controls selected for that intent:
 

--- a/public/src/content/docs/templates/build.md
+++ b/public/src/content/docs/templates/build.md
@@ -12,8 +12,8 @@ mvmctl build
 Or point at a project directory or manifest file:
 
 ```sh
-mvmctl build ./my-worker
-mvmctl build ./my-worker/mvm.toml
+mvmctl machine build --flake ./my-worker
+mvmctl machine build --flake ./my-worker/mvm.toml
 ```
 
 `mvmctl build` discovers `mvm.toml` or `Mvmfile.toml`, runs the Nix build
@@ -49,11 +49,11 @@ VMs. Use `mvmctl manifest *` for build slots and registry state.
 ## Boot after build
 
 ```sh
-mvmctl up
+mvmctl machine run --manifest .
 mvmctl exec ./my-worker -- uname -a
 ```
 
-If there is no built revision for the manifest, `mvmctl up` should fail with a
+If there is no built revision for the manifest, `mvmctl machine run` should fail with a
 hint to run `mvmctl build`.
 
 ## Security checklist

--- a/public/src/content/docs/templates/index.md
+++ b/public/src/content/docs/templates/index.md
@@ -20,7 +20,7 @@ mvmctl init my-worker --preset worker
 cd my-worker
 $EDITOR mvm.toml
 mvmctl build
-mvmctl up
+mvmctl machine run --manifest .
 ```
 
 The build produces a manifest-keyed slot in the local registry. Subsequent

--- a/public/src/content/docs/tutorials/coding-agent.md
+++ b/public/src/content/docs/tutorials/coding-agent.md
@@ -27,7 +27,7 @@ For local development through this repository, the builder VM is the Linux build
 ## Run the task
 
 ```sh
-mvmctl up --flake . --name coding-agent
+mvmctl machine run --flake . --name coding-agent
 mvmctl exec coding-agent -- bash -lc 'cd /work && python task.py'
 ```
 

--- a/public/src/content/docs/tutorials/interactive-terminal.md
+++ b/public/src/content/docs/tutorials/interactive-terminal.md
@@ -14,7 +14,7 @@ Use the existing console and guest RPC surfaces:
 ## Recommended flow
 
 ```sh
-mvmctl up ./mvm.toml --name debug-vm
+mvmctl machine run --manifest ./mvm.toml --name debug-vm -d
 mvmctl machine console debug-vm
 mvmctl machine logs debug-vm -f
 ```

--- a/public/src/content/docs/tutorials/long-running-services.md
+++ b/public/src/content/docs/tutorials/long-running-services.md
@@ -14,7 +14,8 @@ Services need more lifecycle structure than one-shot commands.
 - Use `mvmctl machine logs`, `mvmctl wait`, and `mvmctl boot-report` for diagnostics.
 
 ```sh
-mvmctl up ./mvm.toml --name api-dev -p 8080:8080
+mvmctl machine run --manifest ./mvm.toml --name api-dev -d
+mvmctl machine forward api-dev -p 8080:8080
 mvmctl wait api-dev --for all
 mvmctl machine logs api-dev -f
 ```

--- a/public/src/content/docs/working/commands.md
+++ b/public/src/content/docs/working/commands.md
@@ -29,7 +29,7 @@ mvmctl run --dry-run --json -- python task.py
 ## Named VM commands
 
 ```sh
-mvmctl up ./my-app --name agent-sandbox
+mvmctl machine run --flake ./my-app --name agent-sandbox -d
 mvmctl exec agent-sandbox -- python /work/task.py
 mvmctl machine logs agent-sandbox -f
 ```

--- a/public/src/content/docs/working/index.md
+++ b/public/src/content/docs/working/index.md
@@ -8,8 +8,8 @@ description: Local sandbox management with mvmctl.
 ## Common lifecycle
 
 ```sh
-mvmctl build ./my-app
-mvmctl up ./my-app --name agent-sandbox
+mvmctl machine build --flake ./my-app
+mvmctl machine run --flake ./my-app --name agent-sandbox -d
 mvmctl exec agent-sandbox -- python /work/task.py
 mvmctl machine logs agent-sandbox -f
 mvmctl machine stop agent-sandbox

--- a/public/src/content/docs/working/lifecycle-states.md
+++ b/public/src/content/docs/working/lifecycle-states.md
@@ -13,13 +13,13 @@ cleanup is still required.
 | State | What it means | Common next action | Security note |
 | --- | --- | --- | --- |
 | No image | No build artifact exists for the workload yet. | `mvmctl build` | Build inputs still need policy and secret review before launch. |
-| Built | A launchable artifact exists, but no sandbox is running. | `mvmctl up` or `mvmctl run` | Artifact metadata can reveal package, path, and configuration choices. |
+| Built | A launchable artifact exists, but no sandbox is running. | `mvmctl machine run` or `mvmctl run` | Artifact metadata can reveal package, path, and configuration choices. |
 | Starting | The backend is creating the VM, attaching drives, and waiting for readiness. | `mvmctl wait` or `mvmctl boot-report` | Admission failures should be reported without leaking secrets. |
 | Running | Guest compute is active and can execute commands, expose ports, write files, and emit logs. | `mvmctl exec`, `mvmctl machine logs`, `mvmctl machine fs`, `mvmctl machine stop`, or snapshot commands | Treat command output, files, logs, ports, and receipts as boundary-crossing data. |
 | Paused | Guest execution is suspended and can be resumed by the backend path that created the pause. | `mvmctl resume` | Paused memory can contain tokens, browser sessions, plaintext files, and process state. |
 | Cold | Compute is released while recoverable state is retained through a backend snapshot or checkpoint. | `mvmctl resume` or `mvmctl checkpoint restore` | Cold state is persistence, not a security boundary. Protect it like sensitive data. |
 | Restoring | The backend is loading saved state and re-establishing runtime control. | Wait for readiness, then verify workload health | Restore can fail because of backend, host, image, or policy drift. |
-| Stopped | Guest compute is no longer running, while build artifacts, logs, receipts, volumes, or snapshots may remain. | `mvmctl up`, `mvmctl sandbox gc`, or `mvmctl cleanup` | Stop is not erase. Review retained state before reusing or sharing the host. |
+| Stopped | Guest compute is no longer running, while build artifacts, logs, receipts, volumes, or snapshots may remain. | `mvmctl machine run`, `mvmctl sandbox gc`, or `mvmctl cleanup` | Stop is not erase. Review retained state before reusing or sharing the host. |
 | Cleaned | Local registry entries and selected generated state have been removed by cleanup commands. | Rebuild from source if needed | Strong erasure depends on filesystem, volume, snapshot, and cache behavior. |
 
 ## Command map
@@ -27,7 +27,7 @@ cleanup is still required.
 | Transition | CLI surface |
 | --- | --- |
 | Source to image | `mvmctl build` |
-| Image to running sandbox | `mvmctl up` or `mvmctl run` |
+| Image to running sandbox | `mvmctl machine run` or `mvmctl run` |
 | Wait for readiness | `mvmctl wait`, `mvmctl boot-report` |
 | Run work | `mvmctl exec`, `mvmctl machine fs`, `mvmctl machine logs`, port-forwarding commands |
 | Running to paused or cold | `mvmctl pause`, `mvmctl checkpoint create` |

--- a/public/src/content/docs/working/network.md
+++ b/public/src/content/docs/working/network.md
@@ -10,17 +10,17 @@ Networking is part of the sandbox contract. Name what the guest can reach, name 
 Use a preset when it matches the workload:
 
 ```sh
-mvmctl up --flake . --network-preset none
-mvmctl up --flake . --network-preset registries
-mvmctl up --flake . --network-preset dev
+mvmctl machine run --flake .
+mvmctl machine run --flake . --net
+mvmctl machine run --flake . --net
 ```
 
 Use explicit allow rules for narrow agent workloads:
 
 ```sh
-mvmctl up --flake . \
-  --network-allow api.example.com:443 \
-  --network-allow github.com:443
+mvmctl machine run --flake . \
+  --allow-host api.example.com:443 \
+  --allow-host github.com:443
 ```
 
 For security-sensitive examples, start from no egress and add only required destinations.
@@ -31,8 +31,9 @@ For grant review, SDK declarations, and agent-tool policy, see [Network egress p
 Expose a guest service to the host:
 
 ```sh
-mvmctl up --flake . --name api-dev -p 8080:8080
-mvmctl forward api-dev -p 3000:3000
+mvmctl machine run --flake . --name api-dev -d
+mvmctl machine forward api-dev -p 8080:8080
+mvmctl machine forward api-dev -p 3000:3000
 ```
 
 Use readiness and logs while developing services:

--- a/public/src/content/docs/working/sandbox-management.md
+++ b/public/src/content/docs/working/sandbox-management.md
@@ -9,11 +9,11 @@ Use `mvmctl` when you need the local management layer for sandboxes.
 
 ```sh
 mvmctl init ./agent-sandbox --preset python
-mvmctl build ./agent-sandbox
-mvmctl up ./agent-sandbox --name agent-sandbox
+mvmctl machine build --flake ./agent-sandbox
+mvmctl machine run --flake ./agent-sandbox --name agent-sandbox -d
 ```
 
-`mvmctl build` uses the builder VM for Linux image construction. `mvmctl up` boots the runtime guest from the built artifact.
+`mvmctl build` uses the builder VM for Linux image construction. `mvmctl machine run` boots the runtime guest from the built artifact.
 
 ## Inspect
 
@@ -30,7 +30,7 @@ Use JSON output where commands support it when integrating with tooling.
 ```sh
 mvmctl exec agent-sandbox -- python /work/task.py
 mvmctl machine fs ls agent-sandbox /work
-mvmctl forward agent-sandbox -p 8080:8080
+mvmctl machine forward agent-sandbox -p 8080:8080
 ```
 
 Command execution, file operations, and port forwarding cross trust boundaries. Keep command args explicit, file paths narrow, and ports intentional.


### PR DESCRIPTION
Brings the README and website docs in line with the current `mvmctl` command
tree. Two related passes, docs-only, no code paths touched.

## 1. `mvmctl compile` → `mvmctl build compile`

Build-time verbs moved under the `build` group, so top-level `mvmctl compile`
no longer resolves. Renamed everywhere (README + docs), and fixed the adjacent
dead commands on the same SDK workflow lines:
- `mvmctl invoke <vm> --input k=v` → `mvmctl machine run --entrypoint` with the
  `[args, kwargs]` JSON payload on stdin (empty ⇒ `[[], {}]`)
- bare `mvmctl build <dir>` → `mvmctl machine build --flake <dir>`

## 2. `mvmctl up` → `mvmctl machine run` (+ removed-feature rewrites)

`mvmctl up` is **removed** (folded into `machine run`/`machine create`), and
several of its flags have no `machine run` equivalent — so this is a rewrite,
not a rename. Verified every mapping against the CLI:

- `mvmctl up [--flake|--manifest|<path>|<slot>]` → `mvmctl machine run …`
  (persistent `--name`/console/exec examples get `-d`)
- `mvmctl forward` → `machine forward`; `mvmctl exec <name>` (into a booted
  machine) → `machine exec`; bare `mvmctl build <path>` → `machine build --flake`
- **ports**: `-p` isn't on `machine run` — boot a named machine, then
  `machine forward <name> -p LOCAL:GUEST` (transient one-liners become two commands)
- **egress**: `--network-preset`/`--network-allow` → `--net` / `--allow-host`
  (deny-all default); preset tables replaced with the two-flag model
- **seccomp**: `--seccomp <tier>` → `--profile restrictive|standard|dev|permissive`
- dropped `--metrics-port` / `--network <name>`; `--hypervisor apple-container` → `vz`
- rewrote the `cli-commands.md` VM-lifecycle table + beginner/advanced framing

### Judgment calls (flagged)
- preset granularity (registries/dev/agent) collapses to `--net` or explicit
  `--allow-host`; seccomp tiers map only approximately onto `--profile`
- signed-bundle boot (`up --bundle *.mvmpkg`) has **no** `machine run` equivalent —
  changed to `machine check-artifact` (verify); the actual boot verb needs confirmation

### Known follow-ups (NOT in this PR — separate scope)
- `mvmctl exec` transient examples (~25) split between `machine run` (transient)
  and `machine exec` (into a running machine) — needs the same case-by-case work
- `apple-container`/`docker` **backend-name prose** (networking backends,
  troubleshooting codesigning section, ADR-001) still to update
- validity of `mvmctl wait` / `machine boot-report` / `dev up --metrics-port`
- `mvmctl run --mode plan|live` intentionally kept (hidden but real SDK transport)

~65 files changed across the two commits.