### PR TITLE
docs: add Plan 238 streamed ext4 follow-up

### DIFF
--- a/specs/REFACTOR-STATUS.md
+++ b/specs/REFACTOR-STATUS.md
@@ -1,5 +1,7 @@
 # Refactor status — rollup checklist
 
+**Additional 2026-07-09 — Plan 238 streamed ext4 materialization + OCI/ext4 oracles PROPOSED.** `specs/plans/238-streamed-ext4-materialization-and-oracles.md` records the follow-on to Plan 221 instead of leaving the streamed-materialization idea as an informal note. The scope is intentionally narrow: keep the current block+ext4+dm-verity artifact model, add a sparse streamed block-emission API to `mvm-ext4`, switch the in-process `mvm-build` OCI rootfs path from dense `Vec<u8>` materialization to direct streamed file output, and strengthen the OCI/ext4 seam with Linux-tool oracles (`e2fsck`, `debugfs`) plus dense-vs-streamed differential tests. It is explicitly not a virtiofs-root pivot and does not reopen the Plan 221 architecture decision.
+
 **Additional 2026-07-08 — Plan 213 §C `mvm cache status` + pack cache index + expired-pack prune on branch `feat/plan-213-cC-cache`.** New `mvm_core::pack_cache::list_cached_packs` scans the promoted pack cache (same quarantine/name-mismatch/foreign-content discipline as `resolve_pack`) and returns one `PackCacheEntry` per valid pack — hash, kind, arch, backends, channel, expiry, signing key id, revocation channel, on-disk size, and best-effort last-used mtime — without re-verifying signatures (a cheap listing; `diagnose_pack` remains the trust/eligibility authority). New `mvm cache status [--json]` lists every cached pack (short hash, kind, arch, backends, channel, size, expiry, expired/ok) plus a single instant-launch summary line for the host runtime pack, reusing the already-landed `runtime_pack_diagnosis`/`not_instant_reason` from the `dD-prepare` branch. `mvm cache prune` gained an expired-pack sweep (`prune_expired_packs`, honoring the existing `--dry-run`) — removing an already-expired pack is always safe since it's never instant-launch-eligible; valid-but-unused (LRU/size-budget) reclamation with active-standby/snapshot safety is deferred, tracked in the plan doc's §C. Coverage: `list_cached_packs`/`prune_expired_packs` tests in `mvm-core`'s `pack_cache` module (empty cache, multi-pack listing, dry-run vs real expired-only removal) plus `mvm cache status`/`prune` CLI parse tests.
 
 **Additional 2026-07-09 — Plan 235 native Windows WHP backend PROPOSED / DEFERRED.** `specs/plans/235-native-windows-whp-backend.md` now records the native-Windows follow-up as its own plan instead of leaving it as a vague future note under WSL2. The spec explicitly explores the `WHP` path, including the `whpx`-crate-vs-direct-bindings decision, the portable-VMM seam fit, Windows-specific doctor/bootstrap/install work, and the requirement for a real Windows validation lane. It is intentionally deferred: Plan 234 remains the active shipped Windows path (`WSL2 + libkrun`) until native-Windows work is resourced and proven on a real host.
@@ -1171,6 +1173,11 @@ PLAN 203 — Opt-in forensic network transcript capture   🔴 PROPOSED
   [ ] Add host-boundary capture sink and encrypted transcript payload storage.
   [ ] Add `mvmctl audit transcript` CLI to arm, disarm, list, and export a capture.
   [ ] Add tests for tamper refusal, bounded overflow, and export round-trips.
+
+PLAN 238 — Streamed ext4 materialization and OCI/ext4 oracles   🔴 PROPOSED
+  [ ] Add a sparse streamed block-emission API to `mvm-ext4` with dense-vs-streamed byte identity tests.
+  [ ] Stream the in-process OCI rootfs materialization path directly to the output file instead of building a dense image in memory.
+  [ ] Add Linux-tool OCI/ext4 differential oracles (`e2fsck`, `debugfs`) and dense-vs-streamed boundary tests in `mvm-build`.
 
 PLAN 204 — Builder VM resident control plane   🟢 IN PROGRESS (ADR-089)
   Plan: specs/plans/204-builder-vm-resident-control-plane.md

