### PR TITLE
refactor: two product surfaces — host runtime + user client (Plan 230 WS-1)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -523,6 +523,29 @@ template-registry-s3 = [
     "mvm-cli/template-registry-s3",
 ]
 
+# ── Two product surfaces (the only two knobs a consumer should touch) ─────────
+# There are exactly two things this project ships: what the host machine runs to
+# host sandboxes, and what a user runs to drive them. Every capability flag above
+# rolls up into one of these. Build the host runtime with `--features host`; the
+# user client is `default`. Individual flags above remain only as internal
+# implementation detail (they gate real per-OS/platform code) — they are not the
+# consumer-facing surface. New consumer-facing behaviour joins `host` or `user`;
+# a third top-level product knob is a design error.
+#
+# `host` — everything the host machine runs to boot/manage/secure/build sandboxes.
+# Platform-neutral: backends auto-detect at runtime (the `VmBackend` trait). A
+# host that uses the libkrun backend adds `libkrun-sys`/`libkrun-live` on top;
+# the macOS-26 HVF host needs neither, so they are not in the base umbrella.
+host = [
+    "builder-vm",
+    "pure-mkfs",
+    "custom-dns",
+    "hostd-transport",
+    "template-registry-s3",
+]
+# `user` — everything a user runs to create/drive sandboxes (the client).
+user = ["manifest-verify"]
+
 [profile.release]
 opt-level = 3
 strip = true

