### PR TITLE
fix(run): stop macOS-26 HVF workload runs from waking the builder/dev VM (+ wire interactive console)

### DIFF
--- a/crates/mvm-backend/src/hvf_backend.rs
+++ b/crates/mvm-backend/src/hvf_backend.rs
@@ -278,6 +278,16 @@ impl VmBackend for HvfBackend {
             .and_then(|s| s.parse().ok())
             .unwrap_or(0);
 
+        // Interactive PTY runs (`machine run -it`) pre-open the console data
+        // ports so the host can attach a shell; the supervisor binds them under
+        // `<state_dir>/vsock/`. Create the dir up front so the bind can't miss.
+        let console_data_sockets = hvf_console_data_sockets(&state_dir, config.dev_console);
+        if !console_data_sockets.is_empty() {
+            let vsock_dir = state_dir.join("vsock");
+            std::fs::create_dir_all(&vsock_dir)
+                .with_context(|| format!("create console vsock dir {}", vsock_dir.display()))?;
+        }
+
         let cfg = HvfSupervisorConfig {
             kernel: PathBuf::from(kernel),
             // Workload path: the supervisor's default cmdline (`init=/init`) is the
@@ -295,7 +305,7 @@ impl VmBackend for HvfBackend {
             agent_socket: Some(agent_socket),
             substitution_socket: None,
             egress_relay_socket,
-            console_data_sockets: hvf_console_data_sockets(&state_dir, config.dev_console),
+            console_data_sockets,
         };
         let json = serde_json::to_string(&cfg)
             .map_err(|e| anyhow!("serialize HvfSupervisorConfig: {e}"))?;
@@ -566,5 +576,35 @@ mod tests {
         let r = resolve_supervisor_path();
         unsafe { std::env::remove_var("MVM_HVF_SUPERVISOR_PATH") };
         assert!(r.is_err());
+    }
+
+    #[test]
+    fn hvf_console_data_sockets_empty_for_sealed_boot() {
+        // A sealed prod boot (dev_console = false) opens no console listeners.
+        assert!(hvf_console_data_sockets(Path::new("/tmp/state"), false).is_empty());
+    }
+
+    #[test]
+    fn hvf_console_data_sockets_match_dev_console_transport_paths() {
+        let state = Path::new("/tmp/state");
+        let socks = hvf_console_data_sockets(state, true);
+        assert!(
+            !socks.is_empty(),
+            "an interactive run pre-opens console ports"
+        );
+        // The guest ports are exactly the dev console data range.
+        let got: Vec<u32> = socks.iter().map(|s| s.guest_port).collect();
+        let want: Vec<u32> = mvm_guest::vsock::dev_console_data_ports().collect();
+        assert_eq!(got, want);
+        // Each host UDS is `<state_dir>/vsock/vsock-<port>.sock`, the exact path
+        // `DevConsoleTransport` dials — a drift here silently breaks PTY attach.
+        for s in &socks {
+            assert_eq!(
+                s.host_socket,
+                state
+                    .join("vsock")
+                    .join(mvm_core::config::vsock_socket_filename(s.guest_port)),
+            );
+        }
     }
 }

--- a/crates/mvm-backend/src/microvm.rs
+++ b/crates/mvm-backend/src/microvm.rs
@@ -2186,11 +2186,14 @@ pub fn create_dev_secrets_drive(abs_dir: &str, secret_files: &[DriveFile]) -> Re
     Ok(path)
 }
 
