### PR TITLE
feat(mvm-build): runtime pack carries verity-sealed rootfs (§E prep, keeps claim 3)

### DIFF
--- a/crates/mvm-build/examples/mvm-builder-pack-tool.rs
+++ b/crates/mvm-build/examples/mvm-builder-pack-tool.rs
@@ -77,16 +77,17 @@ fn main() -> ExitCode {
 fn usage() {
     eprintln!(
         "usage: mvm-builder-pack-tool \\\n\
-         \x20 --vmlinux <path> --arch <x86_64|aarch64> \\\n\
-         \x20 (--rootfs <path> | --kind runtime --initramfs <path>) \\\n\
+         \x20 --vmlinux <path> --rootfs <path> --arch <x86_64|aarch64> \\\n\
+         \x20 [--kind runtime --verity <path> --roothash <path>] \\\n\
          \x20 --channel <name> --out-dir <dir> \\\n\
          \x20 --sbom <path> --revocation-channel <url> \\\n\
          \x20 (--signing-key <hex-file> | --keyless --identity <SAN>) \\\n\
          \x20 [--builder-identity <s>] [--build-env <s>] \\\n\
          \x20 [--valid-days <n>] [--mirror-identity <s>] [--sbom-uri <url>]\n\
          \n\
-         --kind defaults to builder (needs --rootfs); --kind runtime needs \
-         --initramfs and is keyless-only (--keyless --identity).\n\
+         --kind defaults to builder; --kind runtime additionally needs \
+         --verity and --roothash (the workload rootfs's dm-verity tree + root \
+         hash) and is keyless-only (--keyless --identity).\n\
          --sbom-uri overrides the manifest's SBOM reference uri with a \
          published location (e.g. a release download URL) instead of the \
          default file:// path of the local --sbom file; the sha256 is \
@@ -104,16 +105,21 @@ fn run(rest: &[String]) -> Result<(), String> {
 
     if parsed.runtime {
         // Runtime packs are keyless-only; `parse_args` guarantees --keyless
-        // --identity and --initramfs when --kind runtime.
+        // --identity, --rootfs, --verity, and --roothash when --kind runtime.
         let identity = parsed
             .identity
             .expect("parse_args guarantees --identity for --kind runtime");
-        let initramfs = parsed
-            .initramfs
-            .expect("parse_args guarantees --initramfs for --kind runtime");
+        let verity = parsed
+            .verity
+            .expect("parse_args guarantees --verity for --kind runtime");
+        let roothash = parsed
+            .roothash
+            .expect("parse_args guarantees --roothash for --kind runtime");
         let params = BuildRuntimePackParams {
             vmlinux: parsed.vmlinux,
-            initramfs,
+            rootfs: parsed.rootfs,
+            verity,
+            roothash,
             target_arch: parsed.arch,
             channel: parsed.channel,
             builder_identity: parsed.builder_identity,
@@ -141,12 +147,9 @@ fn run(rest: &[String]) -> Result<(), String> {
         return Ok(());
     }
 
-    let rootfs = parsed
-        .rootfs
-        .expect("parse_args guarantees --rootfs for a builder pack");
     let params = BuildBuilderPackParams {
         vmlinux: parsed.vmlinux,
-        rootfs,
+        rootfs: parsed.rootfs,
         target_arch: parsed.arch,
         channel: parsed.channel,
         builder_identity: parsed.builder_identity,
@@ -199,11 +202,13 @@ fn run(rest: &[String]) -> Result<(), String> {
 #[derive(Debug, PartialEq, Eq)]
 struct ParsedArgs {
     vmlinux: PathBuf,
-    /// Builder pack artifact (`--rootfs`). `Some` for a builder pack, `None` for
-    /// a runtime pack (which carries `initramfs` instead).
-    rootfs: Option<PathBuf>,
-    /// Runtime pack artifact (`--initramfs`). `Some` iff `--kind runtime`.
-    initramfs: Option<PathBuf>,
+    /// Root filesystem: the builder VM disk for a builder pack, or the
+    /// verity-sealed workload rootfs for a runtime pack. Required for both.
+    rootfs: PathBuf,
+    /// Runtime pack dm-verity hash tree (`--verity`). `Some` iff `--kind runtime`.
+    verity: Option<PathBuf>,
+    /// Runtime pack dm-verity root-hash file (`--roothash`). `Some` iff runtime.
+    roothash: Option<PathBuf>,
     /// `--kind runtime`. A runtime pack is keyless-only (no ed25519 producer).
     runtime: bool,
     arch: GuestArch,
@@ -239,17 +244,22 @@ fn parse_args(rest: &[String]) -> Result<ParsedArgs, String> {
                 .to_string(),
         );
     }
-    // Each kind carries exactly one image artifact: a builder pack's rootfs or a
-    // runtime pack's initramfs.
-    let (rootfs, initramfs) = if runtime {
-        (None, Some(PathBuf::from(required(rest, "initramfs")?)))
+    // Both kinds carry a rootfs; a runtime pack additionally carries the
+    // dm-verity hash tree + root hash so the launch can boot it verity-sealed.
+    let rootfs = PathBuf::from(required(rest, "rootfs")?);
+    let (verity, roothash) = if runtime {
+        (
+            Some(PathBuf::from(required(rest, "verity")?)),
+            Some(PathBuf::from(required(rest, "roothash")?)),
+        )
     } else {
-        (Some(PathBuf::from(required(rest, "rootfs")?)), None)
+        (None, None)
     };
     Ok(ParsedArgs {
         vmlinux: PathBuf::from(required(rest, "vmlinux")?),
         rootfs,
-        initramfs,
+        verity,
+        roothash,
         runtime,
         arch: required(rest, "arch")?
             .parse::<GuestArch>()
@@ -357,13 +367,15 @@ mod tests {
         ])
     }
 
-    /// A runtime pack: `--kind runtime --initramfs ...` (no `--rootfs`) and
+    /// A runtime pack: `--kind runtime` with `--rootfs --verity --roothash` and
     /// keyless (`--keyless --identity ...`).
     fn runtime_args() -> Vec<String> {
         let mut a = args(&[
             ("vmlinux", "/tmp/vmlinux"),
             ("kind", "runtime"),
-            ("initramfs", "/tmp/initramfs"),
+            ("rootfs", "/tmp/rootfs.ext4"),
+            ("verity", "/tmp/rootfs.verity"),
+            ("roothash", "/tmp/rootfs.roothash"),
             ("arch", "aarch64"),
             ("channel", "stable"),
             ("out-dir", "/tmp/out"),
@@ -379,15 +391,26 @@ mod tests {
     }
 
     #[test]
-    fn parses_runtime_kind_with_initramfs_and_keyless() {
+    fn parses_runtime_kind_with_rootfs_verity_roothash_and_keyless() {
         let parsed = parse_args(&runtime_args()).expect("parse runtime");
         assert!(parsed.runtime);
-        assert_eq!(parsed.initramfs, Some(PathBuf::from("/tmp/initramfs")));
-        assert_eq!(parsed.rootfs, None);
+        assert_eq!(parsed.rootfs, PathBuf::from("/tmp/rootfs.ext4"));
+        assert_eq!(parsed.verity, Some(PathBuf::from("/tmp/rootfs.verity")));
+        assert_eq!(parsed.roothash, Some(PathBuf::from("/tmp/rootfs.roothash")));
         assert_eq!(
             parsed.identity.as_deref(),
             Some("https://example.test/wf.yml@refs/tags/v1")
         );
+    }
+
+    #[test]
+    fn runtime_kind_requires_verity_and_roothash() {
+        // A runtime pack must carry the dm-verity tree + root hash.
+        let mut a = runtime_args();
+        let idx = a.iter().position(|x| x == "--verity").unwrap();
+        a.drain(idx..idx + 2);
+        let err = parse_args(&a).expect_err("runtime requires verity");
+        assert!(err.contains("verity"), "got: {err}");
     }
 
     #[test]
@@ -396,7 +419,9 @@ mod tests {
         let a = args(&[
             ("vmlinux", "/tmp/vmlinux"),
             ("kind", "runtime"),
-            ("initramfs", "/tmp/initramfs"),
+            ("rootfs", "/tmp/rootfs.ext4"),
+            ("verity", "/tmp/rootfs.verity"),
+            ("roothash", "/tmp/rootfs.roothash"),
             ("arch", "aarch64"),
             ("channel", "stable"),
             ("out-dir", "/tmp/out"),
@@ -415,8 +440,9 @@ mod tests {
     fn parses_required_args_with_defaults() {
         let parsed = parse_args(&full_args()).expect("parse");
         assert_eq!(parsed.vmlinux, PathBuf::from("/tmp/vmlinux"));
-        assert_eq!(parsed.rootfs, Some(PathBuf::from("/tmp/rootfs.ext4")));
+        assert_eq!(parsed.rootfs, PathBuf::from("/tmp/rootfs.ext4"));
         assert!(!parsed.runtime);
+        assert_eq!(parsed.verity, None);
         assert_eq!(parsed.arch, GuestArch::Aarch64);
         assert_eq!(parsed.channel, "stable");
         assert_eq!(parsed.sbom, PathBuf::from("/tmp/sbom.json"));

--- a/crates/mvm-build/src/builder_pack.rs
+++ b/crates/mvm-build/src/builder_pack.rs
@@ -29,8 +29,13 @@ use thiserror::Error;
 pub const KERNEL_FILE: &str = "vmlinux";
 /// In-pack path of the builder rootfs image.
 pub const ROOTFS_FILE: &str = "rootfs.ext4";
-/// In-pack path of a runtime pack's initramfs.
-pub const INITRAMFS_FILE: &str = "initramfs";
+/// In-pack path of a runtime pack's dm-verity hash tree, carried so the launch
+/// can boot the rootfs verity-sealed (runtime tamper detection, not just the
+/// download-time content hash).
+pub const VERITY_FILE: &str = "rootfs.verity";
+/// In-pack path of the rootfs's dm-verity root hash — the value the launch pins
+/// on the kernel cmdline.
+pub const ROOTHASH_FILE: &str = "rootfs.roothash";
 /// Self-describing manifest written next to the artifacts so a produced pack dir
 /// can be published as-is. Distinct from the cache's own `.pack-manifest.json`
 /// sidecar, and never a declared pack file.
@@ -79,15 +84,22 @@ pub struct BuildBuilderPackParams {
 }
 
 /// Inputs to [`build_keyless_runtime_pack`]. Mirrors [`BuildBuilderPackParams`]
-/// but carries a runtime pack's artifacts (`vmlinux` + `initramfs`) instead of
-/// the builder VM's disk image. Every timestamp is an input, keeping the
-/// producer pure.
+/// but carries a runtime pack's artifacts (`vmlinux` + a verity-sealed workload
+/// `rootfs.ext4` + its dm-verity hash tree + root hash) instead of the builder
+/// VM's disk image. Carrying the verity tree and root hash keeps claim 3
+/// (a tampered rootfs fails to boot) on a pack-sourced launch — the pack's
+/// content hash attests the bytes once, dm-verity re-checks every block at read
+/// time. Every timestamp is an input, keeping the producer pure.
 #[derive(Debug, Clone)]
 pub struct BuildRuntimePackParams {
     /// Source `vmlinux` on disk; copied into the pack as [`KERNEL_FILE`].
     pub vmlinux: PathBuf,
-    /// Source initramfs on disk; copied into the pack as [`INITRAMFS_FILE`].
-    pub initramfs: PathBuf,
+    /// Source workload rootfs on disk; copied into the pack as [`ROOTFS_FILE`].
+    pub rootfs: PathBuf,
+    /// Source dm-verity hash tree; copied into the pack as [`VERITY_FILE`].
+    pub verity: PathBuf,
+    /// Source dm-verity root-hash file; copied into the pack as [`ROOTHASH_FILE`].
+    pub roothash: PathBuf,
     /// Architecture the artifacts target.
     pub target_arch: GuestArch,
     /// Publish channel; becomes `TrustMetadata.channel_identity`.
@@ -235,7 +247,7 @@ pub fn build_keyless_builder_pack(
 
 /// A keyless (Sigstore-authority) Runtime pack: the manifest plus the path of
 /// the file its signable bytes were written to, exactly as [`KeylessBuilderPack`]
-/// but for a runtime pack (kernel + initramfs).
+/// but for a runtime pack (kernel + verity-sealed rootfs + verity tree + root hash).
 #[derive(Debug, Clone)]
 pub struct KeylessRuntimePack {
     pub manifest: PackManifest,
@@ -243,12 +255,14 @@ pub struct KeylessRuntimePack {
 }
 
 /// Keyless counterpart of the builder producer for a `Runtime` pack: copies
-/// `vmlinux` + `initramfs` into `out_dir`, hashes them into the typed
-/// `kernel_hash` / `initramfs_hash` outputs a `Runtime` pack requires, assembles
-/// the manifest via `PackBuilder::new_keyless` (no ed25519 key, no in-manifest
-/// signature), and writes `manifest.canonical_bytes()` verbatim to
-/// `out_dir/manifest.json` — the exact bytes a release pipeline signs out of band
-/// and a keyless verifier re-derives at verify time. Never signs anything.
+/// `vmlinux` + the workload `rootfs.ext4` + its dm-verity hash tree + root hash
+/// into `out_dir`, hashes the kernel + rootfs into the typed `kernel_hash` /
+/// `agent_rootfs_hash` outputs a `Runtime` pack requires, assembles the manifest
+/// via `PackBuilder::new_keyless` (no ed25519 key, no in-manifest signature), and
+/// writes `manifest.canonical_bytes()` verbatim to `out_dir/manifest.json` — the
+/// exact bytes a release pipeline signs out of band and a keyless verifier
+/// re-derives at verify time. The verity tree + root hash ride as attested pack
+/// files so the launch can boot the rootfs verity-sealed. Never signs anything.
 pub fn build_keyless_runtime_pack(
     params: &BuildRuntimePackParams,
     identity: &str,
@@ -258,17 +272,19 @@ pub fn build_keyless_runtime_pack(
 
     let kernel_dest = out_dir.join(KERNEL_FILE);
     copy_file(&params.vmlinux, &kernel_dest)?;
-    let initramfs_dest = out_dir.join(INITRAMFS_FILE);
-    copy_file(&params.initramfs, &initramfs_dest)?;
+    let rootfs_dest = out_dir.join(ROOTFS_FILE);
+    copy_file(&params.rootfs, &rootfs_dest)?;
+    copy_file(&params.verity, &out_dir.join(VERITY_FILE))?;
+    copy_file(&params.roothash, &out_dir.join(ROOTHASH_FILE))?;
 
     let kernel_hash = sha256_file(&kernel_dest)?;
-    let initramfs_hash = sha256_file(&initramfs_dest)?;
+    let rootfs_hash = sha256_file(&rootfs_dest)?;
 
     let manifest = PackBuilder::new_keyless(out_dir, runtime_metadata(params), identity)
-        .files([KERNEL_FILE, INITRAMFS_FILE])
+        .files([KERNEL_FILE, ROOTFS_FILE, VERITY_FILE, ROOTHASH_FILE])
         .output_hashes(PackOutputHashes {
             kernel_hash: Some(kernel_hash),
-            initramfs_hash: Some(initramfs_hash),
+            agent_rootfs_hash: Some(rootfs_hash),
             ..Default::default()
         })
         .build()?;
@@ -319,7 +335,7 @@ fn builder_metadata(params: &BuildBuilderPackParams) -> PackMetadata {
 
 /// Assemble the [`PackMetadata`] a produced Runtime pack carries — the same
 /// hvf/vsock host contract as a builder pack, but `kind = Runtime` so the
-/// verifier requires the runtime output hashes (kernel + initramfs).
+/// verifier requires the runtime output hashes (kernel + agent-rootfs).
 fn runtime_metadata(params: &BuildRuntimePackParams) -> PackMetadata {
     PackMetadata {
         kind: PackKind::Runtime,
@@ -454,16 +470,22 @@ mod tests {
         }
     }
 
-    /// Write synthetic `vmlinux` + `initramfs` sources and return runtime
-    /// producer params pointing at them.
+    /// Write synthetic `vmlinux` + `rootfs` + verity tree + root hash sources and
+    /// return runtime producer params pointing at them.
     fn runtime_params_in(src: &TempDir) -> BuildRuntimePackParams {
         let vmlinux = src.path().join("vmlinux.src");
-        let initramfs = src.path().join("initramfs.src");
+        let rootfs = src.path().join("rootfs.src");
+        let verity = src.path().join("verity.src");
+        let roothash = src.path().join("roothash.src");
         fs::write(&vmlinux, KERNEL_BYTES).expect("write kernel src");
-        fs::write(&initramfs, b"runtime-initramfs-bytes").expect("write initramfs src");
+        fs::write(&rootfs, ROOTFS_BYTES).expect("write rootfs src");
+        fs::write(&verity, b"verity-hash-tree-bytes").expect("write verity src");
+        fs::write(&roothash, b"deadbeefroothash").expect("write roothash src");
         BuildRuntimePackParams {
             vmlinux,
-            initramfs,
+            rootfs,
+            verity,
+            roothash,
             target_arch: GuestArch::host(),
             channel: CHANNEL.to_string(),
             builder_identity: "ci-builder".to_string(),
@@ -495,10 +517,15 @@ mod tests {
         let m = &produced.manifest;
         assert_eq!(m.kind, PackKind::Runtime);
         let files: Vec<&str> = m.outputs.files.iter().map(|f| f.path.as_str()).collect();
-        assert!(files.contains(&KERNEL_FILE) && files.contains(&INITRAMFS_FILE));
-        // A Runtime pack requires kernel + initramfs (or agent-rootfs) hashes.
+        // The pack carries kernel + rootfs + the verity tree + root hash, so the
+        // launch can boot the rootfs verity-sealed.
+        assert!(files.contains(&KERNEL_FILE));
+        assert!(files.contains(&ROOTFS_FILE));
+        assert!(files.contains(&VERITY_FILE));
+        assert!(files.contains(&ROOTHASH_FILE));
+        // A Runtime pack requires kernel + (initramfs | agent-rootfs) hashes.
         assert!(m.outputs.kernel_hash.is_some());
-        assert!(m.outputs.initramfs_hash.is_some());
+        assert!(m.outputs.agent_rootfs_hash.is_some());
         // Keyless: no in-manifest signature, and the written file is the exact
         // signable bytes (canonical), so an out-of-band signature stays valid.
         assert!(m.provenance.signature_bundle.signatures.is_empty());


### PR DESCRIPTION
Unit E1a of the §E runtime-pack launch path: correct the runtime-pack *shape* so a pack-sourced boot can keep our security claims.

## Why

The runtime producer merged in #1556 packaged kernel + **initramfs**. Mapping a runtime pack to the launch path (`VmStartConfig` boots a **rootfs** + optional initrd, with verity/roothash fields) and preserving **claim 3 — a tampered rootfs fails to boot** — requires the pack to carry a **verity-sealed rootfs**, not an initramfs. (Confirmed against the run path: the boot config already threads a dm-verity roothash; the release already emits `overlay.ext4` / `.verity` / `.roothash` as separate assets.)

## What

`build_keyless_runtime_pack` now packages **kernel + rootfs.ext4 + dm-verity hash tree + root hash** (`vmlinux`, `rootfs.ext4`, `rootfs.verity`, `rootfs.roothash`), using the `agent_rootfs_hash` Runtime output. The verity tree + root hash ride as **attested pack files** (hashed + signed), so the launch can boot the rootfs verity-sealed: the pack's content hash attests the bytes once, dm-verity re-checks every block at read time. `mvm-builder-pack-tool --kind runtime` now takes `--rootfs --verity --roothash` (keyless-only).

## Tests

Producer test asserts the pack carries all four files + `kernel_hash`/`agent_rootfs_hash`; tool tests cover the runtime flags + require-verity/roothash + keyless-only. Tool smoke produced a real runtime pack (`kind=runtime`, files `[vmlinux, rootfs.ext4, rootfs.verity, rootfs.roothash]`). mvm-build 716 tests green, clippy/fmt clean.

## Next (E1b)

The launch integration — a `--runtime-pack` branch in `run_secure` that `resolve_pack(Runtime)` → verifies → emits `ImageSource::Prebuilt` **with the roothash wired into `VmStartConfig`**, routes through **ExecutionPlan admission** (pack rootfs digest = image digest, claim 8), and emits a **pack-provenance audit entry**. That's the larger, security-sensitive slice — its own PR with careful review.
