### PR TITLE
Plan 213 SP1: versioned pack cache + lifecycle facade + mvmctl pack

### DIFF
--- a/crates/mvm-cli/src/commands/cmd_audit.rs
+++ b/crates/mvm-cli/src/commands/cmd_audit.rs
@@ -215,6 +215,7 @@ impl Commands {
             Commands::Prepare(_) => "prepare",
             Commands::Manifest(_) => "manifest",
             Commands::Image(_) => "image",
+            Commands::Pack(_) => "pack",
             // `machine <sub>`: folded advanced ops (pause/snapshot/set-ttl/…)
             // keep their per-op verb; native lifecycle verbs report `machine`.
             Commands::Machine(a) => a.action.verb_name(),

--- a/crates/mvm-cli/src/commands/dispatch.rs
+++ b/crates/mvm-cli/src/commands/dispatch.rs
@@ -25,6 +25,7 @@ impl TopLevelCommand for Commands {
             Commands::Build(a) => build::group::run(cli, a, cfg),
             Commands::Manifest(a) => manifest::run(cli, a, cfg),
             Commands::Image(a) => image::run(cli, a, cfg),
+            Commands::Pack(a) => pack::run(cli, a, cfg),
             Commands::Machine(a) => machine::run(cli, a, cfg),
             Commands::Storage(a) => storage::run(cli, a, cfg),
             Commands::ShellInit(a) => env::shell_init::run(cli, a, cfg),

--- a/crates/mvm-cli/src/commands/env/dev_vz.rs
+++ b/crates/mvm-cli/src/commands/env/dev_vz.rs
@@ -1,7 +1,12 @@
 //! Dev environment lifecycle helpers + bundled image fetching, builder-VM
 //! image bootstrap, Stage 0, and dev-cache inspection.
 
-mod bootstrap;
+// `pub(in crate::commands)`: the `attested_builder_pack` release-fetch +
+// verification-context helpers are reused by `commands::pack` (a sibling of
+// `env`, not a descendant of `dev_vz`) to implement `mvmctl pack
+// download/update builder` over the same trust construction, rather than
+// forking a second copy.
+pub(in crate::commands) mod bootstrap;
 #[cfg(test)]
 mod bootstrap_tests;
 #[cfg(test)]

--- a/crates/mvm-cli/src/commands/env/dev_vz/bootstrap.rs
+++ b/crates/mvm-cli/src/commands/env/dev_vz/bootstrap.rs
@@ -723,7 +723,7 @@ pub(in crate::commands) mod attested_builder_pack {
     use mvm_core::arch::GuestArch;
     use mvm_core::config::mvm_keys_dir;
     #[cfg(feature = "manifest-verify")]
-    use mvm_core::pack_cache::promote;
+    use mvm_core::pack_cache::{PackProvenanceInput, promote_and_record};
     use mvm_core::pack_cache::{PackVerifyCtx, VerifiedPackDir, resolve_pack};
     #[cfg(feature = "manifest-verify")]
     use mvm_core::pack_trust::resolve_pack_download_base;
@@ -854,7 +854,16 @@ pub(in crate::commands) mod attested_builder_pack {
                     manifest_path.display()
                 )
             })?;
-        match promote(staging, &manifest, ctx) {
+        // `v{version}` matches the release tag `fetch_release_builder_pack_staging`
+        // builds its download base URL from, so the recorded version always
+        // names the exact release this pack came from.
+        let release_version = format!("v{}", env!("CARGO_PKG_VERSION"));
+        let prov = PackProvenanceInput {
+            channel: manifest.trust.channel_identity.clone(),
+            release_version,
+            promoted_at_unix: chrono::Utc::now().timestamp() as u64,
+        };
+        match promote_and_record(staging, &manifest, &prov, ctx) {
             Ok(dir) => Ok(Some(dir)),
             Err(error) => {
                 ui::warn(&format!(

--- a/crates/mvm-cli/src/commands/env/dev_vz/bootstrap.rs
+++ b/crates/mvm-cli/src/commands/env/dev_vz/bootstrap.rs
@@ -771,9 +771,9 @@ pub(in crate::commands) mod attested_builder_pack {
     /// revoked?". An empty config (no publishers) trusts no key and allows no
     /// channel, so every promoted pack fails verification and the caller falls
     /// back to the download — fail-open on availability, never on trust.
-    struct HostPackVerifyInputs {
-        policy: LocalPackPolicy,
-        trust: PackTrustConfig,
+    pub(in crate::commands) struct HostPackVerifyInputs {
+        pub(in crate::commands) policy: LocalPackPolicy,
+        pub(in crate::commands) trust: PackTrustConfig,
     }
 
     /// Load the on-disk trust config, folding both the absent and the malformed
@@ -795,7 +795,7 @@ pub(in crate::commands) mod attested_builder_pack {
         }
     }
 
-    fn host_pack_verify_inputs(arch: GuestArch) -> HostPackVerifyInputs {
+    pub(in crate::commands) fn host_pack_verify_inputs(arch: GuestArch) -> HostPackVerifyInputs {
         let trust = load_host_pack_trust();
         HostPackVerifyInputs {
             policy: LocalPackPolicy {
@@ -882,7 +882,9 @@ pub(in crate::commands) mod attested_builder_pack {
     /// fetch entirely, and the caller falls back to the local cache or the
     /// builder VM instead of treating it as an error.
     #[cfg(feature = "manifest-verify")]
-    fn fetch_release_builder_pack_staging(arch: &str) -> Result<Option<tempfile::TempDir>> {
+    pub(in crate::commands) fn fetch_release_builder_pack_staging(
+        arch: &str,
+    ) -> Result<Option<tempfile::TempDir>> {
         let trust = load_host_pack_trust();
         let version = env!("CARGO_PKG_VERSION");
         let default_base =

--- a/crates/mvm-cli/src/commands/env/dev_vz/bootstrap_tests.rs
+++ b/crates/mvm-cli/src/commands/env/dev_vz/bootstrap_tests.rs
@@ -750,4 +750,51 @@ mod attested_builder_pack_tests {
 
         promote_staged_builder_pack(staging.path(), &ctx).expect_err("missing manifest must error");
     }
+
+    /// A verifying staged pack must land in the version index — active for its
+    /// key — stamped with the release tag `promote_staged_builder_pack` derives
+    /// from the running binary's own version (the same `v{version}` form
+    /// `fetch_release_builder_pack_staging` builds its download base URL
+    /// from). Covers the recording half of the download acceleration path this
+    /// module exists for; the pure-facade recording behavior itself is proven
+    /// independently by `mvm_core::pack_cache`'s own `promote_and_record` tests.
+    #[cfg(feature = "manifest-verify")]
+    #[test]
+    fn promote_staged_builder_pack_records_release_version_and_active() {
+        let cache = TempDir::new().expect("cache tempdir");
+        let mut env = TestEnv::new();
+        env.set("MVM_CACHE_DIR", cache.path());
+
+        let staged = TempDir::new().expect("staged pack tempdir");
+        write_valid_builder_artifacts(staged.path());
+        let key = signing_key();
+        let manifest = builder_pack_manifest(staged.path(), &key);
+        std::fs::write(
+            staged.path().join("pack-manifest.json"),
+            manifest.canonical_bytes().expect("canonical bytes"),
+        )
+        .expect("write staged manifest");
+
+        let trust = trust_store(&key);
+        let rev = good_revocations();
+        let policy = hvf_policy();
+        let ctx = PackVerifyCtx::ed25519(&policy, &trust, &rev);
+
+        let promoted = promote_staged_builder_pack(staged.path(), &ctx)
+            .expect("promote should not error")
+            .expect("staged pack must verify and be promoted");
+
+        let versions =
+            mvm_core::pack_cache::list_versions(Some(PackKind::Builder)).expect("list_versions ok");
+        let entry = versions
+            .iter()
+            .find(|v| v.pack_hash == promoted.verified.pack_hash)
+            .expect("promoted pack must be recorded in the version index");
+        assert_eq!(
+            entry.release_version,
+            format!("v{}", env!("CARGO_PKG_VERSION")),
+            "recorded version must match the release tag the fetch URL is built from"
+        );
+        assert!(entry.active, "the sole promoted version must be active");
+    }
 }

--- a/crates/mvm-cli/src/commands/mod.rs
+++ b/crates/mvm-cli/src/commands/mod.rs
@@ -103,7 +103,7 @@ pub(in crate::commands) enum Commands {
     /// Explain a run after the fact from the chain-signed audit log
     #[command(display_order = 7)]
     Explain(vm::explain::Args),
-    /// Manage the versioned attested-pack cache (list/rollback/prune/download/update)
+    /// Manage the versioned pack cache (list/rollback/prune/download/update)
     #[command(display_order = 8)]
     Pack(pack::Args),
     /// SDK transport surface (`run --mode live/plan`). Hidden: the user-facing

--- a/crates/mvm-cli/src/commands/mod.rs
+++ b/crates/mvm-cli/src/commands/mod.rs
@@ -10,6 +10,7 @@ mod image;
 mod machine;
 mod manifest;
 mod ops;
+mod pack;
 /// Supervisor warm-pool: the `mvmctl pool warm/status` command + the launch glue
 /// (`try_warm_claim`/`replenish_after_launch`) the transient `machine run` path
 /// (`crate::exec::run_inner`) calls to claim a warm standby (auto-named,
@@ -102,6 +103,9 @@ pub(in crate::commands) enum Commands {
     /// Explain a run after the fact from the chain-signed audit log
     #[command(display_order = 7)]
     Explain(vm::explain::Args),
+    /// Manage the versioned attested-pack cache (list/rollback/prune/download/update)
+    #[command(display_order = 8)]
+    Pack(pack::Args),
     /// SDK transport surface (`run --mode live/plan`). Hidden: the user-facing
     /// transient-run role folded into `machine run`; `run` survives only as the
     /// SDK Sandbox launcher the Python/TS SDKs shell to, so it stays hidden

--- a/crates/mvm-cli/src/commands/ops/cache.rs
+++ b/crates/mvm-cli/src/commands/ops/cache.rs
@@ -541,6 +541,30 @@ pub(in crate::commands) fn run(_cli: &Cli, args: Args, _cfg: &MvmConfig) -> Resu
                 Err(e) => ui::warn(&format!("expired-pack sweep failed: {e}")),
             }
 
+            // Version-aware pack prune: reclaim non-active pack versions
+            // beyond the newest few per key, distinct from the expired-pack
+            // sweep above (which only removes packs whose trust metadata has
+            // lapsed). Keeps the active version plus the most recent
+            // runners-up so a rollback via `mvmctl pack activate` stays
+            // possible instead of every downloaded/built version
+            // accumulating forever.
+            match mvm_core::pack_cache::prune_versions(PACK_VERSION_KEEP_RECENT, dry_run) {
+                Ok(pruned) => {
+                    if !pruned.is_empty() {
+                        ui::info(&pack_version_prune_report(pruned.len(), dry_run));
+                        if !dry_run {
+                            mvm_core::audit_emit!(
+                                CachePrune,
+                                "source=pack_version_prune count={}",
+                                pruned.len()
+                            );
+                        }
+                        removed += pruned.len() as u64;
+                    }
+                }
+                Err(e) => ui::warn(&format!("pack version prune failed: {e}")),
+            }
+
             for entry in walkdir(path)? {
                 let entry_path = entry.path();
                 // Remove temp files (mvm-lima-*, .tmp)
@@ -827,6 +851,23 @@ pub(super) fn sweep_untagged_checkpoints(
         }
     }
     Ok(removed)
+}
+
+/// Number of non-active pack versions `mvmctl cache prune` keeps around per
+/// `(kind, arch, backend)` key, on top of whichever version is active. Kept as
+/// a named constant (not a literal at the call site) so the retention policy
+/// is documented in one place and a rollback via `mvmctl pack activate` stays
+/// possible for a little while after a newer version is promoted.
+const PACK_VERSION_KEEP_RECENT: usize = 2;
+
+/// User-facing summary line for the version-aware pack prune step, split out
+/// so the message format is unit-testable without exercising the pack cache.
+fn pack_version_prune_report(removed: usize, dry_run: bool) -> String {
+    if dry_run {
+        format!("(dry-run) Would remove {removed} old pack version(s).")
+    } else {
+        format!("Removed {removed} old pack version(s).")
+    }
 }
 
 /// Whole-second age of a file from its mtime, or `None` if it can't be
@@ -1341,5 +1382,24 @@ mod tests {
         let rows = cache_dir_breakdown(root);
         assert_eq!(rows[0].0, "ur-seed", "largest entry first");
         assert!(rows.iter().any(|(n, _)| n == "stage0"));
+    }
+
+    /// The version-aware pack prune step reports what it removed (or would
+    /// remove) in the same "would remove"/"removed" shape as the rest of
+    /// `cache prune`'s output.
+    #[test]
+    fn pack_version_prune_report_reflects_dry_run() {
+        assert_eq!(
+            pack_version_prune_report(3, true),
+            "(dry-run) Would remove 3 old pack version(s)."
+        );
+        assert_eq!(
+            pack_version_prune_report(3, false),
+            "Removed 3 old pack version(s)."
+        );
+        assert_eq!(
+            pack_version_prune_report(0, false),
+            "Removed 0 old pack version(s)."
+        );
     }
 }

--- a/crates/mvm-cli/src/commands/pack/download.rs
+++ b/crates/mvm-cli/src/commands/pack/download.rs
@@ -1,0 +1,180 @@
+//! `mvmctl pack download` — fetch a pack version into the cache without
+//! touching the active pointer.
+//!
+//! Only the builder pack class has a release-fetch wired today (via the
+//! `dev up` bootstrap path's published-pack machinery); runtime/dev-image
+//! packs have no publish/fetch story yet, so those refuse explicitly rather
+//! than pretending to do something.
+
+use anyhow::{Result, bail};
+
+use mvm_core::packs::PackKind;
+
+use super::PackKindArg;
+
+pub(in crate::commands) fn run(kind: PackKindArg, version: Option<String>) -> Result<()> {
+    match kind.to_pack_kind() {
+        PackKind::Builder => {
+            let promoted = builder::fetch_and_promote(version.as_deref())?;
+            crate::ui::success(&format!(
+                "Downloaded and cached builder pack {} (release {}).",
+                builder::short_hash(promoted.hash.as_str()),
+                promoted.release_version,
+            ));
+            Ok(())
+        }
+        other => not_fetchable(other),
+    }
+}
+
+/// Shared refusal for pack classes with no release-fetch wired yet. Explicit
+/// and specific per class rather than a generic "not implemented" — a caller
+/// should never wonder whether this is a bug or a known gap.
+pub(in crate::commands) fn not_fetchable(kind: PackKind) -> Result<()> {
+    let label = match kind {
+        PackKind::Builder => "builder",
+        PackKind::Runtime => "runtime",
+        PackKind::ImageProject => "dev-image",
+    };
+    bail!(
+        "{label} pack download is not yet fetchable — {label} release-fetch is not wired \
+         yet (only the builder pack has a publish/fetch path today)"
+    );
+}
+
+/// The builder-pack fetch, isolated in its own module so the `not
+/// all(release-artifact-bootstrap, builder-vm, manifest-verify)` fallback
+/// stays a single, obviously-correct arm regardless of how the feature-gated
+/// implementation evolves.
+pub(in crate::commands) mod builder {
+    use anyhow::Result;
+
+    use mvm_core::packs::Sha256Hex;
+
+    /// A builder pack this process just fetched and promoted (or, for
+    /// `update`, is about to activate).
+    pub(in crate::commands) struct PromotedBuilderPack {
+        pub(in crate::commands) key: mvm_core::pack_cache::PackKey,
+        pub(in crate::commands) hash: Sha256Hex,
+        pub(in crate::commands) release_version: String,
+    }
+
+    pub(in crate::commands) fn short_hash(hash: &str) -> &str {
+        &hash[..hash.len().min(12)]
+    }
+
+    #[cfg(all(
+        feature = "release-artifact-bootstrap",
+        feature = "builder-vm",
+        feature = "manifest-verify"
+    ))]
+    pub(in crate::commands) fn fetch_and_promote(
+        version: Option<&str>,
+    ) -> Result<PromotedBuilderPack> {
+        use anyhow::{Context, bail};
+
+        use mvm_core::arch::GuestArch;
+        use mvm_core::pack_cache::{
+            PackKey, PackProvenanceInput, PackVerifyCtx, promote_and_record,
+        };
+        use mvm_core::packs::PackManifest;
+
+        use crate::commands::env::dev_vz::bootstrap::attested_builder_pack::{
+            fetch_release_builder_pack_staging, host_pack_verify_inputs, keyless_release_policy,
+        };
+
+        // The published-pack fetch always pulls the assets for *this build's
+        // own* release version (the URL is derived from `CARGO_PKG_VERSION`).
+        // An explicit `--version` is honored only when it names that same
+        // release; pinning an arbitrary older/newer version isn't wired.
+        let current = env!("CARGO_PKG_VERSION");
+        if let Some(requested) = version {
+            let normalized = requested.trim_start_matches('v');
+            if normalized != current {
+                bail!(
+                    "only the current mvmctl release (v{current}) is fetchable today; \
+                     pinning a different --version isn't wired yet"
+                );
+            }
+        }
+
+        let arch = GuestArch::host();
+        let arch_str = match arch {
+            GuestArch::X86_64 => "x86_64",
+            GuestArch::Aarch64 => "aarch64",
+        };
+        let inputs = host_pack_verify_inputs(arch);
+        let policy = keyless_release_policy(&inputs.policy);
+        let keyless = mvm_core::release_trust::release_keyless_trust(current);
+        let ctx = PackVerifyCtx::keyless(&policy, &keyless, &inputs.trust);
+
+        let staging = fetch_release_builder_pack_staging(arch_str)
+            .context("fetching the published builder pack")?
+            .context(
+                "published builder pack fetch is disabled by the local pack-trust fetch_mode policy",
+            )?;
+
+        let manifest_path = staging.path().join("pack-manifest.json");
+        let manifest_bytes = std::fs::read(&manifest_path).with_context(|| {
+            format!(
+                "reading staged builder pack manifest at {}",
+                manifest_path.display()
+            )
+        })?;
+        let manifest: PackManifest =
+            serde_json::from_slice(&manifest_bytes).with_context(|| {
+                format!(
+                    "parsing staged builder pack manifest at {}",
+                    manifest_path.display()
+                )
+            })?;
+
+        let release_version = format!("v{current}");
+        let prov = PackProvenanceInput {
+            channel: manifest.trust.channel_identity.clone(),
+            release_version: release_version.clone(),
+            promoted_at_unix: now_unix(),
+        };
+        let key = PackKey {
+            kind: manifest.kind.clone(),
+            arch: manifest.target_arch,
+            backend: inputs.policy.backend.clone(),
+        };
+        let promoted = promote_and_record(staging.path(), &manifest, &prov, &ctx)
+            .context("verifying and promoting the downloaded builder pack")?;
+
+        Ok(PromotedBuilderPack {
+            key,
+            hash: promoted.verified.pack_hash,
+            release_version,
+        })
+    }
+
+    #[cfg(all(
+        feature = "release-artifact-bootstrap",
+        feature = "builder-vm",
+        feature = "manifest-verify"
+    ))]
+    fn now_unix() -> u64 {
+        std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .map(|d| d.as_secs())
+            .unwrap_or(0)
+    }
+
+    #[cfg(not(all(
+        feature = "release-artifact-bootstrap",
+        feature = "builder-vm",
+        feature = "manifest-verify"
+    )))]
+    pub(in crate::commands) fn fetch_and_promote(
+        _version: Option<&str>,
+    ) -> Result<PromotedBuilderPack> {
+        anyhow::bail!(
+            "builder pack download requires an mvmctl built with --features \
+             release-artifact-bootstrap,manifest-verify (end-user release binaries carry \
+             this by default); this binary was built without it, so it cannot fetch a \
+             published pack"
+        );
+    }
+}

--- a/crates/mvm-cli/src/commands/pack/download.rs
+++ b/crates/mvm-cli/src/commands/pack/download.rs
@@ -17,6 +17,11 @@ pub(in crate::commands) fn run(kind: PackKindArg, version: Option<String>) -> Re
     match kind.to_pack_kind() {
         PackKind::Builder => {
             let promoted = builder::fetch_and_promote(version.as_deref())?;
+            mvm_core::audit_emit!(
+                PackCacheChange,
+                "op=pack_download kind=builder version={}",
+                promoted.release_version
+            );
             crate::ui::success(&format!(
                 "Downloaded and cached builder pack {} (release {}).",
                 builder::short_hash(promoted.hash.as_str()),

--- a/crates/mvm-cli/src/commands/pack/download.rs
+++ b/crates/mvm-cli/src/commands/pack/download.rs
@@ -1,5 +1,6 @@
 //! `mvmctl pack download` — fetch a pack version into the cache without
-//! touching the active pointer.
+//! changing which version is active (the one exception: the first version
+//! recorded for a key becomes active, since none existed to preserve).
 //!
 //! Only the builder pack class has a release-fetch wired today (via the
 //! `dev up` bootstrap path's published-pack machinery); runtime/dev-image

--- a/crates/mvm-cli/src/commands/pack/list.rs
+++ b/crates/mvm-cli/src/commands/pack/list.rs
@@ -1,0 +1,80 @@
+//! `mvmctl pack list`.
+
+use anyhow::Result;
+use serde::Serialize;
+
+use mvm_core::arch::GuestArch;
+use mvm_core::packs::{PackBackend, PackKind};
+
+use crate::ui;
+
+use super::PackKindArg;
+
+/// One row of `pack list` — a flattened, JSON-friendly view of a
+/// `PackListEntry` (the facade type carries a `PackKey`, not individually
+/// serializable columns).
+#[derive(Debug, Serialize)]
+struct PackListRow {
+    pack_hash: String,
+    kind: PackKind,
+    arch: GuestArch,
+    backend: PackBackend,
+    channel: String,
+    release_version: String,
+    promoted_at_unix: u64,
+    active: bool,
+}
+
+pub(in crate::commands) fn run(kind: Option<PackKindArg>, json: bool) -> Result<()> {
+    let filter = kind.map(PackKindArg::to_pack_kind);
+    let mut versions = mvm_core::pack_cache::list_versions(filter)?;
+    // Stable, human-friendly ordering: by key (kind/arch/backend), newest
+    // version first within a key. `PackKind`/`GuestArch` carry no `Ord`, so
+    // key on their `Debug` text (stable, just not enum-declaration order).
+    versions.sort_by_key(|entry| {
+        (
+            format!("{:?}", entry.key.kind),
+            format!("{:?}", entry.key.arch),
+            entry.key.backend.clone(),
+            std::cmp::Reverse(entry.promoted_at_unix),
+        )
+    });
+
+    if json {
+        let rows: Vec<PackListRow> = versions
+            .iter()
+            .map(|entry| PackListRow {
+                pack_hash: entry.pack_hash.as_str().to_string(),
+                kind: entry.key.kind.clone(),
+                arch: entry.key.arch,
+                backend: entry.key.backend.clone(),
+                channel: entry.channel.clone(),
+                release_version: entry.release_version.clone(),
+                promoted_at_unix: entry.promoted_at_unix,
+                active: entry.active,
+            })
+            .collect();
+        crate::json_out::emit_json(&rows)?;
+        return Ok(());
+    }
+
+    if versions.is_empty() {
+        ui::info("No pack versions recorded.");
+        return Ok(());
+    }
+
+    for entry in &versions {
+        let short_hash = &entry.pack_hash.as_str()[..entry.pack_hash.as_str().len().min(12)];
+        let marker = if entry.active { "*" } else { " " };
+        println!(
+            "{marker} {short_hash:<12}  {:<10?}  {:<8?}  {:<12}  {:<10}  {}",
+            entry.key.kind,
+            entry.key.arch,
+            entry.key.backend.to_string(),
+            entry.release_version,
+            entry.channel,
+        );
+    }
+    ui::info("(* marks the active version for its kind/arch/backend)");
+    Ok(())
+}

--- a/crates/mvm-cli/src/commands/pack/mod.rs
+++ b/crates/mvm-cli/src/commands/pack/mod.rs
@@ -1,0 +1,116 @@
+//! `mvmctl pack` - list, roll back, prune, and (for the builder pack)
+//! download/update the versioned attested-pack cache.
+//!
+//! Mirrors `commands/image/`: a thin `Args`/`Subcommand` shell dispatching to
+//! one submodule per verb, each of which is a thin wrapper over the
+//! `mvm_core::pack_cache` lifecycle facade.
+
+use anyhow::Result;
+use clap::{Args as ClapArgs, Subcommand, ValueEnum};
+
+use mvm_core::packs::PackKind;
+use mvm_core::user_config::MvmConfig;
+
+use super::Cli;
+
+mod download;
+mod list;
+mod prune;
+mod rollback;
+mod update;
+
+#[derive(ClapArgs, Debug, Clone)]
+pub(in crate::commands) struct Args {
+    #[command(subcommand)]
+    pub action: PackAction,
+}
+
+#[derive(Subcommand, Debug, Clone)]
+pub(in crate::commands) enum PackAction {
+    /// List every recorded pack version, marking each key's active one
+    List {
+        /// Only list versions of this pack class
+        #[arg(long)]
+        kind: Option<PackKindArg>,
+        /// Emit machine-readable JSON to stdout
+        #[arg(long)]
+        json: bool,
+    },
+    /// Point a pack class's active version at an already-cached one
+    Rollback {
+        /// Which pack class to roll back
+        kind: PackKindArg,
+        /// A release version (e.g. "v0.17.0") or a pack-hash prefix to
+        /// activate. Omit to roll back to the second-newest version.
+        #[arg(long)]
+        to: Option<String>,
+    },
+    /// Reclaim non-active pack versions beyond the newest N per key
+    Prune {
+        /// How many of the newest versions per key to keep (beyond the active one)
+        #[arg(long, default_value_t = 2)]
+        keep_recent: usize,
+        /// Print what would be removed without removing anything
+        #[arg(long)]
+        dry_run: bool,
+        /// Emit machine-readable JSON to stdout
+        #[arg(long)]
+        json: bool,
+    },
+    /// Fetch a pack version into the cache without changing the active one
+    Download {
+        /// Which pack class to fetch
+        kind: PackKindArg,
+        /// Release version to fetch. Omit to fetch the latest.
+        #[arg(long)]
+        version: Option<String>,
+    },
+    /// Fetch the latest pack version and activate it
+    Update {
+        /// Which pack class to update
+        kind: PackKindArg,
+    },
+}
+
+/// `mvmctl pack <kind>` CLI selector, mapping onto [`PackKind`]. `dev-image`
+/// is the user-facing name for [`PackKind::ImageProject`].
+#[derive(ValueEnum, Debug, Clone, Copy, PartialEq, Eq)]
+pub(in crate::commands) enum PackKindArg {
+    Builder,
+    Runtime,
+    #[value(name = "dev-image")]
+    DevImage,
+}
+
+impl PackKindArg {
+    pub(in crate::commands) fn to_pack_kind(self) -> PackKind {
+        match self {
+            PackKindArg::Builder => PackKind::Builder,
+            PackKindArg::Runtime => PackKind::Runtime,
+            PackKindArg::DevImage => PackKind::ImageProject,
+        }
+    }
+
+    /// User-facing label for error/status messages — matches the clap value name.
+    pub(in crate::commands) fn label(self) -> &'static str {
+        match self {
+            PackKindArg::Builder => "builder",
+            PackKindArg::Runtime => "runtime",
+            PackKindArg::DevImage => "dev-image",
+        }
+    }
+}
+
+pub(in crate::commands) fn run(_cli: &Cli, args: Args, _cfg: &MvmConfig) -> Result<()> {
+    match args.action {
+        PackAction::List { kind, json } => list::run(kind, json),
+        PackAction::Rollback { kind, to } => rollback::run(kind, to),
+        PackAction::Prune {
+            keep_recent,
+            dry_run,
+            json,
+        } => prune::run(keep_recent, dry_run, json),
+        PackAction::Download { kind, version } => download::run(kind, version),
+        PackAction::Update { kind } => update::run(kind),
+    }
+}

--- a/crates/mvm-cli/src/commands/pack/prune.rs
+++ b/crates/mvm-cli/src/commands/pack/prune.rs
@@ -1,0 +1,53 @@
+//! `mvmctl pack prune`.
+
+use anyhow::Result;
+use serde::Serialize;
+
+use crate::ui;
+
+#[derive(Debug, Serialize)]
+struct PruneReport {
+    dry_run: bool,
+    keep_recent: usize,
+    removed: Vec<String>,
+}
+
+pub(in crate::commands) fn run(keep_recent: usize, dry_run: bool, json: bool) -> Result<()> {
+    let removed = mvm_core::pack_cache::prune_versions(keep_recent, dry_run)?;
+
+    if json {
+        let report = PruneReport {
+            dry_run,
+            keep_recent,
+            removed: removed.iter().map(|h| h.as_str().to_string()).collect(),
+        };
+        crate::json_out::emit_json(&report)?;
+        return Ok(());
+    }
+
+    if removed.is_empty() {
+        ui::info("No prunable pack versions.");
+        return Ok(());
+    }
+
+    let verb = if dry_run { "Would remove" } else { "Removed" };
+    for hash in &removed {
+        println!(
+            "{verb} pack version {}",
+            &hash.as_str()[..hash.as_str().len().min(12)]
+        );
+    }
+    ui::notice(&format!(
+        "{verb} {} pack version(s), keeping the {keep_recent} newest per key plus the active one.",
+        removed.len()
+    ));
+
+    if !dry_run {
+        mvm_core::audit_emit!(
+            CachePrune,
+            "op=pack_prune keep_recent={keep_recent} removed={}",
+            removed.len()
+        );
+    }
+    Ok(())
+}

--- a/crates/mvm-cli/src/commands/pack/rollback.rs
+++ b/crates/mvm-cli/src/commands/pack/rollback.rs
@@ -24,6 +24,12 @@ pub(in crate::commands) fn run(kind: PackKindArg, to: Option<String>) -> Result<
     };
 
     set_active_version(&target.key, &target.pack_hash)?;
+    mvm_core::audit_emit!(
+        PackCacheChange,
+        "op=pack_rollback kind={} to={}",
+        kind.label(),
+        target.release_version
+    );
     ui::success(&format!(
         "Rolled back {} pack to version {} ({}).",
         kind.label(),

--- a/crates/mvm-cli/src/commands/pack/rollback.rs
+++ b/crates/mvm-cli/src/commands/pack/rollback.rs
@@ -1,0 +1,93 @@
+//! `mvmctl pack rollback`.
+
+use anyhow::{Result, bail};
+
+use mvm_core::pack_cache::{PackListEntry, set_active_version};
+
+use crate::ui;
+
+use super::PackKindArg;
+
+pub(in crate::commands) fn run(kind: PackKindArg, to: Option<String>) -> Result<()> {
+    let pack_kind = kind.to_pack_kind();
+    let versions = mvm_core::pack_cache::list_versions(Some(pack_kind))?;
+    if versions.is_empty() {
+        bail!(
+            "no recorded pack versions for kind '{}'; nothing to roll back",
+            kind.label()
+        );
+    }
+
+    let target = match &to {
+        Some(to) => resolve_by_target(&versions, to)?,
+        None => resolve_previous(&versions, kind)?,
+    };
+
+    set_active_version(&target.key, &target.pack_hash)?;
+    ui::success(&format!(
+        "Rolled back {} pack to version {} ({}).",
+        kind.label(),
+        target.release_version,
+        short_hash(target.pack_hash.as_str()),
+    ));
+    Ok(())
+}
+
+/// Resolve `--to` against the recorded versions: a match on `release_version`
+/// exactly, or a `pack_hash` prefix. Ambiguous (more than one match) or
+/// no-match are both refused rather than guessed.
+fn resolve_by_target<'a>(versions: &'a [PackListEntry], to: &str) -> Result<&'a PackListEntry> {
+    let matches: Vec<&PackListEntry> = versions
+        .iter()
+        .filter(|entry| entry.release_version == to || entry.pack_hash.as_str().starts_with(to))
+        .collect();
+    match matches.as_slice() {
+        [] => bail!("no cached pack version matches '{to}'"),
+        [only] => Ok(only),
+        many => bail!(
+            "'{to}' matches {} cached pack versions ambiguously: {}",
+            many.len(),
+            many.iter()
+                .map(|entry| format!(
+                    "{} ({})",
+                    entry.release_version,
+                    short_hash(entry.pack_hash.as_str())
+                ))
+                .collect::<Vec<_>>()
+                .join(", "),
+        ),
+    }
+}
+
+/// Resolve the implicit rollback target (no `--to`): the second-newest
+/// version for this kind's single key. Refuses when the kind spans more than
+/// one `(arch, backend)` key — pick `--to` explicitly in that case — or when
+/// there is no older version to fall back to.
+fn resolve_previous(versions: &[PackListEntry], kind: PackKindArg) -> Result<&PackListEntry> {
+    let mut distinct_keys: Vec<&mvm_core::pack_cache::PackKey> = Vec::new();
+    for entry in versions {
+        if !distinct_keys.iter().any(|k| **k == entry.key) {
+            distinct_keys.push(&entry.key);
+        }
+    }
+    if distinct_keys.len() > 1 {
+        bail!(
+            "'{}' has {} recorded (arch, backend) targets; pass --to to disambiguate",
+            kind.label(),
+            distinct_keys.len(),
+        );
+    }
+
+    let mut by_recency: Vec<&PackListEntry> = versions.iter().collect();
+    by_recency.sort_by_key(|entry| std::cmp::Reverse(entry.promoted_at_unix));
+    by_recency.into_iter().nth(1).ok_or_else(|| {
+        anyhow::anyhow!(
+            "only one version of '{}' is cached; nothing older to roll back to",
+            kind.label()
+        )
+    })
+}
+
+fn short_hash(hash: &str) -> &str {
+    &hash[..hash.len().min(12)]
+}

--- a/crates/mvm-cli/src/commands/pack/update.rs
+++ b/crates/mvm-cli/src/commands/pack/update.rs
@@ -13,6 +13,11 @@ pub(in crate::commands) fn run(kind: PackKindArg) -> Result<()> {
         PackKind::Builder => {
             let promoted = builder::fetch_and_promote(None)?;
             mvm_core::pack_cache::set_active_version(&promoted.key, &promoted.hash)?;
+            mvm_core::audit_emit!(
+                PackCacheChange,
+                "op=pack_update kind=builder version={}",
+                promoted.release_version
+            );
             crate::ui::success(&format!(
                 "Updated builder pack to {} ({}) and activated it.",
                 promoted.release_version,

--- a/crates/mvm-cli/src/commands/pack/update.rs
+++ b/crates/mvm-cli/src/commands/pack/update.rs
@@ -1,0 +1,25 @@
+//! `mvmctl pack update` — fetch the latest pack version and activate it.
+//! `download` + `set_active_version` composed into one step.
+
+use anyhow::Result;
+
+use mvm_core::packs::PackKind;
+
+use super::PackKindArg;
+use super::download::builder;
+
+pub(in crate::commands) fn run(kind: PackKindArg) -> Result<()> {
+    match kind.to_pack_kind() {
+        PackKind::Builder => {
+            let promoted = builder::fetch_and_promote(None)?;
+            mvm_core::pack_cache::set_active_version(&promoted.key, &promoted.hash)?;
+            crate::ui::success(&format!(
+                "Updated builder pack to {} ({}) and activated it.",
+                promoted.release_version,
+                builder::short_hash(promoted.hash.as_str()),
+            ));
+            Ok(())
+        }
+        other => super::download::not_fetchable(other),
+    }
+}

--- a/crates/mvm-cli/tests/cli.rs
+++ b/crates/mvm-cli/tests/cli.rs
@@ -111,6 +111,45 @@ fn explain_with_json_flag_parses() {
     );
 }
 
+/// `pack --help` advertises all five lifecycle subcommands.
+#[test]
+fn pack_help_lists_all_subcommands() {
+    #[allow(deprecated)]
+    let out = Command::cargo_bin("mvmctl")
+        .unwrap()
+        .args(["pack", "--help"])
+        .output()
+        .unwrap();
+    assert!(
+        out.status.success(),
+        "pack --help must exit 0, stderr: {}",
+        String::from_utf8_lossy(&out.stderr)
+    );
+    let help = String::from_utf8_lossy(&out.stdout);
+    for verb in ["list", "rollback", "prune", "download", "update"] {
+        assert!(help.contains(verb), "help is missing '{verb}':\n{help}");
+    }
+}
+
+/// `pack list --json` parses and exits cleanly on a fresh/empty pack cache.
+#[test]
+fn pack_list_json_parses_cleanly() {
+    #[allow(deprecated)]
+    let out = Command::cargo_bin("mvmctl")
+        .unwrap()
+        .args(["pack", "list", "--json"])
+        .output()
+        .unwrap();
+    assert!(
+        out.status.success(),
+        "pack list --json must exit 0, stderr: {}",
+        String::from_utf8_lossy(&out.stderr)
+    );
+    let stdout = String::from_utf8_lossy(&out.stdout);
+    let _: serde_json::Value =
+        serde_json::from_str(stdout.trim()).expect("pack list --json must emit valid JSON");
+}
+
 #[test]
 fn machine_reconfigure_help_lists_patch_flags() {
     #[allow(deprecated)]

--- a/crates/mvm-core/src/pack_cache.rs
+++ b/crates/mvm-core/src/pack_cache.rs
@@ -1481,6 +1481,27 @@ mod tests {
     }
 
     #[test]
+    fn resolve_falls_back_to_scan_when_index_is_corrupt() {
+        let (cache, _env) = isolated_cache();
+        let trust = trust_store();
+        let rev = good_revocation();
+        let policy = policy();
+        let ctx = PackVerifyCtx::ed25519(&policy, &trust, &rev);
+
+        let (staged, manifest) = staged_builder_pack();
+        promote(staged.path(), &manifest, &ctx).expect("promote");
+
+        // A truncated / garbage `index.json` must not break resolution:
+        // `load_index` fails open and resolve re-verifies via the scan.
+        std::fs::write(index_path(cache.path()), b"{ not json").expect("write corrupt index");
+
+        let found = resolve_pack(PackKind::Builder, GuestArch::host(), PackBackend::Hvf, &ctx)
+            .expect("resolve ok")
+            .expect("compatible pack found despite corrupt index");
+        assert_eq!(found.root, pack_dir(manifest.outputs.pack_hash.as_str()));
+    }
+
+    #[test]
     fn resolve_falls_back_when_active_pack_is_corrupt() {
         let (cache, _env) = isolated_cache();
         let trust = trust_store();

--- a/crates/mvm-core/src/pack_cache.rs
+++ b/crates/mvm-core/src/pack_cache.rs
@@ -14,6 +14,9 @@ use std::sync::atomic::{AtomicU64, Ordering};
 use chrono::{DateTime, Utc};
 use thiserror::Error;
 
+mod index;
+pub use index::{PackEntry, PackIndex, PackKey};
+
 use crate::arch::GuestArch;
 use crate::config::{pack_cache_dir, pack_dir};
 use crate::packs::{

--- a/crates/mvm-core/src/pack_cache.rs
+++ b/crates/mvm-core/src/pack_cache.rs
@@ -18,7 +18,7 @@ mod index;
 pub use index::{PackEntry, PackIndex, PackKey};
 
 use crate::arch::GuestArch;
-use crate::config::{pack_cache_dir, pack_dir};
+use crate::config::{mvm_cache_dir, pack_cache_dir, pack_dir};
 use crate::packs::{
     COSIGN_BUNDLE_FILE_NAME, KeylessTrust, LocalPackPolicy, PackBackend, PackKind, PackManifest,
     PackManifestError, PackRevocationChecker, PackTrustStore, PackVerifyError, Sha256Hex,
@@ -235,15 +235,105 @@ fn populate_and_rename(
     Ok(())
 }
 
-/// Scan promoted packs for one matching `(kind, arch, backend)` and re-verify it
-/// before returning. Returns `Ok(None)` when nothing compatible verifies — a
-/// poisoned or mismatched entry is skipped, never served.
+/// Path to the persisted pack index: `<cache_root>/packs/index.json`.
+/// `cache_root` is the top-level mvm cache dir (`mvm_cache_dir()`), the same
+/// root `pack_cache_dir()` nests `packs/` under.
+fn index_path(cache_root: &Path) -> PathBuf {
+    cache_root.join("packs").join("index.json")
+}
+
+/// Load the persisted pack index. Fail-open: a missing file or a corrupt one
+/// (unreadable, truncated, or no longer matching the schema) yields
+/// `PackIndex::default()` rather than an error — the index is a cache of
+/// which promoted pack is "active", and every entry it points at is
+/// re-verified before use, so losing it only costs the active-pointer
+/// shortcut, never correctness.
+pub fn load_index(cache_root: &Path) -> PackIndex {
+    let Ok(bytes) = std::fs::read(index_path(cache_root)) else {
+        return PackIndex::default();
+    };
+    serde_json::from_slice(&bytes).unwrap_or_default()
+}
+
+/// Persist the pack index. Writes to a `.tmp` sibling and `rename`s it onto
+/// the final path so a reader never observes a partially-written file.
+pub fn save_index(cache_root: &Path, index: &PackIndex) -> Result<(), PackCacheError> {
+    let path = index_path(cache_root);
+    if let Some(parent) = path.parent() {
+        std::fs::create_dir_all(parent).map_err(io_at(parent))?;
+    }
+    let tmp_path = path.with_extension("json.tmp");
+    let bytes = serde_json::to_vec_pretty(index).map_err(PackManifestError::Json)?;
+    std::fs::write(&tmp_path, bytes).map_err(io_at(&tmp_path))?;
+    std::fs::rename(&tmp_path, &path).map_err(io_at(&path))?;
+    Ok(())
+}
+
+/// Verify one candidate promoted-pack dir against the requested
+/// `(kind, arch, backend)`. Shared by the active-pointer lookup and the
+/// directory scan in [`resolve_pack`] so both paths apply the exact same
+/// checks: a readable manifest whose declared hash matches the dir's name, a
+/// compatible `(kind, arch, backend)`, and a successful re-verify against
+/// `ctx`. Returns `None` for any dir that isn't a valid, matching, verifying
+/// promoted pack — never distinguishing "not found" from "found but
+/// rejected" (callers that need that distinction use [`diagnose_pack`]).
+fn verify_candidate_pack_dir(
+    dir: &Path,
+    kind: &PackKind,
+    arch: GuestArch,
+    backend: &PackBackend,
+    ctx: &PackVerifyCtx<'_>,
+) -> Option<VerifiedPackDir> {
+    let manifest = read_manifest(dir)?;
+    // Defense in depth: a content-addressed dir must be named for the pack
+    // hash it holds. A name/content mismatch is observable-and-skipped rather
+    // than served under the wrong identity.
+    if dir.file_name()?.to_str() != Some(manifest.outputs.pack_hash.as_str()) {
+        return None;
+    }
+    if &manifest.kind != kind
+        || manifest.target_arch != arch
+        || !manifest.backend_compatibility.contains(backend)
+    {
+        return None;
+    }
+    // Re-verify every use: a promoted-then-tampered entry fails here and is
+    // skipped, so a poisoned pack is never handed back.
+    let verified = ctx.verify(&manifest, dir).ok()?;
+    Some(VerifiedPackDir {
+        root: dir.to_path_buf(),
+        verified,
+    })
+}
+
+/// Resolve the promoted pack for `(kind, arch, backend)`, preferring the
+/// active version recorded in the persisted index. Falls back to a directory
+/// scan (today's non-deterministic-order behavior) when there is no index,
+/// no active pointer for this key, or the active pack no longer verifies —
+/// so an index that is missing, stale, or pointing at a poisoned pack never
+/// makes a compatible pack unreachable. Returns `Ok(None)` when nothing
+/// compatible verifies anywhere — a poisoned or mismatched entry is skipped,
+/// never served.
 pub fn resolve_pack(
     kind: PackKind,
     arch: GuestArch,
     backend: PackBackend,
     ctx: &PackVerifyCtx<'_>,
 ) -> Result<Option<VerifiedPackDir>, PackCacheError> {
+    let cache_root = PathBuf::from(mvm_cache_dir());
+    let index = load_index(&cache_root);
+    let key = PackKey {
+        kind: kind.clone(),
+        arch,
+        backend: backend.clone(),
+    };
+    if let Some(hash) = index.active_for(&key)
+        && let Some(found) =
+            verify_candidate_pack_dir(&pack_dir(hash.as_str()), &kind, arch, &backend, ctx)
+    {
+        return Ok(Some(found));
+    }
+
     let root = pack_cache_dir();
     let entries = match std::fs::read_dir(&root) {
         Ok(entries) => entries,
@@ -259,31 +349,8 @@ pub fn resolve_pack(
         if !dir.is_dir() || name.to_str() == Some(QUARANTINE_DIR_NAME) {
             continue;
         }
-        // A dir with no sidecar, or an unreadable/undecodable one, is foreign
-        // content — skip it and keep scanning. Never let one damaged entry hide
-        // every valid pack that sorts after it.
-        let Some(manifest) = read_manifest(&dir) else {
-            continue;
-        };
-        // Defense in depth: a content-addressed dir must be named for the pack
-        // hash it holds. A name/content mismatch is observable-and-skipped rather
-        // than served under the wrong identity.
-        if name.to_str() != Some(manifest.outputs.pack_hash.as_str()) {
-            continue;
-        }
-        if manifest.kind != kind
-            || manifest.target_arch != arch
-            || !manifest.backend_compatibility.contains(&backend)
-        {
-            continue;
-        }
-        // Re-verify every use: a promoted-then-tampered entry fails here and is
-        // skipped, so a poisoned pack is never handed back.
-        if let Ok(verified) = ctx.verify(&manifest, &dir) {
-            return Ok(Some(VerifiedPackDir {
-                root: dir,
-                verified,
-            }));
+        if let Some(found) = verify_candidate_pack_dir(&dir, &kind, arch, &backend, ctx) {
+            return Ok(Some(found));
         }
     }
     Ok(None)
@@ -1202,5 +1269,102 @@ mod tests {
         let packs = list_cached_packs().expect("list ok");
         assert_eq!(packs.len(), 1);
         assert_eq!(packs[0].pack_hash, manifest_future.outputs.pack_hash);
+    }
+
+    /// The `(kind, arch, backend)` slot every index test below records
+    /// against — matches what `policy()`/`resolve_pack` calls use.
+    fn builder_key() -> PackKey {
+        PackKey {
+            kind: PackKind::Builder,
+            arch: GuestArch::host(),
+            backend: PackBackend::Hvf,
+        }
+    }
+
+    fn entry_for(promoted: &VerifiedPackDir, channel: &str, promoted_at_unix: u64) -> PackEntry {
+        PackEntry {
+            pack_hash: promoted.verified.pack_hash.clone(),
+            key: builder_key(),
+            channel: channel.to_string(),
+            release_version: "v0.17.0".to_string(),
+            promoted_at_unix,
+        }
+    }
+
+    #[test]
+    fn resolve_prefers_active_pointer_over_scan_order() {
+        let (cache, _env) = isolated_cache();
+        let trust = trust_store();
+        let rev = good_revocation();
+        let policy = policy();
+        let ctx = PackVerifyCtx::ed25519(&policy, &trust, &rev);
+
+        let (staged_a, manifest_a) = staged_builder_pack_bytes(b"kernel-a", b"image-a");
+        let (staged_b, manifest_b) = staged_builder_pack_bytes(b"kernel-b", b"image-b");
+        let promoted_a = promote(staged_a.path(), &manifest_a, &ctx).expect("promote a");
+        let promoted_b = promote(staged_b.path(), &manifest_b, &ctx).expect("promote b");
+
+        let mut ix = load_index(cache.path());
+        ix.record(entry_for(&promoted_a, "stable", 10));
+        ix.record(entry_for(&promoted_b, "stable", 20));
+        assert!(ix.set_active(&builder_key(), &promoted_b.verified.pack_hash));
+        save_index(cache.path(), &ix).expect("save index");
+
+        // Scan order is by directory name (pack hash), which need not put `b`
+        // first — the active pointer must win regardless.
+        let found = resolve_pack(PackKind::Builder, GuestArch::host(), PackBackend::Hvf, &ctx)
+            .expect("resolve ok")
+            .expect("compatible pack found");
+        assert_eq!(found.verified.pack_hash, promoted_b.verified.pack_hash);
+    }
+
+    #[test]
+    fn resolve_falls_back_to_scan_when_no_index() {
+        let (_cache, _env) = isolated_cache();
+        let trust = trust_store();
+        let rev = good_revocation();
+        let policy = policy();
+        let ctx = PackVerifyCtx::ed25519(&policy, &trust, &rev);
+
+        let (staged, manifest) = staged_builder_pack();
+        promote(staged.path(), &manifest, &ctx).expect("promote");
+
+        // No `save_index` call at all — `index.json` never existed.
+        let found = resolve_pack(PackKind::Builder, GuestArch::host(), PackBackend::Hvf, &ctx)
+            .expect("resolve ok")
+            .expect("compatible pack found via scan fallback");
+        assert_eq!(found.root, pack_dir(manifest.outputs.pack_hash.as_str()));
+    }
+
+    #[test]
+    fn resolve_falls_back_when_active_pack_is_corrupt() {
+        let (cache, _env) = isolated_cache();
+        let trust = trust_store();
+        let rev = good_revocation();
+        let policy = policy();
+        let ctx = PackVerifyCtx::ed25519(&policy, &trust, &rev);
+
+        let (staged_a, manifest_a) = staged_builder_pack_bytes(b"kernel-a", b"image-a");
+        let (staged_b, manifest_b) = staged_builder_pack_bytes(b"kernel-b", b"image-b");
+        let promoted_a = promote(staged_a.path(), &manifest_a, &ctx).expect("promote a");
+        let promoted_b = promote(staged_b.path(), &manifest_b, &ctx).expect("promote b");
+
+        let mut ix = load_index(cache.path());
+        ix.record(entry_for(&promoted_a, "stable", 10));
+        ix.record(entry_for(&promoted_b, "stable", 20));
+        assert!(ix.set_active(&builder_key(), &promoted_b.verified.pack_hash));
+        save_index(cache.path(), &ix).expect("save index");
+
+        // Poison the active pack's promoted copy after the fact.
+        fs::write(
+            promoted_b.root.join("boot/kernel"),
+            b"poisoned-after-promote",
+        )
+        .expect("poison active pack");
+
+        let found = resolve_pack(PackKind::Builder, GuestArch::host(), PackBackend::Hvf, &ctx)
+            .expect("resolve ok")
+            .expect("falls back to the other verified pack");
+        assert_eq!(found.verified.pack_hash, promoted_a.verified.pack_hash);
     }
 }

--- a/crates/mvm-core/src/pack_cache.rs
+++ b/crates/mvm-core/src/pack_cache.rs
@@ -83,6 +83,18 @@ impl<'a> PackVerifyCtx<'a> {
         }
     }
 
+    /// The local policy every verification variant carries — in particular
+    /// `backend`, the concrete backend this host session is operating under.
+    /// Used to pin the single `(kind, arch, backend)` index slot a promoted
+    /// pack is recorded/activated against: a manifest's
+    /// `backend_compatibility` is a set (an eligibility check at resolve
+    /// time), not the one slot a given promotion applies to.
+    fn policy(&self) -> &LocalPackPolicy {
+        match self {
+            Self::Ed25519 { policy, .. } | Self::Keyless { policy, .. } => policy,
+        }
+    }
+
     fn verify(
         &self,
         manifest: &PackManifest,
@@ -130,6 +142,8 @@ pub enum PackCacheError {
     },
     #[error("pack declares a file with the reserved cache-sidecar name {0:?}")]
     ReservedFileName(String),
+    #[error("no promoted version {hash:?} recorded for pack key {key:?}")]
+    UnknownPackVersion { key: PackKey, hash: Sha256Hex },
 }
 
 fn io_at(path: &Path) -> impl Fn(std::io::Error) -> PackCacheError + '_ {
@@ -545,13 +559,143 @@ pub fn prune_expired_packs(
     for entry in list_cached_packs()? {
         if entry.expires_at < now {
             if !dry_run {
-                let dir = pack_dir(entry.pack_hash.as_str());
-                std::fs::remove_dir_all(&dir).map_err(io_at(&dir))?;
+                remove_pack_dir(&entry.pack_hash)?;
             }
             removed.push(entry.pack_hash);
         }
     }
     Ok(removed)
+}
+
+/// Delete a promoted pack's content-addressed directory. Shared by every
+/// prune path so the removal step (and its error mapping) is defined once.
+fn remove_pack_dir(hash: &Sha256Hex) -> Result<(), PackCacheError> {
+    let dir = pack_dir(hash.as_str());
+    std::fs::remove_dir_all(&dir).map_err(io_at(&dir))
+}
+
+/// Provenance the lifecycle facade records alongside a promoted pack.
+/// `promoted_at_unix` is supplied by the caller — `mvm-core` never reads the
+/// clock — so a mvm-cli call site computes "now" and passes it in.
+pub struct PackProvenanceInput {
+    pub channel: String,
+    pub release_version: String,
+    pub promoted_at_unix: u64,
+}
+
+/// One recorded pack version, as surfaced by [`list_versions`]: the
+/// [`PackEntry`] fields plus whether it is the active version for its key.
+#[derive(Debug, Clone, PartialEq)]
+pub struct PackListEntry {
+    pub pack_hash: Sha256Hex,
+    pub key: PackKey,
+    pub channel: String,
+    pub release_version: String,
+    pub promoted_at_unix: u64,
+    pub active: bool,
+}
+
+/// Promote a staged pack (verify + place, as [`promote`] does) and record its
+/// provenance into the persisted index.
+///
+/// A manifest's `backend_compatibility` is a *set* used at resolve time to
+/// check eligibility (`resolve_pack`'s `.contains(backend)`); it is not the
+/// one `(kind, arch, backend)` index slot this particular promotion should be
+/// recorded/activated against — `PackIndex::record` upserts by `pack_hash`
+/// alone, so recording the same hash under more than one key would silently
+/// collapse into whichever key was recorded last. Instead this pins the
+/// single slot from `ctx`'s [`LocalPackPolicy`] (`policy.backend`, the
+/// concrete backend this host session is actually running), which is exactly
+/// the slot [`resolve_pack`] is queried against for that session. `arch`
+/// comes from the manifest since a verifying pack's `target_arch` already
+/// matches the policy's `host_arch`.
+pub fn promote_and_record(
+    staged_root: &Path,
+    manifest: &PackManifest,
+    prov: &PackProvenanceInput,
+    ctx: &PackVerifyCtx<'_>,
+) -> Result<VerifiedPackDir, PackCacheError> {
+    let promoted = promote(staged_root, manifest, ctx)?;
+
+    let cache_root = PathBuf::from(mvm_cache_dir());
+    let mut index = load_index(&cache_root);
+    index.record(PackEntry {
+        pack_hash: manifest.outputs.pack_hash.clone(),
+        key: PackKey {
+            kind: manifest.kind.clone(),
+            arch: manifest.target_arch,
+            backend: ctx.policy().backend.clone(),
+        },
+        channel: prov.channel.clone(),
+        release_version: prov.release_version.clone(),
+        promoted_at_unix: prov.promoted_at_unix,
+    });
+    save_index(&cache_root, &index)?;
+
+    Ok(promoted)
+}
+
+/// Point `key`'s active version at `hash`. Errs if `hash` was never recorded
+/// for `key` — the index only ever activates a version it already knows
+/// about.
+pub fn set_active_version(key: &PackKey, hash: &Sha256Hex) -> Result<(), PackCacheError> {
+    let cache_root = PathBuf::from(mvm_cache_dir());
+    let mut index = load_index(&cache_root);
+    if !index.set_active(key, hash) {
+        return Err(PackCacheError::UnknownPackVersion {
+            key: key.clone(),
+            hash: hash.clone(),
+        });
+    }
+    save_index(&cache_root, &index)?;
+    Ok(())
+}
+
+/// Every recorded pack version, optionally filtered by `kind`, flagged with
+/// whether it is the active version for its key.
+pub fn list_versions(filter: Option<PackKind>) -> Result<Vec<PackListEntry>, PackCacheError> {
+    let cache_root = PathBuf::from(mvm_cache_dir());
+    let index = load_index(&cache_root);
+    let out = index
+        .entries()
+        .iter()
+        .filter(|entry| filter.as_ref().is_none_or(|kind| entry.key.kind == *kind))
+        .map(|entry| PackListEntry {
+            pack_hash: entry.pack_hash.clone(),
+            key: entry.key.clone(),
+            channel: entry.channel.clone(),
+            release_version: entry.release_version.clone(),
+            promoted_at_unix: entry.promoted_at_unix,
+            active: index.active_for(&entry.key) == Some(&entry.pack_hash),
+        })
+        .collect();
+    Ok(out)
+}
+
+/// Reclaim non-active pack versions beyond the newest `keep_recent` per key
+/// (see [`PackIndex::prunable`]), deleting both the content-addressed
+/// directory and the index entry. Never removes a key's active hash. The
+/// candidate hash list is deduplicated before acting — defense in depth
+/// against a hash ever being recorded under more than one key, so a shared
+/// pack directory is removed (and reported) at most once rather than erroring
+/// on a second, already-gone directory. With `dry_run`, reports what would be
+/// removed without deleting anything.
+pub fn prune_versions(keep_recent: usize, dry_run: bool) -> Result<Vec<Sha256Hex>, PackCacheError> {
+    let cache_root = PathBuf::from(mvm_cache_dir());
+    let mut index = load_index(&cache_root);
+    let mut prunable = index.prunable(keep_recent);
+    prunable.sort_by(|a, b| a.as_str().cmp(b.as_str()));
+    prunable.dedup();
+
+    if !dry_run {
+        for hash in &prunable {
+            remove_pack_dir(hash)?;
+            index.remove(hash);
+        }
+        save_index(&cache_root, &index)?;
+    }
+
+    Ok(prunable)
 }
 
 fn new_quarantine_dir() -> Result<PathBuf, PackCacheError> {
@@ -1366,5 +1510,160 @@ mod tests {
             .expect("resolve ok")
             .expect("falls back to the other verified pack");
         assert_eq!(found.verified.pack_hash, promoted_a.verified.pack_hash);
+    }
+
+    fn provenance(
+        channel: &str,
+        release_version: &str,
+        promoted_at_unix: u64,
+    ) -> PackProvenanceInput {
+        PackProvenanceInput {
+            channel: channel.to_string(),
+            release_version: release_version.to_string(),
+            promoted_at_unix,
+        }
+    }
+
+    #[test]
+    fn promote_and_record_makes_pack_resolvable_and_listed_active() {
+        let (_cache, _env) = isolated_cache();
+        let (staged, manifest) = staged_builder_pack();
+        let trust = trust_store();
+        let rev = good_revocation();
+        let policy = policy();
+        let ctx = PackVerifyCtx::ed25519(&policy, &trust, &rev);
+
+        let promoted = promote_and_record(
+            staged.path(),
+            &manifest,
+            &provenance("stable", "v0.17.0", 10),
+            &ctx,
+        )
+        .expect("promote_and_record");
+
+        // The production `mvm_cache_dir()` path is what both `promote_and_record`
+        // and `resolve_pack` use internally — this is the end-to-end guard that a
+        // cache-root/index-path mismatch would break.
+        let found = resolve_pack(PackKind::Builder, GuestArch::host(), PackBackend::Hvf, &ctx)
+            .expect("resolve ok")
+            .expect("compatible pack found");
+        assert_eq!(found.verified.pack_hash, promoted.verified.pack_hash);
+
+        let versions = list_versions(Some(PackKind::Builder)).expect("list ok");
+        let hvf_entry = versions
+            .iter()
+            .find(|v| v.key.backend == PackBackend::Hvf)
+            .expect("hvf-key entry listed");
+        assert_eq!(hvf_entry.pack_hash, promoted.verified.pack_hash);
+        assert_eq!(hvf_entry.release_version, "v0.17.0");
+        assert!(hvf_entry.active, "sole promoted version must be active");
+    }
+
+    #[test]
+    fn set_active_version_errors_on_unknown_hash_and_switches_resolution() {
+        let (_cache, _env) = isolated_cache();
+        let trust = trust_store();
+        let rev = good_revocation();
+        let policy = policy();
+        let ctx = PackVerifyCtx::ed25519(&policy, &trust, &rev);
+
+        let (staged_a, manifest_a) = staged_builder_pack_bytes(b"kernel-a", b"image-a");
+        let (staged_b, manifest_b) = staged_builder_pack_bytes(b"kernel-b", b"image-b");
+        let promoted_a = promote_and_record(
+            staged_a.path(),
+            &manifest_a,
+            &provenance("stable", "v0.17.0", 10),
+            &ctx,
+        )
+        .expect("promote a");
+        let promoted_b = promote_and_record(
+            staged_b.path(),
+            &manifest_b,
+            &provenance("stable", "v0.18.0", 20),
+            &ctx,
+        )
+        .expect("promote b");
+
+        // `a` promoted first, so it is the default active version.
+        let found = resolve_pack(PackKind::Builder, GuestArch::host(), PackBackend::Hvf, &ctx)
+            .expect("resolve ok")
+            .expect("compatible pack found");
+        assert_eq!(found.verified.pack_hash, promoted_a.verified.pack_hash);
+
+        let unknown_hash = Sha256Hex::from_bytes(b"not-a-recorded-pack");
+        let err = set_active_version(&builder_key(), &unknown_hash)
+            .expect_err("unknown hash must be refused");
+        assert!(matches!(err, PackCacheError::UnknownPackVersion { .. }));
+
+        set_active_version(&builder_key(), &promoted_b.verified.pack_hash).expect("set active b");
+
+        let found = resolve_pack(PackKind::Builder, GuestArch::host(), PackBackend::Hvf, &ctx)
+            .expect("resolve ok")
+            .expect("compatible pack found");
+        assert_eq!(found.verified.pack_hash, promoted_b.verified.pack_hash);
+    }
+
+    #[test]
+    fn prune_versions_keeps_active_removes_oldest_and_dry_run_is_noop() {
+        let (_cache, _env) = isolated_cache();
+        let trust = trust_store();
+        let rev = good_revocation();
+        let policy = policy();
+        let ctx = PackVerifyCtx::ed25519(&policy, &trust, &rev);
+
+        let (staged_a, manifest_a) = staged_builder_pack_bytes(b"kernel-a", b"image-a");
+        let (staged_b, manifest_b) = staged_builder_pack_bytes(b"kernel-b", b"image-b");
+        let (staged_c, manifest_c) = staged_builder_pack_bytes(b"kernel-c", b"image-c");
+        let promoted_a = promote_and_record(
+            staged_a.path(),
+            &manifest_a,
+            &provenance("stable", "v0.17.0", 10),
+            &ctx,
+        )
+        .expect("promote a");
+        let promoted_b = promote_and_record(
+            staged_b.path(),
+            &manifest_b,
+            &provenance("stable", "v0.18.0", 20),
+            &ctx,
+        )
+        .expect("promote b");
+        let promoted_c = promote_and_record(
+            staged_c.path(),
+            &manifest_c,
+            &provenance("stable", "v0.19.0", 30),
+            &ctx,
+        )
+        .expect("promote c");
+
+        // `a` (promoted first) is active; keep_recent=1 also keeps `c` (the
+        // newest by promoted_at_unix); `b` is neither, so it is prunable.
+        let dry = prune_versions(1, true).expect("dry-run prune ok");
+        assert_eq!(dry, vec![promoted_b.verified.pack_hash.clone()]);
+        assert!(promoted_a.root.exists());
+        assert!(promoted_b.root.exists(), "dry-run must not delete anything");
+        assert!(promoted_c.root.exists());
+
+        let removed = prune_versions(1, false).expect("prune ok");
+        assert_eq!(removed, vec![promoted_b.verified.pack_hash.clone()]);
+        assert!(promoted_a.root.exists(), "active pack dir must survive");
+        assert!(
+            !promoted_b.root.exists(),
+            "oldest non-active pack dir must be removed"
+        );
+        assert!(promoted_c.root.exists(), "newest pack dir must be kept");
+
+        let versions = list_versions(Some(PackKind::Builder)).expect("list ok");
+        assert!(
+            !versions
+                .iter()
+                .any(|v| v.pack_hash == promoted_b.verified.pack_hash),
+            "pruned entry must be gone from the index"
+        );
+        assert!(
+            versions
+                .iter()
+                .any(|v| v.pack_hash == promoted_a.verified.pack_hash && v.active)
+        );
     }
 }

--- a/crates/mvm-core/src/pack_cache/index.rs
+++ b/crates/mvm-core/src/pack_cache/index.rs
@@ -1,0 +1,221 @@
+//! Versioned index of promoted packs with one active pointer per key.
+//!
+//! Pure in-memory data + logic: no filesystem access, no clock reads. A
+//! caller records each promoted pack with its own recency timestamp, then
+//! decides which version is "active" per `(kind, arch, backend)` slot.
+//! Persisting this index and wiring it into `resolve_pack`'s lookup are
+//! separate concerns handled elsewhere.
+
+use serde::{Deserialize, Serialize};
+
+use crate::arch::GuestArch;
+use crate::packs::{PackBackend, PackKind, Sha256Hex};
+
+/// Identifies one pack slot — a `(kind, arch, backend)` combination that can
+/// have multiple promoted versions and exactly one active pointer.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct PackKey {
+    pub kind: PackKind,
+    pub arch: GuestArch,
+    pub backend: PackBackend,
+}
+
+/// One promoted pack version recorded in the index.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct PackEntry {
+    pub pack_hash: Sha256Hex,
+    pub key: PackKey,
+    /// `trust.channel_identity` from the pack manifest.
+    pub channel: String,
+    /// The release version from the download context, e.g. `"v0.17.0"`.
+    pub release_version: String,
+    /// Unix timestamp used for recency ordering; supplied by the caller —
+    /// this type never reads the clock.
+    pub promoted_at_unix: u64,
+}
+
+/// Versioned index of promoted packs, with one active pointer per
+/// [`PackKey`].
+#[derive(Debug, Clone, Default, PartialEq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct PackIndex {
+    entries: Vec<PackEntry>,
+    active: Vec<(PackKey, Sha256Hex)>,
+}
+
+impl PackIndex {
+    /// Upsert `e` by `pack_hash` — an existing entry with the same hash is
+    /// replaced in place. The first entry ever recorded for `e.key` becomes
+    /// that key's active version.
+    pub fn record(&mut self, e: PackEntry) {
+        if let Some(existing) = self
+            .entries
+            .iter_mut()
+            .find(|entry| entry.pack_hash == e.pack_hash)
+        {
+            *existing = e;
+            return;
+        }
+        let is_first_for_key = !self.entries.iter().any(|entry| entry.key == e.key);
+        let key = e.key.clone();
+        let hash = e.pack_hash.clone();
+        self.entries.push(e);
+        if is_first_for_key {
+            self.active.push((key, hash));
+        }
+    }
+
+    /// Point `key`'s active version at `hash`. Returns `false` and leaves the
+    /// index unchanged if `hash` is not a recorded entry for `key`.
+    pub fn set_active(&mut self, key: &PackKey, hash: &Sha256Hex) -> bool {
+        if !self
+            .entries
+            .iter()
+            .any(|entry| &entry.key == key && &entry.pack_hash == hash)
+        {
+            return false;
+        }
+        if let Some(slot) = self.active.iter_mut().find(|(k, _)| k == key) {
+            slot.1 = hash.clone();
+        } else {
+            self.active.push((key.clone(), hash.clone()));
+        }
+        true
+    }
+
+    /// The active hash for `key`, if any.
+    pub fn active_for(&self, key: &PackKey) -> Option<&Sha256Hex> {
+        self.active
+            .iter()
+            .find(|(k, _)| k == key)
+            .map(|(_, hash)| hash)
+    }
+
+    /// Every recorded version for `key`, newest `promoted_at_unix` first.
+    pub fn versions_for(&self, key: &PackKey) -> Vec<&PackEntry> {
+        let mut versions: Vec<&PackEntry> = self
+            .entries
+            .iter()
+            .filter(|entry| &entry.key == key)
+            .collect();
+        versions.sort_by_key(|entry| std::cmp::Reverse(entry.promoted_at_unix));
+        versions
+    }
+
+    /// Drop the entry with `hash` and any active pointer referencing it.
+    pub fn remove(&mut self, hash: &Sha256Hex) {
+        self.entries.retain(|entry| &entry.pack_hash != hash);
+        self.active.retain(|(_, active_hash)| active_hash != hash);
+    }
+
+    /// Per key: every hash except the active one and the newest
+    /// `keep_recent` by `promoted_at_unix`.
+    pub fn prunable(&self, keep_recent: usize) -> Vec<Sha256Hex> {
+        let mut keys: Vec<&PackKey> = Vec::new();
+        for entry in &self.entries {
+            if !keys.iter().any(|seen| **seen == entry.key) {
+                keys.push(&entry.key);
+            }
+        }
+        let mut out = Vec::new();
+        for key in keys {
+            let versions = self.versions_for(key);
+            let active = self.active_for(key);
+            for (idx, entry) in versions.iter().enumerate() {
+                let is_active = active == Some(&entry.pack_hash);
+                let is_kept_recent = idx < keep_recent;
+                if !is_active && !is_kept_recent {
+                    out.push(entry.pack_hash.clone());
+                }
+            }
+        }
+        out
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::arch::GuestArch;
+    use crate::packs::{PackBackend, PackKind};
+
+    fn key() -> PackKey {
+        PackKey {
+            kind: PackKind::Builder,
+            arch: GuestArch::Aarch64,
+            backend: PackBackend::Libkrun,
+        }
+    }
+    fn entry(hash: &str, ver: &str, at: u64) -> PackEntry {
+        PackEntry {
+            pack_hash: Sha256Hex::new(hash).unwrap(),
+            key: key(),
+            channel: "stable".into(),
+            release_version: ver.into(),
+            promoted_at_unix: at,
+        }
+    }
+
+    #[test]
+    fn first_record_becomes_active() {
+        let mut ix = PackIndex::default();
+        ix.record(entry(&"a".repeat(64), "v0.17.0", 10));
+        assert_eq!(
+            ix.active_for(&key()),
+            Some(&Sha256Hex::new("a".repeat(64)).unwrap())
+        );
+    }
+
+    #[test]
+    fn record_second_does_not_change_active_but_lists_both_newest_first() {
+        let mut ix = PackIndex::default();
+        ix.record(entry(&"a".repeat(64), "v0.17.0", 10));
+        ix.record(entry(&"b".repeat(64), "v0.18.0", 20));
+        assert_eq!(
+            ix.active_for(&key()),
+            Some(&Sha256Hex::new("a".repeat(64)).unwrap())
+        );
+        let v = ix.versions_for(&key());
+        assert_eq!(v[0].release_version, "v0.18.0"); // newest first
+        assert_eq!(v[1].release_version, "v0.17.0");
+    }
+
+    #[test]
+    fn set_active_rejects_unknown_hash() {
+        let mut ix = PackIndex::default();
+        ix.record(entry(&"a".repeat(64), "v0.17.0", 10));
+        assert!(!ix.set_active(&key(), &Sha256Hex::new("c".repeat(64)).unwrap()));
+        assert!(ix.set_active(&key(), &Sha256Hex::new("a".repeat(64)).unwrap()));
+    }
+
+    #[test]
+    fn remove_drops_entry_and_active_ref() {
+        let mut ix = PackIndex::default();
+        ix.record(entry(&"a".repeat(64), "v0.17.0", 10));
+        ix.remove(&Sha256Hex::new("a".repeat(64)).unwrap());
+        assert_eq!(ix.active_for(&key()), None);
+        assert!(ix.versions_for(&key()).is_empty());
+    }
+
+    #[test]
+    fn prunable_keeps_active_and_newest_n() {
+        let mut ix = PackIndex::default();
+        ix.record(entry(&"a".repeat(64), "v0.17.0", 10)); // active
+        ix.record(entry(&"b".repeat(64), "v0.18.0", 20));
+        ix.record(entry(&"c".repeat(64), "v0.19.0", 30));
+        // keep active (a) + newest 1 (c) -> b is prunable
+        let p = ix.prunable(1);
+        assert_eq!(p, vec![Sha256Hex::new("b".repeat(64)).unwrap()]);
+    }
+
+    #[test]
+    fn json_roundtrip_denies_unknown_fields() {
+        let mut ix = PackIndex::default();
+        ix.record(entry(&"a".repeat(64), "v0.17.0", 10));
+        let s = serde_json::to_string(&ix).unwrap();
+        let back: PackIndex = serde_json::from_str(&s).unwrap();
+        assert_eq!(ix, back);
+    }
+}

--- a/crates/mvm-core/src/pack_cache/index.rs
+++ b/crates/mvm-core/src/pack_cache/index.rs
@@ -93,6 +93,13 @@ impl PackIndex {
             .map(|(_, hash)| hash)
     }
 
+    /// Every recorded entry, across every key, in insertion order. Used by
+    /// callers that enumerate the whole index (e.g. an unfiltered version
+    /// listing) rather than one key's versions.
+    pub fn entries(&self) -> &[PackEntry] {
+        &self.entries
+    }
+
     /// Every recorded version for `key`, newest `promoted_at_unix` first.
     pub fn versions_for(&self, key: &PackKey) -> Vec<&PackEntry> {
         let mut versions: Vec<&PackEntry> = self

--- a/crates/mvm-core/src/policy/audit.rs
+++ b/crates/mvm-core/src/policy/audit.rs
@@ -136,6 +136,13 @@ pub enum LocalAuditKind {
     /// from `~/.cache/mvm`. Pure read-only `cache info` is not
     /// audited; the prune verb is, because it deletes host bytes.
     CachePrune,
+    /// `mvmctl pack rollback` / `pack download` / `pack update` changed
+    /// the attested-pack cache: retargeted a key's active version, or
+    /// fetched and (for `update`) activated a new one. Distinct from
+    /// `CachePrune`, which only ever removes bytes; this kind covers
+    /// additions and pointer swaps. Detail carries `op=<verb>` plus the
+    /// pack key and version affected.
+    PackCacheChange,
     /// `mvmctl cleanup` ran a host-side tier sweep
     /// (`--cache` / `--state` / `--nuclear`). The detail field carries
     /// the tier name, byte count freed, and number of top-level paths

--- a/specs/notes/instant-first-use-pack-design.md
+++ b/specs/notes/instant-first-use-pack-design.md
@@ -1,0 +1,87 @@
+# Instant first-use via prepared, versioned packs + seeded builder closure
+
+**Status:** design approved 2026-07-10
+**Relation:** Plan 213 (attested fast-first-boot packs) — realizes WS-C (hardened
+cache), WS-D (install/prepare UX), WS-F (fast builder path / seeded closure),
+WS-J (benchmark). This note is the umbrella design; each sub-project below gets
+its own spec → plan → implementation.
+
+## Goal
+
+Post-install, `mvmctl dev up` and `machine run` feel **instantaneous** — on par
+with the sub-second dev-sandbox tools this project is measured against. The
+installation phase pays the cost; the hot path pays nothing.
+
+## Invariants
+
+- **Builder-only closure.** The seeded Nix closure lives *only* in the builder
+  VM's persistent Nix store. It is never included in, copied to, or reachable
+  from a workload microVM rootfs — already enforced by
+  `xtask check-guest-images-no-builder-tools`. Workload VMs boot a minimal
+  materialized rootfs (the build *output*), never a build environment.
+- **No hot-path cost after prepare.** After the prepare phase, first `dev up` /
+  first common flake build performs zero network fetch, zero Nix substitution,
+  and no builder cold-boot.
+- **Never bypass verification.** Every cached pack version is signature- and
+  hash-verified before it can become the active version. Rollback only ever
+  activates an already-verified cached version.
+
+## The four pieces
+
+1. **Versioned pack cache + lifecycle facade + CLI.** The content-addressed pack
+   cache keeps *multiple* versions side by side with an **active pointer**. A
+   facade API over `mvm_core::pack_cache` exposes `download` / `update` /
+   `rollback` / `list` / `prune`, surfaced through the `mvmctl::*` re-exports so
+   the CLI, the SDK, and mvmd all drive the same operations. Covers every pack
+   class (builder pack incl. the seeded closure, runtime pack, dev image). A new
+   release is fetched + verified *alongside* the current version; promotion moves
+   the pointer; rollback moves it back; nothing is destructively overwritten.
+
+2. **Prepare phase + `install.sh`.** `mvmctl prepare` (and the `install.sh`
+   hook, extending today's `mvmctl bootstrap` builder-image prefetch) does the
+   slow work once: fetch + verify packs, import the seeded closure into the
+   builder Nix store, warm the builder, and capture the warm snapshot. Opt-out
+   knobs mirror the existing `MVM_SKIP_BUILDER_PREFETCH`.
+
+3. **Seed-closure mechanism.** Content-agnostic: a NAR closure produced into the
+   builder pack (`--closure` on `mvm-builder-pack-tool` + a release-pipeline step
+   that exports it), carried by the pack's existing per-file hash + signature
+   machinery (wiring the already-present but unused `PackOutputs.closure_hash`),
+   and imported guest-side (`nix-store --import`) with a **content-keyed
+   idempotency marker** so a changed closure re-imports rather than being skipped.
+   Import is fail-open (an accelerator, never a hard dependency). The closure
+   *contents* are policy/config — a generous common-toolchain +
+   common-materialization set — never hardcoded in Rust.
+
+4. **Benchmark harness.** A clean-box measurement proving post-prepare first
+   `dev up` / common flake build hits the instant bar: zero network + zero Nix
+   substitution on the hot path, boot within the warm-restore budget. The
+   numeric target is tunable; the pass/fail gate is "no hot-path stall."
+
+## Composition & build order
+
+Piece 3 delivers value only on top of 1 + 2; piece 4 measures the whole. Build
+order: **1 → 2 → 3, with 4 alongside.**
+
+## Decomposition into sub-projects
+
+- **SP1 — Versioned pack cache + lifecycle facade + CLI** *(this effort first)*.
+  The foundation, and independently ships the `download` / `update` / `rollback`
+  / `list` / `prune` surface. No seed closure yet — just multi-version cache +
+  active pointer + verified promotion/rollback across pack classes, wired through
+  the facade.
+- **SP2 — Prepare phase + install.sh.** `mvmctl prepare`, install.sh hook, warm
+  + snapshot capture. (Also cleans install.sh's dead `mvm-vz-supervisor` ref.)
+- **SP3 — Seed-closure mechanism.** Producer `--closure` + release export + guest
+  import + idempotency; closure-content policy decided with a size/measurement
+  pass.
+- **SP4 — Benchmark harness.** Instant-bar measurement, gating SP2/SP3.
+
+## Open / deferred (decided per sub-project, not here)
+
+- The exact seeded-closure **content set** and its **size budget** — decided in
+  SP3 against SP4's measurement, not up front (avoids reintroducing the ~1 GB
+  cost the builder rootfs deliberately excludes).
+- The numeric **instant bar** — set in SP4.
+- Warm-snapshot capture mechanics (SP2) build on the adjacent warm-start /
+  hvf-snapshot work, not re-designed here.

--- a/specs/plans/243-versioned-pack-cache-lifecycle.md
+++ b/specs/plans/243-versioned-pack-cache-lifecycle.md
@@ -1,0 +1,327 @@
+# Versioned Pack Cache + Lifecycle Facade + CLI (SP1) Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax.
+
+**Goal:** Give the content-addressed pack cache a deterministic *active version* per pack class, plus `download`/`update`/`rollback`/`list`/`prune` operations exposed through the `mvmctl::core::pack_cache` facade and an `mvmctl pack` CLI group — so a new release is fetched+verified alongside the current one, promotion/rollback just move a pointer, and nothing is destructively overwritten.
+
+**Architecture:** The cache already stores one dir per pack keyed by `pack_hash` and multiple versions coexist fine; the gap is that `resolve_pack` returns whichever `read_dir` hits first. SP1 adds a cache-side JSON **index** (`<cache>/packs/index.json`) recording each promoted pack's provenance (pack_hash, kind, arch, backend, channel, release version, promoted-at) plus an **active pointer** per `(kind, arch, backend)`. `resolve_pack` prefers the active pointer, falling back to today's scan. Version labels come from the *download context* (the release version in the asset URL), never a manifest change. This is Plan 213 SP1; design: `specs/notes/instant-first-use-pack-design.md`.
+
+**Tech Stack:** Rust (edition 2024), `mvm-core` (`pack_cache`, `packs`), `mvm-cli` (clap commands).
+
+## Global Constraints
+
+- Edition **2024**. No `#[allow(clippy::too_many_arguments)]` in hand-written code — use a params struct/builder.
+- No spec/plan/PR/ADR references in code comments (CI-gated: `Plan N`, `ADR-\d+`, `#NNNN`, `W\d.`).
+- No `Co-Authored-By: Claude` trailer.
+- **Never bypass verification**: an active pointer only ever resolves to a pack that re-verifies through the existing `PackVerifyCtx`; rollback only activates an already-cached, verified pack.
+- **No manifest schema change** — version/provenance lives in the cache-side index, not `PackManifest`.
+- `mvm-core` must stay runtime-free (no new `tokio`); the index is sync `std::fs` + `serde_json` (already a dep).
+- Verification gate before "done": `cargo fmt --all -- --check`, `cargo clippy --workspace --all-targets -- -D warnings`, `cargo nextest run -p mvm-core -p mvm-cli`, `cargo test --workspace --doc`.
+- Work in worktree `/Users/auser/work/tinylabs/mvmco/.worktrees/mvm-pack-lifecycle` (branch `feat/plan-213-pack-lifecycle`).
+
+## Scope
+
+IN: the versioned-index + active-pointer primitive; `resolve_pack` preferring the active pointer; lifecycle facade (`record`/`set_active`/`list`/`version-aware prune`); the `mvmctl pack` CLI group; `download`/`update` wired for the **builder pack** (which already has release-fetch via `bootstrap.rs`), `list`/`rollback`/`prune` generic across all cached classes.
+
+OUT (later sub-projects / follow-on): `download`/`update` for runtime + dev-image classes (their release-fetch isn't wired yet — `list`/`rollback` still cover them once present); the prepare phase + install.sh (SP2); the seed closure (SP3); the benchmark (SP4).
+
+## File Structure
+
+- `crates/mvm-core/src/pack_cache.rs` — **modify**: add the index types + read/write, extend `promote` to record provenance, add `set_active`/`get_active`/`list_versions`/`prune_versions`, make `resolve_pack` prefer the active pointer.
+- `crates/mvm-core/src/pack_cache/index.rs` — **new** (child module): the `PackIndex` struct + pure load/mutate/save logic, unit-tested in isolation.
+- `crates/mvm-cli/src/commands/pack/mod.rs` — **new**: `Args` + `PackAction` (Download/Update/Rollback/List/Prune) + `run()`.
+- `crates/mvm-cli/src/commands/pack/{download,update,rollback,list,prune}.rs` — **new**: thin verb impls over the facade (mirrors `commands/image/`).
+- `crates/mvm-cli/src/commands/mod.rs` — **modify**: add `Pack(pack::Args)` to `Commands`.
+- `crates/mvm-cli/src/commands/dispatch.rs` — **modify**: add the `Commands::Pack(a) => pack::run(...)` arm.
+- `crates/mvm-cli/src/commands/env/dev_vz/bootstrap.rs` — **modify**: `promote_staged_builder_pack` records the downloaded release version into the index.
+- `crates/mvm-cli/src/commands/ops/cache.rs` — **modify**: add version-aware `prune_versions` to the `Prune` arm.
+
+---
+
+## Task 1: PackIndex primitive (types + pure load/mutate/save)
+
+**Files:**
+- Create: `crates/mvm-core/src/pack_cache/index.rs`
+- Modify: `crates/mvm-core/src/pack_cache.rs` (add `mod index; pub use index::*;`)
+- Test: inline `#[cfg(test)]` in `index.rs`
+
+**Interfaces:**
+- Produces:
+  ```rust
+  pub struct PackKey { pub kind: PackKind, pub arch: GuestArch, pub backend: PackBackend }
+  pub struct PackEntry {
+      pub pack_hash: Sha256Hex,
+      pub key: PackKey,
+      pub channel: String,          // trust.channel_identity
+      pub release_version: String,  // from the download context (e.g. "v0.17.0")
+      pub promoted_at_unix: u64,     // recency ordering
+  }
+  pub struct PackIndex { entries: Vec<PackEntry>, active: Vec<(PackKey, Sha256Hex)> }
+  impl PackIndex {
+      pub fn record(&mut self, e: PackEntry);                 // upsert by pack_hash; first record for a key sets active
+      pub fn set_active(&mut self, key: &PackKey, hash: &Sha256Hex) -> bool; // false if hash not present for key
+      pub fn active_for(&self, key: &PackKey) -> Option<&Sha256Hex>;
+      pub fn versions_for(&self, key: &PackKey) -> Vec<&PackEntry>;   // newest promoted_at first
+      pub fn remove(&mut self, hash: &Sha256Hex);            // drops entry + any active ref
+      pub fn prunable(&self, keep_recent: usize) -> Vec<Sha256Hex>;   // per key: all but active + newest `keep_recent`
+  }
+  ```
+  `PackKey`/`PackEntry`/`PackIndex` derive `Serialize, Deserialize, Clone, PartialEq, Debug` with `#[serde(deny_unknown_fields)]` on the wire types.
+
+- [ ] **Step 1: Write the failing tests** — in `crates/mvm-core/src/pack_cache/index.rs`, define the types (above) and:
+
+```rust
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::ids::GuestArch;
+    use crate::packs::{PackBackend, PackKind};
+
+    fn key() -> PackKey {
+        PackKey { kind: PackKind::Builder, arch: GuestArch::Aarch64, backend: PackBackend::Any }
+    }
+    fn entry(hash: &str, ver: &str, at: u64) -> PackEntry {
+        PackEntry { pack_hash: Sha256Hex::from_hex(hash).unwrap(), key: key(),
+            channel: "stable".into(), release_version: ver.into(), promoted_at_unix: at }
+    }
+
+    #[test]
+    fn first_record_becomes_active() {
+        let mut ix = PackIndex::default();
+        ix.record(entry(&"a".repeat(64), "v0.17.0", 10));
+        assert_eq!(ix.active_for(&key()), Some(&Sha256Hex::from_hex(&"a".repeat(64)).unwrap()));
+    }
+
+    #[test]
+    fn record_second_does_not_change_active_but_lists_both_newest_first() {
+        let mut ix = PackIndex::default();
+        ix.record(entry(&"a".repeat(64), "v0.17.0", 10));
+        ix.record(entry(&"b".repeat(64), "v0.18.0", 20));
+        assert_eq!(ix.active_for(&key()), Some(&Sha256Hex::from_hex(&"a".repeat(64)).unwrap()));
+        let v = ix.versions_for(&key());
+        assert_eq!(v[0].release_version, "v0.18.0"); // newest first
+        assert_eq!(v[1].release_version, "v0.17.0");
+    }
+
+    #[test]
+    fn set_active_rejects_unknown_hash() {
+        let mut ix = PackIndex::default();
+        ix.record(entry(&"a".repeat(64), "v0.17.0", 10));
+        assert!(!ix.set_active(&key(), &Sha256Hex::from_hex(&"c".repeat(64)).unwrap()));
+        assert!(ix.set_active(&key(), &Sha256Hex::from_hex(&"a".repeat(64)).unwrap()));
+    }
+
+    #[test]
+    fn remove_drops_entry_and_active_ref() {
+        let mut ix = PackIndex::default();
+        ix.record(entry(&"a".repeat(64), "v0.17.0", 10));
+        ix.remove(&Sha256Hex::from_hex(&"a".repeat(64)).unwrap());
+        assert_eq!(ix.active_for(&key()), None);
+        assert!(ix.versions_for(&key()).is_empty());
+    }
+
+    #[test]
+    fn prunable_keeps_active_and_newest_n() {
+        let mut ix = PackIndex::default();
+        ix.record(entry(&"a".repeat(64), "v0.17.0", 10)); // active
+        ix.record(entry(&"b".repeat(64), "v0.18.0", 20));
+        ix.record(entry(&"c".repeat(64), "v0.19.0", 30));
+        // keep active (a) + newest 1 (c) -> b is prunable
+        let p = ix.prunable(1);
+        assert_eq!(p, vec![Sha256Hex::from_hex(&"b".repeat(64)).unwrap()]);
+    }
+
+    #[test]
+    fn json_roundtrip_denies_unknown_fields() {
+        let mut ix = PackIndex::default();
+        ix.record(entry(&"a".repeat(64), "v0.17.0", 10));
+        let s = serde_json::to_string(&ix).unwrap();
+        let back: PackIndex = serde_json::from_str(&s).unwrap();
+        assert_eq!(ix, back);
+    }
+}
+```
+
+- [ ] **Step 2: Run to verify they fail**
+
+Run: `cargo test -p mvm-core --lib pack_cache::index 2>&1 | tail -15`
+Expected: compile errors — types/methods not defined.
+
+- [ ] **Step 3: Implement the types + methods** in `index.rs`. `record` upserts by `pack_hash` and, if the key has no active entry yet, sets it active. `versions_for` sorts by `promoted_at_unix` desc. `prunable` returns, per key, every hash except the active one and the newest `keep_recent` by `promoted_at_unix`. Use `Sha256Hex` and the `PackKind`/`PackBackend`/`GuestArch` enums from `crate::packs`/`crate::ids` (confirm exact paths first with `rg`). Add `mod index; pub use index::{PackIndex, PackEntry, PackKey};` to `pack_cache.rs`.
+
+- [ ] **Step 4: Run to verify pass**
+
+Run: `cargo test -p mvm-core --lib pack_cache::index 2>&1 | tail -15`
+Expected: all 6 PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+cd /Users/auser/work/tinylabs/mvmco/.worktrees/mvm-pack-lifecycle
+git add crates/mvm-core/src/pack_cache/index.rs crates/mvm-core/src/pack_cache.rs
+git commit -m "feat(pack-cache): add versioned index + active-pointer primitive"
+```
+
+---
+
+## Task 2: Persist the index + make resolve_pack prefer the active pointer
+
+**Files:**
+- Modify: `crates/mvm-core/src/pack_cache.rs`
+- Test: inline `#[cfg(test)]` in `pack_cache.rs`
+
+**Interfaces:**
+- Consumes: Task 1's `PackIndex`.
+- Produces:
+  ```rust
+  fn index_path(cache_root: &Path) -> PathBuf;                 // <cache>/packs/index.json
+  fn load_index(cache_root: &Path) -> PackIndex;               // missing/corrupt -> default (fail-open)
+  fn save_index(cache_root: &Path, ix: &PackIndex) -> Result<(), PackCacheError>; // temp+rename atomic
+  ```
+  `resolve_pack` gains active-pointer preference; signature unchanged.
+
+- [ ] **Step 1: Write failing tests** (append to `pack_cache.rs` tests): promote two builder packs, `save_index` with `b` active, assert `resolve_pack` returns `b` (not scan-order `a`); then a test that with no index present `resolve_pack` still returns a compatible pack (fallback); then a test that if the active pack dir is corrupt, `resolve_pack` falls back to another verified entry.
+
+```rust
+    #[test]
+    fn resolve_prefers_active_pointer_over_scan_order() {
+        let tmp = tempfile::tempdir().unwrap();
+        // promote two compatible builder packs (reuse the existing test helper
+        // that builds+promotes a pack; see resolve_pack_returns_compatible_promoted_pack)
+        let (a, b) = promote_two_builder_packs(tmp.path());
+        let mut ix = load_index(tmp.path());
+        ix.record(entry_for(&a)); ix.record(entry_for(&b));
+        assert!(ix.set_active(&key_for(&b), &b.pack_hash()));
+        save_index(tmp.path(), &ix).unwrap();
+        let got = resolve_pack(PackKind::Builder, arch, backend, &ctx(tmp.path())).unwrap().unwrap();
+        assert_eq!(got.pack_hash(), b.pack_hash());
+    }
+
+    #[test]
+    fn resolve_falls_back_to_scan_when_no_index() { /* no save_index; assert Some(compatible) */ }
+
+    #[test]
+    fn resolve_falls_back_when_active_pack_is_corrupt() { /* corrupt b's sidecar, active=b; assert returns a */ }
+```
+(Use/extend the existing promote-a-pack test scaffolding already in `pack_cache.rs` — do not invent a second harness.)
+
+- [ ] **Step 2: Run to verify fail** — `cargo test -p mvm-core --lib pack_cache 2>&1 | tail -20` → the new tests fail (active preference not implemented).
+
+- [ ] **Step 3: Implement.** Add `index_path`/`load_index` (missing or `serde_json` error → `PackIndex::default()`, log nothing/fail-open)/`save_index` (write to `index.json.tmp`, `rename`). In `resolve_pack`, before the scan: `let ix = load_index(&cache_root); if let Some(h) = ix.active_for(&PackKey{kind,arch,backend}) { if let Some(dir) = verified_pack_dir_for_hash(h, ...) { return Ok(Some(dir)); } }` then fall through to the existing scan. Factor the "verify one pack dir by hash" step out of the existing scan loop so both paths share it (DRY).
+
+- [ ] **Step 4: Run to verify pass** — all `pack_cache` tests PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add crates/mvm-core/src/pack_cache.rs
+git commit -m "feat(pack-cache): persist index; resolve_pack prefers the active version"
+```
+
+---
+
+## Task 3: Lifecycle facade (record on promote, set_active, list, version-aware prune)
+
+**Files:**
+- Modify: `crates/mvm-core/src/pack_cache.rs`
+- Test: inline `#[cfg(test)]`
+
+**Interfaces:**
+- Produces (public facade, reachable as `mvmctl::core::pack_cache::*`):
+  ```rust
+  pub struct PackProvenanceInput { pub channel: String, pub release_version: String, pub promoted_at_unix: u64 }
+  /// Promote (verify+place) AND record into the index. Wraps `promote`.
+  pub fn promote_and_record(staged_root: &Path, manifest: &PackManifest, prov: &PackProvenanceInput, ctx: &PackVerifyCtx) -> Result<VerifiedPackDir, PackCacheError>;
+  pub fn set_active_version(cache_root: &Path, key: &PackKey, hash: &Sha256Hex) -> Result<(), PackCacheError>; // err if hash not in index for key
+  pub fn list_versions(cache_root: &Path, filter: Option<PackKind>) -> Result<Vec<PackEntry>, PackCacheError>; // active-flagged via a returned wrapper or side map
+  pub fn prune_versions(cache_root: &Path, keep_recent: usize, dry_run: bool) -> Result<Vec<Sha256Hex>, PackCacheError>; // never removes an active hash; deletes pack dir + index entry
+  ```
+- [ ] **Step 1: Write failing tests** — `promote_and_record` makes the pack resolvable AND appears in `list_versions`; `set_active_version` errors on an unknown hash and switches resolution when valid; `prune_versions(keep_recent=1)` removes the oldest non-active pack dir + its index entry but never the active one, and `dry_run=true` removes nothing.
+
+- [ ] **Step 2: Run to verify fail** — methods undefined.
+
+- [ ] **Step 3: Implement** by composing Task 1/2 primitives with the existing `promote`/`pack_dir`/`remove_pack_dir` helpers. `prune_versions` computes `load_index(...).prunable(keep_recent)`, and for each hash (unless `dry_run`) removes the pack dir and the index entry, then `save_index`. Reuse the existing dir-removal helper the current `prune_expired_packs` uses — do not duplicate it.
+
+- [ ] **Step 4: Run to verify pass.**
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add crates/mvm-core/src/pack_cache.rs
+git commit -m "feat(pack-cache): lifecycle facade — record/set_active/list/prune_versions"
+```
+
+---
+
+## Task 4: `mvmctl pack` CLI group (list/rollback/prune + builder download/update)
+
+**Files:**
+- Create: `crates/mvm-cli/src/commands/pack/mod.rs` + `{list,rollback,prune,download,update}.rs`
+- Modify: `crates/mvm-cli/src/commands/mod.rs` (add `Pack(pack::Args)` to `Commands`, with a `display_order`), `crates/mvm-cli/src/commands/dispatch.rs` (add the arm)
+- Test: `crates/mvm-cli/tests/cli.rs` (help/arg-parse smoke, following existing patterns)
+
+**Interfaces:**
+- Consumes: Task 3 facade.
+- Produces the clap group (mirror `commands/image/mod.rs`):
+  ```rust
+  #[derive(clap::Args)] pub struct Args { #[command(subcommand)] pub action: PackAction }
+  #[derive(clap::Subcommand)] pub enum PackAction {
+      List  { #[arg(long)] kind: Option<PackKindArg>, #[arg(long)] json: bool },
+      Rollback { kind: PackKindArg, #[arg(long)] to: Option<String> }, // to = release_version or pack_hash prefix
+      Prune { #[arg(long, default_value_t = 2)] keep_recent: usize, #[arg(long)] dry_run: bool, #[arg(long)] json: bool },
+      Download { kind: PackKindArg, #[arg(long)] version: Option<String> },
+      Update { kind: PackKindArg },
+  }
+  pub fn run(cli: &Cli, args: Args, cfg: &UserConfig) -> Result<()>;
+  ```
+  `PackKindArg` is a clap `ValueEnum` (`builder`/`runtime`/`dev-image`) mapping to `PackKind`.
+
+- [ ] **Step 1: Write the failing CLI test** in `tests/cli.rs`: assert `mvmctl pack --help` lists `list`/`rollback`/`prune`/`download`/`update`, and `mvmctl pack list --json` parses (following the existing `image --help` test pattern in that file).
+
+- [ ] **Step 2: Run to verify fail** — `cargo test -p mvm-cli --test cli pack 2>&1 | tail` → command unknown.
+
+- [ ] **Step 3: Implement** the module (mirror `commands/image/`): `mod.rs` declares `Args`/`PackAction`/`run` dispatching to the five submodules. `list` calls `pack_cache::list_versions` + renders a table/JSON (model on `ops/cache.rs::cache status`, which already formats `PackCacheEntry`), marking the active version. `rollback` resolves `--to` (a `release_version` or `pack_hash` prefix) against `list_versions`, then `set_active_version`. `prune` calls `prune_versions`. `download`/`update`: for `kind=builder`, reuse the existing `bootstrap.rs` release fetch (`fetch_release_builder_pack_staging` + `promote_and_record`); for `runtime`/`dev-image`, return a clear "not yet fetchable — <class> release-fetch is not wired" error (do NOT stub silently). Add `Pack(pack::Args)` to `Commands` (with `display_order`) and the `dispatch.rs` arm.
+
+- [ ] **Step 4: Run to verify pass** — `cargo test -p mvm-cli --test cli pack` PASS; `cargo run -- pack --help` shows the group.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add crates/mvm-cli/src/commands/pack crates/mvm-cli/src/commands/mod.rs crates/mvm-cli/src/commands/dispatch.rs crates/mvm-cli/tests/cli.rs
+git commit -m "feat(cli): mvmctl pack — list/rollback/prune/download/update"
+```
+
+---
+
+## Task 5: Record versions on the builder-pack download path + version-aware cache prune
+
+**Files:**
+- Modify: `crates/mvm-cli/src/commands/env/dev_vz/bootstrap.rs` (`promote_staged_builder_pack`)
+- Modify: `crates/mvm-cli/src/commands/ops/cache.rs` (the `Prune` arm)
+- Test: inline where feasible + a `pack_cache` integration test
+
+**Interfaces:**
+- Consumes: Task 3 facade.
+
+- [ ] **Step 1: Write the failing test** — a `pack_cache` test asserting that after `promote_and_record` for a builder pack labelled `v0.17.0`, `list_versions(Some(Builder))` reports that version and it is active; and a `cache.rs`-level assertion (unit, on the pure retention decision) that `prune_versions(keep_recent=2)` is invoked by the prune path (extract the retention call so it's unit-testable, per the repo's "small testable units" rule).
+
+- [ ] **Step 2: Run to verify fail.**
+
+- [ ] **Step 3: Implement.** In `promote_staged_builder_pack`, replace the bare `pack_cache::promote(...)` with `promote_and_record(..., &PackProvenanceInput { channel: manifest.trust.channel_identity.clone(), release_version: <the version used to build the fetch URL>, promoted_at_unix: <now, passed in — do not call Date::now() in mvm-core; compute at the mvm-cli call site> }, ...)`. In `ops/cache.rs::Prune`, after the existing `prune_expired_packs` call, add `pack_cache::prune_versions(&cache_root, keep_recent, dry_run)?`, honoring the arm's `dry_run`/`--deep` conventions and emitting the same `audit_emit!(CachePrune, ...)` shape.
+
+- [ ] **Step 4: Run to verify pass** — `cargo nextest run -p mvm-core -p mvm-cli -E 'test(pack)'`.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add crates/mvm-cli/src/commands/env/dev_vz/bootstrap.rs crates/mvm-cli/src/commands/ops/cache.rs
+git commit -m "feat: record builder-pack version on download; version-aware cache prune"
+```
+
+---
+
+## Self-Review
+
+- **Spec coverage:** versioned index + active pointer → T1/T2; resolve prefers active → T2; lifecycle facade (record/set_active/list/prune) → T3; CLI group → T4; builder download/update wired + version-aware prune + provenance recording → T4/T5; runtime/dev-image download explicitly errors (not stubbed) → T4; verification never bypassed (active resolves only through `PackVerifyCtx`, fallback on corrupt) → T2; no manifest change (index-side versions) → T1/T5.
+- **Type consistency:** `PackKey`/`PackEntry`/`PackIndex` names identical across T1–T5; `promote_and_record`/`set_active_version`/`list_versions`/`prune_versions` signatures fixed in T3 and consumed unchanged in T4/T5; `promoted_at_unix` computed at the mvm-cli call site (mvm-core stays clock-free).
+- **No placeholders:** runtime/dev-image download returns an explicit error, not a silent stub.

--- a/specs/plans/243-versioned-pack-cache-lifecycle.md
+++ b/specs/plans/243-versioned-pack-cache-lifecycle.md
@@ -227,16 +227,19 @@ git commit -m "feat(pack-cache): persist index; resolve_pack prefers the active 
 - Test: inline `#[cfg(test)]`
 
 **Interfaces:**
-- Produces (public facade, reachable as `mvmctl::core::pack_cache::*`):
+- Produces (public facade, reachable as `mvmctl::core::pack_cache::*`). **These derive the cache root via `mvm_cache_dir()` internally — the same as `resolve_pack`/`promote` — and take NO `cache_root` param**, so a production caller cannot pass `pack_cache_dir()` (which already appends `packs/`) by mistake. Tests isolate via the existing `isolated_cache()` helper (sets `MVM_CACHE_DIR`). The `load_index`/`save_index(cache_root)` internals keep their param; only the *public facade* drops it.
   ```rust
   pub struct PackProvenanceInput { pub channel: String, pub release_version: String, pub promoted_at_unix: u64 }
   /// Promote (verify+place) AND record into the index. Wraps `promote`.
   pub fn promote_and_record(staged_root: &Path, manifest: &PackManifest, prov: &PackProvenanceInput, ctx: &PackVerifyCtx) -> Result<VerifiedPackDir, PackCacheError>;
-  pub fn set_active_version(cache_root: &Path, key: &PackKey, hash: &Sha256Hex) -> Result<(), PackCacheError>; // err if hash not in index for key
-  pub fn list_versions(cache_root: &Path, filter: Option<PackKind>) -> Result<Vec<PackEntry>, PackCacheError>; // active-flagged via a returned wrapper or side map
-  pub fn prune_versions(cache_root: &Path, keep_recent: usize, dry_run: bool) -> Result<Vec<Sha256Hex>, PackCacheError>; // never removes an active hash; deletes pack dir + index entry
+  pub fn set_active_version(key: &PackKey, hash: &Sha256Hex) -> Result<(), PackCacheError>; // err if hash not in index for key
+  pub fn list_versions(filter: Option<PackKind>) -> Result<Vec<PackListEntry>, PackCacheError>; // PackListEntry = PackEntry + `active: bool`
+  pub fn prune_versions(keep_recent: usize, dry_run: bool) -> Result<Vec<Sha256Hex>, PackCacheError>; // never removes an active hash; deletes pack dir + index entry
   ```
-- [ ] **Step 1: Write failing tests** — `promote_and_record` makes the pack resolvable AND appears in `list_versions`; `set_active_version` errors on an unknown hash and switches resolution when valid; `prune_versions(keep_recent=1)` removes the oldest non-active pack dir + its index entry but never the active one, and `dry_run=true` removes nothing.
+- [ ] **Step 1: Write failing tests** (use `isolated_cache()` for the cache root — the same helper Task 2's tests use):
+  - **End-to-end guard (critical):** `promote_and_record` a builder pack, then `resolve_pack(Builder, …)` returns it as active — this exercises the *production* `mvm_cache_dir()` path end to end and catches any index-path/cache-root mismatch. It also appears in `list_versions` flagged `active: true`.
+  - `set_active_version` errors on an unknown hash; switches which pack `resolve_pack` returns when valid.
+  - `prune_versions(keep_recent=1)` removes the oldest non-active pack dir + its index entry but never the active one; `dry_run=true` removes nothing (dirs + index intact).
 
 - [ ] **Step 2: Run to verify fail** — methods undefined.
 

--- a/tests/audit_total_coverage.rs
+++ b/tests/audit_total_coverage.rs
@@ -174,6 +174,18 @@ const IMAGE_SUB: &[(&str, AuditPosture)] = &[
     ("rm", AuditPosture::Emits("CachePrune")),
 ];
 
+// `mvmctl pack` — the versioned attested-pack cache lifecycle
+// (list/rollback/prune/download/update). `rollback`/`download`/`update`
+// mutate the cache (pointer swap or new version fetched) and share
+// `PackCacheChange`; `prune` removes bytes so it reuses `CachePrune`.
+const PACK_SUB: &[(&str, AuditPosture)] = &[
+    ("list", AuditPosture::ReadOnly),
+    ("rollback", AuditPosture::Emits("PackCacheChange")),
+    ("prune", AuditPosture::Emits("CachePrune")),
+    ("download", AuditPosture::Emits("PackCacheChange")),
+    ("update", AuditPosture::Emits("PackCacheChange")),
+];
+
 // Plan 200 — beginner machine UX. `machine run` translates into the same
 // transient-runner path as top-level `run`, so it shares `run`'s
 // `InteractiveOrControl` posture (it streams guest output; the admitted
@@ -413,6 +425,7 @@ const AUDIT_POSTURE: &[(&str, AuditPosture)] = &[
     ("__ssh-agent-proxy", AuditPosture::InteractiveOrControl),
     ("catalog", AuditPosture::ReadOnly),
     ("image", AuditPosture::DelegatesToSub(IMAGE_SUB)),
+    ("pack", AuditPosture::DelegatesToSub(PACK_SUB)),
     // Plan 200 — beginner microVM workflows.
     ("machine", AuditPosture::DelegatesToSub(MACHINE_SUB)),
     // Operational surfaces.
@@ -598,6 +611,7 @@ fn audit_posture_emits_entries_reference_known_audit_kinds() {
         "CheckpointRestored",
         "NetworkCreate",
         "NetworkRemove",
+        "PackCacheChange",
         "PoolWarm",
         "RegistryReconcile",
         "SecretGet",


### PR DESCRIPTION
Plan 213 **SP1** toward instant first-use: give the content-addressed pack cache a deterministic **active version** per pack class, plus lifecycle operations exposed through the `mvmctl::core::pack_cache` facade and an `mvmctl pack` CLI. Design: `specs/notes/instant-first-use-pack-design.md`; plan: `specs/plans/243-versioned-pack-cache-lifecycle.md`.

## Why
Today the cache stores one dir per `pack_hash` (multiple versions already coexist), but `resolve_pack` returns whichever `read_dir` hits first — non-deterministic, and there's no way to update/rollback. This adds a versioned index + active pointer so a new release is fetched+verified *alongside* the current one, promotion/rollback just move a pointer, and nothing is destructively overwritten.

## What
- **Versioned index + active pointer** (`mvm-core/src/pack_cache/index.rs`, `pack_cache.rs`): `<cache>/packs/index.json` records each promoted pack's provenance (`pack_hash`, kind/arch/backend, channel, release version, promoted-at) + an active pointer per `(kind, arch, backend)`. Version labels come from the **download context**, not a (breaking) manifest change.
- **`resolve_pack` prefers the active pointer**, re-verifying it through the existing `PackVerifyCtx`, falling back to the scan if there's no index or the active pack is missing/corrupt. Verification is never bypassed.
- **Lifecycle facade** (reachable by CLI + SDK + mvmd): `promote_and_record`, `set_active_version`, `list_versions`, version-aware `prune_versions` (never removes the active version). The facade derives `mvm_cache_dir()` internally so callers can't pass the wrong root.
- **`mvmctl pack`** — `list` / `rollback` / `prune` / `download` / `update`. `download`/`update` are wired for the **builder pack** (reusing the existing release-fetch + real `PackVerifyCtx`); `runtime`/`dev-image` return an explicit "not yet wired" error (no silent stub).
- **Dev-up path** now records the builder pack's version on download; `mvmctl cache prune` gained version-aware retention (keep active + newest N).

## Scope
OUT (later sub-projects): runtime/dev-image download wiring; the `mvmctl prepare` phase + install.sh (SP2); the seed Nix closure (SP3); the benchmark harness (SP4).

## Testing
Full workspace gate green: `fmt --all`, `clippy --workspace --all-targets -D warnings`, `build --all-targets`, `nextest --workspace`, doctests. New coverage: index primitive (6), persist + active-pointer resolve incl. corrupt-fallback (3), facade incl. an end-to-end guard (`promote_and_record` → `resolve_pack` returns active), CLI smoke tests, dev-up version-recording, prune-report helper.