### PR TITLE
Document reversible replacement behavior

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,8 @@ Every machine boots its own Linux kernel under a real hypervisor. There is no
 Docker on the runtime path, no SSH in any guest, and (on the in-house macOS
 backend) no guest network device at all: guest I/O crosses **vsock**, where the
 host can audit flows, substitute secrets so the workload never sees raw
-credentials, and enforce default-deny egress from a signed execution plan.
+credentials, detect-and-replace secrets and structured PII on owned cleartext
+egress paths, and enforce default-deny egress from a signed execution plan.
 
 ```
 macOS 26+ (Apple Silicon)  →  in-house HVF VMM (Hypervisor.framework, zero extra deps)
@@ -468,6 +469,10 @@ claims), each backed by a named test or workflow gate. In summary:
     `ExecutionPlan.services` binding,** enforced before dispatch, audited.
 13. **No raw secret value crosses to the guest** — destination-bound,
     time-bound signed credentials only; real bytes never leave the supervisor.
+    For owned cleartext outbound flows, the host can also detect and replace
+    matched secrets and structured PII with request-scoped opaque tokens, then
+    restore the original bytes only when the exact token returns on an owned,
+    authorized cleartext path.
 14. **Every `run --image` admission records OCI image provenance** in the
     chain-signed audit log.
 15. **No interactive access to a sealed production microVM** — the console is
@@ -494,6 +499,9 @@ attestation.
   [Python SDK](sdks/python/README.md) ·
   [TypeScript SDK](sdks/typescript/README.md)
 - [Writing Nix flakes for guests (mkGuest)](public/src/content/docs/guides/nix-flakes.md)
+- [Secrets and credentials](public/src/content/docs/guides/secrets-and-credentials.mdx) ·
+  [Network egress policy](public/src/content/docs/guides/network-egress-policy.mdx) ·
+  [AI agent integration](public/src/content/docs/guides/ai-agent-integration.md)
 - [Security](public/src/content/docs/security/) ·
   [Troubleshooting](public/src/content/docs/guides/troubleshooting.md)
 - [Architecture & ADRs](specs/adrs/)

--- a/public/src/content/docs/guides/ai-agent-integration.md
+++ b/public/src/content/docs/guides/ai-agent-integration.md
@@ -21,6 +21,28 @@ Every tool result should include a sandbox identifier and audit/run identifier w
 
 - Keep egress deny-by-default.
 - Grant only the secrets needed for the current operation.
+- Treat structured PII the same way as secrets on runtime-owned cleartext paths:
+  detect it, replace it before egress, and only restore it on an owned return
+  path when policy allows that plaintext back to the caller.
 - Redact command output before returning it to a model if it may contain credentials or user data.
 - Use short TTLs for transient sandboxes.
 - Preserve cold state only when the workflow needs memory or filesystem continuity.
+
+## Request and response mediation
+
+When an agent calls an external model or API through a runtime-owned path, keep
+the contract narrow and auditable:
+
+- detect and replace secrets plus supported structured PII before the outbound
+  request leaves the runtime;
+- use opaque, flow-scoped tokens rather than stable pseudonyms;
+- restore original bytes only for exact token round trips on the owned response
+  path;
+- deny or redact when the response is transformed, delayed, replayed, or comes
+  back through an unowned path;
+- record the protection and reinjection decisions with the run or audit
+  identifier.
+
+This is exact-token restoration, not semantic reconstruction. If the upstream
+service rewrites the value in natural language, the safe behavior is to leave
+it redacted or tokenized.

--- a/public/src/content/docs/guides/network-egress-policy.mdx
+++ b/public/src/content/docs/guides/network-egress-policy.mdx
@@ -132,8 +132,18 @@ Validation rules:
   policy explicitly supports them;
 - allow only expected ports for each tool capability;
 - keep DNS policy explicit when the workload depends on names;
+- treat outbound detect/replace and inbound plaintext reinjection as separate
+  policy decisions;
 - store the grant decision with the audit/run identifier;
 - return policy denial distinctly from transport or guest command failure.
+
+If a tool path is allowed to send secrets or user data to a remote service,
+prefer runtime-owned mediation over raw pass-through. On owned cleartext paths,
+the runtime can detect secrets and structured PII, replace them with opaque
+flow-scoped tokens, and restore the original bytes only when the exact token
+returns on the owned response path. Do not claim this as general content
+reconstruction: paraphrased or transformed remote output should stay redacted
+or tokenized.
 
 ## Browser and desktop automation
 

--- a/public/src/content/docs/guides/secrets-and-credentials.mdx
+++ b/public/src/content/docs/guides/secrets-and-credentials.mdx
@@ -24,6 +24,27 @@ reviewable grant.
 The secure default is reference-first. Raw values should not appear in source
 files, examples, command history, model prompts, or long-lived logs.
 
+## Detect, replace, and reinject
+
+For owned cleartext request paths, mvm can mediate caller-visible content in
+addition to managed secret refs:
+
+| Step | Behavior |
+| --- | --- |
+| Detect | Match declared secrets plus structured PII such as `email`, `us_ssn`, `credit_card`, `e164_phone`, and `iban`. |
+| Replace | Rewrite matched bytes to request-scoped opaque tokens before they leave the runtime-owned path. |
+| Reinject | Restore the original bytes only when the exact token returns on an owned cleartext response path and policy allows plaintext reinjection. |
+| Fallback | If the path is unowned, transformed, expired, unauthorized, or uncorrelatable, do not restore; fall back to redaction, denial, or pass-through per policy. |
+
+This is an exact-token contract, not semantic recovery. If a model paraphrases,
+splits, reformats, or partially copies the sensitive value, the runtime should
+not guess. Reinjection is for exact opaque-token round trips only.
+
+Cloud deployments should keep reinjection policy load-bearing at the control
+plane: which classes are handled, which sinks may receive replacements, which
+callers may receive plaintext restoration, and how long correlation state is
+retained.
+
 ## CLI flow
 
 Store a named reference:
@@ -139,7 +160,9 @@ tool capability to an allowed reference:
 Rules for model-facing tools:
 
 - grant secrets per operation;
+- keep PII handling explicit alongside secret grants;
 - never echo resolved values to the model;
+- treat restored plaintext as a separate permission from outbound replacement;
 - redact command output before it becomes model context;
 - reject requests that ask to print, exfiltrate, or persist credentials;
 - record the grant decision with the audit/run identifier.
@@ -152,13 +175,16 @@ Every secret-bearing path should have a failure behavior:
 | --- | --- |
 | Missing reference | Fail closed before VM launch or command execution. |
 | Unauthorized reference | Return policy denial, not a generic runtime failure. |
+| Structured PII detected on an owned outbound path | Replace with an opaque token when policy enables it; otherwise redact or deny per policy. |
 | Guest prints a secret | Redact before logs or model-facing responses leave the app. |
+| Exact opaque token returns on an owned response path | Reinject only when correlation and permissions are still valid. |
+| Token returns from an unowned or transformed path | Do not reinject; keep the replacement or redact the value. |
 | Cleanup fails | Report cleanup failure separately and mark retained state as sensitive. |
 | Snapshot retained | Attach retention metadata and delete or rotate when no longer needed. |
 
 Do not collapse secret failures into generic command errors. Operators need to
 know whether a workload failed because of policy, missing credentials, guest
-behavior, or cleanup.
+behavior, PII mediation, reinjection authorization, or cleanup.
 
 ## Related pages
 


### PR DESCRIPTION
## Summary
- document the owned-path detect/replace/reinject contract in the top-level README
- document exact-token reinjection, supported secret/PII handling, and fail-closed policy behavior in the site guides
- clarify the agent and network docs so they do not overclaim semantic restoration

## Validation
- npm --prefix public run build
