### PR TITLE
Plan 213: harden pack-signing custody + add reproducibility gate

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -478,6 +478,11 @@ jobs:
   default-microvm:
     # Skipped on a dry-run dispatch (see builder-vm-image).
     if: ${{ github.event_name == 'push' || github.event.inputs.dry_run == 'false' }}
+    # This job mints a keyless (OIDC/Fulcio) signature over the attested
+    # runtime pack manifest under the same release.yml@<tag> identity class as
+    # builder-vm-image — gating it behind the same protected environment
+    # constrains which ref can mint a valid signing identity.
+    environment: release-signing
     strategy:
       matrix:
         include:

--- a/.github/workflows/revocations.yml
+++ b/.github/workflows/revocations.yml
@@ -26,6 +26,12 @@ env:
 
 jobs:
   publish:
+    # This job mints a keyless (OIDC/Fulcio) signature over the revocation
+    # list under the revocations.yml@refs/tags/revocations identity. A
+    # dedicated protected environment (separate from release-signing, whose
+    # tag rule is scoped to v* and would otherwise block this job) constrains
+    # which ref can mint a valid signing identity.
+    environment: revocations-signing
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -765,3 +765,347 @@ jobs:
           fi
           echo "ok: builder-vm image reproduces byte-identically across two clean builds"
           cat /tmp/bvm-hash-a.txt
