### PR TITLE
feat(mvm-core): signed pack revocation list + combined revocation checker (Plan 213 §I)

### DIFF
--- a/crates/mvm-core/src/lib.rs
+++ b/crates/mvm-core/src/lib.rs
@@ -50,6 +50,7 @@ pub mod migration;
 pub mod naming;
 pub mod observability;
 pub mod pack_cache;
+pub mod pack_revocation;
 pub mod pack_trust;
 pub mod packs;
 /// Compiled-in release-signing identity: the OIDC issuer and identity

--- a/crates/mvm-core/src/pack_revocation.rs
+++ b/crates/mvm-core/src/pack_revocation.rs
@@ -1,0 +1,285 @@
+//! Signed, fetchable pack revocation list.
+//!
+//! `pack_trust::PackTrustConfig.revocations` is a hand-placed, operator-owned
+//! list — fine once an operator has curated a trust config, useless on a
+//! fresh install that has never seen one. This module adds the other half:
+//! a list the project itself signs and publishes, so a fresh install can
+//! learn about a revoked pack without any local config. `CombinedRevocations`
+//! lets a caller union the two sources into one `PackRevocationChecker`.
+
+use chrono::{DateTime, Utc};
+use serde::{Deserialize, Serialize};
+
+use crate::pack_trust::{RevokedPack, revocation_status};
+use crate::packs::{KeylessTrust, PackRevocationChecker, RevocationStatus, Sha256Hex};
+use crate::plan::bundle::KeyId;
+
+pub const PACK_REVOCATION_SCHEMA_VERSION: u32 = 1;
+
+/// The project-signed counterpart to `PackTrustConfig.revocations`. Carries
+/// its own validity window (`issued_at`/`not_after`) since, unlike an
+/// operator's hand-placed config, a fetched list can go stale if the
+/// publishing pipeline stalls — a caller that trusted a stale list would
+/// miss a real revocation.
+#[derive(Debug, Clone, Default, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct PackRevocationList {
+    pub schema_version: u32,
+    #[serde(default)]
+    pub revocations: Vec<RevokedPack>,
+    pub issued_at: DateTime<Utc>,
+    pub not_after: DateTime<Utc>,
+}
+
+impl PackRevocationChecker for PackRevocationList {
+    fn status(&self, key_id: &KeyId, pack_hash: &Sha256Hex) -> RevocationStatus {
+        revocation_status(&self.revocations, key_id, pack_hash)
+    }
+}
+
+/// Unions any number of revocation sources: a pack is revoked if *any*
+/// source revokes it. Lets a caller feed both the fetched
+/// `PackRevocationList` and the on-disk `PackTrustConfig` to `verify_pack_at`
+/// / `verify_pack_keyless_at` as a single checker.
+pub struct CombinedRevocations<'a>(pub Vec<&'a dyn PackRevocationChecker>);
+
+impl PackRevocationChecker for CombinedRevocations<'_> {
+    fn status(&self, key_id: &KeyId, pack_hash: &Sha256Hex) -> RevocationStatus {
+        for source in &self.0 {
+            if let revoked @ RevocationStatus::Revoked { .. } = source.status(key_id, pack_hash) {
+                return revoked;
+            }
+        }
+        RevocationStatus::Good
+    }
+}
+
+#[derive(Debug, thiserror::Error)]
+pub enum PackRevocationError {
+    #[error("pack revocation list signature is invalid: {0}")]
+    SignatureInvalid(String),
+    #[error("pack revocation list is not valid JSON: {0}")]
+    Parse(String),
+    #[error("pack revocation list schema version {found} not supported (expected {supported})")]
+    UnsupportedSchema { found: u32, supported: u32 },
+    #[error("pack revocation list is stale: not_after {not_after} (now {now})")]
+    Stale {
+        not_after: DateTime<Utc>,
+        now: DateTime<Utc>,
+    },
+}
+
+/// Verify a fetched revocation list's cosign signature, then parse and
+/// validate it. Signature verification runs first and the JSON is parsed
+/// only after it succeeds — `list_bytes` is untrusted network input until
+/// then. Tries every identity in `keyless.accepted_identities` in order and
+/// succeeds if any one verifies.
+#[cfg(feature = "manifest-verify")]
+pub fn verify_pack_revocation_list(
+    list_bytes: &[u8],
+    cosign_bundle: &[u8],
+    keyless: &KeylessTrust,
+    now: DateTime<Utc>,
+) -> Result<PackRevocationList, PackRevocationError> {
+    let mut failure: Option<String> = None;
+    let verified = keyless.accepted_identities.iter().any(|identity| {
+        match crate::crypto::image_verify::verify_signed_payload(
+            list_bytes,
+            cosign_bundle,
+            identity,
+            &keyless.issuer,
+        ) {
+            Ok(()) => true,
+            Err(error) => {
+                failure = Some(error.to_string());
+                false
+            }
+        }
+    });
+    if !verified {
+        return Err(PackRevocationError::SignatureInvalid(
+            failure.unwrap_or_else(|| {
+                "no accepted identities configured for keyless verification".to_string()
+            }),
+        ));
+    }
+    let list: PackRevocationList = serde_json::from_slice(list_bytes)
+        .map_err(|error| PackRevocationError::Parse(error.to_string()))?;
+    if list.schema_version != PACK_REVOCATION_SCHEMA_VERSION {
+        return Err(PackRevocationError::UnsupportedSchema {
+            found: list.schema_version,
+            supported: PACK_REVOCATION_SCHEMA_VERSION,
+        });
+    }
+    if list.not_after <= now {
+        return Err(PackRevocationError::Stale {
+            not_after: list.not_after,
+            now,
+        });
+    }
+    Ok(list)
+}
+
+/// No-feature fallback: refuse every fetched revocation list. Builds
+/// without `manifest-verify` drop the sigstore dependency tree in exchange
+/// for losing the ability to verify a fetched list; the on-disk
+/// `PackTrustConfig` revocation path is unaffected.
+#[cfg(not(feature = "manifest-verify"))]
+pub fn verify_pack_revocation_list(
+    _list_bytes: &[u8],
+    _cosign_bundle: &[u8],
+    _keyless: &KeylessTrust,
+    _now: DateTime<Utc>,
+) -> Result<PackRevocationList, PackRevocationError> {
+    Err(PackRevocationError::SignatureInvalid(
+        "manifest-verify feature disabled in this build; rebuild mvmctl with \
+         default features to verify a fetched pack revocation list"
+            .to_string(),
+    ))
+}
+
+#[cfg(test)]
+mod tests {
+    use chrono::TimeZone;
+
+    use super::*;
+    use crate::pack_trust::PackTrustConfig;
+
+    fn utc(y: i32, m: u32, d: u32) -> DateTime<Utc> {
+        Utc.with_ymd_and_hms(y, m, d, 0, 0, 0)
+            .single()
+            .expect("valid timestamp")
+    }
+
+    fn key_id(seed: u8) -> KeyId {
+        use ed25519_dalek::SigningKey;
+        KeyId::from_pubkey(&SigningKey::from_bytes(&[seed; 32]).verifying_key())
+    }
+
+    fn sample_list() -> PackRevocationList {
+        PackRevocationList {
+            schema_version: PACK_REVOCATION_SCHEMA_VERSION,
+            revocations: vec![RevokedPack {
+                key_id: key_id(1),
+                pack_hash: None,
+                reason: "key compromised".to_string(),
+            }],
+            issued_at: utc(2026, 1, 1),
+            not_after: utc(2026, 12, 31),
+        }
+    }
+
+    #[test]
+    fn list_roundtrips() {
+        let list = sample_list();
+        let json = serde_json::to_string(&list).expect("serialize");
+        let recovered: PackRevocationList = serde_json::from_str(&json).expect("deserialize");
+        assert_eq!(recovered, list);
+    }
+
+    #[test]
+    fn unknown_field_is_rejected() {
+        let mut value = serde_json::to_value(sample_list()).expect("to_value");
+        value
+            .as_object_mut()
+            .expect("object")
+            .insert("surprise".to_string(), serde_json::Value::Bool(true));
+        let err = serde_json::from_value::<PackRevocationList>(value).expect_err("rejected");
+        assert!(err.to_string().contains("surprise"), "got: {err}");
+    }
+
+    #[test]
+    fn whole_key_entry_revokes_any_pack_hash() {
+        let list = sample_list();
+        let id = key_id(1);
+        assert!(matches!(
+            list.status(&id, &Sha256Hex::from_bytes(b"anything")),
+            RevocationStatus::Revoked { .. }
+        ));
+        assert!(matches!(
+            list.status(&id, &Sha256Hex::from_bytes(b"else")),
+            RevocationStatus::Revoked { .. }
+        ));
+    }
+
+    #[test]
+    fn pinned_entry_revokes_only_that_pack_hash() {
+        let bad = Sha256Hex::from_bytes(b"bad-pack");
+        let good = Sha256Hex::from_bytes(b"good-pack");
+        let id = key_id(2);
+        let list = PackRevocationList {
+            schema_version: PACK_REVOCATION_SCHEMA_VERSION,
+            revocations: vec![RevokedPack {
+                key_id: id.clone(),
+                pack_hash: Some(bad.clone()),
+                reason: "bad build".to_string(),
+            }],
+            issued_at: utc(2026, 1, 1),
+            not_after: utc(2026, 12, 31),
+        };
+        assert!(matches!(
+            list.status(&id, &bad),
+            RevocationStatus::Revoked { .. }
+        ));
+        assert_eq!(list.status(&id, &good), RevocationStatus::Good);
+    }
+
+    #[test]
+    fn no_matching_entry_is_good() {
+        let list = sample_list();
+        let unrelated = key_id(9);
+        assert_eq!(
+            list.status(&unrelated, &Sha256Hex::from_bytes(b"pack")),
+            RevocationStatus::Good
+        );
+    }
+
+    #[test]
+    fn combined_revoked_if_either_source_revokes() {
+        let id = key_id(1);
+        let list = sample_list(); // revokes key_id(1) wholesale
+        let empty_config = PackTrustConfig::default();
+        let combined = CombinedRevocations(vec![&list, &empty_config]);
+        assert!(matches!(
+            combined.status(&id, &Sha256Hex::from_bytes(b"pack")),
+            RevocationStatus::Revoked { .. }
+        ));
+    }
+
+    #[test]
+    fn combined_good_if_neither_source_revokes() {
+        let unrelated = key_id(42);
+        let list = sample_list();
+        let empty_config = PackTrustConfig::default();
+        let combined = CombinedRevocations(vec![&list, &empty_config]);
+        assert_eq!(
+            combined.status(&unrelated, &Sha256Hex::from_bytes(b"pack")),
+            RevocationStatus::Good
+        );
+    }
+
+    #[cfg(feature = "manifest-verify")]
+    #[test]
+    fn garbage_bundle_is_signature_invalid() {
+        let keyless = crate::release_trust::revocation_keyless_trust();
+        let list_bytes = serde_json::to_vec(&sample_list()).expect("json");
+        let err = verify_pack_revocation_list(
+            &list_bytes,
+            b"not a real bundle",
+            &keyless,
+            utc(2026, 6, 1),
+        )
+        .expect_err("garbage bundle must fail signature verification");
+        assert!(matches!(err, PackRevocationError::SignatureInvalid(_)));
+    }
+
+    #[cfg(not(feature = "manifest-verify"))]
+    #[test]
+    fn no_feature_build_always_refuses() {
+        let keyless = crate::release_trust::revocation_keyless_trust();
+        let list_bytes = serde_json::to_vec(&sample_list()).expect("json");
+        let err = verify_pack_revocation_list(&list_bytes, b"anything", &keyless, utc(2026, 6, 1))
+            .expect_err("no-feature build always refuses");
+        assert!(matches!(err, PackRevocationError::SignatureInvalid(_)));
+    }
+}