--- a/specs/SPRINT.md
+++ b/specs/SPRINT.md
@@ -207,6 +207,16 @@ plan 25 sequences the work into six independently-shippable workstreams.
 ## Planning updates
 
 - [x] Started
+      [`plans/238-streamed-ext4-materialization-and-oracles.md`](plans/238-streamed-ext4-materialization-and-oracles.md)
+      to turn the post-Plan-221 rootfs follow-up into an execution plan. It
+      keeps the shipped block+ext4+dm-verity posture, but sequences the next
+      concrete improvements at the OCI/ext4 seam: a sparse streamed block
+      emission API in `mvm-ext4`, direct streamed file output in
+      `mvm-build` instead of a dense in-memory image, and stronger Linux-tool
+      oracles (`e2fsck`/`debugfs`) plus dense-vs-streamed differential tests at
+      both the writer and OCI materialization layers.
+
+- [x] Started
       [`plans/237-hvf-density-memory-footprint.md`](plans/237-hvf-density-memory-footprint.md)
       to turn the HVF density investigation into an execution plan. The
       measured 25-VM Alpine sleep wave is recorded at 2.21 GiB counted RSS

--- a/specs/plans/238-streamed-ext4-materialization-and-oracles.md
+++ b/specs/plans/238-streamed-ext4-materialization-and-oracles.md
@@ -1,0 +1,160 @@
+# Plan 238 - Streamed ext4 materialization and OCI/ext4 oracles
+
+**Status:** PROPOSED
+**Created:** 2026-07-09
+**Goal:** remove dense in-memory ext4 image materialization from the in-process
+OCI rootfs path while preserving byte-for-byte output confidence through
+streamed writers and Linux-tool validation oracles.
+
+## Why this plan exists
+
+`mvm` already ships a block+ext4+dm-verity rootfs posture, and the current
+in-process OCI materialization path works, but it still pays a memory tax by
+building dense ext4 images in memory before writing them to disk. The low-level
+ext4 writer surface is also strong enough to produce the right bytes without yet
+having a dedicated streamed emission seam or a robust set of independent oracles
+that prove the streamed path is equivalent to the dense path.
+
+This plan captures the next narrow improvement step: keep the shipped artifact
+model, add a sparse streamed block-emission API at the ext4 layer, switch the
+OCI materialization path to write directly to the destination file, and harden
+the seam with Linux-tool and dense-vs-streamed differential tests.
+
+## Non-goals
+
+- Do not change the shipped block+ext4+dm-verity artifact model.
+- Do not pivot the runtime to a directory-backed or virtiofs root filesystem.
+- Do not weaken determinism or verification just to save memory.
+- Do not mix unrelated builder, runtime, or network refactors into this work.
+
+## Current state
+
+- `mvm-ext4` can already materialize the filesystem image in-process, but the
+  current integration favors dense image assembly.
+- `mvm-build` can produce rootfs artifacts from OCI input, but the in-process
+  path still routes through dense ext4 image materialization before writing the
+  result.
+- Existing tests prove substantial ext4 behavior already, but the streamed
+  writer seam and OCI integration need explicit equivalence witnesses.
+- Linux filesystem tools can serve as independent validation oracles, but they
+  are not yet wired in as a first-class proof layer for this path.
+
+## Design constraints
+
+1. The final ext4 bytes emitted by the streamed path must match the accepted
+   dense path for the same logical input.
+2. Sparse output is allowed during construction, but the finished artifact must
+   remain compatible with the existing verity and boot expectations.
+3. The streamed writer API must be narrow enough to test directly without
+   forcing unrelated callers to understand ext4 internals.
+4. Independent Linux-tool witnesses should validate filesystem correctness in
+   addition to internal byte-for-byte differential tests.
+
+## Phase 0 - Baseline the dense path and proof points
+
+**Goal:** record exactly what the current path guarantees before replacing it.
+
+- [ ] Identify the current dense ext4 materialization entry points in
+      `mvm-ext4` and the in-process OCI call path in `mvm-build`.
+- [ ] Record the current test coverage and any existing determinism guarantees
+      that the streamed path must preserve.
+- [ ] Identify the artifact boundaries where independent Linux-tool validation
+      can run reliably in CI or targeted local validation.
+
+**Validation**
+
+- Existing ext4/materialization tests still describe the baseline behavior.
+- The dense path remains the comparison oracle until the streamed path proves
+  equivalence.
+
+## Phase 1 - Add a sparse streamed ext4 emission API
+
+**Goal:** let callers write the ext4 image directly to an output sink instead of
+forcing dense whole-image assembly first.
+
+- [ ] Add a streamed block-emission API to `mvm-ext4` that can write the final
+      image to an output target incrementally.
+- [ ] Keep the API narrow and explicit about offsets, sparse ranges, and final
+      image length so callers can reason about correctness.
+- [ ] Preserve the existing dense path long enough to use it as a direct
+      differential oracle during rollout.
+- [ ] Add tests proving that dense and streamed emission produce byte-identical
+      final filesystem images for the same logical input.
+
+**Validation**
+
+- `mvm-ext4` tests cover dense-vs-streamed byte identity.
+- Error-path tests prove partial or malformed writes fail with `Err`, not panic.
+
+## Phase 2 - Switch OCI rootfs materialization to direct streamed output
+
+**Goal:** remove the dense in-memory image from the in-process OCI materialize
+path.
+
+- [ ] Thread the new streamed ext4 emission API into the `mvm-build` OCI rootfs
+      materialization path.
+- [ ] Write the ext4 output directly to the destination file instead of building
+      a full dense image in memory first.
+- [ ] Keep the integration boundary small so the OCI layer still reasons in
+      terms of filesystem contents, not ext4 internals.
+- [ ] Preserve any existing metadata, sizing, and verity-preparation invariants
+      that the current artifact pipeline expects.
+
+**Validation**
+
+- `mvm-build` tests prove the streamed OCI materialization path succeeds for the
+  same fixture inputs as the dense path.
+- Boundary tests cover empty, small, and multi-file OCI filesystem inputs.
+
+## Phase 3 - Add independent OCI/ext4 validation oracles
+
+**Goal:** prove the streamed path with tools outside the Rust implementation.
+
+- [ ] Add Linux-tool validation oracles using `e2fsck` and `debugfs` against the
+      emitted ext4 image.
+- [ ] Add differential tests that compare dense and streamed outputs at the OCI
+      materialization boundary, not only at the raw writer boundary.
+- [ ] Verify directory structure, file presence, and expected metadata using the
+      external tools in addition to raw byte comparison where appropriate.
+- [ ] Keep these oracle tests scoped to the ext4/OCI seam so failures are easy
+      to attribute.
+
+**Validation**
+
+- Oracle-backed tests pass for known-good dense and streamed outputs.
+- Corrupted or intentionally wrong artifacts are rejected by the Linux-tool
+  witnesses.
+
+## Phase 4 - Remove the dense-only fallback from the in-process path
+
+**Goal:** make the streamed path the normal in-process materialization route
+once equivalence is proven.
+
+- [ ] Remove or retire the dense-only in-process OCI materialization path where
+      it is no longer needed.
+- [ ] Keep any helper logic that remains genuinely reusable; delete only the
+      memory-heavy path that has been replaced.
+- [ ] Re-run the full ext4/OCI differential and oracle coverage after the
+      fallback removal.
+
+**Validation**
+
+- No in-process OCI path still requires dense whole-image buffering.
+- All ext4 writer, OCI differential, and Linux-tool oracle tests stay green.
+
+## Sequencing
+
+1. Baseline the current dense path and proof points.
+2. Add streamed ext4 emission with byte-identity tests.
+3. Thread streamed output into OCI rootfs materialization.
+4. Add Linux-tool oracles and OCI-boundary differential tests.
+5. Remove the dense-only in-process fallback once equivalence is proven.
+
+## Completion criteria
+
+- `mvm-ext4` exposes a streamed emission seam suitable for direct file output.
+- The in-process OCI rootfs path no longer requires dense whole-image
+  materialization in memory.
+- Dense-vs-streamed differential tests prove byte identity at the writer and OCI
+  boundaries.
+- Independent Linux-tool oracles validate the emitted ext4 artifacts.


### PR DESCRIPTION
## Summary
- add Plan 238 for streamed ext4 materialization and OCI/ext4 oracle follow-up work
- record the new planning item in `specs/SPRINT.md`
- add the matching rollup entry in `specs/REFACTOR-STATUS.md`

## Testing
- not run (docs/planning only)
