### PR TITLE
fix oci image kernel bootstrap

### DIFF
--- a/crates/mvm-cli/src/commands/env/dev_vz.rs
+++ b/crates/mvm-cli/src/commands/env/dev_vz.rs
@@ -34,13 +34,6 @@ const DEV_VM_SESSION_ID: &str = mvm_build::vz_builder::DEV_SESSION_ID;
 #[cfg(feature = "builder-vm")]
 const DEV_VZ_ACTIVITY_FILE: &str = "last-activity-unix-secs";
 const BUILDER_VM_SOURCE_FINGERPRINT_FILE: &str = ".mvm-source.sha256";
-/// Sidecar written next to a cached workload `vmlinux` recording the SHA-256 of
-/// its kernel-config nix source (`nix/images/kernel/`). A source-checkout boot
-/// treats a cached kernel as stale when this fingerprint no longer matches the
-/// on-disk config, so an edit to `base.nix`/`workload.nix` rebuilds on the very
-/// next `machine run` instead of silently reusing the old vmlinux (the cache is
-/// otherwise keyed by path-existence, which cannot see a config change).
-const KERNEL_SOURCE_FINGERPRINT_FILE: &str = ".mvm-kernel-source.sha256";
 const BUILDER_VM_ARTIFACT_DIGEST_FILE: &str = ".mvm-artifacts.sha256";
 const BUILDER_VM_PROVENANCE_FILE: &str = ".mvm-provenance.json";
 #[cfg(feature = "builder-vm")]
