### PR TITLE
Harden OCI runtime injection

### DIFF
--- a/crates/mvm-build/src/guest_agent_build.rs
+++ b/crates/mvm-build/src/guest_agent_build.rs
@@ -1,5 +1,5 @@
-//! Host-side source of the guest agent, netinit, and egress-client binaries baked into an
-//! OCI rootfs ([`crate::oci_runtime_inject`]).
+//! Host-side source of the guest runtime binaries baked into an OCI rootfs
+//! ([`crate::oci_runtime_inject`]).
 //!
 //! An mkGuest rootfs gets the agent from a nix build inside the builder
 //! VM. An arbitrary OCI image has no nix build of its own, so for the
@@ -41,9 +41,31 @@ pub enum GuestAgentBuildError {
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct GuestAgentLayout {
     pub dir: PathBuf,
+    pub oci_init: PathBuf,
     pub agent: PathBuf,
     pub netinit: PathBuf,
     pub egress_client: PathBuf,
+    pub entrypoint_runner: PathBuf,
+}
+
+/// Built guest runtime binary paths ready to install into the cache.
+#[derive(Debug, Clone, Copy)]
+pub struct GuestRuntimeBinaryPaths<'a> {
+    pub oci_init: &'a Path,
+    pub agent: &'a Path,
+    pub netinit: &'a Path,
+    pub egress_client: &'a Path,
+    pub entrypoint_runner: &'a Path,
+}
+
+/// Embedded guest runtime binary bytes ready to install into the cache.
+#[derive(Debug, Clone, Copy)]
+pub struct GuestRuntimeBinaryBytes<'a> {
+    pub oci_init: &'a [u8],
+    pub agent: &'a [u8],
+    pub netinit: &'a [u8],
+    pub egress_client: &'a [u8],
+    pub entrypoint_runner: &'a [u8],
 }
 
 /// Cache segment keying the agent build variant. The `run --image` path needs
@@ -62,22 +84,30 @@ impl GuestAgentLayout {
             .join(arch.to_string())
             .join(AGENT_VARIANT);
         Self {
+            oci_init: dir.join("mvm-oci-init"),
             agent: dir.join("mvm-guest-agent"),
             netinit: dir.join("mvm-guest-netinit"),
             egress_client: dir.join("mvm-egress-client"),
+            entrypoint_runner: dir.join("mvm-oci-entrypoint"),
             dir,
         }
     }
 
     fn is_complete(&self) -> bool {
-        self.agent.is_file() && self.netinit.is_file() && self.egress_client.is_file()
+        self.oci_init.is_file()
+            && self.agent.is_file()
+            && self.netinit.is_file()
+            && self.egress_client.is_file()
+            && self.entrypoint_runner.is_file()
     }
 
     fn binaries(&self) -> MvmRuntimeBinaries {
         MvmRuntimeBinaries {
+            oci_init: self.oci_init.clone(),
             agent: self.agent.clone(),
             netinit: self.netinit.clone(),
             egress_client: self.egress_client.clone(),
+            entrypoint_runner: self.entrypoint_runner.clone(),
         }
     }
 }
@@ -115,7 +145,7 @@ impl GuestAgentBuildSpec {
         musl_target_triple(self.arch)
     }
 
