### PR TITLE
docs(plan): Plan 246 — kernel-cheap `machine run --image` + builder-VM demotion (1/3: plan)

### DIFF
--- a/specs/notes/2026-07-11-oci-run-builder-vm-demotion-design.md
+++ b/specs/notes/2026-07-11-oci-run-builder-vm-demotion-design.md
@@ -189,3 +189,22 @@ WS1→WS3 fix the reported bug and the DX. WS4→WS6 complete the vision.
   coordinate the descope so we don't strand merged pieces.
 - **Release asset availability.** The end-user download path is only as good as
   the release job actually publishing the kernel asset per arch.
+
+## Phasing (agreed 2026-07-11) — 2 phases, 3 PRs
+
+- **PR 1 — the plan.** The implementation plan doc; no code.
+- **PR 2 — Phase 1: kernel-cheap `machine run --image`.** WS1 (land
+  `fix/stage0-homeless-shelter-purity`) + WS2 (reuse-or-build-once-and-cache
+  kernel; `--image` never triggers a redundant full builder-image build) + **WS3
+  (build logging/inspection — first-class, not polish)**. Confirm working
+  end-to-end before Phase 2.
+- **PR 3 — Phase 2: remove `mvmctl dev`.** WS6. **Hard gate:** ships only once
+  Phase 1's logging/inspection is *proven* able to diagnose a builder-VM build
+  failure from its logs — that inspection capability is the reason `dev` can go.
+
+### Deferred follow-ups (outside the 3-PR scope)
+
+- **WS4 — end-user prebuilt-kernel download / release asset.** Contributor path
+  (build-once) is what Phase 1 fixes; the installed-user download is separate.
+- **WS5 — builder audited-egress cutover.** Hand off to Plan 236's existing
+  builder no-guest-NIC / host-brokered-egress work; do not duplicate it here.

