### PR TITLE
fix(builder): reap orphaned gvproxy by socket; prefer fresh local supervisor

### DIFF
--- a/crates/deps/libkrun-sys/src/gvproxy.rs
+++ b/crates/deps/libkrun-sys/src/gvproxy.rs
@@ -470,6 +470,91 @@ pub fn reap_by_pid_file(scratch_dir: &Path) {
     let _ = std::fs::remove_file(scratch_dir.join("gvproxy.sock"));
 }
 
+/// Backstop reaper that kills a gvproxy still bound to
+/// `<scratch_dir>/gvproxy.sock` even when no `gvproxy.pid` sidecar exists —
+/// the case a supervisor binary predating the sidecar leaves behind (it spawns
+/// gvproxy without writing the pid file, so [`reap_by_pid_file`] finds nothing
+/// to reap and the daemon reparents to the init process). Scans the process
+/// table for whatever gateway is bound to this VM's socket (gvproxy, or the
+/// native gateway swapped in via `MVM_GATEWAY_BIN` — both carry the socket path
+/// in argv) and `SIGKILL`s it, then unlinks the socket. gvproxy ignores
+/// `SIGTERM`, so a graceful window buys nothing here.
+///
+/// Idempotent: a missing socket or no argv match is a clean no-op. Keyed on the
+/// per-VM socket path, which is unique to this VM's scratch dir, so it never
+/// touches another VM's gateway. The parent-aware sweep behind `mvmctl cache
+/// prune` supersedes this for cross-VM cleanup; this is the per-teardown
+/// guarantee the spawning host makes for the one VM it just waited on.
+pub fn reap_by_socket_path(scratch_dir: &Path) {
+    let socket_path = scratch_dir.join("gvproxy.sock");
+    if !socket_path.exists() {
+        return;
+    }
+    let self_pid = std::process::id() as i32;
+    for pid in pids_bound_to_socket(&socket_path) {
+        if pid == self_pid || pid <= 1 {
+            continue;
+        }
+        // SAFETY: kill on a since-exited pid races to ESRCH, which is benign.
+        unsafe { libc::kill(pid, libc::SIGKILL) };
+    }
+    let _ = std::fs::remove_file(&socket_path);
+}
+
+/// PIDs whose argv references `socket_path` — the gateway daemon(s) bound to
+/// this VM's gvproxy socket. Reads one process-table snapshot: `/proc` on
+/// Linux, a single `ps` on macOS/BSD (no `/proc`). The far richer, parent-aware
+/// process sweep behind `mvmctl cache prune` lives in the CLI layer; this crate
+/// can't reach up to it, so this stays a minimal self-contained probe scoped to
+/// a single known socket path.
+fn pids_bound_to_socket(socket_path: &Path) -> Vec<i32> {
+    let needle = socket_path.to_string_lossy();
+
+    #[cfg(target_os = "linux")]
+    {
+        let mut pids = Vec::new();
+        let Ok(entries) = std::fs::read_dir("/proc") else {
+            return pids;
+        };
+        for entry in entries.flatten() {
+            let Some(pid) = entry
+                .file_name()
+                .to_str()
+                .and_then(|s| s.parse::<i32>().ok())
+            else {
+                continue;
+            };
+            // cmdline is NUL-separated argv; a lossy join preserves the path
+            // substring across argument boundaries.
+            if let Ok(bytes) = std::fs::read(entry.path().join("cmdline"))
+                && String::from_utf8_lossy(&bytes).contains(needle.as_ref())
+            {
+                pids.push(pid);
+            }
+        }
+        pids
+    }
+
+    #[cfg(not(target_os = "linux"))]
+    {
+        let Ok(output) = Command::new("ps").args(["-Ao", "pid=,command="]).output() else {
+            return Vec::new();
+        };
+        if !output.status.success() {
+            return Vec::new();
+        }
+        String::from_utf8_lossy(&output.stdout)
+            .lines()
+            .filter_map(|line| {
+                let (pid, cmd) = line.trim_start().split_once(char::is_whitespace)?;
+                cmd.contains(needle.as_ref())
+                    .then(|| pid.parse::<i32>().ok())
+                    .flatten()
+            })
+            .collect()
+    }
+}
+
 /// True if `pid` names a live process we can signal (`kill(pid, 0)`).
 fn pid_alive(pid: i32) -> bool {
     pid > 0 && unsafe { libc::kill(pid, 0) == 0 }
@@ -719,5 +804,62 @@ mod tests {
         std::fs::write(tmp.path().join(PID_FILE_NAME), dead.to_string()).unwrap();
         reap_by_pid_file(tmp.path());
         assert!(!tmp.path().join(PID_FILE_NAME).exists());
+    }
+
+    /// `reap_by_socket_path` SIGKILLs a gateway bound to `<dir>/gvproxy.sock`
+    /// found by its argv alone — the pid-file-less case a supervisor predating
+    /// the sidecar leaves behind. Stand-in is a `sh` sleeper carrying the socket
+    /// path in argv, exactly as gvproxy's `-listen-vfkit unixgram://<path>` does.
+    #[test]
+    fn reap_by_socket_path_kills_gateway_found_by_argv() {
+        use std::os::unix::process::ExitStatusExt;
+        let _env = TestEnv::new();
+        let tmp = tempfile::tempdir().unwrap();
+        let socket = tmp.path().join("gvproxy.sock");
+        std::fs::write(&socket, b"").unwrap();
+
+        // Stand-in gateway: `sh` blocking on the `read` builtin, so it stays in
+        // one process (no forked child to leak) with the socket path in its argv
+        // — exactly where gvproxy's `-listen-vfkit unixgram://<path>` carries it.
+        // The held-open stdin pipe keeps `read` blocking until we SIGKILL it.
+        let mut child = Command::new("sh")
+            .arg("-c")
+            .arg("read _")
+            .arg(socket.display().to_string())
+            .stdin(std::process::Stdio::piped())
+            .spawn()
+            .expect("spawn sh stand-in carrying the socket path in argv");
+        let pid = child.id() as i32;
+
+        // The process table can lag the spawn; poll until the scan sees it.
+        let deadline = Instant::now() + Duration::from_secs(5);
+        while !pids_bound_to_socket(&socket).contains(&pid) {
+            assert!(
+                Instant::now() < deadline,
+                "argv scan never saw the stand-in gateway pid {pid}"
+            );
+            std::thread::sleep(Duration::from_millis(25));
+        }
+
+        reap_by_socket_path(tmp.path());
+
+        // We're the stand-in's parent, so a SIGKILL'd child lingers as a zombie
+        // until we wait() — prove the kill via the wait status, mirroring the
+        // pid-file reap test.
+        let status = child.wait().expect("wait stand-in");
+        assert_eq!(
+            status.signal(),
+            Some(libc::SIGKILL),
+            "stand-in gateway was not SIGKILL'd by the socket reap (status: {status:?})"
+        );
+        assert!(!socket.exists(), "socket not removed by the socket reap");
+    }
+
+    /// No socket file → nothing bound → clean no-op (no scan, no panic).
+    #[test]
+    fn reap_by_socket_path_is_noop_without_socket() {
+        let tmp = tempfile::tempdir().unwrap();
+        reap_by_socket_path(tmp.path());
+        assert!(!tmp.path().join("gvproxy.sock").exists());
     }
 }

