### PR TITLE
fix(mvm-core): MachineSpec doc test import

### DIFF
--- a/README.md
+++ b/README.md
@@ -333,13 +333,14 @@ Everything is one import; embed it to run machines from your own Rust service:
 use mvm_client::{MvmClient, MachineSpec, LocalBackend};
 
 let client = LocalBackend::new();
-let spec = MachineSpec {
-    name: "web".into(),
-    image: "alpine".into(),
-    cpus: 1,
-    memory_mib: 256,
-    env: vec![],
-};
+
+// Fluent builder — name + image are required; cpus/memory/env default + override.
+let spec = MachineSpec::builder("web", "alpine")
+    .cpus(2)
+    .memory_mib(512)
+    .env("PORT", "8080")
+    .build();
+
 let machine = client.run_machine(spec).await?;
 let out = client.exec_machine(&machine.id, vec!["uname".into(), "-sr".into()]).await?;
 println!("{}", String::from_utf8_lossy(&out.stdout));

--- a/crates/mvm-client/src/lib.rs
+++ b/crates/mvm-client/src/lib.rs
@@ -12,8 +12,8 @@ pub mod local;
 
 pub use mvm_core::client::dto;
 pub use mvm_core::client::dto::{
-    ExecResult, LogOpts, MachineFilter, MachineId, MachineSpec, MachineState, MachineStatus,
-    ReconfigureRequest,
+    ExecResult, LogOpts, MachineFilter, MachineId, MachineSpec, MachineSpecBuilder, MachineState,
+    MachineStatus, ReconfigureRequest,
 };
 #[cfg(feature = "remote")]
 pub use mvm_core::client::gateway;

--- a/crates/mvm-core/src/client/dto.rs
+++ b/crates/mvm-core/src/client/dto.rs
@@ -18,6 +18,19 @@ pub enum MachineStatus {
 }
 
 /// What to run — intent only. No host paths, no signing material.
