### PR TITLE
feat(oci): assemble the verity initramfs in-process (Slice 2a)

### DIFF
--- a/crates/mvm-build/src/guest_agent_build.rs
+++ b/crates/mvm-build/src/guest_agent_build.rs
@@ -46,6 +46,7 @@ pub struct GuestAgentLayout {
     pub netinit: PathBuf,
     pub egress_client: PathBuf,
     pub entrypoint_runner: PathBuf,
+    pub verity_init: PathBuf,
 }
 
 /// Built guest runtime binary paths ready to install into the cache.
@@ -56,6 +57,7 @@ pub struct GuestRuntimeBinaryPaths<'a> {
     pub netinit: &'a Path,
     pub egress_client: &'a Path,
     pub entrypoint_runner: &'a Path,
+    pub verity_init: &'a Path,
 }
 
 /// Embedded guest runtime binary bytes ready to install into the cache.
@@ -66,6 +68,7 @@ pub struct GuestRuntimeBinaryBytes<'a> {
     pub netinit: &'a [u8],
     pub egress_client: &'a [u8],
     pub entrypoint_runner: &'a [u8],
+    pub verity_init: &'a [u8],
 }
 
 /// Cache segment keying the agent build variant. The `run --image` path needs
@@ -89,6 +92,7 @@ impl GuestAgentLayout {
             netinit: dir.join("mvm-guest-netinit"),
             egress_client: dir.join("mvm-egress-client"),
             entrypoint_runner: dir.join("mvm-oci-entrypoint"),
+            verity_init: dir.join("mvm-verity-init"),
             dir,
         }
     }
@@ -99,6 +103,7 @@ impl GuestAgentLayout {
             && self.netinit.is_file()
             && self.egress_client.is_file()
             && self.entrypoint_runner.is_file()
+            && self.verity_init.is_file()
     }
 
     fn binaries(&self) -> MvmRuntimeBinaries {
@@ -108,6 +113,7 @@ impl GuestAgentLayout {
             netinit: self.netinit.clone(),
             egress_client: self.egress_client.clone(),
             entrypoint_runner: self.entrypoint_runner.clone(),
+            verity_init: self.verity_init.clone(),
         }
     }
 }
