### PR TITLE
fix(builder): scope the Linux/KVM steady-state guard to the libkrun backend (unblocks qemu-KVM)

### DIFF
--- a/crates/mvm-build/src/libkrun_builder.rs
+++ b/crates/mvm-build/src/libkrun_builder.rs
@@ -980,7 +980,7 @@ impl LibkrunBuilderVm {
         let supervisor_path = resolve_supervisor_path()?;
         let image = match &self.image_override {
             Some(image) => image.clone(),
-            None => ensure_builder_vm_image()?,
+            None => ensure_builder_vm_image_for_libkrun()?,
         };
         let nix_store_lock = acquire_nix_store_image_lock(
             &builder_vm_cache_dir(),
@@ -1451,7 +1451,7 @@ impl BuilderVm for LibkrunBuilderVm {
         //    image cache without first downloading it.
         let image = match &self.image_override {
             Some(image) => image.clone(),
-            None => ensure_builder_vm_image()?,
+            None => ensure_builder_vm_image_for_libkrun()?,
         };
 
         // 5. Allocate / locate the persistent `/nix-store`
@@ -1736,7 +1736,7 @@ impl LibkrunBuilderBackend {
     /// installed" at the call site rather than at first run.
     pub fn new() -> Result<Self, BuilderVmError> {
         let supervisor_path = resolve_supervisor_path()?;
-        let image = ensure_builder_vm_image()?;
+        let image = ensure_builder_vm_image_for_libkrun()?;
         Ok(Self {
             supervisor_path,
             image,
@@ -2208,13 +2208,30 @@ pub fn steady_state_rootfs_builder_unavailable_reason_for(
     }
 }
 
-fn ensure_rootfs_builder_supported_on_host() -> Result<(), BuilderVmError> {
-    if let Some(reason) =
-        steady_state_rootfs_builder_unavailable_reason_for(mvm_core::platform::current())
-    {
-        return Err(BuilderVmError::LibkrunUnavailable(reason.to_string()));
+/// Refuse to boot the steady-state rootfs-backed builder under libkrun on
+/// hosts where that image is known not to reach userspace (Linux/KVM). This
+/// restriction is libkrun-specific: the qemu and hvf builders load the same
+/// cached image without it, so the guard belongs on the libkrun boot path,
+/// not on the shared image loader. Parameterised on the platform so it is
+/// unit-testable off the host it guards.
+fn ensure_steady_state_libkrun_builder_supported_on(
+    plat: mvm_core::platform::Platform,
+) -> Result<(), BuilderVmError> {
+    match steady_state_rootfs_builder_unavailable_reason_for(plat) {
+        Some(reason) => Err(BuilderVmError::LibkrunUnavailable(reason.to_string())),
+        None => Ok(()),
     }
-    Ok(())
+}
+
+/// Resolve the steady-state builder VM image for a libkrun boot, failing
+/// closed on hosts the libkrun builder does not support. The single libkrun
+/// chokepoint: `run_build`, `run_shell_script`, the persistent VM start, and
+/// the `VmBackendForBuilder` constructor all route steady-state image
+/// resolution through here. Stage 0 and other callers that supply an explicit
+/// image override never reach this path.
+fn ensure_builder_vm_image_for_libkrun() -> Result<BuilderVmImage, BuilderVmError> {
+    ensure_steady_state_libkrun_builder_supported_on(mvm_core::platform::current())?;
+    ensure_builder_vm_image()
 }
 
 fn seed_builder_vm_image_from_default_cache(arch_dir: &Path) -> Result<bool, BuilderVmError> {
@@ -2525,8 +2542,6 @@ fn load_builder_vm_image_from_cache(arch_dir: &Path) -> Result<BuilderVmImage, B
     let kernel_path = arch_dir.join("vmlinux");
     let rootfs_path = arch_dir.join("rootfs.ext4");
     let cmdline = validate_builder_vm_image_cache(arch_dir)?;
-
-    ensure_rootfs_builder_supported_on_host()?;
 
     Ok(BuilderVmImage::new(kernel_path, rootfs_path, cmdline))
 }
@@ -4148,7 +4163,7 @@ impl LibkrunPersistentHostVm {
         let supervisor_path = resolve_supervisor_path()?;
         let image = match &self.image_override {
             Some(image) => image.clone(),
-            None => ensure_builder_vm_image()?,
+            None => ensure_builder_vm_image_for_libkrun()?,
         };
         // Acquire the cross-process flock on the nix-store image
         // for the persistent VM's lifetime. Concurrent
@@ -5411,33 +5426,13 @@ mod tests {
     }
 
     #[test]
-    #[cfg(target_os = "linux")]
-    fn ensure_builder_vm_image_refuses_rootfs_builder_cache_on_linux_native() {
-        let _env_lock = ENV_TEST_LOCK.lock().unwrap_or_else(|e| e.into_inner());
-        let mut env = TestEnv::new();
-        let scratch = TempDir::new().unwrap();
-        env.set("XDG_CACHE_HOME", scratch.path());
+    fn steady_state_libkrun_builder_guard_fails_closed_only_on_linux_native() {
+        use mvm_core::platform::Platform;
 
-        let arch_dir = scratch
-            .path()
-            .join("mvm")
-            .join("builder-vm")
-            .join(host_arch_tag());
-        std::fs::create_dir_all(&arch_dir).unwrap();
-        std::fs::write(arch_dir.join("vmlinux"), b"kernel").unwrap();
-        std::fs::write(arch_dir.join("rootfs.ext4"), b"rootfs").unwrap();
-        std::fs::write(
-            arch_dir.join("cmdline.txt"),
-            "console=hvc0 root=/dev/vda ro rootfstype=ext4 rootwait panic=-1 loglevel=8 init=/init mvm.chain_init=/sbin/mvm-host-vm-init\n",
-        )
-        .unwrap();
-        std::fs::write(
-            arch_dir.join("manifest.json"),
-            r#"{"cache_contract_version":3,"runtime_overlay_ready":true,"vsock_egress_ready":true}"#,
-        )
-        .unwrap();
-
-        let err = ensure_builder_vm_image().unwrap_err();
+        // Linux/KVM: the rootfs-backed libkrun builder image does not reach
+        // userspace, so the libkrun boot path must fail closed and point at qemu.
+        let err = ensure_steady_state_libkrun_builder_supported_on(Platform::LinuxNative)
+            .expect_err("libkrun steady-state builder must fail closed on Linux/KVM");
         match err {
             BuilderVmError::LibkrunUnavailable(message) => {
                 assert!(
@@ -5447,6 +5442,20 @@ mod tests {
                 assert!(message.contains("qemu builder"), "got {message}");
             }
             other => panic!("expected LibkrunUnavailable, got {other:?}"),
+        }
+
+        // Every other host permits the libkrun steady-state builder — the guard
+        // is scoped to the one platform whose boot is known to hang, not applied
+        // to the shared image loader that qemu and hvf also use.
+        for plat in [
+            Platform::MacOS,
+            Platform::LinuxNoKvm,
+            Platform::Wsl2,
+            Platform::Windows,
+        ] {
+            ensure_steady_state_libkrun_builder_supported_on(plat).unwrap_or_else(|e| {
+                panic!("{plat:?} should permit the libkrun builder, got {e:?}")
+            });
         }
     }
 
@@ -5478,46 +5487,22 @@ mod tests {
         let arch_dir = cache_root.join("builder-vm").join(&arch);
         let expected_cmdline = "console=hvc0 root=/dev/vda ro rootfstype=ext4 rootwait panic=-1 loglevel=8 init=/init mvm.chain_init=/sbin/mvm-host-vm-init";
 
-        #[cfg(target_os = "linux")]
-        {
-            let err = ensure_builder_vm_image()
-                .expect_err("Linux/KVM should fail closed after helper bootstrap");
-            match err {
-                BuilderVmError::LibkrunUnavailable(message) => {
-                    assert!(
-                        message.contains("rootfs-backed libkrun builder"),
-                        "got {message}"
-                    );
-                    assert!(message.contains("qemu builder"), "got {message}");
-                }
-                other => panic!("expected LibkrunUnavailable, got {other:?}"),
+        // Backend-agnostic loader: the auto-bootstrap helper populates the
+        // cache and the shared image load succeeds on every host, including
+        // Linux/KVM (qemu/hvf boot the same image). The libkrun steady-state
+        // guard is exercised separately on the libkrun boot path.
+        let image = ensure_builder_vm_image().expect("auto-bootstrap should populate cache");
+        match image {
+            BuilderVmImage::Rootfs {
+                kernel_path,
+                rootfs_path,
+                cmdline,
+            } => {
+                assert_eq!(kernel_path, arch_dir.join("vmlinux"));
+                assert_eq!(rootfs_path, arch_dir.join("rootfs.ext4"));
+                assert_eq!(cmdline, expected_cmdline);
             }
-            assert_eq!(std::fs::read(arch_dir.join("vmlinux")).unwrap(), b"kernel");
-            assert_eq!(
-                std::fs::read(arch_dir.join("rootfs.ext4")).unwrap(),
-                b"rootfs"
-            );
-            assert_eq!(
-                std::fs::read_to_string(arch_dir.join("cmdline.txt")).unwrap(),
-                format!("{expected_cmdline}\n")
-            );
-        }
-
-        #[cfg(not(target_os = "linux"))]
-        {
-            let image = ensure_builder_vm_image().expect("auto-bootstrap should populate cache");
-            match image {
-                BuilderVmImage::Rootfs {
-                    kernel_path,
-                    rootfs_path,
-                    cmdline,
-                } => {
-                    assert_eq!(kernel_path, arch_dir.join("vmlinux"));
-                    assert_eq!(rootfs_path, arch_dir.join("rootfs.ext4"));
-                    assert_eq!(cmdline, expected_cmdline);
-                }
-                BuilderVmImage::RootDir { .. } => panic!("expected rootfs builder image"),
-            }
+            BuilderVmImage::RootDir { .. } => panic!("expected rootfs builder image"),
         }
     }
 
@@ -5558,44 +5543,23 @@ mod tests {
             .join("builder-vm")
             .join(&arch);
 
-        #[cfg(target_os = "linux")]
-        {
-            let err = ensure_builder_vm_image().expect_err(
-                "Linux native steady-state builder image should fail closed after seeding",
-            );
-            match err {
-                BuilderVmError::LibkrunUnavailable(message) => {
-                    assert!(
-                        message.contains("rootfs-backed libkrun builder is not supported"),
-                        "unexpected error: {message}"
-                    );
-                }
-                other => panic!("expected LibkrunUnavailable, got {other:?}"),
+        // Seeding from the default cache populates the isolated cache and the
+        // shared loader returns the image on every host, Linux/KVM included.
+        let image = ensure_builder_vm_image().expect("seed from default cache");
+        assert_eq!(
+            std::fs::read(target_arch_dir.join("manifest.json")).unwrap(),
+            std::fs::read(source_arch_dir.join("manifest.json")).unwrap()
+        );
+        match image {
+            BuilderVmImage::Rootfs {
+                kernel_path,
+                rootfs_path,
+                ..
+            } => {
+                assert_eq!(kernel_path, target_arch_dir.join("vmlinux"));
+                assert_eq!(rootfs_path, target_arch_dir.join("rootfs.ext4"));
             }
-            assert_eq!(
-                std::fs::read(target_arch_dir.join("manifest.json")).unwrap(),
-                std::fs::read(source_arch_dir.join("manifest.json")).unwrap()
-            );
-        }
-
-        #[cfg(not(target_os = "linux"))]
-        {
-            let image = ensure_builder_vm_image().expect("seed from default cache");
-            assert_eq!(
-                std::fs::read(target_arch_dir.join("manifest.json")).unwrap(),
-                std::fs::read(source_arch_dir.join("manifest.json")).unwrap()
-            );
-            match image {
-                BuilderVmImage::Rootfs {
-                    kernel_path,
-                    rootfs_path,
-                    ..
-                } => {
-                    assert_eq!(kernel_path, target_arch_dir.join("vmlinux"));
-                    assert_eq!(rootfs_path, target_arch_dir.join("rootfs.ext4"));
-                }
-                BuilderVmImage::RootDir { .. } => panic!("expected rootfs builder image"),
-            }
+            BuilderVmImage::RootDir { .. } => panic!("expected rootfs builder image"),
         }
     }
 
@@ -5649,51 +5613,31 @@ mod tests {
             .join("builder-vm")
             .join(&arch);
 
-        #[cfg(target_os = "linux")]
-        {
-            let err = ensure_builder_vm_image()
-                .expect_err("stale default cache should still fail closed on Linux");
-            match err {
-                BuilderVmError::LibkrunUnavailable(message) => {
-                    assert!(
-                        message.contains("rootfs-backed libkrun builder is not supported"),
-                        "unexpected error: {message}"
-                    );
-                }
-                other => panic!("expected LibkrunUnavailable, got {other:?}"),
-            }
-            assert_eq!(
-                std::fs::read_to_string(target_arch_dir.join("manifest.json"))
-                    .unwrap()
-                    .trim(),
-                "{\"cache_contract_version\":3,\"runtime_overlay_ready\":true,\"vsock_egress_ready\":true}"
-            );
-        }
-
-        #[cfg(not(target_os = "linux"))]
-        {
-            let image = ensure_builder_vm_image().expect("stale default cache should fall through");
-            assert_eq!(
-                std::fs::read_to_string(target_arch_dir.join("manifest.json"))
-                    .unwrap()
-                    .trim(),
-                "{\"cache_contract_version\":3,\"runtime_overlay_ready\":true,\"vsock_egress_ready\":true}"
-            );
-            match image {
-                BuilderVmImage::Rootfs {
-                    kernel_path,
-                    rootfs_path,
+        // Backend-agnostic loader: the stale default cache is skipped, the
+        // helper repopulates the isolated cache, and the shared image load
+        // succeeds on every host, Linux/KVM included — the libkrun steady-state
+        // guard is enforced on the libkrun boot path, not here.
+        let image = ensure_builder_vm_image().expect("stale default cache should fall through");
+        assert_eq!(
+            std::fs::read_to_string(target_arch_dir.join("manifest.json"))
+                .unwrap()
+                .trim(),
+            "{\"cache_contract_version\":3,\"runtime_overlay_ready\":true,\"vsock_egress_ready\":true}"
+        );
+        match image {
+            BuilderVmImage::Rootfs {
+                kernel_path,
+                rootfs_path,
+                cmdline,
+            } => {
+                assert_eq!(kernel_path, target_arch_dir.join("vmlinux"));
+                assert_eq!(rootfs_path, target_arch_dir.join("rootfs.ext4"));
+                assert_eq!(
                     cmdline,
-                } => {
-                    assert_eq!(kernel_path, target_arch_dir.join("vmlinux"));
-                    assert_eq!(rootfs_path, target_arch_dir.join("rootfs.ext4"));
-                    assert_eq!(
-                        cmdline,
-                        "console=hvc0 root=/dev/vda ro rootfstype=ext4 rootwait panic=-1 loglevel=8 init=/init mvm.chain_init=/sbin/mvm-host-vm-init"
-                    );
-                }
-                BuilderVmImage::RootDir { .. } => panic!("expected rootfs builder image"),
+                    "console=hvc0 root=/dev/vda ro rootfstype=ext4 rootwait panic=-1 loglevel=8 init=/init mvm.chain_init=/sbin/mvm-host-vm-init"
+                );
             }
+            BuilderVmImage::RootDir { .. } => panic!("expected rootfs builder image"),
         }
     }
 

--- a/specs/plans/250-linux-libkrun-steady-state-builder.md
+++ b/specs/plans/250-linux-libkrun-steady-state-builder.md
@@ -1,0 +1,79 @@
+# Plan 250 — Linux/KVM rootfs-backed steady-state libkrun builder
+
+**Status: P1 complete; P0/P2–P5 open.**
+
+## Goal
+
+Lift the hard guard that disables the rootfs-backed **steady-state** libkrun
+builder on Linux/KVM so it runs there instead of forcing qemu — matching macOS,
+where the same path already works. Today `steady_state_rootfs_builder_unavailable_reason_for(LinuxNative)`
+returns "the rootfs-backed libkrun builder is not supported on Linux/KVM yet;
+use the qemu builder", and the check sat on the **shared** image loader, so it
+also knocked out `--builder qemu` on any KVM host.
+
+## Background
+
+Three builder shapes: **Stage 0** (`BuilderVmImage::RootDir`, libkrun
+`krun_set_root` + bundled kernel — *produces* `vmlinux` + `rootfs.ext4`; runs on
+Linux, unguarded), **steady-state** (`BuilderVmImage::Rootfs` — boots the
+external kernel + ext4 block root to *consume* the image and run the user's `nix
+build`), and **qemu** (a second consumer of the same `Rootfs` image).
+
+Root cause of the guard: libkrun's rootfs-mode boot (external kernel + ext4
+block root) **does not reach userspace under Linux/KVM** — a minimal repro left
+the guest console at zero bytes, while the identical image boots under libkrun
+on macOS (HVF). KVM external-kernel page-alignment was one fix (see ADR-093); a
+residual boot silence remains and may be a libkrun upstream limitation for
+external-kernel + KVM boots.
+
+## Phases
+
+- [x] **P1 — Rescope the guard from platform to backend.** The guard lived in
+  `load_builder_vm_image_from_cache`, which `ensure_builder_vm_image()` calls for
+  *every* backend, so on a KVM host (`Platform::LinuxNative` ⇒ `/dev/kvm`
+  present) it failed `--builder qemu` too — with a message telling you to use
+  qemu. This PR moves the check onto the single libkrun steady-state chokepoint
+  (`ensure_builder_vm_image_for_libkrun()`, routed from `run_build`,
+  `run_shell_script`, the persistent VM start, and the libkrun backend
+  constructor); qemu and hvf load the same cached image with no guard. The
+  predicate is parameterised on `Platform` so it is unit-testable off the host it
+  guards. Fixes a live regression on KVM hosts.
+
+- [ ] **P0 — Reproduce + root-cause the libkrun rootfs-mode boot silence on
+  Linux/KVM.** On the Hetzner KVM box, rebuild the minimal-ext4 repro plus the
+  real builder image and bisect what differs from macOS: kernel format
+  (`Elf`/`Raw`), `console=hvc0` enumeration for external-kernel boots under KVM,
+  the root virtio-blk node. Deliverable: a green boot-to-console and a green
+  trivial `nix build` under libkrun `rootfs_path` on KVM, or a determination that
+  the fix belongs upstream (patch / version pin). **Highest risk; gates P2–P4.**
+
+- [ ] **P2 — Land the ext4 share/disk transport for `run_build` on
+  libkrun-Linux.** Reuse the merged Stage-0 `pack_stage0_work_disk` ext4 delivery
+  for the `run_build` input/output shares; resolve the `virtio-fs: tag not found`
+  attach failure and reconcile per-backend disk-slot ceilings.
+
+- [ ] **P3 — Flip the guard off for libkrun on `LinuxNative` + attach the verity
+  runtime-overlay disk.** Remove `LinuxNative` from the predicate; confirm the
+  read-only runtime-overlay disk + `required_overlay` policy attach and that
+  dm-verity mounts under libkrun-KVM in the builder guest.
+
+- [ ] **P4 — Live-validate on the KVM box + un-ignore the live builder tests.**
+  Convert the `#[ignore]` live libkrun/qemu builder tests into a gated live lane;
+  run `mvmctl build image --builder libkrun` end-to-end on the box; prove
+  read-only `/mvm/runtime`, a real user `nix build`, and a clean audit.
+
+- [ ] **P5 — Auto-default + docs decision.** Decide whether the LinuxNative
+  builder auto-default flips back to libkrun-first or stays qemu-default with
+  libkrun opt-in; refresh ADR-093's status, the builder-backend runbook table,
+  and the stale CLAUDE.md libkrun→qemu fallback paragraph.
+
+## Risks / open questions
+
+- The boot silence may be a libkrun **upstream** limitation for external-kernel +
+  KVM boots — could force a libkrun patch or version pin, or keep steady-state on
+  a root-dir shape.
+- The macOS (HVF, tolerant) ↔ Linux (KVM, strict) asymmetry means fixes may need
+  KVM-specific handling of the same artifact.
+- dm-verity under libkrun-KVM in the builder guest is unproven.
+- The auto-fallback libkrun→qemu on Linux was removed, so making libkrun-Linux
+  work becomes the only auto path unless the user passes `--builder qemu`.


### PR DESCRIPTION
## Problem

The rootfs-backed **steady-state** libkrun builder doesn't reach userspace on Linux/KVM (its external-kernel boot hangs), so it's guarded off there. But the guard lived on the **shared** builder-image loader (`load_builder_vm_image_from_cache` → `ensure_builder_vm_image`), which `--builder qemu` and `--builder hvf` also call. On any KVM host (`Platform::LinuxNative` ⇒ `/dev/kvm` present), `--builder qemu` therefore failed with:

```
the rootfs-backed libkrun builder is not supported on Linux/KVM yet; use the qemu builder
```

— i.e. it told you to use the very builder it had just blocked. The one qemu-on-Linux e2e test is `#[ignore]`, so CI never caught it.

Timing note: the guard fires *after* Stage 0. `load_builder_vm_image_from_cache` runs `validate_builder_vm_image_cache` first (cold cache → Err → auto-bootstrap → Stage 0), then the guard on the post-Stage-0 reload — so the regression bites only once the builder image exists.

## Fix

Move the check onto the single libkrun steady-state chokepoint, `ensure_builder_vm_image_for_libkrun()`, routed from the four libkrun entry points (`run_build`, `run_shell_script`, persistent VM start, backend constructor). `--builder qemu` and `--builder hvf` load the same cached image unguarded. The predicate is parameterised on `Platform` so it is unit-testable off the host it guards.

## Tests

- New `steady_state_libkrun_builder_guard_fails_closed_only_on_linux_native` — parameterised over every `Platform`; asserts the guard fires only on `LinuxNative`, permits the rest.
- The two cache-load tests (`auto_bootstraps…`, `seeds…`) now assert the shared loader succeeds on every host, Linux included.

## Follow-ups

`specs/plans/250-linux-libkrun-steady-state-builder.md` lays out the remaining phases: **P0** root-cause the libkrun rootfs-mode boot silence on KVM (the hard gate), **P2** ext4 share transport for `run_build`, **P3** flip the guard for libkrun-Linux + verity overlay, **P4** live validation on the KVM box, **P5** auto-default + docs.
