### PR TITLE
docs(website): refresh guides/reference for the post-consolidation crates + CLI

### DIFF
--- a/public/src/content/docs/contributing/adding-an-arch-or-backend.md
+++ b/public/src/content/docs/contributing/adding-an-arch-or-backend.md
@@ -15,11 +15,11 @@ hunt down scattered `match` statements.
 |---|---|---|
 | Guest CPU architecture | `GuestArch` | `mvm_core::arch` |
 | Kernel artifact format | `KernelFormat` | `mvm_core::kernel_format` |
-| MicroVM backend identity | `MicrovmBackend` | `mvm_backend::compat` |
-| Rootfs format | `RootfsFormat` | `mvm_backend::compat` |
-| Capability matrix | `BackendCompat` + `compat()` | `mvm_backend::compat` |
+| MicroVM backend identity | `MicrovmBackend` | `mvm_runtime::compat` |
+| Rootfs format | `RootfsFormat` | `mvm_runtime::compat` |
+| Capability matrix | `BackendCompat` + `compat()` | `mvm_runtime::compat` |
 
-`mvm-core` holds only pure types (no runtime deps); `mvm-backend` owns backend
+`mvm-core` holds only pure types (no runtime deps); `mvm-runtime` owns backend
 identity and the capability table.
 
 ## Add a new architecture
@@ -33,14 +33,14 @@ identity and the capability table.
    `guest_arches` and add a `(GuestArch::Riscv64, &[…])` entry to
    `kernel_formats`.
 5. Add a test asserting alias normalization and that the relevant backends
-   accept it (`cargo test -p mvm-core arch::`, `cargo test -p mvm-backend compat::`).
+   accept it (`cargo test -p mvm-core arch::`, `cargo test -p mvm-runtime compat::`).
 
 That's it — `ArtifactValidator` and the config writers consume the table, so no
 other file changes.
 
 ## Add a new backend
 
-1. Add a variant to `MicrovmBackend` (`crates/mvm-backend/src/compat.rs`).
+1. Add a variant to `MicrovmBackend` (`crates/mvm-runtime/src/compat.rs`).
 2. Add a `static` `BackendCompat` row describing its real capabilities —
    `guest_arches`, per-arch `kernel_formats`, `rootfs_formats`,
    `required_boot_args`, `supports_snapshots`, `supports_jailer`, `networking` —
@@ -50,7 +50,7 @@ other file changes.
    `//` comment citing the source or stating the assumption. The model is allowed
    to *declare* requirements for a backend that has no runtime impl yet.
 3. (Optional, when you want config generation) add a `BackendConfigWriter` impl
-   under `crates/mvm-backend/src/artifacts/config/` and wire it into the
+   under `crates/mvm-runtime/src/artifacts/config/` and wire it into the
    `mvmctl artifact model-config --backend <name>` dispatch.
 4. Add accept/reject tests to `compat::tests`.
 
@@ -72,7 +72,7 @@ real-mode setup code *plus* a compressed payload — exactly the wrapper these V
 don't unwrap. An x86 backend needs the uncompressed ELF `vmlinux`, not the
 `bzImage`. The Nix image build is where this bites (it once copied
 `${kernel}/bzImage` to a file *named* `vmlinux`), so `sniff_kernel_format`
-(`crates/mvm-backend/src/artifacts/builders/nix.rs`) detects a stray bzImage by
+(`crates/mvm-runtime/src/artifacts/builders/nix.rs`) detects a stray bzImage by
 its setup-header magic `HdrS` at offset `0x202` and classifies it `Raw`.
 `Raw` isn't in any direct-boot backend's `kernel_formats`, so `ArtifactValidator`
 rejects it with a clear format error at build time — instead of the kernel

--- a/public/src/content/docs/contributing/development.md
+++ b/public/src/content/docs/contributing/development.md
@@ -12,13 +12,13 @@ description: Getting started as a contributor to mvm.
 
 ### Do I need to install libkrun?
 
-It depends on your machine. The builder VM (the Linux guest that runs
-`nix build` inside `mvmctl build` / `up` / `dev`) auto-selects its host
-VMM:
+It depends on your machine. The builder VM (the headless Linux guest that runs
+`nix build` inside `mvmctl build` / `mvmctl machine build` / `mvmctl machine
+run`) auto-selects its host VMM:
 
 | Host | libkrun (`slp/krun/*`) needed? |
 |---|---|
-| macOS 26+ Apple Silicon | **No** — auto-detect picks the **HVF** builder (Hypervisor.framework, ships with the OS, no Homebrew deps). `mvmctl dev up` only retries libkrun if the HVF path fails. |
+| macOS 26+ Apple Silicon | **No** — auto-detect picks the **HVF** builder (Hypervisor.framework, ships with the OS, no Homebrew deps); mvm transparently retries with libkrun if HVF fails to create its VM (ADR-093 auto-fallback). |
 | macOS 13–25 Apple Silicon | **Yes** — `brew install slp/krun/libkrun slp/krun/libkrunfw`. |
 | Linux + `/dev/kvm` | **No** — auto-detect picks the **QEMU** builder, so libkrun is not part of the default builder path on native Linux hosts. |
 
@@ -36,7 +36,7 @@ git clone https://github.com/tinylabscom/mvm.git
 cd mvm
 cargo build
 cargo run -- doctor     # reports the builder backend + anything missing
-cargo run -- dev        # auto-bootstrap + drop into the builder-VM shell
+cargo run -- bootstrap  # pre-fetch the builder VM image (optional — builds auto-bootstrap it)
 ```
 
 Or run the bootstrap script on a fresh machine:
@@ -58,8 +58,9 @@ just runtime-overlay-build
 # Run CLI
 just run -- --help
 
-# Dev mode (auto-bootstraps the dev VM + Firecracker)
-just run -- dev
+# Boot a throwaway workload — the (headless) builder VM auto-bootstraps
+# on first use, then the workload boots on the platform's default backend.
+just run -- machine run --image alpine -- uname -a
 
 # Release build (stripped, LTO)
 just release-build
@@ -76,15 +77,15 @@ The builder-VM and workload microVM kernels are slim custom Linux
 builds: one shared config in `nix/images/kernel/base.nix` plus a
 per-variant delta (`workload.nix` adds dm-verity; `builder.nix` adds
 the nix-build sandbox + egress-lockdown bits). Because the config is
-custom, `cache.nixos.org` has no substitute, so the first `dev up` on a
+custom, `cache.nixos.org` has no substitute, so the first build on a
 fresh machine compiles the kernel from source (3-10 min, memory-heavy).
 
 `mvmctl build kernel build` makes that compile explicit and one-time, so
-it stops hijacking your first `dev up`:
+it stops hijacking your first build:
 
 ```bash
 # Compile the builder kernel once into the cache + persistent nix store.
-# The next `dev up` reuses it (substituted, not rebuilt).
+# The next build reuses it (substituted, not rebuilt).
 just run -- build kernel build --which builder
 
 # Or both kernels:
@@ -96,7 +97,7 @@ VM on a published kernel (once a release has shipped one):
 
 ```bash
 # Build only the rootfs locally; fetch + hash-verify the kernel.
-just run -- --kernel-source download dev up
+just run -- --kernel-source download bootstrap
 # `auto` downloads if available, else compiles in-image (the default).
 ```
 
@@ -125,7 +126,7 @@ just run -- build kernel build --which workload
 
 # 2. Boot-smoke it — a kernel that builds isn't proof it boots. Boot a
 #    throwaway VM and confirm the in-guest agent answers over vsock.
-just run -- up --flake examples/sleeper --hypervisor libkrun --name smoke -d
+just run -- machine run --flake examples/sleeper --hypervisor libkrun --name smoke -d
 just run -- machine boot-report smoke   # "control plane  ready" == good
 just run -- machine stop smoke
 ```
@@ -183,7 +184,7 @@ just ci
 
 ### Gated E2E: the core-demo regression guard
 
-`crates/mvm-cli/tests/core_demo_e2e.rs` exercises the whole `dev up → compile → up → vsock ping` spine end-to-end. It boots the persistent builder VM, lowers `examples/python/hello-app/app.py` to a flake, builds + boots the workload microVM, and waits for the guest agent to answer over vsock. Default-skips so it doesn't fire on routine `cargo test` runs; gate is `MVM_E2E_SMOKE=1`:
+`crates/mvm-cli/tests/core_demo_e2e.rs` exercises the whole `bootstrap → compile → machine run → vsock ping` spine end-to-end. It boots the persistent builder VM, lowers `examples/python/hello-app/app.py` to a flake, builds + boots the workload microVM, and waits for the guest agent to answer over vsock. Default-skips so it doesn't fire on routine `cargo test` runs; gate is `MVM_E2E_SMOKE=1`:
 
 ```bash
 # Local run — requires libkrun + libkrunfw on pre-26 macOS, or
@@ -260,7 +261,7 @@ just run -- image fetch minimal     # build from catalog entry
 # Named dev networks
 just run -- network create isolated # create a named network
 just run -- network list            # list all networks
-just run -- up --flake .  # attach VM to a network
+just run -- machine run --flake .  # attach VM to a network
 
 # Interactive console (PTY-over-vsock, no SSH)
 just run -- console myvm            # interactive shell

