### PR TITLE
docs(adr): ADR-110 uniform userspace vsock egress

### DIFF
--- a/specs/adrs/110-uniform-userspace-vsock-egress.md
+++ b/specs/adrs/110-uniform-userspace-vsock-egress.md
@@ -1,0 +1,123 @@
+# ADR-110: Uniform userspace vsock egress (one smoltcp forwarder + host-originated secret substitution)
+
+**Status:** Proposed — 2026-07-11
+**Summary:** Collapse host-side workload egress onto a single userspace model on every
+backend (libkrun, Firecracker, HVF, future WHP): a `smoltcp` forwarder for direct
+flows and a host-originated vsock substitution endpoint for secret-bearing flows.
+Retire the Linux host-TUN + kernel-NAT path. No NAT device, no privilege, no guest
+networking stack beyond vsock.
+
+## Context
+
+The Phase 2A raw-L3 egress data plane landed across five PRs: Linux host-`/dev/net/tun`
++ kernel masquerade NAT (#1634), and a macOS userspace `smoltcp` forwarder for TCP
+(#1639), UDP (#1647), and ICMP echo (#1650), plus a fuzz target for the packet gate
+(#1643). That left **two different host-side forwarding mechanisms** for what is one
+job.
+
+The invariant this ADR is written against (reaffirmed by the maintainer):
+
+- The microVM's **only** I/O channel is vsock. There is no networking stack *beyond*
+  vsock from the guest's perspective, and **no NAT device** in the egress path.
+- **Zero secrets or sensitive data land in the microVM.** Secrets are replaced
+  host-side and the substituted request + its response ride the **vsock** channel.
+
+The Linux host-TUN + kernel-NAT path conflicts with the spirit of that invariant: it
+needs `CAP_NET_ADMIN`, installs a NAT device, is Linux-specific, and has no
+unprivileged equivalent on macOS (`pf` needs root) or Windows.
+
+## The requirement
+
+One host-side egress model that is: **uniform** across libkrun / Firecracker / HVF /
+WHP, **unprivileged**, uses **no NAT device**, keeps the microVM **vsock-only**, keeps
+the guest with **no networking stack beyond vsock**, and lets **zero secrets** reach
+the guest.
+
+## Options considered
+
+**A. Kernel NAT everywhere** (host TUN + kernel NAT on each OS). Fastest, but needs
+`CAP_NET_ADMIN`/root and a NAT device, and has no unprivileged form on macOS/Windows.
+Rejected — violates the no-NAT / unprivileged / uniform requirement.
+
+**B. One userspace `smoltcp` forwarder everywhere.** `smoltcp` runs entirely
+host-side and is **VMM-agnostic**: the guest pumps raw-L3 packets over vsock and the
+host worker feeds them into a `smoltcp::Interface` that terminates TCP/UDP and splices
+the byte stream to ordinary host `std::net` sockets. The VMM only supplies the vsock
+transport — which libkrun (in-process vsock) and Firecracker (host AF_VSOCK) already
+do, which is why the worker was built backend-neutral. Uniform, unprivileged, no NAT,
+vsock-only. **Chosen.**
+
+**C. Host kernel sockets via a socket-level vsock proxy (TSI-style).** The guest
+relays socket operations over vsock instead of running a TCP/IP stack; the host opens
+**kernel** sockets and splices. No userspace TCP anywhere — the performance end-state,
+and an even tighter fit for "no networking stack beyond vsock" (the guest has no IP
+stack at all). Deferred (see Performance).
+
+## Recommendation
+
+1. **Unify host forwarding on `smoltcp` (option B) across all backends.** Promote the
+   `smoltcp` forwarder from `#[cfg(target_os = "macos")]` to the universal host
+   forwarder; **retire** `host_tun` + the nft NAT + the `host_tun_nat_live` witness.
+2. **One codebase, one thin trait.** TCP/UDP termination + packet framing + the socket
+   bridge are pure `smoltcp` + `std::net` — identical on every OS. The *only*
+   platform-specific piece is the unprivileged ICMP-echo socket (Linux ping socket /
+   macOS `SOCK_DGRAM`+`IPPROTO_ICMP` / Windows raw), which lives behind a thin
+   `HostIcmpEcho` trait with per-OS impls. Nothing else forks by platform.
+3. **End-to-end TLS is preserved, no MITM.** `smoltcp` terminates the *TCP transport*
+   and byte-splices the encrypted stream to the host socket; the TLS handshake stays
+   end-to-end between guest and real server. The host relays ciphertext only. The
+   existing CI guard that bans TLS/transform symbols from the data-plane files stays.
+4. **Secret egress is host-originated vsock substitution, never a NAT/terminator.**
+   Per the substitution mechanism the codebase already implements: the guest sends a
+   request carrying an opaque placeholder over vsock; the host resolves the
+   placeholder to the real secret, verifies the destination is bound to that secret,
+   **originates the real egress itself**, and returns the response over vsock. The raw
+   secret only ever exists in the one confined host process; it never lands in the
+   microVM. This is *not* the transparent nft-REDIRECT terminator — no host network
+   device the guest routes through.
+5. **All egress is one uniform host-side model:** the `smoltcp` forwarder for direct /
+   non-secret flows (guest does its own end-to-end TLS) and the vsock substitution
+   endpoint for secret flows (host originates). Both unprivileged, both vsock-only,
+   both audited, no NAT.
+
+## Performance
+
+Userspace TCP (`smoltcp`) is slower than kernel NAT (extra copies + a userspace TCP
+state machine). This is **accepted for simplicity and uniformity**, and is modest for
+the actual workload profile — dev/agent microVMs making API calls, pulling packages,
+and streaming model output, not a multi-Gbps proxy. The tradeoff is to be
+**benchmarked**, not asserted.
+
+If a real throughput bottleneck ever appears, the escape hatch is **option C** (host
+kernel sockets via a socket-level vsock proxy / TSI): faster, still
+unprivileged/uniform/no-NAT, and a tighter fit for the invariant. Two constraints on
+that future path: it needs guest-side socket interception (feasible in the in-house
+HVF VMM and already present in libkrun; a shim elsewhere), and it **must be the
+egress-enforcement gate** — every `connect` policy-checked and audited host-side. The
+earlier libkrun TSI mode was removed precisely because it *bypassed* the egress
+gateway; a socket proxy that *is* the gate is the opposite and is acceptable. Build it
+only if the numbers force it.
+
+## Consequences
+
+- Delete `crates/mvm-hostd/src/host_tun.rs`, its nft NAT setup/teardown, and the
+  `host_tun_nat_live` witness; generalize `smoltcp_egress`; add `HostIcmpEcho`.
+- **Drops the `CAP_NET_ADMIN` requirement on Linux** — workload egress becomes
+  uniformly unprivileged.
+- Correct the **stale claim-12/13 prose in ADR-002**: it still describes a removed
+  signed-credential broker (`host.secrets.v1`); the real, shipped mechanism is
+  host-side egress substitution. Reconcile the numbered claims with the substitution
+  path.
+- The implementation **must coordinate with the in-flight egress branches**
+  (`fix/host-http-forward-proxy`, `feat/guest-vsock-session-refactor`, the
+  vsock-egress-cutover line) rather than opening a competing branch — those touch the
+  same substitution/vsock code.
+
+## Out of scope (for this ADR)
+
+- The option-C kernel-socket vsock proxy / TSI implementation (documented escape hatch
+  only, not built here).
+- IPv6 forwarding and per-flow credit backpressure (tracked separately).
+- The live booted-workload egress witness (needs a Linux + libkrun host; the host
+  TUN/NAT *mechanism* was live-proven on Linux 2026-07-11, but that path is being
+  retired — a `smoltcp` live witness replaces it).

--- a/specs/adrs/110-uniform-userspace-vsock-egress.md
+++ b/specs/adrs/110-uniform-userspace-vsock-egress.md
@@ -108,10 +108,15 @@ only if the numbers force it.
   signed-credential broker (`host.secrets.v1`); the real, shipped mechanism is
   host-side egress substitution. Reconcile the numbered claims with the substitution
   path.
-- The implementation **must coordinate with the in-flight egress branches**
-  (`fix/host-http-forward-proxy`, `feat/guest-vsock-session-refactor`, the
-  vsock-egress-cutover line) rather than opening a competing branch — those touch the
-  same substitution/vsock code.
+- The implementation **must rebase onto the active tunnel-hardening work**, not open a
+  competing branch. The primary base is `feat/plan-236-2a-l3-forward`, which is
+  actively expanding `network_tunnel.rs` / `network_tunnel_spawn.rs` / `net_l3.rs`
+  (adds a no-guest-NIC claim + a legacy-workload-transport gate) — the exact
+  orchestration this unification reworks. It composes with that work (it locks in
+  vsock-only/no-NIC; this ADR unifies the host forwarder behind it), but the
+  unification lands only after it settles. The substitution/vsock edges also overlap
+  `fix/host-http-forward-proxy`, `feat/guest-vsock-session-refactor`, and the
+  vsock-egress-cutover line.
 
 ## Out of scope (for this ADR)
 


### PR DESCRIPTION
## What

Adds **ADR-110** deciding the host-side egress architecture that reconciles the two mechanisms shipped in Phase 2A (Linux host-TUN + kernel NAT #1634; macOS userspace smoltcp #1639/#1647/#1650) into **one uniform userspace model** across libkrun, Firecracker, HVF, and future WHP.

## Decision

- **One smoltcp forwarder everywhere** for direct/non-secret flows — smoltcp is host-side and VMM-agnostic, so it operates identically on the production backends (libkrun in-process vsock, Firecracker host AF_VSOCK). **Retire the Linux host-TUN + kernel-NAT path.**
- **Unprivileged, no NAT device, vsock-only.** Drops the `CAP_NET_ADMIN` requirement on Linux. One codebase; the only per-OS fork is the unprivileged ICMP-echo socket behind a thin `HostIcmpEcho` trait.
- **End-to-end TLS preserved** (byte-splice, no MITM).
- **Secret egress = host-originated vsock substitution**, never a NAT/terminator: the guest sends an opaque placeholder over vsock, the host resolves + destination-checks + originates the real egress + returns over vsock. Zero secrets in the microVM.

## Performance

Userspace TCP is slower than kernel NAT — **accepted for simplicity/uniformity**, modest for the dev/agent workload profile, to be **benchmarked**. Documents the **kernel-socket vsock proxy (TSI)** as the deferred escape hatch if a real bottleneck appears — must be the egress-enforcement gate (the old libkrun TSI was removed for *bypassing* it).

## Scope

Design decision only. Implementation must coordinate with the in-flight egress branches (host-http-forward-proxy, guest-vsock-session-refactor, vsock-egress-cutover) rather than open a competing branch.