### PR TITLE
ci(release): produce, keyless-sign, and publish attested runtime packs

### DIFF
--- a/.github/workflows/pack-signing-smoke.yml
+++ b/.github/workflows/pack-signing-smoke.yml
@@ -80,6 +80,34 @@ jobs:
             --manifest smoke/pack-manifest.json --bundle smoke/pack-manifest.json.bundle \
             --identity "${IDENTITY}" --issuer "https://token.actions.githubusercontent.com"
 
+      - name: Round-trip a runtime pack manifest through the Rust verifier
+        # The runtime pack the release pipeline publishes uses a distinct
+        # keyless producer (kernel + verity-sealed rootfs + verity/roothash
+        # sidecars) from the builder pack above. Produce one over dummy
+        # artifacts, sign its manifest with the same real `cosign sign-blob
+        # --new-bundle-format`, and verify through the same production
+        # primitive — so this smoke guards the runtime-pack signing path too.
+        run: |
+          set -euo pipefail
+          printf 'dummy-verity'   > smoke/rootfs.verity
+          printf '%064d' 0        > smoke/rootfs.roothash
+          cargo run --release -p mvm-build --example mvm-builder-pack-tool -- \
+            --kind runtime \
+            --vmlinux smoke/vmlinux --rootfs smoke/rootfs.ext4 \
+            --verity smoke/rootfs.verity --roothash smoke/rootfs.roothash \
+            --arch x86_64 --channel stable --keyless \
+            --identity "${IDENTITY}" --out-dir smoke --sbom smoke/sbom.txt \
+            --revocation-channel "https://example.test/rev.json"
+          mv smoke/manifest.json smoke/runtime-pack-manifest.json
+          cosign sign-blob \
+            --yes \
+            --new-bundle-format \
+            --bundle smoke/runtime-pack-manifest.json.bundle \
+            smoke/runtime-pack-manifest.json
+          cargo run --release -p mvm-core --example verify-pack-signature --features manifest-verify -- \
+            --manifest smoke/runtime-pack-manifest.json --bundle smoke/runtime-pack-manifest.json.bundle \
+            --identity "${IDENTITY}" --issuer "https://token.actions.githubusercontent.com"
+
       - name: Round-trip an image manifest through the dev-image verifier
         # The same Rust stack backs the dev-image download signature check
         # (image_verify::verify_manifest), which hard-fails on a bundle it

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -492,6 +492,12 @@ jobs:
       - name: Install Nix
         uses: DeterminateSystems/nix-installer-action@main
 
+      - name: Install Rust toolchain
+        uses: dtolnay/rust-toolchain@stable
+
+      - name: Install cosign
+        uses: sigstore/cosign-installer@v3
+
       - name: Build default microVM image (prod variant)
         env:
           ARCH: ${{ matrix.arch }}
@@ -500,19 +506,93 @@ jobs:
           nix build "./nix/images/default-tenant#packages.${SYSTEM}.default" \
             --impure --no-link --print-out-paths > /tmp/store-path.txt
           STORE_PATH=$(head -1 /tmp/store-path.txt)
+          echo "STORE_PATH=${STORE_PATH}" >> "$GITHUB_ENV"
           mkdir -p staging
           cp -L "$STORE_PATH/vmlinux"         "staging/default-microvm-vmlinux-${ARCH}"
           cp -L "$STORE_PATH/rootfs.ext4"     "staging/default-microvm-rootfs-${ARCH}.ext4"
           cp -L "$STORE_PATH/rootfs.verity"   "staging/default-microvm-rootfs-${ARCH}.verity"
           cp -L "$STORE_PATH/rootfs.roothash" "staging/default-microvm-rootfs-${ARCH}.roothash"
           cp -L "$STORE_PATH/mvm-meta.json"   "staging/default-microvm-meta-${ARCH}.json"
