### PR TITLE
test(net-tunnel): fuzz the raw-L3 egress gate packet parser (claim 5)

### DIFF
--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -416,6 +416,19 @@ jobs:
         # path, not a panic).
         run: cargo fuzz run fuzz_packet_parse -- -max_total_time="$DURATION"
 
+      - name: Fuzz raw-L3 egress gate packet parse (host-side)
+        working-directory: crates/mvm-hostd
+        env:
+          DURATION: ${{ steps.duration.outputs.secs }}
+          RUSTUP_TOOLCHAIN: nightly-2026-06-11
+        # The raw-L3 egress gate parses every guest IPv4 packet before any
+        # host forwarding decision — the first parse on the vsock-tunnel
+        # egress path, on attacker-influenced bytes (claim 5). "Never panic on
+        # any input": the parser fails closed to None on malformed/short/
+        # non-IPv4 bytes, and the gate decision never panics for any accepted
+        # or rejected packet.
+        run: cargo fuzz run fuzz_l3_gate -- -max_total_time="$DURATION"
+
       - name: Fuzz runtime recording (SDK trace)
         working-directory: crates/mvm-sdk
         env:

--- a/crates/mvm-hostd/fuzz/Cargo.toml
+++ b/crates/mvm-hostd/fuzz/Cargo.toml
@@ -26,6 +26,9 @@ time = ">=0.3, <0.3.48"
 [dependencies.mvm-hostd]
 path = ".."
 
+[dependencies.mvm-core]
+path = "../../mvm-core"
+
 # Fuzz the gateway packet parser + payload rebuilder.
 # `packet::parse` runs on every frame the guest puts on the wire (the
 # first real parse on that path); `rebuild_with_payload` re-serializes
@@ -36,6 +39,18 @@ path = ".."
 [[bin]]
 name = "fuzz_packet_parse"
 path = "fuzz_targets/fuzz_packet_parse.rs"
+test = false
+doc = false
+bench = false
+
+# Fuzz the raw-L3 egress gate's guest-packet parser + decision.
+# `parse_ipv4_dst_and_l4` is the first parse on the vsock-tunnel egress path
+# (untrusted guest bytes, claim 5); `decide_packet` runs the full gate
+# decision over the admission allow-set. Harness goal: never panic on any
+# input; the parser fails closed to `None` on garbage.
+[[bin]]
+name = "fuzz_l3_gate"
+path = "fuzz_targets/fuzz_l3_gate.rs"
 test = false
 doc = false
 bench = false

--- a/crates/mvm-hostd/fuzz/fuzz_targets/fuzz_l3_gate.rs
+++ b/crates/mvm-hostd/fuzz/fuzz_targets/fuzz_l3_gate.rs
@@ -1,0 +1,36 @@
+// The raw-L3 egress gate parses every guest IPv4 packet before any host
+// forwarding decision — the first parse on the vsock-tunnel egress path, on
+// attacker-influenced bytes. "Never panic on any input": the parser fails
+// closed to `None` on malformed/short/non-IPv4 bytes, and the full gate
+// decision never panics for any accepted or rejected packet.
+
+#![no_main]
+
+use std::net::{IpAddr, Ipv4Addr};
+use std::sync::LazyLock;
+
+use libfuzzer_sys::fuzz_target;
+use mvm_core::policy::dns_pin::{DnsPin, DnsPinRegistry};
+use mvm_core::policy::network_policy::{HostPort, NetworkPolicy};
+use mvm_hostd::net_l3::{L3ForwardPolicy, parse_ipv4_dst_and_l4};
+
+// One admitted host pinned to a fixed IPv4 so the decision path exercises the
+// allow-set lookup for arbitrary parsed destinations, not just the drop path.
+static GATE: LazyLock<L3ForwardPolicy> = LazyLock::new(|| {
+    let policy = NetworkPolicy::allow_list(vec![HostPort::new("example.com", 443)]);
+    let mut pins = DnsPinRegistry::new();
+    pins.add(DnsPin::at(
+        "example.com",
+        vec![IpAddr::V4(Ipv4Addr::new(203, 0, 113, 7))],
+        "2030-01-01T00:00:00Z",
+        "2030-01-01T01:00:00Z",
+    ));
+    L3ForwardPolicy::new(policy, pins)
+});
+
+fuzz_target!(|data: &[u8]| {
+    // Raw destination/L4 parser on arbitrary bytes: fail closed, never panic.
+    let _ = parse_ipv4_dst_and_l4(data);
+    // Full gate decision on arbitrary bytes: never panic.
+    let _ = GATE.decide_packet(data);
+});


### PR DESCRIPTION
## Fuzz the raw-L3 egress gate packet parser (claim 5)

Closes the fuzz-coverage follow-up flagged in #1639: the raw-L3 egress data plane (#1634 Linux, #1639 macOS) added a new untrusted-input parser — `mvm_hostd::net_l3::parse_ipv4_dst_and_l4`, which parses **every guest IPv4 packet** before any host forwarding decision, on both the Linux and macOS egress paths. That's the first parse on the vsock-tunnel egress surface and belongs under claim 5.

### What's here
- New `fuzz_l3_gate` cargo-fuzz target in the existing (workspace-excluded) `crates/mvm-hostd/fuzz` crate. It drives arbitrary bytes through `parse_ipv4_dst_and_l4` (the raw dst/L4 parser) and `L3ForwardPolicy::decide_packet` (the full gate decision over a fixed admission allow-set). Contract: **never panic on any input** — the parser fails closed to `None` on malformed/short/non-IPv4 bytes, and the decision never panics for any accepted or rejected packet.
- A `security.yml` fuzz-lane step mirroring its sibling `fuzz_packet_parse` (same pinned `nightly-2026-06-11`, runs on the nightly/tag fuzz lane).

### Verification
Built and ran locally under cargo-fuzz: **165k+ runs, 0 crashes** (coverage stabilized). The fuzz crate is workspace-excluded, so the main workspace build/clippy/tests are unaffected; the fuzz lane itself runs on the nightly/tag schedule, not per-PR.

Remaining follow-ups (unchanged): UDP/ICMP forwarding on the macOS path, and a live workload egress witness (needs Linux+libkrun hardware).
