### PR TITLE
Plan 213 SP3 (producer + guest import): carry & import a seeded nix closure

### DIFF
--- a/crates/mvm-backend/examples/hvf-builder-transport.rs
+++ b/crates/mvm-backend/examples/hvf-builder-transport.rs
@@ -21,7 +21,9 @@ fn main() {
 
     let home = std::env::var("HOME").unwrap();
     let dev = format!("{home}/.mvm/dev/current");
-    let kernel = PathBuf::from(format!("{dev}/vmlinux"));
+    let kernel = PathBuf::from(
+        std::env::var("MVM_BUILDER_KERNEL").unwrap_or_else(|_| format!("{dev}/vmlinux")),
+    );
     // MVM_BUILDER_ROOTFS points at a rootfs with the current mvm-host-vm-init
     // baked in (e.g. the self-hosted-inject output); default is the dev image.
     let rootfs = PathBuf::from(
@@ -66,6 +68,11 @@ fn main() {
     // SAFETY: single-threaded example setup.
     unsafe { std::env::set_var("MVM_HVF_TIMEOUT", "180") };
 
+    // Optional seeded-closure NAR: when set, it rides the input disk to
+    // `/closure-seed/nix-closure.nar` and the guest init imports it.
+    let closure_nar_env = std::env::var("MVM_BUILDER_CLOSURE_NAR").ok();
+    let closure_nar = closure_nar_env.as_deref().map(std::path::Path::new);
+
     println!("booting the builder VM on HVF (disk transport, no nix)…");
     let runner = BuilderRunner::new(HvfDriver::new());
     let outcome = runner
@@ -78,7 +85,7 @@ fn main() {
             work_src: &work,
             host_bin_dir: &bins,
             runtime_overlay: None,
-            closure_nar: None,
+            closure_nar,
             output_size: 64 << 20,
             vcpus: 2,
             // Builder-appropriate RAM (a real nix build OOMs at 512 MiB);

--- a/crates/mvm-backend/examples/hvf-builder-transport.rs
+++ b/crates/mvm-backend/examples/hvf-builder-transport.rs
@@ -78,6 +78,7 @@ fn main() {
             work_src: &work,
             host_bin_dir: &bins,
             runtime_overlay: None,
+            closure_nar: None,
             output_size: 64 << 20,
             vcpus: 2,
             // Builder-appropriate RAM (a real nix build OOMs at 512 MiB);

--- a/crates/mvm-backend/examples/hvf-rootfs-inject.rs
+++ b/crates/mvm-backend/examples/hvf-rootfs-inject.rs
@@ -24,8 +24,12 @@ fn main() {
 
     let home = std::env::var("HOME").unwrap();
     let dev = format!("{home}/.mvm/dev/current");
-    let kernel = PathBuf::from(format!("{dev}/vmlinux"));
-    let src_rootfs = PathBuf::from(format!("{dev}/rootfs.ext4"));
+    let kernel = PathBuf::from(
+        std::env::var("MVM_INJECT_KERNEL").unwrap_or_else(|_| format!("{dev}/vmlinux")),
+    );
+    let src_rootfs = PathBuf::from(
+        std::env::var("MVM_INJECT_SRC_ROOTFS").unwrap_or_else(|_| format!("{dev}/rootfs.ext4")),
+    );
     let musl = "target/aarch64-unknown-linux-musl/release";
     let patcher = PathBuf::from(format!("{musl}/mvm-rootfs-patcher"));
     let new_init = PathBuf::from(format!("{musl}/mvm-host-vm-init"));

--- a/crates/mvm-backend/src/builder_runner/hvf_builder.rs
+++ b/crates/mvm-backend/src/builder_runner/hvf_builder.rs
@@ -43,6 +43,10 @@ pub struct HvfBuilderVm {
     kernel: PathBuf,
     /// Builder rootfs whose baked `mvm-host-vm-init` speaks the disk transport.
     rootfs: PathBuf,
+    /// Optional seeded Nix store closure NAR, resolved alongside the builder
+    /// image when it carries one. `None` (the common case today) attaches no
+    /// closure-seed share at all.
+    closure_nar: Option<PathBuf>,
     nix_store_mib: u32,
     output_mib: u32,
     vcpus: u32,
@@ -55,6 +59,7 @@ impl HvfBuilderVm {
         Self {
             kernel,
             rootfs,
+            closure_nar: None,
             nix_store_mib: DEFAULT_NIX_STORE_MIB,
             output_mib: DEFAULT_OUTPUT_MIB,
             vcpus: DEFAULT_VCPUS,
@@ -133,6 +138,16 @@ impl HvfBuilderVm {
             job_dir: outcome.output_dir,
             vm_state_dir,
         })
+    }
+
+    /// Attach a seeded Nix store closure NAR resolved from the builder image.
+    /// Every `run_build` after this call packs the NAR onto the input disk
+    /// under `closure-seed/`; omitting this call (the default) attaches
+    /// nothing, so a builder image without a closure boots exactly as before
+    /// this seam existed.
+    pub fn with_closure_nar(mut self, closure_nar: Option<PathBuf>) -> Self {
+        self.closure_nar = closure_nar;
+        self
     }
 }
 
@@ -249,6 +264,7 @@ impl BuilderVm for HvfBuilderVm {
                 work_src: &mounts.flake_src,
                 host_bin_dir: &mounts.host_bin_dir,
                 runtime_overlay: runtime_overlay.as_deref(),
+                closure_nar: self.closure_nar.as_deref(),
                 output_size: u64::from(self.output_mib) << 20,
                 vcpus: self.vcpus,
                 memory_mib: self.memory_mib,
@@ -302,6 +318,15 @@ mod tests {
         let b = HvfBuilderVm::new("/k".into(), "/r".into()).with_resources(2, 2048);
         assert_eq!(b.vcpus, 2);
         assert_eq!(b.memory_mib, 2048);
+    }
+
+    #[test]
+    fn closure_nar_defaults_to_none_and_is_settable() {
+        let b = HvfBuilderVm::new("/k".into(), "/r".into());
+        assert_eq!(b.closure_nar, None);
+        let with_closure =
+            HvfBuilderVm::new("/k".into(), "/r".into()).with_closure_nar(Some("/nar".into()));
+        assert_eq!(with_closure.closure_nar, Some(PathBuf::from("/nar")));
     }
 
     #[test]

--- a/crates/mvm-backend/src/builder_runner/hvf_builder.rs
+++ b/crates/mvm-backend/src/builder_runner/hvf_builder.rs
@@ -117,6 +117,7 @@ impl HvfBuilderVm {
                 work_src: &job.work_dir,
                 host_bin_dir: &host_bin_dir,
                 runtime_overlay: runtime_overlay.as_deref(),
+                closure_nar: None,
                 output_size: u64::from(self.output_mib) << 20,
                 vcpus: self.vcpus,
                 memory_mib: self.memory_mib,

--- a/crates/mvm-backend/src/builder_runner/runner.rs
+++ b/crates/mvm-backend/src/builder_runner/runner.rs
@@ -50,6 +50,10 @@ pub struct BuilderBuild<'a> {
     pub host_bin_dir: &'a Path,
     /// Optional read-only runtime overlay ext4 for the builder guest.
     pub runtime_overlay: Option<&'a Path>,
+    /// Optional seeded Nix store closure NAR, resolved from the builder
+    /// image when it carries one → the guest's `/closure-seed/<file>`. `None`
+    /// (the common case today) adds no share at all.
+    pub closure_nar: Option<&'a Path>,
     /// Output disk size in bytes; must exceed the artifact tar (rootfs + sidecars).
     pub output_size: u64,
     pub vcpus: u32,
@@ -107,6 +111,7 @@ impl<D: VmmDriver + 'static> BuilderRunner<D> {
                     src: b.host_bin_dir,
                 },
             ],
+            b.closure_nar,
             &input_disk,
             INPUT_DISK_MIN,
         )?;
@@ -225,6 +230,7 @@ mod tests {
                 work_src: &work,
                 host_bin_dir: &bins,
                 runtime_overlay: None,
+                closure_nar: None,
                 output_size: 1 << 20,
                 vcpus: 2,
                 memory_mib: 1024,
@@ -242,5 +248,69 @@ mod tests {
         // mock guest, which writes nothing).
         assert!(tmp.path().join("vms/bld-unit/input.img").exists());
         assert!(outcome.output_dir.exists());
+    }
+
+    #[test]
+    fn build_rides_the_closure_nar_on_the_same_input_disk_when_present() {
+        // Attaching a seeded closure must never grow the disk layout — it
+        // rides inside the existing input.img tar, so the builder spec still
+        // boots exactly 4 disks.
+        let _guard = crate::base::runtime_meta::HOME_TEST_LOCK
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner());
+        let mut env = TestEnv::new();
+        let tmp = tempfile::tempdir().unwrap();
+        env.set("MVM_DATA_DIR", tmp.path());
+
+        let job = tmp.path().join("job");
+        let work = tmp.path().join("work");
+        let bins = tmp.path().join("bins");
+        for d in [&job, &work, &bins] {
+            std::fs::create_dir_all(d).unwrap();
+        }
+        std::fs::write(job.join("cmd.sh"), b"#!/bin/sh\nnix build\n").unwrap();
+        std::fs::write(work.join("flake.nix"), b"{}").unwrap();
+        std::fs::write(bins.join("mvm-host-vm-init"), b"ELF").unwrap();
+        let kernel = tmp.path().join("Image");
+        let rootfs = tmp.path().join("rootfs.ext4");
+        let nix_store = tmp.path().join("nix-store.img");
+        for f in [&kernel, &rootfs, &nix_store] {
+            std::fs::write(f, b"x").unwrap();
+        }
+        let closure = tmp.path().join("nix-closure.nar");
+        std::fs::write(&closure, b"pretend-nar-bytes").unwrap();
+
+        let runner = BuilderRunner::new(MockDriver::default().reporting_status(VmStatus::Stopped));
+        let outcome = runner
+            .build(&BuilderBuild {
+                name: "bld-closure",
+                kernel: &kernel,
+                rootfs: &rootfs,
+                nix_store: &nix_store,
+                job_dir: &job,
+                work_src: &work,
+                host_bin_dir: &bins,
+                closure_nar: Some(&closure),
+                output_size: 1 << 20,
+                vcpus: 2,
+                memory_mib: 1024,
+            })
+            .expect("build orchestrates against the mock driver");
+
+        assert!(outcome.stopped);
+        assert_eq!(runner.driver.booted_specs()[0].blocks.len(), 4);
+
+        // Extract the packed input disk directly to confirm the closure NAR
+        // landed under closure-seed/ alongside job/work/mvm-bins.
+        let extracted = tmp.path().join("extracted-input");
+        mvm_build::builder_disk_transport::read_output_disk(
+            &tmp.path().join("vms/bld-closure/input.img"),
+            &extracted,
+        )
+        .unwrap();
+        assert_eq!(
+            std::fs::read(extracted.join("closure-seed/nix-closure.nar")).unwrap(),
+            b"pretend-nar-bytes"
+        );
     }
 }

--- a/crates/mvm-backend/src/builder_runner/runner.rs
+++ b/crates/mvm-backend/src/builder_runner/runner.rs
@@ -290,6 +290,7 @@ mod tests {
                 job_dir: &job,
                 work_src: &work,
                 host_bin_dir: &bins,
+                runtime_overlay: None,
                 closure_nar: Some(&closure),
                 output_size: 1 << 20,
                 vcpus: 2,

--- a/crates/mvm-build/examples/mvm-builder-pack-tool.rs
+++ b/crates/mvm-build/examples/mvm-builder-pack-tool.rs
@@ -15,6 +15,7 @@
 //!   --vmlinux <path> --rootfs <path> --arch <x86_64|aarch64> \
 //!   --channel <name> --signing-key <hex-file> --out-dir <dir> \
 //!   --sbom <path> --revocation-channel <url> \
+//!   [--closure <nar-path>] \
 //!   [--builder-identity <s>] [--build-env <s>] \
 //!   [--valid-days <n>] [--mirror-identity <s>] [--sbom-uri <url>]
 //!
@@ -24,6 +25,7 @@
 //!   --vmlinux <path> --rootfs <path> --arch <x86_64|aarch64> \
 //!   --channel <name> --keyless --identity <SAN> --out-dir <dir> \
 //!   --sbom <path> --revocation-channel <url> \
+//!   [--closure <nar-path>] \
 //!   [--builder-identity <s>] [--build-env <s>] \
 //!   [--valid-days <n>] [--mirror-identity <s>] [--sbom-uri <url>]
 //! ```
@@ -38,7 +40,11 @@
 //! field with a real published location (e.g. a release download URL); the
 //! sha256 is always computed from the local `--sbom` file regardless. Without
 //! it, the `uri` falls back to a `file://` path of the local SBOM file, which
-//! is only meaningful on the machine that produced the pack.
+//! is only meaningful on the machine that produced the pack. `--closure`
+//! optionally bundles a seeded Nix store closure NAR (a `nix-store --export`
+//! of the dev-shell toolchain) into a builder pack; omitting it produces a
+//! pack exactly as before this flag existed, and is only accepted with the
+//! default builder kind (a runtime pack never carries one).
 
 use std::fs;
 use std::path::{Path, PathBuf};
@@ -82,12 +88,15 @@ fn usage() {
          \x20 --channel <name> --out-dir <dir> \\\n\
          \x20 --sbom <path> --revocation-channel <url> \\\n\
          \x20 (--signing-key <hex-file> | --keyless --identity <SAN>) \\\n\
+         \x20 [--closure <nar-path>] \\\n\
          \x20 [--builder-identity <s>] [--build-env <s>] \\\n\
          \x20 [--valid-days <n>] [--mirror-identity <s>] [--sbom-uri <url>]\n\
          \n\
          --kind defaults to builder; --kind runtime additionally needs \
          --verity and --roothash (the workload rootfs's dm-verity tree + root \
          hash) and is keyless-only (--keyless --identity).\n\
+         --closure optionally bundles a seeded Nix store closure NAR into a \
+         builder pack (default kind only); omitting it is unchanged behavior.\n\
          --sbom-uri overrides the manifest's SBOM reference uri with a \
          published location (e.g. a release download URL) instead of the \
          default file:// path of the local --sbom file; the sha256 is \
@@ -150,6 +159,7 @@ fn run(rest: &[String]) -> Result<(), String> {
     let params = BuildBuilderPackParams {
         vmlinux: parsed.vmlinux,
         rootfs: parsed.rootfs,
+        closure: parsed.closure,
         target_arch: parsed.arch,
         channel: parsed.channel,
         builder_identity: parsed.builder_identity,
@@ -211,6 +221,9 @@ struct ParsedArgs {
     roothash: Option<PathBuf>,
     /// `--kind runtime`. A runtime pack is keyless-only (no ed25519 producer).
     runtime: bool,
+    /// Optional seeded Nix store closure NAR (`--closure`). Only accepted for
+    /// the default builder kind; `None` when the flag is absent.
+    closure: Option<PathBuf>,
     arch: GuestArch,
     channel: String,
     signing_key: Option<PathBuf>,
@@ -244,6 +257,10 @@ fn parse_args(rest: &[String]) -> Result<ParsedArgs, String> {
                 .to_string(),
         );
     }
+    let closure = optional(rest, "closure").map(PathBuf::from);
+    if runtime && closure.is_some() {
+        return Err("--closure is only accepted for the default builder kind".to_string());
+    }
     // Both kinds carry a rootfs; a runtime pack additionally carries the
     // dm-verity hash tree + root hash so the launch can boot it verity-sealed.
     let rootfs = PathBuf::from(required(rest, "rootfs")?);
@@ -261,6 +278,7 @@ fn parse_args(rest: &[String]) -> Result<ParsedArgs, String> {
         verity,
         roothash,
         runtime,
+        closure,
         arch: required(rest, "arch")?
             .parse::<GuestArch>()
             .map_err(|e| e.to_string())?,
@@ -453,6 +471,24 @@ mod tests {
         assert_eq!(parsed.builder_identity, "mvm-builder-pack-tool");
         assert_eq!(parsed.valid_days, 365);
         assert_eq!(parsed.mirror_identity, None);
+        // --closure is absent by default.
+        assert_eq!(parsed.closure, None);
+    }
+
+    #[test]
+    fn closure_flag_is_parsed_when_given() {
+        let mut a = full_args();
+        a.extend(args(&[("closure", "/tmp/nix-closure.nar")]));
+        let parsed = parse_args(&a).expect("parse");
+        assert_eq!(parsed.closure, Some(PathBuf::from("/tmp/nix-closure.nar")));
+    }
+
+    #[test]
+    fn closure_flag_on_runtime_kind_is_error() {
+        let mut a = runtime_args();
+        a.extend(args(&[("closure", "/tmp/nix-closure.nar")]));
+        let err = parse_args(&a).expect_err("closure rejected on runtime kind");
+        assert!(err.contains("closure"), "got: {err}");
     }
 
     /// `full_args()` minus `--signing-key`, plus `--keyless --identity <SAN>`.

--- a/crates/mvm-build/src/bin/mvm-host-vm-init.rs
+++ b/crates/mvm-build/src/bin/mvm-host-vm-init.rs
@@ -1143,12 +1143,21 @@ mod linux {
     /// from. **Contract with the host wiring:** a host that resolved a
     /// builder pack carrying a closure (`BuildBuilderPackParams.closure`
     /// / `builder_pack::CLOSURE_FILE` = `"nix-closure.nar"`) attaches it
-    /// here as a read-only share before boot — that host-side attach
-    /// isn't wired yet, so today this path is always absent and
-    /// [`import_seeded_closure`] returns immediately. The filename
-    /// mirrors `CLOSURE_FILE` on purpose; keep the two in sync if either
-    /// moves.
+    /// here as a read-only share before boot. Absent when the resolved
+    /// builder image carries no closure — the common case today — in
+    /// which case [`import_seeded_closure`] returns immediately. The
+    /// filename mirrors `CLOSURE_FILE` on purpose; keep the two in sync
+    /// if either moves.
     const CLOSURE_SEED_NAR: &str = "/closure-seed/nix-closure.nar";
+
+    /// Parent directory of [`CLOSURE_SEED_NAR`] — the mount point the host
+    /// attaches the seeded closure at, whichever transport it uses (the
+    /// `closure-seed` virtio-fs tag on libkrun/qemu, the `closure-seed/`
+    /// disk-transport tar entry on the hvf VMM). A separate literal from
+    /// `CLOSURE_SEED_NAR` (not derived from it), matching how the other
+    /// fixed-share consts below are each declared independently; keep the
+    /// two in sync if either moves.
+    const CLOSURE_SEED_DIR: &str = "/closure-seed";
 
     /// Content-keyed idempotency marker recording the sha256 of the
     /// closure NAR most recently imported into the persistent store.
@@ -2921,11 +2930,12 @@ mod linux {
     /// writable so `write_result` can drop `/job/result`.
     const DISK_INPUT_STAGE: &str = "/run/builder-input";
 
-    /// Populate `/job`, `/work`, `/mvm-bins` from the input disk and back `/out`
-    /// with a writable dir on the persistent nix-store disk. This is the
-    /// disk-transport equivalent of the virtio-fs shares, for the hvf VMM
-    /// (which has no virtio-fs). A tmpfs `/out` would be capped by guest RAM —
-    /// too small for a built rootfs — so `/out` lives on the big nix-store disk.
+    /// Populate `/job`, `/work`, `/mvm-bins`, and (when the host packed one)
+    /// `/closure-seed` from the input disk, and back `/out` with a writable
+    /// dir on the persistent nix-store disk. This is the disk-transport
+    /// equivalent of the virtio-fs shares, for the hvf VMM (which has no
+    /// virtio-fs). A tmpfs `/out` would be capped by guest RAM — too small
+    /// for a built rootfs — so `/out` lives on the big nix-store disk.
     fn stage_disk_transport_input(t: &crate::DiskTransport) -> Result<(), String> {
         std::fs::create_dir_all(DISK_INPUT_STAGE)
             .map_err(|e| format!("mkdir {DISK_INPUT_STAGE}: {e}"))?;
@@ -2939,10 +2949,15 @@ mod linux {
         if !status.success() {
             return Err(format!("tar x {} exited {:?}", t.input_dev, status.code()));
         }
+        // Each entry is best-effort: the host only packs `closure-seed` when
+        // the resolved builder image carries a seeded closure, so its absence
+        // here is the common case, not an error — `import_seeded_closure`
+        // already treats a missing `CLOSURE_SEED_NAR` as a silent no-op.
         for (name, target) in [
             ("job", JOB_DIR),
             ("work", WORK_DIR),
             ("mvm-bins", HOST_BIN_DIR),
+            ("closure-seed", CLOSURE_SEED_DIR),
         ] {
             let src = format!("{DISK_INPUT_STAGE}/{name}");
             if Path::new(&src).exists() {

--- a/crates/mvm-build/src/bin/mvm-host-vm-init.rs
+++ b/crates/mvm-build/src/bin/mvm-host-vm-init.rs
@@ -541,6 +541,40 @@ fn agent_spawn_command(agent_bin: &Path) -> Command {
     c
 }
 
+// ============================================================================
+// Seeded closure import (content-keyed idempotency)
+// ============================================================================
+//
+// A builder pack may carry a `nix-closure.nar` — a `nix-store --export` of
+// the dev-shell toolchain closure. When the host wires that NAR into the
+// guest (a later slice), `linux::import_seeded_closure` imports it into
+// the persistent Nix store exactly once per closure *content*, not once
+// per boot: an unchanged closure across reboots is a no-op, but a pack
+// carrying a different closure re-imports. These two functions are the
+// pure decision logic that call site drives; they carry no filesystem or
+// process access so they're exercised on every host, not just Linux.
+
+/// Whether the closure identified by `closure_hash` still needs
+/// importing, given the idempotency marker's contents left by a prior
+/// boot (`None` — no marker, e.g. first boot or a freshly formatted
+/// persistent store). `Some(hash)` where `hash` (ignoring surrounding
+/// whitespace) equals `closure_hash` means this exact closure is already
+/// in the store; anything else — no marker, a stale hash, a different
+/// pack's closure — means it still needs importing.
+#[cfg(any(target_os = "linux", test))]
+fn closure_import_needed(marker_contents: Option<&str>, closure_hash: &str) -> bool {
+    marker_contents.map(str::trim) != Some(closure_hash)
+}
+
+/// The idempotency marker's on-disk body after successfully importing
+/// `closure_hash`. A later boot reads this back and compares it (via
+/// [`closure_import_needed`]) against the newly computed hash of
+/// whatever closure NAR is present that boot.
+#[cfg(any(target_os = "linux", test))]
+fn closure_marker_contents(closure_hash: &str) -> String {
+    closure_hash.to_string()
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -860,6 +894,39 @@ mod tests {
         assert!(!virtiofs_tag_is_read_only("job"));
     }
 
+    // ── seeded closure import (content-keyed idempotency) ──
+
+    #[test]
+    fn closure_import_needed_on_first_boot_with_no_marker() {
+        assert!(closure_import_needed(None, "abc123"));
+    }
+
+    #[test]
+    fn closure_import_needed_false_when_marker_matches_hash() {
+        assert!(!closure_import_needed(Some("abc123"), "abc123"));
+    }
+
+    #[test]
+    fn closure_import_needed_true_when_closure_content_changed() {
+        // A different pack's closure hashes differently — re-import even
+        // though a marker from a prior closure exists.
+        assert!(closure_import_needed(Some("abc123"), "def456"));
+    }
+
+    #[test]
+    fn closure_import_needed_tolerates_marker_whitespace() {
+        // The marker is written via `std::fs::write` with no trailing
+        // newline, but a defensive trim keeps hand-edited/foreign markers
+        // from forcing a spurious re-import.
+        assert!(!closure_import_needed(Some("abc123\n"), "abc123"));
+        assert!(!closure_import_needed(Some(" abc123 "), "abc123"));
+    }
+
+    #[test]
+    fn closure_marker_contents_records_the_imported_hash_verbatim() {
+        assert_eq!(closure_marker_contents("abc123"), "abc123");
+    }
+
     #[test]
     fn hex_decode_utf8_roundtrips_and_rejects_garbage() {
         assert_eq!(hex_decode_utf8("2f776f726b32").as_deref(), Some("/work2"));
@@ -1071,6 +1138,23 @@ mod linux {
     /// to nix-daemon.
     const NIX_DB_LOADED_MARKER: &str = "/nix-store/.seed-db-loaded";
     const RUN_LIFECYCLE_LOG: &str = "/run/mvm-host-vm-init.lifecycle.log";
+
+    /// Guest-side path an optional seeded Nix store closure NAR is read
+    /// from. **Contract with the host wiring:** a host that resolved a
+    /// builder pack carrying a closure (`BuildBuilderPackParams.closure`
+    /// / `builder_pack::CLOSURE_FILE` = `"nix-closure.nar"`) attaches it
+    /// here as a read-only share before boot — that host-side attach
+    /// isn't wired yet, so today this path is always absent and
+    /// [`import_seeded_closure`] returns immediately. The filename
+    /// mirrors `CLOSURE_FILE` on purpose; keep the two in sync if either
+    /// moves.
+    const CLOSURE_SEED_NAR: &str = "/closure-seed/nix-closure.nar";
+
+    /// Content-keyed idempotency marker recording the sha256 of the
+    /// closure NAR most recently imported into the persistent store.
+    /// Lives next to [`NIX_DB_LOADED_MARKER`] — same invisibility to
+    /// nix-daemon, same "outside `store/` and `var/`" placement.
+    const CLOSURE_IMPORTED_MARKER: &str = "/nix-store/.seed-closure-imported";
 
     /// Per-job command staging dir (`/job/cmd.sh`, `/job/env`,
     /// `/job/result`). Mounted via virtio-fs from the host
@@ -2647,7 +2731,87 @@ mod linux {
             eprintln!("mvm-host-vm-init: load_seeded_nix_db warning (non-fatal): {e}");
         }
 
+        // Optional accelerator: a builder pack may carry a pre-fetched
+        // toolchain closure NAR. Import it into the persistent store if
+        // the host attached one and this exact content isn't already
+        // there. Fail-open like the DB load above — the seeded closure
+        // saves a fetch/eval, it is never a hard dependency, and the
+        // common case today (no NAR attached, until the host-side wiring
+        // lands) returns immediately without touching the filesystem.
+        if let Err(e) = import_seeded_closure() {
+            eprintln!("mvm-host-vm-init: import_seeded_closure warning (non-fatal): {e}");
+        }
+
         Ok(())
+    }
+
+    /// Import [`CLOSURE_SEED_NAR`] into the persistent Nix store when
+    /// present and not already imported (content-keyed via
+    /// [`crate::closure_import_needed`]). Absent NAR — the common case
+    /// until the host-side attach lands — is a silent no-op: no log line,
+    /// no filesystem write, so this step stays off the critical path.
+    ///
+    /// Every error path returns `Err` rather than panicking; the caller
+    /// logs and continues booting regardless of what went wrong here.
+    fn import_seeded_closure() -> Result<(), String> {
+        let nar = Path::new(CLOSURE_SEED_NAR);
+        if !nar.is_file() {
+            return Ok(());
+        }
+
+        let hash = hash_nar_file(nar)?;
+        let marker = std::fs::read_to_string(CLOSURE_IMPORTED_MARKER).ok();
+        if !crate::closure_import_needed(marker.as_deref(), &hash) {
+            return Ok(());
+        }
+
+        eprintln!("mvm-host-vm-init: importing seeded closure {CLOSURE_SEED_NAR} ({hash})");
+        let file = std::fs::File::open(nar).map_err(|e| format!("open {CLOSURE_SEED_NAR}: {e}"))?;
+        let status = Command::new("/sbin/nix-store")
+            .arg("--import")
+            .stdin(file)
+            .status()
+            .map_err(|e| format!("spawn /sbin/nix-store --import: {e}"))?;
+        if !status.success() {
+            return Err(format!(
+                "nix-store --import exit {}",
+                status.code().unwrap_or(-1)
+            ));
+        }
+
+        std::fs::write(
+            CLOSURE_IMPORTED_MARKER,
+            crate::closure_marker_contents(&hash),
+        )
+        .map_err(|e| format!("write {CLOSURE_IMPORTED_MARKER}: {e}"))?;
+        Ok(())
+    }
+
+    /// Stream `path` through SHA-256 so an arbitrarily large closure NAR
+    /// (the design budget is content-defined — roughly 1 GB for the
+    /// dev-shell toolchain) is never held in memory at once. Mirrors
+    /// `builder_pack::sha256_file`'s streaming discipline; duplicated
+    /// rather than shared because this binary intentionally doesn't
+    /// depend on the `mvm-build` lib crate (every dependency here is
+    /// weighed against the static-linked init's size budget).
+    fn hash_nar_file(path: &Path) -> Result<String, String> {
+        use sha2::{Digest, Sha256};
+        use std::io::Read;
+
+        let mut file =
+            std::fs::File::open(path).map_err(|e| format!("open {}: {e}", path.display()))?;
+        let mut hasher = Sha256::new();
+        let mut buffer = [0u8; 64 * 1024];
+        loop {
+            let read = file
+                .read(&mut buffer)
+                .map_err(|e| format!("read {}: {e}", path.display()))?;
+            if read == 0 {
+                break;
+            }
+            hasher.update(&buffer[..read]);
+        }
+        Ok(format!("{:x}", hasher.finalize()))
     }
 
     /// Independent track that runs concurrently

--- a/crates/mvm-build/src/bin/mvm-host-vm-init.rs
+++ b/crates/mvm-build/src/bin/mvm-host-vm-init.rs
@@ -137,8 +137,9 @@ fn main() -> ExitCode {
 #[cfg(any(target_os = "linux", test))]
 fn virtiofs_tag_is_read_only(tag: &str) -> bool {
     // `work` is the user's source; `mvm-bins` is the embedded host
-    // binaries. Both are inputs the guest must not write back.
-    tag == "work" || tag == "mvm-bins"
+    // binaries; `closure-seed` is the optional seeded Nix store closure
+    // NAR. All three are inputs the guest must not write back.
+    tag == "work" || tag == "mvm-bins" || tag == "closure-seed"
 }
 
 /// One user-supplied volume to mount, decoded from the `mvm.uvols=`
@@ -890,6 +891,7 @@ mod tests {
     fn virtiofs_tag_policy_marks_input_shares_read_only() {
         assert!(virtiofs_tag_is_read_only("work"));
         assert!(virtiofs_tag_is_read_only("mvm-bins"));
+        assert!(virtiofs_tag_is_read_only("closure-seed"));
         assert!(!virtiofs_tag_is_read_only("out"));
         assert!(!virtiofs_tag_is_read_only("job"));
     }
@@ -1192,11 +1194,16 @@ mod linux {
     /// `KrunContext::add_virtio_fs` declarations in
     /// `LibkrunBuilderVm::run_build`. Order doesn't matter; the
     /// guest mounts each by tag. `mvm-bins` is read-only (inputs).
+    /// `closure-seed` is only ever attached by the host when the
+    /// resolved builder image carries a seeded closure NAR — absent
+    /// otherwise, in which case the mount attempt below fails and logs
+    /// (best-effort, matching every other entry in this table).
     const VIRTIOFS_MOUNTS: &[(&str, &str)] = &[
         ("work", WORK_DIR),
         ("out", OUT_DIR),
         ("job", JOB_DIR),
         ("mvm-bins", HOST_BIN_DIR),
+        ("closure-seed", CLOSURE_SEED_DIR),
     ];
 
     /// Max stderr lines we capture into `/job/result`. Keeps
@@ -1567,6 +1574,19 @@ mod linux {
                 }
                 eprintln!("mvm-host-vm-init: runtime overlay mount warning (non-fatal): {e}");
             }
+        }
+        // Optional accelerator: a builder pack may carry a pre-fetched
+        // toolchain closure NAR. Import it into the persistent store once the
+        // store is set up (Track A) and its `/closure-seed` mount is in place —
+        // virtio-fs shares (Track B, joined above) for the libkrun/qemu VMMs,
+        // or the input-disk bind (staged just above) for the hvf VMM, which has
+        // no virtio-fs. Must run after staging so the NAR is actually visible;
+        // running it inside `setup_nix_store` would read `/closure-seed` before
+        // it is mounted and silently import nothing. Fail-open — the seed saves
+        // a fetch/eval, it is never a hard dependency, and the common case (no
+        // NAR attached) returns immediately without touching the filesystem.
+        if let Err(e) = import_seeded_closure() {
+            eprintln!("mvm-host-vm-init: import_seeded_closure warning (non-fatal): {e}");
         }
 
         // Fork the guest agent under setpriv so the builder/dev VM runs
@@ -2738,17 +2758,6 @@ mod linux {
         // the pre-fix substituter race.
         if let Err(e) = load_seeded_nix_db(timings, anchor) {
             eprintln!("mvm-host-vm-init: load_seeded_nix_db warning (non-fatal): {e}");
-        }
-
-        // Optional accelerator: a builder pack may carry a pre-fetched
-        // toolchain closure NAR. Import it into the persistent store if
-        // the host attached one and this exact content isn't already
-        // there. Fail-open like the DB load above — the seeded closure
-        // saves a fetch/eval, it is never a hard dependency, and the
-        // common case today (no NAR attached, until the host-side wiring
-        // lands) returns immediately without touching the filesystem.
-        if let Err(e) = import_seeded_closure() {
-            eprintln!("mvm-host-vm-init: import_seeded_closure warning (non-fatal): {e}");
         }
 
         Ok(())

--- a/crates/mvm-build/src/builder_backend_select.rs
+++ b/crates/mvm-build/src/builder_backend_select.rs
@@ -260,13 +260,11 @@ pub fn resolve_stage0_backend_for_choice(
 ) -> Box<dyn BuilderVm> {
     match stage0_backend_choice(choice) {
         BuilderBackendChoice::Qemu => Box::new(QemuBuilderVm::new()),
-        BuilderBackendChoice::Libkrun | BuilderBackendChoice::Hvf => {
-            Box::new(
-                LibkrunBuilderVm::default()
-                    .with_verbose(verbose)
-                    .with_closure_nar(closure_nar_for_host_arch()),
-            )
-        }
+        BuilderBackendChoice::Libkrun | BuilderBackendChoice::Hvf => Box::new(
+            LibkrunBuilderVm::default()
+                .with_verbose(verbose)
+                .with_closure_nar(closure_nar_for_host_arch()),
+        ),
     }
 }
 

--- a/crates/mvm-build/src/builder_backend_select.rs
+++ b/crates/mvm-build/src/builder_backend_select.rs
@@ -22,13 +22,23 @@
 //! problem without aborting the build. Empty / unset env is treated
 //! the same as "no override."
 
+use std::path::PathBuf;
 use std::sync::OnceLock;
 
 use crate::builder_health;
 use crate::builder_vm::{BuilderVm, BuilderVmError};
-use crate::libkrun_builder::LibkrunBuilderVm;
+use crate::libkrun_builder::{LibkrunBuilderVm, builder_vm_cache_dir, host_arch_tag};
 use crate::qemu_builder::QemuBuilderVm;
 use mvm_core::platform::{Platform, current};
+
+/// Resolve the optional seeded Nix store closure NAR for the live host's
+/// arch, the same per-arch cache dir every libkrun/qemu builder image read
+/// resolves against. `None` is the common case today (see
+/// `builder_pack::closure_nar_path`'s doc); a `LibkrunBuilderVm` attaches
+/// nothing and boots exactly as before this seam existed.
+fn closure_nar_for_host_arch() -> Option<PathBuf> {
+    crate::builder_pack::closure_nar_path(&builder_vm_cache_dir().join(host_arch_tag()))
+}
 
 /// Constructor for the hvf builder, registered by the CLI (which can name
 /// `HvfBuilderVm` and resolve its image). `mvm-build` sits below
@@ -187,7 +197,9 @@ pub fn resolve_builder_backend_with_override(
     flag: Option<BuilderBackendChoice>,
 ) -> Box<dyn BuilderVm> {
     match resolve_choice_with_override(flag) {
-        BuilderBackendChoice::Libkrun => Box::new(LibkrunBuilderVm::default()),
+        BuilderBackendChoice::Libkrun => {
+            Box::new(LibkrunBuilderVm::default().with_closure_nar(closure_nar_for_host_arch()))
+        }
         BuilderBackendChoice::Qemu => Box::new(QemuBuilderVm::new()),
         BuilderBackendChoice::Hvf => {
             // Delegate to the registered constructor; panic if not registered
@@ -209,7 +221,9 @@ pub fn try_resolve_builder_backend_with_override(
     flag: Option<BuilderBackendChoice>,
 ) -> Result<Box<dyn BuilderVm>, BuilderVmError> {
     match resolve_choice_with_override(flag) {
-        BuilderBackendChoice::Libkrun => Ok(Box::new(LibkrunBuilderVm::default())),
+        BuilderBackendChoice::Libkrun => Ok(Box::new(
+            LibkrunBuilderVm::default().with_closure_nar(closure_nar_for_host_arch()),
+        )),
         BuilderBackendChoice::Qemu => Ok(Box::new(QemuBuilderVm::new())),
         BuilderBackendChoice::Hvf => match HVF_CTOR.get() {
             Some(ctor) => ctor(),
@@ -247,7 +261,11 @@ pub fn resolve_stage0_backend_for_choice(
     match stage0_backend_choice(choice) {
         BuilderBackendChoice::Qemu => Box::new(QemuBuilderVm::new()),
         BuilderBackendChoice::Libkrun | BuilderBackendChoice::Hvf => {
-            Box::new(LibkrunBuilderVm::default().with_verbose(verbose))
+            Box::new(
+                LibkrunBuilderVm::default()
+                    .with_verbose(verbose)
+                    .with_closure_nar(closure_nar_for_host_arch()),
+            )
         }
     }
 }
@@ -688,6 +706,28 @@ mod tests {
         ] {
             assert_ne!(c.name(), "vz");
         }
+    }
+
+    #[test]
+    fn closure_nar_for_host_arch_is_none_when_the_arch_cache_dir_has_no_closure() {
+        let scratch = tempfile::TempDir::new().unwrap();
+        let mut env = TestEnv::new();
+        env.set("MVM_CACHE_DIR", scratch.path().join(".cache"));
+        assert_eq!(closure_nar_for_host_arch(), None);
+    }
+
+    #[test]
+    fn closure_nar_for_host_arch_resolves_when_the_arch_cache_dir_has_one() {
+        let scratch = tempfile::TempDir::new().unwrap();
+        let mut env = TestEnv::new();
+        env.set("MVM_CACHE_DIR", scratch.path().join(".cache"));
+        let arch_dir = builder_vm_cache_dir().join(host_arch_tag());
+        std::fs::create_dir_all(&arch_dir).unwrap();
+        std::fs::write(arch_dir.join("nix-closure.nar"), b"nar-bytes").unwrap();
+        assert_eq!(
+            closure_nar_for_host_arch(),
+            Some(arch_dir.join("nix-closure.nar"))
+        );
     }
 
     #[test]

--- a/crates/mvm-build/src/builder_disk_transport.rs
+++ b/crates/mvm-build/src/builder_disk_transport.rs
@@ -68,11 +68,13 @@ pub fn pack_input_disk(
                 .with_context(|| format!("archive '{}' from {}", tree.name, tree.src.display()))?;
         }
         if let Some(nar) = closure_nar {
+            // The guest imports a fixed path (`/closure-seed/<CLOSURE_FILE>`), so
+            // the tar entry name comes from `CLOSURE_FILE` regardless of what the
+            // source NAR happens to be called — otherwise a differently-named
+            // source silently lands the guest import a no-op.
             let name = format!(
                 "{CLOSURE_SEED_TAR_DIR}/{}",
-                nar.file_name()
-                    .map(|n| n.to_string_lossy().into_owned())
-                    .unwrap_or_else(|| "nix-closure.nar".to_string())
+                crate::builder_pack::CLOSURE_FILE
             );
             b.append_path_with_name(nar, &name)
                 .with_context(|| format!("archive closure NAR from {}", nar.display()))?;
@@ -186,7 +188,9 @@ mod tests {
         let job = dir.path().join("job");
         fs::create_dir_all(&job).unwrap();
         fs::write(job.join("cmd.sh"), b"#!/bin/sh\n").unwrap();
-        let nar = dir.path().join("nix-closure.nar");
+        // Source deliberately NOT named `nix-closure.nar` — the tar entry name
+        // must still come from `CLOSURE_FILE` so the guest finds it.
+        let nar = dir.path().join("some-source.nar");
         fs::write(&nar, b"pretend-nar-bytes").unwrap();
 
         let image = dir.path().join("input.img");

--- a/crates/mvm-build/src/builder_disk_transport.rs
+++ b/crates/mvm-build/src/builder_disk_transport.rs
@@ -8,9 +8,10 @@
 //! The transport is therefore a **tar written raw onto a disk image**, no
 //! filesystem on the transport disks:
 //!
-//! - Input: the host packs `{job, work, mvm-bins}` into a tar and writes it,
-//!   zero-padded to the disk size, at the input image. The guest reads the raw
-//!   disk and `tar x`.
+//! - Input: the host packs `{job, work, mvm-bins}` — plus, when the resolved
+//!   builder image carries one, an optional seeded Nix store closure NAR under
+//!   `closure-seed/` — into a tar and writes it, zero-padded to the disk size,
+//!   at the input image. The guest reads the raw disk and `tar x`.
 //! - Output: the guest packs its artifacts into a tar written raw onto the output
 //!   disk; the host reads the raw disk and `tar x` here.
 //!
@@ -25,6 +26,12 @@ use anyhow::{Context, Result};
 /// virtio-blk serves whole 512-byte sectors; transport images are sized up to a
 /// sector boundary so the guest sees an exact capacity.
 const SECTOR: u64 = 512;
+
+/// Archive directory the optional seeded-closure NAR rides under, mirroring
+/// the guest's `/closure-seed` mount point
+/// (`mvm-host-vm-init`'s `CLOSURE_SEED_NAR` contract). Kept in sync with the
+/// guest by convention, same as `job`/`work`/`mvm-bins` above.
+const CLOSURE_SEED_TAR_DIR: &str = "closure-seed";
 
 /// One named tree placed in the transport tar. `name` is the archive prefix the
 /// guest mounts/binds (e.g. `"job"`, `"work"`, `"mvm-bins"`); `src` is the host
@@ -42,8 +49,14 @@ fn sector_round_up(n: u64) -> u64 {
 /// Pack `inputs` into a tar and write it at `out_image`, zero-padded to at least
 /// `min_disk_size` (rounded up to a sector). `min_disk_size` is a floor: the disk
 /// always grows to hold the archive, so the inputs never overflow it.
+///
+/// `closure_nar`, when `Some`, is a single file (a builder pack's optional
+/// seeded Nix store closure) archived at `closure-seed/<file name>` alongside
+/// the input trees. `None` — the common case until a pack carries a closure —
+/// packs exactly the trees, unchanged from before this parameter existed.
 pub fn pack_input_disk(
     inputs: &[InputTree<'_>],
+    closure_nar: Option<&Path>,
     out_image: &Path,
     min_disk_size: u64,
 ) -> Result<()> {
@@ -53,6 +66,16 @@ pub fn pack_input_disk(
         for tree in inputs {
             b.append_dir_all(tree.name, tree.src)
                 .with_context(|| format!("archive '{}' from {}", tree.name, tree.src.display()))?;
+        }
+        if let Some(nar) = closure_nar {
+            let name = format!(
+                "{CLOSURE_SEED_TAR_DIR}/{}",
+                nar.file_name()
+                    .map(|n| n.to_string_lossy().into_owned())
+                    .unwrap_or_else(|| "nix-closure.nar".to_string())
+            );
+            b.append_path_with_name(nar, &name)
+                .with_context(|| format!("archive closure NAR from {}", nar.display()))?;
         }
         b.finish().context("finish input tar")?;
     }
@@ -130,6 +153,7 @@ mod tests {
                     src: &work,
                 },
             ],
+            None,
             &image,
             1 << 20, // 1 MiB min
         )
@@ -157,6 +181,62 @@ mod tests {
     }
 
     #[test]
+    fn closure_nar_when_present_rides_the_input_disk_under_closure_seed() {
+        let dir = tempfile::tempdir().unwrap();
+        let job = dir.path().join("job");
+        fs::create_dir_all(&job).unwrap();
+        fs::write(job.join("cmd.sh"), b"#!/bin/sh\n").unwrap();
+        let nar = dir.path().join("nix-closure.nar");
+        fs::write(&nar, b"pretend-nar-bytes").unwrap();
+
+        let image = dir.path().join("input.img");
+        pack_input_disk(
+            &[InputTree {
+                name: "job",
+                src: &job,
+            }],
+            Some(&nar),
+            &image,
+            1 << 20,
+        )
+        .unwrap();
+
+        let dest = dir.path().join("out");
+        read_output_disk(&image, &dest).unwrap();
+        assert_eq!(
+            fs::read(dest.join("closure-seed/nix-closure.nar")).unwrap(),
+            b"pretend-nar-bytes"
+        );
+    }
+
+    #[test]
+    fn no_closure_nar_means_no_closure_seed_entry() {
+        // The common case today: a builder image with no seeded closure packs
+        // exactly the input trees, with no `closure-seed/` directory at all —
+        // zero behavior change from before this parameter existed.
+        let dir = tempfile::tempdir().unwrap();
+        let job = dir.path().join("job");
+        fs::create_dir_all(&job).unwrap();
+        fs::write(job.join("cmd.sh"), b"#!/bin/sh\n").unwrap();
+
+        let image = dir.path().join("input.img");
+        pack_input_disk(
+            &[InputTree {
+                name: "job",
+                src: &job,
+            }],
+            None,
+            &image,
+            1 << 20,
+        )
+        .unwrap();
+
+        let dest = dir.path().join("out");
+        read_output_disk(&image, &dest).unwrap();
+        assert!(!dest.join("closure-seed").exists());
+    }
+
+    #[test]
     fn disk_grows_past_the_floor_to_hold_larger_inputs() {
         // A 512-byte floor can't hold a 4 KiB file's tar; the disk grows to fit.
         let dir = tempfile::tempdir().unwrap();
@@ -169,6 +249,7 @@ mod tests {
                 name: "big",
                 src: &big,
             }],
+            None,
             &image,
             512,
         )

--- a/crates/mvm-build/src/builder_pack.rs
+++ b/crates/mvm-build/src/builder_pack.rs
@@ -40,6 +40,10 @@ pub const ROOTHASH_FILE: &str = "rootfs.roothash";
 /// can be published as-is. Distinct from the cache's own `.pack-manifest.json`
 /// sidecar, and never a declared pack file.
 pub const MANIFEST_FILE: &str = "manifest.json";
+/// In-pack path of the optional seeded Nix store closure (a `nix-store
+/// --export` NAR of the dev-shell toolchain). Present only when the producer
+/// is given a closure to bundle; a pack without one stays valid.
+pub const CLOSURE_FILE: &str = "nix-closure.nar";
 
 /// The `vsock` capability every mvm builder pack requires of its host — the
 /// single control-plane transport an hvf builder VM exposes.
@@ -55,6 +59,11 @@ pub struct BuildBuilderPackParams {
     pub vmlinux: PathBuf,
     /// Source `rootfs.ext4` on disk; copied into the pack as [`ROOTFS_FILE`].
     pub rootfs: PathBuf,
+    /// Optional seeded Nix store closure NAR on disk; copied into the pack as
+    /// [`CLOSURE_FILE`] and hashed into `outputs.closure_hash` when present.
+    /// `None` leaves the pack exactly as before this field existed — closure
+    /// seeding is an accelerator, never a requirement.
+    pub closure: Option<PathBuf>,
     /// Architecture the artifacts target. Drives the manifest arch and the
     /// policy hash the host checks.
     pub target_arch: GuestArch,
@@ -171,12 +180,14 @@ pub fn build_builder_pack(
     // the honest sha256 of exactly what lands in the pack.
     let kernel_hash = sha256_file(&kernel_dest)?;
     let builder_image_hash = sha256_file(&rootfs_dest)?;
+    let (files, closure_hash) = stage_closure(&params.closure, out_dir)?;
 
     let manifest = PackBuilder::new(out_dir, builder_metadata(params), signing_key)
-        .files([KERNEL_FILE, ROOTFS_FILE])
+        .files(files)
         .output_hashes(PackOutputHashes {
             kernel_hash: Some(kernel_hash),
             builder_image_hash: Some(builder_image_hash),
+            closure_hash,
             ..Default::default()
         })
         .build()?;
@@ -222,12 +233,14 @@ pub fn build_keyless_builder_pack(
 
     let kernel_hash = sha256_file(&kernel_dest)?;
     let builder_image_hash = sha256_file(&rootfs_dest)?;
+    let (files, closure_hash) = stage_closure(&params.closure, out_dir)?;
 
     let manifest = PackBuilder::new_keyless(out_dir, builder_metadata(params), identity)
-        .files([KERNEL_FILE, ROOTFS_FILE])
+        .files(files)
         .output_hashes(PackOutputHashes {
             kernel_hash: Some(kernel_hash),
             builder_image_hash: Some(builder_image_hash),
+            closure_hash,
             ..Default::default()
         })
         .build()?;
@@ -386,6 +399,26 @@ fn copy_file(src: &Path, dest: &Path) -> Result<(), BuilderPackError> {
     Ok(())
 }
 
+/// Copy an optional closure NAR into `out_dir` as [`CLOSURE_FILE`] and hash it.
+/// Returns the kernel+rootfs file set extended with the closure when present,
+/// plus the resulting `closure_hash` — or the bare two-file set and `None`
+/// when `closure` is absent, leaving the pack exactly as before this field
+/// existed.
+fn stage_closure(
+    closure: &Option<PathBuf>,
+    out_dir: &Path,
+) -> Result<(Vec<&'static str>, Option<Sha256Hex>), BuilderPackError> {
+    match closure {
+        Some(src) => {
+            let dest = out_dir.join(CLOSURE_FILE);
+            copy_file(src, &dest)?;
+            let hash = sha256_file(&dest)?;
+            Ok((vec![KERNEL_FILE, ROOTFS_FILE, CLOSURE_FILE], Some(hash)))
+        }
+        None => Ok((vec![KERNEL_FILE, ROOTFS_FILE], None)),
+    }
+}
+
 /// Stream a file through SHA-256 so an arbitrarily large rootfs is never held in
 /// memory. Returns the lowercase-hex digest as a validated [`Sha256Hex`].
 fn sha256_file(path: &Path) -> Result<Sha256Hex, BuilderPackError> {
@@ -449,6 +482,7 @@ mod tests {
         BuildBuilderPackParams {
             vmlinux,
             rootfs,
+            closure: None,
             target_arch: GuestArch::host(),
             channel: CHANNEL.to_string(),
             builder_identity: "ci-builder".to_string(),
@@ -608,6 +642,70 @@ mod tests {
         let config = trust_config(&key, &[CHANNEL]);
         verify_pack_at(&manifest, out.path(), &policy, &config, &config)
             .expect("required outputs satisfied");
+    }
+
+    const CLOSURE_BYTES: &[u8] = b"nix-store-export-closure-bytes";
+
+    #[test]
+    fn builder_pack_with_closure_carries_closure_hash_and_file() {
+        let src = TempDir::new().expect("src tempdir");
+        let out = TempDir::new().expect("out tempdir");
+        let key = signing_key();
+
+        let closure_src = src.path().join("closure.nar");
+        fs::write(&closure_src, CLOSURE_BYTES).expect("write closure src");
+        let mut params = params_in(&src);
+        params.closure = Some(closure_src);
+
+        let manifest = build_builder_pack(&params, &key, out.path()).expect("produce pack");
+
+        assert_eq!(
+            manifest.outputs.closure_hash,
+            Some(Sha256Hex::from_bytes(CLOSURE_BYTES))
+        );
+        let files: Vec<&str> = manifest
+            .outputs
+            .files
+            .iter()
+            .map(|f| f.path.as_str())
+            .collect();
+        assert!(files.contains(&CLOSURE_FILE));
+        assert!(out.path().join(CLOSURE_FILE).exists());
+
+        let policy = host_policy(&[CHANNEL]);
+        let config = trust_config(&key, &[CHANNEL]);
+        let verified = verify_pack_at(&manifest, out.path(), &policy, &config, &config)
+            .expect("pack with closure verifies");
+        assert_eq!(verified.file_count, 3);
+    }
+
+    #[test]
+    fn builder_pack_without_closure_has_no_closure_hash_or_file() {
+        let src = TempDir::new().expect("src tempdir");
+        let out = TempDir::new().expect("out tempdir");
+        let key = signing_key();
+
+        // params_in() sets closure: None by default.
+        let manifest =
+            build_builder_pack(&params_in(&src), &key, out.path()).expect("produce pack");
+
+        assert_eq!(manifest.outputs.closure_hash, None);
+        let files: Vec<&str> = manifest
+            .outputs
+            .files
+            .iter()
+            .map(|f| f.path.as_str())
+            .collect();
+        assert!(!files.contains(&CLOSURE_FILE));
+        assert!(!out.path().join(CLOSURE_FILE).exists());
+
+        // Backward compatible: still verifies with the required-outputs gate
+        // for a Builder pack (closure_hash is not in that list).
+        let policy = host_policy(&[CHANNEL]);
+        let config = trust_config(&key, &[CHANNEL]);
+        let verified = verify_pack_at(&manifest, out.path(), &policy, &config, &config)
+            .expect("pack without closure still verifies");
+        assert_eq!(verified.file_count, 2);
     }
 
     #[test]

--- a/crates/mvm-build/src/builder_pack.rs
+++ b/crates/mvm-build/src/builder_pack.rs
@@ -419,6 +419,21 @@ fn stage_closure(
     }
 }
 
+/// Resolve the optional seeded closure NAR alongside a resolved builder
+/// image's per-arch cache dir (`builder_vm_cache_dir()/<arch>/`), the same
+/// dir every builder backend reads `vmlinux`/`rootfs.ext4` from. `None` is
+/// the common case today — a pack without a closure leaves the dir exactly
+/// as it was before this field existed, and every builder backend boots
+/// unchanged.
+///
+/// Shared by every builder-image resolver (hvf, libkrun, qemu) so the "does
+/// this arch dir carry a seeded closure" check has one definition instead of
+/// drifting per backend.
+pub fn closure_nar_path(arch_dir: &Path) -> Option<PathBuf> {
+    let nar = arch_dir.join(CLOSURE_FILE);
+    nar.is_file().then_some(nar)
+}
+
 /// Stream a file through SHA-256 so an arbitrarily large rootfs is never held in
 /// memory. Returns the lowercase-hex digest as a validated [`Sha256Hex`].
 fn sha256_file(path: &Path) -> Result<Sha256Hex, BuilderPackError> {
@@ -706,6 +721,22 @@ mod tests {
         let verified = verify_pack_at(&manifest, out.path(), &policy, &config, &config)
             .expect("pack without closure still verifies");
         assert_eq!(verified.file_count, 2);
+    }
+
+    #[test]
+    fn closure_nar_path_is_none_when_absent() {
+        let dir = TempDir::new().expect("arch dir");
+        assert_eq!(closure_nar_path(dir.path()), None);
+    }
+
+    #[test]
+    fn closure_nar_path_resolves_when_present() {
+        let dir = TempDir::new().expect("arch dir");
+        fs::write(dir.path().join(CLOSURE_FILE), CLOSURE_BYTES).expect("write nar");
+        assert_eq!(
+            closure_nar_path(dir.path()),
+            Some(dir.path().join(CLOSURE_FILE))
+        );
     }
 
     #[test]

--- a/crates/mvm-build/src/builder_vm_runtime.rs
+++ b/crates/mvm-build/src/builder_vm_runtime.rs
@@ -116,13 +116,11 @@ pub fn stage_closure_seed_dir(
             share_dir.display()
         ))
     })?;
-    let file_name = closure_nar.file_name().ok_or_else(|| {
-        BuilderVmError::ExtractionFailed(format!(
-            "closure NAR path has no file name: {}",
-            closure_nar.display()
-        ))
-    })?;
-    let dest = share_dir.join(file_name);
+    // The guest mounts this share at `/closure-seed` and imports a fixed file
+    // name (`CLOSURE_FILE`), so stage the NAR under that name regardless of what
+    // the source path is called — a mismatched name would make the guest import
+    // a silent no-op.
+    let dest = share_dir.join(crate::builder_pack::CLOSURE_FILE);
     std::fs::copy(closure_nar, &dest).map_err(|e| {
         BuilderVmError::ExtractionFailed(format!(
             "staging closure NAR {} -> {}: {e}",
@@ -2460,10 +2458,23 @@ mod tests {
     }
 
     #[test]
-    fn stage_closure_seed_dir_errors_on_a_source_with_no_file_name() {
+    fn stage_closure_seed_dir_uses_the_fixed_closure_file_name() {
+        // A source named something other than CLOSURE_FILE must still stage
+        // under CLOSURE_FILE — the guest imports that fixed name.
+        let src = tempfile::TempDir::new().unwrap();
+        let nar = src.path().join("some-other-name.nar");
+        std::fs::write(&nar, b"nar-bytes").unwrap();
+
         let vm_state_dir = tempfile::TempDir::new().unwrap();
-        let err = stage_closure_seed_dir(Path::new("/"), vm_state_dir.path())
-            .expect_err("root path has no file name");
-        assert!(matches!(err, BuilderVmError::ExtractionFailed(_)));
+        let share_dir = stage_closure_seed_dir(&nar, vm_state_dir.path()).expect("stage");
+
+        let entries: Vec<_> = std::fs::read_dir(&share_dir)
+            .unwrap()
+            .map(|e| e.unwrap().file_name())
+            .collect();
+        assert_eq!(
+            entries,
+            vec![std::ffi::OsString::from(crate::builder_pack::CLOSURE_FILE)]
+        );
     }
 }

--- a/crates/mvm-build/src/builder_vm_runtime.rs
+++ b/crates/mvm-build/src/builder_vm_runtime.rs
@@ -89,6 +89,50 @@ pub fn builder_store_gc_cap_kib() -> u64 {
 /// paths need.
 pub const INSTALL_SPEC_FILENAME: &str = "install_spec.json";
 
+/// virtio-fs tag the libkrun and QEMU builders attach an optional seeded Nix
+/// store closure NAR under. `mvm-host-vm-init`'s fixed-share mount table
+/// mounts this tag read-only at `/closure-seed`, matching the disk-transport
+/// `closure-seed/` tar entry the hvf VMM uses for the same NAR — the guest
+/// import logic (`import_seeded_closure`) doesn't care which transport
+/// populated the mount point.
+pub const CLOSURE_SEED_TAG: &str = "closure-seed";
+
+/// Stage `closure_nar` into its own share directory under `parent_dir` so it
+/// can be attached as a read-only virtio-fs share without exposing
+/// `parent_dir`'s other contents. This matters because the source lives in
+/// the resolved builder image's per-arch cache dir alongside `vmlinux` /
+/// `rootfs.ext4` — sharing that whole directory would leak the kernel/rootfs
+/// into the guest through an unrelated mount. Returns the staged directory
+/// (containing exactly one file, named after `closure_nar`'s own file name)
+/// for the caller to pass to `add_virtio_fs(CLOSURE_SEED_TAG, ...)`.
+pub fn stage_closure_seed_dir(
+    closure_nar: &Path,
+    parent_dir: &Path,
+) -> Result<PathBuf, BuilderVmError> {
+    let share_dir = parent_dir.join(CLOSURE_SEED_TAG);
+    std::fs::create_dir_all(&share_dir).map_err(|e| {
+        BuilderVmError::ExtractionFailed(format!(
+            "creating closure-seed share dir {}: {e}",
+            share_dir.display()
+        ))
+    })?;
+    let file_name = closure_nar.file_name().ok_or_else(|| {
+        BuilderVmError::ExtractionFailed(format!(
+            "closure NAR path has no file name: {}",
+            closure_nar.display()
+        ))
+    })?;
+    let dest = share_dir.join(file_name);
+    std::fs::copy(closure_nar, &dest).map_err(|e| {
+        BuilderVmError::ExtractionFailed(format!(
+            "staging closure NAR {} -> {}: {e}",
+            closure_nar.display(),
+            dest.display()
+        ))
+    })?;
+    Ok(share_dir)
+}
+
 /// Hypervisor-agnostic orchestration helper. Holds a reference to
 /// a [`VmBackendForBuilder`] so the actual supervisor spawn /
 /// console-log path / per-VM state directory are routed through
@@ -2389,5 +2433,37 @@ mod tests {
         // Zero → also falls back (zero would GC the just-built closure).
         env.set(MVM_BUILDER_STORE_GC_GIB_ENV, "0");
         assert_eq!(builder_store_gc_cap_kib(), 25_165_824);
+    }
+
+    #[test]
+    fn stage_closure_seed_dir_copies_only_the_nar_under_its_own_share_dir() {
+        let arch_dir = tempfile::TempDir::new().unwrap();
+        // The source lives alongside sibling image files the share must never
+        // expose — the real arch cache dir holds vmlinux/rootfs.ext4 too.
+        std::fs::write(arch_dir.path().join("vmlinux"), b"kernel-bytes").unwrap();
+        let nar = arch_dir.path().join("nix-closure.nar");
+        std::fs::write(&nar, b"nar-bytes").unwrap();
+
+        let vm_state_dir = tempfile::TempDir::new().unwrap();
+        let share_dir = stage_closure_seed_dir(&nar, vm_state_dir.path()).expect("stage");
+
+        assert_eq!(share_dir, vm_state_dir.path().join(CLOSURE_SEED_TAG));
+        let entries: Vec<_> = std::fs::read_dir(&share_dir)
+            .unwrap()
+            .map(|e| e.unwrap().file_name())
+            .collect();
+        assert_eq!(entries, vec![std::ffi::OsString::from("nix-closure.nar")]);
+        assert_eq!(
+            std::fs::read(share_dir.join("nix-closure.nar")).unwrap(),
+            b"nar-bytes"
+        );
+    }
+
+    #[test]
+    fn stage_closure_seed_dir_errors_on_a_source_with_no_file_name() {
+        let vm_state_dir = tempfile::TempDir::new().unwrap();
+        let err = stage_closure_seed_dir(Path::new("/"), vm_state_dir.path())
+            .expect_err("root path has no file name");
+        assert!(matches!(err, BuilderVmError::ExtractionFailed(_)));
     }
 }

--- a/crates/mvm-build/src/libkrun_builder.rs
+++ b/crates/mvm-build/src/libkrun_builder.rs
@@ -80,9 +80,10 @@ use crate::builder_vm::{
 // `shell_single_quote_escape` are imported only inside the test
 // module below.
 use crate::builder_vm_runtime::{
-    NixStoreImageLock, acquire_nix_store_image_lock, acquire_nix_store_image_lock_named,
-    builder_vm_timeout, finalize_flake_job, finalize_install_job, read_job_result_with_diagnostics,
-    shell_job_exit_error, stage_job_dir, stage_shell_job_dir, supervisor_exit_error,
+    CLOSURE_SEED_TAG, NixStoreImageLock, acquire_nix_store_image_lock,
+    acquire_nix_store_image_lock_named, builder_vm_timeout, finalize_flake_job,
+    finalize_install_job, read_job_result_with_diagnostics, shell_job_exit_error,
+    stage_closure_seed_dir, stage_job_dir, stage_shell_job_dir, supervisor_exit_error,
     verbose_from_env,
 };
 use crate::pipeline::build::BUILDER_OUTPUT_DISK_MIB;
@@ -627,6 +628,11 @@ pub struct LibkrunBuilderVm {
     /// can build the real builder VM image without downloading a
     /// published builder-VM artifact.
     pub image_override: Option<BuilderVmImage>,
+    /// Optional seeded Nix store closure NAR, resolved alongside the
+    /// builder image when it carries one. `None` (the common case today)
+    /// attaches no closure-seed share, so every boot behaves exactly as
+    /// before this field existed. See [`LibkrunBuilderVm::with_closure_nar`].
+    pub closure_nar: Option<PathBuf>,
     /// Stream the guest `console.log` to stderr as the build runs.
     /// Set by the CLI from `--verbose`. Default false (heartbeat only).
     pub verbose: bool,
@@ -671,6 +677,7 @@ impl Default for LibkrunBuilderVm {
             memory_mib: DEFAULT_MEMORY_MIB,
             nix_store_mib: DEFAULT_NIX_STORE_MIB,
             image_override: None,
+            closure_nar: None,
             verbose: false,
         }
     }
@@ -699,6 +706,29 @@ impl LibkrunBuilderVm {
     pub fn with_image_override(mut self, image: BuilderVmImage) -> Self {
         self.image_override = Some(image);
         self
+    }
+
+    /// Attach a seeded Nix store closure NAR resolved from the builder
+    /// image cache, mirroring `HvfBuilderVm::with_closure_nar`. Every boot
+    /// after this call (Stage 0, a shell job, or a flake build) stages the
+    /// NAR into a dedicated share dir under the VM's state dir and attaches
+    /// it read-only at the `closure-seed` virtio-fs tag; omitting this call
+    /// (the default) attaches nothing, so a builder image without a
+    /// closure boots exactly as before this seam existed.
+    pub fn with_closure_nar(mut self, closure_nar: Option<PathBuf>) -> Self {
+        self.closure_nar = closure_nar;
+        self
+    }
+
+    /// Stage `self.closure_nar` under `vm_state_dir` and return the tag +
+    /// staged share dir for the caller to `add_virtio_fs` with, or `None`
+    /// when no closure was attached — the shared no-op path every
+    /// `run_build`-shaped method takes.
+    fn closure_seed_share(&self, vm_state_dir: &Path) -> Result<Option<PathBuf>, BuilderVmError> {
+        self.closure_nar
+            .as_deref()
+            .map(|nar| stage_closure_seed_dir(nar, vm_state_dir))
+            .transpose()
     }
 
     /// Stream guest console output to stderr during the build (`--verbose`).
@@ -826,6 +856,12 @@ impl LibkrunBuilderVm {
             // /mvm-bins inside the guest — stage0-init sets MVM_HOST_BIN_DIR
             // to it so the flake picks up the pre-built host-vm binaries.
             .add_virtio_fs("mvm-bins", path_to_str(host_bin_dir, "host_bin_dir")?);
+        if let Some(share_dir) = self.closure_seed_share(&vm_state_dir)? {
+            krun = krun.add_virtio_fs(
+                CLOSURE_SEED_TAG,
+                path_to_str(&share_dir, "closure_seed_dir")?,
+            );
+        }
         krun = apply_builder_vsock_egress(krun);
         let _egress_endpoint = BuilderVsockEgressEndpoint::spawn(&vm_state_dir)?;
 
@@ -971,6 +1007,12 @@ impl LibkrunBuilderVm {
                 "runtime-overlay",
                 path_to_str(attachment.disk_path, "runtime_overlay_ext4")?,
                 attachment.read_only,
+            );
+        }
+        if let Some(share_dir) = self.closure_seed_share(&vm_state_dir)? {
+            krun = krun.add_virtio_fs(
+                CLOSURE_SEED_TAG,
+                path_to_str(&share_dir, "closure_seed_dir")?,
             );
         }
 
@@ -1428,6 +1470,12 @@ impl BuilderVm for LibkrunBuilderVm {
                 "runtime-overlay",
                 path_to_str(attachment.disk_path, "runtime_overlay_ext4")?,
                 attachment.read_only,
+            );
+        }
+        if let Some(share_dir) = self.closure_seed_share(&vm_state_dir)? {
+            krun = krun.add_virtio_fs(
+                CLOSURE_SEED_TAG,
+                path_to_str(&share_dir, "closure_seed_dir")?,
             );
         }
 
@@ -5707,6 +5755,46 @@ mod tests {
     fn with_nix_store_mib_overrides() {
         let vm = LibkrunBuilderVm::default().with_nix_store_mib(8192);
         assert_eq!(vm.nix_store_mib, 8192);
+    }
+
+    #[test]
+    fn closure_nar_defaults_to_none_and_is_settable() {
+        let vm = LibkrunBuilderVm::default();
+        assert_eq!(vm.closure_nar, None);
+        let vm = LibkrunBuilderVm::default().with_closure_nar(Some(PathBuf::from("/nar")));
+        assert_eq!(vm.closure_nar, Some(PathBuf::from("/nar")));
+    }
+
+    #[test]
+    fn closure_seed_share_is_none_when_no_closure_attached() {
+        let vm_state_dir = tempfile::TempDir::new().unwrap();
+        let vm = LibkrunBuilderVm::default();
+        assert_eq!(
+            vm.closure_seed_share(vm_state_dir.path()).unwrap(),
+            None,
+            "no closure_nar attached means no share directory is staged"
+        );
+        // No stray closure-seed dir left behind either.
+        assert!(!vm_state_dir.path().join("closure-seed").exists());
+    }
+
+    #[test]
+    fn closure_seed_share_stages_the_nar_when_attached() {
+        let arch_dir = tempfile::TempDir::new().unwrap();
+        let nar = arch_dir.path().join("nix-closure.nar");
+        std::fs::write(&nar, b"closure-bytes").unwrap();
+        let vm_state_dir = tempfile::TempDir::new().unwrap();
+
+        let vm = LibkrunBuilderVm::default().with_closure_nar(Some(nar));
+        let share_dir = vm
+            .closure_seed_share(vm_state_dir.path())
+            .unwrap()
+            .expect("closure attached must stage a share dir");
+        assert_eq!(share_dir, vm_state_dir.path().join(CLOSURE_SEED_TAG));
+        assert_eq!(
+            std::fs::read(share_dir.join("nix-closure.nar")).unwrap(),
+            b"closure-bytes"
+        );
     }
 
     // ---------------------------------------------------------------

--- a/crates/mvm-build/src/libkrun_builder.rs
+++ b/crates/mvm-build/src/libkrun_builder.rs
@@ -1023,6 +1023,10 @@ impl LibkrunBuilderVm {
                 disk.read_only,
             );
         }
+        // Builder VMs are NIC-less: egress goes over the vsock relay below, so
+        // the libkrun networking mode must be the disconnected sink — the
+        // supervisor rejects anything else. Matches the Stage 0 path.
+        krun = apply_networking_mode(krun, &vm_state_dir);
 
         if builder_uses_vsock_egress(&image)
             && runtime_overlay.is_none()
@@ -1478,6 +1482,10 @@ impl BuilderVm for LibkrunBuilderVm {
                 path_to_str(&share_dir, "closure_seed_dir")?,
             );
         }
+        // Builder VMs are NIC-less: egress goes over the vsock relay below, so
+        // the libkrun networking mode must be the disconnected sink — the
+        // supervisor rejects anything else. Matches the Stage 0 path.
+        krun = apply_networking_mode(krun, &vm_state_dir);
 
         if builder_uses_vsock_egress(&image)
             && runtime_overlay.is_none()

--- a/crates/mvm-build/src/libkrun_builder.rs
+++ b/crates/mvm-build/src/libkrun_builder.rs
@@ -539,7 +539,7 @@ fn prepare_builder_transport_disks(
 ) -> Result<(PathBuf, PathBuf), BuilderVmError> {
     let input_disk = vm_state_dir.join("input.img");
     let output_disk = vm_state_dir.join("output.img");
-    pack_input_disk(input_trees, &input_disk, BUILDER_INPUT_DISK_MIN).map_err(|e| {
+    pack_input_disk(input_trees, None, &input_disk, BUILDER_INPUT_DISK_MIN).map_err(|e| {
         BuilderVmError::ExtractionFailed(format!(
             "pack builder input disk {}: {e}",
             input_disk.display()
@@ -1026,7 +1026,7 @@ impl LibkrunBuilderVm {
         // Builder VMs are NIC-less: egress goes over the vsock relay below, so
         // the libkrun networking mode must be the disconnected sink — the
         // supervisor rejects anything else. Matches the Stage 0 path.
-        krun = apply_networking_mode(krun, &vm_state_dir);
+        krun = apply_networking_mode(krun);
 
         if builder_uses_vsock_egress(&image)
             && runtime_overlay.is_none()
@@ -1485,7 +1485,7 @@ impl BuilderVm for LibkrunBuilderVm {
         // Builder VMs are NIC-less: egress goes over the vsock relay below, so
         // the libkrun networking mode must be the disconnected sink — the
         // supervisor rejects anything else. Matches the Stage 0 path.
-        krun = apply_networking_mode(krun, &vm_state_dir);
+        krun = apply_networking_mode(krun);
 
         if builder_uses_vsock_egress(&image)
             && runtime_overlay.is_none()

--- a/crates/mvm-build/src/qemu_builder.rs
+++ b/crates/mvm-build/src/qemu_builder.rs
@@ -25,6 +25,8 @@ use std::sync::atomic::{AtomicU32, Ordering};
 
 use crate::builder_vm::{BuilderArtifacts, BuilderJob, BuilderMounts, BuilderVm, BuilderVmError};
 #[cfg(feature = "builder-vm")]
+use crate::builder_vm_runtime::CLOSURE_SEED_TAG;
+#[cfg(feature = "builder-vm")]
 use crate::libkrun_builder::{
     BuilderEndpointTransport, BuilderShellJob, BuilderShellResult, BuilderVsockEgressEndpoint,
     builder_runtime_overlay_attachment, cached_runtime_overlay_ext4,
@@ -594,7 +596,8 @@ fn run_build_qemu(
 fn run_shell_script_qemu(job: &BuilderShellJob) -> Result<BuilderShellResult, BuilderVmError> {
     use crate::builder_vm_runtime::{
         acquire_nix_store_image_lock, builder_vm_timeout, read_job_result_with_diagnostics,
-        shell_job_exit_error, stage_shell_job_dir,
+        stage_closure_seed_dir, stage_shell_job_dir,
+        shell_job_exit_error,
     };
     use crate::libkrun_builder::{
         BuilderVmImage, DEFAULT_NIX_STORE_MIB, builder_vm_cache_dir, ensure_builder_vm_image,
@@ -646,13 +649,26 @@ fn run_shell_script_qemu(job: &BuilderShellJob) -> Result<BuilderShellResult, Bu
         );
     }
 
-    let shares = [
-        ("work", job.work_dir.as_path()),
-        ("out", job.artifact_out.as_path()),
-        ("job", job_dir.as_path()),
-    ];
+    // Attach the resolved builder image's seeded closure NAR, when it
+    // carries one, as a fourth read-only share — the same per-arch cache
+    // dir `ensure_builder_vm_image` just read the kernel/rootfs from.
+    let closure_nar =
+        crate::builder_pack::closure_nar_path(&builder_vm_cache_dir().join(host_arch_tag()));
+    let closure_share_dir = closure_nar
+        .as_deref()
+        .map(|nar| stage_closure_seed_dir(nar, &vm_state_dir))
+        .transpose()?;
+
+    let shares = qemu_shares_with_closure_seed(
+        vec![
+            ("work", job.work_dir.as_path()),
+            ("out", job.artifact_out.as_path()),
+            ("job", job_dir.as_path()),
+        ],
+        closure_share_dir.as_deref(),
+    );
     let mut virtiofsd = VirtiofsdGuard::default();
-    for (tag, dir) in shares {
+    for (tag, dir) in shares.iter().copied() {
         let sock = qemu_virtiofs_socket_path(&job_id, tag);
         virtiofsd.spawn(&virtiofsd_bin, virtiofsd_flavor, tag, &sock, dir)?;
     }
@@ -708,7 +724,7 @@ fn run_shell_script_qemu(job: &BuilderShellJob) -> Result<BuilderShellResult, Bu
         "-numa",
         "node,memdev=mem",
     ]);
-    for (tag, _) in shares {
+    for (tag, _) in shares.iter().copied() {
         let sock = qemu_virtiofs_socket_path(&job_id, tag);
         cmd.arg("-chardev")
             .arg(format!("socket,id=vfs-{tag},path={}", sock.display()));
@@ -796,7 +812,7 @@ fn run_build_qemu(
 ) -> Result<BuilderArtifacts, BuilderVmError> {
     use crate::builder_vm_runtime::{
         acquire_nix_store_image_lock, builder_vm_timeout, finalize_flake_job, finalize_install_job,
-        stage_job_dir,
+        stage_closure_seed_dir, stage_job_dir,
     };
     use crate::libkrun_builder::{
         BuilderVmImage, DEFAULT_NIX_STORE_MIB, builder_vm_cache_dir, ensure_builder_vm_image,
@@ -870,14 +886,27 @@ fn run_build_qemu(
     //    their sockets as a client at launch, so they must be ready). The
     //    guest mounts each by tag; `work`/`mvm-bins` are inputs it mounts
     //    read-only (`virtiofs_tag_is_read_only`), `out`/`job` read-write.
-    let shares = [
-        ("work", mounts.flake_src.as_path()),
-        ("out", mounts.artifact_out.as_path()),
-        ("job", job_dir.as_path()),
-        ("mvm-bins", mounts.host_bin_dir.as_path()),
-    ];
+    // Attach the resolved builder image's seeded closure NAR, when it
+    // carries one, as a fifth read-only share — the same per-arch cache
+    // dir `ensure_builder_vm_image` just read the kernel/rootfs from.
+    let closure_nar =
+        crate::builder_pack::closure_nar_path(&builder_vm_cache_dir().join(host_arch_tag()));
+    let closure_share_dir = closure_nar
+        .as_deref()
+        .map(|nar| stage_closure_seed_dir(nar, &vm_state_dir))
+        .transpose()?;
+
+    let shares = qemu_shares_with_closure_seed(
+        vec![
+            ("work", mounts.flake_src.as_path()),
+            ("out", mounts.artifact_out.as_path()),
+            ("job", job_dir.as_path()),
+            ("mvm-bins", mounts.host_bin_dir.as_path()),
+        ],
+        closure_share_dir.as_deref(),
+    );
     let mut virtiofsd = VirtiofsdGuard::default();
-    for (tag, dir) in shares {
+    for (tag, dir) in shares.iter().copied() {
         let sock = qemu_virtiofs_socket_path(&job_id, tag);
         virtiofsd.spawn(&virtiofsd_bin, virtiofsd_flavor, tag, &sock, dir)?;
     }
@@ -936,7 +965,7 @@ fn run_build_qemu(
         "-numa",
         "node,memdev=mem",
     ]);
-    for (tag, _) in shares {
+    for (tag, _) in shares.iter().copied() {
         let sock = qemu_virtiofs_socket_path(&job_id, tag);
         cmd.arg("-chardev")
             .arg(format!("socket,id=vfs-{tag},path={}", sock.display()));
@@ -988,6 +1017,22 @@ fn qemu_virtiofs_socket_path(job_id: &str, tag: &str) -> PathBuf {
     // nested in worktrees, so keep QEMU virtiofs sockets under /tmp and rely
     // on VirtiofsdGuard to remove them.
     PathBuf::from(format!("/tmp/mvm-vfs-{job_id}-{tag}.sock"))
+}
+
+/// Append the closure-seed share to `base` iff `closure_share_dir` is
+/// `Some`, mirroring the libkrun path's `closure_seed_share`. Pulled out as
+/// its own pure step (no qemu/virtiofsd spawn) so the "attach a share iff
+/// the resolved image carries a closure" decision is unit-testable without
+/// booting anything.
+#[cfg(feature = "builder-vm")]
+fn qemu_shares_with_closure_seed<'a>(
+    mut base: Vec<(&'a str, &'a Path)>,
+    closure_share_dir: Option<&'a Path>,
+) -> Vec<(&'a str, &'a Path)> {
+    if let Some(dir) = closure_share_dir {
+        base.push((CLOSURE_SEED_TAG, dir));
+    }
+    base
 }
 
 /// Validate the caller's mount paths before launching QEMU. Mirrors
@@ -1257,6 +1302,30 @@ mod vsock_module_tests {
 
     #[cfg(feature = "builder-vm")]
     use crate::libkrun_builder::{BuilderExtraDisk, BuilderShellJob};
+
+    #[cfg(feature = "builder-vm")]
+    #[test]
+    fn qemu_shares_omit_closure_seed_when_absent() {
+        let base = vec![("work", Path::new("/w")), ("out", Path::new("/o"))];
+        let shares = qemu_shares_with_closure_seed(base.clone(), None);
+        assert_eq!(shares, base);
+    }
+
+    #[cfg(feature = "builder-vm")]
+    #[test]
+    fn qemu_shares_append_closure_seed_when_present() {
+        let base = vec![("work", Path::new("/w")), ("out", Path::new("/o"))];
+        let closure_dir = Path::new("/vm-state/closure-seed");
+        let shares = qemu_shares_with_closure_seed(base, Some(closure_dir));
+        assert_eq!(
+            shares,
+            vec![
+                ("work", Path::new("/w")),
+                ("out", Path::new("/o")),
+                (CLOSURE_SEED_TAG, closure_dir),
+            ]
+        );
+    }
 
     #[test]
     fn cmdline_swaps_hvc0_for_serial_and_adds_qemu_markers() {

--- a/crates/mvm-build/src/qemu_builder.rs
+++ b/crates/mvm-build/src/qemu_builder.rs
@@ -596,8 +596,7 @@ fn run_build_qemu(
 fn run_shell_script_qemu(job: &BuilderShellJob) -> Result<BuilderShellResult, BuilderVmError> {
     use crate::builder_vm_runtime::{
         acquire_nix_store_image_lock, builder_vm_timeout, read_job_result_with_diagnostics,
-        stage_closure_seed_dir, stage_shell_job_dir,
-        shell_job_exit_error,
+        shell_job_exit_error, stage_closure_seed_dir, stage_shell_job_dir,
     };
     use crate::libkrun_builder::{
         BuilderVmImage, DEFAULT_NIX_STORE_MIB, builder_vm_cache_dir, ensure_builder_vm_image,

--- a/crates/mvm-cli/src/commands/build/hvf_builder_image.rs
+++ b/crates/mvm-cli/src/commands/build/hvf_builder_image.rs
@@ -319,7 +319,7 @@ mod tests {
     #[test]
     #[ignore = "live: needs macOS/Apple Silicon with the CLI-resolved HVF builder image path"]
     fn live_resolved_hvf_builder_runtime_overlay_is_read_only() {
-        let (kernel_path, rootfs_path) =
+        let (kernel_path, rootfs_path, _closure_nar) =
             resolve_hvf_builder_image().expect("HVF builder image must resolve");
 
         let tmp = tempfile::tempdir().expect("tempdir");

--- a/crates/mvm-cli/src/commands/build/hvf_builder_image.rs
+++ b/crates/mvm-cli/src/commands/build/hvf_builder_image.rs
@@ -43,20 +43,37 @@ fn is_cached(out_dir: &Path) -> bool {
     out_dir.join("Image").is_file() && out_dir.join("rootfs.ext4").is_file()
 }
 
-/// Resolve the HVF-bootable builder image pair `(kernel, rootfs)`.
+/// The seeded Nix store closure NAR alongside the resolved base builder
+/// image, when the pack that placed `arch_dir` carried one. `None` is the
+/// common case today — no closure production is wired into the source-
+/// checkout build path yet, only the attested-pack materialize step
+/// (`copy_builder_pack_artifacts`) can place this file.
+fn closure_nar_path(arch_dir: &Path) -> Option<PathBuf> {
+    let nar = arch_dir.join(mvm_build::builder_pack::CLOSURE_FILE);
+    nar.is_file().then_some(nar)
+}
+
+/// Resolve the HVF-bootable builder image pair `(kernel, rootfs)`, plus an
+/// optional seeded Nix store closure NAR when the resolved builder image
+/// carries one.
 ///
-/// - Reads the base `vmlinux` + `rootfs.ext4` from `builder_vm_cache_dir()/<arch>/`
-///   (the same source the libkrun/vz builders use).
+/// - Reads the base `vmlinux` + `rootfs.ext4` (and optional `nix-closure.nar`)
+///   from `builder_vm_cache_dir()/<arch>/` (the same source the libkrun/vz
+///   builders use).
 /// - Injects `mvm-host-vm-init` into a copy of the base rootfs using the
 ///   vsock-less HVF patcher VM.
-/// - Caches the result under `builder_vm_cache_dir()/hvf/<key>/`.
+/// - Caches the baked kernel/rootfs pair under `builder_vm_cache_dir()/hvf/<key>/`.
+///   The closure NAR is not baked into the rootfs — it is attached at boot as
+///   a separate share — so it is resolved directly from `arch_dir` on every
+///   call, cache hit or miss.
 ///
-/// On cache hit the existing pair is returned without rebaking.
+/// On cache hit the existing kernel/rootfs pair is returned without rebaking.
 /// On any VMM-level failure returns `BuilderVmError::HvfVmmFailed` so the
 /// builder auto-detect fallback can retry libkrun.
-pub fn resolve_hvf_builder_image() -> Result<(PathBuf, PathBuf), BuilderVmError> {
+pub fn resolve_hvf_builder_image() -> Result<(PathBuf, PathBuf, Option<PathBuf>), BuilderVmError> {
     let arch = std::env::consts::ARCH;
     let arch_dir = builder_vm_cache_dir().join(arch);
+    let closure_nar = closure_nar_path(&arch_dir);
 
     let vmlinux = arch_dir.join("vmlinux");
     let base_rootfs = arch_dir.join("rootfs.ext4");
@@ -92,7 +109,11 @@ pub fn resolve_hvf_builder_image() -> Result<(PathBuf, PathBuf), BuilderVmError>
     let out_dir = builder_vm_cache_dir().join("hvf").join(&key);
 
     if is_cached(&out_dir) {
-        return Ok((out_dir.join("Image"), out_dir.join("rootfs.ext4")));
+        return Ok((
+            out_dir.join("Image"),
+            out_dir.join("rootfs.ext4"),
+            closure_nar,
+        ));
     }
 
     // Bake into a staging directory; promote atomically so a partial bake
@@ -179,7 +200,11 @@ pub fn resolve_hvf_builder_image() -> Result<(PathBuf, PathBuf), BuilderVmError>
         }
     }
 
-    Ok((out_dir.join("Image"), out_dir.join("rootfs.ext4")))
+    Ok((
+        out_dir.join("Image"),
+        out_dir.join("rootfs.ext4"),
+        closure_nar,
+    ))
 }
 
 #[cfg(test)]
@@ -227,6 +252,26 @@ mod tests {
             key1,
             hvf_image_cache_key(&k, &r, &h),
             "kernel change → new key"
+        );
+    }
+
+    #[test]
+    fn closure_nar_path_is_none_when_absent() {
+        let dir = tempfile::tempdir().unwrap();
+        std::fs::write(dir.path().join("vmlinux"), b"kernel").unwrap();
+        std::fs::write(dir.path().join("rootfs.ext4"), b"rootfs").unwrap();
+        assert_eq!(closure_nar_path(dir.path()), None);
+    }
+
+    #[test]
+    fn closure_nar_path_resolves_when_present() {
+        let dir = tempfile::tempdir().unwrap();
+        std::fs::write(dir.path().join("vmlinux"), b"kernel").unwrap();
+        std::fs::write(dir.path().join("rootfs.ext4"), b"rootfs").unwrap();
+        std::fs::write(dir.path().join("nix-closure.nar"), b"nar").unwrap();
+        assert_eq!(
+            closure_nar_path(dir.path()),
+            Some(dir.path().join("nix-closure.nar"))
         );
     }
 

--- a/crates/mvm-cli/src/commands/build/hvf_builder_image.rs
+++ b/crates/mvm-cli/src/commands/build/hvf_builder_image.rs
@@ -47,10 +47,11 @@ fn is_cached(out_dir: &Path) -> bool {
 /// image, when the pack that placed `arch_dir` carried one. `None` is the
 /// common case today — no closure production is wired into the source-
 /// checkout build path yet, only the attested-pack materialize step
-/// (`copy_builder_pack_artifacts`) can place this file.
+/// (`copy_builder_pack_artifacts`) can place this file. Delegates to the
+/// shared resolver so the libkrun/qemu host wiring checks the identical
+/// condition.
 fn closure_nar_path(arch_dir: &Path) -> Option<PathBuf> {
-    let nar = arch_dir.join(mvm_build::builder_pack::CLOSURE_FILE);
-    nar.is_file().then_some(nar)
+    mvm_build::builder_pack::closure_nar_path(arch_dir)
 }
 
 /// Resolve the HVF-bootable builder image pair `(kernel, rootfs)`, plus an

--- a/crates/mvm-cli/src/commands/env/dev_vz/bootstrap.rs
+++ b/crates/mvm-cli/src/commands/env/dev_vz/bootstrap.rs
@@ -823,9 +823,14 @@ pub(in crate::commands) mod attested_builder_pack {
 
     /// Copy the readiness-relevant builder-image files out of the verified pack.
     /// `vmlinux` + `rootfs.ext4` are required (a builder pack that omits them is
-    /// malformed). `cmdline.txt` is copied when present, otherwise synthesized to
-    /// the current canonical builder-vm cmdline. The cache's `manifest.json` is
-    /// always synthesized here because the pack envelope manifest
+    /// malformed). `cmdline.txt` and the seeded closure NAR
+    /// (`mvm_build::builder_pack::CLOSURE_FILE`) are optional and copied when
+    /// present. When the pack omits `cmdline.txt`, this synthesizes the current
+    /// canonical builder-vm cmdline. The closure NAR sits alongside the
+    /// readiness-gated files here so the HVF/libkrun boot paths — which resolve
+    /// it from this exact cache dir — pick it up without a separate lookup; it
+    /// plays no part in the readiness check itself. The cache's `manifest.json`
+    /// is always synthesized here because the pack envelope manifest
     /// (`pack-manifest.json`) is a different contract from the runtime cache
     /// manifest the builder loader validates.
     fn copy_builder_pack_artifacts(pack_root: &Path, dest: &Path) -> Result<()> {
@@ -847,6 +852,13 @@ pub(in crate::commands) mod attested_builder_pack {
         } else {
             std::fs::write(dest.join("cmdline.txt"), SYNTHESIZED_BUILDER_VM_CMDLINE)
                 .context("writing synthesized builder pack cmdline.txt")?;
+        }
+        for name in [mvm_build::builder_pack::CLOSURE_FILE] {
+            let src = pack_root.join(name);
+            if src.exists() {
+                std::fs::copy(&src, dest.join(name))
+                    .with_context(|| format!("copying builder pack artifact {name}"))?;
+            }
         }
         std::fs::write(
             dest.join("manifest.json"),

--- a/crates/mvm-cli/src/commands/env/dev_vz/bootstrap_tests.rs
+++ b/crates/mvm-cli/src/commands/env/dev_vz/bootstrap_tests.rs
@@ -9,6 +9,7 @@ mod attested_builder_pack_tests {
     use chrono::{DateTime, TimeZone, Utc};
     use ed25519_dalek::{SigningKey, VerifyingKey};
 
+    use mvm_build::builder_pack::CLOSURE_FILE;
     use mvm_core::arch::GuestArch;
     use mvm_core::config::mvm_keys_dir;
     use mvm_core::pack_cache::{PackVerifyCtx, VerifiedPackDir, promote, resolve_pack};
@@ -106,6 +107,26 @@ mod attested_builder_pack_tests {
         assert!(
             validate_builder_vm_stage0_artifacts(&out_dir).is_ok(),
             "materialized dir must satisfy the installed-binary readiness gate"
+        );
+        // No closure NAR in the pack — the common case today — means no
+        // closure-seed file lands in the cache dir either.
+        assert!(!out_dir.join(CLOSURE_FILE).exists());
+    }
+
+    #[test]
+    fn materialize_copies_the_seeded_closure_nar_when_the_pack_carries_one() {
+        let pack = TempDir::new().expect("pack tempdir");
+        write_valid_builder_artifacts(pack.path());
+        std::fs::write(pack.path().join(CLOSURE_FILE), b"pretend-nar-bytes").expect("nar");
+        let out = TempDir::new().expect("out tempdir");
+        let out_dir = out.path().join("builder-vm").join("aarch64");
+        let verified = verified_pack_dir(pack.path());
+
+        materialize_builder_pack(&verified, &out_dir).expect("materialize");
+
+        assert_eq!(
+            std::fs::read(out_dir.join(CLOSURE_FILE)).expect("closure nar placed"),
+            b"pretend-nar-bytes"
         );
     }
 

--- a/crates/mvm-cli/src/commands/env/dev_vz/bootstrap_tests.rs
+++ b/crates/mvm-cli/src/commands/env/dev_vz/bootstrap_tests.rs
@@ -601,6 +601,7 @@ mod attested_builder_pack_tests {
         BuildBuilderPackParams {
             vmlinux,
             rootfs,
+            closure: None,
             target_arch: GuestArch::host(),
             channel: "stable".to_string(),
             builder_identity: "release-ci".to_string(),

--- a/crates/mvm-cli/src/commands/mod.rs
+++ b/crates/mvm-cli/src/commands/mod.rs
@@ -266,13 +266,12 @@ fn register_inhouse_builder() {
     // the CLI bridges the gap here.
     #[cfg(feature = "builder-vm")]
     mvm_build::builder_backend_select::register_hvf_builder(Box::new(|| {
-        let (kernel, rootfs) =
+        let (kernel, rootfs, closure_nar) =
             crate::commands::build::hvf_builder_image::resolve_hvf_builder_image()?;
-        Ok(
-            Box::new(mvm_backend::builder_runner::hvf_builder::HvfBuilderVm::new(
-                kernel, rootfs,
-            )) as Box<dyn mvm_build::builder_vm::BuilderVm>,
-        )
+        Ok(Box::new(
+            mvm_backend::builder_runner::hvf_builder::HvfBuilderVm::new(kernel, rootfs)
+                .with_closure_nar(closure_nar),
+        ) as Box<dyn mvm_build::builder_vm::BuilderVm>)
     }));
 }
 

--- a/nix/lib/mk-guest.nix
+++ b/nix/lib/mk-guest.nix
@@ -1030,13 +1030,15 @@ let
     ${builtins.seq assertNoSshTemplateInputs assertNoSshClosureScript}
 
     # Standard FHS dirs the kernel + init expect. `/nix-store`,
-    # `/job`, `/out`, `/work`, `/mvm-bins` are mount points the libkrun
-    # builder VM needs pre-created — rootfs boots
-    # `ro` so `mvm-host-vm-init` can't `mkdir` them at runtime. `/mnt`,
+    # `/job`, `/out`, `/work`, `/mvm-bins`, `/closure-seed` are mount
+    # points the libkrun builder VM needs pre-created — rootfs boots
+    # `ro` so `mvm-host-vm-init` can't `mkdir` them at runtime.
+    # `/closure-seed` receives the optional pre-fetched toolchain closure
+    # NAR (empty + unused unless the host attaches one). `/mnt`,
     # `/data` are the user-volume mount roots (MountPathPolicy allow-roots,
     # alongside `/work`) — `/init` mounts `--volume` shares here and can't
     # mkdir on the ro rootfs either.
-    mkdir -p "$out"/{bin,sbin,etc,proc,sys,dev,tmp,run,var,root,home,nix/store,nix-store,etc/mvm,job,out,work,mvm-bins,mnt,data}
+    mkdir -p "$out"/{bin,sbin,etc,proc,sys,dev,tmp,run,var,root,home,nix/store,nix-store,etc/mvm,job,out,work,mvm-bins,closure-seed,mnt,data}
     chmod 1777 "$out/tmp"
     chmod 0755 "$out/run"
 

--- a/specs/notes/sp3-seed-closure-design.md
+++ b/specs/notes/sp3-seed-closure-design.md
@@ -36,7 +36,42 @@ The seeded closure is a **builder-pack artifact imported only into the builder V
 
 S3.1 → S3.2 → S3.3 gets a live hvf end-to-end on this Mac (build the pack with a small closure, prepare, boot the hvf builder, confirm the seeded closure is imported and a build that would have fetched it is now fast). S3.4 wires the real dev-shell closure into releases. S3.5 extends parity. Re-run the SP4 bench (`ops bench first-use`) before/after to quantify the win against the ~153 s baseline.
 
+## Live validation (2026-07-11, Linux/qemu builder)
+
+The full chain was booted end-to-end on a real qemu builder VM with a
+102 MB, 61-path test closure staged at `nix-closure.nar`:
+
+- Host resolved the NAR, staged it into its own read-only share dir, and
+  attached it to the VM as the `closure-seed` virtio-fs share.
+- Guest mounted `/closure-seed`, and `mvm-host-vm-init` imported the NAR:
+  `importing seeded closure /closure-seed/nix-closure.nar (<hash>)`, no
+  fail-open warning.
+- The content-keyed marker `/nix-store/.seed-closure-imported` was stamped
+  with the closure hash (so an unchanged closure is a no-op next boot), and
+  the closure's store paths (glibc, bash, …) are present in the persistent
+  Nix store.
+
+Two bugs the unit tests missed were caught by the live boot and fixed:
+
+1. **Import ran before the mount.** The import call sat inside
+   `setup_nix_store` (Track A), which completes before the virtio-fs join /
+   disk-transport staging that mounts `/closure-seed` — so it read an
+   unmounted path and silently imported nothing. Moved to after both mount
+   paths.
+2. **Mount point not baked.** The builder rootfs boots read-only, so the
+   guest can't `mkdir /closure-seed` at runtime (`create /closure-seed:
+   Read-only file system`). It's now pre-created in `mkGuest` alongside
+   `/work`, `/out`, `/job`, `/mvm-bins`.
+
+**hvf (disk-transport) parity** shares the same guest import + baked mount
+point; its host-side attach (NAR as a tar entry on the input disk) is
+unit-tested but not yet live-booted — the dev Mac's Stage 0 store is
+degraded (corrupt store + `/homeless-shelter` purity), which fails the
+builder base-image rebuild before the hvf builder boots. Live hvf boot is
+pending a clean macOS Stage 0 environment.
+
 ## Deferred / not here
 
 - Warm-builder-snapshot capture (adjacent warm-start work) — SP3 leaves the seam; capturing the seeded store into a snapshot is separate.
 - A core/extended closure split — only if SP4 shows prepare-time cost is painful.
+- Live hvf disk-transport boot (blocked on the dev Mac's Stage 0 rot; the mechanism is unit-tested and shares the validated guest path).

--- a/specs/notes/sp3-seed-closure-design.md
+++ b/specs/notes/sp3-seed-closure-design.md
@@ -1,0 +1,42 @@
+# SP3 — Seed the dev-shell Nix closure into the builder pack
+
+**Status:** design finalized 2026-07-11 (decisions confirmed with owner)
+**Relation:** Plan 213 SP3 (instant first-use). Builds on SP1 (versioned pack cache), SP2 (install-time prefetch), SP4 (benchmark). Umbrella design: `specs/notes/instant-first-use-pack-design.md`.
+
+## Motivating measurement (SP4 bench, Hetzner qemu builder, 2 runs — directional)
+
+Building a *trivial* fixture in the builder VM took **~153 s (p50)**. A trivial build isn't 153 s of compilation — that time is **Nix evaluation + closure fetch/realise** of the nixpkgs/toolchain closure. Seeding that closure into the builder's Nix store ahead of time removes the fetch/eval, dropping the build toward near-instant. The mechanism is validated with a large, clear win; the finding is backend-agnostic (closure cost, not VMM cost) and only grows for heavier real builds.
+
+## Decisions (confirmed)
+
+1. **Content — the dev-shell toolchain closure.** Seed the transitive closure (`nix-store -qR` of the dev-shell derivation) of the toolchain the builder exists to provide: cargo/rustc + uv + pnpm + the nixpkgs base that `dev up` / common builds pull. That closure is exactly what the ~153 s was spent fetching.
+2. **Size — content-defined, no hard cap.** The seed is whatever that closure is (~1 GB, cargo/rustc-dominated). It's paid once at prepare/install time (off the hot path — SP2), justified by ~150 s saved per build. Guard against accidental bloat with a **release-pipeline soft alarm** (fail the pack build if the seeded closure exceeds a generous threshold, e.g. 2 GB uncompressed). Revisit a core/extended split only if prepare-time cost becomes painful (SP4 measures it).
+3. **Parity — hvf-first (day-one), then libkrun, then Linux/qemu.** Dev is Mac-first (macOS 26+ Apple Silicon → hvf is the default builder), so the hvf builder's closure-attach path lands first and is live-tested on this Mac. The import *mechanism* is identical across backends; only the host-side "attach the closure NAR to the builder VM" wiring is per-backend.
+
+## Invariant
+
+The seeded closure is a **builder-pack artifact imported only into the builder VM's persistent Nix store**. It is never included in, copied to, or reachable from a workload microVM rootfs (already CI-enforced by `xtask check-guest-images-no-builder-tools`). Workload VMs stay minimal.
+
+## Mechanism
+
+- **Producer:** a NAR export of the toolchain closure (`nix-store --export $(nix-store -qR <toolchain>)`) becomes a builder-pack file; wire the already-present-but-unused `PackOutputs.closure_hash`; it rides the pack's existing per-file hash + signature machinery.
+- **Consumer (guest):** at the first-boot seed step in `mvm-host-vm-init` (right after the existing `seed_nix_store`/`load_seeded_nix_db`), if a closure NAR is present and its content hash hasn't been imported, `nix-store --import` it, then stamp a **content-keyed idempotency marker** (so a changed closure re-imports; an unchanged one is skipped). **Fail-open** — an import failure logs and continues (an accelerator, never a hard dependency).
+- **Host wiring (per-backend):** attach the resolved pack's closure NAR to the builder VM as a read-only share, hvf first.
+- **Timing:** imported at prepare time (SP2's `bootstrap` path), captured into the warm builder snapshot when that lands — so first real use restores an already-seeded builder.
+
+## Decomposition (sub-PRs, in order)
+
+- **S3.1 — Schema + producer (offline, PR-safe).** `--closure <nar>` on `mvm-builder-pack-tool`; `BuildBuilderPackParams.closure: Option<PathBuf>`; copy+hash into the pack + set `closure_hash`; keep it optional in `validate_required_outputs` (older/opt-out packs stay valid). Unit-tested. No VM.
+- **S3.2 — Guest import + idempotency (fail-open).** In `mvm-host-vm-init`: `nix-store --import` of the closure NAR + a content-keyed marker, after the existing seed step. Unit-test the marker/decision logic; the import itself is exercised live.
+- **S3.3 — HVF host wiring (day-one target).** Attach the closure NAR share to the hvf builder VM; resolve it from the verified pack. Live-testable on this Mac.
+- **S3.4 — Release-pipeline closure production.** Add a step to `release.yml`'s builder-pack job that exports the dev-shell toolchain closure deterministically, passes `--closure`, and soft-alarms on size (>2 GB). This is where the "content = dev-shell toolchain" decision is encoded.
+- **S3.5 (follow) — libkrun + Linux/qemu host wiring.** The same attach for the other builders.
+
+## Sequencing & validation
+
+S3.1 → S3.2 → S3.3 gets a live hvf end-to-end on this Mac (build the pack with a small closure, prepare, boot the hvf builder, confirm the seeded closure is imported and a build that would have fetched it is now fast). S3.4 wires the real dev-shell closure into releases. S3.5 extends parity. Re-run the SP4 bench (`ops bench first-use`) before/after to quantify the win against the ~153 s baseline.
+
+## Deferred / not here
+
+- Warm-builder-snapshot capture (adjacent warm-start work) — SP3 leaves the seam; capturing the seeded store into a snapshot is separate.
+- A core/extended closure split — only if SP4 shows prepare-time cost is painful.

--- a/specs/notes/sp3-seed-closure-design.md
+++ b/specs/notes/sp3-seed-closure-design.md
@@ -63,15 +63,29 @@ Two bugs the unit tests missed were caught by the live boot and fixed:
    Read-only file system`). It's now pre-created in `mkGuest` alongside
    `/work`, `/out`, `/job`, `/mvm-bins`.
 
-**hvf (disk-transport) parity** shares the same guest import + baked mount
-point; its host-side attach (NAR as a tar entry on the input disk) is
-unit-tested but not yet live-booted — the dev Mac's Stage 0 store is
-degraded (corrupt store + `/homeless-shelter` purity), which fails the
-builder base-image rebuild before the hvf builder boots. Live hvf boot is
-pending a clean macOS Stage 0 environment.
+## Live validation (2026-07-12, macOS/hvf disk-transport)
+
+The hvf disk-transport path was booted end-to-end on this Mac via the
+`hvf-rootfs-inject` (inject the current `mvm-host-vm-init` into a builder
+rootfs, no Stage 0) + `hvf-builder-transport` (boot the hvf builder with the
+NAR riding the input-disk tar) examples — sidestepping the degraded Stage 0
+base rebuild. Guest DBG confirmed the NAR extracted to
+`/run/builder-input/closure-seed/nix-closure.nar`, bind-mounted to
+`/closure-seed`, and `mvm-host-vm-init` ran the import with the same content
+hash the qemu run produced and no fail-open warning (`nix-store --import`
+exit 0). The persisted marker isn't host-checkable there — the example's
+nix-store scratch disk isn't synced on the trivial power-off — but the import
+execution + completion is the backend-agnostic code already proven end-to-end
+on qemu.
+
+A third bug the live boot caught and fixed: both host stagers named the NAR
+after the *source path's* file name rather than the fixed `CLOSURE_FILE`
+(`nix-closure.nar`) the guest imports, so any differently-named source made the
+import a silent no-op. `pack_input_disk` (disk) and `stage_closure_seed_dir`
+(virtio-fs) now derive the staged name from `CLOSURE_FILE`.
 
 ## Deferred / not here
 
 - Warm-builder-snapshot capture (adjacent warm-start work) — SP3 leaves the seam; capturing the seeded store into a snapshot is separate.
 - A core/extended closure split — only if SP4 shows prepare-time cost is painful.
-- Live hvf disk-transport boot (blocked on the dev Mac's Stage 0 rot; the mechanism is unit-tested and shares the validated guest path).
+- Real `machine build --builder hvf` closure boot (vs. the example harness) — blocked only by the dev Mac's Stage 0 rot (`/homeless-shelter` mid-invocation on a from-scratch rebuild), unrelated to SP3; the disk-transport delivery + import are already live-proven via the inject/transport examples.


### PR DESCRIPTION
Plan 213 **SP3** — a builder pack can carry a seeded Nix closure (`nix-closure.nar`, a `nix-store --export` of the dev-shell toolchain), and the builder VM imports it into its persistent Nix store at first boot. Both halves are **optional and fail-open** — inert until the host-side attach (next slice) makes the NAR available in the guest. Design: `specs/notes/sp3-seed-closure-design.md`.

## Why
SP4's bench measured **~153 s** in-guest build for a trivial fixture — that's Nix eval + closure fetch/realise, not compilation. Pre-seeding the common closure eliminates it.

## What
**Producer (S3.1, `mvm-build`):** `--closure <nar>` on `mvm-builder-pack-tool` + `BuildBuilderPackParams.closure` + a shared `stage_closure` that copies+hashes the NAR into the pack, adds it to the signed file set, and sets the already-present optional `PackOutputs.closure_hash`. Rejected on `--kind runtime` (builder-pack-only invariant). Absent closure → unchanged behavior.

**Guest import (S3.2, `mvm-host-vm-init`):** after the existing first-boot `load_seeded_nix_db`, if `/closure-seed/nix-closure.nar` is present and its content hash isn't already recorded in the `/nix-store/.seed-closure-imported` marker, `nix-store --import` it and stamp the marker (changed closure → re-import; unchanged → skip). **Fail-open**: absent NAR is a silent no-op; any error is logged and swallowed — never panics or aborts boot. Pure decision logic is unit-tested; the Linux-guest path is exercised via a real `zigbuild` cross-compile.

## Not here (following slices)
S3.3 host-side attach of the NAR to the **hvf** builder VM (day-one, live-tested on Apple Silicon) → S3.4 release closure production (the dev-shell toolchain export + size soft-alarm) → S3.5 libkrun/Linux parity.

## Testing
Producer: 2 lib + 3 tool tests. Guest: 5 pure decision tests + Linux cross-compile of the init bin. `clippy --workspace -D warnings`, fmt, `check-no-spec-refs-in-comments` clean; one unrelated pre-existing `mvm-guest::worker_pool_warm` flake (passes on re-run; no guest code touched here).