### PR TITLE
chore: ignore transfer directory

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -45,6 +45,7 @@ nix/images/dev-prebuilt/
 
 # Worktree-local dev env (use .envrc.example as template)
 /.envrc
+/.codex-transfer/
 /.mvm-test/
 # Ad-hoc parallel-session isolation dirs (MVM_CACHE_DIR / MVM_DATA_DIR pointed
 # inside the worktree). Never commit a host cache or chain-signed audit log.


### PR DESCRIPTION
## Summary
- ignore the local transfer directory in .gitignore

## Testing
- not run (ignore-file only)