### PR TITLE
feat(hostd): chain-sign workload health transitions and restarts

### DIFF
--- a/crates/mvm-hostd/src/audit_signer/helper.rs
+++ b/crates/mvm-hostd/src/audit_signer/helper.rs
@@ -149,14 +149,34 @@ impl SignerHelper {
                 message: "append workload does not match registered signer helper workload".into(),
             };
         }
+        // Category is host-set on every append path: the workload-facing
+        // `host.audit.v1` broker forces `workload_audit`, and the daemon's own
+        // health watcher sets `host` — the guest never supplies it. Honor the
+        // caller's category (falling back to the workload default when unset)
+        // so host-asserted health entries stay distinguishable from
+        // workload-asserted ones; the chain re-validates it against the
+        // allow-list, so an unknown category still fails closed here.
+        let category = if req.category.is_empty() {
+            WORKLOAD_AUDIT_CATEGORY.to_string()
+        } else {
+            req.category
+        };
+        if !crate::audit_signer::category::is_allowed(&category) {
+            return SignerHelperResponse::Err {
+                request_id,
+                code: AuditSignerErrorCode::InvalidRequest,
+                message: "append category not in allow-list".into(),
+            };
+        }
         debug!(
             vm_id = %req.vm_id,
             workload_id = %vm.workload_id,
             request_id = %request_id,
+            category = %category,
             "signer helper appending entry"
         );
         let entry = CanonicalEntry {
-            category: WORKLOAD_AUDIT_CATEGORY.into(),
+            category,
             correlation_id: req.correlation_id,
             fields: req.fields,
             prev_hash: vm.chain.head().to_string(),
@@ -332,6 +352,110 @@ mod tests {
             correlation_id: format!("brk-{request_id}"),
             fields: serde_json::json!({"event": request_id}),
         })
+    }
+
+    fn append_req_with_category(
+        vm_id: &str,
+        request_id: &str,
+        category: &str,
+    ) -> SignerHelperRequest {
+        SignerHelperRequest::AppendEntry(SignerHelperAppendEntry {
+            request_id: request_id.into(),
+            vm_id: vm_id.into(),
+            category: category.into(),
+            ts: "2026-06-17T00:00:00Z".into(),
+            workload_id: format!("wl-{vm_id}"),
+            tenant_id: "local".into(),
+            session_id: "sess-1".into(),
+            correlation_id: format!("brk-{request_id}"),
+            fields: serde_json::json!({"event": request_id}),
+        })
+    }
+
+    /// Read a per-VM chain file and return its entries' decoded JCS bytes as one
+    /// string. Each on-disk line stores the entry base64-encoded in `canonical`,
+    /// so category assertions must decode it rather than grep the raw line.
+    fn chain_lines(dir: &Path, vm_id: &str) -> String {
+        use base64::Engine;
+        let raw =
+            std::fs::read_to_string(dir.join(format!("local.{vm_id}.workload.jsonl"))).unwrap();
+        raw.lines()
+            .map(|line| {
+                let v: serde_json::Value = serde_json::from_str(line).unwrap();
+                let bytes = base64::engine::general_purpose::STANDARD
+                    .decode(v["canonical"].as_str().unwrap())
+                    .unwrap();
+                String::from_utf8(bytes).unwrap()
+            })
+            .collect::<Vec<_>>()
+            .join("\n")
+    }
+
+    #[test]
+    fn append_honors_allowlisted_host_category() {
+        // A host-asserted health entry (category "host") must be recorded as
+        // "host" — not silently reclassified as a workload emission.
+        let dir = tempdir().unwrap();
+        let mut helper = SignerHelper::new("local", Some(key_path(dir.path())));
+        helper.dispatch(register_req(dir.path(), "vm-h", "local"));
+
+        let resp = helper.dispatch(append_req_with_category("vm-h", "a1", "host"));
+        assert!(
+            matches!(resp, SignerHelperResponse::Ok { .. }),
+            "got {resp:?}"
+        );
+
+        let chain = chain_lines(dir.path(), "vm-h");
+        assert!(
+            chain.contains("\"category\":\"host\""),
+            "host category must be recorded, got: {chain}"
+        );
+        assert!(
+            !chain.contains("workload_audit"),
+            "host entry must not be reclassified as workload_audit"
+        );
+    }
+
+    #[test]
+    fn append_defaults_empty_category_to_workload_audit() {
+        // An older caller that leaves the category unset still lands on the
+        // workload default (backward-safe fallback).
+        let dir = tempdir().unwrap();
+        let mut helper = SignerHelper::new("local", Some(key_path(dir.path())));
+        helper.dispatch(register_req(dir.path(), "vm-e", "local"));
+
+        let resp = helper.dispatch(append_req_with_category("vm-e", "a1", ""));
+        assert!(
+            matches!(resp, SignerHelperResponse::Ok { .. }),
+            "got {resp:?}"
+        );
+
+        let chain = chain_lines(dir.path(), "vm-e");
+        assert!(
+            chain.contains("\"category\":\"workload_audit\""),
+            "empty category must default to workload_audit, got: {chain}"
+        );
+    }
+
+    #[test]
+    fn append_rejects_category_outside_allow_list() {
+        // A category not in the allow-list fails closed rather than seeding the
+        // chain with something downstream tooling won't recognise.
+        let dir = tempdir().unwrap();
+        let mut helper = SignerHelper::new("local", Some(key_path(dir.path())));
+        helper.dispatch(register_req(dir.path(), "vm-x", "local"));
+
+        let resp = helper.dispatch(append_req_with_category("vm-x", "a1", "totally-bogus"));
+        assert!(
+            matches!(
+                resp,
+                SignerHelperResponse::Err {
+                    code: AuditSignerErrorCode::InvalidRequest,
+                    ..
+                }
+            ),
+            "unlisted category must be refused, got {resp:?}"
+        );
     }
 
     #[test]

