### PR TITLE
fix(hostd): allow lseek in the substitution-endpoint seccomp allowlist

### DIFF
--- a/crates/mvm-hostd/src/jailer/seccomp.rs
+++ b/crates/mvm-hostd/src/jailer/seccomp.rs
@@ -42,6 +42,9 @@ pub(crate) const BRIDGE_SYSCALLS: &[(&str, libc::c_long)] = &[
     ("fsync", libc::SYS_fsync),
     ("openat", libc::SYS_openat),
     ("close", libc::SYS_close),
+    // glibc's resolver seeks while reading /etc/hosts (getaddrinfo); a missing
+    // `lseek` SIGSYS-kills the endpoint mid-egress on a Linux host.
+    ("lseek", libc::SYS_lseek),
     // arch divergence: x86_64 keeps `stat` / `lstat` as their own
     // syscalls; aarch64 folds both into `fstatat` (see aarch64 block).
     ("stat", libc::SYS_stat),
@@ -146,6 +149,9 @@ pub(crate) const BRIDGE_SYSCALLS: &[(&str, libc::c_long)] = &[
     ("fsync", libc::SYS_fsync),
     ("openat", libc::SYS_openat),
     ("close", libc::SYS_close),
+    // glibc's resolver seeks while reading /etc/hosts (getaddrinfo); a missing
+    // `lseek` SIGSYS-kills the endpoint mid-egress on a Linux host.
+    ("lseek", libc::SYS_lseek),
     // arch divergence: aarch64 does not expose `stat` / `lstat` as
     // their own syscalls — both fold into `newfstatat` (syscall 79; libc
     // exposes no bare `SYS_fstatat` on aarch64). The policy layer still
@@ -304,6 +310,9 @@ mod tests {
         assert!(syscall_name_to_nr("write").is_some());
         assert!(syscall_name_to_nr("splice").is_some());
         assert!(syscall_name_to_nr("fsync").is_some());
+        // glibc resolver path — omitting it SIGSYS-killed the substitution
+        // endpoint mid-egress on a live Firecracker host.
+        assert!(syscall_name_to_nr("lseek").is_some());
     }
 
     #[test]


### PR DESCRIPTION
The per-VM substitution endpoint (`mvm-substitution-endpoint`) self-confines with a seccomp allowlist (`jailer::seccomp::BRIDGE_SYSCALLS`) that **omitted `lseek`**. glibc's resolver (`getaddrinfo` reading `/etc/hosts`) calls `lseek`, so the endpoint took a `SIGSYS` and exited ~100ms after logging `self-confined` — *after* the ready-handshake (so the VM still boots) but *before* serving. When the guest then dialed the egress port, nothing was listening → `ECONNREFUSED` → egress silently failed.

This never surfaced before because seccomp confinement is a **no-op on macOS**, so the existing libkrun/HVF Model-B path never exercised the confined endpoint. Firecracker is the first *Linux* Model-B backend to run it for real, and a **live KVM witness** caught it (strace `si_syscall=__NR_lseek`). It would have broken egress on every Linux Model-B host.

Fix: add `("lseek", libc::SYS_lseek)` to both the x86_64 and aarch64 `BRIDGE_SYSCALLS` blocks (`lseek` exists on both), plus a regression assertion. This follows the existing pattern — the allowlist already carries a `sigaltstack` entry with the note "Found via live FC strace — the allowlist had never been exercised on the real sidecar."

Verified: `cargo zigbuild --target x86_64-unknown-linux-gnu -p mvm-hostd --tests` clean under `-D warnings` (seccomp is Linux-gated; the assertion runs in the CI Linux lane) + `check-no-spec-refs-in-comments`. Unblocks the Firecracker Model-B cutover (#1748).