+
+      - name: Generate default microVM SBOM
+        env:
+          ARCH: ${{ matrix.arch }}
+        run: |
+          # Real store-path bill of materials for the default microVM closure —
+          # the attested runtime pack manifest's SBOM reference hashes this
+          # file's bytes.
+          nix-store --query --requisites "$STORE_PATH" > "staging/default-microvm-${ARCH}.sbom.txt"
+
+      - name: Produce and keyless-sign attested runtime pack manifest
+        # The runtime pack is an instant-launch accelerator, never a hard
+        # dependency. A Fulcio/Rekor/OIDC hiccup must not block the plain
+        # vmlinux/rootfs/verity publish above, so a signing failure here is
+        # tolerated: the job continues, no pack ships, and installed binaries
+        # fall back to the plain hash-verified download + verity-sealed boot.
+        continue-on-error: true
+        env:
+          ARCH: ${{ matrix.arch }}
+          REPOSITORY: ${{ github.repository }}
+          REF: ${{ github.ref }}
+        run: |
+          set -euo pipefail
+          # A runtime pack's keyless identity is the version tag ref cosign
+          # embeds in the certificate SAN and a released mvmctl reconstructs
+          # when verifying. Skip production unless the ref is a version tag
+          # whose version equals the crate version; anything else yields an
+          # identity no installed binary can reconstruct, so it would fail-open
+          # to the plain download. Skipping keeps that explicit.
+          if [[ "${REF}" != refs/tags/v* ]]; then
+            echo "::notice::${REF} is not a version tag; skipping attested runtime pack."
+            exit 0
+          fi
+          TAG_VERSION="${REF#refs/tags/v}"
+          CRATE_VERSION="$(cargo metadata --no-deps --format-version 1 \
+            | jq -r '.packages[] | select(.name=="mvm-cli") | .version')"
+          if [[ "${TAG_VERSION}" != "${CRATE_VERSION}" ]]; then
+            echo "::warning::tag ${REF} does not match crate version v${CRATE_VERSION}; installed binaries could not verify this pack — skipping attested runtime pack."
+            exit 0
+          fi
+          IDENTITY="https://github.com/${REPOSITORY}/.github/workflows/release.yml@${REF}"
+          REVOCATION_CHANNEL="https://github.com/${REPOSITORY}/releases/download/revocations/runtime-pack-revocations.json"
+          SBOM_URI="https://github.com/${REPOSITORY}/releases/download/${REF#refs/tags/}/default-microvm-${ARCH}.sbom.txt"
+          cargo run --release -p mvm-build --example mvm-builder-pack-tool -- \
+            --kind runtime \
+            --vmlinux "$STORE_PATH/vmlinux" --rootfs "$STORE_PATH/rootfs.ext4" \
+            --verity "$STORE_PATH/rootfs.verity" --roothash "$STORE_PATH/rootfs.roothash" \
+            --arch "$ARCH" --channel stable --keyless \
+            --identity "$IDENTITY" \
+            --out-dir staging \
+            --sbom "staging/default-microvm-${ARCH}.sbom.txt" \
+            --sbom-uri "$SBOM_URI" \
+            --revocation-channel "$REVOCATION_CHANNEL"
+          mv staging/manifest.json "staging/default-microvm-${ARCH}.pack-manifest.json"
+
+          # Keyless OIDC sign — --new-bundle-format emits the Sigstore bundle
+          # (with verificationMaterial) the installed binary's Rust verifier
+          # parses; the legacy --bundle format is not accepted by that stack.
+          cosign sign-blob \
+            --yes \
+            --new-bundle-format \
+            --bundle "staging/default-microvm-${ARCH}.pack-manifest.json.bundle" \
+            "staging/default-microvm-${ARCH}.pack-manifest.json"
+
+      - name: Generate default microVM checksums
+        env:
+          ARCH: ${{ matrix.arch }}
+        run: |
           cd staging
-          sha256sum "default-microvm-vmlinux-${ARCH}" \
-                    "default-microvm-rootfs-${ARCH}.ext4" \
-                    "default-microvm-rootfs-${ARCH}.verity" \
-                    "default-microvm-rootfs-${ARCH}.roothash" \
-                    "default-microvm-meta-${ARCH}.json" \
-            > "default-microvm-${ARCH}-checksums-sha256.txt"
+          FILES="default-microvm-vmlinux-${ARCH} \
+                 default-microvm-rootfs-${ARCH}.ext4 \
+                 default-microvm-rootfs-${ARCH}.verity \
+                 default-microvm-rootfs-${ARCH}.roothash \
+                 default-microvm-meta-${ARCH}.json"
+          # The attested pack is optional (signing may be skipped or fail); only
+          # checksum its files when they are actually present.
+          if [ -f "default-microvm-${ARCH}.pack-manifest.json.bundle" ]; then
+            FILES="$FILES default-microvm-${ARCH}.pack-manifest.json default-microvm-${ARCH}.pack-manifest.json.bundle default-microvm-${ARCH}.sbom.txt"
+          fi
+          sha256sum $FILES > "default-microvm-${ARCH}-checksums-sha256.txt"
 
       - name: Upload default microVM image artifacts
         uses: actions/upload-artifact@v7
