### PR TITLE
feat(runtime): dispatch backend metadata through the VmmDriver seam

### DIFF
--- a/crates/mvm-runtime/src/driver/hvf.rs
+++ b/crates/mvm-runtime/src/driver/hvf.rs
@@ -17,7 +17,8 @@ use mvm_agentd::vsock::{CONSOLE_PORT_BASE, EGRESS_PORT, GUEST_AGENT_PORT, dev_co
 use mvm_build::hvf_supervisor::{ConsoleDataSocket, HvfDisk, HvfSupervisorConfig};
 use mvm_core::config::{vm_hvf_vsock_port_socket_at, vm_state_dir};
 use mvm_core::vm_backend::{
-    SnapshotCapability, VmBackend, VmCapabilities, VmExitStatus, VmId, VmStatus,
+    BackendKind, BackendSecurityProfile, GuestChannelInfo, SnapshotCapability, VmBackend,
+    VmCapabilities, VmExitStatus, VmId, VmStatus,
 };
 
 use crate::driver::spec::KernelImage;
@@ -175,6 +176,10 @@ impl VmmDriver for HvfDriver {
         self.backend.name()
     }
 
+    fn kind(&self) -> BackendKind {
+        self.backend.kind()
+    }
+
     fn is_available(&self) -> Result<bool> {
         self.backend.is_available()
     }
@@ -185,6 +190,10 @@ impl VmmDriver for HvfDriver {
 
     fn snapshot_capability(&self) -> SnapshotCapability {
         self.backend.snapshot_capability()
+    }
+
+    fn security_profile(&self) -> BackendSecurityProfile {
+        self.backend.security_profile()
     }
 
     fn boot(&self, spec: &VmmSpec) -> Result<Box<dyn RunningVm>> {
@@ -276,6 +285,10 @@ impl VmmDriver for HvfDriver {
             state_dir,
             id: id.clone(),
         }))
+    }
+
+    fn guest_channel_info(&self, id: &VmId) -> Result<GuestChannelInfo> {
+        self.backend.guest_channel_info(id)
     }
 }
 
@@ -409,8 +422,24 @@ mod tests {
     fn identity_and_capabilities_delegate_to_the_hvf_backend() {
         let d = HvfDriver::new();
         assert_eq!(d.name(), "hvf");
+        assert_eq!(d.kind(), BackendKind::Hvf);
         assert!(d.capabilities().vsock);
         assert_eq!(d.snapshot_capability(), SnapshotCapability::Unsupported);
+        assert_eq!(
+            d.security_profile().tier,
+            HvfBackend.security_profile().tier
+        );
+    }
+
+    #[test]
+    fn guest_channel_info_delegates_to_the_hvf_backend() {
+        // HvfBackend declares no guest channel (the agent bridge is a fixed
+        // vsock port, not a queryable per-VM channel) — the driver must relay
+        // that same fail-closed answer rather than inventing one.
+        let d = HvfDriver::new();
+        let id = VmId("hvf-guest-channel-info-test-vm".into());
+        assert!(d.guest_channel_info(&id).is_err());
+        assert!(HvfBackend.guest_channel_info(&id).is_err());
     }
 
     #[test]

--- a/crates/mvm-runtime/src/driver/mock.rs
+++ b/crates/mvm-runtime/src/driver/mock.rs
@@ -7,8 +7,11 @@ use std::collections::HashMap;
 use std::os::unix::net::UnixStream;
 use std::sync::{Arc, Mutex};
 
-use anyhow::{Result, anyhow};
-use mvm_core::vm_backend::{SnapshotCapability, VmCapabilities, VmExitStatus, VmId, VmStatus};
+use anyhow::{Result, anyhow, bail};
+use mvm_core::vm_backend::{
+    BackendKind, BackendSecurityProfile, ClaimStatus, GuestChannelInfo, LayerCoverage,
+    SnapshotCapability, VmCapabilities, VmExitStatus, VmId, VmStatus,
+};
 
 use crate::driver::spec::VmmSpec;
 use crate::driver::traits::{DuplexStream, RunningVm, VmmDriver};
@@ -67,6 +70,9 @@ impl VmmDriver for MockDriver {
     fn name(&self) -> &str {
         "mock"
     }
+    fn kind(&self) -> BackendKind {
+        BackendKind::Mock
+    }
     fn is_available(&self) -> Result<bool> {
         Ok(true)
     }
@@ -78,6 +84,19 @@ impl VmmDriver for MockDriver {
     }
     fn snapshot_capability(&self) -> SnapshotCapability {
         SnapshotCapability::Unsupported
+    }
+    fn security_profile(&self) -> BackendSecurityProfile {
+        // Mirrors `MockBackend::security_profile` — the mock runs no guest and
+        // holds none of the seven CI-enforced claims.
+        BackendSecurityProfile {
+            claims: [ClaimStatus::DoesNotHold; 7],
+            layer_coverage: LayerCoverage::default(),
+            tier: "Tier 3 (test-only)",
+            notes: &[
+                "MockDriver is in-process test infrastructure.",
+                "No guest, no rootfs, no isolation; never use in production.",
+            ],
+        }
     }
     fn boot(&self, spec: &VmmSpec) -> Result<Box<dyn RunningVm>> {
         self.booted.lock().unwrap().push(spec.clone());
@@ -96,6 +115,10 @@ impl VmmDriver for MockDriver {
             status: self.status.clone(),
             guest_ends: Arc::clone(&self.guest_ends),
         }))
+    }
+
+    fn guest_channel_info(&self, _id: &VmId) -> Result<GuestChannelInfo> {
+        bail!("mock driver does not provide guest channel info")
     }
 }
 
