### PR TITLE
Plan 249 WS-B PR-1: fix builder disk-transport input bloat (unblocks --flake, layer 2)

### DIFF
--- a/crates/mvm-build/src/bin/mvm-host-vm-init.rs
+++ b/crates/mvm-build/src/bin/mvm-host-vm-init.rs
@@ -212,9 +212,10 @@ fn parse_user_volumes_cmdline(cmdline: &str) -> Vec<UserVolMount> {
     out
 }
 
-/// Disk-transport config parsed from the kernel cmdline. The hvf VMM has no
-/// virtio-fs, so the builder moves the job in and the artifacts out over raw
-/// disks (tar-on-a-block-device) instead of virtio-fs shares.
+/// Disk-transport config parsed from the kernel cmdline. A Rootfs-image
+/// libkrun builder VM moves the job in and the artifacts out over raw disks
+/// (tar-on-a-block-device) rather than virtio-fs shares; the hvf VMM has no
+/// virtio-fs at all, so this is its only option.
 /// `mvm.builder_transport=disk` enables it; `mvm.builder_input=` /
 /// `mvm.builder_output=` name the block devices (defaulting to the vdc/vdd
 /// convention). Absent ⇒ `None`, and the init keeps the virtio-fs path unchanged.
@@ -1467,15 +1468,22 @@ mod linux {
         // Threads write into the same `Mutex<BootTimings>`;
         // contention is a non-issue (a handful of writes per
         // boot, none on the hot path).
-        // Disk-transport mode (the hvf VMM has no virtio-fs): decided once
-        // from the cmdline. `None` keeps the virtio-fs builder path unchanged.
+        // Disk-transport mode: decided once from the cmdline. `None` keeps
+        // the virtio-fs builder path unchanged; `Some` means the host
+        // staged `/job`/`/work`/`/mvm-bins` on a raw block device instead
+        // (every Rootfs-image libkrun builder run, plus the hvf VMM, which
+        // has no virtio-fs at all) — the fixed virtio-fs share attempts
+        // below would just fail with "tag not found" noise.
         let disk_transport = crate::parse_disk_transport_cmdline(
             &std::fs::read_to_string("/proc/cmdline").unwrap_or_default(),
         );
+        let disk_transport_active = disk_transport.is_some();
 
         let track_b = {
             let timings = Arc::clone(&timings);
-            std::thread::spawn(move || setup_modules_and_virtiofs(&timings, anchor))
+            std::thread::spawn(move || {
+                setup_modules_and_virtiofs(&timings, anchor, disk_transport_active)
+            })
         };
         let track_c = {
             let timings = Arc::clone(&timings);
@@ -2835,8 +2843,18 @@ mod linux {
     /// Independent track that runs concurrently
     /// with `setup_nix_store`. Loads the `fuse` + `virtiofs`
     /// kernel modules (themselves fanned out across two threads),
-    /// then mounts the three virtio-fs shares.
-    fn setup_modules_and_virtiofs(timings: &Arc<Mutex<BootTimings>>, anchor: Instant) {
+    /// then mounts the three virtio-fs shares — unless disk-transport
+    /// staged those inputs onto a raw block device instead, in which case
+    /// the host never declared these virtio-fs shares and the mount
+    /// attempts would just fail with "tag not found".
+    /// `--volume` user shares still ride virtio-fs regardless (a
+    /// separate mechanism from the job's own input/output transport), so
+    /// the modprobes and [`mount_user_volumes`] always run.
+    fn setup_modules_and_virtiofs(
+        timings: &Arc<Mutex<BootTimings>>,
+        anchor: Instant,
+        disk_transport_active: bool,
+    ) {
         append_init_breadcrumb("setup_modules_and_virtiofs_enter", "start");
         // Load FUSE + virtio-fs kernel modules before mounting the
         // host-exported shares. Stock nixpkgs kernel ships these as
@@ -2868,12 +2886,24 @@ mod linux {
         // `/job/cmd.sh` if `/job` was supplied. Per-share errors
         // print to stderr but don't fail init — the failing share
         // surfaces as a normal file-not-found inside cmd.sh.
-        for (tag, target) in VIRTIOFS_MOUNTS {
-            if let Err(e) = mount_virtiofs(tag, target) {
-                append_init_breadcrumb("virtiofs_mount_error", &format!("{tag}->{target}: {e}"));
-                eprintln!("mvm-host-vm-init: virtio-fs '{tag}' -> {target} failed: {e}");
-            } else {
-                append_init_breadcrumb("virtiofs_mount_ok", &format!("{tag}->{target}"));
+        //
+        // Skipped entirely under disk-transport: the host never declares
+        // these tags in that mode (`stage_disk_transport_input` populates
+        // `/job`/`/work`/`/mvm-bins` from the raw input disk instead), so
+        // every attempt would fail with "tag not found".
+        if disk_transport_active {
+            append_init_breadcrumb("virtiofs_mounts_skipped", "disk-transport active");
+        } else {
+            for (tag, target) in VIRTIOFS_MOUNTS {
+                if let Err(e) = mount_virtiofs(tag, target) {
+                    append_init_breadcrumb(
+                        "virtiofs_mount_error",
+                        &format!("{tag}->{target}: {e}"),
+                    );
+                    eprintln!("mvm-host-vm-init: virtio-fs '{tag}' -> {target} failed: {e}");
+                } else {
+                    append_init_breadcrumb("virtiofs_mount_ok", &format!("{tag}->{target}"));
+                }
             }
         }
         // User-supplied volumes (`--volume` / MVM_VOLUMES),
@@ -2933,22 +2963,33 @@ mod linux {
             .map_err(|e| format!("mount virtiofs {tag} -> {target}: {e}"))
     }
 
-    /// Disk-transport staging root (tmpfs). The input disk's tar is extracted
-    /// here so `/job`, `/work`, `/mvm-bins` become writable bind targets — the
+    /// Disk-transport staging root. The input disk's tar is extracted here
+    /// so `/job`, `/work`, `/mvm-bins` become writable bind targets — the
     /// virtio-fs path binds host dirs, but the disk path must leave `/job`
-    /// writable so `write_result` can drop `/job/result`.
-    const DISK_INPUT_STAGE: &str = "/run/builder-input";
+    /// writable so `write_result` can drop `/job/result`. Lives on the
+    /// persistent nix-store disk rather than a RAM tmpfs: a tmpfs defaults to
+    /// roughly half of guest RAM, and a large `work` tree (even filtered)
+    /// can overflow it — the same reason [`OUT_DIR`]'s backing directory
+    /// below is on this disk, not tmpfs.
+    const DISK_INPUT_STAGE: &str = "/nix-store/builder-input";
 
+<<<<<<< HEAD
     /// Populate `/job`, `/work`, `/mvm-bins`, and (when the host packed one)
     /// `/closure-seed` from the input disk, and back `/out` with a writable
     /// dir on the persistent nix-store disk. This is the disk-transport
     /// equivalent of the virtio-fs shares, for the hvf VMM (which has no
     /// virtio-fs). A tmpfs `/out` would be capped by guest RAM — too small
     /// for a built rootfs — so `/out` lives on the big nix-store disk.
+=======
+    /// Populate `/job`, `/work`, `/mvm-bins` from the input disk and back `/out`
+    /// with a writable dir on the persistent nix-store disk. This is the
+    /// disk-transport equivalent of the virtio-fs shares — the primary
+    /// transport for a Rootfs-image libkrun builder VM, and the only option
+    /// for the hvf VMM (which has no virtio-fs).
+>>>>>>> 772e9bb83 (fix(builder-guest): stage disk-transport input off the RAM tmpfs)
     fn stage_disk_transport_input(t: &crate::DiskTransport) -> Result<(), String> {
         std::fs::create_dir_all(DISK_INPUT_STAGE)
             .map_err(|e| format!("mkdir {DISK_INPUT_STAGE}: {e}"))?;
-        mount_fs("tmpfs", DISK_INPUT_STAGE, "tmpfs")?;
         // Extract the input tar straight off the raw block device; tar stops at
         // the archive EOF marker before the disk's zero padding.
         let status = Command::new("/bin/busybox")

--- a/crates/mvm-build/src/bin/mvm-host-vm-init.rs
+++ b/crates/mvm-build/src/bin/mvm-host-vm-init.rs
@@ -2973,20 +2973,12 @@ mod linux {
     /// below is on this disk, not tmpfs.
     const DISK_INPUT_STAGE: &str = "/nix-store/builder-input";
 
-<<<<<<< HEAD
     /// Populate `/job`, `/work`, `/mvm-bins`, and (when the host packed one)
     /// `/closure-seed` from the input disk, and back `/out` with a writable
     /// dir on the persistent nix-store disk. This is the disk-transport
-    /// equivalent of the virtio-fs shares, for the hvf VMM (which has no
-    /// virtio-fs). A tmpfs `/out` would be capped by guest RAM — too small
-    /// for a built rootfs — so `/out` lives on the big nix-store disk.
-=======
-    /// Populate `/job`, `/work`, `/mvm-bins` from the input disk and back `/out`
-    /// with a writable dir on the persistent nix-store disk. This is the
-    /// disk-transport equivalent of the virtio-fs shares — the primary
-    /// transport for a Rootfs-image libkrun builder VM, and the only option
-    /// for the hvf VMM (which has no virtio-fs).
->>>>>>> 772e9bb83 (fix(builder-guest): stage disk-transport input off the RAM tmpfs)
+    /// equivalent of the virtio-fs shares — the primary transport for a
+    /// Rootfs-image libkrun builder VM, and the only option for the hvf VMM
+    /// (which has no virtio-fs).
     fn stage_disk_transport_input(t: &crate::DiskTransport) -> Result<(), String> {
         std::fs::create_dir_all(DISK_INPUT_STAGE)
             .map_err(|e| format!("mkdir {DISK_INPUT_STAGE}: {e}"))?;

--- a/crates/mvm-build/src/builder_disk_transport.rs
+++ b/crates/mvm-build/src/builder_disk_transport.rs
@@ -1,9 +1,10 @@
-//! Disk-only job/artifact transport for the hvf-VMM builder.
+//! Disk-only job/artifact transport for the builder VM.
 //!
-//! The libkrun/vz builder moves the job in and the artifacts out over virtio-fs
-//! shares (host directories). The hvf VMM has no virtio-fs, and the host is
-//! macOS — which can neither format nor read an ext4 — so the transport must
-//! never require host-side access to a guest filesystem.
+//! A Rootfs-image libkrun builder VM — the common `machine build` / `machine
+//! run --flake` case — moves the job in and the artifacts out this way. So
+//! does the hvf VMM, which has no virtio-fs at all; since its host is macOS,
+//! which can neither format nor read an ext4, the transport must never
+//! require host-side access to a guest filesystem.
 //!
 //! The transport is therefore a **tar written raw onto a disk image**, no
 //! filesystem on the transport disks:

--- a/crates/mvm-build/src/builder_vm_runtime.rs
+++ b/crates/mvm-build/src/builder_vm_runtime.rs
@@ -335,8 +335,10 @@ fn stage_filtered_workspace(workspace: &Path, mvm_src: &Path) -> std::io::Result
 }
 
 /// Recursive copy that prunes `WORKSPACE_SNAPSHOT_SKIP` basenames (and
-/// `result-*` symlinks) at any depth.
-fn copy_dir_filtered(src: &Path, dst: &Path) -> std::io::Result<()> {
+/// `result-*` symlinks) at any depth. `pub(crate)` so the disk-transport
+/// `work` input staging (`libkrun_builder`) can reuse this exclusion
+/// instead of forking a second skip list.
+pub(crate) fn copy_dir_filtered(src: &Path, dst: &Path) -> std::io::Result<()> {
     std::fs::create_dir_all(dst)?;
     for entry in std::fs::read_dir(src)? {
         let entry = entry?;

--- a/crates/mvm-build/src/libkrun_builder.rs
+++ b/crates/mvm-build/src/libkrun_builder.rs
@@ -554,6 +554,32 @@ fn prepare_builder_transport_disks(
     Ok((input_disk, output_disk))
 }
 
+/// Stage a filtered copy of `src` for the disk-transport `work` input.
+///
+/// On a source checkout, `src` (`BuilderMounts::flake_src` /
+/// `BuilderShellJob::work_dir`) can be the repo root, which carries
+/// `target/`, `.worktrees/`, `.git/`, and other build/VCS scratch —
+/// tens of GB that the guest's RAM-capped extraction tmpfs can't
+/// absorb. Reuses the same `WORKSPACE_SNAPSHOT_SKIP` exclusion the
+/// mvm-workspace snapshot (`stage_job_dir`'s `mvm-src` staging) already
+/// applies, rather than forking a second skip list.
+///
+/// Returns the `TempDir` holding the filtered copy; callers must keep
+/// it alive until the disk-transport pack that reads it completes.
+fn stage_filtered_work_input(src: &Path) -> Result<tempfile::TempDir, BuilderVmError> {
+    let staged = tempfile::TempDir::new().map_err(|e| {
+        BuilderVmError::ExtractionFailed(format!("creating filtered work staging dir: {e}"))
+    })?;
+    crate::builder_vm_runtime::copy_dir_filtered(src, staged.path()).map_err(|e| {
+        BuilderVmError::ExtractionFailed(format!(
+            "staging filtered work input {} -> {}: {e}",
+            src.display(),
+            staged.path().display()
+        ))
+    })?;
+    Ok(staged)
+}
+
 fn extract_builder_transport_output(
     output_disk: &Path,
     artifact_out: &Path,
@@ -970,6 +996,10 @@ impl LibkrunBuilderVm {
         let runtime_overlay = cached_runtime_overlay_ext4();
         let guest_agent_vsock =
             builder_runtime_overlay_guest_agent_enabled(&image, runtime_overlay.as_deref());
+        // `job.work_dir` can be the repo root on a source checkout; stage a
+        // filtered copy so `target/`/`.worktrees/`/`.git/` never ride the
+        // input tar. `work_staging` must outlive this call.
+        let work_staging = stage_filtered_work_input(&job.work_dir)?;
         let (input_disk, output_disk) = prepare_builder_transport_disks(
             &vm_state_dir,
             &[
@@ -979,7 +1009,7 @@ impl LibkrunBuilderVm {
                 },
                 InputTree {
                     name: "work",
-                    src: &job.work_dir,
+                    src: work_staging.path(),
                 },
             ],
             u64::from(BUILDER_OUTPUT_DISK_MIB) << 20,
@@ -1434,6 +1464,12 @@ impl BuilderVm for LibkrunBuilderVm {
         let runtime_overlay = cached_runtime_overlay_ext4();
         let guest_agent_vsock =
             builder_runtime_overlay_guest_agent_enabled(&image, runtime_overlay.as_deref());
+        // `mounts.flake_src` is the repo root itself on a source checkout
+        // (the "local-mvm override" invariant): stage a filtered copy so
+        // `target/`/`.worktrees/`/`.git/` never ride the input tar into the
+        // guest's RAM-capped extraction tmpfs. `work_staging` must outlive
+        // this call.
+        let work_staging = stage_filtered_work_input(&mounts.flake_src)?;
         let (input_disk, output_disk) = prepare_builder_transport_disks(
             &vm_state_dir,
             &[
@@ -1443,7 +1479,7 @@ impl BuilderVm for LibkrunBuilderVm {
                 },
                 InputTree {
                     name: "work",
-                    src: &mounts.flake_src,
+                    src: work_staging.path(),
                 },
                 InputTree {
                     name: "mvm-bins",
@@ -4941,6 +4977,69 @@ mod tests {
             cmd.matches(r#"--override-input mvm/mvm-workspace "path:$MVM_SRC""#)
                 .count(),
             3
+        );
+    }
+
+    #[test]
+    fn stage_filtered_work_input_excludes_scratch_dirs_and_keeps_source() {
+        // A source checkout's `work` input (`BuilderMounts::flake_src` /
+        // `BuilderShellJob::work_dir`) can be the repo root itself, which
+        // carries `target/` (Rust build output), `.worktrees/` (sibling
+        // checkouts), and `.git/` (full history) — tens of GB unfiltered.
+        // Staging through the same exclusion the mvm-workspace snapshot
+        // uses must prune all three while keeping real source files, or
+        // the packed input overflows the guest's RAM-capped extraction
+        // tmpfs ("No space left on device").
+        let scratch = TempDir::new().unwrap();
+        let src = scratch.path().join("repo");
+        std::fs::create_dir_all(src.join("target/debug")).unwrap();
+        std::fs::write(src.join("target/debug/junk"), "x").unwrap();
+        std::fs::create_dir_all(src.join(".worktrees/other-branch")).unwrap();
+        std::fs::write(src.join(".worktrees/other-branch/junk"), "x").unwrap();
+        std::fs::create_dir_all(src.join(".git")).unwrap();
+        std::fs::write(src.join(".git/HEAD"), "ref: refs/heads/main").unwrap();
+        std::fs::create_dir_all(src.join("crates/mvm-build/src")).unwrap();
+        std::fs::write(src.join("crates/mvm-build/src/lib.rs"), "// real source").unwrap();
+
+        let staged = stage_filtered_work_input(&src).expect("stage ok");
+
+        assert!(
+            !staged.path().join("target").exists(),
+            "target/ must be pruned from the work input"
+        );
+        assert!(
+            !staged.path().join(".worktrees").exists(),
+            ".worktrees/ must be pruned from the work input"
+        );
+        assert!(
+            !staged.path().join(".git").exists(),
+            ".git/ must be pruned from the work input"
+        );
+        assert_eq!(
+            std::fs::read_to_string(staged.path().join("crates/mvm-build/src/lib.rs")).unwrap(),
+            "// real source"
+        );
+
+        // Prove the exclusion survives the actual disk-transport pack —
+        // this tar is what rides into the guest.
+        let image = scratch.path().join("input.img");
+        pack_input_disk(
+            &[InputTree {
+                name: "work",
+                src: staged.path(),
+            }],
+            &image,
+            512,
+        )
+        .unwrap();
+        let dest = scratch.path().join("unpacked");
+        read_output_disk(&image, &dest).unwrap();
+        assert!(!dest.join("work/target").exists());
+        assert!(!dest.join("work/.worktrees").exists());
+        assert!(!dest.join("work/.git").exists());
+        assert_eq!(
+            std::fs::read_to_string(dest.join("work/crates/mvm-build/src/lib.rs")).unwrap(),
+            "// real source"
         );
     }
 

--- a/crates/mvm-build/src/libkrun_builder.rs
+++ b/crates/mvm-build/src/libkrun_builder.rs
@@ -5028,6 +5028,7 @@ mod tests {
                 name: "work",
                 src: staged.path(),
             }],
+            None,
             &image,
             512,
         )

--- a/nix/lib/mk-guest.nix
+++ b/nix/lib/mk-guest.nix
@@ -1151,20 +1151,19 @@ let
     ln -sf /etc/ssl/certs/ca-bundle.crt "$out/etc/ssl/certs/ca-certificates.crt"
     chmod 0644 "$out/etc/ssl/certs/ca-bundle.crt"
 
+    # /usr/local/bin must exist before ANY of the conditional binary cp blocks
+    # below: addon-dns and exit-report are baked regardless of runtimeLean, so
+    # a lean/overlay rootfs skips the agent block yet still cp's into this dir.
+    # Keep the mkdir unconditional here, not inside the non-lean agent block.
+    mkdir -p "$out/usr/local/bin"
+
     ${if runtimeLean then ""
     else ''
       # mvm-guest-agent — installed under /usr/local/bin so /init can
       # exec it on dev-tier fallback paths. Mode 0555 so the agent can't
       # rewrite itself; ownership is the build-time user (Nix sandbox has no
       # root) — a later layer binds /etc + /usr read-only at boot to make
-      # this load-bearing.
-      #
-      # mkdir before the cp: when `packages = []` the directory-creation
-      # block below is a no-op, so /usr/local/bin doesn't exist yet and
-      # the cp fails with "No such file or directory". That was the
-      # latent bug that broke release.yml's dev-image lane and the
-      # ch-linux bootcheck before this fix.
-      mkdir -p "$out/usr/local/bin"
+      # this load-bearing. (/usr/local/bin is created unconditionally above.)
       cp ${agentBinary} "$out/usr/local/bin/mvm-guest-agent"
       chmod 0555 "$out/usr/local/bin/mvm-guest-agent"
 

--- a/specs/plans/249-builder-substrate-and-robustness.md
+++ b/specs/plans/249-builder-substrate-and-robustness.md
@@ -85,3 +85,22 @@ WS-B (robustness) is the highest-value-per-effort — it turns a hard, cryptic, 
 failure into a self-healing one, and it's what bit the live check. WS-A (substrate) is the
 largest and unblocks two commands; do it once WS-B makes the builder reliable to iterate
 on. WS-C is small and independent. Each is its own PR.
+
+
+---
+
+## Discovered during WS-B PR-1 validation (2026-07-12) — a 3rd, separate `--flake` blocker
+
+Live-testing PR-1 (fault ii fixed: input no longer overflows, the real nix build now runs)
+uncovered a **third** independent bug that still blocks `machine run --flake` for SDK flakes,
+in the nix image build — NOT builder-store robustness, NOT PR-1 (which touches no `nix/`):
+
+    mvm-rootfs-tree-exit-code> cp: cannot create regular file
+      '…/mvm-rootfs-tree-…/usr/local/bin/mvm-addon-dns': No such file or directory
+
+The `mkGuest` rootfs-tree derivation `cp`s guest binaries into `usr/local/bin/` without the
+parent dir existing. `nix/lib/mk-guest.nix` was last changed by #1658 (Plan 213 SP3, seeded
+closure) and #1613 (runtime overlay) — the regression is in one of those. Likely a one-line
+`mkdir -p $out/usr/local/bin` in the rootfs-tree buildCommand, but it needs its own
+investigation (the overlay reworked rootfs assembly). **Own fix — file separately.** Until it
+lands, `machine run --flake` stays blocked here even with PR-1 + a clean store.


### PR DESCRIPTION
**Stacked on #1680.** First WS-B PR — fixes the builder-VM fault that makes `machine run --flake` / `machine build` crash the guest ("guest did not write result") on a source checkout. **Validated live on macOS-26.**

## Root cause (the virtiofs errors were a red herring)
Disk-transport is the *intended* libkrun-builder path (virtiofs is `#[cfg(test)]`-only). The real bug: the builder tarred the **entire unfiltered repo tree** as the `work` input — for a source checkout that's the repo root (`target/`, `.worktrees/`, `.git/` — tens of GB) — then extracted it into a **RAM-capped tmpfs** → `No space left on device`.

## Fix
1. **Filter the `work` input** — reuse the existing `WORKSPACE_SNAPSHOT_SKIP` filter (already prunes `target`/`.worktrees`/`.git`/`.claude`); ~40 GB → <500 MB. No new skip-list, no `pack_input_disk` API change (staged filtered copy via `TempDir`).
2. **Stage input off the RAM tmpfs** onto the nix-store disk (mirrors `/out`) — defense-in-depth; also fixes the HVF builder (same tmpfs path).

## Live validation (macOS-26, fresh store)
Before: died at input staging (`No space`). After: **input staging succeeds, the real nix build runs** (fetches from cache.nixos.org, compiles guest binaries) — fault (ii) is gone.

**Note — a *third* blocker surfaced (out of scope, filed in the plan):** the build now fails deeper, in the `mkGuest` rootfs-tree derivation (`cp … usr/local/bin/mvm-addon-dns: No such file or directory` — a missing `mkdir -p`), a nix-image-build regression from #1658/#1613, **not this PR** (touches no `nix/`). So `--flake` stays blocked here until that separate fix lands — but layer 2 is fixed.

## Tests
TDD RED→GREEN on the filter; `mvm-build` 911 (builder-vm) / 751 (default); build/clippy/fmt clean.

## Remaining WS-B (this plan, follow-on PRs)
Corruption detect + auto-recover (fault i), eager transient reaping, `fstrim`-after-GC + accurate doctor sizing. See `specs/plans/249-builder-substrate-and-robustness.md`.