@@ -524,6 +604,9 @@ jobs:
             staging/default-microvm-rootfs-${{ matrix.arch }}.verity
             staging/default-microvm-rootfs-${{ matrix.arch }}.roothash
             staging/default-microvm-meta-${{ matrix.arch }}.json
+            staging/default-microvm-${{ matrix.arch }}.pack-manifest.json
+            staging/default-microvm-${{ matrix.arch }}.pack-manifest.json.bundle
+            staging/default-microvm-${{ matrix.arch }}.sbom.txt
             staging/default-microvm-${{ matrix.arch }}-checksums-sha256.txt
 
   release:
@@ -653,6 +736,9 @@ jobs:
             artifacts/default-microvm-vmlinux-*
             artifacts/default-microvm-rootfs-*
             artifacts/default-microvm-meta-*
+            artifacts/default-microvm-*.pack-manifest.json
+            artifacts/default-microvm-*.pack-manifest.json.bundle
+            artifacts/default-microvm-*.sbom.txt
             artifacts/default-microvm-*-checksums-sha256.txt
             sbom.cdx.json
             sbom.cdx.json.bundle

--- a/packaging/release/verify-release-assets.sh
+++ b/packaging/release/verify-release-assets.sh
@@ -20,6 +20,7 @@ ASSETS_DIR=""
 TARGETS="aarch64-apple-darwin x86_64-unknown-linux-gnu aarch64-unknown-linux-gnu"
 # Keep in lockstep with the release.yml `builder-vm-image` matrix.
 BUILDER_ARCHES="aarch64 x86_64"
+RUNTIME_ARCHES="aarch64 x86_64"
 DO_COSIGN=0
 EXPECT_VERSION=""
 
@@ -28,6 +29,7 @@ while [ $# -gt 0 ]; do
     --assets-dir)     ASSETS_DIR="$2"; shift 2 ;;
     --targets)        TARGETS="$2"; shift 2 ;;
     --builder-arches) BUILDER_ARCHES="$2"; shift 2 ;;
+    --runtime-arches) RUNTIME_ARCHES="$2"; shift 2 ;;
     --cosign)         DO_COSIGN=1; shift ;;
     # Assert the packaged binary reports this version. Only the target that
     # matches the host can be executed; cross-arch targets are skipped (their
@@ -174,6 +176,44 @@ for arch in $BUILDER_ARCHES; do
     [ "$want" = "$got" ] || fail "[$arch] $f sha256 mismatch: recorded=$want actual=$got"
   done
   [ "$FAILED" = 0 ] && echo "ok: [$arch] attested builder pack complete (manifest + bundle + SBOM, checksummed)."
+done
+
+# Attested runtime packs follow the identical accelerator contract as builder
+# packs: COMPLETE (manifest + cosign bundle + SBOM, each listed in and matching
+# the per-arch default-microvm checksums manifest) or entirely ABSENT. A partial
+# runtime pack fails closed for the same reason — an installed binary would
+# fetch it, fail to verify, and silently fall back to the plain download.
+for arch in $RUNTIME_ARCHES; do
+  rp_manifest="default-microvm-${arch}.pack-manifest.json"
+  rp_bundle="default-microvm-${arch}.pack-manifest.json.bundle"
+  rp_sbom="default-microvm-${arch}.sbom.txt"
+  rp_checks="$ASSETS_DIR/default-microvm-${arch}-checksums-sha256.txt"
+
+  present=0
+  for f in "$rp_manifest" "$rp_bundle" "$rp_sbom"; do
+    [ -f "$ASSETS_DIR/$f" ] && present=$((present + 1))
+  done
+
+  if [ "$present" -eq 0 ]; then
+    echo "note: [$arch] no attested runtime pack published (accelerator absent) — ok"
+    continue
+  fi
+  if [ "$present" -ne 3 ]; then
+    fail "[$arch] partial attested runtime pack: manifest=$([ -f "$ASSETS_DIR/$rp_manifest" ] && echo y || echo n) bundle=$([ -f "$ASSETS_DIR/$rp_bundle" ] && echo y || echo n) sbom=$([ -f "$ASSETS_DIR/$rp_sbom" ] && echo y || echo n)"
+    continue
+  fi
+
+  [ -f "$rp_checks" ] || { fail "[$arch] default-microvm checksums manifest missing: default-microvm-${arch}-checksums-sha256.txt"; continue; }
+  for f in "$rp_manifest" "$rp_bundle" "$rp_sbom"; do
+    want=$(awk -v n="$f" '$2 == n { print $1 }' "$rp_checks" | head -1)
+    if [ -z "$want" ]; then
+      fail "[$arch] $f not listed in default-microvm-${arch}-checksums-sha256.txt"
+      continue
+    fi
+    got=$(sha256_of "$ASSETS_DIR/$f")
+    [ "$want" = "$got" ] || fail "[$arch] $f sha256 mismatch: recorded=$want actual=$got"
+  done
+  [ "$FAILED" = 0 ] && echo "ok: [$arch] attested runtime pack complete (manifest + bundle + SBOM, checksummed)."
 done
 
 if [ "$FAILED" = 0 ]; then