--- a/specs/plans/230-two-surface-consolidation.md
+++ b/specs/plans/230-two-surface-consolidation.md
@@ -1,0 +1,120 @@
+# Plan 230 — Two-surface consolidation: host runtime + user client, nothing else
+
+**Status: PROPOSED**
+**Created: 2026-07-06**
+**Owner directive:** "As few features as possible. One for the host machine to
+run and another for the user to run. That's IT."
+
+## The two surfaces (the only two)
+
+Everything in the workspace collapses into exactly two product surfaces. Any
+code that is neither is dev/test scaffolding and is quarantined out of the
+shipped product (not a third surface).
+
+### 1. `host` — what the host machine runs
+
+The host-side runtime that boots, manages, secures, and builds sandboxes. One
+install on a machine that hosts workloads. Comprises:
+
+- **VMM + backends** (`mvm-backend`) and per-VM supervisors (`mvm-vm-host`:
+  `mvm-hvf-supervisor`, `mvm-libkrun-supervisor`, `mvm-bridge`; `mvm-vz-supervisor`
+  sunset).
+- **Host daemons — the process moat** (`mvm-hostd`: `mvm-broker`,
+  `mvm-host-signer`, `mvm-audit-signer`, `mvm-substitution-endpoint`,
+  `mvm-host-agent`). These stay separate processes — claims 12/13 depend on it —
+  but they are one *surface*: the host runtime.
+- **Builder** (`mvm-build`: `mvm-builderd`, `mvm-host-vm-init`, `stage0-init`,
+  `mvm-egress-proxy`, `mvm-rootfs-patcher`).
+- **Guest binaries the host bakes into images** (`mvm-guest`, `mvm-guest-helpers`:
+  `mvm-guest-agent`, `mvm-guest-netinit`, `mvm-runner`, `mvm-verity-init`,
+  `mvm-exit-report`, `mvm-addon-*`). They run *in* the guest but are a build
+  output of the host surface, not a third product.
+
+### 2. `user` — what the user runs
+
+The client a developer runs to create/run/drive sandboxes. Comprises:
+
+- **`mvmctl`** (the CLI) — but as a *client*, driving the host runtime through
+  the `MvmClient` facade (`mvm-client`), local or remote. No embedded host-side
+  VM management in the user surface (that's the host runtime's job).
+- **SDKs** — `mvm-sdk` (decorator authoring → Workload IR) + the Python/TS
+  packages + `mvm-client` (runtime facade). `mvm-mcp` (the MCP sandbox server) is
+  a user-surface entry point too.
+
+### Not a surface (quarantine, do not ship)
+
+`*/fuzz/*`, schema emitters (`emit_*_schema`), and test tools
+(`syscall-probe`, `audit-probe`, `fake-runner`, `mvm-entrypoint-test-wrapper`,
+`mvm-ext4`) are development scaffolding. They move behind a non-default
+`dev-tools`/`fuzz` gate or out of the workspace default members, so a product
+build of either surface never compiles them.
+
+## The consolidation
+
+### Feature flags: ~30 → 2 umbrellas
+
+Today: `contributor-bootstrap builder-vm pure-mkfs custom-dns dev-watch
+libkrun-live libkrun-sys hostd-transport manifest-verify template-registry-s3
+release-artifact-bootstrap egress-ca test-support attestation-{tpm2,sev-snp,tdx}
+schema remote client-facade protocol-only stdio s3 dev-shell` scattered across
+14 crates.
+
+Target: two workspace-root umbrella features a consumer selects, each
+aggregating the sub-features by surface. Sub-features become internal
+implementation detail (not deleted where they gate real platform code, but no
+longer part of the consumer-facing knob set):
+
+- **`host`** = builder-vm + pure-mkfs + libkrun-sys + libkrun-live + custom-dns +
+  hostd-transport + egress-ca + attestation-* + template-registry-s3/s3 +
+  the guest `dev-shell` build. Everything the host runtime needs.
+- **`user`** = manifest-verify (cosign at the client) + `mvm-client/remote` +
+  `mvm-sdk/client-facade` + MCP stdio. Everything the user client needs.
+- Retire as product knobs: `contributor-bootstrap`, `dev-watch`,
+  `release-artifact-bootstrap`, `test-support`, `schema` — dev/build/CI
+  scaffolding, moved under a single non-default `dev` feature or out of the
+  default build.
+
+A consumer builds the host runtime with `--features host` or the client with
+`--features user`. `default` picks the user client (the common case).
+
+### CLI verbs: split client vs host-op
+
+`mvmctl`'s verb sprawl divides: user-client verbs (`machine run/create/start/
+stop/exec/logs/reconfigure/ls`, `secret`, SDK-facing) stay in the user surface
+and route through `MvmClient`; host-operation verbs (`dev`, `build`, `bootstrap`,
+`doctor` host-probes, `cache`, `pool`) belong to the host runtime. The user CLI
+gains a `--remote` to drive a host runtime elsewhere; on a dev laptop the two
+still ship together but the *code* boundary is the facade.
+
+## Workstreams
+
+- [ ] **WS-1 (umbrella features):** add root `host` + `user` features aggregating
+      the existing flags; re-point `default`. Workspace builds under each. *(slice 1 — this PR)*
+- [ ] **WS-2 (quarantine scaffolding):** move fuzz + schema-emitter + test-tool
+      bins behind a non-default `dev-tools` gate / out of default workspace
+      members; a product build compiles neither surface's scaffolding.
+- [ ] **WS-3 (retire dead knobs):** fold `contributor-bootstrap` / `dev-watch` /
+      `release-artifact-bootstrap` / `test-support` / `schema` into one `dev`
+      feature; delete any genuinely-unused flag.
+- [ ] **WS-4 (CLI client/host split):** route every user verb through
+      `MvmClient` (Plan 216 S2); move host-op verbs behind the `host` surface;
+      the user client is a facade consumer only.
+- [ ] **WS-5 (docs + claims):** README/CLAUDE.md/doctor describe exactly two
+      surfaces; `xtask` gate asserts no third product surface reappears (a lint
+      that fails if a new consumer-facing feature is added outside `host`/`user`).
+
+## Sequencing & safety
+
+WS-1 is additive and safe (verify the workspace builds under `--features host`
+and `--features user`). WS-2/WS-3 are removals gated on green CI. WS-4 is the
+large one (depends on Plan 216 S2 facade routing) and is where the *runtime*
+(not just build) boundary lands. Each slice keeps CI green; no surface merges
+until it builds and tests pass.
+
+## Non-goals
+
+- Collapsing the host runtime's separate signer/broker/substitution processes
+  into one binary — the process moat is load-bearing for claims 12/13. "One
+  surface" ≠ "one process".
+- Deleting platform sub-features that gate real per-OS code (libkrun-sys,
+  attestation-*) — they stop being *consumer knobs*, not code.


### PR DESCRIPTION
**Goal (owner):** as few features as possible — one thing the host machine runs, one thing the user runs, and that's it.

## Plan 230 defines the two surfaces
`specs/plans/230-two-surface-consolidation.md` maps every crate/binary/feature into exactly one of two product surfaces:
- **`host`** — what the host machine runs to boot/manage/secure/build sandboxes: VMM + backends, per-VM supervisors (`mvm-vm-host`), the host-daemon process moat (`mvm-hostd`: broker/signers/substitution-endpoint/host-agent), the builder (`mvm-build`), and the guest binaries it bakes into images.
- **`user`** — what a user runs to drive sandboxes: `mvmctl` (as a *client*, through the `MvmClient` facade), the SDKs (`mvm-sdk` + Python/TS + `mvm-client`), and the MCP server.
- **Not a surface:** fuzz targets, schema emitters, and test tools — quarantined as scaffolding, never shipped in either product.

## WS-1 (this PR — additive, safe)
Adds two workspace-root umbrella features — `host` and `user` — so a consumer selects one surface instead of hand-picking from ~30 scattered flags across 14 crates. `host` is platform-neutral (backends auto-detect at runtime; `libkrun-sys` stays an opt-in sub-feature, so the macOS-26 HVF host needs neither libkrun nor Vz).

**Verified:** the workspace builds under both `cargo check --no-default-features --features host` and `--features user`. `check-spec-numbers` clean.

## Remaining slices (sequenced in the plan)
WS-2 quarantine scaffolding bins behind a non-default gate · WS-3 retire dead knobs (`contributor-bootstrap`/`dev-watch`/`release-artifact-bootstrap`/`test-support`/`schema` → one `dev` feature) · WS-4 route the user CLI through `MvmClient` so host/user is a *runtime* seam (Plan 216 S2) · WS-5 docs + an `xtask` gate that fails if a third consumer-facing product knob appears.

**Non-goal:** collapsing the host runtime's separate signer/broker/substitution processes into one binary — the process moat is load-bearing for claims 12/13. "One surface" ≠ "one process".