--- a/crates/mvm-hostd/src/broker/daemon.rs
+++ b/crates/mvm-hostd/src/broker/daemon.rs
@@ -28,7 +28,8 @@ use std::sync::Arc;
 use anyhow::{Context, Result, bail};
 use ed25519_dalek::VerifyingKey;
 use mvm_core::protocol::audit_signer::{
-    SignerHelperDeregisterVm, SignerHelperRegisterVm, SignerHelperRequest, SignerHelperResponse,
+    SignerHelperAppendEntry, SignerHelperDeregisterVm, SignerHelperRegisterVm, SignerHelperRequest,
+    SignerHelperResponse,
 };
 use tokio::net::UnixListener;
 use tokio::sync::Mutex;
@@ -41,6 +42,13 @@ use super::control::{ControlRequest, ControlResponse, RegisterVm, SignedControl}
 use super::handlers::host_audit_v1::HostAuditV1Handler;
 use super::registry::Registry;
 use super::server::{read_frame, serve_on_listener, write_frame};
+
+/// Audit category for daemon-emitted health entries. Health probing is
+/// mvm-hostd lifecycle activity, so it files under the host-asserted `host`
+/// category — distinct from a workload's own `workload_audit` emissions — with
+/// the event name carried in the entry's fields. Must stay in the
+/// audit-signer allow-list.
+const HEALTH_AUDIT_CATEGORY: &str = "host";
 
 /// Default control-frame cap — Register/Deregister are tiny; this bounds a
 /// hostile/garbled control message.
