### PR TITLE
chore(release): enable the builder-VM prebuilt download in release builds

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -24,7 +24,7 @@ permissions:
 
 env:
   CARGO_TERM_COLOR: always
-  MVMCTL_RELEASE_FEATURES: template-registry-s3,dev-watch,custom-dns,manifest-verify
+  MVMCTL_RELEASE_FEATURES: template-registry-s3,dev-watch,custom-dns,manifest-verify,release-artifact-bootstrap
 
 jobs:
   build:

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -493,6 +493,15 @@ builder-vm = [
 # reaches the shipped binary without this. Default-on so the run path
 # materializes in-process; `MVM_MATERIALIZE_BUILDER_VM` is the runtime opt-out.
 pure-mkfs = ["mvm-cli/pure-mkfs"]
+# Let an installed binary download mvm-published prebuilt builder VM images
+# from GitHub releases on a cache miss. Forwarded here for the same reason as
+# `pure-mkfs`: the root `mvmctl` binary builds mvm-cli with
+# `default-features = false`, so mvm-cli's gate never reaches the shipped
+# binary without this line. Off by default — contributor builds must build the
+# builder VM locally from the in-repo flake — and turned on only by the release
+# workflow, so an installed binary fetches the prebuilt instead of failing
+# closed on a cache miss.
+release-artifact-bootstrap = ["mvm-cli/release-artifact-bootstrap"]
 custom-dns = ["mvm-cli/custom-dns"]
 dev-watch = ["mvm-cli/dev-watch"]
 libkrun-live = ["mvm-cli/libkrun-live"]


### PR DESCRIPTION
## Problem

`download_builder_vm_image` (fetch a prebuilt builder VM image + kernel from GitHub releases on a cache miss) is compiled only under the `release-artifact-bootstrap` cargo feature — and the release workflow never enabled it. So every published `mvmctl` shipped with that path **compiled out**: an installed (non-source) binary on a builder-VM cache miss hit a hard error ("built without the `release-artifact-bootstrap` feature… cannot pull a published prebuilt") instead of downloading it. The download machinery and the `builder-vm-image` release job both exist; the feature that connects them was simply off.

## Fix

- Add `release-artifact-bootstrap` to `MVMCTL_RELEASE_FEATURES` in `release.yml`.
- Add the forwarding `release-artifact-bootstrap = ["mvm-cli/release-artifact-bootstrap"]` entry to the root `Cargo.toml` — the root binary builds `mvm-cli` with `default-features = false`, so a sub-crate feature never reaches the shipped binary without an explicit forward (same reason `pure-mkfs` is forwarded).

Off by default for contributor builds (which must build the builder VM locally from the in-repo flake, per the source-checkout invariant); only the release workflow turns it on.

Verified `cargo check -p mvmctl --features release-artifact-bootstrap` compiles the previously-dead download path in.