### PR TITLE
fix(builder): deliver libkrun Stage 0 /work as an ext4 disk (avoid virtio-fs handle exhaustion)

### DIFF
--- a/crates/mvm-build/Cargo.toml
+++ b/crates/mvm-build/Cargo.toml
@@ -172,9 +172,13 @@ pure-mkfs = ["dep:xattr"]
 dev-shell = []
 # libkrun-direct builder VM launcher. Pulls the
 # `mvm-libkrun` FFI crate which itself gates the underlying
-# `libkrun-sys` bindings.
+# `libkrun-sys` bindings. Implies `pure-mkfs`: Stage 0 packs its `/work`
+# share onto an in-process ext4 disk (`libkrun_builder::run_stage0_impl`)
+# rather than virtio-fs, so any crate compiling this module needs the pure
+# writer too — including an isolated `-p` build that never asks for
+# `pure-mkfs` on its own (e.g. the per-VM supervisor crate).
 contributor-bootstrap = []
-builder-vm = ["dep:libkrun-sys", "dep:mvm-network"]
+builder-vm = ["dep:libkrun-sys", "dep:mvm-network", "pure-mkfs"]
 
 [lints]
 workspace = true

--- a/crates/mvm-build/src/bin/stage0-init.rs
+++ b/crates/mvm-build/src/bin/stage0-init.rs
@@ -4,7 +4,12 @@
 //! `/nix/store` + this binary as `/init` — no Alpine, no apk, no busybox.
 //!
 //! **libkrun** (macOS/aarch64): the seed root arrives over virtiofs
-//! (`krun_set_root`) on libkrunfw's bundled kernel; shares are virtio-fs; we
+//! (`krun_set_root`) on libkrunfw's bundled kernel; `/out` and `/mvm-bins`
+//! stay virtio-fs, while `/work` prefers an ext4 disk identified by volume
+//! label (`nix build` reading a large workspace tree through
+//! virtio-fs-over-FUSE exhausts libkrun's virtio-fs handle pool — "Too many
+//! open files" — so the host packs it onto a block device instead; falls
+//! back to the old `"work"` virtio-fs tag when no such disk is attached); we
 //! copy the seed `/nix/store` into a tmpfs and bind it over `/nix` (virtiofs
 //! writes fail under FUSE); outbound fetches go through the shared vsock
 //! egress proxy. Proven E2E on aarch64.