-/// Probe the host-visible directory containing `rootfs_path` for the dm-verity
-/// sidecar files emitted by mkGuest when `verifiedBoot = true`. Returns
-/// `(Some(verity_path), Some(roothash))` when both files are present and the
-/// roothash decodes to a 64-char hex string; otherwise `(None, None)` so
-/// callers fall back to the unverified-boot path.
+/// Probe the directory containing `rootfs_path` for the dm-verity sidecar
+/// files emitted by mkGuest when `verifiedBoot = true`. The rootfs and its
+/// sidecars are host files the VMM attaches as block devices, so the probe
+/// reads the host filesystem directly — it must not shell into a builder/dev
+/// VM, which both missed the real host sidecars and woke a heavyweight VM on
+/// every run. Returns `(Some(verity_path), Some(roothash))` when both files
+/// are present and the roothash decodes to a 64-char hex string; otherwise
+/// `(None, None)` so callers fall back to the unverified-boot path.
 pub fn probe_verity_sidecar(rootfs_path: &str) -> (Option<String>, Option<String>) {
     use std::path::Path;
 
@@ -3551,6 +3554,54 @@ mod tests {
         assert!(got.contains(&format!("mvm.runtime_roothash={OVERLAY_HASH}")));
         assert!(got.contains("mvm.runtime_data=/dev/vdc"));
         assert!(got.contains("mvm.runtime_hash=/dev/vdd"));
+    }
+
+    #[test]
+    fn probe_verity_sidecar_reads_host_sidecars() {
+        // The rootfs and its dm-verity sidecars are host files the VMM
+        // attaches as block devices, so the probe must read the host
+        // filesystem — never shell into a builder/dev VM. Regression guard
+        // for the stale nested-model probe that reached into the dev VM and
+        // so (a) missed real host sidecars and (b) auto-started a heavyweight
+        // dev VM on any interactive `machine run --image`.
+        let dir = tempfile::tempdir().unwrap();
+        let rootfs = dir.path().join("rootfs.ext4");
+        std::fs::write(&rootfs, b"data").unwrap();
+        std::fs::write(dir.path().join("rootfs.verity"), b"hash-tree").unwrap();
+        std::fs::write(
+            dir.path().join("rootfs.roothash"),
+            format!("{ROOTFS_HASH}\n"),
+        )
+        .unwrap();
+
+        let (verity, roothash) = probe_verity_sidecar(rootfs.to_str().unwrap());
+        assert_eq!(
+            verity.as_deref(),
+            Some(dir.path().join("rootfs.verity").to_str().unwrap()),
+        );
+        assert_eq!(roothash.as_deref(), Some(ROOTFS_HASH));
+    }
+
+    #[test]
+    fn probe_verity_sidecar_none_without_sidecars() {
+        // A non-sealed rootfs (e.g. an unpacked OCI image) has no sidecars;
+        // the probe falls back to unverified boot without touching any VM.
+        let dir = tempfile::tempdir().unwrap();
+        let rootfs = dir.path().join("rootfs.ext4");
+        std::fs::write(&rootfs, b"data").unwrap();
+        assert_eq!(probe_verity_sidecar(rootfs.to_str().unwrap()), (None, None));
+    }
+
+    #[test]
+    fn probe_verity_sidecar_rejects_malformed_roothash() {
+        // A present-but-garbage roothash must fail closed to unverified
+        // boot rather than feed a bogus hash into the kernel cmdline.
+        let dir = tempfile::tempdir().unwrap();
+        let rootfs = dir.path().join("rootfs.ext4");
+        std::fs::write(&rootfs, b"data").unwrap();
+        std::fs::write(dir.path().join("rootfs.verity"), b"hash-tree").unwrap();
+        std::fs::write(dir.path().join("rootfs.roothash"), b"not-a-hex-roothash").unwrap();
+        assert_eq!(probe_verity_sidecar(rootfs.to_str().unwrap()), (None, None));
     }
 
     #[test]

--- a/crates/mvm-backend/src/microvm.rs
+++ b/crates/mvm-backend/src/microvm.rs
@@ -182,9 +182,24 @@ pub fn resolve_vm_dir(slot: &VmSlot) -> Result<String> {
 }
 
 /// Resolve the absolute directory path for a running VM by name.
+///
+/// Expands `~/microvm/vms` on the host. This used to `echo` it *inside* the VM
+/// to resolve `~`, but on macOS every `run_in_vm` shells into the dev VM —
+/// auto-starting a heavyweight builder — and this resolver sits on the
+/// agent-reachability poll (`wait_for_agent`), so a Firecracker-fallback probe
+/// for an hvf workload woke the dev VM before the hvf agent bound. The instance
+/// dir is a host path the VMM reads; expand it here. On Linux (Firecracker) the
+/// in-VM env is the host, so this is identical to the old echo.
 pub fn resolve_running_vm_dir(name: &str) -> Result<String> {
-    let abs_vms = run_in_vm_stdout(&format!("echo {}", VMS_DIR))?;
-    Ok(format!("{}/{}", abs_vms, name))
+    let abs_vms = VMS_DIR
+        .strip_prefix("~/")
+        .and_then(|rest| {
+            std::env::var("HOME")
+                .ok()
+                .map(|home| format!("{home}/{rest}"))
+        })
+        .unwrap_or_else(|| VMS_DIR.to_string());
+    Ok(format!("{abs_vms}/{name}"))
 }
 
 /// Return the host-side path to Firecracker's PID file for VM `name`.
@@ -3602,6 +3617,19 @@ mod tests {
         std::fs::write(dir.path().join("rootfs.verity"), b"hash-tree").unwrap();
         std::fs::write(dir.path().join("rootfs.roothash"), b"not-a-hex-roothash").unwrap();
         assert_eq!(probe_verity_sidecar(rootfs.to_str().unwrap()), (None, None));
+    }
+
+    #[test]
+    fn resolve_running_vm_dir_expands_host_side() {
+        // Must resolve `~/microvm/vms` on the host, never shelling into the VM:
+        // this sits on the agent-reachability poll, and a `run_in_vm` here wakes
+        // the macOS dev VM. (The old in-VM `echo` returned Err in a test env with
+        // no dev VM reachable.)
+        let home = std::env::var("HOME").expect("HOME set in the test env");
+        assert_eq!(
+            resolve_running_vm_dir("my-vm").unwrap(),
+            format!("{home}/microvm/vms/my-vm"),
+        );
     }
 
     #[test]

--- a/crates/mvm-cli/src/commands/vm/console.rs
+++ b/crates/mvm-cli/src/commands/vm/console.rs
@@ -62,11 +62,16 @@ fn pick_console_transport(name: &str) -> Result<Arc<dyn VsockTransport>> {
     }
     // HVF runner (WorkloadRunner / HVF) exposes the agent at
     // `<vm_state_dir>/hvf-agent.sock` and console data ports at
-    // `<vm_state_dir>/vsock/vsock-<port>.sock`. The sockets are workload-local;
-    // global dev mode is not required for a foreground `machine run -it`.
-    let hvf = DevConsoleTransport::for_vm(name);
-    if hvf.connect(mvm_guest::vsock::GUEST_AGENT_PORT).is_ok() {
-        return Ok(Arc::new(hvf));
+    // `<vm_state_dir>/vsock/vsock-<port>.sock`. Gate on the workload being
+    // accessible (non-sealed), not on an ambient
+    // `MVM_ENV=dev`, so `machine run -it` reaches its own console without an
+    // env dance. A sealed prod runner is `accessible = false` here and its
+    // agent carries no Console capability regardless.
+    if hvf_console_arm_enabled(name) {
+        let hvf = DevConsoleTransport::for_vm(name);
+        if hvf.connect(mvm_guest::vsock::GUEST_AGENT_PORT).is_ok() {
+            return Ok(Arc::new(hvf));
+        }
     }
     // Vz workloads expose the agent at `<vm_state_dir>/vsock/vsock-<port>.sock`
     // (one subdir deeper than libkrun); without this probe `console` fell
@@ -79,6 +84,16 @@ fn pick_console_transport(name: &str) -> Result<Arc<dyn VsockTransport>> {
         return Ok(Arc::new(FirecrackerTransport::for_vm(name)?));
     }
     anyhow::bail!("no host-side console transport found for VM {name:?}")
+}
+
+/// Whether the HVF interactive console-data arm may fire for `name`. Enabled for
+/// an accessible (non-sealed) workload; a sealed prod runner's
+/// `runtime_meta.accessible` is `false` so it never routes to the console
+/// (`enforce_accessible_gate` refuses the attach up front, and the sealed agent
+/// links no Console capability). Missing/legacy metadata reads as accessible —
+/// the same backward-compat default `enforce_accessible_gate` uses.
+fn hvf_console_arm_enabled(name: &str) -> bool {
+    !matches!(mvm::vm::runtime_meta::read(name), Ok(Some(meta)) if !meta.accessible)
 }
 
 #[derive(ClapArgs, Debug, Clone)]
@@ -795,30 +810,76 @@ mod picker_hvf_tests {
             .expect("selected transport must connect to hvf-agent.sock");
     }
 
+    // A sealed workload must not route to the hvf console even with
+    // `hvf-agent.sock` present. It falls through to Vz/Firecracker, so a sealed
+    // prod runner never receives an interactive attach.
     #[test]
-    fn pick_console_transport_selects_hvf_without_global_dev_mode() {
+    fn pick_console_transport_skips_hvf_for_sealed_workload() {
         let mut env = mvm_core::util::test_env::TestEnv::new();
         let tmp = tempfile::tempdir_in("/tmp").expect("state tempdir");
         env.set("MVM_DATA_DIR", tmp.path());
-        env.set("MVM_ENV", "prod");
 
-        let name = "hvf-prod-workload";
+        let name = "hvf-sealed-workload";
         let state = mvm_core::config::vm_state_dir(name);
         std::fs::create_dir_all(&state).unwrap();
         let agent = mvm_core::config::vm_hvf_agent_socket(name);
         let _listener = UnixListener::bind(&agent).unwrap();
 
-        let transport = pick_console_transport(name)
-            .expect("picker must resolve hvf transport without global dev mode");
-        transport
-            .connect(mvm_guest::vsock::GUEST_AGENT_PORT)
-            .expect("selected transport must connect to hvf-agent.sock");
+        // Mark the image sealed.
+        mvm::vm::runtime_meta::write(
+            name,
+            &mvm::vm::runtime_meta::VmRuntimeMeta {
+                mode: mvm::vm::runtime_meta::StartModeKind::Attached,
+                accessible: false,
+                rootfs_path: None,
+            },
+        )
+        .unwrap();
+
+        match pick_console_transport(name) {
+            Err(_) => {
+                // Expected: picker fell through to FC which failed — fine.
+            }
+            Ok(transport) => {
+                assert!(
+                    transport
+                        .connect(mvm_guest::vsock::GUEST_AGENT_PORT)
+                        .is_err(),
+                    "a sealed workload must not route to the hvf agent socket"
+                );
+            }
+        }
     }
 
-    // Extend the boundary test: the picker selects the workload's OWN hvf
-    // socket — not the dev/builder VM socket — when both are present. The hvf
-    // arm probes `hvf-agent.sock` under the workload's own state dir, which is
-    // disjoint from the builder cache, so it can never cross-route.
+    // The fix: an accessible workload's console is reachable WITHOUT MVM_ENV=dev,
+    // so `machine run -it` attaches its own PTY with no env dance.
+    #[test]
+    fn pick_console_transport_selects_hvf_for_accessible_workload_without_dev_env() {
+        let mut env = mvm_core::util::test_env::TestEnv::new();
+        let tmp = tempfile::tempdir_in("/tmp").expect("state tempdir");
+        env.set("MVM_DATA_DIR", tmp.path());
+        // Deliberately NOT dev mode.
+        env.set("MVM_ENV", "prod");
+
+        let name = "hvf-accessible-workload";
+        let state = mvm_core::config::vm_state_dir(name);
+        std::fs::create_dir_all(&state).unwrap();
+        let agent = mvm_core::config::vm_hvf_agent_socket(name);
+        let _listener = UnixListener::bind(&agent).unwrap();
+        // No runtime_meta written → accessible by the backward-compat default.
+
+        let transport = pick_console_transport(name)
+            .expect("accessible workload must resolve the hvf transport");
+        transport
+            .connect(mvm_guest::vsock::GUEST_AGENT_PORT)
+            .expect("selected transport must connect to the workload agent socket");
+    }
+
+    // Extend the boundary test: even with MVM_ENV=dev (which enables the
+    // hvf arm), the picker selects the workload's OWN hvf socket — not
+    // the dev/builder VM socket — when both are present. The hvf arm probes
+    // `hvf-agent.sock` under the workload's own state dir, which is disjoint
+    // from the builder cache, so it can never cross-route.
     #[cfg(feature = "builder-vm")]
     #[test]
     fn pick_console_transport_hvf_uses_workload_not_dev_socket() {

--- a/crates/mvm-cli/src/exec.rs
+++ b/crates/mvm-cli/src/exec.rs
@@ -1990,16 +1990,53 @@ mod tests {
 
     #[test]
     fn staging_cleanup_skipped_without_add_dirs() {
-        assert!(!transient_run_needs_staging_cleanup(&[]));
+        let calls = std::sync::Arc::new(std::sync::atomic::AtomicUsize::new(0));
+        let calls_for_handler = calls.clone();
+        let _handler = mvm::shell_mock::install_handler(move |_script: &str| {
+            calls_for_handler.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
+            mvm::shell_mock::MockResponse {
+                exit_code: 0,
+                stdout: String::new(),
+            }
+        });
+
+        clean_add_dir_staging(&[], "/tmp/mvm-staging");
+
+        assert_eq!(
+            calls.load(std::sync::atomic::Ordering::SeqCst),
+            0,
+            "no --add-dir means no builder cleanup command"
+        );
     }
 
     #[test]
     fn staging_cleanup_enabled_with_add_dirs() {
+        let scripts = std::sync::Arc::new(std::sync::Mutex::new(Vec::<String>::new()));
+        let scripts_for_handler = scripts.clone();
+        let _handler = mvm::shell_mock::install_handler(move |script: &str| {
+            scripts_for_handler
+                .lock()
+                .expect("mutex must not be poisoned")
+                .push(script.to_string());
+            mvm::shell_mock::MockResponse {
+                exit_code: 0,
+                stdout: String::new(),
+            }
+        });
         let add_dir = AddDir {
             host_path: "/tmp/host".to_string(),
             guest_path: "/mnt/host".to_string(),
             read_only: true,
         };
-        assert!(transient_run_needs_staging_cleanup(&[add_dir]));
+
+        clean_add_dir_staging(&[add_dir], "/tmp/mvm-staging");
+
+        let scripts = scripts.lock().expect("mutex must not be poisoned");
+        assert_eq!(scripts.len(), 1, "one cleanup command must be issued");
+        assert!(
+            scripts[0].contains("rm -rf /tmp/mvm-staging"),
+            "cleanup command must remove the staging directory: {}",
+            scripts[0]
+        );
     }
 }

--- a/crates/mvm-cli/src/exec.rs
+++ b/crates/mvm-cli/src/exec.rs
@@ -467,8 +467,17 @@ pub fn transient_run_dev_console(pty: bool, verity_path: Option<&str>) -> bool {
     pty && verity_path.is_none()
 }
 
-fn transient_run_needs_staging_cleanup(add_dirs: &[AddDir]) -> bool {
-    !add_dirs.is_empty()
+/// Remove the transient `--add-dir` staging dir, but only when extras were
+/// actually staged. `build_dir_image_ro` builds those ext4 images inside the
+/// builder Linux env (it needs `mkfs`/`mount`), so cleanup routes back through
+/// that env — and a run with no `--add-dir` never created the dir. Skipping the
+/// call there keeps a plain OCI/workload run from waking a builder VM just to
+/// `rm -rf` a path that does not exist.
+fn clean_add_dir_staging(add_dirs: &[AddDir], staging_dir: &str) {
+    if add_dirs.is_empty() {
+        return;
+    }
+    let _ = mvm::shell::run_in_vm(&format!("rm -rf {staging_dir}"));
 }
 
 /// Decide whether snapshot restore is safe for this request.
@@ -819,9 +828,7 @@ fn run_inner(
     if !booted {
         ui::info(&format!("Booting transient VM '{vm_name}'..."));
         if let Err(e) = backend.start(&start_config) {
-            if transient_run_needs_staging_cleanup(&req.add_dirs) {
-                let _ = mvm::shell::run_in_vm(&format!("rm -rf {staging_dir}"));
-            }
+            clean_add_dir_staging(&req.add_dirs, &staging_dir);
             return Err(e).context("starting transient microVM");
         }
     }
@@ -874,9 +881,7 @@ fn run_inner(
         }
     }
 
-    if transient_run_needs_staging_cleanup(&req.add_dirs) {
-        let _ = mvm::shell::run_in_vm(&format!("rm -rf {staging_dir}"));
-    }
+    clean_add_dir_staging(&req.add_dirs, &staging_dir);
     let t_torn_down = timing.then(std::time::Instant::now);
 
     // Emit the phase breakdown when every seam was marked (i.e. timing was

--- a/crates/mvm-client/src/local.rs
+++ b/crates/mvm-client/src/local.rs
@@ -202,29 +202,12 @@ fn unpack_one_layer(layer: &LayerDescriptor, bytes: &[u8], dest: &Path) -> Resul
 }
 
 /// Probe the dm-verity sidecars the pure materializer writes beside the image
-/// (`rootfs.verity` + `rootfs.roothash`), reading them from the host filesystem
-/// directly. Returns `(verity_path, roothash)` when both are present and the
-/// hash is well-formed (64-hex); `(None, None)` for an unverified image.
-///
-/// Distinct from `mvm_backend::probe_verity_sidecar`, which reads the sidecars
-/// from inside a builder VM — wrong for a host-materialized rootfs.
+/// (`rootfs.verity` + `rootfs.roothash`) from the host filesystem. Returns
+/// `(verity_path, roothash)` when both are present and the hash is well-formed
+/// (64-hex); `(None, None)` for an unverified image. A `&Path` adapter over
+/// `mvm_backend::microvm::probe_verity_sidecar`, which does the host-side read.
 fn host_verity_sidecars(rootfs: &Path) -> (Option<String>, Option<String>) {
-    let Some(parent) = rootfs.parent() else {
-        return (None, None);
-    };
-    let verity = parent.join("rootfs.verity");
-    let roothash_file = parent.join("rootfs.roothash");
-    if !verity.is_file() {
-        return (None, None);
-    }
-    let Ok(raw) = std::fs::read_to_string(&roothash_file) else {
-        return (None, None);
-    };
-    let hash = raw.trim().to_string();
-    if hash.len() != 64 || !hash.chars().all(|c| c.is_ascii_hexdigit()) {
-        return (None, None);
-    }
-    (Some(verity.to_string_lossy().into_owned()), Some(hash))
+    mvm_backend::microvm::probe_verity_sidecar(&rootfs.to_string_lossy())
 }
 
 #[async_trait]

--- a/crates/mvm/src/vsock_transport.rs
+++ b/crates/mvm/src/vsock_transport.rs
@@ -163,11 +163,11 @@ impl VsockTransport for VzTransport {
 ///   — same `vsock/` subdir convention the Vz supervisor uses, populated
 ///   only when `VmStartConfig.dev_console` is true.
 ///
-/// The **agent-RPC** use (via [`for_vm`]) is not dev-gated — every
+/// The **agent-RPC** use (via [`for_vm`]) is not gated — every
 /// `machine run -- <cmd>` / `machine exec` / `invoke` reaches the agent this
-/// way, on prod runners too. The **console-data** use is dev-only:
-/// `pick_console_transport` selects it for console ports only when
-/// `is_dev_mode()` is set, so a sealed production runner cannot receive an
+/// way, on prod runners too. The **console-data** use is gated:
+/// `pick_console_transport` selects it for console ports only for an accessible
+/// (non-sealed) workload, so a sealed production runner cannot receive an
 /// interactive attach over this path.
 pub struct DevConsoleTransport {
     state_dir: PathBuf,


### PR DESCRIPTION
On macOS-26 (HVF default), running an OCI workload from an **interactive terminal** silently rerouted into the Vz dev/builder VM and hung. Several independent root causes, all stale nested-model (`run_in_vm` = the dev VM) artifacts now that every VMM file-serves disks from host files.

## Commit 1 — `machine run --image … -- <cmd>` no longer wakes the dev VM

`machine run --image alpine -- ls` from a TTY hung booting the dev VM (on a stale dev-image cache, a full multi-minute rebuild); piped runs worked, masking it. The transient run did host-side FS work via `run_in_vm`, which routes into the dev VM's guest agent (auto-started only on a TTY).

- `probe_verity_sidecar` shelled into the VM to stat/read the verity sidecars. Read the **host filesystem** directly. Also fixes verity detection, which previously always missed real host sidecars.
- The `--add-dir` staging cleanup (`rm -rf` via `run_in_vm`) ran unconditionally; skip it when nothing was staged.
- Collapsed `mvm-client`'s duplicate `host_verity_sidecars` (a prior workaround-fork) onto the now-host-side backend function.

## Commit 2 — wire the HVF interactive console for `machine run -it`

- Transport selection gated the HVF console arm on `is_dev_mode()` (`MVM_ENV=dev`), which `machine run -it` never sets — so the picker fell through to the Firecracker fallback and mis-routed to the dev VM. Gate on the workload being **accessible** (non-sealed) instead — the claim-15 boundary. Sealed prod runners still can't attach.
- The HVF backend hardcoded `console_data_sockets: vec![]`, so the supervisor bound no console data ports. Populate them from `config.dev_console`, reusing the workload-runner mapping.

## Commit 3 — `-it` cold boot no longer floods / wakes the dev VM

Cold `machine run -it` flooded builder-VM errors and raced the shell. `wait_for_agent` polls `vsock_transport::for_vm`, whose Firecracker fallback calls `resolve_running_vm_dir`, which `echo`ed `~/microvm/vms` **inside the VM** just to expand `~` — waking a background `dev up` builder before the hvf agent bound. Expand `~/microvm/vms` on the host instead (identical to the old echo on Linux, where the in-VM env is the host).

## Verified end-to-end

- `machine run --image alpine -- ls` under a pty: boots HVF, runs `ls`, ~7s, never touches the dev VM.
- `machine run -it --image alpine -- /bin/sh` (cold **and** warm): reaches a shell reliably, `uname` → `Linux`, dev VM never touched.

## Tests

New unit coverage: `probe_verity_sidecar` (host-fs read, malformed-hash reject), `resolve_running_vm_dir` (host-side expansion), `hvf_console_data_sockets` (paths match `DevConsoleTransport`, empty for sealed), `pick_console_transport` (fires for accessible workload without dev env, skips sealed). clippy `-D warnings` + fmt clean.