### PR TITLE
ci(release): new Sigstore bundle format for image-manifest signatures (dev-image verify was broken)

### DIFF
--- a/.github/workflows/pack-signing-smoke.yml
+++ b/.github/workflows/pack-signing-smoke.yml
@@ -75,3 +75,35 @@ jobs:
           cargo run --release -p mvm-core --example verify-pack-signature --features manifest-verify -- \
             --manifest smoke/pack-manifest.json --bundle smoke/pack-manifest.json.bundle \
             --identity "${IDENTITY}" --issuer "https://token.actions.githubusercontent.com"
+
+      - name: Round-trip an image manifest through the dev-image verifier
+        # The same Rust stack backs the dev-image download signature check
+        # (image_verify::verify_manifest), which hard-fails on a bundle it
+        # cannot parse. Sign a real image manifest and verify it through that
+        # exact entrypoint, so this smoke also guards the dev-image trust path.
+        run: |
+          set -euo pipefail
+          cat > smoke/image-manifest.json <<'JSON'
+          {
+            "schema_version": 1,
+            "version": "0.0.0-smoke",
+            "arch": "x86_64",
+            "variant": "dev",
+            "rootfs_format": "ext4",
+            "artifacts": [{"name": "dev-rootfs-x86_64.ext4", "sha256": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"}],
+            "nix_store_hash": "smoke",
+            "source_git_sha": "smoke",
+            "flake_locks": {},
+            "addressed_advisories": [],
+            "built_at": "2026-01-01T00:00:00Z",
+            "not_after": "2099-01-01T00:00:00Z"
+          }
+          JSON
+          cosign sign-blob \
+            --yes \
+            --new-bundle-format \
+            --bundle smoke/image-manifest.json.bundle \
+            smoke/image-manifest.json
+          cargo run --release -p mvm-core --example verify-signed-manifest --features manifest-verify -- \
+            --manifest smoke/image-manifest.json --bundle smoke/image-manifest.json.bundle \
+            --identity "${IDENTITY}" --issuer "https://token.actions.githubusercontent.com"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -588,8 +588,14 @@ jobs:
             exit 0
           fi
           for manifest in "${manifests[@]}"; do
+            # --new-bundle-format emits the Sigstore bundle (with
+            # verificationMaterial) that the in-binary Rust verifier
+            # (image_verify::verify_manifest) parses; the legacy --bundle
+            # format is rejected by that stack, which would hard-fail the
+            # dev-image download's signature check.
             cosign sign-blob \
               --yes \
+              --new-bundle-format \
               --bundle "${manifest}.bundle" \
               "${manifest}"
             echo "Signed: ${manifest}"

--- a/crates/mvm-core/Cargo.toml
+++ b/crates/mvm-core/Cargo.toml
@@ -144,6 +144,12 @@ required-features = ["schema"]
 name = "verify-pack-signature"
 required-features = ["manifest-verify"]
 
+# Same purpose for the image-manifest signature path (the dev-image download
+# verifier), calling `image_verify::verify_manifest` directly.
+[[example]]
+name = "verify-signed-manifest"
+required-features = ["manifest-verify"]
+
 [dev-dependencies]
 # `OsRng` for generating fresh ed25519 keys in signed_config tests
 # without committing static fixtures. (Also a non-dev dep above for the

--- a/crates/mvm-core/examples/verify-signed-manifest.rs
+++ b/crates/mvm-core/examples/verify-signed-manifest.rs
@@ -1,0 +1,77 @@
+//! Standalone verifier for a keyless-signed image manifest.
+//!
+//! Given a `SignedManifest` JSON file and its detached cosign bundle, this
+//! calls the exact entrypoint the dev-image download path uses
+//! (`image_verify::verify_manifest`): it checks the bundle against the raw
+//! manifest bytes through the Rust sigstore-verify stack, then parses the
+//! manifest. It exists so a CI smoke job can prove a real `cosign sign-blob`
+//! bundle over an image manifest round-trips through that verifier.
+//!
+//! ```text
+//! verify-signed-manifest \
+//!   --manifest <path> --bundle <path> \
+//!   --identity <SAN> --issuer <url>
+//! ```
+//!
+//! Exits `0` and prints "image manifest signature verified" on success; exits
+//! nonzero and prints the error to stderr on any failure (bad JSON, bad bundle,
+//! identity/issuer mismatch, tampered payload).
+
+use std::fs;
+use std::process::ExitCode;
+
+use mvm_core::crypto::image_verify::verify_manifest;
+
+fn main() -> ExitCode {
+    let argv: Vec<String> = std::env::args().collect();
+    if argv.len() < 2 || matches!(argv[1].as_str(), "-h" | "--help" | "help") {
+        usage();
+        return if argv.len() < 2 {
+            ExitCode::FAILURE
+        } else {
+            ExitCode::SUCCESS
+        };
+    }
+    match run(&argv[1..]) {
+        Ok(()) => {
+            println!("image manifest signature verified");
+            ExitCode::SUCCESS
+        }
+        Err(e) => {
+            eprintln!("error: {e}");
+            ExitCode::FAILURE
+        }
+    }
+}
+
+fn usage() {
+    eprintln!(
+        "usage: verify-signed-manifest \\\n\
+         \x20 --manifest <path> --bundle <path> \\\n\
+         \x20 --identity <SAN> --issuer <url>"
+    );
+}
+
+fn run(rest: &[String]) -> Result<(), String> {
+    let manifest_path = required(rest, "manifest")?;
+    let bundle_path = required(rest, "bundle")?;
+    let identity = required(rest, "identity")?;
+    let issuer = required(rest, "issuer")?;
+
+    let manifest_bytes =
+        fs::read(manifest_path).map_err(|e| format!("read {manifest_path}: {e}"))?;
+    let bundle = fs::read(bundle_path).map_err(|e| format!("read {bundle_path}: {e}"))?;
+
+    verify_manifest(&manifest_bytes, &bundle, identity, issuer)
+        .map(|_| ())
+        .map_err(|e| format!("signature verification failed: {e}"))
+}
+
+fn required<'a>(rest: &'a [String], key: &str) -> Result<&'a str, String> {
+    let needle = format!("--{key}");
+    rest.iter()
+        .position(|arg| arg == &needle)
+        .and_then(|i| rest.get(i + 1))
+        .map(String::as_str)
+        .ok_or_else(|| format!("missing required arg: --{key}"))
+}


