### PR TITLE
Shorten CLI help text

### DIFF
--- a/crates/mvm-cli/src/commands/machine/mod.rs
+++ b/crates/mvm-cli/src/commands/machine/mod.rs
@@ -160,129 +160,98 @@ impl MachineAction {
 /// flags and translates into the same admitted execution path.
 #[derive(ClapArgs, Debug, Clone)]
 pub(in crate::commands) struct MachineRunArgs {
-    /// OCI image reference to boot (pulled or reused from the local cache).
-    /// Required for a fresh boot; optional when reconnecting to an existing
-    /// persistent machine by `--name`. Mutually exclusive with `--manifest`,
-    /// `--flake`, and `--runtime-pack`.
+    /// Boot an OCI image.
     #[arg(long, value_name = "REF", conflicts_with_all = ["manifest", "flake", "runtime_pack"])]
     pub image: Option<String>,
-    /// Pre-built manifest slot (path to `mvm.toml`, its directory, or a slot
-    /// name). Mutually exclusive with `--image`, `--flake`, and
-    /// `--runtime-pack`.
+    /// Boot a pre-built manifest.
     #[arg(long, value_name = "PATH", conflicts_with_all = ["image", "flake", "runtime_pack"])]
     pub manifest: Option<String>,
-    /// Nix flake reference — build in the builder VM, then boot the result.
-    /// Mutually exclusive with `--image`, `--manifest`, and `--runtime-pack`.
+    /// Build and boot a Nix flake.
     #[arg(long, value_name = "PATH", conflicts_with_all = ["image", "manifest", "runtime_pack"])]
     pub flake: Option<String>,
-    /// Boot from a verified attested runtime pack in the local cache instead
-    /// of building/pulling an image. Its own image source: mutually
-    /// exclusive with `--image`, `--manifest`, and `--flake`.
+    /// Boot a verified runtime pack.
     #[arg(long, conflicts_with_all = ["image", "manifest", "flake"])]
     pub runtime_pack: bool,
-    /// Flake package variant (with `--flake`). Omit to use flake default.
+    /// Select a flake package.
     #[arg(long, value_name = "PROFILE", requires = "flake")]
     pub flake_profile: Option<String>,
-    /// Enable dev-tier outbound networking (broad egress + DNS). Off by
-    /// default (deny-all). Narrow it with `--allow-host`.
+    /// Enable outbound networking (off by default).
     #[arg(long)]
     pub net: bool,
-    /// Allow egress only to these hosts: `HOST[:PORT]` (PORT defaults to
-    /// 443), repeatable. Implies networking and **wins over `--net`**.
+    /// Allow outbound access to HOST[:PORT] (repeatable).
     #[arg(long = "allow-host", value_name = "HOST[:PORT]")]
     pub allow_host: Vec<String>,
-    /// vCPU cores.
+    /// Set the vCPU count.
     #[arg(long, default_value = "2")]
     pub cpus: u32,
-    /// Memory (supports human-readable: 512M, 1G, ...).
+    /// Set memory (for example, 512M or 1G).
     #[arg(long, default_value = "512M")]
     pub memory: String,
-    /// Security profile for the run.
+    /// Select a security profile.
     #[arg(long, value_enum, default_value = "standard")]
     pub profile: RunProfile,
-    /// Restrict the guest agent to these control verbs (repeatable). Overrides
-    /// the computed sealed-prod default. Values must be production-safe verbs.
+    /// Allow a production-safe guest-agent verb (repeatable).
     #[arg(long = "agent-verb", value_name = "VERB")]
     pub agent_verb: Vec<String>,
-    /// Mount a host directory into the guest: `HOST_PATH:/GUEST_PATH[:MODE]`.
-    /// MODE defaults to `ro`; `rw` needs `--profile dev` or `permissive`.
-    /// `--volume` remains as a compatibility alias; `-v` is global verbosity.
+    /// Mount HOST_PATH at GUEST_PATH[:MODE].
     #[arg(long = "mount", visible_alias = "volume")]
     pub volume: Vec<String>,
-    /// Explicit environment variable to inject (KEY=VALUE). Repeatable.
+    /// Set a guest environment variable (KEY=VALUE; repeatable).
     #[arg(short, long)]
     pub env: Vec<String>,
-    /// Per-command timeout in seconds. Unset ⇒ no per-command kill.
+    /// Set the command timeout in seconds.
     #[arg(long)]
     pub timeout: Option<u64>,
-    /// Write a signed execution receipt to this path.
+    /// Write a signed execution receipt.
     #[arg(long, value_name = "PATH")]
     pub receipt: Option<PathBuf>,
-    /// Print a redacted machine-readable JSON summary instead of streaming output.
+    /// Print a redacted JSON summary.
     #[arg(long)]
     pub json: bool,
-    /// Validate and explain the effective run plan without booting a VM.
+    /// Show the run plan without booting.
     #[arg(long)]
     pub dry_run: bool,
-    /// Run under this machine identity. Foreground runs still tear down when
-    /// the command exits; use `machine create`/`start` for long-lived machines.
+    /// Set the machine name.
     #[arg(long, value_name = "NAME")]
     pub name: Option<String>,
-    /// Boot a persistent machine and return immediately. Auto-names the machine
-    /// when `--name` is absent (the chosen name is printed). Implies persistence.
+    /// Keep the machine running and return.
     #[arg(short = 'd', long)]
     pub detach: bool,
-    /// Emit a one-line JSON envelope on stdout when the machine is up.
-    /// Routes all other output to stderr. Implies persistence + detach
-    /// semantics (boot and return). Envelope shape:
-    /// `{"schema_version":1,"vm_id":"<name>","build_mode":"dev"|"prod"}`.
-    /// Used by the SDK live-mode transport to learn the vm_id and build_mode.
+    /// Return machine startup details as JSON.
     #[arg(long = "up-json")]
     pub up_json: bool,
-    /// Set a TTL on the persistent machine after boot: `30s`, `5m`, `2h`, `7d`
-    /// or a bare number of seconds. The reaper tears down expired machines.
+    /// Stop the machine after DURATION (for example, 30s or 2h).
     #[arg(long, value_name = "DURATION")]
     pub ttl: Option<String>,
-    /// Declare this workload a long-running service: the shell command is
-    /// exec'd in the guest as its liveness check (exit 0 = healthy). Its
-    /// presence promotes the run to the persistent lifecycle — it will not tear
-    /// down on a backstop; it runs until `stop`. A run whose entrypoint exits
-    /// still tears down on that exit code.
+    /// Use CMD to check service health (exit 0 is healthy).
     #[arg(long, value_name = "CMD")]
     pub healthcheck: Option<String>,
-    /// Seconds between checks. Recorded now; enforced when active probing lands.
+    /// Record check interval in seconds (not yet enforced).
     #[arg(long = "health-interval", default_value_t = 30)]
     pub health_interval: u32,
-    /// Per-check timeout in seconds. Recorded now; enforced later.
+    /// Record check timeout in seconds (not yet enforced).
     #[arg(long = "health-timeout", default_value_t = 5)]
     pub health_timeout: u32,
-    /// Consecutive failures before unhealthy. Recorded now; enforced later.
+    /// Record failures before unhealthy (not yet enforced).
     #[arg(long = "health-retries", default_value_t = 3)]
     pub health_retries: u32,
-    /// Grace period after start before checks count. Recorded now; enforced later.
+    /// Record the initial grace period (not yet enforced).
     #[arg(long = "health-start-period", default_value_t = 0)]
     pub health_start_period: u32,
-    /// Attach the foreground command to an interactive PTY.
+    /// Attach the command to an interactive PTY.
     #[arg(short = 't', long, conflicts_with_all = ["detach", "up_json", "ttl"])]
     pub tty: bool,
-    /// Accepted as an alias for `-t` so the conventional `-it` bundle parses.
+    /// Alias for `--tty` (supports the conventional `-it`).
     #[arg(
         short = 'i',
         long = "interactive",
         conflicts_with_all = ["detach", "up_json", "ttl"]
     )]
     pub interactive: bool,
