### PR TITLE
fix hvf pause resume

### DIFF
--- a/crates/mvm-backend/src/hvf/kernel_boot.rs
+++ b/crates/mvm-backend/src/hvf/kernel_boot.rs
@@ -164,6 +164,7 @@ fn default_virtiofs_bootargs() -> String {
 /// under the argument-count lint. The two socket paths fall back to the
 /// `MVM_HVF_{AGENT,SUBSTITUTION}_SOCKET` env hooks when `None` (dev/live drivers);
 /// the productionized path threads them through the supervisor config.
+#[derive(Default)]
 pub struct HostChannels {
     pub agent_socket: Option<PathBuf>,
     pub substitution_socket: Option<PathBuf>,
@@ -191,6 +192,98 @@ pub struct HostChannels {
     pub virtiofs_root: Option<PathBuf>,
 }
 
+static NEVER_STOP: AtomicBool = AtomicBool::new(false);
+static NEVER_PAUSE: AtomicBool = AtomicBool::new(false);
+
+/// Inputs for a persistent HVF kernel boot. Grouped so pause/stop/channel
+/// control stays explicit without growing a positional argument list.
+pub struct KernelBootUntilParams<'a> {
+    image: &'a [u8],
+    initramfs: Option<&'a [u8]>,
+    disks: Vec<DiskImage>,
+    vsock: bool,
+    timeout: Duration,
+    stop: &'static AtomicBool,
+    paused: &'static AtomicBool,
+    channels: HostChannels,
+}
+
+impl<'a> KernelBootUntilParams<'a> {
+    pub fn builder(image: &'a [u8], timeout: Duration) -> KernelBootUntilParamsBuilder<'a> {
+        KernelBootUntilParamsBuilder {
+            image,
+            initramfs: None,
+            disks: Vec::new(),
+            vsock: false,
+            timeout,
+            stop: &NEVER_STOP,
+            paused: &NEVER_PAUSE,
+            channels: HostChannels::default(),
+        }
+    }
+}
+
+pub struct KernelBootUntilParamsBuilder<'a> {
+    image: &'a [u8],
+    initramfs: Option<&'a [u8]>,
+    disks: Vec<DiskImage>,
+    vsock: bool,
+    timeout: Duration,
+    stop: &'static AtomicBool,
+    paused: &'static AtomicBool,
+    channels: HostChannels,
+}
+
+impl<'a> KernelBootUntilParamsBuilder<'a> {
+    pub fn initramfs(mut self, initramfs: Option<&'a [u8]>) -> Self {
+        self.initramfs = initramfs;
+        self
+    }
+
+    pub fn disks(mut self, disks: Vec<DiskImage>) -> Self {
+        self.disks = disks;
+        self
+    }
+
+    pub fn vsock(mut self, vsock: bool) -> Self {
+        self.vsock = vsock;
+        self
+    }
+
+    pub fn timeout(mut self, timeout: Duration) -> Self {
+        self.timeout = timeout;
+        self
+    }
+
+    pub fn stop(mut self, stop: &'static AtomicBool) -> Self {
+        self.stop = stop;
+        self
+    }
+
+    pub fn paused(mut self, paused: &'static AtomicBool) -> Self {
+        self.paused = paused;
+        self
+    }
+
+    pub fn channels(mut self, channels: HostChannels) -> Self {
+        self.channels = channels;
+        self
+    }
+
+    pub fn build(self) -> KernelBootUntilParams<'a> {
+        KernelBootUntilParams {
+            image: self.image,
+            initramfs: self.initramfs,
+            disks: self.disks,
+            vsock: self.vsock,
+            timeout: self.timeout,
+            stop: self.stop,
+            paused: self.paused,
+            channels: self.channels,
+        }
+    }
+}
+
 /// Boot `image` (an arm64 `Image`) under HVF, optionally with an `initramfs`
 /// (cpio, gzip-or-raw), returning what it printed within `timeout`.
 pub fn boot_kernel(
@@ -200,23 +293,12 @@ pub fn boot_kernel(
     vsock: bool,
     timeout: Duration,
 ) -> Result<KernelBootResult, HvfError> {
-    static NEVER_STOP: AtomicBool = AtomicBool::new(false);
     boot_kernel_impl(
-        image,
-        initramfs,
-        disks,
-        vsock,
-        timeout,
-        &NEVER_STOP,
-        HostChannels {
-            agent_socket: None,
-            substitution_socket: None,
-            egress_relay: None,
-            console_data_sockets: Vec::new(),
-            cmdline: None,
-            mem_mib: 0,
-            virtiofs_root: None,
-        },
+        KernelBootUntilParams::builder(image, timeout)
+            .initramfs(initramfs)
+            .disks(disks)
+            .vsock(vsock)
+            .build(),
     )
 }
 
@@ -224,29 +306,26 @@ pub fn boot_kernel(
 /// persistent-until-stop VM — and drives egress + the agent/substitution channels
 /// through the caller-supplied [`HostChannels`] (the supervisor builds them from
 /// the admitted plan + per-VM socket paths). The supervisor sets `stop` from a
-/// SIGTERM handler so `HvfBackend::stop` ends the guest cleanly. `timeout` still
-/// caps the run.
-pub fn boot_kernel_until(
-    image: &[u8],
-    initramfs: Option<&[u8]>,
-    disks: Vec<DiskImage>,
-    vsock: bool,
-    timeout: Duration,
-    stop: &'static AtomicBool,
-    channels: HostChannels,
-) -> Result<KernelBootResult, HvfError> {
-    boot_kernel_impl(image, initramfs, disks, vsock, timeout, stop, channels)
+/// SIGTERM handler so `HvfBackend::stop` ends the guest cleanly. Setting `paused`
+/// parks the vCPU out of guest execution (RAM + devices intact) until it clears
+/// again — the supervisor drives it from its SIGUSR1/SIGUSR2 handlers so
+/// `HvfBackend::pause`/`resume` freeze and thaw the guest in place. `timeout`
+/// still caps the run.
+pub fn boot_kernel_until(params: KernelBootUntilParams<'_>) -> Result<KernelBootResult, HvfError> {
+    boot_kernel_impl(params)
 }
 
-fn boot_kernel_impl(
-    image: &[u8],
-    initramfs: Option<&[u8]>,
-    disks: Vec<DiskImage>,
-    vsock: bool,
-    timeout: Duration,
-    stop: &'static AtomicBool,
-    channels: HostChannels,
-) -> Result<KernelBootResult, HvfError> {
+fn boot_kernel_impl(params: KernelBootUntilParams<'_>) -> Result<KernelBootResult, HvfError> {
+    let KernelBootUntilParams {
+        image,
+        initramfs,
+        disks,
+        vsock,
+        timeout,
+        stop,
+        paused,
+        channels,
+    } = params;
     if disks.len() > MAX_DISKS {
         return Err(HvfError::BadKernel);
     }
@@ -364,6 +443,7 @@ fn boot_kernel_impl(
                 virtiofs_root: channels.virtiofs_root,
             },
             stop,
+            paused,
         );
         hv_vm_destroy();
         r
@@ -404,6 +484,7 @@ unsafe fn run(
     dtb_addr: u64,
     inputs: RunInputs,
     stop: &'static AtomicBool,
+    paused: &'static AtomicBool,
 ) -> Result<KernelBootResult, HvfError> {
     let RunInputs {
         disks,
@@ -512,10 +593,17 @@ unsafe fn run(
                     stop.store(true, Ordering::Relaxed); // timeout → end the run
                     break;
                 }
-                // Heartbeat while an agent listener is bound (accept/serve RPC) or
-                // there's host→guest egress to deliver.
-                if agent_bound || egress_active_w.load(Ordering::Relaxed) > 0 {
-                    HvfHandle::force_exit(&[handle]); // wake the run loop to poll
+                // Break the guest out of `hv_vcpu_run` when: a pause was requested
+                // (so the run loop reaches its pause hold and parks the vCPU), an
+                // agent listener is bound (accept/serve RPC), or there's host→guest
+                // egress to deliver. An idle transient VM gets no heartbeat, so the
+                // explicit paused check is what parks it; while it sits in the hold
+                // the extra nudges are harmless (it is out of guest execution).
+                if paused.load(Ordering::Relaxed)
+                    || agent_bound
+                    || egress_active_w.load(Ordering::Relaxed) > 0
+                {
+                    HvfHandle::force_exit(&[handle]); // wake the run loop
                 }
             }
             HvfHandle::force_exit(&[handle]); // final wake → loop sees stop, returns
@@ -661,6 +749,9 @@ unsafe fn run(
                 // graceful); otherwise it's a heartbeat wake so the run loop can drain
                 // egress sockets into a guest blocked in WFI (vsock-only egress async proxy).
                 move || stop.load(Ordering::Relaxed),
+                // Park the vCPU in the run loop's pause hold while `paused` is set,
+                // freezing guest RAM + device state in place until resume clears it.
+                move || paused.load(Ordering::Relaxed),
             )?
         };
 

--- a/crates/mvm-backend/src/hvf/mod.rs
+++ b/crates/mvm-backend/src/hvf/mod.rs
@@ -23,4 +23,6 @@ pub use crate::vmm::virtio::DiskImage;
 pub use boot_smoke::{BootProof, HvfError, MAGIC, boot_smoke, probe_available};
 pub use console_smoke::{ConsoleProof, console_smoke};
 pub use hv_impl::{HvfHandle, HvfVcpu, HvfVm};
-pub use kernel_boot::{HostChannels, KernelBootResult, boot_kernel, boot_kernel_until};
+pub use kernel_boot::{
+    HostChannels, KernelBootResult, KernelBootUntilParams, boot_kernel, boot_kernel_until,
+};

--- a/crates/mvm-backend/src/kvm/vm.rs
+++ b/crates/mvm-backend/src/kvm/vm.rs
@@ -145,6 +145,8 @@ impl KvmVm {
                 |_: &KvmVcpu, _, _| Ok(RunControl::Stop),
                 // No async host I/O on this path yet → a forced exit always stops.
                 || true,
+                // No pause primitive on this console boot path.
+                || false,
             )
         };
         done.store(true, Ordering::Relaxed);
@@ -240,6 +242,8 @@ impl KvmVm {
                 &mut devices,
                 |_: &KvmVcpu, _, _| Ok(RunControl::Stop),
                 || stop.load(Ordering::Relaxed),
+                // No pause primitive on the KVM egress path.
+                || false,
             )
         };
         done.store(true, Ordering::Relaxed);

--- a/crates/mvm-backend/src/vmm/run.rs
+++ b/crates/mvm-backend/src/vmm/run.rs
@@ -11,6 +11,8 @@
 //! KVM, this single loop serves both backends with no `cfg` and no per-backend
 //! device dispatch.
 
+use std::time::Duration;
+
 use super::hv::{HypervisorVcpu, VcpuExit};
 
 /// A guest device the run loop dispatches decoded accesses to. Matched by guest
@@ -102,18 +104,25 @@ where
 ///   run (e.g. draining an egress socket into the guest's rx queue while the guest
 ///   is idle in WFI), so the loop polls devices and keeps going. Backends with no
 ///   async host I/O pass `|| true` (a cancel always stops).
-pub fn run<C, S, X, Q>(
+/// - `should_pause()` parks the vCPU without ending the run: when it returns
+///   `true` (and no stop is pending) after a forced exit, the loop holds the vCPU
+///   out of guest execution — polling once first, then sleeping — so guest RAM and
+///   device state freeze in place until the pause clears (resume) or a stop
+///   arrives. Backends with no pause primitive pass `|| false`.
+pub fn run<C, S, X, Q, P>(
     vcpu: &C,
     set_irq: S,
     devices: &mut [&mut dyn RunDevice],
     mut on_exception: X,
     should_stop: Q,
+    should_pause: P,
 ) -> Result<RunOutcome, C::Error>
 where
     C: HypervisorVcpu,
     S: Fn(u32, bool) -> Result<(), C::Error>,
     X: FnMut(&C, u64, u64) -> Result<RunControl, C::Error>,
     Q: Fn() -> bool,
+    P: Fn() -> bool,
 {
     loop {
         match vcpu.step()? {
@@ -139,6 +148,13 @@ where
                 }
                 if should_stop() {
                     return Ok(RunOutcome::Canceled);
+                }
+                // Pause hold: a pause request parks the vCPU here, out of guest
+                // execution, so RAM and device state stay frozen until resume
+                // clears the pause (or a stop arrives). The device poll above
+                // already drained any in-flight host reply before we park.
+                while should_pause() && !should_stop() {
+                    std::thread::sleep(Duration::from_millis(20));
                 }
             }
             VcpuExit::Halt => return Ok(RunOutcome::Halt),
@@ -256,6 +272,8 @@ mod tests {
     use super::*;
     use std::cell::RefCell;
     use std::collections::VecDeque;
+    use std::sync::Arc;
+    use std::sync::atomic::{AtomicBool, Ordering};
 
     #[derive(Clone, Copy)]
     struct NopHandle;
@@ -391,6 +409,7 @@ mod tests {
             &mut devs,
             no_exceptions,
             || false, // never a real stop → cancels are heartbeat wakes
+            || false, // no pause
         )
         .unwrap();
         assert_eq!(out, RunOutcome::Halt); // ran to the guest halt, not the cancel
@@ -418,11 +437,42 @@ mod tests {
             },
             &mut devs,
             no_exceptions,
-            || true, // real stop
+            || true,  // real stop
+            || false, // no pause
         )
         .unwrap();
         assert_eq!(out, RunOutcome::Canceled);
         assert_eq!(*raised.borrow(), vec![(9u32, true)]); // final drain still delivered
+    }
+
+    #[test]
+    fn canceled_with_pause_holds_until_resume_then_continues() {
+        let vcpu = ScriptVcpu::new(vec![VcpuExit::Canceled, VcpuExit::Halt]);
+        let mut devs: Vec<&mut dyn RunDevice> = vec![];
+        let paused = Arc::new(AtomicBool::new(true));
+        let paused_for_resume = Arc::clone(&paused);
+        let resume = std::thread::spawn(move || {
+            std::thread::sleep(Duration::from_millis(60));
+            paused_for_resume.store(false, Ordering::SeqCst);
+        });
+
+        let started = std::time::Instant::now();
+        let out = run(
+            &vcpu,
+            |_, _| Ok(()),
+            &mut devs,
+            no_exceptions,
+            || false,
+            || paused.load(Ordering::SeqCst),
+        )
+        .unwrap();
+        resume.join().unwrap();
+
+        assert_eq!(out, RunOutcome::Halt);
+        assert!(
+            started.elapsed() >= Duration::from_millis(40),
+            "pause hold should keep the vCPU out of guest execution until resume"
+        );
     }
 
     #[test]
@@ -443,7 +493,15 @@ mod tests {
             writes: vec![],
         };
         let mut devs: Vec<&mut dyn RunDevice> = vec![&mut dev];
-        let out = run(&vcpu, |_, _| Ok(()), &mut devs, no_exceptions, || true).unwrap();
+        let out = run(
+            &vcpu,
+            |_, _| Ok(()),
+            &mut devs,
+            no_exceptions,
+            || true,
+            || false,
+        )
+        .unwrap();
         assert_eq!(out, RunOutcome::Halt);
         assert_eq!(*vcpu.reads.borrow(), vec![0xdead_beef]);
     }
@@ -466,7 +524,15 @@ mod tests {
             writes: vec![],
         };
         let mut devs: Vec<&mut dyn RunDevice> = vec![&mut dev];
-        run(&vcpu, |_, _| Ok(()), &mut devs, no_exceptions, || true).unwrap();
+        run(
+            &vcpu,
+            |_, _| Ok(()),
+            &mut devs,
+            no_exceptions,
+            || true,
+            || false,
+        )
+        .unwrap();
         assert_eq!(dev.writes, vec![(0x10, 0x55)]);
         assert!(
             vcpu.reads.borrow().is_empty(),
@@ -502,6 +568,7 @@ mod tests {
             &mut devs,
             no_exceptions,
             || true,
+            || false,
         )
         .unwrap();
         assert_eq!(*raised.borrow(), vec![(42u32, true)]);
@@ -531,7 +598,15 @@ mod tests {
             writes: vec![],
         };
         let mut devs: Vec<&mut dyn RunDevice> = vec![&mut dev];
-        run(&vcpu, |_, _| Ok(()), &mut devs, no_exceptions, || true).unwrap();
+        run(
+            &vcpu,
+            |_, _| Ok(()),
+            &mut devs,
+            no_exceptions,
+            || true,
+            || false,
+        )
+        .unwrap();
         assert_eq!(*vcpu.reads.borrow(), vec![0xab, 0]); // device value, then RAZ
     }
 
@@ -539,7 +614,15 @@ mod tests {
     fn canceled_exit_ends_the_run() {
         let vcpu = ScriptVcpu::new(vec![VcpuExit::Canceled]);
         let mut devs: Vec<&mut dyn RunDevice> = vec![];
-        let out = run(&vcpu, |_, _| Ok(()), &mut devs, no_exceptions, || true).unwrap();
+        let out = run(
+            &vcpu,
+            |_, _| Ok(()),
+            &mut devs,
+            no_exceptions,
+            || true,
+            || false,
+        )
+        .unwrap();
         assert_eq!(out, RunOutcome::Canceled);
     }
 
@@ -571,6 +654,7 @@ mod tests {
                 })
             },
             || true,
+            || false,
         )
         .unwrap();
         assert_eq!(out, RunOutcome::Stopped);
@@ -581,7 +665,15 @@ mod tests {
     fn vtimer_is_ignored_and_the_loop_continues() {
         let vcpu = ScriptVcpu::new(vec![VcpuExit::VTimer, VcpuExit::VTimer, VcpuExit::Halt]);
         let mut devs: Vec<&mut dyn RunDevice> = vec![];
-        let out = run(&vcpu, |_, _| Ok(()), &mut devs, no_exceptions, || true).unwrap();
+        let out = run(
+            &vcpu,
+            |_, _| Ok(()),
+            &mut devs,
+            no_exceptions,
+            || true,
+            || false,
+        )
+        .unwrap();
         assert_eq!(out, RunOutcome::Halt);
     }
 
@@ -637,7 +729,15 @@ mod tests {
         let vcpu = ScriptVcpu::new(script);
         {
             let mut devs: Vec<&mut dyn RunDevice> = vec![&mut dev];
-            let out = run(&vcpu, |_, _| Ok(()), &mut devs, no_exceptions, || true).unwrap();
+            let out = run(
+                &vcpu,
+                |_, _| Ok(()),
+                &mut devs,
+                no_exceptions,
+                || true,
+                || false,
+            )
+            .unwrap();
             assert_eq!(out, RunOutcome::Halt);
         }
 

--- a/crates/mvm-vm-host/src/bin/mvm-hvf-supervisor.rs
+++ b/crates/mvm-vm-host/src/bin/mvm-hvf-supervisor.rs
@@ -112,9 +112,25 @@ fn ensure_self_signed() {
 #[cfg(all(target_os = "macos", target_arch = "aarch64"))]
 static STOP: std::sync::atomic::AtomicBool = std::sync::atomic::AtomicBool::new(false);
 
+/// Set/cleared by the SIGUSR1/SIGUSR2 handlers; `boot_kernel_until` parks the
+/// guest vCPU out of execution (RAM + devices intact) while this is true, so
+/// `HvfBackend::pause`/`resume` freeze and thaw the guest in place.
+#[cfg(all(target_os = "macos", target_arch = "aarch64"))]
+static PAUSED: std::sync::atomic::AtomicBool = std::sync::atomic::AtomicBool::new(false);
+
 #[cfg(all(target_os = "macos", target_arch = "aarch64"))]
 extern "C" fn on_stop_signal(_: libc::c_int) {
     STOP.store(true, std::sync::atomic::Ordering::Relaxed);
+}
+
+#[cfg(all(target_os = "macos", target_arch = "aarch64"))]
+extern "C" fn on_pause_signal(_: libc::c_int) {
+    PAUSED.store(true, std::sync::atomic::Ordering::Relaxed);
+}
+
+#[cfg(all(target_os = "macos", target_arch = "aarch64"))]
+extern "C" fn on_resume_signal(_: libc::c_int) {
+    PAUSED.store(false, std::sync::atomic::Ordering::Relaxed);
 }
 
 #[cfg(all(target_os = "macos", target_arch = "aarch64"))]
@@ -130,11 +146,17 @@ fn main() -> anyhow::Result<()> {
 
     // Graceful stop: SIGTERM/SIGINT set STOP, which the boot watchdog observes and
     // force-exits the guest (then we flush the console + drop the PID file).
-    // SAFETY: installing a trivial async-signal-safe handler (an atomic store).
+    // Pause/resume: SIGUSR1 sets PAUSED (park the vCPU out of guest execution),
+    // SIGUSR2 clears it (thaw and re-enter the guest).
+    // SAFETY: installing trivial async-signal-safe handlers (each an atomic store).
     unsafe {
         let h = on_stop_signal as extern "C" fn(libc::c_int) as libc::sighandler_t;
         libc::signal(libc::SIGTERM, h);
         libc::signal(libc::SIGINT, h);
+        let pause_h = on_pause_signal as extern "C" fn(libc::c_int) as libc::sighandler_t;
+        libc::signal(libc::SIGUSR1, pause_h);
+        let resume_h = on_resume_signal as extern "C" fn(libc::c_int) as libc::sighandler_t;
+        libc::signal(libc::SIGUSR2, resume_h);
     }
 
     let mut raw = String::new();
@@ -189,29 +211,30 @@ fn main() -> anyhow::Result<()> {
     // whole egress decision (claim-10 default-deny + secret substitution). The
     // supervisor only wires the relay socket paths through.
     let result = mvm_backend::hvf::boot_kernel_until(
-        &image,
-        initramfs.as_deref(),
-        disks,
-        cfg.vsock,
-        timeout,
-        &STOP,
-        mvm_backend::hvf::HostChannels {
-            agent_socket: cfg.agent_socket.clone(),
-            substitution_socket: cfg.substitution_socket.clone(),
-            egress_relay: cfg.egress_relay_socket.clone(),
-            console_data_sockets: cfg
-                .console_data_sockets
-                .iter()
-                .map(|c| (c.guest_port, c.host_socket.clone()))
-                .collect(),
-            cmdline: cfg.cmdline.clone(),
-            mem_mib: cfg.memory_mib,
-            // Dev hook: `MVM_HVF_VIRTIOFS_ROOT=<dir>` boots a virtiofs root without
-            // the full run-path gate wiring, for live-mount iteration on HVF.
-            virtiofs_root: cfg.virtiofs_root.clone().or_else(|| {
-                std::env::var_os("MVM_HVF_VIRTIOFS_ROOT").map(std::path::PathBuf::from)
-            }),
-        },
+        mvm_backend::hvf::KernelBootUntilParams::builder(&image, timeout)
+            .initramfs(initramfs.as_deref())
+            .disks(disks)
+            .vsock(cfg.vsock)
+            .stop(&STOP)
+            .paused(&PAUSED)
+            .channels(mvm_backend::hvf::HostChannels {
+                agent_socket: cfg.agent_socket.clone(),
+                substitution_socket: cfg.substitution_socket.clone(),
+                egress_relay: cfg.egress_relay_socket.clone(),
+                console_data_sockets: cfg
+                    .console_data_sockets
+                    .iter()
+                    .map(|c| (c.guest_port, c.host_socket.clone()))
+                    .collect(),
+                cmdline: cfg.cmdline.clone(),
+                mem_mib: cfg.memory_mib,
+                // Dev hook: `MVM_HVF_VIRTIOFS_ROOT=<dir>` boots a virtiofs root without
+                // the full run-path gate wiring, for live-mount iteration on HVF.
+                virtiofs_root: cfg.virtiofs_root.clone().or_else(|| {
+                    std::env::var_os("MVM_HVF_VIRTIOFS_ROOT").map(std::path::PathBuf::from)
+                }),
+            })
+            .build(),
     );
 
     // The VM has stopped. Persist the outputs (console + workload exit code)


### PR DESCRIPTION
## Summary

Implements HVF pause/resume by wiring supervisor SIGUSR1/SIGUSR2 into the persistent HVF run loop.

- Adds an explicit pause callback to the shared vCPU run loop.
- Parks the HVF vCPU out of guest execution while paused, preserving RAM and device state.
- Keeps KVM paths unchanged by passing a no-pause callback.
- Replaces the growing HVF boot argument list with a builder-backed params struct.

## Validation

- `cargo test -p mvm-backend --quiet`
- `cargo check -p mvm-backend -p mvm-vm-host --quiet`
- `cargo clippy -p mvm-backend -p mvm-vm-host --no-deps --quiet -- -D warnings`
