### PR TITLE
fix(oci-run): boot the dm-verity workload kernel, never the builder kernel

### DIFF
--- a/crates/mvm-cli/src/commands/env/dev_vz.rs
+++ b/crates/mvm-cli/src/commands/env/dev_vz.rs
@@ -39,7 +39,7 @@ use default_microvm::DefaultMicrovmVariant;
 #[cfg(test)]
 use default_microvm::{
     WorkloadKernelBootstrap, default_microvm_assets, find_cached_workload_kernel,
-    find_reusable_builder_kernel, resolve_workload_kernel_bootstrap,
+    resolve_workload_kernel_bootstrap,
 };
 pub(crate) use default_microvm::{
     ensure_default_microvm_image, ensure_workload_kernel, ensure_workload_verity_initrd,

--- a/crates/mvm-cli/src/commands/env/dev_vz/builder_vm_bootstrap_tests.rs
+++ b/crates/mvm-cli/src/commands/env/dev_vz/builder_vm_bootstrap_tests.rs
@@ -86,37 +86,36 @@ fn explicit_source_build_request_builds_workload_kernel_locally() {
 }
 
 #[test]
-fn find_reusable_builder_kernel_detects_builder_image_vmlinux() {
+fn workload_kernel_never_reuses_the_non_verity_builder_kernel() {
     let tmp = tempfile::tempdir().unwrap();
     let cache = tmp.path().to_str().unwrap();
     let arch = "aarch64";
-    // Absent → None (the builder image was never built).
-    assert_eq!(find_reusable_builder_kernel(cache, arch), None);
 
-    // The builder image's kernel lives at `builder-vm/<arch>/vmlinux`; it is a
-    // valid reuse source for a non-sealed launch (boots a plain rootfs).
+    // A builder-image kernel on disk must NOT satisfy the workload kernel: the
+    // builder kernel force-drops device-mapper + dm-verity, but every workload
+    // boots through the verity initrd, so reusing it panics the guest at boot.
+    // It is also not a workload-kernel cache candidate.
     let dir = tmp.path().join(format!("builder-vm/{arch}"));
     std::fs::create_dir_all(&dir).unwrap();
-    let vmlinux = dir.join("vmlinux");
-    std::fs::write(&vmlinux, b"vmlinux").unwrap();
-    assert_eq!(
-        find_reusable_builder_kernel(cache, arch).as_deref(),
-        Some(vmlinux.to_str().unwrap())
-    );
-
-    // The builder kernel is NOT a workload-kernel cache candidate, so reuse is
-    // a deliberate separate step — the cache lookup still misses here.
+    std::fs::write(dir.join("vmlinux"), b"vmlinux").unwrap();
     assert!(find_cached_workload_kernel(cache, arch, false).is_none());
     assert!(find_cached_workload_kernel(cache, arch, true).is_none());
+
+    // With no workload/default kernel cached, resolution builds it (source
+    // checkout) or downloads it (installed) — never the builder kernel, in
+    // either dev or prod.
+    let dest = format!("{cache}/builder-vm/{arch}/kernels/workload/vmlinux");
+    assert_eq!(
+        resolve_workload_kernel_bootstrap(cache, arch, false, true),
+        WorkloadKernelBootstrap::BuildLocal(dest.clone())
+    );
     assert_eq!(
         resolve_workload_kernel_bootstrap(cache, arch, false, false),
-        WorkloadKernelBootstrap::ReusableBuilder(vmlinux.to_str().unwrap().to_string())
+        WorkloadKernelBootstrap::Download(dest.clone())
     );
     assert_eq!(
         resolve_workload_kernel_bootstrap(cache, arch, true, false),
-        WorkloadKernelBootstrap::Download(format!(
-            "{cache}/builder-vm/{arch}/kernels/workload/vmlinux"
-        ))
+        WorkloadKernelBootstrap::Download(dest)
     );
 }
 

--- a/crates/mvm-cli/src/commands/env/dev_vz/default_microvm.rs
+++ b/crates/mvm-cli/src/commands/env/dev_vz/default_microvm.rs
@@ -24,10 +24,6 @@ pub(crate) fn ensure_workload_kernel(prod: bool) -> Result<String> {
         resolve_workload_kernel_bootstrap(&cache, arch, prod, find_builder_vm_flake().is_ok());
     match resolved {
         WorkloadKernelBootstrap::Cached(path) => Ok(path),
-        WorkloadKernelBootstrap::ReusableBuilder(path) => {
-            ui::info("Reusing builder-image kernel as workload kernel (dev mode).");
-            Ok(path)
-        }
         WorkloadKernelBootstrap::BuildLocal(path) => {
             ui::info("Building workload kernel locally (source checkout)...");
             build_workload_kernel_locally()
@@ -108,7 +104,6 @@ fn embedded_verity_init_bytes() -> Option<&'static [u8]> {
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub(super) enum WorkloadKernelBootstrap {
     Cached(String),
-    ReusableBuilder(String),
     BuildLocal(String),
     Download(String),
 }
@@ -122,9 +117,13 @@ pub(super) fn resolve_workload_kernel_bootstrap(
     if let Some(cached) = find_cached_workload_kernel(cache_dir, arch, prod) {
         return WorkloadKernelBootstrap::Cached(cached);
     }
-    if !prod && let Some(builder) = find_reusable_builder_kernel(cache_dir, arch) {
-        return WorkloadKernelBootstrap::ReusableBuilder(builder);
-    }
+    // The workload always boots through the verity initrd (mvm-verity-init opens
+    // /dev/mapper/control and builds the dm-verity target), so its kernel must
+    // carry device-mapper + dm-verity built in. The builder kernel force-drops
+    // both (it boots `root=/dev/vda ro` with no roothash), so it can never stand
+    // in for the workload kernel — reusing it panics the guest at boot. Always
+    // resolve the real workload kernel: build it (source checkout) or download
+    // the published one.
     let dest = format!("{cache_dir}/builder-vm/{arch}/kernels/workload/vmlinux");
     if source_checkout {
         WorkloadKernelBootstrap::BuildLocal(dest)
@@ -144,11 +143,6 @@ fn build_workload_kernel_locally() -> Result<std::path::PathBuf> {
         "building the workload kernel locally requires the `builder-vm` feature; \
          use a release build with published kernels or rebuild mvmctl with builder-vm enabled"
     )
-}
-
-pub(super) fn find_reusable_builder_kernel(cache_dir: &str, arch: &str) -> Option<String> {
-    let path = format!("{cache_dir}/builder-vm/{arch}/vmlinux");
-    std::path::Path::new(&path).is_file().then_some(path)
 }
 
 fn download_workload_kernel(arch: &str, dest: &str) -> Result<()> {

--- a/crates/mvm-cli/src/commands/vm/exec.rs
+++ b/crates/mvm-cli/src/commands/vm/exec.rs
@@ -740,13 +740,12 @@ fn build_exec_request(
                     );
                 }
                 // An `--image` run boots the materialized OCI rootfs (with its
-                // injected agent), so we need only a workload kernel. Resolve just
-                // the kernel — a cached workload/default-image kernel, the
-                // cold-cache published workload-kernel download, or (for non-prod)
-                // an existing builder kernel already on disk — rather than
-                // building/downloading a whole default image whose rootfs we'd
-                // discard. Stage 0 kernel compilation is reserved for explicit
-                // kernel source-build requests.
+                // injected agent), so we need only a workload kernel — a cached
+                // workload/default-image kernel, a local build (source checkout),
+                // or the published download — rather than building/downloading a
+                // whole default image whose rootfs we'd discard. The rootfs boots
+                // verity-sealed, so the kernel must carry dm-verity; the builder
+                // kernel (which drops it) is never a stand-in.
                 let kernel_path = ensure_workload_kernel(prod)?;
                 crate::exec::ImageSource::Prebuilt {
                     kernel_path,

--- a/specs/notes/2026-07-13-oci-run-workload-kernel-verity.md
+++ b/specs/notes/2026-07-13-oci-run-workload-kernel-verity.md
@@ -1,0 +1,84 @@
+# OCI-run workload kernel vs dm-verity: boot panic + infra follow-ups
+
+**Date:** 2026-07-13
+**Status:** symptom fixed (PR #1684); deeper follow-ups open below.
+**Live-repro:** `mvmctl machine run --image busybox --allow-host google.com` on
+macOS 26 Apple Silicon (HVF workload backend), source-checkout mvmctl.
+
+## Symptom
+
+Every OCI `machine run --image` boot kernel-panicked the guest **before any
+userspace**, so no workload ran and no egress was possible:
+
+```
+mvm-verity-init: starting
+mvm-verity-init: rootfs data=/dev/vda hash=/dev/vdb roothash=a454492c…
+mvm-verity-init: overlay data=/dev/vdc hash=/dev/vdd roothash=65f196bf…
+mvm-verity-init: FATAL: open /dev/mapper/control: No such file or directory
+Kernel panic - not syncing: Attempted to kill init! exitcode=0x00000100
+```
+
+## Root cause
+
+The OCI rootfs boots **verity-sealed**: `crates/mvm-guest/src/bin/mvm-verity-init.rs`
+mounts devtmpfs at `/dev`, then opens `/dev/mapper/control` to build the dm-verity
+target via raw ioctls. That control node is created by the kernel's device-mapper
+subsystem only when `CONFIG_BLK_DEV_DM` is built **in**.
+
+The kernel that booted did not have it. `machine run --image` resolves the kernel
+through `ensure_workload_kernel` → `resolve_workload_kernel_bootstrap`
+(`crates/mvm-cli/src/commands/env/dev_vz/default_microvm.rs`), which for **non-prod**
+runs returned `WorkloadKernelBootstrap::ReusableBuilder` — the **builder** kernel at
+`builder-vm/<arch>/vmlinux`. The builder kernel **force-drops** `BLK_DEV_DM` +
+`DM_VERITY` (`nix/images/kernel/builder.nix`; it boots `root=/dev/vda ro` with no
+roothash and never opens a dm device). The workload kernel builds both `=y`
+(`nix/images/kernel/workload.nix`, asserted by `base.nix`'s olddefconfig guard;
+`CONFIG_MODULES=n`, all-built-in).
+
+So: **verity-sealed rootfs + non-dm-verity (builder) kernel → panic.** The
+builder-kernel reuse was a dev-speed optimization that became invalid once
+workloads verity-boot by default.
+
+## Fix shipped (PR #1684)
+
+Removed the builder-kernel reuse entirely: a verity-booting workload always
+resolves the real workload kernel (`Cached` → `BuildLocal` on a source checkout →
+`Download` on a release). Deleted `WorkloadKernelBootstrap::ReusableBuilder`, its
+handler, and `find_reusable_builder_kernel`; the rewritten test
+`workload_kernel_never_reuses_the_non_verity_builder_kernel` asserts the builder
+kernel is never returned, in dev or prod.
+
+**Live-verified:** the guest now builds the workload kernel and **boots past verity
+to a reachable agent** on HVF.
+
+## Deeper follow-ups (the actual infra to decide/fix)
+
+The shipped fix removes the wrong-kernel reuse, but the episode exposes structural
+gaps worth addressing:
+
+1. **No host-side kernel↔rootfs agreement check.** The mismatch surfaced only as a
+   guest kernel panic on the serial console — the host had zero signal. A verity-
+   sealed launch should assert, host-side and before boot, that the resolved kernel
+   supports dm-verity, and fail fast with a clear message instead of panicking the
+   guest. Encode the invariant: **a verity-sealed rootfs requires a dm-verity
+   kernel.**
+
+2. **The other reuse candidate may have the same latent bug.** `find_cached_workload_kernel`
+   still adds `default-microvm/dev/vmlinux` as a **non-prod** candidate. If that
+   dev default-microvm kernel is not dm-verity-capable, a cached-dev-kernel run
+   reproduces the identical panic via a different path. Verify the dev default
+   kernel carries dm-verity, or exclude it for verity-sealed launches.
+
+3. **Should non-prod OCI runs verity-seal at all?** The builder-kernel reuse existed
+   because non-prod dev runs were assumed to boot *unsealed* (a plain rootfs on the
+   builder kernel — fast, no kernel build). Today they verity-seal, so the fix now
+   forces a workload-kernel build (3–5 min cold) on the first non-prod run. Decide
+   the intended dev-tier contract: keep verity on non-prod (correctness, current
+   fix) or boot non-prod unsealed (restores the dev-speed path, but is a larger
+   change to rootfs materialization + the boot path). Whichever is chosen, kernel
+   resolution and rootfs sealing must agree — that agreement is the real invariant.
+
+4. **`mvmctl` gives no `-v` breadcrumb for kernel provenance.** During diagnosis it
+   was not observable which kernel variant a run resolved. A one-line log
+   ("workload kernel: built / cached / downloaded at <path>") would have made this
+   a one-shot diagnosis instead of a source dig.


### PR DESCRIPTION
## Bug
`machine run --image` on the HVF (and any) OCI path **kernel-panics the guest at boot**:
```
mvm-verity-init: FATAL: open /dev/mapper/control: No such file or directory
Kernel panic - not syncing: Attempted to kill init!
```

## Root cause
The OCI rootfs boots **verity-sealed** — `mvm-verity-init` mounts devtmpfs, builds the dm-verity target via raw ioctls, and opens `/dev/mapper/control`. That control node only exists if the kernel has `CONFIG_BLK_DEV_DM` built in. But `resolve_workload_kernel_bootstrap` reused the **builder** kernel for non-prod runs (`WorkloadKernelBootstrap::ReusableBuilder`), and the builder kernel force-drops `BLK_DEV_DM` + `DM_VERITY` (it boots `root=/dev/vda ro`, never opening a dm device). Sealed rootfs + non-dm-verity kernel = the panic, before any userspace.

The workload kernel *does* build both (`nix/images/kernel/workload.nix`, guarded `=y` by `base.nix`'s olddefconfig assertion). The reuse became invalid once workloads verity-boot by default.

## Fix
A verity-booting workload must always get a dm-verity kernel — remove the builder-kernel reuse entirely. The workload kernel now resolves to the real workload kernel: cached → built locally (source checkout) → published download. Deletes `WorkloadKernelBootstrap::ReusableBuilder`, its handler, and `find_reusable_builder_kernel`; the rewritten test `workload_kernel_never_reuses_the_non_verity_builder_kernel` asserts the builder kernel is never returned in dev or prod.

## Verification
- `mvm-cli` builds clean; nightly fmt clean; 12 kernel-bootstrap tests pass.
- **Live on macOS 26 HVF**: `machine run --image busybox` now builds the workload kernel and **boots past verity to a reachable guest agent** — previously an immediate kernel panic.