### PR TITLE
refactor(backend): rename no_guest_nic to no_routable_guest_nic

### DIFF
--- a/crates/mvm-backend/src/hvf_backend.rs
+++ b/crates/mvm-backend/src/hvf_backend.rs
@@ -274,7 +274,7 @@ impl VmBackend for HvfBackend {
             // rides the host vsock proxy (the gating endpoint), not a guest NIC.
             // Advertise those workload-path capabilities only when the detached
             // supervisor path is actually launchable on this host.
-            no_guest_nic: proxy_path_ready,
+            no_routable_guest_nic: proxy_path_ready,
             host_vsock_proxy: proxy_path_ready,
             // The hvf VMM can serve the unpacked OCI tree as a read-only
             // virtiofs root (dev tier); the run-path tier gate selects it only for
@@ -718,7 +718,7 @@ mod tests {
         unsafe {
             std::env::remove_var("MVM_HVF_SUPERVISOR_PATH");
         }
-        assert!(!caps.no_guest_nic);
+        assert!(!caps.no_routable_guest_nic);
         assert!(!caps.host_vsock_proxy);
         assert!(!caps.virtiofs_root);
     }
@@ -744,7 +744,7 @@ mod tests {
             std::env::remove_var("MVM_HVF_SUPERVISOR_PATH");
         }
         assert!(available);
-        assert!(caps.no_guest_nic);
+        assert!(caps.no_routable_guest_nic);
         assert!(caps.host_vsock_proxy);
         assert!(caps.virtiofs_root);
     }

