### PR TITLE
Make verbosity global and rename host shares

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,6 +76,12 @@ mvmctl machine run --image alpine --cpus 2 --memory 512M \
 
 # Build a Nix flake and run it transiently in one step
 mvmctl machine run --flake . -- ./app
+
+# Share a host directory read-only; use :rw only with --profile dev/permissive
+mvmctl machine run --image alpine --mount .:/work -- ls /work
+
+# Increase logging globally; RUST_LOG still overrides the generated filter
+mvmctl machine run --image alpine -vvv --allow-host api.example.com -- ps aux
 ```
 
 ### Persistent machines

--- a/crates/mvm-cli/src/commands/env/cleanup.rs
+++ b/crates/mvm-cli/src/commands/env/cleanup.rs
@@ -41,9 +41,6 @@ pub(in crate::commands) struct Args {
     /// Remove all in-VM cached build revisions
     #[arg(long)]
     pub all: bool,
-    /// Print each cached in-VM build path that gets removed
-    #[arg(long)]
-    pub verbose: bool,
 
     /// Also wipe `~/.cache/mvm` (Stage 0 staging, builder VM artifacts).
     /// All cache contents are regenerable; the next `dev up` rebuilds them.
@@ -94,7 +91,7 @@ impl Tier {
     }
 }
 
-pub(in crate::commands) fn run(_cli: &Cli, args: Args, _cfg: &MvmConfig) -> Result<()> {
+pub(in crate::commands) fn run(cli: &Cli, args: Args, _cfg: &MvmConfig) -> Result<()> {
     let tier = pick_tier(&args);
 
     let keep_count = if args.all { 0 } else { args.keep.unwrap_or(5) };
@@ -128,7 +125,7 @@ pub(in crate::commands) fn run(_cli: &Cli, args: Args, _cfg: &MvmConfig) -> Resu
     let _ = shell::run_in_vm("sudo rm -rf /tmp/* /var/tmp/* 2>/dev/null");
 
     let report = mvm_build::dev_build::cleanup_old_dev_builds(keep_count)?;
-    if args.verbose {
+    if cli.verbose > 0 {
         if report.removed_paths.is_empty() {
             ui::info("No cached build paths removed.");
         } else {
@@ -592,7 +589,6 @@ mod tests {
         let args = Args {
             keep: None,
             all: false,
-            verbose: false,
             cache: true,
             state: true,
             nuclear: true,
@@ -608,7 +604,6 @@ mod tests {
         let args = Args {
             keep: None,
             all: false,
-            verbose: false,
             cache: false,
             state: false,
             nuclear: false,

--- a/crates/mvm-cli/src/commands/env/dev.rs
+++ b/crates/mvm-cli/src/commands/env/dev.rs
@@ -111,12 +111,12 @@ pub(in crate::commands) enum DevAction {
         /// Start the dev VM without attaching an interactive shell.
         #[arg(long, conflicts_with = "shell")]
         no_shell: bool,
-        /// Attach a custom volume (repeatable). Appends to `MVM_VOLUMES`.
+        /// Attach a custom mount (repeatable). Appends to `MVM_VOLUMES`.
         /// `host:/guest` shares a host dir (virtio-fs); `host:/guest:SIZE`
         /// attaches an ext4 disk image. Read-only by default — append
         /// `:rw` to grant writes. Guest path must be under /data, /work,
         /// or /mnt (system mounts stay read-only).
-        #[arg(long, short = 'v', value_parser = clap_volume_spec)]
+        #[arg(long = "mount", visible_alias = "volume", value_parser = clap_volume_spec)]
         volume: Vec<String>,
         /// Emit a machine-readable JSON result after boot instead of text.
         /// Implies non-interactive (`--no-shell`); chrome goes to stderr.
@@ -161,9 +161,9 @@ pub(in crate::commands) enum DevAction {
         /// Open an interactive shell after rebuilding.
         #[arg(long, short = 's')]
         shell: bool,
-        /// Attach a custom volume (repeatable). Appends to `MVM_VOLUMES`.
+        /// Attach a custom mount (repeatable). Appends to `MVM_VOLUMES`.
         /// See `mvmctl dev up --help` for the spec grammar.
-        #[arg(long, short = 'v', value_parser = clap_volume_spec)]
+        #[arg(long = "mount", visible_alias = "volume", value_parser = clap_volume_spec)]
         volume: Vec<String>,
     },
     /// Import a dev image from local files (air-gapped install).
@@ -221,11 +221,11 @@ fn bail_no_dev_backend() -> Result<()> {
 }
 
 /// Resolve the dev VM's custom volumes: `MVM_VOLUMES` env baseline +
-/// `--volume` flags, parsed and validated (reserved-mount + encryption
+/// `--mount` flags, parsed and validated (reserved-mount + encryption
 /// gates) into backend-agnostic [`VmVolume`]s. The dev VM is the
 /// dev-tier builder (not the hardened workload tier), so these are a
 /// host-side convenience — but the same path-safety validation still
-/// applies (a stray `-v ~/.mvm/keys:/x` must not silently expose host
+/// applies (a stray `--mount ~/.mvm/keys:/x` must not silently expose host
 /// secrets to the builder).
 fn resolve_dev_volumes(flag: &[String]) -> Result<Vec<VmVolume>> {
     let volumes: Vec<VmVolume> = merge_volume_specs(flag)
@@ -244,12 +244,12 @@ fn resolve_dev_volumes(flag: &[String]) -> Result<Vec<VmVolume>> {
 /// Custom dev volumes are wired for the libkrun dev VM only. The Vz
 /// builder VM (which wires its own `/dev/vdb` overlay + `/work` share)
 /// and the native-Linux dev path don't thread them yet — warn loudly
-/// rather than silently dropping the user's `-v` request.
+/// rather than silently dropping the user's `--mount` request.
 fn warn_dev_volumes_unsupported(volumes: &[VmVolume], backend: &str) {
     if !volumes.is_empty() {
         ui::warn(&format!(
             "Ignoring {} custom volume(s): the {backend} dev backend doesn't support \
-             --volume yet (libkrun does).",
+             --mount yet (libkrun does).",
             volumes.len()
         ));
     }

--- a/crates/mvm-cli/src/commands/machine/mod.rs
+++ b/crates/mvm-cli/src/commands/machine/mod.rs
@@ -204,11 +204,10 @@ pub(in crate::commands) struct MachineRunArgs {
     /// the computed sealed-prod default. Values must be production-safe verbs.
     #[arg(long = "agent-verb", value_name = "VERB")]
     pub agent_verb: Vec<String>,
-    /// Share a host directory into the guest: `HOST_PATH:/GUEST_PATH[:MODE]`.
+    /// Mount a host directory into the guest: `HOST_PATH:/GUEST_PATH[:MODE]`.
     /// MODE defaults to `ro`; `rw` needs `--profile dev` or `permissive`.
-    /// (No short flag: `-v` is the global verbosity counter and `-d` is
-    /// `--detach`.)
-    #[arg(long = "volume")]
+    /// `--volume` remains as a compatibility alias; `-v` is global verbosity.
+    #[arg(long = "mount", visible_alias = "volume")]
     pub volume: Vec<String>,
     /// Explicit environment variable to inject (KEY=VALUE). Repeatable.
     #[arg(short, long)]
@@ -497,7 +496,7 @@ fn profile_allows_writable_volume(profile: &str) -> bool {
     matches!(profile, "dev" | "permissive")
 }
 
-/// Validate `--volume` specs and normalise them for storage in a managed
+/// Validate `--mount`/`--volume` specs and normalise them for storage in a managed
 /// `MachineSpec`. Each spec is run through the shared
 /// `vm_volume_from_spec_validated` choke point (protected-dir deny-list +
 /// guest-mount validation, claim 1) and its host path is canonicalised to an

--- a/crates/mvm-cli/src/commands/machine/tests.rs
+++ b/crates/mvm-cli/src/commands/machine/tests.rs
@@ -344,7 +344,7 @@ fn run_accepts_passthrough_flags() {
         "1G",
         "--profile",
         "dev",
-        "--volume",
+        "--mount",
         "/host:/work:rw",
         "-e",
         "FOO=bar",
@@ -369,12 +369,12 @@ fn run_accepts_passthrough_flags() {
 }
 
 #[test]
-fn volume_flag_carries_dir_share_and_d_is_no_longer_a_share() {
+fn mount_flag_carries_dir_share_and_d_is_no_longer_a_share() {
     let args = parse_run(&[
         "run",
         "--image",
         "alpine",
-        "--volume",
+        "--mount",
         "/host:/work:rw",
         "--",
         "true",
@@ -651,7 +651,7 @@ fn run_volume_is_threaded_into_managed_spec_with_absolute_host() {
         "x",
         "--name",
         "web",
-        "--volume",
+        "--mount",
         &format!("{host}:/work:ro"),
     ])
     .expect("parse");
@@ -679,7 +679,7 @@ fn run_rw_volume_requires_dev_profile() {
         "x",
         "--name",
         "web",
-        "--volume",
+        "--mount",
         &format!("{host}:/work:rw"),
     ])
     .expect("parse");
@@ -696,7 +696,7 @@ fn run_rw_volume_requires_dev_profile() {
         "web",
         "--profile",
         "dev",
-        "--volume",
+        "--mount",
         &format!("{host}:/work:rw"),
     ])
     .expect("parse");

--- a/crates/mvm-cli/src/commands/mod.rs
+++ b/crates/mvm-cli/src/commands/mod.rs
@@ -62,8 +62,14 @@ pub(in crate::commands) struct Cli {
 
     /// Increase log verbosity: -v (info), -vv (debug), -vvv (trace).
     /// Default is quiet (errors only). `RUST_LOG=<filter>` overrides.
-    /// Place before the subcommand, e.g. `mvmctl -vv run -- …`.
-    #[arg(short = 'v', long = "verbose", action = clap::ArgAction::Count)]
+    /// Global, so it may appear before or after a subcommand.
+    #[arg(
+        short = 'v',
+        long = "verbose",
+        visible_alias = "debug",
+        global = true,
+        action = clap::ArgAction::Count
+    )]
     pub verbose: u8,
 
     #[command(subcommand)]

--- a/crates/mvm-cli/src/commands/shared/parse.rs
+++ b/crates/mvm-cli/src/commands/shared/parse.rs
@@ -61,8 +61,8 @@ pub fn parse_port_spec(spec: &str) -> Result<(u16, u16)> {
     }
 }
 
-/// Parsed volume specification from the `--volume/-v` CLI flag (or the
-/// `MVM_VOLUMES` env var).
+/// Parsed mount specification from the `--mount` CLI flag, its compatibility
+/// `--volume` alias, or the `MVM_VOLUMES` env var.
 ///
 /// Grammar (split on `:`):
 /// - `host:/guest`             — live host-directory share (virtio-fs)
@@ -196,7 +196,7 @@ pub fn parse_volume_spec(spec: &str) -> Result<VolumeSpec> {
     }
 }
 
-/// Merge the `MVM_VOLUMES` env baseline with `--volume` flag values.
+/// Merge the `MVM_VOLUMES` env baseline with `--mount`/`--volume` flag values.
 /// Env entries come first; flag values are appended (the flag adds to
 /// the env, it does not replace it). See `mvm_core::config::mvm_volumes_env`.
 pub fn merge_volume_specs(flag_specs: &[String]) -> Vec<String> {

--- a/crates/mvm-cli/src/commands/tests.rs
+++ b/crates/mvm-cli/src/commands/tests.rs
@@ -91,7 +91,6 @@ fn test_cleanup_defaults() {
         env_group::EnvCmd::Cleanup(cleanup::Args {
             keep,
             all,
-            verbose,
             cache,
             state,
             nuclear,
@@ -101,7 +100,6 @@ fn test_cleanup_defaults() {
         }) => {
             assert_eq!(keep, None);
             assert!(!all);
-            assert!(!verbose);
             assert!(!cache);
             assert!(!state);
             assert!(!nuclear);
@@ -123,7 +121,6 @@ fn test_cleanup_keep_flag() {
         env_group::EnvCmd::Cleanup(args) => {
             assert_eq!(args.keep, Some(9));
             assert!(!args.all);
-            assert!(!args.verbose);
         }
         _ => panic!("Expected Cleanup command"),
     }
@@ -139,7 +136,6 @@ fn test_cleanup_all_flag() {
         env_group::EnvCmd::Cleanup(args) => {
             assert_eq!(args.keep, None);
             assert!(args.all);
-            assert!(!args.verbose);
         }
         _ => panic!("Expected Cleanup command"),
     }
@@ -148,6 +144,7 @@ fn test_cleanup_all_flag() {
 #[test]
 fn test_cleanup_verbose_flag() {
     let cli = Cli::try_parse_from(["mvmctl", "env", "cleanup", "--verbose"]).unwrap();
+    assert_eq!(cli.verbose, 1);
     let Commands::Env(eg) = cli.command else {
         panic!("expected env group")
     };
@@ -155,7 +152,6 @@ fn test_cleanup_verbose_flag() {
         env_group::EnvCmd::Cleanup(args) => {
             assert_eq!(args.keep, None);
             assert!(!args.all);
-            assert!(args.verbose);
         }
         _ => panic!("Expected Cleanup command"),
     }
@@ -895,7 +891,7 @@ fn test_run_volume_dir_inject() {
         "run",
         "--image",
         "alpine:latest",
-        "--volume",
+        "--mount",
         "/tmp/config:/mnt/config",
         "--volume",
         "/tmp/secrets:/mnt/secrets",
@@ -924,7 +920,7 @@ fn test_run_volume_persistent() {
         "run",
         "--image",
         "alpine:latest",
-        "--volume",
+        "--mount",
         "/data:/mnt/data:4G",
         "--",
         "sh",
@@ -3045,7 +3041,7 @@ fn run_transient_with_manifest_and_resources() {
 
 #[test]
 fn run_transient_with_add_dir_and_env() {
-    // `machine run` uses `--volume` for directory shares (not `--add-dir`) and
+    // `machine run` uses `--mount` for directory shares (not `--add-dir`) and
     // `--env` for environment variables.
     let cli = Cli::try_parse_from([
         "mvmctl",
@@ -3053,7 +3049,7 @@ fn run_transient_with_add_dir_and_env() {
         "run",
         "--image",
         "alpine:latest",
-        "--volume",
+        "--mount",
         "/tmp:/work",
         "--volume",
         "/etc:/host-etc",
@@ -3488,6 +3484,21 @@ fn test_dev_up_json_flag_parses() {
         Commands::Dev(dev::Args {
             action: Some(DevAction::Up { json, .. }),
         }) => assert!(json),
+        _ => panic!("Expected Dev Up command"),
+    }
+}
+
+#[test]
+fn test_dev_up_verbose_is_global_not_mount() {
+    let cli = Cli::try_parse_from(["mvmctl", "dev", "up", "-v", "--json"]).unwrap();
+    assert_eq!(cli.verbose, 1);
+    match cli.command {
+        Commands::Dev(dev::Args {
+            action: Some(DevAction::Up { volume, json, .. }),
+        }) => {
+            assert!(json);
+            assert!(volume.is_empty());
+        }
         _ => panic!("Expected Dev Up command"),
     }
 }
@@ -4029,6 +4040,65 @@ fn top_level_help_hides_infra() {
             "infra command `{hidden}` must be hidden from top-level help but was found"
         );
     }
+}
+
+#[test]
+fn machine_run_verbose_after_options_is_not_guest_argv() {
+    let cli = Cli::try_parse_from([
+        "mvmctl",
+        "machine",
+        "run",
+        "--image",
+        "alpine:latest",
+        "-vvv",
+        "--allow-host",
+        "google.com",
+        "--",
+        "ps",
+        "aux",
+    ])
+    .expect("machine run verbosity must parse before trailing guest argv");
+
+    assert_eq!(cli.verbose, 3);
+    let Commands::Machine(machine_args) = cli.command else {
+        panic!("expected machine command")
+    };
+    let machine::MachineAction::Run(args) = machine_args.action else {
+        panic!("expected machine run")
+    };
+    assert_eq!(args.allow_host, vec!["google.com"]);
+    assert_eq!(args.argv, vec!["ps", "aux"]);
+}
+
+#[test]
+fn debug_alias_parses_before_and_after_machine_run() {
+    let cli = Cli::try_parse_from(["mvmctl", "--debug", "doctor"])
+        .expect("root --debug alias must parse before subcommand");
+    assert_eq!(cli.verbose, 1);
+
+    let cli = Cli::try_parse_from(["mvmctl", "doctor", "--debug"])
+        .expect("root --debug alias must parse after subcommand");
+    assert_eq!(cli.verbose, 1);
+
+    let cli = Cli::try_parse_from([
+        "mvmctl",
+        "machine",
+        "run",
+        "--image",
+        "alpine:latest",
+        "--debug",
+        "--",
+        "true",
+    ])
+    .expect("machine run --debug alias must parse before trailing guest argv");
+    assert_eq!(cli.verbose, 1);
+    let Commands::Machine(machine_args) = cli.command else {
+        panic!("expected machine command")
+    };
+    let machine::MachineAction::Run(args) = machine_args.action else {
+        panic!("expected machine run")
+    };
+    assert_eq!(args.argv, vec!["true"]);
 }
 
 #[test]

--- a/crates/mvm-cli/src/commands/vm/session.rs
+++ b/crates/mvm-cli/src/commands/vm/session.rs
@@ -211,13 +211,9 @@ pub(in crate::commands) struct ConsoleArgs {
 }
 
 #[derive(ClapArgs, Debug, Clone)]
-pub(in crate::commands) struct ReapArgs {
-    /// Print the IDs of reaped sessions on stdout (one per line).
-    #[arg(long)]
-    pub verbose: bool,
-}
+pub(in crate::commands) struct ReapArgs {}
 
-pub(in crate::commands) fn run(_cli: &Cli, args: Args, _cfg: &MvmConfig) -> Result<()> {
+pub(in crate::commands) fn run(cli: &Cli, args: Args, _cfg: &MvmConfig) -> Result<()> {
     // Opportunistic lazy reap: every session verb sweeps idle records
     // before its own work. Failures are logged, not propagated —
     // reaping is best-effort cleanup, not load-bearing for the verb.
@@ -236,7 +232,7 @@ pub(in crate::commands) fn run(_cli: &Cli, args: Args, _cfg: &MvmConfig) -> Resu
         Cmd::Exec(a) => cmd_exec(a),
         Cmd::RunCode(a) => cmd_run_code(a),
         Cmd::Console(a) => cmd_console(a),
-        Cmd::Reap(a) => cmd_reap(a),
+        Cmd::Reap(a) => cmd_reap(cli, a),
     }
 }
 
@@ -1021,8 +1017,8 @@ fn cmd_start(args: StartArgs) -> Result<()> {
     Ok(())
 }
 
-fn cmd_reap(args: ReapArgs) -> Result<()> {
-    let reaped = reap_expired_sessions(args.verbose);
+fn cmd_reap(cli: &Cli, _args: ReapArgs) -> Result<()> {
+    let reaped = reap_expired_sessions(cli.verbose > 0);
     ui::info(&format!("Reaped {} idle session(s).", reaped.len()));
     Ok(())
 }

--- a/crates/mvm-cli/src/commands/vm/up.rs
+++ b/crates/mvm-cli/src/commands/vm/up.rs
@@ -135,7 +135,7 @@ pub(super) struct AdmitPlanForBootParams<'a> {
     /// the on-disk sealed volume before launch — claim 9.
     /// `None` preserves the claim-8 baseline (no deps gate).
     pub deps_volume: Option<mvm_core::plan::DepsVolumeBinding>,
-    /// User-supplied host-fs grants (`--volume` / `MVM_VOLUMES`) baked
+    /// User-supplied host-fs grants (`--mount` / `MVM_VOLUMES`) baked
     /// into the signed plan + emitted to the chain-signed audit log
     /// (claim 1 / claim 8). Empty for the common no-volume case.
     pub shares: Vec<mvm_core::plan::HostShareGrant>,

--- a/crates/mvm-sdk/src/machine.rs
+++ b/crates/mvm-sdk/src/machine.rs
@@ -341,7 +341,7 @@ impl MachineRunBuilder {
         let image = require_option(&self.image, "image")?;
         require_non_empty_slice(&self.command, "command")?;
         validate_strings(&self.allow_hosts, "--allow-host")?;
-        validate_strings(&self.volumes, "--volume")?;
+        validate_strings(&self.volumes, "--mount")?;
         validate_strings(&self.env, "--env")?;
 
         let mut args = vec!["run".to_string(), "--image".to_string(), image.to_string()];
@@ -354,7 +354,7 @@ impl MachineRunBuilder {
         }
         append_optional(&mut args, "--memory", self.memory.as_deref())?;
         append_optional(&mut args, "--profile", self.profile.as_deref())?;
-        append_repeated(&mut args, "--volume", &self.volumes);
+        append_repeated(&mut args, "--mount", &self.volumes);
         append_repeated(&mut args, "--env", &self.env);
         if let Some(timeout) = self.timeout {
             args.extend(["--timeout".to_string(), timeout.to_string()]);

--- a/crates/mvm-sdk/tests/machine.rs
+++ b/crates/mvm-sdk/tests/machine.rs
@@ -92,7 +92,7 @@ fn machine_run_builder_emits_machine_cli_argv() {
             "1G",
             "--profile",
             "dev",
-            "--volume",
+            "--mount",
             "/src:/workspace:ro",
             "--env",
             "RUST_LOG=info",

--- a/public/src/content/docs/getting-started/nix-for-mvm.mdx
+++ b/public/src/content/docs/getting-started/nix-for-mvm.mdx
@@ -301,9 +301,9 @@ Volumes let you pass files from your host into the microVM at boot — config fi
 ```bash
 # Mount host directories into the VM
 mvmctl machine run --flake . --name hello -d \
