### PR TITLE
fix(machine): auto-build per-VM helper bins from a source checkout + ship hvf supervisor

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -123,6 +123,9 @@ jobs:
       #   - mvm-bridge: cross-platform external-VMM gateway/audit sidecar
       #     (Firecracker passt + vz VzIngest). Builds everywhere, no extra deps.
       #   - mvm-vz-supervisor (macOS only): the vz VMM supervisor.
+      #   - mvm-hvf-supervisor (macOS only): the HVF VMM supervisor. HVF is the
+      #     auto-detect default on macOS-26 Apple Silicon, so without this a
+      #     downloaded install on that tier can't boot any machine.
       #   - mvm-libkrun-supervisor (macOS only, and INTENTIONALLY so — not a
       #     follow-up): it has `required-features = ["libkrun-sys"]`, and the
       #     released Linux mvmctl deliberately does NOT link libkrun — the
@@ -146,7 +149,7 @@ jobs:
         run: |
           if [[ "${TARGET}" == *apple-darwin ]]; then
             cargo build --release --target "${TARGET}" -p mvm-vm-host \
-              --bin mvm-bridge --bin mvm-vz-supervisor \
+              --bin mvm-bridge --bin mvm-vz-supervisor --bin mvm-hvf-supervisor \
               --bin mvm-libkrun-supervisor --features libkrun-sys
           else
             cargo build --release --target "${TARGET}" -p mvm-vm-host \
@@ -204,7 +207,7 @@ jobs:
           # mvmctl so the backend's adjacent-to-exe resolver finds them on a
           # downloaded install. copy-if-exists: the set differs by OS (macOS
           # gets all three; Linux gets mvm-bridge only).
-          for hostbin in mvm-bridge mvm-vz-supervisor mvm-libkrun-supervisor; do
+          for hostbin in mvm-bridge mvm-vz-supervisor mvm-hvf-supervisor mvm-libkrun-supervisor; do
             src="target/${TARGET}/release/${hostbin}"
             [ -f "$src" ] && cp "$src" "staging/${ARCHIVE_NAME}/" && echo "bundled ${hostbin}"
           done

--- a/crates/mvm-backend/src/hvf_backend.rs
+++ b/crates/mvm-backend/src/hvf_backend.rs
@@ -99,8 +99,17 @@ pub(crate) fn terminate_pid(pid: libc::pid_t) {
     }
 }
 
+/// The per-VM supervisor bin — a separate `mvm-vm-host` target that `cargo run`
+/// never rebuilds alongside `mvmctl`.
+const HVF_SUPERVISOR: crate::supervisor_stale::AuxBin = crate::supervisor_stale::AuxBin {
+    name: "mvm-hvf-supervisor",
+    package: "mvm-vm-host",
+    extra_build_args: &[],
+};
+
 /// Locate the per-VM supervisor binary: `$MVM_HVF_SUPERVISOR_PATH`, else
