### PR TITLE
feat(oci-run): log workload-kernel provenance on resolution

### DIFF
--- a/crates/mvm-cli/src/commands/env/dev_vz/default_microvm.rs
+++ b/crates/mvm-cli/src/commands/env/dev_vz/default_microvm.rs
@@ -22,25 +22,28 @@ pub(crate) fn ensure_workload_kernel(prod: bool) -> Result<String> {
     let arch = builder_vm_host_arch();
     let resolved =
         resolve_workload_kernel_bootstrap(&cache, arch, prod, find_builder_vm_flake().is_ok());
-    match resolved {
-        WorkloadKernelBootstrap::Cached(path) => Ok(path),
+    // Name which kernel variant a run resolved and where it came from. Without
+    // this breadcrumb a wrong-kernel boot (e.g. a non-verity kernel under a
+    // verity-sealed rootfs) is invisible host-side until the guest panics.
+    let (provenance, path) = match resolved {
+        WorkloadKernelBootstrap::Cached(path) => ("cached", path),
         WorkloadKernelBootstrap::BuildLocal(path) => {
             ui::info("Building workload kernel locally (source checkout)...");
-            build_workload_kernel_locally()
-                .map(|built| built.display().to_string())
-                .or_else(|e| {
-                    if std::path::Path::new(&path).is_file() {
-                        Ok(path)
-                    } else {
-                        Err(e)
-                    }
-                })
+            match build_workload_kernel_locally() {
+                Ok(built) => ("built locally", built.display().to_string()),
+                Err(_) if std::path::Path::new(&path).is_file() => {
+                    ("reused cached (local build failed)", path)
+                }
+                Err(e) => return Err(e),
+            }
         }
         WorkloadKernelBootstrap::Download(dest) => {
             download_workload_kernel(arch, &dest)?;
-            Ok(dest)
+            ("downloaded", dest)
         }
-    }
+    };
+    ui::info(&format!("Workload kernel: {provenance} at {path}"));
+    Ok(path)
 }
 
 /// Whether a kernel image carries device-mapper + dm-verity support (needed to

--- a/specs/notes/2026-07-13-oci-run-workload-kernel-verity.md
+++ b/specs/notes/2026-07-13-oci-run-workload-kernel-verity.md
@@ -1,7 +1,8 @@
 # OCI-run workload kernel vs dm-verity: boot panic + infra follow-ups
 
 **Date:** 2026-07-13