--- a/crates/mvm-core/src/pack_trust.rs
+++ b/crates/mvm-core/src/pack_trust.rs
@@ -109,24 +109,37 @@ impl PackTrustStore for PackTrustConfig {
 
 impl PackRevocationChecker for PackTrustConfig {
     fn status(&self, key_id: &KeyId, pack_hash: &Sha256Hex) -> RevocationStatus {
-        for entry in &self.revocations {
-            if &entry.key_id != key_id {
-                continue;
-            }
-            // A pinned pack_hash revokes only that pack; an unpinned entry
-            // revokes the whole key.
-            let matches = match &entry.pack_hash {
-                Some(pinned) => pinned == pack_hash,
-                None => true,
-            };
-            if matches {
-                return RevocationStatus::Revoked {
-                    reason: entry.reason.clone(),
-                };
-            }
-        }
-        RevocationStatus::Good
+        revocation_status(&self.revocations, key_id, pack_hash)
     }
+}
+
+/// Shared revocation-list scan: an entry whose `key_id` matches and whose
+/// `pack_hash` is unset (whole-key) or equal to `pack_hash` (pinned) revokes.
+/// Factored out so `pack_revocation::PackRevocationList` — the fetched,
+/// project-signed counterpart to this operator-owned config — can reuse the
+/// exact same matching rule instead of drifting a second copy.
+pub(crate) fn revocation_status(
+    revocations: &[RevokedPack],
+    key_id: &KeyId,
+    pack_hash: &Sha256Hex,
+) -> RevocationStatus {
+    for entry in revocations {
+        if &entry.key_id != key_id {
+            continue;
+        }
+        // A pinned pack_hash revokes only that pack; an unpinned entry
+        // revokes the whole key.
+        let matches = match &entry.pack_hash {
+            Some(pinned) => pinned == pack_hash,
+            None => true,
+        };
+        if matches {
+            return RevocationStatus::Revoked {
+                reason: entry.reason.clone(),
+            };
+        }
+    }
+    RevocationStatus::Good
 }
 
 #[derive(Debug, Error)]

--- a/crates/mvm-core/src/release_trust.rs
+++ b/crates/mvm-core/src/release_trust.rs
@@ -36,6 +36,27 @@ pub fn release_keyless_trust(version: &str) -> KeylessTrust {
     }
 }
 
