### PR TITLE
feat(guest): deliver host-signer verb-grant anchor to vsock-only guests

### DIFF
--- a/crates/mvm-backend/src/hvf_backend.rs
+++ b/crates/mvm-backend/src/hvf_backend.rs
@@ -210,12 +210,19 @@ fn persist_vsock_egress_marker(name: &str, enabled: bool) -> Result<()> {
 }
 
 fn hvf_workload_cmdline(config: &VmStartConfig, state_dir: &Path) -> Option<String> {
-    let token = vsock_egress_cmdline_token(config, state_dir)?;
+    let egress = vsock_egress_cmdline_token(config, state_dir);
+    let grants = crate::hvf_bootargs::grant_tokens(&config.name);
+    // Nothing to add ⇒ let the boot path fall back to its built-in default.
+    if egress.is_none() && grants.is_empty() {
+        return None;
+    }
     let virtiofs_root = config.virtiofs_root.is_some();
     let has_disk = !virtiofs_root && !config.rootfs_path.is_empty();
     let mut cmdline = crate::hvf_bootargs::workload_bootargs(virtiofs_root, has_disk);
-    cmdline.push(' ');
-    cmdline.push_str(&token);
+    for token in egress.into_iter().chain(grants) {
+        cmdline.push(' ');
+        cmdline.push_str(&token);
+    }
     Some(cmdline)
 }
 

--- a/crates/mvm-backend/src/hvf_bootargs.rs
+++ b/crates/mvm-backend/src/hvf_bootargs.rs
@@ -34,3 +34,84 @@ pub fn workload_bootargs(virtiofs_root: bool, has_disk: bool) -> String {
         default_bootargs(has_disk)
     }
 }
+
+/// Plan-bound grant cmdline tokens for `vm_name`, in the order the libkrun
+/// supervisor cmdline carries them: the verb grant envelope, the enforcement
+/// assertion, and the out-of-band host-signer trust anchor. HVF is a vsock-only
+/// backend with no config drive, so all three ride the cmdline to reach parity
+/// with libkrun. Empty when the plan minted no grant sidecar.
+pub(crate) fn grant_tokens(vm_name: &str) -> Vec<String> {
+    [
+        crate::microvm::verb_grant_cmdline_token(vm_name),
+        crate::microvm::require_grant_cmdline_token(vm_name),
+        crate::microvm::host_signer_pub_cmdline_token(vm_name),
+    ]
+    .into_iter()
+    .flatten()
+    .collect()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn seed_grant_sidecar_and_key(vm_name: &str) {
+        use mvm_core::plan::{Nonce, VerbGrant, VerbId};
+        use mvm_core::protocol::vm_backend::VerbGrantEnvelope;
+
+        let state_dir = mvm_core::config::vm_state_dir(vm_name);
+        std::fs::create_dir_all(&state_dir).unwrap();
+        let nonce = Nonce::from_bytes([3u8; 16]);
+        let not_after = mvm_core::time::parse_iso8601("2099-01-01T00:00:00Z").unwrap();
+        let envelope = VerbGrantEnvelope {
+            pubkey_hex: "cc".repeat(32),
+            plan_nonce_hex: nonce.as_hex().to_string(),
+            grant: VerbGrant {
+                session_id: vm_name.to_string(),
+                plan_nonce: nonce,
+                not_after,
+                verbs: vec![VerbId::new("run-entrypoint").unwrap()],
+                sig: vec![0u8; 64],
+            },
+        };
+        std::fs::write(
+            state_dir.join("verb-grant.json"),
+            serde_json::to_vec(&envelope).unwrap(),
+        )
+        .unwrap();
+        let keys_dir = mvm_core::config::mvm_keys_dir();
+        std::fs::create_dir_all(&keys_dir).unwrap();
+        std::fs::write(keys_dir.join("host-signer.pub"), [0xEEu8; 32]).unwrap();
+    }
+
+    #[test]
+    fn grant_tokens_appends_all_three_for_parity_with_libkrun() {
+        let dir = tempfile::tempdir().unwrap();
+        let mut env = mvm_core::util::test_env::TestEnv::new();
+        env.set("MVM_DATA_DIR", dir.path());
+
+        let vm_name = "hvf-grant-parity";
+        seed_grant_sidecar_and_key(vm_name);
+
+        let tokens = grant_tokens(vm_name);
+        assert_eq!(tokens.len(), 3, "must emit all three grant tokens");
+        assert!(tokens[0].starts_with("mvm.verb_grant="), "verb grant first");
+        assert_eq!(tokens[1], "mvm.require_grant=1", "enforcement assertion");
+        assert!(
+            tokens[2].starts_with("mvm.host_signer_pub="),
+            "trust anchor last"
+        );
+    }
+
+    #[test]
+    fn grant_tokens_empty_without_sidecar() {
+        let dir = tempfile::tempdir().unwrap();
+        let mut env = mvm_core::util::test_env::TestEnv::new();
+        env.set("MVM_DATA_DIR", dir.path());
+
+        assert!(
+            grant_tokens("hvf-no-grant").is_empty(),
+            "no sidecar ⇒ no grant tokens"
+        );
+    }
+}

