### PR TITLE
Fix Docker Hub OCI manifest fetches

### DIFF
--- a/crates/mvm-oci/src/manifest.rs
+++ b/crates/mvm-oci/src/manifest.rs
@@ -263,8 +263,13 @@ impl ManifestFetcher for OciManifestFetcher {
         // for the caller's downstream branching (image vs index).
         // This parse is purely diagnostic; the *digest* check
         // above is the load-bearing one.
-        let manifest: OciManifest = serde_json::from_slice(&bytes)
-            .map_err(|e| OciError::Registry(format!("parse manifest after digest verify: {e}")))?;
+        let manifest: OciManifest = serde_json::from_slice(&bytes).map_err(|e| {
+            OciError::Registry(format!(
+                "parse manifest after digest verify: {e}; content_type={:?}; bytes={}",
+                response.content_type,
+                bytes.len()
+            ))
+        })?;
         let media_type = response
             .content_type
             .unwrap_or_else(|| manifest_media_type(&manifest).to_string());

--- a/crates/mvm-oci/src/registry.rs
+++ b/crates/mvm-oci/src/registry.rs
@@ -255,7 +255,15 @@ impl RegistryClient {
                 }
             }
         };
-        format!("{scheme}://{}{}", reference.registry, path)
+        format!("{scheme}://{}{}", endpoint_host(reference), path)
+    }
+}
+
+fn endpoint_host(reference: &ImageReference) -> &str {
+    if reference.registry == "docker.io" {
+        "registry-1.docker.io"
+    } else {
+        &reference.registry
     }
 }
 
@@ -340,5 +348,23 @@ mod tests {
             parsed.scope.as_deref(),
             Some("repository:library/alpine:pull")
         );
+    }
+
+    #[test]
+    fn docker_hub_canonical_registry_uses_registry_api_host() {
+        let reference: ImageReference = "docker.io/library/alpine:latest"
+            .parse()
+            .expect("reference parses");
+
+        assert_eq!(endpoint_host(&reference), "registry-1.docker.io");
+    }
+
+    #[test]
+    fn non_docker_registry_uses_reference_host() {
+        let reference: ImageReference = "ghcr.io/example/app:latest"
+            .parse()
+            .expect("reference parses");
+
+        assert_eq!(endpoint_host(&reference), "ghcr.io");
     }
 }

--- a/specs/SPRINT.md
+++ b/specs/SPRINT.md
@@ -61,6 +61,17 @@ plan 25 sequences the work into six independently-shippable workstreams.
       `cargo test -p mvm-oci manifest_fetch_accepts_missing_docker_content_digest_header`;
       `cargo test -p mvm-oci manifest_fetch_pinned_digest_still_verifies_without_digest_header`;
       `cargo clippy -p mvm-oci --tests -- -D warnings`.
+- [x] 2026-07-09 Docker Hub OCI manifest endpoint compatibility: `mvm-oci`
+      now keeps `docker.io/...` as the canonical image identity but sends
+      Docker Hub registry API requests to `registry-1.docker.io`, avoiding the
+      HTML response from `https://docker.io/v2/...` that previously surfaced as
+      `parse manifest after digest verify: expected value at line 1 column 1`.
+      Manifest parse failures also include response content type and byte count
+      without echoing arbitrary registry response bodies. Validation:
+      `cargo fmt --all --check`; `cargo test -p mvm-oci`; `cargo clippy -p
+      mvm-oci --tests -- -D warnings`; `MVM_SKIP_EMBED_BINARIES=1 cargo run
+      --release -- machine run --image alpine -it -- /bin/sh` reached the
+      Alpine shell.
 - [x] 2026-07-08 Plan 213 §I builder-pack revocation consumer: the installed
       attested builder-pack path now refreshes a signed
       `pack-revocations.json` from the `revocations` release, caches it under


### PR DESCRIPTION
## Summary
- route canonical docker.io image references to Docker Hub's registry API host registry-1.docker.io for HTTP requests
- keep docker.io/... as the canonical image identity for cache/provenance behavior
- add safer manifest parse-failure context with content type and byte count only
- record the fix and validation in specs/SPRINT.md

## Validation
- cargo fmt --all --check
- cargo check -p mvm-oci
- cargo test -p mvm-oci
- cargo clippy -p mvm-oci --tests -- -D warnings
- MVM_SKIP_EMBED_BINARIES=1 cargo run --release -- machine run --image alpine -it -- /bin/sh reached the Alpine shell

## Notes
- The exact command without MVM_SKIP_EMBED_BINARIES=1 could not run in this clean worktree because pinned zig 0.13.0 is not installed for embedded release binary builds.