### PR TITLE
feat(mvm-cli): default machine run auto-prefers a verified runtime pack

### DIFF
--- a/crates/mvm-cli/src/commands/env/dev_vz/bootstrap.rs
+++ b/crates/mvm-cli/src/commands/env/dev_vz/bootstrap.rs
@@ -403,7 +403,7 @@ pub(in crate::commands) mod attested_builder_pack {
     /// carried by the embedded identity template, not by anything the operator
     /// configures — so it must be allowed independent of `pack-trust.json`.
     #[cfg(feature = "manifest-verify")]
-    pub(super) fn keyless_release_policy(base: &LocalPackPolicy) -> LocalPackPolicy {
+    pub(in crate::commands) fn keyless_release_policy(base: &LocalPackPolicy) -> LocalPackPolicy {
         let mut policy = base.clone();
         policy
             .allowed_channels
@@ -422,7 +422,7 @@ pub(in crate::commands) mod attested_builder_pack {
     /// valid bytes there, so this signals a caller bug rather than an
     /// untrusted-publisher condition.
     #[cfg(feature = "manifest-verify")]
-    pub(super) fn promote_staged_builder_pack(
+    pub(in crate::commands) fn promote_staged_builder_pack(
         staging: &Path,
         ctx: &PackVerifyCtx<'_>,
     ) -> Result<Option<VerifiedPackDir>> {

--- a/crates/mvm-cli/src/commands/vm/exec.rs
+++ b/crates/mvm-cli/src/commands/vm/exec.rs
@@ -741,18 +741,34 @@ fn build_exec_request(
                     }),
                 }
             }
-            (None, None) => {
-                ui::info("No --manifest specified; using bundled default microVM image.");
-                let (kernel_path, rootfs_path) =
-                    ensure_default_microvm_image(mvm_build::pipeline::BuildMode::Dev)?;
-                crate::exec::ImageSource::Prebuilt {
-                    kernel_path,
-                    rootfs_path,
-                    initrd_path: None,
-                    label: "default-microvm".to_string(),
-                    virtiofs_oci_root: None,
+            (None, None) => match super::runtime_pack::try_runtime_pack_image_source(prod) {
+                Some(src) => {
+                    let label = match &src {
+                        crate::exec::ImageSource::Prebuilt { label, .. } => label.clone(),
+                        crate::exec::ImageSource::Template(name) => name.clone(),
+                    };
+                    ui::info(&format!(
+                        "Instant boot from verified runtime pack ({label}); \
+                             skipping the build."
+                    ));
+                    src
                 }
-            }
+                None => {
+                    ui::info(
+                        "No verified runtime pack cached; building the bundled default \
+                             microVM in the builder VM.",
+                    );
+                    let (kernel_path, rootfs_path) =
+                        ensure_default_microvm_image(mvm_build::pipeline::BuildMode::Dev)?;
+                    crate::exec::ImageSource::Prebuilt {
+                        kernel_path,
+                        rootfs_path,
+                        initrd_path: None,
+                        label: "default-microvm".to_string(),
+                        virtiofs_oci_root: None,
+                    }
+                }
+            },
         }
     };
     Ok(crate::exec::ExecRequest {

--- a/crates/mvm-cli/src/commands/vm/runtime_pack.rs
+++ b/crates/mvm-cli/src/commands/vm/runtime_pack.rs
@@ -5,6 +5,13 @@
 //! silent fallback to a build. The kernel + rootfs paths it hands back are a
 //! plain `ImageSource::Prebuilt`, so verity sidecar auto-discovery and plan
 //! admission run unchanged, same as every other image source.
+//!
+//! The default (no `--manifest`/`--image`/`--runtime-pack`) launch path also
+//! consults the same cache as an accelerator: [`try_runtime_pack_image_source`]
+//! shares this module's trust construction but never refuses — a miss or a
+//! resolve error just means the accelerator isn't available, and the caller
+//! falls back to its own default (building the bundled microVM). Only the
+//! explicit `--runtime-pack` flag carries a fail-closed contract.
 
 use anyhow::Result;
 
@@ -20,50 +27,28 @@ use crate::exec::ImageSource;
 /// building or pulling an image. The caller asked for this specific source.
 #[cfg(feature = "manifest-verify")]
 pub(super) fn resolve_runtime_pack_image_source(prod: bool) -> Result<ImageSource> {
-    use std::collections::BTreeSet;
-
     use anyhow::Context;
-    use mvm_core::arch::GuestArch;
-    use mvm_core::config::mvm_keys_dir;
     use mvm_core::pack_cache::{PackVerifyCtx, resolve_pack};
-    use mvm_core::pack_trust::load_pack_trust_config;
-    use mvm_core::packs::{
-        HostCapability, LocalPackPolicy, PackBackend, PackKind, host_pack_policy_hash,
-    };
+    use mvm_core::packs::{PackBackend, PackKind};
 
-    let arch = GuestArch::host();
-    let trust = load_pack_trust_config(&mvm_keys_dir().join("pack-trust.json"))
-        .context("loading pack trust config for --runtime-pack resolution")?
-        .unwrap_or_default();
+    let inputs = trust::RuntimePackTrustInputs::load()
+        .context("building trust inputs for --runtime-pack resolution")?;
+    let ctx = PackVerifyCtx::keyless(&inputs.policy, &inputs.keyless, &inputs.trust);
 
-    // Same trust root a runtime pack from the project's own release pipeline
-    // carries: the operator's on-disk publishers unioned with the compiled-in
-    // release channels, so a stock binary accepts its own release packs with
-    // no operator config required. Mirrors the attested builder-pack
-    // acceleration path's policy construction.
-    let mut policy = LocalPackPolicy {
-        host_arch: arch,
-        backend: PackBackend::Hvf,
-        host_capabilities: BTreeSet::from([HostCapability("vsock".to_string())]),
-        policy_hash: host_pack_policy_hash(arch),
-        allowed_channels: trust.allowed_channels(),
-        now: chrono::Utc::now(),
-    };
-    policy
-        .allowed_channels
-        .extend(mvm_core::release_trust::release_channels());
-    let keyless = mvm_core::release_trust::release_keyless_trust(env!("CARGO_PKG_VERSION"));
-    let ctx = PackVerifyCtx::keyless(&policy, &keyless, &trust);
-
-    let dir = resolve_pack(PackKind::Runtime, arch, PackBackend::Hvf, &ctx)
-        .context("resolving verified runtime pack from the local cache")?
-        .ok_or_else(|| {
-            anyhow::anyhow!(
-                "--runtime-pack requested but no verified attested runtime pack for this host \
+    let dir = resolve_pack(
+        PackKind::Runtime,
+        inputs.policy.host_arch,
+        PackBackend::Hvf,
+        &ctx,
+    )
+    .context("resolving verified runtime pack from the local cache")?
+    .ok_or_else(|| {
+        anyhow::anyhow!(
+            "--runtime-pack requested but no verified attested runtime pack for this host \
                  is cached; produce/promote one first, or drop --runtime-pack to build or pull \
                  an image instead"
-            )
-        })?;
+        )
+    })?;
 
     mvm_core::audit_emit!(
         ImageFetch,
@@ -81,6 +66,115 @@ pub(super) fn resolve_runtime_pack_image_source(_prod: bool) -> Result<ImageSour
         "--runtime-pack requires an mvmctl build with keyless pack verification (the \
          manifest-verify feature); this binary was built without it"
     )
+}
+
+/// Fail-open sibling of [`resolve_runtime_pack_image_source`] for the *default*
+/// launch path (no `--manifest`/`--image`/`--runtime-pack`): an accelerator,
+/// not a source selection. A verified compatible runtime pack yields
+/// `Some(ImageSource::Prebuilt)` exactly as the explicit path would; a resolve
+/// miss (`Ok(None)`) or any error yields `None` — the caller falls back to
+/// building the bundled default microVM. Never returns an error.
+#[cfg(feature = "manifest-verify")]
+pub(super) fn try_runtime_pack_image_source(prod: bool) -> Option<ImageSource> {
+    use mvm_core::pack_cache::{PackVerifyCtx, resolve_pack};
+    use mvm_core::packs::{PackBackend, PackKind};
+
+    let inputs = match trust::RuntimePackTrustInputs::load() {
+        Ok(inputs) => inputs,
+        Err(e) => {
+            tracing::debug!(error = %e, "runtime-pack auto-prefer: trust setup unavailable");
+            return None;
+        }
+    };
+    let ctx = PackVerifyCtx::keyless(&inputs.policy, &inputs.keyless, &inputs.trust);
+
+    let dir = match resolve_pack(
+        PackKind::Runtime,
+        inputs.policy.host_arch,
+        PackBackend::Hvf,
+        &ctx,
+    ) {
+        Ok(Some(dir)) => dir,
+        Ok(None) => return None,
+        Err(e) => {
+            tracing::debug!(error = %e, "runtime-pack auto-prefer: no verified pack resolved");
+            return None;
+        }
+    };
+
+    mvm_core::audit_emit!(
+        ImageFetch,
+        "source=runtime_pack_autoprefer pack_hash={} prod={}",
+        dir.verified.pack_hash.as_str(),
+        prod
+    );
+
+    Some(runtime_pack_image_source(&dir))
+}
+
+#[cfg(not(feature = "manifest-verify"))]
+pub(super) fn try_runtime_pack_image_source(_prod: bool) -> Option<ImageSource> {
+    None
+}
+
+/// Trust construction shared by the fail-closed `--runtime-pack` resolver and
+/// the fail-open auto-prefer accelerator, so the two never drift apart on
+/// which packs a stock binary accepts.
+#[cfg(feature = "manifest-verify")]
+mod trust {
+    use std::collections::BTreeSet;
+
+    use anyhow::{Context, Result};
+    use mvm_core::config::mvm_keys_dir;
+    use mvm_core::pack_trust::{PackTrustConfig, load_pack_trust_config};
+    use mvm_core::packs::{
+        HostCapability, KeylessTrust, LocalPackPolicy, PackBackend, host_pack_policy_hash,
+    };
+    use mvm_core::release_trust;
+
+    /// Owned trust inputs a runtime pack resolution verifies against: the
+    /// local policy the host's arch/backend/capabilities select, and the
+    /// on-disk + compiled-in keyless trust roots a pack's cosign identity
+    /// must match. `PackVerifyCtx` borrows from these, so callers build one
+    /// instance per resolution and construct their own ctx from it.
+    pub(super) struct RuntimePackTrustInputs {
+        pub(super) policy: LocalPackPolicy,
+        pub(super) keyless: KeylessTrust,
+        pub(super) trust: PackTrustConfig,
+    }
+
+    impl RuntimePackTrustInputs {
+        pub(super) fn load() -> Result<Self> {
+            let arch = mvm_core::arch::GuestArch::host();
+            let trust = load_pack_trust_config(&mvm_keys_dir().join("pack-trust.json"))
+                .context("loading pack trust config for runtime pack resolution")?
+                .unwrap_or_default();
+
+            // Same trust root a runtime pack from the project's own release
+            // pipeline carries: the operator's on-disk publishers unioned with
+            // the compiled-in release channels, so a stock binary accepts its
+            // own release packs with no operator config required. Mirrors the
+            // attested builder-pack acceleration path's policy construction.
+            let mut policy = LocalPackPolicy {
+                host_arch: arch,
+                backend: PackBackend::Hvf,
+                host_capabilities: BTreeSet::from([HostCapability("vsock".to_string())]),
+                policy_hash: host_pack_policy_hash(arch),
+                allowed_channels: trust.allowed_channels(),
+                now: chrono::Utc::now(),
+            };
+            policy
+                .allowed_channels
+                .extend(release_trust::release_channels());
+            let keyless = release_trust::release_keyless_trust(env!("CARGO_PKG_VERSION"));
+
+            Ok(Self {
+                policy,
+                keyless,
+                trust,
+            })
+        }
+    }
 }
 
 /// Pure mapping from a verified runtime pack dir to the `ImageSource` the
@@ -180,5 +274,47 @@ mod tests {
             err.to_string()
                 .contains("no verified attested runtime pack")
         );
+    }
+
+    /// The auto-prefer accelerator is fail-open: the same cache miss that
+    /// makes `--runtime-pack` refuse must instead report absence here, so the
+    /// default `machine run` path falls back to building rather than
+    /// propagating an error.
+    #[test]
+    fn try_runtime_pack_returns_none_when_no_pack_is_cached() {
+        let cache = tempfile::TempDir::new().expect("cache tempdir");
+        let data = tempfile::TempDir::new().expect("data tempdir");
+        let mut env = TestEnv::new();
+        env.set("MVM_CACHE_DIR", cache.path());
+        env.set("MVM_DATA_DIR", data.path());
+
+        assert!(try_runtime_pack_image_source(false).is_none());
+    }
+
+    /// Both the fail-closed explicit resolver and the fail-open accelerator
+    /// bottom out in the same `RuntimePackTrustInputs::load()` construction —
+    /// verified here by exercising both against the same empty cache (so
+    /// they observe the identical miss) and then checking the shared helper
+    /// itself produces the host policy either call site would use.
+    #[test]
+    fn resolve_and_try_share_trust_inputs_construction() {
+        let cache = tempfile::TempDir::new().expect("cache tempdir");
+        let data = tempfile::TempDir::new().expect("data tempdir");
+        let mut env = TestEnv::new();
+        env.set("MVM_CACHE_DIR", cache.path());
+        env.set("MVM_DATA_DIR", data.path());
+
+        let explicit_err = resolve_runtime_pack_image_source(false)
+            .expect_err("no cached pack refuses the explicit path");
+        assert!(
+            explicit_err
+                .to_string()
+                .contains("no verified attested runtime pack")
+        );
+        assert!(try_runtime_pack_image_source(false).is_none());
+
+        let inputs = trust::RuntimePackTrustInputs::load().expect("trust inputs load");
+        assert_eq!(inputs.policy.backend, mvm_core::packs::PackBackend::Hvf);
+        assert_eq!(inputs.policy.host_arch, mvm_core::arch::GuestArch::host());
     }
 }


### PR DESCRIPTION
## What

When `machine run` is invoked with no image source (`--manifest`/`--image`/`--flake` all absent), the default path now **prefers a verified runtime pack** over building the bundled default microVM in the builder VM. If a verified pack is cached, it boots instantly:

> Instant boot from verified runtime pack (runtime-pack:<hash>); skipping the build.

If none is cached, it falls back to the existing builder-VM build path, byte-for-byte unchanged:

> No verified runtime pack cached; building the bundled default microVM in the builder VM.

## How

- New `try_runtime_pack_image_source(prod) -> Option<ImageSource>` in `commands/vm/runtime_pack.rs` — the **fail-OPEN** sibling of the explicit `--runtime-pack` path's `resolve_runtime_pack_image_source` (which stays fail-CLOSED). Shared ctx-building factored between them.
- Wired into `build_exec_request`'s `(None, None)` arm in `exec.rs`. The change is confined to `ImageSource` *resolution*; `run_inner`, admission, and verity are untouched.

## Security claims preserved

The resolved `ImageSource::Prebuilt { kernel=vmlinux, rootfs=rootfs.ext4 }` flows into the same downstream machinery: `probe_verity_sidecar` auto-discovers the pack's `rootfs.verity`/`rootfs.roothash` sidecar (**claim 3**), and the admit closure hashes the rootfs (**claim 8**). No admission/verity code changed.

## Note

Folds in a minimal, mechanical visibility fix in `env/dev_vz/bootstrap.rs`: `keyless_release_policy` + `promote_staged_builder_pack` widened `pub(super)` → `pub(in crate::commands)` (matching the enclosing module's own visibility). Their tests in the sibling `bootstrap_tests` module could not compile under `--features manifest-verify` — a latent break the default CI lane never exercised. Confirmed by reverting: reproduces `E0603`.

## Verification

- Builds clean both ways (`default` and `release-artifact-bootstrap,manifest-verify`), `MVM_SKIP_EMBED_BINARIES=1`.
- `mvm-cli` lib suite: 1173 passed / 1 ignored / 0 failed (incl. 5 new/updated `runtime_pack` tests).
- `cargo clippy -D warnings` clean on both feature sets; `cargo fmt --all --check` clean.