### PR TITLE
Unbreak the --all-features build of the release-pack download path

### DIFF
--- a/crates/mvm-cli/src/commands/env/dev_vz/bootstrap.rs
+++ b/crates/mvm-cli/src/commands/env/dev_vz/bootstrap.rs
@@ -545,7 +545,7 @@ pub(in crate::commands) mod attested_builder_pack {
     /// carried by the embedded identity template, not by anything the operator
     /// configures — so it must be allowed independent of `pack-trust.json`.
     #[cfg(feature = "manifest-verify")]
-    pub(super) fn keyless_release_policy(base: &LocalPackPolicy) -> LocalPackPolicy {
+    pub(in crate::commands) fn keyless_release_policy(base: &LocalPackPolicy) -> LocalPackPolicy {
         let mut policy = base.clone();
         policy
             .allowed_channels
@@ -614,7 +614,9 @@ pub(in crate::commands) mod attested_builder_pack {
     /// renames it), so it need not share a filesystem with the pack cache,
     /// and its `Drop` cleans it up on any early return here.
     #[cfg(feature = "manifest-verify")]
-    fn fetch_release_builder_pack_staging(arch: &str) -> Result<tempfile::TempDir> {
+    pub(in crate::commands) fn fetch_release_builder_pack_staging(
+        arch: &str,
+    ) -> Result<tempfile::TempDir> {
         let staging = tempfile::Builder::new()
             .prefix("mvm-builder-pack-")
             .tempdir()

--- a/crates/mvm-cli/src/commands/pack/download.rs
+++ b/crates/mvm-cli/src/commands/pack/download.rs
@@ -115,10 +115,7 @@ pub(in crate::commands) mod builder {
         let ctx = PackVerifyCtx::keyless(&policy, &keyless, &inputs.trust);
 
         let staging = fetch_release_builder_pack_staging(arch_str)
-            .context("fetching the published builder pack")?
-            .context(
-                "published builder pack fetch is disabled by the local pack-trust fetch_mode policy",
-            )?;
+            .context("fetching the published builder pack")?;
 
         let manifest_path = staging.path().join("pack-manifest.json");
         let manifest_bytes = std::fs::read(&manifest_path).with_context(|| {


### PR DESCRIPTION
`just check-linux --all-features` (and any `--all-features` build) failed to compile `mvm-cli`: the `manifest-verify`-gated published-builder-pack download in `commands/pack/download.rs` had never actually been compiled under that feature.

## Fixes (all in `mvm-cli`)
- **Visibility:** `keyless_release_policy` (`pub(super)`) and `fetch_release_builder_pack_staging` (private) in `env::dev_vz::bootstrap::attested_builder_pack` weren't reachable from `commands/pack/download.rs`. Widened both to `pub(in crate::commands)` — matching the sibling `host_pack_verify_inputs` the same call site already imports (E0603 ×2).
- **Bogus double-`context`:** dropped a second `.context(...)?` in `download.rs` that was chained onto the `TempDir` returned by `fetch_release_builder_pack_staging` (which returns `Result<TempDir>`, not `Result<Option<TempDir>>`) — it couldn't compile (E0599).

`cargo check -p mvm-cli --lib --all-features` is now clean (the cascade was exactly these three errors). No behavior change to any compiled path; this only enables a feature-gated block that was previously dead-on-arrival.