### PR TITLE
docs: align Docker/Tier-3 security docs to ADR-002 (Docker deleted; QEMU = Tier 2 dev/test)

### DIFF
--- a/public/src/content/docs/contributing/adr/001-multi-backend.md
+++ b/public/src/content/docs/contributing/adr/001-multi-backend.md
@@ -7,6 +7,8 @@ description: Architecture Decision Record for supporting multiple VM backends wi
 
 Accepted (updated Sprint 38 -- expanded from Firecracker-only to multi-backend)
 
+> **Note (superseded in part):** the Docker and Cloud Hypervisor backends described below were later removed — mvm has no container fallback and no Tier 3 (see the [Matryoshka model](/security/matryoshka/)). The no-`/dev/kvm` Linux path is now the dev/test QEMU/TCG backend (`--hypervisor qemu`).
+
 ## Context
 
 mvmctl needs VM backends for running isolated workloads across different platforms. Options considered:

--- a/public/src/content/docs/contributing/adr/013-libkrun-pivot.md
+++ b/public/src/content/docs/contributing/adr/013-libkrun-pivot.md
@@ -7,6 +7,8 @@ description: Architecture Decision Record for the cross-platform microVM pivot �
 
 Proposed. Implementation tracked in [Plan 60](https://github.com/tinylabscom/mvm/blob/main/specs/plans/60-mvm-libkrun-migration.md). Phase 0 + Phase 1 deliver the build/exec pivot; subsequent phases compose on top.
 
+> **Note (superseded in part):** `DockerBackend` (item 5 below) was not adopted — Docker was removed as a backend; the no-`/dev/kvm` path is the dev/test QEMU backend (`--hypervisor qemu`).
+
 ## Invariant — host does not need Nix
 
 `mvmctl` runs on a stock host. **Nix is not a prerequisite.** On first build, mvm bootstraps a small Linux builder microVM (libkrun-backed), runs `nix build` inside it, and extracts the resulting rootfs to the host. The runtime path stays Nix-free; the builder path keeps Nix inside the sandbox where it belongs.

--- a/public/src/content/docs/guides/troubleshooting.md
+++ b/public/src/content/docs/guides/troubleshooting.md
@@ -281,8 +281,8 @@ Force a specific backend:
 ```bash
 mvmctl machine run --flake . --hypervisor firecracker
 mvmctl machine run --flake . --hypervisor vz
-mvmctl machine run --flake . --hypervisor docker
-mvmctl machine run --flake . --hypervisor qemu    # microvm.nix
+mvmctl machine run --flake . --hypervisor libkrun
+mvmctl machine run --flake . --hypervisor qemu    # dev/test, no /dev/kvm
 mvmctl doctor   # check available backends
 ```
 
@@ -326,12 +326,10 @@ Hitting `KVM not available` on a cloud instance? Three options, in order of reco
 | GCE | n2 with `--enable-nested-virtualization` |
 | Azure | Dasv5 / Easv5 |
 
-**Option 2 — Use the Tier 3 Docker fallback.** Works in any environment with Docker Engine. **Reduced security tier** — see the [Matryoshka model](/security/matryoshka). The L1–L3 layers collapse to the host kernel, so claims 1, 2, and 3 do not hold. Use only for non-security-sensitive workloads (CI scratch, local experiments).
+**Option 2 — Use the QEMU dev/test backend.** On a Linux host without `/dev/kvm`, run the software-emulated QEMU/TCG backend. It's a real microVM but **Tier 2 dev/test** — slower, larger TCB, partial verified boot (see the [Matryoshka model](/security/matryoshka)) — so use it for local dev/test, not production or untrusted workloads.
 
 ```bash
-mvmctl machine run --flake . --hypervisor docker
-# Suppress the per-run banner once you've acknowledged the tier:
-export MVM_ACK_DOCKER_TIER=1
+mvmctl machine run --flake . --hypervisor qemu
 ```
 
 **Option 3 — PVM (advanced, external).** [SlicerVM's PVM mode](https://docs.slicervm.com/tasks/pvm/) runs real microVMs without `/dev/kvm` via a patched Firecracker plus a `kvm_pvm` host kernel module. mvm doesn't ship this — the maintenance cost (kernel patch + custom guest images, x86_64 only) is outside mvm's scope. If you need real microVM isolation on a non-nested-virt cloud VM and Option 1 isn't available, SlicerVM is the working answer in the ecosystem today.

--- a/public/src/content/docs/guides/windows-troubleshooting.md
+++ b/public/src/content/docs/guides/windows-troubleshooting.md
@@ -100,28 +100,6 @@ You're working from a `/mnt/c/...` path. NTFS-via-9p is many times slower than e
 
 `HOME` inside the distro should be `/home/<your-user>`. If you accidentally launched the distro with `HOME=/mnt/c/Users/<you>`, NTFS permissions may not allow the `0700` chmod that `mvmctl` does for `~/.mvm` (W1.5). Fix: `unset HOME` and re-run, or set `HOME=/home/<user>` explicitly.
 
-## Tier 3 Docker fallback
-
-### Banner nagging on every `mvmctl run`
-
-When the auto-selected backend is Tier 3 Docker, mvm prints a security warning. Once you've read [the Matryoshka model](/security/matryoshka) and accept the reduced isolation:
-
-```powershell
-$env:MVM_ACK_DOCKER_TIER = "1"
-```
-
-(or persist it in your shell profile / Windows env settings).
-
-Equivalently: `~/.mvm/config.toml`:
-```toml
-[security]
-ack_docker_tier = true
-```
-
-### Docker Desktop says "WSL2 backend required"
-
-Docker Desktop on Windows 10/11 uses WSL2 by default. If you've manually switched to Hyper-V backend, switch back via *Docker Desktop → Settings → General → Use the WSL 2 based engine*.
-
 ## Anything else
 
 [Open a GitHub issue](https://github.com/tinylabscom/mvm/issues) with the output of:

--- a/public/src/content/docs/install/windows.md
+++ b/public/src/content/docs/install/windows.md
@@ -18,7 +18,6 @@ Use one of these paths today:
 
 - Run mvm on a Linux host with `/dev/kvm`.
 - Run mvm on an Apple Silicon Mac.
-- Use Docker only for non-security-sensitive experimentation, understanding that it is Tier 3 and not a microVM isolation boundary.
 
 ## Experimental: WSL2 With Nested KVM
 
@@ -41,23 +40,6 @@ sh <(curl -L https://nixos.org/nix/install) --daemon
 ```
 
 Installing host-side Nix is optional. The normal `mvmctl build` path still treats the CLI as the host control plane and the builder VM as the image build boundary. See [Builder VM](/guides/builder-vm/).
-
-## Alternative: Tier 3 Docker fallback
-
-Docker Desktop on Windows can run mvm at Tier 3. **You give up microVM isolation** — see the [Matryoshka model](/security/matryoshka) — so this path is for *non-security-sensitive* workloads only.
-
-```powershell
-# Inside a Docker Desktop linux container or WSL2 distro:
-mvmctl run --hypervisor docker --flake .
-```
-
-`mvmctl run` will print a loud warning banner naming the seven CVEs and the dropped claims. Suppress it once you've acknowledged the tier:
-
-```powershell
-$env:MVM_ACK_DOCKER_TIER = "1"
-```
-
-The Docker tier exists as a convenience, not a sandbox. If your workload involves untrusted code, AI-generated scripts, or anything you wouldn't run as your own user, switch to a supported Apple Silicon or Linux KVM host.
 
 ## What about native Windows microVMs?
 

--- a/public/src/content/docs/reference/limits.md
+++ b/public/src/content/docs/reference/limits.md
@@ -30,7 +30,7 @@ Commit the manifest values once the sizing is intentional.
 | --- | --- | --- |
 | Firecracker on Linux/KVM | Strongest local microVM isolation. | Requires `/dev/kvm` and Linux host support. |
 | Apple Virtualization / libkrun | macOS development and supported non-Linux paths. | Feature parity differs by macOS version and backend. |
-| Docker fallback | Convenience on hosts without microVM support. | Not a microVM isolation tier. |
+| QEMU (TCG) | Linux dev/test without `/dev/kvm` (`--hypervisor qemu`). | Tier 2 dev/test; larger TCB, partial verified boot — not for production. |
 
 Always verify the active posture with:
 

--- a/public/src/content/docs/reference/platform-support.md
+++ b/public/src/content/docs/reference/platform-support.md
@@ -4,8 +4,7 @@ description: Current host, architecture, backend, and support-status matrix for 
 ---
 
 `mvm` supports local microVM workflows on native Linux with KVM and on Apple
-Silicon macOS. Windows is tracked as future host work. Docker exists as a
-convenience fallback, not as a security-equivalent microVM backend.
+Silicon macOS. Windows is tracked as future host work. Linux hosts without `/dev/kvm` can run the dev/test QEMU/TCG backend (`--hypervisor qemu`); there is no container fallback.
 
 Use this page to decide where to run `mvmctl`, where Linux image builds happen,
 and which backend limitations apply.
@@ -16,7 +15,7 @@ and which backend limitations apply.
 | --- | --- | --- | --- | --- |
 | Linux with `/dev/kvm` | x86_64, aarch64 | Firecracker | Supported | Strongest local target; direct KVM microVM path. |
 | macOS Apple Silicon | aarch64 | Apple Virtualization / libkrun-backed paths | Supported | Local development and runtime path for M-series Macs. |
-| Linux without `/dev/kvm` | x86_64, aarch64 | Docker fallback | Limited | Convenience only; not a microVM isolation boundary. |
+| Linux without `/dev/kvm` | x86_64, aarch64 | QEMU (TCG) | Dev/test | Software-emulated microVM (`--hypervisor qemu`); Tier 2 dev/test — slower, not for production. |
 | Windows native | x86_64, aarch64 | None | Future | Tracked in [mvm#428](https://github.com/tinylabscom/mvm/issues/428). |
 | WSL2 with nested KVM | x86_64, aarch64 | Experimental Linux path | Future/experimental | May expose `/dev/kvm`; not a supported host path today. |
 | Intel macOS | x86_64 | None | Unsupported | Use Linux KVM or Apple Silicon macOS. |
@@ -42,7 +41,7 @@ Build time and runtime are separate. After an image is built:
 
 - Linux with KVM boots through Firecracker.
 - Apple Silicon macOS uses the supported macOS runtime backend path.
-- Docker fallback runs containers and drops microVM isolation claims.
+- Linux without `/dev/kvm` runs QEMU/TCG — a software-emulated microVM for dev/test (Tier 2), not a production isolation target.
 - Windows native does not have a supported runtime backend today.
 
 When reporting runtime behavior, include host OS, CPU architecture, selected
@@ -67,7 +66,7 @@ The OS segment is `linux` because the workload runs inside a Linux guest.
 | --- | --- |
 | Firecracker on Linux/KVM | Preferred local microVM isolation target. |
 | Apple Virtualization / libkrun-backed macOS path | Supported local microVM path with backend-specific feature differences. |
-| Docker fallback | Reduced isolation; do not use for untrusted code or security-sensitive workloads. |
+| QEMU (TCG, no `/dev/kvm`) | Tier 2 dev/test microVM; do not use for untrusted code or security-sensitive workloads. |
 | WSL2 nested KVM | Research/future path until tested and documented as supported. |
 
 Security-sensitive examples should name the backend when behavior differs.

--- a/public/src/content/docs/security/ci-claims.md
+++ b/public/src/content/docs/security/ci-claims.md
@@ -26,7 +26,7 @@ name the backend.
 
 ## What not to claim
 
-- Do not claim Docker has the same isolation as Firecracker.
+- Do not claim the dev/test QEMU backend carries the same claims as Firecracker (claim 3 partial; Tier 2 dev/test only).
 - Do not claim secret non-leakage for manual file mounts.
 - Do not claim cold-start numbers without a published benchmark.
 - Do not imply Windows local runtime support is shipped.

--- a/public/src/content/docs/security/matryoshka.md
+++ b/public/src/content/docs/security/matryoshka.md
@@ -64,36 +64,20 @@ mvm runs on multiple backends. Not all backends carry all seven claims. The tier
 | **Firecracker** (Linux + KVM) | ✅ | ✅ | ✅ | ✅ | ✅ | **Tier 1** — full ADR-002. All seven claims hold. |
 | **Vz** (macOS 26+ Apple Silicon) | ✅ | ✅ | ⚠️ | ✅ | ✅ | Tier 2 — claim 3 (verified boot) is partial. Other six claims hold. |
 | **libkrun** (Linux KVM, macOS Apple Silicon HVF) | ✅ | ✅ | ⚠️ | ✅ | ✅ | Tier 2 — same as Vz. |
-| **Docker** (any host with Docker) | ❌ | ❌ | ❌ | ✅ | ✅ | **Tier 3** — claims 1, 2, 3 do **not** hold. L1–L3 collapse to the host kernel. |
-| **microvm.nix** (QEMU + KVM) | ✅ | ⚠️ | ⚠️ | ✅ | ✅ | Tier 2 — QEMU's larger device model raises L2 audit cost. |
+| **QEMU** (Linux KVM/TCG) | ✅ | ⚠️ | ⚠️ | ✅ | ✅ | Tier 2 — claim 3 partial; QEMU's larger device model raises L2 audit cost. **Dev/test only** (`--hypervisor qemu`; the no-`/dev/kvm` path via TCG software emulation). Never selected by `mvmd`. |
 
 ✅ = layer fully enforced.  ⚠️ = layer partial (named exception).  ❌ = layer collapsed (claim does not apply).
 
-### Tier 3 (Docker) is convenience, not isolation
+### No container fallback
 
-mvm's Docker backend exists so you can run a workload in a non-virt environment (e.g., a CI host without `/dev/kvm`, a developer laptop without nested virt). It's **not** a microVM. The isolation comes from the Linux kernel's namespace and cgroup machinery, which is *shared with the host kernel*.
-
-In 2024–2025 the container ecosystem produced seven CVEs (Leaky Vessels, NVIDIAScape, runc race conditions, Buildah mount, Docker Desktop priv-esc, runc masked-path, runc `/dev/console`) that all yielded **host escape** from inside a container. None of those matter inside a microVM — the guest kernel is isolated by hardware. They all matter inside a Docker container.
-
-If `mvmctl` auto-selects Tier 3 because no microVM-capable backend is available, the CLI prints a banner naming the dropped claims and the recent CVEs. You can suppress the banner once you've acknowledged the tier with:
-
-```sh
-export MVM_ACK_DOCKER_TIER=1
-```
-
-or in `~/.mvm/config.toml`:
-
-```toml
-[security]
-ack_docker_tier = true
-```
+mvm has **no Tier 3** and no container/Docker fallback. A shared-kernel container is not a microVM: its isolation comes from the host kernel's namespace and cgroup machinery, which is shared with the host. In 2024–2025 the container ecosystem produced multiple CVEs (Leaky Vessels, NVIDIAScape, runc race conditions, Docker Desktop priv-esc, runc masked-path) that yielded **host escape** from inside a container — none of which matter inside a microVM, where the guest kernel is isolated by hardware. If a host has no microVM-capable backend, mvm does not silently drop to a weaker boundary; it fails closed.
 
 ### Choosing a tier
 
 - **Production / untrusted code** → Tier 1. Linux + KVM + Firecracker. No exceptions.
 - **macOS dev or CI on Apple Silicon** → Tier 2 (Vz or libkrun). Verified boot is the open item.
-- **macOS Intel / native Windows / WSL2** → unsupported for local microVM isolation today. WSL2 nested KVM and Hyper-V managed Linux builder support are future backend work.
-- **Anywhere else** → Tier 3 (Docker), with the banner caveats.
+- **Linux dev/test without `/dev/kvm`** → Tier 2 QEMU (`--hypervisor qemu`, TCG software emulation). A real microVM, slower; dev/test only.
+- **macOS Intel / native Windows** → unsupported for local microVM isolation today (no container fallback). WSL2 nested KVM and a Hyper-V managed Linux builder are future backend work.
 
 `mvmctl doctor` reports your current tier on the running host.
 

--- a/public/src/content/docs/security/threat-model.md
+++ b/public/src/content/docs/security/threat-model.md
@@ -37,7 +37,7 @@ from that host.
 
 - Defending against a malicious host.
 - Running mutually distrusting tenants in one guest.
-- Treating Docker fallback as microVM isolation.
+- Treating the dev/test QEMU backend as a production isolation tier.
 - Claiming universal OCI compatibility before digest-pinned ingest is shipped.
 - Claiming secret non-leakage for manual guest-visible secret files.
 

--- a/public/src/content/docs/security/verified-boot.md
+++ b/public/src/content/docs/security/verified-boot.md
@@ -20,7 +20,7 @@ with its limits.
 | --- | --- |
 | Firecracker on Linux/KVM | Strongest target for dm-verity/root hash enforcement. |
 | Apple Virtualization / libkrun | Useful microVM isolation, but verified-boot evidence differs by backend support. |
-| Docker fallback | Not a verified microVM boot path. |
+| QEMU (Linux, dev/test) | Partial verified-boot support; Tier 2 dev/test, not a production target. |
 
 Use [Matryoshka model](/security/matryoshka/) for the tier matrix before making
 a user-facing claim.


### PR DESCRIPTION
**Stacked on #1494** (which is stacked on #1488). Merge order: #1488 → #1494 → this.

Resolves the flagged "Docker fallback" item. I confirmed against the code and
**ADR-002 (your source of truth)** rather than inventing a characterization.

## Finding
- No `Docker` variant in `AnyBackend` (Firecracker, Libkrun, Vz, Qemu, Mock). The
  only `docker` is `PackBackend::Docker` — image *packaging*, not a runtime.
- ADR-002: *"there is no Tier 3 anymore — the only Tier-3 backend was Docker (a
  shared-kernel container)… and was deleted."* QEMU is **Tier 2, dev/test only**
  (claim 3 partial). The docs-site was simply out of sync.

## Changes (mirrored from ADR-002, no invention)
- **matryoshka.md**: dropped the Docker Tier-3 row (folded microvm.nix→QEMU);
  replaced the "Tier 3 (Docker)" subsection with "no container fallback — fails
  closed"; fixed tier-choice guidance.
- **threat-model / ci-claims / verified-boot / platform-support / limits**:
  Docker fallback → QEMU/TCG (Tier 2 dev/test, `--hypervisor qemu`).
- **install/windows + windows-troubleshooting**: removed the "Tier 3 Docker
  fallback" sections (incl. the nonexistent `--hypervisor docker` /
  `MVM_ACK_DOCKER_TIER`); native Windows is unsupported locally.
- **troubleshooting**: no-KVM fallback + backend-force list use `qemu`.
- **ADRs 001/013**: historical text kept; one-line "superseded in part" note added.

Benign Docker mentions (image export to Docker, "mvm does not invoke Docker",
"OCI without Docker as the runtime") were intentionally left — they reinforce
the no-Docker-runtime posture.

## Still open (from earlier rounds, separate scope)
- macOS 26+ default is now in-house **HVF** (Vz transitional) — some docs still
  present Vz as the auto-selected macOS backend.
- Bare `mvmctl build <path>` / `mvmctl build --flake` → `machine build`; `mvmctl wait` / `machine boot-report` validity.