### PR TITLE
fix(oci-run): guard verity kernel host-side + clarify sealed-agent verb denials

### DIFF
--- a/crates/mvm-cli/src/commands/env/dev_vz.rs
+++ b/crates/mvm-cli/src/commands/env/dev_vz.rs
@@ -39,10 +39,11 @@ use default_microvm::DefaultMicrovmVariant;
 #[cfg(test)]
 use default_microvm::{
     WorkloadKernelBootstrap, default_microvm_assets, find_cached_workload_kernel,
-    resolve_workload_kernel_bootstrap,
+    kernel_carries_dm_verity, resolve_workload_kernel_bootstrap,
 };
 pub(crate) use default_microvm::{
-    ensure_default_microvm_image, ensure_workload_kernel, ensure_workload_verity_initrd,
+    assert_workload_kernel_supports_verity, ensure_default_microvm_image, ensure_workload_kernel,
+    ensure_workload_verity_initrd,
 };
 use image_ops::validate_dev_image_artifacts;
 #[cfg(feature = "builder-vm")]

--- a/crates/mvm-cli/src/commands/env/dev_vz/builder_vm_bootstrap_tests.rs
+++ b/crates/mvm-cli/src/commands/env/dev_vz/builder_vm_bootstrap_tests.rs
@@ -120,6 +120,47 @@ fn workload_kernel_never_reuses_the_non_verity_builder_kernel() {
 }
 
 #[test]
+fn kernel_carries_dm_verity_flags_only_a_readable_marker_free_kernel() {
+    // A readable kernel carrying any device-mapper/dm-verity symbol → supported.
+    let verity = b"boot Linux version 6.6.0 ... dm_table_create ... verity_ctr ...".to_vec();
+    assert_eq!(kernel_carries_dm_verity(&verity), Some(true));
+    let dm_only = b"Linux version 6.6 device-mapper: ioctl:".to_vec();
+    assert_eq!(kernel_carries_dm_verity(&dm_only), Some(true));
+
+    // A readable kernel with no dm marker at all → the builder-kernel signature.
+    // This is the only case that fails the launch guard.
+    let builder = b"Linux version 6.6.0 (nixbld) rootwait console=hvc0 target_type".to_vec();
+    assert_eq!(kernel_carries_dm_verity(&builder), Some(false));
+
+    // Not a recognizable kernel (compressed Image, truncated file, junk) →
+    // inconclusive; the guard must never reject on `None`.
+    assert_eq!(kernel_carries_dm_verity(b"\x1f\x8b\x08 gzip payload"), None);
+    assert_eq!(kernel_carries_dm_verity(b""), None);
+    assert_eq!(kernel_carries_dm_verity(b"device-mapper"), None);
+}
+
+#[test]
+fn assert_workload_kernel_supports_verity_rejects_a_marker_free_kernel() {
+    let tmp = tempfile::tempdir().unwrap();
+    // A readable kernel with no dm-verity symbol is refused with a clear message.
+    let bad = tmp.path().join("builder-vmlinux");
+    std::fs::write(&bad, b"Linux version 6.6.0 (nixbld) console=hvc0 rootwait").unwrap();
+    let err = assert_workload_kernel_supports_verity(bad.to_str().unwrap()).unwrap_err();
+    assert!(
+        err.to_string().contains("dm-verity"),
+        "unexpected error: {err}"
+    );
+
+    // A dm-verity-capable kernel passes; an unrecognized blob passes (inconclusive).
+    let good = tmp.path().join("workload-vmlinux");
+    std::fs::write(&good, b"Linux version 6.6.0 dm_table_create verity_ctr").unwrap();
+    assert!(assert_workload_kernel_supports_verity(good.to_str().unwrap()).is_ok());
+    let opaque = tmp.path().join("compressed-image");
+    std::fs::write(&opaque, b"\x1f\x8b\x08 not a decodable kernel").unwrap();
+    assert!(assert_workload_kernel_supports_verity(opaque.to_str().unwrap()).is_ok());
+}
+
+#[test]
 #[cfg(feature = "builder-vm")]
 fn build_heartbeat_emits_while_alive_and_stops_on_drop() {
     use std::sync::Arc;

--- a/crates/mvm-cli/src/commands/env/dev_vz/default_microvm.rs
+++ b/crates/mvm-cli/src/commands/env/dev_vz/default_microvm.rs
@@ -43,6 +43,56 @@ pub(crate) fn ensure_workload_kernel(prod: bool) -> Result<String> {
     }
 }
 
