### PR TITLE
fix ext4 merge-queue determinism

### DIFF
--- a/crates/mvm-build/Cargo.toml
+++ b/crates/mvm-build/Cargo.toml
@@ -65,7 +65,7 @@ tar.workspace = true
 lzma-rs = "0.3"
 
 mvm-core.workspace = true
-mvm-ext4 = { workspace = true, optional = true }
+mvm-ext4.workspace = true
 # Read xattrs during the pure walk so a tree carrying attrs the writer can't
 # represent (e.g. `security.capability`) routes to the builder-VM fallback
 # instead of silently dropping them. Already in the mvmctl closure via mvm-oci.
@@ -157,7 +157,7 @@ manifest-verify = ["mvm-core/manifest-verify"]
 # In-process, pure-Rust ext4 materialization (no builder VM / mkfs). Off by
 # default so the mvmctl default closure does not gain `mvm-ext4` until the pure
 # path is the run-path default; enabled where `materialize_ext4_pure` is used.
-pure-mkfs = ["dep:mvm-ext4", "dep:xattr"]
+pure-mkfs = ["dep:xattr"]
 # Folded in with the mvm-egress-proxy bin. Off by default;
 # tests/dev enable it so the `mvm-egress-proxy` bin honors a
 # `MVM_EGRESS_ALLOWLIST=host1,host2` override. Production binaries (no

--- a/crates/mvm-build/src/oci_to_rootfs/ext4.rs
+++ b/crates/mvm-build/src/oci_to_rootfs/ext4.rs
@@ -1,39 +1,28 @@
 //! ext4 materialization from a staged rootfs.
 //!
-//! After [`crate::oci_to_rootfs::ImageStaging::apply_layer`] has
-//! populated a staging directory, this module produces the
-//! `rootfs.ext4` image that Firecracker / libkrun / Apple
-//! Container load as the guest's root device. Output is **byte-
-//! deterministic** for a given staged tree + options — this is
-//! load-bearing for the pull-time verity story: the verity
-//! sidecar generated next would otherwise differ across runs and
-//! defeat the per-digest verity cache.
+//! After [`crate::oci_to_rootfs::ImageStaging::apply_layer`] has populated a
+//! staging directory, this module produces the `rootfs.ext4` image that
+//! Firecracker / libkrun / Apple Container load as the guest's root device.
+//! Output is **byte-deterministic** for a given staged tree + options — this
+//! is load-bearing for the pull-time verity story: the verity sidecar
+//! generated next would otherwise differ across runs and defeat the per-digest
+//! verity cache.
 //!
-//! Determinism comes from pinning everything `mke2fs` randomizes
-//! by default:
-//!
-//! - `-U <uuid>` — filesystem UUID.
-//! - `-E hash_seed=<uuid>` — htree directory-hash seed (controls
-//!   dirent ordering inside a directory).
-//! - `SOURCE_DATE_EPOCH=0` and `E2FSPROGS_FAKE_TIME=0` env —
-//!   filesystem creation/check times and e2fsprogs current-time
-//!   fallbacks are pinned to the Unix epoch across versions.
-//! - `-E no_copy_xattrs` — xattrs are skipped uniformly (we don't
-//!   forward OCI xattrs through unpack today anyway).
-//! - `-b 4096` — fixed block size.
-//! - `-t ext4` — fixed FS type.
-//! - `-O ^has_journal,^orphan_file` — disable mutable ext4 features that can
-//!   carry run-specific bytes. The OCI rootfs is mounted read-only and sealed
-//!   with dm-verity, so a journal is not useful there.
+//! The default path now uses the in-process `mvm-ext4` writer, which is
+//! deterministic by construction and avoids `mke2fs` timestamp drift on newer
+//! e2fsprogs releases. Option combinations the pure writer does not model yet
+//! still fall back to `mke2fs` on Linux, keeping the existing escape hatch for
+//! non-default formatting requests.
 //!
 //! ## Host support
 //!
