### PR TITLE
WS8: gate the mock VM backend behind test-support (keep it out of the prod closure)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -204,6 +204,13 @@ jobs:
         # closure), so the default workspace run skips these. Cover them here.
         run: cargo test -p mvm-build --features pure-mkfs --lib rootfs::tests::pure
 
+      - name: test-support feature tests (mock backend)
+        # The mock VM backend + its tests are gated behind `test-support` so the
+        # mock never ships in the production closure. The default workspace run
+        # skips its tests — run the workspace with the feature on so they stay
+        # covered on every PR.
+        run: cargo nextest run --workspace --features test-support
+
   test:
     name: Test
     runs-on: ubuntu-latest

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -539,6 +539,14 @@ template-registry-s3 = [
     "mvm-cli/template-registry-s3",
 ]
 
+# Dev/test-only: the hermetic in-memory `MockBackend` + `--hypervisor mock`.
+# Off by default so the shipped `mvmctl` binary never carries the Tier-3 mock
+# backend; this workspace's own `tests/audit_emissions_live.rs` (which spawns
+# `mvmctl --hypervisor mock` as a subprocess and drives `MockGuestAgent`
+# in-process) needs it turned on. `mvm-runtime` is named directly too since
+# this crate depends on it straight, not only through `mvm-cli`.
+test-support = ["mvm-cli/test-support", "mvm-runtime/test-support"]
+
 [profile.release]
 opt-level = 3
 strip = true

--- a/crates/mvm-cli/Cargo.toml
+++ b/crates/mvm-cli/Cargo.toml
@@ -56,6 +56,12 @@ tracing.workspace = true
 tracing-subscriber.workspace = true
 which.workspace = true
 
+[[example]]
+name = "verification_loop"
+# Drives the `WarmLease`/`ExecBuilder` DX layer against the hermetic mock
+# backend so the example runs on any host; needs the mock compiled in.
+required-features = ["test-support"]
+
 [build-dependencies]
 hex.workspace = true
 toml.workspace = true
@@ -125,6 +131,12 @@ manifest-verify = [
     "mvm-core/manifest-verify",
 ]
 template-registry-s3 = ["mvm-runtime/template-registry-s3"]
+# Forwards to `mvm-runtime/test-support` + `mvm-client/test-support`: the
+# hermetic in-memory `MockBackend` and the `--hypervisor mock` fast paths in
+# `fs`/`proc`/`diff` that key off it. Off by default so the mock — a Tier-3
+# test double with none of the security claims — never ships in a production
+# `mvmctl` binary; the test suite and the `verification_loop` example turn it on.
+test-support = ["mvm-runtime/test-support", "mvm-client/test-support"]
 
 [lints]
 workspace = true

--- a/crates/mvm-cli/src/commands/vm/diff.rs
+++ b/crates/mvm-cli/src/commands/vm/diff.rs
@@ -59,11 +59,15 @@ pub(in crate::commands) fn run(_cli: &Cli, args: Args, _cfg: &MvmConfig) -> Resu
 /// Like `fs::fs_request`, the `--hypervisor mock` fast path stays ahead of
 /// the `vsock_transport::for_vm` probe — which resolves the right socket per
 /// VMM (Firecracker's `v.sock`, or the per-port UNIX socket libkrun/QEMU
