### PR TITLE
fix(builder): seed the builder VM clock from the host (cold-store HTTPS)

### DIFF
--- a/crates/mvm-build/src/bin/mvm-host-vm-init.rs
+++ b/crates/mvm-build/src/bin/mvm-host-vm-init.rs
@@ -412,6 +412,20 @@ fn vsock_egress_requested_from_cmdline(cmdline: &str) -> bool {
         .any(|tok| tok == "mvm.vsock_egress=1")
 }
 
+/// Parse `mvm.hostepoch=<unix_seconds>` — the host's wall-clock at launch. The
+/// builder VMMs expose no RTC, so PID 1 seeds the guest clock from this;
+/// otherwise a cold Nix store's HTTPS fetch fails cert validation ("certificate
+/// is not yet valid") against a clock stuck near the 1970 epoch. Rejects
+/// non-positive values so a malformed token can't wind the clock backwards.
+#[cfg(any(target_os = "linux", test))]
+fn hostepoch_from_cmdline(cmdline: &str) -> Option<i64> {
+    cmdline
+        .split_whitespace()
+        .find_map(|tok| tok.strip_prefix("mvm.hostepoch="))
+        .and_then(|v| v.parse::<i64>().ok())
+        .filter(|secs| *secs > 0)
+}
+
 #[cfg(any(target_os = "linux", test))]
 fn vsock_egress_port_from_cmdline(cmdline: &str) -> Option<u32> {
     cmdline
@@ -733,6 +747,20 @@ mod tests {
         assert!(!vsock_egress_requested_from_cmdline(
             "console=hvc0 root=/dev/vda"
         ));
+    }
+
+    #[test]
+    fn hostepoch_from_cmdline_parses_positive_seconds_only() {
+        assert_eq!(
+            hostepoch_from_cmdline("console=hvc0 mvm.hostepoch=1783982554 root=/dev/vda"),
+            Some(1_783_982_554)
+        );
+        // Absent, non-numeric, zero, and negative all yield None (never winds the
+        // clock backwards).
+        assert_eq!(hostepoch_from_cmdline("console=hvc0 root=/dev/vda"), None);
+        assert_eq!(hostepoch_from_cmdline("mvm.hostepoch=notanumber"), None);
+        assert_eq!(hostepoch_from_cmdline("mvm.hostepoch=0"), None);
+        assert_eq!(hostepoch_from_cmdline("mvm.hostepoch=-5"), None);
     }
 
     #[test]
@@ -1398,6 +1426,30 @@ mod linux {
             .all(is_executable)
     }
 
+    /// Set the guest wall clock from the `mvm.hostepoch=` cmdline token. A no-op
+    /// when the token is absent or unparsable (the guest keeps whatever the
+    /// kernel set). Best-effort: a `settimeofday` failure is logged, not fatal.
+    fn set_clock_from_host_epoch(cmdline: &str) {
+        let Some(secs) = super::hostepoch_from_cmdline(cmdline) else {
+            return;
+        };
+        let tv = libc::timeval {
+            tv_sec: secs as libc::time_t,
+            tv_usec: 0,
+        };
+        // SAFETY: `tv` is a valid, fully-initialized timeval; the timezone arg is
+        // null, which Linux ignores.
+        let rc = unsafe { libc::settimeofday(&tv, std::ptr::null()) };
+        if rc != 0 {
+            eprintln!(
+                "mvm-host-vm-init: settimeofday failed: {}",
+                std::io::Error::last_os_error()
+            );
+        } else {
+            eprintln!("mvm-host-vm-init: wall clock set from host epoch {secs}");
+        }
+    }
+
     pub fn run() -> ExitCode {
         eprintln!("mvm-host-vm-init: pid 1 starting");
         append_init_breadcrumb("run_enter", "pid1");
@@ -1449,6 +1501,11 @@ mod linux {
         stamp(&timings, |t| {
             t.pseudofs_ready_ms = Some(BootTimings::ms_since(anchor))
         });
+
+        // Seed the wall clock from the host before any network fetch. The builder
+        // VMMs expose no RTC, so a cold Nix store's HTTPS fetch would otherwise
+        // fail cert validation against a ~1970 clock. No-op without the token.
+        set_clock_from_host_epoch(&std::fs::read_to_string("/proc/cmdline").unwrap_or_default());
 
         // Three independent setup tracks fan out
         // after pseudofs. They share no state with each other

--- a/crates/mvm-build/src/bin/mvm-host-vm-init.rs
+++ b/crates/mvm-build/src/bin/mvm-host-vm-init.rs
@@ -1433,8 +1433,11 @@ mod linux {
         let Some(secs) = super::hostepoch_from_cmdline(cmdline) else {
             return;
         };
+        // Cast to the field's own type (`_`) rather than naming `libc::time_t`,
+        // which is deprecated on musl (it becomes 64-bit in musl 1.2.0) and would
+        // fail CI's `-D warnings`.
         let tv = libc::timeval {
-            tv_sec: secs as libc::time_t,
+            tv_sec: secs as _,
             tv_usec: 0,
         };
         // SAFETY: `tv` is a valid, fully-initialized timeval; the timezone arg is

--- a/crates/mvm-build/src/builder_vm.rs
+++ b/crates/mvm-build/src/builder_vm.rs
@@ -629,6 +629,20 @@ impl BuilderVm for StubBuilderVm {
 ///
 /// Resources (`vcpus`, `memory_mib`) are caller-supplied; the
 /// backend's resource-cap check enforces a host-side ceiling.
+/// The host's current wall clock as an `mvm.hostepoch=<unix_seconds>` cmdline
+/// token. The libkrun + hvf builder VMMs expose no RTC, so the guest boots with a
+/// ~1970 clock; PID 1 (`mvm-host-vm-init`) reads this token and seeds the wall
+/// clock from it, otherwise a cold Nix store's HTTPS fetch fails cert validation
+/// ("certificate is not yet valid"). Appended fresh at each launch so the clock
+/// tracks real time, not a stale image constant.
+pub fn builder_hostepoch_cmdline_token() -> String {
+    let secs = std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .map(|d| d.as_secs())
+        .unwrap_or(0);
+    format!("mvm.hostepoch={secs}")
+}
+
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct BuilderVmRunConfig {
     /// Human-readable VM name. Surfaces in logs + the per-VM state

--- a/crates/mvm-build/src/libkrun_builder.rs
+++ b/crates/mvm-build/src/libkrun_builder.rs
@@ -4440,6 +4440,17 @@ mod tests {
 
     static ENV_TEST_LOCK: std::sync::Mutex<()> = std::sync::Mutex::new(());
 
+    /// Drop the per-run `mvm.hostepoch=<secs>` clock token the image cmdline
+    /// carries (its value is wall-clock-dependent), so exact-cmdline assertions
+    /// stay deterministic.
+    fn strip_hostepoch_token(cmdline: &str) -> String {
+        cmdline
+            .split_whitespace()
+            .filter(|t| !t.starts_with("mvm.hostepoch="))
+            .collect::<Vec<_>>()
+            .join(" ")
+    }
+
     #[test]
     fn align_up_rounds_to_next_multiple() {
         assert_eq!(align_up(0, 4096), 0);
@@ -5425,7 +5436,7 @@ mod tests {
                 assert_eq!(kernel_path, kernel);
                 assert_eq!(rootfs_path, rootfs);
                 assert_eq!(
-                    cmdline,
+                    strip_hostepoch_token(&cmdline),
                     "console=hvc0 root=/dev/vda ro rootfstype=ext4 rootwait panic=-1 loglevel=8 init=/init mvm.chain_init=/sbin/mvm-host-vm-init"
                 );
             }
@@ -5508,7 +5519,7 @@ mod tests {
             } => {
                 assert_eq!(kernel_path, arch_dir.join("vmlinux"));
                 assert_eq!(rootfs_path, arch_dir.join("rootfs.ext4"));
-                assert_eq!(cmdline, expected_cmdline);
+                assert_eq!(strip_hostepoch_token(&cmdline), expected_cmdline);
             }
             BuilderVmImage::RootDir { .. } => panic!("expected rootfs builder image"),
         }
@@ -5641,7 +5652,7 @@ mod tests {
                 assert_eq!(kernel_path, target_arch_dir.join("vmlinux"));
                 assert_eq!(rootfs_path, target_arch_dir.join("rootfs.ext4"));
                 assert_eq!(
-                    cmdline,
+                    strip_hostepoch_token(&cmdline),
                     "console=hvc0 root=/dev/vda ro rootfstype=ext4 rootwait panic=-1 loglevel=8 init=/init mvm.chain_init=/sbin/mvm-host-vm-init"
                 );
             }

--- a/crates/mvm-build/src/libkrun_builder.rs
+++ b/crates/mvm-build/src/libkrun_builder.rs
@@ -2521,6 +2521,14 @@ fn validate_builder_vm_image_cache(arch_dir: &Path) -> Result<String, BuilderVmE
         })?
         .trim()
         .to_string();
+    // Ride the host wall clock onto the base cmdline for every backend that boots
+    // this image (libkrun + hvf are RTC-less): PID 1 seeds the guest clock from it
+    // so a cold Nix store's HTTPS fetch doesn't fail cert validation. Fresh per
+    // run, and preserved through the later per-boot token appends.
+    let cmdline = append_cmdline_token(
+        &cmdline,
+        &crate::builder_vm::builder_hostepoch_cmdline_token(),
+    );
 
     let manifest = read_builder_vm_cache_manifest(&manifest_path, arch_dir)?;
     if manifest.cache_contract_version != BUILDER_VM_CACHE_CONTRACT_VERSION

--- a/crates/mvm-build/src/qemu_builder.rs
+++ b/crates/mvm-build/src/qemu_builder.rs
@@ -199,8 +199,9 @@ fn run_stage0_qemu(
 
     // 2. Launch QEMU (the validated recipe), serial → console.log.
     let egress_port = allocate_qemu_builder_egress_port();
+    let hostepoch = crate::builder_vm::builder_hostepoch_cmdline_token();
     let append = format!(
-        "console=ttyS0 root=/dev/vda rw init={entry_path} mvm.backend=qemu {QEMU_BUILDER_VSOCK_EGRESS_TOKEN} {QEMU_BUILDER_VSOCK_EGRESS_PORT_TOKEN_PREFIX}{egress_port} panic=-1"
+        "console=ttyS0 root=/dev/vda rw init={entry_path} mvm.backend=qemu {QEMU_BUILDER_VSOCK_EGRESS_TOKEN} {QEMU_BUILDER_VSOCK_EGRESS_PORT_TOKEN_PREFIX}{egress_port} {hostepoch} panic=-1"
     );
     let guest_cid = allocate_qemu_builder_guest_cid();
     #[cfg(feature = "builder-vm")]


### PR DESCRIPTION
## Problem

The libkrun and hvf builder VMMs expose no RTC, so the builder guest boots with a wall clock stuck near the 1970 epoch. This is invisible while the Nix store is warm (the build needs no network), but on a **cold store** the builder must fetch nixpkgs over HTTPS — and TLS cert validation fails against the epoch clock:

```
error: unable to download '.../nixpkgs/archive/....tar.gz':
  SSL peer certificate ... certificate is not yet valid or the system clock is incorrect (9)
```

which aborts the workload build. (Surfaced while capturing a live egress witness after clearing the builder cache.)

## Fix

Seed the guest clock from the host at boot:

- **Guest** (`mvm-host-vm-init`): PID 1 reads an `mvm.hostepoch=<unix_seconds>` cmdline token right after mounting `/proc` and calls `settimeofday`. Best-effort + fail-open; the parser rejects non-positive values so a malformed token can never wind the clock backwards.
- **Host**: `builder_hostepoch_cmdline_token()` formats the current wall clock; it's appended fresh (per run) onto the builder image's base cmdline in `validate_builder_vm_image_cache`, so it rides through **every backend that boots the shared image** (libkrun + hvf) and is preserved through the later per-boot token appends. The qemu builder's own cmdline template also gets it.

qemu already emulates an RTC (unaffected), but the token is harmless there and keeps the three builders consistent.

## Tests

- Unit test for `hostepoch_from_cmdline` (positive-only; absent/non-numeric/zero/negative → `None`).
- The `settimeofday` path cross-compiles clean for `aarch64-unknown-linux-musl` (zigbuild).
