### PR TITLE
feat(net): wire the smoltcp egress tunnel into the HVF workload backend

### DIFF
--- a/crates/mvm-backend/src/builder_runner/inject.rs
+++ b/crates/mvm-backend/src/builder_runner/inject.rs
@@ -78,6 +78,8 @@ pub fn inject_host_binaries(req: &InjectRequest<'_>) -> Result<()> {
         egress_relay_socket: None,
         // The rootfs-inject helper VM runs no workload, so no host-services broker.
         broker_socket: None,
+        // The rootfs-inject helper VM has no egress tunnel.
+        network_tunnel_socket: None,
         console_data_sockets: vec![],
     };
     let json = serde_json::to_string(&cfg).context("serialize inject supervisor config")?;

--- a/crates/mvm-backend/src/driver/hvf.rs
+++ b/crates/mvm-backend/src/driver/hvf.rs
@@ -164,6 +164,8 @@ fn relay_supervisor_config(spec: &VmmSpec, paths: &SupervisorPaths) -> Result<Hv
         egress_relay_socket,
         // Builder/dev VMs run no admitted workload, so no host-services broker.
         broker_socket: None,
+        // Builder/dev VMs carry no admitted egress tunnel.
+        network_tunnel_socket: None,
         console_data_sockets,
     })
 }

