### PR TITLE
fix(builder): make cold nix builds resilient to a flaky substituter link

### DIFF
--- a/crates/mvm-build/src/builder_vm_runtime.rs
+++ b/crates/mvm-build/src/builder_vm_runtime.rs
@@ -454,7 +454,17 @@ max-jobs = auto
 cores = 0
 auto-optimise-store = true
 substituters = https://cache.nixos.org/
-trusted-public-keys = cache.nixos.org-1:6NCHdD59X431o0gWypbMrAURkbJ16ZPMQFGspcDShjY="
+trusted-public-keys = cache.nixos.org-1:6NCHdD59X431o0gWypbMrAURkbJ16ZPMQFGspcDShjY=
+# Resilience to a flaky builder-egress link: retry each substitute download a
+# few times, cap concurrent connections so large NARs don't starve/drop mid
+# transfer, and fall back to building a derivation from source when its binary
+# cache download keeps failing (a smaller, different fetch than the large
+# prebuilt NAR). Without this a single dropped NAR aborts the whole build.
+fallback = true
+download-attempts = 5
+http-connections = 8
+connect-timeout = 15
+stalled-download-timeout = 90"
 # Flake convention: workspace-path env var so flakes that reference
 # the workspace root don't depend on relative-path resolution
 # against the store-copied flake dir.


### PR DESCRIPTION
On a flaky builder-egress link, a single dropped NAR download from `cache.nixos.org` (`HTTP 206 / Failure when receiving data from the peer`) aborts the whole in-VM nix build. Add resilience to the builder `NIX_CONFIG`:

- `fallback = true` — build a derivation from source when its binary-cache download keeps failing (a smaller, different fetch than the large prebuilt NAR)
- `download-attempts = 5`, `http-connections = 8`, `connect-timeout = 15`, `stalled-download-timeout = 90` — retry, cap concurrency so large NARs don't starve/drop, and time out cleanly

Surfaced while capturing a live egress witness on a flaky link, where large NARs (perl, windows-\*) dropped repeatedly and aborted cold builds; with `fallback` the build proceeds from source. (The slower source-build path is bounded by the existing `MVM_HVF_TIMEOUT` / `MVM_BUILDER_VM_TIMEOUT_SECS` knobs.)

Part of #1701 (builder robustness surfaced during the live witness).