### PR TITLE
Ship runtime overlay tarball transport

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -412,12 +412,12 @@ jobs:
   # per-image rootfs. Built per-arch from `nix/images/runtime-overlay/`.
   #
   # The host-side `RuntimeOverlayResolver`
-  # (`crates/mvm-build/src/runtime_overlay.rs`) installs these into
-  # `~/.cache/mvm/runtime-overlay/<mvmctl-version>/<arch>/` under the
-  # canonical names (`overlay.ext4`, `overlay.verity`,
-  # `overlay.roothash`, `VERSION`); the release artifact names carry
-  # the arch suffix so the combined release-asset pool doesn't
-  # collide between aarch64 and x86_64.
+  # (`crates/mvm-build/src/runtime_overlay.rs`) downloads one
+  # arch-qualified tarball plus a tarball sha256 sidecar, then
+  # installs the extracted canonical names (`overlay.ext4`,
+  # `overlay.verity`, `overlay.roothash`, `VERSION`,
+  # `checksums-sha256.txt`) into
+  # `~/.cache/mvm/runtime-overlay/<mvmctl-version>/<arch>/`.
   runtime-overlay-image:
     # Skipped on a dry-run dispatch (see builder-vm-image).
     if: ${{ github.event_name == 'push' || github.event.inputs.dry_run == 'false' }}
@@ -443,31 +443,35 @@ jobs:
           nix build "./nix/images/runtime-overlay#packages.${SYSTEM}.default" \
             --no-link --print-out-paths > /tmp/store-path.txt
           STORE_PATH=$(head -1 /tmp/store-path.txt)
-          mkdir -p staging
+          mkdir -p "staging/runtime-overlay-${ARCH}"
           # cp -L so `overlay.*` resolve through nix-store symlinks
           # into the actual blobs; the artifact uploader doesn't
           # follow symlinks.
-          cp -L "$STORE_PATH/overlay.ext4"     "staging/runtime-overlay-${ARCH}.ext4"
-          cp -L "$STORE_PATH/overlay.verity"   "staging/runtime-overlay-${ARCH}.verity"
-          cp -L "$STORE_PATH/overlay.roothash" "staging/runtime-overlay-${ARCH}.roothash"
-          cp -L "$STORE_PATH/VERSION"          "staging/runtime-overlay-${ARCH}.VERSION"
-          cd staging
-          sha256sum "runtime-overlay-${ARCH}.ext4" \
-                    "runtime-overlay-${ARCH}.verity" \
-                    "runtime-overlay-${ARCH}.roothash" \
-                    "runtime-overlay-${ARCH}.VERSION" \
-            > "runtime-overlay-${ARCH}-checksums-sha256.txt"
+          cp -L "$STORE_PATH/overlay.ext4"     "staging/runtime-overlay-${ARCH}/overlay.ext4"
+          cp -L "$STORE_PATH/overlay.verity"   "staging/runtime-overlay-${ARCH}/overlay.verity"
+          cp -L "$STORE_PATH/overlay.roothash" "staging/runtime-overlay-${ARCH}/overlay.roothash"
+          cp -L "$STORE_PATH/VERSION"          "staging/runtime-overlay-${ARCH}/VERSION"
+          (
+            cd "staging/runtime-overlay-${ARCH}"
+            sha256sum overlay.ext4 overlay.verity overlay.roothash VERSION \
+              > checksums-sha256.txt
+          )
+          tar -C "staging/runtime-overlay-${ARCH}" \
+            -czf "staging/runtime-overlay-${ARCH}.tar.gz" \
+            overlay.ext4 overlay.verity overlay.roothash VERSION checksums-sha256.txt
+          (
+            cd staging
+            sha256sum "runtime-overlay-${ARCH}.tar.gz" \
+              > "runtime-overlay-${ARCH}.tar.gz.sha256"
+          )
 
       - name: Upload runtime overlay image artifacts
         uses: actions/upload-artifact@v7
         with:
           name: runtime-overlay-image-${{ matrix.arch }}
           path: |
-            staging/runtime-overlay-${{ matrix.arch }}.ext4
-            staging/runtime-overlay-${{ matrix.arch }}.verity
-            staging/runtime-overlay-${{ matrix.arch }}.roothash
-            staging/runtime-overlay-${{ matrix.arch }}.VERSION
-            staging/runtime-overlay-${{ matrix.arch }}-checksums-sha256.txt
+            staging/runtime-overlay-${{ matrix.arch }}.tar.gz
+            staging/runtime-overlay-${{ matrix.arch }}.tar.gz.sha256
 
   # Plan 158: the bundled default microVM image `mvmctl up`/`exec` boots when
   # no --flake/--template/--image is given. Ships the PROD variant only
@@ -732,11 +736,8 @@ jobs:
             artifacts/builder-vm-*.pack-manifest.json.bundle
             artifacts/builder-vm-*.sbom.txt
             artifacts/builder-vm-*-checksums-sha256.txt
-            artifacts/runtime-overlay-*.ext4
-            artifacts/runtime-overlay-*.verity
-            artifacts/runtime-overlay-*.roothash
-            artifacts/runtime-overlay-*.VERSION
-            artifacts/runtime-overlay-*-checksums-sha256.txt
+            artifacts/runtime-overlay-*.tar.gz
+            artifacts/runtime-overlay-*.tar.gz.sha256
             artifacts/default-microvm-vmlinux-*
             artifacts/default-microvm-rootfs-*
             artifacts/default-microvm-meta-*

--- a/crates/mvm-build/src/runtime_overlay.rs
+++ b/crates/mvm-build/src/runtime_overlay.rs
@@ -166,6 +166,39 @@ pub enum RuntimeOverlayError {
     #[error("checksum manifest at {checksums_url} did not list an entry for {name}")]
     ChecksumMissing { name: String, checksums_url: String },
 
+    /// The checksum manifest lacked an entry for one of the canonical
+    /// runtime-overlay files. Always fail closed — both cached and freshly
+    /// downloaded/extracted overlays must prove per-file integrity before
+    /// attach/install.
+    #[error(
+        "runtime overlay checksum manifest at {manifest_path:?} did not \
+         list an entry for {name}"
+    )]
+    ChecksumManifestMissing {
+        manifest_path: PathBuf,
+        name: String,
+    },
+
+    /// One of the runtime-overlay files drifted from the checksum recorded in
+    /// the manifest. Refuse to attach/install the artifact.
+    #[error(
+        "runtime overlay integrity mismatch for {name}: expected sha256 \
+         {expected}, computed {actual}"
+    )]
+    ChecksumManifestMismatch {
+        name: String,
+        expected: String,
+        actual: String,
+    },
+
+    /// The downloaded runtime-overlay tarball was malformed or unsafe to
+    /// extract. Always fail closed — tar extraction is an attack surface.
+    #[error("runtime overlay archive invalid at {archive_path:?}: {reason}")]
+    InvalidArchive {
+        archive_path: PathBuf,
+        reason: String,
+    },
+
     #[cfg(feature = "pure-mkfs")]
     #[error("direct runtime overlay build failed: {reason}")]
     DirectBuildFailed { reason: String },
@@ -183,6 +216,7 @@ pub struct RuntimeOverlayLayout {
     pub sidecar: PathBuf,
     pub roothash_file: PathBuf,
     pub version_file: PathBuf,
+    pub checksum_manifest_file: PathBuf,
     pub local_source_fingerprint_file: PathBuf,
     pub local_build_epoch_file: PathBuf,
     pub arch: GuestArch,
@@ -202,6 +236,7 @@ impl RuntimeOverlayLayout {
             sidecar: artifact_dir.join("overlay.verity"),
             roothash_file: artifact_dir.join("overlay.roothash"),
             version_file: artifact_dir.join("VERSION"),
+            checksum_manifest_file: artifact_dir.join(CHECKSUM_MANIFEST_FILE),
             local_source_fingerprint_file: artifact_dir.join(LOCAL_SOURCE_FINGERPRINT_FILE),
             local_build_epoch_file: artifact_dir.join(LOCAL_BUILD_EPOCH_FILE),
             artifact_dir,
@@ -242,6 +277,7 @@ const REQUIRED_OVERLAY_GUEST_PATHS: &[&str] = &[
     "/egress-client",
     "/VERSION",
 ];
+const CHECKSUM_MANIFEST_FILE: &str = "checksums-sha256.txt";
 const LOCAL_SOURCE_FINGERPRINT_FILE: &str = "SOURCE_FINGERPRINT";
 const LOCAL_BUILD_EPOCH_FILE: &str = "BUILD_EPOCH";
 const LOCAL_BUILD_EPOCH: &str = "1";
@@ -483,6 +519,12 @@ impl RuntimeOverlayResolver {
             &self.expected_version,
             arch,
         )?;
+        check_exists(
+            &layout.checksum_manifest_file,
+            &layout.artifact_dir,
+            &self.expected_version,
+            arch,
+        )?;
 
         let version = read_version_file(&layout.version_file)?;
         if version != self.expected_version {
@@ -492,6 +534,7 @@ impl RuntimeOverlayResolver {
             });
         }
 
+        verify_cached_artifact_integrity(&layout)?;
         let roothash = read_and_validate_roothash(&layout.roothash_file)?;
         validate_overlay_payload(&layout.overlay_ext4)?;
 
@@ -685,6 +728,57 @@ fn read_and_validate_roothash(path: &Path) -> Result<String, RuntimeOverlayError
         });
     }
     Ok(trimmed.to_string())
