### PR TITLE
docs: migrate `mvmctl exec` split + `Apple Container`→`Vz`; drop Docker-as-backend

### DIFF
--- a/public/src/content/docs/contributing/adr/001-multi-backend.md
+++ b/public/src/content/docs/contributing/adr/001-multi-backend.md
@@ -24,7 +24,7 @@ Use Firecracker as the primary production backend. Support multiple backends: Ap
 ## Rationale
 
 - **Firecracker**: Minimalist design (<50K LOC), ~125ms cold boot, snapshot support, hardware isolation via KVM
-- **Apple Container**: Sub-second startup on macOS 26+, native Hypervisor.framework, native vsock -- ideal for dev workflows
+- **Vz**: Sub-second startup on macOS 26+, native Hypervisor.framework, native vsock -- ideal for dev workflows
 - **Auto-selection**: Developers get the best experience on their platform without manual configuration
 - **Docker**: Universal fallback when no hypervisor is available -- pause/resume via container lifecycle, unix socket guest channel
 - **microvm.nix**: NixOS-native QEMU runner with vsock and TAP networking support
@@ -41,7 +41,7 @@ Override with `--hypervisor firecracker`, `--hypervisor vz`, `--hypervisor qemu`
 
 ## Consequences
 
-- Requires native Linux with `/dev/kvm` for Firecracker, or macOS 26+ Apple Silicon for Apple Container
+- Requires native Linux with `/dev/kvm` for Firecracker, or macOS 26+ Apple Silicon for Vz
 - libkrun support is scoped to Linux KVM and macOS Apple Silicon; macOS Intel is not a supported local host
 - WSL2 nested KVM and Hyper-V managed Linux builders are future backend work, not current support
 - Guests must use a Linux kernel (no Windows/macOS guests)

