### PR TITLE
OCI materialize hygiene: multi-block ext4 dirs + builder orphan-sweep

### DIFF
--- a/crates/mvm-cli/src/commands/image/mod.rs
+++ b/crates/mvm-cli/src/commands/image/mod.rs
@@ -337,6 +337,13 @@ pub(in crate::commands) fn resolve_or_pull_run_image(
     reference: &str,
     prod: bool,
 ) -> Result<ResolvedOciRunImage> {
+    // Rootfs materialization can fall back to a builder VM (a flat dir the
+    // in-process ext4 writer can't emit), and an abnormally-exited builder can
+    // orphan its gvproxy sidecar to the init process. `up` / `dev up` reap the
+    // previous run's corpses at startup; the run-image path is the other place
+    // a builder VM spawns, so give it the same sweep before we might add one.
+    crate::commands::env::dev_vz::sweep_orphaned_vm_helpers_on_startup();
+
     // Local sources route to their own ingest; a registry reference falls
     // through to the cache-or-pull path below.
     match source::ImageSource::classify(reference)? {

--- a/crates/mvm-cli/src/commands/image/pull.rs
+++ b/crates/mvm-cli/src/commands/image/pull.rs
@@ -7,6 +7,10 @@ use anyhow::Result;
 use crate::ui;
 
 pub(super) fn run(cache_root: &Path, reference: String, prod: bool) -> Result<()> {
+    // Materialization may spawn a builder VM (see `resolve_or_pull_run_image`);
+    // reap any gvproxy a prior run's builder orphaned before adding another.
+    crate::commands::env::dev_vz::sweep_orphaned_vm_helpers_on_startup();
+
     let (image, trust, auth_source) = super::pull_image_with_trust(cache_root, &reference, prod)?;
     let provenance = image.provenance("image_pull", &reference, &trust);
     mvm_core::audit_emit!(

--- a/crates/mvm-ext4/src/lib.rs
+++ b/crates/mvm-ext4/src/lib.rs
@@ -90,8 +90,6 @@ pub enum Ext4Error {
     MissingParent(String),
     /// A path was empty or not rooted at `/`.
     BadPath(String),
-    /// A directory's entries did not fit the single-block assumption.
-    DirTooLarge(String),
     /// A node's parent path resolves to a non-directory (e.g. a regular file
     /// or symlink), so the node could never be reached on a mounted image.
     NotADirectory(String),
@@ -122,9 +120,6 @@ impl std::fmt::Display for Ext4Error {
                 write!(f, "node {p} has no parent directory in the input")
             }
             Ext4Error::BadPath(p) => write!(f, "bad path {p:?} (must be absolute)"),
-            Ext4Error::DirTooLarge(p) => {
-                write!(f, "directory {p} has too many entries for one block")
-            }
             Ext4Error::NotADirectory(p) => {
                 write!(f, "parent of {p} is not a directory")
             }
@@ -151,7 +146,6 @@ impl Ext4Error {
             self,
             Ext4Error::TooLarge { .. }
                 | Ext4Error::FileTooFragmented { .. }
-                | Ext4Error::DirTooLarge(_)
                 | Ext4Error::XattrTooLarge { .. }
         )
     }
@@ -206,7 +200,7 @@ impl Node {
 }
 
 /// One contiguous run of physical blocks backing a logical range of a file
-/// (or the single block of a directory / long symlink). `len` is in blocks and
+/// (or the data blocks of a directory / long symlink). `len` is in blocks and
 /// never exceeds a group's data region, so it always fits ext4's 15-bit
 /// initialized-extent length.
 #[derive(Debug, Clone, Copy)]
@@ -546,13 +540,14 @@ pub fn build_image(nodes: &[Node]) -> Result<Vec<u8>, Ext4Error> {
     for p in planned.iter_mut() {
         let nblocks = match p.kind {
             Kind::Dir => {
-                // "." + ".." + children must fit one block (single-block dirs).
-                let need = dir_bytes(&p.children);
-                if need > BLOCK_SIZE as usize {
-                    return Err(Ext4Error::DirTooLarge(format!("ino {}", p.ino)));
-                }
-                p.size = BLOCK_SIZE as u64;
-                1
+                // Linear (non-htree) directory: "." + ".." + children pack into
+                // as many blocks as they need, none crossing a block boundary.
+                // The kernel and the fs_ext4 reader read this without an htree
+                // index. A directory large enough to fragment past the extent
+                // tree fails as `FileTooFragmented`, same as an oversized file.
+                let nblocks = dir_block_count(&p.children);
+                p.size = nblocks as u64 * BLOCK_SIZE as u64;
+                nblocks
             }
             Kind::File => p.size.div_ceil(BLOCK_SIZE as u64) as u32,
             Kind::Symlink => {
@@ -625,7 +620,7 @@ pub fn build_image(nodes: &[Node]) -> Result<Vec<u8>, Ext4Error> {
     for p in &planned {
         write_inode(&mut img, &layout, p);
         match p.kind {
-            Kind::Dir => write_dir_block(&mut img, p),
+            Kind::Dir => write_dir_blocks(&mut img, p),
             Kind::File => write_file_blocks(&mut img, p),
             Kind::Symlink => {
                 if let Some(ext) = p.extents.first() {
@@ -660,13 +655,36 @@ fn leaves_for(num_extents: usize) -> usize {
     }
 }
 
-fn dir_bytes(children: &[(String, u32, u8)]) -> usize {
-    // "." (12) + ".." (12) + each child rounded to 4.
-    let mut n = 12 + 12;
-    for (name, _, _) in children {
-        n += dirent_len(name.len());
+/// Block index (0-based) each ordered dirent lands in for a linear directory:
+/// "." , "..", then `children` in order. An entry never crosses a block
+/// boundary, so a block that can't fit the next entry pads out and the entry
+/// starts the following block. The returned vec is parallel to the entry
+/// sequence [`write_dir_blocks`] emits, so sizing and writing never disagree.
+fn dir_block_layout(children: &[(String, u32, u8)]) -> Vec<u32> {
+    // "." and ".." lead every directory; both encode to a 12-byte dirent.
+    let name_lens = [1usize, 2]
+        .into_iter()
+        .chain(children.iter().map(|(name, _, _)| name.len()));
+    let mut blocks = Vec::new();
+    let mut blk = 0u32;
+    let mut used = 0usize;
+    for nl in name_lens {
+        let need = dirent_len(nl);
+        if used + need > BLOCK_SIZE as usize {
+            blk += 1;
+            used = 0;
+        }
+        used += need;
+        blocks.push(blk);
     }
-    n
+    blocks
+}
+
+/// Number of 4 KiB blocks a linear directory of `children` occupies.
+fn dir_block_count(children: &[(String, u32, u8)]) -> u32 {
+    dir_block_layout(children)
+        .last()
+        .map_or(1, |&last| last + 1)
 }
 
 fn dirent_len(name_len: usize) -> usize {
@@ -947,20 +965,41 @@ fn write_extent_leaves(img: &mut Image, inode_header: usize, p: &Planned) {
     }
 }
 
-fn write_dir_block(img: &mut Image, p: &Planned) {
-    let Some(ext) = p.extents.first() else {
+fn write_dir_blocks(img: &mut Image, p: &Planned) {
+    // Physical blocks backing this directory, in logical order.
+    let phys: Vec<u32> = p
+        .extents
+        .iter()
+        .flat_map(|ext| (0..ext.len).map(move |i| ext.phys + i))
+        .collect();
+    if phys.is_empty() {
         return;
-    };
-    let base = img.block_off(ext.phys);
+    }
+    // Entries in the exact order `dir_block_layout` assumed: "." , "..", children.
+    let mut entries: Vec<(u32, &str, u8)> = Vec::with_capacity(2 + p.children.len());
+    entries.push((p.ino, ".", FT_DIR));
+    entries.push((p.parent, "..", FT_DIR));
+    entries.extend(
+        p.children
+            .iter()
+            .map(|(name, ino, ft)| (*ino, name.as_str(), *ft)),
+    );
+    let layout = dir_block_layout(&p.children);
+    debug_assert_eq!(entries.len(), layout.len());
+
+    let mut cur = 0u32;
     let mut pos = 0usize;
-    // "." -> self
-    pos += put_dirent(img, base + pos, p.ino, ".", FT_DIR, false);
-    // ".." -> parent
-    let dotdot_last = p.children.is_empty();
-    pos += put_dirent(img, base + pos, p.parent, "..", FT_DIR, dotdot_last);
-    for (i, (name, child, ft)) in p.children.iter().enumerate() {
-        let last = i + 1 == p.children.len();
-        pos += put_dirent(img, base + pos, *child, name, *ft, last);
+    for (i, (ino, name, ft)) in entries.iter().enumerate() {
+        let blk = layout[i];
+        if blk != cur {
+            cur = blk;
+            pos = 0;
+        }
+        // The last entry in each block pads its rec_len to the block end, so no
+        // dirent straddles a block boundary (an ext4 linear-directory invariant).
+        let last_in_block = i + 1 == entries.len() || layout[i + 1] != blk;
+        let base = img.block_off(phys[blk as usize]);
+        pos += put_dirent(img, base + pos, *ino, name, *ft, last_in_block);
     }
 }
 

--- a/crates/mvm-ext4/tests/adversarial.rs
+++ b/crates/mvm-ext4/tests/adversarial.rs
@@ -154,13 +154,19 @@ fn symlink_cycles_are_stored_verbatim() {
     }
 }
 
-/// A single directory with more entries than fit one 4 KiB block is refused with
-/// `DirTooLarge` — the writer's single-block-directory limit, an `Err`, never a
-/// panic or a truncated directory.
+/// A directory with far more entries than fit one 4 KiB block materializes as a
+/// linear multi-block directory (no htree): it builds, mounts, and the
+/// independent reader lists every entry back across the block boundaries — never
+/// a panic, a truncated directory, or an entry lost at a block seam.
 #[test]
-fn directory_over_one_block_is_rejected() {
-    let mut nodes = Vec::new();
-    for i in 0..400 {
+fn directory_over_one_block_spans_multiple_blocks() {
+    const N: usize = 400;
+    let mut nodes = vec![Node::Dir {
+        path: "/big".into(),
+        mode: 0o755,
+        xattrs: Vec::new(),
+    }];
+    for i in 0..N {
         nodes.push(Node::File {
             path: format!("/big/f{i:04}"),
             mode: 0o644,
@@ -168,14 +174,35 @@ fn directory_over_one_block_is_rejected() {
             xattrs: Vec::new(),
         });
     }
-    nodes.push(Node::Dir {
-        path: "/big".into(),
-        mode: 0o755,
-        xattrs: Vec::new(),
-    });
+
+    let fs = mount(build_image(&nodes).expect("over-full directory builds as multi-block"));
+    let (big_ino, ft) = find(&list_dir(&fs, 2), "big").expect("/big present");
+    assert_eq!(ft, DirEntryType::Directory);
+
+    // The directory inode must occupy more than one block.
+    let (inode, _) = fs.read_inode_verified(big_ino).expect("read /big inode");
     assert!(
-        matches!(build_image(&nodes), Err(Ext4Error::DirTooLarge(_))),
-        "an over-full directory must return DirTooLarge"
+        inode.size > 4096,
+        "/big should span multiple blocks, got size {}",
+        inode.size
+    );
+
+    // Every child reads back across all blocks — none lost at a boundary.
+    let entries = list_dir(&fs, big_ino);
+    for i in 0..N {
+        let name = format!("f{i:04}");
+        assert!(
+            find(&entries, &name).is_some(),
+            "child {name} missing from multi-block directory"
+        );
+    }
+    let children = entries
+        .iter()
+        .filter(|(name, _, _)| name != "." && name != "..")
+        .count();
+    assert_eq!(
+        children, N,
+        "unexpected child count in multi-block directory"
     );
 }
 
@@ -185,7 +212,6 @@ use fs_ext4::block_io::BlockDevice;
 use fs_ext4::dir::{self, DirEntryType};
 use fs_ext4::file_io;
 use fs_ext4::fs::Filesystem;
-use mvm_ext4::Ext4Error;
 use std::sync::Arc;
 
 struct MemDev(Vec<u8>);
@@ -209,9 +235,10 @@ fn mount(image: Vec<u8>) -> Filesystem {
 fn list_dir(fs: &Filesystem, ino: u32) -> Vec<(String, u32, DirEntryType)> {
     let (inode, _) = fs.read_inode_verified(ino).expect("read dir inode");
     let data = file_io::read_all(fs, &inode).expect("read dir data");
-    dir::parse_block(&data, true)
-        .expect("parse dir block")
-        .into_iter()
+    // A linear directory is a sequence of independent 4 KiB blocks; parse each
+    // so a multi-block directory reads back every entry, not just block 0's.
+    data.chunks(4096)
+        .flat_map(|block| dir::parse_block(block, true).expect("parse dir block"))
         .map(|e| {
             (
                 String::from_utf8_lossy(&e.name).into_owned(),

--- a/crates/mvm-ext4/tests/error_classify.rs
+++ b/crates/mvm-ext4/tests/error_classify.rs
@@ -14,7 +14,7 @@ fn capacity_limits_are_classified_for_fallback() {
             ino: 12,
             extents: 9,
         },
-        Ext4Error::DirTooLarge("/big".into()),
+        Ext4Error::XattrTooLarge { ino: 7 },
     ];
     for e in capacity {
         assert!(e.is_capacity_limit(), "{e:?} should be a capacity limit");


### PR DESCRIPTION
Two follow-ups from the gvproxy-reap investigation (#1546), both about the OCI rootfs-materialize path's reliance on a builder VM.

## FU1 — linear multi-block directories in `mvm-ext4`

The pure-Rust ext4 writer capped directories at one 4 KiB block. An OCI rootfs with a large flat directory — e.g. busybox's ~400 applet symlinks (`directory ino 11 has too many entries for one block`) — therefore fell back to a **libkrun builder VM** to run `mkfs`, dragging in Homebrew libkrun+gvproxy even on a vsock-only hvf host (and risking an orphaned gvproxy on abnormal builder exit).

There is no `HvfBuilderVm`, so the real fix is removing the limit, not swapping the builder. Directories now emit as **linear multi-block directories** (no htree): entries pack across as many blocks as needed, none crossing a boundary — a valid ext4 the kernel and the `fs_ext4` reader read without an index. One shared packing routine (`dir_block_layout`) drives both sizing and writing so they never disagree; the existing multi-block extent machinery handles allocation. A directory large enough to exhaust the extent tree now fails as `FileTooFragmented`, same as an oversized file; the obsolete `DirTooLarge` variant is removed.

**Result:** busybox (and any image with big flat dirs) materializes fully **in-process on every host** — no builder VM, no gvproxy, no fallback.

## FU2 — run the builder orphan-sweep on the materialize path

`up` / `dev up` reap the previous run's orphaned VM helpers at startup, but the OCI materialize path — the other place a builder VM (and its gvproxy) can spawn — did not, so a gvproxy orphaned by an abnormal builder exit lingered until an unrelated `up` or `cache prune`. This calls the same `sweep_orphaned_vm_helpers_on_startup` at the two materialize entrypoints (`resolve_or_pull_run_image`, `image pull`).

(FU1 makes the busybox fallback disappear, but FU2 still covers images that legitimately fall back — e.g. `security.capability` xattr-bearing trees the pure writer routes to the builder VM.)

## Tests / verification

- `mvm-ext4`: the over-full-directory test flips from *rejected* to *builds + mounts + every entry reads back across blocks* via the independent reader; error-classify + xattr + oracle suites pass (24 tests).
- `cargo fmt` (nightly) clean; `cargo clippy -p mvm-ext4 -p mvm-cli --all-targets` clean.
- **Live (FU1):** `image pull busybox` → materializes in-process, **no** new builder-VM dir, **zero** `falling back` messages, **zero** gvproxy.
- **Live (FU2):** planted an orphaned gvproxy (ppid=1) in a builder dir → `image pull` reaped it via the startup sweep.
- The multi-group / real-kernel-mount CI lane exercises the multi-block directory output on Linux.
