### PR TITLE
fix(kernel): enable x86 KVM paravirt-clock for the libkrun-KVM builder boot

### DIFF
--- a/nix/images/kernel/base.nix
+++ b/nix/images/kernel/base.nix
@@ -91,6 +91,13 @@ let
 
     # NLS (UTF-8 + ASCII only)
     "NLS" "NLS_UTF8" "NLS_ASCII"
+  ] ++ pkgs.lib.optionals (kernelArch == "x86_64") [
+    # KVM paravirt clock. libkrun's x86 device model exposes no PIT/HPET, so a
+    # guest that doesn't detect the hypervisor has no usable early clocksource
+    # and stalls in setup_arch before the console registers. HYPERVISOR_GUEST +
+    # KVM_GUEST make the kernel detect KVM and use kvm-clock; PARAVIRT is their
+    # prerequisite. arm64 boots under the architected timer and needs none of it.
+    "HYPERVISOR_GUEST" "PARAVIRT" "KVM_GUEST"
   ];
 
   # ── Base disables ──


### PR DESCRIPTION
## Problem (Plan 250 P0)

Lifting the Linux/KVM guard on the rootfs-backed steady-state libkrun builder was blocked on a boot silence. Live-diagnosed on the KVM box with a minimal `libkrun-sys` boot harness: on x86_64/KVM, libkrun **loads and starts** the builder's external ELF kernel (guest runs early boot — CMOS/i8042/vsock activity), then **hangs silently before the console registers** — zero bytes on hvc0/ttyS0/earlycon, 75s timeout.

Everything else is ruled out: the kernel ELF and rootfs are valid; **aarch64/macOS** libkrun boots the same image shape; **qemu** boots it on KVM. So the fault is specific to the **x86_64 external-ELF libkrun-KVM boot**, and it is immune to kernel cmdline workarounds — 10 variants (`tsc=reliable`, `clocksource=jiffies`, `no_timer_check`, `nosmp`, `acpi=off`, `noapic`, …) all hung identically.

## Root cause

`nix/images/kernel/base.nix` enables `RTC_CLASS`/`HIGH_RES_TIMERS` but **no KVM paravirt clock** (`HYPERVISOR_GUEST`/`PARAVIRT`/`KVM_GUEST`), and libkrun's x86 device model exposes **no PIT/HPET**. A guest that doesn't detect the hypervisor therefore has no usable early clocksource and stalls in `setup_arch` before the console comes up. qemu works because it provides legacy timers; aarch64 works via the architected timer; the bundled libkrunfw kernel is patched for libkrun's environment.

## Fix

Enable `HYPERVISOR_GUEST + PARAVIRT + KVM_GUEST`, **x86_64-gated** (mirrors the existing arm64-optionals pattern), so the kernel detects KVM and uses kvm-clock. arm64 is unaffected; the change is arch-gated so the strict `olddefconfig` guard is satisfied on both.

## Validation

A live libkrun-KVM boot of a kernel built **with** this config is running on the KVM box now (build → extract ELF → boot with earlycon). I'll post the console result — the kernel booting past the stall confirms the fix. This PR is the P0 fix only; lifting the guard itself (Plan 250 P3) is a follow-on once this is confirmed live.
