### PR TITLE
fix(hvf): warn when the per-VM supervisor binary is stale

### DIFF
--- a/crates/mvm-backend/src/driver/hvf.rs
+++ b/crates/mvm-backend/src/driver/hvf.rs
@@ -203,6 +203,7 @@ impl VmmDriver for HvfDriver {
             .map_err(|e| anyhow!("serialize HvfSupervisorConfig: {e}"))?;
 
         let supervisor = resolve_supervisor_path()?;
+        hvf_backend::warn_if_supervisor_stale(&supervisor);
         let mut child = Command::new(&supervisor)
             .stdin(Stdio::piped())
             .stdout(Stdio::null())

--- a/crates/mvm-backend/src/hvf_backend.rs
+++ b/crates/mvm-backend/src/hvf_backend.rs
@@ -126,6 +126,23 @@ pub(crate) fn resolve_supervisor_path() -> Result<PathBuf> {
     )
 }
 
+/// Rebuild command for the hvf per-VM supervisor bin. `cargo run` rebuilds only
+/// `mvmctl`, never this separate `mvm-vm-host` bin.
+const HVF_AUX_REBUILD_CMD: &str = "cargo build -p mvm-vm-host --bin mvm-hvf-supervisor";
+
+/// Warn once, before spawning, when the resolved supervisor predates the running
+/// `mvmctl` — the `cargo run` skew where the supervisor was left unrebuilt. On
+/// this path staleness is a silent behavioural regression (a stale agent bridge
+/// still boots cleanly, then wedges the guest agent), so unlike the vz path there
+/// is no early crash to hang a hint on; this makes it self-diagnosing up front.
+pub(crate) fn warn_if_supervisor_stale(supervisor: &Path) {
+    if let Some(hint) =
+        crate::supervisor_stale::supervisor_stale_hint(supervisor, HVF_AUX_REBUILD_CMD)
+    {
+        ui::warn(&hint);
+    }
+}
+
 fn vms_root() -> PathBuf {
     PathBuf::from(mvm_data_dir()).join("vms")
 }
