### PR TITLE
refactor(guest): remove dead HostBoundRequest surface + record Phase 1 progress

### DIFF
--- a/crates/mvm-guest/README.md
+++ b/crates/mvm-guest/README.md
@@ -6,7 +6,7 @@ Vsock protocol definitions and integration management for guest-side agents runn
 
 | Module | Purpose |
 |--------|---------|
-| `vsock` | Guest control protocol: `GuestRequest`/`GuestResponse`, host-bound protocol: `HostBoundRequest`/`HostBoundResponse` |
+| `vsock` | Guest control protocol: `GuestRequest`/`GuestResponse` |
 | `builder_agent` | Host-VM dispatch protocol: `HostVmRequest`/`HostVmResponse` |
 | `integrations` | Integration manifest system: `IntegrationManifest`, `IntegrationEntry`, health checks |
 
@@ -17,13 +17,10 @@ All communication uses **4-byte big-endian length prefix + JSON body** over Fire
 | Port | Direction | Purpose |
 |------|-----------|---------|
 | 5252 | Host -> Guest | Guest agent control (Ping, WorkerStatus, SleepPrep, Wake) |
-| 53 | Guest -> Host | Host-bound requests (WakeInstance, QueryInstanceStatus) |
 | 21470 | Host -> Guest | Builder agent (NixBuild, HealthCheck) |
 
 > Listen-side ports (Host → Guest direction) live above 1023 because the
-> agent runs as uid 901 with no `CAP_NET_BIND_SERVICE` (ADR-002 §W4.5).
-> The connect-side port 53 is fine where it is — the guest *connects*
-> to the host UDS, no `bind(2)` involved.
+> agent runs as uid 901 with no `CAP_NET_BIND_SERVICE`.
 
 ## Binaries
 

--- a/crates/mvm-guest/src/vsock.rs
+++ b/crates/mvm-guest/src/vsock.rs
@@ -2366,66 +2366,6 @@ pub enum RunEntrypointError {
     InternalError,
 }
 
