### PR TITLE
ci: cosign new bundle format for keyless pack + dev-image signatures (Rust verifier requires it)

### DIFF
--- a/.github/workflows/pack-signing-smoke.yml
+++ b/.github/workflows/pack-signing-smoke.yml
@@ -56,8 +56,12 @@ jobs:
       - name: Keyless-sign the manifest with cosign
         run: |
           set -euo pipefail
+          # --new-bundle-format emits the Sigstore bundle (with
+          # verificationMaterial) the Rust verifier parses; legacy --bundle is
+          # rejected by that stack.
           cosign sign-blob \
             --yes \
+            --new-bundle-format \
             --bundle smoke/pack-manifest.json.bundle \
             smoke/pack-manifest.json
 

--- a/.github/workflows/pack-signing-smoke.yml
+++ b/.github/workflows/pack-signing-smoke.yml
@@ -79,3 +79,35 @@ jobs:
           cargo run --release -p mvm-core --example verify-pack-signature --features manifest-verify -- \
             --manifest smoke/pack-manifest.json --bundle smoke/pack-manifest.json.bundle \
             --identity "${IDENTITY}" --issuer "https://token.actions.githubusercontent.com"
+
+      - name: Round-trip an image manifest through the dev-image verifier
+        # The same Rust stack backs the dev-image download signature check
+        # (image_verify::verify_manifest), which hard-fails on a bundle it
+        # cannot parse. Sign a real image manifest and verify it through that
+        # exact entrypoint, so this smoke also guards the dev-image trust path.
+        run: |
+          set -euo pipefail
+          cat > smoke/image-manifest.json <<'JSON'
+          {
+            "schema_version": 1,
+            "version": "0.0.0-smoke",
+            "arch": "x86_64",
+            "variant": "dev",
+            "rootfs_format": "ext4",
+            "artifacts": [{"name": "dev-rootfs-x86_64.ext4", "sha256": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"}],
+            "nix_store_hash": "smoke",
+            "source_git_sha": "smoke",
+            "flake_locks": {},
+            "addressed_advisories": [],
+            "built_at": "2026-01-01T00:00:00Z",
+            "not_after": "2099-01-01T00:00:00Z"
+          }
+          JSON
+          cosign sign-blob \
+            --yes \
+            --new-bundle-format \
+            --bundle smoke/image-manifest.json.bundle \
+            smoke/image-manifest.json
+          cargo run --release -p mvm-core --example verify-signed-manifest --features manifest-verify -- \
+            --manifest smoke/image-manifest.json --bundle smoke/image-manifest.json.bundle \
+            --identity "${IDENTITY}" --issuer "https://token.actions.githubusercontent.com"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -590,8 +590,14 @@ jobs:
             exit 0
           fi
           for manifest in "${manifests[@]}"; do
+            # --new-bundle-format emits the Sigstore bundle (with
+            # verificationMaterial) that the in-binary Rust verifier
+            # (image_verify::verify_manifest) parses; the legacy --bundle
+            # format is rejected by that stack, which would hard-fail the
+            # dev-image download's signature check.
             cosign sign-blob \
               --yes \
+              --new-bundle-format \
               --bundle "${manifest}.bundle" \
               "${manifest}"
             echo "Signed: ${manifest}"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -346,12 +346,14 @@ jobs:
             --revocation-channel "$REVOCATION_CHANNEL"
           mv staging/manifest.json "staging/builder-vm-${ARCH}.pack-manifest.json"
 
-          # Keyless OIDC sign — no secret key needed. The bundle carries the
-          # signature, the short-lived cert, and the transparency-log
-          # inclusion proof; the installed-binary fetch path verifies exactly
-          # this format.
+          # Keyless OIDC sign — no secret key needed. --new-bundle-format emits
+          # the Sigstore bundle (with verificationMaterial) that the installed
+          # binary's Rust verifier parses; the legacy --bundle format is not
+          # accepted by that stack. The bundle carries the signature, the
+          # short-lived cert, and the transparency-log inclusion proof.
           cosign sign-blob \
             --yes \
+            --new-bundle-format \
             --bundle "staging/builder-vm-${ARCH}.pack-manifest.json.bundle" \
             "staging/builder-vm-${ARCH}.pack-manifest.json"
 

--- a/crates/mvm-core/Cargo.toml
+++ b/crates/mvm-core/Cargo.toml
@@ -144,6 +144,12 @@ required-features = ["schema"]
 name = "verify-pack-signature"
 required-features = ["manifest-verify"]
 
+# Same purpose for the image-manifest signature path (the dev-image download
+# verifier), calling `image_verify::verify_manifest` directly.
+[[example]]
+name = "verify-signed-manifest"
+required-features = ["manifest-verify"]
+
 [dev-dependencies]
 # `OsRng` for generating fresh ed25519 keys in signed_config tests
 # without committing static fixtures. (Also a non-dev dep above for the

--- a/crates/mvm-core/examples/verify-signed-manifest.rs
+++ b/crates/mvm-core/examples/verify-signed-manifest.rs
@@ -1,0 +1,77 @@
+//! Standalone verifier for a keyless-signed image manifest.
+//!
+//! Given a `SignedManifest` JSON file and its detached cosign bundle, this
+//! calls the exact entrypoint the dev-image download path uses
+//! (`image_verify::verify_manifest`): it checks the bundle against the raw
+//! manifest bytes through the Rust sigstore-verify stack, then parses the
+//! manifest. It exists so a CI smoke job can prove a real `cosign sign-blob`
+//! bundle over an image manifest round-trips through that verifier.
+//!
+//! ```text
+//! verify-signed-manifest \
+//!   --manifest <path> --bundle <path> \
+//!   --identity <SAN> --issuer <url>
+//! ```
+//!
+//! Exits `0` and prints "image manifest signature verified" on success; exits
+//! nonzero and prints the error to stderr on any failure (bad JSON, bad bundle,
+//! identity/issuer mismatch, tampered payload).
+
+use std::fs;
+use std::process::ExitCode;
+
+use mvm_core::crypto::image_verify::verify_manifest;
+
+fn main() -> ExitCode {
+    let argv: Vec<String> = std::env::args().collect();
+    if argv.len() < 2 || matches!(argv[1].as_str(), "-h" | "--help" | "help") {
+        usage();
+        return if argv.len() < 2 {
+            ExitCode::FAILURE
+        } else {
+            ExitCode::SUCCESS
+        };
+    }
+    match run(&argv[1..]) {
+        Ok(()) => {
+            println!("image manifest signature verified");
+            ExitCode::SUCCESS
+        }
+        Err(e) => {
+            eprintln!("error: {e}");
+            ExitCode::FAILURE
+        }
+    }
+}
+
+fn usage() {
+    eprintln!(
+        "usage: verify-signed-manifest \\\n\
+         \x20 --manifest <path> --bundle <path> \\\n\
+         \x20 --identity <SAN> --issuer <url>"
+    );
+}
+
+fn run(rest: &[String]) -> Result<(), String> {
+    let manifest_path = required(rest, "manifest")?;
+    let bundle_path = required(rest, "bundle")?;
+    let identity = required(rest, "identity")?;
+    let issuer = required(rest, "issuer")?;
+
+    let manifest_bytes =
+        fs::read(manifest_path).map_err(|e| format!("read {manifest_path}: {e}"))?;
+    let bundle = fs::read(bundle_path).map_err(|e| format!("read {bundle_path}: {e}"))?;
+
+    verify_manifest(&manifest_bytes, &bundle, identity, issuer)
+        .map(|_| ())
+        .map_err(|e| format!("signature verification failed: {e}"))
+}
+
+fn required<'a>(rest: &'a [String], key: &str) -> Result<&'a str, String> {
+    let needle = format!("--{key}");
+    rest.iter()
+        .position(|arg| arg == &needle)
+        .and_then(|i| rest.get(i + 1))
+        .map(String::as_str)
+        .ok_or_else(|| format!("missing required arg: --{key}"))
+}