-    --volume ./config:/mnt/config \
-    --volume ./secrets:/mnt/secrets \
-    --volume ./data:/mnt/data:1024
+    --mount ./config:/mnt/config \
+    --mount ./secrets:/mnt/secrets \
+    --mount ./data:/mnt/data:1024
 mvmctl machine forward hello -p 8080:8080
 ```
 
@@ -320,8 +320,8 @@ Config and secrets are read-only by design — you don't want your app accidenta
 ```bash
 # Read-only config + read-write 1GB data volume
 mvmctl machine run --flake . --name hello -d \
-    --volume ./config:/mnt/config \
-    --volume ./data:/mnt/data:1024
+    --mount ./config:/mnt/config \
+    --mount ./data:/mnt/data:1024
 mvmctl machine forward hello -p 8080:8080
 ```
 

--- a/public/src/content/docs/getting-started/quickstart.md
+++ b/public/src/content/docs/getting-started/quickstart.md
@@ -163,7 +163,7 @@ or `--manifest`.
 
 ```bash
 mvmctl machine run --image alpine -- uname -a                    # OCI image, one-shot
-mvmctl machine run --flake . --volume .:/work -- ls /work        # share host dir, read-only
+mvmctl machine run --flake . --mount .:/work -- ls /work         # share host dir, read-only
 mvmctl machine run --image alpine -e DEBUG=1 -- env | grep DEBUG # inject env vars
 mvmctl machine run --manifest my-tpl -- /bin/true                # registered template
 ```

--- a/public/src/content/docs/guides/config-secrets.md
+++ b/public/src/content/docs/guides/config-secrets.md
@@ -19,18 +19,19 @@ echo '{"gateway": {"port": 8080}}' > /tmp/my-config/app.json
 echo 'API_KEY_REF=openai-api-key' > /tmp/my-secrets/app.env
 
 mvmctl machine run --manifest my-app \
-    --volume /tmp/my-config:/mnt/config \
-    --volume /tmp/my-secrets:/mnt/secrets
+    --mount /tmp/my-config:/mnt/config \
+    --mount /tmp/my-secrets:/mnt/secrets
 ```
 