-**Status:** symptom fixed (PR #1684); deeper follow-ups open below.
+**Status:** symptom fixed (PR #1684); follow-ups 1 + 4 landed (host-side verity
+guard + kernel-provenance breadcrumb, #1689 + this change), 2 mitigated, 3 open.
 **Live-repro:** `mvmctl machine run --image busybox --allow-host google.com` on
 macOS 26 Apple Silicon (HVF workload backend), source-checkout mvmctl.
 
@@ -56,29 +57,35 @@ to a reachable agent** on HVF.
 The shipped fix removes the wrong-kernel reuse, but the episode exposes structural
 gaps worth addressing:
 
-1. **No host-side kernel↔rootfs agreement check.** The mismatch surfaced only as a
-   guest kernel panic on the serial console — the host had zero signal. A verity-
-   sealed launch should assert, host-side and before boot, that the resolved kernel
-   supports dm-verity, and fail fast with a clear message instead of panicking the
-   guest. Encode the invariant: **a verity-sealed rootfs requires a dm-verity
-   kernel.**
+1. **No host-side kernel↔rootfs agreement check.** — **DONE (#1689).** The mismatch
+   surfaced only as a guest kernel panic on the serial console; the host had zero
+   signal. `assert_workload_kernel_supports_verity` now runs in the `--image` launch
+   path right after kernel resolution: it reads the resolved kernel and fails fast
+   with a clear host-side message when the kernel carries no device-mapper/dm-verity
+   symbol at all. The check (pure `kernel_carries_dm_verity`) is conservative — only
+   a *readable, marker-free* kernel trips it, so a compressed/unrecognized kernel is
+   never wrongly rejected. Invariant encoded: **a verity-sealed rootfs requires a
+   dm-verity kernel.**
 
-2. **The other reuse candidate may have the same latent bug.** `find_cached_workload_kernel`
-   still adds `default-microvm/dev/vmlinux` as a **non-prod** candidate. If that
-   dev default-microvm kernel is not dm-verity-capable, a cached-dev-kernel run
-   reproduces the identical panic via a different path. Verify the dev default
-   kernel carries dm-verity, or exclude it for verity-sealed launches.
+2. **The other reuse candidate may have the same latent bug.** — **mitigated (#1689),
+   root question open.** `find_cached_workload_kernel` still adds `default-microvm/dev/vmlinux`
+   as a **non-prod** candidate. The #1689 launch guard now catches a non-verity
+   cached-dev kernel at boot with a clear error instead of a panic, so the identical
+   failure mode no longer reaches the guest. Still open: confirm the dev
+   default-microvm kernel actually carries dm-verity (so the guard never fires on a
+   legitimate dev run), or exclude it for verity-sealed launches.
 
-3. **Should non-prod OCI runs verity-seal at all?** The builder-kernel reuse existed
-   because non-prod dev runs were assumed to boot *unsealed* (a plain rootfs on the
-   builder kernel — fast, no kernel build). Today they verity-seal, so the fix now
-   forces a workload-kernel build (3–5 min cold) on the first non-prod run. Decide
-   the intended dev-tier contract: keep verity on non-prod (correctness, current
-   fix) or boot non-prod unsealed (restores the dev-speed path, but is a larger
-   change to rootfs materialization + the boot path). Whichever is chosen, kernel
-   resolution and rootfs sealing must agree — that agreement is the real invariant.
+3. **Should non-prod OCI runs verity-seal at all?** — **open (design decision).** The
+   builder-kernel reuse existed because non-prod dev runs were assumed to boot
+   *unsealed* (a plain rootfs on the builder kernel — fast, no kernel build). Today
+   they verity-seal, so the fix now forces a workload-kernel build (3–5 min cold) on
+   the first non-prod run. Decide the intended dev-tier contract: keep verity on
+   non-prod (correctness, current fix) or boot non-prod unsealed (restores the
+   dev-speed path, but is a larger change to rootfs materialization + the boot path).
+   Whichever is chosen, kernel resolution and rootfs sealing must agree — that
+   agreement is the real invariant.
 
-4. **`mvmctl` gives no `-v` breadcrumb for kernel provenance.** During diagnosis it
-   was not observable which kernel variant a run resolved. A one-line log
-   ("workload kernel: built / cached / downloaded at <path>") would have made this
-   a one-shot diagnosis instead of a source dig.
+4. **`mvmctl` gives no breadcrumb for kernel provenance.** — **DONE.**
+   `ensure_workload_kernel` now emits one `Workload kernel: <cached|built locally|
+   downloaded|reused cached (local build failed)> at <path>` line per resolution, so
+   which kernel variant a run resolved is observable without a source dig.


### PR DESCRIPTION
Follow-up #4 from the OCI `machine run --image` verity-boot incident (note: `specs/notes/2026-07-13-oci-run-workload-kernel-verity.md`).

During the original diagnosis it was not observable which workload-kernel variant a run resolved — the mismatch (a non-verity builder kernel under a verity-sealed rootfs) was invisible host-side until the guest panicked in early init. `ensure_workload_kernel` resolved the kernel silently across its three arms (cached / build-local / download).

This emits one breadcrumb per resolution naming the variant and its origin:

```
Workload kernel: cached at <path>
Workload kernel: built locally at <path>
Workload kernel: downloaded at <path>
Workload kernel: reused cached (local build failed) at <path>
```

The build-local fallback (build fails, a stale cached kernel exists) is labeled distinctly so it isn't mistaken for a fresh build.

Also records follow-ups 1/2/4 as landed/mitigated in the incident note (#1 host-side verity guard + this #4 breadcrumb; #2 mitigated by the #1689 launch guard; #3 — whether non-prod OCI runs should verity-seal at all — remains an open design decision).

## Tests

- `builder_vm_bootstrap_tests` module green (51/51), including the kernel-resolution paths this refactors. clippy, nightly fmt, and the spec-ref comment gate all clean.
