### PR TITLE
release: prep 0.18.0 runtime overlay rollout surface

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,20 @@
 
 All notable changes to mvm are documented in this file.
 
+## [0.18.0] — Unreleased
+
+### Added
+- **runtime**: Roll out the readonly guest-runtime overlay as a first-class
+  release surface. Guest-executed runtime binaries are now published as a
+  version-matched artifact under `~/.cache/mvm/runtime-overlay/<version>/<arch>/`
+  and consumed read-only by admitted overlay-backed backends.
+
+### Changed
+- **runtime**: Document the runtime-overlay operational contract explicitly for
+  release verification and operator rollout: running VMs do not hot-remount,
+  stopped VMs pick up the new version on restart, and Linux rootfs-backed
+  libkrun builder use remains fail-closed.
+
 ## [0.17.0] — 2026-07-08
 
 ### Removed
@@ -1350,7 +1364,8 @@ has a tracking pointer; none is silently broken.
   See [`MIGRATING-FROM-V1.md`](MIGRATING-FROM-V1.md) §"Feature parity
   status" for the per-feature delta.
 
-[Unreleased]: https://github.com/tinylabscom/mvm/compare/v0.16.1...HEAD
+[Unreleased]: https://github.com/tinylabscom/mvm/compare/v0.18.0...HEAD
+[0.18.0]: https://github.com/tinylabscom/mvm/compare/v0.17.0...v0.18.0
 [0.16.1]: https://github.com/tinylabscom/mvm/compare/v0.16.0...v0.16.1
 [0.16.0]: https://github.com/tinylabscom/mvm/compare/v0.15.2...v0.16.0
 [0.15.2]: https://github.com/tinylabscom/mvm/compare/v0.15.1...v0.15.2

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1761,7 +1761,7 @@ checksum = "68ab91017fe16c622486840e4c83c9a37afeff978bd239b5293d61ece587de66"
 
 [[package]]
 name = "libkrun-sys"