-The `--volume` (`-v` for short) flag uses the format `host_dir:/guest/path`:
+The `--mount` flag uses the format `host_dir:/guest/path`. `--volume` remains
+accepted as a compatibility alias, but `-v` is global verbosity:
 
 | Guest path | Drive | Permissions | Purpose |
 |---|---|---|---|
 | `/mnt/config` | `/dev/vdb` | Read-only (0444) | Application configuration |
 | `/mnt/secrets` | `/dev/vdc` | Read-only (0400) | File-shaped secret material |
 
-Every file in the host directory is written to the corresponding drive image. For persistent volumes with explicit size, use the 3-part format: `--volume host:/guest/path:size`.
+Every file in the host directory is written to the corresponding drive image. For persistent mounts with explicit size, use the 3-part format: `--mount host:/guest/path:size`.
 
 ## Library API
 
@@ -94,8 +95,8 @@ worked LLM-agent example showing the pattern end-to-end.
 ```bash
 mvmctl machine build --flake ./openclaw
 mvmctl machine run --flake ./openclaw --name oc -d \
-    --volume nix/examples/openclaw/config:/mnt/config \
-    --volume nix/examples/openclaw/secrets:/mnt/secrets
+    --mount nix/examples/openclaw/config:/mnt/config \
+    --mount nix/examples/openclaw/secrets:/mnt/secrets
 mvmctl machine forward oc -p 3000:3000
 ```
 