@@ -178,6 +201,30 @@ mod tests {
         );
         assert_eq!(vm.id(), &VmId("probe".into()));
         assert_eq!(driver.name(), "mock");
+    }
+
+    #[test]
+    fn mock_driver_reports_mock_identity_and_test_only_security_profile() {
+        let driver = MockDriver::default();
+        assert_eq!(driver.kind(), BackendKind::Mock);
+        let profile = driver.security_profile();
+        assert_eq!(profile.tier, "Tier 3 (test-only)");
+        assert!(
+            profile
+                .claims
+                .iter()
+                .all(|c| *c == ClaimStatus::DoesNotHold)
+        );
+    }
+
+    #[test]
+    fn mock_driver_guest_channel_info_fails_closed() {
+        let driver = MockDriver::default();
+        assert!(
+            driver
+                .guest_channel_info(&VmId("no-such-vm".into()))
+                .is_err()
+        );
     }
 
     #[test]

--- a/crates/mvm-runtime/src/driver/traits.rs
+++ b/crates/mvm-runtime/src/driver/traits.rs
@@ -5,7 +5,10 @@
 //! describes and nothing more.
 
 use anyhow::Result;
-use mvm_core::vm_backend::{SnapshotCapability, VmCapabilities, VmExitStatus, VmId, VmStatus};
+use mvm_core::vm_backend::{
+    BackendKind, BackendSecurityProfile, GuestChannelInfo, SnapshotCapability, VmCapabilities,
+    VmExitStatus, VmId, VmStatus,
+};
 
 use crate::driver::spec::VmmSpec;
 
@@ -17,12 +20,16 @@ impl<T: std::io::Read + std::io::Write + Send> DuplexStream for T {}
 pub trait VmmDriver: Send + Sync {
     /// Stable backend token (`"libkrun"`, `"firecracker"`, `"hvf"`, `"mock"`).
     fn name(&self) -> &str;
+    /// The typed discriminant; branch on this, never on `name()`.
+    fn kind(&self) -> BackendKind;
     /// Whether this VMM can run on the current host.
     fn is_available(&self) -> Result<bool>;
     /// Coarse capability flags.
     fn capabilities(&self) -> VmCapabilities;
     /// Honest warm-start tier.
     fn snapshot_capability(&self) -> SnapshotCapability;
+    /// Which of the CI-enforced security claims this VMM's boot path holds.
+    fn security_profile(&self) -> BackendSecurityProfile;
     /// Boot the VM described by `spec`, returning a live handle.
     fn boot(&self, spec: &VmmSpec) -> Result<Box<dyn RunningVm>>;
 
@@ -31,6 +38,10 @@ pub trait VmmDriver: Send + Sync {
     /// handle is disk-backed (pid file + exit record), so no in-memory boot state
     /// is needed; a returned handle whose VM has since exited reports `Stopped`.
     fn attach(&self, id: &VmId) -> Result<Box<dyn RunningVm>>;
+
+    /// Guest communication channel info for VM `id`. Errors when the VMM has
+    /// none to report.
+    fn guest_channel_info(&self, id: &VmId) -> Result<GuestChannelInfo>;
 }
 
 /// A live VM handle. Launch-model-agnostic: an in-process VMM, a subprocess,

--- a/crates/mvm-runtime/src/workload_runner/runner.rs
+++ b/crates/mvm-runtime/src/workload_runner/runner.rs
@@ -14,7 +14,8 @@ use mvm_core::plan::SecretBinding;
 use mvm_core::policy::RedactionPolicy;
 use mvm_core::policy::network_policy::NetworkPolicy;
 use mvm_core::vm_backend::{
-    BackendKind, VmBackend, VmCapabilities, VmExitStatus, VmId, VmInfo, VmStartConfig, VmStatus,
+    BackendKind, BackendSecurityProfile, GuestChannelInfo, SnapshotCapability, VmBackend,
+    VmCapabilities, VmExitStatus, VmId, VmInfo, VmStartConfig, VmStatus,
 };
 
 use crate::driver::{RunningVm, VmmDriver};
@@ -186,15 +187,24 @@ impl<D: VmmDriver + 'static, S: EndpointSpawner + 'static> VmBackend for Workloa
         self.driver.name()
     }
 
