### PR TITLE
Fix doctor HVF reporting and quiet failures

### DIFF
--- a/crates/mvm-cli/src/doctor.rs
+++ b/crates/mvm-cli/src/doctor.rs
@@ -226,7 +226,7 @@ fn runtime_backend_check(plat: platform::Platform) -> Check {
         Platform::Wsl2 => "WSL2 — a workload runtime needs nested /dev/kvm; without it \
              only `qemu` (dev/test only, no claim-10) runs"
             .to_string(),
-        Platform::MacOS => "macOS — `vz` (macOS 26+) or `libkrun` (macOS 13-25) \
+        Platform::MacOS => "macOS — `hvf` (macOS 26+ Apple Silicon) or `libkrun` (macOS 13-25) \
              workload backends, selectable via `--hypervisor`"
             .to_string(),
         Platform::Windows => "Windows — no local microVM workload path yet".to_string(),
@@ -774,8 +774,8 @@ pub fn run(json: bool, workflow: Option<DoctorWorkflow>) -> Result<()> {
     if !report.all_ok {
         let missing: Vec<&Check> = report.checks.iter().filter(|c| !c.ok).collect();
         ui::warn("\nIssues found:");
-        for m in &missing {
-            ui::info(&format!("  {} — {}", m.name, m.info));
+        for line in issue_summary_lines(&missing) {
+            ui::warn(&line);
         }
 
         // Provide category-specific guidance
@@ -783,10 +783,10 @@ pub fn run(json: bool, workflow: Option<DoctorWorkflow>) -> Result<()> {
         let has_managed = missing.iter().any(|c| c.category == "tools");
 
         if has_prerequisites {
-            ui::info("\nPrerequisites missing: Install Rust from https://rustup.rs");
+            ui::notice("\nPrerequisites missing: Install Rust from https://rustup.rs");
         }
         if has_managed {
-            ui::info("\nManaged tools missing: Run 'mvmctl bootstrap' to install");
+            ui::notice("\nManaged tools missing: Run 'mvmctl bootstrap' to install");
         }
 
         anyhow::bail!("doctor found issues");
@@ -827,6 +827,13 @@ fn render_text(report: &DoctorReport) {
     render_balloon_support(&report.balloon_support);
     render_warm_start_support(&report.warm_start);
     render_capability_table(&report.capability_table);
+}
+
+fn issue_summary_lines(missing: &[&Check]) -> Vec<String> {
+    missing
+        .iter()
+        .map(|check| format!("  {} — {}", check.name, check.info))
+        .collect()
 }
 
 /// Enumerate every backend's `capabilities().balloon`. The doctor
@@ -3556,6 +3563,52 @@ mod tests {
         // `all_ok` over the filtered set is `true`.
         let all_ok_filtered = filtered.iter().all(|c| c.ok);
         assert!(all_ok_filtered);
+    }
+
+    #[test]
+    fn issue_summary_lines_include_every_failed_check() {
+        let missing = [
+            Check {
+                name: "cargo",
+                category: "prerequisites",
+                ok: false,
+                info: "missing".into(),
+            },
+            Check {
+                name: "disk space",
+                category: "platform",
+                ok: false,
+                info: "only 2 GiB free".into(),
+            },
+        ];
+        let refs: Vec<&Check> = missing.iter().collect();
+
+        let lines = issue_summary_lines(&refs);
+
+        assert_eq!(
+            lines,
+            vec![
+                "  cargo — missing".to_string(),
+                "  disk space — only 2 GiB free".to_string(),
+            ]
+        );
+    }
+
+    #[test]
+    fn runtime_backend_check_macos_reports_hvf_not_vz() {
+        let c = runtime_backend_check(Platform::MacOS);
+        assert!(c.ok);
+        assert!(c.info.contains("`hvf`"), "got: {}", c.info);
+        assert!(
+            c.info.contains("`libkrun`"),
+            "expected libkrun fallback in macOS summary; got: {}",
+            c.info
+        );
+        assert!(
+            !c.info.contains("`vz`"),
+            "stale Vz wording must not remain in runtime backend summary: {}",
+            c.info
+        );
     }
 
     // ── builder-backend check format on Linux ──


### PR DESCRIPTION
## What changed
- corrected the macOS `mvmctl doctor` runtime-backend summary to report `hvf` for macOS 26+ Apple Silicon instead of stale `vz` wording
- made failed doctor checks print in quiet mode by routing the per-issue summary through always-visible UI helpers
- added regression coverage for both the quiet failure-summary formatting and the macOS HVF wording

## Why
`mvmctl doctor` could exit nonzero with `Issues found:` while hiding the actual failing checks unless `--verbose` was enabled. Separately, the human-readable macOS runtime-backend line still mentioned `vz` even though HVF is the current backend.

## Impact
Operators now get actionable doctor output in default quiet mode, and the runtime summary matches current macOS backend behavior.

## Validation
- `source scripts/dev-env.sh && cargo test -p mvm-cli runtime_backend_check_macos_reports_hvf_not_vz -- --nocapture`
- `source scripts/dev-env.sh && cargo test -p mvm-cli issue_summary_lines_include_every_failed_check -- --nocapture`