-// ============================================================================
-// Host-bound protocol (guest → host, reverse direction)
-// ============================================================================
-
-/// Port the host listens on for host-bound requests from gateway VMs.
-pub const HOST_BOUND_PORT: u32 = 53;
-
-/// Request FROM a guest VM (gateway) TO the host agent.
-/// Used for wake-on-demand: the gateway VM asks the host to wake a worker.
-#[derive(Debug, Clone, Serialize, Deserialize)]
-#[serde(deny_unknown_fields)]
-pub enum HostBoundRequest {
-    /// Wake a sleeping instance.
-    WakeInstance {
-        tenant_id: String,
-        pool_id: String,
-        instance_id: String,
-    },
-    /// Query current status of an instance.
-    QueryInstanceStatus {
-        tenant_id: String,
-        pool_id: String,
-        instance_id: String,
-    },
-    /// Query host wall-clock time.
-    ///
-    /// The guest agent calls this at boot (and after snapshot
-    /// restore / wake) to set its own clock against host-trusted
-    /// time. Without it, a guest with a broken clock could
-    /// silently bypass TLS certificate-validity checks, JWT
-    /// `exp` checks, and any `expires_at` field in plans /
-    /// secrets / attestation reports.
-    QueryHostTime,
-}
-
-/// Response from host agent to a guest VM's host-bound request.
-#[derive(Debug, Clone, Serialize, Deserialize)]
-#[serde(deny_unknown_fields)]
-pub enum HostBoundResponse {
-    /// Result of a wake request.
-    WakeResult {
-        success: bool,
-        detail: Option<String>,
-    },
-    /// Status of queried instance.
-    InstanceStatus {
-        status: String,
-        guest_ip: Option<String>,
-    },
-    /// Host wall-clock time. Reported as
-    /// (unix_seconds, unix_nanos) so the response is
-    /// representation-stable across host clock crates and
-    /// language runtimes — the guest reconstructs the
-    /// `chrono::DateTime<Utc>` (or platform equivalent) locally.
-    /// `unix_nanos` is the sub-second component, in `[0, 1_000_000_000)`.
-    HostTime { unix_seconds: i64, unix_nanos: u32 },
-    /// Error from host agent.
-    Error { message: String },
-}
-
 /// Read a single length-prefixed JSON frame from a stream.
 /// Returns the deserialized value.
 pub fn read_frame<T: serde::de::DeserializeOwned>(stream: &mut UnixStream) -> Result<T> {
@@ -4779,21 +4719,6 @@ mod tests {
     }
 
     #[test]
-    fn test_host_bound_request_rejects_unknown_field() {
-        let json =
-            r#"{"WakeInstance":{"tenant_id":"a","pool_id":"b","instance_id":"c","extra":true}}"#;
-        let err = serde_json::from_str::<HostBoundRequest>(json).unwrap_err();
-        assert!(err.to_string().contains("unknown field"));
-    }
-
-    #[test]
-    fn test_host_bound_response_rejects_unknown_field() {
-        let json = r#"{"WakeResult":{"success":true,"detail":null,"oops":1}}"#;
-        let err = serde_json::from_str::<HostBoundResponse>(json).unwrap_err();
-        assert!(err.to_string().contains("unknown field"));
-    }
-
-    #[test]
     fn test_fs_change_rejects_unknown_field() {
         let json = r#"{"path":"/x","kind":"created","size":0,"hidden":42}"#;
         let err = serde_json::from_str::<FsChange>(json).unwrap_err();
@@ -5361,96 +5286,6 @@ mod tests {
     }
 
     #[test]
-    fn test_host_bound_request_roundtrip() {
-        let variants: Vec<HostBoundRequest> = vec![
-            HostBoundRequest::WakeInstance {
-                tenant_id: "alice".to_string(),
-                pool_id: "workers".to_string(),
-                instance_id: "i-abc123".to_string(),
-            },
-            HostBoundRequest::QueryInstanceStatus {
-                tenant_id: "alice".to_string(),
-                pool_id: "workers".to_string(),
-                instance_id: "i-abc123".to_string(),
-            },
-            HostBoundRequest::QueryHostTime,
-        ];
-
-        for req in &variants {
-            let json = serde_json::to_string(req).unwrap();
-            let parsed: HostBoundRequest = serde_json::from_str(&json).unwrap();
-            let json2 = serde_json::to_string(&parsed).unwrap();
-            assert_eq!(json, json2);
-        }
-    }
-
-    #[test]
-    fn test_query_host_time_serialises_as_bare_variant() {
-        // QueryHostTime is unit-shaped — make sure it serialises
-        // as the bare string form rather than picking up an empty
-        // object body, so the wire format is forward-compatible
-        // with other unit variants in the enum.
-        let req = HostBoundRequest::QueryHostTime;
-        let json = serde_json::to_string(&req).unwrap();
-        assert_eq!(json, "\"QueryHostTime\"");
-    }
-
-    #[test]
-    fn test_host_time_response_roundtrip() {
-        let resp = HostBoundResponse::HostTime {
-            unix_seconds: 1_777_372_800,
-            unix_nanos: 123_456_789,
-        };
-        let json = serde_json::to_string(&resp).unwrap();
-        let parsed: HostBoundResponse = serde_json::from_str(&json).unwrap();
-        match parsed {
-            HostBoundResponse::HostTime {
-                unix_seconds,
-                unix_nanos,
-            } => {
-                assert_eq!(unix_seconds, 1_777_372_800);
-                assert_eq!(unix_nanos, 123_456_789);
-            }
-            other => panic!("expected HostTime, got {other:?}"),
-        }
-    }
-
-    #[test]
-    fn test_host_time_response_unknown_field_rejected() {
-        // deny_unknown_fields must reject an extra field even on a
-        // successful-looking variant — defends against a future
-        // host accidentally emitting a richer HostTime that older
-        // guests don't understand.
-        let json = r#"{"HostTime":{"unix_seconds":0,"unix_nanos":0,"timezone":"UTC"}}"#;
-        let result: Result<HostBoundResponse, _> = serde_json::from_str(json);
-        assert!(result.is_err(), "extra field must be rejected");
-    }
-
-    #[test]
-    fn test_host_bound_response_roundtrip() {
-        let variants: Vec<HostBoundResponse> = vec![
-            HostBoundResponse::WakeResult {
-                success: true,
-                detail: Some("woke i-abc123".to_string()),
-            },
-            HostBoundResponse::InstanceStatus {
-                status: "Running".to_string(),
-                guest_ip: Some("10.240.1.5".to_string()),
-            },
-            HostBoundResponse::Error {
-                message: "instance not found".to_string(),
-            },
-        ];
-
-        for resp in &variants {
-            let json = serde_json::to_string(resp).unwrap();
-            let parsed: HostBoundResponse = serde_json::from_str(&json).unwrap();
-            let json2 = serde_json::to_string(&parsed).unwrap();
-            assert_eq!(json, json2);
-        }
-    }
-
-    #[test]
     fn test_ping_at_nonexistent_path() {
         let result = ping_at("/nonexistent/v.sock");
         assert!(result.is_err());
@@ -5593,11 +5428,6 @@ mod tests {
             connect_to_port(&socket_path, port, 1).expect("connect succeeds after restart");
         drop(stream);
         worker.join().unwrap();
-    }
-
-    #[test]
-    fn test_host_bound_port_constant() {
-        assert_eq!(HOST_BOUND_PORT, 53);
     }
 
     #[test]

--- a/specs/REFACTOR-STATUS.md
+++ b/specs/REFACTOR-STATUS.md
@@ -1212,8 +1212,16 @@ PLAN 236 — Host-authority runtime roadmap   🟡 IN PROGRESS
   [x] Start execution from an existing prerequisite branch instead of opening a duplicate lane.
   [x] Refresh the cleanest Phase 2A slice (`feat/vsock-port-handler-registry` / PR `#1599`) onto current `main`.
   [x] Re-run host-side validation on the refreshed slice (`cargo check --workspace`, `cargo test --workspace`, `cargo clippy --workspace --all-targets -- -D warnings`).
-  [ ] Fold the refreshed Phase 2A slice into `main`.
-  [x] Reconcile the remaining dirty/behind prerequisite worktrees onto `origin/main`; the temporary Plan 236 readiness helper is no longer kept in-tree.
+  [x] Fold the refreshed Phase 2A slice into `main` (port-handler registry closeout landed as `#1599`).
+  [x] Reconcile the prerequisite worktrees so the Plan 236 readiness check turned `GO` (refresh lanes fast-forwarded; merged slices recognized on `main`); the temporary readiness helper is no longer kept in-tree.
+  [x] Phase 1 §1 — deliver the host-signer verb-grant anchor over the kernel cmdline to the vsock-only backends (libkrun/HVF); sealed guests pin + selectively enforce plan-bound grants (`#1615`).
+  [x] Phase 1 §3.1 — rename `no_guest_nic` → `no_routable_guest_nic` with honest reachability semantics (`#1616`).
+  [x] Phase 2A workload delta — gate the HVF egress endpoint on admitted policy; deny-all spawns none and fails closed, matching libkrun (`#1619`).
+  [x] Phase 1 §2.3.1 — remove the dead `HostBoundRequest` protocol surface.
+  [x] Phase 1 §4 — verb-grant negative-path matrix + `re_pin_verb_grant` self-forgery bypass fix (`#1624`, closes `#1621`).
+  [ ] Phase 1 §1.4 — bake the sealed-image verb-trust policy: blocked on a production/verity OCI seal path (dev-only today; Slice 1 foundation in `#1628`).
+  [ ] Phase 1 §1.6 — macOS live proof of vsock-only verb-grant enforcement (blocked on the workload-kernel checksum manifest).
+  [ ] Bind restore-time authority to per-VM identity — cross-VM replay residual (`#1623`).
 
 PLAN 240 — Vsock port-handler registry production-readiness   ✅ COMPLETE
   [x] Replace the host-I/O thread's fixed 5 ms backstop with readiness-driven fd registration for agent, console, egress, and broker traffic.

--- a/specs/plans/236-host-authority-runtime-roadmap.md
+++ b/specs/plans/236-host-authority-runtime-roadmap.md
@@ -24,6 +24,25 @@ delta. That means the broad branch-staleness blocker is cleared; the remaining
 honest production-readiness blockers for Plan 236 are live-proof and closeout
 evidence, not stale prerequisite worktrees.
 
+**Execution progress (2026-07-10):** the gate turned `GO` and the Phase 1 →
+Phase 2A pivot largely landed on `main`. Shipped: §1 delivers the host-signer
+verb-grant anchor over the kernel cmdline to the vsock-only backends
+(libkrun/HVF), so sealed guests pin and *selectively* enforce plan-bound grants
+instead of failing to deny-all (PR `#1615`); §3.1 renames `no_guest_nic` →
+`no_routable_guest_nic` with honest reachability semantics (PR `#1616`); the
+Phase 2A workload delta gates the HVF egress endpoint on admitted policy so a
+deny-all workload spawns no endpoint and fails closed, matching libkrun
+(PR `#1619`); and the dead `HostBoundRequest` surface is removed. The §4
+negative-path matrix surfaced a real bypass — `re_pin_verb_grant` verified the
+resume envelope against its own embedded key — fixed by verifying against the
+boot-pinned host-signer anchor with a shared verification core (closes the
+self-forgery bypass). Remaining honest blockers: baking the sealed-image
+verb-trust policy needs a production/verity OCI seal path that does not exist
+yet (dev-only today); the macOS live-proof of vsock-only enforcement awaits the
+workload-kernel checksum manifest; and binding restore-time authority to a
+per-VM identity (cross-VM replay of a genuinely host-signed grant) is a tracked
+follow-up.
+
 ## Thesis
 
 `mvm` already has the right base posture:


### PR DESCRIPTION
Plan 236 Phase 1 cleanup (§2.3.1) + status bookkeeping.

## Removes
The `HostBoundRequest` / `HostBoundResponse` protocol family and `HOST_BOUND_PORT` (=53) in `mvm-guest/src/vsock.rs` — confirmed entirely unwired (no host listener, no guest dialer, no dispatch; only serde round-trip tests referenced them), superseded by the signed host-services broker. 170 lines removed plus the stale README rows. Every variant name (`WakeInstance`, `QueryInstanceStatus`, `QueryHostTime`, …) was cross-checked against unrelated live enums in mvm-core and left untouched. `rg` confirms zero remaining references; clippy `--all-targets` clean (no dead-code warnings), 433 mvm-guest tests pass.

## Records
Updates the Plan 236 doc and REFACTOR-STATUS to reflect what landed this cycle — verb-grant anchor delivery to the vsock-only backends (#1615), the `no_routable_guest_nic` rename (#1616), HVF endpoint gating (#1619), the re-pin bypass fix (#1624), the §2.3.1 removal here — and the remaining honest blockers (production/verity OCI seal for §1.4, macOS live proof for §1.6, and the cross-VM re-pin residual #1623).