@@ -245,6 +253,29 @@ impl HostAgentDaemon {
     /// health watcher reads this each pass to decide which guests to probe.
     pub fn registered_vm_ids(&self) -> Vec<String> {
         self.vms.keys().cloned().collect()
+    }
+
+    /// Snapshot the state a [`HealthAuditSink`] needs to append chain-signed
+    /// health entries for the currently-registered VMs, without holding the
+    /// daemon lock across the (blocking) helper round-trip. The health watcher
+    /// takes this alongside [`registered_vm_ids`](Self::registered_vm_ids) while
+    /// briefly locked, then moves it into its blocking probe pass — so a health
+    /// append never serialises against broker request handling.
+    pub fn health_audit_sink(&self) -> HealthAuditSink {
+        let workload_ids = self
+            .registrations
+            .iter()
+            .map(|(vm, reg)| {
+                let wl = reg.workload_id.clone().unwrap_or_else(|| reg.vm_id.clone());
+                (vm.clone(), wl)
+            })
+            .collect();
+        HealthAuditSink {
+            helper_uds: self.signer_helper_uds_path.clone(),
+            tenant_id: self.tenant_id.clone(),
+            max_frame_bytes: self.max_frame_bytes,
+            workload_ids,
+        }
     }
 
     /// Apply a verified control request. Must run inside a tokio runtime (it
@@ -497,6 +528,80 @@ fn validate_vm_id(vm_id: &str) -> Result<()> {
         bail!("vm_id {:?} has characters outside [A-Za-z0-9_-]", vm_id);
     }
     Ok(())
+}
+
+/// A self-contained snapshot that appends chain-signed health entries to
+/// registered VMs' per-VM workload chains via the resident signer helper.
+///
+/// Built by [`HostAgentDaemon::health_audit_sink`] while the daemon is briefly
+/// locked, then moved into the health watcher's blocking probe pass — so the
+/// blocking helper round-trip never runs under the daemon lock. Health entries
+/// land on the same tamper-evident chain that `mvmctl trust audit` verifies and
+/// that the guest-facing `host.audit.v1` path appends to; the helper serialises
+/// per-chain, so host-asserted health entries interleave safely with a
+/// workload's own emissions.
+#[derive(Clone)]
+pub struct HealthAuditSink {
+    helper_uds: Option<PathBuf>,
+    tenant_id: String,
+    max_frame_bytes: usize,
+    /// Server-derived workload id per VM, snapshotted from the registration set.
+    /// The helper rejects an append whose `workload_id` doesn't match the VM's
+    /// registration, so this must mirror what `register_helper_vm` sent.
+    workload_ids: HashMap<String, String>,
+}
+
+impl HealthAuditSink {
+    /// Append one chain-signed health entry for `vm_id`.
+    ///
+    /// The entry carries the host-asserted `host` category (distinct from a
+    /// workload's own `workload_audit` emissions); the event name and state ride
+    /// in `fields`. Best-effort: a VM absent from the snapshot — or a sink with
+    /// no helper — is a silent no-op, and a helper refusal is returned for the
+    /// caller to log rather than propagated into the probe loop.
+    pub fn append(&self, vm_id: &str, fields: serde_json::Value) -> Result<()> {
+        let Some(path) = &self.helper_uds else {
+            return Ok(());
+        };
+        let Some(workload_id) = self.workload_ids.get(vm_id) else {
+            return Ok(());
+        };
+        // The timestamp doubles as the per-event disambiguator: successive
+        // health events for one VM would otherwise share a request/correlation
+        // id, so stamp it into both to keep diagnostics addressable.
+        let ts = chrono::Utc::now().to_rfc3339();
+        let req = SignerHelperRequest::AppendEntry(SignerHelperAppendEntry {
+            request_id: format!("health-{vm_id}-{ts}"),
+            vm_id: vm_id.to_string(),
+            category: HEALTH_AUDIT_CATEGORY.to_string(),
+            ts: ts.clone(),
+            workload_id: workload_id.clone(),
+            tenant_id: self.tenant_id.clone(),
+            // The health chain has no per-session identity of its own; a stable
+            // per-VM marker keeps entries attributable without inventing one.
+            session_id: format!("health-{vm_id}"),
+            correlation_id: format!("health-{vm_id}-{ts}"),
+            fields,
+        });
+        match SignerHelperClient::new(path.clone())
+            .with_max_frame_bytes(self.max_frame_bytes)
+            .send(&req)?
+        {
+            SignerHelperResponse::Ok { .. } => Ok(()),
+            SignerHelperResponse::Err { message, .. } => {
+                bail!("signer-helper health append refused: {message}")
+            }
+            other => bail!("signer-helper returned unexpected append response: {other:?}"),
+        }
+    }
+}
+
+impl crate::health_probe::HealthAudit for HealthAuditSink {
+    fn record(&self, vm_id: &str, fields: serde_json::Value) {
+        if let Err(e) = self.append(vm_id, fields) {
+            warn!(vm_id = %vm_id, error = %e, "health-audit append failed");
+        }
+    }
 }
 
 #[cfg(test)]
@@ -836,5 +941,80 @@ mod tests {
         assert_eq!(std::fs::read_to_string(&chain).unwrap().lines().count(), 2);
 
         restarted.abort();
+    }
+
+    #[test]
+    fn health_audit_sink_is_noop_without_helper() {
+        // A daemon with no signer helper yields a sink whose append is a silent
+        // success — health observability degrades cleanly rather than erroring.
+        let d = daemon("local");
+        let sink = d.health_audit_sink();
+        sink.append("vm-a", serde_json::json!({"event": "health.transition"}))
+            .unwrap();
+    }
+
+    #[test]
+    fn health_audit_sink_is_noop_for_unregistered_vm() {
+        // With nothing registered, the snapshot carries no workload id for the
+        // VM, so append no-ops before it ever connects to the helper (which
+        // isn't running here).
+        let dir = tempfile::tempdir().unwrap();
+        let vk = SigningKey::from_bytes(&[5u8; 32]).verifying_key();
+        let d = HostAgentDaemon::new_with_signer_helper(
+            "local",
+            vk,
+            dir.path().join("helper.sock"),
+            64 * 1024,
+        );
+        let sink = d.health_audit_sink();
+        sink.append("ghost", serde_json::json!({"event": "x"}))
+            .unwrap();
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn health_audit_sink_appends_host_category_entry_to_the_chain() {
+        let dir = tempfile::tempdir().unwrap();
+        let helper_sock = dir.path().join("signer-helper.sock");
+        let key_path = dir.path().join("tenant-key.ed25519");
+        std::fs::write(&key_path, [12u8; 32]).unwrap();
+        let helper_task = start_helper(helper_sock.clone(), "local", key_path).await;
+
+        let vk = SigningKey::from_bytes(&[5u8; 32]).verifying_key();
+        let mut d = HostAgentDaemon::new_with_signer_helper("local", vk, &helper_sock, 64 * 1024);
+        let reg = register(dir.path(), "vm-a", "local", None);
+        let chain = reg.workload_chain_path.clone();
+        d.apply(&ControlRequest::Register(reg)).unwrap();
+        tokio::time::sleep(Duration::from_millis(50)).await;
+
+        // The append does blocking helper I/O, so run it off the reactor.
+        let sink = d.health_audit_sink();
+        let fields = serde_json::json!({"event": "health.transition", "state": "unhealthy"});
+        tokio::task::spawn_blocking(move || sink.append("vm-a", fields))
+            .await
+            .unwrap()
+            .unwrap();
+
+        // The health entry landed on vm-a's per-VM chain, chain-signed under the
+        // helper's tenant key, recording the host category (not workload_audit).
+        let verifying_key = SigningKey::from_bytes(&[12u8; 32]).verifying_key();
+        assert_eq!(verify_workload_chain(&chain, &verifying_key).unwrap(), 1);
+
+        // The entry's fields are stored as base64-encoded JCS bytes in the
+        // on-disk `canonical` field; decode it to inspect the recorded category.
+        let raw = std::fs::read_to_string(&chain).unwrap();
+        let line: serde_json::Value = serde_json::from_str(raw.lines().next().unwrap()).unwrap();
+        let canonical = {
+            use base64::Engine;
+            base64::engine::general_purpose::STANDARD
+                .decode(line["canonical"].as_str().unwrap())
+                .unwrap()
+        };
+        let entry: serde_json::Value = serde_json::from_slice(&canonical).unwrap();
+        assert_eq!(entry["category"], "host");
+        assert_eq!(entry["fields"]["event"], "health.transition");
+        assert_eq!(entry["fields"]["state"], "unhealthy");
+        assert_ne!(entry["category"], "workload_audit");
+
+        helper_task.abort();
     }
 }