-    /// Force-recreate a persistent machine whose on-disk spec exists with a
-    /// different config (stop + overwrite + restart). Without it, a config
-    /// mismatch is an error.
+    /// Recreate a named machine when its config changed.
     #[arg(long)]
     pub force: bool,
-    /// Workload VMM backend. Defaults to the host's best supported backend
-    /// (Linux+KVM → firecracker; macOS 26+ → hvf; macOS 13-25 → libkrun). On a
-    /// Linux+KVM host, `--hypervisor libkrun` opts into the libkrun runtime instead
-    /// of the firecracker default — both require `/dev/kvm` and enforce claim-10
-    /// egress (qemu is a no-`/dev/kvm` dev/test fallback only). `MVM_HYPERVISOR` is
-    /// the env equivalent.
+    /// Select the VMM (firecracker, hvf, libkrun, or qemu).
     #[arg(long, value_name = "HYPERVISOR")]
     pub hypervisor: Option<String>,
     /// Skip plan-admission signing (hidden; for testing only).
@@ -294,40 +263,26 @@ pub(in crate::commands) struct MachineRunArgs {
     #[arg(long = "kernel-pin", value_name = "PIN", hide = true)]
     pub kernel_pin: Option<String>,
     // ── Action axis: --entrypoint dispatches the image's baked entrypoint ──
-    /// Call the image's baked `/etc/mvm/entrypoint` instead of running argv —
-    /// the production-safe call surface (no shell, no argv override): dispatches
-    /// the `RunEntrypoint` vsock verb. Source must be `--manifest`/`--flake`
-    /// (OCI `--image` runs its own command via the default argv action).
-    /// Conflicts with a trailing `-- <argv>` and with the interactive shell.
+    /// Run the image's baked entrypoint.
     #[arg(long, conflicts_with_all = ["argv", "tty", "interactive"])]
     pub entrypoint: bool,
-    /// Boot a fresh transient VM for the entrypoint call (the current default;
-    /// wired so a future warm-session default can be opted out of). Requires
-    /// `--entrypoint`.
+    /// Boot a fresh VM for the entrypoint.
     #[arg(long, requires = "entrypoint", conflicts_with = "reset")]
     pub fresh: bool,
-    /// Restore the session VM from its post-boot snapshot before the entrypoint
-    /// call. Wired but no-op in this build. Requires `--entrypoint`.
+    /// Reset the VM before the entrypoint (currently a no-op).
     #[arg(long, requires = "entrypoint")]
     pub reset: bool,
-    /// Workload IR (`workload.json`) declaring `.secrets` for the entrypoint
-    /// call: the ephemeral VM is admitted so the host spawns the substitution
-    /// endpoint and egress gets the real credential (the guest holds only the
-    /// opaque placeholder). Requires `--entrypoint`.
+    /// Load entrypoint secrets from workload IR.
     #[arg(long, value_name = "PATH", requires = "entrypoint")]
     pub from_workload_ir: Option<PathBuf>,
-    /// Dispatch the entrypoint into an already-running named machine (booted by
-    /// `machine run --name <NAME>`) instead of a transient VM, reusing its
-    /// substitution endpoint. Requires `--entrypoint` + `--name`.
+    /// Run the entrypoint on an existing named machine.
     #[arg(
         long,
         requires_all = ["entrypoint", "name"],
         conflicts_with_all = ["image", "manifest", "flake", "fresh", "reset", "detach"]
     )]
     pub attach: bool,
