### PR TITLE
fix(kernel): enable VIRTIO_MMIO_CMDLINE_DEVICES so the x86 builder kernel boots under libkrun/KVM

### DIFF
--- a/nix/images/kernel/base.nix
+++ b/nix/images/kernel/base.nix
@@ -98,6 +98,16 @@ let
     # KVM_GUEST make the kernel detect KVM and use kvm-clock; PARAVIRT is their
     # prerequisite. arm64 boots under the architected timer and needs none of it.
     "HYPERVISOR_GUEST" "PARAVIRT" "KVM_GUEST"
+
+    # libkrun on x86 has no device tree (aarch64) and no PCI enumeration (vz):
+    # it advertises its virtio-mmio devices *only* through
+    # `virtio_mmio.device=<size>@<addr>:<irq>` kernel-cmdline params. Without
+    # VIRTIO_MMIO_CMDLINE_DEVICES the guest ignores them, the root virtio-blk
+    # never binds, /dev/vda never appears, and boot hangs forever at "Waiting
+    # for root device /dev/vda". arm64 discovers the same devices via FDT, so it
+    # neither needs nor compiles this in (keeping it off the arm64 built-in
+    # symbol budget).
+    "VIRTIO_MMIO_CMDLINE_DEVICES"
   ];
 
   # ── Base disables ──


### PR DESCRIPTION
## The bug

The steady-state (rootfs-backed) libkrun builder VM boots its **external** kernel with an **ext4 block root** (`/dev/vda`). On x86_64/KVM that boot hung forever at:

```
[1.9] Waiting for root device /dev/vda...
```

## Root cause

libkrun on x86_64 has **no device tree** (unlike aarch64) and **no PCI enumeration** (unlike vz). It advertises its virtio-mmio devices *purely* through kernel-cmdline params:

```
virtio_mmio.device=4K@0xd0000000:5 virtio_mmio.device=4K@0xd0001000:6 ...
```

The guest kernel only parses those when built with `CONFIG_VIRTIO_MMIO_CMDLINE_DEVICES`. Our `base.nix` enabled `VIRTIO_MMIO` but **not** `VIRTIO_MMIO_CMDLINE_DEVICES`, so the x86 guest silently ignored every `virtio_mmio.device=` param — the root virtio-blk never bound, `/dev/vda` never appeared, and boot stalled before userspace.

aarch64 was unaffected because it discovers the same devices via FDT (which is why the macOS/HVF path always worked).

## The fix

One line: add `VIRTIO_MMIO_CMDLINE_DEVICES` to the shared `baseEnables`. It's a generic virtio-mmio option (depends on `VIRTIO_MMIO`, present on both arches), survives `olddefconfig` on x86 and arm64, and is inert on arches that use FDT/PCI.

## Validation (live, x86_64 KVM host)

Rebuilt the builder kernel **with** the option and booted it via libkrun against the real builder rootfs, capturing the serial console:

```
[0.997] virtio_blk virtio3: 1/0/0 default/read/poll queues
[0.998] virtio_blk virtio3: [vda] 1523272 512-byte logical blocks (780 MB)   ← /dev/vda appears
[1.821] EXT4-fs (vda): mounted filesystem … ro                                ← rootfs mounts
[1.824] VFS: Mounted root (ext4 filesystem) readonly on device 254:0
[1.833] Freeing unused kernel image (initmem) memory
: pid 1 starting                                                              ← init runs
```

The unfixed kernel, same rootfs, same cmdline, hung indefinitely at `Waiting for root device /dev/vda`.

## Scope

This unblocks the x86 libkrun boot itself. Lifting the `LinuxNative` steady-state guard (so `--builder libkrun` is actually selectable on Linux) is a **follow-up** gated on a full end-to-end `machine build` run — kept separate so this safe, self-contained config fix can land on its own.