### PR TITLE
docs: reframe guides for the headless builder (mvmctl dev removed)

### DIFF
--- a/public/src/content/docs/contributing/development.md
+++ b/public/src/content/docs/contributing/development.md
@@ -13,12 +13,12 @@ description: Getting started as a contributor to mvm.
 ### Do I need to install libkrun?
 
 It depends on your machine. The builder VM (the Linux guest that runs
-`nix build` inside `mvmctl build` / `up` / `dev`) auto-selects its host
+`nix build` inside `mvmctl build` / `machine run`) auto-selects its host
 VMM:
 
 | Host | libkrun (`slp/krun/*`) needed? |
 |---|---|
-| macOS 26+ Apple Silicon | **No** — auto-detect picks the **HVF** builder (Hypervisor.framework, ships with the OS, no Homebrew deps). `mvmctl dev up` only retries libkrun if the HVF path fails. |
+| macOS 26+ Apple Silicon | **No** — auto-detect picks the **HVF** builder (Hypervisor.framework, ships with the OS, no Homebrew deps). The auto-fallback retries libkrun automatically if the HVF path fails. |
 | macOS 13–25 Apple Silicon | **Yes** — `brew install slp/krun/libkrun slp/krun/libkrunfw`. |
 | Linux + `/dev/kvm` | **No** — auto-detect picks the **QEMU** builder, so libkrun is not part of the default builder path on native Linux hosts. |
 
@@ -36,7 +36,7 @@ git clone https://github.com/tinylabscom/mvm.git
 cd mvm
 cargo build
 cargo run -- doctor     # reports the builder backend + anything missing
-cargo run -- dev        # auto-bootstrap + drop into the builder-VM shell
+cargo run -- bootstrap  # pre-warm the builder VM (optional -- builds auto-bootstrap it too)
 ```
 
 Or run the bootstrap script on a fresh machine:
@@ -58,8 +58,8 @@ just runtime-overlay-build
 # Run CLI
 just run -- --help
 
-# Dev mode (auto-bootstraps the dev VM + Firecracker)
-just run -- dev
+# Pre-warm the builder VM (optional -- builds auto-bootstrap it too)
+just run -- bootstrap
 
 # Release build (stripped, LTO)
 just release-build
@@ -76,15 +76,15 @@ The builder-VM and workload microVM kernels are slim custom Linux
 builds: one shared config in `nix/images/kernel/base.nix` plus a
 per-variant delta (`workload.nix` adds dm-verity; `builder.nix` adds
 the nix-build sandbox + egress-lockdown bits). Because the config is
-custom, `cache.nixos.org` has no substitute, so the first `dev up` on a
+custom, `cache.nixos.org` has no substitute, so the first builder VM boot on a
 fresh machine compiles the kernel from source (3-10 min, memory-heavy).
 
 `mvmctl build kernel build` makes that compile explicit and one-time, so
-it stops hijacking your first `dev up`:
+it stops hijacking your first builder VM boot:
 
 ```bash
 # Compile the builder kernel once into the cache + persistent nix store.
-# The next `dev up` reuses it (substituted, not rebuilt).
+# The next builder VM boot reuses it (substituted, not rebuilt).
 just run -- build kernel build --which builder
 
 # Or both kernels:
@@ -96,7 +96,7 @@ VM on a published kernel (once a release has shipped one):
 
 ```bash
 # Build only the rootfs locally; fetch + hash-verify the kernel.
-just run -- --kernel-source download dev up
+just run -- --kernel-source download bootstrap
 # `auto` downloads if available, else compiles in-image (the default).
 ```
 
@@ -183,7 +183,7 @@ just ci
 
 ### Gated E2E: the core-demo regression guard
 
-`crates/mvm-cli/tests/core_demo_e2e.rs` exercises the whole `dev up → compile → up → vsock ping` spine end-to-end. It boots the persistent builder VM, lowers `examples/python/hello-app/app.py` to a flake, builds + boots the workload microVM, and waits for the guest agent to answer over vsock. Default-skips so it doesn't fire on routine `cargo test` runs; gate is `MVM_E2E_SMOKE=1`:
+`crates/mvm-cli/tests/core_demo_e2e.rs` exercises the whole `bootstrap → compile → up → vsock ping` spine end-to-end. It boots the persistent builder VM, lowers `examples/python/hello-app/app.py` to a flake, builds + boots the workload microVM, and waits for the guest agent to answer over vsock. Default-skips so it doesn't fire on routine `cargo test` runs; gate is `MVM_E2E_SMOKE=1`:
 
 ```bash
 # Local run — requires libkrun + libkrunfw on pre-26 macOS, or

--- a/public/src/content/docs/getting-started/first-microvm.md
+++ b/public/src/content/docs/getting-started/first-microvm.md
@@ -15,16 +15,16 @@ macOS 26+ (AS):    mvmctl machine run  -->  HVF microVM (Hypervisor.framework, v
 macOS 13-25 (AS):  mvmctl machine run  -->  libkrun microVM
 ```
 
-| Layer | Access command | Has your project files? |
-|-------|---------------|------------------------|
+| Layer | Access | Has your project files? |
+|-------|--------|------------------------|
 | Host | Your normal terminal | Yes |
-| Dev VM (macOS) | `mvmctl dev` or `mvmctl dev shell` | Yes (~ mounted read/write) |
-| MicroVM | (headless, no SSH) | No (isolated filesystem) |
+| Builder VM (macOS) | Headless -- no shell. Runs `nix build` on your behalf, driven by `mvmctl build` / `mvmctl machine run` | Only for the duration of a build job |
+| MicroVM | Headless, no SSH -- `mvmctl machine console` attaches only to images built with a shell entrypoint | No (isolated filesystem) |
 
-MicroVMs are **headless workloads** with no SSH access -- they communicate via vsock only.
+MicroVMs are **headless workloads** with no SSH access -- they communicate via vsock only. The builder VM is headless too: there's no interactive shell into it, on any platform.
 
 :::note
-On Linux with `/dev/kvm`, the dev-VM layer is skipped entirely -- Firecracker runs directly. On macOS Apple Silicon, microVMs run on the HVF backend (macOS 26+) or libkrun (macOS 13–25). There is no Docker or container runtime path.
+On Linux with `/dev/kvm`, the builder-VM layer is skipped entirely -- Firecracker runs directly. On macOS Apple Silicon, microVMs run on the HVF backend (macOS 26+) or libkrun (macOS 13–25). There is no Docker or container runtime path.
 :::
 
 ## Scaffold a project

--- a/public/src/content/docs/getting-started/happy-paths.md
+++ b/public/src/content/docs/getting-started/happy-paths.md
@@ -3,7 +3,7 @@ title: First-Use Happy Paths
 description: Three-command paths to get a microVM running for each mvm audience.
 ---
 
-mvm has five primary audiences. Each one has a **three-command happy
+mvm has six primary audiences. Each one has a **three-command happy
 path** that takes you from "I have a thing to run" to "it's running
 under mvm." Pair each path with `mvmctl doctor --workflow <name>` to
 preflight only the host requirements that matter for your audience —
