### PR TITLE
fix(builder): seed the HVF builder VM clock from the host too

### DIFF
--- a/crates/mvm-backend/src/builder_runner/spec.rs
+++ b/crates/mvm-backend/src/builder_runner/spec.rs
@@ -85,6 +85,13 @@ pub fn builder_spec(inputs: &BuilderSpecInputs<'_>) -> VmmSpec {
     } else {
         BUILDER_CMDLINE.to_string()
     };
+    // Seed the RTC-less HVF builder guest's wall clock from the host: PID 1
+    // (mvm-host-vm-init) reads this token and calls settimeofday, so a cold Nix
+    // store's HTTPS fetch doesn't fail cert validation against a ~1970 clock.
+    let cmdline = format!(
+        "{cmdline} {}",
+        mvm_build::builder_vm::builder_hostepoch_cmdline_token()
+    );
 
     let mut blocks = vec![
         block(inputs.rootfs, 0, true),       // vda: rootfs, RO


### PR DESCRIPTION
Extends the cold-store builder-clock fix (#1697) to the **HVF builder** path.

#1697 seeded the guest wall clock only on the libkrun builder path — the `mvm.hostepoch=` token was appended in libkrun-builder's cache-load step (`validate_builder_vm_image_cache`). But `--builder hvf` assembles its guest cmdline from the static `BUILDER_CMDLINE` in `crates/mvm-backend/src/builder_runner/spec.rs` (`builder_spec`) and never goes through that path. So the HVF builder booted with a ~1970 clock, and a **cold** Nix store's HTTPS nixpkgs fetch failed cert validation:

```
SSL certificate ... certificate is not yet valid or the system clock is incorrect (9)
```

Verified live: a `machine run --flake examples/egress-probe --builder hvf` on a freshly-cleared cache reproduced this exact failure with #1697 already on main; the HVF builder's console showed `mvm-host-vm-init: pid 1 starting` but no `wall clock set from host epoch` (token absent).

Fix: append the same per-run `mvm.hostepoch=` token (`builder_hostepoch_cmdline_token()`) to the HVF builder cmdline in `builder_spec`, so PID 1 (`mvm-host-vm-init`) seeds the clock there too. The `builder_spec` tests assert cmdline **substrings**, so the dynamic token is compatible (no test changes needed).

Part of #1701 (unblocks the live witness on the HVF builder path).