### PR TITLE
fix(guest): verify PostRestore verb-grant re-pin against the host anchor

### DIFF
--- a/crates/mvm-backend/src/libkrun.rs
+++ b/crates/mvm-backend/src/libkrun.rs
@@ -1662,6 +1662,81 @@ mod tests {
         assert_eq!(vsock_egress_cmdline_token(true, true), None);
     }
 
+    fn seed_grant_sidecar_and_key(vm_name: &str) {
+        use mvm_core::plan::{Nonce, VerbGrant, VerbId};
+        use mvm_core::protocol::vm_backend::VerbGrantEnvelope;
+
+        let state_dir = mvm_core::config::vm_state_dir(vm_name);
+        std::fs::create_dir_all(&state_dir).unwrap();
+        let nonce = Nonce::from_bytes([3u8; 16]);
+        let not_after = mvm_core::time::parse_iso8601("2099-01-01T00:00:00Z").unwrap();
+        let envelope = VerbGrantEnvelope {
+            pubkey_hex: "cc".repeat(32),
+            plan_nonce_hex: nonce.as_hex().to_string(),
+            grant: VerbGrant {
+                session_id: vm_name.to_string(),
+                plan_nonce: nonce,
+                not_after,
+                verbs: vec![VerbId::new("run-entrypoint").unwrap()],
+                sig: vec![0u8; 64],
+            },
+        };
+        std::fs::write(
+            state_dir.join("verb-grant.json"),
+            serde_json::to_vec(&envelope).unwrap(),
+        )
+        .unwrap();
+        let keys_dir = mvm_core::config::mvm_keys_dir();
+        std::fs::create_dir_all(&keys_dir).unwrap();
+        std::fs::write(keys_dir.join("host-signer.pub"), [0xEEu8; 32]).unwrap();
+    }
+
+    /// The libkrun supervisor cmdline must carry all three plan-bound grant
+    /// tokens — the verb grant envelope, the enforcement assertion, and the
+    /// host-signer trust anchor — mirroring the HVF `grant_tokens` parity test.
+    /// A vsock-only guest has no config drive, so all three ride the cmdline;
+    /// an auto-fallback HVF→libkrun must not land on a backend that drops them.
+    #[test]
+    fn build_supervisor_config_cmdline_carries_all_three_grant_tokens() {
+        let _guard = crate::base::runtime_meta::HOME_TEST_LOCK
+            .lock()
+            .unwrap_or_else(|p| p.into_inner());
+        let dir = tempfile::tempdir().unwrap();
+        let mut env = TestEnv::new();
+        env.set("MVM_DATA_DIR", dir.path());
+
+        let vm_name = "libkrun-grant-parity";
+        seed_grant_sidecar_and_key(vm_name);
+
+        let config = VmStartConfig {
+            name: vm_name.into(),
+            rootfs_path: "/tmp/rootfs.ext4".into(),
+            kernel_path: Some("/tmp/vmlinux".into()),
+            cpus: 1,
+            memory_mib: 256,
+            ..Default::default()
+        };
+        let state_dir = mvm_core::config::vm_state_dir(vm_name);
+        let cfg = build_supervisor_config(&config, &state_dir).expect("build");
+        let cmdline = cfg
+            .krun
+            .kernel_cmdline
+            .as_deref()
+            .expect("supervisor cmdline present");
+        assert!(
+            cmdline.contains("mvm.verb_grant="),
+            "verb grant token missing: {cmdline}"
+        );
+        assert!(
+            cmdline.contains(&crate::microvm::require_grant_cmdline_token(vm_name).unwrap()),
+            "require_grant token missing: {cmdline}"
+        );
+        assert!(
+            cmdline.contains("mvm.host_signer_pub="),
+            "host_signer_pub trust anchor missing: {cmdline}"
+        );
+    }
+
     #[test]
     fn persist_vsock_egress_marker_writes_and_clears_marker() {
         let _guard = crate::base::runtime_meta::HOME_TEST_LOCK

--- a/crates/mvm-core/src/protocol/vm_backend.rs
+++ b/crates/mvm-core/src/protocol/vm_backend.rs
@@ -1959,6 +1959,40 @@ mod tests {
         assert!(!caps.satisfies(&required));
     }
 
+    /// Capability-honesty selection over `no_routable_guest_nic`. A vsock-only
+    /// backend (libkrun / HVF advertise this guarantee) satisfies a run that
+    /// requires it, while a NIC-bearing backend (Firecracker / qemu) shortfalls
+    /// and the diagnostic names the field so selection fails closed with a
+    /// recovery hint instead of silently degrading onto a routable-NIC backend.
+    /// The concrete per-backend values are witnessed in the backend crate; this
+    /// pins the selection LOGIC over that renamed capability.
+    #[test]
+    fn no_routable_guest_nic_required_selects_only_vsock_only_backends() {
+        let required = RequiredCapabilities {
+            no_routable_guest_nic: true,
+            ..Default::default()
+        };
+
+        // libkrun / HVF shape: no host-routable guest NIC ⇒ satisfied.
+        let vsock_only = VmCapabilities {
+            no_routable_guest_nic: true,
+            ..VmCapabilities::default()
+        };
+        assert!(vsock_only.shortfall(&required).is_empty());
+        assert!(vsock_only.satisfies(&required));
+
+        // Firecracker / qemu shape: routable guest NIC ⇒ shortfall names the field.
+        let nic_bearing = VmCapabilities {
+            no_routable_guest_nic: false,
+            ..VmCapabilities::default()
+        };
+        assert_eq!(
+            nic_bearing.shortfall(&required),
+            vec!["no_routable_guest_nic"]
+        );
+        assert!(!nic_bearing.satisfies(&required));
+    }
+
     #[test]
     fn satisfies_when_backend_advertises_every_required_capability() {
         let caps = VmCapabilities {

--- a/crates/mvm-guest/src/bin/mvm-guest-agent.rs
+++ b/crates/mvm-guest/src/bin/mvm-guest-agent.rs
@@ -39,7 +39,8 @@ use mvm_guest::vsock::{
     BootTimingReport, ComponentState, EntrypointEvent, FsChange, FsChangeKind, GUEST_AGENT_PORT,
     GuestRequest, GuestResponse, HOST_SIGNER_PUBKEY_PATH, ReadinessReport, RunEntrypointError,
     TrustDecision, VERB_TRUST_POLICY_PATH, enforce_verb_grant, is_verb_trust_baseline,
-    launch_requires_grant, load_pinned_verb_grant, load_verb_trust_policy, trust_decision,
+    launch_requires_grant, load_host_signer_verifying_key, load_pinned_verb_grant,
+    load_verb_trust_policy, trust_decision,
 };
 use mvm_guest::worker_pool::{DispatchError, DispatchOutcome, WorkerPool};
 use mvm_guest::worker_protocol::WorkerOutcome;
@@ -323,6 +324,11 @@ struct BootStateInner {
     /// was validly pinned; control RPCs are refused while this is set.
     /// Cleared when a valid grant is re-pinned via `PostRestore`.
     trust_denied: bool,
+    /// Boot-pinned host-signer trust anchor (from `HOST_SIGNER_PUBKEY_PATH`).
+    /// `None` on a grant-less boot with no provisioned key. `PostRestore`
+    /// re-pin verifies incoming envelopes against THIS anchor, never against
+    /// the self-attested key embedded in the envelope.
+    host_signer_key: Option<ed25519_dalek::VerifyingKey>,
 }
 
 impl AgentBootState {
@@ -484,6 +490,17 @@ impl AgentBootState {
         match self.inner.lock() {
             Ok(s) => (s.trust_denied, s.verb_grant.clone()),
             Err(_) => (true, None), // poisoned lock → fail closed
+        }
+    }
+
+    /// Read the boot-pinned host-signer trust anchor. `PostRestore` re-pin
+    /// verifies incoming envelopes against this; `None` means no anchor was
+    /// provisioned at boot, so a re-pin has nothing to trust and must be
+    /// refused (fail closed).
+    fn host_signer_key(&self) -> Option<ed25519_dalek::VerifyingKey> {
+        match self.inner.lock() {
+            Ok(s) => s.host_signer_key,
+            Err(_) => None, // poisoned lock → no anchor → refuse re-pin
         }
     }
 
@@ -2380,12 +2397,26 @@ fn handle_client(
                 mvm_guest::genid::GenIdAction::Reseeded
             );
             // Re-pin the verb grant if the host sent a fresh envelope. This
-            // covers restore across a plan change where the granted verbs or
-            // expiry differ from the snapshot-captured grant.
-            if let Some(env) = grant_envelope.as_ref()
-                && let Some(g) = mvm_guest::vsock::re_pin_verb_grant(env, chrono::Utc::now())
-            {
-                boot_state.set_verb_grant(g);
+            // covers restore across a plan change (a fork mints a fresh
+            // host-signed grant with the child's new session_id/plan_nonce and
+            // may widen the verb set). The envelope is verified against the
+            // boot-pinned host-signer anchor — NOT the self-attested key inside
+            // the envelope, which any caller able to deliver a PostRestore could
+            // forge. With no boot anchor there is nothing to trust the envelope
+            // against, so the re-pin is refused (fail closed).
+            if let Some(env) = grant_envelope.as_ref() {
+                match boot_state.host_signer_key() {
+                    Some(anchor) => {
+                        if let Some(g) =
+                            mvm_guest::vsock::re_pin_verb_grant(env, &anchor, chrono::Utc::now())
+                        {
+                            boot_state.set_verb_grant(g);
+                        }
+                    }
+                    None => eprintln!(
+                        "mvm-guest-agent: PostRestore re-pin refused — no boot-pinned host-signer anchor"
+                    ),
+                }
             }
             // Then send SIGUSR1 to PID 1 to trigger drive remount + service restart.
             let result = std::process::Command::new("kill")
@@ -3179,12 +3210,24 @@ fn main() {
         std::path::Path::new(HOST_SIGNER_PUBKEY_PATH),
         chrono::Utc::now(),
     );
+    // Resolve the host-signer trust anchor once at boot and hold it for the
+    // agent's lifetime. PostRestore re-pin verifies incoming envelopes against
+    // this anchor, never against the self-attested key inside the envelope.
+    let boot_host_signer_key =
+        match load_host_signer_verifying_key(std::path::Path::new(HOST_SIGNER_PUBKEY_PATH)) {
+            Ok(k) => k,
+            Err(e) => {
+                eprintln!("mvm-guest-agent: host-signer pubkey invalid, no re-pin anchor: {e}");
+                None
+            }
+        };
     let boot_state_val = AgentBootState::new(active_profile, boot_at);
     // Initialise verb_grant + trust_denied under the inner lock so the
     // same path is used by both boot-time init and PostRestore re-pin.
     {
         if let Ok(mut s) = boot_state_val.inner.lock() {
             s.verb_grant = pinned_verb_grant.clone();
+            s.host_signer_key = boot_host_signer_key;
         }
     }
     let policy = load_verb_trust_policy(std::path::Path::new(VERB_TRUST_POLICY_PATH));
@@ -4103,5 +4146,320 @@ mod tests {
         bs.set_warm_pool(ComponentState::Starting);
         bs.set_warm_pool(ComponentState::Ready);
         assert!(bs.snapshot().boot_millis.warm_pool_ready_ms.is_some());
+    }
+
+    // ─── verb-grant / verb-trust enforcement at the request-handling seam ───
+    //
+    // The control-RPC gate is inline in the accept loop, which cannot be driven
+    // without a live vsock. `gate_control_rpc` reproduces the handler's two
+    // ordered steps verbatim — the trust-policy fail-closed check
+    // (`trust_denied && !baseline`) followed by the verb-grant intersection
+    // (`enforce_verb_grant`) — over a real `AgentBootState`, so the negative
+    // paths exercise the same primitives (`grant_state`, `is_verb_trust_baseline`,
+    // `enforce_verb_grant`) the handler composes.
+
+    /// Mirror of the handler's control-RPC gate. `None` = the request would be
+    /// dispatched; `Some(resp)` = the request is refused with `resp`.
+    fn gate_control_rpc(boot_state: &AgentBootState, req: &GuestRequest) -> Option<GuestResponse> {
+        let (trust_denied, verb_grant) = boot_state.grant_state();
+        if trust_denied && !is_verb_trust_baseline(req.kind_name()) {
+            return Some(GuestResponse::VerbNotAuthorized {
+                verb: req.kind_name().to_string(),
+            });
+        }
+        enforce_verb_grant(req, verb_grant.as_ref())
+    }
+
+    /// A host-signed grant listing exactly `verbs` (plus the always-answerable
+    /// baseline). The signing key is irrelevant to enforcement — the pinned grant
+    /// is trusted once seated — so any fixed key suffices here.
+    fn signed_grant(verbs: &[&str]) -> mvm_core::plan::VerbGrant {
+        use ed25519_dalek::Signer;
+        use mvm_core::plan::{Nonce, VerbGrant, VerbId};
+        let signer = ed25519_dalek::SigningKey::from_bytes(&[55u8; 32]);
+        let mut g = VerbGrant {
+            session_id: "sess-agent".into(),
+            plan_nonce: Nonce::from_bytes([56u8; 16]),
+            not_after: chrono::Utc::now() + chrono::Duration::minutes(10),
+            verbs: verbs.iter().map(|v| VerbId::new(v).unwrap()).collect(),
+            sig: vec![],
+        };
+        g.sig = signer.sign(&g.signing_bytes()).to_bytes().to_vec();
+        g
+    }
+
+    /// Row: grant-less deny-all. When the measured policy required a grant and
+    /// none pinned (the boot init `FailClosed` branch), every non-baseline
+    /// control RPC is refused while baseline verbs still answer for liveness.
+    #[test]
+    fn grant_less_fail_closed_denies_non_baseline_serves_baseline() {
+        let bs = fresh_boot_state();
+        {
+            let mut s = bs.inner.lock().unwrap();
+            s.trust_denied = true;
+            s.verb_grant = None;
+        }
+        // Baseline verbs remain answerable.
+        assert!(is_verb_trust_baseline("protocol-hello"));
+        assert!(
+            gate_control_rpc(&bs, &GuestRequest::Ping).is_none(),
+            "ping is baseline and must answer under fail-closed"
+        );
+        // Every non-baseline control RPC is refused with VerbNotAuthorized.
+        for req in [
+            GuestRequest::WorkerStatus,
+            GuestRequest::IntegrationStatus,
+            GuestRequest::UpdateIdleTimeout { secs: 0 },
+        ] {
+            let name = req.kind_name();
+            match gate_control_rpc(&bs, &req) {
+                Some(GuestResponse::VerbNotAuthorized { verb }) => assert_eq!(verb, name),
+                other => panic!("{name} must be refused under fail-closed, got {other:?}"),
+            }
+        }
+    }
+
+    /// Row: verb regain via reconnect. Enforcement state is boot-scoped (the
+    /// shared `AgentBootState`), not per-connection: the gate re-reads
+    /// `grant_state()` on every request, so a dropped-and-reopened control
+    /// connection cannot reset a fail-closed agent to a permissive posture.
+    ///
+    /// A true socket reconnect needs a live vsock accept loop and is not
+    /// unit-testable here; this pins the invariant at the boot-state seam — the
+    /// state the accept loop reads is unchanged across simulated connections.
+    #[test]
+    fn fail_closed_survives_simulated_reconnect() {
+        let bs = fresh_boot_state();
+        {
+            let mut s = bs.inner.lock().unwrap();
+            s.trust_denied = true;
+        }
+        for _connection in 0..3 {
+            assert!(
+                matches!(
+                    gate_control_rpc(&bs, &GuestRequest::WorkerStatus),
+                    Some(GuestResponse::VerbNotAuthorized { .. })
+                ),
+                "reconnect must not clear the fail-closed posture"
+            );
+            assert!(gate_control_rpc(&bs, &GuestRequest::Ping).is_none());
+        }
+    }
+
+    /// Row: verb regain via reconnect (pinned-grant case). A pinned grant applies
+    /// unchanged across a simulated reconnect, and replaying the pre-grant
+    /// handshake cannot widen it — `ProtocolHello` is baseline and never mutates
+    /// the pinned grant, so the served set is identical before and after.
+    #[test]
+    fn reconnect_and_replayed_hello_cannot_widen_pinned_grant() {
+        let bs = fresh_boot_state();
+        bs.set_verb_grant(signed_grant(&["update-idle-timeout"]));
+        let before = bs.grant_state().1.expect("grant pinned");
+
+        for _connection in 0..3 {
+            // A replayed handshake conveys no authority (baseline, no grant edit).
+            assert!(is_verb_trust_baseline("protocol-hello"));
+            // Listed verb served; unlisted non-baseline verb still refused.
+            assert!(
+                gate_control_rpc(&bs, &GuestRequest::UpdateIdleTimeout { secs: 0 }).is_none(),
+                "listed verb must stay served across reconnect"
+            );
+            assert!(
+                matches!(
+                    gate_control_rpc(&bs, &GuestRequest::WorkerStatus),
+                    Some(GuestResponse::VerbNotAuthorized { .. })
+                ),
+                "unlisted verb must stay refused across reconnect"
+            );
+        }
+
+        let after = bs.grant_state().1.expect("grant still pinned");
+        assert_eq!(
+            before.verbs, after.verbs,
+            "handshake replay / reconnect must not widen the pinned grant"
+        );
+    }
+
+    /// Row: two-layer enforcement (profile gate + grant gate) composes as
+    /// defense-in-depth. A DevOnly verb is refused by the profile gate in
+    /// SealedProd regardless of grant; an unlisted ProdSafe verb is refused by
+    /// the grant gate; the listed ProdSafe verb is served.
+    #[test]
+    fn sealed_profile_and_grant_gates_compose() {
+        let bs = fresh_boot_state(); // SealedProd
+        assert_eq!(bs.profile, AgentProfile::SealedProd);
+        bs.set_verb_grant(signed_grant(&["update-idle-timeout"]));
+
+        // Layer 1 — profile gate: a DevOnly verb never runs in SealedProd, even
+        // if a grant were to list it. (The handler emits UnsupportedInProfile
+        // ahead of the grant gate.)
+        let dev_only = GuestRequest::RunDetached {
+            argv: vec!["/bin/true".into()],
+            env: vec![],
+        };
+        assert!(matches!(
+            dev_only.class(),
+            mvm_guest::vsock::RequestClass::DevOnly
+        ));
+        assert!(
+            !dev_only.allowed_in(bs.profile),
+            "DevOnly verb must be refused in SealedProd"
+        );
+
+        // Layer 2 — grant gate: unlisted ProdSafe verb refused, listed served.
+        match gate_control_rpc(&bs, &GuestRequest::WorkerStatus) {
+            Some(GuestResponse::VerbNotAuthorized { verb }) => assert_eq!(verb, "worker-status"),
+            other => panic!("unlisted ProdSafe verb must be refused, got {other:?}"),
+        }
+        assert!(
+            gate_control_rpc(&bs, &GuestRequest::UpdateIdleTimeout { secs: 0 }).is_none(),
+            "listed ProdSafe verb must be served"
+        );
+    }
+
+    // ─── PostRestore re-pin binds to the boot-pinned host-signer anchor ───
+
+    /// Build a `VerbGrantEnvelope` self-signed by `signer` (carrying `signer`'s
+    /// own pubkey), for use as a forged or a genuine restore envelope depending
+    /// on whether `signer` is the boot anchor.
+    fn envelope_signed_by(
+        signer: &ed25519_dalek::SigningKey,
+        session: &str,
+        nonce: mvm_core::plan::Nonce,
+        verbs: &[&str],
+    ) -> mvm_core::protocol::vm_backend::VerbGrantEnvelope {
+        use ed25519_dalek::Signer;
+        use mvm_core::plan::{VerbGrant, VerbId};
+        let mut g = VerbGrant {
+            session_id: session.into(),
+            plan_nonce: nonce.clone(),
+            not_after: chrono::Utc::now() + chrono::Duration::minutes(10),
+            verbs: verbs.iter().map(|v| VerbId::new(v).unwrap()).collect(),
+            sig: vec![],
+        };
+        g.sig = signer.sign(&g.signing_bytes()).to_bytes().to_vec();
+        let pubkey_hex: String = signer
+            .verifying_key()
+            .to_bytes()
+            .iter()
+            .map(|b| format!("{b:02x}"))
+            .collect();
+        mvm_core::protocol::vm_backend::VerbGrantEnvelope {
+            pubkey_hex,
+            plan_nonce_hex: nonce.as_hex().to_string(),
+            grant: g,
+        }
+    }
+
+    /// Mirror of the `PostRestore` re-pin decision: verify the incoming envelope
+    /// against the boot-pinned host anchor and replace the pinned grant only on
+    /// success. `true` = re-pinned; `false` = refused (bad anchor / no anchor).
+    /// The inline handler cannot be driven without a live vsock, so this
+    /// reproduces its two steps verbatim over a real `AgentBootState`.
+    fn apply_post_restore_repin(
+        bs: &AgentBootState,
+        env: &mvm_core::protocol::vm_backend::VerbGrantEnvelope,
+        now: chrono::DateTime<chrono::Utc>,
+    ) -> bool {
+        match bs.host_signer_key() {
+            Some(anchor) => match mvm_guest::vsock::re_pin_verb_grant(env, &anchor, now) {
+                Some(g) => {
+                    bs.set_verb_grant(g);
+                    true
+                }
+                None => false,
+            },
+            None => false,
+        }
+    }
+
+    /// A forged `PostRestore` envelope self-signed by a NON-anchor key must not
+    /// replace the pinned grant nor flip `trust_denied` — the served authority is
+    /// unchanged.
+    #[test]
+    fn post_restore_forged_envelope_does_not_replace_grant() {
+        let anchor = ed25519_dalek::SigningKey::from_bytes(&[60u8; 32]);
+        let attacker = ed25519_dalek::SigningKey::from_bytes(&[61u8; 32]);
+        let bs = fresh_boot_state();
+        {
+            let mut s = bs.inner.lock().unwrap();
+            s.host_signer_key = Some(anchor.verifying_key());
+        }
+        bs.set_verb_grant(signed_grant(&["update-idle-timeout"]));
+
+        let forged = envelope_signed_by(
+            &attacker,
+            "attacker",
+            mvm_core::plan::Nonce::from_bytes([62u8; 16]),
+            &["run-entrypoint", "update-idle-timeout"],
+        );
+        let repinned = apply_post_restore_repin(&bs, &forged, chrono::Utc::now());
+        assert!(!repinned, "forged envelope must not re-pin");
+
+        let (trust_denied, grant) = bs.grant_state();
+        assert!(!trust_denied, "forged envelope must not touch trust_denied");
+        let grant = grant.expect("original grant must remain pinned");
+        assert!(
+            !grant.permits("run-entrypoint"),
+            "forged envelope must not widen the served verb set"
+        );
+    }
+
+    /// A grant-less fail-closed boot (no host-signer anchor pinned) refuses every
+    /// re-pin: with no anchor there is nothing to trust the envelope against.
+    #[test]
+    fn post_restore_no_boot_anchor_refuses_repin() {
+        let some_key = ed25519_dalek::SigningKey::from_bytes(&[63u8; 32]);
+        let bs = fresh_boot_state();
+        {
+            let mut s = bs.inner.lock().unwrap();
+            s.trust_denied = true; // grant-less fail-closed boot
+            s.host_signer_key = None;
+        }
+        let env = envelope_signed_by(
+            &some_key,
+            "sess",
+            mvm_core::plan::Nonce::from_bytes([64u8; 16]),
+            &["run-entrypoint"],
+        );
+        assert!(
+            !apply_post_restore_repin(&bs, &env, chrono::Utc::now()),
+            "re-pin must be refused with no boot anchor"
+        );
+        let (trust_denied, grant) = bs.grant_state();
+        assert!(trust_denied, "fail-closed posture must survive the re-pin");
+        assert!(grant.is_none(), "no grant may be pinned without an anchor");
+    }
+
+    /// A genuine host-signed restore envelope (signed by the boot anchor) re-pins
+    /// and MAY legitimately widen the served set — a fork runs a newly admitted
+    /// plan with a fresh session/nonce, so the boot session/nonce are NOT forced.
+    #[test]
+    fn post_restore_host_signed_envelope_repins_and_may_widen() {
+        let anchor = ed25519_dalek::SigningKey::from_bytes(&[65u8; 32]);
+        let bs = fresh_boot_state();
+        {
+            let mut s = bs.inner.lock().unwrap();
+            s.host_signer_key = Some(anchor.verifying_key());
+        }
+        bs.set_verb_grant(signed_grant(&["update-idle-timeout"]));
+
+        // Fresh child session/nonce, unequal to any boot value, widened verbs.
+        let fork_env = envelope_signed_by(
+            &anchor,
+            "child-session",
+            mvm_core::plan::Nonce::from_bytes([66u8; 16]),
+            &["run-entrypoint", "update-idle-timeout"],
+        );
+        assert!(
+            apply_post_restore_repin(&bs, &fork_env, chrono::Utc::now()),
+            "host-signed fork envelope must re-pin"
+        );
+        let grant = bs.grant_state().1.expect("grant re-pinned");
+        assert_eq!(grant.session_id, "child-session");
+        assert!(
+            grant.permits("run-entrypoint"),
+            "a host-signed fork may widen the served verb set"
+        );
     }
 }

--- a/crates/mvm-guest/src/vsock.rs
+++ b/crates/mvm-guest/src/vsock.rs
@@ -1561,21 +1561,19 @@ pub fn pin_verb_grant(
     }
 }
 
-/// Verify a `VerbGrantEnvelope` and return the pinned grant, or `None` on
-/// any failure.
+/// Verify a `VerbGrantEnvelope` against a caller-supplied host-signer trust
+/// anchor and return the pinned grant, or `None` on any failure.
 ///
 /// Shared verification core used by both boot-time `load_pinned_verb_grant`
-/// (reads from disk) and restore-time `re_pin_verb_grant` (receives the
-/// envelope over vsock). Logs a warning and returns `None` on any error so
-/// callers never crash on a bad envelope.
-///
-/// # Trust note
-/// The verifying key rides in the same launcher-provisioned envelope as the
-/// grant, so this is an integrity check over a launcher-controlled blob — not
-/// proof of an independent issuer. Trust derives from the delivery channel
-/// (kernel-cmdline for boot, vsock for restore).
-pub fn re_pin_verb_grant(
+/// (resolves the anchor from disk) and restore-time `re_pin_verb_grant`
+/// (receives the anchor already resolved). Neither caller reads the verifying
+/// key from the envelope: the key that rides inside the envelope
+/// (`envelope.pubkey_hex`) is self-attested and is never trusted for
+/// verification. Logs a warning and returns `None` on any error so callers
+/// never crash on a bad envelope.
+fn verify_envelope_with_anchor(
     envelope: &mvm_core::protocol::vm_backend::VerbGrantEnvelope,
+    host_signer_key: &ed25519_dalek::VerifyingKey,
     now: chrono::DateTime<chrono::Utc>,
 ) -> Option<mvm_core::plan::VerbGrant> {
     let plan_nonce = match mvm_core::plan::Nonce::from_hex(&envelope.plan_nonce_hex) {
@@ -1585,16 +1583,9 @@ pub fn re_pin_verb_grant(
             return None;
         }
     };
-    let host_key = match verifying_key_from_hex(&envelope.pubkey_hex) {
-        Ok(k) => k,
-        Err(e) => {
-            eprintln!("mvm-guest-agent: verb-grant pubkey_hex malformed, skipping grant: {e}");
-            return None;
-        }
-    };
     match pin_verb_grant(
         Some(&envelope.grant),
-        Some(&host_key),
+        Some(host_signer_key),
         &envelope.grant.session_id,
         &plan_nonce,
         now,
@@ -1605,6 +1596,32 @@ pub fn re_pin_verb_grant(
             None
         }
     }
+}
+
+/// Re-pin a verb grant delivered over vsock at restore time (plain resume sends
+/// no envelope; a fork sends a fresh host-signed one).
+///
+/// Trust derives from the boot-pinned host-signer anchor the guest holds at
+/// `HOST_SIGNER_PUBKEY_PATH`, passed in as `host_signer_key` — NOT from the key
+/// embedded in the envelope. A prior version verified against
+/// `envelope.pubkey_hex`, which is self-attested: any party able to deliver a
+/// `PostRestore` envelope could forge its own keypair and mint an arbitrary
+/// grant. Binding to the boot anchor closes that bypass.
+///
+/// A fork legitimately mints a fresh host-signed envelope carrying the child's
+/// new `session_id`/`plan_nonce` and MAY widen the verb set (it runs a newly
+/// admitted plan), so re-pin does NOT require the boot session/nonce to match;
+/// the sole invariant is that the grant is signed by the host-signer anchor.
+pub fn re_pin_verb_grant(
+    envelope: &mvm_core::protocol::vm_backend::VerbGrantEnvelope,
+    host_signer_key: &ed25519_dalek::VerifyingKey,
+    now: chrono::DateTime<chrono::Utc>,
+) -> Option<mvm_core::plan::VerbGrant> {
+    // Residual limitation: the host-signer anchor is host-global, so this proves
+    // host authorship but does not by itself bind the grant to THIS VM's
+    // identity — a genuinely host-signed grant issued for another VM would still
+    // pass signature verification here. Cross-VM replay is a separate follow-up.
+    verify_envelope_with_anchor(envelope, host_signer_key, now)
 }
 
 /// Read the pinned verb grant written by `/init` and verify it before use.
@@ -1640,15 +1657,6 @@ pub fn load_pinned_verb_grant(
                 return None;
             }
         };
-    let plan_nonce = match mvm_core::plan::Nonce::from_hex(&envelope.plan_nonce_hex) {
-        Ok(n) => n,
-        Err(e) => {
-            eprintln!(
-                "mvm-guest-agent: verb-grant plan_nonce_hex invalid, booting without grant: {e}"
-            );
-            return None;
-        }
-    };
     let host_key = match load_host_signer_verifying_key(host_signer_pubkey_path) {
         Ok(Some(key)) => key,
         Ok(None) => {
@@ -1662,21 +1670,7 @@ pub fn load_pinned_verb_grant(
             return None;
         }
     };
-    match pin_verb_grant(
-        Some(&envelope.grant),
-        Some(&host_key),
-        &envelope.grant.session_id,
-        &plan_nonce,
-        now,
-    ) {
-        Ok(pinned) => pinned,
-        Err(e) => {
-            eprintln!(
-                "mvm-guest-agent: verb-grant verification failed, booting without grant: {e}"
-            );
-            None
-        }
-    }
+    verify_envelope_with_anchor(&envelope, &host_key, now)
 }
 
 /// Well-known guest path for the dm-verity-measured verb-trust policy baked
@@ -7746,59 +7740,49 @@ mod rpc_client_tests {
 
     #[test]
     fn re_pin_verb_grant_valid_returns_some() {
-        let dir = tempfile::tempdir().unwrap();
-        let signer = ed25519_dalek::SigningKey::from_bytes(&[20u8; 32]);
+        // Grant signed by the host anchor, envelope pubkey = anchor, called with
+        // the anchor: verifies and re-pins. A host-signed re-pin MAY widen the
+        // served verb set (a fork runs a newly admitted plan), so we assert the
+        // full listed set comes back.
+        let host = ed25519_dalek::SigningKey::from_bytes(&[20u8; 32]);
         let nonce = mvm_core::plan::Nonce::from_bytes([21u8; 16]);
-        let (grant_path, _pubkey_path) =
-            write_grant_fixture(dir.path(), &signer, "sess-repin", &nonce, &["ping"], 10);
         let now = chrono::Utc::now();
-        // Load the envelope from the fixture file and call re_pin_verb_grant directly.
-        let raw = std::fs::read(&grant_path).unwrap();
-        let envelope: mvm_core::protocol::vm_backend::VerbGrantEnvelope =
-            serde_json::from_slice(&raw).unwrap();
-        let result = re_pin_verb_grant(&envelope, now);
-        assert!(
-            result.is_some(),
-            "valid envelope must yield Some from re_pin_verb_grant"
+        let envelope = self_signed_envelope(
+            &host,
+            "sess-repin",
+            &nonce,
+            &["run-entrypoint", "update-idle-timeout"],
+            now + chrono::Duration::minutes(10),
         );
-        assert_eq!(result.unwrap().session_id, "sess-repin");
+        let result = re_pin_verb_grant(&envelope, &host.verifying_key(), now);
+        let grant = result.expect("valid host-signed envelope must yield Some from re_pin");
+        assert_eq!(grant.session_id, "sess-repin");
+        assert!(grant.permits("run-entrypoint"));
+        assert!(grant.permits("update-idle-timeout"));
     }
 
     #[test]
     fn re_pin_verb_grant_wrong_key_returns_none() {
-        use mvm_core::plan::{VerbGrant, VerbId};
-        use mvm_core::protocol::vm_backend::VerbGrantEnvelope;
+        // Envelope is self-consistent (grant signed by `signer`, pubkey_hex =
+        // signer), but the boot-pinned anchor is a DIFFERENT key. Because re-pin
+        // verifies against the anchor and ignores the embedded pubkey, an
+        // envelope not signed by the anchor is rejected — this is exactly the
+        // property the old embedded-pubkey path lacked.
         let signer = ed25519_dalek::SigningKey::from_bytes(&[22u8; 32]);
-        let attacker = ed25519_dalek::SigningKey::from_bytes(&[23u8; 32]);
+        let anchor = ed25519_dalek::SigningKey::from_bytes(&[23u8; 32]);
         let nonce = mvm_core::plan::Nonce::from_bytes([24u8; 16]);
         let now = chrono::Utc::now();
-        let mut grant = VerbGrant {
-            session_id: "sess-wrong".into(),
-            plan_nonce: nonce.clone(),
-            not_after: now + chrono::Duration::minutes(10),
-            verbs: vec![VerbId::new("ping").unwrap()],
-            sig: vec![],
-        };
-        grant.sig = {
-            use ed25519_dalek::Signer;
-            signer.sign(&grant.signing_bytes()).to_bytes().to_vec()
-        };
-        // Envelope carries the attacker's pubkey but the grant is signed by `signer`.
-        let attacker_pubkey_hex: String = attacker
-            .verifying_key()
-            .to_bytes()
-            .iter()
-            .map(|b| format!("{b:02x}"))
-            .collect();
-        let envelope = VerbGrantEnvelope {
-            pubkey_hex: attacker_pubkey_hex,
-            plan_nonce_hex: nonce.as_hex().to_string(),
-            grant,
-        };
-        let result = re_pin_verb_grant(&envelope, now);
+        let envelope = self_signed_envelope(
+            &signer,
+            "sess-wrong",
+            &nonce,
+            &["ping"],
+            now + chrono::Duration::minutes(10),
+        );
+        let result = re_pin_verb_grant(&envelope, &anchor.verifying_key(), now);
         assert!(
             result.is_none(),
-            "grant signed by different key than envelope.pubkey_hex must return None"
+            "grant not signed by the boot-pinned anchor must return None"
         );
     }
 
@@ -7929,5 +7913,172 @@ mod rpc_client_tests {
         assert!(load_verb_trust_policy(&p).is_none()); // absent
         std::fs::write(&p, b"{ not json").unwrap();
         assert!(load_verb_trust_policy(&p).is_none()); // malformed => None (dev-default)
+    }
+
+    // ---- PostRestore re-pin adversarial (resume-path authority) ----
+
+    /// Build a `VerbGrantEnvelope` self-signed by `signer`, carrying `signer`'s
+    /// own pubkey. Mirrors what the launcher would ship, but usable with any key
+    /// so an adversarial (non-host) signer can be substituted.
+    fn self_signed_envelope(
+        signer: &ed25519_dalek::SigningKey,
+        session: &str,
+        nonce: &mvm_core::plan::Nonce,
+        verbs: &[&str],
+        not_after: chrono::DateTime<chrono::Utc>,
+    ) -> mvm_core::protocol::vm_backend::VerbGrantEnvelope {
+        use ed25519_dalek::Signer;
+        use mvm_core::plan::{VerbGrant, VerbId};
+        use mvm_core::protocol::vm_backend::VerbGrantEnvelope;
+        let mut grant = VerbGrant {
+            session_id: session.into(),
+            plan_nonce: nonce.clone(),
+            not_after,
+            verbs: verbs.iter().map(|v| VerbId::new(v).unwrap()).collect(),
+            sig: vec![],
+        };
+        grant.sig = signer.sign(&grant.signing_bytes()).to_bytes().to_vec();
+        let pubkey_hex: String = signer
+            .verifying_key()
+            .to_bytes()
+            .iter()
+            .map(|b| format!("{b:02x}"))
+            .collect();
+        VerbGrantEnvelope {
+            pubkey_hex,
+            plan_nonce_hex: nonce.as_hex().to_string(),
+            grant,
+        }
+    }
+
+    /// A stale (expired) envelope delivered at restore must not re-pin: replaying
+    /// an old-but-once-valid grant cannot revive authority past its expiry.
+    #[test]
+    fn re_pin_verb_grant_expired_envelope_returns_none() {
+        let signer = ed25519_dalek::SigningKey::from_bytes(&[30u8; 32]);
+        let nonce = mvm_core::plan::Nonce::from_bytes([31u8; 16]);
+        let issued = chrono::Utc::now();
+        let envelope = self_signed_envelope(
+            &signer,
+            "sess-stale",
+            &nonce,
+            &["run-entrypoint"],
+            issued + chrono::Duration::minutes(5),
+        );
+        // Restore happens one minute after expiry. Anchor matches the signer, so
+        // the ONLY reason to reject is the elapsed validity window.
+        let later = issued + chrono::Duration::minutes(6);
+        assert!(
+            re_pin_verb_grant(&envelope, &signer.verifying_key(), later).is_none(),
+            "an expired envelope must not re-pin at restore"
+        );
+    }
+
+    /// Verbs appended to the grant AFTER signing (a widened set the signer never
+    /// authorized) break the Ed25519 signature and must not re-pin.
+    #[test]
+    fn re_pin_verb_grant_verbs_widened_after_signing_returns_none() {
+        use mvm_core::plan::VerbId;
+        let signer = ed25519_dalek::SigningKey::from_bytes(&[32u8; 32]);
+        let nonce = mvm_core::plan::Nonce::from_bytes([33u8; 16]);
+        let now = chrono::Utc::now();
+        let mut envelope = self_signed_envelope(
+            &signer,
+            "sess-widen",
+            &nonce,
+            &["update-idle-timeout"],
+            now + chrono::Duration::minutes(10),
+        );
+        // Tamper: append a broader verb after the signature was computed.
+        envelope
+            .grant
+            .verbs
+            .push(VerbId::new("run-entrypoint").unwrap());
+        // Anchor matches the signer, so rejection is purely the broken signature
+        // over the tampered (widened) verb set.
+        assert!(
+            re_pin_verb_grant(&envelope, &signer.verifying_key(), now).is_none(),
+            "verbs appended after signing must fail signature verification and not re-pin"
+        );
+    }
+
+    /// ADVERSARIAL (resume path). A `PostRestore` envelope self-signed by a key
+    /// that is NOT the boot-pinned host signer must not install a grant. Re-pin
+    /// verifies against the host-signer trust anchor pinned at boot — the same
+    /// anchor `load_pinned_verb_grant` uses and
+    /// `load_pinned_verb_grant_ignores_envelope_pubkey` proves the boot path
+    /// binds to (rather than trusting `envelope.pubkey_hex`). A self-attested
+    /// envelope key carries no authority.
+    #[test]
+    fn post_restore_self_signed_envelope_must_not_widen_authority() {
+        // Boot pins a host-signed grant limited to a single non-baseline verb.
+        let dir = tempfile::tempdir().unwrap();
+        let host = ed25519_dalek::SigningKey::from_bytes(&[40u8; 32]);
+        let boot_nonce = mvm_core::plan::Nonce::from_bytes([41u8; 16]);
+        let now = chrono::Utc::now();
+        let (grant_path, pubkey_path) = write_grant_fixture(
+            dir.path(),
+            &host,
+            "sess-boot",
+            &boot_nonce,
+            &["update-idle-timeout"],
+            10,
+        );
+        let pinned = load_pinned_verb_grant(&grant_path, &pubkey_path, now)
+            .expect("boot grant must pin under the host anchor");
+        assert!(
+            !pinned.permits("run-entrypoint"),
+            "run-entrypoint is forbidden at boot"
+        );
+
+        // Adversary crafts a restore envelope self-signed by a NON-host key,
+        // listing a broadened verb set, carrying its own pubkey.
+        let attacker = ed25519_dalek::SigningKey::from_bytes(&[42u8; 32]);
+        let evil_nonce = mvm_core::plan::Nonce::from_bytes([43u8; 16]);
+        let evil_env = self_signed_envelope(
+            &attacker,
+            "attacker",
+            &evil_nonce,
+            &["run-entrypoint", "update-idle-timeout"],
+            now + chrono::Duration::minutes(10),
+        );
+
+        // Verified against the boot-pinned HOST anchor (not the envelope's
+        // self-attested pubkey), the non-host-signed envelope is rejected
+        // outright — no grant, and certainly no widening to the boot-forbidden
+        // verb.
+        let result = re_pin_verb_grant(&evil_env, &host.verifying_key(), now);
+        assert!(
+            result.is_none(),
+            "SECURITY: a PostRestore envelope self-signed by a non-host key must \
+             not re-pin any grant — it is not signed by the boot host-signer anchor"
+        );
+    }
+
+    /// KNOWN RESIDUAL (documenting). The host-signer anchor is host-global, so a
+    /// grant genuinely signed by the host but issued for a DIFFERENT VM's
+    /// session/nonce still passes signature verification at re-pin: re-pin binds
+    /// to host authorship, not to this VM's identity. This test pins that
+    /// behaviour so the residual is explicit rather than hidden; binding a grant
+    /// to a specific VM identity is a separate follow-up.
+    #[test]
+    fn re_pin_verb_grant_cross_vm_host_signed_currently_passes() {
+        let host = ed25519_dalek::SigningKey::from_bytes(&[44u8; 32]);
+        let other_vm_nonce = mvm_core::plan::Nonce::from_bytes([45u8; 16]);
+        let now = chrono::Utc::now();
+        // Host-signed, but for some other VM's session/nonce.
+        let envelope = self_signed_envelope(
+            &host,
+            "some-other-vm-session",
+            &other_vm_nonce,
+            &["run-entrypoint"],
+            now + chrono::Duration::minutes(10),
+        );
+        let result = re_pin_verb_grant(&envelope, &host.verifying_key(), now);
+        assert!(
+            result.is_some(),
+            "residual: a host-signed grant for another VM currently re-pins — \
+             signature verification is host-global, not VM-bound"
+        );
     }
 }


### PR DESCRIPTION
Closes #1621. Plan 236 Phase 1 §4 (negative-path matrix) + the security fix it surfaced.

## The bug (found by the negative-path tests)
`re_pin_verb_grant` — the `PostRestore`/fork grant re-pin — verified the incoming `VerbGrantEnvelope` against the pubkey carried **inside the envelope itself**, while the boot path (`load_pinned_verb_grant`) verifies against the launcher-provisioned host-signer anchor and ignores the embedded key. So anything able to deliver a `PostRestore { grant_envelope: Some(..) }` frame could self-sign an arbitrary grant and widen its verb set past what was authorized at boot — a verb-grant / host-authority bypass on the resume path.

## Fix
- Extract a shared `verify_envelope_with_anchor` core used by both boot and re-pin, so the two verification paths cannot drift again.
- `re_pin_verb_grant` now verifies against the **boot-pinned host-signer anchor** (held in `AgentBootState`, provisioned via the config-drive/cmdline anchor), never `envelope.pubkey_hex`.
- Fail-closed when no anchor is pinned.
- **Fork preserved:** a genuinely host-signed re-pin with a fresh child session/nonce and a widened verb set is still accepted (fork's prerogative); only self-signed envelopes are rejected. Session/nonce are self-consistency-checked, not compared to boot values (which would break fork).

## Tests
The full negative-path matrix: reconnect/resume/fallback verb-regain, grant-less deny-all, selective enforcement, capability honesty. The bypass regression test (`post_restore_self_signed_envelope_must_not_widen_authority`) is red before the fix, green after. Positive host-signed re-pin + widening, cross-VM residual, and handler-level forged-envelope tests included. 2048/2048 mvm-guest+mvm-core pass; nightly-fmt / clippy `--all-targets` / no-spec-refs / require-grant-allowlist all clean.

## Follow-up
The host-signer anchor is host-global, so this closes self-forgery but not cross-VM replay of a genuinely host-signed grant — tracked in #1623 (needs per-VM identity binding).

Adversarially reviewed; all seven trust-anchor properties confirmed, no boot-path regression.