--- a/specs/notes/2026-07-11-oci-run-builder-vm-demotion-design.md
+++ b/specs/notes/2026-07-11-oci-run-builder-vm-demotion-design.md
@@ -1,0 +1,191 @@
+# Design — Kernel-cheap `machine run --image`; demote the builder VM to a headless nix build engine
+
+**Date:** 2026-07-11
+**Owner:** Ari
+**Status:** design — approved direction, pending spec review
+**Related:** Plan 236 (host-authority runtime roadmap), Plan 242 (overlay-required
+runtime rollout — the guest-binary overlay this design depends on, complete on
+`feat/overlay-required-plan`/#1613), Plan 239 (kernel-config subtraction),
+Plan 221 (in-process rootfs materialize), Plan 213 (attested builder packs),
+ADR-046 (two artifact layers / source-checkout hermeticity),
+`fix/stage0-homeless-shelter-purity`, `#1640` (fetch pinned workload kernels on
+installed builds).
+
+## Problem
+
+`mvmctl machine run --image alpine -it -- /bin/sh` in a source checkout spends
+~2 min on an opaque "Builder VM image build", streams raw cargo/nix compile
+output over a spinner, and then dies on:
+
+    error: home directory "/homeless-shelter" exists; please remove it to
+    assure purity of builds without sandboxing
+
+Running a runtime OCI image should be near-instant and must not build the Nix
+builder VM.
+
+### Root cause
+
+Booting a microVM needs three things: (1) an OCI rootfs, (2) the mvm guest
+binaries inside it, (3) a Linux kernel. On `main`, (1) and (2) are already
+in-process / pure-Rust for an `--image` run — `oci_runtime_inject::inject_mvm_runtime`
+overlays init/agent/netd/egress onto the unpacked tree and `materialize_ext4_pure`
+writes the ext4. **No nix, no builder VM.** The runtime overlay the user asked
+for already exists.
+
+The *only* thing that pulls in the builder VM is **the kernel**:
+
+1. `--image` resolves its kernel via `ensure_workload_kernel()`
+   (`crates/mvm-cli/src/commands/env/dev_vz/default_microvm.rs:19`).
+2. Source checkouts may **not** download mvm-published artifacts (ADR-046
+   hermeticity invariant), so on a cold cache the kernel must be **built
+   locally** (`3135b0cca`, #1588).
+3. A local kernel build is a Stage 0 nix build that first bootstraps the **whole
+   builder VM image** (`bootstrap_builder_vm_image_via_root_dir_stage0`) — the
+   "Builder VM image build" spinner and the leaking compile stream.
+4. That nix build then fails on the `/homeless-shelter` purity bug (already
+   fixed on `fix/stage0-homeless-shelter-purity`).
+
+So the builder VM is today the *vehicle for producing the kernel, and only the
+kernel*. The fix is to make the kernel a cheap cached artifact and to demote the
+builder VM from an interactive dev environment to a headless build engine.
+
+## Goals
+
+1. `machine run --image` never does more than **acquire a cached-or-one-time
+   kernel**; it never redundantly rebuilds the full builder image.
+2. Two audiences, two paths:
+   - **Installed end-user:** download + verify + cache a prebuilt workload
+     kernel (seconds; no builder VM, ever).
+   - **Source-checkout contributor:** build the kernel **once**, cache it
+     forever; every later run is instant.
+3. The **builder VM becomes a headless, single-purpose nix build engine**: it
+   builds images (the kernel and user `--flake` images) and nothing else. No
+   interactive shell.
+4. Builder-VM networking for nix substituters rides **audited host-brokered
+   egress** (guest → vsock → host proxy → `cache.nixos.org`), giving
+   auditability / attestation / traceability by construction. No raw guest NIC.
+5. **`mvmctl dev` interactive subcommands are removed** (`up/down/shell/status`);
+   first-class build **logs** replace the "shell in to debug a build" use case.
+6. Cold builds are honest: one clear labeled line, logged to a file, `-v`
+   streams, failures print the tail + log path.
+
+## Non-goals
+
+- No `mvmctl builder` subcommand tree (YAGNI — auto-build-once needs none; add a
+  thin pre-warm verb later only if CI wants it).
+- No third-party build caches (Cachix/attic stay off the table — hermeticity).
+- No raw guest NIC for the builder VM.
+- Not redesigning attestation or the egress data plane — reuse Plan 213 packs
+  and the existing host-brokered egress path.
+- Not relaxing the ADR-046 source-checkout hermeticity rule for the kernel:
+  contributors still build locally; only *installed* builds download.
+
+## Design
+
+### 1. Kernel as a cached artifact (the core)
+
+`ensure_workload_kernel` resolution order, unchanged in spirit, hardened in
+practice:
+
+1. **Cached** — `find_cached_workload_kernel` hit → use it (no build, no
+   network). Cache key includes the arch + kernel-config fingerprint (already
+   in place, #1477) so a config edit invalidates correctly and nothing else
+   does.
+2. **ReusableBuilder** — non-prod run + an existing builder kernel present →
+   reuse it (no build). A contributor who has ever built anything already has a
+   kernel here, so the common "cold OCI run" costs **zero** extra build.
+3. **Acquire**:
+   - Installed build → **download** `vmlinux-<arch>-workload` + checksums,
+     hash-verify, cache. Fixes the current 404 by having the release actually
+     publish the asset (align with #1640).
+   - Source checkout → **one-time local build**, cached forever.
+
+The source-checkout local build must **not** drag in a full builder-VM image
+rebuild when a reusable kernel exists, and when it genuinely must build, it is
+labeled as a *kernel* build, not a mysterious "Builder VM image build". Land the
+`fix/stage0-homeless-shelter-purity` fix so the one-time build succeeds.
+
+### 2. Builder VM = headless nix build engine
+
+- Keep the launch→build→teardown→prune lifecycle (the Stage 0 reaper already
+  prunes prefix-agnostically). Remove only the interactive layer.
+- **Networking:** no raw NIC. nix substituter fetches go over the audited
+  host-brokered egress path (vsock → host proxy → upstream). The host is the
+  chokepoint that records provenance — this is *how* goal 4's
+  attestation/traceability is satisfied, not a bolt-on.
+- **Attestation/traceability:** reuse Plan 213 attested builder packs + the
+  chain-signed audit log; every brokered substituter fetch is host-logged.
+
+### 3. Logging: inspect / log / fix (replaces the dev shell)
+
+Every builder/nix build emits:
+- one labeled line up front — e.g. `Building workload kernel (one-time, ~2 min)…`
+  or `Building image <name>…`;
+- full output streamed to a **log file** at a stable path echoed to the user;
+- live stream when `-v`/`--verbose` is passed;
+- on failure: the last ~30 lines **plus** the log path, not the raw
+  cargo-over-spinner soup.
+
+This is the entire justification for removing `mvmctl dev`: if you can read,
+tail, and diagnose a build from its log, you never need a shell inside the
+builder.
+
+### 4. Remove `mvmctl dev`
+
+- Delete `dev up/down/shell/status` and the interactive builder-shell paths
+  (PTY/console-over-vsock *into the builder*; the workload console path is
+  untouched — claim 15).
+- Keep the builder VM launch/build/teardown internals the build path calls.
+- **Descope consequence:** in-flight interactive-dev work
+  (`feat/plan-222-phase4-devbackend-hvf` — HVF dev VM + `/work` virtiofs shell,
+  and siblings) is abandoned by this decision. Flag before landing.
+
+## Sequencing (multi-workstream)
+
+- **WS1 — Unblock.** Land `fix/stage0-homeless-shelter-purity`. Small.
+- **WS2 — Kernel-cheap run.** Reuse-or-build-once-and-cache; guarantee a reusable
+  kernel short-circuits; ensure `--image` never bootstraps the full builder
+  image when a kernel is obtainable. Integration test: cold OCI run performs no
+  full-builder-image build; second run is instant.
+- **WS3 — Logging overhaul.** Log-to-file + `-v` stream + tail-on-failure. This
+  gates WS6.
+- **WS4 — End-user download.** Release publishes `vmlinux-<arch>-workload` +
+  checksums; wire/verify the download path for installed builds (with #1640).
+- **WS5 — Builder audited egress.** nix substituters over host-brokered egress;
+  attestation/audit witnesses. Reuse existing egress + Plan 213.
+- **WS6 — Remove `mvmctl dev`.** Delete interactive subcommands + tests + docs
+  once WS3 lands.
+
+WS1→WS3 fix the reported bug and the DX. WS4→WS6 complete the vision.
+
+## Testing
+
+- Cold-cache `machine run --image` integration test: asserts no
+  `bootstrap_builder_vm_image` invocation, kernel materialized + cached, and a
+  second run resolves `Cached` with no build.
+- `/homeless-shelter` purity regression (from the fix branch).
+- Logging: build routed to a file; failure surfaces tail + path; `-v` streams.
+- `dev` removal: `tests/cli.rs` help/arg-parse updated; no `dev` subcommand.
+- Builder egress: substituter fetch is brokered + audited (witness).
+
+## Reconciliation with in-flight work
+
+- **Reuse:** `fix/stage0-homeless-shelter-purity` (WS1), #1640 kernel-pin-fetch
+  (WS4), Plan 242 overlay (already provides the guest-binary overlay), Plan 213
+  attested packs + existing host-brokered egress (WS5).
+- **Supersede / descope:** `mvmctl dev` interactive work incl.
+  `feat/plan-222-phase4-devbackend-hvf`.
+- This design is a DX-focused consolidation over a heavily-worked area; it does
+  not compete with Plan 236 — it delivers Plan 236's "cleaner runtime UX than
+  the field" line for the OCI-run path.
+
+## Open risks
+
+- **Reusable-vs-fresh kernel correctness.** Reusing the builder kernel as the
+  workload kernel is only safe where configs match; the fingerprint key must
+  gate this or a slim workload kernel diverges from a fat builder kernel
+  (interacts with Plan 239).
+- **Removing `dev` mid-flight.** Several worktrees actively build dev-mode HVF;
+  coordinate the descope so we don't strand merged pieces.
+- **Release asset availability.** The end-user download path is only as good as
+  the release job actually publishing the kernel asset per arch.

--- a/specs/plans/246-oci-run-builder-demotion.md
+++ b/specs/plans/246-oci-run-builder-demotion.md
@@ -1,0 +1,341 @@
+# Kernel-cheap `machine run --image` + builder-VM demotion — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: use superpowers:subagent-driven-development
+> (recommended) or superpowers:executing-plans to implement this plan task-by-task.
+> Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Plan number:** 246 (verify still free against open PRs before landing PR 1)
+**Design:** `specs/notes/2026-07-11-oci-run-builder-vm-demotion-design.md`
+**Status:** draft — PR 1 is this document
+**Owner:** Ari
+
+**Goal:** Make `mvmctl machine run --image <oci>` acquire its kernel cheaply
+(reuse-or-build-once-and-cache, never a redundant full builder-image build, never
+a hermeticity-violating download in a source checkout), fix the crash, give every
+builder/nix build first-class logs, and then retire the interactive `mvmctl dev`.
+
+**Architecture:** An `--image` run already materializes its rootfs + guest-binary
+overlay in-process (`oci_runtime_inject` + `materialize_ext4_pure`); only the Linux
+kernel pulls in the builder VM. We (1) land the Stage 0 purity/failure-surfacing
+fix, (2) correct the kernel resolver so a source checkout builds/reuses locally
+(download is installed-builds-only), (3) route the noisy host-side supervisor
+rebuild and in-guest nix stream through a log file with a clean heartbeat and
+`-v` passthrough, then (4) delete the `mvmctl dev` interactive surface — keeping the
+builder VM as a headless nix build engine.
+
+**Tech Stack:** Rust (Cargo workspace, `mvm-cli` / `mvm-build`), libkrun Stage 0
+builder VM, nix, `cargo-nextest`, clap.
+
+## Global Constraints
+
+Copied verbatim from the repo rules — every task's requirements include these:
+
+- `cargo fmt --all -- --check` clean; run `rustup run nightly cargo fmt --all` before push (CI Lint is nightly rustfmt).
+- `cargo nextest run --workspace` green; `cargo test --workspace --doc` green; `cargo clippy --workspace --all-targets -- -D warnings` clean. Run the FULL crate suite, not `-p`-filtered.
+- Never cite plans/PRs/ADRs/workstreams in **code comments** (`Plan N`, `ADR-\d+`, `#NNNN`, `W\d.` are CI-banned via `check-no-spec-refs-in-comments`). Spec/plan prose may cite freely; example code in this plan must not carry such comments.
+- No `#[allow(clippy::too_many_arguments)]`; use a params struct + builder.
+- Reuse-first: no reimplementation of existing helpers; all `~/.mvm` / `~/.cache/mvm` paths via `mvm_core::config`.
+- Source-checkout hermeticity: a source checkout MUST NOT download mvm-published artifacts; it builds locally. Only an installed binary downloads.
+- Commits: no `Co-Authored-By: Claude` trailer; attribute to the user. No AI-tool attribution in PRs.
+- All work in this worktree (`worktree-oci-run-builder-demotion-design`); never edit the main checkout.
+- Keep `specs/SPRINT.md` + `specs/REFACTOR-STATUS.md` in sync in the same change that lands a workstream.
+
+---
+
+# Phase 1 — PR 2: kernel-cheap `machine run --image` (WS1 + WS2 + WS3)
+
+Ship + confirm this whole phase works end-to-end (including reading a failing
+builder log) before starting Phase 2.
+
+### Task 1: Land the Stage 0 purity + failure-surfacing fix (WS1)
+
+The `/homeless-shelter` crash and the "clean exit hides a nix failure" masking are
+already fixed, with tests, on `fix/stage0-homeless-shelter-purity`. Reland, don't
+rewrite.
+
+**Files:**
+- Modify: `crates/mvm-build/src/bin/stage0-init.rs` (`purge_stale_nix_builder_home` + call before nix invoke)
+- Modify: `crates/mvm-build/src/libkrun_builder.rs` (`stage0_console_halt_outcome`, `Stage0HaltOutcome`, `BuildFailed`/`NoCleanHalt` surfacing after supervisor exit)
+- Tests (already authored on the branch): `purge_stale_nix_builder_home_removes_leftover_and_tolerates_absence`, `stage0_console_halt_outcome_distinguishes_success_failure_and_silence`
+
+**Interfaces produced:** a Stage 0 build that (a) self-heals a stale
+`/homeless-shelter` before nix's unsandboxed purity check trips, and (b) returns
+`BuilderVmError::NixBuildFailed(<msg + 20-line console tail>)` instead of a clean
+`Ok(())` when the guest reported `stage0-init: build failed`.
+
+- [ ] **Step 1: Cherry-pick the fix commits onto this branch**
+
+```bash
+git log --oneline main..fix/stage0-homeless-shelter-purity   # identify the commit(s)
+git cherry-pick <sha>...<sha>
+```
+
+- [ ] **Step 2: Run the relanded tests, verify PASS**
+
+```bash
+cargo nextest run -p mvm-build purge_stale_nix_builder_home stage0_console_halt_outcome
+```
+Expected: both tests PASS.
+
+- [ ] **Step 3: Full crate gate + commit**
+
+```bash
+cargo nextest run -p mvm-build && cargo clippy -p mvm-build --all-targets -- -D warnings
+git commit -am "fix(stage0): purge stale nix builder home; surface guest build failure"
+```
+
+### Task 2: Kernel resolver — source checkouts build/reuse locally, never download (WS2)
+
+**Problem (verified on `main`):** `resolve_workload_kernel_bootstrap`
+(`crates/mvm-cli/src/commands/env/dev_vz/default_microvm.rs:61`) routes a
+source checkout with a cold cache to the **`Download`** arm, because
+`workload_kernel_source_build_requested` (`default_microvm.rs:83`) only returns
+true when `MVM_KERNEL_SOURCE=compile`. That download hits
+`releases/download/v{dev-version}` → 404, and it violates source-checkout
+hermeticity. A source checkout must **build** (or reuse the builder kernel); only
+an installed build downloads.
+
+**Files:**
+- Modify: `crates/mvm-cli/src/commands/env/dev_vz/default_microvm.rs:83-93` (`workload_kernel_source_build_requested`)
+- Test: same file's `#[cfg(test)] mod tests` (extend the existing resolver tests)
+
+**Interfaces produced:** `resolve_workload_kernel_bootstrap(cache_dir, arch, prod, source_build_requested)` unchanged in signature; `source_build_requested` now true for *every* source checkout unless `MVM_KERNEL_SOURCE=download` explicitly overrides.
+
+- [ ] **Step 1: Write the failing resolver matrix test**
+
+```rust
+#[test]
+fn source_checkout_cold_cache_builds_never_downloads() {
+    let tmp = tempfile::tempdir().unwrap();
+    let cache = tmp.path().to_str().unwrap();
+    // No cached kernel, no reusable builder kernel, source checkout, non-prod:
+    // must BUILD locally (hermeticity) — must NOT be Download.
+    let got = resolve_workload_kernel_bootstrap(cache, "aarch64", false, /*source_build_requested=*/ true);
+    assert!(matches!(got, WorkloadKernelBootstrap::Build(_)), "got {got:?}");
+}
+
+#[test]
+fn installed_build_cold_cache_downloads() {
+    let tmp = tempfile::tempdir().unwrap();
+    let cache = tmp.path().to_str().unwrap();
+    // Installed binary (source_build_requested=false): Download is correct.
+    let got = resolve_workload_kernel_bootstrap(cache, "aarch64", false, false);
+    assert!(matches!(got, WorkloadKernelBootstrap::Download(_)), "got {got:?}");
+}
+```
+
+- [ ] **Step 2: Run, verify the first test FAILS on current logic**
+
+```bash
+cargo nextest run -p mvm-cli source_checkout_cold_cache_builds_never_downloads
+```
+Expected: FAIL (current default routes source checkout → Download).
+
+- [ ] **Step 3: Flip the default in `workload_kernel_source_build_requested`**
+
+```rust
+fn workload_kernel_source_build_requested(source_checkout: bool) -> bool {
+    #[cfg(feature = "builder-vm")]
+    {
+        // A source checkout builds the kernel locally by default; the
+        // hermeticity rule forbids depending on a published artifact. Only an
+        // explicit opt-out downloads (test/CI escape hatch).
+        source_checkout && !matches!(resolve_kernel_source(), Some(KernelSource::Download))
+    }
+    #[cfg(not(feature = "builder-vm"))]
+    {
+        let _ = source_checkout;
+        false
+    }
+}
+```
+(Verify `KernelSource::Download` exists in `dev_vz/kernel.rs`; it is referenced in `bootstrap.rs`.)
+
+- [ ] **Step 4: Run both resolver tests, verify PASS**
+
+```bash
+cargo nextest run -p mvm-cli source_checkout_cold_cache_builds_never_downloads installed_build_cold_cache_downloads
+```
+Expected: both PASS. Confirm the existing `Cached`/`ReusableBuilder` priority tests still pass (reuse still wins over build for non-prod).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git commit -am "fix(kernel): source checkout builds workload kernel locally, never downloads"
+```
+
+### Task 3: Route the host-side builder rebuild + nix stream through a log file (WS3)
+
+**Problem (verified):** the "terrible logs" are the host cargo rebuild of
+`mvm-libkrun-supervisor` ("[mvm] building mvm-libkrun-supervisor for this source
+checkout…") and the in-guest nix stream printing raw lines that interleave with
+the `BuildHeartbeat` spinner (`bootstrap.rs:524`). Default runs should show one
+clean labeled heartbeat; full output goes to a log file; `-v` streams live.
+
+**Files:**
+- Modify: the host aux-bin rebuild path that emits `building mvm-libkrun-supervisor …` (grep `building mvm-libkrun-supervisor for this source checkout`) — capture its child stdout/stderr to a log file instead of inheriting the terminal, unless verbose.
+- Modify: `crates/mvm-cli/src/commands/env/dev_vz/bootstrap.rs` around the `BuildHeartbeat::start` sites (`:73`) — echo the log path once ("logs: <path> — tail -f, or -v to stream").
+- Test: a unit test on the log-capture helper (child output lands in the file; verbose bypasses capture).
+
+**Interfaces produced:** a small helper, e.g. `run_logged(cmd, log_path, verbose) -> Result<()>`, that streams to the terminal when `verbose`, else writes combined output to `log_path` and returns an error carrying the tail on failure. Reuse the existing `read_console_tail` for the tail.
+
+- [ ] **Step 1: Write the failing capture test**
+
+```rust
+#[test]
+fn run_logged_writes_child_output_to_file_when_quiet() {
+    let tmp = tempfile::tempdir().unwrap();
+    let log = tmp.path().join("build.log");
+    run_logged(std::process::Command::new("sh").args(["-c", "echo hello; echo err 1>&2"]),
+               &log, /*verbose=*/ false).unwrap();
+    let body = std::fs::read_to_string(&log).unwrap();
+    assert!(body.contains("hello") && body.contains("err"), "combined output captured: {body}");
+}
+```
+
+- [ ] **Step 2: Run, verify FAIL (helper absent)**
+
+```bash
+cargo nextest run -p mvm-cli run_logged_writes_child_output_to_file_when_quiet
+```
+Expected: FAIL — `run_logged` not defined.
+
+- [ ] **Step 3: Implement `run_logged` + wire the supervisor rebuild through it**
+
+Implement the helper (combined stdout+stderr → file, or inherit when verbose;
+on nonzero exit return an error with the last ~30 lines via `read_console_tail`).
+Replace the direct terminal-inheriting spawn of the `mvm-libkrun-supervisor`
+rebuild with `run_logged(cmd, &log_path, ui::is_verbose())`. Echo the log path
+once next to the heartbeat.
+
+- [ ] **Step 4: Run capture test + manual smoke, verify PASS + clean output**
+
+```bash
+cargo nextest run -p mvm-cli run_logged_writes_child_output_to_file_when_quiet
+```
+Expected: PASS. Manual: a cold `machine run --image` shows a single heartbeat + a
+`logs: …` line, not a cargo `Building [===]` stream.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git commit -am "feat(build-logs): capture builder rebuild + nix stream to a log; -v streams"
+```
+
+### Task 4: Honest labels + failure surfaces the log path (WS3)
+
+**Files:**
+- Modify: `bootstrap.rs:73` heartbeat label `"Builder VM image build"` → a label that reflects what is happening for an `--image` run, e.g. `"Preparing build environment (one-time)"`; and `default_microvm.rs:32` `"Building workload kernel locally…"` stays but gains the log path.
+- Test: assert the failure error string carries the console log path (compose with Task 1's `NixBuildFailed`).
+
+- [ ] **Step 1: Write/extend the failure-surface test**
+
+```rust
+#[test]
+fn stage0_build_failure_error_names_the_log_path() {
+    let err = BuilderVmError::NixBuildFailed(
+        "nix build failed inside the Stage 0 guest; console log at /tmp/c.log\n<tail>".into());
+    assert!(err.to_string().contains("console log at /tmp/c.log"));
+}
+```
+
+- [ ] **Step 2: Run, verify PASS after relabel (label is cosmetic; error path is Task 1)**
+
+```bash
+cargo nextest run -p mvm-cli -p mvm-build stage0_build_failure_error_names_the_log_path
+```
+
+- [ ] **Step 3: Relabel + commit**
+
+```bash
+git commit -am "feat(build-logs): honest one-time-build label; failures name the log path"
+```
+
+### Task 5: Integration proof — cold `--image` run does no redundant builder-image build (WS2, the confirm gate)
+
+**Files:**
+- Test: `tests/oci_image_runner_smoke.rs` (extend) or a new `tests/machine_run_kernel_resolution.rs`.
+
+- [ ] **Step 1: Write the integration test**
+
+Seed a fake reusable builder kernel at `{cache}/builder-vm/{arch}/vmlinux`, drive
+the kernel-resolution entry the run path uses (`ensure_workload_kernel(false)` or
+`resolve_workload_kernel_bootstrap`), assert it resolves `ReusableBuilder` (no
+build) and does not invoke `bootstrap_builder_vm_image`. Then remove the kernel and
+assert a source checkout resolves `Build` (not `Download`).
+
+- [ ] **Step 2: Run, verify PASS**
+
+```bash
+cargo nextest run -p mvm-cli --test machine_run_kernel_resolution
+```
+
+- [ ] **Step 3: Full workspace gate**
+
+```bash
+cargo fmt --all -- --check && cargo nextest run --workspace && cargo clippy --workspace --all-targets -- -D warnings
+```
+
+- [ ] **Step 4: Update sprint/refactor status + commit**
+
+Tick the Phase 1 items in `specs/SPRINT.md` and `specs/REFACTOR-STATUS.md`.
+
+```bash
+git commit -am "test(oci-run): cold --image reuses builder kernel, never redundant builder-image build"
+```
+
+**Phase 1 exit gate (manual, with the user):** on a *fresh* cache in this source
+checkout, `cargo run -- machine run --image alpine -it -- /bin/sh` boots without a
+mystery "Builder VM image build", any one-time build is honestly labeled + logged,
+and a deliberately-broken builder build is diagnosable from its log file. Confirm
+before Phase 2.
+
+---
+
+# Phase 2 — PR 3: remove `mvmctl dev` (WS6)
+
+**Hard gate:** start only after the Phase 1 exit gate passes — specifically after
+we have *proven* a builder-VM build failure is diagnosable from its log (Tasks 3–4).
+That inspection capability is the entire justification for removing the interactive
+shell.
+
+### Task 6: Delete the `dev` subcommand surface, keep the build internals
+
+**Files:**
+- Modify: the clap command tree (grep `Dev` / `dev up` / `dev shell` in `crates/mvm-cli/src/commands/` and the CLI enum) — remove `dev up/down/shell/status`.
+- Keep: the builder-VM launch/build/teardown internals in `dev_vz/` that the build path (`ensure_workload_kernel`, `build image`, `--flake`) still calls. Only the *interactive* entry points go.
+- Remove: the interactive builder-shell transport (PTY/console-over-vsock **into the builder**; grep `pick_console_transport` / builder console). Do **not** touch the workload console path (claim 15).
+
+- [ ] **Step 1:** Enumerate callers of the `dev` subcommands and the builder-shell transport; separate "interactive-only" from "build-internal" (a short written audit committed to the PR description).
+- [ ] **Step 2:** Remove the interactive command variants + their handlers; leave build internals compiling.
+- [ ] **Step 3:** `cargo nextest run --workspace` + `cargo clippy --workspace --all-targets -- -D warnings`.
+- [ ] **Step 4:** Commit.
+
+### Task 7: Update CLI tests, docs, and CLAUDE.md references
+
+**Files:**
+- Modify: `tests/cli.rs` (drop `dev` help/arg-parse expectations).
+- Modify: `public/src/content/docs/reference/cli-commands.md`, `public/src/content/docs/contributing/development.md` (remove `mvmctl dev …`; document "build logs live at <path>, `-v` to stream" as the debugging story).
+- Modify: `CLAUDE.md` (the `mvmctl dev` bullets under "Key Design Decisions" and "Build and Run").
+
+- [ ] **Step 1:** Update `tests/cli.rs`; run it.
+- [ ] **Step 2:** Update docs + `CLAUDE.md`.
+- [ ] **Step 3:** Update `specs/SPRINT.md` + `specs/REFACTOR-STATUS.md`; note the `feat/plan-222-phase4-devbackend-hvf` descope.
+- [ ] **Step 4:** Full workspace gate + commit.
+
+---
+
+# Deferred follow-ups (out of the 3-PR scope — separate plans)
+
+- **WS4 — end-user prebuilt-kernel download / release asset.** Make the release
+  publish `vmlinux-<arch>-workload` + `kernel-<arch>-checksums-sha256.txt` so the
+  installed-build `Download` arm (`default_microvm.rs:100`) stops 404-ing. Aligns
+  with `#1640`.
+- **WS5 — builder audited-egress cutover.** Route builder-VM nix-substituter
+  fetches over host-brokered egress (attestation/traceability); hand off to Plan
+  236's builder no-guest-NIC work rather than duplicate it.
+
+# Self-review notes
+
+- **Spec coverage:** WS1→Task 1; WS2→Tasks 2,5; WS3→Tasks 3,4; WS6→Tasks 6,7; WS4/WS5 deferred. All design goals mapped.
+- **Open risk carried from design:** reusing the builder kernel as the workload kernel is only safe when configs match — the cache is keyed by kernel-config fingerprint; Task 5 must not weaken that (interacts with Plan 239 kernel slimming).


### PR DESCRIPTION
**PR 1 of 3** — plan only, no code. Design note + implementation plan for making `mvmctl machine run --image` kernel-cheap and demoting the builder VM to a headless nix build engine.

## Why

`machine run --image alpine` in a source checkout spends ~2 min on an opaque "Builder VM image build", garbles its logs, and dies on `home directory "/homeless-shelter" exists`. Running a runtime OCI image should not build the Nix builder VM.

**Root cause:** an `--image` run already materializes its rootfs + guest-binary overlay in-process; only the **kernel** pulls in the builder VM. And on `main` today the kernel resolver sends a *source checkout with a cold cache to the `Download` arm* → `releases/download/v{dev-version}` → **404**, which also violates the source-checkout hermeticity rule. Both the build path and the download path are broken.

## What this plan does

- **Phase 1 (PR 2/3):** reland the Stage 0 purity/failure-surfacing fix; flip the kernel resolver so a source checkout builds/reuses locally (download is installed-builds-only); route the noisy host rebuild + nix stream through a **log file** (`-v` streams); honest labels; integration proof that a cold `--image` run reuses the builder kernel with no redundant builder-image build.
- **Phase 2 (PR 3/3):** hard-gated on Phase 1's build logging being proven able to diagnose a failure — delete the `mvmctl dev` interactive surface, keep the headless build engine.
- **Deferred (separate plans):** end-user prebuilt-kernel download / release asset (WS4); builder audited-egress cutover (WS5, handed to Plan 236).

## Files

- `specs/notes/2026-07-11-oci-run-builder-vm-demotion-design.md` — design
- `specs/plans/246-oci-run-builder-demotion.md` — implementation plan

## Notes

- Plan number 246 is free on `main` and all fetched branches; renumber if it collides.
- Docs-only; no workspace gates run (no Rust changed).