### PR DESCRIPTION
Follow-up from the investigation prompted by #1537. The cosign round-trip smoke revealed that `cosign sign-blob --bundle` emits the legacy bundle format, which the Rust `sigstore-verify` v0.9.0 stack rejects (`missing field verificationMaterial`). That stack is **not** only used by the new attested packs — it also backs the **dev-image download signature check**.

## Confirmed broken

- `mvmctl` dev-image download calls `image_verify::verify_manifest` (`crates/mvm-cli/src/commands/env/dev_vz.rs:1894`) as a **hard error** — the only bypass is `MVM_SKIP_COSIGN_VERIFY=1`.
- `verify_manifest` → `verify_cosign_bundle` uses `sigstore-verify` **0.9.0** (confirmed in `Cargo.lock`), which requires the new Sigstore bundle format.
- The release signs image manifests with **legacy** `cosign sign-blob --bundle` (the `Sign image manifests` step).

So a downloaded dev image's manifest bundle cannot be parsed by the verifier → the signature check hard-fails (short of the emergency skip). Same root cause and same fix as the builder pack (#1537): `--new-bundle-format`.

## Scope — only the Rust-verified path

- **Fixed:** the image-manifest signing step (`--new-bundle-format`).
- **Left as-is (correct):** the release **tarball/SBOM** signatures. Those are verified by the **`cosign verify-blob` CLI** in `mvmctl update` (`crates/mvm-cli/src/update.rs`), which accepts the legacy format and is non-fatal — changing them to the new format could break that CLI verify.

## Validation

Validated **transitively** by the #1537 smoke: `image_verify::verify_manifest`'s signature step is the *same* `verify_cosign_bundle` primitive the smoke exercised, and that smoke went green with `--new-bundle-format` against `sigstore-verify` 0.9.0. The bundle format is independent of the signed payload, so a green pack round-trip proves the image-manifest bundle will parse too. (Happy to extend the smoke to round-trip a `SignedManifest` directly if you want belt-and-suspenders.)

## Also flagged (future gotcha, not a current break)

The signed **revocation list** would be fetched + verified through the same Rust stack (`try_fetch_revocation_list`, `dev_vz.rs`). There is **no** revocation-signing automation in CI today (no `revocations.yml` workflow, no signing script), so nothing is broken now — but whenever a revocation list is signed and published, it must be signed with `--new-bundle-format` or the consumer-side verify will reject it for the same reason.