--- a/crates/mvm-build/src/libkrun_builder.rs
+++ b/crates/mvm-build/src/libkrun_builder.rs
@@ -1700,12 +1700,15 @@ pub(crate) fn unique_job_id() -> String {
 enum SupervisorSource {
     EnvOverride,
     NextToExe,
+    LocalBuild,
     Path,
 }
 
-/// Pure precedence over the three already-probed candidates: explicit env
-/// override > a binary next to the running exe (a fresh local build) > whatever
-/// is on `$PATH`. Each arg is `Some` only when that candidate exists. Returns
+/// Pure precedence over the four already-probed candidates: explicit env
+/// override > a binary next to the running exe (the version-matched local
+/// build) > a fresh build in a sibling cargo profile dir > whatever is on
+/// `$PATH`. Each arg is `Some` only when that candidate exists (and, for
+/// `local_build`, only when the caller judged it fresher than `$PATH`). Returns
 /// the chosen path and where it came from, or `None` when nothing resolved.
 /// Split out from [`resolve_supervisor_path`] so the precedence — and the
 /// "fell back to PATH" signal that drives the staleness warning — is unit
@@ -1713,6 +1716,7 @@ enum SupervisorSource {
 fn choose_supervisor(
     env_override: Option<PathBuf>,
     next_to_exe: Option<PathBuf>,
+    local_build: Option<PathBuf>,
     on_path: Option<PathBuf>,
 ) -> Option<(PathBuf, SupervisorSource)> {
     if let Some(p) = env_override {
@@ -1721,7 +1725,53 @@ fn choose_supervisor(
     if let Some(p) = next_to_exe {
         return Some((p, SupervisorSource::NextToExe));
     }
+    if let Some(p) = local_build {
+        return Some((p, SupervisorSource::LocalBuild));
+    }
     on_path.map(|p| (p, SupervisorSource::Path))
+}
+
+/// A freshly-built `mvm-libkrun-supervisor` in a sibling cargo profile dir —
+/// e.g. running `target/release/mvmctl` while the supervisor was last built
+/// into `target/debug/`. Source checkouts routinely split the driver and this
+/// per-VM binary across profiles because the supervisor is a separate bin that
+/// mvmctl's own build never refreshes; without this probe the resolver skips
+/// the fresh local build and falls through to a stale `$PATH` copy.
+///
+/// Only activates for a cargo `target/<profile>/` layout — an installed mvmctl
+/// (`~/.cargo/bin/mvmctl`, a release download) has no sibling profiles, so
+/// `$PATH` stays the right source there. Returns the newest match by mtime.
+fn sibling_profile_supervisor(exe_dir: &Path) -> Option<PathBuf> {
+    let target_dir = exe_dir.parent()?;
+    if target_dir.file_name()?.to_str()? != "target" {
+        return None;
+    }
+    let mut candidates: Vec<(std::time::SystemTime, PathBuf)> = std::fs::read_dir(target_dir)
+        .ok()?
+        .flatten()
+        .map(|entry| entry.path())
+        .filter(|profile_dir| profile_dir.is_dir() && profile_dir != exe_dir)
+        .map(|profile_dir| profile_dir.join("mvm-libkrun-supervisor"))
+        .filter(|bin| bin.is_file())
+        .filter_map(|bin| Some((std::fs::metadata(&bin).ok()?.modified().ok()?, bin)))
+        .collect();
+    candidates.sort_by_key(|(mtime, _)| *mtime);
+    candidates.pop().map(|(_, bin)| bin)
+}
+
+/// Whether a sibling-profile `candidate` should win over the `$PATH` copy: no
+/// `$PATH` copy, an unreadable mtime on either side (source-checkout intent —
+/// prefer the fresh local build), or `candidate` at least as new. Guards against
+/// a stale leftover build shadowing a freshly *installed* supervisor.
+fn supervisor_build_outranks_path(candidate: &Path, on_path: Option<&Path>) -> bool {
+    let Some(on_path) = on_path else {
+        return true;
+    };
+    let mtime = |p: &Path| std::fs::metadata(p).and_then(|m| m.modified()).ok();
+    match (mtime(candidate), mtime(on_path)) {
+        (Some(cand), Some(path)) => cand >= path,
+        _ => true,
+    }
 }
 
 fn resolve_supervisor_path() -> Result<PathBuf, BuilderVmError> {
@@ -1740,13 +1790,20 @@ fn resolve_supervisor_path() -> Result<PathBuf, BuilderVmError> {
         }
         None => None,
     };
-    let next_to_exe = std::env::current_exe()
-        .ok()
-        .and_then(|exe| exe.parent().map(|dir| dir.join("mvm-libkrun-supervisor")))
+    let exe = std::env::current_exe().ok();
+    let exe_dir = exe.as_deref().and_then(Path::parent);
+    let next_to_exe = exe_dir
+        .map(|dir| dir.join("mvm-libkrun-supervisor"))
         .filter(|candidate| candidate.is_file());
     let on_path = which::which("mvm-libkrun-supervisor").ok();
+    // A sibling-profile build (fresh local `cargo build`) closes the stale-PATH
+    // trap — but only when it's at least as fresh as the `$PATH` copy, so a
+    // stale leftover build can't shadow a freshly installed supervisor.
+    let local_build = exe_dir
+        .and_then(sibling_profile_supervisor)
+        .filter(|candidate| supervisor_build_outranks_path(candidate, on_path.as_deref()));
 
-    match choose_supervisor(env_override, next_to_exe, on_path) {
+    match choose_supervisor(env_override, next_to_exe, local_build, on_path) {
         Some((path, SupervisorSource::Path)) => {
             // The stale-install trap: a `cargo install`ed copy on $PATH is used
             // because no fresh binary sits next to the exe. Source checkouts
@@ -1876,11 +1933,17 @@ fn spawn_supervisor_and_wait(
     // SIGKILL'd it above. None of those run `GvproxyHandle::Drop` (no
     // unwind) or the supervisor's SIGTERM handler (SIGKILL is uncatchable,
     // exit() skips it), so the per-VM gvproxy is left "waiting for clients"
-    // and reparented to launchd. Reap it here: we (the spawning host) have
-    // observed the supervisor exit, so this is the one place teardown is
-    // guaranteed regardless of how libkrun terminated. See
-    // `gvproxy::reap_by_pid_file` (idempotent; no-op if already gone).
+    // and reparented to the init process. Reap it here: we (the spawning
+    // host) have observed the supervisor exit, so this is the one place
+    // teardown is guaranteed regardless of how libkrun terminated.
+    //
+    // Two-stage so the guarantee holds across supervisor versions: the pid
+    // sidecar is the cheap path, and the socket-argv scan backstops a
+    // supervisor binary that predates the sidecar (it spawns gvproxy without
+    // writing `gvproxy.pid`, so the pid reap finds nothing). Both idempotent —
+    // whichever runs first, the second is a no-op.
     libkrun_sys::gvproxy::reap_by_pid_file(vm_state_dir);
+    libkrun_sys::gvproxy::reap_by_socket_path(vm_state_dir);
 
     match outcome {
         Ok(WaitOutcome::Clean(code)) => Ok(code),
@@ -3943,27 +4006,101 @@ mod tests {
     }
 
     #[test]
-    fn choose_supervisor_prefers_env_then_next_to_exe_then_path() {
+    fn choose_supervisor_prefers_env_then_next_to_exe_then_local_build_then_path() {
         let env = PathBuf::from("/env/mvm-libkrun-supervisor");
         let exe = PathBuf::from("/exe/mvm-libkrun-supervisor");
+        let build = PathBuf::from("/ws/target/debug/mvm-libkrun-supervisor");
         let path = PathBuf::from("/usr/bin/mvm-libkrun-supervisor");
 
         // Env override wins over everything.
         assert_eq!(
-            choose_supervisor(Some(env.clone()), Some(exe.clone()), Some(path.clone())),
-            Some((env.clone(), SupervisorSource::EnvOverride))
+            choose_supervisor(
+                Some(env.clone()),
+                Some(exe.clone()),
+                Some(build.clone()),
+                Some(path.clone())
+            ),
+            Some((env, SupervisorSource::EnvOverride))
         );
-        // Next-to-exe wins over PATH when no env override.
+        // Next-to-exe (version-matched) wins over a sibling build and PATH.
         assert_eq!(
-            choose_supervisor(None, Some(exe.clone()), Some(path.clone())),
+            choose_supervisor(
+                None,
+                Some(exe.clone()),
+                Some(build.clone()),
+                Some(path.clone())
+            ),
             Some((exe, SupervisorSource::NextToExe))
+        );
+        // A fresh sibling-profile build beats a (stale) PATH copy — the trap fix.
+        assert_eq!(
+            choose_supervisor(None, None, Some(build.clone()), Some(path.clone())),
+            Some((build, SupervisorSource::LocalBuild))
         );
         // PATH is the last resort — and is flagged as such so the caller can warn.
         assert_eq!(
-            choose_supervisor(None, None, Some(path.clone())),
+            choose_supervisor(None, None, None, Some(path.clone())),
             Some((path, SupervisorSource::Path))
         );
         // Nothing found.
-        assert_eq!(choose_supervisor(None, None, None), None);
+        assert_eq!(choose_supervisor(None, None, None, None), None);
+    }
+
+    /// A supervisor in a sibling cargo profile dir is discovered (newest wins),
+    /// but only under a `target/<profile>/` layout — an installed-exe layout
+    /// returns `None` so `$PATH` stays authoritative there.
+    #[test]
+    fn sibling_profile_supervisor_finds_newest_under_target_layout() {
+        let tmp = tempfile::tempdir().unwrap();
+        let target = tmp.path().join("target");
+        let release = target.join("release");
+        let debug = target.join("debug");
+        std::fs::create_dir_all(&release).unwrap();
+        std::fs::create_dir_all(&debug).unwrap();
+        // The co-located (release) build is excluded; the sibling (debug) is found.
+        std::fs::write(release.join("mvm-libkrun-supervisor"), b"co-located").unwrap();
+        std::fs::write(debug.join("mvm-libkrun-supervisor"), b"sibling").unwrap();
+
+        assert_eq!(
+            sibling_profile_supervisor(&release),
+            Some(debug.join("mvm-libkrun-supervisor")),
+            "must find the sibling-profile build, not the co-located one"
+        );
+
+        // Not a `target/<profile>/` layout → no sibling probing.
+        let installed = tmp.path().join("home/.cargo/bin");
+        std::fs::create_dir_all(&installed).unwrap();
+        assert_eq!(sibling_profile_supervisor(&installed), None);
+    }
+
+    /// A sibling build outranks `$PATH` when it is missing/newer/equal, but a
+    /// stale build must not shadow a freshly installed `$PATH` copy.
+    #[test]
+    fn supervisor_build_outranks_path_respects_freshness() {
+        let tmp = tempfile::tempdir().unwrap();
+        let build = tmp.path().join("build-supervisor");
+        let path = tmp.path().join("path-supervisor");
+        std::fs::write(&build, b"b").unwrap();
+
+        // No `$PATH` copy → the local build always wins.
+        assert!(supervisor_build_outranks_path(&build, None));
+
+        // `$PATH` copy present but older than the build → build wins.
+        std::fs::write(&path, b"p").unwrap();
+        let older = std::time::SystemTime::UNIX_EPOCH;
+        let newer = older + std::time::Duration::from_secs(100);
+        set_mtime(&path, older);
+        set_mtime(&build, newer);
+        assert!(supervisor_build_outranks_path(&build, Some(&path)));
+
+        // `$PATH` copy newer (fresh install) → build must not shadow it.
+        set_mtime(&path, newer);
+        set_mtime(&build, older);
+        assert!(!supervisor_build_outranks_path(&build, Some(&path)));
+    }
+
+    fn set_mtime(path: &Path, when: std::time::SystemTime) {
+        let f = std::fs::File::options().write(true).open(path).unwrap();
+        f.set_modified(when).unwrap();
     }
 }


### PR DESCRIPTION
## Problem

`machine run --image` / `image pull` materializes the OCI rootfs to ext4. When the pure-Rust writer can't emit the tree (e.g. busybox's root dir overflows one ext4 directory block — `directory ino 11 has too many entries for one block`), it falls back to a libkrun builder VM, which spawns a `gvproxy` gateway. On teardown that gvproxy was reaped **only** via its `gvproxy.pid` sidecar.

A supervisor binary predating the pid-sidecar mechanism — e.g. a stale `cargo install`ed `mvm-libkrun-supervisor` picked off `$PATH` because no fresh build sat next to the exe — spawns gvproxy without writing the sidecar. `reap_by_pid_file` then finds nothing and the gateway orphans to the init process: **one leaked gvproxy per fallback materialization**. `mvmctl cache prune`'s pid-file-based reaper couldn't catch them either, so they accumulated.

## Fix

**A — teardown backstop (leak-proof across supervisor versions).**
New `gvproxy::reap_by_socket_path`: a self-contained argv scanner (`/proc` on Linux, one `ps` on macOS/BSD) that kills whatever gateway is still bound to the VM's `gvproxy.sock` and unlinks it — independent of any pid sidecar. `spawn_supervisor_and_wait` runs it right after the pid-file reap, so the "teardown guaranteed regardless of how libkrun terminated" contract is actually true now.

**B — close the resolver trap.**
`resolve_supervisor_path` now probes the sibling cargo-profile dir (e.g. `target/debug` when running `target/release/mvmctl`) and prefers a fresh local build over a stale `$PATH` copy — but only when it's at least as fresh, so a stale leftover build can't shadow a freshly *installed* supervisor. New `SupervisorSource::LocalBuild` tier: env → next-to-exe → local-build → `$PATH`.

## Tests

- Unit: `reap_by_socket_path` kills-by-argv + no-op-without-socket; `choose_supervisor` 4-tier precedence; `sibling_profile_supervisor` newest-under-target-layout; `supervisor_build_outranks_path` freshness guard.
- Full suites: 972 tests pass (libkrun-sys + mvm-build), no leaky processes.
- `cargo fmt` (nightly) clean; clippy clean on both crates; Linux cross-check (zigbuild) compiles the `#[cfg(target_os = "linux")]` scanner branch.
- **Live:** deleted `gvproxy.pid` mid-run (simulating a stale supervisor) → teardown left **0 orphans** via the socket backstop; happy-path `image pull` leaves 0 orphans with no stale-`$PATH` warning.