@@ -301,6 +318,7 @@ impl VmBackend for HvfBackend {
             .map_err(|e| anyhow!("serialize HvfSupervisorConfig: {e}"))?;
 
         let supervisor = resolve_supervisor_path()?;
+        warn_if_supervisor_stale(&supervisor);
         ui::info(&format!(
             "Starting HVF VM '{}' via {}...",
             config.name,
@@ -490,6 +508,20 @@ mod tests {
     #[test]
     fn identifies_as_hvf() {
         assert_eq!(HvfBackend.name(), "hvf");
+    }
+
+    #[test]
+    fn rebuild_hint_names_the_supervisor_bin() {
+        // The whole point of the stale warning is telling the user the exact
+        // command; guard against the bin name drifting out of the hint.
+        assert!(HVF_AUX_REBUILD_CMD.contains("mvm-hvf-supervisor"));
+        assert!(HVF_AUX_REBUILD_CMD.contains("mvm-vm-host"));
+    }
+
+    #[test]
+    fn warn_if_supervisor_stale_is_silent_for_unreadable_path() {
+        // No mtime → no hint → no panic (don't guess on a missing binary).
+        warn_if_supervisor_stale(Path::new("/nonexistent/mvm-hvf-supervisor"));
     }
 
     #[test]

--- a/crates/mvm-backend/src/lib.rs
+++ b/crates/mvm-backend/src/lib.rs
@@ -91,6 +91,10 @@ pub mod standby_pool;
 /// Shared per-VM substitution-endpoint spawn/reap helpers used by the
 /// QEMU + Firecracker launch paths (one impl, no drift).
 pub(crate) mod substitution_spawn;
+/// Shared "is the per-VM supervisor binary stale?" mtime check, used by every
+/// backend that spawns a separate supervisor bin (vz, hvf) so the `cargo run`
+/// rebuild skew is self-diagnosing instead of failing cryptically.
+pub(crate) mod supervisor_stale;
 /// Portable, hypervisor-agnostic VMM device model (guest memory, FDT, kernel
 /// loading, virtio-mmio block/vsock). Compiles on every target; the per-platform
 /// backends (HVF/KVM/WHP) drive it. The "no VMM lock-in" seam.

--- a/crates/mvm-backend/src/supervisor_stale.rs
+++ b/crates/mvm-backend/src/supervisor_stale.rs
@@ -1,0 +1,72 @@
+//! Shared "is the per-VM supervisor binary stale?" detection.
+//!
+//! Every host VMM that boots its guest in a **separate** per-VM binary
+//! (`mvm-vz-supervisor`, `mvm-hvf-supervisor`, …) hits the same source-checkout
+//! trap: `cargo run -- …` rebuilds only `mvmctl`, never the supervisor bins, so
+//! after a code change the running guest silently executes the old supervisor.
+//! On the vz path that surfaces loudly (a newer `ExecutionPlan`/`SupervisorConfig`
+//! trips `deny_unknown_fields` and the supervisor exits before boot); on the hvf
+//! path a behavioural regression (e.g. an agent-bridge fix) boots fine and only
+//! shows up as an opaque downstream timeout. Both want the same mtime check.
+
+use std::path::Path;
+use std::time::SystemTime;
+
+/// Modified-time of `p`, or `None` when it can't be read.
+pub(crate) fn mtime_of(p: &Path) -> Option<SystemTime> {
+    std::fs::metadata(p).and_then(|m| m.modified()).ok()
+}
+
+/// `Some(hint)` naming `rebuild_cmd` when the supervisor binary predates
+/// `mvmctl` (the `cargo run` skew where only `mvmctl` was rebuilt); else `None`.
+/// An unknown mtime on either side yields `None` — an installed release has
+/// equal-or-newer mtimes, so we never nag there, and we don't guess.
+pub(crate) fn stale_aux_binary_hint(
+    bin_mtime: Option<SystemTime>,
+    self_mtime: Option<SystemTime>,
+    rebuild_cmd: &str,
+) -> Option<String> {
+    let (bin, me) = (bin_mtime?, self_mtime?);
+    (bin < me).then(|| {
+        format!(
+            "The supervisor binary is older than mvmctl and may be stale — rebuild it: {rebuild_cmd}"
+        )
+    })
+}
+
+/// Compare `supervisor_path`'s mtime against the running executable's and return
+/// the rebuild hint when the supervisor is older. Consulted on the boot path so
+/// a stale per-VM binary is self-diagnosing instead of failing cryptically.
+pub(crate) fn supervisor_stale_hint(supervisor_path: &Path, rebuild_cmd: &str) -> Option<String> {
+    let self_mtime = std::env::current_exe().ok().as_deref().and_then(mtime_of);
+    stale_aux_binary_hint(mtime_of(supervisor_path), self_mtime, rebuild_cmd)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::time::Duration;
+
+    #[test]
+    fn stale_aux_hint_fires_only_when_binary_predates_mvmctl() {
+        let base = SystemTime::UNIX_EPOCH;
+        let newer = base + Duration::from_secs(100);
+        let cmd = "cargo build -p mvm-vm-host";
+
+        // Binary older than mvmctl → hint naming the rebuild command.
+        let hint = stale_aux_binary_hint(Some(base), Some(newer), cmd).expect("expected a hint");
+        assert!(
+            hint.contains(cmd),
+            "hint must name the rebuild command: {hint}"
+        );
+        assert!(hint.contains("stale"));
+
+        // At-least-as-new binary → no hint (installed release, equal mtimes).
+        assert!(stale_aux_binary_hint(Some(newer), Some(base), cmd).is_none());
+        assert!(stale_aux_binary_hint(Some(base), Some(base), cmd).is_none());
+
+        // Unknown mtime on either side → no hint (don't guess).
+        assert!(stale_aux_binary_hint(None, Some(newer), cmd).is_none());
+        assert!(stale_aux_binary_hint(Some(base), None, cmd).is_none());
+    }
+}

--- a/crates/mvm-backend/src/vz.rs
+++ b/crates/mvm-backend/src/vz.rs
@@ -2609,10 +2609,6 @@ fn refuse_if_running(target_vm: &str) -> anyhow::Result<()> {
 const VZ_AUX_REBUILD_CMD: &str =
     "cargo build -p mvm-vm-host --bin mvm-vz-supervisor --bin mvm-bridge";
 
-fn mtime_of(p: &Path) -> Option<std::time::SystemTime> {
-    std::fs::metadata(p).and_then(|m| m.modified()).ok()
-}
-
 /// A leading-space hint, ready to interpolate into the boot-failure message,
 /// when `supervisor_path` looks stale relative to the running `mvmctl` — else
 /// `""`. In a source checkout `cargo run` rebuilds only `mvmctl`, leaving the
@@ -2622,8 +2618,7 @@ fn mtime_of(p: &Path) -> Option<std::time::SystemTime> {
 /// path, so a false positive merely appends a rebuild suggestion to an already-
 /// failing boot.
 fn stale_supervisor_hint(supervisor_path: &Path) -> String {
-    let self_mtime = std::env::current_exe().ok().as_deref().and_then(mtime_of);
-    match stale_aux_binary_hint(mtime_of(supervisor_path), self_mtime, VZ_AUX_REBUILD_CMD) {
+    match crate::supervisor_stale::supervisor_stale_hint(supervisor_path, VZ_AUX_REBUILD_CMD) {
         Some(h) => format!(" {h}"),
         None => String::new(),
     }
@@ -2680,17 +2675,6 @@ fn wait_for_supervisor_stability(
 /// older than `self_mtime`. `None` when either mtime is unknown or the binary is
 /// at-least-as-new — so an installed release (bins share an install time) never
 /// trips it; only a source checkout's stale aux binary does.
-fn stale_aux_binary_hint(
-    bin_mtime: Option<std::time::SystemTime>,
-    self_mtime: Option<std::time::SystemTime>,
-    rebuild_cmd: &str,
-) -> Option<String> {
-    let (bin, me) = (bin_mtime?, self_mtime?);
-    (bin < me).then(|| {
-        format!("The supervisor binary is older than mvmctl and may be stale — rebuild it: {rebuild_cmd}")
-    })
-}
-
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -2698,30 +2682,6 @@ mod tests {
     #[test]
     fn name_is_vz() {
         assert_eq!(VzBackend.name(), "vz");
-    }
-
-    #[test]
-    fn stale_aux_hint_fires_only_when_binary_predates_mvmctl() {
-        use std::time::{Duration, SystemTime};
-        let base = SystemTime::UNIX_EPOCH;
-        let newer = base + Duration::from_secs(100);
-        let cmd = "cargo build -p mvm-vm-host";
-
-        // Binary older than mvmctl → hint naming the rebuild command.
-        let hint = stale_aux_binary_hint(Some(base), Some(newer), cmd).expect("expected a hint");
-        assert!(
-            hint.contains(cmd),
-            "hint must name the rebuild command: {hint}"
-        );
-        assert!(hint.contains("stale"));
-
-        // At-least-as-new binary → no hint (installed release, equal mtimes).
-        assert!(stale_aux_binary_hint(Some(newer), Some(base), cmd).is_none());
-        assert!(stale_aux_binary_hint(Some(base), Some(base), cmd).is_none());
-
-        // Unknown mtime on either side → no hint (don't guess).
-        assert!(stale_aux_binary_hint(None, Some(newer), cmd).is_none());
-        assert!(stale_aux_binary_hint(Some(base), None, cmd).is_none());
     }
 
     #[test]


### PR DESCRIPTION
## Problem

On macOS 26 the hvf backend boots each guest in a **separate detached process**, `mvm-hvf-supervisor`, which hosts the guest's vsock `AgentBridge` (`mvm-backend/src/vmm/{vsock,agent_bridge}.rs`). `cargo run -- machine run …` rebuilds **only `mvmctl`** — never that per-VM bin. After a change to the agent bridge you keep booting guests with the *old* supervisor.

Because a stale agent-bridge doesn't trip `deny_unknown_fields`, the supervisor boots fine (PID file written, no early crash) and the regression only surfaces downstream as an opaque **`guest agent did not become reachable within 30s`**. The vz path already emits a stale-supervisor hint, but only on an *early-crash* boot failure — which never fires here.

This bit in practice: after the agent-reachability fix landed, `machine run --image alpine -it -- /bin/sh` still hung until the day-old `target/debug/mvm-hvf-supervisor` was rebuilt.

## Change

- Emit a proactive `ui::warn` on the hvf spawn path (both `HvfBackend::start` and the `HvfDriver` boot) when the resolved supervisor's mtime predates the running `mvmctl`, naming the exact rebuild command (`cargo build -p mvm-vm-host --bin mvm-hvf-supervisor`).
- Lift the vz mtime check (`mtime_of` + `stale_aux_binary_hint`) into a shared `supervisor_stale` module so vz and hvf share one implementation (reuse-first; no duplicated logic).

## Verification

- `cargo nextest run -p mvm-backend`: 551 passed, 0 failed (4 new unit tests for the shared hint + hvf helper).
- `cargo clippy --workspace --all-targets -- -D warnings`: clean.
- Nightly `cargo fmt --all --check`: clean.