### PR TITLE
refactor+feat: typed PackBuilder authority, --sbom-uri, protected signing env, runtime-pack producer

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -256,6 +256,16 @@ jobs:
     # Skipped on a dry-run dispatch — Nix image builds are slow and unchanged by
     # the binary-packaging path a dry-run validates. Runs on tag push / dry_run=false.
     if: ${{ github.event_name == 'push' || github.event.inputs.dry_run == 'false' }}
+    # This job mints a keyless (OIDC/Fulcio) signature over the attested
+    # builder pack manifest, and the resulting certificate's SAN is derived
+    # from the workflow ref that ran it. Gating the job on a protected
+    # environment means the ref that can produce a valid signing identity is
+    # constrained by the environment's deployment branch/tag rule (restricted
+    # to version tags in repo settings), with an optional required-reviewer
+    # gate on top of the tag-push trigger already enforced above — so the
+    # identity a released binary trusts can't be minted from an arbitrary
+    # branch or workflow_dispatch run.
+    environment: release-signing
     strategy:
       matrix:
         include:
@@ -339,12 +349,17 @@ jobs:
           fi
           IDENTITY="https://github.com/${REPOSITORY}/.github/workflows/release.yml@${REF}"
           REVOCATION_CHANNEL="https://github.com/${REPOSITORY}/releases/download/revocations/builder-vm-revocations.json"
+          # The published location of the SBOM this release ships, so the
+          # manifest's SBOM reference points at a real download instead of a
+          # path that only exists on the runner that built it.
+          SBOM_URI="https://github.com/${REPOSITORY}/releases/download/${REF#refs/tags/}/builder-vm-${ARCH}.sbom.txt"
           cargo run --release -p mvm-build --example mvm-builder-pack-tool -- \
             --vmlinux "$STORE_PATH/vmlinux" --rootfs "$STORE_PATH/rootfs.ext4" \
             --arch "$ARCH" --channel stable --keyless \
             --identity "$IDENTITY" \
             --out-dir staging \
             --sbom "staging/builder-vm-${ARCH}.sbom.txt" \
+            --sbom-uri "$SBOM_URI" \
             --revocation-channel "$REVOCATION_CHANNEL"
           mv staging/manifest.json "staging/builder-vm-${ARCH}.pack-manifest.json"
 

--- a/crates/mvm-build/examples/mvm-builder-pack-tool.rs
+++ b/crates/mvm-build/examples/mvm-builder-pack-tool.rs
@@ -16,7 +16,7 @@
 //!   --channel <name> --signing-key <hex-file> --out-dir <dir> \
 //!   --sbom <path> --revocation-channel <url> \
 //!   [--builder-identity <s>] [--build-env <s>] \
-//!   [--valid-days <n>] [--mirror-identity <s>]
+//!   [--valid-days <n>] [--mirror-identity <s>] [--sbom-uri <url>]
 //!
 //! # keyless: writes an unsigned Sigstore-authority manifest; a release
 //! # pipeline signs it out of band with `cosign sign-blob`.
@@ -25,7 +25,7 @@
 //!   --channel <name> --keyless --identity <SAN> --out-dir <dir> \
 //!   --sbom <path> --revocation-channel <url> \
 //!   [--builder-identity <s>] [--build-env <s>] \
-//!   [--valid-days <n>] [--mirror-identity <s>]
+//!   [--valid-days <n>] [--mirror-identity <s>] [--sbom-uri <url>]
 //! ```
 //!
 //! `--signing-key` names a file holding the 32-byte Ed25519 secret key as 64
@@ -34,7 +34,11 @@
 //! manifest's `trust.signing_key_id` is derived from; required with
 //! `--keyless`, otherwise ignored. `--sbom` names the SBOM file enumerating
 //! the pack's contents; its bytes are hashed into the manifest's SBOM
-//! reference.
+//! reference. `--sbom-uri` optionally overrides the SBOM reference's `uri`
+//! field with a real published location (e.g. a release download URL); the
+//! sha256 is always computed from the local `--sbom` file regardless. Without
+//! it, the `uri` falls back to a `file://` path of the local SBOM file, which
+//! is only meaningful on the machine that produced the pack.
 
 use std::fs;
 use std::path::{Path, PathBuf};
