### PR TITLE
fix(net): resolve the OCI egress client overlay-first and fail closed

### DIFF
--- a/crates/mvm-agentd/src/bin/mvm-oci-init.rs
+++ b/crates/mvm-agentd/src/bin/mvm-oci-init.rs
@@ -20,6 +20,7 @@ mod linux {
     const NETINIT_FALLBACK: &str = "/usr/local/bin/mvm-guest-netinit";
     const NETINIT_OVERLAY: &str = "/mvm/runtime/netinit";
     const EGRESS_CLIENT: &str = "/usr/local/bin/mvm-egress-client";
+    const EGRESS_CLIENT_OVERLAY: &str = "/mvm/runtime/egress-client";
 
     pub fn main() {
         mount_pseudofs();
@@ -31,7 +32,19 @@ mod linux {
         run_one(resolve_exec([NETINIT_OVERLAY, NETINIT_FALLBACK]), "netinit");
         if cmdline_has_flag("mvm.vsock_egress=1") {
             bring_loopback_up();
-            spawn_one(Path::new(EGRESS_CLIENT), "egress-client");
+            // Egress is required when this flag is set; the client is the only guest
+            // path to the admitted network. Resolve overlay-first (respecting the
+            // runtime-source policy) and fail closed rather than boot a workload that
+            // silently cannot reach its allow-listed egress.
+            let Some(egress_client) = resolve_egress_client() else {
+                eprintln!(
+                    "mvm-oci-init: mvm.vsock_egress=1 but no egress client resolved from \
+                     /mvm/runtime and no baked fallback — refusing to boot a workload that \
+                     cannot reach its admitted egress"
+                );
+                std::process::exit(1);
+            };
+            spawn_one(&egress_client, "egress-client");
         }
         // The guest agent is the mvm vsock control plane — the whole reason this
         // init exists (scratch/distroless/Alpine all get it from the overlay).
@@ -312,6 +325,28 @@ mod linux {
             .map(Path::to_path_buf)
     }
 
+    fn resolve_egress_client() -> Option<PathBuf> {
+        resolve_egress_client_for(runtime_source_policy(), is_executable)
+    }
+
+    fn resolve_egress_client_for(
+        runtime_source_policy: mvm_core::vm_backend::RuntimeSourcePolicy,
+        is_exec: impl Fn(&Path) -> bool,
+    ) -> Option<PathBuf> {
+        let candidates: &[&str] = match runtime_source_policy {
+            mvm_core::vm_backend::RuntimeSourcePolicy::RequiredOverlay => &[EGRESS_CLIENT_OVERLAY],
+            mvm_core::vm_backend::RuntimeSourcePolicy::PreferOverlay => {
+                &[EGRESS_CLIENT_OVERLAY, EGRESS_CLIENT]
+            }
+            mvm_core::vm_backend::RuntimeSourcePolicy::RootfsOnly => &[EGRESS_CLIENT],
+        };
+        candidates
+            .iter()
+            .map(Path::new)
+            .find(|path| is_exec(path))
+            .map(Path::to_path_buf)
+    }
+
     fn is_executable(path: &Path) -> bool {
         path.is_file()
             && fs::metadata(path)
@@ -551,6 +586,74 @@ mod linux {
             let got = resolve_guest_agent_for(
                 mvm_core::vm_backend::RuntimeSourcePolicy::RequiredOverlay,
                 mvm_core::security::AgentProfile::SealedProd,
+                |_path| false,
+            );
+            assert_eq!(got, None);
+        }
+
+        #[test]
+        fn resolve_egress_client_for_required_overlay_resolves_overlay() {
+            let got = resolve_egress_client_for(
+                mvm_core::vm_backend::RuntimeSourcePolicy::RequiredOverlay,
+                |path| path == Path::new(EGRESS_CLIENT_OVERLAY),
+            );
+            assert_eq!(got, Some(PathBuf::from(EGRESS_CLIENT_OVERLAY)));
+        }
+
+        #[test]
+        fn resolve_egress_client_for_required_overlay_returns_none_when_nothing_executable() {
+            // No executable candidate -> None, which main() treats as fatal
+            // (fail closed) rather than booting a workload with no egress path.
+            let got = resolve_egress_client_for(
+                mvm_core::vm_backend::RuntimeSourcePolicy::RequiredOverlay,
+                |_path| false,
+            );
+            assert_eq!(got, None);
+        }
+
+        #[test]
+        fn resolve_egress_client_for_required_overlay_does_not_fall_back_to_baked() {
+            // Only the baked path is executable; required-overlay must not accept it.
+            let got = resolve_egress_client_for(
+                mvm_core::vm_backend::RuntimeSourcePolicy::RequiredOverlay,
+                |path| path == Path::new(EGRESS_CLIENT),
+            );
+            assert_eq!(got, None);
+        }
+
+        #[test]
+        fn resolve_egress_client_for_prefer_overlay_prefers_overlay_when_both_present() {
+            let got = resolve_egress_client_for(
+                mvm_core::vm_backend::RuntimeSourcePolicy::PreferOverlay,
+                |_path| true,
+            );
+            assert_eq!(got, Some(PathBuf::from(EGRESS_CLIENT_OVERLAY)));
+        }
+
+        #[test]
+        fn resolve_egress_client_for_prefer_overlay_falls_back_to_baked() {
+            let got = resolve_egress_client_for(
+                mvm_core::vm_backend::RuntimeSourcePolicy::PreferOverlay,
+                |path| path == Path::new(EGRESS_CLIENT),
+            );
+            assert_eq!(got, Some(PathBuf::from(EGRESS_CLIENT)));
+        }
+
+        #[test]
+        fn resolve_egress_client_for_rootfs_only_ignores_overlay_and_uses_baked() {
+            // Overlay executable but policy is rootfs-only -> only the baked
+            // candidate is considered, so it wins.
+            let got = resolve_egress_client_for(
+                mvm_core::vm_backend::RuntimeSourcePolicy::RootfsOnly,
+                |path| path == Path::new(EGRESS_CLIENT_OVERLAY) || path == Path::new(EGRESS_CLIENT),
+            );
+            assert_eq!(got, Some(PathBuf::from(EGRESS_CLIENT)));
+        }
+
+        #[test]
+        fn resolve_egress_client_for_rootfs_only_returns_none_when_baked_missing() {
+            let got = resolve_egress_client_for(
+                mvm_core::vm_backend::RuntimeSourcePolicy::RootfsOnly,
                 |_path| false,
             );
             assert_eq!(got, None);


### PR DESCRIPTION
Second WS-NET convergence slice. `mvm-oci-init` (PID 1 injected into OCI rootfs trees) spawned `mvm-egress-client` from the hard-coded baked path `/usr/local/bin/mvm-egress-client` only. On a runtime-lean / sealed image that binary is stripped and the client lives solely in the read-only runtime overlay at `/mvm/runtime/egress-client`, so the spawn silently no-oped → nothing bound `127.0.0.1:1080` → the workload had no egress (the second live-witness failure).

Fix: resolve the egress client with the same **policy-aware, overlay-first** logic the guest agent already uses (`resolve_guest_agent_for`): `RequiredOverlay` → overlay only; `PreferOverlay` → overlay then baked; `RootfsOnly` → baked only. When `mvm.vsock_egress=1` is set (egress required — the client is the only guest path to the admitted network) and nothing resolves, **fail closed** (`exit(1)`, which panics the kernel) rather than boot a workload that silently can't reach its allow-listed egress — mirroring the guest-agent fail-closed a few lines below.

Guest bins are `#[cfg(target_os = "linux")]`; verified via `cargo zigbuild --target x86_64-unknown-linux-gnu -p mvm-agentd --bins --tests` under `-D warnings` + `check-guest-binary-lists` / `check-vsock-only-egress` / `check-no-spec-refs-in-comments`. 7 unit tests (run in the CI Linux Test lane) cover each policy incl. required-overlay-no-baked-fallback and nothing-resolves→None (the fail-closed trigger). Pairs with the L3-tunnel removal in the sibling PR.