### PR TITLE
feat(release): publish + verify a signed pack revocation list (Plan 213 §I producer)

### DIFF
--- a/.github/workflows/pack-signing-smoke.yml
+++ b/.github/workflows/pack-signing-smoke.yml
@@ -111,3 +111,23 @@ jobs:
           cargo run --release -p mvm-core --example verify-signed-manifest --features manifest-verify -- \
             --manifest smoke/image-manifest.json --bundle smoke/image-manifest.json.bundle \
             --identity "${IDENTITY}" --issuer "https://token.actions.githubusercontent.com"
+
+      - name: Round-trip a pack revocation list through its verifier
+        # The revocation list is signed + verified through the same Rust stack.
+        # Sign a real list and verify it through the fetch-path entrypoint
+        # (pack_revocation::verify_pack_revocation_list), so this smoke also
+        # guards the revocation channel's signing format.
+        run: |
+          set -euo pipefail
+          now="$(date -u +%Y-%m-%dT%H:%M:%SZ)"
+          cat > smoke/pack-revocations.json <<JSON
+          {"schema_version":1,"revocations":[],"issued_at":"${now}","not_after":"2099-01-01T00:00:00Z"}
+          JSON
+          cosign sign-blob \
+            --yes \
+            --new-bundle-format \
+            --bundle smoke/pack-revocations.json.bundle \
+            smoke/pack-revocations.json
+          cargo run --release -p mvm-core --example verify-pack-revocation-list --features manifest-verify -- \
+            --list smoke/pack-revocations.json --bundle smoke/pack-revocations.json.bundle \
+            --identity "${IDENTITY}" --issuer "https://token.actions.githubusercontent.com"

--- a/.github/workflows/revocations.yml
+++ b/.github/workflows/revocations.yml
@@ -1,0 +1,86 @@
+name: Publish pack revocation list
+
+# Signs and publishes the pack revocation list to the `revocations` release.
+# Triggered by force-updating the `revocations` tag after editing the
+# checked-in source list. The cosign certificate's SAN is this workflow file
+# bound to the `revocations` tag, which is exactly the identity a released
+# mvmctl reconstructs in `release_trust::revocation_keyless_trust()` — a
+# dedicated identity so a leaked release-signing cert can't fabricate a
+# permissive revocation list, and vice versa.
+on:
+  push:
+    tags:
+      - "revocations"
+  workflow_dispatch:
+
+permissions:
+  contents: write
+  id-token: write
+
+env:
+  CARGO_TERM_COLOR: always
+  # How long a published list stays fresh. The consumer refuses a list whose
+  # not_after has passed, so this bounds how long a stalled pipeline can leave
+  # a stale list trusted; re-publish (re-tag) well before it lapses.
+  VALID_DAYS: "30"
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Install Rust toolchain
+        uses: dtolnay/rust-toolchain@stable
+
+      - name: Install cosign
+        uses: sigstore/cosign-installer@v3
+
+      - name: Build the revocation list (stamp validity window)
+        run: |
+          set -euo pipefail
+          now="$(date -u +%Y-%m-%dT%H:%M:%SZ)"
+          not_after="$(date -u -d "+${VALID_DAYS} days" +%Y-%m-%dT%H:%M:%SZ)"
+          jq --arg now "$now" --arg not_after "$not_after" \
+            '. + {issued_at: $now, not_after: $not_after}' \
+            packaging/release/pack-revocations.source.json > pack-revocations.json
+          echo "built pack-revocations.json (issued_at=$now not_after=$not_after)"
+
+      - name: Keyless-sign the revocation list
+        run: |
+          set -euo pipefail
+          # --new-bundle-format emits the Sigstore bundle the Rust verifier
+          # parses; legacy --bundle is rejected by that stack.
+          cosign sign-blob \
+            --yes \
+            --new-bundle-format \
+            --bundle pack-revocations.json.bundle \
+            pack-revocations.json
+
+      - name: Self-verify the signed list through the Rust verifier
+        env:
+          REPOSITORY: ${{ github.repository }}
+          REF: ${{ github.ref }}
+        run: |
+          set -euo pipefail
+          # Refuse to publish a list a released binary could not verify: check
+          # the freshly-signed bundle through the exact fetch-path entrypoint,
+          # against this job's own OIDC identity.
+          IDENTITY="https://github.com/${REPOSITORY}/.github/workflows/revocations.yml@${REF}"
+          cargo run --release -p mvm-core --example verify-pack-revocation-list --features manifest-verify -- \
+            --list pack-revocations.json --bundle pack-revocations.json.bundle \
+            --identity "${IDENTITY}" --issuer "https://token.actions.githubusercontent.com"
+
+      - name: Publish to the revocations release
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          set -euo pipefail
+          # Idempotent: create the release on first publish, then clobber the
+          # two assets on every re-publish so consumers always fetch the latest.
+          gh release view revocations --repo "${GITHUB_REPOSITORY}" >/dev/null 2>&1 \
+            || gh release create revocations --repo "${GITHUB_REPOSITORY}" \
+                 --title "Pack revocations" --notes "Signed pack revocation list."
+          gh release upload revocations \
+            pack-revocations.json pack-revocations.json.bundle \
+            --repo "${GITHUB_REPOSITORY}" --clobber

--- a/crates/mvm-core/Cargo.toml
+++ b/crates/mvm-core/Cargo.toml
@@ -150,6 +150,12 @@ required-features = ["manifest-verify"]
 name = "verify-signed-manifest"
 required-features = ["manifest-verify"]
 
