### PR TITLE
speed up default Rust builds

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1803,7 +1803,6 @@ dependencies = [
  "tokio",
  "tokio-rustls",
  "tower-service",
- "webpki-roots",
 ]
 
 [[package]]
@@ -2565,7 +2564,7 @@ dependencies = [
  "mvm-sdk",
  "nix",
  "rand 0.8.6",
- "reqwest 0.12.28",
+ "reqwest 0.13.3",
  "serde",
  "serde_json",
  "sha2",
@@ -2609,7 +2608,7 @@ dependencies = [
  "notify",
  "notify-debouncer-mini",
  "rand 0.8.6",
- "reqwest 0.12.28",
+ "reqwest 0.13.3",
  "secrecy",
  "serde",
  "serde_json",
@@ -2659,7 +2658,7 @@ dependencies = [
  "rand 0.8.6",
  "rcgen",
  "regex",
- "reqwest 0.12.28",
+ "reqwest 0.13.3",
  "rustls",
  "schemars",
  "secrecy",
@@ -2762,7 +2761,7 @@ dependencies = [
  "mvm-verify",
  "rand 0.8.6",
  "regex",
- "reqwest 0.12.28",
+ "reqwest 0.13.3",
  "rustix 1.1.4",
  "rustls",
  "seccompiler",
@@ -3700,7 +3699,6 @@ checksum = "eddd3ca559203180a307f12d114c268abf583f59b03cb906fd0b3ff8646c1147"
 dependencies = [
  "base64",
  "bytes",
- "futures-channel",
  "futures-core",
  "futures-util",
  "h2",
@@ -3733,7 +3731,6 @@ dependencies = [
  "wasm-bindgen-futures",
  "wasm-streams 0.4.2",
  "web-sys",
- "webpki-roots",
 ]
 
 [[package]]
@@ -3744,6 +3741,7 @@ checksum = "62e0021ea2c22aed41653bc7e1419abb2c97e038ff2c33d0e1309e49a97deec0"
 dependencies = [
  "base64",
  "bytes",
+ "futures-channel",
  "futures-core",
  "futures-util",
  "http",
@@ -5363,15 +5361,6 @@ name = "webpki-root-certs"
 version = "1.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f31141ce3fc3e300ae89b78c0dd67f9708061d1d2eda54b8209346fd6be9a92c"
-dependencies = [
- "rustls-pki-types",
-]
-
-[[package]]
-name = "webpki-roots"
-version = "1.0.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "22cfaf3c063993ff62e73cb4311efde4db1efb31ab78a3e5c457939ad5cc0bed"
 dependencies = [
  "rustls-pki-types",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -228,12 +228,14 @@ colored = "3"
 indicatif = "0.18"
 inquire = "0.9"
 
-# HTTP client (for CLI upgrade)
-reqwest = { version = "0.12", features = ["blocking", "json", "rustls-tls"], default-features = false }
+# HTTP client. Keep the workspace on a single reqwest line so the direct
+# callers and `oci-client` share one HTTP/TLS stack instead of compiling both
+# 0.12 and 0.13 in the same workspace build.
+reqwest = { version = "0.13", features = ["blocking", "json", "rustls"], default-features = false }
 
 # Plan 129 Stage 2 — the egress terminator's server-side TLS (terminate the
 # guest's https to bound hosts under the per-VM name-constrained intermediate).
-# `ring` backend (matches reqwest's rustls-tls + rcgen), no aws-lc-rs/cmake.
+# `ring` backend (matches reqwest's rustls surface + rcgen), no aws-lc-rs/cmake.
 # Direct dep of mvm-hostd only; the upstream re-origination leg reuses reqwest.
 rustls = { version = "0.23", default-features = false, features = ["ring", "std"] }
 

--- a/Justfile
+++ b/Justfile
@@ -79,10 +79,9 @@ dev-check:
 test:
     cargo nextest run --workspace
 
-# Fast inner-loop / fresh-worktree run: skips the embedded host-vm binary
-# cross-compile (cargo zigbuild --release) in mvm-cli/build.rs. Safe for
-# everything except builder-VM boot — the env-gated E2E tests need the
-# real binaries and the `e2e-core-demo` recipe never sets this var.
+# Non-release builds now skip the embedded host-vm binary cross-compile by
+# default. Keep this explicit recipe as the "always stub" path when a caller
+# wants to force the fast mode even after opting into real embeds elsewhere.
 test-fast:
     MVM_SKIP_EMBED_BINARIES=1 cargo nextest run --workspace
 

--- a/crates/mvm-build/Cargo.toml
+++ b/crates/mvm-build/Cargo.toml
@@ -87,7 +87,7 @@ anyhow.workspace = true
 chrono.workspace = true
 fs2.workspace = true
 hex.workspace = true
-reqwest = { workspace = true, default-features = false, features = ["blocking", "rustls-tls"] }
+reqwest = { workspace = true, default-features = false, features = ["blocking", "rustls"] }
 # Optional libkrun FFI dep for the in-tree builder VM
 # launcher (`libkrun_builder::LibkrunBuilderVm`). Gated by
 # `builder-vm`; default-off until the cutover flips polarity.

--- a/crates/mvm-cli/build.rs
+++ b/crates/mvm-cli/build.rs
@@ -1,3 +1,6 @@
+#[path = "build_embed_mode.rs"]
+mod build_embed_mode;
+
 use std::path::{Path, PathBuf};
 use std::process::Command;
 
@@ -55,23 +58,22 @@ fn main() {
     // plain-`cargo build` fast-path was once tried on the false premise that
     // the bins are C-free; it broke CI, which has no musl-gcc.)
 
-    // Fast path for local test/dev iteration: skip the nested
-    // `cargo zigbuild --release` cross-compile of the host-vm binaries and
-    // bake zero-byte stubs instead. Cuts the dominant cold-build tax on
-    // macOS (and any fresh worktree) for everyone who isn't exercising a
-    // builder-VM boot. The only consumers that read the *bytes* are the
-    // env-gated boot/E2E tests (`MVM_E2E_SMOKE`, libkrun lifecycle), which
-    // are skipped in a default `cargo test`/`nextest` run — and the
-    // `e2e-core-demo` recipe never sets this var, so a stub build can't
-    // masquerade as a passing E2E. NEVER set this in CI release builds:
-    // the shipped mvmctl must embed the real reproducible binaries
-    // (claim 11).
-    let skip_embed = std::env::var("MVM_SKIP_EMBED_BINARIES").as_deref() == Ok("1");
+    // Build policy:
+    // - `MVM_SKIP_EMBED_BINARIES=1` always skips the nested cross-compile.
+    // - `MVM_EMBED_BINARIES=1` always performs the real embed, even in dev/test.
+    // - Otherwise, release builds embed the real binaries and non-release
+    //   builds bake zero-byte stubs.
+    //
+    // This keeps production artifacts reproducible by default while removing
+    // the dominant cold-build tax from ordinary `cargo check`/`cargo test`
+    // contributor workflows.
+    let skip_embed = should_skip_embed_binaries();
     println!("cargo:rerun-if-env-changed=MVM_SKIP_EMBED_BINARIES");
+    println!("cargo:rerun-if-env-changed=MVM_EMBED_BINARIES");
     if skip_embed {
         println!(
-            "cargo:warning=MVM_SKIP_EMBED_BINARIES=1: embedding zero-byte host-vm \
-             stubs; builder-VM boot is unavailable in this build"
+            "cargo:warning=embedding zero-byte host-vm stubs for this non-release build; \
+             set MVM_EMBED_BINARIES=1 to force real embedded binaries"
         );
     }
 
@@ -157,6 +159,14 @@ struct Pin {
     zig: String,
     cargo_zigbuild: String,
     target: String,
+}
+
+fn should_skip_embed_binaries() -> bool {
+    build_embed_mode::should_skip_embed_binaries(
+        std::env::var("PROFILE").ok().as_deref(),
+        std::env::var("MVM_SKIP_EMBED_BINARIES").ok().as_deref(),
+        std::env::var("MVM_EMBED_BINARIES").ok().as_deref(),
+    )
 }
 
 fn read_pinned_toolchain(root: &Path) -> Pin {

--- a/crates/mvm-cli/build_embed_mode.rs
+++ b/crates/mvm-cli/build_embed_mode.rs
@@ -1,0 +1,39 @@
+pub(crate) fn should_skip_embed_binaries(
+    profile: Option<&str>,
+    skip_env: Option<&str>,
+    embed_env: Option<&str>,
+) -> bool {
+    if env_flag_enabled(skip_env) {
+        return true;
+    }
+    if env_flag_enabled(embed_env) {
+        return false;
+    }
+    !matches!(profile, Some("release"))
+}
+
+fn env_flag_enabled(value: Option<&str>) -> bool {
+    matches!(value, Some("1"))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::should_skip_embed_binaries;
+
+    #[test]
+    fn non_release_builds_skip_embeds_by_default() {
+        assert!(should_skip_embed_binaries(Some("debug"), None, None));
+        assert!(should_skip_embed_binaries(Some("test"), None, None));
+    }
+
+    #[test]
+    fn release_builds_embed_by_default() {
+        assert!(!should_skip_embed_binaries(Some("release"), None, None));
+    }
+
+    #[test]
+    fn explicit_env_overrides_profile_default() {
+        assert!(!should_skip_embed_binaries(Some("debug"), None, Some("1"),));
+        assert!(should_skip_embed_binaries(Some("release"), Some("1"), None,));
+    }
+}

--- a/crates/mvm-cli/src/commands/env/dev_vz.rs
+++ b/crates/mvm-cli/src/commands/env/dev_vz.rs
@@ -4038,8 +4038,9 @@ fn bootstrap_builder_vm_image_via_root_dir_stage0(
         .ok_or_else(|| anyhow::anyhow!("stage0-init not in the embedded host binaries"))?;
     if stage0_init.bytes.is_empty() {
         anyhow::bail!(
-            "embedded stage0-init is a zero-byte stub — this mvmctl was built with \
-             MVM_SKIP_EMBED_BINARIES=1 and cannot seed Stage 0; rebuild without it"
+            "embedded stage0-init is a zero-byte stub — this mvmctl was built without \
+             real embedded host binaries and cannot seed Stage 0; rebuild with \
+             MVM_EMBED_BINARIES=1 or use a release build"
         );
     }
     mvm_build::stage0::materialize_root_dir(&root_dir, stage0_init.bytes)
@@ -4380,8 +4381,9 @@ pub(crate) fn build_kernel_via_stage0(
         .ok_or_else(|| anyhow::anyhow!("stage0-init not in the embedded host binaries"))?;
     if stage0_init.bytes.is_empty() {
         anyhow::bail!(
-            "embedded stage0-init is a zero-byte stub — this mvmctl was built with \
-             MVM_SKIP_EMBED_BINARIES=1 and cannot seed Stage 0; rebuild without it"
+            "embedded stage0-init is a zero-byte stub — this mvmctl was built without \
+             real embedded host binaries and cannot seed Stage 0; rebuild with \
+             MVM_EMBED_BINARIES=1 or use a release build"
         );
     }
     mvm_build::stage0::materialize_root_dir(&root_dir, stage0_init.bytes)

--- a/crates/mvm-cli/src/commands/image/mod.rs
+++ b/crates/mvm-cli/src/commands/image/mod.rs
@@ -470,8 +470,8 @@ fn inject_runtime_and_materialize(
 }
 
 /// The guest-agent binaries embedded in this mvmctl at build time (build.rs).
-/// `None` when this build baked zero-byte stubs (`MVM_SKIP_EMBED_BINARIES`), in
-/// which case the run path falls back to a source-checkout cross-compile.
+/// `None` when this build baked zero-byte stubs, in which case the run path
+/// falls back to a source-checkout cross-compile.
 fn embedded_guest_binaries() -> Option<mvm_build::run_image::PrebuiltGuestBinaries<'static>> {
     let find = |name: &str| {
         crate::host_binaries::embedded::EMBEDDED

--- a/crates/mvm-cli/src/host_binaries/extract.rs
+++ b/crates/mvm-cli/src/host_binaries/extract.rs
@@ -36,10 +36,10 @@ pub fn ensure_extracted(cache_root: &Path) -> std::io::Result<PathBuf> {
 }
 
 /// Like [`ensure_extracted`], but refuses a stub build — the zero-byte
-/// binaries baked when mvmctl is compiled with `MVM_SKIP_EMBED_BINARIES=1`
-/// (the fast local test/dev path). Call this from any path that actually
-/// boots a VM from the embedded binaries so a fast-test build fails fast
-/// with a clear message instead of an opaque builder-VM boot failure.
+/// binaries baked into non-release builds unless `MVM_EMBED_BINARIES=1`
+/// overrides the fast path. Call this from any path that actually boots a VM
+/// from the embedded binaries so a stub build fails fast with a clear message
+/// instead of an opaque builder-VM boot failure.
 pub fn ensure_extracted_for_boot(cache_root: &Path) -> std::io::Result<PathBuf> {
     let dir = ensure_extracted(cache_root)?;
     for bin in EMBEDDED.iter() {
@@ -48,8 +48,8 @@ pub fn ensure_extracted_for_boot(cache_root: &Path) -> std::io::Result<PathBuf> 
                 std::io::ErrorKind::InvalidData,
                 format!(
                     "embedded host-vm binary `{}` is a zero-byte stub — this mvmctl was \
-                     built with MVM_SKIP_EMBED_BINARIES=1 (fast test build) and cannot boot \
-                     a builder VM; rebuild without that env var",
+                     built without real embedded host binaries and cannot boot a builder VM; \
+                     rebuild with MVM_EMBED_BINARIES=1 or use a release build",
                     bin.name
                 ),
             ));

--- a/crates/mvm-cli/tests/build_embed_mode.rs
+++ b/crates/mvm-cli/tests/build_embed_mode.rs
@@ -1,0 +1,21 @@
+#[path = "../build_embed_mode.rs"]
+mod build_embed_mode;
+
+use build_embed_mode::should_skip_embed_binaries;
+
+#[test]
+fn non_release_builds_skip_embeds_by_default() {
+    assert!(should_skip_embed_binaries(Some("debug"), None, None));
+    assert!(should_skip_embed_binaries(Some("test"), None, None));
+}
+
+#[test]
+fn release_builds_embed_by_default() {
+    assert!(!should_skip_embed_binaries(Some("release"), None, None));
+}
+
+#[test]
+fn explicit_env_overrides_profile_default() {
+    assert!(!should_skip_embed_binaries(Some("debug"), None, Some("1")));
+    assert!(should_skip_embed_binaries(Some("release"), Some("1"), None));
+}

--- a/crates/mvm-cli/tests/embedded_binaries.rs
+++ b/crates/mvm-cli/tests/embedded_binaries.rs
@@ -4,15 +4,18 @@ use sha2::{Digest, Sha256};
 #[test]
 fn each_embedded_binary_starts_with_elf_magic() {
     for bin in EMBEDDED.iter() {
+        if bin.bytes.is_empty() {
+            continue;
+        }
         assert!(
             bin.bytes.len() > 1024,
-            "{}: implausibly small payload",
+            "{}: non-stub payload is implausibly small",
             bin.name
         );
         assert_eq!(
             &bin.bytes[..4],
             &[0x7F, b'E', b'L', b'F'],
-            "{}: payload is not an ELF binary",
+            "{}: non-stub payload is not an ELF binary",
             bin.name
         );
     }

--- a/crates/mvm-cli/tests/host_binaries_extract.rs
+++ b/crates/mvm-cli/tests/host_binaries_extract.rs
@@ -29,9 +29,9 @@ fn ensure_extracted_is_idempotent() {
     assert_eq!(dir1, dir2);
 }
 
-// The boot guard must reject a stub build (MVM_SKIP_EMBED_BINARIES=1) and
-// admit a real one. The expected verdict is whatever this binary was
-// compiled with, so the test is valid in both modes.
+// The boot guard must reject a stub build and admit a real one. The expected
+// verdict is whatever this binary was compiled with, so the test is valid in
+// both modes.
 #[test]
 fn ensure_extracted_for_boot_matches_build_mode() {
     use mvm_cli::host_binaries::embedded::EMBEDDED;


### PR DESCRIPTION
## What changed

This speeds up ordinary Rust workspace builds without changing production release behavior.

- non-release `mvm-cli` builds now skip the nested embedded host-binary `cargo zigbuild --release` step by default
- release builds still embed the real host binaries by default
- `MVM_SKIP_EMBED_BINARIES=1` still forces stub embeds
- `MVM_EMBED_BINARIES=1` now forces real embeds in non-release builds
- the workspace now uses a single `reqwest 0.13` line instead of compiling both `reqwest 0.12` and `0.13`
- added explicit tests for the embed-mode policy and updated boot-path error text/docs to match the new defaults

## Why

The main cold-build tax was `crates/mvm-cli/build.rs` invoking nested `cargo zigbuild --release` during normal local `cargo check` and `cargo test` runs. That work is necessary for production artifacts, but it is unnecessary for most contributor builds and was making the default development path much slower and more fragile.

The duplicate `reqwest` versions were also forcing the workspace to compile two HTTP/TLS stacks.

## Impact

- local debug/test builds get the fast path by default
- production/release artifacts keep real embedded binaries by default
- callers that need real embedded binaries in a non-release build can opt in explicitly with `MVM_EMBED_BINARIES=1`
- the dependency graph is smaller because there is only one `reqwest` version in the workspace

## Validation

Passed:

- `cargo check --workspace`
- `cargo check --workspace --tests`
- `cargo clippy --workspace -- -D warnings`
- `cargo test -p mvm-cli --test build_embed_mode --test host_binaries_extract`

Observed during validation:

- `cargo test --workspace` still fails in three pre-existing unrelated tests in `mvm`:
  - `machine::persist::tests::overwrite_spec_unconditionally`
  - `vm::instance_snapshot::tests::delete_instance_snapshot_removes_files`
  - `vm::instance_snapshot::tests::list_instance_snapshots_returns_each_sealed_vm`
