### PR TITLE
ci: fail the release closed on an incomplete attested builder pack (Plan 213 §B)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -65,10 +65,15 @@ jobs:
       - name: Check formatting
         run: cargo fmt -- --check
 
-      - name: Shellcheck install.sh
+      - name: Shellcheck install.sh + release-asset verifier
         run: |
           sudo apt-get install -y shellcheck
           shellcheck -S warning install.sh
+          shellcheck packaging/release/verify-release-assets.sh \
+                     packaging/release/verify-release-assets.test.sh
+
+      - name: Release-asset verifier gate tests
+        run: bash packaging/release/verify-release-assets.test.sh
 
       - name: Clippy
         run: cargo clippy --all-targets -- -D warnings

--- a/packaging/release/verify-release-assets.sh
+++ b/packaging/release/verify-release-assets.sh
@@ -18,6 +18,8 @@ ASSETS_DIR=""
 # Keep in lockstep with the release.yml `build` matrix. x86_64-apple-darwin is
 # deferred there (no Intel runner), so it is deliberately absent here too.
 TARGETS="aarch64-apple-darwin x86_64-unknown-linux-gnu aarch64-unknown-linux-gnu"
+# Keep in lockstep with the release.yml `builder-vm-image` matrix.
+BUILDER_ARCHES="aarch64 x86_64"
 DO_COSIGN=0
 EXPECT_VERSION=""
 
@@ -25,6 +27,7 @@ while [ $# -gt 0 ]; do
   case "$1" in
     --assets-dir)     ASSETS_DIR="$2"; shift 2 ;;
     --targets)        TARGETS="$2"; shift 2 ;;
+    --builder-arches) BUILDER_ARCHES="$2"; shift 2 ;;
     --cosign)         DO_COSIGN=1; shift ;;
     # Assert the packaged binary reports this version. Only the target that
     # matches the host can be executed; cross-arch targets are skipped (their
@@ -133,6 +136,45 @@ done
 # The SBOM ships signed alongside the binaries on every release.
 [ -f "$ASSETS_DIR/sbom.cdx.json" ]        || fail "SBOM missing: sbom.cdx.json"
 [ -f "$ASSETS_DIR/sbom.cdx.json.bundle" ] || fail "SBOM signature bundle missing: sbom.cdx.json.bundle"
+
+# Attested builder packs are an accelerator, published best-effort: a signing
+# outage skips them and the plain vmlinux/rootfs still ship. So a pack is valid
+# either COMPLETE (manifest + cosign bundle + SBOM, each listed in and matching
+# the per-arch builder checksums manifest) or entirely ABSENT — a partial pack
+# is a packaging bug and fails closed, because an installed binary would fetch
+# it, fail to verify, and silently fall back to the plain download.
+for arch in $BUILDER_ARCHES; do
+  bp_manifest="builder-vm-${arch}.pack-manifest.json"
+  bp_bundle="builder-vm-${arch}.pack-manifest.json.bundle"
+  bp_sbom="builder-vm-${arch}.sbom.txt"
+  bp_checks="$ASSETS_DIR/builder-vm-${arch}-checksums-sha256.txt"
+
+  present=0
+  for f in "$bp_manifest" "$bp_bundle" "$bp_sbom"; do
+    [ -f "$ASSETS_DIR/$f" ] && present=$((present + 1))
+  done
+
+  if [ "$present" -eq 0 ]; then
+    echo "note: [$arch] no attested builder pack published (accelerator absent) — ok"
+    continue
+  fi
+  if [ "$present" -ne 3 ]; then
+    fail "[$arch] partial attested builder pack: manifest=$([ -f "$ASSETS_DIR/$bp_manifest" ] && echo y || echo n) bundle=$([ -f "$ASSETS_DIR/$bp_bundle" ] && echo y || echo n) sbom=$([ -f "$ASSETS_DIR/$bp_sbom" ] && echo y || echo n)"
+    continue
+  fi
+
+  [ -f "$bp_checks" ] || { fail "[$arch] builder checksums manifest missing: builder-vm-${arch}-checksums-sha256.txt"; continue; }
+  for f in "$bp_manifest" "$bp_bundle" "$bp_sbom"; do
+    want=$(awk -v n="$f" '$2 == n { print $1 }' "$bp_checks" | head -1)
+    if [ -z "$want" ]; then
+      fail "[$arch] $f not listed in builder-vm-${arch}-checksums-sha256.txt"
+      continue
+    fi
+    got=$(sha256_of "$ASSETS_DIR/$f")
+    [ "$want" = "$got" ] || fail "[$arch] $f sha256 mismatch: recorded=$want actual=$got"
+  done
+  [ "$FAILED" = 0 ] && echo "ok: [$arch] attested builder pack complete (manifest + bundle + SBOM, checksummed)."
+done
 
 if [ "$FAILED" = 0 ]; then
   echo "ok: all $(echo "$TARGETS" | wc -w | tr -d ' ') target(s) have tarball + matching sha256 + signature bundle + manifest entry; SBOM signed."