-/// alongside the current executable (release + `cargo` layouts both put it there).
+/// alongside the current executable (release + `cargo` layouts both put it
+/// there), else — in a source checkout — build it on demand.
 pub(crate) fn resolve_supervisor_path() -> Result<PathBuf> {
     if let Some(p) = std::env::var_os("MVM_HVF_SUPERVISOR_PATH") {
         let path = PathBuf::from(p);
@@ -112,34 +121,28 @@ pub(crate) fn resolve_supervisor_path() -> Result<PathBuf> {
             path.display()
         );
     }
+
+    // Alongside the running executable (downloaded install + `cargo` layouts).
     if let Ok(exe) = std::env::current_exe()
         && let Some(dir) = exe.parent()
     {
-        let candidate = dir.join("mvm-hvf-supervisor");
+        let candidate = dir.join(HVF_SUPERVISOR.name);
         if candidate.is_file() {
             return Ok(candidate);
         }
     }
-    // Workspace `target/{release,debug}` fallback, mirroring the substitution
-    // endpoint resolver: a source checkout that builds the root `mvmctl` bin
-    // without also building this per-VM helper still resolves it, instead of
-    // hard-failing on one binary while silently reaching for a stale copy of
-    // the other.
-    let manifest_dir = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
-    if let Some(workspace_root) = manifest_dir.parent().and_then(Path::parent) {
-        for variant in ["release", "debug"] {
-            let candidate = workspace_root
-                .join("target")
-                .join(variant)
-                .join("mvm-hvf-supervisor");
-            if candidate.is_file() {
-                return Ok(candidate);
-            }
-        }
+
+    // Source checkout: `cargo run` built only `mvmctl`, so materialize the helper
+    // now instead of hard-failing on this one binary. `None` off a checkout, so a
+    // downloaded install falls through to the clear not-found error below.
+    if let Some(built) = HVF_SUPERVISOR.build_from_checkout() {
+        return built;
     }
+
     bail!(
-        "mvm-hvf-supervisor binary not found (looked at $MVM_HVF_SUPERVISOR_PATH, \
-         alongside the current exe, and <workspace>/target/{{release,debug}})"
+        "{} binary not found (looked at $MVM_HVF_SUPERVISOR_PATH and alongside \
+         the current exe)",
+        HVF_SUPERVISOR.name
     )
 }
 

--- a/crates/mvm-backend/src/libkrun.rs
+++ b/crates/mvm-backend/src/libkrun.rs
@@ -1066,6 +1066,11 @@ pub(crate) fn resolve_supervisor_path() -> Result<PathBuf> {
     if let Ok(path) = which::which("mvm-libkrun-supervisor") {
         return Ok(path);
     }
+    // Source checkout: `cargo run` built only `mvmctl`, so materialize the helper
+    // (its `target/<profile>/` copy or a fresh build); `None` off a checkout.
+    if let Some(built) = LIBKRUN_SUPERVISOR.build_from_checkout() {
+        return built;
+    }
     bail!(
         "mvm-libkrun-supervisor binary not found. Looked for: \
          $MVM_LIBKRUN_SUPERVISOR_PATH, alongside the current exe, and on $PATH. \
@@ -1073,6 +1078,14 @@ pub(crate) fn resolve_supervisor_path() -> Result<PathBuf> {
          or set MVM_LIBKRUN_SUPERVISOR_PATH=/abs/path/to/the/binary."
     )
 }
+
+/// The per-VM libkrun supervisor — an `mvm-vm-host` target gated on the
+/// `libkrun-sys` feature; `cargo run` does not build it alongside `mvmctl`.
+const LIBKRUN_SUPERVISOR: crate::supervisor_stale::AuxBin = crate::supervisor_stale::AuxBin {
+    name: "mvm-libkrun-supervisor",
+    package: "mvm-vm-host",
+    extra_build_args: &["--features", "libkrun-sys"],
+};
 
 fn read_pid(path: &Path) -> Option<libc::pid_t> {
     let s = std::fs::read_to_string(path).ok()?;

--- a/crates/mvm-backend/src/substitution_spawn.rs
+++ b/crates/mvm-backend/src/substitution_spawn.rs
@@ -155,8 +155,21 @@ fn resolve_substitution_endpoint_path() -> Result<PathBuf> {
             }
         }
     }
+    // Source checkout: `cargo run` built only `mvmctl`, so materialize the helper
+    // rather than hard-failing on it; `None` off a checkout (installed mvmctl).
+    if let Some(built) = SUBSTITUTION_ENDPOINT.build_from_checkout() {
+        return built;
+    }
     bail!("could not locate the {BIN} binary (set MVM_SUBSTITUTION_ENDPOINT_PATH)")
 }
+
+/// The per-VM substitution endpoint — a separate `mvm-hostd` target `cargo run`
+/// does not build alongside `mvmctl`.
+const SUBSTITUTION_ENDPOINT: crate::supervisor_stale::AuxBin = crate::supervisor_stale::AuxBin {
+    name: "mvm-substitution-endpoint",
+    package: "mvm-hostd",
+    extra_build_args: &[],
+};
 
 /// Inputs to [`spawn_substitution_endpoint`]. Grouped into a struct (rather
 /// than threading bare positional args) so the backend-shaped fields —

--- a/crates/mvm-backend/src/supervisor_stale.rs
+++ b/crates/mvm-backend/src/supervisor_stale.rs
@@ -1,20 +1,115 @@
-//! Shared "is the per-VM supervisor binary stale?" detection.
+//! Shared handling for the per-VM helper binaries mvmctl spawns at runtime
+//! (`mvm-hvf-supervisor`, `mvm-vz-supervisor`, `mvm-libkrun-supervisor`,
+//! `mvm-bridge`, `mvm-substitution-endpoint`).
 //!
-//! Every host VMM that boots its guest in a **separate** per-VM binary
-//! (`mvm-vz-supervisor`, `mvm-hvf-supervisor`, …) hits the same source-checkout
-//! trap: `cargo run -- …` rebuilds only `mvmctl`, never the supervisor bins, so
-//! after a code change the running guest silently executes the old supervisor.
-//! On the vz path that surfaces loudly (a newer `ExecutionPlan`/`SupervisorConfig`
-//! trips `deny_unknown_fields` and the supervisor exits before boot); on the hvf
-//! path a behavioural regression (e.g. an agent-bridge fix) boots fine and only
-//! shows up as an opaque downstream timeout. Both want the same mtime check.
+//! They are separate bin targets, and `cargo run -- …` rebuilds only `mvmctl`,
+//! never them — so in a source checkout each resolver's env→sibling→`target/`
+//! ladder finds nothing (a missing binary) or a stale copy (an old binary):
+//! after a code change the running guest silently executes the previous
+//! supervisor. On the vz path that surfaces loudly (a newer
+//! `ExecutionPlan`/`SupervisorConfig` trips `deny_unknown_fields`); on the hvf
+//! path it boots fine and shows up only as an opaque downstream timeout. This
+//! module centralizes both the staleness mtime check and the on-demand build
+//! that materializes a missing helper from the checkout.
 