-//! `mke2fs` is Linux-only. On Linux, [`materialize_to_ext4`]
-//! shells out directly. On macOS / Windows the same function
-//! returns [`OciUnpackError::HostUnsupported`]; the CLI
-//! orchestrator routes the call through the libkrun builder VM.
-//! This module's job is to be the in-process orchestrator; the
-//! host-vs-VM routing decision lives one layer up.
+//! The public behavior stays Linux-only for now. On Linux,
+//! [`materialize_to_ext4`] uses the in-process writer for the default,
+//! deterministic profile and falls back to `mke2fs` for unsupported option
+//! combinations. On macOS / Windows the same function returns
+//! [`OciUnpackError::HostUnsupported`]; the CLI orchestrator routes the call
+//! through the libkrun builder VM. This module's job is to be the in-process
+//! orchestrator; the host-vs-VM routing decision lives one layer up.
 
 use crate::oci_to_rootfs::error::OciUnpackError;
 use crate::oci_to_rootfs::unpack::StagedRootfs;
@@ -108,8 +97,7 @@ impl Default for Mke2fsOptions {
 pub struct MaterializedRootfs {
     /// Absolute path to the ext4 image file on the host fs.
     pub path: PathBuf,
-    /// File size in bytes, exactly what was passed to
-    /// `mke2fs` via the preallocated output file.
+    /// File size in bytes.
     pub size_bytes: u64,
     /// Label written into the superblock (matches `options.label`).
     pub label: String,
@@ -159,29 +147,136 @@ pub fn materialize_to_ext4(
     output: &Path,
     options: &Mke2fsOptions,
 ) -> Result<MaterializedRootfs, OciUnpackError> {
-    let size_bytes = estimate_image_size(&staged.root, options)?;
-
     #[cfg(target_os = "linux")]
     {
+        if let Some(build_options) = in_process_build_options(options) {
+            return materialize_in_process(&staged.root, output, options, &build_options);
+        }
+
+        let size_bytes = estimate_image_size(&staged.root, options)?;
         prepare_output_file(output, size_bytes)?;
         run_mke2fs(&staged.root, output, options)?;
-        Ok(MaterializedRootfs {
-            path: output.to_path_buf(),
-            size_bytes,
-            label: options.label.clone(),
-            uuid: options.uuid.clone(),
-        })
+        Ok(materialized_rootfs(output, size_bytes, options))
     }
 
     #[cfg(not(target_os = "linux"))]
     {
         // Touch the variables to silence unused-variable warnings
         // while keeping the same function signature across hosts.
-        let _ = (output, size_bytes);
+        let _ = (staged, output, options);
         Err(OciUnpackError::HostUnsupported {
             operation: "ext4 image materialization (mke2fs)",
             reason: "mke2fs is Linux-only; the W1.5 CLI orchestrator routes this through the libkrun builder VM (ADR-050)",
         })
+    }
+}
+
+#[cfg(target_os = "linux")]
+fn materialized_rootfs(
+    output: &Path,
+    size_bytes: u64,
+    options: &Mke2fsOptions,
+) -> MaterializedRootfs {
+    MaterializedRootfs {
+        path: output.to_path_buf(),
+        size_bytes,
+        label: options.label.clone(),
+        uuid: options.uuid.clone(),
+    }
+}
+
+#[cfg(any(target_os = "linux", test))]
+fn in_process_build_options(options: &Mke2fsOptions) -> Option<mvm_ext4::BuildOptions> {
+    let defaults = Mke2fsOptions::default();
+    if options.hash_seed != defaults.hash_seed
+        || options.block_size != mvm_ext4::BLOCK_SIZE
+        || options.size_padding_bytes != defaults.size_padding_bytes
+        || options.source_date_epoch != defaults.source_date_epoch
+        || options.mke2fs_binary.is_some()
+    {
+        return None;
+    }
+
+    let uuid = uuid::Uuid::parse_str(&options.uuid).ok()?;
+    Some(
+        mvm_ext4::BuildOptions::default()
+            .with_uuid(*uuid.as_bytes())
+            .with_volume_name(options.label.as_bytes()),
+    )
+}
+
+#[cfg(target_os = "linux")]
+fn materialize_in_process(
+    staged_root: &Path,
+    output: &Path,
+    options: &Mke2fsOptions,
+    build_options: &mvm_ext4::BuildOptions,
+) -> Result<MaterializedRootfs, OciUnpackError> {
+    let nodes = collect_nodes(staged_root)?;
+    let image = mvm_ext4::build_image_with_options(&nodes, build_options).map_err(|e| {
+        OciUnpackError::Mke2fsFailed {
+            reason: format!("in-process ext4 build failed: {e}"),
+        }
+    })?;
+    if let Some(parent) = output.parent() {
+        std::fs::create_dir_all(parent)?;
+    }
+    std::fs::write(output, &image)?;
+    Ok(materialized_rootfs(output, image.len() as u64, options))
+}
+
+#[cfg(target_os = "linux")]
+fn collect_nodes(root: &Path) -> Result<Vec<mvm_ext4::Node>, OciUnpackError> {
+    let mut out = Vec::new();
+    let mut stack = vec![root.to_path_buf()];
+    while let Some(dir) = stack.pop() {
+        for entry in std::fs::read_dir(&dir)? {
+            let entry = entry?;
+            let path = entry.path();
+            let guest_path = guest_path_of(root, &path);
+            let ft = entry.file_type()?;
+            if ft.is_symlink() {
+                let target = std::fs::read_link(&path)?;
+                out.push(mvm_ext4::Node::Symlink {
+                    path: guest_path,
+                    target: target.to_string_lossy().into_owned(),
+                });
+            } else if ft.is_dir() {
+                out.push(mvm_ext4::Node::Dir {
+                    path: guest_path,
+                    mode: mode_of(&path, 0o755),
+                    xattrs: Vec::new(),
+                });
+                stack.push(path);
+            } else if ft.is_file() {
+                let data = std::fs::read(&path)?;
+                out.push(mvm_ext4::Node::File {
+                    path: guest_path,
+                    mode: mode_of(&path, 0o644),
+                    data,
+                    xattrs: Vec::new(),
+                });
+            }
+        }
+    }
+    Ok(out)
+}
+
+#[cfg(target_os = "linux")]
+fn guest_path_of(root: &Path, path: &Path) -> String {
+    match path.strip_prefix(root) {
+        Ok(rel) => format!("/{}", rel.to_string_lossy()),
+        Err(_) => format!("/{}", path.to_string_lossy()),
+    }
+}
+
+#[cfg(target_os = "linux")]
+fn mode_of(path: &Path, default: u16) -> u16 {
+    use std::os::unix::fs::PermissionsExt;
+
+    match std::fs::symlink_metadata(path) {
+        Ok(metadata) => (metadata.permissions().mode() & 0o7777) as u16,
+        Err(_) => default,
     }
 }
 
@@ -364,6 +459,20 @@ mod tests {
             disabled.contains(&"^orphan_file"),
             "orphan-file bytes are not stable enough for verity-cache determinism"
         );
+    }
+
+    #[test]
+    fn in_process_path_supports_default_options() {
+        assert!(in_process_build_options(&defaults()).is_some());
+    }
+
+    #[test]
+    fn in_process_path_rejects_non_default_block_size() {
+        let options = Mke2fsOptions {
+            block_size: 1024,
+            ..defaults()
+        };
+        assert!(in_process_build_options(&options).is_none());
     }
 
     #[test]

--- a/crates/mvm-build/tests/oci_ext4_materialization.rs
+++ b/crates/mvm-build/tests/oci_ext4_materialization.rs
@@ -42,12 +42,11 @@ fn materialize_produces_a_real_ext4_image() {
 
     assert!(output.exists(), "ext4 file must exist on disk");
     assert_eq!(mat.path, output);
-    assert!(mat.size_bytes >= 1024 * 1024);
+    assert!(mat.size_bytes > 0, "ext4 image must report a non-zero size");
     assert_eq!(mat.label, "mvm-rootfs");
     assert_eq!(mat.uuid, "00000000-0000-0000-0000-000000000001");
 
-    // Confirm the on-disk size matches what we told mke2fs to
-    // produce. mke2fs respects the file's preallocated length.
+    // Confirm the descriptor reflects the bytes we actually wrote.
     let meta = std::fs::metadata(&output).unwrap();
     assert_eq!(meta.len(), mat.size_bytes);
 
@@ -130,6 +129,6 @@ fn materialize_through_unpack_round_trip() {
     let output = out_dir.path().join("rootfs.ext4");
     let mat =
         materialize_to_ext4(&staged, &output, &Mke2fsOptions::default()).expect("materialize");
-    assert!(mat.size_bytes >= 1024 * 1024);
+    assert!(mat.size_bytes > 0, "ext4 image must report a non-zero size");
     let _ = staging_dir; // keep the staging dir alive for the duration
 }

--- a/crates/mvm-build/tests/oci_ext4_materialization.rs
+++ b/crates/mvm-build/tests/oci_ext4_materialization.rs
@@ -1,17 +1,9 @@
 //! Linux-gated integration test for [`mvm_build::oci_to_rootfs::
 //! materialize_to_ext4`].
 //!
-//! `mke2fs` is Linux-only and not present on macOS / Windows
-//! contributor laptops by default. These tests run when:
-//!
-//! 1. The target OS is Linux (`#[cfg(target_os = "linux")]`).
-//! 2. `mke2fs` is on `$PATH` at test time. If missing, the test
-//!    skips cleanly with a one-line note rather than failing —
-//!    contributor environments that don't have `e2fsprogs`
-//!    installed shouldn't see false negatives.
-//! 3. The CI lane that runs them is the same Linux KVM lane that
-//!    already runs the verity regression — the host has `mke2fs`
-//!    from `e2fsprogs` and the privilege bits `mke2fs -d` needs.
+//! The default deterministic path is in-process now, but the public API remains
+//! Linux-gated for parity with the builder-VM orchestration path. These tests
+//! therefore compile only on Linux.
 
 #![cfg(target_os = "linux")]
 
@@ -21,23 +13,6 @@ use mvm_build::oci_to_rootfs::{
 use std::io::Cursor;
 use std::path::Path;
 use tempfile::TempDir;
-
-/// Returns true when `mke2fs` is on `$PATH`. Tests that need a
-/// real `mke2fs` call this and exit early on miss.
-fn mke2fs_available() -> bool {
-    which::which("mke2fs").is_ok()
-}
-
-fn skip_if_no_mke2fs() -> bool {
-    if !mke2fs_available() {
-        eprintln!(
-            "mvm-oci ext4 integration test skipped: mke2fs not on $PATH \
-             (install e2fsprogs to run this test)"
-        );
-        return true;
-    }
-    false
-}
 
 fn write_file(root: &Path, rel: &str, bytes: &[u8]) {
     let dest = root.join(rel);
@@ -55,10 +30,6 @@ fn fresh_staging() -> (TempDir, ImageStaging) {
 
 #[test]
 fn materialize_produces_a_real_ext4_image() {
-    if skip_if_no_mke2fs() {
-        return;
-    }
-
     let (staging_dir, staging) = fresh_staging();
     write_file(staging_dir.path(), "etc/hello", b"hello mvm");
     write_file(staging_dir.path(), "bin/sh", b"#!/bin/sh\necho ok\n");
@@ -91,10 +62,6 @@ fn materialize_produces_a_real_ext4_image() {
 
 #[test]
 fn materialize_is_byte_deterministic_for_the_same_input() {
-    if skip_if_no_mke2fs() {
-        return;
-    }
-
     // The verity cache invariant: a single staging tree
     // materialised twice must produce byte-identical ext4 output.
     //
@@ -141,10 +108,6 @@ fn materialize_is_byte_deterministic_for_the_same_input() {
 
 #[test]
 fn materialize_through_unpack_round_trip() {
-    if skip_if_no_mke2fs() {
-        return;
-    }
-
     // Build a tar in memory, unpack it via ImageStaging, then
     // materialize. Covers the unpack → materialize boundary.
     use tar::{Builder, Header};

--- a/crates/mvm-ext4/src/lib.rs
+++ b/crates/mvm-ext4/src/lib.rs
@@ -183,6 +183,26 @@ pub struct Xattr {
     pub value: Vec<u8>,
 }
 
+/// Deterministic superblock metadata to stamp into a built image.
+#[derive(Debug, Clone, PartialEq, Eq, Default)]
+pub struct BuildOptions {
+    pub uuid: [u8; 16],
+    pub volume_name: [u8; 16],
+}
+
+impl BuildOptions {
+    pub fn with_uuid(mut self, uuid: [u8; 16]) -> Self {
+        self.uuid = uuid;
+        self
+    }
+
+    pub fn with_volume_name(mut self, volume_name: &[u8]) -> Self {
+        let len = volume_name.len().min(self.volume_name.len());
+        self.volume_name[..len].copy_from_slice(&volume_name[..len]);
+        self
+    }
+}
+
 impl Node {
     fn path(&self) -> &str {
         match self {
@@ -412,6 +432,13 @@ impl RegionAllocator {
 /// Build a deterministic read-only ext4 image containing `nodes` (plus the
 /// implicit root directory). Returns the raw image bytes.
 pub fn build_image(nodes: &[Node]) -> Result<Vec<u8>, Ext4Error> {
+    build_image_with_options(nodes, &BuildOptions::default())
+}
+
+pub fn build_image_with_options(
+    nodes: &[Node],
+    options: &BuildOptions,
+) -> Result<Vec<u8>, Ext4Error> {
     // 1. Deterministic order: sort by path so inode numbers + block layout are
     //    a pure function of the input set.
     let mut sorted: Vec<&Node> = nodes.iter().collect();
@@ -612,7 +639,7 @@ pub fn build_image(nodes: &[Node]) -> Result<Vec<u8>, Ext4Error> {
 
     // 8. Emit.
     let mut img = Image::new(layout.total_blocks);
-    write_superblock(&mut img, &layout);
+    write_superblock(&mut img, &layout, options);
     write_group_descs(&mut img, &layout, &planned);
     write_bitmaps(&mut img, &layout);
     write_backups(&mut img, &layout);
@@ -692,7 +719,7 @@ fn dirent_len(name_len: usize) -> usize {
     (8 + name_len + 3) & !3
 }
 
-fn write_superblock(img: &mut Image, layout: &Layout) {
+fn write_superblock(img: &mut Image, layout: &Layout, options: &BuildOptions) {
     let sb = 1024usize;
     let free_inodes = layout.inode_slots - layout.used_inodes;
 
@@ -715,8 +742,10 @@ fn write_superblock(img: &mut Image, layout: &Layout) {
     img.put_u16(sb + 0x58, INODE_SIZE); // s_inode_size
     img.put_u16(sb + 0x5A, 0); // s_block_group_nr (primary)
     img.put_u32(sb + 0x60, INCOMPAT_FILETYPE_EXTENTS); // s_feature_incompat
+    img.put_bytes(sb + 0x68, &options.uuid);
+    img.put_bytes(sb + 0x78, &options.volume_name);
     // s_feature_ro_compat left 0 (no sparse_super: SB+GDT backups sit at the
-    // start of every group), UUID + volume name left zero for determinism.
+    // start of every group).
 }
 
 fn write_group_descs(img: &mut Image, layout: &Layout, planned: &[Planned]) {
@@ -1067,5 +1096,28 @@ fn leaf_name(path: &str) -> String {
     match path.rfind('/') {
         Some(i) => path[i + 1..].to_string(),
         None => path.to_string(),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{BuildOptions, build_image_with_options};
+
+    #[test]
+    fn build_options_stamp_superblock_uuid_and_volume_name() {
+        let uuid = [
+            0x00, 0x11, 0x22, 0x33, 0x44, 0x55, 0x66, 0x77, 0x88, 0x99, 0xaa, 0xbb, 0xcc, 0xdd,
+            0xee, 0xff,
+        ];
+        let image = build_image_with_options(
+            &[],
+            &BuildOptions::default()
+                .with_uuid(uuid)
+                .with_volume_name(b"mvm-rootfs"),
+        )
+        .expect("build image");
+
+        assert_eq!(&image[1024 + 0x68..1024 + 0x78], &uuid);
+        assert_eq!(&image[1024 + 0x78..1024 + 0x82], b"mvm-rootfs");
     }
 }


### PR DESCRIPTION
## Summary

This switches the default OCI ext4 materialization path to the in-process deterministic `mvm-ext4` writer instead of relying on `mke2fs` for the default option set.

## Root Cause

Merge-group CI was failing `mvm-build::oci_ext4_materialization::materialize_is_byte_deterministic_for_the_same_input` even when the PR itself was green. On the Linux merge-group hosts, `mke2fs` was still emitting different superblock timestamps across two runs of the same staged tree, which changed the ext4 bytes and broke the verity-cache determinism invariant.

## What Changed

- route default `oci_to_rootfs::materialize_to_ext4` calls through the deterministic in-process ext4 writer
- keep the existing `mke2fs` path as a fallback for non-default option combinations
- add deterministic UUID and volume-label stamping support to `mvm-ext4`
- update the Linux integration test to reflect that the default path no longer requires `mke2fs`

## Impact

Default-path OCI ext4 materialization is now deterministic on merge-group Linux hosts, which should stop the queue-only red failure without removing the existing Linux fallback path for special-case formatting.

## Validation

- `cargo test -p mvm-ext4`
- `cargo test -p mvm-build --lib`
- `cargo clippy -p mvm-ext4 -p mvm-build --tests -- -D warnings`
