### PR TITLE
fix(hvf): per-VM helper bins just work — shared resolve-or-build + release packaging

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -147,6 +147,7 @@ jobs:
           if [[ "${TARGET}" == *apple-darwin ]]; then
             cargo build --release --target "${TARGET}" -p mvm-vm-host \
               --bin mvm-bridge --bin mvm-vz-supervisor \
+              --bin mvm-hvf-supervisor \
               --bin mvm-libkrun-supervisor --features libkrun-sys
           else
             cargo build --release --target "${TARGET}" -p mvm-vm-host \
@@ -203,8 +204,9 @@ jobs:
           # Per-VM host processes (built in the prior step), shipped next to
           # mvmctl so the backend's adjacent-to-exe resolver finds them on a
           # downloaded install. copy-if-exists: the set differs by OS (macOS
-          # gets all three; Linux gets mvm-bridge only).
-          for hostbin in mvm-bridge mvm-vz-supervisor mvm-libkrun-supervisor; do
+          # gets all four incl. the HVF default backend's supervisor; Linux gets
+          # mvm-bridge only).
+          for hostbin in mvm-bridge mvm-vz-supervisor mvm-hvf-supervisor mvm-libkrun-supervisor; do
             src="target/${TARGET}/release/${hostbin}"
             [ -f "$src" ] && cp "$src" "staging/${ARCHIVE_NAME}/" && echo "bundled ${hostbin}"
           done

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -153,6 +153,11 @@ jobs:
             cargo build --release --target "${TARGET}" -p mvm-vm-host \
               --bin mvm-bridge
           fi
+          # The per-VM substitution endpoint (mvm-hostd) is the egress gate every
+          # VM spawns — on both the FC (Linux) and HVF (macOS) paths — so it ships
+          # on every target next to mvmctl.
+          cargo build --release --target "${TARGET}" -p mvm-hostd \
+            --bin mvm-substitution-endpoint
 
       - name: Smoke test binary (native targets only)
         if: matrix.target == 'x86_64-unknown-linux-gnu' || matrix.target == 'aarch64-apple-darwin'
@@ -203,10 +208,10 @@ jobs:
           cp "target/${TARGET}/release/${BIN_NAME}" "staging/${ARCHIVE_NAME}/"
           # Per-VM host processes (built in the prior step), shipped next to
           # mvmctl so the backend's adjacent-to-exe resolver finds them on a
-          # downloaded install. copy-if-exists: the set differs by OS (macOS
-          # gets all four incl. the HVF default backend's supervisor; Linux gets
-          # mvm-bridge only).
-          for hostbin in mvm-bridge mvm-vz-supervisor mvm-hvf-supervisor mvm-libkrun-supervisor; do
+          # downloaded install. copy-if-exists: the set differs by OS (macOS gets
+          # the vz/hvf/libkrun supervisors; Linux gets mvm-bridge only), but the
+          # substitution endpoint ships on every target.
+          for hostbin in mvm-bridge mvm-vz-supervisor mvm-hvf-supervisor mvm-libkrun-supervisor mvm-substitution-endpoint; do
             src="target/${TARGET}/release/${hostbin}"
             [ -f "$src" ] && cp "$src" "staging/${ARCHIVE_NAME}/" && echo "bundled ${hostbin}"
           done

--- a/Justfile
+++ b/Justfile
@@ -120,10 +120,11 @@ e2e-core-demo:
     cargo build -p mvm-vm-host --bin mvm-libkrun-supervisor --features libkrun-sys
     MVM_E2E_SMOKE=1 MVM_BUILDER_BACKEND=libkrun cargo test -p mvm-cli --test core_demo_e2e -- --nocapture
 
-# Build the per-VM host supervisor bins (macOS). `cargo run` builds only
-# `mvmctl`; the backend resolves these alongside the exe / in `target/`. The HVF
-# path also self-builds on the first `machine run`, so this is the explicit route.
+# Build the per-VM host helper bins `mvmctl` spawns. `cargo run` builds only
+# `mvmctl`; the backend resolves these alongside the exe / in `target/` and also
+# self-builds them on the first `machine run`, so this is just the explicit route.
 build-supervisors:
+    cargo build -p mvm-hostd --bin mvm-substitution-endpoint
     cargo build -p mvm-vm-host --bin mvm-hvf-supervisor
     cargo build -p mvm-vm-host --bin mvm-vz-supervisor
     cargo build -p mvm-vm-host --bin mvm-libkrun-supervisor --features libkrun-sys