--- a/packaging/release/verify-release-assets.test.sh
+++ b/packaging/release/verify-release-assets.test.sh
@@ -1,0 +1,92 @@
+#!/usr/bin/env bash
+# Focused tests for the attested-builder-pack gate in verify-release-assets.sh:
+# a published pack must be COMPLETE (manifest + bundle + SBOM, each listed in and
+# matching the per-arch builder checksums) or entirely ABSENT — a partial or
+# checksum-mismatched pack fails closed. Runs the real script (no --cosign, no
+# --expect-version, so the OIDC/host-version checks are skipped) against
+# fixtures built here. No network, no cosign.
+set -euo pipefail
+
+HERE="$(cd "$(dirname "$0")" && pwd)"
+SCRIPT="$HERE/verify-release-assets.sh"
+TARGETS="aarch64-apple-darwin x86_64-unknown-linux-gnu aarch64-unknown-linux-gnu"
+BUILDER_ARCHES="aarch64 x86_64"
+
+sha256_of() {
+  if command -v sha256sum >/dev/null 2>&1; then sha256sum "$1" | awk '{print $1}';
+  else shasum -a 256 "$1" | awk '{print $1}'; fi
+}
+
+bins_for() {
+  case "$1" in
+    *apple-darwin) echo "mvmctl mvm-bridge mvm-vz-supervisor mvm-hvf-supervisor mvm-libkrun-supervisor mvm-substitution-endpoint" ;;
+    *)             echo "mvmctl mvm-bridge mvm-substitution-endpoint" ;;
+  esac
+}
+
+# Build a fully-valid release-assets dir (all tarball/SBOM checks pass) with a
+# COMPLETE attested pack for every builder arch. Echoes the dir path.
+build_valid_fixture() {
+  local dir; dir="$(mktemp -d)"
+  : > "$dir/checksums-sha256.txt"
+  for t in $TARGETS; do
+    local pkg="$dir/mvmctl-$t"
+    mkdir -p "$pkg"
+    for b in $(bins_for "$t"); do printf '#!/bin/sh\n' > "$pkg/$b"; chmod +x "$pkg/$b"; done
+    ( cd "$dir" && tar czf "mvmctl-$t.tar.gz" "mvmctl-$t" && rm -rf "mvmctl-$t" )
+    sha256_of "$dir/mvmctl-$t.tar.gz" > "$dir/mvmctl-$t.tar.gz.sha256"
+    printf 'bundle\n' > "$dir/mvmctl-$t.tar.gz.bundle"
+    echo "$(sha256_of "$dir/mvmctl-$t.tar.gz")  mvmctl-$t.tar.gz" >> "$dir/checksums-sha256.txt"
+  done
+  printf '{"sbom":true}\n' > "$dir/sbom.cdx.json"
+  printf 'bundle\n' > "$dir/sbom.cdx.json.bundle"
+  for arch in $BUILDER_ARCHES; do
+    printf '{"pack":"%s"}\n' "$arch" > "$dir/builder-vm-$arch.pack-manifest.json"
+    printf 'sigstore-bundle\n'       > "$dir/builder-vm-$arch.pack-manifest.json.bundle"
+    printf 'store-path-a\nstore-path-b\n' > "$dir/builder-vm-$arch.sbom.txt"
+    : > "$dir/builder-vm-$arch-checksums-sha256.txt"
+    for f in "builder-vm-$arch.pack-manifest.json" "builder-vm-$arch.pack-manifest.json.bundle" "builder-vm-$arch.sbom.txt"; do
+      echo "$(sha256_of "$dir/$f")  $f" >> "$dir/builder-vm-$arch-checksums-sha256.txt"
+    done
+  done
+  echo "$dir"
+}
+
+run() { bash "$SCRIPT" --assets-dir "$1" >/dev/null 2>&1; }  # returns the script's exit code
+
+PASS=0; FAILN=0
+ok()   { PASS=$((PASS+1)); echo "  ok: $1"; }
+bad()  { FAILN=$((FAILN+1)); echo "  FAIL: $1" >&2; }
+
+# 1. Complete packs → pass.
+d="$(build_valid_fixture)"
+if run "$d"; then ok "complete packs verify"; else bad "complete packs should verify"; fi
+rm -rf "$d"
+
+# 2. Partial pack (bundle missing) → fail closed.
+d="$(build_valid_fixture)"
+rm -f "$d/builder-vm-aarch64.pack-manifest.json.bundle"
+if run "$d"; then bad "partial pack (missing bundle) must fail"; else ok "partial pack (missing bundle) fails closed"; fi
+rm -rf "$d"
+
+# 3. Absent pack (all three gone) → pass (accelerator absent).
+d="$(build_valid_fixture)"
+rm -f "$d/builder-vm-x86_64.pack-manifest.json" "$d/builder-vm-x86_64.pack-manifest.json.bundle" \
+      "$d/builder-vm-x86_64.sbom.txt" "$d/builder-vm-x86_64-checksums-sha256.txt"
+if run "$d"; then ok "absent pack is accepted"; else bad "absent pack should be accepted"; fi
+rm -rf "$d"
+
+# 4. Complete pack but checksum tampered → fail closed.
+d="$(build_valid_fixture)"
+printf 'tampered\n' > "$d/builder-vm-aarch64.pack-manifest.json"   # bytes no longer match recorded hash
+if run "$d"; then bad "checksum-mismatched pack must fail"; else ok "checksum-mismatched pack fails closed"; fi
+rm -rf "$d"
+
+# 5. Complete pack but its file is not listed in the checksums manifest → fail.
+d="$(build_valid_fixture)"
+: > "$d/builder-vm-aarch64-checksums-sha256.txt"   # empty: nothing listed
+if run "$d"; then bad "unlisted pack files must fail"; else ok "unlisted pack files fail closed"; fi
+rm -rf "$d"
+
+echo "verify-release-assets pack-gate: $PASS passed, $FAILN failed"
+[ "$FAILN" -eq 0 ]