@@ -121,8 +122,8 @@ ANTHROPIC_API_KEY_REF=anthropic-api-key
 EOF
 
 mvmctl machine run --flake ./openclaw --name oc -d \
-    --volume /tmp/oc-config:/mnt/config \
-    --volume /tmp/oc-secrets:/mnt/secrets
+    --mount /tmp/oc-config:/mnt/config \
+    --mount /tmp/oc-secrets:/mnt/secrets
 mvmctl machine forward oc -p 3000:3000
 ```
 
@@ -141,8 +142,8 @@ and readiness boundary.
 ```bash
 mvmctl machine build --flake ./openclaw --snapshot
 mvmctl machine run --flake ./openclaw --name oc -d \
-    --volume nix/examples/openclaw/config:/mnt/config \
-    --volume nix/examples/openclaw/secrets:/mnt/secrets
+    --mount nix/examples/openclaw/config:/mnt/config \
+    --mount nix/examples/openclaw/secrets:/mnt/secrets
 mvmctl machine forward oc -p 3000:3000
 ```
 
@@ -170,19 +171,19 @@ keys:
 ```bash
 # Production gateway with prod Anthropic key
 mvmctl machine run --manifest openclaw --name oc-prod \
-    --volume ./prod/config:/mnt/config \
-    --volume ./prod/secrets:/mnt/secrets
+    --mount ./prod/config:/mnt/config \
+    --mount ./prod/secrets:/mnt/secrets
 mvmctl machine forward oc-prod -p 3000:3000
 
 # Staging gateway with test key
 mvmctl machine run --manifest openclaw --name oc-staging \
