### PR TITLE
Dev-removal followups: reword stale code comments + Plan 249 (larger deferred items)

### DIFF
--- a/crates/deps/libkrun-sys/examples/libkrun-smoke.rs
+++ b/crates/deps/libkrun-sys/examples/libkrun-smoke.rs
@@ -5,7 +5,7 @@
 //!   cargo build --example libkrun-smoke -p mvm-libkrun --features libkrun-sys
 //!
 //! Run (defaults pull from `~/.mvm/dev/current/`, the dev-VM artifacts
-//! shipped by `mvmctl dev up`):
+//! materialized by `mvmctl bootstrap`):
 //!   target/debug/examples/libkrun-smoke
 //!
 //! Override any path:

--- a/crates/deps/libkrun-sys/src/lib.rs
+++ b/crates/deps/libkrun-sys/src/lib.rs
@@ -1139,7 +1139,7 @@ fn configure_pre_net(ctx: &KrunContext) -> Result<sys::Context, Error> {
         // listener socket behind — the stop path doesn't unlink it —
         // and add_vsock_port2(listen=true) binds here, failing EEXIST
         // (rc -17) on the stale file. Pre-unlink, mirroring the native-gateway
-        // bridge socket above. Keeps `dev up` idempotent across runs.
+        // bridge socket above. Keeps repeated builder VM starts idempotent.
         let _ = std::fs::remove_file(&socket);
         krun.add_vsock_port2(port, &socket, /* listen = */ true)?;
     }

--- a/crates/deps/libkrun-sys/src/native_gateway.rs
+++ b/crates/deps/libkrun-sys/src/native_gateway.rs
@@ -61,7 +61,7 @@ pub const SHUTDOWN_GRACE: Duration = Duration::from_secs(2);
 /// How long [`spawn`] waits for the native gateway's listener socket to appear
 /// on disk. The gateway creates the file within ~tens of milliseconds on
 /// macOS Apple Silicon (no `bind(2)` blocking). 500ms is generous
-/// without measurably slowing `dev up`.
+/// without measurably slowing builder VM startup.
 pub const SOCKET_READY_TIMEOUT: Duration = Duration::from_millis(500);
 
 /// Default MAC for the guest's `eth0`. Locally-administered (bit