@@ -170,6 +176,8 @@ impl GuestAgentBuildSpec {
             "mvm-oci-init".to_string(),
             "--bin".to_string(),
             "mvm-oci-entrypoint".to_string(),
+            "--bin".to_string(),
+            "mvm-verity-init".to_string(),
             "-p".to_string(),
             "mvm-guest-helpers".to_string(),
             "--bin".to_string(),
@@ -211,6 +219,7 @@ pub fn resolve_or_build_guest_binaries(
             netinit: &built.2,
             egress_client: &built.3,
             entrypoint_runner: &built.4,
+            verity_init: &built.5,
         },
         cache_root,
         version,
@@ -234,6 +243,7 @@ pub fn install_into_cache(
     install_one(src.netinit, &layout.netinit)?;
     install_one(src.egress_client, &layout.egress_client)?;
     install_one(src.entrypoint_runner, &layout.entrypoint_runner)?;
+    install_one(src.verity_init, &layout.verity_init)?;
     Ok(layout.binaries())
 }
 
@@ -264,6 +274,7 @@ pub fn install_prebuilt_guest_binaries(
     write_exec(&layout.netinit, bytes.netinit)?;
     write_exec(&layout.egress_client, bytes.egress_client)?;
     write_exec(&layout.entrypoint_runner, bytes.entrypoint_runner)?;
+    write_exec(&layout.verity_init, bytes.verity_init)?;
     Ok(layout.binaries())
 }
 
@@ -286,7 +297,7 @@ fn install_one(src: &Path, dst: &Path) -> Result<(), GuestAgentBuildError> {
 /// Run `cargo zigbuild` for the spec, returning the built binary paths.
 pub fn build_guest_binaries(
     spec: &GuestAgentBuildSpec,
-) -> Result<(PathBuf, PathBuf, PathBuf, PathBuf, PathBuf), GuestAgentBuildError> {
+) -> Result<(PathBuf, PathBuf, PathBuf, PathBuf, PathBuf, PathBuf), GuestAgentBuildError> {
     let argv = spec.argv();
     let mut cmd = std::process::Command::new(&argv[0]);
     cmd.args(&argv[1..]).current_dir(&spec.workspace_root);
@@ -316,18 +327,27 @@ pub fn build_guest_binaries(
     let netinit = dir.join("mvm-guest-netinit");
     let egress_client = dir.join("mvm-egress-client");
     let entrypoint_runner = dir.join("mvm-oci-entrypoint");
+    let verity_init = dir.join("mvm-verity-init");
     for p in [
         &oci_init,
         &agent,
         &netinit,
         &egress_client,
         &entrypoint_runner,
+        &verity_init,
     ] {
         if !p.is_file() {
             return Err(GuestAgentBuildError::OutputMissing(p.clone()));
         }
     }
-    Ok((oci_init, agent, netinit, egress_client, entrypoint_runner))
+    Ok((
+        oci_init,
+        agent,
+        netinit,
+        egress_client,
+        entrypoint_runner,
+        verity_init,
+    ))
 }
 
 /// `rustup which rustc` path, or `None` if rustup isn't installed.
@@ -381,6 +401,7 @@ mod tests {
                 netinit: b"fake-netinit-elf",
                 egress_client: b"fake-egress-client-elf",
                 entrypoint_runner: b"fake-entrypoint-runner-elf",
+                verity_init: b"fake-verity-init-elf",
             },
             cache.path(),
             version,
@@ -392,6 +413,11 @@ mod tests {
         assert!(bins.netinit.is_file());
         assert!(bins.egress_client.is_file());
         assert!(bins.entrypoint_runner.is_file());
+        assert!(bins.verity_init.is_file());
+        assert_eq!(
+            std::fs::read(&bins.verity_init).unwrap(),
+            b"fake-verity-init-elf"
+        );
         assert_eq!(std::fs::read(&bins.oci_init).unwrap(), b"fake-oci-init-elf");
         assert_eq!(std::fs::read(&bins.agent).unwrap(), b"fake-agent-elf");
         assert_eq!(
@@ -447,6 +473,7 @@ mod tests {
         assert_eq!(l.netinit, l.dir.join("mvm-guest-netinit"));
         assert_eq!(l.egress_client, l.dir.join("mvm-egress-client"));
         assert_eq!(l.entrypoint_runner, l.dir.join("mvm-oci-entrypoint"));
+        assert_eq!(l.verity_init, l.dir.join("mvm-verity-init"));
     }
 
     #[test]
@@ -462,6 +489,7 @@ mod tests {
         assert!(argv.contains(&"mvm-guest-netinit".to_string()));
         assert!(argv.contains(&"mvm-oci-init".to_string()));
         assert!(argv.contains(&"mvm-oci-entrypoint".to_string()));
+        assert!(argv.contains(&"mvm-verity-init".to_string()));
         assert!(argv.contains(&"mvm-egress-client".to_string()));
         assert!(argv.contains(&"mvm-guest-helpers".to_string()));
         assert!(argv.contains(&"mvm-guest/dev-shell".to_string()));
@@ -492,11 +520,13 @@ mod tests {
         let netinit_src = tmp.path().join("n");
         let egress_client_src = tmp.path().join("e");
         let entrypoint_runner_src = tmp.path().join("r");
+        let verity_init_src = tmp.path().join("v");
         std::fs::write(&oci_init_src, b"INIT").unwrap();
         std::fs::write(&agent_src, b"AGENT").unwrap();
         std::fs::write(&netinit_src, b"NETINIT").unwrap();
         std::fs::write(&egress_client_src, b"EGRESS").unwrap();
         std::fs::write(&entrypoint_runner_src, b"RUNNER").unwrap();
+        std::fs::write(&verity_init_src, b"VERITY").unwrap();
         let cache = tmp.path().join("cache");
 
         let installed = install_into_cache(
@@ -506,6 +536,7 @@ mod tests {
                 netinit: &netinit_src,
                 egress_client: &egress_client_src,
                 entrypoint_runner: &entrypoint_runner_src,
+                verity_init: &verity_init_src,
             },
             &cache,
             version,
@@ -519,6 +550,7 @@ mod tests {
             std::fs::read(&installed.entrypoint_runner).unwrap(),
             b"RUNNER"
         );
+        assert_eq!(std::fs::read(&installed.verity_init).unwrap(), b"VERITY");
 
         // A subsequent resolve hits the cache and never builds (the
         // workspace path is bogus; if it built it would fail).
@@ -543,6 +575,7 @@ mod tests {
                 netinit: &tmp.path().join("missing-netinit"),
                 egress_client: &tmp.path().join("missing-egress-client"),
                 entrypoint_runner: &tmp.path().join("missing-entrypoint-runner"),
+                verity_init: &tmp.path().join("missing-verity-init"),
             },
             &tmp.path().join("cache"),
             version,

--- a/crates/mvm-build/src/lib.rs
+++ b/crates/mvm-build/src/lib.rs
@@ -119,6 +119,10 @@ pub mod pipeline;
 /// ext4 + verity sidecar + roothash for the running mvmctl version and
 /// host arch from `~/.cache/mvm/runtime-overlay/<version>/<arch>/`.
 pub mod runtime_overlay;
+/// In-process assembler for the `mvm-verity-init` verity initramfs
+/// (`rootfs.initrd`): a deterministic gzip'd newc cpio carrying the init
+/// binary, device nodes, and pivot mount points.
+pub mod verity_initrd;
 
 // Legacy re-exports — preserve `mvm_build::build::*`, `mvm_build::scripts::*`, etc.
 pub use nix::manifest as nix_manifest;

--- a/crates/mvm-build/src/oci_runtime_inject.rs
+++ b/crates/mvm-build/src/oci_runtime_inject.rs
@@ -52,6 +52,12 @@ pub struct MvmRuntimeBinaries {
     pub egress_client: PathBuf,
     /// Static OCI entrypoint runner (`mvm-oci-entrypoint`).
     pub entrypoint_runner: PathBuf,
+    /// Static verity initramfs PID 1 (`mvm-verity-init`). NOT baked into the
+    /// rootfs — it goes into the separate `rootfs.initrd` cpio via
+    /// [`crate::verity_initrd`]. Carried here so the guest-binary resolver
+    /// (cache / source-checkout / embedded) produces it alongside the rootfs
+    /// set; `inject_mvm_runtime` deliberately ignores it.
+    pub verity_init: PathBuf,
 }
 
 /// Shell-free runtime config for an OCI image's declared Entrypoint/Cmd.
@@ -221,17 +227,20 @@ mod tests {
         let netinit = dir.join("netinit.bin");
         let egress_client = dir.join("egress-client.bin");
         let entrypoint_runner = dir.join("entrypoint-runner.bin");
+        let verity_init = dir.join("verity-init.bin");
         std::fs::write(&oci_init, b"\x7fELF-oci-init").unwrap();
         std::fs::write(&agent, b"\x7fELF-agent").unwrap();
         std::fs::write(&netinit, b"\x7fELF-netinit").unwrap();
         std::fs::write(&egress_client, b"\x7fELF-egress-client").unwrap();
         std::fs::write(&entrypoint_runner, b"\x7fELF-entrypoint-runner").unwrap();
+        std::fs::write(&verity_init, b"\x7fELF-verity-init").unwrap();
         MvmRuntimeBinaries {
             oci_init,
             agent,
             netinit,
             egress_client,
             entrypoint_runner,
+            verity_init,
         }
     }
 

--- a/crates/mvm-build/src/rootfs_inject.rs
+++ b/crates/mvm-build/src/rootfs_inject.rs
@@ -13,30 +13,62 @@
 //!
 //! The cpio writer is pure + host-side (no ext4, no VM), so it is unit-testable.
 
-/// One file or directory in the initramfs.
+/// One file, directory, or device node in the initramfs.
 pub struct CpioEntry {
     /// Archive path, no leading slash (e.g. `init`, `payload/manifest`).
     pub path: String,
     /// Full mode incl. type bits (e.g. `0o100755` for an executable file,
-    /// `0o040755` for a directory).
+    /// `0o040755` for a directory, `0o020600` for a char device).
     pub mode: u32,
-    /// File contents (empty for a directory).
+    /// File contents (empty for a directory or device node).
     pub data: Vec<u8>,
+    /// `(major, minor)` for a device node; `None` for files and directories.
+    /// Written into the newc `rdevmajor`/`rdevminor` header fields so the
+    /// kernel materializes the node with the right backing device.
+    pub rdev: Option<(u32, u32)>,
 }
+
+// newc type bits (subset of S_IFMT). Kept local so the cpio writer has no
+// libc dependency and stays host-buildable on every target.
+const S_IFDIR: u32 = 0o040000;
+const S_IFREG: u32 = 0o100000;
+const S_IFCHR: u32 = 0o020000;
+const S_IFBLK: u32 = 0o060000;
+const S_IFMT: u32 = 0o170000;
 
 impl CpioEntry {
     pub fn file(path: &str, mode: u32, data: Vec<u8>) -> Self {
         Self {
             path: path.to_string(),
-            mode: 0o100000 | (mode & 0o7777),
+            mode: S_IFREG | (mode & 0o7777),
             data,
+            rdev: None,
         }
     }
     pub fn dir(path: &str) -> Self {
         Self {
             path: path.to_string(),
-            mode: 0o040000 | 0o755,
+            mode: S_IFDIR | 0o755,
             data: Vec::new(),
+            rdev: None,
+        }
+    }
+    /// A character-special device node (e.g. `/dev/console` = `c 5 1`).
+    pub fn char_dev(path: &str, mode: u32, major: u32, minor: u32) -> Self {
+        Self {
+            path: path.to_string(),
+            mode: S_IFCHR | (mode & 0o7777),
+            data: Vec::new(),
+            rdev: Some((major, minor)),
+        }
+    }
+    /// A block-special device node (e.g. `/dev/vda` = `b 254 0`).
+    pub fn block_dev(path: &str, mode: u32, major: u32, minor: u32) -> Self {
+        Self {
+            path: path.to_string(),
+            mode: S_IFBLK | (mode & 0o7777),
+            data: Vec::new(),
+            rdev: Some((major, minor)),
         }
     }
 }
@@ -55,18 +87,30 @@ pub fn build_newc_cpio(entries: &[CpioEntry]) -> Vec<u8> {
     // A unique inode per entry keeps them distinct (the kernel uses it for
     // hardlink detection; unique inodes mean no accidental links).
     for (i, e) in entries.iter().enumerate() {
-        write_entry(&mut out, i as u32 + 1, e.mode, e.path.as_bytes(), &e.data);
+        write_entry(
+            &mut out,
+            i as u32 + 1,
+            e.mode,
+            e.path.as_bytes(),
+            &e.data,
+            e.rdev.unwrap_or((0, 0)),
+        );
     }
     // Trailer: an entry named TRAILER!!! with nlink 1 and no data.
-    write_entry(&mut out, 0, 0, b"TRAILER!!!", &[]);
+    write_entry(&mut out, 0, 0, b"TRAILER!!!", &[], (0, 0));
     out
 }
 
 /// Write one newc record: a 110-byte ASCII header, the NUL-terminated name
-/// (padded to 4), then the data (padded to 4).
-fn write_entry(out: &mut Vec<u8>, ino: u32, mode: u32, name: &[u8], data: &[u8]) {
+/// (padded to 4), then the data (padded to 4). `rdev` is `(major, minor)` for
+/// device nodes and `(0, 0)` otherwise.
+fn write_entry(out: &mut Vec<u8>, ino: u32, mode: u32, name: &[u8], data: &[u8], rdev: (u32, u32)) {
     let namesize = name.len() as u32 + 1; // includes the trailing NUL
-    let nlink: u32 = if mode & 0o040000 != 0 { 2 } else { 1 };
+    // Directories get nlink 2 (`.` + `..`); everything else (files AND device
+    // nodes) gets 1. The check must mask the full type field — S_IFBLK
+    // (0o060000) shares the 0o040000 bit with S_IFDIR, so a bare bit test
+    // would misclassify block devices as directories.
+    let nlink: u32 = if mode & S_IFMT == S_IFDIR { 2 } else { 1 };
     let f = |v: u32| format!("{v:08x}");
     out.extend_from_slice(b"070701"); // newc magic
     out.extend_from_slice(f(ino).as_bytes());
@@ -78,8 +122,8 @@ fn write_entry(out: &mut Vec<u8>, ino: u32, mode: u32, name: &[u8], data: &[u8])
     out.extend_from_slice(f(data.len() as u32).as_bytes()); // filesize
     out.extend_from_slice(f(0).as_bytes()); // devmajor
     out.extend_from_slice(f(0).as_bytes()); // devminor
-    out.extend_from_slice(f(0).as_bytes()); // rdevmajor
-    out.extend_from_slice(f(0).as_bytes()); // rdevminor
+    out.extend_from_slice(f(rdev.0).as_bytes()); // rdevmajor
+    out.extend_from_slice(f(rdev.1).as_bytes()); // rdevminor
     out.extend_from_slice(f(namesize).as_bytes());
     out.extend_from_slice(f(0).as_bytes()); // check (0 for newc)
     out.extend_from_slice(name);

--- a/crates/mvm-build/src/run_image.rs
+++ b/crates/mvm-build/src/run_image.rs
@@ -27,6 +27,7 @@ pub struct PrebuiltGuestBinaries<'a> {
     pub netinit: &'a [u8],
     pub egress_client: &'a [u8],
     pub entrypoint_runner: &'a [u8],
+    pub verity_init: &'a [u8],
 }
 
 /// Inject the mvm runtime into `unpacked_root`, materialize it into `output` (a
@@ -109,6 +110,7 @@ fn resolve_guest_binaries(
                 netinit: p.netinit,
                 egress_client: p.egress_client,
                 entrypoint_runner: p.entrypoint_runner,
+                verity_init: p.verity_init,
             },
             cache_root,
             version,

--- a/crates/mvm-build/src/verity_initrd.rs
+++ b/crates/mvm-build/src/verity_initrd.rs
@@ -1,0 +1,300 @@
+//! In-process assembler for the `mvm-verity-init` verity initramfs
+//! (`rootfs.initrd`).
+//!
+//! The verity boot pivot runs `mvm-verity-init` as PID 1 of a tiny initramfs:
+//! it mounts pseudo-filesystems, builds the dm-verity device-mapper target(s)
+//! via raw ioctls, mounts the verified rootfs at `/sysroot`, then
+//! `switch_root`s to the real init. That init must ship as a `cpio.gz` the
+//! kernel unpacks into the initial ramfs before it runs `/init`.
+//!
+//! This module produces that archive on the host — no VM, no `mkinitramfs`, no
+//! subprocess — so it is pure and unit-testable. It reuses the newc cpio writer
+//! from [`crate::rootfs_inject`] (extended there to emit device nodes) rather
+//! than forking a second encoder.
+//!
+//! The archive carries exactly what `mvm-verity-init` needs to reach its first
+//! mount:
+//!
+//! - `/init` — the `mvm-verity-init` binary, mode 0755.
+//! - Device nodes for the console and the four virtio-blk disks the init opens
+//!   by path before it mounts devtmpfs over `/dev`. devtmpfs re-materializes
+//!   these once mounted; the baked nodes cover the pre-mount window and the
+//!   console the kernel attaches stdio to.
+//! - The pseudo-fs and pivot mount-point directories.
+//!
+//! Output is deterministic (fixed mtime/uid/gid = 0, fixed gzip header) so the
+//! same init binary always yields byte-identical bytes.
+
+use std::io::Write;
+
+use anyhow::{Context, Result};
+use flate2::Compression;
+
+use crate::rootfs_inject::{CpioEntry, build_newc_cpio};
+
+/// Character-device major for `/dev/console` (Linux `MEM` major, minor 1).
+const CONSOLE_MAJOR: u32 = 5;
+const CONSOLE_MINOR: u32 = 1;
+
+/// Block-device major the virtio-blk disks (`/dev/vda`..`/dev/vdd`) present in
+/// the microVM guest. The four disks are the rootfs data + hash devices and the
+/// optional runtime-overlay data + hash devices `mvm-verity-init` reads by path
+/// (`mvm.data`/`mvm.hash`/`mvm.runtime_data`/`mvm.runtime_hash`, defaulting to
+/// vda/vdb/vdc/vdd). devtmpfs owns the authoritative nodes at boot; these baked
+/// nodes are the pre-devtmpfs fallback.
+const VIRTIO_BLK_MAJOR: u32 = 254;
+
+/// The four virtio-blk device nodes, in disk order (vda..vdd → minor 0..3).
+const VIRTIO_BLK_NODES: [(&str, u32); 4] = [
+    ("dev/vda", 0),
+    ("dev/vdb", 1),
+    ("dev/vdc", 2),
+    ("dev/vdd", 3),
+];
+
+/// The pseudo-fs and pivot mount-point directories `mvm-verity-init` expects to
+/// find already present in the initramfs. Parents precede children (newc
+/// requires it, and the kernel needs the parent to exist to create the child).
+/// `sysroot/mvm/runtime` is baked for completeness even though the `/sysroot`
+/// ext4 mount covers it at boot — the real mount target lives in the verified
+/// rootfs, per the `mvm-verity-init` overlay contract.
+const MOUNT_DIRS: [&str; 6] = [
+    "proc",
+    "sys",
+    "dev",
+    "sysroot",
+    "sysroot/mvm",
+    "sysroot/mvm/runtime",
+];
+
+/// Assemble the gzip'd newc cpio verity initramfs carrying `verity_init_bin` as
+/// `/init`, the required device nodes, and the mount-point directories.
+///
+/// Deterministic: two calls with the same `verity_init_bin` return
+/// byte-identical output.
+pub fn assemble_verity_initramfs(verity_init_bin: &[u8]) -> Result<Vec<u8>> {
+    let mut entries = vec![CpioEntry::file("init", 0o755, verity_init_bin.to_vec())];
+
+    // Directories first (parents before children so `dev` exists before the
+    // device nodes below, and `sysroot`/`sysroot/mvm` before their children).
+    for dir in MOUNT_DIRS {
+        entries.push(CpioEntry::dir(dir));
+    }
+
+    // Console: the kernel attaches stdio here and the init writes early
+    // progress here before devtmpfs is mounted.
+    entries.push(CpioEntry::char_dev(
+        "dev/console",
+        0o600,
+        CONSOLE_MAJOR,
+        CONSOLE_MINOR,
+    ));
+
+    // The four virtio-blk disks the init opens by path.
+    for (path, minor) in VIRTIO_BLK_NODES {
+        entries.push(CpioEntry::block_dev(path, 0o660, VIRTIO_BLK_MAJOR, minor));
+    }
+
+    let cpio = build_newc_cpio(&entries);
+    gzip_deterministic(&cpio).context("gzip verity initramfs cpio")
+}
+
+/// gzip `data` with a zeroed header (mtime 0, no filename) so the output is a
+/// pure function of the input.
+fn gzip_deterministic(data: &[u8]) -> Result<Vec<u8>> {
+    // GzEncoder's default header already zeroes mtime; the explicit builder
+    // pins it so a flate2 default change can't reintroduce a timestamp.
+    let mut enc = flate2::GzBuilder::new()
+        .mtime(0)
+        .write(Vec::new(), Compression::default());
+    enc.write_all(data).context("gzip write")?;
+    enc.finish().context("gzip finish")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// A parsed newc record: everything the structural assertions need.
+    struct Record {
+        name: String,
+        mode: u32,
+        rdevmajor: u32,
+        rdevminor: u32,
+        data: Vec<u8>,
+    }
+
+    impl Record {
+        fn type_bits(&self) -> u32 {
+            self.mode & 0o170000
+        }
+        fn perm_bits(&self) -> u32 {
+            self.mode & 0o7777
+        }
+        fn is_dir(&self) -> bool {
+            self.type_bits() == 0o040000
+        }
+        fn is_char(&self) -> bool {
+            self.type_bits() == 0o020000
+        }
+        fn is_block(&self) -> bool {
+            self.type_bits() == 0o060000
+        }
+        fn is_reg(&self) -> bool {
+            self.type_bits() == 0o100000
+        }
+    }
+
+    /// Parse a newc archive into its records (excluding the trailer), reading
+    /// back the fields the assembler is responsible for.
+    fn parse_newc(buf: &[u8]) -> Vec<Record> {
+        let hex = |s: &[u8]| u32::from_str_radix(std::str::from_utf8(s).unwrap(), 16).unwrap();
+        let mut out = Vec::new();
+        let mut off = 0;
+        loop {
+            assert_eq!(&buf[off..off + 6], b"070701", "newc magic at {off}");
+            let field = |i: usize| hex(&buf[off + 6 + i * 8..off + 6 + i * 8 + 8]);
+            let mode = field(1);
+            let filesize = field(6) as usize;
+            let rdevmajor = field(9);
+            let rdevminor = field(10);
+            let namesize = field(11) as usize;
+            let name_start = off + 110;
+            let name =
+                String::from_utf8(buf[name_start..name_start + namesize - 1].to_vec()).unwrap();
+            let mut data_start = name_start + namesize;
+            while !data_start.is_multiple_of(4) {
+                data_start += 1;
+            }
+            if name == "TRAILER!!!" {
+                break;
+            }
+            let data = buf[data_start..data_start + filesize].to_vec();
+            out.push(Record {
+                name,
+                mode,
+                rdevmajor,
+                rdevminor,
+                data,
+            });
+            let mut next = data_start + filesize;
+            while !next.is_multiple_of(4) {
+                next += 1;
+            }
+            off = next;
+        }
+        out
+    }
+
+    fn gunzip(buf: &[u8]) -> Vec<u8> {
+        use std::io::Read;
+        let mut dec = flate2::read::GzDecoder::new(buf);
+        let mut out = Vec::new();
+        dec.read_to_end(&mut out).expect("gunzip");
+        out
+    }
+
+    fn records_for(init: &[u8]) -> Vec<Record> {
+        let gz = assemble_verity_initramfs(init).expect("assemble");
+        parse_newc(&gunzip(&gz))
+    }
+
+    fn find<'a>(recs: &'a [Record], name: &str) -> &'a Record {
+        recs.iter()
+            .find(|r| r.name == name)
+            .unwrap_or_else(|| panic!("record {name} missing"))
+    }
+
+    #[test]
+    fn init_is_the_passed_binary_mode_0755() {
+        let init = b"\x7fELF-fake-verity-init";
+        let recs = records_for(init);
+        let rec = find(&recs, "init");
+        assert!(rec.is_reg(), "/init must be a regular file");
+        assert_eq!(rec.perm_bits(), 0o755, "/init must be mode 0755");
+        assert_eq!(
+            rec.data, init,
+            "/init contents must equal the passed binary"
+        );
+    }
+
+    #[test]
+    fn console_node_is_char_5_1() {
+        let recs = records_for(b"x");
+        let rec = find(&recs, "dev/console");
+        assert!(rec.is_char(), "/dev/console must be a char device");
+        assert_eq!((rec.rdevmajor, rec.rdevminor), (5, 1));
+        assert_eq!(rec.perm_bits(), 0o600);
+    }
+
+    #[test]
+    fn virtio_blk_nodes_are_block_254_0_through_3() {
+        let recs = records_for(b"x");
+        for (name, minor) in [
+            ("dev/vda", 0),
+            ("dev/vdb", 1),
+            ("dev/vdc", 2),
+            ("dev/vdd", 3),
+        ] {
+            let rec = find(&recs, name);
+            assert!(rec.is_block(), "{name} must be a block device");
+            assert_eq!(
+                (rec.rdevmajor, rec.rdevminor),
+                (254, minor),
+                "{name} major/minor"
+            );
+            assert_eq!(rec.perm_bits(), 0o660, "{name} perms");
+        }
+    }
+
+    #[test]
+    fn mount_point_dirs_present_as_directories() {
+        let recs = records_for(b"x");
+        for dir in [
+            "proc",
+            "sys",
+            "dev",
+            "sysroot",
+            "sysroot/mvm",
+            "sysroot/mvm/runtime",
+        ] {
+            let rec = find(&recs, dir);
+            assert!(rec.is_dir(), "{dir} must be a directory");
+        }
+    }
+
+    #[test]
+    fn parent_dirs_precede_their_children() {
+        // The kernel's cpio unpacker needs `dev` before `dev/console` and
+        // `sysroot/mvm` before `sysroot/mvm/runtime`.
+        let recs = records_for(b"x");
+        let pos = |name: &str| recs.iter().position(|r| r.name == name).unwrap();
+        assert!(pos("dev") < pos("dev/console"));
+        assert!(pos("dev") < pos("dev/vda"));
+        assert!(pos("sysroot") < pos("sysroot/mvm"));
+        assert!(pos("sysroot/mvm") < pos("sysroot/mvm/runtime"));
+    }
+
+    #[test]
+    fn trailer_record_present() {
+        // parse_newc stops at TRAILER!!! — assert it exists by scanning the
+        // raw (decompressed) bytes for the record name.
+        let gz = assemble_verity_initramfs(b"x").expect("assemble");
+        let raw = gunzip(&gz);
+        assert!(
+            raw.windows(b"TRAILER!!!".len()).any(|w| w == b"TRAILER!!!"),
+            "cpio must end with the TRAILER!!! record"
+        );
+    }
+
+    #[test]
+    fn output_is_deterministic() {
+        let init = b"\x7fELF-deterministic";
+        let a = assemble_verity_initramfs(init).expect("assemble a");
+        let b = assemble_verity_initramfs(init).expect("assemble b");
+        assert_eq!(
+            a, b,
+            "two assembles of the same binary must be byte-identical"
+        );
+    }
+}

--- a/crates/mvm-cli/build.rs
+++ b/crates/mvm-cli/build.rs
@@ -117,6 +117,7 @@ fn main() {
         "mvm-guest-agent",
         "mvm-guest-netinit",
         "mvm-egress-client",
+        "mvm-verity-init",
     ] {
         let out_file = bins_out.join(name);
         if skip_embed {
@@ -424,7 +425,8 @@ fn run_cargo_zigbuild(
 fn run_guest_zigbuild(root: &Path, target_dir: &Path, target: &str, zig_pin: &str, out_dir: &Path) {
     eprintln!(
         "[build.rs] cargo zigbuild --release --target {target} -p mvm-guest \
-         --bin mvm-oci-init --bin mvm-oci-entrypoint --bin mvm-guest-agent --bin mvm-guest-netinit -p mvm-guest-helpers \
+         --bin mvm-oci-init --bin mvm-oci-entrypoint --bin mvm-guest-agent --bin mvm-guest-netinit \
+         --bin mvm-verity-init -p mvm-guest-helpers \
          --bin mvm-egress-client --features mvm-guest/dev-shell"
     );
     let (cargo, rustc) = rustup_cargo_and_rustc(strip_glibc(target));
@@ -444,6 +446,8 @@ fn run_guest_zigbuild(root: &Path, target_dir: &Path, target: &str, zig_pin: &st
         "mvm-guest-agent",
         "--bin",
         "mvm-guest-netinit",
+        "--bin",
+        "mvm-verity-init",
         "-p",
         "mvm-guest-helpers",
         "--bin",
@@ -474,6 +478,7 @@ fn run_guest_zigbuild(root: &Path, target_dir: &Path, target: &str, zig_pin: &st
         "mvm-guest-agent",
         "mvm-guest-netinit",
         "mvm-egress-client",
+        "mvm-verity-init",
     ] {
         let built = rel.join(name);
         let dest = out_dir.join(name);

--- a/crates/mvm-cli/src/commands/image/mod.rs
+++ b/crates/mvm-cli/src/commands/image/mod.rs
@@ -593,6 +593,7 @@ fn embedded_guest_binaries() -> Option<mvm_build::run_image::PrebuiltGuestBinari
         netinit: find("mvm-guest-netinit")?,
         egress_client: find("mvm-egress-client")?,
         entrypoint_runner: find("mvm-oci-entrypoint")?,
+        verity_init: find("mvm-verity-init")?,
     })
 }
 


### PR DESCRIPTION
Slice 2a of the production OCI verity-seal path. Step 0 of the prior slice found the blocker: **no `rootfs.initrd` (the `mvm-verity-init` cpio.gz) is produced by any current path** — no cpio assembly in nix, the run path doesn't build/fetch it. Without it, a verity-sealed OCI image has no PID1 to build the dm-verity target + `switch_root` (and Slice 1's guard correctly fails `--prod` closed rather than boot unsealed). This slice produces it **in-process**, matching the OCI run path's "materialize in-process, no builder VM" grain.

## Change
- `verity_initrd::assemble_verity_initramfs(verity_init_bin) -> gzip'd newc cpio` — emits `/init` (mvm-verity-init, 0755), device nodes `/dev/console` (c 5,1) and `/dev/vda..vdd` (b 254,0..3), and the mount dirs (`/proc /sys /dev /sysroot /sysroot/mvm/runtime`). Device majors/minors read from `mvm-verity-init.rs`. Deterministic (fixed uid/gid/mtime, timestamp-free gzip).
- Extend the **shared** `rootfs_inject` newc writer with device-node support (rather than fork it), and **fix its nlink classification** — `S_IFBLK` (0o060000) shares the 0o040000 bit with `S_IFDIR`, so the old bare-bit test mislabeled block nodes as directories; now masks the full type field.
- Cross-compile + embed `mvm-verity-init` alongside the other guest bins (`guest_agent_build`, `mvm-cli/build.rs`, the typed accessors, `embedded_guest_binaries`).

## Tests / scope
7 new structure tests (init bytes, console 5,1, virtio-blk 254,0..3, mount dirs, parent-before-child ordering, trailer, determinism) + no regression on existing `rootfs_inject` tests; 88 mvm-build tests green; fmt/clippy/no-spec-refs clean. **Not wired into `--prod`** (Slice 2b threads the flag + emits the initrd atomically with the seal). **Live-boot correctness (mount + switch_root from this initramfs) is deferred to Slice 3** (Linux/FC hardware); host tests verify archive structure only. Claim-3 posture unchanged (the guard still fails `--prod` closed until 2b lands the bootable path).