-/// expose) but is unaware of the in-memory mock backend.
+/// expose) but is unaware of the in-memory mock backend. Gated behind
+/// `test-support` along with the mock backend itself.
 fn fs_diff(name: &str) -> Result<Vec<FsChange>> {
-    let mock_dir = mvm_runtime::MockBackend::vm_dir(name);
-    if mock_dir.join("runtime").join("v.sock").exists() {
-        return mvm_agentd::vsock::query_fs_diff(&mock_dir.to_string_lossy());
+    #[cfg(feature = "test-support")]
+    {
+        let mock_dir = mvm_runtime::MockBackend::vm_dir(name);
+        if mock_dir.join("runtime").join("v.sock").exists() {
+            return mvm_agentd::vsock::query_fs_diff(&mock_dir.to_string_lossy());
+        }
     }
     let mut stream =
         mvm_runtime::vsock_transport::for_vm(name)?.connect(mvm_agentd::vsock::GUEST_AGENT_PORT)?;

--- a/crates/mvm-cli/src/commands/vm/fs.rs
+++ b/crates/mvm-cli/src/commands/vm/fs.rs
@@ -168,12 +168,17 @@ pub(in crate::commands) fn run(_cli: &Cli, args: Args, _cfg: &MvmConfig) -> Resu
 /// — so `mvmctl fs`/`cp` work regardless of which backend launched the VM.
 /// The `--hypervisor mock` fast path (a mock agent at the VM dir's
 /// `runtime/v.sock`) stays ahead of the probe since `for_vm` is unaware of
-/// the in-memory mock backend.
+/// the in-memory mock backend. Gated behind `test-support` along with the
+/// mock backend itself — a production build never has a mock VM dir to
+/// find, so it goes straight to the real probe.
 pub(super) fn fs_request(name: &str, req: GuestRequest) -> Result<FsResult> {
     validate_vm_name(name).with_context(|| format!("Invalid VM name: {:?}", name))?;
-    let mock_dir = mvm_runtime::MockBackend::vm_dir(name);
-    if mock_dir.join("runtime").join("v.sock").exists() {
-        return mvm_agentd::vsock::send_fs_request(&mock_dir.to_string_lossy(), req);
+    #[cfg(feature = "test-support")]
+    {
+        let mock_dir = mvm_runtime::MockBackend::vm_dir(name);
+        if mock_dir.join("runtime").join("v.sock").exists() {
+            return mvm_agentd::vsock::send_fs_request(&mock_dir.to_string_lossy(), req);
+        }
     }
     let mut stream =
         mvm_runtime::vsock_transport::for_vm(name)?.connect(mvm_agentd::vsock::GUEST_AGENT_PORT)?;

--- a/crates/mvm-cli/src/commands/vm/pause.rs
+++ b/crates/mvm-cli/src/commands/vm/pause.rs
@@ -11,7 +11,9 @@
 use anyhow::{Context, Result};
 use clap::Args as ClapArgs;
 
-use mvm_client::{LocalBackend, MachineId, MvmClient, PauseOpts, ResumeOpts};
+use mvm_client::{
+    LocalBackend, MachineId, MvmClient, PauseOpts, ResumeOpts, require_hypervisor_selectable,
+};
 use mvm_core::naming::validate_vm_name;
 use mvm_core::user_config::MvmConfig;
 
@@ -59,7 +61,7 @@ pub(in crate::commands) struct ResumeArgs {
 
 pub(in crate::commands) fn run_pause(_cli: &Cli, args: PauseArgs, _cfg: &MvmConfig) -> Result<()> {
     validate_vm_name(&args.name).with_context(|| format!("Invalid VM name: {:?}", args.name))?;
-    mvm_runtime::backend::AnyBackend::require_hypervisor_selectable(&args.hypervisor)?;
+    require_hypervisor_selectable(&args.hypervisor)?;
 
     let client = LocalBackend::with_hypervisor(&args.hypervisor);
     let runtime = tokio::runtime::Builder::new_current_thread()
@@ -92,7 +94,7 @@ pub(in crate::commands) fn run_resume(
     _cfg: &MvmConfig,
 ) -> Result<()> {
     validate_vm_name(&args.name).with_context(|| format!("Invalid VM name: {:?}", args.name))?;
-    mvm_runtime::backend::AnyBackend::require_hypervisor_selectable(&args.hypervisor)?;
+    require_hypervisor_selectable(&args.hypervisor)?;
 
     let client = LocalBackend::with_hypervisor(&args.hypervisor);
     let runtime = tokio::runtime::Builder::new_current_thread()

--- a/crates/mvm-cli/src/commands/vm/pause.rs
+++ b/crates/mvm-cli/src/commands/vm/pause.rs
@@ -59,6 +59,7 @@ pub(in crate::commands) struct ResumeArgs {
 
 pub(in crate::commands) fn run_pause(_cli: &Cli, args: PauseArgs, _cfg: &MvmConfig) -> Result<()> {
     validate_vm_name(&args.name).with_context(|| format!("Invalid VM name: {:?}", args.name))?;
+    mvm_runtime::backend::AnyBackend::require_hypervisor_selectable(&args.hypervisor)?;
 
     let client = LocalBackend::with_hypervisor(&args.hypervisor);
     let runtime = tokio::runtime::Builder::new_current_thread()
@@ -91,6 +92,7 @@ pub(in crate::commands) fn run_resume(
     _cfg: &MvmConfig,
 ) -> Result<()> {
     validate_vm_name(&args.name).with_context(|| format!("Invalid VM name: {:?}", args.name))?;
+    mvm_runtime::backend::AnyBackend::require_hypervisor_selectable(&args.hypervisor)?;
 
     let client = LocalBackend::with_hypervisor(&args.hypervisor);
     let runtime = tokio::runtime::Builder::new_current_thread()

--- a/crates/mvm-cli/src/commands/vm/proc.rs
+++ b/crates/mvm-cli/src/commands/vm/proc.rs
@@ -132,9 +132,12 @@ pub(in crate::commands) fn run(_cli: &Cli, args: Args, _cfg: &MvmConfig) -> Resu
 /// mock backend.
 fn proc_request(name: &str, req: GuestRequest) -> Result<ProcResult> {
     validate_vm_name(name).with_context(|| format!("Invalid VM name: {:?}", name))?;
-    let mock_dir = mvm_runtime::MockBackend::vm_dir(name);
-    if mock_dir.join("runtime").join("v.sock").exists() {
-        return mvm_agentd::vsock::send_proc_request(&mock_dir.to_string_lossy(), req);
+    #[cfg(feature = "test-support")]
+    {
+        let mock_dir = mvm_runtime::MockBackend::vm_dir(name);
+        if mock_dir.join("runtime").join("v.sock").exists() {
+            return mvm_agentd::vsock::send_proc_request(&mock_dir.to_string_lossy(), req);
+        }
     }
     let mut stream =
         mvm_runtime::vsock_transport::for_vm(name)?.connect(mvm_agentd::vsock::GUEST_AGENT_PORT)?;
@@ -150,14 +153,17 @@ fn proc_wait<F: FnMut(&ProcWaitEvent)>(
     on_event: F,
 ) -> Result<ProcWaitEvent> {
     validate_vm_name(name).with_context(|| format!("Invalid VM name: {:?}", name))?;
-    let mock_dir = mvm_runtime::MockBackend::vm_dir(name);
-    if mock_dir.join("runtime").join("v.sock").exists() {
-        return mvm_agentd::vsock::send_proc_wait(
-            &mock_dir.to_string_lossy(),
-            token,
-            timeout,
-            on_event,
-        );
+    #[cfg(feature = "test-support")]
+    {
+        let mock_dir = mvm_runtime::MockBackend::vm_dir(name);
+        if mock_dir.join("runtime").join("v.sock").exists() {
+            return mvm_agentd::vsock::send_proc_wait(
+                &mock_dir.to_string_lossy(),
+                token,
+                timeout,
+                on_event,
+            );
+        }
     }
     let mut stream =
         mvm_runtime::vsock_transport::for_vm(name)?.connect(mvm_agentd::vsock::GUEST_AGENT_PORT)?;

--- a/crates/mvm-client/Cargo.toml
+++ b/crates/mvm-client/Cargo.toml
@@ -17,6 +17,11 @@ default = []
 # The remote REST `GatewayBackend` + `connect(Target::Gateway)`. Off by default
 # so a pure-local consumer stays light; a fleet/studio build turns it on.
 remote = ["mvm-core/client-remote"]
+# Forwards to `mvm-runtime/test-support`: the hermetic in-memory mock backend
+# `LocalBackend::with_hypervisor("mock")` drives in `pause`/`resume`'s
+# canned-snapshot test path. Off by default so the mock never reaches a
+# production build; the crate's own pause/resume test suite turns it on.
+test-support = ["mvm-runtime/test-support"]
 
 [dependencies]
 mvm-core = { workspace = true, features = ["client"] }

--- a/crates/mvm-client/src/boot.rs
+++ b/crates/mvm-client/src/boot.rs
@@ -56,3 +56,15 @@ pub fn backend_stop_by_name(hypervisor: &str, name: &str) -> Result<()> {
             reason: format!("{e:#}"),
         })
 }
+
+/// Refuse a `--hypervisor` name the current build cannot select (e.g. `mock`
+/// on a build without the `test-support` feature) before any machine
+/// construction — mirrors the CLI's former inline
+/// `AnyBackend::require_hypervisor_selectable` guard.
+pub fn require_hypervisor_selectable(name: &str) -> Result<()> {
+    mvm_runtime::backend::AnyBackend::require_hypervisor_selectable(name).map_err(|e| {
+        MvmError::Backend {
+            reason: format!("{e:#}"),
+        }
+    })
+}

--- a/crates/mvm-client/src/lib.rs
+++ b/crates/mvm-client/src/lib.rs
@@ -24,7 +24,9 @@ pub use mvm_core::client::gateway;
 pub use mvm_core::client::mock::{self, MockBackend};
 pub use mvm_core::client::{MvmClient, MvmError, Result};
 
-pub use boot::{backend_is_running, backend_stop_by_name, start_prepared};
+pub use boot::{
+    backend_is_running, backend_stop_by_name, require_hypervisor_selectable, start_prepared,
+};
 pub use connect::{Target, connect};
 pub use local::LocalBackend;
 pub use readiness::{readiness_of, record_readiness, touch_activity};

--- a/crates/mvm-client/src/local.rs
+++ b/crates/mvm-client/src/local.rs
@@ -35,8 +35,10 @@ use mvm_core::client::dto::{
 use mvm_core::client::{MvmClient, MvmError, Result};
 use mvm_core::config::vm_state_dir;
 use mvm_core::vm_backend::{SnapshotCapability, VmStartConfig, WarmStartError};
+#[cfg(feature = "test-support")]
+use mvm_runtime::vm::instance_snapshot::CannedIO;
 use mvm_runtime::vm::instance_snapshot::{
-    CannedIO, FirecrackerIO, SnapshotIO, VsockPostRestoreSignal, VsockPrimedSignalSource,
+    FirecrackerIO, SnapshotIO, VsockPostRestoreSignal, VsockPrimedSignalSource,
     await_primed_barrier, pause_and_seal, signal_post_restore, verify_and_resume,
 };
 use mvm_runtime::vm::name_registry::{VmNameRegistry, VmRegistration};
@@ -92,8 +94,13 @@ impl LocalBackend {
     /// Pick the `SnapshotIO` matching this client's backend. The mock writes
     /// deterministic `CannedIO` stub bytes so the seal/verify round-trip runs
     /// without a real Firecracker socket; every other backend drives
-    /// `FirecrackerIO` against the running VM's UDS control socket.
+    /// `FirecrackerIO` against the running VM's UDS control socket. The mock
+    /// arm is gated behind `test-support` along with `is_mock()`'s only
+    /// possible `true` outcome — outside that feature `AnyBackend::Mock`
+    /// doesn't exist, so `is_mock()` is always `false` and this falls
+    /// straight through to the real Firecracker path.
     fn snapshot_io_for(&self, vm_name: &str) -> Result<Box<dyn SnapshotIO>> {
+        #[cfg(feature = "test-support")]
         if self.is_mock() {
             let dir = mvm_runtime::MockBackend::vm_dir(vm_name);
             if !dir.exists() {
@@ -850,16 +857,23 @@ impl MvmClient for LocalBackend {
 #[cfg(test)]
 mod tests {
     use super::*;
+    #[cfg(feature = "test-support")]
     use mvm_core::util::test_env::TestEnv;
 
+    // Only the mock-driven `LocalBackend` tests below need an isolated
+    // `MVM_HOME` (they boot/list/stop machines against real on-disk state);
+    // gated together with the mock backend those tests exercise.
+    #[cfg(feature = "test-support")]
     static DATA_DIR_TEST_LOCK: std::sync::Mutex<()> = std::sync::Mutex::new(());
 
+    #[cfg(feature = "test-support")]
     struct IsolatedDataDir {
         _lock: std::sync::MutexGuard<'static, ()>,
         _env: TestEnv,
         dir: tempfile::TempDir,
     }
 
+    #[cfg(feature = "test-support")]
     impl IsolatedDataDir {
         fn new() -> Self {
             let lock = DATA_DIR_TEST_LOCK
@@ -976,6 +990,7 @@ mod tests {
     }
 
     #[tokio::test]
+    #[cfg(feature = "test-support")]
     async fn list_over_mock_backend_succeeds() {
         // `list_machines` unions the host-wide backend scan + name registry, so
         // isolate the data dir or leftover real `~/.mvm/vms` state leaks in.
@@ -1026,6 +1041,7 @@ mod tests {
     }
 
     #[tokio::test]
+    #[cfg(feature = "test-support")]
     async fn run_boots_admitted_plan_from_materialized_rootfs() {
         let data = IsolatedDataDir::new();
         let rootfs = data.path().join("rootfs.ext4");
@@ -1055,6 +1071,7 @@ mod tests {
     }
 
     #[tokio::test]
+    #[cfg(feature = "test-support")]
     async fn remove_drops_the_machine_from_list_and_is_idempotent() {
         let data = IsolatedDataDir::new();
         let rootfs = data.path().join("rootfs.ext4");
@@ -1098,6 +1115,7 @@ mod tests {
     }
 
     #[tokio::test]
+    #[cfg(feature = "test-support")]
     async fn stop_machine_falls_back_to_configured_backend_and_is_idempotent() {
         // A mock-driven VM writes no pid marker, so `for_started_vm` finds no
         // owning VMM and the stop must fall back to this client's configured
@@ -1194,6 +1212,7 @@ mod tests {
     }
 
     #[tokio::test]
+    #[cfg(feature = "test-support")]
     async fn pause_seals_and_resume_verifies_over_mock_canned_io() {
         // The mock snapshot transport keys off the mock VM's per-VM dir existing.
         let _data = IsolatedDataDir::new();
@@ -1220,6 +1239,7 @@ mod tests {
     }
 
     #[tokio::test]
+    #[cfg(feature = "test-support")]
     async fn pause_on_absent_mock_vm_is_error() {
         let _data = IsolatedDataDir::new();
         let be = LocalBackend::with_hypervisor("mock");
@@ -1239,7 +1259,9 @@ mod tests {
     // ---------------------------------------------------------------------------
 
     /// Persist a minimal image-backed spec named `name` into the current
-    /// `MVM_HOME`-derived machine state dir.
+    /// `MVM_HOME`-derived machine state dir. Only used by the
+    /// `reconfigure_*` tests below, which all drive the mock backend.
+    #[cfg(feature = "test-support")]
     fn persist_test_spec(name: &str) {
         use mvm_runtime::machine::persist::{
             MACHINE_SPEC_SCHEMA_VERSION, MachineSpec as PersistSpec, save_machine_spec,
@@ -1268,6 +1290,7 @@ mod tests {
     }
 
     #[tokio::test]
+    #[cfg(feature = "test-support")]
     async fn reconfigure_refuses_network_changes_on_local_backend() {
         let _data = IsolatedDataDir::new();
         persist_test_spec("web");
@@ -1290,6 +1313,7 @@ mod tests {
     }
 
     #[tokio::test]
+    #[cfg(feature = "test-support")]
     async fn reconfigure_refuses_allow_host_changes_on_local_backend() {
         let _data = IsolatedDataDir::new();
         persist_test_spec("web2");
@@ -1312,6 +1336,7 @@ mod tests {
     }
 
     #[tokio::test]
+    #[cfg(feature = "test-support")]
     async fn reconfigure_unknown_machine_is_error() {
         let _data = IsolatedDataDir::new();
         let be = LocalBackend::with_hypervisor("mock");
@@ -1333,6 +1358,7 @@ mod tests {
     }
 
     #[tokio::test]
+    #[cfg(feature = "test-support")]
     async fn reconfigure_stopped_machine_updates_spec_and_returns_stopped() {
         let _data = IsolatedDataDir::new();
         persist_test_spec("myapp");
@@ -1359,6 +1385,7 @@ mod tests {
     }
 
     #[tokio::test]
+    #[cfg(feature = "test-support")]
     async fn reconfigure_rejects_zero_cpus() {
         let _data = IsolatedDataDir::new();
         persist_test_spec("zero-cpu-machine");
@@ -1386,6 +1413,7 @@ mod tests {
     }
 
     #[tokio::test]
+    #[cfg(feature = "test-support")]
     async fn reconfigure_noop_returns_stopped_without_overwriting_spec() {
         let _data = IsolatedDataDir::new();
         persist_test_spec("noop-machine");

--- a/crates/mvm-hostd/Cargo.toml
+++ b/crates/mvm-hostd/Cargo.toml
@@ -160,6 +160,12 @@ tar.workspace = true
 hex.workspace = true
 # `TestEnv` env-var guard for env-mutating tests (reaper / substitution_endpoint).
 mvm-core = { workspace = true, features = ["test-support"] }
+# `plan_admission`'s own tests drive `AnyBackend::from_hypervisor("mock")` —
+# the hermetic in-memory backend — end-to-end through `admit_and_start`. The
+# mock is gated behind `test-support` in mvm-runtime so it never ships in a
+# production binary; force it on for this crate's own test build the same
+# way the `mvm-core` entry above does.
+mvm-runtime = { workspace = true, features = ["test-support"] }
 tokio = { workspace = true, features = ["macros", "rt", "rt-multi-thread", "net", "io-util", "time", "sync", "test-util"] }
 # jailer property tests re-spawn under SECCOMP_PROBE=1 before main.
 ctor = "0.2"

--- a/crates/mvm-runtime/Cargo.toml
+++ b/crates/mvm-runtime/Cargo.toml
@@ -112,6 +112,13 @@ storage-s3 = ["dep:object_store", "dep:futures"]
 # The claim-free host-wasmtime portability tier (`WasmBackend`). Off by
 # default; pulls the wasmtime + wasmtime-wasi closure only when enabled.
 wasm-backend = ["dep:wasmtime", "dep:wasmtime-wasi"]
+# The hermetic in-memory `MockBackend`/`MockGuestAgent` test double + the
+# `AnyBackend::Mock` variant that selects it. Off by default so the mock — a
+# Tier-3 backend satisfying none of the security claims (no guest, no
+# rootfs, no isolation) — never compiles into a production `mvmctl`
+# binary; only an explicit `--hypervisor mock` (itself refused outside this
+# feature) or the workspace test suite reaches it.
+test-support = ["mvm-core/test-support"]
 
 [lints]
 workspace = true

--- a/crates/mvm-runtime/src/backend.rs
+++ b/crates/mvm-runtime/src/backend.rs
@@ -567,9 +567,9 @@ impl AnyBackend {
     /// `"mock"` is a real, documented selector the caller deliberately
     /// typed — silently substituting Firecracker for it would run the
     /// wrong backend instead of failing. Call this before
-    /// [`Self::from_hypervisor`] / [`crate::LibkrunBackend`]-style
-    /// resolution at any user-facing `--hypervisor` entry point that
-    /// documents the `mock` selector (e.g. `mvmctl pause`/`resume`).
+    /// [`Self::from_hypervisor`] at any user-facing `--hypervisor` entry
+    /// point that documents the `mock` selector (e.g. `mvmctl
+    /// pause`/`resume`).
     pub fn require_hypervisor_selectable(name: &str) -> Result<()> {
         if name == "mock" && !cfg!(feature = "test-support") {
             anyhow::bail!("the mock backend is only available in test-support builds");

--- a/crates/mvm-runtime/src/backend.rs
+++ b/crates/mvm-runtime/src/backend.rs
@@ -16,6 +16,7 @@ use crate::hvf_backend::HvfBackend;
 use crate::image::RuntimeVolume;
 use crate::libkrun::LibkrunBackend;
 use crate::microvm::{DriveFile, FlakeRunConfig};
+#[cfg(feature = "test-support")]
 use crate::mock::MockBackend;
 use crate::qemu::QemuBackend;
 use crate::wasm_backend::WasmBackend;
@@ -490,7 +491,10 @@ pub enum AnyBackend {
     /// the host. Selected only via explicit `--hypervisor mock`;
     /// `auto_select` never falls through here. See
     /// [`crate::mock::MockBackend`] for the rationale and security
-    /// profile (Tier 3 / claims unknown).
+    /// profile (Tier 3 / claims unknown). Gated behind `test-support` so
+    /// this variant — and the mock backend it wraps — never compiles into
+    /// a production `mvmctl` binary.
+    #[cfg(feature = "test-support")]
     Mock(MockBackend),
     /// Raw HVF — Hypervisor.framework on macOS / Apple silicon,
     /// driven by the unified `vmm::run` loop via the detached
@@ -538,6 +542,11 @@ impl AnyBackend {
     /// Supported: `"firecracker"` (default), `"qemu"` (Linux dev/test),
     /// `"hvf"` (in-house Hypervisor.framework VMM, macOS), `"libkrun"`
     /// (Linux KVM / macOS HVF). Unknown names fall back to Firecracker.
+    /// `"mock"` resolves to the hermetic in-memory test double only in a
+    /// `test-support` build; outside it, `"mock"` is unrecognised the same
+    /// way a typo is and falls back to Firecracker too — call
+    /// [`Self::require_hypervisor_selectable`] first at a user-facing
+    /// `--hypervisor` boundary to refuse it loudly instead.
     pub fn from_hypervisor(name: &str) -> Self {
         // The runner isn't const-constructible, so it can't live in the catalog
         // table; special-case its opt-in selector before the descriptor lookup.
@@ -548,6 +557,24 @@ impl AnyBackend {
         catalog::descriptor_for_selector(name)
             .map(|descriptor| descriptor.instantiate())
             .unwrap_or_else(Self::default_backend)
+    }
+
+    /// Refuse a `--hypervisor` name this build cannot actually select,
+    /// instead of letting it silently resolve to a different backend.
+    /// `from_hypervisor` degrades *any* unrecognised name (including a
+    /// plain typo) to the Firecracker default; that tolerance is wrong for
+    /// `"mock"` specifically outside a `test-support` build, because
+    /// `"mock"` is a real, documented selector the caller deliberately
+    /// typed — silently substituting Firecracker for it would run the
+    /// wrong backend instead of failing. Call this before
+    /// [`Self::from_hypervisor`] / [`crate::LibkrunBackend`]-style
+    /// resolution at any user-facing `--hypervisor` entry point that
+    /// documents the `mock` selector (e.g. `mvmctl pause`/`resume`).
+    pub fn require_hypervisor_selectable(name: &str) -> Result<()> {
+        if name == "mock" && !cfg!(feature = "test-support") {
+            anyhow::bail!("the mock backend is only available in test-support builds");
+        }
+        Ok(())
     }
 
     /// Select the best backend for the current platform.
@@ -642,6 +669,7 @@ impl AnyBackend {
             Self::Firecracker(backend) => backend,
             Self::Libkrun(backend) => backend,
             Self::Qemu(backend) => backend,
+            #[cfg(feature = "test-support")]
             Self::Mock(backend) => backend,
             Self::Hvf(backend) => backend,
             Self::HvfRunner(backend) => backend,
@@ -658,6 +686,7 @@ impl AnyBackend {
             }
             Self::Libkrun(backend) => std::sync::Arc::new(backend) as std::sync::Arc<dyn VmBackend>,
             Self::Qemu(backend) => std::sync::Arc::new(backend) as std::sync::Arc<dyn VmBackend>,
+            #[cfg(feature = "test-support")]
             Self::Mock(backend) => std::sync::Arc::new(backend) as std::sync::Arc<dyn VmBackend>,
             Self::Hvf(backend) => std::sync::Arc::new(backend) as std::sync::Arc<dyn VmBackend>,
             Self::HvfRunner(backend) => {
@@ -710,6 +739,7 @@ impl AnyBackend {
         match self {
             AnyBackend::Firecracker(b) => Some(b),
             AnyBackend::Libkrun(b) => Some(b),
+            #[cfg(feature = "test-support")]
             AnyBackend::Mock(b) => Some(b),
             AnyBackend::Qemu(_) => None,
             // HVF carries untrusted workloads: a real mkGuest workload boot, a
@@ -1060,10 +1090,47 @@ mod tests {
     }
 
     #[test]
+    #[cfg(feature = "test-support")]
     fn test_any_backend_from_hypervisor_mock() {
         let backend = AnyBackend::from_hypervisor("mock");
         assert_eq!(backend.name(), "mock");
         assert!(matches!(backend, AnyBackend::Mock(_)));
+    }
+
+    #[test]
+    #[cfg(not(feature = "test-support"))]
+    fn from_hypervisor_mock_falls_back_outside_test_support() {
+        // Outside `test-support`, `"mock"` is unrecognised the same way a
+        // typo is — `from_hypervisor` itself stays infallible and degrades
+        // to the Firecracker default. `require_hypervisor_selectable` is
+        // the fail-closed check a user-facing `--hypervisor` boundary uses
+        // instead of relying on this fallback.
+        let backend = AnyBackend::from_hypervisor("mock");
+        assert_eq!(backend.name(), "firecracker");
+    }
+
+    #[test]
+    fn require_hypervisor_selectable_refuses_mock_without_test_support() {
+        let result = AnyBackend::require_hypervisor_selectable("mock");
+        if cfg!(feature = "test-support") {
+            assert!(result.is_ok(), "test-support build must allow mock");
+        } else {
+            let err = result.expect_err("mock must be refused outside test-support");
+            assert!(
+                err.to_string().contains("test-support"),
+                "error must name the missing feature: {err}"
+            );
+        }
+    }
+
+    #[test]
+    fn require_hypervisor_selectable_allows_every_other_name() {
+        for name in ["firecracker", "libkrun", "qemu", "hvf", "unknown-typo"] {
+            assert!(
+                AnyBackend::require_hypervisor_selectable(name).is_ok(),
+                "{name}: must never be refused"
+            );
+        }
     }
 
     #[test]
@@ -1405,15 +1472,21 @@ mod tests {
 
     #[test]
     fn tier_classification_locks_each_backend_variant() {
-        let cases: &[(&str, BackendTier)] = &[
+        let mut cases: Vec<(&str, BackendTier)> = vec![
             ("firecracker", BackendTier::Tier1),
             ("libkrun", BackendTier::Tier2),
             ("qemu", BackendTier::Tier2),
-            ("mock", BackendTier::Tier3),
         ];
+        // No `AnyBackend::Mock`/`MockBackend` reference here — just a name +
+        // tier pair — so a plain runtime check (not `#[cfg]`) is enough to
+        // keep this test-support-agnostic and `mut` genuinely used in both
+        // configs.
+        if cfg!(feature = "test-support") {
+            cases.push(("mock", BackendTier::Tier3));
+        }
         for (name, expected) in cases {
             let b = AnyBackend::from_hypervisor(name);
-            assert_eq!(b.tier(), *expected, "{name}: tier mismatch");
+            assert_eq!(b.tier(), expected, "{name}: tier mismatch");
         }
     }
 
@@ -1424,7 +1497,10 @@ mod tests {
         // long-standing per-backend tier declaration. `AnyBackend::tier()`
         // is the closed-enum view of the same fact. Bumping one without
         // the other is a regression — keep them wired.
-        let names = ["firecracker", "libkrun", "qemu", "mock"];
+        let mut names = vec!["firecracker", "libkrun", "qemu"];
+        if cfg!(feature = "test-support") {
+            names.push("mock");
+        }
         for name in names {
             let b = AnyBackend::from_hypervisor(name);
             let enum_tier = b.tier();
@@ -1452,7 +1528,11 @@ mod tests {
     fn as_workload_backend_some_for_workload_variants() {
         // mock is included: it is the hermetic lifecycle test double that
         // stands in for a workload backend on the admitted path.
-        for name in ["firecracker", "libkrun", "hvf", "mock"] {
+        let mut names = vec!["firecracker", "libkrun", "hvf"];
+        if cfg!(feature = "test-support") {
+            names.push("mock");
+        }
+        for name in names {
             let backend = AnyBackend::from_hypervisor(name);
             assert!(
                 backend.as_workload_backend().is_some(),
@@ -1525,23 +1605,37 @@ mod tests {
         );
     }
 
+    /// Isolates the `AnyBackend::Mock` construction (unavailable outside
+    /// `test-support`) behind a function that's always defined, so its only
+    /// caller can `.extend(..)` unconditionally instead of needing a
+    /// `#[cfg]`'d `push` — which would otherwise make the collection's
+    /// `mut` binding spuriously unused in a non-`test-support` build.
+    #[cfg(feature = "test-support")]
+    fn mock_variant_for_ssh_check() -> Option<(&'static str, AnyBackend)> {
+        Some(("mock", AnyBackend::Mock(MockBackend::new())))
+    }
+    #[cfg(not(feature = "test-support"))]
+    fn mock_variant_for_ssh_check() -> Option<(&'static str, AnyBackend)> {
+        None
+    }
+
     #[test]
     fn no_backend_advertises_production_ssh() {
         // The capability layer encodes the SSH ban: no backend may advertise an
         // in-guest SSH server. A future backend that flips this trips here.
         // Covers every `AnyBackend` variant, including both hvf entry points
         // (the raw backend and the WorkloadRunner-driven role-runner path).
-        let backends: [(&str, AnyBackend); 6] = [
+        let mut backends: Vec<(&str, AnyBackend)> = vec![
             ("firecracker", AnyBackend::Firecracker(FirecrackerBackend)),
             ("libkrun", AnyBackend::Libkrun(LibkrunBackend)),
             ("qemu", AnyBackend::Qemu(QemuBackend)),
-            ("mock", AnyBackend::Mock(MockBackend::new())),
             ("hvf", AnyBackend::Hvf(HvfBackend)),
             (
                 "hvf_runner",
                 AnyBackend::HvfRunner(WorkloadRunner::new(HvfDriver::new(), RealEndpointSpawner)),
             ),
         ];
+        backends.extend(mock_variant_for_ssh_check());
         for (name, backend) in backends {
             assert!(
                 !backend.capabilities().production_ssh,

--- a/crates/mvm-runtime/src/catalog.rs
+++ b/crates/mvm-runtime/src/catalog.rs
@@ -14,6 +14,7 @@
 
 use crate::backend::{AnyBackend, BackendTier, FirecrackerBackend};
 use crate::libkrun::LibkrunBackend;
+#[cfg(feature = "test-support")]
 use crate::mock::MockBackend;
 use crate::qemu::QemuBackend;
 use crate::wasm_backend::WasmBackend;
@@ -122,6 +123,25 @@ macro_rules! backend_catalog {
     };
 }
 
+/// Construct the mock descriptor's `AnyBackend`. The descriptor row stays in
+/// the catalog in every build (so `"mock"` keeps resolving as a recognised
+/// selector — `mvmctl doctor`, the catalog-matrix test, and the generic
+/// descriptor-driven consumers all still see it), but the mock backend
+/// itself only exists behind `test-support`. Outside that feature this
+/// falls back to the same default `instantiate_kind` would otherwise be
+/// unable to express for a variant that doesn't compile in — callers that
+/// need a hard refusal instead of this fallback use
+/// [`AnyBackend::require_hypervisor_selectable`] ahead of resolution.
+#[cfg(feature = "test-support")]
+fn mock_constructor() -> AnyBackend {
+    AnyBackend::Mock(MockBackend::new())
+}
+
+#[cfg(not(feature = "test-support"))]
+fn mock_constructor() -> AnyBackend {
+    AnyBackend::default_backend()
+}
+
 backend_catalog![
     {
         kind: Firecracker,
@@ -172,7 +192,7 @@ backend_catalog![
         kind: Mock,
         selector: "mock",
         aliases: [],
-        constructor: AnyBackend::Mock(MockBackend::new()),
+        constructor: mock_constructor(),
         tier: Tier3,
         marker_file: None,
         started_vm_probe_order: None,

--- a/crates/mvm-runtime/src/lib.rs
+++ b/crates/mvm-runtime/src/lib.rs
@@ -74,7 +74,14 @@ pub mod image;
 pub mod kvm;
 pub mod libkrun;
 pub mod microvm;
+/// The hermetic in-memory `MockBackend` — see its module docs for the
+/// security posture. Gated behind `test-support` so it never compiles into
+/// a production `mvmctl` binary.
+#[cfg(feature = "test-support")]
 pub mod mock;
+/// In-process mock of the in-guest vsock agent, paired with [`mock`].
+/// Gated the same way — test-only, never in a production build.
+#[cfg(feature = "test-support")]
 pub mod mock_guest_agent;
 pub mod netinit_audit;
 pub mod network;
@@ -131,6 +138,7 @@ pub use base::shell_mock;
 
 pub use backend::{AnyBackend, FirecrackerBackend, FirecrackerConfig};
 pub use libkrun::LibkrunBackend;
+#[cfg(feature = "test-support")]
 pub use mock::MockBackend;
 /// Derive a workload's packet-tunnel launch config from its egress policy. The
 /// admitted launch path (`mvmctl`) calls this to enable the L3 forwarding tunnel

--- a/crates/mvm-runtime/src/machine/mod.rs
+++ b/crates/mvm-runtime/src/machine/mod.rs
@@ -371,6 +371,7 @@ mod tests {
     }
 
     #[test]
+    #[cfg(feature = "test-support")]
     fn produced_config_is_launchable_by_a_backend() {
         // Prove the translation yields a config a backend accepts: the mock
         // (the VmBackend test double) starts it and records a running VM.

--- a/crates/mvm-runtime/src/test_support.rs
+++ b/crates/mvm-runtime/src/test_support.rs
@@ -5,7 +5,7 @@ use std::os::unix::net::UnixListener;
 #[cfg(test)]
 use std::path::Path;
 
-#[cfg(test)]
+#[cfg(all(test, feature = "test-support"))]
 use crate::mock_guest_agent::MockGuestAgent;
 
 #[cfg(test)]
@@ -61,7 +61,7 @@ pub(crate) fn bind_unix_listener(path: &Path) -> Option<UnixListener> {
     }
 }
 
-#[cfg(test)]
+#[cfg(all(test, feature = "test-support"))]
 pub(crate) fn start_mock_guest_agent(vm_dir: &Path) -> Option<MockGuestAgent> {
     match MockGuestAgent::start(vm_dir) {
         Ok(agent) => Some(agent),

--- a/crates/mvm-runtime/src/vm/exec_builder.rs
+++ b/crates/mvm-runtime/src/vm/exec_builder.rs
@@ -329,10 +329,13 @@ pub(crate) fn build_exec_request_for_test(argv: Vec<String>, stdin_bytes: Vec<u8
 #[cfg(test)]
 mod tests {
     use super::*;
+    #[cfg(feature = "test-support")]
     use crate::mock_guest_agent::MockGuestAgent;
+    #[cfg(feature = "test-support")]
     use mvm_agentd::vsock::connect_to_port;
 
     /// Start a mock agent and return a connected, handshaken stream to it.
+    #[cfg(feature = "test-support")]
     fn agent_stream() -> Option<(tempfile::TempDir, MockGuestAgent, UnixStream)> {
         let dir = tempfile::tempdir().unwrap();
         let agent = match MockGuestAgent::start(dir.path()) {
@@ -390,6 +393,7 @@ mod tests {
     }
 
     #[test]
+    #[cfg(feature = "test-support")]
     fn stage_files_then_exec_on_one_stream_returns_outcome() {
         let Some((_d, _a, mut stream)) = agent_stream() else {
             return;
@@ -407,6 +411,7 @@ mod tests {
     }
 
     #[test]
+    #[cfg(feature = "test-support")]
     fn run_entrypoint_returns_outcome_on_one_stream() {
         let Some((_d, _a, mut stream)) = agent_stream() else {
             return;
@@ -418,6 +423,7 @@ mod tests {
     }
 
     #[test]
+    #[cfg(feature = "test-support")]
     fn batch_stages_and_runs_commands_in_one_round_trip() {
         let Some((_d, _a, mut stream)) = agent_stream() else {
             return;
@@ -438,6 +444,7 @@ mod tests {
     }
 
     #[test]
+    #[cfg(feature = "test-support")]
     fn exec_after_staging_multiple_files_still_succeeds() {
         let Some((_d, _a, mut stream)) = agent_stream() else {
             return;

--- a/crates/mvm-runtime/src/vm/lease.rs
+++ b/crates/mvm-runtime/src/vm/lease.rs
@@ -153,7 +153,10 @@ impl Drop for WarmLease {
     }
 }
 
-#[cfg(test)]
+// Every test below drives `WarmLease` through `MockBackend`, the only
+// hermetic `VmBackend` test double available — so the whole module is
+// gated behind `test-support` along with the mock it exercises.
+#[cfg(all(test, feature = "test-support"))]
 mod tests {
     use super::*;
     use crate::MockBackend;

--- a/crates/mvm-runtime/src/workload_backend.rs
+++ b/crates/mvm-runtime/src/workload_backend.rs
@@ -5,6 +5,7 @@
 use crate::backend::{AnyBackend, FirecrackerBackend};
 use crate::hvf_backend::HvfBackend;
 use crate::libkrun::LibkrunBackend;
+#[cfg(feature = "test-support")]
 use crate::mock::MockBackend;
 use anyhow::{Result, anyhow};
 use mvm_core::vm_backend::VmBackend;
@@ -75,6 +76,7 @@ impl WorkloadBackend for HvfBackend {
 // workload, so it stands in for a workload backend on the admitted path in
 // tests. `QemuBackend` (a real dev/test VMM) is deliberately NOT a
 // `WorkloadBackend`: it is the meaningful Tier-2 carve-out.
+#[cfg(feature = "test-support")]
 impl WorkloadBackend for MockBackend {
     fn egress_substitution_transport(&self) -> EgressSubstitutionTransport {
         EgressSubstitutionTransport::None
@@ -125,6 +127,7 @@ mod tests {
         assert_is_workload_backend::<FirecrackerBackend>();
         assert_is_workload_backend::<LibkrunBackend>();
         assert_is_workload_backend::<HvfBackend>();
+        #[cfg(feature = "test-support")]
         assert_is_workload_backend::<MockBackend>();
     }
 
@@ -156,6 +159,7 @@ mod tests {
     }
 
     #[test]
+    #[cfg(feature = "test-support")]
     fn mock_declares_none() {
         let transport = MockBackend::new().egress_substitution_transport();
         assert_eq!(transport, EgressSubstitutionTransport::None);
@@ -201,11 +205,16 @@ mod tests {
 
     #[test]
     fn transparent_egress_terminator_requirement_refuses_proxy_only_backends() {
+        #[cfg(feature = "test-support")]
         let mock = MockBackend::new();
-        for backend in [
+        #[cfg(feature = "test-support")]
+        let backends: Vec<&dyn WorkloadBackend> = vec![
             &HvfBackend as &dyn WorkloadBackend,
             &mock as &dyn WorkloadBackend,
-        ] {
+        ];
+        #[cfg(not(feature = "test-support"))]
+        let backends: Vec<&dyn WorkloadBackend> = vec![&HvfBackend as &dyn WorkloadBackend];
+        for backend in backends {
             let err = match require_transparent_egress_terminator(backend) {
                 Ok(()) => panic!("{} should not satisfy the terminator gate", backend.name()),
                 Err(e) => e,

--- a/tests/audit_emissions_live.rs
+++ b/tests/audit_emissions_live.rs
@@ -1022,6 +1022,7 @@ fn cleanup_emits_slot_prune_audit_entry_even_with_no_builds() {
 /// real Nix; `--hypervisor mock` routes backend dispatch to
 /// [`mvm_runtime::MockBackend`]; `-d` detaches; `--no-supervisor`
 /// skips plan-64 admission.
+#[cfg(feature = "test-support")]
 fn bring_up_mock_vm(sandbox: &AuditSandbox, name: &str) {
     let stub_dir = sandbox.home_path().join("stub");
     std::fs::create_dir_all(&stub_dir).expect("mkdir stub");
@@ -1068,6 +1069,7 @@ fn bring_up_mock_vm(sandbox: &AuditSandbox, name: &str) {
 /// follow-up commands would find a stale socket and fail to connect.
 /// Hosting the agent in the test process keeps it alive across every
 /// subprocess invocation for the duration of the test.
+#[cfg(feature = "test-support")]
 struct MockVmAgentFixture {
     _agent: mvm_runtime::mock_guest_agent::MockGuestAgent,
 }
@@ -1076,6 +1078,7 @@ struct MockVmAgentFixture {
 /// spawn a [`MockGuestAgent`](mvm_runtime::mock_guest_agent::MockGuestAgent)
 /// listening at `<vm_dir>/runtime/v.sock`. Returns when the listener
 /// is ready to accept connections.
+#[cfg(feature = "test-support")]
 fn start_mock_vm_agent(sandbox: &AuditSandbox, name: &str) -> MockVmAgentFixture {
     // The subprocess resolves mvm_home() from the MVM_HOME the sandbox
     // sets, so it computes the same path we compute here.
@@ -1087,6 +1090,7 @@ fn start_mock_vm_agent(sandbox: &AuditSandbox, name: &str) -> MockVmAgentFixture
 }
 
 #[test]
+#[cfg(feature = "test-support")]
 fn machine_run_with_mock_backend_emits_vm_start_audit_entry() {
     // End-to-end test of `mvmctl machine run` against the in-memory
     // `MockBackend`. Pre-MockBackend this row needed a real
@@ -1110,6 +1114,7 @@ fn machine_run_with_mock_backend_emits_vm_start_audit_entry() {
 }
 
 #[test]
+#[cfg(feature = "test-support")]
 fn set_ttl_emits_vm_ttl_set_audit_entry() {
     // `mvmctl set-ttl <vm> <duration>` operates on the persistent
     // name registry that `mvmctl up` populates. Bring up a mock
@@ -1146,6 +1151,7 @@ fn set_ttl_emits_vm_ttl_set_audit_entry() {
 }
 
 #[test]
+#[cfg(feature = "test-support")]
 fn set_ttl_clear_emits_vm_ttl_set_with_cleared_detail() {
     // Negative-shape complement: `set-ttl --clear` removes the
     // TTL and emits the same `vm_ttl_set` kind but with
@@ -1173,6 +1179,7 @@ fn set_ttl_clear_emits_vm_ttl_set_with_cleared_detail() {
 }
 
 #[test]
+#[cfg(feature = "test-support")]
 fn pause_emits_workload_sleep_audit_entry() {
     // Plan 65 W3: `mvmctl pause --hypervisor mock` exercises the
     // snapshot-and-seal path against `CannedIO` (deterministic
@@ -1211,6 +1218,7 @@ fn pause_emits_workload_sleep_audit_entry() {
 }
 
 #[test]
+#[cfg(feature = "test-support")]
 fn resume_emits_workload_wake_audit_entry() {
     // Plan 65 W3: pause-then-resume against the mock backend.
     // The seal-and-verify round-trip works because `CannedIO`
@@ -2214,6 +2222,7 @@ fn build_emits_template_build_audit_entry_against_stub_outdir() {
 // ============================================================================
 
 #[test]
+#[cfg(feature = "test-support")]
 fn fs_write_emits_vm_fs_mutate_audit_entry() {
     let sandbox = AuditSandbox::new();
     let _fixture = start_mock_vm_agent(&sandbox, "t-fsw");
@@ -2251,6 +2260,7 @@ fn fs_write_emits_vm_fs_mutate_audit_entry() {
 }
 
 #[test]
+#[cfg(feature = "test-support")]
 fn fs_mkdir_emits_vm_fs_mutate_audit_entry() {
     let sandbox = AuditSandbox::new();
     let _fixture = start_mock_vm_agent(&sandbox, "t-fsmk");
@@ -2279,6 +2289,7 @@ fn fs_mkdir_emits_vm_fs_mutate_audit_entry() {
 }
 
 #[test]
+#[cfg(feature = "test-support")]
 fn fs_rm_emits_vm_fs_mutate_audit_entry() {
     let sandbox = AuditSandbox::new();
     let _fixture = start_mock_vm_agent(&sandbox, "t-fsrm");
@@ -2307,6 +2318,7 @@ fn fs_rm_emits_vm_fs_mutate_audit_entry() {
 }
 
 #[test]
+#[cfg(feature = "test-support")]
 fn fs_mv_emits_vm_fs_mutate_audit_entry() {
     let sandbox = AuditSandbox::new();
     let _fixture = start_mock_vm_agent(&sandbox, "t-fsmv");
@@ -2335,6 +2347,7 @@ fn fs_mv_emits_vm_fs_mutate_audit_entry() {
 }
 
 #[test]
+#[cfg(feature = "test-support")]
 fn fs_ls_does_not_emit_mutation_audit_entry() {
     // Read-only: `fs ls` doesn't mutate state — must not emit
     // any *mutation-class* LocalAudit kind (`VmFsMutate`,
@@ -2377,6 +2390,7 @@ fn fs_ls_does_not_emit_mutation_audit_entry() {
 }
 
 #[test]
+#[cfg(feature = "test-support")]
 fn proc_start_emits_vm_proc_start_audit_entry() {
     let sandbox = AuditSandbox::new();
     let _fixture = start_mock_vm_agent(&sandbox, "t-ps");
@@ -2405,6 +2419,7 @@ fn proc_start_emits_vm_proc_start_audit_entry() {
 }
 
 #[test]
+#[cfg(feature = "test-support")]
 fn proc_signal_emits_vm_proc_signal_audit_entry() {
     let sandbox = AuditSandbox::new();
     let _fixture = start_mock_vm_agent(&sandbox, "t-psg");
@@ -2440,6 +2455,7 @@ fn proc_signal_emits_vm_proc_signal_audit_entry() {
 }
 
 #[test]
+#[cfg(feature = "test-support")]
 fn proc_kill_emits_kill_audit_entry() {
     let sandbox = AuditSandbox::new();
     let _fixture = start_mock_vm_agent(&sandbox, "t-pk");
@@ -2468,6 +2484,7 @@ fn proc_kill_emits_kill_audit_entry() {
 }
 
 #[test]
+#[cfg(feature = "test-support")]
 fn proc_stdin_emits_vm_proc_stdin_audit_entry() {
     let sandbox = AuditSandbox::new();
     let _fixture = start_mock_vm_agent(&sandbox, "t-pst");
@@ -2504,6 +2521,7 @@ fn proc_stdin_emits_vm_proc_stdin_audit_entry() {
 }
 
 #[test]
+#[cfg(feature = "test-support")]
 fn proc_ls_does_not_emit_mutation_audit_entry() {
     // Read-only: `proc ls` doesn't mutate process state — must
     // not emit any mutation-class LocalAudit kind. It *does*

--- a/xtask/src/check_two_surfaces.rs
+++ b/xtask/src/check_two_surfaces.rs
@@ -26,7 +26,7 @@ const SURFACES: [&str; 2] = ["host", "user"];
 /// forwards are inlined in the root Cargo.toml); what remains here is `default`
 /// plus platform/storage opt-ins that genuinely cannot always be on. Keep this
 /// list tiny — a new entry is a conscious "this cannot live in a surface".
-const INTERNAL: [&str; 5] = [
+const INTERNAL: [&str; 6] = [
     "default",
     // Platform: link the libkrun C VMM (absent on a macOS-26 HVF host).
     "libkrun-sys",
@@ -36,6 +36,9 @@ const INTERNAL: [&str; 5] = [
     // Lean library knob: mvm-core's gated hostd IPC transport, flipped through
     // the facade by a downstream host-side daemon without pulling all of `host`.
     "hostd-transport",
+    // Dev/test-only: the hermetic in-memory mock VM backend. Never part of a
+    // shipped binary; only this workspace's own test suite turns it on.
+    "test-support",
 ];
 
 /// A couple of release/build-only flags are allowed but explicitly *not* part of
@@ -254,6 +257,7 @@ dev = ["host", "user", "dev-watch"]
             "template-registry-s3",
             "hostd-transport",
             "release-artifact-bootstrap",
+            "test-support",
         ] {
             assert!(allowed.contains(f), "{f} must be classified");
         }


### PR DESCRIPTION
## WS8: gate the mock VM backend behind `test-support`

The `MockBackend` + `MockGuestAgent` (Tier-3, test-only — `AnyBackend::auto_select` never picks them; only an explicit `--hypervisor mock` does) were compiled into the default/production `mvmctl` closure. This gates them behind a new `test-support` Cargo feature so they no longer ship.

### What changed
- New `test-support` feature on `mvm-runtime`, forwarded through `mvm-client`, `mvm-cli`, and the root package; `mvm-hostd` pulls it via a `[dev-dependencies]` entry (its own tests need the mock unconditionally). Root feature classified `INTERNAL` in `check-two-surfaces`.
- Gated behind `#[cfg(feature = "test-support")]`: the `mock`/`mock_guest_agent` modules + re-exports, the `AnyBackend::Mock` variant and every dispatch match arm (via cfg'd arms + `mock_constructor`/`mock_variant_for_ssh_check` helpers — no `_ =>` catch-alls), the `WorkloadBackend for MockBackend` impl, the `--hypervisor mock` CLI fast-paths, and the mock-driven tests across `mvm-runtime`/`mvm-client`/`mvm-cli`/root.
- `"mock"` stays a **recognized** selector: a new `AnyBackend::require_hypervisor_selectable(name)` makes `--hypervisor mock` fail with a clear `the mock backend is only available in test-support builds` (verified live) instead of an "unknown backend" error or a panic.
- New CI lane `cargo nextest run --workspace --features test-support` so the ~30 gated mock tests stay covered.

### Left as-is (production-wired, not test-only)
`crates/mvm-runtime/src/base/shell/mock.rs` (`shell_mock`) — its `intercept()` is called unconditionally from the production `run_in_vm` exec paths (a cheap thread-local test-seam no-op). Genuinely load-bearing; untouched.

### Validation
Default build excludes the mock (`mvm-runtime` 895 vs 925 tests with the feature); `cargo nextest run --workspace` 7499 passed / with `--features test-support` 7526 passed; clippy clean both default and `--all-features`; nightly fmt clean; doctests pass; `check-two-surfaces` / `check-no-spec-refs` / `check-no-string-backend-dispatch` clean. Live smoke: `mvmctl machine pause … --hypervisor mock` errors cleanly on a default build and reaches the real mock path under `--features test-support`.