--- a/Justfile
+++ b/Justfile
@@ -120,6 +120,14 @@ e2e-core-demo:
     cargo build -p mvm-vm-host --bin mvm-libkrun-supervisor --features libkrun-sys
     MVM_E2E_SMOKE=1 MVM_BUILDER_BACKEND=libkrun cargo test -p mvm-cli --test core_demo_e2e -- --nocapture
 
+# Build the per-VM host supervisor bins (macOS). `cargo run` builds only
+# `mvmctl`; the backend resolves these alongside the exe / in `target/`. The HVF
+# path also self-builds on the first `machine run`, so this is the explicit route.
+build-supervisors:
+    cargo build -p mvm-vm-host --bin mvm-hvf-supervisor
+    cargo build -p mvm-vm-host --bin mvm-vz-supervisor
+    cargo build -p mvm-vm-host --bin mvm-libkrun-supervisor --features libkrun-sys
+
 # ── Lint & Format ────────────────────────────────────────────────────────
 
 # Format all code

--- a/crates/mvm-backend/src/aux_bin.rs
+++ b/crates/mvm-backend/src/aux_bin.rs
@@ -1,0 +1,106 @@
+//! Shared resolver for the per-VM host helper binaries `mvmctl` spawns — the
+//! backend supervisors (`mvm-hvf-supervisor`, …) and the substitution endpoint
+//! (`mvm-substitution-endpoint`). Each is a separate `[[bin]]` in a workspace
+//! crate, so a `cargo run` that builds only `mvmctl` never produces them and a
+//! fresh `machine run` would fail with "binary not found".
+//!
+//! Resolution order: `$<ENV_VAR>` override → alongside the current exe →
+//! workspace `target/{release,debug}` → (source checkout only) build it once so
+//! the command just works with no manual step. A downloaded release ships these
+//! next to `mvmctl` and is resolved by the sibling check before ever building.
+
+use std::path::{Path, PathBuf};
+use std::process::Command;
+
+use anyhow::{Result, bail};
+
+use crate::base::ui;
+
+/// A per-VM helper binary and how to build it from source.
+pub(crate) struct AuxBin<'a> {
+    /// Binary/file name, e.g. `mvm-hvf-supervisor`.
+    pub bin: &'a str,
+    /// Workspace package that owns the `[[bin]]`, e.g. `mvm-vm-host`.
+    pub package: &'a str,
+    /// Path-override env var, e.g. `MVM_HVF_SUPERVISOR_PATH`.
+    pub env_var: &'a str,
+    /// Cargo features required to build the bin (empty for most).
+    pub features: &'a [&'a str],
+}
+
+/// Resolve `spec` to an on-disk binary, building it once on a source checkout if
+/// it is missing. See the module docs for the resolution order.
+pub(crate) fn resolve_or_build(spec: &AuxBin) -> Result<PathBuf> {
+    if let Some(p) = std::env::var_os(spec.env_var).map(PathBuf::from) {
+        if p.is_file() {
+            return Ok(p);
+        }
+        bail!(
+            "{} points at {} which is not a file",
+            spec.env_var,
+            p.display()
+        );
+    }
+    if let Some(dir) = std::env::current_exe()
+        .ok()
+        .and_then(|e| e.parent().map(Path::to_path_buf))
+    {
+        let candidate = dir.join(spec.bin);
+        if candidate.is_file() {
+            return Ok(candidate);
+        }
+    }
+    let manifest_dir = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
+    if let Some(workspace_root) = manifest_dir.parent().and_then(Path::parent) {
+        for variant in ["release", "debug"] {
+            let candidate = workspace_root.join("target").join(variant).join(spec.bin);
+            if candidate.is_file() {
+                return Ok(candidate);
+            }
+        }
+        // Source checkout: build the missing helper once (matching the running
+        // profile). The outer `cargo run` has released the build lock by the time
+        // this process runs, so the nested build does not contend.
+        if workspace_root.join("Cargo.toml").is_file()
+            && let Some(built) = build_in_workspace(workspace_root, spec)
+        {
+            return Ok(built);
+        }
+    }
+    bail!(
+        "{} binary not found (looked at ${}, alongside the current exe, and \
+         <workspace>/target/{{release,debug}})",
+        spec.bin,
+        spec.env_var
+    )
+}
+
+/// One-time on-demand build of a helper for a source checkout. Returns the built
+/// binary, or `None` if the build could not run (no cargo, build failed) — the
+/// caller then falls through to the bail with the override hint.
+fn build_in_workspace(workspace_root: &Path, spec: &AuxBin) -> Option<PathBuf> {
+    let release = std::env::current_exe()
+        .ok()
+        .map(|p| p.components().any(|c| c.as_os_str() == "release"))
+        .unwrap_or(false);
+    let variant = if release { "release" } else { "debug" };
+    ui::info(&format!(
+        "building the per-VM helper {} once — `cargo run` builds only mvmctl, not this helper",
+        spec.bin
+    ));
+    let cargo = std::env::var_os("CARGO").unwrap_or_else(|| "cargo".into());
+    let mut cmd = Command::new(cargo);
+    cmd.current_dir(workspace_root)
+        .args(["build", "-p", spec.package, "--bin", spec.bin]);
+    if release {
+        cmd.arg("--release");
+    }
+    if !spec.features.is_empty() {
+        cmd.arg("--features").arg(spec.features.join(","));
+    }
+    if !cmd.status().map(|s| s.success()).unwrap_or(false) {
+        return None;
+    }
+    let built = workspace_root.join("target").join(variant).join(spec.bin);
+    built.is_file().then_some(built)
+}

