### PR TITLE
fix: restore dev-env wrappers for just runtime-overlay recipes

### DIFF
--- a/.envrc.example
+++ b/.envrc.example
@@ -1,0 +1,1 @@
+source_env_if_exists ./scripts/dev-env.sh

--- a/Justfile
+++ b/Justfile
@@ -59,7 +59,7 @@ run *ARGS:
 
 # Run mvmctl with the dev env set (worktree-local MVM_DATA_DIR).
 dev *ARGS:
-    bin/dev {{ARGS}}
+    sh ./bin/dev {{ARGS}}
 
 # Run cargo with the dev env set (worktree-local MVM_DATA_DIR /
 # MVM_CACHE_DIR / CARGO_TARGET_DIR).

--- a/bin/dev
+++ b/bin/dev
@@ -1,0 +1,14 @@
+#!/usr/bin/env sh
+set -eu
+
+script_dir=$(
+    CDPATH= cd -- "$(dirname -- "$0")" >/dev/null 2>&1 && pwd
+)
+repo_root=$(
+    CDPATH= cd -- "${script_dir}/.." >/dev/null 2>&1 && pwd
+)
+
+# shellcheck source=/dev/null
+. "${repo_root}/scripts/dev-env.sh"
+
+exec cargo run --quiet -- "$@"

--- a/scripts/dev-env.sh
+++ b/scripts/dev-env.sh
@@ -1,0 +1,23 @@
+#!/usr/bin/env sh
+
+if [ -n "${BASH_SOURCE:-}" ]; then
+    dev_env_path="${BASH_SOURCE}"
+elif [ -n "${ZSH_VERSION:-}" ]; then
+    dev_env_path="${(%):-%N}"
+else
+    dev_env_path="$0"
+fi
+
+dev_env_dir=$(
+    CDPATH= cd -- "$(dirname -- "$dev_env_path")" >/dev/null 2>&1 && pwd
+)
+repo_root=$(
+    CDPATH= cd -- "${dev_env_dir}/.." >/dev/null 2>&1 && pwd
+)
+dev_state_root="${repo_root}/.mvm-test"
+
+export MVM_DATA_DIR="${MVM_DATA_DIR:-${dev_state_root}}"
+export MVM_CACHE_DIR="${MVM_CACHE_DIR:-${dev_state_root}/cache}"
+export CARGO_TARGET_DIR="${CARGO_TARGET_DIR:-${dev_state_root}/target}"
+export CARGO_HOME="${CARGO_HOME:-${dev_state_root}/cargo}"
+export MVM_NO_LEGACY_BANNER="${MVM_NO_LEGACY_BANNER:-1}"


### PR DESCRIPTION
Summary:
- restore the committed dev-env support files that the just recipes rely on
- make the just dev wrapper invoke sh ./bin/dev so the runtime-overlay commands do not depend on a pre-set executable bit
- repair the runtime-overlay convenience commands merged in #1668

Validation:
- just --dry-run runtime-overlay
- just --dry-run runtime-overlay-build

Notes:
- follow-up fix for the already-merged #1668
- no cargo check/test/clippy run for this PR
