### PR TITLE
chore: ignore local dev dir and document PR metadata rule

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -45,6 +45,7 @@ nix/images/dev-prebuilt/
 
 # Worktree-local dev env (use .envrc.example as template)
 /.envrc
+/.codex/
 /.codex-transfer/
 /.mvm-test/
 # Ad-hoc parallel-session isolation dirs (MVM_CACHE_DIR / MVM_DATA_DIR pointed

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -32,6 +32,8 @@ The only `git` commands that should ever target `main` directly are read-only (`
 
 After any pull request merge, immediately sync the local main checkout before doing anything else: `git fetch origin` followed by `git pull --ff-only origin main`. Do not leave local `main` behind the merged PR state.
 
+PR titles and bodies must never include the assistant/tool branding. Keep PR metadata focused on the code change itself.
+
 ### Creating the worktree
 
 All worktrees live in a `.worktrees/` directory that sits as a sibling of the main checkout — never directly next to the main checkout. This keeps the parent directory (which holds the rest of the ecosystem repos) free of feature-branch clutter and makes it obvious at a glance which directories are real repos vs. transient sandboxes.


### PR DESCRIPTION
## Summary
- ignore the local dev directory in the repository gitignore
- record the PR metadata naming rule in AGENTS.md

## Testing
- not run (docs and gitignore only)