+
+  # ── Lane 10: Published builder-pack reproducibility ────────────────
+  # Complements Lane 9 (same-run double build) by rebuilding a builder
+  # pack that was actually published on a release and diffing its
+  # content-addressed output hashes against the published attested
+  # manifest. Lane 9 catches non-determinism the day it's introduced;
+  # this lane catches drift between "what CI built at tag time" and
+  # "what building the same tag from scratch produces today" (toolchain
+  # upgrades, flake input drift, etc). Heavy (Nix build per arch) and
+  # requires a published release to compare against, so it is
+  # PR-skipped like Lane 9 and only runs on release-tag pushes, the
+  # nightly schedule, and workflow_dispatch.
+  #
+  # The target release is discovered independently of the ref that
+  # triggered this run (via `gh release list`/`gh release view`), not
+  # read from `github.ref_name` — this workflow's tag-push trigger fires
+  # in parallel with the release workflow that publishes the pack, so
+  # the just-pushed tag's assets may not exist yet. Looking up the most
+  # recent release that already carries the expected pack manifest and
+  # checking out that tag's commit before rebuilding sidesteps the race
+  # entirely; on a quiet nightly run it simply finds the latest release.
+  #
+  # No untrusted GitHub event input flows into any step — `matrix.arch`
+  # and `github.repository` are workflow-defined, and the release tag
+  # used in later steps is read back out of `GITHUB_ENV` after the
+  # discovery step, not interpolated from any PR-controlled value.
+  pack-reproducibility-builder:
+    name: Published builder-pack reproducibility (${{ matrix.arch }})
+    if: github.event_name != 'pull_request'
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - arch: aarch64
+            runner: ubuntu-24.04-arm
+            musl_target: aarch64-unknown-linux-musl
+          - arch: x86_64
+            runner: ubuntu-latest
+            musl_target: x86_64-unknown-linux-musl
+    runs-on: ${{ matrix.runner }}
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          # A full history + tags checkout — the target release's tag is
+          # discovered at runtime (see above) and may not be the ref that
+          # triggered this workflow, so an arbitrary tag must be
+          # checkable-out later in the job.
+          fetch-depth: 0
+
+      - name: Determine target release tag
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          REPO: ${{ github.repository }}
+          ARCH: ${{ matrix.arch }}
+        run: |
+          set -euo pipefail
+          TARGET_TAG=""
+          while IFS= read -r TAG; do
+            if gh release view "$TAG" --repo "$REPO" --json assets \
+                --jq '.assets[].name' | grep -qx "builder-vm-${ARCH}.pack-manifest.json"; then
+              TARGET_TAG="$TAG"
+              break
+            fi
+          done < <(gh release list --repo "$REPO" --exclude-drafts --exclude-pre-releases \
+                      --limit 30 --json tagName --jq '.[].tagName')
+          if [ -z "$TARGET_TAG" ]; then
+            echo "::notice::No published release carries a builder-vm-${ARCH} attested pack manifest yet; skipping reproducibility check for this arch."
+          fi
+          echo "TARGET_TAG=${TARGET_TAG}" >> "$GITHUB_ENV"
+
+      - name: Checkout target release commit
+        if: env.TARGET_TAG != ''
+        run: git checkout "$TARGET_TAG"
+
+      - name: Install Nix
+        if: env.TARGET_TAG != ''
+        uses: DeterminateSystems/nix-installer-action@main
+
+      - name: Install Rust toolchain
+        if: env.TARGET_TAG != ''
+        uses: dtolnay/rust-toolchain@stable
+
+      - uses: ./.github/actions/install-zigbuild
+        if: env.TARGET_TAG != ''
+
+      - name: Cross-compile host-vm binaries (MVM_HOST_BIN_DIR contract)
+        if: env.TARGET_TAG != ''
+        env:
+          MUSL_TARGET: ${{ matrix.musl_target }}
+        run: |
+          set -euo pipefail
+          cargo zigbuild --release --locked --target "$MUSL_TARGET" \
+            -p mvm-build --bin mvm-host-vm-init --bin mvm-egress-proxy
+          echo "MVM_HOST_BIN_DIR=$PWD/target/${MUSL_TARGET}/release" >> "$GITHUB_ENV"
+
+      - name: Rebuild builder VM image from source at the target tag
+        if: env.TARGET_TAG != ''
+        env:
+          ARCH: ${{ matrix.arch }}
+        run: |
+          set -euo pipefail
+          SYSTEM="${ARCH}-linux"
+          nix build "./nix/images/builder-vm#packages.${SYSTEM}.default" \
+            --impure --no-link --print-out-paths > /tmp/store-path.txt
+          STORE_PATH=$(head -1 /tmp/store-path.txt)
+          echo "STORE_PATH=${STORE_PATH}" >> "$GITHUB_ENV"
+
+      - name: Download the published builder pack
+        if: env.TARGET_TAG != ''
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          REPO: ${{ github.repository }}
+          ARCH: ${{ matrix.arch }}
+        run: |
+          set -euo pipefail
+          mkdir -p downloaded
+          gh release download "$TARGET_TAG" --repo "$REPO" --dir downloaded \
+            --pattern "builder-vm-vmlinux-${ARCH}" \
+            --pattern "builder-vm-rootfs-${ARCH}.ext4" \
+            --pattern "builder-vm-${ARCH}.pack-manifest.json" \
+            --pattern "builder-vm-${ARCH}-checksums-sha256.txt"
+
+      - name: Verify downloaded assets against published checksums
+        if: env.TARGET_TAG != ''
+        env:
+          ARCH: ${{ matrix.arch }}
+        run: |
+          set -euo pipefail
+          cd downloaded
+          sha256sum --ignore-missing -c "builder-vm-${ARCH}-checksums-sha256.txt"
+
+      - name: Produce a manifest from the rebuilt artifacts
+        if: env.TARGET_TAG != ''
+        env:
+          ARCH: ${{ matrix.arch }}
+        run: |
+          set -euo pipefail
+          mkdir -p rebuilt
+          nix-store --query --requisites "$STORE_PATH" > rebuilt/sbom.txt
+          # `--keyless` here is not standing in for a real release signature —
+          # it is the hash-recompute path: the producer copies the rebuilt
+          # vmlinux/rootfs.ext4 into place, hashes them, and assembles a
+          # manifest without touching any signing key. `--identity` only
+          # feeds `trust.signing_key_id`, which this check never compares.
+          cargo run --release -p mvm-build --example mvm-builder-pack-tool -- \
+            --vmlinux "$STORE_PATH/vmlinux" --rootfs "$STORE_PATH/rootfs.ext4" \
+            --arch "$ARCH" --channel stable \
+            --keyless --identity "pack-reproducibility-check" \
+            --out-dir rebuilt \
+            --sbom rebuilt/sbom.txt \
+            --revocation-channel "https://example.invalid/unused-in-reproducibility-check.json"
+
+      - name: Compare rebuilt pack hashes against the published manifest
+        if: env.TARGET_TAG != ''
+        env:
+          ARCH: ${{ matrix.arch }}
+        run: |
+          set -euo pipefail
+          PUBLISHED="downloaded/builder-vm-${ARCH}.pack-manifest.json"
+          REBUILT="rebuilt/manifest.json"
+
+          # `outputs.pack_hash` and the provenance/trust fields legitimately
+          # differ between this run and the original release build (build
+          # timestamp, signer identity, SBOM uri) even when the artifacts
+          # reproduce byte-for-byte — the pack_hash folds the whole manifest
+          # minus signatures into one digest. The fields that depend only on
+          # the artifact bytes are `outputs.kernel_hash`,
+          # `outputs.builder_image_hash`, and each `outputs.files[].sha256`;
+          # those are what this check compares.
+          jq '.outputs | {kernel_hash, builder_image_hash, files: (.files | sort_by(.path))}' \
+            "$PUBLISHED" > /tmp/published-outputs.json
+          jq '.outputs | {kernel_hash, builder_image_hash, files: (.files | sort_by(.path))}' \
+            "$REBUILT" > /tmp/rebuilt-outputs.json
+
+          if ! diff -q /tmp/published-outputs.json /tmp/rebuilt-outputs.json > /dev/null; then
+            echo "::error::Rebuilding the builder pack for ${ARCH} at ${TARGET_TAG} from source did not reproduce the published artifact hashes" >&2
+            echo "Published (from release ${TARGET_TAG}):" >&2
+            cat /tmp/published-outputs.json >&2
+            echo >&2
+            echo "Rebuilt (from source at the same tag):" >&2
+            cat /tmp/rebuilt-outputs.json >&2
+            echo >&2
+            echo "Diff:" >&2
+            diff -u /tmp/published-outputs.json /tmp/rebuilt-outputs.json >&2 || true
+            exit 1
+          fi
+          echo "ok: builder pack for ${ARCH} at ${TARGET_TAG} reproduces byte-identically from source"
+
+      - name: Report skip (no eligible release yet)
+        if: env.TARGET_TAG == ''
+        run: echo "::notice::pack-reproducibility-builder (${{ matrix.arch }}) skipped — no published release with an attested builder pack manifest was found."
+
+  # ── Lane 11: Published runtime-pack reproducibility ────────────────
+  # Same shape as Lane 10, applied to the runtime pack the `default-
+  # microvm` release job produces from `nix/images/default-tenant`. A
+  # runtime pack is keyless-only (`mvm-builder-pack-tool --kind
+  # runtime` refuses an ed25519 signing key), so the rebuilt-manifest
+  # step below always uses `--keyless` regardless.
+  pack-reproducibility-runtime:
+    name: Published runtime-pack reproducibility (${{ matrix.arch }})
+    if: github.event_name != 'pull_request'
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - arch: aarch64
+            runner: ubuntu-24.04-arm
+            musl_target: aarch64-unknown-linux-musl
+          - arch: x86_64
+            runner: ubuntu-latest
+            musl_target: x86_64-unknown-linux-musl
+    runs-on: ${{ matrix.runner }}
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+
+      - name: Determine target release tag
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          REPO: ${{ github.repository }}
+          ARCH: ${{ matrix.arch }}
+        run: |
+          set -euo pipefail
+          TARGET_TAG=""
+          while IFS= read -r TAG; do
+            if gh release view "$TAG" --repo "$REPO" --json assets \
+                --jq '.assets[].name' | grep -qx "default-microvm-${ARCH}.pack-manifest.json"; then
+              TARGET_TAG="$TAG"
+              break
+            fi
+          done < <(gh release list --repo "$REPO" --exclude-drafts --exclude-pre-releases \
+                      --limit 30 --json tagName --jq '.[].tagName')
+          if [ -z "$TARGET_TAG" ]; then
+            echo "::notice::No published release carries a default-microvm-${ARCH} attested pack manifest yet; skipping reproducibility check for this arch."
+          fi
+          echo "TARGET_TAG=${TARGET_TAG}" >> "$GITHUB_ENV"
+
+      - name: Checkout target release commit
+        if: env.TARGET_TAG != ''
+        run: git checkout "$TARGET_TAG"
+
+      - name: Install Nix
+        if: env.TARGET_TAG != ''
+        uses: DeterminateSystems/nix-installer-action@main
+
+      - name: Install Rust toolchain
+        if: env.TARGET_TAG != ''
+        uses: dtolnay/rust-toolchain@stable
+
+      - name: Rebuild the default microVM image from source at the target tag
+        if: env.TARGET_TAG != ''
+        env:
+          ARCH: ${{ matrix.arch }}
+        run: |
+          set -euo pipefail
+          SYSTEM="${ARCH}-linux"
+          nix build "./nix/images/default-tenant#packages.${SYSTEM}.default" \
+            --impure --no-link --print-out-paths > /tmp/store-path.txt
+          STORE_PATH=$(head -1 /tmp/store-path.txt)
+          echo "STORE_PATH=${STORE_PATH}" >> "$GITHUB_ENV"
+
+      - name: Download the published runtime pack
+        if: env.TARGET_TAG != ''
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          REPO: ${{ github.repository }}
+          ARCH: ${{ matrix.arch }}
+        run: |
+          set -euo pipefail
+          mkdir -p downloaded
+          gh release download "$TARGET_TAG" --repo "$REPO" --dir downloaded \
+            --pattern "default-microvm-vmlinux-${ARCH}" \
+            --pattern "default-microvm-rootfs-${ARCH}.ext4" \
+            --pattern "default-microvm-rootfs-${ARCH}.verity" \
+            --pattern "default-microvm-rootfs-${ARCH}.roothash" \
+            --pattern "default-microvm-${ARCH}.pack-manifest.json" \
+            --pattern "default-microvm-${ARCH}-checksums-sha256.txt"
+
+      - name: Verify downloaded assets against published checksums
+        if: env.TARGET_TAG != ''
+        env:
+          ARCH: ${{ matrix.arch }}
+        run: |
+          set -euo pipefail
+          cd downloaded
+          sha256sum --ignore-missing -c "default-microvm-${ARCH}-checksums-sha256.txt"
+
+      - name: Produce a manifest from the rebuilt artifacts
+        if: env.TARGET_TAG != ''
+        env:
+          ARCH: ${{ matrix.arch }}
+        run: |
+          set -euo pipefail
+          mkdir -p rebuilt
+          nix-store --query --requisites "$STORE_PATH" > rebuilt/sbom.txt
+          # Runtime packs have no ed25519 producer path (see the pack tool's
+          # own usage text) — `--keyless` is the only way to invoke this
+          # kind, and it never touches a signing key here either.
+          cargo run --release -p mvm-build --example mvm-builder-pack-tool -- \
+            --kind runtime \
+            --vmlinux "$STORE_PATH/vmlinux" --rootfs "$STORE_PATH/rootfs.ext4" \
+            --verity "$STORE_PATH/rootfs.verity" --roothash "$STORE_PATH/rootfs.roothash" \
+            --arch "$ARCH" --channel stable \
+            --keyless --identity "pack-reproducibility-check" \
+            --out-dir rebuilt \
+            --sbom rebuilt/sbom.txt \
+            --revocation-channel "https://example.invalid/unused-in-reproducibility-check.json"
+
+      - name: Compare rebuilt pack hashes against the published manifest
+        if: env.TARGET_TAG != ''
+        env:
+          ARCH: ${{ matrix.arch }}
+        run: |
+          set -euo pipefail
+          PUBLISHED="downloaded/default-microvm-${ARCH}.pack-manifest.json"
+          REBUILT="rebuilt/manifest.json"
+
+          # Same rationale as the builder-pack lane: compare only the
+          # content-addressed output fields, not `outputs.pack_hash` (which
+          # folds in the build timestamp / signer identity / SBOM uri and so
+          # legitimately differs run to run).
+          jq '.outputs | {kernel_hash, agent_rootfs_hash, files: (.files | sort_by(.path))}' \
+            "$PUBLISHED" > /tmp/published-outputs.json
+          jq '.outputs | {kernel_hash, agent_rootfs_hash, files: (.files | sort_by(.path))}' \
+            "$REBUILT" > /tmp/rebuilt-outputs.json
+
+          if ! diff -q /tmp/published-outputs.json /tmp/rebuilt-outputs.json > /dev/null; then
+            echo "::error::Rebuilding the runtime pack for ${ARCH} at ${TARGET_TAG} from source did not reproduce the published artifact hashes" >&2
+            echo "Published (from release ${TARGET_TAG}):" >&2
+            cat /tmp/published-outputs.json >&2
+            echo >&2
+            echo "Rebuilt (from source at the same tag):" >&2
+            cat /tmp/rebuilt-outputs.json >&2
+            echo >&2
+            echo "Diff:" >&2
+            diff -u /tmp/published-outputs.json /tmp/rebuilt-outputs.json >&2 || true
+            exit 1
+          fi
+          echo "ok: runtime pack for ${ARCH} at ${TARGET_TAG} reproduces byte-identically from source"
+
+      - name: Report skip (no eligible release yet)
+        if: env.TARGET_TAG == ''
+        run: echo "::notice::pack-reproducibility-runtime (${{ matrix.arch }}) skipped — no published release with an attested runtime pack manifest was found."

