### PR TITLE
fix: accept OCI manifests without digest header

### DIFF
--- a/crates/mvm-oci/src/manifest.rs
+++ b/crates/mvm-oci/src/manifest.rs
@@ -241,16 +241,14 @@ impl ManifestFetcher for OciManifestFetcher {
             .bytes()
             .await
             .map_err(|e| OciError::Registry(format!("read manifest response body: {e}")))?;
-        let advertised_digest = response.docker_content_digest.ok_or_else(|| {
-            OciError::Registry("registry manifest response missing Docker-Content-Digest".into())
-        })?;
-
         let computed = format!("sha256:{}", hex::encode(Sha256::digest(&bytes)));
-        if computed != advertised_digest {
-            return Err(OciError::DigestMismatch {
-                expected: advertised_digest,
-                computed,
-            });
+        if let Some(advertised_digest) = response.docker_content_digest {
+            if computed != advertised_digest {
+                return Err(OciError::DigestMismatch {
+                    expected: advertised_digest,
+                    computed,
+                });
+            }
         }
         if let Some(pinned) = &reference.digest {
             if pinned != &computed {

--- a/crates/mvm-oci/tests/common/mod.rs
+++ b/crates/mvm-oci/tests/common/mod.rs
@@ -170,6 +170,36 @@ impl HermeticRegistry {
         digest
     }
 
+    /// Same as [`Self::register_manifest_with_digest_path`], but
+    /// deliberately omits the `Docker-Content-Digest` response
+    /// header to simulate registries that do not advertise it.
+    pub async fn register_manifest_without_digest_header_with_digest_path(
+        &self,
+        repository: &str,
+        reference: &str,
+        media_type: &str,
+        bytes: &[u8],
+    ) -> String {
+        let digest = format!("sha256:{}", hex::encode(Sha256::digest(bytes)));
+        self.register_manifest_route_without_digest_header(
+            repository,
+            reference,
+            media_type,
+            bytes,
+            digest.as_str(),
+            None,
+        );
+        self.register_manifest_route_without_digest_header(
+            repository,
+            digest.as_str(),
+            media_type,
+            bytes,
+            digest.as_str(),
+            None,
+        );
+        digest
+    }
+
     /// Serve a manifest only when the request includes the given
     /// bearer token. Also registers the digest path with the same
     /// auth requirement.
@@ -336,6 +366,31 @@ impl HermeticRegistry {
                 TestResponse::builder(200)
                     .header("Content-Type", media_type)
                     .header("Docker-Content-Digest", digest)
+                    .body_bytes(bytes.to_vec())
+                    .build(),
+            ),
+        );
+        self.server.register(match token {
+            Some(value) => route.with_bearer_auth(value),
+            None => route,
+        });
+    }
+
+    fn register_manifest_route_without_digest_header(
+        &self,
+        repository: &str,
+        reference: &str,
+        media_type: &str,
+        bytes: &[u8],
+        _digest: &str,
+        token: Option<&str>,
+    ) {
+        let route = Route::exact(
+            "GET",
+            format!("/v2/{repository}/manifests/{reference}"),
+            Responder::Static(
+                TestResponse::builder(200)
+                    .header("Content-Type", media_type)
                     .body_bytes(bytes.to_vec())
                     .build(),
             ),

--- a/crates/mvm-oci/tests/hermetic_registry.rs
+++ b/crates/mvm-oci/tests/hermetic_registry.rs
@@ -43,6 +43,57 @@ async fn manifest_fetch_round_trip_against_hermetic_registry() {
 }
 
 #[tokio::test]
+async fn manifest_fetch_accepts_missing_docker_content_digest_header() {
+    let reg = HermeticRegistry::start().await;
+    let layer_bytes = b"layer-payload-no-header";
+    let (manifest_bytes, _layer_digest) = minimal_image_manifest(layer_bytes, LAYER_MEDIA);
+
+    let manifest_digest = reg
+        .register_manifest_without_digest_header_with_digest_path(
+            "library/test",
+            "v1",
+            MANIFEST_MEDIA,
+            &manifest_bytes,
+        )
+        .await;
+
+    let fetcher = OciManifestFetcher::with_config(client_config_for(&reg));
+    let image = reg.image_ref("library/test", "v1");
+    let fetched = fetcher.fetch(&image).await.expect("manifest fetch");
+
+    assert_eq!(fetched.digest, manifest_digest);
+    assert_eq!(fetched.bytes, manifest_bytes);
+}
+
+#[tokio::test]
+async fn manifest_fetch_pinned_digest_still_verifies_without_digest_header() {
+    let reg = HermeticRegistry::start().await;
+    let layer_bytes = b"layer-payload-pinned-no-header";
+    let (manifest_bytes, _layer_digest) = minimal_image_manifest(layer_bytes, LAYER_MEDIA);
+
+    let manifest_digest = reg
+        .register_manifest_without_digest_header_with_digest_path(
+            "library/test",
+            "v1",
+            MANIFEST_MEDIA,
+            &manifest_bytes,
+        )
+        .await;
+
+    let fetcher = OciManifestFetcher::with_config(client_config_for(&reg));
+    let image = format!("{}/library/test@{manifest_digest}", reg.host())
+        .parse()
+        .expect("digest-pinned reference parses");
+    let fetched = fetcher.fetch(&image).await.expect("manifest fetch");
+
+    assert_eq!(fetched.digest, manifest_digest);
+    assert_eq!(
+        fetched.reference.digest.as_deref(),
+        Some(manifest_digest.as_str())
+    );
+}
+
+#[tokio::test]
 async fn manifest_fetch_uses_explicit_bearer_auth() {
     let reg = HermeticRegistry::start().await;
     let layer_bytes = b"private-layer";

--- a/specs/SPRINT.md
+++ b/specs/SPRINT.md
@@ -53,6 +53,14 @@ plan 25 sequences the work into six independently-shippable workstreams.
       `MVM_SKIP_EMBED_BINARIES=1 cargo nextest run --workspace` (6987/6987);
       `MVM_SKIP_EMBED_BINARIES=1 cargo clippy --workspace --all-targets -- -D
       warnings` green.
+- [x] 2026-07-08 OCI manifest fetch compatibility: `mvm-oci` no longer
+      requires registries to send `Docker-Content-Digest` on manifest GET
+      responses. It now always computes the SHA-256 over the returned bytes,
+      still rejects mismatches when the registry *does* advertise a digest, and
+      still enforces any caller-pinned `@sha256:...` reference. Validation:
+      `cargo test -p mvm-oci manifest_fetch_accepts_missing_docker_content_digest_header`;
+      `cargo test -p mvm-oci manifest_fetch_pinned_digest_still_verifies_without_digest_header`;
+      `cargo clippy -p mvm-oci --tests -- -D warnings`.
 - [x] 2026-07-08 Plan 213 §I builder-pack revocation consumer: the installed
       attested builder-pack path now refreshes a signed
       `pack-revocations.json` from the `revocations` release, caches it under


### PR DESCRIPTION
## What changed
- accept OCI manifest responses that omit `Docker-Content-Digest`
- keep digest verification fail-closed when the header is present
- keep pinned `@sha256:...` references enforced even without the header
- add hermetic registry coverage for header-less manifest fetches
- record the fix in `specs/SPRINT.md`

## Why
Some registries serve valid manifest bytes without the `Docker-Content-Digest` response header. The previous fetch path treated that header as mandatory and rejected otherwise valid pulls, which broke `machine run --image alpine` and similar OCI flows.

## Impact
This restores compatibility with registries that omit the header without weakening integrity checks for advertised or pinned digests.

## Validation
- `CARGO_TARGET_DIR=/tmp/mvm-oci-manifest-wt-target CARGO_HOME=/tmp/mvm-oci-manifest-wt-cargo MVM_DATA_DIR=/tmp/mvm-oci-manifest-wt-data cargo test -p mvm-oci`
- `CARGO_TARGET_DIR=/tmp/mvm-oci-manifest-wt-target CARGO_HOME=/tmp/mvm-oci-manifest-wt-cargo MVM_DATA_DIR=/tmp/mvm-oci-manifest-wt-data cargo clippy -p mvm-oci --tests -- -D warnings`