-    /// Argv to run inside the guest (use `--` to separate). Optional for
-    /// persistent (`-d`/`--name`) and interactive (`-t`) modes; required for a
-    /// plain transient run.
+    /// Command and arguments to run in the guest.
     #[arg(trailing_var_arg = true, allow_hyphen_values = true)]
     pub argv: Vec<String>,
 }

--- a/crates/mvm-cli/src/commands/mod.rs
+++ b/crates/mvm-cli/src/commands/mod.rs
@@ -39,31 +39,33 @@ use shared::{CHILD_PIDS, IN_CONSOLE_MODE, with_hints};
 #[derive(Parser, Debug, Clone)]
 #[command(name = "mvmctl", version, about = "Lightweight VM development tool")]
 pub(in crate::commands) struct Cli {
-    /// Log format: human (default) or json (structured)
+    /// Output format
     #[arg(long, global = true)]
     pub log_format: Option<String>,
 
-    /// Override Firecracker version (e.g., v1.14.0)
+    /// Firecracker version
     #[arg(long, global = true)]
     pub fc_version: Option<String>,
 
-    /// Override which hypervisor drives the builder VM.
-    /// Highest priority — beats `MVM_BUILDER_BACKEND`
-    /// env and the platform-default auto-detect (macOS 26+ Apple
-    /// Silicon → hvf; Linux native → qemu; everywhere else → libkrun).
-    #[arg(long, global = true, value_parser = ["libkrun", "qemu", "hvf"])]
+    /// Builder VMM: libkrun, qemu, or hvf
+    #[arg(
+        long,
+        global = true,
+        value_parser = ["libkrun", "qemu", "hvf"],
+        hide_possible_values = true
+    )]
     pub builder: Option<String>,
 