--- a/specs/plans/213-attested-fast-first-boot-packs.md
+++ b/specs/plans/213-attested-fast-first-boot-packs.md
@@ -351,6 +351,15 @@ snapshot) is gated on §C (the content-addressed pack download cache) and §F
       on-disk config, and the resolver's full mode × mirror-set/unset
       matrix (8 cases).
 
+#### §I progress — protected signing environments extended (2026-07-10)
+
+- [x] `405858c9` extends the `release-signing` GitHub environment (already
+  gating `builder-vm-image`, `ae3fa0c15`) to the `default-microvm` runtime-pack
+  job, and adds a dedicated `revocations-signing` environment to
+  `revocations.yml`, so both keyless-signing jobs — not just the builder-pack
+  one — require the same protected-ref approval before a signing identity can
+  be minted. Runbook: `specs/runbooks/release-signing-environments.md`.
+
 **Deferred, named here rather than implemented:**
 
 - Item 3 (key rotation window — overlapping signing keys valid only within
@@ -755,8 +764,10 @@ The design decisions (settled before this slice; see ADR-097 §9):
       action; `id-token: write`), and publishes the sidecar bundle + SBOM +
       checksums + manifest alongside the existing `vmlinux`/`rootfs.ext4` assets.
       (Runtime pack producer/publish deferred — builder pack first.)
