### PR TITLE
test(mvm-cli): lock in runtime-pack warm-standby eligibility

### DIFF
--- a/crates/mvm-cli/src/commands/pool.rs
+++ b/crates/mvm-cli/src/commands/pool.rs
@@ -521,6 +521,41 @@ mod tests {
     }
 
     #[test]
+    fn runtime_pack_prebuilt_config_is_warm_eligible_and_keys_on_pack_identity() {
+        // A verified runtime pack resolves to a prebuilt kernel + rootfs that
+        // land in an ordinary VmStartConfig — the same shape as eligible_cfg().
+        // The warm-pool compat is derived from that config, never from the image
+        // source, so a pack participates in the warm pool (and its saved-state
+        // snapshot) like any other admitted workload. This locks that in: a
+        // future refactor that special-cased the image source would break it.
+        let tmp = tempfile::tempdir().unwrap();
+        let kernel = tmp.path().join("vmlinux");
+        std::fs::write(&kernel, b"pack-kernel").unwrap();
+        let rootfs = tmp.path().join("rootfs.ext4");
+        std::fs::write(&rootfs, b"pack-rootfs").unwrap();
+
+        let mut cfg = eligible_cfg();
+        cfg.kernel_path = Some(kernel.to_string_lossy().into_owned());
+        cfg.rootfs_path = rootfs.to_string_lossy().into_owned();
+
+        // Firecracker keys on the pack's own vmlinux sha; the rootfs is attached
+        // at claim, so the base compat stays image-agnostic.
+        let fc = AnyBackend::from_hypervisor("firecracker");
+        let want = compat_for_launch(fc.as_vm_backend(), &cfg, None).unwrap();
+        assert_eq!(want.kernel_sha256, sha256_hex_of(b"pack-kernel"));
+        assert_eq!(want.vcpus, 2);
+        assert_eq!(want.mem_mib, 1024);
+        assert_eq!(want.image_sha256, None);
+
+        // libkrun boots its bundled kernel, so a pack claims any kernel-matched
+        // libkrun standby and attaches the pack rootfs on claim.
+        let lk = AnyBackend::from_hypervisor("libkrun");
+        let lk_want = compat_for_launch(lk.as_vm_backend(), &cfg, None).unwrap();
+        assert_eq!(lk_want.kernel_sha256, LIBKRUN_BUNDLED_KERNEL_ID);
+        assert_eq!(lk_want.image_sha256, None);
+    }
+
+    #[test]
     fn try_warm_claim_cold_without_admitted_plan() {
         let b = AnyBackend::from_hypervisor("libkrun");
         let mut c = eligible_cfg();

--- a/specs/plans/213-attested-fast-first-boot-packs.md
+++ b/specs/plans/213-attested-fast-first-boot-packs.md
@@ -154,9 +154,22 @@ The target user-visible shape is:
       pack and before injecting secrets.
 - [ ] Record snapshot derivation events with parent pack hash, backend id,
       backend version, memory/CPU shape, policy hash, and agent readiness proof.
-- [ ] Prefer warm-standby claim for prepared runs; fall back to local snapshot
+- [x] Prefer warm-standby claim for prepared runs; fall back to local snapshot
       restore; fall back to prepared cold direct boot; fall back to builder
       prepare only when required.
+      **Finding:** the warm-standby claim, replenish, and saved-state-snapshot
+      path is source-agnostic — it derives its compatibility key from the
+      resolved `VmStartConfig` (kernel + rootfs + resources), never from the
+      `ImageSource` variant. A pack-sourced prebuilt launch therefore already
+      participates in the warm pool and saved-state snapshot exactly like any
+      admitted workload, with no pack-specific plumbing; a dedicated
+      template-style snapshot path for prebuilt sources would duplicate the
+      existing saved-state standby mechanism (rejected as redundant). Locked in
+      by `runtime_pack_prebuilt_config_is_warm_eligible_and_keys_on_pack_identity`
+      (asserts a pack config keys on the pack's own kernel identity and stays
+      claim-eligible). Backend caveat: warm-pool participation is bounded by which
+      VMM implements the standby pool (libkrun today); extending it to the other
+      workload backends is separate backend work, not a pack concern.
 - [ ] Dispatch commands over the guest agent transport rather than SSH or
       network readiness.
 - [ ] Add tests proving prepared launches do not invoke the builder VM path.


### PR DESCRIPTION
## What

Locks in that a verified **runtime pack participates in the warm pool and saved-state snapshot** like any admitted workload — no pack-specific plumbing required.

## Finding

The warm-standby claim (`try_warm_claim`), replenish (`replenish_after_launch`), and saved-state-snapshot standby path derive their compatibility key (`compat_for_launch` → `StandbyCompat`) from the **resolved `VmStartConfig`** (kernel + rootfs + resources) — never from the `ImageSource` variant. A pack-sourced `ImageSource::Prebuilt` produces an ordinary admitted config (same shape as the existing `eligible_cfg()` test fixture: kernel + rootfs, tenant + signed plan, no volumes/virtiofs), so it already flows through the warm pool and saved-state snapshot with no code change.

A dedicated template-style snapshot path for prebuilt sources would **duplicate** the existing saved-state standby mechanism, so it was rejected as redundant (YAGNI).

## Change

- Regression test `runtime_pack_prebuilt_config_is_warm_eligible_and_keys_on_pack_identity`: a pack config keys on the pack's **own** kernel identity (firecracker → pack `vmlinux` sha; libkrun → the bundled-kernel constant, rootfs attached at claim) with an image-agnostic base compat, proving packs aren't gated out and a future image-source special-case would break the test.
- Plan §E: ticks the warm-standby item and records the finding + the backend caveat (warm-pool participation is bounded by which VMM implements the standby pool — libkrun today; extending it to the other workload backends is separate backend work, not a pack concern).

## Verification

- `cargo nextest run -p mvm-cli --lib pool::` — 16 passed incl. the new test.
- `cargo clippy -p mvm-cli --all-targets -D warnings` clean; `cargo fmt --all --check` clean.