+}
+
+fn verify_cached_artifact_integrity(
+    layout: &RuntimeOverlayLayout,
+) -> Result<(), RuntimeOverlayError> {
+    verify_manifest_checksums(
+        &layout.checksum_manifest_file,
+        [
+            ("overlay.ext4", &layout.overlay_ext4),
+            ("overlay.verity", &layout.sidecar),
+            ("overlay.roothash", &layout.roothash_file),
+            ("VERSION", &layout.version_file),
+        ],
+    )
+}
+
+fn verify_extracted_overlay_integrity(dir: &Path) -> Result<(), RuntimeOverlayError> {
+    verify_manifest_checksums(
+        &dir.join(CHECKSUM_MANIFEST_FILE),
+        [
+            ("overlay.ext4", &dir.join("overlay.ext4")),
+            ("overlay.verity", &dir.join("overlay.verity")),
+            ("overlay.roothash", &dir.join("overlay.roothash")),
+            ("VERSION", &dir.join("VERSION")),
+        ],
+    )
+}
+
+fn verify_manifest_checksums<const N: usize>(
+    manifest_path: &Path,
+    entries: [(&str, &Path); N],
+) -> Result<(), RuntimeOverlayError> {
+    let body = std::fs::read_to_string(manifest_path)?;
+    let expected = parse_checksums_manifest(&body);
+    for (name, path) in entries {
+        let Some(expected_hash) = expected.get(name) else {
+            return Err(RuntimeOverlayError::ChecksumManifestMissing {
+                manifest_path: manifest_path.to_path_buf(),
+                name: name.to_string(),
+            });
+        };
+        let actual = compute_file_sha256(path)?;
+        if actual != *expected_hash {
+            return Err(RuntimeOverlayError::ChecksumManifestMismatch {
+                name: name.to_string(),
+                expected: expected_hash.clone(),
+                actual,
+            });
+        }
+    }
+    Ok(())
 }
 
 // =================================================================
