### PR TITLE
feat(runtime): share the workload kernel-cmdline assembler with WorkloadRunner

### DIFF
--- a/crates/mvm-runtime/src/hvf_backend.rs
+++ b/crates/mvm-runtime/src/hvf_backend.rs
@@ -32,6 +32,7 @@ use crate::network_tunnel_spawn::{
     NetworkTunnelListener, NetworkTunnelWorkerSpawnParams, reap_network_tunnel_worker,
     spawn_network_tunnel_worker_if_configured,
 };
+use crate::workload_runner::cmdline;
 
 /// PID file the supervisor writes inside `vm_state_dir`. Distinct from the other
 /// backends' markers so HVF VMs coexist under the same `~/.mvm/vms/` root.
@@ -191,57 +192,12 @@ fn spawn_hvf_gating_endpoint_if_needed(
     Ok((EndpointGuard::new(vm_name), Some(socket)))
 }
 
-/// Kernel cmdline token that turns on the in-guest vsock egress client.
-/// Emitted only when the run actually allows outbound egress and the workload
-/// carries no bound secrets, so the raw SOCKS path never contends with the
-/// substitution endpoint for the shared egress port.
-fn vsock_egress_cmdline_token(config: &VmStartConfig, state_dir: &Path) -> Option<String> {
-    (config.network_policy.allows_egress()
-        && !crate::egress_shared::state_has_bound_secrets(state_dir).unwrap_or(false))
-    .then(|| "mvm.vsock_egress=1".to_string())
-}
-
-fn hvf_verity_initrd_path(config: &VmStartConfig) -> Option<PathBuf> {
-    config
-        .verity_path
-        .as_deref()
-        .zip(config.roothash.as_deref())
-        .and_then(|_| {
-            Path::new(&config.rootfs_path)
-                .parent()
-                .map(|p| p.join("rootfs.initrd"))
-        })
-        .filter(|p| p.exists())
-}
-
-fn hvf_effective_initrd(config: &VmStartConfig) -> Option<PathBuf> {
-    config
-        .initrd_path
-        .as_ref()
-        .map(PathBuf::from)
-        .or_else(|| hvf_verity_initrd_path(config))
-}
-
-fn hvf_verity_enabled(config: &VmStartConfig) -> bool {
-    config.verity_path.is_some()
-        && config.roothash.is_some()
-        && hvf_effective_initrd(config).is_some()
-}
-
-fn hvf_runtime_overlay(config: &VmStartConfig) -> Option<(&str, &str, &str)> {
-    Some((
-        config.runtime_overlay_path.as_deref()?,
-        config.runtime_overlay_verity_path.as_deref()?,
-        config.runtime_overlay_roothash.as_deref()?,
-    ))
-}
-
 fn hvf_workload_disks(config: &VmStartConfig) -> Vec<HvfDisk> {
     if config.virtiofs_root.is_some() {
         return Vec::new();
     }
 
-    if hvf_verity_enabled(config) {
+    if cmdline::verity_enabled(config) {
         let mut disks = vec![
             HvfDisk {
                 path: PathBuf::from(&config.rootfs_path),
@@ -259,7 +215,7 @@ fn hvf_workload_disks(config: &VmStartConfig) -> Vec<HvfDisk> {
                 ephemeral: false,
             },
         ];
-        if let Some((overlay_path, overlay_verity_path, _)) = hvf_runtime_overlay(config) {
+        if let Some((overlay_path, overlay_verity_path, _)) = cmdline::runtime_overlay(config) {
             disks.push(HvfDisk {
                 path: PathBuf::from(overlay_path),
                 read_only: true,
@@ -316,13 +272,13 @@ fn ensure_hvf_runtime_source_supported(config: &VmStartConfig) -> Result<()> {
     // read-only overlay from `/dev/vdb` in its guest `/init`.
     let verity_intended = config.roothash.is_some() || config.verity_path.is_some();
     if verity_intended {
-        if !hvf_verity_enabled(config) {
+        if !cmdline::verity_enabled(config) {
             bail!(
                 "required-overlay hvf boot requires verity metadata plus an initrd \
                  (`--initrd` or sibling rootfs.initrd)"
             );
         }
-        if hvf_runtime_overlay(config).is_none() {
+        if cmdline::runtime_overlay(config).is_none() {
             bail!("required-overlay hvf boot requires the runtime overlay artifact triple");
         }
     } else if crate::microvm::non_verity_overlay_ext4(config).is_none() {
@@ -332,67 +288,6 @@ fn ensure_hvf_runtime_source_supported(config: &VmStartConfig) -> Result<()> {
         );
     }
     Ok(())
-}
-
-fn hvf_workload_cmdline(config: &VmStartConfig, state_dir: &Path) -> Option<String> {
-    let egress = vsock_egress_cmdline_token(config, state_dir);
-    // The userspace L3 egress tunnel: tell the guest (via mvm-guest-netinit →
-    // mvm-guest-netd) to stand up its TUN and pump packets to the host worker over
-    // vsock. Present only for an admitted allow-list run.
-    let tunnel = config
-        .network_tunnel
-        .as_ref()
-        .and_then(mvm_core::vm_backend::encode_network_tunnel_cmdline);
-    let grants = crate::hvf_bootargs::grant_tokens(&config.name);
-    let virtiofs_root = config.virtiofs_root.is_some();
-    let has_disk = !virtiofs_root && !config.rootfs_path.is_empty();
-    let verity_enabled = hvf_verity_enabled(config);
-    if egress.is_none()
-        && tunnel.is_none()
-        && grants.is_empty()
-        && !verity_enabled
-        && config.runtime_source_policy == mvm_core::vm_backend::RuntimeSourcePolicy::RootfsOnly
-    {
-        return None;
-    }
-    let mut cmdline = if verity_enabled {
-        crate::hvf_bootargs::default_verity_bootargs()
-    } else {
-        crate::hvf_bootargs::workload_bootargs(virtiofs_root, has_disk)
-    };
-    if let Some(verity_args) = crate::microvm::build_verity_cmdline_args(
-        config.roothash.as_deref(),
-        if verity_enabled {
-            hvf_runtime_overlay(config).map(|(_, _, roothash)| roothash)
-        } else {
-            None
-        },
-    ) {
-        cmdline.push(' ');
-        cmdline.push_str(&verity_args);
-    }
-    // Non-verity boots carry the runtime overlay as a plain read-only
-    // `/dev/vdb` (attached by `hvf_workload_disks`); emit the token its `/init`
-    // mounts from. Verity boots already emitted the dm-verity variant above.
-    if !verity_enabled
-        && has_disk
-        && let Some(overlay_args) = crate::microvm::build_runtime_overlay_cmdline_args(
-            None,
-            crate::microvm::non_verity_overlay_ext4(config).is_some(),
-        )
-    {
-        cmdline.push(' ');
-        cmdline.push_str(&overlay_args);
-    }
-    cmdline.push(' ');
-    cmdline.push_str(&mvm_core::vm_backend::encode_runtime_source_policy_cmdline(
-        config.runtime_source_policy,
-    ));
-    for token in egress.into_iter().chain(tunnel).chain(grants) {
-        cmdline.push(' ');
-        cmdline.push_str(&token);
-    }
-    Some(cmdline)
 }
 
 fn workspace_root_from_manifest_dir() -> Option<PathBuf> {
@@ -595,9 +490,9 @@ impl VmBackend for HvfBackend {
             kernel: PathBuf::from(kernel),
             // Thread a full cmdline only when we need extra workload tokens;
             // otherwise keep the supervisor default (`init=/init`).
-            cmdline: hvf_workload_cmdline(config, &state_dir),
+            cmdline: cmdline::workload_cmdline(config, &state_dir),
             memory_mib: config.memory_mib,
-            initramfs: hvf_effective_initrd(config),
+            initramfs: cmdline::effective_initrd(config),
             disks,
             virtiofs_root,
             vsock: true,
@@ -1050,110 +945,6 @@ mod tests {
     }
 
     #[test]
-    fn vsock_egress_cmdline_token_only_when_policy_allows_egress() {
-        let dir = tempfile::tempdir().unwrap();
-        let deny_all = VmStartConfig::default();
-        assert_eq!(vsock_egress_cmdline_token(&deny_all, dir.path()), None);
-
-        let allow_egress = VmStartConfig {
-            network_policy: mvm_core::network_policy::NetworkPolicy::preset(
-                mvm_core::network_policy::NetworkPreset::Dev,
-            ),
-            ..Default::default()
-        };
-        assert_eq!(
-            vsock_egress_cmdline_token(&allow_egress, dir.path()).as_deref(),
-            Some("mvm.vsock_egress=1")
-        );
-    }
-
-    #[test]
-    fn hvf_workload_cmdline_appends_vsock_egress_token_for_virtiofs_root() {
-        let dir = tempfile::tempdir().unwrap();
-
-        let config = VmStartConfig {
-            virtiofs_root: Some("/tmp/root".to_string()),
-            network_policy: mvm_core::network_policy::NetworkPolicy::allow_list(vec![
-                mvm_core::network_policy::HostPort::new("example.com", 443),
-            ]),
-            ..Default::default()
-        };
-        let cmdline = hvf_workload_cmdline(&config, dir.path()).expect("cmdline");
-        assert!(cmdline.contains("rootfstype=virtiofs root=mvmroot"));
-        assert!(cmdline.contains("init=/init"));
-        assert!(cmdline.contains("mvm.runtime_source_policy=rootfs_only"));
-        assert!(cmdline.contains("mvm.vsock_egress=1"));
-    }
-
-    #[test]
-    fn hvf_workload_cmdline_appends_network_tunnel_token_for_admitted_allowlist() {
-        let dir = tempfile::tempdir().unwrap();
-        let policy = mvm_core::network_policy::NetworkPolicy::allow_list(vec![
-            mvm_core::network_policy::HostPort::new("93.184.216.34", 443),
-        ]);
-        let tunnel = crate::network_tunnel_spawn::network_tunnel_for_launch(
-            &policy,
-            crate::network_tunnel_spawn::TunnelLaunchIdentity {
-                tenant_id: "acme".to_string(),
-                vm_id: "vm-1".to_string(),
-                boot_id: "boot-1".to_string(),
-                session_nonce: "nonce-1".to_string(),
-            },
-        )
-        .expect("an allow-list launch carries a forwarding tunnel");
-        let expected = mvm_core::vm_backend::encode_network_tunnel_cmdline(&tunnel)
-            .expect("the tunnel encodes to a cmdline token");
-
-        let config = VmStartConfig {
-            virtiofs_root: Some("/tmp/root".to_string()),
-            network_policy: policy,
-            network_tunnel: Some(tunnel),
-            ..Default::default()
-        };
-        let cmdline = hvf_workload_cmdline(&config, dir.path()).expect("cmdline");
-        assert!(
-            cmdline.contains(&expected),
-            "cmdline missing the tunnel token: {cmdline}"
-        );
-        assert!(cmdline.contains("mvm.network_tunnel="));
-        // An allow-list run carrying no bound secrets also turns on the raw vsock
-        // egress client, so both tokens coexist on one cmdline (mirrors libkrun).
-        assert!(cmdline.contains("mvm.vsock_egress=1"));
-    }
-
-    #[test]
-    fn hvf_workload_cmdline_uses_verity_shape_and_runtime_overlay_tokens() {
-        let dir = tempfile::tempdir().unwrap();
-        let rootfs = dir.path().join("rootfs.ext4");
-        let verity = dir.path().join("rootfs.verity");
-        let initrd = dir.path().join("rootfs.initrd");
-        std::fs::write(&rootfs, b"rootfs").unwrap();
-        std::fs::write(&verity, b"verity").unwrap();
-        std::fs::write(&initrd, b"initrd").unwrap();
-
-        let config = VmStartConfig {
-            rootfs_path: rootfs.display().to_string(),
-            verity_path: Some(verity.display().to_string()),
-            roothash: Some("a".repeat(64)),
-            runtime_overlay_path: Some("/tmp/runtime.ext4".into()),
-            runtime_overlay_verity_path: Some("/tmp/runtime.verity".into()),
-            runtime_overlay_roothash: Some("b".repeat(64)),
-            runtime_source_policy: mvm_core::vm_backend::RuntimeSourcePolicy::RequiredOverlay,
-            ..Default::default()
-        };
-        let cmdline = hvf_workload_cmdline(&config, dir.path()).expect("cmdline");
-        assert!(!cmdline.contains("root=/dev/vda"));
-        assert!(!cmdline.contains("init=/init"));
-        assert!(cmdline.contains("mvm.roothash="));
-        assert!(cmdline.contains("mvm.data=/dev/vda"));
-        assert!(cmdline.contains("mvm.hash=/dev/vdb"));
-        assert!(cmdline.contains("mvm.runtime_roothash="));
-        assert!(cmdline.contains("mvm.runtime_data=/dev/vdc"));
-        assert!(cmdline.contains("mvm.runtime_hash=/dev/vdd"));
-        assert!(cmdline.contains("mvm.runtime_source_policy=required_overlay"));
-    }
-
-    #[test]
     fn hvf_workload_disks_use_read_only_verity_layout_with_overlay() {
         let dir = tempfile::tempdir().unwrap();
         let rootfs = dir.path().join("rootfs.ext4");
@@ -1205,12 +996,12 @@ mod tests {
         assert!(!disks[1].ephemeral);
 
         let dir = tempfile::tempdir().unwrap();
-        let cmdline = hvf_workload_cmdline(&config, dir.path()).expect("cmdline");
+        let assembled = cmdline::workload_cmdline(&config, dir.path()).expect("cmdline");
         assert!(
-            cmdline.contains("mvm.runtime_data=/dev/vdb"),
-            "got: {cmdline}"
+            assembled.contains("mvm.runtime_data=/dev/vdb"),
+            "got: {assembled}"
         );
-        assert!(!cmdline.contains("mvm.runtime_hash="), "got: {cmdline}");
+        assert!(!assembled.contains("mvm.runtime_hash="), "got: {assembled}");
     }
 
     #[test]

--- a/crates/mvm-runtime/src/workload_runner/cmdline.rs
+++ b/crates/mvm-runtime/src/workload_runner/cmdline.rs
@@ -1,0 +1,239 @@
+//! Workload kernel-cmdline assembly.
+//!
+//! Every guest kernel-cmdline security token — dm-verity roothash, plan-bound
+//! verb grant + enforcement assertion + host-signer trust anchor, the in-guest
+//! vsock egress client, the network-tunnel handoff, and the runtime-source
+//! policy / overlay knobs — is strung together here, once, so the raw HVF
+//! backend and `WorkloadRunner::start` boot with the identical cmdline. Pure
+//! string assembly (cfg-free) so it stays unit-testable with no hypervisor.
+
+use std::path::{Path, PathBuf};
+
+use mvm_core::vm_backend::VmStartConfig;
+
+/// Kernel cmdline token that turns on the in-guest vsock egress client.
+/// Emitted only when the run actually allows outbound egress and the workload
+/// carries no bound secrets, so the raw SOCKS path never contends with the
+/// substitution endpoint for the shared egress port.
+fn vsock_egress_cmdline_token(config: &VmStartConfig, state_dir: &Path) -> Option<String> {
+    (config.network_policy.allows_egress()
+        && !crate::egress_shared::state_has_bound_secrets(state_dir).unwrap_or(false))
+    .then(|| "mvm.vsock_egress=1".to_string())
+}
+
+fn verity_initrd_path(config: &VmStartConfig) -> Option<PathBuf> {
+    config
+        .verity_path
+        .as_deref()
+        .zip(config.roothash.as_deref())
+        .and_then(|_| {
+            Path::new(&config.rootfs_path)
+                .parent()
+                .map(|p| p.join("rootfs.initrd"))
+        })
+        .filter(|p| p.exists())
+}
+
+/// The initramfs this boot uses: an explicit `--initrd` override, or (for a
+/// verity-sealed boot) the sibling `rootfs.initrd` next to the rootfs image.
+pub(crate) fn effective_initrd(config: &VmStartConfig) -> Option<PathBuf> {
+    config
+        .initrd_path
+        .as_ref()
+        .map(PathBuf::from)
+        .or_else(|| verity_initrd_path(config))
+}
+
+/// Whether this boot has everything dm-verity needs: a verity sidecar, a
+/// roothash, and a resolvable initramfs to run the verification logic.
+pub(crate) fn verity_enabled(config: &VmStartConfig) -> bool {
+    config.verity_path.is_some() && config.roothash.is_some() && effective_initrd(config).is_some()
+}
+
+/// The resolved runtime-overlay artifact triple, when the launch config
+/// carries all three parts.
+pub(crate) fn runtime_overlay(config: &VmStartConfig) -> Option<(&str, &str, &str)> {
+    Some((
+        config.runtime_overlay_path.as_deref()?,
+        config.runtime_overlay_verity_path.as_deref()?,
+        config.runtime_overlay_roothash.as_deref()?,
+    ))
+}
+
+/// Assemble the workload kernel cmdline for `config`, or `None` when no extra
+/// tokens are needed (the driver then falls back to its own default base
+/// cmdline).
+///
+/// The `ttyAMA0` console base lives in `crate::hvf_bootargs` — today's only
+/// runner driver. It moves behind a `VmmDriver` base-cmdline hook once a
+/// second driver with a different console needs to join the runner.
+pub(crate) fn workload_cmdline(config: &VmStartConfig, state_dir: &Path) -> Option<String> {
+    let egress = vsock_egress_cmdline_token(config, state_dir);
+    // The userspace L3 egress tunnel: tell the guest (via mvm-guest-netinit →
+    // mvm-guest-netd) to stand up its TUN and pump packets to the host worker over
+    // vsock. Present only for an admitted allow-list run.
+    let tunnel = config
+        .network_tunnel
+        .as_ref()
+        .and_then(mvm_core::vm_backend::encode_network_tunnel_cmdline);
+    let grants = crate::hvf_bootargs::grant_tokens(&config.name);
+    let virtiofs_root = config.virtiofs_root.is_some();
+    let has_disk = !virtiofs_root && !config.rootfs_path.is_empty();
+    let verity_is_enabled = verity_enabled(config);
+    if egress.is_none()
+        && tunnel.is_none()
+        && grants.is_empty()
+        && !verity_is_enabled
+        && config.runtime_source_policy == mvm_core::vm_backend::RuntimeSourcePolicy::RootfsOnly
+    {
+        return None;
+    }
+    let mut cmdline = if verity_is_enabled {
+        crate::hvf_bootargs::default_verity_bootargs()
+    } else {
+        crate::hvf_bootargs::workload_bootargs(virtiofs_root, has_disk)
+    };
+    if let Some(verity_args) = crate::microvm::build_verity_cmdline_args(
+        config.roothash.as_deref(),
+        if verity_is_enabled {
+            runtime_overlay(config).map(|(_, _, roothash)| roothash)
+        } else {
+            None
+        },
+    ) {
+        cmdline.push(' ');
+        cmdline.push_str(&verity_args);
+    }
+    // Non-verity boots carry the runtime overlay as a plain read-only
+    // `/dev/vdb` (attached by the backend's disk layout); emit the token its
+    // `/init` mounts from. Verity boots already emitted the dm-verity variant
+    // above.
+    if !verity_is_enabled
+        && has_disk
+        && let Some(overlay_args) = crate::microvm::build_runtime_overlay_cmdline_args(
+            None,
+            crate::microvm::non_verity_overlay_ext4(config).is_some(),
+        )
+    {
+        cmdline.push(' ');
+        cmdline.push_str(&overlay_args);
+    }
+    cmdline.push(' ');
+    cmdline.push_str(&mvm_core::vm_backend::encode_runtime_source_policy_cmdline(
+        config.runtime_source_policy,
+    ));
+    for token in egress.into_iter().chain(tunnel).chain(grants) {
+        cmdline.push(' ');
+        cmdline.push_str(&token);
+    }
+    Some(cmdline)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn vsock_egress_cmdline_token_only_when_policy_allows_egress() {
+        let dir = tempfile::tempdir().unwrap();
+        let deny_all = VmStartConfig::default();
+        assert_eq!(vsock_egress_cmdline_token(&deny_all, dir.path()), None);
+
+        let allow_egress = VmStartConfig {
+            network_policy: mvm_core::network_policy::NetworkPolicy::preset(
+                mvm_core::network_policy::NetworkPreset::Dev,
+            ),
+            ..Default::default()
+        };
+        assert_eq!(
+            vsock_egress_cmdline_token(&allow_egress, dir.path()).as_deref(),
+            Some("mvm.vsock_egress=1")
+        );
+    }
+
+    #[test]
+    fn workload_cmdline_appends_vsock_egress_token_for_virtiofs_root() {
+        let dir = tempfile::tempdir().unwrap();
+
+        let config = VmStartConfig {
+            virtiofs_root: Some("/tmp/root".to_string()),
+            network_policy: mvm_core::network_policy::NetworkPolicy::allow_list(vec![
+                mvm_core::network_policy::HostPort::new("example.com", 443),
+            ]),
+            ..Default::default()
+        };
+        let cmdline = workload_cmdline(&config, dir.path()).expect("cmdline");
+        assert!(cmdline.contains("rootfstype=virtiofs root=mvmroot"));
+        assert!(cmdline.contains("init=/init"));
+        assert!(cmdline.contains("mvm.runtime_source_policy=rootfs_only"));
+        assert!(cmdline.contains("mvm.vsock_egress=1"));
+    }
+
+    #[test]
+    fn workload_cmdline_appends_network_tunnel_token_for_admitted_allowlist() {
+        let dir = tempfile::tempdir().unwrap();
+        let policy = mvm_core::network_policy::NetworkPolicy::allow_list(vec![
+            mvm_core::network_policy::HostPort::new("93.184.216.34", 443),
+        ]);
+        let tunnel = crate::network_tunnel_spawn::network_tunnel_for_launch(
+            &policy,
+            crate::network_tunnel_spawn::TunnelLaunchIdentity {
+                tenant_id: "acme".to_string(),
+                vm_id: "vm-1".to_string(),
+                boot_id: "boot-1".to_string(),
+                session_nonce: "nonce-1".to_string(),
+            },
+        )
+        .expect("an allow-list launch carries a forwarding tunnel");
+        let expected = mvm_core::vm_backend::encode_network_tunnel_cmdline(&tunnel)
+            .expect("the tunnel encodes to a cmdline token");
+
+        let config = VmStartConfig {
+            virtiofs_root: Some("/tmp/root".to_string()),
+            network_policy: policy,
+            network_tunnel: Some(tunnel),
+            ..Default::default()
+        };
+        let cmdline = workload_cmdline(&config, dir.path()).expect("cmdline");
+        assert!(
+            cmdline.contains(&expected),
+            "cmdline missing the tunnel token: {cmdline}"
+        );
+        assert!(cmdline.contains("mvm.network_tunnel="));
+        // An allow-list run carrying no bound secrets also turns on the raw vsock
+        // egress client, so both tokens coexist on one cmdline (mirrors libkrun).
+        assert!(cmdline.contains("mvm.vsock_egress=1"));
+    }
+
+    #[test]
+    fn workload_cmdline_uses_verity_shape_and_runtime_overlay_tokens() {
+        let dir = tempfile::tempdir().unwrap();
+        let rootfs = dir.path().join("rootfs.ext4");
+        let verity = dir.path().join("rootfs.verity");
+        let initrd = dir.path().join("rootfs.initrd");
+        std::fs::write(&rootfs, b"rootfs").unwrap();
+        std::fs::write(&verity, b"verity").unwrap();
+        std::fs::write(&initrd, b"initrd").unwrap();
+
+        let config = VmStartConfig {
+            rootfs_path: rootfs.display().to_string(),
+            verity_path: Some(verity.display().to_string()),
+            roothash: Some("a".repeat(64)),
+            runtime_overlay_path: Some("/tmp/runtime.ext4".into()),
+            runtime_overlay_verity_path: Some("/tmp/runtime.verity".into()),
+            runtime_overlay_roothash: Some("b".repeat(64)),
+            runtime_source_policy: mvm_core::vm_backend::RuntimeSourcePolicy::RequiredOverlay,
+            ..Default::default()
+        };
+        let cmdline = workload_cmdline(&config, dir.path()).expect("cmdline");
+        assert!(!cmdline.contains("root=/dev/vda"));
+        assert!(!cmdline.contains("init=/init"));
+        assert!(cmdline.contains("mvm.roothash="));
+        assert!(cmdline.contains("mvm.data=/dev/vda"));
+        assert!(cmdline.contains("mvm.hash=/dev/vdb"));
+        assert!(cmdline.contains("mvm.runtime_roothash="));
+        assert!(cmdline.contains("mvm.runtime_data=/dev/vdc"));
+        assert!(cmdline.contains("mvm.runtime_hash=/dev/vdd"));
+        assert!(cmdline.contains("mvm.runtime_source_policy=required_overlay"));
+    }
+}

--- a/crates/mvm-runtime/src/workload_runner/mod.rs
+++ b/crates/mvm-runtime/src/workload_runner/mod.rs
@@ -4,6 +4,7 @@
 //! audit. This module holds the pure, driver-independent pieces of that mapping
 //! so they are unit-testable without a hypervisor.
 
+pub(crate) mod cmdline;
 pub mod runner;
 pub mod spec_map;
 

--- a/crates/mvm-runtime/src/workload_runner/runner.rs
+++ b/crates/mvm-runtime/src/workload_runner/runner.rs
@@ -29,6 +29,7 @@ use crate::substitution_spawn::{
     spawn_substitution_endpoint,
 };
 use crate::workload_backend::{EgressSubstitutionTransport, WorkloadBackend};
+use crate::workload_runner::cmdline;
 use crate::workload_runner::spec_map::{
     WorkloadSockets, WorkloadSpecInputs, console_data_sockets, network_tunnel_socket, workload_spec,
 };
@@ -236,7 +237,7 @@ impl<D: VmmDriver + 'static, S: EndpointSpawner + 'static> VmBackend for Workloa
             secrets,
             redaction,
             network_policy: &config.network_policy,
-            cmdline: String::new(),
+            cmdline: cmdline::workload_cmdline(config, &state_dir).unwrap_or_default(),
         };
         // The supervisor + endpoint are detached/disk-backed; the live handle is
         // reconstructed by id via `attach`, so the boot handle is dropped here.
@@ -340,7 +341,9 @@ mod tests {
     use std::sync::Mutex;
 
     use mvm_agentd::vsock::EGRESS_PORT;
-    use mvm_core::plan::{SecretBinding, SecretSource};
+    use mvm_core::plan::{Nonce, SecretBinding, SecretSource, VerbGrant, VerbId};
+    use mvm_core::protocol::vm_backend::VerbGrantEnvelope;
+    use mvm_core::util::test_env::TestEnv;
 
     use crate::driver::HvfDriver;
     use crate::driver::mock::MockDriver;
@@ -535,6 +538,97 @@ mod tests {
         assert_eq!(runner.wait(&id).unwrap(), exit);
         // stop reaps a nonexistent endpoint (no-op) then kills the attached handle.
         assert!(runner.stop(&VmId("w".into())).is_ok());
+    }
+
+    /// Write a `verb-grant.json` sidecar plus the host-signer public key
+    /// under `vm_name`'s state dir, the shape the grant cmdline tokens read.
+    fn seed_grant_sidecar_and_key(vm_name: &str) {
+        let state_dir = mvm_core::config::vm_state_dir(vm_name);
+        std::fs::create_dir_all(&state_dir).unwrap();
+        let nonce = Nonce::from_bytes([9u8; 16]);
+        let not_after = mvm_core::time::parse_iso8601("2099-01-01T00:00:00Z").unwrap();
+        let envelope = VerbGrantEnvelope {
+            pubkey_hex: "cc".repeat(32),
+            plan_nonce_hex: nonce.as_hex().to_string(),
+            predecessor_session_id: None,
+            predecessor_plan_nonce_hex: None,
+            grant: VerbGrant {
+                session_id: vm_name.to_string(),
+                plan_nonce: nonce,
+                not_after,
+                verbs: vec![VerbId::new("run-entrypoint").unwrap()],
+                sig: vec![0u8; 64],
+            },
+        };
+        std::fs::write(
+            state_dir.join("verb-grant.json"),
+            serde_json::to_vec(&envelope).unwrap(),
+        )
+        .unwrap();
+        let keys_dir = mvm_core::config::mvm_keys_dir();
+        std::fs::create_dir_all(&keys_dir).unwrap();
+        std::fs::write(keys_dir.join("host-signer.pub"), [0xEEu8; 32]).unwrap();
+    }
+
+    /// `WorkloadRunner::start` (the `VmBackend::start` production path) must
+    /// assemble the same security-bearing kernel cmdline the raw HVF backend
+    /// does — dm-verity, the plan-bound grant triple, vsock egress, and the
+    /// runtime-source-policy token — instead of booting with an empty
+    /// cmdline. Drives the whole trait method through a `MockDriver` and
+    /// inspects the booted `VmmSpec` it recorded.
+    #[test]
+    fn start_assembles_the_security_cmdline_tokens_via_the_shared_assembler() {
+        let _guard = crate::base::runtime_meta::HOME_TEST_LOCK
+            .lock()
+            .unwrap_or_else(|e| e.into_inner());
+        let home = tempfile::tempdir().unwrap();
+        let mut env = TestEnv::new();
+        env.set("MVM_HOME", home.path());
+
+        let rootfs_dir = tempfile::tempdir().unwrap();
+        let rootfs = rootfs_dir.path().join("rootfs.ext4");
+        let verity = rootfs_dir.path().join("rootfs.verity");
+        let initrd = rootfs_dir.path().join("rootfs.initrd");
+        std::fs::write(&rootfs, b"rootfs").unwrap();
+        std::fs::write(&verity, b"verity").unwrap();
+        std::fs::write(&initrd, b"initrd").unwrap();
+
+        let vm_name = "runner-security-cmdline-tokens";
+        seed_grant_sidecar_and_key(vm_name);
+
+        let cfg = VmStartConfig {
+            name: vm_name.into(),
+            rootfs_path: rootfs.display().to_string(),
+            verity_path: Some(verity.display().to_string()),
+            roothash: Some("a".repeat(64)),
+            network_policy: NetworkPolicy::preset(mvm_core::network_policy::NetworkPreset::Dev),
+            ..Default::default()
+        };
+
+        let runner =
+            WorkloadRunner::new(MockDriver::default(), RecordingSpawner::new("/run/ep.sock"));
+        runner.start(&cfg).expect("start succeeds");
+
+        let specs = runner.driver.booted_specs();
+        assert_eq!(specs.len(), 1);
+        let cmdline = &specs[0].cmdline;
+
+        let require_grant = crate::microvm::require_grant_cmdline_token(vm_name)
+            .expect("sidecar present ⇒ enforcement token");
+        for needle in [
+            "mvm.roothash=",
+            "mvm.data=/dev/vda",
+            "mvm.verb_grant=",
+            require_grant.as_str(),
+            "mvm.host_signer_pub=",
+            "mvm.vsock_egress=1",
+            "mvm.runtime_source_policy=",
+        ] {
+            assert!(
+                cmdline.contains(needle),
+                "booted cmdline missing {needle:?}: {cmdline}"
+            );
+        }
     }
 
     #[test]


### PR DESCRIPTION
Enrichment PR-1 of converging every workload backend onto the `WorkloadRunner` seam without regressing claims.

`WorkloadRunner::start` booted workloads with `cmdline: String::new()` — dropping every guest kernel-cmdline **security token** on the runner path: dm-verity `mvm.roothash`/`mvm.data`/`mvm.hash` (claim 3), `mvm.verb_grant`/`mvm.require_grant`/`mvm.host_signer_pub` (plan-bound verb enforcement), `mvm.vsock_egress` (vsock-only egress), and the runtime-overlay tokens. The raw `HvfBackend` already assembled all of these correctly.

This extracts that assembler into a cfg-free `workload_runner/cmdline.rs` (`workload_cmdline`) and points **both** the raw `HvfBackend` and the runner at it — one source of truth, so the raw path is byte-identical (no regression) while the runner gains the tokens. Its verity args use the shared `vda/vdb` layout that matches the `VmmSpec` slot model. The `require_grant` token is built via `require_grant_cmdline_token()` (not the guarded literal); the `ttyAMA0` base stays embedded (moves behind a driver hook only when a second runner driver lands).

Verified: `nextest -p mvm-runtime` 900 passed (incl. a new test proving the runner's booted spec carries `mvm.roothash=`/`mvm.data=/dev/vda`/`mvm.verb_grant=`/require_grant/`mvm.host_signer_pub=`/`mvm.vsock_egress=1`/`mvm.runtime_source_policy=`, plus both grant-parity tests still green), clippy `-D warnings`, `x86_64-unknown-linux-gnu` cross-build, and `check-vsock-only-egress` / `check-require-grant-token-allowlist` / `check-no-spec-refs-in-comments`.