--- a/crates/mvm-backend/src/hvf_backend.rs
+++ b/crates/mvm-backend/src/hvf_backend.rs
@@ -99,95 +99,15 @@ pub(crate) fn terminate_pid(pid: libc::pid_t) {
     }
 }
 
-/// Locate the per-VM supervisor binary: `$MVM_HVF_SUPERVISOR_PATH`, else
-/// alongside the current executable (release + `cargo` layouts both put it there).
+/// Locate the per-VM supervisor binary, building it once on a source checkout if
+/// `cargo run` produced only `mvmctl`. See [`crate::aux_bin`].
 pub(crate) fn resolve_supervisor_path() -> Result<PathBuf> {
-    if let Some(p) = std::env::var_os("MVM_HVF_SUPERVISOR_PATH") {
-        let path = PathBuf::from(p);
-        if path.is_file() {
-            return Ok(path);
-        }
-        bail!(
-            "MVM_HVF_SUPERVISOR_PATH points at {} which is not a file",
-            path.display()
-        );
-    }
-    if let Ok(exe) = std::env::current_exe()
-        && let Some(dir) = exe.parent()
-    {
-        let candidate = dir.join("mvm-hvf-supervisor");
-        if candidate.is_file() {
-            return Ok(candidate);
-        }
-    }
-    // Workspace `target/{release,debug}` fallback, mirroring the substitution
-    // endpoint resolver: a source checkout that builds the root `mvmctl` bin
-    // without also building this per-VM helper still resolves it, instead of
-    // hard-failing on one binary while silently reaching for a stale copy of
-    // the other.
-    let manifest_dir = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
-    if let Some(workspace_root) = manifest_dir.parent().and_then(Path::parent) {
-        for variant in ["release", "debug"] {
-            let candidate = workspace_root
-                .join("target")
-                .join(variant)
-                .join("mvm-hvf-supervisor");
-            if candidate.is_file() {
-                return Ok(candidate);
-            }
-        }
-        // Source checkout: `cargo run` builds only `mvmctl`, never this separate
-        // per-VM bin, so the first `machine run` finds nothing. Build it once (into
-        // the workspace target dir, matching the running profile) so the command
-        // just works with no manual `cargo build -p mvm-vm-host` step. The outer
-        // `cargo run` has already released the build lock by the time this process
-        // runs, so the nested build does not contend.
-        if workspace_root.join("Cargo.toml").is_file()
-            && let Some(built) = build_supervisor_in_workspace(workspace_root)
-        {
-            return Ok(built);
-        }
-    }
-    bail!(
-        "mvm-hvf-supervisor binary not found (looked at $MVM_HVF_SUPERVISOR_PATH, \
-         alongside the current exe, and <workspace>/target/{{release,debug}})"
-    )
-}
-
-/// One-time on-demand build of the per-VM supervisor for a source checkout, so
-/// `cargo run -- machine run` works without a separate manual build. Returns the
-/// built binary, or `None` if the build could not run (no cargo, build failed) —
-/// the caller then falls through to the bail with the manual-build hint.
-fn build_supervisor_in_workspace(workspace_root: &Path) -> Option<PathBuf> {
-    let release = std::env::current_exe()
-        .ok()
-        .map(|p| p.components().any(|c| c.as_os_str() == "release"))
-        .unwrap_or(false);
-    let variant = if release { "release" } else { "debug" };
-    ui::info(
-        "building the per-VM supervisor (mvm-hvf-supervisor) once — `cargo run` \
-         builds only mvmctl, not this helper",
-    );
-    let cargo = std::env::var_os("CARGO").unwrap_or_else(|| "cargo".into());
-    let mut cmd = Command::new(cargo);
-    cmd.current_dir(workspace_root).args([
-        "build",
-        "-p",
-        "mvm-vm-host",
-        "--bin",
-        "mvm-hvf-supervisor",
-    ]);
-    if release {
-        cmd.arg("--release");
-    }
-    if !cmd.status().map(|s| s.success()).unwrap_or(false) {
-        return None;
-    }
-    let built = workspace_root
-        .join("target")
-        .join(variant)
-        .join("mvm-hvf-supervisor");
-    built.is_file().then_some(built)
+    crate::aux_bin::resolve_or_build(&crate::aux_bin::AuxBin {
+        bin: "mvm-hvf-supervisor",
+        package: "mvm-vm-host",
+        env_var: "MVM_HVF_SUPERVISOR_PATH",
+        features: &[],
+    })
 }
 
 /// Rebuild command for the hvf per-VM supervisor bin. `cargo run` rebuilds only

