### PR TITLE
fix(hvf): stop reconcile from reaping live HVF machines (+ supervisor-path fallback)

### DIFF
--- a/crates/mvm-backend/src/hvf_backend.rs
+++ b/crates/mvm-backend/src/hvf_backend.rs
@@ -120,9 +120,26 @@ pub(crate) fn resolve_supervisor_path() -> Result<PathBuf> {
             return Ok(candidate);
         }
     }
+    // Workspace `target/{release,debug}` fallback, mirroring the substitution
+    // endpoint resolver: a source checkout that builds the root `mvmctl` bin
+    // without also building this per-VM helper still resolves it, instead of
+    // hard-failing on one binary while silently reaching for a stale copy of
+    // the other.
+    let manifest_dir = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
+    if let Some(workspace_root) = manifest_dir.parent().and_then(Path::parent) {
+        for variant in ["release", "debug"] {
+            let candidate = workspace_root
+                .join("target")
+                .join(variant)
+                .join("mvm-hvf-supervisor");
+            if candidate.is_file() {
+                return Ok(candidate);
+            }
+        }
+    }
     bail!(
-        "mvm-hvf-supervisor binary not found (looked at $MVM_HVF_SUPERVISOR_PATH \
-         and alongside the current exe)"
+        "mvm-hvf-supervisor binary not found (looked at $MVM_HVF_SUPERVISOR_PATH, \
+         alongside the current exe, and <workspace>/target/{{release,debug}})"
     )
 }
 

--- a/crates/mvm/src/vm/reconcile.rs
+++ b/crates/mvm/src/vm/reconcile.rs
@@ -211,10 +211,11 @@ pub fn sweep(
 }
 
 /// Supervisor pid-file names a per-VM state dir may carry. `pid` is the
-/// Apple-Container dev-VM owner file; `libkrun.pid` / `vz.pid` are the
-/// workload-supervisor files. The first one that exists and points at a
-/// live process marks the dir as having a live owner.
-const PID_FILE_NAMES: &[&str] = &["libkrun.pid", "vz.pid", "pid"];
+/// Apple-Container dev-VM owner file; `libkrun.pid` / `vz.pid` / `hvf.pid` are
+/// the workload-supervisor files (one per backend). The first one that exists
+/// and points at a live process marks the dir as having a live owner. HVF must
+/// be listed here or convergence reaps every running HVF machine's state dir.
+const PID_FILE_NAMES: &[&str] = &["libkrun.pid", "vz.pid", "hvf.pid", "pid"];
 
 /// `kill(pid, 0)` existence probe — delivers no signal, just checks the
 /// process is alive. The cheap half of the live-vs-orphan discrimination
@@ -729,6 +730,35 @@ mod tests {
         let known: BTreeSet<String> = ["registered".to_string()].into();
         let orphans = view.orphan_dirs(&known);
         assert_eq!(orphans, vec!["orphan".to_string()]);
+    }
+
+    #[test]
+    fn fs_view_recognizes_live_hvf_supervisor_pid() {
+        // Regression: the HVF backend records liveness in `hvf.pid`. The
+        // reconciler must treat that as a live owner — otherwise every CLI
+        // entry (which runs convergence) reaps a running HVF machine's state
+        // dir, so `machine ls` reports it stopped and `machine shell` can't
+        // find its agent socket.
+        let tmp = tempfile::tempdir().unwrap();
+        let root = tmp.path();
+        let dir = root.join("hvf-vm");
+        std::fs::create_dir_all(&dir).unwrap();
+        // Only hvf.pid present (no libkrun.pid / vz.pid), pointing at us.
+        std::fs::write(dir.join("hvf.pid"), std::process::id().to_string()).unwrap();
+
+        let view = FsRuntimeView::new(root);
+        let dir_str = dir.to_string_lossy().into_owned();
+        let reg = RegisterParams::minimal("hvf-vm", &dir_str, "default");
+        let mut registry = VmNameRegistry::default();
+        registry.register_with_metadata(reg).unwrap();
+        assert!(
+            view.process_alive(registry.lookup("hvf-vm").unwrap()),
+            "a live hvf.pid must count as a live supervisor"
+        );
+        assert!(
+            view.orphan_dirs(&BTreeSet::new()).is_empty(),
+            "a dir owned by a live hvf supervisor must not be reaped as an orphan"
+        );
     }
 
     #[test]


### PR DESCRIPTION
## Summary

Rebased onto latest `main`. The console-transport wiring this branch originally carried (HVF `console_data_sockets` + de-gating `pick_console_transport`) landed independently in **#1516**, so those commits were dropped as duplicates. What remains are two fixes still missing from `main`:

### 1. Reconcile no longer reaps live HVF machines
The reconcile-on-entry convergence, which runs on every CLI invocation, recognized a live supervisor only via `libkrun.pid` / `vz.pid` / `pid`. The HVF backend records liveness in `hvf.pid`, which was absent from that list, so it classified every running HVF machine as a dead orphan and `remove_dir_all`'d its state dir + dropped its registry record — `machine ls` reporting a just-started machine as stopped, and orphan supervisors left behind. Added `hvf.pid` to `PID_FILE_NAMES`.

This is complementary to #1516: that PR fixed the console picker/sockets, but without this a persistent HVF machine is still torn down out from under the user on the next CLI call.

### 2. Supervisor-path resolver fallback
`resolve_supervisor_path` only checked `$MVM_HVF_SUPERVISOR_PATH` and the dir beside the current exe, while the substitution-endpoint resolver also falls back to `<workspace>/target/{release,debug}`. That asymmetry meant a source checkout which built `mvmctl` without the per-VM `mvm-hvf-supervisor` hard-failed on the supervisor while the endpoint resolver silently reached for a stale copy — two different errors from one missing-binary cause. Mirror the endpoint resolver's fallback.

## Verification
- Unit tests: reconcile recognizes a live `hvf.pid` (`fs_view_recognizes_live_hvf_supervisor_pid`); existing hvf_backend + reconcile suites pass on the rebased base (including #1516's `console_data_sockets_*` / `terminate_pid_reaps`).
- `cargo fmt --all --check` clean.
- Originally verified live on a macOS-26 HVF host: with the reconcile fix, repeated `machine ls` no longer reaps the running machine and an interactive `machine shell` attaches over vsock end-to-end.