### PR TITLE
Fix OCI image PTY run without dev VM

### DIFF
--- a/crates/mvm-backend/src/hvf_backend.rs
+++ b/crates/mvm-backend/src/hvf_backend.rs
@@ -57,24 +57,45 @@ pub(crate) fn pid_alive(pid: libc::pid_t) -> bool {
     unsafe { libc::kill(pid, 0) == 0 }
 }
 
-/// SIGTERM a recorded pid, then SIGKILL if it lingers past a short grace. The
-/// supervisor installs no SIGTERM handler, so the default action terminates it
-/// and the HVF VM dies with it. Shared by the `VmBackend` stop path and the
-/// hvf driver's `kill`.
+fn reap_child_if_exited(pid: libc::pid_t) -> bool {
+    let mut status = 0;
+    // SAFETY: `waitpid` with WNOHANG only reaps this process's child if it has
+    // exited; for non-child PIDs it returns ECHILD and leaves the liveness check
+    // to `kill(pid, 0)`.
+    unsafe { libc::waitpid(pid, &mut status, libc::WNOHANG) == pid }
+}
+
+fn wait_for_pid_exit(pid: libc::pid_t, timeout: Duration) -> bool {
+    let deadline = Instant::now() + timeout;
+    loop {
+        if reap_child_if_exited(pid) || !pid_alive(pid) {
+            return true;
+        }
+        if Instant::now() >= deadline {
+            return false;
+        }
+        std::thread::sleep(Duration::from_millis(50));
+    }
+}
+
+/// SIGTERM a recorded pid, then SIGKILL if it lingers past a short grace. When
+/// the supervisor is still this process's child, reap it with `waitpid` so an
+/// already-exited zombie does not look alive for the full grace window.
+/// Shared by the `VmBackend` stop path and the hvf driver's `kill`.
 pub(crate) fn terminate_pid(pid: libc::pid_t) {
     // SAFETY: signalling a pid we recorded from our own supervisor.
     unsafe {
         libc::kill(pid, libc::SIGTERM);
     }
-    let deadline = Instant::now() + Duration::from_secs(5);
-    while pid_alive(pid) && Instant::now() < deadline {
-        std::thread::sleep(Duration::from_millis(50));
+    if wait_for_pid_exit(pid, Duration::from_secs(5)) {
+        return;
     }
     if pid_alive(pid) {
         // SAFETY: same pid.
         unsafe {
             libc::kill(pid, libc::SIGKILL);
         }
+        let _ = wait_for_pid_exit(pid, Duration::from_millis(500));
     }
 }
 
@@ -513,6 +534,29 @@ mod tests {
         let id = VmId("hvf-nonexistent-test-vm".into());
         assert_eq!(HvfBackend.status(&id).unwrap(), VmStatus::Stopped);
         assert!(HvfBackend.stop(&id).is_ok());
+    }
+
+    #[test]
+    fn terminate_pid_reaps_child_without_grace_timeout() {
+        let mut child = std::process::Command::new("sleep")
+            .arg("30")
+            .stdin(std::process::Stdio::null())
+            .stdout(std::process::Stdio::null())
+            .stderr(std::process::Stdio::null())
+            .spawn()
+            .unwrap();
+        let pid = child.id() as libc::pid_t;
+
+        let started = Instant::now();
+        terminate_pid(pid);
+        let elapsed = started.elapsed();
+
+        let _ = child.wait();
+        assert!(
+            elapsed < Duration::from_secs(2),
+            "terminate_pid took {elapsed:?}, expected it to reap the child before the grace timeout"
+        );
+        assert!(!pid_alive(pid));
     }
 
     #[test]

--- a/crates/mvm-backend/src/hvf_backend.rs
+++ b/crates/mvm-backend/src/hvf_backend.rs
@@ -20,7 +20,7 @@ use std::process::{Command, Stdio};
 use std::time::{Duration, Instant};
 
 use anyhow::{Context, Result, anyhow, bail};
-use mvm_build::hvf_supervisor::{HvfDisk, HvfSupervisorConfig};
+use mvm_build::hvf_supervisor::{ConsoleDataSocket, HvfDisk, HvfSupervisorConfig};
 use mvm_core::config::{mvm_data_dir, vm_state_dir};
 use mvm_core::vm_backend::{
     VmBackend, VmCapabilities, VmExitStatus, VmId, VmInfo, VmStartConfig, VmStatus,
@@ -37,6 +37,16 @@ pub(crate) const PID_FILE_TIMEOUT: Duration = Duration::from_secs(5);
 
 /// Raw HVF (`Hypervisor.framework`) backend. macOS / Apple-silicon only.
 pub struct HvfBackend;
+
+fn hvf_console_data_sockets(state_dir: &Path, dev_console: bool) -> Vec<ConsoleDataSocket> {
+    crate::workload_runner::spec_map::console_data_sockets(state_dir, dev_console)
+        .into_iter()
+        .map(|(guest_port, host_socket)| ConsoleDataSocket {
+            guest_port,
+            host_socket,
+        })
+        .collect()
+}
 
 pub(crate) fn read_pid(path: &Path) -> Option<libc::pid_t> {
     std::fs::read_to_string(path).ok()?.trim().parse().ok()
@@ -264,7 +274,7 @@ impl VmBackend for HvfBackend {
             agent_socket: Some(agent_socket),
             substitution_socket: None,
             egress_relay_socket,
-            console_data_sockets: vec![],
+            console_data_sockets: hvf_console_data_sockets(&state_dir, config.dev_console),
         };
         let json = serde_json::to_string(&cfg)
             .map_err(|e| anyhow!("serialize HvfSupervisorConfig: {e}"))?;
@@ -468,6 +478,27 @@ mod tests {
         assert!(!c.pause_resume);
         assert!(!c.snapshots);
         assert!(!c.tap_networking);
+    }
+
+    #[test]
+    fn console_data_sockets_empty_when_dev_console_disabled() {
+        let sockets = hvf_console_data_sockets(Path::new("/state/hvf"), false);
+        assert!(sockets.is_empty());
+    }
+
+    #[test]
+    fn console_data_sockets_populated_when_dev_console_enabled() {
+        let sockets = hvf_console_data_sockets(Path::new("/state/hvf"), true);
+        assert_eq!(
+            sockets.len(),
+            mvm_guest::vsock::DEV_CONSOLE_DATA_PORT_COUNT as usize
+        );
+        let first = sockets.first().expect("first console socket");
+        assert_eq!(first.guest_port, mvm_guest::vsock::CONSOLE_PORT_BASE + 1);
+        assert_eq!(
+            first.host_socket,
+            PathBuf::from("/state/hvf/vsock/vsock-20001.sock")
+        );
     }
 
     #[test]

--- a/crates/mvm-backend/src/microvm.rs
+++ b/crates/mvm-backend/src/microvm.rs
@@ -2186,34 +2186,34 @@ pub fn create_dev_secrets_drive(abs_dir: &str, secret_files: &[DriveFile]) -> Re
     Ok(path)
 }
 
-/// Probe the directory containing `rootfs_path` (inside the Lima VM)
-/// for the dm-verity sidecar files emitted by mkGuest when
-/// `verifiedBoot = true`. Returns `(Some(verity_path), Some(roothash))`
-/// when both files are present and the roothash decodes to a 64-char
-/// hex string; otherwise `(None, None)` so callers fall back to the
-/// unverified-boot path.
+/// Probe the host-visible directory containing `rootfs_path` for the dm-verity
+/// sidecar files emitted by mkGuest when `verifiedBoot = true`. Returns
+/// `(Some(verity_path), Some(roothash))` when both files are present and the
+/// roothash decodes to a 64-char hex string; otherwise `(None, None)` so
+/// callers fall back to the unverified-boot path.
 pub fn probe_verity_sidecar(rootfs_path: &str) -> (Option<String>, Option<String>) {
-    use crate::base::shell::{run_in_vm, run_in_vm_stdout};
     use std::path::Path;
 
-    let Some(parent) = Path::new(rootfs_path).parent() else {
+    let Some(parent) = Path::new(rootfs_path)
+        .parent()
+        .filter(|p| !p.as_os_str().is_empty())
+    else {
         return (None, None);
     };
-    let parent = parent.to_string_lossy();
-    let verity = format!("{parent}/rootfs.verity");
-    let roothash_file = format!("{parent}/rootfs.roothash");
+    let verity = parent.join("rootfs.verity");
+    let roothash_file = parent.join("rootfs.roothash");
 
-    if run_in_vm(&format!("[ -f {verity} ]")).is_err() {
+    if !verity.is_file() {
         return (None, None);
     }
-    let Ok(raw) = run_in_vm_stdout(&format!("cat {roothash_file}")) else {
+    let Ok(raw) = std::fs::read_to_string(&roothash_file) else {
         return (None, None);
     };
     let hash = raw.trim().to_string();
     if hash.len() != 64 || !hash.chars().all(|c| c.is_ascii_hexdigit()) {
         return (None, None);
     }
-    (Some(verity), Some(hash))
+    (Some(verity.to_string_lossy().into_owned()), Some(hash))
 }
 
 /// Build the cmdline fragment consumed by `mvm-verity-init`
@@ -3926,20 +3926,63 @@ mod tests {
 
     // ──── Verity ──────────────────────────────────────────────────────
     //
-    // The host-side cmdline shape and DM-table construction now live
-    // in `mvm-verity-init` (initramfs PID 1) — those are exercised by
-    // the live boot regression in `specs/runbooks/w3-verified-boot.md`.
-    // The unit test below covers the only host-side helper still
-    // running on the cold-boot path: the sidecar path probe.
+    // The host-side cmdline shape and DM-table construction now live in
+    // `mvm-verity-init` (initramfs PID 1). The unit tests below cover the
+    // host-side helper still running on the cold-boot path: the sidecar probe.
 
     #[test]
     fn probe_verity_sidecar_returns_none_for_path_without_parent() {
-        // A bare relative path with no parent triggers the early-return
-        // branch — should not shell out, should not panic.
         let (v, h) = probe_verity_sidecar("rootfs.ext4");
-        // Either the parent is "" and the probe falls through to a
-        // shell call that fails, or we return early. Both produce
-        // (None, None); the assertion catches either way.
+        assert!(v.is_none());
+        assert!(h.is_none());
+    }
+
+    #[test]
+    fn probe_verity_sidecar_reads_valid_host_sidecars() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let rootfs = dir.path().join("rootfs.ext4");
+        let verity = dir.path().join("rootfs.verity");
+        std::fs::write(&rootfs, b"rootfs").expect("write rootfs");
+        std::fs::write(&verity, b"verity").expect("write verity");
+        std::fs::write(
+            dir.path().join("rootfs.roothash"),
+            format!("{ROOTFS_HASH}\n"),
+        )
+        .expect("write roothash");
+
+        let (v, h) = probe_verity_sidecar(&rootfs.to_string_lossy());
+
+        assert_eq!(v.as_deref(), Some(verity.to_string_lossy().as_ref()));
+        assert_eq!(h.as_deref(), Some(ROOTFS_HASH));
+    }
+
+    #[test]
+    fn probe_verity_sidecar_returns_none_when_sidecar_missing() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let rootfs = dir.path().join("rootfs.ext4");
+        std::fs::write(&rootfs, b"rootfs").expect("write rootfs");
+        std::fs::write(
+            dir.path().join("rootfs.roothash"),
+            format!("{ROOTFS_HASH}\n"),
+        )
+        .expect("write roothash");
+
+        let (v, h) = probe_verity_sidecar(&rootfs.to_string_lossy());
+
+        assert!(v.is_none());
+        assert!(h.is_none());
+    }
+
+    #[test]
+    fn probe_verity_sidecar_returns_none_for_malformed_roothash() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let rootfs = dir.path().join("rootfs.ext4");
+        std::fs::write(&rootfs, b"rootfs").expect("write rootfs");
+        std::fs::write(dir.path().join("rootfs.verity"), b"verity").expect("write verity");
+        std::fs::write(dir.path().join("rootfs.roothash"), b"abc\n").expect("write roothash");
+
+        let (v, h) = probe_verity_sidecar(&rootfs.to_string_lossy());
+
         assert!(v.is_none());
         assert!(h.is_none());
     }

--- a/crates/mvm-backend/src/vmm/console_bridge.rs
+++ b/crates/mvm-backend/src/vmm/console_bridge.rs
@@ -87,6 +87,15 @@ impl ConsoleBridge {
         ports: impl IntoIterator<Item = (u32, &'a Path)>,
     ) -> std::io::Result<()> {
         for (guest_port, path) in ports {
+            if let Some(parent) = path.parent()
+                && let Err(e) = std::fs::create_dir_all(parent)
+            {
+                dbg_log(&format!(
+                    "console port {guest_port} parent create failed at {}: {e}",
+                    parent.display()
+                ));
+                continue;
+            }
             let _ = std::fs::remove_file(path);
             match UnixListener::bind(path) {
                 Ok(l) => {
@@ -344,6 +353,17 @@ mod tests {
         }
         ports.sort_unstable();
         assert_eq!(ports, vec![20001, 20002]);
+    }
+
+    #[test]
+    fn bind_ports_creates_missing_parent_dir() {
+        let dir = tempfile::tempdir().unwrap();
+        let sock = dir.path().join("vsock").join("vsock-20001.sock");
+        let mut bridge = ConsoleBridge::new();
+
+        bridge.bind_ports([(20001u32, sock.as_path())]).unwrap();
+
+        UnixStream::connect(&sock).expect("listener should be bound under created parent dir");
     }
 
     /// Claim 15: an empty console-port list (sealed prod) binds no listeners, so

--- a/crates/mvm-cli/src/commands/cmd_audit.rs
+++ b/crates/mvm-cli/src/commands/cmd_audit.rs
@@ -171,13 +171,20 @@ impl Commands {
         if let Commands::Ls(a) = self {
             return a.touches_vm_state();
         }
-        // `machine <sub>` — start/stop/run all touch running-VM lifecycle state.
+        // `machine <sub>` — named/persistent lifecycle commands touch
+        // running-VM state. Unnamed foreground `machine run` is throwaway
+        // cattle: running global convergence before it can auto-resume
+        // unrelated machines and turn a plain OCI launch into a hidden
+        // builder/dev-VM boot.
         // For the advanced VmCmd variants folded under `machine`, delegate to
         // VmCmd's own touches_vm_state (pause/resume/snapshot/save/restore
         // converge; registry-record and guest-RPC ops opt out).
         if let Commands::Machine(a) = self {
             if let machine::MachineAction::Vm(ref cmd) = a.action {
                 return cmd.touches_vm_state();
+            }
+            if let machine::MachineAction::Run(ref run) = a.action {
+                return machine_run_touches_vm_state(run);
             }
             return true;
         }
@@ -234,6 +241,10 @@ impl Commands {
             Commands::SshAgentProxy(_) => "__ssh-agent-proxy",
         }
     }
+}
+
+fn machine_run_touches_vm_state(run: &machine::MachineRunArgs) -> bool {
+    run.name.is_some() || run.detach || run.up_json || run.ttl.is_some() || run.attach
 }
 
 #[cfg(test)]

--- a/crates/mvm-cli/src/commands/pool.rs
+++ b/crates/mvm-cli/src/commands/pool.rs
@@ -295,12 +295,13 @@ fn compat_for_launch(
 /// shaped, not bridge-admitted, or any error → `None` (the caller cold-boots as normal).
 ///
 /// Eligibility (all required): `warm_pool_size > 0`, the launch is auto-named (no explicit
-/// `--name` — a claimed VM is named by its standby-id), no extra volumes (the attach
-/// threads only the rootfs), the backend supports the pool, and the admitted tenant is
-/// threaded into the config. libkrun/Vz additionally require the signed plan JSON because
-/// their claimed standby enters the gateway-bridge supervisor path; Firecracker can claim
-/// with only the resolved launch config because the default path enforces networking
-/// directly via TAP/nftables and only needs plan JSON when its optional bridge is enabled.
+/// `--name` — a claimed VM is named by its standby-id), no extra volumes or virtio-fs
+/// root (the attach threads only the rootfs), the backend supports the pool, and the
+/// admitted tenant is threaded into the config. libkrun/Vz additionally require the signed
+/// plan JSON because their claimed standby enters the gateway-bridge supervisor path;
+/// Firecracker can claim with only the resolved launch config because the default path
+/// enforces networking directly via TAP/nftables and only needs plan JSON when its optional
+/// bridge is enabled.
 pub fn try_warm_claim(
     backend: &AnyBackend,
     cfg: &VmStartConfig,
@@ -310,6 +311,7 @@ pub fn try_warm_claim(
     if cfg.warm_pool_size == 0
         || user_named
         || !cfg.volumes.is_empty()
+        || cfg.virtiofs_root.is_some()
         || !backend.supports_standby_pool()
     {
         return Ok(None);
@@ -398,8 +400,12 @@ fn should_replenish_inline(
     backend_kind: BackendKind,
     supports_standby_pool: bool,
     warm_pool_size: u32,
+    has_virtiofs_root: bool,
 ) -> bool {
-    warm_pool_size > 0 && supports_standby_pool && backend_kind != BackendKind::Vz
+    warm_pool_size > 0
+        && supports_standby_pool
+        && backend_kind != BackendKind::Vz
+        && !has_virtiofs_root
 }
 
 /// Top the pool back up toward `cfg.warm_pool_size` after a launch (the no-daemon
@@ -419,6 +425,7 @@ pub fn replenish_after_launch(backend: &AnyBackend, cfg: &VmStartConfig) -> Resu
         backend.kind(),
         backend.supports_standby_pool(),
         cfg.warm_pool_size,
+        cfg.virtiofs_root.is_some(),
     ) {
         return Ok(0);
     }
@@ -516,6 +523,14 @@ mod tests {
     }
 
     #[test]
+    fn try_warm_claim_cold_with_virtiofs_root() {
+        let b = AnyBackend::from_hypervisor("libkrun");
+        let mut c = eligible_cfg();
+        c.virtiofs_root = Some("/unpacked/root".into());
+        assert_eq!(try_warm_claim(&b, &c, false, None).unwrap(), None);
+    }
+
+    #[test]
     fn try_warm_claim_cold_without_admitted_plan() {
         let b = AnyBackend::from_hypervisor("libkrun");
         let mut c = eligible_cfg();
@@ -543,10 +558,31 @@ mod tests {
 
     #[test]
     fn inline_replenish_skips_zero_unsupported_and_vz() {
-        assert!(!should_replenish_inline(BackendKind::Libkrun, true, 0));
-        assert!(!should_replenish_inline(BackendKind::Libkrun, false, 1));
-        assert!(!should_replenish_inline(BackendKind::Vz, true, 1));
-        assert!(should_replenish_inline(BackendKind::Libkrun, true, 1));
+        assert!(!should_replenish_inline(
+            BackendKind::Libkrun,
+            true,
+            0,
+            false
+        ));
+        assert!(!should_replenish_inline(
+            BackendKind::Libkrun,
+            false,
+            1,
+            false
+        ));
+        assert!(!should_replenish_inline(BackendKind::Vz, true, 1, false));
+        assert!(!should_replenish_inline(
+            BackendKind::Libkrun,
+            true,
+            1,
+            true
+        ));
+        assert!(should_replenish_inline(
+            BackendKind::Libkrun,
+            true,
+            1,
+            false
+        ));
     }
 
     #[test]

--- a/crates/mvm-cli/src/commands/tests.rs
+++ b/crates/mvm-cli/src/commands/tests.rs
@@ -3826,18 +3826,17 @@ fn exits_early(argv: &[&str]) -> bool {
 #[test]
 fn state_touching_commands_trigger_entry_convergence() {
     // Lifecycle mutate/read commands run the cheap converge pass.
-    // (`up` was retired — `machine run` and `machine start` are the
-    // lifecycle-entry points; they route through MachineAction which
-    // touches_vm_state returns true for.)
+    // (`up` was retired — named/persistent `machine run` and `machine start` are
+    // the lifecycle-entry points.)
     assert!(touches(&[
         "mvmctl",
         "machine",
         "run",
         "--image",
         "alpine:latest",
-        "--",
-        "sh"
+        "-d"
     ]));
+    assert!(touches(&["mvmctl", "machine", "start", "myvm"]));
     assert!(touches(&["mvmctl", "machine", "stop", "--all"]));
     assert!(touches(&["mvmctl", "machine", "console", "myvm"]));
     assert!(touches(&["mvmctl", "machine", "pause", "myvm"]));
@@ -3856,6 +3855,27 @@ fn read_only_and_vm_agnostic_commands_skip_entry_convergence() {
     // `ls --all` must preserve registry-only stopped rows for rendering.
     assert!(!touches(&["mvmctl", "ls", "--all"]));
     assert!(!touches(&["mvmctl", "ls", "--all", "--json"]));
+    // Foreground transient image runs are throwaway launches. They must not
+    // auto-resume unrelated dev/persistent machines before booting the image.
+    assert!(!touches(&[
+        "mvmctl",
+        "machine",
+        "run",
+        "--image",
+        "alpine:latest",
+        "--",
+        "sh"
+    ]));
+    assert!(!touches(&[
+        "mvmctl",
+        "machine",
+        "run",
+        "--image",
+        "alpine:latest",
+        "-it",
+        "--",
+        "/bin/sh"
+    ]));
     // `reconcile` is the convergence verb itself — must not double-run on entry.
     assert!(!touches(&["mvmctl", "reconcile"]));
     assert!(!touches(&["mvmctl", "reconcile", "--dry-run"]));

--- a/crates/mvm-cli/src/commands/vm/console.rs
+++ b/crates/mvm-cli/src/commands/vm/console.rs
@@ -8,6 +8,7 @@ use clap::Args as ClapArgs;
 
 use mvm::vsock_transport::{
     DevConsoleTransport, FirecrackerTransport, LibkrunTransport, VsockTransport, VzTransport,
+    firecracker_transport_supported,
 };
 use mvm_core::naming::validate_vm_name;
 use mvm_core::user_config::MvmConfig;
@@ -23,12 +24,13 @@ use crate::ui;
 ///    different path than `VzTransport::for_vm` resolves).
 /// 2. libkrun per-port Unix socket.
 /// 3. HVF runner (`WorkloadRunner` / HVF) agent socket at
-///    `<vm_state_dir>/agent.sock`, only when `is_dev_mode()` — the
-///    pre-opened console sockets exist only when the dev console was
-///    enabled at boot.
+///    `<vm_state_dir>/hvf-agent.sock`. This is workload-local; the
+///    pre-opened console sockets exist only when the VM was booted with
+///    `dev_console=true`.
 /// 4. Vz per-port Unix socket (`<vm_state_dir>/vsock/vsock-<port>.sock`) —
 ///    the macOS AVF path.
-/// 5. Firecracker UDS multiplexer (fleet/production path).
+/// 5. Firecracker UDS multiplexer (fleet/production path), only on native
+///    Linux where resolving the Firecracker runtime dir is side-effect-free.
 ///
 /// Each probe consumes one stream and drops it; the returned
 /// `Arc<dyn VsockTransport>` is then used for every real connection
@@ -59,15 +61,12 @@ fn pick_console_transport(name: &str) -> Result<Arc<dyn VsockTransport>> {
         return Ok(Arc::new(libkrun));
     }
     // HVF runner (WorkloadRunner / HVF) exposes the agent at
-    // `<vm_state_dir>/agent.sock` and console data ports at
-    // `<vm_state_dir>/vsock/vsock-<port>.sock`. Dev-only: the pre-opened
-    // console sockets are only present when `dev_console` was set at boot,
-    // and this arm is gated on `is_dev_mode()`.
-    if mvm_core::config::is_dev_mode() {
-        let hvf = DevConsoleTransport::for_vm(name);
-        if hvf.connect(mvm_guest::vsock::GUEST_AGENT_PORT).is_ok() {
-            return Ok(Arc::new(hvf));
-        }
+    // `<vm_state_dir>/hvf-agent.sock` and console data ports at
+    // `<vm_state_dir>/vsock/vsock-<port>.sock`. The sockets are workload-local;
+    // global dev mode is not required for a foreground `machine run -it`.
+    let hvf = DevConsoleTransport::for_vm(name);
+    if hvf.connect(mvm_guest::vsock::GUEST_AGENT_PORT).is_ok() {
+        return Ok(Arc::new(hvf));
     }
     // Vz workloads expose the agent at `<vm_state_dir>/vsock/vsock-<port>.sock`
     // (one subdir deeper than libkrun); without this probe `console` fell
@@ -76,7 +75,10 @@ fn pick_console_transport(name: &str) -> Result<Arc<dyn VsockTransport>> {
     if vz.connect(mvm_guest::vsock::GUEST_AGENT_PORT).is_ok() {
         return Ok(Arc::new(vz));
     }
-    Ok(Arc::new(FirecrackerTransport::for_vm(name)?))
+    if firecracker_transport_supported(mvm_core::platform::current()) {
+        return Ok(Arc::new(FirecrackerTransport::for_vm(name)?));
+    }
+    anyhow::bail!("no host-side console transport found for VM {name:?}")
 }
 
 #[derive(ClapArgs, Debug, Clone)]
@@ -762,10 +764,9 @@ mod picker_hvf_tests {
 
     use super::*;
 
-    /// Bind `agent.sock` under a fresh temp state-dir, set `MVM_DATA_DIR` so
-    /// `vm_state_dir` resolves there, and set `MVM_ENV=dev` so the hvf arm
-    /// in `pick_console_transport` fires. Returns the guard objects that keep
-    /// the socket and env alive for the test.
+    /// Bind `hvf-agent.sock` under a fresh temp state-dir and set
+    /// `MVM_DATA_DIR` so `vm_state_dir` resolves there. Returns the guard
+    /// objects that keep the socket and env alive for the test.
     fn setup_hvf_agent(
         name: &str,
     ) -> (
@@ -776,7 +777,6 @@ mod picker_hvf_tests {
         let mut env = mvm_core::util::test_env::TestEnv::new();
         let tmp = tempfile::tempdir_in("/tmp").expect("state tempdir");
         env.set("MVM_DATA_DIR", tmp.path());
-        env.set("MVM_ENV", "dev");
         let state = mvm_core::config::vm_state_dir(name);
         std::fs::create_dir_all(&state).unwrap();
         let agent = mvm_core::config::vm_hvf_agent_socket(name);
@@ -784,27 +784,22 @@ mod picker_hvf_tests {
         (tmp, env, listener)
     }
 
-    // TDD RED: picker selects DevConsoleTransport for an hvf dev workload
-    // when agent.sock is reachable and MVM_ENV=dev.
     #[test]
-    fn pick_console_transport_selects_hvf_for_dev_workload() {
+    fn pick_console_transport_selects_hvf_for_workload() {
         let name = "hvf-dev-workload";
         let (_tmp, _env, _listener) = setup_hvf_agent(name);
 
         let transport = pick_console_transport(name).expect("picker must resolve hvf transport");
         transport
             .connect(mvm_guest::vsock::GUEST_AGENT_PORT)
-            .expect("selected transport must connect to agent.sock");
+            .expect("selected transport must connect to hvf-agent.sock");
     }
 
-    // TDD RED: without MVM_ENV=dev the hvf arm must NOT fire even when
-    // agent.sock is present — falls through to Firecracker (or errors).
     #[test]
-    fn pick_console_transport_skips_hvf_when_not_dev_mode() {
+    fn pick_console_transport_selects_hvf_without_global_dev_mode() {
         let mut env = mvm_core::util::test_env::TestEnv::new();
         let tmp = tempfile::tempdir_in("/tmp").expect("state tempdir");
         env.set("MVM_DATA_DIR", tmp.path());
-        // Explicitly not dev mode — either unset or prod.
         env.set("MVM_ENV", "prod");
 
         let name = "hvf-prod-workload";
@@ -813,34 +808,17 @@ mod picker_hvf_tests {
         let agent = mvm_core::config::vm_hvf_agent_socket(name);
         let _listener = UnixListener::bind(&agent).unwrap();
 
-        // Non-dev: hvf arm must not fire. The picker falls through; the Vz
-        // probe will also miss (no vsock/ socket), so Firecracker fallback runs.
-        // A successful fallback would be wrong here (no FC socket either), so we
-        // accept either an Err OR a transport that can't connect to agent.sock —
-        // the important thing is the transport is NOT the DevConsoleTransport.
-        match pick_console_transport(name) {
-            Err(_) => {
-                // Expected: picker fell through to FC which failed — fine.
-            }
-            Ok(transport) => {
-                // If somehow a transport was selected, it must NOT be the hvf
-                // one — it must fail to connect to agent.sock (FC path won't know
-                // about agent.sock).
-                assert!(
-                    transport
-                        .connect(mvm_guest::vsock::GUEST_AGENT_PORT)
-                        .is_err(),
-                    "non-dev mode must not route to the hvf agent socket"
-                );
-            }
-        }
+        let transport = pick_console_transport(name)
+            .expect("picker must resolve hvf transport without global dev mode");
+        transport
+            .connect(mvm_guest::vsock::GUEST_AGENT_PORT)
+            .expect("selected transport must connect to hvf-agent.sock");
     }
 
-    // Extend the boundary test: even with MVM_ENV=dev (which enables the
-    // hvf arm), the picker selects the workload's OWN hvf socket — not
-    // the dev/builder VM socket — when both are present. The hvf arm probes
-    // agent.sock under the workload's own state dir, which is disjoint from the
-    // builder cache, so it can never cross-route.
+    // Extend the boundary test: the picker selects the workload's OWN hvf
+    // socket — not the dev/builder VM socket — when both are present. The hvf
+    // arm probes `hvf-agent.sock` under the workload's own state dir, which is
+    // disjoint from the builder cache, so it can never cross-route.
     #[cfg(feature = "builder-vm")]
     #[test]
     fn pick_console_transport_hvf_uses_workload_not_dev_socket() {

--- a/crates/mvm-cli/src/exec.rs
+++ b/crates/mvm-cli/src/exec.rs
@@ -467,6 +467,10 @@ pub fn transient_run_dev_console(pty: bool, verity_path: Option<&str>) -> bool {
     pty && verity_path.is_none()
 }
 
+fn transient_run_needs_staging_cleanup(add_dirs: &[AddDir]) -> bool {
+    !add_dirs.is_empty()
+}
+
 /// Decide whether snapshot restore is safe for this request.
 ///
 /// Only enabled for the trivial case: a registered template (so the image
@@ -667,11 +671,10 @@ fn run_inner(
         backend.capabilities().snapshots,
     );
 
-    // Probe for the verity sidecar alongside the rootfs: production
-    // microVMs ship `rootfs.verity` + `rootfs.roothash` next to
-    // `rootfs.ext4`. Their absence is the dev-VM exemption. Files live
-    // inside the VM, so we can't `Path::exists()` them from the host —
-    // shell out into the VM instead.
+    // Probe for the verity sidecar alongside the rootfs: production microVMs
+    // ship `rootfs.verity` + `rootfs.roothash` next to `rootfs.ext4`. Their
+    // absence is the dev-VM exemption. This is host-local and side-effect-free;
+    // foreground OCI launches must never boot the builder/dev VM just to probe.
     let (verity_path, roothash) = mvm_backend::microvm::probe_verity_sidecar(&rootfs);
 
     // Run-path tier gate: a virtiofs-capable backend + a non-prod, non-sealed OCI
@@ -816,7 +819,9 @@ fn run_inner(
     if !booted {
         ui::info(&format!("Booting transient VM '{vm_name}'..."));
         if let Err(e) = backend.start(&start_config) {
-            let _ = mvm::shell::run_in_vm(&format!("rm -rf {staging_dir}"));
+            if transient_run_needs_staging_cleanup(&req.add_dirs) {
+                let _ = mvm::shell::run_in_vm(&format!("rm -rf {staging_dir}"));
+            }
             return Err(e).context("starting transient microVM");
         }
     }
@@ -869,7 +874,9 @@ fn run_inner(
         }
     }
 
-    let _ = mvm::shell::run_in_vm(&format!("rm -rf {staging_dir}"));
+    if transient_run_needs_staging_cleanup(&req.add_dirs) {
+        let _ = mvm::shell::run_in_vm(&format!("rm -rf {staging_dir}"));
+    }
     let t_torn_down = timing.then(std::time::Instant::now);
 
     // Emit the phase breakdown when every seam was marked (i.e. timing was
@@ -1974,5 +1981,20 @@ mod tests {
     #[test]
     fn non_interactive_sealed_run_leaves_dev_console_unset() {
         assert!(!transient_run_dev_console(false, Some("/rootfs.verity")));
+    }
+
+    #[test]
+    fn staging_cleanup_skipped_without_add_dirs() {
+        assert!(!transient_run_needs_staging_cleanup(&[]));
+    }
+
+    #[test]
+    fn staging_cleanup_enabled_with_add_dirs() {
+        let add_dir = AddDir {
+            host_path: "/tmp/host".to_string(),
+            guest_path: "/mnt/host".to_string(),
+            read_only: true,
+        };
+        assert!(transient_run_needs_staging_cleanup(&[add_dir]));
     }
 }

--- a/crates/mvm/src/vsock_transport.rs
+++ b/crates/mvm/src/vsock_transport.rs
@@ -20,6 +20,7 @@ use std::os::unix::net::UnixStream;
 use std::path::PathBuf;
 
 use mvm_backend::microvm;
+use mvm_core::platform::Platform;
 
 /// Open a vsock connection to a port on a guest.
 ///
@@ -32,6 +33,14 @@ pub trait VsockTransport: Send + Sync {
     /// is performed inside this call when applicable; on Apple
     /// Container the framework returns a stream directly.
     fn connect(&self, port: u32) -> Result<UnixStream>;
+}
+
+/// Whether unresolved socket probes may fall back to Firecracker's in-Linux
+/// runtime directory lookup. On macOS that lookup shells through the dev Linux
+/// environment, so it must not run while probing a normal host-side HVF/Vz
+/// workload.
+pub fn firecracker_transport_supported(platform: Platform) -> bool {
+    platform.supports_native_runner()
 }
 
 /// Connects through a Firecracker vsock UDS multiplexer.
@@ -264,10 +273,11 @@ impl VsockTransport for NestingHopTransport {
 
 /// Pick a transport for a VM by name.
 ///
-/// Probes libkrun's per-port Unix socket first, then the vz supervisor's
-/// per-port socket, then Firecracker by resolving the running VM's
-/// instance directory — the cheapest probe that doesn't require the
-/// caller to know the backend ahead of time.
+/// Probes host-side sockets first, then Firecracker only on native Linux where
+/// its runtime directory lookup is local and side-effect-free. macOS must not
+/// fall back to Firecracker here: that path shells through the dev Linux
+/// environment and can auto-start the builder/dev VM while waiting for a normal
+/// HVF/Vz workload socket to appear.
 ///
 /// Note: the probe consumes one stream and immediately drops it;
 /// callers get a *fresh* stream from the returned transport's
@@ -292,9 +302,12 @@ pub fn for_vm(vm_name: &str) -> Result<Box<dyn VsockTransport>> {
     if vz.connect(mvm_guest::vsock::GUEST_AGENT_PORT).is_ok() {
         return Ok(Box::new(vz));
     }
-    let fc = FirecrackerTransport::for_vm(vm_name)
-        .with_context(|| format!("no vsock transport found for VM {:?}", vm_name))?;
-    Ok(Box::new(fc))
+    if firecracker_transport_supported(mvm_core::platform::current()) {
+        let fc = FirecrackerTransport::for_vm(vm_name)
+            .with_context(|| format!("no vsock transport found for VM {:?}", vm_name))?;
+        return Ok(Box::new(fc));
+    }
+    anyhow::bail!("no host-side vsock transport found for VM {:?}", vm_name)
 }
 
 #[cfg(test)]
@@ -408,6 +421,25 @@ mod tests {
             .expect("selected transport should connect to the hvf-agent socket");
 
         unsafe { std::env::remove_var("MVM_DATA_DIR") };
+    }
+
+    #[test]
+    fn firecracker_transport_supported_only_for_native_linux() {
+        assert!(firecracker_transport_supported(
+            mvm_core::platform::Platform::LinuxNative
+        ));
+        assert!(!firecracker_transport_supported(
+            mvm_core::platform::Platform::MacOS
+        ));
+        assert!(!firecracker_transport_supported(
+            mvm_core::platform::Platform::LinuxNoKvm
+        ));
+        assert!(!firecracker_transport_supported(
+            mvm_core::platform::Platform::Wsl2
+        ));
+        assert!(!firecracker_transport_supported(
+            mvm_core::platform::Platform::Windows
+        ));
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- keep foreground transient `machine run --image ...` out of entry convergence so it does not resume unrelated machines
- make rootfs verity sidecar probing host-local instead of shelling through the dev Linux environment
- prevent macOS vsock/console transport probing and no-op cleanup from falling back to Firecracker/dev VM
- wire HVF interactive console sockets for `dev_console` and create missing `vsock/` parent dirs before binding

## Validation
- `cargo test -p mvm-backend probe_verity_sidecar --quiet`
- `cargo test -p mvm vsock_transport --quiet`
- `cargo test -p mvm-cli pick_console_transport --quiet`
- `cargo test -p mvm-cli entry_convergence --quiet`
- `cargo test -p mvm-backend console_bridge --quiet`
- `cargo test -p mvm-backend console_data_sockets --quiet`
- `cargo test -p mvm-cli transient_run --quiet`
- `cargo test -p mvm-cli staging_cleanup --quiet`
- `cargo check -p mvm-backend -p mvm -p mvm-cli -p mvm-vm-host --quiet`
- `cargo clippy -p mvm-backend -p mvm -p mvm-cli -p mvm-vm-host --all-targets --quiet -- -D warnings`
- patched smoke: `mvmctl machine run --image alpine -- /bin/sh -lc 'echo PTY_OK'` prints `PTY_OK`
- patched smoke: `mvmctl machine run --image alpine -it -- /bin/sh -lc 'echo PTY_OK'` prints `PTY_OK`, no Stage 0/dev VM output
- patched smoke: exact shell shape `mvmctl machine run --image alpine -it -- /bin/sh`, then `echo PTY_OK` and `exit`, opens the shell and exits cleanly

Note: smoke binaries were built with `MVM_SKIP_EMBED_BINARIES=1` to prove this path does not depend on builder stubs.