### PR TITLE
test(guest)+build: verify detached-workload handler in CI + keep embedded agent fresh

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -231,6 +231,15 @@ jobs:
       - name: Run tests
         run: cargo nextest run --workspace --all-targets
 
+      - name: Run dev-shell agent handler tests
+        # The default workspace run builds the guest agent without `dev-shell`,
+        # so the dev-tier handlers (exec, run-code, run-detached) and their
+        # tests are compiled out. Run mvm-guest with the feature on so the
+        # detached-workload handler is actually exercised on every PR — a fresh
+        # agent that links the handler but can't run the workload would slip an
+        # all-default run.
+        run: cargo nextest run -p mvm-guest --features dev-shell
+
       - name: Run doctests
         # nextest does not run doctests; gate them separately.
         run: cargo test --workspace --doc

--- a/crates/mvm-cli/build.rs
+++ b/crates/mvm-cli/build.rs
@@ -122,10 +122,15 @@ fn main() {
         let sha = sha256_hex(&out_file);
         entries.push((name.to_string(), out_file, sha));
     }
-    println!(
-        "cargo:rerun-if-changed={}",
-        workspace_root.join("crates/mvm-guest/src").display()
-    );
+    // Watch the guest source trees file-by-file, not as a directory. Cargo's
+    // directory-level `rerun-if-changed` does not reliably fire on a content
+    // edit to an existing file (only on add/remove), so a change to e.g. the
+    // guest agent's request handler would otherwise leave the *embedded* agent
+    // stale on an incremental build — `machine run --image` would then inject an
+    // out-of-date agent. Emitting one `rerun-if-changed` per file guarantees the
+    // cross-compile re-runs on any edit.
+    emit_rerun_for_tree(&workspace_root.join("crates/mvm-guest/src"));
+    emit_rerun_for_tree(&workspace_root.join("crates/mvm-guest-helpers/src"));
 
     let embedded_rs = render_embedded_rs(&entries);
     std::fs::write(out_dir.join("embedded.rs"), embedded_rs).unwrap();
@@ -147,10 +152,29 @@ fn main() {
         "cargo:rerun-if-changed={}",
         workspace_root.join("Cargo.lock").display()
     );
