### PR TITLE
test(bdd): implement the uniform vsock-egress claim scenarios

### DIFF
--- a/crates/mvm-conformance/tests/steps/cli.rs
+++ b/crates/mvm-conformance/tests/steps/cli.rs
@@ -45,3 +45,14 @@ fn help_lists_verb(world: &mut CliWorld, verb: String) {
         "expected top-level verb {verb:?} in `mvmctl --help` output:\n{stdout}"
     );
 }
+
+#[then(expr = "the output contains {string}")]
+fn output_contains(world: &mut CliWorld, needle: String) {
+    let output = world.last_output();
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    assert!(
+        stdout.contains(needle.as_str()),
+        "expected stdout to contain {needle:?}; stdout:\n{stdout}\nstderr:\n{}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+}

--- a/features/suites/s2_egress_vsock/default_deny_egress.feature
+++ b/features/suites/s2_egress_vsock/default_deny_egress.feature
@@ -4,10 +4,45 @@ Feature: Default-deny egress through the auditable vsock seam
   policy, and every workload backend mediates egress through the vsock seam
   rather than a bypassable host NIC/TAP.
 
-  @wip
-  Scenario: An unadmitted workload cannot reach the network
-    Given a scenario awaiting its step implementation
+  Scenario: Host mediates egress over vsock, not a NIC
+    When I run mvmctl with "doctor"
+    Then the output contains "network-backend: OK (direct vsock only; no host gateway binary is part of the active runtime contract)"
+    And the output contains "network policy default (claim 10): OK (deny_all (claim 10 holds — egress refused unless explicitly admitted))"
 
+  Scenario Outline: An unadmitted workload defaults to deny on every backend
+    When I run mvmctl with "machine run --image alpine --name bdd-egress-deny-<backend> -d --hypervisor <backend> --dry-run"
+    Then the command exits with code 0
+    And the output contains "network: deny-all"
+    And the output contains "enforced: flow-drop"
+
+    Examples:
+      | backend     |
+      | hvf         |
+      | libkrun     |
+      | firecracker |
+
+  Scenario Outline: Every workload backend mediates admitted egress over the vsock seam, not a NIC
+    When I run mvmctl with "machine run --image alpine --name bdd-egress-allow-<backend> -d --hypervisor <backend> --allow-host example.com --dry-run"
+    Then the command exits with code 0
+    And the output contains "network: allow-list:example.com:443"
+    And the output contains "enforced: <backend>:l4-host-port"
+
+    Examples:
+      | backend |
+      | hvf     |
+      | libkrun |
+
+  # Firecracker is not yet vsock-only on main: an OCI --image run with an
+  # allow-host rule under --hypervisor firecracker refuses admission instead
+  # of confirming vsock-mediated egress, because the firecracker backend does
+  # not yet advertise the vsock/no-routable-guest-nic/host-vsock-proxy
+  # capability set the other two backends do. This scenario states the
+  # definition-of-done a later firecracker driver change flips to passing —
+  # drop the @wip tag once it does, and fold this row back into the
+  # Scenario Outline above.
   @wip
-  Scenario: An admitted allow-rule reaches only its approved endpoint
-    Given a scenario awaiting its step implementation
+  Scenario: Firecracker mediates admitted egress over the vsock seam, not a NIC
+    When I run mvmctl with "machine run --image alpine --name bdd-egress-allow-firecracker -d --hypervisor firecracker --allow-host example.com --dry-run"
+    Then the command exits with code 0
+    And the output contains "network: allow-list:example.com:443"
+    And the output contains "enforced: firecracker:l4-host-port"


### PR DESCRIPTION
Makes the stubbed `s2_egress_vsock` cucumber feature a real, CI-runnable test — the security claim expressed as Given/When/Then. Claim-first foundation for converging every workload backend onto the one vsock-egress seam.

The claim, now testable at the CLI surface (no live microVM):
- **`doctor`** proves the host mediates egress over vsock (`network-backend: … direct vsock only`) and that claim-10 default-deny holds.
- **Default-deny is uniform across *all three* workload backends** (hvf, libkrun, firecracker): a dry-run with no allow-rule shows `network: deny-all` / `enforced: flow-drop`.
- **Admitted egress is vsock-mediated** on hvf + libkrun (`enforced: <backend>:l4-host-port`).
- **Firecracker admitted-egress is `@wip`** — on main it *refuses admission* (`backend firecracker does not advertise {vsock,no_routable_guest_nic,host_vsock_proxy}`), so the scenario documents the definition-of-done the `FcDriver` convergence flips green.

Reuses the existing `mvm-conformance` harness (cucumber 0.23) — one new generic `the output contains {string}` step, no new deps, no scratch. `cargo test -p mvm-conformance --test conformance --features bdd` → 7/7 scenarios, 30/30 steps; clippy `-D warnings` clean.

Note surfaced while writing this: transient `machine run --hypervisor X --dry-run` silently ignores `--hypervisor` (no field on `RunArgs`); the persistent `-d --name` form threads it correctly, so the scenarios use that. Tracked separately.