### PR TITLE
fix(net): reconcile Firecracker tunnel vs iptables egress

### DIFF
--- a/crates/mvm-backend/src/microvm.rs
+++ b/crates/mvm-backend/src/microvm.rs
@@ -863,6 +863,24 @@ pub fn run_from_prestarted_build(
     run_configured_firecracker(config, abs_dir, abs_socket, false)
 }
 
+/// The egress policy for this run's Firecracker TAP.
+///
+/// Firecracker is the one workload backend that stands up a routable TAP NIC
+/// with a kernel firewall (libkrun/HVF carry egress solely over the vsock
+/// tunnel). When this run also configures a userspace egress tunnel, that
+/// tunnel is the auditable egress seam and must be the *only* one: applying
+/// the run's allow-list to the TAP as well would let a guest bring the NIC up
+/// itself and egress straight to the allow-listed hosts, bypassing the
+/// tunnel's audit/substitution gate. So a tunnel-present run pins the TAP to
+/// deny-all; the tunnel worker still receives the real policy to enforce.
+/// A no-tunnel run keeps the run's policy on the TAP (the direct-NIC path,
+/// including `--net` broad egress).
+fn firecracker_tap_policy(config: &FlakeRunConfig) -> mvm_core::network_policy::NetworkPolicy {
+    config
+        .network_policy
+        .nic_policy_behind_tunnel(config.network_tunnel.is_some())
+}
+
 fn run_configured_firecracker(
     config: &FlakeRunConfig,
     abs_dir: &str,
@@ -880,7 +898,7 @@ fn run_configured_firecracker(
         .provision(
             &mvm_core::protocol::vm_backend::VmId(slot.name.clone()),
             &NetworkSpec {
-                policy: config.network_policy.clone(),
+                policy: firecracker_tap_policy(config),
                 slot_index: slot.index,
             },
         )
@@ -1095,7 +1113,7 @@ pub fn restore_from_template_snapshot(
         .provision(
             &mvm_core::protocol::vm_backend::VmId(slot.name.clone()),
             &NetworkSpec {
-                policy: config.network_policy.clone(),
+                policy: firecracker_tap_policy(config),
                 slot_index: slot.index,
             },
         )
@@ -3603,6 +3621,51 @@ mod tests {
             .expect("cmdline token prefix");
         let decoded = mvm_core::vm_backend::decode_network_tunnel_cmdline(hex).unwrap();
         assert_eq!(decoded, config.network_tunnel.unwrap());
+    }
+
+    #[test]
+    fn firecracker_tap_policy_denies_tap_when_tunnel_present() {
+        // A tunnel-carried FC run must default-deny its TAP so egress can only
+        // leave through the audited vsock tunnel — the TAP allow-list would
+        // otherwise be a bypass. The tunnel worker keeps the real policy
+        // (`network_policy` on the config is untouched).
+        let mut config = baseline_run_config(None);
+        config.network_policy = mvm_core::network_policy::NetworkPolicy::allow_list(vec![
+            mvm_core::network_policy::HostPort::new("1.1.1.1", 443),
+        ]);
+        config.network_tunnel = Some(mvm_core::protocol::network_tunnel::TunnelRuntimeConfig {
+            guest_port: 5302,
+            session: mvm_core::protocol::network_tunnel::TunnelSessionConfig {
+                tenant_id: "t".to_string(),
+                vm_id: "vm-1".to_string(),
+                boot_id: "boot-1".to_string(),
+                session_nonce: "nonce-1".to_string(),
+                requested_features: mvm_core::protocol::network_tunnel::TunnelFeatures {
+                    ipv4: true,
+                    ..mvm_core::protocol::network_tunnel::TunnelFeatures::default()
+                },
+                maximum_frame_size: 4096,
+            },
+        });
+
+        assert_eq!(
+            firecracker_tap_policy(&config),
+            mvm_core::network_policy::NetworkPolicy::deny_all(),
+            "tunnel-present FC TAP must be deny-all"
+        );
+        // The run's policy is preserved for the tunnel worker to enforce.
+        assert!(config.network_policy.allows_egress());
+    }
+
+    #[test]
+    fn firecracker_tap_policy_passes_policy_through_without_tunnel() {
+        // No tunnel → the TAP is the egress path and keeps the run's policy.
+        let mut config = baseline_run_config(None);
+        config.network_policy = mvm_core::network_policy::NetworkPolicy::allow_list(vec![
+            mvm_core::network_policy::HostPort::new("example.com", 443),
+        ]);
+        config.network_tunnel = None;
+        assert_eq!(firecracker_tap_policy(&config), config.network_policy);
     }
 
     fn baseline_run_config(mem_initial: Option<u32>) -> FlakeRunConfig {

--- a/crates/mvm-core/src/policy/network_policy.rs
+++ b/crates/mvm-core/src/policy/network_policy.rs
@@ -415,6 +415,26 @@ impl NetworkPolicy {
             ip = guest_ip,
         ))
     }
+
+    /// The kernel-firewall policy to apply to a routable guest NIC (the
+    /// Firecracker TAP) given whether a userspace egress tunnel is carrying
+    /// this workload's traffic.
+    ///
+    /// A userspace L3 tunnel is the auditable egress seam: it terminates the
+    /// guest's outbound flows over vsock and enforces the allow-list there.
+    /// A routable NIC standing alongside the tunnel must not carry a second,
+    /// competing allow-list — a guest that brings that NIC up itself could
+    /// then egress straight to the allow-listed hosts and bypass the tunnel's
+    /// audit/substitution gate. So when a tunnel is present the NIC policy
+    /// collapses to deny-all (the tunnel owns egress); with no tunnel the NIC
+    /// keeps this policy verbatim (the direct-NIC / broad-egress case).
+    pub fn nic_policy_behind_tunnel(&self, has_tunnel: bool) -> NetworkPolicy {
+        if has_tunnel {
+            NetworkPolicy::deny_all()
+        } else {
+            self.clone()
+        }
+    }
 }
 
 impl Default for NetworkPolicy {
@@ -1000,6 +1020,43 @@ mod tests {
         assert!(script.contains("--dport 443"));
         assert!(script.contains("-s 172.16.0.3"));
         assert!(script.contains("-i br-mvm"));
+    }
+
+    #[test]
+    fn nic_policy_behind_tunnel_collapses_allow_list_to_deny_all() {
+        // A tunnel-carried workload must not leave a competing allow-list on
+        // its routable NIC: the NIC policy collapses to deny-all so the only
+        // egress seam is the audited tunnel.
+        let allow = NetworkPolicy::allow_list(vec![HostPort::new("1.1.1.1", 443)]);
+        let behind = allow.nic_policy_behind_tunnel(true);
+        assert_eq!(
+            behind,
+            NetworkPolicy::deny_all(),
+            "tunnel-present NIC policy is deny-all"
+        );
+        assert!(
+            !behind.allows_egress(),
+            "no direct egress may leak past the tunnel gate"
+        );
+        assert!(
+            behind
+                .iptables_script("br-mvm", "172.16.0.2")
+                .unwrap()
+                .contains("-j DROP"),
+            "the NIC firewall default-denies"
+        );
+        // The original allow-list is untouched — the tunnel worker still gets
+        // the real policy to enforce; only the NIC copy is denied.
+        assert!(allow.allows_egress());
+    }
+
+    #[test]
+    fn nic_policy_behind_tunnel_passes_policy_through_without_a_tunnel() {
+        // No tunnel → the NIC is the egress path and keeps the run's policy.
+        let allow = NetworkPolicy::allow_list(vec![HostPort::new("example.com", 443)]);
+        assert_eq!(allow.nic_policy_behind_tunnel(false), allow);
+        let deny = NetworkPolicy::deny_all();
+        assert_eq!(deny.nic_policy_behind_tunnel(false), deny);
     }
 
     #[test]


### PR DESCRIPTION
Resolves item 5 of #1701 (Firecracker: reconcile tunnel vs iptables).

## Finding: double-path (a policy-bypass window on the untrusted-guest threat model)

With the smoltcp egress tunnel now wired on Firecracker, an FC `--allow-host` run stands up **two** egress paths:

1. **The vsock tunnel** — `run_configured_firecracker` calls `spawn_network_tunnel_worker_if_configured(...)` with `network_policy: Some(&config.network_policy)` (`crates/mvm-backend/src/microvm.rs:960`). The honest guest routes `0.0.0.0/0` through the TUN; `mvm-guest-netinit` **skips** the legacy `eth0` bring-up when the `mvm.network_tunnel=` token is present (`crates/mvm-guest/src/bin/mvm-guest-netinit.rs:121-122`), so a cooperating guest has no competing default route.
2. **The TAP + kernel firewall** — the same start path provisions a routable TAP via `BridgeTapNetworkProvider::provision(...)` with `spec.policy = config.network_policy` (`crates/mvm-backend/src/microvm.rs:901`), which runs `network::apply_network_policy` → `NetworkPolicy::iptables_script` (`crates/mvm-core/src/policy/network_policy.rs:352`) and installs **allow-list ACCEPT** rules for the `--allow-host` destinations on the guest's TAP.

Because the guest is untrusted (that's the whole threat model), the host installing a TAP allow-list is a real bypass: an uncooperative guest can bring `eth0` up itself (`ip addr add ... dev eth0; ip route add default via …`) and egress **straight to the allow-listed hosts over L3**, evading the tunnel's audit / secret-substitution / PII-mask seam. libkrun and HVF have no such competing path — the vsock tunnel is their sole egress.

## Fix

When a network tunnel is configured, pin Firecracker's TAP to **deny-all** so the tunnel is the only egress seam (matching libkrun/HVF and the vsock-only-auditable-data-plane invariant). The tunnel worker still receives the real `network_policy` to enforce the allow-list. No-tunnel runs are unchanged — the TAP keeps the run's policy (the direct-NIC / `--net` broad-egress case is untouched, so the iptables path is not ripped out).

- `NetworkPolicy::nic_policy_behind_tunnel(has_tunnel)` — pure helper in `mvm-core` (`has_tunnel ? deny_all : self.clone()`), unit-tested locally.
- `firecracker_tap_policy(config)` — thin wrapper wired into **both** FC provision sites (`run_configured_firecracker` + `restore_from_template_snapshot`).

## Tests

- `mvm-core`: `nic_policy_behind_tunnel_collapses_allow_list_to_deny_all` (tunnel present → deny-all, DROP in the iptables script, original policy untouched) and `nic_policy_behind_tunnel_passes_policy_through_without_a_tunnel`.
- `mvm-backend`: `firecracker_tap_policy_denies_tap_when_tunnel_present` and `firecracker_tap_policy_passes_policy_through_without_tunnel`.

## Verification

- `cargo build -p mvm-backend` — ok
- `cargo clippy -p mvm-backend -p mvm-core --all-targets -- -D warnings` — clean
- `RUSTFLAGS="-D warnings" cargo zigbuild -p mvm-backend --target x86_64-unknown-linux-gnu` — ok
- `cargo test -p mvm-core` network_policy suite — 62 passed (mvm-backend nextest not run locally: codesign SIGKILL on macOS; the FC-side tests run in CI)
- `cargo fmt --all` (nightly) — clean