### PR TITLE
fix(build): resolve guest-build workspace from the invoking checkout

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -145,6 +145,9 @@ jobs:
       - name: workload guest images bake no host/builder tools
         run: cargo run -p xtask -- check-guest-images-no-builder-tools
 
+      - name: OCI guest-binary name lists agree
+        run: cargo run -p xtask -- check-guest-binary-lists
+
       - name: no new builder shell-job dispatch sites
         run: cargo run -p xtask -- check-builder-shell-job-sites
 

--- a/.gitignore
+++ b/.gitignore
@@ -19,6 +19,9 @@ nixos.qcow2
 keys
 # Stray Rust compiled artifacts (e.g. a misdirected --out-dir); never tracked.
 *.rlib
+# Scratch source files a stray guest/host cross-compile may drop at the repo
+# root; never tracked.
+/.tmp-*.rs
 # Local dev-image build output. The sibling `nix/images/builder/` and
 # `nix/images/builder-vm/` directories are flake sources and stay
 # tracked; this one is a build artifact that can run into the hundreds

--- a/crates/mvm-build/src/guest_agent_build.rs
+++ b/crates/mvm-build/src/guest_agent_build.rs
@@ -83,10 +83,14 @@ pub struct GuestRuntimeBinaryBytes<'a> {
 const AGENT_VARIANT: &str = "dev-shell";
 
 impl GuestAgentLayout {
-    pub fn under(cache_root: &Path, version: &str, arch: GuestArch) -> Self {
+    /// `cache_key` names the cache generation: the mvmctl `version` for an
+    /// embedded/shipped build (content is fixed by the version), or a guest
+    /// source fingerprint (`source_cache_key`) for a contributor checkout so a
+    /// local edit lands in its own cache dir and never reuses a stale agent.
+    pub fn under(cache_root: &Path, cache_key: &str, arch: GuestArch) -> Self {
         let dir = cache_root
             .join("guest-agent")
-            .join(version)
+            .join(cache_key)
             .join(arch.to_string())
             .join(AGENT_VARIANT);
         Self {
@@ -140,15 +144,21 @@ pub struct GuestAgentBuildSpec {
     /// Workspace root (dir containing `Cargo.toml`, `crates/`).
     pub workspace_root: PathBuf,
     pub arch: GuestArch,
+    /// Cargo target dir for the cross-compile. Cache-scoped, deliberately NOT
+    /// `<workspace_root>/target`: a source-checkout guest build must never write
+    /// into the invoking source tree (mirrors `mvm-cli/build.rs`'s OUT_DIR
+    /// target). Set as `CARGO_TARGET_DIR` for the `cargo zigbuild` process.
+    pub target_dir: PathBuf,
     /// Override the cargo binary (tests). `None` ⇒ `cargo` on `$PATH`.
     pub cargo: Option<PathBuf>,
 }
 
 impl GuestAgentBuildSpec {
-    pub fn new(workspace_root: PathBuf, arch: GuestArch) -> Self {
+    pub fn new(workspace_root: PathBuf, arch: GuestArch, target_dir: PathBuf) -> Self {
         Self {
             workspace_root,
             arch,
+            target_dir,
             cargo: None,
         }
     }
@@ -195,30 +205,138 @@ impl GuestAgentBuildSpec {
         ]
     }
 
-    /// Paths the build drops the binaries at under the workspace target
-    /// dir.
+    /// Paths the build drops the binaries at, under the cache-scoped
+    /// `target_dir` (never the source tree's `target/`). Independent of any
+    /// ambient `CARGO_TARGET_DIR` — [`build_guest_binaries`] pins the env to
+    /// `target_dir`.
     pub fn output_dir(&self) -> PathBuf {
-        std::env::var_os("CARGO_TARGET_DIR")
-            .map(PathBuf::from)
-            .unwrap_or_else(|| self.workspace_root.join("target"))
+        self.target_dir
             .join(self.target_triple())
             .join("release")
     }
 }
 
-/// Resolve the guest binaries for `(version, arch)`, building + caching
-/// them from `workspace_root` on a cache miss.
+/// The cache-scoped cargo target dir for the guest cross-compile under
+/// `cache_root`. Kept off the source tree so a contributor's `run --image`
+/// guest build never writes into any checkout's `target/`.
+pub fn guest_build_target_dir(cache_root: &Path) -> PathBuf {
+    cache_root.join("guest-agent-build").join("target")
+}
+
+/// True when `dir` is the root of an mvm source checkout: it carries a top-level
+/// `Cargo.toml` and the `crates/mvm-guest/` crate. That pair uniquely names the
+/// workspace root — the guest crate exists nowhere else in the tree.
+pub fn is_source_workspace_root(dir: &Path) -> bool {
+    dir.join("Cargo.toml").is_file() && dir.join("crates/mvm-guest").is_dir()
+}
+
+/// Walk up from `start`, returning the first ancestor that is a source
+/// workspace root, else `None`. Pure — no ambient state.
+pub fn source_workspace_from(start: &Path) -> Option<PathBuf> {
+    start
+        .ancestors()
+        .find(|d| is_source_workspace_root(d))
+        .map(Path::to_path_buf)
+}
+
+/// The mvm source workspace to cross-compile the guest binaries from, or `None`
+/// for a shipped binary with no checkout (→ the caller uses the embedded bytes).
+///
+/// Resolution: the invoking process's `current_dir` first (so a contributor
+/// running from any worktree/clone builds THAT tree's guest sources, not the
+/// checkout mvmctl happened to be compiled in), walking up to the root; then the
+/// compile-time `CARGO_MANIFEST_DIR` ancestor (preserves an in-place `cargo run`
+/// whose cwd isn't the root); else `None`.
+pub fn detect_source_workspace() -> Option<PathBuf> {
+    if let Ok(cwd) = std::env::current_dir()
+        && let Some(ws) = source_workspace_from(&cwd)
+    {
+        return Some(ws);
+    }
+    source_workspace_from(Path::new(env!("CARGO_MANIFEST_DIR")))
+}
+
+/// Cache-key segment for a source-checkout guest build: a `src-` prefixed
+/// fingerprint of the guest crate sources. A changed guest source ⇒ a changed
+/// key ⇒ a fresh build, so a contributor's local edit is never served a stale
+/// version+arch-cached agent. The `src-` prefix keeps it from ever colliding
+/// with a version-keyed (shipped-binary) cache entry.
+pub fn source_cache_key(workspace_root: &Path) -> Result<String, GuestAgentBuildError> {
+    Ok(format!("src-{}", guest_source_fingerprint(workspace_root)?))
+}
+
+/// A stable content fingerprint over the guest crate sources compiled into the
+/// runtime binaries (`mvm-guest` + `mvm-guest-helpers`): each crate's
+/// `Cargo.toml` plus every file under its `src/`. Hashes workspace-relative
+/// paths and bytes in sorted order so the digest is deterministic.
+pub fn guest_source_fingerprint(workspace_root: &Path) -> Result<String, GuestAgentBuildError> {
+    use sha2::{Digest, Sha256};
+
+    let mut files: Vec<PathBuf> = Vec::new();
+    for crate_rel in ["crates/mvm-guest", "crates/mvm-guest-helpers"] {
+        let crate_dir = workspace_root.join(crate_rel);
+        let manifest = crate_dir.join("Cargo.toml");
+        if manifest.is_file() {
+            files.push(manifest);
+        }
+        collect_source_files(&crate_dir.join("src"), &mut files)?;
+    }
+    files.sort();
+
+    let mut h = Sha256::new();
+    for f in &files {
+        let rel = f.strip_prefix(workspace_root).unwrap_or(f);
+        h.update(rel.to_string_lossy().as_bytes());
+        h.update([0u8]);
+        h.update(std::fs::read(f)?);
+        h.update([0u8]);
+    }
+    Ok(format!("{:x}", h.finalize()))
+}
+
+/// Collect every regular file under `dir` (recursively) into `out`. Skips a
+/// `target` directory defensively; absent `dir` is a no-op.
+fn collect_source_files(dir: &Path, out: &mut Vec<PathBuf>) -> Result<(), GuestAgentBuildError> {
+    if !dir.exists() {
+        return Ok(());
+    }
+    let mut stack = vec![dir.to_path_buf()];
+    while let Some(path) = stack.pop() {
+        let meta = std::fs::symlink_metadata(&path)?;
+        if meta.is_dir() {
+            if path.file_name().is_some_and(|n| n == "target") {
+                continue;
+            }
+            for entry in std::fs::read_dir(&path)? {
+                stack.push(entry?.path());
+            }
+        } else if meta.is_file() {
+            out.push(path);
+        }
+    }
+    Ok(())
+}
+
+/// Resolve the guest binaries for `(cache_key, arch)`, building + caching them
+/// from `workspace_root` on a cache miss. For a source checkout the caller
+/// passes a [`source_cache_key`], so a changed guest source misses the cache and
+/// rebuilds instead of serving a stale agent. The cross-compile writes to a
+/// cache-scoped target dir, never into `workspace_root/target`.
 pub fn resolve_or_build_guest_binaries(
     cache_root: &Path,
-    version: &str,
+    cache_key: &str,
     arch: GuestArch,
     workspace_root: &Path,
 ) -> Result<MvmRuntimeBinaries, GuestAgentBuildError> {
-    let layout = GuestAgentLayout::under(cache_root, version, arch);
+    let layout = GuestAgentLayout::under(cache_root, cache_key, arch);
     if layout.is_complete() {
         return Ok(layout.binaries());
     }
-    let spec = GuestAgentBuildSpec::new(workspace_root.to_path_buf(), arch);
+    let spec = GuestAgentBuildSpec::new(
+        workspace_root.to_path_buf(),
+        arch,
+        guest_build_target_dir(cache_root),
+    );
     let built = build_guest_binaries(&spec)?;
     install_into_cache(
         GuestRuntimeBinaryPaths {
@@ -231,7 +349,7 @@ pub fn resolve_or_build_guest_binaries(
             verity_init: &built.6,
         },
         cache_root,
-        version,
+        cache_key,
         arch,
     )
 }
@@ -242,10 +360,10 @@ pub fn resolve_or_build_guest_binaries(
 pub fn install_into_cache(
     src: GuestRuntimeBinaryPaths<'_>,
     cache_root: &Path,
-    version: &str,
+    cache_key: &str,
     arch: GuestArch,
 ) -> Result<MvmRuntimeBinaries, GuestAgentBuildError> {
-    let layout = GuestAgentLayout::under(cache_root, version, arch);
+    let layout = GuestAgentLayout::under(cache_root, cache_key, arch);
     std::fs::create_dir_all(&layout.dir)?;
     install_one(src.oci_init, &layout.oci_init)?;
     install_one(src.agent, &layout.agent)?;
@@ -261,10 +379,10 @@ pub fn install_into_cache(
 /// Lets a caller check the cache without triggering a source-checkout build.
 pub fn cached_guest_binaries(
     cache_root: &Path,
-    version: &str,
+    cache_key: &str,
     arch: GuestArch,
 ) -> Option<MvmRuntimeBinaries> {
-    let layout = GuestAgentLayout::under(cache_root, version, arch);
+    let layout = GuestAgentLayout::under(cache_root, cache_key, arch);
     layout.is_complete().then(|| layout.binaries())
 }
 
@@ -324,6 +442,10 @@ pub fn build_guest_binaries(
     let argv = spec.argv();
     let mut cmd = std::process::Command::new(&argv[0]);
     cmd.args(&argv[1..]).current_dir(&spec.workspace_root);
+    // Pin the cargo target dir to the cache-scoped dir so the cross-compile
+    // never writes into the invoking source tree's `target/` — the guest-build
+    // worktree-hygiene contract. Overrides any inherited CARGO_TARGET_DIR.
+    cmd.env("CARGO_TARGET_DIR", &spec.target_dir);
     // Pin RUSTC to the rustup toolchain when available — a Homebrew
     // `rustc` earlier on `$PATH` carries no cross-target std and fails
     // the musl build with E0463.
@@ -507,9 +629,11 @@ mod tests {
 
     #[test]
     fn build_argv_targets_musl_with_dev_shell_and_both_bins() {
-        let mut env = TestEnv::new();
-        env.remove("CARGO_TARGET_DIR");
-        let spec = GuestAgentBuildSpec::new(PathBuf::from("/ws"), GuestArch::Aarch64);
+        let spec = GuestAgentBuildSpec::new(
+            PathBuf::from("/ws"),
+            GuestArch::Aarch64,
+            PathBuf::from("/cache/guest-agent-build/target"),
+        );
         let argv = spec.argv();
         assert_eq!(argv[0], "cargo");
         assert_eq!(argv[1], "zigbuild");
@@ -523,21 +647,34 @@ mod tests {
         assert!(argv.contains(&"mvm-egress-client".to_string()));
         assert!(argv.contains(&"mvm-guest-helpers".to_string()));
         assert!(argv.contains(&"mvm-guest/dev-shell".to_string()));
-        // output_dir is under the target triple's release dir.
-        assert_eq!(
-            spec.output_dir(),
-            PathBuf::from("/ws/target/aarch64-unknown-linux-musl/release")
-        );
     }
 
     #[test]
-    fn output_dir_honors_cargo_target_dir_override() {
+    fn output_dir_is_cache_scoped_never_the_source_tree() {
+        // The cross-compile output dir hangs off the explicit cache-scoped
+        // target_dir, NOT the workspace `target/`, and is independent of any
+        // ambient CARGO_TARGET_DIR — so a source-checkout guest build can never
+        // write into the invoking source tree.
         let mut env = TestEnv::new();
-        env.set("CARGO_TARGET_DIR", "/tmp/custom-target");
-        let spec = GuestAgentBuildSpec::new(PathBuf::from("/ws"), GuestArch::Aarch64);
+        env.set("CARGO_TARGET_DIR", "/tmp/ambient-should-be-ignored");
+        let spec = GuestAgentBuildSpec::new(
+            PathBuf::from("/ws"),
+            GuestArch::Aarch64,
+            PathBuf::from("/cache/guest-agent-build/target"),
+        );
         assert_eq!(
             spec.output_dir(),
-            PathBuf::from("/tmp/custom-target/aarch64-unknown-linux-musl/release")
+            PathBuf::from("/cache/guest-agent-build/target/aarch64-unknown-linux-musl/release")
+        );
+        // Never under the workspace source tree.
+        assert!(!spec.output_dir().starts_with("/ws/target"));
+    }
+
+    #[test]
+    fn guest_build_target_dir_is_under_cache_root() {
+        assert_eq!(
+            guest_build_target_dir(Path::new("/c")),
+            PathBuf::from("/c/guest-agent-build/target")
         );
     }
 
@@ -618,5 +755,136 @@ mod tests {
         )
         .unwrap_err();
         assert!(matches!(err, GuestAgentBuildError::OutputMissing(_)));
+    }
+
+    /// Build a minimal fake source checkout under `root`: a workspace `Cargo.toml`
+    /// plus a `crates/mvm-guest/{Cargo.toml,src/main.rs}` carrying `agent_body`.
+    fn make_fake_checkout(root: &Path, agent_body: &str) {
+        std::fs::create_dir_all(root.join("crates/mvm-guest/src")).unwrap();
+        std::fs::create_dir_all(root.join("crates/mvm-guest-helpers/src")).unwrap();
+        std::fs::write(root.join("Cargo.toml"), b"[workspace]\n").unwrap();
+        std::fs::write(root.join("crates/mvm-guest/Cargo.toml"), b"[package]\n").unwrap();
+        std::fs::write(root.join("crates/mvm-guest/src/main.rs"), agent_body).unwrap();
+        std::fs::write(
+            root.join("crates/mvm-guest-helpers/Cargo.toml"),
+            b"[package]\n",
+        )
+        .unwrap();
+        std::fs::write(root.join("crates/mvm-guest-helpers/src/lib.rs"), b"").unwrap();
+    }
+
+    #[test]
+    fn is_source_workspace_root_requires_guest_crate_and_manifest() {
+        let tmp = tempfile::tempdir().unwrap();
+        // Empty dir is not a workspace root.
+        assert!(!is_source_workspace_root(tmp.path()));
+        make_fake_checkout(tmp.path(), "fn main() {}");
+        assert!(is_source_workspace_root(tmp.path()));
+    }
+
+    #[test]
+    fn source_workspace_from_walks_up_to_root() {
+        let tmp = tempfile::tempdir().unwrap();
+        make_fake_checkout(tmp.path(), "fn main() {}");
+        // Canonicalize: tempdir on macOS is under a `/var → /private/var` symlink.
+        let root = std::fs::canonicalize(tmp.path()).unwrap();
+        // From a nested subdir the walk finds the root.
+        let nested = root.join("crates/mvm-guest/src");
+        assert_eq!(source_workspace_from(&nested), Some(root.clone()));
+        // From the root itself, the root.
+        assert_eq!(source_workspace_from(&root), Some(root));
+    }
+
+    #[test]
+    fn source_workspace_from_none_for_non_checkout() {
+        let tmp = tempfile::tempdir().unwrap();
+        assert_eq!(source_workspace_from(tmp.path()), None);
+    }
+
+    #[test]
+    fn detect_source_workspace_resolves_this_repo() {
+        // Running under nextest, cwd is `crates/mvm-build`; the walk up finds the
+        // real workspace root, and it carries the guest crate.
+        let ws = detect_source_workspace().expect("this is a source checkout");
+        assert!(ws.join("crates/mvm-guest").is_dir());
+        assert!(ws.join("Cargo.toml").is_file());
+    }
+
+    #[test]
+    fn fingerprint_changes_with_guest_source_and_is_stable() {
+        let a = tempfile::tempdir().unwrap();
+        let b = tempfile::tempdir().unwrap();
+        let c = tempfile::tempdir().unwrap();
+        make_fake_checkout(a.path(), "fn main() { println!(\"v1\"); }");
+        make_fake_checkout(b.path(), "fn main() { println!(\"v2\"); }");
+        make_fake_checkout(c.path(), "fn main() { println!(\"v1\"); }");
+
+        let fa = guest_source_fingerprint(a.path()).unwrap();
+        let fb = guest_source_fingerprint(b.path()).unwrap();
+        let fc = guest_source_fingerprint(c.path()).unwrap();
+        // A changed guest source yields a different fingerprint.
+        assert_ne!(fa, fb, "source edit must change the fingerprint");
+        // Identical source yields an identical fingerprint (a real cache hit).
+        assert_eq!(fa, fc, "identical source must fingerprint identically");
+        // The digest is lowercase hex.
+        assert_eq!(fa.len(), 64);
+        assert!(fa.bytes().all(|x| x.is_ascii_hexdigit()));
+    }
+
+    #[test]
+    fn source_cache_key_is_src_prefixed() {
+        let tmp = tempfile::tempdir().unwrap();
+        make_fake_checkout(tmp.path(), "fn main() {}");
+        let key = source_cache_key(tmp.path()).unwrap();
+        assert!(key.starts_with("src-"), "key must be src-prefixed: {key}");
+    }
+
+    #[test]
+    fn source_build_never_hits_a_stale_version_arch_cache() {
+        // Reproduces the bug: a prior shipped-binary run populated the version+arch
+        // cache with a STALE agent. A contributor's source checkout keys the cache
+        // on the guest source content instead, so its lookup targets a different
+        // dir and can never be served that stale entry.
+        let cache = tempfile::tempdir().unwrap();
+        let arch = GuestArch::Aarch64;
+        let version = env!("CARGO_PKG_VERSION");
+
+        // Populate the version+arch cache (the embedded/shipped path).
+        install_prebuilt_guest_binaries(
+            GuestRuntimeBinaryBytes {
+                oci_init: b"STALE",
+                agent: b"STALE",
+                netinit: b"STALE",
+                netd: b"STALE",
+                egress_client: b"STALE",
+                entrypoint_runner: b"STALE",
+                verity_init: b"STALE",
+            },
+            cache.path(),
+            version,
+            arch,
+        )
+        .unwrap();
+        assert!(
+            cached_guest_binaries(cache.path(), version, arch).is_some(),
+            "version+arch cache is populated (stale)"
+        );
+
+        // A source checkout resolves to a src-fingerprint key, whose cache dir is
+        // empty — no stale hit.
+        let ws = tempfile::tempdir().unwrap();
+        make_fake_checkout(ws.path(), "fn main() { /* edited */ }");
+        let key = source_cache_key(ws.path()).unwrap();
+        assert_ne!(key, version, "source key must differ from the version key");
+        assert!(
+            cached_guest_binaries(cache.path(), &key, arch).is_none(),
+            "source-keyed lookup must not return the stale version+arch entry"
+        );
+
+        // And an edit produces yet another distinct key — never colliding.
+        let ws2 = tempfile::tempdir().unwrap();
+        make_fake_checkout(ws2.path(), "fn main() { /* different edit */ }");
+        let key2 = source_cache_key(ws2.path()).unwrap();
+        assert_ne!(key, key2, "distinct guest sources yield distinct keys");
     }
 }

--- a/crates/mvm-build/src/guest_agent_build.rs
+++ b/crates/mvm-build/src/guest_agent_build.rs
@@ -210,9 +210,7 @@ impl GuestAgentBuildSpec {
     /// ambient `CARGO_TARGET_DIR` — [`build_guest_binaries`] pins the env to
     /// `target_dir`.
     pub fn output_dir(&self) -> PathBuf {
-        self.target_dir
-            .join(self.target_triple())
-            .join("release")
+        self.target_dir.join(self.target_triple()).join("release")
     }
 }
 

--- a/crates/mvm-build/src/run_image.rs
+++ b/crates/mvm-build/src/run_image.rs
@@ -126,35 +126,37 @@ fn assemble_and_write_verity_initrd(rootfs_ext4: &Path, verity_init_bin: &Path) 
     Ok(initrd_path)
 }
 
-/// Resolve the guest-agent binaries: cache hit → source-checkout cross-compile
-/// → embedded prebuilt bytes.
+/// Resolve the guest-agent binaries: source-checkout cross-compile (content-keyed
+/// cache) → version+arch cache hit → embedded prebuilt bytes.
+///
+/// A source checkout is resolved from the *invoking* process's working dir (not
+/// the checkout mvmctl was compiled in), so a contributor building from any
+/// worktree/clone gets THAT tree's guest sources. Its cache is keyed on the
+/// guest source content, so a local edit always rebuilds instead of serving a
+/// stale, same-version cached agent — the bug that broke local guest-change
+/// validation. A shipped binary with no checkout falls through to the version+arch
+/// cache and the embedded bytes.
 fn resolve_guest_binaries(
     cache_root: &Path,
     prebuilt: Option<PrebuiltGuestBinaries<'_>>,
 ) -> Result<MvmRuntimeBinaries> {
     let arch = mvm_core::arch::GuestArch::host();
-    let version = env!("CARGO_PKG_VERSION");
 
+    if let Some(ws) = crate::guest_agent_build::detect_source_workspace() {
+        let cache_key = crate::guest_agent_build::source_cache_key(&ws)
+            .context("fingerprint guest sources for the build cache")?;
+        return crate::guest_agent_build::resolve_or_build_guest_binaries(
+            cache_root, &cache_key, arch, &ws,
+        )
+        .context("build guest agent binaries from the source checkout");
+    }
+
+    // Shipped mvmctl: the embedded bytes are fixed by this version, so a
+    // version+arch cache is correct here.
+    let version = env!("CARGO_PKG_VERSION");
     if let Some(cached) = crate::guest_agent_build::cached_guest_binaries(cache_root, version, arch)
     {
         return Ok(cached);
-    }
-
-    // A source checkout cross-compiles fresh, so contributors editing `mvm-guest`
-    // get their local changes. `CARGO_MANIFEST_DIR` is baked at this crate's
-    // compile time and points at `crates/mvm-build`; on a shipped binary that
-    // path doesn't exist on the end-user's host — which is exactly how we detect
-    // "not a source checkout" and fall through to the embedded bytes.
-    let workspace_root = Path::new(env!("CARGO_MANIFEST_DIR"))
-        .parent()
-        .and_then(|p| p.parent());
-    if let Some(ws) = workspace_root
-        && ws.join("crates/mvm-guest").is_dir()
-    {
-        return crate::guest_agent_build::resolve_or_build_guest_binaries(
-            cache_root, version, arch, ws,
-        )
-        .context("build guest agent binaries from the source checkout");
     }
 
     if let Some(p) = prebuilt {

--- a/xtask/src/check_guest_binary_lists.rs
+++ b/xtask/src/check_guest_binary_lists.rs
@@ -32,17 +32,31 @@ pub fn run(workspace: &Path) -> Result<()> {
     let universe = guest_bin_universe(workspace)?;
 
     let lists = [
-        ("guest_agent_build.rs argv", extract_bin_flags(workspace, GUEST_AGENT_BUILD)?),
-        ("mvm-cli/build.rs argv", extract_bin_flags(workspace, CLI_BUILD_RS)?),
-        ("oci_runtime_inject.rs MvmRuntimeBinaries", extract_runtime_struct(workspace, OCI_INJECT)?),
-        ("image/mod.rs find() lookups", extract_find_calls(workspace, IMAGE_MOD)?),
+        (
+            "guest_agent_build.rs argv",
+            extract_bin_flags(workspace, GUEST_AGENT_BUILD)?,
+        ),
+        (
+            "mvm-cli/build.rs argv",
+            extract_bin_flags(workspace, CLI_BUILD_RS)?,
+        ),
+        (
+            "oci_runtime_inject.rs MvmRuntimeBinaries",
+            extract_runtime_struct(workspace, OCI_INJECT)?,
+        ),
+        (
+            "image/mod.rs find() lookups",
+            extract_find_calls(workspace, IMAGE_MOD)?,
+        ),
     ];
 
     // Every list must be non-empty — an empty extraction means a refactor moved
     // the list and this check silently stopped guarding it.
     for (label, set) in &lists {
         if set.is_empty() {
-            bail!("no guest binary names extracted from {label}; the list moved — update this check");
+            bail!(
+                "no guest binary names extracted from {label}; the list moved — update this check"
+            );
         }
     }
 
@@ -87,9 +101,13 @@ pub fn run(workspace: &Path) -> Result<()> {
 /// `mvm-guest-helpers` — the universe a listed guest binary must belong to.
 fn guest_bin_universe(workspace: &Path) -> Result<BTreeSet<String>> {
     let mut out = BTreeSet::new();
-    for crate_rel in ["crates/mvm-guest/Cargo.toml", "crates/mvm-guest-helpers/Cargo.toml"] {
+    for crate_rel in [
+        "crates/mvm-guest/Cargo.toml",
+        "crates/mvm-guest-helpers/Cargo.toml",
+    ] {
         let path = workspace.join(crate_rel);
-        let src = std::fs::read_to_string(&path).with_context(|| format!("read {}", path.display()))?;
+        let src =
+            std::fs::read_to_string(&path).with_context(|| format!("read {}", path.display()))?;
         out.extend(parse_bin_names(&src));
     }
     Ok(out)
@@ -122,10 +140,7 @@ fn parse_bin_names(manifest: &str) -> BTreeSet<String> {
 fn extract_bin_flags(workspace: &Path, rel: &str) -> Result<BTreeSet<String>> {
     let src = read(workspace, rel)?;
     let re = Regex::new(r#""--bin"(?:\.to_string\(\))?\s*,\s*"(mvm-[a-z0-9-]+)""#).unwrap();
-    Ok(re
-        .captures_iter(&src)
-        .map(|c| c[1].to_string())
-        .collect())
+    Ok(re.captures_iter(&src).map(|c| c[1].to_string()).collect())
 }
 
 /// Guest binary names named in the `MvmRuntimeBinaries` struct field docs — each
@@ -166,7 +181,10 @@ mod tests {
         let manifest = std::env::var("CARGO_MANIFEST_DIR")
             .map(PathBuf::from)
             .unwrap_or_else(|_| std::env::current_dir().unwrap_or_default());
-        manifest.parent().map(|p| p.to_path_buf()).unwrap_or(manifest)
+        manifest
+            .parent()
+            .map(|p| p.to_path_buf())
+            .unwrap_or(manifest)
     }
 
     #[test]
@@ -184,13 +202,17 @@ name = "mvm-oci-init"
         let bins = parse_bin_names(manifest);
         assert!(bins.contains("mvm-guest-agent"));
         assert!(bins.contains("mvm-oci-init"));
-        assert!(!bins.contains("mvm-guest"), "package name must not be a bin");
+        assert!(
+            !bins.contains("mvm-guest"),
+            "package name must not be a bin"
+        );
     }
 
     #[test]
     fn extract_bin_flags_handles_both_argv_forms() {
         // The plain build.rs form and the `.to_string()` guest_agent_build form.
-        let build_rs = r#"cmd.args(["zigbuild", "--bin", "mvm-oci-init", "--bin", "mvm-guest-agent"]);"#;
+        let build_rs =
+            r#"cmd.args(["zigbuild", "--bin", "mvm-oci-init", "--bin", "mvm-guest-agent"]);"#;
         let tmp = tempfile::tempdir().unwrap();
         std::fs::write(tmp.path().join("a.rs"), build_rs).unwrap();
         let got = extract_bin_flags(tmp.path(), "a.rs").unwrap();
@@ -223,7 +245,10 @@ name = "mvm-oci-init"
             "mvm-egress-client".to_string(),
             "mvm-verity-init".to_string(),
         ]);
-        assert_eq!(extract_bin_flags(&root, GUEST_AGENT_BUILD).unwrap(), expected);
+        assert_eq!(
+            extract_bin_flags(&root, GUEST_AGENT_BUILD).unwrap(),
+            expected
+        );
         assert_eq!(extract_bin_flags(&root, CLI_BUILD_RS).unwrap(), expected);
         assert_eq!(extract_runtime_struct(&root, OCI_INJECT).unwrap(), expected);
         assert_eq!(extract_find_calls(&root, IMAGE_MOD).unwrap(), expected);

--- a/xtask/src/check_guest_binary_lists.rs
+++ b/xtask/src/check_guest_binary_lists.rs
@@ -1,0 +1,247 @@
+//! `xtask check-guest-binary-lists`
+//!
+//! CI lint — the guest runtime binaries baked into an OCI `run --image` rootfs
+//! are named in four hand-maintained lists that must stay in lockstep:
+//!
+//! - `crates/mvm-build/src/guest_agent_build.rs` — the `cargo zigbuild --bin`
+//!   invocation that actually builds them (the authoritative list).
+//! - `crates/mvm-cli/build.rs` — the same `--bin` invocation that cross-compiles
+//!   + embeds them into a shipped mvmctl.
+//! - `crates/mvm-build/src/oci_runtime_inject.rs` — the `MvmRuntimeBinaries`
+//!   struct whose field docs name each bin.
+//! - `crates/mvm-cli/src/commands/image/mod.rs` — the `find("…")` lookups that
+//!   pull the embedded bytes.
+//!
+//! The check asserts those four sets are identical to each other AND that every
+//! name is a real `[[bin]]` of `mvm-guest` or `mvm-guest-helpers`. A drift — a
+//! renamed bin, a list left behind, or a name that no longer maps to a bin —
+//! fails here instead of silently shipping a rootfs missing (or misnaming) a
+//! guest binary.
+
+use anyhow::{Context, Result, bail};
+use regex::Regex;
+use std::collections::BTreeSet;
+use std::path::Path;
+
+const GUEST_AGENT_BUILD: &str = "crates/mvm-build/src/guest_agent_build.rs";
+const CLI_BUILD_RS: &str = "crates/mvm-cli/build.rs";
+const OCI_INJECT: &str = "crates/mvm-build/src/oci_runtime_inject.rs";
+const IMAGE_MOD: &str = "crates/mvm-cli/src/commands/image/mod.rs";
+
+pub fn run(workspace: &Path) -> Result<()> {
+    let universe = guest_bin_universe(workspace)?;
+
+    let lists = [
+        ("guest_agent_build.rs argv", extract_bin_flags(workspace, GUEST_AGENT_BUILD)?),
+        ("mvm-cli/build.rs argv", extract_bin_flags(workspace, CLI_BUILD_RS)?),
+        ("oci_runtime_inject.rs MvmRuntimeBinaries", extract_runtime_struct(workspace, OCI_INJECT)?),
+        ("image/mod.rs find() lookups", extract_find_calls(workspace, IMAGE_MOD)?),
+    ];
+
+    // Every list must be non-empty — an empty extraction means a refactor moved
+    // the list and this check silently stopped guarding it.
+    for (label, set) in &lists {
+        if set.is_empty() {
+            bail!("no guest binary names extracted from {label}; the list moved — update this check");
+        }
+    }
+
+    // All four lists identical.
+    let canonical = &lists[0].1;
+    for (label, set) in &lists[1..] {
+        if set != canonical {
+            bail!(
+                "guest-binary name lists drift:\n  {} = {:?}\n  {} = {:?}\n\n\
+                 Fix: keep the guest runtime binary lists identical across {}, {}, {}, {}.",
+                lists[0].0,
+                canonical,
+                label,
+                set,
+                GUEST_AGENT_BUILD,
+                CLI_BUILD_RS,
+                OCI_INJECT,
+                IMAGE_MOD,
+            );
+        }
+    }
+
+    // Every listed name is a real guest `[[bin]]` — catches an invalid drift.
+    let invalid: BTreeSet<&String> = canonical.difference(&universe).collect();
+    if !invalid.is_empty() {
+        bail!(
+            "guest-binary lists reference names that are not `[[bin]]`s of \
+             mvm-guest / mvm-guest-helpers: {:?}\n  known bins: {:?}",
+            invalid,
+            universe,
+        );
+    }
+
+    eprintln!(
+        "check-guest-binary-lists: 4 lists agree on {} guest binaries, all real [[bin]]s",
+        canonical.len()
+    );
+    Ok(())
+}
+
+/// The set of every `[[bin]]` name declared by `mvm-guest` and
+/// `mvm-guest-helpers` — the universe a listed guest binary must belong to.
+fn guest_bin_universe(workspace: &Path) -> Result<BTreeSet<String>> {
+    let mut out = BTreeSet::new();
+    for crate_rel in ["crates/mvm-guest/Cargo.toml", "crates/mvm-guest-helpers/Cargo.toml"] {
+        let path = workspace.join(crate_rel);
+        let src = std::fs::read_to_string(&path).with_context(|| format!("read {}", path.display()))?;
+        out.extend(parse_bin_names(&src));
+    }
+    Ok(out)
+}
+
+/// `[[bin]] name = "..."` names in a Cargo.toml. A `name =` line counts only when
+/// the most recent section header was `[[bin]]` (skips the `[package] name`).
+fn parse_bin_names(manifest: &str) -> BTreeSet<String> {
+    let name_re = Regex::new(r#"^\s*name\s*=\s*"([^"]+)""#).unwrap();
+    let mut out = BTreeSet::new();
+    let mut in_bin = false;
+    for line in manifest.lines() {
+        let t = line.trim();
+        if t.starts_with('[') {
+            in_bin = t == "[[bin]]";
+            continue;
+        }
+        if in_bin && let Some(c) = name_re.captures(line) {
+            out.insert(c[1].to_string());
+            in_bin = false;
+        }
+    }
+    out
+}
+
+/// Names passed as `--bin <name>` in a `cargo zigbuild` argv. Handles both the
+/// plain `"--bin", "name"` (build.rs) and the `"--bin".to_string(),
+/// "name".to_string()` (guest_agent_build.rs) forms. Only `mvm-*` literals count
+/// — a `--bin <variable>` (host-bin loops) carries no literal and is skipped.
+fn extract_bin_flags(workspace: &Path, rel: &str) -> Result<BTreeSet<String>> {
+    let src = read(workspace, rel)?;
+    let re = Regex::new(r#""--bin"(?:\.to_string\(\))?\s*,\s*"(mvm-[a-z0-9-]+)""#).unwrap();
+    Ok(re
+        .captures_iter(&src)
+        .map(|c| c[1].to_string())
+        .collect())
+}
+
+/// Guest binary names named in the `MvmRuntimeBinaries` struct field docs — each
+/// field carries exactly one `` `mvm-…` `` backtick reference.
+fn extract_runtime_struct(workspace: &Path, rel: &str) -> Result<BTreeSet<String>> {
+    let src = read(workspace, rel)?;
+    let start = src
+        .find("pub struct MvmRuntimeBinaries {")
+        .with_context(|| format!("MvmRuntimeBinaries struct not found in {rel}"))?;
+    let rest = &src[start..];
+    let end = rest
+        .find("\n}")
+        .with_context(|| format!("MvmRuntimeBinaries struct has no closing brace in {rel}"))?;
+    let block = &rest[..end];
+    let re = Regex::new(r"`(mvm-[a-z0-9-]+)`").unwrap();
+    Ok(re.captures_iter(block).map(|c| c[1].to_string()).collect())
+}
+
+/// Guest binary names looked up via `find("…")` (the `embedded_guest_binaries`
+/// resolver).
+fn extract_find_calls(workspace: &Path, rel: &str) -> Result<BTreeSet<String>> {
+    let src = read(workspace, rel)?;
+    let re = Regex::new(r#"find\("(mvm-[a-z0-9-]+)"\)"#).unwrap();
+    Ok(re.captures_iter(&src).map(|c| c[1].to_string()).collect())
+}
+
+fn read(workspace: &Path, rel: &str) -> Result<String> {
+    let path = workspace.join(rel);
+    std::fs::read_to_string(&path).with_context(|| format!("read {}", path.display()))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::path::PathBuf;
+
+    fn workspace_root() -> PathBuf {
+        let manifest = std::env::var("CARGO_MANIFEST_DIR")
+            .map(PathBuf::from)
+            .unwrap_or_else(|_| std::env::current_dir().unwrap_or_default());
+        manifest.parent().map(|p| p.to_path_buf()).unwrap_or(manifest)
+    }
+
+    #[test]
+    fn parse_bin_names_skips_package_name() {
+        let manifest = r#"
+[package]
+name = "mvm-guest"
+
+[[bin]]
+name = "mvm-guest-agent"
+
+[[bin]]
+name = "mvm-oci-init"
+"#;
+        let bins = parse_bin_names(manifest);
+        assert!(bins.contains("mvm-guest-agent"));
+        assert!(bins.contains("mvm-oci-init"));
+        assert!(!bins.contains("mvm-guest"), "package name must not be a bin");
+    }
+
+    #[test]
+    fn extract_bin_flags_handles_both_argv_forms() {
+        // The plain build.rs form and the `.to_string()` guest_agent_build form.
+        let build_rs = r#"cmd.args(["zigbuild", "--bin", "mvm-oci-init", "--bin", "mvm-guest-agent"]);"#;
+        let tmp = tempfile::tempdir().unwrap();
+        std::fs::write(tmp.path().join("a.rs"), build_rs).unwrap();
+        let got = extract_bin_flags(tmp.path(), "a.rs").unwrap();
+        assert_eq!(
+            got,
+            BTreeSet::from(["mvm-oci-init".to_string(), "mvm-guest-agent".to_string()])
+        );
+
+        let gab = r#"vec!["--bin".to_string(), "mvm-verity-init".to_string()]"#;
+        std::fs::write(tmp.path().join("b.rs"), gab).unwrap();
+        let got = extract_bin_flags(tmp.path(), "b.rs").unwrap();
+        assert_eq!(got, BTreeSet::from(["mvm-verity-init".to_string()]));
+    }
+
+    #[test]
+    fn the_four_lists_agree_and_are_real_bins() {
+        // The real gate over the current tree.
+        run(&workspace_root()).expect("guest-binary lists must be in sync");
+    }
+
+    #[test]
+    fn extractors_each_find_the_seven_runtime_bins() {
+        let root = workspace_root();
+        let expected = BTreeSet::from([
+            "mvm-oci-init".to_string(),
+            "mvm-oci-entrypoint".to_string(),
+            "mvm-guest-agent".to_string(),
+            "mvm-guest-netinit".to_string(),
+            "mvm-guest-netd".to_string(),
+            "mvm-egress-client".to_string(),
+            "mvm-verity-init".to_string(),
+        ]);
+        assert_eq!(extract_bin_flags(&root, GUEST_AGENT_BUILD).unwrap(), expected);
+        assert_eq!(extract_bin_flags(&root, CLI_BUILD_RS).unwrap(), expected);
+        assert_eq!(extract_runtime_struct(&root, OCI_INJECT).unwrap(), expected);
+        assert_eq!(extract_find_calls(&root, IMAGE_MOD).unwrap(), expected);
+    }
+
+    #[test]
+    fn universe_contains_the_runtime_bins() {
+        let universe = guest_bin_universe(&workspace_root()).unwrap();
+        for b in [
+            "mvm-oci-init",
+            "mvm-oci-entrypoint",
+            "mvm-guest-agent",
+            "mvm-guest-netinit",
+            "mvm-guest-netd",
+            "mvm-egress-client",
+            "mvm-verity-init",
+        ] {
+            assert!(universe.contains(b), "{b} must be a known guest [[bin]]");
+        }
+    }
+}

--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -20,6 +20,7 @@ mod check_duplicate_majors;
 mod check_forbidden_deps;
 mod check_guest_agent_in_all_images;
 mod check_guest_agent_runtime_free;
+mod check_guest_binary_lists;
 mod check_guest_images_no_builder_tools;
 mod check_kernel_config_budget;
 mod check_kernel_pin_freshness;
@@ -114,6 +115,10 @@ fn main() -> Result<()> {
             let workspace = workspace_root();
             check_guest_images_no_builder_tools::run(&workspace)
         }
+        Some("check-guest-binary-lists") => {
+            let workspace = workspace_root();
+            check_guest_binary_lists::run(&workspace)
+        }
         Some("check-no-overclaim") => {
             let workspace = workspace_root();
             check_no_overclaim::run(&workspace)
@@ -174,7 +179,7 @@ fn main() -> Result<()> {
             gen_stubs::check(&workspace)
         }
         Some(other) => anyhow::bail!(
-            "Unknown xtask: {:?}. Available: gen-man, check-adr-coverage, check-no-display-on-secret-types, check-audit-positional, check-doc-claims, check-machine-doc-guards, check-forbidden-deps, check-core-runtime-free, check-closure-budget, check-duplicate-majors, check-binary-size, check-kernel-config-budget, check-kernel-pin-freshness, check-builder-shell-job-sites, check-guest-agent-runtime-free, check-guest-agent-in-all-images, check-guest-images-no-builder-tools, check-no-overclaim, check-spec-numbers, check-two-surfaces, check-no-spec-refs-in-comments, check-claim-catalog, check-trust-gradient, check-vsock-only-egress, check-require-grant-token-allowlist, check-mvm-host-binaries-sync, check-runtime-overlay-version, perf, build-dev-image, gen-stubs, check-stubs",
+            "Unknown xtask: {:?}. Available: gen-man, check-adr-coverage, check-no-display-on-secret-types, check-audit-positional, check-doc-claims, check-machine-doc-guards, check-forbidden-deps, check-core-runtime-free, check-closure-budget, check-duplicate-majors, check-binary-size, check-kernel-config-budget, check-kernel-pin-freshness, check-builder-shell-job-sites, check-guest-agent-runtime-free, check-guest-agent-in-all-images, check-guest-images-no-builder-tools, check-guest-binary-lists, check-no-overclaim, check-spec-numbers, check-two-surfaces, check-no-spec-refs-in-comments, check-claim-catalog, check-trust-gradient, check-vsock-only-egress, check-require-grant-token-allowlist, check-mvm-host-binaries-sync, check-runtime-overlay-version, perf, build-dev-image, gen-stubs, check-stubs",
             other
         ),
         None => {
@@ -224,6 +229,9 @@ fn main() -> Result<()> {
             );
             eprintln!(
                 "  check-guest-images-no-builder-tools     assert mkGuest never bakes mvmctl / mvm-builderd into workload guest images"
+            );
+            eprintln!(
+                "  check-guest-binary-lists                assert the four OCI guest-binary name lists agree and name real [[bin]]s"
             );
             eprintln!(
                 "  check-runtime-overlay-version           Plan 124 C: assert the runtime-overlay flake's overlayVersion matches the workspace version"


### PR DESCRIPTION
Closes #1630 — the build-hygiene bug that broke worktree isolation and silently validated the wrong guest agent.

## Two bugs
1. **Workspace baked at compile time** — the OCI guest-agent resolution used `env!("CARGO_MANIFEST_DIR")`, so a binary built in one checkout resolved the guest-build workspace to *that* checkout regardless of where it ran. A worktree/clone building a guest change would read main's sources.
2. **Stale cache masks source changes** — the resolution consulted a **version+arch-keyed** cache before cross-compiling, so a guest-source edit in a worktree was served a stale cached agent (this is what made two local peer-CID validations boot the wrong agent).

## Fix
- `detect_source_workspace()` — walk up from the current dir to the first source root (`crates/mvm-guest/` + workspace `Cargo.toml`); fall back to the baked-path ancestor (in-place `cargo run`) else `None` (→ shipped/embedded bytes). Replaces the baked lookup in `run_image.rs`.
- For a source checkout, key the guest-binary cache on `source_cache_key()` (a fingerprint of the guest sources) so an edit yields a fresh agent. Shipped binaries keep the version+arch cache.
- **xtask `check-guest-binary-lists`** (wired into the Lint job): asserts the hand-maintained guest-binary name lists agree and match the real `[[bin]]` set — would have caught the invalid `mvm-guest-netd` drift. ("4 lists agree on 7 guest binaries, all real `[[bin]]`s".)
- `.gitignore /.tmp-*.rs`.

## Scope / tests
Leaves `dev_build.rs`'s workspace sites for a follow-up (a parallel branch is actively editing that file). `detect_source_workspace`/`source_cache_key` unit tests + the xtask gate; full mvm-build+xtask suites: **888 passed, 0 failed**; nightly-fmt / clippy / no-spec-refs clean.