-    --volume ./staging/config:/mnt/config \
-    --volume ./staging/secrets:/mnt/secrets
+    --mount ./staging/config:/mnt/config \
+    --mount ./staging/secrets:/mnt/secrets
 mvmctl machine forward oc-staging -p 3001:3000
 
 # Dev gateway with no key (localhost-only testing)
 mvmctl machine run --manifest openclaw --name oc-dev \
-    --volume ./dev/config:/mnt/config
+    --mount ./dev/config:/mnt/config
 mvmctl machine forward oc-dev -p 3002:3000
 ```
 

--- a/public/src/content/docs/guides/exec.md
+++ b/public/src/content/docs/guides/exec.md
@@ -13,7 +13,7 @@ Think `docker run --rm`, but with a microVM as the isolation boundary.
 
 ```bash
 mvmctl machine run --image alpine -- uname -a
-mvmctl machine run --flake . --volume .:/work -- ls /work
+mvmctl machine run --flake . --mount .:/work -- ls /work
 mvmctl machine run --manifest my-tpl -- /bin/true
 ```
 
@@ -48,23 +48,24 @@ default image:
 - `--manifest <name>` — a pre-built manifest slot or registered template, which
   skips the build step entirely.
 
-## Sharing host directories: `--volume`
+## Sharing host directories: `--mount`
 
-`--volume HOST:GUEST[:MODE]` shares a host directory into the guest at
+`--mount HOST:GUEST[:MODE]` shares a host directory into the guest at
 `GUEST`. `MODE` is `ro` (default) or `rw`; a writable share requires
-`--profile dev` or `--profile permissive`. The flag is repeatable.
+`--profile dev` or `--profile permissive`. The flag is repeatable. `--volume`
+remains accepted as a compatibility alias, but `-v` is global verbosity.
 
 ### Read-only (default)
 
 ```bash
 echo "hello" > /tmp/foo