@@ -40,11 +45,28 @@ fn main() -> ExitCode {
 #[cfg(target_os = "linux")]
 mod linux {
     use sha2::{Digest, Sha256};
+    use std::io::Read as _;
     use std::net::{SocketAddr, TcpStream};
     use std::os::fd::AsRawFd;
     use std::path::{Path, PathBuf};
     use std::process::{Child, Command, ExitCode, ExitStatus, Stdio};
     use std::time::{Duration, Instant};
+
+    /// Byte offset of the ext4 superblock from the start of a filesystem
+    /// image (the boot-sector region ext4 always skips).
+    const EXT4_SUPERBLOCK_OFFSET: usize = 1024;
+    /// `s_magic`, little-endian `0xEF53`, at superblock offset 0x38.
+    const EXT4_MAGIC_OFFSET_IN_SUPERBLOCK: usize = 0x38;
+    const EXT4_MAGIC_LE: [u8; 2] = [0x53, 0xEF];
+    /// `s_volume_name`: 16 raw, NUL-padded bytes at superblock offset 0x78 —
+    /// what `mvm-ext4`'s writer stamps via `BuildOptions::with_volume_name`.
+    const EXT4_VOLUME_NAME_OFFSET_IN_SUPERBLOCK: usize = 0x78;
+    const EXT4_VOLUME_NAME_LEN: usize = 16;
+    /// Fixed set of virtio-blk candidates Stage 0 ever attaches. Small and
+    /// explicit rather than a `/sys/class/block` walk — a RootDir guest never
+    /// has more than a handful of disks, and a missing candidate is just a
+    /// failed `File::open` (cheap, non-fatal).
+    const STAGE0_DISK_CANDIDATES: &[&str] = &["/dev/vda", "/dev/vdb", "/dev/vdc", "/dev/vdd"];
 
     const VSOCK_EGRESS_PROXY_URL: &str = "socks5h://127.0.0.1:1080";
     const VSOCK_EGRESS_NO_PROXY: &str = "127.0.0.1,localhost";
@@ -398,30 +420,28 @@ mod linux {
             if qemu { "qemu" } else { "libkrun" }
         );
 
-        // Host shares. libkrun presents them over virtio-fs by tag; QEMU as
-        // ext4 block disks (the initramfs already loaded virtio_blk for the
-        // ext4 root, so vdb/vdc/vdd enumerate with no extra modules — no
-        // virtiofsd, no 9p). Order matches the device order on the QEMU
-        // cmdline (vda=seed root, then work/out/mvm-bins).
-        let shares: &[(&str, &str, &str)] = if qemu {
-            &[
+        // Host shares. QEMU presents all three as ext4 block disks (the
+        // initramfs already loaded virtio_blk for the ext4 root, so
+        // vdb/vdc/vdd enumerate with no extra modules — no virtiofsd, no
+        // 9p); order matches the device order on the QEMU cmdline (vda=seed
+        // root, then work/out/mvm-bins). libkrun presents `/out` and
+        // `/mvm-bins` over virtio-fs by tag; `/work` prefers an ext4 disk
+        // too (`mount_libkrun_work_share`) — a large workspace read through
+        // virtio-fs-over-FUSE exhausts libkrun's virtio-fs handle pool
+        // (`nix build` fails with "Too many open files"), so the host packs
+        // it onto a block device whenever it attaches one.
+        if qemu {
+            mount_shares(&[
                 ("/dev/vdb", "/work", "ext4"),
                 ("/dev/vdc", "/out", "ext4"),
                 ("/dev/vdd", "/mvm-bins", "ext4"),
-            ]
+            ])?;
         } else {
-            &[
-                ("work", "/work", "virtiofs"),
+            mount_libkrun_work_share()?;
+            mount_shares(&[
                 ("out", "/out", "virtiofs"),
                 ("mvm-bins", "/mvm-bins", "virtiofs"),
-            ]
-        };
-        for (source, target, fstype) in shares {
-            std::fs::create_dir_all(target).map_err(|e| format!("create {target}: {e}"))?;
-            mount_fs(source, target, fstype)?;
-            if !is_mountpoint(target) {
-                return Err(format!("{target} ({fstype}) mount did not take"));
-            }
+            ])?;
         }
 
         if qemu {
@@ -1016,6 +1036,116 @@ mod linux {
         .map_err(|e| format!("mount {source} -> {target} ({fstype}): {e}"))
     }
 
+    /// Like [`mount_fs`], but read-only. The host attaches the `/work` ext4
+    /// disk read-only at the libkrun layer (`krun_add_disk`'s `read_only`
+    /// flag), and a Linux block device that reports itself read-only refuses
+    /// a plain read-write mount — so this must pass `MS_RDONLY` rather than
+    /// reusing `mount_fs`. Mirrors the existing read-only virtio-fs mounts
+    /// the steady-state builder guest already does for the same `/work`
+    /// share (`mvm-host-vm-init`'s `virtiofs_mount_flags`).
+    fn mount_fs_ro(source: &str, target: &str, fstype: &str) -> Result<(), String> {
+        use nix::mount::{MsFlags, mount};
+        mount(
+            Some(source),
+            target,
+            Some(fstype),
+            MsFlags::MS_RDONLY,
+            None::<&str>,
+        )
+        .map_err(|e| format!("mount {source} -> {target} ({fstype}) read-only: {e}"))
+    }
+
+    /// Decode the ext4 volume label (`s_volume_name`) from the first
+    /// superblock in `buf`, matching the layout `mvm-ext4`'s writer stamps
+    /// (`BuildOptions::with_volume_name`). `None` when `buf` is too short,
+    /// the ext4 magic doesn't match (not ext4, or a zeroed/absent device),
+    /// or the label is empty or not valid UTF-8.
+    fn ext4_volume_label_from_superblock(buf: &[u8]) -> Option<String> {
+        let magic_off = EXT4_SUPERBLOCK_OFFSET + EXT4_MAGIC_OFFSET_IN_SUPERBLOCK;
+        let label_off = EXT4_SUPERBLOCK_OFFSET + EXT4_VOLUME_NAME_OFFSET_IN_SUPERBLOCK;
+        if buf.len() < label_off + EXT4_VOLUME_NAME_LEN {
+            return None;
+        }
+        if buf[magic_off..magic_off + EXT4_MAGIC_LE.len()] != EXT4_MAGIC_LE {
+            return None;
+        }
+        let raw = &buf[label_off..label_off + EXT4_VOLUME_NAME_LEN];
+        let end = raw.iter().position(|&b| b == 0).unwrap_or(raw.len());
+        if end == 0 {
+            return None;
+        }
+        std::str::from_utf8(&raw[..end]).ok().map(str::to_string)
+    }
+
+    /// Read just enough of `path` to decode an ext4 volume label. `None` on
+    /// any I/O error — missing device, device shorter than a superblock, or
+    /// (via [`ext4_volume_label_from_superblock`]) not ext4 at all.
+    fn read_ext4_volume_label(path: &Path) -> Option<String> {
+        let probe_len =
+            EXT4_SUPERBLOCK_OFFSET + EXT4_VOLUME_NAME_OFFSET_IN_SUPERBLOCK + EXT4_VOLUME_NAME_LEN;
+        let mut buf = vec![0u8; probe_len];
+        std::fs::File::open(path).ok()?.read_exact(&mut buf).ok()?;
+        ext4_volume_label_from_superblock(&buf)
+    }
+
+    /// Probe `candidates` in order for the first whose ext4 superblock
+    /// carries `label`. Content-addressed rather than position-addressed:
+    /// correct regardless of which candidate the host actually attached the
+    /// labeled disk as (see `libkrun_builder::pack_stage0_work_disk` on the
+    /// host side).
+    fn find_labeled_ext4_disk(candidates: &[&str], label: &str) -> Option<PathBuf> {
+        for candidate in candidates.iter().copied() {
+            let path = Path::new(candidate);
+            if read_ext4_volume_label(path).as_deref() == Some(label) {
+                return Some(path.to_path_buf());
+            }
+        }
+        None
+    }
+
+    /// Mounts `/work` for the libkrun backend. Prefers the ext4 disk
+    /// carrying [`mvm_build::rootfs::STAGE0_WORK_EXT4_LABEL`] — the host
+    /// packs the workspace onto a block device because `nix build` reading
+    /// a large tree through virtio-fs-over-FUSE exhausts libkrun's
+    /// virtio-fs handle pool ("Too many open files"). Falls back to the
+    /// `"work"` virtio-fs tag when no such disk is attached, the shape
+    /// every caller used before this disk existed.
+    fn mount_libkrun_work_share() -> Result<(), String> {
+        std::fs::create_dir_all("/work").map_err(|e| format!("create /work: {e}"))?;
+        let label = mvm_build::rootfs::STAGE0_WORK_EXT4_LABEL;
+        match find_labeled_ext4_disk(STAGE0_DISK_CANDIDATES, label) {
+            Some(dev) => {
+                let dev = dev.to_string_lossy().into_owned();
+                mount_fs_ro(&dev, "/work", "ext4")?;
+                eprintln!("stage0-init: mounted /work from ext4 disk {dev} (label {label:?})");
+            }
+            None => {
+                mount_fs("work", "/work", "virtiofs")?;
+                eprintln!("stage0-init: mounted /work from virtiofs (no {label:?} disk attached)");
+            }
+        }
+        if !is_mountpoint("/work") {
+            return Err("/work (ext4-or-virtiofs) mount did not take".to_string());
+        }
+        Ok(())
+    }
+
+    /// Create + mount each `(source, target, fstype)` share in order,
+    /// verifying the mount took. Shared by the QEMU shares (all ext4) and
+    /// the libkrun `/out` + `/mvm-bins` shares (virtio-fs); `/work` on
+    /// libkrun goes through [`mount_libkrun_work_share`] instead, since it
+    /// picks its own source/fstype/flags.
+    fn mount_shares(shares: &[(&str, &str, &str)]) -> Result<(), String> {
+        for (source, target, fstype) in shares {
+            std::fs::create_dir_all(target).map_err(|e| format!("create {target}: {e}"))?;
+            mount_fs(source, target, fstype)?;
+            if !is_mountpoint(target) {
+                return Err(format!("{target} ({fstype}) mount did not take"));
+            }
+        }
+        Ok(())
+    }
+
     fn mount_fs_idempotent(source: &str, target: &str, fstype: &str) -> Result<(), String> {
         // The nix seed rootfs is minimal (no /tmp, /run, …) and `mount(2)`
         // needs the target dir to exist — create it first.
@@ -1172,10 +1302,116 @@ mod linux {
     #[cfg(test)]
     mod tests {
         use super::{
-            VSOCK_EGRESS_NO_PROXY, VSOCK_EGRESS_PROXY_URL, copy_artifacts_into, run_streaming,
+            VSOCK_EGRESS_NO_PROXY, VSOCK_EGRESS_PROXY_URL, copy_artifacts_into,
+            ext4_volume_label_from_superblock, find_labeled_ext4_disk, run_streaming,
         };
         use std::os::unix::fs::symlink;
         use std::process::Command;
+
+        #[test]
+        fn ext4_volume_label_from_superblock_rejects_too_short_buffers() {
+            assert_eq!(ext4_volume_label_from_superblock(&[]), None);
+            assert_eq!(ext4_volume_label_from_superblock(&[0u8; 1024]), None);
+        }
+
+        #[test]
+        fn ext4_volume_label_from_superblock_rejects_wrong_magic() {
+            let mut buf = vec![0u8; 1024 + 0x78 + 16];
+            buf[1024 + 0x38] = 0xAA;
+            buf[1024 + 0x38 + 1] = 0xBB;
+            buf[1024 + 0x78..1024 + 0x78 + 8].copy_from_slice(b"mvm-work");
+            assert_eq!(ext4_volume_label_from_superblock(&buf), None);
+        }
+
+        #[test]
+        fn ext4_volume_label_from_superblock_rejects_empty_label() {
+            let mut buf = vec![0u8; 1024 + 0x78 + 16];
+            buf[1024 + 0x38] = 0x53;
+            buf[1024 + 0x38 + 1] = 0xEF;
+            // Label bytes left all-zero.
+            assert_eq!(ext4_volume_label_from_superblock(&buf), None);
+        }
+
+        #[test]
+        fn ext4_volume_label_from_superblock_decodes_a_nul_padded_label() {
+            let mut buf = vec![0u8; 1024 + 0x78 + 16];
+            buf[1024 + 0x38] = 0x53;
+            buf[1024 + 0x38 + 1] = 0xEF;
+            buf[1024 + 0x78..1024 + 0x78 + 8].copy_from_slice(b"mvm-work");
+            assert_eq!(
+                ext4_volume_label_from_superblock(&buf),
+                Some("mvm-work".to_string())
+            );
+        }
+
+        #[test]
+        fn ext4_volume_label_from_superblock_decodes_a_full_16_byte_label() {
+            // No trailing NUL at all — the full field is label content.
+            let mut buf = vec![0u8; 1024 + 0x78 + 16];
+            buf[1024 + 0x38] = 0x53;
+            buf[1024 + 0x38 + 1] = 0xEF;
+            buf[1024 + 0x78..1024 + 0x78 + 16].copy_from_slice(b"0123456789abcdef");
+            assert_eq!(
+                ext4_volume_label_from_superblock(&buf),
+                Some("0123456789abcdef".to_string())
+            );
+        }
+
+        #[test]
+        fn ext4_volume_label_round_trips_through_the_real_writer() {
+            // Validate against `mvm-ext4`'s actual writer (not just a synthetic
+            // byte layout assumption) so a future change to the on-disk
+            // superblock format fails this test instead of silently
+            // desynchronizing the host writer and the guest reader.
+            let nodes = vec![mvm_ext4::Node::Dir {
+                path: "/a".to_string(),
+                mode: 0o755,
+                xattrs: vec![],
+            }];
+            let options = mvm_ext4::BuildOptions::default().with_volume_name(b"mvm-work");
+            let image = mvm_ext4::build_image_with_options(&nodes, &options).expect("build image");
+            assert_eq!(
+                ext4_volume_label_from_superblock(&image),
+                Some("mvm-work".to_string())
+            );
+        }
+
+        #[test]
+        fn find_labeled_ext4_disk_picks_the_matching_candidate_regardless_of_position() {
+            let dir = tempfile::tempdir().expect("tempdir");
+            let mut labeled = vec![0u8; 1024 + 0x78 + 16];
+            labeled[1024 + 0x38] = 0x53;
+            labeled[1024 + 0x38 + 1] = 0xEF;
+            labeled[1024 + 0x78..1024 + 0x78 + 8].copy_from_slice(b"mvm-work");
+            let other = vec![0u8; 1024 + 0x78 + 16]; // no magic at all — e.g. an empty/unformatted disk
+
+            // The labeled device is the SECOND candidate — the scan must not
+            // assume it's always first (content-addressed, not position-addressed).
+            let first = dir.path().join("first");
+            let second = dir.path().join("second");
+            std::fs::write(&first, &other).expect("write first");
+            std::fs::write(&second, &labeled).expect("write second");
+
+            let first_str = first.to_str().expect("utf8 path");
+            let second_str = second.to_str().expect("utf8 path");
+            let found = find_labeled_ext4_disk(&[first_str, second_str], "mvm-work");
+            assert_eq!(found, Some(second));
+        }
+
+        #[test]
+        fn find_labeled_ext4_disk_returns_none_when_nothing_matches() {
+            let dir = tempfile::tempdir().expect("tempdir");
+            let unformatted = dir.path().join("unformatted");
+            std::fs::write(&unformatted, vec![0u8; 1024 + 0x78 + 16]).expect("write");
+            let missing = dir.path().join("does-not-exist");
+
+            let unformatted_str = unformatted.to_str().expect("utf8 path");
+            let missing_str = missing.to_str().expect("utf8 path");
+            assert_eq!(
+                find_labeled_ext4_disk(&[missing_str, unformatted_str], "mvm-work"),
+                None
+            );
+        }
 
         #[test]
         fn purge_stale_nix_builder_home_removes_leftover_and_tolerates_absence() {

--- a/crates/mvm-build/src/libkrun_builder.rs
+++ b/crates/mvm-build/src/libkrun_builder.rs
@@ -769,7 +769,7 @@ impl LibkrunBuilderVm {
     /// VM artifacts to `/out`, then powers off cleanly.
     ///
     /// Attaches a dedicated persistent `nix-store-stage0-<arch>.img` as
-    /// the guest's only virtio-blk device (`/dev/vda` — Stage 0 has no
+    /// the guest's first virtio-blk device (`/dev/vda` — Stage 0 has no
     /// block rootfs, its root is virtio-fs via `krun_set_root`). The
     /// guest mounts it at `/nix` (formatting on first boot), so the slim
     /// kernel + Rust host binaries are built once and reused across
@@ -777,6 +777,14 @@ impl LibkrunBuilderVm {
     /// time. ext4 is case-sensitive, which is also why the old in-RAM
     /// tmpfs existed (APFS case-insensitivity breaks Nix substitution) —
     /// the disk keeps that property and adds persistence.
+    ///
+    /// The workspace source travels as a second virtio-blk device rather
+    /// than a virtio-fs share (see [`pack_stage0_work_disk`]): `nix build`
+    /// reading a large workspace tree through virtio-fs-over-FUSE exhausts
+    /// libkrun's virtio-fs handle pool (`nix build` fails with "Too many
+    /// open files"). `stage0-init` identifies the disk by its ext4 volume
+    /// label rather than by enumeration order, and falls back to the old
+    /// `"work"` virtio-fs tag when no such disk is attached.
     ///
     /// On success the caller still validates that the expected artifacts
     /// (`vmlinux`, `rootfs.ext4`) landed in `artifact_out`; this only
@@ -864,20 +872,31 @@ impl LibkrunBuilderVm {
             );
         }
 
+        // Pack the workspace onto an ext4 disk instead of exporting it over
+        // virtio-fs: `nix build` opening every file in a large workspace tree
+        // through virtio-fs-over-FUSE exhausts libkrun's virtio-fs handle
+        // pool (EMFILE, "Too many open files"), which reliably fails the
+        // Stage 0 build. `stage0-init` mounts it by ext4 volume label.
+        let work_disk = pack_stage0_work_disk(workspace_dir, &vm_state_dir)?;
+
         let mut krun = krun_context_for_image(&vm_name, &image)?
             .with_resources(self.vcpus, self.memory_mib)
             .with_console_output(path_to_str(&console_log, "console_log")?)
             .with_vsock_socket_dir(path_to_str(&vm_state_dir, "vm_state_dir")?)
-            // Persistent /nix store disk — the only block device on a RootDir
-            // guest, so it enumerates as /dev/vda. `stage0-init` mounts and
-            // reuses it when it is ext4, formats it when the seed carries
-            // mkfs.ext4, and otherwise falls back to the tmpfs seed copy.
+            // Persistent /nix store disk — the first block device attached
+            // to a RootDir guest, so it enumerates as /dev/vda. `stage0-init`
+            // mounts and reuses it when it is ext4, formats it when the seed
+            // carries mkfs.ext4, and otherwise falls back to the tmpfs seed
+            // copy.
             .add_disk(
                 "nix-store",
                 path_to_str(nix_store_lock.path(), "nix_store_img")?,
                 false,
             )
-            .add_virtio_fs("work", path_to_str(workspace_dir, "workspace_dir")?)
+            // Read-only: `stage0-init` invokes `nix build --no-write-lock-file`
+            // against a flake that already carries a committed lock, so
+            // nothing ever writes back into the workspace tree.
+            .add_disk("work", path_to_str(&work_disk, "work_disk")?, true)
             .add_virtio_fs("out", path_to_str(artifact_out, "artifact_out")?)
             // /mvm-bins inside the guest — stage0-init sets MVM_HOST_BIN_DIR
             // to it so the flake picks up the pre-built host-vm binaries.
@@ -1299,6 +1318,36 @@ impl LibkrunBuilderVm {
         }
         Ok(())
     }
+}
+
+/// Pack `workspace_dir` into a read-only ext4 disk for the Stage 0 `/work`
+/// mount, carrying [`crate::rootfs::STAGE0_WORK_EXT4_LABEL`] so
+/// `stage0-init` can find it by content instead of by device-enumeration
+/// order. Stages a filtered copy first (dropping `target/`, `.git/`, …
+/// — [`crate::qemu_builder::WORK_TREE_EXCLUDE_DIRS`], the same list the
+/// QEMU Stage 0 path drops) so the pure writer never packs a multi-gigabyte
+/// `target/` for nothing, then discards the filtered copy once it's on
+/// disk. The image itself is left under `vm_state_dir` for the same
+/// existing reaper that already prunes stale Stage 0 VM state (console
+/// logs, sockets, …).
+fn pack_stage0_work_disk(
+    workspace_dir: &std::path::Path,
+    vm_state_dir: &std::path::Path,
+) -> Result<PathBuf, BuilderVmError> {
+    let staged = vm_state_dir.join("work-src");
+    crate::qemu_builder::copy_tree_filtered(
+        workspace_dir,
+        &staged,
+        crate::qemu_builder::WORK_TREE_EXCLUDE_DIRS,
+    )?;
+    let image_path = vm_state_dir.join("work.ext4");
+    let input = crate::rootfs::MaterializeExt4Input::new(staged.clone(), image_path.clone(), 0)
+        .with_volume_label(crate::rootfs::STAGE0_WORK_EXT4_LABEL);
+    let result = crate::rootfs::materialize_ext4_pure(&input)
+        .map_err(|e| BuilderVmError::ExtractionFailed(format!("packing /work ext4 disk: {e}")));
+    let _ = std::fs::remove_dir_all(&staged);
+    result?;
+    Ok(image_path)
 }
 
 #[cfg(test)]
@@ -4140,6 +4189,12 @@ impl LibkrunPersistentHostVm {
                 path_to_str(nix_store_lock.path(), "nix_store_img")?,
                 false,
             )
+            // Left on virtio-fs deliberately, unlike Stage 0's `/work`
+            // (`pack_stage0_work_disk`): this is the long-lived persistent
+            // VM, so `/work` has to keep reflecting live host edits across
+            // the session — a packed ext4 snapshot would need repacking on
+            // every change. Revisit if a large workspace ever hits the same
+            // virtio-fs handle exhaustion here.
             .add_virtio_fs("work", path_to_str(&self.workspace_root, "workspace_root")?)
             .add_virtio_fs("out", path_to_str(&job_dir, "job_dir")?)
             .add_virtio_fs("job", path_to_str(&job_dir, "job_dir")?)

--- a/crates/mvm-build/src/qemu_builder.rs
+++ b/crates/mvm-build/src/qemu_builder.rs
@@ -112,6 +112,12 @@ const QEMU_STAGE0_OUT_ARTIFACT_NAMES: &[&str] = &[
     "nix-stderr.log",
 ];
 
+/// Directories `copy_tree_filtered` drops when staging a `/work` tree for
+/// packing — the heavy build/VCS dirs the nix workspace filter ignores
+/// anyway. Shared with the libkrun Stage 0 path (`libkrun_builder`), which
+/// packs `/work` onto an ext4 disk the same way this QEMU path does.
+pub(crate) const WORK_TREE_EXCLUDE_DIRS: &[&str] = &["target", ".git", ".claude", "node_modules"];
+
 /// Ext4 image sizes (sparse — `set_len` + `mkfs.ext4 -d` only touch real
 /// content). The seed disk holds the whole build closure nix downloads.
 const SEED_IMG_BYTES: u64 = 30 * 1024 * 1024 * 1024;
@@ -181,11 +187,7 @@ fn run_stage0_qemu(
     // workspace filter ignores anyway (`target/`, `.git`, …) — otherwise a
     // multi-GB `target/` would bloat the disk + pack time for nothing.
     let work_src = work.join("work-src");
-    copy_tree_filtered(
-        workspace_dir,
-        &work_src,
-        &["target", ".git", ".claude", "node_modules"],
-    )?;
+    copy_tree_filtered(workspace_dir, &work_src, WORK_TREE_EXCLUDE_DIRS)?;
     pack_ext4(&work_src, &vdb, dir_stats(&work_src).work_ext4_size_bytes())?;
     let _ = std::fs::remove_dir_all(&work_src);
     pack_ext4(artifact_out, &vdc, OUT_IMG_BYTES)?;
@@ -273,7 +275,13 @@ fn run_stage0_qemu(
 /// Recursively copy `src` into `dst`, skipping any directory whose name is in
 /// `exclude` (at any depth). Files copied, symlinks recreated. Used to stage a
 /// `/work` tree without the heavy `target/`/`.git` dirs before packing it.
-fn copy_tree_filtered(src: &Path, dst: &Path, exclude: &[&str]) -> Result<(), BuilderVmError> {
+/// `pub(crate)` so the libkrun Stage 0 path can stage its own filtered
+/// `/work` copy with the same walk instead of a second implementation.
+pub(crate) fn copy_tree_filtered(
+    src: &Path,
+    dst: &Path,
+    exclude: &[&str],
+) -> Result<(), BuilderVmError> {
     std::fs::create_dir_all(dst).map_err(|e| io_err("creating staging dir", dst, e))?;
     let mut stack = vec![(src.to_path_buf(), dst.to_path_buf())];
     while let Some((from, to)) = stack.pop() {

--- a/crates/mvm-build/src/rootfs.rs
+++ b/crates/mvm-build/src/rootfs.rs
@@ -21,6 +21,15 @@ const DEFAULT_SIZE_MULTIPLIER_NUMERATOR: u64 = 3;
 const DEFAULT_SIZE_MULTIPLIER_DENOMINATOR: u64 = 2;
 const DEFAULT_GUEST_OUTPUT_DEVICE: &str = "/dev/vdc";
 
+/// ext4 volume label stamped on the libkrun Stage 0 `/work` disk
+/// (`libkrun_builder::run_stage0_impl`) so `stage0-init` can find it by
+/// content instead of by device-enumeration order. ext4's on-disk
+/// `s_volume_name` field caps at 16 bytes; kept well under that. Lives here
+/// (ungated) rather than behind `pure-mkfs` so the Stage 0 guest binary,
+/// which only needs the string and not the writer, can reference it
+/// regardless of which features its own build enables.
+pub const STAGE0_WORK_EXT4_LABEL: &str = "mvm-work";
+
 /// Inputs for [`materialize_ext4`].
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct MaterializeExt4Input {
@@ -36,6 +45,12 @@ pub struct MaterializeExt4Input {
     /// turns it on to make OCI block roots sealed across both the pure and
     /// builder-VM materializers.
     pub emit_verity: bool,
+    /// ext4 volume label (`s_volume_name`) to stamp on the pure-path image,
+    /// truncated to 16 bytes by the underlying writer. `None` (the default)
+    /// leaves the field zeroed, unchanged from before this option existed.
+    /// Only consulted by [`materialize_ext4_pure`] — the builder-VM path
+    /// (`materialize_ext4`) doesn't stamp a label.
+    pub volume_label: Option<String>,
 }
 
 impl MaterializeExt4Input {
@@ -45,12 +60,21 @@ impl MaterializeExt4Input {
             output,
             uncompressed_size_bytes,
             emit_verity: false,
+            volume_label: None,
         }
     }
 
     /// Opt into dm-verity sidecar emission on the pure path.
     pub fn with_verity(mut self) -> Self {
         self.emit_verity = true;
+        self
+    }
+
+    /// Stamp an ext4 volume label on the pure-path image (e.g.
+    /// [`STAGE0_WORK_EXT4_LABEL`]), so a guest can mount it by content
+    /// instead of by device path.
+    pub fn with_volume_label(mut self, label: impl Into<String>) -> Self {
+        self.volume_label = Some(label.into());
         self
     }
 }
@@ -401,8 +425,13 @@ pub fn materialize_ext4_pure(
             source,
         })?;
     }
-    let size_bytes =
-        stream_pure_ext4_output(&nodes, &input.output, &mvm_ext4::BuildOptions::default())?;
+    // Stage-0 /work is mounted by label; every other caller leaves
+    // volume_label None and gets the unchanged default-options image.
+    let build_options = match &input.volume_label {
+        Some(label) => mvm_ext4::BuildOptions::default().with_volume_name(label.as_bytes()),
+        None => mvm_ext4::BuildOptions::default(),
+    };
+    let size_bytes = stream_pure_ext4_output(&nodes, &input.output, &build_options)?;
     let verity_root_hash = maybe_emit_verity_sidecars(input)?;
 
     Ok(MaterializedExt4 {
@@ -861,6 +890,40 @@ mod tests {
         assert!(mat.verity_root_hash.is_none());
         assert!(!out.path().join("rootfs.verity").exists());
         assert!(!out.path().join("rootfs.roothash").exists());
+    }
+
+    #[cfg(feature = "pure-mkfs")]
+    #[test]
+    fn pure_materialize_without_a_label_leaves_volume_name_zeroed() {
+        // Regression guard for the `with_volume_label` plumbing: a caller that
+        // never opts in must get byte-identical output to before the option
+        // existed — an all-zero `s_volume_name`.
+        let src = tempfile::tempdir().unwrap();
+        std::fs::write(src.path().join("hello"), b"hi\n").unwrap();
+        let out = tempfile::tempdir().unwrap();
+        let out_path = out.path().join("rootfs.ext4");
+        let input = MaterializeExt4Input::new(src.path().to_path_buf(), out_path.clone(), 0);
+
+        materialize_ext4_pure(&input).expect("pure materialize");
+        let img = std::fs::read(&out_path).unwrap();
+        assert_eq!(&img[1024 + 0x78..1024 + 0x88], &[0u8; 16]);
+    }
+
+    #[cfg(feature = "pure-mkfs")]
+    #[test]
+    fn pure_materialize_with_a_label_stamps_the_ext4_volume_name() {
+        let src = tempfile::tempdir().unwrap();
+        std::fs::write(src.path().join("hello"), b"hi\n").unwrap();
+        let out = tempfile::tempdir().unwrap();
+        let out_path = out.path().join("rootfs.ext4");
+        let input = MaterializeExt4Input::new(src.path().to_path_buf(), out_path.clone(), 0)
+            .with_volume_label(STAGE0_WORK_EXT4_LABEL);
+
+        materialize_ext4_pure(&input).expect("pure materialize");
+        let img = std::fs::read(&out_path).unwrap();
+        let mut expected = [0u8; 16];
+        expected[..STAGE0_WORK_EXT4_LABEL.len()].copy_from_slice(STAGE0_WORK_EXT4_LABEL.as_bytes());
+        assert_eq!(&img[1024 + 0x78..1024 + 0x88], &expected);
     }
 
     #[cfg(feature = "pure-mkfs")]


### PR DESCRIPTION
## Problem

The libkrun Stage-0 builder delivers the workspace `/work` over **virtio-fs**. When `nix build` walks the large workspace tree, it exhausts libkrun's virtio-fs handle pool and fails with `Too many open files` while copying the source — e.g.:

```
error: cannot read directory "/work/crates/mvm-guest/src/runner": Too many open files
```

This happens even with `RLIMIT_NOFILE` raised to 65536 (the limit isn't the process fd ceiling — it's libkrun's virtio-fs handle pool), and the failure point just shifts when you exclude directories. The QEMU builder never hits this because it delivers `/work` as an ext4 **block disk**, not virtio-fs.

## Fix

`run_stage0_impl` now packs the workspace into a **read-only ext4 disk** via the existing pure-Rust `materialize_ext4_pure` writer (extended with a volume-label option) and attaches it with `add_disk` instead of `add_virtio_fs("work", …)`. The guest mounts `/work` from that disk by ext4 volume label (content-addressed, so device-enumeration order doesn't matter), falling back to the old `work` virtio-fs tag when no labeled disk is attached.

`/out` and `/mvm-bins` stay on virtio-fs (small, not bulk-traversed). This mirrors what the QEMU Stage-0 path already does for its shares.

Only Stage 0 needed this: `run_build`/`run_shell_script` already moved to the tar-disk transport, and the long-lived persistent builder VM stays on virtio-fs (it isn't doing a full nix tree walk).

## Validation

**Live on the KVM box (libkrun 1.18.0, x86_64), the exact scenario that previously failed:**

```
stage0-init: mounted /work from ext4 disk /dev/vdb (label "mvm-work")
stage0-init: building path:/work/nix/images/builder-vm#packages.x86_64-linux.default (output_mode=image)
```

`/work` mounts from the ext4 disk by label, and the Stage-0 nix build proceeds into `building path:/work/...` — the step that used to EMFILE — with **no `Too many open files`**.

**Static / unit:**
- `cargo build` + `clippy -D warnings` clean (default and `builder-vm` feature sets); `cargo zigbuild --target x86_64-unknown-linux-musl` clean; glibc `--lib` cross-check clean.
- `cargo nextest run -p mvm-build --features builder-vm` — 960 passed; +7 new unit tests (ext4 label roundtrip, superblock probe, disk selection).

Rebased onto current main: `stream_pure_ext4_output` already gained `BuildOptions` threading there, so this branch now adds only the `volume_label` plumbing plus the Stage-0 ext4 pack + label-mount.


---

**Why the box build doesn't fully green:** after Stage 0 clears the EMFILE, the run stops at a separate, pre-existing guard — the steady-state rootfs-backed libkrun builder is intentionally gated off on Linux/KVM (`steady_state_rootfs_builder_unavailable_reason_for` → "use the qemu builder", from the readonly-runtime-overlay rollout). That's out of scope here; this PR is solely the Stage-0 `/work` EMFILE fix, which is what the two Stage-0 consoles above validate.