--- a/crates/mvm-backend/src/hvf/kernel_boot.rs
+++ b/crates/mvm-backend/src/hvf/kernel_boot.rs
@@ -159,6 +159,11 @@ pub struct HostChannels {
     /// socket the host-agent daemon bound for this VM — so a guest `host.audit.v1`
     /// call reaches the broker. `None` ⇒ `BROKER_PORT` fails closed at the bridge.
     pub broker_socket: Option<PathBuf>,
+    /// Per-VM userspace L3 egress tunnel UDS. When set, the guest's dial of
+    /// `NETWORK_TUNNEL_GUEST_PORT` relays here — the socket the per-VM tunnel worker
+    /// bound — so guest packets reach the host forwarder and admitted flows egress.
+    /// `None` ⇒ the tunnel port fails closed at the bridge (no forwarder reachable).
+    pub network_tunnel_socket: Option<PathBuf>,
     /// Dev-only host console listeners: one `(guest_port, host_socket)` per console
     /// data port the interactive PTY may reach. Populated only for a `dev_console`
     /// machine; empty for a sealed prod config, so nothing is bound (claim 15).
@@ -502,6 +507,7 @@ fn boot_kernel_impl(params: KernelBootUntilParams<'_>) -> Result<KernelBootResul
                 substitution_socket: channels.substitution_socket,
                 egress_relay: channels.egress_relay,
                 broker_socket: channels.broker_socket,
+                network_tunnel_socket: channels.network_tunnel_socket,
                 console_data_sockets: channels.console_data_sockets,
                 virtiofs_root: channels.virtiofs_root,
             },
@@ -536,6 +542,9 @@ struct RunInputs {
     /// Per-VM host-services broker UDS. When set, `BROKER_PORT` relays here — the
     /// socket the host-agent daemon bound for this VM.
     broker_socket: Option<PathBuf>,
+    /// Per-VM userspace L3 egress tunnel UDS. When set, `NETWORK_TUNNEL_GUEST_PORT`
+    /// relays here — the socket the per-VM tunnel worker bound.
+    network_tunnel_socket: Option<PathBuf>,
     /// Dev-only host console listeners (one `(guest_port, host_socket)` per console
     /// data port). Empty for a sealed prod config — nothing bound (claim 15).
     console_data_sockets: Vec<(u32, PathBuf)>,
@@ -560,6 +569,7 @@ unsafe fn run(
         substitution_socket,
         egress_relay,
         broker_socket,
+        network_tunnel_socket,
         console_data_sockets,
         virtiofs_root,
     } = inputs;
@@ -739,6 +749,16 @@ unsafe fn run(
             if let Some(broker) = broker_socket.as_ref() {
                 v.set_broker_activity(egress_active.clone());
                 v.set_broker_endpoint(broker);
+            }
+            // Userspace L3 egress tunnel (NETWORK_TUNNEL_GUEST_PORT): a pure relay to
+            // the per-VM tunnel worker UDS, which owns the packet-forwarding decision
+            // (default-deny gate + admitted-flow forward). Shares the heartbeat
+            // counter so in-flight forwarded traffic keeps the loop polling. With no
+            // tunnel socket wired, the port fails closed at the bridge — the
+            // deny-all / no-tunnel case.
+            if let Some(tunnel) = network_tunnel_socket.as_ref() {
+                v.set_network_tunnel_activity(egress_active.clone());
+                v.set_network_tunnel_endpoint(tunnel);
             }
             // Dev-only interactive console (`machine run -it`): bind one host
             // listener per guest console data port so the console driver can reach

--- a/crates/mvm-backend/src/hvf_backend.rs
+++ b/crates/mvm-backend/src/hvf_backend.rs
@@ -28,6 +28,10 @@ use mvm_core::vm_backend::{
 };
 
 use crate::base::ui;
+use crate::network_tunnel_spawn::{
+    NetworkTunnelListener, NetworkTunnelWorkerSpawnParams, reap_network_tunnel_worker,
+    spawn_network_tunnel_worker_if_configured,
+};
 
 /// PID file the supervisor writes inside `vm_state_dir`. Distinct from the other
 /// backends' markers so HVF VMs coexist under the same `~/.mvm/vms/` root.
@@ -303,11 +307,19 @@ fn ensure_hvf_runtime_source_supported(config: &VmStartConfig) -> Result<()> {
 
 fn hvf_workload_cmdline(config: &VmStartConfig, state_dir: &Path) -> Option<String> {
     let egress = vsock_egress_cmdline_token(config, state_dir);
+    // The userspace L3 egress tunnel: tell the guest (via mvm-guest-netinit →
+    // mvm-guest-netd) to stand up its TUN and pump packets to the host worker over
+    // vsock. Present only for an admitted allow-list run.
+    let tunnel = config
+        .network_tunnel
+        .as_ref()
+        .and_then(mvm_core::vm_backend::encode_network_tunnel_cmdline);
     let grants = crate::hvf_bootargs::grant_tokens(&config.name);
     let virtiofs_root = config.virtiofs_root.is_some();
     let has_disk = !virtiofs_root && !config.rootfs_path.is_empty();
     let verity_enabled = hvf_verity_enabled(config);
     if egress.is_none()
+        && tunnel.is_none()
         && grants.is_empty()
         && !verity_enabled
         && config.runtime_source_policy == mvm_core::vm_backend::RuntimeSourcePolicy::RootfsOnly
@@ -334,7 +346,7 @@ fn hvf_workload_cmdline(config: &VmStartConfig, state_dir: &Path) -> Option<Stri
     cmdline.push_str(&mvm_core::vm_backend::encode_runtime_source_policy_cmdline(
         config.runtime_source_policy,
     ));
-    for token in egress.into_iter().chain(grants) {
+    for token in egress.into_iter().chain(tunnel).chain(grants) {
         cmdline.push(' ');
         cmdline.push_str(&token);
     }
@@ -472,6 +484,26 @@ impl VmBackend for HvfBackend {
             &config.network_policy,
             config.tenant_id.as_deref().unwrap_or(""),
         )?;
+        // The userspace L3 egress tunnel worker: for an admitted allow-list run it
+        // binds the per-VM tunnel UDS the guest dials over NETWORK_TUNNEL_GUEST_PORT
+        // and forwards admitted flows. Spawned before the supervisor's start_enter
+        // (below) so the UDS is bound before the guest can dial. The relay endpoint in
+        // the supervisor config points at this same socket. The guard reaps the worker
+        // on any early return below and is defused once boot is confirmed (the stop
+        // path then owns teardown); a run with no tunnel yields a defused no-op guard.
+        let network_tunnel_socket = config
+            .network_tunnel
+            .as_ref()
+            .map(|tunnel| mvm_core::config::vm_vsock_port_socket_at(&state_dir, tunnel.guest_port));
+        let mut tunnel_guard =
+            spawn_network_tunnel_worker_if_configured(NetworkTunnelWorkerSpawnParams {
+                state_dir: &state_dir,
+                runtime_config: config.network_tunnel.as_ref(),
+                listener: network_tunnel_socket
+                    .clone()
+                    .map(NetworkTunnelListener::Uds),
+                network_policy: Some(&config.network_policy),
+            })?;
         // Productionized per-VM agent RPC socket threaded through the supervisor
         // config; the `MVM_HVF_AGENT_SOCKET` dev hook still wins for live drivers.
         let agent_socket = std::env::var_os("MVM_HVF_AGENT_SOCKET")
@@ -531,6 +563,7 @@ impl VmBackend for HvfBackend {
             substitution_socket: None,
             egress_relay_socket,
             broker_socket: Some(broker_listen_socket.clone()),
+            network_tunnel_socket,
             console_data_sockets,
         };
         let json = serde_json::to_string(&cfg)
@@ -585,8 +618,10 @@ impl VmBackend for HvfBackend {
 
         // Boot confirmed: the supervisor's device is wired to the endpoint, so it
         // must outlive this launch. Defuse the guard (its Drop becomes a no-op);
-        // the stop path now owns reaping the endpoint.
+        // the stop path now owns reaping the endpoint. Same for the tunnel worker,
+        // which the guest reaches over the relay socket for the VM's lifetime.
         endpoint_guard.defuse();
+        tunnel_guard.defuse();
 
         // Register an admitted workload with the per-tenant host-agent daemon,
         // same as libkrun/vz: the daemon starts tracking this VM and binds its
@@ -648,6 +683,9 @@ impl VmBackend for HvfBackend {
         // check), so a crashed VM's decrypted-secret process can't outlive the
         // guest. Idempotent + no-op when the VM spawned none (no secrets).
         crate::substitution_spawn::reap_substitution_endpoint(&state_dir, &id.0);
+        // Reap the per-VM egress tunnel worker (no-op when the VM spawned none), so
+        // the host forwarder can't outlive the guest.
+        reap_network_tunnel_worker(&state_dir);
         // Deregister from the per-tenant host-agent daemon (no-op if this VM
         // never registered — an unadmitted dev VM, or a failed registration
         // that was already logged). The daemon itself stays warm.
@@ -999,6 +1037,42 @@ mod tests {
         assert!(cmdline.contains("rootfstype=virtiofs root=mvmroot"));
         assert!(cmdline.contains("init=/init"));
         assert!(cmdline.contains("mvm.runtime_source_policy=rootfs_only"));
+        assert!(cmdline.contains("mvm.vsock_egress=1"));
+    }
+
+    #[test]
+    fn hvf_workload_cmdline_appends_network_tunnel_token_for_admitted_allowlist() {
+        let dir = tempfile::tempdir().unwrap();
+        let policy = mvm_core::network_policy::NetworkPolicy::allow_list(vec![
+            mvm_core::network_policy::HostPort::new("93.184.216.34", 443),
+        ]);
+        let tunnel = crate::network_tunnel_spawn::network_tunnel_for_launch(
+            &policy,
+            crate::network_tunnel_spawn::TunnelLaunchIdentity {
+                tenant_id: "acme".to_string(),
+                vm_id: "vm-1".to_string(),
+                boot_id: "boot-1".to_string(),
+                session_nonce: "nonce-1".to_string(),
+            },
+        )
+        .expect("an allow-list launch carries a forwarding tunnel");
+        let expected = mvm_core::vm_backend::encode_network_tunnel_cmdline(&tunnel)
+            .expect("the tunnel encodes to a cmdline token");
+
+        let config = VmStartConfig {
+            virtiofs_root: Some("/tmp/root".to_string()),
+            network_policy: policy,
+            network_tunnel: Some(tunnel),
+            ..Default::default()
+        };
+        let cmdline = hvf_workload_cmdline(&config, dir.path()).expect("cmdline");
+        assert!(
+            cmdline.contains(&expected),
+            "cmdline missing the tunnel token: {cmdline}"
+        );
+        assert!(cmdline.contains("mvm.network_tunnel="));
+        // An allow-list run carrying no bound secrets also turns on the raw vsock
+        // egress client, so both tokens coexist on one cmdline (mirrors libkrun).
         assert!(cmdline.contains("mvm.vsock_egress=1"));
     }
 

--- a/crates/mvm-backend/src/vmm/vsock.rs
+++ b/crates/mvm-backend/src/vmm/vsock.rs
@@ -81,6 +81,14 @@ impl VsockShared {
         self.handlers.set_broker_activity(counter);
     }
 
+    pub fn set_network_tunnel_endpoint(&mut self, path: &std::path::Path) {
+        self.handlers.set_network_tunnel_endpoint(path);
+    }
+
+    pub fn set_network_tunnel_activity(&mut self, counter: Arc<std::sync::atomic::AtomicUsize>) {
+        self.handlers.set_network_tunnel_activity(counter);
+    }
+
     pub fn capture_workload_exit(&mut self, stop: &'static std::sync::atomic::AtomicBool) {
         self.lifecycle.exit_stop = Some(self.handlers.capture_workload_exit(stop));
     }
@@ -222,6 +230,16 @@ impl VirtioVsock {
 
     pub fn set_broker_activity(&mut self, counter: Arc<std::sync::atomic::AtomicUsize>) {
         self.lock().set_broker_activity(counter);
+        self.notify_io();
+    }
+
+    pub fn set_network_tunnel_endpoint(&mut self, path: &std::path::Path) {
+        self.lock().set_network_tunnel_endpoint(path);
+        self.notify_io();
+    }
+
+    pub fn set_network_tunnel_activity(&mut self, counter: Arc<std::sync::atomic::AtomicUsize>) {
+        self.lock().set_network_tunnel_activity(counter);
         self.notify_io();
     }
 

--- a/crates/mvm-backend/src/vmm/vsock_handlers/mod.rs
+++ b/crates/mvm-backend/src/vmm/vsock_handlers/mod.rs
@@ -129,6 +129,12 @@ impl VsockHandlerRegistry {
             mvm_guest::vsock::BROKER_PORT,
             Box::new(StreamRelayHandler::new(mvm_guest::vsock::BROKER_PORT)),
         );
+        guest_ports.insert(
+            mvm_core::protocol::network_tunnel::NETWORK_TUNNEL_GUEST_PORT,
+            Box::new(StreamRelayHandler::new(
+                mvm_core::protocol::network_tunnel::NETWORK_TUNNEL_GUEST_PORT,
+            )),
+        );
 
         let host_initiated: Vec<Box<dyn HostInitiatedHandler>> = vec![
             Box::new(AgentVsockHandler::new()),
@@ -184,6 +190,27 @@ impl VsockHandlerRegistry {
             .expect("broker handler present")
             .bridge
             .set_activity(counter);
+    }
+
+    pub(crate) fn set_network_tunnel_endpoint(&mut self, path: &Path) {
+        self.guest_handler_mut::<StreamRelayHandler>(
+            mvm_core::protocol::network_tunnel::NETWORK_TUNNEL_GUEST_PORT,
+        )
+        .expect("network tunnel handler present")
+        .bridge
+        .set_endpoint(path);
+    }
+
+    pub(crate) fn set_network_tunnel_activity(
+        &mut self,
+        counter: Arc<std::sync::atomic::AtomicUsize>,
+    ) {
+        self.guest_handler_mut::<StreamRelayHandler>(
+            mvm_core::protocol::network_tunnel::NETWORK_TUNNEL_GUEST_PORT,
+        )
+        .expect("network tunnel handler present")
+        .bridge
+        .set_activity(counter);
     }
 
     pub(crate) fn set_console_sockets<'a>(

--- a/crates/mvm-build/src/hvf_supervisor.rs
+++ b/crates/mvm-build/src/hvf_supervisor.rs
@@ -114,6 +114,13 @@ pub struct HvfSupervisorConfig {
     /// other backends. `None` ⇒ `BROKER_PORT` fails closed (no broker reachable).
     #[serde(default)]
     pub broker_socket: Option<PathBuf>,
+    /// Per-VM userspace L3 egress tunnel UDS. When set, the supervisor relays the
+    /// guest's `NETWORK_TUNNEL_GUEST_PORT` dial to the socket the per-VM tunnel
+    /// worker bound, so guest packets reach the host forwarder and admitted flows
+    /// egress. `None` ⇒ the tunnel port fails closed (no forwarder). The backend
+    /// sets it only for an admitted allow-list run that carries a network tunnel.
+    #[serde(default)]
+    pub network_tunnel_socket: Option<PathBuf>,
     /// Dev-only console data sockets: one entry per guest vsock data port the
     /// console driver may connect to. Empty for sealed prod configs (claim 15).
     /// Populated by the driver when `VmStartConfig.dev_console` is true.
@@ -154,6 +161,7 @@ mod tests {
             substitution_socket: Some("/state/substitution-endpoint.sock".into()),
             egress_relay_socket: Some("/state/egress-bridge.sock".into()),
             broker_socket: Some("/state/hvf-broker.sock".into()),
+            network_tunnel_socket: Some("/state/vsock-5302.sock".into()),
             console_data_sockets: vec![],
         };
         let json = serde_json::to_string(&cfg).unwrap();
@@ -172,6 +180,7 @@ mod tests {
         assert_eq!(cfg.substitution_socket, None);
         assert_eq!(cfg.egress_relay_socket, None);
         assert_eq!(cfg.broker_socket, None);
+        assert_eq!(cfg.network_tunnel_socket, None);
     }
 
     #[test]
@@ -210,6 +219,7 @@ mod tests {
             substitution_socket: None,
             egress_relay_socket: None,
             broker_socket: None,
+            network_tunnel_socket: None,
             console_data_sockets: vec![
                 ConsoleDataSocket {
                     guest_port: 20001,

--- a/crates/mvm-vm-host/src/bin/mvm-hvf-supervisor.rs
+++ b/crates/mvm-vm-host/src/bin/mvm-hvf-supervisor.rs
@@ -223,6 +223,7 @@ fn main() -> anyhow::Result<()> {
                 substitution_socket: cfg.substitution_socket.clone(),
                 egress_relay: cfg.egress_relay_socket.clone(),
                 broker_socket: cfg.broker_socket.clone(),
+                network_tunnel_socket: cfg.network_tunnel_socket.clone(),
                 console_data_sockets: cfg
                     .console_data_sockets
                     .iter()


### PR DESCRIPTION
Tracking issue #1701 item 2: wire the smoltcp egress tunnel into the HVF workload backend, so the macOS-26 default backend routes egress through the userspace L3 forwarder (it previously did not — only libkrun + Firecracker did).

Mirrors the libkrun reference implementation (`crates/mvm-backend/src/libkrun.rs`) into `crates/mvm-backend/src/hvf_backend.rs`:

## 1. Cmdline token
`hvf_workload_cmdline` now emits the `mvm.network_tunnel=<hex(JSON)>` token when `config.network_tunnel` is `Some`, alongside the existing `mvm.vsock_egress=1` / grant / runtime-source-policy tokens. The early-return "no extra tokens" guard now also accounts for a tunnel-only launch.

## 2. Worker spawn
`start()` spawns the per-VM `mvm-network-tunnel-worker` (via the shared `spawn_network_tunnel_worker_if_configured`) **before** the supervisor's `start_enter`, so the worker's UDS is bound before the guest can dial. The returned guard is held for the VM's lifetime (defused once boot is confirmed, exactly like the gating-endpoint guard) and reaped in `stop()` via `reap_network_tunnel_worker`.

## 3. Vsock port registration (the interesting part)
HVF has **no** `add_host_listen_port` like libkrun's `KrunContext`. Instead its vsock model maps each guest port to a **named host socket** on the `mvm-hvf-supervisor` config surface (`HvfSupervisorConfig` → `HostChannels` → the `VirtioVsock` device). The tunnel port slots cleanly into the existing `StreamRelayHandler` mechanism that already backs `EGRESS_PORT` / `BROKER_PORT` — a guest dial of a fixed port relayed to a host UDS, failing closed (`OP_RST`) when no endpoint is wired.

Added a `network_tunnel_socket: Option<PathBuf>` field to `HvfSupervisorConfig` and `HostChannels`, registered a `StreamRelayHandler` for `NETWORK_TUNNEL_GUEST_PORT` (5302) in the vsock registry with `set_network_tunnel_endpoint` / `set_network_tunnel_activity`, and wired it in `kernel_boot.rs` next to the broker relay. The backend sets the field (pointing at the same `<state_dir>/vsock-5302.sock` the worker binds) **only when `config.network_tunnel.is_some()`**; otherwise the port stays unwired and fails closed.

The producer (`exec.rs::network_tunnel_for_launch`) already sets `network_tunnel` on the backend-agnostic `VmStartConfig`, so no CLI change was needed.

## Was the host-bind achievable on the HVF supervisor config path?
**Yes.** No follow-up needed. The `StreamRelayHandler` path is the exact HVF analogue of libkrun's `add_host_listen_port` (guest dials a fixed port; host relay connects to the worker's already-bound UDS on first packet; fail-closed when unset). Ordering is preserved — the worker binds its UDS before `start_enter`.

## Verification
- `MVM_SKIP_EMBED_BINARIES=1 cargo build -p mvm-backend` — clean
- `cargo clippy -p mvm-backend -p mvm-build -p mvm-vm-host --all-targets -- -D warnings` — clean
- `RUSTFLAGS="-D warnings" cargo zigbuild -p mvm-backend --target x86_64-unknown-linux-gnu` — clean
- `cargo fmt --all` (nightly) — clean
- Added `hvf_workload_cmdline_appends_network_tunnel_token_for_admitted_allowlist` unit test plus `network_tunnel_socket` roundtrip/default assertions in `hvf_supervisor.rs`. (mvm-backend tests are not run locally — macOS codesign SIGKILLs the test binary — so they run in CI.)