### PR TITLE
Re-land: remove PackBackend::Vz + --builder vz (orphaned by #1620 early-merge)

### DIFF
--- a/crates/mvm-cli/src/commands/mod.rs
+++ b/crates/mvm-cli/src/commands/mod.rs
@@ -50,7 +50,7 @@ pub(in crate::commands) struct Cli {
     /// Highest priority — beats `MVM_BUILDER_BACKEND`
     /// env and the platform-default auto-detect (macOS 26+ Apple
     /// Silicon → hvf; everywhere else → libkrun).
-    #[arg(long, global = true, value_parser = ["libkrun", "vz", "qemu", "hvf"])]
+    #[arg(long, global = true, value_parser = ["libkrun", "qemu", "hvf"])]
     pub builder: Option<String>,
 
     /// Where the builder VM's kernel comes from when its image is

--- a/crates/mvm-cli/src/commands/tests.rs
+++ b/crates/mvm-cli/src/commands/tests.rs
@@ -3693,7 +3693,7 @@ fn builder_flag_appears_in_help() {
         "`--builder` flag not surfaced in `mvmctl --help`; help text was:\n{help}"
     );
     assert!(
-        help.contains("libkrun") && help.contains("vz"),
+        help.contains("libkrun") && help.contains("hvf"),
         "`--builder` value choices missing from help; help text was:\n{help}"
     );
 }
@@ -3705,14 +3705,21 @@ fn builder_flag_accepts_libkrun() {
 }
 
 #[test]
-fn builder_flag_accepts_vz() {
-    let cli = Cli::try_parse_from(["mvmctl", "--builder", "vz", "doctor"]).expect("parse");
-    assert_eq!(cli.builder.as_deref(), Some("vz"));
+fn builder_flag_rejects_vz() {
+    // The vz backend was removed; `--builder vz` must no longer parse.
+    let err = Cli::try_parse_from(["mvmctl", "--builder", "vz", "doctor"]).unwrap_err();
+    let msg = err.to_string();
+    assert!(
+        msg.contains("invalid value")
+            || msg.contains("possible values")
+            || msg.contains("one of the values isn't valid for an argument"),
+        "expected clap to reject `--builder vz`, got: {msg}"
+    );
 }
 
 #[test]
 fn builder_flag_rejects_unknown_value() {
-    // Clap's `value_parser = ["libkrun", "vz"]` should refuse
+    // Clap's `value_parser = ["libkrun", "qemu", "hvf"]` should refuse
     // anything outside that set. Catches typos like `=vmz` early
     // rather than letting `MVM_BUILDER_BACKEND_ENV`'s
     // warn-and-fall-through path eat them.

--- a/crates/mvm-core/src/packs.rs
+++ b/crates/mvm-core/src/packs.rs
@@ -43,7 +43,6 @@ pub enum PackKind {
 pub enum PackBackend {
     Firecracker,
     Libkrun,
-    Vz,
     Qemu,
     Docker,
     Hvf,
@@ -54,7 +53,6 @@ impl fmt::Display for PackBackend {
         f.write_str(match self {
             PackBackend::Firecracker => "firecracker",
             PackBackend::Libkrun => "libkrun",
-            PackBackend::Vz => "vz",
             PackBackend::Qemu => "qemu",
             PackBackend::Docker => "docker",
             PackBackend::Hvf => "hvf",
@@ -1271,7 +1269,7 @@ mod tests {
             schema_version: PACK_SCHEMA_VERSION,
             kind,
             target_arch: GuestArch::host(),
-            backend_compatibility: vec![PackBackend::Libkrun, PackBackend::Vz],
+            backend_compatibility: vec![PackBackend::Libkrun, PackBackend::Hvf],
             required_host_capabilities: vec![HostCapability("vsock".to_string())],
             policy_compatibility: PolicyCompatibility {
                 policy_hash: policy_hash.clone(),


### PR DESCRIPTION
Re-lands two vz-removal commits that orphaned when #1620 auto-merged early (its squash captured only the CI/script cleanup; these two were pushed to the branch afterward and never reached `main`).

`main` currently still carries these — this PR actually removes them:

- **`PackBackend::Vz`** (`crates/mvm-core/src/packs.rs`) — the enum variant + its `Display` arm + a test fixture. The vz backend was deleted, so no pack can declare/resolve it. Sole workspace reference; `cargo check --workspace` confirms no exhaustive-match breaks.
- **`--builder vz`** (`crates/mvm-cli/src/commands/mod.rs`) — dropped `vz` from the `--builder` value_parser; the `accepts_vz` test flips to a `rejects_vz` test.

No new vz references; verified the two files are vz-free and the workspace compiles.