--- a/public/src/content/docs/contributing/development.md
+++ b/public/src/content/docs/contributing/development.md
@@ -6,7 +6,7 @@ description: Getting started as a contributor to mvm.
 ## Prerequisites
 
 - **Rust 1.85+** (Edition 2024) — install via [rustup](https://rustup.rs)
-- **macOS Apple Silicon or Linux** — macOS for development via Apple Container (26+) or libkrun (pre-26); Linux for native `/dev/kvm`. Intel Macs are not a supported local microVM host.
+- **macOS Apple Silicon or Linux** — macOS for development via Vz (26+) or libkrun (pre-26); Linux for native `/dev/kvm`. Intel Macs are not a supported local microVM host.
 - **`zig` + `cargo-zigbuild`** — source-checkout contributors only; `crates/mvm-cli/build.rs` uses them to cross-compile the embedded host-VM binaries (`mvm-host-vm-init`, `mvm-egress-proxy`) as static `aarch64-unknown-linux-musl`. End-users running a downloaded `mvmctl` don't need them.
 - **Nix** — not needed on the host. Nix evaluation and `nix build` run inside the builder VM.
 
@@ -205,7 +205,7 @@ just lint         # Both format check + clippy
 
 ### Multi-Backend
 
-mvmctl's supported local microVM hosts are native Linux with `/dev/kvm` and macOS Apple Silicon. Firecracker is the Linux baseline; Apple Container and libkrun-backed components cover Apple Silicon macOS. Docker remains a Tier 3 convenience fallback, not a microVM isolation boundary. WSL2 nested KVM and a Hyper-V managed Linux builder are future backend work.
+mvmctl's supported local microVM hosts are native Linux with `/dev/kvm` and macOS Apple Silicon. Firecracker is the Linux baseline; Vz and libkrun-backed components cover Apple Silicon macOS. WSL2 nested KVM and a Hyper-V managed Linux builder are future backend work.
 
 ### Host vs. VM
 
@@ -270,7 +270,7 @@ microVMs have no SSH. Interactive access is via `mvmctl machine console` which u
 - Authenticated via the existing Ed25519 vsock protocol
 - Dev-mode only (`access.console` must be `true` in the guest security policy)
 - Single session per VM, 15-minute idle timeout
-- Supports both Firecracker and Apple Container backends
+- Supports both Firecracker and Vz backends
 
 ### XDG Directory Layout
 

--- a/public/src/content/docs/getting-started/quickstart.md
+++ b/public/src/content/docs/getting-started/quickstart.md
@@ -156,16 +156,16 @@ mvmctl machine console myvm --command "ls -la" # One-shot command
 
 ## 8. Sandboxed One-Shot Commands
 
-`mvmctl exec` boots a fresh transient microVM, runs a single command, and tears
-it down on exit -- like `docker run --rm`, but with a Firecracker microVM as
-the sandbox. No `--flake` or `--manifest` needed; the bundled default image
-boots automatically the first time.
+`mvmctl machine run -- <cmd>` boots a fresh transient microVM, runs a single
+command, and tears it down on exit -- like `docker run --rm`, but with a
+Firecracker microVM as the sandbox. Name a source with `--image`, `--flake`,
+or `--manifest`.
 
 ```bash
-mvmctl exec -- uname -a                            # bundled default image
-mvmctl exec --add-dir .:/work -- ls /work          # share host dir, read-only
-mvmctl exec --env DEBUG=1 -- env | grep DEBUG      # inject env vars
-mvmctl exec --manifest my-tpl -- /bin/true         # registered template
+mvmctl machine run --image alpine -- uname -a                    # OCI image, one-shot
+mvmctl machine run --flake . --volume .:/work -- ls /work        # share host dir, read-only
+mvmctl machine run --image alpine -e DEBUG=1 -- env | grep DEBUG # inject env vars
+mvmctl machine run --manifest my-tpl -- /bin/true                # registered template
 ```
 
 When you reuse a registered template that has a captured snapshot, exec

--- a/public/src/content/docs/guides/exec.md
+++ b/public/src/content/docs/guides/exec.md
@@ -3,129 +3,91 @@ title: Sandboxed Exec
 description: Run a single command inside a fresh microVM and tear it down on exit.
 ---
 
-`mvmctl exec` is the "send off a single task in a microVM" workflow.
-It boots a fresh transient Firecracker microVM, runs one command via
-the guest agent, streams stdout/stderr back to your terminal, propagates
-the exit code, and tears the VM down -- success, failure, or Ctrl-C.
+Running a single command in a fresh transient microVM is the
+`mvmctl machine run -- <cmd>` workflow: it boots a microVM from a source you
+name (`--image`, `--flake`, or `--manifest`), runs one command via the guest
+agent, streams stdout/stderr back to your terminal, propagates the exit code,
+and tears the VM down -- success, failure, or Ctrl-C.
 
 Think `docker run --rm`, but with a microVM as the isolation boundary.
 
 ```bash
-mvmctl exec -- uname -a
-mvmctl exec --add-dir .:/work -- ls /work
-mvmctl exec --manifest my-tpl -- /bin/true
-mvmctl exec --launch-plan ./launch.json
+mvmctl machine run --image alpine -- uname -a
+mvmctl machine run --flake . --volume .:/work -- ls /work
+mvmctl machine run --manifest my-tpl -- /bin/true
 ```
 
-> `mvmctl exec` is **dev-mode only** -- the guest agent's Exec handler is
-> compiled in only when the `dev-shell` Cargo feature is enabled. Production
-> guest builds omit the feature, so the handler is not present in the binary
-> at all and `exec` is physically unavailable. It is not meant for production
-> workloads; use `mvmctl machine run` (or `mvmd`) for those.
+> Overriding the guest's argv (a trailing `-- <cmd>`) is a **dev-tier**
+> capability. A sealed production image refuses it (claim 15) — its entrypoint
+> is fixed and there is no interactive command surface. Use `--image`/`--flake`
+> dev builds for ad-hoc commands; production workloads run their baked
+> entrypoint (`machine run --entrypoint`) or go through `mvmd`.
 
 ## When to use it
 
-- **Reach for `mvmctl exec`** when you want to run an untrusted binary,
-  a build script, an LLM-generated command, or any one-shot task that
-  benefits from a strong isolation boundary but doesn't justify standing
-  up a long-running VM.
-- **Reach for `mvmctl machine run`** when you want a long-running VM you can
-  re-enter, share state with, or expose ports from.
-- **Reach for `mvmctl machine console <vm> --command "..."`** when you already
-  have a VM running and want to run something inside it without a fresh
-  boot.
+- **Reach for a transient `mvmctl machine run -- <cmd>`** when you want to run
+  an untrusted binary, a build script, an LLM-generated command, or any
+  one-shot task that benefits from a strong isolation boundary but doesn't
+  justify a long-running VM.
+- **Reach for a persistent `mvmctl machine run --name <n> -d`** when you want a
+  VM you can re-enter, share state with, or forward ports from.
+- **Reach for `mvmctl machine exec <n> -- <cmd>`** when you already have a named
+  VM running and want to run something inside it without a fresh boot.
 
-## The bundled default image
+## Choosing a source
 
-If you don't pass `--manifest` or `--flake`, `mvmctl exec` boots the
-bundled default image:
+`mvmctl machine run` always boots from a source you name — there is no bundled
+default image:
 
-- A minimal `mkGuest` rootfs (busybox-as-PID-1 + the supervised guest
-  agent) shipped with mvm itself. Internally it lives at
-  `nix/profiles/minimal.nix` in the workspace, but you should treat
-  it as opaque infrastructure — to customize the image you write
-  your own flake using `mvm.lib.<system>.mkGuest` (see
+- `--image <ref>` — an OCI image, pulled and cached (no host Nix, no flake).
+  The fastest path for ad-hoc commands.
+- `--flake <ref>` — a Nix flake built in the builder VM. Customize the guest
+  with `mvm.lib.<system>.mkGuest` (see
   [Building MicroVM Images](/guides/building-microvm-images) +
-  [Dev Image](/guides/dev-image)) instead of editing mvm internals.
-- Built via Nix on first use, cached at `~/.cache/mvm/default-microvm/`
-  (kernel + rootfs).
-- Identical for every invocation that doesn't pass `--manifest`.
+  [Dev Image](/guides/dev-image)).
+- `--manifest <name>` — a pre-built manifest slot or registered template, which
+  skips the build step entirely.
 
-If your host has no working Nix builder, `mvmctl exec` will fail with a
-clear error. Pass `--manifest <name>` (a registered template you've
-already built) to skip the Nix path.
+## Sharing host directories: `--volume`
 
-## Sharing host directories: `--add-dir`
-
-`--add-dir HOST:GUEST[:MODE]` materializes the host directory into a
-small ext4 image, attaches it as an extra Firecracker drive, and mounts
-it at `GUEST` inside the microVM. `MODE` is `ro` (default) or `rw`. The
-flag is repeatable.
+`--volume HOST:GUEST[:MODE]` shares a host directory into the guest at
+`GUEST`. `MODE` is `ro` (default) or `rw`; a writable share requires
+`--profile dev` or `--profile permissive`. The flag is repeatable.
 
 ### Read-only (default)
 
 ```bash
 echo "hello" > /tmp/foo
-mvmctl exec --add-dir /tmp:/host -- cat /host/foo     # prints "hello"
+mvmctl machine run --image alpine --volume /tmp:/host -- cat /host/foo     # prints "hello"
 ```
-
-The guest sees the contents at boot. Writes inside the guest are
-discarded when the microVM is torn down.
 
 ### Writable: `:rw`
 
 ```bash
-mvmctl exec --add-dir .:/work:rw -- sh -c 'echo result > /work/output.txt'
+mvmctl machine run --flake . --profile dev --volume .:/work:rw -- sh -c 'echo result > /work/output.txt'
 cat ./output.txt       # "result" — written by the guest
 ```
 
-The mount is read-write inside the guest. Once the command exits and
-the VM stops, the ext4 image is mounted host-side and `rsync -aH
---delete`-ed back over the host directory. New files appear, modified
-files are updated, and files removed inside the guest are removed on
-the host.
-
-This is the equivalent of an external sandbox-wrapper CLI's writable project directory --
-exactly what you want for a coding agent that needs to edit your repo.
-
-#### Trade-offs
-
-See [ADR-002](/contributing/adr/002-writable-add-dir/) for the full
-design rationale. Highlights for v1:
-
-- **No in-flight host visibility.** Guest writes only land on the host
-  *after* the command exits. Host-side `tail -f`-style tooling won't see
-  partial output.
-- **Last-writer-wins on concurrent host writes.** If you modify a file
-  on the host while the guest is also modifying it, the guest's version
-  overwrites the host's at teardown. v1 is for agentic flows where the
-  host isn't editing the same directory in parallel.
-- **No incremental durability.** A 30-minute task that crashes at
-  minute 29 loses all guest writes -- the rsync only runs after a clean
-  exit. Keep `mvmctl exec` for short-lived invocations; long-lived
-  workloads belong in `mvmd`.
-- **Guest deletes propagate.** The rsync uses `--delete`, so files
-  removed inside the guest are removed on the host.
-
-For a live two-way mount (visible during the run, no clobber semantics),
-virtio-fs is on the v2 roadmap once Firecracker ships upstream
-`vhost-user-fs` support.
+A writable share lets the guest edit host files under `GUEST` — exactly what
+you want for a coding agent that needs to edit your repo. For the durability
+and host-visibility semantics of the current volume backend, see the
+[machine volume docs](/guides/machine-use-cases/).
 
 ### Multiple shares
 
 Modes are independent per directory:
 
 ```bash
-mvmctl exec \
-  --add-dir ./src:/work:rw \
-  --add-dir ~/.cargo:/root/.cargo:ro \
+mvmctl machine run --flake . --profile dev \
+  --volume ./src:/work:rw \
+  --volume ~/.cargo:/root/.cargo:ro \
   -- cargo build --manifest-path /work/Cargo.toml
 ```
 
 ## Injecting environment variables: `--env`
 
 ```bash
-mvmctl exec --env FOO=bar --env BAZ=qux -- env | grep -E '^(FOO|BAZ)='
+mvmctl machine run --image alpine -e FOO=bar -e BAZ=qux -- env | grep -E '^(FOO|BAZ)='
 ```
 
 `--env` (or `-e`) is repeatable. When used together with `--launch-plan`,
@@ -134,35 +96,35 @@ CLI `--env` overrides any env vars the launch plan carries (see below).
 ## Snapshot restore (registered templates)
 
 When you pass `--manifest <name>` and that template has a captured
-snapshot, `mvmctl exec` restores from the snapshot instead of cold-booting.
+snapshot, `mvmctl machine run` restores from the snapshot instead of cold-booting.
 This skips the kernel boot and service-start cost -- typically sub-second
 on Linux/KVM.
 
 The snapshot path activates only when:
 
-- the image source is a registered template (the bundled default has no
+- the image source is a registered template (an OCI image or ad-hoc flake has no
   template snapshot to restore from), AND
-- the request has **no** `--add-dir` extras (extra drives would mismatch
+- the request has **no** `--volume` extras (extra drives would mismatch
   the snapshot's recorded layout), AND
 - the active backend reports snapshot support.
 
-On macOS backends without Firecracker (Apple Container, libkrun), vsock snapshots return `os error 95` (EOPNOTSUPP);
+On macOS backends without Firecracker (Vz, libkrun), vsock snapshots return `os error 95` (EOPNOTSUPP);
 restore failures fall back to cold boot with a warning rather than
 aborting. The harder branch -- parameterized snapshots that allow
-`--add-dir` -- is tracked in [issue #7](https://github.com/tinylabscom/mvm/issues/7).
+`--volume` -- is tracked in [issue #7](https://github.com/tinylabscom/mvm/issues/7).
 
 ## Resource controls
 
 ```bash
-mvmctl exec --cpus 4 --memory 1G -- ./benchmark.sh
-mvmctl exec --timeout 300 -- ./long-running-task.sh
+mvmctl machine run --flake . --cpus 4 --memory 1G -- ./benchmark.sh
+mvmctl machine run --flake . --timeout 300 -- ./long-running-task.sh
 ```
 
 Defaults: 2 vCPUs, 512 MiB, 60-second timeout per command.
 
 ## Driving from a launch plan
 
-`mvmctl exec --launch-plan <path>` accepts either of two JSON
+`mvmctl run --launch-plan <path>` accepts either of two JSON
 shapes — a `launch.json` artifact (top-level `entrypoint`) or a
 Workload IR manifest (top-level `apps[]`) — and auto-detects which
 one it is given. Both shapes were historically produced by the
@@ -172,11 +134,11 @@ the canonical producer today is `mvmctl build compile` in the mvm SDK.
 
 ```bash
 mvmctl build compile manifest.json --out ./build
-mvmctl exec --launch-plan ./build/launch.json
+mvmctl run --launch-plan ./build/launch.json
 ```
 
 Only the entrypoint is consumed in v1; image selection still comes from
-`--manifest` or the bundled default.
+`--manifest`/`--image`/`--flake`.
 
 **LaunchPlan artifact** (top-level `entrypoint`):
 
@@ -217,7 +179,7 @@ the SDK bakes the entrypoint into the generated flake's
 reboots.
 
 Multi-app launch plans are rejected -- that's an orchestration concern
-that belongs in `mvmd`, not in `mvmctl exec`. Env precedence (lowest →
+that belongs in `mvmd`, not in `mvmctl machine run`. Env precedence (lowest →
 highest):
 
 1. `apps[].env`
@@ -228,36 +190,36 @@ highest):
 
 ## Teardown semantics
 
-- **Normal exit**: VM is stopped and the staging dir for `--add-dir`
+- **Normal exit**: VM is stopped and the staging dir for `--volume`
   images is cleaned up.
-- **Non-zero exit**: same as normal exit; `mvmctl exec` propagates the
+- **Non-zero exit**: same as normal exit; `mvmctl machine run` propagates the
   guest's exit code.
 - **Ctrl-C**: a SIGINT handler triggers teardown so the Firecracker
   process and any tap interface don't get orphaned.
-- **Hard kill** (`kill -9` on `mvmctl exec` itself): teardown is
+- **Hard kill** (`kill -9` on `mvmctl machine run` itself): teardown is
   best-effort; you may need `mvmctl ls` and `mvmctl machine stop <name>` to
   clean up. Each unnamed transient VM gets a generated name like
   `brisk-otter-a1b2`, so it is easy to spot.
 
 ## Limits
 
-- **Dev-mode only.** `mvmctl exec` requires a guest agent built with the
+- **Dev-mode only.** `mvmctl machine run` requires a guest agent built with the
   `dev-shell` Cargo feature, which is the default for the dev images
   `mvmctl` ships with. Production guest images omit the feature and the
   Exec handler is physically absent from the binary.
 - **Network access.** The guest gets the same network configuration
   any other transient VM gets -- if your `--manifest` exposes outbound
-  internet, so does `mvmctl exec` from that template.
+  internet, so does `mvmctl machine run` from that template.
 - **Stdin** is currently *not* forwarded to the guest. Pipe data via a
-  `--add-dir`-shared file instead. Streaming stdin is a future
+  `--volume`-shared file instead. Streaming stdin is a future
   improvement.
 - **Persistent state** doesn't survive teardown beyond what `:rw`
-  `--add-dir` rsyncs back. For larger or longer-lived state, use
+  `--volume` rsyncs back. For larger or longer-lived state, use
   `mvmctl machine run` with a persistent volume.
 
 ## See also
 
 - [CLI reference: One-shot Exec](/reference/cli-commands/#one-shot-exec)
 - [Manifests guide](/guides/manifests/) -- build a reusable base image
-  via `mvm.toml`; `mvmctl exec [PATH]` accepts the manifest path directly
+  via `mvm.toml`; `mvmctl machine run [PATH]` accepts the manifest path directly
 - [Quick Start](/getting-started/quickstart/#7-sandboxed-one-shot-commands)

--- a/public/src/content/docs/guides/manifests.md
+++ b/public/src/content/docs/guides/manifests.md
@@ -199,7 +199,7 @@ For running VMs (separate concern), continue to use `mvmctl ls` / `mvmctl machin
 ```bash
 mvmctl machine run --manifest .                            # boot from slot keyed by manifest at cwd
 mvmctl machine run --manifest /path/to/project           # explicit
-mvmctl exec /path/to/project -- uname -a   # ephemeral one-shot
+mvmctl machine run --manifest /path/to/project -- uname -a   # ephemeral one-shot
 ```
 
 If no current revision exists, you get an error with a hint to run `mvmctl build`. If the manifest's `vcpus`/`mem` differ from what the slot's snapshot was taken at, the snapshot is ignored and a cold-boot from the rootfs proceeds (with a warning).

--- a/public/src/content/docs/guides/networking.md
+++ b/public/src/content/docs/guides/networking.md
@@ -10,10 +10,9 @@ Networking differs by backend:
 | Backend | Network Type | Guest IP | Host Access |
 |---------|-------------|----------|-------------|
 | Firecracker (Linux native) | TAP device | 172.16.0.2/30 | Direct via TAP |
-| Apple Container | vmnet | DHCP-assigned | Via vmnet bridge |
+| Vz | vmnet | DHCP-assigned | Via vmnet bridge |
 | libkrun (macOS) | TSI (transparent socket impl) | host-loopback | Via per-port vsock listeners |
 | microvm.nix | TAP device | 172.16.0.2/30 | Direct via TAP |
-| Docker | Docker bridge | Docker-assigned | Via Docker port mapping |
 
 ## Firecracker Network Layout
 
@@ -23,7 +22,7 @@ Firecracker microVM (172.16.0.2/30, eth0)
 Linux host (172.16.0.1/30, tap0)  --  iptables NAT  --  internet
 ```
 
-On Linux with `/dev/kvm`, Firecracker boots directly on the host — no VM hop. The TAP device connects the microVM to the host network namespace and gets NAT'd to the internet. On macOS hosts, networking is backend-specific: Apple Container uses vmnet bridge mode; libkrun uses TSI (transparent socket impl) where outbound TCP/UDP appears as host-side socket calls.
+On Linux with `/dev/kvm`, Firecracker boots directly on the host — no VM hop. The TAP device connects the microVM to the host network namespace and gets NAT'd to the internet. On macOS hosts, networking is backend-specific: Vz uses vmnet bridge mode; libkrun uses TSI (transparent socket impl) where outbound TCP/UDP appears as host-side socket calls.
 
 ## Port Forwarding
 
@@ -44,7 +43,7 @@ MicroVMs don't use networking for host communication -- they use **vsock**:
 |------|----------|---------|
 | 5252 | Length-prefixed JSON | Guest agent (health checks, status, snapshot lifecycle) |
 
-The host connects by writing `CONNECT 5252\n` to the vsock socket and reading `OK 5252\n`. All requests are request/response pairs. vsock is supported on Firecracker, Apple Container, and microvm.nix backends. Docker uses a unix socket instead.
+The host connects by writing `CONNECT 5252\n` to the vsock socket and reading `OK 5252\n`. All requests are request/response pairs. vsock is supported on Firecracker, Vz, and microvm.nix backends.
 
 For Firecracker, the host-side vsock UDS is scoped to the running VM directory:
 `<vm-dir>/runtime/v.sock`. It is not a global or master socket. `mvmctl machine run`
@@ -103,7 +102,7 @@ The resolved profile is copied into the signed `ExecutionPlan` admission record 
 
 ## DNS
 
-The guest's `/etc/resolv.conf` is configured at build time to use the host's DNS resolver. Internet access works out of the box through the NAT chain (Firecracker), vmnet (Apple Container), or Docker bridge networking (Docker).
+The guest's `/etc/resolv.conf` is configured at build time to use the host's DNS resolver. Internet access works out of the box through the NAT chain (Firecracker), vmnet (Vz).
 
 ### Local addon DNS (opt-in)
 

--- a/public/src/content/docs/guides/nix-flakes.md
+++ b/public/src/content/docs/guides/nix-flakes.md
@@ -266,7 +266,7 @@ When you run `mvmctl build --flake .`:
 4. Kernel and rootfs artifacts are copied back to the host cache.
 5. Runtime commands boot those already-built artifacts on the selected backend.
 
-The same rootfs works on all backends (Firecracker, Apple Container, microvm.nix, Docker).
+The same rootfs works on all backends (Firecracker, Vz, microvm.nix).
 
 ## Profiles
 

--- a/public/src/content/docs/guides/persistent-workspaces.md
+++ b/public/src/content/docs/guides/persistent-workspaces.md
@@ -98,7 +98,7 @@ prefer copy-in/copy-out:
 
 ```sh
 mvmctl cp ./input.json agent-sandbox:/work/input.json
-mvmctl exec agent-sandbox -- python /work/task.py
+mvmctl machine exec agent-sandbox -- python /work/task.py
 mvmctl cp --max-bytes 16777216 agent-sandbox:/work/output.json ./output.json
 ```
 
@@ -141,7 +141,7 @@ mvmctl volume unlock coding-agent-work
 mvmctl machine run --flake ./agent-image --name coding-agent -d
 mvmctl volume mount coding-agent --volume coding-agent-work --guest /workspace --rw
 mvmctl cp ./task.json coding-agent:/work/task.json
-mvmctl exec coding-agent --timeout 120 -- python /work/run_task.py
+mvmctl machine exec coding-agent --timeout 120 -- python /work/run_task.py
 mvmctl cp --max-bytes 16777216 coding-agent:/work/result.json ./result.json
 mvmctl volume unmount coding-agent /workspace
 mvmctl machine stop coding-agent

--- a/public/src/content/docs/guides/troubleshooting.md
+++ b/public/src/content/docs/guides/troubleshooting.md
@@ -286,14 +286,14 @@ mvmctl machine run --flake . --hypervisor qemu    # microvm.nix
 mvmctl doctor   # check available backends
 ```
 
-### macOS: first-run codesigning for `apple-container` and `libkrun`
+### macOS: first-run codesigning for `vz` and `libkrun`
 
 Both `mvmctl machine run --hypervisor vz` and (once plan 57 W3 wires guest boot) `mvmctl machine run --hypervisor libkrun` need ad-hoc codesigning before the macOS kernel will let the binary touch the hypervisor APIs:
 
-- `com.apple.security.virtualization` — required by `Virtualization.framework` (the `apple-container` backend).
+- `com.apple.security.virtualization` — required by `Virtualization.framework` (the `vz` backend).
 - `com.apple.security.hypervisor` — required by direct `Hypervisor.framework` callers (the `libkrun` backend).
 
-On the **first** run of either backend, `mvmctl` ad-hoc signs itself with both entitlements and re-spawns the current invocation. The same signed binary covers both backends, so swapping `--hypervisor` between `apple-container` and `libkrun` does not re-sign.
+On the **first** run of either backend, `mvmctl` ad-hoc signs itself with both entitlements and re-spawns the current invocation. The same signed binary covers both backends, so swapping `--hypervisor` between `vz` and `libkrun` does not re-sign.
 
 What you'll see on the first run:
 

--- a/public/src/content/docs/guides/windows-wsl2.md
+++ b/public/src/content/docs/guides/windows-wsl2.md
@@ -10,7 +10,7 @@ This page captures WSL2 research notes for future Windows support. WSL2 is **not
 WSL2 is a real Linux kernel running under Hyper-V, but mvm does not yet treat it as a supported backend. A future WSL2 path would require nested KVM to be present and tested in CI. From inside a capable WSL2 distro:
 
 - **`/dev/kvm` may be available** on some Windows 11/WSL2 combinations. When it is missing, mvm cannot run the Linux KVM path.
-- **Filesystem is real Linux ext4**. APFS-style copy-on-write isn't here yet (Sprint 47 Plan D ships APFS CoW for macOS Apple Container; WSL2's ext4 will fall back to byte-copy in `mvm-runtime::vm::cow::reflink_or_copy`), but everything functionally works.
+- **Filesystem is real Linux ext4**. APFS-style copy-on-write isn't here yet (Sprint 47 Plan D ships APFS CoW for macOS Vz; WSL2's ext4 will fall back to byte-copy in `mvm-runtime::vm::cow::reflink_or_copy`), but everything functionally works.
 - **Networking is bridged** through Hyper-V's vmswitch. Port forwarding from Windows host to a WSL2 distro is automatic for `127.0.0.1` binds; mvm guests behind the WSL2 distro need an additional hop, covered below.
 
 The cost is one nested VM hop: workload runs inside a microVM, inside WSL2, inside Hyper-V on the Windows host. We do not currently publish performance or support guarantees for that stack.

--- a/public/src/content/docs/install/macos.md
+++ b/public/src/content/docs/install/macos.md
@@ -3,7 +3,7 @@ title: "Install mvm on macOS"
 description: "mvm on macOS supports Apple Silicon through Hypervisor.framework-backed local builder/runtime paths. Intel Macs are not a supported local microVM host."
 ---
 
-mvm on macOS is supported on **Apple Silicon (M-series)**. The local builder/runtime path uses Apple's Hypervisor.framework via Apple Container and libkrun-backed components. No Docker Desktop is required for the supported path.
+mvm on macOS is supported on **Apple Silicon (M-series)**. The local builder/runtime path uses Apple's Hypervisor.framework via Vz and libkrun-backed components. No Docker Desktop is required for the supported path.
 
 For the full host/backend matrix, see [Platform support](/reference/platform-support/).
 
@@ -12,7 +12,7 @@ Intel Macs are not a supported local microVM host. Use a Linux machine with `/de
 ## Prerequisites
 
 - Apple Silicon Mac.
-- macOS 26+ for the Apple Container dev VM path.
+- macOS 26+ for the Vz dev VM path.
 - libkrun installed for libkrun-backed builder/runtime components.
 
 You **do not need Nix on your Mac**. You run `mvmctl build` from macOS, and mvm runs Nix evaluation and `nix build` inside the Linux builder VM, then extracts the resulting rootfs back to the host. See [§"Linux builds on macOS"](#linux-builds-on-macos--zero-config-by-default) below for the design.
@@ -72,7 +72,7 @@ If you configure [`nix-darwin`'s `linux-builder`](https://nix.dev/manual/nix/sta
 mvmctl doctor
 ```
 
-`doctor` reports the active backend and libkrun availability. On an Apple Silicon Mac with macOS 26+, the dev path uses Apple Container and source image builds auto-detect the builder backend: Vz is preferred, and `mvmctl dev up` retries with libkrun when that auto-selected Vz builder path fails. Explicit `--builder` / `MVM_BUILDER_BACKEND` overrides still win.
+`doctor` reports the active backend and libkrun availability. On an Apple Silicon Mac with macOS 26+, the dev path uses Vz and source image builds auto-detect the builder backend: Vz is preferred, and `mvmctl dev up` retries with libkrun when that auto-selected Vz builder path fails. Explicit `--builder` / `MVM_BUILDER_BACKEND` overrides still win.
 
 ## First microVM
 
@@ -100,7 +100,7 @@ brew install libkrun
 
 ## Apple Silicon vs Intel notes
 
-- **Apple Silicon (M1/M2/M3/M4 and newer)** — supported local path. Apple Container covers the dev VM, and libkrun backs builder/runtime components that need Hypervisor.framework directly.
+- **Apple Silicon (M1/M2/M3/M4 and newer)** — supported local path. Vz covers the dev VM, and libkrun backs builder/runtime components that need Hypervisor.framework directly.
 - **Intel Macs** — unsupported for the local microVM path. Run mvm on a Linux KVM host, or use future remote/Windows-style builder work when it lands.
 
-The Apple Container backend requires Apple Silicon and macOS 26+. libkrun is also treated as an Apple Silicon macOS path for mvm support purposes.
+The Vz backend requires Apple Silicon and macOS 26+. libkrun is also treated as an Apple Silicon macOS path for mvm support purposes.

--- a/public/src/content/docs/reference/architecture.md
+++ b/public/src/content/docs/reference/architecture.md
@@ -32,7 +32,7 @@ genuinely backend-specific:
 | Backend | Selection mode | Notes |
 |---------|----------------|-------|
 | Firecracker | Auto on Linux with native KVM | Production Tier 1 backend |
-| Apple Container | Auto on supported macOS 26+ hosts | Preferred macOS local backend when available |
+| Vz | Auto on supported macOS 26+ hosts | Preferred macOS local backend when available |
 | libkrun | Auto fallback on supported hosts | Fast local Tier 2 backend |
 | Vz | Explicit opt-in (`--hypervisor vz`) | Supported, but not auto-selected |
 | QEMU | Explicit opt-in (`--hypervisor qemu`) | Linux dev/test backend |
@@ -202,7 +202,7 @@ operations. It is not the same thing as the selected workload runtime backend.
 | Host platform | Default runtime path |
 |---------------|----------------------|
 | Linux with native KVM | Firecracker |
-| Supported macOS 26+ host | Apple Container |
+| Supported macOS 26+ host | Vz |
 | Supported host with libkrun available | libkrun |
 
 Other backends such as Vz and QEMU exist, but they are selected explicitly rather than by

--- a/public/src/content/docs/reference/cli-commands.md
+++ b/public/src/content/docs/reference/cli-commands.md
@@ -308,7 +308,7 @@ with a Firecracker microVM as the sandbox. Plan 178 merged the former bare
 security `--profile`, OCI `--image`, signed `--receipt`, `--json`/`--dry-run`,
 and the SDK `--mode`/`--dev`/`--prod` transport. Arbitrary command dispatch
 requires a dev-feature guest agent (the `do_exec` handler is `dev-shell`-gated,
-claim 4); production guests should use `mvmctl invoke` (no shell).
+claim 4); production guests run their baked entrypoint via `mvmctl machine run --entrypoint` (no shell).
 
 | Command | Description |
 |---------|-------------|
@@ -634,7 +634,7 @@ The snapshot path activates only when *all* of the following hold:
   snapshot's recorded drive layout);
 - the active backend reports snapshot support.
 
-On macOS backends without Firecracker (Apple Container, libkrun), vsock
+On macOS backends without Firecracker (Vz, libkrun), vsock
 snapshots return `os error 95` (EOPNOTSUPP); restore failures fall back
 to cold boot with a warning rather than aborting the exec. See the
 [Sandboxed Exec](/guides/exec/) guide for the full background.

--- a/public/src/content/docs/reference/filesystem.md
+++ b/public/src/content/docs/reference/filesystem.md
@@ -5,7 +5,7 @@ description: Drive model, mount points, and filesystem layout inside microVMs.
 
 ## Drive Model
 
-Each microVM gets up to four virtio-block drives (on all backends -- Firecracker, Apple Container, libkrun, microvm.nix, Docker):
+Each microVM gets up to four virtio-block drives (on all backends -- Firecracker, Vz, libkrun, microvm.nix):
 
 | Drive | Mount Point | Permissions | Purpose |
 |-------|-------------|-------------|---------|

--- a/public/src/content/docs/reference/guest-agent.md
+++ b/public/src/content/docs/reference/guest-agent.md
@@ -19,7 +19,7 @@ Every microVM built with `mkGuest` includes **mvm-guest-agent**, a lightweight R
 
 ## Protocol
 
-The agent communicates using **length-prefixed JSON frames** over vsock (Firecracker, Apple Container, microvm.nix) or a unix socket (Docker):
+The agent communicates using **length-prefixed JSON frames** over vsock (Firecracker, Vz, microvm.nix):
 
 1. Host writes `CONNECT 5252\n` to the socket
 2. Agent responds with `OK 5252\n`

--- a/public/src/content/docs/sdk/operations-cookbook.mdx
+++ b/public/src/content/docs/sdk/operations-cookbook.mdx
@@ -21,7 +21,7 @@ language SDK tests prove them.
 | --- | --- | --- | --- |
 | Create sandbox recording | `mvm.Sandbox.create(...)` | `Sandbox.create(...)` | `mvmctl build compile` or `mvmctl run --mode plan` |
 | Create live sandbox | `mvmctl run --mode live ./script.py` | `mvmctl run --mode live ./script.ts` | `mvmctl machine run` |
-| Start command | `sandbox.commands.start([...])` | `sandbox.commands.start([...])` | `mvmctl proc start` or `mvmctl exec` |
+| Start command | `sandbox.commands.start([...])` | `sandbox.commands.start([...])` | `mvmctl proc start` or `mvmctl machine exec` |
 | Capture command result | Target `commands.run(...)` | Target `commands.run(...)` | CLI command result and receipt paths |
 | Write file | `sandbox.files.write(path, data)` | `sandbox.files.write(path, data)` | `mvmctl machine fs write` |
 | Read/list/remove file | Target helpers | Target helpers | `mvmctl machine fs read`, `mvmctl machine fs ls`, `mvmctl machine fs rm` |

--- a/public/src/content/docs/sdk/sandbox-types.md
+++ b/public/src/content/docs/sdk/sandbox-types.md
@@ -11,7 +11,7 @@ can layer specialized helpers over that substrate.
 
 | Type | Best for | Current path | SDK status |
 | --- | --- | --- | --- |
-| General sandbox | Commands, files, services, long-running work. | `mvmctl build`, `mvmctl machine run`, `mvmctl exec`, `mvmctl machine fs`, `mvmctl machine logs`. | Partial Python/TypeScript runtime surface. |
+| General sandbox | Commands, files, services, long-running work. | `mvmctl build`, `mvmctl machine run`, `mvmctl machine exec`, `mvmctl machine fs`, `mvmctl machine logs`. | Partial Python/TypeScript runtime surface. |
 | Code sandbox | Short code execution and interpreter-style tools. | `mvmctl run -- <cmd>` or a named Python manifest. | Planned convenience helper. |
 | Browser sandbox | Browser automation with Playwright/Puppeteer-like tooling. | Build a browser-capable Nix image, run automation inside the guest, forward explicit ports if needed. | Planned high-level helper. |
 | Desktop sandbox | GUI or computer-use workflows. | Backend- and image-specific today; use explicit images and port/console access. | Planned high-level helper. |
@@ -25,7 +25,7 @@ Use this for the broad lifecycle:
 mvmctl init ./worker --preset python
 mvmctl machine build --flake ./worker
 mvmctl machine run --flake ./worker --name worker -d
-mvmctl exec worker -- python /work/task.py
+mvmctl machine exec worker -- python /work/task.py
 ```
 
 Security properties:
@@ -47,7 +47,7 @@ Use a named sandbox when state is intentional:
 
 ```sh
 mvmctl machine run --flake ./python-tool --name pytool -d
-mvmctl exec pytool -- python /work/cell.py
+mvmctl machine exec pytool -- python /work/cell.py
 ```
 
 Security requirements for SDK helpers:

--- a/public/src/content/docs/security/matryoshka.md
+++ b/public/src/content/docs/security/matryoshka.md
@@ -62,8 +62,8 @@ mvm runs on multiple backends. Not all backends carry all seven claims. The tier
 | Backend | L1 | L2 | L3 | L4 | L5 | Tier |
 |---|---|---|---|---|---|---|
 | **Firecracker** (Linux + KVM) | ✅ | ✅ | ✅ | ✅ | ✅ | **Tier 1** — full ADR-002. All seven claims hold. |
-| **Apple Container** (macOS 26+ Apple Silicon) | ✅ | ✅ | ⚠️ | ✅ | ✅ | Tier 2 — claim 3 (verified boot) is partial. Other six claims hold. |
-| **libkrun** (Linux KVM, macOS Apple Silicon HVF) | ✅ | ✅ | ⚠️ | ✅ | ✅ | Tier 2 — same as Apple Container. |
+| **Vz** (macOS 26+ Apple Silicon) | ✅ | ✅ | ⚠️ | ✅ | ✅ | Tier 2 — claim 3 (verified boot) is partial. Other six claims hold. |
+| **libkrun** (Linux KVM, macOS Apple Silicon HVF) | ✅ | ✅ | ⚠️ | ✅ | ✅ | Tier 2 — same as Vz. |
 | **Docker** (any host with Docker) | ❌ | ❌ | ❌ | ✅ | ✅ | **Tier 3** — claims 1, 2, 3 do **not** hold. L1–L3 collapse to the host kernel. |
 | **microvm.nix** (QEMU + KVM) | ✅ | ⚠️ | ⚠️ | ✅ | ✅ | Tier 2 — QEMU's larger device model raises L2 audit cost. |
 
@@ -91,7 +91,7 @@ ack_docker_tier = true
 ### Choosing a tier
 
 - **Production / untrusted code** → Tier 1. Linux + KVM + Firecracker. No exceptions.
-- **macOS dev or CI on Apple Silicon** → Tier 2 (Apple Container or libkrun). Verified boot is the open item.
+- **macOS dev or CI on Apple Silicon** → Tier 2 (Vz or libkrun). Verified boot is the open item.
 - **macOS Intel / native Windows / WSL2** → unsupported for local microVM isolation today. WSL2 nested KVM and Hyper-V managed Linux builder support are future backend work.
 - **Anywhere else** → Tier 3 (Docker), with the banner caveats.
 

--- a/public/src/content/docs/security/sandbox-parity-status.md
+++ b/public/src/content/docs/security/sandbox-parity-status.md
@@ -139,7 +139,7 @@ Tracking work:
 
 ### `cold-start` — Planned
 
-`runtime_boot_bench` covers Apple Container serial and parallel
+`runtime_boot_bench` covers Vz serial and parallel
 boots today, but mvm has no published end-to-end latency number
 covering Firecracker, libkrun, checkpoint restore, and warm-pool
 claim under a single methodology.

--- a/public/src/content/docs/templates/build.md
+++ b/public/src/content/docs/templates/build.md
@@ -50,7 +50,7 @@ VMs. Use `mvmctl manifest *` for build slots and registry state.
 
 ```sh
 mvmctl machine run --manifest .
-mvmctl exec ./my-worker -- uname -a
+mvmctl machine run --manifest ./my-worker -- uname -a
 ```
 
 If there is no built revision for the manifest, `mvmctl machine run` should fail with a

--- a/public/src/content/docs/tutorials/coding-agent.md
+++ b/public/src/content/docs/tutorials/coding-agent.md
@@ -28,7 +28,7 @@ For local development through this repository, the builder VM is the Linux build
 
 ```sh
 mvmctl machine run --flake . --name coding-agent
-mvmctl exec coding-agent -- bash -lc 'cd /work && python task.py'
+mvmctl machine exec coding-agent -- bash -lc 'cd /work && python task.py'
 ```
 
 Use file transfer or a narrow mount for input/output. Keep generated patches and logs outside broad host write access.

--- a/public/src/content/docs/working/commands.md
+++ b/public/src/content/docs/working/commands.md
@@ -30,7 +30,7 @@ mvmctl run --dry-run --json -- python task.py
 
 ```sh
 mvmctl machine run --flake ./my-app --name agent-sandbox -d
-mvmctl exec agent-sandbox -- python /work/task.py
+mvmctl machine exec agent-sandbox -- python /work/task.py
 mvmctl machine logs agent-sandbox -f
 ```
 

--- a/public/src/content/docs/working/index.md
+++ b/public/src/content/docs/working/index.md
@@ -10,7 +10,7 @@ description: Local sandbox management with mvmctl.
 ```sh
 mvmctl machine build --flake ./my-app
 mvmctl machine run --flake ./my-app --name agent-sandbox -d
-mvmctl exec agent-sandbox -- python /work/task.py
+mvmctl machine exec agent-sandbox -- python /work/task.py
 mvmctl machine logs agent-sandbox -f
 mvmctl machine stop agent-sandbox
 ```

--- a/public/src/content/docs/working/lifecycle-states.md
+++ b/public/src/content/docs/working/lifecycle-states.md
@@ -15,7 +15,7 @@ cleanup is still required.
 | No image | No build artifact exists for the workload yet. | `mvmctl build` | Build inputs still need policy and secret review before launch. |
 | Built | A launchable artifact exists, but no sandbox is running. | `mvmctl machine run` or `mvmctl run` | Artifact metadata can reveal package, path, and configuration choices. |
 | Starting | The backend is creating the VM, attaching drives, and waiting for readiness. | `mvmctl wait` or `mvmctl boot-report` | Admission failures should be reported without leaking secrets. |
-| Running | Guest compute is active and can execute commands, expose ports, write files, and emit logs. | `mvmctl exec`, `mvmctl machine logs`, `mvmctl machine fs`, `mvmctl machine stop`, or snapshot commands | Treat command output, files, logs, ports, and receipts as boundary-crossing data. |
+| Running | Guest compute is active and can execute commands, expose ports, write files, and emit logs. | `mvmctl machine exec`, `mvmctl machine logs`, `mvmctl machine fs`, `mvmctl machine stop`, or snapshot commands | Treat command output, files, logs, ports, and receipts as boundary-crossing data. |
 | Paused | Guest execution is suspended and can be resumed by the backend path that created the pause. | `mvmctl resume` | Paused memory can contain tokens, browser sessions, plaintext files, and process state. |
 | Cold | Compute is released while recoverable state is retained through a backend snapshot or checkpoint. | `mvmctl resume` or `mvmctl checkpoint restore` | Cold state is persistence, not a security boundary. Protect it like sensitive data. |
 | Restoring | The backend is loading saved state and re-establishing runtime control. | Wait for readiness, then verify workload health | Restore can fail because of backend, host, image, or policy drift. |
@@ -29,7 +29,7 @@ cleanup is still required.
 | Source to image | `mvmctl build` |
 | Image to running sandbox | `mvmctl machine run` or `mvmctl run` |
 | Wait for readiness | `mvmctl wait`, `mvmctl boot-report` |
-| Run work | `mvmctl exec`, `mvmctl machine fs`, `mvmctl machine logs`, port-forwarding commands |
+| Run work | `mvmctl machine exec`, `mvmctl machine fs`, `mvmctl machine logs`, port-forwarding commands |
 | Running to paused or cold | `mvmctl pause`, `mvmctl checkpoint create` |
 | Paused or cold to running | `mvmctl resume`, `mvmctl checkpoint restore` |
 | Running to stopped | `mvmctl machine stop` |

--- a/public/src/content/docs/working/network.md
+++ b/public/src/content/docs/working/network.md
@@ -51,7 +51,7 @@ Host control does not require SSH. Guest communication uses the mvm control plan
 ```sh
 mvmctl machine console api-dev
 mvmctl machine logs api-dev
-mvmctl exec api-dev -- sh -lc 'id && pwd'
+mvmctl machine exec api-dev -- sh -lc 'id && pwd'
 ```
 
 ## Security notes

--- a/public/src/content/docs/working/sandbox-management.md
+++ b/public/src/content/docs/working/sandbox-management.md
@@ -28,7 +28,7 @@ Use JSON output where commands support it when integrating with tooling.
 ## Operate
 
 ```sh
-mvmctl exec agent-sandbox -- python /work/task.py
+mvmctl machine exec agent-sandbox -- python /work/task.py
 mvmctl machine fs ls agent-sandbox /work
 mvmctl machine forward agent-sandbox -p 8080:8080
 ```


### PR DESCRIPTION
**Stacked on #1488** (docs CLI refresh) — this branch = #1488 + one commit. Merge
after #1488; GitHub will retarget the base to `main` once #1488 lands.

Continues the CLI command-tree refresh with the two adjacent stale surfaces you asked for.

## `mvmctl exec` split (removed top-level verb)
- `mvmctl exec <name> -- <cmd>` into a booted machine → `mvmctl machine exec`
- transient `mvmctl exec [flags] -- <cmd>` → `mvmctl machine run` with an explicit
  source (`--image`/`--flake`/`--manifest`); `--add-dir` → `--volume`; there is no
  bundled default image anymore, so examples now name a source
- reframed the `exec.md` guide around `machine run`; replaced the stale `--add-dir`
  ext4+rsync trade-offs prose (volumes are virtio-fs now) with a mechanism-neutral
  note; `--launch-plan` moved to the internal `run` transport

## Backend-name prose
- `Apple Container` → `Vz`, `apple-container` → `vz` (the in-process apple_container
  backend folded into vz). "Apple Silicon" and "docker run" analogies left untouched
- dropped `Docker` from the co-equal backend lists (vsock, virtio-block drives,
  network table, DNS) — no Docker on the runtime path
- fixed the last `mvmctl invoke` prose in `cli-commands.md`

## Flagged for a separate pass (needs product confirmation, not a rename)
- the documented **"Docker fallback (Tier 3)"** concept (platform-support, limits,
  windows, adr-001/013) — verify whether `DockerBackend` still exists at all
- macOS 26+ default backend is now **in-house HVF** (Vz transitional); several docs
  still present Vz as the auto-selected macOS backend
- `exec.md` snapshot/launch-plan/dev-only sub-sections; `mvmctl wait`/`machine boot-report` validity