### PR TITLE
ci: drop flaky Microsoft/azure apt repos before apt-get update

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,7 +36,7 @@ jobs:
           components: rustfmt, clippy
 
       - name: Install system build deps
-        run: sudo apt-get update && sudo apt-get install -y libcap-ng-dev lld
+        run: sudo rm -f /etc/apt/sources.list.d/microsoft*.list /etc/apt/sources.list.d/azure*.list; sudo apt-get update && sudo apt-get install -y libcap-ng-dev lld
 
       # SDK stub codegen (check-stubs) shells out to `uvx datamodel-codegen`
       # (Python) + `npx json-schema-to-typescript` (TS). The pinned generator
@@ -200,7 +200,7 @@ jobs:
 
       - name: Install system build deps
         run: |
-          sudo apt-get update
+          sudo rm -f /etc/apt/sources.list.d/microsoft*.list /etc/apt/sources.list.d/azure*.list; sudo apt-get update
           sudo apt-get install -y libcap-ng-dev lld
 
       - uses: ./.github/actions/install-zigbuild
@@ -244,7 +244,7 @@ jobs:
       - uses: ./.github/actions/install-zigbuild
 
       - name: Install jq
-        run: sudo apt-get update && sudo apt-get install -y jq
+        run: sudo rm -f /etc/apt/sources.list.d/microsoft*.list /etc/apt/sources.list.d/azure*.list; sudo apt-get update && sudo apt-get install -y jq
 
       - name: Cache cargo
         uses: actions/cache@v5
@@ -272,7 +272,7 @@ jobs:
     steps:
       - uses: actions/checkout@v6
       - name: Install passt
-        run: sudo apt-get update && sudo apt-get install -y passt
+        run: sudo rm -f /etc/apt/sources.list.d/microsoft*.list /etc/apt/sources.list.d/azure*.list; sudo apt-get update && sudo apt-get install -y passt
       - name: Confirm real passt uses the 4-byte-BE qemu-socket framing
         run: python3 scripts/passt-framing-check.py
 
@@ -326,7 +326,7 @@ jobs:
           # Inline xattr: the real kernel reads back the security.capability the
           # writer emitted, byte-for-byte (getfattr reads raw bytes — no cap
           # validation — so an arbitrary fixed blob round-trips deterministically).
-          sudo apt-get update && sudo apt-get install -y attr
+          sudo rm -f /etc/apt/sources.list.d/microsoft*.list /etc/apt/sources.list.d/azure*.list; sudo apt-get update && sudo apt-get install -y attr
           cap=$(sudo getfattr --absolute-names -n security.capability -e hex "$mnt/bin/ping" \
             | grep '^security.capability=' | cut -d= -f2)
           echo "security.capability=$cap"
@@ -335,7 +335,7 @@ jobs:
       - name: dm-verity root hash + hash tree match real veritysetup
         run: |
           set -euo pipefail
-          sudo apt-get update && sudo apt-get install -y cryptsetup-bin
+          sudo rm -f /etc/apt/sources.list.d/microsoft*.list /etc/apt/sources.list.d/azure*.list; sudo apt-get update && sudo apt-get install -y cryptsetup-bin
           # Our writer printed `ROOTHASH <hex>` and wrote the no-superblock hash
           # tree to `<image>.verity`.
           ours=$(grep '^ROOTHASH ' /tmp/sample.out | awk '{print $2}')


### PR DESCRIPTION
## Problem

The `Install system build deps` step fails intermittently across PRs (#1526, #1529, #1530) with:

```
E: The repository 'https://packages.microsoft.com/repos/azure-cli noble InRelease' is no longer signed.
E: Failed to fetch .../ubuntu/24.04/prod/dists/noble/InRelease  Clearsigned file isn't valid, got 'NOSPLIT'
##[error]Process completed with exit code 100.
```

The GitHub ubuntu-24.04 runner image ships `packages.microsoft.com` apt sources (azure-cli + prod) whose InRelease signature intermittently breaks, so `apt-get update` exits 100 and fails the step — a **systemic external flake**, unrelated to our code.

## Fix

We only need the Ubuntu archives, so remove those third-party sources before each `apt-get update` (all 6 call sites). Self-healing: this PR's own CI exercises the fix. Also protects the post-tag `verify-release` pipeline from the same flake.