### PR TITLE
ci(release): raise aarch64-darwin binary budget to 32 MiB

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -181,8 +181,10 @@ jobs:
       - name: Binary size within budget (measured targets only)
         # Per-target byte budget for the release `mvmctl`. Only targets with a
         # measured baseline are gated; add a branch here once a new target is
-        # measured. aarch64-apple-darwin baseline 25,341,040 bytes (2026-06-20),
-        # budget 29,360,128 (28 MiB) for headroom.
+        # measured. aarch64-apple-darwin measured 30,007,616 bytes at v0.17.0
+        # (2026-07-08) — the 0.16→0.17 feature arc (guest RAM, healthcheck,
+        # signing, docs) grew it past the old 28 MiB budget. Budget 33,554,432
+        # (32 MiB) for headroom.
         if: matrix.target == 'aarch64-apple-darwin'
         env:
           TARGET: ${{ matrix.target }}
@@ -190,7 +192,7 @@ jobs:
         run: |
           cargo run --package xtask -- check-binary-size \
             --path "target/${TARGET}/release/mvmctl" \
-            --budget-bytes 29360128
+            --budget-bytes 33554432
 
       - name: Generate man pages
         shell: bash


### PR DESCRIPTION
The v0.17.0 release build failed its size gate: mvmctl is now **30,007,616 bytes** (633 KiB over the 28 MiB budget) after the 0.16→0.17 feature arc (guest RAM, healthcheck, signing, docs). Raise the budget to 33,554,432 (32 MiB) with headroom. Needed on main before re-tagging v0.17.0.