-    /// `cargo zigbuild` argv. Builds both guest bins with `dev-shell`
+    /// `cargo zigbuild` argv. Builds the guest runtime bins with `dev-shell`
     /// (the `run --image` exec path uses the dev-shell-gated handler,
     /// matching `nix/packages/mvm-guest-agent.nix`).
     pub fn argv(&self) -> Vec<String> {
@@ -136,6 +166,10 @@ impl GuestAgentBuildSpec {
             "mvm-guest-agent".to_string(),
             "--bin".to_string(),
             "mvm-guest-netinit".to_string(),
+            "--bin".to_string(),
+            "mvm-oci-init".to_string(),
+            "--bin".to_string(),
+            "mvm-oci-entrypoint".to_string(),
             "-p".to_string(),
             "mvm-guest-helpers".to_string(),
             "--bin".to_string(),
@@ -148,8 +182,9 @@ impl GuestAgentBuildSpec {
     /// Paths the build drops the binaries at under the workspace target
     /// dir.
     pub fn output_dir(&self) -> PathBuf {
-        self.workspace_root
-            .join("target")
+        std::env::var_os("CARGO_TARGET_DIR")
+            .map(PathBuf::from)
+            .unwrap_or_else(|| self.workspace_root.join("target"))
             .join(self.target_triple())
             .join("release")
     }
@@ -168,26 +203,37 @@ pub fn resolve_or_build_guest_binaries(
         return Ok(layout.binaries());
     }
     let spec = GuestAgentBuildSpec::new(workspace_root.to_path_buf(), arch);
-    let (agent, netinit, egress_client) = build_guest_binaries(&spec)?;
-    install_into_cache(&agent, &netinit, &egress_client, cache_root, version, arch)
+    let built = build_guest_binaries(&spec)?;
+    install_into_cache(
+        GuestRuntimeBinaryPaths {
+            oci_init: &built.0,
+            agent: &built.1,
+            netinit: &built.2,
+            egress_client: &built.3,
+            entrypoint_runner: &built.4,
+        },
+        cache_root,
+        version,
+        arch,
+    )
 }
 
 /// Copy already-built guest binaries into the cache and return the
 /// cached paths. Lets a caller that already has the binaries (e.g. a
 /// prior `cargo zigbuild`) pre-warm the cache without rebuilding.
 pub fn install_into_cache(
-    agent_src: &Path,
-    netinit_src: &Path,
-    egress_client_src: &Path,
+    src: GuestRuntimeBinaryPaths<'_>,
     cache_root: &Path,
     version: &str,
     arch: GuestArch,
 ) -> Result<MvmRuntimeBinaries, GuestAgentBuildError> {
     let layout = GuestAgentLayout::under(cache_root, version, arch);
     std::fs::create_dir_all(&layout.dir)?;
-    install_one(agent_src, &layout.agent)?;
-    install_one(netinit_src, &layout.netinit)?;
-    install_one(egress_client_src, &layout.egress_client)?;
+    install_one(src.oci_init, &layout.oci_init)?;
+    install_one(src.agent, &layout.agent)?;
+    install_one(src.netinit, &layout.netinit)?;
+    install_one(src.egress_client, &layout.egress_client)?;
+    install_one(src.entrypoint_runner, &layout.entrypoint_runner)?;
     Ok(layout.binaries())
 }
 
@@ -206,18 +252,18 @@ pub fn cached_guest_binaries(
 /// build time) into the cache. The end-user path: a shipped mvmctl has no
 /// source checkout to cross-compile from, so it writes the embedded bytes here.
 pub fn install_prebuilt_guest_binaries(
-    agent_bytes: &[u8],
-    netinit_bytes: &[u8],
-    egress_client_bytes: &[u8],
+    bytes: GuestRuntimeBinaryBytes<'_>,
     cache_root: &Path,
     version: &str,
     arch: GuestArch,
 ) -> Result<MvmRuntimeBinaries, GuestAgentBuildError> {
     let layout = GuestAgentLayout::under(cache_root, version, arch);
     std::fs::create_dir_all(&layout.dir)?;
-    write_exec(&layout.agent, agent_bytes)?;
-    write_exec(&layout.netinit, netinit_bytes)?;
-    write_exec(&layout.egress_client, egress_client_bytes)?;
+    write_exec(&layout.oci_init, bytes.oci_init)?;
+    write_exec(&layout.agent, bytes.agent)?;
+    write_exec(&layout.netinit, bytes.netinit)?;
+    write_exec(&layout.egress_client, bytes.egress_client)?;
+    write_exec(&layout.entrypoint_runner, bytes.entrypoint_runner)?;
     Ok(layout.binaries())
 }
 
@@ -240,7 +286,7 @@ fn install_one(src: &Path, dst: &Path) -> Result<(), GuestAgentBuildError> {
 /// Run `cargo zigbuild` for the spec, returning the built binary paths.
 pub fn build_guest_binaries(
     spec: &GuestAgentBuildSpec,
-) -> Result<(PathBuf, PathBuf, PathBuf), GuestAgentBuildError> {
+) -> Result<(PathBuf, PathBuf, PathBuf, PathBuf, PathBuf), GuestAgentBuildError> {
     let argv = spec.argv();
     let mut cmd = std::process::Command::new(&argv[0]);
     cmd.args(&argv[1..]).current_dir(&spec.workspace_root);
@@ -265,15 +311,23 @@ pub fn build_guest_binaries(
         });
     }
     let dir = spec.output_dir();
+    let oci_init = dir.join("mvm-oci-init");
     let agent = dir.join("mvm-guest-agent");
     let netinit = dir.join("mvm-guest-netinit");
     let egress_client = dir.join("mvm-egress-client");
-    for p in [&agent, &netinit, &egress_client] {
+    let entrypoint_runner = dir.join("mvm-oci-entrypoint");
+    for p in [
+        &oci_init,
+        &agent,
+        &netinit,
+        &egress_client,
+        &entrypoint_runner,
+    ] {
         if !p.is_file() {
             return Err(GuestAgentBuildError::OutputMissing(p.clone()));
         }
     }
-    Ok((agent, netinit, egress_client))
+    Ok((oci_init, agent, netinit, egress_client, entrypoint_runner))
 }
 
 /// `rustup which rustc` path, or `None` if rustup isn't installed.
@@ -313,30 +367,43 @@ mod tests {
     fn install_prebuilt_then_cached_round_trips() {
         let cache = tempfile::tempdir().unwrap();
         let arch = GuestArch::Aarch64;
+        let version = env!("CARGO_PKG_VERSION");
 
         // Nothing cached yet.
-        assert!(cached_guest_binaries(cache.path(), "9.9.9", arch).is_none());
+        assert!(cached_guest_binaries(cache.path(), version, arch).is_none());
 
         // Install embedded-style bytes, then the cache lookup finds them.
         let bins = install_prebuilt_guest_binaries(
-            b"fake-agent-elf",
-            b"fake-netinit-elf",
-            b"fake-egress-client-elf",
+            GuestRuntimeBinaryBytes {
+                oci_init: b"fake-oci-init-elf",
+                agent: b"fake-agent-elf",
+                netinit: b"fake-netinit-elf",
+                egress_client: b"fake-egress-client-elf",
+                entrypoint_runner: b"fake-entrypoint-runner-elf",
+            },
             cache.path(),
-            "9.9.9",
+            version,
             arch,
         )
         .expect("install prebuilt");
+        assert!(bins.oci_init.is_file());
         assert!(bins.agent.is_file());
         assert!(bins.netinit.is_file());
         assert!(bins.egress_client.is_file());
+        assert!(bins.entrypoint_runner.is_file());
+        assert_eq!(std::fs::read(&bins.oci_init).unwrap(), b"fake-oci-init-elf");
         assert_eq!(std::fs::read(&bins.agent).unwrap(), b"fake-agent-elf");
         assert_eq!(
             std::fs::read(&bins.egress_client).unwrap(),
             b"fake-egress-client-elf"
         );
+        assert_eq!(
+            std::fs::read(&bins.entrypoint_runner).unwrap(),
+            b"fake-entrypoint-runner-elf"
+        );
 
-        let cached = cached_guest_binaries(cache.path(), "9.9.9", arch).expect("now cached");
+        let cached = cached_guest_binaries(cache.path(), version, arch).expect("now cached");
+        assert_eq!(cached.oci_init, bins.oci_init);
         assert_eq!(cached.agent, bins.agent);
         // Executable bit is set on the installed binary.
         #[cfg(unix)]
@@ -364,25 +431,21 @@ mod tests {
 
     #[test]
     fn layout_is_versioned_arched_and_variant_keyed() {
-        let l = GuestAgentLayout::under(Path::new("/c"), "0.16.1", GuestArch::Aarch64);
+        let version = env!("CARGO_PKG_VERSION");
+        let l = GuestAgentLayout::under(Path::new("/c"), version, GuestArch::Aarch64);
+        let expected_dir = PathBuf::from("/c")
+            .join("guest-agent")
+            .join(version)
+            .join("aarch64")
+            .join("dev-shell");
         // The `dev-shell` segment keys the variant so a stale same-version agent
         // built without dev-shell is never reused for the exec-capable request.
-        assert_eq!(
-            l.dir,
-            PathBuf::from("/c/guest-agent/0.16.1/aarch64/dev-shell")
-        );
-        assert_eq!(
-            l.agent,
-            PathBuf::from("/c/guest-agent/0.16.1/aarch64/dev-shell/mvm-guest-agent")
-        );
-        assert_eq!(
-            l.netinit,
-            PathBuf::from("/c/guest-agent/0.16.1/aarch64/dev-shell/mvm-guest-netinit")
-        );
-        assert_eq!(
-            l.egress_client,
-            PathBuf::from("/c/guest-agent/0.16.1/aarch64/dev-shell/mvm-egress-client")
-        );
+        assert_eq!(l.dir, expected_dir);
+        assert_eq!(l.oci_init, l.dir.join("mvm-oci-init"));
+        assert_eq!(l.agent, l.dir.join("mvm-guest-agent"));
+        assert_eq!(l.netinit, l.dir.join("mvm-guest-netinit"));
+        assert_eq!(l.egress_client, l.dir.join("mvm-egress-client"));
+        assert_eq!(l.entrypoint_runner, l.dir.join("mvm-oci-entrypoint"));
     }
 
     #[test]
@@ -394,6 +457,8 @@ mod tests {
         assert!(argv.contains(&"aarch64-unknown-linux-musl".to_string()));
         assert!(argv.contains(&"mvm-guest-agent".to_string()));
         assert!(argv.contains(&"mvm-guest-netinit".to_string()));
+        assert!(argv.contains(&"mvm-oci-init".to_string()));
+        assert!(argv.contains(&"mvm-oci-entrypoint".to_string()));
         assert!(argv.contains(&"mvm-egress-client".to_string()));
         assert!(argv.contains(&"mvm-guest-helpers".to_string()));
         assert!(argv.contains(&"mvm-guest/dev-shell".to_string()));
@@ -407,31 +472,45 @@ mod tests {
     #[test]
     fn install_and_resolve_round_trips_from_cache() {
         let tmp = tempfile::tempdir().unwrap();
+        let version = env!("CARGO_PKG_VERSION");
+        let oci_init_src = tmp.path().join("i");
         let agent_src = tmp.path().join("a");
         let netinit_src = tmp.path().join("n");
         let egress_client_src = tmp.path().join("e");
+        let entrypoint_runner_src = tmp.path().join("r");
+        std::fs::write(&oci_init_src, b"INIT").unwrap();
         std::fs::write(&agent_src, b"AGENT").unwrap();
         std::fs::write(&netinit_src, b"NETINIT").unwrap();
         std::fs::write(&egress_client_src, b"EGRESS").unwrap();
+        std::fs::write(&entrypoint_runner_src, b"RUNNER").unwrap();
         let cache = tmp.path().join("cache");
 
         let installed = install_into_cache(
-            &agent_src,
-            &netinit_src,
-            &egress_client_src,
+            GuestRuntimeBinaryPaths {
+                oci_init: &oci_init_src,
+                agent: &agent_src,
+                netinit: &netinit_src,
+                egress_client: &egress_client_src,
+                entrypoint_runner: &entrypoint_runner_src,
+            },
             &cache,
-            "0.16.1",
+            version,
             GuestArch::Aarch64,
         )
         .expect("install");
+        assert_eq!(std::fs::read(&installed.oci_init).unwrap(), b"INIT");
         assert_eq!(std::fs::read(&installed.agent).unwrap(), b"AGENT");
         assert_eq!(std::fs::read(&installed.egress_client).unwrap(), b"EGRESS");
+        assert_eq!(
+            std::fs::read(&installed.entrypoint_runner).unwrap(),
+            b"RUNNER"
+        );
 
         // A subsequent resolve hits the cache and never builds (the
         // workspace path is bogus; if it built it would fail).
         let resolved = resolve_or_build_guest_binaries(
             &cache,
-            "0.16.1",
+            version,
             GuestArch::Aarch64,
             Path::new("/nonexistent-workspace"),
         )
@@ -442,12 +521,17 @@ mod tests {
     #[test]
     fn install_rejects_missing_source() {
         let tmp = tempfile::tempdir().unwrap();
+        let version = env!("CARGO_PKG_VERSION");
         let err = install_into_cache(
-            &tmp.path().join("missing-agent"),
-            &tmp.path().join("missing-netinit"),
-            &tmp.path().join("missing-egress-client"),
+            GuestRuntimeBinaryPaths {
+                oci_init: &tmp.path().join("missing-oci-init"),
+                agent: &tmp.path().join("missing-agent"),
+                netinit: &tmp.path().join("missing-netinit"),
+                egress_client: &tmp.path().join("missing-egress-client"),
+                entrypoint_runner: &tmp.path().join("missing-entrypoint-runner"),
+            },
             &tmp.path().join("cache"),
-            "0.16.1",
+            version,
             GuestArch::Aarch64,
         )
         .unwrap_err();

--- a/crates/mvm-build/src/oci_runtime_inject.rs
+++ b/crates/mvm-build/src/oci_runtime_inject.rs
@@ -10,19 +10,19 @@
 //! This module is the host-side fix. It runs against the unpacked OCI
 //! tree *before* it is sealed into `rootfs.ext4`, baking in:
 //!
-//! - `/usr/local/bin/mvm-guest-agent`, `/usr/local/bin/mvm-guest-netinit`, and
-//!   `/usr/local/bin/mvm-egress-client` — the cross-compiled guest binaries
-//!   (the agent is the sole control plane; netinit installs the guest-side
-//!   network defense; the egress client talks to the host over vsock).
-//! - `/init` — PID 1. Mounts the pseudo-filesystems, runs netinit, then
-//!   forks the agent and idles. The OCI image's own entrypoint never
-//!   runs as PID 1; it only ever runs *under* the agent, over vsock —
-//!   preserving the agent-is-the-only-exec-gate posture.
+//! - `/init`, `/usr/local/bin/mvm-guest-agent`,
+//!   `/usr/local/bin/mvm-guest-netinit`, and
+//!   `/usr/local/bin/mvm-egress-client` — the cross-compiled guest binaries.
+//!   `/init` is a static Rust PID 1, not a shell script, so the source OCI image
+//!   does not need `/bin/sh`, busybox, coreutils, or its own init system.
+//! - `/usr/lib/mvm/wrappers/oci-entrypoint` plus `/etc/mvm/entrypoint`
+//!   when the OCI config declares Entrypoint/Cmd. The wrapper is a static
+//!   binary that execs the declared argv directly; it never shells out.
 //! - `/mvm/runtime` — the overlay mount point. On Firecracker the host
 //!   attaches a verity-sealed overlay here; the injected `/init` prefers
 //!   the overlay-resident agent and falls back to the baked one, exactly
-//!   like a mkGuest rootfs. On libkrun/Vz no overlay attaches and the
-//!   baked binaries are used.
+//!   like a mkGuest rootfs. When no overlay attaches, the baked binaries are
+//!   used.
 //! - `/etc/mvm/{name,variant}` — the minimal markers the agent reads.
 //!
 //! Because the mount point + overlay-preferring `/init` are genuinely
@@ -42,179 +42,35 @@ use std::path::{Path, PathBuf};
 /// `cargo-zigbuild`) or unpacked from the published runtime overlay.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct MvmRuntimeBinaries {
+    /// Static OCI PID 1 (`mvm-oci-init`), installed as `/init`.
+    pub oci_init: PathBuf,
     /// Static guest agent binary (`mvm-guest-agent`).
     pub agent: PathBuf,
     /// Static guest netinit binary (`mvm-guest-netinit`).
     pub netinit: PathBuf,
     /// Static guest egress shim (`mvm-egress-client`).
     pub egress_client: PathBuf,
+    /// Static OCI entrypoint runner (`mvm-oci-entrypoint`).
+    pub entrypoint_runner: PathBuf,
+}
+
+/// Shell-free runtime config for an OCI image's declared Entrypoint/Cmd.
+#[derive(Debug, Clone, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
+pub struct OciEntrypointConfig {
+    pub argv: Vec<String>,
+    #[serde(default)]
+    pub env: Vec<String>,
+    #[serde(default)]
+    pub working_dir: Option<String>,
 }
 
 /// Where the injected guest binaries land inside the rootfs.
 const AGENT_DEST: &str = "usr/local/bin/mvm-guest-agent";
 const NETINIT_DEST: &str = "usr/local/bin/mvm-guest-netinit";
 const EGRESS_CLIENT_DEST: &str = "usr/local/bin/mvm-egress-client";
-
-/// PID-1 init baked into an OCI rootfs so `run --image` has a vsock
-/// control plane. POSIX `sh` (busybox `ash` in alpine and friends).
-///
-/// Contract, in order:
-/// 1. Mount `/proc`, `/sys`, `/dev` (+ `devpts`, `tmpfs` for `/run`,
-///    `/tmp`) — the agent and any exec'd command need them.
-/// 2. Create the `/mvm/runtime` overlay mount point.
-/// 3. Mount each `machine run --volume` host share (`mvm.uvols=` cmdline)
-///    as virtio-fs at its guest path, before the workload comes up.
-/// 4. Run the guest-side network defense (netinit), overlay copy first.
-/// 5. Fork the agent (overlay copy first, baked fallback) and idle.
-///
-/// The agent is forked, not `exec`'d: PID 1 must stay alive to keep the
-/// VM up while the agent serves vsock RPC. An input-less idle loop
-/// avoids depending on `sleep infinity`.
-pub fn oci_init_script() -> String {
-    // Note: `mkdir -p /mvm/runtime` is created at injection time too, so
-    // the mount point survives even on a read-only rootfs; the runtime
-    // `mkdir` here is belt-and-braces for the writable-rootfs case.
-    r#"#!/bin/sh
-# mvm OCI runtime init. The mvm guest agent is the sole control plane:
-# this PID 1 mounts the pseudo-filesystems, brings up guest-side network
-# defense, then forks the agent and idles. The OCI image entrypoint runs
-# only under the agent (over vsock), never as PID 1.
-set -u
-
-mount -t proc     none /proc    2>/dev/null || true
-mount -t sysfs    none /sys     2>/dev/null || true
-mount -t devtmpfs none /dev     2>/dev/null || true
-mkdir -p /dev/pts /dev/shm /run /tmp /mvm/runtime 2>/dev/null || true
-mount -t devpts none /dev/pts 2>/dev/null || true
-mount -t tmpfs  none /run     2>/dev/null || true
-mount -t tmpfs  none /tmp     2>/dev/null || true
-
-# User volumes (machine run --volume). The host encoded
-# mvm.uvols=<tag>:<hex(guest_path)>:<ro|rw>:<fs|blk>;... onto the kernel
-# cmdline (mvm_core::vm_backend::encode_user_volumes_cmdline); mount each
-# virtio-fs share at its guest path. virtio-fs is built into the workload
-# kernel, so no module load is needed. Best-effort: a bad mount logs and
-# continues rather than wedging PID 1. Disk (blk) volumes are attached as
-# block devices for the workload to mount itself. Mirrors the mkGuest init.
-MVM_UVOLS=$(sed -n 's/.*\bmvm\.uvols=\([^ ]*\).*/\1/p' /proc/cmdline 2>/dev/null)
-if [ -n "$MVM_UVOLS" ]; then
-  echo "$MVM_UVOLS" | tr ';' '\n' | while IFS=: read -r utag uhex umode ukind; do
-    [ -n "$utag" ] || continue
-    [ -n "$uhex" ] || continue
-    upath=$(printf '%b' "$(echo "$uhex" | sed 's/../\\x&/g')")
-    [ -n "$upath" ] || continue
-    if [ "$ukind" = blk ]; then
-      echo "mvm-oci-init: user disk volume for '$upath' attached (guest auto-mount of disks not wired)"
-      continue
-    fi
-    mkdir -p "$upath" 2>/dev/null || true
-    if [ "$umode" = ro ]; then
-      mount -t virtiofs -o ro "$utag" "$upath" \
-        && echo "mvm-oci-init: mounted user volume $utag at $upath (ro)" \
-        || echo "mvm-oci-init: user volume $utag -> $upath failed (mountpoint must exist on the ro rootfs)"
-    else
-      mount -t virtiofs "$utag" "$upath" \
-        && echo "mvm-oci-init: mounted user volume $utag at $upath (rw)" \
-        || echo "mvm-oci-init: user volume $utag -> $upath failed (mountpoint must exist on the ro rootfs)"
-    fi
-  done
-fi
-
-# Egress CA (TLS-substitution trust). The host encoded mvm.egress_ca=<hex(PEM)>
-# onto the kernel cmdline (only when egress substitution is configured); decode
-# it to /run/mvm/ca-bundle.crt so the workload trusts the per-VM egress CA
-# alongside the image's baked roots. The env vars that point a TLS stack here
-# are injected into the entrypoint's env host-side (the agent execs it under
-# env_clear, so a shell export would not reach it). Absent token => no-op.
-# Mirrors the mkGuest egress-ca stage in nix/lib/mk-guest.nix.
-MVM_EGRESS_CA_HEX=$(sed -n 's/.*\bmvm\.egress_ca=\([^ ]*\).*/\1/p' /proc/cmdline 2>/dev/null)
-if [ -n "$MVM_EGRESS_CA_HEX" ]; then
-  mkdir -p /run/mvm 2>/dev/null || true
-  printf '%b' "$(echo "$MVM_EGRESS_CA_HEX" | sed 's/../\\x&/g')" > /run/mvm/egress-ca.crt
-  mvm_baked=
-  for mvm_c in /etc/ssl/certs/ca-certificates.crt /etc/ssl/cert.pem /etc/ssl/certs/ca-bundle.crt; do
-    [ -f "$mvm_c" ] && { mvm_baked="$mvm_c"; break; }
-  done
-  if [ -n "$mvm_baked" ] && cat "$mvm_baked" /run/mvm/egress-ca.crt > /run/mvm/ca-bundle.crt 2>/dev/null; then
-    :
-  else
-    cp /run/mvm/egress-ca.crt /run/mvm/ca-bundle.crt 2>/dev/null || true
-  fi
-  chmod 0644 /run/mvm/egress-ca.crt /run/mvm/ca-bundle.crt 2>/dev/null || true
-  echo "mvm-oci-init: installed per-VM egress CA"
-fi
-
-# Verb grant (plan-bound agent verb capabilities). The host encoded
-# mvm.verb_grant=<hex(JSON envelope)> onto the kernel cmdline; decode it to
-# the tmpfs so the agent can pin + enforce it before serving RPC. Absent
-# token => no-op (byte-identical boot; the agent starts with no grant).
-# Mirrors the mkGuest init verb-grant stage in nix/lib/mk-guest.nix.
-MVM_VERB_GRANT_HEX=$(sed -n 's/.*\bmvm\.verb_grant=\([^ ]*\).*/\1/p' /proc/cmdline 2>/dev/null)
-if [ -n "$MVM_VERB_GRANT_HEX" ]; then
-  mkdir -p /run/mvm 2>/dev/null || true
-  printf '%b' "$(echo "$MVM_VERB_GRANT_HEX" | sed 's/../\\x&/g')" > /run/mvm/verb-grant.json
-  chmod 0644 /run/mvm/verb-grant.json 2>/dev/null || true
-  echo "mvm-oci-init: provisioned verb-grant"
-fi
-
-# Guest-side network defense — prefer the overlay-resident netinit.
-MVM_NETINIT=
-if [ -x /mvm/runtime/netinit ]; then
-  MVM_NETINIT=/mvm/runtime/netinit
-elif [ -x /usr/local/bin/mvm-guest-netinit ]; then
-  MVM_NETINIT=/usr/local/bin/mvm-guest-netinit
-fi
-if [ -n "$MVM_NETINIT" ]; then
-  "$MVM_NETINIT" || echo "mvm-oci-init: netinit exited nonzero; continuing"
-fi
-
-# Decode the vsock-egress opt-in. Eligible workload backends set
-# mvm.vsock_egress=1 on the kernel cmdline; export the env var the
-# egress-client stage keys on. Absent token => no-op.
-if /bin/busybox grep -qE ' mvm\.vsock_egress=1( |$)' /proc/cmdline 2>/dev/null; then
-  export MVM_VSOCK_EGRESS=1
-fi
-
-# Start the guest-side SOCKS5 -> vsock egress shim when this boot requested
-# vsock-mediated egress. The workload itself runs under the agent and does not
-# inherit PID 1's environment, so the host also injects matching proxy vars on
-# the exec/request path; these shell exports keep the boot contract explicit and
-# cover any direct child that does inherit from PID 1.
-if [ -n "$MVM_VSOCK_EGRESS" ] && [ -x /usr/local/bin/mvm-egress-client ]; then
-  /bin/busybox ip link set lo up 2>/dev/null || true
-  /usr/local/bin/mvm-egress-client &
-  export ALL_PROXY="socks5h://127.0.0.1:1080"
-  export HTTP_PROXY="$ALL_PROXY"
-  export HTTPS_PROXY="$ALL_PROXY"
-  export http_proxy="$ALL_PROXY"
-  export https_proxy="$ALL_PROXY"
-  export NO_PROXY="localhost,127.0.0.1,::1"
-  export no_proxy="$NO_PROXY"
-fi
-
-# The agent is the control plane. Prefer the overlay-resident agent
-# (Firecracker verity overlay); fall back to the baked-in copy
-# (libkrun/Vz). Both are exec-tested so a half-attached overlay still
-# boots via the baked path rather than agent-less.
-MVM_AGENT=
-if [ -x /mvm/runtime/agent ]; then
-  MVM_AGENT=/mvm/runtime/agent
-elif [ -x /usr/local/bin/mvm-guest-agent ]; then
-  MVM_AGENT=/usr/local/bin/mvm-guest-agent
-fi
-if [ -n "$MVM_AGENT" ]; then
-  "$MVM_AGENT" &
-else
-  echo "mvm-oci-init: no mvm guest agent present; control plane unavailable" >&2
-fi
-
-# PID 1 idles so the VM stays up while the agent serves vsock RPC.
-while :; do
-  /bin/sh -c 'sleep 2147483647' 2>/dev/null || sleep 86400 || break
-done
-"#
-    .to_string()
-}
+const ENTRYPOINT_RUNNER_DEST: &str = "usr/lib/mvm/wrappers/oci-entrypoint";
+const ENTRYPOINT_MARKER_DEST: &str = "etc/mvm/entrypoint";
+const OCI_ENTRYPOINT_CONFIG_DEST: &str = "etc/mvm/oci-entrypoint.json";
 
 /// Inject the mvm runtime into the OCI-unpacked `rootfs_dir`.
 ///
@@ -224,6 +80,7 @@ done
 pub fn inject_mvm_runtime(
     rootfs_dir: &Path,
     bins: &MvmRuntimeBinaries,
+    entrypoint: Option<&OciEntrypointConfig>,
 ) -> Result<InjectedPaths, io::Error> {
     if !rootfs_dir.is_dir() {
         return Err(io::Error::new(
@@ -235,10 +92,22 @@ pub fn inject_mvm_runtime(
         ));
     }
 
-    // Overlay mount point — present on disk so it survives even when the
-    // rootfs is mounted read-only at boot.
+    // Mount points must exist on disk before a read-only root boot; PID 1
+    // cannot create them once the root is served by a read-only virtiofs device.
+    for (rel, mode) in [
+        ("proc", 0o755),
+        ("sys", 0o755),
+        ("dev", 0o755),
+        ("dev/pts", 0o755),
+        ("dev/shm", 0o1777),
+        ("run", 0o755),
+        ("tmp", 0o1777),
+        ("mvm/runtime", 0o755),
+        ("usr/lib/mvm/wrappers", 0o755),
+    ] {
+        ensure_dir(rootfs_dir, rel, mode)?;
+    }
     let runtime_dir = rootfs_dir.join("mvm").join("runtime");
-    std::fs::create_dir_all(&runtime_dir)?;
 
     // Minimal markers the agent reads. `variant=dev` keeps the
     // interactive/console surface enabled (a `run --image` is a dev
@@ -257,16 +126,35 @@ pub fn inject_mvm_runtime(
     copy_exec(&bins.agent, &agent_dest)?;
     copy_exec(&bins.netinit, &netinit_dest)?;
     copy_exec(&bins.egress_client, &egress_client_dest)?;
+    let entrypoint_runner_dest = rootfs_dir.join(ENTRYPOINT_RUNNER_DEST);
+    copy_file_with_mode(&bins.entrypoint_runner, &entrypoint_runner_dest, 0o555)?;
+    if let Some(entrypoint) = entrypoint
+        && !entrypoint.argv.is_empty()
+    {
+        let entrypoint_json = serde_json::to_vec(entrypoint).map_err(io::Error::other)?;
+        write_file(
+            &rootfs_dir.join(OCI_ENTRYPOINT_CONFIG_DEST),
+            &entrypoint_json,
+            0o644,
+        )?;
+        write_file(
+            &rootfs_dir.join(ENTRYPOINT_MARKER_DEST),
+            b"/usr/lib/mvm/wrappers/oci-entrypoint\n",
+            0o644,
+        )?;
+    }
 
-    // PID 1.
+    // PID 1. This is a static binary, not a shell script, so arbitrary OCI
+    // images do not need busybox/coreutils/shell in their rootfs.
     let init_dest = rootfs_dir.join("init");
-    write_file(&init_dest, oci_init_script().as_bytes(), 0o755)?;
+    copy_exec(&bins.oci_init, &init_dest)?;
 
     Ok(InjectedPaths {
         init: init_dest,
         agent: agent_dest,
         netinit: netinit_dest,
         egress_client: egress_client_dest,
+        entrypoint_runner: entrypoint_runner_dest,
         runtime_mount_point: runtime_dir,
     })
 }
@@ -278,6 +166,7 @@ pub struct InjectedPaths {
     pub agent: PathBuf,
     pub netinit: PathBuf,
     pub egress_client: PathBuf,
+    pub entrypoint_runner: PathBuf,
     pub runtime_mount_point: PathBuf,
 }
 
@@ -289,7 +178,17 @@ fn write_file(path: &Path, contents: &[u8], mode: u32) -> Result<(), io::Error> 
     set_mode(path, mode)
 }
 
+fn ensure_dir(rootfs_dir: &Path, rel: &str, mode: u32) -> Result<(), io::Error> {
+    let path = rootfs_dir.join(rel);
+    std::fs::create_dir_all(&path)?;
+    set_mode(&path, mode)
+}
+
 fn copy_exec(src: &Path, dst: &Path) -> Result<(), io::Error> {
+    copy_file_with_mode(src, dst, 0o755)
+}
+
+fn copy_file_with_mode(src: &Path, dst: &Path, mode: u32) -> Result<(), io::Error> {
     if let Some(parent) = dst.parent() {
         std::fs::create_dir_all(parent)?;
     }
@@ -297,7 +196,7 @@ fn copy_exec(src: &Path, dst: &Path) -> Result<(), io::Error> {
     // binary from a prior inject doesn't reject the overwrite.
     let _ = std::fs::remove_file(dst);
     std::fs::copy(src, dst)?;
-    set_mode(dst, 0o755)
+    set_mode(dst, mode)
 }
 
 #[cfg(unix)]
@@ -314,144 +213,25 @@ fn set_mode(_path: &Path, _mode: u32) -> Result<(), io::Error> {
 #[cfg(test)]
 mod tests {
     use super::*;
-
-    #[test]
-    fn init_script_mounts_pseudofs_and_forks_agent() {
-        let s = oci_init_script();
-        assert!(s.starts_with("#!/bin/sh"));
-        // Pseudo-filesystems the agent + exec'd commands depend on.
-        assert!(s.contains("mount -t proc"));
-        assert!(s.contains("mount -t sysfs"));
-        assert!(s.contains("mount -t devtmpfs"));
-        // Overlay mount point.
-        assert!(s.contains("/mvm/runtime"));
-        // Overlay-preferring agent resolution, baked fallback.
-        assert!(s.contains("/mvm/runtime/agent"));
-        assert!(s.contains("/usr/local/bin/mvm-guest-agent"));
-        assert!(s.contains("/usr/local/bin/mvm-egress-client"));
-        // Agent is forked (control plane), not exec'd — PID 1 must idle.
-        assert!(s.contains("\"$MVM_AGENT\" &"));
-        // Netinit before the agent.
-        let netinit_at = s.find("mvm-guest-netinit").expect("netinit referenced");
-        let agent_fork_at = s.find("\"$MVM_AGENT\" &").expect("agent fork");
-        assert!(
-            netinit_at < agent_fork_at,
-            "netinit must run before the agent fork"
-        );
-    }
-
-    #[test]
-    fn init_script_mounts_user_volumes_before_the_agent() {
-        let s = oci_init_script();
-        // Reads the host-encoded cmdline token and mounts each share as virtio-fs.
-        assert!(
-            s.contains("mvm.uvols="),
-            "init must parse the uvols cmdline"
-        );
-        assert!(
-            s.contains("mount -t virtiofs -o ro"),
-            "ro shares mount as virtio-fs"
-        );
-        assert!(
-            s.contains("mount -t virtiofs \"$utag\""),
-            "rw shares mount as virtio-fs"
-        );
-        assert!(s.contains("mkdir -p \"$upath\""), "mountpoint is created");
-        // Disk volumes are left for the workload, not auto-mounted here.
-        assert!(s.contains("guest auto-mount of disks not wired"));
-        // Shares mount before the workload agent comes up so the workload sees them.
-        let uvols_at = s.find("mvm.uvols=").expect("uvols parse");
-        let agent_fork_at = s.find("\"$MVM_AGENT\" &").expect("agent fork");
-        assert!(
-            uvols_at < agent_fork_at,
-            "user volumes must mount before the agent fork"
-        );
-    }
-
-    #[test]
-    fn init_script_decodes_verb_grant_before_the_agent() {
-        let s = oci_init_script();
-        // Decodes the host-encoded cmdline token into the tmpfs the agent
-        // reads, so an OCI workload pins + enforces its verb grant (parity
-        // with the mkGuest init).
-        assert!(
-            s.contains("mvm.verb_grant="),
-            "init must parse the verb_grant cmdline token"
-        );
-        assert!(
-            s.contains("/run/mvm/verb-grant.json"),
-            "decoded grant is written where the agent loads it"
-        );
-        // Must be provisioned before the agent forks, or the agent boots
-        // with no grant pinned and enforcement is a no-op.
-        let grant_at = s.find("mvm.verb_grant=").expect("verb_grant parse");
-        let agent_fork_at = s.find("\"$MVM_AGENT\" &").expect("agent fork");
-        assert!(
-            grant_at < agent_fork_at,
-            "verb grant must be decoded before the agent fork"
-        );
-    }
-
-    #[test]
-    fn init_script_decodes_egress_ca_before_the_agent() {
-        let s = oci_init_script();
-        // Decodes the per-VM egress CA into the tmpfs bundle the workload's TLS
-        // stack trusts (the env vars pointing here are injected host-side).
-        assert!(
-            s.contains("mvm.egress_ca="),
-            "init must parse the egress_ca cmdline token"
-        );
-        assert!(
-            s.contains("/run/mvm/ca-bundle.crt"),
-            "combined CA bundle is written where the workload's SSL_CERT_FILE points"
-        );
-        // Written before the agent forks, so the file exists when the agent
-        // execs the entrypoint (which the host points at the bundle via env).
-        let ca_at = s.find("mvm.egress_ca=").expect("egress_ca parse");
-        let agent_fork_at = s.find("\"$MVM_AGENT\" &").expect("agent fork");
-        assert!(
-            ca_at < agent_fork_at,
-            "egress CA must be decoded before the agent fork"
-        );
-    }
-
-    #[test]
-    fn init_script_starts_vsock_egress_client_and_sets_proxy_before_the_agent() {
-        let s = oci_init_script();
-        assert!(
-            s.contains("mvm.vsock_egress=1"),
-            "init must parse the vsock egress cmdline token"
-        );
-        assert!(
-            s.contains("/usr/local/bin/mvm-egress-client &"),
-            "init must fork the egress client when requested"
-        );
-        assert!(
-            s.contains("ALL_PROXY=\"socks5h://127.0.0.1:1080\""),
-            "init must export the SOCKS proxy URL"
-        );
-        assert!(s.contains("NO_PROXY=\"localhost,127.0.0.1,::1\""));
-        let egress_at = s
-            .find("/usr/local/bin/mvm-egress-client &")
-            .expect("egress client fork");
-        let agent_fork_at = s.find("\"$MVM_AGENT\" &").expect("agent fork");
-        assert!(
-            egress_at < agent_fork_at,
-            "egress client must start before the agent fork"
-        );
-    }
+    use std::os::unix::fs::PermissionsExt;
 
     fn fake_bins(dir: &Path) -> MvmRuntimeBinaries {
+        let oci_init = dir.join("oci-init.bin");
         let agent = dir.join("agent.bin");
         let netinit = dir.join("netinit.bin");
         let egress_client = dir.join("egress-client.bin");
+        let entrypoint_runner = dir.join("entrypoint-runner.bin");
+        std::fs::write(&oci_init, b"\x7fELF-oci-init").unwrap();
         std::fs::write(&agent, b"\x7fELF-agent").unwrap();
         std::fs::write(&netinit, b"\x7fELF-netinit").unwrap();
         std::fs::write(&egress_client, b"\x7fELF-egress-client").unwrap();
+        std::fs::write(&entrypoint_runner, b"\x7fELF-entrypoint-runner").unwrap();
         MvmRuntimeBinaries {
+            oci_init,
             agent,
             netinit,
             egress_client,
+            entrypoint_runner,
         }
     }
 
@@ -462,11 +242,21 @@ mod tests {
         std::fs::create_dir_all(&root).unwrap();
         let bins = fake_bins(tmp.path());
 
-        let injected = inject_mvm_runtime(&root, &bins).expect("inject");
+        let entrypoint = OciEntrypointConfig {
+            argv: vec![
+                "/app/server".to_string(),
+                "--port".to_string(),
+                "8080".to_string(),
+            ],
+            env: vec!["FOO=bar".to_string()],
+            working_dir: Some("/app".to_string()),
+        };
 
-        // /init present, executable, is our script.
-        let init = std::fs::read_to_string(&injected.init).unwrap();
-        assert!(init.contains("mvm OCI runtime init"));
+        let injected = inject_mvm_runtime(&root, &bins, Some(&entrypoint)).expect("inject");
+
+        // /init is the injected static binary, not a shell script that would
+        // require `/bin/sh` or busybox from the source OCI image.
+        assert_eq!(std::fs::read(&injected.init).unwrap(), b"\x7fELF-oci-init");
         assert!(is_executable(&injected.init));
         // Binaries copied to the baked path, executable, content-equal.
         assert_eq!(std::fs::read(&injected.agent).unwrap(), b"\x7fELF-agent");
@@ -477,9 +267,34 @@ mod tests {
             b"\x7fELF-egress-client"
         );
         assert!(is_executable(&injected.egress_client));
+        assert_eq!(
+            std::fs::read(&injected.entrypoint_runner).unwrap(),
+            b"\x7fELF-entrypoint-runner"
+        );
+        assert!(is_executable(&injected.entrypoint_runner));
+        assert_eq!(
+            std::fs::metadata(&injected.entrypoint_runner)
+                .unwrap()
+                .permissions()
+                .mode()
+                & 0o777,
+            0o555
+        );
+        assert_eq!(
+            std::fs::read_to_string(root.join("etc/mvm/entrypoint")).unwrap(),
+            "/usr/lib/mvm/wrappers/oci-entrypoint\n"
+        );
+        let written_entrypoint: OciEntrypointConfig = serde_json::from_slice(
+            &std::fs::read(root.join("etc/mvm/oci-entrypoint.json")).unwrap(),
+        )
+        .unwrap();
+        assert_eq!(written_entrypoint, entrypoint);
         // Overlay mount point exists on disk.
         assert!(injected.runtime_mount_point.is_dir());
         assert!(root.join("mvm/runtime").is_dir());
+        for rel in ["proc", "sys", "dev/pts", "dev/shm", "run", "tmp"] {
+            assert!(root.join(rel).is_dir(), "{rel} mountpoint exists");
+        }
         // Markers.
         assert_eq!(
             std::fs::read_to_string(root.join("etc/mvm/variant")).unwrap(),
@@ -494,18 +309,19 @@ mod tests {
         std::fs::create_dir_all(&root).unwrap();
         let bins = fake_bins(tmp.path());
 
-        inject_mvm_runtime(&root, &bins).expect("first inject");
+        inject_mvm_runtime(&root, &bins, None).expect("first inject");
         // A second inject (e.g. cache reuse) must not error on existing files.
-        let second = inject_mvm_runtime(&root, &bins).expect("second inject");
+        let second = inject_mvm_runtime(&root, &bins, None).expect("second inject");
         assert!(is_executable(&second.agent));
         assert!(is_executable(&second.egress_client));
+        assert!(!root.join("etc/mvm/entrypoint").exists());
     }
 
     #[test]
     fn inject_rejects_missing_rootfs_dir() {
         let tmp = tempfile::tempdir().unwrap();
         let bins = fake_bins(tmp.path());
-        let err = inject_mvm_runtime(&tmp.path().join("nope"), &bins).unwrap_err();
+        let err = inject_mvm_runtime(&tmp.path().join("nope"), &bins, None).unwrap_err();
         assert_eq!(err.kind(), io::ErrorKind::NotFound);
     }
 

--- a/crates/mvm-build/src/run_image.rs
+++ b/crates/mvm-build/src/run_image.rs
@@ -11,16 +11,19 @@ use std::path::Path;
 
 use anyhow::{Context, Result};
 
-use crate::oci_runtime_inject::MvmRuntimeBinaries;
+use crate::guest_agent_build::GuestRuntimeBinaryBytes;
+use crate::oci_runtime_inject::{MvmRuntimeBinaries, OciEntrypointConfig};
 use crate::rootfs::MaterializeExt4Input;
 
 /// Guest runtime binaries embedded in the host binary at build time — the
 /// end-user fallback for a shipped mvmctl with no source checkout to
 /// cross-compile from.
 pub struct PrebuiltGuestBinaries<'a> {
+    pub oci_init: &'a [u8],
     pub agent: &'a [u8],
     pub netinit: &'a [u8],
     pub egress_client: &'a [u8],
+    pub entrypoint_runner: &'a [u8],
 }
 
 /// Inject the mvm runtime into `unpacked_root`, materialize it into `output` (a
@@ -37,10 +40,11 @@ pub fn inject_and_materialize(
     unpacked_root: &Path,
     output: &Path,
     label: &str,
+    entrypoint: Option<&OciEntrypointConfig>,
     prebuilt: Option<PrebuiltGuestBinaries<'_>>,
 ) -> Result<()> {
     let bins = resolve_guest_binaries(cache_root, prebuilt)?;
-    crate::oci_runtime_inject::inject_mvm_runtime(unpacked_root, &bins)
+    crate::oci_runtime_inject::inject_mvm_runtime(unpacked_root, &bins, entrypoint)
         .context("inject mvm runtime into OCI rootfs")?;
 
     // Measure AFTER injection so the ext4 sizing covers the baked agent/netinit.
@@ -96,9 +100,13 @@ fn resolve_guest_binaries(
 
     if let Some(p) = prebuilt {
         return crate::guest_agent_build::install_prebuilt_guest_binaries(
-            p.agent,
-            p.netinit,
-            p.egress_client,
+            GuestRuntimeBinaryBytes {
+                oci_init: p.oci_init,
+                agent: p.agent,
+                netinit: p.netinit,
+                egress_client: p.egress_client,
+                entrypoint_runner: p.entrypoint_runner,
+            },
             cache_root,
             version,
             arch,

--- a/crates/mvm-cli/build.rs
+++ b/crates/mvm-cli/build.rs
@@ -100,8 +100,8 @@ fn main() {
         );
     }
 
-    // Guest runtime binaries (agent + netinit + egress-client, guest arch =
-    // host arch). Embedded alongside the host bins so an end-user mvmctl with no
+    // Guest runtime binaries (OCI PID 1 + entrypoint runner + agent + netinit + egress-client,
+    // guest arch = host arch). Embedded alongside the host bins so an end-user mvmctl with no
     // source checkout can inject them into an OCI `run --image` rootfs. Built in
     // one cargo invocation; they ride the same `EMBEDDED` array and are looked
     // up by name. Honors MVM_SKIP_EMBED_BINARIES (zero-byte stubs) — a stub
@@ -115,7 +115,13 @@ fn main() {
             &bins_out,
         );
     }
-    for name in ["mvm-guest-agent", "mvm-guest-netinit", "mvm-egress-client"] {
+    for name in [
+        "mvm-oci-init",
+        "mvm-oci-entrypoint",
+        "mvm-guest-agent",
+        "mvm-guest-netinit",
+        "mvm-egress-client",
+    ] {
         let out_file = bins_out.join(name);
         if skip_embed {
             std::fs::write(&out_file, b"")
@@ -124,15 +130,10 @@ fn main() {
         let sha = sha256_hex(&out_file);
         entries.push((name.to_string(), out_file, sha));
     }
-    // Watch the guest source trees file-by-file, not as a directory. Cargo's
-    // directory-level `rerun-if-changed` does not reliably fire on a content
-    // edit to an existing file (only on add/remove), so a change to e.g. the
-    // guest agent's request handler would otherwise leave the *embedded* agent
-    // stale on an incremental build — `machine run --image` would then inject an
-    // out-of-date agent. Emitting one `rerun-if-changed` per file guarantees the
-    // cross-compile re-runs on any edit.
-    emit_rerun_for_tree(&workspace_root.join("crates/mvm-guest/src"));
-    emit_rerun_for_tree(&workspace_root.join("crates/mvm-guest-helpers/src"));
+    println!(
+        "cargo:rerun-if-changed={}",
+        workspace_root.join("crates/mvm-guest/src").display()
+    );
 
     let embedded_rs = render_embedded_rs(&entries);
     std::fs::write(out_dir.join("embedded.rs"), embedded_rs).unwrap();
@@ -154,29 +155,10 @@ fn main() {
         "cargo:rerun-if-changed={}",
         workspace_root.join("Cargo.lock").display()
     );
-    // Same file-by-file watch for the `mvm-build` lib the host bins link (a
-    // content edit there must re-cross-compile the embedded host bins).
-    emit_rerun_for_tree(&workspace_root.join("crates/mvm-build/src"));
-}
-
-/// Emit one `cargo:rerun-if-changed` per file under `root`, recursively. Unlike
-/// a single directory-level `rerun-if-changed` (which cargo does not reliably
-/// re-trigger on a content edit to an existing file), this forces the build
-/// script — and therefore the embedded-binary cross-compile — to re-run whenever
-/// any watched source file changes. Missing trees are silently skipped (the
-/// dir-level watch already fails soft the same way).
-fn emit_rerun_for_tree(root: &Path) {
-    let Ok(entries) = std::fs::read_dir(root) else {
-        return;
-    };
-    for entry in entries.flatten() {
-        let path = entry.path();
-        if path.is_dir() {
-            emit_rerun_for_tree(&path);
-        } else {
-            println!("cargo:rerun-if-changed={}", path.display());
-        }
-    }
+    println!(
+        "cargo:rerun-if-changed={}",
+        workspace_root.join("crates/mvm-build/src").display()
+    );
 }
 
 struct Pin {
@@ -343,7 +325,7 @@ fn run_cargo_zigbuild(
 fn run_guest_zigbuild(root: &Path, target_dir: &Path, target: &str, zig_pin: &str, out_dir: &Path) {
     eprintln!(
         "[build.rs] cargo zigbuild --release --target {target} -p mvm-guest \
-         --bin mvm-guest-agent --bin mvm-guest-netinit -p mvm-guest-helpers \
+         --bin mvm-oci-init --bin mvm-oci-entrypoint --bin mvm-guest-agent --bin mvm-guest-netinit -p mvm-guest-helpers \
          --bin mvm-egress-client --features mvm-guest/dev-shell"
     );
     let (cargo, rustc) = rustup_cargo_and_rustc(strip_glibc(target));
@@ -355,6 +337,10 @@ fn run_guest_zigbuild(root: &Path, target_dir: &Path, target: &str, zig_pin: &st
         target,
         "-p",
         "mvm-guest",
+        "--bin",
+        "mvm-oci-init",
+        "--bin",
+        "mvm-oci-entrypoint",
         "--bin",
         "mvm-guest-agent",
         "--bin",
@@ -383,7 +369,13 @@ fn run_guest_zigbuild(root: &Path, target_dir: &Path, target: &str, zig_pin: &st
         "cargo zigbuild failed for the guest agent"
     );
     let rel = target_dir.join(strip_glibc(target)).join("release");
-    for name in ["mvm-guest-agent", "mvm-guest-netinit", "mvm-egress-client"] {
+    for name in [
+        "mvm-oci-init",
+        "mvm-oci-entrypoint",
+        "mvm-guest-agent",
+        "mvm-guest-netinit",
+        "mvm-egress-client",
+    ] {
         let built = rel.join(name);
         let dest = out_dir.join(name);
         std::fs::copy(&built, &dest)

--- a/crates/mvm-cli/src/commands/image/mod.rs
+++ b/crates/mvm-cli/src/commands/image/mod.rs
@@ -8,6 +8,7 @@ use std::path::{Component, Path, PathBuf};
 use anyhow::{Context, Result, bail};
 use clap::{Args as ClapArgs, Subcommand};
 use flate2::read::GzDecoder;
+use mvm_build::oci_runtime_inject::OciEntrypointConfig;
 use mvm_build::rootfs::MaterializeExt4Input;
 use mvm_oci::{
     ImageReference, LayerDescriptor, LayerFetchOptions, LinuxPlatform, OciLayerFetcher,
@@ -311,20 +312,11 @@ pub(in crate::commands) fn oci_cache_root() -> PathBuf {
     PathBuf::from(mvm_core::config::mvm_cache_dir()).join("oci")
 }
 
-/// Bump when the injected OCI runtime (guest agent, netinit, or `/init`
-/// script) changes such that already-materialized rootfs images must be
-/// re-sealed. Folded with the crate version into [`oci_runtime_tag`]; a
-/// stale rootfs then re-materializes instead of booting an outdated agent.
-/// Epoch 1 introduces the dev-shell exec handler in the OCI agent. Epoch 2 adds
-/// the detached-workload handler — a rootfs sealed with an older agent would
-/// reject the run-detached request, so it must re-materialize.
-const OCI_RUNTIME_EPOCH: u32 = 2;
-
 /// Identity of the guest runtime the running mvmctl bakes into an OCI rootfs.
 /// Cheap and build-free (no agent cross-compile) so it can gate the cache-hit
 /// path without forcing a rebuild on hosts that only have a warm rootfs cache.
 fn oci_runtime_tag() -> String {
-    format!("{}.{}", env!("CARGO_PKG_VERSION"), OCI_RUNTIME_EPOCH)
+    env!("CARGO_PKG_VERSION").to_string()
 }
 
 /// Whether a cached image's materialized rootfs can be booted as-is: it must
@@ -334,16 +326,59 @@ fn cached_rootfs_is_current(cached: &CachedOciImage, runtime_tag: &str) -> bool 
     cached.rootfs_path.is_some() && cached.runtime_tag.as_deref() == Some(runtime_tag)
 }
 
+#[derive(Debug, Deserialize)]
+struct OciImageConfig {
+    #[serde(default)]
+    config: OciImageConfigInner,
+}
+
+#[derive(Debug, Default, Deserialize)]
+struct OciImageConfigInner {
+    #[serde(default, rename = "Entrypoint")]
+    entrypoint: Option<Vec<String>>,
+    #[serde(default, rename = "Cmd")]
+    cmd: Option<Vec<String>>,
+    #[serde(default, rename = "Env")]
+    env: Vec<String>,
+    #[serde(default, rename = "WorkingDir")]
+    working_dir: Option<String>,
+}
+
+fn oci_entrypoint_from_config_bytes(bytes: &[u8]) -> Result<Option<OciEntrypointConfig>> {
+    let config: OciImageConfig = serde_json::from_slice(bytes).context("parse OCI image config")?;
+    let mut argv = config.config.entrypoint.unwrap_or_default();
+    argv.extend(config.config.cmd.unwrap_or_default());
+    if argv.is_empty() {
+        return Ok(None);
+    }
+    Ok(Some(OciEntrypointConfig {
+        argv,
+        env: config.config.env,
+        working_dir: config.config.working_dir.filter(|dir| !dir.is_empty()),
+    }))
+}
+
+fn oci_entrypoint_from_cache_path(
+    cache_root: &Path,
+    config_path: Option<&str>,
+) -> Result<Option<OciEntrypointConfig>> {
+    let Some(config_path) = config_path else {
+        return Ok(None);
+    };
+    let path = safe_cache_path(cache_root, config_path)?;
+    let bytes = fs::read(&path).with_context(|| format!("read OCI config {}", path.display()))?;
+    oci_entrypoint_from_config_bytes(&bytes)
+}
+
 pub(in crate::commands) fn resolve_or_pull_run_image(
     cache_root: &Path,
     reference: &str,
     prod: bool,
 ) -> Result<ResolvedOciRunImage> {
-    // Rootfs materialization can fall back to a builder VM (a flat dir the
-    // in-process ext4 writer can't emit), and an abnormally-exited builder can
-    // orphan its gvproxy sidecar to the init process. `up` / `dev up` reap the
-    // previous run's corpses at startup; the run-image path is the other place
-    // a builder VM spawns, so give it the same sweep before we might add one.
+    // Rootfs materialization can fall back to a builder VM when the in-process
+    // ext4 writer cannot faithfully emit a tree. `up` / `dev up` reap previous
+    // helper processes at startup; the run-image path is the other place a
+    // builder VM can spawn, so give it the same sweep before we might add one.
     crate::commands::env::dev_vz::sweep_orphaned_vm_helpers_on_startup();
 
     // Local sources route to their own ingest; a registry reference falls
@@ -401,6 +436,8 @@ pub(in crate::commands) fn resolve_or_pull_run_image(
                     &unpacked_root,
                     &rootfs_path,
                     &image.reference,
+                    oci_entrypoint_from_cache_path(cache_root, image.config_path.as_deref())?
+                        .as_ref(),
                 )
                 .with_context(|| {
                     format!(
@@ -461,12 +498,14 @@ fn inject_runtime_and_materialize(
     unpacked_root: &Path,
     rootfs_abs: &Path,
     image_label: &str,
+    entrypoint: Option<&OciEntrypointConfig>,
 ) -> Result<()> {
     mvm_build::run_image::inject_and_materialize(
         cache_root,
         unpacked_root,
         rootfs_abs,
         image_label,
+        entrypoint,
         embedded_guest_binaries(),
     )
 }
@@ -483,9 +522,11 @@ fn embedded_guest_binaries() -> Option<mvm_build::run_image::PrebuiltGuestBinari
             .filter(|b| !b.is_empty())
     };
     Some(mvm_build::run_image::PrebuiltGuestBinaries {
+        oci_init: find("mvm-oci-init")?,
         agent: find("mvm-guest-agent")?,
         netinit: find("mvm-guest-netinit")?,
         egress_client: find("mvm-egress-client")?,
+        entrypoint_runner: find("mvm-oci-entrypoint")?,
     })
 }
 
@@ -573,11 +614,13 @@ fn ingest_archive_from_reader<R: Read>(
 
     let rootfs_rel = format!("rootfs/{manifest_hex}-{}/rootfs.ext4", oci_runtime_tag());
     let rootfs_abs = cache_root.join(&rootfs_rel);
+    let entrypoint = oci_entrypoint_from_config_bytes(&image.config_bytes)?;
     inject_runtime_and_materialize(
         cache_root,
         &unpacked_root,
         &rootfs_abs,
         &image.manifest_digest,
+        entrypoint.as_ref(),
     )?;
 
     let provenance = OciProvenance {
@@ -970,6 +1013,7 @@ fn pull_image_ref(
         &unpacked_root,
         &rootfs_abs,
         &image_ref.canonical(),
+        oci_entrypoint_from_cache_path(cache_root, config_path.as_deref())?.as_ref(),
     )?;
 
     let provenance = OciProvenance {
@@ -2358,5 +2402,48 @@ require_signatures = false
         let index = load_index(tmp.path()).expect("load index");
         assert_eq!(index.images.len(), 1);
         assert_eq!(index.images[0].reference, "docker.io/library/busybox:1");
+    }
+
+    #[test]
+    fn oci_entrypoint_combines_entrypoint_and_cmd_without_shell() {
+        let config = br#"{
+          "config": {
+            "Entrypoint": ["/usr/bin/python3", "-m", "app"],
+            "Cmd": ["--port", "8080"],
+            "Env": ["PATH=/custom/bin", "APP_ENV=prod"],
+            "WorkingDir": "/srv/app"
+          }
+        }"#;
+
+        let entrypoint = oci_entrypoint_from_config_bytes(config)
+            .expect("parse")
+            .expect("entrypoint present");
+
+        assert_eq!(
+            entrypoint.argv,
+            ["/usr/bin/python3", "-m", "app", "--port", "8080"]
+        );
+        assert_eq!(entrypoint.env, ["PATH=/custom/bin", "APP_ENV=prod"]);
+        assert_eq!(entrypoint.working_dir.as_deref(), Some("/srv/app"));
+    }
+
+    #[test]
+    fn oci_entrypoint_uses_cmd_when_entrypoint_absent() {
+        let config = br#"{"config":{"Cmd":["/bin/myapp","serve"]}}"#;
+
+        let entrypoint = oci_entrypoint_from_config_bytes(config)
+            .expect("parse")
+            .expect("cmd becomes argv");
+
+        assert_eq!(entrypoint.argv, ["/bin/myapp", "serve"]);
+    }
+
+    #[test]
+    fn oci_entrypoint_absent_for_scratch_config_without_cmd() {
+        let config = br#"{"architecture":"amd64","os":"linux","config":{}}"#;
+
+        let entrypoint = oci_entrypoint_from_config_bytes(config).expect("parse");
+
+        assert!(entrypoint.is_none());
     }
 }

--- a/crates/mvm-client/src/local.rs
+++ b/crates/mvm-client/src/local.rs
@@ -141,9 +141,9 @@ fn run_rootfs_output(name: &str) -> PathBuf {
 fn materialize_from_dir(dir: &Path, name: &str) -> Result<PathBuf> {
     let output = run_rootfs_output(name);
     let cache_root = PathBuf::from(mvm_core::config::mvm_cache_dir());
-    // `None`: this library carries no embedded guest binaries (only the mvmctl
-    // binary does), so it resolves them from the cache or a source checkout.
-    mvm_build::run_image::inject_and_materialize(&cache_root, dir, &output, name, None)
+    // The library carries no embedded guest binaries, so it resolves them from
+    // the cache or a source checkout.
+    mvm_build::run_image::inject_and_materialize(&cache_root, dir, &output, name, None, None)
         .map_err(backend_err)?;
     Ok(output)
 }

--- a/crates/mvm-guest/Cargo.toml
+++ b/crates/mvm-guest/Cargo.toml
@@ -53,6 +53,18 @@ path = "src/bin/mvm-verity-init.rs"
 name = "mvm-guest-netinit"
 path = "src/bin/mvm-guest-netinit.rs"
 
+# Static PID 1 injected into arbitrary OCI rootfs trees by `run --image`.
+# It performs the mvm boot/runtime setup with syscalls and direct process
+# spawns, so scratch/distroless images do not need `/bin/sh`, busybox, coreutils,
+# or an image-native init system.
+[[bin]]
+name = "mvm-oci-init"
+path = "src/bin/mvm-oci-init.rs"
+
+[[bin]]
+name = "mvm-oci-entrypoint"
+path = "src/bin/mvm-oci-entrypoint.rs"
+
 # Test-only probe used by `tests/seccomp_apply.rs` to verify that
 # tier allowlists actually deny what they claim. Not
 # selected by `nix/packages/mvm-guest-agent.nix`, so it never ships

--- a/crates/mvm-guest/src/bin/mvm-oci-entrypoint.rs
+++ b/crates/mvm-guest/src/bin/mvm-oci-entrypoint.rs
@@ -1,0 +1,84 @@
+//! Shell-free OCI entrypoint runner.
+//!
+//! The guest agent validates and executes this binary through the normal
+//! `/etc/mvm/entrypoint` contract. This runner then execs the OCI image's
+//! configured Entrypoint/Cmd argv directly, without `/bin/sh -c`.
+
+#[cfg(target_os = "linux")]
+mod linux {
+    use serde::Deserialize;
+    use std::os::unix::process::CommandExt;
+    use std::process::Command;
+
+    const CONFIG_PATH: &str = "/etc/mvm/oci-entrypoint.json";
+
+    #[derive(Debug, Deserialize)]
+    struct OciEntrypointConfig {
+        argv: Vec<String>,
+        #[serde(default)]
+        env: Vec<String>,
+        #[serde(default)]
+        working_dir: Option<String>,
+    }
+
+    pub fn main() {
+        let config = match read_config() {
+            Ok(config) => config,
+            Err(e) => {
+                eprintln!("mvm-oci-entrypoint: {e}");
+                std::process::exit(127);
+            }
+        };
+        if config.argv.is_empty() {
+            eprintln!("mvm-oci-entrypoint: OCI image declares no Entrypoint or Cmd");
+            std::process::exit(127);
+        }
+
+        let mut command = Command::new(&config.argv[0]);
+        command.args(&config.argv[1..]);
+        command.env_clear();
+        let mut has_path = false;
+        for item in &config.env {
+            if let Some((key, value)) = item.split_once('=') {
+                if key == "PATH" {
+                    has_path = true;
+                }
+                command.env(key, value);
+            }
+        }
+        if !has_path {
+            command.env(
+                "PATH",
+                "/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin",
+            );
+        }
+        if let Some(dir) = &config.working_dir
+            && !dir.is_empty()
+        {
+            command.current_dir(dir);
+        }
+
+        let err = command.exec();
+        eprintln!(
+            "mvm-oci-entrypoint: exec {:?}: {err}",
+            config.argv.first().map(String::as_str)
+        );
+        std::process::exit(127);
+    }
+
+    fn read_config() -> Result<OciEntrypointConfig, String> {
+        let bytes = std::fs::read(CONFIG_PATH).map_err(|e| format!("read {CONFIG_PATH}: {e}"))?;
+        serde_json::from_slice(&bytes).map_err(|e| format!("parse {CONFIG_PATH}: {e}"))
+    }
+}
+
+#[cfg(target_os = "linux")]
+fn main() {
+    linux::main();
+}
+
+#[cfg(not(target_os = "linux"))]
+fn main() {
+    eprintln!("mvm-oci-entrypoint is Linux-only");
+    std::process::exit(1);
+}

--- a/crates/mvm-guest/src/bin/mvm-oci-init.rs
+++ b/crates/mvm-guest/src/bin/mvm-oci-init.rs
@@ -300,10 +300,8 @@ mod linux {
             );
             return;
         }
-        let get_flags = libc::c_int::try_from(libc::SIOCGIFFLAGS)
-            .expect("SIOCGIFFLAGS fits libc ioctl request type");
-        let set_flags = libc::c_int::try_from(libc::SIOCSIFFLAGS)
-            .expect("SIOCSIFFLAGS fits libc ioctl request type");
+        let get_flags = libc::SIOCGIFFLAGS as libc::c_ulong;
+        let set_flags = libc::SIOCSIFFLAGS as libc::c_ulong;
         let mut ifr = IfReq::for_name("lo");
         let get_rc = unsafe { libc::ioctl(sock, get_flags, &mut ifr) };
         if get_rc == 0 {

--- a/crates/mvm-guest/src/bin/mvm-oci-init.rs
+++ b/crates/mvm-guest/src/bin/mvm-oci-init.rs
@@ -1,0 +1,398 @@
+//! PID 1 injected into arbitrary OCI rootfs trees.
+//!
+//! This binary must not depend on `/bin/sh`, busybox, coreutils, or a distro
+//! init system. It is statically linked and baked at `/init` so scratch,
+//! distroless, Alpine, Debian, and language-base images all get the same mvm
+//! vsock control plane.
+
+#[cfg(target_os = "linux")]
+mod linux {
+    use std::ffi::{CString, OsStr};
+    use std::fs;
+    use std::os::unix::ffi::OsStrExt;
+    use std::path::{Path, PathBuf};
+    use std::process::{Command, Stdio};
+    use std::time::Duration;
+
+    const AGENT_FALLBACK: &str = "/usr/local/bin/mvm-guest-agent";
+    const AGENT_OVERLAY: &str = "/mvm/runtime/agent";
+    const NETINIT_FALLBACK: &str = "/usr/local/bin/mvm-guest-netinit";
+    const NETINIT_OVERLAY: &str = "/mvm/runtime/netinit";
+    const EGRESS_CLIENT: &str = "/usr/local/bin/mvm-egress-client";
+
+    pub fn main() {
+        mount_pseudofs();
+        ensure_runtime_dirs();
+        mount_user_volumes();
+        provision_egress_ca();
+        provision_verb_grant();
+        run_one(resolve_exec([NETINIT_OVERLAY, NETINIT_FALLBACK]), "netinit");
+        if cmdline_has_flag("mvm.vsock_egress=1") {
+            bring_loopback_up();
+            spawn_one(Path::new(EGRESS_CLIENT), "egress-client");
+        }
+        spawn_one(
+            &resolve_exec([AGENT_OVERLAY, AGENT_FALLBACK])
+                .unwrap_or_else(|| PathBuf::from(AGENT_FALLBACK)),
+            "guest-agent",
+        );
+        idle_forever();
+    }
+
+    fn mount_pseudofs() {
+        mount_fs("proc", "/proc", "proc", 0, None);
+        mount_fs("sysfs", "/sys", "sysfs", 0, None);
+        mount_fs("devtmpfs", "/dev", "devtmpfs", 0, None);
+        mount_fs("devpts", "/dev/pts", "devpts", 0, None);
+        mount_fs(
+            "tmpfs",
+            "/run",
+            "tmpfs",
+            libc::MS_NOSUID | libc::MS_NODEV,
+            None,
+        );
+        mount_fs(
+            "tmpfs",
+            "/tmp",
+            "tmpfs",
+            libc::MS_NOSUID | libc::MS_NODEV,
+            None,
+        );
+    }
+
+    fn ensure_runtime_dirs() {
+        for path in [
+            "/proc",
+            "/sys",
+            "/dev",
+            "/dev/pts",
+            "/dev/shm",
+            "/run",
+            "/run/mvm",
+            "/tmp",
+            "/mvm/runtime",
+        ] {
+            if let Err(e) = fs::create_dir_all(path) {
+                eprintln!("mvm-oci-init: mkdir {path}: {e}");
+            }
+        }
+    }
+
+    fn mount_user_volumes() {
+        let Some(encoded) = cmdline_value("mvm.uvols") else {
+            return;
+        };
+        for item in encoded.split(';').filter(|s| !s.is_empty()) {
+            let mut parts = item.splitn(4, ':');
+            let (Some(tag), Some(path_hex), Some(mode), Some(kind)) =
+                (parts.next(), parts.next(), parts.next(), parts.next())
+            else {
+                eprintln!("mvm-oci-init: malformed user volume token");
+                continue;
+            };
+            let Ok(path_bytes) = hex_decode(path_hex) else {
+                eprintln!("mvm-oci-init: malformed user volume path");
+                continue;
+            };
+            let upath = PathBuf::from(OsStr::from_bytes(&path_bytes));
+            if kind == "blk" {
+                eprintln!(
+                    "mvm-oci-init: user disk volume for '{}' attached; guest auto-mount not wired",
+                    upath.display()
+                );
+                continue;
+            }
+            if let Err(e) = fs::create_dir_all(&upath) {
+                eprintln!("mvm-oci-init: mkdir user volume {}: {e}", upath.display());
+                continue;
+            }
+            let flags = if mode == "ro" { libc::MS_RDONLY } else { 0 };
+            mount_fs(tag, &upath, "virtiofs", flags, None);
+        }
+    }
+
+    fn provision_egress_ca() {
+        let Some(hex) = cmdline_value("mvm.egress_ca") else {
+            return;
+        };
+        let Ok(cert) = hex_decode(&hex) else {
+            eprintln!("mvm-oci-init: malformed egress CA token");
+            return;
+        };
+        let _ = fs::create_dir_all("/run/mvm");
+        if let Err(e) = fs::write("/run/mvm/egress-ca.crt", &cert) {
+            eprintln!("mvm-oci-init: write egress CA: {e}");
+            return;
+        }
+        let mut bundle = Vec::new();
+        for candidate in [
+            "/etc/ssl/certs/ca-certificates.crt",
+            "/etc/ssl/cert.pem",
+            "/etc/ssl/certs/ca-bundle.crt",
+        ] {
+            if let Ok(bytes) = fs::read(candidate) {
+                bundle.extend_from_slice(&bytes);
+                if !bundle.ends_with(b"\n") {
+                    bundle.push(b'\n');
+                }
+                break;
+            }
+        }
+        bundle.extend_from_slice(&cert);
+        if let Err(e) = fs::write("/run/mvm/ca-bundle.crt", bundle) {
+            eprintln!("mvm-oci-init: write CA bundle: {e}");
+        }
+    }
+
+    fn provision_verb_grant() {
+        let Some(hex) = cmdline_value("mvm.verb_grant") else {
+            return;
+        };
+        let Ok(grant) = hex_decode(&hex) else {
+            eprintln!("mvm-oci-init: malformed verb-grant token");
+            return;
+        };
+        let _ = fs::create_dir_all("/run/mvm");
+        if let Err(e) = fs::write("/run/mvm/verb-grant.json", grant) {
+            eprintln!("mvm-oci-init: write verb grant: {e}");
+        }
+    }
+
+    fn mount_fs(
+        source: impl AsRef<OsStr>,
+        target: impl AsRef<Path>,
+        fstype: &str,
+        flags: libc::c_ulong,
+        data: Option<&str>,
+    ) {
+        let source = match cstring_os(source.as_ref()) {
+            Some(s) => s,
+            None => return,
+        };
+        let target_path = target.as_ref();
+        if let Err(e) = fs::create_dir_all(target_path) {
+            eprintln!(
+                "mvm-oci-init: mkdir mount target {}: {e}",
+                target_path.display()
+            );
+            return;
+        }
+        let Some(target) = cstring_os(target_path.as_os_str()) else {
+            return;
+        };
+        let Some(fstype) = cstring_str(fstype) else {
+            return;
+        };
+        let data_c = data.and_then(cstring_str);
+        let data_ptr = data_c
+            .as_ref()
+            .map_or(std::ptr::null(), |s| s.as_ptr().cast::<libc::c_void>());
+        let rc = unsafe {
+            libc::mount(
+                source.as_ptr(),
+                target.as_ptr(),
+                fstype.as_ptr(),
+                flags,
+                data_ptr,
+            )
+        };
+        if rc != 0 {
+            let e = std::io::Error::last_os_error();
+            if e.raw_os_error() != Some(libc::EBUSY) {
+                eprintln!("mvm-oci-init: mount {}: {e}", target_path.display());
+            }
+        }
+    }
+
+    fn resolve_exec<const N: usize>(candidates: [&str; N]) -> Option<PathBuf> {
+        candidates
+            .into_iter()
+            .map(PathBuf::from)
+            .find(|p| is_executable(p))
+    }
+
+    fn is_executable(path: &Path) -> bool {
+        path.is_file()
+            && fs::metadata(path)
+                .map(|m| {
+                    use std::os::unix::fs::PermissionsExt;
+                    m.permissions().mode() & 0o111 != 0
+                })
+                .unwrap_or(false)
+    }
+
+    fn run_one(path: Option<PathBuf>, label: &str) {
+        let Some(path) = path else {
+            return;
+        };
+        match Command::new(&path)
+            .stdin(Stdio::null())
+            .stdout(Stdio::inherit())
+            .stderr(Stdio::inherit())
+            .status()
+        {
+            Ok(status) if status.success() => {}
+            Ok(status) => eprintln!("mvm-oci-init: {label} exited {status}"),
+            Err(e) => eprintln!("mvm-oci-init: run {label} at {}: {e}", path.display()),
+        }
+    }
+
+    fn spawn_one(path: &Path, label: &str) {
+        if !is_executable(path) {
+            eprintln!("mvm-oci-init: no executable {label} at {}", path.display());
+            return;
+        }
+        match Command::new(path)
+            .stdin(Stdio::null())
+            .stdout(Stdio::inherit())
+            .stderr(Stdio::inherit())
+            .spawn()
+        {
+            Ok(child) => eprintln!("mvm-oci-init: spawned {label} pid={}", child.id()),
+            Err(e) => eprintln!("mvm-oci-init: spawn {label} at {}: {e}", path.display()),
+        }
+    }
+
+    fn cmdline() -> String {
+        fs::read_to_string("/proc/cmdline").unwrap_or_default()
+    }
+
+    fn cmdline_value(key: &str) -> Option<String> {
+        let prefix = format!("{key}=");
+        cmdline()
+            .split_whitespace()
+            .find_map(|part| part.strip_prefix(&prefix).map(ToOwned::to_owned))
+    }
+
+    fn cmdline_has_flag(flag: &str) -> bool {
+        cmdline().split_whitespace().any(|part| part == flag)
+    }
+
+    fn hex_decode(input: &str) -> Result<Vec<u8>, ()> {
+        let bytes = input.as_bytes();
+        if !bytes.len().is_multiple_of(2) {
+            return Err(());
+        }
+        let mut out = Vec::with_capacity(bytes.len() / 2);
+        for pair in bytes.chunks_exact(2) {
+            let hi = hex_val(pair[0])?;
+            let lo = hex_val(pair[1])?;
+            out.push((hi << 4) | lo);
+        }
+        Ok(out)
+    }
+
+    fn hex_val(b: u8) -> Result<u8, ()> {
+        match b {
+            b'0'..=b'9' => Ok(b - b'0'),
+            b'a'..=b'f' => Ok(b - b'a' + 10),
+            b'A'..=b'F' => Ok(b - b'A' + 10),
+            _ => Err(()),
+        }
+    }
+
+    fn bring_loopback_up() {
+        let sock = unsafe { libc::socket(libc::AF_INET, libc::SOCK_DGRAM | libc::SOCK_CLOEXEC, 0) };
+        if sock < 0 {
+            eprintln!(
+                "mvm-oci-init: socket for loopback setup: {}",
+                std::io::Error::last_os_error()
+            );
+            return;
+        }
+        let get_flags = libc::c_int::try_from(libc::SIOCGIFFLAGS)
+            .expect("SIOCGIFFLAGS fits libc ioctl request type");
+        let set_flags = libc::c_int::try_from(libc::SIOCSIFFLAGS)
+            .expect("SIOCSIFFLAGS fits libc ioctl request type");
+        let mut ifr = IfReq::for_name("lo");
+        let get_rc = unsafe { libc::ioctl(sock, get_flags, &mut ifr) };
+        if get_rc == 0 {
+            ifr.flags |= (libc::IFF_UP | libc::IFF_RUNNING) as libc::c_short;
+            let set_rc = unsafe { libc::ioctl(sock, set_flags, &ifr) };
+            if set_rc != 0 {
+                eprintln!(
+                    "mvm-oci-init: bring loopback up: {}",
+                    std::io::Error::last_os_error()
+                );
+            }
+        } else {
+            eprintln!(
+                "mvm-oci-init: read loopback flags: {}",
+                std::io::Error::last_os_error()
+            );
+        }
+        unsafe {
+            libc::close(sock);
+        }
+    }
+
+    #[repr(C)]
+    struct IfReq {
+        name: [libc::c_char; libc::IFNAMSIZ],
+        flags: libc::c_short,
+        pad: [u8; 24],
+    }
+
+    impl IfReq {
+        fn for_name(name: &str) -> Self {
+            let mut ifr = Self {
+                name: [0; libc::IFNAMSIZ],
+                flags: 0,
+                pad: [0; 24],
+            };
+            for (dst, src) in ifr.name.iter_mut().zip(name.as_bytes()) {
+                *dst = *src as libc::c_char;
+            }
+            ifr
+        }
+    }
+
+    fn idle_forever() -> ! {
+        loop {
+            std::thread::sleep(Duration::from_secs(2_147_483_647));
+        }
+    }
+
+    fn cstring_str(s: &str) -> Option<CString> {
+        CString::new(s)
+            .map_err(|_| eprintln!("mvm-oci-init: string contains NUL"))
+            .ok()
+    }
+
+    fn cstring_os(s: &OsStr) -> Option<CString> {
+        CString::new(s.as_bytes())
+            .map_err(|_| eprintln!("mvm-oci-init: path contains NUL"))
+            .ok()
+    }
+
+    #[cfg(test)]
+    mod tests {
+        use super::*;
+
+        #[test]
+        fn hex_decode_accepts_lower_upper_and_rejects_bad_input() {
+            assert_eq!(hex_decode("2f62696e").unwrap(), b"/bin");
+            assert_eq!(hex_decode("2F").unwrap(), b"/");
+            assert!(hex_decode("0").is_err());
+            assert!(hex_decode("zz").is_err());
+        }
+
+        #[test]
+        fn ifreq_name_is_nul_padded() {
+            let ifr = IfReq::for_name("lo");
+            assert_eq!(ifr.name[0], b'l' as libc::c_char);
+            assert_eq!(ifr.name[1], b'o' as libc::c_char);
+            assert_eq!(ifr.name[2], 0);
+        }
+    }
+}
+
+#[cfg(target_os = "linux")]
+fn main() {
+    linux::main();
+}
+
+#[cfg(not(target_os = "linux"))]
+fn main() {
+    eprintln!("mvm-oci-init is Linux-only");
+}

--- a/crates/mvm-oci/src/archive.rs
+++ b/crates/mvm-oci/src/archive.rs
@@ -43,6 +43,8 @@ pub struct OciArchiveImage {
     pub manifest_digest: String,
     /// `sha256:<hex>` of the image config blob.
     pub config_digest: String,
+    /// Digest-verified image config JSON blob.
+    pub config_bytes: Vec<u8>,
     /// `architecture` from the image config (`amd64`, `arm64`, …).
     pub architecture: String,
     /// `os` from the image config — always `linux` (others are refused).
@@ -153,6 +155,7 @@ pub fn read_oci_archive<R: Read>(
     Ok(OciArchiveImage {
         manifest_digest,
         config_digest,
+        config_bytes: config_bytes.to_vec(),
         architecture: config.architecture,
         os: config.os,
         layers,


### PR DESCRIPTION
Summary:
- Replace the shell-script OCI /init with static guest runtime binaries so scratch/distroless OCI images do not need /bin/sh, busybox, or coreutils.
- Preserve OCI Entrypoint/Cmd/Env/WorkingDir by writing a runtime config and executing argv directly through a static entrypoint runner.
- Cache/embed the full guest runtime binary set and derive the OCI runtime tag from the Cargo package version.

Validation:
- cargo fmt --package mvm-build --package mvm-cli --package mvm-guest --package mvm-oci
- cargo test -p mvm-build oci_runtime_inject -- --nocapture
- cargo test -p mvm-build guest_agent_build -- --nocapture
- cargo test -p mvm-cli oci_entrypoint -- --nocapture
- cargo check -p mvm-cli --all-targets
- cargo check -p mvm-guest --bin mvm-oci-entrypoint
- cargo check -p mvm-guest --bin mvm-oci-init
- cargo clippy -p mvm-cli --all-targets -- -D warnings
- cargo clippy -p mvm-build --all-targets -- -D warnings
- cargo clippy -p mvm-guest --bins -- -D warnings
- git diff --cached --check
- cargo test -p mvm-oci --lib -- --nocapture