-mvmctl machine run --image alpine --volume /tmp:/host -- cat /host/foo     # prints "hello"
+mvmctl machine run --image alpine --mount /tmp:/host -- cat /host/foo     # prints "hello"
 ```
 
 ### Writable: `:rw`
 
 ```bash
-mvmctl machine run --flake . --profile dev --volume .:/work:rw -- sh -c 'echo result > /work/output.txt'
+mvmctl machine run --flake . --profile dev --mount .:/work:rw -- sh -c 'echo result > /work/output.txt'
 cat ./output.txt       # "result" — written by the guest
 ```
 
@@ -79,8 +80,8 @@ Modes are independent per directory:
 
 ```bash
 mvmctl machine run --flake . --profile dev \
-  --volume ./src:/work:rw \
-  --volume ~/.cargo:/root/.cargo:ro \
+  --mount ./src:/work:rw \
+  --mount ~/.cargo:/root/.cargo:ro \
   -- cargo build --manifest-path /work/Cargo.toml
 ```
 
@@ -104,14 +105,14 @@ The snapshot path activates only when:
 
 - the image source is a registered template (an OCI image or ad-hoc flake has no
   template snapshot to restore from), AND
-- the request has **no** `--volume` extras (extra drives would mismatch
+- the request has **no** `--mount` extras (extra drives would mismatch
   the snapshot's recorded layout), AND
 - the active backend reports snapshot support.
 
 On macOS backends without Firecracker (HVF, libkrun), vsock snapshots return `os error 95` (EOPNOTSUPP);
 restore failures fall back to cold boot with a warning rather than
 aborting. The harder branch -- parameterized snapshots that allow
-`--volume` -- is tracked in [issue #7](https://github.com/tinylabscom/mvm/issues/7).
+`--mount` -- is tracked in [issue #7](https://github.com/tinylabscom/mvm/issues/7).
 
 ## Resource controls
 
@@ -190,7 +191,7 @@ highest):
 
 ## Teardown semantics
 
-- **Normal exit**: VM is stopped and the staging dir for `--volume`
+- **Normal exit**: VM is stopped and the staging dir for `--mount`
   images is cleaned up.
 - **Non-zero exit**: same as normal exit; `mvmctl machine run` propagates the
   guest's exit code.
@@ -211,10 +212,10 @@ highest):
   any other transient VM gets -- if your `--manifest` exposes outbound
   internet, so does `mvmctl machine run` from that template.
 - **Stdin** is currently *not* forwarded to the guest. Pipe data via a
-  `--volume`-shared file instead. Streaming stdin is a future
+  `--mount`-shared file instead. Streaming stdin is a future
   improvement.
 - **Persistent state** doesn't survive teardown beyond what `:rw`
-  `--volume` rsyncs back. For larger or longer-lived state, use
+  `--mount` rsyncs back. For larger or longer-lived state, use
   `mvmctl machine run` with a persistent volume.
 
 ## See also

--- a/public/src/content/docs/guides/nix-flakes.md
+++ b/public/src/content/docs/guides/nix-flakes.md
@@ -330,8 +330,8 @@ chmod 0400 ~/.config/mvm/secrets/anthropic
 cd my-claude-code-vm
 mvmctl machine build
 mvmctl machine run --manifest . --profile dev \
-  --volume "$PWD:/workspace:rw" \
-  --volume "$HOME/.config/mvm/secrets:/mnt/secrets"
+  --mount "$PWD:/workspace:rw" \
+  --mount "$HOME/.config/mvm/secrets:/mnt/secrets"
 ```
 
 Inside the guest, your workload can read the file you mounted under

