### PR TITLE
feat(mvm-core): bind keyless pack signer id to the verifying identity (Plan 213 §I prep)

### DIFF
--- a/crates/mvm-core/src/packs.rs
+++ b/crates/mvm-core/src/packs.rs
@@ -424,26 +424,44 @@ pub fn verify_pack_keyless_at(
     revocations: &dyn PackRevocationChecker,
 ) -> Result<VerifiedPack, PackVerifyError> {
     validate_signature_bundle_keyless(manifest)?;
+    // Bind the pack's stamped signer id to the identity that actually verifies
+    // it: only consider accepted identities whose derived key id equals
+    // `signing_key_id`, so the signature and the id revocation keys on cannot
+    // name different signers. A pack whose stamped id matches no accepted
+    // identity is refused before any signature bytes are examined.
+    let stamped = &manifest.trust.signing_key_id;
+    let candidates: Vec<&str> = keyless
+        .accepted_identities
+        .iter()
+        .filter(|identity| KeyId::from_identity(identity) == *stamped)
+        .map(String::as_str)
+        .collect();
+    if candidates.is_empty() {
+        return Err(PackVerifyError::SignerIdentityMismatch {
+            signing_key_id: stamped.clone(),
+        });
+    }
     let payload = manifest.signature_payload_bytes()?;
     let mut failure: Option<String> = None;
-    let verified = keyless.accepted_identities.iter().any(|identity| {
-        match crate::crypto::image_verify::verify_signed_payload(
-            &payload,
-            cosign_bundle,
-            identity,
-            &keyless.issuer,
-        ) {
-            Ok(()) => true,
-            Err(error) => {
-                failure = Some(error.to_string());
-                false
-            }
-        }
-    });
+    let verified =
+        candidates.iter().any(
+            |identity| match crate::crypto::image_verify::verify_signed_payload(
+                &payload,
+                cosign_bundle,
+                identity,
+                &keyless.issuer,
+            ) {
+                Ok(()) => true,
+                Err(error) => {
+                    failure = Some(error.to_string());
+                    false
+                }
+            },
+        );
     if !verified {
         return Err(PackVerifyError::KeylessSignatureInvalid(
             failure.unwrap_or_else(|| {
-                "no accepted identities configured for keyless verification".to_string()
+                "keyless signature did not verify under any candidate identity".to_string()
             }),
         ));
     }
@@ -885,6 +903,8 @@ pub enum PackVerifyError {
     },
     #[error("keyless signature verification failed: {0}")]
     KeylessSignatureInvalid(String),
+    #[error("pack signer id {signing_key_id:?} matches no accepted release identity")]
+    SignerIdentityMismatch { signing_key_id: KeyId },
     #[error(transparent)]
     Manifest(#[from] PackManifestError),
 }
@@ -1912,6 +1932,39 @@ mod tests {
             )
             .expect_err("bad bundle");
             assert!(matches!(err, PackVerifyError::KeylessSignatureInvalid(_)));
+        }
+
+        #[test]
+        fn signer_id_not_matching_accepted_identity_is_rejected() {
+            let dir = TempDir::new().expect("tempdir");
+            // sigstore_manifest stamps signing_key_id = from_identity(IDENTITY).
+            let m = sigstore_manifest(&dir);
+            // A trust root that accepts only a different release identity: its
+            // derived id can't equal the stamped one, so the pack is refused
+            // before any signature bytes are examined — the stamped signer id
+            // must correspond to the identity that would verify it.
+            let other = KeylessTrust {
+                accepted_identities: vec![
+                    "https://github.com/tinylabscom/mvm/.github/workflows/release.yml@refs/tags/v9.9.9"
+                        .to_string(),
+                ],
+                issuer: ISSUER.to_string(),
+            };
+            let err = verify_pack_keyless_at(
+                &m,
+                dir.path(),
+                &hvf_policy(),
+                b"bundle",
+                &other,
+                &StaticRevocation {
+                    status: RevocationStatus::Good,
+                },
+            )
+            .expect_err("signer id mismatch");
+            assert!(matches!(
+                err,
+                PackVerifyError::SignerIdentityMismatch { .. }
+            ));
         }
 
         #[test]

--- a/specs/plans/213-attested-fast-first-boot-packs.md
+++ b/specs/plans/213-attested-fast-first-boot-packs.md
@@ -672,11 +672,12 @@ embedded root stays inert.
 
 ### Review follow-ups (Minor, deferred with a home)
 
-- **Cross-bind `signing_key_id` to the matched keyless identity** — the keyless
-  verifier trusts the producer-stamped `signing_key_id` (it is inside the signed
-  payload, so unforgeable, but not checked to equal `from_identity(matched)`).
-  No practical impact until keyless revocation has teeth; fold into the
-  live-revocation work (§I) so revocation-keying can't drift.
+- ✅ **Cross-bind `signing_key_id` to the verifying keyless identity** — the
+  keyless verifier now only considers accepted identities whose
+  `from_identity` equals the stamped `signing_key_id`, and refuses a pack whose
+  id matches none (`SignerIdentityMismatch`) before any signature is examined.
+  The signature and the id revocation keys on can no longer name different
+  signers — the prerequisite for trustworthy keyless revocation (§I).
 - **Keyless materialization error short-circuits the ed25519 fallback** — a
   placement (not resolution) error in the keyless attempt propagates and skips
   the ed25519 attempt before falling through to the plain download. Fail-safe


### PR DESCRIPTION
First slice of the revocation workstream (ADR-097 §I) — and the review follow-up flagged during #1530: bind a keyless pack's `signing_key_id` to the identity that actually verifies it.

## Why

The keyless verifier records `signing_key_id` from the manifest and revocation keys on it. That id is inside the signed payload (so a valid signature vouches for it), but nothing checked it corresponds to the *identity the signature verifies under*. A legitimate-but-buggy producer could stamp an id that doesn't match its signing identity, and revocation — which keys on `signing_key_id` — would then target the wrong signer.

## What

`verify_pack_keyless_at` now:
- considers only accepted identities whose `KeyId::from_identity(identity)` equals the stamped `signing_key_id`;
- refuses a pack whose stamped id matches no accepted identity with a distinct `SignerIdentityMismatch` error, **before** any signature bytes are examined;
- verifies the signature only under a matching identity.

So the signature and the id revocation keys on can no longer name different signers. This makes `signing_key_id` trustworthy for revocation — the prerequisite for the live-revocation-channel work.

## Tests

Offline-provable (this check fires before the un-mockable signature step): a Sigstore pack whose stamped id matches none of the accepted identities is rejected with `SignerIdentityMismatch`. Existing keyless tests unchanged (a correctly-produced pack's identity still matches → same behavior). mvm-core `1568` (default) / `1572` (manifest-verify) tests green; clippy clean both ways; downstream crates compile.

## Next in §I

The live revocation-channel fetch + offline cache (a signed pack-revocation list, keyless-verified and applied as the `PackRevocationChecker`) — a separate, larger PR that builds on this binding.
