### PR TITLE
feat(net-tunnel): macOS userspace smoltcp TCP egress forwarder (Plan 236 Phase 2A)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -619,6 +619,15 @@ checksum = "a4ae5f15dda3c708c0ade84bfee31ccab44a3da4f88015ed22f63732abe300c8"
 
 [[package]]
 name = "defmt"
+version = "0.3.100"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f0963443817029b2024136fc4dd07a5107eb8f977eaf18fcd1fdeb11306b64ad"
+dependencies = [
+ "defmt 1.1.0",
+]
+
+[[package]]
+name = "defmt"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a6e524506490a1953d237cb87b1cfc1e46f88c18f10a22dfe0f507dc6bfc7f7f"
@@ -816,7 +825,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1119,6 +1128,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "hash32"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "47d60b12902ba28e2730cd37e95b8c9223af2808df9e902d4df49588d1470606"
+dependencies = [
+ "byteorder",
+]
+
+[[package]]
 name = "hashbrown"
 version = "0.15.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1132,6 +1150,16 @@ name = "hashbrown"
 version = "0.17.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ed5909b6e89a2db4456e54cd5f673791d7eca6732202bbf2a9cc504fe2f9b84a"
+
+[[package]]
+name = "heapless"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b1edcd5a338e64688fbdcb7531a846cfd3476a54784dcb918a0844682bc7ada5"
+dependencies = [
+ "hash32",
+ "stable_deref_trait",
+]
 
 [[package]]
 name = "heck"