--- a/crates/mvm-hostd/src/health_probe.rs
+++ b/crates/mvm-hostd/src/health_probe.rs
@@ -12,11 +12,12 @@
 //! `Unhealthy` after `retries`, and earns a bounded restart. A clean
 //! disappearance from the live set is treated as possibly-intentional (a
 //! `machine stop` early-deregisters and then erases the registry entry), so
-//! it triggers no restart. Health-state transitions and restart decisions
-//! are recorded as structured `tracing` events (`vm`/`event`/`state`
-//! fields); wiring them into the chain-signed audit log is a follow-up — the
-//! existing `AuditEmitter` binds every entry to a signed `ExecutionPlan`,
-//! which this bare-VM-name probe loop doesn't hold.
+//! it triggers no restart. Health-state transitions and restart decisions are
+//! recorded two ways: structured `tracing` events (`vm`/`event`/`state`
+//! fields) for host logs, and — via the [`HealthAudit`] seam — chain-signed
+//! entries on each VM's per-VM workload chain, so the health history is
+//! tamper-evident on the same chain `mvmctl trust audit` verifies. The seam
+//! keeps the probe loop unit-testable without a live signer helper.
 
 use std::collections::HashMap;
 use std::path::PathBuf;
@@ -140,6 +141,22 @@ pub trait Restarter {
     fn restart(&self, vm_name: &str);
 }
 
+/// Seam over "record a chain-signed health-audit entry for this VM," so the
+/// prober's transition/restart bookkeeping stays unit-testable without a live
+/// signer helper. The real impl (the daemon's `HealthAuditSink`) appends to the
+/// VM's per-VM workload chain; `fields` carries the event name + state.
+pub trait HealthAudit {
+    fn record(&self, vm_name: &str, fields: serde_json::Value);
+}
+
+/// A [`HealthAudit`] that drops every entry. Used where health probing runs
+/// without a chain (tests that only assert state transitions).
+pub struct NoAudit;
+
+impl HealthAudit for NoAudit {
+    fn record(&self, _vm_name: &str, _fields: serde_json::Value) {}
+}
+
 /// Real [`Restarter`] impl: fire-and-forgets `mvmctl machine restart
 /// <vm_name>` as a detached child process. Never waits on the child — a
 /// restart that hangs must not block the health watcher's own loop.
@@ -212,11 +229,8 @@ pub fn map_state(state: HealthState) -> InstanceReadiness {
     }
 }
 
-/// Emit a structured event for a health-state transition. Best-effort
-/// observability: the daemon has no reachable chain-signed audit surface for
-/// a bare VM name (the existing `AuditEmitter` binds every entry to a signed
-/// `ExecutionPlan`, which this probe loop never holds), so this logs a
-/// structured `tracing` event instead — see the module doc comment.
+/// Emit a structured `tracing` event for a health-state transition — the host-
+/// log companion to the chain-signed entry the [`HealthAudit`] seam records.
 fn log_health_transition(vm: &str, new_state: HealthState) {
     match new_state {
         HealthState::Healthy => {
@@ -229,6 +243,22 @@ fn log_health_transition(vm: &str, new_state: HealthState) {
             tracing::info!(vm = %vm, event = "health.transition", state = ?new_state, "healthcheck transitioned to starting");
         }
     }
+}
+
+/// Lower-case wire name for a health state, used in audit-entry fields.
+fn state_str(state: HealthState) -> &'static str {
+    match state {
+        HealthState::Starting => "starting",
+        HealthState::Healthy => "healthy",
+        HealthState::Unhealthy => "unhealthy",
+    }
+}
+
+/// Build the `fields` payload for a health audit entry: the event name plus the
+/// current state. The category (`host`) is stamped by the sink; this is the
+/// per-entry detail an audit reader greps.
+fn health_fields(event: &str, state: HealthState) -> serde_json::Value {
+    serde_json::json!({ "event": event, "state": state_str(state) })
 }
 
 /// Per-VM health probing over the daemon's live registration set.