-use std::path::Path;
+use std::path::{Path, PathBuf};
+use std::process::Command;
 use std::time::SystemTime;
+
+use anyhow::{Context, Result, bail};
+
+use crate::base::ui;
 
 /// Modified-time of `p`, or `None` when it can't be read.
 pub(crate) fn mtime_of(p: &Path) -> Option<SystemTime> {
     std::fs::metadata(p).and_then(|m| m.modified()).ok()
+}
+
+/// When `exe` is a source-checkout build (`<root>/target/<profile>/<bin>` with a
+/// `Cargo.toml` at `<root>`), return `(<root>, "<profile>")` — the context in
+/// which a per-VM helper the outer `cargo build` skipped can be materialized
+/// with a nested `cargo build`. `None` for an installed binary, so an end-user's
+/// mvmctl never shells out to cargo. The profile string doubles as the
+/// `target/<profile>/` output dir name.
+pub(crate) fn source_checkout_root_and_profile(exe: &Path) -> Option<(PathBuf, String)> {
+    let profile_dir = exe.parent()?;
+    let profile = profile_dir.file_name()?.to_str()?.to_owned();
+    let target_dir = profile_dir.parent()?;
+    if target_dir.file_name()?.to_str()? != "target" {
+        return None;
+    }
+    let root = target_dir.parent()?;
+    root.join("Cargo.toml")
+        .is_file()
+        .then(|| (root.to_path_buf(), profile))
+}
+
+/// A per-VM helper binary that `cargo run` does not build alongside `mvmctl`.
+pub(crate) struct AuxBin {
+    /// Bin/target name, e.g. `mvm-hvf-supervisor`.
+    pub name: &'static str,
+    /// Owning workspace package, e.g. `mvm-vm-host`.
+    pub package: &'static str,
+    /// Extra `cargo build` args (a `--features` pair for the libkrun bins).
+    pub extra_build_args: &'static [&'static str],
+}
+
+impl AuxBin {
+    /// Last-resort resolution: when the binary is missing from the usual places
+    /// *and* mvmctl is running from a source checkout, build it now (the same
+    /// `cargo build` a stale-hint would name) so `machine run` from a fresh
+    /// checkout works instead of failing on one un-rebuilt helper. Returns
+    /// `None` for an installed mvmctl — an end-user host never shells out to
+    /// cargo — leaving the caller to bail with its own message.
+    pub fn build_from_checkout(&self) -> Option<Result<PathBuf>> {
+        let exe = std::env::current_exe().ok()?;
+        let (root, profile) = source_checkout_root_and_profile(&exe)?;
+        let prebuilt = root.join("target").join(&profile).join(self.name);
+        if prebuilt.is_file() {
+            return Some(Ok(prebuilt));
+        }
+        Some(self.build(&root, &profile))
+    }
+
+    /// Run `cargo build -p <package> --bin <name>` for `profile` in the checkout
+    /// root and return the built binary's path. Safe to call from the running
+    /// `mvmctl`: cargo releases the workspace build lock before the `run` phase,
+    /// so this nested build does not deadlock the outer `cargo run`.
+    fn build(&self, workspace_root: &Path, profile: &str) -> Result<PathBuf> {
+        ui::info(&format!(
+            "Building {} (one-time — `cargo run` builds only mvmctl)…",
+            self.name
+        ));
+        let cargo = std::env::var_os("CARGO").unwrap_or_else(|| "cargo".into());
+        let mut cmd = Command::new(cargo);
+        cmd.current_dir(workspace_root)
+            .args(["build", "-p", self.package, "--bin", self.name])
+            .args(self.extra_build_args);
+        // The `target/<profile>/` dir name maps back to the build flag.
+        match profile {
+            "debug" => {}
+            "release" => {
+                cmd.arg("--release");
+            }
+            other => {
+                cmd.args(["--profile", other]);
+            }
+        }
+        let status = cmd
+            .status()
+            .with_context(|| format!("run cargo build for {}", self.name))?;
+        if !status.success() {
+            bail!("cargo build -p {} --bin {} failed", self.package, self.name);
+        }
+        let built = workspace_root.join("target").join(profile).join(self.name);
+        if !built.is_file() {
+            bail!(
+                "cargo build reported success but {} is missing",
+                built.display()
+            );
+        }
+        Ok(built)
+    }
 }
 
 /// `Some(hint)` naming `rebuild_cmd` when the supervisor binary predates
