### PR TITLE
Fail closed on a missing guest agent in both guest inits

### DIFF
--- a/crates/mvm-guest/src/bin/mvm-oci-init.rs
+++ b/crates/mvm-guest/src/bin/mvm-oci-init.rs
@@ -33,7 +33,20 @@ mod linux {
             bring_loopback_up();
             spawn_one(Path::new(EGRESS_CLIENT), "egress-client");
         }
-        spawn_one_optional(resolve_guest_agent(), "guest-agent");
+        // The guest agent is the mvm vsock control plane — the whole reason this
+        // init exists (scratch/distroless/Alpine all get it from the overlay).
+        // Fail closed if it can't be resolved: idling on agent-less would leave
+        // the host waiting out its agent-readiness timeout on a silently dead VM.
+        // PID 1 exiting panics the kernel (panic=-1 -> reboot), so the boot fails
+        // loudly instead.
+        let Some(agent) = resolve_guest_agent() else {
+            eprintln!(
+                "mvm-oci-init: no guest agent resolved from /mvm/runtime and no baked \
+                 fallback — refusing to boot without the mvm control plane"
+            );
+            std::process::exit(1);
+        };
+        spawn_one(&agent, "guest-agent");
         idle_forever();
     }
 
@@ -341,14 +354,6 @@ mod linux {
         }
     }
 
-    fn spawn_one_optional(path: Option<PathBuf>, label: &str) {
-        let Some(path) = path else {
-            eprintln!("mvm-oci-init: no executable {label} found");
-            return;
-        };
-        spawn_one(&path, label);
-    }
-
     fn cmdline() -> String {
         fs::read_to_string("/proc/cmdline").unwrap_or_default()
     }
@@ -537,6 +542,18 @@ mod linux {
                 |path| path == Path::new(AGENT_FALLBACK),
             );
             assert_eq!(got, Some(PathBuf::from(AGENT_FALLBACK)));
+        }
+
+        #[test]
+        fn resolve_guest_agent_for_required_overlay_returns_none_when_overlay_missing() {
+            // No executable candidate -> None, which main() treats as fatal
+            // (fail closed) rather than booting agent-less.
+            let got = resolve_guest_agent_for(
+                mvm_core::vm_backend::RuntimeSourcePolicy::RequiredOverlay,
+                mvm_core::security::AgentProfile::SealedProd,
+                |_path| false,
+            );
+            assert_eq!(got, None);
         }
     }
 }

--- a/nix/lib/mk-guest.nix
+++ b/nix/lib/mk-guest.nix
@@ -768,11 +768,13 @@ let
     # `mvm-verity-init` bind-mounts it at /mvm/runtime before
     # switch_root, and on a non-verity boot the overlay is mounted
     # there directly, so /mvm/runtime/agent is the canonical binary
-    # location. mkGuest no longer bakes a /usr/local/bin fallback, so a
-    # required-overlay boot fails closed when the overlay agent is
-    # absent (a half-attached overlay never boots agent-less silently).
-    # The rootfs_only / prefer-overlay branches keep the legacy
-    # /usr/local/bin lookup for images that predate overlay-only.
+    # location. mkGuest no longer bakes a /usr/local/bin fallback, so ANY
+    # boot fails closed when no agent can be resolved (the guard after the
+    # ladder) — a half-attached overlay never boots agent-less silently,
+    # regardless of policy. The rootfs_only / prefer-overlay
+    # /usr/local/bin lookups below are inert for current mkGuest output
+    # (nothing is baked); they matter only if a future non-lean image
+    # reintroduces a baked agent.
     MVM_VARIANT=$(/bin/busybox cat /etc/mvm/variant 2>/dev/null || echo prod)
     MVM_AGENT_BIN=
     if [ "$MVM_RUNTIME_SOURCE_POLICY" = rootfs_only ]; then
@@ -789,16 +791,23 @@ let
     elif [ -x /usr/local/bin/mvm-guest-agent ]; then
       MVM_AGENT_BIN=/usr/local/bin/mvm-guest-agent
     fi
-    if [ -n "$MVM_AGENT_BIN" ]; then
-      # util-linux setpriv — busybox setpriv lacks --reuid /
-      # --regid / --clear-groups; see `setprivWrap` above for
-      # the full reasoning. Without this fix the agent never
-      # forks and vsock port 5252 stays unbound.
-      /bin/busybox setsid ${pkgs.util-linux}/bin/setpriv \
-        --reuid=${toString agentUid} --regid=${toString agentUid} \
-        --clear-groups --no-new-privs \
-        -- "$MVM_AGENT_BIN" &
+    if [ -z "$MVM_AGENT_BIN" ]; then
+      # Fail closed regardless of policy. Every mkGuest /init boot needs the
+      # agent, so an empty resolution means the overlay is missing or
+      # half-attached (or a future non-lean shape lost its baked agent).
+      # Booting on would leave vsock 5252 unbound and the control plane
+      # silently dead — refuse instead.
+      echo "mvm-init: no guest agent resolved from /mvm/runtime and no baked fallback"
+      exit 1
     fi
+    # util-linux setpriv — busybox setpriv lacks --reuid /
+    # --regid / --clear-groups; see `setprivWrap` above for
+    # the full reasoning. Without this fix the agent never
+    # forks and vsock port 5252 stays unbound.
+    /bin/busybox setsid ${pkgs.util-linux}/bin/setpriv \
+      --reuid=${toString agentUid} --regid=${toString agentUid} \
+      --clear-groups --no-new-privs \
+      -- "$MVM_AGENT_BIN" &
 
     # Stage 3 — hostname + console. /dev/console is what the
     # hypervisor wires our virtio-console to; in dev mode we keep


### PR DESCRIPTION
Follow-up to the overlay-only runtime work (the two Minor findings from that PR's whole-branch review, plus their OCI-side equivalent).

## Problem
Both guest PID-1 inits were fail-**open** when the guest agent (the mvm vsock control plane) couldn't be resolved from the runtime overlay: they logged a message and continued. The result is a silently agent-less VM — the host then waits out its full 30s agent-readiness timeout on a dead control plane.

## Fix
- **Nix `mkGuest` `/init`** (`nix/lib/mk-guest.nix`): the agent launch now `exit 1`s when the resolved bin is empty, **regardless of policy**. Previously only `required_overlay` failed closed; a `prefer_overlay`/virtiofs-root shape (unreachable today, but a future workload path) could boot agent-less. Also fixed the stale "predate overlay-only" ladder comment.
- **`mvm-oci-init`** (`crates/mvm-guest/src/bin/mvm-oci-init.rs`) — the static PID 1 injected into arbitrary OCI images (scratch/distroless/Alpine): `main()` now fails closed via `let Some(agent) = resolve_guest_agent() else { exit(1) }` instead of `spawn_one_optional`. As PID 1, an exit panics the kernel (`panic=-1` → reboot), so the boot fails loudly and diagnosably. Removed the now-dead `spawn_one_optional`; added a `None`-resolution unit test.

Both inits already source the agent from the overlay — this only changes the *missing-agent* case from a silent hang into a loud failure. No reachable, working boot changes behavior (a normal boot resolves the agent and launches it exactly as before).

## Validation
- nix eval of `mk-guest-eval.nix`; `nix_flake_structure` (27 passed); macOS build.
- `mvm-oci-init` compile-checked for `aarch64-unknown-linux-musl` with `-D warnings` (it's `#[cfg(target_os = "linux")]`, so its unit tests run on the Linux CI).
- nightly fmt clean.