--- a/packaging/release/verify-release-assets.test.sh
+++ b/packaging/release/verify-release-assets.test.sh
@@ -11,6 +11,7 @@ HERE="$(cd "$(dirname "$0")" && pwd)"
 SCRIPT="$HERE/verify-release-assets.sh"
 TARGETS="aarch64-apple-darwin x86_64-unknown-linux-gnu aarch64-unknown-linux-gnu"
 BUILDER_ARCHES="aarch64 x86_64"
+RUNTIME_ARCHES="aarch64 x86_64"
 
 sha256_of() {
   if command -v sha256sum >/dev/null 2>&1; then sha256sum "$1" | awk '{print $1}';
@@ -47,6 +48,15 @@ build_valid_fixture() {
     : > "$dir/builder-vm-$arch-checksums-sha256.txt"
     for f in "builder-vm-$arch.pack-manifest.json" "builder-vm-$arch.pack-manifest.json.bundle" "builder-vm-$arch.sbom.txt"; do
       echo "$(sha256_of "$dir/$f")  $f" >> "$dir/builder-vm-$arch-checksums-sha256.txt"
+    done
+  done
+  for arch in $RUNTIME_ARCHES; do
+    printf '{"pack":"runtime-%s"}\n' "$arch" > "$dir/default-microvm-$arch.pack-manifest.json"
+    printf 'sigstore-bundle\n'              > "$dir/default-microvm-$arch.pack-manifest.json.bundle"
+    printf 'store-path-a\nstore-path-b\n'   > "$dir/default-microvm-$arch.sbom.txt"
+    : > "$dir/default-microvm-$arch-checksums-sha256.txt"
+    for f in "default-microvm-$arch.pack-manifest.json" "default-microvm-$arch.pack-manifest.json.bundle" "default-microvm-$arch.sbom.txt"; do
+      echo "$(sha256_of "$dir/$f")  $f" >> "$dir/default-microvm-$arch-checksums-sha256.txt"
     done
   done
   echo "$dir"
@@ -86,6 +96,25 @@ rm -rf "$d"
 d="$(build_valid_fixture)"
 : > "$d/builder-vm-aarch64-checksums-sha256.txt"   # empty: nothing listed
 if run "$d"; then bad "unlisted pack files must fail"; else ok "unlisted pack files fail closed"; fi
+rm -rf "$d"
+
+# 6. Partial runtime pack (bundle missing) → fail closed.
+d="$(build_valid_fixture)"
+rm -f "$d/default-microvm-aarch64.pack-manifest.json.bundle"
+if run "$d"; then bad "partial runtime pack (missing bundle) must fail"; else ok "partial runtime pack (missing bundle) fails closed"; fi
+rm -rf "$d"
+
+# 7. Absent runtime pack (all three gone) → pass (accelerator absent).
+d="$(build_valid_fixture)"
+rm -f "$d/default-microvm-x86_64.pack-manifest.json" "$d/default-microvm-x86_64.pack-manifest.json.bundle" \
+      "$d/default-microvm-x86_64.sbom.txt" "$d/default-microvm-x86_64-checksums-sha256.txt"
+if run "$d"; then ok "absent runtime pack is accepted"; else bad "absent runtime pack should be accepted"; fi
+rm -rf "$d"
+
+# 8. Complete runtime pack but checksum tampered → fail closed.
+d="$(build_valid_fixture)"
+printf 'tampered\n' > "$d/default-microvm-aarch64.pack-manifest.json"
+if run "$d"; then bad "checksum-mismatched runtime pack must fail"; else ok "checksum-mismatched runtime pack fails closed"; fi
 rm -rf "$d"
 
 echo "verify-release-assets pack-gate: $PASS passed, $FAILN failed"

--- a/specs/plans/213-attested-fast-first-boot-packs.md
+++ b/specs/plans/213-attested-fast-first-boot-packs.md
@@ -93,17 +93,25 @@ The target user-visible shape is:
 
 ### B. Release production and artifact publishing
 
-- [ ] Extend the release pipeline to produce runtime packs for each supported
+- [x] Extend the release pipeline to produce runtime packs for each supported
       host architecture/backend pair.
+      (`default-microvm` job in `.github/workflows/release.yml` produces +
+      keyless-signs + publishes a runtime pack — kernel + verity-sealed rootfs +
+      sidecars — per arch, on a version-tag push whose version matches the crate.)
 - [ ] Extend the release pipeline to produce builder packs for each supported
       builder architecture.
 - [ ] Include seeded Nix closures for common mvm build and materialization paths
       in builder packs.
-- [ ] Emit SBOMs, checksums, signatures, provenance, and pack manifests for every
+- [x] Emit SBOMs, checksums, signatures, provenance, and pack manifests for every
       release pack.
+      (Both the builder-pack and runtime-pack producers emit a store-path SBOM,
+      a per-arch checksums manifest listing the pack files, a cosign
+      `--new-bundle-format` signature bundle, and the pack manifest.)
 - [x] Add release verification checks that fail closed when any pack lacks a
       manifest, signature bundle, checksum, SBOM, or expected version metadata.
-      (builder-pack gate in `packaging/release/verify-release-assets.sh`)
+      (builder-pack **and** runtime-pack completeness gates in
+      `packaging/release/verify-release-assets.sh` — each pack must be COMPLETE
+      or entirely ABSENT; a partial or checksum-mismatched pack fails closed.)
 - [ ] Add a reproducibility verification job that rebuilds at least one published
       runtime pack and one published builder pack from source pins and compares
       output hashes.


### PR DESCRIPTION
## What

The release pipeline now produces, keyless-signs, and publishes an **attested runtime pack** per architecture — the last missing pack kind (builder packs already ship). A runtime pack is the instant-launch source for a default `machine run` (the auto-prefer path from PR #1575).

## How

The `default-microvm` release job already builds exactly what a runtime pack needs: `vmlinux` + a **verity-sealed** `rootfs.ext4` + `rootfs.verity` + `rootfs.roothash`. This adds to that job:

- Rust toolchain + cosign install, and exports `STORE_PATH` across steps.
- A store-path SBOM (`nix-store --query --requisites`).
- A produce-and-keyless-sign step mirroring the builder-pack flow: `mvm-builder-pack-tool --kind runtime --vmlinux/--rootfs/--verity/--roothash`, then `cosign sign-blob --new-bundle-format` (the only bundle format the Rust `sigstore-verify` stack accepts).
- Version-tag guard (skip unless the tag version equals the crate version, else the keyless identity is unreconstructable by installed binaries).
- Checksums + release-attach globs extended to the pack manifest, bundle, and SBOM.

Best-effort accelerator (`continue-on-error`): a Fulcio/Rekor/OIDC outage skips the pack, and the plain hash-verified images + verity-sealed boot still ship.

## Fail-closed gate

`verify-release-assets.sh` gains a **runtime-pack completeness gate** mirroring the builder-pack one: each pack is COMPLETE (manifest + cosign bundle + SBOM, each listed in and matching the per-arch checksums) or entirely ABSENT — a partial/checksum-mismatched pack fails closed, because an installed binary would fetch it, fail to verify, and silently fall back.

## Tests

- `verify-release-assets.test.sh`: **8 passed** (added runtime-pack partial/absent/tampered scenarios).
- `pack-signing-smoke.yml`: rounds a runtime pack through `build_keyless_runtime_pack` → real `cosign sign-blob --new-bundle-format` → the production `verify-pack-signature` verifier, guarding the distinct keyless runtime producer end to end.
- Runtime producer invocation exercised locally (`kind=runtime` manifest emitted); both workflow files validate as YAML.

Plan §B: ticks "produce runtime packs" + "emit SBOMs/checksums/signatures/manifests for every release pack" and records the dual completeness gate.