-- [ ] Restrict the signing job to protected tag refs / a protected environment so
+- [x] Restrict the signing job to protected tag refs / a protected environment so
       the pinned subject identity cannot be minted from an arbitrary ref.
+      (landed `ae3fa0c15` for `builder-vm-image`, extended to `default-microvm`
+      + `revocations.yml` by `405858c9`.)
 - [x] Add the release verification gate (plan §B) that fails closed when any pack
       lacks a manifest, bundle, checksum, SBOM, or expected version metadata.
       (`verify-release-assets.sh` builder-pack gate: complete-or-absent, checksum-
@@ -863,12 +874,24 @@ release job's dry-run guards partially exercise).
   `cosign sign-blob --bundle` output; every Rust-verified signing step (builder
   pack + dev-image manifest) now signs `--new-bundle-format`, proven live by the
   pack-signing smoke round-tripping both paths.
-- **Protected environment for the signing job** so the pinned SAN can't be minted
-  from an arbitrary ref (beyond the existing tag-push gate).
-- **Producer SBOM URI is `file://<local path>`** (unverified provenance metadata,
-  harmless) — add a `--sbom-uri` so the published manifest records the release URL.
-- **`PackBuilder::build()` panics on a keyless-constructed builder** — a
-  programmer-error `.expect`, unreachable from current callers; make illegal states
-  unrepresentable (typed authority) when the producer is next touched.
-- **Runtime-pack producer/publish** (only the builder pack is wired).
-- **gh workflow run validation** on the branch before the first real tag.
+- ✅ **Protected environment for the signing job** so the pinned SAN can't be
+  minted from an arbitrary ref (beyond the existing tag-push gate) — landed
+  `ae3fa0c15` for `builder-vm-image`; `405858c9` extends the same
+  `release-signing` environment to `default-microvm` and adds a
+  `revocations-signing` environment to `revocations.yml`. Runbook:
+  `specs/runbooks/release-signing-environments.md`.
+- ✅ **Producer SBOM URI is `file://<local path>`** (unverified provenance
+  metadata, harmless) — `ae3fa0c15` adds `--sbom-uri` so the published manifest
+  records the release URL instead.
+- ✅ **`PackBuilder::build()` panics on a keyless-constructed builder** — a
+  programmer-error `.expect`, unreachable from current callers — `ae3fa0c15`
+  replaces the `Option<&SigningKey>` field with a `PackSigner` enum chosen at
+  construction and collapses `build()`/`build_sigstore()` into a single
+  `build()`, making the illegal state unrepresentable at compile time.
+- ✅ **Runtime-pack producer/publish** (previously only the builder pack was
+  wired) — `ae3fa0c15` adds `build_keyless_runtime_pack` + tool `--kind
+  runtime`; `10c74c52c` wires the `default-microvm` release job to produce,
+  keyless-sign, and publish the attested runtime pack alongside the plain
+  `vmlinux`/`rootfs.ext4` assets.
+- **gh workflow run validation** on the branch before the first real tag —
+  not yet run; still open.

--- a/specs/runbooks/release-signing-environments.md
+++ b/specs/runbooks/release-signing-environments.md
@@ -1,0 +1,60 @@
+# Runbook: release-signing GitHub Environments
+
+Three CI jobs mint keyless (OIDC/Fulcio) cosign signatures whose
+certificate SAN encodes the workflow ref that produced them. That ref
+is exactly the identity `crates/mvm-core/src/release_trust.rs` checks
+at verify time (`RELEASE_IDENTITY_TEMPLATES` /
+`REVOCATION_IDENTITY_TEMPLATES`), so whoever can trigger the workflow
+from an arbitrary ref can mint a trusted identity. Each job is gated
+behind a GitHub **Environment** whose "Deployment branches and tags"
+rule is the actual enforcement point — the `environment:` key in the
+workflow YAML alone does nothing until the environment is configured.
+
+## One-time setup (manual — Settings → Environments)
+
+### 1. `release-signing`
+
+- Repo → **Settings → Environments → New environment** → name
+  `release-signing`.
+- Under **Deployment branches and tags**, select **Selected branches
+  and tags** and add a tag rule matching `v*`. This ensures the
+  `release.yml@refs/tags/v…` SAN can only be minted from an actual
+  version-tag push, never a branch or a `workflow_dispatch` run.
+- Consumed by (`.github/workflows/release.yml`):
+  - `builder-vm-image` — signs the attested builder pack manifest.
+  - `default-microvm` — signs the attested runtime pack manifest.
+
+### 2. `revocations-signing`
+
+- **New environment** → name `revocations-signing`.
+- Under **Deployment branches and tags**, add a tag rule matching
+  `revocations` (the literal tag name, not a glob — this job only ever
+  runs off that one tag).
+- Do **not** reuse `release-signing` here: its tag rule (`v*`) would
+  never match the `revocations` tag and would permanently block this
+  job.
+- Consumed by (`.github/workflows/revocations.yml`):
+  - `publish` — signs the pack revocation list.
+
+## Why this step can't be skipped
+
+GitHub auto-creates an environment the first time a workflow
+references it in an `environment:` key, but that auto-created
+environment starts with **no protection rules at all** — any ref can
+run the job and mint a signature under that identity until someone
+visits Settings and adds the branch/tag restriction above. The
+`environment:` line in the workflow is necessary but not sufficient;
+these Settings steps are what actually constrain which ref can mint a
+valid signing identity. Do them before the first real release/revocation
+publish, not after.
+
+## Verify
+
+- Push a `v*` tag and confirm `builder-vm-image` / `default-microvm`
+  wait on (or run under) the `release-signing` environment in the
+  Actions run view.
+- Force-push the `revocations` tag and confirm `publish` in
+  `revocations.yml` runs under `revocations-signing`.
+- A run attempted from a non-matching ref (e.g. `workflow_dispatch` on
+  `main`, or a tag that doesn't match the rule) should be blocked by
+  the environment before the job's steps execute.


### PR DESCRIPTION
Follow-ups on the Plan 213 attested builder-pack pipeline. Continues the work from #1556 (which landed typed `PackBuilder` authority, `--sbom-uri`, the builder-pack protected signing environment, and the runtime-pack producer).

## Changes

**1. Close the signing-custody gap (`release.yml`, `revocations.yml`, new runbook).**
The `builder-vm-image` job already signs under a protected `environment: release-signing`, but two sibling jobs mint the *same* class of trust-critical keyless SAN with no environment gate:
- `default-microvm` (runtime-pack signing) → now `environment: release-signing`.
- `revocations.yml` `publish` (revocation-list signing) → now `environment: revocations-signing` (a **separate** env, since `release-signing`'s `v*` tag rule would never match the `revocations` tag).
- New `specs/runbooks/release-signing-environments.md` documents the one-time Settings → Environments setup (tag rules per env) these gates depend on — GitHub auto-creates a referenced environment *unprotected*, so the Settings step is what actually enforces the restriction.

**2. Pack reproducibility gate (`security.yml`, Lanes 10/11).**
New `pack-reproducibility-builder` + `pack-reproducibility-runtime` jobs (matrixed aarch64/x86_64, `if: github.event_name != 'pull_request'`). Each discovers the most recent published release carrying the relevant `*-pack-manifest.json` (via `gh release`, sidestepping the tag-push/producer race), rebuilds the Nix image from that release's exact commit, regenerates a manifest from the rebuilt artifacts (`mvm-builder-pack-tool` hash-recompute path), and diffs the **content-derived** hash fields (`kernel_hash`, `builder_image_hash`/`agent_rootfs_hash`, sorted `files[].sha256`) against the published manifest — failing closed on any mismatch. It deliberately does *not* diff `pack_hash` (that folds in build timestamp / signer identity / SBOM uri, so it differs every run).

**3. Doc reconciliation (`plan 213`).** Checked off the five follow-up bullets that already landed in #1556 (verified against code), with commit citations, plus a §I note that the runtime-pack + revocation signing jobs are now environment-gated.

## Not validated locally (release-time infra)
The reproducibility jobs and the environment gates only activate on a tagged release / nightly; they can't be exercised from a PR (no published pack to compare, environments enforced by GitHub Settings). The reproducibility jobs skip cleanly ("no eligible release yet") until a pack-carrying release exists.

## Out of scope (deliberately)
The **seed-Nix-closure** builder-pack item (Plan 213 WS-F) is *not* here — the plan gates it on a clean-box benchmark and it carries unresolved product decisions (what closure set is "common," size budget vs. the narrow-builder-image philosophy, hvf parity). It needs its own design pass.