-version = "0.17.0"
+version = "0.18.0"
 dependencies = [
  "libc",
  "mvm-backend",
@@ -1895,7 +1895,7 @@ dependencies = [
 
 [[package]]
 name = "mvm"
-version = "0.17.0"
+version = "0.18.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1924,7 +1924,7 @@ dependencies = [
 
 [[package]]
 name = "mvm-backend"
-version = "0.17.0"
+version = "0.18.0"
 dependencies = [
  "anyhow",
  "ext4-view",
@@ -1952,7 +1952,7 @@ dependencies = [
 
 [[package]]
 name = "mvm-build"
-version = "0.17.0"
+version = "0.18.0"
 dependencies = [
  "anyhow",
  "base64",
@@ -1990,7 +1990,7 @@ dependencies = [
 
 [[package]]
 name = "mvm-cli"
-version = "0.17.0"
+version = "0.18.0"
 dependencies = [
  "anyhow",
  "assert_cmd",
@@ -2033,7 +2033,7 @@ dependencies = [
 
 [[package]]
 name = "mvm-client"
-version = "0.17.0"
+version = "0.18.0"
 dependencies = [
  "async-trait",
  "flate2",
@@ -2049,7 +2049,7 @@ dependencies = [
 
 [[package]]
 name = "mvm-core"
-version = "0.17.0"
+version = "0.18.0"
 dependencies = [
  "aes-gcm",
  "aho-corasick",
@@ -2091,7 +2091,7 @@ dependencies = [
 
 [[package]]
 name = "mvm-ext4"
-version = "0.17.0"
+version = "0.18.0"
 dependencies = [
  "am-fs-ext4",
  "sha2",
@@ -2099,7 +2099,7 @@ dependencies = [
 
 [[package]]
 name = "mvm-guest"
-version = "0.17.0"
+version = "0.18.0"
 dependencies = [
  "anyhow",
  "base64",
@@ -2120,7 +2120,7 @@ dependencies = [
 
 [[package]]
 name = "mvm-guest-helpers"
-version = "0.17.0"
+version = "0.18.0"
 dependencies = [
  "anyhow",
  "hickory-proto",
@@ -2135,7 +2135,7 @@ dependencies = [
 
 [[package]]
 name = "mvm-host-services-ffi"
-version = "0.17.0"
+version = "0.18.0"
 dependencies = [
  "mvm-core",
  "mvm-guest",
@@ -2145,7 +2145,7 @@ dependencies = [
 
 [[package]]
 name = "mvm-hostd"
-version = "0.17.0"
+version = "0.18.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2194,7 +2194,7 @@ dependencies = [
 
 [[package]]
 name = "mvm-mcp"
-version = "0.17.0"
+version = "0.18.0"
 dependencies = [
  "anyhow",
  "serde",
@@ -2205,7 +2205,7 @@ dependencies = [
 
 [[package]]
 name = "mvm-network"
-version = "0.17.0"
+version = "0.18.0"
 dependencies = [
  "mvm-core",
  "mvm-sdk",
@@ -2214,7 +2214,7 @@ dependencies = [
 
 [[package]]
 name = "mvm-oci"
-version = "0.17.0"
+version = "0.18.0"
 dependencies = [
  "async-trait",
  "base64",
@@ -2235,7 +2235,7 @@ dependencies = [
 
 [[package]]
 name = "mvm-sdk"
-version = "0.17.0"
+version = "0.18.0"
 dependencies = [
  "async-trait",
  "base64",
@@ -2262,7 +2262,7 @@ dependencies = [
 
 [[package]]
 name = "mvm-storage"
-version = "0.17.0"
+version = "0.18.0"
 dependencies = [
  "async-trait",
  "bytes",
@@ -2280,7 +2280,7 @@ dependencies = [
 
 [[package]]
 name = "mvm-verify"
-version = "0.17.0"
+version = "0.18.0"
 dependencies = [
  "base64",
  "ed25519-dalek",
@@ -2291,7 +2291,7 @@ dependencies = [
 
 [[package]]
 name = "mvm-vm-host"
-version = "0.17.0"
+version = "0.18.0"
 dependencies = [
  "anyhow",
  "chrono",
@@ -2316,7 +2316,7 @@ dependencies = [
 
 [[package]]
 name = "mvmctl"
-version = "0.17.0"
+version = "0.18.0"
 dependencies = [
  "anyhow",
  "assert_cmd",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -156,7 +156,7 @@ resolver = "3"
 # functionally different software. Bumping the minor signals "0.x
 # breaking changes" without prematurely committing to a 1.0 stability
 # promise.
-version = "0.17.0"
+version = "0.18.0"
 edition = "2024"
 rust-version = "1.85"
 license = "Apache-2.0"
@@ -347,36 +347,36 @@ tree-sitter-typescript = "0.23.2"
 # here because member crates can't override that on a workspace-inherited
 # dependency unless the workspace entry already carries it. The root binary
 # opts back into user-facing defaults through its own `[features]` block.
-mvm-core = { path = "crates/mvm-core", version = "0.17.0" }
-mvm-client = { path = "crates/mvm-client", version = "0.17.0" }
-mvm-guest = { path = "crates/mvm-guest", version = "0.17.0" }
-mvm-guest-helpers = { path = "crates/mvm-guest-helpers", version = "0.17.0" }
-mvm-build = { path = "crates/mvm-build", version = "0.17.0", default-features = false }
-mvm = { path = "crates/mvm", version = "0.17.0", default-features = false }
-mvm-oci = { path = "crates/mvm-oci", version = "0.17.0" }
-mvm-ext4 = { path = "crates/mvm-ext4", version = "0.17.0" }
-mvm-storage = { path = "crates/mvm-storage", version = "0.17.0" }
-mvm-network = { path = "crates/mvm-network", version = "0.17.0" }
-mvm-cli = { path = "crates/mvm-cli", version = "0.17.0", default-features = false }
-mvm-hostd = { path = "crates/mvm-hostd", version = "0.17.0" }
+mvm-core = { path = "crates/mvm-core", version = "0.18.0" }
+mvm-client = { path = "crates/mvm-client", version = "0.18.0" }
+mvm-guest = { path = "crates/mvm-guest", version = "0.18.0" }
+mvm-guest-helpers = { path = "crates/mvm-guest-helpers", version = "0.18.0" }
+mvm-build = { path = "crates/mvm-build", version = "0.18.0", default-features = false }
+mvm = { path = "crates/mvm", version = "0.18.0", default-features = false }
+mvm-oci = { path = "crates/mvm-oci", version = "0.18.0" }
+mvm-ext4 = { path = "crates/mvm-ext4", version = "0.18.0" }
+mvm-storage = { path = "crates/mvm-storage", version = "0.18.0" }
+mvm-network = { path = "crates/mvm-network", version = "0.18.0" }
+mvm-cli = { path = "crates/mvm-cli", version = "0.18.0", default-features = false }
+mvm-hostd = { path = "crates/mvm-hostd", version = "0.18.0" }
 
 # plan 60 Phase 5 — build-time SDK port from ../mvmforge.
-mvm-sdk = { path = "crates/mvm-sdk", version = "0.17.0" }
-mvm-mcp = { path = "crates/mvm-mcp", version = "0.17.0" }
+mvm-sdk = { path = "crates/mvm-sdk", version = "0.18.0" }
+mvm-mcp = { path = "crates/mvm-mcp", version = "0.18.0" }
 # Plan 57 W1 — libkrun FFI bindings split out of mvm-providers so the
 # bindgen + libclang build cost is isolated from the Apple-VZ objc2
 # stack. Default feature set is empty; consumers wanting real FFI
 # enable `libkrun-sys` on a host with libkrun installed.
-libkrun-sys = { path = "crates/deps/libkrun-sys", version = "0.17.0" }
+libkrun-sys = { path = "crates/deps/libkrun-sys", version = "0.18.0" }
 # Plan 97 Phase B — type-safe interface to `mvm-vz-supervisor`. No FFI,
 # Linux-safe (compiles everywhere; `Platform::has_vz()` short-circuits
 # on non-macOS).
-mvm-backend = { path = "crates/mvm-backend", version = "0.17.0", default-features = false }
+mvm-backend = { path = "crates/mvm-backend", version = "0.18.0", default-features = false }
 
 # Plan 73 Followup B.2.x — builder-VM egress allowlist proxy.
 # mvm-host-vm-init spawns this as a subprocess before the
 # installer + tears it down after.
-mvm-egress-proxy = { path = "crates/mvm-egress-proxy", version = "0.17.0" }
+mvm-egress-proxy = { path = "crates/mvm-egress-proxy", version = "0.18.0" }
 
 # Plan 113 / ADR-064 §Decision 5 — A2 confinement helper (seccompiler +
 # landlock). Consumed by the per-VM `mvm-bridge` sidecar.

--- a/nix/images/runtime-overlay/flake.nix
+++ b/nix/images/runtime-overlay/flake.nix
@@ -117,7 +117,7 @@
       # the two in lock-step or `mvmctl up` admission fails.
       # `xtask check-runtime-overlay-version` (a CI gate)
       # asserts this match so the pin can't silently go stale.
-      overlayVersion = "0.17.0";
+      overlayVersion = "0.18.0";
 
       # mvm-guest binaries — agent + seccomp shim + verity-init.
       # `mvm-verity-init` is the initrd PID 1; it lives in the

--- a/public/src/content/docs/guides/verify-release.md
+++ b/public/src/content/docs/guides/verify-release.md
@@ -103,7 +103,7 @@ Overlay-backed workloads consume a separate readonly guest-runtime artifact from
 the same release. To verify it manually:
 
 ```bash
-VERSION=v0.17.0
+VERSION=v0.18.0
 ARCH=aarch64   # or x86_64
 
 curl -LO "https://github.com/tinylabscom/mvm/releases/download/${VERSION}/runtime-overlay-${ARCH}.ext4"


### PR DESCRIPTION
## Summary
- bump the workspace and in-workspace crate versions to 0.18.0
- add the readonly runtime-overlay release note entry for the next release line
- update release verification and operator rollout docs for the version-matched readonly runtime overlay contract

## Verification
- cargo check --workspace --offline