--- a/specs/plans/213-attested-fast-first-boot-packs.md
+++ b/specs/plans/213-attested-fast-first-boot-packs.md
@@ -101,8 +101,9 @@ The target user-visible shape is:
       in builder packs.
 - [ ] Emit SBOMs, checksums, signatures, provenance, and pack manifests for every
       release pack.
-- [ ] Add release verification checks that fail closed when any pack lacks a
+- [x] Add release verification checks that fail closed when any pack lacks a
       manifest, signature bundle, checksum, SBOM, or expected version metadata.
+      (builder-pack gate in `packaging/release/verify-release-assets.sh`)
 - [ ] Add a reproducibility verification job that rebuilds at least one published
       runtime pack and one published builder pack from source pins and compares
       output hashes.
@@ -608,8 +609,10 @@ The design decisions (settled before this slice; see ADR-097 §9):
       (Runtime pack producer/publish deferred — builder pack first.)
 - [ ] Restrict the signing job to protected tag refs / a protected environment so
       the pinned subject identity cannot be minted from an arbitrary ref.
-- [ ] Add the release verification gate (plan §B) that fails closed when any pack
+- [x] Add the release verification gate (plan §B) that fails closed when any pack
       lacks a manifest, bundle, checksum, SBOM, or expected version metadata.
