### PR TITLE
ci: drop flaky Microsoft/azure apt repos in release.yml aarch64 step

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -93,6 +93,7 @@ jobs:
       - name: Install cross-compilation tools (Linux aarch64)
         if: matrix.target == 'aarch64-unknown-linux-gnu'
         run: |
+          sudo rm -f /etc/apt/sources.list.d/microsoft*.list /etc/apt/sources.list.d/azure*.list
           sudo apt-get update
           sudo apt-get install -y gcc-aarch64-linux-gnu
 


### PR DESCRIPTION
Companion to #1532 (which hardened ci.yml). release.yml's aarch64 cross-compile step also runs `apt-get update`, which can hit the same intermittent Microsoft-apt-repo signature flake during the post-tag release pipeline. Same one-line fix: drop the third-party sources first.