### PR TITLE
docs: how to use mvm from studio, mvmd, and custom frontends

### DIFF
--- a/README.md
+++ b/README.md
@@ -346,8 +346,65 @@ let out = client.exec_machine(&machine.id, vec!["uname".into(), "-sr".into()]).a
 println!("{}", String::from_utf8_lossy(&out.stdout));
 ```
 
-The same facade is what the CLI, the GUI/studio, and the fleet orchestrator all
-consume — one surface, every frontend.
+The same facade is what the CLI, the desktop **studio** GUI, and the fleet
+orchestrator (**mvmd**) all consume — one surface, every frontend.
+
+#### Embedding mvm — studio, mvmd, and custom frontends
+
+There are two integration seams, depending on what you're building.
+
+**Driving machines from a frontend** (the desktop studio, a custom GUI/CLI, a web
+service): link `mvm-client` and go through the `MvmClient` trait. `connect(Target)`
+picks the transport; the returned `Box<dyn MvmClient>` behaves identically either
+way, so the same UI code drives a local host or a remote fleet:
+
+```rust
+use mvm_client::{connect, MvmClient, Target};
+
+// In-process — this host's microVMs, auto-selected VMM. No daemon required.
+let local = connect(Target::Local)?;              // == mvm_client_local::LocalBackend::new()
+
+// Remote — a hosted fleet or a local sidecar, over REST (needs feature `remote`).
+let remote = connect(Target::Gateway {
+    base_url: "https://fleet.example.com".into(),
+    token: std::env::var("MVM_TOKEN")?,
+})?;
+
+// Identical methods on both: create / run / start / stop / remove, exec, logs, reconfigure.
+for m in remote.list_machines(Default::default()).await? {
+    println!("{}", m.id);
+}
+```
+
+The **studio** desktop app is exactly this pattern — a `GatewayBackend` by
+default, or the in-process `LocalBackend` when built `--features local` with
+`MVM_STUDIO_BACKEND=local` — one `dyn MvmClient` behind its Tauri commands. Its
+`Cargo.toml`:
+
+```toml
+mvm-client       = { path = "../mvm/crates/mvm-client", features = ["remote"] }
+mvm-client-local = { path = "../mvm/crates/mvm-client-local" }   # optional, gated by a `local` feature
+```
+
+**Embedding the runtime in a host-side daemon** (the **mvmd** fleet orchestrator,
+or your own controller that manages instances directly): link the `mvmctl`
+library facade for the runtime types, the host shell seam, and the gated
+host↔guest IPC transport. Keep `default-features = false` so no async runtime is
+pulled in unless you opt into the transport:
+
+```toml
+mvmctl = { path = "../mvm", default-features = false, features = ["hostd-transport"] }
+```
+
+```rust
+use mvmctl::core::{instance::InstanceStatus, pool::Role, protocol};
+use mvmctl::runtime::shell;   // host command-execution seam
+```
+
+`mvmd` reconciles pools/instances and reaches each guest agent over the
+`hostd-transport` protocol through this seam, while workload-driving frontends
+stay on the `MvmClient` facade above. Rule of thumb: **drive sandboxes → `MvmClient`;
+run the host that hosts them → the `mvmctl` facade.**
 
 ---
 

--- a/public/src/content/docs/sdk/rust.md
+++ b/public/src/content/docs/sdk/rust.md
@@ -73,3 +73,54 @@ client.stop_machine(&machine.id).await?;
 The builder is equivalent to a struct literal — every field stays public — but
 reads far better at call sites and lets new optional fields land without churning
 existing callers.
+
+### Embedding it — studio, mvmd, and custom frontends
+
+`connect(Target)` returns a `Box<dyn MvmClient>` and hides the transport, so one
+piece of UI/service code drives either this host or a remote fleet:
+
+```rust
+use mvm_client::{connect, MvmClient, Target};
+
+// In-process — this host's microVMs (auto-selected VMM). No daemon required.
+let local = connect(Target::Local)?;          // == mvm_client_local::LocalBackend::new()
+
+// Remote — a hosted fleet or a local sidecar over REST (feature `remote`).
+let remote = connect(Target::Gateway {
+    base_url: "https://fleet.example.com".into(),
+    token: std::env::var("MVM_TOKEN")?,
+})?;
+
+for m in remote.list_machines(Default::default()).await? {
+    println!("{}", m.id);
+}
+```
+
+The **studio** desktop app is this pattern: a `GatewayBackend` by default, or the
+in-process `LocalBackend` when built `--features local` with
+`MVM_STUDIO_BACKEND=local` — one `dyn MvmClient` behind its Tauri commands.
+
+```toml
+# a frontend that drives machines
+mvm-client       = { path = "../mvm/crates/mvm-client", features = ["remote"] }
+mvm-client-local = { path = "../mvm/crates/mvm-client-local" }   # optional, in-process backend
+```
+
+A **host-side daemon that manages instances directly** — the **mvmd** fleet
+orchestrator, or your own controller — instead links the `mvmctl` library facade
+for the runtime types, host shell seam, and the gated host↔guest IPC transport.
+`default-features = false` keeps it lean (no async runtime unless you opt into the
+transport):
+
+```toml
+# a daemon that runs the host that hosts sandboxes
+mvmctl = { path = "../mvm", default-features = false, features = ["hostd-transport"] }
+```
+
+```rust
+use mvmctl::core::{instance::InstanceStatus, pool::Role, protocol};
+use mvmctl::runtime::shell;   // host command-execution seam
+```
+
+Rule of thumb: **drive sandboxes → the `MvmClient` facade; run the host that hosts
+them → the `mvmctl` facade.**


### PR DESCRIPTION
Documents the two integration seams for consuming mvm, in the README and the website Rust SDK page:

- **Frontends** (the desktop **studio**, custom GUIs/CLIs, web services) drive machines through the `MvmClient` facade — `connect(Target::Local)` in-process or `Target::Gateway { base_url, token }` remote, one `dyn MvmClient` either way.
- **Host-side daemons** (**mvmd**, custom orchestrators) link the `mvmctl` library facade (`default-features = false, features = ["hostd-transport"]`) for the runtime types, host shell seam, and gated host↔guest IPC transport.

Both shown with the real Cargo deps each project uses. Rule of thumb: drive sandboxes → `MvmClient`; run the host that hosts them → `mvmctl`.