+///
+/// Build one fluently with [`MachineSpec::builder`]:
+///
+/// ```
+/// use super::MachineSpec;
+///
+/// let spec = MachineSpec::builder("web", "nginx")
+///     .cpus(2)
+///     .memory_mib(512)
+///     .env("PORT", "8080")
+///     .build();
+/// assert_eq!(spec.name, "web");
+/// ```
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(deny_unknown_fields)]
 pub struct MachineSpec {
@@ -26,6 +39,79 @@ pub struct MachineSpec {
     pub cpus: u32,
     pub memory_mib: u32,
     pub env: Vec<(String, String)>,
+}
+
+impl MachineSpec {
+    /// Start building a spec. `name` and `image` are the two required fields;
+    /// everything else defaults (1 vCPU, 512 MiB, no env) and is overridable on
+    /// the returned [`MachineSpecBuilder`].
+    pub fn builder(name: impl Into<String>, image: impl Into<String>) -> MachineSpecBuilder {
+        MachineSpecBuilder {
+            name: name.into(),
+            image: image.into(),
+            cpus: 1,
+            memory_mib: 512,
+            env: Vec::new(),
+        }
+    }
+}
+
+/// Fluent builder for [`MachineSpec`]. Obtain one from [`MachineSpec::builder`].
+///
+/// `name` and `image` are required (supplied up front), so [`build`] is
+/// infallible; `cpus`/`memory_mib` default to 1 vCPU / 512 MiB and `env`
+/// accumulates across calls.
+///
+/// [`build`]: MachineSpecBuilder::build
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct MachineSpecBuilder {
+    name: String,
+    image: String,
+    cpus: u32,
+    memory_mib: u32,
+    env: Vec<(String, String)>,
+}
+
+impl MachineSpecBuilder {
+    /// Set the vCPU count (default 1).
+    #[must_use]
+    pub fn cpus(mut self, cpus: u32) -> Self {
+        self.cpus = cpus;
+        self
+    }
+
+    /// Set the guest memory in MiB (default 512).
+    #[must_use]
+    pub fn memory_mib(mut self, memory_mib: u32) -> Self {
+        self.memory_mib = memory_mib;
+        self
+    }
+
+    /// Append one environment variable. Repeatable.
+    #[must_use]
+    pub fn env(mut self, key: impl Into<String>, value: impl Into<String>) -> Self {
+        self.env.push((key.into(), value.into()));
+        self
+    }
+
+    /// Append many environment variables at once.
+    #[must_use]
+    pub fn envs(mut self, vars: impl IntoIterator<Item = (String, String)>) -> Self {
+        self.env.extend(vars);
+        self
+    }
+
+    /// Finish building. Infallible — `name` and `image` were required up front.
+    #[must_use]
+    pub fn build(self) -> MachineSpec {
+        MachineSpec {
+            name: self.name,
+            image: self.image,
+            cpus: self.cpus,
+            memory_mib: self.memory_mib,
+            env: self.env,
+        }
+    }
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
@@ -102,6 +188,56 @@ mod tests {
         let json = serde_json::to_string(&spec).unwrap();
         let back: MachineSpec = serde_json::from_str(&json).unwrap();
         assert_eq!(spec, back);
+    }
+
+    #[test]
+    fn builder_applies_defaults_and_overrides() {
+        let spec = MachineSpec::builder("web", "nginx").build();
+        assert_eq!(
+            spec,
+            MachineSpec {
+                name: "web".into(),
+                image: "nginx".into(),
+                cpus: 1,
+                memory_mib: 512,
+                env: vec![],
+            }
+        );
+
+        let spec = MachineSpec::builder("web", "nginx")
+            .cpus(4)
+            .memory_mib(1024)
+            .env("A", "1")
+            .envs([("B".to_string(), "2".to_string())])
+            .env("C", "3")
+            .build();
+        assert_eq!(spec.cpus, 4);
+        assert_eq!(spec.memory_mib, 1024);
+        assert_eq!(
+            spec.env,
+            vec![
+                ("A".into(), "1".into()),
+                ("B".into(), "2".into()),
+                ("C".into(), "3".into()),
+            ]
+        );
+    }
+
+    #[test]
+    fn builder_equals_struct_literal() {
+        let built = MachineSpec::builder("web", "docker.io/lib/nginx:1")
+            .cpus(2)
+            .memory_mib(512)
+            .env("PORT", "8080")
+            .build();
+        let literal = MachineSpec {
+            name: "web".into(),
+            image: "docker.io/lib/nginx:1".into(),
+            cpus: 2,
+            memory_mib: 512,
+            env: vec![("PORT".into(), "8080".into())],
+        };
+        assert_eq!(built, literal);
     }
 
     #[test]

--- a/examples/audit-probe/flake.nix
+++ b/examples/audit-probe/flake.nix
@@ -2,7 +2,7 @@
   description = "audit-probe — in-guest host.audit.v1 round-trip fixture.";
 
   # A sealed workload whose PID-1 command is the baked `audit-probe` binary.
-  # On an admitted `mvmctl up` (tenant defaults to `local`) the backend spawns
+  # On an admitted `mvmctl machine run` (tenant defaults to `local`) the backend spawns
   # the per-VM mvm-broker + mvm-audit-signer, the probe dials BROKER_PORT and
   # emits over `host.audit.v1`, and the entry lands in the per-VM workload
   # chain `~/.mvm/audit/<tenant>.<vm>.workload.jsonl` — verifiable with
@@ -10,7 +10,7 @@
   # bakes the binary; the production guest closure never carries it.
   #
   # The `github:tinylabscom/mvm` pin is load-bearing: a source-checkout
-  # `mvmctl up` rewrites it to the in-repo flake, so this builds without a
+  # `mvmctl machine run` rewrites it to the in-repo flake, so this builds without a
   # release round-trip.
 
   inputs.mvm.url = "github:tinylabscom/mvm/main?dir=nix";

--- a/examples/egress-probe/flake.nix
+++ b/examples/egress-probe/flake.nix
@@ -3,7 +3,7 @@
 
   # A sealed one-shot workload: PID-1 attempts two outbound TCP connections and
   # exits a verdict code encoding both results, captured over the control vsock
-  # and returned by `mvmctl up --wait`. Used to verify a libkrun workload guest
+  # and returned by `mvmctl machine run --flake .`. Used to verify a libkrun workload guest
   # actually gets network (the guest console is not host-readable, so the exit
   # code is the observable). Raw IPs (no DNS) keep the probe independent of name
   # resolution.
@@ -14,7 +14,7 @@
   #   3 = both blocked (deny-all, or — the bug this fixture caught — no network)
   #
   # The `github:tinylabscom/mvm` pin is load-bearing: a source-checkout
-  # `mvmctl up` rewrites it to the in-repo flake, so this builds without a
+  # `mvmctl machine run` rewrites it to the in-repo flake, so this builds without a
   # release round-trip.
 
   inputs.mvm.url = "github:tinylabscom/mvm/main?dir=nix";

--- a/examples/exit_code/flake.nix
+++ b/examples/exit_code/flake.nix
@@ -9,9 +9,9 @@
   #   3. Call mvm-exit-report "$MVM_CODE" over the control vsock port.
   #   4. Sync + poweroff -f.
   #
-  # The host (mvmctl up --wait) reads the reported code and exits with it.
+  # The host (mvmctl machine run --flake .) reads the reported code and exits with it.
   # This fixture bakes `sh -c 'exit 7'` as the sealed workload so a clean
-  # E2E run of `mvmctl up --flake ./examples/exit_code --wait` must exit 7.
+  # E2E run of `mvmctl machine run --flake ./examples/exit_code --wait` must exit 7.
   #
   # ── Canonical user-flake form (matches `mvmctl compile`'s output) ──
   #
@@ -19,7 +19,7 @@
   # (crates/mvm-sdk/src/compile/flake.rs): it declares `inputs.mvm`
   # pinned to GitHub, follows `mvm/nixpkgs`, and builds the image via
   # `mvm.lib.<system>.mkGuest`. The literal `github:tinylabscom/mvm`
-  # string is load-bearing: from a source checkout, `mvmctl up`'s
+  # string is load-bearing: from a source checkout, `mvmctl machine run`'s
   # source-checkout override mode (dev_build.rs `local_mvm_workspace`)
   # only triggers when the user flake pins `mvm` to GitHub — it then
   # rewrites it to the in-repo `path:/work/nix` via

--- a/examples/python/hello-app-with-deps/README.md
+++ b/examples/python/hello-app-with-deps/README.md
@@ -23,7 +23,7 @@ mount layout.
 ## Compile (no VM needed)
 
 ```sh
-mvmctl compile examples/python/hello-app-with-deps/app.py --out /tmp/hello-with-deps
+mvmctl build compile examples/python/hello-app-with-deps/app.py --out /tmp/hello-with-deps
 ls /tmp/hello-with-deps
 # flake.nix  launch.json  src/
 jq '.dependencies' /tmp/hello-with-deps/launch.json
@@ -39,9 +39,9 @@ jq '.dependencies' /tmp/hello-with-deps/launch.json
 ```sh
 mvmctl build examples/python/hello-app-with-deps/
 # … installs deps inside the builder VM, seals the volume …
-mvmctl up examples/python/hello-app-with-deps/ --prod
+mvmctl machine run examples/python/hello-app-with-deps/ --prod
 # claim 9 gate: the supervisor verifies the sealed volume before launching
-mvmctl invoke hello-app-with-deps --input name='ari'
+mvmctl machine run --flake examples/python/hello-app-with-deps/ --profile prod --entrypoint
 # expect: "hello ari"
 ```
 

--- a/examples/python/hello-app-with-deps/app.py
+++ b/examples/python/hello-app-with-deps/app.py
@@ -10,7 +10,7 @@ The lockfile pins `requests==2.32.3` — a recent release with hashes,
 known to scan clean under pip-audit at the time this example was added.
 The Followup D CI lane uses this example as the positive-path fixture.
 
-  - `mvmctl compile examples/python/hello-app-with-deps/app.py` walks
+  - `mvmctl build compile examples/python/hello-app-with-deps/app.py` walks
     the AST statically (no network, no VM) and emits flake.nix +
     launch.json + bundled src/.
   - `mvmctl build --deps examples/python/hello-app-with-deps/` would

--- a/examples/python/hello-app/README.md
+++ b/examples/python/hello-app/README.md
@@ -15,10 +15,8 @@ Demonstrates:
 ## Build, run, invoke
 
 ```sh
-mvmctl compile examples/python/hello-app/app.py --out /tmp/hello-app
-mvmctl build /tmp/hello-app
-mvmctl up hello-app
-mvmctl invoke hello-app --input name='ari'
+mvmctl build compile examples/python/hello-app/app.py --out /tmp/hello-app
+mvmctl machine run --flake /tmp/hello-app --entrypoint
 # expect: "hello ari"
 ```
 

--- a/examples/python/hello-app/app.py
+++ b/examples/python/hello-app/app.py
@@ -2,7 +2,7 @@
 
 Two routes from this file produce the same Workload IR:
 
-  - `mvmctl compile examples/python/hello-app/app.py` walks the AST
+  - `mvmctl build compile examples/python/hello-app/app.py` walks the AST
     statically and emits flake.nix + launch.json + bundled src/. The
     host never imports or executes this script.
 
@@ -11,8 +11,7 @@ Two routes from this file produce the same Workload IR:
     `mvm.emit_json()` to disk for the same IR. This route runs the
     script and is useful for IDE introspection.
 
-`mvmctl invoke hello-app --input name='ari'` (after a full build +
-boot cycle) dispatches `greet(name="ari")` over the function-entrypoint
+`mvmctl machine run --flake . --entrypoint` (after a build) dispatches `greet(name="ari")` over the function-entrypoint
 protocol and returns the encoded string.
 """
 

--- a/examples/python/secret-egress/README.md
+++ b/examples/python/secret-egress/README.md
@@ -22,7 +22,7 @@ Demonstrates:
 1. **Host stores it** — `mvmctl secret set echo-key --host httpbin.org
    --type bearer --value -` writes the encrypted value + its binding into
    `~/.mvm` (never the guest).
-2. **Boot** — `mvmctl up` spawns the per-VM substitution endpoint (the only
+2. **Boot** — `mvmctl machine run` spawns the per-VM substitution endpoint (the only
    process holding the value in the clear), which mints the placeholder.
 3. **Invoke** — the host injects `HTTP_PROXY` + the placeholder env var; the
    workload's request carries the placeholder; the endpoint substitutes the
@@ -41,14 +41,14 @@ printf '%s' "$REAL_KEY" | mvmctl secret set echo-key \
 Compile the app to local boot artifacts, then boot it on a `/dev/kvm` host:
 
 ```sh
-mvmctl compile examples/python/secret-egress/app.py --out /tmp/secret-egress
-mvmctl up --flake /tmp/secret-egress
+mvmctl build compile examples/python/secret-egress/app.py --out /tmp/secret-egress
+mvmctl machine run --flake /tmp/secret-egress
 ```
 
 `mvmctl compile` strips the managed `SecretRef` out of the baked image — the
 rootfs is secret-free by construction, the guest var is injected as an opaque
 placeholder only at boot — and writes the binding into `workload.json`, the
-admission input. `mvmctl up` auto-discovers `/tmp/secret-egress/workload.json`,
+admission input. `mvmctl machine run` auto-discovers `/tmp/secret-egress/workload.json`,
 lowers its `SecretRef` into a signed `ExecutionPlan.secrets`, and admits it —
 which is what spawns the per-VM substitution endpoint at boot. (Pass
 `--from-workload-ir <path>` to point elsewhere.) Deploying to a multi-tenant

--- a/examples/python/secret-egress/app.py
+++ b/examples/python/secret-egress/app.py
@@ -15,7 +15,7 @@ Set the secret on the host first (the value is piped, never on argv):
 Run it locally on a /dev/kvm host:
 
     mvmctl build compile examples/python/secret-egress/app.py --out /tmp/secret-egress
-    mvmctl up --flake /tmp/secret-egress
+    mvmctl machine run --flake /tmp/secret-egress
 
 `compile` strips the managed `SecretRef` out of the baked image (secret-free
 rootfs) and records it in `workload.json`; `up` lowers that into a signed

--- a/examples/sleeper/flake.nix
+++ b/examples/sleeper/flake.nix
@@ -5,7 +5,7 @@
   # VM stays resident long enough to checkpoint / fork / pause / resume and be
   # probed over the guest-agent vsock. The `command` form makes mkGuest infer
   # the sealed/prod image (agent built without the dev-shell console). The
-  # `github:tinylabscom/mvm` pin is load-bearing: a source-checkout `mvmctl up`
+  # `github:tinylabscom/mvm` pin is load-bearing: a source-checkout `mvmctl machine run`
   # rewrites it to the in-repo flake, so this builds without a release round-trip.
 
   inputs.mvm.url = "github:tinylabscom/mvm/main?dir=nix";

--- a/examples/typescript/hello-app-with-deps/README.md
+++ b/examples/typescript/hello-app-with-deps/README.md
@@ -22,7 +22,7 @@ rm -rf node_modules    # never committed — the build produces it
 ## Build, run, invoke
 
 ```sh
-mvmctl compile examples/typescript/hello-app-with-deps/app.ts --out /tmp/hello-ts-deps
-mvmctl up --flake /tmp/hello-ts-deps
+mvmctl build compile examples/typescript/hello-app-with-deps/app.ts --out /tmp/hello-ts-deps
+mvmctl machine run --flake /tmp/hello-ts-deps
 # invoke greet → uses is-number from the baked node_modules
 ```

--- a/examples/typescript/hello-app/README.md
+++ b/examples/typescript/hello-app/README.md
@@ -7,10 +7,8 @@ either source language.
 ## Build
 
 ```sh
-mvmctl compile examples/typescript/hello-app/app.ts --out /tmp/hello-app
-mvmctl build /tmp/hello-app
-mvmctl up hello-app
-mvmctl invoke hello-app --input name='ari'
+mvmctl build compile examples/typescript/hello-app/app.ts --out /tmp/hello-app
+mvmctl machine run --flake /tmp/hello-app --entrypoint
 ```
 
 The decorator + bootscript hook behavior is identical to the Python

--- a/examples/typescript/hello-app/app.ts
+++ b/examples/typescript/hello-app/app.ts
@@ -1,7 +1,7 @@
 /**
  * Minimal `mvm.app({...})(fn)` example — port-plan Phase 8 follow-up.
  *
- * `mvmctl compile examples/typescript/hello-app/app.ts` walks this
+ * `mvmctl build compile examples/typescript/hello-app/app.ts` walks this
  * file's AST statically and emits the same Workload IR a `node app.ts`
  * (with `mvm.emitJson()`) would. The host never executes the script —
  * the decorator is read, not run.

--- a/public/src/content/docs/getting-started/rust-quickstart.md
+++ b/public/src/content/docs/getting-started/rust-quickstart.md
@@ -3,9 +3,11 @@ title: Rust quickstart
 description: Declare mvm workloads from Rust and emit Workload IR.
 ---
 
-The Rust SDK is the lower-level authoring surface and the ground-truth type model for Workload IR.
+Rust has both an authoring surface (`mvm-sdk`, the ground-truth type model for
+Workload IR) and a runtime surface (`mvm-client`, the `MvmClient` lifecycle
+facade shared with the CLI and the fleet orchestrator).
 
-> **Status:** `crates/mvm-sdk` ships build-time workload builders and the runtime recording/lowering contract. A high-level Rust runtime lifecycle client is future parity work.
+> **Status:** `crates/mvm-sdk` ships build-time workload builders and the runtime recording/lowering contract; `crates/mvm-client` ships the `MvmClient` runtime facade (`LocalBackend` in-process, `GatewayBackend` over REST).
 
 ## Build-time declaration
 
@@ -30,6 +32,32 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
 ```
 
 Pipe the generated IR into the normal compile/build path used by the CLI.
+
+## Runtime lifecycle
+
+Drive machines from Rust with the `MvmClient` facade. `MachineSpec::builder`
+gives a fluent, forward-compatible way to describe what to run:
+
+```rust
+use mvm_client::{MvmClient, MachineSpec};
+use mvm_client_local::LocalBackend;
+
+// inside an async context:
+let client = LocalBackend::new();
+
+let spec = MachineSpec::builder("web", "nginx")
+    .cpus(2)
+    .memory_mib(512)
+    .env("PORT", "8080")
+    .build();
+
+let machine = client.run_machine(spec).await?;
+println!("started {}", machine.name);
+client.stop_machine(&machine.id).await?;
+```
+
+See the [Rust SDK reference](/sdk/rust/) for the authoring and runtime surfaces
+side by side.
 
 ## When to use Rust
 

--- a/public/src/content/docs/sdk/rust.md
+++ b/public/src/content/docs/sdk/rust.md
@@ -3,7 +3,15 @@ title: Rust SDK
 description: Rust build-time SDK and Workload IR contract.
 ---
 
-The Rust SDK is the typed authoring and lowering surface for `mvm`.
+Rust has two SDK surfaces:
+
+- **Authoring** — `mvm-sdk`: build Workload IR (the same IR the Python/TypeScript
+  decorators emit).
+- **Runtime** — `mvm-client`: the `MvmClient` facade for driving machines
+  (create/run/exec/stop/reconfigure), shared with the CLI, the GUI, and the
+  fleet orchestrator.
+
+## Authoring — build Workload IR (`mvm-sdk`)
 
 Current:
 
@@ -12,13 +20,6 @@ Current:
 - Workload IR emission;
 - static decorator parsing support in `mvm-sdk`;
 - runtime recording types and lowering.
-
-Planned:
-
-- high-level local runtime lifecycle client;
-- shared fixture parity with Python and TypeScript runtime clients.
-
-## Example
 
 ```rust
 use mvm_sdk::*;
@@ -37,3 +38,38 @@ emit(&workload)?;
 ```
 
 Rust is the right layer for tools that generate or validate Workload IR directly.
+
+## Runtime — drive machines (`mvm-client`)
+
+The `MvmClient` trait is the runtime SDK: a `LocalBackend` drives the host
+in-process, and a `GatewayBackend` (feature `remote`) drives a remote fleet over
+REST. Both speak the same `MachineSpec` intent type.
+
+Build a `MachineSpec` fluently with `MachineSpec::builder(name, image)` — the two
+required fields are supplied up front, so `build()` is infallible; `cpus`
+(default 1), `memory_mib` (default 512), and `env` (accumulates) are optional:
+
+```rust
+use mvm_client::{MvmClient, MachineSpec};
+use mvm_client_local::LocalBackend;
+
+// inside an async context:
+let client = LocalBackend::new();
+
+let spec = MachineSpec::builder("web", "nginx")
+    .cpus(2)
+    .memory_mib(512)
+    .env("PORT", "8080")
+    .build();
+
+let machine = client.run_machine(spec).await?;
+let out = client
+    .exec_machine(&machine.id, vec!["nginx".into(), "-v".into()])
+    .await?;
+println!("{}", String::from_utf8_lossy(&out.stderr));
+client.stop_machine(&machine.id).await?;
+```
+
+The builder is equivalent to a struct literal — every field stays public — but
+reads far better at call sites and lets new optional fields land without churning
+existing callers.


### PR DESCRIPTION
Fix doc test import in MachineSpec - was using mvm_client::MachineSpec which does not work because mvm-core can not depend on mvm-client. Changed to super::MachineSpec.