-    println!(
-        "cargo:rerun-if-changed={}",
-        workspace_root.join("crates/mvm-build/src").display()
-    );
+    // Same file-by-file watch for the `mvm-build` lib the host bins link (a
+    // content edit there must re-cross-compile the embedded host bins).
+    emit_rerun_for_tree(&workspace_root.join("crates/mvm-build/src"));
+}
+
+/// Emit one `cargo:rerun-if-changed` per file under `root`, recursively. Unlike
+/// a single directory-level `rerun-if-changed` (which cargo does not reliably
+/// re-trigger on a content edit to an existing file), this forces the build
+/// script — and therefore the embedded-binary cross-compile — to re-run whenever
+/// any watched source file changes. Missing trees are silently skipped (the
+/// dir-level watch already fails soft the same way).
+fn emit_rerun_for_tree(root: &Path) {
+    let Ok(entries) = std::fs::read_dir(root) else {
+        return;
+    };
+    for entry in entries.flatten() {
+        let path = entry.path();
+        if path.is_dir() {
+            emit_rerun_for_tree(&path);
+        } else {
+            println!("cargo:rerun-if-changed={}", path.display());
+        }
+    }
 }
 
 struct Pin {

--- a/crates/mvm-guest/src/bin/mvm-guest-agent.rs
+++ b/crates/mvm-guest/src/bin/mvm-guest-agent.rs
@@ -1022,6 +1022,27 @@ fn do_exec_streaming(
 /// (docker `-d` semantics). The reaper never blocks the agent request loop.
 #[cfg(feature = "dev-shell")]
 fn do_run_detached(argv: Vec<String>, env: Vec<(String, String)>) -> GuestResponse {
+    do_run_detached_with(
+        argv,
+        env,
+        std::path::Path::new("/dev/console"),
+        std::path::Path::new("/usr/local/bin/mvm-exit-report"),
+    )
+}
+
+/// Testable core of [`do_run_detached`]. `console` receives the workload's
+/// stdout/stderr (production: `/dev/console`, captured by the backend to
+/// `console.log`); `exit_report_bin` is the reporter the reaper execs with the
+/// workload's exit code (production: `/usr/local/bin/mvm-exit-report`). A test
+/// points both at a tempdir to observe the spawn, the console redirect, and the
+/// reported exit code without a live guest.
+#[cfg(feature = "dev-shell")]
+fn do_run_detached_with(
+    argv: Vec<String>,
+    env: Vec<(String, String)>,
+    console: &std::path::Path,
+    exit_report_bin: &std::path::Path,
+) -> GuestResponse {
     use std::os::unix::process::CommandExt;
     use std::process::{Command, Stdio};
 
@@ -1041,19 +1062,19 @@ fn do_run_detached(argv: Vec<String>, env: Vec<(String, String)>) -> GuestRespon
     };
     // Two independent write handles to the console so stdout and stderr
     // each own their fd (no shared-offset surprises).
-    let console_out = match std::fs::OpenOptions::new().write(true).open("/dev/console") {
+    let console_out = match std::fs::OpenOptions::new().write(true).open(console) {
         Ok(f) => f,
         Err(e) => {
             return GuestResponse::Error {
-                message: format!("run-detached: open /dev/console: {e}"),
+                message: format!("run-detached: open console {}: {e}", console.display()),
             };
         }
     };
-    let console_err = match std::fs::OpenOptions::new().write(true).open("/dev/console") {
+    let console_err = match std::fs::OpenOptions::new().write(true).open(console) {
         Ok(f) => f,
         Err(e) => {
             return GuestResponse::Error {
-                message: format!("run-detached: open /dev/console: {e}"),
+                message: format!("run-detached: open console {}: {e}", console.display()),
             };
         }
     };
@@ -1103,13 +1124,14 @@ fn do_run_detached(argv: Vec<String>, env: Vec<(String, String)>) -> GuestRespon
     // Reaper: wait for the detached workload, then report its exit code
     // to the host so the VM powers off (best-effort). Never touches the
     // agent request loop.
+    let exit_report_bin = exit_report_bin.to_path_buf();
     std::thread::spawn(move || {
         let mut child = child;
         let code = match child.wait() {
             Ok(status) => status.code().unwrap_or(-1),
             Err(_) => -1,
         };
-        let _ = std::process::Command::new("/usr/local/bin/mvm-exit-report")
+        let _ = std::process::Command::new(&exit_report_bin)
             .arg(code.to_string())
             .status();
     });
@@ -3338,6 +3360,82 @@ fn main() {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    /// The detached-workload handler actually spawns the argv, redirects its
+    /// stdout to the console target, and the reaper reports the exit code — the
+    /// end-to-end behaviour behind `machine run -d -- <cmd>`, exercised on the
+    /// host without a live guest. This is the regression guard for a guest agent
+    /// that links the `RunDetached` handler but doesn't actually run the workload.
+    #[cfg(feature = "dev-shell")]
+    #[test]
+    fn run_detached_spawns_redirects_console_and_reports_exit() {
+        use std::os::unix::fs::PermissionsExt as _;
+
+        let dir = tempfile::tempdir().unwrap();
+        let console = dir.path().join("console");
+        let reported = dir.path().join("reported-code");
+        // The handler opens the console for writing (it exists in production as
+        // `/dev/console`); pre-create the stand-in so the open succeeds.
+        std::fs::File::create(&console).unwrap();
+
+        // Stand-in for `mvm-exit-report`: records its exit-code argument so the
+        // reaper's report is observable.
+        let reporter = dir.path().join("exit-report.sh");
+        std::fs::write(
+            &reporter,
+            format!("#!/bin/sh\nprintf '%s' \"$1\" > {}\n", reported.display()),
+        )
+        .unwrap();
+        std::fs::set_permissions(&reporter, std::fs::Permissions::from_mode(0o755)).unwrap();
+
+        let resp = do_run_detached_with(
+            vec![
+                "/bin/sh".into(),
+                "-c".into(),
+                "printf RAN-DETACHED; exit 7".into(),
+            ],
+            vec![],
+            &console,
+            &reporter,
+        );
+        let pid = match resp {
+            GuestResponse::DetachedStarted { pid } => pid,
+            other => panic!("expected DetachedStarted, got {other:?}"),
+        };
+        assert!(pid > 0, "expected a positive pid, got {pid}");
+
+        // The spawn is asynchronous: poll until the workload's stdout reaches the
+        // console target AND the reaper reports the exit code.
+        let deadline = std::time::Instant::now() + std::time::Duration::from_secs(10);
+        loop {
+            let console_body = std::fs::read_to_string(&console).unwrap_or_default();
+            let reported_code = std::fs::read_to_string(&reported).unwrap_or_default();
+            if console_body.contains("RAN-DETACHED") && reported_code == "7" {
+                break;
+            }
+            assert!(
+                std::time::Instant::now() < deadline,
+                "detached workload did not complete: console={console_body:?} reported_code={reported_code:?}"
+            );
+            std::thread::sleep(std::time::Duration::from_millis(25));
+        }
+    }
+
+    #[cfg(feature = "dev-shell")]
+    #[test]
+    fn run_detached_refuses_empty_argv() {
+        match do_run_detached_with(
+            vec![],
+            vec![],
+            std::path::Path::new("/dev/null"),
+            std::path::Path::new("/bin/true"),
+        ) {
+            GuestResponse::Error { message } => {
+                assert!(message.contains("empty argv"), "got: {message}")
+            }
+            other => panic!("expected Error, got {other:?}"),
+        }
+    }
     use mvm_guest::integrations::{IntegrationEntry, IntegrationHealthResult, IntegrationStatus};
     use mvm_guest::vsock::{GuestCapability, read_frame, write_frame};
     use std::os::fd::IntoRawFd;

--- a/crates/mvm-guest/src/console.rs
+++ b/crates/mvm-guest/src/console.rs
@@ -622,8 +622,8 @@ mod tests {
         assert_eq!(ConsoleError::OpenPtyFailed.to_string(), "openpty() failed");
         assert_eq!(ConsoleError::ForkFailed.to_string(), "fork() failed");
         assert_eq!(
-            ConsoleError::InvalidCommand.to_string(),
-            "console command contains an interior NUL"
+            ConsoleError::InvalidCommand("argv must not contain NUL bytes".to_string()).to_string(),
+            "invalid console command: argv must not contain NUL bytes"
         );
         assert_eq!(
             ConsoleError::BindFailed(20001).to_string(),


### PR DESCRIPTION
Closes the verification gap left by #1559 (`machine run -d -- <cmd>`): the detached-workload handler now has a real test that runs it, that test runs in CI, and the local build no longer injects a stale agent.

## Why
- `#1559` shipped the `RunDetached` handler but nothing **ran** it — coverage was serde roundtrip + a mock send-helper only.
- The guest agent's entire `dev-shell` handler surface (`exec`, `run-code`, `run-detached`) was **never compiled with the feature in CI** — the workspace test run uses default features, so those handlers and their tests were compiled out.
- Editing guest source didn't reliably refresh the agent **embedded** into `mvmctl`, so a local `machine run --image` could inject a stale agent that rejects a newly-added request (this is exactly what confounded the live verification of #1559).

## What
1. **Handler test (the missing observation).** Refactored `do_run_detached` → testable `do_run_detached_with(argv, env, console, exit_report_bin)` (production passes `/dev/console` + `/usr/local/bin/mvm-exit-report`). New host test drives the **real handler** end-to-end: spawns the argv, asserts the workload's stdout reaches the console target, and asserts the reaper reports the exit code — the `-d` behaviour, on the host, no live guest. **Verified passing locally on a fresh compile.**
2. **CI dev-shell lane.** New step `cargo nextest run -p mvm-guest --features dev-shell`, so the detached handler + the rest of the dev-tier surface run on every PR (472 tests).
3. **Latent bug the lane exposed.** `console.rs`'s `test_console_error_display` built `ConsoleError::InvalidCommand` as a unit variant, but it carries a `String` and Displays as `invalid console command: {message}`. Fixed. (Never caught because no dev-shell test lane existed.)
4. **build.rs embed freshness.** `crates/mvm-cli/build.rs` now watches the guest / `mvm-build` source trees **file-by-file** instead of directory-level. Cargo's directory `rerun-if-changed` doesn't reliably re-trigger on a content edit to an existing file, so the embedded-binary cross-compile could skip a real change; per-file emission forces a re-run so `machine run --image` never injects a stale agent after a local edit.

## Result
This turns #1559's "verified by construction" into "verified by a CI test that actually runs the handler," and prevents the stale-embedded-agent class of local confusion. Gates green locally: nightly fmt, `clippy -D warnings` (incl. `mvm-guest --features dev-shell --all-targets`), the full `mvm-guest --features dev-shell` suite (472 pass).