+      (`verify-release-assets.sh` builder-pack gate: complete-or-absent, checksum-
+      matched; self-tested + CI-linted.)
 - [ ] Validate the workflow off release tags via `gh workflow run --ref <branch>`
       (the release/security workflows are tag/nightly-gated and PR-invisible).
 
@@ -702,10 +705,15 @@ OIDC signing, the nix image build + SBOM step, and end-to-end publish→download
 Prove on the next tagged release (or `gh workflow run` against the branch, which the
 release job's dry-run guards partially exercise).
 
-### Units 3–4 follow-ups (not done)
+### Units 3–4 follow-ups
 
-- **Release verification gate (§B):** extend the "Verify release asset set" job to
-  fail closed when a builder pack lacks its manifest / bundle / checksum / SBOM.
+- ✅ **Release verification gate (§B)** — `verify-release-assets.sh` now fails the
+  release closed on a partial / checksum-mismatched / unlisted builder pack
+  (complete-or-absent), with a self-contained fixture test wired into CI Lint.
+- ✅ **cosign bundle format** — the Rust `sigstore-verify` stack rejects the legacy
+  `cosign sign-blob --bundle` output; every Rust-verified signing step (builder
+  pack + dev-image manifest) now signs `--new-bundle-format`, proven live by the
+  pack-signing smoke round-tripping both paths.
 - **Protected environment for the signing job** so the pinned SAN can't be minted
   from an arbitrary ref (beyond the existing tag-push gate).
 - **Producer SBOM URI is `file://<local path>`** (unverified provenance metadata,


### PR DESCRIPTION
Implements Plan 213 §B's release-verification gate for attested builder packs — the belt-and-suspenders that turns "a signing step silently produced no pack" into a loud, release-failing error.

## Why

A builder pack is an accelerator, published best-effort: a Fulcio/OIDC outage skips signing (guarded by `continue-on-error` + the tag/version guard) and the plain `vmlinux`/`rootfs` still ship. But a **partial** pack — say, a manifest with no cosign bundle — is a packaging bug: an installed binary would fetch it, fail keyless verification, and **silently fall back to the plain download**. Nothing today catches that at release time.

## What

Extends `packaging/release/verify-release-assets.sh` (already run by the `verify-release` job post-publish) with a per-builder-arch check:

- **Complete** (`builder-vm-<arch>.pack-manifest.json` + `.bundle` + `.sbom.txt`, each listed in and hash-matching `builder-vm-<arch>-checksums-sha256.txt`) → ok.
- **Absent** (all three missing) → ok (accelerator legitimately skipped; plain images shipped).
- **Partial or checksum-mismatched or unlisted** → **fail closed**, failing the release.

## Tests

`packaging/release/verify-release-assets.test.sh` — self-contained, no network/cosign: builds a valid fixture and asserts complete→pass, partial→fail, absent→pass, tampered-checksum→fail, unlisted→fail (5/5). Wired into the CI `Lint` job, which also now shellchecks the release script (both shellcheck-clean).

## Scope

Independent of the cosign-format fix (#1537) — this touches the verifier script + CI only, not `release.yml`'s signing steps. Complements it: #1537 makes the bundle *verifiable*; this makes an *incomplete* pack fail the release.