+/// Whether a kernel image carries device-mapper + dm-verity support (needed to
+/// boot a verity-sealed rootfs). `None` when the input is not a readable,
+/// uncompressed kernel we can judge (a compressed `Image`, a truncated file, or
+/// any non-kernel blob) — callers must NOT block on `None`. `Some(false)` only
+/// when the kernel is readable yet carries no device-mapper/dm-verity symbol at
+/// all — the signature of a kernel built without `CONFIG_BLK_DEV_DM`/`DM_VERITY`
+/// (e.g. the builder kernel, which force-drops them).
+pub(super) fn kernel_carries_dm_verity(bytes: &[u8]) -> Option<bool> {
+    // Only an uncompressed vmlinux exposes symbol strings; anything else is
+    // inconclusive, and blocking on it would false-reject a valid kernel.
+    if !byte_contains(bytes, b"Linux version") {
+        return None;
+    }
+    // A dm-verity-capable kernel carries these device-mapper / dm-verity symbols
+    // (via KALLSYMS + the dm subsystem's log strings). A kernel built without the
+    // device-mapper umbrella carries none of them.
+    const MARKERS: &[&[u8]] = &[
+        b"device-mapper",
+        b"dm_bufio",
+        b"verity_ctr",
+        b"dm_table_create",
+        b"dm-verity",
+    ];
+    Some(MARKERS.iter().any(|m| byte_contains(bytes, m)))
+}
+
+fn byte_contains(haystack: &[u8], needle: &[u8]) -> bool {
+    needle.len() <= haystack.len() && haystack.windows(needle.len()).any(|w| w == needle)
+}
+
+/// Fail fast when a verity-sealed launch resolved a kernel with no dm-verity
+/// support. Without this the guest panics in early init opening
+/// `/dev/mapper/control` ("No such file or directory") with zero host signal —
+/// so surface a clear host-side error instead. Conservative: only a *readable*
+/// kernel with no dm-verity symbol at all trips it, so an unrecognized/compressed
+/// kernel is never wrongly rejected.
+pub(crate) fn assert_workload_kernel_supports_verity(kernel_path: &str) -> Result<()> {
+    let bytes = std::fs::read(kernel_path)
+        .with_context(|| format!("read resolved workload kernel {kernel_path}"))?;
+    if kernel_carries_dm_verity(&bytes) == Some(false) {
+        anyhow::bail!(
+            "resolved workload kernel {kernel_path} carries no device-mapper/dm-verity \
+             support, but the workload boots verity-sealed. It would panic the guest at boot \
+             (mvm-verity-init: open /dev/mapper/control: No such file or directory). This \
+             kernel cannot back a sealed workload — resolve or rebuild the workload kernel."
+        );
+    }
+    Ok(())
+}
+
 pub(crate) fn ensure_workload_verity_initrd() -> Result<String> {
     let cache_root = std::path::PathBuf::from(mvm_core::config::mvm_cache_dir());
     let version = env!("CARGO_PKG_VERSION");

--- a/crates/mvm-cli/src/commands/vm/exec.rs
+++ b/crates/mvm-cli/src/commands/vm/exec.rs
@@ -16,7 +16,9 @@ use serde::{Deserialize, Serialize};
 use sha2::{Digest, Sha256};
 use std::path::{Path, PathBuf};
 
-use super::super::env::dev_vz::{ensure_default_microvm_image, ensure_workload_kernel};
+use super::super::env::dev_vz::{
+    assert_workload_kernel_supports_verity, ensure_default_microvm_image, ensure_workload_kernel,
+};
 use super::Cli;
 use super::audit_chain::AuditEmitter;
 use super::host_signer::{PUBLIC_FILENAME, host_signer_id, load_or_init};
@@ -747,6 +749,10 @@ fn build_exec_request(
                 // verity-sealed, so the kernel must carry dm-verity; the builder
                 // kernel (which drops it) is never a stand-in.
                 let kernel_path = ensure_workload_kernel(prod)?;
+                // Enforce that invariant host-side: a kernel with no dm-verity
+                // support would panic the guest in early init opening
+                // /dev/mapper/control, with no host signal. Fail fast instead.
+                assert_workload_kernel_supports_verity(&kernel_path)?;
                 crate::exec::ImageSource::Prebuilt {
                     kernel_path,
                     rootfs_path: cached.rootfs_path.display().to_string(),

--- a/crates/mvm-guest/src/bin/mvm-guest-agent.rs
+++ b/crates/mvm-guest/src/bin/mvm-guest-agent.rs
@@ -2471,7 +2471,7 @@ fn handle_client(
 
         #[cfg(not(feature = "dev-shell"))]
         GuestRequest::Exec { .. } => GuestResponse::Error {
-            message: "exec not available: guest agent built without dev-shell feature".to_string(),
+            message: "exec not available on a production workload: this is a dev-only control verb, absent from sealed agents — run a dev-tier workload for interactive/exec access".to_string(),
         },
 
         #[cfg(feature = "dev-shell")]
@@ -2490,7 +2490,7 @@ fn handle_client(
 
         #[cfg(not(feature = "dev-shell"))]
         GuestRequest::ExecBatch { .. } => GuestResponse::Error {
-            message: "exec-batch not available: guest agent built without dev-shell feature"
+            message: "exec-batch not available on a production workload: this is a dev-only control verb, absent from sealed agents — run a dev-tier workload for interactive/exec access"
                 .to_string(),
         },
 
@@ -2511,7 +2511,7 @@ fn handle_client(
 
         #[cfg(not(feature = "dev-shell"))]
         GuestRequest::RunCode { .. } => GuestResponse::Error {
-            message: "run-code not available: guest agent built without dev-shell feature"
+            message: "run-code not available on a production workload: this is a dev-only control verb, absent from sealed agents — run a dev-tier workload for interactive/exec access"
                 .to_string(),
         },
 
@@ -2547,7 +2547,7 @@ fn handle_client(
 
         #[cfg(not(feature = "dev-shell"))]
         GuestRequest::RunDetached { .. } => GuestResponse::Error {
-            message: "run-detached not available: guest agent built without dev-shell feature"
+            message: "run-detached not available on a production workload: this is a dev-only control verb, absent from sealed agents — run a dev-tier workload for interactive/exec access"
                 .to_string(),
         },
 
@@ -2638,7 +2638,7 @@ fn handle_client(
 
         #[cfg(not(feature = "dev-shell"))]
         GuestRequest::ConsoleOpen { .. } => GuestResponse::Error {
-            message: "console not available: guest agent built without dev-shell feature"
+            message: "console not available on a production workload: this is a dev-only control verb, absent from sealed agents — run a dev-tier workload for interactive/exec access"
                 .to_string(),
         },
 
@@ -2666,7 +2666,7 @@ fn handle_client(
 
         #[cfg(not(feature = "dev-shell"))]
         GuestRequest::ConsoleClose { .. } => GuestResponse::Error {
-            message: "console not available: guest agent built without dev-shell feature"
+            message: "console not available on a production workload: this is a dev-only control verb, absent from sealed agents — run a dev-tier workload for interactive/exec access"
                 .to_string(),
         },
 
@@ -2688,7 +2688,7 @@ fn handle_client(
 
         #[cfg(not(feature = "dev-shell"))]
         GuestRequest::ConsoleResize { .. } => GuestResponse::Error {
-            message: "console not available: guest agent built without dev-shell feature"
+            message: "console not available on a production workload: this is a dev-only control verb, absent from sealed agents — run a dev-tier workload for interactive/exec access"
                 .to_string(),
         },
 
@@ -2827,7 +2827,7 @@ fn handle_client(
                 GuestResponse::ProcResult(mvm_guest::vsock::ProcResult::Error {
                     kind: mvm_guest::vsock::ProcErrorKind::UnsupportedInProduction,
                     message:
-                        "process control not available: guest agent built without dev-shell feature"
+                        "process control not available on a production workload: this is a dev-only control verb, absent from sealed agents — run a dev-tier workload for interactive/exec access"
                             .to_string(),
                 })
             }
@@ -2842,7 +2842,7 @@ fn handle_client(
                 GuestResponse::ProcResult(mvm_guest::vsock::ProcResult::Error {
                     kind: mvm_guest::vsock::ProcErrorKind::UnsupportedInProduction,
                     message:
-                        "process control not available: guest agent built without dev-shell feature"
+                        "process control not available on a production workload: this is a dev-only control verb, absent from sealed agents — run a dev-tier workload for interactive/exec access"
                             .to_string(),
                 })
             }
@@ -2862,7 +2862,7 @@ fn handle_client(
                 GuestResponse::ProcResult(mvm_guest::vsock::ProcResult::Error {
                     kind: mvm_guest::vsock::ProcErrorKind::UnsupportedInProduction,
                     message:
-                        "process control not available: guest agent built without dev-shell feature"
+                        "process control not available on a production workload: this is a dev-only control verb, absent from sealed agents — run a dev-tier workload for interactive/exec access"
                             .to_string(),
                 })
             }
@@ -2884,7 +2884,7 @@ fn handle_client(
                 GuestResponse::ProcResult(mvm_guest::vsock::ProcResult::Error {
                     kind: mvm_guest::vsock::ProcErrorKind::UnsupportedInProduction,
                     message:
-                        "process control not available: guest agent built without dev-shell feature"
+                        "process control not available on a production workload: this is a dev-only control verb, absent from sealed agents — run a dev-tier workload for interactive/exec access"
                             .to_string(),
                 })
             }
@@ -2903,7 +2903,7 @@ fn handle_client(
                 GuestResponse::ProcResult(mvm_guest::vsock::ProcResult::Error {
                     kind: mvm_guest::vsock::ProcErrorKind::UnsupportedInProduction,
                     message:
-                        "process control not available: guest agent built without dev-shell feature"
+                        "process control not available on a production workload: this is a dev-only control verb, absent from sealed agents — run a dev-tier workload for interactive/exec access"
                             .to_string(),
                 })
             }
@@ -2923,7 +2923,7 @@ fn handle_client(
                 GuestResponse::ProcWaitEvent(mvm_guest::vsock::ProcWaitEvent::Error {
                     kind: mvm_guest::vsock::ProcErrorKind::UnsupportedInProduction,
                     message:
-                        "process control not available: guest agent built without dev-shell feature"
+                        "process control not available on a production workload: this is a dev-only control verb, absent from sealed agents — run a dev-tier workload for interactive/exec access"
                             .to_string(),
                 })
             }


### PR DESCRIPTION
Two follow-ups from the OCI `machine run --image` verity-boot incident (root cause fixed in #1684; these harden around it).

## #1688 — host-side kernel↔rootfs dm-verity agreement guard

An `--image` run boots a verity-sealed rootfs, so the resolved workload kernel must carry device-mapper + dm-verity built in. A kernel without it panics the guest in early init opening `/dev/mapper/control` ("No such file or directory") — with **zero host-side signal**; the mismatch surfaced only on the guest serial console.

- `kernel_carries_dm_verity(bytes) -> Option<bool>`: pure, unit-tested. `None` when the input isn't a readable/uncompressed kernel (compressed Image, truncated file, junk) — callers never block on it. `Some(false)` only when a readable kernel carries no device-mapper/dm-verity symbol at all — the builder-kernel signature (it force-drops `CONFIG_BLK_DEV_DM`/`DM_VERITY`).
- `assert_workload_kernel_supports_verity(path)`: reads the resolved kernel and fails fast with a clear host-side error when it's `Some(false)`. Wired into the `--image` launch path right after `ensure_workload_kernel`.
- Conservative by design: only a readable, marker-free kernel trips it, so a real verity kernel is never wrongly rejected.

## #1687 — clarify sealed-agent verb-denial message

The terse `guest agent built without dev-shell feature` error was accurate but unhelpful when it surfaced from a sealed production run. Reworded across every dev-shell-gated verb (exec, exec-batch, run-code, run-detached, console, process-control) to: `<verb> not available on a production workload: this is a dev-only control verb, absent from sealed agents — run a dev-tier workload for interactive/exec access`.

## Tests

- `kernel_carries_dm_verity_flags_only_a_readable_marker_free_kernel` — verity-symbol, dm-only, marker-free, and inconclusive (compressed/empty/non-kernel) cases.
- `assert_workload_kernel_supports_verity_rejects_a_marker_free_kernel` — refuses a marker-free kernel with a clear message; passes a verity kernel and an unrecognized blob.
- Full workspace suite green (6862/6862; mvm-backend excluded locally for the macOS codesign-SIGKILL issue). fmt (nightly), clippy, and the spec-ref comment gate all clean.

Closes #1687
Closes #1688
