### PR TITLE
feat(cli): surface image/secret/bundle/trust in --help (WS7)

### DIFF
--- a/crates/mvm-cli/src/commands/mod.rs
+++ b/crates/mvm-cli/src/commands/mod.rs
@@ -130,8 +130,8 @@ pub(in crate::commands) enum Commands {
     /// Manage built manifest slots
     #[command(hide = true)]
     Manifest(manifest::Args),
-    /// Inspect cached OCI images
-    #[command(hide = true)]
+    /// Inspect and manage cached OCI images
+    #[command(display_order = 9)]
     Image(image::Args),
     /// Inspect the dm-thin storage pool
     #[command(hide = true)]
@@ -158,13 +158,13 @@ pub(in crate::commands) enum Commands {
     #[command(hide = true)]
     Reconcile(ops::reconcile::Args),
     /// Manage local secret namespaces
-    #[command(hide = true)]
+    #[command(display_order = 10)]
     Secret(ops::secret::Args),
-    /// Seal or verify portable VM bundles
-    #[command(hide = true)]
+    /// Seal, fetch, and verify portable VM bundles
+    #[command(display_order = 11)]
     Bundle(bundle::Args),
     /// Manage trusted bundle publishers
-    #[command(hide = true)]
+    #[command(display_order = 12)]
     Trust(trust::Args),
     /// Inspect cached application dependencies
     #[command(hide = true)]


### PR DESCRIPTION
First WS7 (simple-CLI) slice. Promotes four first-class user-facing nouns from hidden to the visible top-level `--help` surface:

- `image` — inspect/manage the cached OCI images
- `secret` — manage local secret namespaces
- `bundle` — seal/fetch/verify portable VM bundles
- `trust` — manage trusted bundle publishers

Behavior-preserving: these already dispatched identically; only their `#[command(hide = true)]` → `#[command(display_order = N)]` visibility changes. No test asserted they were hidden; clippy + the CLI flag-contract tests (`tests/cli.rs`, 8/8) pass.

Context: the broader WS7 redesign (resolving top-level-vs-`machine`-nested redundancy — `build`/`machine build`, `ls`/`machine ls` — and the canonical noun-verb shape) is a design decision I'll bring separately; this slice is the unambiguous, zero-risk part.