@@ -68,5 +163,39 @@ mod tests {
         // Unknown mtime on either side → no hint (don't guess).
         assert!(stale_aux_binary_hint(None, Some(newer), cmd).is_none());
         assert!(stale_aux_binary_hint(Some(base), None, cmd).is_none());
+    }
+
+    #[test]
+    fn source_checkout_detected_only_under_target_with_a_manifest() {
+        let root = tempfile::tempdir().expect("tempdir");
+        let root = root.path();
+        std::fs::write(root.join("Cargo.toml"), "[workspace]\n").unwrap();
+        let rel = root.join("target").join("release");
+        std::fs::create_dir_all(&rel).unwrap();
+
+        // `<root>/target/release/mvmctl` → the checkout root + "release" profile.
+        let (got_root, profile) =
+            source_checkout_root_and_profile(&rel.join("mvmctl")).expect("checkout");
+        assert_eq!(got_root, root);
+        assert_eq!(profile, "release");
+
+        // A custom profile dir is reported verbatim (it names the output dir).
+        let custom = root.join("target").join("dist");
+        std::fs::create_dir_all(&custom).unwrap();
+        assert_eq!(
+            source_checkout_root_and_profile(&custom.join("mvmctl"))
+                .unwrap()
+                .1,
+            "dist"
+        );
+
+        // Installed layout (not under a `target/` dir) → None: never build.
+        assert!(source_checkout_root_and_profile(Path::new("/usr/local/bin/mvmctl")).is_none());
+
+        // Under `target/` but no manifest at the root → None (not a checkout).
+        let bare = tempfile::tempdir().unwrap();
+        let bare_rel = bare.path().join("target").join("debug");
+        std::fs::create_dir_all(&bare_rel).unwrap();
+        assert!(source_checkout_root_and_profile(&bare_rel.join("mvmctl")).is_none());
     }
 }


### PR DESCRIPTION
## Problem

`cargo run -- machine run --image alpine -- ps aux` fails on a fresh checkout:

```
Error: starting transient microVM
Caused by:
    mvm-hvf-supervisor binary not found (looked at $MVM_HVF_SUPERVISOR_PATH and alongside the current exe)
```

The per-VM helper binaries mvmctl spawns at runtime (`mvm-hvf-supervisor`, `mvm-substitution-endpoint`, `mvm-libkrun-supervisor`, …) are **separate bin targets in other crates**. `cargo run` builds only `mvmctl`, never them, so each backend's `env → sibling → target/` resolver ladder hard-fails on the first missing helper — and fixing one just exposes the next.

Two distinct bugs:
1. **Dev:** the command can't run from a source checkout without manually building each helper.
2. **Prod:** `release.yml` never shipped `mvm-hvf-supervisor` at all — so a **downloaded `mvmctl` on macOS-26 Apple Silicon, where HVF is the auto-detect default, can't boot any machine.**

## Fix

- Add a shared `AuxBin { name, package, extra_build_args }` with `build_from_checkout()` in `supervisor_stale`: when a helper is missing **and** mvmctl runs from a source checkout (`exe` under `<root>/target/<profile>/` with a `Cargo.toml` at the root), materialize it with the same `cargo build` a stale-hint would name. Gated to a checkout, so an installed mvmctl **never** shells out to cargo. Safe to call from the running mvmctl — cargo releases the workspace build lock before the `run` phase, so the nested build can't deadlock the outer `cargo run` (verified empirically).
- Route the **hvf**, **libkrun**, and **substitution-endpoint** resolvers through it (each: one const + one `if let` before their existing bail). **vz** already had an equivalent (`ensure_source_checkout_vz_helpers`) and is untouched.
- Ship `mvm-hvf-supervisor` in `release.yml` (build + package alongside mvmctl).

## Verification

- `machine run --image alpine -- ps aux` boots a guest and runs the workload in **both debug and release** from a fresh checkout, auto-building the helper on first launch.
- Unit test covers source-checkout detection (under `target/` with a manifest → build; installed layout / no manifest → `None`, so no cargo shell-out).
- `cargo fmt` (nightly), `clippy -p mvm-backend -p mvm-cli --all-targets -D warnings`, resolver + `supervisor_stale` unit tests, and `check-no-spec-refs-in-comments` all green.

## Follow-up (not in this PR)

`AuxBin` handles the **missing** case; vz's mechanism also rebuilds a **stale** helper (input-mtime based). Unifying the two — and giving hvf/libkrun stale-rebuild too — is a clean follow-up, left out here to avoid churning vz's working, un-live-testable path.