--- a/crates/mvm-backend/src/libkrun.rs
+++ b/crates/mvm-backend/src/libkrun.rs
@@ -480,7 +480,9 @@ impl VmBackend for LibkrunBackend {
             snapshots: false,
             vsock: true,
             tap_networking: false,
-            no_guest_nic: true,
+            // The virtio-net device is attached but drained into a disconnected
+            // sink with no upstream route, so the guest still has no routable NIC.
+            no_routable_guest_nic: true,
             host_vsock_proxy: true,
             // libkrun's C API doesn't expose virtio-balloon control
             // today; the upstream crate carries no `.balloon(...)`
@@ -1195,7 +1197,7 @@ mod tests {
     fn libkrun_capabilities() {
         let caps = LibkrunBackend.capabilities();
         assert!(caps.vsock);
-        assert!(caps.no_guest_nic);
+        assert!(caps.no_routable_guest_nic);
         assert!(caps.host_vsock_proxy);
         assert!(!caps.snapshots);
         assert!(!caps.pause_resume);

--- a/crates/mvm-cli/src/commands/vm/exec.rs
+++ b/crates/mvm-cli/src/commands/vm/exec.rs
@@ -1266,7 +1266,7 @@ fn oci_vsock_proxy_env_for_capabilities(
     if !image_requested || !network_policy.allows_egress() {
         return Vec::new();
     }
-    if !(caps.vsock && caps.no_guest_nic && caps.host_vsock_proxy) {
+    if !(caps.vsock && caps.no_routable_guest_nic && caps.host_vsock_proxy) {
         return Vec::new();
     }
     mvm_core::guest_netd::proxy_env_vars("127.0.0.1:1080")
@@ -1540,7 +1540,7 @@ mod tests {
     fn oci_vsock_proxy_env_requires_image_egress_and_vsock_proxy_backend() {
         let hvf_proxy_caps = mvm_core::vm_backend::VmCapabilities {
             vsock: true,
-            no_guest_nic: true,
+            no_routable_guest_nic: true,
             host_vsock_proxy: true,
             ..mvm_core::vm_backend::VmCapabilities::default()
         };
@@ -1603,7 +1603,7 @@ mod tests {
             oci_vsock_proxy_env_for_capabilities(
                 &mvm_core::vm_backend::VmCapabilities {
                     vsock: true,
-                    no_guest_nic: true,
+                    no_routable_guest_nic: true,
                     host_vsock_proxy: true,
                     ..mvm_core::vm_backend::VmCapabilities::default()
                 },

--- a/crates/mvm-cli/src/exec.rs
+++ b/crates/mvm-cli/src/exec.rs
@@ -317,7 +317,7 @@ fn requires_vsock_proxy_backend(
 fn vsock_proxy_backend_requirements() -> RequiredCapabilities {
     RequiredCapabilities {
         vsock: true,
-        no_guest_nic: true,
+        no_routable_guest_nic: true,
         host_vsock_proxy: true,
         ..Default::default()
     }
@@ -1557,7 +1557,7 @@ mod tests {
         assert!(msg.contains("NIC-less host-vsock-proxy backend"));
         assert!(msg.contains("backend hvf lacks ["));
         assert!(msg.contains("host_vsock_proxy"));
-        assert!(msg.contains("no_guest_nic"));
+        assert!(msg.contains("no_routable_guest_nic"));
     }
 
     #[cfg(all(target_os = "macos", target_arch = "aarch64"))]

--- a/crates/mvm-core/src/protocol/vm_backend.rs
+++ b/crates/mvm-core/src/protocol/vm_backend.rs
@@ -549,8 +549,13 @@ pub struct VmCapabilities {
     /// Backend can restore a guest by eager copy-on-write (`MAP_PRIVATE`) of a
     /// snapshot RAM section — the primary local warm-restore path.
     pub eager_cow_restore: bool,
-    /// Backend can run a guest with no virtio-net device (no guest NIC).
-    pub no_guest_nic: bool,
+    /// Guest has no host-routable NIC: nothing in the guest can reach the
+    /// network by IP. This is a reachability guarantee, not a device-count one
+    /// — a backend that attaches a virtio-net device but drains/sinks it with
+    /// no upstream route still satisfies this (libkrun), and so does a backend
+    /// that presents no NIC at all (HVF). Egress, when permitted, rides the
+    /// vsock proxy instead.
+    pub no_routable_guest_nic: bool,
     /// Backend supports host/vsock-mediated networking (egress/ingress brokers
     /// over vsock) instead of a guest NIC.
     pub host_vsock_proxy: bool,
@@ -581,7 +586,7 @@ pub struct RequiredCapabilities {
     pub device_state_snapshot: bool,
     pub vcpu_state_snapshot: bool,
     pub vsock: bool,
-    pub no_guest_nic: bool,
+    pub no_routable_guest_nic: bool,
     pub host_vsock_proxy: bool,
     pub pty_exec: bool,
 }
@@ -617,7 +622,11 @@ impl VmCapabilities {
                 "vcpu_state_snapshot",
             ),
             (required.vsock, self.vsock, "vsock"),
-            (required.no_guest_nic, self.no_guest_nic, "no_guest_nic"),
+            (
+                required.no_routable_guest_nic,
+                self.no_routable_guest_nic,
+                "no_routable_guest_nic",
+            ),
             (
                 required.host_vsock_proxy,
                 self.host_vsock_proxy,

--- a/crates/mvm/src/machine/mod.rs
+++ b/crates/mvm/src/machine/mod.rs
@@ -171,7 +171,7 @@ impl Machine {
             NetworkMode::None => {}
             NetworkMode::HostVsockProxy => {
                 req.host_vsock_proxy = true;
-                req.no_guest_nic = true;
+                req.no_routable_guest_nic = true;
             }
         }
         req
@@ -264,7 +264,7 @@ mod tests {
             .unwrap();
         let req = machine.required_capabilities();
         assert!(req.host_vsock_proxy);
-        assert!(req.no_guest_nic);
+        assert!(req.no_routable_guest_nic);
     }
 
     #[test]
@@ -315,7 +315,7 @@ mod tests {
         let backend = machine.select_backend().expect("select backend");
         let caps = backend.capabilities();
         assert!(caps.host_vsock_proxy);
-        assert!(caps.no_guest_nic);
+        assert!(caps.no_routable_guest_nic);
     }
 
     #[test]

--- a/public/src/content/docs/reference/cli-commands.md
+++ b/public/src/content/docs/reference/cli-commands.md
@@ -553,9 +553,11 @@ stored machine requests outbound egress and is OCI-backed (`machine create
 --image`, `machine create --manifest` with an image-backed manifest, or
 `machine run -d --image`), `machine start` applies the same NIC-less
 host-vsock-proxy backend gate as transient `run --image`: only backends that
-honestly advertise `{ vsock, no_guest_nic, host_vsock_proxy }` are allowed,
-and incapable backends are refused instead of silently falling back to a guest
-NIC helper or `passt`. When the named spec came from an image-backed
+honestly advertise `{ vsock, no_routable_guest_nic, host_vsock_proxy }` are
+allowed, and incapable backends are refused instead of silently falling back to
+a guest NIC helper or `passt`. `no_routable_guest_nic` is a reachability
+guarantee: it holds whether the backend attaches a drained/sinked virtio-net
+device with no upstream route or presents no NIC device at all. When the named spec came from an image-backed
 manifest, `machine create --manifest`
 persists the manifest's `net`, `[network].allow_hosts`, `cpus`, `mem`,
 `mem_initial`, `[dev].volumes`, and `[dev].init` fields into the durable


### PR DESCRIPTION
Plan 236 Phase 1 §3.1 — the capability-honesty rename.

`no_guest_nic` was documented as device-level absence ("no virtio-net device"), but libkrun attaches a drained/sinked virtio-net device (no upstream route, no gateway) — so the field was literally false there while the security-relevant property (no host-routable NIC) held. Backend selection matches this field fail-closed, so an inaccurate name risked sealing a workload onto a backend under a false premise.

## Change
- Rename `no_guest_nic` → `no_routable_guest_nic` on `VmCapabilities` and `RequiredCapabilities`, and the `shortfall()` diagnostic string.
- Redefine the doc-comment to the reachability guarantee it actually encodes: nothing in the guest can reach the network by IP; a drained/sinked NIC (libkrun) and no NIC at all (HVF) both satisfy it.
- Values unchanged: libkrun/HVF `true`, Firecracker/qemu `false`.

## Safety
The capability structs carry no serde derives — no wire/on-disk contract, no mvmd coordination — so this is a contained in-process hard rename (~15 sites, 3 crates + one user-facing doc). nightly-fmt / clippy `--all-targets` / no-spec-refs all clean.

Companion to #1615 (which edits `hvf_backend.rs`/`libkrun.rs` in different regions — cmdline token appends, not the `capabilities()` field); a trivial rebase may be needed depending on merge order.