@@ -272,8 +272,8 @@ pub fn spawn(
     // via `Command::output()`) blocks forever — the gateway keeps the pipe
     // open for the life of the VM (and beyond, since libkrun's exit() on
     // guest shutdown skips `NativeGatewayHandle::Drop`, orphaning it). That fd
-    // inheritance is exactly what hung `core_demo_e2e`: `dev up`'s build
-    // VM powered down, mvmctl exited, but the orphaned gateway held the
+    // inheritance is exactly what hung `core_demo_e2e`: the builder VM
+    // powered down, mvmctl exited, but the orphaned gateway held the
     // pipe so `output()` never saw EOF.
     //
     // Redirect both streams to a per-VM capture file instead. This still

--- a/crates/deps/libkrun-sys/src/passt.rs
+++ b/crates/deps/libkrun-sys/src/passt.rs
@@ -247,7 +247,7 @@ pub fn spawn(scratch_dir: &std::path::Path) -> Result<PasstHandle, PasstError> {
     // it died, surface that instead of letting libkrun fail with
     // a cryptic socket error later. 50ms is enough to catch the
     // immediate exits (missing arg, spawn failure) without
-    // measurably slowing dev up.
+    // measurably slowing builder VM startup.
     std::thread::sleep(Duration::from_millis(50));
     let mut child = child;
     if let Some(status) = child.try_wait().map_err(PasstError::Spawn)? {

--- a/crates/mvm-backend/src/base/linux_env.rs
+++ b/crates/mvm-backend/src/base/linux_env.rs
@@ -105,8 +105,8 @@ fn is_stdin_tty() -> bool {
     unsafe { libc::isatty(std::io::stdin().as_raw_fd()) == 1 }
 }
 
-/// Name of the dev VM. `mvmctl dev up` boots it as the libkrun dev VM
-/// under `~/.mvm/vms/mvm-dev`; this is the display name the dev env carries.
+/// Name of the dev VM: it runs as the libkrun dev VM under
+/// `~/.mvm/vms/mvm-dev`; this is the display name the dev env carries.
 const DEV_VM_NAME: &str = "mvm-dev";
 
 /// Connect to the libkrun dev VM's guest-agent vsock through its per-port

--- a/crates/mvm-backend/src/base/linux_env.rs
+++ b/crates/mvm-backend/src/base/linux_env.rs
@@ -309,6 +309,53 @@ pub fn create_linux_env() -> Box<dyn LinuxEnv> {
     Box::new(NativeEnv)
 }
 
+/// Whether a `run_in_vm`-style guest op can reach a real Linux execution
+/// environment today.
+///
+/// True on native Linux and macOS 13-25, both of which [`create_linux_env`]
+/// resolves to [`NativeEnv`]. False only on macOS 26+ Apple Silicon, where
+/// [`create_linux_env`] hands back [`DevVmEnv`] and — since the dev-VM
+/// auto-start path was retired (see [`start_dev_daemon`]) — a `run_in_vm`
+/// call has nothing left to dispatch to. Guest ops that still need a Linux
+/// builder on that tier should check this and fail closed via
+/// [`require_guest_exec_available`] instead of attempting the doomed call.
+pub fn guest_exec_via_vm_available() -> bool {
+    !platform::current().is_vz_default_tier()
+}
+
+/// Fails closed with an actionable error naming `limitation` when
+/// [`guest_exec_via_vm_available`] is false; otherwise a no-op.
+///
+/// Callers hold a `run_in_vm`-backed op that has no builder to run against
+/// on the current tier; this lets them return an upfront, honest error
+/// instead of letting the call fail deep inside the vsock exec path.
+pub fn require_guest_exec_available(limitation: &str) -> Result<()> {
+    guest_exec_gate(guest_exec_via_vm_available(), limitation)
+}
+
+/// Pure decision behind [`require_guest_exec_available`], taking the
+/// availability bool directly so it (and callers' gates) can be
+/// unit-tested by forcing both branches, without faking the host's OS tier.
+fn guest_exec_gate(available: bool, limitation: &str) -> Result<()> {
+    if available {
+        return Ok(());
+    }
+    Err(guest_exec_unavailable_error(limitation))
+}
+
+/// Build the actionable error a gated guest op returns once
+/// [`guest_exec_via_vm_available`] is false. `limitation` is a short clause
+/// naming what the op needs (e.g. "needs an ext4 reader, which doesn't
+/// exist yet"); the workaround text is centralized here so it can't drift
+/// between call sites.
+pub fn guest_exec_unavailable_error(limitation: &str) -> anyhow::Error {
+    anyhow::anyhow!(
+        "{limitation}. This macOS tier has no Linux builder to run it against \
+         — run it on Linux or in CI, or start a persistent libkrun builder \
+         manually as a workaround."
+    )
+}
+
 /// Global default environment used by `shell.rs` free functions.
 static DEFAULT_ENV: OnceLock<Box<dyn LinuxEnv>> = OnceLock::new();
 
@@ -459,5 +506,40 @@ mod tests {
             .expect("sh");
         assert!(out.status.success(), "stderr: {:?}", out.stderr);
         assert_eq!(String::from_utf8_lossy(&out.stdout).trim(), "ok");
+    }
+
+    // ── guest_exec gating ───────────────────────────────────────────
+
+    #[test]
+    fn guest_exec_via_vm_available_is_negation_of_vz_default_tier() {
+        assert_eq!(
+            guest_exec_via_vm_available(),
+            !platform::current().is_vz_default_tier()
+        );
+    }
+
+    /// The gate's decision is forced through the same bool
+    /// [`guest_exec_via_vm_available`] feeds, so both branches are
+    /// covered without needing to fake the host's OS tier.
+    #[test]
+    fn guest_exec_gate_passes_when_available() {
+        assert!(guest_exec_gate(true, "irrelevant").is_ok());
+    }
+
+    #[test]
+    fn guest_exec_gate_fails_closed_naming_limitation_and_workaround() {
+        let err = guest_exec_gate(false, "needs an ext4 reader, which doesn't exist yet")
+            .expect_err("must fail closed when unavailable");
+        let msg = err.to_string();
+        assert!(msg.contains("ext4 reader"), "missing limitation: {msg}");
+        assert!(msg.contains("Linux"), "missing Linux workaround: {msg}");
+        assert!(msg.contains("libkrun"), "missing libkrun workaround: {msg}");
+    }
+
+    #[test]
+    fn require_guest_exec_available_matches_gate() {
+        let available = guest_exec_via_vm_available();
+        let result = require_guest_exec_available("doing a thing");
+        assert_eq!(result.is_ok(), available);
     }
 }

--- a/crates/mvm-backend/src/base/linux_env.rs
+++ b/crates/mvm-backend/src/base/linux_env.rs
@@ -351,8 +351,7 @@ fn guest_exec_gate(available: bool, limitation: &str) -> Result<()> {
 pub fn guest_exec_unavailable_error(limitation: &str) -> anyhow::Error {
     anyhow::anyhow!(
         "{limitation}. This macOS tier has no Linux builder to run it against \
-         — run it on Linux or in CI, or start a persistent libkrun builder \
-         manually as a workaround."
+         — run it on Linux or in CI."
     )
 }
 
@@ -533,7 +532,6 @@ mod tests {
         let msg = err.to_string();
         assert!(msg.contains("ext4 reader"), "missing limitation: {msg}");
         assert!(msg.contains("Linux"), "missing Linux workaround: {msg}");
-        assert!(msg.contains("libkrun"), "missing libkrun workaround: {msg}");
     }
 
     #[test]

--- a/crates/mvm-backend/src/image.rs
+++ b/crates/mvm-backend/src/image.rs
@@ -747,14 +747,21 @@ ls -lh "$IMAGES_DIR/{name}.$(uname -m).elf"
 /// directory.
 ///
 /// Used by `mvmctl exec --add-dir host:guest` to share a host directory
-/// into a transient microVM without virtio-fs. The image is created inside
-/// the Linux build environment (Lima VM on macOS, host on Linux) and sized
-/// from the directory's actual contents plus headroom.
+/// into a transient microVM without virtio-fs. The image is built
+/// in-process with the memory-safe `mvm-ext4` writer — no builder/dev VM,
+/// no `mkfs`, no mount/copy/unmount — so `host_dir` is read directly by this
+/// process: any path the caller can read qualifies, with no "must be
+/// reachable inside the Linux build environment" caveat.
 ///
-/// `host_dir` must already be reachable inside the Linux build environment
-/// (Lima auto-mounts the host home; Linux passes paths through directly).
-/// `label` is used as the ext4 volume label (max 16 chars, ASCII).
-/// `dest_image_path` is where the resulting `.ext4` file is written.
+/// `label` is stamped into the ext4 superblock as the volume name, so it
+/// must be exactly what the guest passes to `mount LABEL={label}` (max 16
+/// chars, ASCII alphanumeric/dash). `dest_image_path` is where the
+/// resulting `.ext4` file is written; its size is computed exactly from
+/// `host_dir`'s contents, not estimated.
+///
+/// Fails closed if `host_dir` contains a device, FIFO, or socket special
+/// file — the ext4 writer has no node kind to represent them, and silently
+/// omitting one would leave the guest with less than what was shared.
 ///
 /// Returns the absolute image path on success.
 pub fn build_dir_image_ro(host_dir: &str, label: &str, dest_image_path: &str) -> Result<String> {
@@ -764,51 +771,31 @@ pub fn build_dir_image_ro(host_dir: &str, label: &str, dest_image_path: &str) ->
     {
         anyhow::bail!("ext4 label '{label}' must be 1-16 ASCII alphanumeric/dash chars",);
     }
-    let parent = std::path::Path::new(dest_image_path)
-        .parent()
-        .map(|p| p.to_string_lossy().to_string())
-        .unwrap_or_default();
-    let mkdir_parent = if parent.is_empty() {
-        String::new()
-    } else {
-        format!("mkdir -p {parent}")
-    };
 
-    // Compute size: directory content + 8 MiB headroom + 16 MiB minimum,
-    // rounded up to the next 4-MiB boundary so mkfs.ext4 is happy.
-    // We do this inside the Linux env so `du` sees the same view as `cp`.
-    let script = format!(
-        r#"
-        set -e
-        {mkdir_parent}
-        rm -f {dest}
-        SRC_KB=$(du -sk {src} 2>/dev/null | awk '{{print $1}}')
-        SIZE_MIB=$(( (SRC_KB / 1024) + 8 ))
-        if [ "$SIZE_MIB" -lt 16 ]; then SIZE_MIB=16; fi
-        SIZE_MIB=$(( ((SIZE_MIB + 3) / 4) * 4 ))
-        truncate -s "${{SIZE_MIB}}M" {dest}
-        mkfs.ext4 -q -L {label} {dest}
+    let nodes = mvm_build::rootfs::collect_nodes(
+        std::path::Path::new(host_dir),
+        mvm_build::rootfs::UnsupportedNodePolicy::Reject,
+    )
+    .with_context(|| format!("walking host directory '{host_dir}' for --add-dir"))?;
 
-        MOUNT_DIR=$(mktemp -d)
-        sudo mount {dest} "$MOUNT_DIR"
-        if [ -d {src} ]; then
-            sudo cp -aT {src} "$MOUNT_DIR" 2>/dev/null || true
-        else
-            sudo cp -a {src} "$MOUNT_DIR/" 2>/dev/null || true
-        fi
-        sudo umount "$MOUNT_DIR"
-        rmdir "$MOUNT_DIR"
-        chmod 0644 {dest}
-        "#,
-        mkdir_parent = mkdir_parent,
-        src = host_dir,
-        dest = dest_image_path,
-        label = label,
-    );
-
-    run_in_vm(&script).with_context(|| {
+    mvm_build::rootfs::materialize_ext4_pure_labeled(
+        &nodes,
+        std::path::Path::new(dest_image_path),
+        label.as_bytes(),
+    )
+    .with_context(|| {
         format!("building read-only ext4 image from '{host_dir}' at '{dest_image_path}'")
     })?;
+
+    // Normalize permissions the way the old mkfs-in-a-VM path's trailing
+    // `chmod 0644` did, regardless of the calling process's umask.
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::PermissionsExt;
+        std::fs::set_permissions(dest_image_path, std::fs::Permissions::from_mode(0o644))
+            .with_context(|| format!("chmod 0644 '{dest_image_path}'"))?;
+    }
+
     Ok(dest_image_path.to_string())
 }
 
@@ -878,6 +865,77 @@ mod tests {
     fn build_dir_image_ro_rejects_empty_label() {
         let err = build_dir_image_ro("/tmp/x", "", "/tmp/x.ext4").unwrap_err();
         assert!(err.to_string().contains("ext4 label"));
+    }
+
+    /// `build_dir_image_ro` must materialize the ext4 image in-process (no
+    /// `run_in_vm`, no builder/dev VM) and stamp `label` into the superblock
+    /// as the ext4 volume name — the guest mounts this image with
+    /// `mount LABEL={label}`, so a wrong or missing label fails the guest
+    /// mount, not just this call.
+    #[test]
+    fn build_dir_image_ro_materializes_in_process_with_correct_label() {
+        let src = tempfile::tempdir().expect("tempdir");
+        std::fs::write(src.path().join("hello.txt"), b"hi\n").expect("write fixture file");
+        std::fs::create_dir(src.path().join("sub")).expect("mkdir sub");
+        std::fs::write(src.path().join("sub").join("nested.txt"), b"nested\n")
+            .expect("write nested fixture file");
+
+        let out_dir = tempfile::tempdir().expect("tempdir");
+        let dest = out_dir.path().join("extra.ext4");
+
+        let returned = build_dir_image_ro(
+            src.path().to_str().expect("utf8 tempdir path"),
+            "mvm-extra-0",
+            dest.to_str().expect("utf8 dest path"),
+        )
+        .expect("build_dir_image_ro must materialize in-process without a VM");
+        assert_eq!(returned, dest.to_string_lossy());
+
+        // Read the produced file back with the real ext4 reader already used
+        // elsewhere in this crate to validate boot artifacts (`artifacts::validate`)
+        // — an independent parser, not just a byte-offset echo of what we wrote.
+        let fs = ext4_view::Ext4::load_from_path(&dest).expect("produced file is a valid ext4 fs");
+        assert_eq!(
+            fs.label().to_str().expect("label is utf8"),
+            "mvm-extra-0",
+            "the guest's `mount LABEL=mvm-extra-0` depends on this exact label"
+        );
+        assert_eq!(
+            fs.read_to_string("/hello.txt").expect("read /hello.txt"),
+            "hi\n"
+        );
+        assert_eq!(
+            fs.read_to_string("/sub/nested.txt")
+                .expect("read /sub/nested.txt"),
+            "nested\n"
+        );
+    }
+
+    /// The old `cp -a`-in-a-VM path preserved special files (fifo/socket/
+    /// device) via `mknod`; the pure ext4 writer's `Node` enum has no variant
+    /// for them. Silently dropping one would leave the guest with less than
+    /// what the user asked to share, so this must fail closed instead.
+    #[cfg(unix)]
+    #[test]
+    fn build_dir_image_ro_rejects_a_socket_instead_of_silently_dropping_it() {
+        let src = tempfile::tempdir().expect("tempdir");
+        let sock_path = src.path().join("weird.sock");
+        let _listener =
+            std::os::unix::net::UnixListener::bind(&sock_path).expect("bind a real test socket");
+
+        let out_dir = tempfile::tempdir().expect("tempdir");
+        let dest = out_dir.path().join("extra.ext4");
+
+        let err = build_dir_image_ro(
+            src.path().to_str().expect("utf8 tempdir path"),
+            "mvm-extra-1",
+            dest.to_str().expect("utf8 dest path"),
+        )
+        .expect_err("a directory containing a socket must fail closed, not silently diverge");
+        assert!(
+            format!("{err:#}").contains("cannot represent"),
+            "expected an unsupported-node-type error, got: {err:#}"
+        );
     }
 
     #[test]

--- a/crates/mvm-backend/src/image.rs
+++ b/crates/mvm-backend/src/image.rs
@@ -814,6 +814,10 @@ pub fn build_dir_image_ro(host_dir: &str, label: &str, dest_image_path: &str) ->
 /// must be stopped before calling this — the kernel will refuse to mount
 /// an image still attached to a running Firecracker.
 pub fn rsync_image_to_host(image_path: &str, host_dir: &str) -> Result<()> {
+    crate::base::linux_env::require_guest_exec_available(
+        "writing '--add-dir :rw' changes back to the host needs an ext4 reader, which doesn't exist yet",
+    )?;
+
     let script = format!(
         r#"
         set -e
@@ -935,6 +939,25 @@ mod tests {
         assert!(
             format!("{err:#}").contains("cannot represent"),
             "expected an unsupported-node-type error, got: {err:#}"
+        );
+    }
+
+    /// `rsync_image_to_host` has no in-process ext4 reader yet, so on the
+    /// macOS 26+ tier (no builder to run the mount-and-rsync script against)
+    /// it must fail closed with an actionable error before ever touching
+    /// `run_in_vm` — not fail confusingly deep inside a doomed vsock call.
+    /// Host-conditioned: only asserts on the tier it actually applies to.
+    #[cfg(target_os = "macos")]
+    #[test]
+    fn rsync_image_to_host_fails_closed_on_vz_default_tier() {
+        if !mvm_core::platform::current().is_vz_default_tier() {
+            return;
+        }
+        let err = rsync_image_to_host("/nonexistent.ext4", "/nonexistent-host-dir")
+            .expect_err("must fail closed with no builder available");
+        assert!(
+            err.to_string().contains("ext4 reader"),
+            "unexpected message: {err}"
         );
     }
 

--- a/crates/mvm-backend/src/image.rs
+++ b/crates/mvm-backend/src/image.rs
@@ -772,6 +772,10 @@ pub fn build_dir_image_ro(host_dir: &str, label: &str, dest_image_path: &str) ->
         anyhow::bail!("ext4 label '{label}' must be 1-16 ASCII alphanumeric/dash chars",);
     }
 
+    if !std::path::Path::new(host_dir).is_dir() {
+        anyhow::bail!("--add-dir host path must be a directory: {host_dir}");
+    }
+
     let nodes = mvm_build::rootfs::collect_nodes(
         std::path::Path::new(host_dir),
         mvm_build::rootfs::UnsupportedNodePolicy::Reject,

--- a/crates/mvm-backend/tests/phase3c_supervisor_dispatch.rs
+++ b/crates/mvm-backend/tests/phase3c_supervisor_dispatch.rs
@@ -19,8 +19,8 @@
 //!   substrate ⇒ supervisor calls `run_supervisor` (the legacy
 //!   path) and fails downstream at libkrun's
 //!   `krun_start_enter` (rc -22 because the fake kernel/rootfs
-//!   don't exist). Confirms the back-compat path for `mvmctl dev`,
-//!   session VMs, and template restore.
+//!   don't exist). Confirms the back-compat path for the builder VM
+//!   bootstrap, session VMs, and template restore.
 //!
 //! ## How to run
 //!

--- a/crates/mvm-build/src/bin/mvm-host-vm-init.rs
+++ b/crates/mvm-build/src/bin/mvm-host-vm-init.rs
@@ -1069,7 +1069,7 @@ mod tests {
         assert_eq!(parse_ext4_recorded_size_bytes(&sb), None);
     }
 
-    /// Regression for the May 2026 `mvmctl dev up` failure: a
+    /// Regression for the May 2026 builder VM bootstrap failure: a
     /// stale 64 GiB ext4 image got re-attached to a `/dev/vdb`
     /// libkrun exposed as 64 GiB − 64 KiB. The kernel rejected
     /// mount with `EINVAL: bad geometry: block count 16777216
@@ -2029,7 +2029,7 @@ mod linux {
     fn run_dispatch_loop(mut cold_boot_timings: Option<BootTimings>) -> i32 {
         // No accept timeout — the dispatch loop is persistent and
         // blocks waiting for the supervisor's next submit. The
-        // outer `mvmctl dev down` signals shutdown via a
+        // outer `mvmctl persistent-builder stop` signals shutdown via a
         // `HostVmRequest::Shutdown` frame on a fresh connection.
         // Bring up the workload-vsock forwarder before
         // the dispatch loop. It runs for the VM's lifetime on its own
@@ -2876,7 +2876,7 @@ mod linux {
                 append_init_breadcrumb("virtiofs_mount_ok", &format!("{tag}->{target}"));
             }
         }
-        // User-supplied volumes (`mvmctl dev up -v …` / MVM_VOLUMES),
+        // User-supplied volumes (`--volume` / MVM_VOLUMES),
         // declared by the host on the kernel cmdline. Best-effort, same
         // as the fixed shares above — a failed user mount logs and
         // continues so it can never wedge PID 1.

--- a/crates/mvm-build/src/bin/stage0-init.rs
+++ b/crates/mvm-build/src/bin/stage0-init.rs
@@ -713,7 +713,7 @@ mod linux {
     /// purity check. A build that was interrupted mid-flight (power-off, OOM, a
     /// store fault) leaves the dir behind on the persistent guest root, and
     /// because the root is reused across boots whenever its seed marker matches,
-    /// every later `dev up` then fails with
+    /// every later bootstrap then fails with
     /// `error: home directory "/homeless-shelter" exists`. Remove a stale one
     /// before invoking nix so a crashed prior run self-heals instead of wedging
     /// the bootstrap. `root` is the filesystem root (`/` in the guest; a tempdir
@@ -761,7 +761,7 @@ mod linux {
 
     /// `nix build` the builder-VM flake, then copy kernel + rootfs to /out.
     /// The host-side contract (`/out/stage0-build.conf`, output modes) is the
-    /// same one `dev up` / `kernel build` write.
+    /// same one `mvmctl bootstrap` / `kernel build` write.
     fn build_and_copy() -> Result<(), String> {
         let nix = find_seed_bin("nix")?;
         let cacert = find_seed_cacert()?;

--- a/crates/mvm-build/src/builder_protocol.rs
+++ b/crates/mvm-build/src/builder_protocol.rs
@@ -1,7 +1,7 @@
 //! Wire types for the long-lived host VM's vsock dispatch channel.
 //!
 //! The host dispatches Nix-build jobs over vsock into a persistent
-//! libkrun VM, boot-once-per-`mvmctl dev`-session. The channel is a
+//! libkrun VM, booted once per builder session. The channel is a
 //! backend-agnostic dispatch surface — the same long-lived libkrun VM
 //! serves both Nix builds and nested Firecracker workload spawns. The
 //! `Workload*` variants below are stubbed (the guest-side arm panics
@@ -117,7 +117,7 @@ pub enum HostVmRequest {
     },
 
     /// Tell the guest's dispatch loop to exit cleanly. Triggered
-    /// by `mvmctl dev down` or the supervisor's idle timer.
+    /// by `mvmctl persistent-builder stop` or the supervisor's idle timer.
     ///
     /// Empty struct variant rather than unit so
     /// `#[serde(deny_unknown_fields)]` actually rejects extra

--- a/crates/mvm-build/src/builder_vm.rs
+++ b/crates/mvm-build/src/builder_vm.rs
@@ -466,8 +466,8 @@ pub enum BuilderVmError {
     HvfVmmFailed { detail: String },
 
     /// The persistent builder Nix store has a dangling/GC'd path — every build
-    /// re-evals to the same missing path and fails identically, so `dev up`
-    /// appears to "loop". Distinguished from a generic build failure so
+    /// re-evals to the same missing path and fails identically, so builds
+    /// appear to "loop". Distinguished from a generic build failure so
     /// the user gets the one-line recovery instead of an opaque nix error.
     #[error(
         "the builder VM's Nix store has a dangling/garbage-collected path — \
@@ -545,7 +545,7 @@ pub struct BuilderStoreRepair {
 }
 
 /// Recover a degraded builder Nix store by removing the builder-VM cache
-/// dir so the next `dev up` / `build` cold-rebuilds it clean — the documented
+/// dir so the next `mvmctl bootstrap` / `build` cold-rebuilds it clean — the documented
 /// `rm -rf ~/.cache/mvm/builder-vm` recovery as a first-class operation. The
 /// whole dir goes (store image + per-VM dirs + job dirs): the store image is the
 /// degraded piece, and the kernel/rootfs/jobs are all rebuildable. `dry_run`

--- a/crates/mvm-build/src/builder_vm_runtime.rs
+++ b/crates/mvm-build/src/builder_vm_runtime.rs
@@ -501,7 +501,7 @@ printf '%s\n' "$NIX_OUT" > /job/store-path
 # reachable only through the transient build root — so without this the next
 # build recompiles the kernel and re-pulls the base closure.
 #
-# Key the root by build kind so alternating builder-vm-image (dev up / stage0)
+# Key the root by build kind so alternating builder-vm-image (bootstrap / stage0)
 # and workload (machine run) builds don't evict each other's closure. Two
 # bounded fixed names keep the store bounded — the cap GC still frees a
 # superseded closure within a kind, and an unchanged derivation is a store hit
@@ -998,7 +998,7 @@ pub fn finalize_flake_job(
         let derivation_tail = read_last_bytes_of(&stderr_log, 4 * 1024)
             .unwrap_or_else(|_| String::from("<nix-stderr.log not present on host>"));
 
-        // A dangling/GC'd store path makes every `dev up` fail identically
+        // A dangling/GC'd store path makes every build fail identically
         // (the user re-runs and "loops"). Detect that exact nix signature and
         // return the one-line recovery instead of the opaque build error.
         if let Some(line) = crate::builder_vm::dangling_store_path_line(&derivation_tail)
@@ -1371,7 +1371,7 @@ pub fn acquire_nix_store_image_lock(
 /// Stage 0 (the builder-VM *image* build) uses this to key a dedicated
 /// `nix-store-stage0-<arch>.img` separate from the steady-state
 /// builder's `nix-store-<arch>.img`. Two reasons for the split: the
-/// flock would otherwise serialize a `dev up` bootstrap against any
+/// flock would otherwise serialize the builder VM bootstrap against any
 /// concurrent `mvmctl build` in another session, and the bootstrap's
 /// kernel/Rust-toolchain closure has no reason to share a store with
 /// user-workload builds. Both images live in the same cache dir and
@@ -2337,7 +2337,7 @@ mod tests {
         assert!(gc_idx > meta_idx, "GC tail must follow output emission");
 
         // The warm gcroot must be keyed by build kind so alternating
-        // builder-vm-image (dev up / stage0) and workload (machine run) builds
+        // builder-vm-image (bootstrap / stage0) and workload (machine run) builds
         // don't evict each other's closure. Two bounded roots
         // (mvm-warm-builder / mvm-warm-workload), classified from $NIX_OUT's
         // derivation name, registered BEFORE the GC; the pre-fix single

--- a/crates/mvm-build/src/libkrun_builder.rs
+++ b/crates/mvm-build/src/libkrun_builder.rs
@@ -747,7 +747,7 @@ impl LibkrunBuilderVm {
     /// block rootfs, its root is virtio-fs via `krun_set_root`). The
     /// guest mounts it at `/nix` (formatting on first boot), so the slim
     /// kernel + Rust host binaries are built once and reused across
-    /// `dev up` runs instead of recompiled into a throwaway tmpfs every
+    /// bootstrap runs instead of recompiled into a throwaway tmpfs every
     /// time. ext4 is case-sensitive, which is also why the old in-RAM
     /// tmpfs existed (APFS case-insensitivity breaks Nix substitution) —
     /// the disk keeps that property and adds persistence.
@@ -802,7 +802,7 @@ impl LibkrunBuilderVm {
 
         // Persistent, host-locked Nix store for the image build. Sparse
         // image, formatted in-guest on first boot; survives across
-        // `dev up` runs so the slim kernel + Rust toolchain closure are
+        // bootstrap runs so the slim kernel + Rust toolchain closure are
         // built once. Dedicated filename (not the builder's
         // `nix-store-<arch>.img`) so the flock never contends with a
         // concurrent `mvmctl build`. The guard must outlive the
@@ -2450,7 +2450,7 @@ fn load_builder_vm_image_from_cache(arch_dir: &Path) -> Result<BuilderVmImage, B
 
 /// Filename of Stage 0's dedicated persistent Nix-store image,
 /// `nix-store-stage0-<arch>.img`. Distinct from the steady-state
-/// builder's `nix-store-<arch>.img` so a `dev up` bootstrap and a
+/// builder's `nix-store-<arch>.img` so a builder VM bootstrap and a
 /// concurrent `mvmctl build` never contend on the same flock — see
 /// [`acquire_nix_store_image_lock_named`]. Lives in
 /// [`builder_vm_cache_dir`] and matches `cache info`'s
@@ -3987,7 +3987,7 @@ pub const DISPATCH_SOCK_MARKER: &str = "dispatch.sock.marker";
 ///
 /// ## Not yet wired
 ///
-/// - `mvmctl dev up` integration is what actually constructs one of
+/// - The builder VM bootstrap integration is what actually constructs one of
 ///   these against the dev session's lifecycle.
 /// - Per-job namespace isolation inside the dispatch loop.
 #[cfg(feature = "builder-vm")]
@@ -4801,9 +4801,9 @@ mod tests {
         //     supervisor starts but exits before the requested job runs →
         //     SupervisorExited
         // All five are legitimate "environment gap" surfaces. The
-        // fourth is what `mvmctl dev up` reports to operators with
-        // a populated cache; the first three are what `mvmctl dev
-        // up` reports before the Stage 0 bootstrap completes.
+        // fourth is what `mvmctl bootstrap` reports to operators with
+        // a populated cache; the first three are what `mvmctl bootstrap`
+        // reports before the Stage 0 bootstrap completes.
         let scratch = TempDir::new().unwrap();
         let mounts = ok_mounts(&scratch);
         let err = LibkrunBuilderVm::default()

--- a/crates/mvm-build/src/persistent_builder.rs
+++ b/crates/mvm-build/src/persistent_builder.rs
@@ -5,7 +5,7 @@
 //! dispatch socket libkrun creates at
 //! `<vm_state_dir>/vsock-<BUILDER_DISPATCH_PORT>.sock` once the
 //! persistent VM is up. Callers — eventually `mvmctl build` from
-//! inside an active `mvmctl dev` session — submit a
+//! inside an active persistent-builder session — submit a
 //! [`crate::builder_vm::BuilderJob`] via `Self::submit`; the
 //! supervisor serializes it to a
 //! [`crate::builder_protocol::HostVmRequest::Run`], writes the

--- a/crates/mvm-build/src/pipeline/dev_build.rs
+++ b/crates/mvm-build/src/pipeline/dev_build.rs
@@ -88,7 +88,7 @@ fn dev_builds_dir() -> String {
     format!("{}/dev/builds", mvm_core::config::mvm_data_dir())
 }
 
-/// Path the CLI writes when `dev up` notices the host-backed Nix
+/// Path the CLI writes when a build notices the host-backed Nix
 /// store has grown past the GC threshold. Lives under the data dir
 /// because the data dir is the only path the dev VM and the host
 /// agree on (via the `datadir` VirtioFS share mounted at the same
@@ -342,7 +342,7 @@ fn dev_build_via_shell_env(
     }
 
     // Honour the host-side GC sentinel before any new build work
-    // touches the store. The CLI's `dev up` writes
+    // touches the store. The CLI writes
     // `~/.mvm/dev/nix-store-needs-gc` (mounted at the same path
     // inside the VM via the datadir share) when the upper layer's
     // allocated bytes cross threshold; we collect garbage exactly
@@ -746,7 +746,7 @@ fn dev_build_with_builder_vm<B: crate::builder_vm::BuilderVm + ?Sized>(
     std::fs::create_dir_all(&staging).with_context(|| format!("creating staging dir {staging}"))?;
 
     // dev_build_with_builder_vm is called for
-    // user-flake builds (mvmctl build / dev up against the user's flake).
+    // user-flake builds (mvmctl build against the user's flake).
     // User flakes do not embed host-vm binaries, so /mvm-bins is unused
     // here. A temp dir satisfies validate_mounts' directory-exists check.
     let host_bins_tmp =

--- a/crates/mvm-build/src/pipeline/mod.rs
+++ b/crates/mvm-build/src/pipeline/mod.rs
@@ -11,7 +11,7 @@ pub mod vsock_builder;
 /// **The command run by the user dictates this**, not the user's
 /// flake. `mvmctl up`/`run`/`start` are production-shape commands;
 /// they build sealed images with the prod guest agent (no exec/
-/// console surface). `mvmctl dev` runs a separate dev-shell
+/// console surface). The builder VM's dev shell runs a separate dev-shell
 /// sandbox that doesn't go through this build path. An explicit
 /// `--dev` flag on production-shape commands is the documented
 /// escape hatch for debugging a microVM-shape image; without it,
@@ -30,8 +30,8 @@ pub mod vsock_builder;
 /// on invocation context."
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum BuildMode {
-    /// Dev-shape build: dev agent + accessible. Used by `mvmctl
-    /// dev`-adjacent paths and by `--dev` opt-ins on production-
+    /// Dev-shape build: dev agent + accessible. Used by dev-shell-adjacent
+    /// paths and by `--dev` opt-ins on production-
     /// shape commands.
     Dev,
     /// Prod-shape build: prod agent (no exec surface) + sealed

--- a/crates/mvm-build/src/rootfs.rs
+++ b/crates/mvm-build/src/rootfs.rs
@@ -118,12 +118,18 @@ pub enum RootfsError {
     BuilderVm(#[from] crate::builder_vm::BuilderVmError),
 
     #[cfg(feature = "pure-mkfs")]
-    #[error("walking unpacked tree at {path}: {source}")]
+    #[error("walking directory tree at {path}: {source}")]
     PureWalk {
         path: PathBuf,
         #[source]
         source: std::io::Error,
     },
+
+    #[cfg(feature = "pure-mkfs")]
+    #[error(
+        "host path {0} is a device, FIFO, or socket special file the ext4 writer cannot represent"
+    )]
+    UnsupportedNodeType(PathBuf),
 
     #[cfg(feature = "pure-mkfs")]
     #[error("building ext4 image in-process: {0}")]
@@ -385,7 +391,7 @@ pub fn materialize_ext4_pure(
             input.unpacked_root.clone(),
         ));
     }
-    let nodes = collect_nodes(&input.unpacked_root)?;
+    let nodes = collect_nodes(&input.unpacked_root, UnsupportedNodePolicy::Skip)?;
     // The run path's cache dir (`.../rootfs/<key>/`) may not exist yet — the
     // builder-VM path created it via `allocate_sparse_image`, so the pure path
     // must create it too before writing the image + its sidecars.
@@ -395,7 +401,8 @@ pub fn materialize_ext4_pure(
             source,
         })?;
     }
-    let size_bytes = stream_pure_ext4_output(&nodes, &input.output)?;
+    let size_bytes =
+        stream_pure_ext4_output(&nodes, &input.output, &mvm_ext4::BuildOptions::default())?;
     let verity_root_hash = maybe_emit_verity_sidecars(input)?;
 
     Ok(MaterializedExt4 {
@@ -406,15 +413,47 @@ pub fn materialize_ext4_pure(
 }
 
 #[cfg(feature = "pure-mkfs")]
+/// Materialize a pre-collected node list into an in-process ext4 image at
+/// `output`, stamping `volume_name` into the superblock so a guest can
+/// `mount LABEL=<volume_name>` it.
+///
+/// Used by callers that mount the resulting image by label rather than boot
+/// from it — e.g. the `--add-dir` host-directory share. Unlike
+/// [`materialize_ext4_pure`], the caller supplies its own `nodes` (built from
+/// a bare host directory via [`collect_nodes`] rather than an OCI-unpacked
+/// rootfs tree), and there is no size estimate or verity sidecar: both are
+/// boot-rootfs concerns this kind of image doesn't have.
+pub fn materialize_ext4_pure_labeled(
+    nodes: &[mvm_ext4::Node],
+    output: &std::path::Path,
+    volume_name: &[u8],
+) -> Result<MaterializedExt4, RootfsError> {
+    if let Some(parent) = output.parent() {
+        std::fs::create_dir_all(parent).map_err(|source| RootfsError::WriteOutput {
+            path: parent.to_path_buf(),
+            source,
+        })?;
+    }
+    let options = mvm_ext4::BuildOptions::default().with_volume_name(volume_name);
+    let size_bytes = stream_pure_ext4_output(nodes, output, &options)?;
+    Ok(MaterializedExt4 {
+        path: output.to_path_buf(),
+        size_bytes,
+        verity_root_hash: None,
+    })
+}
+
+#[cfg(feature = "pure-mkfs")]
 fn stream_pure_ext4_output(
     nodes: &[mvm_ext4::Node],
     output: &std::path::Path,
+    options: &mvm_ext4::BuildOptions,
 ) -> Result<u64, RootfsError> {
     let mut file = std::fs::File::create(output).map_err(|source| RootfsError::WriteOutput {
         path: output.to_path_buf(),
         source,
     })?;
-    let size_bytes = match mvm_ext4::emit_image(nodes, |offset, bytes| {
+    let size_bytes = match mvm_ext4::emit_image_with_options(nodes, options, |offset, bytes| {
         file.seek(SeekFrom::Start(offset))
             .and_then(|_| file.write_all(bytes))
     }) {
@@ -493,11 +532,31 @@ fn emit_verity_sidecars_for_image(
 }
 
 #[cfg(feature = "pure-mkfs")]
+/// How [`collect_nodes`] handles a host inode kind the ext4 [`mvm_ext4::Node`]
+/// enum has no variant for (device, FIFO, socket).
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum UnsupportedNodePolicy {
+    /// Omit the node from the image. Correct for an OCI rootfs: those special
+    /// files are re-created by devtmpfs at boot, so leaving them out of the
+    /// image is the intended behavior, not a loss.
+    Skip,
+    /// Fail the walk instead of silently dropping the node. Used by callers
+    /// materializing a user-supplied host directory (e.g. `--add-dir`),
+    /// where an omitted file would leave the guest with less than what the
+    /// user asked to share.
+    Reject,
+}
+
+#[cfg(feature = "pure-mkfs")]
 /// Walk `root` into a flat `Node` list (guest-absolute paths), symlink-aware
 /// (never follows). Directories and their descendants, regular files (contents
 /// read in), and symlinks are captured; other inode types (fifo/socket/device)
-/// are skipped — an OCI rootfs mounts devtmpfs for those.
-fn collect_nodes(root: &std::path::Path) -> Result<Vec<mvm_ext4::Node>, RootfsError> {
+/// are handled per `on_unsupported`, since the `Node` enum has no way to
+/// represent them.
+pub fn collect_nodes(
+    root: &std::path::Path,
+    on_unsupported: UnsupportedNodePolicy,
+) -> Result<Vec<mvm_ext4::Node>, RootfsError> {
     let mut out = Vec::new();
     let mut stack = vec![root.to_path_buf()];
     while let Some(dir) = stack.pop() {
@@ -551,6 +610,13 @@ fn collect_nodes(root: &std::path::Path) -> Result<Vec<mvm_ext4::Node>, RootfsEr
                     data,
                     xattrs,
                 });
+            } else {
+                match on_unsupported {
+                    UnsupportedNodePolicy::Skip => {}
+                    UnsupportedNodePolicy::Reject => {
+                        return Err(RootfsError::UnsupportedNodeType(path));
+                    }
+                }
             }
         }
     }
@@ -805,7 +871,7 @@ mod tests {
         std::fs::write(src.path().join("etc/hosts"), b"127.0.0.1 localhost\n").unwrap();
         std::fs::write(src.path().join("hello"), b"hi\n").unwrap();
 
-        let nodes = collect_nodes(src.path()).expect("collect nodes");
+        let nodes = collect_nodes(src.path(), UnsupportedNodePolicy::Skip).expect("collect nodes");
         let dense = mvm_ext4::build_image(&nodes).expect("dense ext4 image");
 
         let out = tempfile::tempdir().unwrap();
@@ -828,7 +894,7 @@ mod tests {
         std::fs::write(&shadow, b"root:*:19793:0:99999:7:::\n").unwrap();
         std::fs::set_permissions(&shadow, std::fs::Permissions::from_mode(0o0)).unwrap();
 
-        let nodes = collect_nodes(src.path()).expect("collect nodes");
+        let nodes = collect_nodes(src.path(), UnsupportedNodePolicy::Skip).expect("collect nodes");
         let node = nodes
             .into_iter()
             .find_map(|node| match node {
@@ -847,6 +913,68 @@ mod tests {
             .mode()
             & 0o7777;
         assert_eq!(restored_mode, 0);
+    }
+
+    #[cfg(all(feature = "pure-mkfs", unix))]
+    #[test]
+    fn collect_nodes_skip_vs_reject_policy_for_unsupported_node_types() {
+        let src = tempfile::tempdir().unwrap();
+        let sock_path = src.path().join("weird.sock");
+        let _listener =
+            std::os::unix::net::UnixListener::bind(&sock_path).expect("bind a real test socket");
+
+        // OCI-rootfs-style walk: devtmpfs recreates these at boot, so silently
+        // omitting the node from the image is correct, not a loss.
+        let nodes = collect_nodes(src.path(), UnsupportedNodePolicy::Skip).expect("skip policy");
+        assert!(
+            nodes.is_empty(),
+            "a socket must be silently omitted under Skip, got {nodes:?}"
+        );
+
+        // Host-directory-share-style walk (`--add-dir`): a dropped file would
+        // silently diverge from what the user asked to share, so fail closed.
+        let err = collect_nodes(src.path(), UnsupportedNodePolicy::Reject)
+            .expect_err("a socket must be rejected, not silently dropped");
+        assert!(
+            matches!(err, RootfsError::UnsupportedNodeType(_)),
+            "expected UnsupportedNodeType, got {err:?}"
+        );
+    }
+
+    #[cfg(feature = "pure-mkfs")]
+    #[test]
+    fn materialize_ext4_pure_labeled_stamps_the_volume_name() {
+        let out = tempfile::tempdir().unwrap();
+        let out_path = out.path().join("extra.ext4");
+        let nodes = vec![mvm_ext4::Node::File {
+            path: "/hello".into(),
+            mode: 0o644,
+            data: b"hi\n".to_vec(),
+            xattrs: Vec::new(),
+        }];
+
+        let mat = materialize_ext4_pure_labeled(&nodes, &out_path, b"mvm-extra-0")
+            .expect("labeled materialize");
+        assert_eq!(mat.path, out_path);
+        assert!(
+            mat.verity_root_hash.is_none(),
+            "labeled images are mounted by label, not booted — no verity sidecar"
+        );
+
+        // Same superblock offset the mvm-ext4 writer's own test checks
+        // (`s_volume_name` at byte 0x78 into the superblock, which starts at
+        // byte 1024): the label written here must be the exact bytes the
+        // guest's `mount LABEL=mvm-extra-0` will match against.
+        let label: &[u8] = b"mvm-extra-0";
+        let image = std::fs::read(&out_path).unwrap();
+        let field_start = 1024 + 0x78;
+        assert_eq!(&image[field_start..field_start + label.len()], label);
+        assert!(
+            image[field_start + label.len()..field_start + 16]
+                .iter()
+                .all(|&b| b == 0),
+            "the volume_name field's unused tail must stay zero-padded"
+        );
     }
 
     #[cfg(feature = "pure-mkfs")]

--- a/crates/mvm-cli/src/commands/build/build.rs
+++ b/crates/mvm-cli/src/commands/build/build.rs
@@ -318,7 +318,7 @@ fn build_flake(
 
     // A steady-state `mvmctl build` runs the user's nix build
     // inside the builder VM, which needs the layer-1 builder image (vmlinux +
-    // rootfs.ext4) in cache. `dev up` bootstraps it on macOS, but the native-
+    // rootfs.ext4) in cache. `mvmctl bootstrap` bootstraps it on macOS, but the native-
     // Linux dev path never does — so ensure it here (Stage 0 honours the
     // selected builder backend; a cached image is a no-op). Without this the
     // first `mvmctl build` on a fresh Linux host fails in `ensure_builder_vm_image`.

--- a/crates/mvm-cli/src/commands/build/kernel.rs
+++ b/crates/mvm-cli/src/commands/build/kernel.rs
@@ -5,9 +5,9 @@
 //! deltas). Because the
 //! config is custom, `cache.nixos.org` has no substitute, so a fresh
 //! machine compiles from source — the slow, memory-heavy step a first
-//! `mvmctl dev up` otherwise hits implicitly. This command makes that
+//! build otherwise hits implicitly. This command makes that
 //! compile explicit and one-time: build the kernel once into the
-//! persistent nix store, and every later `dev up` reuses it.
+//! persistent nix store, and every later build reuses it.
 //!
 //! `--source download` (fetch a hash-verified published prebuilt) lands
 //! with the kernel-build publish workflow, which is what produces the

--- a/crates/mvm-cli/src/commands/build/mod.rs
+++ b/crates/mvm-cli/src/commands/build/mod.rs
@@ -14,7 +14,7 @@ pub(super) mod kernel;
 /// host-side `LibkrunPersistentHostVm` and
 /// `PersistentBuilderSupervisor` together via three subcommands
 /// (start / submit / stop) so contributors can exercise the
-/// dispatch path end-to-end without going through `mvmctl dev up`.
+/// dispatch path end-to-end without going through a full build.
 /// Gated on the `builder-vm` feature because the host-side types
 /// it dispatches into (`LibkrunPersistentHostVm` etc.) only
 /// exist with that feature — `mvm-cli`'s default features include

--- a/crates/mvm-cli/src/commands/build/persistent_builder.rs
+++ b/crates/mvm-cli/src/commands/build/persistent_builder.rs
@@ -14,9 +14,9 @@
 //! - **`stop`** — sends `HostVmRequest::Shutdown` to the dispatch
 //!   loop, waits for the supervisor child to exit cleanly.
 //!
-//! This is deliberately separate from `mvmctl dev up`. The
-//! lifecycle binding (`mvmctl dev up` auto-starts the persistent
-//! supervisor) lands in a follow-up. Once it does, `mvmctl dev up`
+//! This is deliberately separate from the builder VM bootstrap. The
+//! lifecycle binding (the bootstrap auto-starting the persistent
+//! supervisor) lands in a follow-up. Once it does, the bootstrap
 //! becomes a thin caller of the same
 //! `LibkrunPersistentHostVm::start()` this verb invokes.
 //!
@@ -29,7 +29,7 @@
 //!
 //! ## What's deferred
 //!
-//! - Auto-start from `mvmctl dev up` (post-merge follow-up).
+//! - Auto-start from the builder VM bootstrap (post-merge follow-up).
 //! - `mvmctl build` routing into the persistent supervisor when a
 //!   session is active (`submit` now produces real artifacts, so
 //!   the routing target exists).

--- a/crates/mvm-cli/src/commands/build/validate.rs
+++ b/crates/mvm-cli/src/commands/build/validate.rs
@@ -37,6 +37,8 @@ pub(in crate::commands) fn run(_cli: &Cli, args: Args, _cfg: &MvmConfig) -> Resu
         return render_typed_verdict(result, args.json);
     }
 
+    ensure_guest_exec_available()?;
+
     let script = format!("nix flake check {resolved}");
 
     if args.json {
@@ -106,5 +108,35 @@ fn render_typed_verdict(
         // The daemon was reachable but the typed exchange failed. Surface it
         // rather than silently doing host work — the opt-in was explicit.
         Err(e) => Err(anyhow::anyhow!("typed flake check failed: {e}")),
+    }
+}
+
+/// Guard the `run_in_vm` fallback below: `nix flake check` needs a real
+/// Linux builder, which the typed-daemon path above doesn't reach on every
+/// tier yet. Fails closed with an actionable error instead of letting
+/// `run_in_vm` fail deep inside a doomed vsock call.
+fn ensure_guest_exec_available() -> Result<()> {
+    mvm::linux_env::require_guest_exec_available("running 'nix flake check'")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Host-conditioned: only asserts on the tier it actually applies to
+    /// (macOS 26+, where there's no builder for the `run_in_vm` fallback to
+    /// dispatch to).
+    #[cfg(target_os = "macos")]
+    #[test]
+    fn ensure_guest_exec_available_fails_closed_on_vz_default_tier() {
+        if !mvm_core::platform::current().is_vz_default_tier() {
+            return;
+        }
+        let err =
+            ensure_guest_exec_available().expect_err("must fail closed with no builder available");
+        assert!(
+            err.to_string().contains("flake check"),
+            "unexpected message: {err}"
+        );
     }
 }

--- a/crates/mvm-cli/src/commands/build/validate.rs
+++ b/crates/mvm-cli/src/commands/build/validate.rs
@@ -121,6 +121,7 @@ fn ensure_guest_exec_available() -> Result<()> {
 
 #[cfg(test)]
 mod tests {
+    #[cfg(target_os = "macos")]
     use super::ensure_guest_exec_available;
 
     /// Host-conditioned: only asserts on the tier it actually applies to

--- a/crates/mvm-cli/src/commands/build/validate.rs
+++ b/crates/mvm-cli/src/commands/build/validate.rs
@@ -121,7 +121,7 @@ fn ensure_guest_exec_available() -> Result<()> {
 
 #[cfg(test)]
 mod tests {
-    use super::*;
+    use super::ensure_guest_exec_available;
 
     /// Host-conditioned: only asserts on the tier it actually applies to
     /// (macOS 26+, where there's no builder for the `run_in_vm` fallback to

--- a/crates/mvm-cli/src/commands/env/cleanup.rs
+++ b/crates/mvm-cli/src/commands/env/cleanup.rs
@@ -43,7 +43,7 @@ pub(in crate::commands) struct Args {
     pub all: bool,
 
     /// Also wipe `~/.cache/mvm` (Stage 0 staging, builder VM artifacts).
-    /// All cache contents are regenerable; the next `dev up` rebuilds them.
+    /// All cache contents are regenerable; the next build rebuilds them.
     #[arg(long)]
     pub cache: bool,
     /// Wipe `~/.cache/mvm` PLUS regenerable subdirs of `~/.mvm`

--- a/crates/mvm-cli/src/commands/env/dev_vz/bootstrap.rs
+++ b/crates/mvm-cli/src/commands/env/dev_vz/bootstrap.rs
@@ -506,7 +506,7 @@ pub(in crate::commands) mod attested_builder_pack {
 
     /// Load the on-disk trust config, folding both the absent and the malformed
     /// case into the inert empty config. A missing file is the expected default;
-    /// a broken file must never brick `dev up`, so we warn and stay inert — the
+    /// a broken file must never brick the builder VM bootstrap, so we warn and stay inert — the
     /// pack path then trusts nothing and falls through to the plain download. It
     /// can never trust an unverified pack, so failing open here is safe.
     fn load_host_pack_trust() -> PackTrustConfig {
@@ -673,8 +673,8 @@ pub(in crate::commands) mod attested_builder_pack {
     /// the local cache when it verifies. Both the fetch and the promote step
     /// are fail-open: any error is logged and swallowed here, never
     /// propagated, so [`attempt_attested_builder_pack`] always falls
-    /// back to the plain checksum download rather than hard-failing `dev up`
-    /// on a network hiccup or a broken publish.
+    /// back to the plain checksum download rather than hard-failing the
+    /// builder VM bootstrap on a network hiccup or a broken publish.
     #[cfg(feature = "manifest-verify")]
     fn fetch_and_promote_release_builder_pack(arch: &str, ctx: &PackVerifyCtx<'_>) {
         let staging = match fetch_release_builder_pack_staging(arch) {
@@ -944,7 +944,7 @@ fn bootstrap_builder_vm_image_via_root_dir_stage0(
     // on a published, hash-verified kernel — build only the rootfs and
     // pair the kernel in, skipping the in-image kernel compile. Unset or
     // `compile` → the normal `default` build (kernel compiled in-image;
-    // also the cheaper single-boot path, so `dev up --kernel-source
+    // also the cheaper single-boot path, so `mvmctl bootstrap --kernel-source
     // compile` deliberately stays on it).
     let external_kernel: Option<std::path::PathBuf> = match resolve_kernel_source() {
         Some(KernelSource::Download) => {

--- a/crates/mvm-cli/src/commands/env/dev_vz/builder_vm_bootstrap_tests.rs
+++ b/crates/mvm-cli/src/commands/env/dev_vz/builder_vm_bootstrap_tests.rs
@@ -639,7 +639,7 @@ fn sweep_skips_when_stage0_lock_is_held() {
 }
 
 /// Sweep on a non-existent root is a no-op. Exercises
-/// the early-return for fresh hosts that have never run `dev up`.
+/// the early-return for fresh hosts that have never bootstrapped.
 #[test]
 fn sweep_is_noop_when_root_missing() {
     let tmp = tempfile::tempdir().expect("tempdir");
@@ -1051,7 +1051,7 @@ fn builder_vm_source_cache_status_reports_safe_reason_codes() {
 
 // Fix A — `build_image_via_libkrun` writes the same fingerprint +
 // artifact-digest + provenance sidecars the Layer-1 cache uses, so the
-// next `dev up` fast-paths past the builder VM. Round-trip: a sidecar
+// next build fast-paths past the builder VM. Round-trip: a sidecar
 // write for a fingerprint reads back as a hit for that fingerprint and a
 // miss for any other — which is exactly the gate `ensure_dev_image`
 // consults before deciding to rebuild.

--- a/crates/mvm-cli/src/commands/env/dev_vz/kernel.rs
+++ b/crates/mvm-cli/src/commands/env/dev_vz/kernel.rs
@@ -47,7 +47,7 @@ impl KernelVariant {
 /// image, from `MVM_KERNEL_SOURCE` (set by the global `--kernel-source`
 /// flag). `download` boots the builder VM on a published, hash-verified
 /// kernel — building only the rootfs locally and pairing the kernel in,
-/// so a fresh `dev up` skips the multi-minute kernel compile. Unset →
+/// so a fresh bootstrap skips the multi-minute kernel compile. Unset →
 /// the default `nix build default` path (kernel compiled in-image).
 #[cfg(feature = "builder-vm")]
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]

--- a/crates/mvm-cli/src/commands/env/dev_vz/vm_helpers.rs
+++ b/crates/mvm-cli/src/commands/env/dev_vz/vm_helpers.rs
@@ -11,7 +11,7 @@ pub(in crate::commands) struct ReapOutcome {
 }
 
 /// Reap orphaned per-VM helpers left behind by killed
-/// `mvmctl dev up` runs. Covers each backend's supervisor
+/// mvmctl runs. Covers each backend's supervisor
 /// (`mvm-libkrun-supervisor`, `mvm-hvf-supervisor`).
 ///
 /// mvmctl spawns the active backend's supervisor binary, which in turn
@@ -45,7 +45,7 @@ pub(in crate::commands) struct ReapOutcome {
 ///    `dev down` / `stop <name>`. On an ephemeral per-job builder dir,
 ///    an alive launchd-parented supervisor is a build whose CLI crashed
 ///    and should be SIGTERM'd. Without the managed carve-out the startup
-///    sweep kills the live dev VM on every `up` / `dev up` / `ls`.
+///    sweep kills the live dev VM on every `cache prune` / `image pull`.
 /// 2. **Helper phase.** Any argv-scanned grandchildren whose argv
 ///    carries the dir's unique basename. A helper's fate follows its
 ///    supervisor: if Phase 1 found the VM live every helper is spared;
@@ -68,9 +68,9 @@ pub(in crate::commands) fn reap_orphaned_vm_helpers(dry_run: bool) -> Result<Rea
     reap_orphaned_vm_helpers_both_roots(/* remove_builder_dirs = */ true, dry_run)
 }
 
-/// Best-effort orphan-helper sweep run at the start of `mvmctl dev up`
-/// / `mvmctl up`. The next launch reaps the previous run's corpses:
-/// startup is the robust trigger because an abnormal exit (^C, SIGKILL,
+/// Best-effort orphan-helper sweep run at the start of `mvmctl image pull`
+/// and the OCI run-image path. The next launch reaps the previous run's
+/// corpses: startup is the robust trigger because an abnormal exit (^C, SIGKILL,
 /// crash, the libkrun `krun_start_enter` `exit()`) is exactly when the CLI
 /// can't self-clean and reparents its helpers to launchd.
 ///

--- a/crates/mvm-cli/src/commands/image/mod.rs
+++ b/crates/mvm-cli/src/commands/image/mod.rs
@@ -473,9 +473,9 @@ fn resolve_or_pull_run_image_with(
     materialize: RuntimeMaterializer,
 ) -> Result<ResolvedOciRunImage> {
     // Rootfs materialization can fall back to a builder VM when the in-process
-    // ext4 writer cannot faithfully emit a tree. `up` / `dev up` reap previous
-    // helper processes at startup; the run-image path is the other place a
-    // builder VM can spawn, so give it the same sweep before we might add one.
+    // ext4 writer cannot faithfully emit a tree. `mvmctl image pull` reaps
+    // previous helper processes at startup; the run-image path is the other
+    // place a builder VM can spawn, so give it the same sweep before we might add one.
     crate::commands::env::dev_vz::sweep_orphaned_vm_helpers_on_startup();
 
     // Local sources route to their own ingest; a registry reference falls

--- a/crates/mvm-cli/src/commands/ops/cache.rs
+++ b/crates/mvm-cli/src/commands/ops/cache.rs
@@ -36,7 +36,7 @@ pub(in crate::commands) enum CacheAction {
         /// mid-run, plus their `~/.cache/mvm/builder-vm/vms/<id>/` cache
         /// directories — so dead microVMs don't accumulate. The sweep is
         /// liveness-aware: a running VM (a detached `up -d`, the persistent dev
-        /// builder, any in-flight `dev up`) is spared; only already-dead
+        /// builder, any in-flight builder VM bootstrap) is spared; only already-dead
         /// helpers are reaped. Pass this to prune disk only, touching no
         /// processes.
         #[arg(long)]
@@ -71,8 +71,8 @@ pub(in crate::commands) enum CacheAction {
         json: bool,
     },
     /// Repair a degraded builder VM store. Clears
-    /// `~/.cache/mvm/builder-vm/` so the next `dev up`/`build` cold-rebuilds it.
-    /// Use this when `dev up` keeps failing with a dangling-store error
+    /// `~/.cache/mvm/builder-vm/` so the next `mvmctl bootstrap`/`build` cold-rebuilds it.
+    /// Use this when a build keeps failing with a dangling-store error
     /// (`error: path '/nix/store/…-source/flake.nix' does not exist`).
     Repair {
         /// Print what would be freed without removing anything
@@ -83,7 +83,7 @@ pub(in crate::commands) enum CacheAction {
         json: bool,
         /// Clear the store even while a Stage 0 bootstrap is in flight. By
         /// default repair refuses if the Stage 0 advisory lock is held (another
-        /// `dev up`/`build` is mid-bootstrap) so it never yanks the store from
+        /// build is mid-bootstrap) so it never yanks the store from
         /// an active build. Only pass this if you are certain the lock is stale
         /// (e.g. left by a crashed run).
         #[arg(long)]
@@ -297,7 +297,7 @@ pub(in crate::commands) fn run(_cli: &Cli, args: Args, _cfg: &MvmConfig) -> Resu
             use super::super::env::dev_vz;
 
             // Guard 1 — never yank the store from an in-flight bootstrap. A
-            // held Stage 0 lock means another `dev up`/`build` is mid-bootstrap.
+            // held Stage 0 lock means another build is mid-bootstrap.
             // `--force` overrides (for a stale lock left by a crash).
             if !force && dev_vz::stage0_bootstrap_in_flight() {
                 anyhow::bail!(
@@ -424,7 +424,7 @@ pub(in crate::commands) fn run(_cli: &Cli, args: Args, _cfg: &MvmConfig) -> Resu
             // Sweep orphaned Stage 0 staging dirs first.
             // They live under `~/.cache/mvm/builder-vm/.<arch>.stage0-*`
             // (or the legacy `<arch>-staging` shape) and are left
-            // behind by crashed `mvmctl dev up` invocations. The sweep
+            // behind by crashed builder VM bootstrap invocations. The sweep
             // takes the Stage 0 advisory lock to avoid racing a live
             // bootstrap; if the lock is held it skips silently and we
             // proceed with the temp-file sweep.

--- a/crates/mvm-cli/src/commands/pack/download.rs
+++ b/crates/mvm-cli/src/commands/pack/download.rs
@@ -3,7 +3,7 @@
 //! recorded for a key becomes active, since none existed to preserve).
 //!
 //! Only the builder pack class has a release-fetch wired today (via the
-//! `dev up` bootstrap path's published-pack machinery); runtime/dev-image
+//! builder VM bootstrap path's published-pack machinery); runtime/dev-image
 //! packs have no publish/fetch story yet, so those refuse explicitly rather
 //! than pretending to do something.
 

--- a/crates/mvm-cli/src/commands/shared/parse.rs
+++ b/crates/mvm-cli/src/commands/shared/parse.rs
@@ -395,7 +395,7 @@ fn validate_host_path(host: &str, expect_dir: bool) -> Result<String> {
 }
 
 /// Parse-then-validate a single volume spec into a [`VmVolume`], the
-/// shared choke point for both `mvmctl up`/`run` and `mvmctl dev`.
+/// shared choke point for both `mvmctl up`/`run`.
 ///
 /// Enforces, in order:
 /// - **Encryption fail-closed:** a `:enc` disk is refused with a clear

--- a/crates/mvm-cli/src/commands/shared/resolve.rs
+++ b/crates/mvm-cli/src/commands/shared/resolve.rs
@@ -2,15 +2,13 @@
 
 use anyhow::{Context, Result};
 
-use mvm::config;
-use mvm::shell;
 use mvm_backend::firecracker;
+use mvm_backend::microvm;
 
 /// Resolve a VM name to its absolute directory path and verify the VM
 /// is running.
 pub fn resolve_running_vm(name: &str) -> Result<String> {
-    let abs_vms = shell::run_in_vm_stdout(&format!("echo {}", config::VMS_DIR))?;
-    let abs_dir = format!("{}/{}", abs_vms, name);
+    let abs_dir = microvm::resolve_running_vm_dir(name)?;
     let pid_file = format!("{}/fc.pid", abs_dir);
 
     if !firecracker::is_vm_running(&pid_file)? {

--- a/crates/mvm-cli/src/commands/vm/artifact.rs
+++ b/crates/mvm-cli/src/commands/vm/artifact.rs
@@ -85,8 +85,8 @@ pub(in crate::commands) enum Cmd {
     ModelConfig(ModelConfigArgs),
     /// Build a microVM artifact via the existing build pipeline.
     ///
-    /// This is a thin delegation stub — use `mvmctl build` or
-    /// `mvmctl dev` for the full build workflow. This subcommand
+    /// This is a thin delegation stub — use `mvmctl build`
+    /// for the full build workflow. This subcommand
     /// exists to make the artifact group self-contained.
     #[command(name = "model-build")]
     ModelBuild(ModelBuildArgs),
@@ -557,7 +557,7 @@ fn run_model_config(args: ModelConfigArgs) -> Result<()> {
 }
 
 fn run_model_build(_args: ModelBuildArgs) -> Result<()> {
-    // Thin stub: the full build pipeline lives in `mvmctl build` / `mvmctl dev`.
+    // Thin stub: the full build pipeline lives in `mvmctl build`.
     // Wiring NixMicrovmBuilder end-to-end here would require a running builder
     // VM, which is a larger slice. Delegate with a clear message.
     crate::ui::info(

--- a/crates/mvm-cli/src/commands/vm/exec.rs
+++ b/crates/mvm-cli/src/commands/vm/exec.rs
@@ -30,7 +30,7 @@ pub(in crate::commands) struct Args {
     /// legacy slot name). If omitted, the bundled
     /// `nix/images/default-tenant/` image is used (built via Nix on first use,
     /// cached at `~/.cache/mvm/default-microvm/`). Each invocation boots a
-    /// fresh transient microVM — never the long-running `mvmctl dev` VM.
+    /// fresh transient microVM — never the long-running builder VM.
     #[arg(short = 'm', long)]
     pub manifest: Option<String>,
     /// Internal (not a CLI flag): warm-pool size for this run, carried

--- a/crates/mvm-cli/src/doctor.rs
+++ b/crates/mvm-cli/src/doctor.rs
@@ -38,7 +38,7 @@ pub enum DoctorWorkflow {
     /// Operator launching a prebuilt `.mvmpkg` bundle. No host
     /// build tooling required.
     BundleRun,
-    /// `mvmctl dev` flow — drops the operator into a builder-VM
+    /// Builder-VM shell workflow — drops the operator into a builder-VM
     /// shell. Builder tooling + platform capabilities only;
     /// no host-side rust toolchain required.
     DevShell,
@@ -63,7 +63,7 @@ impl DoctorWorkflow {
             // so a bundle-running operator isn't blocked by a
             // missing `cargo` they don't need.
             Self::BundleRun => &["platform", "security", "disk"],
-            // `mvmctl dev` is the bootstrap-time flow; the host
+            // The dev-shell workflow is the bootstrap-time flow; the host
             // doesn't need rustup/cargo for it (the dev VM owns
             // the build toolchain). Drop `prerequisites`.
             Self::DevShell => &["tools", "platform", "security", "disk"],

--- a/crates/mvm-cli/src/update.rs
+++ b/crates/mvm-cli/src/update.rs
@@ -214,7 +214,7 @@ fn download_release(version: &str, target: &str, tmp_dir: &Path) -> Result<()> {
 /// set it in CI.
 ///
 /// Gated to `builder-vm`: the only callers (`mvmctl kernel build`'s
-/// download arm + the `dev up --kernel-source` bootstrap) live behind
+/// download arm + the `mvmctl bootstrap --kernel-source` path) live behind
 /// that feature.
 #[cfg(feature = "builder-vm")]
 pub(crate) fn download_kernel(arch: &str, variant: &str, dest: &Path) -> Result<()> {

--- a/crates/mvm-core/src/config.rs
+++ b/crates/mvm-core/src/config.rs
@@ -7,7 +7,7 @@ pub const FC_VERSION_DEFAULT: &str = match option_env!("MVM_FC_VERSION") {
 /// Host CPU architecture for arch-tagged downloads (the Firecracker release
 /// binary, firecracker-ci kernel/rootfs). `std::env::consts::ARCH` is the arch
 /// mvmctl was compiled for == the arch it runs on, so the downloaded binaries
-/// match the host. (Was hardcoded `"aarch64"` — wrong on x86_64: `dev up`
+/// match the host. (Was hardcoded `"aarch64"` — wrong on x86_64: a build
 /// fetched the aarch64 firecracker on an x86_64 host → "Exec format error".)
 pub const ARCH: &str = std::env::consts::ARCH;
 
@@ -100,7 +100,7 @@ pub fn mvm_data_dir_strict() -> std::io::Result<std::path::PathBuf> {
 /// mode `0700` and return its path. Idempotent: if the dir already
 /// exists with looser perms, chmod it to `0700` so a host that was
 /// created before this lockdown still gets locked down on the next
-/// `dev up`.
+/// run.
 ///
 /// `~/.mvm` holds the dev VM's GC root, the host-backed Nix store
 /// disk image, the per-VM `vsock.sock` proxy listener path, build

--- a/crates/mvm-core/src/crypto/image_verify.rs
+++ b/crates/mvm-core/src/crypto/image_verify.rs
@@ -7,7 +7,7 @@
 //! content hashes) so the input bytes are recoverable from the signed
 //! manifest alone.
 //!
-//! This module is consumed by mvmctl on `dev up` and by mvmd on pool image
+//! This module is consumed by mvmctl (e.g. `mvmctl up`) and by mvmd on pool image
 //! verification. The typed `VerifyError` contract lets mvmd's reconciliation
 //! loop pattern-match outcomes instead of crash-looping on `anyhow::Error`.
 

--- a/crates/mvm-core/src/policy/audit.rs
+++ b/crates/mvm-core/src/policy/audit.rs
@@ -319,8 +319,8 @@ pub enum LocalAuditKind {
     // --- Stage 0 builder VM bootstrap lifecycle ---
     //
     // Three events bracket the per-host Stage 0 lifecycle so a
-    // contributor can answer "did `dev up` actually run Stage 0 last
-    // night, and how did it land?" after the fact. We emit into the
+    // contributor can answer "did the builder VM bootstrap actually run
+    // Stage 0 last night, and how did it land?" after the fact. We emit into the
     // shared local audit log (rather than a separate
     // `~/.mvm/audit/stage0.jsonl`) because (a) every
     // other contributor-side event already lands there, (b) the
@@ -331,7 +331,7 @@ pub enum LocalAuditKind {
     // Detail formats are space-separated key=value pairs to match
     // every other call site (the macro can't emit JSON without a
     // wider schema change). SHAs are intentionally omitted — hashing
-    // a 700 MiB rootfs on every `dev up` is too expensive for an
+    // a 700 MiB rootfs on every builder VM bootstrap is too expensive for an
     // audit event; the seed label + source fingerprint prefix are
     // enough to correlate against the build cache.
     //

--- a/crates/mvm-core/src/protocol/vm_backend.rs
+++ b/crates/mvm-core/src/protocol/vm_backend.rs
@@ -224,7 +224,7 @@ pub struct VmStartConfig {
     /// backends activate the gateway audit substrate (bridge factory +
     /// chain-signed audit emit). `None` keeps the legacy
     /// `run_supervisor` path for callers
-    /// without admission (`mvmctl dev` Stage 0 builder, session VMs,
+    /// without admission (the builder VM bootstrap, session VMs,
     /// template restore).
     pub tenant_id: Option<String>,
     /// JSON-encoded `SignedExecutionPlan` envelope. Carried as a
@@ -628,7 +628,7 @@ pub enum VmStatus {
 /// for:
 ///
 ///   - `mvmctl run` followed by `mvmctl exec` in the same shell.
-///   - `mvmctl dev` interactive sessions where the user expects the
+///   - Interactive foreground sessions where the user expects the
 ///     VM to disappear when they Ctrl-C.
 ///   - Test harnesses that want deterministic teardown.
 ///

--- a/crates/mvm/src/vm/template/lifecycle.rs
+++ b/crates/mvm/src/vm/template/lifecycle.rs
@@ -908,6 +908,8 @@ pub fn template_build_from_manifest(
         "if [ -f {flake}/flake.lock ]; then nix hash path {flake}/flake.lock; else echo ''; fi",
         flake = persisted.flake_ref
     ))
+    // On a tier with no Linux builder to run this against, the call itself
+    // errors here and silently degrades to the revision hash below.
     .unwrap_or_default()
     .trim()
     .to_string();
@@ -980,6 +982,10 @@ pub fn template_build_from_manifest(
 /// On failure, the original hash is restored.
 #[instrument(skip_all, fields(flake_ref))]
 fn update_fod_hash(flake_ref: &str) -> Result<()> {
+    crate::linux_env::require_guest_exec_available(
+        "recomputing the fixed-output-derivation hash needs a real 'nix build'",
+    )?;
+
     ui::info("Recomputing fixed-output derivation hash...");
 
     // Save original hash for recovery.
@@ -1587,6 +1593,25 @@ mod tests {
             created_at: "2026-06-16T00:00:00Z".to_string(),
             updated_at: "2026-06-16T00:00:00Z".to_string(),
         }
+    }
+
+    /// `update_fod_hash` needs a real Linux builder to run `nix build`
+    /// against; on the macOS 26+ tier (no builder to dispatch to) it must
+    /// fail closed with an actionable error up front rather than failing
+    /// deep inside a doomed `run_in_vm` call. Host-conditioned: only
+    /// asserts on the tier it actually applies to.
+    #[cfg(target_os = "macos")]
+    #[test]
+    fn update_fod_hash_fails_closed_on_vz_default_tier() {
+        if !mvm_core::platform::current().is_vz_default_tier() {
+            return;
+        }
+        let err = update_fod_hash("/nonexistent/flake")
+            .expect_err("must fail closed with no builder available");
+        assert!(
+            err.to_string().contains("fixed-output-derivation"),
+            "unexpected message: {err}"
+        );
     }
 
     #[test]

--- a/crates/mvm/src/vm/template/lifecycle.rs
+++ b/crates/mvm/src/vm/template/lifecycle.rs
@@ -166,23 +166,6 @@ fn validate_legacy_template_name(id: &str) -> Result<()> {
     validate_template_name(id).with_context(|| format!("Invalid template name: {id:?}"))
 }
 
-/// Run a shell command in the VM and check its exit code.
-/// Returns an error with stderr context if the command fails.
-fn vm_exec(script: &str) -> Result<()> {
-    let out = shell::run_in_vm(script)?;
-    if !out.status.success() {
-        let stderr = String::from_utf8_lossy(&out.stderr).trim().to_string();
-        let first_line = script.lines().next().unwrap_or(script);
-        return Err(anyhow!(
-            "Command failed (exit {}): {}\n  command: {}",
-            out.status.code().unwrap_or(-1),
-            stderr,
-            first_line,
-        ));
-    }
-    Ok(())
-}
-
 #[instrument(skip_all, fields(template_id = %spec.template_id))]
 pub fn template_create(spec: &TemplateSpec) -> Result<()> {
     validate_legacy_template_name(&spec.template_id)?;
@@ -241,17 +224,6 @@ pub fn template_delete(id: &str, force: bool) -> Result<()> {
         Err(e) if e.kind() == std::io::ErrorKind::NotFound && force => Ok(()),
         Err(e) => Err(e).with_context(|| format!("Failed to delete template {}", id)),
     }
-}
-
-/// Initialize an on-disk template directory layout (empty artifacts, no spec).
-/// Safe to call multiple times; existing contents are preserved.
-#[instrument(skip_all, fields(template_id = id))]
-pub fn template_init(id: &str) -> Result<()> {
-    let dir = template_dir(id);
-    let artifacts = format!("{}/artifacts/revisions", dir);
-    vm_exec(&format!("mkdir -p {dir} {artifacts}"))
-        .with_context(|| format!("Failed to initialize template directory {}", dir))?;
-    Ok(())
 }
 
 // ---------------------------------------------------------------------------

--- a/specs/plans/248-guest-ops-macos.md
+++ b/specs/plans/248-guest-ops-macos.md
@@ -1,0 +1,104 @@
+# Plan 248 — Guest-op fallout on macOS 26+ (Plan 247 W4, tractable set)
+
+> **For agentic workers:** REQUIRED SUB-SKILL: superpowers:subagent-driven-development.
+
+**Created:** 2026-07-12
+**Related:** Plan 247 (`specs/plans/247-runvm-macos-shell-ops.md` §W4).
+**Base:** `feat/plan-247-runvm-macos` (stacked on #1669 → #1667).
+**Status:** draft
+
+**Goal:** finish the macOS 26+ `run_in_vm` fallout for the "genuine guest op" set —
+fix the common `--add-dir` case in-process with the pure-Rust ext4 writer, fix a
+stale-duplicate `resolve_running_vm`, delete dead `template_init`, and replace the
+remaining hard-fails with clear platform-gates. The one op that genuinely needs a
+Linux builder — `build validate` (`nix flake check`) — is deferred: its typed-daemon
+substrate is libkrun-only + persistent-only and HVF (the macOS 26+ default) was never
+wired into it, which is its own plan.
+
+**Naming (corrected from the W4 sketch):** the flag is `--add-dir HOST:GUEST[:ro|rw]`
+(not `--mount`); the orchestration call sites are in `crates/mvm-cli/src/exec.rs`
+(not `commands/vm/exec.rs`).
+
+## Global Constraints
+- `cargo fmt --all -- --check` (nightly) clean; `cargo nextest run -p <crate>` green; `cargo clippy --workspace --all-targets -- -D warnings` clean.
+- No plan/PR/ADR/issue refs in CODE comments. No `#[allow(clippy::too_many_arguments)]`. Reuse existing helpers. No AI-attribution in commits.
+- `mvm-backend` test bin is SIGKILL'd by codesign locally — build-check, don't nextest it.
+- All work in the `plan-248-w4` worktree.
+
+---
+
+### Task 1: `--add-dir` create → pure-Rust ext4 (the high-value fix)
+
+`crates/mvm-backend/src/image.rs::build_dir_image_ro` (~line 760) builds an ext4 from
+a host dir via `run_in_vm("mkfs.ext4 …" + mount + copy + unmount)` — hard-fails on
+macOS 26+. `mvm-backend` already depends on `mvm-build` with `features =
+["builder-vm","pure-mkfs"]`, so `mvm_build::rootfs::materialize_ext4_pure` is reachable
+with no new Cargo wiring. The only gap: the guest mounts the volume by LABEL
+(`mount LABEL={label}`, `crates/mvm-cli/src/exec.rs:706`), and the pure writer's current
+call chain uses the label-less `mvm_ext4::emit_image`; but `mvm_ext4::BuildOptions::with_volume_name`
++ `emit_image_with_options` (`crates/mvm-ext4/src/lib.rs:212-226`) already exist.
+
+**Files:** `crates/mvm-backend/src/image.rs` (`build_dir_image_ro`), and whichever
+`materialize_ext4_pure`/`rootfs.rs` seam is needed to pass a volume label through.
+
+- [ ] **Step 1:** Read `build_dir_image_ro` end-to-end (what host dir → what ext4 path → what label the guest expects) and `materialize_ext4_pure` / `emit_image_with_options`.
+- [ ] **Step 2: Failing test** — a tempdir tree → `build_dir_image_ro` produces an ext4 file whose superblock volume label matches the expected `{label}`, WITHOUT any `run_in_vm`. Read the label back with the existing `mvm-ext4` reader-of-superblock, or assert the writer was called with the label (whichever is testable). RED first.
+- [ ] **Step 3:** Reimplement `build_dir_image_ro` to walk the host dir and call `materialize_ext4_pure` (threading the volume label via `BuildOptions::with_volume_name` / `emit_image_with_options`). Remove the `run_in_vm` mkfs/mount/copy/unmount block. Preserve the exact output ext4 path + label the guest mount depends on.
+- [ ] **Step 4:** GREEN. `cargo build --workspace --all-targets` + the affected tests.
+- [ ] **Step 5:** Commit: `fix(add-dir): build the ext4 volume in-process, not via a VM`.
+
+### Task 2: `resolve_running_vm` → call the already-fixed sibling
+
+`crates/mvm-cli/src/commands/shared/resolve.rs:11 resolve_running_vm` (used only by
+`machine forward`, `forward.rs:47`) echoes `config::VMS_DIR` inside a VM and greps
+`/proc`. `crates/mvm-backend/src/microvm.rs:197 resolve_running_vm_dir` already fixed
+this exact bug (expands `VMS_DIR` via `std::env::var("HOME")`, no VM); every other call
+site uses it.
+
+- [ ] **Step 1:** Read both. Confirm `resolve_running_vm_dir` returns what `forward.rs` needs (the running-VM dir / state).
+- [ ] **Step 2:** Replace `resolve.rs`'s `resolve_running_vm` body with a call to `microvm::resolve_running_vm_dir` (or delete `resolve.rs`'s version and repoint `forward.rs:47` at the sibling). Keep behavior for `forward`.
+- [ ] **Step 3:** `cargo build --workspace --all-targets` + `cargo nextest run -p mvm-cli`. Commit: `fix(forward): resolve the running VM on the host, not through a VM`.
+
+Note (document, don't fix): `forward`'s `socat`-to-guest-IP mechanism needs a routable
+guest IP, which HVF (vsock-only) never has, and its `fc.pid` check is Firecracker-only —
+a pre-existing gap unrelated to the dev-VM removal. This task only removes the
+`run_in_vm` crash in resolution; full `forward`-on-macOS is out of scope.
+
+### Task 3: Delete dead `template_init` / `vm_exec`
+
+`git grep -n template_init crates/` → one hit (its own definition); `mvmctl` has no
+`template` verb. `vm_exec` (`lifecycle.rs:171`) is called only by `template_init`
+(`:249`). Both dead.
+
+- [ ] **Step 1:** Confirm zero live callers (grep). Delete both functions + any now-dead imports.
+- [ ] **Step 2:** `cargo build --workspace --all-targets` + `cargo clippy --workspace --all-targets -- -D warnings` clean. Commit: `refactor(template): delete dead template_init/vm_exec (no template verb)`.
+
+### Task 4: Clear platform-gates for the deferred guest ops
+
+Replace the raw `run_in_vm` hard-crash with an honest, actionable error on the tiers
+where these can't run yet (macOS 26+ HVF, which has no builder-exec path):
+
+- `crates/mvm-backend/src/image.rs::rsync_image_to_host` (`--add-dir :rw` write-back — needs an ext4 *reader*, which doesn't exist).
+- `crates/mvm/src/vm/template/lifecycle.rs::update_fod_hash` (`--update-hash` — a real TOFU `nix build`).
+- `crates/mvm-cli/src/commands/build/validate.rs` (`nix flake check` — the deferred typed-builder case).
+
+- [ ] **Step 1:** For each, before it would call `run_in_vm`, detect the no-builder-exec tier and return an `Err` whose message names the limitation + the workaround (run on Linux / in CI, or start a persistent libkrun builder), as a plain concept (no spec-refs). A tiny shared helper `fn require_guest_exec_available() -> Result<()>` is fine. Prefer reusing an existing platform/backend predicate — grep first (e.g. the tier check `is_vz_default_tier` used elsewhere).
+- [ ] **Step 2:** Tests: each gated path returns the clear `Err` on the HVF tier (or asserts the helper's decision). Leave `lifecycle.rs`'s flake.lock `nix hash` line alone (already `.unwrap_or_default()` soft-fail — add a one-line code comment that it degrades to the revision hash off-Linux).
+- [ ] **Step 3:** Workspace gate. Commit: `fix(guest-ops): gate builder-only ops with a clear error instead of a VM crash`.
+
+### Task 5: Gate + status
+
+- [ ] Full gate (`fmt --all` nightly, `nextest --workspace -E 'not package(mvm-backend)'`, `clippy --workspace --all-targets -D warnings`, `cargo build -p mvm-backend --all-targets`). Update `specs/REFACTOR-STATUS.md`. Commit.
+
+---
+
+# Deferred (own plan): `validate`/`update_fod_hash` real substrate
+
+Make genuine guest ops work on macOS 26+ by giving the builder VM an on-demand
+boot-run-teardown typed-exec path and wiring HVF into the persistent/typed-daemon mode
+(today: libkrun-only, persistent-only, hidden verb; discovery still carries dead Vz-shape
+code). This is the real "typed-RPC to headless builder" substrate — sized as its own plan.
+
+# Self-review notes
+- The common `--add-dir` case (T1) and both cleanups (T2, T3) make macOS 26+ correct for what's tractable in-process; T4 converts the rest from confusing crashes to honest gates.
+- T1 risk: the guest mounts by LABEL — the pure-Rust ext4 MUST carry the same volume label, or `mount LABEL=…` fails in-guest. The failing test must assert the label.

--- a/specs/plans/249-builder-substrate-and-robustness.md
+++ b/specs/plans/249-builder-substrate-and-robustness.md
@@ -31,11 +31,21 @@ are gated with a clear error today (Plan 248 T4).
 
 ## WS-B — Builder-store robustness (the corruption/space failure we hit)
 
-**Problem.** A corrupted persistent builder nix-store (ext4 checksum failures → mounts
-read-only) makes **every** flake build fail hard with a cryptic "guest did not write
-result", on both backends. Recovery today is a manual `rm -rf ~/.cache/mvm/builder-vm` +
-full rebuild. The store also grows unbounded, and a crashed build leaves its multi-GB
-`input.img` transient behind (the reaper only runs on `cache prune` / next launch).
+**Problem.** `machine run --flake` / `machine build` fail hard with a cryptic "guest did
+not write result" from **two independent builder-VM faults**, observed live on macOS-26:
+- **(i) Store corruption.** A corrupted persistent nix-store (`EXT4-fs error … Directory
+  block failed checksum` → mounts read-only) fails every build. Recovery today is a manual
+  `rm -rf ~/.cache/mvm/builder-vm` + full rebuild. The store also grows unbounded (seen at
+  111 GB), and a crashed build leaves its multi-GB `input.img` transient behind (the reaper
+  only runs on `cache prune` / next launch).
+- **(ii) virtiofs share failure → disk-transport no-space.** Even with a **fresh** store,
+  the libkrun builder's virtiofs shares don't attach (`virtio-fs: tag <work>/<out>/<job>/
+  <mvm-bins> not found` → EINVAL), forcing the disk-transport fallback (`tar x /dev/vdc`),
+  which then fails `No space left on device` staging the closure → read-only → no result.
+  This is a transport-attach + input-disk-sizing bug, distinct from (i), and blocks
+  `--flake` builds on this host regardless of store health. Root-cause the virtiofs
+  tag-not-found on the libkrun builder (supervisor share config vs. libkrun version), and
+  size the disk-transport input/store for real closures.
 
 **Design.**
 1. **Detect + auto-recover a bad store.** When the builder guest reports a read-only /
@@ -50,7 +60,7 @@ full rebuild. The store also grows unbounded, and a crashed build leaves its mul
 4. **`mvmctl doctor` surfaces store health** (size, last-known-good, corruption flag) and
    `mvmctl cache repair` gains a builder-store path.
 
-**Tasks (sketch):** console marker for read-only/corrupt store; host detect + `e2fsck`/rebuild recovery; eager transient reap; store size cap + GC; doctor/cache-repair surface. **Effort: medium.**
+**Tasks (sketch):** console marker for read-only/corrupt store; host detect + `e2fsck`/rebuild recovery; eager transient reap; store size cap + GC; doctor/cache-repair surface; **root-cause the libkrun virtiofs tag-not-found and size the disk-transport input/store (fault ii)**. **Effort: medium.**
 
 ## WS-C — Air-gapped builder-image import (successor to the removed `mvmctl dev import-image`)
 

--- a/specs/plans/249-builder-substrate-and-robustness.md
+++ b/specs/plans/249-builder-substrate-and-robustness.md
@@ -1,0 +1,77 @@
+# Plan 249 — Headless builder substrate, store robustness, air-gapped import
+
+**Created:** 2026-07-12
+**Related:** Plan 246 (dev removal), Plan 247/248 (macOS-26 `run_in_vm` fallout).
+This plan covers the **larger** deferred items those left open.
+**Status:** draft (design + sequencing; not yet executed)
+
+The small followups (stale `dev up` code-comments; the stale-doc `mvmctl build --flake`
+→ `mvmctl build image --flake` fix) are handled separately. This plan is the three
+substantial pieces.
+
+---
+
+## WS-A — Headless builder typed-exec substrate (unblocks `build validate` + `--update-hash` on macOS 26+)
+
+**Problem.** On macOS 26+ these genuine guest ops (`nix flake check`, the `--update-hash`
+TOFU `nix build`) have no way to reach a Linux builder: the typed `mvm-builderd` daemon
+only runs in the **persistent** boot mode (opt-in, hidden `persistent-builder` verb), the
+single-shot builder VM that `build image` uses never spawns it, the persistent path is
+**libkrun-only** (Vz was the second backend, now deleted — the socket-discovery still
+carries dead Vz-shape code), and HVF (the macOS-26 default) was never wired into it. They
+are gated with a clear error today (Plan 248 T4).
+
+**Design.**
+1. **On-demand typed-exec wrapper.** A `boot builder → submit one typed op → collect result → teardown` path, reusing the existing `BuilderVm::run_build` boot/teardown machinery but submitting a typed request instead of a `BuilderJob`. This is the missing primitive — `build image` already boots-runs-one-job-teardowns; generalize that to typed ops.
+2. **New/confirmed typed ops** in `builder_protocol.rs` (`HostVmRequest`): `FlakeCheck` already exists (used by the opt-in `MVM_BUILDERD_TYPED` path) — route `validate` through the on-demand wrapper by default. Add a `ComputeFodHash { flake_ref, attr }` op for `--update-hash` (blanks `outputHash`, runs `nix build`, scrapes `got: sha256-…`). Do NOT add a generic `Exec { script }` — keep it job/op-shaped.
+3. **HVF into the typed path.** Give the HVF builder a persistent/dispatch-marker boot mode + an HVF control-socket-discovery shape (replacing the dead Vz-shape candidate in `resolve_running_builder_socket`). For the on-demand wrapper this can be simpler than full persistent mode — a single typed op over the same transport the single-shot boot already establishes.
+4. **Flip the gate → the substrate.** Once (1)–(3) land, `validate`/`--update-hash` call the on-demand typed path instead of returning the Plan 248 T4 error; keep the error only as the `--no-default-features`/unavailable fallback.
+
+**Tasks (sketch):** typed op + protocol; on-demand wrapper (boot→op→teardown); route `validate` through it; `ComputeFodHash` op + route `--update-hash`; HVF socket-discovery shape; remove the T4 gate for these two; live-proof on macOS-26. **Effort: large.** `validate` (FlakeCheck exists) is the near half; `--update-hash` + HVF discovery are the far half.
+
+## WS-B — Builder-store robustness (the corruption/space failure we hit)
+
+**Problem.** A corrupted persistent builder nix-store (ext4 checksum failures → mounts
+read-only) makes **every** flake build fail hard with a cryptic "guest did not write
+result", on both backends. Recovery today is a manual `rm -rf ~/.cache/mvm/builder-vm` +
+full rebuild. The store also grows unbounded, and a crashed build leaves its multi-GB
+`input.img` transient behind (the reaper only runs on `cache prune` / next launch).
+
+**Design.**
+1. **Detect + auto-recover a bad store.** When the builder guest reports a read-only /
+   checksum-failed store (surface the marker from `mvm-host-vm-init` in the console), the
+   host recognizes it and either `e2fsck -fy` the store image or rebuilds it from Stage 0,
+   with a clear one-line message — instead of the opaque "guest did not write result".
+2. **Eager transient reaping.** Reap a crashed build's transient VM dir (its `input.img`)
+   on the next launch even without an explicit `cache prune` (the Stage-0 reaper is
+   prefix-agnostic — extend it to the job-transient dirs).
+3. **Bound the persistent store.** A size ceiling + GC (`nix-collect-garbage` inside the
+   builder, or a store-size check that triggers a prune) so it can't grow to 100 GB+.
+4. **`mvmctl doctor` surfaces store health** (size, last-known-good, corruption flag) and
+   `mvmctl cache repair` gains a builder-store path.
+
+**Tasks (sketch):** console marker for read-only/corrupt store; host detect + `e2fsck`/rebuild recovery; eager transient reap; store size cap + GC; doctor/cache-repair surface. **Effort: medium.**
+
+## WS-C — Air-gapped builder-image import (successor to the removed `mvmctl dev import-image`)
+
+**Problem.** `mvmctl dev import-image` let air-gapped operators install a builder VM image
+from a local file (no network). It was deleted with `mvmctl dev`; no successor exists
+(`BuilderVmBootstrapArgs` is an empty struct), so `mvmctl bootstrap`'s air-gapped hint was
+dropped (Plan 248 T4) and the docs carry a `:::caution`.
+
+**Design.** Resurrect the import logic (from the deleted `cmd_dev_import_image` in git
+history) as a headless verb — the cleanest shape is a flag on the existing bootstrap verb:
+`mvmctl bootstrap --from-image <path>` (installs a local builder image into
+`~/.cache/mvm/builder-vm/<arch>/` with hash-verification, no network), plus the matching
+`mvmctl builder-vm-bootstrap` internal path. Decide vs. a standalone `mvmctl builder
+import <path>` verb. Then restore the air-gapped hint + drop the docs caution.
+
+**Tasks (sketch):** recover import + verify logic; pick the verb shape; wire it; restore the hint/docs. **Effort: small–medium.** Gate on whether air-gapped operators are a supported audience — if not, formally record the capability as dropped instead.
+
+---
+
+## Sequencing
+WS-B (robustness) is the highest-value-per-effort — it turns a hard, cryptic, all-builds
+failure into a self-healing one, and it's what bit the live check. WS-A (substrate) is the
+largest and unblocks two commands; do it once WS-B makes the builder reliable to iterate
+on. WS-C is small and independent. Each is its own PR.


### PR DESCRIPTION
**Stacked on #1672.** Knocks out the small dev-removal followups and files the plan for the larger ones.

## Small item — done
- **72 stale `dev up` / `mvmctl dev` code-comments reworded** across 36 files (pointing at `mvmctl bootstrap` / "a build" / the actual mechanism). Comment-only; build/fmt/spec-refs clean. A couple of factually-wrong comments (orphan-sweep wiring) were corrected to match reality.

## Plan for the larger items — `specs/plans/249-builder-substrate-and-robustness.md`
- **WS-A — headless builder typed-exec substrate** (unblocks `build validate` + `--update-hash` on macOS-26): an on-demand *boot→one-typed-op→teardown* path + a `ComputeFodHash` op + wiring HVF into the typed-daemon discovery (today libkrun-only, dead Vz-shape code). *Large.*
- **WS-B — builder-store robustness** (what bit the live check): two live-observed faults — **(i)** nix-store ext4 corruption → read-only → every build fails (recovered by wiping 111 GB here), and **(ii)** even on a fresh store, the libkrun builder's virtiofs shares don't attach (`tag not found`) → disk-transport fallback → `No space left on device`. Design: detect + auto-recover (`e2fsck`/rebuild), eager transient reaping, a store size cap + GC, root-cause the virtiofs attach + size the disk-transport. *Medium — highest value/effort.*
- **WS-C — air-gapped `import-image` successor** (`mvmctl bootstrap --from-image <path>`), resurrecting the deleted logic — or formally record air-gapped as unsupported. *Small–med.*

## Notes
- The "Plan-208 `mvmctl build --flake` bug" is **not a code bug** — `build` is a subcommand group, so the correct form is `mvmctl build image --flake`. It's just stale-doc usages of the bare form (small doc fix, belongs with the docs PR).