@@ -13,6 +13,7 @@ nothing more, nothing less.
 |---|---|---|
 | [CLI user with an OCI image](#cli-image-user) | `--workflow cli-run` | Run a command in a transient image-backed microVM. |
 | [CLI user with a flake](#cli-user) | `--workflow cli-run` | Boot a microVM from a Nix flake. |
+| [CLI user with a manifest](#manifest-user) | `--workflow cli-run` | Build and boot a manifest-backed microVM. |
 | [Python SDK user](#python-sdk) | `--workflow python-sdk` | Run a `@mvm.app()`-decorated Python script. |
 | [TypeScript / Node SDK user](#typescript-sdk) | `--workflow typescript-sdk` | Run an `mvm.app()` TypeScript app. |
 | [Prebuilt bundle operator](#bundle-run) | `--workflow bundle-run` | Launch a signed `.mvmpkg` artifact. |
@@ -79,6 +80,31 @@ source checkout); subsequent runs reuse the warm builder. Skip the
   demand.
 - `disk space < N GiB` → free space on `~/.mvm/` (default cache
   location); `mvmctl cache info` shows what's there.
+
+## <a id="manifest-user"></a>CLI user with a manifest
+
+You already have an `mvm.toml` / `Mvmfile.toml` and want to build and boot the
+microVM it describes.
+
+```bash
+mvmctl doctor --workflow cli-run                # preflight
+mvmctl build                                    # discover manifest + build
+mvmctl machine run --manifest .                 # boot the built microVM
+```
+
+This is the shortest path when the project is already modeled as a manifest.
+The manifest selects the source (`flake` or `image`) plus sizing, while
+`mvmctl build` and `mvmctl machine run --manifest .` reuse the same project
+slot across runs.
+
+**Failure recovery:**
+
+- `manifest not found` → run from the project directory or pass an explicit
+  manifest path.
+- `host nix not required` errors → none expected. Manifest-backed flake builds
+  still run inside the builder VM, not on the host.
+- `drift detected` → the manifest's source or profile changed; rebuild or force
+  the update after confirming the new target is intentional.
 
 ## <a id="python-sdk"></a>Python SDK user
 

--- a/public/src/content/docs/getting-started/happy-paths.md
+++ b/public/src/content/docs/getting-started/happy-paths.md
@@ -3,7 +3,7 @@ title: First-Use Happy Paths
 description: Three-command paths to get a microVM running for each mvm audience.
 ---
 
-mvm has six primary audiences. Each one has a **three-command happy
+mvm has five primary audiences. Each one has a **three-command happy
 path** that takes you from "I have a thing to run" to "it's running
 under mvm." Pair each path with `mvmctl doctor --workflow <name>` to
 preflight only the host requirements that matter for your audience —
@@ -16,12 +16,11 @@ nothing more, nothing less.
 | [Python SDK user](#python-sdk) | `--workflow python-sdk` | Run a `@mvm.app()`-decorated Python script. |
 | [TypeScript / Node SDK user](#typescript-sdk) | `--workflow typescript-sdk` | Run an `mvm.app()` TypeScript app. |
 | [Prebuilt bundle operator](#bundle-run) | `--workflow bundle-run` | Launch a signed `.mvmpkg` artifact. |
-| [`mvmctl dev` user](#dev-shell) | `--workflow dev-shell` | Drop into a builder-VM shell for tinkering. |
 
 The preflight filter (plan 74 W5 / ADR-050 §1) only fails on missing
 prerequisites your workflow actually needs. A bundle operator no
 longer sees a "missing `cargo`" failure they don't care about; a
-`mvmctl dev` user no longer needs host rustup.
+flake CLI user isn't blocked by SDK-only prerequisites they don't need.
 
 ## <a id="cli-image-user"></a>CLI user with an OCI image
 
@@ -74,7 +73,7 @@ source checkout); subsequent runs reuse the warm builder. Skip the
 
 - `host nix not required` errors → none expected. mvm's builder VM
   owns Nix; the host doesn't need it.
-- `dev VM not running — run mvmctl dev up to verify` → that's just
+- `dev VM not running; run mvmctl bootstrap to verify` → that's just
   doctor telling you tool checks were skipped because the builder
   VM is asleep. It's not a failure; `mvmctl machine run` boots it on
   demand.
@@ -154,32 +153,6 @@ remain.
 - `bundle pin missing` (audit-chain admission) → the supervisor's
   signed-plan path failed to find a matching `PlanArtifact`. Pull
   a fresh copy from the publisher.
-
-## <a id="dev-shell"></a>`mvmctl dev` user
-
-You want a shell with a real Linux toolchain — for building, testing,
-or just exploring.
-
-```bash
-mvmctl doctor --workflow dev-shell              # preflight (no host rust needed)
-mvmctl dev                                      # boot + drop into shell
-# inside the shell: do work; exit / Ctrl+D returns you to the host
-```
-
-`mvmctl dev` auto-bootstraps the first time (downloads the dev image
-or builds it locally from `nix/images/dev-shell/`). Your project
-directory is bind-mounted at `/work`. Background services keep
-running after you exit; `mvmctl dev down` stops them.
-
-**Failure recovery:**
-
-- `builder VM image missing` → `mvmctl dev up` downloads or builds
-  it. From a source checkout, the in-repo flakes are always
-  preferred over published artifacts.
-- `dev shell exited immediately with no command output` → check
-  `~/.mvm/dev/console.log` for the kernel/init transcript. Plan
-  72 W5.D documented the nine bring-up bugs that produced this
-  symptom; if you hit one of them the log names it.
 
 ## See also
 

--- a/public/src/content/docs/getting-started/installation.md
+++ b/public/src/content/docs/getting-started/installation.md
@@ -121,7 +121,7 @@ mvmctl automatically detects your platform at startup and selects the best VM ba
 There is no Docker or container backend on the runtime path. A `qemu`
 (microvm.nix) backend exists for local dev/test only and is never auto-selected.
 
-You don't need Nix on the host. On first build, mvm bootstraps or reuses a Linux builder VM, runs Nix evaluation and `nix build` inside it, and extracts the rootfs back. You run `mvmctl build` from the host; you do not need to enter a dev shell first. See [Builder VM](/guides/builder-vm/) for the full model.
+You don't need Nix on the host. On first build, mvm bootstraps or reuses a Linux builder VM, runs Nix evaluation and `nix build` inside it, and extracts the rootfs back. You run `mvmctl build` from the host; the builder VM is headless, so there is no shell to enter first. See [Builder VM](/guides/builder-vm/) for the full model.
 
 ### First-Time Setup
 
@@ -133,7 +133,7 @@ mvmctl init
 
 This walks through platform detection, dependency installation (Firecracker on Linux; the `slp/krun` Homebrew trio for libkrun on macOS 13–25, nothing extra for the HVF backend on macOS 26+), default network setup, and XDG directory creation. Use `--non-interactive` for scripted environments.
 
-Running `mvmctl dev` or `mvmctl bootstrap` also handles setup automatically -- they detect your platform, select the backend, and stage the builder microVM image on first use.
+Running `mvmctl bootstrap` also handles setup automatically -- it detects your platform, selects the backend, and stages the builder microVM image ahead of time (builds trigger the same staging automatically if you skip this step).
 
 You can force a specific backend with `--hypervisor`:
 

--- a/public/src/content/docs/getting-started/nix-for-mvm.mdx
+++ b/public/src/content/docs/getting-started/nix-for-mvm.mdx
@@ -197,8 +197,9 @@ mvm.lib.${system}.mkGuest {
 Search for packages at [search.nixos.org/packages](https://search.nixos.org/packages) or from the command line:
 
 ```bash
-# Inside the dev shell (mvmctl dev)
-# Use 2>/dev/null to hide nixpkgs deprecation warnings
+# Requires optional host-side Nix (see Installation) -- the builder VM
+# is headless, so there's no shell to run this inside. Use 2>/dev/null
+# to hide nixpkgs deprecation warnings.
 nix search nixpkgs python 2>/dev/null
 nix search nixpkgs "node.*22" 2>/dev/null
 ```

--- a/public/src/content/docs/getting-started/quickstart.md
+++ b/public/src/content/docs/getting-started/quickstart.md
@@ -6,8 +6,8 @@ description: Get a microVM running in under 5 minutes.
 :::tip[Looking for the shortest path to "it's running"?]
 [First-Use Happy Paths](/getting-started/happy-paths/) lists a
 three-command sequence for each mvm audience: OCI-image CLI users,
-flake CLI users, Python SDK users, TypeScript SDK users, and prebuilt
-bundle operators. Each path is paired with
+flake CLI users, manifest CLI users, Python SDK users, TypeScript SDK
+users, and prebuilt bundle operators. Each path is paired with
 `mvmctl doctor --workflow <name>` so the preflight only flags blockers
 your audience actually has.
 :::

--- a/public/src/content/docs/getting-started/quickstart.md
+++ b/public/src/content/docs/getting-started/quickstart.md
@@ -6,8 +6,8 @@ description: Get a microVM running in under 5 minutes.
 :::tip[Looking for the shortest path to "it's running"?]
 [First-Use Happy Paths](/getting-started/happy-paths/) lists a
 three-command sequence for each mvm audience: OCI-image CLI users,
-flake CLI users, Python SDK users, TypeScript SDK users, prebuilt bundle
-operators, and `mvmctl dev` users. Each path is paired with
+flake CLI users, Python SDK users, TypeScript SDK users, and prebuilt
+bundle operators. Each path is paired with
 `mvmctl doctor --workflow <name>` so the preflight only flags blockers
 your audience actually has.
 :::
@@ -24,8 +24,8 @@ This pulls or reuses the cached image, records OCI provenance, boots a transient
 microVM, runs the command, and tears the VM down. You do not need host Nix for
 this path.
 
-Use this when you want "run this command in a fresh microVM." Use the flake,
-manifest, and dev-shell flows below when you are building a custom image or a
+Use this when you want "run this command in a fresh microVM." Use the flake
+and manifest flows below when you are building a custom image or a
 repeatable project environment.
 
 For a scenario-led map of when to use each machine workflow, read
@@ -41,44 +41,46 @@ mvmctl machine exec alpine-dev -- uname -a
 mvmctl machine stop alpine-dev
 ```
 
-## 2. Launch the Dev Environment
+## 2. Pre-warm the Builder VM (optional)
 
 ```bash
-mvmctl dev
+mvmctl bootstrap
 ```
 
-This single command detects your platform and handles everything. **Builds run in a builder microVM that mvm sets up automatically — you don't need Nix on your host.** The builder owns its own `/nix/store` and keeps it warm across builds. Where the builder VM runs depends on your platform:
+The builder VM is a **headless** Linux microVM that runs Nix builds on your
+behalf -- there's no shell into it. `mvmctl bootstrap` detects your platform
+and pre-fetches or builds its image so the setup cost is paid up front
+instead of on your first build. It's entirely optional: skip it and
+`mvmctl build` / `mvmctl machine run` bootstrap it automatically the first
+time they need it. **Builds run in this builder microVM — you don't need
+Nix on your host.** The builder owns its own `/nix/store` and keeps it warm
+across builds. Where it runs depends on your platform:
 
 **On Linux with `/dev/kvm`:**
 1. Selects Firecracker as the runtime backend
 2. Bootstraps the builder microVM on first build (one-time fetch); `nix build` runs inside it
-3. Drops you into a dev shell
 
 **On macOS 26+ Apple Silicon:**
 1. Selects the HVF backend (Hypervisor.framework, vsock-only, no Homebrew deps)
 2. Boots the builder microVM there; `nix build` runs inside it
-3. Drops you into a dev shell
 
 **On macOS 13–25 Apple Silicon:**
 1. Selects libkrun (the in-process VMM from the `slp/krun` Homebrew trio)
 2. Same builder microVM, hosted on libkrun
-3. Drops you into a dev shell
 
 mvm targets Apple Silicon on macOS and `/dev/kvm` on Linux. There is no Docker
 or container runtime path; a host without a supported microVM backend surfaces a
 backend-unavailable error rather than silently degrading.
 
-Inside the dev shell your project directory is bind-mounted at `/work`. Exit with `exit` or `Ctrl+D` -- background services keep running.
-
 :::note
-Release binaries download the builder image (~200MB) and dev microVM image on first run. From a source checkout, `mvmctl dev up` builds from the in-repo flakes.
+Release binaries download the builder image (~200MB) on first use. From a
+source checkout, `mvmctl bootstrap` builds it from the in-repo flakes.
 :::
 
 ## 3. Day-to-Day Commands
 
 ```bash
 mvmctl ls         # List running VMs (aliases: ps, status)
-mvmctl dev shell  # Open a shell in the dev microVM
 mvmctl machine stop --all       # Stop all running VMs
 mvmctl doctor     # Check system dependencies and configuration
 mvmctl machine console vm # Interactive shell into a running VM (PTY-over-vsock)

--- a/public/src/content/docs/guides/airgapped-bootstrap.md
+++ b/public/src/content/docs/guides/airgapped-bootstrap.md
@@ -5,18 +5,32 @@ description: How to run mvmctl in environments that can't reach github.com witho
 
 # Air-gapped Bootstrap
 
+:::caution[Air-gapped import command removed]
+`mvmctl dev import-image` — the command this guide was written around — was
+removed along with the rest of the interactive `mvmctl dev` command surface,
+and there is currently no successor command for importing a verified builder
+image from local files on a host that can't reach `github.com`. The
+verification pipeline it drove (cosign + SHA-256 + version-pin + max-age +
+revocation checks) is kept below as reference for what a headless successor
+needs to reproduce. If you operate air-gapped hosts, track this gap before
+relying on anything past this notice.
+:::
+
 mvmctl normally fetches its dev image (kernel + rootfs) and the
 project's [cosign-signed manifest](verify-release) from GitHub
-Releases. In regulated, government, or otherwise air-gapped
-environments where the host can't reach `github.com`, plan 36 ships
-a sanctioned trusted path: `mvmctl dev import-image` runs the same
-cosign signature + SHA-256 + version-pin + max-age + revocation
+Releases automatically, as part of `mvmctl bootstrap` or the first
+`mvmctl build` / `mvmctl machine run`. In regulated, government, or
+otherwise air-gapped environments where the host can't reach
+`github.com`, plan 36 shipped a sanctioned trusted path — the
+now-removed `mvmctl dev import-image` — that ran the same cosign
+signature + SHA-256 + version-pin + max-age + revocation
 verification pipeline against operator-provided local files.
 
-This is the *only* recommended way to run mvmctl in an air-gapped
-host. Setting `MVM_SKIP_HASH_VERIFY=1` to bypass the network fetch
+That was the *only* recommended way to run mvmctl in an air-gapped
+host, and the underlying principle still holds now that the command
+is gone: setting `MVM_SKIP_HASH_VERIFY=1` to bypass the network fetch
 disables the supply-chain check entirely, which is exactly the
-unsafe escape this path exists to discourage.
+unsafe escape this path existed to discourage.
 
 ## What you need
 
@@ -67,9 +81,10 @@ cosign verify-blob \
   "dev-image-${ARCH}.manifest.json"
 ```
 
-Expect `Verified OK`. mvmctl re-runs this check during `import-image`,
-so this step is optional — it just gives you a fast-fail before
-transferring 200 MB of rootfs over a slow side channel.
+Expect `Verified OK`. This step was optional even when `import-image`
+existed (mvmctl re-ran the same check on import) — it just gives you
+a fast-fail before transferring 200 MB of rootfs over a slow side
+channel.
 
 ### 3. Transfer to the air-gapped host
 
@@ -78,9 +93,11 @@ host — whatever your environment allows. The four files must arrive
 together; any one being modified or replaced in transit will fail
 verification on import.
 
-### 4. Import on the air-gapped host
+### 4. Import on the air-gapped host (command removed)
 
 ```bash
+# This command no longer exists — kept to document the pipeline a
+# successor needs to reproduce.
 mvmctl dev import-image \
   --manifest dev-image-aarch64.manifest.json \
   --bundle   dev-image-aarch64.manifest.json.bundle \
@@ -88,7 +105,7 @@ mvmctl dev import-image \
   --rootfs   dev-rootfs-aarch64.ext4
 ```
 
-mvmctl runs the full verification pipeline:
+This ran the full verification pipeline:
 
 1. Cosign-verify the manifest signature against the project's
    release-workflow OIDC identity.
@@ -100,9 +117,9 @@ mvmctl runs the full verification pipeline:
    digests.
 6. Copy the verified bytes into `~/.mvm/dev/prebuilt/v{version}/`.
 
-On success, the next `mvmctl dev up` boots the dev VM from the
-imported artifacts without re-running verification or touching the
-network.
+On success, the imported artifacts became the cache mvm's next
+builder VM boot would use, without re-running verification or
+touching the network.
 
 ## Revocation list in air-gapped environments
 
@@ -135,13 +152,14 @@ cp revoked-versions.json.bundle ~/.cache/mvm/revocations/
 touch ~/.cache/mvm/revocations/revoked-versions.json
 ```
 
-`mvmctl dev up` will read the cached file, cosign-verify it, and
-enforce any matching recall.
+The next builder VM fetch (`mvmctl bootstrap`, or auto-bootstrap on
+a build) reads the cached file, cosign-verifies it, and enforces any
+matching recall.
 
-## Failure modes
+## Failure modes (historical — `mvmctl dev import-image`)
 
-`mvmctl dev import-image` fails closed. The most common errors and
-what they mean:
+`mvmctl dev import-image` failed closed when it existed. The most
+common errors and what they meant, kept for reference:
 
 | Error wording | Cause | Fix |
 |--------------|-------|-----|

--- a/public/src/content/docs/guides/builder-vm.md
+++ b/public/src/content/docs/guides/builder-vm.md
@@ -1,9 +1,9 @@
 ---
 title: "Builder VM"
-description: How mvm builds Linux microVM images from the host without requiring you to enter a dev shell or install host-side Nix.
+description: How mvm builds Linux microVM images from the host — the builder VM is headless, and host-side Nix is optional.
 ---
 
-The short version: **you run `mvmctl build` from the host, and mvm runs Nix inside the builder VM.** You do not need to enter an interactive dev shell to build a template or runtime image.
+The short version: **you run `mvmctl build` from the host, and mvm runs Nix inside the builder VM.** The builder VM is headless — there is no interactive shell to enter, for a template build or a runtime image.
 
 The host process is the control plane. The builder VM is the Linux execution boundary for Nix evaluation, Nix builds, and image assembly. The runtime backend is separate: after the image is built, mvm boots the prebuilt kernel and rootfs with the selected microVM backend, such as Firecracker on Linux or Apple Virtualization on macOS.
 
@@ -40,32 +40,26 @@ runtime microVM
 
 This separation is deliberate. A build can take seconds or minutes because it may fetch and compile Nix closures. A runtime boot benchmark should normally measure only the already-built image booting, not the build phase.
 
-## You Do Not Need a Dev Shell to Build
+## The Builder VM Is Headless — Debug via Logs
 
 The normal build command is:
 
 ```bash
-mvmctl build --flake .
+mvmctl machine build --flake .
 ```
 
 That command should be run from your project directory on the host. `mvmctl` takes care of starting or reaching the builder VM, staging the flake, running the build, and copying the result back.
 
-Use an interactive shell only when you want to debug the builder environment:
+There is no interactive shell into the builder VM, on any platform. When you need to see what the build is doing, use the logs instead of a shell:
 
-```bash
-mvmctl dev shell
-```
+- **Live progress** — pass `-v` (or set `RUST_LOG`) and the in-builder `nix build` output streams to your terminal as the build runs.
+- **Post-mortem** — a failed build's error message names the on-disk Nix stderr log path and includes its tail, so you don't have to guess where to look or re-run with `-v` after the fact.
+- **Nix store disk usage** — `mvmctl doctor` reports Nix store size (and warns above 20 GiB); `mvmctl cache info` shows overall cache usage.
+- **Reproducing a Linux-only build failure** — the log already carries the same `nix build` output a shell session would show; there's no separate environment state to inspect that isn't in the log.
 
-Examples of things a dev shell is useful for:
+Things that never required a shell and still don't:
 
-- inspecting the Linux build environment;
-- manually running `nix build` to debug a flake error;
-- checking disk usage in the builder VM's Nix store;
-- reproducing an issue that only appears inside the Linux build boundary.
-
-Examples of things that should not require a dev shell:
-
-- `mvmctl build --flake .`;
+- `mvmctl machine build --flake .`;
 - `mvmctl run`;
 - `mvmctl machine run --flake .`;
 - building a registered template;
@@ -115,14 +109,9 @@ The builder VM and runtime microVM have different jobs:
 
 Do not benchmark the builder VM when you want runtime boot time. The builder VM exists so that the host can ask for Linux builds without becoming a Linux build machine itself.
 
-## Persistent builder personas
+## The persistent builder VM
 
-There are two builder personas in the developer experience:
-
-| Persona | Command shape | Interaction model | Purpose |
-|---|---|---|---|
-| Developer builder VM | `cargo run -- dev up` / `mvmctl dev up` | Persistent and debuggable; may open an interactive shell with `--shell`. | Keep the Linux development/build boundary warm while a developer iterates. |
-| Build worker VM | `cargo run -- build` / `mvmctl build` | Persistent but non-interactive. | Run normal Nix/image build jobs without making the user manage the VM. |
+The builder VM can run as a persistent, non-interactive worker (`cargo run -- build` / `mvmctl build`) so repeated builds amortize the boot cost instead of paying it per job. It has exactly one persona: a headless build worker. There is no separate interactive/developer persona to keep warm — the builder VM was never meant to be a place you work from, and now there's no command that lets you try.
 
 The low-level persistent-builder controls already exist:
 
@@ -133,13 +122,13 @@ mvmctl persistent-builder submit --flake path:/work --attr packages.aarch64-linu
 mvmctl persistent-builder stop
 ```
 
-`mvmctl build` also has an explicit escape hatch:
+`mvmctl machine build` also has an explicit escape hatch:
 
 ```bash
-mvmctl build --no-persistent-builder
+mvmctl machine build --no-persistent-builder
 ```
 
-The intended top-level DX is that developers do not need to invoke the low-level controls for normal use. `dev up` should ensure the interactive/developer builder is present, and `build` should use a persistent non-interactive builder by default when the platform supports it. If the persistent path is unavailable, the command should say why it fell back rather than silently changing the trust and performance model.
+The intended top-level DX is that developers do not need to invoke the low-level controls for normal use: `build` uses a persistent non-interactive builder by default when the platform supports it. If the persistent path is unavailable, the command should say why it fell back rather than silently changing the trust and performance model.
 
 ## Communication Model
 
@@ -206,7 +195,7 @@ The builder VM keeps build state warm so repeated builds avoid re-fetching the w
 
 The first build is allowed to be slower because it may bootstrap the builder image and populate the Nix store. Later builds should be dominated by changed inputs.
 
-When `mvmctl` is running from this source checkout, the builder image is local-build only. A populated `~/.cache/mvm/builder-vm/<arch>/` cache can be reused only when its source fingerprint matches the current `nix/images/builder-vm/{flake.nix,flake.lock}` inputs, its recorded artifact digests still match the cached `vmlinux`, `rootfs.ext4`, and optional `cmdline.txt`, and its provenance summary matches the same source fingerprint and artifact filename set. On cache miss, fingerprint drift, artifact drift, or provenance drift, mvm uses a dev image that contains `/sbin/mvm-host-vm-init` as a Stage 0 bootstrap image to build `nix/images/builder-vm/` into a hidden staging directory, validates the kernel and rootfs, records the source fingerprint, artifact digests, and non-sensitive provenance summary, then promotes the staged output into the live cache. It prefers a local Stage 0 seed from `~/.mvm/dev/current/`, `~/.mvm/dev/prebuilt/v*/`, or `~/.mvm/dev/builds/*/`; if none of those images satisfies the Stage 0 contract, it may download the normal published dev image through the signed/hash-verified dev-image path and use it as the bootstrap seed only. It still refuses to download a published builder-VM image in a source checkout, so edits under `nix/images/builder-vm/` are built locally and are not masked by release artifacts. With `--verbose`, source-checkout cache decisions include a safe reason code such as `hit`, `missing_artifact`, `invalid_stage0_artifacts`, `missing_fingerprint`, `fingerprint_mismatch`, `missing_artifact_digest_manifest`, `artifact_digest_mismatch`, `missing_provenance`, or `provenance_mismatch`; these diagnostics do not print artifact contents, local paths, or raw digest metadata. `mvmctl dev status` also reports the builder-cache kind, readiness, and the same safe reason code without attempting a rebuild. `mvmctl dev cache inspect` exposes the same safe builder-cache summary plus dev-image presence, and `--json` emits only sanitized labels for automation.
+When `mvmctl` is running from this source checkout, the builder image is local-build only. A populated `~/.cache/mvm/builder-vm/<arch>/` cache can be reused only when its source fingerprint matches the current `nix/images/builder-vm/{flake.nix,flake.lock}` inputs, its recorded artifact digests still match the cached `vmlinux`, `rootfs.ext4`, and optional `cmdline.txt`, and its provenance summary matches the same source fingerprint and artifact filename set. On cache miss, fingerprint drift, artifact drift, or provenance drift, mvm uses a dev image that contains `/sbin/mvm-host-vm-init` as a Stage 0 bootstrap image to build `nix/images/builder-vm/` into a hidden staging directory, validates the kernel and rootfs, records the source fingerprint, artifact digests, and non-sensitive provenance summary, then promotes the staged output into the live cache. It prefers a local Stage 0 seed from `~/.mvm/dev/current/`, `~/.mvm/dev/prebuilt/v*/`, or `~/.mvm/dev/builds/*/`; if none of those images satisfies the Stage 0 contract, it may download the normal published dev image through the signed/hash-verified dev-image path and use it as the bootstrap seed only. It still refuses to download a published builder-VM image in a source checkout, so edits under `nix/images/builder-vm/` are built locally and are not masked by release artifacts. With `--verbose`, source-checkout cache decisions include a safe reason code such as `hit`, `missing_artifact`, `invalid_stage0_artifacts`, `missing_fingerprint`, `fingerprint_mismatch`, `missing_artifact_digest_manifest`, `artifact_digest_mismatch`, `missing_provenance`, or `provenance_mismatch`; these diagnostics do not print artifact contents, local paths, or raw digest metadata. `mvmctl bootstrap --verbose` reports the same safe reason code on demand — `bootstrap` is idempotent, so re-running it against an already-warm cache is a fast inspection, not a rebuild.
 
 ## Benchmarking Runtime Boot
 

--- a/public/src/content/docs/guides/building-microvm-images.md
+++ b/public/src/content/docs/guides/building-microvm-images.md
@@ -51,7 +51,7 @@ mvmctl build              # reads mvm.toml; builds the named flake target
 mvmctl run                # builds (if needed) + boots
 ```
 
-`mvmctl build` is a host command. You run it from macOS or Linux, and mvm sends the Linux-only Nix work into the builder VM. You do not need to enter `mvmctl dev shell` first. The shell is for debugging the build environment manually, not a prerequisite for normal builds.
+`mvmctl build` is a host command. You run it from macOS or Linux, and mvm sends the Linux-only Nix work into the builder VM. The builder VM is headless, so there's no shell to enter first — debug a failed build from its log instead (`-v` streams it live; a failure names the log path).
 
 `mvmctl` selects the runtime backend automatically when you boot the finished image. Use `--hypervisor` on runtime commands when you want to force a specific runtime backend:
 
@@ -114,7 +114,7 @@ Independent of the sealed/accessible distinction, mvm exposes two **runtime life
 
 | Mode | What it means | When to use |
 |---|---|---|
-| `attached` | VM lifecycle bound to the calling process — Ctrl-C / process exit sends SIGTERM to the VM. | `mvmctl run` interactive, `mvmctl dev` shell sessions, test harnesses that want deterministic teardown. |
+| `attached` | VM lifecycle bound to the calling process — Ctrl-C / process exit sends SIGTERM to the VM. | `mvmctl run` interactive, test harnesses that want deterministic teardown. |
 | `detached` | VM survives caller exit — only `mvmctl machine stop` (or `VmBackend::stop`) terminates it. | `mvmctl machine run` (background), production agents, CI fixtures that boot once and run multiple phases. |
 
 The default is `detached`. Override:
@@ -199,7 +199,7 @@ nix flake check --no-build
 
 ## Cross-platform notes
 
-mvm runs Nix builds inside the project builder VM and copies the finished kernel/rootfs artifacts back to the host cache. You don't need host-side Nix, and you don't need to enter a dev shell before building.
+mvm runs Nix builds inside the project builder VM and copies the finished kernel/rootfs artifacts back to the host cache. You don't need host-side Nix, and the builder VM is headless -- there's no shell to enter before building.
 
 - **Linux**: the builder VM provides the Linux build boundary and cache policy. Firecracker is the default runtime backend when `/dev/kvm` is available.
 - **macOS**: the host `mvmctl build` command orchestrates a Linux builder VM. The resulting runtime image boots on the HVF backend by default on macOS 26+ (Hypervisor.framework, vsock-only), or libkrun on macOS 13–25.

--- a/public/src/content/docs/guides/dev-image.md
+++ b/public/src/content/docs/guides/dev-image.md
@@ -1,16 +1,13 @@
 ---
 title: Dev Image
-description: How `mvmctl dev` boots a development microVM, the default image that ships with mvm, and how to write your own.
+description: The accessible microVM image shape (shell entrypoint) for build/test/exploration, and how to write your own.
 ---
 
-A **dev image** is a microVM image whose entrypoint is an interactive shell — what `mvmctl dev` boots when you want a sandboxed shell for build/test/exploration. It's just an `mkGuest` call with `entrypoint.shell` set; the same library, the same flake shape, the same builder pipeline as any other mvm image.
+A **dev image** is a microVM image whose entrypoint is an interactive shell — an `mkGuest` call with `entrypoint.shell` set instead of `entrypoint.command`. It's the same library, the same flake shape, and the same builder pipeline as any other mvm image; the shell entrypoint is what makes the resulting image **accessible**, so `mvmctl machine console` can attach an interactive PTY over vsock once it's booted. There's no separate "dev mode" command — you build it with `mvmctl machine build` and boot it with `mvmctl machine run` like any other image.
 
-There are two paths:
+Declare it in your project's flake using `mvm.lib.<system>.mkGuest`. Add your packages, your services, your config. The mvm repository's internals stay untouched — you're a consumer of the library, not a fork. See [Writing your own dev image](#writing-your-own-dev-image) below.
 
-1. **Use the default dev image that ships with mvm** — zero config, run `mvmctl dev up` and you're in a shell. Good for "I just want a sandboxed Linux shell to poke around in." See [The default dev image](#the-default-dev-image) below.
-2. **Write your own dev image** — declare it in your project's flake using `mvm.lib.<system>.mkGuest`. Adds your packages, your services, your config. The mvm repository's internals stay untouched — you're a consumer of the library, not a fork. See [Writing your own dev image](#writing-your-own-dev-image) below.
-
-Per [ADR-013](/contributing/adr/013-libkrun-pivot/), the dev/prod distinction is encoded in the entrypoint shape (`shell` → accessible, `command`/`services` → sealed). The same `mvm.lib.<system>.mkGuest` API serves both.
+Per [ADR-013](/contributing/adr/013-libkrun-pivot/), the dev/prod distinction is encoded in the entrypoint shape (`shell` → accessible, `command`/`services` → sealed). The same `mvm.lib.<system>.mkGuest` API serves both. [Building MicroVM Images § Sealed vs accessible](/guides/building-microvm-images/#sealed-vs-accessible--the-same-flake-works-for-both) covers that matrix in full; this page focuses on authoring the dev-image shape itself.
 
 ## Writing your own dev image
 
@@ -36,7 +33,7 @@ A dev image is just an mkGuest call with `entrypoint.shell` set. Your project's 
           entrypoint.command = [ "/usr/local/bin/serve" ];
         };
 
-        # Dev image — what `mvmctl dev up` builds.
+        # Dev image — the accessible, console-attachable output.
         dev = mvm.lib.${system}.mkGuest {
           name = "my-app-dev";
 
@@ -73,9 +70,10 @@ memory_mib = 1024
 Then:
 
 ```sh
-mvmctl dev up         # builds the .dev output, boots it, drops you into the shell
-mvmctl dev down       # stop the dev VM
-mvmctl machine console        # reattach to the running shell
+mvmctl machine build --flake . --profile dev                          # builds the .dev output
+mvmctl machine run --flake . --flake-profile dev -d --name my-app-dev # boots it, detached
+mvmctl machine console my-app-dev                                     # attach the interactive shell
+mvmctl machine stop my-app-dev                                        # stop it
 ```
 
 You **never edit anything inside the mvm repository** to customize your dev image. Your project owns its dev image; mvm is the library.
@@ -117,38 +115,30 @@ dev = mvm.lib.${system}.mkGuest {
 
 See [Building MicroVM Images](/guides/building-microvm-images#sealed-vs-accessible--the-same-flake-works-for-both) for the full sealed/accessible matrix.
 
-## The default dev image
-
-If your project doesn't declare a `.dev` flake output, `mvmctl dev up` falls back to the default image that ships with mvm — a minimal busybox rootfs with a shell entrypoint. It exists so you can run `mvmctl dev up` with zero config and get something useful.
-
-The default image is **not** a starter template — don't fork it. It's there for the "I just want a shell" case. Once you have specific package or service requirements, switch to writing your own per the section above.
-
-(Internally the default lives at the workspace's `nix/profiles/minimal.nix` — but that file is a test fixture, not a user-facing entry point. The library's `mvm.lib.<system>.mkGuest` is what you should be calling.)
-
 ## Building the dev image locally
 
 The build path is the same as any mvm image:
 
 ```sh
 # From your project directory:
-mvmctl build --flake . --profile dev
+mvmctl machine build --flake . --profile dev
 ```
 
-If you intentionally manage your own Nix environment, you can run `nix build .#dev` directly. The normal mvm path is `mvmctl build`, which runs Nix inside the builder VM. Output is a derivation with `passthru.mvm.{accessible, sealed, expectedBootMs}`. Check it from a Nix-enabled debug environment:
+If you intentionally manage your own Nix environment, you can run `nix build .#dev` directly. The normal mvm path is `mvmctl machine build`, which runs Nix inside the builder VM. Output is a derivation with `passthru.mvm.{accessible, sealed, expectedBootMs}`. Check it from a Nix-enabled debug environment:
 
 ```sh
 nix eval .#dev.passthru.mvm
 # { accessible = true; entrypointKind = "shell"; expectedBootMs = 300; ... }
 ```
 
-`mvmctl dev up` runs the same `nix build` under the hood and boots the result.
+`mvmctl machine run --flake . --flake-profile dev` runs the same `nix build` under the hood (if the artifact isn't already cached) and boots the result.
 
 ### Cross-platform build notes
 
-mvm runs Nix builds inside the project builder VM and copies the finished artifacts back to the host cache. You don't need Nix on your host, and you don't need to enter a dev shell before building. See [Builder VM](/guides/builder-vm/).
+mvm runs Nix builds inside the project builder VM and copies the finished artifacts back to the host cache. You don't need Nix on your host, and the builder VM is headless -- there's no shell to enter before building. See [Builder VM](/guides/builder-vm/).
 
 - **Linux** (with `/dev/kvm`): the builder VM owns image construction; Firecracker is the default runtime backend.
-- **macOS Apple Silicon**: the host `mvmctl build` command orchestrates the builder VM. The resulting dev image can then boot on the selected macOS runtime backend.
+- **macOS Apple Silicon**: the host `mvmctl machine build` command orchestrates the builder VM. The resulting dev image can then boot on the selected macOS runtime backend.
 - **Windows / WSL2**: WSL2 with nested `/dev/kvm` is supported for the libkrun-backed workload runtime path. Native Windows and a Hyper-V managed Linux builder are not supported local paths today.
 
 ## Why this is structured this way
@@ -159,7 +149,7 @@ The current shape:
 
 - mvm exposes `mvm.lib.<system>.mkGuest` — a stable function the library promises not to break.
 - Your project's flake calls `mkGuest` and exports a `.dev` package.
-- `mvmctl dev` reads `mvm.toml`, runs `nix build .#dev` against your flake, boots the result.
+- `mvmctl machine build` / `mvmctl machine run` read `mvm.toml`, run `nix build .#dev` against your flake, and build/boot the result.
 - mvm's internal layout (where `mkGuest` lives, what tests use it, etc.) can change freely without your project noticing.
 
 [Building MicroVM Images](/guides/building-microvm-images) covers the same model for production (sealed) images. The dev case is the same library with `entrypoint.shell` set.

--- a/public/src/content/docs/guides/kernels.md
+++ b/public/src/content/docs/guides/kernels.md
@@ -38,7 +38,7 @@ kernel cache entry.
 
 The compiled or downloaded kernel is cached at
 `~/.cache/mvm/builder-vm/<arch>/kernels/<variant>/vmlinux` and reused by every
-later `dev up`.
+later builder VM boot.
 
 When the kernel was compiled locally, the cache directory also carries a
 resolved `config` sidecar and `kernel-metrics-<arch>.json`, so you can inspect

--- a/public/src/content/docs/guides/macos-sandbox-debugging.md
+++ b/public/src/content/docs/guides/macos-sandbox-debugging.md
@@ -15,7 +15,6 @@ macOS is a supported local development target. Linux-specific build and runtime 
 ## Useful commands
 
 ```sh
-mvmctl dev status
 mvmctl doctor
 mvmctl machine logs <name>
 mvmctl boot-report <name>

--- a/public/src/content/docs/guides/nix-flakes.md
+++ b/public/src/content/docs/guides/nix-flakes.md
@@ -5,7 +5,7 @@ description: Create custom Nix flakes that build microVM images for mvm.
 
 mvmctl uses Nix flakes to produce reproducible microVM images. You run `mvmctl build` from the host, and mvm runs Nix evaluation and `nix build` inside the Linux builder VM. The result is a kernel and rootfs that can boot on any supported runtime backend, including Firecracker, Apple Virtualization, and libkrun.
 
-You do not need to enter a dev shell to build a flake. The dev shell is only for manually debugging the Linux build environment. See [Builder VM](/guides/builder-vm/) for the full host-vs-builder model.
+You do not need an interactive shell to build a flake — the builder VM is headless and has no shell at all. Debug a failed build from its log instead (`-v` streams it live; a failure names the log path). See [Builder VM](/guides/builder-vm/) for the full host-vs-builder model.
 
 ## Minimal Flake
 

--- a/public/src/content/docs/guides/troubleshooting.md
+++ b/public/src/content/docs/guides/troubleshooting.md
@@ -3,33 +3,29 @@ title: Troubleshooting
 description: Common issues and their solutions.
 ---
 
-## Builder VM and Dev Shell Issues
+## Builder VM Issues
 
-The builder VM is the Linux environment mvmctl uses for Nix evaluation and image builds. You normally do not enter it yourself: `mvmctl build --flake .` is a host command that stages work for the builder VM and copies artifacts back to the host cache. `mvmctl dev shell` is only for manual debugging. See [Builder VM](/guides/builder-vm/) for the full model.
+The builder VM is the Linux environment mvmctl uses for Nix evaluation and image builds. You never enter it: `mvmctl machine build --flake .` is a host command that stages work for the builder VM and copies artifacts back to the host cache. The builder VM is headless — debug a failed build from its log instead of a shell. See [Builder VM](/guides/builder-vm/) for the full model.
 
-### "Dev VM is not running"
+### Builder VM cache looks stuck or corrupted
 
-```
-Error: Dev VM is not running. Start it with: mvmctl dev up
-```
-
-**Fix**: `mvmctl dev up` (idempotent — installs Firecracker if missing, no-ops otherwise).
-
-### Dev VM is stuck
+The builder VM is managed automatically — there's no explicit "start it"
+step, and no `dev up` / `dev down` to cycle it. If a build behaves as though
+the builder VM's cache is wedged (stale store, half-built image), repair
+the cache instead:
 
 ```bash
-mvmctl dev down
-mvmctl dev up
+mvmctl cache repair
 ```
 
-If that fails, rebuild from scratch:
-```bash
-mvmctl dev rebuild
-```
+`cache repair` clears the degraded builder VM store so the next build
+cold-rebuilds it; it auto-stops a running builder VM first, and refuses
+while a Stage 0 bootstrap is in flight (`--force` only if that lock is
+stale, e.g. after a crash).
 
-Or for a full reset:
+For a full reset:
 ```bash
-mvmctl uninstall
+mvmctl env uninstall
 mvmctl bootstrap
 ```
 
@@ -46,10 +42,10 @@ mvmctl doctor
 # directories and probes each daemon's control socket.
 ```
 
-- **Daemon absent / socket not answering**: the builder VM may not be up. Run
-  `mvmctl dev up`, then re-check `mvmctl doctor`.
-- **Still not ready after `dev up`**: recycle the builder VM with `mvmctl dev
-  down && mvmctl dev up`; if it persists, `mvmctl dev rebuild`.
+- **Daemon absent / socket not answering**: the builder VM may not be up yet.
+  Run `mvmctl bootstrap`, then re-check `mvmctl doctor`.
+- **Still not ready after `bootstrap`**: repair the builder VM's cache with
+  `mvmctl cache repair`, then let the next build re-warm it.
 
 A build job can be cancelled from the host; the daemon stops the in-flight
 operation and returns a cancellation result rather than leaving a wedged build.
@@ -70,10 +66,10 @@ isolation) can panic in the libkrun guest during virtio device activation,
 before userspace. The Stage 0 device topology is identical to a warm build, so
 this is not a device-count problem; it surfaces in the upstream VMM's
 device-activation path under the bundled Stage 0 kernel. It does **not** occur on
-a normal cold `mvmctl dev up` against the default cache.
+a normal cold `mvmctl bootstrap` against the default cache.
 
 **Fix**: Don't run a builder bootstrap against a fully-isolated empty cache. Use
-the default cache, or pre-warm the builder once (`mvmctl dev up` with the default
+the default cache, or pre-warm the builder once (`mvmctl bootstrap` with the default
 cache) before pointing a test at an isolated `MVM_DATA_DIR`. If you must isolate,
 let the run share the default `MVM_CACHE_DIR` so the builder VM image and nix
 store are reused rather than rebuilt from zero. A contributor host with
@@ -95,11 +91,11 @@ mvmctl machine logs <name> --hypervisor   # Firecracker logs
 
 **Cause**: Insufficient permissions or TAP device name collision.
 
-**Fix**:
-```bash
-# Check for orphaned TAP devices (inside the dev VM)
-mvmctl dev shell -- ip link show | grep tap
-```
+**Fix**: There's no shell into the builder VM anymore to inspect its TAP
+interface directly. `mvmctl doctor` reports the active network backend; if
+you suspect a wedged TAP allocation, `mvmctl cache repair` clears the
+builder VM's store (stopping a running builder VM first), so the next
+build starts from a clean network setup.
 
 ### Instance won't start after sleep
 
@@ -116,13 +112,14 @@ mvmctl machine run --flake <project-dir> --name <name> -d
 ### Nix build fails
 
 ```bash
-# Re-run the normal host-orchestrated build.
-mvmctl build --flake .
-
-# If you need an interactive Linux debug environment:
-mvmctl dev shell
-nix build .#default
+# Re-run the normal host-orchestrated build, streaming the Nix log live.
+mvmctl machine build --flake . -v
 ```
+
+There's no interactive Linux debug environment to drop into — the `-v`
+output above is the same `nix build` transcript a shell session would have
+shown you. A failed build's error message also names the on-disk log path
+if you want the full transcript after the fact.
 
 ### "Cache miss" rebuilds
 
@@ -148,16 +145,21 @@ mvmctl build --flake .
 error: No space left on device
 ```
 
-**Cause**: The Nix store or dev VM disk is full.
+**Cause**: The Nix store or builder VM disk is full.
 
 **Fix**:
 ```bash
 # Check Nix store size (mvmctl doctor warns if >20 GiB)
 mvmctl doctor
 
-# For manual cleanup inside a debug shell:
-mvmctl dev shell
-nix-collect-garbage -d
+# Clear the builder VM's store entirely (no shell to run a surgical
+# nix-collect-garbage inside it anymore; the next build re-populates
+# only what it needs).
+mvmctl cache repair
+
+# Also reclaim host-side regenerable caches (Stage 0 blobs, the
+# default microVM image, pulled OCI layers).
+mvmctl cache prune --deep
 ```
 
 ### Hash mismatch (fixed-output derivation)
@@ -284,27 +286,37 @@ mvmctl machine stop  <N>          # tear it down (prompts; add --yes to skip)
 
 ### MicroVM has no internet
 
-```bash
-# Inside the dev VM, check NAT rules
-mvmctl dev shell -- sudo iptables -t nat -L
+There's no shell into the builder or workload VM to check NAT rules or TAP
+devices directly anymore. Start with:
 
-# Check the TAP device exists
-mvmctl dev shell -- ip link show tap0
+```bash
+mvmctl doctor              # reports the active network backend
+mvmctl machine logs <name> # guest console output, including boot-time network setup
 ```
+
+Workload networking is deny-by-default; if the guest simply has no policy
+grant, see [Network egress policy](/guides/network-egress-policy/) for
+`--net` / `--allow-host`.
 
 ### Can't access project files inside microVM
 
-The Firecracker microVM has an **isolated filesystem**. Use `mvmctl dev shell` to access the dev VM where your home directory is mounted, or pass host shares with `--mount`.
+The Firecracker microVM has an **isolated filesystem** by design. Pass host
+directories in explicitly with `--mount` (`mvmctl machine run --mount
+HOST:GUEST`) — there's no shell into a build-time VM to reach them another way.
 
 ## Performance Issues
 
-### Dev VM is slow
+### Builder VM feels slow
 
-Adjust resources (or persist the override with `mvmctl config set dev_vm_cpus 8 && mvmctl config set dev_vm_mem_gib 16`):
+Adjust its default resources:
 ```bash
-mvmctl dev down
-mvmctl dev up --cpus 8 --memory 16
+mvmctl ops config set dev_vm_cpus 8
+mvmctl ops config set dev_vm_mem_gib 16
 ```
+
+There's no explicit up/down cycle to apply it — the new sizing takes effect
+the next time the builder VM (re)boots, which `mvmctl bootstrap` or your
+next build triggers for you.
 
 ### Wrong backend selected
 
@@ -411,7 +423,7 @@ Plan 36 pins `manifest.version` to `mvmctl --version` exactly. Either:
 
 SHA-256 of the downloaded artifact doesn't match the manifest's recorded digest. Possible causes, in order:
 
-1. Mid-flight corruption — retry `mvmctl dev up` to re-download.
+1. Mid-flight corruption — retry `mvmctl bootstrap` to re-download.
 2. Mirror/CDN cache poisoning — rare but real; open a security issue with the SHA-256 you got vs what the manifest says.
 3. The release was re-uploaded after the manifest was signed (publishing process bug) — wait for the next tag.
 

--- a/public/src/content/docs/guides/verify-release.md
+++ b/public/src/content/docs/guides/verify-release.md
@@ -179,9 +179,9 @@ A compromised CDN or GitHub Releases page cannot forge a valid signature without
 
 ## Verifying the Dev Image and Builder Image Manifests (plan 36)
 
-Starting with the plan-36 work, every release also publishes a cosign-keyless-signed manifest for the dev image (consumed by `mvmctl dev up`) and the builder image (consumed by mvmd's pool-build pipeline). The manifest is the trust anchor — it carries SHA-256 of every image artifact, the Nix store hash, the source git SHA, and the SHA-256 of every flake lockfile, all bound by one cosign signature.
+Starting with the plan-36 work, every release also publishes a cosign-keyless-signed manifest for the dev image (consumed automatically whenever the builder VM image is fetched — via `mvmctl bootstrap` or auto-bootstrap on the first build) and the builder image (consumed by mvmd's pool-build pipeline). The manifest is the trust anchor — it carries SHA-256 of every image artifact, the Nix store hash, the source git SHA, and the SHA-256 of every flake lockfile, all bound by one cosign signature.
 
-mvmctl verifies these automatically on every `mvmctl dev up`. To verify manually:
+mvmctl verifies these automatically every time it fetches the builder VM image. To verify manually:
 
 ```bash
 VERSION=v0.14.0  # replace with the release you're verifying
@@ -207,11 +207,11 @@ jq -r '.artifacts[] | "\(.sha256)  \(.name)"' "${VARIANT}-image-${ARCH}.manifest
 
 ### Air-gapped install
 
-`mvmctl dev import-image` runs the same verification against local files for hosts that can't reach github.com. See [Air-gapped Bootstrap](airgapped-bootstrap) for the operator workflow.
+Air-gapped hosts that can't reach github.com need this same verification run against local files instead of a network fetch. See [Air-gapped Bootstrap](airgapped-bootstrap) for the current status of that path.
 
 ### Recall (revocation list)
 
-A separate `revocations` release tag publishes a cosign-signed `revoked-versions.json`. mvmctl checks this list on every `dev up` and refuses to use any image whose version is recalled. The recall reason is surfaced verbatim in the failure message, pointing at the upgrade path.
+A separate `revocations` release tag publishes a cosign-signed `revoked-versions.json`. mvmctl checks this list every time it fetches or verifies the builder VM image and refuses to use any image whose version is recalled. The recall reason is surfaced verbatim in the failure message, pointing at the upgrade path.
 
 ```bash
 curl -LO "https://github.com/tinylabscom/mvm/releases/download/revocations/revoked-versions.json"

--- a/public/src/content/docs/install/macos.md
+++ b/public/src/content/docs/install/macos.md
@@ -86,7 +86,7 @@ If you configure [`nix-darwin`'s `linux-builder`](https://nix.dev/manual/nix/sta
 mvmctl doctor
 ```
 
-`doctor` reports the active backend and libkrun availability. On an Apple Silicon Mac with macOS 26+, the dev path uses the HVF builder; source image builds auto-detect the builder backend (HVF on macOS 26+ Apple Silicon), and `mvmctl dev up` retries with libkrun when the HVF builder path fails. Explicit `--builder` / `MVM_BUILDER_BACKEND` overrides still win.
+`doctor` reports the active backend and libkrun availability. On an Apple Silicon Mac with macOS 26+, builds auto-detect the builder backend (HVF on macOS 26+ Apple Silicon), and the auto-fallback retries with libkrun when the HVF builder path fails. Explicit `--builder` / `MVM_BUILDER_BACKEND` overrides still win.
 
 ## First microVM
 

--- a/public/src/content/docs/llms-index.md
+++ b/public/src/content/docs/llms-index.md
@@ -89,6 +89,6 @@ template: doc
 
 - Strong claims need Shipped/Preview/Planned/Not claimed status.
 - Runtime SDK lifecycle APIs are Partial until shared SDK tests cover the full lifecycle.
-- Persistent builder DX is Preview until top-level `dev up` and `build` behavior is proven.
+- Persistent builder DX is Preview until top-level `bootstrap` and `build` behavior is proven.
 - OCI examples should use digest-pinned or clearly local/dev references.
 - Secret examples should use references or redacted example values, not plaintext credentials.

--- a/public/src/content/docs/reference/guest-agent.md
+++ b/public/src/content/docs/reference/guest-agent.md
@@ -170,7 +170,7 @@ sent to a sealed-prod agent are rejected before any handler runs:
 | Profile | Effective verb set | Used by |
 |---------|-------------------|---------|
 | `sealed-prod` (default) | Lifecycle, status, entrypoint, sleep/wake, volume mount/unmount, idle-timeout updates. The full ADR-002 production-safe surface. | Production images. The policy file lives on a dm-verity rootfs (ADR-002 §W3) so the profile cannot be widened at runtime. |
-| `dev` | `sealed-prod` plus shell `Exec`, process RPC, filesystem RPC, console PTY, port forwarding, and `RunCode`. | `mvmctl dev` images and any image built with `dev-shell` feature. |
+| `dev` | `sealed-prod` plus shell `Exec`, process RPC, filesystem RPC, console PTY, port forwarding, and `RunCode`. | Accessible (`entrypoint.shell`) images, and any image built with the `dev-shell` feature. |
 | `builder` | Reserved for builder-only verbs. The current builder agent speaks a separate `BuilderRequest` protocol, so this profile is wire-stable but unused for the tenant agent. | Future builder VM agent if/when its verbs land on the tenant wire. |
 
 Rejected requests return a typed `UnsupportedInProfile` response:

--- a/public/src/content/docs/security/claim-ledger.md
+++ b/public/src/content/docs/security/claim-ledger.md
@@ -16,7 +16,7 @@ For sandbox-parity claims, the detailed status table lives in [Sandbox parity st
 | `runtime-sdk-lifecycle` | Planned | Python, TypeScript, and Rust lifecycle APIs pass shared create/exec/files/logs/snapshot/stop tests. |
 | `secure-sandbox-product-parity` | Planned | [Plan 114](https://github.com/tinylabscom/mvm/blob/main/specs/plans/114-secure-sandbox-product-parity.md) tracks parity capability by capability without copying another product's runtime architecture. |
 | `builder-vm-secure-builds` | Shipped | [Builder VM](/guides/builder-vm/) documents host-orchestrated Linux builds; source-checkout cache reuse and bootstrap policy are covered by current CLI behavior. |
-| `persistent-builder-dx` | Preview | Low-level `persistent-builder` controls and build routing exist; top-level `cargo run -- dev up` and `cargo run -- build` docs must match the actual command behavior before this becomes Shipped. |
+| `persistent-builder-dx` | Preview | Low-level `persistent-builder` controls and build routing exist; top-level `cargo run -- bootstrap` and `cargo run -- build` docs must match the actual command behavior before this becomes Shipped. |
 | `cold-mode-snapshot-recovery` | Preview | Firecracker sealed pause/resume and pool Sleeping/Running paths exist; full-VM save/restore is currently unsupported on macOS (Firecracker-only, on Linux) pending HVF save/restore. Docs must name backend support and restore semantics. |
 | `platform-linux-macos` | Shipped | Local docs name Linux execution and macOS as the supported targets and keep Windows in the future/issue-tracked bucket. |
 | `platform-windows` | Planned | Windows docs link [mvm#428](https://github.com/tinylabscom/mvm/issues/428) and avoid implying shipped local runtime support. |


### PR DESCRIPTION
Companion to #1667 (removes `mvmctl dev`). Reframes the public guides off the removed interactive dev-shell workflow onto the headless-builder reality. (CLAUDE.md + the CLI reference were done in #1667; this is the getting-started + guides set.)

## Reframe
- `mvmctl dev up` / "start the dev environment" → `mvmctl bootstrap` (optional pre-warm; the builder VM also boots automatically on first `build`/`machine run`).
- `mvmctl dev shell` → gone; **debug builds from their logs** (the build log path is printed; `-v` streams).
- `mvmctl dev status` → `mvmctl doctor`; `mvmctl dev down` → managed automatically (`mvmctl cache prune`/`repair` for cache issues).

19 files (+185/-201): the getting-started "start here" set rewritten coherently (not just find-replaced), plus the guides/reference/security/contributing pages. Claim-15 / workload-console / `dev-shell`-feature content left intact (that's a separate, still-accurate thing).

## Flagged for a maintainer decision
- **`guides/dev-image.md`** — reworked (kept the valid `mkGuest`/accessible-image content, dropped the now-unreplicable "default dev image" fallback). Consider folding it into `building-microvm-images.md`.
- **`guides/airgapped-bootstrap.md`** — `mvmctl dev import-image` has **no successor command**; added a `:::caution` rather than inventing one. This is the real air-gapped capability gap (deferred follow-up #3), surfaced honestly in the docs.

## Noticed but out of scope (separate passes)
- Bare `mvmctl build --flake` no longer parses site-wide (Plan 208, unrelated to dev removal) — worth its own doc pass.
- Two `.rs` help-text doc-comments still cite `dev up` (known deferred code-comment cleanup).