### PR TITLE
fix: unblock in-process HVF boots through the MvmClient facade

### DIFF
--- a/crates/mvm-client/src/local.rs
+++ b/crates/mvm-client/src/local.rs
@@ -143,8 +143,10 @@ fn materialize_from_dir(dir: &Path, name: &str) -> Result<PathBuf> {
     let cache_root = PathBuf::from(mvm_core::config::mvm_cache_dir());
     // The library carries no embedded guest binaries, so it resolves them from
     // the cache or a source checkout.
+    // `{:#}` keeps the anyhow context chain — the top context alone
+    // ("build guest agent binaries…") hides the actionable root cause.
     mvm_build::run_image::inject_and_materialize(&cache_root, dir, &output, name, None, None)
-        .map_err(backend_err)?;
+        .map_err(|e| backend_err(format!("{e:#}")))?;
     Ok(output)
 }
 
@@ -245,12 +247,30 @@ impl MvmClient for LocalBackend {
         let rootfs = resolve_local_rootfs(&spec.image, &spec.name).await?;
         let (verity_path, roothash) = host_verity_sidecars(&rootfs);
 
+        // libkrun/Vz/mock carry their own kernel; HVF boots an explicit
+        // arm64 kernel Image. Resolve it from the per-arch workload-kernel
+        // cache the CLI's run path populates — the facade stays
+        // cache-hit-or-error; the heavier build/fetch flows are CLI concerns.
+        let kernel_path = if self.backend.name() == "hvf" {
+            let cache = PathBuf::from(mvm_core::config::mvm_cache_dir());
+            let arch = mvm_core::arch::GuestArch::host().to_string();
+            let path = mvm_build::kernel_fetch::cached_kernel_path(&cache, &arch, "workload");
+            if !path.exists() {
+                return Err(backend_err(format!(
+                    "hvf needs a workload kernel at {} — run a `mvmctl machine run` once \
+                     (or `mvmctl build kernel build`) to populate the cache",
+                    path.display()
+                )));
+            }
+            Some(path)
+        } else {
+            None
+        };
+
         let req = LocalRunRequest {
             name: spec.name.clone(),
             rootfs_path: rootfs,
-            // libkrun/Vz/mock carry their own kernel; a Firecracker local run
-            // that needs an explicit kernel path is a later slice.
-            kernel_path: None,
+            kernel_path,
             verity_path: verity_path.map(PathBuf::from),
             roothash,
             cpus: spec.cpus,
@@ -264,6 +284,8 @@ impl MvmClient for LocalBackend {
         // `~/.mvm/keys/`.
         let ledger = InMemoryNonceLedger::new();
         let clock = SystemClock;
+        // `{:#}` keeps the anyhow context chain — "backend start after
+        // signed-plan admission" alone hides the actionable root cause.
         let started = admit_and_boot_local(
             &self.backend,
             &req,
@@ -273,7 +295,7 @@ impl MvmClient for LocalBackend {
                 host_signer_keys_dir: None,
             },
         )
-        .map_err(backend_err)?;
+        .map_err(|e| backend_err(format!("{e:#}")))?;
 
         Ok(MachineState {
             id: MachineId(started.vm_id.0),

--- a/crates/mvm-guest/src/bin/mvm-oci-init.rs
+++ b/crates/mvm-guest/src/bin/mvm-oci-init.rs
@@ -300,8 +300,10 @@ mod linux {
             );
             return;
         }
-        let get_flags = libc::SIOCGIFFLAGS as libc::c_ulong;
-        let set_flags = libc::SIOCSIFFLAGS as libc::c_ulong;
+        // libc's ioctl request type differs per target (c_ulong on gnu,
+        // c_int on musl) — `as _` defers to whichever this libc declares.
+        let get_flags = libc::SIOCGIFFLAGS as _;
+        let set_flags = libc::SIOCSIFFLAGS as _;
         let mut ifr = IfReq::for_name("lo");
         let get_rc = unsafe { libc::ioctl(sock, get_flags, &mut ifr) };
         if get_rc == 0 {


### PR DESCRIPTION
## Summary

Three fixes that make `LocalBackend::run_machine` boot a real HVF microVM in-process. Found by driving the facade end-to-end from **mvm-studio** (its ADR-0003 real-boot smoke test); each was hit, fixed, and re-verified empirically. With these, a UI click boots a live Linux 6.12.87 microVM in ~200 ms.

### 1. musl guest cross-compile broken (`mvm-oci-init`)
`libc::ioctl` request flags were cast to `c_ulong`, but libc's Ioctl type is `c_int` on musl targets — every source-checkout guest-agent build failed with E0308 inside cargo-zigbuild. `as _` defers to whichever type the target's libc declares.

### 2. HVF boots had no kernel (`LocalBackend`)
`run_machine` passed `kernel_path: None` (correct for libkrun/Vz/mock, which carry their own kernel), but HVF — the macOS-26 default backend — requires an explicit arm64 kernel Image. Resolve it from the per-arch workload-kernel cache the CLI populates (`~/.cache/mvm/builder-vm/<arch>/kernels/workload/vmlinux`), cache-hit-or-error with an actionable message. The heavier build/fetch flows stay CLI concerns.

### 3. Error chains flattened (`LocalBackend`)
Two `map_err(backend_err)` sites reduced anyhow chains to their top context — callers saw `"build guest agent binaries from the source checkout"` with no hint of the E0308 underneath, and `"backend start after signed-plan admission"` with no hint of the missing kernel. `{:#}` formatting keeps the chain in `MvmError::Backend`.

## Test plan

- `cargo check -p mvm-client` green on this branch.
- Empirical, on an Apple-Silicon macOS-26 host: `mvmctl machine run --image public.ecr.aws/docker/library/alpine:latest -- echo ok` succeeds (guest binaries cross-compile after fix 1); mvm-studio's facade smoke then boots/lists/logs/stops/removes a live HVF microVM (fixes 2–3), and the same flow works interactively from the studio UI.

## Related gaps observed (not addressed here, happy to file issues)

- `docker.io` refs fail in mvm-oci: the registry host is resolved verbatim and `https://docker.io/v2/...` 302s to a marketing page — needs the standard `docker.io → registry-1.docker.io` alias.
- The facade's registry pull doesn't reuse the OCI cache (repeat runs re-pull; anonymous rate limits bite).
- `resolve_or_build_guest_binaries` inherits `RUSTUP_TOOLCHAIN`/`CARGO*` when the caller was itself launched by cargo (e.g. `cargo test`/`cargo tauri dev`), pinning the nested build to a toolchain that may lack the musl target — the child env should be scrubbed.