@@ -1545,7 +1573,7 @@ version = "0.2.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "34f877a98676d2fb664698d74cc6a51ce6c484ce8c770f05d0108ec9090aeb46"
 dependencies = [
- "defmt",
+ "defmt 1.1.0",
  "jiff-static",
  "jiff-tzdb-platform",
  "log",
@@ -1788,6 +1816,12 @@ dependencies = [
  "byteorder",
  "crc",
 ]
+
+[[package]]
+name = "managed"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0ca88d725a0a943b096803bd34e73a4437208b6077654cc4ecb2947a5f91618d"
 
 [[package]]
 name = "matchers"
@@ -2142,6 +2176,7 @@ dependencies = [
  "serde_jcs",
  "serde_json",
  "sha2",
+ "smoltcp",
  "sysinfo",
  "tar",
  "tempfile",
@@ -2395,7 +2430,7 @@ version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -2799,7 +2834,7 @@ dependencies = [
  "once_cell",
  "socket2",
  "tracing",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -3096,7 +3131,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -3154,7 +3189,7 @@ dependencies = [
  "security-framework",
  "security-framework-sys",
  "webpki-root-certs",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -3643,6 +3678,20 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8ed6a63f02c8539c91a8685a86f4099661ba3da017932f6ebbea6de3f0fa7c90"
 
 [[package]]
+name = "smoltcp"
+version = "0.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5f73d40463bba65efc9adc6370b56df76d563cc46e2482bba58351b4afb7535e"
+dependencies = [
+ "bitflags 1.3.2",
+ "byteorder",
+ "cfg-if",
+ "defmt 0.3.100",
+ "heapless",
+ "managed",
+]
+
+[[package]]
 name = "snafu"
 version = "0.8.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3670,7 +3719,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "52d1cfed4120b4d927bf7c0f86d2087a4a7d6027c906d9f9d525a80573b9be51"
 dependencies = [
  "libc",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -3791,10 +3840,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "82a72c767771b47409d2345987fda8628641887d5466101319899796367354a0"
 dependencies = [
  "fastrand",
- "getrandom 0.3.4",
+ "getrandom 0.4.1",
  "once_cell",
  "rustix",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -4529,7 +4578,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -279,6 +279,11 @@ ipnet = { version = "2", features = ["serde"] }
 # deps, fuzzed upstream. Lands on the untrusted-guest-bytes path (claim 5),
 # so a mature parser beats a hand-rolled one.
 etherparse = "0.20"
+# Userspace TCP/IP stack. macOS has no unprivileged kernel NAT, so the host
+# terminates guest tunnel flows in this in-process stack and bridges each
+# admitted flow to an ordinary host socket. Pure-Rust, no_std/heapless,
+# upstream-fuzzed; std + IPv4 + TCP only. Consumed only under cfg(macos).
+smoltcp = { version = "0.13", default-features = false, features = ["std", "medium-ip", "proto-ipv4", "socket-tcp"] }
 # Plan 74 W2 — mvm-guest-netinit installs kernel blackhole routes
 # for `MANDATORY_DENY_RANGES` inside every microVM. rtnetlink wraps
 # the AF_NETLINK socket and the RTM_NEWROUTE message construction;

--- a/crates/mvm-hostd/Cargo.toml
+++ b/crates/mvm-hostd/Cargo.toml
@@ -103,6 +103,12 @@ tracing-subscriber.workspace = true
 libc.workspace = true
 rustix = { version = "1.1", features = ["fs"] }
 
+# macOS userspace TCP/IP egress: terminate guest tunnel flows in-process and
+# bridge each admitted flow to a host socket (no unprivileged kernel NAT on
+# macOS). Linux uses the kernel TUN + NAT path instead, so this is macOS-only.
+[target.'cfg(target_os = "macos")'.dependencies]
+smoltcp.workspace = true
+
 # mvm-jailer-lite confinement: seccomp + landlock are Linux-only.
 [target.'cfg(target_os = "linux")'.dependencies]
 seccompiler = { workspace = true }

--- a/crates/mvm-hostd/src/bin/mvm-network-tunnel-worker.rs
+++ b/crates/mvm-hostd/src/bin/mvm-network-tunnel-worker.rs
@@ -169,6 +169,13 @@ fn main() -> Result<()> {
     let audit = JsonlAuditSink::open(&config.audit_jsonl_path)?;
     let (stream, cleanup_uds_path) = listener.accept()?;
     let packet_policy = config.worker.packet_policy.clone();
+    // The macOS userspace stack needs the admitted gate; grab it before the
+    // worker consumes the config (the outer match moves `interface_name`).
+    #[cfg(target_os = "macos")]
+    let macos_l3_gate = match &config.worker.packet_policy {
+        TunnelPacketPolicy::L3Forward { gate, .. } => Some(gate.clone()),
+        _ => None,
+    };
     let mut worker = HostTunnelWorker::new(stream, audit, config.worker)
         .context("create host network tunnel worker")?;
     worker
@@ -205,10 +212,33 @@ fn main() -> Result<()> {
                 }
                 result.context("run host network tunnel L3 forward")?;
             }
-            #[cfg(not(target_os = "linux"))]
+            #[cfg(target_os = "macos")]
+            {
+                // macOS has no unprivileged kernel NAT; terminate admitted guest
+                // TCP flows in an in-process userspace stack and bridge each to a
+                // host socket. `interface_name` is unused here — no OS device.
+                let _ = interface_name;
+                let gate = macos_l3_gate
+                    .as_ref()
+                    .expect("matched an l3_forward policy above");
+                let mut egress = mvm_hostd::smoltcp_egress::SmoltcpEgress::new(
+                    gate,
+                    mvm_hostd::smoltcp_egress::EgressConfig {
+                        mtu: worker.negotiated_frame_size().min(1500),
+                        ..mvm_hostd::smoltcp_egress::EgressConfig::default()
+                    },
+                )
+                .context("create macOS userspace TCP egress stack")?;
+                egress
+                    .run(&mut worker)
+                    .context("run macOS userspace TCP egress")?;
+            }
+            #[cfg(not(any(target_os = "linux", target_os = "macos")))]
             {
                 let _ = interface_name;
-                anyhow::bail!("l3_forward host TUN egress is only supported on Linux");
+                anyhow::bail!(
+                    "l3_forward host egress is only supported on Linux (kernel TUN) and macOS (userspace stack)"
+                );
             }
         }
         TunnelPacketPolicy::L3Forward {

--- a/crates/mvm-hostd/src/lib.rs
+++ b/crates/mvm-hostd/src/lib.rs
@@ -49,4 +49,10 @@ pub mod network_tunnel;
 pub mod parent_death;
 pub mod plan_admission;
 pub mod run;
+/// macOS userspace TCP/IP egress for the packet tunnel: terminate admitted
+/// guest TCP flows in an in-process `smoltcp` stack and bridge each to an
+/// ordinary host socket. macOS has no unprivileged kernel NAT; Linux uses the
+/// [`host_tun`] kernel-TUN path instead.
+#[cfg(target_os = "macos")]
+pub mod smoltcp_egress;
 pub mod supervisor;

--- a/crates/mvm-hostd/src/net_l3.rs
+++ b/crates/mvm-hostd/src/net_l3.rs
@@ -140,6 +140,12 @@ impl L3ForwardPolicy {
         }
     }
 
+    /// Every admitted `(dst_ip, dst_port)` pair. The macOS userspace stack
+    /// derives its listening ports from these.
+    pub fn admitted_ipv4_endpoints(&self) -> impl Iterator<Item = (Ipv4Addr, u16)> + '_ {
+        self.allow_ip_port.iter().copied()
+    }
+
     /// The admitted policy this gate was built from.
     pub fn policy(&self) -> &NetworkPolicy {
         &self.policy

--- a/crates/mvm-hostd/src/network_tunnel.rs
+++ b/crates/mvm-hostd/src/network_tunnel.rs
@@ -363,6 +363,29 @@ pub enum TunnelAuditEvent {
         bytes: usize,
         interface_name: String,
     },
+    /// A userspace TCP flow to an admitted destination was accepted and bridged
+    /// to a host socket (the macOS userspace-stack egress path).
+    TcpFlowOpened {
+        flow_id: u32,
+        dst: Ipv4Addr,
+        dst_port: u16,
+    },
+    /// A bridged userspace TCP flow closed, with the byte counts spliced each
+    /// way.
+    TcpFlowClosed {
+        flow_id: u32,
+        dst: Ipv4Addr,
+        dst_port: u16,
+        guest_to_host_bytes: u64,
+        host_to_guest_bytes: u64,
+    },
+    /// A userspace TCP connection was refused before any host socket opened
+    /// because the gate denied its destination.
+    TcpFlowDenied {
+        dst: Ipv4Addr,
+        dst_port: u16,
+        reason: L3DropReason,
+    },
     SessionClosed {
         outcome: TunnelWorkerOutcome,
         stats: TunnelWorkerStats,
@@ -565,6 +588,13 @@ where
 
     pub fn audit(&self) -> &A {
         &self.audit
+    }
+
+    /// The negotiated maximum frame size — the upper bound on a single packet
+    /// this session will carry in either direction.
+    pub fn negotiated_frame_size(&self) -> usize {
+        usize::try_from(self.config.expected_session.maximum_frame_size)
+            .expect("u32 frame size always fits usize on supported targets")
     }
 
     pub fn bootstrap(
@@ -1222,6 +1252,142 @@ where
         )?;
         Ok(TunnelWorkerOutcome::PacketPathFailed)
     }
+
+    /// Block up to `timeout_ms` for the guest session fd to become readable. A
+    /// negative timeout blocks indefinitely. A poll-driven egress loop (the
+    /// macOS userspace stack) uses this so its own timers still fire while no
+    /// guest frame is pending.
+    pub fn poll_guest_readable(&self, timeout_ms: i32) -> Result<bool, TunnelWorkerError> {
+        let mut fds = [libc::pollfd {
+            fd: self.session.stream.as_raw_fd(),
+            events: libc::POLLIN,
+            revents: 0,
+        }];
+        // SAFETY: `fds` is one valid pollfd for the lifetime of the call.
+        let rc = unsafe { libc::poll(fds.as_mut_ptr(), 1, timeout_ms) };
+        if rc < 0 {
+            let err = std::io::Error::last_os_error();
+            if err.kind() == std::io::ErrorKind::Interrupted {
+                return Ok(false);
+            }
+            return Err(TunnelWorkerError::transport(anyhow::Error::new(err)));
+        }
+        if (fds[0].revents & (libc::POLLERR | libc::POLLHUP | libc::POLLNVAL)) != 0 {
+            return Err(TunnelWorkerError::Transport(format!(
+                "guest tunnel session poll failed with revents=0x{:x}",
+                fds[0].revents
+            )));
+        }
+        Ok((fds[0].revents & libc::POLLIN) != 0)
+    }
+
+    /// Read exactly one frame from the guest session and classify it for a
+    /// poll-driven egress loop. Callers must confirm readability first
+    /// (`poll_guest_readable`) so this doesn't block mid-loop.
+    ///
+    /// A packet frame is accounted against the per-session quota; a spent quota
+    /// tells the guest to stop (fail closed) and yields
+    /// [`GuestSessionEvent::Closed`]. A shutdown control frame also yields
+    /// `Closed`; benign control frames yield [`GuestSessionEvent::Control`].
+    pub fn read_guest_session_event(&mut self) -> Result<GuestSessionEvent, TunnelWorkerError> {
+        let frame = self
+            .session
+            .read_frame()
+            .map_err(TunnelWorkerError::transport)?;
+        match frame.header.frame_type {
+            FrameType::Packet => {
+                let payload_len =
+                    u64::try_from(frame.payload.len()).expect("packet length always fits u64");
+                if let Some(outcome) =
+                    self.account_and_check_quota(frame.header.sequence, payload_len)?
+                {
+                    return Ok(GuestSessionEvent::Closed(outcome));
+                }
+                Ok(GuestSessionEvent::Packet {
+                    flow_id: frame.header.flow_id,
+                    sequence: frame.header.sequence,
+                    payload: frame.payload,
+                })
+            }
+            other => match self.handle_control(other, &frame.payload)? {
+                Some(outcome) => Ok(GuestSessionEvent::Closed(outcome)),
+                None => Ok(GuestSessionEvent::Control),
+            },
+        }
+    }
+
+    /// Frame one host-origin IPv4 packet back to the guest. Reverse bytes count
+    /// against the same per-session quota as guest egress; a spent quota tells
+    /// the guest to stop and returns the outcome without delivering the packet.
+    pub fn send_guest_packet(
+        &mut self,
+        flow_id: u32,
+        sequence: u64,
+        payload: Vec<u8>,
+    ) -> Result<Option<TunnelWorkerOutcome>, TunnelWorkerError> {
+        let payload_len = u64::try_from(payload.len()).expect("packet length always fits u64");
+        if let Some(outcome) = self.account_and_check_quota(sequence, payload_len)? {
+            return Ok(Some(outcome));
+        }
+        let bytes = payload.len();
+        self.session
+            .send_packet(0, flow_id, sequence, payload)
+            .map_err(TunnelWorkerError::transport)?;
+        self.stats.host_packets_delivered = self.stats.host_packets_delivered.saturating_add(1);
+        self.stats.host_bytes_delivered =
+            self.stats.host_bytes_delivered.saturating_add(payload_len);
+        self.record_audit(TunnelAuditEvent::PacketDeliveredToGuest {
+            flow_id,
+            sequence,
+            bytes,
+            interface_name: "mvm-smoltcp".to_string(),
+        })?;
+        Ok(None)
+    }
+
+    /// Record one tunnel audit event from a poll-driven egress loop.
+    pub fn record_tunnel_audit(
+        &mut self,
+        event: TunnelAuditEvent,
+    ) -> Result<(), TunnelWorkerError> {
+        self.record_audit(event)
+    }
+
+    /// Tell the guest to stop on a host-side egress failure (Error + Shutdown),
+    /// yielding [`TunnelWorkerOutcome::PacketPathFailed`].
+    pub fn close_for_host_error(
+        &mut self,
+        detail: String,
+    ) -> Result<TunnelWorkerOutcome, TunnelWorkerError> {
+        self.close_for_packet_path_failure(detail)
+    }
+
+    /// Record the terminal `SessionClosed` audit event with final stats.
+    pub fn record_session_closed(
+        &mut self,
+        outcome: TunnelWorkerOutcome,
+    ) -> Result<(), TunnelWorkerError> {
+        self.record_audit(TunnelAuditEvent::SessionClosed {
+            outcome,
+            stats: self.stats,
+        })
+    }
+}
+
+/// One event pulled from the guest session inside a poll-driven egress loop.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum GuestSessionEvent {
+    /// A raw guest IPv4 packet payload, with its framing coordinates.
+    Packet {
+        flow_id: u32,
+        sequence: u64,
+        payload: Vec<u8>,
+    },
+    /// The session ended (guest shutdown or a spent quota); stop with this
+    /// outcome.
+    Closed(TunnelWorkerOutcome),
+    /// A benign control frame (heartbeat/credit) — keep looping.
+    Control,
 }
 
 #[derive(Debug, Default, Clone, PartialEq, Eq)]

--- a/crates/mvm-hostd/src/smoltcp_egress.rs
+++ b/crates/mvm-hostd/src/smoltcp_egress.rs
@@ -1,0 +1,1125 @@
+//! macOS userspace TCP/IP egress for the host-forwarded packet tunnel.
+//!
+//! The guest hands the host raw IPv4 packets over the network tunnel. On Linux
+//! admitted packets are injected into a kernel TUN + NAT. macOS has no
+//! unprivileged kernel NAT, so the host instead terminates the guest's TCP
+//! flows in an in-process `smoltcp` stack and bridges each admitted flow to an
+//! ordinary host socket — no root, no utun.
+//!
+//! Admission is unchanged: every guest packet is gated by
+//! [`L3ForwardPolicy::decide_packet`] before it reaches the stack, exactly like
+//! the raw-L3 decision gate. Only admitted packets are fed to `smoltcp`; a
+//! denied destination is audited and dropped and never opens a socket. The
+//! stack's gateway address mirrors the Linux TUN path (`10.240.0.1/30`, guest
+//! `10.240.0.2`).
+//!
+//! Scope: TCP only. DNS already works via the guest `/etc/hosts` injection
+//! (the tunnel hands the guest pin-consistent entries), so no resolver is
+//! needed here. UDP and ICMP are dropped + audited for now — see the
+//! `follow-up:` notes below.
+
+use std::collections::{HashMap, VecDeque};
+use std::io::{Read, Write};
+use std::net::{IpAddr, Ipv4Addr, Shutdown, SocketAddr, TcpStream};
+use std::os::fd::AsRawFd;
+use std::sync::Arc;
+use std::sync::atomic::{AtomicBool, Ordering};
+use std::time::Duration;
+
+use smoltcp::iface::{Config, Interface, SocketHandle, SocketSet};
+use smoltcp::phy::{Device, DeviceCapabilities, Medium, RxToken, TxToken};
+use smoltcp::socket::tcp;
+use smoltcp::socket::tcp::State;
+use smoltcp::time::Instant;
+use smoltcp::wire::{HardwareAddress, IpAddress, IpCidr, Ipv4Address};
+
+use crate::net_l3::{L3Decision, L3DropReason, L3ForwardPolicy};
+use crate::network_tunnel::{
+    GuestSessionEvent, HostTunnelWorker, TunnelAuditEvent, TunnelAuditSink, TunnelWorkerError,
+    TunnelWorkerOutcome,
+};
+
+/// IPv4 protocol number for TCP.
+const IP_PROTO_TCP: u8 = 6;
+/// Userspace-stack gateway address + prefix, matching the Linux TUN gateway so
+/// the guest sees identical addressing on both host platforms. The guest lives
+/// at `10.240.0.2` inside the same `/30`.
+const GATEWAY_OCTETS: [u8; 4] = [10, 240, 0, 1];
+const GATEWAY_PREFIX_LEN: u8 = 30;
+/// Read/write scratch used when splicing between a guest socket and its host
+/// stream.
+const SPLICE_CHUNK: usize = 8192;
+
+/// Host-internal knobs for the userspace egress stack. Not a wire type — it is
+/// constructed by the worker binary, never deserialized from an untrusted
+/// source.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct EgressConfig {
+    /// Maximum concurrent bridged flows (also caps live `smoltcp` sockets).
+    pub max_flows: usize,
+    /// Per-flow cap on bytes buffered in each direction. Splicing stops filling
+    /// a direction once its buffer reaches this, applying backpressure.
+    pub max_flow_buffer_bytes: usize,
+    /// IP MTU for the stack. Clamp to the negotiated tunnel frame size so a
+    /// single stack packet always fits one tunnel frame.
+    pub mtu: usize,
+    /// Per-flow `smoltcp` receive-ring size.
+    pub tcp_rx_buffer_bytes: usize,
+    /// Per-flow `smoltcp` transmit-ring size.
+    pub tcp_tx_buffer_bytes: usize,
+    /// Bound on the blocking host `connect()` for a newly admitted flow.
+    pub host_connect_timeout: Duration,
+    /// Upper bound on how long a loop iteration waits for a guest frame, so the
+    /// stack's own timers still fire under an idle session.
+    pub idle_poll_timeout: Duration,
+}
+
+impl Default for EgressConfig {
+    fn default() -> Self {
+        Self {
+            max_flows: 64,
+            max_flow_buffer_bytes: 256 * 1024,
+            mtu: 1500,
+            tcp_rx_buffer_bytes: 64 * 1024,
+            tcp_tx_buffer_bytes: 64 * 1024,
+            host_connect_timeout: Duration::from_secs(10),
+            idle_poll_timeout: Duration::from_millis(100),
+        }
+    }
+}
+
+/// In-memory L3 device: its RX queue is fed guest packets, its TX queue is
+/// drained back to the guest. No OS device — `smoltcp` is poll-driven over
+/// these two queues.
+struct TunnelDevice {
+    rx: VecDeque<Vec<u8>>,
+    tx: VecDeque<Vec<u8>>,
+    mtu: usize,
+}
+
+impl TunnelDevice {
+    fn new(mtu: usize) -> Self {
+        Self {
+            rx: VecDeque::new(),
+            tx: VecDeque::new(),
+            mtu,
+        }
+    }
+
+    /// Enqueue one raw IPv4 packet from the guest for the stack to ingest.
+    fn push_guest_packet(&mut self, packet: Vec<u8>) {
+        self.rx.push_back(packet);
+    }
+
+    /// Dequeue one raw IPv4 packet the stack emitted toward the guest.
+    fn pop_host_packet(&mut self) -> Option<Vec<u8>> {
+        self.tx.pop_front()
+    }
+}
+
+impl Device for TunnelDevice {
+    type RxToken<'a> = TunnelRxToken;
+    type TxToken<'a> = TunnelTxToken<'a>;
+
+    fn capabilities(&self) -> DeviceCapabilities {
+        let mut caps = DeviceCapabilities::default();
+        caps.medium = Medium::Ip;
+        caps.max_transmission_unit = self.mtu;
+        caps
+    }
+
+    fn receive(&mut self, _now: Instant) -> Option<(Self::RxToken<'_>, Self::TxToken<'_>)> {
+        let buffer = self.rx.pop_front()?;
+        let rx = TunnelRxToken { buffer };
+        let tx = TunnelTxToken {
+            tx: &mut self.tx,
+            mtu: self.mtu,
+        };
+        Some((rx, tx))
+    }
+
+    fn transmit(&mut self, _now: Instant) -> Option<Self::TxToken<'_>> {
+        Some(TunnelTxToken {
+            tx: &mut self.tx,
+            mtu: self.mtu,
+        })
+    }
+}
+
+struct TunnelRxToken {
+    buffer: Vec<u8>,
+}
+
+impl RxToken for TunnelRxToken {
+    fn consume<R, F>(self, f: F) -> R
+    where
+        F: FnOnce(&[u8]) -> R,
+    {
+        f(&self.buffer)
+    }
+}
+
+struct TunnelTxToken<'a> {
+    tx: &'a mut VecDeque<Vec<u8>>,
+    mtu: usize,
+}
+
+impl TxToken for TunnelTxToken<'_> {
+    fn consume<R, F>(self, len: usize, f: F) -> R
+    where
+        F: FnOnce(&mut [u8]) -> R,
+    {
+        let mut buffer = vec![0_u8; len];
+        let result = f(&mut buffer);
+        // Fail closed on an oversize emit rather than framing a packet the
+        // guest can't accept; a well-behaved stack never exceeds the MTU.
+        if len <= self.mtu {
+            self.tx.push_back(buffer);
+        }
+        result
+    }
+}
+
+/// One admitted guest TCP flow bridged to a host socket. `to_host` carries
+/// guest→host bytes awaiting the host stream; `to_guest` carries host→guest
+/// bytes awaiting the guest socket.
+struct HostBridge {
+    stream: TcpStream,
+    dst: Ipv4Addr,
+    dst_port: u16,
+    flow_id: u32,
+    to_host: VecDeque<u8>,
+    to_guest: VecDeque<u8>,
+    host_eof: bool,
+    host_write_shut: bool,
+    guest_to_host_bytes: u64,
+    host_to_guest_bytes: u64,
+}
+
+/// Userspace TCP egress stack: terminates admitted guest flows and bridges each
+/// to a host socket.
+pub struct SmoltcpEgress {
+    gate: L3ForwardPolicy,
+    config: EgressConfig,
+    device: TunnelDevice,
+    iface: Interface,
+    sockets: SocketSet<'static>,
+    /// Listening sockets, keyed by handle → the port they listen on.
+    listeners: HashMap<SocketHandle, u16>,
+    /// Established bridged flows, keyed by their `smoltcp` socket handle.
+    flows: HashMap<SocketHandle, HostBridge>,
+    /// Distinct admitted destination ports the stack listens on.
+    listen_ports: Vec<u16>,
+    next_flow_id: u32,
+    next_tx_sequence: u64,
+    stop: Option<Arc<AtomicBool>>,
+}
+
+impl SmoltcpEgress {
+    /// Build the stack from the admitted gate. Assigns the gateway address,
+    /// enables any-destination termination (safe because only gate-admitted
+    /// packets are ever fed in), and opens one listener per admitted port.
+    pub fn new(gate: &L3ForwardPolicy, config: EgressConfig) -> Result<Self, TunnelWorkerError> {
+        if config.max_flows == 0 {
+            return Err(TunnelWorkerError::InvalidConfig(
+                "smoltcp egress max_flows must be non-zero",
+            ));
+        }
+        let mtu = config.mtu.max(576);
+        let mut device = TunnelDevice::new(mtu);
+
+        let mut iface_config = Config::new(HardwareAddress::Ip);
+        iface_config.random_seed = random_seed();
+        let mut iface = Interface::new(iface_config, &mut device, Instant::now());
+        iface.update_ip_addrs(|addrs| {
+            let gw = IpCidr::new(
+                IpAddress::Ipv4(Ipv4Address::new(
+                    GATEWAY_OCTETS[0],
+                    GATEWAY_OCTETS[1],
+                    GATEWAY_OCTETS[2],
+                    GATEWAY_OCTETS[3],
+                )),
+                GATEWAY_PREFIX_LEN,
+            );
+            // Single address; the heapless address list has ample room.
+            let _ = addrs.push(gw);
+        });
+        // Terminate flows to any destination the gate already admitted. Non-
+        // admitted packets are dropped at ingest and never reach the stack.
+        iface.set_any_ip(true);
+
+        // Distinct admitted ports, sorted for deterministic listener setup.
+        let mut ports: Vec<u16> = gate
+            .admitted_ipv4_endpoints()
+            .map(|(_ip, port)| port)
+            .collect();
+        ports.sort_unstable();
+        ports.dedup();
+
+        let mut egress = Self {
+            gate: gate.clone(),
+            config,
+            device,
+            iface,
+            sockets: SocketSet::new(Vec::new()),
+            listeners: HashMap::new(),
+            flows: HashMap::new(),
+            listen_ports: ports,
+            next_flow_id: 0,
+            next_tx_sequence: 0,
+            stop: None,
+        };
+        egress.replenish_listeners();
+        Ok(egress)
+    }
+
+    /// Attach a shared stop flag; when set, the loop tells the guest to stop and
+    /// returns fail-closed.
+    pub fn with_stop_flag(mut self, stop: Arc<AtomicBool>) -> Self {
+        self.stop = Some(stop);
+        self
+    }
+
+    /// Drive the stack until the guest shuts down, a quota is spent, or the stop
+    /// flag fires. Reuses the worker's session (guest packet in/out), its audit
+    /// sink, and its per-session quota; the gate gates every packet at ingest.
+    pub fn run<S, A>(
+        &mut self,
+        worker: &mut HostTunnelWorker<S, A>,
+    ) -> Result<TunnelWorkerOutcome, TunnelWorkerError>
+    where
+        S: Read + Write + AsRawFd,
+        A: TunnelAuditSink,
+    {
+        loop {
+            if self.stop_requested() {
+                let outcome = worker.close_for_host_error("smoltcp egress stopped".to_string())?;
+                worker.record_session_closed(outcome.clone())?;
+                return Ok(outcome);
+            }
+
+            let timeout_ms = self.iteration_timeout_ms();
+            if worker.poll_guest_readable(timeout_ms)? {
+                match worker.read_guest_session_event()? {
+                    GuestSessionEvent::Packet {
+                        flow_id,
+                        sequence,
+                        payload,
+                    } => self.ingest_guest_packet(worker, flow_id, sequence, payload)?,
+                    GuestSessionEvent::Closed(outcome) => {
+                        worker.record_session_closed(outcome.clone())?;
+                        return Ok(outcome);
+                    }
+                    GuestSessionEvent::Control => {}
+                }
+            }
+
+            // Ingest freshly-queued guest packets and run stack timers.
+            self.iface
+                .poll(Instant::now(), &mut self.device, &mut self.sockets);
+
+            // Accept new flows and splice bytes on established ones.
+            self.service_flows(worker)?;
+
+            // Flush socket writes into the device TX queue.
+            self.iface
+                .poll(Instant::now(), &mut self.device, &mut self.sockets);
+
+            // Deliver stack output back to the guest.
+            if let Some(outcome) = self.drain_tx_to_guest(worker)? {
+                worker.record_session_closed(outcome.clone())?;
+                return Ok(outcome);
+            }
+        }
+    }
+
+    fn stop_requested(&self) -> bool {
+        self.stop
+            .as_ref()
+            .is_some_and(|flag| flag.load(Ordering::Relaxed))
+    }
+
+    /// Wait a short slice when flows are active (to move bytes promptly) and up
+    /// to the idle timeout otherwise (so timers still fire).
+    fn iteration_timeout_ms(&self) -> i32 {
+        let timeout = if self.flows.is_empty() {
+            self.config.idle_poll_timeout
+        } else {
+            Duration::from_millis(5)
+        };
+        i32::try_from(timeout.as_millis()).unwrap_or(i32::MAX)
+    }
+
+    /// Gate one guest packet and, if admitted, hand it to the stack. A denied
+    /// destination is audited and dropped — no socket is opened.
+    ///
+    /// follow-up: UDP and ICMP to an admitted destination are dropped + audited
+    /// here (TCP-only first slice); they must never be silently forwarded.
+    fn ingest_guest_packet<S, A>(
+        &mut self,
+        worker: &mut HostTunnelWorker<S, A>,
+        flow_id: u32,
+        sequence: u64,
+        payload: Vec<u8>,
+    ) -> Result<(), TunnelWorkerError>
+    where
+        S: Read + Write + AsRawFd,
+        A: TunnelAuditSink,
+    {
+        let bytes = payload.len();
+        match self.gate.decide_packet(&payload) {
+            L3Decision::Allow => {
+                self.device.push_guest_packet(payload);
+                Ok(())
+            }
+            L3Decision::Drop(reason) => {
+                worker.record_tunnel_audit(TunnelAuditEvent::PacketL3Dropped {
+                    flow_id,
+                    sequence,
+                    bytes,
+                    reason,
+                })
+            }
+        }
+    }
+
+    /// Promote accepted listeners into bridges and splice established flows.
+    fn service_flows<S, A>(
+        &mut self,
+        worker: &mut HostTunnelWorker<S, A>,
+    ) -> Result<(), TunnelWorkerError>
+    where
+        S: Read + Write + AsRawFd,
+        A: TunnelAuditSink,
+    {
+        self.promote_accepted_listeners(worker)?;
+        self.pump_established_flows(worker)?;
+        self.replenish_listeners();
+        Ok(())
+    }
+
+    /// A listener that left the `Listen` state received a SYN. Read its intended
+    /// destination, re-check the gate (defence in depth — ingest already
+    /// admitted it), open a host stream, and register a bridge; on deny or a
+    /// failed host connect, reset the guest socket.
+    fn promote_accepted_listeners<S, A>(
+        &mut self,
+        worker: &mut HostTunnelWorker<S, A>,
+    ) -> Result<(), TunnelWorkerError>
+    where
+        S: Read + Write + AsRawFd,
+        A: TunnelAuditSink,
+    {
+        let handles: Vec<SocketHandle> = self.listeners.keys().copied().collect();
+        for handle in handles {
+            let target = {
+                let socket = self.sockets.get::<tcp::Socket>(handle);
+                if socket.is_listening() {
+                    continue;
+                }
+                accepted_target(socket)
+            };
+            self.listeners.remove(&handle);
+            let Some((dst, dst_port)) = target else {
+                // Left Listen without a peer (aborted/closed); reclaim it.
+                self.sockets.remove(handle);
+                continue;
+            };
+
+            match self.gate.decide(dst, IP_PROTO_TCP, Some(dst_port)) {
+                L3Decision::Allow => {
+                    self.open_admitted_flow(worker, handle, dst, dst_port)?;
+                }
+                L3Decision::Drop(reason) => {
+                    self.sockets.get_mut::<tcp::Socket>(handle).abort();
+                    self.sockets.remove(handle);
+                    worker.record_tunnel_audit(TunnelAuditEvent::TcpFlowDenied {
+                        dst,
+                        dst_port,
+                        reason,
+                    })?;
+                }
+            }
+        }
+        Ok(())
+    }
+
+    fn open_admitted_flow<S, A>(
+        &mut self,
+        worker: &mut HostTunnelWorker<S, A>,
+        handle: SocketHandle,
+        dst: Ipv4Addr,
+        dst_port: u16,
+    ) -> Result<(), TunnelWorkerError>
+    where
+        S: Read + Write + AsRawFd,
+        A: TunnelAuditSink,
+    {
+        if self.flows.len() >= self.config.max_flows {
+            // At the flow cap: reset rather than exceed the bound.
+            self.sockets.get_mut::<tcp::Socket>(handle).abort();
+            self.sockets.remove(handle);
+            worker.record_tunnel_audit(TunnelAuditEvent::TcpFlowDenied {
+                dst,
+                dst_port,
+                reason: L3DropReason::PortNotAllowed,
+            })?;
+            return Ok(());
+        }
+
+        let target = SocketAddr::new(IpAddr::V4(dst), dst_port);
+        match TcpStream::connect_timeout(&target, self.config.host_connect_timeout) {
+            Ok(stream) => {
+                stream
+                    .set_nonblocking(true)
+                    .map_err(|e| TunnelWorkerError::PacketPath(e.to_string()))?;
+                let flow_id = self.next_flow_id;
+                self.next_flow_id = self.next_flow_id.wrapping_add(1);
+                self.flows.insert(
+                    handle,
+                    HostBridge {
+                        stream,
+                        dst,
+                        dst_port,
+                        flow_id,
+                        to_host: VecDeque::new(),
+                        to_guest: VecDeque::new(),
+                        host_eof: false,
+                        host_write_shut: false,
+                        guest_to_host_bytes: 0,
+                        host_to_guest_bytes: 0,
+                    },
+                );
+                worker.record_tunnel_audit(TunnelAuditEvent::TcpFlowOpened {
+                    flow_id,
+                    dst,
+                    dst_port,
+                })?;
+            }
+            Err(err) => {
+                // Host unreachable: RST the guest flow. Not a gate denial, so no
+                // TcpFlowDenied — record a drop for observability.
+                self.sockets.get_mut::<tcp::Socket>(handle).abort();
+                self.sockets.remove(handle);
+                tracing::warn!(%dst, dst_port, error = %err, "smoltcp egress host connect failed");
+            }
+        }
+        Ok(())
+    }
+
+    /// Splice every established bridge in both directions, retiring finished
+    /// flows with a `TcpFlowClosed` audit.
+    fn pump_established_flows<S, A>(
+        &mut self,
+        worker: &mut HostTunnelWorker<S, A>,
+    ) -> Result<(), TunnelWorkerError>
+    where
+        S: Read + Write + AsRawFd,
+        A: TunnelAuditSink,
+    {
+        let cap = self.config.max_flow_buffer_bytes;
+        let handles: Vec<SocketHandle> = self.flows.keys().copied().collect();
+        for handle in handles {
+            let finished = {
+                let socket = self.sockets.get_mut::<tcp::Socket>(handle);
+                let bridge = self.flows.get_mut(&handle).expect("bridge for handle");
+                pump_flow(socket, bridge, cap);
+                !socket.is_open()
+            };
+            if finished {
+                let bridge = self.flows.remove(&handle).expect("bridge for handle");
+                self.sockets.remove(handle);
+                worker.record_tunnel_audit(TunnelAuditEvent::TcpFlowClosed {
+                    flow_id: bridge.flow_id,
+                    dst: bridge.dst,
+                    dst_port: bridge.dst_port,
+                    guest_to_host_bytes: bridge.guest_to_host_bytes,
+                    host_to_guest_bytes: bridge.host_to_guest_bytes,
+                })?;
+            }
+        }
+        Ok(())
+    }
+
+    /// Ensure each admitted port has one live listener, up to the flow cap.
+    fn replenish_listeners(&mut self) {
+        let total = self.sockets.iter().count();
+        if total >= self.config.max_flows {
+            return;
+        }
+        let mut budget = self.config.max_flows - total;
+        let ports = self.listen_ports.clone();
+        for port in ports {
+            if budget == 0 {
+                break;
+            }
+            if self.listeners.values().any(|&p| p == port) {
+                continue;
+            }
+            let mut socket = tcp::Socket::new(
+                tcp::SocketBuffer::new(vec![0_u8; self.config.tcp_rx_buffer_bytes]),
+                tcp::SocketBuffer::new(vec![0_u8; self.config.tcp_tx_buffer_bytes]),
+            );
+            // Any local address on this port; `any_ip` accepts the concrete dst.
+            if socket.listen(port).is_err() {
+                continue;
+            }
+            let handle = self.sockets.add(socket);
+            self.listeners.insert(handle, port);
+            budget -= 1;
+        }
+    }
+
+    fn drain_tx_to_guest<S, A>(
+        &mut self,
+        worker: &mut HostTunnelWorker<S, A>,
+    ) -> Result<Option<TunnelWorkerOutcome>, TunnelWorkerError>
+    where
+        S: Read + Write + AsRawFd,
+        A: TunnelAuditSink,
+    {
+        while let Some(packet) = self.device.pop_host_packet() {
+            let sequence = self.next_tx_sequence;
+            self.next_tx_sequence = self.next_tx_sequence.wrapping_add(1);
+            if let Some(outcome) = worker.send_guest_packet(0, sequence, packet)? {
+                return Ok(Some(outcome));
+            }
+        }
+        Ok(None)
+    }
+}
+
+/// The concrete `(dst, port)` a just-accepted listener socket targets, or
+/// `None` if it left `Listen` without an established peer.
+fn accepted_target(socket: &tcp::Socket) -> Option<(Ipv4Addr, u16)> {
+    let local = socket.local_endpoint()?;
+    socket.remote_endpoint()?;
+    let dst = ipv4_of(local.addr)?;
+    Some((dst, local.port))
+}
+
+fn ipv4_of(addr: IpAddress) -> Option<Ipv4Addr> {
+    match IpAddr::from(addr) {
+        IpAddr::V4(v4) => Some(v4),
+        IpAddr::V6(_) => None,
+    }
+}
+
+/// Splice one bridged flow both ways: guest socket ⇄ host stream. Bounded by
+/// `cap` per direction; drops nothing — backpressure falls out of the caps.
+fn pump_flow(socket: &mut tcp::Socket, bridge: &mut HostBridge, cap: usize) {
+    // guest → host buffer
+    while socket.can_recv() && bridge.to_host.len() < cap {
+        let mut chunk = [0_u8; SPLICE_CHUNK];
+        match socket.recv_slice(&mut chunk) {
+            Ok(0) => break,
+            Ok(n) => bridge.to_host.extend(&chunk[..n]),
+            Err(_) => break,
+        }
+    }
+    // host buffer → host stream
+    while !bridge.to_host.is_empty() {
+        let written = {
+            let (head, _) = bridge.to_host.as_slices();
+            bridge.stream.write(head)
+        };
+        match written {
+            Ok(0) => break,
+            Ok(n) => {
+                bridge.guest_to_host_bytes += n as u64;
+                bridge.to_host.drain(..n);
+            }
+            Err(ref e) if e.kind() == std::io::ErrorKind::WouldBlock => break,
+            Err(_) => {
+                bridge.host_eof = true;
+                break;
+            }
+        }
+    }
+    // Guest closed its send side and everything drained → shut host write so
+    // the server sees EOF. Keyed on a genuine peer-FIN state: `may_recv()` is
+    // also false pre-handshake (SynReceived), which must not be mistaken for a
+    // close.
+    let guest_sent_fin = matches!(
+        socket.state(),
+        State::CloseWait | State::Closing | State::LastAck | State::TimeWait | State::Closed
+    );
+    if guest_sent_fin && bridge.to_host.is_empty() && !bridge.host_write_shut {
+        let _ = bridge.stream.shutdown(Shutdown::Write);
+        bridge.host_write_shut = true;
+    }
+    // host stream → guest buffer
+    if !bridge.host_eof && bridge.to_guest.len() < cap {
+        let mut chunk = [0_u8; SPLICE_CHUNK];
+        match bridge.stream.read(&mut chunk) {
+            Ok(0) => bridge.host_eof = true,
+            Ok(n) => bridge.to_guest.extend(&chunk[..n]),
+            Err(ref e) if e.kind() == std::io::ErrorKind::WouldBlock => {}
+            Err(_) => bridge.host_eof = true,
+        }
+    }
+    // guest buffer → guest socket
+    while socket.can_send() && !bridge.to_guest.is_empty() {
+        let sent = {
+            let (head, _) = bridge.to_guest.as_slices();
+            socket.send_slice(head)
+        };
+        match sent {
+            Ok(0) => break,
+            Ok(n) => {
+                bridge.host_to_guest_bytes += n as u64;
+                bridge.to_guest.drain(..n);
+            }
+            Err(_) => break,
+        }
+    }
+    // Host closed and everything forwarded → close the guest send side.
+    if bridge.host_eof && bridge.to_guest.is_empty() && socket.may_send() {
+        socket.close();
+    }
+}
+
+fn random_seed() -> u64 {
+    std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .map(|d| d.as_nanos() as u64)
+        .unwrap_or(0x9E37_79B9_7F4A_7C15)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::net_l3::L3ForwardPolicy;
+    use crate::network_tunnel::{
+        ExpectedTunnelSession, HostTunnelWorker, NoopTunnelAuditSink, TunnelPacketPolicy,
+        TunnelWorkerConfig, TunnelWorkerLimits,
+    };
+    use mvm_core::policy::dns_pin::{DnsPin, DnsPinRegistry};
+    use mvm_core::policy::network_policy::{HostPort, NetworkPolicy};
+    use mvm_core::protocol::network_tunnel::{
+        NETWORK_TUNNEL_VERSION, TunnelControlMessage, TunnelCreditUpdate, TunnelFeatures,
+        TunnelHello, TunnelNetworkConfig, TunnelShutdownReason,
+    };
+    use smoltcp::iface::{
+        Config as IfaceConfig, Interface as GuestIface, SocketSet as GuestSockets,
+    };
+    use smoltcp::socket::tcp as gtcp;
+    use smoltcp::wire::{IpCidr as WireCidr, Ipv4Address as WireV4};
+    use std::net::TcpListener;
+    use std::os::unix::net::UnixStream;
+    use std::sync::atomic::AtomicBool;
+
+    fn gate_for(host: &str, port: u16, pinned: &[&str]) -> L3ForwardPolicy {
+        let policy = NetworkPolicy::allow_list(vec![HostPort::new(host, port)]);
+        let mut pins = DnsPinRegistry::new();
+        pins.add(DnsPin::at(
+            host,
+            pinned.iter().map(|s| s.parse().expect("ip")).collect(),
+            "2026-05-15T12:00:00Z",
+            "2026-05-15T13:00:00Z",
+        ));
+        L3ForwardPolicy::new(policy, pins)
+    }
+
+    #[test]
+    fn new_opens_one_listener_per_distinct_admitted_port() {
+        let policy = NetworkPolicy::allow_list(vec![
+            HostPort::new("a.test", 443),
+            HostPort::new("b.test", 443),
+            HostPort::new("c.test", 8443),
+        ]);
+        let mut pins = DnsPinRegistry::new();
+        pins.add(DnsPin::at(
+            "a.test",
+            vec!["10.0.0.1".parse().unwrap()],
+            "2026-05-15T12:00:00Z",
+            "2026-05-15T13:00:00Z",
+        ));
+        pins.add(DnsPin::at(
+            "b.test",
+            vec!["10.0.0.2".parse().unwrap()],
+            "2026-05-15T12:00:00Z",
+            "2026-05-15T13:00:00Z",
+        ));
+        pins.add(DnsPin::at(
+            "c.test",
+            vec!["10.0.0.3".parse().unwrap()],
+            "2026-05-15T12:00:00Z",
+            "2026-05-15T13:00:00Z",
+        ));
+        let gate = L3ForwardPolicy::new(policy, pins);
+        let egress = SmoltcpEgress::new(&gate, EgressConfig::default()).unwrap();
+        // Two distinct ports (443, 8443) → two listeners.
+        assert_eq!(egress.listen_ports, vec![443, 8443]);
+        assert_eq!(egress.listeners.len(), 2);
+    }
+
+    #[test]
+    fn new_rejects_zero_max_flows() {
+        let gate = gate_for("api.test", 443, &["10.0.0.9"]);
+        match SmoltcpEgress::new(
+            &gate,
+            EgressConfig {
+                max_flows: 0,
+                ..EgressConfig::default()
+            },
+        ) {
+            Err(TunnelWorkerError::InvalidConfig(_)) => {}
+            other => panic!(
+                "zero max_flows must be rejected, got {:?}",
+                other.map(|_| ())
+            ),
+        }
+    }
+
+    #[test]
+    fn device_rx_feeds_stack_and_tx_drains_to_guest() {
+        let mut dev = TunnelDevice::new(1500);
+        assert!(dev.pop_host_packet().is_none());
+        dev.push_guest_packet(vec![1, 2, 3]);
+        // The RX token yields exactly the pushed bytes.
+        let (rx, _tx) = dev.receive(Instant::now()).expect("rx token");
+        rx.consume(|bytes| assert_eq!(bytes, &[1, 2, 3]));
+        // A TX token over the MTU is dropped (fail closed); within it enqueues.
+        let tx = dev.transmit(Instant::now()).expect("tx token");
+        tx.consume(4, |buf| buf.copy_from_slice(&[9, 8, 7, 6]));
+        assert_eq!(dev.pop_host_packet(), Some(vec![9, 8, 7, 6]));
+    }
+
+    fn expected() -> ExpectedTunnelSession {
+        ExpectedTunnelSession {
+            tenant_id: "tenant-a".to_string(),
+            vm_id: "vm-1".to_string(),
+            boot_id: "boot-1".to_string(),
+            session_nonce: "nonce-1".to_string(),
+            maximum_frame_size: 1500,
+            accepted_features: TunnelFeatures {
+                ipv4: true,
+                split_control_stream: true,
+                ..TunnelFeatures::default()
+            },
+        }
+    }
+
+    fn hello() -> TunnelHello {
+        TunnelHello {
+            protocol_version: NETWORK_TUNNEL_VERSION,
+            tenant_id: "tenant-a".to_string(),
+            vm_id: "vm-1".to_string(),
+            boot_id: "boot-1".to_string(),
+            session_nonce: "nonce-1".to_string(),
+            guest_agent_version: "guest-netd/1".to_string(),
+            requested_features: TunnelFeatures {
+                ipv4: true,
+                split_control_stream: true,
+                ..TunnelFeatures::default()
+            },
+            maximum_frame_size: 1500,
+        }
+    }
+
+    fn network_config() -> TunnelNetworkConfig {
+        TunnelNetworkConfig {
+            interface_name: "mvm-net0".to_string(),
+            guest_ipv4: "10.240.0.2".parse().unwrap(),
+            prefix_len: 30,
+            gateway_ipv4: "10.240.0.1".parse().unwrap(),
+            dns_servers: vec!["10.240.0.1".parse().unwrap()],
+            mtu: 1500,
+            host_entries: Vec::new(),
+        }
+    }
+
+    fn worker_config(gate: L3ForwardPolicy) -> TunnelWorkerConfig {
+        TunnelWorkerConfig {
+            expected_session: expected(),
+            network_config: network_config(),
+            initial_credit: TunnelCreditUpdate {
+                flow_id: 0,
+                bytes: 1_000_000,
+                packets: 100_000,
+            },
+            packet_policy: TunnelPacketPolicy::L3Forward {
+                gate,
+                interface_name: Some("mvm-smoltcp".to_string()),
+            },
+            limits: TunnelWorkerLimits {
+                max_packets: 1_000_000,
+                max_bytes: 64 * 1024 * 1024,
+            },
+        }
+    }
+
+    fn poll_readable(fd: std::os::fd::RawFd, timeout_ms: i32) -> bool {
+        let mut fds = [libc::pollfd {
+            fd,
+            events: libc::POLLIN,
+            revents: 0,
+        }];
+        let rc = unsafe { libc::poll(fds.as_mut_ptr(), 1, timeout_ms) };
+        rc > 0 && (fds[0].revents & libc::POLLIN) != 0
+    }
+
+    /// End-to-end: a guest smoltcp client connects through the host
+    /// `SmoltcpEgress` to a real OS TCP server at the pinned destination,
+    /// sends a request, and receives the server's response — proving one
+    /// admitted TCP flow bridged to a host socket.
+    #[test]
+    fn admitted_tcp_flow_reaches_host_server_and_replies() {
+        const REQUEST: &[u8] = b"ping-over-smoltcp";
+        const RESPONSE: &[u8] = b"pong-from-host";
+
+        // Real OS server at the pinned destination.
+        let listener = TcpListener::bind("127.0.0.1:0").unwrap();
+        let server_addr = listener.local_addr().unwrap();
+        let server_port = server_addr.port();
+        let server = std::thread::spawn(move || {
+            let (mut conn, _) = listener.accept().unwrap();
+            let mut buf = vec![0_u8; REQUEST.len()];
+            conn.read_exact(&mut buf).unwrap();
+            assert_eq!(buf, REQUEST);
+            conn.write_all(RESPONSE).unwrap();
+            conn.flush().unwrap();
+            // Hold the connection open until the client is done reading.
+            let mut sink = Vec::new();
+            let _ = conn.read_to_end(&mut sink);
+        });
+
+        let gate = gate_for("server.test", server_port, &["127.0.0.1"]);
+        let (guest_raw, host_raw) = UnixStream::pair().unwrap();
+
+        // Host: worker + smoltcp egress.
+        let host_gate = gate.clone();
+        let host = std::thread::spawn(move || {
+            let mut worker = HostTunnelWorker::new(
+                host_raw,
+                NoopTunnelAuditSink,
+                worker_config(host_gate.clone()),
+            )
+            .unwrap();
+            worker.bootstrap(1, 2, 3).unwrap();
+            let mut egress = SmoltcpEgress::new(
+                &host_gate,
+                EgressConfig {
+                    mtu: 1500,
+                    ..EgressConfig::default()
+                },
+            )
+            .unwrap();
+            let outcome = egress.run(&mut worker).unwrap();
+            assert!(matches!(
+                outcome,
+                TunnelWorkerOutcome::GuestShutdown(TunnelShutdownReason::GuestStopping)
+            ));
+        });
+
+        // Guest: negotiate the tunnel, then run a smoltcp client that connects
+        // to the pinned destination and speaks over the tunnel.
+        let mut session =
+            mvm_guest::network_tunnel::GuestNetworkTunnelSession::from_stream(guest_raw);
+        session.negotiate(hello(), 1).unwrap();
+        session.recv_network_config().unwrap();
+        session.recv_control().unwrap(); // initial credit
+
+        let mut guest_dev = TunnelDevice::new(1500);
+        let mut gcfg = IfaceConfig::new(HardwareAddress::Ip);
+        gcfg.random_seed = 0xC0FF_EE00;
+        let mut giface = GuestIface::new(gcfg, &mut guest_dev, Instant::now());
+        giface.update_ip_addrs(|addrs| {
+            let _ = addrs.push(WireCidr::new(
+                IpAddress::Ipv4(WireV4::new(10, 240, 0, 2)),
+                30,
+            ));
+        });
+        giface
+            .routes_mut()
+            .add_default_ipv4_route(WireV4::new(10, 240, 0, 1))
+            .unwrap();
+
+        let mut gsockets = GuestSockets::new(Vec::new());
+        let client = gsockets.add(gtcp::Socket::new(
+            gtcp::SocketBuffer::new(vec![0_u8; 64 * 1024]),
+            gtcp::SocketBuffer::new(vec![0_u8; 64 * 1024]),
+        ));
+        gsockets
+            .get_mut::<gtcp::Socket>(client)
+            .connect(
+                giface.context(),
+                (WireV4::new(127, 0, 0, 1), server_port),
+                49_152,
+            )
+            .unwrap();
+
+        let mut sent = false;
+        let mut received = Vec::new();
+        let mut tx_seq = 0_u64;
+        let fd = session.as_raw_fd();
+        let deadline = std::time::Instant::now() + Duration::from_secs(15);
+
+        loop {
+            assert!(
+                std::time::Instant::now() < deadline,
+                "flow did not complete"
+            );
+            giface.poll(Instant::now(), &mut guest_dev, &mut gsockets);
+
+            while let Some(pkt) = guest_dev.pop_host_packet() {
+                session.send_packet(0, 0, tx_seq, pkt).unwrap();
+                tx_seq += 1;
+            }
+
+            if poll_readable(fd, 5)
+                && let Ok(frame) = session.recv_packet()
+            {
+                guest_dev.push_guest_packet(frame.payload);
+            }
+
+            let socket = gsockets.get_mut::<gtcp::Socket>(client);
+            if socket.can_send() && !sent {
+                socket.send_slice(REQUEST).unwrap();
+                sent = true;
+            }
+            while socket.can_recv() {
+                let mut chunk = [0_u8; 1024];
+                match socket.recv_slice(&mut chunk) {
+                    Ok(0) | Err(_) => break,
+                    Ok(n) => received.extend_from_slice(&chunk[..n]),
+                }
+            }
+            if received.len() >= RESPONSE.len() {
+                break;
+            }
+        }
+
+        assert_eq!(received, RESPONSE);
+
+        // Close the client and tear the tunnel down.
+        gsockets.get_mut::<gtcp::Socket>(client).close();
+        for _ in 0..50 {
+            giface.poll(Instant::now(), &mut guest_dev, &mut gsockets);
+            while let Some(pkt) = guest_dev.pop_host_packet() {
+                session.send_packet(0, 0, tx_seq, pkt).unwrap();
+                tx_seq += 1;
+            }
+            if poll_readable(fd, 5)
+                && let Ok(frame) = session.recv_packet()
+            {
+                guest_dev.push_guest_packet(frame.payload);
+            }
+        }
+
+        session
+            .send_control(
+                TunnelControlMessage::Shutdown(TunnelShutdownReason::GuestStopping),
+                0,
+                0,
+                tx_seq,
+            )
+            .unwrap();
+
+        host.join().unwrap();
+        server.join().unwrap();
+    }
+
+    /// A denied (unpinned) destination opens no host connection and is audited
+    /// as a drop.
+    #[test]
+    fn denied_destination_opens_no_host_connection() {
+        use std::sync::{Arc, Mutex};
+
+        #[derive(Clone, Default)]
+        struct SharedAudit(Arc<Mutex<Vec<TunnelAuditEvent>>>);
+        impl TunnelAuditSink for SharedAudit {
+            type Error = std::convert::Infallible;
+            fn record(&mut self, event: TunnelAuditEvent) -> Result<(), Self::Error> {
+                self.0.lock().unwrap().push(event);
+                Ok(())
+            }
+        }
+
+        // A server exists, but the gate pins a DIFFERENT address, so the guest's
+        // destination is unadmitted.
+        let listener = TcpListener::bind("127.0.0.1:0").unwrap();
+        let server_port = listener.local_addr().unwrap().port();
+        let never_connected = Arc::new(AtomicBool::new(true));
+        let flag = never_connected.clone();
+        let server = std::thread::spawn(move || {
+            listener
+                .set_nonblocking(true)
+                .expect("nonblocking listener");
+            let start = std::time::Instant::now();
+            while start.elapsed() < Duration::from_secs(2) {
+                if listener.accept().is_ok() {
+                    flag.store(false, Ordering::Relaxed);
+                    return;
+                }
+                std::thread::sleep(Duration::from_millis(20));
+            }
+        });
+
+        // Pin an address the guest will NOT target (guest targets 127.0.0.1).
+        let gate = gate_for("server.test", server_port, &["10.13.13.13"]);
+        let audit = SharedAudit::default();
+        let events = audit.0.clone();
+        let (guest_raw, host_raw) = UnixStream::pair().unwrap();
+
+        let host_gate = gate.clone();
+        let host = std::thread::spawn(move || {
+            let mut worker =
+                HostTunnelWorker::new(host_raw, audit, worker_config(host_gate.clone())).unwrap();
+            worker.bootstrap(1, 2, 3).unwrap();
+            let mut egress = SmoltcpEgress::new(&host_gate, EgressConfig::default()).unwrap();
+            egress.run(&mut worker).unwrap();
+        });
+
+        let mut session =
+            mvm_guest::network_tunnel::GuestNetworkTunnelSession::from_stream(guest_raw);
+        session.negotiate(hello(), 1).unwrap();
+        session.recv_network_config().unwrap();
+        session.recv_control().unwrap();
+
+        // A hand-built IPv4/TCP SYN to the unadmitted destination.
+        let mut syn = vec![0_u8; 40];
+        syn[0] = 0x45; // v4, IHL 5
+        syn[9] = IP_PROTO_TCP;
+        syn[16..20].copy_from_slice(&Ipv4Addr::new(127, 0, 0, 1).octets());
+        syn[22..24].copy_from_slice(&server_port.to_be_bytes());
+        session.send_packet(0, 0, 0, syn).unwrap();
+
+        // Give the host loop time to gate + audit the drop.
+        std::thread::sleep(Duration::from_millis(200));
+        session
+            .send_control(
+                TunnelControlMessage::Shutdown(TunnelShutdownReason::GuestStopping),
+                0,
+                0,
+                1,
+            )
+            .unwrap();
+
+        host.join().unwrap();
+        server.join().unwrap();
+
+        assert!(
+            never_connected.load(Ordering::Relaxed),
+            "no host connection may open for a denied destination"
+        );
+        let recorded = events.lock().unwrap();
+        assert!(
+            recorded.iter().any(|e| matches!(
+                e,
+                TunnelAuditEvent::PacketL3Dropped {
+                    reason: L3DropReason::UnpinnedDst,
+                    ..
+                }
+            )),
+            "a denied destination must be audited as an L3 drop"
+        );
+        assert!(
+            !recorded
+                .iter()
+                .any(|e| matches!(e, TunnelAuditEvent::TcpFlowOpened { .. })),
+            "no TCP flow may open for a denied destination"
+        );
+    }
+}

