### PR TITLE
chore: simplify just runtime overlay commands

### DIFF
--- a/Justfile
+++ b/Justfile
@@ -61,23 +61,34 @@ run *ARGS:
 dev *ARGS:
     bin/dev {{ARGS}}
 
+# Run cargo with the dev env set (worktree-local MVM_DATA_DIR /
+# MVM_CACHE_DIR / CARGO_TARGET_DIR).
+dev-cargo *ARGS:
+    bash -c 'source scripts/dev-env.sh && cargo {{ARGS}}'
+
 # Run cargo test --workspace with the dev env.
 dev-test:
-    bash -c 'source scripts/dev-env.sh && cargo test --workspace'
+    just dev-cargo test --workspace
 
 # Run clippy with the dev env.
 dev-clippy:
-    bash -c 'source scripts/dev-env.sh && cargo clippy --workspace -- -D warnings'
+    just dev-cargo clippy --workspace -- -D warnings
 
 # Run cargo check with the dev env.
 dev-check:
-    bash -c 'source scripts/dev-env.sh && cargo check --workspace'
+    just dev-cargo check --workspace
 
 # Prebuild or refresh the version-matched read-only runtime overlay once so
 # later required-overlay boots can reuse it without rebuilding guest binaries
 # on the hot path. Pass through extra args like `--force` or `--source download`.
+runtime-overlay *ARGS:
+    just dev build runtime-overlay build {{ARGS}}
+
+# Prebuild or refresh the version-matched read-only runtime overlay once so
+# later required-overlay boots can reuse it without rebuilding guest binaries
+# on the hot path. Kept as a compatibility alias for `just runtime-overlay`.
 runtime-overlay-build *ARGS:
-    bin/dev build runtime-overlay build {{ARGS}}
+    just runtime-overlay {{ARGS}}
 
 # ── Testing (nextest) ────────────────────────────────────────────────────
 

--- a/public/src/content/docs/reference/cli-commands.md
+++ b/public/src/content/docs/reference/cli-commands.md
@@ -123,7 +123,8 @@ guest-RPC surface, fleet-shaped workflows).
 | `mvmctl build runtime-overlay build --force` | Refresh the cached overlay even when the matching cache entry already exists |
 | `mvmctl build runtime-overlay build --source build\|download\|auto` | Choose whether the overlay is assembled from the source checkout, downloaded from the published release, or resolved the same way ordinary required-overlay boots do |
 | Runtime overlay update model | Stopped VMs pick up the newer version-matched overlay on the next boot. Running VMs keep the overlay they booted with; mvm does not hot-remount a different runtime overlay into a live guest |
-| `just runtime-overlay-build [--force]` | Worktree-local convenience wrapper around `mvmctl build runtime-overlay build`; sources `scripts/dev-env.sh` first so cache/target state stays isolated per worktree |
+| `just runtime-overlay [--force]` | Preferred worktree-local convenience wrapper around `mvmctl build runtime-overlay build`; sources `scripts/dev-env.sh` first so cache/target state stays isolated per worktree |
+| `just runtime-overlay-build [--force]` | Compatibility alias for `just runtime-overlay` |
 | `mvmctl env cleanup` | Remove old dev-build artifacts and run Nix garbage collection |
 | `mvmctl env cleanup --all` | Remove all cached build revisions |
 | `mvmctl env cleanup --keep <N>` | Keep the N newest build revisions |
@@ -263,7 +264,8 @@ admission until their transports are wired.
 | `mvmctl build runtime-overlay build --source download` | Download the published runtime-overlay artifact for this version into the cache |
 | `mvmctl build runtime-overlay build --arch aarch64\|x86_64 --version <semver>` | Override the target architecture or the expected overlay version |
 | Runtime overlay update model | Running VMs keep the overlay they booted with; a changed overlay takes effect on the next boot of a stopped VM |
-| `just runtime-overlay-build` | Prebuild the overlay through the worktree-local dev environment so later required-overlay boots avoid rebuilding guest binaries on the hot path |
+| `just runtime-overlay` | Prebuild the overlay through the worktree-local dev environment so later required-overlay boots avoid rebuilding guest binaries on the hot path |
+| `just runtime-overlay-build` | Compatibility alias for `just runtime-overlay` |
 
 ## Networks
 


