### PR TITLE
feat(oci): wire --prod to a bootable verity-sealed image (Slice 2b)

### DIFF
--- a/crates/mvm-build/src/builder_vm.rs
+++ b/crates/mvm-build/src/builder_vm.rs
@@ -274,20 +274,21 @@ impl GuestSidecar {
     /// honest claim, not a gate bypass — only emit this sidecar once
     /// the injection has actually run.
     ///
-    /// Posture: a `run --image` guest is a dev/interactive surface, so
-    /// it is `accessible` (console may attach) and not `sealed`; the
-    /// `--prod` path refuses mutable OCI references upstream and never
-    /// reaches this constructor. The baked agent is the real
+    /// Posture: `sealed` selects the tier. A plain `run --image` guest is
+    /// a dev/interactive surface, so it is `accessible` (console may attach)
+    /// and not `sealed`. A `--prod` run boots a dm-verity-sealed rootfs, so
+    /// it is `sealed` and **not** `accessible` — the console/exec gate and
+    /// the agent-verb grant both read these fields and must see a sealed
+    /// image refuse interactive access. The baked agent is the real
     /// cross-compiled binary, not the stub. `hypervisor` is left
     /// backend-neutral ("oci"): the materialized rootfs is cached and
     /// boots on any backend, so it can't honestly name one — and no
-    /// gate reads this field (it is informational; only `accessible`
-    /// drives a runtime decision).
-    pub fn for_oci_run(name: &str) -> Self {
+    /// gate reads that field (it is informational).
+    pub fn for_oci_run(name: &str, sealed: bool) -> Self {
         Self {
             name: name.to_string(),
-            accessible: true,
-            sealed: false,
+            accessible: !sealed,
+            sealed,
             entrypoint_kind: "command".to_string(),
             init_system: "busybox".to_string(),
             // Unknown for an arbitrary OCI image; not load-bearing
@@ -1243,11 +1244,28 @@ mod tests {
         // the `for_oci_run` sidecar next to the rootfs must satisfy
         // `admit_overlay_aware` — without it, `run --image` never boots.
         let tmp = tempfile::tempdir().expect("tempdir");
-        let sidecar = GuestSidecar::for_oci_run("oci:sha256-deadbeef");
+        let sidecar = GuestSidecar::for_oci_run("oci:sha256-deadbeef", false);
         assert!(sidecar.is_overlay_aware());
         assert_eq!(sidecar.agent_binary, "real");
         sidecar.write_to_dir(tmp.path()).expect("write");
         admit_overlay_aware(tmp.path()).expect("OCI-run rootfs must admit");
+    }
+
+    #[test]
+    fn oci_run_sidecar_sealed_flag_flips_posture() {
+        // A dev OCI run is accessible + unsealed; a `--prod` OCI run is
+        // sealed + not accessible so the console/exec gate refuses it.
+        let dev = GuestSidecar::for_oci_run("oci:dev", false);
+        assert!(!dev.sealed);
+        assert!(dev.accessible);
+        assert!(dev.is_overlay_aware());
+
+        let prod = GuestSidecar::for_oci_run("oci:prod", true);
+        assert!(prod.sealed);
+        assert!(!prod.accessible);
+        // Sealing does not change the honest overlay-aware claim.
+        assert!(prod.is_overlay_aware());
+        assert_eq!(prod.agent_binary, "real");
     }
 
     #[test]

--- a/crates/mvm-build/src/oci_runtime_inject.rs
+++ b/crates/mvm-build/src/oci_runtime_inject.rs
@@ -87,6 +87,7 @@ pub fn inject_mvm_runtime(
     rootfs_dir: &Path,
     bins: &MvmRuntimeBinaries,
     entrypoint: Option<&OciEntrypointConfig>,
+    sealed: bool,
 ) -> Result<InjectedPaths, io::Error> {
     if !rootfs_dir.is_dir() {
         return Err(io::Error::new(
@@ -116,11 +117,13 @@ pub fn inject_mvm_runtime(
     let runtime_dir = rootfs_dir.join("mvm").join("runtime");
 
     // Minimal markers the agent reads. `variant=dev` keeps the
-    // interactive/console surface enabled (a `run --image` is a dev
-    // surface); `--prod` refuses mutable OCI references upstream.
+    // interactive/console surface enabled (a plain `run --image` is a dev
+    // surface); a `--prod` run bakes `variant=prod` so the sealed agent
+    // links no console/exec and the runtime gate refuses interactive access.
     let etc_mvm = rootfs_dir.join("etc").join("mvm");
     std::fs::create_dir_all(&etc_mvm)?;
-    write_file(&etc_mvm.join("variant"), b"dev\n", 0o644)?;
+    let variant: &[u8] = if sealed { b"prod\n" } else { b"dev\n" };
+    write_file(&etc_mvm.join("variant"), variant, 0o644)?;
     write_file(&etc_mvm.join("name"), b"oci\n", 0o644)?;
 
     // Baked guest binaries.
@@ -261,7 +264,7 @@ mod tests {
             working_dir: Some("/app".to_string()),
         };
 
-        let injected = inject_mvm_runtime(&root, &bins, Some(&entrypoint)).expect("inject");
+        let injected = inject_mvm_runtime(&root, &bins, Some(&entrypoint), false).expect("inject");
 
         // /init is the injected static binary, not a shell script that would
         // require `/bin/sh` or busybox from the source OCI image.
@@ -318,9 +321,9 @@ mod tests {
         std::fs::create_dir_all(&root).unwrap();
         let bins = fake_bins(tmp.path());
 
-        inject_mvm_runtime(&root, &bins, None).expect("first inject");
+        inject_mvm_runtime(&root, &bins, None, false).expect("first inject");
         // A second inject (e.g. cache reuse) must not error on existing files.
-        let second = inject_mvm_runtime(&root, &bins, None).expect("second inject");
+        let second = inject_mvm_runtime(&root, &bins, None, false).expect("second inject");
         assert!(is_executable(&second.agent));
         assert!(is_executable(&second.egress_client));
         assert!(!root.join("etc/mvm/entrypoint").exists());
@@ -330,8 +333,31 @@ mod tests {
     fn inject_rejects_missing_rootfs_dir() {
         let tmp = tempfile::tempdir().unwrap();
         let bins = fake_bins(tmp.path());
-        let err = inject_mvm_runtime(&tmp.path().join("nope"), &bins, None).unwrap_err();
+        let err = inject_mvm_runtime(&tmp.path().join("nope"), &bins, None, false).unwrap_err();
         assert_eq!(err.kind(), io::ErrorKind::NotFound);
+    }
+
+    #[test]
+    fn sealed_inject_writes_prod_variant() {
+        // A `--prod` OCI run bakes `variant=prod`; the dev run keeps `dev`.
+        let tmp = tempfile::tempdir().unwrap();
+        let bins = fake_bins(tmp.path());
+
+        let dev_root = tmp.path().join("dev-rootfs");
+        std::fs::create_dir_all(&dev_root).unwrap();
+        inject_mvm_runtime(&dev_root, &bins, None, false).expect("dev inject");
+        assert_eq!(
+            std::fs::read_to_string(dev_root.join("etc/mvm/variant")).unwrap(),
+            "dev\n"
+        );
+
+        let prod_root = tmp.path().join("prod-rootfs");
+        std::fs::create_dir_all(&prod_root).unwrap();
+        inject_mvm_runtime(&prod_root, &bins, None, true).expect("prod inject");
+        assert_eq!(
+            std::fs::read_to_string(prod_root.join("etc/mvm/variant")).unwrap(),
+            "prod\n"
+        );
     }
 
     #[cfg(unix)]

--- a/crates/mvm-build/src/run_image.rs
+++ b/crates/mvm-build/src/run_image.rs
@@ -7,7 +7,7 @@
 //! mvm runtime into the unpacked tree, materialize the ext4 image, and write the
 //! overlay-aware guest sidecar beside it.
 
-use std::path::Path;
+use std::path::{Path, PathBuf};
 
 use anyhow::{Context, Result};
 
@@ -35,6 +35,11 @@ pub struct PrebuiltGuestBinaries<'a> {
 /// `cache_root` holds the guest-agent binary cache; `label` names the image in
 /// the sidecar.
 ///
+/// When `sealed` is set (the `--prod` OCI run), the materialized rootfs is
+/// dm-verity-sealed and a verity initramfs is assembled beside it — atomically
+/// (see [`seal_and_assemble_verity`]) — and the sidecar is written `sealed`, so
+/// the runtime routes the block+ext4 verity boot and refuses interactive access.
+///
 /// Guest binaries resolve in order: a cache hit, then a source-checkout
 /// cross-compile (contributors get their local edits), then the `prebuilt`
 /// bytes embedded in the host binary (the shipped-mvmctl end-user path). A
@@ -46,9 +51,10 @@ pub fn inject_and_materialize(
     label: &str,
     entrypoint: Option<&OciEntrypointConfig>,
     prebuilt: Option<PrebuiltGuestBinaries<'_>>,
+    sealed: bool,
 ) -> Result<()> {
     let bins = resolve_guest_binaries(cache_root, prebuilt)?;
-    crate::oci_runtime_inject::inject_mvm_runtime(unpacked_root, &bins, entrypoint)
+    crate::oci_runtime_inject::inject_mvm_runtime(unpacked_root, &bins, entrypoint, sealed)
         .context("inject mvm runtime into OCI rootfs")?;
 
     // Measure AFTER injection so the ext4 sizing covers the baked agent/netinit.
@@ -60,15 +66,63 @@ pub fn inject_and_materialize(
         tree_size,
     ))?;
 
+    // `--prod`: seal the rootfs and stand up its verity initramfs together,
+    // before the sidecar is written. If this fails we surface it and never
+    // write a `sealed` sidecar over a rootfs that can't verity-boot.
+    if sealed {
+        seal_and_assemble_verity(output, &bins.verity_init)?;
+    }
+
     // The sidecar lives next to rootfs.ext4 so the backend's admit_overlay_aware
     // gate reads it at start.
     let rootfs_dir = output
         .parent()
         .ok_or_else(|| anyhow::anyhow!("rootfs path has no parent dir: {}", output.display()))?;
-    crate::builder_vm::GuestSidecar::for_oci_run(label)
+    crate::builder_vm::GuestSidecar::for_oci_run(label, sealed)
         .write_to_dir(rootfs_dir)
         .with_context(|| format!("write OCI sidecar in {}", rootfs_dir.display()))?;
     Ok(())
+}
+
+/// Seal an already-materialized `rootfs_ext4` and stand up its verity initramfs
+/// **atomically**: on success both the seal sidecars (`rootfs.verity` +
+/// `rootfs.roothash`) and `rootfs.initrd` exist; on any failure none of them do.
+///
+/// The boot-time guard fails a boot closed when a roothash is present without a
+/// sibling `rootfs.initrd`. To make that state unreachable, the initramfs is
+/// written *first* (it is pure host work, no `veritysetup`), then the seal runs;
+/// a seal failure rolls the initramfs back. So a roothash never lands before its
+/// initramfs, and neither is ever left without the other.
+fn seal_and_assemble_verity(rootfs_ext4: &Path, verity_init_bin: &Path) -> Result<()> {
+    let initrd_path = assemble_and_write_verity_initrd(rootfs_ext4, verity_init_bin)?;
+
+    match seal_run_rootfs_with_verity(rootfs_ext4) {
+        Ok(_) => Ok(()),
+        Err(e) => {
+            // Roll the initramfs back so the artifact set is all-or-nothing —
+            // an initrd hinting at a sealed boot must not outlive a failed seal.
+            let _ = std::fs::remove_file(&initrd_path);
+            Err(anyhow::Error::new(e))
+                .with_context(|| format!("dm-verity seal {}", rootfs_ext4.display()))
+        }
+    }
+}
+
+/// Assemble the verity initramfs from `verity_init_bin` and write it to
+/// `rootfs.initrd` beside `rootfs_ext4`. Pure host work — no `veritysetup`, so
+/// it runs identically on every host. Returns the path written.
+fn assemble_and_write_verity_initrd(rootfs_ext4: &Path, verity_init_bin: &Path) -> Result<PathBuf> {
+    let verity_init = std::fs::read(verity_init_bin)
+        .with_context(|| format!("read mvm-verity-init binary {}", verity_init_bin.display()))?;
+    let initrd = crate::verity_initrd::assemble_verity_initramfs(&verity_init)
+        .context("assemble verity initramfs")?;
+    let rootfs_dir = rootfs_ext4.parent().ok_or_else(|| {
+        anyhow::anyhow!("rootfs path has no parent dir: {}", rootfs_ext4.display())
+    })?;
+    let initrd_path = rootfs_dir.join("rootfs.initrd");
+    std::fs::write(&initrd_path, &initrd)
+        .with_context(|| format!("write verity initramfs {}", initrd_path.display()))?;
+    Ok(initrd_path)
 }
 
 /// Resolve the guest-agent binaries: cache hit → source-checkout cross-compile
@@ -207,10 +261,9 @@ pub fn unpacked_tree_size(root: &Path) -> Result<u64> {
 ///
 /// Linux-only at runtime. On macOS `veritysetup` is unavailable, so this returns
 /// [`OciUnpackError::HostUnsupported`] rather than a fabricated hash — the seal
-/// runs on Linux (or via the builder VM in a later slice). This is a
-/// test-exercised capability and is **not** yet wired into the live `--prod` run
-/// path; that lands atomically with the verity initramfs so no unsealed or
-/// no-boot window is ever exposed.
+/// runs on Linux (or via the builder VM in a later slice). The `--prod` run path
+/// drives it through [`seal_and_assemble_verity`], which pairs it atomically with
+/// the verity initramfs so no roothash-without-initrd window is ever exposed.
 pub fn seal_run_rootfs_with_verity(
     rootfs_ext4: &Path,
 ) -> Result<VeritySealedRootfs, OciUnpackError> {
@@ -300,6 +353,107 @@ mod tests {
             matches!(err, OciUnpackError::Io(_)),
             "expected Io error for missing input, got {err:?}"
         );
+    }
+
+    /// A gzip stream starts with the two-byte magic `1f 8b`.
+    fn is_gzip(bytes: &[u8]) -> bool {
+        bytes.len() >= 2 && bytes[0] == 0x1f && bytes[1] == 0x8b
+    }
+
+    #[test]
+    fn assemble_and_write_verity_initrd_emits_gzip_cpio_with_init() {
+        // The written `rootfs.initrd` must be the deterministic gzip'd cpio the
+        // verity boot pivot unpacks — carrying the passed init as `/init`.
+        let tmp = tempfile::tempdir().unwrap();
+        let rootfs = tmp.path().join("rootfs.ext4");
+        std::fs::write(&rootfs, b"ext4-bytes").unwrap();
+        let verity_init_bin = tmp.path().join("mvm-verity-init");
+        let init_bytes = b"\x7fELF-fake-verity-init";
+        std::fs::write(&verity_init_bin, init_bytes).unwrap();
+
+        let path = assemble_and_write_verity_initrd(&rootfs, &verity_init_bin).expect("assemble");
+        assert_eq!(path, tmp.path().join("rootfs.initrd"));
+        let written = std::fs::read(&path).unwrap();
+        assert!(!written.is_empty(), "initrd must be non-empty");
+        assert!(is_gzip(&written), "initrd must be gzip'd");
+        // Byte-identical to the pure assembler (which is unit-proven to carry a
+        // `/init` regular-file record equal to the passed binary).
+        let expected =
+            crate::verity_initrd::assemble_verity_initramfs(init_bytes).expect("assemble ref");
+        assert_eq!(written, expected);
+    }
+
+    #[cfg(not(target_os = "linux"))]
+    #[test]
+    fn seal_and_assemble_verity_rolls_back_when_seal_unavailable() {
+        // Atomicity: on a host without `veritysetup` the seal fails, and the
+        // helper must leave NEITHER a roothash NOR an initrd — the initramfs it
+        // wrote first is rolled back. The boot guard therefore never sees a
+        // roothash without its initrd.
+        let tmp = tempfile::tempdir().unwrap();
+        let rootfs = tmp.path().join("rootfs.ext4");
+        std::fs::write(&rootfs, b"ext4-bytes").unwrap();
+        let verity_init_bin = tmp.path().join("mvm-verity-init");
+        std::fs::write(&verity_init_bin, b"\x7fELF-fake-verity-init").unwrap();
+
+        let err = seal_and_assemble_verity(&rootfs, &verity_init_bin)
+            .expect_err("seal is unavailable off Linux");
+        // The seal path was invoked (this is the veritysetup failure surfacing).
+        assert!(
+            err.to_string().contains("dm-verity seal"),
+            "error must name the seal step: {err:#}"
+        );
+        assert!(
+            !tmp.path().join("rootfs.roothash").exists(),
+            "no roothash on a failed seal"
+        );
+        assert!(
+            !tmp.path().join("rootfs.verity").exists(),
+            "no verity sidecar on a failed seal"
+        );
+        assert!(
+            !tmp.path().join("rootfs.initrd").exists(),
+            "initrd must be rolled back on a failed seal"
+        );
+    }
+
+    #[cfg(target_os = "linux")]
+    #[test]
+    fn seal_and_assemble_verity_emits_all_artifacts_together() {
+        // The load-bearing `--prod` invariant: seal + initrd land TOGETHER.
+        // Skips cleanly when `veritysetup` (cryptsetup) is not installed.
+        if which::which("veritysetup").is_err() {
+            eprintln!("skipped: veritysetup not on $PATH (install cryptsetup)");
+            return;
+        }
+        let tmp = tempfile::tempdir().unwrap();
+        let rootfs = tmp.path().join("rootfs.ext4");
+        // veritysetup formats over the raw device bytes; a multiple of the
+        // 1024-byte data-block size is enough (no real ext4 needed here).
+        std::fs::write(&rootfs, vec![0u8; 4096]).unwrap();
+        let verity_init_bin = tmp.path().join("mvm-verity-init");
+        std::fs::write(&verity_init_bin, b"\x7fELF-fake-verity-init").unwrap();
+
+        seal_and_assemble_verity(&rootfs, &verity_init_bin).expect("seal + initrd");
+
+        let roothash = tmp.path().join("rootfs.roothash");
+        let verity = tmp.path().join("rootfs.verity");
+        let initrd = tmp.path().join("rootfs.initrd");
+        assert!(verity.is_file(), "rootfs.verity present");
+        assert!(roothash.is_file(), "rootfs.roothash present");
+        assert!(initrd.is_file(), "rootfs.initrd present");
+        // Both-or-neither: the roothash never lands without its initrd.
+        assert_eq!(
+            roothash.is_file(),
+            initrd.is_file(),
+            "roothash and initrd are all-or-nothing"
+        );
+        let hash = std::fs::read_to_string(&roothash).unwrap();
+        assert!(
+            hash.trim().len() == 64 && hash.trim().bytes().all(|b| b.is_ascii_hexdigit()),
+            "roothash is 64-hex: {hash:?}"
+        );
+        assert!(is_gzip(&std::fs::read(&initrd).unwrap()), "initrd gzip'd");
     }
 
     #[test]

--- a/crates/mvm-cli/src/commands/image/mod.rs
+++ b/crates/mvm-cli/src/commands/image/mod.rs
@@ -379,7 +379,7 @@ pub(in crate::commands) fn resolve_or_pull_run_image(
 }
 
 type RuntimeMaterializer =
-    fn(&Path, &Path, &Path, &str, Option<&OciEntrypointConfig>) -> Result<()>;
+    fn(&Path, &Path, &Path, &str, Option<&OciEntrypointConfig>, bool) -> Result<()>;
 
 fn resolve_or_pull_run_image_with(
     cache_root: &Path,
@@ -421,7 +421,7 @@ fn resolve_or_pull_run_image_with(
             (cached, false, None, None)
         }
         Some(cached) => {
-            match rematerialize_cached_image(cache_root, cached, &runtime_tag, materialize)? {
+            match rematerialize_cached_image(cache_root, cached, &runtime_tag, materialize, prod)? {
                 Some(repaired) => (repaired, false, None, None),
                 None => {
                     let (cached, trust, auth_source) =
@@ -460,6 +460,7 @@ fn resolve_or_pull_run_image_with(
                     &image.reference,
                     oci_entrypoint_from_cache_path(cache_root, image.config_path.as_deref())?
                         .as_ref(),
+                    prod,
                 )
                 .with_context(|| {
                     format!(
@@ -499,6 +500,7 @@ fn rematerialize_cached_image(
     mut image: CachedOciImage,
     runtime_tag: &str,
     materialize: RuntimeMaterializer,
+    prod: bool,
 ) -> Result<Option<CachedOciImage>> {
     let Some(unpacked_root) = unpacked_dir_if_present(cache_root, &image.resolved_digest) else {
         return Ok(None);
@@ -521,6 +523,7 @@ fn rematerialize_cached_image(
             &rootfs_abs,
             &image.reference,
             oci_entrypoint_from_cache_path(cache_root, image.config_path.as_deref())?.as_ref(),
+            prod,
         )
         .with_context(|| {
             format!(
@@ -565,6 +568,7 @@ fn inject_runtime_and_materialize(
     rootfs_abs: &Path,
     image_label: &str,
     entrypoint: Option<&OciEntrypointConfig>,
+    sealed: bool,
 ) -> Result<()> {
     mvm_build::run_image::inject_and_materialize(
         cache_root,
@@ -573,6 +577,7 @@ fn inject_runtime_and_materialize(
         image_label,
         entrypoint,
         embedded_guest_binaries(),
+        sealed,
     )
 }
 
@@ -688,6 +693,8 @@ fn ingest_archive_from_reader<R: Read>(
         &rootfs_abs,
         &image.manifest_digest,
         entrypoint.as_ref(),
+        // Local archives are dev-only (prod refused upstream); never sealed.
+        false,
     )?;
 
     let provenance = OciProvenance {
@@ -1081,6 +1088,7 @@ fn pull_image_ref(
         &rootfs_abs,
         &image_ref.canonical(),
         oci_entrypoint_from_cache_path(cache_root, config_path.as_deref())?.as_ref(),
+        prod,
     )?;
 
     let provenance = OciProvenance {
@@ -1739,6 +1747,7 @@ mod tests {
         rootfs_abs: &Path,
         image_label: &str,
         _entrypoint: Option<&OciEntrypointConfig>,
+        _sealed: bool,
     ) -> Result<()> {
         assert!(unpacked_root.is_dir(), "unpacked root must exist");
         fs::create_dir_all(rootfs_abs.parent().expect("rootfs has parent"))?;

--- a/crates/mvm-cli/src/commands/vm/agent_verbs.rs
+++ b/crates/mvm-cli/src/commands/vm/agent_verbs.rs
@@ -150,11 +150,10 @@ mod tests {
         let rootfs = dir.path().join("rootfs.ext4");
         std::fs::write(&rootfs, b"x").unwrap();
 
-        // A sealed prod sidecar => sealed.
-        let mut sc = GuestSidecar::for_oci_run("t"); // accessible:true, sealed:false baseline
-        sc.accessible = false;
-        sc.sealed = true;
-        sc.write_to_dir(dir.path()).unwrap();
+        // A sealed prod sidecar => sealed (accessible:false, sealed:true).
+        GuestSidecar::for_oci_run("t", true)
+            .write_to_dir(dir.path())
+            .unwrap();
         assert!(image_is_sealed(&rootfs));
     }
 
@@ -169,7 +168,7 @@ mod tests {
         assert!(!image_is_sealed(&rootfs));
 
         // OCI sidecar (accessible:true, sealed:false) => not sealed.
-        GuestSidecar::for_oci_run("t")
+        GuestSidecar::for_oci_run("t", false)
             .write_to_dir(dir.path())
             .unwrap();
         assert!(!image_is_sealed(&rootfs));

--- a/crates/mvm-cli/src/commands/vm/invoke.rs
+++ b/crates/mvm-cli/src/commands/vm/invoke.rs
@@ -828,10 +828,9 @@ mod tests {
         env.set("MVM_DATA_DIR", dir.path());
         let rootfs = dir.path().join("rootfs.ext4");
         std::fs::write(&rootfs, b"rootfs").expect("write rootfs");
-        let mut sidecar = GuestSidecar::for_oci_run("audit-probe");
-        sidecar.accessible = false;
-        sidecar.sealed = true;
-        sidecar.write_to_dir(dir.path()).expect("write sidecar");
+        GuestSidecar::for_oci_run("audit-probe", true)
+            .write_to_dir(dir.path())
+            .expect("write sidecar");
 
         let lowered_secrets = LoweredPlanSecrets::default();
         let admitted = admit_entrypoint_boot(

--- a/crates/mvm-client/src/local.rs
+++ b/crates/mvm-client/src/local.rs
@@ -145,8 +145,18 @@ fn materialize_from_dir(dir: &Path, name: &str) -> Result<PathBuf> {
     // the cache or a source checkout.
     // `{:#}` keeps the anyhow context chain — the top context alone
     // ("build guest agent binaries…") hides the actionable root cause.
-    mvm_build::run_image::inject_and_materialize(&cache_root, dir, &output, name, None, None)
-        .map_err(|e| backend_err(format!("{e:#}")))?;
+    // The in-process local backend materializes dev run rootfs only; the sealed
+    // `--prod` path is driven by the CLI's `run --image --prod`.
+    mvm_build::run_image::inject_and_materialize(
+        &cache_root,
+        dir,
+        &output,
+        name,
+        None,
+        None,
+        false,
+    )
+    .map_err(|e| backend_err(format!("{e:#}")))?;
     Ok(output)
 }
 


### PR DESCRIPTION
Slice 2b — completes the production OCI verity-seal wiring (Slices 1 + 2a already on main). A `--prod` OCI image now materializes a dm-verity-sealed rootfs with its `mvm-verity-init` initramfs and a sealed sidecar.

## Change
- `inject_and_materialize` gains `sealed`; on `--prod` it runs `seal_and_assemble_verity` **atomically**: assemble `rootfs.initrd` first (pure host work, via Slice 2a's `assemble_verity_initramfs` fed the embedded `mvm-verity-init` bytes), then run `seal_run_rootfs_with_verity` (Slice 1) → `rootfs.verity` + `rootfs.roothash`. **If the seal fails, the initrd is rolled back** — the artifact set is all-or-nothing, so Slice 1's boot guard never sees a roothash without its initramfs.
- `--prod` flag threaded from the CLI (`pull_image_ref` → `inject_runtime_and_materialize` → `inject_and_materialize`).
- Sealed sidecar: `GuestSidecar::for_oci_run(name, sealed)` → `sealed:true`, `accessible:false`; `inject_mvm_runtime` writes `variant=prod`. `image_is_sealed` then true, `select_root_strategy` routes prod → `BlockExt4`, and the DM_VERITY workload kernel is already selected on this path.
- **Dev (non-`--prod`) OCI path is byte-for-byte unchanged.**

## Tests / scope
Atomicity (`seal_and_assemble_verity_rolls_back_when_seal_unavailable` — neither artifact survives a failed seal), all-artifacts-together (Linux+veritysetup), sealed-sidecar posture flip, prod-variant, and no regression on the existing sealed/guard tests. 526 mvm-build + 1219 mvm-cli lib tests pass. fmt/clippy/no-spec-refs clean. **Live FC verity boot + tamper regression remain Slice 3 (hardware)** — host tests verify artifact emission + atomicity, not that the roothash verifies at boot.

Unblocks §1.4 (bake `verb-trust.json` into a sealed OCI image) and §1.6 (macOS live proof) — the production/sealed OCI substrate now exists.