--- a/public/src/content/docs/getting-started/first-microvm.md
+++ b/public/src/content/docs/getting-started/first-microvm.md
@@ -15,16 +15,16 @@ macOS 26+ (AS):    mvmctl machine run  -->  HVF microVM (Hypervisor.framework, v
 macOS 13-25 (AS):  mvmctl machine run  -->  libkrun microVM
 ```
 
-| Layer | Access command | Has your project files? |
-|-------|---------------|------------------------|
+| Layer | Access | Has your project files? |
+|-------|--------|--------------------------|
 | Host | Your normal terminal | Yes |
-| Dev VM (macOS) | `mvmctl dev` or `mvmctl dev shell` | Yes (~ mounted read/write) |
-| MicroVM | (headless, no SSH) | No (isolated filesystem) |
+| Builder VM (`--flake` builds only) | Headless — runs `nix build` on your behalf, no shell | Staged in for the build only |
+| MicroVM (workload) | `mvmctl machine console` (dev-tier images) or `mvmctl machine run -it` | Only what you explicitly `--mount` |
 
-MicroVMs are **headless workloads** with no SSH access -- they communicate via vsock only.
+MicroVMs are **headless workloads** with no SSH access -- they communicate via vsock only. The builder VM is headless too -- it auto-bootstraps the first time you run `mvmctl machine build` or `mvmctl machine run --flake ...`; `mvmctl bootstrap` pre-fetches its image ahead of time and `mvmctl doctor` reports the resolved builder backend.
 
 :::note
-On Linux with `/dev/kvm`, the dev-VM layer is skipped entirely -- Firecracker runs directly. On macOS Apple Silicon, microVMs run on the HVF backend (macOS 26+) or libkrun (macOS 13–25). There is no Docker or container runtime path.
+On Linux with `/dev/kvm`, workloads boot straight on Firecracker; a `--flake` build still routes `nix build` through the headless builder VM. On macOS Apple Silicon, workloads run on the HVF backend (macOS 26+) or libkrun (macOS 13–25). There is no Docker or container runtime path.
 :::
 
 ## Scaffold a project

--- a/public/src/content/docs/getting-started/happy-paths.md
+++ b/public/src/content/docs/getting-started/happy-paths.md
@@ -16,12 +16,12 @@ nothing more, nothing less.
 | [Python SDK user](#python-sdk) | `--workflow python-sdk` | Run a `@mvm.app()`-decorated Python script. |
 | [TypeScript / Node SDK user](#typescript-sdk) | `--workflow typescript-sdk` | Run an `mvm.app()` TypeScript app. |
 | [Prebuilt bundle operator](#bundle-run) | `--workflow bundle-run` | Launch a signed `.mvmpkg` artifact. |
-| [`mvmctl dev` user](#dev-shell) | `--workflow dev-shell` | Drop into a builder-VM shell for tinkering. |
+| [Interactive shell user](#dev-shell) | `--workflow dev-shell` | Boot a dev-tier image and drop into an interactive shell. |
 
 The preflight filter (plan 74 W5 / ADR-017 §1) only fails on missing
 prerequisites your workflow actually needs. A bundle operator no
-longer sees a "missing `cargo`" failure they don't care about; a
-`mvmctl dev` user no longer needs host rustup.
+longer sees a "missing `cargo`" failure they don't care about; an
+interactive-shell user no longer needs host rustup.
 
 ## <a id="cli-image-user"></a>CLI user with an OCI image
 
@@ -74,10 +74,10 @@ source checkout); subsequent runs reuse the warm builder. Skip the
 
 - `host nix not required` errors → none expected. mvm's builder VM
   owns Nix; the host doesn't need it.
-- `dev VM not running — run mvmctl dev up to verify` → that's just
-  doctor telling you tool checks were skipped because the builder
-  VM is asleep. It's not a failure; `mvmctl machine run` boots it on
-  demand.
+- `skipped — dev VM not running; run mvmctl bootstrap to verify` →
+  that's just doctor telling you tool checks were skipped because the
+  builder VM is asleep. It's not a failure; `mvmctl machine run` boots
+  it on demand.
 - `disk space < N GiB` → free space on `~/.mvm/` (default cache
   location); `mvmctl cache info` shows what's there.
 
@@ -155,31 +155,38 @@ remain.
   signed-plan path failed to find a matching `PlanArtifact`. Pull
   a fresh copy from the publisher.
 
-## <a id="dev-shell"></a>`mvmctl dev` user
+## <a id="dev-shell"></a>Interactive shell user
 
-You want a shell with a real Linux toolchain — for building, testing,
-or just exploring.
+You want a shell inside a microVM — for building, testing, or just
+exploring. There's no standalone dev VM to boot into anymore: the
+builder VM is headless (it only exists to run `nix build` on your
+behalf), so an interactive shell means booting a dev-tier *workload*
+and attaching your terminal to it.
 
 ```bash
 mvmctl doctor --workflow dev-shell              # preflight (no host rust needed)
-mvmctl dev                                      # boot + drop into shell
-# inside the shell: do work; exit / Ctrl+D returns you to the host
+mvmctl machine run --image alpine -it -- /bin/sh  # boot + drop into shell
+# inside the shell: do work; exit / Ctrl+D tears the VM down
 ```
 
-`mvmctl dev` auto-bootstraps the first time (downloads the dev image
-or builds it locally from `nix/images/dev-shell/`). Your project
-directory is bind-mounted at `/work`. Background services keep
-running after you exit; `mvmctl dev down` stops them.
+`machine run -it` boots a fresh transient microVM and is foreground-only
+— exiting the shell tears the VM down, the same as any other transient
+`machine run`. For a shell you can leave running and re-enter later, use
+a persistent machine instead: `mvmctl machine create --name devbox
+--image alpine`, then `mvmctl machine start devbox` and `mvmctl machine
+shell devbox`.
 
 **Failure recovery:**
 
-- `builder VM image missing` → `mvmctl dev up` downloads or builds
-  it. From a source checkout, the in-repo flakes are always
+- `skipped — dev VM not running; run mvmctl bootstrap to verify` →
+  only relevant when your source is `--flake` (an OCI `--image` run
+  pulls the image directly and never touches the builder VM);
+  `mvmctl bootstrap` pre-fetches the builder VM image, or builds it
+  locally from a source checkout where the in-repo flakes are always
   preferred over published artifacts.
-- `dev shell exited immediately with no command output` → check
-  `~/.mvm/dev/console.log` for the kernel/init transcript. Plan
-  72 W5.D documented the nine bring-up bugs that produced this
-  symptom; if you hit one of them the log names it.
+- Shell exits immediately with no output → `mvmctl machine logs
+  <name>` shows the kernel/init transcript; pass `--name` on the run
+  so you have a name to look it up by.
 
 ## See also
 

--- a/public/src/content/docs/getting-started/installation.md
+++ b/public/src/content/docs/getting-started/installation.md
@@ -133,7 +133,7 @@ mvmctl init
 
 This walks through platform detection, dependency installation (Firecracker on Linux; the `slp/krun` Homebrew trio for libkrun on macOS 13–25, nothing extra for the HVF backend on macOS 26+), default network setup, and XDG directory creation. Use `--non-interactive` for scripted environments.
 
-Running `mvmctl dev` or `mvmctl bootstrap` also handles setup automatically -- they detect your platform, select the backend, and stage the builder microVM image on first use.
+Running `mvmctl bootstrap` -- or simply your first `mvmctl machine build` / `mvmctl machine run --flake ...` -- also handles setup automatically: mvm detects your platform, selects the backend, and stages the builder microVM image on first use.
 
 You can force a specific backend with `--hypervisor`:
 

--- a/public/src/content/docs/getting-started/nix-for-mvm.mdx
+++ b/public/src/content/docs/getting-started/nix-for-mvm.mdx
@@ -197,7 +197,9 @@ mvm.lib.${system}.mkGuest {
 Search for packages at [search.nixos.org/packages](https://search.nixos.org/packages) or from the command line:
 
 ```bash
-# Inside the dev shell (mvmctl dev)
+# If you have Nix installed on your host (optional -- mvm's own build
+# path never needs it; see "host-side Nix for power users" in the
+# install guide)
 # Use 2>/dev/null to hide nixpkgs deprecation warnings
 nix search nixpkgs python 2>/dev/null
 nix search nixpkgs "node.*22" 2>/dev/null

--- a/public/src/content/docs/getting-started/quickstart.md
+++ b/public/src/content/docs/getting-started/quickstart.md
@@ -7,7 +7,7 @@ description: Get a microVM running in under 5 minutes.
 [First-Use Happy Paths](/getting-started/happy-paths/) lists a
 three-command sequence for each mvm audience: OCI-image CLI users,
 flake CLI users, Python SDK users, TypeScript SDK users, prebuilt bundle
-operators, and `mvmctl dev` users. Each path is paired with
+operators, and interactive-shell users. Each path is paired with
 `mvmctl doctor --workflow <name>` so the preflight only flags blockers
 your audience actually has.
 :::
@@ -24,8 +24,8 @@ This pulls or reuses the cached image, records OCI provenance, boots a transient
 microVM, runs the command, and tears the VM down. You do not need host Nix for
 this path.
 
-Use this when you want "run this command in a fresh microVM." Use the flake,
-manifest, and dev-shell flows below when you are building a custom image or a
+Use this when you want "run this command in a fresh microVM." Use the flake
+and manifest flows below when you are building a custom image or a
 repeatable project environment.
 
 For a scenario-led map of when to use each machine workflow, read
@@ -41,44 +41,48 @@ mvmctl machine exec alpine-dev -- uname -a
 mvmctl machine stop alpine-dev
 ```
 
-## 2. Launch the Dev Environment
+## 2. Prepare the Builder VM (optional)
 
 ```bash
-mvmctl dev
+mvmctl bootstrap
 ```
 
-This single command detects your platform and handles everything. **Builds run in a builder microVM that mvm sets up automatically — you don't need Nix on your host.** The builder owns its own `/nix/store` and keeps it warm across builds. Where the builder VM runs depends on your platform:
+`nix build` for a `--flake` source runs inside a **headless builder
+VM** — a build engine, not something you get a shell into. It
+auto-bootstraps the first time you run `mvmctl machine build` or
+`mvmctl machine run --flake ...`; `mvmctl bootstrap` pre-fetches it
+ahead of time so that first build isn't slowed by a cold-start fetch.
+**Builds run in a builder microVM that mvm sets up automatically — you
+don't need Nix on your host.** The builder owns its own `/nix/store`
+and keeps it warm across builds. Where the builder VM runs depends on
+your platform:
 
-**On Linux with `/dev/kvm`:**
-1. Selects Firecracker as the runtime backend
-2. Bootstraps the builder microVM on first build (one-time fetch); `nix build` runs inside it
-3. Drops you into a dev shell
-
-**On macOS 26+ Apple Silicon:**
-1. Selects the HVF backend (Hypervisor.framework, vsock-only, no Homebrew deps)
-2. Boots the builder microVM there; `nix build` runs inside it
-3. Drops you into a dev shell
-
-**On macOS 13–25 Apple Silicon:**
-1. Selects libkrun (the in-process VMM from the `slp/krun` Homebrew trio)
-2. Same builder microVM, hosted on libkrun
-3. Drops you into a dev shell
+- **Linux with `/dev/kvm`:** auto-selects the QEMU builder backend;
+  your built workloads boot on Firecracker.
+- **macOS 26+ Apple Silicon:** auto-selects the HVF builder backend
+  (Hypervisor.framework, vsock-only, no Homebrew deps), with an
+  automatic fallback to libkrun if HVF fails to create its VM.
+- **macOS 13–25 Apple Silicon:** auto-selects the libkrun builder
+  backend (the in-process VMM from the `slp/krun` Homebrew trio).
 
 mvm targets Apple Silicon on macOS and `/dev/kvm` on Linux. There is no Docker
 or container runtime path; a host without a supported microVM backend surfaces a
 backend-unavailable error rather than silently degrading.
 
-Inside the dev shell your project directory is bind-mounted at `/work`. Exit with `exit` or `Ctrl+D` -- background services keep running.
+`mvmctl doctor` reports the resolved builder backend and flags any missing
+host dependencies. For an interactive shell, boot a workload instead — see
+[Interactive Console](#7-interactive-console) below.
 
 :::note
-Release binaries download the builder image (~200MB) and dev microVM image on first run. From a source checkout, `mvmctl dev up` builds from the in-repo flakes.
+Release binaries download the builder image (~200MB) on first use. From a
+source checkout, the builder VM image is always built locally from the
+in-repo flakes.
 :::
 
 ## 3. Day-to-Day Commands
 
 ```bash
 mvmctl ls         # List running VMs (aliases: ps, status)
-mvmctl dev shell  # Open a shell in the dev microVM
 mvmctl machine stop --all       # Stop all running VMs
 mvmctl doctor     # Check system dependencies and configuration
 mvmctl machine console vm # Interactive shell into a running VM (PTY-over-vsock)

--- a/public/src/content/docs/guides/airgapped-bootstrap.md
+++ b/public/src/content/docs/guides/airgapped-bootstrap.md
@@ -5,155 +5,110 @@ description: How to run mvmctl in environments that can't reach github.com witho
 
 # Air-gapped Bootstrap
 
-mvmctl normally fetches its dev image (kernel + rootfs) and the
-project's [cosign-signed manifest](verify-release) from GitHub
-Releases. In regulated, government, or otherwise air-gapped
-environments where the host can't reach `github.com`, plan 36 ships
-a sanctioned trusted path: `mvmctl dev import-image` runs the same
-cosign signature + SHA-256 + version-pin + max-age + revocation
-verification pipeline against operator-provided local files.
+In regulated, government, or otherwise air-gapped environments where
+the host can't reach the network at all, the sanctioned path is a
+**signed portable bundle** (`.mvmpkg`): build or seal one on a
+connected host, then verify and launch it on the air-gapped host from
+local files only — no network access needed for that step.
 
-This is the *only* recommended way to run mvmctl in an air-gapped
-host. Setting `MVM_SKIP_HASH_VERIFY=1` to bypass the network fetch
-disables the supply-chain check entirely, which is exactly the
-unsafe escape this path exists to discourage.
+:::note[What changed]
+The former `mvmctl dev import-image` command — a local-file import
+path specifically for the dev/workload microVM image, verified against
+a cosign-signed manifest — was removed along with the standalone
+`mvmctl dev` command. Its would-be successor (the `dev-image` pack
+class) has no publish/fetch path wired yet: `mvmctl pack download
+--kind dev-image` refuses explicitly rather than pretending to work.
+Signed bundles are the current sanctioned air-gapped path for shipping
+a prebuilt workload; this guide describes that flow.
+:::
 
 ## What you need
 
-For your target architecture (`aarch64` or `x86_64`), four files
-from the GitHub release page:
-
-| File | Purpose |
-|------|---------|
-| `dev-image-{arch}.manifest.json` | Cosign-signed manifest — the trust anchor. Records SHA-256 of every other file. |
-| `dev-image-{arch}.manifest.json.bundle` | Cosign signature bundle for the manifest. |
-| `dev-vmlinux-{arch}` | Kernel binary. |
-| `dev-rootfs-{arch}.ext4` | Root filesystem. |
-
-All four come from the same release tag — they're a set. Mismatched
-manifest + artifacts will fail SHA-256 verification.
+A signed `.mvmpkg` bundle from a trusted publisher, plus that
+publisher's raw 32-byte Ed25519 public key (no PEM, no headers). The
+bundle carries its own manifest (per-artifact SHA-256, target arch,
+publisher `key_id`) and the artifact bytes in one archive — nothing
+else needs to cross the air gap for a single workload.
 
 ## Workflow
 
-### 1. Fetch the four files from a connected host
-
-On a host that can reach github.com:
+### 1. Enroll the publisher's key (once, on the air-gapped host)
 
 ```bash
-VERSION=v0.14.0  # match the mvmctl version that will consume them
-ARCH=aarch64     # or x86_64
-BASE="https://github.com/tinylabscom/mvm/releases/download/${VERSION}"
-
-for f in \
-  "dev-image-${ARCH}.manifest.json" \
-  "dev-image-${ARCH}.manifest.json.bundle" \
-  "dev-vmlinux-${ARCH}" \
-  "dev-rootfs-${ARCH}.ext4"
-do
-  curl -LO "${BASE}/${f}"
-done
+mvmctl trust add ./publisher.pub
+mvmctl trust list
 ```
 
-### 2. (Optional) Verify the manifest before transit
+This writes `~/.mvm/trusted-publishers/<key_id>.pub`. No network
+access required — the key file itself has to reach the host by some
+other channel (sneakernet, artifact mirror, USB).
 
-The connected host can verify the manifest now to catch
-manifest-only tampering before sneakernet:
-
-```bash
-cosign verify-blob \
-  --bundle "dev-image-${ARCH}.manifest.json.bundle" \
-  --certificate-oidc-issuer "https://token.actions.githubusercontent.com" \
-  --certificate-identity-regexp "https://github.com/tinylabscom/mvm/.github/workflows/release.yml@refs/tags/${VERSION}" \
-  "dev-image-${ARCH}.manifest.json"
-```
-
-Expect `Verified OK`. mvmctl re-runs this check during `import-image`,
-so this step is optional — it just gives you a fast-fail before
-transferring 200 MB of rootfs over a slow side channel.
-
-### 3. Transfer to the air-gapped host
+### 2. Transfer the bundle
 
 Sneakernet, internal artifact mirror, signed USB, scp through a jump
-host — whatever your environment allows. The four files must arrive
-together; any one being modified or replaced in transit will fail
-verification on import.
+host — whatever your environment allows.
 
-### 4. Import on the air-gapped host
+### 3. Verify before installing
 
 ```bash
-mvmctl dev import-image \
-  --manifest dev-image-aarch64.manifest.json \
-  --bundle   dev-image-aarch64.manifest.json.bundle \
-  --vmlinux  dev-vmlinux-aarch64 \
-  --rootfs   dev-rootfs-aarch64.ext4
+mvmctl bundle fetch ./my-app.mvmpkg
 ```
 
-mvmctl runs the full verification pipeline:
+`bundle fetch` accepts a local path (or an `https://` URL) and, for a
+local path, does no network I/O at all: it checks the manifest
+signature against the enrolled publisher's `key_id` in the local trust
+store, then re-verifies every artifact's SHA-256, and reports the
+parsed manifest. It rejects an unknown `key_id`, a tampered manifest,
+or a tampered artifact before anything is installed.
 
-1. Cosign-verify the manifest signature against the project's
-   release-workflow OIDC identity.
-2. Pin `manifest.version == mvmctl --version` exactly.
-3. Warn (don't fail) if the manifest is past its 90-day max-age.
-4. Check the revocation list (skipped if cached and offline; see
-   below).
-5. Verify each artifact's SHA-256 against the manifest's recorded
-   digests.
-6. Copy the verified bytes into `~/.mvm/dev/prebuilt/v{version}/`.
-
-On success, the next `mvmctl dev up` boots the dev VM from the
-imported artifacts without re-running verification or touching the
-network.
-
-## Revocation list in air-gapped environments
-
-The project's [revocation list](verify-release#recall-revocation-list)
-lives at a separate `revocations` release tag and tells mvmctl that
-specific versions have been recalled. mvmctl caches the list under
-`~/.mvm/cache/revocations/` and the cache policy is generous for
-offline tolerance:
-
-- Cache valid for **24 hours** before refresh.
-- **7 days** of cached staleness tolerated when the network is
-  unavailable.
-- A 404 on the upstream URL is treated as "no recalls today" — not
-  an error.
-
-For long-running air-gapped deployments, periodically transfer a
-fresh `revoked-versions.json` + `.bundle` pair into
-`~/.mvm/cache/revocations/`:
+### 4. Install and run
 
 ```bash
-# On a connected host:
-BASE="https://github.com/tinylabscom/mvm/releases/download/revocations"
-curl -LO "${BASE}/revoked-versions.json"
-curl -LO "${BASE}/revoked-versions.json.bundle"
-
-# Transfer both files, then on the air-gapped host:
-mkdir -p ~/.mvm/cache/revocations
-cp revoked-versions.json ~/.mvm/cache/revocations/
-cp revoked-versions.json.bundle ~/.mvm/cache/revocations/
-touch ~/.mvm/cache/revocations/revoked-versions.json
+mvmctl bundle install ./my-app.mvmpkg
+mvmctl manifest ls                        # find the installed slot (keyed by bundle sha256)
+mvmctl machine run --manifest <bundle-sha256>
 ```
 
-`mvmctl dev up` will read the cached file, cosign-verify it, and
-enforce any matching recall.
+`bundle install` re-runs the same verification as `fetch`, then
+atomically extracts the archive into `~/.mvm/bundles/<bundle_sha256>/`.
+
+The bundle trust model above — a local `key_id`-pinned Ed25519 trust
+store — is self-contained and carries no revocation list of its own.
+
+## Provisioning the builder VM
+
+A `--flake` source still needs the builder VM's Nix toolchain, which
+ships as its own release artifact (the "builder pack") under a
+separate cosign/OIDC-based keyless trust model. That model does
+consult a [revocation list](verify-release#recall-revocation-list) —
+mvmctl caches it under `~/.mvm/cache/revocations/`, valid for 24 hours
+before refresh and tolerated up to 7 days stale when the network is
+unavailable; a 404 on the upstream URL is treated as "no recalls
+today," not an error.
+
+On a connected host, fetch and verify the builder pack:
+
+```bash
+mvmctl pack download --kind builder    # fetch + verify, don't activate
+mvmctl pack update --kind builder      # fetch + verify + activate
+```
+
+Carrying the resulting cache into a fully air-gapped host isn't a wired
+CLI flow today. If your source is `--flake`, that means the builder
+pack currently has to be fetched from a host that can reach the
+network. Sources that don't need the builder VM at all — an OCI
+`--image`, or a sealed `.mvmpkg` bundle as above — remain fully
+air-gap-friendly once transferred.
 
 ## Failure modes
 
-`mvmctl dev import-image` fails closed. The most common errors and
-what they mean:
+`mvmctl bundle fetch` / `mvmctl bundle install` fail closed. The most
+common errors and what they mean:
 
 | Error wording | Cause | Fix |
 |--------------|-------|-----|
-| `Cosign verification failed for the imported manifest` | Manifest + bundle don't match, or manifest was tampered with after signing | Re-export both files together from the same release tag |
-| `Imported manifest is for a different mvmctl version` | manifest.version doesn't match `mvmctl --version` exactly | Use a manifest from the matching release; or upgrade mvmctl first |
-| `Manifest is for arch X but this host is Y` | Wrong arch | Re-export the manifest for your host arch |
-| `kernel SHA-256 mismatch` / `rootfs SHA-256 mismatch` | Artifact tampered or corrupted in transit | Re-transfer the full set; check transit medium |
-| `Imported manifest is on the project's revocation list` | The release was recalled | Use a non-revoked release |
-
-Every failure path bumps a Prometheus counter exposed via
-`mvmctl metrics --json` (and the `mvmctl status` JSON output). For
-fleet operators, plan 23 wires the same counters into mvmd's
-reconciliation loop so attack-shaped spikes — rapid
-`dev_image_verify_sig_invalid_total` increases across hosts, in
-particular — surface as alerts.
+| `trust store has no entry for key_id <id>` | The bundle's publisher key isn't enrolled on this host | `mvmctl trust add <pubkey>` for the correct publisher, or double-check you transferred the right key file |
+| `signature does not verify under trusted key <id>` | The manifest was tampered with after signing, or paired with the wrong signature | Re-export the bundle from the publisher; never hand-edit a `.mvmpkg` archive |
+| `artifact <name> sha256 mismatch` | Artifact bytes were tampered with or corrupted in transit | Re-transfer the bundle; check the transit medium |
+| `manifest references artifact <name> but it is missing from the archive` | Truncated or corrupted archive | Re-transfer the full `.mvmpkg` file |
+| `archive entry path is unsafe: ...` | Malicious or malformed archive contents | Get a fresh bundle from a trusted publisher |

--- a/public/src/content/docs/guides/builder-vm.md
+++ b/public/src/content/docs/guides/builder-vm.md
@@ -40,7 +40,7 @@ runtime microVM
 
 This separation is deliberate. A build can take seconds or minutes because it may fetch and compile Nix closures. A runtime boot benchmark should normally measure only the already-built image booting, not the build phase.
 
-## You Do Not Need a Dev Shell to Build
+## There Is No Shell Into The Builder VM
 
 The normal build command is:
 
@@ -50,20 +50,13 @@ mvmctl build --flake .
 
 That command should be run from your project directory on the host. `mvmctl` takes care of starting or reaching the builder VM, staging the flake, running the build, and copying the result back.
 
-Use an interactive shell only when you want to debug the builder environment:
+The builder VM is headless by design — there is no interactive shell into it, not even for debugging. You never "enter" it to inspect the Linux build environment, manually run `nix build`, or check Nix store disk usage; you debug through its logs and structured output instead:
 
-```bash
-mvmctl dev shell
-```
+- `mvmctl build --flake .` prints the build's own progress and errors.
+- `mvmctl doctor` reports the resolved builder backend and its readiness.
+- A failing `nix build` inside the builder VM surfaces its error back to the host command that triggered it — there's no separate shell session to reproduce it in.
 
-Examples of things a dev shell is useful for:
-
-- inspecting the Linux build environment;
-- manually running `nix build` to debug a flake error;
-- checking disk usage in the builder VM's Nix store;
-- reproducing an issue that only appears inside the Linux build boundary.
-
-Examples of things that should not require a dev shell:
+None of the following ever require or offer a shell into the builder VM:
 
 - `mvmctl build --flake .`;
 - `mvmctl run`;
@@ -115,14 +108,13 @@ The builder VM and runtime microVM have different jobs:
 
 Do not benchmark the builder VM when you want runtime boot time. The builder VM exists so that the host can ask for Linux builds without becoming a Linux build machine itself.
 
-## Persistent builder personas
+## Persistent builder VM
 
-There are two builder personas in the developer experience:
-
-| Persona | Command shape | Interaction model | Purpose |
-|---|---|---|---|
-| Developer builder VM | `cargo run -- dev up` / `mvmctl dev up` | Persistent and debuggable; may open an interactive shell with `--shell`. | Keep the Linux development/build boundary warm while a developer iterates. |
-| Build worker VM | `cargo run -- build` / `mvmctl build` | Persistent but non-interactive. | Run normal Nix/image build jobs without making the user manage the VM. |
+There is exactly one builder persona: a persistent, non-interactive build
+worker VM. It stays warm across builds (`cargo run -- build` / `mvmctl
+build`) so a developer iterating on a flake doesn't pay a builder-VM boot
+on every invocation. There is no separate "developer" persona with a
+shell — the builder VM is headless in every mode.
 
 The low-level persistent-builder controls already exist:
 
@@ -139,7 +131,7 @@ mvmctl persistent-builder stop
 mvmctl build --no-persistent-builder
 ```
 
-The intended top-level DX is that developers do not need to invoke the low-level controls for normal use. `dev up` should ensure the interactive/developer builder is present, and `build` should use a persistent non-interactive builder by default when the platform supports it. If the persistent path is unavailable, the command should say why it fell back rather than silently changing the trust and performance model.
+The intended top-level DX is that developers do not need to invoke the low-level controls for normal use: `mvmctl bootstrap` pre-fetches the builder VM image, and `build` uses a persistent non-interactive builder by default when the platform supports it. If the persistent path is unavailable, the command should say why it fell back rather than silently changing the trust and performance model.
 
 ## Communication Model
 
@@ -206,7 +198,7 @@ The builder VM keeps build state warm so repeated builds avoid re-fetching the w
 
 The first build is allowed to be slower because it may bootstrap the builder image and populate the Nix store. Later builds should be dominated by changed inputs.
 
-When `mvmctl` is running from this source checkout, the builder image is local-build only. A populated `~/.mvm/cache/builder-vm/<arch>/` cache can be reused only when its source fingerprint matches the current `nix/images/builder-vm/{flake.nix,flake.lock}` inputs, its recorded artifact digests still match the cached `vmlinux`, `rootfs.ext4`, and optional `cmdline.txt`, and its provenance summary matches the same source fingerprint and artifact filename set. On cache miss, fingerprint drift, artifact drift, or provenance drift, mvm uses a dev image that contains `/sbin/mvm-host-vm-init` as a Stage 0 bootstrap image to build `nix/images/builder-vm/` into a hidden staging directory, validates the kernel and rootfs, records the source fingerprint, artifact digests, and non-sensitive provenance summary, then promotes the staged output into the live cache. It prefers a local Stage 0 seed from `~/.mvm/dev/current/`, `~/.mvm/dev/prebuilt/v*/`, or `~/.mvm/dev/builds/*/`; if none of those images satisfies the Stage 0 contract, it may download the normal published dev image through the signed/hash-verified dev-image path and use it as the bootstrap seed only. It still refuses to download a published builder-VM image in a source checkout, so edits under `nix/images/builder-vm/` are built locally and are not masked by release artifacts. With `--verbose`, source-checkout cache decisions include a safe reason code such as `hit`, `missing_artifact`, `invalid_stage0_artifacts`, `missing_fingerprint`, `fingerprint_mismatch`, `missing_artifact_digest_manifest`, `artifact_digest_mismatch`, `missing_provenance`, or `provenance_mismatch`; these diagnostics do not print artifact contents, local paths, or raw digest metadata. `mvmctl dev status` also reports the builder-cache kind, readiness, and the same safe reason code without attempting a rebuild. `mvmctl dev cache inspect` exposes the same safe builder-cache summary plus dev-image presence, and `--json` emits only sanitized labels for automation.
+When `mvmctl` is running from this source checkout, the builder image is local-build only. A populated `~/.mvm/cache/builder-vm/<arch>/` cache can be reused only when its source fingerprint matches the current `nix/images/builder-vm/{flake.nix,flake.lock}` inputs, its recorded artifact digests still match the cached `vmlinux`, `rootfs.ext4`, and optional `cmdline.txt`, and its provenance summary matches the same source fingerprint and artifact filename set. On cache miss, fingerprint drift, artifact drift, or provenance drift, mvm uses a dev image that contains `/sbin/mvm-host-vm-init` as a Stage 0 bootstrap image to build `nix/images/builder-vm/` into a hidden staging directory, validates the kernel and rootfs, records the source fingerprint, artifact digests, and non-sensitive provenance summary, then promotes the staged output into the live cache. It prefers a local Stage 0 seed from `~/.mvm/dev/current/`, `~/.mvm/dev/prebuilt/v*/`, or `~/.mvm/dev/builds/*/`; if none of those images satisfies the Stage 0 contract, it may download the normal published dev image through the signed/hash-verified dev-image path and use it as the bootstrap seed only. It still refuses to download a published builder-VM image in a source checkout, so edits under `nix/images/builder-vm/` are built locally and are not masked by release artifacts. With `--verbose`, source-checkout cache decisions include a safe reason code such as `hit`, `missing_artifact`, `invalid_stage0_artifacts`, `missing_fingerprint`, `fingerprint_mismatch`, `missing_artifact_digest_manifest`, `artifact_digest_mismatch`, `missing_provenance`, or `provenance_mismatch`; these diagnostics do not print artifact contents, local paths, or raw digest metadata. `mvmctl doctor` reports the builder-cache readiness and the resolved builder backend without attempting a rebuild, and its `--json` output emits only sanitized labels for automation.
 
 ## Benchmarking Runtime Boot
 

--- a/public/src/content/docs/guides/building-microvm-images.md
+++ b/public/src/content/docs/guides/building-microvm-images.md
@@ -51,7 +51,7 @@ mvmctl build              # reads mvm.toml; builds the named flake target
 mvmctl run                # builds (if needed) + boots
 ```
 
-`mvmctl build` is a host command. You run it from macOS or Linux, and mvm sends the Linux-only Nix work into the builder VM. You do not need to enter `mvmctl dev shell` first. The shell is for debugging the build environment manually, not a prerequisite for normal builds.
+`mvmctl build` is a host command. You run it from macOS or Linux, and mvm sends the Linux-only Nix work into the builder VM. The builder VM is headless — there is no shell into it, not even for debugging; you never need one before or during a normal build.
 
 `mvmctl` selects the runtime backend automatically when you boot the finished image. Use `--hypervisor` on runtime commands when you want to force a specific runtime backend:
 
@@ -114,7 +114,7 @@ Independent of the sealed/accessible distinction, mvm exposes two **runtime life
 
 | Mode | What it means | When to use |
 |---|---|---|
-| `attached` | VM lifecycle bound to the calling process — Ctrl-C / process exit sends SIGTERM to the VM. | `mvmctl run` interactive, `mvmctl dev` shell sessions, test harnesses that want deterministic teardown. |
+| `attached` | VM lifecycle bound to the calling process — Ctrl-C / process exit sends SIGTERM to the VM. | `mvmctl run` interactive, `mvmctl machine run -it` shell sessions, test harnesses that want deterministic teardown. |
 | `detached` | VM survives caller exit — only `mvmctl machine stop` (or `VmBackend::stop`) terminates it. | `mvmctl machine run` (background), production agents, CI fixtures that boot once and run multiple phases. |
 
 The default is `detached`. Override:

--- a/public/src/content/docs/guides/dev-image.md
+++ b/public/src/content/docs/guides/dev-image.md
@@ -1,13 +1,13 @@
 ---
 title: Dev Image
-description: How `mvmctl dev` boots a development microVM, the default image that ships with mvm, and how to write your own.
+description: How to boot a development microVM with an interactive shell, the fastest zero-config path to one, and how to write your own.
 ---
 
-A **dev image** is a microVM image whose entrypoint is an interactive shell — what `mvmctl dev` boots when you want a sandboxed shell for build/test/exploration. It's just an `mkGuest` call with `entrypoint.shell` set; the same library, the same flake shape, the same builder pipeline as any other mvm image.
+A **dev image** is a microVM image whose entrypoint is an interactive shell — what you boot when you want a sandboxed shell for build/test/exploration. It's just an `mkGuest` call with `entrypoint.shell` set; the same library, the same flake shape, the same builder pipeline as any other mvm image. There's no separate "dev VM" command anymore: a dev image is a workload like any other, booted through `mvmctl machine`.
 
 There are two paths:
 
-1. **Use the default dev image that ships with mvm** — zero config, run `mvmctl dev up` and you're in a shell. Good for "I just want a sandboxed Linux shell to poke around in." See [The default dev image](#the-default-dev-image) below.
+1. **Boot a shell with zero config** — no flake needed: `mvmctl machine run --image alpine -it -- /bin/sh`. Good for "I just want a sandboxed Linux shell to poke around in." See [The fastest path](#the-fastest-path) below.
 2. **Write your own dev image** — declare it in your project's flake using `mvm.lib.<system>.mkGuest`. Adds your packages, your services, your config. The mvm repository's internals stay untouched — you're a consumer of the library, not a fork. See [Writing your own dev image](#writing-your-own-dev-image) below.
 
 Per [ADR-030](https://github.com/tinylabscom/mvm/blob/main/specs/adrs/030-libkrun-pivot.md), the dev/prod distinction is encoded in the entrypoint shape (`shell` → accessible, `command`/`services` → sealed). The same `mvm.lib.<system>.mkGuest` API serves both.
@@ -36,7 +36,7 @@ A dev image is just an mkGuest call with `entrypoint.shell` set. Your project's 
           entrypoint.command = [ "/usr/local/bin/serve" ];
         };
 
-        # Dev image — what `mvmctl dev up` builds.
+        # Dev image — what `mvmctl machine create` + `start` below builds.
         dev = mvm.lib.${system}.mkGuest {
           name = "my-app-dev";
 
@@ -73,9 +73,11 @@ memory_mib = 1024
 Then:
 
 ```sh
-mvmctl dev up         # builds the .dev output, boots it, drops you into the shell
-mvmctl dev down       # stop the dev VM
-mvmctl machine console        # reattach to the running shell
+mvmctl machine create --name my-app-dev   # reads mvm.toml (profile = "dev") from cwd
+mvmctl machine start my-app-dev           # builds the .dev output, boots it
+mvmctl machine console my-app-dev         # attach the interactive shell
+# Ctrl-D / exit detaches — the machine and any background services keep running.
+mvmctl machine stop my-app-dev            # tear it down
 ```
 
 You **never edit anything inside the mvm repository** to customize your dev image. Your project owns its dev image; mvm is the library.
@@ -117,13 +119,17 @@ dev = mvm.lib.${system}.mkGuest {
 
 See [Building MicroVM Images](/guides/building-microvm-images#sealed-vs-accessible--the-same-flake-works-for-both) for the full sealed/accessible matrix.
 
-## The default dev image
+## The fastest path
 
-If your project doesn't declare a `.dev` flake output, `mvmctl dev up` falls back to the default image that ships with mvm — a minimal busybox rootfs with a shell entrypoint. It exists so you can run `mvmctl dev up` with zero config and get something useful.
+For "I just want a shell," skip the flake entirely:
 
-The default image is **not** a starter template — don't fork it. It's there for the "I just want a shell" case. Once you have specific package or service requirements, switch to writing your own per the section above.
+```sh
+mvmctl machine run --image alpine -it -- /bin/sh
+```
 
-(Internally the default lives at the workspace's `nix/profiles/minimal.nix` — but that file is a test fixture, not a user-facing entry point. The library's `mvm.lib.<system>.mkGuest` is what you should be calling.)
+This pulls (or reuses the cached) `alpine` OCI image, boots a transient microVM, and attaches your terminal to `/bin/sh` inside it. Exiting the shell tears the VM down — the same lifecycle as any other transient `machine run`. No `flake.nix`, no `mvm.toml`, no host Nix.
+
+Once you have specific package or service requirements — beyond what an off-the-shelf OCI image gives you — switch to writing your own dev image per the section above.
 
 ## Building the dev image locally
 
@@ -141,7 +147,7 @@ nix eval .#dev.passthru.mvm
 # { accessible = true; entrypointKind = "shell"; expectedBootMs = 300; ... }
 ```
 
-`mvmctl dev up` runs the same `nix build` under the hood and boots the result.
+`mvmctl machine start` (against a manifest with `profile = "dev"`) runs the same `nix build` under the hood and boots the result.
 
 ### Cross-platform build notes
 
@@ -159,7 +165,7 @@ The current shape:
 
 - mvm exposes `mvm.lib.<system>.mkGuest` — a stable function the library promises not to break.
 - Your project's flake calls `mkGuest` and exports a `.dev` package.
-- `mvmctl dev` reads `mvm.toml`, runs `nix build .#dev` against your flake, boots the result.
+- `mvmctl machine start` reads `mvm.toml`, runs `nix build .#dev` against your flake, and boots the result.
 - mvm's internal layout (where `mkGuest` lives, what tests use it, etc.) can change freely without your project noticing.
 
 [Building MicroVM Images](/guides/building-microvm-images) covers the same model for production (sealed) images. The dev case is the same library with `entrypoint.shell` set.

--- a/public/src/content/docs/guides/exec.md
+++ b/public/src/content/docs/guides/exec.md
@@ -205,7 +205,7 @@ highest):
 ## Limits
 
 - **Dev-mode only.** `mvmctl machine run` requires a guest agent built with the
-  `dev-shell` Cargo feature, which is the default for the dev images
+  `interactive` Cargo feature, which is the default for the dev images
   `mvmctl` ships with. Production guest images omit the feature and the
   Exec handler is physically absent from the binary.
 - **Network access.** The guest gets the same network configuration

--- a/public/src/content/docs/guides/ir-to-image.mdx
+++ b/public/src/content/docs/guides/ir-to-image.mdx
@@ -259,7 +259,7 @@ What it provides:
 
 - **Firecracker kernel** (`vmlinux`)
 - **Busybox-as-PID-1 init** — under-5-second cold boot, no systemd
-- **Guest agent** — Rust binary built from `mvm-src`, communicates over vsock (ADR-001 W4.1, W6.1.2). In production builds, the `do_exec` symbol is gated out of the agent (CI claim 4); the `dev-shell` feature flag enables it for dev images only.
+- **Guest agent** — Rust binary built from `mvm-src`, communicates over vsock (ADR-001 W4.1, W6.1.2). In production builds, the `do_exec` symbol is gated out of the agent (CI claim 4); the `interactive` feature flag enables it for dev images only.
 - **Networking** — `eth0` configured via kernel boot args, NAT to host
 - **Privilege model** — PID 1 runs as uid 0 (kernel requirement); the entrypoint and agent run rootless (uid 1000 in prod, uid 0 in dev for the dev shell)
 - **Hardening** — `setpriv --no-new-privs` (W2.3), seccomp `standard` (W2.4), per-service uids (W2.1), read-only `/etc` overlay (W2.2), dm-verity verified boot (W3)
@@ -560,7 +560,7 @@ Once the rootfs is booted and the agent is up, a function call is just a vsock R
 host (mvmctl machine run --entrypoint --flake <dir>, stdin=[[], {"name": "Alice"}])
      │
      ▼  vsock: RunEntrypoint { stdin = encoded([args, kwargs]) }
-agent (uid 990, dev_image: do_exec gated by `dev-shell` feature)
+agent (uid 990, dev_image: do_exec gated by `interactive` feature)
      │
      ▼  fork+exec /etc/mvm/entrypoint → /usr/lib/mvm/wrappers/runner
 wrapper (cold: per-call process; warm: per-pool process)
@@ -618,13 +618,13 @@ The IR hash isn't decorative — it's load-bearing in the admission path.
 
 The admission profile is the security-posture binding. It records the declared intent, selected seccomp tier, network/filesystem/egress/tool policy refs, secret-release posture, and audit taxonomy. It is deliberately not a new runtime engine: seccomp is still enforced by the guest manifest, network and tool policies are still enforced by their existing resolvers. The profile makes those choices signed and auditable.
 
-**Audit emissions** (`crates/mvm-supervisor/src/audit_recorder.rs`):
+**Audit emissions** (`crates/mvm-hostd/src/supervisor/audit_recorder.rs`):
 
 - `plan.admitted` — admission accepted, chain-signed
 - `plan.launched` — backend dispatch succeeded
 - `plan.failed` — admission rejected, with reason
 
-All three reference `(plan_id, plan_version)`, the IR hash, and admission labels such as `intent`, `admission_profile`, and `seccomp_tier`. The log is hash-chained: entry N includes the hash of entry N-1. Tampering breaks `mvm_supervisor::verify_audit_chain`, which `mvmctl audit verify` surfaces as a nonzero exit.
+All three reference `(plan_id, plan_version)`, the IR hash, and admission labels such as `intent`, `admission_profile`, and `seccomp_tier`. The log is hash-chained: entry N includes the hash of entry N-1. Tampering breaks `mvm_hostd::supervisor::verify_audit_chain`, which `mvmctl audit verify` surfaces as a nonzero exit.
 
 The contract: **every workload mvm runs is launched from a signed ExecutionPlan that names a specific IR hash**. No IR hash, no launch.
 

--- a/public/src/content/docs/guides/macos-sandbox-debugging.md
+++ b/public/src/content/docs/guides/macos-sandbox-debugging.md
@@ -14,10 +14,9 @@ macOS is a supported local development target. Linux-specific build and runtime 
 ## Useful commands
 
 ```sh
-mvmctl dev status
 mvmctl doctor
 mvmctl machine logs <name>
-mvmctl boot-report <name>
+mvmctl machine boot-report <name>
 ```
 
 When debugging runtime behavior, name the backend and platform in bug reports.

--- a/public/src/content/docs/guides/troubleshooting.md
+++ b/public/src/content/docs/guides/troubleshooting.md
@@ -3,33 +3,31 @@ title: Troubleshooting
 description: Common issues and their solutions.
 ---
 
-## Builder VM and Dev Shell Issues
+## Builder VM Issues
 
-The builder VM is the Linux environment mvmctl uses for Nix evaluation and image builds. You normally do not enter it yourself: `mvmctl build --flake .` is a host command that stages work for the builder VM and copies artifacts back to the host cache. `mvmctl dev shell` is only for manual debugging. See [Builder VM](/guides/builder-vm/) for the full model.
+The builder VM is the Linux environment mvmctl uses for Nix evaluation and image builds. It is headless — you never enter it, not even for debugging: `mvmctl build --flake .` is a host command that stages work for the builder VM and copies artifacts back to the host cache, streaming the build's own output to your terminal. See [Builder VM](/guides/builder-vm/) for the full model.
 
-### "Dev VM is not running"
+### "skipped — dev VM not running"
 
 ```
-Error: Dev VM is not running. Start it with: mvmctl dev up
+skipped — dev VM not running; run `mvmctl bootstrap` to verify
 ```
 
-**Fix**: `mvmctl dev up` (idempotent — installs Firecracker if missing, no-ops otherwise).
+This is `mvmctl doctor` telling you a check was skipped because the builder VM is asleep, not a failure — it boots on demand.
 
-### Dev VM is stuck
+**Fix**: `mvmctl bootstrap` (idempotent — pre-fetches or builds the builder VM image, no-ops if it's already warm).
+
+### Builder VM store is stuck or degraded
 
 ```bash
-mvmctl dev down
-mvmctl dev up
+mvmctl cache repair
 ```
 
-If that fails, rebuild from scratch:
-```bash
-mvmctl dev rebuild
-```
+This clears `~/.mvm/cache/builder-vm/` so the next `mvmctl bootstrap`/`mvmctl build` cold-rebuilds it. Use it for a dangling-store error such as `error: path '/nix/store/…-source/flake.nix' does not exist`.
 
 Or for a full reset:
 ```bash
-mvmctl uninstall
+mvmctl env uninstall
 mvmctl bootstrap
 ```
 
@@ -47,9 +45,9 @@ mvmctl doctor
 ```
 
 - **Daemon absent / socket not answering**: the builder VM may not be up. Run
-  `mvmctl dev up`, then re-check `mvmctl doctor`.
-- **Still not ready after `dev up`**: recycle the builder VM with `mvmctl dev
-  down && mvmctl dev up`; if it persists, `mvmctl dev rebuild`.
+  `mvmctl bootstrap`, then re-check `mvmctl doctor`.
+- **Still not ready after `bootstrap`**: repair the builder store with
+  `mvmctl cache repair`, then `mvmctl bootstrap` again.
 
 A build job can be cancelled from the host; the daemon stops the in-flight
 operation and returns a cancellation result rather than leaving a wedged build.
@@ -69,10 +67,10 @@ isolation) can panic in the libkrun guest during virtio device activation,
 before userspace. The Stage 0 device topology is identical to a warm build, so
 this is not a device-count problem; it surfaces in the upstream VMM's
 device-activation path under the bundled Stage 0 kernel. It does **not** occur on
-a normal cold `mvmctl dev up` against the default cache.
+a normal cold `mvmctl bootstrap` against the default cache.
 
 **Fix**: Don't run a builder bootstrap against a fully-isolated empty cache. Use
-the default cache, or pre-warm the builder once (`mvmctl dev up` with the default
+the default cache, or pre-warm the builder once (`mvmctl bootstrap` with the default
 cache) before pointing a test at an isolated `MVM_HOME`. Isolated roots
 seed the builder VM image and runtime overlay opportunistically from the
 default `~/.mvm/cache`, so a pre-warmed default cache keeps isolated runs
@@ -95,11 +93,9 @@ mvmctl machine logs <name> --hypervisor   # Firecracker logs
 
 **Cause**: Insufficient permissions or TAP device name collision.
 
-**Fix**:
-```bash
-# Check for orphaned TAP devices (inside the dev VM)
-mvmctl dev shell -- ip link show | grep tap
-```
+**Fix**: There's no shell into the builder VM to inspect this directly.
+Check `mvmctl doctor` for the resolved network backend, and
+`mvmctl machine logs <name>` for the failing VM's own boot output.
 
 ### Instance won't start after sleep
 
@@ -116,12 +112,9 @@ mvmctl machine run --flake <project-dir> --name <name> -d
 ### Nix build fails
 
 ```bash
-# Re-run the normal host-orchestrated build.
-mvmctl build --flake .
-
-# If you need an interactive Linux debug environment:
-mvmctl dev shell
-nix build .#default
+# Re-run the normal host-orchestrated build; the error streams back
+# from the builder VM the same way as the first attempt.
+mvmctl build --flake . -vv
 ```
 
 ### "Cache miss" rebuilds
@@ -155,9 +148,9 @@ error: No space left on device
 # Check Nix store size (mvmctl doctor warns if >20 GiB)
 mvmctl doctor
 
-# For manual cleanup inside a debug shell:
-mvmctl dev shell
-nix-collect-garbage -d
+# Remove old build artifacts and run Nix garbage collection
+# inside the builder VM (no shell needed):
+mvmctl env cleanup
 ```
 
 ### Hash mismatch (fixed-output derivation)
@@ -284,26 +277,31 @@ mvmctl machine stop  <N>          # tear it down (prompts; add --yes to skip)
 
 ### MicroVM has no internet
 
-```bash
-# Inside the dev VM, check NAT rules
-mvmctl dev shell -- sudo iptables -t nat -L
+There's no shell into the builder VM to inspect NAT/TAP state directly.
+Start from the network policy the VM was launched with:
 
-# Check the TAP device exists
-mvmctl dev shell -- ip link show tap0
+```bash
+mvmctl doctor              # resolved network backend (gvproxy/passt/native)
+mvmctl machine logs <name>  # guest-side boot + networking errors
 ```
+
+Remember networking is deny-by-default: a transient `machine run` needs
+`--net` or `--allow-host` before outbound traffic works at all.
 
 ### Can't access project files inside microVM
 
-The Firecracker microVM has an **isolated filesystem**. Use `mvmctl dev shell` to access the dev VM where your home directory is mounted, or pass host shares with `--mount`.
+The Firecracker microVM has an **isolated filesystem** and there's no shell into the builder VM to bridge it. Pass host shares explicitly with `--mount HOST:GUEST[:rw]` (see [Sandboxed Exec](/guides/exec/)).
 
 ## Performance Issues
 
-### Dev VM is slow
+### Builder VM is slow
 
-Adjust resources (or persist the override with `mvmctl config set dev_vm_cpus 8 && mvmctl config set dev_vm_mem_gib 16`):
+Persist a resource override, then re-provision it:
 ```bash
-mvmctl dev down
-mvmctl dev up --cpus 8 --memory 16
+mvmctl ops config set dev_vm_cpus 8
+mvmctl ops config set dev_vm_mem_gib 16
+mvmctl cache repair
+mvmctl bootstrap
 ```
 
 ### Wrong backend selected
@@ -378,9 +376,13 @@ RUST_LOG=debug mvmctl <command>
 RUST_LOG=mvm=trace mvmctl <command>
 ```
 
-## Dev Image Signature Verification (plan 36)
+## Builder Pack Signature Verification
 
-### "Cosign verification failed for {variant}-image-{arch}.manifest.json"
+The builder VM image ships as a release artifact (the "builder pack") under
+the same cosign-signed-manifest + SHA-256 + revocation model that used to
+also cover the now-removed dev-image fetch path.
+
+### "Cosign verification failed for builder-vm-{arch}.manifest.json"
 
 The cosign-signed manifest didn't validate against the project's release-workflow OIDC identity. Treat this as a supply-chain incident until proven otherwise.
 
@@ -391,10 +393,10 @@ Triage in this order:
 3. **Verify with the cosign CLI** to localize the failure:
    ```bash
    cosign verify-blob \
-     --bundle dev-image-aarch64.manifest.json.bundle \
+     --bundle builder-vm-aarch64.manifest.json.bundle \
      --certificate-oidc-issuer "https://token.actions.githubusercontent.com" \
      --certificate-identity-regexp "https://github.com/tinylabscom/mvm/.github/workflows/release.yml@refs/tags/v0.14.0" \
-     dev-image-aarch64.manifest.json
+     builder-vm-aarch64.manifest.json
    ```
    Same identity wording mvmctl uses internally.
 4. **Open a security issue** if the signature is genuinely invalid against the official identity. Don't ship a workaround locally.
@@ -403,15 +405,15 @@ Emergency rotation when Sigstore TUF/Rekor is unavailable: `MVM_SKIP_COSIGN_VERI
 
 ### "Manifest is for v0.14.1 but mvmctl is v0.14.0"
 
-Plan 36 pins `manifest.version` to `mvmctl --version` exactly. Either:
+The manifest pins `manifest.version` to `mvmctl --version` exactly. Either:
 - Upgrade `mvmctl` to match (`brew upgrade mvmctl` / `cargo install mvmctl`); or
 - Use a manifest from the matching release (re-export from the v0.14.0 release page).
 
-### "Integrity check failed for dev-rootfs-aarch64.ext4"
+### "Integrity check failed for rootfs.ext4"
 
 SHA-256 of the downloaded artifact doesn't match the manifest's recorded digest. Possible causes, in order:
 
-1. Mid-flight corruption — retry `mvmctl dev up` to re-download.
+1. Mid-flight corruption — retry with `mvmctl bootstrap` (or `mvmctl pack download --kind builder`) to re-download.
 2. Mirror/CDN cache poisoning — rare but real; open a security issue with the SHA-256 you got vs what the manifest says.
 3. The release was re-uploaded after the manifest was signed (publishing process bug) — wait for the next tag.
 

--- a/public/src/content/docs/guides/verify-release.md
+++ b/public/src/content/docs/guides/verify-release.md
@@ -178,41 +178,44 @@ A compromised CDN or GitHub Releases page cannot forge a valid signature without
 
 ---
 
-## Verifying the Dev Image and Builder Image Manifests (plan 36)
+## Verifying the Builder Image Manifest
 
-Starting with the plan-36 work, every release also publishes a cosign-keyless-signed manifest for the dev image (consumed by `mvmctl dev up`) and the builder image (consumed by mvmd's pool-build pipeline). The manifest is the trust anchor — it carries SHA-256 of every image artifact, the Nix store hash, the source git SHA, and the SHA-256 of every flake lockfile, all bound by one cosign signature.
+Every release also publishes a cosign-keyless-signed manifest for the builder image (consumed by `mvmctl bootstrap` / `mvmctl pack download --kind builder` and mvmd's pool-build pipeline). The manifest is the trust anchor — it carries SHA-256 of every image artifact, the Nix store hash, the source git SHA, and the SHA-256 of every flake lockfile, all bound by one cosign signature.
 
-mvmctl verifies these automatically on every `mvmctl dev up`. To verify manually:
+mvmctl verifies this automatically on every builder-pack fetch (`mvmctl bootstrap`, or the first `machine build` / `machine run --flake ...` that needs the builder VM). To verify manually:
 
 ```bash
 VERSION=v0.14.0  # replace with the release you're verifying
 ARCH=aarch64     # or x86_64
-VARIANT=dev      # or builder
 
-curl -LO "https://github.com/tinylabscom/mvm/releases/download/${VERSION}/${VARIANT}-image-${ARCH}.manifest.json"
-curl -LO "https://github.com/tinylabscom/mvm/releases/download/${VERSION}/${VARIANT}-image-${ARCH}.manifest.json.bundle"
+curl -LO "https://github.com/tinylabscom/mvm/releases/download/${VERSION}/builder-vm-${ARCH}.pack-manifest.json"
+curl -LO "https://github.com/tinylabscom/mvm/releases/download/${VERSION}/builder-vm-${ARCH}.pack-manifest.json.bundle"
 
 cosign verify-blob \
-  --bundle "${VARIANT}-image-${ARCH}.manifest.json.bundle" \
+  --bundle "builder-vm-${ARCH}.pack-manifest.json.bundle" \
   --certificate-oidc-issuer "https://token.actions.githubusercontent.com" \
   --certificate-identity-regexp "https://github.com/tinylabscom/mvm/.github/workflows/release.yml@refs/tags/${VERSION}" \
-  "${VARIANT}-image-${ARCH}.manifest.json"
+  "builder-vm-${ARCH}.pack-manifest.json"
 ```
 
 A successful verification prints `Verified OK`. After verification, every artifact whose SHA-256 is recorded in the manifest can be checked with `sha256sum` and the manifest's value:
 
 ```bash
-jq -r '.artifacts[] | "\(.sha256)  \(.name)"' "${VARIANT}-image-${ARCH}.manifest.json" \
+jq -r '.artifacts[] | "\(.sha256)  \(.name)"' "builder-vm-${ARCH}.pack-manifest.json" \
   | sha256sum --check
 ```
 
-### Air-gapped install
-
-`mvmctl dev import-image` runs the same verification against local files for hosts that can't reach github.com. See [Air-gapped Bootstrap](airgapped-bootstrap) for the operator workflow.
+:::note[What changed]
+This section used to also cover a dev-image variant, verified locally via
+`mvmctl dev import-image`. That command was removed along with `mvmctl dev`;
+the dev-image pack class has no publish/fetch path today. See
+[Air-gapped Bootstrap](airgapped-bootstrap) for the current air-gapped path
+(signed `.mvmpkg` bundles).
+:::
 
 ### Recall (revocation list)
 
-A separate `revocations` release tag publishes a cosign-signed `revoked-versions.json`. mvmctl checks this list on every `dev up` and refuses to use any image whose version is recalled. The recall reason is surfaced verbatim in the failure message, pointing at the upgrade path.
+A separate `revocations` release tag publishes a cosign-signed `revoked-versions.json`. mvmctl checks this list on every builder-pack fetch and refuses to use any image whose version is recalled. The recall reason is surfaced verbatim in the failure message, pointing at the upgrade path.
 
 ```bash
 curl -LO "https://github.com/tinylabscom/mvm/releases/download/revocations/revoked-versions.json"

--- a/public/src/content/docs/install/linux.md
+++ b/public/src/content/docs/install/linux.md
@@ -42,7 +42,7 @@ MVM_VERSION=v0.16.1 curl -fsSL https://raw.githubusercontent.com/tinylabscom/mvm
 git clone https://github.com/tinylabscom/mvm.git
 cd mvm
 cargo build --release --bin mvmctl
-cargo build --release -p mvm-vm-host --bin mvm-bridge
+cargo build --release -p mvm-hostd --bin mvm-bridge
 cargo build --release -p mvm-hostd --bin mvm-substitution-endpoint
 install -m 0755 \
   target/release/mvmctl \

--- a/public/src/content/docs/install/macos.md
+++ b/public/src/content/docs/install/macos.md
@@ -37,7 +37,7 @@ MVM_VERSION=v0.16.1 curl -fsSL https://raw.githubusercontent.com/tinylabscom/mvm
 git clone https://github.com/tinylabscom/mvm.git
 cd mvm
 cargo build --release --bin mvmctl
-cargo build --release -p mvm-vm-host \
+cargo build --release -p mvm-hostd \
   --bin mvm-bridge --bin mvm-hvf-supervisor \
   --bin mvm-libkrun-supervisor --features libkrun-sys
 cargo build --release -p mvm-hostd --bin mvm-substitution-endpoint
@@ -86,7 +86,7 @@ If you configure [`nix-darwin`'s `linux-builder`](https://nix.dev/manual/nix/sta
 mvmctl doctor
 ```
 
-`doctor` reports the active backend and libkrun availability. On an Apple Silicon Mac with macOS 26+, the dev path uses the HVF builder; source image builds auto-detect the builder backend (HVF on macOS 26+ Apple Silicon), and `mvmctl dev up` retries with libkrun when the HVF builder path fails. Explicit `--builder` / `MVM_BUILDER_BACKEND` overrides still win.
+`doctor` reports the active backend and libkrun availability. On an Apple Silicon Mac with macOS 26+, image builds auto-detect the HVF builder; if HVF fails to create its VM, mvm transparently retries with libkrun (the same auto-fallback that covers every builder entry point — `mvmctl bootstrap`, `machine build`, `machine run`). Explicit `--builder` / `MVM_BUILDER_BACKEND` overrides still win.
 
 ## First microVM
 

--- a/public/src/content/docs/reference/architecture.md
+++ b/public/src/content/docs/reference/architecture.md
@@ -20,7 +20,7 @@ on launcher and service traits.
 Concrete runtime backends implement `mvm_core::vm_backend::VmBackend` — the one runtime
 behavior contract. Backend *discovery* (which backends exist and their metadata) lives in the
 compile-time descriptor registry described below; the closed enum
-`mvm_backend::backend::AnyBackend` is the dispatch layer for the operations that are still
+`mvm_runtime::backend::AnyBackend` is the dispatch layer for the operations that are still
 genuinely backend-specific:
 
 - applies platform auto-selection policy,
@@ -37,7 +37,7 @@ genuinely backend-specific:
 | QEMU | Explicit opt-in (`--hypervisor qemu`) | Linux dev/test backend |
 | Mock | Explicit opt-in (`--hypervisor mock`) | Test-only in-memory backend |
 
-The backend descriptor registry in `crates/mvm-backend/src/catalog.rs` is the single source of
+The backend descriptor registry in `crates/mvm-runtime/src/catalog.rs` is the single source of
 truth for backend discovery: each `BackendDescriptor` carries the selector, aliases, isolation
 tier, per-VM marker file, started-VM probe order, and the listing/support sets that `mvmctl
 doctor` and `mvmctl ls` read. Both enum (`AnyBackend`) and trait-object (`Arc<dyn VmBackend>`)
@@ -97,14 +97,14 @@ The workspace is organized by responsibility rather than by platform:
 | Area | Crates | Role |
 |------|--------|------|
 | Core types and contracts | `mvm-core` | Shared types, protocols, config helpers, canonical lightweight traits |
-| Runtime backends | `mvm-backend`, `mvm`, `mvm-vm-host` | VM lifecycle, backend adapters, per-VM host helpers |
+| Runtime backends | `mvm-runtime` | VM lifecycle, backend adapters, storage/volume backends |
 | Build pipeline | `mvm-build` | Builder VM flow, artifact production, builder backend seams |
-| Host policy / supervision | `mvm-hostd` | Admission, audit, policy enforcement, launch preparation |
-| Guest / protocol surfaces | `mvm-guest`, `mvm-guest-helpers`, `mvm-mcp` | Guest agent and protocol-facing tooling |
-| Domain-specific subsystems | `mvm-storage`, `mvm-net`, `mvm-oci`, `mvm-verify` | Storage, networking, OCI, audit verification |
-| CLI / SDK surface | `mvm-cli`, `mvm-sdk`, `mvm-sdk-macros` | User interface and workload authoring APIs |
+| Host policy / supervision | `mvm-hostd` | Admission, audit, policy enforcement, launch preparation, per-VM host processes |
+| Guest / protocol surfaces | `mvm-agentd` | Guest agent and in-guest protocol tooling |
+| Domain-specific subsystems | `mvm-fs`, `mvm-net`, `mvm-protocol` | OCI/filesystem handling, networking, audit-log verification |
+| CLI / SDK surface | `mvm-cli`, `mvm-sdk` | User interface and workload authoring APIs (the `mcp` feature folds the former MCP-server crate into `mvm-cli`) |
 
-The root crate (`mvm`) is the facade/runtime integration crate. `mvm-cli` is the binary-facing
+The root crate (`mvmctl`) is the facade/runtime integration crate. `mvm-cli` is the binary-facing
 command surface.
 
 ## Dependency Graph
@@ -113,20 +113,18 @@ At a high level:
 
 ```text
 mvm-core
-├── mvm-storage
 ├── mvm-net
 ├── mvm-build
-├── mvm-backend
+├── mvm-runtime
 ├── mvm-hostd
-├── mvm-guest
-├── mvm
+├── mvm-agentd
 └── mvm-cli
 ```
 
 Interpretation:
 
 - `mvm-core` is the dependency root and should stay runtime-light.
-- `mvm-backend`, `mvm-build`, and `mvm-hostd` are peer owning crates for their
+- `mvm-runtime`, `mvm-build`, and `mvm-hostd` are peer owning crates for their
   respective execution domains.
 - `mvm-cli` sits at the top of the stack and composes the lower layers.
 
@@ -147,7 +145,7 @@ These are the main behavior seams in the current codebase:
 | `VmBackendForBuilder` | `mvm-build` | Low-level builder backend seam |
 | `BackendLauncher` | `mvm-hostd` | Host-side backend launch preparation/execution |
 | `NetworkProvider` | `mvm-net` | Network provisioning / policy seam |
-| `VolumeBackend` | `mvm-storage` | Storage backend seam |
+| `VolumeBackend` | `mvm-runtime` | Storage backend seam |
 
 ### Ownership rule
 
@@ -162,7 +160,7 @@ Backend- or subsystem-specific seams stay in the owning crate:
 - `VmBackendForBuilder` belongs in `mvm-build`.
 - `BackendLauncher` belongs in `mvm-hostd`.
 - `NetworkProvider` belongs in `mvm-net`.
-- `VolumeBackend` belongs in `mvm-storage`.
+- `VolumeBackend` belongs in `mvm-runtime`.
 
 This keeps `mvm-core` small while still giving the rest of the workspace stable contracts.
 
@@ -172,7 +170,7 @@ Runtime launch is layered:
 
 1. `mvm-cli` parses intent and assembles launch configuration.
 2. `mvm-hostd` handles admission, audit, and launch-time host policy.
-3. `mvm-backend` selects a concrete `VmBackend` implementation.
+3. `mvm-runtime` selects a concrete `VmBackend` implementation.
 4. The selected backend boots the Nix-built artifacts.
 
 The ownership split is deliberate: `VmBackend` owns runtime behavior, the compile-time backend

--- a/public/src/content/docs/reference/cli-commands.md
+++ b/public/src/content/docs/reference/cli-commands.md
@@ -309,7 +309,7 @@ with a Firecracker microVM as the sandbox. Plan 178 merged the former bare
 `mvmctl exec` into `run` (it was already a strict superset); `run` adds a
 security `--profile`, OCI `--image`, signed `--receipt`, `--json`/`--dry-run`,
 and the SDK `--mode`/`--dev`/`--prod` transport. Arbitrary command dispatch
-requires a dev-feature guest agent (the `do_exec` handler is `dev-shell`-gated,
+requires a dev-feature guest agent (the `do_exec` handler is `interactive`-gated,
 claim 4); production guests run their baked entrypoint via `mvmctl machine run --entrypoint` (no shell).
 
 | Command | Description |

--- a/public/src/content/docs/reference/guest-agent.md
+++ b/public/src/content/docs/reference/guest-agent.md
@@ -82,7 +82,7 @@ split is **orthogonal**. `Exec` (dev-only) is a data-plane verb;
 ### Control-plane verbs
 
 Small bounded JSON in / small bounded JSON out. Maximum response
-frame size is `MAX_FRAME_SIZE = 256 KiB` (`crates/mvm-guest/src/vsock.rs`).
+frame size is `MAX_FRAME_SIZE = 256 KiB` (`crates/mvm-agentd/src/vsock/mod.rs`).
 No streaming. No payload bytes from user processes.
 
 | Verb | Response shape | Notes |
@@ -170,7 +170,7 @@ sent to a sealed-prod agent are rejected before any handler runs:
 | Profile | Effective verb set | Used by |
 |---------|-------------------|---------|
 | `sealed-prod` (default) | Lifecycle, status, entrypoint, sleep/wake, volume mount/unmount, idle-timeout updates. The full ADR-001 production-safe surface. | Production images. The policy file lives on a dm-verity rootfs (ADR-001 §W3) so the profile cannot be widened at runtime. |
-| `dev` | `sealed-prod` plus shell `Exec`, process RPC, filesystem RPC, console PTY, port forwarding, and `RunCode`. | `mvmctl dev` images and any image built with `dev-shell` feature. |
+| `dev` | `sealed-prod` plus shell `Exec`, process RPC, filesystem RPC, console PTY, port forwarding, and `RunCode`. | Dev-tier images built with the `interactive` feature — the ones `mvmctl machine console` or `mvmctl machine run -it` can attach to. |
 | `builder` | Reserved for builder-only verbs. The current builder agent speaks a separate `BuilderRequest` protocol, so this profile is wire-stable but unused for the tenant agent. | Future builder VM agent if/when its verbs land on the tenant wire. |
 
 Rejected requests return a typed `UnsupportedInProfile` response:
@@ -184,7 +184,7 @@ this is the protocol-layer analog of
 `ProcErrorKind::UnsupportedInProduction` for process RPC.
 
 The profile gate is **complementary** to the existing compile-time
-gate (`#[cfg(feature = "dev-shell")]` for `do_exec` / `do_run_code` /
+gate (`#[cfg(feature = "interactive")]` for `do_exec` / `do_run_code` /
 process RPC handlers per ADR-001 §W4.3, claim 4). The compile-time
 gate keeps the handler symbols *absent* from production binaries; the
 profile gate keeps the dispatcher *reachable but refusing* for dev

--- a/public/src/content/docs/security/sandbox-parity-status.md
+++ b/public/src/content/docs/security/sandbox-parity-status.md
@@ -59,7 +59,7 @@ exists.
 Today mvm builds rootfs from a Nix flake or from a bundled template
 catalog. There is no `mvmctl image pull` command, no OCI layer
 unpacker, and no digest-pinned launch path. The
-[round-trip OCI bridge](https://github.com/tinylabscom/mvm/blob/main/crates/mvm-backend/src/docker.rs)
+[round-trip OCI bridge](https://github.com/tinylabscom/mvm/blob/main/crates/mvm-runtime/src/docker.rs)
 loads mvm-built images into Docker; it does NOT pull upstream images.
 
 To move to Preview: ship `mvmctl image pull` with digest

--- a/tests/nix_flake_structure.rs
+++ b/tests/nix_flake_structure.rs
@@ -436,13 +436,13 @@ fn quickstart_docs_lead_with_image_backed_run() {
     let image_heading = content
         .find("## 1. Run an OCI Image")
         .expect("quickstart must lead with an OCI image run section");
-    let dev_heading = content
-        .find("## 2. Launch the Dev Environment")
-        .expect("quickstart must still document the dev environment");
+    let builder_heading = content
+        .find("## 2. Prepare the Builder VM")
+        .expect("quickstart must still document the builder VM after the image path");
 
     assert!(
-        image_heading < dev_heading,
-        "quickstart must put the image-backed one-shot path before dev/flake workflows"
+        image_heading < builder_heading,
+        "quickstart must put the image-backed one-shot path before the builder/flake workflows"
     );
     assert!(
         content.contains("mvmctl machine run --image alpine -- uname -a")


### PR DESCRIPTION
Companion to the README/CLAUDE.md refresh (#1742). Brings the website docs under `public/src/content/docs/` in line with the shipped v1-refactor state across 22 files (296+/327−).

Three fix classes:
- **Crate renames** — `mvm-backend`/`mvm`/`mvm-storage`→`mvm-runtime`, `mvm-guest`(+helpers)→`mvm-agentd`, `mvm-vm-host`/`mvm-supervisor`→`mvm-hostd`, `mvm-ext4`/`mvm-oci`→`mvm-fs`, `mvm-network`→`mvm-net`, `mvm-libkrun`→`libkrun-sys`, `mvm-verify`→`mvm-protocol`, `mvm-mcp`→folded into `mvm-cli`. Rewrote `reference/architecture.md`'s workspace table + dependency graph. (Binary names like `mvm-guest-agent`/`mvm-libkrun-supervisor` unchanged.)
- **`dev-shell`→`interactive`** — the Cargo feature rename (guest console/exec gate). Kept the real `--workflow dev-shell` *doctor flag* (a distinct `DoctorWorkflow`, verified still wired).
- **`mvmctl dev` removed** — the builder VM is headless; reframed every occurrence around `mvmctl bootstrap`/`doctor` + transient `machine run -it`, each command grounded against the real `Commands` enum. Structural reframes for `guides/{dev-image,builder-vm,airgapped-bootstrap,troubleshooting,verify-release}.md` (the old dev-image import/fetch flow is gone; documented the signed-bundle path that actually works). Caught and fixed several *pre-existing* wrong commands in the old docs (e.g. `mvmctl bundle verify` → `bundle fetch`, bare `machine console` → needs a name).

Verified: `check-{doc-claims,machine-doc-guards,no-overclaim}` clean; the stale-pattern grep is zero net (remaining hits are unchanged binary names + deliberate "the former `mvmctl dev`… was removed" notes).

Out-of-scope follow-ups the subagent flagged (separate WS12 slice): Apple-Vz references still in `guides/{manifests,nix-flakes}.md` / `reference/limits.md` / `security/verified-boot.md`; top-level `mvmctl boot-report` (vs `machine boot-report`) drift in several `working/*` docs; a dead `core_demo_e2e` test/CI reference in `contributing/development.md`.