-    /// Where the builder VM's kernel comes from when its image is
-    /// (re)built: `compile` (default — build it in-image via Stage 0),
-    /// `download` (boot on a published, hash-verified kernel — skips the
-    /// kernel compile), or `auto` (download if available, else compile).
-    #[arg(long, global = true, value_parser = ["compile", "download", "auto"])]
+    /// Kernel source: compile, download, or auto
+    #[arg(
+        long,
+        global = true,
+        value_parser = ["compile", "download", "auto"],
+        hide_possible_values = true
+    )]
     pub kernel_source: Option<String>,
 
-    /// Increase log verbosity: -v (info), -vv (debug), -vvv (trace).
-    /// Default is quiet (errors only). `RUST_LOG=<filter>` overrides.
-    /// Global, so it may appear before or after a subcommand.
+    /// Increase verbosity
     #[arg(
         short = 'v',
         long = "verbose",

--- a/crates/mvm-cli/src/commands/tests.rs
+++ b/crates/mvm-cli/src/commands/tests.rs
@@ -60,6 +60,61 @@ fn top_level_command_summaries_stay_short() {
 }
 
 #[test]
+fn global_option_summaries_stay_short() {
+    let longest_allowed = 48;
+    let long_summaries = cli_command()
+        .get_arguments()
+        .filter(|arg| arg.is_global_set())
+        .filter_map(|arg| {
+            arg.get_long_help()
+                .or_else(|| arg.get_help())
+                .and_then(|help| {
+                    let help = help.to_string();
+                    (help.chars().count() > longest_allowed)
+                        .then(|| format!("--{}: {help}", arg.get_id()))
+                })
+        })
+        .collect::<Vec<_>>();
+
+    assert!(
+        long_summaries.is_empty(),
+        "global option summaries must be {longest_allowed} chars or shorter:\n{}",
+        long_summaries.join("\n")
+    );
+}
+
+#[test]
+fn machine_run_option_summaries_stay_short() {
+    let longest_allowed = 64;
+    let command = cli_command();
+    let machine = command
+        .find_subcommand("machine")
+        .expect("machine command must exist");
+    let run = machine
+        .find_subcommand("run")
+        .expect("machine run command must exist");
+    let long_summaries = run
+        .get_arguments()
+        .filter(|arg| !arg.is_hide_set())
+        .filter_map(|arg| {
+            arg.get_long_help()
+                .or_else(|| arg.get_help())
+                .and_then(|help| {
+                    let help = help.to_string();
+                    (help.chars().count() > longest_allowed)
+                        .then(|| format!("{}: {help}", arg.get_id()))
+                })
+        })
+        .collect::<Vec<_>>();
+
+    assert!(
+        long_summaries.is_empty(),
+        "machine run option summaries must be {longest_allowed} chars or shorter:\n{}",
+        long_summaries.join("\n")
+    );
+}
+
+#[test]
 fn internal_subprocess_commands_are_hidden_from_help() {
     // Subprocess/internal commands must not clutter the user-facing
     // surface. They stay dispatchable but `hide = true`.

--- a/crates/mvm-cli/src/commands/vm/exec.rs
+++ b/crates/mvm-cli/src/commands/vm/exec.rs
@@ -91,13 +91,13 @@ pub(in crate::commands) struct Args {
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, ValueEnum)]
 pub(in crate::commands) enum RunProfile {
-    /// No env injection and no host directory shares.
+    /// No environment variables or host mounts.
     Restrictive,
-    /// Explicit env is allowed; host directory shares must stay read-only.
+    /// Environment variables and read-only host mounts.
     Standard,
-    /// Dev-mode ergonomics: explicit env and writable host shares are allowed.
+    /// Environment variables and writable host mounts.
     Dev,
-    /// Escape hatch for local experiments; requires MVM_ACK_PERMISSIVE_RUN=1.
+    /// Local escape hatch; requires MVM_ACK_PERMISSIVE_RUN=1.
     Permissive,
 }
 