--- a/public/src/content/docs/guides/troubleshooting.md
+++ b/public/src/content/docs/guides/troubleshooting.md
@@ -231,7 +231,7 @@ change converges to a fresh machine.
 
 **If that wasn't what you wanted** (e.g. a typo'd `--image`): the machine's own
 rootfs is ephemeral, so just re-run with the right config. Durable data should
-live in a `--volume` host share, which lives on the host and survives the
+live in a `--mount` host share, which lives on the host and survives the
 recreate. To keep two configs side by side, give them different `--name`s.
 
 **To reconnect without changing anything**, run `mvmctl machine run --name X`
@@ -263,7 +263,7 @@ mvmctl dev shell -- ip link show tap0
 
 ### Can't access project files inside microVM
 
-The Firecracker microVM has an **isolated filesystem**. Use `mvmctl dev shell` to access the dev VM where your home directory is mounted, or pass volumes with `--volume`.
+The Firecracker microVM has an **isolated filesystem**. Use `mvmctl dev shell` to access the dev VM where your home directory is mounted, or pass host shares with `--mount`.
 
 ## Performance Issues
 

--- a/public/src/content/docs/reference/cli-commands.md
+++ b/public/src/content/docs/reference/cli-commands.md
@@ -54,7 +54,8 @@ guest-RPC surface, fleet-shaped workflows).
 | `mvmctl machine run --health-interval <secs> --health-timeout <secs> --health-retries <n> --health-start-period <secs>` | Tune the healthcheck cadence: seconds between checks (default `30`), per-check timeout (default `5`), consecutive failures before unhealthy (default `3`), and grace period after start before checks count (default `0`). Recorded on the machine spec and actively enforced by the host-agent daemon's probe loop |
 | `mvmctl machine run --cpus N --memory SIZE` | vCPU count and memory (supports 512M, 4G, etc.) |
 | `mvmctl machine run -e KEY=VALUE` | Inject an environment variable (repeatable; gated by `--profile`) |
-| `mvmctl machine run --volume host:/guest[:mode]` | Share a host directory (mode defaults to `ro`; `rw` needs `--profile dev`/`permissive`) |
+| `mvmctl machine run -v/-vv/-vvv` | Increase global logging (`info`/`debug`/`trace`) without passing the flag through to guest argv; `RUST_LOG` still overrides the generated filter |
+| `mvmctl machine run --mount host:/guest[:mode]` | Share a host directory (mode defaults to `ro`; `rw` needs `--profile dev`/`permissive`; `--volume` remains a compatibility alias) |
 | `mvmctl machine run --profile <p>` | Security posture: `restrictive`, `standard` (default), `dev`, `permissive` |
 | `mvmctl machine run --net` | Enable broad dev-tier outbound egress (default is deny-all) |
 | `mvmctl machine run --allow-host HOST[:PORT]` | Allow egress only to these hosts (repeatable; PORT defaults to 443; wins over `--net`) |
@@ -359,7 +360,7 @@ flag:
 - **Transient** (default): boot a fresh microVM from an OCI image, run the
   command, tear the VM down. Routes into the same code path as
   `mvmctl run --image`, inheriting **deny-all networking by default**, opt-in
-  egress via `--net` / `--allow-host`, and the same `--profile`, `--volume`,
+  egress via `--net` / `--allow-host`, and the same `--profile`, `--mount`,
   `--receipt`, `--json`, and `--dry-run` semantics.
 - **Foreground interactive** (`-t`/`--tty`, with `-i` accepted so `-it`
   parses): boot a fresh transient VM, run the requested argv attached to a PTY,
@@ -409,7 +410,8 @@ host agent, so it only applies to backends where that agent is reachable.
 Identity and lifetime are separate: `--name <N>` names a foreground transient
 run but does not make it persistent. `-d`/`--detach`, `--up-json`, or the
 explicit `machine create`/`start` lifecycle make a long-lived machine.
-`--volume` host shares work on every run mode. The syntax is
+`--mount` host shares work on every run mode (`--volume` remains accepted as a
+compatibility alias). The syntax is
 `HOST:/GUEST[:MODE]` (`MODE` defaults to `ro`; `rw` needs `--profile dev` or
 `permissive`). Persistent machine specs canonicalize host paths to absolute
 paths so later reconnects re-mount the same share regardless of your working
@@ -425,7 +427,7 @@ or mounts private keys, `~/.ssh`, known-hosts material, or SSH config.
 | `mvmctl machine run --image <ref> -- <cmd>...` | Boot an OCI image, run `<cmd>` with no network, tear down |
 | `mvmctl machine run --net --image <ref> -- <cmd>...` | Boot with dev-tier outbound networking enabled |
 | `mvmctl machine run --image <ref> --allow-host <host[:port]> -- <cmd>...` | Boot with egress narrowed to the listed TCP host/port entries (`<host>` alone defaults to `:443`) |