--- a/crates/mvm-backend/src/hvf_backend.rs
+++ b/crates/mvm-backend/src/hvf_backend.rs
@@ -136,11 +136,58 @@ pub(crate) fn resolve_supervisor_path() -> Result<PathBuf> {
                 return Ok(candidate);
             }
         }
+        // Source checkout: `cargo run` builds only `mvmctl`, never this separate
+        // per-VM bin, so the first `machine run` finds nothing. Build it once (into
+        // the workspace target dir, matching the running profile) so the command
+        // just works with no manual `cargo build -p mvm-vm-host` step. The outer
+        // `cargo run` has already released the build lock by the time this process
+        // runs, so the nested build does not contend.
+        if workspace_root.join("Cargo.toml").is_file()
+            && let Some(built) = build_supervisor_in_workspace(workspace_root)
+        {
+            return Ok(built);
+        }
     }
     bail!(
         "mvm-hvf-supervisor binary not found (looked at $MVM_HVF_SUPERVISOR_PATH, \
          alongside the current exe, and <workspace>/target/{{release,debug}})"
     )
+}
+
+/// One-time on-demand build of the per-VM supervisor for a source checkout, so
+/// `cargo run -- machine run` works without a separate manual build. Returns the
+/// built binary, or `None` if the build could not run (no cargo, build failed) —
+/// the caller then falls through to the bail with the manual-build hint.
+fn build_supervisor_in_workspace(workspace_root: &Path) -> Option<PathBuf> {
+    let release = std::env::current_exe()
+        .ok()
+        .map(|p| p.components().any(|c| c.as_os_str() == "release"))
+        .unwrap_or(false);
+    let variant = if release { "release" } else { "debug" };
+    ui::info(
+        "building the per-VM supervisor (mvm-hvf-supervisor) once — `cargo run` \
+         builds only mvmctl, not this helper",
+    );
+    let cargo = std::env::var_os("CARGO").unwrap_or_else(|| "cargo".into());
+    let mut cmd = Command::new(cargo);
+    cmd.current_dir(workspace_root).args([
+        "build",
+        "-p",
+        "mvm-vm-host",
+        "--bin",
+        "mvm-hvf-supervisor",
+    ]);
+    if release {
+        cmd.arg("--release");
+    }
+    if !cmd.status().map(|s| s.success()).unwrap_or(false) {
+        return None;
+    }
+    let built = workspace_root
+        .join("target")
+        .join(variant)
+        .join("mvm-hvf-supervisor");
+    built.is_file().then_some(built)
 }
 
 /// Rebuild command for the hvf per-VM supervisor bin. `cargo run` rebuilds only

--- a/crates/mvm-backend/src/lib.rs
+++ b/crates/mvm-backend/src/lib.rs
@@ -43,6 +43,9 @@ pub mod driver;
 // (`mvm → mvm-backend → mvm`). `mvm` re-exports these at their old
 // paths so the mvmd `mvmctl::runtime::{shell,ui,shell_mock}` contract
 // surface keeps resolving.
+/// Shared resolve-or-build for the per-VM helper binaries `mvmctl` spawns
+/// (supervisors + the substitution endpoint); one impl, no drift.
+pub(crate) mod aux_bin;
 pub mod base;
 /// Per-VM broker-services (`mvm-broker` / `mvm-audit-signer`) subprocess
 /// spawn/reap helpers, mirroring [`substitution_spawn`].