@@ -77,13 +81,18 @@ fn usage() {
          \x20 --sbom <path> --revocation-channel <url> \\\n\
          \x20 (--signing-key <hex-file> | --keyless --identity <SAN>) \\\n\
          \x20 [--builder-identity <s>] [--build-env <s>] \\\n\
-         \x20 [--valid-days <n>] [--mirror-identity <s>]"
+         \x20 [--valid-days <n>] [--mirror-identity <s>] [--sbom-uri <url>]\n\
+         \n\
+         --sbom-uri overrides the manifest's SBOM reference uri with a \
+         published location (e.g. a release download URL) instead of the \
+         default file:// path of the local --sbom file; the sha256 is \
+         always computed from the local file."
     );
 }
 
 fn run(rest: &[String]) -> Result<(), String> {
     let parsed = parse_args(rest)?;
-    let sbom = sbom_reference(&parsed.sbom)?;
+    let sbom = sbom_reference(&parsed.sbom, parsed.sbom_uri.as_deref())?;
 
     // The producers are pure; this wrapper owns the single wall-clock read.
     let now = Utc::now();
@@ -150,6 +159,7 @@ struct ParsedArgs {
     identity: Option<String>,
     out_dir: PathBuf,
     sbom: PathBuf,
+    sbom_uri: Option<String>,
     revocation_channel: String,
     builder_identity: String,
     build_environment_identity: String,
@@ -181,6 +191,7 @@ fn parse_args(rest: &[String]) -> Result<ParsedArgs, String> {
         identity,
         out_dir: PathBuf::from(required(rest, "out-dir")?),
         sbom: PathBuf::from(required(rest, "sbom")?),
+        sbom_uri: optional(rest, "sbom-uri").map(str::to_string),
         revocation_channel: required(rest, "revocation-channel")?.to_string(),
         builder_identity: optional(rest, "builder-identity")
             .unwrap_or("mvm-builder-pack-tool")
@@ -234,13 +245,18 @@ fn load_signing_key(path: &Path) -> Result<SigningKey, String> {
 }
 
 /// Build the manifest's SBOM reference from the SBOM file: hash its bytes and
-/// point the uri at the file.
-fn sbom_reference(path: &Path) -> Result<SbomReference, String> {
+/// point the uri at `uri_override` when given, or at the local file otherwise.
+/// The sha256 always comes from hashing `path`, regardless of `uri_override`.
+fn sbom_reference(path: &Path, uri_override: Option<&str>) -> Result<SbomReference, String> {
     use sha2::{Digest, Sha256};
     let bytes = fs::read(path).map_err(|e| format!("read sbom {}: {e}", path.display()))?;
     let hex = format!("{:x}", Sha256::digest(&bytes));
+    let uri = match uri_override {
+        Some(uri) => uri.to_string(),
+        None => format!("file://{}", path.display()),
+    };
     Ok(SbomReference {
-        uri: format!("file://{}", path.display()),
+        uri,
         sha256: Sha256Hex::new(hex).map_err(|e| e.to_string())?,
     })
 }
@@ -366,5 +382,46 @@ mod tests {
         a.extend(args(&[("valid-days", "soon")]));
         let err = parse_args(&a).expect_err("bad valid-days");
         assert!(err.contains("valid-days"), "got: {err}");
+    }
+
+    #[test]
+    fn sbom_uri_flag_is_absent_by_default() {
+        let parsed = parse_args(&full_args()).expect("parse");
+        assert_eq!(parsed.sbom_uri, None);
+    }
+
+    #[test]
+    fn sbom_uri_flag_is_parsed_when_given() {
+        let mut a = full_args();
+        a.extend(args(&[("sbom-uri", "https://example.test/s.txt")]));
+        let parsed = parse_args(&a).expect("parse");
+        assert_eq!(
+            parsed.sbom_uri,
+            Some("https://example.test/s.txt".to_string())
+        );
+    }
+
+    #[test]
+    fn sbom_reference_uses_override_uri_when_given() {
+        use sha2::Digest as _;
+        let dir = tempfile::TempDir::new().expect("tempdir");
+        let path = dir.path().join("sbom.json");
+        fs::write(&path, b"sbom bytes").expect("write sbom");
+        let reference =
+            sbom_reference(&path, Some("https://example.test/s.txt")).expect("sbom reference");
+        assert_eq!(reference.uri, "https://example.test/s.txt");
+        assert_eq!(
+            reference.sha256.as_str(),
+            format!("{:x}", sha2::Sha256::digest(b"sbom bytes"))
+        );
+    }
+
+    #[test]
+    fn sbom_reference_defaults_to_file_uri_when_no_override() {
+        let dir = tempfile::TempDir::new().expect("tempdir");
+        let path = dir.path().join("sbom.json");
+        fs::write(&path, b"sbom bytes").expect("write sbom");
+        let reference = sbom_reference(&path, None).expect("sbom reference");
+        assert_eq!(reference.uri, format!("file://{}", path.display()));
     }
 }

--- a/crates/mvm-build/examples/mvm-builder-pack-tool.rs
+++ b/crates/mvm-build/examples/mvm-builder-pack-tool.rs
@@ -47,7 +47,8 @@ use std::process::ExitCode;
 use chrono::{Duration, Utc};
 use ed25519_dalek::SigningKey;
 use mvm_build::builder_pack::{
-    BuildBuilderPackParams, build_builder_pack, build_keyless_builder_pack,
+    BuildBuilderPackParams, BuildRuntimePackParams, build_builder_pack, build_keyless_builder_pack,
+    build_keyless_runtime_pack,
 };
 use mvm_core::arch::GuestArch;
 use mvm_core::packs::{
@@ -76,13 +77,16 @@ fn main() -> ExitCode {
 fn usage() {
     eprintln!(
         "usage: mvm-builder-pack-tool \\\n\
-         \x20 --vmlinux <path> --rootfs <path> --arch <x86_64|aarch64> \\\n\
+         \x20 --vmlinux <path> --arch <x86_64|aarch64> \\\n\
+         \x20 (--rootfs <path> | --kind runtime --initramfs <path>) \\\n\
          \x20 --channel <name> --out-dir <dir> \\\n\
          \x20 --sbom <path> --revocation-channel <url> \\\n\
          \x20 (--signing-key <hex-file> | --keyless --identity <SAN>) \\\n\
          \x20 [--builder-identity <s>] [--build-env <s>] \\\n\
          \x20 [--valid-days <n>] [--mirror-identity <s>] [--sbom-uri <url>]\n\
          \n\
+         --kind defaults to builder (needs --rootfs); --kind runtime needs \
+         --initramfs and is keyless-only (--keyless --identity).\n\
          --sbom-uri overrides the manifest's SBOM reference uri with a \
          published location (e.g. a release download URL) instead of the \
          default file:// path of the local --sbom file; the sha256 is \
@@ -97,9 +101,52 @@ fn run(rest: &[String]) -> Result<(), String> {
     // The producers are pure; this wrapper owns the single wall-clock read.
     let now = Utc::now();
     let expires_at = now + Duration::days(parsed.valid_days);
+
+    if parsed.runtime {
+        // Runtime packs are keyless-only; `parse_args` guarantees --keyless
+        // --identity and --initramfs when --kind runtime.
+        let identity = parsed
+            .identity
+            .expect("parse_args guarantees --identity for --kind runtime");
+        let initramfs = parsed
+            .initramfs
+            .expect("parse_args guarantees --initramfs for --kind runtime");
+        let params = BuildRuntimePackParams {
+            vmlinux: parsed.vmlinux,
+            initramfs,
+            target_arch: parsed.arch,
+            channel: parsed.channel,
+            builder_identity: parsed.builder_identity,
+            build_environment_identity: parsed.build_environment_identity,
+            build_timestamp: now,
+            reproducibility: ReproducibilityStatus::NotChecked,
+            sbom,
+            expires_at,
+            revocation_channel: parsed.revocation_channel,
+            mirror_identity: parsed.mirror_identity,
+            transparency_log: None::<TransparencyLogReference>,
+            signature: SignatureValidity {
+                signed_at: now,
+                expires_at,
+            },
+        };
+        let produced = build_keyless_runtime_pack(&params, &identity, &parsed.out_dir)
+            .map_err(|e| e.to_string())?;
+        println!(
+            "wrote unsigned keyless runtime pack manifest {} to {} (sign {} with cosign)",
+            produced.manifest.outputs.pack_hash.as_str(),
+            parsed.out_dir.display(),
+            produced.manifest_path.display()
+        );
+        return Ok(());
+    }
+
+    let rootfs = parsed
+        .rootfs
+        .expect("parse_args guarantees --rootfs for a builder pack");
     let params = BuildBuilderPackParams {
         vmlinux: parsed.vmlinux,
-        rootfs: parsed.rootfs,
+        rootfs,
         target_arch: parsed.arch,
         channel: parsed.channel,
         builder_identity: parsed.builder_identity,
@@ -152,7 +199,13 @@ fn run(rest: &[String]) -> Result<(), String> {
 #[derive(Debug, PartialEq, Eq)]
 struct ParsedArgs {
     vmlinux: PathBuf,
-    rootfs: PathBuf,
+    /// Builder pack artifact (`--rootfs`). `Some` for a builder pack, `None` for
+    /// a runtime pack (which carries `initramfs` instead).
+    rootfs: Option<PathBuf>,
+    /// Runtime pack artifact (`--initramfs`). `Some` iff `--kind runtime`.
+    initramfs: Option<PathBuf>,
+    /// `--kind runtime`. A runtime pack is keyless-only (no ed25519 producer).
+    runtime: bool,
     arch: GuestArch,
     channel: String,
     signing_key: Option<PathBuf>,
@@ -179,9 +232,25 @@ fn parse_args(rest: &[String]) -> Result<ParsedArgs, String> {
             "missing required arg: --signing-key (or pass --keyless --identity)".to_string(),
         );
     }
+    let runtime = matches!(optional(rest, "kind"), Some("runtime"));
+    if runtime && !keyless {
+        return Err(
+            "--kind runtime requires --keyless --identity (no ed25519 runtime producer)"
+                .to_string(),
+        );
+    }
+    // Each kind carries exactly one image artifact: a builder pack's rootfs or a
+    // runtime pack's initramfs.
+    let (rootfs, initramfs) = if runtime {
+        (None, Some(PathBuf::from(required(rest, "initramfs")?)))
+    } else {
+        (Some(PathBuf::from(required(rest, "rootfs")?)), None)
+    };
     Ok(ParsedArgs {
         vmlinux: PathBuf::from(required(rest, "vmlinux")?),
-        rootfs: PathBuf::from(required(rest, "rootfs")?),
+        rootfs,
+        initramfs,
+        runtime,
         arch: required(rest, "arch")?
             .parse::<GuestArch>()
             .map_err(|e| e.to_string())?,
@@ -288,11 +357,66 @@ mod tests {
         ])
     }
 
+    /// A runtime pack: `--kind runtime --initramfs ...` (no `--rootfs`) and
+    /// keyless (`--keyless --identity ...`).
+    fn runtime_args() -> Vec<String> {
+        let mut a = args(&[
+            ("vmlinux", "/tmp/vmlinux"),
+            ("kind", "runtime"),
+            ("initramfs", "/tmp/initramfs"),
+            ("arch", "aarch64"),
+            ("channel", "stable"),
+            ("out-dir", "/tmp/out"),
+            ("sbom", "/tmp/sbom.json"),
+            (
+                "revocation-channel",
+                "https://example.test/revocations.json",
+            ),
+            ("identity", "https://example.test/wf.yml@refs/tags/v1"),
+        ]);
+        a.push("--keyless".to_string());
+        a
+    }
+
+    #[test]
+    fn parses_runtime_kind_with_initramfs_and_keyless() {
+        let parsed = parse_args(&runtime_args()).expect("parse runtime");
+        assert!(parsed.runtime);
+        assert_eq!(parsed.initramfs, Some(PathBuf::from("/tmp/initramfs")));
+        assert_eq!(parsed.rootfs, None);
+        assert_eq!(
+            parsed.identity.as_deref(),
+            Some("https://example.test/wf.yml@refs/tags/v1")
+        );
+    }
+
+    #[test]
+    fn runtime_kind_without_keyless_is_rejected() {
+        // Runtime is keyless-only: swap the keyless flag for an ed25519 key.
+        let a = args(&[
+            ("vmlinux", "/tmp/vmlinux"),
+            ("kind", "runtime"),
+            ("initramfs", "/tmp/initramfs"),
+            ("arch", "aarch64"),
+            ("channel", "stable"),
+            ("out-dir", "/tmp/out"),
+            ("sbom", "/tmp/sbom.json"),
+            (
+                "revocation-channel",
+                "https://example.test/revocations.json",
+            ),
+            ("signing-key", "/tmp/key.hex"),
+        ]);
+        let err = parse_args(&a).expect_err("runtime requires keyless");
+        assert!(err.contains("keyless"), "got: {err}");
+    }
+
     #[test]
     fn parses_required_args_with_defaults() {
         let parsed = parse_args(&full_args()).expect("parse");
         assert_eq!(parsed.vmlinux, PathBuf::from("/tmp/vmlinux"));
-        assert_eq!(parsed.rootfs, PathBuf::from("/tmp/rootfs.ext4"));
+        assert_eq!(parsed.rootfs, Some(PathBuf::from("/tmp/rootfs.ext4")));
+        assert!(!parsed.runtime);
         assert_eq!(parsed.arch, GuestArch::Aarch64);
         assert_eq!(parsed.channel, "stable");
         assert_eq!(parsed.sbom, PathBuf::from("/tmp/sbom.json"));

--- a/crates/mvm-build/src/builder_pack.rs
+++ b/crates/mvm-build/src/builder_pack.rs
@@ -29,6 +29,8 @@ use thiserror::Error;
 pub const KERNEL_FILE: &str = "vmlinux";
 /// In-pack path of the builder rootfs image.
 pub const ROOTFS_FILE: &str = "rootfs.ext4";
+/// In-pack path of a runtime pack's initramfs.
+pub const INITRAMFS_FILE: &str = "initramfs";
 /// Self-describing manifest written next to the artifacts so a produced pack dir
 /// can be published as-is. Distinct from the cache's own `.pack-manifest.json`
 /// sidecar, and never a declared pack file.
@@ -53,6 +55,42 @@ pub struct BuildBuilderPackParams {
     pub target_arch: GuestArch,
     /// Publish channel; becomes `TrustMetadata.channel_identity`, the value the
     /// host's allowed-channel set must contain.
+    pub channel: String,
+    /// Identity of the builder that produced the artifacts.
+    pub builder_identity: String,
+    /// Identity of the environment the build ran in.
+    pub build_environment_identity: String,
+    /// When the artifacts were built.
+    pub build_timestamp: DateTime<Utc>,
+    /// Whether the build was reproduced.
+    pub reproducibility: ReproducibilityStatus,
+    /// SBOM enumerating the pack's contents.
+    pub sbom: SbomReference,
+    /// When the pack's trust metadata expires.
+    pub expires_at: DateTime<Utc>,
+    /// Where a consumer looks up revocations for this signer.
+    pub revocation_channel: String,
+    /// Optional mirror identity.
+    pub mirror_identity: Option<String>,
+    /// Optional transparency-log anchor for the signature.
+    pub transparency_log: Option<TransparencyLogReference>,
+    /// Validity window stamped onto the produced signature.
+    pub signature: SignatureValidity,
+}
+
+/// Inputs to [`build_keyless_runtime_pack`]. Mirrors [`BuildBuilderPackParams`]
+/// but carries a runtime pack's artifacts (`vmlinux` + `initramfs`) instead of
+/// the builder VM's disk image. Every timestamp is an input, keeping the
+/// producer pure.
+#[derive(Debug, Clone)]
+pub struct BuildRuntimePackParams {
+    /// Source `vmlinux` on disk; copied into the pack as [`KERNEL_FILE`].
+    pub vmlinux: PathBuf,
+    /// Source initramfs on disk; copied into the pack as [`INITRAMFS_FILE`].
+    pub initramfs: PathBuf,
+    /// Architecture the artifacts target.
+    pub target_arch: GuestArch,
+    /// Publish channel; becomes `TrustMetadata.channel_identity`.
     pub channel: String,
     /// Identity of the builder that produced the artifacts.
     pub builder_identity: String,
@@ -195,6 +233,56 @@ pub fn build_keyless_builder_pack(
     })
 }
 
+/// A keyless (Sigstore-authority) Runtime pack: the manifest plus the path of
+/// the file its signable bytes were written to, exactly as [`KeylessBuilderPack`]
+/// but for a runtime pack (kernel + initramfs).
+#[derive(Debug, Clone)]
+pub struct KeylessRuntimePack {
+    pub manifest: PackManifest,
+    pub manifest_path: PathBuf,
+}
+
+/// Keyless counterpart of the builder producer for a `Runtime` pack: copies
+/// `vmlinux` + `initramfs` into `out_dir`, hashes them into the typed
+/// `kernel_hash` / `initramfs_hash` outputs a `Runtime` pack requires, assembles
+/// the manifest via `PackBuilder::new_keyless` (no ed25519 key, no in-manifest
+/// signature), and writes `manifest.canonical_bytes()` verbatim to
+/// `out_dir/manifest.json` — the exact bytes a release pipeline signs out of band
+/// and a keyless verifier re-derives at verify time. Never signs anything.
+pub fn build_keyless_runtime_pack(
+    params: &BuildRuntimePackParams,
+    identity: &str,
+    out_dir: &Path,
+) -> Result<KeylessRuntimePack, BuilderPackError> {
+    fs::create_dir_all(out_dir).map_err(io_at(out_dir))?;
+
+    let kernel_dest = out_dir.join(KERNEL_FILE);
+    copy_file(&params.vmlinux, &kernel_dest)?;
+    let initramfs_dest = out_dir.join(INITRAMFS_FILE);
+    copy_file(&params.initramfs, &initramfs_dest)?;
+
+    let kernel_hash = sha256_file(&kernel_dest)?;
+    let initramfs_hash = sha256_file(&initramfs_dest)?;
+
+    let manifest = PackBuilder::new_keyless(out_dir, runtime_metadata(params), identity)
+        .files([KERNEL_FILE, INITRAMFS_FILE])
+        .output_hashes(PackOutputHashes {
+            kernel_hash: Some(kernel_hash),
+            initramfs_hash: Some(initramfs_hash),
+            ..Default::default()
+        })
+        .build()?;
+
+    let manifest_bytes = manifest.canonical_bytes()?;
+    let manifest_path = out_dir.join(MANIFEST_FILE);
+    fs::write(&manifest_path, &manifest_bytes).map_err(io_at(&manifest_path))?;
+
+    Ok(KeylessRuntimePack {
+        manifest,
+        manifest_path,
+    })
+}
+
 /// Assemble the [`PackMetadata`] a produced Builder pack carries. The hash-derived
 /// outputs and the signature bundle are the builder's job; this is everything the
 /// caller supplies plus the fixed hvf/vsock host contract.
@@ -206,6 +294,39 @@ fn builder_metadata(params: &BuildBuilderPackParams) -> PackMetadata {
         required_host_capabilities: vec![HostCapability(VSOCK_CAPABILITY.to_string())],
         policy_compatibility: PolicyCompatibility {
             // Shared with the host verifier so the two sides cannot drift.
+            policy_hash: host_pack_policy_hash(params.target_arch),
+            local_rebuild_required: false,
+            allowed_channels: vec![params.channel.clone()],
+        },
+        inputs: empty_inputs(),
+        provenance: PackProvenanceMeta {
+            builder_identity: params.builder_identity.clone(),
+            build_environment_identity: params.build_environment_identity.clone(),
+            build_timestamp: params.build_timestamp,
+            reproducibility: params.reproducibility.clone(),
+            sbom: params.sbom.clone(),
+        },
+        trust: PackTrustMeta {
+            expires_at: params.expires_at,
+            revocation_channel: params.revocation_channel.clone(),
+            channel_identity: params.channel.clone(),
+            mirror_identity: params.mirror_identity.clone(),
+            transparency_log: params.transparency_log.clone(),
+        },
+        signature: params.signature.clone(),
+    }
+}
+
+/// Assemble the [`PackMetadata`] a produced Runtime pack carries — the same
+/// hvf/vsock host contract as a builder pack, but `kind = Runtime` so the
+/// verifier requires the runtime output hashes (kernel + initramfs).
+fn runtime_metadata(params: &BuildRuntimePackParams) -> PackMetadata {
+    PackMetadata {
+        kind: PackKind::Runtime,
+        target_arch: params.target_arch,
+        backend_compatibility: vec![PackBackend::Hvf],
+        required_host_capabilities: vec![HostCapability(VSOCK_CAPABILITY.to_string())],
+        policy_compatibility: PolicyCompatibility {
             policy_hash: host_pack_policy_hash(params.target_arch),
             local_rebuild_required: false,
             allowed_channels: vec![params.channel.clone()],
@@ -331,6 +452,58 @@ mod tests {
                 expires_at: utc(2026, 12, 31),
             },
         }
+    }
+
+    /// Write synthetic `vmlinux` + `initramfs` sources and return runtime
+    /// producer params pointing at them.
+    fn runtime_params_in(src: &TempDir) -> BuildRuntimePackParams {
+        let vmlinux = src.path().join("vmlinux.src");
+        let initramfs = src.path().join("initramfs.src");
+        fs::write(&vmlinux, KERNEL_BYTES).expect("write kernel src");
+        fs::write(&initramfs, b"runtime-initramfs-bytes").expect("write initramfs src");
+        BuildRuntimePackParams {
+            vmlinux,
+            initramfs,
+            target_arch: GuestArch::host(),
+            channel: CHANNEL.to_string(),
+            builder_identity: "ci-builder".to_string(),
+            build_environment_identity: "github-actions".to_string(),
+            build_timestamp: utc(2026, 6, 23),
+            reproducibility: ReproducibilityStatus::Reproduced,
+            sbom: SbomReference {
+                uri: "https://example.test/sbom.spdx.json".to_string(),
+                sha256: Sha256Hex::from_bytes(b"sbom"),
+            },
+            expires_at: utc(2026, 12, 31),
+            revocation_channel: "https://example.test/revocations.json".to_string(),
+            mirror_identity: None,
+            transparency_log: None,
+            signature: SignatureValidity {
+                signed_at: utc(2026, 6, 24),
+                expires_at: utc(2026, 12, 31),
+            },
+        }
+    }
+
+    #[test]
+    fn keyless_runtime_pack_has_runtime_kind_outputs_and_no_signature() {
+        let src = TempDir::new().expect("src");
+        let out = TempDir::new().expect("out");
+        let produced =
+            build_keyless_runtime_pack(&runtime_params_in(&src), KEYLESS_IDENTITY, out.path())
+                .expect("produce runtime pack");
+        let m = &produced.manifest;
+        assert_eq!(m.kind, PackKind::Runtime);
+        let files: Vec<&str> = m.outputs.files.iter().map(|f| f.path.as_str()).collect();
+        assert!(files.contains(&KERNEL_FILE) && files.contains(&INITRAMFS_FILE));
+        // A Runtime pack requires kernel + initramfs (or agent-rootfs) hashes.
+        assert!(m.outputs.kernel_hash.is_some());
+        assert!(m.outputs.initramfs_hash.is_some());
+        // Keyless: no in-manifest signature, and the written file is the exact
+        // signable bytes (canonical), so an out-of-band signature stays valid.
+        assert!(m.provenance.signature_bundle.signatures.is_empty());
+        let on_disk = fs::read(&produced.manifest_path).expect("read manifest file");
+        assert_eq!(on_disk, m.canonical_bytes().expect("canonical bytes"));
     }
 
     /// The host policy an hvf machine derives for the running arch — the one the

--- a/crates/mvm-build/src/builder_pack.rs
+++ b/crates/mvm-build/src/builder_pack.rs
@@ -153,7 +153,7 @@ pub struct KeylessBuilderPack {
 }
 
 /// Keyless counterpart to [`build_builder_pack`]: same artifact layout and typed
-/// output hashes, but the manifest is assembled via `PackBuilder::build_sigstore`
+/// output hashes, but the manifest is assembled via `PackBuilder::new_keyless`
 /// (no ed25519 key, no in-manifest signature) and the file written to
 /// `out_dir/manifest.json` is `manifest.canonical_bytes()` verbatim — the exact
 /// bytes a release pipeline signs out of band and a keyless verifier re-derives
@@ -173,14 +173,14 @@ pub fn build_keyless_builder_pack(
     let kernel_hash = sha256_file(&kernel_dest)?;
     let builder_image_hash = sha256_file(&rootfs_dest)?;
 
-    let manifest = PackBuilder::new_keyless(out_dir, builder_metadata(params))
+    let manifest = PackBuilder::new_keyless(out_dir, builder_metadata(params), identity)
         .files([KERNEL_FILE, ROOTFS_FILE])
         .output_hashes(PackOutputHashes {
             kernel_hash: Some(kernel_hash),
             builder_image_hash: Some(builder_image_hash),
             ..Default::default()
         })
-        .build_sigstore(identity)?;
+        .build()?;
 
     // Not pretty-printed: this file's bytes are exactly what gets signed, so it
     // must match `manifest.canonical_bytes()` byte-for-byte rather than a

--- a/crates/mvm-core/src/packs.rs
+++ b/crates/mvm-core/src/packs.rs
@@ -967,19 +967,27 @@ pub struct PackOutputHashes {
     pub builder_image_hash: Option<Sha256Hex>,
 }
 
+/// The signing authority a `PackBuilder` assembles under. Carried at
+/// construction rather than as an `Option<&SigningKey>` field so the two build
+/// shapes — ed25519-keyed and keyless (Sigstore) — cannot be mismatched: there
+/// is exactly one `build()` method, and which signing path it takes is fixed
+/// the moment the builder is constructed, not decided by which finisher method
+/// happens to get called.
+enum PackSigner<'a> {
+    Ed25519(&'a SigningKey),
+    Keyless { identity: String },
+}
+
 /// Inverse of `verify_pack_at`: hashes a file set under `root`, computes the pack
 /// hash, and signs the manifest so `verify_pack_at` accepts the result. Files are
 /// addressed by their in-pack relative path and hashed with the same helper the
 /// verifier uses, so producer and verifier can never drift.
-///
-/// `signing_key` is absent for a keyless (Sigstore-authority) build: construct
-/// with `new_keyless` and finish with `build_sigstore` instead of `build`.
 pub struct PackBuilder<'a> {
     root: PathBuf,
     metadata: PackMetadata,
     output_hashes: PackOutputHashes,
     files: Vec<String>,
-    signing_key: Option<&'a SigningKey>,
+    signer: PackSigner<'a>,
 }
 
 impl<'a> PackBuilder<'a> {
@@ -993,20 +1001,27 @@ impl<'a> PackBuilder<'a> {
             metadata,
             output_hashes: PackOutputHashes::default(),
             files: Vec::new(),
-            signing_key: Some(signing_key),
+            signer: PackSigner::Ed25519(signing_key),
         }
     }
 
     /// Keyless counterpart to `new`: no ed25519 key, since the produced manifest
     /// carries no in-manifest signature — the detached cosign bundle a release
-    /// pipeline signs separately is authoritative. Finish with `build_sigstore`.
-    pub fn new_keyless(root: impl Into<PathBuf>, metadata: PackMetadata) -> Self {
+    /// pipeline signs separately is authoritative. `identity` is the release
+    /// identity the manifest's `signing_key_id` is derived from.
+    pub fn new_keyless(
+        root: impl Into<PathBuf>,
+        metadata: PackMetadata,
+        identity: impl Into<String>,
+    ) -> Self {
         Self {
             root: root.into(),
             metadata,
             output_hashes: PackOutputHashes::default(),
             files: Vec::new(),
-            signing_key: None,
+            signer: PackSigner::Keyless {
+                identity: identity.into(),
+            },
         }
     }
 
@@ -1027,35 +1042,48 @@ impl<'a> PackBuilder<'a> {
         self
     }
 
+    /// Assembles and, for the ed25519 authority, signs the manifest. Which
+    /// path runs is fixed by the `PackSigner` chosen at construction time:
+    ///
+    /// - `Ed25519`: signs the assembled manifest under the held key and
+    ///   appends the resulting signature to the bundle.
+    /// - `Keyless`: stamps a `Sigstore`-authority manifest with an
+    ///   identity-derived `signing_key_id` and an empty in-manifest signature
+    ///   list, and leaves it unsigned. The caller (a release pipeline) signs
+    ///   `manifest.canonical_bytes()` out of band with `cosign sign-blob` and
+    ///   ships the detached bundle as the pack's authority.
     pub fn build(self) -> Result<PackManifest, PackManifestError> {
-        let signing_key = self
-            .signing_key
-            .expect("PackBuilder::build requires a signing key; construct via PackBuilder::new, or use build_sigstore for a keyless pack");
-        let signing_key_id = KeyId::from_pubkey(&signing_key.verifying_key());
+        // Read the signer through a borrow first so `self` stays whole for the
+        // `assemble` call below — `&SigningKey` is `Copy`, so this doesn't move
+        // anything out of `self.signer`.
+        let (signing_key_id, signature_format, signing_key) = match &self.signer {
+            PackSigner::Ed25519(signing_key) => (
+                KeyId::from_pubkey(&signing_key.verifying_key()),
+                SignatureFormat::Ed25519,
+                Some(*signing_key),
+            ),
+            PackSigner::Keyless { identity } => (
+                KeyId::from_identity(identity),
+                SignatureFormat::Sigstore,
+                None,
+            ),
+        };
         let signature_validity = self.metadata.signature.clone();
-        let mut manifest = self.assemble(signing_key_id.clone(), SignatureFormat::Ed25519)?;
-        let signature = signing_key.sign(&manifest.signature_payload_bytes()?);
-        manifest
-            .provenance
-            .signature_bundle
-            .signatures
-            .push(PackSignature {
-                key_id: signing_key_id,
-                signature_base64: B64.encode(signature.to_bytes()),
-                signed_at: signature_validity.signed_at,
-                expires_at: signature_validity.expires_at,
-            });
+        let mut manifest = self.assemble(signing_key_id.clone(), signature_format)?;
+        if let Some(signing_key) = signing_key {
+            let signature = signing_key.sign(&manifest.signature_payload_bytes()?);
+            manifest
+                .provenance
+                .signature_bundle
+                .signatures
+                .push(PackSignature {
+                    key_id: signing_key_id,
+                    signature_base64: B64.encode(signature.to_bytes()),
+                    signed_at: signature_validity.signed_at,
+                    expires_at: signature_validity.expires_at,
+                });
+        }
         Ok(manifest)
-    }
-
-    /// Keyless counterpart to `build`: stamps a `Sigstore`-authority manifest
-    /// with an identity-derived `signing_key_id` and an empty in-manifest
-    /// signature list, and leaves it unsigned. The caller (a release pipeline)
-    /// signs `manifest.canonical_bytes()` out of band with `cosign sign-blob`
-    /// and ships the detached bundle as the pack's authority.
-    pub fn build_sigstore(self, identity: &str) -> Result<PackManifest, PackManifestError> {
-        let signing_key_id = KeyId::from_identity(identity);
-        self.assemble(signing_key_id, SignatureFormat::Sigstore)
     }
 
     /// Shared assembly for both authority shapes: hash the declared files,
@@ -1782,21 +1810,25 @@ mod tests {
     const SIGSTORE_IDENTITY: &str =
         "https://github.com/tinylabscom/mvm/.github/workflows/release.yml@refs/tags/v0.17.0";
 
-    /// Produce a `Builder` pack via `PackBuilder::new_keyless` +
-    /// `build_sigstore`, exercising the same file set as
-    /// `produced_hvf_builder_pack` but with no ed25519 key.
+    /// Produce a `Builder` pack via `PackBuilder::new_keyless` + `build`,
+    /// exercising the same file set as `produced_hvf_builder_pack` but with no
+    /// ed25519 key.
     fn produced_keyless_builder_pack(dir: &TempDir) -> PackManifest {
         fs::write(dir.path().join("kernel"), b"builder-kernel").expect("write kernel");
         fs::write(dir.path().join("builder.img"), b"builder-image").expect("write builder");
-        PackBuilder::new_keyless(dir.path(), producer_metadata(PackKind::Builder))
-            .files(["kernel", "builder.img"])
-            .output_hashes(PackOutputHashes {
-                kernel_hash: Some(Sha256Hex::from_bytes(b"builder-kernel")),
-                builder_image_hash: Some(Sha256Hex::from_bytes(b"builder-image")),
-                ..Default::default()
-            })
-            .build_sigstore(SIGSTORE_IDENTITY)
-            .expect("produce keyless pack")
+        PackBuilder::new_keyless(
+            dir.path(),
+            producer_metadata(PackKind::Builder),
+            SIGSTORE_IDENTITY,
+        )
+        .files(["kernel", "builder.img"])
+        .output_hashes(PackOutputHashes {
+            kernel_hash: Some(Sha256Hex::from_bytes(b"builder-kernel")),
+            builder_image_hash: Some(Sha256Hex::from_bytes(b"builder-image")),
+            ..Default::default()
+        })
+        .build()
+        .expect("produce keyless pack")
     }
 
     #[test]


### PR DESCRIPTION
Producer + release-signing hardening, plus the runtime-pack producer.

## 1. Typed `PackBuilder` authority — kills the `build()` footgun
`PackBuilder` stored `signing_key: Option<&SigningKey>` and `build()` `.expect()`ed `Some` — so `new_keyless().build()` **panicked**, and `new(key).build_sigstore(id)` silently ignored the key. Now it stores a typed `PackSigner<'a>` (`Ed25519(&SigningKey)` / `Keyless { identity }`) set at construction, with a single `build()` that dispatches. The illegal keyless-vs-ed25519 combination is a **compile-time impossibility**, not a runtime panic. `build_sigstore` is gone; all callers updated; produced manifests are byte-identical.

## 2. `--sbom-uri` on the producer tool
The manifest recorded `sbom.uri = file://<local path>` — meaningless in a published pack. New optional `--sbom-uri <url>` sets the real release URL (sha256 still hashed from the local file); `release.yml`'s signing step passes it. Falls back to `file://` when omitted.

## 3. Protected signing environment
`release.yml`'s `builder-vm-image` job gains `environment: release-signing` (a hook for repo-settings protection restricting the keyless-signing job to `v*` tags / required reviewers), documented in-line.

## 4. Runtime-pack producer
`build_keyless_runtime_pack` mirrors the builder producer for `PackKind::Runtime` (kernel + initramfs → the required Runtime output hashes), and `mvm-builder-pack-tool` gains `--kind runtime` (`--initramfs`, keyless-only). Smoke-produced a valid runtime pack: `kind=runtime`, files `[vmlinux, initramfs]`, Sigstore authority.

**Honest scope on #4:** this is the producer *surface* only. A runtime pack is not yet **published** in `release.yml` or **consumed/launched** — that's the runtime launch path (plan §E), a separate workstream. So the runtime producer is invokable and tested but not yet wired end-to-end.

## Tests
mvm-core + mvm-build 2294 (default) / 1583 (mvm-core `manifest-verify`); mvm-build 716; tool 14 (incl. runtime parse + reject-non-keyless); producer tests incl. runtime kind/outputs/canonical-bytes. Clippy `-D warnings` both feature sets, YAML/actionlint, fmt all clean.