@@ -4858,38 +4851,52 @@ pub(crate) fn ensure_default_microvm_image(
 /// `--image` run path needs just a kernel — the materialized OCI rootfs (with
 /// its injected agent) is the workload — so this avoids building/downloading a
 /// whole default image. It's the same `workload-kernel` the default microVM
-/// boots on. An end-user mvmctl downloads the published, hash-verified
-/// `vmlinux-<arch>-workload` (~10 MB, no Nix); a source checkout builds just the
-/// `workload-kernel` flake target locally (no rootfs/verity). Cache-hit-fast.
+/// boots on.
+///
+/// Important: this is a runtime boot path, not a Nix build path. It must never
+/// spin up Stage 0 / the builder VM on a cold cache. We reuse any cached
+/// workload/default-image kernel already on disk. A non-prod launch may also
+/// reuse an existing builder kernel because that does not build anything; a
+/// sealed/prod launch falls through to the published, hash-verified
+/// `vmlinux-<arch>-workload` download when no workload kernel is cached.
 pub(crate) fn ensure_workload_kernel(prod: bool) -> Result<String> {
     let arch = builder_vm_host_arch();
     let cache = mvm_core::config::mvm_cache_dir();
-    // Source-checkout: fingerprint `nix/images/kernel/` so a stale cached vmlinux
-    // from since-edited config is rejected and rebuilt (path-existence alone
-    // can't see a config change). End-user prebuilt → None → prior behavior.
-    let source_fingerprint = workload_kernel_source_fingerprint_opt();
-    if let Some(cached) = find_cached_workload_kernel(&cache, arch, source_fingerprint.as_deref()) {
-        return Ok(cached);
-    }
-    // A non-sealed launch boots on the builder kernel already on disk — the
-    // shared kernel base plus builder extras, lacking only the dm-verity a
-    // sealed guest opens — so an image launch reuses it instead of compiling a
-    // workload kernel via Stage 0. Keeps a plain `machine run --image` off the
-    // builder VM. A sealed/prod guest needs the real dm-verity workload kernel,
-    // so it falls through to build/download below.
-    if !prod && let Some(builder) = find_reusable_builder_kernel(&cache, arch) {
-        ui::info("Reusing the builder kernel for this dev launch (no workload-kernel build).");
-        return Ok(builder);
-    }
-    let dest = format!("{cache}/builder-vm/{arch}/kernels/workload/vmlinux");
-    if let Some(built) = try_build_workload_kernel_locally()? {
-        if let Some(fp) = &source_fingerprint {
-            write_kernel_source_fingerprint(std::path::Path::new(&built), fp);
+    let resolved = resolve_workload_kernel_bootstrap(&cache, arch, prod);
+    match resolved {
+        WorkloadKernelBootstrap::Cached(path) => Ok(path),
+        WorkloadKernelBootstrap::ReusableBuilder(path) => {
+            ui::info("Reusing the builder kernel for this dev launch (no workload-kernel build).");
+            Ok(path)
         }
-        return Ok(built);
+        WorkloadKernelBootstrap::Download(dest) => {
+            download_workload_kernel(arch, &dest)?;
+            Ok(dest)
+        }
     }
-    download_workload_kernel(arch, &dest)?;
-    Ok(dest)
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+enum WorkloadKernelBootstrap {
+    Cached(String),
+    ReusableBuilder(String),
+    Download(String),
+}
+
+fn resolve_workload_kernel_bootstrap(
+    cache_dir: &str,
+    arch: &str,
+    prod: bool,
+) -> WorkloadKernelBootstrap {
+    if let Some(cached) = find_cached_workload_kernel(cache_dir, arch) {
+        return WorkloadKernelBootstrap::Cached(cached);
+    }
+    if !prod && let Some(builder) = find_reusable_builder_kernel(cache_dir, arch) {
+        return WorkloadKernelBootstrap::ReusableBuilder(builder);
+    }
+    WorkloadKernelBootstrap::Download(format!(
+        "{cache_dir}/builder-vm/{arch}/kernels/workload/vmlinux"
+    ))
 }
 
 /// The builder VM's own kernel at `builder-vm/<arch>/vmlinux`, present whenever a
@@ -4904,10 +4911,9 @@ fn find_reusable_builder_kernel(cache_dir: &str, arch: &str) -> Option<String> {
 }
 
 /// End-user download of the published, hash-verified `vmlinux-<arch>-workload`
-/// (~10 MB, no Nix) for this mvmctl's release tag. Mirrors
-/// `download_default_microvm_image`'s verify-then-cache flow via the same
-/// non-gated artifact helpers, so the OCI `--image` path resolves a kernel even
-/// when mvmctl is built without the `builder-vm` feature.
+/// (~10 MB, no Nix) for this mvmctl's release tag. Used by both installed
+/// binaries and source checkouts when the runtime path has no cached workload
+/// kernel — launching an OCI image must not boot Stage 0 just to compile one.
 fn download_workload_kernel(arch: &str, dest: &str) -> Result<()> {
     if let Some(parent) = std::path::Path::new(dest).parent() {
         std::fs::create_dir_all(parent)?;
@@ -4930,107 +4936,18 @@ fn download_workload_kernel(arch: &str, dest: &str) -> Result<()> {
     Ok(())
 }
 
-/// SHA-256 fingerprint of the workload kernel's nix-config source
-/// (`nix/images/kernel/` — base.nix, workload.nix, builder.nix, flake.nix,
-/// flake.lock). `None` when not in a source checkout (no in-repo flake to
-/// locate the workspace): an end-user mvmctl boots the published, hash-verified
-/// `vmlinux-<arch>-workload` prebuilt, which carries no local source to compare,
-/// so the cache stays keyed by path-existence as before. On a source checkout
-/// this fingerprint gates the cache so a `base.nix`/`workload.nix` edit rebuilds
-/// on the next boot — the same "your change appears in the very next run"
-/// contract the builder-VM image already honors via its own source fingerprint.
-fn workload_kernel_source_fingerprint_opt() -> Option<String> {
-    let flake = find_builder_vm_flake().ok()?;
-    let workspace_root = workspace_root_for_builder_flake(std::path::Path::new(&flake)).ok()?;
-    workload_kernel_source_fingerprint(&workspace_root).ok()
-}
-
-/// Hash `nix/images/kernel/` recursively (the complete workload-kernel config
-/// source). Separated from the flake lookup so it is hermetically testable
-/// against a fixture workspace.
-fn workload_kernel_source_fingerprint(workspace_root: &std::path::Path) -> Result<String> {
-    let kernel_dir = workspace_root.join("nix").join("images").join("kernel");
-    if !kernel_dir.is_dir() {
-        anyhow::bail!(
-            "workload kernel source dir missing at {}",
-            kernel_dir.display()
-        );
-    }
-    let mut hasher = Sha256::new();
-    hash_dir_recursive(&mut hasher, "nix/images/kernel", &kernel_dir)?;
-    Ok(format!("{:x}", hasher.finalize()))
-}
-
-/// Does the `KERNEL_SOURCE_FINGERPRINT_FILE` sidecar in `dir` match `expected`?
-/// A missing/unreadable sidecar is a miss (treated as stale → rebuild), so a
-/// kernel cached before this gate existed is refreshed once.
-fn kernel_source_fingerprint_matches(dir: &std::path::Path, expected: &str) -> bool {
-    std::fs::read_to_string(dir.join(KERNEL_SOURCE_FINGERPRINT_FILE))
-        .map(|actual| actual.trim() == expected)
-        .unwrap_or(false)
-}
-
-/// Record the kernel-config source fingerprint next to a freshly-built
-/// `vmlinux` so subsequent boots recognise it as current. Best-effort — a write
-/// failure only costs a redundant rebuild next time, never a stale boot.
-fn write_kernel_source_fingerprint(vmlinux_path: &std::path::Path, fingerprint: &str) {
-    if let Some(dir) = vmlinux_path.parent() {
-        let _ = std::fs::write(
-            dir.join(KERNEL_SOURCE_FINGERPRINT_FILE),
-            format!("{fingerprint}\n"),
-        );
-    }
-}
-
 /// First workload-kernel `vmlinux` on disk among the dedicated kernel cache and
 /// the default-microvm images — all the identical `mkWorkloadKernel` derivation,
-/// so any one is a valid workload kernel. `None` ⇒ build/download.
-///
-/// `expected_fingerprint` gates a source-checkout boot: a candidate is accepted
-/// only when its `KERNEL_SOURCE_FINGERPRINT_FILE` sidecar matches, so a stale
-/// vmlinux from a since-edited `nix/images/kernel/` is rejected and rebuilt.
-/// `None` (end-user prebuilt, no local source) keeps the prior path-existence
-/// behavior. Path-injectable (no global state) so it's hermetically testable.
-fn find_cached_workload_kernel(
-    cache_dir: &str,
-    arch: &str,
-    expected_fingerprint: Option<&str>,
-) -> Option<String> {
+/// so any one is a valid workload kernel. `None` ⇒ download the published
+/// workload kernel.
+fn find_cached_workload_kernel(cache_dir: &str, arch: &str) -> Option<String> {
     [
         format!("{cache_dir}/builder-vm/{arch}/kernels/workload/vmlinux"),
         format!("{cache_dir}/default-microvm/prod/vmlinux"),
         format!("{cache_dir}/default-microvm/dev/vmlinux"),
     ]
     .into_iter()
-    .find(|p| {
-        let path = std::path::Path::new(p);
-        if !path.is_file() {
-            return false;
-        }
-        match expected_fingerprint {
-            None => true,
-            Some(fp) => path
-                .parent()
-                .is_some_and(|dir| kernel_source_fingerprint_matches(dir, fp)),
-        }
-    })
-}
-
-/// Source-checkout local build of just the workload kernel. `Some` when the
-/// in-repo `builder-vm` flake resolves; `None` (→ caller downloads) otherwise.
-#[cfg(feature = "builder-vm")]
-fn try_build_workload_kernel_locally() -> Result<Option<String>> {
-    if find_builder_vm_flake().is_err() {
-        return Ok(None);
-    }
-    ui::info("Building the workload microVM kernel locally (source checkout)...");
-    let path = build_kernel_via_stage0(KernelVariant::Workload, false)?;
-    Ok(Some(path.display().to_string()))
-}
-
-#[cfg(not(feature = "builder-vm"))]
-fn try_build_workload_kernel_locally() -> Result<Option<String>> {
-    Ok(None)
+    .find(|p| std::path::Path::new(p).is_file())
 }
 
 /// Prod-mode default image. On a source checkout (the in-repo `builder-vm` flake
@@ -5234,13 +5151,6 @@ fn build_default_microvm_via_libkrun(
     }
     let kernel = format!("{out_dir}/vmlinux");
     let rootfs = format!("{out_dir}/rootfs.ext4");
-    // Stamp the kernel-config fingerprint next to this image's bundled vmlinux so
-    // the OCI `ensure_workload_kernel` path recognises it as a current workload
-    // kernel (same mkWorkloadKernel derivation) rather than building a separate
-    // copy, and so a later config edit invalidates it here too.
-    if let Some(fp) = workload_kernel_source_fingerprint_opt() {
-        write_kernel_source_fingerprint(std::path::Path::new(&kernel), &fp);
-    }
     Ok((kernel, rootfs))
 }
 
@@ -6418,7 +6328,7 @@ mod builder_vm_bootstrap_tests {
         let cache = tmp.path().to_str().unwrap();
         let arch = "x86_64";
         // Nothing on disk → None (caller will build/download).
-        assert_eq!(find_cached_workload_kernel(cache, arch, None), None);
+        assert_eq!(find_cached_workload_kernel(cache, arch), None);
 
         let mk = |rel: &str| {
             let p = tmp.path().join(rel);
@@ -6429,51 +6339,34 @@ mod builder_vm_bootstrap_tests {
         // The dev default image's kernel is a valid reuse source.
         let dev = mk("default-microvm/dev/vmlinux");
         assert_eq!(
-            find_cached_workload_kernel(cache, arch, None).as_deref(),
+            find_cached_workload_kernel(cache, arch).as_deref(),
             Some(dev.as_str())
         );
         // Prod wins over dev (checked first).
         let prod = mk("default-microvm/prod/vmlinux");
         assert_eq!(
-            find_cached_workload_kernel(cache, arch, None).as_deref(),
+            find_cached_workload_kernel(cache, arch).as_deref(),
             Some(prod.as_str())
         );
         // The dedicated kernel cache wins over everything.
         let dedicated = mk(&format!("builder-vm/{arch}/kernels/workload/vmlinux"));
         assert_eq!(
-            find_cached_workload_kernel(cache, arch, None).as_deref(),
+            find_cached_workload_kernel(cache, arch).as_deref(),
             Some(dedicated.as_str())
         );
     }
 
     #[test]
-    fn find_cached_workload_kernel_rejects_stale_fingerprint() {
+    fn cold_cache_downloads_instead_of_building_locally() {
         let tmp = tempfile::tempdir().unwrap();
         let cache = tmp.path().to_str().unwrap();
         let arch = "x86_64";
-        let dir = tmp
-            .path()
-            .join(format!("builder-vm/{arch}/kernels/workload"));
-        std::fs::create_dir_all(&dir).unwrap();
-        let vmlinux = dir.join("vmlinux");
-        std::fs::write(&vmlinux, b"vmlinux").unwrap();
-
-        // No sidecar yet: with a fingerprint expectation the candidate is a miss
-        // (treated as stale → rebuild), but None (end-user prebuilt) accepts it.
-        assert_eq!(find_cached_workload_kernel(cache, arch, Some("abc")), None);
         assert_eq!(
-            find_cached_workload_kernel(cache, arch, None).as_deref(),
-            Some(vmlinux.to_str().unwrap())
+            resolve_workload_kernel_bootstrap(cache, arch, true),
+            WorkloadKernelBootstrap::Download(format!(
+                "{cache}/builder-vm/{arch}/kernels/workload/vmlinux"
+            ))
         );
-
-        // Stamp fingerprint "abc": matching expectation hits, a changed config
-        // ("xyz") misses.
-        write_kernel_source_fingerprint(&vmlinux, "abc");
-        assert_eq!(
-            find_cached_workload_kernel(cache, arch, Some("abc")).as_deref(),
-            Some(vmlinux.to_str().unwrap())
-        );
-        assert_eq!(find_cached_workload_kernel(cache, arch, Some("xyz")), None);
     }
 
     #[test]
@@ -6497,29 +6390,17 @@ mod builder_vm_bootstrap_tests {
 
         // The builder kernel is NOT a workload-kernel cache candidate, so reuse is
         // a deliberate separate step — the cache lookup still misses here.
-        assert!(find_cached_workload_kernel(cache, arch, None).is_none());
-    }
-
-    #[test]
-    fn workload_kernel_source_fingerprint_changes_with_config() {
-        let tmp = tempfile::tempdir().unwrap();
-        let kernel_dir = tmp.path().join("nix/images/kernel");
-        std::fs::create_dir_all(&kernel_dir).unwrap();
-        std::fs::write(kernel_dir.join("base.nix"), b"baseEnables = [ ];\n").unwrap();
-        std::fs::write(kernel_dir.join("workload.nix"), b"extraDisables = [ ];\n").unwrap();
-
-        let before = workload_kernel_source_fingerprint(tmp.path()).unwrap();
-        // Editing the config (a new disable) changes the fingerprint.
-        std::fs::write(
-            kernel_dir.join("workload.nix"),
-            b"extraDisables = [ \"BLK_DEV_NBD\" ];\n",
-        )
-        .unwrap();
-        let after = workload_kernel_source_fingerprint(tmp.path()).unwrap();
-        assert_ne!(before, after, "a config edit must change the fingerprint");
-
-        // Missing source dir → Err (caller maps to None → path-existence mode).
-        assert!(workload_kernel_source_fingerprint(&tmp.path().join("nope")).is_err());
+        assert!(find_cached_workload_kernel(cache, arch).is_none());
+        assert_eq!(
+            resolve_workload_kernel_bootstrap(cache, arch, false),
+            WorkloadKernelBootstrap::ReusableBuilder(vmlinux.to_str().unwrap().to_string())
+        );
+        assert_eq!(
+            resolve_workload_kernel_bootstrap(cache, arch, true),
+            WorkloadKernelBootstrap::Download(format!(
+                "{cache}/builder-vm/{arch}/kernels/workload/vmlinux"
+            ))
+        );
     }
 
     #[test]

--- a/crates/mvm-cli/src/commands/vm/exec.rs
+++ b/crates/mvm-cli/src/commands/vm/exec.rs
@@ -676,13 +676,11 @@ fn build_exec_request(
             }
             // An `--image` run boots the materialized OCI rootfs (with its
             // injected agent), so we need only a workload kernel. Resolve just
-            // the kernel — the published `vmlinux-<arch>-workload` download for
-            // an end-user mvmctl (no Nix), or a local `workload-kernel` build on
-            // a source checkout — rather than building/downloading a whole
-            // default image whose rootfs we'd discard. This keeps the OCI path
-            // free of Nix (end users) and of a ~220 MB unused-rootfs fetch. A
-            // non-prod launch reuses the on-disk builder kernel rather than
-            // building one, so this stays off the builder VM entirely.
+            // the kernel — a cached workload/default-image kernel, the cold-cache
+            // published workload-kernel download, or (for non-prod) an existing
+            // builder kernel already on disk — rather than building/downloading a
+            // whole default image whose rootfs we'd discard. This runtime path
+            // never builds Stage 0 or compiles a workload kernel.
             let kernel_path = ensure_workload_kernel(prod)?;
             crate::exec::ImageSource::Prebuilt {
                 kernel_path,

--- a/crates/mvm-cli/src/commands/vm/up.rs
+++ b/crates/mvm-cli/src/commands/vm/up.rs
@@ -1182,11 +1182,10 @@ pub(in crate::commands) fn start_persistent_oci_machine(
         // The rootfs is supplied (OCI image / manifest); we need only a kernel.
         // Resolve just the workload kernel — same as the transient OCI path
         // (`exec.rs`) — rather than building/downloading a whole default-microvm
-        // image whose 220 MB rootfs we'd discard. This also routes through the
-        // kernel's source-fingerprint cache, so a `nix/images/kernel/` edit
-        // rebuilds on the next boot instead of reusing a stale default image.
-        // A non-sealed (dev) profile reuses the on-disk builder kernel; a sealed
-        // profile needs the real dm-verity workload kernel, so `prod` is set.
+        // image whose 220 MB rootfs we'd discard. This runtime path never builds
+        // Stage 0 or compiles a workload kernel: dev may reuse an existing
+        // builder kernel, while sealed/prod uses a cached workload kernel or the
+        // published workload-kernel download.
         ensure_workload_kernel(profile != "dev")?
     };
     register_vm_name(name, "default");


### PR DESCRIPTION
## Summary

Fixes the `machine run --image ...` path so launching an OCI image never boots Stage 0 or builds the builder VM just to resolve a workload kernel.

- Reuses an existing cached workload/default-image kernel when present.
- Downloads the published `vmlinux-<arch>-workload` on a cold cache.
- Removes the source-checkout local workload-kernel build/fingerprint path from OCI runtime boot.
- Updates transient and persistent OCI comments to match the runtime behavior.

## Validation

- `cargo check -p mvm-cli --quiet`
- `cargo test -p mvm-cli builder_vm_bootstrap_tests --quiet`
- `cargo clippy -p mvm-cli --no-deps --quiet -- -D warnings`
- Live smoke was previously run from this worktree with `cargo run -- machine run --image alpine --timeout 30 -- /bin/true`; it exited successfully with no Stage 0 build output.
