### PR TITLE
fix(run): reuse the builder kernel for dev image launches (no Stage 0)

### DIFF
--- a/crates/mvm-cli/src/commands/env/dev_vz.rs
+++ b/crates/mvm-cli/src/commands/env/dev_vz.rs
@@ -4861,7 +4861,7 @@ pub(crate) fn ensure_default_microvm_image(
 /// boots on. An end-user mvmctl downloads the published, hash-verified
 /// `vmlinux-<arch>-workload` (~10 MB, no Nix); a source checkout builds just the
 /// `workload-kernel` flake target locally (no rootfs/verity). Cache-hit-fast.
-pub(crate) fn ensure_workload_kernel() -> Result<String> {
+pub(crate) fn ensure_workload_kernel(prod: bool) -> Result<String> {
     let arch = builder_vm_host_arch();
     let cache = mvm_core::config::mvm_cache_dir();
     // Source-checkout: fingerprint `nix/images/kernel/` so a stale cached vmlinux
@@ -4870,6 +4870,16 @@ pub(crate) fn ensure_workload_kernel() -> Result<String> {
     let source_fingerprint = workload_kernel_source_fingerprint_opt();
     if let Some(cached) = find_cached_workload_kernel(&cache, arch, source_fingerprint.as_deref()) {
         return Ok(cached);
+    }
+    // A non-sealed launch boots on the builder kernel already on disk — the
+    // shared kernel base plus builder extras, lacking only the dm-verity a
+    // sealed guest opens — so an image launch reuses it instead of compiling a
+    // workload kernel via Stage 0. Keeps a plain `machine run --image` off the
+    // builder VM. A sealed/prod guest needs the real dm-verity workload kernel,
+    // so it falls through to build/download below.
+    if !prod && let Some(builder) = find_reusable_builder_kernel(&cache, arch) {
+        ui::info("Reusing the builder kernel for this dev launch (no workload-kernel build).");
+        return Ok(builder);
     }
     let dest = format!("{cache}/builder-vm/{arch}/kernels/workload/vmlinux");
     if let Some(built) = try_build_workload_kernel_locally()? {
@@ -4880,6 +4890,17 @@ pub(crate) fn ensure_workload_kernel() -> Result<String> {
     }
     download_workload_kernel(arch, &dest)?;
     Ok(dest)
+}
+
+/// The builder VM's own kernel at `builder-vm/<arch>/vmlinux`, present whenever a
+/// source checkout has built the builder image. It shares the workload kernel's
+/// base config and lacks only dm-verity, so it boots a non-sealed workload guest
+/// — a valid reuse source that needs neither a Stage 0 build nor a prebuilt
+/// download. `None` when absent (an end-user mvmctl that never built the image).
+/// Path-injectable (no global state) so it's hermetically testable.
+fn find_reusable_builder_kernel(cache_dir: &str, arch: &str) -> Option<String> {
+    let path = format!("{cache_dir}/builder-vm/{arch}/vmlinux");
+    std::path::Path::new(&path).is_file().then_some(path)
 }
 
 /// End-user download of the published, hash-verified `vmlinux-<arch>-workload`
@@ -6453,6 +6474,30 @@ mod builder_vm_bootstrap_tests {
             Some(vmlinux.to_str().unwrap())
         );
         assert_eq!(find_cached_workload_kernel(cache, arch, Some("xyz")), None);
+    }
+
+    #[test]
+    fn find_reusable_builder_kernel_detects_builder_image_vmlinux() {
+        let tmp = tempfile::tempdir().unwrap();
+        let cache = tmp.path().to_str().unwrap();
+        let arch = "aarch64";
+        // Absent → None (the builder image was never built).
+        assert_eq!(find_reusable_builder_kernel(cache, arch), None);
+
+        // The builder image's kernel lives at `builder-vm/<arch>/vmlinux`; it is a
+        // valid reuse source for a non-sealed launch (boots a plain rootfs).
+        let dir = tmp.path().join(format!("builder-vm/{arch}"));
+        std::fs::create_dir_all(&dir).unwrap();
+        let vmlinux = dir.join("vmlinux");
+        std::fs::write(&vmlinux, b"vmlinux").unwrap();
+        assert_eq!(
+            find_reusable_builder_kernel(cache, arch).as_deref(),
+            Some(vmlinux.to_str().unwrap())
+        );
+
+        // The builder kernel is NOT a workload-kernel cache candidate, so reuse is
+        // a deliberate separate step — the cache lookup still misses here.
+        assert!(find_cached_workload_kernel(cache, arch, None).is_none());
     }
 
     #[test]

--- a/crates/mvm-cli/src/commands/vm/exec.rs
+++ b/crates/mvm-cli/src/commands/vm/exec.rs
@@ -680,8 +680,10 @@ fn build_exec_request(
             // an end-user mvmctl (no Nix), or a local `workload-kernel` build on
             // a source checkout — rather than building/downloading a whole
             // default image whose rootfs we'd discard. This keeps the OCI path
-            // free of Nix (end users) and of a ~220 MB unused-rootfs fetch.
-            let kernel_path = ensure_workload_kernel()?;
+            // free of Nix (end users) and of a ~220 MB unused-rootfs fetch. A
+            // non-prod launch reuses the on-disk builder kernel rather than
+            // building one, so this stays off the builder VM entirely.
+            let kernel_path = ensure_workload_kernel(prod)?;
             crate::exec::ImageSource::Prebuilt {
                 kernel_path,
                 rootfs_path: cached.rootfs_path.display().to_string(),

--- a/crates/mvm-cli/src/commands/vm/up.rs
+++ b/crates/mvm-cli/src/commands/vm/up.rs
@@ -1185,7 +1185,9 @@ pub(in crate::commands) fn start_persistent_oci_machine(
         // image whose 220 MB rootfs we'd discard. This also routes through the
         // kernel's source-fingerprint cache, so a `nix/images/kernel/` edit
         // rebuilds on the next boot instead of reusing a stale default image.
-        ensure_workload_kernel()?
+        // A non-sealed (dev) profile reuses the on-disk builder kernel; a sealed
+        // profile needs the real dm-verity workload kernel, so `prod` is set.
+        ensure_workload_kernel(profile != "dev")?
     };
     register_vm_name(name, "default");
 


### PR DESCRIPTION
## Problem

`machine run --image <oci>` on a source checkout boots a **Stage 0 builder VM
just to compile the workload kernel** when none is cached. A plain image launch
should never build with Nix — the OCI rootfs materializes in-process; only the
kernel was still forcing a builder-VM round-trip. (`ensure_workload_kernel` fell
through to `try_build_workload_kernel_locally` → `build_kernel_via_stage0` on any
cache miss.)

## Fix

Add a builder-kernel **reuse** step to `ensure_workload_kernel`, between the
cached-kernel lookup and the build/download fallback:

- A **non-sealed** launch reuses the builder kernel already on disk
  (`builder-vm/<arch>/vmlinux`) — the shared kernel base plus builder extras,
  lacking only the dm-verity a sealed guest opens, so it boots a plain rootfs.
  No Stage 0, no prebuilt download.
- A **sealed/prod** launch still resolves the real dm-verity workload kernel
  (unchanged).

Callers pass the seal signal: the transient path (`exec.rs`) forwards `prod`;
the persistent path (`up.rs`) passes `profile != "dev"`.

New `find_reusable_builder_kernel()` helper is path-injectable and unit-tested.

## Verification

Live proof (source checkout, workload-kernel cache cleared, builder kernel present):

```
[mvm] Using OCI image docker.io/library/alpine:latest (...)
[mvm] Reusing the builder kernel for this dev launch (no workload-kernel build).
[mvm] Booting transient VM 'happy-pika-4c9b'...
```

No Stage-0 build, no builder VM, no Nix — it proceeds straight to plan admission
and boot.

- `nextest -p mvm-cli`: green (new test `find_reusable_builder_kernel_detects_builder_image_vmlinux` + existing kernel/fingerprint tests). The one unrelated failure — `doctor::collect_security_posture_returns_a_real_tier` (`unexpected tier: Unknown`) — is pre-existing (fails identically on the clean base; host-posture env dependency).
- nightly `fmt --all --check`, `clippy -p mvm-cli --all-targets -D warnings`: clean.

## Note

Overlaps the in-flight `fix/oci-image-no-builder-vm` branch, which takes a
download-only approach to the same function. This branch is the complementary
source-checkout fallback (reuse the on-disk builder kernel) rather than a
prebuilt download — whichever lands first, the other should rebase onto it.