--- a/deny.toml
+++ b/deny.toml
@@ -73,6 +73,14 @@ name = "ring"
 expression = "MIT AND ISC AND OpenSSL"
 license-files = [{ path = "LICENSE", hash = 0xbd0eed23 }]
 
+# Admitted dependency note: `smoltcp` (0BSD, in the allow list above) is the
+# macOS userspace TCP/IP stack that terminates guest flows for the
+# vsock packet tunnel where no unprivileged kernel NAT exists. It is
+# pure-Rust, no_std/heapless, upstream-fuzzed, and carries only leaf deps
+# (byteorder/managed/heapless/bitflags). It lands on untrusted guest packet
+# bytes, so a mature audited stack beats a hand-rolled one. Its `bitflags 1.x`
+# pull is already covered by the skip entry below.
+
 # ── Bans ──────────────────────────────────────────────────────────
 [bans]
 # Multiple major versions of the same crate inflate the binary,

--- a/xtask/src/check_duplicate_majors.rs
+++ b/xtask/src/check_duplicate_majors.rs
@@ -32,6 +32,9 @@ const ALLOWLIST: &[&str] = &[
     "base64",
     "bitflags",
     "cpufeatures",
+    // logging facade pulled transitively by smoltcp's heapless; the second
+    // major is benign — there is no defmt consumer in the build.
+    "defmt",
     "der-parser",
     "event-listener",
     "getrandom",


### PR DESCRIPTION
## Plan 236 Phase 2A — macOS userspace egress forwarder (dev-grade TCP slice)

Follow-up to the Linux raw-L3 tunnel (#1634). Gives an admitted workload on **macOS** (vsock-only HVF) real TCP egress over the same vsock packet tunnel — **without root**.

### Why a userspace stack (not utun + pf)
The Linux host forwarder uses `/dev/net/tun` + kernel NAT (needs `CAP_NET_ADMIN`). macOS has no unprivileged kernel NAT — `pfctl` needs root, which would force `sudo machine run`. So the host instead terminates the guest's TCP flows in a userspace TCP/IP stack (**`smoltcp`**) and bridges each admitted flow to an ordinary (unprivileged) host socket. No root, no `utun`.

### What's here
- New `#[cfg(target_os = "macos")]` `mvm_hostd::smoltcp_egress`: a `smoltcp` interface (gateway `10.240.0.1/30`) fed by guest raw-IP frames from the tunnel session; a poll-driven loop that gates every new flow with the existing `L3ForwardPolicy` (allow iff dst pinned+port), opens a host `TcpStream` to the real destination for admitted flows, splices bytes both ways, and frames replies back to the guest.
- Reuses the **same seam** as Linux — worker session (`send_packet`/`recv_packet`), `L3ForwardPolicy`, `TunnelWorkerLimits` (per-session quota, fail-closed), and audit (`TcpFlowOpened`/`TcpFlowClosed`/`TcpFlowDenied`). The worker, gate, guest, and wire are unchanged; only the macOS host-device impl is new. The Linux arm is byte-for-byte untouched.
- Adds `smoltcp = 0.13` (macOS-target dep only; pure-Rust, `no_std`, 0BSD, minimal leaf deps — introduces no new duplicate-major).

### Scope (honest, dev-grade first slice)
- **TCP egress only.** DNS already works via the guest `/etc/hosts` pin injection (no resolver needed).
- **UDP and ICMP** to an admitted destination are **dropped + audited** (never silently forwarded) — tracked follow-ups.
- **No fuzz harness yet.** Packet ingest is fail-closed (`parse_ipv4_dst_and_l4`), but this is a new untrusted-input parser and warrants a `cargo-fuzz` target (claim 5) as a follow-up before it's called production-hardened. macOS is the dev tier, so this lands as a working dev-grade forwarder, not a production subsystem.

### Verification
Note: CI's Lint+Test run on Linux and do **not** exercise `#[cfg(macos)]` code, so this was verified **locally on macOS**: nightly `rustfmt`, `clippy --workspace --all-targets -D warnings`, `nextest --workspace` (6700 pass, incl. an end-to-end test bridging a real admitted TCP flow through smoltcp to a host `TcpListener`, plus a denied-dst test proving no host connection opens), xtask gates (`check-no-spec-refs`, `check-forbidden-deps`, `check-core-runtime-free`), and `cargo zigbuild --workspace --lib/--bins --target x86_64-unknown-linux-gnu` confirming the Linux build is unaffected.
