### PR TITLE
feat(net): make Firecracker a vsock-only (Model-B) egress backend

### DIFF
--- a/crates/mvm-cli/src/doctor/warm_start.rs
+++ b/crates/mvm-cli/src/doctor/warm_start.rs
@@ -283,7 +283,10 @@ mod tests {
 
         let fc = by("firecracker").unwrap();
         assert_eq!(fc.snapshot_tier, "live-memory");
-        assert!(fc.tap_networking, "firecracker uses a host TAP device");
+        assert!(
+            !fc.tap_networking,
+            "firecracker is vsock-only: no routable guest NIC"
+        );
         assert!(fc.vsock);
         assert!(fc.balloon);
         assert!(

--- a/crates/mvm-runtime/src/backend.rs
+++ b/crates/mvm-runtime/src/backend.rs
@@ -214,11 +214,17 @@ impl VmBackend for FirecrackerBackend {
         // `VmStartConfig::mem_initial_mib` is `Some`. Capability is
         // advertised unconditionally so the host-side controller can
         // discover support before deciding to plumb a workload.
+        //
+        // A workload guest is vsock-only: it attaches no routable NIC, so all
+        // ingress/egress rides the host-mediated vsock proxy — matching the
+        // libkrun/HVF posture.
         VmCapabilities {
             pause_resume: true,
             snapshots: true,
             vsock: true,
-            tap_networking: true,
+            tap_networking: false,
+            no_routable_guest_nic: true,
+            host_vsock_proxy: true,
             balloon: true,
             fs_quick_checkpoint: false,
             ..VmCapabilities::default()
@@ -907,7 +913,10 @@ mod tests {
         assert!(caps.pause_resume);
         assert!(caps.snapshots);
         assert!(caps.vsock);
-        assert!(caps.tap_networking);
+        // vsock-only (Model-B): no routable NIC, egress rides the host vsock proxy.
+        assert!(!caps.tap_networking);
+        assert!(caps.no_routable_guest_nic);
+        assert!(caps.host_vsock_proxy);
     }
 
     #[test]
@@ -1179,10 +1188,13 @@ mod tests {
 
     #[test]
     fn test_any_backend_capabilities() {
+        // The default backend is Firecracker, now a vsock-only workload backend.
         let backend = AnyBackend::default_backend();
         let caps = backend.capabilities();
         assert!(caps.vsock);
-        assert!(caps.tap_networking);
+        assert!(!caps.tap_networking);
+        assert!(caps.no_routable_guest_nic);
+        assert!(caps.host_vsock_proxy);
     }
 
     #[test]

--- a/crates/mvm-runtime/src/microvm/boot_config.rs
+++ b/crates/mvm-runtime/src/microvm/boot_config.rs
@@ -5,7 +5,6 @@
 use anyhow::{Context, Result};
 use tracing::instrument;
 
-use crate::base::config::BRIDGE_IP;
 use crate::base::ui;
 
 use super::daemon::{api_put_socket, prepare_vsock_runtime_dir};
@@ -189,7 +188,8 @@ pub fn configure_flake_microvm_with_drives_dir(
     configure_boot_source(socket, config, overlay)?;
     configure_machine(socket, config)?;
     configure_drives(socket, config, drives_dir, overlay)?;
-    configure_network(socket, config)?;
+    // No routable NIC: a workload guest has no `/network-interfaces` device.
+    // All ingress and egress ride the vsock device configured below.
     configure_vsock(socket, drives_dir)?;
     configure_balloon(socket, config)?;
     Ok(())
@@ -208,26 +208,38 @@ fn configure_logger(socket: &str, abs_dir: &str) -> Result<()> {
     )
 }
 
+/// The always-present kernel cmdline prefix for a workload boot. A vsock-only
+/// guest has no routable NIC, so it carries no `mvm.ip=`/`mvm.gw=` token — the
+/// guest configures no eth0 and every byte of ingress/egress rides vsock.
+fn base_boot_args() -> String {
+    "console=ttyS0 reboot=k panic=1 net.ifnames=0".to_string()
+}
+
+/// Kernel cmdline token that turns on the in-guest vsock egress client.
+/// Emitted only when outbound egress is allowed and the workload carries no
+/// bound secrets, so the raw relay never contends with the substitution
+/// endpoint for the shared egress port. Mirrors the libkrun/HVF gate.
+fn vsock_egress_cmdline_token(config: &FlakeRunConfig) -> Option<String> {
+    let state_dir = mvm_core::config::vm_state_dir(&config.slot.name);
+    (config.network_policy.allows_egress()
+        && !crate::egress_shared::state_has_bound_secrets(&state_dir).unwrap_or(false))
+    .then(|| "mvm.vsock_egress=1".to_string())
+}
+
 /// Configure the Firecracker boot source (`/boot-source`): kernel image
-/// path, initrd, and the full kernel cmdline — guest IP/gateway, dm-verity
-/// roothash, runtime-overlay tokens, egress CA, secret placeholders, and
-/// verb-grant sidecars.
+/// path, initrd, and the full kernel cmdline — dm-verity roothash,
+/// runtime-overlay tokens, egress CA, the vsock egress switch, secret
+/// placeholders, and verb-grant sidecars. A workload guest has no routable
+/// NIC, so the cmdline carries no guest IP/gateway.
 fn configure_boot_source(
     socket: &str,
     config: &FlakeRunConfig,
     overlay: Option<(&str, &str, &str)>,
 ) -> Result<()> {
-    let slot = &config.slot;
-
-    // Boot args: pass guest IP and gateway via kernel cmdline.
     // When initrd is present (NixOS guest or verity initrd), the initrd
     // handles root mounting. When absent (minimal guest, no verity),
     // the kernel mounts /dev/vda directly.
-    let base_args = format!(
-        "console=ttyS0 reboot=k panic=1 net.ifnames=0 mvm.ip={ip}/24 mvm.gw={gw}",
-        ip = slot.guest_ip,
-        gw = BRIDGE_IP,
-    );
+    let base_args = base_boot_args();
 
     // dm-verity boot path: when verity is on, the kernel
     // mounts the verity initramfs first, which is `mvm-verity-init`
@@ -271,6 +283,13 @@ fn configure_boot_source(
     // `mvm.egress_ca=` token into the guest trust bundle (cert only — the key
     // stays host-side in the terminator endpoint).
     let boot_args = match egress_ca_cmdline_token(&config.slot.name) {
+        Some(token) => format!("{boot_args} {token}"),
+        None => boot_args,
+    };
+    // Turn on the in-guest vsock egress client for a secret-free egress
+    // workload — the guest speaks raw egress over vsock to the host endpoint,
+    // matching the libkrun/HVF vsock-only path (no routable NIC to bypass it).
+    let boot_args = match vsock_egress_cmdline_token(config) {
         Some(token) => format!("{boot_args} {token}"),
         None => boot_args,
     };
@@ -482,24 +501,6 @@ fn configure_drives(
     Ok(())
 }
 
-/// Configure the Firecracker network interface (`/network-interfaces/net1`).
-fn configure_network(socket: &str, config: &FlakeRunConfig) -> Result<()> {
-    let slot = &config.slot;
-    ui::info(&format!(
-        "Setting network interface: {} (MAC {})",
-        slot.tap_dev, slot.mac
-    ));
-    api_put_socket(
-        socket,
-        "/network-interfaces/net1",
-        &format!(
-            r#"{{"iface_id": "net1", "guest_mac": "{mac}", "host_dev_name": "{tap}"}}"#,
-            mac = slot.mac,
-            tap = slot.tap_dev,
-        ),
-    )
-}
-
 /// Configure the Firecracker vsock device (`/vsock`).
 fn configure_vsock(socket: &str, drives_dir: &str) -> Result<()> {
     ui::info("Setting vsock device...");
@@ -576,6 +577,53 @@ mod tests {
             network_policy: mvm_core::network_policy::NetworkPolicy::default(),
             network_tunnel: None,
         }
+    }
+
+    // ------------------------------------------------------------------
+    // vsock-only (Model-B) boot cmdline
+    // ------------------------------------------------------------------
+
+    #[test]
+    fn base_boot_args_carries_no_routable_nic_tokens() {
+        // A vsock-only workload guest has no routable NIC, so the base cmdline
+        // must emit no guest IP / gateway — the guest configures no eth0 and all
+        // traffic rides vsock.
+        let args = base_boot_args();
+        assert!(
+            !args.contains("mvm.ip="),
+            "vsock-only guest carries no guest IP: {args}"
+        );
+        assert!(
+            !args.contains("mvm.gw="),
+            "vsock-only guest carries no gateway: {args}"
+        );
+        assert!(args.contains("console=ttyS0"));
+        assert!(args.contains("net.ifnames=0"));
+    }
+
+    #[test]
+    fn vsock_egress_cmdline_token_only_when_policy_allows_egress() {
+        let _g = crate::base::runtime_meta::HOME_TEST_LOCK
+            .lock()
+            .unwrap_or_else(|p| p.into_inner());
+        let dir = tempfile::tempdir().unwrap();
+        let mut env = mvm_core::util::test_env::TestEnv::new();
+        env.set("MVM_HOME", dir.path());
+
+        // Deny-all default → no token (short-circuits before any fs read).
+        let mut deny = baseline_run_config(None);
+        deny.network_policy = mvm_core::network_policy::NetworkPolicy::deny_all();
+        assert_eq!(vsock_egress_cmdline_token(&deny), None);
+
+        // Allow-egress, no bound secrets → the guest runs the vsock egress client.
+        let mut allow = baseline_run_config(None);
+        allow.network_policy = mvm_core::network_policy::NetworkPolicy::preset(
+            mvm_core::network_policy::NetworkPreset::Dev,
+        );
+        assert_eq!(
+            vsock_egress_cmdline_token(&allow).as_deref(),
+            Some("mvm.vsock_egress=1")
+        );
     }
 
     // ------------------------------------------------------------------

--- a/crates/mvm-runtime/src/microvm/egress_bridge.rs
+++ b/crates/mvm-runtime/src/microvm/egress_bridge.rs
@@ -145,71 +145,65 @@ fn resolve_fc_bridge_path() -> Result<std::path::PathBuf> {
     )
 }
 
-/// Spawn the per-VM substitution endpoint **before** the guest boots,
-/// so the `(var → placeholder)` pairs it mints (and
-/// writes to `vm_substitution_env_path`) are available when `boot_args` is built
-/// and can ride the cmdline (`mvm.secret_env=`) into a sealed entrypoint. Binds
-/// the terminator listener too; the nft REDIRECT that feeds it is installed
-/// post-boot by [`install_egress_redirect`] (it needs the guest's TAP). No-op
-/// when the plan carries no egress secrets. Returns an armed [`EndpointGuard`]
-/// the caller defuses once the VM is fully up.
+/// Spawn the per-VM substitution endpoint **before** the guest boots, so the
+/// `(var → placeholder)` pairs it mints (and writes to `vm_substitution_env_path`)
+/// are available when `boot_args` is built and can ride the cmdline
+/// (`mvm.secret_env=`) into a sealed entrypoint.
+///
+/// vsock-only (Model-B): the endpoint binds the per-port host UDS Firecracker's
+/// userspace virtio-vsock muxes a guest dial to `CID_HOST:EGRESS_PORT` onto
+/// (`<vsock>_<port>`), NOT a host AF_VSOCK listener the guest can never reach.
+/// A secret-bound run gets the substitution wire path; a secret-free run whose
+/// policy admits egress gets the raw vsock relay. Its `EgressGate` is the sole
+/// claim-10 authority — there is no NIC and no nft REDIRECT to gate elsewhere.
+/// Deny-all secret-free runs keep the endpoint defused (the guest is never told
+/// to start the egress client). Returns an armed [`EndpointGuard`] the caller
+/// defuses once the VM is fully up.
 #[cfg(target_os = "linux")]
-pub(super) fn spawn_egress_endpoint(config: &FlakeRunConfig) -> Result<EndpointGuard> {
-    use crate::egress_redirect::terminator_port_for;
-    use crate::substitution_spawn::spawn_substitution_endpoint;
-    use std::net::SocketAddr;
-
-    let name = &config.slot.name;
-    let state_dir = mvm_core::config::vm_state_dir(name);
-    let Some((secrets, redaction, tenant)) =
-        crate::egress_shared::decode_plan_secrets_from_state(&state_dir)?
-    else {
-        return Ok(EndpointGuard { vm_name: None });
+pub(super) fn spawn_egress_endpoint(
+    config: &FlakeRunConfig,
+    drives_dir: &str,
+) -> Result<EndpointGuard> {
+    use crate::substitution_spawn::{
+        EndpointTransport, SubstitutionSpawnParams, spawn_substitution_endpoint,
     };
 
-    // Per-slot terminator port so concurrent VMs never collide host-side.
-    // 0.0.0.0: a PREROUTING REDIRECT delivers the forwarded packet to a local
-    // socket on the host, so the terminator must accept on the host's addrs.
-    let term_port = terminator_port_for(config.slot.index);
-    let listen = SocketAddr::from(([0, 0, 0, 0], term_port));
-    // `mvmctl up` staged the per-VM name-constrained intermediate (cert+key) in
-    // the sidecar. Hand the KEY to the endpoint so the `https` terminator can
-    // mint per-SNI leaves; it never reaches the guest. Absent ⇒ `http`-only.
-    let tls_intermediate = crate::substitution_spawn::read_egress_intermediate(&state_dir)?;
-    spawn_substitution_endpoint(crate::substitution_spawn::SubstitutionSpawnParams {
-        vm_name: name,
-        state_dir: &state_dir,
-        tenant: &tenant,
-        secrets: &secrets,
-        redaction: &redaction,
-        transport: crate::substitution_spawn::EndpointTransport::Vsock {
-            port: mvm_agentd::vsock::EGRESS_PORT,
-        },
-        terminator_listen: Some(listen),
-        tls_intermediate,
-        network_policy: None,
-        raw_egress: false,
-    })?;
-    Ok(EndpointGuard::new(name))
-}
-
-/// Install the per-VM nft TAP REDIRECT (`:80`/`:443` → the terminator)
-/// **after** the guest boots (the TAP exists). No-op when the plan carries no
-/// egress secrets. Persists the table so it outlives this frame; `stop_vm`
-/// removes it by name.
-#[cfg(target_os = "linux")]
-pub(super) fn install_egress_redirect(config: &FlakeRunConfig) -> Result<()> {
-    use crate::egress_redirect::{EgressRedirect, terminator_port_for};
-
     let name = &config.slot.name;
     let state_dir = mvm_core::config::vm_state_dir(name);
-    if crate::egress_shared::decode_plan_secrets_from_state(&state_dir)?.is_none() {
-        return Ok(());
+    let default_redaction = mvm_core::policy::RedactionPolicy::default();
+    let decoded = crate::egress_shared::decode_plan_secrets_from_state(&state_dir)?;
+    let (secrets, redaction, tenant): (&[_], &mvm_core::policy::RedactionPolicy, &str) =
+        match &decoded {
+            Some((secrets, redaction, tenant)) => (secrets.as_slice(), redaction, tenant.as_str()),
+            None => (&[], &default_redaction, "local"),
+        };
+    if secrets.is_empty() && !config.network_policy.allows_egress() {
+        return Ok(EndpointGuard { vm_name: None });
     }
-    let term_port = terminator_port_for(config.slot.index);
-    let redirect = EgressRedirect::install(name, &config.slot.tap_dev, term_port)?;
-    redirect.persist();
-    Ok(())
+    // `mvmctl up` staged the per-VM name-constrained intermediate (cert+key) in
+    // the sidecar. Hand the KEY to the endpoint so it can terminate host-bound
+    // TLS and substitute inside the stream; it never reaches the guest. Absent
+    // (secret-free / http-only) ⇒ `None`.
+    let tls_intermediate = crate::substitution_spawn::read_egress_intermediate(&state_dir)?;
+    spawn_substitution_endpoint(SubstitutionSpawnParams {
+        vm_name: name,
+        state_dir: &state_dir,
+        tenant,
+        secrets,
+        redaction,
+        transport: EndpointTransport::Uds {
+            path: std::path::PathBuf::from(format!(
+                "{}_{}",
+                crate::microvm::firecracker_vsock_uds_path(drives_dir),
+                mvm_agentd::vsock::EGRESS_PORT
+            )),
+        },
+        terminator_listen: None,
+        tls_intermediate,
+        network_policy: Some(&config.network_policy),
+        raw_egress: secrets.is_empty(),
+    })?;
+    Ok(EndpointGuard::new(name))
 }
 
 #[cfg(test)]
@@ -641,6 +635,81 @@ mod tests {
             network_policy: mvm_core::network_policy::NetworkPolicy::default(),
             network_tunnel: None,
         }
+    }
+
+    // The Model-B egress endpoint must speak `Uds` at the FC per-port socket
+    // (`<vsock>_<EGRESS_PORT>`), gate egress itself (`network_policy: Some`), run
+    // no host TCP terminator (`terminator_listen: None`), and serve the raw relay
+    // for a secret-free egress workload (`egress_mode: raw`). Drive the real
+    // spawn with a stub endpoint bin (via `MVM_SUBSTITUTION_ENDPOINT_PATH`) that
+    // copies its stdin config to a file for inspection.
+    #[test]
+    #[cfg(target_os = "linux")]
+    fn spawn_egress_endpoint_binds_per_port_uds_and_self_gates() {
+        let _g = crate::base::runtime_meta::HOME_TEST_LOCK
+            .lock()
+            .unwrap_or_else(|p| p.into_inner());
+        let home = tempfile::tempdir().unwrap();
+        let mut env = mvm_core::util::test_env::TestEnv::new();
+        env.set("MVM_HOME", home.path());
+
+        // Stub endpoint: dump the config JSON to a file, then emit one handshake
+        // line so `read_handshake_line` in the spawn helper succeeds.
+        let cfg_out = home.path().join("captured-config.json");
+        let stub = home.path().join("stub-endpoint.sh");
+        std::fs::write(
+            &stub,
+            format!(
+                "#!/bin/sh\ncat > {}\necho 'ready handshake'\n",
+                cfg_out.display()
+            ),
+        )
+        .unwrap();
+        {
+            use std::os::unix::fs::PermissionsExt;
+            std::fs::set_permissions(&stub, std::fs::Permissions::from_mode(0o755)).unwrap();
+        }
+        env.set("MVM_SUBSTITUTION_ENDPOINT_PATH", &stub);
+
+        // A secret-free workload whose policy admits egress: no plan.json is
+        // written, so `decode_plan_secrets_from_state` yields no secrets and the
+        // endpoint serves the raw relay.
+        let mut config = baseline_run_config(None);
+        config.network_policy = mvm_core::network_policy::NetworkPolicy::preset(
+            mvm_core::network_policy::NetworkPreset::Dev,
+        );
+        // The spawn helper writes the pid file into the state dir and the minted
+        // handshake into `vm_substitution_env_path`; ensure both parents exist.
+        let state_dir = mvm_core::config::vm_state_dir(&config.slot.name);
+        std::fs::create_dir_all(&state_dir).unwrap();
+        if let Some(parent) = mvm_core::config::vm_substitution_env_path(&config.slot.name).parent()
+        {
+            std::fs::create_dir_all(parent).unwrap();
+        }
+
+        let drives_dir = home.path().join("drives");
+        let guard = spawn_egress_endpoint(&config, drives_dir.to_str().unwrap())
+            .expect("spawn with stub endpoint should succeed");
+        assert!(guard.vm_name.is_some(), "an egress workload arms the guard");
+
+        let captured = std::fs::read_to_string(&cfg_out).expect("stub wrote config");
+        let v: serde_json::Value = serde_json::from_str(&captured).expect("config is JSON");
+        assert_eq!(v["transport"]["kind"], "uds");
+        let expected_uds = format!(
+            "{}_{}",
+            crate::microvm::firecracker_vsock_uds_path(drives_dir.to_str().unwrap()),
+            mvm_agentd::vsock::EGRESS_PORT
+        );
+        assert_eq!(v["transport"]["path"], expected_uds);
+        assert_eq!(v["egress_mode"], "raw");
+        assert!(
+            v.get("network_policy").is_some(),
+            "the endpoint is the sole claim-10 authority: {v}"
+        );
+        assert!(
+            v.get("terminator_listen").is_none(),
+            "Model-B runs no host TCP terminator: {v}"
+        );
     }
 
     #[test]

--- a/crates/mvm-runtime/src/microvm/flake_run.rs
+++ b/crates/mvm-runtime/src/microvm/flake_run.rs
@@ -8,15 +8,13 @@ use crate::base::shell::run_in_vm;
 use crate::base::ui;
 use crate::firecracker;
 use crate::image::RuntimeVolume;
-use crate::network_provider::BridgeTapNetworkProvider;
 use crate::network_tunnel_spawn::{
     NetworkTunnelListener, NetworkTunnelWorkerSpawnParams,
     spawn_network_tunnel_worker_if_configured,
 };
-use mvm_net::{NetworkProvider, NetworkSpec};
 
 use super::daemon::{api_put_socket, start_vm_firecracker};
-use super::guards::{FirecrackerGuard, TapGuard};
+use super::guards::FirecrackerGuard;
 use super::{firecracker_vsock_uds_path, require_linux_env};
 
 // ============================================================================
@@ -241,21 +239,10 @@ fn run_configured_firecracker(
 ) -> Result<()> {
     let slot = &config.slot;
 
-    // Provision the VM's bridge+TAP network + egress policy through the
-    // NetworkProvider seam. `provision` is transactional
-    // — it drops the TAP itself if the policy apply fails — and the TapGuard
-    // below re-arms to tear the TAP down if a *later* start step fails. Same
-    // operations, same order, as the direct calls this replaces.
-    BridgeTapNetworkProvider::new()
-        .provision(
-            &mvm_core::protocol::vm_backend::VmId(slot.name.clone()),
-            &NetworkSpec {
-                policy: firecracker_tap_policy(config),
-                slot_index: slot.index,
-            },
-        )
-        .map_err(|e| anyhow::anyhow!("network provision: {e}"))?;
-    let mut tap_guard = TapGuard::new(slot);
+    // A workload guest is vsock-only: it attaches no routable NIC, so there is
+    // no host TAP / bridge to provision and no kernel-firewall egress moat to
+    // arm. Claim-10 egress enforcement lives on the host-side vsock egress
+    // endpoint's `EgressGate` (spawned below), matching libkrun/HVF.
 
     // Spawn `mvm-bridge` alongside the Firecracker VM.
     // The sidecar runs under
@@ -280,8 +267,8 @@ fn run_configured_firecracker(
     // watchdog hard-fail policy would tear down an otherwise healthy
     // VM. Before the egress moat landed, no producer wrote `plan.json`
     // pre-boot on this path, so the bridge never actually spawned;
-    // the gate preserves that default while the moat (substitution
-    // endpoint + nft redirect below) runs unconditionally.
+    // the gate preserves that default while the moat (the vsock egress
+    // endpoint below) runs unconditionally.
     #[cfg(target_os = "linux")]
     let mut bridge_guard = if std::env::var("MVM_GATEWAY_BRIDGE").as_deref() == Ok("1") {
         super::egress_bridge::spawn_fc_bridge(&config.slot.name, abs_dir)?
@@ -299,15 +286,15 @@ fn run_configured_firecracker(
     }
     let mut fc_guard = FirecrackerGuard::new(abs_dir);
 
-    // Spawn the substitution endpoint BEFORE configuring boot args,
-    // so the placeholders it mints land in
-    // `vm_substitution_env_path` and `configure_flake_microvm` can carry them on
-    // the cmdline (`mvm.secret_env=`) into a sealed entrypoint. The endpoint
-    // binds its listener now; the nft REDIRECT that feeds it is installed
-    // post-boot (the TAP must exist). The guard reaps the endpoint if any step
-    // below fails before the VM is fully up. No-op without egress secrets.
+    // Spawn the substitution endpoint BEFORE configuring boot args, so the
+    // placeholders it mints land in `vm_substitution_env_path` and
+    // `configure_flake_microvm` can carry them on the cmdline (`mvm.secret_env=`)
+    // into a sealed entrypoint. The endpoint binds the per-port host UDS the
+    // guest reaches over vsock and self-enforces the resolved egress policy — no
+    // TAP, no nft REDIRECT. The guard reaps the endpoint if any step below fails
+    // before the VM is fully up. Defused for a deny-all secret-free run.
     #[cfg(target_os = "linux")]
-    let mut endpoint_guard = super::egress_bridge::spawn_egress_endpoint(config)?;
+    let mut endpoint_guard = super::egress_bridge::spawn_egress_endpoint(config, abs_dir)?;
     let mut tunnel_guard =
         spawn_network_tunnel_worker_if_configured(NetworkTunnelWorkerSpawnParams {
             state_dir: &mvm_core::config::vm_state_dir(&config.name),
@@ -366,32 +353,12 @@ fn run_configured_firecracker(
         );
     }
 
-    // When the admitted plan carries secret bindings, stand up this
-    // VM's transparent egress moat now that the guest is healthy:
-    //   1. spawn the per-VM substitution endpoint with the terminator listener
-    //      bound on a per-slot host port, and
-    //   2. install the nft TAP prerouting REDIRECT that steers the guest's
-    //      outbound :80 to that terminator.
-    // Fail closed: a secret-bearing workload must not keep running without its
-    // substitution path, so any failure rolls the VM back. Linux-only (nft +
-    // the FC path itself). The plan source is the same `plan.json` the bridge
-    // parsed; a missing/unsigned file means a legacy/non-admitted boot with no
-    // secrets — nothing to install.
-    #[cfg(target_os = "linux")]
-    if let Err(e) = super::egress_bridge::install_egress_redirect(config) {
-        // Roll back the running VM + its network. The guards were about to be
-        // defused; instead let them fire by returning before defuse — but the
-        // bridge watchdog already detached, so tear down explicitly. `stop_vm`
-        // reaps the substitution endpoint, so the (still-armed) endpoint_guard's
-        // Drop is then a harmless no-op.
-        warn!(vm = %config.slot.name, "egress redirect install failed; rolling back VM: {e}");
-        let _ = super::control::stop_vm(&config.slot.name);
-        return Err(e);
-    }
+    // The egress endpoint spawned pre-boot is the whole moat now: it self-gates
+    // egress over the guest's vsock channel, so there is no post-boot nft
+    // REDIRECT to install once the guest is healthy.
 
     // VM is fully started — defuse guards so normal stop path handles cleanup
     fc_guard.defuse();
-    tap_guard.defuse();
     #[cfg(target_os = "linux")]
     endpoint_guard.defuse();
     tunnel_guard.defuse();

--- a/crates/mvm-runtime/src/workload_backend.rs
+++ b/crates/mvm-runtime/src/workload_backend.rs
@@ -55,7 +55,11 @@ pub trait WorkloadBackend: VmBackend {
 
 impl WorkloadBackend for FirecrackerBackend {
     fn egress_substitution_transport(&self) -> EgressSubstitutionTransport {
-        EgressSubstitutionTransport::NftTerminator
+        // Vsock-only (Model-B): the guest dials the egress port over vsock,
+        // Firecracker muxes it to the per-VM host unix socket that owns claim-10
+        // enforcement and claims 12/13. No transparent :80/:443 terminator (no
+        // routable NIC to intercept) — proxy-aware substitution only, like hvf.
+        EgressSubstitutionTransport::VsockUdsChannel
     }
 }
 impl WorkloadBackend for LibkrunBackend {
@@ -140,11 +144,11 @@ mod tests {
     }
 
     #[test]
-    fn firecracker_declares_nft_terminator() {
+    fn firecracker_declares_vsock_uds_channel() {
         let transport = FirecrackerBackend.egress_substitution_transport();
-        assert_eq!(transport, EgressSubstitutionTransport::NftTerminator);
+        assert_eq!(transport, EgressSubstitutionTransport::VsockUdsChannel);
         assert!(transport.supports_proxy_aware_substitution());
-        assert!(transport.supports_transparent_terminator());
+        assert!(!transport.supports_transparent_terminator());
     }
 
     #[test]
@@ -192,12 +196,6 @@ mod tests {
     }
 
     #[test]
-    fn transparent_egress_terminator_requirement_accepts_firecracker() {
-        require_transparent_egress_terminator(&FirecrackerBackend)
-            .expect("firecracker declares the nft terminator leg");
-    }
-
-    #[test]
     fn transparent_egress_terminator_requirement_accepts_libkrun() {
         require_transparent_egress_terminator(&LibkrunBackend)
             .expect("libkrun declares the rvproxy terminator leg");
@@ -209,11 +207,15 @@ mod tests {
         let mock = MockBackend::new();
         #[cfg(feature = "test-support")]
         let backends: Vec<&dyn WorkloadBackend> = vec![
+            &FirecrackerBackend as &dyn WorkloadBackend,
             &HvfBackend as &dyn WorkloadBackend,
             &mock as &dyn WorkloadBackend,
         ];
         #[cfg(not(feature = "test-support"))]
-        let backends: Vec<&dyn WorkloadBackend> = vec![&HvfBackend as &dyn WorkloadBackend];
+        let backends: Vec<&dyn WorkloadBackend> = vec![
+            &FirecrackerBackend as &dyn WorkloadBackend,
+            &HvfBackend as &dyn WorkloadBackend,
+        ];
         for backend in backends {
             let err = match require_transparent_egress_terminator(backend) {
                 Ok(()) => panic!("{} should not satisfy the terminator gate", backend.name()),


### PR DESCRIPTION
Firecracker becomes a NIC-less, vsock/UDS-only egress backend, matching libkrun/HVF. This is the cutover that lets the smoltcp-L3 stack be deleted (separate follow-up, gated on live-KVM validation). One atomic change — any partial state is a bypass or breaks egress:

- **Token** — FC emits `mvm.vsock_egress=1` (gated `allows_egress() && !bound_secrets`), so the guest brings up the `mvm-egress-client` vsock proxy.
- **Host endpoint** — spawn the substitution endpoint over the **Uds** transport at `<vsock>_<EGRESS_PORT>`. FC's userspace virtio-vsock muxes a guest dial to `CID_HOST:EGRESS_PORT` onto that per-port host UDS, **not** a host `AF_VSOCK` listener (which an FC guest can never reach) — so the previous `Vsock` transport was unreachable. Self-gates on `secrets OR allows_egress`; `network_policy: Some` makes the host `EgressGate` the sole claim-10 authority; `raw_egress` per secrets; `terminator_listen: None`.
- **No routable NIC** — drop the `/network-interfaces/net1` device, `mvm.ip=`/`mvm.gw=`, the bridge/TAP provision, and the post-boot nft `:80`/`:443` REDIRECT. So **both ingress and egress now flow over vsock/UDS** (ingress via vsock port-forward). Scoped to the FC *workload* path only — the FC *builder* VM and the legacy `mvmctl start` dev path keep their NICs (verified).
- **Caps** — `no_routable_guest_nic`/`host_vsock_proxy` true, `tap_networking` false.
- **Transport declaration** — `egress_substitution_transport()` → `VsockUdsChannel` (was the now-removed `NftTerminator`), identical to HVF: proxy-aware substitution, no transparent terminator.

**Security-property note:** claim-10 enforcement moves from admission-time IP pinning at nftables to the host-side `EgressGate` (re-resolves per connection). Non-proxy-aware (transparent `:80`/`:443`) workloads are no longer accepted on FC — the honest consequence of NIC-less egress, same as HVF.

Verified: `mvm-runtime` clippy `-D warnings`, the FC/egress/network test sweep + `workload_backend` suite (FC now `VsockUdsChannel`, refused by the transparent-terminator gate), the `x86_64-unknown-linux-gnu` cross-build (Linux-only endpoint edit), and `check-vsock-only-egress` / `check-no-spec-refs-in-comments`. The end-to-end live witness (FC guest egressing over vsock; claims 12/13 rejection ladder) is a deferred KVM-box follow-up, same posture as the existing libkrun/HVF Model-B code. smoltcp-L3 stack left in place until that lands.