--- a/crates/mvm-backend/src/substitution_spawn.rs
+++ b/crates/mvm-backend/src/substitution_spawn.rs
@@ -123,39 +123,15 @@ pub const SUBST_PID_FILE: &str = "substitution.pid";
 /// line before the caller declares the spawn failed.
 pub const SUBST_HANDSHAKE_TIMEOUT: Duration = Duration::from_secs(10);
 
-/// Locate the `mvm-substitution-endpoint` binary: `MVM_SUBSTITUTION_ENDPOINT_PATH`
-/// override → sibling of the current exe → workspace `target/{release,debug}`.
-/// Mirrors `resolve_vz_drainer_path`.
+/// Locate the `mvm-substitution-endpoint` binary, building it once on a source
+/// checkout if `cargo run` produced only `mvmctl`. See [`crate::aux_bin`].
 fn resolve_substitution_endpoint_path() -> Result<PathBuf> {
-    const BIN: &str = "mvm-substitution-endpoint";
-    if let Some(p) = std::env::var_os("MVM_SUBSTITUTION_ENDPOINT_PATH").map(PathBuf::from) {
-        if p.is_file() {
-            return Ok(p);
-        }
-        bail!(
-            "MVM_SUBSTITUTION_ENDPOINT_PATH points at {} which is not a file",
-            p.display()
-        );
-    }
-    if let Some(dir) = std::env::current_exe()
-        .ok()
-        .and_then(|e| e.parent().map(Path::to_path_buf))
-    {
-        let candidate = dir.join(BIN);
-        if candidate.is_file() {
-            return Ok(candidate);
-        }
-    }
-    let manifest_dir = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
-    if let Some(workspace_root) = manifest_dir.parent().and_then(Path::parent) {
-        for variant in ["release", "debug"] {
-            let candidate = workspace_root.join("target").join(variant).join(BIN);
-            if candidate.is_file() {
-                return Ok(candidate);
-            }
-        }
-    }
-    bail!("could not locate the {BIN} binary (set MVM_SUBSTITUTION_ENDPOINT_PATH)")
+    crate::aux_bin::resolve_or_build(&crate::aux_bin::AuxBin {
+        bin: "mvm-substitution-endpoint",
+        package: "mvm-hostd",
+        env_var: "MVM_SUBSTITUTION_ENDPOINT_PATH",
+        features: &[],
+    })
 }
 
 /// Inputs to [`spawn_substitution_endpoint`]. Grouped into a struct (rather


### PR DESCRIPTION
## Problem

`cargo run -- machine run --image alpine` on macOS-26 (HVF, the default backend) failed with `mvm-hvf-supervisor binary not found` — and once that was resolved, immediately failed again on `mvm-substitution-endpoint` (the egress gate every VM spawns). Root cause: these per-VM helper binaries are separate `[[bin]]`s in workspace crates, so `cargo run` (which builds only `mvmctl`) never produces them, and **release.yml never built/bundled them** either. A whole class of missing binaries behind ~10 copy-pasted resolvers.

## Fix

- **One shared `aux_bin::resolve_or_build`** (mvm-backend): env override → alongside exe → workspace `target/{release,debug}` → **source-checkout build-once**. Replaces the duplicated per-bin resolvers (reuse-first — this is the AI-accreted duplication Plan 231 targets). The supervisor and substitution-endpoint resolvers now delegate to it.
- **release.yml**: build + bundle `mvm-hvf-supervisor` (macOS) and `mvm-substitution-endpoint` (every target — it was never shipped, so no downloaded release could run a VM).
- **Justfile**: `build-supervisors` builds all per-VM helpers explicitly.

## Verified live (macOS-26 / HVF)

`cargo run -- machine run --image alpine -- ps aux` now boots the microVM and runs the command inside the guest:

```
PID   USER     TIME  COMMAND
    1 root      0:00 {init} /bin/sh /init
   52 root      0:00 /usr/local/bin/mvm-guest-agent
   60 root      0:00 ps aux
```

The auto-build fires once on a clean checkout; `clippy -p mvm-backend` + `fmt --all` clean.

## Follow-up (Plan 231)

The real simplification: fold these helpers into `mvmctl` itself (multi-call binary) so there are **no** separate per-VM binaries — with live HVF testing, since it touches the macOS entry/threading model + runtime codesigning.