-    // The runner is driver-generic, but the only `VmmDriver` wired up today is
-    // `HvfDriver` — mirror `AnyBackend::kind()`'s `HvfRunner -> Hvf` mapping. A
-    // future second driver would need this to become driver-dispatched too.
     fn kind(&self) -> BackendKind {
-        BackendKind::Hvf
+        self.driver.kind()
     }
 
     fn capabilities(&self) -> VmCapabilities {
         self.driver.capabilities()
+    }
+
+    fn snapshot_capability(&self) -> SnapshotCapability {
+        self.driver.snapshot_capability()
+    }
+
+    fn security_profile(&self) -> BackendSecurityProfile {
+        self.driver.security_profile()
+    }
+
+    fn guest_channel_info(&self, id: &VmId) -> Result<GuestChannelInfo> {
+        self.driver.guest_channel_info(id)
     }
 
     fn is_available(&self) -> Result<bool> {
@@ -332,6 +342,7 @@ mod tests {
     use mvm_agentd::vsock::EGRESS_PORT;
     use mvm_core::plan::{SecretBinding, SecretSource};
 
+    use crate::driver::HvfDriver;
     use crate::driver::mock::MockDriver;
 
     /// An `EndpointSpawner` test double: records the request it was handed and
@@ -536,6 +547,27 @@ mod tests {
         assert_eq!(runner.name(), want_name);
         assert_eq!(runner.capabilities().vsock, want_caps.vsock);
         assert!(runner.is_available().unwrap());
+    }
+
+    #[test]
+    fn vmbackend_kind_snapshot_security_and_channel_delegate_to_the_hvf_driver() {
+        // Proves the runner reads these from the driver rather than the old
+        // `BackendKind::Hvf` hardcode / the VmBackend trait's fail-closed
+        // defaults — a runner wrapping a *different* driver would report that
+        // driver's own values instead.
+        let driver = HvfDriver::new();
+        let want_kind = driver.kind();
+        let want_snapshot = driver.snapshot_capability();
+        let want_security_tier = driver.security_profile().tier;
+        let id = VmId("kind-delegation-test-vm".into());
+        let want_channel_err = driver.guest_channel_info(&id).is_err();
+        let runner = WorkloadRunner::new(driver, RecordingSpawner::new("/run/ep.sock"));
+
+        assert_eq!(runner.kind(), want_kind);
+        assert_eq!(runner.kind(), BackendKind::Hvf);
+        assert_eq!(runner.snapshot_capability(), want_snapshot);
+        assert_eq!(runner.security_profile().tier, want_security_tier);
+        assert_eq!(runner.guest_channel_info(&id).is_err(), want_channel_err);
     }
 
     #[test]


### PR DESCRIPTION
First slice of converging every workload backend onto the uniform `WorkloadRunner<VmmDriver, RealEndpointSpawner>` seam (so the vsock-egress + substitution claims are enforced in one audited place every backend traverses).

Today `WorkloadRunner`'s `VmBackend` impl hardcodes `kind()` to `BackendKind::Hvf` and inherits the trait's fail-closed defaults for `snapshot_capability`/`security_profile`/`guest_channel_info` — so it can't host a second driver and mis-reports HVF-runner's own posture. This makes the runner **delegate** backend metadata to the driver:
- Adds `kind`/`security_profile`/`guest_channel_info` to the `VmmDriver` trait (`snapshot_capability` was already there). These are identity/capability reporters — they fit the trait's "pure mechanics, no plan, no policy" contract.
- `HvfDriver` delegates all to its `HvfBackend` (same pattern as its existing `name`/`capabilities`); `MockDriver` implements mock-appropriate values.
- The runner's `VmBackend` impl delegates all four to `self.driver`.

Behavior-preserving for HVF except one intended fix: HVF-runner now reports its real Tier-2 `security_profile` instead of the fail-closed `Unknown` default (the latent bug this unblocks). Foundation that unblocks `LibkrunDriver`/`FcDriver`.

Verified: `nextest -p mvm-runtime` 899 passed (6 new tests covering the driver methods + the runner's delegation), clippy `-D warnings`, `x86_64-unknown-linux-gnu` cross-build. No existing test asserted the old hardcode/defaults.