--- a/crates/mvm-conformance/tests/steps/cli.rs
+++ b/crates/mvm-conformance/tests/steps/cli.rs
@@ -56,3 +56,50 @@ fn output_contains(world: &mut CliWorld, needle: String) {
         String::from_utf8_lossy(&output.stderr)
     );
 }
+
+#[then(expr = "the help output contains {string}")]
+fn help_contains(world: &mut CliWorld, expected: String) {
+    let output = world.last_output();
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    assert!(
+        stdout.contains(&expected),
+        "expected help output to contain {expected:?}:\n{stdout}"
+    );
+}
+
+#[then(expr = "the help output does not contain {string}")]
+fn help_does_not_contain(world: &mut CliWorld, unexpected: String) {
+    let output = world.last_output();
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    assert!(
+        !stdout.contains(&unexpected),
+        "expected help output not to contain {unexpected:?}:\n{stdout}"
+    );
+}
+
+#[then(expr = "the help options fit within {int} columns")]
+fn help_options_fit_within(world: &mut CliWorld, width: i64) {
+    let output = world.last_output();
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    let option_lines = stdout
+        .lines()
+        .skip_while(|line| line.trim() != "Options:")
+        .skip(1)
+        .filter(|line| !line.trim().is_empty())
+        .collect::<Vec<_>>();
+
+    assert!(
+        !option_lines.is_empty(),
+        "help output has no options:\n{stdout}"
+    );
+    for line in option_lines {
+        assert!(
+            line.trim_start().starts_with('-'),
+            "help option wrapped onto a continuation line:\n{line}\n\n{stdout}"
+        );
+        assert!(
+            i64::try_from(line.chars().count()).expect("line length must fit in i64") <= width,
+            "help option exceeds {width} columns:\n{line}\n\n{stdout}"
+        );
+    }
+}

--- a/features/suites/s0_cli/verbs.feature
+++ b/features/suites/s0_cli/verbs.feature
@@ -12,3 +12,23 @@ Feature: mvmctl top-level CLI surface
     And the help output lists the "doctor" verb
     And the help output lists the "ls" verb
     And the help output lists the "bootstrap" verb
+
+  Scenario: mvmctl --help keeps global option descriptions concise
+    When I run mvmctl with "--help"
+    Then the command exits with code 0
+    And the help output contains "Output format"
+    And the help output contains "Builder VMM: libkrun, qemu, or hvf"
+    And the help output contains "Kernel source: compile, download, or auto"
+    And the help options fit within 80 columns
+    But the help output does not contain "Highest priority"
+    And the help output does not contain "platform-default auto-detect"
+
+  Scenario: machine run help keeps option descriptions concise
+    When I run mvmctl with "machine run --help"
+    Then the command exits with code 0
+    And the help output contains "Boot an OCI image"
+    And the help output contains "Allow outbound access to HOST[:PORT] (repeatable)"
+    And the help output contains "Select the VMM (firecracker, hvf, libkrun, or qemu)"
+    And the help output contains "Record check interval in seconds (not yet enforced)"
+    But the help output does not contain "Mutually exclusive with"
+    And the help output does not contain "production-safe call surface"


### PR DESCRIPTION
## Summary

- shorten global and `machine run` option descriptions
- keep the top-level options table on one line per option and within 80 columns
- preserve accepted builder and kernel-source values without duplicated generated value lists
- add unit length guards and real-binary Cucumber coverage for concise rendered help

## Why

The option descriptions had grown into implementation-heavy paragraphs. Clap rendered them as long, wrapping rows that made the primary help output difficult to scan.

## Validation

- `cargo fmt --check`
- `cargo test -p mvm-cli summaries_stay_short --lib`
- `just bdd` — 3 scenarios, 23 steps passed
- `cargo clippy -p mvm-cli --lib -- -D warnings`
- `cargo clippy -p mvm-conformance --all-targets --features bdd -- -D warnings`
- `git diff --check`

A broader workspace test run encountered existing parallel shared-state lock races in builder tests; each failing test passed when rerun alone.