-| `mvmctl machine run --image <ref> --profile dev --volume .:/work:rw -- <cmd>` | Same, with a writable host share under the dev profile |
+| `mvmctl machine run --image <ref> --profile dev --mount .:/work:rw -- <cmd>` | Same, with a writable host share under the dev profile |
 | `mvmctl machine run --image <ref> --cpus <n> --memory <size> -- <cmd>` | Resize the transient VM |
 | `mvmctl machine run --image <ref> --dry-run -- <cmd>` | Validate and explain the run plan without booting a VM |
 | `mvmctl machine run --image <ref> --json -- <cmd>` | Print a redacted JSON execution summary |
@@ -795,7 +797,7 @@ All commands accept these global options:
 |--------|-------------|
 | `--log-format <human\|json>` | Log format: human (default) or json (structured) |
 | `--fc-version <VERSION>` | Override Firecracker version (e.g., v1.14.0) |
-| `--verbose` (alias `--debug`) | Show verbose `[mvm]` progress messages. Implied when `RUST_LOG` is set. |
+| `-v`, `-vv`, `-vvv`, `--verbose`, `--debug` | Increase global log verbosity (`info`/`debug`/`trace`). The flag may be placed before or after subcommands, including after `machine run` options before `-- <argv>`. `RUST_LOG` overrides the generated filter. |
 
 ## Environment Variables
 
@@ -826,7 +828,7 @@ All commands accept these global options:
 | `MVM_OCI_POLICY` | OCI production policy TOML used by `mvmctl image pull --prod` and `mvmctl run --image --prod` | `$MVM_DATA_DIR/oci-policy.toml` |
 | `MVM_OCI_BEARER_TOKEN_<HOST>` | Bearer token for one OCI registry host (`ghcr.io` -> `MVM_OCI_BEARER_TOKEN_GHCR_IO`) | Unset |
 | `MVM_OCI_BEARER_TOKEN` | Global fallback bearer token for OCI registry pulls | Unset |
-| `RUST_LOG` | Logging level (e.g., `debug`, `mvm=trace`) | `info` |
+| `RUST_LOG` | Logging filter (e.g., `debug`, `mvm=trace`). Overrides `-v` / `--verbose`. | Unset |
 | `MVM_CACHE_DIR` | Override cache directory | `~/.cache/mvm` |
 | `MVM_CONFIG_DIR` | Override config directory | XDG default |
 | `MVM_STATE_DIR` | Override state directory | XDG default |

--- a/public/src/content/docs/reference/filesystem.md
+++ b/public/src/content/docs/reference/filesystem.md
@@ -63,10 +63,10 @@ The data drive (`/dev/vdd`, mounted at `/mnt/data/`) is a persistent ext4 volume
 - Survives restarts and snapshots
 - Use for application state, databases, logs
 
-Specify size with `--volume`:
+Specify size with `--mount`:
 
 ```bash
-mvmctl machine run --flake . --volume ./data:/data:1024
+mvmctl machine run --flake . --mount ./data:/data:1024
 ```
 
 For managed encrypted local volumes and workspace cleanup policy, see

--- a/sdks/machine-fixtures/run-admission.argv
+++ b/sdks/machine-fixtures/run-admission.argv
@@ -9,7 +9,7 @@ api.example.com
 1G
 --profile
 dev
---volume
+--mount
 /tmp/mvm-sdk-src:/workspace:ro
 --env
 TOKEN=secret

--- a/sdks/python/mvm/_machine.py
+++ b/sdks/python/mvm/_machine.py
@@ -142,7 +142,7 @@ def _machine_run_argv(
         argv.extend(["--memory", _require_non_empty_str(memory, "memory")])
     if profile is not None:
         argv.extend(["--profile", _require_non_empty_str(profile, "profile")])
-    _append_repeated(argv, "--volume", volumes)
+    _append_repeated(argv, "--mount", volumes)
     _append_repeated(argv, "--env", env)
     if timeout is not None:
         argv.extend(["--timeout", str(timeout)])

--- a/sdks/typescript/src/_machine.ts
+++ b/sdks/typescript/src/_machine.ts
@@ -167,7 +167,7 @@ export function machineRunArgv(options: MachineRunOptions): string[] {
   if (options.cpus !== undefined) argv.push("--cpus", String(options.cpus));
   if (options.memory !== undefined) argv.push("--memory", requireString(options.memory, "memory"));
   if (options.profile !== undefined) argv.push("--profile", requireString(options.profile, "profile"));
-  appendRepeated(argv, "--volume", options.volumes);
+  appendRepeated(argv, "--mount", options.volumes);
   appendRepeated(argv, "--env", options.env);
   if (options.timeout !== undefined) argv.push("--timeout", String(options.timeout));
   if (options.receipt !== undefined) argv.push("--receipt", requireString(options.receipt, "receipt"));


### PR DESCRIPTION
## Summary

- Make `-v`/`--verbose`/`--debug` a true global verbosity flag that can appear after subcommands, including `machine run` options before guest argv.
- Rename host-share CLI spelling to canonical `--mount` while retaining `--volume` as a compatibility alias for `machine run` and `dev` custom mounts.
- Keep managed volume commands using `machine volume mount --volume <name>`.
- Update Rust/Python/TypeScript SDK argv generation, conformance fixtures, README, and website docs to prefer `--mount`.

## Validation

- `cargo fmt --all`
- `cargo check --workspace`
- `cargo clippy --workspace -- -D warnings`
- `cargo test --workspace -- --test-threads=1`
