### PR TITLE
docs: keep scratch/temp files in /tmp, never the repo tree

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -297,7 +297,9 @@ Documentation is a **first-class deliverable**. Every code change that touches u
 
 ## Screenshots & Temporary Files
 
-**NEVER** save screenshots, images, or any binary artifacts to the project root or any directory within the repository. Always save screenshots and temporary files to `/tmp/` (e.g. `/tmp/screenshot.png`, `/tmp/page-snapshot.png`). This prevents binary files from polluting the git history.
+**NEVER** write scratch, temporary, or intermediate files anywhere inside the repository working tree — not the project root, not a subdirectory, not a hidden dotfile (`.foo.txt`), not even a gitignored path. This applies to **every** kind of agent-created scratch, not just screenshots/binaries: analysis lists, command output, intermediate JSON/TSV, logs, ad-hoc scripts, `git merge-file` inputs, etc.
+
+Always write such files under `/tmp/` instead (e.g. `/tmp/screenshot.png`, `/tmp/worktree-audit.txt`). This keeps the working directory clean and keeps junk out of git. If you need three-way-merge scratch or similar, use `/tmp/`, never the repo.
 
 When using Playwright or other browser tools, explicitly set the output path to `/tmp/`:
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -440,6 +440,10 @@ Every new module, type, or function needs test coverage:
 - CLI: integration tests in `tests/cli.rs` for help text and argument parsing
 - Security: positive path, negative path (wrong key, tampered, replay), edge cases
 
+## Scratch & temporary files
+
+Never write scratch, temporary, or intermediate files anywhere inside the repo working tree — not the root, not a subdirectory, not a hidden dotfile, not a gitignored path. This covers **every** kind of agent-created scratch (analysis lists, command output, intermediate JSON/TSV, logs, ad-hoc scripts, `git merge-file` inputs), not just screenshots/binaries. Write them under `/tmp/` instead. See AGENTS.md §"Screenshots & Temporary Files" for the full rule.
+
 ## Build and Run
 
 ```bash


### PR DESCRIPTION
Generalizes the temp-file rule so it isn't read as screenshots-only.

- **AGENTS.md** §"Screenshots & Temporary Files": broaden "NEVER save screenshots/binaries" to "NEVER write scratch/temporary/intermediate files anywhere in the repo working tree" — covering analysis lists, command output, logs, ad-hoc scripts, `git merge-file` inputs, hidden dotfiles, and gitignored paths. All scratch goes under `/tmp/`.
- **CLAUDE.md**: add a short `## Scratch & temporary files` section with the same rule, pointing at the AGENTS.md section.

Motivation: scratch text files were left in the repo root; the previous wording was screenshot/binary-centric and didn't clearly forbid non-binary scratch.