### PR TITLE
feat(oci): verity-seal foundation — fail-closed initrd guard + seal capability

### DIFF
--- a/crates/mvm-backend/src/microvm.rs
+++ b/crates/mvm-backend/src/microvm.rs
@@ -2271,6 +2271,39 @@ pub fn resolved_runtime_overlay(config: &FlakeRunConfig) -> Option<(&str, &str, 
     ))
 }
 
+/// Resolve the initrd to attach for a flake boot, enforcing the dm-verity
+/// fail-closed invariant.
+///
+/// A caller-supplied stage-1 initrd wins over the verity initramfs at
+/// `<rootfs_dir>/rootfs.initrd` (the two never co-exist in practice). When
+/// verity is requested — a `roothash` is set — but neither an initrd is
+/// available, refuse to boot: without the verity initramfs the kernel would
+/// silently mount `/dev/vda` directly, dropping dm-verity and booting an
+/// unsealed root. That must fail closed, not fall through to an unverified
+/// boot.
+fn resolve_effective_initrd(config: &FlakeRunConfig) -> Result<Option<String>> {
+    // Convention from the flake: the verity initrd lives at
+    // `<rev_dir>/rootfs.initrd`, alongside `rootfs.{ext4,verity,roothash}`.
+    // Only derived when both the verity sidecar and roothash are present.
+    let verity_initrd_path = config
+        .verity_path
+        .as_deref()
+        .zip(config.roothash.as_deref())
+        .and_then(|_| {
+            std::path::Path::new(&config.rootfs_path)
+                .parent()
+                .map(|p| format!("{}/rootfs.initrd", p.display()))
+        })
+        .filter(|p| std::path::Path::new(p).exists());
+
+    let effective_initrd = config.initrd_path.clone().or(verity_initrd_path);
+
+    if config.roothash.is_some() && effective_initrd.is_none() {
+        anyhow::bail!("verity roothash present but no verity initramfs; refusing to boot unsealed");
+    }
+    Ok(effective_initrd)
+}
+
 /// Configure a flake-built microVM via the Firecracker API (multi-VM).
 #[instrument(skip_all, fields(name = %config.name))]
 pub fn configure_flake_microvm(config: &FlakeRunConfig, abs_dir: &str, socket: &str) -> Result<()> {
@@ -2321,20 +2354,10 @@ pub fn configure_flake_microvm_with_drives_dir(
     // the pivot in userspace via the initramfs, the kernel's `root=`
     // setting becomes irrelevant — `mvm-verity-init` chooses the real
     // root explicitly via `mount` + `switch_root`.
-    let verity_initrd_path = config
-        .verity_path
-        .as_deref()
-        .zip(config.roothash.as_deref())
-        .and_then(|_| {
-            // Convention from `nix/flake.nix`: the verity initrd lives
-            // at `<rev_dir>/rootfs.initrd`, alongside `rootfs.{ext4,
-            // verity,roothash}`. Fall back to `None` if the file isn't
-            // present (older templates that pre-date the initrd path).
-            std::path::Path::new(&config.rootfs_path)
-                .parent()
-                .map(|p| format!("{}/rootfs.initrd", p.display()))
-        })
-        .filter(|p| std::path::Path::new(p).exists());
+    // Resolve the initrd, enforcing the fail-closed verity invariant: a
+    // roothash-requested boot with no verity initramfs must error rather than
+    // silently mount /dev/vda unsealed.
+    let effective_initrd = resolve_effective_initrd(config)?;
     // The runtime overlay only has a consumer when verity is on —
     // `mvm-verity-init` is the PID 1 that reads
     // `mvm.runtime_roothash=` and bind-mounts the overlay at
@@ -2350,15 +2373,6 @@ pub fn configure_flake_microvm_with_drives_dir(
     };
     let verity_args: Option<String> =
         build_verity_cmdline_args(config.roothash.as_deref(), overlay.map(|(_, _, h)| h));
-
-    // Pick the initrd to attach: caller-supplied (NixOS stage-1) wins
-    // over the verity initrd. They can't both be present in practice —
-    // the production minimal-init path doesn't use a NixOS stage-1 —
-    // but the precedence is documented for future contributors.
-    let effective_initrd = config
-        .initrd_path
-        .clone()
-        .or_else(|| verity_initrd_path.clone());
 
     let boot_args = if effective_initrd.is_some() {
         // initrd owns root mounting. Verity adds the cmdline knobs the
@@ -3646,6 +3660,87 @@ mod tests {
         std::fs::write(dir.path().join("rootfs.verity"), b"hash-tree").unwrap();
         std::fs::write(dir.path().join("rootfs.roothash"), b"not-a-hex-roothash").unwrap();
         assert_eq!(probe_verity_sidecar(rootfs.to_str().unwrap()), (None, None));
+    }
+
+    #[test]
+    fn resolve_effective_initrd_fails_closed_when_verity_requested_without_initramfs() {
+        // A roothash means dm-verity was requested. With no verity
+        // initramfs present (and no caller-supplied stage-1), booting would
+        // silently mount /dev/vda unsealed — the claim-3 hole. Refuse.
+        let dir = tempfile::tempdir().unwrap();
+        let rootfs = dir.path().join("rootfs.ext4");
+        std::fs::write(&rootfs, b"data").unwrap();
+        std::fs::write(dir.path().join("rootfs.verity"), b"hash-tree").unwrap();
+        // Deliberately do NOT write rootfs.initrd.
+
+        let mut cfg = baseline_run_config(None);
+        cfg.rootfs_path = rootfs.to_string_lossy().into_owned();
+        cfg.verity_path = Some(
+            dir.path()
+                .join("rootfs.verity")
+                .to_string_lossy()
+                .into_owned(),
+        );
+        cfg.roothash = Some(ROOTFS_HASH.into());
+
+        let err = resolve_effective_initrd(&cfg).expect_err("must fail closed");
+        let msg = format!("{err:#}");
+        assert!(
+            msg.contains("refusing to boot unsealed"),
+            "unexpected error message: {msg}"
+        );
+    }
+
+    #[test]
+    fn resolve_effective_initrd_proceeds_when_verity_initramfs_present() {
+        // Roothash + the sibling rootfs.initrd present ⇒ the verity boot
+        // path is complete, so resolution yields that initrd.
+        let dir = tempfile::tempdir().unwrap();
+        let rootfs = dir.path().join("rootfs.ext4");
+        std::fs::write(&rootfs, b"data").unwrap();
+        std::fs::write(dir.path().join("rootfs.verity"), b"hash-tree").unwrap();
+        let initrd = dir.path().join("rootfs.initrd");
+        std::fs::write(&initrd, b"initramfs").unwrap();
+
+        let mut cfg = baseline_run_config(None);
+        cfg.rootfs_path = rootfs.to_string_lossy().into_owned();
+        cfg.verity_path = Some(
+            dir.path()
+                .join("rootfs.verity")
+                .to_string_lossy()
+                .into_owned(),
+        );
+        cfg.roothash = Some(ROOTFS_HASH.into());
+
+        let got = resolve_effective_initrd(&cfg).expect("verity boot path is complete");
+        assert_eq!(got.as_deref(), Some(initrd.to_str().unwrap()));
+    }
+
+    #[test]
+    fn resolve_effective_initrd_proceeds_with_caller_supplied_initrd() {
+        // A caller-supplied stage-1 initrd satisfies the invariant even when
+        // no sibling rootfs.initrd exists, and takes precedence.
+        let dir = tempfile::tempdir().unwrap();
+        let rootfs = dir.path().join("rootfs.ext4");
+        std::fs::write(&rootfs, b"data").unwrap();
+
+        let mut cfg = baseline_run_config(None);
+        cfg.rootfs_path = rootfs.to_string_lossy().into_owned();
+        cfg.roothash = Some(ROOTFS_HASH.into());
+        cfg.initrd_path = Some("/k/stage1.initrd".into());
+
+        let got = resolve_effective_initrd(&cfg).expect("caller initrd satisfies the guard");
+        assert_eq!(got.as_deref(), Some("/k/stage1.initrd"));
+    }
+
+    #[test]
+    fn resolve_effective_initrd_unsealed_boot_unaffected() {
+        // No roothash ⇒ verity is not requested. The guard must not fire;
+        // a plain unsealed rootfs boots with no initrd (kernel mounts vda).
+        let cfg = baseline_run_config(None);
+        assert!(cfg.roothash.is_none());
+        let got = resolve_effective_initrd(&cfg).expect("plain unsealed boot proceeds");
+        assert_eq!(got, None);
     }
 
     #[test]

--- a/crates/mvm-build/src/run_image.rs
+++ b/crates/mvm-build/src/run_image.rs
@@ -13,6 +13,9 @@ use anyhow::{Context, Result};
 
 use crate::guest_agent_build::GuestRuntimeBinaryBytes;
 use crate::oci_runtime_inject::{MvmRuntimeBinaries, OciEntrypointConfig};
+use crate::oci_to_rootfs::{
+    MaterializedRootfs, OciUnpackError, VeritySealedRootfs, VeritysetupOptions, seal_with_verity,
+};
 use crate::rootfs::MaterializeExt4Input;
 
 /// Guest runtime binaries embedded in the host binary at build time — the
@@ -190,6 +193,38 @@ pub fn unpacked_tree_size(root: &Path) -> Result<u64> {
     Ok(total)
 }
 
+/// Seal an already-materialized `rootfs.ext4` at `rootfs_ext4` into a dm-verity
+/// artifact set, emitting the sibling `rootfs.verity` (Merkle hash tree) and
+/// `rootfs.roothash` (lowercase-hex root hash) files. Those are the exact sibling
+/// names the backend's boot-time sidecar probe reads to decide a sealed boot.
+///
+/// Delegates to [`seal_with_verity`], which pins the 1024-byte data block size
+/// the verity initramfs requires. Do **not** reach for
+/// `materialize_ext4_pure(..).with_verity()` in this role: its 4096-byte data
+/// blocks disagree with the initramfs and the resulting image will not boot.
+///
+/// Linux-only at runtime. On macOS `veritysetup` is unavailable, so this returns
+/// [`OciUnpackError::HostUnsupported`] rather than a fabricated hash — the seal
+/// runs on Linux (or via the builder VM in a later slice). This is a
+/// test-exercised capability and is **not** yet wired into the live `--prod` run
+/// path; that lands atomically with the verity initramfs so no unsealed or
+/// no-boot window is ever exposed.
+pub fn seal_run_rootfs_with_verity(
+    rootfs_ext4: &Path,
+) -> Result<VeritySealedRootfs, OciUnpackError> {
+    let size_bytes = std::fs::metadata(rootfs_ext4)?.len();
+    // `seal_with_verity` only reads `path`; the descriptor's label/uuid are
+    // metadata mirrored for diagnostics. Name them like the materialize path so
+    // the two artifacts read together coherently.
+    let descriptor = MaterializedRootfs {
+        path: rootfs_ext4.to_path_buf(),
+        size_bytes,
+        label: "mvm-rootfs".to_string(),
+        uuid: String::new(),
+    };
+    seal_with_verity(&descriptor, &VeritysetupOptions::default())
+}
+
 /// Which rootfs strategy the run path uses for a workload.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum RootStrategy {
@@ -233,6 +268,37 @@ pub fn select_root_strategy(s: RootStrategySelection) -> RootStrategy {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[cfg(not(target_os = "linux"))]
+    #[test]
+    fn seal_run_rootfs_surfaces_host_unsupported_on_non_linux() {
+        // On macOS the sealing capability is compiled and callable, but the
+        // underlying `veritysetup` is Linux-only, so it must surface
+        // `HostUnsupported` — never a fabricated roothash. The real seal runs on
+        // Linux / via the builder VM.
+        let tmp = tempfile::tempdir().unwrap();
+        let rootfs = tmp.path().join("rootfs.ext4");
+        std::fs::write(&rootfs, b"ext4-bytes").unwrap();
+        let err = seal_run_rootfs_with_verity(&rootfs).expect_err("veritysetup is Linux-only");
+        assert!(
+            matches!(err, OciUnpackError::HostUnsupported { .. }),
+            "expected HostUnsupported on non-Linux, got {err:?}"
+        );
+    }
+
+    #[cfg(not(target_os = "linux"))]
+    #[test]
+    fn seal_run_rootfs_errors_on_missing_input_file() {
+        // A missing input surfaces the metadata I/O error before any host probe —
+        // fail closed, never a silent success.
+        let tmp = tempfile::tempdir().unwrap();
+        let missing = tmp.path().join("rootfs.ext4");
+        let err = seal_run_rootfs_with_verity(&missing).expect_err("missing input must error");
+        assert!(
+            matches!(err, OciUnpackError::Io(_)),
+            "expected Io error for missing input, got {err:?}"
+        );
+    }
 
     #[test]
     fn virtiofs_root_only_for_capable_non_prod_non_sealed() {

--- a/crates/mvm-build/tests/oci_verity_sealing.rs
+++ b/crates/mvm-build/tests/oci_verity_sealing.rs
@@ -20,6 +20,7 @@ use mvm_build::oci_to_rootfs::{
     ImageStaging, MaterializedRootfs, Mke2fsOptions, OciUnpackError, StagingOptions,
     VeritysetupOptions, materialize_to_ext4, seal_with_verity,
 };
+use mvm_build::run_image::seal_run_rootfs_with_verity;
 use std::path::Path;
 use tempfile::TempDir;
 
@@ -238,6 +239,77 @@ fn seal_detects_post_format_rootfs_tamper() {
         "veritysetup verify must reject a tampered rootfs; stdout={} stderr={}",
         String::from_utf8_lossy(&verify.stdout),
         String::from_utf8_lossy(&verify.stderr)
+    );
+}
+
+/// Materialize a small ext4 whose `etc/version` carries `payload`, so two
+/// distinct payloads yield rootfs images with distinct data blocks — the input
+/// the content-binding assertion needs. Output is named `rootfs.ext4` so the
+/// sealer derives the `rootfs.verity` / `rootfs.roothash` sibling names the boot
+/// probe expects.
+fn make_ext4_with_payload(payload: &[u8]) -> (TempDir, std::path::PathBuf) {
+    let staging_tmp = TempDir::new().unwrap();
+    let staging = ImageStaging::new(staging_tmp.path(), StagingOptions::default()).unwrap();
+    write_file(staging_tmp.path(), "etc/version", payload);
+    write_file(staging_tmp.path(), "bin/sh", b"#!/bin/sh\necho ok\n");
+    let staged = staging.finalize().unwrap();
+
+    let out_dir = TempDir::new().unwrap();
+    let output = out_dir.path().join("rootfs.ext4");
+    let mke2fs_options = Mke2fsOptions {
+        block_size: 1024,
+        ..Mke2fsOptions::default()
+    };
+    materialize_to_ext4(&staged, &output, &mke2fs_options).expect("materialize_to_ext4");
+    (out_dir, output)
+}
+
+#[test]
+fn seal_run_rootfs_emits_probe_compatible_sidecars() {
+    // The path-based capability must emit the exact sibling names the backend's
+    // `probe_verity_sidecar` reads (`rootfs.verity` + `rootfs.roothash`) with a
+    // 64-char lowercase-hex roothash — the probe's acceptance contract.
+    if skip_if_no_veritysetup() || skip_if_no_mke2fs() {
+        return;
+    }
+    let (_keep, rootfs_ext4) = make_ext4_with_payload(b"v1");
+    let sealed = seal_run_rootfs_with_verity(&rootfs_ext4).expect("seal_run_rootfs_with_verity");
+
+    let dir = rootfs_ext4.parent().unwrap();
+    assert_eq!(sealed.sidecar_path, dir.join("rootfs.verity"));
+    assert_eq!(sealed.roothash_path, dir.join("rootfs.roothash"));
+    assert!(sealed.sidecar_path.exists(), "verity sidecar must exist");
+    assert!(sealed.roothash_path.exists(), "roothash file must exist");
+
+    let on_disk = std::fs::read_to_string(&sealed.roothash_path).unwrap();
+    let hash = on_disk.trim();
+    assert!(!hash.is_empty(), "roothash file must be non-empty");
+    // Mirror `probe_verity_sidecar`'s acceptance check exactly: 64 hex chars.
+    assert_eq!(hash.len(), 64, "sha256 hex roothash must be 64 chars");
+    assert!(
+        hash.bytes().all(|b| b.is_ascii_hexdigit()),
+        "roothash must be hex: {hash:?}"
+    );
+    assert_eq!(hash, sealed.roothash);
+}
+
+#[test]
+fn seal_run_rootfs_roothash_binds_to_content() {
+    // Changing the rootfs bytes must change the roothash — the load-bearing
+    // claim-3 content-binding property. Different `etc/version` payloads produce
+    // different data blocks and so must produce different roothashes.
+    if skip_if_no_veritysetup() || skip_if_no_mke2fs() {
+        return;
+    }
+    let (_keep_a, rootfs_a) = make_ext4_with_payload(b"content-alpha");
+    let (_keep_b, rootfs_b) = make_ext4_with_payload(b"content-bravo-differs");
+
+    let sealed_a = seal_run_rootfs_with_verity(&rootfs_a).expect("seal a");
+    let sealed_b = seal_run_rootfs_with_verity(&rootfs_b).expect("seal b");
+
+    assert_ne!(
+        sealed_a.roothash, sealed_b.roothash,
+        "distinct rootfs content must yield distinct roothashes"
     );
 }
 


### PR DESCRIPTION
Slice 1 of the production/sealed OCI verity path (no hardware). Lays the safe foundation without exposing any insecure window.

## 1. Fail-closed boot guard (the security win)
`resolve_effective_initrd` replaces the inline initrd resolution: when a rootfs carries a verity `roothash` but no verity initramfs resolves (`rootfs.initrd` sibling or caller stage-1), the backend now **refuses to boot** instead of silently mounting the root device without dm-verity. This closes a latent silent-unsealed-boot hole. Non-verity boots (`roothash: None`) are unaffected. Confirmed no legitimate flow relied on the old fallback (sealed flake artifacts always ship `rootfs.initrd`; the OCI path's `probe_verity_sidecar` returns `None` today).

## 2. Seal capability
`seal_run_rootfs_with_verity(rootfs_ext4)` seals a materialized OCI rootfs into `rootfs.verity` + `rootfs.roothash` siblings via `oci_to_rootfs::seal_with_verity` (veritysetup, 1024-byte data blocks matching `mvm-verity-init` — the pure 4096-byte writer would produce a non-booting hash). macOS returns `HostUnsupported` (never a faked hash). **Not yet wired into `--prod`** — that lands atomically with the verity initramfs in Slice 2, so no silent-unsealed or no-boot window is exposed on main.

## Tests
4 guard unit tests (fail-closed / both-present / caller-initrd / unsealed-unaffected); 2 macOS capability tests (HostUnsupported surfaced, missing-input error); 2 Linux+veritysetup integration tests (probe-compatible sidecar names + 64-hex roothash; roothash binds to content) — compile-verified via zigbuild, run in CI's Linux lane. nightly-fmt / clippy `--all-targets` / no-spec-refs clean.

Part of the OCI verity-seal slice plan; Slices 2–3 add the initrd + `--prod` wiring + the live-boot tamper regression (hardware).