--- a/crates/mvm-backend/src/hvf_bootargs.rs
+++ b/crates/mvm-backend/src/hvf_bootargs.rs
@@ -96,7 +96,11 @@ mod tests {
         let tokens = grant_tokens(vm_name);
         assert_eq!(tokens.len(), 3, "must emit all three grant tokens");
         assert!(tokens[0].starts_with("mvm.verb_grant="), "verb grant first");
-        assert_eq!(tokens[1], "mvm.require_grant=1", "enforcement assertion");
+        assert_eq!(
+            tokens[1],
+            crate::microvm::require_grant_cmdline_token(vm_name).unwrap(),
+            "enforcement token matches the canonical emitter"
+        );
         assert!(
             tokens[2].starts_with("mvm.host_signer_pub="),
             "trust anchor last"

--- a/crates/mvm-backend/src/libkrun.rs
+++ b/crates/mvm-backend/src/libkrun.rs
@@ -315,6 +315,12 @@ fn build_supervisor_config(config: &VmStartConfig, state_dir: &Path) -> Result<S
         cmdline.push(' ');
         cmdline.push_str(&token);
     }
+    // Vsock-only guests have no config drive, so the grant trust anchor rides
+    // the cmdline instead.
+    if let Some(token) = crate::microvm::host_signer_pub_cmdline_token(&config.name) {
+        cmdline.push(' ');
+        cmdline.push_str(&token);
+    }
     let vsock_egress_opt_in = mvm_build::libkrun_network_provider::vsock_egress_opt_in();
     if let Some(token) = vsock_egress_cmdline_token(
         vsock_egress_opt_in,

--- a/crates/mvm-backend/src/microvm.rs
+++ b/crates/mvm-backend/src/microvm.rs
@@ -3065,6 +3065,35 @@ pub(crate) fn require_grant_cmdline_token(vm_name: &str) -> Option<String> {
     path.exists().then(|| "mvm.require_grant=1".to_string())
 }
 
+/// Filename of the host-signer public verifying key under the keys dir. The raw
+/// 32-byte Ed25519 public key the grant is verified against.
+const HOST_SIGNER_PUBKEY_FILENAME: &str = "host-signer.pub";
+
+/// The `mvm.host_signer_pub=<hex>` cmdline token for `vm_name`, or `None` when
+/// no verb-grant sidecar was minted (plan carried no `agent_verbs`).
+///
+/// Delivers the host-signer public verifying key — the grant trust anchor — out
+/// of band on the kernel cmdline. On the block backends the anchor rides the
+/// config drive, but a sealed vsock-only guest has no config drive, so the
+/// cmdline is its only per-VM channel. This is a public key, safe on
+/// `/proc/cmdline`. Keyed on the same sidecar the grant token reads, so the
+/// anchor is present exactly when a grant is. Best-effort: a missing or
+/// wrong-sized key file yields `None`, degrading to a grant-less boot rather
+/// than blocking.
+pub(crate) fn host_signer_pub_cmdline_token(vm_name: &str) -> Option<String> {
+    let sidecar = mvm_core::config::vm_state_dir(vm_name).join("verb-grant.json");
+    if !sidecar.exists() {
+        return None;
+    }
+    let pubkey_path = mvm_core::config::mvm_keys_dir().join(HOST_SIGNER_PUBKEY_FILENAME);
+    let bytes = std::fs::read(&pubkey_path).ok()?;
+    if bytes.len() != 32 {
+        return None;
+    }
+    let hex: String = bytes.iter().map(|b| format!("{b:02x}")).collect();
+    Some(format!("mvm.host_signer_pub={hex}"))
+}
+
 /// Spawn the `mvm-bridge` sibling. Creates a UNIX
 /// socketpair, clears `O_CLOEXEC` on both halves in the child via
 /// `CommandExt::pre_exec` so they survive `execve`, then pipes the
@@ -4433,6 +4462,85 @@ mod tests {
         assert!(
             require_grant_cmdline_token(vm_name).is_none(),
             "absent sidecar must yield None"
+        );
+    }
+
+    // ---- host_signer_pub_cmdline_token ----
+
+    /// Write both the verb-grant sidecar (its content is irrelevant here — the
+    /// token is keyed on existence) and a raw 32-byte host-signer pubkey under
+    /// the data dir keys/ directory.
+    fn seed_grant_and_pubkey(vm_name: &str, pubkey: &[u8; 32]) {
+        let state_dir = mvm_core::config::vm_state_dir(vm_name);
+        std::fs::create_dir_all(&state_dir).unwrap();
+        std::fs::write(state_dir.join("verb-grant.json"), b"{}").unwrap();
+        let keys_dir = mvm_core::config::mvm_keys_dir();
+        std::fs::create_dir_all(&keys_dir).unwrap();
+        std::fs::write(keys_dir.join("host-signer.pub"), pubkey).unwrap();
+    }
+
+    #[test]
+    fn host_signer_pub_cmdline_token_some_when_grant_and_key_present() {
+        let dir = tempfile::tempdir().unwrap();
+        let mut env = mvm_core::util::test_env::TestEnv::new();
+        env.set("MVM_DATA_DIR", dir.path());
+
+        let vm_name = "host-signer-pub-present";
+        let pubkey = [0xABu8; 32];
+        seed_grant_and_pubkey(vm_name, &pubkey);
+
+        let token = host_signer_pub_cmdline_token(vm_name).expect("token must be Some");
+        let expected_hex = "ab".repeat(32);
+        assert_eq!(token, format!("mvm.host_signer_pub={expected_hex}"));
+
+        // Round-trip: the value decodes back to the exact key bytes.
+        let hex_part = token.trim_start_matches("mvm.host_signer_pub=");
+        let decoded: Vec<u8> = (0..hex_part.len())
+            .step_by(2)
+            .map(|i| u8::from_str_radix(&hex_part[i..i + 2], 16).unwrap())
+            .collect();
+        assert_eq!(decoded, pubkey.to_vec());
+    }
+
+    #[test]
+    fn host_signer_pub_cmdline_token_none_when_grant_absent() {
+        let dir = tempfile::tempdir().unwrap();
+        let mut env = mvm_core::util::test_env::TestEnv::new();
+        env.set("MVM_DATA_DIR", dir.path());
+
+        // Key present, but no verb-grant sidecar (plan carried no agent_verbs).
+        let keys_dir = mvm_core::config::mvm_keys_dir();
+        std::fs::create_dir_all(&keys_dir).unwrap();
+        std::fs::write(keys_dir.join("host-signer.pub"), [0u8; 32]).unwrap();
+
+        let vm_name = "host-signer-pub-no-grant";
+        let state_dir = mvm_core::config::vm_state_dir(vm_name);
+        std::fs::create_dir_all(&state_dir).unwrap();
+
+        assert!(
+            host_signer_pub_cmdline_token(vm_name).is_none(),
+            "no grant sidecar must yield None even when the key exists"
+        );
+    }
+
+    #[test]
+    fn host_signer_pub_cmdline_token_none_when_key_wrong_size() {
+        let dir = tempfile::tempdir().unwrap();
+        let mut env = mvm_core::util::test_env::TestEnv::new();
+        env.set("MVM_DATA_DIR", dir.path());
+
+        let vm_name = "host-signer-pub-bad-key";
+        let state_dir = mvm_core::config::vm_state_dir(vm_name);
+        std::fs::create_dir_all(&state_dir).unwrap();
+        std::fs::write(state_dir.join("verb-grant.json"), b"{}").unwrap();
+        let keys_dir = mvm_core::config::mvm_keys_dir();
+        std::fs::create_dir_all(&keys_dir).unwrap();
+        // 31 bytes: not a valid Ed25519 public key length.
+        std::fs::write(keys_dir.join("host-signer.pub"), [1u8; 31]).unwrap();
+
+        assert!(
+            host_signer_pub_cmdline_token(vm_name).is_none(),
+            "a wrong-sized key must yield None (best-effort, no boot block)"
         );
     }
 }

--- a/crates/mvm-guest/src/bin/mvm-oci-init.rs
+++ b/crates/mvm-guest/src/bin/mvm-oci-init.rs
@@ -26,6 +26,7 @@ mod linux {
         mount_user_volumes();
         provision_egress_ca();
         provision_verb_grant();
+        provision_host_signer_pub();
         run_one(resolve_exec([NETINIT_OVERLAY, NETINIT_FALLBACK]), "netinit");
         if cmdline_has_flag("mvm.vsock_egress=1") {
             bring_loopback_up();
@@ -156,6 +157,35 @@ mod linux {
         if let Err(e) = fs::write("/run/mvm/verb-grant.json", grant) {
             eprintln!("mvm-oci-init: write verb grant: {e}");
         }
+    }
+
+    /// Provision the out-of-band host-signer trust anchor delivered on the kernel
+    /// cmdline. Block backends copy this key off the config drive; a vsock-only
+    /// guest has no config drive, so the launcher rides the 32-byte public key on
+    /// `mvm.host_signer_pub=<hex>` and the agent verifies the grant against it.
+    fn provision_host_signer_pub() {
+        let Some(hex) = cmdline_value("mvm.host_signer_pub") else {
+            return;
+        };
+        if let Err(e) = write_host_signer_pub(Path::new("/"), &hex) {
+            eprintln!("mvm-oci-init: {e}");
+        }
+    }
+
+    /// Decode the hex host-signer pubkey token and write the raw key bytes to
+    /// `<root>/run/mvm/host-signer.pub` with mode 0644. `root` is a seam for
+    /// tests; production passes `/`.
+    fn write_host_signer_pub(root: &Path, hex: &str) -> Result<(), String> {
+        use std::os::unix::fs::PermissionsExt;
+        let bytes =
+            hex_decode(hex).map_err(|()| "malformed host-signer pubkey token".to_string())?;
+        let dir = root.join("run/mvm");
+        fs::create_dir_all(&dir).map_err(|e| format!("mkdir {}: {e}", dir.display()))?;
+        let path = dir.join("host-signer.pub");
+        fs::write(&path, &bytes).map_err(|e| format!("write {}: {e}", path.display()))?;
+        fs::set_permissions(&path, fs::Permissions::from_mode(0o644))
+            .map_err(|e| format!("chmod {}: {e}", path.display()))?;
+        Ok(())
     }
 
     fn mount_fs(
@@ -385,6 +415,32 @@ mod linux {
             assert!(!loopback_flags_indicate_up("0x8\n"));
             assert!(loopback_flags_indicate_up("0x9\n"));
             assert!(!loopback_flags_indicate_up("garbage"));
+        }
+
+        #[test]
+        fn write_host_signer_pub_writes_bytes_mode_0644() {
+            use std::os::unix::fs::PermissionsExt;
+            let dir = tempfile::tempdir().unwrap();
+            let pubkey = [0xABu8; 32];
+            let hex: String = pubkey.iter().map(|b| format!("{b:02x}")).collect();
+
+            write_host_signer_pub(dir.path(), &hex).unwrap();
+
+            let path = dir.path().join("run/mvm/host-signer.pub");
+            let written = fs::read(&path).unwrap();
+            assert_eq!(written, pubkey.to_vec(), "raw key bytes must round-trip");
+            let mode = fs::metadata(&path).unwrap().permissions().mode() & 0o777;
+            assert_eq!(mode, 0o644, "host-signer.pub must be mode 0644");
+        }
+
+        #[test]
+        fn write_host_signer_pub_rejects_malformed_hex() {
+            let dir = tempfile::tempdir().unwrap();
+            assert!(write_host_signer_pub(dir.path(), "zz").is_err());
+            assert!(
+                !dir.path().join("run/mvm/host-signer.pub").exists(),
+                "no file written on malformed input"
+            );
         }
     }
 }

--- a/crates/mvm-guest/src/vsock.rs
+++ b/crates/mvm-guest/src/vsock.rs
@@ -7483,6 +7483,7 @@ mod rpc_client_tests {
         signer: &ed25519_dalek::SigningKey,
         session: &str,
         nonce: &mvm_core::plan::Nonce,
+        verbs: &[&str],
         valid_minutes: i64,
     ) -> (std::path::PathBuf, std::path::PathBuf) {
         use mvm_core::plan::{VerbGrant, VerbId};
@@ -7492,7 +7493,7 @@ mod rpc_client_tests {
             session_id: session.into(),
             plan_nonce: nonce.clone(),
             not_after: now + chrono::Duration::minutes(valid_minutes),
-            verbs: vec![VerbId::new("ping").unwrap()],
+            verbs: verbs.iter().map(|v| VerbId::new(v).unwrap()).collect(),
             sig: vec![],
         };
         grant.sig = {
@@ -7523,7 +7524,7 @@ mod rpc_client_tests {
         let signer = ed25519_dalek::SigningKey::from_bytes(&[7u8; 32]);
         let nonce = mvm_core::plan::Nonce::from_bytes([8u8; 16]);
         let (grant_path, pubkey_path) =
-            write_grant_fixture(dir.path(), &signer, "sess-valid", &nonce, 10);
+            write_grant_fixture(dir.path(), &signer, "sess-valid", &nonce, &["ping"], 10);
         let now = chrono::Utc::now();
         let result = load_pinned_verb_grant(&grant_path, &pubkey_path, now);
         assert!(
@@ -7589,7 +7590,7 @@ mod rpc_client_tests {
         let attacker = ed25519_dalek::SigningKey::from_bytes(&[13u8; 32]);
         let nonce = mvm_core::plan::Nonce::from_bytes([14u8; 16]);
         let (grant_path, pubkey_path) =
-            write_grant_fixture(dir.path(), &signer, "sess-wrong-key", &nonce, 10);
+            write_grant_fixture(dir.path(), &signer, "sess-wrong-key", &nonce, &["ping"], 10);
         let attacker_pubkey_hex: String = attacker
             .verifying_key()
             .to_bytes()
@@ -7610,14 +7611,109 @@ mod rpc_client_tests {
         let dir = tempfile::tempdir().unwrap();
         let signer = ed25519_dalek::SigningKey::from_bytes(&[15u8; 32]);
         let nonce = mvm_core::plan::Nonce::from_bytes([16u8; 16]);
-        let (grant_path, pubkey_path) =
-            write_grant_fixture(dir.path(), &signer, "sess-bad-pubkey", &nonce, 10);
+        let (grant_path, pubkey_path) = write_grant_fixture(
+            dir.path(),
+            &signer,
+            "sess-bad-pubkey",
+            &nonce,
+            &["ping"],
+            10,
+        );
         std::fs::write(&pubkey_path, "not-valid-hex\n").unwrap();
         let result = load_pinned_verb_grant(&grant_path, &pubkey_path, chrono::Utc::now());
         assert!(
             result.is_none(),
             "malformed config-drive pubkey must return None"
         );
+    }
+
+    /// The vsock-only payoff: when the host-signer pubkey is present (as the
+    /// cmdline-delivered trust anchor now provides on the OCI/vsock path), a
+    /// valid pinned grant enforces its verb list SELECTIVELY — the listed verb
+    /// (and baseline verbs) are served while an unlisted verb is refused —
+    /// instead of collapsing to a deny-all posture. Drives the real per-verb
+    /// gate `enforce_verb_grant` against the pinned grant, not just a
+    /// grant-present shortcut.
+    #[test]
+    fn present_host_signer_pub_enforces_verb_list_selectively() {
+        let dir = tempfile::tempdir().unwrap();
+        let signer = ed25519_dalek::SigningKey::from_bytes(&[21u8; 32]);
+        let nonce = mvm_core::plan::Nonce::from_bytes([22u8; 16]);
+        // List a single non-baseline verb so "listed" is distinguishable from
+        // the always-answerable baseline set.
+        let (grant_path, pubkey_path) = write_grant_fixture(
+            dir.path(),
+            &signer,
+            "sess-selective",
+            &nonce,
+            &["update-idle-timeout"],
+            10,
+        );
+        let now = chrono::Utc::now();
+
+        // Anchor present ⇒ grant pins, carrying the listed verb.
+        let pinned = load_pinned_verb_grant(&grant_path, &pubkey_path, now)
+            .expect("anchor present ⇒ valid grant must pin");
+        assert!(
+            pinned
+                .verbs
+                .iter()
+                .any(|v| v.as_str() == "update-idle-timeout"),
+            "listed verb must survive into the pinned grant"
+        );
+
+        // Listed, non-baseline verb ⇒ enforce_verb_grant permits (no refusal).
+        let listed = GuestRequest::UpdateIdleTimeout { secs: 0 };
+        assert!(
+            enforce_verb_grant(&listed, Some(&pinned)).is_none(),
+            "listed verb must be served under the pinned grant"
+        );
+        // Baseline verb ⇒ permitted even though absent from the verb list.
+        assert!(
+            enforce_verb_grant(&GuestRequest::Ping, Some(&pinned)).is_none(),
+            "baseline verb must be served regardless of the verb list"
+        );
+        // Unlisted, non-baseline verb ⇒ refused. This is what proves selective
+        // enforcement rather than deny-all or serve-all.
+        let unlisted = GuestRequest::WorkerStatus;
+        let unlisted_name = unlisted.kind_name();
+        match enforce_verb_grant(&unlisted, Some(&pinned)) {
+            Some(GuestResponse::VerbNotAuthorized { verb }) => assert_eq!(verb, unlisted_name),
+            other => panic!("unlisted verb must be refused, got {other:?}"),
+        }
+
+        // Anchor absent ⇒ no grant pins ⇒ launch-asserted enforcement fails closed.
+        let missing_anchor = dir.path().join("no-host-signer.pub");
+        assert!(
+            load_pinned_verb_grant(&grant_path, &missing_anchor, now).is_none(),
+            "absent anchor is the current OCI/vsock regression: grant cannot pin"
+        );
+        assert_eq!(
+            trust_decision(None, false, true),
+            TrustDecision::FailClosed,
+            "no grant under launch-asserted enforcement is the deny-all path"
+        );
+    }
+
+    /// The shipped anchor form: `mvm-oci-init` writes `host-signer.pub` as the
+    /// RAW 32 pubkey bytes, not hex. Exercise that byte layout end-to-end
+    /// through the reader into `load_pinned_verb_grant`.
+    #[test]
+    fn load_pinned_verb_grant_accepts_raw_32_byte_pubkey() {
+        let dir = tempfile::tempdir().unwrap();
+        let signer = ed25519_dalek::SigningKey::from_bytes(&[23u8; 32]);
+        let nonce = mvm_core::plan::Nonce::from_bytes([24u8; 16]);
+        let (grant_path, pubkey_path) =
+            write_grant_fixture(dir.path(), &signer, "sess-raw", &nonce, &["ping"], 10);
+        // Replace the hex fixture pubkey with the raw 32-byte form.
+        std::fs::write(&pubkey_path, signer.verifying_key().to_bytes()).unwrap();
+        assert_eq!(std::fs::read(&pubkey_path).unwrap().len(), 32);
+        let result = load_pinned_verb_grant(&grant_path, &pubkey_path, chrono::Utc::now());
+        assert!(
+            result.is_some(),
+            "raw 32-byte host-signer pubkey must pin the grant (not the anchor-absent None path)"
+        );
+        assert_eq!(result.unwrap().session_id, "sess-raw");
     }
 
     #[test]
@@ -7654,7 +7750,7 @@ mod rpc_client_tests {
         let signer = ed25519_dalek::SigningKey::from_bytes(&[20u8; 32]);
         let nonce = mvm_core::plan::Nonce::from_bytes([21u8; 16]);
         let (grant_path, _pubkey_path) =
-            write_grant_fixture(dir.path(), &signer, "sess-repin", &nonce, 10);
+            write_grant_fixture(dir.path(), &signer, "sess-repin", &nonce, &["ping"], 10);
         let now = chrono::Utc::now();
         // Load the envelope from the fixture file and call re_pin_verb_grant directly.
         let raw = std::fs::read(&grant_path).unwrap();


### PR DESCRIPTION
Plan 236 Phase 1, §1.1–1.3 + §1.5. Enables sealed guests on the vsock-only backends (libkrun, HVF) to pin and selectively enforce plan-bound verb grants on the real boot path.

## Problem
The host-signer public key (verb-grant trust anchor) shipped only via the config drive, which exists only on the block backends (Firecracker/qemu). On the OCI/vsock path there is no config drive, so `load_pinned_verb_grant` always hit the anchor-absent arm: libkrun fell to fail-closed deny-all, and HVF (which appended no grant tokens at all) enforced nothing.

## Change
- New `host_signer_pub_cmdline_token` emits `mvm.host_signer_pub=<hex>` (public key — safe on `/proc/cmdline`), gated on the grant sidecar existing, reading the same key source as the config-drive path.
- libkrun appends the new token; HVF brought to full grant-token parity (verb_grant + require_grant + host_signer_pub — previously none).
- `mvm-oci-init` provisions `/run/mvm/host-signer.pub` (0644) before the agent starts.

## Tests
- Cmdline token round-trip + absent/wrong-size cases; HVF three-token parity.
- OCI provisioning writes the anchor (0644) — Linux-cfg-gated, zigbuild-verified.
- Selective enforcement: drives `enforce_verb_grant` proving a listed verb is served, baseline served, and an unlisted verb → `VerbNotAuthorized`; plus a raw-32-byte anchor round-trip.

Adversarial review confirmed key-correspondence is correct and every failure mode fails closed (deny-all), never toward bypass. nightly-fmt / clippy `--all-targets` / full mvm-guest suite (441) green.

## Scope / deferred
Does not bake `verb-trust.json` (§1.4, next slice), does not rename `no_guest_nic` (§3.1), and does not touch Firecracker/qemu. macOS live proof (§1.6) is deferred pending the workload-kernel checksum manifest.