@@ -270,6 +300,7 @@ impl HealthProber {
         live_vm_ids: &[String],
         now_unix: u64,
         exec: &dyn GuestExec,
+        audit: &dyn HealthAudit,
     ) -> Vec<(String, HealthAction)> {
         // Retire a tracker only when the machine is genuinely no longer a
         // managed healthchecked machine — its spec is gone or no longer declares
@@ -335,6 +366,7 @@ impl HealthProber {
             let new_state = entry.0.state;
             if new_state != previous_state {
                 log_health_transition(vm, new_state);
+                audit.record(vm, health_fields("health.transition", new_state));
             }
             record_readiness(vm, map_state(new_state));
 
@@ -347,6 +379,7 @@ impl HealthProber {
                         state = ?new_state,
                         "healthcheck unhealthy; restart requested"
                     );
+                    audit.record(vm, health_fields("health.restart", new_state));
                     actions.push((vm.clone(), action));
                 }
                 HealthAction::GiveUp => {
@@ -356,6 +389,7 @@ impl HealthProber {
                         state = ?new_state,
                         "healthcheck unhealthy; restart budget exhausted"
                     );
+                    audit.record(vm, health_fields("health.give_up", new_state));
                     actions.push((vm.clone(), action));
                 }
             }
@@ -508,7 +542,7 @@ mod tests {
         // window. The third failed probe flips Unhealthy and asks for a restart.
         let mut actions = Vec::new();
         for i in 0..3u64 {
-            actions.extend(prober.tick(&vms, 1000 + i * 30, &exec));
+            actions.extend(prober.tick(&vms, 1000 + i * 30, &exec, &NoAudit));
         }
 
         assert!(
@@ -523,6 +557,84 @@ mod tests {
         );
     }
 
+    /// Captures every health-audit entry the prober records, so tests can
+    /// assert the chain-signed observability fires on the right events.
+    struct CapturingAudit(std::cell::RefCell<Vec<(String, serde_json::Value)>>);
+    impl CapturingAudit {
+        fn new() -> Self {
+            Self(std::cell::RefCell::new(Vec::new()))
+        }
+    }
+    impl HealthAudit for CapturingAudit {
+        fn record(&self, vm_name: &str, fields: serde_json::Value) {
+            self.0.borrow_mut().push((vm_name.to_string(), fields));
+        }
+    }
+
+    #[test]
+    fn tick_records_chain_audit_on_transition() {
+        // The first passing probe moves Starting → Healthy — a transition — and
+        // must emit a chain-signed health.transition entry alongside the log.
+        let tmp = tempfile::tempdir().unwrap();
+        let _env = data_env(tmp.path());
+        save_machine_spec(&spec_with_hc("api", Some(hc())), true).unwrap();
+
+        let audit = CapturingAudit::new();
+        let mut prober = HealthProber::new();
+        prober.tick(
+            &["api".to_string()],
+            1000,
+            &Fake(ExecOutcome::Exited(0)),
+            &audit,
+        );
+
+        let events = audit.0.borrow();
+        assert!(
+            events.iter().any(|(vm, f)| vm == "api"
+                && f["event"] == "health.transition"
+                && f["state"] == "healthy"),
+            "expected a health.transition/healthy audit entry, got {events:?}"
+        );
+    }
+
+    #[test]
+    fn tick_records_chain_audit_on_restart_request() {
+        // A wedged (unreachable) service flips Unhealthy after the retry budget
+        // and requests a restart; that decision must be recorded on the chain.
+        let tmp = tempfile::tempdir().unwrap();
+        let _env = data_env(tmp.path());
+        save_machine_spec(&spec_with_hc("svc", Some(hc())), true).unwrap();
+
+        let audit = CapturingAudit::new();
+        let mut prober = HealthProber::new();
+        let unreachable = Fake(ExecOutcome::Unreachable);
+        let vms = vec!["svc".to_string()];
+
+        let mut requested = false;
+        for i in 0..10u64 {
+            let actions = prober.tick(&vms, 1000 + i * 30, &unreachable, &audit);
+            if actions
+                .iter()
+                .any(|(_, a)| matches!(a, HealthAction::Restart))
+            {
+                requested = true;
+                break;
+            }
+        }
+        assert!(
+            requested,
+            "expected a restart request within the retry budget"
+        );
+
+        let events = audit.0.borrow();
+        assert!(
+            events
+                .iter()
+                .any(|(vm, f)| vm == "svc" && f["event"] == "health.restart"),
+            "expected a health.restart audit entry, got {events:?}"
+        );
+    }
+
     #[test]
     fn tick_skips_machine_without_healthcheck() {
         let tmp = tempfile::tempdir().unwrap();
@@ -531,7 +643,12 @@ mod tests {
         save_machine_spec(&spec_with_hc("bare", None), true).unwrap();
 
         let mut prober = HealthProber::new();
-        let actions = prober.tick(&["bare".to_string()], 1000, &Fake(ExecOutcome::Exited(0)));
+        let actions = prober.tick(
+            &["bare".to_string()],
+            1000,
+            &Fake(ExecOutcome::Exited(0)),
+            &NoAudit,
+        );
 
         assert!(actions.is_empty());
         assert!(!prober.trackers.contains_key("bare"));
@@ -551,7 +668,12 @@ mod tests {
         reg.save(&rpath).unwrap();
 
         let mut prober = HealthProber::new();
-        let actions = prober.tick(&["api".to_string()], 1000, &Fake(ExecOutcome::Exited(0)));
+        let actions = prober.tick(
+            &["api".to_string()],
+            1000,
+            &Fake(ExecOutcome::Exited(0)),
+            &NoAudit,
+        );
 
         assert!(actions.is_empty(), "a pass should not request a restart");
         let loaded = VmNameRegistry::load(&rpath).unwrap();
@@ -569,14 +691,19 @@ mod tests {
         save_machine_spec(&spec_with_hc("gone", Some(hc())), true).unwrap();
 
         let mut prober = HealthProber::new();
-        prober.tick(&["gone".to_string()], 1000, &Fake(ExecOutcome::Exited(1)));
+        prober.tick(
+            &["gone".to_string()],
+            1000,
+            &Fake(ExecOutcome::Exited(1)),
+            &NoAudit,
+        );
         assert!(prober.trackers.contains_key("gone"));
 
         // A momentary absence from the live set (e.g. a restart's stop→start
         // window) must NOT drop the tracker: its restart budget has to survive
         // the gap, or a broken service crash-loops past its cap. The absent VM
         // is not probed, so it also earns no new restart.
-        let actions = prober.tick(&[], 1100, &Fake(ExecOutcome::Exited(1)));
+        let actions = prober.tick(&[], 1100, &Fake(ExecOutcome::Exited(1)), &NoAudit);
         assert!(
             prober.trackers.contains_key("gone"),
             "a briefly-absent healthchecked machine keeps its tracker"
@@ -589,7 +716,7 @@ mod tests {
         // Once the machine's spec no longer declares a healthcheck it is
         // genuinely no longer managed, so its tracker is retired.
         save_machine_spec(&spec_with_hc("gone", None), true).unwrap();
-        prober.tick(&[], 1200, &Fake(ExecOutcome::Exited(1)));
+        prober.tick(&[], 1200, &Fake(ExecOutcome::Exited(1)), &NoAudit);
         assert!(
             !prober.trackers.contains_key("gone"),
             "dropping the healthcheck retires the tracker"
@@ -614,7 +741,7 @@ mod tests {
 
         let mut actions = Vec::new();
         for i in 0..3u64 {
-            actions.extend(prober.tick(&vms, 1000 + i * 30, &unreachable));
+            actions.extend(prober.tick(&vms, 1000 + i * 30, &unreachable, &NoAudit));
         }
 
         assert!(
@@ -665,7 +792,7 @@ mod tests {
         // the future. Running the full tick→act cycle each pass mirrors the
         // watcher loop; the restart must NOT fire on the instant it was set.
         for now in [1000u64, 1030, 1060] {
-            prober.tick(&vms, now, &exec);
+            prober.tick(&vms, now, &exec, &NoAudit);
             prober.act(&vms, now, &restarter);
         }
         assert!(
@@ -688,7 +815,7 @@ mod tests {
         // A later tick, still before the next probe-due window (t=1090), fires
         // the pending restart exactly once and consumes the gate. This is the
         // path the old `act` never reached — the bug left it dead.
-        prober.tick(&vms, gate, &exec);
+        prober.tick(&vms, gate, &exec, &NoAudit);
         prober.act(&vms, gate, &restarter);
         assert_eq!(*restarter.calls.lock().unwrap(), vec!["web".to_string()]);
         assert!(
@@ -703,7 +830,7 @@ mod tests {
         );
 
         // Further ticks at/after the gate do not re-fire the consumed restart.
-        prober.tick(&vms, gate + 1, &exec);
+        prober.tick(&vms, gate + 1, &exec, &NoAudit);
         prober.act(&vms, gate + 1, &restarter);
         assert_eq!(
             restarter.calls.lock().unwrap().len(),
@@ -732,7 +859,7 @@ mod tests {
         // Drive to Unhealthy with a pending, not-yet-fired gate (act on the
         // setting instant defers, so nothing fires during the drive).
         for now in [1000u64, 1030, 1060] {
-            prober.tick(&vms, now, &exec);
+            prober.tick(&vms, now, &exec, &NoAudit);
             prober.act(&vms, now, &restarter);
         }
         let gate = prober
@@ -785,12 +912,12 @@ mod tests {
 
         // Drive to the first restart (Unhealthy, restart_attempts=1 at t=1060).
         for now in [1000u64, 1030, 1060] {
-            prober.tick(&vms, now, &exec);
+            prober.tick(&vms, now, &exec, &NoAudit);
             prober.act(&vms, now, &restarter);
         }
         assert_eq!(prober.trackers.get("web").unwrap().0.restart_attempts, 1);
         // The gate fires on a later, non-probe tick.
-        prober.tick(&vms, 1062, &exec);
+        prober.tick(&vms, 1062, &exec, &NoAudit);
         prober.act(&vms, 1062, &restarter);
         assert_eq!(
             restarter.calls.lock().unwrap().len(),
@@ -801,7 +928,7 @@ mod tests {
         // Restart window: the machine deregisters (absent from live set) for a
         // couple of ticks. The tracker — and its restart_attempts — must survive.
         for now in [1064u64, 1066] {
-            prober.tick(&[], now, &exec);
+            prober.tick(&[], now, &exec, &NoAudit);
             prober.act(&[], now, &restarter);
         }
         assert!(
@@ -819,7 +946,7 @@ mod tests {
         let mut now = 1068u64;
         let mut gave_up = false;
         while now < 1600 && !gave_up {
-            let actions = prober.tick(&vms, now, &exec);
+            let actions = prober.tick(&vms, now, &exec, &NoAudit);
             prober.act(&vms, now, &restarter);
             if actions
                 .iter()
@@ -848,7 +975,7 @@ mod tests {
 
         // Ticking on past give-up spawns no further restarts.
         for _ in 0..5u64 {
-            prober.tick(&vms, now, &exec);
+            prober.tick(&vms, now, &exec, &NoAudit);
             prober.act(&vms, now, &restarter);
             now += 30;
         }
@@ -875,7 +1002,7 @@ mod tests {
         // Unhealthy flip earns another restart attempt.
         let mut now = 1000u64;
         for _ in 0..3u64 {
-            prober.tick(&vms, now, &exec);
+            prober.tick(&vms, now, &exec, &NoAudit);
             now += 30;
         }
         // Tracker is now Unhealthy with restart_attempts == 1. Keep failing
@@ -883,7 +1010,7 @@ mod tests {
         // the next fail after that yields GiveUp.
         let mut last_actions = Vec::new();
         for _ in 0..6u64 {
-            last_actions = prober.tick(&vms, now, &exec);
+            last_actions = prober.tick(&vms, now, &exec, &NoAudit);
             now += 30;
         }
 

--- a/crates/mvm-hostd/src/host_agent_idle.rs
+++ b/crates/mvm-hostd/src/host_agent_idle.rs
@@ -123,7 +123,14 @@ pub async fn run_health_watcher(daemon: Arc<Mutex<HostAgentDaemon>>) {
     let mut prober = HealthProber::new();
     loop {
         ticker.tick().await;
-        let vm_ids = daemon.lock().await.registered_vm_ids();
+        // Snapshot the live set and the health-audit sink together under one
+        // brief lock, then release it before the blocking pass — the sink is
+        // self-contained (it does its own blocking helper round-trip inside the
+        // pass), so a health append never runs under the daemon lock.
+        let (vm_ids, audit) = {
+            let d = daemon.lock().await;
+            (d.registered_vm_ids(), d.health_audit_sink())
+        };
         if vm_ids.is_empty() {
             continue;
         }
@@ -138,7 +145,7 @@ pub async fn run_health_watcher(daemon: Arc<Mutex<HostAgentDaemon>>) {
             // (every tick, inside `act`): `tick` schedules a restart into the
             // future, and `act` fires any gate that has since elapsed. A restart
             // scheduled this pass therefore fires on a later pass, not this one.
-            prober.tick(&vm_ids, now, &AgentExec);
+            prober.tick(&vm_ids, now, &AgentExec, &audit);
             prober.act(&vm_ids, now, &MachineRestarter);
             prober
         })

--- a/specs/plans/233-workload-healthcheck-phase-c.md
+++ b/specs/plans/233-workload-healthcheck-phase-c.md
@@ -546,3 +546,13 @@ sleep 25; ./target/debug/mvmctl machine ls            # unhealthy → restart(s)
 **Type consistency:** `ProbeResult`/`HealthState`/`HealthAction`/`HealthPolicy`/`HealthTracker`/`fold` (Task 1) are used verbatim in Tasks 5/6; `record_readiness` (Task 2) is called in Task 5; `GuestExec`/`ExecOutcome`/`probe_with` (Task 3) are consumed in Task 5; `map_state`/`health_cell` map the same `InstanceReadiness` variants across Tasks 4/5. `mvm-core` must not reference `mvm-sdk` (Task 1 holds raw numbers; the caller builds `HealthPolicy`). ✓
 
 **Known risk:** Task 0 (HVF daemon wiring) can turn up a BLOCKED — the design's fallback (probe thread in the per-VM supervisor) is a different plan; escalate rather than force it.
+
+---
+
+## Follow-ups (post-merge)
+
+Tracked here as they land off the merged phase-C branch.
+
+- [x] **Chain-signed health audit.** Task 7 shipped the transition/restart audit as structured `tracing` only, because the daemon holds just the signer's *public* key (the private key lives in the supervised signer-helper — the process moat). Resolved by routing health events through the same signer-helper `AppendEntry` path the guest-facing `host.audit.v1` already uses: a new `HealthAuditSink` (snapshotted from the daemon under one brief lock, then moved into the blocking probe pass) appends each transition/restart to the VM's per-VM workload chain, tamper-evident on the same chain `mvmctl trust audit` verifies. Entries carry the host-asserted `host` category — the signer-helper's `append` now honors an allow-listed caller category instead of hard-coding `workload_audit`, so host health events stay distinguishable from a workload's own emissions (the guest can't spoof it: every append path stamps the category host-side). Threaded into the prober via a `HealthAudit` seam so transitions stay unit-testable. Files: `crates/mvm-hostd/src/audit_signer/helper.rs`, `crates/mvm-hostd/src/broker/daemon.rs`, `crates/mvm-hostd/src/health_probe.rs`, `crates/mvm-hostd/src/host_agent_idle.rs`.
+- [ ] **HVF signer-helper `BROKER_PORT` guest bridge.** Guest-side `host.audit.v1` still isn't routed on HVF (`HvfSupervisorConfig` carries no broker-listen field; the HVF vsock dispatcher routes only workload-exit/egress). The host-emitted health audit above needs no guest bridge, but guest-originated audit parity with libkrun/vz on HVF remains open.
+- [ ] **HVF supervisor teardown reliability.** `mvm-hvf-supervisor` orphaning after stop/rm dents restart reliability on HVF; needs a live-hardware root-cause (blocked while a parallel session shares `~/.mvm`).


### PR DESCRIPTION
## What

Makes the resident per-tenant host-agent daemon record workload **health-state transitions and restart decisions as chain-signed audit entries**, resolving the observability follow-up left open by phase C (#1536), which shipped them as structured `tracing` only.

## Why it was deferred

Phase C's Task 7 couldn't chain-sign health events because the daemon holds only the signer's **public** key — the private key lives in the supervised `mvm-signer-helper` (the process moat) — so the plan-bound `AuditEmitter` was unreachable from the bare-VM-name probe loop.

## How

Route health events through the **same signer-helper `AppendEntry` path** the guest-facing `host.audit.v1` already uses:

- A `HealthAuditSink` is snapshotted from the daemon under one brief lock, then moved into the blocking probe pass — so the blocking helper round-trip never runs under the daemon lock. It appends each transition/restart to the VM's per-VM workload chain, tamper-evident on the same chain `mvmctl trust audit` verifies, interleaving safely with the workload's own emissions under the helper's per-chain serialization.
- Health entries carry the host-asserted **`host` category**: the signer-helper's `append` now honors an allow-listed caller category instead of hard-coding `workload_audit`, so host-emitted health stays distinguishable from workload-asserted entries. The category is stamped host-side on every append path (the guest supplies only `ts`+`fields`, enforced by `deny_unknown_fields`), and `chain.append` re-validates against the allow-list — so it can't be guest-spoofed and an unknown category still fails closed.
- The prober gets a `HealthAudit` seam so transitions/restarts stay unit-testable without a live helper; the watcher wires the real sink.

## Tests

Helper honors `host` / defaults empty → `workload_audit` / rejects unlisted category; sink no-ops without a helper or for an unregistered VM; full round-trip appends a `host`-category entry that verifies on the per-VM chain (base64-decoding the on-disk `canonical` to assert the category); prober seam records transition + restart events.

Gates run locally: nightly `fmt --all --check`, `clippy -p mvm-hostd --all-targets -D warnings`, full `mvm-hostd` nextest (1088 pass), doctests, and workspace `build --all-targets -D warnings`. Adversarially reviewed for guest category-spoofing (safe) and async-lock/`workload_id`-match correctness (clean).

## Follow-ups still open (tracked in `specs/plans/233`)

- HVF signer-helper `BROKER_PORT` guest bridge (guest-originated `host.audit.v1` parity on HVF)
- HVF supervisor teardown reliability (orphaned `mvm-hvf-supervisor` after stop/rm — needs live-hardware root-cause)