+/// Identity for the workflow that signs the pack revocation list. Unlike
+/// `RELEASE_IDENTITY_TEMPLATES`, this carries no `{version}` placeholder — a
+/// revocation list applies across every released version, so its signing
+/// identity is bound to a dedicated `revocations` tag instead of a
+/// per-release one. A separate identity from the release workflow also means
+/// a leaked release-signing cert can't forge a revocation entry.
+const REVOCATION_IDENTITY_TEMPLATES: &[&str] =
+    &["https://github.com/tinylabscom/mvm/.github/workflows/revocations.yml@refs/tags/revocations"];
+
+/// Build the keyless trust root a stock binary uses to verify the fetched
+/// pack revocation list.
+pub fn revocation_keyless_trust() -> KeylessTrust {
+    KeylessTrust {
+        accepted_identities: REVOCATION_IDENTITY_TEMPLATES
+            .iter()
+            .map(|s| s.to_string())
+            .collect(),
+        issuer: RELEASE_OIDC_ISSUER.to_string(),
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -66,5 +87,31 @@ mod tests {
         let t = release_keyless_trust("0.17.0");
         assert_eq!(t.issuer, RELEASE_OIDC_ISSUER);
         assert_eq!(t.accepted_identities, accepted_release_identities("0.17.0"));
+    }
+
+    #[test]
+    fn revocation_keyless_trust_uses_release_issuer() {
+        let t = revocation_keyless_trust();
+        assert_eq!(t.issuer, RELEASE_OIDC_ISSUER);
+    }
+
+    #[test]
+    fn revocation_keyless_trust_identities_target_revocations_tag() {
+        let t = revocation_keyless_trust();
+        assert!(
+            t.accepted_identities
+                .iter()
+                .any(|i| i.contains("revocations.yml@refs/tags/revocations"))
+        );
+    }
+
+    #[test]
+    fn revocation_keyless_trust_has_no_version_placeholder() {
+        let t = revocation_keyless_trust();
+        assert!(
+            t.accepted_identities
+                .iter()
+                .all(|i| !i.contains("{version}"))
+        );
     }
 }


### PR DESCRIPTION
Second slice of the revocation workstream (ADR-097 §I): the signed, fetchable **revocation list** — the offline-testable core that lets a fresh install learn about a revoked pack without a hand-placed config. (Builds on #1543's signer-id binding, which made revocation keying trustworthy.)

## What

New `mvm-core::pack_revocation`:
- **`PackRevocationList`** — the project-signed counterpart to `PackTrustConfig.revocations`, with its own validity window (`issued_at`/`not_after`) so a stale list (publishing pipeline stalled) is rejected rather than silently trusted past a real revocation. Implements `PackRevocationChecker`.
- **`CombinedRevocations`** — unions any number of sources (a pack is revoked if *any* source revokes it), so a caller feeds both the fetched list and the on-disk `PackTrustConfig` to the verifier as one checker.
- **`verify_pack_revocation_list`** (`manifest-verify`-gated) — verifies the keyless cosign signature over the list bytes **first** (untrusted network input isn't parsed until the signature checks out), then parses, rejects an unsupported schema, and rejects a stale list. Fail-closed no-feature fallback.
- **`release_trust::revocation_keyless_trust()`** — the revocation signing identity is the fixed `revocations.yml@refs/tags/revocations` (version-*independent*, since a revocation list applies across releases — mirrors the existing dev-image revocation identity), not the version-interpolated release identity.

Also factors the revocation-status loop out of `PackTrustConfig` into a shared `revocation_status(...)` both checkers use (behavior-preserving).

## Tests

Offline: list serde roundtrip + `deny_unknown_fields`; whole-key vs pinned-pack revocation vs no-match; `CombinedRevocations` revoked-if-either / good-if-neither; the no-feature fallback refuses; and (manifest-verify) a garbage bundle → `SignatureInvalid`. The positive signature + schema + freshness paths sit behind the un-mockable cosign step and prove out live. mvm-core `1579` (default) / `1582` (manifest-verify) green; clippy clean both ways.

## Next in §I

The network leg: fetch the signed list from the channel, keyless-verify it, cache it offline with a fresh window, and pass `CombinedRevocations(fetched + config)` into the pack verify path — plus a `revocations.yml` producer to actually publish/sign a list (none exists yet, so this consumer is inert until then, mirroring how the pack path started).