### PR DESCRIPTION
Consolidated fix for the cosign bundle-format bug the smoke caught, covering **both** Rust-verified signing paths. (Absorbs and replaces #1539, now closed.)

## The bug

`cosign sign-blob --bundle` emits the **legacy** cosign bundle format, which lacks `verificationMaterial` and is **rejected** by the Rust `sigstore-verify` v0.9.0 stack:

```
cosign bundle parse failed: JSON error: missing field `verificationMaterial`
```

Two shipped/added paths verify cosign bundles through that Rust stack, and both were (or would be) broken:

1. **Attested builder packs** (`packs::verify_pack_keyless_at`) — new in #1530; every released pack would carry an unverifiable bundle → silent fail-open to plain download.
2. **Dev-image download** (`image_verify::verify_manifest`, `dev_vz.rs:1894`) — a **hard error**; a downloaded dev image's manifest signature check fails (only `MVM_SKIP_COSIGN_VERIFY=1` bypasses it). Broken since `sigstore-verify` reached 0.9.0.

## The fix

`--new-bundle-format` on the two `cosign sign-blob` calls whose output the Rust stack verifies: the builder-pack manifest and the image manifests (`release.yml`).

**Left legacy on purpose:** the release tarball/SBOM signatures — verified by the `cosign verify-blob` **CLI** in `mvmctl update` (accepts legacy, non-fatal), not the Rust stack.

**Rule:** bundle consumed by the Rust `sigstore-verify` stack → sign `--new-bundle-format`; bundle consumed by the `cosign verify-blob` CLI → legacy is fine.

## Live proof (the smoke earned its keep)

The `pack-signing-smoke.yml` gate (also in this PR) now round-trips **both** paths against a **real** OIDC cosign bundle: produce → `cosign sign-blob --new-bundle-format` → verify through the exact production Rust entrypoints (`verify_pack_keyless_at`'s primitive, and `image_verify::verify_manifest`). Dispatched on this branch — **green** (run 28909873345):

```
pack signature verified
image manifest signature verified
```

This is the first end-to-end proof of both keyless verify paths with real bundles; the offline unit suites can't mint a real cosign bundle.

## Also flagged (future, not a current break)

No CI signs a revocation list today (no workflow/script), so nothing's broken there — but whenever revocation-list signing is automated, it must also use `--new-bundle-format` (same Rust-verified path).
