### PR TITLE
feat(net): wire the smoltcp egress tunnel into the transient run path

### DIFF
--- a/crates/mvm-backend/src/libkrun.rs
+++ b/crates/mvm-backend/src/libkrun.rs
@@ -112,13 +112,20 @@ fn vsock_egress_cmdline_token(config: &VmStartConfig, state_dir: &Path) -> Optio
     .then(|| "mvm.vsock_egress=1".to_string())
 }
 
-fn validate_libkrun_network_policy(policy: &mvm_core::network_policy::NetworkPolicy) -> Result<()> {
-    if !policy.allows_egress() {
+fn validate_libkrun_network_policy(
+    policy: &mvm_core::network_policy::NetworkPolicy,
+    has_tunnel: bool,
+) -> Result<()> {
+    // Egress is served by the userspace L3 tunnel (a bounded allow-list). Deny-all
+    // needs no tunnel; a bounded allow-list gets one. The only unserved case is
+    // unrestricted allow-all, which has no finite gate to hand the forwarder.
+    if !policy.allows_egress() || has_tunnel {
         return Ok(());
     }
     bail!(
-        "libkrun does not support outbound workload egress in the current direct-path architecture; \
-         boot with deny-all networking or choose a backend that implements the no-NIC host-vsock-proxy egress path"
+        "libkrun serves outbound egress only through the bounded userspace L3 tunnel (an explicit \
+         allow-list); unrestricted allow-all egress has no finite gate on this backend. \
+         Name destinations with --allow-host, boot deny-all networking, or choose another backend"
     );
 }
 
@@ -407,6 +414,15 @@ fn build_supervisor_config(config: &VmStartConfig, state_dir: &Path) -> Result<S
         cmdline.push(' ');
         cmdline.push_str(&token);
     }
+    // The userspace L3 egress tunnel: tell the guest (via mvm-guest-netinit →
+    // mvm-guest-netd) to stand up its TUN and pump packets to the host worker
+    // over vsock. Present only for an admitted allow-list run.
+    if let Some(tunnel) = config.network_tunnel.as_ref()
+        && let Some(token) = mvm_core::vm_backend::encode_network_tunnel_cmdline(tunnel)
+    {
+        cmdline.push(' ');
+        cmdline.push_str(&token);
+    }
     // Workload-independent KrunContext (kernel + resources + vsock + gateway), shared
     // verbatim with the standby spawn so the two paths can't drift. The cold path
     // then sets the workload rootfs + user volumes below.
@@ -421,6 +437,15 @@ fn build_supervisor_config(config: &VmStartConfig, state_dir: &Path) -> Result<S
     krun = krun
         .with_kernel_format(kernel_format)
         .with_console_output(vm_console_log(&config.name).display().to_string());
+    // A tunnel run adds the guest→worker vsock port: libkrun proxies the guest's
+    // connect to the UDS the tunnel worker bound (before start_enter) at
+    // `<state_dir>/vsock-<port>.sock`. Conditional so non-tunnel launches and the
+    // warm-standby base don't register an inert port.
+    if config.network_tunnel.is_some() {
+        krun = krun.add_host_listen_port(
+            mvm_core::protocol::network_tunnel::NETWORK_TUNNEL_GUEST_PORT,
+        );
+    }
     if libkrun_verity_enabled(config) {
         krun.initramfs_path =
             libkrun_effective_initrd(config).map(|p| p.to_string_lossy().into_owned());
@@ -773,7 +798,7 @@ impl VmBackend for LibkrunBackend {
                 libkrun_sys::install_hint()
             );
         }
-        validate_libkrun_network_policy(&config.network_policy)?;
+        validate_libkrun_network_policy(&config.network_policy, config.network_tunnel.is_some())?;
         ensure_libkrun_runtime_source_supported(config)?;
 
         // Early kernel-path check. `build_supervisor_config`
@@ -1198,7 +1223,10 @@ impl VmBackend for LibkrunBackend {
         handle: &StandbyHandle,
         claim: &StandbyClaim,
     ) -> std::result::Result<VmId, StandbyError> {
-        validate_libkrun_network_policy(&claim.network_policy)
+        // A warm standby was booted without a tunnel; an egress run forces cold
+        // boot (`use_snapshot = false` when a tunnel is configured) so it never
+        // lands here, and a stray egress claim fails closed → fails open to cold.
+        validate_libkrun_network_policy(&claim.network_policy, false)
             .map_err(|e| StandbyError::ClaimFailed(e.to_string()))?;
         let attach = standby_attach_config(claim, handle.binding_nonce.clone())?;
         let mut stream = UnixStream::connect(&handle.control_socket).map_err(|e| {
@@ -2219,21 +2247,34 @@ mod tests {
 
     #[test]
     fn validate_libkrun_network_policy_accepts_deny_all() {
-        validate_libkrun_network_policy(&mvm_core::network_policy::NetworkPolicy::deny_all())
+        validate_libkrun_network_policy(&mvm_core::network_policy::NetworkPolicy::deny_all(), false)
             .expect("deny-all must remain valid for libkrun");
     }
 
     #[test]
-    fn validate_libkrun_network_policy_refuses_outbound_egress() {
+    fn validate_libkrun_network_policy_refuses_egress_without_a_tunnel() {
         let err =
             validate_libkrun_network_policy(&mvm_core::network_policy::NetworkPolicy::preset(
                 mvm_core::network_policy::NetworkPreset::Dev,
-            ))
-            .expect_err("libkrun outbound workload egress must fail closed");
+            ), false)
+            .expect_err("libkrun outbound egress with no tunnel must fail closed");
         assert!(
-            err.to_string().contains("direct-path architecture"),
+            err.to_string().contains("bounded userspace L3 tunnel"),
             "unexpected error: {err:#}"
         );
+    }
+
+    #[test]
+    fn validate_libkrun_network_policy_accepts_egress_served_by_a_tunnel() {
+        // An admitted allow-list run gets a network tunnel; egress is then served
+        // by the userspace L3 forwarder, so validation must pass.
+        validate_libkrun_network_policy(
+            &mvm_core::network_policy::NetworkPolicy::preset(
+                mvm_core::network_policy::NetworkPreset::Dev,
+            ),
+            true,
+        )
+        .expect("egress served by a tunnel must be accepted");
     }
 
     #[test]

--- a/crates/mvm-backend/src/libkrun.rs
+++ b/crates/mvm-backend/src/libkrun.rs
@@ -2305,7 +2305,7 @@ mod tests {
         match err {
             StandbyError::ClaimFailed(msg) => {
                 assert!(
-                    msg.contains("direct-path architecture"),
+                    msg.contains("bounded userspace L3 tunnel"),
                     "unexpected error: {msg}"
                 );
             }

--- a/crates/mvm-backend/src/libkrun.rs
+++ b/crates/mvm-backend/src/libkrun.rs
@@ -442,9 +442,8 @@ fn build_supervisor_config(config: &VmStartConfig, state_dir: &Path) -> Result<S
     // `<state_dir>/vsock-<port>.sock`. Conditional so non-tunnel launches and the
     // warm-standby base don't register an inert port.
     if config.network_tunnel.is_some() {
-        krun = krun.add_host_listen_port(
-            mvm_core::protocol::network_tunnel::NETWORK_TUNNEL_GUEST_PORT,
-        );
+        krun = krun
+            .add_host_listen_port(mvm_core::protocol::network_tunnel::NETWORK_TUNNEL_GUEST_PORT);
     }
     if libkrun_verity_enabled(config) {
         krun.initramfs_path =
@@ -2247,17 +2246,22 @@ mod tests {
 
     #[test]
     fn validate_libkrun_network_policy_accepts_deny_all() {
-        validate_libkrun_network_policy(&mvm_core::network_policy::NetworkPolicy::deny_all(), false)
-            .expect("deny-all must remain valid for libkrun");
+        validate_libkrun_network_policy(
+            &mvm_core::network_policy::NetworkPolicy::deny_all(),
+            false,
+        )
+        .expect("deny-all must remain valid for libkrun");
     }
 
     #[test]
     fn validate_libkrun_network_policy_refuses_egress_without_a_tunnel() {
-        let err =
-            validate_libkrun_network_policy(&mvm_core::network_policy::NetworkPolicy::preset(
+        let err = validate_libkrun_network_policy(
+            &mvm_core::network_policy::NetworkPolicy::preset(
                 mvm_core::network_policy::NetworkPreset::Dev,
-            ), false)
-            .expect_err("libkrun outbound egress with no tunnel must fail closed");
+            ),
+            false,
+        )
+        .expect_err("libkrun outbound egress with no tunnel must fail closed");
         assert!(
             err.to_string().contains("bounded userspace L3 tunnel"),
             "unexpected error: {err:#}"

--- a/crates/mvm-cli/src/exec.rs
+++ b/crates/mvm-cli/src/exec.rs
@@ -376,13 +376,35 @@ pub(crate) fn select_exec_backend(
     image_requested: bool,
     network_policy: &mvm_core::network_policy::NetworkPolicy,
 ) -> Result<AnyBackend> {
+    let backend_override = explicit_hypervisor_override();
     let backend_name = select_backend_name_for_egress(
-        None,
+        backend_override.as_deref(),
         image_requested,
         network_policy,
         "OCI --image runs with outbound egress enabled",
     )?;
     Ok(AnyBackend::from_hypervisor(&backend_name))
+}
+
+/// An explicit workload-backend override from the environment. The transient
+/// run path otherwise auto-detects the backend; this lets `MVM_HYPERVISOR`
+/// (or `MVM_BACKEND`) pin it — e.g. `libkrun`, whose vsock-tunnel egress path
+/// the auto-detected default would otherwise never select on this host. Every
+/// `select_exec_backend` call site reads the same value, so the admitted plan's
+/// backend and the boot backend agree.
+fn explicit_hypervisor_override() -> Option<String> {
+    ["MVM_HYPERVISOR", "MVM_BACKEND"]
+        .into_iter()
+        .filter_map(std::env::var_os)
+        .find_map(|raw| normalize_backend_override(&raw.to_string_lossy()))
+}
+
+/// Normalize a backend-override string (trim + lowercase); a blank value yields
+/// `None` so an empty env var is treated as "unset" rather than an invalid
+/// backend name.
+fn normalize_backend_override(raw: &str) -> Option<String> {
+    let value = raw.trim().to_ascii_lowercase();
+    (!value.is_empty()).then_some(value)
 }
 
 pub(crate) fn select_backend_name_for_egress(
@@ -1056,10 +1078,29 @@ fn run_inner(
         secret_files: Vec::new(),
         runner_dir: None,
         network_policy: req.network_policy.clone(),
+        // Derive the userspace L3 egress tunnel from the resolved policy: an
+        // admitted allow-list gets a `mvm-network-tunnel-worker` (the smoltcp
+        // forwarder) whose gate enforces exactly those flows; deny-all /
+        // unrestricted return None (no forwarding tunnel). The identity is
+        // minted here so the guest cmdline token and the host worker's
+        // expected-session validate against identical values.
+        network_tunnel: mvm_backend::network_tunnel_for_launch(
+            &req.network_policy,
+            mvm_backend::TunnelLaunchIdentity {
+                tenant_id: "local".to_string(),
+                vm_id: vm_name.clone(),
+                boot_id: uuid::Uuid::new_v4().to_string(),
+                session_nonce: uuid::Uuid::new_v4().to_string(),
+            },
+        ),
         warm_pool_size: req.warm_pool_size,
         runtime_source_policy,
         ..Default::default()
     };
+    // The tunnel worker spawns on the cold-boot path, not snapshot-restore.
+    if start_config.network_tunnel.is_some() {
+        use_snapshot = false;
+    }
 
     // Admit the transient run as a locally-signed workload. Setting
     // tenant_id + plan_json makes the libkrun/Vz supervisor spawn the gateway
@@ -2656,5 +2697,19 @@ mod tests {
             "cleanup command must remove the staging directory: {}",
             scripts[0]
         );
+    }
+
+    #[test]
+    fn normalize_backend_override_trims_lowercases_and_drops_blank() {
+        assert_eq!(
+            normalize_backend_override("  LibKrun \n"),
+            Some("libkrun".to_string())
+        );
+        assert_eq!(
+            normalize_backend_override("firecracker"),
+            Some("firecracker".to_string())
+        );
+        assert_eq!(normalize_backend_override("   "), None);
+        assert_eq!(normalize_backend_override(""), None);
     }
 }

--- a/nix/lib/mk-guest.nix
+++ b/nix/lib/mk-guest.nix
@@ -956,6 +956,12 @@ let
   # can attempt egress.
   mvmGuestNetinitBinary = "${guestAgentPkg}/bin/mvm-guest-netinit";
 
+  # Userspace L3 egress pump. netinit spawns it only when the
+  # `mvm.network_tunnel=` cmdline token is present; it opens the guest TUN
+  # and relays packets to the host tunnel worker over vsock. Inert (never
+  # spawned) without the token, so it is safe to bake into every rootfs.
+  mvmGuestNetdBinary = "${guestAgentPkg}/bin/mvm-guest-netd";
+
   # In-guest addon DNS resolver. Loopback-only UDP server that serves
   # exact configured addon hostnames and forwards everything else to
   # the pre-rewrite upstream resolver snapshot. Activated by /init
@@ -1175,6 +1181,11 @@ let
       # time beyond the CAP_NET_ADMIN that PID 1 already has.
       cp ${mvmGuestNetinitBinary} "$out/usr/local/bin/mvm-guest-netinit"
       chmod 0555 "$out/usr/local/bin/mvm-guest-netinit"
+
+      # Userspace L3 egress pump, spawned by netinit only under the
+      # `mvm.network_tunnel=` cmdline token. Same 0555 mode as netinit.
+      cp ${mvmGuestNetdBinary} "$out/usr/local/bin/mvm-guest-netd"
+      chmod 0555 "$out/usr/local/bin/mvm-guest-netd"
     ''}
 
     # In-guest addon DNS resolver. Baked into every workload rootfs
@@ -1424,7 +1435,7 @@ rootfsImage.overrideAttrs (old: {
     # downstream derivations (verity-initrd, per-service launch line
     # in `mkServiceBlock`) can reach `mvm-seccomp-apply` and
     # `mvm-verity-init` without re-running the cargo build.
-    inherit guestAgentPkg seccompApplyBinary verityInitBinary mvmGuestNetinitBinary;
+    inherit guestAgentPkg seccompApplyBinary verityInitBinary mvmGuestNetinitBinary mvmGuestNetdBinary;
     inherit addonDnsPkg mvmAddonDnsBinary;
   };
 })

--- a/nix/packages/mvm-guest-agent.nix
+++ b/nix/packages/mvm-guest-agent.nix
@@ -63,6 +63,10 @@ pkgs.rustPlatform.buildRustPackage {
     # for `MANDATORY_DENY_RANGES` at boot from `/init` (uid 0) before
     # the main agent forks under setpriv.
     "--bin" "mvm-guest-netinit"
+    # Userspace L3 egress pump: opens the guest TUN and relays packets to
+    # the host tunnel worker over vsock. netinit spawns it only when the
+    # `mvm.network_tunnel=` cmdline token is present; inert otherwise.
+    "--bin" "mvm-guest-netd"
   ] ++ lib.optionals withDevShell [
     "--features" "mvm-guest/dev-shell"
   ];


### PR DESCRIPTION
## What this fixes

The userspace L3 egress forwarder — `mvm-network-tunnel-worker` / `TunnelPacketPolicy::L3Forward`, the smoltcp host stack built and benchmarked in Plan 236 Phase 2B — was **never spawned on any real run**. `network_tunnel_for_launch` (the only function that builds `VmStartConfig.network_tunnel` from a policy) had **no non-test caller**, so `network_tunnel` was always `None` and every backend's spawn site was inert. Transient-run egress was handled per-backend instead: libkrun refused it outright, HVF had no raw-TCP data plane, and only Firecracker enforced (via iptables/nft). The forwarder was dead code on the run path.

This connects the producer end-to-end for a libkrun transient run.

## Changes

**Trigger — populate the tunnel from policy** (`crates/mvm-cli/src/exec.rs`)
- `run_secure` sets `network_tunnel = network_tunnel_for_launch(&policy, TunnelLaunchIdentity{..})` for an admitted allow-list, minting a fresh `boot_id` + `session_nonce` so the guest cmdline token and the host worker's expected-session validate identical identity. A tunnel run forces cold boot.

**Backend selection honors the override** (`crates/mvm-cli/src/exec.rs`)
- `select_exec_backend` now reads `MVM_HYPERVISOR` / `MVM_BACKEND` (previously the transient path only auto-detected, so libkrun — whose vsock-tunnel egress path is the whole point — could never be selected). All three call sites read the same value, so the admitted plan's backend and the boot backend agree. `normalize_backend_override` is unit-tested.

**libkrun host wiring** (`crates/mvm-backend/src/libkrun.rs`)
- Emits the `mvm.network_tunnel=` cmdline token, registers the guest→worker vsock port (`NETWORK_TUNNEL_GUEST_PORT`), and `validate_libkrun_network_policy` now accepts tunnel-served egress — it bails only on *unrestricted* allow-all (which has no finite gate). Unit tests cover the tunnel / no-tunnel / deny-all branches.

**Guest image ships the TUN pump** (`nix/packages/mvm-guest-agent.nix`, `nix/lib/mk-guest.nix`)
- `mvm-guest-netd` was built by **no** guest image, so netinit tried to spawn it, failed, and the guest booted with no networking. Now baked into every rootfs (inert without the cmdline token). It opens the guest TUN, installs the default route, and relays packets to the host worker over vsock.

The forwarder's gate itself (`net_l3.rs` — drops unpinned destinations, allows pinned) was already correct and unit-tested; this connects it to the run path.

## Test status

- **Unit**: backend-override normalization; libkrun egress-validation branches (tunnel-served accepted, no-tunnel refused, deny-all accepted). `network_tunnel_for_launch` and the smoltcp gate are already unit-tested on `main`.
- **Worker binary**: `mvm-network-tunnel-worker` builds with `packet-forwarder` (default-on) — verified 635 smoltcp symbols linked.
- **Live end-to-end witness (pending)**: `crates/mvm-cli/tests/tunnel_net_e2e.rs` (gated on `MVM_TUNNEL_NET_SMOKE=1`) drives `machine run --allow-host` on a workload-microVM host. I ran the equivalent `machine run --flake examples/egress-probe --hypervisor libkrun --allow-host 1.1.1.1` locally; the wiring path exercised correctly through builder rebuild + kernel build, but the run was blocked by **orthogonal builder infrastructure** (a full host disk, then a cold-nix-store HTTPS fetch failing on the builder VM's unset clock — both unrelated to this change). The live verdict-2 witness should be captured on a stable Linux+libkrun host via the gated smoke.

## Follow-ups (out of scope here)

- Thread the resolved policy through the `--entrypoint` admission (`invoke.rs` hardcodes `deny_all`) so the baked-entrypoint path also enforces `--allow-host`.
- Ship `mvm-guest-netd` in the runtime-overlay image so OCI `--image` (RuntimeLean) runs get the tunnel too.
- Add the `spawn_network_tunnel_worker_if_configured` call site to the transient HVF backend (`hvf_backend.rs`) — today only libkrun and Firecracker have it.
- Builder VM clock: set the guest clock at boot so a cold-store HTTPS fetch works (a latent builder-robustness gap, normally masked by a warm nix store).
