### PR TITLE
Fix Stage 0 build wedge from leftover /homeless-shelter

### DIFF
--- a/crates/mvm-build/src/bin/stage0-init.rs
+++ b/crates/mvm-build/src/bin/stage0-init.rs
@@ -548,6 +548,32 @@ mod linux {
         Ok(())
     }
 
+    /// Nix builds unsandboxed inside the Stage 0 guest (no user namespaces
+    /// available), so it uses `/homeless-shelter` as the builder's HOME and
+    /// **refuses to run** if that directory already exists — its no-sandbox
+    /// purity check. A build that was interrupted mid-flight (power-off, OOM, a
+    /// store fault) leaves the dir behind on the persistent guest root, and
+    /// because the root is reused across boots whenever its seed marker matches,
+    /// every later `dev up` then fails with
+    /// `error: home directory "/homeless-shelter" exists`. Remove a stale one
+    /// before invoking nix so a crashed prior run self-heals instead of wedging
+    /// the bootstrap. `root` is the filesystem root (`/` in the guest; a tempdir
+    /// under test). A `NotFound` is the normal clean-boot case, not an error.
+    fn purge_stale_nix_builder_home(root: &Path) -> std::io::Result<()> {
+        let home = root.join("homeless-shelter");
+        match std::fs::remove_dir_all(&home) {
+            Ok(()) => {
+                eprintln!(
+                    "stage0-init: removed stale nix builder home {}",
+                    home.display()
+                );
+                Ok(())
+            }
+            Err(e) if e.kind() == std::io::ErrorKind::NotFound => Ok(()),
+            Err(e) => Err(e),
+        }
+    }
+
     /// Recursively copy `src` -> `dst` preserving symlinks + file modes
     /// (the seed has no `cp`). Iterative to avoid deep-tree recursion limits.
     /// Hardlinks degrade to copies — fine for a one-shot bootstrap store.
@@ -641,6 +667,11 @@ mod linux {
             workspace_root.display()
         );
         let extra_build_flags = stage0_nix_extra_flags(&conf)?;
+
+        // Clear a `/homeless-shelter` left by a crashed prior build before nix's
+        // unsandboxed purity check trips on it and wedges the bootstrap.
+        purge_stale_nix_builder_home(Path::new("/"))
+            .map_err(|e| format!("clearing stale nix builder home: {e}"))?;
 
         eprintln!("stage0-init: building {flake_ref} (output_mode={mode})");
         let proxy = if is_qemu() {
@@ -1213,6 +1244,20 @@ mod linux {
         use std::collections::HashMap;
         use std::path::Path;
         use std::process::Command;
+
+        #[test]
+        fn purge_stale_nix_builder_home_removes_leftover_and_tolerates_absence() {
+            let root = tempfile::tempdir().expect("tempdir");
+            // Clean boot: no `/homeless-shelter` present — a no-op, never an error.
+            super::purge_stale_nix_builder_home(root.path()).expect("absent home is ok");
+            // Crashed prior build: a populated leftover must be removed wholesale
+            // so nix's unsandboxed purity check doesn't wedge the next build.
+            let home = root.path().join("homeless-shelter");
+            std::fs::create_dir_all(home.join(".cargo")).expect("seed leftover tree");
+            std::fs::write(home.join(".cargo/config"), b"stale").expect("seed leftover file");
+            super::purge_stale_nix_builder_home(root.path()).expect("removes leftover");
+            assert!(!home.exists(), "stale nix builder home must be gone");
+        }
 
         #[test]
         fn streams_stderr_live_keeps_full_log_and_captures_stdout() {

--- a/crates/mvm-build/src/libkrun_builder.rs
+++ b/crates/mvm-build/src/libkrun_builder.rs
@@ -422,7 +422,23 @@ impl LibkrunBuilderVm {
                 console_log.display()
             )));
         }
-        Ok(())
+        // A clean supervisor exit only means the guest powered off; stage0-init
+        // powers off on a failed build too. Read the guest's terminal marker
+        // from the console so a nix failure surfaces here with its own log
+        // instead of as a downstream "rootfs.ext4 missing" error.
+        let console_str = console_log.to_string_lossy();
+        let console = std::fs::read_to_string(&console_log).unwrap_or_default();
+        match stage0_console_halt_outcome(&console) {
+            Stage0HaltOutcome::CleanHalt => Ok(()),
+            Stage0HaltOutcome::BuildFailed => Err(BuilderVmError::NixBuildFailed(format!(
+                "nix build failed inside the Stage 0 guest; console log at {console_str}\n{}",
+                read_console_tail(&console_str, 20)
+            ))),
+            Stage0HaltOutcome::NoCleanHalt => Err(BuilderVmError::ExtractionFailed(format!(
+                "Stage 0 guest did not reach a clean halt; console log at {console_str}\n{}",
+                read_console_tail(&console_str, 20)
+            ))),
+        }
     }
 
     /// Run an in-tree shell script inside the existing builder VM
@@ -2493,6 +2509,34 @@ fn read_console_tail(console_log_path: &str, max_lines: usize) -> String {
     lines[start..].join("\n")
 }
 