@@ -1036,6 +1130,7 @@ pub fn install_overlay_into_cache(
     install_file_with_perms(&source.sidecar, &staging.join("overlay.verity"))?;
     install_file_with_perms(&source.roothash_file, &staging.join("overlay.roothash"))?;
     install_file_with_perms(&source_version_file, &staging.join("VERSION"))?;
+    write_checksum_manifest(&staging)?;
     std::fs::write(
         staging.join(LOCAL_BUILD_EPOCH_FILE),
         format!("{LOCAL_BUILD_EPOCH}\n"),
@@ -1067,6 +1162,7 @@ fn all_required_files_present(layout: &RuntimeOverlayLayout) -> bool {
         && layout.sidecar.is_file()
         && layout.roothash_file.is_file()
         && layout.version_file.is_file()
+        && layout.checksum_manifest_file.is_file()
 }
 
 fn staging_dir_name(arch: GuestArch) -> String {
@@ -1080,6 +1176,23 @@ fn staging_dir_name(arch: GuestArch) -> String {
 fn install_file_with_perms(src: &Path, dst: &Path) -> Result<(), RuntimeOverlayError> {
     std::fs::copy(src, dst)?;
     set_cache_perms(dst)?;
+    Ok(())
+}
+
+fn write_checksum_manifest(dir: &Path) -> Result<(), RuntimeOverlayError> {
+    let entries = [
+        ("overlay.ext4", dir.join("overlay.ext4")),
+        ("overlay.verity", dir.join("overlay.verity")),
+        ("overlay.roothash", dir.join("overlay.roothash")),
+        ("VERSION", dir.join("VERSION")),
+    ];
+    let mut body = String::new();
+    for (name, path) in entries {
+        let digest = compute_file_sha256(&path)?;
+        body.push_str(&format!("{digest}  {name}\n"));
+    }
+    std::fs::write(dir.join(CHECKSUM_MANIFEST_FILE), body)?;
+    set_cache_perms(&dir.join(CHECKSUM_MANIFEST_FILE))?;
     Ok(())
 }
 
@@ -1123,11 +1236,8 @@ pub(crate) const SKIP_HASH_VERIFY_ENV: &str = "MVM_SKIP_HASH_VERIFY";
 /// download network path.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct RuntimeOverlayArtifactNames {
-    pub ext4: String,
-    pub verity: String,
-    pub roothash: String,
-    pub version: String,
-    pub checksums: String,
+    pub archive: String,
+    pub archive_checksum: String,
 }
 
 impl RuntimeOverlayArtifactNames {
@@ -1140,11 +1250,8 @@ impl RuntimeOverlayArtifactNames {
     pub fn for_arch(arch: GuestArch) -> Self {
         let a = arch.to_string();
         Self {
-            ext4: format!("runtime-overlay-{a}.ext4"),
-            verity: format!("runtime-overlay-{a}.verity"),
-            roothash: format!("runtime-overlay-{a}.roothash"),
-            version: format!("runtime-overlay-{a}.VERSION"),
-            checksums: format!("runtime-overlay-{a}-checksums-sha256.txt"),
+            archive: format!("runtime-overlay-{a}.tar.gz"),
+            archive_checksum: format!("runtime-overlay-{a}.tar.gz.sha256"),
         }
     }
 }
@@ -1160,14 +1267,15 @@ pub fn release_base_url(version: &str) -> String {
     format!("{}/v{version}", base.trim_end_matches('/'))
 }
 
-/// Download the runtime overlay for `version` + `arch` from the
-/// published GitHub Release, SHA-256-verify each artifact, and
-/// install into `cache_root` under the canonical layout
+/// Download the runtime overlay tarball for `version` + `arch` from the
+/// published GitHub Release, SHA-256-verify the archive, safely extract it,
+/// re-verify each inner artifact against the archive's embedded
+/// `checksums-sha256.txt`, and install into `cache_root` under the canonical layout
 /// `<cache_root>/runtime-overlay/<version>/<arch>/`.
 ///
 /// Mirrors the integrity pattern of `download_dev_image` /
-/// `download_builder_vm_image`: fetch the checksums file first;
-/// reject downloads whose hash isn't pre-committed there; honor
+/// `download_builder_vm_image`: fetch the archive checksum first; reject
+/// downloads whose hash isn't pre-committed there; honor
 /// `MVM_SKIP_HASH_VERIFY=1` only as a documented emergency
 /// rotation escape (never set in CI).
 ///
@@ -1180,49 +1288,31 @@ pub fn download_runtime_overlay(
 ) -> Result<RuntimeOverlayArtifact, RuntimeOverlayError> {
     let names = RuntimeOverlayArtifactNames::for_arch(arch);
     let base = release_base_url(version);
-    let checksums_url = format!("{base}/{}", names.checksums);
+    let archive_checksum_url = format!("{base}/{}", names.archive_checksum);
 
-    // Step 1: fetch the checksum manifest before touching the
-    // artifacts. The manifest is the trust anchor even before
-    // signed manifests catch up; fetching it first
-    // means a missing manifest aborts before we waste bandwidth
-    // on the (potentially large) ext4.
-    let expected = fetch_expected_hashes(
-        &checksums_url,
-        &[&names.ext4, &names.verity, &names.roothash, &names.version],
-    )?;
+    // Step 1: fetch the archive checksum sidecar before touching the tarball.
+    // The archive is the transport unit; a missing checksum aborts before we
+    // spend bandwidth on the payload.
+    let expected = fetch_expected_hashes(&archive_checksum_url, &[&names.archive])?;
 
-    // Step 2: download into a temp dir, naming files locally
-    // under their canonical names so `install_overlay_into_cache`
-    // (which expects `overlay.{ext4,verity,roothash}` + `VERSION`
-    // side-by-side) can consume the temp dir directly.
+    // Step 2: download the tarball into a temp dir, verify the tarball's
+    // checksum, then safely extract it into canonical filenames so
+    // `install_overlay_into_cache` can consume the extracted directory
+    // directly.
     let tmp = tempfile::tempdir()?;
     let stage = tmp.path();
-
-    let ext4_local = stage.join("overlay.ext4");
-    let verity_local = stage.join("overlay.verity");
-    let roothash_local = stage.join("overlay.roothash");
-    let version_local = stage.join("VERSION");
-
-    curl_download(&format!("{base}/{}", names.ext4), &ext4_local)?;
-    verify_file_sha256(&ext4_local, &names.ext4, expected.get(&names.ext4))?;
-
-    curl_download(&format!("{base}/{}", names.verity), &verity_local)?;
-    verify_file_sha256(&verity_local, &names.verity, expected.get(&names.verity))?;
-
-    curl_download(&format!("{base}/{}", names.roothash), &roothash_local)?;
-    verify_file_sha256(
-        &roothash_local,
-        &names.roothash,
-        expected.get(&names.roothash),
-    )?;
-
-    curl_download(&format!("{base}/{}", names.version), &version_local)?;
-    verify_file_sha256(&version_local, &names.version, expected.get(&names.version))?;
+    let archive_local = stage.join(&names.archive);
+    curl_download(&format!("{base}/{}", names.archive), &archive_local)?;
+    verify_file_sha256(&archive_local, &names.archive, expected.get(&names.archive))?;
+    extract_runtime_overlay_archive(&archive_local, stage)?;
+    verify_extracted_overlay_integrity(stage)?;
 
     // Step 3: read the roothash text so the returned
     // `RuntimeOverlayArtifact` carries the value the backend
     // bakes into the kernel cmdline (`mvm.runtime_roothash=…`).
+    let ext4_local = stage.join("overlay.ext4");
+    let verity_local = stage.join("overlay.verity");
+    let roothash_local = stage.join("overlay.roothash");
     let roothash = parse_roothash_text(&roothash_local)?;
 
     // Step 4: hand off to the existing atomic installer. It
@@ -1243,6 +1333,93 @@ pub fn download_runtime_overlay(
         cache_root,
         &InstallOptions { overwrite: true },
     )
+}
+
+fn extract_runtime_overlay_archive(
+    archive_path: &Path,
+    stage: &Path,
+) -> Result<(), RuntimeOverlayError> {
+    let file = std::fs::File::open(archive_path)?;
+    let decoder = flate2::read::GzDecoder::new(file);
+    let mut archive = tar::Archive::new(decoder);
+    let mut seen = std::collections::BTreeSet::new();
+
+    for entry in archive
+        .entries()
+        .map_err(|e| RuntimeOverlayError::InvalidArchive {
+            archive_path: archive_path.to_path_buf(),
+            reason: format!("read tar entries: {e}"),
+        })?
+    {
+        let mut entry = entry.map_err(|e| RuntimeOverlayError::InvalidArchive {
+            archive_path: archive_path.to_path_buf(),
+            reason: format!("read tar entry: {e}"),
+        })?;
+        let path = entry
+            .path()
+            .map_err(|e| RuntimeOverlayError::InvalidArchive {
+                archive_path: archive_path.to_path_buf(),
+                reason: format!("read tar path: {e}"),
+            })?
+            .into_owned();
+        let Some(name) = canonical_archive_member_name(&path) else {
+            return Err(RuntimeOverlayError::InvalidArchive {
+                archive_path: archive_path.to_path_buf(),
+                reason: format!("unsafe or unexpected path {:?}", path.display()),
+            });
+        };
+        match entry.header().entry_type() {
+            tar::EntryType::Regular => {
+                let dest = stage.join(name);
+                let mut out = std::fs::File::create(&dest)?;
+                std::io::copy(&mut entry, &mut out)?;
+                set_cache_perms(&dest)?;
+                seen.insert(name.to_string());
+            }
+            tar::EntryType::Directory => {}
+            other => {
+                return Err(RuntimeOverlayError::InvalidArchive {
+                    archive_path: archive_path.to_path_buf(),
+                    reason: format!(
+                        "unsupported tar entry type {other:?} for {:?}",
+                        path.display()
+                    ),
+                });
+            }
+        }
+    }
+
+    for required in [
+        "overlay.ext4",
+        "overlay.verity",
+        "overlay.roothash",
+        "VERSION",
+        CHECKSUM_MANIFEST_FILE,
+    ] {
+        if !seen.contains(required) && !stage.join(required).is_file() {
+            return Err(RuntimeOverlayError::InvalidArchive {
+                archive_path: archive_path.to_path_buf(),
+                reason: format!("missing required archive member {required}"),
+            });
+        }
+    }
+    Ok(())
+}
+
+fn canonical_archive_member_name(path: &Path) -> Option<&'static str> {
+    let mut components = path.components();
+    let component = match (components.next(), components.next()) {
+        (Some(std::path::Component::Normal(name)), None) => name,
+        _ => return None,
+    };
+    match component.to_str()? {
+        "overlay.ext4" => Some("overlay.ext4"),
+        "overlay.verity" => Some("overlay.verity"),
+        "overlay.roothash" => Some("overlay.roothash"),
+        "VERSION" => Some("VERSION"),
+        CHECKSUM_MANIFEST_FILE => Some(CHECKSUM_MANIFEST_FILE),
+        _ => None,
+    }
 }
 
 /// HTTP GET the per-release `sha256sum`-format checksums file and
@@ -1420,6 +1597,17 @@ mod tests {
         for (name, contents) in with_files {
             std::fs::write(artifact_dir.join(name), contents).unwrap();
         }
+        let have_all_canonical_files = [
+            "overlay.ext4",
+            "overlay.verity",
+            "overlay.roothash",
+            "VERSION",
+        ]
+        .iter()
+        .all(|name| artifact_dir.join(name).is_file());
+        if have_all_canonical_files {
+            write_checksum_manifest(&artifact_dir).unwrap();
+        }
         tmp
     }
 
@@ -1524,6 +1712,10 @@ mod tests {
             layout.version_file,
             PathBuf::from("/cache/runtime-overlay/0.14.0/aarch64/VERSION")
         );
+        assert_eq!(
+            layout.checksum_manifest_file,
+            PathBuf::from("/cache/runtime-overlay/0.14.0/aarch64/checksums-sha256.txt")
+        );
         assert_eq!(layout.arch, GuestArch::Aarch64);
         assert_eq!(layout.version, "0.14.0");
     }
@@ -1558,6 +1750,38 @@ mod tests {
         match err {
             RuntimeOverlayError::ArtifactIncomplete { missing, .. } => {
                 assert!(missing.ends_with("overlay.ext4"), "missing={missing:?}");
+            }
+            other => panic!("expected ArtifactIncomplete, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn resolve_fails_when_checksum_manifest_missing() {
+        let cache = make_cache(
+            "0.14.0",
+            GuestArch::Aarch64,
+            &[
+                ("overlay.ext4", &valid_overlay_ext4_bytes(true)),
+                ("overlay.verity", b"sidecar"),
+                ("overlay.roothash", format!("{FAKE_ROOTHASH}\n").as_bytes()),
+                ("VERSION", b"0.14.0\n"),
+            ],
+        );
+        std::fs::remove_file(
+            cache
+                .path()
+                .join("runtime-overlay/0.14.0/aarch64")
+                .join(CHECKSUM_MANIFEST_FILE),
+        )
+        .unwrap();
+        let resolver = RuntimeOverlayResolver::new(cache.path().to_path_buf(), "0.14.0".into());
+        let err = resolver.resolve(GuestArch::Aarch64).unwrap_err();
+        match err {
+            RuntimeOverlayError::ArtifactIncomplete { missing, .. } => {
+                assert!(
+                    missing.ends_with(CHECKSUM_MANIFEST_FILE),
+                    "missing={missing:?}"
+                );
             }
             other => panic!("expected ArtifactIncomplete, got {other:?}"),
         }
@@ -1748,6 +1972,55 @@ mod tests {
                 assert_eq!(missing_path, "/egress-client");
             }
             other => panic!("expected PayloadIncomplete, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn resolve_rejects_cache_when_overlay_bytes_drift_from_checksum_manifest() {
+        let (_keep, source) = make_source_artifact("0.14.0", GuestArch::Aarch64, FAKE_ROOTHASH);
+        let cache = TempDir::new().unwrap();
+        let installed =
+            install_overlay_into_cache(&source, cache.path(), &InstallOptions::default())
+                .expect("install");
+        std::fs::write(&installed.overlay_ext4, b"tampered-overlay-bytes").unwrap();
+
+        let resolver = RuntimeOverlayResolver::new(cache.path().to_path_buf(), "0.14.0".into());
+        let err = resolver.resolve(GuestArch::Aarch64).unwrap_err();
+        match err {
+            RuntimeOverlayError::ChecksumManifestMismatch { name, .. } => {
+                assert_eq!(name, "overlay.ext4");
+            }
+            other => panic!("expected ChecksumManifestMismatch, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn resolve_rejects_cache_when_checksum_manifest_entry_missing() {
+        let (_keep, source) = make_source_artifact("0.14.0", GuestArch::Aarch64, FAKE_ROOTHASH);
+        let cache = TempDir::new().unwrap();
+        let installed =
+            install_overlay_into_cache(&source, cache.path(), &InstallOptions::default())
+                .expect("install");
+        let manifest_path = installed
+            .overlay_ext4
+            .parent()
+            .expect("artifact dir")
+            .join(CHECKSUM_MANIFEST_FILE);
+        let ext4_hash = compute_file_sha256(&installed.overlay_ext4).unwrap();
+        let sidecar_hash = compute_file_sha256(&installed.sidecar).unwrap();
+        std::fs::write(
+            &manifest_path,
+            format!("{ext4_hash}  overlay.ext4\n{sidecar_hash}  overlay.verity\n"),
+        )
+        .unwrap();
+
+        let resolver = RuntimeOverlayResolver::new(cache.path().to_path_buf(), "0.14.0".into());
+        let err = resolver.resolve(GuestArch::Aarch64).unwrap_err();
+        match err {
+            RuntimeOverlayError::ChecksumManifestMissing { name, .. } => {
+                assert_eq!(name, "overlay.roothash");
+            }
+            other => panic!("expected ChecksumManifestMissing, got {other:?}"),
         }
     }
 
@@ -1980,6 +2253,11 @@ mod tests {
         let build_epoch =
             std::fs::read_to_string(expected_dir.join(LOCAL_BUILD_EPOCH_FILE)).unwrap();
         assert_eq!(build_epoch.trim(), LOCAL_BUILD_EPOCH);
+        let checksums = std::fs::read_to_string(expected_dir.join(CHECKSUM_MANIFEST_FILE)).unwrap();
+        assert!(checksums.contains("overlay.ext4"));
+        assert!(checksums.contains("overlay.verity"));
+        assert!(checksums.contains("overlay.roothash"));
+        assert!(checksums.contains("VERSION"));
     }
 
     #[test]
@@ -2235,6 +2513,11 @@ mod tests {
             &installed.overlay_ext4,
             &installed.sidecar,
             &installed.roothash_file,
+            &installed
+                .overlay_ext4
+                .parent()
+                .expect("artifact dir")
+                .join(CHECKSUM_MANIFEST_FILE),
         ] {
             let mode = std::fs::metadata(p).unwrap().permissions().mode() & 0o777;
             assert_eq!(mode, 0o644, "cache file {p:?} must be 0644 (got {mode:o})");
@@ -2282,26 +2565,20 @@ mod tests {
     #[test]
     fn artifact_names_match_release_yml_naming_aarch64() {
         let names = RuntimeOverlayArtifactNames::for_arch(GuestArch::Aarch64);
-        assert_eq!(names.ext4, "runtime-overlay-aarch64.ext4");
-        assert_eq!(names.verity, "runtime-overlay-aarch64.verity");
-        assert_eq!(names.roothash, "runtime-overlay-aarch64.roothash");
-        assert_eq!(names.version, "runtime-overlay-aarch64.VERSION");
+        assert_eq!(names.archive, "runtime-overlay-aarch64.tar.gz");
         assert_eq!(
-            names.checksums,
-            "runtime-overlay-aarch64-checksums-sha256.txt"
+            names.archive_checksum,
+            "runtime-overlay-aarch64.tar.gz.sha256"
         );
     }
 
     #[test]
     fn artifact_names_match_release_yml_naming_x86_64() {
         let names = RuntimeOverlayArtifactNames::for_arch(GuestArch::X86_64);
-        assert_eq!(names.ext4, "runtime-overlay-x86_64.ext4");
-        assert_eq!(names.verity, "runtime-overlay-x86_64.verity");
-        assert_eq!(names.roothash, "runtime-overlay-x86_64.roothash");
-        assert_eq!(names.version, "runtime-overlay-x86_64.VERSION");
+        assert_eq!(names.archive, "runtime-overlay-x86_64.tar.gz");
         assert_eq!(
-            names.checksums,
-            "runtime-overlay-x86_64-checksums-sha256.txt"
+            names.archive_checksum,
+            "runtime-overlay-x86_64.tar.gz.sha256"
         );
     }
 
@@ -2341,16 +2618,16 @@ mod tests {
     #[test]
     fn parse_checksums_manifest_accepts_sha256sum_canonical() {
         let body = "\
-0000000000000000000000000000000000000000000000000000000000000001  runtime-overlay-aarch64.ext4
-0000000000000000000000000000000000000000000000000000000000000002  runtime-overlay-aarch64.verity
+0000000000000000000000000000000000000000000000000000000000000001  runtime-overlay-aarch64.tar.gz
+0000000000000000000000000000000000000000000000000000000000000002  runtime-overlay-aarch64.tar.gz.sha256
 ";
         let map = parse_checksums_manifest(body);
         assert_eq!(
-            map.get("runtime-overlay-aarch64.ext4").unwrap(),
+            map.get("runtime-overlay-aarch64.tar.gz").unwrap(),
             "0000000000000000000000000000000000000000000000000000000000000001"
         );
         assert_eq!(
-            map.get("runtime-overlay-aarch64.verity").unwrap(),
+            map.get("runtime-overlay-aarch64.tar.gz.sha256").unwrap(),
             "0000000000000000000000000000000000000000000000000000000000000002"
         );
     }
@@ -2359,10 +2636,10 @@ mod tests {
     fn parse_checksums_manifest_strips_binary_mode_star() {
         // `sha256sum -b` emits `<hash> *<file>` for binary mode.
         // Both modes must parse identically.
-        let body = "0000000000000000000000000000000000000000000000000000000000000003 *runtime-overlay-x86_64.ext4";
+        let body = "0000000000000000000000000000000000000000000000000000000000000003 *runtime-overlay-x86_64.tar.gz";
         let map = parse_checksums_manifest(body);
         assert_eq!(
-            map.get("runtime-overlay-x86_64.ext4").unwrap(),
+            map.get("runtime-overlay-x86_64.tar.gz").unwrap(),
             "0000000000000000000000000000000000000000000000000000000000000003"
         );
     }
@@ -2422,13 +2699,13 @@ short  bar.ext4
     }
 
     /// End-to-end download flow against a `file://` fixture: stage
-    /// the four artifacts + a checksums file on disk under names
-    /// matching the release-pipeline layout, point
+    /// a tarball + archive checksum sidecar under names matching the
+    /// release-pipeline layout, point
     /// `MVM_OVERLAY_BASE_URL` at the fixture dir, and assert the
     /// installer materializes everything correctly into the cache.
     /// Exercises every code path except the actual GitHub network
-    /// hop — same wire format, same checksums verification, same
-    /// atomic install.
+    /// hop — same wire format, same archive verification, same
+    /// inner-manifest verification, same atomic install.
     ///
     /// `file://` URLs work with curl (`-fSL`) the same way HTTP
     /// URLs do, so the test exercises the exact code path
@@ -2444,38 +2721,30 @@ short  bar.ext4
         std::fs::create_dir_all(&release_dir).unwrap();
 
         // Fixture bytes — the actual contents don't matter for the
-        // download path, only their sha256.
+        // download path, only their checksums.
         let ext4_bytes = b"fake-ext4-bytes";
         let verity_bytes = b"fake-verity-sidecar";
         let roothash_text = "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef\n";
         let version_text = "9.9.9\n";
-        write_fixture(&release_dir, "runtime-overlay-aarch64.ext4", ext4_bytes);
-        write_fixture(&release_dir, "runtime-overlay-aarch64.verity", verity_bytes);
-        write_fixture(
-            &release_dir,
-            "runtime-overlay-aarch64.roothash",
+        let archive_bytes = runtime_overlay_archive_bytes(
+            ext4_bytes,
+            verity_bytes,
             roothash_text.as_bytes(),
-        );
-        write_fixture(
-            &release_dir,
-            "runtime-overlay-aarch64.VERSION",
             version_text.as_bytes(),
         );
-
-        let checksums = format!(
-            "{}  runtime-overlay-aarch64.ext4\n\
-             {}  runtime-overlay-aarch64.verity\n\
-             {}  runtime-overlay-aarch64.roothash\n\
-             {}  runtime-overlay-aarch64.VERSION\n",
-            sha256_hex(ext4_bytes),
-            sha256_hex(verity_bytes),
-            sha256_hex(roothash_text.as_bytes()),
-            sha256_hex(version_text.as_bytes()),
+        write_fixture(
+            &release_dir,
+            "runtime-overlay-aarch64.tar.gz",
+            &archive_bytes,
         );
         write_fixture(
             &release_dir,
-            "runtime-overlay-aarch64-checksums-sha256.txt",
-            checksums.as_bytes(),
+            "runtime-overlay-aarch64.tar.gz.sha256",
+            format!(
+                "{}  runtime-overlay-aarch64.tar.gz\n",
+                sha256_hex(&archive_bytes)
+            )
+            .as_bytes(),
         );
 
         let base_url = format!("file://{}", upstream.path().display());
@@ -2519,32 +2788,31 @@ short  bar.ext4
         let release_dir = upstream.path().join("v9.9.9");
         std::fs::create_dir_all(&release_dir).unwrap();
 
-        let real_bytes = b"the-real-ext4-bytes";
-        let tampered_bytes = b"tampered!";
-        // Manifest commits to `real_bytes`'s hash but the served
-        // ext4 file is the tampered version.
-        write_fixture(&release_dir, "runtime-overlay-aarch64.ext4", tampered_bytes);
-        write_fixture(&release_dir, "runtime-overlay-aarch64.verity", b"v");
-        write_fixture(
-            &release_dir,
-            "runtime-overlay-aarch64.roothash",
+        let expected_archive_bytes = runtime_overlay_archive_bytes(
+            b"the-real-ext4-bytes",
+            b"v",
             b"0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef\n",
+            b"9.9.9\n",
         );
-        write_fixture(&release_dir, "runtime-overlay-aarch64.VERSION", b"9.9.9\n");
-        let checksums = format!(
-            "{}  runtime-overlay-aarch64.ext4\n\
-             {}  runtime-overlay-aarch64.verity\n\
-             {}  runtime-overlay-aarch64.roothash\n\
-             {}  runtime-overlay-aarch64.VERSION\n",
-            sha256_hex(real_bytes),
-            sha256_hex(b"v"),
-            sha256_hex(b"0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef\n"),
-            sha256_hex(b"9.9.9\n"),
+        let tampered_archive_bytes = runtime_overlay_archive_bytes(
+            b"tampered!",
+            b"v",
+            b"0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef\n",
+            b"9.9.9\n",
         );
         write_fixture(
             &release_dir,
-            "runtime-overlay-aarch64-checksums-sha256.txt",
-            checksums.as_bytes(),
+            "runtime-overlay-aarch64.tar.gz",
+            &tampered_archive_bytes,
+        );
+        write_fixture(
+            &release_dir,
+            "runtime-overlay-aarch64.tar.gz.sha256",
+            format!(
+                "{}  runtime-overlay-aarch64.tar.gz\n",
+                sha256_hex(&expected_archive_bytes)
+            )
+            .as_bytes(),
         );
 
         let base_url = format!("file://{}", upstream.path().display());
@@ -2556,7 +2824,7 @@ short  bar.ext4
         let err = result.expect_err("tampered ext4 must reject");
         match err {
             RuntimeOverlayError::ChecksumMismatch { name, .. } => {
-                assert_eq!(name, "runtime-overlay-aarch64.ext4");
+                assert_eq!(name, "runtime-overlay-aarch64.tar.gz");
             }
             other => panic!("expected ChecksumMismatch, got {other:?}"),
         }
@@ -2564,8 +2832,8 @@ short  bar.ext4
         assert!(!cache.path().join("runtime-overlay/9.9.9/aarch64").exists());
     }
 
-    /// A checksums manifest missing one of the wanted entries
-    /// aborts before any artifact is fetched.
+    /// An archive checksum sidecar missing the tarball entry aborts before the
+    /// archive is fetched.
     #[test]
     fn download_runtime_overlay_rejects_missing_checksum_entry() {
         let mut env = TestEnv::new();
@@ -2573,15 +2841,13 @@ short  bar.ext4
         let upstream = TempDir::new().unwrap();
         let release_dir = upstream.path().join("v9.9.9");
         std::fs::create_dir_all(&release_dir).unwrap();
-        // Manifest only lists three of four required entries.
+        // Sidecar lists the wrong name, not the archive we need.
         let checksums = "\
-0000000000000000000000000000000000000000000000000000000000000001  runtime-overlay-aarch64.ext4
-0000000000000000000000000000000000000000000000000000000000000002  runtime-overlay-aarch64.verity
-0000000000000000000000000000000000000000000000000000000000000003  runtime-overlay-aarch64.roothash
+0000000000000000000000000000000000000000000000000000000000000001  runtime-overlay-aarch64-not-it.tar.gz
 ";
         write_fixture(
             &release_dir,
-            "runtime-overlay-aarch64-checksums-sha256.txt",
+            "runtime-overlay-aarch64.tar.gz.sha256",
             checksums.as_bytes(),
         );
 
@@ -2591,13 +2857,45 @@ short  bar.ext4
         let result = download_runtime_overlay("9.9.9", GuestArch::Aarch64, cache.path());
         env.remove("MVM_OVERLAY_BASE_URL");
 
-        let err = result.expect_err("missing VERSION entry must reject");
+        let err = result.expect_err("missing archive checksum entry must reject");
         match err {
             RuntimeOverlayError::ChecksumMissing { name, .. } => {
-                assert_eq!(name, "runtime-overlay-aarch64.VERSION");
+                assert_eq!(name, "runtime-overlay-aarch64.tar.gz");
             }
             other => panic!("expected ChecksumMissing, got {other:?}"),
         }
+    }
+
+    fn runtime_overlay_archive_bytes(
+        ext4_bytes: &[u8],
+        verity_bytes: &[u8],
+        roothash_bytes: &[u8],
+        version_bytes: &[u8],
+    ) -> Vec<u8> {
+        let checksums = format!(
+            "{}  overlay.ext4\n{}  overlay.verity\n{}  overlay.roothash\n{}  VERSION\n",
+            sha256_hex(ext4_bytes),
+            sha256_hex(verity_bytes),
+            sha256_hex(roothash_bytes),
+            sha256_hex(version_bytes),
+        );
+        let encoder = flate2::write::GzEncoder::new(Vec::new(), flate2::Compression::default());
+        let mut tar = tar::Builder::new(encoder);
+        append_archive_file(&mut tar, "overlay.ext4", ext4_bytes);
+        append_archive_file(&mut tar, "overlay.verity", verity_bytes);
+        append_archive_file(&mut tar, "overlay.roothash", roothash_bytes);
+        append_archive_file(&mut tar, "VERSION", version_bytes);
+        append_archive_file(&mut tar, CHECKSUM_MANIFEST_FILE, checksums.as_bytes());
+        let encoder = tar.into_inner().unwrap();
+        encoder.finish().unwrap()
+    }
+
+    fn append_archive_file<W: std::io::Write>(tar: &mut tar::Builder<W>, path: &str, bytes: &[u8]) {
+        let mut header = tar::Header::new_gnu();
+        header.set_mode(0o644);
+        header.set_size(u64::try_from(bytes.len()).unwrap());
+        header.set_cksum();
+        tar.append_data(&mut header, path, bytes).unwrap();
     }
 
     fn write_fixture(dir: &Path, name: &str, bytes: &[u8]) {

--- a/crates/mvm-cli/src/commands/vm/up.rs
+++ b/crates/mvm-cli/src/commands/vm/up.rs
@@ -1855,14 +1855,25 @@ mod runtime_overlay_attach_tests {
         let layout =
             RuntimeOverlayResolver::new(cache.to_path_buf(), version.to_string()).layout(arch);
         std::fs::create_dir_all(&layout.artifact_dir).unwrap();
+        let overlay_ext4 = valid_overlay_ext4_bytes(version, true);
+        let sidecar = b"verity-bytes";
+        let roothash = format!("{}\n", "a".repeat(64));
+        let version_text = format!("{version}\n");
+        std::fs::write(&layout.overlay_ext4, &overlay_ext4).unwrap();
+        std::fs::write(&layout.sidecar, sidecar).unwrap();
+        std::fs::write(&layout.roothash_file, &roothash).unwrap();
+        std::fs::write(&layout.version_file, &version_text).unwrap();
         std::fs::write(
-            &layout.overlay_ext4,
-            valid_overlay_ext4_bytes(version, true),
+            &layout.checksum_manifest_file,
+            format!(
+                "{}  overlay.ext4\n{}  overlay.verity\n{}  overlay.roothash\n{}  VERSION\n",
+                sha256_hex(&overlay_ext4),
+                sha256_hex(sidecar),
+                sha256_hex(roothash.as_bytes()),
+                sha256_hex(version_text.as_bytes()),
+            ),
         )
         .unwrap();
-        std::fs::write(&layout.sidecar, b"verity-bytes").unwrap();
-        std::fs::write(&layout.roothash_file, format!("{}\n", "a".repeat(64))).unwrap();
-        std::fs::write(&layout.version_file, format!("{version}\n")).unwrap();
         if let Some(workspace_root) =
             crate::commands::runtime_overlay::runtime_overlay_source_checkout_root()
         {
@@ -1888,6 +1899,38 @@ mod runtime_overlay_attach_tests {
         std::fs::write(dir.join(name), bytes).unwrap();
     }
 
+    fn runtime_overlay_archive_bytes(
+        ext4_bytes: &[u8],
+        verity_bytes: &[u8],
+        roothash_bytes: &[u8],
+        version_bytes: &[u8],
+    ) -> Vec<u8> {
+        let checksums = format!(
+            "{}  overlay.ext4\n{}  overlay.verity\n{}  overlay.roothash\n{}  VERSION\n",
+            sha256_hex(ext4_bytes),
+            sha256_hex(verity_bytes),
+            sha256_hex(roothash_bytes),
+            sha256_hex(version_bytes),
+        );
+        let encoder = flate2::write::GzEncoder::new(Vec::new(), flate2::Compression::default());
+        let mut tar = tar::Builder::new(encoder);
+        append_archive_file(&mut tar, "overlay.ext4", ext4_bytes);
+        append_archive_file(&mut tar, "overlay.verity", verity_bytes);
+        append_archive_file(&mut tar, "overlay.roothash", roothash_bytes);
+        append_archive_file(&mut tar, "VERSION", version_bytes);
+        append_archive_file(&mut tar, "checksums-sha256.txt", checksums.as_bytes());
+        let encoder = tar.into_inner().unwrap();
+        encoder.finish().unwrap()
+    }
+
+    fn append_archive_file<W: std::io::Write>(tar: &mut tar::Builder<W>, path: &str, bytes: &[u8]) {
+        let mut header = tar::Header::new_gnu();
+        header.set_mode(0o644);
+        header.set_size(u64::try_from(bytes.len()).unwrap());
+        header.set_cksum();
+        tar.append_data(&mut header, path, bytes).unwrap();
+    }
+
     fn seed_release_fixture(base: &std::path::Path, version: &str, arch: GuestArch) {
         let names = mvm_build::runtime_overlay::RuntimeOverlayArtifactNames::for_arch(arch);
         let release_dir = base.join(format!("v{version}"));
@@ -1897,24 +1940,18 @@ mod runtime_overlay_attach_tests {
         let verity_bytes = b"downloaded-verity";
         let roothash_text = b"0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef\n";
         let version_text = format!("{version}\n");
-
-        write_fixture(&release_dir, &names.ext4, ext4_bytes);
-        write_fixture(&release_dir, &names.verity, verity_bytes);
-        write_fixture(&release_dir, &names.roothash, roothash_text);
-        write_fixture(&release_dir, &names.version, version_text.as_bytes());
-
-        let checksums = format!(
-            "{}  {}\n{}  {}\n{}  {}\n{}  {}\n",
-            sha256_hex(ext4_bytes),
-            names.ext4,
-            sha256_hex(verity_bytes),
-            names.verity,
-            sha256_hex(roothash_text),
-            names.roothash,
-            sha256_hex(version_text.as_bytes()),
-            names.version
+        let archive_bytes = runtime_overlay_archive_bytes(
+            ext4_bytes,
+            verity_bytes,
+            roothash_text,
+            version_text.as_bytes(),
         );
-        write_fixture(&release_dir, &names.checksums, checksums.as_bytes());
+        write_fixture(&release_dir, &names.archive, &archive_bytes);
+        write_fixture(
+            &release_dir,
+            &names.archive_checksum,
+            format!("{}  {}\n", sha256_hex(&archive_bytes), names.archive).as_bytes(),
+        );
     }
 
     #[test]

--- a/public/src/content/docs/guides/verify-release.md
+++ b/public/src/content/docs/guides/verify-release.md
@@ -106,18 +106,19 @@ the same release. To verify it manually:
 VERSION=v0.18.0
 ARCH=aarch64   # or x86_64
 
-curl -LO "https://github.com/tinylabscom/mvm/releases/download/${VERSION}/runtime-overlay-${ARCH}.ext4"
-curl -LO "https://github.com/tinylabscom/mvm/releases/download/${VERSION}/runtime-overlay-${ARCH}.verity"
-curl -LO "https://github.com/tinylabscom/mvm/releases/download/${VERSION}/runtime-overlay-${ARCH}.roothash"
-curl -LO "https://github.com/tinylabscom/mvm/releases/download/${VERSION}/runtime-overlay-${ARCH}.VERSION"
-curl -LO "https://github.com/tinylabscom/mvm/releases/download/${VERSION}/runtime-overlay-${ARCH}-checksums-sha256.txt"
+curl -LO "https://github.com/tinylabscom/mvm/releases/download/${VERSION}/runtime-overlay-${ARCH}.tar.gz"
+curl -LO "https://github.com/tinylabscom/mvm/releases/download/${VERSION}/runtime-overlay-${ARCH}.tar.gz.sha256"
 
-grep "runtime-overlay-${ARCH}" "runtime-overlay-${ARCH}-checksums-sha256.txt" | sha256sum --check
+shasum -a 256 --check "runtime-overlay-${ARCH}.tar.gz.sha256"
+tar xzf "runtime-overlay-${ARCH}.tar.gz"
+sha256sum --check checksums-sha256.txt
 ```
 
-When `mvmctl build runtime-overlay build --source download` installs these
-assets into `~/.cache/mvm/runtime-overlay/<version>/<arch>/`, it expects the
-same version-matched set.
+When `mvmctl build runtime-overlay build --source download` installs this
+payload into `~/.cache/mvm/runtime-overlay/<version>/<arch>/`, it first
+verifies the tarball, then verifies the extracted inner files against the
+embedded `checksums-sha256.txt`, and later required-overlay boots recheck those
+cached file hashes before attach. A drifted cache entry is refused.
 
 ## Runtime overlay update model
 

--- a/public/src/content/docs/reference/filesystem.md
+++ b/public/src/content/docs/reference/filesystem.md
@@ -44,6 +44,9 @@ overlay** that is mounted inside the guest at `/mvm/runtime`.
 - The overlay is mounted read-only in the guest. A backend that cannot provide
   that read-only contract must stay on the fallback policy instead of using
   `RequiredOverlay`.
+- Before attach, mvm re-verifies the cached `overlay.ext4`, `overlay.verity`,
+  `overlay.roothash`, and `VERSION` files against the recorded
+  `checksums-sha256.txt` manifest and refuses the boot on any mismatch.
 - The artifact is shared across microVMs from the local cache under
   `~/.cache/mvm/runtime-overlay/<version>/<arch>/`.
 
@@ -157,5 +160,6 @@ On the host (on Linux) or inside the builder VM (on macOS), mvm stores data at:
 
 The shared guest-runtime overlay cache lives separately under
 `~/.cache/mvm/runtime-overlay/<version>/<arch>/` and contains the sealed
-`overlay.ext4`, `overlay.verity`, and version metadata reused by every VM that
-boots that runtime version.
+`overlay.ext4`, `overlay.verity`, `overlay.roothash`, `VERSION`, and
+`checksums-sha256.txt` metadata reused by every VM that boots that runtime
+version.

--- a/public/src/content/docs/reference/releases.md
+++ b/public/src/content/docs/reference/releases.md
@@ -26,23 +26,27 @@ GitHub Release:
 | `cargo install mvmctl` | source from crates.io (CLI binary only; no adjacent helper bundle) |
 | `mvmctl update` | the tarball for the latest release, in-place swap |
 | `mvmctl kernel build --source download` | `vmlinux-<arch>-<variant>` + `kernel-<arch>-checksums-sha256.txt`, pinned to the binary's own release tag |
-| `mvmctl build runtime-overlay build --source download` | `runtime-overlay-<arch>.{ext4,verity,roothash,VERSION}` + `runtime-overlay-<arch>-checksums-sha256.txt`, installed into `~/.cache/mvm/runtime-overlay/<version>/<arch>/` |
+| `mvmctl build runtime-overlay build --source download` | `runtime-overlay-<arch>.tar.gz` + `runtime-overlay-<arch>.tar.gz.sha256`; the tarball contains `overlay.ext4`, `overlay.verity`, `overlay.roothash`, `VERSION`, and `checksums-sha256.txt`, installed into `~/.cache/mvm/runtime-overlay/<version>/<arch>/` |
 
 ## Runtime overlay release assets
 
 Every release publishes the shared guest-runtime overlay alongside the CLI
 tarballs and the default images:
 
-- `runtime-overlay-<arch>.ext4`
-- `runtime-overlay-<arch>.verity`
-- `runtime-overlay-<arch>.roothash`
-- `runtime-overlay-<arch>.VERSION`
-- `runtime-overlay-<arch>-checksums-sha256.txt`
+- `runtime-overlay-<arch>.tar.gz`
+- `runtime-overlay-<arch>.tar.gz.sha256`
 
 Those assets are the readonly, version-matched guest-runtime payload consumed by
 overlay-backed boots. They are not an optional side channel or a developer-only
 cache convenience; they are part of the shipped release surface for the
 backends that admit `RequiredOverlay`.
+
+The tarball itself is hash-verified before extraction. Inside it, the canonical
+payload is still per-file checked: `overlay.ext4`, `overlay.verity`,
+`overlay.roothash`, `VERSION`, and an inner `checksums-sha256.txt`. When
+`mvmctl` installs that payload into `~/.cache/mvm/runtime-overlay/<version>/<arch>/`,
+every required-overlay boot re-hashes those cached files before attach and
+refuses to mount the overlay if the cache entry has drifted.
 
 Only **guest-executed** runtime binaries belong in this artifact. Host-side
 helpers and supervisors still ship in the `mvmctl-<target>.tar.gz` bundle next
@@ -53,7 +57,8 @@ to `mvmctl`.
 Operationally, runtime-overlay updates are a **release + restart** story:
 
 - A fresh boot on an admitted backend resolves the runtime overlay for the
-  running `mvmctl` version and mounts it read-only inside the guest.
+  running `mvmctl` version, re-verifies the cached artifact checksums, and
+  mounts it read-only inside the guest.
 - A stopped VM picks up the newer version-matched overlay on its next
   `machine start` or `machine restart`.
 - A running VM keeps the overlay version it already booted with until restart.

--- a/specs/REFACTOR-STATUS.md
+++ b/specs/REFACTOR-STATUS.md
@@ -6,7 +6,9 @@ centralized into the shared read-only cache artifact under
 either mounts that artifact read-only with real proof or refuses the
 unsupported path fail-closed; stopped VMs pick up newer version-matched
 overlays on restart, while running VMs keep the runtime they booted with. The
-current closeout slice also fixes the exact-current candidate witnesses by
+cache now carries a recorded `checksums-sha256.txt`, and required-overlay
+boots re-verify those cached bytes before attach. The current closeout slice
+also fixes the exact-current candidate witnesses by
 aligning the SDK/fixture receipt posture tests with the current vsock-only
 libkrun contract and isolating the `mvm-build` library tests from shared
 env/cache races. Fresh host gates are green on the current candidate, and the

--- a/specs/SPRINT.md
+++ b/specs/SPRINT.md
@@ -208,9 +208,11 @@ plan 25 sequences the work into six independently-shippable workstreams.
 > the shared read-only cache artifact under
 > `~/.cache/mvm/runtime-overlay/<version>/<arch>/`; host-executed binaries stay
 > outside it. Every admitted backend/tier either mounts that artifact read-only
-> with real proof or refuses the unsupported path fail-closed. Stopped VMs pick
-> up updated version-matched overlays on restart; running VMs keep the runtime
-> they booted with. The current candidate has green host
+> with real proof or refuses the unsupported path fail-closed. The cache now
+> carries a per-artifact `checksums-sha256.txt`, and required-overlay boots
+> re-verify that manifest before attach so drifted cache bytes cannot be
+> mounted. Stopped VMs pick up updated version-matched overlays on restart;
+> running VMs keep the runtime they booted with. The current candidate has green host
 > `cargo check --workspace --offline`, `cargo clippy --workspace --all-targets
 > --offline -- -D warnings`, and `cargo test --workspace --offline` gates, and
 > the Linux/KVM `cargo test -p mvm-build --lib --offline` witness has been

--- a/specs/adrs/051-mvm-runtime-overlay-disk.md
+++ b/specs/adrs/051-mvm-runtime-overlay-disk.md
@@ -59,6 +59,16 @@ read-only at `/mvm/runtime` inside the guest. Service launches
 inject the language-specific path env vars (`PYTHONPATH`,
 `NODE_PATH`, …) before forking the workload.
 
+**The host does not attach an unchecked cache entry.** Before any
+backend threads the overlay paths into a boot config, mvm
+re-hashes the cached `overlay.ext4`, `overlay.verity`,
+`overlay.roothash`, and `VERSION` files and compares them to the
+recorded SHA-256 manifest stored beside the artifact in
+`~/.cache/mvm/runtime-overlay/<version>/<arch>/`. A mismatch is an
+admission-time error that forces a rebuild or re-download. The
+guest then mounts only the dm-verity device, never the raw ext4
+payload directly.
+
 ### Overlay contents (per-arch, ~10-20 MB)
 
 ```text
@@ -117,6 +127,11 @@ Identical to rootfs verity:
 - Sidecar emitted alongside the overlay ext4 as part of the
   release artifacts: `runtime-overlay-{arch}-{version}.ext4`,
   `.verity`, `.roothash`.
+- The cached artifact also carries a local `checksums-sha256.txt`
+  over the canonical cache filenames (`overlay.ext4`,
+  `overlay.verity`, `overlay.roothash`, `VERSION`). mvm rechecks
+  those hashes before attach so a drifted cache entry cannot be
+  mounted.
 - mvmctl picks the overlay whose `VERSION` matches the running
   `mvmctl` semver. Mismatched versions are an admission-time
   error, not a silent boot.
@@ -180,7 +195,9 @@ the issue.
   (W3 verity shipped 2026-04-30 with two drives already; three
   is on the edge of what's tested).
 - An additional release artifact per arch
-  (`runtime-overlay-{arch}.ext4` + `.verity` + `.roothash`).
+  (`runtime-overlay-{arch}.tar.gz` + `.tar.gz.sha256`), whose
+  contents are still the canonical `overlay.ext4` + `.verity` +
+  `.roothash` + `VERSION` set.
   Adds ~10-20 MB per arch to the release payload.
 - `/mvm` path reservation is a contract with users. Documented
   on the public `oci-ingest` status row; admission-time check

--- a/specs/contracts/runtime-overlay-control-plane-boundary.md
+++ b/specs/contracts/runtime-overlay-control-plane-boundary.md
@@ -49,6 +49,10 @@ The practical rule is simple:
 ## Mount contract
 
 - The runtime overlay is mounted read-only at `/mvm/runtime`.
+- The host must verify the cached overlay artifact against its recorded
+  SHA-256 manifest before attach.
+- The guest must mount only the verified dm-verity mapping, never the raw
+  `overlay.ext4` block device directly.
 - Workloads must not depend on `/mvm/runtime` as an application search path.
 - The workload rootfs remains the source of truth for workload binaries and
   workload libraries.
@@ -117,6 +121,8 @@ against the stricter boundary:
   `/mvm/runtime`.
 - No binary needed before overlay mount is classified as an overlay payload.
 - The overlay remains readonly on every admitted backend.
+- A runtime overlay cache entry with missing or mismatched checksums is refused
+  before boot.
 - The rootfs/image remains the only owner of workload execution semantics.
 
 ## Code-audit checklist

--- a/specs/notes/plan-199-release-artifact-matrix.md
+++ b/specs/notes/plan-199-release-artifact-matrix.md
@@ -28,7 +28,7 @@ SBOM `sbom.cdx.json` (+ `.bundle`).
 Per arch (`aarch64`, `x86_64`), each with a `*-checksums-sha256.txt`:
 
 - **builder-vm** — `builder-vm-vmlinux-<arch>`, `builder-vm-rootfs-<arch>.ext4`, optional `.cmdline.txt` / `.manifest.json`
-- **runtime-overlay** — `runtime-overlay-<arch>.{ext4,verity,roothash,VERSION}`
+- **runtime-overlay** — `runtime-overlay-<arch>.tar.gz` containing `overlay.ext4`, `overlay.verity`, `overlay.roothash`, `VERSION`, and `checksums-sha256.txt`
 - **default-microvm** (prod variant) — `default-microvm-vmlinux-<arch>`, `default-microvm-rootfs-<arch>.{ext4,verity,roothash}`, `default-microvm-meta-<arch>.json`
 
 Image `*.manifest.json` files are cosign-signed (`.bundle`) per ADR-005 so

--- a/specs/runbooks/release-readiness.md
+++ b/specs/runbooks/release-readiness.md
@@ -109,11 +109,8 @@ matches the product contract before tagging.
 
 Release artifacts that must exist per architecture:
 
-- `runtime-overlay-<arch>.ext4`
-- `runtime-overlay-<arch>.verity`
-- `runtime-overlay-<arch>.roothash`
-- `runtime-overlay-<arch>.VERSION`
-- `runtime-overlay-<arch>-checksums-sha256.txt`
+- `runtime-overlay-<arch>.tar.gz`
+- `runtime-overlay-<arch>.tar.gz.sha256`
 
 The operator confirms:
 
@@ -121,9 +118,12 @@ The operator confirms:
    `~/.cache/mvm/runtime-overlay/<version>/<arch>/`
 2. only **guest-executed** runtime binaries belong in the overlay
 3. admitted backends mount it read-only
-4. running VMs do not hot-remount
-5. stopped VMs adopt a new version-matched overlay only on restart
-6. unsupported Linux rootfs-backed libkrun builder use is fail-closed
+4. the tarball contains `overlay.ext4`, `overlay.verity`,
+   `overlay.roothash`, `VERSION`, and `checksums-sha256.txt`
+5. the host re-verifies cached overlay files before attach
+6. running VMs do not hot-remount
+7. stopped VMs adopt a new version-matched overlay only on restart
+8. unsupported Linux rootfs-backed libkrun builder use is fail-closed
 
 The release workflow itself publishes the overlay assets, but the
 operator still verifies the contract by checking the docs and

--- a/specs/runbooks/runtime-overlay-production-rollout.md
+++ b/specs/runbooks/runtime-overlay-production-rollout.md
@@ -21,12 +21,15 @@ Contents:
 - `overlay.verity`
 - `overlay.roothash`
 - `VERSION`
+- `checksums-sha256.txt`
 
 Rules:
 
 - Only **guest-executed** runtime binaries belong here.
 - The guest mounts this artifact **read-only** on admitted overlay-backed
   backends.
+- The host re-verifies every cached runtime-overlay file against
+  `checksums-sha256.txt` before attach.
 - The runtime is **version-matched** to the host `mvmctl` release, not "latest
   in cache".
 - Running VMs do **not** hot-remount a new overlay.
@@ -50,6 +53,7 @@ Before cutting or approving the RC tag:
    exact ship candidate or on release assets built from it.
 5. Confirm release docs still say:
    - readonly mount
+   - host-side checksum revalidation before attach
    - version-matched, not latest
    - stopped VMs restart onto new runtime
    - running VMs do not hot-remount
@@ -59,22 +63,18 @@ Before cutting or approving the RC tag:
 The release pipeline must publish the runtime overlay assets for each supported
 architecture:
 
-- `runtime-overlay-aarch64.ext4`
-- `runtime-overlay-aarch64.verity`
-- `runtime-overlay-aarch64.roothash`
-- `runtime-overlay-aarch64.VERSION`
-- `runtime-overlay-aarch64-checksums-sha256.txt`
-- `runtime-overlay-x86_64.ext4`
-- `runtime-overlay-x86_64.verity`
-- `runtime-overlay-x86_64.roothash`
-- `runtime-overlay-x86_64.VERSION`
-- `runtime-overlay-x86_64-checksums-sha256.txt`
+- `runtime-overlay-aarch64.tar.gz`
+- `runtime-overlay-aarch64.tar.gz.sha256`
+- `runtime-overlay-x86_64.tar.gz`
+- `runtime-overlay-x86_64.tar.gz.sha256`
 
 Verify:
 
 1. The release tag version matches the workspace version.
-2. The published `runtime-overlay-<arch>.VERSION` file matches that release.
-3. `mvmctl build runtime-overlay build --source download` resolves the expected
+2. Extracting `runtime-overlay-<arch>.tar.gz` yields `overlay.ext4`,
+   `overlay.verity`, `overlay.roothash`, `VERSION`, and `checksums-sha256.txt`.
+3. The inner `VERSION` file matches that release.
+4. `mvmctl build runtime-overlay build --source download` resolves the expected
    asset set into `~/.cache/mvm/runtime-overlay/<version>/<arch>/`.
 
 ## Rollout procedure
@@ -133,11 +133,13 @@ to the following:
 > This release ships the readonly guest-runtime overlay as a first-class
 > versioned artifact under `~/.cache/mvm/runtime-overlay/<version>/<arch>/`.
 > Only guest-executed runtime binaries live in that overlay; host-side helpers
-> remain in the host bundle. Admitted overlay-backed backends mount the runtime
-> artifact read-only. Running VMs keep the runtime they booted with until
-> restart; stopped VMs pick up the new version-matched runtime on the next
-> start/restart. Linux rootfs-backed libkrun builder use remains fail-closed and
-> is not silently admitted.
+> remain in the host bundle. Before attach, `mvmctl` re-verifies the cached
+> overlay files against the recorded SHA-256 manifest; admitted overlay-backed
+> backends then mount only the readonly, verity-validated runtime device.
+> Running VMs keep the runtime they booted with until restart; stopped VMs pick
+> up the new version-matched runtime on the next start/restart. Linux
+> rootfs-backed libkrun builder use remains fail-closed and is not silently
+> admitted.
 
 If the release must be rolled back, pair the binary downgrade with a VM restart
 so restarted guests resolve the matching older runtime overlay.


### PR DESCRIPTION
## What changed
- switch the production runtime-overlay release transport from five separate files to a single `runtime-overlay-<arch>.tar.gz` plus `runtime-overlay-<arch>.tar.gz.sha256`
- keep per-file integrity inside the tarball via embedded `checksums-sha256.txt`, and re-verify cached overlay files before attach
- update the runtime-overlay downloader, release workflow, ADR, runbooks, and public docs to match the new transport contract

## Why
- reduce release/download surface to one overlay payload per arch while preserving the existing fail-closed integrity model
- make the runtime-overlay release easier to consume operationally without weakening the guest mount contract

## Impact
- dev required-overlay boots still auto-build/rebuild the overlay from a source checkout when the local cache is missing, invalid, or stale
- production releases still ship the overlay alongside `mvmctl`, but now as a tarball transport wrapper rather than five top-level assets
- the guest still mounts only the verified dm-verity device; no unchecked raw ext4 path is introduced

## Validation
- `cargo fmt --all`
- `cargo test -p mvm-build runtime_overlay --lib`
- `cargo clippy -p mvm-build --lib --tests -- -D warnings`