### PR DESCRIPTION
## Summary
- add a shorter  recipe as the preferred overlay rebuild command
- keep  as a compatibility alias
- collapse repeated dev-env cargo wrappers behind a generic  recipe
- update CLI docs to point to the simplified command surface

## Validation
- Available recipes:
    audit                                          # Security audit (cargo-audit — RUSTSEC advisories against Cargo.lock)
    build                                          # Build all crates (debug)
    build-supervisors                              # a targeted rebuild or CI.
    check                                          # Type-check without codegen
    check-linux TARGET="x86_64-unknown-linux-gnu"  # COW FICLONE path (mvm-backend) only type-checks against glibc.
    ci                                             # Full CI gate: lint + test + doctests (nextest skips doctests).
    clean                                          # Clean build artifacts
    clippy                                         # Run clippy with warnings as errors
    default                                        # Default recipe - show help
    deny                                           # Supply chain check (cargo-deny — advisories + licenses + bans + sources)
    deploy-guard                                   # Pre-publish verification (version, tag, clippy)
    dev *ARGS                                      # Run mvmctl with the dev env set (worktree-local MVM_DATA_DIR).
    dev-cargo *ARGS                                # MVM_CACHE_DIR / CARGO_TARGET_DIR).
    dev-check                                      # Run cargo check with the dev env.
    dev-clippy                                     # Run clippy with the dev env.
    dev-test                                       # Run cargo test --workspace with the dev env.
    docs-build                                     # Build docs site
    docs-dev                                       # Start docs dev server
    docs-install                                   # Install docs site dependencies
    e2e-core-demo                                  # hazard remains.
    fmt                                            # Format all code
    fmt-check                                      # Check formatting (no changes)
    fuzz-authenticated-frame SECONDS="300"         # Run the AuthenticatedFrame envelope fuzzer (ADR-002 §W4.2). Default 5min.
    fuzz-guest-request SECONDS="300"               # Override with: just fuzz-guest-request 3600
    hvf-oci-allow-host-smoke                       # 2. admit/deny relay proof over the host-vsock egress endpoint
    install-hooks                                  # Wire core.hooksPath at .githooks/ (one-time per clone)
    lint                                           # Format check + clippy
    outdated                                       # Check for outdated dependencies
    preflight                                      # Alias for ci
    publish-dry-run                                # Dry-run crates.io publish (all crates in dependency order)
    reap-helpers MINUTES="30"                      # preview, e.g. `DRY_RUN=1 just reap-helpers` or `just reap-helpers 5`.
    release VERSION                                # Cut a specific version via a PR: just release 0.17.0
    release-auto                                   # `just release-tag <version>` to publish.
    release-build                                  # Build optimized release binary
    release-build-target TARGET                    # Cross-compile release binary for a target
    release-tag VERSION                            # which triggers the build + publish pipeline. Tags are not branch-protected.
    run *ARGS                                      # Run mvmctl with arguments
    runtime-overlay *ARGS                          # on the hot path. Pass through extra args like `--force` or `--source download`.
    runtime-overlay-build *ARGS                    # on the hot path. Kept as a compatibility alias for `just runtime-overlay`.
    security-gate-prod-agent                       # Verify production guest agent has no dev-only Exec symbols (ADR-002 §W4.3)
    setup                                          # Install libkrun (the macOS VMM mvm targets)
    setup-libkrun                                  # Install libkrun (macOS via slp/krun tap; Linux via apt/dnf/pacman)
    supply-chain                                   # Combined supply-chain gate (ADR-002 §W5.2)
    tag                                            # Create a git tag for the current workspace version
    test                                           # Run all tests
    test-cached                                    # incremental for cross-worktree cache hits. Needs `cargo install sccache`.
    test-cargo                                     # Run tests with cargo test (fallback if nextest not installed)
    test-ci                                        # Run tests with CI profile (retries, JUnit output)
    test-crate CRATE                               # Test a single crate
    test-doc                                       # this is the companion that keeps doc-fence coverage gated.
    test-fast                                      # wants to force the fast mode even after opting into real embeds elsewhere.
    test-filter FILTER                             # Run tests matching a filter expression
    toolchain-embed                                # Run once per machine (or after a toolchain pin bump).
    version                                        # Print workspace version
    watch-prs repo="tinylabscom/mvm" interval="10" # Watch open PRs for a GitHub repo

## Notes
- docs/justfile-only change
- no cargo check/test/clippy run for this PR
