### PR TITLE
fix(machine): make `run -d -- <cmd>` detach instead of foreground-blocking

### DIFF
--- a/crates/mvm-cli/src/commands/image/mod.rs
+++ b/crates/mvm-cli/src/commands/image/mod.rs
@@ -315,8 +315,10 @@ pub(in crate::commands) fn oci_cache_root() -> PathBuf {
 /// script) changes such that already-materialized rootfs images must be
 /// re-sealed. Folded with the crate version into [`oci_runtime_tag`]; a
 /// stale rootfs then re-materializes instead of booting an outdated agent.
-/// Epoch 1 introduces the dev-shell exec handler in the OCI agent.
-const OCI_RUNTIME_EPOCH: u32 = 1;
+/// Epoch 1 introduces the dev-shell exec handler in the OCI agent. Epoch 2 adds
+/// the detached-workload handler — a rootfs sealed with an older agent would
+/// reject the run-detached request, so it must re-materialize.
+const OCI_RUNTIME_EPOCH: u32 = 2;
 
 /// Identity of the guest runtime the running mvmctl bakes into an OCI rootfs.
 /// Cheap and build-free (no agent cross-compile) so it can gate the cache-hit

--- a/crates/mvm-cli/src/commands/machine/mod.rs
+++ b/crates/mvm-cli/src/commands/machine/mod.rs
@@ -2467,6 +2467,29 @@ fn run_persistent_post_start(
         if !super::shared::wait_for_guest_agent(name, 30) {
             bail!("guest agent for {name:?} not reachable to run the command");
         }
+        // `-d` with a command detaches: the guest agent spawns the argv as
+        // an independent workload (its own session, output to the captured
+        // console) and acks immediately, so we return instead of
+        // foreground-streaming a connection-scoped exec that the output cap
+        // would eventually kill.
+        if args.detach {
+            let env = machine_console_env(spec.ssh_agent);
+            let transport = mvm::vsock_transport::for_vm(name)?;
+            let mut stream = transport.connect(mvm_guest::vsock::GUEST_AGENT_PORT)?;
+            super::shared::emit_vsock_rpc_audit(
+                name,
+                &mvm_guest::vsock::GuestRequest::RunDetached {
+                    argv: args.argv.clone(),
+                    env: env.clone(),
+                },
+            );
+            let pid = mvm_guest::vsock::send_run_detached(&mut stream, args.argv.clone(), env)?;
+            if !args.json {
+                eprintln!("detached workload started (guest pid {pid})");
+                println!("{name}");
+            }
+            return Ok(());
+        }
         return console::run(
             cli,
             console::Args {

--- a/crates/mvm-guest/src/bin/mvm-guest-agent.rs
+++ b/crates/mvm-guest/src/bin/mvm-guest-agent.rs
@@ -1010,6 +1010,113 @@ fn do_exec_streaming(
     GuestResponse::ExecEvent(terminal)
 }
 
+/// Spawn `argv` as a detached workload and return its ack (dev-shell only).
+///
+/// Models the image `/init` entrypoint launch, but agent-driven and
+/// non-blocking: the child gets its own session (`setsid`), stdin from
+/// `/dev/null`, and stdout/stderr on `/dev/console` (which the host
+/// backend captures to `console.log`). The call returns immediately with
+/// `DetachedStarted { pid }`; a detached reaper thread waits on the child
+/// and reports its exit code to the host's workload-exit port via
+/// `mvm-exit-report`, so the VM powers off when the workload finishes
+/// (docker `-d` semantics). The reaper never blocks the agent request loop.
+#[cfg(feature = "dev-shell")]
+fn do_run_detached(argv: Vec<String>, env: Vec<(String, String)>) -> GuestResponse {
+    use std::os::unix::process::CommandExt;
+    use std::process::{Command, Stdio};
+
+    let Some((program, args)) = argv.split_first() else {
+        return GuestResponse::Error {
+            message: "run-detached refused: empty argv".to_string(),
+        };
+    };
+
+    let devnull = match std::fs::File::open("/dev/null") {
+        Ok(f) => f,
+        Err(e) => {
+            return GuestResponse::Error {
+                message: format!("run-detached: open /dev/null: {e}"),
+            };
+        }
+    };
+    // Two independent write handles to the console so stdout and stderr
+    // each own their fd (no shared-offset surprises).
+    let console_out = match std::fs::OpenOptions::new().write(true).open("/dev/console") {
+        Ok(f) => f,
+        Err(e) => {
+            return GuestResponse::Error {
+                message: format!("run-detached: open /dev/console: {e}"),
+            };
+        }
+    };
+    let console_err = match std::fs::OpenOptions::new().write(true).open("/dev/console") {
+        Ok(f) => f,
+        Err(e) => {
+            return GuestResponse::Error {
+                message: format!("run-detached: open /dev/console: {e}"),
+            };
+        }
+    };
+
+    // env_clear(), then a minimal safe base plus the caller's vars.
+    // Drop malformed entries rather than let `Command::env` panic
+    // (empty key, key containing '=' or NUL, value containing NUL).
+    let safe_env = env.into_iter().filter(|(k, v)| {
+        !k.is_empty() && !k.contains('=') && !k.contains('\0') && !v.contains('\0')
+    });
+
+    let mut cmd = Command::new(program);
+    cmd.args(args)
+        .env_clear()
+        .env(
+            "PATH",
+            "/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin",
+        )
+        .envs(safe_env)
+        .stdin(Stdio::from(devnull))
+        .stdout(Stdio::from(console_out))
+        .stderr(Stdio::from(console_err));
+
+    // SAFETY: runs in the post-fork pre-exec child. `setsid(2)` is
+    // async-signal-safe and is the only work done here — it detaches the
+    // workload into its own session so it outlives this request's
+    // connection and isn't tied to the agent's controlling terminal.
+    unsafe {
+        cmd.pre_exec(|| {
+            if libc::setsid() < 0 {
+                return Err(std::io::Error::last_os_error());
+            }
+            Ok(())
+        });
+    }
+
+    let child = match cmd.spawn() {
+        Ok(c) => c,
+        Err(e) => {
+            return GuestResponse::Error {
+                message: format!("run-detached: spawn {program}: {e}"),
+            };
+        }
+    };
+    let pid = child.id() as i32;
+
+    // Reaper: wait for the detached workload, then report its exit code
+    // to the host so the VM powers off (best-effort). Never touches the
+    // agent request loop.
+    std::thread::spawn(move || {
+        let mut child = child;
+        let code = match child.wait() {
+            Ok(status) => status.code().unwrap_or(-1),
+            Err(_) => -1,
+        };
+        let _ = std::process::Command::new("/usr/local/bin/mvm-exit-report")
+            .arg(code.to_string())
+            .status();
+    });
+
+    GuestResponse::DetachedStarted { pid }
+}
+
 /// Write one staged file to disk (creating parents, applying mode) before an
 /// `ExecBatch` runs its commands. (dev-shell only)
 #[cfg(feature = "dev-shell")]
@@ -2361,6 +2468,20 @@ fn handle_client(
                 handle_run_entrypoint(&mut file, stdin, timeout_secs, env)
             }
         }
+
+        #[cfg(feature = "dev-shell")]
+        GuestRequest::RunDetached { argv, env } => {
+            // Argv is NOT logged: it can carry user-typed secrets, mirroring
+            // the run-code audit posture.
+            eprintln!("[audit] run-detached request: {} args", argv.len());
+            do_run_detached(argv, env)
+        }
+
+        #[cfg(not(feature = "dev-shell"))]
+        GuestRequest::RunDetached { .. } => GuestResponse::Error {
+            message: "run-detached not available: guest agent built without dev-shell feature"
+                .to_string(),
+        },
 
         GuestRequest::FsDiff => {
             // Walk the overlay upper dir to find changes since boot.

--- a/crates/mvm-guest/src/vsock.rs
+++ b/crates/mvm-guest/src/vsock.rs
@@ -249,6 +249,27 @@ pub enum GuestRequest {
         #[serde(default)]
         env: Vec<(String, String)>,
     },
+    /// Run an arbitrary argv as a detached workload (dev-only).
+    ///
+    /// Mirrors how the image's `/init` runs its baked entrypoint, but
+    /// driven from the agent and non-blocking: the agent spawns the
+    /// program in its own session (`setsid`), with stdin from
+    /// `/dev/null` and stdout/stderr on the guest console (which the
+    /// host backend captures to `console.log`), returns an immediate
+    /// `DetachedStarted { pid }` ack, and a reaper reports the
+    /// workload's exit code to the host's workload-exit port when it
+    /// finishes — so the VM powers off once the workload exits
+    /// (docker `-d` semantics). Unlike `Exec`, the workload's lifetime
+    /// is not bound to this request's connection.
+    RunDetached {
+        /// The program and its arguments. `argv[0]` is the program;
+        /// resolved via PATH when not absolute.
+        argv: Vec<String>,
+        /// Env vars injected after `env_clear()` (plus a minimal safe
+        /// base). Empty when omitted on the wire.
+        #[serde(default)]
+        env: Vec<(String, String)>,
+    },
     /// Signal post-restore: rotate the VMGenID, then remount drives and
     /// restart services. `token` is the host-minted generation token for this
     /// resume; the guest feeds it to its `GenIdReseeder` so two clones of one
@@ -575,6 +596,7 @@ impl GuestRequest {
             Self::Exec { .. } => "exec",
             Self::ExecBatch { .. } => "exec-batch",
             Self::RunEntrypoint { .. } => "run-entrypoint",
+            Self::RunDetached { .. } => "run-detached",
             Self::PostRestore { .. } => "post-restore",
             Self::FsDiff => "fs-diff",
             Self::StartPortForward { .. } => "start-port-forward",
@@ -787,6 +809,7 @@ impl GuestRequest {
             GuestRequest::Exec { .. } => Verb::Exec,
             GuestRequest::ExecBatch { .. } => Verb::ExecBatch,
             GuestRequest::RunEntrypoint { .. } => Verb::RunEntrypoint,
+            GuestRequest::RunDetached { .. } => Verb::RunDetached,
             GuestRequest::PostRestore { .. } => Verb::PostRestore,
             GuestRequest::FsDiff => Verb::FsDiff,
             GuestRequest::StartPortForward { .. } => Verb::StartPortForward,
@@ -859,6 +882,7 @@ impl GuestRequest {
             // RPC surface is DevOnly in v1.
             GuestRequest::Exec { .. }
             | GuestRequest::ExecBatch { .. }
+            | GuestRequest::RunDetached { .. }
             | GuestRequest::FsDiff
             | GuestRequest::StartPortForward { .. }
             | GuestRequest::StartUnixSocketForward { .. }
@@ -1012,6 +1036,11 @@ pub enum GuestResponse {
     /// Buffered outcomes of an `ExecBatch` call (dev-shell only), one per
     /// command in request order (truncated at the first non-zero exit).
     ExecBatchResult { outcomes: Vec<ExecOutcomeWire> },
+    /// Ack for a `RunDetached` call: the detached workload was spawned
+    /// with the given guest PID. The workload runs independently of this
+    /// request's connection; its exit is later reported to the host's
+    /// workload-exit port by the agent's reaper.
+    DetachedStarted { pid: i32 },
     /// Post-restore acknowledgement.
     PostRestoreAck {
         success: bool,
@@ -1127,6 +1156,7 @@ name_enum! {
     pub enum Verb {
         ProtocolHello, WorkerStatus, SleepPrep, Wake, Ping, IntegrationStatus,
         CheckpointIntegrations, ProbeStatus, PrimedStatus, Exec, ExecBatch, RunEntrypoint,
+        RunDetached,
         PostRestore,
         FsDiff, StartPortForward, StartUnixSocketForward, ConsoleOpen,
         ConsoleClose, ConsoleResize, EntrypointStatus, ReadinessStatus, FsRead,
@@ -1144,7 +1174,7 @@ name_enum! {
         ProtocolHelloAck, ProtocolMismatch, WorkerStatus, SleepPrepAck, WakeAck,
         Pong, Error, UnsupportedInProfile, VerbNotAuthorized, IntegrationStatusReport,
         CheckpointResult, ProbeStatusReport, PrimedStatusReport, EntrypointEvent, ExecEvent,
-        ExecBatchResult,
+        ExecBatchResult, DetachedStarted,
         PostRestoreAck, FsDiffResult, PortForwardStarted,
         UnixSocketForwardStarted, ConsoleOpened, ConsoleExited, ConsoleResized,
         EntrypointStatusReport,
@@ -1217,6 +1247,7 @@ impl Verb {
             Verb::Exec => stream(&[R::ExecEvent]),
             Verb::ExecBatch => unary(&[R::ExecBatchResult]),
             Verb::RunEntrypoint => stream(&[R::EntrypointEvent]),
+            Verb::RunDetached => unary(&[R::DetachedStarted]),
             Verb::PostRestore => unary(&[R::PostRestoreAck]),
             Verb::FsDiff => unary(&[R::FsDiffResult]),
             Verb::StartPortForward => unary(&[R::PortForwardStarted]),
@@ -1270,6 +1301,7 @@ impl GuestResponse {
             GuestResponse::EntrypointEvent(_) => ResponseVariant::EntrypointEvent,
             GuestResponse::ExecEvent(_) => ResponseVariant::ExecEvent,
             GuestResponse::ExecBatchResult { .. } => ResponseVariant::ExecBatchResult,
+            GuestResponse::DetachedStarted { .. } => ResponseVariant::DetachedStarted,
             GuestResponse::PostRestoreAck { .. } => ResponseVariant::PostRestoreAck,
             GuestResponse::FsDiffResult { .. } => ResponseVariant::FsDiffResult,
             GuestResponse::PortForwardStarted { .. } => ResponseVariant::PortForwardStarted,
@@ -3030,6 +3062,34 @@ where
     read_exec_stream(stream, on_event)
 }
 
+/// Send a `RunDetached` request and read its single `DetachedStarted`
+/// ack, returning the detached workload's guest PID.
+///
+/// Non-streaming: the workload runs independently of this connection, so
+/// there is exactly one response frame. Its exit is reported to the
+/// host's workload-exit port by the agent's reaper, not over this
+/// stream. Like `Exec`, `RunDetached` carries no `GuestCapability` — the
+/// agent gates it at compile time via the `dev-shell` feature — so this
+/// does a plain protocol hello.
+pub fn send_run_detached(
+    stream: &mut UnixStream,
+    argv: Vec<String>,
+    env: Vec<(String, String)>,
+) -> Result<i32> {
+    let _ = negotiate_protocol(stream, Vec::new())?;
+    let req = GuestRequest::RunDetached { argv, env };
+    write_frame(stream, &req)?;
+    let resp: GuestResponse = read_frame(stream)?;
+    match resp {
+        GuestResponse::DetachedStarted { pid } => Ok(pid),
+        GuestResponse::Error { message } => bail!("guest agent error: {message}"),
+        GuestResponse::VerbNotAuthorized { verb } => {
+            Err(RpcError::VerbNotAuthorized { verb }.into())
+        }
+        other => bail!("expected DetachedStarted for RunDetached, got {other:?}"),
+    }
+}
+
 /// Read an `ExecEvent` response stream from `stream`: invoke `on_event`
 /// for each non-terminal chunk, return the terminal `Exit`. The caller
 /// must have already done the protocol hello and written the request
@@ -4659,6 +4719,150 @@ mod tests {
         }
     }
 
+    // -------------------------------------------------------------------
+    // RunDetached wire protocol
+    // -------------------------------------------------------------------
+
+    #[test]
+    fn test_run_detached_request_roundtrip() {
+        let req = GuestRequest::RunDetached {
+            argv: vec!["/bin/sh".into(), "-lc".into(), "true".into()],
+            env: vec![("FOO".into(), "bar".into())],
+        };
+        let json = serde_json::to_string(&req).expect("serialize");
+        let decoded: GuestRequest = serde_json::from_str(&json).expect("deserialize");
+        match decoded {
+            GuestRequest::RunDetached { argv, env } => {
+                assert_eq!(argv, vec!["/bin/sh", "-lc", "true"]);
+                assert_eq!(env, vec![("FOO".into(), "bar".into())]);
+            }
+            other => panic!("expected RunDetached, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn test_run_detached_request_env_defaults_empty_when_omitted() {
+        // `env` is `#[serde(default)]`: a frame without it decodes to an
+        // empty env, matching the fuzz-seed shape.
+        let json = r#"{"RunDetached":{"argv":["/bin/sh","-lc","true"]}}"#;
+        let decoded: GuestRequest = serde_json::from_str(json).expect("deserialize");
+        match decoded {
+            GuestRequest::RunDetached { argv, env } => {
+                assert_eq!(argv, vec!["/bin/sh", "-lc", "true"]);
+                assert!(env.is_empty());
+            }
+            other => panic!("expected RunDetached, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn test_run_detached_request_rejects_unknown_field() {
+        let json = r#"{"RunDetached":{"argv":["/bin/true"],"env":[],"oops":1}}"#;
+        let err = serde_json::from_str::<GuestRequest>(json).unwrap_err();
+        assert!(err.to_string().contains("unknown field"));
+    }
+
+    #[test]
+    fn test_detached_started_response_roundtrip() {
+        let resp = GuestResponse::DetachedStarted { pid: 4242 };
+        let json = serde_json::to_string(&resp).expect("serialize");
+        let decoded: GuestResponse = serde_json::from_str(&json).expect("deserialize");
+        match decoded {
+            GuestResponse::DetachedStarted { pid } => assert_eq!(pid, 4242),
+            other => panic!("expected DetachedStarted, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn run_detached_classifies_dev_only() {
+        let req = GuestRequest::RunDetached {
+            argv: vec!["/bin/true".into()],
+            env: vec![],
+        };
+        assert!(matches!(req.class(), RequestClass::DevOnly));
+        assert_eq!(req.kind_name(), "run-detached");
+        assert!(!req.allowed_in(AgentProfile::SealedProd));
+        assert!(req.allowed_in(AgentProfile::Dev));
+    }
+
+    #[test]
+    fn test_send_run_detached_returns_pid() {
+        let (mut host, mut guest) = UnixStream::pair().unwrap();
+
+        let guest_thread = std::thread::spawn(move || {
+            // Hello prelude.
+            let req: GuestRequest = read_frame(&mut guest).unwrap();
+            match req {
+                GuestRequest::ProtocolHello {
+                    host_protocol_version,
+                    min_supported_version,
+                    host_version,
+                    requested_capabilities,
+                } => {
+                    let resp = protocol_hello_response(
+                        host_protocol_version,
+                        min_supported_version,
+                        &host_version,
+                        &requested_capabilities,
+                    );
+                    write_frame(&mut guest, &resp).unwrap();
+                }
+                other => panic!("expected ProtocolHello, got {other:?}"),
+            }
+            // The RunDetached frame, then ack with a pid.
+            let req: GuestRequest = read_frame(&mut guest).unwrap();
+            match req {
+                GuestRequest::RunDetached { argv, env } => {
+                    assert_eq!(argv, vec!["/bin/echo", "hi"]);
+                    assert_eq!(env, vec![("K".to_string(), "V".to_string())]);
+                    write_frame(&mut guest, &GuestResponse::DetachedStarted { pid: 777 }).unwrap();
+                }
+                other => panic!("expected RunDetached, got {other:?}"),
+            }
+        });
+
+        let pid = send_run_detached(
+            &mut host,
+            vec!["/bin/echo".into(), "hi".into()],
+            vec![("K".into(), "V".into())],
+        )
+        .expect("send_run_detached should return the pid");
+        guest_thread.join().unwrap();
+        assert_eq!(pid, 777);
+    }
+
+    #[test]
+    fn test_send_run_detached_maps_agent_error() {
+        let (mut host, mut guest) = UnixStream::pair().unwrap();
+
+        let guest_thread = std::thread::spawn(move || {
+            let _hello: GuestRequest = read_frame(&mut guest).unwrap();
+            write_frame(
+                &mut guest,
+                &GuestResponse::ProtocolHelloAck {
+                    agent_protocol_version: PROTOCOL_VERSION,
+                    min_supported_version: MIN_SUPPORTED_PROTOCOL_VERSION,
+                    agent_version: "0.1.0".to_string(),
+                    capabilities: vec![],
+                },
+            )
+            .unwrap();
+            let _req: GuestRequest = read_frame(&mut guest).unwrap();
+            write_frame(
+                &mut guest,
+                &GuestResponse::Error {
+                    message: "spawn failed".to_string(),
+                },
+            )
+            .unwrap();
+        });
+
+        let err = send_run_detached(&mut host, vec!["/bin/true".into()], vec![])
+            .expect_err("agent Error must surface as a helper error");
+        guest_thread.join().unwrap();
+        assert!(err.to_string().contains("spawn failed"), "err: {err}");
+    }
+
     #[test]
     fn test_run_entrypoint_request_env_defaults_empty_when_omitted() {
         // `env` is `#[serde(default)]`: a wire frame without it decodes to an
@@ -5793,6 +5997,10 @@ mod tests {
             GuestRequest::RunEntrypoint {
                 stdin: vec![],
                 timeout_secs: 1,
+                env: vec![],
+            },
+            GuestRequest::RunDetached {
+                argv: vec!["/bin/sh".into(), "-lc".into(), "true".into()],
                 env: vec![],
             },
             GuestRequest::PostRestore {

--- a/schema/protocol-v0.json
+++ b/schema/protocol-v0.json
@@ -1163,6 +1163,50 @@
           "additionalProperties": false
         },
         {
+          "description": "Run an arbitrary argv as a detached workload (dev-only).\n\nMirrors how the image's `/init` runs its baked entrypoint, but driven from the agent and non-blocking: the agent spawns the program in its own session (`setsid`), with stdin from `/dev/null` and stdout/stderr on the guest console (which the host backend captures to `console.log`), returns an immediate `DetachedStarted { pid }` ack, and a reaper reports the workload's exit code to the host's workload-exit port when it finishes — so the VM powers off once the workload exits (docker `-d` semantics). Unlike `Exec`, the workload's lifetime is not bound to this request's connection.",
+          "type": "object",
+          "required": [
+            "RunDetached"
+          ],
+          "properties": {
+            "RunDetached": {
+              "type": "object",
+              "required": [
+                "argv"
+              ],
+              "properties": {
+                "argv": {
+                  "description": "The program and its arguments. `argv[0]` is the program; resolved via PATH when not absolute.",
+                  "type": "array",
+                  "items": {
+                    "type": "string"
+                  }
+                },
+                "env": {
+                  "description": "Env vars injected after `env_clear()` (plus a minimal safe base). Empty when omitted on the wire.",
+                  "default": [],
+                  "type": "array",
+                  "items": {
+                    "type": "array",
+                    "items": [
+                      {
+                        "type": "string"
+                      },
+                      {
+                        "type": "string"
+                      }
+                    ],
+                    "maxItems": 2,
+                    "minItems": 2
+                  }
+                }
+              },
+              "additionalProperties": false
+            }
+          },
+          "additionalProperties": false
+        },
+        {
           "description": "Signal post-restore: rotate the VMGenID, then remount drives and restart services. `token` is the host-minted generation token for this resume; the guest feeds it to its `GenIdReseeder` so two clones of one snapshot reseed their CSPRNG to distinct state. An all-zero token (the `serde` default, used by no-rotation callers like template restore) means \"no rotation\" — the remount/restart still runs.",
           "type": "object",
           "required": [
@@ -2331,6 +2375,29 @@
                   "items": {
                     "$ref": "#/definitions/ExecOutcomeWire"
                   }
+                }
+              },
+              "additionalProperties": false
+            }
+          },
+          "additionalProperties": false
+        },
+        {
+          "description": "Ack for a `RunDetached` call: the detached workload was spawned with the given guest PID. The workload runs independently of this request's connection; its exit is later reported to the host's workload-exit port by the agent's reaper.",
+          "type": "object",
+          "required": [
+            "DetachedStarted"
+          ],
+          "properties": {
+            "DetachedStarted": {
+              "type": "object",
+              "required": [
+                "pid"
+              ],
+              "properties": {
+                "pid": {
+                  "type": "integer",
+                  "format": "int32"
                 }
               },
               "additionalProperties": false

--- a/sdks/python/mvm/_protocol/protocol.py
+++ b/sdks/python/mvm/_protocol/protocol.py
@@ -403,10 +403,21 @@ class GuestRequest12:
     RunEntrypoint: RunEntrypoint
 
 
+@dataclass
+class RunDetached:
+    argv: List[str]
+    env: Optional[List[List[str]]] = field(default_factory=lambda: [])
+
+
+@dataclass
+class GuestRequest13:
+    RunDetached: RunDetached
+
+
 TokenItem = int
 
 
-class GuestRequest14(Enum):
+class GuestRequest15(Enum):
     FsDiff = 'FsDiff'
 
 
@@ -416,7 +427,7 @@ class StartPortForward:
 
 
 @dataclass
-class GuestRequest15:
+class GuestRequest16:
     StartPortForward: StartPortForward
 
 
@@ -428,7 +439,7 @@ class StartUnixSocketForward:
 
 
 @dataclass
-class GuestRequest16:
+class GuestRequest17:
     StartUnixSocketForward: StartUnixSocketForward
 
 
@@ -441,7 +452,7 @@ class ConsoleOpen:
 
 
 @dataclass
-class GuestRequest17:
+class GuestRequest18:
     ConsoleOpen: ConsoleOpen
 
 
@@ -451,7 +462,7 @@ class ConsoleClose:
 
 
 @dataclass
-class GuestRequest18:
+class GuestRequest19:
     ConsoleClose: ConsoleClose
 
 
@@ -463,15 +474,15 @@ class ConsoleResize:
 
 
 @dataclass
-class GuestRequest19:
+class GuestRequest20:
     ConsoleResize: ConsoleResize
 
 
-class GuestRequest20(Enum):
+class GuestRequest21(Enum):
     EntrypointStatus = 'EntrypointStatus'
 
 
-class GuestRequest21(Enum):
+class GuestRequest22(Enum):
     ReadinessStatus = 'ReadinessStatus'
 
 
@@ -484,7 +495,7 @@ class FsRead:
 
 
 @dataclass
-class GuestRequest22:
+class GuestRequest23:
     FsRead: FsRead
 
 
@@ -498,7 +509,7 @@ class FsWrite:
 
 
 @dataclass
-class GuestRequest23:
+class GuestRequest24:
     FsWrite: FsWrite
 
 
@@ -509,7 +520,7 @@ class FsList:
 
 
 @dataclass
-class GuestRequest24:
+class GuestRequest25:
     FsList: FsList
 
 
@@ -520,7 +531,7 @@ class FsStat1:
 
 
 @dataclass
-class GuestRequest25:
+class GuestRequest26:
     FsStat: FsStat1
 
 
@@ -532,7 +543,7 @@ class FsMkdir:
 
 
 @dataclass
-class GuestRequest26:
+class GuestRequest27:
     FsMkdir: FsMkdir
 
 
@@ -544,7 +555,7 @@ class FsRemove:
 
 
 @dataclass
-class GuestRequest27:
+class GuestRequest28:
     FsRemove: FsRemove
 
 
@@ -556,7 +567,7 @@ class FsMove:
 
 
 @dataclass
-class GuestRequest28:
+class GuestRequest29:
     FsMove: FsMove
 
 
@@ -570,11 +581,11 @@ class ProcStart:
 
 
 @dataclass
-class GuestRequest29:
+class GuestRequest30:
     ProcStart: ProcStart
 
 
-class GuestRequest30(Enum):
+class GuestRequest31(Enum):
     ProcList = 'ProcList'
 
 
@@ -585,7 +596,7 @@ class ProcSignal:
 
 
 @dataclass
-class GuestRequest31:
+class GuestRequest32:
     ProcSignal: ProcSignal
 
 
@@ -596,7 +607,7 @@ class ProcSendInput:
 
 
 @dataclass
-class GuestRequest32:
+class GuestRequest33:
     ProcSendInput: ProcSendInput
 
 
@@ -607,7 +618,7 @@ class ProcWait:
 
 
 @dataclass
-class GuestRequest33:
+class GuestRequest34:
     ProcWait: ProcWait
 
 
@@ -617,7 +628,7 @@ class ProcKill:
 
 
 @dataclass
-class GuestRequest34:
+class GuestRequest35:
     ProcKill: ProcKill
 
 
@@ -629,7 +640,7 @@ class MountVolume:
 
 
 @dataclass
-class GuestRequest35:
+class GuestRequest36:
     MountVolume: MountVolume
 
 
@@ -640,7 +651,7 @@ class UnmountVolume:
 
 
 @dataclass
-class GuestRequest36:
+class GuestRequest37:
     UnmountVolume: UnmountVolume
 
 
@@ -650,7 +661,7 @@ class UpdateIdleTimeout:
 
 
 @dataclass
-class GuestRequest37:
+class GuestRequest38:
     UpdateIdleTimeout: UpdateIdleTimeout
 
 
@@ -661,7 +672,7 @@ class RunCode:
 
 
 @dataclass
-class GuestRequest38:
+class GuestRequest39:
     RunCode: RunCode
 
 
@@ -783,6 +794,16 @@ class GuestResponse16:
 
 
 @dataclass
+class DetachedStarted:
+    pid: int
+
+
+@dataclass
+class GuestResponse17:
+    DetachedStarted: DetachedStarted
+
+
+@dataclass
 class PostRestoreAck:
     success: bool
     detail: Optional[str] = None
@@ -790,7 +811,7 @@ class PostRestoreAck:
 
 
 @dataclass
-class GuestResponse17:
+class GuestResponse18:
     PostRestoreAck: PostRestoreAck
 
 
@@ -801,7 +822,7 @@ class PortForwardStarted:
 
 
 @dataclass
-class GuestResponse19:
+class GuestResponse20:
     PortForwardStarted: PortForwardStarted
 
 
@@ -812,7 +833,7 @@ class UnixSocketForwardStarted:
 
 
 @dataclass
-class GuestResponse20:
+class GuestResponse21:
     UnixSocketForwardStarted: UnixSocketForwardStarted
 
 
@@ -823,7 +844,7 @@ class ConsoleOpened:
 
 
 @dataclass
-class GuestResponse21:
+class GuestResponse22:
     ConsoleOpened: ConsoleOpened
 
 
@@ -834,7 +855,7 @@ class ConsoleExited:
 
 
 @dataclass
-class GuestResponse22:
+class GuestResponse23:
     ConsoleExited: ConsoleExited
 
 
@@ -844,7 +865,7 @@ class ConsoleResized:
 
 
 @dataclass
-class GuestResponse23:
+class GuestResponse24:
     ConsoleResized: ConsoleResized
 
 
@@ -856,7 +877,7 @@ class EntrypointStatusReport:
 
 
 @dataclass
-class GuestResponse24:
+class GuestResponse25:
     EntrypointStatusReport: EntrypointStatusReport
 
 
@@ -867,7 +888,7 @@ class UpdateIdleTimeoutAck:
 
 
 @dataclass
-class GuestResponse30:
+class GuestResponse31:
     UpdateIdleTimeoutAck: UpdateIdleTimeoutAck
 
 
@@ -1332,27 +1353,27 @@ class FsDiffResult:
 
 
 @dataclass
-class GuestResponse18:
+class GuestResponse19:
     FsDiffResult: FsDiffResult
 
 
 @dataclass
-class GuestResponse25:
+class GuestResponse26:
     ReadinessStatusReport: ReadinessReport
 
 
 @dataclass
-class GuestResponse26:
+class GuestResponse27:
     FsResult: FsResult
 
 
 @dataclass
-class GuestResponse28:
+class GuestResponse29:
     ProcWaitEvent: ProcWaitEvent
 
 
 @dataclass
-class GuestResponse29:
+class GuestResponse30:
     VolumeMountResult: VolumeMountResult
 
 
@@ -1413,7 +1434,7 @@ class PostRestore:
 
 
 @dataclass
-class GuestRequest13:
+class GuestRequest14:
     PostRestore: PostRestore
 
 
@@ -1456,6 +1477,7 @@ GuestRequest = Union[
     GuestRequest36,
     GuestRequest37,
     GuestRequest38,
+    GuestRequest39,
 ]
 
 
@@ -1470,7 +1492,7 @@ class GuestResponse10:
 
 
 @dataclass
-class GuestResponse27:
+class GuestResponse28:
     ProcResult: ProcResult
 
 
@@ -1505,6 +1527,7 @@ GuestResponse = Union[
     GuestResponse28,
     GuestResponse29,
     GuestResponse30,
+    GuestResponse31,
 ]
 
 

--- a/sdks/typescript/src/protocol/protocol.ts
+++ b/sdks/typescript/src/protocol/protocol.ts
@@ -53,6 +53,17 @@ stdin: number[]
 timeout_secs: number
 }
 } | {
+RunDetached: {
+/**
+ * The program and its arguments. `argv[0]` is the program; resolved via PATH when not absolute.
+ */
+argv: string[]
+/**
+ * Env vars injected after `env_clear()` (plus a minimal safe base). Empty when omitted on the wire.
+ */
+env?: [string, string][]
+}
+} | {
 PostRestore: {
 /**
  * Host-minted verb-grant envelope to re-pin after restore. When the plan changes across a snapshot boundary the host delivers a fresh envelope here so the guest updates its pinned grant without a reboot. Absent on callers that do not rotate grants.
@@ -308,6 +319,10 @@ ExecEvent: ExecEvent
 } | {
 ExecBatchResult: {
 outcomes: ExecOutcomeWire[]
+}
+} | {
+DetachedStarted: {
+pid: number
 }
 } | {
 PostRestoreAck: {


### PR DESCRIPTION
## The bug
`mvmctl machine run -d -- <cmd>` printed "started" then **hung**: the persistent argv path unconditionally foreground-streamed the command through a connection-scoped agent exec, ignoring `-d`. That exec can't be fire-and-forgotten either — the guest buffers an unattended workload's output and kills it once a cap is hit.

## The fix (production-ready shape)
A dev-gated guest-agent `RunDetached` verb runs the argv as an independent workload, mirroring how `/init` runs a baked entrypoint:
- spawned in its own session (`setsid`), stdin ← `/dev/null`, stdout/stderr → the guest console (which the backend already captures to `console.log`);
- the agent acks immediately (`DetachedStarted { pid }`), so `machine run -d -- <cmd>` returns instead of blocking;
- a reaper reports the workload's exit code to the workload-exit vsock port, so the VM powers off when the workload finishes (docker-`-d` semantics).

The no-`-d` path still foreground-streams. The verb is `dev-shell`-gated exactly like `Exec` (arbitrary argv is a dev-tier capability; a sealed prod agent links no handler). Bumps the injected-OCI-runtime epoch so a rootfs sealed with an older agent — which would reject the unknown request — re-materializes with the new one.

Includes the guest classification tables, a non-streaming `send_run_detached` host helper, serde/roundtrip/classification/mock-roundtrip tests, and a fuzz seed.

## Verification
- **Hang fixed — live-proven on HVF:** `machine run -d -- <cmd>` now returns immediately (~1s) instead of blocking.
- **432 mvm-guest unit tests pass** incl. `RunDetached` serde roundtrip, `DevOnly` classification guard, and `send_run_detached` mock happy-path + error mapping.
- **Foreground path live-verified** unaffected (agent infra healthy).
- Nightly `fmt`, `clippy -D warnings`, workspace `build --all-targets -D warnings` green.
- **Full detached round-trip (workload actually running):** exercised by the unit tests + the mock agent, and it relies on the freshly cross-compiled guest agent carrying the new verb (confirmed present in a clean cross-compile). I could not complete the local end-to-end because my worktree's shared `cargo-zigbuild` cache kept serving a stale embedded agent into the injected OCI rootfs — a local incremental-build artifact, not a code issue; **CI's clean build (the `oci-image-runner-smoke` lane) exercises it with a fresh agent.**