+/// What the Stage 0 guest's console says about how it terminated.
+#[derive(Debug, PartialEq, Eq)]
+enum Stage0HaltOutcome {
+    /// `stage0-init` finished the build and copied artifacts to `/out`.
+    CleanHalt,
+    /// `nix build` (or a copy step) failed; the guest powered off anyway.
+    BuildFailed,
+    /// No terminal marker at all — a panic, kill, or truncated console.
+    NoCleanHalt,
+}
+
+/// Decide Stage 0 success from the guest console, not the VMM exit code. A
+/// libkrun supervisor that exits 0 only means the guest powered off — and
+/// `stage0-init` powers off cleanly on build failure too (its own error is
+/// printed, then `reboot`). Absent this check the caller would trip on a
+/// downstream "rootfs.ext4 missing" error that hides the real nix failure.
+/// `stage0-init` prints one stable terminal line, so match on it (the QEMU
+/// Stage 0 path keys on the same markers).
+fn stage0_console_halt_outcome(log: &str) -> Stage0HaltOutcome {
+    if log.contains("stage0-init: build failed") {
+        Stage0HaltOutcome::BuildFailed
+    } else if log.contains("stage0-init: done; halting") {
+        Stage0HaltOutcome::CleanHalt
+    } else {
+        Stage0HaltOutcome::NoCleanHalt
+    }
+}
+
 /// Render a Path as a `&str` or surface a clear error if it
 /// contains non-UTF-8 bytes. libkrun's C API takes
 /// `*const c_char`; rejecting non-UTF-8 here pins the failure
@@ -3625,6 +3669,36 @@ mod tests {
         assert_eq!(tail, "c\nd");
         // Missing file → empty, never panics.
         assert_eq!(read_console_tail("/nonexistent/console.log", 5), "");
+    }
+
+    #[test]
+    fn stage0_console_halt_outcome_distinguishes_success_failure_and_silence() {
+        // Clean build: the terminal success marker is present.
+        assert_eq!(
+            stage0_console_halt_outcome("nix log…\nstage0-init: done; halting\n"),
+            Stage0HaltOutcome::CleanHalt
+        );
+        // Failed build: the guest powers off cleanly but reports the failure —
+        // this must NOT read as success just because the VMM exited 0.
+        assert_eq!(
+            stage0_console_halt_outcome(
+                "error: home directory \"/homeless-shelter\" exists\n\
+                 stage0-init: build failed: nix build exit 1\n"
+            ),
+            Stage0HaltOutcome::BuildFailed
+        );
+        // Failure marker wins even if a stray success-looking line precedes it.
+        assert_eq!(
+            stage0_console_halt_outcome(
+                "stage0-init: done; halting\nstage0-init: build failed: x\n"
+            ),
+            Stage0HaltOutcome::BuildFailed
+        );
+        // Panic / kill / truncation: no terminal marker at all.
+        assert_eq!(
+            stage0_console_halt_outcome("kernel panic - not syncing\n"),
+            Stage0HaltOutcome::NoCleanHalt
+        );
     }
 
     #[cfg(unix)]


### PR DESCRIPTION
## Problem

`mvmctl dev` failed with a misleading error:

```
opening ~/.cache/mvm/builder-vm/.aarch64.stage0-<pid>-<nonce>/rootfs.ext4 as ext4
  io error: No such file or directory (os error 2)
```

The Stage 0 nix build had actually **failed inside the guest**. The guest console showed the real cause:

```
error: home directory "/homeless-shelter" exists; please remove it to assure purity of builds without sandboxing
stage0-init: build failed: nix build exit 1
```

Two defects:

1. **The blocker.** Nix runs *unsandboxed* inside the libkrun Stage 0 guest, so it uses `/homeless-shelter` as the builder's HOME and refuses to build if that dir already exists (its no-sandbox purity check). A crashed/interrupted prior build leaves it on the persistent guest root (`~/.cache/mvm/stage0/root/`), and `materialize_root_dir` reuses that root on a seed-marker match **without scrubbing guest-runtime dirs** — so every later `dev up` was wedged.

2. **The masking.** `run_stage0_impl` judged success purely by the supervisor/VMM exit code, but `stage0-init` powers the guest off cleanly even on `nix build exit 1`. The host returned `Ok` and then tripped downstream on the absent `rootfs.ext4`, hiding the real failure.

## Fix

- `stage0-init.rs`: `purge_stale_nix_builder_home()` removes a stale `/homeless-shelter` before invoking nix, so a crashed run self-heals instead of wedging the bootstrap.
- `libkrun_builder.rs`: `stage0_console_halt_outcome()` reads the guest's `done; halting` / `build failed` terminal markers from the console after the VMM exits (matching the QEMU Stage 0 path) and surfaces `NixBuildFailed` with the console tail instead of the "rootfs.ext4 missing" red herring.

## Testing

- New unit tests for both helpers (`purge_stale_nix_builder_home_*`, `stage0_console_halt_outcome_*`).
- Both changes compile for Linux (zigbuild cross, `stage0-init` bin + tests).
- `fmt --all --check` (nightly) clean; `clippy --all-features` clean; `mvm-build` suite 639 passed.