### PR TITLE
fix(build): scope host-binary manifest parse to HOST_BINARIES

### DIFF
--- a/crates/mvm-cli/build.rs
+++ b/crates/mvm-cli/build.rs
@@ -325,13 +325,7 @@ fn resolve_target_for_arch(toolchain: &toml::Value, arch: &str) -> String {
 fn read_rust_manifest(root: &Path) -> Vec<String> {
     let src =
         std::fs::read_to_string(root.join("crates/mvm-cli/src/host_binaries/manifest.rs")).unwrap();
-    let mut out = Vec::new();
-    for line in src.lines() {
-        if let Some(n) = extract_quoted_after(line, "name:") {
-            out.push(n);
-        }
-    }
-    out
+    build_aux_helpers::parse_host_binary_names(&src)
 }
 
 /// Parse the bare-string array `pub const SEED_BINARIES: &[&str] = &[ ... ]`
@@ -359,14 +353,6 @@ fn read_seed_binaries(root: &Path) -> Vec<String> {
 }
 
 /// Extract the first double-quoted string on `line` that appears after `key`.
-fn extract_quoted_after(line: &str, key: &str) -> Option<String> {
-    let i = line.find(key)? + key.len();
-    let rest = &line[i..];
-    let q1 = rest.find('"')? + 1;
-    let q2 = rest[q1..].find('"')?;
-    Some(rest[q1..q1 + q2].to_string())
-}
-
 fn run_cargo_zigbuild(
     root: &Path,
     target_dir: &Path,
@@ -530,15 +516,6 @@ mod tests {
             strip_glibc("aarch64-unknown-linux-gnu"),
             "aarch64-unknown-linux-gnu"
         );
-    }
-
-    #[test]
-    fn extract_quoted_after_basic() {
-        assert_eq!(
-            extract_quoted_after(r#"        name: "mvm-host-vm-init","#, "name:"),
-            Some("mvm-host-vm-init".to_string())
-        );
-        assert_eq!(extract_quoted_after("no key here", "name:"), None);
     }
 
     #[test]

--- a/crates/mvm-cli/build_aux_helpers.rs
+++ b/crates/mvm-cli/build_aux_helpers.rs
@@ -62,9 +62,70 @@ pub(crate) fn should_skip_aux_helpers(skip_env: Option<&str>) -> bool {
     matches!(skip_env, Some("1"))
 }
 
+/// Extract the quoted string after `key` on one line, e.g.
+/// `name: "mvm-host-vm-init",` + `"name:"` → `Some("mvm-host-vm-init")`.
+pub(crate) fn extract_quoted_after(line: &str, key: &str) -> Option<String> {
+    let i = line.find(key)? + key.len();
+    let rest = &line[i..];
+    let q1 = rest.find('"')? + 1;
+    let q2 = rest[q1..].find('"')?;
+    Some(rest[q1..q1 + q2].to_string())
+}
+
+/// Names in the `HOST_BINARIES` array of `manifest.rs` only — these are the
+/// `-p mvm-build` binaries embedded per-bin. The `SourceBuiltBinary` lists that
+/// follow (e.g. `BOOTSTRAP_SUPPORT_BINARIES`) carry their own owning `package`
+/// and are cross-compiled by the combined guest invocation, so their names must
+/// NOT be swept into the per-bin loop — otherwise the embed build fails with
+/// `no bin target named <name> in mvm-build`. Scoped to the `HOST_BINARIES`
+/// block for exactly that reason (mirrors the `SEED_BINARIES` scan).
+pub(crate) fn parse_host_binary_names(src: &str) -> Vec<String> {
+    let start = src
+        .find("HOST_BINARIES")
+        .expect("HOST_BINARIES array in manifest.rs");
+    let rest = &src[start..];
+    let end = rest.find("];").map(|i| i + 2).unwrap_or(rest.len());
+    rest[..end]
+        .lines()
+        .filter_map(|line| extract_quoted_after(line, "name:"))
+        .collect()
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn extract_quoted_after_reads_the_quoted_value() {
+        assert_eq!(
+            extract_quoted_after(r#"        name: "mvm-host-vm-init","#, "name:"),
+            Some("mvm-host-vm-init".to_string())
+        );
+        assert_eq!(extract_quoted_after("no key here", "name:"), None);
+    }
+
+    #[test]
+    fn parse_host_binary_names_excludes_source_built_lists() {
+        // HOST_BINARIES are `-p mvm-build` bins; the SourceBuiltBinary lists
+        // that follow carry their own `package` and are built separately, so
+        // their `name:`s must not be swept into the per-bin loop.
+        let src = r#"
+pub const HOST_BINARIES: &[HostBinary] = &[
+    HostBinary { name: "mvm-host-vm-init", install_path: "/sbin/mvm-host-vm-init", mode: 0o755 },
+    HostBinary { name: "mvm-builderd", install_path: "/sbin/mvm-builderd", mode: 0o755 },
+];
+pub const SEED_BINARIES: &[&str] = &["stage0-init"];
+pub const BOOTSTRAP_SUPPORT_BINARIES: &[SourceBuiltBinary] = &[SourceBuiltBinary {
+    package: "mvm-guest-helpers",
+    name: "mvm-egress-client",
+}];
+"#;
+        assert_eq!(
+            parse_host_binary_names(src),
+            vec!["mvm-host-vm-init".to_string(), "mvm-builderd".to_string()]
+        );
+        assert!(!parse_host_binary_names(src).contains(&"mvm-egress-client".to_string()));
+    }
 
     #[test]
     fn hostd_helpers_include_substitution_endpoint_and_tunnel_worker() {


### PR DESCRIPTION
## Problem

`MVM_EMBED_BINARIES=1 cargo build` fails on current main with:

```
[build.rs] cargo zigbuild ... -p mvm-build --bin mvm-egress-client
error: no bin target named `mvm-egress-client` in `mvm-build` package
```

This breaks every real embedded build (release artifacts, and any `--builder libkrun/qemu` build that needs a Stage-0 rebuild), because the resulting `mvmctl` embeds zero-byte stubs.

## Root cause

The runtime-overlay work added `BOOTSTRAP_SUPPORT_BINARIES` to `crates/mvm-cli/src/host_binaries/manifest.rs`, declaring `mvm-egress-client` with an explicit `package: "mvm-guest-helpers"`. But `build.rs`'s `read_rust_manifest` sweeps **every** `name:` line in the file into the per-binary loop, which builds each as `cargo zigbuild -p mvm-build --bin <name>`. `mvm-egress-client` lives in `mvm-guest-helpers` (and is already built by the combined guest invocation), so the per-bin build errors.

## Fix

Scope the parse to the `HOST_BINARIES` block only (mirrors the existing `SEED_BINARIES` scan). `SourceBuiltBinary` lists carry their own `package` and are cross-compiled separately, so their names must not leak into the `-p mvm-build` loop.

Also moves `parse_host_binary_names` + `extract_quoted_after` into `build_aux_helpers` so the added regression test actually runs — the `build.rs`-local `mod tests` is never compiled by `cargo test`.

## Verification

- `MVM_EMBED_BINARIES=1 cargo build --bin mvmctl` now finishes (no `mvm-egress-client` error).
- New tests `parse_host_binary_names_excludes_source_built_lists` + `extract_quoted_after_reads_the_quoted_value` run and pass via the `build_aux_helpers` test shim.
- `cargo build -p mvm-cli` clean; touched files clippy-clean.