+# Same purpose for the pack revocation list, calling
+# `pack_revocation::verify_pack_revocation_list` directly.
+[[example]]
+name = "verify-pack-revocation-list"
+required-features = ["manifest-verify"]
+
 [dev-dependencies]
 # `OsRng` for generating fresh ed25519 keys in signed_config tests
 # without committing static fixtures. (Also a non-dev dep above for the

--- a/crates/mvm-core/examples/verify-pack-revocation-list.rs
+++ b/crates/mvm-core/examples/verify-pack-revocation-list.rs
@@ -1,0 +1,81 @@
+//! Standalone verifier for a signed pack revocation list.
+//!
+//! Given a `PackRevocationList` JSON file and its detached cosign bundle, this
+//! calls the exact entrypoint the fetch path uses
+//! (`pack_revocation::verify_pack_revocation_list`): it checks the bundle over
+//! the raw list bytes through the Rust sigstore-verify stack, then parses and
+//! validates schema + freshness. It exists so a CI smoke job can prove a real
+//! `cosign sign-blob` bundle over a revocation list round-trips through that
+//! verifier.
+//!
+//! ```text
+//! verify-pack-revocation-list \
+//!   --list <path> --bundle <path> \
+//!   --identity <SAN> --issuer <url>
+//! ```
+//!
+//! Exits `0` and prints "pack revocation list signature verified" on success;
+//! exits nonzero and prints the error to stderr on any failure.
+
+use std::fs;
+use std::process::ExitCode;
+
+use mvm_core::pack_revocation::verify_pack_revocation_list;
+use mvm_core::packs::KeylessTrust;
+
+fn main() -> ExitCode {
+    let argv: Vec<String> = std::env::args().collect();
+    if argv.len() < 2 || matches!(argv[1].as_str(), "-h" | "--help" | "help") {
+        usage();
+        return if argv.len() < 2 {
+            ExitCode::FAILURE
+        } else {
+            ExitCode::SUCCESS
+        };
+    }
+    match run(&argv[1..]) {
+        Ok(()) => {
+            println!("pack revocation list signature verified");
+            ExitCode::SUCCESS
+        }
+        Err(e) => {
+            eprintln!("error: {e}");
+            ExitCode::FAILURE
+        }
+    }
+}
+
+fn usage() {
+    eprintln!(
+        "usage: verify-pack-revocation-list \\\n\
+         \x20 --list <path> --bundle <path> \\\n\
+         \x20 --identity <SAN> --issuer <url>"
+    );
+}
+
+fn run(rest: &[String]) -> Result<(), String> {
+    let list_path = required(rest, "list")?;
+    let bundle_path = required(rest, "bundle")?;
+    let identity = required(rest, "identity")?;
+    let issuer = required(rest, "issuer")?;
+
+    let list_bytes = fs::read(list_path).map_err(|e| format!("read {list_path}: {e}"))?;
+    let bundle = fs::read(bundle_path).map_err(|e| format!("read {bundle_path}: {e}"))?;
+    let trust = KeylessTrust {
+        accepted_identities: vec![identity.to_string()],
+        issuer: issuer.to_string(),
+    };
+
+    verify_pack_revocation_list(&list_bytes, &bundle, &trust, chrono::Utc::now())
+        .map(|_| ())
+        .map_err(|e| format!("revocation list verification failed: {e}"))
+}
+
+fn required<'a>(rest: &'a [String], key: &str) -> Result<&'a str, String> {
+    let needle = format!("--{key}");
+    rest.iter()
+        .position(|arg| arg == &needle)
+        .and_then(|i| rest.get(i + 1))
+        .map(String::as_str)
+        .ok_or_else(|| format!("missing required arg: --{key}"))
+}

--- a/packaging/release/pack-revocations.source.json
+++ b/packaging/release/pack-revocations.source.json
@@ -1,0 +1,4 @@
+{
+  "schema_version": 1,
+  "revocations": []
+}


### PR DESCRIPTION
Fourth slice of the revocation workstream (ADR-097 §I): the **producer** — publish a signed pack revocation list, so the fetch/apply consumer (#1552) has something to consume. Completes the revocation vertical.

## What

- **`packaging/release/pack-revocations.source.json`** — the human-curated source (starts empty). Maintainers add `RevokedPack` entries here.
- **`.github/workflows/revocations.yml`** — triggered by force-updating the `revocations` tag: stamps a validity window (`issued_at` / `not_after`, `VALID_DAYS=30`), keyless-signs the list with `cosign --new-bundle-format` under the **dedicated `revocations.yml@refs/tags/revocations` identity** (so a leaked release-signing cert can't fabricate a permissive list — matching `release_trust::revocation_keyless_trust()`), **self-verifies** the signed list through the Rust entrypoint before publishing (refuses to ship a list a released binary couldn't verify), and uploads `pack-revocations.json` + `.bundle` to the `revocations` release.
- **`verify-pack-revocation-list`** mvm-core example — calls `pack_revocation::verify_pack_revocation_list` directly (the fetch-path entrypoint).
- **`pack-signing-smoke.yml`** — now also round-trips a real signed revocation list, so the smoke guards all three keyless channels (pack, image manifest, revocation list).

## Validation

Local: the example builds; the jq-stamped source is a valid `PackRevocationList`; a garbage bundle is rejected (`exit=1`); all workflows + the source JSON parse; clippy + actionlint clean. **Live:** I dispatched `pack-signing-smoke.yml` on this branch to prove the revocation round-trip end-to-end with a real cosign bundle (result linked in a comment).

## The vertical is now complete

Core (#1545) → signer binding (#1543) → fetch/apply (#1552) → producer (this). Publishing a revocation = edit the source list, force-update the `revocations` tag. The consumer fetches, keyless-verifies, offline-caches, and unions it with the on-disk config.
