### PR TITLE
Verify published workload kernel release assets

### DIFF
--- a/packaging/release/verify-release-assets.sh
+++ b/packaging/release/verify-release-assets.sh
@@ -20,6 +20,7 @@ ASSETS_DIR=""
 TARGETS="aarch64-apple-darwin x86_64-unknown-linux-gnu aarch64-unknown-linux-gnu"
 # Keep in lockstep with the release.yml `builder-vm-image` matrix.
 BUILDER_ARCHES="aarch64 x86_64"
+KERNEL_ARCHES="aarch64 x86_64"
 RUNTIME_ARCHES="aarch64 x86_64"
 DO_COSIGN=0
 EXPECT_VERSION=""
@@ -29,6 +30,7 @@ while [ $# -gt 0 ]; do
     --assets-dir)     ASSETS_DIR="$2"; shift 2 ;;
     --targets)        TARGETS="$2"; shift 2 ;;
     --builder-arches) BUILDER_ARCHES="$2"; shift 2 ;;
+    --kernel-arches)  KERNEL_ARCHES="$2"; shift 2 ;;
     --runtime-arches) RUNTIME_ARCHES="$2"; shift 2 ;;
     --cosign)         DO_COSIGN=1; shift ;;
     # Assert the packaged binary reports this version. Only the target that
@@ -133,6 +135,27 @@ for target in $TARGETS; do
     fi
     rm -rf "$tmp"
   fi
+done
+
+# Slim workload-kernel release assets are consumed directly by
+# `mvmctl build kernel build --source download`, and installed-binary
+# cold-cache `--kernel-pin` now reuses that same verified fetch path. So a
+# release is incomplete unless each declared kernel arch ships both the
+# workload `vmlinux` asset and the matching per-arch checksums manifest entry.
+for arch in $KERNEL_ARCHES; do
+  workload_kernel="$ASSETS_DIR/vmlinux-${arch}-workload"
+  kernel_checks="$ASSETS_DIR/kernel-${arch}-checksums-sha256.txt"
+
+  [ -f "$workload_kernel" ] || { fail "[$arch] workload kernel missing: vmlinux-${arch}-workload"; continue; }
+  [ -f "$kernel_checks" ] || { fail "[$arch] kernel checksums manifest missing: kernel-${arch}-checksums-sha256.txt"; continue; }
+
+  want=$(awk -v n="vmlinux-${arch}-workload" '$2 == n { print $1 }' "$kernel_checks" | head -1)
+  if [ -z "$want" ]; then
+    fail "[$arch] vmlinux-${arch}-workload not listed in kernel-${arch}-checksums-sha256.txt"
+    continue
+  fi
+  got=$(sha256_of "$workload_kernel")
+  [ "$want" = "$got" ] || fail "[$arch] workload kernel sha256 mismatch: recorded=$want actual=$got"
 done
 
 # The SBOM ships signed alongside the binaries on every release.

--- a/packaging/release/verify-release-assets.test.sh
+++ b/packaging/release/verify-release-assets.test.sh
@@ -11,6 +11,7 @@ HERE="$(cd "$(dirname "$0")" && pwd)"
 SCRIPT="$HERE/verify-release-assets.sh"
 TARGETS="aarch64-apple-darwin x86_64-unknown-linux-gnu aarch64-unknown-linux-gnu"
 BUILDER_ARCHES="aarch64 x86_64"
+KERNEL_ARCHES="aarch64 x86_64"
 RUNTIME_ARCHES="aarch64 x86_64"
 
 sha256_of() {
@@ -38,6 +39,11 @@ build_valid_fixture() {
     sha256_of "$dir/mvmctl-$t.tar.gz" > "$dir/mvmctl-$t.tar.gz.sha256"
     printf 'bundle\n' > "$dir/mvmctl-$t.tar.gz.bundle"
     echo "$(sha256_of "$dir/mvmctl-$t.tar.gz")  mvmctl-$t.tar.gz" >> "$dir/checksums-sha256.txt"
+  done
+  for arch in $KERNEL_ARCHES; do
+    printf 'kernel-%s-workload\n' "$arch" > "$dir/vmlinux-$arch-workload"
+    : > "$dir/kernel-$arch-checksums-sha256.txt"
+    echo "$(sha256_of "$dir/vmlinux-$arch-workload")  vmlinux-$arch-workload" >> "$dir/kernel-$arch-checksums-sha256.txt"
   done
   printf '{"sbom":true}\n' > "$dir/sbom.cdx.json"
   printf 'bundle\n' > "$dir/sbom.cdx.json.bundle"
@@ -115,6 +121,24 @@ rm -rf "$d"
 d="$(build_valid_fixture)"
 printf 'tampered\n' > "$d/default-microvm-aarch64.pack-manifest.json"
 if run "$d"; then bad "checksum-mismatched runtime pack must fail"; else ok "checksum-mismatched runtime pack fails closed"; fi
+rm -rf "$d"
+
+# 9. Missing kernel checksums manifest → fail closed.
+d="$(build_valid_fixture)"
+rm -f "$d/kernel-aarch64-checksums-sha256.txt"
+if run "$d"; then bad "missing kernel checksums manifest must fail"; else ok "missing kernel checksums manifest fails closed"; fi
+rm -rf "$d"
+
+# 10. Workload kernel present but absent from per-arch kernel manifest → fail.
+d="$(build_valid_fixture)"
+: > "$d/kernel-x86_64-checksums-sha256.txt"
+if run "$d"; then bad "unlisted workload kernel must fail"; else ok "unlisted workload kernel fails closed"; fi
+rm -rf "$d"
+
+# 11. Workload kernel checksum mismatch → fail closed.
+d="$(build_valid_fixture)"
+printf 'tampered-kernel\n' > "$d/vmlinux-aarch64-workload"
+if run "$d"; then bad "checksum-mismatched workload kernel must fail"; else ok "checksum-mismatched workload kernel fails closed"; fi
 rm -rf "$d"
 
 echo "verify-release-assets pack-gate: $PASS passed, $FAILN failed"


### PR DESCRIPTION
## Summary
- teach the release-asset verifier to require per-arch workload kernel assets and their matching checksum manifests
- fail closed when a workload kernel is missing, unlisted, or hash-mismatched
- extend the verifier fixture tests to cover the missing-manifest failure mode that is currently blocking late macOS Plan 236 proof

## Validation
- bash packaging/release/verify-release-assets.test.sh
- shellcheck -S warning packaging/release/verify-release-assets.sh packaging/release/verify-release-assets.test.sh
