### PR TITLE
ci: cosign keyless pack signing round-trip smoke (follow-up to #1530)

### DIFF
--- a/.github/workflows/pack-signing-smoke.yml
+++ b/.github/workflows/pack-signing-smoke.yml
@@ -1,0 +1,77 @@
+name: Pack signing smoke
+
+# Manual-only gate that proves the keyless pack signing round-trip works
+# against a REAL cosign bundle, not just the offline fixtures the unit
+# suite exercises. It produces a throwaway keyless manifest over dummy
+# artifacts, signs it with `cosign sign-blob` using this job's own GitHub
+# Actions OIDC identity, then feeds the real bundle through the Rust
+# sigstore-verify stack the pack verifier uses in production. Signs nothing
+# a real user consumes and publishes no artifacts.
+
+on:
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  id-token: write
+
+env:
+  CARGO_TERM_COLOR: always
+
+jobs:
+  smoke:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Install Rust toolchain
+        uses: dtolnay/rust-toolchain@stable
+
+      - name: Install cosign
+        uses: sigstore/cosign-installer@v3
+
+      - name: Produce a keyless builder pack manifest over dummy artifacts
+        env:
+          REPOSITORY: ${{ github.repository }}
+          REF: ${{ github.ref }}
+        run: |
+          set -euo pipefail
+          mkdir -p smoke
+          printf 'dummy-kernel' > smoke/vmlinux
+          printf 'dummy-rootfs' > smoke/rootfs.ext4
+          printf 'dummy-sbom'   > smoke/sbom.txt
+          # The SAN cosign embeds in the certificate for a GitHub Actions
+          # OIDC-keyless signature is this workflow file bound to the
+          # dispatch ref — reconstruct exactly that so the verify step
+          # below checks against the identity the signature actually
+          # carries.
+          IDENTITY="https://github.com/${REPOSITORY}/.github/workflows/pack-signing-smoke.yml@${REF}"
+          echo "IDENTITY=${IDENTITY}" >> "$GITHUB_ENV"
+          cargo run --release -p mvm-build --example mvm-builder-pack-tool -- \
+            --vmlinux smoke/vmlinux --rootfs smoke/rootfs.ext4 --arch x86_64 --channel stable --keyless \
+            --identity "${IDENTITY}" --out-dir smoke --sbom smoke/sbom.txt \
+            --revocation-channel "https://example.test/rev.json"
+          mv smoke/manifest.json smoke/pack-manifest.json
+
+      - name: Keyless-sign the manifest with cosign
+        run: |
+          set -euo pipefail
+          cosign sign-blob \
+            --yes \
+            --bundle smoke/pack-manifest.json.bundle \
+            smoke/pack-manifest.json
+
+      - name: Verify the real cosign bundle through the Rust verifier
+        # This is the gap a real signature closes: every other pack-signing
+        # test signs with an in-process ed25519 key or feeds a synthetic
+        # bundle fixture. Here `cosign sign-blob`'s actual bundle output —
+        # certificate chain, signature, and transparency-log inclusion
+        # proof — is checked by the same `verify_signed_payload` primitive
+        # the production pack verifier calls. A nonzero exit here means the
+        # Rust sigstore-verify stack and the installed cosign CLI have
+        # drifted apart on bundle format, and fails the job.
+        run: |
+          set -euo pipefail
+          cargo run --release -p mvm-core --example verify-pack-signature --features manifest-verify -- \
+            --manifest smoke/pack-manifest.json --bundle smoke/pack-manifest.json.bundle \
+            --identity "${IDENTITY}" --issuer "https://token.actions.githubusercontent.com"

--- a/crates/mvm-core/Cargo.toml
+++ b/crates/mvm-core/Cargo.toml
@@ -136,6 +136,14 @@ name = "emit_broker_schema"
 path = "src/bin/emit_broker_schema.rs"
 required-features = ["schema"]
 
+# Standalone cosign-bundle verifier for a pack manifest's signature payload —
+# used by the pack-signing CI smoke to prove a real `cosign sign-blob` bundle
+# round-trips through the sigstore-verify stack. `required-features` keeps it
+# out of any default build, matching `manifest-verify`'s opt-in cosign deps.
+[[example]]
+name = "verify-pack-signature"
+required-features = ["manifest-verify"]
+
 [dev-dependencies]
 # `OsRng` for generating fresh ed25519 keys in signed_config tests
 # without committing static fixtures. (Also a non-dev dep above for the

--- a/crates/mvm-core/examples/verify-pack-signature.rs
+++ b/crates/mvm-core/examples/verify-pack-signature.rs
@@ -1,0 +1,86 @@
+//! Standalone verifier for a keyless-signed pack manifest.
+//!
+//! Given a pack manifest file and its detached cosign bundle, this checks
+//! the bundle against the manifest's signature payload using the exact same
+//! primitive the real pack verifier (`packs::verify_pack_keyless_at`) calls.
+//! It exists so a CI smoke job can prove a real `cosign sign-blob` bundle
+//! round-trips through the Rust sigstore-verify stack without depending on
+//! the full pack-cache machinery.
+//!
+//! ```text
+//! verify-pack-signature \
+//!   --manifest <path> --bundle <path> \
+//!   --identity <SAN> --issuer <url>
+//! ```
+//!
+//! Exits `0` and prints "pack signature verified" on success; exits nonzero
+//! and prints the error to stderr on any failure (bad JSON, bad bundle,
+//! identity/issuer mismatch, tampered payload).
+
+use std::fs;
+use std::process::ExitCode;
+
+use mvm_core::crypto::image_verify::verify_signed_payload;
+use mvm_core::packs::PackManifest;
+
+fn main() -> ExitCode {
+    let argv: Vec<String> = std::env::args().collect();
+    if argv.len() < 2 || matches!(argv[1].as_str(), "-h" | "--help" | "help") {
+        usage();
+        return if argv.len() < 2 {
+            ExitCode::FAILURE
+        } else {
+            ExitCode::SUCCESS
+        };
+    }
+    match run(&argv[1..]) {
+        Ok(()) => {
+            println!("pack signature verified");
+            ExitCode::SUCCESS
+        }
+        Err(e) => {
+            eprintln!("error: {e}");
+            ExitCode::FAILURE
+        }
+    }
+}
+
+fn usage() {
+    eprintln!(
+        "usage: verify-pack-signature \\\n\
+         \x20 --manifest <path> --bundle <path> \\\n\
+         \x20 --identity <SAN> --issuer <url>"
+    );
+}
+
+fn run(rest: &[String]) -> Result<(), String> {
+    let manifest_path = required(rest, "manifest")?;
+    let bundle_path = required(rest, "bundle")?;
+    let identity = required(rest, "identity")?;
+    let issuer = required(rest, "issuer")?;
+
+    let manifest_bytes =
+        fs::read(manifest_path).map_err(|e| format!("read {manifest_path}: {e}"))?;
+    let manifest: PackManifest = serde_json::from_slice(&manifest_bytes)
+        .map_err(|e| format!("parse manifest {manifest_path}: {e}"))?;
+    let payload = manifest
+        .signature_payload_bytes()
+        .map_err(|e| format!("build signature payload: {e}"))?;
+    let bundle = fs::read(bundle_path).map_err(|e| format!("read {bundle_path}: {e}"))?;
+
+    verify_signed_payload(&payload, &bundle, identity, issuer)
+        .map_err(|e| format!("signature verification failed: {e}"))
+}
+
+fn required<'a>(rest: &'a [String], key: &str) -> Result<&'a str, String> {
+    optional(rest, key).ok_or_else(|| format!("missing required arg: --{key}"))
+}
+
+/// Return the value following `--key`, or `None` if the flag is absent.
+fn optional<'a>(rest: &'a [String], key: &str) -> Option<&'a str> {
+    let needle = format!("--{key}");
+    rest.iter()
+        .position(|arg| arg == &needle)
+        .and_then(|i| rest.get(i + 1))
+        .map(String::as_str)
+}


### PR DESCRIPTION
Follow-up to #1530 (Plan 213 Slice 2). Adds the one thing that could not be proven offline in that PR: that a **real** `cosign sign-blob` bundle verifies through the Rust `sigstore-verify` stack.

- `crates/mvm-core/examples/verify-pack-signature.rs` (`manifest-verify`-gated example): parses a pack manifest, computes `signature_payload_bytes()` — exactly what `verify_pack_keyless_at` checks — and verifies a detached cosign bundle over it via `image_verify::verify_signed_payload`. Exit 0 on success, nonzero on failure.
- `.github/workflows/pack-signing-smoke.yml` (`workflow_dispatch`): produces a keyless manifest over dummy artifacts → `cosign sign-blob` under the job's OIDC identity → verifies the real bundle through the Rust example. A permanent, on-demand gate for the signing↔verifying handshake.

**Why separate:** a new `workflow_dispatch` file is only dispatchable once it's on `main` (GitHub registers dispatch triggers from the default branch), so this had to land after #1530 merged.

**Verified locally:** the example builds on current `main`; the negative path is proven — a real Sigstore manifest + a garbage bundle is rejected with a nonzero exit ("cosign bundle parse failed"). The positive (real-OIDC) path runs by dispatching this workflow after merge.
